### PR TITLE
driver: eth: Support for lan8651 T1S ETH (with OA TC6 library)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -303,6 +303,7 @@
 /drivers/ethernet/*xlnx_gem*              @ibirnbaum
 /drivers/ethernet/*smsc91x*               @sgrrzhf
 /drivers/ethernet/*adin2111*              @GeorgeCGV
+/drivers/ethernet/*oa_tc6*                @lmajewski
 /drivers/ethernet/phy/                    @rlubos @tbursztyka @arvinf @jukkar
 /drivers/ethernet/phy/*adin2111*          @GeorgeCGV
 /drivers/mdio/                            @rlubos @tbursztyka @arvinf

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -304,6 +304,7 @@
 /drivers/ethernet/*smsc91x*               @sgrrzhf
 /drivers/ethernet/*adin2111*              @GeorgeCGV
 /drivers/ethernet/*oa_tc6*                @lmajewski
+/drivers/ethernet/*lan865x*               @lmajewski
 /drivers/ethernet/phy/                    @rlubos @tbursztyka @arvinf @jukkar
 /drivers/ethernet/phy/*adin2111*          @GeorgeCGV
 /drivers/mdio/                            @rlubos @tbursztyka @arvinf

--- a/drivers/ethernet/CMakeLists.txt
+++ b/drivers/ethernet/CMakeLists.txt
@@ -34,6 +34,7 @@ zephyr_library_sources_ifdef(CONFIG_SLIP_TAP		eth_slip_tap.c)
 zephyr_library_sources_ifdef(CONFIG_ETH_SMSC91X		eth_smsc91x.c)
 zephyr_library_sources_ifdef(CONFIG_ETH_IVSHMEM 	eth_ivshmem.c eth_ivshmem_queue.c)
 zephyr_library_sources_ifdef(CONFIG_ETH_ADIN2111	eth_adin2111.c)
+zephyr_library_sources_ifdef(CONFIG_ETH_LAN865X	        eth_lan865x.c oa_tc6.c)
 
 if(CONFIG_ETH_NXP_S32_NETC)
   zephyr_library_sources(eth_nxp_s32_netc.c)

--- a/drivers/ethernet/Kconfig
+++ b/drivers/ethernet/Kconfig
@@ -62,6 +62,7 @@ source "drivers/ethernet/Kconfig.smsc91x"
 source "drivers/ethernet/Kconfig.ivshmem"
 source "drivers/ethernet/Kconfig.adin2111"
 source "drivers/ethernet/Kconfig.numaker"
+source "drivers/ethernet/Kconfig.lan865x"
 
 source "drivers/ethernet/phy/Kconfig"
 

--- a/drivers/ethernet/Kconfig.lan865x
+++ b/drivers/ethernet/Kconfig.lan865x
@@ -1,0 +1,50 @@
+# Copyright (c) 2023 DENX Software Engineering GmbH
+# SPDX-License-Identifier: Apache-2.0
+
+menuconfig ETH_LAN865X
+	bool "LAN865X 10BASE-T1S Controller"
+	default y
+	depends on DT_HAS_MICROCHIP_LAN865X_ENABLED
+	select SPI
+	help
+	  The LAN865X is a low power, 10BASE-T1S transceiver compliant with
+	  the IEEE® 802.3cg-2019™ Ethernet standard for long reach, 10
+	  Mbps single pair Ethernet (SPE).
+
+	  Featuring an integrated media access control (MAC) and a PHY,
+	  the LAN865X enables direct connectivity with a variety of controllers
+	  via a serial peripheral inter-face (SPI).
+
+if ETH_LAN865X
+
+config ETH_LAN865X_INIT_PRIORITY
+	int "LAN865X driver init priority"
+	default 72
+	help
+	  LAN865X device driver initialization priority.
+	  Must be initialized after SPI.
+
+
+config ETH_LAN865X_IRQ_THREAD_STACK_SIZE
+	int "Stack size for a thread that processes IRQ"
+	default 512
+	help
+	  Size of the stack used for internal thread which is ran to
+	  process raised INT IRQ.
+
+config ETH_LAN865X_IRQ_THREAD_PRIO
+	int "Priority for internal incoming packet handler"
+	default 2
+	help
+	  Priority level for internal thread which is ran for LAN
+	  INT IRQ processing.
+
+config ETH_LAN865X_TIMEOUT
+	int "IP buffer timeout"
+	default 100
+	help
+	  Given timeout in milliseconds. Maximum amount of time
+	  that the driver will wait from the IP stack to get
+	  a memory buffer before the Ethernet frame is dropped.
+
+endif # ETH_LAN865X

--- a/drivers/ethernet/eth_lan865x.c
+++ b/drivers/ethernet/eth_lan865x.c
@@ -1,0 +1,585 @@
+/*
+ * Copyright (c) 2023 DENX Software Engineering GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT microchip_lan865x
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(eth_lan865x, CONFIG_ETHERNET_LOG_LEVEL);
+
+#include <zephyr/net/ethernet.h>
+#include <zephyr/net/phy.h>
+
+#include <string.h>
+#include <errno.h>
+
+#include <zephyr/net/net_if.h>
+#include <zephyr/net/ethernet.h>
+#include <zephyr/net/phy.h>
+
+#include "eth_lan865x_priv.h"
+
+static int lan865x_mac_rxtx_control(const struct device *dev, bool en)
+{
+	struct lan865x_data *ctx = dev->data;
+	uint32_t ctl = 0;
+
+	if (en) {
+		ctl = LAN865x_MAC_NCR_TXEN | LAN865x_MAC_NCR_RXEN;
+	}
+
+	return oa_tc6_reg_write(ctx->tc6, LAN865x_MAC_NCR, ctl);
+}
+
+static void lan865x_iface_init(struct net_if *iface)
+{
+	const struct device *dev = net_if_get_device(iface);
+	struct lan865x_data *ctx = dev->data;
+
+	net_if_set_link_addr(iface, ctx->mac_address, sizeof(ctx->mac_address),
+			     NET_LINK_ETHERNET);
+
+	if (ctx->iface == NULL) {
+		ctx->iface = iface;
+	}
+
+	ethernet_init(iface);
+
+	net_eth_carrier_on(iface);
+	ctx->iface_initialized = true;
+}
+
+static enum ethernet_hw_caps lan865x_port_get_capabilities(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+	return ETHERNET_LINK_10BASE_T | ETHERNET_PROMISC_MODE;
+}
+
+static void lan865x_write_macaddress(const struct device *dev);
+static int lan865x_set_config(const struct device *dev, enum ethernet_config_type type,
+			      const struct ethernet_config *config)
+{
+	struct lan865x_data *ctx = dev->data;
+	int ret = -ENOTSUP;
+
+	if (type == ETHERNET_CONFIG_TYPE_PROMISC_MODE) {
+		ret = lan865x_mac_rxtx_control(dev, LAN865x_MAC_TXRX_OFF);
+		if (ret) {
+			return ret;
+		}
+
+		ret = oa_tc6_reg_write(ctx->tc6, LAN865x_MAC_NCFGR,
+				       LAN865x_MAC_NCFGR_CAF);
+		if (ret) {
+			return ret;
+		}
+
+		return lan865x_mac_rxtx_control(dev, LAN865x_MAC_TXRX_ON);
+	}
+
+	if (type == ETHERNET_CONFIG_TYPE_MAC_ADDRESS) {
+		ret = lan865x_mac_rxtx_control(dev, LAN865x_MAC_TXRX_OFF);
+		if (ret) {
+			return ret;
+		}
+
+		memcpy(ctx->mac_address, config->mac_address.addr,
+		       sizeof(ctx->mac_address));
+
+		lan865x_write_macaddress(dev);
+
+		net_if_set_link_addr(ctx->iface, ctx->mac_address,
+				     sizeof(ctx->mac_address),
+				     NET_LINK_ETHERNET);
+
+		return lan865x_mac_rxtx_control(dev, LAN865x_MAC_TXRX_ON);
+	}
+
+	return ret;
+}
+
+static int lan865x_wait_for_reset(const struct device *dev)
+{
+	struct lan865x_data *ctx = dev->data;
+	uint8_t i;
+
+	/* Wait for end of LAN865x reset */
+	for (i = 0; !ctx->reset && i < LAN865X_RESET_TIMEOUT; i++) {
+		k_msleep(1);
+	}
+
+	if (i == LAN865X_RESET_TIMEOUT) {
+		LOG_ERR("LAN865x reset timeout reached!");
+		return -ENODEV;
+	}
+
+	return 0;
+}
+
+static int lan865x_gpio_reset(const struct device *dev)
+{
+	const struct lan865x_config *cfg = dev->config;
+
+	/* Perform (GPIO based) HW reset */
+	/* assert RESET_N low for 10 µs (5 µs min) */
+	gpio_pin_set_dt(&cfg->reset, 1);
+	k_busy_wait(10U);
+	/* deassert - end of reset indicated by IRQ_N low  */
+	gpio_pin_set_dt(&cfg->reset, 0);
+
+	return lan865x_wait_for_reset(dev);
+}
+
+static int lan865x_check_spi(const struct device *dev)
+{
+	struct lan865x_data *ctx = dev->data;
+	uint32_t val;
+	int ret;
+
+	ret = oa_tc6_reg_read(ctx->tc6, LAN865x_DEVID, &val);
+	if (ret < 0) {
+		return -ENODEV;
+	}
+
+	ctx->silicon_rev = val & LAN865X_REV_MASK;
+	if (ctx->silicon_rev != 1 && ctx->silicon_rev != 2) {
+		return -ENODEV;
+	}
+
+	ctx->chip_id = (val >> 4) & 0xFFFF;
+	if (ctx->chip_id != LAN8650_DEVID && ctx->chip_id != LAN8651_DEVID) {
+		return -ENODEV;
+	}
+
+	return ret;
+}
+
+/* Implementation of pseudo code from AN1760 */
+static uint8_t lan865x_read_indirect_reg(const struct device *dev, uint8_t addr,
+					 uint8_t mask)
+{
+	struct lan865x_data *ctx = dev->data;
+	uint32_t val;
+
+	oa_tc6_reg_write(ctx->tc6, 0x000400D8, addr);
+	oa_tc6_reg_write(ctx->tc6, 0x000400DA, 0x02);
+
+	oa_tc6_reg_read(ctx->tc6, 0x000400D9, &val);
+
+	return (uint8_t) val & mask;
+}
+
+static int lan865x_init_chip(const struct device *dev, uint8_t silicon_rev)
+{
+	struct lan865x_data *ctx = dev->data;
+	uint8_t value1, value2;
+	int8_t offset1 = 0, offset2 = 0, ret;
+	uint16_t value3, value4, value5, value6, value7;
+	uint16_t cfgparam1, cfgparam2, cfgparam3, cfgparam4, cfgparam5;
+	uint32_t val;
+
+	ret = lan865x_read_indirect_reg(dev, 0x05, 0x40);
+	if (ret == 0) {
+		LOG_ERR("LAN865x error! Please contact microchip support for replacement.");
+		return -EIO;
+	}
+
+	value1 = lan865x_read_indirect_reg(dev, 0x04, 0x1F);
+	if ((value1 & 0x10) != 0) { /* Convert uint8_t to int8_t */
+		offset1 = value1 | 0xE0;
+		if (offset1 < -5) {
+			LOG_ERR("LAN865x internal error!");
+			return -EIO;
+		}
+	} else {
+		offset1 = value1;
+	}
+
+	value2 = lan865x_read_indirect_reg(dev, 0x08, 0x1F);
+	if ((value2 & 0x10) != 0) { /* Convert uint8_t to int8_t */
+		offset2 = value2 | 0xE0;
+	} else {
+		offset2 = value2;
+	}
+
+	oa_tc6_reg_read(ctx->tc6, 0x00040084, &val);
+	value3 = (uint16_t)val;
+
+	oa_tc6_reg_read(ctx->tc6, 0x0004008A, &val);
+	value4 = (uint16_t)val;
+
+	oa_tc6_reg_read(ctx->tc6, 0x000400AD, &val);
+	value5 = (uint16_t)val;
+
+	oa_tc6_reg_read(ctx->tc6, 0x000400AE, &val);
+	value6 = (uint8_t)val;
+
+	oa_tc6_reg_read(ctx->tc6, 0x000400AF, &val);
+	value7 = (uint8_t)val;
+
+	cfgparam1 = (value3 & 0xF) | (((9 + offset1) << 10) | ((14 + offset1) << 4));
+	cfgparam2 = (value4 & 0x3FF) | ((40 + offset2) << 10);
+	cfgparam3 = (value5 & 0xC0C0) | (((5 + offset1) << 8) | (9 + offset1));
+	cfgparam4 = (value6 & 0xC0C0) | (((9 + offset1) << 8) | (14 + offset1));
+	cfgparam5 = (value7 & 0xC0C0) | (((17 + offset1) << 8) | (22 + offset1));
+
+	oa_tc6_reg_write(ctx->tc6, 0x00040084, (uint32_t) cfgparam1);
+	oa_tc6_reg_write(ctx->tc6, 0x0004008A, (uint32_t) cfgparam2);
+	oa_tc6_reg_write(ctx->tc6, 0x000400AD, (uint32_t) cfgparam3);
+	oa_tc6_reg_write(ctx->tc6, 0x000400AE, (uint32_t) cfgparam4);
+	oa_tc6_reg_write(ctx->tc6, 0x000400AF, (uint32_t) cfgparam5);
+
+	return 0;
+}
+/* Implementation of pseudo code from AN1760 - END */
+
+static int lan865x_config_plca(const struct device *dev, uint8_t node_id,
+			       uint8_t node_cnt, uint8_t burst_cnt, uint8_t burst_timer)
+{
+	struct lan865x_data *ctx = dev->data;
+	uint32_t val;
+
+	/* Collision Detection */
+	oa_tc6_reg_write(ctx->tc6, 0x00040087, 0x0083u); /* COL_DET_CTRL0 */
+
+	/* T1S Phy Node Id and Max Node Count */
+	val = ((uint32_t)node_cnt << 8) | node_id;
+	oa_tc6_reg_write(ctx->tc6, 0x0004CA02, val); /* PLCA_CONTROL_1_REGISTER */
+
+	/* PLCA Burst Count and Burst Timer */
+	val = ((uint32_t)burst_cnt << 8) | burst_timer;
+	oa_tc6_reg_write(ctx->tc6, 0x0004CA05, val); /* PLCA_BURST_MODE_REGISTER */
+
+	/* Enable PLCA */
+	oa_tc6_reg_write(ctx->tc6, 0x0004CA01, BIT(15)); /* PLCA_CONTROL_0_REGISTER */
+
+	return 0;
+}
+
+static void lan865x_write_macaddress(const struct device *dev)
+{
+	struct lan865x_data *ctx = dev->data;
+	uint8_t *mac = &ctx->mac_address[0];
+	uint32_t val;
+
+	/* SPEC_ADD2_BOTTOM */
+	val = (mac[3] << 24) | (mac[2] << 16) | (mac[1] << 8) | mac[0];
+	oa_tc6_reg_write(ctx->tc6, LAN865x_MAC_SAB2, val);
+
+	/* SPEC_ADD2_TOP */
+	val = (mac[5] << 8) | mac[4];
+	oa_tc6_reg_write(ctx->tc6, LAN865x_MAC_SAT2, val);
+
+	/* SPEC_ADD1_BOTTOM */
+	val = (mac[5] << 24) | (mac[4] << 16) | (mac[3] << 8) | mac[2];
+	oa_tc6_reg_write(ctx->tc6, LAN865x_MAC_SAB1, val);
+}
+
+static int lan865x_default_config(const struct device *dev, uint8_t silicon_rev)
+{
+	/* Values in the below table are the same for LAN865x rev. B0 and B1 */
+	static const oa_mem_map_t lan865x_conf[] = {
+		{ .address = 0x00010000, .value = 0x00000000 },
+		{ .address = 0x00040091, .value = 0x00009660 },
+		{ .address = 0x00040081, .value = 0x00000080 },
+		{ .address = 0x00010077, .value = 0x00000028 },
+		{ .address = 0x00040043, .value = 0x000000FF },
+		{ .address = 0x00040044, .value = 0x0000FFFF },
+		{ .address = 0x00040045, .value = 0x00000000 },
+		{ .address = 0x00040053, .value = 0x000000FF },
+		{ .address = 0x00040054, .value = 0x0000FFFF },
+		{ .address = 0x00040055, .value = 0x00000000 },
+		{ .address = 0x00040040, .value = 0x00000002 },
+		{ .address = 0x00040050, .value = 0x00000002 },
+		{ .address = 0x000400E9, .value = 0x00009E50 },
+		{ .address = 0x000400F5, .value = 0x00001CF8 },
+		{ .address = 0x000400F4, .value = 0x0000C020 },
+		{ .address = 0x000400F8, .value = 0x00009B00 },
+		{ .address = 0x000400F9, .value = 0x00004E53 },
+		{ .address = 0x000400B0, .value = 0x00000103 },
+		{ .address = 0x000400B1, .value = 0x00000910 },
+		{ .address = 0x000400B2, .value = 0x00001D26 },
+		{ .address = 0x000400B3, .value = 0x0000002A },
+		{ .address = 0x000400B4, .value = 0x00000103 },
+		{ .address = 0x000400B5, .value = 0x0000070D },
+		{ .address = 0x000400B6, .value = 0x00001720 },
+		{ .address = 0x000400B7, .value = 0x00000027 },
+		{ .address = 0x000400B8, .value = 0x00000509 },
+		{ .address = 0x000400B9, .value = 0x00000E13 },
+		{ .address = 0x000400BA, .value = 0x00001C25 },
+		{ .address = 0x000400BB, .value = 0x0000002B },
+		{ .address = 0x0000000C, .value = 0x00000100 },
+		{ .address = 0x00040081, .value = 0x000000E0 },
+	};
+	const struct lan865x_config *cfg = dev->config;
+	uint8_t i, size = ARRAY_SIZE(lan865x_conf);
+	struct lan865x_data *ctx = dev->data;
+	int ret;
+
+	/* Enable protected control RW */
+	oa_tc6_set_protected_ctrl(ctx->tc6, true);
+
+	for (i = 0; i < size; i++) {
+		oa_tc6_reg_write(ctx->tc6, lan865x_conf[i].address,
+				 lan865x_conf[i].value);
+	}
+
+	if (silicon_rev == 1) {
+		/* For silicon rev 1 (B0): (bit [3..0] from 0x0A0084 */
+		oa_tc6_reg_write(ctx->tc6, 0x000400D0, 0x5F21);
+	}
+
+	lan865x_write_macaddress(dev);
+
+	ret = lan865x_init_chip(dev, silicon_rev);
+	if (ret < 0)
+		return ret;
+
+	if (cfg->plca_enable) {
+		ret = lan865x_config_plca(dev, cfg->plca_node_id,
+					  cfg->plca_node_count,
+					  cfg->plca_burst_count,
+					  cfg->plca_burst_timer);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+	return 0;
+}
+
+static void lan865x_int_callback(const struct device *dev,
+				  struct gpio_callback *cb,
+				  uint32_t pins)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(pins);
+
+	struct lan865x_data *ctx =
+		CONTAINER_OF(cb, struct lan865x_data, gpio_int_callback);
+
+	k_sem_give(&ctx->int_sem);
+}
+
+static void lan865x_read_chunks(const struct device *dev)
+{
+	const struct lan865x_config *cfg = dev->config;
+	struct lan865x_data *ctx = dev->data;
+	struct oa_tc6 *tc6 = ctx->tc6;
+	struct net_pkt *pkt;
+	int ret;
+
+	k_sem_take(&ctx->tx_rx_sem, K_FOREVER);
+	pkt = net_pkt_rx_alloc(K_MSEC(cfg->timeout));
+	if (!pkt) {
+		LOG_ERR("OA RX: Could not allocate packet!");
+		k_sem_give(&ctx->tx_rx_sem);
+		return;
+	}
+
+	ret = oa_tc6_read_chunks(tc6, pkt);
+	k_sem_give(&ctx->tx_rx_sem);
+	if (ret < 0) {
+		eth_stats_update_errors_rx(ctx->iface);
+		net_pkt_unref(pkt);
+		return;
+	}
+
+	/* Feed buffer frame to IP stack */
+	ret = net_recv_data(ctx->iface, pkt);
+	if (ret < 0) {
+		LOG_ERR("OA RX: Could not process packet (%d)!", ret);
+		net_pkt_unref(pkt);
+	}
+}
+
+static void lan865x_int_thread(const struct device *dev)
+{
+	struct lan865x_data *ctx = dev->data;
+	struct oa_tc6 *tc6 = ctx->tc6;
+	uint32_t sts, val, ftr;
+
+	while (true) {
+		k_sem_take(&ctx->int_sem, K_FOREVER);
+		if (!ctx->reset) {
+			oa_tc6_reg_read(tc6, OA_STATUS0, &sts);
+			if (sts & OA_STATUS0_RESETC) {
+				oa_tc6_reg_write(tc6, OA_STATUS0, sts);
+				lan865x_default_config(dev, ctx->silicon_rev);
+				oa_tc6_reg_read(tc6, OA_CONFIG0, &val);
+				oa_tc6_reg_write(tc6, OA_CONFIG0, OA_CONFIG0_SYNC | val);
+				lan865x_mac_rxtx_control(dev, LAN865x_MAC_TXRX_ON);
+
+				ctx->reset = true;
+				/*
+				 * According to OA T1S standard - it is mandatory to
+				 * read chunk of data to get the IRQ_N negated (deasserted).
+				 */
+				oa_tc6_read_status(tc6, &ftr);
+				continue;
+			}
+		}
+
+		/*
+		 * The IRQ_N is asserted when RCA becomes > 0, so update its value
+		 * before reading chunks.
+		 */
+		oa_tc6_update_buf_info(tc6);
+
+		while (tc6->rca > 0) {
+			lan865x_read_chunks(dev);
+		}
+
+		if (tc6->exst) {
+			/*
+			 * Just clear any pending interrupts - data RX will be served
+			 * earlier.
+			 * The RESETC is handled separately as it requires LAN865x device
+			 * configuration.
+			 */
+			oa_tc6_reg_read(tc6, OA_STATUS0, &sts);
+			if (sts != 0) {
+				oa_tc6_reg_write(tc6, OA_STATUS0, sts);
+			}
+
+			oa_tc6_reg_read(tc6, OA_STATUS1, &sts);
+			if (sts != 0) {
+				oa_tc6_reg_write(tc6, OA_STATUS1, sts);
+			}
+		}
+	}
+}
+
+static int lan865x_init(const struct device *dev)
+{
+	const struct lan865x_config *cfg = dev->config;
+	struct lan865x_data *ctx = dev->data;
+	int ret;
+
+	__ASSERT(cfg->spi.config.frequency <= LAN865X_SPI_MAX_FREQUENCY,
+		 "SPI frequency exceeds supported maximum\n");
+
+	if (!spi_is_ready_dt(&cfg->spi)) {
+		LOG_ERR("SPI bus %s not ready", cfg->spi.bus->name);
+		return -ENODEV;
+	}
+
+	if (!gpio_is_ready_dt(&cfg->interrupt)) {
+		LOG_ERR("Interrupt GPIO device %s is not ready",
+			cfg->interrupt.port->name);
+		return -ENODEV;
+	}
+
+	/* Check SPI communication after reset */
+	ret = lan865x_check_spi(dev);
+	if (ret < 0) {
+		LOG_ERR("SPI communication not working, %d", ret);
+		return ret;
+	}
+
+	/*
+	 * Configure interrupt service routine for LAN865x IRQ
+	 */
+	ret = gpio_pin_configure_dt(&cfg->interrupt, GPIO_INPUT);
+	if (ret < 0) {
+		LOG_ERR("Failed to configure interrupt GPIO, %d", ret);
+		return ret;
+	}
+
+	gpio_init_callback(&(ctx->gpio_int_callback), lan865x_int_callback,
+			   BIT(cfg->interrupt.pin));
+
+	ret = gpio_add_callback(cfg->interrupt.port, &ctx->gpio_int_callback);
+	if (ret < 0) {
+		LOG_ERR("Failed to add INT callback, %d", ret);
+		return ret;
+	}
+
+	gpio_pin_interrupt_configure_dt(&cfg->interrupt, GPIO_INT_EDGE_TO_ACTIVE);
+
+	/* Start interruption-poll thread */
+	ctx->tid_int =
+		k_thread_create(&ctx->thread, ctx->thread_stack,
+				CONFIG_ETH_LAN865X_IRQ_THREAD_STACK_SIZE,
+				(k_thread_entry_t)lan865x_int_thread,
+				(void *)dev, NULL, NULL,
+				K_PRIO_COOP(CONFIG_ETH_LAN865X_IRQ_THREAD_PRIO),
+				0, K_NO_WAIT);
+	k_thread_name_set(ctx->tid_int, "lan865x_interrupt");
+
+	ctx->reset = false;
+
+	/* Perform HW reset - 'rst-gpios' required property set in DT */
+	if (!gpio_is_ready_dt(&cfg->reset)) {
+		LOG_ERR("Reset GPIO device %s is not ready",
+			cfg->reset.port->name);
+		return -ENODEV;
+	}
+
+	ret = gpio_pin_configure_dt(&cfg->reset, GPIO_OUTPUT_INACTIVE);
+	if (ret < 0) {
+		LOG_ERR("Failed to configure reset GPIO, %d", ret);
+		return ret;
+	}
+
+	return lan865x_gpio_reset(dev);
+}
+
+static int lan865x_port_send(const struct device *dev, struct net_pkt *pkt)
+{
+	struct lan865x_data *ctx = dev->data;
+	struct oa_tc6 *tc6 = ctx->tc6;
+	int ret;
+
+	k_sem_take(&ctx->tx_rx_sem, K_FOREVER);
+	ret = oa_tc6_send_chunks(tc6, pkt);
+	k_sem_give(&ctx->tx_rx_sem);
+	if (ret < 0) {
+		LOG_ERR("TX transmission error, %d", ret);
+		eth_stats_update_errors_tx(net_pkt_iface(pkt));
+		return ret;
+	}
+
+	return 0;
+}
+
+static const struct ethernet_api lan865x_api_func = {
+	.iface_api.init = lan865x_iface_init,
+	.get_capabilities = lan865x_port_get_capabilities,
+	.set_config = lan865x_set_config,
+	.send = lan865x_port_send,
+};
+
+#define LAN865X_DEFINE(inst)                                                                       \
+	static const struct lan865x_config lan865x_config_##inst = {                               \
+		.spi = SPI_DT_SPEC_INST_GET(inst, SPI_WORD_SET(8), 0),                             \
+		.interrupt = GPIO_DT_SPEC_INST_GET(inst, int_gpios),                               \
+		.reset = GPIO_DT_SPEC_INST_GET(inst, rst_gpios),                                   \
+		.timeout = CONFIG_ETH_LAN865X_TIMEOUT,                                             \
+		.plca_node_id = DT_INST_PROP(inst, plca_node_id),                                  \
+		.plca_node_count = DT_INST_PROP(inst, plca_node_count),                            \
+		.plca_burst_count = DT_INST_PROP(inst, plca_burst_count),                          \
+		.plca_burst_timer = DT_INST_PROP(inst, plca_burst_timer),                          \
+		.plca_to_timer = DT_INST_PROP(inst, plca_to_timer),                                \
+		.plca_enable = DT_INST_PROP(inst, plca_enable),                                    \
+	};                                                                                         \
+												   \
+	struct oa_tc6 oa_tc6_##inst = {                                                            \
+		.cps = 64,                                                                         \
+		.protected = 0,                                                                    \
+		.spi = &lan865x_config_##inst.spi                                                  \
+	};                                                                                         \
+	static struct lan865x_data lan865x_data_##inst = {                                         \
+		.mac_address = DT_INST_PROP(inst, local_mac_address),                              \
+		.tx_rx_sem =                                                                       \
+			Z_SEM_INITIALIZER((lan865x_data_##inst).tx_rx_sem, 1, UINT_MAX),           \
+		.int_sem = Z_SEM_INITIALIZER((lan865x_data_##inst).int_sem, 0, UINT_MAX),          \
+		.tc6 = &oa_tc6_##inst                                                              \
+	};                                                                                         \
+												   \
+	ETH_NET_DEVICE_DT_INST_DEFINE(inst, lan865x_init, NULL, &lan865x_data_##inst,              \
+				      &lan865x_config_##inst, CONFIG_ETH_INIT_PRIORITY,            \
+				      &lan865x_api_func, NET_ETH_MTU);
+
+DT_INST_FOREACH_STATUS_OKAY(LAN865X_DEFINE);

--- a/drivers/ethernet/eth_lan865x_priv.h
+++ b/drivers/ethernet/eth_lan865x_priv.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2023 DENX Software Engineering GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ETH_LAN865X_PRIV_H__
+#define ETH_LAN865X_PRIV_H__
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/net/net_if.h>
+#include <ethernet/eth_stats.h>
+#include "oa_tc6.h"
+
+#define LAN865X_SPI_MAX_FREQUENCY		25000000U
+#define LAN865X_HW_BOOT_DELAY_MS                7
+#define LAN8650_DEVID                           0x8650
+#define LAN8651_DEVID                           0x8651
+#define LAN865X_REV_MASK                        GENMASK(3, 0)
+#define LAN865X_RESET_TIMEOUT                   10
+
+/* Memory Map Sector (MMS) 1 (0x1) */
+#define LAN865x_MAC_NCR		        MMS_REG(0x1, 0x000)
+#define LAN865x_MAC_NCR_TXEN		BIT(3)
+#define LAN865x_MAC_NCR_RXEN		BIT(2)
+#define LAN865x_MAC_NCFGR		MMS_REG(0x1, 0x001)
+#define LAN865x_MAC_NCFGR_CAF		BIT(4)
+#define LAN865x_MAC_SAB1		MMS_REG(0x1, 0x022)
+#define LAN865x_MAC_SAB2		MMS_REG(0x1, 0x024)
+#define LAN865x_MAC_SAT2		MMS_REG(0x1, 0x025)
+
+#define LAN865x_MAC_TXRX_ON             1
+#define LAN865x_MAC_TXRX_OFF            0
+
+/* Memory Map Sector (MMS) 10 (0xA) */
+#define LAN865x_DEVID MMS_REG(0xA, 0x094)
+
+struct lan865x_config {
+	struct spi_dt_spec spi;
+	struct gpio_dt_spec interrupt;
+	struct gpio_dt_spec reset;
+	int32_t timeout;
+
+	/* PLCA */
+	bool plca_enable : 1; /* 1 - PLCA enable, 0 - CSMA/CD enable */
+	uint8_t plca_node_id  /* PLCA node id range: 0 to 254 */;
+	uint8_t plca_node_count;  /* PLCA node count range: 1 to 255 */
+	uint8_t plca_burst_count;  /* PLCA burst count range: 0x0 to 0xFF */
+	uint8_t plca_burst_timer;  /* PLCA burst timer */
+	uint8_t plca_to_timer;  /* PLCA TO value */
+
+	/* MAC */
+	bool tx_cut_through_mode; /* 1 - tx cut through, 0 - Store and forward */
+	bool rx_cut_through_mode; /* 1 - rx cut through, 0 - Store and forward */
+};
+
+struct lan865x_data {
+	struct net_if *iface;
+	struct gpio_callback gpio_int_callback;
+	struct k_sem tx_rx_sem;
+	struct k_sem int_sem;
+	struct oa_tc6 *tc6;
+	uint16_t chip_id;
+	uint8_t silicon_rev;
+	uint8_t mac_address[6];
+	bool iface_initialized;
+	bool reset;
+
+	K_KERNEL_STACK_MEMBER(thread_stack, CONFIG_ETH_LAN865X_IRQ_THREAD_STACK_SIZE);
+	struct k_thread thread;
+	k_tid_t tid_int;
+};
+
+#endif /* ETH_LAN865X_PRIV_H__ */

--- a/drivers/ethernet/oa_tc6.c
+++ b/drivers/ethernet/oa_tc6.c
@@ -1,0 +1,393 @@
+/*
+ * Copyright (c) 2023 DENX Software Engineering GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "oa_tc6.h"
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(oa_tc6, CONFIG_ETHERNET_LOG_LEVEL);
+
+int oa_tc6_reg_read(struct oa_tc6 *tc6, const uint32_t reg, uint32_t *val)
+{
+	uint8_t buf[OA_TC6_HDR_SIZE + 12] = { 0 };
+	struct spi_buf tx_buf = { .buf = buf, .len = sizeof(buf) };
+	const struct spi_buf_set tx = {	.buffers = &tx_buf, .count = 1 };
+	struct spi_buf rx_buf = { .buf = buf, .len = sizeof(buf) };
+	const struct spi_buf_set rx = {	.buffers = &rx_buf, .count = 1 };
+	uint32_t rv, rvn, hdr_bkp, *hdr = (uint32_t *) &buf[0];
+	int ret = 0;
+
+	/*
+	 * Buffers are allocated for protected (larger) case (by 4 bytes).
+	 * When non-protected case - we need to decrase them
+	 */
+	if (!tc6->protected) {
+		tx_buf.len -= sizeof(rvn);
+		rx_buf.len -= sizeof(rvn);
+	}
+
+	*hdr = FIELD_PREP(OA_CTRL_HDR_DNC, 0) |
+		FIELD_PREP(OA_CTRL_HDR_WNR, 0) |
+		FIELD_PREP(OA_CTRL_HDR_AID, 0) |
+		FIELD_PREP(OA_CTRL_HDR_MMS, reg >> 16) |
+		FIELD_PREP(OA_CTRL_HDR_ADDR, reg) |
+		FIELD_PREP(OA_CTRL_HDR_LEN, 0); /* To read single register len = 0 */
+	*hdr |= FIELD_PREP(OA_CTRL_HDR_P, oa_tc6_get_parity(*hdr));
+	hdr_bkp = *hdr;
+	*hdr = sys_cpu_to_be32(*hdr);
+
+	ret = spi_transceive_dt(tc6->spi, &tx, &rx);
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Check if echoed control command header is correct */
+	rv = sys_be32_to_cpu(*(uint32_t *)&buf[4]);
+	if (hdr_bkp != rv) {
+		LOG_ERR("Header transmission error!");
+		return -1;
+	}
+
+	rv = sys_be32_to_cpu(*(uint32_t *)&buf[8]);
+
+	/* In protected mode read data is followed by its compliment value */
+	if (tc6->protected) {
+		rvn = sys_be32_to_cpu(*(uint32_t *)&buf[12]);
+		if (rv != ~rvn) {
+			LOG_ERR("Protected mode transmission error!");
+			return -1;
+		}
+	}
+
+	*val = rv;
+
+	return ret;
+}
+
+int oa_tc6_reg_write(struct oa_tc6 *tc6, const uint32_t reg, uint32_t val)
+{
+	uint8_t buf_tx[OA_TC6_HDR_SIZE + 12] = { 0 };
+	uint8_t buf_rx[OA_TC6_HDR_SIZE + 12] = { 0 };
+	struct spi_buf tx_buf = { .buf = buf_tx, .len = sizeof(buf_tx) };
+	const struct spi_buf_set tx = {	.buffers = &tx_buf, .count = 1 };
+	struct spi_buf rx_buf = { .buf = buf_rx, .len = sizeof(buf_rx) };
+	const struct spi_buf_set rx = {	.buffers = &rx_buf, .count = 1	};
+	uint32_t rv, rvn, hdr_bkp, *hdr = (uint32_t *) &buf_tx[0];
+	int ret;
+
+	/*
+	 * Buffers are allocated for protected (larger) case (by 4 bytes).
+	 * When non-protected case - we need to decrase them
+	 */
+	if (!tc6->protected) {
+		tx_buf.len -= sizeof(rvn);
+		rx_buf.len -= sizeof(rvn);
+	}
+
+	*hdr = FIELD_PREP(OA_CTRL_HDR_DNC, 0) |
+		FIELD_PREP(OA_CTRL_HDR_WNR, 1) |
+		FIELD_PREP(OA_CTRL_HDR_AID, 0) |
+		FIELD_PREP(OA_CTRL_HDR_MMS, reg >> 16) |
+		FIELD_PREP(OA_CTRL_HDR_ADDR, reg) |
+		FIELD_PREP(OA_CTRL_HDR_LEN, 0); /* To read single register len = 0 */
+	*hdr |= FIELD_PREP(OA_CTRL_HDR_P, oa_tc6_get_parity(*hdr));
+	hdr_bkp = *hdr;
+	*hdr = sys_cpu_to_be32(*hdr);
+
+	*(uint32_t *)&buf_tx[4] = sys_cpu_to_be32(val);
+	if (tc6->protected) {
+		*(uint32_t *)&buf_tx[8] = sys_be32_to_cpu(~val);
+	}
+
+	ret = spi_transceive_dt(tc6->spi, &tx, &rx);
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Check if echoed control command header is correct */
+	rv = sys_be32_to_cpu(*(uint32_t *)&buf_rx[4]);
+	if (hdr_bkp != rv) {
+		LOG_ERR("Header transmission error!");
+		return -1;
+	}
+
+	/* Check if echoed value is correct */
+	rv = sys_be32_to_cpu(*(uint32_t *)&buf_rx[8]);
+	if (val != rv) {
+		LOG_ERR("Header transmission error!");
+		return -1;
+	}
+
+	/*
+	 * In protected mode check if read value is followed by its
+	 * compliment value
+	 */
+	if (tc6->protected) {
+		rvn = sys_be32_to_cpu(*(uint32_t *)&buf_rx[12]);
+		if (val != ~rvn) {
+			LOG_ERR("Protected mode transmission error!");
+			return -1;
+		}
+	}
+
+	return ret;
+}
+
+int oa_tc6_set_protected_ctrl(struct oa_tc6 *tc6, bool prote)
+{
+	uint32_t val;
+	int ret;
+
+	ret = oa_tc6_reg_read(tc6, OA_CONFIG0, &val);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (prote) {
+		val |= OA_CONFIG0_PROTE;
+	} else {
+		val &= ~OA_CONFIG0_PROTE;
+	}
+
+	ret = oa_tc6_reg_write(tc6, OA_CONFIG0, val);
+	if (ret < 0) {
+		return ret;
+	}
+
+	tc6->protected = prote;
+	return 0;
+}
+
+int oa_tc6_send_chunks(struct oa_tc6 *tc6, struct net_pkt *pkt)
+{
+	uint16_t len = net_pkt_get_len(pkt);
+	uint8_t oa_tx[tc6->cps];
+	uint32_t hdr, ftr;
+	uint8_t chunks, i;
+	int ret;
+
+	chunks = (len / tc6->cps) + 1;
+
+	/* Check if LAN865x has any free internal buffer space */
+	if (chunks > tc6->txc) {
+		return -EIO;
+	}
+
+	/* Transform struct net_pkt content into chunks */
+	for (i = 1; i <= chunks; i++) {
+		hdr = FIELD_PREP(OA_DATA_HDR_DNC, 1) |
+			FIELD_PREP(OA_DATA_HDR_DV, 1) |
+			FIELD_PREP(OA_DATA_HDR_NORX, 1) |
+			FIELD_PREP(OA_DATA_HDR_SWO, 0);
+
+		if (i == 1) {
+			hdr |=	FIELD_PREP(OA_DATA_HDR_SV, 1);
+		}
+
+		if (i == chunks) {
+			hdr |= FIELD_PREP(OA_DATA_HDR_EBO, len - 1) |
+				FIELD_PREP(OA_DATA_HDR_EV, 1);
+		}
+
+		hdr |= FIELD_PREP(OA_DATA_HDR_P, oa_tc6_get_parity(hdr));
+
+		ret = net_pkt_read(pkt, oa_tx, len > tc6->cps ? tc6->cps : len);
+		if (ret < 0) {
+			return ret;
+		}
+
+		ret = oa_tc6_chunk_spi_transfer(tc6, NULL, oa_tx, hdr, &ftr);
+		if (ret < 0) {
+			return ret;
+		}
+
+		len -= tc6->cps;
+	}
+
+	return 0;
+}
+
+static void oa_tc6_update_status(struct oa_tc6 *tc6, uint32_t ftr)
+{
+	tc6->exst = FIELD_GET(OA_DATA_FTR_EXST, ftr);
+	tc6->sync = FIELD_GET(OA_DATA_FTR_SYNC, ftr);
+	tc6->rca = FIELD_GET(OA_DATA_FTR_RCA, ftr);
+	tc6->txc = FIELD_GET(OA_DATA_FTR_TXC, ftr);
+}
+
+int oa_tc6_update_buf_info(struct oa_tc6 *tc6)
+{
+	uint32_t val;
+	int ret;
+
+	ret = oa_tc6_reg_read(tc6, OA_BUFSTS, &val);
+	if (ret < 0) {
+		return ret;
+	}
+
+	tc6->rca = FIELD_GET(OA_BUFSTS_RCA, val);
+	tc6->txc = FIELD_GET(OA_BUFSTS_TXC, val);
+
+	return 0;
+}
+
+int oa_tc6_chunk_spi_transfer(struct oa_tc6 *tc6, uint8_t *buf_rx, uint8_t *buf_tx,
+				     uint32_t hdr, uint32_t *ftr)
+{
+	struct spi_buf tx_buf[2];
+	struct spi_buf rx_buf[2];
+	struct spi_buf_set tx;
+	struct spi_buf_set rx;
+	int ret;
+
+	hdr = sys_cpu_to_be32(hdr);
+	tx_buf[0].buf = &hdr;
+	tx_buf[0].len = sizeof(hdr);
+
+	tx_buf[1].buf = buf_tx;
+	tx_buf[1].len = tc6->cps;
+
+	tx.buffers = tx_buf;
+	tx.count = ARRAY_SIZE(tx_buf);
+
+	rx_buf[0].buf = buf_rx;
+	rx_buf[0].len = tc6->cps;
+
+	rx_buf[1].buf = ftr;
+	rx_buf[1].len = sizeof(*ftr);
+
+	rx.buffers = rx_buf;
+	rx.count = ARRAY_SIZE(rx_buf);
+
+	ret = spi_transceive_dt(tc6->spi, &tx, &rx);
+	if (ret < 0) {
+		return ret;
+	}
+	*ftr = sys_be32_to_cpu(*ftr);
+	oa_tc6_update_status(tc6, *ftr);
+
+	return 0;
+}
+
+int oa_tc6_read_status(struct oa_tc6 *tc6, uint32_t *ftr)
+{
+	uint32_t hdr;
+
+	hdr = FIELD_PREP(OA_DATA_HDR_DNC, 1) |
+		FIELD_PREP(OA_DATA_HDR_DV, 0) |
+		FIELD_PREP(OA_DATA_HDR_NORX, 1);
+	hdr |= FIELD_PREP(OA_DATA_HDR_P, oa_tc6_get_parity(hdr));
+
+	return oa_tc6_chunk_spi_transfer(tc6, NULL, NULL, hdr, ftr);
+}
+
+int oa_tc6_read_chunks(struct oa_tc6 *tc6, struct net_pkt *pkt)
+{
+	struct net_buf *buf_rx = NULL;
+	uint8_t chunks, sbo, ebo;
+	uint32_t hdr, ftr;
+	int ret;
+
+	/*
+	 * Special case - append already received data (extracted from previous
+	 * chunk) to new packet.
+	 */
+	if (tc6->concat_buf) {
+		net_pkt_append_buffer(pkt, tc6->concat_buf);
+		tc6->concat_buf = NULL;
+	}
+
+	for (chunks = tc6->rca; chunks; chunks--) {
+		buf_rx = net_pkt_get_frag(pkt, tc6->cps, OA_TC6_BUF_ALLOC_TIMEOUT);
+		if (!buf_rx) {
+			LOG_ERR("OA RX: Can't allocate RX buffer fordata!");
+			return -ENOMEM;
+		}
+
+		hdr = FIELD_PREP(OA_DATA_HDR_DNC, 1);
+		hdr |= FIELD_PREP(OA_DATA_HDR_P, oa_tc6_get_parity(hdr));
+
+		ret = oa_tc6_chunk_spi_transfer(tc6, buf_rx->data, NULL, hdr, &ftr);
+		if (ret < 0) {
+			LOG_ERR("OA RX: transmission error: %d!", ret);
+			goto unref_buf;
+		}
+
+		ret = -EIO;
+		if (oa_tc6_get_parity(ftr)) {
+			LOG_ERR("OA RX: Footer parity error!");
+			goto unref_buf;
+		}
+
+		if (!FIELD_GET(OA_DATA_FTR_SYNC, ftr)) {
+			LOG_ERR("OA RX: Configuration not SYNC'ed!");
+			goto unref_buf;
+		}
+
+		if (!FIELD_GET(OA_DATA_FTR_DV, ftr)) {
+			LOG_ERR("OA RX: Data chunk not valid, skip!");
+			goto unref_buf;
+		}
+
+		sbo = FIELD_GET(OA_DATA_FTR_SWO, ftr) * sizeof(uint32_t);
+		ebo = FIELD_GET(OA_DATA_FTR_EBO, ftr) + 1;
+
+		if (FIELD_GET(OA_DATA_FTR_SV, ftr)) {
+			/*
+			 * Adjust beginning of the buffer with SWO only when
+			 * we DO NOT have two frames concatenated together
+			 * in one chunk.
+			 */
+			if (!(FIELD_GET(OA_DATA_FTR_EV, ftr) && (ebo <= sbo))) {
+				if (sbo) {
+					net_buf_pull(buf_rx, sbo);
+				}
+			}
+		}
+
+		net_pkt_append_buffer(pkt, buf_rx);
+		buf_rx->len = tc6->cps;
+
+		if (FIELD_GET(OA_DATA_FTR_EV, ftr)) {
+			/*
+			 * Check if received frame shall be dropped - i.e. MAC has
+			 * detected error condition, which shall result in frame drop
+			 * by the SPI host.
+			 */
+			if (FIELD_GET(OA_DATA_FTR_FD, ftr)) {
+				ret = -EIO;
+				goto unref_buf;
+			}
+
+			/*
+			 * Concatenation of frames in a single chunk - one frame ends
+			 * and second one starts just afterwards (ebo == sbo).
+			 */
+			if (FIELD_GET(OA_DATA_FTR_SV, ftr) && (ebo <= sbo)) {
+				tc6->concat_buf = net_buf_clone(buf_rx, OA_TC6_BUF_ALLOC_TIMEOUT);
+				if (!tc6->concat_buf) {
+					LOG_ERR("OA RX: Can't allocate RX buffer for data!");
+					ret = -ENOMEM;
+					goto unref_buf;
+				}
+				net_buf_pull(tc6->concat_buf, sbo);
+			}
+
+			/* Set final size of the buffer */
+			buf_rx->len = ebo;
+			/*
+			 * Exit when complete packet is read and added to
+			 * struct net_pkt
+			 */
+			break;
+		}
+	}
+
+	return 0;
+
+ unref_buf:
+	net_buf_unref(buf_rx);
+	return ret;
+}

--- a/drivers/ethernet/oa_tc6.h
+++ b/drivers/ethernet/oa_tc6.h
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2023 DENX Software Engineering GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef OA_TC6_CFG_H__
+#define OA_TC6_CFG_H__
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/net/net_pkt.h>
+
+#define MMS_REG(m, r) ((((m) & GENMASK(3, 0)) << 16) | ((r) & GENMASK(15, 0)))
+/* Memory Map Sector (MMS) 0 */
+#define OA_ID                         MMS_REG(0x0, 0x000) /* expect 0x11 */
+#define OA_PHYID                      MMS_REG(0x0, 0x001)
+#define OA_RESET                      MMS_REG(0x0, 0x003)
+#define OA_RESET_SWRESET              BIT(0)
+#define OA_CONFIG0                    MMS_REG(0x0, 0x004)
+#define OA_CONFIG0_SYNC               BIT(15)
+#define OA_CONFIG0_PROTE              BIT(5)
+#define OA_STATUS0                    MMS_REG(0x0, 0x008)
+#define OA_STATUS0_RESETC             BIT(6)
+#define OA_STATUS1                    MMS_REG(0x0, 0x009)
+#define OA_BUFSTS                     MMS_REG(0x0, 0x00B)
+#define OA_BUFSTS_TXC		      GENMASK(15, 8)
+#define OA_BUFSTS_RCA		      GENMASK(7, 0)
+#define OA_IMASK0                     MMS_REG(0x0, 0x00C)
+#define OA_IMASK0_TXPEM               BIT(0)
+#define OA_IMASK0_TXBOEM              BIT(1)
+#define OA_IMASK0_TXBUEM              BIT(2)
+#define OA_IMASK0_RXBOEM              BIT(3)
+#define OA_IMASK0_LOFEM               BIT(4)
+#define OA_IMASK0_HDREM               BIT(5)
+#define OA_IMASK1                     MMS_REG(0x0, 0x00D)
+#define OA_IMASK0_UV18M               BIT(19)
+
+/* OA Control header */
+#define OA_CTRL_HDR_DNC		      BIT(31)
+#define OA_CTRL_HDR_HDRB	      BIT(30)
+#define OA_CTRL_HDR_WNR		      BIT(29)
+#define OA_CTRL_HDR_AID		      BIT(28)
+#define OA_CTRL_HDR_MMS		      GENMASK(27, 24)
+#define OA_CTRL_HDR_ADDR	      GENMASK(23, 8)
+#define OA_CTRL_HDR_LEN		      GENMASK(7, 1)
+#define OA_CTRL_HDR_P		      BIT(0)
+
+/* OA Data header */
+#define OA_DATA_HDR_DNC		      BIT(31)
+#define OA_DATA_HDR_SEQ		      BIT(30)
+#define OA_DATA_HDR_NORX              BIT(29)
+#define OA_DATA_HDR_DV		      BIT(21)
+#define OA_DATA_HDR_SV		      BIT(20)
+#define OA_DATA_HDR_SWO		      GENMASK(19, 16)
+#define OA_DATA_HDR_EV		      BIT(14)
+#define OA_DATA_HDR_EBO		      GENMASK(13, 8)
+#define OA_DATA_HDR_P		      BIT(0)
+
+/* OA Data footer */
+#define OA_DATA_FTR_EXST	      BIT(31)
+#define OA_DATA_FTR_HDRB	      BIT(30)
+#define OA_DATA_FTR_SYNC	      BIT(29)
+#define OA_DATA_FTR_RCA		      GENMASK(28, 24)
+#define OA_DATA_FTR_DV		      BIT(21)
+#define OA_DATA_FTR_SV		      BIT(20)
+#define OA_DATA_FTR_SWO		      GENMASK(19, 16)
+#define OA_DATA_FTR_FD		      BIT(15)
+#define OA_DATA_FTR_EV		      BIT(14)
+#define OA_DATA_FTR_EBO		      GENMASK(13, 8)
+#define OA_DATA_FTR_TXC		      GENMASK(5, 1)
+#define OA_DATA_FTR_P		      BIT(0)
+
+#define OA_TC6_HDR_SIZE		      4
+#define OA_TC6_FTR_SIZE		      4
+#define OA_TC6_BUF_ALLOC_TIMEOUT      K_MSEC(10)
+
+/**
+ * @brief OA TC6 data.
+ */
+struct oa_tc6 {
+	/** Pointer to SPI device */
+	const struct spi_dt_spec *spi;
+
+	/** OA data payload (chunk) size */
+	uint8_t cps;
+
+	/**
+	 * Number of available chunks buffers in OA TC6 device to store
+	 * data for transmission
+	 */
+	uint8_t txc;
+
+	/** Number of available chunks to read from OA TC6 device */
+	uint8_t rca;
+
+	/** Indication of pending interrupt in OA TC6 device */
+	bool exst;
+
+	/** Indication of OA TC6 device being ready for transmission */
+	bool sync;
+
+	/** Indication of protected control transmission mode */
+	bool protected;
+
+	/** Pointer to network buffer concatenated from received chunk */
+	struct net_buf *concat_buf;
+};
+
+typedef struct {
+	uint32_t address;
+	uint32_t value;
+} oa_mem_map_t;
+
+/**
+ * @brief Calculate parity bit from data
+ *
+ * @param x data to calculate parity
+ *
+ * @return 0 if number of ones is odd, 1 otherwise.
+ */
+static inline bool oa_tc6_get_parity(const uint32_t x)
+{
+	uint32_t y;
+
+	y = x ^ (x >> 1);
+	y = y ^ (y >> 2);
+	y = y ^ (y >> 4);
+	y = y ^ (y >> 8);
+	y = y ^ (y >> 16);
+
+	return !(y & 1);
+}
+
+/**
+ * @brief Read OA TC6 compliant device single register
+ *
+ * @param tc6 OA TC6 specific data
+ *
+ * @param reg register to read
+
+ * @param val pointer to variable to store read value
+ *
+ * @return 0 if read was successful, <0 otherwise.
+ */
+int oa_tc6_reg_read(struct oa_tc6 *tc6, const uint32_t reg, uint32_t *val);
+
+/**
+ * @brief Write to OA TC6 compliant device a single register
+ *
+ * @param tc6 OA TC6 specific data
+ *
+ * @param reg register to read
+
+ * @param val data to send to device
+ *
+ * @return 0 if write was successful, <0 otherwise.
+ */
+int oa_tc6_reg_write(struct oa_tc6 *tc6, const uint32_t reg, uint32_t val);
+
+/**
+ * @brief Enable or disable the protected mode for control transactions
+ *
+ * @param tc6 OA TC6 specific data
+ *
+ * @param prote enable or disable protected control transactions
+ *
+ * @return 0 if operation was successful, <0 otherwise.
+ */
+int oa_tc6_set_protected_ctrl(struct oa_tc6 *tc6, bool prote);
+
+/**
+ * @brief Send OA TC6 data chunks to the device
+ *
+ * @param tc6 OA TC6 specific data
+ *
+ * @param pkt network packet to be send
+ *
+ * @return 0 if data send was successful, <0 otherwise.
+ */
+int oa_tc6_send_chunks(struct oa_tc6 *tc6, struct net_pkt *pkt);
+
+/**
+ * @brief Read data chunks from OA TC6 device
+ *
+ * @param tc6 OA TC6 specific data
+ *
+ * @param pkt network packet to store received data
+ *
+ * @return 0 if read was successful, <0 otherwise.
+ */
+int oa_tc6_read_chunks(struct oa_tc6 *tc6, struct net_pkt *pkt);
+
+/**
+ * @brief Perform SPI transfer of single chunk from/to OA TC6 device
+ *
+ * @param tc6 OA TC6 specific data
+ *
+ * @param buf_rx buffer to store read data
+ *
+ * @param buf_tx buffer with data to send
+ *
+ * @param hdr OA TC6 data transmission header value
+ *
+ * @param ftr poniter to OA TC6 data received footer
+ *
+ * @return 0 if transmission was successful, <0 otherwise.
+ */
+int oa_tc6_chunk_spi_transfer(struct oa_tc6 *tc6, uint8_t *buf_rx, uint8_t *buf_tx,
+			      uint32_t hdr, uint32_t *ftr);
+
+/**
+ * @brief Read status from OA TC6 device
+ *
+ * @param tc6 OA TC6 specific data
+ *
+ * @param ftr poniter to OA TC6 data received footer
+ *
+ * @return 0 if successful, <0 otherwise.
+ */
+int oa_tc6_read_status(struct oa_tc6 *tc6, uint32_t *ftr);
+
+/**
+ * @brief Read from OA TC6 device and update buffer information
+ *
+ * @param tc6 OA TC6 specific data
+ *
+ * @return 0 if successful, <0 otherwise.
+ */
+int oa_tc6_update_buf_info(struct oa_tc6 *tc6);
+#endif /* OA_TC6_CFG_H__ */

--- a/dts/bindings/ethernet/microchip,lan865x.yaml
+++ b/dts/bindings/ethernet/microchip,lan865x.yaml
@@ -1,0 +1,46 @@
+# Copyright (c) 2023 DENX Software Engineering GmbH
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  LAN865x standalone 10BASE-T1L Ethernet controller with SPI interface.
+
+compatible: "microchip,lan865x"
+
+include: [spi-device.yaml, ethernet-controller.yaml]
+
+properties:
+  tx-cut-through-mode:
+    type: boolean
+    description: Enable TX cut through mode
+  rx-cut-through-mode:
+    type: boolean
+    description: Enable RX cut through mode
+  plca-enable:
+    type: boolean
+    description: Enable or disable PLCA support
+  plca-node-id:
+    type: int
+    description: Specify the PLCA node ID number
+  plca-node-count:
+    type: int
+    description: Specify the PLCA node count
+  plca-burst-count:
+    type: int
+    description: Specify the PLCA burst count
+  plca-burst-timer:
+    type: int
+    description: Specify the PLCA burst timer value
+  plca-to-timer:
+    type: int
+    description: Specify the PLCA to timer value
+  int-gpios:
+    type: phandle-array
+    required: true
+    description: |
+      The interrupt pin of LAN865X is active low.
+      If connected directly the MCU pin should be configured
+      as active low.
+  rst-gpios:
+    type: phandle-array
+    required: true
+    description: The reset pin of LAN865X.


### PR DESCRIPTION
This patch set provides support for T1S ethernet device - LAN8651.

For communication the approach described in Open Alliance TC6 specification is used. This code (from oa_tc6.[ch]) can be reused with other ICs following this standard.

Test HW:
- nucleo_g491re development board from STM
- Microe LAN8651 module
- LAN8670-USB dongle with debian12 as host

Build:
```
west build -p always -b nucleo_g431rb samples/net/sockets/echo_server/ \
	-- -DCONF_FILE=boards/nucleo_g431rb.conf
```
Test on host PC (one needs to first build echo-client program from net-tools):
```
while :; do ./echo-client -r -i enx001ec0d1cc4d  192.168.3.3; sleep 1; \
	ping -c3 192.168.3.3; done
```

Code required for testing and debugging:
https://github.com/lmajewski/zephyr/commits/t1s-lan8651-nucleo_g431rb-test