### PR TITLE
doc: samples: add JSON-LD and meta description for code samples

### DIFF
--- a/doc/_extensions/zephyr/domain.py
+++ b/doc/_extensions/zephyr/domain.py
@@ -98,9 +98,6 @@ class ConvertCodeSampleNode(SphinxTransform):
             new_section = nodes.section(ids=[node["id"]])
             new_section += nodes.title(text=node["name"])
 
-            # Move existing content from the custom node to the new section
-            new_section.extend(node.children)
-
             # Move the sibling nodes under the new section
             new_section.extend(siblings_to_move)
 


### PR DESCRIPTION
Since samples are starting to leverage the new `:zephyr:code-sample` directive, let's leverage the available meta data to expose structured information to search engines.

This PR adds JSON-LD markup to the HTML output of code sample pages, and also sets the meta-description of the document to the sample's description. 

Note regarding JSON-LD: I refrained from setting the "programmingLanguage" property to "C" since we do have a few code samples in C++, so we'd need to capture the information about the main programming language in the directive, defaulting to C, or, more likely, we probably don't really care about this level of detail.

Example of the metadata made available through the added markup:

<img width="741" alt="image" src="https://github.com/zephyrproject-rtos/zephyr/assets/128251/913c707a-48f0-420b-ae86-ca2556b23dc4">
