### PR TITLE
dts: bindings: adxl372-i2c: update description

### DIFF
--- a/dts/bindings/sensor/adi,adxl372-i2c.yaml
+++ b/dts/bindings/sensor/adi,adxl372-i2c.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2018 Analog Devices Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-description: ADXL372 3-axis high-g I2C/SPI accelerometer
+description: ADXL372 3-axis high-g accelerometer, accessed through I2C bus
 
 compatible: "adi,adxl372"
 


### PR DESCRIPTION
Specify only the bus corresponding to the current yaml file, as done in the adi,adxl372-spi.yaml.