### PR TITLE
twister: harness: Fix Console pattern matching for ztest

### DIFF
--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -1037,6 +1037,9 @@ class ProjectBuilder(FilterBuilder):
         instance = self.instance
 
         if instance.handler.ready:
+            logger.info(f"Reset instance status from '{instance.status}' to None before run.")
+            instance.status = None
+
             if instance.handler.type_str == "device":
                 instance.handler.duts = self.duts
 


### PR DESCRIPTION
Fix the Twister Console harness ordered 'multi_line' and 'one_line' pattern matching to treat the ztest as failed when not all of the expected patterns were found in the console output, but the ztest application itself reports 'PROJECT EXECUTION SUCCESSFUL'.
Currently, the Console harness with ztest is used (in tree) for:
* tests/subsys/debug/coredump_backends
* tests/boards/intel_adsp/hda_log
* tests/drivers/coredump/coredump_api

Reset TestInstance status when ProjectBuilder.run() is called to run the test after its successful build, so the build status will not propagate as the run status if the run fails.

Separating this fix from #63472