### PR TITLE
SPARC: Add support for coredump

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -66,6 +66,7 @@ config SPARC
 	bool
 	select ARCH_IS_SET
 	select HAS_DTS
+	select ARCH_SUPPORTS_COREDUMP
 	select USE_SWITCH
 	select USE_SWITCH_SUPPORTED
 	select BIG_ENDIAN

--- a/arch/sparc/core/CMakeLists.txt
+++ b/arch/sparc/core/CMakeLists.txt
@@ -18,3 +18,4 @@ zephyr_library_sources(
 
 zephyr_library_sources_ifdef(CONFIG_IRQ_OFFLOAD irq_offload.c)
 zephyr_library_sources_ifdef(CONFIG_THREAD_LOCAL_STORAGE tls.c)
+zephyr_library_sources_ifdef(CONFIG_DEBUG_COREDUMP coredump.c)

--- a/arch/sparc/core/coredump.c
+++ b/arch/sparc/core/coredump.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2023 Frontgrade Gaisler AB
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <string.h>
+#include <zephyr/debug/coredump.h>
+
+#define ARCH_HDR_VER 1
+
+struct arch_block {
+	struct {
+		uint32_t out[8];
+		uint32_t global[8];
+		uint32_t psr;
+		uint32_t pc;
+		uint32_t npc;
+		uint32_t wim;
+		uint32_t tbr;
+		uint32_t y;
+	} r;
+} __packed;
+
+static struct arch_block arch_blk;
+
+void arch_coredump_info_dump(const z_arch_esf_t *esf)
+{
+	struct coredump_arch_hdr_t hdr = {
+		.id = COREDUMP_ARCH_HDR_ID,
+		.hdr_version = ARCH_HDR_VER,
+		.num_bytes = sizeof(arch_blk),
+	};
+
+	if (esf == NULL) {
+		return;
+	}
+
+	(void)memset(&arch_blk, 0, sizeof(arch_blk));
+
+	for (int i = 0; i < 8; i++) {
+		arch_blk.r.out[i] = esf->out[i];
+		arch_blk.r.global[i] = esf->global[i];
+	}
+	arch_blk.r.psr = esf->psr;
+	arch_blk.r.pc = esf->pc;
+	arch_blk.r.npc = esf->npc;
+	arch_blk.r.wim = esf->wim;
+	arch_blk.r.tbr = esf->tbr;
+	arch_blk.r.y = esf->y;
+
+	coredump_buffer_output((uint8_t *)&hdr, sizeof(hdr));
+	coredump_buffer_output((uint8_t *)&arch_blk, sizeof(arch_blk));
+}
+
+uint16_t arch_coredump_tgt_code_get(void)
+{
+	return COREDUMP_TGT_SPARC;
+}

--- a/include/zephyr/debug/coredump.h
+++ b/include/zephyr/debug/coredump.h
@@ -145,6 +145,7 @@ enum coredump_tgt_code {
 	COREDUMP_TGT_RISC_V,
 	COREDUMP_TGT_XTENSA,
 	COREDUMP_TGT_ARM64,
+	COREDUMP_TGT_SPARC,
 };
 
 /* Coredump header */

--- a/subsys/debug/coredump/coredump_core.c
+++ b/subsys/debug/coredump/coredump_core.c
@@ -177,8 +177,8 @@ void coredump_memory_dump(uintptr_t start_addr, uintptr_t end_addr)
 	m.hdr_version = COREDUMP_MEM_HDR_VER;
 
 	if (sizeof(uintptr_t) == 8) {
-		m.start	= sys_cpu_to_le64(start_addr);
-		m.end = sys_cpu_to_le64(end_addr);
+		m.start	= sys_cpu_to_le64((uint64_t) start_addr);
+		m.end = sys_cpu_to_le64((uint64_t) end_addr);
 	} else if (sizeof(uintptr_t) == 4) {
 		m.start	= sys_cpu_to_le32(start_addr);
 		m.end = sys_cpu_to_le32(end_addr);


### PR DESCRIPTION
This adds the kernel support for coredump on SPARC architectures. All information available in `z_arch_esf_t` is dumped.

Testcases which filter on `ARCH_SUPPORTS_COREDUMP` have been run with twister and reports PASSED on the following boards:
- qemu_leon3
- generic_leon3
- gr716a_mini