### PR TITLE
mgmt: mcumgr: update bt smp initialization

### DIFF
--- a/subsys/mgmt/mcumgr/transport/src/smp_bt.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp_bt.c
@@ -675,7 +675,7 @@ static void smp_bt_setup(void)
 	if (rc == 0) {
 		smp_client_transport.smpt = &smp_bt_transport;
 		smp_client_transport.smpt_type = SMP_BLUETOOTH_TRANSPORT;
-		rc = smp_client_transport_register(&smp_client_transport);
+		smp_client_transport_register(&smp_client_transport);
 	}
 #endif
 


### PR DESCRIPTION
Small oneline fix to smp_bt.c smp transport register. 

`smp_client_transport_register()` is a void function and has no return value, so it should be ignored.