### PR TITLE
drivers: flash: flexspi_mx25um513: enforce write size limit in DTR mode

### DIFF
--- a/drivers/flash/flash_mcux_flexspi_mx25um51345g.c
+++ b/drivers/flash/flash_mcux_flexspi_mx25um51345g.c
@@ -17,7 +17,6 @@
 #include <fsl_cache.h>
 #endif
 
-#define NOR_WRITE_SIZE	1
 #define NOR_ERASE_VALUE	0xff
 
 #ifdef CONFIG_FLASH_MCUX_FLEXSPI_NOR_WRITE_BUFFER
@@ -40,8 +39,11 @@ static uint8_t nor_write_buf[SPI_NOR_PAGE_SIZE];
 /* FLASH_ENABLE_OCTAL_CMD: (01 = STR OPI Enable) , (02 = DTR OPI Enable) */
 #if CONFIG_FLASH_MCUX_FLEXSPI_MX25UM51345G_OPI_DTR
 #define NOR_FLASH_ENABLE_OCTAL_CMD 0x2
+/* In OPI DTR mode, all writes must be 2 byte aligned, and multiples of 2 bytes */
+#define NOR_WRITE_SIZE	2
 #else
 #define NOR_FLASH_ENABLE_OCTAL_CMD 0x1
+#define NOR_WRITE_SIZE	1
 #endif
 
 LOG_MODULE_REGISTER(flash_flexspi_nor, CONFIG_FLASH_LOG_LEVEL);
@@ -387,6 +389,12 @@ static int flash_flexspi_nor_write(const struct device *dev, off_t offset,
 		 * code and data accessed must reside in ram.
 		 */
 		key = irq_lock();
+	}
+	if (IS_ENABLED(CONFIG_FLASH_MCUX_FLEXSPI_MX25UM51345G_OPI_DTR)) {
+		/* Check that write size and length are even */
+		if ((offset & 0x1) || (len & 0x1)) {
+			return -EINVAL;
+		}
 	}
 
 	while (len) {


### PR DESCRIPTION
Per the MX25UM51325G datasheet, all page programs in OPI DTR mode need to start at an even address, and be of even length. Update the minimum write size reported by the driver and check all writes when OPI DTR mode is enabled, so that subsystems using the flash driver can align to this requirement.

Fixes #63639