### PR TITLE
drivers: led: led_pwm: Fix PM callback error logging

### DIFF
--- a/drivers/led/led_pwm.c
+++ b/drivers/led/led_pwm.c
@@ -116,7 +116,7 @@ static int led_pwm_pm_action(const struct device *dev,
 
 		err = pm_device_action_run(led->dev, action);
 		if (err && (err != -EALREADY)) {
-			LOG_ERR("Cannot switch PWM %p power state", led->dev);
+			LOG_DBG("Cannot switch PWM %p power state (err = %d)", led->dev, err);
 		}
 	}
 


### PR DESCRIPTION
If the underlying PWM device does not have a PM callback, the PWM LED driver will flood the console with error logs. The change ignores the error if there is no PM callback for the PWM device.