### PR TITLE
llext: Update the sample readme with a board

### DIFF
--- a/samples/subsys/llext/shell_loader/README.rst
+++ b/samples/subsys/llext/shell_loader/README.rst
@@ -13,13 +13,14 @@ ability to manage loadable code extensions in the shell.
 Requirements
 ************
 
-A board with shell capable console.
+A board with a supported llext architecture and shell capable console.
 
 Building
 ********
 
 .. zephyr-app-commands::
    :zephyr-app: samples/subsys/llext/shell_loader
+   :board: tdk_robokit1
    :goals: build
    :compact:
 


### PR DESCRIPTION
The commands showing west build had -b None which isn't quite right. Add a :board: property with the tdk_robokit1 as its what I tested on myself. Also noted that llext isn't supported on every architecture but intentionally left this a bit vague as updating this little comment every time something is added seems like a recipe for doc rot.