### PR TITLE
dsi_mcux_2l changes

### DIFF
--- a/drivers/mipi_dsi/dsi_mcux_2l.c
+++ b/drivers/mipi_dsi/dsi_mcux_2l.c
@@ -162,7 +162,8 @@ static int dsi_mcux_tx_color(const struct device *dev, uint8_t channel,
 		.sendDscCmd = true,
 		.dscCmd = msg->cmd,
 		.txDataType = kDSI_TxDataDcsLongWr,
-		.flags = kDSI_TransferUseHighSpeed,
+		/* default to high speed unless told to use low power */
+		.flags = (msg->flags & MIPI_DSI_MSG_USE_LPM) ? 0 : kDSI_TransferUseHighSpeed,
 	};
 
 	/*
@@ -354,6 +355,8 @@ static ssize_t dsi_mcux_transfer(const struct device *dev, uint8_t channel,
 	dsi_xfer.txData = msg->tx_buf;
 	dsi_xfer.rxDataSize = msg->rx_len;
 	dsi_xfer.rxData = msg->rx_buf;
+	/* default to high speed unless told to use low power */
+	dsi_xfer.flags = (msg->flags & MIPI_DSI_MSG_USE_LPM) ? 0 : kDSI_TransferUseHighSpeed;
 
 	switch (msg->type) {
 	case MIPI_DSI_DCS_READ:
@@ -373,7 +376,6 @@ static ssize_t dsi_mcux_transfer(const struct device *dev, uint8_t channel,
 		dsi_xfer.sendDscCmd = true;
 		dsi_xfer.dscCmd = msg->cmd;
 		dsi_xfer.txDataType = kDSI_TxDataDcsLongWr;
-		dsi_xfer.flags = kDSI_TransferUseHighSpeed;
 		if (msg->flags & MCUX_DSI_2L_FB_DATA) {
 			/*
 			 * Special case- transfer framebuffer data using

--- a/drivers/mipi_dsi/dsi_mcux_2l.c
+++ b/drivers/mipi_dsi/dsi_mcux_2l.c
@@ -28,6 +28,7 @@ struct mcux_mipi_dsi_config {
 	MIPI_DSI_HOST_Type *base;
 	dsi_dpi_config_t dpi_config;
 	bool auto_insert_eotp;
+	bool noncontinuous_hs_clk;
 	const struct device *bit_clk_dev;
 	clock_control_subsys_t bit_clk_subsys;
 	const struct device *esc_clk_dev;
@@ -224,6 +225,7 @@ static int dsi_mcux_attach(const struct device *dev,
 	DSI_GetDefaultConfig(&dsi_config);
 	dsi_config.numLanes = mdev->data_lanes;
 	dsi_config.autoInsertEoTp = config->auto_insert_eotp;
+	dsi_config.enableNonContinuousHsClk = config->noncontinuous_hs_clk;
 
 	/* Init the DSI module. */
 	DSI_Init(config->base, &dsi_config);
@@ -502,6 +504,7 @@ static int mcux_mipi_dsi_init(const struct device *dev)
 		(.irq_config_func = mipi_dsi_##n##_irq_config_func,))				\
 		.base = (MIPI_DSI_HOST_Type *)DT_INST_REG_ADDR(id),				\
 		.auto_insert_eotp = DT_INST_PROP(id, autoinsert_eotp),				\
+		.noncontinuous_hs_clk = DT_INST_PROP(id, noncontinuous_hs_clk),			\
 		.dphy_ref_freq = DT_INST_PROP_OR(id, dphy_ref_frequency, 0),			\
 		.bit_clk_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR_BY_NAME(id, dphy)),		\
 		.bit_clk_subsys =								\

--- a/dts/bindings/mipi-dsi/nxp,mipi-dsi-2l.yaml
+++ b/dts/bindings/mipi-dsi/nxp,mipi-dsi-2l.yaml
@@ -70,3 +70,9 @@ properties:
     description:
       Maximum clock speed supported by the device, in Hz. Leave at default
       if no DPHY PLL is present
+
+  noncontinuous-hs-clk:
+    type: boolean
+    description:
+      Enable non-contiuous high speed clock. Saves power but introduces latency
+      when transitioning to high speed mode.

--- a/include/zephyr/drivers/mipi_dsi.h
+++ b/include/zephyr/drivers/mipi_dsi.h
@@ -217,6 +217,12 @@ struct mipi_dsi_device {
 	uint32_t mode_flags;
 };
 
+/*
+ * Per message flag to indicate the message must be sent
+ * using Low Power Mode instead of controller default.
+ */
+#define MIPI_DSI_MSG_USE_LPM BIT(0x0)
+
 /** MIPI-DSI read/write message. */
 struct mipi_dsi_msg {
 	/** Payload data type. */


### PR DESCRIPTION
CL1: use pxfmt to select SMARTDMA slot instead of hardcoding it to RGB565/RGB565_SWAP. This allows support for displays that use pxfmt RGB888.

CL2: allow msg to select high speed mode transfers instead of hardcoding some messages to use high speed mode and some to use low power mode

