### PR TITLE
bluetooth: conn: Fix compiler warning

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -579,7 +579,7 @@ static inline uint16_t conn_mtu(struct bt_conn *conn)
 static int do_send_frag(struct bt_conn *conn, struct net_buf *buf, uint8_t flags)
 {
 	struct bt_conn_tx *tx = tx_data(buf)->tx;
-	uint32_t *pending_no_cb;
+	uint32_t *pending_no_cb = NULL;
 	unsigned int key;
 	int err = 0;
 


### PR DESCRIPTION
When compiling conn.c using arm-none-eabi-gcc version 11.3.1 20220712 with the -Wmaybe-uninitialized flag a warning is emitted due to pending_no_cb not being initialized. I'm not sure if initializing it to NULL is the "correct" fix, but it's certainly not any worse then it being uninitialized, and it fixes the warning.