### PR TITLE
random: Rename random header

### DIFF
--- a/drivers/entropy/entropy_mcux_caam.c
+++ b/drivers/entropy/entropy_mcux_caam.c
@@ -8,7 +8,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/entropy.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 

--- a/drivers/entropy/entropy_mcux_css.c
+++ b/drivers/entropy/entropy_mcux_css.c
@@ -11,7 +11,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/entropy.h>
 #include <zephyr/init.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 static int entropy_mcux_css_get_entropy(const struct device *dev, uint8_t *buffer, uint16_t length)
 {

--- a/drivers/entropy/entropy_mcux_rng.c
+++ b/drivers/entropy/entropy_mcux_rng.c
@@ -8,7 +8,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/entropy.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <zephyr/init.h>
 
 #include "fsl_rng.h"

--- a/drivers/entropy/entropy_mcux_rnga.c
+++ b/drivers/entropy/entropy_mcux_rnga.c
@@ -8,7 +8,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/entropy.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <zephyr/init.h>
 
 #include "fsl_rnga.h"

--- a/drivers/entropy/entropy_mcux_trng.c
+++ b/drivers/entropy/entropy_mcux_trng.c
@@ -8,7 +8,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/entropy.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <zephyr/init.h>
 
 #include "fsl_trng.h"

--- a/drivers/entropy/entropy_rv32m1_trng.c
+++ b/drivers/entropy/entropy_rv32m1_trng.c
@@ -8,7 +8,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/entropy.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <zephyr/init.h>
 
 #include "fsl_trng.h"

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -12,7 +12,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/entropy.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <zephyr/init.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/util.h>

--- a/drivers/ethernet/eth.h
+++ b/drivers/ethernet/eth.h
@@ -8,7 +8,7 @@
 #define ZEPHYR_DRIVERS_ETHERNET_ETH_H_
 
 #include <zephyr/types.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 /* helper macro to return mac address octet from local_mac_address prop */
 #define NODE_MAC_ADDR_OCTET(node, n) DT_PROP_BY_IDX(node, local_mac_address, n)

--- a/drivers/flash/flash_simulator.c
+++ b/drivers/flash/flash_simulator.c
@@ -13,7 +13,7 @@
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <zephyr/stats/stats.h>
 #include <string.h>
 

--- a/drivers/ieee802154/ieee802154_b91.c
+++ b/drivers/ieee802154/ieee802154_b91.c
@@ -19,7 +19,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <zephyr/net/ieee802154_radio.h>
 #include <zephyr/irq.h>
 #if defined(CONFIG_NET_L2_OPENTHREAD)

--- a/drivers/ieee802154/ieee802154_cc1200.c
+++ b/drivers/ieee802154/ieee802154_cc1200.c
@@ -27,7 +27,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #include <zephyr/sys/byteorder.h>
 #include <string.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include <zephyr/drivers/spi.h>
 #include <zephyr/drivers/gpio.h>

--- a/drivers/ieee802154/ieee802154_cc13xx_cc26xx.c
+++ b/drivers/ieee802154/ieee802154_cc13xx_cc26xx.c
@@ -17,7 +17,7 @@ LOG_MODULE_REGISTER(ieee802154_cc13xx_cc26xx);
 #include <zephyr/net/ieee802154_radio.h>
 #include <zephyr/net/ieee802154.h>
 #include <zephyr/net/net_pkt.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <string.h>
 #include <zephyr/sys/sys_io.h>
 

--- a/drivers/ieee802154/ieee802154_cc13xx_cc26xx_subg.c
+++ b/drivers/ieee802154/ieee802154_cc13xx_cc26xx_subg.c
@@ -17,7 +17,7 @@ LOG_MODULE_REGISTER(ieee802154_cc13xx_cc26xx_subg);
 #include <zephyr/net/ieee802154.h>
 #include <zephyr/net/ieee802154_radio.h>
 #include <zephyr/net/net_pkt.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/crc.h>
 #include <zephyr/sys/sys_io.h>

--- a/drivers/ieee802154/ieee802154_cc2520.c
+++ b/drivers/ieee802154/ieee802154_cc2520.c
@@ -27,7 +27,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #include <zephyr/sys/byteorder.h>
 #include <string.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include <zephyr/drivers/gpio.h>
 

--- a/drivers/ieee802154/ieee802154_dw1000.c
+++ b/drivers/ieee802154/ieee802154_dw1000.c
@@ -18,7 +18,7 @@ LOG_MODULE_REGISTER(dw1000, LOG_LEVEL_INF);
 
 #include <zephyr/sys/byteorder.h>
 #include <string.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <zephyr/debug/stack.h>
 #include <math.h>
 

--- a/drivers/ieee802154/ieee802154_kw41z.c
+++ b/drivers/ieee802154/ieee802154_kw41z.c
@@ -22,7 +22,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/sys/byteorder.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include "fsl_xcvr.h"
 

--- a/drivers/ieee802154/ieee802154_mcr20a.c
+++ b/drivers/ieee802154/ieee802154_mcr20a.c
@@ -27,7 +27,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #include <zephyr/sys/byteorder.h>
 #include <string.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <zephyr/debug/stack.h>
 
 #include <zephyr/drivers/gpio.h>

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -39,7 +39,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #include <zephyr/sys/byteorder.h>
 #include <string.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include <zephyr/net/ieee802154_radio.h>
 #include <zephyr/irq.h>

--- a/drivers/ieee802154/ieee802154_rf2xx.c
+++ b/drivers/ieee802154/ieee802154_rf2xx.c
@@ -29,7 +29,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #include <zephyr/sys/byteorder.h>
 #include <string.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <zephyr/linker/sections.h>
 #include <zephyr/sys/atomic.h>
 

--- a/drivers/ieee802154/ieee802154_uart_pipe.c
+++ b/drivers/ieee802154/ieee802154_uart_pipe.c
@@ -21,7 +21,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <zephyr/init.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_pkt.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include <zephyr/drivers/uart_pipe.h>
 #include <zephyr/net/ieee802154_radio.h>

--- a/drivers/modem/wncm14a2a.c
+++ b/drivers/modem/wncm14a2a.c
@@ -20,7 +20,7 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/device.h>
 #include <zephyr/init.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include <zephyr/net/net_context.h>
 #include <zephyr/net/net_if.h>

--- a/drivers/net/ppp.c
+++ b/drivers/net/ppp.c
@@ -31,7 +31,7 @@ LOG_MODULE_REGISTER(net_ppp, LOG_LEVEL);
 #include <zephyr/sys/crc.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/drivers/console/uart_mux.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include "../../subsys/net/ip/net_stats.h"
 #include "../../subsys/net/ip/net_private.h"

--- a/drivers/net/slip.c
+++ b/drivers/net/slip.c
@@ -28,7 +28,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/dummy.h>
 #include <zephyr/drivers/uart_pipe.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include "slip.h"
 

--- a/include/zephyr/random/rand32.h
+++ b/include/zephyr/random/rand32.h
@@ -1,86 +1,15 @@
 /*
  * Copyright (c) 2013-2014 Wind River Systems, Inc.
+ * Copyright (c) 2023 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
- * @file
- * @brief Random number generator header file
- *
- * This header file declares prototypes for the kernel's random number
- * generator APIs.
- *
- * Typically, a platform enables the appropriate source for the random
- * number generation based on the hardware platform's capabilities or
- * (for testing purposes only) enables the TEST_RANDOM_GENERATOR
- * configuration option.
  */
 
 #ifndef ZEPHYR_INCLUDE_RANDOM_RAND32_H_
 #define ZEPHYR_INCLUDE_RANDOM_RAND32_H_
 
-#include <zephyr/types.h>
-#include <stddef.h>
-#include <zephyr/kernel.h>
+#include <zephyr/random/random.h>
 
-/**
- * @brief Random Function APIs
- * @defgroup random_api Random Function APIs
- * @ingroup crypto
- * @{
- */
+#warning "<zephyr/random/rand32.h> is deprecated, include <zephyr/random/random.h> instead"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-/**
- * @brief Return a 32-bit random value that should pass general
- * randomness tests.
- *
- * @note The random value returned is not a cryptographically secure
- * random number value.
- *
- * @return 32-bit random value.
- */
-__syscall uint32_t sys_rand32_get(void);
-
-/**
- * @brief Fill the destination buffer with random data values that should
- * pass general randomness tests.
- *
- * @note The random values returned are not considered cryptographically
- * secure random number values.
- *
- * @param [out] dst destination buffer to fill with random data.
- * @param len size of the destination buffer.
- *
- */
-__syscall void sys_rand_get(void *dst, size_t len);
-
-/**
- * @brief Fill the destination buffer with cryptographically secure
- * random data values.
- *
- * @note If the random values requested do not need to be cryptographically
- * secure then use sys_rand_get() instead.
- *
- * @param [out] dst destination buffer to fill.
- * @param len size of the destination buffer.
- *
- * @return 0 if success, -EIO if entropy reseed error
- *
- */
-__syscall int sys_csrand_get(void *dst, size_t len);
-
-#ifdef __cplusplus
-}
-#endif
-
-/**
- * @}
- */
-
-#include <syscalls/rand32.h>
 #endif /* ZEPHYR_INCLUDE_RANDOM_RAND32_H_ */

--- a/include/zephyr/random/random.h
+++ b/include/zephyr/random/random.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2013-2014 Wind River Systems, Inc.
+ * Copyright (c) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Random number generator header file
+ *
+ * This header file declares prototypes for the kernel's random number
+ * generator APIs.
+ *
+ * Typically, a platform enables the appropriate source for the random
+ * number generation based on the hardware platform's capabilities or
+ * (for testing purposes only) enables the TEST_RANDOM_GENERATOR
+ * configuration option.
+ */
+
+#ifndef ZEPHYR_INCLUDE_RANDOM_RANDOM_H_
+#define ZEPHYR_INCLUDE_RANDOM_RANDOM_H_
+
+#include <zephyr/types.h>
+#include <stddef.h>
+#include <zephyr/kernel.h>
+
+/**
+ * @brief Random Function APIs
+ * @defgroup random_api Random Function APIs
+ * @ingroup crypto
+ * @{
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Return a 32-bit random value that should pass general
+ * randomness tests.
+ *
+ * @note The random value returned is not a cryptographically secure
+ * random number value.
+ *
+ * @return 32-bit random value.
+ */
+__syscall uint32_t sys_rand32_get(void);
+
+/**
+ * @brief Fill the destination buffer with random data values that should
+ * pass general randomness tests.
+ *
+ * @note The random values returned are not considered cryptographically
+ * secure random number values.
+ *
+ * @param [out] dst destination buffer to fill with random data.
+ * @param len size of the destination buffer.
+ *
+ */
+__syscall void sys_rand_get(void *dst, size_t len);
+
+/**
+ * @brief Fill the destination buffer with cryptographically secure
+ * random data values.
+ *
+ * @note If the random values requested do not need to be cryptographically
+ * secure then use sys_rand_get() instead.
+ *
+ * @param [out] dst destination buffer to fill.
+ * @param len size of the destination buffer.
+ *
+ * @return 0 if success, -EIO if entropy reseed error
+ *
+ */
+__syscall int sys_csrand_get(void *dst, size_t len);
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+
+#include <syscalls/random.h>
+#endif /* ZEPHYR_INCLUDE_RANDOM_RANDOM_H_ */

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -15,7 +15,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/debug/stack.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <zephyr/linker/sections.h>
 #include <zephyr/toolchain.h>
 #include <zephyr/kernel_structs.h>

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -26,7 +26,7 @@
 #include <stdbool.h>
 #include <zephyr/irq_offload.h>
 #include <zephyr/sys/check.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/iterable_sections.h>

--- a/lib/os/thread_entry.c
+++ b/lib/os/thread_entry.c
@@ -13,7 +13,7 @@
 
 #include <zephyr/kernel.h>
 #ifdef CONFIG_THREAD_LOCAL_STORAGE
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 __thread k_tid_t z_tls_current;
 #endif

--- a/modules/mbedtls/zephyr_init.c
+++ b/modules/mbedtls/zephyr_init.c
@@ -13,7 +13,7 @@
 #include <zephyr/init.h>
 #include <zephyr/app_memory/app_memdomain.h>
 #include <zephyr/drivers/entropy.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <mbedtls/entropy.h>
 
 #include <mbedtls/debug.h>

--- a/modules/openthread/platform/entropy.c
+++ b/modules/openthread/platform/entropy.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <zephyr/logging/log.h>
 
 #include <openthread/platform/entropy.h>

--- a/modules/openthread/platform/settings.c
+++ b/modules/openthread/platform/settings.c
@@ -7,7 +7,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/settings/settings.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include <openthread/platform/settings.h>
 

--- a/samples/arch/smp/pktqueue/src/main.h
+++ b/samples/arch/smp/pktqueue/src/main.h
@@ -7,7 +7,7 @@
 #include <zephyr/kernel.h>
 #include <stdio.h>
 #include <zephyr/sys/crc.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 
 /* Amount of parallel processed sender/receiver queues of packet headers */

--- a/samples/arch/smp/pktqueue/src/pktqueue.h
+++ b/samples/arch/smp/pktqueue/src/pktqueue.h
@@ -7,7 +7,7 @@
 #include <zephyr/kernel.h>
 #include <stdio.h>
 #include <zephyr/sys/crc.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 struct phdr_desc {
 	struct phdr_desc  *next;    /* Next pkt descriptor in respective queue */

--- a/samples/basic/hash_map/src/main.c
+++ b/samples/basic/hash_map/src/main.c
@@ -7,7 +7,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/hash_map.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 LOG_MODULE_REGISTER(hashmap_sample);
 

--- a/samples/bluetooth/peripheral_csc/src/main.c
+++ b/samples/bluetooth/peripheral_csc/src/main.c
@@ -11,7 +11,7 @@
 #include <stddef.h>
 #include <string.h>
 #include <errno.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/kernel.h>

--- a/samples/net/cloud/aws_iot_mqtt/src/main.c
+++ b/samples/net/cloud/aws_iot_mqtt/src/main.c
@@ -17,7 +17,7 @@
 #include <zephyr/net/sntp.h>
 #include <zephyr/net/tls_credentials.h>
 #include <zephyr/data/json.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <zephyr/posix/time.h>
 #include <zephyr/logging/log.h>
 

--- a/samples/net/cloud/mqtt_azure/src/main.c
+++ b/samples/net/cloud/mqtt_azure/src/main.c
@@ -12,7 +12,7 @@ LOG_MODULE_REGISTER(mqtt_azure, LOG_LEVEL_DBG);
 #include <zephyr/net/mqtt.h>
 
 #include <zephyr/sys/printk.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <string.h>
 #include <errno.h>
 

--- a/samples/net/cloud/tagoio_http_post/src/main.c
+++ b/samples/net/cloud/tagoio_http_post/src/main.c
@@ -10,7 +10,7 @@ LOG_MODULE_REGISTER(tagoio_http_post, CONFIG_TAGOIO_HTTP_POST_LOG_LEVEL);
 #include <zephyr/kernel.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/net/http/client.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <stdio.h>
 
 #include "wifi.h"

--- a/samples/net/lwm2m_client/src/temperature.c
+++ b/samples/net/lwm2m_client/src/temperature.c
@@ -14,7 +14,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/net/lwm2m.h>
 #include <zephyr/kernel.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <stdint.h>
 
 static struct k_work_delayable temp_work;

--- a/samples/net/mqtt_publisher/src/main.c
+++ b/samples/net/mqtt_publisher/src/main.c
@@ -10,7 +10,7 @@ LOG_MODULE_REGISTER(net_mqtt_publisher_sample, LOG_LEVEL_DBG);
 #include <zephyr/kernel.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/net/mqtt.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include <string.h>
 #include <errno.h>

--- a/samples/net/sockets/echo_client/src/tcp.c
+++ b/samples/net/sockets/echo_client/src/tcp.c
@@ -16,7 +16,7 @@ LOG_MODULE_DECLARE(net_echo_client_sample, LOG_LEVEL_DBG);
 
 #include <zephyr/net/socket.h>
 #include <zephyr/net/tls_credentials.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include "common.h"
 #include "ca_certificate.h"

--- a/samples/net/sockets/echo_client/src/udp.c
+++ b/samples/net/sockets/echo_client/src/udp.c
@@ -16,7 +16,7 @@ LOG_MODULE_DECLARE(net_echo_client_sample, LOG_LEVEL_DBG);
 
 #include <zephyr/net/socket.h>
 #include <zephyr/net/tls_credentials.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include "common.h"
 #include "ca_certificate.h"

--- a/samples/net/sockets/websocket_client/src/main.c
+++ b/samples/net/sockets/websocket_client/src/main.c
@@ -11,7 +11,7 @@ LOG_MODULE_REGISTER(net_websocket_client_sample, LOG_LEVEL_DBG);
 #include <zephyr/net/socket.h>
 #include <zephyr/net/tls_credentials.h>
 #include <zephyr/net/websocket.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <zephyr/shell/shell.h>
 
 #include "ca_certificate.h"

--- a/samples/net/wpan_serial/src/main.c
+++ b/samples/net/wpan_serial/src/main.c
@@ -18,7 +18,7 @@ LOG_MODULE_REGISTER(wpan_serial, CONFIG_USB_DEVICE_LOG_LEVEL);
 #include <zephyr/drivers/uart.h>
 #include <zephyr/kernel.h>
 #include <zephyr/usb/usb_device.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include <zephyr/net/buf.h>
 #include <net_private.h>

--- a/samples/subsys/usb/hid-cdc/src/main.c
+++ b/samples/subsys/usb/hid-cdc/src/main.c
@@ -8,7 +8,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/uart.h>
 #include <string.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include <zephyr/usb/usb_device.h>
 #include <zephyr/usb/class/usb_hid.h>

--- a/soc/arm/nxp_kinetis/k2x/soc.h
+++ b/soc/arm/nxp_kinetis/k2x/soc.h
@@ -35,7 +35,7 @@ extern "C" {
 #include <fsl_common.h>
 #include <zephyr/device.h>
 #include <zephyr/sys/util.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #endif /* !_ASMLANGUAGE */
 

--- a/soc/x86/alder_lake/soc.h
+++ b/soc/x86/alder_lake/soc.h
@@ -20,7 +20,7 @@
 
 #ifndef _ASMLANGUAGE
 #include <zephyr/device.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #endif
 
 #ifdef CONFIG_GPIO_INTEL

--- a/soc/x86/apollo_lake/soc.h
+++ b/soc/x86/apollo_lake/soc.h
@@ -20,7 +20,7 @@
 
 #ifndef _ASMLANGUAGE
 #include <zephyr/device.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #endif
 
 #ifdef CONFIG_GPIO_INTEL

--- a/soc/x86/atom/soc.h
+++ b/soc/x86/atom/soc.h
@@ -19,7 +19,7 @@
 
 #ifndef _ASMLANGUAGE
 #include <zephyr/device.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #endif
 
 /* PCI definitions */

--- a/soc/x86/elkhart_lake/soc.h
+++ b/soc/x86/elkhart_lake/soc.h
@@ -20,7 +20,7 @@
 
 #ifndef _ASMLANGUAGE
 #include <zephyr/device.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #endif
 
 #ifdef CONFIG_GPIO_INTEL

--- a/soc/x86/ia32/soc.h
+++ b/soc/x86/ia32/soc.h
@@ -19,7 +19,7 @@
 
 #ifndef _ASMLANGUAGE
 #include <zephyr/device.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #endif
 
 /* PCI definitions */

--- a/soc/x86/intel_ish/intel_ish5/soc.h
+++ b/soc/x86/intel_ish/intel_ish5/soc.h
@@ -11,7 +11,7 @@
 
 #ifndef _ASMLANGUAGE
 #include <zephyr/device.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #ifdef CONFIG_HPET_TIMER
 #include "sedi_driver_hpet.h"

--- a/soc/x86/raptor_lake/soc.h
+++ b/soc/x86/raptor_lake/soc.h
@@ -18,7 +18,7 @@
 
 #ifndef _ASMLANGUAGE
 #include <zephyr/device.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #endif
 
 #ifdef CONFIG_GPIO_INTEL

--- a/subsys/bluetooth/mesh/dfu_cli.c
+++ b/subsys/bluetooth/mesh/dfu_cli.c
@@ -10,7 +10,7 @@
 #include "access.h"
 #include "dfu.h"
 #include "blob.h"
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <common/bt_str.h>
 
 #define LOG_LEVEL CONFIG_BT_MESH_DFU_LOG_LEVEL

--- a/subsys/bluetooth/mesh/rpr_srv.c
+++ b/subsys/bluetooth/mesh/rpr_srv.c
@@ -6,7 +6,7 @@
 
 #include <stdlib.h>
 #include <zephyr/sys/slist.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/mesh/rpr_srv.h>

--- a/subsys/fs/ext2/ext2_format.c
+++ b/subsys/fs/ext2/ext2_format.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/logging/log.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <zephyr/fs/ext2.h>
 #include <zephyr/sys/byteorder.h>
 

--- a/subsys/jwt/jwt.c
+++ b/subsys/jwt/jwt.c
@@ -15,7 +15,7 @@
 #include <mbedtls/pk.h>
 #include <mbedtls/rsa.h>
 #include <mbedtls/sha256.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #endif
 
 #ifdef CONFIG_JWT_SIGN_ECDSA
@@ -24,7 +24,7 @@
 #include <tinycrypt/ecc_dsa.h>
 #include <tinycrypt/constants.h>
 
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #endif
 
 /*

--- a/subsys/lorawan/services/clock_sync.c
+++ b/subsys/lorawan/services/clock_sync.c
@@ -15,7 +15,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/lorawan/lorawan.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 LOG_MODULE_REGISTER(lorawan_clock_sync, CONFIG_LORAWAN_SERVICES_LOG_LEVEL);
 

--- a/subsys/mgmt/osdp/src/osdp_common.c
+++ b/subsys/mgmt/osdp/src/osdp_common.c
@@ -12,7 +12,7 @@
 
 #ifdef CONFIG_OSDP_SC_ENABLED
 #include <zephyr/crypto/crypto.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #endif
 
 #include "osdp_common.h"

--- a/subsys/net/ip/dhcpv4.c
+++ b/subsys/net/ip/dhcpv4.c
@@ -16,7 +16,7 @@ LOG_MODULE_REGISTER(net_dhcpv4, CONFIG_NET_DHCPV4_LOG_LEVEL);
 #include <errno.h>
 #include <inttypes.h>
 #include <stdbool.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_if.h>

--- a/subsys/net/ip/dhcpv6.c
+++ b/subsys/net/ip/dhcpv6.c
@@ -13,7 +13,7 @@ LOG_MODULE_REGISTER(net_dhcpv6, CONFIG_NET_DHCPV6_LOG_LEVEL);
 
 #include <zephyr/net/dhcpv6.h>
 #include <zephyr/net/net_ip.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <zephyr/sys/math_extras.h>
 
 #include "dhcpv6_internal.h"

--- a/subsys/net/ip/icmp.c
+++ b/subsys/net/ip/icmp.c
@@ -29,7 +29,7 @@
 LOG_MODULE_REGISTER(net_icmp, ICMP_LOG_LEVEL);
 
 #include <errno.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/icmp.h>

--- a/subsys/net/ip/ipv4_autoconf.c
+++ b/subsys/net/ip/ipv4_autoconf.c
@@ -18,7 +18,7 @@ LOG_MODULE_REGISTER(net_ipv4_autoconf, CONFIG_NET_IPV4_AUTO_LOG_LEVEL);
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/net_if.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include "ipv4_autoconf_internal.h"
 

--- a/subsys/net/ip/ipv4_fragment.c
+++ b/subsys/net/ip/ipv4_fragment.c
@@ -14,7 +14,7 @@ LOG_MODULE_DECLARE(net_ipv4, CONFIG_NET_IPV4_LOG_LEVEL);
 #include <zephyr/net/net_stats.h>
 #include <zephyr/net/net_context.h>
 #include <zephyr/net/net_mgmt.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include "net_private.h"
 #include "connection.h"
 #include "icmpv4.h"

--- a/subsys/net/ip/ipv6_fragment.c
+++ b/subsys/net/ip/ipv6_fragment.c
@@ -17,7 +17,7 @@ LOG_MODULE_DECLARE(net_ipv6, CONFIG_NET_IPV6_LOG_LEVEL);
 #include <zephyr/net/net_stats.h>
 #include <zephyr/net/net_context.h>
 #include <zephyr/net/net_mgmt.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include "net_private.h"
 #include "connection.h"
 #include "icmpv6.h"

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -15,7 +15,7 @@
 LOG_MODULE_REGISTER(net_ctx, CONFIG_NET_CONTEXT_LOG_LEVEL);
 
 #include <zephyr/kernel.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <string.h>
 #include <errno.h>
 #include <stdbool.h>

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -11,7 +11,7 @@ LOG_MODULE_REGISTER(net_if, CONFIG_NET_IF_LOG_LEVEL);
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/linker/sections.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <zephyr/syscall_handler.h>
 #include <stdlib.h>
 #include <string.h>

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -17,7 +17,7 @@ LOG_MODULE_REGISTER(net_shell, LOG_LEVEL_DBG);
 #include <zephyr/kernel.h>
 #include <kernel_internal.h>
 #include <zephyr/pm/device.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <zephyr/shell/shell.h>

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -11,7 +11,7 @@ LOG_MODULE_REGISTER(net_tcp, CONFIG_NET_TCP_LOG_LEVEL);
 #include <stdio.h>
 #include <stdlib.h>
 #include <zephyr/kernel.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #if defined(CONFIG_NET_TCP_ISN_RFC6528)
 #include <mbedtls/md5.h>

--- a/subsys/net/ip/tcp_internal.h
+++ b/subsys/net/ip/tcp_internal.h
@@ -14,7 +14,7 @@
 #define __TCP_INTERNAL_H
 
 #include <zephyr/types.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/net_ip.h>

--- a/subsys/net/ip/trickle.c
+++ b/subsys/net/ip/trickle.c
@@ -15,7 +15,7 @@ LOG_MODULE_REGISTER(net_trickle, CONFIG_NET_TRICKLE_LOG_LEVEL);
 
 #include <errno.h>
 #include <zephyr/sys/util.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/trickle.h>

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -14,7 +14,7 @@ LOG_MODULE_REGISTER(net_ethernet, CONFIG_NET_L2_ETHERNET_LOG_LEVEL);
 #include <zephyr/net/ethernet.h>
 #include <zephyr/net/ethernet_mgmt.h>
 #include <zephyr/net/gptp.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #if defined(CONFIG_NET_LLDP)
 #include <zephyr/net/lldp.h>

--- a/subsys/net/l2/ethernet/gptp/gptp.c
+++ b/subsys/net/l2/ethernet/gptp/gptp.c
@@ -10,7 +10,7 @@ LOG_MODULE_REGISTER(net_gptp, CONFIG_NET_GPTP_LOG_LEVEL);
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/drivers/ptp_clock.h>
 #include <zephyr/net/ethernet_mgmt.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include <zephyr/net/gptp.h>
 

--- a/subsys/net/l2/ieee802154/ieee802154.c
+++ b/subsys/net/l2/ieee802154/ieee802154.c
@@ -22,7 +22,7 @@ LOG_MODULE_REGISTER(net_ieee802154, CONFIG_NET_L2_IEEE802154_LOG_LEVEL);
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_l2.h>
 #include <zephyr/net/net_linkaddr.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #ifdef CONFIG_NET_6LO
 #include "ieee802154_6lo.h"

--- a/subsys/net/l2/ieee802154/ieee802154_radio_csma_ca.c
+++ b/subsys/net/l2/ieee802154/ieee802154_radio_csma_ca.c
@@ -12,7 +12,7 @@ LOG_MODULE_REGISTER(net_ieee802154_csma, CONFIG_NET_L2_IEEE802154_LOG_LEVEL);
 #include <zephyr/net/ieee802154.h>
 #include <zephyr/net/ieee802154_radio.h>
 #include <zephyr/net/net_if.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <zephyr/toolchain.h>
 
 #include <errno.h>

--- a/subsys/net/l2/ppp/fsm.c
+++ b/subsys/net/l2/ppp/fsm.c
@@ -12,7 +12,7 @@ LOG_MODULE_DECLARE(net_l2_ppp, CONFIG_NET_L2_PPP_LOG_LEVEL);
 #include <zephyr/net/net_if.h>
 
 #include <zephyr/net/ppp.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include "net_private.h"
 

--- a/subsys/net/l2/virtual/virtual.c
+++ b/subsys/net/l2/virtual/virtual.c
@@ -13,7 +13,7 @@ LOG_MODULE_REGISTER(net_virtual, CONFIG_NET_L2_VIRTUAL_LOG_LEVEL);
 #include <zephyr/net/net_mgmt.h>
 #include <zephyr/net/virtual.h>
 #include <zephyr/net/virtual_mgmt.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include "net_private.h"
 

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -12,7 +12,7 @@ LOG_MODULE_REGISTER(net_coap, CONFIG_COAP_LOG_LEVEL);
 #include <string.h>
 #include <stdbool.h>
 #include <errno.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/util.h>
 

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -14,7 +14,7 @@
 LOG_MODULE_REGISTER(net_dns_resolve, CONFIG_DNS_RESOLVER_LOG_LEVEL);
 
 #include <zephyr/types.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <string.h>
 #include <errno.h>
 #include <stdlib.h>

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -18,7 +18,7 @@ LOG_MODULE_REGISTER(net_sock_tls, CONFIG_NET_SOCKETS_LOG_LEVEL);
 #include <zephyr/init.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/net/socket.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <zephyr/syscall_handler.h>
 #include <zephyr/sys/fdtable.h>
 

--- a/subsys/net/lib/websocket/websocket.c
+++ b/subsys/net/lib/websocket/websocket.c
@@ -31,7 +31,7 @@ LOG_MODULE_REGISTER(net_websocket, CONFIG_NET_WEBSOCKET_LOG_LEVEL);
 #include <zephyr/net/http/client.h>
 #include <zephyr/net/websocket.h>
 
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/base64.h>
 #include <mbedtls/sha1.h>

--- a/subsys/random/CMakeLists.txt
+++ b/subsys/random/CMakeLists.txt
@@ -3,7 +3,7 @@
 if (CONFIG_ENTROPY_DEVICE_RANDOM_GENERATOR OR
     CONFIG_TIMER_RANDOM_GENERATOR OR
     CONFIG_XOSHIRO_RANDOM_GENERATOR)
-zephyr_syscall_header(${ZEPHYR_BASE}/include/zephyr/random/rand32.h)
+zephyr_syscall_header(${ZEPHYR_BASE}/include/zephyr/random/random.h)
 zephyr_library()
 zephyr_library_sources_ifdef(CONFIG_USERSPACE           rand32_handlers.c)
 endif()

--- a/subsys/random/rand32_handlers.c
+++ b/subsys/random/rand32_handlers.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <zephyr/syscall_handler.h>
 
 

--- a/subsys/random/rand32_timer.c
+++ b/subsys/random/rand32_timer.c
@@ -14,7 +14,7 @@
  * provide a random number generator.
  */
 
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/kernel.h>
 #include <zephyr/spinlock.h>

--- a/subsys/testsuite/busy_sim/busy_sim.c
+++ b/subsys/testsuite/busy_sim/busy_sim.c
@@ -8,7 +8,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/busy_sim.h>
 #include <zephyr/sys/ring_buffer.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #define BUFFER_SIZE 32
 

--- a/subsys/testsuite/ztest/src/ztest_new.c
+++ b/subsys/testsuite/ztest/src/ztest_new.c
@@ -22,7 +22,7 @@ static bool failed_expectation;
 #include <stdlib.h>
 #include <time.h>
 
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #define NUM_ITER_PER_SUITE CONFIG_ZTEST_SHUFFLE_SUITE_REPEAT_COUNT
 #define NUM_ITER_PER_TEST  CONFIG_ZTEST_SHUFFLE_TEST_REPEAT_COUNT
 #else

--- a/subsys/testsuite/ztest/src/ztress.c
+++ b/subsys/testsuite/ztest/src/ztress.c
@@ -6,7 +6,7 @@
 #include <zephyr/ztress.h>
 #include <zephyr/ztest_test.h>
 #include <zephyr/sys/printk.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <string.h>
 
 /* Flag set at startup which determines if stress test can run on this platform.

--- a/tests/benchmarks/mbedtls/src/benchmark.c
+++ b/tests/benchmarks/mbedtls/src/benchmark.c
@@ -70,7 +70,7 @@
 
 #include <zephyr/types.h>
 #include <zephyr/sys/byteorder.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include <zephyr/kernel.h>
 

--- a/tests/boards/espressif_esp32/cache_coex/src/cache_coex.c
+++ b/tests/boards/espressif_esp32/cache_coex/src/cache_coex.c
@@ -9,7 +9,7 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/drivers/flash.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <soc/soc_memory_layout.h>
 
 /* definitions used in Flash & RAM operations */

--- a/tests/crypto/rand32/src/main.c
+++ b/tests/crypto/rand32/src/main.c
@@ -15,7 +15,7 @@
 
 #include <zephyr/ztest.h>
 #include <kernel_internal.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #define N_VALUES 10
 

--- a/tests/crypto/tinycrypt/src/ecc_dsa.c
+++ b/tests/crypto/tinycrypt/src/ecc_dsa.c
@@ -67,7 +67,7 @@
 #include <zephyr/test_utils.h>
 #include "test_ecc_utils.h"
 #include <zephyr/sys/util.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/drivers/disk/disk_performance/src/main.c
+++ b/tests/drivers/disk/disk_performance/src/main.c
@@ -10,7 +10,7 @@
 #include <zephyr/storage/disk_access.h>
 #include <zephyr/device.h>
 #include <zephyr/timing/timing.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #if defined(CONFIG_DISK_DRIVER_SDMMC)
 #define DISK_NAME CONFIG_SDMMC_VOLUME_NAME

--- a/tests/drivers/fuel_gauge/sbs_gauge/boards/qemu_cortex_a53.conf
+++ b/tests/drivers/fuel_gauge/sbs_gauge/boards/qemu_cortex_a53.conf
@@ -1,1 +1,4 @@
-emulated_board.conf
+# Copyright (c) 2022 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_EMUL=y

--- a/tests/drivers/smbus/smbus_emul/src/smbus.c
+++ b/tests/drivers/smbus/smbus_emul/src/smbus.c
@@ -7,7 +7,7 @@
 #include <zephyr/ztest.h>
 #include <zephyr/tc_util.h>
 #include <zephyr/sys/byteorder.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include <zephyr/drivers/pcie/pcie.h>
 #include <zephyr/drivers/smbus.h>

--- a/tests/drivers/uart/uart_mix_fifo_poll/src/main.c
+++ b/tests/drivers/uart/uart_mix_fifo_poll/src/main.c
@@ -14,7 +14,7 @@
 #include <zephyr/drivers/uart.h>
 #include <zephyr/ztest.h>
 #include <zephyr/drivers/counter.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 /* RX and TX pins have to be connected together*/
 
 #if DT_NODE_EXISTS(DT_NODELABEL(dut))

--- a/tests/kernel/sched/deadline/src/main.c
+++ b/tests/kernel/sched/deadline/src/main.c
@@ -5,7 +5,7 @@
  */
 #include <zephyr/kernel.h>
 #include <zephyr/ztest.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #define NUM_THREADS 8
 /* this should be large enough for us

--- a/tests/kernel/timer/timer_api/src/timer_convert.c
+++ b/tests/kernel/timer/timer_api/src/timer_convert.c
@@ -6,7 +6,7 @@
 #include <zephyr/ztest.h>
 #include <zephyr/types.h>
 #include <zephyr/sys/time_units.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #define NUM_RANDOM 100
 

--- a/tests/lib/hash_function/src/main.c
+++ b/tests/lib/hash_function/src/main.c
@@ -6,7 +6,7 @@
 
 #include <stdlib.h>
 
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <zephyr/sys/hash_function.h>
 #include <zephyr/ztest.h>
 

--- a/tests/lib/mpsc_pbuf/src/concurrent.c
+++ b/tests/lib/mpsc_pbuf/src/concurrent.c
@@ -7,7 +7,7 @@
 #include <zephyr/ztress.h>
 #include <zephyr/sys/mpsc_pbuf.h>
 #include <zephyr/sys/ring_buffer.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(test);
 

--- a/tests/lib/mpsc_pbuf/src/main.c
+++ b/tests/lib/mpsc_pbuf/src/main.c
@@ -15,7 +15,7 @@
 #include <stdbool.h>
 #include <zephyr/kernel.h>
 #include <zephyr/ztest.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #define PUT_EXT_LEN \
 	((sizeof(union mpsc_pbuf_generic) + sizeof(void *)) / sizeof(uint32_t))

--- a/tests/lib/p4workq/src/main.c
+++ b/tests/lib/p4workq/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <zephyr/kernel.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <zephyr/ztest.h>
 #include <zephyr/sys/p4wq.h>
 

--- a/tests/lib/ringbuffer/src/concurrent.c
+++ b/tests/lib/ringbuffer/src/concurrent.c
@@ -7,7 +7,7 @@
 #include <zephyr/ztress.h>
 #include <zephyr/sys/ring_buffer.h>
 #include <zephyr/sys/mutex.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <stdint.h>
 
 /**

--- a/tests/lib/spsc_pbuf/src/main.c
+++ b/tests/lib/spsc_pbuf/src/main.c
@@ -7,7 +7,7 @@
 #include <zephyr/ztest.h>
 #include <zephyr/ztress.h>
 #include <zephyr/sys/spsc_pbuf.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #define HDR_LEN sizeof(uint32_t)
 #define TLEN(len) ROUND_UP(HDR_LEN + len, sizeof(uint32_t))

--- a/tests/net/arp/src/main.c
+++ b/tests/net/arp/src/main.c
@@ -25,7 +25,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_ARP_LOG_LEVEL);
 #include <zephyr/net/net_ip.h>
 #include <zephyr/net/dummy.h>
 #include <zephyr/ztest.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include "arp.h"
 

--- a/tests/net/checksum_offload/src/main.c
+++ b/tests/net/checksum_offload/src/main.c
@@ -18,7 +18,7 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 #include <errno.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/linker/sections.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include <zephyr/ztest.h>
 

--- a/tests/net/context/src/main.c
+++ b/tests/net/context/src/main.c
@@ -17,7 +17,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_CONTEXT_LOG_LEVEL);
 #include <errno.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/linker/sections.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include <zephyr/tc_util.h>
 

--- a/tests/net/hostname/src/main.c
+++ b/tests/net/hostname/src/main.c
@@ -16,7 +16,7 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 #include <stddef.h>
 #include <string.h>
 #include <errno.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/linker/sections.h>
 

--- a/tests/net/iface/src/main.c
+++ b/tests/net/iface/src/main.c
@@ -19,7 +19,7 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 #include <errno.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/linker/sections.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include <zephyr/ztest.h>
 

--- a/tests/net/igmp/src/main.c
+++ b/tests/net/igmp/src/main.c
@@ -28,7 +28,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_IPV4_LOG_LEVEL);
 #include <zephyr/net/net_event.h>
 #include <zephyr/net/igmp.h>
 
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include "ipv4.h"
 

--- a/tests/net/ip-addr/src/main.c
+++ b/tests/net/ip-addr/src/main.c
@@ -16,7 +16,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_IPV6_LOG_LEVEL);
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 #include <zephyr/linker/sections.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include <zephyr/ztest.h>
 

--- a/tests/net/ipv4_fragment/src/main.c
+++ b/tests/net/ipv4_fragment/src/main.c
@@ -13,7 +13,7 @@ LOG_MODULE_REGISTER(net_ipv4_test, CONFIG_NET_IPV4_LOG_LEVEL);
 #include <string.h>
 #include <errno.h>
 #include <zephyr/linker/sections.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <zephyr/ztest.h>
 #include <zephyr/net/ethernet.h>
 #include <zephyr/net/dummy.h>

--- a/tests/net/ipv6/src/main.c
+++ b/tests/net/ipv6/src/main.c
@@ -15,7 +15,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_IPV6_LOG_LEVEL);
 #include <string.h>
 #include <errno.h>
 #include <zephyr/linker/sections.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include <zephyr/ztest.h>
 

--- a/tests/net/ipv6_fragment/src/main.c
+++ b/tests/net/ipv6_fragment/src/main.c
@@ -16,7 +16,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_IPV6_LOG_LEVEL);
 #include <errno.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/linker/sections.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include <zephyr/ztest.h>
 

--- a/tests/net/lib/dns_addremove/src/main.c
+++ b/tests/net/lib/dns_addremove/src/main.c
@@ -13,7 +13,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_DNS_RESOLVER_LOG_LEVEL);
 #include <string.h>
 #include <errno.h>
 #include <zephyr/sys/printk.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include <zephyr/ztest.h>
 

--- a/tests/net/lib/dns_resolve/src/main.c
+++ b/tests/net/lib/dns_resolve/src/main.c
@@ -13,7 +13,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_DNS_RESOLVER_LOG_LEVEL);
 #include <string.h>
 #include <errno.h>
 #include <zephyr/sys/printk.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include <zephyr/ztest.h>
 

--- a/tests/net/lib/mqtt_publisher/src/test_mqtt_publish.c
+++ b/tests/net/lib/mqtt_publisher/src/test_mqtt_publish.c
@@ -14,7 +14,7 @@ LOG_MODULE_REGISTER(net_test, LOG_LEVEL_WRN);
 #include <string.h>
 #include <errno.h>
 
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include "config.h"
 

--- a/tests/net/lib/mqtt_pubsub/src/test_mqtt_pubsub.c
+++ b/tests/net/lib/mqtt_pubsub/src/test_mqtt_pubsub.c
@@ -10,7 +10,7 @@ LOG_MODULE_REGISTER(net_test, LOG_LEVEL_WRN);
 #include <zephyr/ztest.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/net/mqtt.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include <string.h>
 #include <errno.h>

--- a/tests/net/lib/mqtt_subscriber/src/test_mqtt_subscribe.c
+++ b/tests/net/lib/mqtt_subscriber/src/test_mqtt_subscribe.c
@@ -10,7 +10,7 @@ LOG_MODULE_REGISTER(net_test, LOG_LEVEL_WRN);
 #include <zephyr/ztest.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/net/mqtt.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include <string.h>
 #include <errno.h>

--- a/tests/net/mld/src/main.c
+++ b/tests/net/mld/src/main.c
@@ -27,7 +27,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_IPV6_LOG_LEVEL);
 #include <zephyr/net/net_mgmt.h>
 #include <zephyr/net/net_event.h>
 
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include "icmpv6.h"
 #include "ipv6.h"

--- a/tests/net/net_pkt/src/main.c
+++ b/tests/net/net_pkt/src/main.c
@@ -14,7 +14,7 @@
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_ip.h>
 #include <zephyr/net/ethernet.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include <zephyr/ztest.h>
 

--- a/tests/net/pm/src/main.c
+++ b/tests/net/pm/src/main.c
@@ -10,7 +10,7 @@
 #include <zephyr/linker/sections.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/ztest.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include <zephyr/net/ethernet.h>
 #include <zephyr/net/dummy.h>

--- a/tests/net/ptp/clock/src/main.c
+++ b/tests/net/ptp/clock/src/main.c
@@ -31,7 +31,7 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 #include <zephyr/net/net_ip.h>
 #include <zephyr/net/net_l2.h>
 
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #define NET_LOG_ENABLED 1
 #include "net_private.h"

--- a/tests/net/route/src/main.c
+++ b/tests/net/route/src/main.c
@@ -17,7 +17,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_ROUTE_LOG_LEVEL);
 #include <errno.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/linker/sections.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include <zephyr/tc_util.h>
 

--- a/tests/net/route_mcast/src/main.c
+++ b/tests/net/route_mcast/src/main.c
@@ -17,7 +17,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_ROUTE_LOG_LEVEL);
 #include <errno.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/linker/sections.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include <zephyr/tc_util.h>
 

--- a/tests/net/shell/src/main.c
+++ b/tests/net/shell/src/main.c
@@ -29,7 +29,7 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 #include <zephyr/net/ethernet.h>
 #include <zephyr/net/dummy.h>
 #include <zephyr/net/udp.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include "ipv4.h"
 #include "ipv6.h"

--- a/tests/net/socket/af_packet_ipproto_raw/src/main.c
+++ b/tests/net/socket/af_packet_ipproto_raw/src/main.c
@@ -10,7 +10,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_SOCKETS_LOG_LEVEL);
 #include <zephyr/kernel.h>
 #include <zephyr/linker/sections.h>
 #include <zephyr/ztest.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include <fcntl.h>
 

--- a/tests/net/traffic_class/src/main.c
+++ b/tests/net/traffic_class/src/main.c
@@ -18,7 +18,7 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 #include <errno.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/linker/sections.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include <zephyr/ztest.h>
 

--- a/tests/net/tx_timestamp/src/main.c
+++ b/tests/net/tx_timestamp/src/main.c
@@ -18,7 +18,7 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 #include <errno.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/linker/sections.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include <zephyr/ztest.h>
 

--- a/tests/net/udp/src/main.c
+++ b/tests/net/udp/src/main.c
@@ -29,7 +29,7 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 #include <zephyr/net/ethernet.h>
 #include <zephyr/net/dummy.h>
 #include <zephyr/net/udp.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include "ipv4.h"
 #include "ipv6.h"

--- a/tests/net/virtual/src/main.c
+++ b/tests/net/virtual/src/main.c
@@ -17,7 +17,7 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 #include <string.h>
 #include <errno.h>
 #include <zephyr/sys/printk.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include <zephyr/ztest.h>
 

--- a/tests/net/vlan/src/main.c
+++ b/tests/net/vlan/src/main.c
@@ -18,7 +18,7 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 #include <errno.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/linker/sections.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include <zephyr/ztest.h>
 

--- a/tests/net/wifi/wifi_nm/src/main.c
+++ b/tests/net/wifi/wifi_nm/src/main.c
@@ -18,7 +18,7 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 #include <errno.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/linker/sections.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include <zephyr/ztest.h>
 

--- a/tests/subsys/logging/log_stress/src/main.c
+++ b/tests/subsys/logging/log_stress/src/main.c
@@ -8,7 +8,7 @@
 #include <zephyr/sys/util.h>
 #include <string.h>
 #include <zephyr/ztress.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/logging/log_ctrl.h>
 #include <zephyr/logging/log_backend.h>


### PR DESCRIPTION
rand32.h does not make much sense, since the random subsystem provides more APIs than just getting a random 32 bits value.

Rename it to random.h and get consistently with other subsystems.