### PR TITLE
doc: release: 3.5: (partial) kernel release notes

### DIFF
--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -44,6 +44,9 @@ https://docs.zephyrproject.org/latest/security/vulnerabilities.html
 Kernel
 ******
 
+* Added support for dynamic thread stack allocation via :c:func:`k_thread_stack_alloc`
+* Added support for :c:func:`k_spin_trylock`
+
 Architectures
 *************
 


### PR DESCRIPTION
Include dynamic thread stack allocation and support for k_spin_trylock().