### PR TITLE
dts: arm: st: u5: correct lptim2 clock enable bit

### DIFF
--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -443,7 +443,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40009400 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000200>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000020>;
 			interrupts = <68 0>;
 			interrupt-names = "global";
 			st,static-prescaler;


### PR DESCRIPTION
The LPTIM2 clock enable is bit 5 of RCC APB1 clock enable register 2 (RM0456 Rev 4 11.8.34).

Fixes: #63663