### PR TITLE
tests: bluetooth: tester: Fix provisioning context initialization in PTS tests

### DIFF
--- a/tests/bluetooth/tester/src/btp/btp_mesh.h
+++ b/tests/bluetooth/tester/src/btp/btp_mesh.h
@@ -1038,6 +1038,8 @@ struct btp_proxy_solicit_cmd {
 	uint16_t net_idx;
 } __packed;
 
+#define BTP_MESH_START				0x78
+
 /* events */
 #define BTP_MESH_EV_OUT_NUMBER_ACTION		0x80
 struct btp_mesh_out_number_action_ev {

--- a/tests/bluetooth/tester/src/btp_mesh.c
+++ b/tests/bluetooth/tester/src/btp_mesh.c
@@ -1289,6 +1289,14 @@ static uint8_t init(const void *cmd, uint16_t cmd_len,
 		return BTP_STATUS_FAILED;
 	}
 
+	return BTP_STATUS_SUCCESS;
+}
+
+static uint8_t start(const void *cmd, uint16_t cmd_len,
+		     void *rsp, uint16_t *rsp_len)
+{
+	int err;
+
 	LOG_DBG("");
 
 	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
@@ -4945,6 +4953,11 @@ static const struct btp_handler handlers[] = {
 		.func = proxy_solicit
 	},
 #endif
+	{
+		.opcode = BTP_MESH_START,
+		.expect_len = 0,
+		.func = start
+	},
 };
 
 


### PR DESCRIPTION
This fixes regression introduced in
https://github.com/zephyrproject-rtos/zephyr/pull/63556

In the PR above `bt_mesh_init()` call was moved to `BTP_MESH_INIT` command to allow to select alternative composition data when starting the stack. AutoPTS sends `BTP_MESH_CONFIG_PROVISIONING` command before `BTP_MESH_INIT` to prepare the provisioning context. But because `bt_mesh_init()` is now called after `BTP_MESH_CONFIG_PROVISIONING` command is sent, this configuration is reset to the default which makes PTS tests to fail.

To solve this, this commit calls introduces a new command, `BTP_MESH_START`, which will replace the original `BTP_MESH_INIT` command. `bt_mesh_init()` will stay in `BTP_MESH_INIT` while the stack will be started in `BTP_MESH_START` command.

Fixes #63657

AutoPTS PR: https://github.com/auto-pts/auto-pts/pull/1026