### PR TITLE
drivers: fuel_gauge: max17048: Fix overflow when calculating voltage

### DIFF
--- a/drivers/fuel_gauge/max17048/max17048.c
+++ b/drivers/fuel_gauge/max17048/max17048.c
@@ -90,7 +90,7 @@ int max17048_voltage(const struct device *i2c_dev, uint16_t *response)
 	 * milli volts instead of volts.
 	 */
 
-	*response = *response * 78125 / 1000000;
+	*response = (uint16_t)((uint32_t)*response * 78125L / 1000000L);
 	return 0;
 }
 


### PR DESCRIPTION
Annotate the calculation with type casts to force
promotion to uint32_t and then cast back down
to uint16_t for the return. This solves the issue
with invalid voltage (mV) values being returned
due to overflow during the conversion from the
register value on the max17048 chip.

fixes #63659 

Signed-off-by: Martin Calsyn <martin.calsyn@outcomex.com.au>