### PR TITLE
samples: usb: mass Raspberry Pi Pico Support

### DIFF
--- a/samples/subsys/usb/mass/boards/rpi_pico.overlay
+++ b/samples/subsys/usb/mass/boards/rpi_pico.overlay
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024 Kelly Lord
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &code_partition;
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/*
+		 * Usable flash. Starts at 0x100, after the bootloader. The partition
+		 * size is 1MB minus the 0x100 bytes taken by the bootloader.
+		 */
+		code_partition: partition@100 {
+			label = "code";
+			reg = <0x100 (DT_SIZE_M(1) - 0x100)>;
+			read-only;
+		};
+
+		storage_partition: partition@100000 {
+			label = "storage";
+			reg = <0x100000  DT_SIZE_M(1)>;
+		};
+	};
+};
+
+/ {
+	msc_disk0 {
+		compatible = "zephyr,flash-disk";
+		partition = <&storage_partition>;
+		disk-name = "NAND";
+		cache-size = <4096>;
+	};
+};


### PR DESCRIPTION
Added a flash partition for the mass storage example.

Signed-off-by: Kelly Lord <kellyhlord@gmail.com>