### PR TITLE
Bluetooth: Controller: Kconfig: Move out BT_LL_SW_SPLIT configs

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -206,13 +206,6 @@ config BT_CTLR_ISO_TX_BUFFER_SIZE
 	  Size of the Isochronous Tx buffers and the value returned in HCI LE
 	  Read Buffer Size V2 command response.
 
-config BT_CTLR_ISOAL_LOG_DBG_VERBOSE
-	bool "ISO-AL verbose debug logging"
-	depends on BT_CTLR_ISOAL_LOG_LEVEL = 4
-	default n
-	help
-	  Use this option to enable ISO-AL verbose debug logging.
-
 config BT_CTLR_ISOAL_SOURCES
 	int "Number of Isochronous Adaptation Layer sources"
 	depends on BT_CTLR_ADV_ISO || BT_CTLR_CONN_ISO
@@ -243,15 +236,6 @@ config BT_CTLR_ISO_RX_SDU_BUFFERS
 	  The number of buffers and maximum SDU fragment size will limit the
 	  maximum size of an SDU that can be accurately declared in the HCI ISO
 	  Data header.
-
-config BT_CTLR_ISO_TX_SEG_PLAYLOAD_MIN
-	int "Minimum number of playload data bytes in a new segment"
-	depends on BT_CTLR_ADV_ISO || BT_CTLR_CONN_ISO
-	default 1
-	range 1 64
-	help
-	  Minimum number of payload bytes that would make inserting a new
-	  segment into a PDU worthwhile.
 
 config BT_CTLR_ISO_VENDOR_DATA_PATH
 	bool "Vendor-specific ISO data path"
@@ -908,17 +892,6 @@ config BT_CTLR_CONN_ISO_STREAMS_MAX_FT
 	default 255
 	help
 	  Maximum number of CIS flush timeout events.
-
-config BT_CTLR_CONN_ISO_AVOID_SEGMENTATION
-	bool "Avoid SDU fragmentation for framed mode"
-	depends on BT_CTLR_CENTRAL_ISO
-	help
-	  When creating a CIG, the Max_PDU size is calculated according to BT
-	  Core 5.4 Vol 6, Part G, Section 2.2. However, HAP specifies a need for
-	  avoiding segmentation by forcing the Max_PDU to the appropriate value.
-	  Since there is no way to control the Max_PDU using the non-test
-	  interface, the config provides a way to force the Max_PDU to Max_SDU +
-	  5 (header + offset).
 
 config BT_CTLR_ISO
 	bool

--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -206,12 +206,39 @@ config BT_CTLR_CHECK_SAME_PEER_SYNC
 
 endif # BT_CTLR_ADV_EXT
 
+config BT_CTLR_ISOAL_LOG_DBG_VERBOSE
+	bool "ISO-AL verbose debug logging"
+	depends on BT_CTLR_ISOAL_LOG_LEVEL = 4
+	default n
+	help
+	  Use this option to enable ISO-AL verbose debug logging.
+
+config BT_CTLR_ISO_TX_SEG_PLAYLOAD_MIN
+	int "Minimum number of playload data bytes in a new segment"
+	depends on BT_CTLR_ADV_ISO || BT_CTLR_CONN_ISO
+	default 1
+	range 1 64
+	help
+	  Minimum number of payload bytes that would make inserting a new
+	  segment into a PDU worthwhile.
+
 config BT_CTLR_CONN_ISO_HCI_DATAPATH_SKIP_INVALID_DATA
 	bool "Do not pass invalid SDUs on HCI datapath"
 	depends on BT_CTLR_CONN_ISO
 	help
 	  This allows for applications to decide whether to
 	  forward invalid SDUs through HCI upwards.
+
+config BT_CTLR_CONN_ISO_AVOID_SEGMENTATION
+	bool "Avoid SDU fragmentation for framed mode"
+	depends on BT_CTLR_CENTRAL_ISO
+	help
+	  When creating a CIG, the Max_PDU size is calculated according to BT
+	  Core 5.4 Vol 6, Part G, Section 2.2. However, HAP specifies a need for
+	  avoiding segmentation by forcing the Max_PDU to the appropriate value.
+	  Since there is no way to control the Max_PDU using the non-test
+	  interface, the config provides a way to force the Max_PDU to Max_SDU +
+	  5 (header + offset).
 
 config BT_CTLR_ADVANCED_FEATURES
 	bool "Show advanced features"


### PR DESCRIPTION
BT_CTLR_ISOAL_LOG_DBG_VERBOSE, BT_CTLR_ISO_TX_SEG_PLAYLOAD_MIN, and BT_CTLR_CONN_ISO_AVOID_SEGMENTATION are very tied to the BT_LL_SW_SPLIT implementation. It is very unlikely that these will ever be used by another controller

Therefore move them out to the BT_LL_SW_SPLIT specific configuration file. This will likely create less confusion when using another controller.