### PR TITLE
drivers: can: avoid integer overflow in expression

### DIFF
--- a/drivers/can/can_stm32_bxcan.c
+++ b/drivers/can/can_stm32_bxcan.c
@@ -21,7 +21,7 @@
 
 LOG_MODULE_REGISTER(can_stm32, CONFIG_CAN_LOG_LEVEL);
 
-#define CAN_INIT_TIMEOUT  (10 * sys_clock_hw_cycles_per_sec() / MSEC_PER_SEC)
+#define CAN_INIT_TIMEOUT  (10 * (sys_clock_hw_cycles_per_sec() / MSEC_PER_SEC))
 
 #define DT_DRV_COMPAT st_stm32_bxcan
 


### PR DESCRIPTION
Change the integer arithmetic to divide first before multiply.

The muliplication of sys_clock_hw_cycles_per_sec() by ten leads to a really big number on boards with high-speed clocking, thus to the overflow warning, and to errors for integration tests.

Fixes: #63678