### PR TITLE
Bluetooth: Mesh: Fix re-start of failed DFU on Firmware Distribution Server

### DIFF
--- a/subsys/bluetooth/mesh/dfd_srv.c
+++ b/subsys/bluetooth/mesh/dfd_srv.c
@@ -1015,6 +1015,13 @@ enum bt_mesh_dfd_status bt_mesh_dfd_srv_start(struct bt_mesh_dfd_srv *srv,
 
 	sys_slist_init(&srv->inputs.targets);
 	for (i = 0; i < srv->target_cnt; i++) {
+		uint16_t addr = srv->targets[i].blob.addr;
+
+		memset(&srv->targets[i].blob, 0, sizeof(struct bt_mesh_blob_target));
+		memset(&srv->pull_ctxs[i], 0, sizeof(struct bt_mesh_blob_target_pull));
+		srv->targets[i].blob.addr = addr;
+		srv->targets[i].blob.pull = &srv->pull_ctxs[i];
+
 		sys_slist_append(&srv->inputs.targets, &srv->targets[i].blob.n);
 	}
 


### PR DESCRIPTION
The list of receives in the Firmware Distribution Server model and and the Firmware Update Client model are 2 different lists.

In the Firmware Update Client model it is called the Update Receives state and the Active Update Receivers state which is a subset of receivers from the Update Receivers State. In the Firmware Distribution Server model it is called the Distribution Receivers List state.

When Distribute Firmware procedure starts, in the Initiate step, the Receivers List input (which is the input for the Update Receivers state), is composed of the Distribution Receives List state. During DFU, the Update Receivers state becomes the Active Update Receivers state which keeps only active nodes. Timed out or failed nodes dropped out from this list. The Distribution Receivers List state stays unchanged and thus don't need to be populated again after every successfull and failed DFU.

Fixes #63680