### PR TITLE
sensors: default_rtio_sensor: fix build warning

### DIFF
--- a/drivers/sensor/default_rtio_sensor.c
+++ b/drivers/sensor/default_rtio_sensor.c
@@ -235,7 +235,7 @@ static void sensor_submit_fallback(const struct device *dev, struct rtio_iodev_s
 		}
 		sample_idx += num_samples;
 	}
-	LOG_DBG("Total channels in header: %zu", header->num_channels);
+	LOG_DBG("Total channels in header: %u", header->num_channels);
 	rtio_iodev_sqe_ok(iodev_sqe, 0);
 }
 


### PR DESCRIPTION
Repro: `west build -p -b qemu_x86_64 samples/sensor/sensor_shell`

---

Fix a build warning on 64 bit architectures:

zephyr/drivers/sensor/default_rtio_sensor.c:238:17: error: format '%zu' expects argument of type 'size_t', but argument 2 has type 'uint32_t' {aka 'unsigned int'}

num_channels type changed to uint32_t in 96175fcc47.