### PR TITLE
drivers: stm32-rtc: return -ENODATA when RTC is uninitialized

### DIFF
--- a/drivers/rtc/rtc_ll_stm32.c
+++ b/drivers/rtc/rtc_ll_stm32.c
@@ -259,6 +259,15 @@ static int rtc_stm32_get_time(const struct device *dev, struct rtc_time *timeptr
 		return err;
 	}
 
+	if (!LL_RTC_IsActiveFlag_INITS(RTC)) {
+		/* INITS flag is set when the calendar has been initialiazed. This flag is
+		 * reset only on backup domain reset, so it can be read after a system
+		 * reset to check if the calendar has been initialized.
+		 */
+		k_mutex_unlock(&data->lock);
+		return -ENODATA;
+	}
+
 	do {
 		/* read date, time and subseconds and relaunch if a day increment occurred
 		 * while doing so as it will result in an erroneous result otherwise


### PR DESCRIPTION
The RTC driver on STM32 does not implement the -ENODATA return code. This prevents testing the initialisation status of the RTC by reading the return value of rtc_get_time().

Fixed by reading INITS flag and adding a error path in rtc_stm32_get_time().