### PR TITLE
Bluetooth: drivers/rpmsg: Ensure coop prio bt_recv

### DIFF
--- a/drivers/bluetooth/hci/rpmsg.c
+++ b/drivers/bluetooth/hci/rpmsg.c
@@ -230,7 +230,18 @@ static void bt_rpmsg_rx(const uint8_t *data, size_t len)
 	if (buf) {
 		LOG_DBG("Calling bt_recv(%p)", buf);
 
+		/* The IPC service does not guarantee that the handler thread
+		 * is cooperative. In particular, the OpenAMP implementation is
+		 * preemtible by default. OTOH, the HCI driver interface requires
+		 * that the bt_recv() function is called from a cooperative
+		 * thread.
+		 *
+		 * Calling `k_sched lock()` has the effect of making the current
+		 * thread cooperative.
+		 */
+		k_sched_lock();
 		bt_recv(buf);
+		k_sched_unlock();
 
 		LOG_HEXDUMP_DBG(buf->data, buf->len, "RX buf payload:");
 	}

--- a/include/zephyr/drivers/bluetooth/hci_driver.h
+++ b/include/zephyr/drivers/bluetooth/hci_driver.h
@@ -89,6 +89,8 @@ static inline uint8_t bt_hci_evt_get_flags(uint8_t evt)
  * for so-called high priority HCI events, which should instead be delivered to
  * the host stack through bt_recv_prio().
  *
+ * @note This function must only be called from a cooperative thread.
+ *
  * @param buf Network buffer containing data from the controller.
  *
  * @return 0 on success or negative error number on failure.


### PR DESCRIPTION
Ensure that the Bluetooth rpmsg driver thread is temporarly in cooperative mode using `k_sched_lock`.

Even though it's not documented yet on `bt_recv`, there is a general consensus among maintainers that `bt_recv` may not be called from preemptible priorites.

Many uses may be affected by this race condition, since the default configuration of rpmsg driver selects a preemtible priority.