### PR TITLE
stm32 sensors and ADC have pin conflict wit uart on stm32l475 disco kit

### DIFF
--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -288,9 +288,8 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &adc1 {
-	pinctrl-0 = <&adc1_in5_pa0 &adc1_in3_pc2
-		     &adc1_in4_pc3 &adc1_in13_pc4
-		     &adc1_in14_pc5>;
+	pinctrl-0 = <&adc1_in3_pc2 &adc1_in4_pc3
+		     &adc1_in13_pc4 &adc1_in14_pc5>;
 	pinctrl-names = "default";
 	st,adc-clock-source = <SYNC>;
 	st,adc-prescaler = <4>;

--- a/drivers/sensor/stm32_vref/Kconfig
+++ b/drivers/sensor/stm32_vref/Kconfig
@@ -7,6 +7,6 @@ config STM32_VREF
 	bool "STM32 VREF Sensor"
 	default y
 	depends on DT_HAS_ST_STM32_VREF_ENABLED
-	select ADC
+	depends on ADC && (SOC_FAMILY_STM32 && !SOC_SERIES_STM32F1X)
 	help
 	  Enable driver for STM32 Vref sensor.


### PR DESCRIPTION
When Vref or Vbat are enabled on the ADC1 of the stm32l475 board disco_l475_iot1, the ADC 1 is also enabled with its input pins as defined by the board DTS. Especially the input5 on pin PA0 makes gpio conflict with the uart4_tx_pa0 .

- Kconfig for the STM32 VREF Sensor  is depending on ADC, not enabling it, like the Kconfig of the drivers/sensor/stm32_vbat does.

- This PR is removing the input channel 5 of the ADC which is not defined as analog pin on the board schematics (MB1297)

![UserManual_ disco_l475_iot1](https://github.com/zephyrproject-rtos/zephyr/assets/51417392/3e9f1096-0780-4747-9c89-46191fbc75ba)


Fixes https://github.com/zephyrproject-rtos/zephyr/issues/63319