### PR TITLE
bluetooth: host: gatt: statically init callback list

### DIFF
--- a/doc/releases/migration-guide-3.6.rst
+++ b/doc/releases/migration-guide-3.6.rst
@@ -50,6 +50,10 @@ Bluetooth
   Devicetree chosen is now ``zephyr,bt-hci-ipc``. The existing sample has also
   been renamed, from ``samples/bluetooth/hci_rpmsg`` to
   ``samples/bluetooth/hci_ipc``.
+* The BT GATT callback list, appended to by :c:func:`bt_gatt_cb_register`, is no longer
+  cleared on :c:func:`bt_enable`. Callbacks can now be registered before the initial
+  call to :c:func:`bt_enable`, and should no longer be re-registered after a :c:func:`bt_disable`
+  :c:func:`bt_enable` cycle.
 
 Networking
 ==========

--- a/include/zephyr/bluetooth/gatt.h
+++ b/include/zephyr/bluetooth/gatt.h
@@ -370,7 +370,8 @@ struct bt_gatt_cpf {
 
 /** @brief Register GATT callbacks.
  *
- *  Register callbacks to monitor the state of GATT.
+ *  Register callbacks to monitor the state of GATT. The callback struct
+ *  must remain valid for the remainder of the program.
  *
  *  @param cb Callback struct.
  */

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -80,7 +80,7 @@ struct gatt_sub {
  *              <=> (subscriptions[x].peer == BT_ADDR_LE_ANY).
  */
 static struct gatt_sub subscriptions[SUB_MAX];
-static sys_slist_t callback_list;
+static sys_slist_t callback_list = SYS_SLIST_STATIC_INIT(&callback_list);
 
 #if defined(CONFIG_BT_GATT_DYNAMIC_DB)
 static sys_slist_t db;
@@ -1463,8 +1463,6 @@ void bt_gatt_init(void)
 	}
 
 	bt_gatt_service_init();
-
-	sys_slist_init(&callback_list);
 
 #if defined(CONFIG_BT_GATT_CACHING)
 	k_work_init_delayable(&db_hash.work, db_hash_process);


### PR DESCRIPTION
Statically initialise the callback list so that subscriptions can be registered before the call to `bt_enable`.