### PR TITLE
doc: release-notes: add CAN release notes for v3.5.0

### DIFF
--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -201,6 +201,13 @@ Drivers and Sensors
 
 * CAN
 
+  * Added support for TI TCAN4x5x CAN-FD controller with integrated transceiver
+    (:dtcompatible:`ti,tcan4x5x`).
+  * Added support for Microchip MCP251xFD CAN-FD controller (:dtcompatible:`microchip,mcp251xfd`).
+  * Added support for CAN statistics to the Bosch M_CAN controller driver backend.
+  * Switched the NXP S32 CANXL driver to use clock control for the CAN clock instead of hard-coding
+    a CAN clock frequency in the devicetree.
+
 * Clock control
 
   * Added support for Nuvoton NuMaker M46x


### PR DESCRIPTION
Add CAN related release notes for Zephyr v3.5.0. API changes are already described in the migration guide for v3.5.0.