### PR TITLE
doc: release-notes: add EEPROM release notes for v3.5.0

### DIFF
--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -223,6 +223,8 @@ Drivers and Sensors
 
 * EEPROM
 
+  * Added support for Fujitsu MB85RCxx series I2C FRAM (:dtcompatible:`fujitsu,mb85rcxx`).
+
 * Entropy
 
 * ESPI


### PR DESCRIPTION
Add EEPROM related release notes for Zephyr v3.5.0.