### PR TITLE
drivers: ethernet: eth_stm32_hal.c Fix mixup of DMA error and MAC error

### DIFF
--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -489,10 +489,10 @@ static int eth_tx(const struct device *dev, struct net_pkt *pkt)
 		}
 
 		/* Check for MAC errors */
-		if (HAL_ETH_GetDMAError(heth)) {
-			LOG_ERR("%s: ETH DMA error: macerror:%x",
+		if (HAL_ETH_GetMACError(heth)) {
+			LOG_ERR("%s: ETH MAC error: macerror:%x",
 				__func__,
-				HAL_ETH_GetDMAError(heth));
+				HAL_ETH_GetMACError(heth));
 			/* MAC errors are putting in error state*/
 			/* TODO recover from this */
 		}


### PR DESCRIPTION
There seems to be a copy-paste error in `drivers/ethernet/eth_stm32_hal.c` where DMA errors are checked twice and comments says MAC error for one of the checks.