### PR TITLE
doc: release: Fix formatting of bullet lists

### DIFF
--- a/doc/releases/migration-guide-3.5.rst
+++ b/doc/releases/migration-guide-3.5.rst
@@ -282,6 +282,7 @@ Recommended Changes
 * The following CAN controller devicetree properties are now deprecated in favor specifying the
   initial CAN bitrate using the ``bus-speed``, ``sample-point``, ``bus-speed-data``, and
   ``sample-point-data`` properties:
+
   * ``sjw``
   * ``prop-seg``
   * ``phase-seg1``

--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -415,6 +415,7 @@ Networking
   * Added new :c:macro:`LWM2M_RD_CLIENT_EVENT_DEREGISTER` event.
 
 * Wi-Fi
+
   * Added Passive scan support.
   * The Wi-Fi scan API updated with Wi-Fi scan parameter to allow scan mode selection.
 


### PR DESCRIPTION
Without the extra newline, Sphinx does not render bullet lists correctly.