### PR TITLE
tests: drivers: spi: improve spi_loopback async test

### DIFF
--- a/tests/drivers/spi/spi_loopback/src/spi.c
+++ b/tests/drivers/spi/spi_loopback/src/spi.c
@@ -555,11 +555,19 @@ static int spi_async_call(struct spi_dt_spec *spec)
 			.buf = buffer_tx,
 			.len = BUF_SIZE,
 		},
+		{
+			.buf = buffer2_tx,
+			.len = BUF2_SIZE,
+		},
 	};
 	const struct spi_buf rx_bufs[] = {
 		{
 			.buf = buffer_rx,
 			.len = BUF_SIZE,
+		},
+		{
+			.buf = buffer2_rx,
+			.len = BUF2_SIZE,
 		},
 	};
 	const struct spi_buf_set tx = {
@@ -573,6 +581,8 @@ static int spi_async_call(struct spi_dt_spec *spec)
 	int ret;
 
 	LOG_INF("Start async call");
+	memset(buffer_rx, 0, sizeof(buffer_rx));
+	memset(buffer2_rx, 0, sizeof(buffer2_rx));
 
 	ret = spi_transceive_signal(spec->bus, &spec->config, &tx, &rx, &async_sig);
 	if (ret == -ENOTSUP) {
@@ -591,6 +601,24 @@ static int spi_async_call(struct spi_dt_spec *spec)
 	if (result) {
 		LOG_ERR("Call code %d", ret);
 		zassert_false(result, "SPI transceive failed");
+		return -1;
+	}
+
+	if (memcmp(buffer_tx, buffer_rx, BUF_SIZE)) {
+		to_display_format(buffer_tx, BUF_SIZE, buffer_print_tx);
+		to_display_format(buffer_rx, BUF_SIZE, buffer_print_rx);
+		LOG_ERR("Buffer contents are different: %s", buffer_print_tx);
+		LOG_ERR("                           vs: %s", buffer_print_rx);
+		zassert_false(1, "Buffer contents are different");
+		return -1;
+	}
+
+	if (memcmp(buffer2_tx, buffer2_rx, BUF2_SIZE)) {
+		to_display_format(buffer2_tx, BUF2_SIZE, buffer_print_tx2);
+		to_display_format(buffer2_rx, BUF2_SIZE, buffer_print_rx2);
+		LOG_ERR("Buffer 2 contents are different: %s", buffer_print_tx2);
+		LOG_ERR("                             vs: %s", buffer_print_rx2);
+		zassert_false(1, "Buffer 2 contents are different");
 		return -1;
 	}
 


### PR DESCRIPTION
Add the following improvements to the spi_loopback async test:
- Verify that a set of multiple spi_buf structures can be sent successfully
- Check that the contents of the RX and TX buffers match after transfer completion