### PR TITLE
drivers: modem: add Telit ME910G1

### DIFF
--- a/drivers/modem/Kconfig.cellular
+++ b/drivers/modem/Kconfig.cellular
@@ -13,7 +13,7 @@ config MODEM_CELLULAR
 	select NET_L2_PPP_OPTION_MRU
 	depends on (DT_HAS_QUECTEL_BG95_ENABLED || DT_HAS_ZEPHYR_GSM_PPP_ENABLED || \
 		    DT_HAS_SIMCOM_SIM7080_ENABLED || DT_HAS_U_BLOX_SARA_R4_ENABLED || \
-		    DT_HAS_SWIR_HL7800_ENABLED)
+		    DT_HAS_SWIR_HL7800_ENABLED || DT_HAS_TELIT_ME910G1_ENABLED)
 	help
 	  This driver uses the generic 3gpp AT commands, along
 	  with the standard protocols CMUX and PPP, to configure

--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -1461,49 +1461,157 @@ MODEM_CHAT_SCRIPT_DEFINE(swir_hl7800_dial_chat_script, swir_hl7800_dial_chat_scr
 #define MODEM_CELLULAR_INST_NAME(name, inst) \
 	_CONCAT(_CONCAT(_CONCAT(name, _), DT_DRV_COMPAT), inst)
 
-#define MODEM_CELLULAR_DEVICE(inst)								\
-	MODEM_PPP_DEFINE(MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 98, 1500, 64);		\
-												\
-	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {		\
-		.chat_delimiter = {'\r'},							\
-		.chat_filter = {'\n'},								\
-		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),					\
-	};											\
-												\
-	static struct modem_cellular_config MODEM_CELLULAR_INST_NAME(config, inst) = {		\
-		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),					\
-		.power_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_power_gpios, {}),		\
-		.reset_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_reset_gpios, {}),		\
-		.power_pulse_duration_ms = 1500,						\
-		.reset_pulse_duration_ms = 100,							\
-		.startup_time_ms = 10000,							\
-		.shutdown_time_ms = 5000,							\
-		.init_chat_script = &_CONCAT(DT_DRV_COMPAT, _init_chat_script),			\
-		.dial_chat_script = &_CONCAT(DT_DRV_COMPAT, _dial_chat_script),			\
-	};											\
-												\
-	PM_DEVICE_DT_INST_DEFINE(inst, modem_cellular_pm_action);				\
-												\
-	DEVICE_DT_INST_DEFINE(inst, modem_cellular_init, PM_DEVICE_DT_INST_GET(inst),		\
-			      &MODEM_CELLULAR_INST_NAME(data, inst),				\
+#define MODEM_CELLULAR_DEVICE_QUECTEL_BG95(inst)                                                   \
+	MODEM_PPP_DEFINE(MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 98, 1500, 64);                 \
+                                                                                                   \
+	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
+		.chat_delimiter = {'\r'},                                                          \
+		.chat_filter = {'\n'},                                                             \
+		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
+	};                                                                                         \
+                                                                                                   \
+	static struct modem_cellular_config MODEM_CELLULAR_INST_NAME(config, inst) = {             \
+		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),                                          \
+		.power_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_power_gpios, {}),                 \
+		.reset_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_reset_gpios, {}),                 \
+		.power_pulse_duration_ms = 1500,                                                   \
+		.reset_pulse_duration_ms = 100,                                                    \
+		.startup_time_ms = 10000,                                                          \
+		.shutdown_time_ms = 5000,                                                          \
+		.init_chat_script = &quectel_bg95_init_chat_script,                                \
+		.dial_chat_script = &quectel_bg95_dial_chat_script,                                \
+	};                                                                                         \
+                                                                                                   \
+	PM_DEVICE_DT_INST_DEFINE(inst, modem_cellular_pm_action);                                  \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(inst, modem_cellular_init, PM_DEVICE_DT_INST_GET(inst),              \
+			      &MODEM_CELLULAR_INST_NAME(data, inst),                               \
+			      &MODEM_CELLULAR_INST_NAME(config, inst), POST_KERNEL, 99, NULL);
+
+#define MODEM_CELLULAR_DEVICE_GSM_PPP(inst)                                                        \
+	MODEM_PPP_DEFINE(MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 98, 1500, 64);                 \
+                                                                                                   \
+	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
+		.chat_delimiter = {'\r'},                                                          \
+		.chat_filter = {'\n'},                                                             \
+		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
+	};                                                                                         \
+                                                                                                   \
+	static struct modem_cellular_config MODEM_CELLULAR_INST_NAME(config, inst) = {             \
+		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),                                          \
+		.power_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_power_gpios, {}),                 \
+		.reset_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_reset_gpios, {}),                 \
+		.power_pulse_duration_ms = 1500,                                                   \
+		.reset_pulse_duration_ms = 100,                                                    \
+		.startup_time_ms = 10000,                                                          \
+		.shutdown_time_ms = 5000,                                                          \
+		.init_chat_script = &zephyr_gsm_ppp_init_chat_script,                              \
+		.dial_chat_script = &zephyr_gsm_ppp_dial_chat_script,                              \
+	};                                                                                         \
+                                                                                                   \
+	PM_DEVICE_DT_INST_DEFINE(inst, modem_cellular_pm_action);                                  \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(inst, modem_cellular_init, PM_DEVICE_DT_INST_GET(inst),              \
+			      &MODEM_CELLULAR_INST_NAME(data, inst),                               \
+			      &MODEM_CELLULAR_INST_NAME(config, inst), POST_KERNEL, 99, NULL);
+
+#define MODEM_CELLULAR_DEVICE_SIMCOM_SIM7080(inst)                                                 \
+	MODEM_PPP_DEFINE(MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 98, 1500, 64);                 \
+                                                                                                   \
+	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
+		.chat_delimiter = {'\r'},                                                          \
+		.chat_filter = {'\n'},                                                             \
+		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
+	};                                                                                         \
+                                                                                                   \
+	static struct modem_cellular_config MODEM_CELLULAR_INST_NAME(config, inst) = {             \
+		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),                                          \
+		.power_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_power_gpios, {}),                 \
+		.reset_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_reset_gpios, {}),                 \
+		.power_pulse_duration_ms = 1500,                                                   \
+		.reset_pulse_duration_ms = 100,                                                    \
+		.startup_time_ms = 10000,                                                          \
+		.shutdown_time_ms = 5000,                                                          \
+		.init_chat_script = &simcom_sim7080_init_chat_script,                              \
+		.dial_chat_script = &simcom_sim7080_dial_chat_script,                              \
+	};                                                                                         \
+                                                                                                   \
+	PM_DEVICE_DT_INST_DEFINE(inst, modem_cellular_pm_action);                                  \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(inst, modem_cellular_init, PM_DEVICE_DT_INST_GET(inst),              \
+			      &MODEM_CELLULAR_INST_NAME(data, inst),                               \
+			      &MODEM_CELLULAR_INST_NAME(config, inst), POST_KERNEL, 99, NULL);
+
+#define MODEM_CELLULAR_DEVICE_U_BLOX_SARA_R4(inst)                                                 \
+	MODEM_PPP_DEFINE(MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 98, 1500, 64);                 \
+                                                                                                   \
+	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
+		.chat_delimiter = {'\r'},                                                          \
+		.chat_filter = {'\n'},                                                             \
+		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
+	};                                                                                         \
+                                                                                                   \
+	static struct modem_cellular_config MODEM_CELLULAR_INST_NAME(config, inst) = {             \
+		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),                                          \
+		.power_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_power_gpios, {}),                 \
+		.reset_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_reset_gpios, {}),                 \
+		.power_pulse_duration_ms = 1500,                                                   \
+		.reset_pulse_duration_ms = 100,                                                    \
+		.startup_time_ms = 10000,                                                          \
+		.shutdown_time_ms = 5000,                                                          \
+		.init_chat_script = &u_blox_sara_r4_init_chat_script,                              \
+		.dial_chat_script = &u_blox_sara_r4_dial_chat_script,                              \
+	};                                                                                         \
+                                                                                                   \
+	PM_DEVICE_DT_INST_DEFINE(inst, modem_cellular_pm_action);                                  \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(inst, modem_cellular_init, PM_DEVICE_DT_INST_GET(inst),              \
+			      &MODEM_CELLULAR_INST_NAME(data, inst),                               \
+			      &MODEM_CELLULAR_INST_NAME(config, inst), POST_KERNEL, 99, NULL);
+
+#define MODEM_CELLULAR_DEVICE_SWIR_HL7800(inst)                                                    \
+	MODEM_PPP_DEFINE(MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 98, 1500, 64);                 \
+                                                                                                   \
+	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
+		.chat_delimiter = {'\r'},                                                          \
+		.chat_filter = {'\n'},                                                             \
+		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
+	};                                                                                         \
+                                                                                                   \
+	static struct modem_cellular_config MODEM_CELLULAR_INST_NAME(config, inst) = {             \
+		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),                                          \
+		.power_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_power_gpios, {}),                 \
+		.reset_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_reset_gpios, {}),                 \
+		.power_pulse_duration_ms = 1500,                                                   \
+		.reset_pulse_duration_ms = 100,                                                    \
+		.startup_time_ms = 10000,                                                          \
+		.shutdown_time_ms = 5000,                                                          \
+		.init_chat_script = &swir_hl7800_init_chat_script,                                 \
+		.dial_chat_script = &swir_hl7800_dial_chat_script,                                 \
+	};                                                                                         \
+                                                                                                   \
+	PM_DEVICE_DT_INST_DEFINE(inst, modem_cellular_pm_action);                                  \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(inst, modem_cellular_init, PM_DEVICE_DT_INST_GET(inst),              \
+			      &MODEM_CELLULAR_INST_NAME(data, inst),                               \
 			      &MODEM_CELLULAR_INST_NAME(config, inst), POST_KERNEL, 99, NULL);
 
 #define DT_DRV_COMPAT quectel_bg95
-DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE)
+DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_QUECTEL_BG95)
 #undef DT_DRV_COMPAT
 
 #define DT_DRV_COMPAT zephyr_gsm_ppp
-DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE)
+DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_GSM_PPP)
 #undef DT_DRV_COMPAT
 
 #define DT_DRV_COMPAT simcom_sim7080
-DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE)
+DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_SIMCOM_SIM7080)
 #undef DT_DRV_COMPAT
 
 #define DT_DRV_COMPAT u_blox_sara_r4
-DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE)
+DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_U_BLOX_SARA_R4)
 #undef DT_DRV_COMPAT
 
 #define DT_DRV_COMPAT swir_hl7800
-DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE)
+DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_SWIR_HL7800)
 #undef DT_DRV_COMPAT

--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -1458,6 +1458,48 @@ MODEM_CHAT_SCRIPT_DEFINE(swir_hl7800_dial_chat_script, swir_hl7800_dial_chat_scr
 			 dial_abort_matches, modem_cellular_chat_callback_handler, 10);
 #endif
 
+#if DT_HAS_COMPAT_STATUS_OKAY(telit_me910g1)
+MODEM_CHAT_SCRIPT_CMDS_DEFINE(telit_me910g1_init_chat_script_cmds,
+				  MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 100),
+				  MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 100),
+				  MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 100),
+				  MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 100),
+				  MODEM_CHAT_SCRIPT_CMD_RESP("ATE0", ok_match),
+				  /* The Telit me910g1 often has an error trying
+				   * to set the PDP context. The radio must be on to set
+				   * the context, and this step must be successful.
+				   * It is moved to the init script to allow retries.
+				   */
+				  MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGDCONT=1,\"IP\","
+							 "\"" CONFIG_MODEM_CELLULAR_APN "\"",
+							 ok_match),
+				  MODEM_CHAT_SCRIPT_CMD_RESP("AT+CFUN=4", ok_match),
+				  MODEM_CHAT_SCRIPT_CMD_RESP("AT+CMEE=1", ok_match),
+				  MODEM_CHAT_SCRIPT_CMD_RESP("AT+CREG=1", ok_match),
+				  MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGREG=1", ok_match),
+				  MODEM_CHAT_SCRIPT_CMD_RESP("AT+CEREG=1", ok_match),
+				  MODEM_CHAT_SCRIPT_CMD_RESP("AT+CREG?", ok_match),
+				  MODEM_CHAT_SCRIPT_CMD_RESP("AT+CEREG?", ok_match),
+				  MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGREG?", ok_match),
+				  MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGSN", imei_match),
+				  MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
+				  MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMM", cgmm_match),
+				  MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
+				  MODEM_CHAT_SCRIPT_CMD_RESP("AT+CFUN=1", ok_match),
+				  MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT+CMUX=0,0,5,127,10,3,30,10,2",
+								  300));
+
+MODEM_CHAT_SCRIPT_DEFINE(telit_me910g1_init_chat_script, telit_me910g1_init_chat_script_cmds,
+			 abort_matches, modem_cellular_chat_callback_handler, 10);
+
+MODEM_CHAT_SCRIPT_CMDS_DEFINE(telit_me910g1_dial_chat_script_cmds,
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT", ok_match),
+			      MODEM_CHAT_SCRIPT_CMD_RESP_NONE("ATD*99***1#", 0),);
+
+MODEM_CHAT_SCRIPT_DEFINE(telit_me910g1_dial_chat_script, telit_me910g1_dial_chat_script_cmds,
+			 dial_abort_matches, modem_cellular_chat_callback_handler, 10);
+#endif
+
 #define MODEM_CELLULAR_INST_NAME(name, inst) \
 	_CONCAT(_CONCAT(_CONCAT(name, _), DT_DRV_COMPAT), inst)
 
@@ -1596,6 +1638,33 @@ MODEM_CHAT_SCRIPT_DEFINE(swir_hl7800_dial_chat_script, swir_hl7800_dial_chat_scr
 			      &MODEM_CELLULAR_INST_NAME(data, inst),                               \
 			      &MODEM_CELLULAR_INST_NAME(config, inst), POST_KERNEL, 99, NULL);
 
+#define MODEM_CELLULAR_DEVICE_TELIT_ME910G1(inst)                                                  \
+	MODEM_PPP_DEFINE(MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 98, 1500, 64);                 \
+                                                                                                   \
+	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
+		.chat_delimiter = {'\r'},                                                          \
+		.chat_filter = {'\n'},                                                             \
+		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
+	};                                                                                         \
+                                                                                                   \
+	static struct modem_cellular_config MODEM_CELLULAR_INST_NAME(config, inst) = {             \
+		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),                                          \
+		.power_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_power_gpios, {}),                 \
+		.reset_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_reset_gpios, {}),                 \
+		.power_pulse_duration_ms = 5050,                                                   \
+		.reset_pulse_duration_ms = 250,                                                    \
+		.startup_time_ms = 15000,                                                          \
+		.shutdown_time_ms = 5000,                                                          \
+		.init_chat_script = &telit_me910g1_init_chat_script,                               \
+		.dial_chat_script = &telit_me910g1_dial_chat_script,                               \
+	};                                                                                         \
+                                                                                                   \
+	PM_DEVICE_DT_INST_DEFINE(inst, modem_cellular_pm_action);                                  \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(inst, modem_cellular_init, PM_DEVICE_DT_INST_GET(inst),              \
+			      &MODEM_CELLULAR_INST_NAME(data, inst),                               \
+			      &MODEM_CELLULAR_INST_NAME(config, inst), POST_KERNEL, 99, NULL);
+
 #define DT_DRV_COMPAT quectel_bg95
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_QUECTEL_BG95)
 #undef DT_DRV_COMPAT
@@ -1614,4 +1683,8 @@ DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_U_BLOX_SARA_R4)
 
 #define DT_DRV_COMPAT swir_hl7800
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_SWIR_HL7800)
+#undef DT_DRV_COMPAT
+
+#define DT_DRV_COMPAT telit_me910g1
+DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_TELIT_ME910G1)
 #undef DT_DRV_COMPAT

--- a/dts/bindings/modem/telit,me910g1.yaml
+++ b/dts/bindings/modem/telit,me910g1.yaml
@@ -1,0 +1,23 @@
+# Copyright(c) 2023 Jeff Welder (Ellenby Technologies, Inc.)
+# SPDX-License-Identifier: Apache-2.0
+
+description: Telit ME910G1 Modem
+
+compatible: "telit,me910g1"
+
+include: uart-device.yaml
+
+properties:
+  mdm-power-gpios:
+    type: phandle-array
+    required: true
+
+  mdm-reset-gpios:
+    type: phandle-array
+    required: true
+
+  mdm-dtr-gpios:
+    type: phandle-array
+
+  mdm-ri-gpios:
+    type: phandle-array

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -606,6 +606,7 @@ tdo	Shangai Top Display Optoelectronics Co., Ltd
 technexion	TechNexion
 technologic	Technologic Systems
 telink	Telink Semiconductor
+telit	Telit Cinterion
 tempo	Tempo Semiconductor
 techstar	Shenzhen Techstar Electronics Co., Ltd.
 terasic	Terasic Inc.

--- a/tests/drivers/build_all/modem/uart.dtsi
+++ b/tests/drivers/build_all/modem/uart.dtsi
@@ -51,6 +51,16 @@ test_gsm_ppp: gsm_ppp {
 	compatible = "zephyr,gsm-ppp";
 };
 
+test_telit_me910g1: telit_me910g1 {
+	compatible = "telit,me910g1";
+
+	mdm-power-gpios = <&test_gpio 0 0>;
+	mdm-reset-gpios = <&test_gpio 0 0>;
+
+	mdm-dtr-gpios = <&test_gpio 0 0>;
+	mdm-ri-gpios = <&test_gpio 0 0>;
+};
+
 test_esp_at: esp_at {
 	compatible = "espressif,esp-at";
 };


### PR DESCRIPTION
Added Telit ME910G1 dts and modem chat scripts.

Refactor device macro to be custom for each modem to allow custom configurations on each modem (assisted by @bjarki-trackunit). 
(This was needed by Telit ME910G1 to allow for ON_OFF to be toggled for minimum of 5 seconds as per Telit)

