### PR TITLE
doc: release-notes: Add 3.5.0 release notes for random and entropy

### DIFF
--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -495,6 +495,10 @@ Libraries / Subsystems
     operation for SDMMC devices in case when we align buffers on CONFIG_SDHC_BUFFER_ALIGNMENT,
     because we can avoid extra copy of data from card bffer to read/prog buffer.
 
+* Random
+
+  * ``CONFIG_XOROSHIRO_RANDOM_GENERATOR``, deprecated a long time ago, is finally removed.
+
 * Retention
 
   * Added the :ref:`blinfo_api` subsystem.

--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -234,6 +234,9 @@ Drivers and Sensors
 
 * Entropy
 
+  * Added a requirement for ``entropy_get_entropy()`` to be thread-safe because
+    of random subsystem needs.
+
 * ESPI
 
 * Ethernet


### PR DESCRIPTION
Release notes for entropy drivers and random subsys.