### PR TITLE
doc: release/3.5: add bits about Xtensa, UART, PCIe, I3C, userspace, syscalls, and shadow variables

### DIFF
--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -49,6 +49,8 @@ Kernel
 
 * Added support for dynamic thread stack allocation via :c:func:`k_thread_stack_alloc`
 * Added support for :c:func:`k_spin_trylock`
+* Added :c:func:`k_object_is_valid` to check if a kernel object is valid. This replaces
+  code that has been duplicated throughout the tree.
 
 Architectures
 *************
@@ -215,6 +217,10 @@ Build system and infrastructure
 
 * Added a new ``initlevels`` target for printing the final device and
   :c:macro:`SYS_INIT` initialization sequence from the final ELF file.
+
+* Reworked syscall code generations so that not all marshalling functions
+  will be included in the final binary. Syscalls associated with disabled
+  subsystems no longer have their marshalling functions generated.
 
 Drivers and Sensors
 *******************

--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -68,6 +68,8 @@ Architectures
 
 * Xtensa
 
+  * Added basic MMU v2 Support.
+
 * POSIX
 
   * Has been reworked to use the native simulator.
@@ -109,6 +111,7 @@ Boards & SoC Support
     and CONFIG_NXP_IMX_EXTERNAL_SDRAM to enabled.
   * i.MX RT SOCs no longer support CONFIG_OCRAM_NOCACHE, as this functionality
     can be achieved using devicetree memory regions
+  * Refactored ESP32 SoC folders. So now these are a proper SoC series.
 
 * Added support for these ARC boards:
 
@@ -123,6 +126,19 @@ Boards & SoC Support
 * Added support for these X86 boards:
 
 * Added support for these Xtensa boards:
+
+  * Added ``esp32_devkitc_wroom`` and ``esp32_devkitc_wrover``.
+
+  * Added ``esp32s3_luatos_core``.
+
+  * Added ``m5stack_core2``.
+
+  * Added ``qemu_xtensa_mmu`` utilizing Diamond DC233c SoC to support
+    testing Xtensa MMU.
+
+  * Added ``xiao_esp32s3``.
+
+  * Added ``yd_esp32``.
 
 * Added support for these POSIX boards:
 
@@ -142,6 +158,12 @@ Boards & SoC Support
 
 * Made these changes for Xtensa boards:
 
+  * esp32s3_devkitm:
+
+    * Added USB-CDC support.
+
+    * Added CAN support.
+
 * Made these changes for POSIX boards:
 
   * nrf52_bsim:
@@ -160,6 +182,8 @@ Boards & SoC Support
 * Removed support for these X86 boards:
 
 * Removed support for these Xtensa boards:
+
+  * Removed ``esp32``. Use ``esp32_devkitc_*`` instead.
 
 * Made these changes in other boards:
 

--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -222,6 +222,10 @@ Build system and infrastructure
   will be included in the final binary. Syscalls associated with disabled
   subsystems no longer have their marshalling functions generated.
 
+* Partially enabled compiler warning about shadow variables for subset of
+  in-tree code. Out-of-tree code needs to be patched before we can fully
+  enable shadow variable warnings.
+
 Drivers and Sensors
 *******************
 

--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -340,6 +340,15 @@ Drivers and Sensors
 
 * PCIE
 
+  * Added support in shell to display PCIe capabilities.
+
+  * Added virtual channel support.
+
+  * Added kconfig :kconfig:option:`CONFIG_PCIE_INIT_PRIORITY` to specify
+    initialization priority for host controller.
+
+  * Added support to get IRQ from ACPI PCI Routing Table (PRT).
+
 * PECI
 
 * Pin control

--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -287,6 +287,13 @@ Drivers and Sensors
 
 * I3C
 
+  * ``i3c_cdns``:
+
+    * Fixed build error when :kconfig:option:`CONFIG_I3C_USE_IBI` is disabled.
+
+    * Fixed transfer issue when controller is busy. Now wait for controller to
+      idle before proceeding with another transfer.
+
 * IEEE 802.15.4
 
   * A new mandatory method attr_get() was introduced into ieee802154_radio_api.

--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -416,9 +416,31 @@ Drivers and Sensors
 
   * NS16550: Reworked how device initialization macros.
 
-    * CONFIG_UART_NS16550_ACCESS_IOPORT and CONFIG_UART_NS16550_SIMULT_ACCESS
-      are removed. For UART using IO port access, add "io-mapped" property to
+    * ``CONFIG_UART_NS16550_ACCESS_IOPORT`` and ``CONFIG_UART_NS16550_SIMULT_ACCESS``
+      are removed. For UART using IO port access, add ``io-mapped`` property to
       device tree node.
+
+  * Added async support for ESP32S3.
+
+  * Added support for serial TTY under ``native_posix``.
+
+  * Added support for UART on Efinix Sapphire SoCs.
+
+  * Added Intel SEDI UART driver.
+
+  * Added support for UART on BCM2711.
+
+  * ``uart_stm32``:
+
+    * Added RS485 support.
+
+    * Added wide data support.
+
+  * ``uart_pl011``: added support for Ambiq SoCs.
+
+  * ``serial_test``: added support for interrupt and async APIs.
+
+  * ``uart_emul``: added support for interrupt API.
 
 * SPI
 


### PR DESCRIPTION
(See individual commits for details.)