### PR TITLE
kernel: early_random: Internal early 'random' subsys fixes

### DIFF
--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -149,7 +149,7 @@ extern void smp_timer_init(void);
 #endif
 #endif
 
-extern void z_early_boot_rand_get(uint8_t *buf, size_t length);
+extern void z_early_rand_get(uint8_t *buf, size_t length);
 
 #if CONFIG_STACK_POINTER_RANDOM
 extern int z_stack_adjust_initialized;

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -510,7 +510,7 @@ static FUNC_NORETURN void switch_to_main_thread(char *stack_ptr)
 
 #if defined(CONFIG_ENTROPY_HAS_DRIVER) || defined(CONFIG_TEST_RANDOM_GENERATOR)
 __boot_func
-void z_early_boot_rand_get(uint8_t *buf, size_t length)
+void z_early_rand_get(uint8_t *buf, size_t length)
 {
 #ifdef CONFIG_ENTROPY_HAS_DRIVER
 	const struct device *const entropy = DEVICE_DT_GET_OR_NULL(DT_CHOSEN(zephyr_entropy));
@@ -592,7 +592,7 @@ FUNC_NORETURN void z_cstart(void)
 #ifdef CONFIG_STACK_CANARIES
 	uintptr_t stack_guard;
 
-	z_early_boot_rand_get((uint8_t *)&stack_guard, sizeof(stack_guard));
+	z_early_rand_get((uint8_t *)&stack_guard, sizeof(stack_guard));
 	__stack_chk_guard = stack_guard;
 	__stack_chk_guard <<= 8;
 #endif	/* CONFIG_STACK_CANARIES */

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -510,7 +510,7 @@ static FUNC_NORETURN void switch_to_main_thread(char *stack_ptr)
 
 #if defined(CONFIG_ENTROPY_HAS_DRIVER) || defined(CONFIG_TEST_RANDOM_GENERATOR)
 __boot_func
-void z_early_rand_get(uint8_t *buf, size_t length)
+void __weak z_early_rand_get(uint8_t *buf, size_t length)
 {
 #ifdef CONFIG_ENTROPY_HAS_DRIVER
 	const struct device *const entropy = DEVICE_DT_GET_OR_NULL(DT_CHOSEN(zephyr_entropy));

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -511,7 +511,7 @@ static FUNC_NORETURN void switch_to_main_thread(char *stack_ptr)
 __boot_func
 void __weak z_early_rand_get(uint8_t *buf, size_t length)
 {
-	static uint64_t state = 123456789UL;
+	static uint64_t state = (uint64_t)CONFIG_TIMER_RANDOM_INITIAL_STATE;
 	int rc;
 
 #ifdef CONFIG_ENTROPY_HAS_DRIVER

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -464,7 +464,7 @@ static size_t random_offset(size_t stack_size)
 	size_t random_val;
 
 	if (!z_stack_adjust_initialized) {
-		z_early_boot_rand_get((uint8_t *)&random_val, sizeof(random_val));
+		z_early_rand_get((uint8_t *)&random_val, sizeof(random_val));
 	} else {
 		sys_rand_get((uint8_t *)&random_val, sizeof(random_val));
 	}

--- a/subsys/random/Kconfig
+++ b/subsys/random/Kconfig
@@ -28,6 +28,14 @@ config TEST_RANDOM_GENERATOR
 	  device-backed random number generator, if available, will be selected by
 	  default even when CONFIG_TEST_RANDOM_GENERATOR=y.
 
+config TIMER_RANDOM_INITIAL_STATE
+	int "Initial state used by clock based number generator"
+	default 123456789
+	help
+	  Initial state value used by TIMER_RANDOM_GENERATOR and
+	  early random number genenator.
+
+
 choice RNG_GENERATOR_CHOICE
 	prompt "Random generator"
 	default ENTROPY_DEVICE_RANDOM_GENERATOR if ENTROPY_HAS_DRIVER

--- a/subsys/random/rand32_timer.c
+++ b/subsys/random/rand32_timer.c
@@ -35,7 +35,8 @@ static struct k_spinlock rand32_lock;
  */
 uint32_t z_impl_sys_rand32_get(void)
 {
-	static uint64_t state = 123456789UL;  /* initial seed value */
+	/* initial seed value */
+	static uint64_t state = (uint64_t)CONFIG_TIMER_RANDOM_INITIAL_STATE;
 	k_spinlock_key_t key = k_spin_lock(&rand32_lock);
 
 	state = state + k_cycle_get_32();

--- a/tests/crypto/rand32/src/main.c
+++ b/tests/crypto/rand32/src/main.c
@@ -8,7 +8,7 @@
 
 /*
  * This tests the following random number routines:
- * void z_early_boot_rand_get(uint8_t *buf, size_t length)
+ * void z_early_rand_get(uint8_t *buf, size_t length)
  * uint32_t sys_rand32_get(void);
  */
 
@@ -35,11 +35,11 @@ ZTEST(rand32_common, test_rand32)
 
 	/* Test early boot random number generation function */
 	/* Cover the case, where argument "length" is < size of "size_t" */
-	z_early_boot_rand_get((uint8_t *)&tmp, (size_t)1);
-	z_early_boot_rand_get((uint8_t *)&last_gen, sizeof(last_gen));
-	z_early_boot_rand_get((uint8_t *)&gen, sizeof(gen));
+	z_early_rand_get((uint8_t *)&tmp, (size_t)1);
+	z_early_rand_get((uint8_t *)&last_gen, sizeof(last_gen));
+	z_early_rand_get((uint8_t *)&gen, sizeof(gen));
 	zassert_true(last_gen != gen && last_gen != tmp && tmp != gen,
-			"z_early_boot_rand_get failed");
+			"z_early_rand_get failed");
 
 	/*
 	 * Test subsequently calls sys_rand32_get(), checking


### PR DESCRIPTION
- Rename `z_early_boot_rand_get` with `z_early_rand_get` to get consistent with other early functions.
- Make z_early_rand_get a weak symbol
   - Allow targets come up with their own early random generator since the default can be NOT so random due constraints.
 - Fixes for z_early_rand_get

    - The early random get function was making many wrong assumptions
    about random subsys and entropy drivers. First, it was assuming
    that entropy_get_entropy() would be ISR safe, that is not right,
    the driver has an ISR safe callback and if it is not implemented
    or not working it is not ok using the other callback.
    Second, the fallback to the random subsys is even more problematic
    since they can use kernel services to protect internal states and be
    thread-safe.

    - Another incorrect thing in this function was the guard around it.
    It was needed by features like stack randomization and stack canaries,
    and not when those conditions were match. Just remove it and in case
    it is not needed the linker will take care of it.

    - The drawback of this change is that in the absence of an entropy
    generator with support to be called from ISR the randomness is very
    weak.
