### PR TITLE
Bluetooth: ascs: Check subscription state on ASE notification

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -147,7 +147,8 @@ static void ase_status_changed(struct bt_ascs_ase *ase, uint8_t state)
 			return;
 		}
 
-		if (conn_info.state == BT_CONN_STATE_CONNECTED) {
+		if (conn_info.state == BT_CONN_STATE_CONNECTED &&
+		    bt_gatt_is_subscribed(conn, ase->attr, BT_GATT_CCC_NOTIFY)) {
 			const uint8_t att_ntf_header_size = 3; /* opcode (1) + handle (2) */
 			const uint16_t max_ntf_size = bt_gatt_get_mtu(conn) - att_ntf_header_size;
 			uint16_t ntf_size;

--- a/tests/bluetooth/audio/mocks/include/gatt.h
+++ b/tests/bluetooth/audio/mocks/include/gatt.h
@@ -15,6 +15,8 @@ void mock_bt_gatt_cleanup(void);
 
 DECLARE_FAKE_VALUE_FUNC(int, mock_bt_gatt_notify_cb, struct bt_conn *,
 			struct bt_gatt_notify_params *);
+DECLARE_FAKE_VALUE_FUNC(bool, mock_bt_gatt_is_subscribed, struct bt_conn *,
+			const struct bt_gatt_attr *, uint16_t);
 
 void bt_gatt_notify_cb_reset(void);
 uint16_t bt_gatt_get_mtu(struct bt_conn *conn);

--- a/tests/bluetooth/audio/mocks/src/gatt.c
+++ b/tests/bluetooth/audio/mocks/src/gatt.c
@@ -18,9 +18,12 @@ LOG_MODULE_REGISTER(bt_gatt);
 /* List of fakes used by this unit tester */
 #define FFF_FAKES_LIST(FAKE)                                                                       \
 	FAKE(mock_bt_gatt_notify_cb)                                                               \
+	FAKE(mock_bt_gatt_is_subscribed)                                                           \
 
 DEFINE_FAKE_VALUE_FUNC(int, mock_bt_gatt_notify_cb, struct bt_conn *,
 		       struct bt_gatt_notify_params *);
+DEFINE_FAKE_VALUE_FUNC(bool, mock_bt_gatt_is_subscribed, struct bt_conn *,
+		       const struct bt_gatt_attr *, uint16_t);
 
 ssize_t bt_gatt_attr_read_service(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
 				  uint16_t len, uint16_t offset)
@@ -53,6 +56,8 @@ ssize_t bt_gatt_attr_write_ccc(struct bt_conn *conn, const struct bt_gatt_attr *
 void mock_bt_gatt_init(void)
 {
 	FFF_FAKES_LIST(RESET_FAKE);
+
+	mock_bt_gatt_is_subscribed_fake.return_val = true;
 }
 
 static void notify_params_deep_copy_destroy(void)
@@ -245,4 +250,10 @@ ssize_t bt_gatt_attr_read(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 uint16_t bt_gatt_get_mtu(struct bt_conn *conn)
 {
 	return 64;
+}
+
+bool bt_gatt_is_subscribed(struct bt_conn *conn,
+			   const struct bt_gatt_attr *attr, uint16_t ccc_type)
+{
+	return mock_bt_gatt_is_subscribed(conn, attr, ccc_type);
 }


### PR DESCRIPTION
Check whether peer is subscribed for ASE state notification before calling bt_gatt_notify. This handles an assert thrown when the notification failed to be sent.

Fixes: #63728