### PR TITLE
Fix net mgmt recvfrom

### DIFF
--- a/subsys/net/lib/sockets/sockets_net_mgmt.c
+++ b/subsys/net/lib/sockets/sockets_net_mgmt.c
@@ -209,8 +209,12 @@ again:
 
 	if (info) {
 		ret = info_len + sizeof(hdr);
-		ret = MIN(max_len, ret);
-		memcpy(&copy_to[sizeof(hdr)], info, ret);
+		if (ret > max_len) {
+			errno = EMSGSIZE;
+			return -1;
+		}
+
+		memcpy(&copy_to[sizeof(hdr)], info, info_len);
 	} else {
 		ret = 0;
 	}

--- a/tests/net/socket/net_mgmt/src/main.c
+++ b/tests/net/socket/net_mgmt/src/main.c
@@ -457,6 +457,34 @@ ZTEST_USER(net_socket_net_mgmt, test_net_mgmt_catch_user)
 	test_net_mgmt_catch_events();
 }
 
+static void test_net_mgmt_catch_events_failure(void)
+{
+#define SMALL_BUF_LEN 16
+	struct sockaddr_nm event_addr;
+	socklen_t event_addr_len;
+	uint8_t buf[SMALL_BUF_LEN];
+	int ret;
+
+	memset(buf, 0, sizeof(buf));
+	event_addr_len = sizeof(event_addr);
+
+	ret = recvfrom(fd, buf, sizeof(buf), 0,
+		       (struct sockaddr *)&event_addr,
+		       &event_addr_len);
+	zassert_equal(ret, -1, "Msg check failed, %d", errno);
+	zassert_equal(errno, EMSGSIZE, "Msg check failed, errno %d", errno);
+}
+
+ZTEST(net_socket_net_mgmt, test_net_mgmt_catch_failure_kernel)
+{
+	test_net_mgmt_catch_events_failure();
+}
+
+ZTEST_USER(net_socket_net_mgmt, test_net_mgmt_catch_failure_user)
+{
+	test_net_mgmt_catch_events_failure();
+}
+
 ZTEST(net_socket_net_mgmt, test_net_mgmt_cleanup)
 {
 	k_thread_abort(trigger_events_thread_id);


### PR DESCRIPTION
The `recvfrom()` should return `EMSGSIZE` if we try to receive data to too small buffer. Add also test case for it.

Fixes #63835