### PR TITLE
drivers: eswifi: Fix the SSID copying

### DIFF
--- a/drivers/wifi/eswifi/eswifi_core.c
+++ b/drivers/wifi/eswifi/eswifi_core.c
@@ -491,7 +491,7 @@ int eswifi_mgmt_iface_status(const struct device *dev,
 
 	status->state = WIFI_STATE_COMPLETED;
 	status->ssid_len = strnlen(sta->ssid, WIFI_SSID_MAX_LEN);
-	strncpy(status->ssid, sta->ssid, sta->ssid_len);
+	strncpy(status->ssid, sta->ssid, status->ssid_len);
 	status->band = WIFI_FREQ_BAND_2_4_GHZ;
 	status->channel = 0;
 


### PR DESCRIPTION
The wrong ssid_len was used which causes build error.