### PR TITLE
ci: tags: include wifi/net drivers in the net group

### DIFF
--- a/scripts/ci/tags.yaml
+++ b/scripts/ci/tags.yaml
@@ -50,6 +50,11 @@ net:
   files:
     - subsys/net/
     - include/zephyr/net/
+    - drivers/wifi/
+    - drivers/net/
+    - drivers/ethernet/
+    - drivers/ieee802154/
+    - drivers/ptp_clock/
 
 test_framework:
   files:


### PR DESCRIPTION
Changes to networking and wifi drivers should trigger networking tests.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
