### PR TITLE
boards: arm: LPC55Sx6: Enable LinkServer and PyOCD runners.

### DIFF
--- a/boards/arm/lpcxpresso55s06/board.cmake
+++ b/boards/arm/lpcxpresso55s06/board.cmake
@@ -1,9 +1,12 @@
 #
 # Copyright (c) 2022 metraTec
+# Copyright 2023 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 
+board_runner_args(linkserver  "--device=LPC55S06:LPCXpresso55S06")
 board_runner_args(jlink "--device=LPC55S06" "--reset-after-load")
 
+include(${ZEPHYR_BASE}/boards/common/linkserver.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/lpcxpresso55s16/board.cmake
+++ b/boards/arm/lpcxpresso55s16/board.cmake
@@ -1,9 +1,14 @@
 #
 # Copyright (c) 2020 Henrik Brix Andersen <henrik@brixandersen.dk>
+# Copyright 2023 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 
+board_runner_args(linkserver  "--device=LPC55S16:LPCXpresso55S16")
 board_runner_args(jlink "--device=LPC55S16" "--reset-after-load")
+board_runner_args(pyocd "--target=lpc55s16")
 
+include(${ZEPHYR_BASE}/boards/common/linkserver.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/lpcxpresso55s36/board.cmake
+++ b/boards/arm/lpcxpresso55s36/board.cmake
@@ -1,11 +1,13 @@
 #
-# Copyright 2022 NXP
+# Copyright 2022-2023 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 
+board_runner_args(linkserver  "--device=LPC55S36:LPCXpresso55S36")
 board_runner_args(jlink "--device=LPC55S36" "--reset-after-load")
 board_runner_args(pyocd "--target=lpc55s36")
 
+include(${ZEPHYR_BASE}/boards/common/linkserver.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)


### PR DESCRIPTION
Enable LinkerServer and PyOCD runners for LPC55Sx6 EVKs, where it is supported.
It was tested on a real HW.