### PR TITLE
Bluetooth: CAP: Add size and rank checks for CAS register

### DIFF
--- a/subsys/bluetooth/audio/cap_acceptor.c
+++ b/subsys/bluetooth/audio/cap_acceptor.c
@@ -27,6 +27,16 @@ int bt_cap_acceptor_register(const struct bt_csip_set_member_register_param *par
 	static struct bt_gatt_service cas;
 	int err;
 
+	CHECKIF(param->set_size == 0U) {
+		LOG_DBG("param->set_size shall be non-zero");
+		return -EINVAL;
+	}
+
+	CHECKIF(param->rank == 0U) {
+		LOG_DBG("param->rank shall be non-zero");
+		return -EINVAL;
+	}
+
 	err = bt_csip_set_member_register(param, svc_inst);
 	if (err != 0) {
 		LOG_DBG("Failed to register CSIP");


### PR DESCRIPTION
For the CAP acceptor the size and rank characteristic shall be set as per the CAP spec. Add checks for 0, as 0 indicates not initializing the characteristics in the CSIS instance.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/55456