### PR TITLE
tests: drivers: Fix adc labels in sensors test

### DIFF
--- a/tests/drivers/build_all/sensor/adc.dtsi
+++ b/tests/drivers/build_all/sensor/adc.dtsi
@@ -45,7 +45,7 @@ test_adc_emul: adc-emul {
 
 test_adc_ntc_thermistor_generic: ntc-thermistor-generic {
 	compatible = "ntc-thermistor-generic";
-	io-channels = <&adc0 0>;
+	io-channels = <&test_adc 0>;
 	pullup-uv = <3300000>;
 	pullup-ohm = <0>;
 	pulldown-ohm = <10000>;
@@ -55,7 +55,7 @@ test_adc_ntc_thermistor_generic: ntc-thermistor-generic {
 
 test_adc_epcos_b57861s0103a039: epcos-b57861s0103a039 {
 	compatible = "epcos,b57861s0103a039";
-	io-channels = <&adc0 0>;
+	io-channels = <&test_adc 0>;
 	pullup-uv = <3300000>;
 	pullup-ohm = <0>;
 	pulldown-ohm = <10000>;
@@ -64,7 +64,7 @@ test_adc_epcos_b57861s0103a039: epcos-b57861s0103a039 {
 
 test_murata_ncp15wb473: murata-ncp15wb473 {
 	compatible = "murata,ncp15wb473";
-	io-channels = <&adc0 0>;
+	io-channels = <&test_adc 0>;
 	pullup-uv = <3300000>;
 	pullup-ohm = <0>;
 	pulldown-ohm = <10000>;


### PR DESCRIPTION
Fix the labels used in io-channels to be consistent in whole `tests/drivers/build_all/sensor/adc.dtsi` file.