### PR TITLE
MAINTAINERS: Create dedicated entries for 3rd party toolchains

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2795,7 +2795,7 @@ TF-M Integration:
   labels:
     - "area: TF-M"
 
-Toolchain Integration:
+"Toolchain Integration":
   status: maintained
   maintainers:
     - tejlmand
@@ -2806,6 +2806,40 @@ Toolchain Integration:
     - cmake/compiler/
     - cmake/linker/
     - cmake/toolchain/
+  labels:
+    - "area: Toolchains"
+
+"Toolchain ARC MWDT":
+  status: maintained
+  maintainers:
+    - evgeniy-paltsev
+    - abrodkin
+  files:
+    - cmake/*/arcmwdt/
+    - include/zephyr/toolchain/mwdt.h
+    - lib/libc/arcmwdt/*
+  labels:
+    - "area: Toolchains"
+
+"Toolchain arm compiler 6":
+  status: maintained
+  maintainers:
+    - tejlmand
+  files:
+    - cmake/*/armclang/
+    - cmake/linker/armlink/
+    - include/zephyr/toolchain/armclang.h
+    - lib/libc/armstdc/*
+  labels:
+    - "area: Toolchains"
+
+"Toolchain oneApi":
+  status: maintained
+  maintainers:
+    - nashif
+  files:
+    - cmake/*/oneApi/
+    - cmake/compiler/icx/
   labels:
     - "area: Toolchains"
 


### PR DESCRIPTION
Fixes: #63738

Create dedicated entries for ARC MWDT, arm compiler 6, and one Api toolchains.

This helps contributors to identify whom to contact in case of issues related to those toolchains.

The Zephyr SDK, cross-compile, and other GCC based compilers are covered as part of the general cmake/toolchain,compiler,linker,bintools entry in the MAINTAINERS file.