### PR TITLE
dts: usb-c: fix invalid power-role in example

### DIFF
--- a/dts/bindings/usb-c/usb-c-connector.yaml
+++ b/dts/bindings/usb-c/usb-c-connector.yaml
@@ -29,7 +29,7 @@ description: |
             reg = <1>;
             tcpc = <&ucpd1>;
             vbus = <&vbus1>;
-            power-role = "SINK";
+            power-role = "sink";
             sink-pdos = <PDO_FIXED(5000, 2000, PDO_FIXED_USB_COMM)
                          PDO_VAR(5000, 12000, 2000)>;
             op-sink-microwatt = <10000000>;


### PR DESCRIPTION
The example sets the power-role to "SINK", but the value is case-sensitive and only accepts lowercase "sink".
Copy pasting the example from the docs otherwise leads to
```
devicetree error: value of property 'power-role' on /ports/usbc-port@1 in [...]/build/zephyr/zephyr.dts.pre ('SINK') is not in 'enum' list in [...]/zephyr/dts/bindings/usb-c/usb-c-connector.yaml (['sink', 'source', 'dual'])
```
