### PR TITLE
drivers:modem: introducing config for cereg/creg for gsm

### DIFF
--- a/drivers/modem/Kconfig.gsm
+++ b/drivers/modem/Kconfig.gsm
@@ -36,6 +36,24 @@ config MODEM_GSM_QUECTEL
 
 endchoice
 
+choice MODEM_GSM_STATUS_COMMAND_TYPE
+	prompt "Select AT command Type"
+	default MODEM_GSM_SELECT_CREG
+	help
+	  Use particular type of AT command for registration status.
+
+config MODEM_GSM_SELECT_CREG
+	bool "CREG command"
+	help
+	  Use this if the modem works only with AT+CREG?.
+
+config MODEM_GSM_SELECT_CEREG
+	bool "CEREG command"
+	help
+	  Use this if the modem does not work with AT+CREG?.
+
+endchoice
+
 config MODEM_GSM_RX_STACK_SIZE
 	int "Size of the stack allocated for receiving data from modem"
 	default 512


### PR DESCRIPTION
As some tests with our 4G modems shown that AT+CREG? does not work as expected with the modems. Therefore, the modem does not get internet connection as the modem expects AT+CREG=0,5 for successful PPP connection but this is never accomplished as some modems do not return AT+CREG=0,5 on successful connection to an operator rather AT+CEREG? is the right AT command to use for such modems. Therefore, a new CONFIG is added to use AT+CEREG? for such modems.
The user can select AT+CREG? or AT+CEREG? according to the type the modem supports.
This PR fixes #63917