### PR TITLE
Remove stale information from benchmark test README files

### DIFF
--- a/tests/benchmarks/app_kernel/README.txt
+++ b/tests/benchmarks/app_kernel/README.txt
@@ -1,31 +1,9 @@
-Title: Microkernel Object Performance
+Title: Kernel Object Performance
 
 Description:
 
-AppKernel is used to measure the performance of microkernel events, mutexes,
-semaphores, FIFOs, mailboxes, pipes, memory maps, and memory pools.
-
---------------------------------------------------------------------------------
-
-Building and Running Project:
-
-This project outputs to the console. It can be built and executed
-on QEMU as follows:
-
-    make run
-
---------------------------------------------------------------------------------
-
-Troubleshooting:
-
-Problems caused by out-dated project information can be addressed by
-issuing one of the following commands then rebuilding the project:
-
-    make clean          # discard results of previous builds
-                        # but keep existing configuration info
-or
-    make pristine       # discard results of previous builds
-                        # and restore pre-defined configuration info
+The app_kernel test is used to measure the performance of the following
+kernel objects: message queues, semaphores, memory slabs, mailboxes and pipes.
 
 --------------------------------------------------------------------------------
 
@@ -45,24 +23,10 @@ Sample Output:
 | signal semaphore                                                 |    NNNNNN|
 | signal to waiting high pri task                                  |    NNNNNN|
 | signal to waiting high pri task, with timeout                    |    NNNNNN|
-| signal to waitm (2)                                              |    NNNNNN|
-| signal to waitm (2), with timeout                                |    NNNNNN|
-| signal to waitm (3)                                              |    NNNNNN|
-| signal to waitm (3), with timeout                                |   NNNNNNN|
-| signal to waitm (4)                                              |   NNNNNNN|
-| signal to waitm (4), with timeout                                |   NNNNNNN|
 |-----------------------------------------------------------------------------|
 | average lock and unlock mutex                                    |    NNNNNN|
 |-----------------------------------------------------------------------------|
 | average alloc and dealloc memory page                            |    NNNNNN|
-|-----------------------------------------------------------------------------|
-| average alloc and dealloc memory pool block                      |    NNNNNN|
-|-----------------------------------------------------------------------------|
-| Signal enabled event                                             |    NNNNNN|
-| Signal event & Test event                                        |    NNNNNN|
-| Signal event & TestW event                                       |    NNNNNN|
-| Signal event with installed handler                                         |
-|    Handler responds OK                                                      |
 |-----------------------------------------------------------------------------|
 |                M A I L B O X   M E A S U R E M E N T S                      |
 |-----------------------------------------------------------------------------|

--- a/tests/benchmarks/sys_kernel/README.txt
+++ b/tests/benchmarks/sys_kernel/README.txt
@@ -7,34 +7,12 @@ lifo, fifo, stack and memslab objects.
 
 --------------------------------------------------------------------------------
 
-Building and Running Project:
-
-This project outputs to the console. It can be built and executed
-on QEMU as follows:
-
-    make run
-
---------------------------------------------------------------------------------
-
-Troubleshooting:
-
-Problems caused by out-dated project information can be addressed by
-issuing one of the following commands then rebuilding the project:
-
-    make clean          # discard results of previous builds
-                        # but keep existing configuration info
-or
-    make pristine       # discard results of previous builds
-                        # and restore pre-defined configuration info
-
---------------------------------------------------------------------------------
-
 Sample Output:
 
 MODULE: kernel API test
-KERNEL VERSION: 0x1066300
+KERNEL VERSION: 0xXXYYZZZZ
 
-Each test below is repeated 5000 times;
+Each test below is repeated 10 times;
 average time for one iteration is displayed.
 
 TEST CASE: Semaphore #1
@@ -50,7 +28,7 @@ END TEST CASE
 TEST CASE: Semaphore #2
 TEST COVERAGE:
         k_sem_init
-        k_sem_take(TICKS_NONE)
+        k_sem_take(K_NO_WAIT)
         k_yield
         k_sem_give
 Starting test. Please wait...
@@ -84,7 +62,7 @@ TEST CASE: LIFO #2
 TEST COVERAGE:
         k_lifo_init
         k_lifo_get(K_FOREVER)
-        k_lifo_get(TICKS_NONE)
+        k_lifo_get(K_NO_WAIT)
         k_lifo_put
         k_yield
 Starting test. Please wait...
@@ -118,7 +96,7 @@ TEST CASE: FIFO #2
 TEST COVERAGE:
         k_fifo_init
         k_fifo_get(K_FOREVER)
-        k_fifo_get(TICKS_NONE)
+        k_fifo_get(K_NO_WAIT)
         k_fifo_put
         k_yield
 Starting test. Please wait...
@@ -189,4 +167,3 @@ DETAILS: Average time for 1 iteration: NNNN nSec
 END TEST CASE
 
 PROJECT EXECUTION SUCCESSFUL
-QEMU: Terminated

--- a/tests/benchmarks/sys_kernel/src/lifo.c
+++ b/tests/benchmarks/sys_kernel/src/lifo.c
@@ -177,7 +177,7 @@ int lifo_test(void)
 	fprintf(output_file, sz_description,
 			"\n\tk_lifo_init"
 			"\n\tk_lifo_get(K_FOREVER)"
-			"\n\tk_lifo_get(TICKS_NONE)"
+			"\n\tk_lifo_get(K_NO_WAIT)"
 			"\n\tk_lifo_put"
 			"\n\tk_yield");
 	printf(sz_test_start_fmt);

--- a/tests/benchmarks/sys_kernel/src/mwfifo.c
+++ b/tests/benchmarks/sys_kernel/src/mwfifo.c
@@ -177,7 +177,7 @@ int fifo_test(void)
 	fprintf(output_file, sz_description,
 			"\n\tk_fifo_init"
 			"\n\tk_fifo_get(K_FOREVER)"
-			"\n\tk_fifo_get(TICKS_NONE)"
+			"\n\tk_fifo_get(K_NO_WAIT)"
 			"\n\tk_fifo_put"
 			"\n\tk_yield");
 	printf(sz_test_start_fmt);

--- a/tests/benchmarks/sys_kernel/src/sema.c
+++ b/tests/benchmarks/sys_kernel/src/sema.c
@@ -137,7 +137,7 @@ int sema_test(void)
 			"Semaphore #2");
 	fprintf(output_file, sz_description,
 			"\n\tk_sem_init"
-			"\n\tk_sem_take(TICKS_NONE)"
+			"\n\tk_sem_take(K_NO_WAIT)"
 			"\n\tk_yield"
 			"\n\tk_sem_give");
 	printf(sz_test_start_fmt);


### PR DESCRIPTION
Remove stale information from benchmark test README files.

The app_kernel project had ...
   1. A stale reference to the microkernel (which has been gone for years)
   2. Obsolete build instructions
   3. Sample output that contained defunct functionality

The sys_kernel project had ...
   1. Obsolete build instructions
   2. References to TICKS_NONE instead of K_NO_WAIT
   3. Some miscellaneous stale output