### PR TITLE
ci: move footprint workflows to zephyr runners

### DIFF
--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   footprint-tracking:
-    runs-on: ubuntu-22.04
+    runs-on: zephyr-runner-linux-x64-4xlarge
     if: github.repository_owner == 'zephyrproject-rtos'
     container:
       image: ghcr.io/zephyrproject-rtos/ci:v0.26.5

--- a/.github/workflows/footprint.yml
+++ b/.github/workflows/footprint.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   footprint-delta:
-    runs-on: ubuntu-22.04
+    runs-on: zephyr-runner-linux-x64-4xlarge
     if: github.repository == 'zephyrproject-rtos/zephyr'
     container:
       image: ghcr.io/zephyrproject-rtos/ci:v0.26.5


### PR DESCRIPTION
looks like our docker image is way too big for the GH runners, so move
to own runners until we have a better solution.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
