### PR TITLE
kernel: deprecate K_THREAD_STACK_MEMBER

### DIFF
--- a/doc/kernel/usermode/mpu_stack_objects.rst
+++ b/doc/kernel/usermode/mpu_stack_objects.rst
@@ -6,8 +6,7 @@ MPU Stack Objects
 Thread Stack Creation
 *********************
 
-Thread stacks are declared statically with :c:macro:`K_THREAD_STACK_DEFINE()`
-or embedded within structures using :c:macro:`K_THREAD_STACK_MEMBER()`
+Thread stacks are declared statically with :c:macro:`K_THREAD_STACK_DEFINE()`.
 
 For architectures which utilize memory protection unit (MPU) hardware,
 stacks are physically contiguous allocations.  This contiguous allocation

--- a/drivers/adc/adc_ads1x1x.c
+++ b/drivers/adc/adc_ads1x1x.c
@@ -140,7 +140,7 @@ struct ads1x1x_data {
 	struct k_thread thread;
 	bool differential;
 
-	K_THREAD_STACK_MEMBER(stack, CONFIG_ADC_ADS1X1X_ACQUISITION_THREAD_STACK_SIZE);
+	K_KERNEL_STACK_MEMBER(stack, CONFIG_ADC_ADS1X1X_ACQUISITION_THREAD_STACK_SIZE);
 };
 
 static int ads1x1x_read_reg(const struct device *dev, enum ads1x1x_reg reg_addr, uint16_t *buf)

--- a/drivers/adc/adc_b91.c
+++ b/drivers/adc/adc_b91.c
@@ -35,7 +35,7 @@ struct b91_adc_data {
 	struct k_sem acq_sem;
 	struct k_thread thread;
 
-	K_THREAD_STACK_MEMBER(stack, CONFIG_ADC_B91_ACQUISITION_THREAD_STACK_SIZE);
+	K_KERNEL_STACK_MEMBER(stack, CONFIG_ADC_B91_ACQUISITION_THREAD_STACK_SIZE);
 };
 
 struct b91_adc_cfg {

--- a/drivers/adc/adc_max1125x.c
+++ b/drivers/adc/adc_max1125x.c
@@ -226,7 +226,7 @@ struct max1125x_data {
 	struct k_thread thread;
 	bool differential;
 
-	K_THREAD_STACK_MEMBER(stack, CONFIG_ADC_MAX1125X_ACQUISITION_THREAD_STACK_SIZE);
+	K_KERNEL_STACK_MEMBER(stack, CONFIG_ADC_MAX1125X_ACQUISITION_THREAD_STACK_SIZE);
 };
 
 static void max1125x_data_ready_handler(const struct device *dev, struct gpio_callback *gpio_cb,

--- a/drivers/ethernet/eth_w5500_priv.h
+++ b/drivers/ethernet/eth_w5500_priv.h
@@ -90,7 +90,7 @@ struct w5500_config {
 struct w5500_runtime {
 	struct net_if *iface;
 
-	K_THREAD_STACK_MEMBER(thread_stack,
+	K_KERNEL_STACK_MEMBER(thread_stack,
 			      CONFIG_ETH_W5500_RX_THREAD_STACK_SIZE);
 	struct k_thread thread;
 	uint8_t mac_addr[6];

--- a/drivers/sensor/fdc2x1x/fdc2x1x.h
+++ b/drivers/sensor/fdc2x1x/fdc2x1x.h
@@ -159,7 +159,7 @@ struct fdc2x1x_data {
 	const struct device *dev;
 
 #ifdef CONFIG_FDC2X1X_TRIGGER_OWN_THREAD
-	K_THREAD_STACK_MEMBER(thread_stack, CONFIG_FDC2X1X_THREAD_STACK_SIZE);
+	K_KERNEL_STACK_MEMBER(thread_stack, CONFIG_FDC2X1X_THREAD_STACK_SIZE);
 	struct k_sem gpio_sem;
 	struct k_thread thread;
 #elif CONFIG_FDC2X1X_TRIGGER_GLOBAL_THREAD

--- a/drivers/sensor/sm351lt/sm351lt.h
+++ b/drivers/sensor/sm351lt/sm351lt.h
@@ -30,7 +30,7 @@ struct sm351lt_data {
 	const struct sensor_trigger *changed_trigger;
 
 #if defined(CONFIG_SM351LT_TRIGGER_OWN_THREAD)
-	K_THREAD_STACK_MEMBER(thread_stack, CONFIG_SM351LT_THREAD_STACK_SIZE);
+	K_KERNEL_STACK_MEMBER(thread_stack, CONFIG_SM351LT_THREAD_STACK_SIZE);
 	struct k_thread thread;
 	struct k_sem gpio_sem;
 #elif defined(CONFIG_SM351LT_TRIGGER_GLOBAL_THREAD)

--- a/drivers/sensor/tmag5170/tmag5170.h
+++ b/drivers/sensor/tmag5170/tmag5170.h
@@ -48,7 +48,7 @@ struct tmag5170_data {
 	struct k_sem sem;
 	struct k_thread thread;
 
-	K_THREAD_STACK_MEMBER(thread_stack,
+	K_KERNEL_STACK_MEMBER(thread_stack,
 			      CONFIG_TMAG5170_THREAD_STACK_SIZE);
 #elif defined(CONFIG_TMAG5170_TRIGGER_GLOBAL_THREAD)
 	struct k_work work;

--- a/drivers/sensor/tsl2540/tsl2540.h
+++ b/drivers/sensor/tsl2540/tsl2540.h
@@ -91,7 +91,7 @@ struct tsl2540_data {
 	sensor_trigger_handler_t als_handler;
 #endif
 #ifdef CONFIG_TSL2540_TRIGGER_OWN_THREAD
-	K_THREAD_STACK_MEMBER(thread_stack, CONFIG_TSL2540_THREAD_STACK_SIZE);
+	K_KERNEL_STACK_MEMBER(thread_stack, CONFIG_TSL2540_THREAD_STACK_SIZE);
 	struct k_thread thread;
 	struct k_sem trig_sem;
 #endif

--- a/drivers/sensor/vcnl4040/vcnl4040.h
+++ b/drivers/sensor/vcnl4040/vcnl4040.h
@@ -118,7 +118,7 @@ struct vcnl4040_data {
 	const struct sensor_trigger *als_trigger;
 #endif
 #ifdef CONFIG_VCNL4040_TRIGGER_OWN_THREAD
-	K_THREAD_STACK_MEMBER(thread_stack, CONFIG_VCNL4040_THREAD_STACK_SIZE);
+	K_KERNEL_STACK_MEMBER(thread_stack, CONFIG_VCNL4040_THREAD_STACK_SIZE);
 	struct k_thread thread;
 	struct k_sem trig_sem;
 #endif

--- a/include/zephyr/kernel/thread_stack.h
+++ b/include/zephyr/kernel/thread_stack.h
@@ -701,13 +701,13 @@ static inline char *Z_KERNEL_STACK_BUFFER(k_thread_stack_t *sym)
  * A user thread can only be started with a stack defined in this way if
  * the thread starting it is in supervisor mode.
  *
- * This is now deprecated, as stacks defined in this way are not usable from
- * user mode. Use K_KERNEL_STACK_MEMBER.
+ * @deprecated This is now deprecated, as stacks defined in this way are not
+ *             usable from user mode. Use K_KERNEL_STACK_MEMBER.
  *
  * @param sym Thread stack symbol name
  * @param size Size of the stack memory region
  */
-#define K_THREAD_STACK_MEMBER(sym, size) \
+#define K_THREAD_STACK_MEMBER(sym, size) __DEPRECATED_MACRO \
 	Z_THREAD_STACK_DEFINE_IN(sym, size,)
 
 /** @} */


### PR DESCRIPTION
The macro K_THREAD_STACK_MEMBER has actually been deprecated since v2.4.0 in the macro doxygen description, but it was never marked with __DEPRECATED_MACRO. Since this was being used in various drivers, make it follow the deprecation process.