### PR TITLE
west.yml: update esp32s3 to enable all flash ranges

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -155,7 +155,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: 635063971ee16d1fcdfd35136feda99a90926327
+      revision: 31fc5758f3507f8f0af00b1dea1a0df7af99bfc0
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
Current hal only enable up to 16MB flash size in esp32s3 SoC.  
This updates hal_espressif to include 32MB, 64MB and 128MB.

This also fixes "random.h" include header.

Fixes #63336