### PR TITLE
Bluetooth: CAP: Add verification of CCIDs as the initiator

### DIFF
--- a/subsys/bluetooth/audio/ccid.c
+++ b/subsys/bluetooth/audio/ccid.c
@@ -6,6 +6,9 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <zephyr/bluetooth/att.h>
+#include <zephyr/bluetooth/gatt.h>
+#include <zephyr/bluetooth/uuid.h>
 
 #include "ccid_internal.h"
 
@@ -22,4 +25,42 @@ uint8_t bt_ccid_get_value(void)
 		 "Cannot allocate any more control control IDs");
 
 	return ccid_value++;
+}
+
+struct ccid_search_param {
+	const struct bt_gatt_attr *attr;
+	uint8_t ccid;
+};
+
+static uint8_t ccid_attr_cb(const struct bt_gatt_attr *attr, uint16_t handle, void *user_data)
+{
+	struct ccid_search_param *search_param = user_data;
+
+	if (attr->read != NULL) {
+		uint8_t ccid = 0U;
+		ssize_t res;
+
+		res = attr->read(NULL, attr, &ccid, sizeof(ccid), 0);
+
+		if (res == sizeof(ccid) && search_param->ccid == ccid) {
+			search_param->attr = attr;
+
+			return BT_GATT_ITER_STOP;
+		}
+	}
+
+	return BT_GATT_ITER_CONTINUE;
+}
+
+const struct bt_gatt_attr *bt_ccid_find_attr(uint8_t ccid)
+{
+	struct ccid_search_param search_param = {
+		.attr = NULL,
+		.ccid = ccid,
+	};
+
+	bt_gatt_foreach_attr_type(BT_ATT_FIRST_ATTRIBUTE_HANDLE, BT_ATT_LAST_ATTRIBUTE_HANDLE,
+				  BT_UUID_CCID, NULL, 0, ccid_attr_cb, &search_param);
+
+	return search_param.attr;
 }

--- a/subsys/bluetooth/audio/ccid_internal.h
+++ b/subsys/bluetooth/audio/ccid_internal.h
@@ -23,4 +23,16 @@
  */
 uint8_t bt_ccid_get_value(void);
 
+/**
+ * @brief Get the GATT attribute of a CCID value
+ *
+ * Searches the current GATT database for a CCID characteristic that has the supplied CCID value.
+ *
+ * @param ccid The CCID the search for
+ *
+ * @retval NULL if none was found
+ * @retval A pointer to a GATT attribute if found
+ */
+const struct bt_gatt_attr *bt_ccid_find_attr(uint8_t ccid);
+
 #endif /* ZEPHYR_INCLUDE_BLUETOOTH_CCID_H_ */

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_broadcast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_broadcast_test.c
@@ -406,11 +406,18 @@ static void test_broadcast_audio_update_inval(struct bt_cap_broadcast_source *br
 
 static void test_broadcast_audio_update(struct bt_cap_broadcast_source *broadcast_source)
 {
-	const uint16_t mock_ccid = 0xAB;
+#if defined(CONFIG_BT_TBS)
+	/* TODO: We do not have a way to get the CCID value of GTBS, but for now set to 0x00 as we
+	 * know that it is the first content control service initialized
+	 */
+	const uint16_t gtbs_ccid = 0x00;
+#endif /* CONFIG_BT_TBS */
 	const uint8_t new_metadata[] = {
 		BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_STREAM_CONTEXT,
-				    BT_BYTES_LIST_LE16(BT_AUDIO_CONTEXT_TYPE_MEDIA)),
-		BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_CCID_LIST, mock_ccid),
+				    BT_BYTES_LIST_LE16(BT_AUDIO_CONTEXT_TYPE_CONVERSATIONAL)),
+#if defined(CONFIG_BT_TBS)
+		BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_CCID_LIST, gtbs_ccid),
+#endif /* CONFIG_BT_TBS */
 	};
 	int err;
 


### PR DESCRIPTION
When the initiator provides CCID in the metadata, we verify that the CCIDs exist on the device.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/57442