### PR TITLE
drivers: pinctrl: update Infineon CAT1 pinctrl driver

### DIFF
--- a/drivers/pinctrl/pinctrl_ifx_cat1.c
+++ b/drivers/pinctrl/pinctrl_ifx_cat1.c
@@ -52,41 +52,44 @@ static uint32_t soc_gpio_get_drv_mode(uint32_t flags)
 
 	if (_flags & SOC_GPIO_OPENDRAIN) {
 		/* drive_open_drain */
-		drv_mode = CY_GPIO_DM_OD_DRIVESLOW_IN_OFF;
+		drv_mode = (_flags & SOC_GPIO_INPUTENABLE) ? CY_GPIO_DM_OD_DRIVESLOW
+							   : CY_GPIO_DM_OD_DRIVESLOW_IN_OFF;
 
 	} else if (_flags & SOC_GPIO_OPENSOURCE) {
 		/* drive_open_source */
-		drv_mode = CY_GPIO_DM_OD_DRIVESHIGH_IN_OFF;
+		drv_mode = (_flags & SOC_GPIO_INPUTENABLE) ? CY_GPIO_DM_OD_DRIVESHIGH
+							   : CY_GPIO_DM_OD_DRIVESHIGH_IN_OFF;
 
 	} else if (_flags & SOC_GPIO_PUSHPULL) {
 		/* drive_push_pull */
-		drv_mode = CY_GPIO_DM_STRONG_IN_OFF;
+		drv_mode = (_flags & SOC_GPIO_INPUTENABLE) ? CY_GPIO_DM_STRONG
+							   : CY_GPIO_DM_STRONG_IN_OFF;
 
 	} else if ((_flags & SOC_GPIO_PULLUP) && (_flags & SOC_GPIO_PULLDOWN)) {
 		/* bias_pull_up and bias_pull_down */
-		drv_mode = CY_GPIO_DM_PULLUP_DOWN_IN_OFF;
+		drv_mode = (_flags & SOC_GPIO_INPUTENABLE) ? CY_GPIO_DM_PULLUP_DOWN
+							   : CY_GPIO_DM_PULLUP_DOWN_IN_OFF;
 
 	} else if (_flags & SOC_GPIO_PULLUP) {
 		/* bias_pull_up */
-		drv_mode = CY_GPIO_DM_PULLUP_IN_OFF;
+		drv_mode = (_flags & SOC_GPIO_INPUTENABLE) ? CY_GPIO_DM_PULLUP
+							   : CY_GPIO_DM_PULLUP_IN_OFF;
 
 	} else if (_flags & SOC_GPIO_PULLDOWN) {
 		/* bias_pull_down */
-		drv_mode = CY_GPIO_DM_PULLDOWN_IN_OFF;
+		drv_mode = (_flags & SOC_GPIO_INPUTENABLE) ? CY_GPIO_DM_PULLDOWN
+							   : CY_GPIO_DM_PULLDOWN_IN_OFF;
+	} else if ((_flags & SOC_GPIO_HIGHZ) | (_flags & SOC_GPIO_INPUTENABLE)) {
+		/* bias_pull_down */
+		drv_mode = CY_GPIO_DM_HIGHZ;
 	} else {
 		/* nothing do here */
-	}
-
-	if (_flags & SOC_GPIO_INPUTENABLE) {
-		/* input_enable */
-		drv_mode |= CY_GPIO_DM_HIGHZ;
 	}
 
 	return drv_mode;
 }
 
-int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
-			   uintptr_t reg)
+int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt, uintptr_t reg)
 {
 	ARG_UNUSED(reg);
 

--- a/dts/bindings/pinctrl/infineon,cat1-pinctrl.yaml
+++ b/dts/bindings/pinctrl/infineon,cat1-pinctrl.yaml
@@ -21,6 +21,7 @@ description: |
   Pin configuration can also specify the pin properties, for example the
   'bias-pull-up' property. Here is a list of the supported standard pin
   properties:
+    * bias-high-impedance
     * bias-pull-up
     * bias-pull-down
     * drive-open-drain
@@ -105,6 +106,7 @@ child-binding:
   include:
     - name: pincfg-node.yaml
       property-allowlist:
+        - bias-high-impedance
         - bias-pull-down
         - bias-pull-up
         - drive-push-pull

--- a/soc/arm/infineon_cat1/common/pinctrl_soc.h
+++ b/soc/arm/infineon_cat1/common/pinctrl_soc.h
@@ -59,6 +59,9 @@ extern "C" {
 #define SOC_GPIO_INPUTENABLE_POS        (5)
 #define SOC_GPIO_INPUTENABLE            (1 << SOC_GPIO_INPUTENABLE_POS)
 
+#define SOC_GPIO_HIGHZ_POS              (6)
+#define SOC_GPIO_HIGHZ                  (1 << SOC_GPIO_HIGHZ_POS)
+
 /** Type for CAT1 Soc pin. */
 typedef struct {
 	/**
@@ -96,7 +99,8 @@ typedef struct {
 		(DT_PROP(node_id, drive_open_drain) << SOC_GPIO_OPENDRAIN_POS) |   \
 		(DT_PROP(node_id, drive_open_source) << SOC_GPIO_OPENSOURCE_POS) | \
 		(DT_PROP(node_id, drive_push_pull) << SOC_GPIO_PUSHPULL_POS) |	   \
-		(DT_PROP(node_id, input_enable) << SOC_GPIO_INPUTENABLE_POS))
+		(DT_PROP(node_id, input_enable) << SOC_GPIO_INPUTENABLE_POS) | \
+		(DT_PROP(node_id, bias_high_impedance) << SOC_GPIO_HIGHZ_POS))
 
 /**
  * @brief Utility macro to initialize each pin.


### PR DESCRIPTION
- if we have input enable use CY_GPIO_DM_xxxx else CY_GPIO_DM_xxx_IN_OFF;

- added bias_high_impedance option

- Updated HIGHZ drive mode, now it sets if: 
--- we have bias_high_impedance
--- or if input_enable and no addition bias mode