### PR TITLE
cmake: remove clang++ lookup in clang/generic.cmake

### DIFF
--- a/cmake/compiler/clang/generic.cmake
+++ b/cmake/compiler/clang/generic.cmake
@@ -5,7 +5,6 @@ if(DEFINED TOOLCHAIN_HOME)
 endif()
 
 find_program(CMAKE_C_COMPILER clang ${find_program_clang_args} REQUIRED)
-find_program(CMAKE_CXX_COMPILER clang++ ${find_program_clang_args})
 find_program(CMAKE_LLVM_COV llvm-cov ${find_program_clang_args})
 set(CMAKE_GCOV "${CMAKE_LLVM_COV} gcov")
 


### PR DESCRIPTION
Fixes: #63771

The 'compiler/*/generic.cmake' is intended to set a C preprocessor which can be used for devicetree preprocessing.

No C++ compiler is needed as host tool and should therefore not be set in this file.

Remove the code to avoid setting a not required C++ compiler.

-----

for more information, please take a look here: https://github.com/zephyrproject-rtos/zephyr/pull/63412#issuecomment-1757202117