### PR TITLE
Fix USART_NUM where only 1 USART is present 

### DIFF
--- a/drivers/pinctrl/pinctrl_gecko.c
+++ b/drivers/pinctrl/pinctrl_gecko.c
@@ -15,6 +15,10 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt, uintp
 #ifdef CONFIG_SOC_GECKO_SERIES1
 	LEUART_TypeDef *lebase = (LEUART_TypeDef *)reg;
 #else
+	#ifndef USART_NUM
+	#define USART_NUM(ref)	(((ref) == USART0) ? 0 \
+			       : -1)
+	#endif
 	int usart_num = USART_NUM(base);
 #endif
 

--- a/drivers/serial/uart_gecko.c
+++ b/drivers/serial/uart_gecko.c
@@ -29,6 +29,8 @@
 #if (USART_COUNT == 1)
 #define CLOCK_USART(ref)	(((ref) == USART0) ? cmuClock_USART0 \
 			       : -1)
+#define USART_NUM(ref)	(((ref) == USART0) ? 0 \
+			       : -1)
 #elif (USART_COUNT == 2)
 #define CLOCK_USART(ref)	(((ref) == USART0) ? cmuClock_USART0 \
 			       : ((ref) == USART1) ? cmuClock_USART1 \


### PR DESCRIPTION
Handled the missing case for upcoming EFR32MG24 boards where only one USART pin is present. Currently this code is incorrectly placed inside hal_silabs device files. The device files in [https://github.com/zephyrproject-rtos/hal_silabs](url) should be similar to the one in [https://github.com/SiliconLabs/gecko_sdk](url), to avoid any future conflicts. 