### PR TITLE
edtlib: always insert root node to the graph

### DIFF
--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -2061,6 +2061,10 @@ class EDT:
         # first time the scc_order property is read.
 
         for node in self.nodes:
+            # Always insert root node
+            if not node.parent:
+                self._graph.add_node(node)
+
             # A Node always depends on its parent.
             for child in node.children.values():
                 self._graph.add_edge(child, node)

--- a/scripts/dts/python-devicetree/src/devicetree/grutils.py
+++ b/scripts/dts/python-devicetree/src/devicetree/grutils.py
@@ -26,6 +26,12 @@ class Graph:
         self.__reverse_map = collections.defaultdict(set)
         self.__nodes = set()
 
+    def add_node(self, node):
+        """
+        Add a node without any target to the graph.
+        """
+        self.__nodes.add(node)
+
     def add_edge(self, source, target):
         """
         Add a directed edge from the C{source} to the C{target}.


### PR DESCRIPTION
When we have an empty Devicetree, ie,

```
/dts-v1/;

/ {

};
```

The node's dep_ordinal is never initialized because the node graph is empty. This ends up with invalid ordinal tokens (-1) in devicetree_generated.h which in turn produce some cryptic compiler errors, see e.g.

```
error: pasting "dts_ord_" and "-" does not give a valid preprocessing
token
   95 | #define Z_DEVICE_DT_DEV_ID(node_id) _CONCAT(dts_ord_,
      DT_DEP_ORD(node_id))

...

include/zephyr/devicetree.h:2498:41:
note: in expansion of macro 'DT_FOREACH_OKAY_HELPER'
 2498 | #define DT_FOREACH_STATUS_OKAY_NODE(fn)
      DT_FOREACH_OKAY_HELPER(fn)
            |
	    ^~~~~~~~~~~~~~~~~~~~~~
include/zephyr/device.h:1022:1:
note: in expansion of macro 'DT_FOREACH_STATUS_OKAY_NODE'
     1022 |
	  DT_FOREACH_STATUS_OKAY_NODE(Z_MAYBE_DEVICE_DECLARE_INTERNAL)

```

(devicetree_generated.h)

```
...
 #define DT_N_ORD -1
 #define DT_N_ORD_STR_SORTABLE 000-1
...
```

This patch makes sure root node is always inserted (without any target)
so that it gets initialized later.

Discovered as part of
https://github.com/zephyrproject-rtos/zephyr/pull/63696

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/63808