### PR TITLE
drivers: can: only copy frame data for non-RTR frames

### DIFF
--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -219,7 +219,7 @@ static void mcp2515_convert_canframe_to_mcp2515frame(const struct can_frame
 {
 	uint8_t rtr;
 	uint8_t dlc;
-	uint8_t data_idx = 0U;
+	uint8_t data_idx;
 
 	if ((source->flags & CAN_FRAME_IDE) != 0) {
 		target[MCP2515_FRAME_OFFSET_SIDH] = source->id >> 21;
@@ -239,16 +239,18 @@ static void mcp2515_convert_canframe_to_mcp2515frame(const struct can_frame
 
 	target[MCP2515_FRAME_OFFSET_DLC] = rtr | dlc;
 
-	for (; data_idx < CAN_MAX_DLC; data_idx++) {
-		target[MCP2515_FRAME_OFFSET_D0 + data_idx] =
-			source->data[data_idx];
+	if (rtr == 0U) {
+		for (data_idx = 0U; data_idx < dlc; data_idx++) {
+			target[MCP2515_FRAME_OFFSET_D0 + data_idx] =
+				source->data[data_idx];
+		}
 	}
 }
 
 static void mcp2515_convert_mcp2515frame_to_canframe(const uint8_t *source,
 						     struct can_frame *target)
 {
-	uint8_t data_idx = 0U;
+	uint8_t data_idx;
 
 	memset(target, 0, sizeof(*target));
 
@@ -269,11 +271,11 @@ static void mcp2515_convert_mcp2515frame_to_canframe(const uint8_t *source,
 
 	if ((source[MCP2515_FRAME_OFFSET_DLC] & BIT(6)) != 0) {
 		target->flags |= CAN_FRAME_RTR;
-	}
-
-	for (; data_idx < CAN_MAX_DLC; data_idx++) {
-		target->data[data_idx] = source[MCP2515_FRAME_OFFSET_D0 +
-						data_idx];
+	} else {
+		for (data_idx = 0U; data_idx < target->dlc; data_idx++) {
+			target->data[data_idx] = source[MCP2515_FRAME_OFFSET_D0 +
+							data_idx];
+		}
 	}
 }
 

--- a/drivers/can/can_nxp_s32_canxl.c
+++ b/drivers/can/can_nxp_s32_canxl.c
@@ -728,12 +728,10 @@ static void can_nxp_s32_err_callback(const struct device *dev,
 static void nxp_s32_msg_data_to_zcan_frame(Canexcel_RxFdMsg msg_data,
 							struct can_frame *frame)
 {
+	memset(frame, 0, sizeof(*frame));
+
 	if (!!(msg_data.Header.Id & CANXL_TX_HEADER_IDE_MASK)) {
 		frame->flags |= CAN_FRAME_IDE;
-	}
-
-	if (!!(msg_data.Header.Id & CANXL_TX_HEADER_RTR_MASK)) {
-		frame->flags |= CAN_FRAME_RTR;
 	}
 
 	if (!!(frame->flags & CAN_FRAME_IDE)) {
@@ -754,7 +752,11 @@ static void nxp_s32_msg_data_to_zcan_frame(Canexcel_RxFdMsg msg_data,
 		frame->flags |= CAN_FRAME_BRS;
 	}
 
-	memcpy(frame->data, msg_data.data, can_dlc_to_bytes(frame->dlc));
+	if (!!(msg_data.Header.Id & CANXL_TX_HEADER_RTR_MASK)) {
+		frame->flags |= CAN_FRAME_RTR;
+	} else {
+		memcpy(frame->data, msg_data.data, can_dlc_to_bytes(frame->dlc));
+	}
 
 #ifdef CONFIG_CAN_RX_TIMESTAMP
 	frame->timestamp = msg_data.timeStampL;

--- a/drivers/can/can_rcar.c
+++ b/drivers/can/can_rcar.c
@@ -399,10 +399,6 @@ static void can_rcar_rx_isr(const struct device *dev)
 		frame.id = (val & RCAR_CAN_MB_SID_MASK) >> RCAR_CAN_MB_SID_SHIFT;
 	}
 
-	if (val & RCAR_CAN_MB_RTR) {
-		frame.flags |= CAN_FRAME_RTR;
-	}
-
 	frame.dlc = sys_read16(config->reg_addr +
 			       RCAR_CAN_MB_60 + RCAR_CAN_MB_DLC_OFFSET) & 0xF;
 
@@ -413,9 +409,13 @@ static void can_rcar_rx_isr(const struct device *dev)
 		frame.dlc = CAN_MAX_DLC;
 	}
 
-	for (i = 0; i < frame.dlc; i++) {
-		frame.data[i] = sys_read8(config->reg_addr +
-					  RCAR_CAN_MB_60 + RCAR_CAN_MB_DATA_OFFSET + i);
+	if (val & RCAR_CAN_MB_RTR) {
+		frame.flags |= CAN_FRAME_RTR;
+	} else {
+		for (i = 0; i < frame.dlc; i++) {
+			frame.data[i] = sys_read8(config->reg_addr +
+						  RCAR_CAN_MB_60 + RCAR_CAN_MB_DATA_OFFSET + i);
+		}
 	}
 #if defined(CONFIG_CAN_RX_TIMESTAMP)
 	/* read upper byte */
@@ -914,9 +914,11 @@ static int can_rcar_send(const struct device *dev, const struct can_frame *frame
 	sys_write16(frame->dlc, config->reg_addr
 		    + RCAR_CAN_MB_56 + RCAR_CAN_MB_DLC_OFFSET);
 
-	for (i = 0; i < frame->dlc; i++) {
-		sys_write8(frame->data[i], config->reg_addr
-			   + RCAR_CAN_MB_56 + RCAR_CAN_MB_DATA_OFFSET + i);
+	if ((frame->flags & CAN_FRAME_RTR) == 0) {
+		for (i = 0; i < frame->dlc; i++) {
+			sys_write8(frame->data[i], config->reg_addr
+				   + RCAR_CAN_MB_56 + RCAR_CAN_MB_DATA_OFFSET + i);
+		}
 	}
 
 	compiler_barrier();

--- a/drivers/can/can_sja1000.c
+++ b/drivers/can/can_sja1000.c
@@ -292,8 +292,11 @@ static void can_sja1000_read_frame(const struct device *dev, struct can_frame *f
 		frame->id |= FIELD_PREP(GENMASK(4, 0),
 				can_sja1000_read_reg(dev, CAN_SJA1000_EFF_ID4) >> 3);
 
-		for (i = 0; i < frame->dlc; i++) {
-			frame->data[i] = can_sja1000_read_reg(dev, CAN_SJA1000_EFF_DATA + i);
+		if ((frame->flags & CAN_FRAME_RTR) == 0U) {
+			for (i = 0; i < frame->dlc; i++) {
+				frame->data[i] = can_sja1000_read_reg(dev, CAN_SJA1000_EFF_DATA +
+								      i);
+			}
 		}
 	} else {
 		frame->id = FIELD_PREP(GENMASK(10, 3),
@@ -301,8 +304,11 @@ static void can_sja1000_read_frame(const struct device *dev, struct can_frame *f
 		frame->id |= FIELD_PREP(GENMASK(2, 0),
 				can_sja1000_read_reg(dev, CAN_SJA1000_XFF_ID2) >> 5);
 
-		for (i = 0; i < frame->dlc; i++) {
-			frame->data[i] = can_sja1000_read_reg(dev, CAN_SJA1000_SFF_DATA + i);
+		if ((frame->flags & CAN_FRAME_RTR) == 0U) {
+			for (i = 0; i < frame->dlc; i++) {
+				frame->data[i] = can_sja1000_read_reg(dev, CAN_SJA1000_SFF_DATA +
+								      i);
+			}
 		}
 	}
 }
@@ -334,8 +340,11 @@ void can_sja1000_write_frame(const struct device *dev, const struct can_frame *f
 		can_sja1000_write_reg(dev, CAN_SJA1000_EFF_ID4,
 				FIELD_GET(GENMASK(4, 0), frame->id) << 3);
 
-		for (i = 0; i < frame->dlc; i++) {
-			can_sja1000_write_reg(dev, CAN_SJA1000_EFF_DATA + i, frame->data[i]);
+		if ((frame->flags & CAN_FRAME_RTR) == 0U) {
+			for (i = 0; i < frame->dlc; i++) {
+				can_sja1000_write_reg(dev, CAN_SJA1000_EFF_DATA + i,
+						      frame->data[i]);
+			}
 		}
 	} else {
 		can_sja1000_write_reg(dev, CAN_SJA1000_XFF_ID1,
@@ -343,8 +352,11 @@ void can_sja1000_write_frame(const struct device *dev, const struct can_frame *f
 		can_sja1000_write_reg(dev, CAN_SJA1000_XFF_ID2,
 				FIELD_GET(GENMASK(2, 0), frame->id) << 5);
 
-		for (i = 0; i < frame->dlc; i++) {
-			can_sja1000_write_reg(dev, CAN_SJA1000_SFF_DATA + i, frame->data[i]);
+		if ((frame->flags & CAN_FRAME_RTR) == 0U) {
+			for (i = 0; i < frame->dlc; i++) {
+				can_sja1000_write_reg(dev, CAN_SJA1000_SFF_DATA + i,
+						      frame->data[i]);
+			}
 		}
 	}
 }

--- a/include/zephyr/net/socketcan_utils.h
+++ b/include/zephyr/net/socketcan_utils.h
@@ -44,7 +44,11 @@ static inline void socketcan_to_can_frame(const struct socketcan_frame *sframe,
 	zframe->flags |= (sframe->flags & CANFD_BRS) != 0 ? CAN_FRAME_BRS : 0;
 	zframe->id = sframe->can_id & BIT_MASK(29);
 	zframe->dlc = can_bytes_to_dlc(sframe->len);
-	memcpy(zframe->data, sframe->data, MIN(sizeof(sframe->data), sizeof(zframe->data)));
+
+	if ((zframe->flags & CAN_FRAME_RTR) == 0U) {
+		memcpy(zframe->data, sframe->data,
+		       MIN(sframe->len, MIN(sizeof(sframe->data), sizeof(zframe->data))));
+	}
 }
 
 /**
@@ -71,7 +75,10 @@ static inline void socketcan_from_can_frame(const struct can_frame *zframe,
 		sframe->flags |= CANFD_BRS;
 	}
 
-	memcpy(sframe->data, zframe->data, MIN(sizeof(zframe->data), sizeof(sframe->data)));
+	if ((zframe->flags & CAN_FRAME_RTR) == 0U) {
+		memcpy(sframe->data, zframe->data,
+		       MIN(sframe->len, MIN(sizeof(zframe->data), sizeof(sframe->data))));
+	}
 }
 
 /**

--- a/tests/drivers/can/api/src/common.c
+++ b/tests/drivers/can/api/src/common.c
@@ -252,5 +252,9 @@ void assert_frame_equal(const struct can_frame *frame1,
 	zassert_equal(frame1->flags, frame2->flags, "Flags do not match");
 	zassert_equal(frame1->id | id_mask, frame2->id | id_mask, "ID does not match");
 	zassert_equal(frame1->dlc, frame2->dlc, "DLC does not match");
-	zassert_mem_equal(frame1->data, frame2->data, frame1->dlc, "Received data differ");
+
+	if ((frame1->flags & CAN_FRAME_RTR) == 0U) {
+		zassert_mem_equal(frame1->data, frame2->data, can_dlc_to_bytes(frame1->dlc),
+				  "Received data differ");
+	}
 }

--- a/tests/net/socket/can/src/main.c
+++ b/tests/net/socket/can/src/main.c
@@ -23,13 +23,14 @@ ZTEST(socket_can, test_socketcan_frame_to_can_frame)
 	const uint8_t data[SOCKETCAN_MAX_DLEN] = { 0x01, 0x02, 0x03, 0x04,
 						   0x05, 0x06, 0x07, 0x08 };
 
-	sframe.can_id = BIT(31) | BIT(30) | 1234;
+	sframe.can_id = BIT(31) | 1234;
 	sframe.len = sizeof(data);
 	memcpy(sframe.data, data, sizeof(sframe.data));
 
-	expected.flags = CAN_FRAME_IDE | CAN_FRAME_RTR;
+	expected.flags = CAN_FRAME_IDE;
 	expected.id = 1234U;
-	expected.dlc = sizeof(data);
+	expected.dlc = can_bytes_to_dlc(sizeof(data));
+	memcpy(expected.data, data, sizeof(data));
 
 	socketcan_to_can_frame(&sframe, &zframe);
 
@@ -40,6 +41,17 @@ ZTEST(socket_can, test_socketcan_frame_to_can_frame)
 	zassert_equal(zframe.flags, expected.flags, "Flags not equal");
 	zassert_equal(zframe.id, expected.id, "CAN id invalid");
 	zassert_equal(zframe.dlc, expected.dlc, "Msg length invalid");
+	zassert_mem_equal(&zframe.data, &expected.data, can_dlc_to_bytes(expected.dlc),
+			  "CAN data not same");
+
+	/* Test RTR flag conversion after comparing data payload */
+	sframe.can_id |= BIT(30);
+	expected.flags |= CAN_FRAME_RTR;
+
+	socketcan_to_can_frame(&sframe, &zframe);
+
+	zassert_equal(zframe.flags, expected.flags, "Flags not equal");
+	zassert_equal(zframe.id, expected.id, "CAN id invalid");
 }
 
 /**
@@ -53,13 +65,13 @@ ZTEST(socket_can, test_can_frame_to_socketcan_frame)
 	const uint8_t data[SOCKETCAN_MAX_DLEN] = { 0x01, 0x02, 0x03, 0x04,
 						   0x05, 0x06, 0x07, 0x08 };
 
-	expected.can_id = BIT(31) | BIT(30) | 1234;
+	expected.can_id = BIT(31) | 1234;
 	expected.len = sizeof(data);
 	memcpy(expected.data, data, sizeof(expected.data));
 
-	zframe.flags = CAN_FRAME_IDE | CAN_FRAME_RTR;
+	zframe.flags = CAN_FRAME_IDE;
 	zframe.id = 1234U;
-	zframe.dlc = sizeof(data);
+	zframe.dlc = can_bytes_to_dlc(sizeof(data));
 	memcpy(zframe.data, data, sizeof(data));
 
 	socketcan_from_can_frame(&zframe, &sframe);
@@ -69,10 +81,15 @@ ZTEST(socket_can, test_can_frame_to_socketcan_frame)
 	LOG_HEXDUMP_DBG((const uint8_t *)&expected, sizeof(expected), "expected");
 
 	zassert_equal(sframe.can_id, expected.can_id, "CAN ID not same");
-	zassert_mem_equal(&sframe.data, &expected.data, sizeof(sframe.data),
-			  "CAN data not same");
-	zassert_equal(sframe.len, expected.len,
-		      "CAN msg length not same");
+	zassert_equal(sframe.len, expected.len, "CAN msg length not same");
+	zassert_mem_equal(&sframe.data, &expected.data, sizeof(sframe.data), "CAN data not same");
+
+	/* Test RTR flag conversion after comparing data payload */
+	expected.can_id |= BIT(30);
+	zframe.flags |= CAN_FRAME_RTR;
+
+	socketcan_from_can_frame(&zframe, &sframe);
+	zassert_equal(sframe.can_id, expected.can_id, "CAN ID not same");
 }
 
 /**


### PR DESCRIPTION
Only copy frame data for non-RTR frames as RTR frames do not carry any data.

Fixes: #57002