### PR TITLE
nrf53bsim: Add support for IPC & split stack builds

### DIFF
--- a/boards/posix/nrf_bsim/CMakeLists.txt
+++ b/boards/posix/nrf_bsim/CMakeLists.txt
@@ -35,6 +35,12 @@ target_sources(native_simulator INTERFACE
 	common/trace_hook.c
 )
 
+if (CONFIG_IPC_SERVICE)
+	target_sources(native_simulator INTERFACE
+		ipc_backend.c
+	)
+endif()
+
 zephyr_include_directories(
   soc
   common

--- a/boards/posix/nrf_bsim/Kconfig.defconfig
+++ b/boards/posix/nrf_bsim/Kconfig.defconfig
@@ -42,6 +42,29 @@ config BT_CTLR
 	default y if BOARD_NRF52_BSIM || BOARD_NRF5340BSIM_NRF5340_CPUNET
 	depends on BT
 
+config HEAP_MEM_POOL_SIZE
+	default 4096 if BT_RPMSG
+	default 4096 if NRF_802154_SER_HOST && BOARD_NRF5340BSIM_NRF5340_CPUAPP
+	default 4096 if NRF_802154_SER_RADIO && BOARD_NRF5340BSIM_NRF5340_CPUNET
+
+if BOARD_NRF5340BSIM_NRF5340_CPUAPP || BOARD_NRF5340BSIM_NRF5340_CPUNET
+
+config MBOX_NRFX_IPC
+	default MBOX
+
+endif # BOARD_NRF5340BSIM_NRF5340_CPUAPP || BOARD_NRF5340BSIM_NRF5340_CPUNET
+
+if BOARD_NRF5340BSIM_NRF5340_CPUAPP
+
+config IPC_SERVICE_BACKEND_RPMSG_SHMEM_RESET
+	default y if IPC_SERVICE_BACKEND_RPMSG
+
+choice BT_HCI_BUS_TYPE
+	default BT_RPMSG
+endchoice
+
+endif # BOARD_NRF5340BSIM_NRF5340_CPUAPP
+
 # The 15.4 driver Tx encryption is currently not functional with this
 # simulated board => we disable it by default. With this Openthread will normally
 # default to encrypt packets on its own.

--- a/boards/posix/nrf_bsim/common/phy_sync_ctrl.c
+++ b/boards/posix/nrf_bsim/common/phy_sync_ctrl.c
@@ -214,6 +214,13 @@ NSI_TASK(phy_sync_ctrl_register_args, PRE_BOOT_1, 10);
 
 void phy_sync_ctrl_connect_to_2G4_phy(void)
 {
+	static bool ever_run;
+
+	if (ever_run) {
+		return;
+	}
+	ever_run = true;
+
 	bs_trace_raw(9, "%s: Connecting to phy...\n", __func__);
 	hwll_connect_to_phy(bsim_args_get_2G4_device_nbr(),
 			    bsim_args_get_simid(),
@@ -223,6 +230,13 @@ void phy_sync_ctrl_connect_to_2G4_phy(void)
 
 void phy_sync_ctrl_pre_boot2(void)
 {
+	static bool ever_run;
+
+	if (ever_run) {
+		return;
+	}
+	ever_run = true;
+
 	if (((sync_args.start_offset > 0) && (sync_args.delay_init))
 		|| sync_args.sync_preinit) {
 		/* Delay the next steps until the simulation time has
@@ -235,6 +249,13 @@ void phy_sync_ctrl_pre_boot2(void)
 
 void phy_sync_ctrl_pre_boot3(void)
 {
+	static bool ever_run;
+
+	if (ever_run) {
+		return;
+	}
+	ever_run = true;
+
 	/*
 	 * If sync_preboot was set, we sync with the phy
 	 * right before booting the CPU

--- a/boards/posix/nrf_bsim/ipc_backend.c
+++ b/boards/posix/nrf_bsim/ipc_backend.c
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * This buffer is the shared memory buffer for the RPMSG IPC backed
+ * in simulation.
+ * It must be at last as large as the size defined in device tree, but as it will be compiled in
+ * the native simulator runner context we cannot refer to DT itself to size it.
+ * The default buffer for this target is defined in
+ * boards/arm/nrf5340dk_nrf5340/nrf5340_shared_sram_planning_conf.dtsi
+ */
+char IPC0_shm_buffer[65536];

--- a/boards/posix/nrf_bsim/nrf5340bsim_nrf5340_cpuapp.dts
+++ b/boards/posix/nrf_bsim/nrf5340bsim_nrf5340_cpuapp.dts
@@ -46,6 +46,7 @@
 
 	chosen {
 		zephyr,flash = &flash0;
+		zephyr,bt-hci-rpmsg-ipc = &ipc0;
 	};
 
 	soc {
@@ -78,10 +79,8 @@
 			/delete-node/ pwm@24000;
 			/delete-node/ pdm@26000;
 			/delete-node/ i2s@28000;
-			/delete-node/ mbox@2a000;
 			/delete-node/ qspi@2b000;
 			/delete-node/ nfct@2d000;
-			/delete-node/ mutex@30000;
 			/delete-node/ qdec@33000;
 			/delete-node/ qdec@34000;
 			/delete-node/ usbd@36000;
@@ -97,7 +96,6 @@
 	};
 
 	/delete-node/ cpus;
-	/delete-node/ ipc;
 	/delete-node/ sw-pwm;
 };
 
@@ -118,3 +116,8 @@
 		};
 	};
 };
+
+/* We re-use the IPC shared buffer definition from the real HW. But note the start address of the
+ * buffer won't be used.
+ */
+#include <../boards/arm/nrf5340dk_nrf5340/nrf5340_shared_sram_planning_conf.dtsi>

--- a/boards/posix/nrf_bsim/nrf5340bsim_nrf5340_cpunet.dts
+++ b/boards/posix/nrf_bsim/nrf5340bsim_nrf5340_cpunet.dts
@@ -27,6 +27,7 @@
 	};
 
 	chosen {
+		zephyr,bt-hci-rpmsg-ipc = &ipc0;
 		zephyr,ieee802154 = &ieee802154;
 		/delete-property/ zephyr,flash-controller;
 		zephyr,flash = &flash1;
@@ -37,7 +38,6 @@
 		/delete-node/ memory@21000000;
 		/delete-node/ gpiote@4100a000;
 		/delete-node/ watchdog@4100b000;
-		/delete-node/ mbox@41012000;
 		/delete-node/ i2c@41013000;
 		/delete-node/ spi@41013000;
 		/delete-node/ uart@41013000;
@@ -48,7 +48,6 @@
 	};
 
 	/delete-node/ cpus;
-	/delete-node/ ipc;
 	/delete-node/ sw-pwm;
 };
 
@@ -75,3 +74,8 @@
 		};
 	};
 };
+
+/* We re-use the IPC shared buffer definition from the real HW. But note the start address of the
+ * buffer won't be used.
+ */
+#include <../boards/arm/nrf5340dk_nrf5340/nrf5340_shared_sram_planning_conf.dtsi>

--- a/west.yml
+++ b/west.yml
@@ -294,7 +294,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: f4595802d32d103718bf50b3d390b7a450895843
+      revision: f7842d717c73aaeb0354f9e70e6d5ad275106f52
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
       revision: 42b7c577714b8f22ce82a901e19c1814af4609a8

--- a/west.yml
+++ b/west.yml
@@ -257,7 +257,7 @@ manifest:
       groups:
         - hal
     - name: libmetal
-      revision: b91611a6f47dd29fb24c46e5621e797557f80ec6
+      revision: 03140d7f4bd9ba474ebfbb6256e84a9089248e67
       path: modules/hal/libmetal
       groups:
         - hal


### PR DESCRIPTION
Add support for split stack builds in the simulated nrf5340.
This enables building and testing this configurations.

Apart from the main changes: updating the HW models to a version which includes the IPC peripheral and providing the necessary default kconfigs for these simulated boards; and allocate the share memory buffer used the IPC rpmsg backend in this target , this PR includes some ancillary changes necessary for this to work:
* An update to libmetal so it can be used with the posix architecture,
* A minor fix for the simulated board to avoid a runtime warning (due to a double connection to the phy).

Note, this PR enables this use case, but it is not too evident in the sense that it does not include any examples or so.
Those will follow in other subsecuent PRs like https://github.com/zephyrproject-rtos/zephyr/pull/64134 and more, which will enable some of the current samples for this target, convert them to sysbuild, and enable them as runtime samples in CI.

