### PR TITLE
Bluetooth: BAP: Broadcast Sink should not terminate the PA Sync

### DIFF
--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -1075,8 +1075,6 @@ int bt_bap_broadcast_sink_stop(struct bt_bap_broadcast_sink *sink)
 
 int bt_bap_broadcast_sink_delete(struct bt_bap_broadcast_sink *sink)
 {
-	int err;
-
 	CHECKIF(sink == NULL) {
 		LOG_DBG("sink is NULL");
 		return -EINVAL;
@@ -1096,17 +1094,6 @@ int bt_bap_broadcast_sink_delete(struct bt_bap_broadcast_sink *sink)
 			LOG_DBG("Sink is not stopped");
 			return -EBADMSG;
 		}
-	}
-
-	if (sink->pa_sync == NULL) {
-		LOG_DBG("Broadcast sink is already deleted");
-		return -EALREADY;
-	}
-
-	err = bt_le_per_adv_sync_delete(sink->pa_sync);
-	if (err != 0) {
-		LOG_DBG("Failed to delete periodic advertising sync (err %d)", err);
-		return err;
 	}
 
 	/* Reset the broadcast sink */


### PR DESCRIPTION
When calling bt_bap_broadcast_sink_delete, the broadcast sink should not attempt to terminate the PA Sync. The PA sync can live on without the broadcast sink, just as the broadcast sink can live on without the PA sync (which is why the PA sync check was completely removed).

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/63810