### PR TITLE
drivers: sensor: lsm6dsl: Add the 1.6Hz accelerometer rate

### DIFF
--- a/drivers/sensor/lsm6dsl/Kconfig
+++ b/drivers/sensor/lsm6dsl/Kconfig
@@ -130,7 +130,7 @@ config LSM6DSL_ACCEL_FS
 
 config LSM6DSL_ACCEL_ODR
 	int "Accelerometer Output data rate frequency"
-	range 0 10
+	range 0 11
 	default 0
 	help
 	  Specify the default accelerometer output data rate expressed in
@@ -146,6 +146,7 @@ config LSM6DSL_ACCEL_ODR
 	  8: 1666Hz
 	  9: 3332Hz
 	  10: 6664Hz
+	  11: 1.6Hz
 endmenu
 
 endif # LSM6DSL

--- a/drivers/sensor/lsm6dsl/lsm6dsl.c
+++ b/drivers/sensor/lsm6dsl/lsm6dsl.c
@@ -24,7 +24,7 @@
 LOG_MODULE_REGISTER(LSM6DSL, CONFIG_SENSOR_LOG_LEVEL);
 
 static const uint16_t lsm6dsl_odr_map[] = {0, 12, 26, 52, 104, 208, 416, 833,
-					1666, 3332, 6664};
+					1666, 3332, 6664, 1};
 
 #if defined(LSM6DSL_ACCEL_ODR_RUNTIME) || defined(LSM6DSL_GYRO_ODR_RUNTIME)
 static int lsm6dsl_freq_to_odr_val(uint16_t freq)
@@ -48,8 +48,9 @@ static int lsm6dsl_odr_to_freq_val(uint16_t odr)
 		return lsm6dsl_odr_map[odr];
 	}
 
-	/* invalid index, return last entry */
-	return lsm6dsl_odr_map[ARRAY_SIZE(lsm6dsl_odr_map) - 1];
+	/* invalid index, return the fastest entry (6.66kHz) */
+	BUILD_ASSERT(ARRAY_SIZE(lsm6dsl_odr_map) > 10);
+	return lsm6dsl_odr_map[10];
 }
 
 #ifdef LSM6DSL_ACCEL_FS_RUNTIME


### PR DESCRIPTION
Since the accelerometer's HM (high-performance mode) bit is forced to 1, the 1.6Hz frequency is available by setting the ODR to 11.

1.6Hz is a low-power mode that conserves energy and is suitable for some applications, such as determining the orientation (portrait or landscape) of a device.