### PR TITLE
doc: releases: Rename Arm to Arc

### DIFF
--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -58,14 +58,14 @@ Kernel
 Architectures
 *************
 
+* ARC
+
 * ARM
 
   * Architectural support for Arm Cortex-M has been separated from Arm
     Cortex-A and Cortex-R. This includes separate source modules to handle
     tasks like IRQ management, exception handling, thread handling and swap.
     For implementation details see :github:`60031`.
-
-* ARM
 
 * ARM64
 


### PR DESCRIPTION
Fixes a typo in the release notes where two 'Arm' entries were present, and the first should have been 'Arc'.