### PR TITLE
linker: esp32: move snippets-section within rom boundary

### DIFF
--- a/soc/riscv/espressif_esp32/esp32c3/default.ld
+++ b/soc/riscv/espressif_esp32/esp32c3/default.ld
@@ -197,6 +197,7 @@ SECTIONS
   #include <zephyr/linker/common-rom/common-rom-bt.ld>
   #include <zephyr/linker/common-rom/common-rom-debug.ld>
   #include <zephyr/linker/common-rom/common-rom-misc.ld>
+  #include <snippets-sections.ld>
 
   /* Create an explicit section at the end of all the data that shall be mapped into drom.
    * This is used to calculate the size of the _image_drom_size variable */
@@ -310,8 +311,6 @@ SECTIONS
     *(.noinit.*)
     . = ALIGN(4);
   } GROUP_LINK_IN(RAMABLE_REGION)
-
-  #include <snippets-sections.ld>
 
   .dram0.data :
   {

--- a/soc/xtensa/espressif_esp32/esp32/default.ld
+++ b/soc/xtensa/espressif_esp32/esp32/default.ld
@@ -221,6 +221,7 @@ SECTIONS
   #include <zephyr/linker/common-rom/common-rom-bt.ld>
   #include <zephyr/linker/common-rom/common-rom-debug.ld>
   #include <zephyr/linker/common-rom/common-rom-misc.ld>
+  #include <snippets-sections.ld>
 
   /* Create an explicit section at the end of all the data that shall be mapped into drom.
    * This is used to calculate the size of the _image_drom_size variable */
@@ -233,8 +234,6 @@ SECTIONS
   _image_dram_start = LOADADDR(.dram0.data);
   _image_dram_size = LOADADDR(.dram0.end) + SIZEOF(.dram0.end) - _image_dram_start;
   _image_dram_vaddr = ADDR(.dram0.data);
-
-  #include <snippets-sections.ld>
 
   .dram0.data :
   {

--- a/soc/xtensa/espressif_esp32/esp32_net/linker.ld
+++ b/soc/xtensa/espressif_esp32/esp32_net/linker.ld
@@ -212,6 +212,7 @@ SECTIONS
   #include <zephyr/linker/common-rom/common-rom-bt.ld>
   #include <zephyr/linker/common-rom/common-rom-debug.ld>
   #include <zephyr/linker/common-rom/common-rom-misc.ld>
+  #include <snippets-sections.ld>
 
   /* Create an explicit section at the end of all the data that shall be mapped into drom.
    * This is used to calculate the size of the _image_drom_size variable */
@@ -224,8 +225,6 @@ SECTIONS
   _image_dram_start = LOADADDR(.dram0.data);
   _image_dram_size = LOADADDR(.dram0.end) + SIZEOF(.dram0.end) - _image_dram_start;
   _image_dram_vaddr = ADDR(.dram0.data);
-
-  #include <snippets-sections.ld>
 
   .dram0.data :
   {

--- a/soc/xtensa/espressif_esp32/esp32s2/default.ld
+++ b/soc/xtensa/espressif_esp32/esp32s2/default.ld
@@ -192,6 +192,7 @@ SECTIONS
   #include <zephyr/linker/common-rom/common-rom-net.ld>
   #include <zephyr/linker/common-rom/common-rom-debug.ld>
   #include <zephyr/linker/common-rom/common-rom-misc.ld>
+  #include <snippets-sections.ld>
 
   /* Create an explicit section at the end of all the data that shall be mapped into drom.
    * This is used to calculate the size of the _image_drom_size variable */
@@ -362,8 +363,6 @@ SECTIONS
     *(.noinit.*)
     . = ALIGN(8);
   } GROUP_LINK_IN(RAMABLE_REGION)
-
-#include <snippets-sections.ld>
 
   .dram0.data :
   {

--- a/soc/xtensa/espressif_esp32/esp32s3/default.ld
+++ b/soc/xtensa/espressif_esp32/esp32s3/default.ld
@@ -229,6 +229,7 @@ SECTIONS
   #include <zephyr/linker/common-rom/common-rom-bt.ld>
   #include <zephyr/linker/common-rom/common-rom-debug.ld>
   #include <zephyr/linker/common-rom/common-rom-misc.ld>
+  #include <snippets-sections.ld>
 
   /* Create an explicit section at the end of all the data that shall be mapped into drom.
    * This is used to calculate the size of the _image_drom_size variable */
@@ -425,8 +426,6 @@ SECTIONS
     *(.noinit.*)
     . = ALIGN(8) ;
   } GROUP_LINK_IN(RAMABLE_REGION)
-
-#include <snippets-sections.ld>
 
   .dram0.data :
   {


### PR DESCRIPTION
This will guarantee that application snippets will be placed into ROM section properly.

Fixes #63062