### PR TITLE
doc: west: build: fix info on --pristine default

### DIFF
--- a/doc/develop/west/build-flash-debug.rst
+++ b/doc/develop/west/build-flash-debug.rst
@@ -177,8 +177,12 @@ it the value ``always``. For example, these commands are equivalent::
   west build -p -b reel_board samples/hello_world
   west build -p=always -b reel_board samples/hello_world
 
-By default, ``west build`` applies a heuristic to detect if the build directory
-needs to be made pristine. This is the same as using ``--pristine=auto``.
+By default, ``west build`` makes no attempt to detect if the build directory
+needs to be made pristine. This can lead to errors if you do something like
+try to re-use a build directory for a different ``--board``.
+
+Using ``--pristine=auto`` makes ``west build`` detect some of these situations
+and make the build directory pristine before trying the build.
 
 .. tip::
 


### PR DESCRIPTION
In commit commit c19c6fb438b98e54d38eeff4a606d6d9a3d801c8 ("Revert "scripts: west build: default build.pristine to auto""), we set the default --pristine value back to 'never', but the documentation never got updated. Fix it.