### PR TITLE
drivers/fdc2x1x: Depend on full C library, not just newlib

### DIFF
--- a/drivers/sensor/fdc2x1x/Kconfig
+++ b/drivers/sensor/fdc2x1x/Kconfig
@@ -7,7 +7,7 @@ menuconfig FDC2X1X
 	bool "FDC2X1X Capacitance-to-Digital Converter"
 	default y
 	depends on DT_HAS_TI_FDC2X1X_ENABLED
-	depends on NEWLIB_LIBC || EXTERNAL_LIBC
+	depends on FULL_LIBC_SUPPORTED || EXTERNAL_LIBC
 	select I2C
 	help
 	  Enable driver for FDC2X1X Capacitance-to-Digital Converter.


### PR DESCRIPTION
This driver uses the math library, so it cannot use the minimal C library. However, it should be fine with any complete C library, not just newlib.

This is extracted as a separate PR from #63332 as it would prevent applications from using this driver with picolibc.