### PR TITLE
mcumgr: grp: settings_mgmt: Handle settings return values

### DIFF
--- a/include/zephyr/mgmt/mcumgr/grp/settings_mgmt/settings_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/settings_mgmt/settings_mgmt.h
@@ -37,6 +37,15 @@ enum settings_mgmt_ret_code_t {
 
 	/** The provided key name does not support being read. */
 	SETTINGS_MGMT_ERR_READ_NOT_SUPPORTED,
+
+	/** The provided root key name does not exist. */
+	SETTINGS_MGMT_ERR_ROOT_KEY_NOT_FOUND,
+
+	/** The provided key name does not support being written. */
+	SETTINGS_MGMT_ERR_WRITE_NOT_SUPPORTED,
+
+	/** The provided key name does not support being deleted. */
+	SETTINGS_MGMT_ERR_DELETE_NOT_SUPPORTED,
 };
 
 #ifdef __cplusplus

--- a/subsys/mgmt/mcumgr/grp/settings_mgmt/src/settings_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/settings_mgmt/src/settings_mgmt.c
@@ -120,6 +120,8 @@ static int settings_mgmt_read(struct smp_streamer *ctxt)
 
 	if (rc < 0) {
 		if (rc == -EINVAL) {
+			rc = SETTINGS_MGMT_ERR_ROOT_KEY_NOT_FOUND;
+		} else if (rc == -ENOENT) {
 			rc = SETTINGS_MGMT_ERR_KEY_NOT_FOUND;
 		} else if (rc == -ENOTSUP) {
 			rc = SETTINGS_MGMT_ERR_READ_NOT_SUPPORTED;
@@ -231,7 +233,11 @@ static int settings_mgmt_write(struct smp_streamer *ctxt)
 
 	if (rc < 0) {
 		if (rc == -EINVAL) {
+			rc = SETTINGS_MGMT_ERR_ROOT_KEY_NOT_FOUND;
+		} else if (rc == -ENOENT) {
 			rc = SETTINGS_MGMT_ERR_KEY_NOT_FOUND;
+		} else if (rc == -ENOTSUP) {
+			rc = SETTINGS_MGMT_ERR_WRITE_NOT_SUPPORTED;
 		} else {
 			rc = SETTINGS_MGMT_ERR_UNKNOWN;
 		}
@@ -329,8 +335,12 @@ static int settings_mgmt_delete(struct smp_streamer *ctxt)
 #endif
 
 	if (rc < 0) {
-		if (rc == -ENOENT) {
+		if (rc == -EINVAL) {
+			rc = SETTINGS_MGMT_ERR_ROOT_KEY_NOT_FOUND;
+		} else if (rc == -ENOENT) {
 			rc = SETTINGS_MGMT_ERR_KEY_NOT_FOUND;
+		} else if (rc == -ENOTSUP) {
+			rc = SETTINGS_MGMT_ERR_DELETE_NOT_SUPPORTED;
 		} else {
 			rc = SETTINGS_MGMT_ERR_UNKNOWN;
 		}


### PR DESCRIPTION
Handles return values from settings handlers which were missing and would return "Unknown error" to clients instead of the read error

Fixes #63825