### PR TITLE
mcumgr: grp: fs_mgmt: Fix error on hash/checksum of empty file

### DIFF
--- a/include/zephyr/mgmt/mcumgr/grp/fs_mgmt/fs_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/fs_mgmt/fs_mgmt.h
@@ -79,6 +79,9 @@ enum fs_mgmt_err_code_t {
 
 	/** The specified mount point is that of a read-only filesystem. */
 	FS_MGMT_ERR_READ_ONLY_FILESYSTEM,
+
+	/** The operation cannot be performed because the file is empty with no contents. */
+	FS_MGMT_ERR_FILE_EMPTY,
 };
 
 #ifdef __cplusplus

--- a/subsys/mgmt/mcumgr/grp/fs_mgmt/src/fs_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/fs_mgmt/src/fs_mgmt.c
@@ -732,9 +732,12 @@ static int fs_mgmt_file_hash_checksum(struct smp_streamer *ctxt)
 	}
 
 	if (file_len <= off) {
-		/* Requested offset is larger than target file size */
+		/* Requested offset is larger than target file size or file length is 0, which
+		 * means no hash/checksum can be performed
+		 */
 		ok = smp_add_cmd_err(zse, MGMT_GROUP_ID_FS,
-				     FS_MGMT_ERR_FILE_OFFSET_LARGER_THAN_FILE);
+				     (file_len == 0 ? FS_MGMT_ERR_FILE_EMPTY :
+						      FS_MGMT_ERR_FILE_OFFSET_LARGER_THAN_FILE));
 		goto end;
 	}
 


### PR DESCRIPTION
Fixes the error code being returned when trying to perform a hash/checksum on an empty file to show it is because the file is empty, not because a paramter (which was not provided) was too large.

Fixes #63828