### PR TITLE
ITE: soc: Add the variant of it82002aw

### DIFF
--- a/soc/riscv/riscv-ite/it8xxx2/Kconfig.defconfig.it82002aw
+++ b/soc/riscv/riscv-ite/it8xxx2/Kconfig.defconfig.it82002aw
@@ -1,0 +1,12 @@
+# Copyright (c) 2023 ITE Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_IT82002_AW
+
+config SOC
+	default "it82002aw"
+
+config SOC_IT8XXX2_GPIO_GROUP_K_L_DEFAULT_PULL_DOWN
+	default y
+
+endif

--- a/soc/riscv/riscv-ite/it8xxx2/Kconfig.soc
+++ b/soc/riscv/riscv-ite/it8xxx2/Kconfig.soc
@@ -66,6 +66,10 @@ config SOC_IT82302_AX
 	bool "IT82302 AX version"
 	select SOC_IT8XXX2_REG_SET_V2
 
+config SOC_IT82002_AW
+	bool "IT82002 AW version"
+	select SOC_IT8XXX2_REG_SET_V2
+
 endchoice
 
 config SOC_IT8XXX2_PLL_FLASH_48M


### PR DESCRIPTION
This variant uses the same die as IT82202/IT82302 series and has a pinout compatible with IT513xx series packages.