### PR TITLE
doc: release: 3.5: Add note on 2 fixed MCUmgr bugs

### DIFF
--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -800,6 +800,11 @@ Libraries / Subsystems
 
   * Added STM32 SPI backend for EC Host command protocol.
 
+  * Fixed settings_mgmt returning unknown error instead of invalid key specified error.
+
+  * Fixed fs_mgmt returning parameter too large error instead of file is empty error when
+    attempting to hash/checksum a file which is empty.
+
 * File systems
 
   * Added support for ext2 file system.


### PR DESCRIPTION
Adds notes on a fixed settings_mgmt and fs_mgmt bug

DNM until https://github.com/zephyrproject-rtos/zephyr/pull/63833 and https://github.com/zephyrproject-rtos/zephyr/pull/63834 are merged