### PR TITLE
Bluetooth: Mesh: Fix Capabilities Status message with OOB upload enabled

### DIFF
--- a/subsys/bluetooth/mesh/dfd_srv.c
+++ b/subsys/bluetooth/mesh/dfd_srv.c
@@ -233,11 +233,10 @@ static int handle_capabilities_get(struct bt_mesh_model *mod, struct bt_mesh_msg
 		net_buf_simple_add_mem(&rsp, srv->oob_schemes.schemes,
 				       srv->oob_schemes.count);
 	} else
-#else
+#endif
 	{
 		net_buf_simple_add_u8(&rsp, 0);
 	}
-#endif
 
 	bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
 


### PR DESCRIPTION
The `else` case was incorrectly excluded by preprocessor.

Fixes #63846