### PR TITLE
Bluetooth: BAP: Broadcast sink: Clear pa_sync on PA terminated

### DIFF
--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -570,6 +570,16 @@ static void pa_recv(struct bt_le_per_adv_sync *sync,
 	bt_data_parse(buf, pa_decode_base, (void *)sink);
 }
 
+static void pa_term_cb(struct bt_le_per_adv_sync *sync,
+		       const struct bt_le_per_adv_sync_term_info *info)
+{
+	struct bt_bap_broadcast_sink *sink = broadcast_sink_get_by_pa(sync);
+
+	if (sink != NULL) {
+		sink->pa_sync = NULL;
+	}
+}
+
 static void update_recv_state_encryption(const struct bt_bap_broadcast_sink *sink)
 {
 	struct bt_bap_scan_delegator_mod_src_param mod_src_param = { 0 };
@@ -1114,6 +1124,7 @@ static int broadcast_sink_init(void)
 	static struct bt_le_per_adv_sync_cb cb = {
 		.recv = pa_recv,
 		.biginfo = biginfo_recv,
+		.term = pa_term_cb,
 	};
 
 	bt_le_per_adv_sync_cb_register(&cb);


### PR DESCRIPTION
If the PA gets terminated, we clear the pa_sync field of the corresponding broadcast sink object.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/63811