### PR TITLE
net: socket: mgmt: Check buf size in recvfrom()

### DIFF
--- a/subsys/net/lib/sockets/sockets_net_mgmt.c
+++ b/subsys/net/lib/sockets/sockets_net_mgmt.c
@@ -205,8 +205,12 @@ again:
 
 	if (info) {
 		ret = info_len + sizeof(hdr);
-		ret = MIN(max_len, ret);
-		memcpy(&copy_to[sizeof(hdr)], info, ret);
+		if (ret > max_len) {
+			errno = EMSGSIZE;
+			return -1;
+		}
+
+		memcpy(&copy_to[sizeof(hdr)], info, info_len);
 	} else {
 		ret = 0;
 	}


### PR DESCRIPTION
Return EMSGSIZE if trying to copy too much data into user supplied buffer.

Fixes #63835

Signed-off-by: Jukka Rissanen <jukka.rissanen@nordicsemi.no>
(cherry picked from commit 0a16d5c7c332efc13ead8babf512ec0358135eea)
(cherry picked from commit b13b4eb38a50ee02d599332eb99752e814340487)

This is a backport of #63742