### PR TITLE
Bluetooth: Mesh: Fix failing DFU/SR/FD/BV-08-C test

### DIFF
--- a/subsys/bluetooth/mesh/dfd_srv.c
+++ b/subsys/bluetooth/mesh/dfd_srv.c
@@ -413,12 +413,20 @@ static inline int set_upload_fwid(struct bt_mesh_dfd_srv *srv, struct bt_mesh_ms
 	case -EFBIG: /* Fwid too long */
 	case -EALREADY: /* Other server is in progress with this fwid */
 		bt_mesh_dfu_slot_release(srv->upload.slot);
+		srv->upload.slot = NULL;
 		upload_status_rsp(srv, ctx, BT_MESH_DFD_ERR_INTERNAL);
 		break;
 	case -EEXIST: /* Img with this fwid already is in list */
 		srv->upload.phase = BT_MESH_DFD_UPLOAD_PHASE_TRANSFER_SUCCESS;
 		bt_mesh_dfu_slot_release(srv->upload.slot);
-		upload_status_rsp_with_progress(srv, ctx, BT_MESH_DFD_SUCCESS, 100);
+
+		err = bt_mesh_dfu_slot_get(fwid, fwid_len, &srv->upload.slot);
+		if (!err) {
+			upload_status_rsp_with_progress(srv, ctx, BT_MESH_DFD_SUCCESS, 100);
+		} else {
+			srv->upload.slot = NULL;
+			upload_status_rsp(srv, ctx, BT_MESH_DFD_ERR_INTERNAL);
+		}
 		break;
 	case 0:
 		srv->upload.phase = BT_MESH_DFD_UPLOAD_PHASE_TRANSFER_ACTIVE;


### PR DESCRIPTION
The `upload_status_rsp_with_progress` function uses the currently set slot pointer to set firmware id field in the message. If another upload starts but the firmware is already received, the slot API won't let us to set the fwid and will return an error code. In this case, the slot pointer stays invalid as fwid wasn't set, and `upload_status_rsp_with_progress` will not add fwid as the lenght is zero.

Fixes #63852