### PR TITLE
libC kconfig: default to PICOLIBC for NATIVE_LIBRARY if POSIX_API or GETOPT

### DIFF
--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -53,7 +53,7 @@ menu "C Library"
 
 choice LIBC_IMPLEMENTATION
 	prompt "C Library Implementation"
-	default EXTERNAL_LIBC if NATIVE_BUILD
+	default EXTERNAL_LIBC if NATIVE_BUILD && !(NATIVE_LIBRARY && (POSIX_API || GETOPT))
 	default PICOLIBC
 	default NEWLIB_LIBC if REQUIRES_FULL_LIBC
 	default MINIMAL_LIBC


### PR DESCRIPTION
When building with the POSIX_API we cannot use the host libC.
When using GETOPT it is similarly quite difficult for users
to use the host libC.
So to make it easier for users, let's just default to PICOBLIC
in those cases,
while we continue defaulting to the host library in other cases
so users can use the Linux APIs for whatever test functionality
they want.