### PR TITLE
linker: riscv: Align .last_section

### DIFF
--- a/include/zephyr/arch/riscv/common/linker.ld
+++ b/include/zephyr/arch/riscv/common/linker.ld
@@ -396,6 +396,10 @@ SECTION_PROLOGUE(.last_section,,)
   /* Fill last section with a word to ensure location counter and actual rom
    * region data usage match. */
   LONG(CONFIG_LINKER_LAST_SECTION_ID_PATTERN)
+  /* __rom_region_size is used when configuring the PMP entry of the ROM region.
+   * Addresses (pmpaddr) in PMP registers need to be aligned to 4. Align
+   * __rom_region_size to 4 to meet that requirement. */
+  MPU_MIN_SIZE_ALIGN
 #endif
 } GROUP_LINK_IN(ROMABLE_REGION)
 


### PR DESCRIPTION
Fixes #62975.

Zephyr expects `__rom_region_size` to be aligned to 4, otherwise assertion will fail.

This commit alignes last_section which results in aligned `__rom_region_size`.