### PR TITLE
twister: Fix error for --device-testing with not runnable integration

### DIFF
--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -751,7 +751,7 @@ class TestPlan:
                         instance.add_filter("Not part of requested test plan", Filters.TESTSUITE)
 
                 if runnable and not instance.run:
-                    instance.add_filter("Not runnable on device", Filters.PLATFORM)
+                    instance.add_filter("Not runnable on device", Filters.CMD_LINE)
 
                 if self.options.integration and ts.integration_platforms and plat.name not in ts.integration_platforms:
                     instance.add_filter("Not part of integration platforms", Filters.TESTSUITE)


### PR DESCRIPTION
An urforseen error was introduce with #62713. When "--device-testing" or "--filter runnable" is used in CLI, twister will skip tests which cannot be executed (not just built) on a given platform. If a given platform is among integration platforms it will cause an error. However, it shouldn't be the case. Such skip is intentional and shouldn't be an error. Fixed by assigning an existing Filter.CMD_LINE, which is exempted from being turned to error.

fixes: #63844