### PR TITLE
MAINTAINER: SimpleLink platform should only include ti_simplelink

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2673,7 +2673,7 @@ TI SimpleLink Platforms:
     - drivers/*/*cc32*
     - dts/arm/ti/
     - dts/bindings/*/ti,*
-    - soc/arm/ti*/
+    - soc/arm/ti_simplelink/
     - dts/bindings/*/ti,*
   labels:
     - "platform: TI SimpleLink"


### PR DESCRIPTION
Do not include all TI platform in something that is supposed to include
Simplelink.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
