### PR TITLE
drivers: can: mcux: flexcan: override maximum HAL wait loop iterations

### DIFF
--- a/drivers/can/Kconfig.mcux
+++ b/drivers/can/Kconfig.mcux
@@ -21,6 +21,13 @@ config CAN_MCUX_FLEXCAN_FD
 	help
 	  Enable support for CAN-FD capable NXP FlexCAN devices.
 
+config CAN_MCUX_FLEXCAN_WAIT_TIMEOUT
+	int "Maximum number of wait loop iterations"
+	default 10000
+	help
+	  Maximum number of wait loop iterations for the MCUX FlexCAN HAL when entering/leaving
+	  freeze mode.
+
 config CAN_MAX_MB
 	int "Maximum number of message buffers for concurrent active instances"
 	default 16

--- a/modules/hal_nxp/CMakeLists.txt
+++ b/modules/hal_nxp/CMakeLists.txt
@@ -12,4 +12,7 @@ if(CONFIG_HAS_MCUX OR CONFIG_HAS_IMX_HAL OR CONFIG_HAS_NXP_S32_HAL)
   zephyr_include_directories_ifdef(CONFIG_PWM_MCUX_CTIMER
     ${ZEPHYR_CURRENT_MODULE_DIR}/mcux/mcux-sdk/drivers/ctimer/)
   zephyr_include_directories(.)
+
+  zephyr_compile_definitions_ifdef(CONFIG_CAN_MCUX_FLEXCAN
+    FLEXCAN_WAIT_TIMEOUT=${CONFIG_CAN_MCUX_FLEXCAN_WAIT_TIMEOUT})
 endif()


### PR DESCRIPTION
Add option for overriding the maximum number of wait loop iterations for entering/leaving freeze mode. Set the default to 10000 (as opposed to a default of 1000 used in the HAL).

Fixes: #56171