### PR TITLE
Bluetooth: host: Only reserve EATT header bytes for EATT enabled channels

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -267,7 +267,7 @@ static int chan_send(struct bt_att_chan *chan, struct net_buf *buf)
 		return -ENOTSUP;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_EATT) && bt_att_is_enhanced(chan)) {
+	if (bt_att_is_enhanced(chan)) {
 		/* Check if sent is pending already, if it does it cannot be
 		 * modified so the operation will need to be queued.
 		 */
@@ -737,7 +737,7 @@ static struct net_buf *bt_att_chan_create_pdu(struct bt_att_chan *chan, uint8_t 
 		}
 	}
 
-	if (IS_ENABLED(CONFIG_BT_EATT)) {
+	if (bt_att_is_enhanced(chan)) {
 		net_buf_reserve(buf, BT_L2CAP_SDU_BUF_SIZE(0));
 	}
 


### PR DESCRIPTION
Don't reserve extra EATT header bytes for non EATT enabled channels.

2 bytes of the net_buf were reserved for no reason in un-enhanced ATT channels. Effectively allowing it to carry two less bytes in unenhanced ATT.
