### PR TITLE
Minor fixes to improve compatibility between the POSIX API and native builds

### DIFF
--- a/include/zephyr/posix/posix_types.h
+++ b/include/zephyr/posix/posix_types.h
@@ -7,7 +7,7 @@
 #ifndef ZEPHYR_INCLUDE_POSIX_TYPES_H_
 #define ZEPHYR_INCLUDE_POSIX_TYPES_H_
 
-#ifndef CONFIG_ARCH_POSIX
+#if !(defined(CONFIG_ARCH_POSIX) && defined(CONFIG_EXTERNAL_LIBC))
 #include <sys/types.h>
 #endif
 

--- a/tests/posix/eventfd/src/stress.c
+++ b/tests/posix/eventfd/src/stress.c
@@ -78,6 +78,7 @@ static void th_fun(void *arg1, void *arg2, void *arg3)
 				report += report_ms;
 			}
 		}
+		Z_SPIN_DELAY(10);
 	}
 
 	printk("avg: %zu %s/s\n", (size_t)((count[id] * MSEC_PER_SEC) / end_ms), msg[id]);

--- a/tests/posix/getopt/src/main.c
+++ b/tests/posix/getopt/src/main.c
@@ -12,11 +12,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/ztest.h>
 #include <string.h>
-#ifdef CONFIG_ARCH_POSIX
-#include <unistd.h>
-#else
 #include <zephyr/posix/unistd.h>
-#endif
 #include <getopt.h>
 
 ZTEST_SUITE(getopt_test_suite, NULL, NULL, NULL, NULL, NULL);

--- a/tests/posix/pthread_pressure/src/main.c
+++ b/tests/posix/pthread_pressure/src/main.c
@@ -122,6 +122,7 @@ static void test_create_join_common(const char *tag, create_fn create, join_fn j
 
 			print_stats(now_ms, end_ms);
 		}
+		Z_SPIN_DELAY(100);
 	} while (end_ms > now_ms);
 
 	print_stats(now_ms, end_ms);


### PR DESCRIPTION
A set of minor fixes to improve compatibility between the POSIX API and native builds (most getting all POSIX API tests running on native_sim).
This is more obvious when combined with https://github.com/zephyrproject-rtos/zephyr/pull/63855

----

    POSIX API: Fix posix_types.h for native builds
    
    The inclusion of the compiler provided sys/types.h
    should depend on not using the host C library,
    and not just of building for a native target.
    
-----

    tests posix pthread_pressure: Fix for native targtets
    
    The infinite loop during the test needs to be broken
    with a small delay when built for native targets.
    Let's add it.
    Note that this delay is only added for ARCH_POSIX targets
    and not any other.
    
-----

    tests posix getopt: Minor fix for native targets
    
    This test should be compiled without host headers
    when built without the host libC, and at the same
    time, it does not support building with the host
    libC, so let's remove the condition that includes
    the host libC header to avoid extra confusion.
    
-----

    tests posix event_fd: Fix for native targets
    
    The infinite loop during the stress needs to be broken
    with a small delay when built for native targets.
    Let's add it.
    Note that this delay is only added for ARCH_POSIX targets
    and not any other.
    