### PR TITLE
tests: bsim: send SIGKILL if app doesn't respond to SIGTERM

### DIFF
--- a/tests/bsim/sh_common.source
+++ b/tests/bsim/sh_common.source
@@ -43,5 +43,5 @@ function Execute() {
   EXECUTE_TIMEOUT="${EXECUTE_TIMEOUT:-30}"
 
   check_program_exists $1
-  run_in_background timeout -v ${EXECUTE_TIMEOUT} $@
+  run_in_background timeout --kill-after=5 -v ${EXECUTE_TIMEOUT} $@
 }


### PR DESCRIPTION
I have seen the CI hang (both downstream and upstream) as the executable doesn't always respond to the SIGTERM sent by `timeout`.

This will prevent that behavior. 5 whole seconds ought to be enough to clean-up a small program.