### PR TITLE
tests: bluetooth: tester: add page number to response

### DIFF
--- a/tests/bluetooth/tester/src/btp_mesh.c
+++ b/tests/bluetooth/tester/src/btp_mesh.c
@@ -2017,8 +2017,9 @@ static uint8_t composition_data_get(const void *cmd, uint16_t cmd_len,
 		return BTP_STATUS_FAILED;
 	}
 
-	memcpy(rp->data, comp->data, comp->len);
-	*rsp_len = comp->len;
+	rp->data[0] = page;
+	memcpy(rp->data + 1, comp->data, comp->len);
+	*rsp_len = comp->len + 1;
 
 	return BTP_STATUS_SUCCESS;
 }


### PR DESCRIPTION
PTS requires IUT to send requests with page number with 0xFF or the highest supported page number in order to retrieve all the composition data pages from the lower tester.

This commit add the page number to the response, thus the upper tester can follow the last page number and send the next page request until page 0 is requested.

Corresponding AutoPTS PR: https://github.com/auto-pts/auto-pts/pull/1035