### PR TITLE
gPTP fixes and improvements

### DIFF
--- a/include/zephyr/net/net_ip.h
+++ b/include/zephyr/net/net_ip.h
@@ -423,11 +423,11 @@ enum net_priority {
 	NET_PRIORITY_BK = 1, /**< Background (lowest)                */
 	NET_PRIORITY_BE = 0, /**< Best effort (default)              */
 	NET_PRIORITY_EE = 2, /**< Excellent effort                   */
-	NET_PRIORITY_CA = 3, /**< Critical applications (highest)    */
+	NET_PRIORITY_CA = 3, /**< Critical applications              */
 	NET_PRIORITY_VI = 4, /**< Video, < 100 ms latency and jitter */
 	NET_PRIORITY_VO = 5, /**< Voice, < 10 ms latency and jitter  */
 	NET_PRIORITY_IC = 6, /**< Internetwork control               */
-	NET_PRIORITY_NC = 7  /**< Network control                    */
+	NET_PRIORITY_NC = 7  /**< Network control (highest)          */
 } __packed;
 
 #define NET_MAX_PRIORITIES 8 /* How many priority values there are */

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -219,8 +219,8 @@ config NET_TC_RX_COUNT
 config NET_TC_SKIP_FOR_HIGH_PRIO
 	bool "Push high priority packets directly to network driver"
 	help
-	  If this is set, then high priority (NET_PRIORITY_CA) net_pkt will be
-	  pushed directly to network driver and will skip the traffic class
+	  If this is set, then high priority (>= NET_PRIORITY_CA) net_pkt will
+	  be pushed directly to network driver and will skip the traffic class
 	  queues. This is currently not enabled by default.
 
 choice NET_TC_THREAD_TYPE

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -348,7 +348,7 @@ void net_if_queue_tx(struct net_if *iface, struct net_pkt *pkt)
 	 * directly to the driver.
 	 */
 	if ((IS_ENABLED(CONFIG_NET_TC_SKIP_FOR_HIGH_PRIO) &&
-	     prio == NET_PRIORITY_CA) || NET_TC_TX_COUNT == 0) {
+	     prio >= NET_PRIORITY_CA) || NET_TC_TX_COUNT == 0) {
 		net_pkt_set_tx_stats_tick(pkt, k_cycle_get_32());
 
 		net_if_tx(net_pkt_iface(pkt), pkt);

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -518,7 +518,8 @@ static struct net_buf *ethernet_fill_header(struct ethernet_context *ctx,
 	}
 
 	if (IS_ENABLED(CONFIG_NET_VLAN) &&
-	    net_eth_is_vlan_enabled(ctx, net_pkt_iface(pkt))) {
+	    net_eth_is_vlan_enabled(ctx, net_pkt_iface(pkt)) &&
+	    (IS_ENABLED(CONFIG_NET_GPTP_VLAN) || ptype != htons(NET_ETH_PTYPE_PTP))) {
 		struct net_eth_vlan_hdr *hdr_vlan;
 
 		hdr_vlan = (struct net_eth_vlan_hdr *)(hdr_frag->data);
@@ -695,7 +696,8 @@ static int ethernet_send(struct net_if *iface, struct net_pkt *pkt)
 	}
 
 	if (IS_ENABLED(CONFIG_NET_VLAN) &&
-	    net_eth_is_vlan_enabled(ctx, iface)) {
+	    net_eth_is_vlan_enabled(ctx, iface) &&
+	    (IS_ENABLED(CONFIG_NET_GPTP_VLAN) || ptype != htons(NET_ETH_PTYPE_PTP))) {
 		if (set_vlan_tag(ctx, iface, pkt) == NET_DROP) {
 			ret = -EINVAL;
 			goto error;

--- a/subsys/net/l2/ethernet/gptp/Kconfig
+++ b/subsys/net/l2/ethernet/gptp/Kconfig
@@ -117,10 +117,13 @@ config NET_GPTP_VLAN
 	select NET_MGMT_EVENT
 	select NET_MGMT_EVENT_INFO
 	help
-	  This setting allows gPTP to run over VLAN link. Currently only
-	  one port can have VLAN tag set. Note that CONFIG_NET_GPTP_VLAN_TAG
-	  setting must have a proper tag value set, otherwise the gPTP over
-	  VLAN will not work.
+	  The standard requires gPTP packets to not be VLAN-tagged (see IEEE
+	  802.1AS chapter 11.3.3).
+	  This setting is for testing purposes. It allows to deviate from the
+	  standard by running gPTP over a VLAN link. Currently only one port can
+	  have VLAN tag set. Note that CONFIG_NET_GPTP_VLAN_TAG setting must
+	  have a proper tag value set, otherwise the gPTP over VLAN will not
+	  work.
 
 config NET_GPTP_VLAN_TAG
 	int "VLAN tag to use"

--- a/subsys/net/l2/ethernet/gptp/Kconfig
+++ b/subsys/net/l2/ethernet/gptp/Kconfig
@@ -103,6 +103,13 @@ config NET_GPTP_CLOCK_ACCURACY
 	default 0x31 if NET_GPTP_CLOCK_ACCURACY_GT_10S
 	default 0xfe
 
+config NET_GPTP_STACK_SIZE
+	int "gPTP thread stack size"
+	default 2048
+	help
+	  Set the gPTP thread stack size in bytes. The gPTP thread handles the
+	  gPTP state machine. There is one gPTP thread in the system.
+
 config NET_GPTP_NUM_PORTS
 	int "Number of gPTP ports"
 	default 1

--- a/subsys/net/l2/ethernet/gptp/gptp.c
+++ b/subsys/net/l2/ethernet/gptp/gptp.c
@@ -20,8 +20,6 @@ LOG_MODULE_REGISTER(net_gptp, CONFIG_NET_GPTP_LOG_LEVEL);
 
 #include "gptp_private.h"
 
-#define NET_GPTP_STACK_SIZE 2048
-
 #if CONFIG_NET_GPTP_NUM_PORTS > 32
 /*
  * Boolean arrays sizes have been hardcoded.
@@ -31,7 +29,7 @@ LOG_MODULE_REGISTER(net_gptp, CONFIG_NET_GPTP_LOG_LEVEL);
 #error Maximum number of ports exceeded. (Max is 32).
 #endif
 
-K_KERNEL_STACK_DEFINE(gptp_stack, NET_GPTP_STACK_SIZE);
+K_KERNEL_STACK_DEFINE(gptp_stack, CONFIG_NET_GPTP_STACK_SIZE);
 K_FIFO_DEFINE(gptp_rx_queue);
 
 static k_tid_t tid;

--- a/subsys/net/l2/ethernet/gptp/gptp_messages.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_messages.c
@@ -198,7 +198,7 @@ struct net_pkt *gptp_prepare_sync(int port)
 		return NULL;
 	}
 
-	net_pkt_set_priority(pkt, NET_PRIORITY_CA);
+	net_pkt_set_priority(pkt, NET_PRIORITY_IC);
 
 	port_ds = GPTP_PORT_DS(port);
 	sync = GPTP_SYNC(pkt);
@@ -254,7 +254,7 @@ struct net_pkt *gptp_prepare_follow_up(int port, struct net_pkt *sync)
 		return NULL;
 	}
 
-	net_pkt_set_priority(pkt, NET_PRIORITY_IC);
+	net_pkt_set_priority(pkt, NET_PRIORITY_CA);
 
 	hdr = GPTP_HDR(pkt);
 	fup = GPTP_FOLLOW_UP(pkt);
@@ -318,7 +318,7 @@ struct net_pkt *gptp_prepare_pdelay_req(int port)
 		return NULL;
 	}
 
-	net_pkt_set_priority(pkt, NET_PRIORITY_CA);
+	net_pkt_set_priority(pkt, NET_PRIORITY_IC);
 
 	port_ds = GPTP_PORT_DS(port);
 	req = GPTP_PDELAY_REQ(pkt);
@@ -373,7 +373,7 @@ struct net_pkt *gptp_prepare_pdelay_resp(int port,
 		return NULL;
 	}
 
-	net_pkt_set_priority(pkt, NET_PRIORITY_CA);
+	net_pkt_set_priority(pkt, NET_PRIORITY_IC);
 
 	port_ds = GPTP_PORT_DS(port);
 
@@ -434,7 +434,7 @@ struct net_pkt *gptp_prepare_pdelay_follow_up(int port,
 		return NULL;
 	}
 
-	net_pkt_set_priority(pkt, NET_PRIORITY_IC);
+	net_pkt_set_priority(pkt, NET_PRIORITY_CA);
 
 	port_ds = GPTP_PORT_DS(port);
 
@@ -503,7 +503,7 @@ struct net_pkt *gptp_prepare_announce(int port)
 		return NULL;
 	}
 
-	net_pkt_set_priority(pkt, NET_PRIORITY_IC);
+	net_pkt_set_priority(pkt, NET_PRIORITY_CA);
 
 	hdr = GPTP_HDR(pkt);
 	ann = GPTP_ANNOUNCE(pkt);


### PR DESCRIPTION
#### Network priorities

On the TX path, the gPTP subsystem is currently using priority 3 (`NET_PRIORITY_CA`) for its higher priority network packets and priority 6 (`NET_PRIORITY_IC`) for its lower priority packets (both meant to be higher priority than normal traffic). This is wrong and the symptom is that with enough traffic classes enabled, follow-up PTP messages are getting sent before their initial message.

gPTP is almost the only system making use of the `NET_PRIORITY_*` defines. They go from 0 (lowest) to 7 (highest). But priority 3 is incorrectly marked as highest priority in the code, which may explain this inversion.
`NET_TC_SKIP_FOR_HIGH_PRIO` was another use of the priorities that looked based on the incorrect assumption that CA was the highest priority. I am trying to fix it by not changing the current level at which it starts having an effect. But this option is not tested in CI or in any of the samples and I haven't been able to test it. I don't know if it is worth modifying.

Note that the `eth_native_posix` and `eth_sam_gmac` drivers seem to also make use of those priority in the wrong order for the RX path. I don't know if should be modifying them given that I wouldn't be able to test the change.

#### VLAN

Currently, when VLAN is enabled, gPTP messages are sent with a VLAN tag, which is not allowed by the standard. Change the behavior of the Ethernet stack to fix it. This change may affect the usefulness of `CONFIG_NET_GPTP_VLAN`.
Please let me know if this requires further discussion, I can create another PR in order not to block the other changes described here.

#### Stack size Kconfig

Move a hard-coded stack size to a Kconfig for ease of use.