### PR TITLE
boards: numaker_pfm_m467: do not treat as a default test platform

### DIFF
--- a/boards/arm/numaker_pfm_m467/numaker_pfm_m467.yaml
+++ b/boards/arm/numaker_pfm_m467/numaker_pfm_m467.yaml
@@ -13,6 +13,4 @@ ram: 512
 flash: 1024
 supported:
   - gpio
-testing:
-  default: true
 vendor: nuvoton


### PR DESCRIPTION
This is not something we run in CI, so remove as a default test
platform.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
