### PR TITLE
Revert "tests: kernel: xip: exclude qemu_riscv32_xip"

### DIFF
--- a/tests/kernel/xip/testcase.yaml
+++ b/tests/kernel/xip/testcase.yaml
@@ -7,8 +7,6 @@ tests:
     integration_platforms:
       - qemu_arc_em
       - qemu_x86_xip
-    platform_exclude:
-      - qemu_riscv32_xip # See issue #62975
   arch.common.xip.minimallibc:
     filter: CONFIG_XIP and CONFIG_MINIMAL_LIBC_SUPPORTED
     tags:
@@ -17,7 +15,5 @@ tests:
     integration_platforms:
       - qemu_arc_em
       - qemu_x86_xip
-    platform_exclude:
-      - qemu_riscv32_xip # See issue #62975
     extra_configs:
       - CONFIG_MINIMAL_LIBC=y


### PR DESCRIPTION
This reverts commit 341590545ac80b7a2abd9902b7f10d577323ccde, the issue has been fixed in e1647e35c0, tested with

west build -t run -p -b qemu_riscv32_xip \
	-T tests/kernel/xip/arch.common.xip

west build -t run -p -b qemu_riscv32_xip \
	-T tests/kernel/xip/arch.common.xip.minimallibc

These were added as part of https://github.com/zephyrproject-rtos/zephyr/issues/62975