### PR TITLE
twister: runner: change log message from info to debug

### DIFF
--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -1037,7 +1037,7 @@ class ProjectBuilder(FilterBuilder):
         instance = self.instance
 
         if instance.handler.ready:
-            logger.info(f"Reset instance status from '{instance.status}' to None before run.")
+            logger.debug(f"Reset instance status from '{instance.status}' to None before run.")
             instance.status = None
 
             if instance.handler.type_str == "device":


### PR DESCRIPTION
Very verbose log message without too much context that should be a debug
message rather than a info().

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
