### PR TITLE
xtensa: add custom mem range check functions

### DIFF
--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -126,6 +126,7 @@ config XTENSA_MMU
 	default n
 	select MMU
 	select XTENSA_SMALL_VECTOR_TABLE_ENTRY
+	select KERNEL_VM_USE_CUSTOM_MEM_RANGE_CHECK if XTENSA_RPO_CACHE
 	help
 	  Enable support for Xtensa Memory Management Unit.
 

--- a/arch/xtensa/core/CMakeLists.txt
+++ b/arch/xtensa/core/CMakeLists.txt
@@ -23,6 +23,11 @@ zephyr_library_sources_ifdef(CONFIG_TIMING_FUNCTIONS timing.c)
 zephyr_library_sources_ifdef(CONFIG_GDBSTUB gdbstub.c)
 zephyr_library_sources_ifdef(CONFIG_XTENSA_MMU xtensa_mmu.c)
 
+zephyr_library_sources_ifdef(
+  CONFIG_KERNEL_VM_USE_CUSTOM_MEM_RANGE_CHECK
+  mem_manage.c
+)
+
 if("${ZEPHYR_TOOLCHAIN_VARIANT}" STREQUAL "xcc")
   zephyr_library_sources(xcc_stubs.c)
 endif()

--- a/arch/xtensa/core/mem_manage.c
+++ b/arch/xtensa/core/mem_manage.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/toolchain.h>
+#include <zephyr/arch/xtensa/arch.h>
+#include <zephyr/arch/xtensa/cache.h>
+#include <zephyr/sys/mem_manage.h>
+
+__weak bool sys_mm_is_phys_addr_in_range(uintptr_t phys)
+{
+	bool valid;
+	uintptr_t cached = (uintptr_t)arch_xtensa_cached_ptr((void *)phys);
+
+	valid = ((phys >= CONFIG_SRAM_BASE_ADDRESS) &&
+		 (phys < (CONFIG_SRAM_BASE_ADDRESS + (CONFIG_SRAM_SIZE * 1024UL))));
+
+	valid |= ((cached >= CONFIG_SRAM_BASE_ADDRESS) &&
+		  (cached < (CONFIG_SRAM_BASE_ADDRESS + (CONFIG_SRAM_SIZE * 1024UL))));
+
+	return valid;
+}
+
+__weak bool sys_mm_is_virt_addr_in_range(void *virt)
+{
+	bool valid;
+	uintptr_t addr = (uintptr_t)virt;
+
+	uintptr_t cached = (uintptr_t)arch_xtensa_cached_ptr(virt);
+
+	valid = ((addr >= CONFIG_KERNEL_VM_BASE) &&
+		 (addr < (CONFIG_KERNEL_VM_BASE + CONFIG_KERNEL_VM_SIZE)));
+
+	valid |= ((cached >= CONFIG_KERNEL_VM_BASE) &&
+		  (cached < (CONFIG_KERNEL_VM_BASE + CONFIG_KERNEL_VM_SIZE)));
+
+	return valid;
+}

--- a/kernel/Kconfig.vm
+++ b/kernel/Kconfig.vm
@@ -198,4 +198,13 @@ config DEMAND_PAGING_TIMING_HISTOGRAM_NUM_BINS
 endif # DEMAND_PAGING
 endif # MMU
 
+config KERNEL_VM_USE_CUSTOM_MEM_RANGE_CHECK
+	bool
+	help
+	  Use custom memory range check functions instead of the generic
+	  checks in z_mem_phys_addr() and z_mem_virt_addr().
+
+	  sys_mm_is_phys_addr_in_range() and
+	  sys_mm_is_virt_addr_in_range() must be implemented.
+
 endmenu # Virtual Memory Support


### PR DESCRIPTION
With the cached and uncached regions, checking valid physical and virtual memory addresses gets a bit more complicated when MMU is enabled. So add the arch-specific mechanisms to check for valid addresses and implement these on Xtensa.