### PR TITLE
drivers: ieee802154: dw1000: implement set_txpower()

### DIFF
--- a/drivers/ieee802154/Kconfig.dw1000
+++ b/drivers/ieee802154/Kconfig.dw1000
@@ -35,4 +35,17 @@ config IEEE802154_DW1000_INIT_PRIO
 	  be ready first (and sometime gpio should be the very first as spi
 	  might need it too). And of course it has to start before the net stack.
 
+config IEEE802154_DW1000_ENABLE_MANUAL_TX_POWER_CONTROL
+	bool "Manual TX Power Control"
+	help
+	  Manual TX Power control disables Smart TX Power Control and makes
+	  TX power independent of data rate and frame length. Direct control
+	  of the power to the PHR part and the rest of the transmit frame
+	  separately.
+	  Smart TX power control applies at the 6.8 Mbps data rate. When sending
+	  short data frames at this rate (and providing that the frame
+	  transmission rate is < 1 frame per millisecond) it is possible to
+	  increase the transmit power and still remain within regulatory power limits
+	  which are typically specified as average power per millisecond.
+
 endif

--- a/drivers/ieee802154/Kconfig.dw1000
+++ b/drivers/ieee802154/Kconfig.dw1000
@@ -48,4 +48,18 @@ config IEEE802154_DW1000_ENABLE_MANUAL_TX_POWER_CONTROL
 	  increase the transmit power and still remain within regulatory power limits
 	  which are typically specified as average power per millisecond.
 
+choice IEEE802154_DW1000_PRF
+	prompt "Pulse Repetion Frequency"
+	default IEEE802154_DW1000_PRF_64MHZ
+	help
+	  Specify the Pulse repetition frequency used by the driver.
+
+config IEEE802154_DW1000_PRF_16MHZ
+	bool "16 MHz"
+
+config IEEE802154_DW1000_PRF_64MHZ
+	bool "64 MHz"
+
+endchoice
+
 endif

--- a/drivers/ieee802154/ieee802154_dw1000.c
+++ b/drivers/ieee802154/ieee802154_dw1000.c
@@ -128,7 +128,11 @@ static struct dwt_context dwt_0_context = {
 	.rf_cfg = {
 		.channel = 5,
 		.dr = DWT_BR_6M8,
+#if CONFIG_IEEE802154_DW1000_PRF_64MHZ
 		.prf = DWT_PRF_64M,
+#else
+		.prf = DWT_PRF_16M,
+#endif
 
 		.rx_pac_l = DWT_PAC8,
 		.rx_shr_code = 10,
@@ -466,6 +470,7 @@ static inline void dwt_irq_handle_rx(const struct device *dev, uint32_t sys_stat
 	} else {
 		a_const = DWT_RX_SIG_PWR_A_CONST_PRF64;
 	}
+
 
 	if (rx_pacc != 0) {
 #if defined(CONFIG_NEWLIB_LIBC)

--- a/drivers/ieee802154/ieee802154_dw1000.c
+++ b/drivers/ieee802154/ieee802154_dw1000.c
@@ -1370,16 +1370,16 @@ static int dwt_configure_rf_phy(const struct device *dev)
 	if (IS_ENABLED(CONFIG_ENABLE_MANUAL_TX_POWER_CONTROL)) {
 		sys_cfg |= DWT_SYS_CFG_DIS_STXP;
 		if (rf_cfg->prf == DWT_PRF_64M) {
-			power = dwt_txpwr_stxp1_64[dwt_ch_to_cfg[chan]];
+			power = dwt_txpwr_64[dwt_ch_to_cfg[chan]];
 		} else {
-			power = dwt_txpwr_stxp1_16[dwt_ch_to_cfg[chan]];
+			power = dwt_txpwr_16[dwt_ch_to_cfg[chan]];
 		}
 	} else {
 		sys_cfg &= ~DWT_SYS_CFG_DIS_STXP;
 		if (rf_cfg->prf == DWT_PRF_64M) {
-			power = dwt_txpwr_stxp0_64[dwt_ch_to_cfg[chan]];
+			power = dwt_txpwr_64[dwt_ch_to_cfg[chan]];
 		} else {
-			power = dwt_txpwr_stxp0_16[dwt_ch_to_cfg[chan]];
+			power = dwt_txpwr_16[dwt_ch_to_cfg[chan]];
 		}
 	}
 

--- a/drivers/ieee802154/ieee802154_dw1000.c
+++ b/drivers/ieee802154/ieee802154_dw1000.c
@@ -1362,13 +1362,15 @@ static int dwt_configure_rf_phy(const struct device *dev)
 		}
 	}
 
-	if (sys_cfg & DWT_SYS_CFG_DIS_STXP) {
+	if (IS_ENABLED(CONFIG_ENABLE_MANUAL_TX_POWER_CONTROL)) {
+		sys_cfg |= DWT_SYS_CFG_DIS_STXP;
 		if (rf_cfg->prf == DWT_PRF_64M) {
 			power = dwt_txpwr_stxp1_64[dwt_ch_to_cfg[chan]];
 		} else {
 			power = dwt_txpwr_stxp1_16[dwt_ch_to_cfg[chan]];
 		}
 	} else {
+		sys_cfg &= ~DWT_SYS_CFG_DIS_STXP;
 		if (rf_cfg->prf == DWT_PRF_64M) {
 			power = dwt_txpwr_stxp0_64[dwt_ch_to_cfg[chan]];
 		} else {

--- a/drivers/ieee802154/ieee802154_dw1000_regs.h
+++ b/drivers/ieee802154/ieee802154_dw1000_regs.h
@@ -1949,7 +1949,7 @@ const uint32_t dwt_txpwr_stxp0_64[] = {
 	 0x07274767,
 	 0x2B4B6B8B,
 	 0x3A5A7A9A,
-	 0x25456585,
+	 0x25466788,
 	 0x5171B1D1
 };
 

--- a/drivers/ieee802154/ieee802154_dw1000_regs.h
+++ b/drivers/ieee802154/ieee802154_dw1000_regs.h
@@ -687,6 +687,16 @@
 /* TX Power Control */
 #define DWT_TX_POWER_ID             0x1E
 #define DWT_TX_POWER_LEN            4
+
+/* Units of TX Power Control. From User Manual 7.2.31.1 */
+#define DWT_TX_POWER_CTRL_COARSE_MASK          6
+#define DWT_TX_POWER_CTRL_COARSE_STEPS_MDB_X2  50
+#define DWT_TX_POWER_CTRL_FINE_MASK            0x1F
+#define DWT_TX_POWER_CTRL_FINE_STEPS_MDB_X2    10
+#define DWT_TX_POWER_CTRL_MAX_MDB              305
+#define DWT_TX_POWER_CTRL_MAX                  0x1F
+#define DWT_TX_POWER_CTRL_MIN                  0xC0
+
 /*
  * Mask and shift definition for Smart Transmit Power Control:
  *
@@ -726,11 +736,13 @@
  * of the PHY header (PHR) portion of the frame.
  */
 #define DWT_TX_POWER_TXPOWPHR_MASK  0x0000FF00UL
+#define DWT_TX_POWER_TXPOWPHR_SHIFT 8
 /*
  * This power setting is applied during the transmission
  * of the synchronisation header (SHR) and data portions of the frame.
  */
 #define DWT_TX_POWER_TXPOWSD_MASK   0x00FF0000UL
+#define DWT_TX_POWER_TXPOWSD_SHIFT  16
 
 /* Channel Control */
 #define DWT_CHAN_CTRL_ID            0x1F
@@ -1925,8 +1937,7 @@ const uint8_t dwt_pgdelay_defs[] = {
 	DWT_TC_PGDELAY_CH7
 };
 
-#ifdef CONFIG_ENABLE_MANUAL_TX_POWER_CONTROL
-
+#ifdef CONFIG_IEEE802154_DW1000_ENABLE_MANUAL_TX_POWER_CONTROL
 
 /*
  * Default from Table 20: Reference values Register file:
@@ -1943,6 +1954,19 @@ const uint32_t dwt_txpwr_64[] = {
 };
 
 /*
+ * Defaults decoded from Table 20 at 64 MHz to mdB
+ * For each channel: TXPOWPHR=TXPOWSD
+ */
+const uint16_t dwt_txpwr_64_mdb[] = {
+	135,
+	135,
+	105,
+	180,
+	75,
+	85,
+};
+
+/*
  * Default from Table 20: Reference values Register file:
  *     0x1E – Transmit Power Control for Manual Transmit Power Control
  *     Transmit Power Control values for 16 MHz, with DIS_STXP = 1
@@ -1956,8 +1980,20 @@ const uint32_t dwt_txpwr_16[] = {
 	0x92929292
 };
 
-#else
+/*
+ * Defaults decoded from Table 20 at 16 MHz to mdB
+ * For each channel: TXPOWPHR=TXPOWSD
+ */
+const uint16_t dwt_txpwr_16_mdb[] = {
+	180,
+	180,
+	150,
+	255,
+	140,
+	140,
+};
 
+#else
 
 /*
  * Defaults from Table 19: Reference values for Register file:
@@ -1974,6 +2010,19 @@ const uint32_t dwt_txpwr_64[] = {
 };
 
 /*
+ * Defaults decoded from Table 19 to mdB
+ * For each channel: BOOSTNORM, BOOSTP500, BOOST250, BOOST125
+ */
+const uint16_t dwt_txpwr_64_mdb[][4] = {
+	{110, 135, 160, 185},
+	{110, 135, 160, 185},
+	{105, 130, 155, 180},
+	{180, 205, 230, 255},
+	{90, 110, 130, 150},
+	{85, 110, 160, 185}
+};
+
+/*
  * Defaults from Table 19: Reference values for Register file:
  *     0x1E – Transmit Power Control for Smart Transmit Power Control
  *     Transmit Power Control values for 16 MHz, with DIS_STXP = 0
@@ -1985,6 +2034,19 @@ const uint32_t dwt_txpwr_16[] = {
 	0x1F1F3F5F,
 	0x0E082848,
 	0x32527292
+};
+
+/*
+ * Defaults decoded from Table 19 at 16 MHz to mdB
+ * For each channel: BOOSTNORM, BOOSTP500, BOOST250, BOOST125
+ */
+const uint16_t dwt_txpwr_16_mdb[][4] = {
+	{180, 205, 230, 255},
+	{180, 205, 230, 255},
+	{150, 175, 200, 225},
+	{255, 280, 305, 305},
+	{140, 165, 190, 220},
+	{140, 165, 190, 215}
 };
 
 #endif

--- a/drivers/ieee802154/ieee802154_dw1000_regs.h
+++ b/drivers/ieee802154/ieee802154_dw1000_regs.h
@@ -1925,26 +1925,46 @@ const uint8_t dwt_pgdelay_defs[] = {
 	DWT_TC_PGDELAY_CH7
 };
 
+#ifdef CONFIG_ENABLE_MANUAL_TX_POWER_CONTROL
+
+
 /*
- * Defaults from Table 19: Reference values for Register file:
- *     0x1E – Transmit Power Control for Smart Transmit Power Control
- *     Transmit Power Control values for 16 MHz, with DIS_STXP = 0
+ * Default from Table 20: Reference values Register file:
+ *     0x1E – Transmit Power Control for Manual Transmit Power Control
+ *     Transmit Power Control values for 64 MHz, with DIS_STXP = 1
  */
-const uint32_t dwt_txpwr_stxp0_16[] = {
-	0x15355575,
-	0x15355575,
-	0x0F2F4F6F,
-	0x1F1F3F5F,
-	0x0E082848,
-	0x32527292
+const uint32_t dwt_txpwr_64[] = {
+	0x67676767,
+	0x67676767,
+	0x8B8B8B8B,
+	0x9A9A9A9A,
+	0x85858585,
+	0xD1D1D1D1
 };
+
+/*
+ * Default from Table 20: Reference values Register file:
+ *     0x1E – Transmit Power Control for Manual Transmit Power Control
+ *     Transmit Power Control values for 16 MHz, with DIS_STXP = 1
+ */
+const uint32_t dwt_txpwr_16[] = {
+	0x75757575,
+	0x75757575,
+	0x6F6F6F6F,
+	0x5F5F5F5F,
+	0x48484848,
+	0x92929292
+};
+
+#else
+
 
 /*
  * Defaults from Table 19: Reference values for Register file:
  *     0x1E – Transmit Power Control for Smart Transmit Power Control
  *     Transmit Power Control values for 64 MHz, with DIS_STXP = 0
  */
-const uint32_t dwt_txpwr_stxp0_64[] = {
+const uint32_t dwt_txpwr_64[] = {
 	 0x07274767,
 	 0x07274767,
 	 0x2B4B6B8B,
@@ -1954,32 +1974,20 @@ const uint32_t dwt_txpwr_stxp0_64[] = {
 };
 
 /*
- * Default from Table 20: Reference values Register file:
- *     0x1E – Transmit Power Control for Manual Transmit Power Control
- *     Transmit Power Control values for 16 MHz, with DIS_STXP = 1
+ * Defaults from Table 19: Reference values for Register file:
+ *     0x1E – Transmit Power Control for Smart Transmit Power Control
+ *     Transmit Power Control values for 16 MHz, with DIS_STXP = 0
  */
-const uint32_t dwt_txpwr_stxp1_16[] = {
-	0x75757575,
-	0x75757575,
-	0x6F6F6F6F,
-	0x5F5F5F5F,
-	0x48484848,
-	0x92929292
+const uint32_t dwt_txpwr_16[] = {
+	0x15355575,
+	0x15355575,
+	0x0F2F4F6F,
+	0x1F1F3F5F,
+	0x0E082848,
+	0x32527292
 };
 
-/*
- * Default from Table 20: Reference values Register file:
- *     0x1E – Transmit Power Control for Manual Transmit Power Control
- *     Transmit Power Control values for 64 MHz, with DIS_STXP = 1
- */
-const uint32_t dwt_txpwr_stxp1_64[] = {
-	0x67676767,
-	0x67676767,
-	0x8B8B8B8B,
-	0x9A9A9A9A,
-	0x85858585,
-	0xD1D1D1D1
-};
+#endif
 
 enum dwt_pulse_repetition_frequency {
 	DWT_PRF_16M = 0,


### PR DESCRIPTION
Implementation for setting the transmit power on Qorvo (Decawave) DW1001

This allows the user to increase or decrease the transmit power relative to the default values which are based on a typical IC and an assumed IC to antenna loss of 1.5 dB with a 0 dBi antenna (User Manual - Chapter 7.2.31.4).

Setting TX power below max allowed by regulation allows applications to dynamically reduce range and thereby interference. Plus, as we don't support calibration yet, this can also be used to calibrate TX power level per design/board or per unit for regulatory reasons.
