### PR TITLE
posix: fdtable: ensure stdin, stdout, and stderr are initialized

### DIFF
--- a/lib/os/fdtable.c
+++ b/lib/os/fdtable.c
@@ -14,6 +14,8 @@
  */
 
 #include <errno.h>
+#include <string.h>
+
 #include <zephyr/posix/fcntl.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/fdtable.h>
@@ -41,17 +43,23 @@ static struct fd_entry fdtable[CONFIG_POSIX_MAX_FDS] = {
 	{
 		/* STDIN */
 		.vtable = &stdinout_fd_op_vtable,
-		.refcount = ATOMIC_INIT(1)
+		.refcount = ATOMIC_INIT(1),
+		.lock = Z_MUTEX_INITIALIZER(fdtable[0].lock),
+		.cond = Z_CONDVAR_INITIALIZER(fdtable[0].cond),
 	},
 	{
 		/* STDOUT */
 		.vtable = &stdinout_fd_op_vtable,
-		.refcount = ATOMIC_INIT(1)
+		.refcount = ATOMIC_INIT(1),
+		.lock = Z_MUTEX_INITIALIZER(fdtable[1].lock),
+		.cond = Z_CONDVAR_INITIALIZER(fdtable[1].cond),
 	},
 	{
 		/* STDERR */
 		.vtable = &stdinout_fd_op_vtable,
-		.refcount = ATOMIC_INIT(1)
+		.refcount = ATOMIC_INIT(1),
+		.lock = Z_MUTEX_INITIALIZER(fdtable[2].lock),
+		.cond = Z_CONDVAR_INITIALIZER(fdtable[2].cond),
 	},
 #else
 	{
@@ -123,6 +131,30 @@ static int _check_fd(int fd)
 
 	return 0;
 }
+
+#ifdef CONFIG_ZTEST
+bool fdtable_fd_is_initialized(int fd)
+{
+	struct k_mutex ref_lock;
+	struct k_condvar ref_cond;
+
+	if (fd < 0 || fd >= ARRAY_SIZE(fdtable)) {
+		return false;
+	}
+
+	ref_lock = (struct k_mutex)Z_MUTEX_INITIALIZER(fdtable[fd].lock);
+	if (memcmp(&ref_lock, &fdtable[fd].lock, sizeof(ref_lock)) != 0) {
+		return false;
+	}
+
+	ref_cond = (struct k_condvar)Z_CONDVAR_INITIALIZER(fdtable[fd].cond);
+	if (memcmp(&ref_cond, &fdtable[fd].cond, sizeof(ref_cond)) != 0) {
+		return false;
+	}
+
+	return true;
+}
+#endif /* CONFIG_ZTEST */
 
 void *z_get_fd_obj(int fd, const struct fd_op_vtable *vtable, int err)
 {

--- a/tests/posix/common/src/_main.c
+++ b/tests/posix/common/src/_main.c
@@ -4,8 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <pthread.h>
-
 #include <zephyr/ztest.h>
 
-ZTEST_SUITE(posix_apis, NULL, NULL, NULL, NULL, NULL);
+extern bool fdtable_fd_is_initialized(int fd);
+
+static void *setup(void)
+{
+	/* ensure that the the stdin, stdout, and stderr fdtable entries are initialized */
+	zassert_true(fdtable_fd_is_initialized(0));
+	zassert_true(fdtable_fd_is_initialized(1));
+	zassert_true(fdtable_fd_is_initialized(2));
+
+	return NULL;
+}
+
+ZTEST_SUITE(posix_apis, NULL, setup, NULL, NULL, NULL);


### PR DESCRIPTION
Ensure that stdin, stdout, and stderr are initialized statically.

Previously, the mutex and condition variable were uninitialized.

Fixes #63831