### PR TITLE
twister: harness: Fix several issues at Console harness

### DIFF
--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -161,12 +161,25 @@ class Robot(Harness):
 
 class Console(Harness):
 
+    def get_testcase_name(self):
+        '''
+        Get current TestCase name.
+
+        Console Harness id has only TestSuite id without TestCase name suffix.
+        Only the first TestCase name might be taken if available when a Ztest with
+        a single test case is configured to use this harness type for simplified
+        output parsing instead of the Ztest harness as Ztest suite should do.
+        '''
+        if self.instance and len(self.instance.testcases) == 1:
+            return self.instance.testcases[0].name
+        return self.id
+
     def configure(self, instance):
         super(Console, self).configure(instance)
         if self.regex is None or len(self.regex) == 0:
             self.state = "failed"
             tc = self.instance.set_case_status_by_name(
-                self.id,
+                self.get_testcase_name(),
                 "failed",
                 f"HARNESS:{self.__class__.__name__}:no regex patterns configured."
             )
@@ -182,7 +195,7 @@ class Console(Harness):
         else:
             self.state = "failed"
             tc = self.instance.set_case_status_by_name(
-                self.id,
+                self.get_testcase_name(),
                 "failed",
                 f"HARNESS:{self.__class__.__name__}:incorrect type={self.type}"
             )
@@ -260,7 +273,7 @@ class Console(Harness):
                          f" expected unordered patterns.")
             self.state = "failed"
 
-        tc = self.instance.get_case_or_create(self.id)
+        tc = self.instance.get_case_or_create(self.get_testcase_name())
         if self.state == "passed":
             tc.status = "passed"
         else:

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -174,13 +174,16 @@ class Console(Harness):
     def handle(self, line):
         if self.type == "one_line":
             if self.pattern.search(line):
-                logger.debug(f"HARNESS:{self.__class__.__name__}:EXPECTED({self.next_pattern}):'{self.pattern.pattern}'")
+                logger.debug(f"HARNESS:{self.__class__.__name__}:EXPECTED:"
+                             f"'{self.pattern.pattern}'")
                 self.next_pattern += 1
                 self.state = "passed"
         elif self.type == "multi_line" and self.ordered:
             if (self.next_pattern < len(self.patterns) and
                 self.patterns[self.next_pattern].search(line)):
-                logger.debug(f"HARNESS:{self.__class__.__name__}:EXPECTED({self.next_pattern}):'{self.patterns[self.next_pattern].pattern}'")
+                logger.debug(f"HARNESS:{self.__class__.__name__}:EXPECTED("
+                             f"{self.next_pattern + 1}/{self.patterns_expected}):"
+                             f"'{self.patterns[self.next_pattern].pattern}'")
                 self.next_pattern += 1
                 if self.next_pattern >= len(self.patterns):
                     self.state = "passed"
@@ -189,6 +192,9 @@ class Console(Harness):
                 r = self.regex[i]
                 if pattern.search(line) and not r in self.matches:
                     self.matches[r] = line
+                    logger.debug(f"HARNESS:{self.__class__.__name__}:EXPECTED("
+                                 f"{len(self.matches)}/{self.patterns_expected}):"
+                                 f"'{pattern.pattern}'")
             if len(self.matches) == len(self.regex):
                 self.state = "passed"
         else:
@@ -218,16 +224,22 @@ class Console(Harness):
                 self.recording.append(csv)
 
         self.process_test(line)
-        # Reset the resulting test state to 'failed' for 'one_line' and
-        # ordered 'multi_line' patterns when not all of these patterns were
+        # Reset the resulting test state to 'failed' when not all of the patterns were
         # found in the output, but just ztest's 'PROJECT EXECUTION SUCCESSFUL'.
         # It might happen because of the pattern sequence diverged from the
         # test code, the test platform has console issues, or even some other
         # test image was executed.
-        # TODO: Introduce explicit match policy type either to reject
-        # unexpected console output, or to allow missing patterns.
+        # TODO: Introduce explicit match policy type to reject
+        # unexpected console output, allow missing patterns, deny duplicates.
         if self.state == "passed" and self.ordered and self.next_pattern < self.patterns_expected:
-            logger.error(f"HARNESS:{self.__class__.__name__}: failed with only {self.next_pattern} matched patterns from expected {self.patterns_expected}")
+            logger.error(f"HARNESS:{self.__class__.__name__}: failed with"
+                         f" {self.next_pattern} of {self.patterns_expected}"
+                         f" expected ordered patterns.")
+            self.state = "failed"
+        if self.state == "passed" and not self.ordered and len(self.matches) < self.patterns_expected:
+            logger.error(f"HARNESS:{self.__class__.__name__}: failed with"
+                         f" {len(self.matches)} of {self.patterns_expected}"
+                         f" expected unordered patterns.")
             self.state = "failed"
 
         tc = self.instance.get_case_or_create(self.id)

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -25,7 +25,7 @@ from colorama import Fore
 from domains import Domains
 from twisterlib.cmakecache import CMakeCache
 from twisterlib.environment import canonical_zephyr_base
-from twisterlib.error import BuildError
+from twisterlib.error import BuildError, ConfigurationError
 
 import elftools
 from elftools.elf.elffile import ELFFile
@@ -1053,7 +1053,14 @@ class ProjectBuilder(FilterBuilder):
                 instance.handler.extra_test_args = self.options.extra_test_args
 
             harness = HarnessImporter.get_harness(instance.testsuite.harness.capitalize())
-            harness.configure(instance)
+            try:
+                harness.configure(instance)
+            except ConfigurationError as error:
+                instance.status = "error"
+                instance.reason = str(error)
+                logger.error(instance.reason)
+                return
+            #
             if isinstance(harness, Pytest):
                 harness.pytest_run(instance.handler.get_test_timeout())
             else:


### PR DESCRIPTION
Twister Console Harness several fixes and small improvements:

* Fix **unordered** pattern matching to treat the ztest as failed when not all of the expected patterns were found in the console output, but the ztest application itself reports 'PROJECT EXECUTION SUCCESSFUL'.
Extends #63621

* Unify debug logging on pattern match for ordered and unordered patterns.

* Check for non-empty pattern list configured for Console: If Console Harness has no regexp pattens configured, then ConfigurationError is raised, handled, and the failure of the test case correctly accounted in the summary results.

* Implement a workaround for Console harness to compose TestCase identifier correctly when Ztest suite with a single TestCase is executed (generally, Ztest suite should use Ztest harness).
Without the fix each TestCase result at Console is duplicated (and written into twister.json) with short 'identifier' set to TestSuite id only, without TestCase suffix added. The resulting entry with the full TestCase id is also stored, but its values are set empty to defaults.