### PR TITLE
Bluetooth: Mesh: Fix sending BLOB Partial Block Report Message after completing BLOB Transfer in Pull mode

### DIFF
--- a/subsys/bluetooth/host/testing.c
+++ b/subsys/bluetooth/host/testing.c
@@ -102,6 +102,7 @@ void bt_test_mesh_trans_incomp_timer_exp(void)
 	}
 }
 
+#if defined(CONFIG_BT_MESH_LOW_POWER)
 int bt_test_mesh_lpn_group_add(uint16_t group)
 {
 	bt_mesh_lpn_group_add(group);
@@ -115,6 +116,7 @@ int bt_test_mesh_lpn_group_remove(uint16_t *groups, size_t groups_count)
 
 	return 0;
 }
+#endif /* CONFIG_BT_MESH_LOW_POWER */
 
 int bt_test_mesh_rpl_clear(void)
 {

--- a/subsys/bluetooth/mesh/blob_srv.c
+++ b/subsys/bluetooth/mesh/blob_srv.c
@@ -251,6 +251,37 @@ static void resume(struct bt_mesh_blob_srv *srv)
 	reset_timer(srv);
 }
 
+static void end(struct bt_mesh_blob_srv *srv)
+{
+	phase_set(srv, BT_MESH_BLOB_XFER_PHASE_COMPLETE);
+	k_work_cancel_delayable(&srv->rx_timeout);
+	k_work_cancel_delayable(&srv->pull.report);
+	io_close(srv);
+	erase_state(srv);
+
+	if (srv->cb && srv->cb->end) {
+		srv->cb->end(srv, srv->state.xfer.id, true);
+	}
+}
+
+static bool all_blocks_received(struct bt_mesh_blob_srv *srv)
+{
+	for (int i = 0; i < ARRAY_SIZE(srv->state.blocks); ++i) {
+		if (srv->state.blocks[i]) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+static bool pull_mode_xfer_complete(struct bt_mesh_blob_srv *srv)
+{
+	return srv->state.xfer.mode == BT_MESH_BLOB_XFER_MODE_PULL &&
+	       srv->phase == BT_MESH_BLOB_XFER_PHASE_WAITING_FOR_CHUNK &&
+	       all_blocks_received(srv);
+}
+
 static void timeout(struct k_work *work)
 {
 	struct bt_mesh_blob_srv *srv =
@@ -260,6 +291,8 @@ static void timeout(struct k_work *work)
 
 	if (srv->phase == BT_MESH_BLOB_XFER_PHASE_WAITING_FOR_START) {
 		cancel(srv);
+	} else if (pull_mode_xfer_complete(srv)) {
+		end(srv);
 	} else {
 		suspend(srv);
 	}
@@ -388,6 +421,15 @@ static int handle_xfer_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ct
 	struct bt_mesh_blob_srv *srv = mod->user_data;
 
 	LOG_DBG("");
+
+	if (pull_mode_xfer_complete(srv)) {
+		/* The client requested transfer. If we are in Pull mode and all blocks were
+		 * received, we should change the Transfer state here to Complete so that the client
+		 * receives the correct state.
+		 */
+		end(srv);
+	}
+
 	xfer_status_rsp(srv, ctx, BT_MESH_BLOB_SUCCESS);
 
 	return 0;
@@ -685,7 +727,7 @@ static int handle_chunk(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 	struct bt_mesh_blob_chunk chunk;
 	size_t expected_size = 0;
 	uint16_t idx;
-	int i, err;
+	int err;
 
 	idx = net_buf_simple_pull_le16(buf);
 	chunk.size = buf->len;
@@ -745,26 +787,26 @@ static int handle_chunk(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 
 	atomic_clear_bit(srv->state.blocks, srv->block.number);
 
-	for (i = 0; i < ARRAY_SIZE(srv->state.blocks); ++i) {
-		if (!srv->state.blocks[i]) {
-			continue;
-		}
-
+	if (!all_blocks_received(srv)) {
 		phase_set(srv, BT_MESH_BLOB_XFER_PHASE_WAITING_FOR_BLOCK);
 		store_state(srv);
 		return 0;
 	}
 
-	phase_set(srv, BT_MESH_BLOB_XFER_PHASE_COMPLETE);
-	k_work_cancel_delayable(&srv->rx_timeout);
-	k_work_cancel_delayable(&srv->pull.report);
-	io_close(srv);
-	erase_state(srv);
-
-	if (srv->cb && srv->cb->end) {
-		srv->cb->end(srv, srv->state.xfer.id, true);
+	if (srv->state.xfer.mode == BT_MESH_BLOB_XFER_MODE_PULL) {
+		/* By spec (section 5.2.4), the BLOB Server stops sending BLOB Partial Block Report
+		 * messages "If the current block is the last block, then the server determines that
+		 * the client knows the transfer is complete. For example, a higher-layer model may
+		 * indicate that the client considers the transfer complete."
+		 *
+		 * We don't have any way for higher-layer model to indicate that the transfer is
+		 * complete. Therefore we need to keep sending Partial Block Report messages until
+		 * the client sends BLOB Transfer Get message or the Block Timer expires.
+		 */
+		return 0;
 	}
 
+	end(srv);
 	return 0;
 }
 

--- a/tests/bluetooth/tester/src/btp_mesh.c
+++ b/tests/bluetooth/tester/src/btp_mesh.c
@@ -4451,10 +4451,10 @@ static uint8_t blob_srv_recv(const void *cmd, uint16_t cmd_len,
 	struct model_data *model_bound;
 	int err;
 
-#if defined(CONFIG_BT_MESH_DFU_SRV)
-	struct bt_mesh_blob_srv *srv = &dfu_srv.blob;
-#elif defined(CONFIG_BT_MESH_DFD_SRV)
+#if defined(CONFIG_BT_MESH_DFD_SRV)
 	struct bt_mesh_blob_srv *srv = &dfd_srv.upload.blob;
+#elif defined(CONFIG_BT_MESH_DFU_SRV)
+	struct bt_mesh_blob_srv *srv = &dfu_srv.blob;
 #endif
 
 	model_bound = lookup_model_bound(BT_MESH_MODEL_ID_BLOB_SRV);

--- a/tests/bluetooth/tester/src/btp_mesh.c
+++ b/tests/bluetooth/tester/src/btp_mesh.c
@@ -1537,6 +1537,7 @@ static uint8_t ivu_toggle_state(const void *cmd, uint16_t cmd_len,
 	return BTP_STATUS_SUCCESS;
 }
 
+#if defined(CONFIG_BT_MESH_LOW_POWER)
 static uint8_t lpn(const void *cmd, uint16_t cmd_len,
 		   void *rsp, uint16_t *rsp_len)
 {
@@ -1568,6 +1569,7 @@ static uint8_t lpn_poll(const void *cmd, uint16_t cmd_len,
 
 	return BTP_STATUS_SUCCESS;
 }
+#endif /* CONFIG_BT_MESH_LOW_POWER */
 
 static uint8_t net_send(const void *cmd, uint16_t cmd_len,
 			void *rsp, uint16_t *rsp_len)
@@ -1749,6 +1751,7 @@ static uint8_t model_send(const void *cmd, uint16_t cmd_len,
 }
 
 #if defined(CONFIG_BT_TESTING)
+#if defined(CONFIG_BT_MESH_LOW_POWER)
 static uint8_t lpn_subscribe(const void *cmd, uint16_t cmd_len,
 			     void *rsp, uint16_t *rsp_len)
 {
@@ -1784,6 +1787,7 @@ static uint8_t lpn_unsubscribe(const void *cmd, uint16_t cmd_len,
 
 	return BTP_STATUS_SUCCESS;
 }
+#endif /* CONFIG_BT_MESH_LOW_POWER */
 
 static uint8_t rpl_clear(const void *cmd, uint16_t cmd_len,
 			 void *rsp, uint16_t *rsp_len)
@@ -4562,6 +4566,7 @@ static const struct btp_handler handlers[] = {
 		.expect_len = 0,
 		.func = ivu_toggle_state,
 	},
+#if defined(CONFIG_BT_MESH_LOW_POWER)
 	{
 		.opcode = BTP_MESH_LPN,
 		.expect_len = sizeof(struct btp_mesh_lpn_set_cmd),
@@ -4572,6 +4577,7 @@ static const struct btp_handler handlers[] = {
 		.expect_len = 0,
 		.func = lpn_poll,
 	},
+#endif /* CONFIG_BT_MESH_LOW_POWER */
 	{
 		.opcode = BTP_MESH_NET_SEND,
 		.expect_len = BTP_HANDLER_LENGTH_VARIABLE,
@@ -4883,6 +4889,7 @@ static const struct btp_handler handlers[] = {
 		.func = va_del,
 	},
 #if defined(CONFIG_BT_TESTING)
+#if defined(CONFIG_BT_MESH_LOW_POWER)
 	{
 		.opcode = BTP_MESH_LPN_SUBSCRIBE,
 		.expect_len = sizeof(struct btp_mesh_lpn_subscribe_cmd),
@@ -4893,6 +4900,7 @@ static const struct btp_handler handlers[] = {
 		.expect_len = sizeof(struct btp_mesh_lpn_unsubscribe_cmd),
 		.func = lpn_unsubscribe,
 	},
+#endif /* CONFIG_BT_MESH_LOW_POWER */
 	{
 		.opcode = BTP_MESH_RPL_CLEAR,
 		.expect_len = 0,


### PR DESCRIPTION
This PR fixes 3 issues:
- Sending BLOB Partial Block Report message after receiving all blocks in Pull mode
- Correctly selects BLOB server pointer in tester when DFD server is also enabled
- Allows to compile tester without LPN to qualify BLOB server models tests MBT/SR/BT/BV-05-C, MBT/SR/BT/BV-07-C, MBT/SR/BT/BV-08-C and MBT/SR/BT/BV-10-C without establishing a friendship