### PR TITLE
shell: fix a memory corruption coverity issue

### DIFF
--- a/subsys/shell/shell_log_backend.c
+++ b/subsys/shell/shell_log_backend.c
@@ -143,6 +143,9 @@ static bool copy_to_pbuffer(struct mpsc_pbuf_buffer *mpsc_buffer,
 	uint8_t *src_data = (uint8_t *)msg + sizeof(struct mpsc_pbuf_hdr);
 	size_t hdr_wlen = DIV_ROUND_UP(sizeof(struct mpsc_pbuf_hdr),
 					   sizeof(uint32_t));
+	if (wlen <= hdr_wlen) {
+		return false;
+	}
 
 	dst->hdr.data = msg->buf.hdr.data;
 	memcpy(dst_data, src_data, (wlen - hdr_wlen) * sizeof(uint32_t));


### PR DESCRIPTION
Added a condition to check if the size of the copied memory is a positive number.

Fixes #58700
Fixes #58703