### PR TITLE
samples: Bluetooth: Add missing reset of sems in iso_receive

### DIFF
--- a/samples/bluetooth/iso_receive/src/main.c
+++ b/samples/bluetooth/iso_receive/src/main.c
@@ -281,6 +281,16 @@ static struct bt_iso_big_sync_param big_sync_param = {
 	.sync_timeout = 100, /* in 10 ms units */
 };
 
+static void reset_semaphores(void)
+{
+	k_sem_reset(&sem_per_adv);
+	k_sem_reset(&sem_per_sync);
+	k_sem_reset(&sem_per_sync_lost);
+	k_sem_reset(&sem_per_big_info);
+	k_sem_reset(&sem_big_sync);
+	k_sem_reset(&sem_big_sync_lost);
+}
+
 int main(void)
 {
 	struct bt_le_per_adv_sync_param sync_create_param;
@@ -328,6 +338,7 @@ int main(void)
 	printk("Success.\n");
 
 	do {
+		reset_semaphores();
 		per_adv_lost = false;
 
 		printk("Start scanning...");


### PR DESCRIPTION
In the iso_receive sample, the semaphores were not reset in each iteration.

This caused the ISO receiver to act incorrectly and cause issues with some controllers.