### PR TITLE
cmake: Add support for sysbuild-set signing script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1818,16 +1818,21 @@ if(NOT CMAKE_C_COMPILER_ID STREQUAL "ARMClang")
   )
 endif()
 
-# Generate and use MCUboot related artifacts as needed.
-if(CONFIG_BOOTLOADER_MCUBOOT)
+# Generate signed (MCUboot or other) related artifacts as needed. Priority is:
+# * Sysbuild (if set)
+# * SIGNING_SCRIPT target property (if set)
+# * MCUboot signing script (if MCUboot is enabled)
+zephyr_get(signing_script VAR SIGNING_SCRIPT SYSBUILD)
+
+if(NOT signing_script)
   get_target_property(signing_script zephyr_property_target SIGNING_SCRIPT)
-  if(NOT signing_script)
-    set_target_properties(zephyr_property_target PROPERTIES SIGNING_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/cmake/mcuboot.cmake)
+
+  if(NOT signing_script AND CONFIG_BOOTLOADER_MCUBOOT)
+    set(signing_script ${CMAKE_CURRENT_LIST_DIR}/cmake/mcuboot.cmake)
   endif()
 endif()
 
 # Include signing script, if set
-get_target_property(signing_script zephyr_property_target SIGNING_SCRIPT)
 if(signing_script)
   message(STATUS "Including signing script: ${signing_script}")
 

--- a/doc/develop/west/sign.rst
+++ b/doc/develop/west/sign.rst
@@ -100,8 +100,23 @@ The signing script used when running ``west flash`` can be extended or replaced
 to change features or introduce different signing mechanisms. By default with
 MCUboot enabled, signing is setup by the :file:`cmake/mcuboot.cmake` file in
 Zephyr which adds extra post build commands for generating the signed images.
-The file used for signing can be replaced by adjusting the ``SIGNING_SCRIPT``
-property on the `zephyr_property_target`, ideally done by a module using:
+The file used for signing can be replaced from a sysbuild scope (if being used)
+or from a zephyr/zephyr module scope, the priority of which is:
+
+* Sysbuild
+* Zephyr property
+* Default MCUboot script (if enabled)
+
+From sysbuild, ``-D<target>_SIGNING_SCRIPT`` can be used to set a signing script
+for a specific image or ``-DSIGNING_SCRIPT`` can be used to set a signing script
+for all images, for example:
+
+.. code-block:: console
+
+   west build -b <board> <application> -DSIGNING_SCRIPT=<file>
+
+The zephyr property method is achieved by adjusting the ``SIGNING_SCRIPT`` property
+on the `zephyr_property_target`, ideally from by a module by using:
 
 .. code-block:: cmake
 

--- a/doc/releases/release-notes-3.6.rst
+++ b/doc/releases/release-notes-3.6.rst
@@ -172,6 +172,9 @@ Build system and infrastructure
   After this change users may need to define them for their own applications or libraries if they
   require them.
 
+* Added support for sysbuild setting a signing script (``SIGNING_SCRIPT``), see
+  :ref:`west-extending-signing` for details.
+
 Drivers and Sensors
 *******************
 


### PR DESCRIPTION
Allows a sysbuild project to specify a signing script file to use instead of the default zephyr one