### PR TITLE
clang: target: Include gcc-m-fpu.cmake file

### DIFF
--- a/cmake/compiler/clang/target.cmake
+++ b/cmake/compiler/clang/target.cmake
@@ -20,6 +20,7 @@ find_program(CMAKE_CXX_COMPILER clang++ ${find_program_clang_args})
 
 if(NOT "${ARCH}" STREQUAL "posix")
   include(${ZEPHYR_BASE}/cmake/gcc-m-cpu.cmake)
+  include(${ZEPHYR_BASE}/cmake/gcc-m-fpu.cmake)
 
   if("${ARCH}" STREQUAL "arm")
     list(APPEND TOOLCHAIN_C_FLAGS


### PR DESCRIPTION
File gcc-m-fpu.cmake is responsible for determining what should be passed to -mfpu option. Fortunately GCC and Clang options are compatible so we can use the file for clang.

The list of supported -mfpu options can be found at https://github.com/llvm/llvm-project in
llvm/include/llvm/TargetParser/ARMTargetParser.def file.