### PR TITLE
boards: riscv: longan_nano: add adc support

### DIFF
--- a/boards/riscv/longan_nano/doc/index.rst
+++ b/boards/riscv/longan_nano/doc/index.rst
@@ -71,6 +71,9 @@ The board configuration supports the following hardware features:
    * - DAC
      - :kconfig:option:`CONFIG_DAC`
      - :dtcompatible:`gd,gd32-dac`
+   * - ADC
+     - :kconfig:option:`CONFIG_ADC`
+     - :dtcompatible:`gd,gd32-adc`
 
 Serial Port
 ===========

--- a/boards/riscv/longan_nano/longan_nano-common.dtsi
+++ b/boards/riscv/longan_nano/longan_nano-common.dtsi
@@ -165,6 +165,12 @@
 	};
 };
 
+&adc0 {
+	status = "okay";
+	pinctrl-0 = <&adc0_default>;
+	pinctrl-names = "default";
+};
+
 &fwdgt {
 	status = "okay";
 };

--- a/boards/riscv/longan_nano/longan_nano-pinctrl.dtsi
+++ b/boards/riscv/longan_nano/longan_nano-pinctrl.dtsi
@@ -37,4 +37,11 @@
 				 <SPI1_MOSI_PB15_OUT>, <SPI1_NSS_PB12_OUT>;
 		};
 	};
+
+	adc0_default: adc0_default {
+		group1 {
+			pinmux = <ADC01_IN0_PA0>;
+		};
+	};
+
 };

--- a/samples/drivers/adc/boards/longan_nano.overlay
+++ b/samples/drivers/adc/boards/longan_nano.overlay
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		/* adjust channel number according to pinmux in board.dts */
+		io-channels = <&adc0 0>;
+	};
+};
+
+&adc0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+};

--- a/samples/drivers/adc/boards/longan_nano_lite.overlay
+++ b/samples/drivers/adc/boards/longan_nano_lite.overlay
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		/* adjust channel number according to pinmux in board.dts */
+		io-channels = <&adc0 0>;
+	};
+};
+
+&adc0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+};

--- a/samples/drivers/adc/sample.yaml
+++ b/samples/drivers/adc/sample.yaml
@@ -26,6 +26,8 @@ tests:
       - gd32l233r_eval
       - lpcxpresso55s36
       - mr_canhubk3
+      - longan_nano
+      - longan_nano_lite
     integration_platforms:
       - nucleo_l073rz
       - nrf52840dk_nrf52840


### PR DESCRIPTION
Add ADC support for longan nano.

Tested using samples/drivers/adc