### PR TITLE
sam: mdio: Fix Transfer Timeout at Initialization

### DIFF
--- a/dts/arm/atmel/sam4e.dtsi
+++ b/dts/arm/atmel/sam4e.dtsi
@@ -171,6 +171,7 @@
 		mdio: mdio@40034000 {
 			compatible = "atmel,sam-mdio";
 			reg = <0x40034000 0x4000>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 44>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -333,6 +333,7 @@
 		mdio: mdio@40050000 {
 			compatible = "atmel,sam-mdio";
 			reg = <0x40050000 0x4000>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 39>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/bindings/mdio/atmel,sam-mdio.yaml
+++ b/dts/bindings/mdio/atmel,sam-mdio.yaml
@@ -8,3 +8,7 @@ compatible: "atmel,sam-mdio"
 include:
   - name: mdio-controller.yaml
   - name: pinctrl-device.yaml
+
+properties:
+  clocks:
+    type: phandle-array


### PR DESCRIPTION
Initialize the MDIO peripheral clock (normally done during GMAC initialization) before trying any MDIO transfers, preventing startup errors.

Fixes issue #63899.