### PR TITLE
drivers: dma: dma_intel_lpss: Enhance LPSS DMA to support I2C and UART

### DIFF
--- a/drivers/dma/dma_dw_common.c
+++ b/drivers/dma/dma_dw_common.c
@@ -434,7 +434,7 @@ bool dw_dma_is_enabled(const struct device *dev, uint32_t channel)
 {
 	const struct dw_dma_dev_cfg *const dev_cfg = dev->config;
 
-	return dw_read(dev_cfg->base, DW_DMA_CHAN_EN) & DW_CHAN_MASK(channel);
+	return dw_read(dev_cfg->base, DW_DMA_CHAN_EN) & DW_CHAN(channel);
 }
 
 int dw_dma_start(const struct device *dev, uint32_t channel)

--- a/include/zephyr/drivers/dma/dma_intel_lpss.h
+++ b/include/zephyr/drivers/dma/dma_intel_lpss.h
@@ -7,7 +7,6 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_DMA_INTEL_LPSS_H_
 #define ZEPHYR_INCLUDE_DRIVERS_DMA_INTEL_LPSS_H_
 
-#define DMA_INTEL_LPSS_INIT_PRIORITY	80
 #define DMA_INTEL_LPSS_OFFSET		0x800
 #define DMA_INTEL_LPSS_REMAP_LOW	0x240
 #define DMA_INTEL_LPSS_REMAP_HI		0x244
@@ -16,5 +15,7 @@
 #define DMA_INTEL_LPSS_ADDR_RIGHT_SHIFT	32
 
 void dma_intel_lpss_isr(const struct device *dev);
+int dma_intel_lpss_setup(const struct device *dev);
+void dma_intel_lpss_set_base(const struct device *dev, uintptr_t base);
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_DMA_INTEL_LPSS_H_ */


### PR DESCRIPTION
Updated drivers init priority to vary based on the dependency of the parent, I2C's dma depends on I2Cs init to get base and UART depends on UART's DMA to initiate async operations.
Enabled dma_get_status and dma_reload features.
Corrected dw_dma_is_enabled functions comparison value from DMA_CHAN_MASK to DMA_CHAN. 

Signed-off-by: Anisetti Avinash Krishna <anisetti.avinash.krishna@intel.com>