### PR TITLE
fs: nvs: Note about nvs_write with len equal to 0.

### DIFF
--- a/include/zephyr/fs/nvs.h
+++ b/include/zephyr/fs/nvs.h
@@ -94,6 +94,11 @@ int nvs_clear(struct nvs_fs *fs);
 /**
  * @brief Write an entry to the file system.
  *
+ * @note  When @p len parameter is equal to @p 0 then entry is effectively removed (it is
+ * equivalent to calling of nvs_delete). Any calls to nvs_read for entries with data of length
+ * @p 0 will return error.@n It is not possible to distinguish between deleted entry and entry
+ * with data of length 0.
+ *
  * @param fs Pointer to file system
  * @param id Id of the entry to be written
  * @param data Pointer to the data to be written


### PR DESCRIPTION
Add a note to explain what happens when entry with 0 data length is written to NVS storage.

Signed-off-by: Artur Lipowski <artur.lipowski@hidglobal.com>