### PR TITLE
doc: Add ability to generate single HTML file output

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -141,7 +141,7 @@ add_doc_target(
   html
   COMMAND ${CMAKE_COMMAND} -E env ${SPHINX_ENV}
   ${SPHINXBUILD}
-    -b html
+    -b singlehtml
     -c ${DOCS_CFG_DIR}
     -d ${DOCS_DOCTREE_DIR}
     -w ${DOCS_BUILD_DIR}/html.log

--- a/doc/_extensions/zephyr/vcs_link.py
+++ b/doc/_extensions/zephyr/vcs_link.py
@@ -67,7 +67,7 @@ def vcs_link_get_url(app: Sphinx, pagename: str) -> Optional[str]:
 
 
 def add_jinja_filter(app: Sphinx):
-    if app.builder.name != "html":
+    if app.builder.format != "html":
         return
 
     app.builder.templates.environment.filters["vcs_link_get_url"] = partial(


### PR DESCRIPTION
Implemented by hijacking the existing html target for now, but would eventually become its own target.
Not quite sure what we'd want to do with Kconfig options and DTS bindings, but I would assume linking to the existing Kconfig and dts index page initially would be a valid option.

As the page is pretty heavy, it's likely that should we want to move forward with this, adding lazy loading to image resources would be required, along other tweaks to help not kill people's browsers.