### PR TITLE
Logging: improve help message of LOG_PRINTK Kconfig option

### DIFF
--- a/subsys/logging/Kconfig.processing
+++ b/subsys/logging/Kconfig.processing
@@ -9,7 +9,8 @@ config LOG_PRINTK
 	bool "Process printk messages"
 	default y if PRINTK && (!ZTEST || ZTEST_NEW_API)
 	help
-	  LOG_PRINTK messages are formatted in place and logged unconditionally.
+	  If enabled, printk messages are redirected to the logging subsystem.
+	  The messages are formatted in place and logged unconditionally.
 
 if LOG_MODE_DEFERRED && !LOG_FRONTEND_ONLY
 


### PR DESCRIPTION
Improve it so that:
- it mentions the important fact that it redirects `printk` messages to the logging subsystem
- it is consistent with the help messages of the other options in this file (i.e. it starts with "If enabled")