### PR TITLE
kernel: Add mutex wrapper for single thread app

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -2898,6 +2898,7 @@ extern struct k_work_q k_sys_work_q;
  * @ingroup mutex_apis
  */
 struct k_mutex {
+#ifdef CONFIG_MULTITHREADING
 	/** Mutex wait queue */
 	_wait_q_t wait_q;
 	/** Mutex owner */
@@ -2908,6 +2909,7 @@ struct k_mutex {
 
 	/** Original thread priority */
 	int owner_orig_prio;
+#endif /* CONFIG_MULTITHREADING */
 
 	SYS_PORT_TRACING_TRACKING_FIELD(k_mutex)
 
@@ -2920,12 +2922,12 @@ struct k_mutex {
  * @cond INTERNAL_HIDDEN
  */
 #define Z_MUTEX_INITIALIZER(obj) \
-	{ \
+	{IF_ENABLED(CONFIG_MULTITHREADING, ( \
 	.wait_q = Z_WAIT_Q_INIT(&obj.wait_q), \
 	.owner = NULL, \
 	.lock_count = 0, \
 	.owner_orig_prio = K_LOWEST_APPLICATION_THREAD_PRIO, \
-	}
+	))}
 
 /**
  * INTERNAL_HIDDEN @endcond

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -57,6 +57,7 @@ list(APPEND kernel_files
   init.c
   kheap.c
   mem_slab.c
+  mutex.c
   thread.c
   version.c
   sched.c
@@ -67,7 +68,6 @@ list(APPEND kernel_files
   idle.c
   mailbox.c
   msg_q.c
-  mutex.c
   queue.c
   sem.c
   stack.c


### PR DESCRIPTION
There are subsystems in Zephyr that require synchronization primitives because the default behavior of Zephyr is to build multi-thread applications. This add very small change in the kernel related to mutexes that affects only single thread build. ~It add a new file only to wrap the API.~ The change define the k_mutex as an empty struct and the lock/unlock functions are bypassed. This allows few subsystem be used in single thread application without touch the subsystem code.

The change keeps Zephyr flexible and help to stay with very low code and sram profile for the very constrained applications that still require some functionality like Non-Volatile Storage.

With this change is still possible to build a single thread application that uses:
* serial
* timers
* flash driver and layout
* Non-Volatile Storage NVS
* pinctrl
* clocks
* ring buffers

Prove of Concept:
* Microcontroller: STM32L010X4
* Main thread: 512 bytes
* Transmission buffers: 2 x 128 bytes
* Serial protocol for communication

```
Memory region         Used Size  Region Size  %age Used
           FLASH:       14060 B        15 KB     91.53%
             RAM:        1480 B         2 KB     72.27%
```

The proposal start to make sense when the solution is compared with the **samples/subsys/nvs** in their default configuration using a define from the same family:

```
west build -b b_l072z_lrwan1 samples/subsys/nvs

Memory region         Used Size  Region Size  %age Used
           FLASH:       27392 B       192 KB     13.93%
             RAM:        4216 B        20 KB     20.59%
```