### PR TITLE
Mcp2518fd driver - Fix filtering RTR CAN frames

### DIFF
--- a/drivers/can/Kconfig.mcp251xfd
+++ b/drivers/can/Kconfig.mcp251xfd
@@ -54,7 +54,7 @@ config CAN_MCP251XFD_READ_CRC_RETRIES
 config CAN_MAX_FILTER
 	int "Maximum number of concurrent active filters"
 	default 5
-	range 1 31
+	range 1 32
 	help
 	  Maximum number of filters supported by the can_add_rx_callback() API call.
 

--- a/drivers/can/can_mcp251xfd.h
+++ b/drivers/can/can_mcp251xfd.h
@@ -496,7 +496,7 @@ struct mcp251xfd_data {
 	struct mcp251xfd_mailbox mailbox[CONFIG_CAN_MCP251XFD_MAX_TX_QUEUE];
 
 	/* Filter Data */
-	uint64_t filter_usage;
+	uint32_t filter_usage;
 	struct can_filter filter[CONFIG_CAN_MAX_FILTER];
 	can_rx_callback_t rx_cb[CONFIG_CAN_MAX_FILTER];
 	void *cb_arg[CONFIG_CAN_MAX_FILTER];


### PR DESCRIPTION
The mcp251xfd doesn't apply hardware filtering on the RTR flag. The frame is written to the fifo regardless of the flag. Thus we need to explicitly check that the frame matches the stored filter before notifying the user. Also if the frame doesn't match, we need check whether another stored filter matches the frame.

After this change, tests receive_ext_id_rtr and receice_std_id_rtr
are no longer skipped and successfully pass in tests/drivers/can/api.
