### PR TITLE
Test native libc too

### DIFF
--- a/tests/lib/c_lib/src/main.c
+++ b/tests/lib/c_lib/src/main.c
@@ -1206,11 +1206,15 @@ ZTEST(test_c_lib, test_rand_reproducibility)
  */
 ZTEST(test_c_lib, test_abort)
 {
+#ifdef CONFIG_EXTERNAL_LIBC
+	ztest_test_skip();
+#else
 	int a = 0;
 
 	ztest_set_fault_valid(true);
 	abort();
 	zassert_equal(a, 0, "abort failed");
+#endif
 }
 
 /**

--- a/tests/lib/c_lib/src/main.c
+++ b/tests/lib/c_lib/src/main.c
@@ -157,6 +157,20 @@ ZTEST(test_c_lib, test_stdint)
 #endif
 }
 
+/**
+ *
+ * @brief Test time_t to make sure it is at least 64 bits
+ *
+ */
+ZTEST(test_c_lib, test_time_t)
+{
+#ifdef CONFIG_EXTERNAL_LIBC
+	ztest_test_skip();
+#else
+	zassert_true(sizeof(time_t) >= sizeof(uint64_t));
+#endif
+}
+
 /*
  * variables used during string library testing
  */

--- a/tests/lib/c_lib/src/main.c
+++ b/tests/lib/c_lib/src/main.c
@@ -1067,7 +1067,7 @@ ZTEST(test_c_lib, test_time)
 {
 	time_t tests1 = 0;
 	time_t tests2 = -5;
-	time_t tests3 = -214748364800;
+	time_t tests3 = (time_t) -214748364800;
 	time_t tests4 = 951868800;
 
 	struct tm tp;

--- a/tests/lib/c_lib/src/test_strerror.c
+++ b/tests/lib/c_lib/src/test_strerror.c
@@ -32,6 +32,7 @@ ZTEST(test_c_lib, test_strerror)
 	/* do not change errno on success */
 	zassert_equal(4242, errno, "");
 
+#ifndef CONFIG_EXTERNAL_LIBC
 	/* consistent behaviour w.r.t. errno with invalid input */
 	errno = 0;
 	expected = "";
@@ -43,6 +44,7 @@ ZTEST(test_c_lib, test_strerror)
 		      expected, actual);
 	/* do not change errno on failure (for consistence) */
 	zassert_equal(0, errno, "");
+#endif
 
 	/* consistent behaviour for "Success" */
 	if (!IS_ENABLED(CONFIG_MINIMAL_LIBC_DISABLE_STRING_ERROR_TABLE)) {

--- a/tests/lib/c_lib/testcase.yaml
+++ b/tests/lib/c_lib/testcase.yaml
@@ -1,13 +1,11 @@
 common:
   tags:
     - clib
-  filter: not CONFIG_NATIVE_APPLICATION
   integration_platforms:
     - mps2_an385
 tests:
   libraries.libc:
     ignore_faults: true
-    filter: not (CONFIG_ARCH_POSIX and CONFIG_EXTERNAL_LIBC)
   libraries.libc.picolibc:
     filter: CONFIG_PICOLIBC_SUPPORTED
     tags: picolibc
@@ -29,11 +27,13 @@ tests:
       - CONFIG_NEWLIB_LIBC=y
       - CONFIG_NEWLIB_LIBC_NANO=y
   libraries.libc.minimal.strerror_table:
+    filter: CONFIG_MINIMAL_LIBC_SUPPORTED
     tags: minimal_libc
     extra_configs:
       - CONFIG_MINIMAL_LIBC=y
       - CONFIG_MINIMAL_LIBC_STRING_ERROR_TABLE=y
   libraries.libc.minimal.no_strerror_table:
+    filter: CONFIG_MINIMAL_LIBC_SUPPORTED
     tags: minimal_libc
     extra_configs:
       - CONFIG_MINIMAL_LIBC=y


### PR DESCRIPTION
Enabling testing with the native targets serves to make sure they aren't broken as well as checking the tests against a "known good" target.

Getting these working required only a few minor adjustments to the tests themselves.

I've also added another test in this series to make sure time_t is at least 64 bits. That is skipped for targets using EXTERNAL_LIBC because the 32-bit version on x86 still uses a 32-bit time_t by default. We can change that test if we change that configuration.

This is related to #63331 where we're trying to figure out if we should be configuring the native platform to use 64-bit time_t values. Getting that platform tested here will allow that change to be verified.