### PR TITLE
doc: ring_buffer: small Doxygen and doc fixes

### DIFF
--- a/doc/kernel/data_structures/ring_buffers.rst
+++ b/doc/kernel/data_structures/ring_buffers.rst
@@ -44,7 +44,7 @@ A ring buffer has the following key properties:
   bytes or 32-bit words that have been added to the ring buffer but not yet
   removed.
 
-* A **data buffer size**, measured in bytes or 32-byte words. This governs
+* A **data buffer size**, measured in bytes or 32-bit words. This governs
   the maximum amount of data (including possible metadata values) the ring
   buffer can hold.
 
@@ -53,7 +53,7 @@ data buffer to empty.
 
 A ``struct ring_buf`` may be placed anywhere in user-accessible
 memory, and must be initialized with :c:func:`ring_buf_init` or
-:c:func:`ring_buf_element_init` before use. This must be provided a region
+:c:func:`ring_buf_item_init` before use. This must be provided a region
 of user-controlled memory for use as the buffer itself.  Note carefully that the units of the size of the
 buffer passed change (either bytes or words) depending on how the ring
 buffer will be used later.  Macros for combining these steps in a

--- a/include/zephyr/sys/ring_buffer.h
+++ b/include/zephyr/sys/ring_buffer.h
@@ -26,6 +26,16 @@ extern "C" {
 /** @endcond */
 
 /**
+ * @file
+ * @defgroup ring_buffer_apis Ring Buffer APIs
+ * @ingroup datastructure_apis
+ *
+ * @brief Simple ring buffer implementation.
+ *
+ * @{
+ */
+
+/**
  * @brief A structure to represent a ring buffer
  */
 struct ring_buf {
@@ -40,16 +50,6 @@ struct ring_buf {
 	uint32_t size;
 	/** @endcond */
 };
-
-/**
- * @file
- * @defgroup ring_buffer_apis Ring Buffer APIs
- * @ingroup datastructure_apis
- *
- * @brief Simple ring buffer implementation.
- *
- * @{
- */
 
 /**
  * @brief Function to force ring_buf internal states to given value


### PR DESCRIPTION
Fixed an incorrect mention of buffer size being expressed in 32-byte words for data item mode when it's in fact 32-bit.
Fixed a broken reference and moved `ring_buf` struct in the same doxygen group as all other APIs. 