### PR TITLE
dts: x86: intel: raptor_lake: Remove unavailable UARTs

### DIFF
--- a/dts/x86/intel/raptor_lake.dtsi
+++ b/dts/x86/intel/raptor_lake.dtsi
@@ -307,54 +307,6 @@
 			current-speed = <115200>;
 			status = "disabled";
 		};
-
-		uart3: uart3 {
-			compatible = "ns16550";
-			vendor-id = <0x8086>;
-			device-id = <0x7adc>;
-			reg-shift = <2>;
-			clock-frequency = <1843200>;
-			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
-			interrupt-parent = <&intc>;
-			current-speed = <115200>;
-			status = "disabled";
-		};
-
-		uart4: uart4 {
-			compatible = "ns16550";
-			vendor-id = <0x8086>;
-			device-id = <0x7add>;
-			reg-shift = <2>;
-			clock-frequency = <1843200>;
-			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
-			interrupt-parent = <&intc>;
-			current-speed = <115200>;
-			status = "disabled";
-		};
-
-		uart5: uart5 {
-			compatible = "ns16550";
-			vendor-id = <0x8086>;
-			device-id = <0x7ade>;
-			reg-shift = <2>;
-			clock-frequency = <1843200>;
-			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
-			interrupt-parent = <&intc>;
-			current-speed = <115200>;
-			status = "disabled";
-		};
-
-		uart6: uart6 {
-			compatible = "ns16550";
-			vendor-id = <0x8086>;
-			device-id = <0x7adf>;
-			reg-shift = <2>;
-			clock-frequency = <1843200>;
-			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
-			interrupt-parent = <&intc>;
-			current-speed = <115200>;
-			status = "disabled";
-		};
 	};
 
 	soc {


### PR DESCRIPTION
Remove unavailable UART instances on RPL platform.

Signed-off-by: Anisetti Avinash Krishna <anisetti.avinash.krishna@intel.com>