### PR TITLE
subsys: logging: log_core: correct timeout of -1 ms to K_FOREVER

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -597,8 +597,11 @@ static struct log_msg *msg_alloc(struct mpsc_pbuf_buffer *buffer, uint32_t wlen)
 		return NULL;
 	}
 
-	return (struct log_msg *)mpsc_pbuf_alloc(buffer, wlen,
-				K_MSEC(CONFIG_LOG_BLOCK_IN_THREAD_TIMEOUT_MS));
+	return (struct log_msg *)mpsc_pbuf_alloc(
+		buffer, wlen,
+		(CONFIG_LOG_BLOCK_IN_THREAD_TIMEOUT_MS == -1)
+			? K_FOREVER
+			: K_MSEC(CONFIG_LOG_BLOCK_IN_THREAD_TIMEOUT_MS));
 }
 
 struct log_msg *z_log_msg_alloc(uint32_t wlen)


### PR DESCRIPTION
Many releases ago, specifying to block indefinitely in the log processing thread would do just that.

However, a subtle bug was introduced  such that specifying -1 for `CONFIG_LOG_BLOCK_IN_THREAD_TIMEOUT_MS` would have the exact opposite effect than what was intended.

As per Kconfig, a value of -1 should translate to a timeout of `K_FOREVER`. However, conversion via `K_MSEC(-1)` results in a `k_timeout_t` that is equal to `K_NO_WAIT`.

Add a dedicated check to to ensure that a value of -1 is correctly interpreted as `K_FOREVER` in `log_core.c`.

For reference, the blocking feature was described in #15196, added in #16194, and it would appear that the regression happened in c5f2cdef09.

Fixes #63965