### PR TITLE
Bluetooth: ISO: extend API for setting SDU interval

### DIFF
--- a/include/zephyr/bluetooth/iso.h
+++ b/include/zephyr/bluetooth/iso.h
@@ -335,19 +335,33 @@ struct bt_iso_cig_param {
 	 */
 	uint8_t num_cis;
 
-	/** @brief Channel interval in us.
+	/** @brief Channel interval in us for SDUs sent from Central to Peripheral.
 	 *
 	 *  Value range BT_ISO_SDU_INTERVAL_MIN - BT_ISO_SDU_INTERVAL_MAX.
 	 */
-	uint32_t interval;
+	uint32_t c_to_p_interval;
 
-	/** @brief Channel Latency in ms.
+	/** @brief Channel interval in us for SDUs sent from Peripheral to Central.
+	 *
+	 *  Value range BT_ISO_SDU_INTERVAL_MIN - BT_ISO_SDU_INTERVAL_MAX.
+	 */
+	uint32_t p_to_c_interval;
+
+	/** @brief Channel Latency in ms for SDUs sent from Central to Peripheral
 	 *
 	 *  Value range BT_ISO_LATENCY_MIN - BT_ISO_LATENCY_MAX.
 	 *
 	 *  This value is ignored if any advanced ISO parameters are set.
 	 */
-	uint16_t latency;
+	uint16_t c_to_p_latency;
+
+	/** @brief Channel Latency in ms for SDUs sent from Peripheral to Central
+	 *
+	 *  Value range BT_ISO_LATENCY_MIN - BT_ISO_LATENCY_MAX.
+	 *
+	 *  This value is ignored if any advanced ISO parameters are set.
+	 */
+	uint16_t p_to_c_latency;
 
 	/** @brief Channel peripherals sleep clock accuracy Only for CIS
 	 *

--- a/samples/bluetooth/central_iso/src/main.c
+++ b/samples/bluetooth/central_iso/src/main.c
@@ -25,6 +25,7 @@ static struct bt_conn *default_conn;
 static struct k_work_delayable iso_send_work;
 static struct bt_iso_chan iso_chan;
 static uint16_t seq_num;
+static uint16_t latency_ms = 10U; /* 10ms */
 static uint32_t interval_us = 10U * USEC_PER_MSEC; /* 10 ms */
 NET_BUF_POOL_FIXED_DEFINE(tx_pool, 1, BT_ISO_SDU_BUF_SIZE(CONFIG_BT_ISO_TX_MTU),
 			  CONFIG_BT_CONN_TX_USER_DATA_SIZE, NULL);
@@ -251,8 +252,10 @@ int main(void)
 	param.sca = BT_GAP_SCA_UNKNOWN;
 	param.packing = 0;
 	param.framing = 0;
-	param.latency = 10; /* ms */
-	param.interval = interval_us; /* us */
+	param.c_to_p_latency = latency_ms; /* ms */
+	param.p_to_c_latency = latency_ms; /* ms */
+	param.c_to_p_interval = interval_us; /* us */
+	param.p_to_c_interval = interval_us; /* us */
 
 	err = bt_iso_cig_create(&param, &cig);
 

--- a/samples/bluetooth/iso_connected_benchmark/src/main.c
+++ b/samples/bluetooth/iso_connected_benchmark/src/main.c
@@ -28,6 +28,11 @@ enum benchmark_role {
 	ROLE_QUIT
 };
 
+enum sdu_dir {
+	DIR_C_TO_P,
+	DIR_P_TO_C
+};
+
 #define DEFAULT_CIS_RTN         2
 #define DEFAULT_CIS_INTERVAL_US 7500
 #define DEFAULT_CIS_LATENCY_MS  40
@@ -116,8 +121,10 @@ static struct bt_iso_chan_qos iso_qos = {
 };
 
 static struct bt_iso_cig_param cig_create_param = {
-	.interval = DEFAULT_CIS_INTERVAL_US, /* in microseconds */
-	.latency = DEFAULT_CIS_LATENCY_MS, /* milliseconds */
+	.c_to_p_interval = DEFAULT_CIS_INTERVAL_US, /* in microseconds */
+	.p_to_c_interval = DEFAULT_CIS_INTERVAL_US, /* in microseconds */
+	.c_to_p_latency = DEFAULT_CIS_LATENCY_MS, /* milliseconds */
+	.p_to_c_latency = DEFAULT_CIS_LATENCY_MS, /* milliseconds */
 	.sca = BT_GAP_SCA_UNKNOWN,
 	.packing = DEFAULT_CIS_PACKING,
 	.framing = DEFAULT_CIS_FRAMING,
@@ -179,6 +186,7 @@ static void iso_send(struct bt_iso_chan *chan)
 	int ret;
 	struct net_buf *buf;
 	struct iso_chan_work *chan_work;
+	uint32_t interval;
 
 	chan_work = CONTAINER_OF(chan, struct iso_chan_work, chan);
 
@@ -186,10 +194,13 @@ static void iso_send(struct bt_iso_chan *chan)
 		return;
 	}
 
+	interval = (role == ROLE_CENTRAL) ?
+		   cig_create_param.c_to_p_interval : cig_create_param.p_to_c_interval;
+
 	buf = net_buf_alloc(&tx_pool, K_FOREVER);
 	if (buf == NULL) {
 		LOG_ERR("Could not allocate buffer");
-		k_work_reschedule(&chan_work->send_work, K_USEC(cig_create_param.interval));
+		k_work_reschedule(&chan_work->send_work, K_USEC(interval));
 		return;
 	}
 
@@ -201,7 +212,7 @@ static void iso_send(struct bt_iso_chan *chan)
 	if (ret < 0) {
 		LOG_ERR("Unable to send data: %d", ret);
 		net_buf_unref(buf);
-		k_work_reschedule(&chan_work->send_work, K_USEC(cig_create_param.interval));
+		k_work_reschedule(&chan_work->send_work, K_USEC(interval));
 		return;
 	}
 
@@ -535,14 +546,18 @@ static int parse_rtn_arg(struct bt_iso_chan_io_qos *qos)
 	return (int)rtn;
 }
 
-static int parse_interval_arg(void)
+static int parse_interval_arg(enum sdu_dir direction)
 {
 	char buffer[9];
 	size_t char_count;
 	uint64_t interval;
 
-	printk("Set interval (us) (current %u, default %u)\n",
-	       cig_create_param.interval, DEFAULT_CIS_INTERVAL_US);
+	interval = (direction == DIR_C_TO_P) ?
+		   cig_create_param.c_to_p_interval : cig_create_param.p_to_c_interval;
+
+	printk("Set %s interval (us) (current %llu, default %u)\n",
+	       (direction == DIR_C_TO_P) ? "C to P" : "P to C",
+	       interval, DEFAULT_CIS_INTERVAL_US);
 
 	char_count = get_chars(buffer, sizeof(buffer) - 1);
 	if (char_count == 0) {
@@ -550,7 +565,6 @@ static int parse_interval_arg(void)
 	}
 
 	interval = strtoul(buffer, NULL, 0);
-	/* TODO: Replace literal ints with a #define once it has been created */
 	if (interval < BT_ISO_SDU_INTERVAL_MIN || interval > BT_ISO_SDU_INTERVAL_MAX) {
 		printk("Invalid interval %llu", interval);
 		return -EINVAL;
@@ -559,14 +573,18 @@ static int parse_interval_arg(void)
 	return (int)interval;
 }
 
-static int parse_latency_arg(void)
+static int parse_latency_arg(enum sdu_dir direction)
 {
 	char buffer[6];
 	size_t char_count;
 	uint64_t latency;
 
-	printk("Set latency (ms) (current %u, default %u)\n",
-	       cig_create_param.latency, DEFAULT_CIS_LATENCY_MS);
+	latency = (direction == DIR_C_TO_P) ?
+		  cig_create_param.c_to_p_latency : cig_create_param.p_to_c_latency;
+
+	printk("Set %s latency (ms) (current %llu, default %u)\n",
+	       (direction == DIR_C_TO_P) ? "C to P" : "P to C",
+	       latency, DEFAULT_CIS_LATENCY_MS);
 
 	char_count = get_chars(buffer, sizeof(buffer) - 1);
 	if (char_count == 0) {
@@ -805,8 +823,10 @@ static int parse_cis_count_arg(void)
 
 static int parse_cig_args(void)
 {
-	int interval;
-	int latency;
+	int c_to_p_interval;
+	int p_to_c_interval;
+	int c_to_p_latency;
+	int p_to_c_latency;
 	int cis_count;
 #if defined(CONFIG_BT_ISO_TEST_PARAMS)
 	int c_to_p_ft;
@@ -822,13 +842,23 @@ static int parse_cig_args(void)
 		return -EINVAL;
 	}
 
-	interval = parse_interval_arg();
-	if (interval < 0) {
+	c_to_p_interval = parse_interval_arg(DIR_C_TO_P);
+	if (c_to_p_interval < 0) {
 		return -EINVAL;
 	}
 
-	latency = parse_latency_arg();
-	if (latency < 0) {
+	p_to_c_interval = parse_interval_arg(DIR_P_TO_C);
+	if (p_to_c_interval < 0) {
+		return -EINVAL;
+	}
+
+	c_to_p_latency = parse_latency_arg(DIR_C_TO_P);
+	if (c_to_p_latency < 0) {
+		return -EINVAL;
+	}
+
+	p_to_c_latency = parse_latency_arg(DIR_P_TO_C);
+	if (p_to_c_latency < 0) {
 		return -EINVAL;
 	}
 
@@ -854,8 +884,10 @@ static int parse_cig_args(void)
 	}
 #endif /* CONFIG_BT_ISO_TEST_PARAMS */
 
-	cig_create_param.interval = interval;
-	cig_create_param.latency = latency;
+	cig_create_param.c_to_p_interval = c_to_p_interval;
+	cig_create_param.p_to_c_interval = p_to_c_interval;
+	cig_create_param.c_to_p_latency = c_to_p_latency;
+	cig_create_param.p_to_c_latency = p_to_c_latency;
 	cig_create_param.num_cis = cis_count;
 #if defined(CONFIG_BT_ISO_TEST_PARAMS)
 	cig_create_param.c_to_p_ft = c_to_p_ft;
@@ -923,9 +955,11 @@ static int change_central_settings(void)
 	int err;
 
 	printk("Change CIG settings (y/N)? (Current settings: cis_count=%u, "
-	       "interval=%u, latency=%u)\n",
-	       cig_create_param.num_cis, cig_create_param.interval,
-	       cig_create_param.latency);
+	       "C to P interval=%u, P to C interval=%u "
+	       "C to P latency=%u, P to C latency=%u)\n",
+	       cig_create_param.num_cis, cig_create_param.c_to_p_interval,
+	       cig_create_param.p_to_c_interval, cig_create_param.c_to_p_latency,
+	       cig_create_param.p_to_c_latency);
 
 	c = tolower(console_getchar());
 	if (c == 'y') {
@@ -934,9 +968,12 @@ static int change_central_settings(void)
 			return err;
 		}
 
-		printk("New settings: cis_count=%u, inteval=%u, latency=%u\n",
-		       cig_create_param.num_cis, cig_create_param.interval,
-		       cig_create_param.latency);
+		printk("New settings: cis_count=%u, C to P interval=%u, "
+		       "P TO C interval=%u, C to P latency=%u "
+		       "P TO C latency=%u\n",
+		       cig_create_param.num_cis, cig_create_param.c_to_p_interval,
+		       cig_create_param.p_to_c_interval, cig_create_param.c_to_p_latency,
+		       cig_create_param.p_to_c_latency);
 	}
 
 	printk("Change TX settings (y/N)? (Current settings: rtn=%u, "

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -2090,8 +2090,10 @@ static void bt_audio_codec_qos_to_cig_param(struct bt_iso_cig_param *cig_param,
 {
 	cig_param->framing = qos->framing;
 	cig_param->packing = BT_ISO_PACKING_SEQUENTIAL; /*  TODO: Add to QoS struct */
-	cig_param->interval = qos->interval;
-	cig_param->latency = qos->latency;
+	cig_param->c_to_p_interval = qos->interval;
+	cig_param->p_to_c_interval = qos->interval;
+	cig_param->c_to_p_latency = qos->latency;
+	cig_param->p_to_c_latency = qos->latency;
 	cig_param->sca = BT_GAP_SCA_UNKNOWN;
 
 	if (group_param != NULL) {

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -1863,27 +1863,23 @@ static bool valid_cig_param(const struct bt_iso_cig_param *param, bool advanced,
 		return false;
 	}
 
-	if (param->c_to_p_interval < BT_ISO_SDU_INTERVAL_MIN ||
-	    param->c_to_p_interval > BT_ISO_SDU_INTERVAL_MAX) {
+	if (!IN_RANGE(param->c_to_p_interval, BT_ISO_SDU_INTERVAL_MIN, BT_ISO_SDU_INTERVAL_MAX)) {
 		LOG_DBG("Invalid C to P interval: %u", param->c_to_p_interval);
 		return false;
 	}
 
-	if (param->p_to_c_interval < BT_ISO_SDU_INTERVAL_MIN ||
-	    param->p_to_c_interval > BT_ISO_SDU_INTERVAL_MAX) {
+	if (!IN_RANGE(param->p_to_c_interval, BT_ISO_SDU_INTERVAL_MIN, BT_ISO_SDU_INTERVAL_MAX)) {
 		LOG_DBG("Invalid P to C interval: %u", param->p_to_c_interval);
 		return false;
 	}
 
 	if (!advanced &&
-	    (param->c_to_p_latency < BT_ISO_LATENCY_MIN ||
-	     param->c_to_p_latency > BT_ISO_LATENCY_MAX)) {
+	    !IN_RANGE(param->c_to_p_latency, BT_ISO_LATENCY_MIN, BT_ISO_LATENCY_MAX)) {
 		LOG_DBG("Invalid C to P latency: %u", param->c_to_p_latency);
 		return false;
 	}
 	if (!advanced &&
-	    (param->p_to_c_latency < BT_ISO_LATENCY_MIN ||
-	     param->p_to_c_latency > BT_ISO_LATENCY_MAX)) {
+	    !IN_RANGE(param->p_to_c_latency, BT_ISO_LATENCY_MIN, BT_ISO_LATENCY_MAX)) {
 		LOG_DBG("Invalid P to C latency: %u", param->p_to_c_latency);
 		return false;
 	}

--- a/subsys/bluetooth/shell/iso.c
+++ b/subsys/bluetooth/shell/iso.c
@@ -136,6 +136,56 @@ NET_BUF_POOL_FIXED_DEFINE(tx_pool, 1, BT_ISO_SDU_BUF_SIZE(CONFIG_BT_ISO_TX_MTU),
 #if defined(CONFIG_BT_ISO_CENTRAL)
 static struct bt_iso_cig *cig;
 
+static long parse_interval(const struct shell *sh, const char *interval_str)
+{
+	unsigned long interval;
+	int err;
+
+	err = 0;
+	interval = shell_strtoul(interval_str, 0, &err);
+	if (err != 0) {
+		shell_error(sh, "Could not parse interval: %d", err);
+
+		return -ENOEXEC;
+	}
+
+	if (!IN_RANGE(interval,
+		      BT_ISO_SDU_INTERVAL_MIN,
+		      BT_ISO_SDU_INTERVAL_MAX)) {
+		shell_error(sh, "Invalid interval %lu", interval);
+
+		return -ENOEXEC;
+	}
+
+	return interval;
+}
+
+static long parse_latency(const struct shell *sh, const char *latency_str)
+{
+	unsigned long latency;
+	int err;
+
+	err = 0;
+	latency = shell_strtoul(latency_str, 0, &err);
+	if (err != 0) {
+		shell_error(sh, "Could not parse latency: %d", err);
+
+		return -ENOEXEC;
+	}
+
+	if (!IN_RANGE(latency,
+		      BT_ISO_LATENCY_MIN,
+		      BT_ISO_LATENCY_MAX)) {
+		shell_error(sh, "Invalid latency %lu", latency);
+
+		return -ENOEXEC;
+	}
+
+	return latency;
+}
+
+
+
 static int cmd_cig_create(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err;
@@ -164,33 +214,44 @@ static int cmd_cig_create(const struct shell *sh, size_t argc, char *argv[])
 
 	err = 0;
 	if (argc > 2) {
-		unsigned long interval;
+		long interval;
 
 		interval = shell_strtoul(argv[2], 0, &err);
-		if (err != 0) {
-			shell_error(sh, "Could not parse interval: %d", err);
-
-			return -ENOEXEC;
+		interval = parse_interval(sh, argv[2]);
+		if (interval < 0) {
+			return interval;
 		}
 
-		if (!IN_RANGE(interval,
-			      BT_ISO_SDU_INTERVAL_MIN,
-			      BT_ISO_SDU_INTERVAL_MAX)) {
-			shell_error(sh, "Invalid interval %lu", interval);
-
-			return -ENOEXEC;
-		}
-
-		param.interval = interval;
+		param.c_to_p_interval = interval;
 	} else {
-		param.interval = 10000;
+		param.c_to_p_interval = 10000;
 	}
-	cis_sdu_interval_us = param.interval;
 
 	if (argc > 3) {
+		long interval;
+
+		interval = parse_interval(sh, argv[3]);
+		if (interval < 0) {
+			return interval;
+		}
+
+		param.p_to_c_interval = interval;
+	} else {
+		param.p_to_c_interval = param.c_to_p_interval;
+	}
+
+	/* cis_sdu_interval_us is used to increase the sequence number.
+	 * cig_create can be called before an ACL is created, so the role
+	 * information may not be available.
+	 * Since we are central however we can safely set the cis_sdu_interval
+	 * to the Central to Peer interval
+	 */
+	cis_sdu_interval_us = param.c_to_p_interval;
+
+	if (argc > 4) {
 		unsigned long packing;
 
-		packing = shell_strtoul(argv[3], 0, &err);
+		packing = shell_strtoul(argv[4], 0, &err);
 		if (err != 0) {
 			shell_error(sh, "Could not parse packing: %d", err);
 
@@ -208,10 +269,10 @@ static int cmd_cig_create(const struct shell *sh, size_t argc, char *argv[])
 		param.packing = 0;
 	}
 
-	if (argc > 4) {
+	if (argc > 5) {
 		unsigned long framing;
 
-		framing = shell_strtoul(argv[4], 0, &err);
+		framing = shell_strtoul(argv[5], 0, &err);
 		if (err != 0) {
 			shell_error(sh, "Could not parse framing: %d", err);
 
@@ -229,33 +290,38 @@ static int cmd_cig_create(const struct shell *sh, size_t argc, char *argv[])
 		param.framing = 0;
 	}
 
-	if (argc > 5) {
-		unsigned long latency;
+	if (argc > 6) {
+		long latency;
 
-		latency = shell_strtoul(argv[5], 0, &err);
-		if (err != 0) {
-			shell_error(sh, "Could not parse latency: %d", err);
+		latency = parse_latency(sh, argv[6]);
 
-			return -ENOEXEC;
+		if (latency < 0) {
+			return latency;
 		}
 
-		if (!IN_RANGE(latency,
-			      BT_ISO_LATENCY_MIN,
-			      BT_ISO_LATENCY_MAX)) {
-			shell_error(sh, "Invalid latency %lu", latency);
-
-			return -ENOEXEC;
-		}
-
-		param.latency = latency;
+		param.c_to_p_latency = latency;
 	} else {
-		param.latency = 10;
+		param.c_to_p_latency = 10;
 	}
 
-	if (argc > 6) {
+	if (argc > 7) {
+		long latency;
+
+		latency = parse_latency(sh, argv[7]);
+
+		if (latency < 0) {
+			return latency;
+		}
+
+		param.p_to_c_latency = latency;
+	} else {
+		param.p_to_c_latency = param.c_to_p_latency;
+	}
+
+	if (argc > 7) {
 		unsigned long sdu;
 
-		sdu = shell_strtoul(argv[6], 0, &err);
+		sdu = shell_strtoul(argv[7], 0, &err);
 		if (err != 0) {
 			shell_error(sh, "Could not parse sdu: %d", err);
 
@@ -277,10 +343,10 @@ static int cmd_cig_create(const struct shell *sh, size_t argc, char *argv[])
 		}
 	}
 
-	if (argc > 7) {
+	if (argc > 8) {
 		unsigned long phy;
 
-		phy = shell_strtoul(argv[7], 0, &err);
+		phy = shell_strtoul(argv[8], 0, &err);
 		if (err != 0) {
 			shell_error(sh, "Could not parse phy: %d", err);
 
@@ -304,10 +370,10 @@ static int cmd_cig_create(const struct shell *sh, size_t argc, char *argv[])
 		}
 	}
 
-	if (argc > 8) {
+	if (argc > 9) {
 		unsigned long rtn;
 
-		rtn = shell_strtoul(argv[8], 0, &err);
+		rtn = shell_strtoul(argv[9], 0, &err);
 		if (err != 0) {
 			shell_error(sh, "Could not parse rtn: %d", err);
 
@@ -860,8 +926,9 @@ static int cmd_big_term(const struct shell *sh, size_t argc, char *argv[])
 SHELL_STATIC_SUBCMD_SET_CREATE(iso_cmds,
 #if defined(CONFIG_BT_ISO_UNICAST)
 #if defined(CONFIG_BT_ISO_CENTRAL)
-	SHELL_CMD_ARG(cig_create, NULL, "[dir=tx,rx,txrx] [interval] [packing] [framing] "
-		      "[latency] [sdu] [phy] [rtn]", cmd_cig_create, 1, 8),
+	SHELL_CMD_ARG(cig_create, NULL, "[dir=tx,rx,txrx] [C to P interval] [P to C interval] "
+		      "[packing] [framing] [C to P latency] [P to C latency] [sdu] [phy] [rtn]",
+		      cmd_cig_create, 1, 10),
 	SHELL_CMD_ARG(cig_term, NULL, "Terminate the CIG", cmd_cig_term, 1, 0),
 #if defined(CONFIG_BT_SMP)
 	SHELL_CMD_ARG(connect, NULL, "Connect ISO Channel [security level]", cmd_connect, 1, 1),

--- a/tests/bsim/bluetooth/host/iso/cis/src/cis_central.c
+++ b/tests/bsim/bluetooth/host/iso/cis/src/cis_central.c
@@ -18,6 +18,7 @@ static struct bt_iso_chan *default_chan = &iso_chans[0];
 static struct bt_iso_cig *cig;
 static uint16_t seq_num;
 static volatile size_t enqueue_cnt;
+static uint32_t latency_ms = 10U; /* 10ms */
 static uint32_t interval_us = 10U * USEC_PER_MSEC; /* 10 ms */
 NET_BUF_POOL_FIXED_DEFINE(tx_pool, ENQUEUE_COUNT, BT_ISO_SDU_BUF_SIZE(CONFIG_BT_ISO_TX_MTU),
 			  CONFIG_BT_CONN_TX_USER_DATA_SIZE, NULL);
@@ -173,18 +174,26 @@ static void init(void)
 	}
 }
 
+static void set_cig_defaults(struct bt_iso_cig_param *param)
+{
+	param->cis_channels = &default_chan;
+	param->num_cis = 1U;
+	param->sca = BT_GAP_SCA_UNKNOWN;
+	param->packing = BT_ISO_PACKING_SEQUENTIAL;
+	param->framing = BT_ISO_FRAMING_UNFRAMED;
+	param->c_to_p_latency = latency_ms;   /* ms */
+	param->p_to_c_latency = latency_ms;   /* ms */
+	param->c_to_p_interval = interval_us; /* us */
+	param->p_to_c_interval = interval_us; /* us */
+
+}
+
 static void create_cig(void)
 {
 	struct bt_iso_cig_param param;
 	int err;
 
-	param.cis_channels = &default_chan;
-	param.num_cis = 1U;
-	param.sca = BT_GAP_SCA_UNKNOWN;
-	param.packing = BT_ISO_PACKING_SEQUENTIAL;
-	param.framing = BT_ISO_FRAMING_UNFRAMED;
-	param.latency = 10U;          /* ms */
-	param.interval = interval_us; /* us */
+	set_cig_defaults(&param);
 
 	err = bt_iso_cig_create(&param, &cig);
 	if (err != 0) {
@@ -192,6 +201,68 @@ static void create_cig(void)
 
 		return;
 	}
+}
+
+static int reconfigure_cig_interval(struct bt_iso_cig_param *param)
+{
+	int err;
+
+	/* Test modifying CIG parameter without any CIS */
+	param->num_cis = 0U;
+	param->c_to_p_interval = 7500; /* us */
+	param->p_to_c_interval = param->c_to_p_interval;
+	err = bt_iso_cig_reconfigure(cig, param);
+	if (err != 0) {
+		FAIL("Failed to reconfigure CIG to new interval (%d)\n", err);
+
+		return err;
+	}
+
+	err = bt_iso_cig_reconfigure(cig, param);
+	if (err != 0) {
+		FAIL("Failed to reconfigure CIG to same interval (%d)\n", err);
+
+		return err;
+	}
+
+	/* Test modifying to different values for both intervals */
+	param->c_to_p_interval = 5000; /* us */
+	param->p_to_c_interval = 2500; /* us */
+	err = bt_iso_cig_reconfigure(cig, param);
+	if (err != 0) {
+		FAIL("Failed to reconfigure CIG to new interval (%d)\n", err);
+
+		return err;
+	}
+
+	return 0;
+}
+
+static int reconfigure_cig_latency(struct bt_iso_cig_param *param)
+{
+	int err;
+
+	/* Test modifying CIG latency without any CIS */
+	param->num_cis = 0U;
+	param->c_to_p_latency = 20; /* ms */
+	param->p_to_c_latency = param->c_to_p_latency;
+	err = bt_iso_cig_reconfigure(cig, param);
+	if (err != 0) {
+		FAIL("Failed to reconfigure CIG latency (%d)\n", err);
+
+		return err;
+	}
+
+	param->c_to_p_latency = 30; /* ms */
+	param->p_to_c_latency = 40; /* ms */
+	err = bt_iso_cig_reconfigure(cig, param);
+	if (err != 0) {
+		FAIL("Failed to reconfigure CIG for different latencies (%d)\n", err);
+
+		return err;
+	}
+
+	return 0;
 }
 
 static void reconfigure_cig(void)
@@ -204,14 +275,7 @@ static void reconfigure_cig(void)
 		channels[i] = &iso_chans[i];
 	}
 
-	/* Set parameters to same as the ones used to create the CIG */
-	param.cis_channels = &default_chan;
-	param.num_cis = 1U;
-	param.sca = BT_GAP_SCA_UNKNOWN;
-	param.packing = BT_ISO_PACKING_SEQUENTIAL;
-	param.framing = BT_ISO_FRAMING_UNFRAMED;
-	param.latency = 10U;          /* ms */
-	param.interval = interval_us; /* us */
+	set_cig_defaults(&param);
 
 	/* Test modifying existing CIS */
 	default_chan->qos->tx->rtn++;
@@ -223,25 +287,25 @@ static void reconfigure_cig(void)
 		return;
 	}
 
-	/* Test modifying CIG parameter without any CIS */
-	param.num_cis = 0U;
-	param.interval = 7500U; /* us */
-
-	err = bt_iso_cig_reconfigure(cig, &param);
+	/* Test modifying interval parameter */
+	err = reconfigure_cig_interval(&param);
 	if (err != 0) {
-		FAIL("Failed to reconfigure CIG to new interval (%d)\n", err);
-
 		return;
 	}
 
-	/* Add CIS to the CIG and restore interval to 10ms */
+	/* Test modifying latency parameter */
+	err = reconfigure_cig_latency(&param);
+	if (err != 0) {
+		return;
+	}
+
+	/* Add CIS to the CIG and restore all other parameters */
+	set_cig_defaults(&param);
 	param.cis_channels = &channels[1];
-	param.num_cis = 1U;
-	param.interval = interval_us; /* us */
 
 	err = bt_iso_cig_reconfigure(cig, &param);
 	if (err != 0) {
-		FAIL("Failed to reconfigure CIG with new CIS and original interval (%d)\n", err);
+		FAIL("Failed to reconfigure CIG with new CIS and original parameters (%d)\n", err);
 
 		return;
 	}

--- a/tests/bsim/bluetooth/ll/cis/src/main.c
+++ b/tests/bsim/bluetooth/ll/cis/src/main.c
@@ -413,11 +413,14 @@ static void test_cis_central(void)
 	cig_param.sca = BT_GAP_SCA_UNKNOWN;
 	cig_param.packing = 0U;
 	cig_param.framing = 0U;
-	cig_param.interval = ISO_INTERVAL_US;
+	cig_param.c_to_p_interval = ISO_INTERVAL_US;
+	cig_param.p_to_c_interval = ISO_INTERVAL_US;
 	if (IS_ENABLED(CONFIG_TEST_FT_SKIP_SUBEVENTS)) {
-		cig_param.latency = ISO_LATENCY_FT_MS;
+		cig_param.c_to_p_latency = ISO_LATENCY_FT_MS;
+		cig_param.p_to_c_latency = ISO_LATENCY_FT_MS;
 	} else {
-		cig_param.latency = ISO_LATENCY_MS;
+		cig_param.c_to_p_latency = ISO_LATENCY_MS;
+		cig_param.p_to_c_latency = ISO_LATENCY_MS;
 	}
 
 	printk("Create CIG...");


### PR DESCRIPTION
The BT Core Spec v5.4 allows separate SDU_Interval to be set on C_To_P and P_To_C directions, but this is not possible with the existing interface. This PR splits the interval parameter in the call to bt_iso_sig_create into one for C_To_P and one for P_To_C

The same is done for the latency parameter

The babblesim tests are also updated


Fixes #62216