### PR TITLE
bsim: Bluetooth: mesh: fix model extension

### DIFF
--- a/include/zephyr/bluetooth/mesh/access.h
+++ b/include/zephyr/bluetooth/mesh/access.h
@@ -1070,6 +1070,10 @@ void bt_mesh_model_data_store_schedule(struct bt_mesh_model *mod);
  *  extension list and element, giving the models extended subscription list
  *  capacity.
  *
+ * If @kconfig{CONFIG_BT_MESH_COMP_PAGE_1} is enabled, it is not allowed to call
+ * this function before the @ref bt_mesh_model_cb.init callback is called
+ * for both models, except if it is called as part of the final callback.
+ *
  *  @param extending_mod      Mesh model that is extending the base model.
  *  @param base_mod           The model being extended.
  *

--- a/tests/bsim/bluetooth/mesh/src/test_access.c
+++ b/tests/bsim/bluetooth/mesh/src/test_access.c
@@ -261,8 +261,8 @@ static int model3_init(struct bt_mesh_model *model)
 	ASSERT_OK(bt_mesh_model_extend(model, model - 2));
 	ASSERT_OK(bt_mesh_model_extend(model, model - 1));
 
-	if (model->elem_idx == 0) {
-		ASSERT_OK(bt_mesh_model_extend(&models_ne[2], model));
+	if (model->elem_idx == 1) {
+		ASSERT_OK(bt_mesh_model_extend(model, &models[4]));
 	}
 
 	return 0;


### PR DESCRIPTION
In 'test_access.c', model 3 on element 1 extending model 3 on element 0 is now registered correctly. When calling 'bt_mesh_model_extend' on models on different elements, this needs to called from the model with the highest element index to be registered correctly.