### PR TITLE
boards: suppress dtc warning for SPI bridge on b_u585i_iot02a

### DIFF
--- a/boards/arm/b_u585i_iot02a/pre_dt_board.cmake
+++ b/boards/arm/b_u585i_iot02a/pre_dt_board.cmake
@@ -1,0 +1,3 @@
+
+# SPI is implemented via octospi so node name isn't spi@...
+list(APPEND EXTRA_DTC_FLAGS "-Wno-spi_bus_bridge")


### PR DESCRIPTION
As discussed [here](https://github.com/zephyrproject-rtos/zephyr/issues/24499), the current way to suppress DTC warnings is through `pre_dt_board.cmake`. 