### PR TITLE
tfm: Enable TFM_EXCEPTION_INFO_DUMP by default

### DIFF
--- a/modules/trusted-firmware-m/Kconfig.tfm
+++ b/modules/trusted-firmware-m/Kconfig.tfm
@@ -431,6 +431,7 @@ endchoice
 
 config TFM_EXCEPTION_INFO_DUMP
 	bool "TF-M exception info dump"
+	default y
 	help
 	  On fatal errors in the secure firmware, capture info about the exception.
 	  Print the info if the SPM log level is sufficient.


### PR DESCRIPTION
Exception info dump is a very basic feature so it should IMHO be enabled by default.

For instance, a simple null-pointer exception in the non-secure app will not be logged unless this option is enabled.