### PR TITLE
zbus: Remove obsolete function from header

### DIFF
--- a/include/zephyr/zbus/zbus.h
+++ b/include/zephyr/zbus/zbus.h
@@ -225,7 +225,6 @@ struct zbus_channel_observation {
 #define _ZBUS_RUNTIME_OBSERVERS_DECL(_name)
 #endif /* CONFIG_ZBUS_RUNTIME_OBSERVERS */
 
-k_timeout_t _zbus_timeout_remainder(uint64_t end_ticks);
 /** @endcond */
 
 /**


### PR DESCRIPTION
`_zbus_timeout_remainder` was removed in a7b3584745d8e26e70f530ee18ba4e6af7c18ff1 however 7e44469dcc6c34561aa422b64e3c7bfefc55d48e re-introduced it in the header.