### PR TITLE
kernel: Move sched.c out of multithreading rule

### DIFF
--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -51,6 +51,7 @@ list(APPEND kernel_files
   init.c
   kheap.c
   mem_slab.c
+  sched.c
   thread.c
   version.c
   )
@@ -66,7 +67,6 @@ list(APPEND kernel_files
   stack.c
   system_work_q.c
   work.c
-  sched.c
   condvar.c
   )
 


### PR DESCRIPTION
The current single thread mode can not be build when using k_sleep because sched.c is only build in multithread mode. This moves sched.c to right place in the CMakeLists.txt to fix the issue.

The #34279 added the rule which confined `sched.c` to be build only when multithreading is selected.