### PR TITLE
Extend weekly run twister timeout

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -244,7 +244,7 @@ jobs:
           fi
 
       - if: github.event_name == 'schedule'
-        name: Run Tests with Twister (Daily)
+        name: Run Tests with Twister (Schedule)
         run: |
           export ZEPHYR_BASE=${PWD}
           export ZEPHYR_TOOLCHAIN_VARIANT=zephyr

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -245,6 +245,7 @@ jobs:
 
       - if: github.event_name == 'schedule'
         name: Run Tests with Twister (Schedule)
+        timeout-minutes: 480
         run: |
           export ZEPHYR_BASE=${PWD}
           export ZEPHYR_TOOLCHAIN_VARIANT=zephyr


### PR DESCRIPTION
Recent weekly CI runs have few shards that consistently [fails](https://github.com/zephyrproject-rtos/zephyr/actions/runs/6521606521/job/17733917798) close to completion by exceeding the default 6h limit. Extend the timeout to 8h.

