### PR TITLE
docs: releases: RTIO Release Notes for 3.5

### DIFF
--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -879,6 +879,13 @@ Libraries / Subsystems
 
   * Added support for CAN FD.
 
+* RTIO
+
+  * Added atomic completion counter fixing a race caught by unit tests
+  * Added a :c:macro:`RTIO_SQE_NO_RESPONSE` flag for submissions when no completion notification
+    is needed
+  * Removed unused Kconfig options for different executors
+
 HALs
 ****
 


### PR DESCRIPTION
Adds release notes for the RTIO subsystem for 3.5 with notable bug fixes, changes, and feature additions.