### PR TITLE
kernel: Implement k_sleep for Single Thread

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1527,26 +1527,28 @@ static inline void z_vrfy_k_yield(void)
 
 static int32_t z_tick_sleep(k_ticks_t ticks)
 {
-#ifdef CONFIG_MULTITHREADING
 	uint32_t expected_wakeup_ticks;
 
 	__ASSERT(!arch_is_in_isr(), "");
 
 	LOG_DBG("thread %p for %lu ticks", _current, (unsigned long)ticks);
 
+#ifdef CONFIG_MULTITHREADING
 	/* wait of 0 ms is treated as a 'yield' */
 	if (ticks == 0) {
 		k_yield();
 		return 0;
 	}
+#endif
 
-	k_timeout_t timeout = Z_TIMEOUT_TICKS(ticks);
 	if (Z_TICK_ABS(ticks) <= 0) {
 		expected_wakeup_ticks = ticks + sys_clock_tick_get_32();
 	} else {
 		expected_wakeup_ticks = Z_TICK_ABS(ticks);
 	}
 
+#ifdef CONFIG_MULTITHREADING
+	k_timeout_t timeout = Z_TIMEOUT_TICKS(ticks);
 	k_spinlock_key_t key = k_spin_lock(&sched_spinlock);
 
 #if defined(CONFIG_TIMESLICING) && defined(CONFIG_SWAP_NONATOMIC)
@@ -1564,6 +1566,9 @@ static int32_t z_tick_sleep(k_ticks_t ticks)
 	if (ticks > 0) {
 		return ticks;
 	}
+#else
+	/* busy wait to be time coherent since subsystems may depend on it */
+	z_impl_k_busy_wait(k_ticks_to_us_ceil32(expected_wakeup_ticks));
 #endif
 
 	return 0;
@@ -1579,8 +1584,12 @@ int32_t z_impl_k_sleep(k_timeout_t timeout)
 
 	/* in case of K_FOREVER, we suspend */
 	if (K_TIMEOUT_EQ(timeout, K_FOREVER)) {
+#ifdef CONFIG_MULTITHREADING
 		k_thread_suspend(_current);
-
+#else
+		/* In Single Thread, just wait for an interrupt saving power */
+		k_cpu_idle();
+#endif
 		SYS_PORT_TRACING_FUNC_EXIT(k_thread, sleep, timeout, (int32_t) K_TICKS_FOREVER);
 
 		return (int32_t) K_TICKS_FOREVER;


### PR DESCRIPTION
The current z_tick_sleep return directly when building kernel for Single Thread model. This reorganize the code and implement a spin lock to wait pass the required ticks.