### PR TITLE
docs: migration-guide-3.5: LPC55XXX Clock Init

### DIFF
--- a/boards/arm/lpcxpresso55s16/doc/index.rst
+++ b/boards/arm/lpcxpresso55s16/doc/index.rst
@@ -139,7 +139,7 @@ System Clock
 ============
 
 The LPC55S16 SoC is configured to use PLL1 clocked from the external 24MHz
-crystal, running at 150MHz as a source for the system clock. When the flash
+crystal, running at 144MHz as a source for the system clock. When the flash
 controller is enabled, the core clock will be reduced to 96MHz. The application
 may reconfigure clocks after initialization, provided that the core clock is
 always set to 96MHz when flash programming operations are performed.

--- a/boards/arm/lpcxpresso55s28/doc/index.rst
+++ b/boards/arm/lpcxpresso55s28/doc/index.rst
@@ -126,7 +126,7 @@ System Clock
 ============
 
 The LPC55S28 SoC is configured to use PLL1 clocked from the external 24MHz
-crystal, running at 150MHz as a source for the system clock. When the flash
+crystal, running at 144MHz as a source for the system clock. When the flash
 controller is enabled, the core clock will be reduced to 96MHz. The application
 may reconfigure clocks after initialization, provided that the core clock is
 always set to 96MHz when flash programming operations are performed.

--- a/boards/arm/lpcxpresso55s36/doc/index.rst
+++ b/boards/arm/lpcxpresso55s36/doc/index.rst
@@ -147,8 +147,9 @@ the functionality of a pin.
 System Clock
 ============
 
-The LPC55S36 SoC is configured to use the internal FRO at 96MHz as a
-source for the system clock. Other sources for the system clock are
+The LPC55S36 SoC is configured to use PLL1 clocked from the external 24MHz
+crystal, running at 144MHz as a source for the system clock. When the flash
+controller is enabled, the core clock will be reduced to 96MHz. Other sources for the system clock are
 provided in the SOC, depending on your system requirements.
 
 Serial Port

--- a/boards/arm/lpcxpresso55s69/doc/index.rst
+++ b/boards/arm/lpcxpresso55s69/doc/index.rst
@@ -257,7 +257,7 @@ System Clock
 ============
 
 The LPC55S69 SoC is configured to use PLL1 clocked from the external 24MHz
-crystal, running at 150MHz as a source for the system clock. When the flash
+crystal, running at 144MHz as a source for the system clock. When the flash
 controller is enabled, the core clock will be reduced to 96MHz. The application
 may reconfigure clocks after initialization, provided that the core clock is
 always set to 96MHz when flash programming operations are performed.

--- a/doc/releases/migration-guide-3.5.rst
+++ b/doc/releases/migration-guide-3.5.rst
@@ -292,6 +292,11 @@ Required changes
 * :c:func:`pm_state_set` and :c:func:`pm_exit_post_ops` are mandatory now
   for any platform supporting power management.
 
+* The LPC55XXX series SOC (except LPC55S06) default main clock has been
+  updated to PLL1 source from XTAL32K running at 144MHZ. If the new
+  kconfig option :kconfig:option:`CONFIG_INIT_PLL1`
+  is disabled then the main clock is muxed to FRO_HR as before.
+
 Recommended Changes
 *******************
 


### PR DESCRIPTION
The inclusion of this note in the migration guide
explains the clocking change that occured in the
LPC55XXX soc as well as the added Kconfig that toggles the PLL1 from being initialized.