### PR TITLE
dts: bindings: Fix NXP USB bindings

### DIFF
--- a/drivers/usb/device/Kconfig
+++ b/drivers/usb/device/Kconfig
@@ -147,7 +147,7 @@ config USB_KINETIS
 config USB_MCUX
 	bool "NXP MCUX USB Device Controller Driver"
 	default y
-	depends on DT_HAS_NXP_MCUX_USBD_ENABLED
+	depends on DT_HAS_NXP_EHCI_ENABLED || DT_HAS_NXP_LPCIP3511_ENABLED
 	help
 	  NXP MCUX USB Device Controller Driver for MXRT and LPC SoC's.
 

--- a/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
@@ -240,11 +240,10 @@
 	};
 
 	usbhs: usbhs@144000 {
-		compatible = "nxp,mcux-usbd";
+		compatible = "nxp,lpcip3511";
 		reg = <0x94000 0x1000>;
 		interrupts = <47 1>;
 		num-bidir-endpoints = <6>;
-		usb-controller-index = "LpcIp3511Hs0";
 		status = "disabled";
 	};
 };

--- a/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
@@ -284,11 +284,10 @@
 	};
 
 	usbhs: usbhs@144000 {
-		compatible = "nxp,mcux-usbd";
+		compatible = "nxp,lpcip3511";
 		reg = <0x94000 0x1000>;
 		interrupts = <47 1>;
 		num-bidir-endpoints = <6>;
-		usb-controller-index = "LpcIp3511Hs0";
 		status = "disabled";
 	};
 };

--- a/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
@@ -443,12 +443,11 @@
 	};
 
 	usbfs: usbfs@84000 {
-		compatible = "nxp,mcux-usbd";
+		compatible = "nxp,lpcip3511";
 		reg = <0x84000 0x1000>;
 		interrupts = <28 0>;
 		num-bidir-endpoints = <5>;
 		maximum-speed = "full-speed";
-		usb-controller-index = "LpcIp3511Fs0";
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
@@ -325,21 +325,19 @@
 	};
 
 	usbfs: usbfs@84000 {
-		compatible = "nxp,mcux-usbd";
+		compatible = "nxp,lpcip3511";
 		reg = <0x84000 0x1000>;
 		interrupts = <28 1>;
 		num-bidir-endpoints = <5>;
 		maximum-speed = "full-speed";
-		usb-controller-index = "LpcIp3511Fs0";
 		status = "disabled";
 	};
 
 	usbhs: usbhs@94000 {
-		compatible = "nxp,mcux-usbd";
+		compatible = "nxp,lpcip3511";
 		reg = <0x94000 0x1000>;
 		interrupts = <47 1>;
 		num-bidir-endpoints = <6>;
-		usb-controller-index = "LpcIp3511Hs0";
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/nxp_rt1010.dtsi
+++ b/dts/arm/nxp/nxp_rt1010.dtsi
@@ -234,13 +234,12 @@
 		/* Fixup USB it has different base addr and interrupt numbers on RT1010 */
 		/delete-node/ usbd@402e0000;
 		usb1: usbd@400e4000 {
-			compatible = "nxp,mcux-usbd";
+			compatible = "nxp,ehci";
 			reg = <0x400e4000 0x200>;
 			interrupts = <25 1>;
 			interrupt-names = "usb_otg";
 			clocks = <&usbclk>;
 			num-bidir-endpoints = <8>;
-			usb-controller-index = "Ehci0";
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/nxp_rt10xx.dtsi
+++ b/dts/arm/nxp/nxp_rt10xx.dtsi
@@ -790,24 +790,22 @@
 		};
 
 		usb1: usbd@402e0000 {
-			compatible = "nxp,mcux-usbd";
+			compatible = "nxp,ehci";
 			reg = <0x402E0000 0x200>;
 			interrupts = <113 1>;
 			interrupt-names = "usb_otg";
 			clocks = <&usbclk>;
 			num-bidir-endpoints = <8>;
-			usb-controller-index = "Ehci0";
 			status = "disabled";
 		};
 
 		usb2: usbd@402e0200 {
-			compatible = "nxp,mcux-usbd";
+			compatible = "nxp,ehci";
 			reg = <0x402E0200 0x200>;
 			interrupts = <112 1>;
 			interrupt-names = "usb_otg";
 			clocks = <&usbclk>;
 			num-bidir-endpoints = <8>;
-			usb-controller-index = "Ehci1";
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -749,24 +749,22 @@
 		};
 
 		usb1: usbd@40430000 {
-			compatible = "nxp,mcux-usbd";
+			compatible = "nxp,ehci";
 			reg = <0x40430000 0x200>;
 			interrupts = <136 1>;
 			interrupt-names = "usb_otg";
 			clocks = <&xtal>;
 			num-bidir-endpoints = <8>;
-			usb-controller-index = "Ehci0";
 			status = "disabled";
 		};
 
 		usb2: usbd@4042c000 {
-			compatible = "nxp,mcux-usbd";
+			compatible = "nxp,ehci";
 			reg = <0x4042c000 0x200>;
 			interrupts = <135 1>;
 			interrupt-names = "usb_otg";
 			clocks = <&xtal>;
 			num-bidir-endpoints = <8>;
-			usb-controller-index = "Ehci1";
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/nxp_rt5xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt5xx_common.dtsi
@@ -338,11 +338,10 @@
 	};
 
 	usbhs: usbhs@144000 {
-		compatible = "nxp,mcux-usbd";
+		compatible = "nxp,lpcip3511";
 		reg = <0x144000 0x1000>;
 		interrupts = <50 1>;
 		num-bidir-endpoints = <6>;
-		usb-controller-index = "LpcIp3511Hs0";
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/nxp_rt6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt6xx_common.dtsi
@@ -259,11 +259,10 @@
 	};
 
 	usbhs: usbhs@144000 {
-		compatible = "nxp,mcux-usbd";
+		compatible = "nxp,lpcip3511";
 		reg = <0x144000 0x1000>;
 		interrupts = <50 1>;
 		num-bidir-endpoints = <6>;
-		usb-controller-index = "LpcIp3511Hs0";
 		status = "disabled";
 	};
 

--- a/dts/bindings/usb/nxp,ehci.yaml
+++ b/dts/bindings/usb/nxp,ehci.yaml
@@ -1,0 +1,8 @@
+# Copyright 2023 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: NXP EHCI USB device mode
+
+compatible: nxp,ehci
+
+include: "nxp,mcux-usbd.yaml"

--- a/dts/bindings/usb/nxp,lpcip3511.yaml
+++ b/dts/bindings/usb/nxp,lpcip3511.yaml
@@ -1,0 +1,8 @@
+# Copyright 2023 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: NXP LPCIP3511 USB device mode
+
+compatible: nxp,lpcip3511
+
+include: "nxp,mcux-usbd.yaml"

--- a/dts/bindings/usb/nxp,mcux-usbd.yaml
+++ b/dts/bindings/usb/nxp,mcux-usbd.yaml
@@ -4,8 +4,6 @@
 description: |
     NPX MXRT and LPC USBOTG Controller in device mode
 
-compatible: "nxp,mcux-usbd"
-
 include: [usb-ep.yaml, pinctrl-device.yaml]
 
 properties:
@@ -14,24 +12,3 @@ properties:
 
   interrupts:
     required: true
-
-  usb-controller-index:
-    required: true
-    type: string
-    description: |
-      This is taken from the usb_controller_index_t enum that is included inside the NXP SDK
-    enum:
-      - "Khci0"
-      - "Khci1"
-      - "Ehci0"
-      - "Ehci1"
-      - "LpcIp3511Fs0"
-      - "LpcIp3511Fs1"
-      - "LpcIp3511Hs0"
-      - "LpcIp3511Hs1"
-      - "Ohci0"
-      - "Ohci1"
-      - "Ip3516Hs0"
-      - "Ip3516Hs1"
-      - "Dwc30"
-      - "Dwc31"

--- a/modules/hal_nxp/usb/usb_device_config.h
+++ b/modules/hal_nxp/usb/usb_device_config.h
@@ -39,7 +39,15 @@
 /* Whether device is self power. 1U supported, 0U not supported */
 #define USB_DEVICE_CONFIG_SELF_POWER (1U)
 
-#define DT_DRV_COMPAT nxp_mcux_usbd
+#define NUM_INSTS DT_NUM_INST_STATUS_OKAY(nxp_ehci) + DT_NUM_INST_STATUS_OKAY(nxp_lpcip3511)
+BUILD_ASSERT(NUM_INSTS <= 1, "Only one USB device supported");
+#if DT_HAS_COMPAT_STATUS_OKAY(nxp_lpcip3511)
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT nxp_lpcip3511
+#elif DT_HAS_COMPAT_STATUS_OKAY(nxp_ehci)
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT nxp_ehci
+#endif
 
 /* Number of endpoints supported */
 #define USB_DEVICE_CONFIG_ENDPOINTS (DT_INST_PROP(0, num_bidir_endpoints))

--- a/soc/arm/nxp_lpc/lpc55xxx/soc.c
+++ b/soc/arm/nxp_lpc/lpc55xxx/soc.c
@@ -217,7 +217,7 @@ static ALWAYS_INLINE void clock_init(void)
 
 #if CONFIG_USB_DC_NXP_LPCIP3511
 
-#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(usbfs), nxp_mcux_usbd, okay)
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(usbfs), nxp_lpcip3511, okay)
 	/*< Turn on USB Phy */
 #if defined(CONFIG_SOC_LPC55S36)
 	POWER_DisablePD(kPDRUNCFG_PD_USBFSPHY);
@@ -248,7 +248,7 @@ static ALWAYS_INLINE void clock_init(void)
 
 #endif /* USB_DEVICE_TYPE_FS */
 
-#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(usbhs), nxp_mcux_usbd, okay)
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(usbhs), nxp_lpcip3511, okay)
 	/* enable usb1 host clock */
 	CLOCK_EnableClock(kCLOCK_Usbh1);
 	/* Put PHY powerdown under software control */


### PR DESCRIPTION
NXP USB bindings were combined into one binding and using a property corresponding to HAL enums which is improper use of devicetree. This PR takes an approach that is uglier in the driver but that is more in line with how DT should be used. 

Fixes #50506. 