### PR TITLE
doc: Releases page cleanup

### DIFF
--- a/doc/releases/eol_releases.rst
+++ b/doc/releases/eol_releases.rst
@@ -1,0 +1,14 @@
+End-of-life releases
+====================
+
+Release notes for end-of-life releases of Zephyr RTOS are kept here for historical purposes.
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+   :reversed:
+
+   release-notes-1.?
+   release-notes-1.*
+   release-notes-2.[0-6]
+   release-notes-3.[0-2]

--- a/doc/releases/index.rst
+++ b/doc/releases/index.rst
@@ -74,20 +74,14 @@ so with the help of west.
 The project's technical documentation is also tagged to correspond with a
 specific release and can be found at https://docs.zephyrproject.org/.
 
-.. comment We need to split the globbing of release notes to get the
-   single-digit and double-digit subversions sorted correctly.  Specify
-   names in normal order and use the :reversed: option to reverse it.
-   This will get us through 10 subversions (0-9) before we need to
-   update this list for two-digit subversions again.
-
 .. toctree::
    :maxdepth: 1
    :glob:
    :reversed:
 
-   release-notes-1.?
-   release-notes-1.*
-   release-notes-*
+   eol_releases
+   release-notes-2.7
+   release-notes-3.[3-5]
 
 Migration Guides
 ****************

--- a/doc/releases/index.rst
+++ b/doc/releases/index.rst
@@ -3,11 +3,17 @@
 Releases
 ########
 
-Zephyr project is provided as source code and build scripts for different
-target architectures and configurations, and not as a binary image. Updated
-versions of the Zephyr project are released approximately every four months.
+Zephyr project is provided as source code and build scripts for different target
+architectures and configurations, and not as a binary image. Updated versions of
+the Zephyr project are released approximately every four months.
 
-All Zephyr project source code is maintained in a `GitHub repository`_.
+All Zephyr project source code is maintained in a `GitHub repository`_. In order
+to use a released version of the Zephyr project, it is recommended that you use
+:ref:`west` to :ref:`get_the_code` of the release you are interested in.
+
+The technical documentation for current and past releases is available at
+https://docs.zephyrproject.org/ (use the version selector to select your release
+of interest).
 
 Release Life Cycle and Maintenance
 **********************************
@@ -61,18 +67,6 @@ As of 2022-01-01, LTS1 (1.14.x) is not supported and has reached end of life (EO
 
 Release Notes
 *************
-
-For Zephyr versions up to 1.13, you can either download source as a tar.gz file
-(see the bottom of the `GitHub tagged releases`_ page corresponding to each
-release), or clone the GitHub repository.
-
-With the introduction of the :ref:`west` tool after the release of Zephyr 1.13,
-it is no longer recommended to download or clone the source code manually.
-Instead we recommend you follow the instructions in :ref:`get_the_code` to do
-so with the help of west.
-
-The project's technical documentation is also tagged to correspond with a
-specific release and can be found at https://docs.zephyrproject.org/.
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
**📄 CI-built doc version: https://builds.zephyrproject.io/zephyr/pr/64003/docs/releases/index.html**

The ever growing list of release notes for past releases was making it too easy to miss the migration guide for the latest release. This commit moves the release notes for EOL releases to a dedicated page.

Also cleaned up and moved some outdated bits from the release notes section to the actual intro.

I might work on a future update to add some kind of Sphinx magic to allow maintaining the list of active/supported releases in only one place, and then automatically generate things like the table of currently supported releases, list of release notes for current vs. past releases etc. 