### PR TITLE
i3c_mcux changes

### DIFF
--- a/drivers/i3c/i3c_mcux.c
+++ b/drivers/i3c/i3c_mcux.c
@@ -539,9 +539,6 @@ static inline void mcux_i3c_request_daa(I3C_Type *base)
 /**
  * @brief Tell controller to start auto IBI.
  *
- * This also waits for the controller to indicate auto IBI
- * has started before returning.
- *
  * @param base Pointer to controller registers.
  */
 static inline void mcux_i3c_request_auto_ibi(I3C_Type *base)
@@ -549,8 +546,6 @@ static inline void mcux_i3c_request_auto_ibi(I3C_Type *base)
 	reg32_update(&base->MCTRL,
 		     I3C_MCTRL_REQUEST_MASK | I3C_MCTRL_IBIRESP_MASK | I3C_MCTRL_RDTERM_MASK,
 		     I3C_MCTRL_REQUEST_AUTO_IBI | I3C_MCTRL_IBIRESP_ACK_AUTO);
-
-	mcux_i3c_status_wait_clear(base, I3C_MSTATUS_MCTRLDONE_MASK);
 }
 
 /**

--- a/drivers/i3c/i3c_mcux.c
+++ b/drivers/i3c/i3c_mcux.c
@@ -81,6 +81,9 @@ struct mcux_i3c_config {
 
 	/** Interrupt configuration function. */
 	void (*irq_config_func)(const struct device *dev);
+
+	/** Disable open drain high push pull */
+	bool disable_open_drain_high_pp;
 };
 
 struct mcux_i3c_data {
@@ -1847,6 +1850,7 @@ static int mcux_i3c_configure(const struct device *dev,
 
 	master_config.baudRate_Hz.i2cBaud = ctrl_cfg->scl.i2c;
 	master_config.baudRate_Hz.i3cPushPullBaud = ctrl_cfg->scl.i3c;
+	master_config.enableOpenDrainHigh = dev_cfg->disable_open_drain_high_pp ? false : true;
 
 	if (dev_data->clocks.i3c_od_scl_hz) {
 		master_config.baudRate_Hz.i3cOpenDrainBaud = dev_data->clocks.i3c_od_scl_hz;
@@ -2090,6 +2094,8 @@ static const struct i3c_driver_api mcux_i3c_driver_api = {
 		.common.dev_list.i2c = mcux_i3c_i2c_device_array_##id,			\
 		.common.dev_list.num_i2c = ARRAY_SIZE(mcux_i3c_i2c_device_array_##id),	\
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(id),			\
+		.disable_open_drain_high_pp =					\
+			DT_INST_PROP_OR(id, disable_open_drain_high_pp, false), \
 	};									\
 	static struct mcux_i3c_data mcux_i3c_data_##id = {			\
 		.clocks.i3c_od_scl_hz = DT_INST_PROP_OR(id, i3c_od_scl_hz, 0),	\

--- a/drivers/i3c/i3c_mcux.c
+++ b/drivers/i3c/i3c_mcux.c
@@ -879,9 +879,7 @@ static int mcux_i3c_recover_bus(const struct device *dev)
  */
 static int mcux_i3c_do_one_xfer_read(I3C_Type *base, uint8_t *buf, uint8_t buf_sz)
 {
-	int rx_count;
 	bool completed = false;
-	bool overflow = false;
 	int ret = 0;
 	int offset = 0;
 
@@ -908,28 +906,19 @@ static int mcux_i3c_do_one_xfer_read(I3C_Type *base, uint8_t *buf, uint8_t buf_s
 		}
 
 		/*
-		 * Transfer data from FIFO into buffer.
+		 * Transfer data from FIFO into buffer. Read
+		 * in a tight loop to reduce chance of losing
+		 * FIFO data when the i3c speed is high.
 		 */
-		rx_count = mcux_i3c_fifo_rx_count_get(base);
-		while (rx_count > 0) {
-			uint8_t data = (uint8_t)base->MRDATAB;
-
-			if (offset < buf_sz) {
-				buf[offset] = data;
-				offset += 1;
-			} else {
-				overflow = true;
+		while (offset < buf_sz) {
+			if (mcux_i3c_fifo_rx_count_get(base) == 0) {
+				break;
 			}
-
-			rx_count -= 1;
+			buf[offset++] = (uint8_t)base->MRDATAB;
 		}
 	}
 
-	if (overflow) {
-		ret = -EINVAL;
-	} else {
-		ret = offset;
-	}
+	ret = offset;
 
 one_xfer_read_out:
 	return ret;

--- a/dts/bindings/i3c/nxp,mcux-i3c.yaml
+++ b/dts/bindings/i3c/nxp,mcux-i3c.yaml
@@ -36,3 +36,12 @@ properties:
     type: int
     description: Slow clock divider for I3C
     required: true
+
+  disable-open-drain-high-pp:
+    type: boolean
+    description: |
+      If false, open drain high time is 1 PPBAUD count,
+      which is short high and long low.
+      If true, open drain high time is same as ODBAUD
+      so that open drain clock is 50% duty cycle.
+      Default is false.


### PR DESCRIPTION
Three changes to i3c_mcux:
1) fix config_get() not returning last configured speeds
2) send 7h7e at start of each i3c transfer, unless flags say not to. makes i3c_mcux consistent with i3c_cdns.c
3) tighten the FIFO read loop to reduce occurrence of hangs when i3c speed is high