### PR TITLE
doc: Improves "Resources" section of README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,8 +66,6 @@ Here's a quick summary of resources to help you find your way around:
   respectively. You can join the developer's list and search its archives at
   `Zephyr Development mailing list`_. The other `Zephyr mailing list
   subgroups`_ have their own archives and sign-up pages.
-* **Nightly CI Build Status**: https://lists.zephyrproject.org/g/builds
-  The builds@lists.zephyrproject.org mailing list archives the CI nightly build results.
 * **Chat**: Real-time chat happens in Zephyr's Discord Server. Use
   this `Discord Invite`_ to register.
 * **Contributing**: see the `Contribution Guide`_

--- a/README.rst
+++ b/README.rst
@@ -54,37 +54,59 @@ Resources
 
 Here's a quick summary of resources to help you find your way around:
 
-* **Help**: `Asking for Help Tips`_
-* **Documentation**: http://docs.zephyrproject.org (`Getting Started Guide`_)
-* **Source Code**: https://github.com/zephyrproject-rtos/zephyr is the main
-  repository; https://elixir.bootlin.com/zephyr/latest/source contains a
-  searchable index
-* **Releases**: https://github.com/zephyrproject-rtos/zephyr/releases
-* **Samples and example code**: see `Sample and Demo Code Examples`_
-* **Mailing Lists**: users@lists.zephyrproject.org and
-  devel@lists.zephyrproject.org are the main user and developer mailing lists,
-  respectively. You can join the developer's list and search its archives at
-  `Zephyr Development mailing list`_. The other `Zephyr mailing list
-  subgroups`_ have their own archives and sign-up pages.
-* **Chat**: Real-time chat happens in Zephyr's Discord Server. Use
-  this `Discord Invite`_ to register.
-* **Contributing**: see the `Contribution Guide`_
-* **Wiki**: `Zephyr GitHub wiki`_
-* **Issues**: https://github.com/zephyrproject-rtos/zephyr/issues
-* **Security Issues**: Email vulnerabilities@zephyrproject.org to report
-  security issues; also see our `Security`_ documentation. Security issues are
-  tracked separately at https://zephyrprojectsec.atlassian.net.
-* **Zephyr Project Website**: https://zephyrproject.org
+Getting Started
+---------------
 
-.. _Discord Invite: https://chat.zephyrproject.org
-.. _supported boards: http://docs.zephyrproject.org/latest/boards/index.html
-.. _Zephyr Documentation: http://docs.zephyrproject.org
-.. _Introduction to Zephyr: http://docs.zephyrproject.org/latest/introduction/index.html
-.. _Getting Started Guide: http://docs.zephyrproject.org/latest/develop/getting_started/index.html
-.. _Contribution Guide: http://docs.zephyrproject.org/latest/contribute/index.html
-.. _Zephyr GitHub wiki: https://github.com/zephyrproject-rtos/zephyr/wiki
-.. _Zephyr Development mailing list: https://lists.zephyrproject.org/g/devel
-.. _Zephyr mailing list subgroups: https://lists.zephyrproject.org/g/main/subgroups
-.. _Sample and Demo Code Examples: http://docs.zephyrproject.org/latest/samples/index.html
-.. _Security: http://docs.zephyrproject.org/latest/security/index.html
-.. _Asking for Help Tips: https://docs.zephyrproject.org/latest/develop/getting_started/index.html#asking-for-help
+  | 📖 `Zephyr Documentation`_
+  | 🚀 `Getting Started Guide`_
+  | 🙋🏽 `Tips when asking for help`_
+  | 💻 `Code samples`_
+
+Code and Development
+--------------------
+
+  | 🌐 `Source Code Repository`_
+  | 📦 `Releases`_
+  | 🤝 `Contribution Guide`_
+
+Community and Support
+---------------------
+
+  | 💬 `Discord Server`_ for real-time community discussions
+  | 📧 `User mailing list (users@lists.zephyrproject.org)`_
+  | 📧 `Developer mailing list (devel@lists.zephyrproject.org)`_
+  | 📬 `Other project mailing lists`_
+  | 📚 `Project Wiki`_
+
+Issue Tracking and Security
+---------------------------
+
+  | 🐛 `GitHub Issues`_
+  | 🔒 `Security documentation`_
+  | 🛡️ `Security Advisories Repository`_
+  | ⚠️ Report security vulnerabilities at vulnerabilities@zephyrproject.org
+
+Additional Resources
+--------------------
+  | 🌐 `Zephyr Project Website`_
+  | 📺 `Zephyr Tech Talks`_
+
+.. _Zephyr Project Website: https://www.zephyrproject.org
+.. _Discord Server: https://chat.zephyrproject.org
+.. _supported boards: https://docs.zephyrproject.org/latest/boards/index.html
+.. _Zephyr Documentation: https://docs.zephyrproject.org
+.. _Introduction to Zephyr: https://docs.zephyrproject.org/latest/introduction/index.html
+.. _Getting Started Guide: https://docs.zephyrproject.org/latest/develop/getting_started/index.html
+.. _Contribution Guide: https://docs.zephyrproject.org/latest/contribute/index.html
+.. _Source Code Repository: https://github.com/zephyrproject-rtos/zephyr
+.. _GitHub Issues: https://github.com/zephyrproject-rtos/zephyr/issues
+.. _Releases: https://github.com/zephyrproject-rtos/zephyr/releases
+.. _Project Wiki: https://github.com/zephyrproject-rtos/zephyr/wiki
+.. _User mailing list (users@lists.zephyrproject.org): https://lists.zephyrproject.org/g/users
+.. _Developer mailing list (devel@lists.zephyrproject.org): https://lists.zephyrproject.org/g/devel
+.. _Other project mailing lists: https://lists.zephyrproject.org/g/main/subgroups
+.. _Code samples: https://docs.zephyrproject.org/latest/samples/index.html
+.. _Security documentation: https://docs.zephyrproject.org/latest/security/index.html
+.. _Security Advisories Repository: https://github.com/zephyrproject-rtos/zephyr/security
+.. _Tips when asking for help: https://docs.zephyrproject.org/latest/develop/getting_started/index.html#asking-for-help
+.. _Zephyr Tech Talks: https://www.zephyrproject.org/tech-talks

--- a/doc/introduction/index.rst
+++ b/doc/introduction/index.rst
@@ -9,6 +9,7 @@ sensors and LED wearables to sophisticated embedded controllers, smart
 watches, and IoT wireless applications.
 
 The Zephyr kernel supports multiple architectures, including:
+
  - ARCv2 (EM and HS) and ARCv3 (HS6X)
  - ARMv6-M, ARMv7-M, and ARMv8-M (Cortex-M)
  - ARMv7-A and ARMv8-A (Cortex-A, 32- and 64-bit)


### PR DESCRIPTION
> [New version of the README](https://github.com/zephyrproject-rtos/zephyr/blob/eb23e5809825cced2af6a117b109f4c8bf0569e5/README.rst#resources)
> [New version of the README when re-embedded in the Introduction doc page](https://builds.zephyrproject.io/zephyr/pr/64007/docs/introduction/index.html#resources) 

With close to 20 different links, the Resources section was not really easy to navigate, defeating the intended purpose of providing quick access to information.
Reworked the section to break it down into sub sections, and reworded the links to make them self explanatory. 
I don't have a strong opinion on the use of emojis but I feel they are doing a good job at having the still somewhat lengthy/initimidating list of pointers feel slightly less so. Each sub-section has been re-ordered so that most important links appear first.

Also removed stale mention and link to nightly builds.