### PR TITLE
soc: npcx: add HAS_PM to npcx4

### DIFF
--- a/soc/arm/nuvoton_npcx/npcx4/Kconfig.series
+++ b/soc/arm/nuvoton_npcx/npcx4/Kconfig.series
@@ -11,5 +11,6 @@ config SOC_SERIES_NPCX4
 	select CPU_HAS_FPU
 	select CPU_HAS_ARM_MPU
 	select SOC_FAMILY_NPCX
+	select HAS_PM
 	help
 	  Enable support for Nuvoton NPCX4 series


### PR DESCRIPTION
The Kconfig option HAS_PM, which must be needed for SoCs providing PM hooks, is missing in npcx4.
This commit adds it to soc/arm/nuvoton_npcx/npcx4/Kconfig.series.