### PR TITLE
manifest: update hal_nordic revision to fix nrfx_gpiote for nRF52820

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -186,7 +186,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: d054a315eb888ba70e09e5f6decd4097b0276d1f
+      revision: pull/148/head
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
New hal_nordic revision contains updated nrfx
with a fix to GPIOTE driver array out-of-bounds
access on nRF52820.