### PR TITLE
Revert "samples: hello_world: use printf" (fixes: hello_world support for USB CDC devices)

### DIFF
--- a/samples/hello_world/src/main.c
+++ b/samples/hello_world/src/main.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <stdio.h>
+#include <zephyr/kernel.h>
 
 int main(void)
 {
-	printf("Hello World! %s\n", CONFIG_BOARD);
+	printk("Hello World! %s\n", CONFIG_BOARD);
 	return 0;
 }


### PR DESCRIPTION
This reverts commit f623fcf3987cb35d73e1e5537822da5af865269f.

Fixes #64023

See linked bug for details