### PR TITLE
drivers: modem: introducing config for cereg/creg for gsm

### DIFF
--- a/drivers/modem/Kconfig.gsm
+++ b/drivers/modem/Kconfig.gsm
@@ -37,6 +37,25 @@ config MODEM_GSM_QUECTEL
 
 endchoice
 
+choice MODEM_GSM_STATUS_COMMAND
+	prompt "Select status command Type"
+	default MODEM_GSM_STATUS_CMD_USE_CREG
+	help
+	  Use particular type of AT command for cell tower registration status.
+
+config MODEM_GSM_STATUS_CMD_USE_CREG
+	bool "CREG command"
+
+config MODEM_GSM_STATUS_CMD_USE_CEREG
+	bool "CEREG command"
+
+endchoice
+
+config MODEM_GSM_STATUS_COMMAND
+	string "Status Command"
+	default "CREG" if MODEM_GSM_STATUS_CMD_USE_CREG
+	default "CEREG" if MODEM_GSM_STATUS_CMD_USE_CEREG
+
 config MODEM_GSM_RX_STACK_SIZE
 	int "Size of the stack allocated for receiving data from modem"
 	default 512

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -525,7 +525,7 @@ static const struct modem_cmd read_cops_cmd =
 	MODEM_CMD_ARGS_MAX("+COPS:", on_cmd_atcmdinfo_cops, 1U, 4U, ",");
 
 static const struct modem_cmd check_net_reg_cmd =
-	MODEM_CMD("+CREG: ", on_cmd_net_reg_sts, 2U, ",");
+	MODEM_CMD("+" CONFIG_MODEM_GSM_STATUS_COMMAND, on_cmd_net_reg_sts, 2U, ",");
 
 static const struct modem_cmd check_attached_cmd =
 	MODEM_CMD("+CGATT:", on_cmd_atcmdinfo_attached, 1U, ",");
@@ -751,7 +751,7 @@ registering:
 	ret = modem_cmd_send_nolock(&gsm->context.iface,
 				    &gsm->context.cmd_handler,
 				    &check_net_reg_cmd, 1,
-				    "AT+CREG?",
+				    "AT+" CONFIG_MODEM_GSM_STATUS_COMMAND "?",
 				    &gsm->sem_response,
 				    GSM_CMD_SETUP_TIMEOUT);
 	if ((ret < 0) || ((gsm->net_state != GSM_NET_ROAMING) &&


### PR DESCRIPTION
This contribution addresses the support for various types of modems in gsm driver. As some 4G modems have failed to return correct output from AT+CREG?, so AT+CEREG? is the right AT command in such situation. This commit provides the possibility for user to select one type of AT command. This PR fixes zephyrproject-rtos#63917

Supersede #63769