### PR TITLE
net: tcp: Send RST reply for unexpected TCP packets 

### DIFF
--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -564,6 +564,13 @@ config NET_TCP_WORKER_PRIO
 	  execution to the lower layer network stack, with a high risk of
 	  running out of net_bufs.
 
+config NET_TCP_REJECT_CONN_WITH_RST
+	bool "Reject connection attempts on unbound TCP ports with RST"
+	default y
+	help
+	  If enabled, TCP stack will reject connection attempts on unbound ports
+	  with TCP RST packet.
+
 config NET_TEST_PROTOCOL
 	bool "JSON based test protocol (UDP)"
 	help

--- a/subsys/net/ip/connection.c
+++ b/subsys/net/ip/connection.c
@@ -828,7 +828,8 @@ enum net_verdict net_conn_input(struct net_pkt *pkt,
 
 	if (IS_ENABLED(CONFIG_NET_IP) && (pkt_family == AF_INET || pkt_family == AF_INET6) &&
 	    !(is_mcast_pkt || is_bcast_pkt)) {
-		if (IS_ENABLED(CONFIG_NET_TCP) && proto == IPPROTO_TCP) {
+		if (IS_ENABLED(CONFIG_NET_TCP) && proto == IPPROTO_TCP &&
+		    IS_ENABLED(CONFIG_NET_TCP_REJECT_CONN_WITH_RST)) {
 			net_tcp_reply_rst(pkt);
 			net_stats_update_tcp_seg_connrst(pkt_iface);
 		} else {

--- a/subsys/net/ip/connection.c
+++ b/subsys/net/ip/connection.c
@@ -828,10 +828,11 @@ enum net_verdict net_conn_input(struct net_pkt *pkt,
 
 	if (IS_ENABLED(CONFIG_NET_IP) && (pkt_family == AF_INET || pkt_family == AF_INET6) &&
 	    !(is_mcast_pkt || is_bcast_pkt)) {
-		conn_send_icmp_error(pkt);
-
 		if (IS_ENABLED(CONFIG_NET_TCP) && proto == IPPROTO_TCP) {
+			net_tcp_reply_rst(pkt);
 			net_stats_update_tcp_seg_connrst(pkt_iface);
+		} else {
+			conn_send_icmp_error(pkt);
 		}
 	}
 

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -1859,6 +1859,8 @@ static enum net_verdict tcp_recv(struct net_conn *net_conn,
  in:
 	if (conn) {
 		verdict = tcp_in(conn, pkt);
+	} else {
+		net_tcp_reply_rst(pkt);
 	}
 
 	return verdict;
@@ -2585,7 +2587,10 @@ next_state:
 			 * priority.
 			 */
 			connection_ok = true;
+		} else if (pkt) {
+			net_tcp_reply_rst(pkt);
 		}
+
 		break;
 	case TCP_ESTABLISHED:
 		/* full-close */

--- a/subsys/net/ip/tcp_internal.h
+++ b/subsys/net/ip/tcp_internal.h
@@ -423,6 +423,20 @@ struct k_sem *net_tcp_tx_sem_get(struct net_context *context);
  */
 struct k_sem *net_tcp_conn_sem_get(struct net_context *context);
 
+/**
+ * @brief Send a TCP RST reply for the received packet w/o associated connection.
+ *
+ * @param pkt TCP packet to reply for.
+ */
+#if defined(CONFIG_NET_NATIVE_TCP)
+void net_tcp_reply_rst(struct net_pkt *pkt);
+#else
+static inline void net_tcp_reply_rst(struct net_pkt *pkt)
+{
+	ARG_UNUSED(pkt);
+}
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/net/ip/tcp_private.h
+++ b/subsys/net/ip/tcp_private.h
@@ -98,6 +98,23 @@
 	_pkt;								\
 })
 
+#define tcp_pkt_alloc_no_conn(_iface, _family, _len)			\
+({									\
+	struct net_pkt *_pkt;						\
+									\
+	if ((_len) > 0) {						\
+		_pkt = net_pkt_alloc_with_buffer(			\
+			(_iface), (_len), (_family),			\
+			IPPROTO_TCP,					\
+			TCP_PKT_ALLOC_TIMEOUT);				\
+	} else {							\
+		_pkt = net_pkt_alloc(TCP_PKT_ALLOC_TIMEOUT);		\
+	}								\
+									\
+	tp_pkt_alloc(_pkt, tp_basename(__FILE__), __LINE__);		\
+									\
+	_pkt;								\
+})
 
 #if defined(CONFIG_NET_TEST_PROTOCOL)
 #define conn_seq(_conn, _req) \

--- a/tests/lib/thrift/ThriftTest/prj.conf
+++ b/tests/lib/thrift/ThriftTest/prj.conf
@@ -23,6 +23,7 @@ CONFIG_TEST_RANDOM_GENERATOR=y
 CONFIG_NET_TEST=y
 CONFIG_NET_DRIVERS=y
 CONFIG_NET_LOOPBACK=y
+CONFIG_NET_TCP_TIME_WAIT_DELAY=100
 
 # Some platforms require relatively large stack sizes.
 # This can be tuned per-board.

--- a/tests/lib/thrift/ThriftTest/src/main.cpp
+++ b/tests/lib/thrift/ThriftTest/src/main.cpp
@@ -141,6 +141,9 @@ static void thrift_test_before(void *data)
 	rv = pthread_create(&context.server_thread, attrp, server_func, nullptr);
 	zassert_equal(0, rv, "pthread_create failed: %d", rv);
 
+	/* Give the server thread a chance to start and prepare the socket */
+	k_msleep(50);
+
 	// set up client
 	context.client = setup_client();
 }
@@ -160,6 +163,8 @@ static void thrift_test_after(void *data)
 
 	context.client.reset();
 	context.server.reset();
+
+	k_msleep(CONFIG_NET_TCP_TIME_WAIT_DELAY);
 }
 
 ZTEST_SUITE(thrift, NULL, thrift_test_setup, thrift_test_before, thrift_test_after, NULL);

--- a/tests/net/tcp/src/main.c
+++ b/tests/net/tcp/src/main.c
@@ -111,7 +111,8 @@ enum test_state {
 	T_FIN_ACK,
 	T_FIN_1,
 	T_FIN_2,
-	T_CLOSING
+	T_CLOSING,
+	T_RST,
 };
 
 static enum test_state t_state;
@@ -130,6 +131,9 @@ static void handle_client_closing_test(sa_family_t af, struct tcphdr *th);
 static void handle_data_fin1_test(sa_family_t af, struct tcphdr *th);
 static void handle_data_during_fin1_test(sa_family_t af, struct tcphdr *th);
 static void handle_server_recv_out_of_order(struct net_pkt *pkt);
+static void handle_server_rst_on_closed_port(sa_family_t af, struct tcphdr *th);
+static void handle_server_rst_on_listening_port(sa_family_t af, struct tcphdr *th);
+static void handle_syn_invalid_ack(sa_family_t af, struct tcphdr *th);
 
 static void verify_flags(struct tcphdr *th, uint8_t flags,
 			 const char *fun, int line)
@@ -375,6 +379,15 @@ static struct net_pkt *prepare_rst_packet(sa_family_t af, uint16_t src_port,
 	return tester_prepare_tcp_pkt(af, src_port, dst_port, RST, NULL, 0U);
 }
 
+static bool is_icmp_pkt(struct net_pkt *pkt)
+{
+	if (net_pkt_family(pkt) == AF_INET) {
+		return NET_IPV4_HDR(pkt)->proto == IPPROTO_ICMP;
+	} else {
+		return NET_IPV6_HDR(pkt)->nexthdr == IPPROTO_ICMPV6;
+	}
+}
+
 static int read_tcp_header(struct net_pkt *pkt, struct tcphdr *th)
 {
 	int ret;
@@ -404,6 +417,11 @@ static int tester_send(const struct device *dev, struct net_pkt *pkt)
 {
 	struct tcphdr th;
 	int ret;
+
+	/* Ignore ICMP explicitly */
+	if (is_icmp_pkt(pkt)) {
+		return 0;
+	}
 
 	ret = read_tcp_header(pkt, &th);
 	if (ret < 0) {
@@ -441,6 +459,16 @@ static int tester_send(const struct device *dev, struct net_pkt *pkt)
 	case 12:
 		handle_syn_rst_ack(net_pkt_family(pkt), &th);
 		break;
+	case 13:
+		handle_server_rst_on_closed_port(net_pkt_family(pkt), &th);
+		break;
+	case 14:
+		handle_server_rst_on_listening_port(net_pkt_family(pkt), &th);
+		break;
+	case 15:
+		handle_syn_invalid_ack(net_pkt_family(pkt), &th);
+		break;
+
 	default:
 		zassert_true(false, "Undefined test case");
 	}
@@ -714,7 +742,8 @@ fail:
 
 static void test_server_timeout(struct k_work *work)
 {
-	if (test_case_no == 3 || test_case_no == 4) {
+	if (test_case_no == 3 || test_case_no == 4 || test_case_no == 13 ||
+	    test_case_no == 14) {
 		handle_server_test(AF_INET, NULL);
 	} else if (test_case_no == 5) {
 		handle_server_test(AF_INET6, NULL);
@@ -1882,6 +1911,220 @@ ZTEST(net_tcp, test_server_out_of_order_data)
 {
 	test_server_recv_out_of_order_data();
 	test_server_timeout_out_of_order_data();
+}
+
+static void handle_server_rst_on_closed_port(sa_family_t af, struct tcphdr *th)
+{
+	switch (t_state) {
+	case T_SYN_ACK:
+		/* Port was closed so expect RST instead of SYN */
+		test_verify_flags(th, RST | ACK);
+		zassert_equal(ntohl(th->th_seq), 0, "Invalid SEQ value");
+		zassert_equal(ntohl(th->th_ack), seq, "Invalid ACK value");
+		t_state = T_CLOSING;
+		test_sem_give();
+		break;
+	default:
+		return;
+	}
+}
+
+/* Test case scenario
+ *   Send SYN
+ *   expect RST ACK (closed port)
+ *   any failures cause test case to fail.
+ */
+ZTEST(net_tcp, test_server_rst_on_closed_port)
+{
+	t_state = T_SYN;
+	test_case_no = 13;
+	seq = ack = 0;
+
+	k_sem_reset(&test_sem);
+
+	/* Trigger the peer to send SYN */
+	k_work_reschedule(&test_server, K_NO_WAIT);
+
+	/* Peer will release the semaphore after it receives RST */
+	test_sem_take(K_MSEC(100), __LINE__);
+}
+
+static void handle_server_rst_on_listening_port(sa_family_t af, struct tcphdr *th)
+{
+	switch (t_state) {
+	case T_DATA_ACK:
+		/* No active connection so expect RST instead of ACK */
+		test_verify_flags(th, RST);
+		zassert_equal(ntohl(th->th_seq), ack, "Invalid SEQ value");
+		t_state = T_CLOSING;
+		test_sem_give();
+		break;
+	default:
+		return;
+	}
+}
+
+static void dummy_accept_cb(struct net_context *ctx, struct sockaddr *addr,
+			    socklen_t addrlen, int status, void *user_data)
+{
+	/* Should not ever be called. */
+	zassert_unreachable("Should not have called dummy accept cb");
+}
+
+/* Test case scenario
+ *   Open listening port
+ *   Send DATA packet to the listening port
+ *   expect RST (no matching connection)
+ *   any failures cause test case to fail.
+ */
+ZTEST(net_tcp, test_server_rst_on_listening_port_no_active_connection)
+{
+	struct net_context *ctx;
+	int ret;
+
+	t_state = T_DATA;
+	test_case_no = 14;
+	seq = ack = 200;
+
+	k_sem_reset(&test_sem);
+
+	ret = net_context_get(AF_INET, SOCK_STREAM, IPPROTO_TCP, &ctx);
+	if (ret < 0) {
+		zassert_true(false, "Failed to get net_context");
+	}
+
+	net_context_ref(ctx);
+
+	ret = net_context_bind(ctx, (struct sockaddr *)&my_addr_s,
+			       sizeof(struct sockaddr_in));
+	if (ret < 0) {
+		zassert_true(false, "Failed to bind net_context");
+	}
+
+	ret = net_context_listen(ctx, 1);
+	if (ret < 0) {
+		zassert_true(false, "Failed to listen on net_context");
+	}
+
+	ret = net_context_accept(ctx, dummy_accept_cb, K_NO_WAIT, NULL);
+	if (ret < 0) {
+		zassert_true(false, "Failed to set accept on net_context");
+	}
+
+	/* Trigger the peer to send data to the listening port w/o active connection */
+	k_work_reschedule(&test_server, K_NO_WAIT);
+
+	/* Peer will release the semaphore after it receives RST */
+	test_sem_take(K_MSEC(100), __LINE__);
+
+	net_context_put(ctx);
+}
+
+/* Test case scenario
+ *   Expect SYN
+ *   Send ACK (wrong ACK number),
+ *   expect RST,
+ *   expect SYN (retransmission),
+ *   send SYN ACK,
+ *   expect ACK (handshake success),
+ *   expect FIN,
+ *   send FIN ACK,
+ *   expect ACK.
+ *   any failures cause test case to fail.
+ */
+static void handle_syn_invalid_ack(sa_family_t af, struct tcphdr *th)
+{
+	static bool invalid_ack = true;
+	struct net_pkt *reply;
+	int ret;
+
+
+	switch (t_state) {
+	case T_SYN:
+		test_verify_flags(th, SYN);
+		if (invalid_ack) {
+			ack = ntohl(th->th_seq) + 1000U;
+			reply = prepare_ack_packet(af, htons(MY_PORT),
+						   th->th_sport);
+			/* Expect RST now. */
+			t_state = T_RST;
+			invalid_ack = false;
+		} else {
+			ack = ntohl(th->th_seq) + 1U;
+			reply = prepare_syn_ack_packet(af, htons(MY_PORT),
+						       th->th_sport);
+			/* Proceed with the handshake on second attempt. */
+			t_state = T_SYN_ACK;
+		}
+
+		break;
+	case T_SYN_ACK:
+		test_verify_flags(th, ACK);
+		/* connection is successful */
+		t_state = T_FIN;
+		return;
+	case T_FIN:
+		test_verify_flags(th, FIN | ACK);
+		seq++;
+		ack++;
+		t_state = T_FIN_ACK;
+		reply = prepare_fin_ack_packet(af, htons(MY_PORT),
+					       th->th_sport);
+		break;
+	case T_FIN_ACK:
+		test_verify_flags(th, ACK);
+		test_sem_give();
+		return;
+	case T_RST:
+		test_verify_flags(th, RST);
+		zassert_equal(ntohl(th->th_seq), ack, "Invalid SEQ value");
+
+		/* Wait for SYN retransmission. */
+		t_state = T_SYN;
+		return;
+	default:
+		return;
+	}
+
+	ret = net_recv_data(net_iface, reply);
+	if (ret < 0) {
+		goto fail;
+	}
+
+	return;
+fail:
+	zassert_true(false, "%s failed", __func__);
+}
+
+ZTEST(net_tcp, test_client_rst_on_unexpected_ack_on_syn)
+{
+	struct net_context *ctx;
+	int ret;
+
+	t_state = T_SYN;
+	test_case_no = 15;
+	seq = ack = 0;
+
+	ret = net_context_get(AF_INET, SOCK_STREAM, IPPROTO_TCP, &ctx);
+	if (ret < 0) {
+		zassert_true(false, "Failed to get net_context");
+	}
+
+	net_context_ref(ctx);
+
+	ret = net_context_connect(ctx, (struct sockaddr *)&peer_addr_s,
+				  sizeof(struct sockaddr_in),
+				  NULL, K_MSEC(1000), NULL);
+
+	zassert_equal(ret, 0, "Connect failed");
+	zassert_equal(net_context_get_state(ctx), NET_CONTEXT_CONNECTED,
+			  "Context should be connected");
+
+	/* Just wait for the connection teardown. */
+	net_context_put(ctx);
+
+	/* Peer will release the semaphore after it receives final ACK */
+	test_sem_take(K_MSEC(100), __LINE__);
 }
 
 ZTEST_SUITE(net_tcp, NULL, presetup, NULL, NULL, NULL);


### PR DESCRIPTION
This PR improves the handling of unexpected packets within Zephyr's TCP stack. The TCP stack will now send RST packet in a response to unexpected TCP packets, to address issues mostly related to ungraceful TCP connection shutdown (for example due to reboot):
1) Invalid ACK value received during handshake (connection still open
   on the peer side),
2) Unexpected data packet on a listening port (accepted connection
   closed),
3) SYN received on a closed port.

For this, a new helper function was introduced which allows to send an RST packet to **any** destination (current functions allow only to send TCP packets to destinations associated with a TCP connection context, which is not always the case in this scenario).

Finally, add a few new tests to cover this functionality.

Fixes #63966