### PR TITLE
Bluetooth: Mesh: Allow to set the extension list size to zero

### DIFF
--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -1399,7 +1399,7 @@ config BT_MESH_COMP_PAGE_2
 config BT_MESH_MODEL_EXTENSION_LIST_SIZE
 	int "Model extensions list size"
 	depends on BT_MESH_COMP_PAGE_1
-	range 1 255
+	range 0 255
 	default 10
 	help
 	  This option specifies how many models relations can be saved.


### PR DESCRIPTION
If instantiated models don't have any relations at all, then the extensions list will be empty. We should allow to disable it at all to not waste RAM.