### PR TITLE
drivers: bbram: stm32-bbram: Port to stm32wl

### DIFF
--- a/drivers/bbram/bbram_stm32.c
+++ b/drivers/bbram/bbram_stm32.c
@@ -14,7 +14,14 @@
 LOG_MODULE_REGISTER(bbram, CONFIG_BBRAM_LOG_LEVEL);
 
 #define STM32_BKP_REG_BYTES		 4
-#define STM32_BKP_REG_OFFSET		 0x50
+#ifdef TAMP
+/* If a SoC has a TAMP peripherals, then the backup registers are defined there,
+ * not in the RTC.
+ */
+#define STM32_BKP_REG_OFFSET		 (TAMP_BASE + offsetof(TAMP_TypeDef, BKP0R) - RTC_BASE)
+#else
+#define STM32_BKP_REG_OFFSET		 offsetof(RTC_TypeDef, BKP0R)
+#endif
 #define STM32_BKP_REG_INDEX(offset)	 ((offset) >> 2)
 #define STM32_BKP_REG_BYTE_INDEX(offset) ((offset)&0x3UL)
 #define STM32_BKP_REG(i)		 (((volatile uint32_t *)config->base_addr)[(i)])

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -207,6 +207,18 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000400>;
 			prescaler = <32768>;
 			status = "disabled";
+
+			/* In STM32WL, the backup registers are defined as part of the TAMP
+			 * peripheral. This peripheral is not implemented in Zephyr yet, however,
+			 * the reference manual states that tamp_pclk is connected to rtc_pclk.
+			 * It makes sense to have BBRAM instantiated as a child of RTC, so that
+			 * the driver can verify that its parent device (RTC) is ready.
+			 */
+			bbram: backup_regs {
+				compatible = "st,stm32-bbram";
+				st,backup-regs = <20>;
+				status = "disabled";
+			};
 		};
 
 		iwdg: watchdog@40003000 {


### PR DESCRIPTION
Historically, STM32 SOCs have described their backup registers as part of the RTC. However, in the [reference manual](https://www.st.com/resource/en/reference_manual/rm0461-stm32wlex-advanced-armbased-32bit-mcus-with-subghz-radio-solution-stmicroelectronics.pdf) for STM32WL, the backup registers are declared as part of the TAMP peripheral. This peripheral doesn't have an equivalent in Zephyr and is not implemented as of now.

Considering that tamp_pclk is rtc_pclk (RM0461, Table 205. TAMP internal input/output signals)

> | Internal signal name | Signal type | Description |
> |-----------------------------|----------------|-----------------|
> | tamp_pclk                 | Input           | TAMP APB clock, connected to rtc_pclk |

and that the current implementation of stm32-bbram verifies that its parent (the RTC) is ready during its initialization, the shortest port would be to modify stm32-bbram implementation to run as a child instance of the stm32-rtc.

This port modifies `STM32_BKP_REG_OFFSET` in `bbram_stm32.c` so that the offset is calculated as the distance between 
the first backup register address and the base addresse of the RTC instance.

Also, this PR includes a configuration change on board `nucleo_wl55jc` so that LSE is used to clock LPTIM and the RTC. This is coherent with the configuration of board `nucleo_wb55rg` and I think it better demonstrates the capabilities of the board.