### PR TITLE
drivers: regulator: pca9420: Add support for configuring ASYS UVLO

### DIFF
--- a/dts/bindings/regulator/nxp,pca9420.yaml
+++ b/dts/bindings/regulator/nxp,pca9420.yaml
@@ -63,6 +63,18 @@ properties:
       To disable current limit, set property to zero. Defaults to 425mA, the IC
       default value.
 
+  nxp,asys-uvlo-sel-millivolt:
+    type: int
+    default: 2700
+    enum:
+      - 2400
+      - 2500
+      - 2600
+      - 2700
+    description: |
+      ASYS UVLO (under voltage lock out) threshold, in millivolts. Defaults to
+      2700mV to match the IC default value.
+
 child-binding:
   include:
     - name: regulator.yaml


### PR DESCRIPTION
Add support for configuring ASYS UVLO (under voltage lock out) threshold

See relevant register description from the pca9420 datasheet attached

![Screenshot from 2023-10-17 08-53-15](https://github.com/zephyrproject-rtos/zephyr/assets/131993256/0b9f5679-7771-4647-9d63-3cb63b371f33)
