### PR TITLE
arm: using -EAGAIN directly instead of _k_neg_eagain

### DIFF
--- a/arch/arm/core/cortex_a_r/swap.c
+++ b/arch/arm/core/cortex_a_r/swap.c
@@ -7,7 +7,7 @@
 #include <zephyr/kernel.h>
 #include <kernel_internal.h>
 
-extern const int _k_neg_eagain;
+#include <errno.h>
 
 /* The 'key' actually represents the BASEPRI register
  * prior to disabling interrupts via the BASEPRI mechanism.
@@ -18,7 +18,7 @@ int arch_swap(unsigned int key)
 {
 	/* store off key and return value */
 	_current->arch.basepri = key;
-	_current->arch.swap_return_value = _k_neg_eagain;
+	_current->arch.swap_return_value = -EAGAIN;
 
 	z_arm_cortex_r_svc();
 	irq_unlock(key);

--- a/arch/arm/core/cortex_m/swap.c
+++ b/arch/arm/core/cortex_m/swap.c
@@ -7,7 +7,7 @@
 #include <zephyr/kernel.h>
 #include <kernel_internal.h>
 
-extern const int _k_neg_eagain;
+#include <errno.h>
 
 /* The 'key' actually represents the BASEPRI register
  * prior to disabling interrupts via the BASEPRI mechanism.
@@ -34,7 +34,7 @@ int arch_swap(unsigned int key)
 {
 	/* store off key and return value */
 	_current->arch.basepri = key;
-	_current->arch.swap_return_value = _k_neg_eagain;
+	_current->arch.swap_return_value = -EAGAIN;
 
 	/* set pending bit to make sure we will take a PendSV exception */
 	SCB->ICSR |= SCB_ICSR_PENDSVSET_Msk;


### PR DESCRIPTION
_k_neg_eagain is there for used in assembly where including errno.h is not possible. However, the usage in ARM was simply to assign value to swap_return_value in a C file, which is no need to use _k_neg_eagain as errno.h can be included. So change that to use -EAGAIN directly. Saves 4 bytes in built binaries in rodata.