### PR TITLE
doc: smf: Properly highlight C code

### DIFF
--- a/doc/services/smf/index.rst
+++ b/doc/services/smf/index.rst
@@ -3,6 +3,8 @@
 State Machine Framework
 #######################
 
+.. highlight:: c
+
 Overview
 ========
 


### PR DESCRIPTION
Set default syntax highlighting language to C for this page.