### PR TITLE
doc: kconfig: Add syntax highlighting for Kconfig snippets

### DIFF
--- a/doc/build/kconfig/extensions.rst
+++ b/doc/build/kconfig/extensions.rst
@@ -26,7 +26,7 @@ which includes some Kconfig extensions:
 
   Consider the following example:
 
-  .. code-block:: none
+  .. code-block:: kconfig
 
       source "foo/bar/*/Kconfig"
 
@@ -34,7 +34,7 @@ which includes some Kconfig extensions:
   :file:`foo/bar/baz/Kconfig` and :file:`foo/bar/qaz/Kconfig`, the statement
   above is equivalent to the following two ``source`` statements:
 
-  .. code-block:: none
+  .. code-block:: kconfig
 
       source "foo/bar/baz/Kconfig"
       source "foo/bar/qaz/Kconfig"
@@ -61,7 +61,7 @@ which includes some Kconfig extensions:
   :file:`Kconfig` file, and that :file:`foo/bar/Kconfig` has the following
   statements:
 
-  .. code-block:: none
+  .. code-block:: kconfig
 
       source "qaz/Kconfig1"
       rsource "qaz/Kconfig2"
@@ -83,7 +83,7 @@ which includes some Kconfig extensions:
   For example, the following statement will include :file:`Kconfig1` and
   :file:`Kconfig2` from the current directory (if they exist):
 
-  .. code-block:: none
+  .. code-block:: kconfig
 
       orsource "Kconfig[12]"
 

--- a/doc/build/kconfig/preprocessor-functions.rst
+++ b/doc/build/kconfig/preprocessor-functions.rst
@@ -75,7 +75,7 @@ Example Usage
 
 Assume that the devicetree for some board looks like this:
 
-.. code-block:: none
+.. code-block:: devicetree
 
    {
    	soc {
@@ -94,14 +94,14 @@ The second entry in ``reg`` in ``spi@1001400`` (``<0x20010000 0x3c0900>``)
 corresponds to ``mem``, and has the address ``0x20010000``. This address can be
 inserted into Kconfig as follows:
 
-.. code-block:: none
+.. code-block:: kconfig
 
    config FLASH_BASE_ADDRESS
    	default $(dt_node_reg_addr_hex,/soc/spi@1001400,1)
 
 After preprocessor expansion, this turns into the definition below:
 
-.. code-block:: none
+.. code-block:: kconfig
 
    config FLASH_BASE_ADDRESS
    	default 0x20010000

--- a/doc/build/kconfig/setting.rst
+++ b/doc/build/kconfig/setting.rst
@@ -28,7 +28,7 @@ between *visible* and *invisible* symbols.
 
   Here's an example of a visible symbol:
 
-  .. code-block:: none
+  .. code-block:: kconfig
 
      config FPU
      	bool "Support floating point operations"
@@ -47,7 +47,7 @@ between *visible* and *invisible* symbols.
 
   Here's an example of an invisible symbol:
 
-  .. code-block:: none
+  .. code-block:: kconfig
 
      config CPU_HAS_FPU
      	bool
@@ -68,7 +68,7 @@ board with application settings, usually from :file:`prj.conf`. See
 
 Assignments in configuration files use this syntax:
 
-.. code-block:: none
+.. code-block:: cfg
 
    CONFIG_<symbol name>=<value>
 
@@ -78,7 +78,7 @@ There should be no spaces around the equals sign.
 respectively. The ``FPU`` symbol from the example above could be enabled like
 this:
 
-.. code-block:: none
+.. code-block:: cfg
 
    CONFIG_FPU=y
 
@@ -87,7 +87,7 @@ this:
    A boolean symbol can also be set to ``n`` with a comment formatted like
    this:
 
-   .. code-block:: none
+   .. code-block:: cfg
 
       # CONFIG_SOME_OTHER_BOOL is not set
 
@@ -100,14 +100,14 @@ this:
 
 Other symbol types are assigned like this:
 
-.. code-block:: none
+.. code-block:: cfg
 
    CONFIG_SOME_STRING="cool value"
    CONFIG_SOME_INT=123
 
 Comments use a #:
 
-.. code-block:: none
+.. code-block:: cfg
 
    # This is a comment
 
@@ -212,7 +212,7 @@ Assigning values in :file:`Kconfig.defconfig` relies on defining a Kconfig
 symbol in multiple locations. As an example, say we want to set ``FOO_WIDTH``
 below to 32:
 
-.. code-block:: none
+.. code-block:: kconfig
 
     config FOO_WIDTH
     	int
@@ -220,7 +220,7 @@ below to 32:
 To do this, we extend the definition of ``FOO_WIDTH`` as follows, in
 :file:`Kconfig.defconfig`:
 
-.. code-block:: none
+.. code-block:: kconfig
 
     if BOARD_MY_BOARD
 
@@ -255,7 +255,7 @@ symbol properties, so the above ``default`` is equivalent to
    For example, the direct dependencies of the symbol below becomes
    ``DEP1 || DEP2``:
 
-   .. code-block:: none
+   .. code-block:: kconfig
 
       config FOO
       	...
@@ -312,7 +312,7 @@ There are two ways to configure a Kconfig ``choice``:
    As an example, assume that a choice has the following base definition (here,
    the name of the choice is ``FOO``):
 
-   .. code-block:: none
+   .. code-block:: kconfig
 
        choice FOO
            bool "Foo choice"
@@ -329,7 +329,7 @@ There are two ways to configure a Kconfig ``choice``:
    To change the default symbol of ``FOO`` to ``A``, you would add the
    following definition to :file:`Kconfig.defconfig`:
 
-   .. code-block:: none
+   .. code-block:: kconfig
 
        choice FOO
            default A

--- a/doc/build/kconfig/tips.rst
+++ b/doc/build/kconfig/tips.rst
@@ -92,7 +92,7 @@ The ``select`` statement is used to force one symbol to ``y`` whenever another
 symbol is ``y``. For example, the following code forces ``CONSOLE`` to ``y``
 whenever ``USB_CONSOLE`` is ``y``:
 
-.. code-block:: none
+.. code-block:: kconfig
 
    config CONSOLE
    	bool "Console support"
@@ -116,7 +116,7 @@ For example, say that a new dependency is added to the ``CONSOLE`` symbol
 above, by a developer who is unaware of the ``USB_CONSOLE`` symbol (or simply
 forgot about it):
 
-.. code-block:: none
+.. code-block:: kconfig
 
    config CONSOLE
    	bool "Console support"
@@ -128,7 +128,7 @@ Enabling ``USB_CONSOLE`` now forces ``CONSOLE`` to ``y``, even if
 To fix the problem, the ``STRING_ROUTINES`` dependency needs to be added to
 ``USB_CONSOLE`` as well:
 
-.. code-block:: none
+.. code-block:: kconfig
 
    config USB_CONSOLE
    	bool "USB console support"
@@ -146,7 +146,7 @@ statements are common.
 An alternative attempt to solve the issue might be to turn the ``depends on``
 into another ``select``:
 
-.. code-block:: none
+.. code-block:: kconfig
 
    config CONSOLE
    	bool "Console support"
@@ -181,7 +181,7 @@ Alternatives to ``select``
 For the example in the previous section, a better solution is usually to turn
 the ``select`` into a ``depends on``:
 
-.. code-block:: none
+.. code-block:: kconfig
 
    config CONSOLE
    	bool "Console support"
@@ -198,7 +198,7 @@ dependencies only ever have to be updated in a single spot.
 An objection to using ``depends on`` here might be that configuration files
 that enable ``USB_CONSOLE`` now also need to enable ``CONSOLE``:
 
-.. code-block:: none
+.. code-block:: cfg
 
    CONFIG_CONSOLE=y
    CONFIG_USB_CONSOLE=y
@@ -206,7 +206,7 @@ that enable ``USB_CONSOLE`` now also need to enable ``CONSOLE``:
 This comes down to a trade-off, but if enabling ``CONSOLE`` is the norm, then a
 mitigation is to make ``CONSOLE`` default to ``y``:
 
-.. code-block:: none
+.. code-block:: kconfig
 
    config CONSOLE
    	bool "Console support"
@@ -214,14 +214,14 @@ mitigation is to make ``CONSOLE`` default to ``y``:
 
 This gives just a single assignment in configuration files:
 
-.. code-block:: none
+.. code-block:: cfg
 
    CONFIG_USB_CONSOLE=y
 
 Note that configuration files that do not want ``CONSOLE`` enabled now have to
 explicitly disable it:
 
-.. code-block:: none
+.. code-block:: cfg
 
    CONFIG_CONSOLE=n
 
@@ -238,7 +238,7 @@ dependencies.
 For example, a helper symbol for indicating that a particular CPU/SoC has an
 FPU could be defined as follows:
 
-.. code-block:: none
+.. code-block:: kconfig
 
    config CPU_HAS_FPU
    	bool
@@ -260,7 +260,7 @@ FPU could be defined as follows:
 This makes it possible for other symbols to check for FPU support in a generic
 way, without having to look for particular architectures:
 
-.. code-block:: none
+.. code-block:: kconfig
 
    config FPU
    	bool "Support floating point operations"
@@ -269,7 +269,7 @@ way, without having to look for particular architectures:
 The alternative would be to have dependencies like the following, possibly
 duplicated in several spots:
 
-.. code-block:: none
+.. code-block:: kconfig
 
    config FPU
    	bool "Support floating point operations"
@@ -279,7 +279,7 @@ Invisible helper symbols can also be useful without ``select``. For example,
 the following code defines a helper symbol that has the value ``y`` if the
 machine has some arbitrarily-defined "large" amount of memory:
 
-.. code-block:: none
+.. code-block:: kconfig
 
    config LARGE_MEM
    	def_bool MEM_SIZE >= 64
@@ -288,7 +288,7 @@ machine has some arbitrarily-defined "large" amount of memory:
 
    This is short for the following:
 
-   .. code-block:: none
+   .. code-block:: kconfig
 
       config LARGE_MEM
       	bool
@@ -325,7 +325,7 @@ on`` was used.
 A common misunderstanding related to ``if`` is to think that the following code
 conditionally includes the file :file:`Kconfig.other`:
 
-.. code-block:: none
+.. code-block:: kconfig
 
    if DEP
    source "Kconfig.other"
@@ -342,14 +342,14 @@ meaning around a ``source``.
 
 Say that :file:`Kconfig.other` above contains this definition:
 
-.. code-block:: none
+.. code-block:: kconfig
 
    config FOO
    	bool "Support foo"
 
 In this case, ``FOO`` will end up with this definition:
 
-.. code-block:: none
+.. code-block:: kconfig
 
    config FOO
    	bool "Support foo"
@@ -371,7 +371,7 @@ twice.
 There is a common subtle gotcha related to interdependent configuration symbols
 with prompts. Consider these symbols:
 
-.. code-block:: none
+.. code-block:: kconfig
 
    config FOO
    	bool "Foo"
@@ -396,7 +396,7 @@ To understand what's going on, remember that ``STACK_SIZE`` has a prompt,
 meaning it is user-configurable, and consider that all Kconfig has to go on
 from the initial configuration is this:
 
-.. code-block:: none
+.. code-block:: cfg
 
    CONFIG_STACK_SIZE=0x100
 
@@ -412,7 +412,7 @@ with suggestions:
 - If ``STACK_SIZE`` can always be derived automatically and does not need to be
   user-configurable, then just remove the prompt:
 
-  .. code-block:: none
+  .. code-block:: kconfig
 
      config STACK_SIZE
      	hex
@@ -425,7 +425,7 @@ with suggestions:
   0x200 when ``FOO`` is enabled, then disable its prompt when ``FOO`` is
   enabled, as described in `optional prompts`_:
 
-  .. code-block:: none
+  .. code-block:: kconfig
 
      config STACK_SIZE
      	hex "Stack size" if !FOO
@@ -436,7 +436,7 @@ with suggestions:
   set to a custom value in rare circumstances, then add another option for
   making ``STACK_SIZE`` user-configurable:
 
-  .. code-block:: none
+  .. code-block:: kconfig
 
      config CUSTOM_STACK_SIZE
      	bool "Use a custom stack size"
@@ -500,7 +500,7 @@ calculating symbol values.
 The Kconfig definitions below will hide the ``FOO_DEVICE_FREQUENCY`` symbol and
 disable any configuration output for it when ``FOO_DEVICE`` is disabled.
 
-.. code-block:: none
+.. code-block:: kconfig
 
    config FOO_DEVICE
    	bool "Foo device"
@@ -530,7 +530,7 @@ children in a separate menu rooted at ``FOO``.
 ``menuconfig`` can cut down on the number of menus and make the menu structure
 easier to navigate. For example, say you have the following definitions:
 
-.. code-block:: none
+.. code-block:: kconfig
 
    menu "Foo subsystem"
 
@@ -557,7 +557,7 @@ easier to navigate. For example, say you have the following definitions:
 In this case, it's probably better to get rid of the ``menu`` and turn
 ``FOO_SUBSYSTEM`` into a ``menuconfig`` symbol:
 
-.. code-block:: none
+.. code-block:: kconfig
 
    menuconfig FOO_SUBSYSTEM
    	bool "Foo subsystem"
@@ -599,7 +599,7 @@ Commas in macro arguments
 Kconfig uses commas to separate macro arguments.
 This means a construct like this will fail:
 
-.. code-block:: none
+.. code-block:: kconfig
 
     config FOO
         bool
@@ -608,7 +608,7 @@ This means a construct like this will fail:
 To solve this problem, create a variable with the text and use this variable as
 argument, as follows:
 
-.. code-block:: none
+.. code-block:: kconfig
 
     DT_CHOSEN_ZEPHYR_BAR := zephyr,bar
 
@@ -688,7 +688,7 @@ be factored out with an ``if``.
 
 As an example, consider the following code:
 
-.. code-block:: none
+.. code-block:: kconfig
 
    config FOO
    	bool "Foo"
@@ -712,7 +712,7 @@ As an example, consider the following code:
 
 Here, the ``DEP`` dependency can be factored out like this:
 
-.. code-block:: none
+.. code-block:: kconfig
 
    if DEP
 
@@ -742,7 +742,7 @@ Here, the ``DEP`` dependency can be factored out like this:
 If a sequence of symbols/choices with shared dependencies are all in the same
 menu, the dependency can be put on the menu itself:
 
-.. code-block:: none
+.. code-block:: kconfig
 
    menu "Foo features"
    	depends on FOO_SUPPORT
@@ -782,7 +782,7 @@ a previously defined ``default y``.
 That is, FOO will be set to ``n`` in the example below. If the ``default n`` was
 omitted in the first definition, FOO would have been set to ``y``.
 
-  .. code-block:: none
+  .. code-block:: kconfig
 
      config FOO
      	bool "foo"
@@ -794,7 +794,7 @@ omitted in the first definition, FOO would have been set to ``y``.
 
 In the following example FOO will get the value ``y``.
 
-  .. code-block:: none
+  .. code-block:: kconfig
 
      config FOO
      	bool "foo"
@@ -814,12 +814,12 @@ Kconfig has two shorthands that deal with prompts and defaults.
 - ``<type> "prompt"`` is a shorthand for giving a symbol/choice a type and a
   prompt at the same time. These two definitions are equal:
 
-  .. code-block:: none
+  .. code-block:: kconfig
 
      config FOO
      	bool "foo"
 
-  .. code-block:: none
+  .. code-block:: kconfig
 
      config FOO
      	bool
@@ -830,12 +830,12 @@ Kconfig has two shorthands that deal with prompts and defaults.
 - ``def_<type> <value>`` is a shorthand for giving a type and a value at the
   same time. These two definitions are equal:
 
-  .. code-block:: none
+  .. code-block:: kconfig
 
      config FOO
      	def_bool BAR && BAZ
 
-  .. code-block:: none
+  .. code-block:: kconfig
 
      config FOO
      	bool
@@ -907,7 +907,7 @@ doesn't force a value. For example, the following code could be used to enable
 USB keyboard support by default on the FOO SoC, while still allowing the user
 to turn it off:
 
-.. code-block:: none
+.. code-block:: kconfig
 
    config SOC_FOO
    	bool "FOO SoC"
@@ -928,7 +928,7 @@ A condition can be put on a symbol's prompt to make it optionally configurable
 by the user. For example, a value ``MASK`` that's hardcoded to 0xFF on some
 boards and configurable on others could be expressed as follows:
 
-.. code-block:: none
+.. code-block:: kconfig
 
    config MASK
    	hex "Bitmask" if HAS_CONFIGURABLE_MASK
@@ -938,7 +938,7 @@ boards and configurable on others could be expressed as follows:
 
    This is short for the following:
 
-   .. code-block:: none
+   .. code-block:: kconfig
 
       config MASK
       	hex
@@ -956,7 +956,7 @@ Optional choices
 Defining a choice with the ``optional`` keyword allows the whole choice to be
 toggled off to select none of the symbols:
 
-.. code-block:: none
+.. code-block:: kconfig
 
    choice
    	prompt "Use legacy protocol"
@@ -983,7 +983,7 @@ within it, while still allowing symbol default values to kick in.
 
 As a motivating example, consider the following code:
 
-.. code-block:: none
+.. code-block:: kconfig
 
    menu "Foo subsystem"
    	depends on HAS_CONFIGURABLE_FOO
@@ -1002,7 +1002,7 @@ When ``HAS_CONFIGURABLE_FOO`` is ``n``, no configuration output is generated
 for ``FOO_SETTING_1`` and ``FOO_SETTING_2``, as the code above is logically
 equivalent to the following code:
 
-.. code-block:: none
+.. code-block:: kconfig
 
    config FOO_SETTING_1
    	int "Foo setting 1"
@@ -1018,7 +1018,7 @@ If we want the symbols to still get their default values even when
 ``HAS_CONFIGURABLE_FOO`` is ``n``, but not be configurable by the user, then we
 can use ``visible if`` instead:
 
-.. code-block:: none
+.. code-block:: kconfig
 
    menu "Foo subsystem"
    	visible if HAS_CONFIGURABLE_FOO
@@ -1035,7 +1035,7 @@ can use ``visible if`` instead:
 
 This is logically equivalent to the following:
 
-.. code-block:: none
+.. code-block:: kconfig
 
    config FOO_SETTING_1
    	int "Foo setting 1" if HAS_CONFIGURABLE_FOO
@@ -1053,7 +1053,7 @@ This is logically equivalent to the following:
 When ``HAS_CONFIGURABLE`` is ``n``, we now get the following configuration
 output for the symbols, instead of no output:
 
-.. code-block:: none
+.. code-block:: cfg
 
    ...
    CONFIG_FOO_SETTING_1=1


### PR DESCRIPTION
Add proper pygments settings to make Kconfig snippets look pretty. Also fixed a few config and devicetree code blocks.