### PR TITLE
doc: boards: Set proper languages for syntax highlighting

### DIFF
--- a/boards/arm/cc3220sf_launchxl/doc/index.rst
+++ b/boards/arm/cc3220sf_launchxl/doc/index.rst
@@ -172,7 +172,7 @@ Prerequisites:
    to the paths of the OpenOCD binary and its scripts, before
    including the common openocd.board.cmake file:
 
-   .. code-block:: none
+   .. code-block:: cmake
 
       set(OPENOCD "/usr/local/bin/openocd" CACHE FILEPATH "" FORCE)
       set(OPENOCD_DEFAULT_PATH /usr/local/share/openocd/scripts)

--- a/boards/arm/cc3235sf_launchxl/doc/index.rst
+++ b/boards/arm/cc3235sf_launchxl/doc/index.rst
@@ -172,7 +172,7 @@ Prerequisites:
    to the paths of the OpenOCD binary and its scripts, before
    including the common openocd.board.cmake file:
 
-   .. code-block:: none
+   .. code-block:: cmake
 
       set(OPENOCD "/usr/local/bin/openocd" CACHE FILEPATH "" FORCE)
       set(OPENOCD_DEFAULT_PATH /usr/local/share/openocd/scripts)

--- a/boards/arm/mimxrt1050_evk/doc/index.rst
+++ b/boards/arm/mimxrt1050_evk/doc/index.rst
@@ -436,9 +436,9 @@ Board Revisions
 ***************
 
 The original MIMXRT1050-EVK (rev A0) board was updated with a newer
-MIMXRT1050-EVKB (rev A1) board, with these major hardware differences::
+MIMXRT1050-EVKB (rev A1) board, with these major hardware differences:
 
-- SoC changed from MIMXRT1052DVL6**A** to MIMXRT1052DVL6**B**
+- SoC changed from MIMXRT1052DVL6\ **A** to MIMXRT1052DVL6\ **B**
 - Hardware bug fixes for: power, interfaces, and memory
 - Arduino headers included
 

--- a/boards/arm/msp_exp432p401r_launchxl/doc/index.rst
+++ b/boards/arm/msp_exp432p401r_launchxl/doc/index.rst
@@ -88,7 +88,7 @@ Prerequisites:
    to the paths of the OpenOCD binary and its scripts, before
    including the common openocd.board.cmake file:
 
-   .. code-block:: none
+   .. code-block:: cmake
 
       set(OPENOCD "/usr/local/bin/openocd" CACHE FILEPATH "" FORCE)
       set(OPENOCD_DEFAULT_PATH /usr/local/share/openocd/scripts)

--- a/boards/arm/nrf9160dk_nrf52840/doc/index.rst
+++ b/boards/arm/nrf9160dk_nrf52840/doc/index.rst
@@ -228,7 +228,7 @@ P0.17, P0.18, and P0.19 so that they are routed to nRF52840 pins P0.17, P0.20,
 and P0.15, respectively, add the following in the devicetree overlay in your
 application:
 
-.. code-block:: none
+.. code-block:: devicetree
 
    &nrf_interface_pins_0_2_routing {
            status = "okay";
@@ -237,7 +237,7 @@ application:
 And if you want to, for example, disable routing for the VCOM2 pins, add the
 following:
 
-.. code-block:: none
+.. code-block:: devicetree
 
    &vcom2_pins_routing {
            status = "disabled";
@@ -252,7 +252,7 @@ configure the signal routing between nRF9160 and nRF52840 on the nRF9160 DK.
 For example, to use ``uart1`` on both these chips for communication between
 them, add the following line in the overlays for applications on both sides:
 
-.. code-block:: none
+.. code-block:: devicetree
 
    #include <nrf9160dk_uart1_on_if0_3.dtsi>
 

--- a/boards/arm/twr_ke18f/doc/index.rst
+++ b/boards/arm/twr_ke18f/doc/index.rst
@@ -117,7 +117,7 @@ In order to support FXOS8700 triggers (interrupts) the 0 ohm resistors
 devicetree must also be modified to describe the FXOS8700 interrupt
 GPIOs:
 
-.. code-block:: none
+.. code-block:: devicetree
 
   /dts-v1/;
 

--- a/boards/riscv/rv32m1_vega/doc/index.rst
+++ b/boards/riscv/rv32m1_vega/doc/index.rst
@@ -498,7 +498,7 @@ first make sure you're booting the right core.
 
    The output should look like this:
 
-   .. code-block:: none
+   .. code-block:: console
 
       $ ~/rv32m1-openocd -f boards/riscv/rv32m1_vega/support/openocd_rv32m1_vega_ri5cy.cfg
       Open On-Chip Debugger 0.10.0+dev-00431-ge1ec3c7d (2018-10-31-07:29)

--- a/boards/shields/x_nucleo_idb05a1/doc/index.rst
+++ b/boards/shields/x_nucleo_idb05a1/doc/index.rst
@@ -85,7 +85,7 @@ build command:
 
 Alternatively, set use of this shield in the project's ``CMakeLists.txt`` file:
 
-.. code-block:: none
+.. code-block:: cmake
 
 	set(SHIELD x_nucleo_idb05a1)
 

--- a/boards/xtensa/esp32_ethernet_kit/doc/index.rst
+++ b/boards/xtensa/esp32_ethernet_kit/doc/index.rst
@@ -581,7 +581,9 @@ You can debug an application in the usual way. Here is an example for the :ref:`
 Enabling Ethernet
 *****************
 
-Enable Ethernet MAC, PHY and MDIO; add these to your device tree overlay::
+Enable Ethernet MAC, PHY and MDIO; add these to your device tree overlay:
+
+.. code-block:: devicetree
 
     &eth {
         status = "okay";
@@ -595,7 +597,9 @@ Enable Ethernet MAC, PHY and MDIO; add these to your device tree overlay::
         status = "okay";
     };
 
-Enable Ethernet in KConfig::
+Enable Ethernet in KConfig:
+
+.. code-block:: cfg
 
     CONFIG_ETH_ESP32=y
     CONFIG_NETWORKING=y


### PR DESCRIPTION
Make sure devicetree, kconfig, etc. code snippets all have proper pygments language set.

**Note**: only existing code-block:: directives have been updated. Another pass should be made to address implicit code-blocks (`::`)