### PR TITLE
doc: devicetree: Fix highlighting of code blocks

### DIFF
--- a/doc/build/dts/howtos.rst
+++ b/doc/build/dts/howtos.rst
@@ -149,7 +149,9 @@ that the node has ``status = "okay"``, like this:
 
 If you see the ``#error`` output, make sure to enable the node in your
 devicetree. In some situations your code will compile but it will fail to link
-with a message similar to::
+with a message similar to:
+
+.. code-block:: none
 
    ...undefined reference to `__device_dts_ord_N'
    collect2: error: ld returned 1 exit status
@@ -299,6 +301,7 @@ For example, if your BOARD.dts contains this node:
 These are equivalent ways to override the ``current-speed`` value in an
 overlay:
 
+.. Disable syntax highlighting as this construct does not seem supported by pygments
 .. code-block:: none
 
    /* Option 1 */
@@ -316,7 +319,7 @@ We'll use the ``&serial0`` style for the rest of these examples.
 You can add aliases to your devicetree using overlays: an alias is just a
 property of the ``/aliases`` node. For example:
 
-.. code-block:: none
+.. code-block:: devicetree
 
    / {
    	aliases {
@@ -326,7 +329,7 @@ property of the ``/aliases`` node. For example:
 
 Chosen nodes work the same way. For example:
 
-.. code-block:: none
+.. code-block:: devicetree
 
    / {
    	chosen {
@@ -337,7 +340,7 @@ Chosen nodes work the same way. For example:
 To delete a property (in addition to deleting properties in general, this is
 how to set a boolean property to false if it's true in BOARD.dts):
 
-.. code-block:: none
+.. code-block:: devicetree
 
    &serial0 {
    	/delete-property/ some-unwanted-property;
@@ -346,7 +349,7 @@ how to set a boolean property to false if it's true in BOARD.dts):
 You can add subnodes using overlays. For example, to configure a SPI or I2C
 child device on an existing bus node, do something like this:
 
-.. code-block:: none
+.. code-block:: devicetree
 
    /* SPI device example */
    &spi1 {

--- a/doc/build/dts/intro-input-output.rst
+++ b/doc/build/dts/intro-input-output.rst
@@ -23,7 +23,9 @@ There are four types of devicetree input files:
 - overlays (``.overlay``)
 - bindings (``.yaml``)
 
-The devicetree files inside the :file:`zephyr` directory look like this::
+The devicetree files inside the :file:`zephyr` directory look like this:
+
+.. code-block:: none
 
   boards/<ARCH>/<BOARD>/<BOARD>.dts
   dts/common/skeleton.dtsi

--- a/doc/build/dts/intro-syntax-structure.rst
+++ b/doc/build/dts/intro-syntax-structure.rst
@@ -387,9 +387,11 @@ Additional notes on the above:
   that order.
 
 - Parentheses, arithmetic operators, and bitwise operators are allowed. The
-  ``bar`` property contains a single cell with value 64::
+  ``bar`` property contains a single cell with value 64:
 
-  	bar = <(2 * (1 << 5))>;
+  .. code-block:: devicetree
+
+     bar = <(2 * (1 << 5))>;
 
   Note that the entire expression must be parenthesized.
 
@@ -419,7 +421,7 @@ Additional notes on the above:
 - Array and similar type property values can be split into several ``<>``
   blocks, like this:
 
-  .. code-block:: none
+  .. code-block:: devicetree
 
      foo = <1 2>, <3 4>;                         // Okay for 'type: array'
      foo = <&label1 &label2>, <&label3 &label4>; // Okay for 'type: phandles'

--- a/doc/build/dts/troubleshooting.rst
+++ b/doc/build/dts/troubleshooting.rst
@@ -193,7 +193,7 @@ as you enable the devicetree node. Otherwise, it is sometimes as simple as
 adding a line like this to your application's :file:`prj.conf` file and then
 making sure to :ref:`dt-trouble-try-pristine`:
 
-.. code-block:: none
+.. code-block:: cfg
 
    CONFIG_FOO=y
 


### PR DESCRIPTION
Make sure devicetree code blocks all have proper pygments language set. Fixed a few other "none" code blocks as well.