### PR TITLE
doc: Configure copybutton extension for ignoring shell prompts

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -313,6 +313,11 @@ graphviz_dot_args = [
     "-Ecolor=gray60",
 ]
 
+# -- Options for sphinx_copybutton ----------------------------------------
+
+copybutton_prompt_text = r"\$ |uart:~\$ "
+copybutton_prompt_is_regexp = True
+
 # -- Linkcheck options ----------------------------------------------------
 
 extlinks = {

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -200,12 +200,6 @@ latex_documents = [
     ("index-tex", "zephyr.tex", "Zephyr Project Documentation", author, "manual"),
 ]
 
-# -- Options for linkcheck ------------------------------------------------
-
-linkcheck_ignore = [
-    r"https://github.com/zephyrproject-rtos/zephyr/issues/.*"
-]
-
 # -- Options for zephyr.doxyrunner plugin ---------------------------------
 
 doxyrunner_doxygen = os.environ.get("DOXYGEN_EXECUTABLE", "doxygen")
@@ -319,6 +313,10 @@ copybutton_prompt_text = r"\$ |uart:~\$ "
 copybutton_prompt_is_regexp = True
 
 # -- Linkcheck options ----------------------------------------------------
+
+linkcheck_ignore = [
+    r"https://github.com/zephyrproject-rtos/zephyr/issues/.*"
+]
 
 extlinks = {
     "github": ("https://github.com/zephyrproject-rtos/zephyr/issues/%s", "GitHub #%s"),


### PR DESCRIPTION
**You may test this PR directly here: https://builds.zephyrproject.io/zephyr/pr/64058/docs/connectivity/bluetooth/bluetooth-shell.html#scan-for-devices or https://builds.zephyrproject.io/zephyr/pr/64058/docs/boards/arm/olimexino_stm32/doc/index.html#building-stm32flash-command-line-tool** 

Add required settings for telling the copybutton Sphinx extension to ignore prompts when copying a code block.

Both bash prompt and Zephyr UART prompt are ignored.

Examples of the new behavior:

```
.. code-block:: console

    $ echo "Hello World"
    Hello World
```

The copied text will be: 'echo "Hello World"'.

```
.. code-block:: console

   uart:~$ l2cap connect 29
   Chan sec: 1
   L2CAP connection pending
   Channel 0x20000210 connected
   Channel 0x20000210 status 1
   uart:~$ l2cap send 3 14
   Rem 2
   Rem 1
   Rem 0
   Outgoing data channel 0x20000210 transmitted
   Outgoing data channel 0x20000210 transmitted
   Outgoing data channel 0x20000210 transmitted
```

The copied text will be: 'l2cap connect 29\nl2cap send 3 14'.