### PR TITLE
drivers timer nrf: Correct dependencies for simulation

### DIFF
--- a/drivers/timer/Kconfig.nrf_rtc
+++ b/drivers/timer/Kconfig.nrf_rtc
@@ -19,7 +19,7 @@ if NRF_RTC_TIMER
 
 config NRF_RTC_TIMER_USER_CHAN_COUNT
 	int "Additional channels that can be used"
-	default 2 if NRF_802154_RADIO_DRIVER && SOC_NRF5340_CPUNET
+	default 2 if NRF_802154_RADIO_DRIVER && SOC_COMPATIBLE_NRF5340_CPUNET
 	default 3 if NRF_802154_RADIO_DRIVER
 	default 0
 	help


### PR DESCRIPTION
Let's make the nrf rtc kconfig depend on the SOC_COMPATIBLE options which are set both by the real and simulated targets so the configuration matches in both cases.