### PR TITLE
mgmt: mcumgr: grp: img_mgmt: Fix erase returning unknown error

### DIFF
--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/zephyr_img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/zephyr_img_mgmt.c
@@ -298,6 +298,11 @@ int img_mgmt_erase_slot(int slot)
 			LOG_ERR("Failed to erase flash area: %d", rc);
 			rc = IMG_MGMT_ERR_FLASH_ERASE_FAILED;
 		}
+	} else if (rc == 1) {
+		/* A return value of 1 indicates that the slot is already erased, thus
+		 * return a success code to the client
+		 */
+		rc = 0;
 	}
 
 	flash_area_close(fa);


### PR DESCRIPTION
Fixes an issue whereby the erase function would return an unknown error, which would happen when the slot was already erased.