### PR TITLE
drivers: mfd: gpio: adjust init priority

### DIFF
--- a/drivers/gpio/Kconfig.axp192
+++ b/drivers/gpio/Kconfig.axp192
@@ -14,7 +14,7 @@ config GPIO_AXP192
 config GPIO_AXP192_INIT_PRIORITY
 	int "AXP192 GPIO driver initialization priority"
 	depends on GPIO_AXP192
-	default 80
+	default 81
 	help
 	  Initialization priority for the AXP192 GPIO driver. It must be
 	  greater than the I2C controller init priority and the mfd driver

--- a/drivers/gpio/Kconfig.nct38xx
+++ b/drivers/gpio/Kconfig.nct38xx
@@ -16,14 +16,14 @@ if GPIO_NCT38XX
 
 config GPIO_NCT38XX_INIT_PRIORITY
 	int "NCT38XX GPIO init priority"
-	default 62
+	default 82
 	help
 	  NCT38xx GPIO driver initialization priority. The priority must be lower
 	  than MFD_INIT_PRIORITY.
 
 config GPIO_NCT38XX_PORT_INIT_PRIORITY
 	int "NCT38XX GPIO port init priority"
-	default 64
+	default 84
 	help
 	  NCT38xx GPIO port device driver initialization priority. The priority
 	  must be lower than GPIO_NCT38XX_INIT_PRIORITY device.
@@ -37,7 +37,7 @@ config GPIO_NCT38XX_ALERT
 
 config GPIO_NCT38XX_ALERT_INIT_PRIORITY
 	int "NCT38XX GPIO alert handler init priority"
-	default 64
+	default 84
 	depends on GPIO_NCT38XX_ALERT
 	help
 	  NCT38XX alert handler initialization priority. This initialization

--- a/drivers/gpio/Kconfig.npm1300
+++ b/drivers/gpio/Kconfig.npm1300
@@ -13,7 +13,7 @@ config GPIO_NPM1300
 config GPIO_NPM1300_INIT_PRIORITY
 	int "nPM1300 GPIO driver initialization priority"
 	depends on GPIO_NPM1300
-	default 70
+	default 85
 	help
 	  Initialization priority for the nPM1300 GPIO driver. It must be
 	  greater than the I2C controller init priority.

--- a/drivers/gpio/Kconfig.npm6001
+++ b/drivers/gpio/Kconfig.npm6001
@@ -13,6 +13,6 @@ config GPIO_NPM6001
 config GPIO_NPM6001_INIT_PRIORITY
 	int "nPM6001 GPIO driver initialization priority"
 	depends on GPIO_NPM6001
-	default 65
+	default 85
 	help
 	  Initialization priority for the nPM6001 GPIO driver.

--- a/drivers/mfd/Kconfig
+++ b/drivers/mfd/Kconfig
@@ -14,7 +14,7 @@ source "subsys/logging/Kconfig.template.log_config"
 
 config MFD_INIT_PRIORITY
 	int "Initialization priority"
-	default 60
+	default 80
 	help
 	  Multi-function devices initialization priority.
 

--- a/drivers/regulator/Kconfig.npm1300
+++ b/drivers/regulator/Kconfig.npm1300
@@ -14,14 +14,14 @@ if REGULATOR_NPM1300
 
 config REGULATOR_NPM1300_COMMON_INIT_PRIORITY
 	int "nPM1300 regulator driver init priority (common part)"
-	default 75
+	default 85
 	help
 	  Init priority for the Nordic nPM1300 regulator driver (common part).
 	  It must be greater than I2C init priority.
 
 config REGULATOR_NPM1300_INIT_PRIORITY
 	int "nPM1300 regulator driver init priority"
-	default 76
+	default 86
 	help
 	  Init priority for the Nordic nPM1300 regulator driver. It must be
 	  greater than REGULATOR_NPM1300_COMMON_INIT_PRIORITY.

--- a/drivers/regulator/Kconfig.npm6001
+++ b/drivers/regulator/Kconfig.npm6001
@@ -12,7 +12,7 @@ config REGULATOR_NPM6001
 
 config REGULATOR_NPM6001_INIT_PRIORITY
 	int "nPM6001 regulator driver init priority"
-	default 76
+	default 86
 	depends on REGULATOR_NPM6001
 	help
 	  Init priority for the Nordic nPM6001 regulator driver.

--- a/drivers/watchdog/Kconfig.npm1300
+++ b/drivers/watchdog/Kconfig.npm1300
@@ -13,7 +13,7 @@ config WDT_NPM1300
 config WDT_NPM1300_INIT_PRIORITY
 	int "nPM1300 Watchdog driver initialization priority"
 	depends on WDT_NPM1300
-	default 75
+	default 85
 	help
 	  Initialization priority for the nPM1300 Watchdog driver.
 	  It must be greater than GPIO_NPM1300_INIT_PRIORITY.

--- a/drivers/watchdog/Kconfig.npm6001
+++ b/drivers/watchdog/Kconfig.npm6001
@@ -13,6 +13,6 @@ config WDT_NPM6001
 config WDT_NPM6001_INIT_PRIORITY
 	int "nPM6001 Watchdog driver initialization priority"
 	depends on WDT_NPM6001
-	default 65
+	default 85
 	help
 	  Initialization priority for the nPM6001 Watchdog driver.


### PR DESCRIPTION
Take into account the SPI bus init priority that can be used for MFD drivers.