### PR TITLE
drivers: stm32-exti: do not lock hwsem on irq disable

### DIFF
--- a/drivers/interrupt_controller/intc_exti_stm32.c
+++ b/drivers/interrupt_controller/intc_exti_stm32.c
@@ -72,8 +72,6 @@ void stm32_exti_enable(int line)
 
 void stm32_exti_disable(int line)
 {
-	z_stm32_hsem_lock(CFG_HW_EXTI_SEMID, HSEM_LOCK_DEFAULT_RETRY);
-
 	if (line < 32) {
 #if defined(CONFIG_SOC_SERIES_STM32H7X) && defined(CONFIG_CPU_CORTEX_M4)
 		LL_C2_EXTI_DisableIT_0_31(1 << line);
@@ -83,7 +81,6 @@ void stm32_exti_disable(int line)
 	} else {
 		__ASSERT_NO_MSG(line);
 	}
-	z_stm32_hsem_unlock(CFG_HW_EXTI_SEMID);
 }
 
 /**


### PR DESCRIPTION
Remove the hardware semaphore locking around stm32_exti_disable().

The STM32 EXTI driver uses the core-local interrupt mask regsiters on STM32H7x7 asym. dualcore MCUs. There is no need to lock the HWSEM guarding the EXTI when accessing these registers.
Locking it anyways produces hangups and race conditions when done too often e.g. by sensor drivers as discussed in
https://github.com/zephyrproject-rtos/zephyr/pull/62303.

Note: The opposing stm32_exti_enable() was already correctly without locking.