### PR TITLE
doc: build: Fix highlighting of code blocks

### DIFF
--- a/doc/build/sysbuild/index.rst
+++ b/doc/build/sysbuild/index.rst
@@ -104,21 +104,27 @@ As mentioned above, you can run sysbuild via ``west build`` or ``cmake``.
       .. tip::
 
          To configure ``west build`` to use ``--sysbuild`` by default from now on,
-         run::
+         run:
 
-           west config build.sysbuild True
+         .. code-block:: shell
+
+            west config build.sysbuild True
 
          Since sysbuild supports both single- and multi-image builds, this lets you
          use sysbuild all the time, without worrying about what type of build you are
          running.
 
-         To turn this off, run this before generating your build system::
+         To turn this off, run this before generating your build system:
 
-           west config build.sysbuild False
+         .. code-block:: shell
 
-         To turn this off for just one ``west build`` command, run::
+            west config build.sysbuild False
 
-           west build --no-sysbuild ...
+         To turn this off for just one ``west build`` command, run:
+
+         .. code-block:: shell
+
+            west build --no-sysbuild ...
 
    .. group-tab:: ``cmake``
 
@@ -206,15 +212,15 @@ build system to the value ``BAR``, run the following commands:
 
    .. group-tab:: ``west build``
 
-      ::
+      .. code-block:: shell
 
          west build --sysbuild ... -- -Dmy_sample_FOO=BAR
 
    .. group-tab:: ``cmake``
 
-      ::
+      .. code-block:: shell
 
-        cmake -Dmy_sample_FOO=BAR ...
+         cmake -Dmy_sample_FOO=BAR ...
 
 .. _sysbuild_kconfig_namespacing:
 
@@ -242,13 +248,13 @@ build system to the value ``BAR``, run the following commands:
 
    .. group-tab:: ``west build``
 
-      ::
+      .. code-block:: shell
 
          west build --sysbuild ... -- -Dmy_sample_CONFIG_FOO=BAR
 
    .. group-tab:: ``cmake``
 
-      ::
+      .. code-block:: shell
 
         cmake -Dmy_sample_CONFIG_FOO=BAR ...
 
@@ -263,13 +269,13 @@ build system to the value ``BAR``, run the following commands:
    the same syntax for setting Kconfig values at CMake time.
    For example, the following commands will work in the same way:
 
-   ::
+   .. code-block:: shell
 
-     west build -b <board> my_sample -- -DCONFIG_FOO=BAR
+      west build -b <board> my_sample -- -DCONFIG_FOO=BAR
 
-   ::
+   .. code-block:: shell
 
-     west build -b <board> --sysbuild my_sample -- -DCONFIG_FOO=BAR
+      west build -b <board> --sysbuild my_sample -- -DCONFIG_FOO=BAR
 
 Sysbuild flashing using ``west flash``
 **************************************
@@ -359,7 +365,7 @@ MCUboot whenever sysbuild is used:
    └── sysbuild.conf
 
 
-.. code-block:: none
+.. code-block:: cfg
 
    SB_CONFIG_BOOTLOADER_MCUBOOT=y
 
@@ -432,7 +438,7 @@ target to execute and it will run.
       location, the ``rom_report`` build target for ``mcuboot`` can be ran
       with:
 
-      .. code-block:: bash
+      .. code-block:: shell
 
          west build -d build/mcuboot -t rom_report
 
@@ -442,7 +448,7 @@ target to execute and it will run.
       using ``ninja`` using sysbuild with mcuboot enabled, the ``rom_report``
       build target for ``mcuboot`` can be ran with:
 
-      .. code-block:: bash
+      .. code-block:: shell
 
          ninja -C mcuboot rom_report
 
@@ -452,7 +458,7 @@ target to execute and it will run.
       using ``make`` using sysbuild with mcuboot enabled, the ``rom_report``
       build target for ``mcuboot`` can be ran with:
 
-      .. code-block:: bash
+      .. code-block:: shell
 
          make -C mcuboot rom_report
 
@@ -607,7 +613,7 @@ file or a devicetree overlay :file:`sysbuild/my_sample.overlay`.
 
 A Kconfig fragment could look as:
 
-.. code-block:: none
+.. code-block:: cfg
 
    # sysbuild/my_sample.conf
    CONFIG_FOO=n

--- a/doc/build/version/index.rst
+++ b/doc/build/version/index.rst
@@ -26,7 +26,7 @@ which must be placed at the base directory of the application, where the CMakeLi
 located. This is a simple text file which contains the various version information fields, each on
 a newline. The basic ``VERSION`` file has the following structure:
 
-.. code-block:: none
+.. code-block:: cfg
 
    VERSION_MAJOR =
    VERSION_MINOR =
@@ -58,7 +58,7 @@ manually re-ran for changes to this file.
 
 For the sections below, examples are provided for the following :file:`VERSION` file:
 
-.. code-block:: none
+.. code-block:: cfg
 
    VERSION_MAJOR = 1
    VERSION_MINOR = 2

--- a/doc/build/zephyr_cmake_package.rst
+++ b/doc/build/zephyr_cmake_package.rst
@@ -233,15 +233,17 @@ In case no Zephyr is found which satisfies the version required, as example, the
    find_package(Zephyr 2.z)
    project(app)
 
-then an error similar to below will be printed::
+then an error similar to below will be printed:
 
-  Could not find a configuration file for package "Zephyr" that is compatible
-  with requested version "2.z".
+.. code-block:: none
 
-  The following configuration files were considered but not accepted:
+   Could not find a configuration file for package "Zephyr" that is compatible
+   with requested version "2.z".
 
-    <projects>/zephyr-workspace-2.a/zephyr/share/zephyr-package/cmake/ZephyrConfig.cmake, version: 2.a.0
-    <projects>/zephyr-workspace-2.b/zephyr/share/zephyr-package/cmake/ZephyrConfig.cmake, version: 2.b.0
+   The following configuration files were considered but not accepted:
+
+     <projects>/zephyr-workspace-2.a/zephyr/share/zephyr-package/cmake/ZephyrConfig.cmake, version: 2.a.0
+     <projects>/zephyr-workspace-2.b/zephyr/share/zephyr-package/cmake/ZephyrConfig.cmake, version: 2.b.0
 
 
 .. note:: It can also be beneficial to specify a version number for Zephyr repository applications


### PR DESCRIPTION
Set appropriate language for code blocks to show up with the right syntax highlighting.