### PR TITLE
doc: samples: smbus: Add console highlight to code block

### DIFF
--- a/samples/drivers/smbus/README.rst
+++ b/samples/drivers/smbus/README.rst
@@ -27,13 +27,17 @@ The sample can be built and run as follows for the ``qemu_x86_64`` board:
 Sample Output
 *************
 
-Output from console when application started::
+Output from console when application started:
+
+.. code-block:: console
 
    *** Booting Zephyr OS build zephyr-v3.2.0-804-gfedd72615e82  ***
    Start SMBUS shell sample qemu_x86_64
    uart:~$
 
-List available SMBus shell commands with::
+List available SMBus shell commands with:
+
+.. code-block:: console
 
    uart:~$ smbus
    smbus - smbus commands
@@ -59,7 +63,9 @@ List available SMBus shell commands with::
      block_read       :SMBus: Block Read command
                        Usage: block_read <device> <addr> <cmd>
 
-Scan for available SMBus devices with command::
+Scan for available SMBus devices with command:
+
+.. code-block:: console
 
    uart:~$ smbus scan smbus@fb00
         0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f


### PR DESCRIPTION
Display Zephyr console as 'code-block:: console'.