### PR TITLE
drivers: serial: return int value from uart_poll_out

### DIFF
--- a/drivers/auxdisplay/auxdisplay_itron.c
+++ b/drivers/auxdisplay/auxdisplay_itron.c
@@ -368,7 +368,7 @@ static int send_cmd(const struct device *dev, const uint8_t *command, uint8_t le
 		}
 #endif
 
-		uart_poll_out(uart, command[i]);
+		(void)uart_poll_out(uart, command[i]);
 		++i;
 	}
 

--- a/drivers/bluetooth/hci/h5.c
+++ b/drivers/bluetooth/hci/h5.c
@@ -265,15 +265,15 @@ static uint8_t h5_slip_byte(uint8_t byte)
 {
 	switch (byte) {
 	case SLIP_DELIMITER:
-		uart_poll_out(h5_dev, SLIP_ESC);
-		uart_poll_out(h5_dev, SLIP_ESC_DELIM);
+		(void)uart_poll_out(h5_dev, SLIP_ESC);
+		(void)uart_poll_out(h5_dev, SLIP_ESC_DELIM);
 		return 2;
 	case SLIP_ESC:
-		uart_poll_out(h5_dev, SLIP_ESC);
-		uart_poll_out(h5_dev, SLIP_ESC_ESC);
+		(void)uart_poll_out(h5_dev, SLIP_ESC);
+		(void)uart_poll_out(h5_dev, SLIP_ESC_ESC);
 		return 2;
 	default:
-		uart_poll_out(h5_dev, byte);
+		(void)uart_poll_out(h5_dev, byte);
 		return 1;
 	}
 }
@@ -306,7 +306,7 @@ static void h5_send(const uint8_t *payload, uint8_t type, int len)
 
 	h5_print_header(hdr, "TX: <");
 
-	uart_poll_out(h5_dev, SLIP_DELIMITER);
+	(void)uart_poll_out(h5_dev, SLIP_DELIMITER);
 
 	for (i = 0; i < 4; i++) {
 		h5_slip_byte(hdr[i]);
@@ -316,7 +316,7 @@ static void h5_send(const uint8_t *payload, uint8_t type, int len)
 		h5_slip_byte(payload[i]);
 	}
 
-	uart_poll_out(h5_dev, SLIP_DELIMITER);
+	(void)uart_poll_out(h5_dev, SLIP_DELIMITER);
 }
 
 /* Delayed work taking care about retransmitting packets */

--- a/drivers/console/uart_console.c
+++ b/drivers/console/uart_console.c
@@ -97,9 +97,9 @@ static int console_out(int c)
 	}
 
 	if ('\n' == c) {
-		uart_poll_out(uart_console_dev, '\r');
+		(void)uart_poll_out(uart_console_dev, '\r');
 	}
-	uart_poll_out(uart_console_dev, c);
+	(void)uart_poll_out(uart_console_dev, c);
 
 	if (pm_device_runtime_is_enabled(uart_console_dev)) {
 		/* As errors cannot be returned, ignore the return value */
@@ -180,7 +180,7 @@ static void insert_char(char *pos, char c, uint8_t end)
 	char tmp;
 
 	/* Echo back to console */
-	uart_poll_out(uart_console_dev, c);
+	(void)uart_poll_out(uart_console_dev, c);
 
 	if (end == 0U) {
 		*pos = c;
@@ -193,7 +193,7 @@ static void insert_char(char *pos, char c, uint8_t end)
 	cursor_save();
 
 	while (end-- > 0) {
-		uart_poll_out(uart_console_dev, tmp);
+		(void)uart_poll_out(uart_console_dev, tmp);
 		c = *pos;
 		*(pos++) = tmp;
 		tmp = c;
@@ -205,11 +205,11 @@ static void insert_char(char *pos, char c, uint8_t end)
 
 static void del_char(char *pos, uint8_t end)
 {
-	uart_poll_out(uart_console_dev, '\b');
+	(void)uart_poll_out(uart_console_dev, '\b');
 
 	if (end == 0U) {
-		uart_poll_out(uart_console_dev, ' ');
-		uart_poll_out(uart_console_dev, '\b');
+		(void)uart_poll_out(uart_console_dev, ' ');
+		(void)uart_poll_out(uart_console_dev, '\b');
 		return;
 	}
 
@@ -217,10 +217,10 @@ static void del_char(char *pos, uint8_t end)
 
 	while (end-- > 0) {
 		*pos = *(pos + 1);
-		uart_poll_out(uart_console_dev, *(pos++));
+		(void)uart_poll_out(uart_console_dev, *(pos++));
 	}
 
-	uart_poll_out(uart_console_dev, ' ');
+	(void)uart_poll_out(uart_console_dev, ' ');
 
 	/* Move cursor back to right place */
 	cursor_restore();
@@ -529,8 +529,8 @@ static void uart_console_isr(const struct device *unused, void *user_data)
 				}
 			case '\r':
 				cmd->line[cur + end] = '\0';
-				uart_poll_out(uart_console_dev, '\r');
-				uart_poll_out(uart_console_dev, '\n');
+				(void)uart_poll_out(uart_console_dev, '\r');
+				(void)uart_poll_out(uart_console_dev, '\n');
 				cur = 0U;
 				end = 0U;
 				k_fifo_put(lines_queue, cmd);

--- a/drivers/console/uart_mcumgr.c
+++ b/drivers/console/uart_mcumgr.c
@@ -206,7 +206,7 @@ static int uart_mcumgr_send_raw(const void *data, int len)
 
 	u8p = data;
 	while (len--) {
-		uart_poll_out(uart_mcumgr_dev, *u8p++);
+		(void)uart_poll_out(uart_mcumgr_dev, *u8p++);
 	}
 
 	return 0;

--- a/drivers/console/uart_mux.c
+++ b/drivers/console/uart_mux.c
@@ -810,7 +810,7 @@ int uart_mux_send(const struct device *uart, const uint8_t *buf, size_t size)
 	k_mutex_lock(&dev_data->real_uart->lock, K_FOREVER);
 
 	do {
-		uart_poll_out(dev_data->real_uart->uart, *buf++);
+		(void)uart_poll_out(dev_data->real_uart->uart, *buf++);
 	} while (--remaining);
 
 	k_mutex_unlock(&dev_data->real_uart->lock);

--- a/drivers/i2c/i2c_sc18im704.c
+++ b/drivers/i2c/i2c_sc18im704.c
@@ -59,7 +59,7 @@ int sc18im704_transfer(const struct device *dev,
 
 	if (tx_data != NULL) {
 		for (uint8_t i = 0; i < tx_len; ++i)  {
-			uart_poll_out(cfg->bus, tx_data[i]);
+			(void)uart_poll_out(cfg->bus, tx_data[i]);
 		}
 	}
 

--- a/drivers/modem/modem_iface_uart_interrupt.c
+++ b/drivers/modem/modem_iface_uart_interrupt.c
@@ -157,7 +157,7 @@ static int modem_iface_uart_write(struct modem_iface *iface,
 		uart_fifo_fill(iface->dev, buf, size);
 	} else {
 		do {
-			uart_poll_out(iface->dev, *buf++);
+			(void)uart_poll_out(iface->dev, *buf++);
 		} while (--size);
 	}
 

--- a/drivers/modem/modem_receiver.c
+++ b/drivers/modem/modem_receiver.c
@@ -190,7 +190,7 @@ int mdm_receiver_send(struct mdm_receiver_context *ctx,
 	}
 
 	do {
-		uart_poll_out(ctx->uart_dev, *buf++);
+		(void)uart_poll_out(ctx->uart_dev, *buf++);
 	} while (--size);
 
 	return 0;

--- a/drivers/net/ppp.c
+++ b/drivers/net/ppp.c
@@ -380,7 +380,7 @@ static int ppp_send_flush(struct ppp_driver_context *ppp, int off)
 #endif
 	} else {
 		while (off--) {
-			uart_poll_out(ppp->dev, *buf++);
+			(void)uart_poll_out(ppp->dev, *buf++);
 		}
 	}
 

--- a/drivers/serial/leuart_gecko.c
+++ b/drivers/serial/leuart_gecko.c
@@ -60,7 +60,7 @@ static int leuart_gecko_poll_in(const struct device *dev, unsigned char *c)
 	return -1;
 }
 
-static void leuart_gecko_poll_out(const struct device *dev, unsigned char c)
+static int leuart_gecko_poll_out(const struct device *dev, unsigned char c)
 {
 	LEUART_TypeDef *base = DEV_BASE(dev);
 
@@ -68,6 +68,8 @@ static void leuart_gecko_poll_out(const struct device *dev, unsigned char c)
 	 * and and waits for the bus to be free to transmit.
 	 */
 	LEUART_Tx(base, c);
+
+	return 0;
 }
 
 static int leuart_gecko_err_check(const struct device *dev)

--- a/drivers/serial/serial_esp32_usb.c
+++ b/drivers/serial/serial_esp32_usb.c
@@ -71,7 +71,7 @@ static int serial_esp32_usb_poll_in(const struct device *dev, unsigned char *p_c
 	return 0;
 }
 
-static void serial_esp32_usb_poll_out(const struct device *dev, unsigned char c)
+static int serial_esp32_usb_poll_out(const struct device *dev, unsigned char c)
 {
 	struct serial_esp32_usb_data *data = dev->data;
 
@@ -84,9 +84,11 @@ static void serial_esp32_usb_poll_out(const struct device *dev, unsigned char c)
 			usb_serial_jtag_ll_write_txfifo(&c, 1);
 			usb_serial_jtag_ll_txfifo_flush();
 			data->last_tx_time = k_uptime_get();
-			return;
+			return 0;
 		}
 	} while ((k_uptime_get() - data->last_tx_time) < USBSERIAL_POLL_OUT_TIMEOUT_MS);
+
+	return -EIO;
 }
 
 static int serial_esp32_usb_err_check(const struct device *dev)

--- a/drivers/serial/serial_test.c
+++ b/drivers/serial/serial_test.c
@@ -198,19 +198,21 @@ static int serial_vnd_poll_in(const struct device *dev, unsigned char *c)
 #endif
 }
 
-static void serial_vnd_poll_out(const struct device *dev, unsigned char c)
+static int serial_vnd_poll_out(const struct device *dev, unsigned char c)
 {
 	struct serial_vnd_data *data = dev->data;
 
 #ifdef CONFIG_RING_BUFFER
 	if (data == NULL || data->written == NULL) {
-		return;
+		return -EIO;
 	}
 	ring_buf_put(data->written, &c, 1);
 #endif
 	if (data->callback) {
 		data->callback(dev, data->callback_data);
 	}
+
+	return 0;
 }
 
 #ifdef CONFIG_UART_ASYNC_API

--- a/drivers/serial/uart_altera.c
+++ b/drivers/serial/uart_altera.c
@@ -178,7 +178,7 @@ static int uart_altera_poll_in(const struct device *dev, unsigned char *p_char)
  * @param dev UART device instance
  * @param c Character to send
  */
-static void uart_altera_poll_out(const struct device *dev, unsigned char c)
+static int uart_altera_poll_out(const struct device *dev, unsigned char c)
 {
 	const struct uart_altera_device_config *config = dev->config;
 	struct uart_altera_device_data *data = dev->data;
@@ -194,6 +194,8 @@ static void uart_altera_poll_out(const struct device *dev, unsigned char c)
 	sys_write32(c, config->base + ALTERA_AVALON_UART_TXDATA_REG_OFFSET);
 
 	k_spin_unlock(&data->lock, key);
+
+	return 0;
 }
 
 /**

--- a/drivers/serial/uart_altera_jtag.c
+++ b/drivers/serial/uart_altera_jtag.c
@@ -115,7 +115,7 @@ static int uart_altera_jtag_poll_in(const struct device *dev,
  * @param dev UART device instance
  * @param c Character to send
  */
-static void uart_altera_jtag_poll_out(const struct device *dev,
+static int uart_altera_jtag_poll_out(const struct device *dev,
 					       unsigned char c)
 {
 #ifdef CONFIG_UART_ALTERA_JTAG_HAL
@@ -137,6 +137,8 @@ static void uart_altera_jtag_poll_out(const struct device *dev,
 
 	k_spin_unlock(&data->lock, key);
 #endif /* CONFIG_UART_ALTERA_JTAG_HAL */
+
+	return 0;
 }
 
 /**

--- a/drivers/serial/uart_apbuart.c
+++ b/drivers/serial/uart_apbuart.c
@@ -140,7 +140,7 @@ struct apbuart_dev_data {
  * This routine waits for the TX holding register or TX FIFO to be ready and
  * then it writes a character to the data register.
  */
-static void apbuart_poll_out(const struct device *dev, unsigned char x)
+static int apbuart_poll_out(const struct device *dev, unsigned char x)
 {
 	const struct apbuart_dev_cfg *config = dev->config;
 	struct apbuart_dev_data *data = dev->data;
@@ -162,6 +162,8 @@ static void apbuart_poll_out(const struct device *dev, unsigned char x)
 	}
 
 	regs->data = x & 0xff;
+
+	return 0;
 }
 
 static int apbuart_poll_in(const struct device *dev, unsigned char *c)

--- a/drivers/serial/uart_b91.c
+++ b/drivers/serial/uart_b91.c
@@ -334,7 +334,7 @@ static int uart_b91_driver_init(const struct device *dev)
 }
 
 /* API implementation: poll_out */
-static void uart_b91_poll_out(const struct device *dev, uint8_t c)
+static int uart_b91_poll_out(const struct device *dev, uint8_t c)
 {
 	volatile struct uart_b91_t *uart = GET_UART(dev);
 	struct uart_b91_data *data = dev->data;
@@ -344,6 +344,8 @@ static void uart_b91_poll_out(const struct device *dev, uint8_t c)
 
 	uart->data_buf[data->tx_byte_index] = c;
 	data->tx_byte_index = (data->tx_byte_index + 1) % ARRAY_SIZE(uart->data_buf);
+
+	return 0;
 }
 
 /* API implementation: poll_in */

--- a/drivers/serial/uart_bcm2711.c
+++ b/drivers/serial/uart_bcm2711.c
@@ -137,11 +137,13 @@ static int uart_bcm2711_init(const struct device *dev)
 	return 0;
 }
 
-static void uart_bcm2711_poll_out(const struct device *dev, unsigned char c)
+static int uart_bcm2711_poll_out(const struct device *dev, unsigned char c)
 {
 	struct bcm2711_uart_data *uart_data = dev->data;
 
 	bcm2711_mu_lowlevel_putc(uart_data->uart_addr, c);
+
+	return 0;
 }
 
 static int uart_bcm2711_poll_in(const struct device *dev, unsigned char *c)

--- a/drivers/serial/uart_cc13xx_cc26xx.c
+++ b/drivers/serial/uart_cc13xx_cc26xx.c
@@ -60,7 +60,7 @@ static int uart_cc13xx_cc26xx_poll_in(const struct device *dev,
 	return 0;
 }
 
-static void uart_cc13xx_cc26xx_poll_out(const struct device *dev,
+static int uart_cc13xx_cc26xx_poll_out(const struct device *dev,
 					unsigned char c)
 {
 	const struct uart_cc13xx_cc26xx_config *config = dev->config;
@@ -72,6 +72,8 @@ static void uart_cc13xx_cc26xx_poll_out(const struct device *dev,
 	 */
 	while (UARTBusy(config->reg) == true) {
 	}
+
+	return 0;
 }
 
 static int uart_cc13xx_cc26xx_err_check(const struct device *dev)

--- a/drivers/serial/uart_cc32xx.c
+++ b/drivers/serial/uart_cc32xx.c
@@ -104,11 +104,13 @@ static int uart_cc32xx_poll_in(const struct device *dev, unsigned char *c)
 	return 0;
 }
 
-static void uart_cc32xx_poll_out(const struct device *dev, unsigned char c)
+static int uart_cc32xx_poll_out(const struct device *dev, unsigned char c)
 {
 	const struct uart_cc32xx_dev_config *config = dev->config;
 
 	MAP_UARTCharPut(config->base, c);
+
+	return 0;
 }
 
 static int uart_cc32xx_err_check(const struct device *dev)

--- a/drivers/serial/uart_cdns.c
+++ b/drivers/serial/uart_cdns.c
@@ -52,13 +52,15 @@ void uart_cdns_set_baudrate(struct uart_cdns_regs *uart_regs,
 				   ((dev_cfg->bdiv + 1) * baud_rate);
 }
 
-static void uart_cdns_poll_out(const struct device *dev, unsigned char out_char)
+static int uart_cdns_poll_out(const struct device *dev, unsigned char out_char)
 {
 	struct uart_cdns_regs *uart_regs = DEV_UART(dev);
 	/* Wait while TX FIFO is full */
 	while (uart_cdns_is_tx_fifo_full(uart_regs)) {
 	}
 	uart_regs->rx_tx_fifo = (uint32_t)out_char;
+
+	return 0;
 }
 
 /** @brief Poll the device for input. */

--- a/drivers/serial/uart_cmsdk_apb.c
+++ b/drivers/serial/uart_cmsdk_apb.c
@@ -187,7 +187,7 @@ static int uart_cmsdk_apb_poll_in(const struct device *dev, unsigned char *c)
  * @param dev UART device struct
  * @param c Character to send
  */
-static void uart_cmsdk_apb_poll_out(const struct device *dev,
+static int uart_cmsdk_apb_poll_out(const struct device *dev,
 					     unsigned char c)
 {
 	const struct uart_cmsdk_apb_config *dev_cfg = dev->config;
@@ -199,6 +199,8 @@ static void uart_cmsdk_apb_poll_out(const struct device *dev,
 
 	/* Send a character */
 	dev_cfg->uart->data = (uint32_t)c;
+
+	return 0;
 }
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN

--- a/drivers/serial/uart_efinix_sapphire.c
+++ b/drivers/serial/uart_efinix_sapphire.c
@@ -37,13 +37,15 @@ struct uart_efinix_sapphire_config {
 	uint32_t baudrate;
 };
 
-static void uart_efinix_sapphire_poll_out(const struct device *dev, unsigned char c)
+static int uart_efinix_sapphire_poll_out(const struct device *dev, unsigned char c)
 {
 	/* uart_writeAvailability */
 	while ((sys_read32(UART0_STATUS_REG_ADDR) & BSP_UART_WRITE_AVAILABILITY_MASK) == 0) {
 	}
 
 	sys_write8(c, UART0_DATA_REG_ADDR);
+
+	return 0;
 }
 
 static int uart_efinix_sapphire_poll_in(const struct device *dev, unsigned char *c)

--- a/drivers/serial/uart_emul.c
+++ b/drivers/serial/uart_emul.c
@@ -65,7 +65,7 @@ static int uart_emul_poll_in(const struct device *dev, unsigned char *p_char)
 	return 0;
 }
 
-static void uart_emul_poll_out(const struct device *dev, unsigned char out_char)
+static int uart_emul_poll_out(const struct device *dev, unsigned char out_char)
 {
 	struct uart_emul_data *drv_data = dev->data;
 	const struct uart_emul_config *drv_cfg = dev->config;
@@ -78,7 +78,7 @@ static void uart_emul_poll_out(const struct device *dev, unsigned char out_char)
 
 	if (!written) {
 		LOG_DBG("Tx buffer is full");
-		return;
+		return -EIO;
 	}
 
 	if (drv_cfg->loopback) {
@@ -88,6 +88,8 @@ static void uart_emul_poll_out(const struct device *dev, unsigned char out_char)
 		(drv_data->tx_data_ready_cb)(dev, ring_buf_size_get(drv_data->tx_rb),
 					     drv_data->user_data);
 	}
+
+	return 0;
 }
 
 static int uart_emul_err_check(const struct device *dev)

--- a/drivers/serial/uart_esp32.c
+++ b/drivers/serial/uart_esp32.c
@@ -130,7 +130,7 @@ static int uart_esp32_poll_in(const struct device *dev, unsigned char *p_char)
 	return 0;
 }
 
-static void uart_esp32_poll_out(const struct device *dev, unsigned char c)
+static int uart_esp32_poll_out(const struct device *dev, unsigned char c)
 {
 	struct uart_esp32_data *data = dev->data;
 	uint32_t written;
@@ -142,6 +142,8 @@ static void uart_esp32_poll_out(const struct device *dev, unsigned char c)
 
 	/* Send a character */
 	uart_hal_write_txfifo(&data->hal, &c, 1, &written);
+
+	return 0;
 }
 
 static int uart_esp32_err_check(const struct device *dev)

--- a/drivers/serial/uart_gecko.c
+++ b/drivers/serial/uart_gecko.c
@@ -169,11 +169,13 @@ static int uart_gecko_poll_in(const struct device *dev, unsigned char *c)
 	return -1;
 }
 
-static void uart_gecko_poll_out(const struct device *dev, unsigned char c)
+static int uart_gecko_poll_out(const struct device *dev, unsigned char c)
 {
 	const struct uart_gecko_config *config = dev->config;
 
 	USART_Tx(config->base, c);
+
+	return 0;
 }
 
 static int uart_gecko_err_check(const struct device *dev)

--- a/drivers/serial/uart_handlers.c
+++ b/drivers/serial/uart_handlers.c
@@ -42,19 +42,19 @@ static inline int z_vrfy_uart_poll_in_u16(const struct device *dev,
 }
 #include <syscalls/uart_poll_in_u16_mrsh.c>
 
-static inline void z_vrfy_uart_poll_out(const struct device *dev,
+static inline int z_vrfy_uart_poll_out(const struct device *dev,
 					unsigned char out_char)
 {
 	Z_OOPS(Z_SYSCALL_DRIVER_UART(dev, poll_out));
-	z_impl_uart_poll_out((const struct device *)dev, out_char);
+	return z_impl_uart_poll_out((const struct device *)dev, out_char);
 }
 #include <syscalls/uart_poll_out_mrsh.c>
 
-static inline void z_vrfy_uart_poll_out_u16(const struct device *dev,
+static inline int z_vrfy_uart_poll_out_u16(const struct device *dev,
 					    uint16_t out_u16)
 {
 	Z_OOPS(Z_SYSCALL_DRIVER_UART(dev, poll_out));
-	z_impl_uart_poll_out_u16((const struct device *)dev, out_u16);
+	return z_impl_uart_poll_out_u16((const struct device *)dev, out_u16);
 }
 #include <syscalls/uart_poll_out_u16_mrsh.c>
 

--- a/drivers/serial/uart_hostlink.c
+++ b/drivers/serial/uart_hostlink.c
@@ -387,11 +387,13 @@ static int uart_hostlink_poll_in(const struct device *dev, unsigned char *c)
  * @param dev UART device struct
  * @param c Character to send
  */
-static void uart_hostlink_poll_out(const struct device *dev, unsigned char c)
+static int uart_hostlink_poll_out(const struct device *dev, unsigned char c)
 {
 	ARG_UNUSED(dev);
 
 	hl_write_char(1, c);
+
+	return 0;
 }
 
 static const struct uart_driver_api uart_hostlink_driver_api = {

--- a/drivers/serial/uart_hvc_xen.c
+++ b/drivers/serial/uart_hvc_xen.c
@@ -98,11 +98,13 @@ static int xen_hvc_poll_in(const struct device *dev,
 	return 0;
 }
 
-static void xen_hvc_poll_out(const struct device *dev,
+static int xen_hvc_poll_out(const struct device *dev,
 			unsigned char c)
 {
 	/* Not a good solution (notifying HV every time), but needed for poll_out */
 	(void) write_to_ring(dev, &c, sizeof(c));
+
+	return 0;
 }
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN

--- a/drivers/serial/uart_hvc_xen_consoleio.c
+++ b/drivers/serial/uart_hvc_xen_consoleio.c
@@ -33,10 +33,12 @@ static int xen_consoleio_poll_in(const struct device *dev,
 	return 0;
 }
 
-static void xen_consoleio_poll_out(const struct device *dev,
+static int xen_consoleio_poll_out(const struct device *dev,
 			unsigned char c)
 {
 	(void) HYPERVISOR_console_io(CONSOLEIO_write, sizeof(c), &c);
+
+	return 0;
 }
 
 static const struct uart_driver_api xen_consoleio_hvc_api = {

--- a/drivers/serial/uart_ifx_cat1.c
+++ b/drivers/serial/uart_ifx_cat1.c
@@ -174,11 +174,13 @@ static int ifx_cat1_uart_poll_in(const struct device *dev, unsigned char *c)
 	return ((rec == CY_SCB_UART_RX_NO_DATA) ? -1 : 0);
 }
 
-static void ifx_cat1_uart_poll_out(const struct device *dev, unsigned char c)
+static int ifx_cat1_uart_poll_out(const struct device *dev, unsigned char c)
 {
 	struct ifx_cat1_uart_data *data = dev->data;
 
 	(void) cyhal_uart_putc(&data->obj, (uint32_t)c);
+
+	return 0;
 }
 
 static int ifx_cat1_uart_err_check(const struct device *dev)

--- a/drivers/serial/uart_imx.c
+++ b/drivers/serial/uart_imx.c
@@ -102,13 +102,15 @@ static int uart_imx_init(const struct device *dev)
 	return 0;
 }
 
-static void uart_imx_poll_out(const struct device *dev, unsigned char c)
+static int uart_imx_poll_out(const struct device *dev, unsigned char c)
 {
 	UART_Type *uart = UART_STRUCT(dev);
 
 	while (!UART_GetStatusFlag(uart, uartStatusTxReady)) {
 	}
 	UART_Putchar(uart, c);
+
+	return 0;
 }
 
 static int uart_imx_poll_in(const struct device *dev, unsigned char *c)

--- a/drivers/serial/uart_liteuart.c
+++ b/drivers/serial/uart_liteuart.c
@@ -55,13 +55,15 @@ struct uart_liteuart_data {
  * @param dev UART device struct
  * @param c Character to send
  */
-static void uart_liteuart_poll_out(const struct device *dev, unsigned char c)
+static int uart_liteuart_poll_out(const struct device *dev, unsigned char c)
 {
 	/* wait for space */
 	while (litex_read8(UART_TXFULL_ADDR)) {
 	}
 
 	litex_write8(c, UART_RXTX_ADDR);
+
+	return 0;
 }
 
 /**

--- a/drivers/serial/uart_lpc11u6x.c
+++ b/drivers/serial/uart_lpc11u6x.c
@@ -26,13 +26,15 @@ static int lpc11u6x_uart0_poll_in(const struct device *dev, unsigned char *c)
 	return 0;
 }
 
-static void lpc11u6x_uart0_poll_out(const struct device *dev, unsigned char c)
+static int lpc11u6x_uart0_poll_out(const struct device *dev, unsigned char c)
 {
 	const struct lpc11u6x_uart0_config *cfg = dev->config;
 
 	while (!(cfg->uart0->lsr & LPC11U6X_UART0_LSR_THRE)) {
 	}
 	cfg->uart0->thr = c;
+
+	return 0;
 }
 
 static int lpc11u6x_uart0_err_check(const struct device *dev)
@@ -456,13 +458,15 @@ static int lpc11u6x_uartx_poll_in(const struct device *dev, unsigned char *c)
 	return 0;
 }
 
-static void lpc11u6x_uartx_poll_out(const struct device *dev, unsigned char c)
+static int lpc11u6x_uartx_poll_out(const struct device *dev, unsigned char c)
 {
 	const struct lpc11u6x_uartx_config *cfg = dev->config;
 
 	while (!(cfg->base->stat & LPC11U6X_UARTX_STAT_TXRDY)) {
 	}
 	cfg->base->tx_dat = c;
+
+	return 0;
 }
 
 static int lpc11u6x_uartx_err_check(const struct device *dev)

--- a/drivers/serial/uart_mchp_xec.c
+++ b/drivers/serial/uart_mchp_xec.c
@@ -586,7 +586,7 @@ static int uart_xec_poll_in(const struct device *dev, unsigned char *c)
  * @param dev UART device struct
  * @param c Character to send
  */
-static void uart_xec_poll_out(const struct device *dev, unsigned char c)
+static int uart_xec_poll_out(const struct device *dev, unsigned char c)
 {
 	const struct uart_xec_device_config * const dev_cfg = dev->config;
 	struct uart_xec_dev_data *dev_data = dev->data;
@@ -600,6 +600,8 @@ static void uart_xec_poll_out(const struct device *dev, unsigned char c)
 	regs->RTXB = c;
 
 	k_spin_unlock(&dev_data->lock, key);
+
+	return 0;
 }
 
 /**

--- a/drivers/serial/uart_mcux.c
+++ b/drivers/serial/uart_mcux.c
@@ -136,7 +136,7 @@ static int uart_mcux_poll_in(const struct device *dev, unsigned char *c)
 	return ret;
 }
 
-static void uart_mcux_poll_out(const struct device *dev, unsigned char c)
+static int uart_mcux_poll_out(const struct device *dev, unsigned char c)
 {
 	const struct uart_mcux_config *config = dev->config;
 
@@ -144,6 +144,8 @@ static void uart_mcux_poll_out(const struct device *dev, unsigned char c)
 	}
 
 	UART_WriteByte(config->base, c);
+
+	return 0;
 }
 
 static int uart_mcux_err_check(const struct device *dev)

--- a/drivers/serial/uart_mcux_flexcomm.c
+++ b/drivers/serial/uart_mcux_flexcomm.c
@@ -102,7 +102,7 @@ static int mcux_flexcomm_poll_in(const struct device *dev, unsigned char *c)
 	return ret;
 }
 
-static void mcux_flexcomm_poll_out(const struct device *dev,
+static int mcux_flexcomm_poll_out(const struct device *dev,
 					     unsigned char c)
 {
 	const struct mcux_flexcomm_config *config = dev->config;
@@ -112,6 +112,8 @@ static void mcux_flexcomm_poll_out(const struct device *dev,
 	}
 
 	USART_WriteByte(config->base, c);
+
+	return 0;
 }
 
 static int mcux_flexcomm_err_check(const struct device *dev)

--- a/drivers/serial/uart_mcux_iuart.c
+++ b/drivers/serial/uart_mcux_iuart.c
@@ -47,7 +47,7 @@ static int mcux_iuart_poll_in(const struct device *dev, unsigned char *c)
 	return ret;
 }
 
-static void mcux_iuart_poll_out(const struct device *dev, unsigned char c)
+static int mcux_iuart_poll_out(const struct device *dev, unsigned char c)
 {
 	const struct mcux_iuart_config *config = dev->config;
 
@@ -55,6 +55,8 @@ static void mcux_iuart_poll_out(const struct device *dev, unsigned char c)
 	}
 
 	UART_WriteByte(config->base, c);
+
+	return 0;
 }
 
 static int mcux_iuart_err_check(const struct device *dev)

--- a/drivers/serial/uart_mcux_lpsci.c
+++ b/drivers/serial/uart_mcux_lpsci.c
@@ -47,7 +47,7 @@ static int mcux_lpsci_poll_in(const struct device *dev, unsigned char *c)
 	return ret;
 }
 
-static void mcux_lpsci_poll_out(const struct device *dev, unsigned char c)
+static int mcux_lpsci_poll_out(const struct device *dev, unsigned char c)
 {
 	const struct mcux_lpsci_config *config = dev->config;
 
@@ -56,6 +56,8 @@ static void mcux_lpsci_poll_out(const struct device *dev, unsigned char c)
 	}
 
 	LPSCI_WriteByte(config->base, c);
+
+	return 0;
 }
 
 static int mcux_lpsci_err_check(const struct device *dev)

--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -133,7 +133,7 @@ static int mcux_lpuart_poll_in(const struct device *dev, unsigned char *c)
 	return ret;
 }
 
-static void mcux_lpuart_poll_out(const struct device *dev, unsigned char c)
+static int mcux_lpuart_poll_out(const struct device *dev, unsigned char c)
 {
 	const struct mcux_lpuart_config *config = dev->config;
 	unsigned int key;
@@ -165,6 +165,8 @@ static void mcux_lpuart_poll_out(const struct device *dev, unsigned char c)
 
 	LPUART_WriteByte(config->base, c);
 	irq_unlock(key);
+
+	return 0;
 }
 
 static int mcux_lpuart_err_check(const struct device *dev)

--- a/drivers/serial/uart_miv.c
+++ b/drivers/serial/uart_miv.c
@@ -149,7 +149,7 @@ struct uart_miv_data {
 	((struct uart_miv_regs_t *)				\
 	 ((const struct uart_miv_device_config * const)(dev)->config)->uart_addr)
 
-static void uart_miv_poll_out(const struct device *dev,
+static int uart_miv_poll_out(const struct device *dev,
 				       unsigned char c)
 {
 	volatile struct uart_miv_regs_t *uart = DEV_UART(dev);
@@ -158,6 +158,8 @@ static void uart_miv_poll_out(const struct device *dev,
 	}
 
 	uart->tx = c;
+
+	return 0;
 }
 
 static int uart_miv_poll_in(const struct device *dev, unsigned char *c)

--- a/drivers/serial/uart_msp432p4xx.c
+++ b/drivers/serial/uart_msp432p4xx.c
@@ -162,12 +162,14 @@ static int uart_msp432p4xx_poll_in(const struct device *dev, unsigned char *c)
 	return 0;
 }
 
-static void uart_msp432p4xx_poll_out(const struct device *dev,
+static int uart_msp432p4xx_poll_out(const struct device *dev,
 				     unsigned char c)
 {
 	const struct uart_msp432p4xx_config *config = dev->config;
 
 	MAP_UART_transmitData(config->base, c);
+
+	return 0;
 }
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN

--- a/drivers/serial/uart_native_ptty.c
+++ b/drivers/serial/uart_native_ptty.c
@@ -38,7 +38,7 @@ static int np_uart_stdin_poll_in(const struct device *dev,
 				 unsigned char *p_char);
 static int np_uart_tty_poll_in(const struct device *dev,
 			       unsigned char *p_char);
-static void np_uart_poll_out(const struct device *dev,
+static int np_uart_poll_out(const struct device *dev,
 				      unsigned char out_char);
 
 static bool auto_attach;
@@ -126,8 +126,7 @@ static int np_uart_1_init(const struct device *dev)
  * @param dev UART device struct
  * @param out_char Character to send.
  */
-static void np_uart_poll_out(const struct device *dev,
-				      unsigned char out_char)
+static int np_uart_poll_out(const struct device *dev, unsigned char out_char)
 {
 	int ret;
 	struct native_uart_status *d = (struct native_uart_status *)dev->data;
@@ -144,11 +143,9 @@ static void np_uart_poll_out(const struct device *dev,
 		}
 	}
 
-	/* The return value of write() cannot be ignored (there is a warning)
-	 * but we do not need the return value for anything.
-	 */
 	ret = nsi_host_write(d->out_fd, &out_char, 1);
-	(void) ret;
+
+	return ret != -1 ? 0 : -EIO;
 }
 
 /**

--- a/drivers/serial/uart_native_tty.c
+++ b/drivers/serial/uart_native_tty.c
@@ -116,7 +116,7 @@ static int native_tty_conv_to_bottom_cfg(struct native_tty_bottom_cfg *bottom_cf
  * @param dev		UART device structure.
  * @param out_char	Character to send.
  */
-static void native_tty_uart_poll_out(const struct device *dev, unsigned char out_char)
+static int native_tty_uart_poll_out(const struct device *dev, unsigned char out_char)
 {
 	struct native_tty_data *data = dev->data;
 
@@ -124,7 +124,10 @@ static void native_tty_uart_poll_out(const struct device *dev, unsigned char out
 
 	if (ret == -1) {
 		ERROR("Could not write to %s\n", data->serial_port);
+		return -EIO;
 	}
+
+	return 0;
 }
 
 /**

--- a/drivers/serial/uart_neorv32.c
+++ b/drivers/serial/uart_neorv32.c
@@ -111,12 +111,14 @@ static int neorv32_uart_poll_in(const struct device *dev, unsigned char *c)
 	return -1;
 }
 
-static void neorv32_uart_poll_out(const struct device *dev, unsigned char c)
+static int neorv32_uart_poll_out(const struct device *dev, unsigned char c)
 {
 	while ((neorv32_uart_read_ctrl(dev) & NEORV32_UART_CTRL_TX_BUSY) != 0) {
 	}
 
 	neorv32_uart_write_data(dev, c);
+
+	return 0;
 }
 
 static int neorv32_uart_configure(const struct device *dev, const struct uart_config *cfg)

--- a/drivers/serial/uart_npcx.c
+++ b/drivers/serial/uart_npcx.c
@@ -339,10 +339,12 @@ static int uart_npcx_poll_in(const struct device *dev, unsigned char *c)
  * Poll-out implementation for interrupt driven config, forward call to
  * uart_npcx_fifo_fill().
  */
-static void uart_npcx_poll_out(const struct device *dev, unsigned char c)
+static int uart_npcx_poll_out(const struct device *dev, unsigned char c)
 {
 	while (!uart_npcx_fifo_fill(dev, &c, 1))
 		continue;
+
+	return 0;
 }
 
 #else /* !CONFIG_UART_INTERRUPT_DRIVEN */
@@ -367,7 +369,7 @@ static int uart_npcx_poll_in(const struct device *dev, unsigned char *c)
 /*
  * Poll-out implementation for byte mode config, write byte to UTBUF if empty.
  */
-static void uart_npcx_poll_out(const struct device *dev, unsigned char c)
+static int uart_npcx_poll_out(const struct device *dev, unsigned char c)
 {
 	const struct uart_npcx_config *const config = dev->config;
 	struct uart_reg *const inst = config->inst;
@@ -377,6 +379,8 @@ static void uart_npcx_poll_out(const struct device *dev, unsigned char c)
 		continue;
 
 	inst->UTBUF = c;
+
+	return 0;
 }
 #endif /* !CONFIG_UART_INTERRUPT_DRIVEN */
 

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1477,7 +1477,7 @@ static int uarte_nrfx_poll_in(const struct device *dev, unsigned char *c)
  * @param dev UARTE device struct
  * @param c Character to send
  */
-static void uarte_nrfx_poll_out(const struct device *dev, unsigned char c)
+static int uarte_nrfx_poll_out(const struct device *dev, unsigned char c)
 {
 	struct uarte_nrfx_data *data = dev->data;
 	bool isr_mode = k_is_in_isr() || k_is_pre_kernel();
@@ -1508,6 +1508,8 @@ static void uarte_nrfx_poll_out(const struct device *dev, unsigned char c)
 	tx_start(dev, data->char_out, 1);
 
 	irq_unlock(key);
+
+	return 0;
 }
 
 

--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -733,7 +733,7 @@ static int uart_ns16550_poll_in(const struct device *dev, unsigned char *c)
  * @param dev UART device struct
  * @param c Character to send
  */
-static void uart_ns16550_poll_out(const struct device *dev,
+static int uart_ns16550_poll_out(const struct device *dev,
 					   unsigned char c)
 {
 	struct uart_ns16550_dev_data *data = dev->data;
@@ -746,6 +746,8 @@ static void uart_ns16550_poll_out(const struct device *dev,
 	ns16550_outbyte(dev_cfg, THR(dev), c);
 
 	k_spin_unlock(&data->lock, key);
+
+	return 0;
 }
 
 /**

--- a/drivers/serial/uart_numaker.c
+++ b/drivers/serial/uart_numaker.c
@@ -54,11 +54,13 @@ static int uart_numaker_poll_in(const struct device *dev, unsigned char *c)
 	return 0;
 }
 
-static void uart_numaker_poll_out(const struct device *dev, unsigned char c)
+static int uart_numaker_poll_out(const struct device *dev, unsigned char c)
 {
 	const struct uart_numaker_config *config = dev->config;
 
 	UART_Write(config->uart, &c, 1);
+
+	return 0;
 }
 
 static int uart_numaker_err_check(const struct device *dev)

--- a/drivers/serial/uart_numicro.c
+++ b/drivers/serial/uart_numicro.c
@@ -37,11 +37,13 @@ static int uart_numicro_poll_in(const struct device *dev, unsigned char *c)
 	return 0;
 }
 
-static void uart_numicro_poll_out(const struct device *dev, unsigned char c)
+static int uart_numicro_poll_out(const struct device *dev, unsigned char c)
 {
 	const struct uart_numicro_config *config = dev->config;
 
 	UART_Write(config->uart, &c, 1);
+
+	return 0;
 }
 
 static int uart_numicro_err_check(const struct device *dev)

--- a/drivers/serial/uart_opentitan.c
+++ b/drivers/serial/uart_opentitan.c
@@ -81,7 +81,7 @@ static int uart_opentitan_poll_in(const struct device *dev, unsigned char *c)
 	return 0;
 }
 
-static void uart_opentitan_poll_out(const struct device *dev, unsigned char c)
+static int uart_opentitan_poll_out(const struct device *dev, unsigned char c)
 {
 	const struct uart_opentitan_config *cfg = dev->config;
 
@@ -92,6 +92,8 @@ static void uart_opentitan_poll_out(const struct device *dev, unsigned char c)
 	}
 
 	sys_write32(c, cfg->base + UART_WDATA_REG_OFFSET);
+
+	return 0;
 }
 
 static const struct uart_driver_api uart_opentitan_driver_api = {

--- a/drivers/serial/uart_pipe.c
+++ b/drivers/serial/uart_pipe.c
@@ -70,7 +70,7 @@ int uart_pipe_send(const uint8_t *data, int len)
 	LOG_HEXDUMP_DBG(data, len, "TX");
 
 	while (len--)  {
-		uart_poll_out(uart_pipe_dev, *data++);
+		(void)uart_poll_out(uart_pipe_dev, *data++);
 	}
 
 	return 0;

--- a/drivers/serial/uart_pl011.c
+++ b/drivers/serial/uart_pl011.c
@@ -127,7 +127,7 @@ static int pl011_poll_in(const struct device *dev, unsigned char *c)
 	return get_uart(dev)->rsr & PL011_RSR_ERROR_MASK;
 }
 
-static void pl011_poll_out(const struct device *dev,
+static int pl011_poll_out(const struct device *dev,
 					     unsigned char c)
 {
 	/* Wait for space in FIFO */
@@ -137,6 +137,8 @@ static void pl011_poll_out(const struct device *dev,
 
 	/* Send a character */
 	get_uart(dev)->dr = (uint32_t)c;
+
+	return 0;
 }
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN

--- a/drivers/serial/uart_psoc6.c
+++ b/drivers/serial/uart_psoc6.c
@@ -141,12 +141,14 @@ static int uart_psoc6_poll_in(const struct device *dev, unsigned char *c)
 	return ((rec == CY_SCB_UART_RX_NO_DATA) ? -1 : 0);
 }
 
-static void uart_psoc6_poll_out(const struct device *dev, unsigned char c)
+static int uart_psoc6_poll_out(const struct device *dev, unsigned char c)
 {
 	const struct cypress_psoc6_config *config = dev->config;
 
 	while (Cy_SCB_UART_Put(config->base, (uint32_t)c) != 1UL) {
 	}
+
+	return 0;
 }
 
 static int uart_psoc6_err_check(const struct device *dev)

--- a/drivers/serial/uart_ql_usbserialport_s3b.c
+++ b/drivers/serial/uart_ql_usbserialport_s3b.c
@@ -49,12 +49,14 @@ static bool usbserial_rx_fifo_empty(void)
  * @param dev UART device struct
  * @param c Character to send
  */
-static void uart_usbserial_poll_out(const struct device *dev, unsigned char c)
+static int uart_usbserial_poll_out(const struct device *dev, unsigned char c)
 {
 	 /* Wait for room in Tx FIFO */
 	while (usbserial_tx_fifo_full())
 		;
 	usbserial_regs->wdata = c;
+
+	return 0;
 }
 
 /**

--- a/drivers/serial/uart_rcar.c
+++ b/drivers/serial/uart_rcar.c
@@ -158,7 +158,7 @@ unlock:
 	return ret;
 }
 
-static void uart_rcar_poll_out(const struct device *dev, unsigned char out_char)
+static int uart_rcar_poll_out(const struct device *dev, unsigned char out_char)
 {
 	struct uart_rcar_data *data = dev->data;
 	uint16_t reg_val;
@@ -175,6 +175,8 @@ static void uart_rcar_poll_out(const struct device *dev, unsigned char out_char)
 	uart_rcar_write_16(dev, SCFSR, reg_val);
 
 	k_spin_unlock(&data->lock, key);
+
+	return 0;
 }
 
 static int uart_rcar_configure(const struct device *dev,

--- a/drivers/serial/uart_rpi_pico.c
+++ b/drivers/serial/uart_rpi_pico.c
@@ -47,7 +47,7 @@ static int uart_rpi_poll_in(const struct device *dev, unsigned char *c)
 	return 0;
 }
 
-static void uart_rpi_poll_out(const struct device *dev, unsigned char c)
+static int uart_rpi_poll_out(const struct device *dev, unsigned char c)
 {
 	const struct uart_rpi_config *config = dev->config;
 	uart_hw_t * const uart_hw = config->uart_regs;
@@ -57,6 +57,8 @@ static void uart_rpi_poll_out(const struct device *dev, unsigned char c)
 	}
 
 	uart_hw->dr = c;
+
+	return 0;
 }
 
 static int uart_rpi_set_format(const struct device *dev, const struct uart_config *cfg)

--- a/drivers/serial/uart_rpi_pico_pio.c
+++ b/drivers/serial/uart_rpi_pico_pio.c
@@ -132,12 +132,14 @@ static int pio_uart_poll_in(const struct device *dev, unsigned char *c)
 	return 0;
 }
 
-static void pio_uart_poll_out(const struct device *dev, unsigned char c)
+static int pio_uart_poll_out(const struct device *dev, unsigned char c)
 {
 	const struct pio_uart_config *config = dev->config;
 	struct pio_uart_data *data = dev->data;
 
 	pio_sm_put_blocking(pio_rpi_pico_get_pio(config->piodev), data->tx_sm, (uint32_t)c);
+
+	return 0;
 }
 
 static int pio_uart_init(const struct device *dev)

--- a/drivers/serial/uart_rtt.c
+++ b/drivers/serial/uart_rtt.c
@@ -71,12 +71,13 @@ static int uart_rtt_poll_in(const struct device *dev, unsigned char *c)
  * @param dev UART device struct
  * @param c Character to send
  */
-static void uart_rtt_poll_out(const struct device *dev, unsigned char c)
+static int uart_rtt_poll_out(const struct device *dev, unsigned char c)
 {
 	const struct uart_rtt_config *config = dev->config;
 	unsigned int ch = config ? config->channel : 0;
+	unsigned int ret = SEGGER_RTT_Write(ch, &c, 1);
 
-	SEGGER_RTT_Write(ch, &c, 1);
+	return ret > 0 ? 0 : -EIO;
 }
 
 #ifdef CONFIG_UART_ASYNC_API

--- a/drivers/serial/uart_rv32m1_lpuart.c
+++ b/drivers/serial/uart_rv32m1_lpuart.c
@@ -51,7 +51,7 @@ static int rv32m1_lpuart_poll_in(const struct device *dev, unsigned char *c)
 	return ret;
 }
 
-static void rv32m1_lpuart_poll_out(const struct device *dev, unsigned char c)
+static int rv32m1_lpuart_poll_out(const struct device *dev, unsigned char c)
 {
 	const struct rv32m1_lpuart_config *config = dev->config;
 
@@ -60,6 +60,8 @@ static void rv32m1_lpuart_poll_out(const struct device *dev, unsigned char c)
 	}
 
 	LPUART_WriteByte(config->base, c);
+
+	return 0;
 }
 
 static int rv32m1_lpuart_err_check(const struct device *dev)

--- a/drivers/serial/uart_sam.c
+++ b/drivers/serial/uart_sam.c
@@ -58,7 +58,7 @@ static int uart_sam_poll_in(const struct device *dev, unsigned char *c)
 	return 0;
 }
 
-static void uart_sam_poll_out(const struct device *dev, unsigned char c)
+static int uart_sam_poll_out(const struct device *dev, unsigned char c)
 {
 	const struct uart_sam_dev_cfg *const cfg = dev->config;
 
@@ -70,6 +70,8 @@ static void uart_sam_poll_out(const struct device *dev, unsigned char c)
 
 	/* send a character */
 	uart->UART_THR = (uint32_t)c;
+
+	return 0;
 }
 
 static int uart_sam_err_check(const struct device *dev)

--- a/drivers/serial/uart_sam0.c
+++ b/drivers/serial/uart_sam0.c
@@ -650,7 +650,7 @@ static int uart_sam0_poll_in(const struct device *dev, unsigned char *c)
 	return 0;
 }
 
-static void uart_sam0_poll_out(const struct device *dev, unsigned char c)
+static int uart_sam0_poll_out(const struct device *dev, unsigned char c)
 {
 	const struct uart_sam0_dev_cfg *config = dev->config;
 
@@ -661,6 +661,8 @@ static void uart_sam0_poll_out(const struct device *dev, unsigned char c)
 
 	/* send a character */
 	usart->DATA.reg = c;
+
+	return 0;
 }
 
 static int uart_sam0_err_check(const struct device *dev)

--- a/drivers/serial/uart_sedi.c
+++ b/drivers/serial/uart_sedi.c
@@ -239,12 +239,16 @@ static int uart_sedi_poll_in(const struct device *dev, unsigned char *data)
 	return ret;
 }
 
-static void uart_sedi_poll_out(const struct device *dev,
+static int uart_sedi_poll_out(const struct device *dev,
 			       unsigned char data)
 {
+	int ret;
+
 	sedi_uart_t instance = GET_CONTROLLER_INSTANCE(dev);
 
-	sedi_uart_write(instance, data);
+	ret = sedi_uart_write(instance, data);
+
+	return ret == SEDI_DRIVER_OK ? 0 : -EIO;
 }
 
 #ifdef CONFIG_UART_LINE_CTRL

--- a/drivers/serial/uart_sifive.c
+++ b/drivers/serial/uart_sifive.c
@@ -80,7 +80,7 @@ struct uart_sifive_data {
  * @param dev UART device struct
  * @param c Character to send
  */
-static void uart_sifive_poll_out(const struct device *dev,
+static int uart_sifive_poll_out(const struct device *dev,
 					 unsigned char c)
 {
 	volatile struct uart_sifive_regs_t *uart = DEV_UART(dev);
@@ -90,6 +90,8 @@ static void uart_sifive_poll_out(const struct device *dev,
 	}
 
 	uart->tx = (int)c;
+
+	return 0;
 }
 
 /**

--- a/drivers/serial/uart_smartbond.c
+++ b/drivers/serial/uart_smartbond.c
@@ -107,7 +107,7 @@ static int uart_smartbond_poll_in(const struct device *dev, unsigned char *p_cha
 	return 0;
 }
 
-static void uart_smartbond_poll_out(const struct device *dev, unsigned char out_char)
+static int uart_smartbond_poll_out(const struct device *dev, unsigned char out_char)
 {
 	const struct uart_smartbond_cfg *config = dev->config;
 	struct uart_smartbond_data *data = dev->data;
@@ -120,6 +120,8 @@ static void uart_smartbond_poll_out(const struct device *dev, unsigned char out_
 	config->regs->UART2_RBR_THR_DLL_REG = out_char;
 
 	k_spin_unlock(&data->lock, key);
+
+	return 0;
 }
 
 static int uart_smartbond_configure(const struct device *dev,

--- a/drivers/serial/uart_stellaris.c
+++ b/drivers/serial/uart_stellaris.c
@@ -285,7 +285,7 @@ static int uart_stellaris_poll_in(const struct device *dev, unsigned char *c)
  * @param dev UART device struct
  * @param c Character to send
  */
-static void uart_stellaris_poll_out(const struct device *dev,
+static int uart_stellaris_poll_out(const struct device *dev,
 					     unsigned char c)
 {
 	const struct uart_stellaris_config *config = dev->config;
@@ -295,6 +295,8 @@ static void uart_stellaris_poll_out(const struct device *dev,
 
 	/* send a character */
 	config->uart->dr = (uint32_t)c;
+
+	return 0;
 }
 
 #if CONFIG_UART_INTERRUPT_DRIVEN

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -696,9 +696,11 @@ static int uart_stm32_poll_in(const struct device *dev, unsigned char *c)
 	return uart_stm32_poll_in_visitor(dev, (void *)c, poll_in_u8);
 }
 
-static void uart_stm32_poll_out(const struct device *dev, unsigned char c)
+static int uart_stm32_poll_out(const struct device *dev, unsigned char c)
 {
 	uart_stm32_poll_out_visitor(dev, (void *)&c, poll_out_u8);
+
+	return 0;
 }
 
 #ifdef CONFIG_UART_WIDE_DATA
@@ -718,9 +720,11 @@ static int uart_stm32_poll_in_u16(const struct device *dev, uint16_t *in_u16)
 	return uart_stm32_poll_in_visitor(dev, (void *)in_u16, poll_in_u9);
 }
 
-static void uart_stm32_poll_out_u16(const struct device *dev, uint16_t out_u16)
+static int uart_stm32_poll_out_u16(const struct device *dev, uint16_t out_u16)
 {
 	uart_stm32_poll_out_visitor(dev, (void *)&out_u16, poll_out_u9);
+
+	return 0;
 }
 
 #endif

--- a/drivers/serial/uart_xlnx_ps.c
+++ b/drivers/serial/uart_xlnx_ps.c
@@ -367,7 +367,7 @@ static int uart_xlnx_ps_poll_in(const struct device *dev, unsigned char *c)
  *
  * @return Sent character
  */
-static void uart_xlnx_ps_poll_out(const struct device *dev, unsigned char c)
+static int uart_xlnx_ps_poll_out(const struct device *dev, unsigned char c)
 {
 	uintptr_t reg_base = DEVICE_MMIO_GET(dev);
 	uint32_t reg_val;
@@ -382,6 +382,8 @@ static void uart_xlnx_ps_poll_out(const struct device *dev, unsigned char c)
 	do {
 		reg_val = sys_read32(reg_base + XUARTPS_SR_OFFSET);
 	} while ((reg_val & XUARTPS_SR_TXEMPTY) == 0);
+
+	return 0;
 }
 
 /**

--- a/drivers/serial/uart_xlnx_uartlite.c
+++ b/drivers/serial/uart_xlnx_uartlite.c
@@ -119,7 +119,7 @@ static int xlnx_uartlite_poll_in(const struct device *dev, unsigned char *c)
 	return ret;
 }
 
-static void xlnx_uartlite_poll_out(const struct device *dev, unsigned char c)
+static int xlnx_uartlite_poll_out(const struct device *dev, unsigned char c)
 {
 	uint32_t status;
 	k_spinlock_key_t key;
@@ -135,6 +135,8 @@ static void xlnx_uartlite_poll_out(const struct device *dev, unsigned char c)
 		}
 		k_spin_unlock(&data->tx_lock, key);
 	}
+
+	return 0;
 }
 
 static int xlnx_uartlite_err_check(const struct device *dev)

--- a/drivers/serial/uart_xmc4xxx.c
+++ b/drivers/serial/uart_xmc4xxx.c
@@ -91,7 +91,7 @@ static int uart_xmc4xxx_poll_in(const struct device *dev, unsigned char *c)
 	return 0;
 }
 
-static void uart_xmc4xxx_poll_out(const struct device *dev, unsigned char c)
+static int uart_xmc4xxx_poll_out(const struct device *dev, unsigned char c)
 {
 	const struct uart_xmc4xxx_config *config = dev->config;
 
@@ -100,6 +100,8 @@ static void uart_xmc4xxx_poll_out(const struct device *dev, unsigned char c)
 	while (config->fifo_tx_size > 0 && XMC_USIC_CH_TXFIFO_IsFull(config->uart)) {
 	}
 	XMC_UART_CH_Transmit(config->uart, c);
+
+	return 0;
 }
 
 #if defined(CONFIG_UART_ASYNC_API)

--- a/drivers/serial/usart_gd32.c
+++ b/drivers/serial/usart_gd32.c
@@ -122,7 +122,7 @@ static int usart_gd32_poll_in(const struct device *dev, unsigned char *c)
 	return 0;
 }
 
-static void usart_gd32_poll_out(const struct device *dev, unsigned char c)
+static int usart_gd32_poll_out(const struct device *dev, unsigned char c)
 {
 	const struct gd32_usart_config *const cfg = dev->config;
 
@@ -131,6 +131,8 @@ static void usart_gd32_poll_out(const struct device *dev, unsigned char c)
 	while (usart_flag_get(cfg->reg, USART_FLAG_TBE) == RESET) {
 		;
 	}
+
+	return 0;
 }
 
 static int usart_gd32_err_check(const struct device *dev)

--- a/drivers/serial/usart_sam.c
+++ b/drivers/serial/usart_sam.c
@@ -59,7 +59,7 @@ static int usart_sam_poll_in(const struct device *dev, unsigned char *c)
 	return 0;
 }
 
-static void usart_sam_poll_out(const struct device *dev, unsigned char c)
+static int usart_sam_poll_out(const struct device *dev, unsigned char c)
 {
 	const struct usart_sam_dev_cfg *config = dev->config;
 
@@ -71,6 +71,8 @@ static void usart_sam_poll_out(const struct device *dev, unsigned char c)
 
 	/* send a character */
 	usart->US_THR = (uint32_t)c;
+
+	return 0;
 }
 
 static int usart_sam_err_check(const struct device *dev)

--- a/drivers/w1/w1_zephyr_serial.c
+++ b/drivers/w1/w1_zephyr_serial.c
@@ -82,7 +82,7 @@ static int serial_tx_rx(const struct device *dev, const uint8_t *tx_data,
 			/* poll in any buffered data */
 		}
 
-		uart_poll_out(cfg->uart_dev, tx_data[i]);
+		(void)uart_poll_out(cfg->uart_dev, tx_data[i]);
 		end = sys_timepoint_calc(K_USEC(timeout));
 
 		do {

--- a/drivers/wifi/eswifi/eswifi_bus_uart.c
+++ b/drivers/wifi/eswifi/eswifi_bus_uart.c
@@ -198,7 +198,7 @@ static int eswifi_uart_request(struct eswifi_dev *eswifi, char *cmd,
 
 	/* Send CMD */
 	for (count = 0; count < clen; count++) {
-		uart_poll_out(uart->dev, cmd[count]);
+		(void)uart_poll_out(uart->dev, cmd[count]);
 	}
 
 	uart->fsm = ESWIFI_UART_FSM_WAIT_CR;

--- a/modules/openthread/platform/uart.c
+++ b/modules/openthread/platform/uart.c
@@ -248,7 +248,7 @@ otError otPlatUartFlush(void)
 
 	if (write_length) {
 		for (size_t i = 0; i < write_length; i++) {
-			uart_poll_out(ot_uart.dev, *(write_buffer+i));
+			(void)uart_poll_out(ot_uart.dev, *(write_buffer+i));
 		}
 	}
 

--- a/samples/bluetooth/hci_uart/src/main.c
+++ b/samples/bluetooth/hci_uart/src/main.c
@@ -301,25 +301,25 @@ void bt_ctlr_assert_handle(char *file, uint32_t line)
 		len -= pos;
 	}
 
-	uart_poll_out(hci_uart_dev, H4_EVT);
+	(void)uart_poll_out(hci_uart_dev, H4_EVT);
 	/* Vendor-Specific debug event */
-	uart_poll_out(hci_uart_dev, 0xff);
+	(void)uart_poll_out(hci_uart_dev, 0xff);
 	/* 0xAA + strlen + \0 + 32-bit line number */
-	uart_poll_out(hci_uart_dev, 1 + len + 1 + 4);
-	uart_poll_out(hci_uart_dev, 0xAA);
+	(void)uart_poll_out(hci_uart_dev, 1 + len + 1 + 4);
+	(void)uart_poll_out(hci_uart_dev, 0xAA);
 
 	if (len) {
 		while (*file != '\0') {
-			uart_poll_out(hci_uart_dev, *file);
+			(void)uart_poll_out(hci_uart_dev, *file);
 			file++;
 		}
-		uart_poll_out(hci_uart_dev, 0x00);
+		(void)uart_poll_out(hci_uart_dev, 0x00);
 	}
 
-	uart_poll_out(hci_uart_dev, line >> 0 & 0xff);
-	uart_poll_out(hci_uart_dev, line >> 8 & 0xff);
-	uart_poll_out(hci_uart_dev, line >> 16 & 0xff);
-	uart_poll_out(hci_uart_dev, line >> 24 & 0xff);
+	(void)uart_poll_out(hci_uart_dev, line >> 0 & 0xff);
+	(void)uart_poll_out(hci_uart_dev, line >> 8 & 0xff);
+	(void)uart_poll_out(hci_uart_dev, line >> 16 & 0xff);
+	(void)uart_poll_out(hci_uart_dev, line >> 24 & 0xff);
 
 	while (1) {
 	}
@@ -387,8 +387,7 @@ int main(void)
 		};
 
 		for (i = 0; i < sizeof(cc_evt); i++) {
-			uart_poll_out(hci_uart_dev,
-				      *(((const uint8_t *)&cc_evt)+i));
+			(void)uart_poll_out(hci_uart_dev, *(((const uint8_t *)&cc_evt)+i));
 		}
 	}
 

--- a/samples/boards/rpi_pico/uart_pio/src/main.c
+++ b/samples/boards/rpi_pico/uart_pio/src/main.c
@@ -24,11 +24,11 @@ int main(void)
 
 	while (1) {
 		if (!uart_poll_in(uart0, &data)) {
-			uart_poll_out(uart0, data);
+			(void)uart_poll_out(uart0, data);
 		}
 
 		if (!uart_poll_in(uart1, &data)) {
-			uart_poll_out(uart1, data);
+			(void)uart_poll_out(uart1, data);
 		}
 	}
 

--- a/samples/boards/stm32/uart/single_wire/src/main.c
+++ b/samples/boards/stm32/uart/single_wire/src/main.c
@@ -26,7 +26,7 @@ int main(void)
 
 	while (true) {
 
-		uart_poll_out(sl_uart1, 'c');
+		(void)uart_poll_out(sl_uart1, 'c');
 
 		/* give the uarts some time to get the data through */
 		k_sleep(K_MSEC(50));

--- a/samples/drivers/uart/echo_bot/src/main.c
+++ b/samples/drivers/uart/echo_bot/src/main.c
@@ -66,7 +66,7 @@ void print_uart(char *buf)
 	int msg_len = strlen(buf);
 
 	for (int i = 0; i < msg_len; i++) {
-		uart_poll_out(uart_dev, buf[i]);
+		(void)uart_poll_out(uart_dev, buf[i]);
 	}
 }
 

--- a/samples/drivers/uart/native_tty/src/main.c
+++ b/samples/drivers/uart/native_tty/src/main.c
@@ -29,7 +29,7 @@ void send_str(const struct device *uart, char *str)
 	int msg_len = strlen(str);
 
 	for (int i = 0; i < msg_len; i++) {
-		uart_poll_out(uart, str[i]);
+		(void)uart_poll_out(uart, str[i]);
 	}
 
 	printk("Device %s sent: \"%s\"\n", uart->name, str);

--- a/samples/subsys/shell/shell_module/src/uart_reinit.c
+++ b/samples/subsys/shell/shell_module/src/uart_reinit.c
@@ -75,7 +75,7 @@ static void uart_poll_timeout(struct k_timer *timer)
 
 	while (uart_poll_in(dev, &c) == 0) {
 		if (c != 'x') {
-			uart_poll_out(dev, c);
+			(void)uart_poll_out(dev, c);
 		} else {
 			k_timer_stop(timer);
 		}

--- a/samples/subsys/zbus/remote_mock/src/mock_proxy.c
+++ b/samples/subsys/zbus/remote_mock/src/mock_proxy.c
@@ -67,15 +67,16 @@ static void proxy_callback(const struct zbus_channel *chan)
 
 		*generated_by_the_bridge = false;
 	} else {
-		uart_poll_out(uart_dev, '$');
+		(void)uart_poll_out(uart_dev, '$');
 
-		uart_poll_out(uart_dev, encoder(chan));
+		(void)uart_poll_out(uart_dev, encoder(chan));
 
 		for (int i = 0; i < zbus_chan_msg_size(chan); ++i) {
-			uart_poll_out(uart_dev, ((unsigned char *)zbus_chan_const_msg(chan))[i]);
+			(void)uart_poll_out(uart_dev,
+					    ((unsigned char *)zbus_chan_const_msg(chan))[i]);
 		}
 
-		uart_poll_out(uart_dev, '*');
+		(void)uart_poll_out(uart_dev, '*');
 
 		LOG_DBG("sending message to host (channel %s)", zbus_chan_name(chan));
 	}

--- a/samples/subsys/zbus/uart_bridge/src/bridge.c
+++ b/samples/subsys/zbus/uart_bridge/src/bridge.c
@@ -47,24 +47,25 @@ static void bridge_tx_thread(void)
 				if (!generated_by_the_bridge) {
 					LOG_DBG("Bridge send %s", zbus_chan_name(chan));
 
-					uart_poll_out(bridge_uart, '$');
+					(void)uart_poll_out(bridge_uart, '$');
 
 					for (int i = 0; i < strlen(zbus_chan_name(chan)); ++i) {
-						uart_poll_out(bridge_uart, zbus_chan_name(chan)[i]);
+						(void)uart_poll_out(bridge_uart,
+								    zbus_chan_name(chan)[i]);
 					}
 
-					uart_poll_out(bridge_uart, ',');
+					(void)uart_poll_out(bridge_uart, ',');
 
-					uart_poll_out(bridge_uart, zbus_chan_msg_size(chan));
+					(void)uart_poll_out(bridge_uart, zbus_chan_msg_size(chan));
 
 					for (int i = 0; i < zbus_chan_msg_size(chan); ++i) {
-						uart_poll_out(bridge_uart,
+						(void)uart_poll_out(bridge_uart,
 							      ((uint8_t *)zbus_chan_msg(chan))[i]);
 					}
 
-					uart_poll_out(bridge_uart, '\r');
+					(void)uart_poll_out(bridge_uart, '\r');
 
-					uart_poll_out(bridge_uart, '\n');
+					(void)uart_poll_out(bridge_uart, '\n');
 				}
 			}
 		}

--- a/subsys/bluetooth/host/monitor.c
+++ b/subsys/bluetooth/host/monitor.c
@@ -146,7 +146,7 @@ static const struct device *const monitor_dev =
 
 static void poll_out(char c)
 {
-	uart_poll_out(monitor_dev, c);
+	(void)uart_poll_out(monitor_dev, c);
 }
 
 static void monitor_send(const void *data, size_t len)

--- a/subsys/console/tty.c
+++ b/subsys/console/tty.c
@@ -108,7 +108,7 @@ ssize_t tty_write(struct tty_serial *tty, const void *buf, size_t size)
 		out_size = size;
 
 		while (size--) {
-			uart_poll_out(tty->uart_dev, *p++);
+			(void)uart_poll_out(tty->uart_dev, *p++);
 		}
 
 		return out_size;

--- a/subsys/debug/gdbstub/gdbstub_backend_serial.c
+++ b/subsys/debug/gdbstub/gdbstub_backend_serial.c
@@ -35,7 +35,7 @@ int z_gdb_backend_init(void)
 
 void z_gdb_putchar(unsigned char ch)
 {
-	uart_poll_out(uart_dev, ch);
+	(void)uart_poll_out(uart_dev, ch);
 }
 
 unsigned char z_gdb_getchar(void)

--- a/subsys/logging/backends/log_backend_uart.c
+++ b/subsys/logging/backends/log_backend_uart.c
@@ -52,12 +52,12 @@ static void dict_char_out_hex(uint8_t *data, size_t length)
 		/* upper 8-bit */
 		x = data[i] >> 4;
 		(void)hex2char(x, &c);
-		uart_poll_out(uart_dev, c);
+		(void)uart_poll_out(uart_dev, c);
 
 		/* lower 8-bit */
 		x = data[i] & 0x0FU;
 		(void)hex2char(x, &c);
-		uart_poll_out(uart_dev, c);
+		(void)uart_poll_out(uart_dev, c);
 	}
 }
 
@@ -82,7 +82,7 @@ static int char_out(uint8_t *data, size_t length, void *ctx)
 
 	if (!IS_ENABLED(CONFIG_LOG_BACKEND_UART_ASYNC) || in_panic || !use_async) {
 		for (size_t i = 0; i < length; i++) {
-			uart_poll_out(uart_dev, data[i]);
+			(void)uart_poll_out(uart_dev, data[i]);
 		}
 		goto cleanup;
 	}
@@ -133,7 +133,7 @@ static void log_backend_uart_init(struct log_backend const *const backend)
 		 * (e.g. bootloader).
 		 */
 		for (int i = 0; i < sizeof(LOG_HEX_SEP); i++) {
-			uart_poll_out(uart_dev, LOG_HEX_SEP[i]);
+			(void)uart_poll_out(uart_dev, LOG_HEX_SEP[i]);
 		}
 
 		return;

--- a/subsys/logging/log_frontend_dict_uart.c
+++ b/subsys/logging/log_frontend_dict_uart.c
@@ -111,7 +111,7 @@ static void tx(void)
 
 	if (in_panic) {
 		for (int i = 0; i < len; i++) {
-			uart_poll_out(uart_dev, pkt->data[i]);
+			(void)uart_poll_out(uart_dev, pkt->data[i]);
 		}
 		atomic_dec(&active_cnt);
 	} else {
@@ -253,7 +253,7 @@ static void sync_msg(const void *source,
 
 	for (int i = 0; i < ARRAY_SIZE(datas); i++) {
 		for (int j = 0; j < len[i]; j++) {
-			uart_poll_out(uart_dev, datas[i][j]);
+			(void)uart_poll_out(uart_dev, datas[i][j]);
 		}
 	}
 }

--- a/subsys/mgmt/mcumgr/transport/src/smp_shell.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp_shell.c
@@ -219,7 +219,7 @@ static int smp_shell_tx_raw(const void *data, int len)
 	const uint8_t *out = data;
 
 	while ((out != NULL) && (len != 0)) {
-		uart_poll_out(scb->dev, *out);
+		(void)uart_poll_out(scb->dev, *out);
 		++out;
 		--len;
 	}

--- a/subsys/shell/backends/shell_uart.c
+++ b/subsys/shell/backends/shell_uart.c
@@ -296,7 +296,7 @@ static int write(const struct shell_transport *transport,
 		irq_write(sh_uart, data, length, cnt);
 	} else {
 		for (size_t i = 0; i < length; i++) {
-			uart_poll_out(sh_uart->ctrl_blk->dev, data8[i]);
+			(void)uart_poll_out(sh_uart->ctrl_blk->dev, data8[i]);
 		}
 
 		*cnt = length;

--- a/subsys/tracing/tracing_backend_uart.c
+++ b/subsys/tracing/tracing_backend_uart.c
@@ -71,7 +71,7 @@ static void tracing_backend_uart_output(
 	uint8_t *data, uint32_t length)
 {
 	for (uint32_t i = 0; i < length; i++) {
-		uart_poll_out(tracing_uart_dev, data[i]);
+		(void)uart_poll_out(tracing_uart_dev, data[i]);
 	}
 }
 

--- a/tests/bluetooth/tester/src/btp.c
+++ b/tests/bluetooth/tester/src/btp.c
@@ -214,7 +214,7 @@ static void uart_send(const uint8_t *data, size_t len)
 	int i;
 
 	for (i = 0; i < len; i++) {
-		uart_poll_out(dev, data[i]);
+		(void)uart_poll_out(dev, data[i]);
 	}
 }
 #endif /* CONFIG_UART_PIPE */

--- a/tests/drivers/uart/uart_basic_api/src/test_uart_poll.c
+++ b/tests/drivers/uart/uart_basic_api/src/test_uart_poll.c
@@ -47,9 +47,9 @@ static int test_poll_out(void)
 		return TC_FAIL;
 	}
 
-	/* Verify uart_poll_out() */
+	/* Verify (void)uart_poll_out() */
 	for (i = 0; i < strlen(poll_data); i++) {
-		uart_poll_out(uart_dev, poll_data[i]);
+		(void)uart_poll_out(uart_dev, poll_data[i]);
 	}
 
 	return TC_PASS;

--- a/tests/drivers/uart/uart_emul/src/main.c
+++ b/tests/drivers/uart/uart_emul/src/main.c
@@ -45,7 +45,7 @@ ZTEST_F(uart_emul, test_polling_out)
 	size_t tx_len;
 
 	for (size_t i = 0; i < SAMPLE_DATA_SIZE; i++) {
-		uart_poll_out(fixture->dev, fixture->sample_data[i]);
+		(void)uart_poll_out(fixture->dev, fixture->sample_data[i]);
 	}
 
 	tx_len = uart_emul_get_tx_data(fixture->dev, tx_content, sizeof(tx_content));

--- a/tests/drivers/uart/uart_mix_fifo_poll/src/main.c
+++ b/tests/drivers/uart/uart_mix_fifo_poll/src/main.c
@@ -225,7 +225,7 @@ static void bulk_poll_out(struct test_data *data, int wait_base, int wait_range)
 	for (int i = 0; i < data->max; i++) {
 
 		data->cnt++;
-		uart_poll_out(uart_dev, data->buf[i % BUF_SIZE]);
+		(void)uart_poll_out(uart_dev, data->buf[i % BUF_SIZE]);
 		if (wait_base) {
 			int r = sys_rand32_get();
 
@@ -286,7 +286,7 @@ static void poll_out_timer_handler(struct k_timer *timer)
 {
 	struct test_data *data = k_timer_user_data_get(timer);
 
-	uart_poll_out(uart_dev, data->buf[data->cnt % BUF_SIZE]);
+	(void)uart_poll_out(uart_dev, data->buf[data->cnt % BUF_SIZE]);
 
 	data->cnt++;
 	if (data->cnt == data->max) {

--- a/tests/drivers/uart/uart_pm/src/main.c
+++ b/tests/drivers/uart/uart_pm/src/main.c
@@ -23,7 +23,7 @@ static void polling_verify(const struct device *dev, bool is_async, bool active)
 		 * not hang.
 		 */
 		for (int i = 0; i < ARRAY_SIZE(outs); i++) {
-			uart_poll_out(dev, outs[i]);
+			(void)uart_poll_out(dev, outs[i]);
 		}
 
 		return;
@@ -33,7 +33,7 @@ static void polling_verify(const struct device *dev, bool is_async, bool active)
 	zassert_equal(err, -1);
 
 	for (int i = 0; i < ARRAY_SIZE(outs); i++) {
-		uart_poll_out(dev, outs[i]);
+		(void)uart_poll_out(dev, outs[i]);
 		k_busy_wait(1000);
 
 		if (active) {
@@ -180,7 +180,7 @@ ZTEST(uart_pm, test_uart_pm_poll_tx)
 
 	communication_verify(dev, true);
 
-	uart_poll_out(dev, 'a');
+	(void)uart_poll_out(dev, 'a');
 	action_run(dev, PM_DEVICE_ACTION_SUSPEND, 0);
 
 	communication_verify(dev, false);
@@ -190,7 +190,7 @@ ZTEST(uart_pm, test_uart_pm_poll_tx)
 	communication_verify(dev, true);
 
 	/* Now same thing but with callback */
-	uart_poll_out(dev, 'a');
+	(void)uart_poll_out(dev, 'a');
 	action_run(dev, PM_DEVICE_ACTION_SUSPEND, 0);
 
 	communication_verify(dev, false);
@@ -226,7 +226,7 @@ ZTEST(uart_pm, test_uart_pm_poll_tx_interrupted)
 		k_timer_start(&pm_timer, K_USEC(i * 10), K_NO_WAIT);
 
 		for (int j = 0; j < sizeof(str); j++) {
-			uart_poll_out(dev, str[j]);
+			(void)uart_poll_out(dev, str[j]);
 		}
 
 		k_timer_status_sync(&pm_timer);


### PR DESCRIPTION
With the previous return type `void` some drivers silently dropped characters without any possibility for a user of the API to notice whether a character was transmitted successfully or not.

This is not a breaking change of the stable API, as existing code (ignoring the return value) will continue to work as before.