### PR TITLE
doc: gsg: fix syntax highlighting of code blocks

### DIFF
--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -94,7 +94,9 @@ The current minimum required version for the main dependencies are:
               python3-dev python3-pip python3-setuptools python3-tk python3-wheel xz-utils file \
               make gcc gcc-multilib g++-multilib libsdl2-dev libmagic1
 
-      #. Verify the versions of the main dependencies installed on your system by entering::
+      #. Verify the versions of the main dependencies installed on your system by entering:
+
+         .. code-block:: bash
 
             cmake --version
             python3 --version
@@ -153,13 +155,13 @@ The current minimum required version for the main dependencies are:
       #. Disable global confirmation to avoid having to confirm the
          installation of individual programs:
 
-         .. code-block:: console
+         .. code-block:: bat
 
             choco feature enable -n allowGlobalConfirmation
 
       #. Use ``choco`` to install the required dependencies:
 
-         .. code-block:: console
+         .. code-block:: bat
 
             choco install cmake --installargs 'ADD_CMAKE_TO_PATH=System'
             choco install ninja gperf python git dtc-msys2 wget 7zip
@@ -246,7 +248,7 @@ additional Python dependencies.
                automatically load boilerplate code required for building Zephyr
                applications.
 
-               .. code-block:: console
+               .. code-block:: bash
 
                   west zephyr-export
 
@@ -280,7 +282,7 @@ additional Python dependencies.
                automatically load boilerplate code required for building Zephyr
                applications.
 
-               .. code-block:: console
+               .. code-block:: bash
 
                   west zephyr-export
 
@@ -336,7 +338,7 @@ additional Python dependencies.
                automatically load boilerplate code required for building Zephyr
                applications.
 
-               .. code-block:: console
+               .. code-block:: bash
 
                   west zephyr-export
 
@@ -367,7 +369,7 @@ additional Python dependencies.
                automatically load boilerplate code required for building Zephyr
                applications.
 
-               .. code-block:: console
+               .. code-block:: bash
 
                   west zephyr-export
 
@@ -411,13 +413,13 @@ additional Python dependencies.
 
             #. Install west:
 
-               .. code-block:: bash
+               .. code-block:: bat
 
                   pip install west
 
             #. Get the Zephyr source code:
 
-               .. code-block:: bash
+               .. code-block:: bat
 
                   west init zephyrproject
                   cd zephyrproject
@@ -427,14 +429,14 @@ additional Python dependencies.
                automatically load boilerplate code required for building Zephyr
                applications.
 
-               .. code-block:: console
+               .. code-block:: bat
 
                   west zephyr-export
 
             #. Zephyr's ``scripts\requirements.txt`` file declares additional Python
                dependencies. Install them with ``pip``.
 
-               .. code-block:: bash
+               .. code-block:: bat
 
                   pip install -r %HOMEPATH%\zephyrproject\zephyr\scripts\requirements.txt
 
@@ -599,14 +601,14 @@ that are used to emulate, flash and debug Zephyr applications.
       #. Download the `Zephyr SDK bundle
          <https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.16.3>`_:
 
-         .. code-block:: console
+         .. code-block:: bat
 
             cd %HOMEPATH%
             wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.3/zephyr-sdk-0.16.3_windows-x86_64.7z
 
       #. Extract the Zephyr SDK bundle archive:
 
-         .. code-block:: console
+         .. code-block:: bat
 
             7z x zephyr-sdk-0.16.3_windows-x86_64.7z
 
@@ -622,7 +624,7 @@ that are used to emulate, flash and debug Zephyr applications.
 
       #. Run the Zephyr SDK bundle setup script:
 
-         .. code-block:: console
+         .. code-block:: bat
 
             cd zephyr-sdk-0.16.3
             setup.cmd
@@ -686,7 +688,7 @@ If in doubt about what to do, check your board's page in :ref:`boards`.
 
 Then flash the sample using :ref:`west flash <west-flashing>`:
 
-.. code-block:: console
+.. code-block:: shell
 
    west flash
 


### PR DESCRIPTION
Added explicit code blocks throughout the document.
Removed several incorrect uses of "console" language where it should have been shell or bat.
"console" is only for _bash_ sessions that include a prompt.