### PR TITLE
doc: Render app commands with "shell" language

### DIFF
--- a/doc/_extensions/zephyr/application.py
+++ b/doc/_extensions/zephyr/application.py
@@ -229,7 +229,7 @@ class ZephyrAppCommandsDirective(Directive):
         # Create the nodes.
         literal = nodes.literal_block(content, content)
         self.add_name(literal)
-        literal['language'] = 'console'
+        literal['language'] = 'shell'
         return literal
 
 


### PR DESCRIPTION
The 'console' language in pygments is for Bash shell session, i.e code snippets where commands MUST start with a prompt.
The commands rendered by the ZephyrAppCommandsDirective do not include a prompt, and should therefore be set as "shell".