### PR TITLE
net: tcp: Change FL() macro to avoid runtime overhead

### DIFF
--- a/subsys/net/ip/tcp_private.h
+++ b/subsys/net/ip/tcp_private.h
@@ -311,6 +311,6 @@ struct tcp { /* TCP connection */
 })
 
 #define FL(_fl, _op, _mask, _args...)					\
-	_flags(_fl, _op, _mask, strlen("" #_args) ? _args : true)
+	_flags(_fl, _op, _mask, sizeof(#_args) > 1 ? _args : true)
 
 typedef void (*net_tcp_cb_t)(struct tcp *conn, void *user_data);


### PR DESCRIPTION
Instead of strlen() use sizeof() in FL() macro. This way all the checks are done at compile time instead of runtime.