### PR TITLE
RFC: DEVICE_DT_DEFINE_SUB and example of usage with soc-nv-flash device

### DIFF
--- a/boards/arc/nsim/nsim-flash-sram-mem.dtsi
+++ b/boards/arc/nsim/nsim-flash-sram-mem.dtsi
@@ -12,9 +12,15 @@
 
 / {
 	/* We are carving out of DRAM for a pseudo flash and sram region */
-	flash0: flash@80000000 {
-		compatible = "soc-nv-flash";
-		reg = <0x80000000 DT_FLASH_SIZE>;
+	no_flash_controller {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "zephyr,null-controller";
+
+		flash0: flash@80000000 {
+			compatible = "soc-nv-flash";
+			reg = <0x80000000 DT_FLASH_SIZE>;
+		};
 	};
 
 	sram0: sram@80400000 {

--- a/boards/arc/qemu_arc/qemu_arc.dtsi
+++ b/boards/arc/qemu_arc/qemu_arc.dtsi
@@ -37,9 +37,15 @@
 	};
 
 	/* We are carving out of DRAM for a pseudo flash and sram region */
-	flash0: flash@80000000 {
-		compatible = "soc-nv-flash";
-		reg = <0x80000000 DT_FLASH_SIZE>;
+	no_flash_controller {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "zephyr,null-controller";
+
+		flash0: flash@80000000 {
+			compatible = "soc-nv-flash";
+			reg = <0x80000000 DT_FLASH_SIZE>;
+		};
 	};
 
 	sram0: sram@80400000 {

--- a/boards/arm/fvp_baser_aemv8r_aarch32/fvp_baser_aemv8r_aarch32.dts
+++ b/boards/arm/fvp_baser_aemv8r_aarch32/fvp_baser_aemv8r_aarch32.dts
@@ -27,9 +27,15 @@
 	};
 
 	soc {
-		flash0: flash@88000000 {
-			compatible = "soc-nv-flash";
-			reg = <0x88000000 DT_SIZE_M(64)>;
+		no_flash_controller {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			compatible = "zephyr,null-controller";
+
+			flash0: flash@88000000 {
+				compatible = "soc-nv-flash";
+				reg = <0x88000000 DT_SIZE_M(64)>;
+			};
 		};
 
 		dram0: memory@0 {

--- a/boards/arm/mps2_an385/mps2_an385.dts
+++ b/boards/arm/mps2_an385/mps2_an385.dts
@@ -68,9 +68,15 @@
 		reg = <0x20000000 0x400000>;
 	};
 
-	flash0: flash@0 {
-		compatible = "soc-nv-flash";
-		reg = <0 0x400000>;
+	no_flash_controller {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "zephyr,null-controller";
+
+		flash0: flash@0 {
+			compatible = "soc-nv-flash";
+			reg = <0 0x400000>;
+		};
 	};
 
 	sysclk: system-clock {

--- a/boards/arm/v2m_beetle/v2m_beetle.dts
+++ b/boards/arm/v2m_beetle/v2m_beetle.dts
@@ -35,9 +35,15 @@
 		reg = <0x20000000 0x20000>;
 	};
 
-	flash0: flash@0 {
-		compatible = "soc-nv-flash";
-		reg = <0 0x40000>;
+	no_flash_controller {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "zephyr,null-controller";
+
+		flash0: flash@0 {
+			compatible = "soc-nv-flash";
+			reg = <0 0x40000>;
+		};
 	};
 
 	sysclk: system-clock {

--- a/boards/arm64/fvp_base_revc_2xaemv8a/fvp_base_revc_2xaemv8a.dts
+++ b/boards/arm64/fvp_base_revc_2xaemv8a/fvp_base_revc_2xaemv8a.dts
@@ -157,9 +157,15 @@
 			};
 		};
 
-		flash0: flash@0 {
-			compatible = "soc-nv-flash";
-			reg = <0x0 DT_SIZE_K(64)>;
+		no_flash_controller {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			compatible = "zephyr,null-controller";
+
+			flash0: flash@0 {
+				compatible = "soc-nv-flash";
+				reg = <0x0 DT_SIZE_K(64)>;
+			};
 		};
 
 		dram0: memory@88000000 {

--- a/boards/arm64/fvp_baser_aemv8r/fvp_baser_aemv8r.dts
+++ b/boards/arm64/fvp_baser_aemv8r/fvp_baser_aemv8r.dts
@@ -28,9 +28,15 @@
 	};
 
 	soc {
-		flash0: flash@88000000 {
-			compatible = "soc-nv-flash";
-			reg = <0x88000000 DT_SIZE_M(64)>;
+		no_flash_controller {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			compatible = "zephyr,null-controller";
+
+			flash0: flash@88000000 {
+				compatible = "soc-nv-flash";
+				reg = <0x88000000 DT_SIZE_M(64)>;
+			};
 		};
 
 		dram0: memory@0 {

--- a/boards/riscv/neorv32/neorv32.dts
+++ b/boards/riscv/neorv32/neorv32.dts
@@ -27,14 +27,20 @@
 	};
 
 	soc {
-		imem: memory@0 {
-			compatible = "soc-nv-flash", "mmio-sram";
-			reg = <0x0 DT_SIZE_K(64)>;
-		};
+		no_flash_controller {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			compatible = "zephyr,null-controller";
 
-		bootrom: memory@ffff0000 {
-			compatible = "soc-nv-flash", "mmio-sram";
-			reg = <0xffff0000 DT_SIZE_K(4)>;
+			imem: memory@0 {
+				compatible = "soc-nv-flash", "mmio-sram";
+				reg = <0x0 DT_SIZE_K(64)>;
+			};
+
+			bootrom: memory@ffff0000 {
+				compatible = "soc-nv-flash", "mmio-sram";
+				reg = <0xffff0000 DT_SIZE_K(4)>;
+			};
 		};
 
 		dmem: memory@80000000 {

--- a/boards/shields/v2c_daplink/v2c_daplink_cfg.overlay
+++ b/boards/shields/v2c_daplink/v2c_daplink_cfg.overlay
@@ -12,9 +12,15 @@
 	};
 
 	soc {
-		daplink_flash0_v2c_daplink_cfg: flash@0 {
-			compatible = "soc-nv-flash";
-			reg = <0x00000000 DT_SIZE_M(1)>;
+		no_flash_controller {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			compatible = "zephyr,null-controller";
+
+			daplink_flash0_v2c_daplink_cfg: flash@0 {
+				compatible = "soc-nv-flash";
+				reg = <0x00000000 DT_SIZE_M(1)>;
+			};
 		};
 
 		itcm_v2c_daplink_cfg: memory@10000000 {

--- a/boards/x86/qemu_x86/qemu_x86.dts
+++ b/boards/x86/qemu_x86/qemu_x86.dts
@@ -19,9 +19,15 @@
 	model = "QEMU X86 emulator";
 	compatible = "qemu,x86_emulator";
 
-	flash0: flash@500000 {
-		compatible = "soc-nv-flash";
-		reg = <0x00500000 DT_FLASH_SIZE>;
+	no_flash_controller {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "zephyr,null-controller";
+
+		flash0: flash@500000 {
+			compatible = "soc-nv-flash";
+			reg = <0x00500000 DT_FLASH_SIZE>;
+		};
 	};
 
 	aliases {

--- a/drivers/flash/CMakeLists.txt
+++ b/drivers/flash/CMakeLists.txt
@@ -53,6 +53,12 @@ zephyr_library_sources_ifdef(CONFIG_FLASH_RPI_PICO flash_rpi_pico.c)
 zephyr_library_sources_ifdef(CONFIG_FLASH_ANDES_QSPI flash_andes_qspi.c)
 zephyr_library_sources_ifdef(CONFIG_FLASH_AMBIQ flash_ambiq.c)
 
+dt_comp_path(soc_nv_flash_node COMPATIBLE "soc-nv-flash")
+if(NOT ("${soc_nv_flash_node}" STREQUAL ""))
+  dt_node_has_status(status PATH ${soc_nv_flash_node} STATUS "okay")
+  zephyr_library_sources(soc_nv_generic.c)
+endif()
+
 if(CONFIG_FLASH_MCUX_FLEXSPI_XIP)
   dt_chosen(chosen_flash PROPERTY "zephyr,flash")
   dt_prop(compat_flash PATH ${chosen_flash} PROPERTY compatible)

--- a/drivers/flash/soc_nv_generic.c
+++ b/drivers/flash/soc_nv_generic.c
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <errno.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/drivers/flash.h>
+#include <string.h>
+
+/* This driver supports multi-instance and also covers the soc-nv-null device
+ * which is additional compatible to be placed on soc-nv-flash with no controller,
+ * as for example happens in x86 QEMU device.
+ */
+#define DT_DRV_COMPAT soc_nv_flash
+
+/* In case when there is only single device with null-controller as parent, then
+ * there is nothing to build.
+ * Unfortunatley it is not possible to filter this in CMakeLists.txt.
+ */
+#if !(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 1 &&                             \
+	DT_NODE_HAS_COMPAT(DT_PARENT(DT_INST(0, DT_DRV_COMPAT)), zephyr_null_controller))
+
+#define SOC_NVM_PARENT_API(dev) ((struct flash_driver_api *)SOC_NVM_PARENT(dev)->api)
+
+#if DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) > 1
+#define SOC_NVM_CONFIG(dev) ((const struct soc_nv_flash_config *)(dev)->config)
+#define SOC_NVM_PARENT(dev) ((SOC_NVM_CONFIG(dev)->parent))
+#define SOC_NVM_DEV_TOUCH(dev)
+#else
+/* Single instance */
+#define SOC_NV_FLASH_NODE DT_INST(0, DT_DRV_COMPAT)
+#define SOC_NVM_CONFIG(dev) NULL
+#define SOC_NVM_PARENT(dev) DEVICE_DT_GET(DT_PARENT(SOC_NV_FLASH_NODE))
+#define SOC_NVM_DEV_TOUCH(dev) ARG_UNUSED(dev)
+#endif
+
+struct soc_nv_flash_config {
+	const struct device *parent;
+};
+
+static int soc_nv_mem_read(const struct device *dev, off_t addr, void *data, size_t len)
+{
+	SOC_NVM_DEV_TOUCH(dev);
+
+	return SOC_NVM_PARENT_API(dev)->read(SOC_NVM_PARENT(dev), addr, data, len);
+}
+
+static int soc_nv_mem_write(const struct device *dev, off_t addr,
+			    const void *data, size_t len)
+{
+	SOC_NVM_DEV_TOUCH(dev);
+
+	return SOC_NVM_PARENT_API(dev)->write(SOC_NVM_PARENT(dev), addr, data, len);
+}
+
+static int soc_nv_mem_erase(const struct device *dev, off_t addr, size_t size)
+{
+	SOC_NVM_DEV_TOUCH(dev);
+
+	return SOC_NVM_PARENT_API(dev)->erase(SOC_NVM_PARENT(dev), addr, size);
+}
+
+static const struct flash_parameters *soc_nv_mem_parameters(const struct device *dev)
+{
+	SOC_NVM_DEV_TOUCH(dev);
+
+	return SOC_NVM_PARENT_API(dev)->get_parameters(SOC_NVM_PARENT(dev));
+}
+
+#if defined(CONFIG_FLASH_PAGE_LAYOUT)
+static void soc_nv_mem_layout(const struct device *dev,
+			   const struct flash_pages_layout **layout,
+			   size_t *layout_size)
+{
+	SOC_NVM_DEV_TOUCH(dev);
+
+	SOC_NVM_PARENT_API(dev)->page_layout(SOC_NVM_PARENT(dev), layout, layout_size);
+}
+#endif
+
+static const struct flash_driver_api soc_nrf_flash_api = {
+	.read = soc_nv_mem_read,
+	.write = soc_nv_mem_write,
+	.erase = soc_nv_mem_erase,
+	.get_parameters = soc_nv_mem_parameters,
+#if defined(CONFIG_FLASH_PAGE_LAYOUT)
+	.page_layout = soc_nv_mem_layout,
+#endif
+};
+
+/* In case when there is more than one instance we need to store parent, controller,
+ * in config of a instance as each instance may have different controller.
+ */
+#if DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) > 1
+#define DEFINE_SOC_NVM_FLASH_INSTANCE(n)						\
+	const static struct soc_nv_flash_config soc_nv_flash_config_##n = {		\
+		.parent = DEVICE_DT_GET(DT_PARENT(DT_DRV_INST(n))),			\
+	};										\
+	DEVICE_DT_DEFINE_SUB(DT_DRV_INST(n), NULL, NULL,				\
+			     &soc_nv_flash_config_##n,					\
+			     POST_KERNEL, CONFIG_FLASH_INIT_PRIORITY,			\
+			     &soc_nrf_flash_api);
+
+/* Only devices that have controller will be defined, because otherwise there is no
+ * parent to call. So when you do DEVICE_DT_GET on node that does not have controller
+ * you will get linker error as no device will be provided for it.
+ */
+#define SOC_NV_ONLY_WITH_CONTROLLER(inst)							\
+	COND_CODE_1(										\
+		DT_NODE_HAS_COMPAT(DT_PARENT(DT_DRV_INST(inst)), zephyr_null_controller),	\
+		(),										\
+		(DEFINE_SOC_NVM_FLASH_INSTANCE(inst)))
+
+DT_INST_FOREACH_STATUS_OKAY(SOC_NV_ONLY_WITH_CONTROLLER);
+#else
+/* With single instance device there is no config provided. */
+DEVICE_DT_DEFINE_SUB(DT_DRV_INST(0), NULL, NULL, NULL, POST_KERNEL,
+		     CONFIG_FLASH_INIT_PRIORITY, &soc_nrf_flash_api);
+#endif
+
+#endif

--- a/dts/bindings/flash_controller/zephyr,null-controller.yaml
+++ b/dts/bindings/flash_controller/zephyr,null-controller.yaml
@@ -1,0 +1,11 @@
+description: |
+  Special no-controller device used as parent for soc-nv-flash
+  devices that are only used to define flash region used during
+  compilation to define application placement in NV-memory.
+  soc-nv-flash nodes hanging from such controller may not be
+  accessed, using flash_api, at run-time but can still be evaluated
+  at compile time using DT macros.
+
+compatible: "zephyr,null-controller"
+
+include: base.yaml

--- a/dts/nios2/intel/nios2-qemu.dtsi
+++ b/dts/nios2/intel/nios2-qemu.dtsi
@@ -16,9 +16,15 @@
 		};
 	};
 
-	flash0: flash@420000 {
-		compatible = "soc-nv-flash";
-		reg = <0x420000 0x20000>;
+	no_flash_controller {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "zephyr,null-controller";
+
+		flash0: flash@420000 {
+			compatible = "soc-nv-flash";
+			reg = <0x420000 0x20000>;
+		};
 	};
 
 	sram0: memory@400000 {

--- a/dts/nios2/intel/nios2f.dtsi
+++ b/dts/nios2/intel/nios2f.dtsi
@@ -17,9 +17,15 @@
 		};
 	};
 
-	flash0: flash@0 {
-		compatible = "soc-nv-flash";
-		reg = <0x00 0xb8000>;
+	no_flash_controller {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "zephyr,null-controller";
+
+		flash0: flash@0 {
+			compatible = "soc-nv-flash";
+			reg = <0x00 0xb8000>;
+		};
 	};
 
 	sram0: memory@400000 {

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -185,6 +185,43 @@ typedef int16_t device_handle_t;
 			__VA_ARGS__)
 
 /**
+ * @brief Create a sub-device object from a devicetree node identifier and set
+ * it up for boot time initialization.
+ *
+ * This macro defines a @ref device that is automatically configured by the
+ * kernel during system initialization. The global device object's name as a C
+ * identifier is derived from the node's dependency ordinal. @ref device.name is
+ * set to `DEVICE_DT_NAME(node_id)`.
+ *
+ * Sub-device takes state from parent device.
+ * Sub-device has capability to have own initialization, but in case when
+ * this initialization should follow initialization of parent it should be
+ * provided own pririty that is lower than of parent. If initialization
+ * does not require main device to be ready, then the priority can
+ * be kept the same.
+ * Sub-device has no power state as the power management is done by
+ * the main device.
+ *
+ * @param node_id Devicetree node id for the device (DT_INVALID_NODE if a
+ * software device).
+ * @param init_fn Device init function, optional and may be NULL.
+ * @param data Reference to device data.
+ * @param config Reference to device config.
+ * @param level Initialization level.
+ * @param prio Initialization priority.
+ * @param api Reference to device API.
+ */
+#define DEVICE_DT_DEFINE_SUB(node_id, init_fn, data, config, level, prio, api, \
+			     ...)                                              \
+	extern struct device_state Z_DEVICE_STATE_NAME(                        \
+				Z_DEVICE_DT_DEV_ID(DT_PARENT(node_id)));       \
+	Z_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_ID(node_id),                  \
+			DEVICE_DT_NAME(node_id), init_fn, NULL, data, config,  \
+			level, prio, api,                                      \
+			&Z_DEVICE_STATE_NAME(                                  \
+				Z_DEVICE_DT_DEV_ID(DT_PARENT(node_id))))
+
+/**
  * @brief Like DEVICE_DT_DEFINE(), but uses an instance of a `DT_DRV_COMPAT`
  * compatible instead of a node identifier.
  *
@@ -764,7 +801,7 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
  * @param dev_id Device identifier.
  */
 #define Z_DEVICE_STATE_DEFINE(dev_id)                                          \
-	static Z_DECL_ALIGN(struct device_state) Z_DEVICE_STATE_NAME(dev_id)   \
+	Z_DECL_ALIGN(struct device_state) Z_DEVICE_STATE_NAME(dev_id)   \
 		__attribute__((__section__(".z_devstate")))
 
 #if defined(CONFIG_DEVICE_DEPS) || defined(__DOXYGEN__)


### PR DESCRIPTION
The series off commits that:
 1) add DEVICE_DT_DEFINE_SUB that allows to define sub-device which is a device that shares ~~power management and~~ state with parent device (actually it redirects everything to parent device).
 2) define zephyr,null-controller compatible binding that is used in following commits to place soc-nv-flash compatible sub-device under controller in case where soc-nv-flash device is used only for the purpose of compilation.
 3) defines soc-nv-flash generic driver that allows to access flash device by actual node of flash device, not by controller; this makes flash device access uniform with (Q)SPI hanging devices which are addressed directly; the driver is multi-instance driver so it allows several soc-nv-flash devices to co-exist.
4) modifies dts for all devices that have been defining soc-nv-flash node without controller.
5) Moves flash-simulator sample to directly use the soc-nf-flash instead of accessing it via controllre.

