### PR TITLE
microchip: ps2: fix compilation error

### DIFF
--- a/drivers/ps2/ps2_mchp_xec.c
+++ b/drivers/ps2/ps2_mchp_xec.c
@@ -16,10 +16,8 @@
 #include <zephyr/drivers/interrupt_controller/intc_mchp_xec_ecia.h>
 #endif
 #include <zephyr/drivers/pinctrl.h>
-#ifdef CONFIG_PM_DEVICE
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/policy.h>
-#endif
 #include <zephyr/drivers/ps2.h>
 #include <soc.h>
 #include <zephyr/logging/log.h>


### PR DESCRIPTION
fix compilation error when CONFIG_PM_DEVICE is not enabled

fixes #64052