### PR TITLE
drivers: adc: Fix misuse of const and k_tid_t

### DIFF
--- a/drivers/adc/adc_ads1119.c
+++ b/drivers/adc/adc_ads1119.c
@@ -463,7 +463,7 @@ static int ads1119_init(const struct device *dev)
 	}
 
 #if CONFIG_ADC_ASYNC
-	const k_tid_t tid =
+	k_tid_t tid =
 		k_thread_create(&data->thread, config->stack,
 				CONFIG_ADC_ADS1119_ACQUISITION_THREAD_STACK_SIZE,
 				(k_thread_entry_t)ads1119_acquisition_thread,

--- a/drivers/adc/adc_ads114s0x.c
+++ b/drivers/adc/adc_ads114s0x.c
@@ -1352,7 +1352,7 @@ static int ads114s0x_init(const struct device *dev)
 	}
 
 #if CONFIG_ADC_ASYNC
-	const k_tid_t tid = k_thread_create(
+	k_tid_t tid = k_thread_create(
 		&data->thread, config->stack, CONFIG_ADC_ADS114S0X_ACQUISITION_THREAD_STACK_SIZE,
 		(k_thread_entry_t)ads114s0x_acquisition_thread, (void *)dev, NULL, NULL,
 		CONFIG_ADC_ADS114S0X_ASYNC_THREAD_INIT_PRIO, 0, K_NO_WAIT);

--- a/drivers/adc/adc_ads1x1x.c
+++ b/drivers/adc/adc_ads1x1x.c
@@ -570,7 +570,7 @@ static int ads1x1x_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	const k_tid_t tid =
+	k_tid_t tid =
 		k_thread_create(&data->thread, data->stack, K_THREAD_STACK_SIZEOF(data->stack),
 				(k_thread_entry_t)ads1x1x_acquisition_thread, (void *)dev, NULL,
 				NULL, CONFIG_ADC_ADS1X1X_ACQUISITION_THREAD_PRIO, 0, K_NO_WAIT);

--- a/drivers/adc/adc_max11102_17.c
+++ b/drivers/adc/adc_max11102_17.c
@@ -366,7 +366,7 @@ static int max11102_17_init(const struct device *dev)
 	data->current_channel_id = 0;
 
 #if CONFIG_ADC_ASYNC
-	const k_tid_t tid = k_thread_create(
+	k_tid_t tid = k_thread_create(
 		&data->thread, data->stack, CONFIG_ADC_MAX11102_17_ACQUISITION_THREAD_STACK_SIZE,
 		(k_thread_entry_t)max11102_17_acquisition_thread, (void *)dev, NULL, NULL,
 		CONFIG_ADC_MAX11102_17_ACQUISITION_THREAD_INIT_PRIO, 0, K_NO_WAIT);

--- a/drivers/adc/adc_max1125x.c
+++ b/drivers/adc/adc_max1125x.c
@@ -750,7 +750,7 @@ static int max1125x_init(const struct device *dev)
 		return -EIO;
 	}
 
-	const k_tid_t tid = k_thread_create(
+	k_tid_t tid = k_thread_create(
 		&data->thread, data->stack, K_THREAD_STACK_SIZEOF(data->stack),
 		(k_thread_entry_t)max1125x_acquisition_thread, (void *)dev, NULL, NULL,
 		CONFIG_ADC_MAX1125X_ACQUISITION_THREAD_PRIORITY, 0, K_NO_WAIT);


### PR DESCRIPTION
"const k_tid_t" is "struct k_thread * const" and not "const struct k_thread *" as the code may be assuming. Just drop it.