### PR TITLE
scripts/requirements: bump imgtool to 2.0.0

### DIFF
--- a/scripts/requirements-extras.txt
+++ b/scripts/requirements-extras.txt
@@ -19,7 +19,7 @@ lpc_checksum
 Pillow>=10.0
 
 # can be used to sign a Zephyr application binary for consumption by a bootloader
-imgtool>=1.9
+imgtool>=2.0.0
 
 # used by nanopb module to generate sources from .proto files
 grpcio-tools>=1.47.0


### PR DESCRIPTION
Resolves incorrectly located `image_ok` tag in generated hex files when  CONFIG_MCUBOOT_GENERATE_CONFIRMED_IMAGE is used.

Fixes #64098