### PR TITLE
ci: Fix license check false pass

### DIFF
--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout the code
       uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - name: Scan the code
       id: scancode
       uses: zephyrproject-rtos/action_scancode@v4


### PR DESCRIPTION
The license check workflow quietly stopped working after commit 8f66f854c3238d67de7c64da86a3de18bf3e4683. Upgrading the checkout action changed default behavior to only fetch one commit instead of all history for all branches, which caused an uncaught fatal error in the scancode action:

fatal: ambiguous argument 'origin/main..': unknown revision or path not in the working tree.

The scancode action then completed successfully having not actually checked anything.

Fix this by setting the checkout action fetch depth to 0, similar to other workflows.