### PR TITLE
bluetooth: hci_core: handle NUM_COMPLETED_PACKETS rsp

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2337,6 +2337,14 @@ static void hci_cmd_complete(struct net_buf *buf)
 	 */
 	status = buf->data[0];
 
+	/* HOST_NUM_COMPLETED_PACKETS should not generate a response under normal operation.
+	 * The generation of this command ignores `ncmd_sem`, so should not be given here.
+	 */
+	if (opcode == BT_HCI_OP_HOST_NUM_COMPLETED_PACKETS) {
+		LOG_WRN("Unexpected HOST_NUM_COMPLETED_PACKETS (status 0x%02x)", status);
+		return;
+	}
+
 	hci_cmd_done(opcode, status, buf);
 
 	/* Allow next command to be sent */


### PR DESCRIPTION
The `BT_HCI_OP_HOST_NUM_COMPLETED_PACKETS` is not expected to generate a response from the controller, but from the spec:

Normally, no event is generated after the HCI_Host_Number_Of_Completed_Packets command has completed. However, if the HCI_Host_Number_Of_Completed_Packets command contains one or more invalid parameters, the Controller shall return an HCI_Command_Complete event with a failure status indicating the Invalid HCI Command Parameters error code.

In practice, this can also be generated if flow control is inadvertedly turned off during operation. Running `hci_cmd_done` is not correct when the event happens (as there is no corresponding command buffer), and `ncmd_sem` should not be given as this command ignores the semaphore when sending.