### PR TITLE
include: pinctrl.h: Make PINCTRL_SKIP_SLEEP available with CONIG_PM

### DIFF
--- a/doc/hardware/pinctrl/index.rst
+++ b/doc/hardware/pinctrl/index.rst
@@ -145,9 +145,10 @@ In most situations, the states defined in Devicetree will be the ones used in
 the compiled firmware. However, there are some cases where certain states will
 be conditionally used depending on a compilation flag. A typical case is the
 ``sleep`` state. This state is only used in practice if
-:kconfig:option:`CONFIG_PM_DEVICE` is enabled. If a firmware variant without device
-power management is needed, one should in theory remove the ``sleep`` state from
-Devicetree to not waste ROM space storing such unused state.
+:kconfig:option:`CONFIG_PM` or :kconfig:option:`CONFIG_PM_DEVICE` is enabled.
+If a firmware variant without these power management configurations is needed,
+one should in theory remove the ``sleep`` state from Devicetree to not waste ROM
+space storing such unused state.
 
 States can be skipped by the ``pinctrl`` Devicetree macros if a definition named
 ``PINCTRL_SKIP_{STATE_NAME}`` expanding to ``1`` is present when pin control
@@ -157,8 +158,8 @@ management:
 
 .. code-block:: c
 
-    #ifndef CONFIG_PM_DEVICE
-    /** If device power management is not enabled, "sleep" state will be ignored. */
+    #if !defined(CONFIG_PM) && !defined(CONFIG_PM_DEVICE)
+    /** Out of power management configurations, ignore "sleep" state. */
     #define PINCTRL_SKIP_SLEEP 1
     #endif
 

--- a/include/zephyr/drivers/pinctrl.h
+++ b/include/zephyr/drivers/pinctrl.h
@@ -76,8 +76,8 @@ struct pinctrl_dev_config {
 
 /** @cond INTERNAL_HIDDEN */
 
-#ifndef CONFIG_PM_DEVICE
-/** If device power management is not enabled, "sleep" state will be ignored. */
+#if !defined(CONFIG_PM) && !defined(CONFIG_PM_DEVICE)
+/** Out of power management configurations, ignore "sleep" state. */
 #define PINCTRL_SKIP_SLEEP 1
 #endif
 


### PR DESCRIPTION
In some cases, PINCTRL_STATE_SLEEP may be required even when CONFIG_PM_DEVICE is not defined.
One example is the possibility/need to put JTAG pins to analog when CONIG_PM=y and CONFIG_DEBUG=n.