### PR TITLE
mgmt: ec_host_cmd: remove timeout for UART callback

### DIFF
--- a/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_uart.c
+++ b/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_uart.c
@@ -100,8 +100,6 @@ static int request_expected_size(const struct ec_host_cmd_request_header *r)
 		.ctx = &_name##_hc_uart,                                                           \
 	}
 
-/* Waiting time in microseconds to detect overrun */
-#define UART_OVERRUN_TIMEOUT_US 300
 /* Timeout after receiving first byte */
 #define UART_REQ_RX_TIMEOUT     K_MSEC(150)
 
@@ -135,8 +133,7 @@ static void rx_timeout(struct k_work *work)
 	}
 
 	res = uart_rx_disable(hc_uart->uart_dev);
-	res = uart_rx_enable(hc_uart->uart_dev, hc_uart->rx_ctx->buf, hc_uart->rx_buf_size,
-			     UART_OVERRUN_TIMEOUT_US);
+	res = uart_rx_enable(hc_uart->uart_dev, hc_uart->rx_ctx->buf, hc_uart->rx_buf_size, 0);
 
 	hc_uart->state = UART_HOST_CMD_READY_TO_RX;
 }
@@ -247,8 +244,7 @@ static int ec_host_cmd_uart_init(const struct ec_host_cmd_backend *backend,
 
 	k_work_init_delayable(&hc_uart->timeout_work, rx_timeout);
 	uart_callback_set(hc_uart->uart_dev, uart_callback, hc_uart);
-	ret = uart_rx_enable(hc_uart->uart_dev, hc_uart->rx_ctx->buf, hc_uart->rx_buf_size,
-			     UART_OVERRUN_TIMEOUT_US);
+	ret = uart_rx_enable(hc_uart->uart_dev, hc_uart->rx_ctx->buf, hc_uart->rx_buf_size, 0);
 
 	hc_uart->state = UART_HOST_CMD_READY_TO_RX;
 
@@ -270,8 +266,7 @@ static int ec_host_cmd_uart_send(const struct ec_host_cmd_backend *backend)
 	/* The rx buffer is no longer in use by command handler.
 	 * Enable receiving to be ready to get a new command right after sending the response.
 	 */
-	uart_rx_enable(hc_uart->uart_dev, hc_uart->rx_ctx->buf, hc_uart->rx_buf_size,
-		       UART_OVERRUN_TIMEOUT_US);
+	uart_rx_enable(hc_uart->uart_dev, hc_uart->rx_ctx->buf, hc_uart->rx_buf_size, 0);
 
 	/* uart_tx is non-blocking asynchronous function.
 	 * The state is changed to UART_HOST_CMD_READY_TO_RX in the UART_TX_DONE event.


### PR DESCRIPTION
Do not use timeout for UART callback. The UART IRQ bases on the IDLE line, so waiting for additional bytes is not necessary and it introduce additional latency.

Another issue with the timeout is that the UART drivers use sysworkq for implementing timeout. The sysworkq thread may have lower prio than the host command thread, which may cause a delay in calling the UART callback, which gives the semaphore to the HC handler.