### PR TITLE
doc: release: 3.5: Add x86-related release notes

### DIFF
--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -100,6 +100,11 @@ Architectures
 
   * Added basic MMU v2 Support.
 
+* x86
+
+  * Added support for Intel Alder Lake boards
+  * Added support for Intel Sensor Hub (ISH)
+
 * POSIX
 
   * Has been reworked to use the native simulator.

--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -625,6 +625,10 @@ Drivers and Sensors
 
   * Added support to get IRQ from ACPI PCI Routing Table (PRT).
 
+* ACPI
+
+  * Adopted the ACPICA library as a new module to further enhance ACPI support.
+
 * PECI
 
 * Pin control


### PR DESCRIPTION
Add information on new x86 boards and the ACPICA library.