### PR TITLE
boards: arm: disco_l475_iot1: add stm32cubeprogrammer

### DIFF
--- a/boards/arm/disco_l475_iot1/board.cmake
+++ b/boards/arm/disco_l475_iot1/board.cmake
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 board_runner_args(jlink "--device=STM32L475VG" "--speed=4000")
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)


### PR DESCRIPTION
add stm32cubeprogrammer runner for disco_l475_iot1 boards

Since https://github.com/zephyrproject-rtos/zephyr/pull/62647, debug in stop mode is explicitely disabled in f/w when debug is not enabled. 
After running application with PM enabled, it is not possible to flash using openocd. One consequence is tests failed in CI when openocd is used. However we can still use flash using stm32cubeprogrammer runner, so add stm32cubeprogrammer to this board in order to use it with twister.