### PR TITLE
Bluetooth: BAP: Shell: Fixed cmd_stream_qos

### DIFF
--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -1157,7 +1157,7 @@ static int cmd_stream_qos(const struct shell *sh, size_t argc, char *argv[])
 {
 	struct bt_audio_codec_qos *qos;
 	unsigned long interval;
-	int err;
+	int err = 0;
 
 	if (default_stream == NULL) {
 		shell_print(sh, "No stream selected");


### PR DESCRIPTION
Fixed cmd_stream_qos. Added missing initialisation of variable int err.