### PR TITLE
net: ieee802154: Fix `nrf5_get_acc` to return value selected for board.

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -640,7 +640,7 @@ static uint8_t nrf5_get_acc(const struct device *dev)
 {
 	ARG_UNUSED(dev);
 
-	return CONFIG_IEEE802154_NRF5_DELAY_TRX_ACC;
+	return CONFIG_CLOCK_CONTROL_NRF_ACCURACY;
 }
 
 static int nrf5_start(const struct device *dev)


### PR DESCRIPTION
`nrf5_get_acc` was returning value hardcoded from the Kconfig related to openthread rather than actual value selected for the board.