### PR TITLE
ipc: backend: rpmsg: Add support for POSIX arch

### DIFF
--- a/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.c
+++ b/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.c
@@ -774,11 +774,21 @@ static int backend_init(const struct device *instance)
 	return 0;
 }
 
+
+#if defined(CONFIG_ARCH_POSIX)
+#define BACKEND_PRE(i) extern char IPC##i##_shm_buffer[];
+#define BACKEND_SHM_ADDR(i) (const uintptr_t)IPC##i##_shm_buffer
+#else
+#define BACKEND_PRE(i)
+#define BACKEND_SHM_ADDR(i) DT_REG_ADDR(DT_INST_PHANDLE(i, memory_region))
+#endif /* defined(CONFIG_ARCH_POSIX) */
+
 #define DEFINE_BACKEND_DEVICE(i)							\
+	BACKEND_PRE(i)									\
 	static struct backend_config_t backend_config_##i = {				\
 		.role = DT_ENUM_IDX_OR(DT_DRV_INST(i), role, ROLE_HOST),		\
 		.shm_size = DT_REG_SIZE(DT_INST_PHANDLE(i, memory_region)),		\
-		.shm_addr = DT_REG_ADDR(DT_INST_PHANDLE(i, memory_region)),		\
+		.shm_addr = BACKEND_SHM_ADDR(i),					\
 		.mbox_tx = MBOX_DT_CHANNEL_GET(DT_DRV_INST(i), tx),			\
 		.mbox_rx = MBOX_DT_CHANNEL_GET(DT_DRV_INST(i), rx),			\
 		.wq_prio = COND_CODE_1(DT_INST_NODE_HAS_PROP(i, zephyr_priority),	\


### PR DESCRIPTION
To enable runninng and testing this backend on the POSIX architecture, we need to allow defining the shared memory buffer as a compiler provided symbol, instead of a hard address provided by the DTS.
For this case we refer to a symbol a POSIX arch implementation (typically the board) needs to provide.
It is the responsability of that implementation to ensure that symbol exists and points to a memory buffer of the DT defined size.

---

This change can go in in isolation as it does not break anything; It is a prerequisite for more changes.
Though an example of how this will be used can be seen in https://github.com/zephyrproject-rtos/zephyr/pull/64134 .
