### PR TITLE
modules: canopennode: make the CANopenNode module optional

### DIFF
--- a/samples/modules/canopennode/README.rst
+++ b/samples/modules/canopennode/README.rst
@@ -26,6 +26,13 @@ Requirements
 Building and Running
 ********************
 
+First, ensure the optional CANopenNode module is enabled and available:
+
+   .. code-block:: console
+
+      west config manifest.group-filter +optional
+      west update canopennode
+
 Building and Running for TWR-KE18F
 ==================================
 The :ref:`twr_ke18f` board is equipped with an onboard CAN

--- a/submanifests/optional.yaml
+++ b/submanifests/optional.yaml
@@ -3,6 +3,12 @@ manifest:
     - name: upstream
       url-base: https://github.com/zephyrproject-rtos
   projects:
+    - name: canopennode
+      revision: dec12fa3f0d790cafa8414a4c2930ea71ab72ffd
+      path: modules/lib/canopennode
+      remote: upstream
+      groups:
+        - optional
     - name: chre
       revision: 3b32c76efee705af146124fb4190f71be5a4e36e
       path: modules/lib/chre

--- a/west.yml
+++ b/west.yml
@@ -115,9 +115,6 @@ manifest:
       revision: eed6d7038e839153e340bd333bc43541cb90ba64
       groups:
         - babblesim
-    - name: canopennode
-      revision: dec12fa3f0d790cafa8414a4c2930ea71ab72ffd
-      path: modules/lib/canopennode
     - name: cmsis
       revision: 5a00331455dd74e31e80efa383a489faea0590e3
       path: modules/hal/cmsis


### PR DESCRIPTION
Make the CANopenNode module, which provides a CANopen protocol implementation, optional.