### PR TITLE
Fix PDF build

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -199,6 +199,7 @@ latex_logo = str(ZEPHYR_BASE / "doc" / "_static" / "images" / "logo-latex.pdf")
 latex_documents = [
     ("index-tex", "zephyr.tex", "Zephyr Project Documentation", author, "manual"),
 ]
+latex_engine = "xelatex"
 
 # -- Options for zephyr.doxyrunner plugin ---------------------------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -5,6 +5,7 @@ import sys
 import os
 from pathlib import Path
 import re
+import textwrap
 
 from sphinx.cmd.build import get_parser
 import sphinx_rtd_theme
@@ -182,7 +183,11 @@ latex_elements = {
     "papersize": "a4paper",
     "maketitle": open(ZEPHYR_BASE / "doc" / "_static" / "latex" / "title.tex").read(),
     "preamble": open(ZEPHYR_BASE / "doc" / "_static" / "latex" / "preamble.tex").read(),
-    "fontpkg": r"\usepackage{charter}",
+    "fontpkg": textwrap.dedent(r"""
+                                    \usepackage{noto}
+                                    \usepackage{inconsolata-nerd-font}
+                                    \usepackage[T1]{fontenc}
+                                """),
     "sphinxsetup": ",".join(
         (
             # NOTE: colors match those found in light.css stylesheet


### PR DESCRIPTION
This fixes the PDF build by switching to a more future-proof typesetting engine with proper Unicode and OTF fonts handling.

While emojis don't fail the build, they render as 'tofu' (▢) for now, but since this is by far not the most broken thing in the PDF at this point, I think it's good to go :)

Note that I've also switched to more modern fonts so we're not having things like ligatures, and in many, most instances, code block don't unnecessarily wrap since the font that is now used is a bit narrower..... that PDF might be salvageable after all! :-)

See fixed PDF here: https://github.com/zephyrproject-rtos/zephyr/suites/17416644300/artifacts/995482922 -- note that CI doesn't build the PDF, so this is a link to a build where I had these 2 commits plus a tweak to the GH action that I've now removed. Once this is merged, PDF should be appear on the website in the next max. 3 hours.

