### PR TITLE
shell: backend: telnet: Do not try to disconnect if we already are disconnected

### DIFF
--- a/subsys/shell/backends/shell_telnet.c
+++ b/subsys/shell/backends/shell_telnet.c
@@ -39,6 +39,11 @@ static void telnet_end_client_connection(void)
 {
 	struct net_pkt *pkt;
 
+	/* Do not try to disconnect if we already are disconnected */
+	if (sh_telnet->client_ctx == NULL) {
+		return;
+	}
+
 	(void)net_context_put(sh_telnet->client_ctx);
 
 	sh_telnet->client_ctx = NULL;


### PR DESCRIPTION
If there is a network error when using telnet, there are a sequence of calls that each calls `telnet_end_client_communication()`.
The first one succeeds, but the next one tries to call with the client context pointer being NULL. That causes a crash.

The sequence can for example be `telnet_send()` fails, calls `telnet_end_client_communication()` and returns an error code. `write()` receives the error code and then also calls `telnet_end_client_communication()`.

I just realized that this case maybe is more specific to my code, but I think the extra check for NULL pointer in this case is always good. It is fragile if you must check every error path to make sure you  just call `telnet_end_client_communication()` once.