### PR TITLE
Fix pca9685 set_pre_scale when not in restart mode

### DIFF
--- a/drivers/pwm/pwm_pca9685.c
+++ b/drivers/pwm/pwm_pca9685.c
@@ -119,6 +119,7 @@ static int set_pre_scale(const struct device *dev, uint8_t value)
 	struct pca9685_data *data = dev->data;
 	uint8_t mode1;
 	int ret;
+	uint8_t restart = RESTART;
 
 	k_mutex_lock(&data->mutex, K_FOREVER);
 
@@ -134,9 +135,7 @@ static int set_pre_scale(const struct device *dev, uint8_t value)
 	}
 
 	if ((mode1 & RESTART) == 0x00) {
-		LOG_ERR("RESTART bit should be set");
-		ret = -EIO;
-		goto out;
+		restart = 0;
 	}
 
 	ret = set_reg(dev, ADDR_PRE_SCALE, value);
@@ -152,7 +151,7 @@ static int set_pre_scale(const struct device *dev, uint8_t value)
 
 	k_sleep(OSCILLATOR_STABILIZE);
 
-	ret = set_reg(dev, ADDR_MODE1, AUTO_INC | RESTART);
+	ret = set_reg(dev, ADDR_MODE1, AUTO_INC | restart);
 	if (ret != 0) {
 		goto out;
 	}


### PR DESCRIPTION
The pca9685 driver assumes the chip will be in "restart" mode after putting it to sleep. This is not necessarily the case, which causes setting the prescaler to fail. This fix allows the precaler to always be set and only restart the pwm's when the chip was actually in restart mode after being put to sleep.