### PR TITLE
PM: Add missing tests to increase coverage

### DIFF
--- a/tests/subsys/pm/device_runtime_api/src/main.c
+++ b/tests/subsys/pm/device_runtime_api/src/main.c
@@ -270,7 +270,7 @@ ZTEST(device_runtime_api, test_unsupported)
 	zassert_equal(pm_device_runtime_disable(dev), -ENOTSUP, "");
 	zassert_equal(pm_device_runtime_get(dev), 0, "");
 	zassert_equal(pm_device_runtime_put(dev), 0, "");
-	zassert_false(pm_device_runtime_put_async(dev), "");
+	zassert_false(pm_device_runtime_put_async(dev, K_NO_WAIT),  "");
 }
 
 int dev_pm_control(const struct device *dev, enum pm_device_action action)

--- a/tests/subsys/pm/device_runtime_api/src/main.c
+++ b/tests/subsys/pm/device_runtime_api/src/main.c
@@ -270,6 +270,7 @@ ZTEST(device_runtime_api, test_unsupported)
 	zassert_equal(pm_device_runtime_disable(dev), -ENOTSUP, "");
 	zassert_equal(pm_device_runtime_get(dev), 0, "");
 	zassert_equal(pm_device_runtime_put(dev), 0, "");
+	zassert_false(pm_device_runtime_put_async(dev), "");
 }
 
 int dev_pm_control(const struct device *dev, enum pm_device_action action)


### PR DESCRIPTION
Cover missing tests for increase code coverage for power management : 
- pm_state_force, 
- pm_state_cpu_get_all, 
- pm_state_next_get.