### PR TITLE
arch: Fixes potential mangled isr table when SHARED_INTERRUPTS is ena…

### DIFF
--- a/include/zephyr/linker/common-rom/common-rom-kernel-devices.ld
+++ b/include/zephyr/linker/common-rom/common-rom-kernel-devices.ld
@@ -40,6 +40,11 @@
 		/* TODO: does this section require alignment? */
 		KEEP(*(_SHARED_SW_ISR_TABLE_SECTION_SYMS))
 	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+
+	SECTION_PROLOGUE(.text.z_shared_isr,,)
+	{
+		KEEP(*(.text.z_shared_isr))
+	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 #endif
 
 #endif


### PR DESCRIPTION
…bled

The linker was optimizing away z_shared_isr() the zephyr_pre0.elf image since the function is not used. However, zephyr.elf does use this function via isr_tables.c file, generated after zephyr_pre0.elf.

This difference caused a shift in all symbol addresses by the size of the z_shared_isr() function. isr_tables.c had pointers for zephyr_pre0.elf. The build system assumes the ISR addresses are the same between both .elf files, when in fact, before this fix, they were not.

When run on a device, interrupts were calling non-interrupt functions.

The fix is to force z_shared_isr() to be included in both elf images. This is done through linker modification.

See https://github.com/zephyrproject-rtos/zephyr/issues/64110