### PR TITLE
llext: Fix wrong check

### DIFF
--- a/subsys/llext/llext.c
+++ b/subsys/llext/llext.c
@@ -386,7 +386,7 @@ static inline int llext_copy_symbols(struct llext_loader *ldr, struct llext *ext
 			goto out;
 		}
 
-		llext_read(ldr, name, sizeof(name));
+		ret = llext_read(ldr, name, sizeof(name));
 		if (ret != 0) {
 			goto out;
 		}


### PR DESCRIPTION
In llext_copy_symbols the check after llext_read
was looking the result of llext_seek operation instead of the read.