### PR TITLE
Add CODE_UNREACHABLE after k_thread_abort(k_current_get())

### DIFF
--- a/lib/posix/pthread.c
+++ b/lib/posix/pthread.c
@@ -628,6 +628,8 @@ void pthread_exit(void *retval)
 		/* not a valid posix_thread */
 		LOG_DBG("Aborting non-pthread %p", k_current_get());
 		k_thread_abort(k_current_get());
+
+		CODE_UNREACHABLE;
 	}
 
 	/* Make a thread as cancelable before exiting */

--- a/samples/modules/tflite-micro/tflm_ethosu/src/main.cpp
+++ b/samples/modules/tflite-micro/tflm_ethosu/src/main.cpp
@@ -149,6 +149,8 @@ void inferenceProcessTask(void *_name, void *heap, void *_params)
 	}
 
 	k_thread_abort(k_current_get());
+
+	CODE_UNREACHABLE;
 }
 
 /* inferenceSenderTask - Creates NUM_INFERENCE_JOBS jobs, queues them, and then

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1307,6 +1307,8 @@ static void kill_handler(const struct shell *sh)
 
 	sh->ctx->tid = NULL;
 	k_thread_abort(k_current_get());
+
+	CODE_UNREACHABLE;
 }
 
 void shell_thread(void *shell_handle, void *arg_log_backend,

--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -440,6 +440,8 @@ static void test_finalize(void)
 	if (IS_ENABLED(CONFIG_MULTITHREADING)) {
 		k_thread_abort(&ztest_thread);
 		k_thread_abort(k_current_get());
+
+		CODE_UNREACHABLE;
 	}
 }
 

--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -439,8 +439,11 @@ static void test_finalize(void)
 {
 	if (IS_ENABLED(CONFIG_MULTITHREADING)) {
 		k_thread_abort(&ztest_thread);
-		k_thread_abort(k_current_get());
+		if (k_is_in_isr()) {
+			return;
+		}
 
+		k_thread_abort(k_current_get());
 		CODE_UNREACHABLE;
 	}
 }

--- a/subsys/testsuite/ztest/src/ztest_error_hook.c
+++ b/subsys/testsuite/ztest/src/ztest_error_hook.c
@@ -106,6 +106,8 @@ static inline void z_vrfy_ztest_set_assert_valid(bool valid)
 __weak void ztest_post_assert_fail_hook(void)
 {
 	k_thread_abort(k_current_get());
+
+	CODE_UNREACHABLE;
 }
 
 #ifdef CONFIG_ASSERT_NO_FILE_INFO

--- a/subsys/testsuite/ztest/src/ztest_new.c
+++ b/subsys/testsuite/ztest/src/ztest_new.c
@@ -440,6 +440,8 @@ static void test_finalize(void)
 	if (IS_ENABLED(CONFIG_MULTITHREADING)) {
 		k_thread_abort(&ztest_thread);
 		k_thread_abort(k_current_get());
+
+		CODE_UNREACHABLE;
 	}
 }
 

--- a/subsys/testsuite/ztest/src/ztest_new.c
+++ b/subsys/testsuite/ztest/src/ztest_new.c
@@ -439,8 +439,11 @@ static void test_finalize(void)
 {
 	if (IS_ENABLED(CONFIG_MULTITHREADING)) {
 		k_thread_abort(&ztest_thread);
-		k_thread_abort(k_current_get());
+		if (k_is_in_isr()) {
+			return;
+		}
 
+		k_thread_abort(k_current_get());
 		CODE_UNREACHABLE;
 	}
 }

--- a/tests/kernel/sched/deadline/src/main.c
+++ b/tests/kernel/sched/deadline/src/main.c
@@ -125,6 +125,8 @@ void yield_worker(void *p1, void *p2, void *p3)
 	zassert_true(n_exec == NUM_THREADS, "");
 
 	k_thread_abort(k_current_get());
+
+	CODE_UNREACHABLE;
 }
 
 ZTEST(suite_deadline, test_yield)

--- a/tests/kernel/threads/thread_apis/src/test_threads_cancel_abort.c
+++ b/tests/kernel/threads/thread_apis/src/test_threads_cancel_abort.c
@@ -25,6 +25,7 @@ static void thread_entry_abort(void *p1, void *p2, void *p3)
 	/**TESTPOINT: abort current thread*/
 	execute_flag = 1;
 	k_thread_abort(k_current_get());
+	CODE_UNREACHABLE;
 	/*unreachable*/
 	execute_flag = 2;
 	zassert_true(1 == 0);


### PR DESCRIPTION
Compiler can't tell that k_thread_abort() won't return and issues a warning unless we tell it that control never gets this far.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/61393