### PR TITLE
include/zephyr: Add a new macro __malloc_like_with_free()

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -5417,6 +5417,18 @@ void k_heap_init(struct k_heap *h, void *mem,
 		size_t bytes) __attribute_nonnull(1);
 
 /**
+ * @brief Free memory allocated by k_heap_alloc()
+ *
+ * Returns the specified memory block, which must have been returned
+ * from k_heap_alloc(), to the heap for use by other callers.  Passing
+ * a NULL block is legal, and has no effect.
+ *
+ * @param h Heap to which to return the memory
+ * @param mem A valid memory block, or NULL
+ */
+void k_heap_free(struct k_heap *h, void *mem) __attribute_nonnull(1);
+
+/**
  * @brief Allocate aligned memory from a k_heap
  *
  * Behaves in all ways like k_heap_alloc(), except that the returned
@@ -5436,6 +5448,7 @@ void k_heap_init(struct k_heap *h, void *mem,
  * @param timeout How long to wait, or K_NO_WAIT
  * @return Pointer to memory the caller can now use
  */
+__deallocate_with(k_heap_free, 2)
 void *k_heap_aligned_alloc(struct k_heap *h, size_t align, size_t bytes,
 			k_timeout_t timeout) __attribute_nonnull(1);
 
@@ -5460,6 +5473,7 @@ void *k_heap_aligned_alloc(struct k_heap *h, size_t align, size_t bytes,
  * @param timeout How long to wait, or K_NO_WAIT
  * @return A pointer to valid heap memory, or NULL
  */
+__deallocate_with(k_heap_free, 2)
 void *k_heap_alloc(struct k_heap *h, size_t bytes,
 		k_timeout_t timeout) __attribute_nonnull(1);
 
@@ -5488,18 +5502,6 @@ void *k_heap_alloc(struct k_heap *h, size_t bytes,
  */
 void *k_heap_realloc(struct k_heap *h, void *ptr, size_t bytes, k_timeout_t timeout)
 	__attribute_nonnull(1);
-
-/**
- * @brief Free memory allocated by k_heap_alloc()
- *
- * Returns the specified memory block, which must have been returned
- * from k_heap_alloc(), to the heap for use by other callers.  Passing
- * a NULL block is legal, and has no effect.
- *
- * @param h Heap to which to return the memory
- * @param mem A valid memory block, or NULL
- */
-void k_heap_free(struct k_heap *h, void *mem) __attribute_nonnull(1);
 
 /* Hand-calculated minimum heap sizes needed to return a successful
  * 1-byte allocation.  See details in lib/os/heap.[ch]
@@ -5579,6 +5581,18 @@ void k_heap_free(struct k_heap *h, void *mem) __attribute_nonnull(1);
  */
 
 /**
+ * @brief Free memory allocated from heap.
+ *
+ * This routine provides traditional free() semantics. The memory being
+ * returned must have been allocated from the heap memory pool.
+ *
+ * If @a ptr is NULL, no operation is performed.
+ *
+ * @param ptr Pointer to previously allocated memory.
+ */
+void k_free(void *ptr);
+
+/**
  * @brief Allocate memory from the heap with a specified alignment.
  *
  * This routine provides semantics similar to aligned_alloc(); memory is
@@ -5596,6 +5610,7 @@ void k_heap_free(struct k_heap *h, void *mem) __attribute_nonnull(1);
  *
  * @return Address of the allocated memory if successful; otherwise NULL.
  */
+__deallocate_with(k_free, 1)
 void *k_aligned_alloc(size_t align, size_t size);
 
 /**
@@ -5609,19 +5624,8 @@ void *k_aligned_alloc(size_t align, size_t size);
  *
  * @return Address of the allocated memory if successful; otherwise NULL.
  */
+__deallocate_with(k_free, 1)
 void *k_malloc(size_t size);
-
-/**
- * @brief Free memory allocated from heap.
- *
- * This routine provides traditional free() semantics. The memory being
- * returned must have been allocated from the heap memory pool.
- *
- * If @a ptr is NULL, no operation is performed.
- *
- * @param ptr Pointer to previously allocated memory.
- */
-void k_free(void *ptr);
 
 /**
  * @brief Allocate memory from heap, array style

--- a/include/zephyr/toolchain/gcc.h
+++ b/include/zephyr/toolchain/gcc.h
@@ -247,6 +247,7 @@ do {                                                                    \
 #define __used		__attribute__((__used__))
 #define __unused	__attribute__((__unused__))
 #define __maybe_unused	__attribute__((__unused__))
+#define __deallocate_with(d, i)	__attribute__((malloc (d, i)))
 
 #ifndef __deprecated
 #define __deprecated	__attribute__((deprecated))

--- a/include/zephyr/toolchain/llvm.h
+++ b/include/zephyr/toolchain/llvm.h
@@ -17,6 +17,8 @@
 #define __fallthrough __attribute__((fallthrough))
 #endif
 
+#define __deallocate_with(d, i)
+
 #define TOOLCHAIN_CLANG_VERSION \
 	((__clang_major__ * 10000) + (__clang_minor__ * 100) + \
 	  __clang_patchlevel__)

--- a/kernel/mempool.c
+++ b/kernel/mempool.c
@@ -53,7 +53,12 @@ void k_free(void *ptr)
 
 		k_heap_free(*heap_ref, ptr);
 
+		#pragma GCC diagnostic push
+		#if TOOLCHAIN_GCC_VERSION >= 120000
+		#pragma GCC diagnostic ignored "-Wuse-after-free"
+		#endif
 		SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_heap_sys, k_free, *heap_ref, heap_ref);
+		#pragma GCC diagnostic pop
 	}
 }
 

--- a/lib/libc/minimal/include/stdlib.h
+++ b/lib/libc/minimal/include/stdlib.h
@@ -24,12 +24,18 @@ unsigned long long strtoull(const char *nptr, char **endptr, int base);
 long long strtoll(const char *nptr, char **endptr, int base);
 int atoi(const char *s);
 
+void free(void *ptr);
+
+__deallocate_with(free, 1)
 void *malloc(size_t size);
+__deallocate_with(free, 1)
 void *aligned_alloc(size_t alignment, size_t size); /* From C11 */
 
-void free(void *ptr);
+__deallocate_with(free, 1)
 void *calloc(size_t nmemb, size_t size);
+__deallocate_with(free, 1)
 void *realloc(void *ptr, size_t size);
+__deallocate_with(free, 1)
 void *reallocarray(void *ptr, size_t nmemb, size_t size);
 
 void *bsearch(const void *key, const void *array,


### PR DESCRIPTION
[GCC 11 introduced](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94527) a new function attribute malloc, which, as the GCC document says, indicates that a function is ‘malloc’-like.

With this attribute, GCC can find a silly use-after-free. Given that:

```c
#include <zephyr/kernel.h>

struct Foo { int a; };

int main(void)
{
    struct Foo *p = k_malloc(sizeof(struct Foo));
    if (p) {
        k_free(p);
        p->a = 1;
    }
    return 0;
}
```
GCC can now warn you:

    use-after-free/src/main.c: In function 'main':
    use-after-free/src/main.c:10:22: warning: pointer 'p' used after 'k_free' [-Wuse-after-free]
       10 |                 p->a = 1;
          |                 ~~~~~^~~
    use-after-free/src/main.c:9:17: note: call to 'k_free' here
        9 |                 k_free(p);
          |                 ^~~~~~~~~

The macro name, `__malloc_like_with_free`, is chosen to align with picolibc since there are some usage of `__malloc_like` in zephyr modules.
