### PR TITLE
dts: arm: npcx: fix family and device ID for npcx4

### DIFF
--- a/dts/arm/nuvoton/npcx/npcx4.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx4.dtsi
@@ -318,6 +318,7 @@
 	};
 
 	soc-id {
+		family-id = <0x23>;
 		chip-id = <0x0a>;
 		revision-reg = <0x0000FFFC 4>;
 	};

--- a/dts/arm/nuvoton/npcx4m3f.dtsi
+++ b/dts/arm/nuvoton/npcx4m3f.dtsi
@@ -22,7 +22,7 @@
 	};
 
 	soc-id {
-		device-id = <0x2d>;
+		device-id = <0x25>;
 	};
 };
 

--- a/dts/arm/nuvoton/npcx4m8f.dtsi
+++ b/dts/arm/nuvoton/npcx4m8f.dtsi
@@ -22,7 +22,7 @@
 	};
 
 	soc-id {
-		device-id = <0x2b>;
+		device-id = <0x23>;
 	};
 };
 


### PR DESCRIPTION
This commit fixes the incorrect family/device ID declaration in npcx4m3f and npcx4m8f dtsi file.