### PR TITLE
Bluetooth: Mesh: Update spec ref 1.0.1->1.1

### DIFF
--- a/doc/connectivity/bluetooth/api/mesh.rst
+++ b/doc/connectivity/bluetooth/api/mesh.rst
@@ -7,7 +7,7 @@ The Bluetooth mesh profile adds secure wireless multi-hop communication for
 Bluetooth Low Energy. This module implements the
 `Bluetooth Mesh Profile Specification v1.0.1 <https://www.bluetooth.com/specifications/specs/mesh-profile-1-0-1/>`_.
 
-Implementation of the `Bluetooth Mesh Protocol Specification v1.1 <https://www.bluetooth.com/specifications/specs/mesh-protocol-1-1/>`_
+Implementation of the `Bluetooth Mesh Protocol Specification v1.1 <https://www.bluetooth.com/specifications/specs/mesh-protocol/>`_
 is in experimental state.
 
 Read more about Bluetooth mesh on the

--- a/doc/connectivity/bluetooth/api/mesh/provisioning.rst
+++ b/doc/connectivity/bluetooth/api/mesh/provisioning.rst
@@ -180,7 +180,7 @@ a set of vulnerabilities in the Bluetooth mesh provisioning protocol that showca
 how the low entropy provided by the Blink, Vibrate, Push, Twist and
 Input/Output numeric OOB methods could be exploited in impersonation and MITM
 attacks. In response, the Bluetooth SIG has reclassified these OOB methods as
-insecure in the Mesh Profile specification `erratum 16350 <https://www.bluetooth.org/docman/handlers/DownloadDoc.ashx?doc_id=516072>`_,
+insecure in the Bluetooth Mesh Profile Specification v1.0.1 `erratum 16350 <https://www.bluetooth.org/docman/handlers/DownloadDoc.ashx?doc_id=516072>`_,
 as AuthValue may be brute forced in real time. To ensure secure provisioning, applications
 should use a static OOB value and OOB public key transfer.
 

--- a/include/zephyr/bluetooth/mesh/dfu_metadata.h
+++ b/include/zephyr/bluetooth/mesh/dfu_metadata.h
@@ -87,7 +87,7 @@ int bt_mesh_dfu_metadata_encode(const struct bt_mesh_dfu_metadata *metadata,
 
 /** @brief Compute hash of the Composition Data state.
  *
- *  The format of the Composition Data is defined in MshPRFv1.0.1, section 4.2.1.1.
+ *  The format of the Composition Data is defined in MshPRTv1.1: 4.2.2.1.
  *
  *  @param buf Pointer to buffer holding Composition Data.
  *  @param key 128-bit key to be used in the hash computation.

--- a/include/zephyr/bluetooth/mesh/main.h
+++ b/include/zephyr/bluetooth/mesh/main.h
@@ -1,5 +1,5 @@
 /** @file
- *  @brief Bluetooth mesh Profile APIs.
+ *  @brief Bluetooth mesh Protocol APIs.
  */
 
 /*

--- a/subsys/bluetooth/mesh/access.c
+++ b/subsys/bluetooth/mesh/access.c
@@ -377,7 +377,7 @@ static int comp_add_elem(struct net_buf_simple *buf, struct bt_mesh_elem *elem,
 
 	if (net_buf_simple_tailroom(buf) < ((elem_size - *offset) + BT_MESH_MIC_SHORT)) {
 		if (IS_ENABLED(CONFIG_BT_MESH_LARGE_COMP_DATA_SRV)) {
-			/* Mesh Profile 1.1 Section 4.4.1.2.2:
+			/* MshPRTv1.1: 4.4.1.2.2:
 			 * If the complete list of models does not fit in the Data field,
 			 * the element shall not be reported.
 			 */
@@ -611,7 +611,7 @@ static int bt_mesh_comp_data_get_page_1(struct net_buf_simple *buf, size_t offse
 
 		if (net_buf_simple_tailroom(buf) < ((elem_size - offset) + BT_MESH_MIC_SHORT)) {
 			if (IS_ENABLED(CONFIG_BT_MESH_LARGE_COMP_DATA_SRV)) {
-				/* Mesh Profile 1.1 Section 4.4.1.2.2:
+				/* MshPRTv1.1: 4.4.1.2.2:
 				 * If the complete list of models does not fit in the Data field,
 				 * the element shall not be reported.
 				 */
@@ -669,7 +669,7 @@ static int bt_mesh_comp_data_get_page_2(struct net_buf_simple *buf, size_t offse
 
 		if (net_buf_simple_tailroom(buf) < ((elem_size - offset) + BT_MESH_MIC_SHORT)) {
 			if (IS_ENABLED(CONFIG_BT_MESH_LARGE_COMP_DATA_SRV)) {
-				/* Mesh Profile 1.1 Section 4.4.1.2.2:
+				/* MshPRTv1.1: 4.4.1.2.2:
 				 * If the complete list of models does not fit in the Data field,
 				 * the element shall not be reported.
 				 */

--- a/subsys/bluetooth/mesh/app_keys.c
+++ b/subsys/bluetooth/mesh/app_keys.c
@@ -556,7 +556,7 @@ uint16_t bt_mesh_app_key_find(bool dev_key, uint8_t aid,
 			}
 		}
 
-		/** Bluetooth Mesh Specification v1.0.1, section 3.4.3:
+		/** MshPRTv1.1: 3.4.3:
 		 *  The Device key is only valid for unicast addresses.
 		 */
 		if (BT_MESH_ADDR_IS_UNICAST(rx->ctx.recv_dst)) {
@@ -569,7 +569,7 @@ uint16_t bt_mesh_app_key_find(bool dev_key, uint8_t aid,
 			if (atomic_test_bit(bt_mesh.flags, BT_MESH_DEVKEY_CAND)) {
 				err = cb(rx, &bt_mesh.dev_key_cand, cb_data);
 				if (!err) {
-					/* Bluetooth Mesh Specification v1.1.0, section 3.6.4.2:
+					/* MshPRTv1.1: 3.6.4.2:
 					 * If a message is successfully decrypted using the device
 					 * key candidate, the device key candidate should
 					 * permanently replace the original devkey.

--- a/subsys/bluetooth/mesh/blob.h
+++ b/subsys/bluetooth/mesh/blob.h
@@ -33,7 +33,7 @@
  *
  * The macros expand to a series of ternary expressions, effectively
  * searching through power of twos until a match is found.
- * According to the specification, the block size cannot be larger than 2^20,
+ * According to MshMBTv1.0, the block size cannot be larger than 2^20,
  * so we'll stop the search at 20.
  */
 #define _BLOB_LOG_2_CEIL(l, x) ((x) <= (1U << l)) ? l :

--- a/subsys/bluetooth/mesh/blob_cli.c
+++ b/subsys/bluetooth/mesh/blob_cli.c
@@ -1375,8 +1375,8 @@ static int handle_block_status(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx
 		LOG_DBG("Missing: %s", bt_hex(status.block.missing, len));
 		break;
 	case BT_MESH_BLOB_CHUNKS_MISSING_ENCODED:
-		/** An empty Missing Chunks field entails that there are no
-		 *  missing chunks for this block (Spec 5.3.8)
+		/** MshMBTv1.0: 5.3.8: An empty Missing Chunks field entails that there are no
+		 * missing chunks for this block.
 		 */
 		if (!buf->len) {
 			status.missing = BT_MESH_BLOB_CHUNKS_MISSING_NONE;

--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -2305,7 +2305,7 @@ static int heartbeat_pub_set(struct bt_mesh_model *model,
 
 	pub.dst = sys_le16_to_cpu(param->dst);
 	if (param->count_log == 0x11) {
-		/* Special case defined in Mesh Profile Errata 11737 */
+		/* Special case defined in MshPRFv1.1 Errata 11737 */
 		pub.count = 0xfffe;
 	} else {
 		pub.count = bt_mesh_hb_pwr2(param->count_log);

--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -95,9 +95,8 @@ struct bt_mesh_net bt_mesh = {
 #endif
 };
 
-/* Mesh Profile Specification 3.10.6
- * The node shall not execute more than one IV Index Recovery within a period of
- * 192 hours.
+/* MshPRTv1.1: 3.11.5:
+ * "A node shall not start an IV Update procedure more often than once every 192 hours."
  *
  * Mark that the IV Index Recovery has been done to prevent two recoveries to be
  * done before a normal IV Index update has been completed within 96h+96h.
@@ -293,7 +292,7 @@ bool bt_mesh_net_iv_update(uint32_t iv_index, bool iv_update)
 			return false;
 		}
 
-		/* The Mesh profile specification allows to initiate an
+		/* MshPRTv1.1 allows to initiate an
 		 * IV Index Recovery procedure if previous IV update has
 		 * been missed. This allows the node to remain
 		 * functional.
@@ -560,7 +559,7 @@ int bt_mesh_net_send(struct bt_mesh_net_tx *tx, struct net_buf *buf,
 		}
 	}
 
-	/* Mesh spec 3.4.5.2: "The output filter of the interface connected to
+	/* MshPRTv1.1: 3.4.5.2: "The output filter of the interface connected to
 	 * advertising or GATT bearers shall drop all messages with TTL value
 	 * set to 1." If a TTL=1 packet wasn't for a local interface, it is
 	 * invalid.

--- a/subsys/bluetooth/mesh/pb_adv.c
+++ b/subsys/bluetooth/mesh/pb_adv.c
@@ -922,7 +922,7 @@ static void prov_link_close(enum prov_bearer_link_status status)
 	}
 
 	/*
-	 * According to mesh profile spec (5.3.1.4.3), the close message should
+	 * According to MshPRTv1.1: 5.3.1.4.3, the close message should
 	 * be restransmitted at least three times. Retransmit the LINK_CLOSE
 	 * message until CLOSING_TIMEOUT has elapsed.
 	 */

--- a/subsys/bluetooth/mesh/prov.c
+++ b/subsys/bluetooth/mesh/prov.c
@@ -153,15 +153,10 @@ static uint32_t get_auth_number(bt_mesh_output_action_t output,
 
 	bt_rand(&num, sizeof(num));
 
-	if (output == BT_MESH_BLINK ||
-	    output == BT_MESH_BEEP ||
-	    output == BT_MESH_VIBRATE ||
-	    input == BT_MESH_PUSH ||
-	    input == BT_MESH_TWIST) {
-		/* According to the Bluetooth Mesh Profile
-		 * Specification Section 5.4.2.4, blink, beep
-		 * vibrate, push and twist should be a random integer
-		 * between 0 and 10^size, *exclusive*:
+	if (output == BT_MESH_BLINK || output == BT_MESH_BEEP || output == BT_MESH_VIBRATE ||
+	    input == BT_MESH_PUSH || input == BT_MESH_TWIST) {
+		/* According to MshPRTv1.1: 5.4.2.4, blink, beep vibrate, push and twist should be
+		 * a random integer between 0 and 10^size, *exclusive*:
 		 */
 		num = (num % (divider[size - 1] - 1)) + 1;
 	} else {

--- a/subsys/bluetooth/mesh/prov_device.c
+++ b/subsys/bluetooth/mesh/prov_device.c
@@ -57,9 +57,8 @@ static void prov_send_fail_msg(uint8_t err)
 
 static void prov_fail(uint8_t reason)
 {
-	/* According to Bluetooth Mesh Specification v1.0.1, Section 5.4.4, the
-	 * provisioner just closes the link when something fails, while the
-	 * provisionee sends the fail message, and waits for the provisioner to
+	/* According to MshPRTv1.1: 5.4.4, the provisioner just closes the link when something
+	 * fails, while the provisionee sends the fail message, and waits for the provisioner to
 	 * close the link.
 	 */
 	prov_send_fail_msg(reason);

--- a/subsys/bluetooth/mesh/provisioner.c
+++ b/subsys/bluetooth/mesh/provisioner.c
@@ -72,7 +72,7 @@ static void prov_link_close(enum prov_bearer_link_status status)
 
 static void prov_fail(uint8_t reason)
 {
-	/* According to Bluetooth Mesh Specification v1.0.1, Section 5.4.4, the
+	/* According to MshPRTv1.1: 5.4.4, the
 	 * provisioner just closes the link when something fails, while the
 	 * provisionee sends the fail message, and waits for the provisioner to
 	 * close the link.

--- a/subsys/bluetooth/mesh/proxy_msg.c
+++ b/subsys/bluetooth/mesh/proxy_msg.c
@@ -38,7 +38,7 @@ LOG_MODULE_REGISTER(bt_mesh_proxy);
 
 #define PDU_SAR(data)      (data[0] >> 6)
 
-/* Mesh Profile 1.0 Section 6.6:
+/* MshPRTv1.1: 6.3.2.2:
  * "The timeout for the SAR transfer is 20 seconds. When the timeout
  *  expires, the Proxy Server shall disconnect."
  */

--- a/subsys/bluetooth/mesh/proxy_srv.c
+++ b/subsys/bluetooth/mesh/proxy_srv.c
@@ -518,7 +518,7 @@ static int enc_id_adv(struct bt_mesh_subnet *sub, uint8_t type,
 		return err;
 	}
 
-	/* Section 7.2.2.2.4: The AdvA field shall be regenerated whenever the Random field is
+	/* MshPRTv1.1: 7.2.2.2.4: The AdvA field shall be regenerated whenever the Random field is
 	 * regenerated.
 	 */
 	err = randomize_bt_addr();
@@ -785,14 +785,14 @@ static int gatt_proxy_advertise(struct bt_mesh_subnet *sub)
 			}
 		}
 
-		/* Mesh Profile Specification v1.0.1, section 7.2.2.2.1
-		 * A node that does not support the Proxy feature or
-		 * has the GATT Proxy state disabled shall not advertise with Network ID.
+		/* MshPRTv1.1: section 7.2.2.2.1:
+		 * "A node that does not support the Proxy feature or
+		 * has the GATT Proxy state disabled shall not advertise with Network ID."
 		 */
 		if (sub->node_id == BT_MESH_NODE_IDENTITY_STOPPED) {
 			if (IS_ENABLED(CONFIG_BT_MESH_PRIV_BEACONS) &&
 			    (bt_mesh_priv_gatt_proxy_get() == BT_MESH_GATT_PROXY_ENABLED)) {
-				/* Bluetooth mesh specification v1.1, section 7.2.2.2.4: The Random
+				/* MshPRTv1.1: 7.2.2.2.4: The Random
 				 * field should be updated every 10 minutes. Limit advertising to
 				 * 10 minutes to ensure regeneration of a new random value at least
 				 * that often.
@@ -1078,7 +1078,7 @@ static void gatt_connected(struct bt_conn *conn, uint8_t err)
 					       proxy_msg_recv);
 
 #if defined(CONFIG_BT_MESH_PRIV_BEACONS)
-	/* Binding from section 7.2.2.2.6 of MshPRTv1.1. */
+	/* Binding from MshPRTv1.1: 7.2.2.2.6. */
 	enum bt_mesh_subnets_node_id_state cur_node_id = bt_mesh_subnets_node_id_state_get();
 
 	if (bt_mesh_gatt_proxy_get() == BT_MESH_FEATURE_ENABLED ||

--- a/subsys/bluetooth/mesh/rpr_srv.c
+++ b/subsys/bluetooth/mesh/rpr_srv.c
@@ -423,7 +423,7 @@ static void subnet_evt_handler(struct bt_mesh_subnet *subnet,
 		link_close(BT_MESH_RPR_ERR_LINK_CLOSED_BY_SERVER,
 			   PROV_BEARER_LINK_STATUS_FAIL);
 		/* Skip the link closing stage, as specified in the Bluetooth
-		 * Mesh Profile specification, section 4.4.5.4.
+		 * MshPRTv1.1: 4.4.5.4.
 		 */
 		srv.link.state = BT_MESH_RPR_LINK_IDLE;
 	} else if (atomic_test_bit(srv.flags, SCANNING) &&
@@ -634,7 +634,7 @@ static int handle_extended_scan_start(struct bt_mesh_model *mod, struct bt_mesh_
 	uint8_t timeout;
 	int i;
 
-	/* According to the Bluetooth Mesh specification, section 4.4.5.5.1.7, scan reports shall be
+	/* According to MshPRTv1.1: 4.4.5.5.1.7, scan reports shall be
 	 * sent as segmented messages.
 	 */
 	ctx->send_rel = true;

--- a/subsys/bluetooth/mesh/subnet.c
+++ b/subsys/bluetooth/mesh/subnet.c
@@ -252,7 +252,7 @@ void bt_mesh_kr_update(struct bt_mesh_subnet *sub, bool kr_flag, bool new_key)
 	}
 
 	if (sub->kr_phase == BT_MESH_KR_PHASE_1) {
-		/* Bluetooth Mesh Profile Specification Section 3.10.4.1:
+		/* MshPRTv1.1: 3.11.4.1:
 		 * Can skip phase 2 if we get KR=0 on new key.
 		 */
 		key_refresh(sub, (kr_flag ? BT_MESH_KR_PHASE_2 :
@@ -511,7 +511,7 @@ void bt_mesh_friend_cred_destroy(struct bt_mesh_net_cred *cred)
 
 uint8_t bt_mesh_subnet_kr_phase_set(uint16_t net_idx, uint8_t *phase)
 {
-	/* Table in Bluetooth Mesh Profile Specification Section 4.2.14: */
+	/* Table in MshPRTv1.1: 4.2.15: */
 	const uint8_t valid_transitions[] = {
 		BIT(BT_MESH_KR_PHASE_3), /* Normal phase: KR is started by key update */
 		BIT(BT_MESH_KR_PHASE_2) | BIT(BT_MESH_KR_PHASE_3), /* Phase 1 */
@@ -582,7 +582,7 @@ uint8_t bt_mesh_subnet_node_id_set(uint16_t net_idx,
 	}
 
 #if defined(CONFIG_BT_MESH_PRIV_BEACONS)
-	/* Implements binding from section 4.2.46.1 of MshPRTv1.1. When enabling non-private node
+	/* Implements binding from MshPRTv1.1: 4.2.46.1. When enabling non-private node
 	 * identity state, disable its private counterpart.
 	 */
 	for (int i = 0; i < ARRAY_SIZE(subnets); i++) {
@@ -645,8 +645,8 @@ uint8_t bt_mesh_subnet_priv_node_id_set(uint16_t net_idx,
 	}
 
 #if defined(CONFIG_BT_MESH_PRIV_BEACONS)
-	/* Reverse binding from section 4.2.46.1 doesn't allow to set private state if non-private
-	 * state is enabled.
+	/* Reverse binding from MshPRTv1.1: 4.2.46.1 doesn't
+	 * allow to set private state if non-private state is enabled.
 	 */
 	for (int i = 0; i < ARRAY_SIZE(subnets); i++) {
 		if (subnets[i].net_idx != BT_MESH_KEY_UNUSED &&

--- a/subsys/bluetooth/mesh/transport.c
+++ b/subsys/bluetooth/mesh/transport.c
@@ -934,12 +934,10 @@ static int trans_ack(struct bt_mesh_net_rx *rx, uint8_t hdr,
 
 			uint32_t delta_ms = (uint32_t)(k_uptime_get() - tx->adv_start_timestamp);
 
-			/* According to the Bluetooth Mesh Profile specification,
-			 * section 3.5.3.3, we should reset the retransmit timer and
-			 * retransmit immediately when receiving a valid ack message
-			 * while Retransmisison timer is running. However, transport should
-			 * still keep segment transmission interval time between
-			 * transmission of each segment.
+			/* According to MshPRTv1.1: 3.5.3.3.2, we should reset the retransmit timer
+			 * and retransmit immediately when receiving a valid ack message while
+			 * Retransmisison timer is running. However, transport should still keep
+			 * segment transmission interval time between transmission of each segment.
 			 */
 			if (delta_ms < BT_MESH_SAR_TX_SEG_INT_MS) {
 				timeout = K_MSEC(BT_MESH_SAR_TX_SEG_INT_MS - delta_ms);
@@ -1370,7 +1368,7 @@ static int trans_seg(struct net_buf_simple *buf, struct bt_mesh_net_rx *net_rx,
 		return -EBADMSG;
 	}
 
-	/* According to Mesh 1.0 specification:
+	/* According to MshPRTv1.1:
 	 * "The SeqAuth is composed of the IV Index and the sequence number
 	 *  (SEQ) of the first segment"
 	 *
@@ -1466,7 +1464,7 @@ static int trans_seg(struct net_buf_simple *buf, struct bt_mesh_net_rx *net_rx,
 
 	/* Keep track of the received SeqAuth values received from this address
 	 * and discard segmented messages that are not newer, as described in
-	 * the Bluetooth Mesh specification section 3.5.3.4.
+	 * MshPRTv1.1: 3.5.3.4.
 	 *
 	 * The logic on the first segmented receive is a bit special, since the
 	 * initial value of rpl->seg is 0, which would normally fail the

--- a/subsys/bluetooth/mesh/transport_legacy.c
+++ b/subsys/bluetooth/mesh/transport_legacy.c
@@ -870,11 +870,9 @@ static int trans_ack(struct bt_mesh_net_rx *rx, uint8_t hdr,
 	}
 
 	if (tx->nack_count) {
-		/* According to the Bluetooth Mesh Profile specification,
-		 * section 3.5.3.3, we should reset the retransmit timer and
-		 * retransmit immediately when receiving a valid ack message.
-		 * Don't reset the retransmit timer if we didn't finish sending
-		 * segments.
+		/* According to MshPRFv1.0.1: 3.5.3.3, we should reset the retransmit timer and
+		 * retransmit immediately when receiving a valid ack message. Don't reset the
+		 * retransmit timer if we didn't finish sending segments.
 		 */
 		if (tx->seg_o == 0) {
 			k_work_reschedule(&tx->retransmit, K_NO_WAIT);
@@ -1314,7 +1312,7 @@ static int trans_seg(struct net_buf_simple *buf, struct bt_mesh_net_rx *net_rx,
 		return -EINVAL;
 	}
 
-	/* According to Mesh 1.0 specification:
+	/* According to MshPRFv1.0.1:
 	 * "The SeqAuth is composed of the IV Index and the sequence number
 	 *  (SEQ) of the first segment"
 	 *
@@ -1401,7 +1399,7 @@ static int trans_seg(struct net_buf_simple *buf, struct bt_mesh_net_rx *net_rx,
 
 	/* Keep track of the received SeqAuth values received from this address
 	 * and discard segmented messages that are not newer, as described in
-	 * the Bluetooth Mesh specification section 3.5.3.4.
+	 * MshPRFv1.0.1: 3.5.3.4.
 	 *
 	 * The logic on the first segmented receive is a bit special, since the
 	 * initial value of rpl->seg is 0, which would normally fail the


### PR DESCRIPTION
Updates Bluetooth mesh specification references:

- Change "Profile" to "Protocol" since the main specification has changed its name.
- Update/align formating of specification references. This will make it easier to find spec references in the future.
- Change some section references to point to the correct section of the newest version of the specification (v1.1).