### PR TITLE
Optimize for size and performance the most common log message

### DIFF
--- a/doc/services/logging/index.rst
+++ b/doc/services/logging/index.rst
@@ -142,9 +142,15 @@ packet buffer.
 
 :kconfig:option:`CONFIG_LOG_FRONTEND_ONLY`: No backends are used when messages goes to frontend.
 
+:kconfig:option:`CONFIG_LOG_FRONTEND_OPT_API`: Optional API optimized for the most common
+simple messages.
+
 :kconfig:option:`CONFIG_LOG_CUSTOM_HEADER`: Injects an application provided header into log.h
 
 :kconfig:option:`CONFIG_LOG_TIMESTAMP_64BIT`: 64 bit timestamp.
+
+:kconfig:option:`CONFIG_LOG_SIMPLE_MSG_OPTIMIZE`: Optimizes simple log messages for size
+and performance. Option available only for 32 bit architectures.
 
 Formatting options:
 

--- a/include/zephyr/logging/log_core.h
+++ b/include/zephyr/logging/log_core.h
@@ -413,7 +413,7 @@ TYPE_SECTION_END_EXTERN(struct log_source_const_data, log_const);
 		z_log_printf_arg_checker(__VA_ARGS__); \
 	} \
 	Z_LOG_MSG_CREATE(!IS_ENABLED(CONFIG_USERSPACE), _mode, \
-			  Z_LOG_LOCAL_DOMAIN_ID, (uintptr_t)_is_raw, \
+			  Z_LOG_LOCAL_DOMAIN_ID, (const void *)(uintptr_t)_is_raw, \
 			  LOG_LEVEL_INTERNAL_RAW_STRING, NULL, 0, __VA_ARGS__);\
 } while (0)
 

--- a/include/zephyr/logging/log_frontend.h
+++ b/include/zephyr/logging/log_frontend.h
@@ -12,7 +12,7 @@
  */
 void log_frontend_init(void);
 
-/** @brief Log message.
+/** @brief Log generic message.
  *
  * Message details does not contain timestamp. Since function is called in the
  * context of log message call, implementation can use its own timestamping scheme.
@@ -31,6 +31,52 @@ void log_frontend_init(void);
 void log_frontend_msg(const void *source,
 		      const struct log_msg_desc desc,
 		      uint8_t *package, const void *data);
+
+/** @brief Log message with 0 arguments.
+ *
+ * Optimized version for log message which does not have arguments (only string).
+ * This API is optional and is used only if optimizing common log messages is enabled.
+ *
+ * @param source Pointer to a structure associated with given source. It points to
+ * static structure or dynamic structure if runtime filtering is enabled.
+ * @ref log_const_source_id or @ref log_dynamic_source_id can be used to determine
+ * source id.
+ * @param level Severity level.
+ * @param fmt  String.
+ */
+void log_frontend_simple_0(const void *source, uint32_t level, const char *fmt);
+
+/** @brief Log message with 1 argument.
+ *
+ * Optimized version for log message which has one argument that fits in a 32 bit word.
+ * This API is optional and is used only if optimizing common log messages is enabled.
+ *
+ * @param source Pointer to a structure associated with given source. It points to
+ * static structure or dynamic structure if runtime filtering is enabled.
+ * @ref log_const_source_id or @ref log_dynamic_source_id can be used to determine
+ * source id.
+ * @param level Severity level.
+ * @param fmt  String.
+ * @param arg  Argument passed to the string.
+ */
+void log_frontend_simple_1(const void *source, uint32_t level, const char *fmt, uint32_t arg);
+
+/** @brief Log message with 2 arguments.
+ *
+ * Optimized version for log message which has two arguments that fit in a 32 bit word.
+ * This API is optional and is used only if optimizing common log messages is enabled.
+ *
+ * @param source Pointer to a structure associated with given source. It points to
+ * static structure or dynamic structure if runtime filtering is enabled.
+ * @ref log_const_source_id or @ref log_dynamic_source_id can be used to determine
+ * source id.
+ * @param level Severity level.
+ * @param fmt   String.
+ * @param arg0  First argument passed to the string.
+ * @param arg1  Second argument passed to the string.
+ */
+void log_frontend_simple_2(const void *source, uint32_t level,
+			   const char *fmt, uint32_t arg0, uint32_t arg1);
 
 /** @brief Panic state notification. */
 void log_frontend_panic(void);

--- a/include/zephyr/logging/log_msg.h
+++ b/include/zephyr/logging/log_msg.h
@@ -503,7 +503,37 @@ struct log_msg *z_log_msg_alloc(uint32_t wlen);
 void z_log_msg_finalize(struct log_msg *msg, const void *source,
 			 const struct log_msg_desc desc, const void *data);
 
-/** @brief Create simple message from message details and string package.
+/** @brief Create log message using simplified method for string with no arguments.
+ *
+ * @param source Pointer to the source structure.
+ * @param level  Severity level.
+ * @param fmt    String pointer.
+ */
+__syscall void z_log_msg_simple_create_0(const void *source, uint32_t level,
+					 const char *fmt);
+
+/** @brief Create log message using simplified method for string with a one argument.
+ *
+ * @param source Pointer to the source structure.
+ * @param level  Severity level.
+ * @param fmt    String pointer.
+ * @param arg    String argument.
+ */
+__syscall void z_log_msg_simple_create_1(const void *source, uint32_t level,
+					 const char *fmt, uint32_t arg);
+
+/** @brief Create log message using simplified method for string with two arguments.
+ *
+ * @param source Pointer to the source structure.
+ * @param level  Severity level.
+ * @param fmt    String pointer.
+ * @param arg0   String argument.
+ * @param arg1   String argument.
+ */
+__syscall void z_log_msg_simple_create_2(const void *source, uint32_t level,
+					 const char *fmt, uint32_t arg0, uint32_t arg1);
+
+/** @brief Create a logging message from message details and string package.
  *
  * @param source Source.
  *

--- a/include/zephyr/sys/cbprintf_cxx.h
+++ b/include/zephyr/sys/cbprintf_cxx.h
@@ -88,6 +88,57 @@ static inline int z_cbprintf_cxx_is_pchar(T arg, bool const_as_fixed)
 	_Pragma("GCC diagnostic pop")
 }
 
+/* C++ version for determining if variable type is numeric and fits in 32 bit word. */
+static inline int z_cbprintf_cxx_is_word_num(char)
+{
+	return 1;
+}
+
+static inline int z_cbprintf_cxx_is_word_num(unsigned char)
+{
+	return 1;
+}
+
+static inline int z_cbprintf_cxx_is_word_num(short)
+{
+	return 1;
+}
+
+static inline int z_cbprintf_cxx_is_word_num(unsigned short)
+{
+	return 1;
+}
+
+static inline int z_cbprintf_cxx_is_word_num(int)
+{
+	return 1;
+}
+
+static inline int z_cbprintf_cxx_is_word_num(unsigned int)
+{
+	return 1;
+}
+
+static inline int z_cbprintf_cxx_is_word_num(long)
+{
+	return (sizeof(long) <= sizeof(uint32_t)) ? 1 : 0;
+}
+
+static inline int z_cbprintf_cxx_is_word_num(unsigned long)
+{
+	return (sizeof(long) <= sizeof(uint32_t)) ? 1 : 0;
+}
+
+template < typename T >
+static inline int z_cbprintf_cxx_is_word_num(T arg)
+{
+	ARG_UNUSED(arg);
+	_Pragma("GCC diagnostic push")
+	_Pragma("GCC diagnostic ignored \"-Wpointer-arith\"")
+	return 0;
+	_Pragma("GCC diagnostic pop")
+}
+
 /* C++ version for calculating argument size. */
 static inline size_t z_cbprintf_cxx_arg_size(float f)
 {

--- a/include/zephyr/sys/cbprintf_internal.h
+++ b/include/zephyr/sys/cbprintf_internal.h
@@ -113,6 +113,31 @@ extern "C" {
 			0)
 #endif
 
+/** @brief Check if argument fits in 32 bit word.
+ *
+ * @param x Input argument.
+ *
+ * @retval 1 if variable is of type that fits in 32 bit word.
+ * @retval 0 if variable is of different type.
+ */
+#ifdef __cplusplus
+#define Z_CBPRINTF_IS_WORD_NUM(x) \
+	z_cbprintf_cxx_is_word_num(x)
+#else
+#define Z_CBPRINTF_IS_WORD_NUM(x) \
+	_Generic(x, \
+		char : 1, \
+		unsigned char : 1, \
+		short : 1, \
+		unsigned short : 1, \
+		int : 1, \
+		unsigned int : 1, \
+		long : sizeof(long) <= 4, \
+		unsigned long : sizeof(long) <= 4, \
+		default : \
+			0)
+#endif
+
 /* @brief Check if argument is a certain type of char pointer. What exectly is checked
  * depends on @p flags. If flags is 0 then 1 is returned if @p x is a char pointer.
  *

--- a/subsys/logging/Kconfig.misc
+++ b/subsys/logging/Kconfig.misc
@@ -33,6 +33,16 @@ config LOG_USE_VLA
 	  supported. Note that VLA are used for arrays which size is resolved at
 	  compile time so at runtime arrays have fixed size.
 
+config LOG_SIMPLE_MSG_OPTIMIZE
+	bool "Optimize simple messages for size"
+	depends on !64BIT && !CBPRINTF_PACKAGE_HEADER_STORE_CREATION_FLAGS
+	default y
+	help
+	  Dedicated code for handling simple log messages (0-2 32 bit word arguments).
+	  Approximately, 70%-80% log messages in the application fit into that category.
+	  Depending on the architecture code size reduction is from 0-40% (highest seen on
+	  RISCV32) and execution time also up to 40%.
+
 config LOG_ALWAYS_RUNTIME
 	bool "Always use runtime message creation (v2)"
 	default y if NO_OPTIMIZATIONS

--- a/subsys/logging/Kconfig.mode
+++ b/subsys/logging/Kconfig.mode
@@ -53,6 +53,12 @@ config LOG_FRONTEND_ONLY
 	  Option indicates that there are no backends intended to be used.
 	  Code asserts if any backend is enabled.
 
+config LOG_FRONTEND_OPT_API
+	bool "Frontend optimized API"
+	help
+	  When enabled, frontend implements functions which are optimized versions
+	  used for the most common log messages.
+
 config LOG_CUSTOM_HEADER
 	bool "Include Custom Log Header"
 	help

--- a/subsys/logging/log_msg.c
+++ b/subsys/logging/log_msg.c
@@ -97,23 +97,30 @@ void z_impl_z_log_msg_simple_create_0(const void *source, uint32_t level, const 
 {
 
 	if (IS_ENABLED(CONFIG_LOG_FRONTEND)) {
-		uint32_t plen32 = CBPRINTF_DESC_SIZE32 + 1;
-		union cbprintf_package_hdr hdr = {
-			.desc = {
-				.len = plen32
-			}
-		};
-		uint32_t package[] = {
-			(uint32_t)(uintptr_t)hdr.raw,
-			(uint32_t)(uintptr_t)fmt,
-		};
-		struct log_msg_desc desc = {
-			.level = level,
-			.package_len = plen32 * sizeof(uint32_t),
-			.data_len = 0,
-		};
+		if (IS_ENABLED(CONFIG_LOG_FRONTEND_OPT_API)) {
+			log_frontend_simple_0(source, level, fmt);
+		} else {
+			/* If frontend does not support optimized API prepare data for
+			 * the generic call.
+			 */
+			uint32_t plen32 = CBPRINTF_DESC_SIZE32 + 1;
+			union cbprintf_package_hdr hdr = {
+				.desc = {
+					.len = plen32
+				}
+			};
+			uint32_t package[] = {
+				(uint32_t)(uintptr_t)hdr.raw,
+				(uint32_t)(uintptr_t)fmt,
+			};
+			struct log_msg_desc desc = {
+				.level = level,
+				.package_len = plen32 * sizeof(uint32_t),
+				.data_len = 0,
+			};
 
-		log_frontend_msg(source, desc, (uint8_t *)package, NULL);
+			log_frontend_msg(source, desc, (uint8_t *)package, NULL);
+		}
 	}
 
 	if (!BACKENDS_IN_USE()) {
@@ -129,24 +136,31 @@ void z_impl_z_log_msg_simple_create_1(const void *source, uint32_t level,
 				      const char *fmt, uint32_t arg)
 {
 	if (IS_ENABLED(CONFIG_LOG_FRONTEND)) {
-		uint32_t plen32 = CBPRINTF_DESC_SIZE32 + 2;
-		union cbprintf_package_hdr hdr = {
-			.desc = {
-				.len = plen32
-			}
-		};
-		uint32_t package[] = {
-			(uint32_t)(uintptr_t)hdr.raw,
-			(uint32_t)(uintptr_t)fmt,
-			arg
-		};
-		struct log_msg_desc desc = {
-			.level = level,
-			.package_len = plen32 * sizeof(uint32_t),
-			.data_len = 0,
-		};
+		if (IS_ENABLED(CONFIG_LOG_FRONTEND_OPT_API)) {
+			log_frontend_simple_1(source, level, fmt, arg);
+		} else {
+			/* If frontend does not support optimized API prepare data for
+			 * the generic call.
+			 */
+			uint32_t plen32 = CBPRINTF_DESC_SIZE32 + 2;
+			union cbprintf_package_hdr hdr = {
+				.desc = {
+					.len = plen32
+				}
+			};
+			uint32_t package[] = {
+				(uint32_t)(uintptr_t)hdr.raw,
+				(uint32_t)(uintptr_t)fmt,
+				arg
+			};
+			struct log_msg_desc desc = {
+				.level = level,
+				.package_len = plen32 * sizeof(uint32_t),
+				.data_len = 0,
+			};
 
-		log_frontend_msg(source, desc, (uint8_t *)package, NULL);
+			log_frontend_msg(source, desc, (uint8_t *)package, NULL);
+		}
 	}
 
 	if (!BACKENDS_IN_USE()) {
@@ -162,25 +176,32 @@ void z_impl_z_log_msg_simple_create_2(const void *source, uint32_t level,
 				      const char *fmt, uint32_t arg0, uint32_t arg1)
 {
 	if (IS_ENABLED(CONFIG_LOG_FRONTEND)) {
-		uint32_t plen32 = CBPRINTF_DESC_SIZE32 + 3;
-		union cbprintf_package_hdr hdr = {
-			.desc = {
-				.len = plen32
-			}
-		};
-		uint32_t package[] = {
-			[0](uint32_t)(uintptr_t)hdr.raw,
-			(uint32_t)(uintptr_t)fmt,
-			arg0,
-			arg1
-		};
-		struct log_msg_desc desc = {
-			.level = level,
-			.package_len = plen32 * sizeof(uint32_t),
-			.data_len = 0,
-		};
+		if (IS_ENABLED(CONFIG_LOG_FRONTEND_OPT_API)) {
+			log_frontend_simple_2(source, level, fmt, arg0, arg1);
+		} else {
+			/* If frontend does not support optimized API prepare data for
+			 * the generic call.
+			 */
+			uint32_t plen32 = CBPRINTF_DESC_SIZE32 + 3;
+			union cbprintf_package_hdr hdr = {
+				.desc = {
+					.len = plen32
+				}
+			};
+			uint32_t package[] = {
+				[0](uint32_t)(uintptr_t)hdr.raw,
+				(uint32_t)(uintptr_t)fmt,
+				arg0,
+				arg1
+			};
+			struct log_msg_desc desc = {
+				.level = level,
+				.package_len = plen32 * sizeof(uint32_t),
+				.data_len = 0,
+			};
 
-		log_frontend_msg(source, desc, (uint8_t *)package, NULL);
+			log_frontend_msg(source, desc, (uint8_t *)package, NULL);
+		}
 	}
 
 	if (!BACKENDS_IN_USE()) {

--- a/subsys/logging/log_msg.c
+++ b/subsys/logging/log_msg.c
@@ -22,6 +22,11 @@ BUILD_ASSERT(sizeof(struct log_msg_desc) == sizeof(uint32_t),
 
 #define CBPRINTF_DESC_SIZE32 (sizeof(struct cbprintf_package_desc) / sizeof(uint32_t))
 
+/* For simplified message handling cprintf package must have only 1 word. */
+BUILD_ASSERT(!IS_ENABLED(CONFIG_LOG_SIMPLE_MSG_OPTIMIZE) ||
+	     (IS_ENABLED(CONFIG_LOG_SIMPLE_MSG_OPTIMIZE) && (CBPRINTF_DESC_SIZE32 == 1)));
+
+
 void z_log_msg_finalize(struct log_msg *msg, const void *source,
 			 const struct log_msg_desc desc, const void *data)
 {


### PR DESCRIPTION
It's been noticed that logging messages takes more ROM on RISCV platform others (like ARM Cortex-M). On RISCV32 message takes 70-80 bytes and on Cortex-M 30-40 bytes. This PR is an attempt to improve that by focusing on the most common log messages and optimizing them and using legacy generic approach whenever optimized approach cannot be applied.

I've analyzed zephyr code base (and other projects) which log messages are the most common and got following results:
- 45% of all logs are strings without arguments (e.g. `LOG_INF("foo")`)
- 24% of all logs are strings with one 32 bit argument (e.g.` LOG_INF("char: %c", c)`)
- 6 % of all logs are strings with two 32 bit arguments (e.g. `LOG_INF("%08x %d, a, b)`)

Overall there is usually between 75%-80% of those "simple" messages in the application. On 32 bit platforms messages like that can be built very easily since there is no alignment or padding to consider. Based on that analysis, targeted approach was taken to provide optimized macros and functions for logging "simple" messages on 32 bit architectures.

Optimization is enabled by default (`CONFIG_LOG_SIMPLE_MSG_OPTIMIZE=n` to disable).

Optimization results on RISCV32 (~40% less code)

| Log type    | Before  | After |
| -------------- | ---------- | ---- 
| Log 0 args | 46     | 30 |
| Log 1 arg   | 68     | 38 |
| Log 2 args | 70     | 40 |

Optimization results on ARM Cortex-M3 (~10% less code)

| Log type    | Before  | After |
| -------------- | ---------- | ---- 
| Log 0 args | 36     | 28 |
| Log 1 arg   | 44     | 32 |
| Log 2 args | 44     | 40 |

If we consider RISCV32 application with 300 log messages with average distribution of message types that means 5kB code saving. Improvements on ARM Cortex-M3 are not that significant but they are seen in performance where "simple" logs logging went from **14us** to **10us**. On RISCV32 performance gain is approx.40%.

PR extends also log_frontend API with optional functions for handling "simple" messages.
