### PR TITLE
native simulator: Get latest from upstream

### DIFF
--- a/scripts/native_simulator/common/src/nsi_internal.h
+++ b/scripts/native_simulator/common/src/nsi_internal.h
@@ -14,7 +14,6 @@ extern "C" {
 #endif
 
 /**
- *
  * @brief find least significant bit set in a 32-bit word
  *
  * This routine finds the first bit set starting from the least significant bit
@@ -28,6 +27,22 @@ extern "C" {
 static inline unsigned int nsi_find_lsb_set(uint32_t op)
 {
 	return __builtin_ffs(op);
+}
+
+/**
+ * @brief find least significant bit set in a 64-bit word
+ *
+ * This routine finds the first bit set starting from the least significant bit
+ * in the argument passed in and returns the index of that bit. Bits are
+ * numbered starting at 1 from the least significant bit.  A return value of
+ * zero indicates that the value passed is zero.
+ *
+ * @return least significant bit set, 0 if @a op is 0
+ */
+
+static inline unsigned int nsi_find_lsb_set64(uint64_t op)
+{
+	return __builtin_ffsll(op);
 }
 
 #ifdef __cplusplus

--- a/scripts/native_simulator/native/src/include/hw_counter.h
+++ b/scripts/native_simulator/native/src/include/hw_counter.h
@@ -22,9 +22,12 @@ void hw_counter_triggered(void);
 
 void hw_counter_set_period(uint64_t period);
 void hw_counter_set_target(uint64_t counter_target);
+void hw_counter_set_wrap_value(uint64_t wrap_value);
 void hw_counter_start(void);
 void hw_counter_stop(void);
+bool hw_counter_is_started(void);
 uint64_t hw_counter_get_value(void);
+void hw_counter_reset(void);
 
 #ifdef __cplusplus
 }

--- a/scripts/native_simulator/native/src/irq_ctrl.c
+++ b/scripts/native_simulator/native/src/irq_ctrl.c
@@ -95,7 +95,7 @@ int hw_irq_ctrl_get_highest_prio_irq(void)
 	int winner_prio = 256;
 
 	while (irq_status != 0U) {
-		int irq_nbr = nsi_find_lsb_set(irq_status) - 1;
+		int irq_nbr = nsi_find_lsb_set64(irq_status) - 1;
 
 		irq_status &= ~((uint64_t) 1 << irq_nbr);
 		if ((winner_prio > (int)irq_prio[irq_nbr])


### PR DESCRIPTION
Align with native_simulator's upstream main
d32b2504ad2b6d6d541bc71a0f9b16ab7b6a3831

Which includes:
* d32b250 Minor format fix
* 7b4f35b native HW counter: Provide new API to reset and control
* 4f815cb INT CNTLR: Bugfix for more than 32 interrupts
* 1d36254 Provide new 64 version of nsi_find_lsb_set