### PR TITLE
Hostap glue module

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3608,6 +3608,16 @@ West:
   labels:
     - "area: Sensors"
 
+"West project: hostap":
+  status: maintained
+  maintainers:
+    - krish2718
+    - jukkar
+  files:
+    - modules/hostap/
+  labels:
+    - "area: Wi-Fi"
+
 Xtensa arch:
   status: maintained
   maintainers:

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -651,6 +651,7 @@ menu "Work Queue Options"
 config SYSTEM_WORKQUEUE_STACK_SIZE
 	int "System workqueue stack size"
 	default 4096 if COVERAGE_GCOV
+	default 2560 if WIFI_NM_WPA_SUPPLICANT
 	default 1024
 
 config SYSTEM_WORKQUEUE_PRIORITY

--- a/lib/posix/Kconfig
+++ b/lib/posix/Kconfig
@@ -5,6 +5,7 @@
 
 config POSIX_MAX_FDS
 	int "Maximum number of open file descriptors"
+	default 16 if WIFI_NM_WPA_SUPPLICANT
 	default 16 if POSIX_API
 	default 4
 	help

--- a/modules/Kconfig
+++ b/modules/Kconfig
@@ -43,6 +43,7 @@ source "modules/Kconfig.xtensa"
 source "modules/zcbor/Kconfig"
 source "modules/Kconfig.mcuboot"
 source "modules/Kconfig.intel"
+source "modules/hostap/Kconfig"
 
 comment "Unavailable modules, please install those via the project manifest."
 

--- a/modules/hostap/CMakeLists.txt
+++ b/modules/hostap/CMakeLists.txt
@@ -1,0 +1,84 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+if(CONFIG_WIFI_NM_WPA_SUPPLICANT)
+
+zephyr_library()
+
+set(HOSTAP_BASE ${ZEPHYR_HOSTAP_MODULE_DIR})
+set(WIFI_NM_WPA_SUPPLICANT_BASE ${HOSTAP_BASE}/wpa_supplicant)
+set(HOSTAP_SRC_BASE ${HOSTAP_BASE}/src)
+
+set(CMAKE_EXE_LINKER_FLAGS "--specs=nosys.specs -lnosys")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DMISSING_SYSCALL_NAMES")
+
+zephyr_compile_definitions(
+	CONFIG_ZEPHYR
+)
+
+zephyr_include_directories(
+	${HOSTAP_BASE}/
+	${WIFI_NM_WPA_SUPPLICANT_BASE}/
+	${HOSTAP_SRC_BASE}/
+)
+
+zephyr_library_compile_definitions(
+	TLS_DEFAULT_CIPHERS=\""DEFAULT:!EXP:!LOW"\"
+	CONFIG_SME
+	CONFIG_NO_CONFIG_WRITE
+	CONFIG_NO_CONFIG_BLOBS
+	CONFIG_CTRL_IFACE
+	CONFIG_NO_RANDOM_POOL
+	CONFIG_NO_WPA
+	CONFIG_NO_PBKDF2
+	)
+
+zephyr_library_include_directories(
+	${CMAKE_CURRENT_SOURCE_DIR}/src
+	${HOSTAP_BASE}/
+	${HOSTAP_SRC_BASE}/utils
+	${HOSTAP_SRC_BASE}/drivers
+	${HOSTAP_BASE}/src
+	${ZEPHYR_BASE}/include
+	${ZEPHYR_BASE}/include/net
+)
+
+zephyr_library_sources(
+	${HOSTAP_SRC_BASE}/common/wpa_common.c
+	${HOSTAP_SRC_BASE}/common/ieee802_11_common.c
+	${HOSTAP_SRC_BASE}/common/hw_features_common.c
+	${HOSTAP_SRC_BASE}/common/wpa_ctrl.c
+	${HOSTAP_SRC_BASE}/common/cli.c
+
+	${HOSTAP_SRC_BASE}/drivers/driver_common.c
+	${HOSTAP_SRC_BASE}/drivers/drivers.c
+	${HOSTAP_SRC_BASE}/utils/base64.c
+	${HOSTAP_SRC_BASE}/utils/common.c
+	${HOSTAP_SRC_BASE}/utils/wpabuf.c
+	${HOSTAP_SRC_BASE}/utils/bitfield.c
+	${HOSTAP_SRC_BASE}/utils/eloop.c
+	${HOSTAP_SRC_BASE}/utils/os_zephyr.c
+	${HOSTAP_SRC_BASE}/utils/wpa_debug_zephyr.c
+	${HOSTAP_SRC_BASE}/crypto/crypto_none.c
+	${HOSTAP_SRC_BASE}/crypto/tls_none.c
+
+	${WIFI_NM_WPA_SUPPLICANT_BASE}/config.c
+	${WIFI_NM_WPA_SUPPLICANT_BASE}/notify.c
+	${WIFI_NM_WPA_SUPPLICANT_BASE}/eap_register.c
+	${WIFI_NM_WPA_SUPPLICANT_BASE}/op_classes.c
+	${WIFI_NM_WPA_SUPPLICANT_BASE}/rrm.c
+	${WIFI_NM_WPA_SUPPLICANT_BASE}/wmm_ac.c
+	${WIFI_NM_WPA_SUPPLICANT_BASE}/config_none.c
+	${WIFI_NM_WPA_SUPPLICANT_BASE}/bssid_ignore.c
+	${WIFI_NM_WPA_SUPPLICANT_BASE}/wpas_glue.c
+	${WIFI_NM_WPA_SUPPLICANT_BASE}/scan.c
+	${WIFI_NM_WPA_SUPPLICANT_BASE}/ctrl_iface.c
+
+	# Zephyr specific files (glue code)
+	# TBD
+)
+
+endif()

--- a/modules/hostap/Kconfig
+++ b/modules/hostap/Kconfig
@@ -1,0 +1,104 @@
+# WPA Supplicant configuration options
+#
+# Copyright (c) 2023 Nordic Semiconductor
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+config WIFI_NM_WPA_SUPPLICANT
+	bool "WPA Suplicant from hostap project [EXPERIMENTAL]"
+	select POSIX_CLOCK
+	select NET_SOCKETS
+	select NET_SOCKETS_PACKET
+	select NET_SOCKETPAIR
+	select NET_L2_WIFI_MGMT
+	select WIFI_NM
+	select EXPERIMENTAL
+	help
+	  WPA supplicant as a network management backend for WIFI_NM.
+
+config WIFI_NM_WPA_SUPPLICANT_THREAD_STACK_SIZE
+	int "Stack size for wpa_supplicant thread"
+	default 8192
+
+config NET_SOCKETPAIR_BUFFER_SIZE
+	default 4096
+
+config POSIX_MAX_FDS
+	# l2_packet - 1
+	# ctrl_iface - 2 * socketpairs = 4(local and global)
+	# z_wpa_event_sock - 1 socketpair = 2
+	# Remaining left for the applications running in default configuration
+	default 16 if !POSIX_API
+
+# Control interface is stack heavy (buffers + snprintfs)
+# Making calls to RPU from net_mgmt callbacks (status - RSSI)
+config NET_MGMT_EVENT_STACK_SIZE
+	default 4096
+
+config NET_SOCKETS_POLL_MAX
+	default 6
+
+
+# Supplicant API is stack heavy (buffers + snprintfs) and control interface
+# uses socketpair which pushes the stack usage causing overflow for 2048 bytes.
+config SYSTEM_WORKQUEUE_STACK_SIZE
+	default 2560
+
+module = WIFI_NM_WPA_SUPPLICANT
+module-str = WPA supplicant
+source "subsys/logging/Kconfig.template.log_config"
+
+config WIFI_NM_WPA_SUPPLICANT_DEBUG_LEVEL
+	int "Min compiled-in debug message level for WPA supplicant"
+	default 0 if WIFI_NM_WPA_SUPPLICANT_LOG_LEVEL_DBG # MSG_EXCESSIVE
+	default 3 if WIFI_NM_WPA_SUPPLICANT_LOG_LEVEL_INF # MSG_INFO
+	default 4 if WIFI_NM_WPA_SUPPLICANT_LOG_LEVEL_WRN # MSG_WARNING
+	default 5 if WIFI_NM_WPA_SUPPLICANT_LOG_LEVEL_ERR # MSG_ERROR
+	default 6
+	help
+	  Minimum priority level of a debug message emitted by WPA supplicant that
+	  is compiled-in the firmware. See wpa_debug.h file of the supplicant for
+	  available levels and functions for emitting the messages. Note that
+	  runtime filtering can also be configured in addition to the compile-time
+	  filtering.
+
+if WIFI_NM_WPA_SUPPLICANT
+
+# Create hidden config options that are used in hostap. This way we do not need
+# to mark them as allowed for CI checks, and also someone else cannot use the
+# same name options.
+
+config SME
+	bool
+	default y
+
+config NO_CONFIG_WRITE
+	bool
+	default y
+
+config NO_CONFIG_BLOBS
+	bool
+	default y
+
+config CTRL_IFACE
+	bool
+	default y
+
+config NO_RANDOM_POOL
+	bool
+	default y
+
+config NO_WPA
+	bool
+	default y
+
+config NO_PBKDF2
+	bool
+	default y
+
+config ZEPHYR
+	bool
+	default y
+
+endif # WIFI_NM_WPA_SUPPLICANT

--- a/modules/hostap/Kconfig
+++ b/modules/hostap/Kconfig
@@ -21,29 +21,15 @@ config WIFI_NM_WPA_SUPPLICANT_THREAD_STACK_SIZE
 	int "Stack size for wpa_supplicant thread"
 	default 8192
 
-config NET_SOCKETPAIR_BUFFER_SIZE
-	default 4096
-
-config POSIX_MAX_FDS
-	# l2_packet - 1
-	# ctrl_iface - 2 * socketpairs = 4(local and global)
-	# z_wpa_event_sock - 1 socketpair = 2
-	# Remaining left for the applications running in default configuration
-	default 16 if !POSIX_API
-
-# Control interface is stack heavy (buffers + snprintfs)
-# Making calls to RPU from net_mgmt callbacks (status - RSSI)
-config NET_MGMT_EVENT_STACK_SIZE
-	default 4096
-
-config NET_SOCKETS_POLL_MAX
-	default 6
-
+# Currently we default POSIX_MAX_FDS to 16 in lib/posix/Kconfig
+# l2_packet - 1
+# ctrl_iface - 2 * socketpairs = 4(local and global)
+# z_wpa_event_sock - 1 socketpair = 2
+# Remaining left for the applications running in default configuration
 
 # Supplicant API is stack heavy (buffers + snprintfs) and control interface
 # uses socketpair which pushes the stack usage causing overflow for 2048 bytes.
-config SYSTEM_WORKQUEUE_STACK_SIZE
-	default 2560
+# So we set SYSTEM_WORKQUEUE_STACK_SIZE default to 2560 in kernel/Kconfig
 
 module = WIFI_NM_WPA_SUPPLICANT
 module-str = WPA supplicant

--- a/subsys/net/ip/Kconfig.mgmt
+++ b/subsys/net/ip/Kconfig.mgmt
@@ -21,6 +21,7 @@ if NET_MGMT_EVENT
 
 config NET_MGMT_EVENT_STACK_SIZE
 	int "Stack size for the inner thread handling event callbacks"
+	default 4096 if WIFI_NM_WPA_SUPPLICANT
 	default 2048 if COVERAGE_GCOV
 	default 840 if X86
 	default 800 if THREAD_LOCAL_STORAGE

--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -42,6 +42,7 @@ config NET_SOCKETS_POSIX_NAMES
 
 config NET_SOCKETS_POLL_MAX
 	int "Max number of supported poll() entries"
+	default 6 if WIFI_NM_WPA_SUPPLICANT
 	default 3
 	help
 	  Maximum number of entries supported for poll() call.
@@ -261,6 +262,7 @@ if NET_SOCKETPAIR
 
 config NET_SOCKETPAIR_BUFFER_SIZE
 	int "Size of the intermediate buffer, in bytes"
+	default 4096 if WIFI_NM_WPA_SUPPLICANT
 	default 64
 	range 1 4096
 	help

--- a/west.yml
+++ b/west.yml
@@ -256,6 +256,10 @@ manifest:
       path: modules/hal/xtensa
       groups:
         - hal
+    - name: hostap
+      repo-path: hostap
+      path: modules/lib/hostap
+      revision: 7adaff26baa48e26a32c576125e0a749a5239b12
     - name: libmetal
       revision: 03140d7f4bd9ba474ebfbb6256e84a9089248e67
       path: modules/hal/libmetal


### PR DESCRIPTION
Add Kconfig + CMakeLists.txt files for hostap module. Allows compilation of hostap with zephyr but does not do anything useful yet. Integration code for wifi drivers is coming in subsequent PRs.

