### PR TITLE
Doc: extend application sphinx extension to support flash arguments and fix uses

### DIFF
--- a/boards/arm/adafruit_itsybitsy_m4_express/doc/index.rst
+++ b/boards/arm/adafruit_itsybitsy_m4_express/doc/index.rst
@@ -179,7 +179,8 @@ debugged using a SWD probe such as the Segger J-Link.
    .. zephyr-app-commands::
       :zephyr-app: samples/hello_world
       :board: adafruit_itsybitsy_m4_express
-      :goals: flash -r openocd
+      :goals: flash
+      :flash-args: -r openocd
       :compact:
 
 #. Start debugging:

--- a/boards/arm/wio_terminal/doc/index.rst
+++ b/boards/arm/wio_terminal/doc/index.rst
@@ -180,7 +180,8 @@ debugged using an SWD probe such as the Segger J-Link.
    .. zephyr-app-commands::
       :zephyr-app: samples/basic/button
       :board: wio_terminal
-      :goals: flash -r openocd
+      :goals: flash
+      :flash-args: -r openocd
       :compact:
 
 #. Start debugging:

--- a/doc/_extensions/zephyr/application.py
+++ b/doc/_extensions/zephyr/application.py
@@ -92,6 +92,9 @@ class ZephyrAppCommandsDirective(Directive):
     \:west-args:
       if set, additional arguments to the west invocation (ignored for CMake)
 
+    \:flash-args:
+      if set, additional arguments to the flash invocation
+
     '''
     has_content = False
     required_arguments = 0
@@ -114,6 +117,7 @@ class ZephyrAppCommandsDirective(Directive):
         'maybe-skip-config': directives.flag,
         'compact': directives.flag,
         'west-args': directives.unchanged,
+        'flash-args': directives.unchanged,
     }
 
     TOOLS = ['cmake', 'west', 'all']
@@ -143,6 +147,7 @@ class ZephyrAppCommandsDirective(Directive):
         skip_config = 'maybe-skip-config' in self.options
         compact = 'compact' in self.options
         west_args = self.options.get('west-args', None)
+        flash_args = self.options.get('flash-args', None)
 
         if tool not in self.TOOLS:
             raise self.error('Unknown tool {}; choose from: {}'.format(
@@ -194,7 +199,8 @@ class ZephyrAppCommandsDirective(Directive):
             'compact': compact,
             'skip_config': skip_config,
             'generator': generator,
-            'west_args': west_args
+            'west_args': west_args,
+            'flash_args': flash_args,
             }
 
         if 'west' in tools:
@@ -244,12 +250,14 @@ class ZephyrAppCommandsDirective(Directive):
         build_dir = kwargs['build_dir']
         compact = kwargs['compact']
         west_args = kwargs['west_args']
+        flash_args = kwargs['flash_args']
         kwargs['board'] = None
         # west always defaults to ninja
         gen_arg = ' -G\'Unix Makefiles\'' if generator == 'make' else ''
         cmake_args = gen_arg + self._cmake_args(**kwargs)
         cmake_args = ' --{}'.format(cmake_args) if cmake_args != '' else ''
         west_args = ' {}'.format(west_args) if west_args else ''
+        flash_args = ' {}'.format(flash_args) if flash_args else ''
         # ignore zephyr_app since west needs to run within
         # the installation. Instead rely on relative path.
         src = ' {}'.format(app) if app and not cd_into else ''
@@ -284,7 +292,7 @@ class ZephyrAppCommandsDirective(Directive):
             if goal in {'build', 'sign'}:
                 continue
             elif goal == 'flash':
-                content.append('west flash{}'.format(dst))
+                content.append('west flash{}{}'.format(flash_args, dst))
             elif goal == 'debug':
                 content.append('west debug{}'.format(dst))
             elif goal == 'debugserver':

--- a/samples/boards/nrf/nrf53_sync_rtc/README.rst
+++ b/samples/boards/nrf/nrf53_sync_rtc/README.rst
@@ -28,7 +28,8 @@ Building the application for nrf5340dk_nrf5340_cpuapp
 .. zephyr-app-commands::
    :zephyr-app: samples/boards/nrf/nrf53_sync_rtc
    :board: nrf5340dk_nrf5340_cpuapp
-   :goals: flash "flash --hex-file build/sync_rtc_net-prefix/src/sync_rtc_net-build/zephyr/zephyr.hex"
+   :goals: flash
+   :flash-args: --hex-file build/sync_rtc_net-prefix/src/sync_rtc_net-build/zephyr/zephyr.hex
 
 Open a serial terminals (for example Minicom or PuTTY) and connect the board with the
 following settings:

--- a/samples/net/mqtt_sn_publisher/README.rst
+++ b/samples/net/mqtt_sn_publisher/README.rst
@@ -68,7 +68,7 @@ Then, locate your zephyr directory and type:
 .. zephyr-app-commands::
    :zephyr-app: samples/net/mqtt_sn_publisher
    :board: native_posix_64
-   :goals: build -t run
+   :goals: run
    :compact:
 
 Optionally, use any MQTT explorer to connect to your broker.


### PR DESCRIPTION
Passing arguments to west flash is needed in many cases but there was no way to properly generate documentation with such examples. With this new "flash-args" option we can now.

And fix the west flash command examples which needed it using this new flash-args option.

Fixes #64130

---

And a bonus fix:

    doc: samples net mqtt_sn_publisher fix west invokation

    Fix the west invokation. "-t" is added automatically
    to the run goal, otherwise we get a "-t -t" command.