### PR TITLE
ace: alh: Only ACE1.5 has OSEL feature

### DIFF
--- a/drivers/dai/intel/alh/Kconfig.alh
+++ b/drivers/dai/intel/alh/Kconfig.alh
@@ -16,8 +16,9 @@ config DAI_INTEL_ALH
 if DAI_INTEL_ALH
 
 config DAI_ALH_HAS_OWNERSHIP
-	bool "Intel ALH driver has ownership"
-	default y if SOC_SERIES_INTEL_ACE
+	bool "Intel ALH driver has ownership only on ACE 1.5"
+	default y
+	depends on SOC_INTEL_ACE15_MTPM
 	help
 	  Select this to enable programming HW ownership
 


### PR DESCRIPTION
The OSEL bits in ALHASCTL register are present only in ACE1.5 version - MTL. Platforms ACE2.0 do not have the OSEL bits. Therefore DAI_ALH_HAS_OWNERSHIP configuration option should be set only for particular ACE1.5 version. 
This patch fixes the issue: 
https://github.com/thesofproject/sof/issues/8345

 Signed-off-by: Jaroslaw Stelter <Jaroslaw.Stelter@intel.com>