### PR TITLE
net: Set Dummy net_if as default one for tests

### DIFF
--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -846,8 +846,12 @@ config NET_HEADERS_ALWAYS_CONTIGUOUS
 	  NET_BUF_FIXED_DATA_SIZE enabled and NET_BUF_DATA_SIZE of 128 for
 	  instance.
 
+# If we are running network tests found in tests/net, then the NET_TEST is
+# set and in that case we default to Dummy L2 layer as typically the tests
+# use that by default.
 choice
 	prompt "Default Network Interface"
+	default NET_DEFAULT_IF_DUMMY if NET_TEST
 	default NET_DEFAULT_IF_FIRST
 	help
 	  If system has multiple interfaces enabled, then user shall be able

--- a/tests/net/iface/src/main.c
+++ b/tests/net/iface/src/main.c
@@ -1157,7 +1157,7 @@ ZTEST(net_iface, test_interface_name)
 	ret = net_if_set_name(iface, name);
 	zassert_equal(ret, -ENAMETOOLONG, "Unexpected value (%d) returned", ret);
 
-	name = "eth0";
+	name = "abc0";
 	ret = net_if_set_name(iface, name);
 	zassert_equal(ret, 0, "Unexpected value (%d) returned", ret);
 


### PR DESCRIPTION
If we run network tests under tests/net, then set the Dummy network interface as a default one so that it will be picked up first.

This should solve the issue if the DUT is having a real network interfaces like onboard Ethernet interface which could cause the test to fail. The test might fail in this case because the network tests assume that only simulated network interfaces are used by the tests.