### PR TITLE
MAINTAINERS: update "Release Notes" area maintainers

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -657,13 +657,13 @@ Documentation Infrastructure:
 Release Notes:
   status: maintained
   maintainers:
-    - jhedberg
-    - fabiobaltieri
+    - MaureenHelm
+    - henrikbrixandersen
+  collaborators:
+    - kartben
   files:
     - doc/releases/migration-guide-*
     - doc/releases/release-notes-*
-  collaborators:
-    - kartben
   labels:
     - "Release Notes"
 


### PR DESCRIPTION
Update Release Notes maintainers to point at the 3.6 release owners usernames.