### PR TITLE
soc: arm: st_stm32: common: special case DBGStopMode for SOC U5

### DIFF
--- a/soc/arm/st_stm32/common/soc_config.c
+++ b/soc/arm/st_stm32/common/soc_config.c
@@ -81,7 +81,9 @@ static int st_stm32_common_config(void)
 	LL_DBGMCU_EnableDBGStopMode();
 	LL_APB2_GRP1_DisableClock(LL_APB2_GRP1_PERIPH_DBGMCU);
 #else /* all other parts */
+#if !defined(CONFIG_SOC_SERIES_STM32U5X)
 	LL_DBGMCU_EnableDBGStopMode();
+#endif  /* !CONFIG_SOC_SERIES_STM32U5X */
 #endif
 #endif /* CONFIG_SOC_SERIES_STM32H7X || CONFIG_SOC_SERIES_STM32MP1X */
 
@@ -104,7 +106,10 @@ static int st_stm32_common_config(void)
 	LL_DBGMCU_DisableDBGStopMode();
 	LL_APB2_GRP1_DisableClock(LL_APB2_GRP1_PERIPH_DBGMCU);
 #else /* all other parts */
+#if !defined(CONFIG_SOC_SERIES_STM32U5X)
 	LL_DBGMCU_DisableDBGStopMode();
+#endif /* !CONFIG_SOC_SERIES_STM32U5X */
+	
 #endif
 #endif /* CONFIG_SOC_SERIES_STM32H7X || CONFIG_SOC_SERIES_STM32MP1X */
 


### PR DESCRIPTION
remove DBGStopMode management in case of SOC U5
Since #62647, debug in stop mode is explicitely disabled in f/w when debug is not enabled.
After running application with PM enabled, it is not possible to flash using openocd. One consequence is tests failed in CI when openocd is used. However we can still use flash using stm32cubeprogrammer runner, so add stm32cubeprogrammer to this board in order to use it with twister.