### PR TITLE
drivers: sensor: npm1300: Fixed charge current scaling

### DIFF
--- a/drivers/sensor/npm1300_charger/npm1300_charger.c
+++ b/drivers/sensor/npm1300_charger/npm1300_charger.c
@@ -159,13 +159,11 @@ static void calc_current(const struct npm1300_charger_config *const config,
 		full_scale_ma = config->dischg_limit_microamp / 1000;
 		break;
 	case IBAT_STAT_CHARGE_TRICKLE:
-		full_scale_ma = -config->current_microamp / 10000;
-		break;
+	/* Fallthrough */
 	case IBAT_STAT_CHARGE_COOL:
-		full_scale_ma = -config->current_microamp / 2000;
-		break;
+	/* Fallthrough */
 	case IBAT_STAT_CHARGE_NORMAL:
-		full_scale_ma = -config->current_microamp / 1000;
+		full_scale_ma = -config->current_microamp / 800;
 		break;
 	default:
 		full_scale_ma = 0;


### PR DESCRIPTION
The scaling factor for current measurement was incorrect. 

Full range scaling during charge is 1.25 * charge current limit, 
and there is no additional scaling factor applied in different charge modes.

Bench tested on representative setup with production silicon.