### PR TITLE
samples: sensor: dht: add longan_nano overlay

### DIFF
--- a/samples/sensor/dht/boards/longan_nano.overlay
+++ b/samples/sensor/dht/boards/longan_nano.overlay
@@ -1,0 +1,11 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	dht22 {
+		compatible = "aosong,dht";
+		status = "okay";
+		dio-gpios = <&gpiob 9 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+	};
+};


### PR DESCRIPTION
Add an overlay to use DHT11 temperature/humidity sensor in Longan Nano.