### PR TITLE
drivers: flash: stm32 ospi: fix compilation warning

### DIFF
--- a/drivers/flash/flash_stm32_ospi.c
+++ b/drivers/flash/flash_stm32_ospi.c
@@ -2167,10 +2167,9 @@ static int flash_stm32_ospi_init(const struct device *dev)
 	dev_cfg->irq_config(dev);
 
 	/* Send the instruction to read the SFDP  */
-	const uint8_t decl_nph = 2;
 	union {
 		/* We only process BFP so use one parameter block */
-		uint8_t raw[JESD216_SFDP_SIZE(decl_nph)];
+		uint8_t raw[JESD216_SFDP_SIZE(2)];
 		struct jesd216_sfdp_header sfdp;
 	} u;
 	const struct jesd216_sfdp_header *hp = &u.sfdp;
@@ -2193,7 +2192,7 @@ static int flash_stm32_ospi_init(const struct device *dev)
 
 	const struct jesd216_param_header *php = hp->phdr;
 	const struct jesd216_param_header *phpe = php +
-						     MIN(decl_nph, 1 + hp->nph);
+						     MIN(2, 1 + hp->nph);
 
 	while (php != phpe) {
 		uint16_t id = jesd216_param_id(php);


### PR DESCRIPTION
C99 standard does not allow union members to be VLAs. Change the union member to be fixed length array. This fixes GCC warning:

     warning: dangling pointer 'php' to 'u.13637' may be used