### PR TITLE
Kconfig: drop `COMPAT_INCLUDES`

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -900,14 +900,3 @@ config BOOTLOADER_BOSSA_ADAFRUIT_UF2
 endchoice
 
 endmenu
-
-menu "Compatibility"
-
-config COMPAT_INCLUDES
-	bool "Suppress warnings when using header shims"
-	default y
-	help
-	  Suppress any warnings from the pre-processor when including
-	  deprecated header files.
-
-endmenu


### PR DESCRIPTION
`COMPAT_INCLUDES` was introduced a few years ago (#21326 v2.2.0) to suppress compiler warnings when using old header location. These headers shim have since been removed from tree and no source in tree refers to `CONFIG_COMPAT_INCLUDES` anymore.

Dropping it as it is not used.