### PR TITLE
net: wifi: Fix compile error when -Werror -Wextra are set

### DIFF
--- a/include/zephyr/net/wifi.h
+++ b/include/zephyr/net/wifi.h
@@ -56,7 +56,7 @@ enum wifi_security_type {
 };
 
 /** Helper function to get user-friendly security type name. */
-const char * const wifi_security_txt(enum wifi_security_type security);
+const char *wifi_security_txt(enum wifi_security_type security);
 
 /** IEEE 802.11w - Management frame protection. */
 enum wifi_mfp_options {
@@ -73,7 +73,7 @@ enum wifi_mfp_options {
 };
 
 /** Helper function to get user-friendly MFP name.*/
-const char * const wifi_mfp_txt(enum wifi_mfp_options mfp);
+const char *wifi_mfp_txt(enum wifi_mfp_options mfp);
 
 /**
  * @brief IEEE 802.11 operational frequency bands (not exhaustive).
@@ -95,7 +95,7 @@ enum wifi_frequency_bands {
 };
 
 /** Helper function to get user-friendly frequency band name. */
-const char * const wifi_band_txt(enum wifi_frequency_bands band);
+const char *wifi_band_txt(enum wifi_frequency_bands band);
 
 #define WIFI_SSID_MAX_LEN 32
 #define WIFI_PSK_MIN_LEN 8
@@ -139,7 +139,7 @@ enum wifi_iface_state {
 };
 
 /** Helper function to get user-friendly interface state name. */
-const char * const wifi_state_txt(enum wifi_iface_state state);
+const char *wifi_state_txt(enum wifi_iface_state state);
 
 /** Wi-Fi interface modes.
  *
@@ -165,7 +165,7 @@ enum wifi_iface_mode {
 };
 
 /** Helper function to get user-friendly interface mode name. */
-const char * const wifi_mode_txt(enum wifi_iface_mode mode);
+const char *wifi_mode_txt(enum wifi_iface_mode mode);
 
 /** Wi-Fi link operating modes
  *
@@ -197,7 +197,7 @@ enum wifi_link_mode {
 };
 
 /** Helper function to get user-friendly link mode name. */
-const char * const wifi_link_mode_txt(enum wifi_link_mode link_mode);
+const char *wifi_link_mode_txt(enum wifi_link_mode link_mode);
 
 /** Wi-Fi scanning types. */
 enum wifi_scan_type {
@@ -216,7 +216,7 @@ enum wifi_ps {
 };
 
 /** Helper function to get user-friendly ps name. */
-const char * const wifi_ps_txt(enum wifi_ps ps_name);
+const char *wifi_ps_txt(enum wifi_ps ps_name);
 
 /** Wi-Fi power save modes. */
 enum wifi_ps_mode {
@@ -230,7 +230,7 @@ enum wifi_ps_mode {
 };
 
 /** Helper function to get user-friendly ps mode name. */
-const char * const wifi_ps_mode_txt(enum wifi_ps_mode ps_mode);
+const char *wifi_ps_mode_txt(enum wifi_ps_mode ps_mode);
 
 /* Interface index Min and Max values */
 #define WIFI_INTERFACE_INDEX_MIN 1
@@ -273,7 +273,7 @@ enum wifi_twt_operation {
 };
 
 /** Helper function to get user-friendly twt operation name. */
-const char * const wifi_twt_operation_txt(enum wifi_twt_operation twt_operation);
+const char *wifi_twt_operation_txt(enum wifi_twt_operation twt_operation);
 
 /** Wi-Fi Target Wake Time (TWT) negotiation types. */
 enum wifi_twt_negotiation_type {
@@ -286,7 +286,7 @@ enum wifi_twt_negotiation_type {
 };
 
 /** Helper function to get user-friendly twt negotiation type name. */
-const char * const wifi_twt_negotiation_type_txt(enum wifi_twt_negotiation_type twt_negotiation);
+const char *wifi_twt_negotiation_type_txt(enum wifi_twt_negotiation_type twt_negotiation);
 
 /** Wi-Fi Target Wake Time (TWT) setup commands. */
 enum wifi_twt_setup_cmd {
@@ -309,7 +309,7 @@ enum wifi_twt_setup_cmd {
 };
 
 /** Helper function to get user-friendly twt setup cmd name. */
-const char * const wifi_twt_setup_cmd_txt(enum wifi_twt_setup_cmd twt_setup);
+const char *wifi_twt_setup_cmd_txt(enum wifi_twt_setup_cmd twt_setup);
 
 /** Wi-Fi Target Wake Time (TWT) negotiation status. */
 enum wifi_twt_setup_resp_status {
@@ -401,7 +401,7 @@ enum wifi_ps_wakeup_mode {
 };
 
 /** Helper function to get user-friendly ps wakeup mode name. */
-const char * const wifi_ps_wakeup_mode_txt(enum wifi_ps_wakeup_mode ps_wakeup_mode);
+const char *wifi_ps_wakeup_mode_txt(enum wifi_ps_wakeup_mode ps_wakeup_mode);
 
 /** Wi-Fi power save error codes. */
 enum wifi_config_ps_param_fail_reason {

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -17,7 +17,7 @@ LOG_MODULE_REGISTER(net_wifi_mgmt, CONFIG_NET_L2_WIFI_MGMT_LOG_LEVEL);
 #include <zephyr/net/wifi_nm.h>
 #endif /* CONFIG_WIFI_NM */
 
-const char * const wifi_security_txt(enum wifi_security_type security)
+const char *wifi_security_txt(enum wifi_security_type security)
 {
 	switch (security) {
 	case WIFI_SECURITY_TYPE_NONE:
@@ -42,7 +42,7 @@ const char * const wifi_security_txt(enum wifi_security_type security)
 	}
 }
 
-const char * const wifi_mfp_txt(enum wifi_mfp_options mfp)
+const char *wifi_mfp_txt(enum wifi_mfp_options mfp)
 {
 	switch (mfp) {
 	case WIFI_MFP_DISABLE:
@@ -57,7 +57,7 @@ const char * const wifi_mfp_txt(enum wifi_mfp_options mfp)
 	}
 }
 
-const char * const wifi_band_txt(enum wifi_frequency_bands band)
+const char *wifi_band_txt(enum wifi_frequency_bands band)
 {
 	switch (band) {
 	case WIFI_FREQ_BAND_2_4_GHZ:
@@ -72,7 +72,7 @@ const char * const wifi_band_txt(enum wifi_frequency_bands band)
 	}
 }
 
-const char * const wifi_state_txt(enum wifi_iface_state state)
+const char *wifi_state_txt(enum wifi_iface_state state)
 {
 	switch (state) {
 	case WIFI_STATE_DISCONNECTED:
@@ -101,7 +101,7 @@ const char * const wifi_state_txt(enum wifi_iface_state state)
 	}
 }
 
-const char * const wifi_mode_txt(enum wifi_iface_mode mode)
+const char *wifi_mode_txt(enum wifi_iface_mode mode)
 {
 	switch (mode) {
 	case WIFI_MODE_INFRA:
@@ -122,7 +122,7 @@ const char * const wifi_mode_txt(enum wifi_iface_mode mode)
 	}
 }
 
-const char * const wifi_link_mode_txt(enum wifi_link_mode link_mode)
+const char *wifi_link_mode_txt(enum wifi_link_mode link_mode)
 {
 	switch (link_mode) {
 	case WIFI_0:
@@ -149,7 +149,7 @@ const char * const wifi_link_mode_txt(enum wifi_link_mode link_mode)
 	}
 }
 
-const char * const wifi_ps_txt(enum wifi_ps ps_name)
+const char *wifi_ps_txt(enum wifi_ps ps_name)
 {
 	switch (ps_name) {
 	case WIFI_PS_DISABLED:
@@ -161,7 +161,7 @@ const char * const wifi_ps_txt(enum wifi_ps ps_name)
 	}
 }
 
-const char * const wifi_ps_mode_txt(enum wifi_ps_mode ps_mode)
+const char *wifi_ps_mode_txt(enum wifi_ps_mode ps_mode)
 {
 	switch (ps_mode) {
 	case WIFI_PS_MODE_LEGACY:
@@ -173,7 +173,7 @@ const char * const wifi_ps_mode_txt(enum wifi_ps_mode ps_mode)
 	}
 }
 
-const char * const wifi_twt_operation_txt(enum wifi_twt_operation twt_operation)
+const char *wifi_twt_operation_txt(enum wifi_twt_operation twt_operation)
 {
 	switch (twt_operation) {
 	case WIFI_TWT_SETUP:
@@ -185,7 +185,7 @@ const char * const wifi_twt_operation_txt(enum wifi_twt_operation twt_operation)
 	}
 }
 
-const char * const wifi_twt_negotiation_type_txt(enum wifi_twt_negotiation_type twt_negotiation)
+const char *wifi_twt_negotiation_type_txt(enum wifi_twt_negotiation_type twt_negotiation)
 {
 	switch (twt_negotiation) {
 	case WIFI_TWT_INDIVIDUAL:
@@ -199,7 +199,7 @@ const char * const wifi_twt_negotiation_type_txt(enum wifi_twt_negotiation_type 
 	}
 }
 
-const char * const wifi_twt_setup_cmd_txt(enum wifi_twt_setup_cmd twt_setup)
+const char *wifi_twt_setup_cmd_txt(enum wifi_twt_setup_cmd twt_setup)
 {
 	switch (twt_setup) {
 	case WIFI_TWT_SETUP_CMD_REQUEST:
@@ -223,7 +223,7 @@ const char * const wifi_twt_setup_cmd_txt(enum wifi_twt_setup_cmd twt_setup)
 	}
 }
 
-const char * const wifi_ps_wakeup_mode_txt(enum wifi_ps_wakeup_mode ps_wakeup_mode)
+const char *wifi_ps_wakeup_mode_txt(enum wifi_ps_wakeup_mode ps_wakeup_mode)
 {
 	switch (ps_wakeup_mode) {
 	case WIFI_PS_WAKEUP_MODE_DTIM:


### PR DESCRIPTION
The warning which became error looks like this

error: type qualifiers ignored on function return type [-Werror=ignored-qualifiers]
  219 | const char * const wifi_ps_txt(enum wifi_ps ps_name);

It is pointless to add a const qualifier to a return value. So remove the const pointer to avoid this warning.

Fixes #64197