### PR TITLE
drivers: pinctrl: sam: Add wake-up source support

### DIFF
--- a/drivers/pinctrl/pinctrl_sam.c
+++ b/drivers/pinctrl/pinctrl_sam.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, Gerson Fernando Budke <nandojve@gmail.com>
+ * Copyright (c) 2022-2023 Gerson Fernando Budke <nandojve@gmail.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -65,12 +65,16 @@ static void pinctrl_configure_pin(pinctrl_soc_pin_t pin)
 	soc_pin.regs = (Pio *) sam_port_addrs[port_idx];
 #endif
 	soc_pin.periph_id = sam_port_clocks[port_idx].peripheral_id;
-	soc_pin.mask = 1 << SAM_PINMUX_PIN_GET(pin);
+	soc_pin.mask = BIT(SAM_PINMUX_PIN_GET(pin));
 	soc_pin.flags = SAM_PINCTRL_FLAGS_GET(pin) << SOC_GPIO_FLAGS_POS;
 
 	if (port_func == SAM_PINMUX_FUNC_periph) {
 		soc_pin.flags |= (SAM_PINMUX_PERIPH_GET(pin)
 				  << SOC_GPIO_FUNC_POS);
+	} else if (port_func == SAM_PINMUX_FUNC_wakeup) {
+		soc_pin.flags |= (SAM_PINMUX_PERIPH_GET(pin)
+				  << SOC_GPIO_FUNC_POS)
+				 | SAM_PINCTRL_WAKEUP;
 	}
 
 	soc_gpio_configure(&soc_pin);

--- a/dts/bindings/pinctrl/atmel,sam-pinctrl.yaml
+++ b/dts/bindings/pinctrl/atmel,sam-pinctrl.yaml
@@ -1,6 +1,6 @@
 # Copyright (c) 2020, Linaro Limited
 # Copyright (c) 2021, Teslabs Engineering S.L.
-# Copyright (c) 2021-2022, Gerson Fernando Budke <nandojve@gmail.com>
+# Copyright (c) 2021-2023, Gerson Fernando Budke <nandojve@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
@@ -43,6 +43,26 @@ description: |
           bias-pull-up;
         };
       };
+      wakeup_source0_default: wakeup_source0_default {
+        /* group 1 */
+        group1 {
+          /* configure PA0 as WAKE-UP source for the the core power supply */
+          pinmux = <PA0X_SUPC_WKUP0>;
+          /* The pull-down instructs to SUPC to detect a wake-up event at PA0
+           * rising edge followed by a high level.
+           */
+          bias-pull-down;
+        };
+        /* group 2 */
+        group2 {
+          /* configure PA1 as WAKE-UP source for the the core power supply */
+          pinmux = <PA1X_SUPC_WKUP1>;
+          /* The pull-down instructs to SUPC to detect a wake-up event at PA1
+           * falling edge followed by a low level.
+           */
+          bias-pull-up;
+        };
+      };
     };
 
   The 'usart0_default' child node encodes the pin configurations for a
@@ -70,6 +90,10 @@ description: |
           pinctrl-0 = <&usart0_default>;
           pinctrl-names = "default";
     };
+
+  The 'wakeup_source0_default' child node shows how the bias-pull-up/down can
+  be used to select the wake-up type when selecting that specific pin function.
+  It is mandatory add the bias-pull-up/down to have correct behavior.
 
 compatible: "atmel,sam-pinctrl"
 

--- a/include/zephyr/drivers/pinctrl/pinctrl_soc_sam_common.h
+++ b/include/zephyr/drivers/pinctrl/pinctrl_soc_sam_common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Gerson Fernando Budke <nandojve@gmail.com>
+ * Copyright (c) 2022-2023 Gerson Fernando Budke <nandojve@gmail.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -87,7 +87,9 @@ typedef uint32_t pinctrl_soc_pin_t;
 #define SAM_PINCTRL_PULLDOWN            (1U << SAM_PINCTRL_PULLDOWN_POS)
 #define SAM_PINCTRL_OPENDRAIN_POS       (SAM_PINCTRL_PULLDOWN_POS + 1U)
 #define SAM_PINCTRL_OPENDRAIN           (1U << SAM_PINCTRL_OPENDRAIN_POS)
-#define SAM_PINCTRL_INPUTENABLE_POS     (SAM_PINCTRL_OPENDRAIN_POS + 1U)
+#define SAM_PINCTRL_WAKEUP_POS          (SAM_PINCTRL_OPENDRAIN_POS + 1U)
+#define SAM_PINCTRL_WAKEUP              (1U << SAM_PINCTRL_WAKEUP_POS)
+#define SAM_PINCTRL_INPUTENABLE_POS     (SAM_PINCTRL_WAKEUP_POS + 1U)
 #define SAM_PINCTRL_INPUTENABLE         (1U << SAM_PINCTRL_INPUTENABLE_POS)
 #define SAM_PINCTRL_OUTPUTENABLE_POS    (SAM_PINCTRL_INPUTENABLE_POS + 1U)
 #define SAM_PINCTRL_OUTPUTENABLE        (1U << SAM_PINCTRL_OUTPUTENABLE_POS)

--- a/soc/arm/atmel_sam/common/soc_gpio.h
+++ b/soc/arm/atmel_sam/common/soc_gpio.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016-2017 Piotr Mienkowski
- * Copyright (c) 2020 Gerson Fernando Budke <nandojve@gmail.com>
+ * Copyright (c) 2020-2023 Gerson Fernando Budke <nandojve@gmail.com>
+ *
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -26,26 +27,33 @@
 #define SOC_GPIO_DEFAULT                (0)
 
 #define SOC_GPIO_FLAGS_POS              (0)
-#define SOC_GPIO_FLAGS_MASK             (7 << SOC_GPIO_FLAGS_POS)
+#define SOC_GPIO_FLAGS_SIZE             (4)
+#define SOC_GPIO_FLAGS_MASK             (0x0FU << SOC_GPIO_FLAGS_POS)
 #define SOC_GPIO_PULLUP_POS             (0)
 #define SOC_GPIO_PULLUP                 (1 << SOC_GPIO_PULLUP_POS)
 #define SOC_GPIO_PULLDOWN_POS           (1)
 #define SOC_GPIO_PULLDOWN               (1 << SOC_GPIO_PULLDOWN_POS)
 #define SOC_GPIO_OPENDRAIN_POS          (2)
 #define SOC_GPIO_OPENDRAIN              (1 << SOC_GPIO_OPENDRAIN_POS)
+#define SOC_GPIO_WAKEUP_POS             (3)
+#define SOC_GPIO_WAKEUP                 (1 << SOC_GPIO_WAKEUP_POS)
 
 /* Bit field: SOC_GPIO_IN_FILTER */
-#define SOC_GPIO_IN_FILTER_POS          (3)
-#define SOC_GPIO_IN_FILTER_MASK         (3 << SOC_GPIO_IN_FILTER_POS)
+#define SOC_GPIO_IN_FILTER_POS          (SOC_GPIO_FLAGS_POS + SOC_GPIO_FLAGS_SIZE)
+#define SOC_GPIO_IN_FILTER_SIZE         (2)
+#define SOC_GPIO_IN_FILTER_MASK         (0x03U << SOC_GPIO_IN_FILTER_POS)
 #define SOC_GPIO_IN_FILTER_NONE         (0 << SOC_GPIO_IN_FILTER_POS)
 #define SOC_GPIO_IN_FILTER_DEBOUNCE     (1 << SOC_GPIO_IN_FILTER_POS)
 #define SOC_GPIO_IN_FILTER_DEGLITCH     (2 << SOC_GPIO_IN_FILTER_POS)
 
-#define SOC_GPIO_INT_ENABLE             (1 << 5)
+#define SOC_GPIO_INT_POS                (SOC_GPIO_IN_FILTER_POS + SOC_GPIO_IN_FILTER_SIZE)
+#define SOC_GPIO_INT_SIZE               (1)
+#define SOC_GPIO_INT_ENABLE             (1 << SOC_GPIO_INT_POS)
 
 /* Bit field: SOC_GPIO_INT_TRIG */
-#define SOC_GPIO_INT_TRIG_POS           (6)
-#define SOC_GPIO_INT_TRIG_MASK          (3 << SOC_GPIO_INT_TRIG_POS)
+#define SOC_GPIO_INT_TRIG_POS           (SOC_GPIO_INT_POS + SOC_GPIO_INT_SIZE)
+#define SOC_GPIO_INT_TRIG_SIZE          (2)
+#define SOC_GPIO_INT_TRIG_MASK          (0x03U << SOC_GPIO_INT_TRIG_POS)
 /** Interrupt is triggered by a level detection event. */
 #define SOC_GPIO_INT_TRIG_LEVEL         (0 << SOC_GPIO_INT_TRIG_POS)
 /** Interrupt is triggered by an edge detection event. */
@@ -54,11 +62,13 @@
 #define SOC_GPIO_INT_TRIG_DOUBLE_EDGE   (2 << SOC_GPIO_INT_TRIG_POS)
 
 /** Interrupt is triggered by a high level / rising edge detection event */
-#define SOC_GPIO_INT_ACTIVE_HIGH        (1 << 8)
+#define SOC_GPIO_INT_ACTIVE_POS         (SOC_GPIO_INT_TRIG_POS + SOC_GPIO_INT_TRIG_SIZE)
+#define SOC_GPIO_INT_ACTIVE_SIZE        (1)
+#define SOC_GPIO_INT_ACTIVE_HIGH        (1 << SOC_GPIO_INT_ACTIVE_POS)
 
 /* Bit field: SOC_GPIO_FUNC */
 #define SOC_GPIO_FUNC_POS               (16)
-#define SOC_GPIO_FUNC_MASK              (15 << SOC_GPIO_FUNC_POS)
+#define SOC_GPIO_FUNC_MASK              (0x0F << SOC_GPIO_FUNC_POS)
 /** Connect pin to peripheral A. */
 #define SOC_GPIO_FUNC_A                 (0 << SOC_GPIO_FUNC_POS)
 /** Connect pin to peripheral B. */
@@ -75,12 +85,14 @@
 #define SOC_GPIO_FUNC_G                 (6 << SOC_GPIO_FUNC_POS)
 /** Connect pin to peripheral H. */
 #define SOC_GPIO_FUNC_H                 (7 << SOC_GPIO_FUNC_POS)
+/** Configure pin as wakeup input source. */
+#define SOC_GPIO_FUNC_WAKEUP            (8 << SOC_GPIO_FUNC_POS)
 /** Configure pin as input. */
-#define SOC_GPIO_FUNC_IN                (8 << SOC_GPIO_FUNC_POS)
+#define SOC_GPIO_FUNC_IN                (9 << SOC_GPIO_FUNC_POS)
 /** Configure pin as output and set it initial value to 0. */
-#define SOC_GPIO_FUNC_OUT_0             (9 << SOC_GPIO_FUNC_POS)
+#define SOC_GPIO_FUNC_OUT_0             (10 << SOC_GPIO_FUNC_POS)
 /** Configure pin as output and set it initial value to 1. */
-#define SOC_GPIO_FUNC_OUT_1             (10 << SOC_GPIO_FUNC_POS)
+#define SOC_GPIO_FUNC_OUT_1             (11 << SOC_GPIO_FUNC_POS)
 
 struct soc_gpio_pin {
 	uint32_t mask;     /** pin(s) bit mask */

--- a/soc/arm/atmel_sam/common/soc_supc.c
+++ b/soc/arm/atmel_sam/common/soc_supc.c
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2023 Bjarki Arge Andreasen
+ * Copyright (c) 2023 Gerson Fernando Budke <nandojve@gmail.com>
+ *
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -28,5 +30,24 @@ void soc_supc_enable_wakeup_source(uint32_t wakeup_source_id)
 	__ASSERT(wakeup_source_id <= SOC_SUPC_WAKEUP_SOURCE_IDS,
 		 "Wakeup source channel is invalid");
 
-	SUPC->SUPC_WUMR |= 1 << wakeup_source_id;
+	SUPC->SUPC_WUMR |= BIT(wakeup_source_id);
+}
+
+void soc_supc_enable_wakeup_pin_source(uint32_t wkup_src,
+				       enum soc_supc_pin_wkup_type wkup_type)
+{
+	uint32_t wuir_high = BIT(wkup_src + 0x10U);
+
+	SUPC->SUPC_WUIR |= BIT(wkup_src);
+
+	if (wkup_type == SOC_SUPC_PIN_WKUP_TYPE_HIGH) {
+		SUPC->SUPC_WUIR |= wuir_high;
+	} else {
+		SUPC->SUPC_WUIR &= ~wuir_high;
+	}
+}
+
+void soc_supc_disable_wakeup_pin_source(uint32_t wkup_src)
+{
+	SUPC->SUPC_WUIR &= ~BIT(wkup_src);
 }

--- a/soc/arm/atmel_sam/common/soc_supc.h
+++ b/soc/arm/atmel_sam/common/soc_supc.h
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2023 Bjarki Arge Andreasen
+ * Copyright (c) 2023 Gerson Fernando Budke <nandojve@gmail.com>
+ *
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -7,6 +9,11 @@
 #define _ATMEL_SAM_SOC_SUPC_H_
 
 #include <zephyr/types.h>
+
+enum soc_supc_pin_wkup_type {
+	SOC_SUPC_PIN_WKUP_TYPE_LOW,
+	SOC_SUPC_PIN_WKUP_TYPE_HIGH,
+};
 
 /**
  * @brief Enable the clock of specified peripheral module.
@@ -22,5 +29,16 @@ void soc_supc_slow_clock_select_crystal_osc(void);
  * @brief Enable wakeup source
  */
 void soc_supc_enable_wakeup_source(uint32_t wakeup_source_id);
+
+/**
+ * @brief Enable wakeup pin source
+ */
+void soc_supc_enable_wakeup_pin_source(uint32_t wkup_src,
+				       enum soc_supc_pin_wkup_type wkup_type);
+
+/**
+ * @brief Disable wakeup pin source
+ */
+void soc_supc_disable_wakeup_pin_source(uint32_t wkup_src);
 
 #endif /* _ATMEL_SAM_SOC_SUPC_H_ */

--- a/soc/arm/atmel_sam0/common/soc_port.h
+++ b/soc/arm/atmel_sam0/common/soc_port.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016-2017 Piotr Mienkowski
- * Copyright (c) 2020-2022 Gerson Fernando Budke
+ * Copyright (c) 2020-2023 Gerson Fernando Budke
+ *
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -19,15 +20,19 @@
 #define SOC_PORT_DEFAULT                (0)
 
 #define SOC_PORT_FLAGS_POS              (0)
-#define SOC_PORT_FLAGS_MASK             (0x7B << SOC_PORT_FLAGS_POS)
+#define SOC_PORT_FLAGS_MASK             (0xF3 << SOC_PORT_FLAGS_POS)
 #define SOC_PORT_PULLUP_POS             (SOC_PORT_FLAGS_POS)
 #define SOC_PORT_PULLUP                 (1 << SOC_PORT_PULLUP_POS)
 #define SOC_PORT_PULLDOWN_POS           (SOC_PORT_PULLUP_POS + 1U)
 #define SOC_PORT_PULLDOWN               (1 << SOC_PORT_PULLDOWN_POS)
 /* Open-Drain is a reserved entry at pinctrl driver */
 #define SOC_GPIO_OPENDRAIN_POS          (SOC_PORT_PULLDOWN_POS + 1U)
+#define SOC_GPIO_OPENDRAIN		(0)
+/* Wake-Up is a reserved entry at pinctrl driver */
+#define SOC_GPIO_WAKEUP_POS             (SOC_GPIO_OPENDRAIN_POS + 1U)
+#define SOC_GPIO_WAKEUP			(0)
 /* Input-Enable means Input-Buffer, see dts/pinctrl/pincfg-node.yaml */
-#define SOC_PORT_INPUT_ENABLE_POS       (SOC_GPIO_OPENDRAIN_POS + 1U)
+#define SOC_PORT_INPUT_ENABLE_POS       (SOC_GPIO_WAKEUP_POS + 1U)
 #define SOC_PORT_INPUT_ENABLE           (1 << SOC_PORT_INPUT_ENABLE_POS)
 /* Output-Enable, see dts/pinctrl/pincfg-node.yaml */
 #define SOC_PORT_OUTPUT_ENABLE_POS      (SOC_PORT_INPUT_ENABLE_POS + 1U)

--- a/west.yml
+++ b/west.yml
@@ -147,7 +147,7 @@ manifest:
       groups:
         - hal
     - name: hal_atmel
-      revision: 942d664e48f7a2725933a93facc112b87b1de32b
+      revision: add80d4bf53c3b2b54261b5a14fc2c02c3833d8e
       path: modules/hal/atmel
       groups:
         - hal


### PR DESCRIPTION
This add the pin wake-up source configuration capabilities to the SAM pinctrl driver. It add the SUPC functions at SoC and update gpio and pinctrl drivers to allow user configure the wake-up core power supply functionality.

depends on #63961