### PR TITLE
drivers: flash: sam: Redesign controller to fully utilize flash page layout

### DIFF
--- a/drivers/flash/Kconfig.sam
+++ b/drivers/flash/Kconfig.sam
@@ -7,6 +7,7 @@ config SOC_FLASH_SAM
 	bool "Atmel SAM flash driver"
 	default y
 	depends on DT_HAS_ATMEL_SAM_FLASH_CONTROLLER_ENABLED
+	select FLASH_PAGE_LAYOUT
 	select FLASH_HAS_PAGE_LAYOUT
 	select FLASH_HAS_DRIVER_ENABLED
 	select MPU_ALLOW_FLASH_WRITE if ARM_MPU

--- a/dts/arm/atmel/sam3x.dtsi
+++ b/dts/arm/atmel/sam3x.dtsi
@@ -53,6 +53,7 @@
 		eefc: flash-controller@400e0a00 {
 			compatible = "atmel,sam-flash-controller";
 			reg = <0x400e0a00 0x200>;
+			interrupts = <6 0>;
 			clocks = <&pmc PMC_TYPE_PERIPHERAL 6>;
 
 			#address-cells = <1>;

--- a/dts/arm/atmel/sam4e.dtsi
+++ b/dts/arm/atmel/sam4e.dtsi
@@ -80,15 +80,16 @@
 			compatible = "atmel,sam-flash-controller";
 			reg = <0x400e0a00 0x200>;
 			clocks = <&pmc PMC_TYPE_PERIPHERAL 6>;
+			status = "okay";
 
 			#address-cells = <1>;
 			#size-cells = <1>;
+			#erase-block-cells = <2>;
 
 			flash0: flash@400000 {
-				compatible = "soc-nv-flash";
-
-				write-block-size = <16>;
-				erase-block-size = <8192>;
+				compatible = "atmel,sam-flash", "soc-nv-flash";
+				write-block-size = <8>;
+				erase-block-size = <4096>;
 			};
 		};
 

--- a/dts/arm/atmel/sam4e.dtsi
+++ b/dts/arm/atmel/sam4e.dtsi
@@ -79,6 +79,7 @@
 		eefc: flash-controller@400e0a00 {
 			compatible = "atmel,sam-flash-controller";
 			reg = <0x400e0a00 0x200>;
+			interrupts = <6 0>;
 			clocks = <&pmc PMC_TYPE_PERIPHERAL 6>;
 			status = "okay";
 

--- a/dts/arm/atmel/sam4e16c.dtsi
+++ b/dts/arm/atmel/sam4e16c.dtsi
@@ -12,6 +12,7 @@
 		flash-controller@400e0a00 {
 			flash0: flash@400000 {
 				reg = <0x00400000 DT_SIZE_K(1024)>;
+				erase-blocks = <&eefc 8 2048>, <&eefc 252 4096>;
 			};
 		};
 

--- a/dts/arm/atmel/sam4e16e.dtsi
+++ b/dts/arm/atmel/sam4e16e.dtsi
@@ -12,6 +12,7 @@
 		flash-controller@400e0a00 {
 			flash0: flash@400000 {
 				reg = <0x00400000 DT_SIZE_K(1024)>;
+				erase-blocks = <&eefc 8 2048>, <&eefc 252 4096>;
 			};
 		};
 

--- a/dts/arm/atmel/sam4e8c.dtsi
+++ b/dts/arm/atmel/sam4e8c.dtsi
@@ -12,6 +12,7 @@
 		flash-controller@400e0a00 {
 			flash0: flash@400000 {
 				reg = <0x00400000 DT_SIZE_K(512)>;
+				erase-blocks = <&eefc 8 2048>, <&eefc 124 4096>;
 			};
 		};
 

--- a/dts/arm/atmel/sam4e8e.dtsi
+++ b/dts/arm/atmel/sam4e8e.dtsi
@@ -12,6 +12,7 @@
 		flash-controller@400e0a00 {
 			flash0: flash@400000 {
 				reg = <0x00400000 DT_SIZE_K(512)>;
+				erase-blocks = <&eefc 8 2048>, <&eefc 124 4096>;
 			};
 		};
 

--- a/dts/arm/atmel/sam4s.dtsi
+++ b/dts/arm/atmel/sam4s.dtsi
@@ -67,12 +67,12 @@
 
 			#address-cells = <1>;
 			#size-cells = <1>;
+			#erase-block-cells = <2>;
 
 			flash0: flash@400000 {
-				compatible = "soc-nv-flash";
-
-				write-block-size = <16>;
-				erase-block-size = <8192>;
+				compatible = "atmel,sam-flash", "soc-nv-flash";
+				write-block-size = <8>;
+				erase-block-size = <4096>;
 			};
 		};
 

--- a/dts/arm/atmel/sam4s.dtsi
+++ b/dts/arm/atmel/sam4s.dtsi
@@ -63,6 +63,7 @@
 		eefc: flash-controller@400e0a00 {
 			compatible = "atmel,sam-flash-controller";
 			reg = <0x400e0a00 0x200>;
+			interrupts = <6 0>;
 			clocks = <&pmc PMC_TYPE_PERIPHERAL 6>;
 
 			#address-cells = <1>;

--- a/dts/arm/atmel/sam4s16b.dtsi
+++ b/dts/arm/atmel/sam4s16b.dtsi
@@ -12,6 +12,7 @@
 		flash-controller@400e0a00 {
 			flash0: flash@400000 {
 				reg = <0x00400000 DT_SIZE_K(1024)>;
+				erase-blocks = <&eefc 8 2048>, <&eefc 252 4096>;
 			};
 		};
 

--- a/dts/arm/atmel/sam4s16c.dtsi
+++ b/dts/arm/atmel/sam4s16c.dtsi
@@ -12,6 +12,7 @@
 		flash-controller@400e0a00 {
 			flash0: flash@400000 {
 				reg = <0x00400000 DT_SIZE_K(1024)>;
+				erase-blocks = <&eefc 8 2048>, <&eefc 252 4096>;
 			};
 		};
 

--- a/dts/arm/atmel/sam4s2a.dtsi
+++ b/dts/arm/atmel/sam4s2a.dtsi
@@ -12,6 +12,7 @@
 		flash-controller@400e0a00 {
 			flash0: flash@400000 {
 				reg = <0x00400000 DT_SIZE_K(128)>;
+				erase-blocks = <&eefc 8 2048>, <&eefc 28 4096>;
 			};
 		};
 

--- a/dts/arm/atmel/sam4s2b.dtsi
+++ b/dts/arm/atmel/sam4s2b.dtsi
@@ -12,6 +12,7 @@
 		flash-controller@400e0a00 {
 			flash0: flash@400000 {
 				reg = <0x00400000 DT_SIZE_K(128)>;
+				erase-blocks = <&eefc 8 2048>, <&eefc 28 4096>;
 			};
 		};
 

--- a/dts/arm/atmel/sam4s2c.dtsi
+++ b/dts/arm/atmel/sam4s2c.dtsi
@@ -12,6 +12,7 @@
 		flash-controller@400e0a00 {
 			flash0: flash@400000 {
 				reg = <0x00400000 DT_SIZE_K(128)>;
+				erase-blocks = <&eefc 8 2048>, <&eefc 28 4096>;
 			};
 		};
 

--- a/dts/arm/atmel/sam4s4a.dtsi
+++ b/dts/arm/atmel/sam4s4a.dtsi
@@ -12,6 +12,7 @@
 		flash-controller@400e0a00 {
 			flash0: flash@400000 {
 				reg = <0x00400000 DT_SIZE_K(256)>;
+				erase-blocks = <&eefc 8 2048>, <&eefc 60 4096>;
 			};
 		};
 

--- a/dts/arm/atmel/sam4s4b.dtsi
+++ b/dts/arm/atmel/sam4s4b.dtsi
@@ -12,6 +12,7 @@
 		flash-controller@400e0a00 {
 			flash0: flash@400000 {
 				reg = <0x00400000 DT_SIZE_K(356)>;
+				erase-blocks = <&eefc 8 2048>, <&eefc 60 4096>;
 			};
 		};
 

--- a/dts/arm/atmel/sam4s4c.dtsi
+++ b/dts/arm/atmel/sam4s4c.dtsi
@@ -12,6 +12,7 @@
 		flash-controller@400e0a00 {
 			flash0: flash@400000 {
 				reg = <0x00400000 DT_SIZE_K(256)>;
+				erase-blocks = <&eefc 8 2048>, <&eefc 60 4096>;
 			};
 		};
 

--- a/dts/arm/atmel/sam4s8b.dtsi
+++ b/dts/arm/atmel/sam4s8b.dtsi
@@ -12,6 +12,7 @@
 		flash-controller@400e0a00 {
 			flash0: flash@400000 {
 				reg = <0x00400000 DT_SIZE_K(512)>;
+				erase-blocks = <&eefc 8 2048>, <&eefc 124 4096>;
 			};
 		};
 

--- a/dts/arm/atmel/sam4s8c.dtsi
+++ b/dts/arm/atmel/sam4s8c.dtsi
@@ -12,6 +12,7 @@
 		flash-controller@400e0a00 {
 			flash0: flash@400000 {
 				reg = <0x00400000 DT_SIZE_K(512)>;
+				erase-blocks = <&eefc 8 2048>, <&eefc 124 4096>;
 			};
 		};
 

--- a/dts/arm/atmel/sam4sa16c.dtsi
+++ b/dts/arm/atmel/sam4sa16c.dtsi
@@ -12,6 +12,7 @@
 		flash-controller@400e0a00 {
 			flash0: flash@400000 {
 				reg = <0x00400000 DT_SIZE_K(1024)>;
+				erase-blocks = <&eefc 8 2048>, <&eefc 252 4096>;
 			};
 		};
 

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -72,14 +72,13 @@
 
 			#address-cells = <1>;
 			#size-cells = <1>;
+			#erase-block-cells = <2>;
 
 			flash0: flash@400000 {
-				compatible = "soc-nv-flash";
-
+				compatible = "atmel,sam-flash", "soc-nv-flash";
 				write-block-size = <16>;
 				erase-block-size = <8192>;
 			};
-
 		};
 
 		wdt: watchdog@400e1850 {

--- a/dts/arm/atmel/same70q19.dtsi
+++ b/dts/arm/atmel/same70q19.dtsi
@@ -17,6 +17,7 @@
 		flash-controller@400e0c00 {
 			flash0: flash@400000 {
 				reg = <0x00400000 DT_SIZE_K(512)>;
+				erase-blocks = <&eefc 8 2048>, <&eefc 62 8192>;
 			};
 		};
 	};

--- a/dts/arm/atmel/same70q19b.dtsi
+++ b/dts/arm/atmel/same70q19b.dtsi
@@ -17,6 +17,7 @@
 		flash-controller@400e0c00 {
 			flash0: flash@400000 {
 				reg = <0x00400000 DT_SIZE_K(512)>;
+				erase-blocks = <&eefc 8 2048>, <&eefc 62 8192>;
 			};
 		};
 	};

--- a/dts/arm/atmel/same70q21.dtsi
+++ b/dts/arm/atmel/same70q21.dtsi
@@ -17,6 +17,7 @@
 		flash-controller@400e0c00 {
 			flash0: flash@400000 {
 				reg = <0x00400000 DT_SIZE_K(2048)>;
+				erase-blocks = <&eefc 8 2048>, <&eefc 252 8192>;
 			};
 		};
 	};

--- a/dts/arm/atmel/same70q21b.dtsi
+++ b/dts/arm/atmel/same70q21b.dtsi
@@ -18,6 +18,7 @@
 		flash-controller@400e0c00 {
 			flash0: flash@400000 {
 				reg = <0x00400000 DT_SIZE_K(2048)>;
+				erase-blocks = <&eefc 8 2048>, <&eefc 252 8192>;
 			};
 		};
 	};

--- a/dts/arm/atmel/samv71x19.dtsi
+++ b/dts/arm/atmel/samv71x19.dtsi
@@ -16,6 +16,7 @@
 		flash-controller@400e0c00 {
 			flash0: flash@400000 {
 				reg = <0x00400000 DT_SIZE_K(512)>;
+				erase-blocks = <&eefc 8 2048>, <&eefc 62 8192>;
 			};
 		};
 	};

--- a/dts/arm/atmel/samv71x19b.dtsi
+++ b/dts/arm/atmel/samv71x19b.dtsi
@@ -17,6 +17,7 @@
 		flash-controller@400e0c00 {
 			flash0: flash@400000 {
 				reg = <0x00400000 DT_SIZE_K(512)>;
+				erase-blocks = <&eefc 8 2048>, <&eefc 62 8192>;
 			};
 		};
 	};

--- a/dts/arm/atmel/samv71x20.dtsi
+++ b/dts/arm/atmel/samv71x20.dtsi
@@ -16,6 +16,7 @@
 		flash-controller@400e0c00 {
 			flash0: flash@400000 {
 				reg = <0x00400000 DT_SIZE_K(1024)>;
+				erase-blocks = <&eefc 8 2048>, <&eefc 126 8192>;
 			};
 		};
 	};

--- a/dts/arm/atmel/samv71x20b.dtsi
+++ b/dts/arm/atmel/samv71x20b.dtsi
@@ -17,6 +17,7 @@
 		flash-controller@400e0c00 {
 			flash0: flash@400000 {
 				reg = <0x00400000 DT_SIZE_K(1024)>;
+				erase-blocks = <&eefc 8 2048>, <&eefc 126 8192>;
 			};
 		};
 	};

--- a/dts/arm/atmel/samv71x21.dtsi
+++ b/dts/arm/atmel/samv71x21.dtsi
@@ -16,6 +16,7 @@
 		flash-controller@400e0c00 {
 			flash0: flash@400000 {
 				reg = <0x00400000 DT_SIZE_K(2048)>;
+				erase-blocks = <&eefc 8 2048>, <&eefc 252 8192>;
 			};
 		};
 	};

--- a/dts/arm/atmel/samv71x21b.dtsi
+++ b/dts/arm/atmel/samv71x21b.dtsi
@@ -17,6 +17,7 @@
 		flash-controller@400e0c00 {
 			flash0: flash@400000 {
 				reg = <0x00400000 DT_SIZE_K(2048)>;
+				erase-blocks = <&eefc 8 2048>, <&eefc 252 8192>;
 			};
 		};
 	};

--- a/dts/bindings/flash_controller/atmel,sam-flash-controller.yaml
+++ b/dts/bindings/flash_controller/atmel,sam-flash-controller.yaml
@@ -10,3 +10,11 @@ include: flash-controller.yaml
 properties:
   clocks:
     required: true
+
+  "#erase-block-cells":
+    type: int
+    const: 2
+
+erase-block-cells:
+  - pages-count
+  - pages-size

--- a/dts/bindings/mtd/atmel,sam-flash.yaml
+++ b/dts/bindings/mtd/atmel,sam-flash.yaml
@@ -1,0 +1,117 @@
+# Copyright (c) 2023 Bjarki Arge Andreasen
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  This binding describes the Atmel SAM flash area layout.
+
+  The Atmel SAM flash area varies in write-block-size, memory area,
+  and the layout of erase-blocks.
+
+  E.g. the flash area layout of the ATSAM4E16C:
+
+    |--------------------|
+    | 8 Kbytes           |  erase block size = 2048
+    |--------------------|
+    | 8 Kbytes           |  erase block size = 2048
+    |--------------------|
+    | 48 Kbytes          |  erase block size = 4096
+    |--------------------|
+    | 64 Kbytes          |  erase block size = 4096
+    |--------------------|
+    | ...                |
+
+  The ATSAM4E16C has a flash area which is 1000Kbytes
+  (1024 * 1024 bytes) with a write-block-size of 8 bytes. The first
+  16 Kbytes can be erased in blocks of 2048 bytes
+  (8 blocks of 2048 bytes), the remaining flash area is erasable
+  in blocks of 4096 bytes (252 blocks of 4096 bytes).
+
+  This flash area layout would described as:
+
+    / {
+      soc {
+        eefc: flash-controller@400e0a00 {
+        compatible = "atmel,sam-flash-controller";
+        reg = <0x400e0a00 0x200>;
+        clocks = <&pmc PMC_TYPE_PERIPHERAL 6>;
+        status = "okay";
+
+        #address-cells = <1>;
+        #size-cells = <1>;
+        #erase-block-cells = <2>;
+
+        flash0: flash@400000 {
+          compatible = "atmel,sam-flash", "soc-nv-flash";
+          reg = <0x400000 0x100000>;
+          write-block-size = <8>;
+          erase-block-size = <4096>;
+          erase-blocks = <&eefc 8 2048>, <&eefc 252 4096>;
+        };
+      };
+    };
+
+  Notes:
+    The flash area layout node flash0 should have both this
+    compatible, "atmel,sam-flash", and the "soc-nv-flash"
+    compatible. The latter is used from mcuboot and other
+    modules to identify the flash area.
+
+    If partitions are used, remember that their addresses are
+    offsets relative to the flash area address.  E.g. using
+    mcuboot and a allocating a storage partition:
+
+      &flash0 {
+        partitions {
+          compatible = "fixed-partitions";
+          #address-cells = <1>;
+          #size-cells = <1>;
+
+          boot_partition: partition@0 {
+            label = "mcuboot";
+            reg = <0x0 0x10000>;
+          };
+
+          slot0_partition: partition@10000 {
+            label = "slot0";
+            reg = <0x10000 0x70000>;
+          };
+
+          slot1_partition: partition@80000 {
+            label = "slot1";
+            reg = <0x80000 0x70000>;
+          };
+
+          storage_partition: partition@f0000 {
+            label = "storage";
+            reg = <0xf0000 0x100000>;
+          };
+        };
+      };
+
+compatible: "atmel,sam-flash"
+
+include: base.yaml
+
+properties:
+  write-block-size:
+    type: int
+    description: |
+      The flash controller is limited by hardware to writing blocks of
+      this size, aligned to this size, in bytes, to previously erased
+      flash, within the flash memory area.
+
+  erase-block-size:
+    type: int
+    description: |
+      The flash controller is limited by hardware to erase whole
+      blocks of flash at a time. This property describes the largest
+      erase block size in erase-blocks.
+
+  erase-blocks:
+    type: phandle-array
+    required: true
+    description: |
+      The flash controller is limited by hardware to erase whole
+      blocks of flash at a time. This propery describes the layout of
+      the erase-blocks, which can vary in size within the flash memory
+      area.

--- a/dts/bindings/mtd/atmel,sam-flash.yaml
+++ b/dts/bindings/mtd/atmel,sam-flash.yaml
@@ -112,6 +112,6 @@ properties:
     required: true
     description: |
       The flash controller is limited by hardware to erase whole
-      blocks of flash at a time. This propery describes the layout of
+      blocks of flash at a time. This property describes the layout of
       the erase-blocks, which can vary in size within the flash memory
       area.

--- a/tests/drivers/flash/erase_blocks/CMakeLists.txt
+++ b/tests/drivers/flash/erase_blocks/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Copyright (c) 2023 Bjarki Arge Andreasen
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(erase_blocks)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/drivers/flash/erase_blocks/prj.conf
+++ b/tests/drivers/flash/erase_blocks/prj.conf
@@ -1,0 +1,5 @@
+# Copyright (c) 2023 Bjarki Arge Andreasen
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_FLASH=y
+CONFIG_ZTEST=y

--- a/tests/drivers/flash/erase_blocks/src/main.c
+++ b/tests/drivers/flash/erase_blocks/src/main.c
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2023 Bjarki Arge Andreasen
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <string.h>
+#include <zephyr/drivers/flash.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/ztest.h>
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(test_flash);
+
+#ifdef CONFIG_BOOTLOADER_MCUBOOT
+
+#define TEST_FLASH_PART_NODE \
+	DT_NODELABEL(boot_partition)
+
+#else
+
+#define TEST_FLASH_PART_NODE \
+	DT_NODELABEL(slot1_partition)
+
+#endif
+
+#define TEST_FLASH_PART_OFFSET \
+	DT_REG_ADDR(TEST_FLASH_PART_NODE)
+
+#define TEST_FLASH_PART_SIZE \
+	DT_REG_SIZE(TEST_FLASH_PART_NODE)
+
+#define TEST_FLASH_PART_END_OFFSET \
+	(TEST_FLASH_PART_OFFSET + TEST_FLASH_PART_SIZE)
+
+#define TEST_FLASH_CONTROLLER_NODE \
+	DT_MTD_FROM_FIXED_PARTITION(TEST_FLASH_PART_NODE)
+
+static const struct device *flash_controller = DEVICE_DT_GET(TEST_FLASH_CONTROLLER_NODE);
+static uint8_t test_write_block[128];
+static uint8_t test_read_block[128];
+
+static void test_flash_fill_test_write_block(void)
+{
+	for (uint8_t i = 0; i < sizeof(test_write_block); i++) {
+		test_write_block[i] = i;
+	}
+}
+
+static void *test_flash_setup(void)
+{
+	test_flash_fill_test_write_block();
+	return NULL;
+}
+
+static bool test_flash_mem_is_set_to(const uint8_t *data, uint8_t to, size_t size)
+{
+	for (size_t i = 0; i < size; i++) {
+		if (data[i] != to) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+static bool test_flash_is_erased(off_t offset, size_t size)
+{
+	static uint8_t test_erase_buffer[99];
+	const struct flash_parameters *parameters = flash_get_parameters(flash_controller);
+	size_t remaining;
+	size_t readsize;
+
+	while (offset < size) {
+		remaining = size - (size_t)offset;
+		readsize = MIN(sizeof(test_erase_buffer), remaining);
+
+		if (flash_read(flash_controller, offset, test_erase_buffer, readsize) < 0) {
+			return false;
+		}
+
+		if (!test_flash_mem_is_set_to(test_erase_buffer, parameters->erase_value,
+					      readsize)) {
+			return false;
+		}
+
+		offset += (off_t)readsize;
+	}
+
+	return true;
+}
+
+static bool test_flash_verify_partition_is_erased(void)
+{
+	return test_flash_is_erased(TEST_FLASH_PART_OFFSET, TEST_FLASH_PART_SIZE);
+}
+
+static int test_flash_erase_partition(void)
+{
+	LOG_INF("Erasing section of size %zu at offset %zu controlled by %s",
+		TEST_FLASH_PART_SIZE,
+		TEST_FLASH_PART_OFFSET,
+		flash_controller->name);
+
+	return flash_erase(flash_controller, TEST_FLASH_PART_OFFSET,
+			   TEST_FLASH_PART_SIZE);
+}
+
+static void test_flash_before(void *f)
+{
+	ARG_UNUSED(f);
+	__ASSERT(test_flash_erase_partition() == 0,
+		 "Failed to erase partition");
+	__ASSERT(test_flash_verify_partition_is_erased(),
+		 "Failed to erase partition");
+}
+
+static void test_flash_write_block_at_offset(off_t offset, size_t size)
+{
+	zassert_ok(flash_write(flash_controller, offset, test_write_block, size),
+		   "Failed to write block at offset %zu, of size %zu", (size_t)offset, size);
+	zassert_ok(flash_read(flash_controller, offset, test_read_block, size),
+		   "Failed to read block at offset %zu, of size %zu", (size_t)offset, size);
+	zassert_ok(memcmp(test_write_block, test_read_block, size),
+		   "Failed to write block at offset %zu, of size %zu to page", (size_t)offset,
+		   size);
+}
+
+static void test_flash_write_across_page_boundary(const struct flash_pages_info *info,
+						  size_t write_block_size)
+{
+	off_t page_boundary = info->start_offset;
+	uint32_t page0_index = info->index - 1;
+	uint32_t page1_index = info->index;
+	off_t cross_write_start_offset = page_boundary - (off_t)write_block_size;
+	size_t cross_write_size = write_block_size * 2;
+
+	LOG_INF("Writing across page boundary at %zu, between page index %u and %u",
+		(size_t)page_boundary,
+		page0_index,
+		page1_index);
+
+	test_flash_write_block_at_offset(cross_write_start_offset, cross_write_size);
+}
+
+static bool test_flash_write_across_page_boundaries(const struct flash_pages_info *info,
+						    void *data)
+{
+	size_t write_block_size = *((size_t *)data);
+
+	if (info->start_offset <= TEST_FLASH_PART_OFFSET) {
+		/* Not yet reached second page within partition */
+		return true;
+	}
+
+	if (info->start_offset >= TEST_FLASH_PART_END_OFFSET) {
+		/* Reached first page after partition end */
+		return false;
+	}
+
+	test_flash_write_across_page_boundary(info, write_block_size);
+	return true;
+}
+
+ZTEST(flash_page_layout, test_write_across_page_boundaries_in_part)
+{
+	const struct flash_parameters *parameters = flash_get_parameters(flash_controller);
+	size_t write_block_size = parameters->write_block_size;
+
+	flash_page_foreach(flash_controller, test_flash_write_across_page_boundaries,
+			   &write_block_size);
+}
+
+static void test_flash_erase_page(const struct flash_pages_info *info)
+{
+	off_t page_offset = info->start_offset;
+	size_t page_size = info->size;
+	size_t page_index = info->index;
+
+	LOG_INF("Erasing page at %zu of size %zu with index %zu",
+		(size_t)page_offset, page_size, page_index);
+
+	zassert_ok(flash_erase(flash_controller, page_offset, page_size),
+		   "Failed to erase page");
+
+	zassert_true(test_flash_is_erased(page_offset, page_size),
+		     "Failed to erase page");
+}
+
+static bool test_flash_erase_pages(const struct flash_pages_info *info, void *data)
+{
+	if (info->start_offset < TEST_FLASH_PART_OFFSET) {
+		/* Not yet reached first page within partition */
+		return true;
+	}
+
+	if (info->start_offset >= TEST_FLASH_PART_END_OFFSET) {
+		/* Reached first page after partition end */
+		return false;
+	}
+
+	test_flash_erase_page(info);
+	return true;
+}
+
+ZTEST(flash_page_layout, test_erase_single_pages_in_part)
+{
+	const struct flash_parameters *parameters = flash_get_parameters(flash_controller);
+	size_t write_block_size = parameters->write_block_size;
+
+	flash_page_foreach(flash_controller, test_flash_write_across_page_boundaries,
+			   &write_block_size);
+
+	flash_page_foreach(flash_controller, test_flash_erase_pages, NULL);
+}
+
+ZTEST_SUITE(flash_page_layout, NULL, test_flash_setup, test_flash_before, NULL, NULL);

--- a/tests/drivers/flash/erase_blocks/sysbuild.conf
+++ b/tests/drivers/flash/erase_blocks/sysbuild.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2023 Bjarki Arge Andreasen
+# SPDX-License-Identifier: Apache-2.0
+
+SB_CONFIG_BOOTLOADER_MCUBOOT=y

--- a/tests/drivers/flash/erase_blocks/testcase.yaml
+++ b/tests/drivers/flash/erase_blocks/testcase.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2023 Bjarki Arge Andreasen
+# SPDX-License-Identifier: Apache-2.0
+
+common:
+  sysbuild: true
+  tags:
+    - drivers
+    - flash
+tests:
+  flash.erase_blocks.build_only:
+    harness: ztest
+    build_only: true
+    platform_allow:
+      - sam_v71_xult
+      - b_u585i_iot02a
+      - nrf9160dk_nrf9160
+      - nrf5340dk_nrf5340_cpuapp


### PR DESCRIPTION
This PR redesigns the atmel sam flash controller to fully utilize the flash page layout and capabilities of each individual soc.

An example is the ATSAM4E series socs, they have a flash layout like:
```
|--------------------|
| 8 Kbytes           |  erase block size = 2048
|--------------------|
| 8 Kbytes           |  erase block size = 2048
|--------------------|
| 48 Kbytes          |  erase block size = 4096
|--------------------|
| 64 Kbytes          |  erase block size = 4096
|--------------------|
| ...                |

and a write block size of 8 bytes.
```
This PR adds a new `flash-pages` cell property which is used to describe this layout fully:
```
flash0: flash@400000 {
	compatible = "atmel,sam-flash", "soc-nv-flash";
	write-block-size = <8>;
	flash-pages = <&eefc 8 2048>, <&eefc 252 4096>;
};
```
Comparing this to the ATSAME70 series
```
|--------------------|
| 8 Kbytes           |  erase block size = 2048
|--------------------|
| 8 Kbytes           |  erase block size = 2048
|--------------------|
| 112 Kbytes         |  erase block size = 8192
|--------------------|
| 128 Kbytes         |  erase block size = 8192
|--------------------|
| ...                |

and a write block size of 16 bytes.
```
It is described as
```
flash0: flash@400000 {
	compatible = "atmel,sam-flash", "soc-nv-flash";
	write-block-size = <16>;
	flash-pages = <&eefc 8 2048>, <&eefc 252 8192>;
};
```
The redesigned driver is based on the `flash_page_layout.c` driver to avoid duplicate code. The redesigned flash driver is still a bit naive, it will be expanded with logging and error handling.