### PR TITLE
dts: esp32: fix gpio-reserved-ranges

### DIFF
--- a/dts/xtensa/espressif/esp32/esp32_d0wd_v3.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_d0wd_v3.dtsi
@@ -8,7 +8,7 @@
 
 /* Reserved GPIO pins */
 &gpio0 {
-	gpio-reserved-ranges = <20>,<24>,<28 31>; // NC
+	gpio-reserved-ranges = <20 1>, <24 1>, <28 4>; // NC
 };
 
 /* Add flash or psram on board or application level */

--- a/dts/xtensa/espressif/esp32/esp32_d0wdr2_v3.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_d0wdr2_v3.dtsi
@@ -8,9 +8,9 @@
 
 /* Reserved GPIO pins */
 &gpio0 {
-	gpio-reserved-ranges =	<6 10>, // embeddef psram
-				<11>,	// flash CS
-				<20>,<24>,<28 31>; // NC
+	gpio-reserved-ranges =	<6 5>, // embeddef psram
+				<11 1>,	// flash CS
+				<20 1>, <24 1>, <28 4>; // NC
 };
 
 /* 2MB psram */

--- a/dts/xtensa/espressif/esp32/esp32_net.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_net.dtsi
@@ -8,7 +8,7 @@
 
 /* Reserved GPIO pins */
 &gpio0 {
-	gpio-reserved-ranges = <20>,<24>,<28 31>; // NC
+	gpio-reserved-ranges = <20 1>, <24 1>, <28 4>; // NC
 };
 
 &flash0 {

--- a/dts/xtensa/espressif/esp32/esp32_pico_d4.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_pico_d4.dtsi
@@ -8,8 +8,8 @@
 
 /* Reserved GPIO pins */
 &gpio0 {
-	gpio-reserved-ranges = <6 8>,<11>,<16 17>, // embedded flash
-				<20>, <24>, <28 31>; // NC
+	gpio-reserved-ranges = <6 3>, <11 1>, <16 2>, // embedded flash
+				<20 1>, <24 1>, <28 4>; // NC
 };
 
 /* 4MB flash */

--- a/dts/xtensa/espressif/esp32/esp32_pico_v3.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_pico_v3.dtsi
@@ -8,8 +8,8 @@
 
 /* Reserved GPIO pins */
 &gpio0 {
-	gpio-reserved-ranges = <16 18>,<23>,	// limitations
-				<24>,<28 31>;	// NC
+	gpio-reserved-ranges = <16 3>, <23 1>,	// limitations
+				<24 1>, <28 4>;	// NC
 };
 
 /* 4MB flash */

--- a/dts/xtensa/espressif/esp32/esp32_pico_v3_02.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_pico_v3_02.dtsi
@@ -8,8 +8,8 @@
 
 /* Reserved GPIO pins */
 &gpio0 {
-	gpio-reserved-ranges = <6 11>, // flash
-			<24 25>,<28 31>; // NC
+	gpio-reserved-ranges = <6 6>, // flash
+			<24 2>, <28 4>; // NC
 };
 
 /* 8MB flash */

--- a/dts/xtensa/espressif/esp32/esp32_u4wdh.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_u4wdh.dtsi
@@ -8,7 +8,7 @@
 
 /* Reserved GPIO pins */
 &gpio0 {
-	gpio-reserved-ranges = <20>, <24>, <28 31>;
+	gpio-reserved-ranges = <20 1>, <24 1>, <28 4>;
 };
 
 /* 4MB flash */

--- a/dts/xtensa/espressif/esp32/esp32_wroom_32ue_n16.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wroom_32ue_n16.dtsi
@@ -8,12 +8,12 @@
 
 /* Reserved GPIO pins */
 &gpio0 {
-	gpio-reserved-ranges = <6 11>, // flash
-			<20>, <24>, <28 31>; // NC
+	gpio-reserved-ranges = <6 6>, // flash
+			<20 1>, <24 1>, <28 4>; // NC
 };
 
 &gpio1 {
-	gpio-reserved-ranges = <6>,<7>; // GPIO37-38 NC
+	gpio-reserved-ranges = <6 2>; // GPIO37-38 NC
 };
 
 /* 16MB flash */

--- a/dts/xtensa/espressif/esp32/esp32_wroom_32ue_n4.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wroom_32ue_n4.dtsi
@@ -8,12 +8,12 @@
 
 /* Reserved GPIO pins */
 &gpio0 {
-	gpio-reserved-ranges = <6 11>, // flash
-			<20>,<24>,<28 31>; // NC
+	gpio-reserved-ranges = <6 6>, // flash
+			<20 1>, <24 1>, <28 4>; // NC
 };
 
 &gpio1 {
-	gpio-reserved-ranges = <6>,<7>; // GPIO37-38 NC
+	gpio-reserved-ranges = <6 2>; // GPIO37-38 NC
 };
 
 /* 4MB flash */

--- a/dts/xtensa/espressif/esp32/esp32_wroom_32ue_n8.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wroom_32ue_n8.dtsi
@@ -8,12 +8,12 @@
 
 /* Reserved GPIO pins */
 &gpio0 {
-	gpio-reserved-ranges = <6 11>,	// flash
-			<20>,<24>,<28 31>; // NC
+	gpio-reserved-ranges = <6 6>,	// flash
+			<20 1>, <24 1>, <28 4>; // NC
 };
 
 &gpio1 {
-	gpio-reserved-ranges = <6>,<7>; // GPIO37-38 NC
+	gpio-reserved-ranges = <6 2>; // GPIO37-38 NC
 };
 
 /* 8MB flash */

--- a/dts/xtensa/espressif/esp32/esp32_wroom_da_n16.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wroom_da_n16.dtsi
@@ -8,13 +8,13 @@
 
 /* Reserved GPIO pins */
 &gpio0 {
-	gpio-reserved-ranges = <2>,<25>, // NC/test
-				<6 11>, // flash
-				<20>,<24>,<28 31>; // NC
+	gpio-reserved-ranges = <2 1>, <25 1>, // NC/test
+				<6 6>, // flash
+				<20 1>, <24 1>, <28 4>; // NC
 };
 
 &gpio1 {
-	gpio-reserved-ranges = <6>,<7>; // GPIO37-38 NC
+	gpio-reserved-ranges = <6 2>; // GPIO37-38 NC
 };
 
 /* 16MB flash */

--- a/dts/xtensa/espressif/esp32/esp32_wroom_da_n4.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wroom_da_n4.dtsi
@@ -8,13 +8,13 @@
 
 /* Reserved GPIO pins */
 &gpio0 {
-	gpio-reserved-ranges = <2>,<25>, // NC/test
-				<6 11>, // flash
-				<20>,<24>,<28 31>; // NC
+	gpio-reserved-ranges = <2 1>, <25 1>, // NC/test
+				<6 6>, // flash
+				<20 1>, <24 1>, <28 4>; // NC
 };
 
 &gpio1 {
-	gpio-reserved-ranges = <6>,<7>; // GPIO37-38 NC
+	gpio-reserved-ranges = <6 2>; // GPIO37-38 NC
 };
 
 /* 4MB flash */

--- a/dts/xtensa/espressif/esp32/esp32_wroom_da_n8.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wroom_da_n8.dtsi
@@ -8,13 +8,13 @@
 
 /* Reserved GPIO pins */
 &gpio0 {
-	gpio-reserved-ranges = <2>,<25>, // NC/test
-				<6 11>, // flash
-				<20>,<24>,<28 31>; // NC
+	gpio-reserved-ranges = <2 1>, <25 1>, // NC/test
+				<6 6>, // flash
+				<20 1>, <24 1>, <28 4>; // NC
 };
 
 &gpio1 {
-	gpio-reserved-ranges = <6>,<7>; // GPIO37-38 NC
+	gpio-reserved-ranges = <6 2>; // GPIO37-38 NC
 };
 
 /* 8MB flash */

--- a/dts/xtensa/espressif/esp32/esp32_wrover_e_n16r2.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wrover_e_n16r2.dtsi
@@ -8,12 +8,12 @@
 
 /* Reserved GPIO pins */
 &gpio0 {
-	gpio-reserved-ranges = <6 11>,<16 17>,  // flash&psram
-			<20>,<24>,<28 31>; // NC
+	gpio-reserved-ranges = <6 6>, <16 2>,  // flash&psram
+			<20 1>, <24 1>, <28 4>; // NC
 };
 
 &gpio1 {
-	gpio-reserved-ranges = <6>,<7>; // GPIO37-38 NC
+	gpio-reserved-ranges = <6 2>; // GPIO37-38 NC
 };
 
 /* 16MB flash */

--- a/dts/xtensa/espressif/esp32/esp32_wrover_e_n16r4.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wrover_e_n16r4.dtsi
@@ -8,12 +8,12 @@
 
 /* Reserved GPIO pins */
 &gpio0 {
-	gpio-reserved-ranges = <6 11>,<16 17>,  // flash&psram
-			<20>,<24>,<28 31>; // NC
+	gpio-reserved-ranges = <6 6>, <16 2>,  // flash&psram
+			<20 1>, <24 1>, <28 4>; // NC
 };
 
 &gpio1 {
-	gpio-reserved-ranges = <6>,<7>; // GPIO37-38 NC
+	gpio-reserved-ranges = <6 2>; // GPIO37-38 NC
 };
 
 /* 16MB flash */

--- a/dts/xtensa/espressif/esp32/esp32_wrover_e_n16r8.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wrover_e_n16r8.dtsi
@@ -8,12 +8,12 @@
 
 /* Reserved GPIO pins */
 &gpio0 {
-	gpio-reserved-ranges = <6 11>,<16 17>,  // flash&psram
-			<20>,<24>,<28 31>; // NC
+	gpio-reserved-ranges = <6 6>, <16 2>,  // flash&psram
+			<20 1>, <24 1>, <28 4>; // NC
 };
 
 &gpio1 {
-	gpio-reserved-ranges = <6>,<7>; // GPIO37-38 NC
+	gpio-reserved-ranges = <6 2>; // GPIO37-38 NC
 };
 
 /* 16MB flash */

--- a/dts/xtensa/espressif/esp32/esp32_wrover_e_n4r2.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wrover_e_n4r2.dtsi
@@ -8,12 +8,12 @@
 
 /* Reserved GPIO pins */
 &gpio0 {
-	gpio-reserved-ranges = <6 11>,<16 17>,  // flash&psram
-			<20>,<24>,<28 31>; // NC
+	gpio-reserved-ranges = <6 6>, <16 2>,  // flash&psram
+			<20 1>, <24 1>, <28 4>; // NC
 };
 
 &gpio1 {
-	gpio-reserved-ranges = <6>,<7>; // GPIO37-38 NC
+	gpio-reserved-ranges = <6 1>, <7 1>; // GPIO37-38 NC
 };
 
 /* 4MB flash */

--- a/dts/xtensa/espressif/esp32/esp32_wrover_e_n4r8.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wrover_e_n4r8.dtsi
@@ -8,12 +8,12 @@
 
 /* Reserved GPIO pins */
 &gpio0 {
-	gpio-reserved-ranges = <6 11>,<16 17>,  // flash&psram
-			<20>,<24>,<28 31>; // NC
+	gpio-reserved-ranges = <6 6>, <16 2>,  // flash&psram
+			<20 1>, <24 1>, <28 4>; // NC
 };
 
 &gpio1 {
-	gpio-reserved-ranges = <6>,<7>; // GPIO37-38 NC
+	gpio-reserved-ranges = <6 1>, <7 1>; // GPIO37-38 NC
 };
 
 /* 4MB flash */

--- a/dts/xtensa/espressif/esp32/esp32_wrover_e_n8r2.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wrover_e_n8r2.dtsi
@@ -8,12 +8,12 @@
 
 /* Reserved GPIO pins */
 &gpio0 {
-	gpio-reserved-ranges = <6 11>,<16 17>,  // flash&psram
-			<20>,<24>,<28 31>; // NC
+	gpio-reserved-ranges = <6 6>, <16 2>,  // flash&psram
+			<20 1>, <24 1>, <28 4>; // NC
 };
 
 &gpio1 {
-	gpio-reserved-ranges = <6>,<7>; // GPIO37-38 NC
+	gpio-reserved-ranges = <6 2>; // GPIO37-38 NC
 };
 
 /* 8MB flash */

--- a/dts/xtensa/espressif/esp32/esp32_wrover_e_n8r8.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_wrover_e_n8r8.dtsi
@@ -8,13 +8,13 @@
 
 /* Reserved GPIO pins */
 &gpio0 {
-	gpio-reserved-ranges = <20>, <24>, <28 31>;
-	gpio-reserved-ranges = <6 11>,<16 17>,  // flash&psram
-			<20>,<24>,<28 31>; // NC
+	gpio-reserved-ranges = <20 1>, <24 1>, <28 4>;
+	gpio-reserved-ranges = <6 6>, <16 2>,  // flash&psram
+			<20 1>, <24 1>, <28 4>; // NC
 };
 
 &gpio1 {
-	gpio-reserved-ranges = <6>,<7>; // GPIO37-38 NC
+	gpio-reserved-ranges = <6 2>; // GPIO37-38 NC
 };
 
 /* 8MB flash */


### PR DESCRIPTION
Fixed to follow correct format.

I noticed this issue when working on: https://github.com/zephyrproject-rtos/zephyr/pull/63019