### PR TITLE
drivers: ethernet: fix adin2111 devicetree init to work with adin1110

### DIFF
--- a/drivers/ethernet/eth_adin2111.c
+++ b/drivers/ethernet/eth_adin2111.c
@@ -972,8 +972,8 @@ static const struct ethernet_api adin2111_port_api = {
 	static struct adin2111_data name##_data_##inst = {					\
 		.ifaces_left_to_init = ifaces,							\
 		.port = {},									\
-		.offload_sem = Z_SEM_INITIALIZER(adin2111_data_##inst.offload_sem, 0, 1),	\
-		.lock = Z_MUTEX_INITIALIZER(adin2111_data_##inst.lock),				\
+		.offload_sem = Z_SEM_INITIALIZER(name##_data_##inst.offload_sem, 0, 1),         \
+		.lock = Z_MUTEX_INITIALIZER(name##_data_##inst.lock),				\
 		.buf = name##_buffer_##inst,							\
 	};											\
 	/* adin */										\


### PR DESCRIPTION
The initialisation of the device data struct was giving a build error when using the adi,adin1110 devicetree compatible. Fixed to allow both adi,adin2111 and adi,adin1110 devices to be defined.