### PR TITLE
s32z270dc2_r52: add missing vendor and supported drivers

### DIFF
--- a/boards/arm/s32z270dc2_r52/s32z270dc2_rtu0_r52.yaml
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_rtu0_r52.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 NXP
+# Copyright 2022-2023 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 identifier: s32z270dc2_rtu0_r52
@@ -14,4 +14,6 @@ supported:
   - watchdog
   - netif:eth
   - can
+  - spi
+  - counter
 vendor: nxp

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_rtu0_r52_D.yaml
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_rtu0_r52_D.yaml
@@ -14,3 +14,6 @@ supported:
   - watchdog
   - netif:eth
   - can
+  - spi
+  - counter
+vendor: nxp

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_rtu1_r52.yaml
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_rtu1_r52.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 NXP
+# Copyright 2022-2023 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 identifier: s32z270dc2_rtu1_r52
@@ -14,4 +14,6 @@ supported:
   - watchdog
   - netif:eth
   - can
+  - spi
+  - counter
 vendor: nxp

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_rtu1_r52_D.yaml
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_rtu1_r52_D.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 NXP
+# Copyright 2022-2023 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 identifier: s32z270dc2_rtu1_r52@D
@@ -14,3 +14,6 @@ supported:
   - watchdog
   - netif:eth
   - can
+  - spi
+  - counter
+vendor: nxp


### PR DESCRIPTION
Add missing vendor and supported drivers for the `s32z270dc2_r52` boards.

```
$ west twister -p s32z270dc2_rtu0_r52@D --device-testing --device-serial=/dev/ttyUSB0 -T tests/drivers/spi/ -T tests/drivers/counter/
Renaming output directory to /home/user/zephyrproject/zephyr/twister-out.5
INFO    - Using Ninja..
INFO    - Zephyr version: zephyr-v3.5.0-239-ga5ce568bba5b
INFO    - Using 'zephyr' toolchain.
INFO    - Building initial testsuite list...
INFO    - Writing JSON report /home/user/zephyrproject/zephyr/twister-out/testplan.json

Device testing on:

| Platform              | ID   | Serial device   |
|-----------------------|------|-----------------|
| s32z270dc2_rtu0_r52@D |      | /dev/ttyUSB0    |

INFO    - JOBS: 8
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - Total complete:   29/  29  100%  skipped:   27, failed:    0, error:    0
INFO    - 29 test scenarios (29 test instances) selected, 27 configurations skipped (27 by static filter, 0 at runtime).
INFO    - 2 of 29 test configurations passed (100.00%), 0 failed, 0 errored, 27 skipped with 0 warnings in 46.15 seconds
INFO    - In total 11 test cases were executed, 74 skipped on 1 out of total 627 platforms (0.16%)
INFO    - 2 test configurations executed on platforms, 0 test configurations were only built.

```