### PR TITLE
libC Kconfig: Do not default to picolibc for native_sim due to GETOPT

### DIFF
--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -53,7 +53,7 @@ menu "C Library"
 
 choice LIBC_IMPLEMENTATION
 	prompt "C Library Implementation"
-	default EXTERNAL_LIBC if NATIVE_BUILD && !(NATIVE_LIBRARY && (POSIX_API || GETOPT))
+	default EXTERNAL_LIBC if NATIVE_BUILD && !(NATIVE_LIBRARY && POSIX_API)
 	default PICOLIBC
 	default NEWLIB_LIBC if REQUIRES_FULL_LIBC
 	default MINIMAL_LIBC


### PR DESCRIPTION
Defaulting to picolibc when selecting GETOPT is a bit nicer for users in some cases, but not required.
But too many things require GETOPT (for ex. some SHELL configurations) in combinations with native posix drivers which do not support yet embedded libcs (for ex. the native USB driver) (see https://github.com/zephyrproject-rtos/zephyr/issues/60096 )

Which leads to configurations in those cases which cannot be built. Keep defaulting to the external libC in this case.

This reverts the getop part of this commit:
5f8057e26211e0ce69c782adfbfe511fa27b598d

Fixes #64227