### PR TITLE
intc: nxp_s32: use instance-based DT macros

### DIFF
--- a/drivers/interrupt_controller/intc_eirq_nxp_s32.c
+++ b/drivers/interrupt_controller/intc_eirq_nxp_s32.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT nxp_s32_siul2_eirq
+
 #include <zephyr/irq.h>
 #include <zephyr/sys/sys_io.h>
 #include <zephyr/drivers/pinctrl.h>
@@ -124,23 +126,17 @@ static int eirq_nxp_s32_init(const struct device *dev)
 	return 0;
 }
 
-#define EIRQ_NXP_S32_NODE(n)	DT_NODELABEL(eirq##n)
-
 #define EIRQ_NXP_S32_CALLBACK(line, n)								\
 	void nxp_s32_icu_##n##_eirq_line_##line##_callback(void)				\
 	{											\
-		const struct device *dev = DEVICE_DT_GET(EIRQ_NXP_S32_NODE(n));			\
-												\
-		eirq_nxp_s32_callback(dev, line);						\
+		eirq_nxp_s32_callback(DEVICE_DT_INST_GET(n), line);				\
 	}
 
 #define EIRQ_NXP_S32_CHANNEL_CONFIG(idx, n)							\
 	{											\
 		.hwChannel = idx,								\
-		.digFilterEn = DT_PROP_OR(DT_CHILD(EIRQ_NXP_S32_NODE(n), line_##idx),		\
-						filter_enable, 0),				\
-		.maxFilterCnt = DT_PROP_OR(DT_CHILD(EIRQ_NXP_S32_NODE(n), line_##idx),		\
-						filter_counter, 0),				\
+		.digFilterEn = DT_INST_PROP_OR(DT_CHILD(n, line_##idx), filter_enable, 0),	\
+		.maxFilterCnt = DT_INST_PROP_OR(DT_CHILD(n, line_##idx), filter_counter, 0),	\
 		.intSel = SIUL2_ICU_IRQ,							\
 		.intEdgeSel = SIUL2_ICU_DISABLE,						\
 		.callback = NULL,								\
@@ -155,8 +151,7 @@ static int eirq_nxp_s32_init(const struct device *dev)
 
 #define EIRQ_NXP_S32_INSTANCE_CONFIG(n)								\
 	static const Siul2_Icu_Ip_InstanceConfigType eirq_##n##_instance_nxp_s32_cfg = {	\
-		.intFilterClk = DT_PROP_OR(EIRQ_NXP_S32_NODE(n),				\
-						filter_prescaler, (0)),				\
+		.intFilterClk = DT_INST_PROP_OR(n, filter_prescaler, 0),			\
 		.altIntFilterClk = 0U,								\
 	}
 
@@ -176,42 +171,45 @@ static int eirq_nxp_s32_init(const struct device *dev)
 #define _EIRQ_NXP_S32_IRQ_NAME(name)	DT_CAT3(SIUL2_EXT_IRQ_, name, _ISR)
 
 #define EIRQ_NXP_S32_IRQ_NAME(idx, n)								\
-	COND_CODE_1(DT_NODE_HAS_PROP(EIRQ_NXP_S32_NODE(n), interrupt_names),			\
-		(_EIRQ_NXP_S32_IRQ_NAME(							\
-			DT_STRING_TOKEN_BY_IDX(EIRQ_NXP_S32_NODE(n), interrupt_names, idx))),	\
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, interrupt_names),					\
+		(_EIRQ_NXP_S32_IRQ_NAME(DT_INST_STRING_TOKEN_BY_IDX(n, interrupt_names, idx))),	\
 		(DT_CAT3(SIUL2_, n, _ICU_EIRQ_SINGLE_INT_HANDLER)))
 
 #define _EIRQ_NXP_S32_IRQ_CONFIG(idx, n)							\
 	do {											\
-		IRQ_CONNECT(DT_IRQ_BY_IDX(EIRQ_NXP_S32_NODE(n), idx, irq),			\
-			DT_IRQ_BY_IDX(EIRQ_NXP_S32_NODE(n), idx, priority),			\
+		IRQ_CONNECT(DT_INST_IRQ_BY_IDX(n, idx, irq),					\
+			DT_INST_IRQ_BY_IDX(n, idx, priority),					\
 			EIRQ_NXP_S32_IRQ_NAME(idx, n),						\
-			DEVICE_DT_GET(EIRQ_NXP_S32_NODE(n)),					\
-			COND_CODE_1(CONFIG_GIC,							\
-				(DT_IRQ_BY_IDX(EIRQ_NXP_S32_NODE(n), idx, flags)),		\
-				(0)));								\
-		irq_enable(DT_IRQ_BY_IDX(EIRQ_NXP_S32_NODE(n), idx, irq));			\
+			DEVICE_DT_INST_GET(n),							\
+			COND_CODE_1(CONFIG_GIC, (DT_INST_IRQ_BY_IDX(n, idx, flags)), (0)));	\
+		irq_enable(DT_INST_IRQ_BY_IDX(n, idx, irq));					\
 	} while (false);
 
 #define EIRQ_NXP_S32_IRQ_CONFIG(n)								\
-	LISTIFY(DT_NUM_IRQS(EIRQ_NXP_S32_NODE(n)), _EIRQ_NXP_S32_IRQ_CONFIG, (), n)
+	LISTIFY(DT_NUM_IRQS(DT_DRV_INST(n)), _EIRQ_NXP_S32_IRQ_CONFIG, (), n)
+
+#define EIRQ_NXP_S32_HW_INSTANCE_CHECK(i, n) \
+	(((DT_REG_ADDR(DT_INST_PARENT(n))) == IP_SIUL2_##i##_BASE) ? i : 0)
+
+#define EIRQ_NXP_S32_HW_INSTANCE(n) \
+	LISTIFY(__DEBRACKET SIUL2_INSTANCE_COUNT, EIRQ_NXP_S32_HW_INSTANCE_CHECK, (|), n)
 
 #define EIRQ_NXP_S32_INIT_DEVICE(n)								\
 	EIRQ_NXP_S32_CONFIG(n)									\
-	PINCTRL_DT_DEFINE(EIRQ_NXP_S32_NODE(n));						\
+	PINCTRL_DT_INST_DEFINE(n);								\
 	static const struct eirq_nxp_s32_config eirq_nxp_s32_conf_##n = {			\
-		.instance = n,									\
-		.disr0    = (mem_addr_t)DT_REG_ADDR_BY_NAME(EIRQ_NXP_S32_NODE(n), disr0),	\
-		.direr0   = (mem_addr_t)DT_REG_ADDR_BY_NAME(EIRQ_NXP_S32_NODE(n), direr0),	\
+		.instance = EIRQ_NXP_S32_HW_INSTANCE(n),					\
+		.disr0    = (mem_addr_t)DT_INST_REG_ADDR_BY_NAME(n, disr0),			\
+		.direr0   = (mem_addr_t)DT_INST_REG_ADDR_BY_NAME(n, direr0),			\
 		.icu_cfg  = (Siul2_Icu_Ip_ConfigType *)&eirq_##n##_nxp_s32_cfg,			\
-		.pincfg   = PINCTRL_DT_DEV_CONFIG_GET(EIRQ_NXP_S32_NODE(n))			\
+		.pincfg   = PINCTRL_DT_INST_DEV_CONFIG_GET(n)					\
 	};											\
 	static struct eirq_nxp_s32_cb eirq_nxp_s32_cb_##n[NXP_S32_NUM_CHANNELS];		\
 	static struct eirq_nxp_s32_data eirq_nxp_s32_data_##n = {				\
 		.cb = eirq_nxp_s32_cb_##n,							\
 	};											\
 	static int eirq_nxp_s32_init##n(const struct device *dev);				\
-	DEVICE_DT_DEFINE(EIRQ_NXP_S32_NODE(n),							\
+	DEVICE_DT_INST_DEFINE(n,								\
 		eirq_nxp_s32_init##n,								\
 		NULL,										\
 		&eirq_nxp_s32_data_##n,								\
@@ -233,18 +231,4 @@ static int eirq_nxp_s32_init(const struct device *dev)
 		return 0;									\
 	}
 
-#if DT_NODE_HAS_STATUS(EIRQ_NXP_S32_NODE(0), okay)
-EIRQ_NXP_S32_INIT_DEVICE(0)
-#endif
-
-#if DT_NODE_HAS_STATUS(EIRQ_NXP_S32_NODE(1), okay)
-EIRQ_NXP_S32_INIT_DEVICE(1)
-#endif
-
-#if DT_NODE_HAS_STATUS(EIRQ_NXP_S32_NODE(4), okay)
-EIRQ_NXP_S32_INIT_DEVICE(4)
-#endif
-
-#if DT_NODE_HAS_STATUS(EIRQ_NXP_S32_NODE(5), okay)
-EIRQ_NXP_S32_INIT_DEVICE(5)
-#endif
+DT_INST_FOREACH_STATUS_OKAY(EIRQ_NXP_S32_INIT_DEVICE)

--- a/soc/arm/nxp_s32/s32k/soc.h
+++ b/soc/arm/nxp_s32/s32k/soc.h
@@ -18,4 +18,9 @@
 #undef FALSE
 #endif
 
+/* Aliases for peripheral base addresses */
+
+/* SIUL2 */
+#define IP_SIUL2_0_BASE         IP_SIUL2_BASE
+
 #endif /* _NXP_S32_S32K_SOC_H_ */

--- a/soc/arm/nxp_s32/s32ze/soc.h
+++ b/soc/arm/nxp_s32/s32ze/soc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 NXP
+ * Copyright 2022-2023 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -9,5 +9,10 @@
 
 /* Do not let CMSIS to handle GIC */
 #define __GIC_PRESENT 0
+
+/* Aliases for peripheral base addresses */
+
+/* SIUL2 */
+#define IP_SIUL2_2_BASE         0U  /* instance does not exist on this SoC */
 
 #endif /* _NXP_S32_S32ZE_SOC_H_ */

--- a/west.yml
+++ b/west.yml
@@ -193,7 +193,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 361ccc5962dfc691f6134d73605fed063c4d26cd
+      revision: 3731aefd0cd55f8507498c336b3256268ecd9d61
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
At present, many of the NXP S32 shim drivers do not make use of devicetree instance-based macros because the NXP S32 HAL relies on an index-based approach, requiring knowledge of the peripheral instance index during both compilation and runtime, and this index might not align with the devicetree instance index.

The proposed solution in this patch eliminates this limitation by determining the peripheral instance index during compilation through macrobatics and defining the driver's ISR within the shim driver itself.

Note that for some peripheral instances is needed to define the HAL macros of the peripheral base address because there are gaps in the instances or there are SoCs with a single instance.

```
$ west twister -p mr_canhubk3 --device-testing --device-serial=/dev/ttyUSB1 -T tests/drivers/gpio --fixture gpio_loopback
INFO    - Using Ninja..
INFO    - Zephyr version: zephyr-v3.5.0-239-gceaab19ab566
INFO    - Using 'zephyr' toolchain.
INFO    - Building initial testsuite list...
INFO    - Writing JSON report /home/user/zephyrproject/zephyr/twister-out/testplan.json

Device testing on:

| Platform    | ID   | Serial device   |
|-------------|------|-----------------|
| mr_canhubk3 |      | /dev/ttyUSB1    |

INFO    - JOBS: 8
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - Total complete:    8/   8  100%  skipped:    3, failed:    0, error:    0
INFO    - 8 test scenarios (8 test instances) selected, 3 configurations skipped (2 by static filter, 1 at runtime).
INFO    - 5 of 8 test configurations passed (100.00%), 0 failed, 0 errored, 3 skipped with 0 warnings in 124.27 seconds
INFO    - In total 41 test cases were executed, 19 skipped on 1 out of total 627 platforms (0.16%)
INFO    - 5 test configurations executed on platforms, 0 test configurations were only built.

$ west twister -p s32z270dc2_rtu0_r52@D --device-testing --device-serial=/dev/ttyUSB0 -T tests/drivers/gpio --fixture gpio_loopback
INFO    - Using Ninja..
INFO    - Zephyr version: zephyr-v3.5.0-239-gceaab19ab566
INFO    - Using 'zephyr' toolchain.
INFO    - Building initial testsuite list...
INFO    - Writing JSON report /home/user/zephyrproject/zephyr/twister-out/testplan.json

Device testing on:

| Platform              | ID   | Serial device   |
|-----------------------|------|-----------------|
| s32z270dc2_rtu0_r52@D |      | /dev/ttyUSB0    |

INFO    - JOBS: 8
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - Total complete:    8/   8  100%  skipped:    5, failed:    0, error:    0
INFO    - 8 test scenarios (8 test instances) selected, 5 configurations skipped (4 by static filter, 1 at runtime).
INFO    - 3 of 8 test configurations passed (100.00%), 0 failed, 0 errored, 5 skipped with 0 warnings in 57.86 seconds
INFO    - In total 30 test cases were executed, 30 skipped on 1 out of total 627 platforms (0.16%)
INFO    - 3 test configurations executed on platforms, 0 test configurations were only built.
```