### PR TITLE
samples posix uname: Fix sample yaml filtering

### DIFF
--- a/samples/posix/uname/sample.yaml
+++ b/samples/posix/uname/sample.yaml
@@ -3,9 +3,11 @@ sample:
   name: posix uname
 common:
   tags: posix
-  filter: not CONFIG_ARCH_POSIX
-  integration_platforms:
+  platform_exclude:
+    - native_posix
     - native_posix_64
+  integration_platforms:
+    - native_sim
     - qemu_riscv64
   harness: console
   harness_config:


### PR DESCRIPTION
The sample was at the same time filtered for the whole posix architecture and had native_posix as its integration platform. This is selfcontradictory.

In any case, this sample cannot run in native_posix but can run in native_sim.
So let's fix the filtering.