### PR TITLE
cmake: extra_flags: Use zephyr_get

### DIFF
--- a/cmake/extra_flags.cmake
+++ b/cmake/extra_flags.cmake
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 foreach(extra_flags EXTRA_CPPFLAGS EXTRA_LDFLAGS EXTRA_CFLAGS EXTRA_CXXFLAGS EXTRA_AFLAGS)
+  # Note: zephyr_get MERGE should not be used until issue #43959 is resolved.
+  zephyr_get(${extra_flags})
   list(LENGTH ${extra_flags} flags_length)
   if(flags_length LESS_EQUAL 1)
     # A length of zero means no argument.


### PR DESCRIPTION
This allows users to set `EXTRA_*FLAGS` variables when using sysbuild.

If these flags are provided in both local and global sysbuild scopes, then only the local ones will be used for a given image. This is to circumvent issues with mixing space-separated and `;`-separated lists.