### PR TITLE
net: Fix NULL LL address pointer dereference on packet socket

### DIFF
--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -211,6 +211,15 @@ static void init_rx_queues(void)
 /* Check if the IPv{4|6} addresses are proper. As this can be expensive,
  * make this optional.
  */
+
+static inline void copy_ll_addr(struct net_pkt *pkt)
+{
+	memcpy(net_pkt_lladdr_src(pkt), net_pkt_lladdr_if(pkt),
+	       sizeof(struct net_linkaddr));
+	memcpy(net_pkt_lladdr_dst(pkt), net_pkt_lladdr_if(pkt),
+	       sizeof(struct net_linkaddr));
+}
+
 static inline int check_ip_addr(struct net_pkt *pkt)
 {
 	uint8_t family = net_pkt_family(pkt);
@@ -238,6 +247,9 @@ static inline int check_ip_addr(struct net_pkt *pkt)
 			net_ipv6_addr_copy_raw(NET_IPV6_HDR(pkt)->src,
 					       NET_IPV6_HDR(pkt)->dst);
 			net_ipv6_addr_copy_raw(NET_IPV6_HDR(pkt)->dst, (uint8_t *)&addr);
+
+			net_pkt_set_ll_proto_type(pkt, ETH_P_IPV6);
+			copy_ll_addr(pkt);
 
 			return 1;
 		}
@@ -285,6 +297,9 @@ static inline int check_ip_addr(struct net_pkt *pkt)
 			net_ipv4_addr_copy_raw(NET_IPV4_HDR(pkt)->src,
 					       NET_IPV4_HDR(pkt)->dst);
 			net_ipv4_addr_copy_raw(NET_IPV4_HDR(pkt)->dst, (uint8_t *)&addr);
+
+			net_pkt_set_ll_proto_type(pkt, ETH_P_IP);
+			copy_ll_addr(pkt);
 
 			return 1;
 		}

--- a/subsys/net/lib/shell/ping.c
+++ b/subsys/net/lib/shell/ping.c
@@ -259,6 +259,12 @@ static void ping_work(struct k_work *work)
 		return;
 	}
 
+	if (ctx->sequence < ctx->count) {
+		k_work_reschedule(&ctx->work, K_MSEC(ctx->interval));
+	} else {
+		k_work_reschedule(&ctx->work, K_SECONDS(2));
+	}
+
 	params.identifier = sys_rand32_get();
 	params.sequence = ctx->sequence;
 	params.tc_tos = ctx->tos;
@@ -275,12 +281,6 @@ static void ping_work(struct k_work *work)
 		PR_WARNING("Failed to send ping, err: %d", ret);
 		ping_done(ctx);
 		return;
-	}
-
-	if (ctx->sequence < ctx->count) {
-		k_work_reschedule(&ctx->work, K_MSEC(ctx->interval));
-	} else {
-		k_work_reschedule(&ctx->work, K_SECONDS(2));
 	}
 }
 


### PR DESCRIPTION
In case packet is looped back to the stack, set LL address information
on the packet, using the LL address set on the corresponding network
interface, so that the information can be interpreted by the SOCK_DGRAM
packet socket.