### PR TITLE
Bluetooth: ISO: Minor fixes for ISO shell

### DIFF
--- a/subsys/bluetooth/shell/iso.c
+++ b/subsys/bluetooth/shell/iso.c
@@ -24,6 +24,8 @@
 
 #include "bt.h"
 
+#define TX_BUF_TIMEOUT K_SECONDS(1)
+
 static uint32_t cis_sn_last;
 static uint32_t bis_sn_last;
 static int64_t cis_sn_last_updated_ticks;
@@ -131,7 +133,7 @@ struct bt_iso_chan iso_chan = {
 };
 
 NET_BUF_POOL_FIXED_DEFINE(tx_pool, 1, BT_ISO_SDU_BUF_SIZE(CONFIG_BT_ISO_TX_MTU),
-			  8, NULL);
+			  CONFIG_BT_CONN_TX_USER_DATA_SIZE, NULL);
 
 #if defined(CONFIG_BT_ISO_CENTRAL)
 static struct bt_iso_cig *cig;
@@ -139,7 +141,7 @@ static struct bt_iso_cig *cig;
 static int cmd_cig_create(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err;
-	struct bt_iso_cig_param param;
+	struct bt_iso_cig_param param = {0};
 	struct bt_iso_chan *chans[CIS_ISO_CHAN_COUNT];
 
 	if (cig != NULL) {
@@ -504,11 +506,16 @@ static int cmd_send(const struct shell *sh, size_t argc, char *argv[])
 				  cis_sdu_interval_us);
 
 	while (count--) {
-		buf = net_buf_alloc(&tx_pool, K_FOREVER);
+		buf = net_buf_alloc(&tx_pool, TX_BUF_TIMEOUT);
+		if (buf == NULL) {
+			shell_error(sh, "Failed to get buffer...");
+			return -ENOEXEC;
+		}
+
 		net_buf_reserve(buf, BT_ISO_CHAN_SEND_RESERVE);
 
 		net_buf_add_mem(buf, buf_data, len);
-		shell_info(sh, "send: %d bytes of data", len);
+		shell_info(sh, "send: %d bytes of data with PSN %u", len, cis_sn_last);
 		ret = bt_iso_chan_send(&iso_chan, buf, cis_sn_last,
 				       BT_ISO_TIMESTAMP_NONE);
 		if (ret < 0) {
@@ -612,23 +619,25 @@ static int cmd_broadcast(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	len = MIN(bis_iso_chan.qos->tx->sdu, CONFIG_BT_ISO_TX_MTU);
-
 	bis_sn_last = get_next_sn(bis_sn_last, &bis_sn_last_updated_ticks,
 				  bis_sdu_interval_us);
 
 	while (count--) {
-		for (int i = 0; i < BIS_ISO_CHAN_COUNT; i++) {
-			buf = net_buf_alloc(&bis_tx_pool, K_FOREVER);
-			net_buf_reserve(buf, BT_ISO_CHAN_SEND_RESERVE);
+		buf = net_buf_alloc(&bis_tx_pool, TX_BUF_TIMEOUT);
+		if (buf == NULL) {
+			shell_error(sh, "Failed to get buffer...");
+			return -ENOEXEC;
+		}
 
-			net_buf_add_mem(buf, buf_data, len);
-			ret = bt_iso_chan_send(&bis_iso_chan, buf, bis_sn_last,
-					       BT_ISO_TIMESTAMP_NONE);
-			if (ret < 0) {
-				shell_print(sh, "[%i]: Unable to broadcast: %d", i, -ret);
-				net_buf_unref(buf);
-				return -ENOEXEC;
-			}
+		net_buf_reserve(buf, BT_ISO_CHAN_SEND_RESERVE);
+
+		net_buf_add_mem(buf, buf_data, len);
+		shell_info(sh, "send: %d bytes of data with PSN %u", len, bis_sn_last);
+		ret = bt_iso_chan_send(&bis_iso_chan, buf, bis_sn_last, BT_ISO_TIMESTAMP_NONE);
+		if (ret < 0) {
+			shell_print(sh, "Unable to broadcast: %d", -ret);
+			net_buf_unref(buf);
+			return -ENOEXEC;
 		}
 	}
 
@@ -640,7 +649,7 @@ static int cmd_broadcast(const struct shell *sh, size_t argc, char *argv[])
 static int cmd_big_create(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err;
-	struct bt_iso_big_create_param param;
+	struct bt_iso_big_create_param param = {0};
 	struct bt_le_ext_adv *adv = adv_sets[selected_adv];
 
 	if (!adv) {


### PR DESCRIPTION
If CONFIG_BT_ISO_TEST_PARAMS=y then the CIG and BIG create params was not properly initialized.

Modified the TX for BIS and CIS to be more similar

Added a timeout on the buffer to avoid any potentional deadlocks.