### PR TITLE
net: shell: fix compilation errors

### DIFF
--- a/subsys/net/lib/shell/resume.c
+++ b/subsys/net/lib/shell/resume.c
@@ -6,6 +6,7 @@
  */
 
 #include <zephyr/logging/log.h>
+#include <zephyr/pm/device.h>
 LOG_MODULE_DECLARE(net_shell);
 
 #include "common.h"

--- a/subsys/net/lib/shell/suspend.c
+++ b/subsys/net/lib/shell/suspend.c
@@ -6,6 +6,7 @@
  */
 
 #include <zephyr/logging/log.h>
+#include <zephyr/pm/device.h>
 LOG_MODULE_DECLARE(net_shell);
 
 #include "common.h"


### PR DESCRIPTION
`suspend.c` and `resume.c` are missing the `zephyr/pm/device.h`, add that to fix compilation warning:

```
.802154.rf2xx.arduino-mba:zephyrproject ycsin$ west build -b frdm_k64f -p auto -T zephyr/samples/net/sockets/echo_server/sample.net.sockets.echo_serve.
-- west build: generating a build system
Loading Zephyr default modules (Zephyr base (cached)).
-- Application: /Users/ycsin/zephyrproject/zephyr/samples/net/sockets/echo_server
-- CMake version: 3.26.3
-- Cache files will be written to: /Users/ycsin/Library/Caches/zephyr
-- Zephyr version: 3.5.99 (/Users/ycsin/zephyrproject/zephyr)
-- Found west (found suitable version "1.0.0", minimum required is "0.14.0")
-- Board: frdm_k64f
-- Shield(s): atmel_rf2xx_arduino
-- Found host-tools: zephyr 0.16.1 (/Users/ycsin/zephyr-sdk-0.16.1)
-- Found toolchain: zephyr 0.16.1 (/Users/ycsin/zephyr-sdk-0.16.1)
-- Found BOARD.dts: /Users/ycsin/zephyrproject/zephyr/boards/arm/frdm_k64f/frdm_k64f.dts
-- Found devicetree overlay: /Users/ycsin/zephyrproject/zephyr/boards/shields/atmel_rf2xx/atmel_rf2xx_arduino.overlay
-- Generated zephyr.dts: /Users/ycsin/zephyrproject/build/zephyr/zephyr.dts
-- Generated devicetree_generated.h: /Users/ycsin/zephyrproject/build/zephyr/include/generated/devicetree_generated.h
-- Including generated dts.cmake file: /Users/ycsin/zephyrproject/build/zephyr/dts.cmake
Parsing /Users/ycsin/zephyrproject/zephyr/samples/net/sockets/echo_server/Kconfig
Loaded configuration '/Users/ycsin/zephyrproject/build/zephyr/.config'
No change to configuration in '/Users/ycsin/zephyrproject/build/zephyr/.config'
No change to Kconfig header in '/Users/ycsin/zephyrproject/build/zephyr/include/generated/autoconf.h'
Load components for MK64F12:
driver_common component is included.
driver_reset component is included.
device_CMSIS component is included.
CMSIS_Include_core_cm component is included.
device_system component is included.
driver_rnga component is included.
driver_dspi component is included.
driver_uart component is included.
driver_enet component is included.
driver_port component is included.
driver_sysmpu component is included.
-- Configuring done (9.5s)
-- Generating done (1.3s)
-- Build files have been written to: /Users/ycsin/zephyrproject/build
-- west build: building application
[2/16] Generating include/generated/version.h
-- Zephyr version: 3.5.99 (/Users/ycsin/zephyrproject/zephyr), build: zephyr-v3.4.0-5710-g7cf4eff73141
[8/16] Building C object zephyr/subsys/net/CMakeFiles/subsys__net.dir/lib/shell/suspend.c.obj
FAILED: zephyr/subsys/net/CMakeFiles/subsys__net.dir/lib/shell/suspend.c.obj 
ccache /Users/ycsin/zephyr-sdk-0.16.1/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc -DCPU_MK64FN1M0VLL12 -DKERNEL -DNDEBUG -DPICOLIBC_INTEGER_PRINTF_SCANF -c
/Users/ycsin/zephyrproject/zephyr/subsys/net/lib/shell/suspend.c: In function 'cmd_net_suspend':
/Users/ycsin/zephyrproject/zephyr/subsys/net/lib/shell/suspend.c:35:23: warning: implicit declaration of function 'pm_device_action_run' [-Wimplicit-f]
   35 |                 ret = pm_device_action_run(dev, PM_DEVICE_ACTION_SUSPEND);
      |                       ^~~~~~~~~~~~~~~~~~~~
/Users/ycsin/zephyrproject/zephyr/subsys/net/lib/shell/suspend.c:35:49: error: 'PM_DEVICE_ACTION_SUSPEND' undeclared (first use in this function)
   35 |                 ret = pm_device_action_run(dev, PM_DEVICE_ACTION_SUSPEND);
      |                                                 ^~~~~~~~~~~~~~~~~~~~~~~~
/Users/ycsin/zephyrproject/zephyr/subsys/net/lib/shell/suspend.c:35:49: note: each undeclared identifier is reported only once for each function it apn
[9/16] Building C object zephyr/subsys/net/CMakeFiles/subsys__net.dir/lib/shell/resume.c.obj
FAILED: zephyr/subsys/net/CMakeFiles/subsys__net.dir/lib/shell/resume.c.obj 
ccache /Users/ycsin/zephyr-sdk-0.16.1/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc -DCPU_MK64FN1M0VLL12 -DKERNEL -DNDEBUG -DPICOLIBC_INTEGER_PRINTF_SCANF -c
/Users/ycsin/zephyrproject/zephyr/subsys/net/lib/shell/resume.c: In function 'cmd_net_resume':
/Users/ycsin/zephyrproject/zephyr/subsys/net/lib/shell/resume.c:35:23: warning: implicit declaration of function 'pm_device_action_run' [-Wimplicit-fu]
   35 |                 ret = pm_device_action_run(dev, PM_DEVICE_ACTION_RESUME);
      |                       ^~~~~~~~~~~~~~~~~~~~
/Users/ycsin/zephyrproject/zephyr/subsys/net/lib/shell/resume.c:35:49: error: 'PM_DEVICE_ACTION_RESUME' undeclared (first use in this function); did y?
   35 |                 ret = pm_device_action_run(dev, PM_DEVICE_ACTION_RESUME);
      |                                                 ^~~~~~~~~~~~~~~~~~~~~~~
      |                                                 Z_DEVICE_SECTION_NAME
/Users/ycsin/zephyrproject/zephyr/subsys/net/lib/shell/resume.c:35:49: note: each undeclared identifier is reported only once for each function it appn
[10/16] Linking C static library zephyr/kernel/libkernel.a
ninja: build stopped: subcommand failed.
FATAL ERROR: command exited with status 1: /Users/ycsin/homebrew/bin/cmake --build /Users/ycsin/zephyrproject/build
```