### PR TITLE
Bluetooth: BAP: Shell: Fixed cmd_stream_qos and cmd_sync_broadcast

### DIFF
--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -1157,7 +1157,7 @@ static int cmd_stream_qos(const struct shell *sh, size_t argc, char *argv[])
 {
 	struct bt_audio_codec_qos *qos;
 	unsigned long interval;
-	int err;
+	int err = 0;
 
 	if (default_stream == NULL) {
 		shell_print(sh, "No stream selected");
@@ -2276,7 +2276,7 @@ static int cmd_sync_broadcast(const struct shell *sh, size_t argc, char *argv[])
 	struct bt_bap_stream *streams[ARRAY_SIZE(broadcast_sink_streams)];
 	uint32_t bis_bitfield;
 	size_t stream_cnt;
-	int err;
+	int err = 0;
 
 	bis_bitfield = 0;
 	stream_cnt = 0U;


### PR DESCRIPTION
Added missing initializer for int err.