### PR TITLE
tests/posix/common & fs: Fix timer test and improve filtering for POSIX arch

### DIFF
--- a/tests/posix/common/testcase.yaml
+++ b/tests/posix/common/testcase.yaml
@@ -2,8 +2,10 @@ common:
   filter: not (CONFIG_NATIVE_BUILD and CONFIG_EXTERNAL_LIBC)
   # FIXME: qemu_leon3 is excluded because of the alignment-related failure
   #        reported in the GitHub issue zephyrproject-rtos/zephyr#48992.
-  arch_exclude: posix
-  platform_exclude: qemu_leon3
+  platform_exclude:
+    - qemu_leon3
+    - native_posix
+    - native_posix_64
   tags: posix
   min_ram: 64
   timeout: 240
@@ -24,6 +26,8 @@ tests:
     filter: TOOLCHAIN_HAS_NEWLIB == 1
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
+    arch_exclude:
+      - posix
     integration_platforms:
       - qemu_x86
   portability.posix.common.armclang_std_libc:
@@ -51,6 +55,8 @@ tests:
       - lpcxpresso55s06
     filter: TOOLCHAIN_HAS_NEWLIB == 1 and CONFIG_ARCH_HAS_THREAD_LOCAL_STORAGE and
       CONFIG_TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE
+    arch_exclude:
+      - posix
     integration_platforms:
       - qemu_x86
     extra_configs:

--- a/tests/posix/fs/testcase.yaml
+++ b/tests/posix/fs/testcase.yaml
@@ -2,6 +2,9 @@ common:
   filter: not (CONFIG_NATIVE_BUILD and CONFIG_EXTERNAL_LIBC)
   arch_exclude:
     - nios2
+  platform_exclude:
+    - native_posix
+    - native_posix_64
   tags:
     - posix
     - filesystem
@@ -17,6 +20,8 @@ tests:
       - qemu_x86
   portability.posix.fs.newlib:
     filter: TOOLCHAIN_HAS_NEWLIB == 1
+    arch_exclude:
+      - posix
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
     integration_platforms:
@@ -31,6 +36,8 @@ tests:
   portability.posix.fs.tls.newlib:
     filter: TOOLCHAIN_HAS_NEWLIB == 1 and CONFIG_ARCH_HAS_THREAD_LOCAL_STORAGE and
       CONFIG_TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE
+    arch_exclude:
+      - posix
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
       - CONFIG_THREAD_LOCAL_STORAGE=y


### PR DESCRIPTION
    tests posix timer: Fix timer check
    
    The timer check does not work properly for platforms
    which have a system tick timer with a period that
    does not properly divide the configured time interval.
    
    In those, depending on when the timer is started and
    stopped, one signal less may be received.
    
    This is for example the case for nrf5x platforms,
    where the system tick timer is driven by a 32.768KHz
    clock.
    
    => Correct the test, to accept receiving 1 signal
    too little during the wait.

-----

    tests/posix/common: Fix filtering for POSIX arch
    
    All these tests where filtered for the whole POSIX
    architecture, but quite a few of them can be run in
    native_sim.
    So let's filter out native_posix(_64) in general,
    (allowing other native simulator based targes),
    and filter for thsi arch out explicitly the 2 tests
    which need NEWLIB as this arch does not provide it.
----------
    
    tests/posix/fs: Improve filtering around posix arch
    
    These tests cannot be run on the native_posix(_64) targets,
    so let's filter them explicitly. Before they were filtered
    due to the "filter", but using platform_exclude is faster.
    
    Also the tests that depend on newlib cannot be run
    in this architecture at all, so let's filter them by
    architecture too.