### PR TITLE
tests/samples: Better filtering for the POSIX architecture

### DIFF
--- a/samples/subsys/logging/logger/sample.yaml
+++ b/samples/subsys/logging/logger/sample.yaml
@@ -22,6 +22,8 @@ tests:
       - frdm_k64f
     tags: logging
     filter: CONFIG_HAS_SEGGER_RTT
+    arch_exclude:
+      - posix
     harness: keyboard
     extra_configs:
       - CONFIG_LOG_BACKEND_RTT=y
@@ -30,6 +32,8 @@ tests:
   sample.logger.usermode:
     integration_platforms:
       - mps2_an385
+    arch_exclude:
+      - posix
     tags:
       - logging
       - usermode

--- a/samples/userspace/hello_world_user/sample.yaml
+++ b/samples/userspace/hello_world_user/sample.yaml
@@ -14,4 +14,6 @@ common:
 tests:
   sample.helloworld:
     filter: CONFIG_ARCH_HAS_USERSPACE
+    arch_exclude:
+      - posix
     tags: introduction

--- a/samples/userspace/prod_consumer/sample.yaml
+++ b/samples/userspace/prod_consumer/sample.yaml
@@ -13,3 +13,5 @@ common:
 tests:
   sample.userspace.prod_consumer:
     filter: CONFIG_ARCH_HAS_USERSPACE
+    arch_exclude:
+      - posix

--- a/samples/userspace/shared_mem/sample.yaml
+++ b/samples/userspace/shared_mem/sample.yaml
@@ -14,6 +14,8 @@ common:
 tests:
   sample.kernel.memory_protection.shared_mem:
     filter: CONFIG_ARCH_HAS_USERSPACE
+    arch_exclude:
+      - posix
     platform_exclude:
       - twr_ke18f
       - cy8cproto_062_4343w

--- a/tests/benchmarks/cmsis_dsp/basicmath/testcase.yaml
+++ b/tests/benchmarks/cmsis_dsp/basicmath/testcase.yaml
@@ -1,27 +1,24 @@
+common:
+  arch_allow: arm
+  filter: (CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB
+    == 1
+  tags:
+    - benchmark
+    - cmsis_dsp
+  min_flash: 128
+  min_ram: 64
 tests:
   benchmark.cmsis_dsp.basicmath:
-    filter: (CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB
-      == 1
     integration_platforms:
       - frdm_k64f
       - sam_e70_xplained
       - mps2_an521
-    tags:
-      - benchmark
-      - cmsis_dsp
-    min_flash: 128
-    min_ram: 64
   benchmark.cmsis_dsp.basicmath.fpu:
-    filter: (CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU
-      and TOOLCHAIN_HAS_NEWLIB == 1
+    filter: CONFIG_CPU_HAS_FPU
     integration_platforms:
       - mps2_an521_remote
       - mps3_an547
     tags:
-      - benchmark
-      - cmsis_dsp
       - fpu
     extra_configs:
       - CONFIG_FPU=y
-    min_flash: 128
-    min_ram: 64

--- a/tests/benchmarks/sched_userspace/testcase.yaml
+++ b/tests/benchmarks/sched_userspace/testcase.yaml
@@ -7,6 +7,8 @@ tests:
       - userspace
     slow: true
     filter: CONFIG_ARCH_HAS_USERSPACE
+    arch_exclude:
+      - posix
     harness: console
     harness_config:
       type: multi_line

--- a/tests/drivers/coredump/coredump_api/testcase.yaml
+++ b/tests/drivers/coredump/coredump_api/testcase.yaml
@@ -33,6 +33,8 @@ tests:
   debug.coredump.drivers.api:
     filter: CONFIG_ARCH_SUPPORTS_COREDUMP
     platform_exclude: qemu_riscv32
+    arch_exclude:
+      - posix
     harness: console
     integration_platforms:
       - qemu_x86

--- a/tests/kernel/events/sys_event/testcase.yaml
+++ b/tests/kernel/events/sys_event/testcase.yaml
@@ -1,6 +1,8 @@
 tests:
   kernel.events.usage:
     filter: CONFIG_ARCH_HAS_USERSPACE
+    arch_exclude:
+      - posix
     tags:
       - kernel
       - userspace

--- a/tests/kernel/fatal/exception/testcase.yaml
+++ b/tests/kernel/fatal/exception/testcase.yaml
@@ -5,6 +5,8 @@ tests:
     extra_args: CONF_FILE=prj.conf
     platform_exclude: twr_ke18f
     filter: CONFIG_ARCH_HAS_STACK_PROTECTION
+    arch_exclude:
+      - posix
     tags:
       - kernel
       - userspace
@@ -18,6 +20,7 @@ tests:
   kernel.common.stack_protection_arm_fpu_sharing:
     extra_args: CONF_FILE=prj_arm_fpu_sharing.conf
     platform_exclude: twr_ke18f
+    arch_allow: arm
     filter: CONFIG_ARCH_HAS_STACK_PROTECTION and CONFIG_ARMV7_M_ARMV8_M_FP
     tags:
       - fpu

--- a/tests/kernel/mem_protect/futex/testcase.yaml
+++ b/tests/kernel/mem_protect/futex/testcase.yaml
@@ -1,6 +1,8 @@
 tests:
   kernel.futex:
     filter: CONFIG_ARCH_HAS_USERSPACE
+    arch_exclude:
+      - posix
     tags:
       - kernel
       - userspace

--- a/tests/kernel/mem_protect/mem_protect/testcase.yaml
+++ b/tests/kernel/mem_protect/mem_protect/testcase.yaml
@@ -7,6 +7,8 @@ common:
 tests:
   kernel.memory_protection:
     filter: CONFIG_ARCH_HAS_USERSPACE
+    arch_exclude:
+      - posix
     platform_exclude: twr_ke18f
     extra_args:
       - CONFIG_TEST_HW_STACK_PROTECTION=n

--- a/tests/kernel/mem_protect/obj_validation/testcase.yaml
+++ b/tests/kernel/mem_protect/obj_validation/testcase.yaml
@@ -1,6 +1,8 @@
 tests:
   kernel.memory_protection.obj_validation:
     filter: CONFIG_ARCH_HAS_USERSPACE
+    arch_exclude:
+      - posix
     tags:
       - kernel
       - security

--- a/tests/kernel/mem_protect/stack_random/testcase.yaml
+++ b/tests/kernel/mem_protect/stack_random/testcase.yaml
@@ -1,6 +1,7 @@
 tests:
   kernel.memory_protection.stack_random:
-    arch_exclude: posix
+    arch_exclude:
+      - posix
     tags:
       - kernel
       - memory_protection

--- a/tests/kernel/mem_protect/sys_sem/testcase.yaml
+++ b/tests/kernel/mem_protect/sys_sem/testcase.yaml
@@ -1,6 +1,8 @@
 tests:
   kernel.memory_protection.sys_sem:
     filter: CONFIG_ARCH_HAS_USERSPACE
+    arch_exclude:
+      - posix
     tags:
       - kernel
       - userspace

--- a/tests/kernel/mem_protect/syscalls/testcase.yaml
+++ b/tests/kernel/mem_protect/syscalls/testcase.yaml
@@ -2,6 +2,8 @@ tests:
   kernel.memory_protection.syscalls:
     platform_exclude: qemu_arc_em
     filter: CONFIG_ARCH_HAS_USERSPACE
+    arch_exclude:
+      - posix
     tags:
       - kernel
       - security

--- a/tests/kernel/mem_protect/userspace/testcase.yaml
+++ b/tests/kernel/mem_protect/userspace/testcase.yaml
@@ -4,6 +4,8 @@ common:
     - kernel
     - security
     - userspace
+  arch_exclude:
+    - posix
 tests:
   kernel.memory_protection.userspace:
     filter: CONFIG_ARCH_HAS_USERSPACE

--- a/tests/kernel/mutex/mutex_error_case/testcase.yaml
+++ b/tests/kernel/mutex/mutex_error_case/testcase.yaml
@@ -1,6 +1,8 @@
 tests:
   kernel.mutex.error:
     filter: CONFIG_ARCH_HAS_USERSPACE
+    arch_exclude:
+      - posix
     tags:
       - kernel
       - userspace

--- a/tests/kernel/mutex/sys_mutex/testcase.yaml
+++ b/tests/kernel/mutex/sys_mutex/testcase.yaml
@@ -1,11 +1,12 @@
 tests:
   kernel.mutex.system:
     filter: CONFIG_ARCH_HAS_USERSPACE
+    arch_exclude:
+      - posix
     tags:
       - kernel
       - userspace
       - mutex
-
   kernel.mutex.system.nouser:
     tags:
       - kernel

--- a/tests/kernel/semaphore/sys_sem/testcase.yaml
+++ b/tests/kernel/semaphore/sys_sem/testcase.yaml
@@ -1,6 +1,8 @@
 tests:
   kernel.semaphore.usage:
     filter: CONFIG_ARCH_HAS_USERSPACE
+    arch_exclude:
+      - posix
     tags:
       - kernel
       - userspace

--- a/tests/kernel/threads/dynamic_thread/testcase.yaml
+++ b/tests/kernel/threads/dynamic_thread/testcase.yaml
@@ -6,5 +6,7 @@ tests:
       - userspace
     ignore_faults: true
     filter: CONFIG_ARCH_HAS_USERSPACE
+    arch_exclude:
+      - posix
     integration_platforms:
       - qemu_x86

--- a/tests/kernel/threads/tls/testcase.yaml
+++ b/tests/kernel/threads/tls/testcase.yaml
@@ -14,6 +14,8 @@ tests:
       - userspace
     filter: CONFIG_ARCH_HAS_THREAD_LOCAL_STORAGE and CONFIG_ARCH_HAS_USERSPACE and
       CONFIG_TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE
+    arch_exclude:
+      - posix
     # ARCMWDT can't handle THREAD_LOCAL_STORAGE with USERSPACE, see #52570 for details
     toolchain_exclude: arcmwdt
     extra_configs:

--- a/tests/kernel/workq/user_work/testcase.yaml
+++ b/tests/kernel/workq/user_work/testcase.yaml
@@ -2,6 +2,8 @@ tests:
   kernel.workqueue.user:
     min_flash: 34
     filter: CONFIG_ARCH_HAS_USERSPACE
+    arch_exclude:
+      - posix
     tags:
       - kernel
       - userspace

--- a/tests/lib/newlib/heap_listener/testcase.yaml
+++ b/tests/lib/newlib/heap_listener/testcase.yaml
@@ -4,6 +4,7 @@ tests:
       - clib
       - newlib
     filter: TOOLCHAIN_HAS_NEWLIB == 1
+    arch_exclude: posix
     integration_platforms:
       - mps2_an385
       - qemu_x86

--- a/tests/lib/newlib/thread_safety/testcase.yaml
+++ b/tests/lib/newlib/thread_safety/testcase.yaml
@@ -1,5 +1,6 @@
 common:
   filter: TOOLCHAIN_HAS_NEWLIB == 1
+  arch_exclude: posix
   tags:
     - clib
     - newlib

--- a/tests/subsys/debug/coredump/testcase.yaml
+++ b/tests/subsys/debug/coredump/testcase.yaml
@@ -5,6 +5,8 @@ tests:
     ignore_qemu_crash: true
     filter: CONFIG_ARCH_SUPPORTS_COREDUMP
     platform_exclude: acrn_ehl_crb
+    arch_exclude:
+      - posix
     integration_platforms:
       - qemu_x86
     harness: console

--- a/tests/subsys/debug/coredump_backends/testcase.yaml
+++ b/tests/subsys/debug/coredump_backends/testcase.yaml
@@ -2,6 +2,8 @@ common:
   tags: coredump
   ignore_faults: true
   ignore_qemu_crash: true
+  arch_exclude:
+    - posix
   integration_platforms:
     - qemu_x86
 tests:

--- a/tests/subsys/rtio/rtio_api/testcase.yaml
+++ b/tests/subsys/rtio/rtio_api/testcase.yaml
@@ -20,6 +20,8 @@ tests:
     filter: CONFIG_ARCH_HAS_USERSPACE
     extra_configs:
       - CONFIG_USERSPACE=y
+    arch_exclude:
+      - posix
     tags:
       - rtio
       - userspace
@@ -30,6 +32,8 @@ tests:
     extra_configs:
       - CONFIG_USERSPACE=y
       - CONFIG_RTIO_SUBMIT_SEM=y
+    arch_exclude:
+      - posix
     tags:
       - rtio
       - userspace

--- a/tests/ztest/error_hook/testcase.yaml
+++ b/tests/ztest/error_hook/testcase.yaml
@@ -4,6 +4,8 @@ common:
 tests:
   testing.ztest.error_hook:
     filter: CONFIG_ARCH_HAS_USERSPACE
+    arch_exclude:
+      - posix
     tags:
       - userspace
     ignore_faults: true


### PR DESCRIPTION
There are quite a few samples & tests which cannot be run in the POSIX architecture

Today they are filtered by kconfig, which works but spends quite a lot of time running cmake.
As native_posix is a default test platform it is better to filter it all together by arch,
which saves quite a lot of time.

As a bonus, there is one arm specific test that also got a arch_allow by arm architecture.