### PR TITLE
modules: Updated the Percepio module to v4.8.1.hotfix1

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -304,7 +304,7 @@ manifest:
       path: modules/lib/openthread
     - name: percepio
       path: modules/debug/percepio
-      revision: a3728efccc47dd372f40e6313589ca4c5cc7d5e9
+      revision: 0fbc5b72aeab8a6434523a3a7bc8111c17f0bc73
       groups:
         - debug
     - name: picolibc


### PR DESCRIPTION
This synchronizes the percepio module with the upstreams repository.