### PR TITLE
dts: mec1727nsz: fix few build issues

### DIFF
--- a/dts/arm/microchip/mec1727nsz.dtsi
+++ b/dts/arm/microchip/mec1727nsz.dtsi
@@ -12,7 +12,9 @@
 #include <zephyr/dt-bindings/interrupt-controller/mchp-xec-ecia.h>
 
 #include "mec172x/mec172x-vw-routing.dtsi"
-#include "mec172x/mec172xnsz-pinctrl.dtsi"
+
+#include <mem.h>
+#include <freq.h>
 
 / {
 	cpus {
@@ -82,6 +84,16 @@
 		jedec-id = [62 06 13];
 	};
 };
+
+&nvic {
+	arm,num-irq-priority-bits = <3>;
+};
+
+&systick {
+	status = "disabled";
+};
+
+#include "mec172x/mec172xnsz-pinctrl.dtsi"
 
 &gpspi_wp_n_gpio076 {
 	output-high;


### PR DESCRIPTION
Fixes a handful of bulid errors we bumped into downstream. Honestly the way that these files are organized is a bit odd but for the moment I'm more concerned about having the file usable again.

---

This files has been changed as part of a refactoring in 13a87081b9. Unfortunately the refactoring introduced few issues:

- usage of devicetree macros before their definition
- usage of pinctrl label before the definition of the corresponding node
- removal of few node overrides that are causing build errors

Unfortunately there's no board usptream using this specific dts file, so the issue has not been caught in CI and was only found downstream.