### PR TITLE
linker: common-rom: Keep z_shared_isr regardless of dynamic interrupts

### DIFF
--- a/include/zephyr/linker/common-rom/common-rom-kernel-devices.ld
+++ b/include/zephyr/linker/common-rom/common-rom-kernel-devices.ld
@@ -22,6 +22,26 @@
 
 	ITERABLE_SECTION_ROM_NUMERIC(device, 4)
 
+#if defined(CONFIG_GEN_SW_ISR_TABLE) && defined(CONFIG_SHARED_INTERRUPTS)
+	/* since z_shared_isr() is not referenced anywhere when
+	 * zephyr_pre0.elf is built, the linker will end up dropping it.
+	 * Later on, during the second linking stage (when zephyr.elf is
+	 * built), the symbol will be added to the text section since it's
+	 * now being referenced (thanks to isr_tables.c). This is very
+	 * problematic because adding the z_shared_isr symbol between
+	 * the linking stages will end up shifting the addresses of the
+	 * functions, which, in turn, will end up messing the ISR table
+	 * (as the entries from _sw_isr_table will end up pointing to
+	 * old addresses of the registered ISRs). To prevent this from
+	 * happening, instruct the linker to avoid dropping z_shared_isr
+	 * if it's not being referenced anywhere.
+	 */
+	SECTION_PROLOGUE(.text.z_shared_isr,,)
+	{
+		KEEP(*(.text.z_shared_isr))
+	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+#endif
+
 #if defined(CONFIG_GEN_SW_ISR_TABLE) && !defined(CONFIG_DYNAMIC_INTERRUPTS)
 	SECTION_PROLOGUE(sw_isr_table,,)
 	{
@@ -39,11 +59,6 @@
 	{
 		/* TODO: does this section require alignment? */
 		KEEP(*(_SHARED_SW_ISR_TABLE_SECTION_SYMS))
-	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
-
-	SECTION_PROLOGUE(.text.z_shared_isr,,)
-	{
-		KEEP(*(.text.z_shared_isr))
 	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 #endif
 


### PR DESCRIPTION
Currently, the z_shared_isr symbol is only kept if CONFIG_DYNAMIC_INTERRUPTS=n. Whenever CONFG_DYNAMIC_INTERRUPTS is set to 'y', said symbol gets dropped when zephyr_pre0.elf is created. This is wrong because dropping/keeping z_shared_isr shouldn't be influenced by enabling/disabling support for the dynamic interrupts.

This commit fixes the aforementioned issue by removing the dependency on CONFIG_DYNAMIC_INTERRUPTS.

I was able to reproduce this issue on `qemu_cortex_a53_xip`. Steps:

1. Modify samples/hello_world/src/main.c such that you perform 2 `IRQ_CONNECT` on the same INTID.
2. Enable shared interrupts.
3. Do a `west build -p -b qemu_cortex_a53_xip samples/hello_world`
4. Notice how `z_shared_isr` wasn't dropped in `zephyr_pre0.elf`
5. Enable dynamic interrupts
6. Rebuild
7. Notice how `z_shared_isr` was dropped in `zephyr_pre0.elf`.
8. Do a `west build -t run`. QEMU should hang.
