### PR TITLE
[v2.7] correct timeout of 1ms to k forever

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -1190,8 +1190,11 @@ void z_log_msg2_init(void)
 
 struct log_msg2 *z_log_msg2_alloc(uint32_t wlen)
 {
-	return (struct log_msg2 *)mpsc_pbuf_alloc(&log_buffer, wlen,
-				K_MSEC(CONFIG_LOG_BLOCK_IN_THREAD_TIMEOUT_MS));
+	return (struct log_msg2 *)mpsc_pbuf_alloc(
+		&log_buffer, wlen,
+		(CONFIG_LOG_BLOCK_IN_THREAD_TIMEOUT_MS == -1)
+			? K_FOREVER
+			: K_MSEC(CONFIG_LOG_BLOCK_IN_THREAD_TIMEOUT_MS));
 }
 
 void z_log_msg2_commit(struct log_msg2 *msg)


### PR DESCRIPTION
Backport of #63958 to `v2.7-branch`

Fixes #63965
Fixes #64002