### PR TITLE
test: twister: testplan.py use normpath

### DIFF
--- a/scripts/pylib/twister/twisterlib/testsuite.py
+++ b/scripts/pylib/twister/twisterlib/testsuite.py
@@ -450,7 +450,7 @@ class TestSuite(DisablePyTestCollectionMixin):
             relative_ts_root = ""
 
         # workdir can be "."
-        unique = os.path.normpath(os.path.join(relative_ts_root, workdir, name))
+        unique = os.path.normpath(os.path.join(relative_ts_root, workdir, name)).replace(os.sep, '/')
         return unique
 
     @staticmethod


### PR DESCRIPTION
when load test plan it is possible the plan is built in another os so the case key would be
'samples/hello_world/samples.baseic.hello_world'
but the testsuite is scaned in current os may in window and the key is like
'samples\\hello_world\\samples.baseic.hello_world'

use ps.path.normpath, will solve this.