### PR TITLE
Bluetooth: Controller: Fix missing ext adv terminate event 

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -646,8 +646,8 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 		window_widening_us = SCA_DRIFT_500_PPM_US(aux_offset_us);
 	}
 
-	lll_aux->window_size_us += (EVENT_TICKER_RES_MARGIN_US +
-				    ((EVENT_JITTER_US + window_widening_us) << 1));
+	lll_aux->window_size_us += ((EVENT_TICKER_RES_MARGIN_US + EVENT_JITTER_US +
+				     window_widening_us) << 1);
 
 	ready_delay_us = lll_radio_rx_ready_delay_get(lll_aux->phy,
 						      PHY_FLAGS_S8);


### PR DESCRIPTION
Fix missing Extended Advertising terminate event and
advertising scheduling not being stopped.

Under race conditions, auxiliary event is aborted without
the generation  of done extra event which is suppose to
stop the scheduling when max events count is used.

The fix now generates the done extra event.

Fix periodic advertising sync window calculation to include
the scheduling resolution margin, i.e. be double as with
the event jitter value.

Fixes #65056.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>