### PR TITLE
[v3.3] dts: vendor-prefixes: deprecate facebook and add meta

### DIFF
--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -201,7 +201,7 @@ evervision	Evervision Electronics Co. Ltd.
 exar	Exar Corporation
 excito	Excito
 ezchip	EZchip Semiconductor
-facebook	Facebook
+facebook	Facebook (deprecated, use meta)
 fairphone	Fairphone B.V.
 faraday	Faraday Technology Corporation
 fastrax	Fastrax Oy
@@ -368,6 +368,7 @@ menlo	Menlo Systems GmbH
 mentor	Mentor Graphics
 meraki	Cisco Meraki, LLC
 merrii	Merrii Technology Co., Ltd.
+meta	Meta Platforms, Inc.
 micrel	Micrel Inc.
 microbit	Micro:bit Educational Foundation
 microchip	Microchip Technology Inc.


### PR DESCRIPTION
Backport of #61351 for `v3.3-branch`.

Fixes #61337
Fixes #61381

See also #64274