### PR TITLE
manifest: update sof to commit e7cb489d4

### DIFF
--- a/scripts/west_commands/runners/intel_adsp.py
+++ b/scripts/west_commands/runners/intel_adsp.py
@@ -16,7 +16,7 @@ from zephyr_ext_common import ZEPHYR_BASE
 DEFAULT_CAVSTOOL='soc/xtensa/intel_adsp/tools/cavstool_client.py'
 DEFAULT_SOF_MOD_DIR=os.path.join(ZEPHYR_BASE, '../modules/audio/sof')
 DEFAULT_RIMAGE_TOOL=shutil.which('rimage')
-DEFAULT_CONFIG_DIR=os.path.join(DEFAULT_SOF_MOD_DIR, 'rimage/config')
+DEFAULT_CONFIG_DIR=os.path.join(DEFAULT_SOF_MOD_DIR, 'tools/rimage/config')
 DEFAULT_KEY_DIR=os.path.join(DEFAULT_SOF_MOD_DIR, 'keys')
 
 

--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -502,7 +502,7 @@ class RimageSigner(Signer):
         elif cache.get('RIMAGE_CONFIG_PATH'):
             conf_dir = pathlib.Path(cache['RIMAGE_CONFIG_PATH'])
         else:
-            conf_dir = sof_src_dir / 'rimage' / 'config'
+            conf_dir = sof_src_dir / 'tools' / 'rimage' / 'config'
 
         conf_path_cmd = ['-c', str(conf_dir / cmake_toml)] if conf_dir else []
 

--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -517,6 +517,13 @@ class RimageSigner(Signer):
         else:
             no_manifest = False
 
+        # Non-SOF build does not have extended manifest data for
+        # rimage to process, which might result in rimage error.
+        # So skip it when not doing SOF builds.
+        is_sof_build = build_conf.getboolean('CONFIG_SOF')
+        if not is_sof_build:
+            no_manifest = True
+
         if no_manifest:
             extra_ri_args = [ ]
         else:

--- a/submanifests/optional.yaml
+++ b/submanifests/optional.yaml
@@ -28,7 +28,7 @@ manifest:
       groups:
         - optional
     - name: sof
-      revision: c0f20b69daa44e3563f970b366e49ccfcfa1b71c
+      revision: e7cb489d430dc2181e4a5f7f953ed1eaeec6668d
       path: modules/audio/sof
       remote: upstream
       groups:


### PR DESCRIPTION
This updates SOF modules to commit
https://github.com/zephyrproject-rtos/sof/commit/e7cb489d430dc2181e4a5f7f953ed1eaeec6668d. This includes
a change where rimage is pulled into the tree and is no
longer a submodule. So update the rimage config path so
signing still works.

Also fixed an issue where rimage would fail if there is no
extended manifest information.