### PR TITLE
riscv: pmp: Fix assertion for PMP misaligned start address and size

### DIFF
--- a/arch/riscv/core/pmp.c
+++ b/arch/riscv/core/pmp.c
@@ -161,8 +161,8 @@ static bool set_pmp_entry(unsigned int *index_p, uint8_t perm,
 	unsigned int index = *index_p;
 	bool ok = true;
 
-	__ASSERT((start & 0x3) == 0, "misaligned start address");
-	__ASSERT((size & 0x3) == 0, "misaligned size");
+	__ASSERT((start & (CONFIG_PMP_GRANULARITY - 1)) == 0, "misaligned start address");
+	__ASSERT((size & (CONFIG_PMP_GRANULARITY - 1)) == 0, "misaligned size");
 
 	if (index >= index_limit) {
 		LOG_ERR("out of PMP slots");


### PR DESCRIPTION
The start address and size of pmp slot must be aligned with PMP granularity specified by `CONIFG_PMP_GRANULARITY`. Therefore, I modified the assertion in set_pmp_entry() to check whether the start address and size align with PMP granularity.