### PR TITLE
drivers: watchdog: wdt_nrfx: Implement disable API

### DIFF
--- a/drivers/watchdog/wdt_nrfx.c
+++ b/drivers/watchdog/wdt_nrfx.c
@@ -28,29 +28,32 @@ static int wdt_nrf_setup(const struct device *dev, uint8_t options)
 {
 	const struct wdt_nrfx_config *config = dev->config;
 	struct wdt_nrfx_data *data = dev->data;
-	uint32_t behaviour;
+	nrfx_err_t err_code;
 
 	/* Activate all available options. Run in all cases. */
-	behaviour = NRF_WDT_BEHAVIOUR_RUN_SLEEP_MASK | NRF_WDT_BEHAVIOUR_RUN_HALT_MASK;
+	config->config.behaviour = NRF_WDT_BEHAVIOUR_RUN_SLEEP_MASK |
+#if NRF_WDT_HAS_STOP
+				   NRF_WDT_BEHAVIOUR_STOP_ENABLE_MASK |
+#endif
+				   NRF_WDT_BEHAVIOUR_RUN_HALT_MASK;
 
 	/* Deactivate running in sleep mode. */
 	if (options & WDT_OPT_PAUSE_IN_SLEEP) {
-		behaviour &= ~NRF_WDT_BEHAVIOUR_RUN_SLEEP_MASK;
+		config->config.behaviour &= ~NRF_WDT_BEHAVIOUR_RUN_SLEEP_MASK;
 	}
 
 	/* Deactivate running when debugger is attached. */
 	if (options & WDT_OPT_PAUSE_HALTED_BY_DBG) {
-		behaviour &= ~NRF_WDT_BEHAVIOUR_RUN_HALT_MASK;
+		config->config.behaviour &= ~NRF_WDT_BEHAVIOUR_RUN_HALT_MASK;
 	}
 
-	nrf_wdt_behaviour_set(config->wdt.p_reg, behaviour);
-	/* The watchdog timer is driven by the LFCLK clock running at 32768 Hz.
-	 * The timeout value given in milliseconds needs to be converted here
-	 * to watchdog ticks.*/
-	nrf_wdt_reload_value_set(
-		config->wdt.p_reg,
-		(uint32_t)(((uint64_t)data->m_timeout * 32768U)
-			   / 1000));
+	config->config.reload_value = data->m_timeout;
+
+	err_code = nrfx_wdt_reconfigure(&config->wdt, &config->config);
+
+	if (err_code != NRFX_SUCCESS) {
+		return -EBUSY;
+	}
 
 	nrfx_wdt_enable(&config->wdt);
 
@@ -59,9 +62,21 @@ static int wdt_nrf_setup(const struct device *dev, uint8_t options)
 
 static int wdt_nrf_disable(const struct device *dev)
 {
-	/* Started watchdog cannot be stopped on nRF devices. */
+#if NRFX_WDT_HAS_STOP
+	const struct wdt_nrfx_config *config = dev->config;
+	nrfx_err_t err_code;
+
+	err_code = nrfx_wdt_stop(&config->wdt);
+
+	if (err_code != NRFX_SUCCESS) {
+		return -ENOTSUP;
+	}
+
+	return 0;
+#else
 	ARG_UNUSED(dev);
 	return -EPERM;
+#endif
 }
 
 static int wdt_nrf_install_timeout(const struct device *dev,


### PR DESCRIPTION
nRF5340 SoC has `TASK_STOP` this patch implements disabling watchdog for that SoC.

Changed body of `wdt_nrf_setup()` to utilize `nrfx_wdt_reconfigure()` driver API.