### PR TITLE
samples: mgmt: mcumgr: smp_svr: Fix start if USB already init

### DIFF
--- a/samples/subsys/mgmt/mcumgr/smp_svr/src/main.c
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/src/main.c
@@ -73,7 +73,9 @@ int main(void)
 
 	if (IS_ENABLED(CONFIG_USB_DEVICE_STACK)) {
 		rc = usb_enable(NULL);
-		if (rc) {
+
+		/* Ignore EALREADY error as USB CDC is likely already initialised */
+		if (rc != 0 && rc != -EALREADY) {
 			LOG_ERR("Failed to enable USB");
 			return 0;
 		}


### PR DESCRIPTION
Fixes an issue whereby the application init will stall if USB init failed if it's already been setup, this is likely due to USB CDC being enabled in which case the failure can be ignored