### PR TITLE
doc: migration-guide/release: 3.6: Add MCUmgr changes

### DIFF
--- a/doc/releases/migration-guide-3.6.rst
+++ b/doc/releases/migration-guide-3.6.rst
@@ -38,5 +38,9 @@ Networking
 Other Subsystems
 ================
 
+* MCUmgr applications that make use of serial transports (shell or UART) must now select
+  :kconfig:option:`CONFIG_CRC`, this was previously erroneously selected if MCUmgr was enabled,
+  when for non-serial transports it was not needed.
+
 Recommended Changes
 *******************

--- a/doc/releases/release-notes-3.6.rst
+++ b/doc/releases/release-notes-3.6.rst
@@ -236,6 +236,15 @@ Libraries / Subsystems
 
 * Management
 
+  * Fixed an issue in MCUmgr image management whereby erasing an already erased slot would return
+    an unknown error, it now returns success.
+
+  * Fixed MCUmgr UDP transport structs being statically initialised, this results in about a
+    ~5KiB flash saving.
+
+  * Fixed an issue in MCUmgr which would cause a user data buffer overflow if the UDP transport was
+    enabled on IPv4 only but IPv6 support was enabled in the kernel.
+
 * File systems
 
 * Modem modules
@@ -278,3 +287,6 @@ Documentation
 
 Tests and Samples
 *****************
+
+* Fixed an issue in :zephyr:code-sample:`smp-svr` sample whereby if USB was already initialised,
+  application would fail to boot properly.


### PR DESCRIPTION
    doc: release: 3.6: Add notes on MCUmgr fixes
    
    Adds notes on a fixed MCUmgr issue and smp_svr sample issue


    doc: migration-guide: 3.6: Add note on MCUmgr CRC change
    
    Adds a note that an additional Kconfig needs to be selected if a
    serial MCUmgr transport is used
