### PR TITLE
boards: Fix nrf9160 NS flash partition layout

### DIFF
--- a/boards/arm/circuitdojo_feather_nrf9160/circuitdojo_feather_nrf9160_common.dtsi
+++ b/boards/arm/circuitdojo_feather_nrf9160/circuitdojo_feather_nrf9160_common.dtsi
@@ -187,22 +187,19 @@
 		slot0_partition: partition@10000 {
 			label = "image-0";
 		};
-		slot0_ns_partition: partition@40000 {
+		slot0_ns_partition: partition@50000 {
 			label = "image-0-nonsecure";
 		};
 		slot1_partition: partition@80000 {
 			label = "image-1";
 		};
-		slot1_ns_partition: partition@b0000 {
+		slot1_ns_partition: partition@c0000 {
 			label = "image-1-nonsecure";
 		};
-		scratch_partition: partition@f0000 {
-			label = "image-scratch";
-			reg = <0x000f0000 0xa000>;
-		};
-		storage_partition: partition@fa000 {
+		/* 0xf0000 to 0xf7fff reserved for TF-M partitions */
+		storage_partition: partition@f8000 {
 			label = "storage";
-			reg = <0x000fa000 0x00006000>;
+			reg = <0x000f8000 0x00008000>;
 		};
 	};
 };

--- a/boards/arm/circuitdojo_feather_nrf9160/circuitdojo_feather_nrf9160_ns.yaml
+++ b/boards/arm/circuitdojo_feather_nrf9160/circuitdojo_feather_nrf9160_ns.yaml
@@ -7,7 +7,7 @@ toolchain:
   - xtools
   - zephyr
 ram: 128
-flash: 256
+flash: 192
 supported:
   - i2c
   - pwm

--- a/boards/arm/circuitdojo_feather_nrf9160/circuitdojo_feather_nrf9160_partition_conf.dtsi
+++ b/boards/arm/circuitdojo_feather_nrf9160/circuitdojo_feather_nrf9160_partition_conf.dtsi
@@ -23,19 +23,19 @@
  */
 
 &slot0_partition {
-	reg = <0x00010000 0x30000>;
+	reg = <0x00010000 0x40000>;
 };
 
 &slot0_ns_partition {
-	reg = <0x00040000 0x40000>;
+	reg = <0x00050000 0x30000>;
 };
 
 &slot1_partition {
-	reg = <0x00080000 0x30000>;
+	reg = <0x00080000 0x40000>;
 };
 
 &slot1_ns_partition {
-	reg = <0x000b0000 0x40000>;
+	reg = <0x000c0000 0x30000>;
 };
 
 /* Default SRAM planning when building for nRF9160 with

--- a/boards/arm/nrf9160_innblue21/nrf9160_innblue21_common.dtsi
+++ b/boards/arm/nrf9160_innblue21/nrf9160_innblue21_common.dtsi
@@ -168,27 +168,23 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0xc000>;
+			reg = <0x00000000 0x10000>;
 		};
-		slot0_partition: partition@c000 {
+		slot0_partition: partition@10000 {
 			label = "image-0";
 		};
-		slot0_ns_partition: partition@3e000 {
+		slot0_ns_partition: partition@50000 {
 			label = "image-0-nonsecure";
 		};
-		slot1_partition: partition@7e000 {
+		slot1_partition: partition@80000 {
 			label = "image-1";
 		};
-		slot1_ns_partition: partition@b0000 {
+		slot1_ns_partition: partition@c0000 {
 			label = "image-1-nonsecure";
 		};
-		scratch_partition: partition@f0000 {
-			label = "image-scratch";
-			reg = <0x000f0000 0xa000>;
-		};
-		storage_partition: partition@fa000 {
+		storage_partition: partition@f8000 {
 			label = "storage";
-			reg = <0x000fa000 0x00006000>;
+			reg = <0x000f8000 0x00008000>;
 		};
 	};
 };

--- a/boards/arm/nrf9160_innblue21/nrf9160_innblue21_ns.yaml
+++ b/boards/arm/nrf9160_innblue21/nrf9160_innblue21_ns.yaml
@@ -7,7 +7,7 @@ toolchain:
   - xtools
   - zephyr
 ram: 128
-flash: 256
+flash: 192
 supported:
   - i2c
   - pwm

--- a/boards/arm/nrf9160_innblue21/nrf9160_innblue21_partition_conf.dtsi
+++ b/boards/arm/nrf9160_innblue21/nrf9160_innblue21_partition_conf.dtsi
@@ -22,19 +22,19 @@
  */
 
 &slot0_partition {
-	reg = <0x0000c000 0x30000>;
+	reg = <0x00010000 0x40000>;
 };
 
 &slot0_ns_partition {
-	reg = <0x0003e000 0x40000>;
+	reg = <0x00050000 0x30000>;
 };
 
 &slot1_partition {
-	reg = <0x0007e000 0x30000>;
+	reg = <0x00080000 0x40000>;
 };
 
 &slot1_ns_partition {
-	reg = <0x000b0000 0x40000>;
+	reg = <0x000c0000 0x30000>;
 };
 
 /* Default SRAM planning when building for nRF9160 with

--- a/boards/arm/nrf9160_innblue22/nrf9160_innblue22_common.dtsi
+++ b/boards/arm/nrf9160_innblue22/nrf9160_innblue22_common.dtsi
@@ -171,27 +171,24 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0xc000>;
+			reg = <0x00000000 0x10000>;
 		};
-		slot0_partition: partition@c000 {
+		slot0_partition: partition@10000 {
 			label = "image-0";
 		};
-		slot0_ns_partition: partition@3e000 {
+		slot0_ns_partition: partition@50000 {
 			label = "image-0-nonsecure";
 		};
-		slot1_partition: partition@7e000 {
+		slot1_partition: partition@80000 {
 			label = "image-1";
 		};
-		slot1_ns_partition: partition@b0000 {
+		slot1_ns_partition: partition@c0000 {
 			label = "image-1-nonsecure";
 		};
-		scratch_partition: partition@f0000 {
-			label = "image-scratch";
-			reg = <0x000f0000 0xa000>;
-		};
-		storage_partition: partition@fa000 {
+		/* 0xf0000 to 0xf7fff reserved for TF-M partitions */
+		storage_partition: partition@f8000 {
 			label = "storage";
-			reg = <0x000fa000 0x00006000>;
+			reg = <0x000f8000 0x00008000>;
 		};
 	};
 };

--- a/boards/arm/nrf9160_innblue22/nrf9160_innblue22_ns.yaml
+++ b/boards/arm/nrf9160_innblue22/nrf9160_innblue22_ns.yaml
@@ -7,7 +7,7 @@ toolchain:
   - xtools
   - zephyr
 ram: 128
-flash: 256
+flash: 192
 supported:
   - i2c
   - pwm

--- a/boards/arm/nrf9160_innblue22/nrf9160_innblue22_partition_conf.dtsi
+++ b/boards/arm/nrf9160_innblue22/nrf9160_innblue22_partition_conf.dtsi
@@ -22,19 +22,19 @@
  */
 
 &slot0_partition {
-	reg = <0x0000c000 0x30000>;
+	reg = <0x00010000 0x40000>;
 };
 
 &slot0_ns_partition {
-	reg = <0x0003e000 0x40000>;
+	reg = <0x00050000 0x30000>;
 };
 
 &slot1_partition {
-	reg = <0x0007e000 0x30000>;
+	reg = <0x00080000 0x40000>;
 };
 
 &slot1_ns_partition {
-	reg = <0x000b0000 0x40000>;
+	reg = <0x000c0000 0x30000>;
 };
 
 /* Default SRAM planning when building for nRF9160 with

--- a/boards/arm/sparkfun_thing_plus_nrf9160/sparkfun_thing_plus_nrf9160_common.dtsi
+++ b/boards/arm/sparkfun_thing_plus_nrf9160/sparkfun_thing_plus_nrf9160_common.dtsi
@@ -185,22 +185,19 @@
 		slot0_partition: partition@10000 {
 			label = "image-0";
 		};
-		slot0_ns_partition: partition@40000 {
+		slot0_ns_partition: partition@50000 {
 			label = "image-0-nonsecure";
 		};
 		slot1_partition: partition@80000 {
 			label = "image-1";
 		};
-		slot1_ns_partition: partition@b0000 {
+		slot1_ns_partition: partition@c0000 {
 			label = "image-1-nonsecure";
 		};
-		scratch_partition: partition@f0000 {
-			label = "image-scratch";
-			reg = <0x000f0000 0xa000>;
-		};
-		storage_partition: partition@fa000 {
+		/* 0xf0000 to 0xf7fff reserved for TF-M partitions */
+		storage_partition: partition@f8000 {
 			label = "storage";
-			reg = <0x000fa000 0x00006000>;
+			reg = <0x000f8000 0x00008000>;
 		};
 	};
 };

--- a/boards/arm/sparkfun_thing_plus_nrf9160/sparkfun_thing_plus_nrf9160_ns.yaml
+++ b/boards/arm/sparkfun_thing_plus_nrf9160/sparkfun_thing_plus_nrf9160_ns.yaml
@@ -7,7 +7,7 @@ toolchain:
   - xtools
   - zephyr
 ram: 128
-flash: 256
+flash: 192
 supported:
   - i2c
   - pwm

--- a/boards/arm/sparkfun_thing_plus_nrf9160/sparkfun_thing_plus_nrf9160_partition_conf.dtsi
+++ b/boards/arm/sparkfun_thing_plus_nrf9160/sparkfun_thing_plus_nrf9160_partition_conf.dtsi
@@ -23,19 +23,19 @@
  */
 
 &slot0_partition {
-	 reg = <0x00010000 0x30000>;
+	reg = <0x00010000 0x40000>;
 };
 
 &slot0_ns_partition {
-	reg = <0x00040000 0x40000>;
+	reg = <0x00050000 0x30000>;
 };
 
 &slot1_partition {
-	reg = <0x00080000 0x30000>;
+	reg = <0x00080000 0x40000>;
 };
 
 &slot1_ns_partition {
-	reg = <0x000b0000 0x40000>;
+	reg = <0x000c0000 0x30000>;
 };
 
 /* Default SRAM planning when building for nRF9160 with


### PR DESCRIPTION
Fix secure and non-secure images overlapping because of incompatible flash layout configurations.

Align the board configurations to match the nRF9160 DK default partition layout.

This enforces that the SPU alignment requirement is satisfied for the nrf9160 MCU.