### PR TITLE
Bluetooth: Mesh: HB pub status

### DIFF
--- a/subsys/bluetooth/mesh/cfg_cli.c
+++ b/subsys/bluetooth/mesh/cfg_cli.c
@@ -950,8 +950,8 @@ static int hb_pub_status(struct bt_mesh_model *model,
 	pub.count = net_buf_simple_pull_u8(buf);
 	pub.period = net_buf_simple_pull_u8(buf);
 	pub.ttl = net_buf_simple_pull_u8(buf);
-	pub.feat = net_buf_simple_pull_u8(buf);
-	pub.net_idx = net_buf_simple_pull_u8(buf);
+	pub.feat = net_buf_simple_pull_le16(buf);
+	pub.net_idx = net_buf_simple_pull_le16(buf) & 0xfff;
 
 	if (bt_mesh_msg_ack_ctx_match(&cli->ack_ctx, OP_HEARTBEAT_PUB_STATUS,
 				      ctx->addr, (void **)&param)) {

--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -2274,7 +2274,7 @@ static int hb_pub_send_status(struct bt_mesh_model *model,
 		net_buf_simple_add_u8(&msg, bt_mesh_hb_log(pub->period));
 		net_buf_simple_add_u8(&msg, pub->ttl);
 		net_buf_simple_add_le16(&msg, pub->feat);
-		net_buf_simple_add_le16(&msg, pub->net_idx);
+		net_buf_simple_add_le16(&msg, pub->net_idx & 0xfff);
 	}
 
 	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {

--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -2267,11 +2267,15 @@ static int hb_pub_send_status(struct bt_mesh_model *model,
 	net_buf_simple_add_u8(&msg, status);
 
 	net_buf_simple_add_le16(&msg, pub->dst);
-	net_buf_simple_add_u8(&msg, hb_pub_count_log(pub->count));
-	net_buf_simple_add_u8(&msg, bt_mesh_hb_log(pub->period));
-	net_buf_simple_add_u8(&msg, pub->ttl);
-	net_buf_simple_add_le16(&msg, pub->feat);
-	net_buf_simple_add_le16(&msg, pub->net_idx);
+	if (pub->dst == BT_MESH_ADDR_UNASSIGNED) {
+		(void)memset(net_buf_simple_add(&msg, 7), 0, 7);
+	} else {
+		net_buf_simple_add_u8(&msg, hb_pub_count_log(pub->count));
+		net_buf_simple_add_u8(&msg, bt_mesh_hb_log(pub->period));
+		net_buf_simple_add_u8(&msg, pub->ttl);
+		net_buf_simple_add_le16(&msg, pub->feat);
+		net_buf_simple_add_le16(&msg, pub->net_idx);
+	}
 
 	if (bt_mesh_model_send(model, ctx, &msg, NULL, NULL)) {
 		LOG_ERR("Unable to send Heartbeat Publication Status");


### PR DESCRIPTION
- Fixes issue where Heartbeat Publication Status message sends garbage data when destination field is set to the unassigned address.
- Fixes incorrect unpacking of Heartbeat Publication status messages on the Configuration client.
- Ensures correct packing of net idx in Heartbeat Publication Status messages on the Configuration Server.