### PR TITLE
Bluetooth: BAP: Shell: Remove unused variable stream_frame_duration_us

### DIFF
--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -2617,7 +2617,6 @@ static int cmd_send(const struct shell *sh, size_t argc, char *argv[])
 #if defined(CONFIG_LIBLC3)
 static bool stream_start_sine_verify(const struct bt_bap_stream *bap_stream)
 {
-	int stream_frame_duration_us;
 	struct bt_bap_ep_info info;
 	int err;
 


### PR DESCRIPTION
The variable was unsused and caused compiler warnings.