### PR TITLE
task_wdt: start feeding hardware watchdog immediately after init

### DIFF
--- a/subsys/task_wdt/task_wdt.c
+++ b/subsys/task_wdt/task_wdt.c
@@ -147,6 +147,7 @@ int task_wdt_init(const struct device *hw_wdt)
 	}
 
 	k_timer_init(&timer, task_wdt_trigger, NULL);
+	schedule_next_timeout(sys_clock_tick_get());
 
 	return 0;
 }


### PR DESCRIPTION
Without this, the hardware watchdog would expire if no task watchdogs were registered within one hardware watchdog period after init. Start the background channel immediately after init to avoid this.