### PR TITLE
sys: util: Avoid macro name collision with CMSIS DSP library

### DIFF
--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -250,18 +250,22 @@ extern "C" {
 		((type *)(((char *)(ptr)) - offsetof(type, field))); \
 	})
 
+#ifndef ROUND_UP
 /**
  * @brief Value of @p x rounded up to the next multiple of @p align.
  */
 #define ROUND_UP(x, align)                                   \
 	((((unsigned long)(x) + ((unsigned long)(align) - 1)) / \
 	  (unsigned long)(align)) * (unsigned long)(align))
+#endif
 
+#ifndef ROUND_DOWN
 /**
  * @brief Value of @p x rounded down to the previous multiple of @p align.
  */
 #define ROUND_DOWN(x, align)                                 \
 	(((unsigned long)(x) / (unsigned long)(align)) * (unsigned long)(align))
+#endif
 
 /** @brief Value of @p x rounded up to the next word boundary. */
 #define WB_UP(x) ROUND_UP(x, sizeof(void *))


### PR DESCRIPTION
The macro names ROUND_UP and ROUND_DOWN are both used in the CMSIS DSP library. In the CMSIS DSP library the definition of these macros are protected by #ifndef/#endif, but not in the Zephyr implementation. So the order of inclusion comes into play.