### PR TITLE
nrf53_bsim: Get IPC shared memory buffer size from DT

### DIFF
--- a/boards/posix/nrf_bsim/CMakeLists.txt
+++ b/boards/posix/nrf_bsim/CMakeLists.txt
@@ -35,8 +35,8 @@ target_sources(native_simulator INTERFACE
 	common/trace_hook.c
 )
 
-if (CONFIG_IPC_SERVICE)
-	target_sources(native_simulator INTERFACE
+if (CONFIG_IPC_SERVICE AND CONFIG_BOARD_NRF5340BSIM_NRF5340_CPUAPP)
+	zephyr_library_sources(
 		ipc_backend.c
 	)
 endif()

--- a/boards/posix/nrf_bsim/Kconfig.defconfig
+++ b/boards/posix/nrf_bsim/Kconfig.defconfig
@@ -6,7 +6,9 @@ config BUILD_OUTPUT_BIN
 	default n
 
 config BUILD_OUTPUT_EXE
-	default y
+	# When the IPC service is used, the net core image requires the application core image, as it needs
+	# access to its IPC buffer. Without it, the executable cannot be built.
+	default y if !(BOARD_NRF5340BSIM_NRF5340_CPUNET && IPC_SERVICE && (NATIVE_SIMULATOR_EXTRA_IMAGE_PATHS = ""))
 
 config OUTPUT_PRINT_MEMORY_USAGE
 	default n

--- a/boards/posix/nrf_bsim/ipc_backend.c
+++ b/boards/posix/nrf_bsim/ipc_backend.c
@@ -5,11 +5,23 @@
  */
 
 /*
- * This buffer is the shared memory buffer for the RPMSG IPC backed
- * in simulation.
- * It must be at last as large as the size defined in device tree, but as it will be compiled in
- * the native simulator runner context we cannot refer to DT itself to size it.
- * The default buffer for this target is defined in
- * boards/arm/nrf5340dk_nrf5340/nrf5340_shared_sram_planning_conf.dtsi
+ * Here we define the shared memory buffers for the RPMSG IPC back-end in simulation.
+ * In real HW, these are booked in RAM thru device tree configuration.
+ * In this simulated target, we just define them at build time to have the size defined
+ * in device tree.
+ *
+ * Note that this file is only compiled as part of the application core image, and therefore
+ * when the network core is built with the IPC service, we cannot produce an executable
+ * with the network core image alone, as we would lack this buffer during linking.
  */
-char IPC0_shm_buffer[65536];
+
+#include "nsi_cpu_if.h"
+#include <zephyr/device.h>
+
+#define DT_DRV_COMPAT zephyr_ipc_openamp_static_vrings
+
+#define DEFINE_BACKEND_BUFFER(i) \
+	NATIVE_SIMULATOR_IF \
+	char IPC##i##_shm_buffer[DT_REG_SIZE(DT_INST_PHANDLE(i, memory_region))];
+
+DT_INST_FOREACH_STATUS_OKAY(DEFINE_BACKEND_BUFFER)


### PR DESCRIPTION
Before we were defining the buffer in the runner context which is simpler and less error prone, but it had a hardcoded size decoupled from DT as it could not be based on DT information.
Instead, let's allocate the buffer in the application core image. This allows us to size it based on the device tree configuration.
Note that this then requires the application core image to be present during link time of the final executable when the IPC subsystem is used.