### PR TITLE
tests: obj_core: Increase test thread stack sizes

### DIFF
--- a/tests/kernel/obj_core/obj_core/src/main.c
+++ b/tests/kernel/obj_core/obj_core/src/main.c
@@ -50,10 +50,11 @@ static K_SEM_DEFINE(sem1, 0, 1);
 static struct k_sem sem2;
 
 static void thread_entry(void *, void *, void *);
-K_THREAD_DEFINE(thread1, 512, thread_entry, NULL, NULL, NULL,
+K_THREAD_DEFINE(thread1, 512 + CONFIG_TEST_EXTRA_STACK_SIZE,
+		thread_entry, NULL, NULL, NULL,
 		K_HIGHEST_THREAD_PRIO, 0, 0);
 static struct k_thread thread2;
-K_THREAD_STACK_DEFINE(thread2_stack, 512);
+K_THREAD_STACK_DEFINE(thread2_stack, 512 + CONFIG_TEST_EXTRA_STACK_SIZE);
 
 struct obj_core_find_data {
 	struct k_obj_core *obj_core;    /* Object core to search for */

--- a/tests/kernel/obj_core/obj_core_stats/src/main.c
+++ b/tests/kernel/obj_core/obj_core_stats/src/main.c
@@ -13,7 +13,8 @@ K_MEM_SLAB_DEFINE(mem_slab, 32, 4, 16);       /* Four 32 byte blocks */
 
 #if !defined(CONFIG_ARCH_POSIX) && !defined(CONFIG_SPARC) && !defined(CONFIG_MIPS)
 static void test_thread_entry(void *, void *, void *);
-K_THREAD_DEFINE(test_thread, 1024, test_thread_entry, NULL, NULL, NULL,
+K_THREAD_DEFINE(test_thread, 1024 + CONFIG_TEST_EXTRA_STACK_SIZE,
+		test_thread_entry, NULL, NULL, NULL,
 		K_HIGHEST_THREAD_PRIO, 0, 0);
 
 K_SEM_DEFINE(wake_main_thread, 0, 1);
@@ -21,7 +22,8 @@ K_SEM_DEFINE(wake_test_thread, 0, 1);
 #endif /* !CONFIG_ARCH_POSIX && !CONFIG_SPARC && !CONFIG_MIPS */
 
 #if CONFIG_MP_MAX_NUM_CPUS > 1
-K_THREAD_STACK_ARRAY_DEFINE(busy_thread_stack, CONFIG_MP_MAX_NUM_CPUS - 1, 512);
+K_THREAD_STACK_ARRAY_DEFINE(busy_thread_stack, CONFIG_MP_MAX_NUM_CPUS - 1,
+			    512 + CONFIG_TEST_EXTRA_STACK_SIZE);
 
 struct k_thread busy_thread[CONFIG_MP_MAX_NUM_CPUS - 1];
 

--- a/tests/kernel/obj_core/obj_core_stats_api/src/main.c
+++ b/tests/kernel/obj_core/obj_core_stats_api/src/main.c
@@ -10,7 +10,8 @@
 K_SEM_DEFINE(test_sem, 0, 1);
 
 static void test_thread_entry(void *, void *, void *);
-K_THREAD_DEFINE(test_thread, 512, test_thread_entry, NULL, NULL, NULL,
+K_THREAD_DEFINE(test_thread, 512 + CONFIG_TEST_EXTRA_STACK_SIZE,
+		test_thread_entry, NULL, NULL, NULL,
 		K_HIGHEST_THREAD_PRIO, 0, 0);
 
 /*


### PR DESCRIPTION
Increase the size of the thread stacks used by the obj_core tests by CONFIG_TEST_EXTRA_STACK_SIZE bytes. This is useful to prevent stack overflow/corruption when options such such as "--coverage --gcov-tool gcov" are applied to twister runs.