### PR TITLE
tests: kernel: timer: jitter_drift: Fix FPU exception with picolibc

### DIFF
--- a/tests/kernel/timer/timer_behavior/prj.conf
+++ b/tests/kernel/timer/timer_behavior/prj.conf
@@ -1,6 +1,9 @@
 CONFIG_ZTEST=y
 CONFIG_CBPRINTF_FP_SUPPORT=y
 
+# Needs to be set explicitly with picolibc as default libc implementation.
+CONFIG_FPU=y
+
 # Make sure this is off. Otherwise a single 60-character line at
 # 115200 bauds would grab the printk lock and disable IRQs for more
 # than 5 ms screwing up timer latency statistics.


### PR DESCRIPTION
Fix 'Floating point unit device not available' exception at test_jitter_drift_timer_period when picolibc is default libc implementation.

fixes #64333 