### PR TITLE
soc: arm: nxp_imx: rt5xx: make some clock init functions weak

### DIFF
--- a/soc/arm/nxp_imx/rt5xx/soc.c
+++ b/soc/arm/nxp_imx/rt5xx/soc.c
@@ -216,7 +216,8 @@ void z_arm_platform_init(void)
 	SystemInit();
 }
 
-static void clock_init(void)
+/* Weak so that board can override with their own clock init routine. */
+void __weak rt5xx_clock_init(void)
 {
 	/* Configure LPOSC 1M */
 	/* Power on LPOSC (1MHz) */
@@ -426,7 +427,8 @@ static void clock_init(void)
 }
 
 #if CONFIG_MIPI_DSI
-void imxrt_pre_init_display_interface(void)
+/* Weak so board can override this function */
+void __weak imxrt_pre_init_display_interface(void)
 {
 	/* Assert MIPI DPHY reset. */
 	RESET_SetPeripheralReset(kMIPI_DSI_PHY_RST_SHIFT_RSTn);
@@ -462,7 +464,7 @@ void imxrt_pre_init_display_interface(void)
 	RESET_ClearPeripheralReset(kMIPI_DSI_CTRL_RST_SHIFT_RSTn);
 }
 
-void imxrt_post_init_display_interface(void)
+void __weak imxrt_post_init_display_interface(void)
 {
 	/* Deassert MIPI DPHY reset. */
 	RESET_ClearPeripheralReset(kMIPI_DSI_PHY_RST_SHIFT_RSTn);
@@ -481,7 +483,7 @@ void imxrt_post_init_display_interface(void)
 static int nxp_rt500_init(void)
 {
 	/* Initialize clocks with tool generated code */
-	clock_init();
+	rt5xx_clock_init();
 
 #ifndef CONFIG_IMXRT5XX_CODE_CACHE
 	CACHE64_DisableCache(CACHE64_CTRL0);


### PR DESCRIPTION
Allows a board to provide their own functions if
they wish to init clocks differently.