### PR TITLE
Revert "modules: tinycrypt: Options only when module is available"

### DIFF
--- a/modules/Kconfig.tinycrypt
+++ b/modules/Kconfig.tinycrypt
@@ -3,12 +3,8 @@
 # Copyright (c) 2015 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-config ZEPHYR_TINYCRYPT_MODULE
-	bool
-
 config TINYCRYPT
 	bool "TinyCrypt Support"
-	depends on ZEPHYR_TINYCRYPT_MODULE
 	help
 	  This option enables the TinyCrypt cryptography library.
 


### PR DESCRIPTION
This reverts commit 713ca15224c3223e99bf045b1ab50a6917bf60ea.

This change broken several BT unit tests breaking CI in the main branch. Let's revert it.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/64344