### PR TITLE
ci: test using Python 3.12 as well

### DIFF
--- a/.github/workflows/devicetree_checks.yml
+++ b/.github/workflows/devicetree_checks.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10', '3.11']
+        python-version: [3.8, 3.9, '3.10', '3.11', '3.12']
         os: [ubuntu-22.04, macos-11, windows-2022]
         exclude:
         - os: macos-11

--- a/.github/workflows/pylib_tests.yml
+++ b/.github/workflows/pylib_tests.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10', '3.11']
+        python-version: [3.8, 3.9, '3.10', '3.11', '3.12']
         os: [ubuntu-22.04]
     steps:
     - name: checkout

--- a/.github/workflows/scripts_tests.yml
+++ b/.github/workflows/scripts_tests.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10', '3.11']
+        python-version: [3.8, 3.9, '3.10', '3.11', '3.12']
         os: [ubuntu-20.04]
     steps:
       - name: checkout

--- a/.github/workflows/twister_tests.yml
+++ b/.github/workflows/twister_tests.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10', '3.11']
+        python-version: [3.8, 3.9, '3.10', '3.11', '3.12']
         os: [ubuntu-22.04]
     steps:
     - name: checkout

--- a/.github/workflows/twister_tests_blackbox.yml
+++ b/.github/workflows/twister_tests_blackbox.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10', '3.11']
+        python-version: [3.8, 3.9, '3.10', '3.11', '3.12']
         os: [ubuntu-22.04]
     container:
       image: ghcr.io/zephyrproject-rtos/ci:v0.26.5

--- a/.github/workflows/west_cmds.yml
+++ b/.github/workflows/west_cmds.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10', '3.11']
+        python-version: [3.8, 3.9, '3.10', '3.11', '3.12']
         os: [ubuntu-22.04, macos-11, windows-2022]
         exclude:
         - os: macos-11

--- a/scripts/west_commands/tests/test_dfu_util.py
+++ b/scripts/west_commands/tests/test_dfu_util.py
@@ -86,7 +86,7 @@ def test_dfu_util_init(cc, req, find_device, tc, runner_config):
     with patch('os.path.isfile', side_effect=os_path_isfile_patch):
         runner.run('flash')
     assert find_device.called
-    assert req.called_with(exe)
+    assert req.call_args_list == [call(exe)]
     assert cc.call_args_list == [call(EXPECTED_COMMAND[tc])]
 
 def get_flash_address_patch(args, bcfg):
@@ -141,5 +141,5 @@ def test_dfu_util_create(cc, req, gfa, find_device, tc, runner_config, tmpdir):
         cfg = None
     map_tc = (exe or DFU_UTIL, alt, cfg, img or RC_KERNEL_BIN)
     assert find_device.called
-    assert req.called_with(exe)
+    assert req.call_args_list == [call(exe or DFU_UTIL)]
     assert cc.call_args_list == [call(EXPECTED_COMMAND[map_tc])]


### PR DESCRIPTION
Run CI tests against Python v3.12 as well.