### PR TITLE
debug: coredump: flash backend: print error if write fails

### DIFF
--- a/subsys/debug/coredump/coredump_backend_flash_partition.c
+++ b/subsys/debug/coredump/coredump_backend_flash_partition.c
@@ -527,6 +527,7 @@ static void coredump_flash_backend_buffer_output(uint8_t *buf, size_t buflen)
 					&backend_ctx.stream_ctx,
 					tmp_buf, copy_sz, false);
 		if (backend_ctx.error != 0) {
+			LOG_ERR("Flash write error: %d", backend_ctx.error);
 			break;
 		}
 


### PR DESCRIPTION
The loop in `coredump_flash_backend_buffer_output` might fail without any alerts. This could be due to e.g. a too small coredump-partion.

Add a LOG_ERR if an error occurs.