### PR TITLE
tests: spinlock: Clear test globals before each test

### DIFF
--- a/tests/kernel/spinlock/src/main.c
+++ b/tests/kernel/spinlock/src/main.c
@@ -233,6 +233,9 @@ static void before(void *ctx)
 	ARG_UNUSED(ctx);
 
 	bounce_done = 0;
+	bounce_owner = 0;
+	trylock_failures = 0;
+	trylock_successes = 0;
 }
 
 ZTEST_SUITE(spinlock, NULL, NULL, before, NULL, NULL);


### PR DESCRIPTION
Clear test global variables before each test execution.