### PR TITLE
mgmt: ec_host_cmd: improve handling buffer sizes

### DIFF
--- a/include/zephyr/mgmt/ec_host_cmd/backend.h
+++ b/include/zephyr/mgmt/ec_host_cmd/backend.h
@@ -43,11 +43,14 @@ struct ec_host_cmd_rx_ctx {
 	/**
 	 * Buffer to hold received data. The buffer is provided by the handler if
 	 * CONFIG_EC_HOST_CMD_HANDLER_RX_BUFFER_SIZE > 0. Otherwise, the backend should provide
-	 * the buffer on its own and overwrites @a buf pointer in the init function.
+	 * the buffer on its own and overwrites @a buf pointer and @a len_max
+	 * in the init function.
 	 */
 	uint8_t *buf;
 	/** Number of bytes written to @a buf by backend. */
 	size_t len;
+	/** Maximum number of bytes to receive with one request packet. */
+	size_t len_max;
 };
 
 /**
@@ -63,7 +66,7 @@ struct ec_host_cmd_tx_buf {
 	void *buf;
 	/** Number of bytes to write from @a buf. */
 	size_t len;
-	/** Size of @a buf. */
+	/** Maximum number of bytes to send with one response packet. */
 	size_t len_max;
 };
 

--- a/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_espi.c
+++ b/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_espi.c
@@ -114,6 +114,10 @@ static int ec_host_cmd_espi_init(const struct ec_host_cmd_backend *backend,
 	espi_read_lpc_request(hc_espi->espi_dev, ECUSTOM_HOST_CMD_GET_PARAM_MEMORY_SIZE,
 			      &tx->len_max);
 
+	/* Set the max len for RX as the min of buffer to store data and shared memory. */
+	hc_espi->rx_ctx->len_max =
+		MIN(CONFIG_EC_HOST_CMD_HANDLER_RX_BUFFER_SIZE, hc_espi->tx->len_max);
+
 	hc_espi->state = ESPI_STATE_READY_TO_RECV;
 
 	return 0;

--- a/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_shi_ite.c
+++ b/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_shi_ite.c
@@ -455,8 +455,9 @@ static int shi_ite_backend_init(const struct ec_host_cmd_backend *backend,
 	data->tx = tx;
 
 	rx_ctx->buf = data->in_msg;
+	rx_ctx->len_max = CONFIG_EC_HOST_CMD_BACKEND_SHI_MAX_REQUEST;
 	tx->buf = data->out_msg + sizeof(out_preamble);
-	data->tx->len_max = sizeof(data->out_msg) - EC_SHI_PREAMBLE_LENGTH - EC_SHI_PAST_END_LENGTH;
+	data->tx->len_max = CONFIG_EC_HOST_CMD_BACKEND_SHI_MAX_RESPONSE;
 
 	return 0;
 }

--- a/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_shi_npcx.c
+++ b/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_shi_npcx.c
@@ -882,6 +882,7 @@ static int shi_npcx_backend_init(const struct ec_host_cmd_backend *backend,
 	data->tx = tx;
 
 	rx_ctx->buf = data->in_msg;
+	rx_ctx->len_max = CONFIG_EC_HOST_CMD_BACKEND_SHI_MAX_REQUEST;
 	tx->buf = data->out_msg_padded + SHI_OUT_START_PAD;
 	tx->len_max = CONFIG_EC_HOST_CMD_BACKEND_SHI_MAX_RESPONSE;
 

--- a/subsys/mgmt/ec_host_cmd/ec_host_cmd_handler.c
+++ b/subsys/mgmt/ec_host_cmd/ec_host_cmd_handler.c
@@ -47,6 +47,8 @@ static struct ec_host_cmd ec_host_cmd = {
 	.rx_ctx = {
 			.buf = COND_CODE_1(CONFIG_EC_HOST_CMD_HANDLER_RX_BUFFER_DEF, (hc_rx_buffer),
 					   (NULL)),
+			.len_max = COND_CODE_1(CONFIG_EC_HOST_CMD_HANDLER_RX_BUFFER_DEF,
+					       (CONFIG_EC_HOST_CMD_HANDLER_RX_BUFFER_SIZE), (0)),
 		},
 	.tx = {
 			.buf = COND_CODE_1(CONFIG_EC_HOST_CMD_HANDLER_TX_BUFFER_DEF, (hc_tx_buffer),


### PR DESCRIPTION
Add the len_max rx structure member to indicate maximum number of bytes possible to receive. It is needed to send information about our protocol parameters to host.

Also, limit the maximum size of request/responses for backends that uses buffers provided by the handler.