### PR TITLE
tests/coredump: Force unaligned access exception on RISC-V

### DIFF
--- a/tests/subsys/debug/coredump/src/main.c
+++ b/tests/subsys/debug/coredump/src/main.c
@@ -8,6 +8,8 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/debug/coredump.h>
 
+uint32_t *addr1 = (void *) 1;
+
 void func_3(uint32_t *addr)
 {
 #if defined(CONFIG_BOARD_M2GL025_MIV) || \
@@ -22,6 +24,9 @@ void func_3(uint32_t *addr)
 	 * a lot, so it's good to check that it causes a coredump.
 	 */
 	k_panic();
+#elif defined(CONFIG_RISCV)
+	ARG_UNUSED(addr);
+	*addr1 = 0;
 #elif !defined(CONFIG_CPU_CORTEX_M)
 	/* For null pointer reference */
 	*addr = 0;


### PR DESCRIPTION
Previously the compiler compiled the `tests/subsys/debug/coredump/src/main.c:main()` function into this:
```
  000000000000024c <main>:
       24c:       1141                    addi    sp,sp,-16
       24e:       00003597                auipc   a1,0x3
       252:       43a58593                addi    a1,a1,1082
       256:       00003517                auipc   a0,0x3
       25a:       44250513                addi    a0,a0,1090
       25e:       e406                    sd      ra,8(sp)
       260:       074000ef                jal     ra,2d4 <printk>
       264:       00002023                sw      zero,0(zero)
       268:       9002                    ebreak
```

In particular the compiler emits an `ebreak` because it has (correctly) identified that the code path implies undefined behavior. The compiler also happens to insert the store to address 0 but we should not depend on that.

On a RISC-V system where a write to address zero generates a store exception, this works.

On a RISC-V system where a write to address zero is accepted, the ebreak will hit instead. In my particular RISC-V system, writing to address zero does not generate an exception, and an `ebreak` gives control back to the debugger and thus the coredump subsys will not be invoked.

This commit changes the behavior to dereference a `uint32_t` pointing to address 1 instead. The compiler can not detect undefined behavior at compile-time and thus no `ebreak` is emitted. The exception will now be "Store/AMO address misaligned".

With this commit, the `main()` function will look something like this:
```
  000000000000024c <main>:
       24c:       1141                    addi    sp,sp,-16
       24e:       00003517                auipc   a0,0x3
       252:       45a50513                addi    a0,a0,1114
       256:       00003597                auipc   a1,0x3
       25a:       44258593                addi    a1,a1,1090
       25e:       e406                    sd      ra,8(sp)
       260:       082000ef                jal     ra,2e2
       264:       00006797                auipc   a5,0x6
       268:       26c7b783                ld      a5,620(a5)
       26c:       0007a023                sw      zero,0(a5)
       270:       60a2                    ld      ra,8(sp)
       272:       4501                    li      a0,0
       274:       0141                    addi    sp,sp,16
       276:       8082                    ret
```