### PR TITLE
tests: Fix spinlock test

### DIFF
--- a/tests/kernel/spinlock/src/main.c
+++ b/tests/kernel/spinlock/src/main.c
@@ -233,6 +233,9 @@ static void before(void *ctx)
 	ARG_UNUSED(ctx);
 
 	bounce_done = 0;
+	bounce_owner = 0;
+	trylock_failures = 0;
+	trylock_successes = 0;
 }
 
 ZTEST_SUITE(spinlock, NULL, NULL, before, NULL, NULL);

--- a/tests/kernel/spinlock/src/main.c
+++ b/tests/kernel/spinlock/src/main.c
@@ -70,6 +70,7 @@ static void bounce_once(int id, bool trylock)
 			ret = k_spin_trylock(&bounce_lock, &key);
 			if (ret == -EBUSY) {
 				trylock_failures++;
+				k_busy_wait(10);
 				continue;
 			}
 			trylock_successes++;
@@ -82,6 +83,7 @@ static void bounce_once(int id, bool trylock)
 			break;
 		}
 
+		k_busy_wait(10);
 		k_spin_unlock(&bounce_lock, key);
 		k_busy_wait(100);
 	}


### PR DESCRIPTION
Spinlock tests are reusing some parts of the code in several test paths, making it unreadable and depending on the result of the previous executing (using too much globals).

Clear globals and adding delays for fast CPUs.

Fixes #60330