### PR TITLE
drivers: regulator: fixed/gpio: Add non-multithreading support

### DIFF
--- a/drivers/regulator/regulator_fixed.c
+++ b/drivers/regulator/regulator_fixed.c
@@ -42,7 +42,11 @@ static int regulator_fixed_enable(const struct device *dev)
 	}
 
 	if (cfg->off_on_delay_us > 0U) {
+#ifdef CONFIG_MULTITHREADING
 		k_sleep(K_USEC(cfg->off_on_delay_us));
+#else
+		k_busy_wait(cfg->off_on_delay_us);
+#endif
 	}
 
 	return 0;

--- a/drivers/regulator/regulator_gpio.c
+++ b/drivers/regulator/regulator_gpio.c
@@ -74,7 +74,11 @@ static int regulator_gpio_enable(const struct device *dev)
 	}
 
 	if (cfg->startup_delay_us > 0U) {
+#ifdef CONFIG_MULTITHREADING
 		k_sleep(K_USEC(cfg->startup_delay_us));
+#else
+		k_busy_wait(cfg->startup_delay_us);
+#endif
 	}
 
 	return 0;


### PR DESCRIPTION
Adds support for using the fixed and GPIO regulator drivers when multithreading is disabled, such as in MCUboot.