### PR TITLE
nrf53bsim: Add support for split 15.4 builds

### DIFF
--- a/boards/posix/nrf_bsim/nrf5340bsim_nrf5340_cpuapp.dts
+++ b/boards/posix/nrf_bsim/nrf5340bsim_nrf5340_cpuapp.dts
@@ -47,6 +47,7 @@
 	chosen {
 		zephyr,flash = &flash0;
 		zephyr,bt-hci-rpmsg-ipc = &ipc0;
+		nordic,802154-spinel-ipc = &ipc0;
 	};
 
 	soc {

--- a/boards/posix/nrf_bsim/nrf5340bsim_nrf5340_cpunet.dts
+++ b/boards/posix/nrf_bsim/nrf5340bsim_nrf5340_cpunet.dts
@@ -28,6 +28,7 @@
 
 	chosen {
 		zephyr,bt-hci-rpmsg-ipc = &ipc0;
+		nordic,802154-spinel-ipc = &ipc0;
 		zephyr,ieee802154 = &ieee802154;
 		/delete-property/ zephyr,flash-controller;
 		zephyr,flash = &flash1;

--- a/samples/boards/nrf/ieee802154/802154_rpmsg/sample.yaml
+++ b/samples/boards/nrf/ieee802154/802154_rpmsg/sample.yaml
@@ -5,4 +5,6 @@ sample:
 tests:
   sample.boards.nrf.802154_rpmsg:
     build_only: true
-    platform_allow: nrf5340dk_nrf5340_cpunet
+    platform_allow:
+      - nrf5340dk_nrf5340_cpunet
+      - nrf5340bsim_nrf5340_cpunet


### PR DESCRIPTION
Add the required chosen DT properties to enable split 15.4 builds.
Enable building the 802154_rpmsg on the simulated nrf5340 net core.
