### PR TITLE
samples/bluetooth/hci_rpmsg: Allow building for simulated nrf5340

### DIFF
--- a/samples/bluetooth/hci_rpmsg/sample.yaml
+++ b/samples/bluetooth/hci_rpmsg/sample.yaml
@@ -8,6 +8,7 @@ tests:
     platform_allow:
       - nrf5340dk_nrf5340_cpunet
       - nrf5340_audio_dk_nrf5340_cpunet
+      - nrf5340bsim_nrf5340_cpunet
     integration_platforms:
       - nrf5340dk_nrf5340_cpunet
       - nrf5340_audio_dk_nrf5340_cpunet
@@ -18,6 +19,7 @@ tests:
     platform_allow:
       - nrf5340dk_nrf5340_cpunet
       - nrf5340_audio_dk_nrf5340_cpunet
+      - nrf5340bsim_nrf5340_cpunet
     integration_platforms:
       - nrf5340dk_nrf5340_cpunet
       - nrf5340_audio_dk_nrf5340_cpunet
@@ -28,6 +30,7 @@ tests:
     platform_allow:
       - nrf5340dk_nrf5340_cpunet
       - nrf5340_audio_dk_nrf5340_cpunet
+      - nrf5340bsim_nrf5340_cpunet
     integration_platforms:
       - nrf5340dk_nrf5340_cpunet
   sample.bluetooth.hci_rpmsg.bis.bt_ll_sw_split:
@@ -37,6 +40,7 @@ tests:
     platform_allow:
       - nrf5340dk_nrf5340_cpunet
       - nrf5340_audio_dk_nrf5340_cpunet
+      - nrf5340bsim_nrf5340_cpunet
     integration_platforms:
       - nrf5340dk_nrf5340_cpunet
   sample.bluetooth.hci_rpmsg.iso_central.bt_ll_sw_split:
@@ -46,6 +50,7 @@ tests:
     platform_allow:
       - nrf5340dk_nrf5340_cpunet
       - nrf5340_audio_dk_nrf5340_cpunet
+      - nrf5340bsim_nrf5340_cpunet
     integration_platforms:
       - nrf5340dk_nrf5340_cpunet
   sample.bluetooth.hci_rpmsg.iso_peripheral.bt_ll_sw_split:
@@ -55,6 +60,7 @@ tests:
     platform_allow:
       - nrf5340dk_nrf5340_cpunet
       - nrf5340_audio_dk_nrf5340_cpunet
+      - nrf5340bsim_nrf5340_cpunet
     integration_platforms:
       - nrf5340dk_nrf5340_cpunet
   sample.bluetooth.hci_rpmsg.cis.bt_ll_sw_split:
@@ -64,13 +70,16 @@ tests:
     platform_allow:
       - nrf5340dk_nrf5340_cpunet
       - nrf5340_audio_dk_nrf5340_cpunet
+      - nrf5340bsim_nrf5340_cpunet
     integration_platforms:
       - nrf5340dk_nrf5340_cpunet
   sample.bluetooth.hci_rpmsg.iso.bt_ll_sw_split:
     harness: bluetooth
     tags: bluetooth
     extra_args: CONF_FILE="nrf5340_cpunet_iso-bt_ll_sw_split.conf"
-    platform_allow: nrf5340dk_nrf5340_cpunet
+    platform_allow:
+      - nrf5340dk_nrf5340_cpunet
+      - nrf5340bsim_nrf5340_cpunet
     integration_platforms:
       - nrf5340dk_nrf5340_cpunet
   sample.bluetooth.hci_rpmsg.df.bt_ll_sw_split:


### PR DESCRIPTION
Allow building these samples for the simulted nrf5340 net core.