### PR TITLE
drivers: gpio: gpio_pca953x: Adding input latch and interrupt mask configuration

### DIFF
--- a/drivers/gpio/gpio_pca953x.c
+++ b/drivers/gpio/gpio_pca953x.c
@@ -27,6 +27,8 @@ LOG_MODULE_REGISTER(pca953x, CONFIG_GPIO_LOG_LEVEL);
 #define PCA953X_INPUT_PORT		0x00
 #define PCA953X_OUTPUT_PORT		0x01
 #define PCA953X_CONFIGURATION		0x03
+#define REG_INPUT_LATCH_PORT0 0x42
+#define REG_INT_MASK_PORT0    0x45
 
 /* Number of pins supported by the device */
 #define NUM_PINS 8
@@ -67,6 +69,8 @@ struct pca953x_config {
 	struct i2c_dt_spec i2c;
 	const struct gpio_dt_spec gpio_int;
 	bool interrupt_enabled;
+	uint8_t interrupt_mask;
+	uint8_t input_latch;
 };
 
 /**
@@ -439,6 +443,12 @@ static int gpio_pca953x_init(const struct device *dev)
 
 		rc = gpio_add_callback(cfg->gpio_int.port,
 					&drv_data->gpio_cb);
+
+		//Input latch config
+		i2c_reg_write_byte_dt(&cfg->i2c, REG_INPUT_LATCH_PORT0, cfg->input_latch);
+
+		//Interrupt mask config
+		i2c_reg_write_byte_dt(&cfg->i2c, REG_INT_MASK_PORT0, cfg->interrupt_mask);
 	}
 out:
 	if (rc) {
@@ -467,8 +477,10 @@ static const struct gpio_driver_api api_table = {
 			.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(n),	\
 		},								\
 		.interrupt_enabled = DT_INST_NODE_HAS_PROP(n, nint_gpios),	\
-		.gpio_int = GPIO_DT_SPEC_INST_GET_OR(n, nint_gpios, {0}),	\
-	};									\
+		.gpio_int = GPIO_DT_SPEC_INST_GET_OR(n, nint_gpios, {0}),  \
+		.interrupt_mask = DT_INST_PROP_OR(n, interrupt_mask, 0),	\
+		.input_latch = DT_INST_PROP_OR(n, input_latch, 0)		\
+		};									\
 										\
 	static struct pca953x_drv_data pca953x_drvdata_##n = {			\
 		.lock = Z_SEM_INITIALIZER(pca953x_drvdata_##n.lock, 1, 1),	\

--- a/drivers/gpio/gpio_pca953x.c
+++ b/drivers/gpio/gpio_pca953x.c
@@ -27,8 +27,8 @@ LOG_MODULE_REGISTER(pca953x, CONFIG_GPIO_LOG_LEVEL);
 #define PCA953X_INPUT_PORT		0x00
 #define PCA953X_OUTPUT_PORT		0x01
 #define PCA953X_CONFIGURATION		0x03
-#define REG_INPUT_LATCH_PORT0 0x42
-#define REG_INT_MASK_PORT0    0x45
+#define REG_INPUT_LATCH_PORT0   0x42
+#define REG_INT_MASK_PORT0      0x45
 
 /* Number of pins supported by the device */
 #define NUM_PINS 8
@@ -444,10 +444,10 @@ static int gpio_pca953x_init(const struct device *dev)
 		rc = gpio_add_callback(cfg->gpio_int.port,
 					&drv_data->gpio_cb);
 
-		//Input latch config
+		/* Input latch config */
 		i2c_reg_write_byte_dt(&cfg->i2c, REG_INPUT_LATCH_PORT0, cfg->input_latch);
 
-		//Interrupt mask config
+		/* Interrupt mask config */
 		i2c_reg_write_byte_dt(&cfg->i2c, REG_INT_MASK_PORT0, cfg->interrupt_mask);
 	}
 out:

--- a/dts/bindings/gpio/ti,tca9538.yaml
+++ b/dts/bindings/gpio/ti,tca9538.yaml
@@ -24,6 +24,18 @@ properties:
       Connection for the NINT signal. This signal is active-low when
       produced by tca9538 GPIO node.
 
+  input-latch:
+    type: int
+    default: 0
+    description: |
+      Setting for Input Latch.
+
+  interrupt-mask:
+    type: int
+    default: 0
+    description: |
+      Setting for Interrupt mask.
+
 gpio-cells:
   - pin
   - flags


### PR DESCRIPTION
The gpio_pca953x gpio driver doesn't have the input latch and interrupt mask configuration which causes a lack of accessing and using those features on an gpio expander device. Fix it by adding input latch and interrupt mask configurations in this driver.