### PR TITLE
ci: twister: store the list of python packages

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -273,6 +273,24 @@ jobs:
             module_tests/twister.xml
             testplan.json
 
+      - if: matrix.subset == 1 && github.event_name == 'push'
+        name: Save the list of Python packages
+        shell: bash
+        run: |
+          FREEZE_FILE="frozen-requirements.txt"
+          timestamp="$(date)"
+          version="$(git describe --abbrev=12 --always)"
+          echo -e "# Generated at $timestamp ($version)\n" > $FREEZE_FILE
+          pip3 freeze | tee -a $FREEZE_FILE
+
+      - if: matrix.subset == 1 && github.event_name == 'push'
+        name: Upload the list of Python packages
+        uses: actions/upload-artifact@v3
+        with:
+          name: Frozen PIP package set
+          path: |
+            frozen-requirements.txt
+
   twister-test-results:
     name: "Publish Unit Tests Results"
     env:


### PR DESCRIPTION
This adds the Python package list used by the CI image to the list of uploaded artifacts as part of the push runs so it can be stored as part of the release, see the discussion in https://github.com/zephyrproject-rtos/zephyr/issues/64281.

Ideally this would be fully automated, so a followup would be to add a workflow that runs on tag events that gets the list and uploads it as a PR for the release target branch.

Note that this has to run on one of the workflows using the same CI image as twister (i.e. can't run it in `release.yml`, at least in the current setup).

~~Test run: https://github.com/zephyrproject-rtos/zephyr-testing/actions/runs/6643831683 outdated~~

---

Add a step to the #1 twister shard to upload the list of Python packages used with the build.