### PR TITLE
tests/cmsis_dsp: Check ARM conv func for output overrun

### DIFF
--- a/tests/lib/cmsis_dsp/filtering/src/misc_q15.c
+++ b/tests/lib/cmsis_dsp/filtering/src/misc_q15.c
@@ -81,7 +81,8 @@ static void test_arm_conv_q15(
 	q15_t *output;
 
 	/* Allocate output buffer */
-	output = calloc(ref_length, sizeof(q15_t));
+	output = calloc(ref_length + 1, sizeof(q15_t));
+	output[ref_length] = 0x5aa5;
 
 	/* Run test function */
 	arm_conv_q15(in_com1, in1_length, in_com2, in2_length, output);
@@ -95,6 +96,9 @@ static void test_arm_conv_q15(
 		test_near_equal_q15(ref_length, ref, output,
 			ABS_ERROR_THRESH_Q15),
 		ASSERT_MSG_ABS_ERROR_LIMIT_EXCEED);
+
+	zassert_true(output[ref_length] == 0x5aa5,
+		     "output buffer overflow");
 
 	/* Free output buffer */
 	free(output);

--- a/tests/lib/cmsis_dsp/filtering/src/misc_q31.c
+++ b/tests/lib/cmsis_dsp/filtering/src/misc_q31.c
@@ -106,7 +106,8 @@ static void test_arm_conv_q31(
 	q31_t *output;
 
 	/* Allocate output buffer */
-	output = calloc(ref_length, sizeof(q31_t));
+	output = calloc(ref_length + 1, sizeof(q31_t));
+	output[ref_length] = 0x5aa5a55a;
 
 	/* Run test function */
 	arm_conv_q31(in_com1, in1_length, in_com2, in2_length, output);
@@ -120,6 +121,9 @@ static void test_arm_conv_q31(
 		test_near_equal_q31(ref_length, ref, output,
 			ABS_ERROR_THRESH_Q31),
 		ASSERT_MSG_ABS_ERROR_LIMIT_EXCEED);
+
+	zassert_true(output[ref_length] == 0x5aa5a55a,
+		     "output buffer overflow");
 
 	/* Free output buffer */
 	free(output);

--- a/tests/lib/cmsis_dsp/filtering/src/misc_q7.c
+++ b/tests/lib/cmsis_dsp/filtering/src/misc_q7.c
@@ -80,7 +80,8 @@ static void test_arm_conv_q7(
 	q7_t *output;
 
 	/* Allocate output buffer */
-	output = calloc(ref_length, sizeof(q7_t));
+	output = calloc(ref_length + 1, sizeof(q7_t));
+	output[ref_length] = 0x5a;
 
 	/* Run test function */
 	arm_conv_q7(in_com1, in1_length, in_com2, in2_length, output);
@@ -94,6 +95,9 @@ static void test_arm_conv_q7(
 		test_near_equal_q7(ref_length, ref, output,
 			ABS_ERROR_THRESH_Q7),
 		ASSERT_MSG_ABS_ERROR_LIMIT_EXCEED);
+
+	zassert_true(output[ref_length] == 0x5a,
+		     "output buffer overflow");
 
 	/* Free output buffer */
 	free(output);


### PR DESCRIPTION
The ARM conv functions q7 and q15 occasionally overrun the expected output buffer length by one value. Add a simplistic buffer overflow check to the tests for those (and q31) so that this issue can be more easily tracked.

See issue #64387 