### PR TITLE
modules: lvgl: Fix usage of LVGL log levels

### DIFF
--- a/modules/lvgl/Kconfig
+++ b/modules/lvgl/Kconfig
@@ -22,6 +22,36 @@ config LV_CONF_SKIP
 	bool
 	default n
 
+config LV_USE_LOG
+	bool
+
+config LV_LOG_LEVEL_NONE
+	bool
+
+config LV_LOG_LEVEL_ERROR
+	bool
+
+config LV_LOG_LEVEL_WARN
+	bool
+
+config LV_LOG_LEVEL_INFO
+	bool
+
+config LV_LOG_LEVEL_USER
+	bool
+
+config LV_LOG_LEVEL_TRACE
+	bool
+
+config LV_Z_LOG_LEVEL
+	int
+	default 0 if LV_LOG_LEVEL_NONE || !LV_USE_LOG
+	default 1 if LV_LOG_LEVEL_ERROR
+	default 2 if LV_LOG_LEVEL_WARN
+	default 3 if LV_LOG_LEVEL_INFO
+	default 3 if LV_LOG_LEVEL_USER
+	default 4 if LV_LOG_LEVEL_TRACE
+
 config APP_LINK_WITH_LVGL
 	bool "Link 'app' with LVGL"
 	default y

--- a/modules/lvgl/input/lvgl_button_input.c
+++ b/modules/lvgl/input/lvgl_button_input.c
@@ -11,7 +11,7 @@
 
 #include <zephyr/logging/log.h>
 
-LOG_MODULE_DECLARE(lvgl);
+LOG_MODULE_DECLARE(lvgl, CONFIG_LV_Z_LOG_LEVEL);
 
 struct lvgl_button_input_config {
 	struct lvgl_common_input_config common_config; /* Needs to be first member */

--- a/modules/lvgl/input/lvgl_common_input.c
+++ b/modules/lvgl/input/lvgl_common_input.c
@@ -13,7 +13,7 @@
 #include "lvgl_button_input.h"
 #include "lvgl_encoder_input.h"
 
-LOG_MODULE_DECLARE(lvgl);
+LOG_MODULE_DECLARE(lvgl, CONFIG_LV_Z_LOG_LEVEL);
 
 lv_indev_t *lvgl_input_get_indev(const struct device *dev)
 {

--- a/modules/lvgl/input/lvgl_encoder_input.c
+++ b/modules/lvgl/input/lvgl_encoder_input.c
@@ -11,7 +11,7 @@
 
 #include <zephyr/logging/log.h>
 
-LOG_MODULE_DECLARE(lvgl);
+LOG_MODULE_DECLARE(lvgl, CONFIG_LV_Z_LOG_LEVEL);
 
 struct lvgl_encoder_input_config {
 	struct lvgl_common_input_config common_config; /* Needs to be first member */

--- a/modules/lvgl/input/lvgl_pointer_input.c
+++ b/modules/lvgl/input/lvgl_pointer_input.c
@@ -12,7 +12,7 @@
 #include <lvgl_display.h>
 #include <zephyr/logging/log.h>
 
-LOG_MODULE_DECLARE(lvgl);
+LOG_MODULE_DECLARE(lvgl, CONFIG_LV_Z_LOG_LEVEL);
 
 struct lvgl_pointer_input_config {
 	struct lvgl_common_input_config common_config; /* Needs to be first member */

--- a/modules/lvgl/input/lvgl_pointer_kscan.c
+++ b/modules/lvgl/input/lvgl_pointer_kscan.c
@@ -10,7 +10,7 @@
 #include "lvgl_display.h"
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_DECLARE(lvgl);
+LOG_MODULE_DECLARE(lvgl, CONFIG_LV_Z_LOG_LEVEL);
 
 static lv_indev_drv_t indev_drv;
 #define KSCAN_NODE DT_CHOSEN(zephyr_keyboard_scan)

--- a/modules/lvgl/lvgl.c
+++ b/modules/lvgl/lvgl.c
@@ -17,9 +17,8 @@
 #endif
 #include LV_MEM_CUSTOM_INCLUDE
 
-#define LOG_LEVEL CONFIG_LV_LOG_LEVEL
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(lvgl);
+LOG_MODULE_REGISTER(lvgl, CONFIG_LV_Z_LOG_LEVEL);
 
 static lv_disp_drv_t disp_drv;
 struct lvgl_disp_data disp_data = {
@@ -61,7 +60,7 @@ static uint8_t buf1[BUFFER_SIZE]
 
 #endif /* CONFIG_LV_Z_BUFFER_ALLOC_STATIC */
 
-#if CONFIG_LV_LOG_LEVEL != 0
+#if CONFIG_LV_Z_LOG_LEVEL != 0
 /*
  * In LVGLv8 the signature of the logging callback has changes and it no longer
  * takes the log level as an integer argument. Instead, the log level is now
@@ -83,13 +82,16 @@ static void lvgl_log(const char *buf)
 		LOG_ERR("%s", buf + strlen("[Error] "));
 		break;
 	case 'W':
-		LOG_WRN("%s", buf + strlen("Warn] "));
+		LOG_WRN("%s", buf + strlen("[Warn] "));
 		break;
 	case 'I':
 		LOG_INF("%s", buf + strlen("[Info] "));
 		break;
 	case 'T':
 		LOG_DBG("%s", buf + strlen("[Trace] "));
+		break;
+	case 'U':
+		LOG_INF("%s", buf + strlen("[User] "));
 		break;
 	}
 }
@@ -207,7 +209,7 @@ static int lvgl_init(void)
 	lvgl_heap_init();
 #endif
 
-#if CONFIG_LV_LOG_LEVEL != 0
+#if CONFIG_LV_Z_LOG_LEVEL != 0
 	lv_log_register_print_cb(lvgl_log);
 #endif
 


### PR DESCRIPTION
Introduces a Kconfig symbol `LV_Z_LOG_LEVEL` because contrary to Zephyr the numerical value of log levels in LVGL increases with severity. Also support for the `LV_LOG_LEVEL_USER` is added.
Resolves issue #64351.

Also:
- Fixed an issue with the "WARN" string offset length when parsing messages,
- Added support for USER messages. This one might be controversial in how it  should be working. From the docs:
```
LV_LOG_LEVEL_USER Only user messages
```
 I mapped it  to be an `INFO` message since I guess the point is to have certain logs the user puts into his app stand out specifically and at least from my experience LVGL internals do not do excessive logging when set to INFO.
 
**Note** When building with `CONFIG_LV_LOG_LEVEL_NONE=y`  this will generate a format-truncation warning in this file: [src/misc/lv_log.c#L99](https://github.com/zephyrproject-rtos/lvgl/blob/zephyr/src/misc/lv_log.c#L99). To me this looks like a false positive.

