### PR TITLE
drivers: can: be consistent in filter_id checks when removing rx filters

### DIFF
--- a/drivers/can/can_loopback.c
+++ b/drivers/can/can_loopback.c
@@ -211,7 +211,7 @@ static void can_loopback_remove_rx_filter(const struct device *dev, int filter_i
 {
 	struct can_loopback_data *data = dev->data;
 
-	if (filter_id >= ARRAY_SIZE(data->filters)) {
+	if (filter_id < 0 || filter_id >= ARRAY_SIZE(data->filters)) {
 		LOG_ERR("filter ID %d out-of-bounds", filter_id);
 		return;
 	}

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -1149,12 +1149,17 @@ void can_mcan_remove_rx_filter(const struct device *dev, int filter_id)
 	struct can_mcan_data *data = dev->data;
 	int err;
 
+	if (filter_id < 0) {
+		LOG_ERR("filter ID %d out of bounds", filter_id);
+		return;
+	}
+
 	k_mutex_lock(&data->lock, K_FOREVER);
 
 	if (filter_id >= cbs->num_std) {
 		filter_id -= cbs->num_std;
 		if (filter_id >= cbs->num_ext) {
-			LOG_ERR("Wrong filter id");
+			LOG_ERR("filter ID %d out of bounds", filter_id);
 			k_mutex_unlock(&data->lock);
 			return;
 		}

--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -663,6 +663,11 @@ static void mcp2515_remove_rx_filter(const struct device *dev, int filter_id)
 {
 	struct mcp2515_data *dev_data = dev->data;
 
+	if (filter_id < 0 || filter_id >= CONFIG_CAN_MAX_FILTER) {
+		LOG_ERR("filter ID %d out of bounds", filter_id);
+		return;
+	}
+
 	k_mutex_lock(&dev_data->mutex, K_FOREVER);
 	dev_data->filter_usage &= ~BIT(filter_id);
 	k_mutex_unlock(&dev_data->mutex);

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -922,9 +922,8 @@ static void mcux_flexcan_remove_rx_filter(const struct device *dev, int filter_i
 {
 	struct mcux_flexcan_data *data = dev->data;
 
-	if (filter_id >= MCUX_FLEXCAN_MAX_RX) {
-		LOG_ERR("Detach: Filter id >= MAX_RX (%d >= %d)", filter_id,
-			MCUX_FLEXCAN_MAX_RX);
+	if (filter_id < 0 || filter_id >= MCUX_FLEXCAN_MAX_RX) {
+		LOG_ERR("filter ID %d out of bounds", filter_id);
 		return;
 	}
 

--- a/drivers/can/can_native_posix_linux.c
+++ b/drivers/can/can_native_posix_linux.c
@@ -239,6 +239,7 @@ static void can_npl_remove_rx_filter(const struct device *dev, int filter_id)
 	struct can_npl_data *data = dev->data;
 
 	if (filter_id < 0 || filter_id >= ARRAY_SIZE(data->filters)) {
+		LOG_ERR("filter ID %d out of bounds");
 		return;
 	}
 

--- a/drivers/can/can_nxp_s32_canxl.c
+++ b/drivers/can/can_nxp_s32_canxl.c
@@ -396,7 +396,10 @@ static void can_nxp_s32_remove_rx_filter(const struct device *dev, int filter_id
 	struct can_nxp_s32_data *data = dev->data;
 	int mb_indx = ALLOC_IDX_TO_RXMB_IDX(filter_id);
 
-	__ASSERT_NO_MSG(filter_id >= 0 && filter_id < CONFIG_CAN_NXP_S32_MAX_RX);
+	if (filter_id < 0 || filter_id >= CONFIG_CAN_NXP_S32_MAX_RX) {
+		LOG_ERR("filter ID %d out of bounds", filter_id);
+		return;
+	}
 
 	k_mutex_lock(&data->rx_mutex, K_FOREVER);
 

--- a/drivers/can/can_rcar.c
+++ b/drivers/can/can_rcar.c
@@ -975,7 +975,8 @@ static void can_rcar_remove_rx_filter(const struct device *dev, int filter_id)
 {
 	struct can_rcar_data *data = dev->data;
 
-	if (filter_id >= CONFIG_CAN_RCAR_MAX_FILTER) {
+	if (filter_id < 0 || filter_id >= CONFIG_CAN_RCAR_MAX_FILTER) {
+		LOG_ERR("filter ID %d out of bounds", filter_id);
 		return;
 	}
 

--- a/drivers/can/can_stm32_bxcan.c
+++ b/drivers/can/can_stm32_bxcan.c
@@ -1035,7 +1035,10 @@ static void can_stm32_remove_rx_filter(const struct device *dev, int filter_id)
 	int bank_num;
 	bool bank_unused;
 
-	__ASSERT_NO_MSG(filter_id >= 0 && filter_id < CAN_STM32_MAX_FILTER_ID);
+	if (filter_id < 0 || filter_id >= CAN_STM32_MAX_FILTER_ID) {
+		LOG_ERR("filter ID %d out of bounds", filter_id);
+		return;
+	}
 
 	k_mutex_lock(&filter_mutex, K_FOREVER);
 	k_mutex_lock(&data->inst_mutex, K_FOREVER);


### PR DESCRIPTION
Change the CAN controller driver implementations for the `can_remove_rx_filter()` API call to be consistent in their validation of the supplied `filter_id`.

Fixes: #64398