### PR TITLE
unittest: Fix issue with modules

### DIFF
--- a/cmake/modules/unittest.cmake
+++ b/cmake/modules/unittest.cmake
@@ -6,6 +6,9 @@ include(root)
 include(boards)
 include(arch)
 include(configuration_files)
+
+include(west)
+include(zephyr_module)
 include(kconfig)
 
 find_package(TargetTools)

--- a/modules/Kconfig.tinycrypt
+++ b/modules/Kconfig.tinycrypt
@@ -3,8 +3,12 @@
 # Copyright (c) 2015 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+config ZEPHYR_TINYCRYPT_MODULE
+	bool
+
 config TINYCRYPT
 	bool "TinyCrypt Support"
+	depends on ZEPHYR_TINYCRYPT_MODULE
 	help
 	  This option enables the TinyCrypt cryptography library.
 


### PR DESCRIPTION
Unit tests may use zephyr modules, so we need to run zephyr_module.py