### PR TITLE
toolchain: add nonnull attribute macro

### DIFF
--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -2397,6 +2397,7 @@ PREDEFINED             = __DOXYGEN__ \
                          __deprecated= \
                          __packed= \
                          __aligned(x)= \
+                         __attribute_nonnull(...)= \
                          "__printf_like(x, y)=" \
                          __attribute__(x)= \
                          __syscall= \

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -5377,7 +5377,7 @@ void *k_heap_alloc(struct k_heap *h, size_t bytes,
  * @param h Heap to which to return the memory
  * @param mem A valid memory block, or NULL
  */
-void k_heap_free(struct k_heap *h, void *mem);
+void k_heap_free(struct k_heap *h, void *mem) __attribute_nonnull(1);
 
 /* Hand-calculated minimum heap sizes needed to return a successful
  * 1-byte allocation.  See details in lib/os/heap.[ch]

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -5319,7 +5319,8 @@ struct k_heap {
  * @param mem Pointer to memory.
  * @param bytes Size of memory region, in bytes
  */
-void k_heap_init(struct k_heap *h, void *mem, size_t bytes);
+void k_heap_init(struct k_heap *h, void *mem,
+		size_t bytes) __attribute_nonnull(1);
 
 /** @brief Allocate aligned memory from a k_heap
  *

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -5341,7 +5341,7 @@ void k_heap_init(struct k_heap *h, void *mem, size_t bytes);
  * @return Pointer to memory the caller can now use
  */
 void *k_heap_aligned_alloc(struct k_heap *h, size_t align, size_t bytes,
-			k_timeout_t timeout);
+			k_timeout_t timeout) __attribute_nonnull(1);
 
 /**
  * @brief Allocate memory from a k_heap

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -5365,7 +5365,7 @@ void *k_heap_aligned_alloc(struct k_heap *h, size_t align, size_t bytes,
  * @return A pointer to valid heap memory, or NULL
  */
 void *k_heap_alloc(struct k_heap *h, size_t bytes,
-				 k_timeout_t timeout);
+		k_timeout_t timeout) __attribute_nonnull(1);
 
 /**
  * @brief Free memory allocated by k_heap_alloc()

--- a/include/zephyr/toolchain/gcc.h
+++ b/include/zephyr/toolchain/gcc.h
@@ -274,6 +274,10 @@ do {                                                                    \
 #define __weak __attribute__((__weak__))
 #endif
 
+#ifndef __attribute_nonnull
+#define __attribute_nonnull(...) __attribute__((nonnull(__VA_ARGS__)))
+#endif
+
 /* Builtins with availability that depend on the compiler version. */
 #if __GNUC__ >= 5
 #define HAS_BUILTIN___builtin_add_overflow 1


### PR DESCRIPTION
Add a new macro to declare that certain parameters should be non-null. When NULL is passed to these non-null declared parameters a warning is generated.
Starting using this macro in k_heap_free and k_heap_aligned_alloc.

Inspired in https://github.com/zephyrproject-rtos/zephyr/pull/64159