### PR TITLE
scripts: coverage: gcovr to ignore negative counters

### DIFF
--- a/scripts/pylib/twister/twisterlib/coverage.py
+++ b/scripts/pylib/twister/twisterlib/coverage.py
@@ -221,11 +221,11 @@ class Gcovr(CoverageTool):
         excludes = Gcovr._interleave_list("-e", self.ignores)
 
         # We want to remove tests/* and tests/ztest/test/* but save tests/ztest
-        cmd = ["gcovr", "-r", self.base_dir, "--gcov-executable",
-               str(self.gcov_tool), "-e", "tests/*"] + excludes + ["--json",
-                                                                   "-o",
-                                                                   coveragefile,
-                                                                   outdir]
+        cmd = ["gcovr", "-r", self.base_dir,
+               "--gcov-ignore-parse-errors=negative_hits.warn_once_per_file",
+               "--gcov-executable", str(self.gcov_tool),
+               "-e", "tests/*"]
+        cmd += excludes + ["--json", "-o", coveragefile, outdir]
         cmd_str = " ".join(cmd)
         logger.debug(f"Running {cmd_str}...")
         subprocess.call(cmd, stdout=coveragelog)

--- a/scripts/requirements-build-test.txt
+++ b/scripts/requirements-build-test.txt
@@ -10,7 +10,7 @@ colorama
 ply>=3.10
 
 # used for code coverage
-gcovr>=4.2
+gcovr>=6.0
 coverage
 
 # used for west-command testing


### PR DESCRIPTION
Apply a workaround for an issue introduced with bc8b7dd for code coverage collection at qemu_x86 when gcov data was broken because of optimized out memcpy() in write_u64() static inline function, so gcovr parser fails with "gcovr.gcov_parser.NegativeHits: Got negative hit value in gcov line 'branch  1 taken -1'".

Add gcovr command line option to ignore such errors (since v.6.0): "--gcov-ignore-parse-errors=negative_hits.warn_once_per_file"

See also:
https://gcovr.com/en/stable/changelog.html#march-2023
https://github.com/gcovr/gcovr/pull/701

Fixes #64396
Alternative fix: #64397 