### PR TITLE
Join IPv4 or IPv6 multicast group in net-shell if needed

### DIFF
--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -159,6 +159,7 @@ config NET_SHELL
 	bool "Network shell utilities"
 	select SHELL
 	select NET_IPV4_IGMP if NET_IPV4
+	select NET_IPV6_MLD if NET_IPV6
 	help
 	  Activate shell module that provides network commands like
 	  ping to the console.

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -158,6 +158,7 @@ config NET_IPV4_MAPPING_TO_IPV6
 config NET_SHELL
 	bool "Network shell utilities"
 	select SHELL
+	select NET_IPV4_IGMP if NET_IPV4
 	help
 	  Activate shell module that provides network commands like
 	  ping to the console.


### PR DESCRIPTION
If user adds a multicast address to a network interface, the net-shell command will join the multicast group automatically.

Fixes #64389