### PR TITLE
tests cmsis_dsp filtering: Do not run filtering.misc.fpu on mps3_an547

### DIFF
--- a/tests/lib/cmsis_dsp/filtering/testcase.yaml
+++ b/tests/lib/cmsis_dsp/filtering/testcase.yaml
@@ -113,6 +113,7 @@ tests:
       and CONFIG_FULL_LIBC_SUPPORTED) or CONFIG_ARCH_POSIX
     integration_platforms:
       - mps2_an521_remote
+    platform_exclude:
       - mps3_an547
     tags:
       - cmsis_dsp


### PR DESCRIPTION
tests cmsis_dsp filtering: Do not run filtering.misc.fpu on mps3_an547

Merging 565c9376f1a6da4d67cae08126fcb342c0c27658
exposed an issue in this test, which causes an assert in the mps3_an547.
For more information check
https://github.com/zephyrproject-rtos/zephyr/issues/64387

The issue needs further analysis.
With this platform being an integration platform for this test, it gets triggered in CI by unrelated PRs, causing CI failures and blocking development.

As an interim measure, to unblock development in the main branch, let's exclude this platform from this test.

This commit should be reverted once the underlying issue is identified and addressed.