### PR TITLE
Log strings removal from the binary

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -306,6 +306,24 @@ config LINKER_USE_RELAX
 
 endmenu # "Linker Sections"
 
+config LINKER_DEVNULL_SUPPORT
+	bool
+	default y if CPU_CORTEX_M || (RISCV && !64BIT)
+
+config LINKER_DEVNULL_MEMORY
+	bool "Devnull region"
+	depends on LINKER_DEVNULL_SUPPORT
+	help
+	  Devnull region is created. It is stripped from final binary but remains
+	  in byproduct elf file.
+
+config LINKER_DEVNULL_MEMORY_SIZE
+	int "Devnull region size"
+	depends on LINKER_DEVNULL_MEMORY
+	default 262144
+	help
+	  Size can be adjusted so it fits all data placed in that region.
+
 endmenu
 
 menu "Compiler Options"

--- a/include/zephyr/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/zephyr/arch/arm/cortex_m/scripts/linker.ld
@@ -35,7 +35,7 @@
 #if CONFIG_FLASH_LOAD_SIZE > 0
 #define ROM_SIZE CONFIG_FLASH_LOAD_SIZE
 #else
-#define ROM_SIZE (CONFIG_FLASH_SIZE*1K - CONFIG_FLASH_LOAD_OFFSET)
+#define ROM_SIZE (CONFIG_FLASH_SIZE * 1024 - CONFIG_FLASH_LOAD_OFFSET)
 #endif
 
 #if defined(CONFIG_XIP)
@@ -75,10 +75,15 @@ _region_min_align = 4;
     . = ALIGN(_region_min_align)
 #endif
 
+#include <zephyr/linker/linker-devnull.h>
+
 MEMORY
     {
     FLASH (rx) : ORIGIN = ROM_ADDR, LENGTH = ROM_SIZE
     RAM   (wx) : ORIGIN = RAM_ADDR, LENGTH = RAM_SIZE
+#if defined(CONFIG_LINKER_DEVNULL_MEMORY)
+    DEVNULL_ROM (rx) : ORIGIN = DEVNULL_ADDR, LENGTH = DEVNULL_SIZE
+#endif
     LINKER_DT_REGIONS()
     /* Used by and documented in include/linker/intlist.ld */
     IDT_LIST (wx) : ORIGIN = 0xFFFFF7FF, LENGTH = 2K

--- a/include/zephyr/arch/riscv/common/linker.ld
+++ b/include/zephyr/arch/riscv/common/linker.ld
@@ -72,12 +72,18 @@
 	#define MPU_ALIGN(region_size) . = ALIGN(4)
 #endif
 
+#include <zephyr/linker/linker-devnull.h>
+
 MEMORY
 {
 #ifdef CONFIG_XIP
     ROM (rx)  : ORIGIN = ROM_BASE, LENGTH = ROM_SIZE
 #endif
     RAM (rwx) : ORIGIN = RAM_BASE, LENGTH = RAM_SIZE
+
+#if defined(CONFIG_LINKER_DEVNULL_MEMORY)
+    DEVNULL_ROM (rx) : ORIGIN = DEVNULL_ADDR, LENGTH = DEVNULL_SIZE
+#endif
 
     LINKER_DT_REGIONS()
 

--- a/include/zephyr/linker/common-rom/common-rom-logging.ld
+++ b/include/zephyr/linker/common-rom/common-rom-logging.ld
@@ -2,7 +2,14 @@
 
 #include <zephyr/linker/iterable_sections.h>
 
+#ifdef CONFIG_LOG_FMT_SECTION_STRIP
+	SECTION_PROLOGUE(log_strings,(COPY),SUBALIGN(4))
+	{
+		Z_LINK_ITERABLE(log_strings);
+	} GROUP_ROM_LINK_IN(DEVNULL_REGION, DEVNULL_REGION)
+#else
 	ITERABLE_SECTION_ROM(log_strings, 4)
+#endif
 
 	ITERABLE_SECTION_ROM(log_const, 4)
 

--- a/include/zephyr/linker/linker-devnull.h
+++ b/include/zephyr/linker/linker-devnull.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * DESCRIPTION
+ * Platform independent set of macros for creating a memory segment for
+ * aggregating data that shall be kept in the elf file but not in the binary.
+ */
+
+#ifndef ZEPHYR_INCLUDE_LINKER_LINKER_DEVNULL_H_
+
+#if defined(CONFIG_LINKER_DEVNULL_MEMORY)
+
+#if defined(CONFIG_XIP)
+#if (!defined(ROM_ADDR) && !defined(ROM_BASE)) || !defined(ROM_SIZE)
+#error "ROM_SIZE, ROM_ADDR or ROM_BASE not defined"
+#endif
+#endif /* CONFIG_XIP */
+
+#if (!defined(RAM_ADDR) && !defined(RAM_BASE)) || !defined(RAM_SIZE)
+#error "RAM_SIZE, RAM_ADDR or RAM_BASE not defined"
+#endif
+
+#if defined(CONFIG_XIP) && !defined(ROM_ADDR)
+#define ROM_ADDR ROM_BASE
+#endif
+
+#if !defined(RAM_ADDR)
+#define RAM_ADDR RAM_BASE
+#endif
+
+#define ROM_END_ADDR (ROM_ADDR + ROM_SIZE)
+#define DEVNULL_SIZE CONFIG_LINKER_DEVNULL_MEMORY_SIZE
+#define ROM_DEVNULL_END_ADDR (ROM_END_ADDR + DEVNULL_SIZE)
+#define MAX_ADDR UINT32_MAX
+
+/* Determine where to put the devnull region. It should be adjacent to the ROM
+ * region. If ROM starts after RAM or the distance between ROM and RAM is big
+ * enough to fit the devnull region then devnull region is placed just after
+ * the ROM region. If it cannot be done then the devnull region is placed before
+ * the ROM region. It is possible that the devnull region cannot be placed
+ * adjacent to the ROM (e.g. ROM starts at 0 and RAM follows ROM). In that
+ * case compilation fails and the devnull region is not supported in that
+ * configuration.
+ */
+#if !defined(CONFIG_XIP)
+
+#if RAM_ADDR >= DEVNULL_SIZE
+#define DEVNULL_ADDR (RAM_ADDR - DEVNULL_SIZE)
+#else
+#define DEVNULL_ADDR (RAM_ADDR + RAM_SIZE)
+#endif
+
+#else /* CONFIG_XIP */
+
+#if ((ROM_ADDR > RAM_ADDR) && ((MAX_ADDR - ROM_END_ADDR) >= DEVNULL_SIZE)) || \
+	((ROM_END_ADDR + DEVNULL_SIZE) <= RAM_ADDR)
+#define DEVNULL_ADDR ROM_END_ADDR
+#elif ROM_ADDR > DEVNULL_SIZE
+#define DEVNULL_ADDR (ROM_ADDR - DEVNULL_SIZE)
+#else
+#error "Cannot place devnull segment adjacent to ROM region."
+#endif
+
+#if defined(CONFIG_LINKER_DEVNULL_MEMORY)
+#define DEVNULL_REGION DEVNULL_ROM
+#else
+#define DEVNULL_REGION ROMABLE_REGION
+#endif
+
+#endif /* CONFIG_XIP */
+
+#endif /* CONFIG_LINKER_DEVNULL_MEMORY */
+
+#endif /* ZEPHYR_INCLUDE_LINKER_LINKER_DEVNULL_H_ */

--- a/include/zephyr/logging/log.h
+++ b/include/zephyr/logging/log.h
@@ -298,14 +298,19 @@ void z_log_vprintk(const char *fmt, va_list ap);
 /* Return first argument */
 #define _LOG_ARG1(arg1, ...) arg1
 
-#define _LOG_MODULE_CONST_DATA_CREATE(_name, _level)			       \
-	IF_ENABLED(LOG_IN_CPLUSPLUS, (extern))				       \
-	const STRUCT_SECTION_ITERABLE_ALTERNATE(log_const,		       \
-		log_source_const_data,					       \
-		Z_LOG_ITEM_CONST_DATA(_name)) =				       \
-	{								       \
-		.name = STRINGIFY(_name),				       \
-		.level = _level						       \
+#define _LOG_MODULE_CONST_DATA_CREATE(_name, _level)						\
+	IF_ENABLED(CONFIG_LOG_FMT_SECTION, (							\
+		static const char UTIL_CAT(_name, _str)[]					\
+		     __in_section(_log_strings, static, _CONCAT(_name, _)) __used __noasan =	\
+		     STRINGIFY(_name);))							\
+	IF_ENABLED(LOG_IN_CPLUSPLUS, (extern))							\
+	const STRUCT_SECTION_ITERABLE_ALTERNATE(log_const,					\
+		log_source_const_data,								\
+		Z_LOG_ITEM_CONST_DATA(_name)) =							\
+	{											\
+		.name = COND_CODE_1(CONFIG_LOG_FMT_SECTION,					\
+				(UTIL_CAT(_name, _str)), (STRINGIFY(_name))),			\
+		.level = _level									\
 	}
 
 #define _LOG_MODULE_DYNAMIC_DATA_CREATE(_name)					\

--- a/subsys/logging/Kconfig.frontends
+++ b/subsys/logging/Kconfig.frontends
@@ -8,6 +8,8 @@ config LOG_FRONTEND_DICT_UART
 	select LOG_DICTIONARY_DB
 	select MPSC_PBUF
 	depends on UART_ASYNC_API || UART_INTERRUPT_DRIVEN
+	imply LOG_FMT_SECTION
+	imply LOG_FMT_SECTION_STRIP
 	help
 	  Frontend sends data in binary dictionary mode.
 

--- a/subsys/logging/Kconfig.misc
+++ b/subsys/logging/Kconfig.misc
@@ -55,6 +55,13 @@ config LOG_FMT_SECTION
 	  removing strings from final binary and should be used for dictionary
 	  logging.
 
+config LOG_FMT_SECTION_STRIP
+	bool "Strip log strings from binary"
+	depends on !LOG_OUTPUT
+	depends on LOG_FMT_SECTION
+	depends on LINKER_DEVNULL_SUPPORT
+	imply LINKER_DEVNULL_MEMORY
+
 config LOG_USE_TAGGED_ARGUMENTS
 	bool "Using tagged arguments for packaging"
 	depends on !PICOLIBC


### PR DESCRIPTION
PR introduces option to remove logging strings from binary. It can be used if logging backend/frontend does not format the string but only uses the address of the string (dictionary based logging).
It is done by creating a memory region (devnull region) adjacent to the ROM region. Then section with logging strings is put in that region with `(COPY)` property so that it ends in elf file but not in binary.

Support is initially added to Cortex-M and RISCV but it should be fairly easy to extend other linker scripts.

`samples/subsys/logging/dictionary/sample.logger.basic.dictionary.uart_async_frontend` sample is now using that. 3200 bytes are saved by taking this approach:
```
Memory region         Used Size  Region Size  %age Used
           FLASH:       27860 B         1 MB      2.66%
             RAM:        6976 B       256 KB      2.66%
     DEVNULL_ROM:        3200 B       256 KB      1.22%
        IDT_LIST:          0 GB         2 KB      0.00%
```

Fixes #44942.
Fixes #42840.
