### PR TITLE
[Backport v3.3-branch] drivers: can: be consistent in filter_id checks when removing rx filters

### DIFF
--- a/drivers/can/can_loopback.c
+++ b/drivers/can/can_loopback.c
@@ -213,7 +213,7 @@ static void can_loopback_remove_rx_filter(const struct device *dev, int filter_i
 {
 	struct can_loopback_data *data = dev->data;
 
-	if (filter_id >= ARRAY_SIZE(data->filters)) {
+	if (filter_id < 0 || filter_id >= ARRAY_SIZE(data->filters)) {
 		LOG_ERR("filter ID %d out-of-bounds", filter_id);
 		return;
 	}

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -1109,12 +1109,17 @@ void can_mcan_remove_rx_filter(const struct device *dev, int filter_id)
 {
 	struct can_mcan_data *data = dev->data;
 	struct can_mcan_msg_sram *msg_ram = data->msg_ram;
+	if (filter_id < 0) {
+		LOG_ERR("filter ID %d out of bounds", filter_id);
+		return;
+	}
+
 
 	k_mutex_lock(&data->inst_mutex, K_FOREVER);
 	if (filter_id >= NUM_STD_FILTER_DATA) {
 		filter_id -= NUM_STD_FILTER_DATA;
 		if (filter_id >= NUM_EXT_FILTER_DATA) {
-			LOG_ERR("Wrong filter id");
+			LOG_ERR("filter ID %d out of bounds", filter_id);
 			return;
 		}
 

--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -674,6 +674,11 @@ static void mcp2515_remove_rx_filter(const struct device *dev, int filter_id)
 {
 	struct mcp2515_data *dev_data = dev->data;
 
+	if (filter_id < 0 || filter_id >= CONFIG_CAN_MAX_FILTER) {
+		LOG_ERR("filter ID %d out of bounds", filter_id);
+		return;
+	}
+
 	k_mutex_lock(&dev_data->mutex, K_FOREVER);
 	dev_data->filter_usage &= ~BIT(filter_id);
 	k_mutex_unlock(&dev_data->mutex);

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -604,9 +604,8 @@ static void mcux_flexcan_remove_rx_filter(const struct device *dev, int filter_i
 	const struct mcux_flexcan_config *config = dev->config;
 	struct mcux_flexcan_data *data = dev->data;
 
-	if (filter_id >= MCUX_FLEXCAN_MAX_RX) {
-		LOG_ERR("Detach: Filter id >= MAX_RX (%d >= %d)", filter_id,
-			MCUX_FLEXCAN_MAX_RX);
+	if (filter_id < 0 || filter_id >= MCUX_FLEXCAN_MAX_RX) {
+		LOG_ERR("filter ID %d out of bounds", filter_id);
 		return;
 	}
 

--- a/drivers/can/can_native_posix_linux.c
+++ b/drivers/can/can_native_posix_linux.c
@@ -241,6 +241,7 @@ static void can_npl_remove_rx_filter(const struct device *dev, int filter_id)
 	struct can_npl_data *data = dev->data;
 
 	if (filter_id < 0 || filter_id >= ARRAY_SIZE(data->filters)) {
+		LOG_ERR("filter ID %d out of bounds");
 		return;
 	}
 

--- a/drivers/can/can_rcar.c
+++ b/drivers/can/can_rcar.c
@@ -965,7 +965,8 @@ static void can_rcar_remove_rx_filter(const struct device *dev, int filter_id)
 {
 	struct can_rcar_data *data = dev->data;
 
-	if (filter_id >= CONFIG_CAN_RCAR_MAX_FILTER) {
+	if (filter_id < 0 || filter_id >= CONFIG_CAN_RCAR_MAX_FILTER) {
+		LOG_ERR("filter ID %d out of bounds", filter_id);
 		return;
 	}
 

--- a/drivers/can/can_stm32.c
+++ b/drivers/can/can_stm32.c
@@ -988,7 +988,10 @@ static void can_stm32_remove_rx_filter(const struct device *dev, int filter_id)
 	int bank_num;
 	bool bank_unused;
 
-	__ASSERT_NO_MSG(filter_id >= 0 && filter_id < CAN_STM32_MAX_FILTER_ID);
+	if (filter_id < 0 || filter_id >= CAN_STM32_MAX_FILTER_ID) {
+		LOG_ERR("filter ID %d out of bounds", filter_id);
+		return;
+	}
 
 	k_mutex_lock(&filter_mutex, K_FOREVER);
 	k_mutex_lock(&data->inst_mutex, K_FOREVER);


### PR DESCRIPTION
Backport 6c5400d2e1dbc6fc278dad8cce396208fbecc59a from #64399.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/64398 #64414