### PR TITLE
[Backport v2.7-branch] drivers: can: be consistent in filter_id checks when removing rx filters

### DIFF
--- a/drivers/can/can_loopback.c
+++ b/drivers/can/can_loopback.c
@@ -171,6 +171,11 @@ void can_loopback_detach(const struct device *dev, int filter_id)
 {
 	struct can_loopback_data *data = DEV_DATA(dev);
 
+	if (filter_id < 0 || filter_id >= ARRAY_SIZE(data->filters)) {
+		LOG_ERR("filter ID %d out of bounds", filter_id);
+		return;
+	}
+
 	LOG_DBG("Detach filter ID: %d", filter_id);
 	k_mutex_lock(&data->mtx, K_FOREVER);
 	data->filters[filter_id].rx_cb = NULL;

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -894,11 +894,16 @@ int can_mcan_attach_isr(struct can_mcan_data *data,
 void can_mcan_detach(struct can_mcan_data *data,
 		     struct can_mcan_msg_sram *msg_ram, int filter_nr)
 {
+	if (filter_nr < 0) {
+		LOG_ERR("filter ID %d out of bounds", filter_nr);
+		return;
+	}
+
 	k_mutex_lock(&data->inst_mutex, K_FOREVER);
 	if (filter_nr >= NUM_STD_FILTER_DATA) {
 		filter_nr -= NUM_STD_FILTER_DATA;
 		if (filter_nr >= NUM_STD_FILTER_DATA) {
-			LOG_ERR("Wrong filter id");
+			LOG_ERR("filter ID %d out of bounds", filter_nr);
 			return;
 		}
 

--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -551,6 +551,11 @@ static void mcp2515_detach(const struct device *dev, int filter_nr)
 {
 	struct mcp2515_data *dev_data = DEV_DATA(dev);
 
+	if (filter_nr < 0 || filter_nr >= CONFIG_CAN_MAX_FILTER) {
+		LOG_ERR("filter ID %d out of bounds", filter_nr);
+		return;
+	}
+
 	k_mutex_lock(&dev_data->mutex, K_FOREVER);
 	dev_data->filter_usage &= ~BIT(filter_nr);
 	k_mutex_unlock(&dev_data->mutex);

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -480,9 +480,8 @@ static void mcux_flexcan_detach(const struct device *dev, int filter_id)
 	const struct mcux_flexcan_config *config = dev->config;
 	struct mcux_flexcan_data *data = dev->data;
 
-	if (filter_id >= MCUX_FLEXCAN_MAX_RX) {
-		LOG_ERR("Detach: Filter id >= MAX_RX (%d >= %d)", filter_id,
-			MCUX_FLEXCAN_MAX_RX);
+	if (filter_id < 0 || filter_id >= MCUX_FLEXCAN_MAX_RX) {
+		LOG_ERR("filter ID %d out of bounds", filter_id);
 		return;
 	}
 

--- a/drivers/can/can_rcar.c
+++ b/drivers/can/can_rcar.c
@@ -829,7 +829,8 @@ void can_rcar_detach(const struct device *dev, int filter_nr)
 {
 	struct can_rcar_data *data = DEV_CAN_DATA(dev);
 
-	if (filter_nr >= CONFIG_CAN_RCAR_MAX_FILTER) {
+	if (filter_nr < 0 || filter_nr >= CONFIG_CAN_RCAR_MAX_FILTER) {
+		LOG_ERR("filter ID %d out of bounds", filter_nr);
 		return;
 	}
 


### PR DESCRIPTION
Backport 6c5400d2e1dbc6fc278dad8cce396208fbecc59a from #64399.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/64398 #64413