### PR TITLE
dts: arm: silabs: Move gpio gecko header include

### DIFF
--- a/boards/arm/efr32_thunderboard/thunderboard.dtsi
+++ b/boards/arm/efr32_thunderboard/thunderboard.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <silabs/gpio_gecko.h>
 
 / {
 	chosen {

--- a/dts/arm/silabs/efr32bg2x-pinctrl.dtsi
+++ b/dts/arm/silabs/efr32bg2x-pinctrl.dtsi
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <arm/silabs/gpio_gecko.h>
 #include <dt-bindings/pinctrl/gecko-pinctrl.h>
 
 &pinctrl {

--- a/dts/arm/silabs/efr32bg2x.dtsi
+++ b/dts/arm/silabs/efr32bg2x.dtsi
@@ -5,7 +5,6 @@
  */
 
 #include <arm/armv8-m.dtsi>
-#include <arm/silabs/gpio_gecko.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/i2c/i2c.h>
 #include <dt-bindings/pinctrl/gecko-pinctrl.h>


### PR DESCRIPTION
Move the include to places where it is actually used.