### PR TITLE
kernel: avoid SCA warning "extra semicolon ignored"

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -60,7 +60,7 @@ BUILD_ASSERT(sizeof(intptr_t) == sizeof(long));
 #ifdef CONFIG_POLL
 #define _POLL_EVENT_OBJ_INIT(obj) \
 	.poll_events = SYS_DLIST_STATIC_INIT(&obj.poll_events),
-#define _POLL_EVENT sys_dlist_t poll_events
+#define _POLL_EVENT sys_dlist_t poll_events;
 #else
 #define _POLL_EVENT_OBJ_INIT(obj)
 #define _POLL_EVENT
@@ -1848,7 +1848,7 @@ struct k_queue {
 	struct k_spinlock lock;
 	_wait_q_t wait_q;
 
-	_POLL_EVENT;
+	_POLL_EVENT
 
 	SYS_PORT_TRACING_TRACKING_FIELD(k_queue)
 };
@@ -3110,7 +3110,7 @@ struct k_sem {
 	unsigned int count;
 	unsigned int limit;
 
-	_POLL_EVENT;
+	_POLL_EVENT
 
 	SYS_PORT_TRACING_TRACKING_FIELD(k_sem)
 
@@ -4423,7 +4423,7 @@ struct k_msgq {
 	/** Number of used messages */
 	uint32_t used_msgs;
 
-	_POLL_EVENT;
+	_POLL_EVENT
 
 	/** Message queue */
 	uint8_t flags;
@@ -4863,7 +4863,7 @@ struct k_pipe {
 		_wait_q_t      writers; /**< Writer wait queue */
 	} wait_q;			/** Wait queue */
 
-	_POLL_EVENT;
+	_POLL_EVENT
 
 	uint8_t	       flags;		/**< Flags */
 

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -58,12 +58,12 @@ BUILD_ASSERT(sizeof(intptr_t) == sizeof(long));
 #define K_LOWEST_APPLICATION_THREAD_PRIO (K_LOWEST_THREAD_PRIO - 1)
 
 #ifdef CONFIG_POLL
-#define _POLL_EVENT_OBJ_INIT(obj) \
+#define Z_POLL_EVENT_OBJ_INIT(obj) \
 	.poll_events = SYS_DLIST_STATIC_INIT(&obj.poll_events),
-#define _POLL_EVENT sys_dlist_t poll_events;
+#define Z_DECL_POLL_EVENT sys_dlist_t poll_events;
 #else
-#define _POLL_EVENT_OBJ_INIT(obj)
-#define _POLL_EVENT
+#define Z_POLL_EVENT_OBJ_INIT(obj)
+#define Z_DECL_POLL_EVENT
 #endif
 
 struct k_thread;
@@ -1848,7 +1848,7 @@ struct k_queue {
 	struct k_spinlock lock;
 	_wait_q_t wait_q;
 
-	_POLL_EVENT
+	Z_DECL_POLL_EVENT
 
 	SYS_PORT_TRACING_TRACKING_FIELD(k_queue)
 };
@@ -1862,7 +1862,7 @@ struct k_queue {
 	.data_q = SYS_SFLIST_STATIC_INIT(&obj.data_q), \
 	.lock = { }, \
 	.wait_q = Z_WAIT_Q_INIT(&obj.wait_q),	\
-	_POLL_EVENT_OBJ_INIT(obj)		\
+	Z_POLL_EVENT_OBJ_INIT(obj)		\
 	}
 
 /**
@@ -3110,7 +3110,7 @@ struct k_sem {
 	unsigned int count;
 	unsigned int limit;
 
-	_POLL_EVENT
+	Z_DECL_POLL_EVENT
 
 	SYS_PORT_TRACING_TRACKING_FIELD(k_sem)
 
@@ -3124,7 +3124,7 @@ struct k_sem {
 	.wait_q = Z_WAIT_Q_INIT(&obj.wait_q), \
 	.count = initial_count, \
 	.limit = count_limit, \
-	_POLL_EVENT_OBJ_INIT(obj) \
+	Z_POLL_EVENT_OBJ_INIT(obj) \
 	}
 
 /**
@@ -4423,7 +4423,7 @@ struct k_msgq {
 	/** Number of used messages */
 	uint32_t used_msgs;
 
-	_POLL_EVENT
+	Z_DECL_POLL_EVENT
 
 	/** Message queue */
 	uint8_t flags;
@@ -4449,7 +4449,7 @@ struct k_msgq {
 	.read_ptr = q_buffer, \
 	.write_ptr = q_buffer, \
 	.used_msgs = 0, \
-	_POLL_EVENT_OBJ_INIT(obj) \
+	Z_POLL_EVENT_OBJ_INIT(obj) \
 	}
 
 /**
@@ -4863,7 +4863,7 @@ struct k_pipe {
 		_wait_q_t      writers; /**< Writer wait queue */
 	} wait_q;			/** Wait queue */
 
-	_POLL_EVENT
+	Z_DECL_POLL_EVENT
 
 	uint8_t	       flags;		/**< Flags */
 
@@ -4891,7 +4891,7 @@ struct k_pipe {
 		.readers = Z_WAIT_Q_INIT(&obj.wait_q.readers),       \
 		.writers = Z_WAIT_Q_INIT(&obj.wait_q.writers)        \
 	},                                                          \
-	_POLL_EVENT_OBJ_INIT(obj)                                   \
+	Z_POLL_EVENT_OBJ_INIT(obj)                                   \
 	.flags = 0,                                                 \
 	}
 


### PR DESCRIPTION
The marco _POLL_EVENT causes static code analysis warnings due to a remaining semicolon in the case _POLL_EVENT is empty.

./zephyr/include/zephyr/kernel.h:1746:13: warning #381-D: extra ";" ignored
./zephyr/include/zephyr/kernel.h:2958:13: warning #381-D: extra ";" ignored
./zephyr/include/zephyr/kernel.h:4268:13: warning #381-D: extra ";" ignored
./zephyr/include/zephyr/kernel.h:4708:13: warning #381-D: extra ";" ignored

Move the semicolon into the macro and remove the semicolons behind the macros where used in the struct declarations. Rename to _DECL_POLL_EVENT for better recognition.