### PR TITLE
twister: unittests: Use mock for os.name in unittests

### DIFF
--- a/scripts/tests/twister/test_testinstance.py
+++ b/scripts/tests/twister/test_testinstance.py
@@ -11,6 +11,8 @@ import os
 import sys
 import pytest
 
+from unittest import mock
+
 ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
 from twisterlib.testinstance import TestInstance
@@ -29,7 +31,7 @@ TESTDATA_1 = [
     (False, True, "sensor", "native", "", True, [], (True, False)),
 ]
 @pytest.mark.parametrize("build_only, slow, harness, platform_type, platform_sim, device_testing,fixture, expected", TESTDATA_1)
-def test_check_build_or_run(class_testplan, monkeypatch, all_testsuites_dict, platforms_list, build_only, slow, harness, platform_type, platform_sim, device_testing, fixture, expected):
+def test_check_build_or_run(class_testplan, all_testsuites_dict, platforms_list, build_only, slow, harness, platform_type, platform_sim, device_testing, fixture, expected):
     """" Test to check the conditions for build_only and run scenarios
     Scenario 1: Test when different parameters are passed, build_only and run are set correctly
     Scenario 2: Test if build_only is enabled when the OS is Windows"""
@@ -51,9 +53,9 @@ def test_check_build_or_run(class_testplan, monkeypatch, all_testsuites_dict, pl
     _, r = expected
     assert run == r
 
-    monkeypatch.setattr("os.name", "nt")
-    run = testinstance.check_runnable()
-    assert not run
+    with mock.patch('os.name', 'nt'):
+        run = testinstance.check_runnable()
+        assert not run
 
 TESTDATA_2 = [
     (True, True, True, ["demo_board_2"], "native", None, '\nCONFIG_COVERAGE=y\nCONFIG_COVERAGE_DUMP=y\nCONFIG_ASAN=y\nCONFIG_UBSAN=y'),


### PR DESCRIPTION
Use `mock.patch` instead of `monkeypatch` for `os.name` in unittests to fix error when executing tests under VSCode.

When I tried to execute tests under VSCode, I received strange error for `test_testinstance.py::test_check_build_or_run`:
```
The python test process was terminated before it could exit on its own, the process errored with: Code: 1, Signal: null
```
Changing `monteypatch` to `with mock.patch` fixes that problem.