### PR TITLE
net: openthread: Fix dependency on openthread max ip addr.

### DIFF
--- a/modules/openthread/Kconfig.thread
+++ b/modules/openthread/Kconfig.thread
@@ -68,7 +68,6 @@ config OPENTHREAD_MAX_IP_ADDR_PER_CHILD
 	int "The maximum number of IPv6 address registrations per child"
 	range 4 255
 	default 6
-	depends on OPENTHREAD_FTD
 
 config OPENTHREAD_CONFIG_PLATFORM_INFO
 	string "The platform-specific string to insert into the OpenThread version string"


### PR DESCRIPTION
Fixes discrepancy between FTD and MTD in amount of ipaddr in `ChildUpdateRequest`.