### PR TITLE
drivers: i2c: i2c_nrfx_twi*: don't print errors in case of transfer failure

### DIFF
--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -126,7 +126,6 @@ static int i2c_nrfx_twi_transfer(const struct device *dev,
 			 * to make sure everything has been done to restore the
 			 * bus from this error.
 			 */
-			LOG_ERR("Error on I2C line occurred for message %d", i);
 			nrfx_twi_disable(&config->twi);
 			(void)i2c_nrfx_twi_recover_bus(dev);
 			ret = -EIO;
@@ -135,7 +134,6 @@ static int i2c_nrfx_twi_transfer(const struct device *dev,
 
 		res = data->res;
 		if (res != NRFX_SUCCESS) {
-			LOG_ERR("Error 0x%08X occurred for message %d", res, i);
 			ret = -EIO;
 			break;
 		}

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -166,7 +166,6 @@ static int i2c_nrfx_twim_transfer(const struct device *dev,
 			 * to make sure everything has been done to restore the
 			 * bus from this error.
 			 */
-			LOG_ERR("Error on I2C line occurred for message %d", i);
 			(void)i2c_nrfx_twim_recover_bus(dev);
 			ret = -EIO;
 			break;
@@ -175,7 +174,6 @@ static int i2c_nrfx_twim_transfer(const struct device *dev,
 		res = dev_data->res;
 
 		if (res != NRFX_SUCCESS) {
-			LOG_ERR("Error 0x%08X occurred for message %d", res, i);
 			ret = -EIO;
 			break;
 		}


### PR DESCRIPTION
Let the caller decide what should be done in case of the transfer failure. It will reduce the number of error log prints when the i2c scan is called for the bus where nothing is connected.