### PR TITLE
doc: x86: Use start-after to include after right part

### DIFF
--- a/boards/x86/common/efi_boot.rst
+++ b/boards/x86/common/efi_boot.rst
@@ -1,5 +1,7 @@
 :orphan:
 
+.. start_include_here
+
 Preparing the Boot Device
 -------------------------
 

--- a/boards/x86/common/net_boot.rst
+++ b/boards/x86/common/net_boot.rst
@@ -1,5 +1,7 @@
 :orphan:
 
+.. start_include_here
+
 Prepare Linux host
 ------------------
 

--- a/boards/x86/intel_adl/doc/index.rst
+++ b/boards/x86/intel_adl/doc/index.rst
@@ -60,5 +60,6 @@ Booting the Alder Lake N CRB Board using UEFI
 =============================================
 
 .. include:: ../../common/efi_boot.rst
+   :start-after: start_include_here
 
 .. _INTEL_ADL: https://edc.intel.com/content/www/us/en/design/products/platforms/processor-and-core-i3-n-series-datasheet-volume-1-of-2/

--- a/boards/x86/intel_ehl/doc/index.rst
+++ b/boards/x86/intel_ehl/doc/index.rst
@@ -56,11 +56,13 @@ Booting the Elkhart Lake CRB Board using UEFI
 =============================================
 
 .. include:: ../../common/efi_boot.rst
+   :start-after: start_include_here
 
 Booting the Elkhart Lake CRB Board over network
 ===============================================
 
 .. include:: ../../common/net_boot.rst
+   :start-after: start_include_here
 
 .. note::
    To enable PXE boot for Elkhart Lake CRB board do the following:

--- a/boards/x86/intel_rpl/doc/index.rst
+++ b/boards/x86/intel_rpl/doc/index.rst
@@ -56,5 +56,6 @@ Booting the Raptor Lake S CRB Board using UEFI
 ==============================================
 
 .. include:: ../../common/efi_boot.rst
+   :start-after: start_include_here
 
 .. _RPL: https://www.intel.com/content/www/us/en/newsroom/resources/13th-gen-core.html#gs.glf2fn

--- a/boards/x86/up_squared/doc/index.rst
+++ b/boards/x86/up_squared/doc/index.rst
@@ -80,7 +80,7 @@ Booting the UP Squared Board using UEFI
 =======================================
 
 .. include:: ../../common/efi_boot.rst
-
+   :start-after: start_include_here
 
 .. note::
    Refer to the `UP Squared Serial Console Wiki page
@@ -98,6 +98,7 @@ Booting the UP Squared Board over network
 =========================================
 
 .. include:: ../../common/net_boot.rst
+   :start-after: start_include_here
 
 .. note::
    Refer to the `UP Squared Serial Console Wiki page


### PR DESCRIPTION
In the documentation recently started to appear ':orphan:', which is marking for orphaned page. Use start-after to include after marking.