### PR TITLE
tests: rtc_api: Update y2k test to allow unknown values

### DIFF
--- a/tests/drivers/rtc/rtc_api/src/test_y2k.c
+++ b/tests/drivers/rtc/rtc_api/src/test_y2k.c
@@ -50,8 +50,10 @@ ZTEST(rtc_api, test_y2k)
 	zassert_equal(rtm[Y2K].tm_year + 1900, 2000, "wrong year: %d", rtm[Y2K].tm_year + 1900);
 	zassert_equal(rtm[Y2K].tm_mon, 0, "wrong month: %d", rtm[Y2K].tm_mon);
 	zassert_equal(rtm[Y2K].tm_mday, 1, "wrong day-of-month: %d", rtm[Y2K].tm_mday);
-	zassert_equal(rtm[Y2K].tm_yday, 0, "wrong day-of-year: %d", rtm[Y2K].tm_yday);
-	zassert_equal(rtm[Y2K].tm_wday, 6, "wrong day-of-week: %d", rtm[Y2K].tm_wday);
+	zassert_true(rtm[Y2K].tm_yday == 0 || rtm[Y2K].tm_yday == -1, "wrong day-of-year: %d",
+		     rtm[Y2K].tm_yday);
+	zassert_true(rtm[Y2K].tm_wday == 6 || rtm[Y2K].tm_wday == -1, "wrong day-of-week: %d",
+		     rtm[Y2K].tm_wday);
 	zassert_equal(rtm[Y2K].tm_hour, 0, "wrong hour: %d", rtm[Y2K].tm_hour);
 	zassert_equal(rtm[Y2K].tm_min, 0, "wrong minute: %d", rtm[Y2K].tm_min);
 	zassert_equal(rtm[Y2K].tm_sec, SECONDS_AFTER, "wrong second: %d", rtm[Y2K].tm_sec);


### PR DESCRIPTION
The RTC Y2K test (time passing midnight at new year) fails if RTCs correctly report that they don't support the year day (`.tm_yday`) or day of week (`.tm_wday`) fields of the `struct rtc_time`.

This PR adds a condition to allow the test to ignore the fields if they are set as "unknown" (-1)