### PR TITLE
Bluetooth: shell: make behaviour of iso cmd same as bt cmd

### DIFF
--- a/subsys/bluetooth/shell/iso.c
+++ b/subsys/bluetooth/shell/iso.c
@@ -976,14 +976,15 @@ SHELL_STATIC_SUBCMD_SET_CREATE(iso_cmds,
 
 static int cmd_iso(const struct shell *sh, size_t argc, char **argv)
 {
-	if (argc > 1) {
-		shell_error(sh, "%s unknown parameter: %s",
-			    argv[0], argv[1]);
-	} else {
-		shell_error(sh, "%s Missing subcommand", argv[0]);
+	if (argc == 1) {
+		shell_help(sh);
+
+		return SHELL_CMD_HELP_PRINTED;
 	}
 
-	return -ENOEXEC;
+	shell_error(sh, "%s unknown parameter: %s", argv[0], argv[1]);
+
+	return -EINVAL;
 }
 
 SHELL_CMD_ARG_REGISTER(iso, &iso_cmds, "Bluetooth ISO shell commands",


### PR DESCRIPTION
When no parameters are given to the 'bt' command it prints the help message. The 'iso' command responds with 'missing subcommand'. This commit updates the behaviour of the iso command so that it behaves the same as the bt command, i.e. it prints a help message if no parameters are given

In other words: the code for this behaviour is now the same in bt.c and iso.c