### PR TITLE
debug: coredump: logging backend should always select LOG

### DIFF
--- a/subsys/debug/coredump/Kconfig
+++ b/subsys/debug/coredump/Kconfig
@@ -30,6 +30,7 @@ config DEBUG_COREDUMP_BACKEND_FLASH_PARTITION
 
 config DEBUG_COREDUMP_BACKEND_INTEL_ADSP_MEM_WINDOW
 	bool "Use memory window for coredump on Intel ADSP"
+	depends on DT_HAS_INTEL_ADSP_MEM_WINDOW_ENABLED
 	help
 	  Core dump is done via memory window slot[1].
 	  It is Intel ADSP memory region shared with xtensa DSP.

--- a/subsys/debug/coredump/Kconfig
+++ b/subsys/debug/coredump/Kconfig
@@ -11,11 +11,11 @@ if DEBUG_COREDUMP
 
 choice DEBUG_COREDUMP_BACKEND
 	prompt "Coredump backend"
-	default DEBUG_COREDUMP_BACKEND_LOGGING if LOG
+	default DEBUG_COREDUMP_BACKEND_LOGGING
 
 config DEBUG_COREDUMP_BACKEND_LOGGING
 	bool "Use Logging subsystem for coredump"
-	depends on LOG
+	select LOG
 	help
 	  Core dump is done via logging subsystem.
 


### PR DESCRIPTION
debug.coredump.logging_backend tests is using
CONFIG_DEBUG_COREDUMP_BACKEND_LOGGING which depends on LOG.

To reproduce, in 530a3092feef04bc9038f00ac088125b8514aba3, try to run the debug.coredump.logging_backend sample

```
scripts/twister -T tests/subsys/debug/coredump -p m5stack_core2 -j 1
```

The test fails to compile as `DEBUG_COREDUMP_BACKEND` ends up being set to `DEBUG_COREDUMP_BACKEND_INTEL_ADSP_MEM_WINDOW` (**which is likely another bug, as I believe this should be guarded behind e.g. `depends on SOC_FAMILY_INTEL_ADSP`?**), causing a compilation error

```
/home/kartben/zephyrproject/zephyr/subsys/debug/coredump/coredump_backend_intel_adsp_mem_window.c:15:10: fatal error: adsp_memory.h: No such file or directory
   15 | #include <adsp_memory.h>
      |          ^~~~~~~~~~~~~~~
```