### PR TITLE
shell: fix SHELL_SUBCMD_COND_ADD with NULL as _handler parameter

### DIFF
--- a/include/zephyr/shell/shell.h
+++ b/include/zephyr/shell/shell.h
@@ -350,8 +350,8 @@ struct shell_static_entry {
 			SHELL_EXPR_CMD_ARG(1, _syntax, _subcmd, _help, \
 					   _handler, _mand, _opt)\
 		), \
-		(static shell_cmd_handler dummy_##syntax##_handler __unused = _handler;\
-		 static const union shell_cmd_entry dummy_subcmd_##syntax __unused = { \
+		(static shell_cmd_handler dummy_handler_##_syntax __unused = _handler;\
+		 static const union shell_cmd_entry dummy_subcmd_##_syntax __unused = { \
 			.entry = (const struct shell_static_entry *)_subcmd\
 		 } \
 		) \


### PR DESCRIPTION
In `dummy_subcmd_##syntax` statement, `syntax` keyword should be replaced with `_syntax`, that is the argument name.

In `dummy_##syntax##_handler` there are two problems:
 - wrong `syntax` keyword
 - `_handler` is an argument

So if `NULL` is passed as an argument to `_handler`, and the `syntax` is `abcd`, there is `dummy_##abcd##NULL`, what causes a build error.