### PR TITLE
ci: compliance: fetch only the last revision and skip tags

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -45,7 +45,7 @@ jobs:
         git log  --pretty=oneline | head -n 10
         west init -l . || true
         west config manifest.group-filter -- +ci,+optional
-        west update 2>&1 1> west.update.log || west update 2>&1 1> west.update2.log
+        west update -o=--depth=1 -n 2>&1 1> west.update.log || west update -o=--depth=1 -n 2>&1 1> west.update2.log
 
     - name: Run Compliance Tests
       continue-on-error: true


### PR DESCRIPTION
Add some west update flags to do a shallow fetch of the modules and skip the tags. That data is not needed anyway, should make the compliance check initialization a bit faster.

---

Speeds up the "west setup" step from ~3:30m to ~1m40.