### PR TITLE
MAINTAINERS: Add entry for multi-function devices (MFD)

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1139,6 +1139,19 @@ Release Notes:
   labels:
     - "area: LED"
 
+"Drivers: MFD":
+  status: odd fixes
+  collaborators:
+    - gmarull
+    - aasinclair
+  files:
+    - drivers/mfd/
+    - include/zephyr/drivers/mfd/
+    - dts/bindings/mfd/
+    - tests/drivers/build_all/mfd/
+  labels:
+    - "area: MFD"
+
 "Drivers: Modem":
   status: maintained
   maintainers:


### PR DESCRIPTION
Adds a new entry for multi-function device (mfd) drivers to ensure that incoming PRs to this area get labeled appropriately and have reviews requested.