### PR TITLE
doc: dts: api: update the inter-node dependencies documentation

### DIFF
--- a/doc/build/dts/api/api.rst
+++ b/doc/build/dts/api/api.rst
@@ -140,6 +140,7 @@ depends on" relation:
 - a node directly depends on any nodes its properties refer to by phandle
 - a node directly depends on its ``interrupt-parent`` if it has an
   ``interrupts`` property
+- a parent node inherits all dependencies from its child nodes
 
 A *dependency ordering* of a devicetree is a list of its nodes, where each node
 ``n`` appears earlier in the list than any nodes that depend on ``n``. A node's


### PR DESCRIPTION
Update the inter-node dependencies documentation to clarify the child node dependency inheritance recently introduced in 403640b75e.