### PR TITLE
soc: xtensa/nxp_adsp: put guard Kconfig.defconfig

### DIFF
--- a/soc/xtensa/nxp_adsp/Kconfig.defconfig
+++ b/soc/xtensa/nxp_adsp/Kconfig.defconfig
@@ -3,6 +3,8 @@
 # Copyright (c) 2021 NXP
 # SPDX-License-Identifier: Apache-2.0
 
+if SOC_FAMILY_NXP_ADSP
+
 source "soc/xtensa/nxp_adsp/*/Kconfig.defconfig.series"
 
 config CACHE_MANAGEMENT
@@ -27,3 +29,5 @@ config 2ND_LEVEL_INTERRUPTS
 config TEST_LOGGING_DEFAULTS
 	default n
 	depends on TEST
+
+endif


### PR DESCRIPTION
This adds a if CONFIG_SOC_FAMILY_NXP_ADSP guard in Kconfig.defconfig for nxp_adsp. Or else all of its default get applied everywhere. For example, qemu_xtensa fails kernel.logging.message_capture tests because
CONFIG_TEST_LOGGING_DEFAULTS is disabled in
nxp_adsp/Kconfig.defconfig which should not have applied to qemu_xtensa at all. So put a guard in there.