### PR TITLE
drivers: intel: ssp: On startup only drain RX FIFO if it is overflown

### DIFF
--- a/drivers/dai/intel/ssp/ssp.c
+++ b/drivers/dai/intel/ssp/ssp.c
@@ -839,7 +839,6 @@ static void dai_ssp_empty_tx_fifo(struct dai_intel_ssp *dp)
 
 static void ssp_empty_rx_fifo_on_start(struct dai_intel_ssp *dp)
 {
-	uint32_t retry = DAI_INTEL_SSP_RX_FLUSH_RETRY_MAX;
 	uint32_t i, sssr;
 
 	sssr = sys_read32(dai_base(dp) + SSSR);
@@ -851,18 +850,6 @@ static void ssp_empty_rx_fifo_on_start(struct dai_intel_ssp *dp)
 
 		/* Clear the overflow status */
 		dai_ssp_update_bits(dp, SSSR, SSSR_ROR, SSSR_ROR);
-		/* Re-read the SSSR register */
-		sssr = sys_read32(dai_base(dp) + SSSR);
-	}
-
-	while ((sssr & SSSR_RNE) && retry--) {
-		uint32_t entries = SSCR3_RFL_VAL(sys_read32(dai_base(dp) + SSCR3));
-
-		/* Empty the RX FIFO (the DMA is not running at this point) */
-		for (i = 0; i < entries + 1; i++)
-			sys_read32(dai_base(dp) + SSDR);
-
-		sssr = sys_read32(dai_base(dp) + SSSR);
 	}
 }
 


### PR DESCRIPTION
On RX startup only drain the RX FIFO if the FIFO is in overflow condition.

When the FIFO is overflown it is not going to keep the DMA request line asserted and a DMA which is triggered by edge transition will not going to be able to start reading data out.