### PR TITLE
kernel: mmu: Fix possible null de-reference

### DIFF
--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -469,7 +469,9 @@ static int virt_to_page_frame(void *virt, uintptr_t *phys)
 		if (z_page_frame_is_mapped(pf)) {
 			if (virt == pf->addr) {
 				ret = 0;
-				*phys = z_page_frame_to_phys(pf);
+				if (phys != NULL) {
+					*phys = z_page_frame_to_phys(pf);
+				}
 				break;
 			}
 		}


### PR DESCRIPTION
virt_page_phys_get can be called with phy parameter NULL when the intention is just checking if a virtual address is mapped.

This function is generally overwritten by a an arch API that checks if phys is null before using it but this default implementation doesn't.