### PR TITLE
dts: bindings: adxl372: move int1-gpios to common

### DIFF
--- a/dts/bindings/sensor/adi,adxl372-common.yaml
+++ b/dts/bindings/sensor/adi,adxl372-common.yaml
@@ -56,3 +56,10 @@ properties:
       - 2
       - 3
       - 4
+
+  int1-gpios:
+    type: phandle-array
+    description: |
+      The INT1 signal defaults to active high as produced by the
+      sensor.  The property value should ensure the flags properly
+      describe the signal that is presented to the driver.

--- a/dts/bindings/sensor/adi,adxl372-i2c.yaml
+++ b/dts/bindings/sensor/adi,adxl372-i2c.yaml
@@ -6,11 +6,3 @@ description: ADXL372 3-axis high-g accelerometer, accessed through I2C bus
 compatible: "adi,adxl372"
 
 include: ["i2c-device.yaml", "adi,adxl372-common.yaml"]
-
-properties:
-  int1-gpios:
-    type: phandle-array
-    description: |
-      The INT1 signal defaults to active high as produced by the
-      sensor.  The property value should ensure the flags properly
-      describe the signal that is presented to the driver.

--- a/dts/bindings/sensor/adi,adxl372-spi.yaml
+++ b/dts/bindings/sensor/adi,adxl372-spi.yaml
@@ -7,11 +7,3 @@ description: ADXL372 3-axis high-g accelerometer, accessed through SPI bus
 compatible: "adi,adxl372"
 
 include: ["spi-device.yaml", "adi,adxl372-common.yaml"]
-
-properties:
-  int1-gpios:
-    type: phandle-array
-    description: |
-      The INT1 signal defaults to active high as produced by the
-      sensor.  The property value should ensure the flags properly
-      describe the signal that is presented to the driver.


### PR DESCRIPTION
The `int1-gpios` property is common for both spi and i2c implementations of adxl372. Therefore move it to
`adi,adxl372-common.yaml`