### PR TITLE
doc: Style improvements to "Related code samples" admonition.

### DIFF
--- a/doc/_extensions/zephyr/domain.py
+++ b/doc/_extensions/zephyr/domain.py
@@ -154,9 +154,10 @@ class ProcessRelatedCodeSamplesNode(SphinxPostTransform):
             if len(code_samples) > 0:
                 admonition = nodes.admonition()
                 admonition += nodes.title(text="Related code samples")
-                admonition["collapsible"] = "" # used by sphinx-immaterial theme
                 admonition["classes"].append("related-code-samples")
                 admonition["classes"].append("dropdown") # used by sphinx-togglebutton extension
+                admonition["classes"].append("toggle-shown") # show the content by default
+
                 sample_dl = nodes.definition_list()
 
                 for code_sample in sorted(code_samples, key=lambda x: x["name"]):

--- a/doc/_extensions/zephyr/domain.py
+++ b/doc/_extensions/zephyr/domain.py
@@ -157,9 +157,11 @@ class ProcessRelatedCodeSamplesNode(SphinxPostTransform):
                 admonition["collapsible"] = "" # used by sphinx-immaterial theme
                 admonition["classes"].append("related-code-samples")
                 admonition["classes"].append("dropdown") # used by sphinx-togglebutton extension
-                sample_ul = nodes.bullet_list()
+                sample_dl = nodes.definition_list()
+
                 for code_sample in sorted(code_samples, key=lambda x: x["name"]):
-                    sample_para = nodes.paragraph()
+                    term = nodes.term()
+
                     sample_xref = addnodes.pending_xref(
                         "",
                         refdomain="zephyr",
@@ -168,13 +170,14 @@ class ProcessRelatedCodeSamplesNode(SphinxPostTransform):
                         refwarn=True,
                     )
                     sample_xref += nodes.inline(text=code_sample["name"])
-                    sample_para += sample_xref
-                    sample_para += nodes.inline(text=" - ")
-                    sample_para += nodes.inline(text=code_sample["description"].astext())
-                    sample_li = nodes.list_item()
-                    sample_li += sample_para
-                    sample_ul += sample_li
-                admonition += sample_ul
+                    term += sample_xref
+                    definition = nodes.definition()
+                    definition += nodes.paragraph(text=code_sample["description"].astext())
+                    sample_dli = nodes.definition_list_item()
+                    sample_dli += term
+                    sample_dli += definition
+                    sample_dl += sample_dli
+                admonition += sample_dl
 
                 # replace node with the newly created admonition
                 node.replace_self(admonition)


### PR DESCRIPTION
Live example: https://builds.zephyrproject.io/zephyr/pr/64484/docs/connectivity/networking/api/mqtt.html#api-reference

* Render related code samples as a definition list to make the list easier to parse visually (i.e. all the descriptions are left-aligned)
* Expand the contents of the admonition by default

**Now**:

![image](https://github.com/zephyrproject-rtos/zephyr/assets/128251/596288dc-f78a-4a39-a290-3a5d7007f6dd)

**Before** (screenshot taken after expanding the admonition, obviously):

![image](https://github.com/zephyrproject-rtos/zephyr/assets/128251/663b3a9b-9acd-4d90-9339-722de0c9642b)
