### PR TITLE
scripts: check_init_priorities: usability updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1798,14 +1798,10 @@ if(CONFIG_BUILD_OUTPUT_INFO_HEADER)
 endif()
 
 if(CONFIG_CHECK_INIT_PRIORITIES)
-  if(CONFIG_CHECK_INIT_PRIORITIES_FAIL_ON_WARNING)
-    set(fail_on_warning "--fail-on-warning")
-  endif()
   list(APPEND
     post_build_commands
     COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/check_init_priorities.py
       --elf-file=${ZEPHYR_BINARY_DIR}/${KERNEL_ELF_NAME}
-      ${fail_on_warning}
     )
 endif()
 

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -767,16 +767,7 @@ config CHECK_INIT_PRIORITIES
 	  derived from the devicetree definition.
 
 	  Fails the build on priority errors (dependent devices, inverted
-	  priority), see CHECK_INIT_PRIORITIES_FAIL_ON_WARNING to fail on
-	  warnings (dependent devices, same priority) as well.
-
-config CHECK_INIT_PRIORITIES_FAIL_ON_WARNING
-	bool "Fail the build on priority check warnings"
-	depends on CHECK_INIT_PRIORITIES
-	help
-	  Fail the build if the dependency check script identifies any pair of
-	  devices depending on each other but initialized with the same
-	  priority.
+	  priority).
 
 config EMIT_ALL_SYSCALLS
 	bool "Emit all possible syscalls in the tree"

--- a/scripts/build/check_init_priorities.py
+++ b/scripts/build/check_init_priorities.py
@@ -244,7 +244,6 @@ class Validator():
 
         self._obj = ZephyrInitLevels(elf_file_path)
 
-        self.warnings = 0
         self.errors = 0
 
     def _check_dep(self, dev_ord, dep_ord):
@@ -275,9 +274,8 @@ class Validator():
             return
 
         if dev_prio == dep_prio:
-            self.warnings += 1
-            self.log.warning(
-                    f"{dev_node.path} {dev_prio} == {dep_node.path} {dep_prio}")
+            raise ValueError(f"{dev_node.path} and {dep_node.path} have the "
+                             f"same priority: {dev_prio}")
         elif dev_prio < dep_prio:
             self.errors += 1
             self.log.error(
@@ -311,8 +309,6 @@ def _parse_args(argv):
     parser.add_argument("-v", "--verbose", action="count",
                         help=("enable verbose output, can be used multiple times "
                               "to increase verbosity level"))
-    parser.add_argument("-w", "--fail-on-warning", action="store_true",
-                        help="fail on both warnings and errors")
     parser.add_argument("--always-succeed", action="store_true",
                         help="always exit with a return code of 0, used for testing")
     parser.add_argument("-o", "--output",
@@ -362,9 +358,6 @@ def main(argv=None):
 
     if args.always_succeed:
         return 0
-
-    if args.fail_on_warning and validator.warnings:
-        return 1
 
     if validator.errors:
         return 1

--- a/tests/misc/check_init_priorities/boards/native_posix.overlay
+++ b/tests/misc/check_init_priorities/boards/native_posix.overlay
@@ -34,12 +34,5 @@
 			reg = <0x11>;
 			supply-gpios = <&test_gpio_0 2 0>;
 		};
-
-		test_dev_c: test-i2c-dev@12 {
-			compatible = "vnd,i2c-device";
-			status = "okay";
-			reg = <0x12>;
-			supply-gpios = <&test_gpio_0 3 0>;
-		};
 	};
 };

--- a/tests/misc/check_init_priorities/src/main.c
+++ b/tests/misc/check_init_priorities/src/main.c
@@ -6,19 +6,12 @@
 
 #include <zephyr/device.h>
 
-static int device_init(const struct device *dev)
-{
-	return 0;
-}
-
-DEVICE_DT_DEFINE(DT_INST(0, vnd_gpio_device), device_init, NULL, NULL, NULL,
+DEVICE_DT_DEFINE(DT_INST(0, vnd_gpio_device), NULL, NULL, NULL, NULL,
 		 PRE_KERNEL_1, 50, NULL);
-DEVICE_DT_DEFINE(DT_INST(0, vnd_i2c), device_init, NULL, NULL, NULL,
+DEVICE_DT_DEFINE(DT_INST(0, vnd_i2c), NULL, NULL, NULL, NULL,
 		 PRE_KERNEL_1, 50, NULL);
 
-DEVICE_DT_DEFINE(DT_INST(0, vnd_i2c_device), device_init, NULL, NULL, NULL,
+DEVICE_DT_DEFINE(DT_INST(0, vnd_i2c_device), NULL, NULL, NULL, NULL,
 		 PRE_KERNEL_1, 49, NULL);
-DEVICE_DT_DEFINE(DT_INST(1, vnd_i2c_device), device_init, NULL, NULL, NULL,
+DEVICE_DT_DEFINE(DT_INST(1, vnd_i2c_device), NULL, NULL, NULL, NULL,
 		 PRE_KERNEL_1, 50, NULL);
-DEVICE_DT_DEFINE(DT_INST(2, vnd_i2c_device), device_init, NULL, NULL, NULL,
-		 PRE_KERNEL_1, 51, NULL);

--- a/tests/misc/check_init_priorities/validate_check_init_priorities_output.py
+++ b/tests/misc/check_init_priorities/validate_check_init_priorities_output.py
@@ -8,10 +8,11 @@
 import sys
 
 REFERENCE_OUTPUT = [
-        "ERROR: /i2c@11112222/test-i2c-dev@10 PRE_KERNEL_1 0 < /gpio@ffff PRE_KERNEL_1 1",
-        "ERROR: /i2c@11112222/test-i2c-dev@10 PRE_KERNEL_1 0 < /i2c@11112222 PRE_KERNEL_1 2",
-        "INFO: /i2c@11112222/test-i2c-dev@11 PRE_KERNEL_1 3 > /gpio@ffff PRE_KERNEL_1 1",
-        "INFO: /i2c@11112222/test-i2c-dev@11 PRE_KERNEL_1 3 > /i2c@11112222 PRE_KERNEL_1 2",
+        "ERROR: Device initialization priority validation failed, the sequence of initialization calls does not match the devicetree dependencies.",
+        "ERROR: /i2c@11112222/test-i2c-dev@10 <NULL> is initialized before its dependency /gpio@ffff <NULL> (PRE_KERNEL_1+0 < PRE_KERNEL_1+1)",
+        "ERROR: /i2c@11112222/test-i2c-dev@10 <NULL> is initialized before its dependency /i2c@11112222 <NULL> (PRE_KERNEL_1+0 < PRE_KERNEL_1+2)",
+        "INFO: /i2c@11112222/test-i2c-dev@11 <NULL> PRE_KERNEL_1+3 > /gpio@ffff <NULL> PRE_KERNEL_1+1",
+        "INFO: /i2c@11112222/test-i2c-dev@11 <NULL> PRE_KERNEL_1+3 > /i2c@11112222 <NULL> PRE_KERNEL_1+2",
 ]
 
 if len(sys.argv) != 2:

--- a/tests/misc/check_init_priorities/validate_check_init_priorities_output.py
+++ b/tests/misc/check_init_priorities/validate_check_init_priorities_output.py
@@ -12,8 +12,6 @@ REFERENCE_OUTPUT = [
         "ERROR: /i2c@11112222/test-i2c-dev@10 PRE_KERNEL_1 0 < /i2c@11112222 PRE_KERNEL_1 2",
         "INFO: /i2c@11112222/test-i2c-dev@11 PRE_KERNEL_1 3 > /gpio@ffff PRE_KERNEL_1 1",
         "INFO: /i2c@11112222/test-i2c-dev@11 PRE_KERNEL_1 3 > /i2c@11112222 PRE_KERNEL_1 2",
-        "INFO: /i2c@11112222/test-i2c-dev@12 PRE_KERNEL_1 4 > /gpio@ffff PRE_KERNEL_1 1",
-        "INFO: /i2c@11112222/test-i2c-dev@12 PRE_KERNEL_1 4 > /i2c@11112222 PRE_KERNEL_1 2",
 ]
 
 if len(sys.argv) != 2:


### PR DESCRIPTION
Since bb590b5b6e introduced ordinals in the priority sequence, the "same priority" case cannot happen anymore, furthermore the priority value in the script is now the position of the function in the init sequence, so if two devices have the same priority there's something real bad going on.

Drop all the "same priority" handling code and tests, convert the case into ane exception instead. Drop the init stubs as well from the test, they are not required anymore.

---

The current error messages are a bit cryptic, rework them to make them more meaningful:

- add an extra message on the first error to explain what the errors refer to.
- rework the error message to be more explicit.
- rework the priority string print to use a LEVEL+offset format to somehow highlight that the number is the offset from the level, not the actual priority.
- print the init function name in addition to the devicetree path.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/64386