### PR TITLE
tests/bsim/bt bis: Do not call into controller in split builds

### DIFF
--- a/tests/bsim/bluetooth/ll/bis/src/main.c
+++ b/tests/bsim/bluetooth/ll/bis/src/main.c
@@ -441,7 +441,7 @@ static void test_iso_main(void)
 	k_sleep(K_MSEC(2500));
 
 	printk("Periodic Advertising and ISO Channel Map Update...");
-	err = ll_chm_update(chan_map);
+	err = bt_le_set_chan_map(chan_map);
 	if (err) {
 		FAIL("Channel Map Update failed.\n");
 	}


### PR DESCRIPTION
Use the HCI layer to update the channel map instead of calling directly into the controller.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/64441