### PR TITLE
drivers: sensor: bq274xx: Configure or confirm chemistry profile

### DIFF
--- a/drivers/sensor/bq274xx/bq274xx.h
+++ b/drivers/sensor/bq274xx/bq274xx.h
@@ -9,6 +9,7 @@
 
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/dt-bindings/sensor/bq274xx.h>
 
 /*** General Constant ***/
 #define BQ274XX_UNSEAL_KEY_A 0x8000 /* Unseal code one on BQ27441-G1A and similar */
@@ -58,6 +59,11 @@
 #define BQ274XX_CTRL_SOFT_RESET      0x0042
 #define BQ274XX_CTRL_EXIT_CFGUPDATE  0x0043
 #define BQ274XX_CTRL_EXIT_RESIM      0x0044
+
+/* BQ27427 */
+#define BQ27427_CTRL_CHEM_A 0x0030
+#define BQ27427_CTRL_CHEM_B 0x0031
+#define BQ27427_CTRL_CHEM_C 0x0032
 
 /*** Extended Data Commands ***/
 #define BQ274XX_EXT_OPCONFIG                   0x3A /* OpConfig() */
@@ -119,6 +125,7 @@ struct bq274xx_config {
 #if defined(CONFIG_BQ274XX_PM) || defined(CONFIG_BQ274XX_TRIGGER)
 	struct gpio_dt_spec int_gpios;
 #endif
+	uint16_t chemistry_id;
 	bool lazy_loading;
 };
 

--- a/dts/bindings/sensor/ti,bq274xx.yaml
+++ b/dts/bindings/sensor/ti,bq274xx.yaml
@@ -31,6 +31,12 @@ properties:
     required: true
     description: Battery Terminate Voltage in mV
 
+  chemistry-id:
+    type: int
+    description: |
+      The value of the Chem ID register. When zero, the driver will not check the register.
+      See the reference manual for the specific BQ274xx variant for values.
+
   int-gpios:
     type: phandle-array
     description: |

--- a/include/zephyr/dt-bindings/sensor/bq274xx.h
+++ b/include/zephyr/dt-bindings/sensor/bq274xx.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2023 The Zephyr Contributors.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Relevant documents:
+ * - BQ27421
+ *   Datasheet: https://www.ti.com/lit/gpn/bq27421-g1
+ *   Technical reference manual: https://www.ti.com/lit/pdf/sluuac5
+ * - BQ27427
+ *   Datasheet: https://www.ti.com/lit/gpn/bq27427
+ *   Technical reference manual: https://www.ti.com/lit/pdf/sluucd5
+ */
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_BQ274XX_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_BQ274XX_H_
+
+/* Chemistry IDs for BQ27427 */
+#define BQ27427_CHEM_ID_A 0x3230
+#define BQ27427_CHEM_ID_B 0x1202
+#define BQ27427_CHEM_ID_C 0x3142
+
+/* Chemistry IDs for BQ27421 variants */
+#define BQ27421_G1A_CHEM_ID 0x0128
+#define BQ27421_G1B_CHEM_ID 0x0312
+#define BQ27421_G1D_CHEM_ID 0x3142
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_BQ274XX_H_ */


### PR DESCRIPTION
Both the BQ27421 and BQ27427 have a few preset Chemistry profiles.
For the BQ27421 there exists three variants of the IC, and for the BQ27427,
it can be configured. The chemistry profile among other things includes the
taper voltage, which is used to detect charge termination.

This adds an optional `chemistry-id` config option to the driver. On the
BQ27421, it will confirm that the correct variant of the IC is mounted,
and on the BQ27427, it will configure it with the correct value.

Side note: The reference manual for the BQ27427
(https://www.ti.com/lit/ug/sluucd5/sluucd5.pdf) currently contains some
errors and inconsistencies regarding these registers. The table on page 7
appears to be correct.

