### PR TITLE
Bluetooth: Controller: Fix corruption during BIG_CHANNEL_MAP_IND

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -671,9 +671,9 @@ void *radio_pkt_decrypt_get(void)
 
 #if defined(CONFIG_BT_CTLR_ADV_ISO) || defined(CONFIG_BT_CTLR_SYNC_ISO)
 /* Dedicated Rx PDU Buffer for Control PDU independent of node_rx with BIS Data
- * PDU buffer
+ * PDU buffer. Note this buffer will be used to store whole PDUs, not just the BIG control payload.
  */
-static uint8_t pkt_big_ctrl[sizeof(struct pdu_big_ctrl)];
+static uint8_t pkt_big_ctrl[offsetof(struct pdu_bis, payload) + sizeof(struct pdu_big_ctrl)];
 
 void *radio_pkt_big_ctrl_get(void)
 {


### PR DESCRIPTION
radio_pkt_big_ctrl_get() returns a statically allocated
buffer of type pdu_big_ctrl, but the callers expect a
buffer where a whole PDU for a BIG control packet can fit
(not just space for the payload),
and use it as such, overflowing this statically
allocated buffer, and smashing other variables after.

Let's fix it by allocating a buffer of the correct size
to fit a BIG control PDU.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/64497