### PR TITLE
drivers: can: add accessor for the CAN bit error counter

### DIFF
--- a/drivers/can/can_handlers.c
+++ b/drivers/can/can_handlers.c
@@ -246,6 +246,14 @@ static inline int z_vrfy_can_recover(const struct device *dev, k_timeout_t timeo
 
 #ifdef CONFIG_CAN_STATS
 
+static inline uint32_t z_vrfy_can_stats_get_bit_errors(const struct device *dev)
+{
+	Z_OOPS(Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_CAN));
+
+	return z_impl_can_stats_get_bit_errors(dev);
+}
+#include <syscalls/can_stats_get_bit_errors_mrsh.c>
+
 static inline uint32_t z_vrfy_can_stats_get_bit0_errors(const struct device *dev)
 {
 	Z_OOPS(Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_CAN));

--- a/drivers/can/can_shell.c
+++ b/drivers/can/can_shell.c
@@ -364,8 +364,9 @@ static int cmd_can_show(const struct shell *sh, size_t argc, char **argv)
 
 #ifdef CONFIG_CAN_STATS
 	shell_print(sh, "statistics:");
-	shell_print(sh, "  bit0 errors:   %u", can_stats_get_bit0_errors(dev));
-	shell_print(sh, "  bit1 errors:   %u", can_stats_get_bit1_errors(dev));
+	shell_print(sh, "  bit errors:    %u", can_stats_get_bit_errors(dev));
+	shell_print(sh, "    bit0 errors: %u", can_stats_get_bit0_errors(dev));
+	shell_print(sh, "    bit1 errors: %u", can_stats_get_bit1_errors(dev));
 	shell_print(sh, "  stuff errors:  %u", can_stats_get_stuff_errors(dev));
 	shell_print(sh, "  crc errors:    %u", can_stats_get_crc_errors(dev));
 	shell_print(sh, "  form errors:   %u", can_stats_get_form_errors(dev));

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -1376,6 +1376,27 @@ static inline void can_set_state_change_callback(const struct device *dev,
  */
 
 /**
+ * @brief Get the bit error counter for a CAN device
+ *
+ * The bit error counter is incremented when the CAN controller is unable to
+ * transmit either a dominant or a recessive bit.
+ *
+ * @note @kconfig{CONFIG_CAN_STATS} must be selected for this function to be
+ * available.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @return bit error counter
+ */
+__syscall uint32_t can_stats_get_bit_errors(const struct device *dev);
+
+#ifdef CONFIG_CAN_STATS
+static inline uint32_t z_impl_can_stats_get_bit_errors(const struct device *dev)
+{
+	return Z_CAN_GET_STATS(dev).bit_error;
+}
+#endif /* CONFIG_CAN_STATS */
+
+/**
  * @brief Get the bit0 error counter for a CAN device
  *
  * The bit0 error counter is incremented when the CAN controller is unable to
@@ -1383,6 +1404,8 @@ static inline void can_set_state_change_callback(const struct device *dev,
  *
  * @note @kconfig{CONFIG_CAN_STATS} must be selected for this function to be
  * available.
+ *
+ * @see can_stats_get_bit_errors()
  *
  * @param dev Pointer to the device structure for the driver instance.
  * @return bit0 error counter
@@ -1404,6 +1427,8 @@ static inline uint32_t z_impl_can_stats_get_bit0_errors(const struct device *dev
  *
  * @note @kconfig{CONFIG_CAN_STATS} must be selected for this function to be
  * available.
+ *
+ * @see can_stats_get_bit_errors()
  *
  * @param dev Pointer to the device structure for the driver instance.
  * @return bit1 error counter

--- a/tests/drivers/can/api/src/stats.c
+++ b/tests/drivers/can/api/src/stats.c
@@ -23,6 +23,7 @@ ZTEST_USER(can_stats, test_can_stats_accessors)
 {
 	uint32_t val;
 
+	val = can_stats_get_bit_errors(can_dev);
 	val = can_stats_get_bit0_errors(can_dev);
 	val = can_stats_get_bit1_errors(can_dev);
 	val = can_stats_get_stuff_errors(can_dev);


### PR DESCRIPTION
Add accessor function for the CAN bit error counter.

This was missed in #63733 since #63432 was merged the same day.