### PR TITLE
samples: modules: canopennode: suggest using manifest.project-filter

### DIFF
--- a/samples/modules/canopennode/README.rst
+++ b/samples/modules/canopennode/README.rst
@@ -30,7 +30,7 @@ First, ensure the optional CANopenNode module is enabled and available:
 
    .. code-block:: console
 
-      west config manifest.group-filter +optional
+      west config manifest.project-filter +canopennode
       west update canopennode
 
 Building and Running for TWR-KE18F


### PR DESCRIPTION
Suggest users to use "west config manifest.project-filter +canopennode" instead of "west config manifest.group-filter +optional" in the sample documentation to avoid pulling in unrelated, optional modules.