### PR TITLE
doc: fix Doxygen light theme

### DIFF
--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -1368,7 +1368,7 @@ HTML_EXTRA_FILES       = @ZEPHYR_BASE@/doc/_doxygen/doxygen-awesome-darkmode-tog
 # The default value is: AUTO_LIGHT.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_COLORSTYLE        = AUTO_LIGHT
+HTML_COLORSTYLE        = LIGHT
 
 # The HTML_COLORSTYLE_HUE tag controls the color of the HTML output. Doxygen
 # will adjust the colors in the style sheet and background images according to


### PR DESCRIPTION
As per Doxygen Awesome documentation:
"HTML_COLORSTYLE must be set to LIGHT since Doxygen 1.9.5!"

See fixed light theme here: https://builds.zephyrproject.io/zephyr/pr/64506/docs/doxygen/html/group__connectivity.html

Fixes #64505