### PR TITLE
drivers: gpio: gpio_pca953x: Adding input latch and interrupt mask

### DIFF
--- a/drivers/gpio/gpio_pca953x.c
+++ b/drivers/gpio/gpio_pca953x.c
@@ -27,6 +27,8 @@ LOG_MODULE_REGISTER(pca953x, CONFIG_GPIO_LOG_LEVEL);
 #define PCA953X_INPUT_PORT		0x00
 #define PCA953X_OUTPUT_PORT		0x01
 #define PCA953X_CONFIGURATION		0x03
+#define REG_INPUT_LATCH_PORT0		0x42
+#define REG_INT_MASK_PORT0		0x45
 
 /* Number of pins supported by the device */
 #define NUM_PINS 8
@@ -67,6 +69,8 @@ struct pca953x_config {
 	struct i2c_dt_spec i2c;
 	const struct gpio_dt_spec gpio_int;
 	bool interrupt_enabled;
+	int interrupt_mask;
+	int input_latch;
 };
 
 /**
@@ -439,6 +443,14 @@ static int gpio_pca953x_init(const struct device *dev)
 
 		rc = gpio_add_callback(cfg->gpio_int.port,
 					&drv_data->gpio_cb);
+
+		/* This may not present on all variants of device */
+		if (cfg->input_latch > -1) {
+			i2c_reg_write_byte_dt(&cfg->i2c, REG_INPUT_LATCH_PORT0, cfg->input_latch);
+		}
+		if (cfg->interrupt_mask > -1) {
+			i2c_reg_write_byte_dt(&cfg->i2c, REG_INT_MASK_PORT0, cfg->interrupt_mask);
+		}
 	}
 out:
 	if (rc) {
@@ -468,6 +480,8 @@ static const struct gpio_driver_api api_table = {
 		},								\
 		.interrupt_enabled = DT_INST_NODE_HAS_PROP(n, nint_gpios),	\
 		.gpio_int = GPIO_DT_SPEC_INST_GET_OR(n, nint_gpios, {0}),	\
+		.interrupt_mask = DT_INST_PROP_OR(n, interrupt_mask, -1),	\
+		.input_latch = DT_INST_PROP_OR(n, input_latch, -1),		\
 	};									\
 										\
 	static struct pca953x_drv_data pca953x_drvdata_##n = {			\

--- a/dts/bindings/gpio/ti,tca9538.yaml
+++ b/dts/bindings/gpio/ti,tca9538.yaml
@@ -24,6 +24,20 @@ properties:
       Connection for the NINT signal. This signal is active-low when
       produced by tca9538 GPIO node.
 
+  input-latch:
+    type: int
+    description: |
+      Input latch register bit is 0 by default and the input pin state
+      is not latched. When input latch register bit is 1 and the input
+      pin state is latched.
+
+  interrupt-mask:
+    type: int
+    description: |
+      Interrupt mask register is set to logic 1 by default without
+      enabling interrupts. Setting corresponding mask bits to logic
+      0 to enable the interrupts.
+
 gpio-cells:
   - pin
   - flags


### PR DESCRIPTION
The gpio_pca953x gpio driver doesn't have
the input latch and interrupt mask
configuration which causes a lack of accessing
and using those features on an gpio expander
device. Fix it by adding input latch and
interrupt mask configurations in this driver.