### PR TITLE
kernel: init: conditional .bss section zeroing

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -139,6 +139,8 @@ config ARCH_POSIX
 	select NATIVE_BUILD
 	select HAS_COVERAGE_SUPPORT
 	select BARRIER_OPERATIONS_BUILTIN
+	# native_posix gets its memory cleared on entry by the host OS
+	select SKIP_BSS_CLEAR
 	help
 	  POSIX (native) architecture
 

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -382,6 +382,16 @@ config INIT_STACKS
 	  water mark can be easily determined. This applies to the stack areas
 	  for threads, as well as to the interrupt stack.
 
+config SKIP_BSS_CLEAR
+	bool
+	help
+	  This option disables software .bss section zeroing during Zephyr
+	  initialization. Such boot-time optimization could be used for
+	  platforms where .bss section is zeroed-out externally.
+	  Please pay attention that when this option is enabled
+	  the responsibility for .bss zeroing in all possible scenarios
+	  (mind e.g. SW reset) is delegated to the external SW or HW.
+
 config BOOT_BANNER
 	bool "Boot banner"
 	default y

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -165,12 +165,7 @@ void __weak z_early_memcpy(void *dst, const void *src, size_t n)
 __boot_func
 void z_bss_zero(void)
 {
-	if (IS_ENABLED(CONFIG_ARCH_POSIX)) {
-		/* native_posix gets its memory cleared on entry by
-		 * the host OS, and in any case the host clang/lld
-		 * doesn't emit the __bss_end symbol this code expects
-		 * to see
-		 */
+	if (IS_ENABLED(CONFIG_SKIP_BSS_CLEAR)) {
 		return;
 	}
 


### PR DESCRIPTION
Some platforms already have .bss section zeroed-out externally before the Zephyr initialization and there is no sence to zero it out the second time from the SW.
Such boot-time optimization could be critical e.g. for RTL Simulation.