### PR TITLE
boards: bl653_dvk: Fix incorrect definition of cs-gpios in spi1

### DIFF
--- a/boards/arm/bl653_dvk/bl653_dvk.dts
+++ b/boards/arm/bl653_dvk/bl653_dvk.dts
@@ -148,7 +148,7 @@
 &spi1 {
 	compatible = "nordic,nrf-spi";
 	status = "okay";
-	cs-gpios = <&gpio1 23 0>;
+	cs-gpios = <&gpio0 23 GPIO_ACTIVE_LOW>;
 	pinctrl-0 = <&spi1_default>;
 	pinctrl-1 = <&spi1_sleep>;
 	pinctrl-names = "default", "sleep";


### PR DESCRIPTION
`cs-gpios = <&gpio1 23 0>;` is incorrect, since pin P1.23 does not even exist in nRF52833. According to schematic, it should be P0.23 and this CS line should be configured as active low.