### PR TITLE
headers: Drop extern attribute from functions

### DIFF
--- a/include/zephyr/arch/cache.h
+++ b/include/zephyr/arch/cache.h
@@ -32,7 +32,7 @@
  *
  * Enable the data cache.
  */
-extern void arch_dcache_enable(void);
+void arch_dcache_enable(void);
 
 #define cache_data_enable arch_dcache_enable
 
@@ -41,7 +41,7 @@ extern void arch_dcache_enable(void);
  *
  * Disable the data cache.
  */
-extern void arch_dcache_disable(void);
+void arch_dcache_disable(void);
 
 #define cache_data_disable arch_dcache_disable
 
@@ -54,7 +54,7 @@ extern void arch_dcache_disable(void);
  * @retval -ENOTSUP If not supported.
  * @retval -errno Negative errno for other failures.
  */
-extern int arch_dcache_flush_all(void);
+int arch_dcache_flush_all(void);
 
 #define cache_data_flush_all arch_dcache_flush_all
 
@@ -67,7 +67,7 @@ extern int arch_dcache_flush_all(void);
  * @retval -ENOTSUP If not supported.
  * @retval -errno Negative errno for other failures.
  */
-extern int arch_dcache_invd_all(void);
+int arch_dcache_invd_all(void);
 
 #define cache_data_invd_all arch_dcache_invd_all
 
@@ -80,7 +80,7 @@ extern int arch_dcache_invd_all(void);
  * @retval -ENOTSUP If not supported.
  * @retval -errno Negative errno for other failures.
  */
-extern int arch_dcache_flush_and_invd_all(void);
+int arch_dcache_flush_and_invd_all(void);
 
 #define cache_data_flush_and_invd_all arch_dcache_flush_and_invd_all
 
@@ -103,7 +103,7 @@ extern int arch_dcache_flush_and_invd_all(void);
  * @retval -ENOTSUP If not supported.
  * @retval -errno Negative errno for other failures.
  */
-extern int arch_dcache_flush_range(void *addr, size_t size);
+int arch_dcache_flush_range(void *addr, size_t size);
 
 #define cache_data_flush_range(addr, size) arch_dcache_flush_range(addr, size)
 
@@ -127,7 +127,7 @@ extern int arch_dcache_flush_range(void *addr, size_t size);
  * @retval -ENOTSUP If not supported.
  * @retval -errno Negative errno for other failures.
  */
-extern int arch_dcache_invd_range(void *addr, size_t size);
+int arch_dcache_invd_range(void *addr, size_t size);
 
 #define cache_data_invd_range(addr, size) arch_dcache_invd_range(addr, size)
 
@@ -152,7 +152,7 @@ extern int arch_dcache_invd_range(void *addr, size_t size);
  * @retval -errno Negative errno for other failures.
  */
 
-extern int arch_dcache_flush_and_invd_range(void *addr, size_t size);
+int arch_dcache_flush_and_invd_range(void *addr, size_t size);
 
 #define cache_data_flush_and_invd_range(addr, size) \
 	arch_dcache_flush_and_invd_range(addr, size)
@@ -172,7 +172,7 @@ extern int arch_dcache_flush_and_invd_range(void *addr, size_t size);
  * @retval size Size of the d-cache line.
  * @retval 0 If the d-cache is not enabled.
  */
-extern size_t arch_dcache_line_size_get(void);
+size_t arch_dcache_line_size_get(void);
 
 #define cache_data_line_size_get arch_dcache_line_size_get
 
@@ -187,7 +187,7 @@ extern size_t arch_dcache_line_size_get(void);
  *
  * Enable the instruction cache.
  */
-extern void arch_icache_enable(void);
+void arch_icache_enable(void);
 
 #define cache_instr_enable arch_icache_enable
 
@@ -196,7 +196,7 @@ extern void arch_icache_enable(void);
  *
  * Disable the instruction cache.
  */
-extern void arch_icache_disable(void);
+void arch_icache_disable(void);
 
 #define cache_instr_disable arch_icache_disable
 
@@ -209,7 +209,7 @@ extern void arch_icache_disable(void);
  * @retval -ENOTSUP If not supported.
  * @retval -errno Negative errno for other failures.
  */
-extern int arch_icache_flush_all(void);
+int arch_icache_flush_all(void);
 
 #define cache_instr_flush_all arch_icache_flush_all
 
@@ -222,7 +222,7 @@ extern int arch_icache_flush_all(void);
  * @retval -ENOTSUP If not supported.
  * @retval -errno Negative errno for other failures.
  */
-extern int arch_icache_invd_all(void);
+int arch_icache_invd_all(void);
 
 #define cache_instr_invd_all arch_icache_invd_all
 
@@ -235,7 +235,7 @@ extern int arch_icache_invd_all(void);
  * @retval -ENOTSUP If not supported.
  * @retval -errno Negative errno for other failures.
  */
-extern int arch_icache_flush_and_invd_all(void);
+int arch_icache_flush_and_invd_all(void);
 
 #define cache_instr_flush_and_invd_all arch_icache_flush_and_invd_all
 
@@ -258,7 +258,7 @@ extern int arch_icache_flush_and_invd_all(void);
  * @retval -ENOTSUP If not supported.
  * @retval -errno Negative errno for other failures.
  */
-extern int arch_icache_flush_range(void *addr, size_t size);
+int arch_icache_flush_range(void *addr, size_t size);
 
 #define cache_instr_flush_range(addr, size) arch_icache_flush_range(addr, size)
 
@@ -282,7 +282,7 @@ extern int arch_icache_flush_range(void *addr, size_t size);
  * @retval -ENOTSUP If not supported.
  * @retval -errno Negative errno for other failures.
  */
-extern int arch_icache_invd_range(void *addr, size_t size);
+int arch_icache_invd_range(void *addr, size_t size);
 
 #define cache_instr_invd_range(addr, size) arch_icache_invd_range(addr, size)
 
@@ -306,7 +306,7 @@ extern int arch_icache_invd_range(void *addr, size_t size);
  * @retval -ENOTSUP If not supported.
  * @retval -errno Negative errno for other failures.
  */
-extern int arch_icache_flush_and_invd_range(void *addr, size_t size);
+int arch_icache_flush_and_invd_range(void *addr, size_t size);
 
 #define cache_instr_flush_and_invd_range(addr, size) \
 	arch_icache_flush_and_invd_range(addr, size)
@@ -327,7 +327,7 @@ extern int arch_icache_flush_and_invd_range(void *addr, size_t size);
  * @retval 0 If the d-cache is not enabled.
  */
 
-extern size_t arch_icache_line_size_get(void);
+size_t arch_icache_line_size_get(void);
 
 #define cache_instr_line_size_get arch_icache_line_size_get
 

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -118,7 +118,7 @@ typedef void (*k_thread_user_cb_t)(const struct k_thread *thread,
  * list which means creation of new threads and terminations of existing
  * threads are blocked until this API returns.
  */
-extern void k_thread_foreach(k_thread_user_cb_t user_cb, void *user_data);
+void k_thread_foreach(k_thread_user_cb_t user_cb, void *user_data);
 
 /**
  * @brief Iterate over all the threads in the system without locking.
@@ -147,7 +147,7 @@ extern void k_thread_foreach(k_thread_user_cb_t user_cb, void *user_data);
  * Do not reuse the memory that was occupied by k_thread structure of aborted
  * task if it was aborted after this function was called in any context.
  */
-extern void k_thread_foreach_unlocked(
+void k_thread_foreach_unlocked(
 	k_thread_user_cb_t user_cb, void *user_data);
 
 /** @} */
@@ -371,7 +371,7 @@ __syscall k_tid_t k_thread_create(struct k_thread *new_thread,
  * @param p2 2nd entry point parameter
  * @param p3 3rd entry point parameter
  */
-extern FUNC_NORETURN void k_thread_user_mode_enter(k_thread_entry_t entry,
+FUNC_NORETURN void k_thread_user_mode_enter(k_thread_entry_t entry,
 						   void *p1, void *p2,
 						   void *p3);
 
@@ -643,8 +643,8 @@ __syscall void k_thread_abort(k_tid_t thread);
  */
 __syscall void k_thread_start(k_tid_t thread);
 
-extern k_ticks_t z_timeout_expires(const struct _timeout *timeout);
-extern k_ticks_t z_timeout_remaining(const struct _timeout *timeout);
+k_ticks_t z_timeout_expires(const struct _timeout *timeout);
+k_ticks_t z_timeout_remaining(const struct _timeout *timeout);
 
 #ifdef CONFIG_SYS_CLOCK_EXISTS
 
@@ -1022,7 +1022,7 @@ __syscall void k_thread_resume(k_tid_t thread);
  * @param slice Maximum time slice length (in milliseconds).
  * @param prio Highest thread priority level eligible for time slicing.
  */
-extern void k_sched_time_slice_set(int32_t slice, int prio);
+void k_sched_time_slice_set(int32_t slice, int prio);
 
 /**
  * @brief Set thread time slice
@@ -1083,7 +1083,7 @@ void k_thread_time_slice_set(struct k_thread *th, int32_t slice_ticks,
  * @return false if invoked by a thread.
  * @return true if invoked by an ISR.
  */
-extern bool k_is_in_isr(void);
+bool k_is_in_isr(void);
 
 /**
  * @brief Determine if code is running in a preemptible thread.
@@ -1155,7 +1155,7 @@ static inline bool k_is_pre_kernel(void)
  * In general this is a historical API not well-suited to modern
  * applications, use with care.
  */
-extern void k_sched_lock(void);
+void k_sched_lock(void);
 
 /**
  * @brief Unlock the scheduler.
@@ -1164,7 +1164,7 @@ extern void k_sched_lock(void);
  * A thread must call the routine once for each time it called k_sched_lock()
  * before the thread becomes preemptible.
  */
-extern void k_sched_unlock(void);
+void k_sched_unlock(void);
 
 /**
  * @brief Set current thread's custom data.
@@ -1561,7 +1561,7 @@ typedef void (*k_timer_stop_t)(struct k_timer *timer);
  * @param expiry_fn Function to invoke each time the timer expires.
  * @param stop_fn   Function to invoke if the timer is stopped while running.
  */
-extern void k_timer_init(struct k_timer *timer,
+void k_timer_init(struct k_timer *timer,
 			 k_timer_expiry_t expiry_fn,
 			 k_timer_stop_t stop_fn);
 
@@ -1911,7 +1911,7 @@ __syscall void k_queue_cancel_wait(struct k_queue *queue);
  * @param queue Address of the queue.
  * @param data Address of the data item.
  */
-extern void k_queue_append(struct k_queue *queue, void *data);
+void k_queue_append(struct k_queue *queue, void *data);
 
 /**
  * @brief Append an element to a queue.
@@ -1943,7 +1943,7 @@ __syscall int32_t k_queue_alloc_append(struct k_queue *queue, void *data);
  * @param queue Address of the queue.
  * @param data Address of the data item.
  */
-extern void k_queue_prepend(struct k_queue *queue, void *data);
+void k_queue_prepend(struct k_queue *queue, void *data);
 
 /**
  * @brief Prepend an element to a queue.
@@ -1976,7 +1976,7 @@ __syscall int32_t k_queue_alloc_prepend(struct k_queue *queue, void *data);
  * @param prev Address of the previous data item.
  * @param data Address of the data item.
  */
-extern void k_queue_insert(struct k_queue *queue, void *prev, void *data);
+void k_queue_insert(struct k_queue *queue, void *prev, void *data);
 
 /**
  * @brief Atomically append a list of elements to a queue.
@@ -1996,7 +1996,7 @@ extern void k_queue_insert(struct k_queue *queue, void *prev, void *data);
  * @retval -EINVAL on invalid supplied data
  *
  */
-extern int k_queue_append_list(struct k_queue *queue, void *head, void *tail);
+int k_queue_append_list(struct k_queue *queue, void *head, void *tail);
 
 /**
  * @brief Atomically add a list of elements to a queue.
@@ -2013,7 +2013,7 @@ extern int k_queue_append_list(struct k_queue *queue, void *head, void *tail);
  * @retval 0 on success
  * @retval -EINVAL on invalid data
  */
-extern int k_queue_merge_slist(struct k_queue *queue, sys_slist_t *list);
+int k_queue_merge_slist(struct k_queue *queue, sys_slist_t *list);
 
 /**
  * @brief Get an element from a queue.
@@ -3350,7 +3350,7 @@ int k_work_submit_to_queue(struct k_work_q *queue,
  *
  * @return as with k_work_submit_to_queue().
  */
-extern int k_work_submit(struct k_work *work);
+int k_work_submit(struct k_work *work);
 
 /** @brief Wait for last-submitted instance to complete.
  *
@@ -3653,7 +3653,7 @@ int k_work_schedule_for_queue(struct k_work_q *queue,
  *
  * @return as with k_work_schedule_for_queue().
  */
-extern int k_work_schedule(struct k_work_delayable *dwork,
+int k_work_schedule(struct k_work_delayable *dwork,
 				   k_timeout_t delay);
 
 /** @brief Reschedule a work item to a queue after a delay.
@@ -3707,7 +3707,7 @@ int k_work_reschedule_for_queue(struct k_work_q *queue,
  *
  * @return as with k_work_reschedule_for_queue().
  */
-extern int k_work_reschedule(struct k_work_delayable *dwork,
+int k_work_reschedule(struct k_work_delayable *dwork,
 				     k_timeout_t delay);
 
 /** @brief Flush delayable work.
@@ -4228,7 +4228,7 @@ static inline int k_work_user_submit_to_queue(struct k_work_user_q *work_q,
  * @param name optional thread name.  If not null a copy is made into the
  *		thread's name buffer.
  */
-extern void k_work_user_queue_start(struct k_work_user_q *work_q,
+void k_work_user_queue_start(struct k_work_user_q *work_q,
 				    k_thread_stack_t *stack,
 				    size_t stack_size, int prio,
 				    const char *name);
@@ -4297,7 +4297,7 @@ struct k_work_poll {
  * @param work Address of triggered work item.
  * @param handler Function to invoke each time work item is processed.
  */
-extern void k_work_poll_init(struct k_work_poll *work,
+void k_work_poll_init(struct k_work_poll *work,
 			     k_work_handler_t handler);
 
 /**
@@ -4334,7 +4334,7 @@ extern void k_work_poll_init(struct k_work_poll *work,
  * @retval -EINVAL Work item is being processed or has completed its work.
  * @retval -EADDRINUSE Work item is pending on a different workqueue.
  */
-extern int k_work_poll_submit_to_queue(struct k_work_q *work_q,
+int k_work_poll_submit_to_queue(struct k_work_q *work_q,
 				       struct k_work_poll *work,
 				       struct k_poll_event *events,
 				       int num_events,
@@ -4371,7 +4371,7 @@ extern int k_work_poll_submit_to_queue(struct k_work_q *work_q,
  * @retval -EINVAL Work item is being processed or has completed its work.
  * @retval -EADDRINUSE Work item is pending on a different workqueue.
  */
-extern int k_work_poll_submit(struct k_work_poll *work,
+int k_work_poll_submit(struct k_work_poll *work,
 				     struct k_poll_event *events,
 				     int num_events,
 				     k_timeout_t timeout);
@@ -4390,7 +4390,7 @@ extern int k_work_poll_submit(struct k_work_poll *work,
  * @retval 0 Work item canceled.
  * @retval -EINVAL Work item is being processed or has completed its work.
  */
-extern int k_work_poll_cancel(struct k_work_poll *work);
+int k_work_poll_cancel(struct k_work_poll *work);
 
 /** @} */
 
@@ -4766,7 +4766,7 @@ struct k_mbox {
  *
  * @param mbox Address of the mailbox.
  */
-extern void k_mbox_init(struct k_mbox *mbox);
+void k_mbox_init(struct k_mbox *mbox);
 
 /**
  * @brief Send a mailbox message in a synchronous manner.
@@ -4787,7 +4787,7 @@ extern void k_mbox_init(struct k_mbox *mbox);
  * @retval -ENOMSG Returned without waiting.
  * @retval -EAGAIN Waiting period timed out.
  */
-extern int k_mbox_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg,
+int k_mbox_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg,
 		      k_timeout_t timeout);
 
 /**
@@ -4803,7 +4803,7 @@ extern int k_mbox_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg,
  * @param tx_msg Address of the transmit message descriptor.
  * @param sem Address of a semaphore, or NULL if none is needed.
  */
-extern void k_mbox_async_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg,
+void k_mbox_async_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg,
 			     struct k_sem *sem);
 
 /**
@@ -4823,7 +4823,7 @@ extern void k_mbox_async_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg,
  * @retval -ENOMSG Returned without waiting.
  * @retval -EAGAIN Waiting period timed out.
  */
-extern int k_mbox_get(struct k_mbox *mbox, struct k_mbox_msg *rx_msg,
+int k_mbox_get(struct k_mbox *mbox, struct k_mbox_msg *rx_msg,
 		      void *buffer, k_timeout_t timeout);
 
 /**
@@ -4839,7 +4839,7 @@ extern int k_mbox_get(struct k_mbox *mbox, struct k_mbox_msg *rx_msg,
  * @param buffer Address of the buffer to receive data, or NULL to discard
  *               the data.
  */
-extern void k_mbox_data_get(struct k_mbox_msg *rx_msg, void *buffer);
+void k_mbox_data_get(struct k_mbox_msg *rx_msg, void *buffer);
 
 /** @} */
 
@@ -5175,7 +5175,7 @@ struct k_mem_slab {
  * @retval -EINVAL invalid data supplied
  *
  */
-extern int k_mem_slab_init(struct k_mem_slab *slab, void *buffer,
+int k_mem_slab_init(struct k_mem_slab *slab, void *buffer,
 			   size_t block_size, uint32_t num_blocks);
 
 /**
@@ -5200,7 +5200,7 @@ extern int k_mem_slab_init(struct k_mem_slab *slab, void *buffer,
  * @retval -EAGAIN Waiting period timed out.
  * @retval -EINVAL Invalid data supplied
  */
-extern int k_mem_slab_alloc(struct k_mem_slab *slab, void **mem,
+int k_mem_slab_alloc(struct k_mem_slab *slab, void **mem,
 			    k_timeout_t timeout);
 
 /**
@@ -5212,7 +5212,7 @@ extern int k_mem_slab_alloc(struct k_mem_slab *slab, void **mem,
  * @param slab Address of the memory slab.
  * @param mem Pointer to the memory block (as returned by k_mem_slab_alloc()).
  */
-extern void k_mem_slab_free(struct k_mem_slab *slab, void *mem);
+void k_mem_slab_free(struct k_mem_slab *slab, void *mem);
 
 /**
  * @brief Get the number of used blocks in a memory slab.
@@ -5474,7 +5474,7 @@ void k_heap_free(struct k_heap *h, void *mem);
  *
  * @return Address of the allocated memory if successful; otherwise NULL.
  */
-extern void *k_aligned_alloc(size_t align, size_t size);
+void *k_aligned_alloc(size_t align, size_t size);
 
 /**
  * @brief Allocate memory from the heap.
@@ -5487,7 +5487,7 @@ extern void *k_aligned_alloc(size_t align, size_t size);
  *
  * @return Address of the allocated memory if successful; otherwise NULL.
  */
-extern void *k_malloc(size_t size);
+void *k_malloc(size_t size);
 
 /**
  * @brief Free memory allocated from heap.
@@ -5499,7 +5499,7 @@ extern void *k_malloc(size_t size);
  *
  * @param ptr Pointer to previously allocated memory.
  */
-extern void k_free(void *ptr);
+void k_free(void *ptr);
 
 /**
  * @brief Allocate memory from heap, array style
@@ -5512,7 +5512,7 @@ extern void k_free(void *ptr);
  *
  * @return Address of the allocated memory if successful; otherwise NULL.
  */
-extern void *k_calloc(size_t nmemb, size_t size);
+void *k_calloc(size_t nmemb, size_t size);
 
 /** @} */
 
@@ -5724,7 +5724,7 @@ struct k_poll_event {
  * @param obj Kernel object or poll signal.
  */
 
-extern void k_poll_event_init(struct k_poll_event *event, uint32_t type,
+void k_poll_event_init(struct k_poll_event *event, uint32_t type,
 			      int mode, void *obj);
 
 /**
@@ -5947,7 +5947,7 @@ static inline void k_cpu_atomic_idle(unsigned int key)
 /**
  * @internal
  */
-extern void z_init_static_threads(void);
+void z_init_static_threads(void);
 #else
 /**
  * @internal
@@ -5958,7 +5958,7 @@ extern void z_init_static_threads(void);
 /**
  * @internal
  */
-extern void z_timer_expiration_handler(struct _timeout *t);
+void z_timer_expiration_handler(struct _timeout *t);
 /**
  * INTERNAL_HIDDEN @endcond
  */
@@ -6063,7 +6063,7 @@ int k_thread_runtime_stats_all_get(k_thread_runtime_stats_t *stats);
  * @param thread ID of thread
  * @return -EINVAL if invalid thread ID, otherwise 0
  */
-extern int k_thread_runtime_stats_enable(k_tid_t thread);
+int k_thread_runtime_stats_enable(k_tid_t thread);
 
 /**
  * @brief Disable gathering of runtime statistics for specified thread
@@ -6074,7 +6074,7 @@ extern int k_thread_runtime_stats_enable(k_tid_t thread);
  * @param thread ID of thread
  * @return -EINVAL if invalid thread ID, otherwise 0
  */
-extern int k_thread_runtime_stats_disable(k_tid_t thread);
+int k_thread_runtime_stats_disable(k_tid_t thread);
 
 /**
  * @brief Enable gathering of system runtime statistics
@@ -6083,7 +6083,7 @@ extern int k_thread_runtime_stats_disable(k_tid_t thread);
  * it does not affect the gathering of similar statistics for individual
  * threads.
  */
-extern void k_sys_runtime_stats_enable(void);
+void k_sys_runtime_stats_enable(void);
 
 /**
  * @brief Disable gathering of system runtime statistics
@@ -6092,7 +6092,7 @@ extern void k_sys_runtime_stats_enable(void);
  * it does not affect the gathering of similar statistics for individual
  * threads.
  */
-extern void k_sys_runtime_stats_disable(void);
+void k_sys_runtime_stats_disable(void);
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/kernel_structs.h
+++ b/include/zephyr/kernel_structs.h
@@ -232,7 +232,7 @@ typedef struct {
 	struct _priq_rb waitq;
 } _wait_q_t;
 
-extern bool z_priq_rb_lessthan(struct rbnode *a, struct rbnode *b);
+bool z_priq_rb_lessthan(struct rbnode *a, struct rbnode *b);
 
 #define Z_WAIT_Q_INIT(wait_q) { { { .lessthan_fn = z_priq_rb_lessthan } } }
 

--- a/include/zephyr/kernel_version.h
+++ b/include/zephyr/kernel_version.h
@@ -44,7 +44,7 @@ extern "C" {
  *
  * @return kernel version
  */
-extern uint32_t sys_kernel_version_get(void);
+uint32_t sys_kernel_version_get(void);
 
 /**
  * @}

--- a/include/zephyr/posix/dirent.h
+++ b/include/zephyr/posix/dirent.h
@@ -24,9 +24,9 @@ struct dirent {
 };
 
 /* Directory related operations */
-extern DIR *opendir(const char *dirname);
-extern int closedir(DIR *dirp);
-extern struct dirent *readdir(DIR *dirp);
+DIR *opendir(const char *dirname);
+int closedir(DIR *dirp);
+struct dirent *readdir(DIR *dirp);
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/posix/unistd.h
+++ b/include/zephyr/posix/unistd.h
@@ -23,16 +23,16 @@ extern "C" {
 
 #ifdef CONFIG_POSIX_API
 /* File related operations */
-extern int close(int file);
-extern ssize_t write(int file, const void *buffer, size_t count);
-extern ssize_t read(int file, void *buffer, size_t count);
-extern off_t lseek(int file, off_t offset, int whence);
+int close(int file);
+ssize_t write(int file, const void *buffer, size_t count);
+ssize_t read(int file, void *buffer, size_t count);
+off_t lseek(int file, off_t offset, int whence);
 
 /* File System related operations */
-extern int rename(const char *old, const char *newp);
-extern int unlink(const char *path);
-extern int stat(const char *path, struct stat *buf);
-extern int mkdir(const char *path, mode_t mode);
+int rename(const char *old, const char *newp);
+int unlink(const char *path);
+int stat(const char *path, struct stat *buf);
+int mkdir(const char *path, mode_t mode);
 
 FUNC_NORETURN void _exit(int status);
 

--- a/include/zephyr/sw_isr_table.h
+++ b/include/zephyr/sw_isr_table.h
@@ -23,10 +23,10 @@ extern "C" {
 #endif
 
 /* Default vector for the IRQ vector table */
-extern void _isr_wrapper(void);
+void _isr_wrapper(void);
 
 /* Spurious interrupt handler. Throws an error if called */
-extern void z_irq_spurious(const void *unused);
+void z_irq_spurious(const void *unused);
 
 /*
  * Note the order: arg first, then ISR. This allows a table entry to be

--- a/include/zephyr/sys/atomic_arch.h
+++ b/include/zephyr/sys/atomic_arch.h
@@ -11,39 +11,39 @@
 
 /* Arch specific atomic primitives */
 
-extern bool atomic_cas(atomic_t *target, atomic_val_t old_value,
+bool atomic_cas(atomic_t *target, atomic_val_t old_value,
 			 atomic_val_t new_value);
 
-extern bool atomic_ptr_cas(atomic_ptr_t *target, void *old_value,
+bool atomic_ptr_cas(atomic_ptr_t *target, void *old_value,
 			      void *new_value);
 
-extern atomic_val_t atomic_add(atomic_t *target, atomic_val_t value);
+atomic_val_t atomic_add(atomic_t *target, atomic_val_t value);
 
-extern atomic_val_t atomic_sub(atomic_t *target, atomic_val_t value);
+atomic_val_t atomic_sub(atomic_t *target, atomic_val_t value);
 
-extern atomic_val_t atomic_inc(atomic_t *target);
+atomic_val_t atomic_inc(atomic_t *target);
 
-extern atomic_val_t atomic_dec(atomic_t *target);
+atomic_val_t atomic_dec(atomic_t *target);
 
-extern atomic_val_t atomic_get(const atomic_t *target);
+atomic_val_t atomic_get(const atomic_t *target);
 
-extern void *atomic_ptr_get(const atomic_ptr_t *target);
+void *atomic_ptr_get(const atomic_ptr_t *target);
 
-extern atomic_val_t atomic_set(atomic_t *target, atomic_val_t value);
+atomic_val_t atomic_set(atomic_t *target, atomic_val_t value);
 
-extern void *atomic_ptr_set(atomic_ptr_t *target, void *value);
+void *atomic_ptr_set(atomic_ptr_t *target, void *value);
 
-extern atomic_val_t atomic_clear(atomic_t *target);
+atomic_val_t atomic_clear(atomic_t *target);
 
-extern void *atomic_ptr_clear(atomic_ptr_t *target);
+void *atomic_ptr_clear(atomic_ptr_t *target);
 
-extern atomic_val_t atomic_or(atomic_t *target, atomic_val_t value);
+atomic_val_t atomic_or(atomic_t *target, atomic_val_t value);
 
-extern atomic_val_t atomic_xor(atomic_t *target, atomic_val_t value);
+atomic_val_t atomic_xor(atomic_t *target, atomic_val_t value);
 
-extern atomic_val_t atomic_and(atomic_t *target, atomic_val_t value);
+atomic_val_t atomic_and(atomic_t *target, atomic_val_t value);
 
-extern atomic_val_t atomic_nand(atomic_t *target, atomic_val_t value);
+atomic_val_t atomic_nand(atomic_t *target, atomic_val_t value);
 
 
 #endif /* ZEPHYR_INCLUDE_SYS_ATOMIC_ARCH_H_ */

--- a/include/zephyr/sys/atomic_c.h
+++ b/include/zephyr/sys/atomic_c.h
@@ -39,9 +39,9 @@ static inline atomic_val_t atomic_dec(atomic_t *target)
 
 }
 
-extern atomic_val_t atomic_get(const atomic_t *target);
+atomic_val_t atomic_get(const atomic_t *target);
 
-extern atomic_ptr_val_t atomic_ptr_get(const atomic_ptr_t *target);
+atomic_ptr_val_t atomic_ptr_get(const atomic_ptr_t *target);
 
 __syscall atomic_val_t atomic_set(atomic_t *target, atomic_val_t value);
 

--- a/include/zephyr/sys/printk.h
+++ b/include/zephyr/sys/printk.h
@@ -44,8 +44,8 @@ extern "C" {
  */
 #ifdef CONFIG_PRINTK
 
-extern __printf_like(1, 2) void printk(const char *fmt, ...);
-extern __printf_like(1, 0) void vprintk(const char *fmt, va_list ap);
+__printf_like(1, 2) void printk(const char *fmt, ...);
+__printf_like(1, 0) void vprintk(const char *fmt, va_list ap);
 
 #else
 static inline __printf_like(1, 2) void printk(const char *fmt, ...)
@@ -69,9 +69,9 @@ static inline __printf_like(1, 0) void vprintk(const char *fmt, va_list ap)
 
 #else
 
-extern __printf_like(3, 4) int snprintk(char *str, size_t size,
+__printf_like(3, 4) int snprintk(char *str, size_t size,
 					const char *fmt, ...);
-extern __printf_like(3, 0) int vsnprintk(char *str, size_t size,
+__printf_like(3, 0) int vsnprintk(char *str, size_t size,
 					  const char *fmt, va_list ap);
 
 #endif

--- a/include/zephyr/sys/reboot.h
+++ b/include/zephyr/sys/reboot.h
@@ -32,7 +32,7 @@ extern "C" {
  *
  * When successful, this routine does not return.
  */
-extern FUNC_NORETURN void sys_reboot(int type);
+FUNC_NORETURN void sys_reboot(int type);
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/syscall_handler.h
+++ b/include/zephyr/syscall_handler.h
@@ -89,8 +89,8 @@ int z_object_validate(struct z_object *ko, enum k_objects otype,
  * @param ko If retval=-EPERM, struct z_object * that was looked up, or NULL
  * @param otype Expected type of the kernel object
  */
-extern void z_dump_object_error(int retval, const void *obj,
-				struct z_object *ko, enum k_objects otype);
+void z_dump_object_error(int retval, const void *obj,
+			struct z_object *ko, enum k_objects otype);
 
 /**
  * Kernel object validation function
@@ -102,7 +102,7 @@ extern void z_dump_object_error(int retval, const void *obj,
  * @return Kernel object's metadata, or NULL if the parameter wasn't the
  * memory address of a kernel object
  */
-extern struct z_object *z_object_find(const void *obj);
+struct z_object *z_object_find(const void *obj);
 
 typedef void (*_wordlist_cb_func_t)(struct z_object *ko, void *context);
 
@@ -112,7 +112,7 @@ typedef void (*_wordlist_cb_func_t)(struct z_object *ko, void *context);
  * @param func function to run on each struct z_object
  * @param context Context pointer to pass to each invocation
  */
-extern void z_object_wordlist_foreach(_wordlist_cb_func_t func, void *context);
+void z_object_wordlist_foreach(_wordlist_cb_func_t func, void *context);
 
 /**
  * Copy all kernel object permissions from the parent to the child
@@ -120,7 +120,7 @@ extern void z_object_wordlist_foreach(_wordlist_cb_func_t func, void *context);
  * @param parent Parent thread, to get permissions from
  * @param child Child thread, to copy permissions to
  */
-extern void z_thread_perms_inherit(struct k_thread *parent,
+void z_thread_perms_inherit(struct k_thread *parent,
 				  struct k_thread *child);
 
 /**
@@ -129,7 +129,7 @@ extern void z_thread_perms_inherit(struct k_thread *parent,
  * @param ko Kernel object metadata to update
  * @param thread The thread to grant permission
  */
-extern void z_thread_perms_set(struct z_object *ko, struct k_thread *thread);
+void z_thread_perms_set(struct z_object *ko, struct k_thread *thread);
 
 /**
  * Revoke a thread's permission to a kernel object
@@ -137,7 +137,7 @@ extern void z_thread_perms_set(struct z_object *ko, struct k_thread *thread);
  * @param ko Kernel object metadata to update
  * @param thread The thread to grant permission
  */
-extern void z_thread_perms_clear(struct z_object *ko, struct k_thread *thread);
+void z_thread_perms_clear(struct z_object *ko, struct k_thread *thread);
 
 /*
  * Revoke access to all objects for the provided thread
@@ -147,7 +147,7 @@ extern void z_thread_perms_clear(struct z_object *ko, struct k_thread *thread);
  *
  * @param thread Thread object to revoke access
  */
-extern void z_thread_perms_all_clear(struct k_thread *thread);
+void z_thread_perms_all_clear(struct k_thread *thread);
 
 /**
  * Clear initialization state of a kernel object
@@ -222,7 +222,7 @@ static inline size_t z_user_string_nlen(const char *src, size_t maxlen,
  * @return An allocated buffer with the data copied within it, or NULL
  *	if some error condition occurred
  */
-extern void *z_user_alloc_from_copy(const void *src, size_t size);
+void *z_user_alloc_from_copy(const void *src, size_t size);
 
 /**
  * @brief Copy data from user mode
@@ -237,7 +237,7 @@ extern void *z_user_alloc_from_copy(const void *src, size_t size);
  * @retval 0 On success
  * @retval EFAULT On memory access error
  */
-extern int z_user_from_copy(void *dst, const void *src, size_t size);
+int z_user_from_copy(void *dst, const void *src, size_t size);
 
 /**
  * @brief Copy data to user mode
@@ -252,7 +252,7 @@ extern int z_user_from_copy(void *dst, const void *src, size_t size);
  * @retval 0 On success
  * @retval EFAULT On memory access error
  */
-extern int z_user_to_copy(void *dst, const void *src, size_t size);
+int z_user_to_copy(void *dst, const void *src, size_t size);
 
 /**
  * @brief Copy a C string from userspace into a resource pool allocation
@@ -268,7 +268,7 @@ extern int z_user_to_copy(void *dst, const void *src, size_t size);
  * @param maxlen Maximum size of the string including trailing NULL
  * @return The duplicated string, or NULL if an error occurred.
  */
-extern char *z_user_string_alloc_copy(const char *src, size_t maxlen);
+char *z_user_string_alloc_copy(const char *src, size_t maxlen);
 
 /**
  * @brief Copy a C string from userspace into a provided buffer
@@ -286,7 +286,7 @@ extern char *z_user_string_alloc_copy(const char *src, size_t maxlen);
  *	to maxlen
  * @retval EFAULT On memory access error
  */
-extern int z_user_string_copy(char *dst, const char *src, size_t maxlen);
+int z_user_string_copy(char *dst, const char *src, size_t maxlen);
 
 #define Z_OOPS(expr) \
 	do { \


### PR DESCRIPTION
Extern attribute is not needed and it is not consistently used across Zephyr headers.