### PR TITLE
dts: bindings: clock: fixed-factor-clock: Add clock-names

### DIFF
--- a/dts/bindings/clock/fixed-factor-clock.yaml
+++ b/dts/bindings/clock/fixed-factor-clock.yaml
@@ -20,5 +20,9 @@ properties:
     type: phandle-array
     description: input clock source
 
+  clock-names:
+    type: string-array
+    description: name of input clock
+
   "#clock-cells":
     const: 0


### PR DESCRIPTION
Add the `clock-names` property to fixed-factor-clock. It enables `names` property enhancement.