### PR TITLE
drivers: led_strip: ws2812: Remove scratch selection

### DIFF
--- a/drivers/led_strip/Kconfig.ws2812
+++ b/drivers/led_strip/Kconfig.ws2812
@@ -9,7 +9,6 @@
 
 menuconfig WS2812_STRIP
 	bool "WS2812 (and compatible) LED strip driver"
-	select LED_STRIP_RGB_SCRATCH
 	help
 	  Enable LED strip driver for daisy chains of WS2812-ish (or WS2812B,
 	  WS2813, SK6812, Everlight B1414, or compatible) devices.
@@ -39,6 +38,7 @@ config WS2812_STRIP_GPIO
 	# Only an Cortex-M0 inline assembly implementation for the nRF51
 	# is supported currently.
 	depends on SOC_SERIES_NRF51X
+	select LED_STRIP_RGB_SCRATCH
 	help
 	  The GPIO driver does bit-banging with inline assembly,
 	  and is not available on all SoCs.


### PR DESCRIPTION
The WS2812 LED strip driver does not use a scratch byte, therefore free up a byte per pixel which was unused.