### PR TITLE
drivers: i3c: rename dcr i2c mode macro to lvr

### DIFF
--- a/doc/releases/release-notes-3.6.rst
+++ b/doc/releases/release-notes-3.6.rst
@@ -145,6 +145,9 @@ Drivers and Sensors
 
 * I3C
 
+  * The Legacy Virtual Register defines have been renamed from ``I3C_DCR_I2C_*``
+    to ``I3C_LVR_I2C_*``.
+
 * IEEE 802.15.4
 
 * Interrupt Controller

--- a/drivers/i3c/i3c_cdns.c
+++ b/drivers/i3c/i3c_cdns.c
@@ -2300,18 +2300,18 @@ static enum i3c_bus_mode i3c_bus_mode(const struct i3c_dev_list *dev_list)
 	enum i3c_bus_mode mode = I3C_BUS_MODE_PURE;
 
 	for (int i = 0; i < dev_list->num_i2c; i++) {
-		switch (I3C_DCR_I2C_DEV_IDX(dev_list->i2c[i].lvr)) {
-		case I3C_DCR_I2C_DEV_IDX_0:
+		switch (I3C_LVR_I2C_DEV_IDX(dev_list->i2c[i].lvr)) {
+		case I3C_LVR_I2C_DEV_IDX_0:
 			if (mode < I3C_BUS_MODE_MIXED_FAST) {
 				mode = I3C_BUS_MODE_MIXED_FAST;
 			}
 			break;
-		case I3C_DCR_I2C_DEV_IDX_1:
+		case I3C_LVR_I2C_DEV_IDX_1:
 			if (mode < I3C_BUS_MODE_MIXED_LIMITED) {
 				mode = I3C_BUS_MODE_MIXED_LIMITED;
 			}
 			break;
-		case I3C_DCR_I2C_DEV_IDX_2:
+		case I3C_LVR_I2C_DEV_IDX_2:
 			if (mode < I3C_BUS_MODE_MIXED_SLOW) {
 				mode = I3C_BUS_MODE_MIXED_SLOW;
 			}

--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -130,7 +130,7 @@ extern "C" {
 /** @} */
 
 /**
- * @name Device Characteristic Register (DCR)
+ * @name Legacy Virtual Register (LVR)
  *
  * Legacy Virtual Register (LVR)
  * - LVR[7:5]: I2C device index:
@@ -149,26 +149,26 @@ extern "C" {
  */
 
 /** I2C FM+ Mode. */
-#define I3C_DCR_I2C_FM_PLUS_MODE			0
+#define I3C_LVR_I2C_FM_PLUS_MODE			0
 
 /** I2C FM Mode. */
-#define I3C_DCR_I2C_FM_MODE				1
+#define I3C_LVR_I2C_FM_MODE				1
 
 /** I2C Mode Indicator bit shift value. */
-#define I3C_DCR_I2C_MODE_SHIFT				4
+#define I3C_LVR_I2C_MODE_SHIFT				4
 
 /** I2C Mode Indicator bitmask. */
-#define I3C_DCR_I2C_MODE_MASK				BIT(4)
+#define I3C_LVR_I2C_MODE_MASK				BIT(4)
 
 /**
  * @brief I2C Mode
  *
- * Obtain I2C Mode value from the DCR value obtained via GETDCR.
+ * Obtain I2C Mode value from the LVR value.
  *
- * @param dcr DCR value
+ * @param lvr LVR value
  */
-#define I3C_DCR_I2C_MODE(dcr)				\
-	(((mode) & I3C_DCR_I2C_MODE_MASK) >> I3C_DCR_I2C_MODE_SHIFT)
+#define I3C_LVR_I2C_MODE(lvr)				\
+	(((lvr) & I3C_LVR_I2C_MODE_MASK) >> I3C_LVR_I2C_MODE_SHIFT)
 
 /**
  * @brief I2C Device Index 0.
@@ -176,7 +176,7 @@ extern "C" {
  * I2C device has a 50 ns spike filter where it is not affected by high
  * frequency on SCL.
  */
-#define I3C_DCR_I2C_DEV_IDX_0				0
+#define I3C_LVR_I2C_DEV_IDX_0				0
 
 /**
  * @brief I2C Device Index 1.
@@ -184,7 +184,7 @@ extern "C" {
  * I2C device does not have a 50 ns spike filter but can work with high
  * frequency on SCL.
  */
-#define I3C_DCR_I2C_DEV_IDX_1				1
+#define I3C_LVR_I2C_DEV_IDX_1				1
 
 /**
  * @brief I2C Device Index 2.
@@ -192,23 +192,23 @@ extern "C" {
  * I2C device does not have a 50 ns spike filter and cannot work with high
  * frequency on SCL.
  */
-#define I3C_DCR_I2C_DEV_IDX_2				2
+#define I3C_LVR_I2C_DEV_IDX_2				2
 
 /** I2C Device Index bit shift value. */
-#define I3C_DCR_I2C_DEV_IDX_SHIFT			5
+#define I3C_LVR_I2C_DEV_IDX_SHIFT			5
 
 /** I2C Device Index bitmask. */
-#define I3C_DCR_I2C_DEV_IDX_MASK			(0x07U << I3C_DCR_I2C_DEV_IDX_SHIFT)
+#define I3C_LVR_I2C_DEV_IDX_MASK			(0x07U << I3C_LVR_I2C_DEV_IDX_SHIFT)
 
 /**
  * @brief I2C Device Index
  *
- * Obtain I2C Device Index value from the DCR value obtained via GETDCR.
+ * Obtain I2C Device Index value from the LVR value.
  *
- * @param dcr DCR value
+ * @param lvr LVR value
  */
-#define I3C_DCR_I2C_DEV_IDX(dcr)			\
-	(((dcr) & I3C_DCR_I2C_DEV_IDX_MASK) >> I3C_DCR_I2C_DEV_IDX_SHIFT)
+#define I3C_LVR_I2C_DEV_IDX(lvr)			\
+	(((lvr) & I3C_LVR_I2C_DEV_IDX_MASK) >> I3C_LVR_I2C_DEV_IDX_SHIFT)
 
 /** @} */
 


### PR DESCRIPTION
This renames the I2C 'DCR' mode to 'LVR' as that is the variable it
should be looking at and not the dcr value. This also fixes the get
'lvr' mode argument.