### PR TITLE
fs: fat: Explicitly set write flag when writing to a file

### DIFF
--- a/subsys/fs/fat_fs.c
+++ b/subsys/fs/fat_fs.c
@@ -183,6 +183,7 @@ static ssize_t fatfs_read(struct fs_file_t *zfp, void *ptr, size_t size)
 static ssize_t fatfs_write(struct fs_file_t *zfp, const void *ptr, size_t size)
 {
 	int res = -ENOTSUP;
+	FIL *fp = zfp->filep;
 
 #if !defined(CONFIG_FS_FATFS_READ_ONLY)
 	unsigned int bw;
@@ -199,7 +200,9 @@ static ssize_t fatfs_write(struct fs_file_t *zfp, const void *ptr, size_t size)
 	}
 
 	if (res == FR_OK) {
+		fp->flag |= FA_WRITE;
 		res = f_write(zfp->filep, ptr, size, &bw);
+		fp->flag &= ~FA_WRITE;
 	}
 
 	if (res != FR_OK) {


### PR DESCRIPTION
The FA_WRITE flag must be set when calling the underlying FAT implementation during a file write.

When testing a FAT FS implementation on an SPI-connected micro SD card, I observed the following error:

`<err> fs: file write error (-13)`

After digging into the `fs_write` function of the fat_fs module, I noticed the following line:
`if (!(fp->flag & FA_WRITE)) LEAVE_FF(fs, FR_DENIED);    /* Check access mode */`

After adding the FA_WRITE flag in the subsystem implementation, I was able to successfully write to the SD card and read the file on a PC.