### PR TITLE
auxdisplay: Enhance SerLCD auxdisplay driver

### DIFF
--- a/dts/bindings/auxdisplay/sparkfun,serlcd.yaml
+++ b/dts/bindings/auxdisplay/sparkfun,serlcd.yaml
@@ -11,6 +11,8 @@ description: |
         reg = <0x72>;
         columns = <16>;
         rows = <2>;
+        command-delay = <10>;
+        special-command-delay = <50>;
       };
     };
 
@@ -32,3 +34,23 @@ properties:
     enum:
       - 2
       - 4
+
+  command-delay-ms:
+    type: int
+    default: 10
+    description: |
+      Delay in milliseconds (defaults to 10ms if not set) after a normal command was sent.
+      The default value is based on the original SparkFun SerLCD library
+      implementation which assumes 100 kbps I2C configuration. This value
+      might require tweaking if using I2C at a higher bitrare and/or relativily
+      high update frequency of the display.
+
+  special-command-delay-ms:
+    type: int
+    default: 50
+    description: |
+      Delay in milliseconds (defaults to 50ms if not set) after a special command was sent.
+      The default value is based on the original SparkFun SerLCD library
+      implementation which assumes 100 kbps I2C configuration. This value
+      might require tweaking if using I2C at a higher bitrare and/or relativily
+      high update frequency of the display.


### PR DESCRIPTION
Added export of command and special command delays as configurable options.

Based on the excellent work done by @janhenke, I've done some additional testing on a Nordic board (PCA10056 with nRF52840 chipset) and when trying some high intenesity updates to the LCD, it seems the timeouts might require some tweeking (in contrast to implementing a retry logic in the application)

So I've decided to expose those settings a part of the driver configuration (while leaving the inital values in the code as the defaults)