### PR TITLE
soc: intel_adsp: cavs: don't enable interrupt before k_cpu_idle

### DIFF
--- a/soc/xtensa/intel_adsp/cavs/power.c
+++ b/soc/xtensa/intel_adsp/cavs/power.c
@@ -107,7 +107,6 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 			/* do power down - this function won't return */
 			power_down_cavs(true, uncache_to_cache(&hpsram_mask[0]));
 		} else {
-			z_xt_ints_on(core_desc[cpu].intenable);
 			k_cpu_idle();
 		}
 	} else {


### PR DESCRIPTION
Fix a bug on cavs platform that secondary core is not powered off by SET_DX ipc message sometimes. Secondary core is set into idle state when switching to SOF_OFF state and then halted by primary core. The interrupt is enabled before entring idle state, so the secondary core may be woken up by interrupt and soc_cpus_active is set to true before it is halted by hardware power gating. This result to error when SOF check soc_cpus_active after the secondary is halted.



issue related : https://github.com/thesofproject/sof/pull/8240