### PR TITLE
Minor tweaks after logging string removal

### DIFF
--- a/lib/os/Kconfig.cbprintf
+++ b/lib/os/Kconfig.cbprintf
@@ -159,3 +159,11 @@ config CBPRINTF_PACKAGE_SUPPORT_TAGGED_ARGUMENTS
 	  to determine the types of arguments, but instead, each argument is
 	  tagged with a type by preceding it with another argument as type
 	  (integer).
+
+config CBPRINTF_CONVERT_CHECK_PTR
+	bool
+	default y if !LOG_FMT_SECTION_STRIP
+	help
+	  If enabled, cbprintf_package_convert() supports checking if string
+	  candidate is used for %p format specifier. Check cannot be performed
+	  if string is not present in the memory.

--- a/lib/os/cbprintf_packaged.c
+++ b/lib/os/cbprintf_packaged.c
@@ -999,7 +999,8 @@ int cbprintf_package_convert(void *in_packaged,
 			bool is_ro = ptr_in_rodata(str);
 			int len;
 
-			if (fmt_present && is_ptr(fmt, arg_idx)) {
+			if (IS_ENABLED(CONFIG_CBPRINTF_CONVERT_CHECK_PTR) &&
+			    fmt_present && is_ptr(fmt, arg_idx)) {
 				LOG_WRN("(unsigned) char * used for %%p argument. "
 					"It's recommended to cast it to void * because "
 					"it may cause misbehavior in certain "
@@ -1077,7 +1078,8 @@ calculate_string_length:
 		const char *str = *(const char **)&buf32[arg_pos];
 		bool is_ro = ptr_in_rodata(str);
 
-		if (fmt_present && is_ptr(fmt, arg_idx)) {
+		if (IS_ENABLED(CONFIG_CBPRINTF_CONVERT_CHECK_PTR) &&
+		    fmt_present && is_ptr(fmt, arg_idx)) {
 			continue;
 		}
 

--- a/subsys/logging/log_msg.c
+++ b/subsys/logging/log_msg.c
@@ -236,7 +236,8 @@ void z_impl_z_log_msg_static_create(const void *source,
 
 	if (inlen > 0) {
 		uint32_t flags = CBPRINTF_PACKAGE_CONVERT_RW_STR |
-				 CBPRINTF_PACKAGE_CONVERT_PTR_CHECK;
+				 (IS_ENABLED(CONFIG_LOG_FMT_SECTION_STRIP) ?
+				 0 : CBPRINTF_PACKAGE_CONVERT_PTR_CHECK);
 		uint16_t strl[4];
 		int len;
 


### PR DESCRIPTION
Follow up after #64424.

`cbprintf_package_convert()` has a feature to check if `char *` is not used for `%p` and generates warning in that case. This check requires that there is an access to the string content. It's not the case when logging strings are stripped. It's prevented in 2 ways: cbprintf has this feature disabled when strings are stripped (to save space), logging is not setting the flag to perform this check. 