### PR TITLE
ACPI: Fix full initialisation on several platforms

### DIFF
--- a/boards/x86/intel_adl/Kconfig.defconfig
+++ b/boards/x86/intel_adl/Kconfig.defconfig
@@ -36,6 +36,8 @@ config HEAP_MEM_POOL_SIZE
 	default 64000000
 config MAIN_STACK_SIZE
 	default 320000
+config ACPI_PRT_BUS_NAME
+	default "_SB.PC00"
 
 if SHELL
 config SHELL_STACK_SIZE

--- a/boards/x86/intel_ehl/Kconfig.defconfig
+++ b/boards/x86/intel_ehl/Kconfig.defconfig
@@ -20,7 +20,7 @@ config SHELL_BACKEND_SERIAL_INTERRUPT_DRIVEN
 endif
 
 config HEAP_MEM_POOL_SIZE
-	default 32768 if ACPI
+	default 2097152 if ACPI
 	depends on KERNEL_MEM_POOL
 
 # TSC on this board is 1.9 GHz, HPET and APIC are 19.2 MHz

--- a/boards/x86/intel_ehl/Kconfig.defconfig
+++ b/boards/x86/intel_ehl/Kconfig.defconfig
@@ -19,6 +19,10 @@ config SHELL_BACKEND_SERIAL_INTERRUPT_DRIVEN
 	default n
 endif
 
+config ACPI_PRT_BUS_NAME
+	depends on ACPI
+	default "_SB.PC00"
+
 config HEAP_MEM_POOL_SIZE
 	default 2097152 if ACPI
 	depends on KERNEL_MEM_POOL

--- a/boards/x86/intel_rpl/Kconfig.defconfig
+++ b/boards/x86/intel_rpl/Kconfig.defconfig
@@ -29,6 +29,10 @@ endif
 config ACPI
 	default y
 
+config ACPI_PRT_BUS_NAME
+	depends on ACPI
+	default "_SB.PC00"
+
 if DMA
 config DMA_64BIT
 	default y

--- a/boards/x86/qemu_x86/Kconfig.defconfig
+++ b/boards/x86/qemu_x86/Kconfig.defconfig
@@ -25,7 +25,7 @@ config KERNEL_VM_SIZE
 	default 0x10000000 if ACPI
 
 config HEAP_MEM_POOL_SIZE
-	default 32768 if ACPI
+	default 1048576 if ACPI
 	depends on KERNEL_MEM_POOL
 
 config MULTIBOOT
@@ -54,7 +54,7 @@ config KERNEL_VM_SIZE
 	default 0x10000000 if ACPI
 
 config HEAP_MEM_POOL_SIZE
-	default 32768 if ACPI
+	default 1048576 if ACPI
 	depends on KERNEL_MEM_POOL
 
 endif # BOARD_QEMU_X86_64

--- a/boards/x86/up_squared/Kconfig.defconfig
+++ b/boards/x86/up_squared/Kconfig.defconfig
@@ -9,7 +9,7 @@ config MP_MAX_NUM_CPUS
 	default 2 if BOARD_UP_SQUARED
 
 config HEAP_MEM_POOL_SIZE
-	default 32768 if ACPI
+	default 1048576 if ACPI
 	depends on KERNEL_MEM_POOL
 
 config BUILD_OUTPUT_STRIPPED

--- a/lib/acpi/Kconfig
+++ b/lib/acpi/Kconfig
@@ -14,6 +14,12 @@ module = ACPI
 module-str = acpi
 source "subsys/logging/Kconfig.template.log_config"
 
+config ACPI_PRT_BUS_NAME
+	string "ACPI name of PCI bus"
+	default "_SB.PCI0"
+	help
+	  ACPI name of PCI bus.
+
 config ACPI_MAX_PRT_ENTRY
 	int "Size of PRT buffer"
 	default 4096

--- a/lib/acpi/acpi.c
+++ b/lib/acpi/acpi.c
@@ -91,10 +91,10 @@ static ACPI_STATUS initialize_acpica(void)
 		goto exit;
 	}
 
-	/* Initialize the ACPI hardware */
-	status = AcpiEnableSubsystem(ACPI_FULL_INITIALIZATION);
+	/* Create the ACPI namespace from ACPI tables */
+	status = AcpiLoadTables();
 	if (ACPI_FAILURE(status)) {
-		ACPI_EXCEPTION((AE_INFO, status, "While enabling ACPI"));
+		ACPI_EXCEPTION((AE_INFO, status, "While loading ACPI tables"));
 		goto exit;
 	}
 
@@ -105,10 +105,10 @@ static ACPI_STATUS initialize_acpica(void)
 		goto exit;
 	}
 
-	/* Create the ACPI namespace from ACPI tables */
-	status = AcpiLoadTables();
+	/* Initialize the ACPI hardware */
+	status = AcpiEnableSubsystem(ACPI_FULL_INITIALIZATION);
 	if (ACPI_FAILURE(status)) {
-		ACPI_EXCEPTION((AE_INFO, status, "While loading ACPI tables"));
+		ACPI_EXCEPTION((AE_INFO, status, "While enabling ACPI"));
 		goto exit;
 	}
 

--- a/lib/acpi/acpi.c
+++ b/lib/acpi/acpi.c
@@ -239,7 +239,8 @@ static int acpi_get_irq_table(struct acpi *bus, char *bus_name,
 static int acpi_retrieve_legacy_irq(struct acpi *bus)
 {
 	/* TODO: assume platform have only one PCH with single PCI bus (bus 0). */
-	return acpi_get_irq_table(bus, "_SB.PC00", bus->pci_prt_table, sizeof(bus->pci_prt_table));
+	return acpi_get_irq_table(bus, CONFIG_ACPI_PRT_BUS_NAME,
+				  bus->pci_prt_table, sizeof(bus->pci_prt_table));
 }
 
 static ACPI_STATUS dev_resource_enum_callback(ACPI_HANDLE obj_handle, UINT32 level, void *ctx,

--- a/lib/acpi/acpi.c
+++ b/lib/acpi/acpi.c
@@ -52,24 +52,6 @@ static void notify_handler(ACPI_HANDLE device, UINT32 value, void *ctx)
 	ACPI_INFO(("Received a notify 0x%X", value));
 }
 
-static ACPI_STATUS region_handler(UINT32 Function, ACPI_PHYSICAL_ADDRESS address, UINT32 bit_width,
-				  UINT64 *value, void *handler_ctx, void *region_ctx)
-{
-	return AE_OK;
-}
-
-static ACPI_STATUS region_init(ACPI_HANDLE RegionHandle, UINT32 Function, void *handler_ctx,
-			       void **region_ctx)
-{
-	if (Function == ACPI_REGION_DEACTIVATE) {
-		*region_ctx = NULL;
-	} else {
-		*region_ctx = RegionHandle;
-	}
-
-	return AE_OK;
-}
-
 static ACPI_STATUS install_handlers(void)
 {
 	ACPI_STATUS status;
@@ -82,13 +64,7 @@ static ACPI_STATUS install_handlers(void)
 		goto exit;
 	}
 
-	status = AcpiInstallAddressSpaceHandler(ACPI_ROOT_OBJECT, ACPI_ADR_SPACE_SYSTEM_MEMORY,
-						region_handler, region_init, NULL);
-	if (ACPI_FAILURE(status)) {
-		ACPI_EXCEPTION((AE_INFO, status, "While installing an OpRegion handler"));
-	}
 exit:
-
 	return status;
 }
 

--- a/lib/acpi/acpi.c
+++ b/lib/acpi/acpi.c
@@ -215,7 +215,7 @@ static int acpi_get_irq_table(struct acpi *bus, char *bus_name,
 	}
 
 	rt_buffer.Pointer = rt_table;
-	rt_buffer.Length = ACPI_DEBUG_BUFFER_SIZE;
+	rt_buffer.Length = rt_size;
 
 	status = AcpiGetIrqRoutingTable(node, &rt_buffer);
 	if (ACPI_FAILURE(status)) {

--- a/west.yml
+++ b/west.yml
@@ -30,7 +30,7 @@ manifest:
   # Please add items below based on alphabetical order
   projects:
     - name: acpica
-      revision: 0333c2af13179f9b33d495cf7cb9a509f751cbb1
+      revision: 10ae1038e51eb9306f73c3bbcfc4fde954bb9625
       path: modules/lib/acpica
     - name: bsim
       repo-path: babblesim-manifest


### PR DESCRIPTION
Full ACPI init was failing on many platforms. Some of the most critical issues were:

 - Attempt to write read-only memory (fixed by ACPICA module update)
 - Too small k_malloc heap for qemu_x86_64, up_squared and intel_ehl_crb
 - Attempt to register custom ACPICA system memory handler without unregistering default one
 - Incorrect PCI bus ACPI object name for up_squared and qemu_x86_64