### PR TITLE
drivers: ieee802154: nrf: limit number of serialized calls

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.h
+++ b/drivers/ieee802154/ieee802154_nrf5.h
@@ -92,6 +92,14 @@ struct nrf5_802154_data {
 	/* The maximum number of extra CCA attempts to be performed before transmission. */
 	uint8_t max_extra_cca_attempts;
 #endif
+
+#if defined(CONFIG_NRF_802154_SER_HOST) && defined(CONFIG_IEEE802154_CSL_ENDPOINT)
+	/* The last configured value of CSL period in units of 10 symbols. */
+	uint32_t csl_period;
+
+	/* The last configured value of CSL phase time in nanoseconds. */
+	net_time_t csl_rx_time;
+#endif /* CONFIG_NRF_802154_SER_HOST && CONFIG_IEEE802154_CSL_ENDPOINT */
 };
 
 #endif /* ZEPHYR_DRIVERS_IEEE802154_IEEE802154_NRF5_H_ */


### PR DESCRIPTION
For serialized nRF IEEE 802.15.4 Driver host, avoid using `nrf_802154_csl_writer_anchor_time_set` too often by caching the CSL RX time and period and using them to detect any shift on the periodic pattern.

This improves power consumption by limiting the number of serialized calls.