### PR TITLE
github: compliance: fix python cache keys

### DIFF
--- a/.github/workflows/coding_guidelines.yml
+++ b/.github/workflows/coding_guidelines.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-doc-pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('.github/workflows/coding_guidelines.yml') }}
 
     - name: Install python dependencies
       run: |

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-doc-pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('.github/workflows/compliance.yml') }}
 
     - name: Install python dependencies
       run: |


### PR DESCRIPTION
The compliance and coding guidelines workflows are using the same pip cache key, but they install a different set of packages. This is probably a copy paste error from the documentation build workflow, which has been changed to use a hash, and is causing one of the two steps to restore from a incorrect cache.

Fix this by using a hash of the workflow file itself as a key, as that's where the python package list is defined.