### PR TITLE
doc: hardware: peripherals: can: split CAN transceiver from controller

### DIFF
--- a/doc/develop/api/overview.rst
+++ b/doc/develop/api/overview.rst
@@ -61,6 +61,10 @@ between major releases are available in the :ref:`zephyr_release_notes`.
      - Stable
      - 1.14
 
+   * - :ref:`can_transceiver_api`
+     - Experimental
+     - 3.1
+
    * - :ref:`charger_api`
      - Experimental
      - 3.5

--- a/doc/hardware/peripherals/can/controller.rst
+++ b/doc/hardware/peripherals/can/controller.rst
@@ -16,34 +16,12 @@ ISO 11898-1:2003 standard.
 CAN is mostly known for its application in the automotive domain. However, it
 is also used in home and industrial automation and other products.
 
-A CAN transceiver is an external device that converts the logic level signals
-from the CAN controller to the bus-levels. The bus lines are called
-CAN High (CAN H) and CAN Low (CAN L).
-The transmit wire from the controller to the transceiver is called CAN TX,
-and the receive wire is called CAN RX.
-These wires use the logic levels whereas the bus-level is interpreted
-differentially between CAN H and CAN L.
-The bus can be either in the recessive (logical one) or dominant (logical zero)
-state. The recessive state is when both lines, CAN H and CAN L, at roughly at
-the same voltage level. This state is also the idle state.
-To write a dominant bit to the bus, open-drain transistors tie CAN H to Vdd
-and CAN L to ground.
-The first and last node use a 120-ohm resistor between CAN H and CAN L to
-terminate the bus. The dominant state always overrides the recessive state.
-This structure is called a wired-AND.
-
 .. warning::
 
    CAN controllers can only initialize when the bus is in the idle (recessive)
    state for at least 11 recessive bits. Therefore you have to make sure that
    CAN RX is high, at least for a short time. This is also necessary for
    loopback mode.
-
-.. image:: transceiver.svg
-   :width: 70%
-   :align: center
-   :alt: CAN Transceiver
-
 
 The bit-timing as defined in ISO 11898-1:2003 looks as following:
 
@@ -340,9 +318,3 @@ CAN Controller API Reference
 ****************************
 
 .. doxygengroup:: can_interface
-
-
-CAN Transceiver API Reference
-*****************************
-
-.. doxygengroup:: can_transceiver

--- a/doc/hardware/peripherals/can/index.rst
+++ b/doc/hardware/peripherals/can/index.rst
@@ -7,3 +7,4 @@ Controller Area Network (CAN)
    :maxdepth: 2
 
    controller.rst
+   transceiver.rst

--- a/doc/hardware/peripherals/can/transceiver.rst
+++ b/doc/hardware/peripherals/can/transceiver.rst
@@ -1,0 +1,37 @@
+.. _can_transceiver_api:
+
+CAN Transceiver
+###############
+
+.. contents::
+    :local:
+    :depth: 2
+
+Overview
+********
+
+A CAN transceiver is an external device that converts the logic level signals
+from the CAN controller to the bus-levels. The bus lines are called
+CAN High (CAN H) and CAN Low (CAN L).
+The transmit wire from the controller to the transceiver is called CAN TX,
+and the receive wire is called CAN RX.
+These wires use the logic levels whereas the bus-level is interpreted
+differentially between CAN H and CAN L.
+The bus can be either in the recessive (logical one) or dominant (logical zero)
+state. The recessive state is when both lines, CAN H and CAN L, are roughly at
+the same voltage level. This state is also the idle state.
+To write a dominant bit to the bus, open-drain transistors tie CAN H to Vdd
+and CAN L to ground.
+The first and last node use a 120-ohm resistor between CAN H and CAN L to
+terminate the bus. The dominant state always overrides the recessive state.
+This structure is called a wired-AND.
+
+.. image:: transceiver.svg
+   :width: 70%
+   :align: center
+   :alt: CAN Transceiver
+
+CAN Transceiver API Reference
+*****************************
+
+.. doxygengroup:: can_transceiver


### PR DESCRIPTION
Split out the CAN transceiver API documentation from the CAN controller API documentation. The CAN transceiver API was introduced in Zephyr v3.1.0.