### PR TITLE
tests bsim cis: Fix sim_id collision

### DIFF
--- a/tests/bsim/bluetooth/host/iso/cis/tests_scripts/cis.sh
+++ b/tests/bsim/bluetooth/host/iso/cis/tests_scripts/cis.sh
@@ -4,7 +4,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-simulation_id="l2cap_send_on_connect"
+simulation_id="iso_cis"
 verbosity_level=2
 EXECUTE_TIMEOUT=120
 


### PR DESCRIPTION
This test was reusing the sim_id from an l2cap test, which was colliding with the corresponding l2cap test when they were run in parallel.
Fix it.

Fixes #64550

CI failure due to this: https://github.com/zephyrproject-rtos/zephyr/actions/runs/6690298077/job/18175347128?pr=64544#step:12:198