### PR TITLE
sysbuild: use relative path for portable

### DIFF
--- a/scripts/pylib/build_helpers/domains.py
+++ b/scripts/pylib/build_helpers/domains.py
@@ -10,6 +10,7 @@ Domain class.
 
 from dataclasses import dataclass
 
+import os
 import yaml
 import pykwalify.core
 import logging
@@ -58,7 +59,7 @@ logger.addHandler(handler)
 
 class Domains:
 
-    def __init__(self, domains_yaml):
+    def __init__(self, domains_yaml, build_dir=""):
         try:
             data = yaml.safe_load(domains_yaml)
             pykwalify.core.Core(source_data=data,
@@ -66,8 +67,11 @@ class Domains:
         except (yaml.YAMLError, pykwalify.errors.SchemaError):
             logger.critical(f'malformed domains.yaml')
             exit(1)
-
-        self._build_dir = data['build_dir']
+        if build_dir == "":
+            self._build_dir = data['build_dir']
+        else:
+            self._build_dir = build_dir
+        data["build_dir"] = self._build_dir
         self._domains = {
             d['name']: Domain(d['name'], d['build_dir'])
             for d in data['domains']
@@ -90,8 +94,8 @@ class Domains:
         except FileNotFoundError:
             logger.critical(f'domains.yaml file not found: {domains_file}')
             exit(1)
-
-        return Domains(domains_yaml)
+        build_dir = os.path.dirname(domains_file)
+        return Domains(domains_yaml, build_dir)
 
     @staticmethod
     def from_yaml(domains_yaml):

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -275,7 +275,7 @@ class TestInstance:
         if content:
             os.makedirs(subdir, exist_ok=True)
             file = os.path.join(subdir, "testsuite_extra.conf")
-            with open(file, "w") as f:
+            with open(file, "w", encoding='utf-8') as f:
                 f.write(content)
 
         return content

--- a/scripts/tests/build_helpers/test_domains.py
+++ b/scripts/tests/build_helpers/test_domains.py
@@ -77,9 +77,9 @@ flash_order: I don\'t think this is correct
 build_dir: build/dir
 domains:
 - name: a domain
-  build_dir: dir/1
+  build_dir: "build/dir/a domain"
 - name: default_domain
-  build_dir: dir/2
+  build_dir: build/dir/default_domain
 default: default_domain
 flash_order:
 - default_domain
@@ -87,10 +87,10 @@ flash_order:
 """,
         None,
         'build/dir',
-        [('default_domain', 'dir/2'), ('a domain', 'dir/1')],
-        ('default_domain', 'dir/2'),
-        {'a domain': ('a domain', 'dir/1'),
-         'default_domain': ('default_domain', 'dir/2')}
+        [('default_domain', 'build/dir/default_domain'), ('a domain', "build/dir/a domain")],
+        ('default_domain', 'build/dir/default_domain'),
+        {'a domain': ('a domain', "build/dir/a domain"),
+         'default_domain': ('default_domain', 'build/dir/default_domain')}
     ),
 ]
 


### PR DESCRIPTION
in the sysbuild cmake the output domians.yaml is asb path, but if we move the test pacakge to another machine this would be a problem, so change it to rel path.

Also use os.path.join in domains in build_helper.py

- build test:

` ./scripts/twister -p mimxrt1060_evk --prep-artifacts-for-testing --package-artifacts twister_test_only.tar.gz -T tset/boot/test_mcuboot`

- run test:

unzip the twister_test_only.tar.gz
`tar cvf twister_test_only.tar.gz`
run command line:
`${ZEPHYR_BASE}/scripts/twister --device-testing --hardware-map <your local map file> --test-only`



