### PR TITLE
boards: arm: stm32f746 with all mpu regions when testing in userspace

### DIFF
--- a/samples/userspace/shared_mem/boards/nucleo_f746zg.overlay
+++ b/samples/userspace/shared_mem/boards/nucleo_f746zg.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2023 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Disable quadspi MPU region for testing
+ * on this stm32f7 target
+ * else one region is missing among 8 MPU regions
+ */
+
+/delete-node/ &quadspi_memory;

--- a/tests/kernel/mem_protect/userspace/boards/nucleo_f746zg.overlay
+++ b/tests/kernel/mem_protect/userspace/boards/nucleo_f746zg.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2023 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Disable quadspi MPU region for testing
+ * on this stm32f7 target
+ * else one region is missing among 8 MPU regions
+ */
+
+/delete-node/ &quadspi_memory;


### PR DESCRIPTION
Disable the  quadspi mpu region of the nucleo_f746zg when testing the samples/userspace/shared_mem
or tests/kernel/mem_protect/userspace.
Impact on stm32 CI 

The stm32f7 cortex M7 has 8 MPU regions (fixed by MPU HW @0xe000ed90 ) and the one for quadspi
```
	quadspi_memory: memory@90000000 {
		compatible = "zephyr,memory-region", "mmio-sram";
		reg = <0x90000000 DT_SIZE_M(256)>;
		zephyr,memory-region = "QSPI";
		zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_EXTMEM) )>;
	};
```
 prevents the testcase to PASS. 
As example, running the samples/userspace/shared_mem/sample.kernel.memory_protection.shared_mem  on nucleo_f746zg:
```
ENC Thread Created 0x20010c90
E: num_parts of 4 exceeds maximum allowable partitions (3)
ASSERTION FAIL [ret == 0] @ WEST_TOPDIR/zephyr/samples/userspace/shared_mem/src/main.c:144
k_mem_domain_init() on enc_domain failed -22
```


Linked to https://github.com/zephyrproject-rtos/zephyr/pull/57467
