### PR TITLE
[Backport v2.7-branch] drivers: can: mcan: Move RF0L and RF1L to line 1

### DIFF
--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -404,7 +404,8 @@ int can_mcan_init(const struct device *dev, const struct can_mcan_config *cfg,
 #ifdef CONFIG_CAN_STM32FD
 	can->ils = CAN_MCAN_ILS_RXFIFO0 | CAN_MCAN_ILS_RXFIFO1;
 #else
-	can->ils = CAN_MCAN_ILS_RF0N | CAN_MCAN_ILS_RF1N;
+	can->ils = CAN_MCAN_ILS_RF0N | CAN_MCAN_ILS_RF1N |
+		CAN_MCAN_ILS_RF0L | CAN_MCAN_ILS_RF1L;
 #endif
 	can->ile = CAN_MCAN_ILE_EINT0 | CAN_MCAN_ILE_EINT1;
 	/* Interrupt on every TX fifo element*/


### PR DESCRIPTION
Backport 6e789e7492049af5a530302b8d43ac8d60629f84 from #63489.

Fixes: #63544
Fixes: #63626