### PR TITLE
Build fixes for bluetooth samples: unicast audio client/server

### DIFF
--- a/samples/bluetooth/unicast_audio_client/src/main.c
+++ b/samples/bluetooth/unicast_audio_client/src/main.c
@@ -245,17 +245,17 @@ static int init_lc3(void)
 
 	if (freq_hz < 0) {
 		printk("Error: Codec frequency not set, cannot start codec.");
-		return;
+		return -1;
 	}
 
 	if (frame_duration_us < 0) {
 		printk("Error: Frame duration not set, cannot start codec.");
-		return;
+		return -1;
 	}
 
 	if (octets_per_frame < 0) {
 		printk("Error: Octets per frame not set, cannot start codec.");
-		return;
+		return -1;
 	}
 
 	frame_duration_100us = frame_duration_us / 100;
@@ -277,7 +277,9 @@ static int init_lc3(void)
 
 	if (lc3_encoder == NULL) {
 		printk("ERROR: Failed to setup LC3 encoder - wrong parameters?\n");
+		return -1;
 	}
+	return 0;
 }
 
 #else

--- a/samples/bluetooth/unicast_audio_server/src/main.c
+++ b/samples/bluetooth/unicast_audio_server/src/main.c
@@ -372,7 +372,7 @@ static int lc3_enable(struct bt_bap_stream *stream, const uint8_t meta[], size_t
 			return ret;
 		}
 
-		ret = bt_audio_codec_cfg_get_frame_dur(codec_cfg);
+		ret = bt_audio_codec_cfg_get_frame_dur(stream->codec_cfg);
 		if (ret > 0) {
 			frame_duration_us = bt_audio_codec_cfg_frame_dur_to_frame_dur_us(ret);
 		} else {


### PR DESCRIPTION
Fix two build issues in these samples.

    Bluetooth samples: unicast audio server: Fix codec initialization
    
    The lc3_enable code was refering to a variable that does not exist.
    Fix it.
    
    Issue was introduced in 9c47eb924fa.

------

    Bluetooth samples: unicast audio client: Fix build warnings
    
    In 85bb2624bc562becde8b1b6e3b570e2d4b45c7e5
    init_lc3()'s prototype was changed to return an int,
    but the code was not updated to return something !=0
    on all errors, or 0 on success.
    
    Fix it.