### PR TITLE
tests: drivers: flash stm32l4 RDP on internal flash partition

### DIFF
--- a/tests/drivers/flash/stm32/boards/disco_l475_iot1.overlay
+++ b/tests/drivers/flash/stm32/boards/disco_l475_iot1.overlay
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2023 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Do not use the storage-partition of the external qspi-NOR flash */
+/delete-node/ &storage_partition;
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* Reserve 4KiB of flash for storage_partition. */
+		storage_partition: partition@f0000 {
+			label = "storage";
+			reg = <0x000f0000 DT_SIZE_K(4)>;
+		};
+	};
+};


### PR DESCRIPTION
Define the storage_partition in the internal flash instead of the external NOR qspi flash,
so the testcase can PASS on the disco_l4754_iot1 board.
Impact on stm32 CI 

Running the west build -p auto -b disco_l475_iot1 tests/drivers/flash/stm32/
with CONFIG_FLASH_STM32_READOUT_PROTECTION=y
It fails taking the storage_partition of the external qspi NOR

```
Running TESTSUITE flash_stm32
===================================================================
START - test_stm32_readout_protection_disabled

    Assertion failed at WEST_TOPDIR/zephyr/tests/drivers/flash/stm32/src/main.c:174: flash_stm32_tes)
Failed to get RDP status
 FAIL - test_stm32_readout_protection_disabled in 0.017 seconds
===================================================================
TESTSUITE flash_stm32 failed.

------ TESTSUITE SUMMARY START ------

SUITE FAIL -   0.00% [flash_stm32]: pass = 0, fail = 1, skip = 0, total = 1 duration = 0.017 seconds
 - FAIL - [flash_stm32.test_stm32_readout_protection_disabled] duration = 0.017 seconds

------ TESTSUITE SUMMARY END ------
```


The disco_l475_iot1 partitionning is set by the https://github.com/zephyrproject-rtos/zephyr/pull/30864