### PR TITLE
arch: x86: add a sperate timer interface for acpica lib

### DIFF
--- a/include/zephyr/arch/x86/x86_acpi_osal.h
+++ b/include/zephyr/arch/x86/x86_acpi_osal.h
@@ -26,4 +26,10 @@ static inline void *acpi_rsdp_get(void)
 	return bios_acpi_rsdp_get();
 }
 #endif /* CONFIG_X86_EFI */
+
+static inline uint64_t acpi_timer_get(void)
+{
+	return z_tsc_read();
+}
+
 #endif /* ZEPHYR_ARCH_X86_INCLUDE_X86_ACPI_H_ */

--- a/west.yml
+++ b/west.yml
@@ -23,6 +23,8 @@ manifest:
       url-base: https://github.com/zephyrproject-rtos
     - name: babblesim
       url-base: https://github.com/BabbleSim
+    - name: acpi
+      url-base: https://github.com/najumon1980
 
   group-filter: [-babblesim, -optional]
 
@@ -30,7 +32,8 @@ manifest:
   # Please add items below based on alphabetical order
   projects:
     - name: acpica
-      revision: 0333c2af13179f9b33d495cf7cb9a509f751cbb1
+      remote: acpi
+      revision: acpi_timer
       path: modules/lib/acpica
     - name: bsim
       repo-path: babblesim-manifest


### PR DESCRIPTION
add a separate timer interface for acpica lib instead of using system timer which might use HPET and this might cause init priority issue if a driver which need to init before HPET timer instantiate.