### PR TITLE
twister: bugfix: Fix infinite loop in test_plan.py script

### DIFF
--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -284,6 +284,8 @@ class Filters:
                             tests.add(os.path.dirname(yaml))
                         self.resolved_files.append(f)
                         scope_found = True
+                    else:
+                        d = os.path.dirname(d)
                 else:
                     d = os.path.dirname(d)
 


### PR DESCRIPTION
Commit 72f416f382f061199900096f50315608b75aae8b added a horizontal scan for .yaml files when a modification was made in "common" folder. If yamls were found in such way, the loop ended. However, the implementation didn't address what happens if such yamls are not found. This made the script going into an infinite loop. If yamls are not found next to "common", the script should proceed as before, i.e. go to the directory above an start looking there.