### PR TITLE
drivers: dma: mcux_mcux_lpc: support hardware triggering

### DIFF
--- a/drivers/dma/dma_mcux_lpc.c
+++ b/drivers/dma/dma_mcux_lpc.c
@@ -18,6 +18,7 @@
 #include <zephyr/sys/barrier.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/drivers/dma/dma_mcux_lpc.h>
 
 #define DT_DRV_COMPAT nxp_lpc_dma
 
@@ -554,7 +555,30 @@ static int dma_mcux_lpc_configure(const struct device *dev, uint32_t channel,
 		data->descriptors_queued = true;
 	}
 
-	if (is_periph) {
+	if (config->dma_slot) {
+		uint32_t cfg_reg = 0;
+
+		/* User supplied manual trigger configuration */
+		if (config->dma_slot & LPC_DMA_PERIPH_REQ_EN) {
+			cfg_reg |= DMA_CHANNEL_CFG_PERIPHREQEN_MASK;
+		}
+		if (config->dma_slot & LPC_DMA_HWTRIG_EN) {
+			/* Setup hardware trigger */
+			cfg_reg |= DMA_CHANNEL_CFG_HWTRIGEN_MASK;
+			if (config->dma_slot & LPC_DMA_TRIGTYPE_LEVEL) {
+				cfg_reg |= DMA_CHANNEL_CFG_TRIGTYPE_MASK;
+			}
+			if (config->dma_slot & LPC_DMA_TRIGPOL_HIGH_RISING) {
+				cfg_reg |= DMA_CHANNEL_CFG_TRIGPOL_MASK;
+			}
+			if (config->dma_slot & LPC_DMA_TRIGBURST) {
+				cfg_reg |= DMA_CHANNEL_CFG_TRIGBURST_MASK;
+				cfg_reg |= DMA_CHANNEL_CFG_BURSTPOWER(
+					LPC_DMA_GET_BURSTPOWER(config->dma_slot));
+			}
+		}
+		p_handle->base->CHANNEL[p_handle->channel].CFG = cfg_reg;
+	} else if (is_periph) {
 		DMA_EnableChannelPeriphRq(p_handle->base, p_handle->channel);
 	} else {
 		DMA_DisableChannelPeriphRq(p_handle->base, p_handle->channel);

--- a/include/zephyr/drivers/dma/dma_mcux_lpc.h
+++ b/include/zephyr/drivers/dma/dma_mcux_lpc.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_DMA_DMA_MCUX_LPC_H_
+#define ZEPHYR_INCLUDE_DRIVERS_DMA_DMA_MCUX_LPC_H_
+
+/*
+ * LPC DMA engine channel hardware trigger attributes.
+ * These attributes can be set to the "dma_slot" field
+ * in a dma_config structure to configure a channel for
+ * hardware triggering.
+ */
+
+/* Peripheral request enable. When set, the peripheral
+ * request line associated with this channel is used to pace DMA transfers.
+ */
+#define LPC_DMA_PERIPH_REQ_EN BIT(0)
+
+/* Hardware trigger enable. When set, the hardware trigger connected to this
+ * channel via INPUTMUX can be used to trigger a transfer
+ */
+#define LPC_DMA_HWTRIG_EN BIT(1)
+
+/* HW trigger polarity. When this bit is set, the trigger will be active
+ * high or rising edge triggered, based on TRIG_TYPE selection
+ */
+#define LPC_DMA_TRIGPOL_HIGH_RISING BIT(2)
+
+/* HW trigger type. When this bit is set, the trigger will be level triggered.
+ * When it is cleared, the hardware trigger will be edge triggered.
+ */
+#define LPC_DMA_TRIGTYPE_LEVEL BIT(3)
+
+/* HW trigger burst mode. When set, the hardware trigger will cause a burst
+ * transfer to occur, the length of which is determined by BURST_POWER.
+ * When cleared, a single transfer (of the width selected by XFERCFG register)
+ * will occur.
+ */
+#define LPC_DMA_TRIGBURST BIT(4)
+
+/* HW trigger burst power. Note that due to the size limit of the dma_slot
+ * field, the maximum transfer burst possible is 128. The hardware supports
+ * up to 1024 transfers in BURSTPOWER. The value set here will result in
+ * 2^BURSTPOWER transfers occurring. So for BURSTPOWER=3, 8 transfers would
+ * occur.
+ */
+#define LPC_DMA_BURSTPOWER(pwr) (((pwr) & 0x7) << 5)
+
+
+/* Used by driver to extract burstpower setting */
+#define LPC_DMA_GET_BURSTPOWER(slot) (((slot) & 0xE0) >> 5)
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_DMA_DMA_MCUX_LPC_H_ */


### PR DESCRIPTION
The LPC DMA IP offers hardware triggering via a series of SOC-specific signals, often including sources like GPIO pins or hardware timers. Support hardware triggers via the "dma_slot" field of the DMA configuration structure. Currently support is offered for setting the following:
- Trigger polarity
- Trigger level/edge mode
- burst mode
- burst length
- peripheral request