### PR TITLE
scripts: Add test_plan.py to twister_ignore.txt

### DIFF
--- a/scripts/ci/twister_ignore.txt
+++ b/scripts/ci/twister_ignore.txt
@@ -24,6 +24,7 @@ doc/*
 *.md
 # if we change this file or associated script, it should not trigger a full
 # twister.
+scripts/ci/test_plan.py
 scripts/ci/twister_ignore.txt
 scripts/ci/what_changed.py
 scripts/ci/version_mgr.py


### PR DESCRIPTION
There is no point in running full twister scope when test_plan.py script is modified.