### PR TITLE
tests: kernel: fix thread function signatures

### DIFF
--- a/tests/kernel/mem_protect/stackprot/src/main.c
+++ b/tests/kernel/mem_protect/stackprot/src/main.c
@@ -78,8 +78,12 @@ void __attribute__((noinline)) check_input(const char *name, const char *input)
  * and will not set ret to TC_FAIL.
  *
  */
-void alternate_thread(void)
+void alternate_thread(void *p1, void *p2, void *p3)
 {
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
 	TC_PRINT("Starts %s\n", __func__);
 	check_input(__func__,
 		    "Input string is too long and stack overflowed!\n");

--- a/tests/kernel/mutex/sys_mutex/src/main.c
+++ b/tests/kernel/mutex/sys_mutex/src/main.c
@@ -100,8 +100,12 @@ static ZTEST_BMEM SYS_MUTEX_DEFINE(bad_count_mutex);
  *
  */
 
-void thread_05(void)
+void thread_05(void *p1, void *p2, void *p3)
 {
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
 	int rv;
 
 	k_sleep(K_MSEC(3500));
@@ -122,8 +126,12 @@ void thread_05(void)
  *
  */
 
-void thread_06(void)
+void thread_06(void *p1, void *p2, void *p3)
 {
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
 	int rv;
 
 	k_sleep(K_MSEC(3750));
@@ -153,8 +161,12 @@ void thread_06(void)
  *
  */
 
-void thread_07(void)
+void thread_07(void *p1, void *p2, void *p3)
 {
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
 	int rv;
 
 	k_sleep(K_MSEC(2500));
@@ -182,8 +194,12 @@ void thread_07(void)
  *
  */
 
-void thread_08(void)
+void thread_08(void *p1, void *p2, void *p3)
 {
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
 	int rv;
 
 	k_sleep(K_MSEC(1500));
@@ -205,8 +221,12 @@ void thread_08(void)
  *
  */
 
-void thread_09(void)
+void thread_09(void *p1, void *p2, void *p3)
 {
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
 	int rv;
 
 	k_sleep(K_MSEC(500));	/* Allow lower priority thread to run */
@@ -237,8 +257,12 @@ void thread_09(void)
  *
  */
 
-void thread_11(void)
+void thread_11(void *p1, void *p2, void *p3)
 {
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
 	int rv;
 
 	k_sleep(K_MSEC(3500));
@@ -253,7 +277,7 @@ void thread_11(void)
 
 K_THREAD_STACK_DEFINE(thread_12_stack_area, STACKSIZE);
 struct k_thread thread_12_thread_data;
-extern void thread_12(void);
+extern void thread_12(void *p1, void *p2, void *p3);
 
 
 

--- a/tests/kernel/sched/metairq/src/main.c
+++ b/tests/kernel/sched/metairq/src/main.c
@@ -59,8 +59,12 @@ volatile int coop_cnt2;
 #define LOOP_CNT  4 /* Number of times low priority thread waits */
 
 /* Meta-IRQ thread */
-void metairq_thread(void)
+void metairq_thread(void *p1, void *p2, void *p3)
 {
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
 	k_sem_take(&metairq_sem, K_FOREVER);
 
 	printk("metairq start\n");
@@ -82,8 +86,12 @@ void metairq_thread(void)
 }
 
 /* High-priority cooperative thread */
-void coop_thread1(void)
+void coop_thread1(void *p1, void *p2, void *p3)
 {
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
 	int cnt1, cnt2;
 
 	printk("thread1 take sem\n");
@@ -109,8 +117,12 @@ void coop_thread1(void)
 }
 
 /* Low-priority cooperative thread */
-void coop_thread2(void)
+void coop_thread2(void *p1, void *p2, void *p3)
 {
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
 	int cnt1, cnt2;
 
 	printk("thread2 take sem\n");

--- a/tests/kernel/sleep/src/main.c
+++ b/tests/kernel/sleep/src/main.c
@@ -102,10 +102,10 @@ static int sleep_time_valid(uint32_t start, uint32_t end, uint32_t dur)
 
 static void test_thread(void *p1, void *p2, void *p3)
 {
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
 	ARG_UNUSED(p3);
 
-	int arg1 = POINTER_TO_INT(p1);
-	int arg2 = POINTER_TO_INT(p2);
 	uint32_t start_tick;
 	uint32_t end_tick;
 
@@ -177,10 +177,9 @@ static void irq_offload_isr(const void *arg)
 
 static void helper_thread(void *p1, void *p2, void *p3)
 {
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
 	ARG_UNUSED(p3);
-
-	int arg1 = POINTER_TO_INT(p1);
-	int arg2 = POINTER_TO_INT(p2);
 
 	k_sem_take(&helper_thread_sem, K_FOREVER);
 	/* Wake the test thread */

--- a/tests/kernel/smp/src/main.c
+++ b/tests/kernel/smp/src/main.c
@@ -1079,15 +1079,15 @@ static int run_concurrency(void *p1, void *p2, void *p3)
 ZTEST(smp, test_inc_concurrency)
 {
 	/* increasing global var with irq lock */
-	zassert_true(run_concurrency(LOCK_IRQ, inc_global_cnt),
+	zassert_true(run_concurrency(INT_TO_POINTER(LOCK_IRQ), inc_global_cnt, NULL),
 			"total count %d is wrong(i)", global_cnt);
 
 	/* increasing global var with irq lock */
-	zassert_true(run_concurrency(LOCK_SEM, inc_global_cnt),
+	zassert_true(run_concurrency(INT_TO_POINTER(LOCK_SEM), inc_global_cnt, NULL),
 			"total count %d is wrong(s)", global_cnt);
 
 	/* increasing global var with irq lock */
-	zassert_true(run_concurrency(LOCK_MUTEX, inc_global_cnt),
+	zassert_true(run_concurrency(INT_TO_POINTER(LOCK_MUTEX), inc_global_cnt, NULL),
 			"total count %d is wrong(M)", global_cnt);
 }
 


### PR DESCRIPTION
Fix thread function signatures to avoid stack corruption on exit. Fixes #64578