### PR TITLE
settings: file: do not unlink the settings file unnecessarily

### DIFF
--- a/subsys/settings/src/settings_file.c
+++ b/subsys/settings/src/settings_file.c
@@ -351,7 +351,7 @@ static int settings_file_save_and_compress(struct settings_file *cf,
 
 	rc = fs_close(&wf);
 	rc2 = fs_close(&rf);
-	if (rc == 0 && rc2 == 0 && fs_unlink(cf->cf_name) == 0) {
+	if (rc == 0 && rc2 == 0) {
 		if (fs_rename(tmp_file, cf->cf_name)) {
 			return -ENOENT;
 		}


### PR DESCRIPTION
fs_rename can handle the file move atomically without unlinking the file first if the filesystem supports that. This change makes the settings file more power cut resilient so that the whole settings file is not lost with poorly timed power cut.

Fixes #64582