### PR TITLE
boards: efr32bg22_thunderboard: add PWM support

### DIFF
--- a/boards/arm/efr32_thunderboard/doc/brd4184.rst
+++ b/boards/arm/efr32_thunderboard/doc/brd4184.rst
@@ -78,6 +78,8 @@ The efr32bg22_brd4184a/b board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | RADIO     | on-chip    | bluetooth                           |
 +-----------+------------+-------------------------------------+
+| PWM       | on-chip    | pwm                                 |
++-----------+------------+-------------------------------------+
 
 The default configuration can be found in the defconfig files:
 - ``boards/arm/efr32_thunderboard/efr32bg22_brd4184a_defconfig``
@@ -86,11 +88,10 @@ The default configuration can be found in the defconfig files:
 Connections and IOs
 ===================
 
-The EFR32BG SoC has six gpio controllers (PORTA, PORTB, PORTC, PORTD,
-PORTE and PORTF).
+The EFR32BG22 SoC has four gpio controllers (PORTA, PORTB, PORTC, and PORTD).
 
-In the following tables, the column Name contains Pin names. For example, PE2
-means Pin number 2 on PORTE and #27 represents the location bitfield, as used
+In the following tables, the column Name contains Pin names. For example, PA5
+means Pin number 5 on PORTA and #1 represents the location bitfield, as used
 in the board's and microcontroller's datasheets and manuals.
 
 There are two variants of this board, "A" and "B". Please take a look at your PCB,

--- a/boards/arm/efr32_thunderboard/efr32bg22_brd4184.dtsi
+++ b/boards/arm/efr32_thunderboard/efr32bg22_brd4184.dtsi
@@ -10,6 +10,7 @@
 	/* These aliases are provided for compatibility with samples */
 	aliases {
 		led0 = &led0;
+		pwm-led0 = &pwm_led0;
 		sw0 = &button0;
 		spi-flash0 = &mx25r80;
 		spi0 = &usart0;
@@ -21,6 +22,14 @@
 
 	chosen {
 		zephyr,code-partition = &slot0_partition;
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+		status = "okay";
+		pwm_led0: pwm_led0 {
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+		};
 	};
 };
 
@@ -55,4 +64,13 @@
 
 &sw_imu_enable {
 	enable-gpios = <&gpiob GECKO_PIN(4) GPIO_ACTIVE_HIGH>;
+};
+
+&timer0 {
+	status = "okay";
+
+	pwm0: pwm {
+		status = "okay";
+		pin-location = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(4)>;
+	};
 };

--- a/boards/arm/efr32_thunderboard/efr32bg22_brd4184a.yaml
+++ b/boards/arm/efr32_thunderboard/efr32bg22_brd4184a.yaml
@@ -14,6 +14,7 @@ supported:
   - uart
   - i2c
   - spi
+  - pwm
 testing:
   ignore_tags:
     - net

--- a/boards/arm/efr32_thunderboard/efr32bg22_brd4184b.yaml
+++ b/boards/arm/efr32_thunderboard/efr32bg22_brd4184b.yaml
@@ -14,6 +14,7 @@ supported:
   - uart
   - i2c
   - spi
+  - pwm
 testing:
   ignore_tags:
     - net

--- a/dts/arm/silabs/efr32bg2x.dtsi
+++ b/dts/arm/silabs/efr32bg2x.dtsi
@@ -10,6 +10,7 @@
 #include <dt-bindings/i2c/i2c.h>
 #include <dt-bindings/pinctrl/gecko-pinctrl.h>
 #include <dt-bindings/adc/adc.h>
+#include <dt-bindings/pwm/pwm.h>
 
 / {
 	chosen {
@@ -120,6 +121,30 @@
 			clock-frequency = <32768>;
 			prescaler = <1>;
 			status = "disabled";
+		};
+
+		timer0: timer@50048000 {
+			compatible = "silabs,gecko-timers";
+			reg = <0x50048000 0x310C>;
+			status = "disabled";
+
+			pwm {
+				compatible = "silabs,gecko-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+		};
+
+		timer1: timer@5004C000 {
+			compatible = "silabs,gecko-timers";
+			reg = <0x5004C000 0x310C>;
+			status = "disabled";
+
+			pwm {
+				compatible = "silabs,gecko-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
 		};
 
 		trng: trng@4c021000 {

--- a/tests/drivers/pwm/pwm_api/src/test_pwm.c
+++ b/tests/drivers/pwm/pwm_api/src/test_pwm.c
@@ -50,6 +50,9 @@
 #elif DT_HAS_COMPAT_STATUS_OKAY(intel_blinky_pwm)
 #define PWM_DEV_NODE DT_INST(0, intel_blinky_pwm)
 
+#elif DT_HAS_COMPAT_STATUS_OKAY(silabs_gecko_pwm)
+#define PWM_DEV_NODE DT_INST(0, silabs_gecko_pwm)
+
 #else
 #error "Define a PWM device"
 #endif

--- a/tests/drivers/pwm/pwm_api/testcase.yaml
+++ b/tests/drivers/pwm/pwm_api/testcase.yaml
@@ -6,5 +6,5 @@ tests:
       - userspace
     filter: dt_alias_exists("pwm-0") or dt_alias_exists("pwm-1") or dt_alias_exists("pwm-2")
       or dt_alias_exists("pwm-3") or dt_compat_enabled("st,stm32-pwm")
-      or dt_compat_enabled("intel,blinky-pwm")
+      or dt_compat_enabled("intel,blinky-pwm") or dt_compat_enabled("silabs,gecko-pwm")
     depends_on: pwm

--- a/tests/drivers/pwm/pwm_loopback/boards/efr32bg22_brd4184a.overlay
+++ b/tests/drivers/pwm/pwm_loopback/boards/efr32bg22_brd4184a.overlay
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2023 Centro de Inovação EDGE
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	pwm_loopback_0 {
+		compatible = "test-pwm-loopback";
+		pwms = <&pwm0 0 0 PWM_POLARITY_NORMAL>,
+		       <&pwm1 0 0 PWM_POLARITY_NORMAL>;
+	};
+};
+
+&timer1 {
+	status = "okay";
+
+	pwm1: pwm {
+		status = "okay";
+		pin-location = <GECKO_LOCATION(0) GECKO_PORT_B GECKO_PIN(3)>;
+	};
+};

--- a/tests/drivers/pwm/pwm_loopback/boards/efr32bg22_brd4184b.overlay
+++ b/tests/drivers/pwm/pwm_loopback/boards/efr32bg22_brd4184b.overlay
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2023 Centro de Inovação EDGE
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	pwm_loopback_0 {
+		compatible = "test-pwm-loopback";
+		pwms = <&pwm0 0 0 PWM_POLARITY_NORMAL>,
+		       <&pwm1 0 0 PWM_POLARITY_NORMAL>;
+	};
+};
+
+&timer1 {
+	status = "okay";
+
+	pwm1: pwm {
+		status = "okay";
+		pin-location = <GECKO_LOCATION(0) GECKO_PORT_B GECKO_PIN(3)>;
+	};
+};


### PR DESCRIPTION
Add PWM support to the EFR32BG22 SoC. Also include the boards on the PWM tests, and update the documentation on the BG22 boards family.