### PR TITLE
security: Add compiler static analysis support

### DIFF
--- a/cmake/sca/gcc/sca.cmake
+++ b/cmake/sca/gcc/sca.cmake
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (c) 2024 Intel Corporation
+
+list(APPEND TOOLCHAIN_C_FLAGS -fanalyzer)

--- a/doc/develop/sca/gcc.rst
+++ b/doc/develop/sca/gcc.rst
@@ -1,0 +1,18 @@
+.. _gcc:
+
+GCC static analysis support
+###########################
+
+Static analysis was introduced in `GCC <https://gcc.gnu.org/>`__ 10 and it is enabled
+with the option ``-fanalyzer``. This option performs a much more expensive and thorough
+analysis of the code than traditional warnings.
+
+Run GCC static analysis
+***********************
+
+To run GCC static analysis, :ref:`west build <west-building>` should be
+called with a ``-DZEPHYR_SCA_VARIANT=gcc`` parameter, e.g.
+
+.. code-block:: shell
+
+    west build -b qemu_x86 samples/userspace/hello_world_user -- -DZEPHYR_SCA_VARIANT=gcc

--- a/doc/develop/sca/index.rst
+++ b/doc/develop/sca/index.rst
@@ -63,3 +63,4 @@ The following is a list of SCA tools natively supported by Zephyr build system.
 
    codechecker
    sparse
+   gcc


### PR DESCRIPTION
Add a build option to enable GCC builtin static analysis.

To enable it an application has to set
CONFIG_COMPILER_STATIC_ANALYSIS=y

When this option is enabled GCC performs a static analysis and can point problems like:

sample.c
```
+	int *j; +
+	if (j != NULL) {
+		printf("j != NULL\n");
```
output:
```
${ZEPHYR_BASE}/samples/userspace/hello_world_user/src/main.c:30:12: warning: use of uninitialized value 'j' [CWE-457]
[-Wanalyzer-use-of-uninitialized-value]
   30 |         if (j != NULL) {
      |            ^
  'main': events 1-2
    |
    |   25 |         int *j;
    |      |              ^
    |      |              |
    |      |              (1) region created on stack here
    |......
    |   30 |         if (j != NULL) {
    |      |            ~
    |      |            |
    |      |            (2) use of uninitialized value 'j' here
```