### PR TITLE
drivers: wifi: esp32: Fix compilation error

### DIFF
--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -61,7 +61,7 @@ struct esp32_wifi_runtime {
 	uint8_t state;
 };
 
-static void esp_wifi_event_task(void);
+static void esp_wifi_event_task(void *, void *, void *);
 
 K_MSGQ_DEFINE(esp_wifi_msgq, sizeof(system_event_t), 10, 4);
 K_THREAD_STACK_DEFINE(esp_wifi_event_stack, CONFIG_ESP32_WIFI_EVENT_TASK_STACK_SIZE);


### PR DESCRIPTION
Fix compilation error caused be the conflicting function declaration.
Steps to reproduce: `west build -b esp32s3_devkitm samples/net/wifi/ -p`