### PR TITLE
Bluetooth: Host: add unregister connection callback function

### DIFF
--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -1063,6 +1063,14 @@ struct bt_conn_cb {
  */
 void bt_conn_cb_register(struct bt_conn_cb *cb);
 
+/** @brief Unregister connection callbacks.
+ *
+ *  Unregister the state of connections callbacks.
+ *
+ *  @param cb Callback struct. Must point to memory that remains valid.
+ */
+void bt_conn_cb_unregister(struct bt_conn_cb *cb);
+
 /**
  *  @brief Register a callback structure for connection events.
  *

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2338,6 +2338,25 @@ void bt_conn_cb_register(struct bt_conn_cb *cb)
 	callback_list = cb;
 }
 
+void bt_conn_cb_unregister(struct bt_conn_cb *cb)
+{
+	struct bt_conn_cb *previous_callback = callback_list;
+
+	if (callback_list == cb) {
+		callback_list = callback_list->_next;
+		return;
+	}
+
+	while (previous_callback->_next)
+	{
+		if (previous_callback->_next == cb) {
+			previous_callback->_next = previous_callback->_next->_next;
+			return;
+		}
+		previous_callback = previous_callback->_next;
+	}
+}
+
 bool bt_conn_exists_le(uint8_t id, const bt_addr_le_t *peer)
 {
 	struct bt_conn *conn = bt_conn_lookup_addr_le(id, peer);

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -973,6 +973,8 @@ static void bt_ready(int err)
 #if defined(CONFIG_BT_CONN)
 	default_conn = NULL;
 
+	/* Unregister to avoid register repeatedly */
+	bt_conn_cb_unregister(&conn_callbacks);
 	bt_conn_cb_register(&conn_callbacks);
 #endif /* CONFIG_BT_CONN */
 


### PR DESCRIPTION
[Description]
tests: shell: Restart bt will register the same connection callback twice. Callback next node point to itself, when connection created callback infinite looping. 
[Fix]
Unregister the previous callback to avoid register repeatedly. 
[Test]
After bt init / bt disable more than once, create connection successfully.