### PR TITLE
drivers: pinctrl_nrf: Fix pin drive configuration

### DIFF
--- a/include/zephyr/dt-bindings/pinctrl/nrf-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/nrf-pinctrl.h
@@ -131,7 +131,6 @@
 
 /**
  * @name nRF pinctrl output drive.
- * @note Values match nrf_gpio_pin_drive_t constants.
  * @{
  */
 
@@ -152,7 +151,7 @@
 /** High drive '0', disconnect '1'. */
 #define NRF_DRIVE_H0D1 7U
 /** Extra high drive '0', extra high drive '1'. */
-#define NRF_DRIVE_E0E1 11U
+#define NRF_DRIVE_E0E1 8U
 
 /** @} */
 


### PR DESCRIPTION
With the introduction of nrfx 3.0.0, values of `nrf_gpio_pin_drive_t` constants may be defined differently, depending on the SoC family. Since the nrf-pinctrl.h file is included also from dts files, it is not possible to use there different definitions of `NRF_GPIO_PIN_*` values based on Kconfig symbols that indicate given SoC family (as Kconfig is processed after devicetree) so that those values could still match `nrf_gpio_pin_drive_t` constants.
To solve this problem, the pinctrl_nrf driver now uses a lookup table for mapping `NRF_GPIO_PIN_*` indexes to drive configuration values required by the GPIO HAL.