### PR TITLE
ITE: drivers/i2c: Add I2C channel swapping option

### DIFF
--- a/drivers/i2c/Kconfig.it8xxx2
+++ b/drivers/i2c/Kconfig.it8xxx2
@@ -24,6 +24,13 @@ config I2C_IT8XXX2_FIFO_MODE
 	  I2C FIFO mode of it8xxx2 can support I2C APIs including:
 	  i2c_write(), i2c_read(), i2c_burst_read.
 
+config I2C_IT8XXX2_SWAP_CHA_CHC
+	bool "IT8XXX2 I2C channel swap"
+	help
+	  This is an option to swap channel as described below.
+	  Channel C is located at SMCLK0/SMDAT0.
+	  Channel A is located at SMCLK2/SMDAT2.
+
 endif # I2C_ITE_IT8XXX2
 
 config I2C_ITE_ENHANCE

--- a/drivers/i2c/i2c_ite_it8xxx2.c
+++ b/drivers/i2c/i2c_ite_it8xxx2.c
@@ -1133,7 +1133,12 @@ static int i2c_it8xxx2_init(const struct device *dev)
 		*reg_mstfctrl = IT8XXX2_SMB_FFCHSEL2_C;
 	}
 #endif
-
+#ifdef CONFIG_I2C_IT8XXX2_SWAP_CHA_CHC
+	/* Channel C is located at SMCLK0/SMDAT0. */
+	IT8XXX2_SMB_SMB01CHS = IT8XXX2_SMB_CHB_SMB1 | IT8XXX2_SMB_CHC_SMB0;
+	/* Channel A is located at SMCLK2/SMDAT2. */
+	IT8XXX2_SMB_SMB23CHS = IT8XXX2_SMB_CHD_SMB3;
+#endif
 	/* Set clock frequency for I2C ports */
 	if (config->bitrate == I2C_BITRATE_STANDARD ||
 		config->bitrate == I2C_BITRATE_FAST ||

--- a/soc/riscv/riscv-ite/common/chip_chipregs.h
+++ b/soc/riscv/riscv-ite/common/chip_chipregs.h
@@ -1203,11 +1203,11 @@ enum chip_pll_mode {
 #define IT8XXX2_SMB_MSTFSTS1        ECREG(IT8XXX2_SMB_BASE + 0x0E)
 #define IT8XXX2_SMB_MSTFCTRL2       ECREG(IT8XXX2_SMB_BASE + 0x0F)
 #define IT8XXX2_SMB_MSTFSTS2        ECREG(IT8XXX2_SMB_BASE + 0x10)
-#define IT8XXX2_SMB_CHSEF           ECREG(IT8XXX2_SMB_BASE + 0x11)
+#define IT8XXX2_SMB_SMB45CHS        ECREG(IT8XXX2_SMB_BASE + 0x11)
 #define IT8XXX2_SMB_I2CW2RF         ECREG(IT8XXX2_SMB_BASE + 0x12)
 #define IT8XXX2_SMB_IWRFISTA        ECREG(IT8XXX2_SMB_BASE + 0x13)
-#define IT8XXX2_SMB_CHSAB           ECREG(IT8XXX2_SMB_BASE + 0x20)
-#define IT8XXX2_SMB_CHSCD           ECREG(IT8XXX2_SMB_BASE + 0x21)
+#define IT8XXX2_SMB_SMB01CHS        ECREG(IT8XXX2_SMB_BASE + 0x20)
+#define IT8XXX2_SMB_SMB23CHS        ECREG(IT8XXX2_SMB_BASE + 0x21)
 #define IT8XXX2_SMB_SFFCTL          ECREG(IT8XXX2_SMB_BASE + 0x55)
 #define IT8XXX2_SMB_HOSTA(base)     ECREG(base + 0x00)
 #define IT8XXX2_SMB_HOCTL(base)     ECREG(base + 0x01)
@@ -1301,6 +1301,12 @@ enum chip_pll_mode {
 /* 0x13: I2C Wr To Rd FIFO Interrupt Status */
 #define IT8XXX2_SMB_MCIFID            BIT(2)
 #define IT8XXX2_SMB_MAIFID            BIT(0)
+/* 0x20: SMB0/1 Channel Select */
+#define IT8XXX2_SMB_CHB_SMB1          BIT(4)
+#define IT8XXX2_SMB_CHC_SMB0          BIT(1)
+/* 0x21: SMB2/3 Channel Select */
+#define IT8XXX2_SMB_CHD_SMB3          GENMASK(5, 4)
+#define IT8XXX2_SMB_CHA_SMB2          GENMASK(2, 0)
 /* 0x41 0x81 0xC1: Host Control */
 #define IT8XXX2_SMB_SRT               BIT(6)
 #define IT8XXX2_SMB_LABY              BIT(5)


### PR DESCRIPTION
Since using FIFO mode with channel C would cause issue, channel C is currently unable to utilize FIFO mode. Sometimes, the device connected to channel C requires faster transmission. Add this option to allow channel C(A) to be located at SMCLK0/SMDAT0(SMCLK2/SMDAT2).