### PR TITLE
drivers: dai: intel: ssp: RX FIFO drain rework and DMA request management changes (take 2)

### DIFF
--- a/drivers/dai/intel/ssp/ssp.c
+++ b/drivers/dai/intel/ssp/ssp.c
@@ -1759,15 +1759,25 @@ static void dai_ssp_set_reg_config(struct dai_intel_ssp *dp, const struct dai_co
 				   const struct dai_intel_ipc4_ssp_config *regs)
 {
 	struct dai_intel_ssp_pdata *ssp = dai_get_drvdata(dp);
-	uint32_t ssc0, sstsa, ssrsa;
+	uint32_t ssc0, sstsa, ssrsa, sscr1;
 
 	ssc0 = regs->ssc0;
-	sstsa = regs->sstsa;
-	ssrsa = regs->ssrsa;
+	sstsa = SSTSA_GET(regs->sstsa);
+	ssrsa = SSRSA_GET(regs->ssrsa);
+	sscr1 = regs->ssc1 & ~(SSCR1_RSRE | SSCR1_TSRE);
+
+	if (regs->sstsa & SSTSA_TXEN || regs->ssrsa & SSRSA_RXEN ||
+	    regs->ssc1 & (SSCR1_RSRE | SSCR1_TSRE)) {
+		LOG_INF("%s: Ignoring %s%s%s%sfrom blob", __func__,
+			regs->sstsa & SSTSA_TXEN ? "SSTSA:TXEN " : "",
+			regs->ssrsa & SSRSA_RXEN ? "SSRSA:RXEN " : "",
+			regs->ssc1 & SSCR1_TSRE ? "SSCR1:TSRE " : "",
+			regs->ssc1 & SSCR1_RSRE ? "SSCR1:RSRE " : "");
+	}
 
 	sys_write32(ssc0, dai_base(dp) + SSCR0);
 	sys_write32(regs->ssc2 & ~SSCR2_SFRMEN, dai_base(dp) + SSCR2); /* hardware specific flow */
-	sys_write32(regs->ssc1, dai_base(dp) + SSCR1);
+	sys_write32(sscr1, dai_base(dp) + SSCR1);
 	sys_write32(regs->ssc2 | SSCR2_SFRMEN, dai_base(dp) + SSCR2); /* hardware specific flow */
 	sys_write32(regs->ssc2, dai_base(dp) + SSCR2);
 	sys_write32(regs->ssc3, dai_base(dp) + SSCR3);
@@ -1779,7 +1789,7 @@ static void dai_ssp_set_reg_config(struct dai_intel_ssp *dp, const struct dai_co
 	sys_write32(ssrsa, dai_base(dp) + SSRSA);
 
 	LOG_INF("%s sscr0 = 0x%08x, sscr1 = 0x%08x, ssto = 0x%08x, sspsp = 0x%0x", __func__,
-		ssc0, regs->ssc1, regs->sscto, regs->sspsp);
+		ssc0, sscr1, regs->sscto, regs->sspsp);
 	LOG_INF("%s sscr2 = 0x%08x, sspsp2 = 0x%08x, sscr3 = 0x%08x", __func__,
 		regs->ssc2, regs->sspsp2, regs->ssc3);
 	LOG_INF("%s ssioc = 0x%08x, ssrsa = 0x%08x, sstsa = 0x%08x", __func__,

--- a/drivers/dai/intel/ssp/ssp.h
+++ b/drivers/dai/intel/ssp/ssp.h
@@ -29,7 +29,7 @@
 #define DAI_INTEL_SSP_DEFAULT_IDX		1
 
 /* the SSP port fifo depth */
-#define DAI_INTEL_SSP_FIFO_DEPTH		16
+#define DAI_INTEL_SSP_FIFO_DEPTH		32
 
 /* the watermark for the SSP fifo depth setting */
 #define DAI_INTEL_SSP_FIFO_WATERMARK		8


### PR DESCRIPTION
Hi,

#62596 caused regression in internal CI test and got reverted, however the RX FIFO rework is needed for error free operation.
The root cause of the failure has been identified and fixed by a new patch (the first one in the PR):
The generated blob that is used by the internal CI had the RX/TX enable bits set along with the RX/TX DMA request enable bits. This is not correct and it will be fixed in the blob but the driver should be able to handle such cases by ignoring these enable bits from the blob.
The SSP driver manages both the RX/TX enable and DMA request bits itself.

The other new patch in the series is the change on how the DMA request is managed. There is no reason to enable both at the same time since if we have only TX then why would we have the RX DMA request enabled?
The DMA request has nothing to do with clock generation either.

This also makes the code a bit easier to follow because we don't have the DMA request toggling scattered around.

The PR is passing now both SOF CI and Internal CI (5 test runs has been done to make sure that we will not end up reverting again).