### PR TITLE
linker: Fix missing DEVNULL_REGION for XIP configuration

### DIFF
--- a/include/zephyr/linker/linker-devnull.h
+++ b/include/zephyr/linker/linker-devnull.h
@@ -65,13 +65,9 @@
 #error "Cannot place devnull segment adjacent to ROM region."
 #endif
 
-#if defined(CONFIG_LINKER_DEVNULL_MEMORY)
-#define DEVNULL_REGION DEVNULL_ROM
-#else
-#define DEVNULL_REGION ROMABLE_REGION
-#endif
-
 #endif /* CONFIG_XIP */
+
+#define DEVNULL_REGION DEVNULL_ROM
 
 #endif /* CONFIG_LINKER_DEVNULL_MEMORY */
 


### PR DESCRIPTION
DEVNULL_REGION was created only for !CONFIG_XIP. Moved definition outside of that #ifdef.
Removed condition which was repeated as it is present at the beginning of the file.

Fixes #64596.