### PR TITLE
drivers: ieee802154: nrf: handle tx metadata

### DIFF
--- a/doc/releases/release-notes-3.6.rst
+++ b/doc/releases/release-notes-3.6.rst
@@ -147,6 +147,8 @@ Drivers and Sensors
 
 * IEEE 802.15.4
 
+  * Removed :kconfig:option:`CONFIG_IEEE802154_SELECTIVE_TXPOWER` Kconfig option.
+
 * Interrupt Controller
 
 * Input

--- a/drivers/ieee802154/Kconfig
+++ b/drivers/ieee802154/Kconfig
@@ -98,11 +98,6 @@ config IEEE802154_CSL_DEBUG
 	help
 	  Enable support for CSL debugging by avoiding sleep state in favor of receive state.
 
-config IEEE802154_SELECTIVE_TXPOWER
-	bool "Support selective TX power setting"
-	help
-	  Enable support for selectively setting TX power for every transmission request.
-
 module = IEEE802154_DRIVER
 module-str = IEEE 802.15.4 driver
 module-help = Sets log level for IEEE 802.15.4 Device Drivers.

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -241,6 +241,8 @@ static int nrf5_cca(const struct device *dev)
 {
 	struct nrf5_802154_data *nrf5_radio = NRF5_802154_DATA(dev);
 
+	nrf_802154_channel_set(nrf5_data.channel);
+
 	if (!nrf_802154_cca()) {
 		LOG_DBG("CCA failed");
 		return -EBUSY;
@@ -266,7 +268,7 @@ static int nrf5_set_channel(const struct device *dev, uint16_t channel)
 		return channel < 11 ? -ENOTSUP : -EINVAL;
 	}
 
-	nrf_802154_channel_set(channel);
+	nrf5_data.channel = channel;
 
 	return 0;
 }
@@ -278,6 +280,8 @@ static int nrf5_energy_scan_start(const struct device *dev,
 	int err = 0;
 
 	ARG_UNUSED(dev);
+
+	nrf_802154_channel_set(nrf5_data.channel);
 
 	if (nrf5_data.energy_scan_done == NULL) {
 		nrf5_data.energy_scan_done = done_cb;
@@ -444,6 +448,10 @@ static bool nrf5_tx_immediate(struct net_pkt *pkt, uint8_t *payload, bool cca)
 			.use_metadata_value = true,
 			.power = nrf5_data.txpwr,
 		},
+		.tx_channel = {
+			.use_metadata_value = true,
+			.channel = nrf5_data.channel,
+		},
 	};
 
 	return nrf_802154_transmit_raw(payload, &metadata);
@@ -460,6 +468,10 @@ static bool nrf5_tx_csma_ca(struct net_pkt *pkt, uint8_t *payload)
 		.tx_power = {
 			.use_metadata_value = true,
 			.power = nrf5_data.txpwr,
+		},
+		.tx_channel = {
+			.use_metadata_value = true,
+			.channel = nrf5_data.channel,
 		},
 	};
 
@@ -500,7 +512,7 @@ static bool nrf5_tx_at(struct nrf5_802154_data *nrf5_radio, struct net_pkt *pkt,
 			.dynamic_data_is_set = net_pkt_ieee802154_mac_hdr_rdy(pkt),
 		},
 		.cca = cca,
-		.channel = nrf_802154_channel_get(),
+		.channel = nrf5_data.channel,
 		.tx_power = {
 			.use_metadata_value = true,
 			.power = nrf5_data.txpwr,
@@ -642,6 +654,7 @@ static int nrf5_start(const struct device *dev)
 	ARG_UNUSED(dev);
 
 	nrf_802154_tx_power_set(nrf5_data.txpwr);
+	nrf_802154_channel_set(nrf5_data.channel);
 
 	if (!nrf_802154_receive()) {
 		LOG_ERR("Failed to enter receive state");
@@ -685,6 +698,7 @@ static int nrf5_continuous_carrier(const struct device *dev)
 	ARG_UNUSED(dev);
 
 	nrf_802154_tx_power_set(nrf5_data.txpwr);
+	nrf_802154_channel_set(nrf5_data.channel);
 
 	if (!nrf_802154_continuous_carrier()) {
 		LOG_ERR("Failed to enter continuous carrier state");

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -362,7 +362,7 @@ static int nrf5_set_txpower(const struct device *dev, int16_t dbm)
 
 	LOG_DBG("%d", dbm);
 
-	nrf_802154_tx_power_set(dbm);
+	nrf5_data.txpwr = dbm;
 
 	return 0;
 }
@@ -441,10 +441,8 @@ static bool nrf5_tx_immediate(struct net_pkt *pkt, uint8_t *payload, bool cca)
 		},
 		.cca = cca,
 		.tx_power = {
-			.use_metadata_value = IS_ENABLED(CONFIG_IEEE802154_SELECTIVE_TXPOWER),
-#if defined(CONFIG_IEEE802154_SELECTIVE_TXPOWER)
-			.power = net_pkt_ieee802154_txpwr(pkt),
-#endif
+			.use_metadata_value = true,
+			.power = nrf5_data.txpwr,
 		},
 	};
 
@@ -460,10 +458,8 @@ static bool nrf5_tx_csma_ca(struct net_pkt *pkt, uint8_t *payload)
 			.dynamic_data_is_set = net_pkt_ieee802154_mac_hdr_rdy(pkt),
 		},
 		.tx_power = {
-			.use_metadata_value = IS_ENABLED(CONFIG_IEEE802154_SELECTIVE_TXPOWER),
-#if defined(CONFIG_IEEE802154_SELECTIVE_TXPOWER)
-			.power = net_pkt_ieee802154_txpwr(pkt),
-#endif
+			.use_metadata_value = true,
+			.power = nrf5_data.txpwr,
 		},
 	};
 
@@ -506,10 +502,8 @@ static bool nrf5_tx_at(struct nrf5_802154_data *nrf5_radio, struct net_pkt *pkt,
 		.cca = cca,
 		.channel = nrf_802154_channel_get(),
 		.tx_power = {
-			.use_metadata_value = IS_ENABLED(CONFIG_IEEE802154_SELECTIVE_TXPOWER),
-#if defined(CONFIG_IEEE802154_SELECTIVE_TXPOWER)
-			.power = net_pkt_ieee802154_txpwr(pkt),
-#endif
+			.use_metadata_value = true,
+			.power = nrf5_data.txpwr,
 		},
 #if defined(CONFIG_IEEE802154_NRF5_MULTIPLE_CCA)
 		.extra_cca_attempts = max_extra_cca_attempts,
@@ -647,6 +641,8 @@ static int nrf5_start(const struct device *dev)
 {
 	ARG_UNUSED(dev);
 
+	nrf_802154_tx_power_set(nrf5_data.txpwr);
+
 	if (!nrf_802154_receive()) {
 		LOG_ERR("Failed to enter receive state");
 		return -EIO;
@@ -687,6 +683,8 @@ static int nrf5_stop(const struct device *dev)
 static int nrf5_continuous_carrier(const struct device *dev)
 {
 	ARG_UNUSED(dev);
+
+	nrf_802154_tx_power_set(nrf5_data.txpwr);
 
 	if (!nrf_802154_continuous_carrier()) {
 		LOG_ERR("Failed to enter continuous carrier state");

--- a/drivers/ieee802154/ieee802154_nrf5.h
+++ b/drivers/ieee802154/ieee802154_nrf5.h
@@ -92,6 +92,9 @@ struct nrf5_802154_data {
 	/* The maximum number of extra CCA attempts to be performed before transmission. */
 	uint8_t max_extra_cca_attempts;
 #endif
+
+	/* The TX power in dBm. */
+	int8_t txpwr;
 };
 
 #endif /* ZEPHYR_DRIVERS_IEEE802154_IEEE802154_NRF5_H_ */

--- a/drivers/ieee802154/ieee802154_nrf5.h
+++ b/drivers/ieee802154/ieee802154_nrf5.h
@@ -95,6 +95,9 @@ struct nrf5_802154_data {
 
 	/* The TX power in dBm. */
 	int8_t txpwr;
+
+	/* The radio channel. */
+	uint8_t channel;
 };
 
 #endif /* ZEPHYR_DRIVERS_IEEE802154_IEEE802154_NRF5_H_ */

--- a/include/zephyr/net/ieee802154_pkt.h
+++ b/include/zephyr/net/ieee802154_pkt.h
@@ -59,12 +59,6 @@ struct net_pkt_cb_ieee802154 {
 			 */
 			uint8_t rssi;
 		};
-#if defined(CONFIG_IEEE802154_SELECTIVE_TXPOWER)
-		/* TX packets */
-		struct {
-			int8_t txpwr; /* TX power in dBm. */
-		};
-#endif /* CONFIG_IEEE802154_SELECTIVE_TXPOWER */
 	};
 
 	/* Flags */
@@ -188,18 +182,6 @@ static inline void net_pkt_set_ieee802154_rssi_dbm(struct net_pkt *pkt, int16_t 
 
 	CODE_UNREACHABLE;
 }
-
-#if defined(CONFIG_IEEE802154_SELECTIVE_TXPOWER)
-static inline int8_t net_pkt_ieee802154_txpwr(struct net_pkt *pkt)
-{
-	return net_pkt_cb_ieee802154(pkt)->txpwr;
-}
-
-static inline void net_pkt_set_ieee802154_txpwr(struct net_pkt *pkt, int8_t txpwr)
-{
-	net_pkt_cb_ieee802154(pkt)->txpwr = txpwr;
-}
-#endif /* CONFIG_IEEE802154_SELECTIVE_TXPOWER */
 
 static inline bool net_pkt_ieee802154_arb(struct net_pkt *pkt)
 {

--- a/modules/openthread/platform/radio.c
+++ b/modules/openthread/platform/radio.c
@@ -380,13 +380,8 @@ void transmit_message(struct k_work *tx_job)
 
 	channel = sTransmitFrame.mChannel;
 
-	radio_api->set_channel(radio_dev, sTransmitFrame.mChannel);
-
-#if defined(CONFIG_IEEE802154_SELECTIVE_TXPOWER)
-	net_pkt_set_ieee802154_txpwr(tx_pkt, get_transmit_power_for_channel(channel));
-#else
+	radio_api->set_channel(radio_dev, channel);
 	radio_api->set_txpower(radio_dev, get_transmit_power_for_channel(channel));
-#endif /* CONFIG_IEEE802154_SELECTIVE_TXPOWER */
 
 	net_pkt_set_ieee802154_frame_secured(tx_pkt,
 					     sTransmitFrame.mInfo.mTxInfo.mIsSecurityProcessed);


### PR DESCRIPTION
- Remove `IEEE802154_SELECTIVE_TXPOWER` option.
- Cache tx power and radio channel in nRF5 driver.
- Apply channel before reception, ED, CCA or transmit carrier operations.
- Apply tx power before reception and transmit carrier.
- For tx operations, apply tx power and channel as metadata.