### PR TITLE
ztest: Add comfort functions for non-zero return codes

### DIFF
--- a/subsys/testsuite/ztest/include/zephyr/ztest_assert.h
+++ b/subsys/testsuite/ztest/include/zephyr/ztest_assert.h
@@ -283,6 +283,13 @@ static inline bool z_zexpect(bool cond, const char *default_msg, const char *fil
 #define zassert_ok(cond, ...) zassert(!(cond), #cond " is non-zero", ##__VA_ARGS__)
 
 /**
+ * @brief Assert that @a cond is not 0 (failure)
+ * @param cond Condition to check
+ * @param ... Optional message and variables to print if the assertion fails
+ */
+#define zassert_not_ok(cond, ...) zassert(!!(cond), #cond " is zero", ##__VA_ARGS__)
+
+/**
  * @brief Assert that @a ptr is NULL
  * @param ptr Pointer to compare
  * @param ... Optional message and variables to print if the assertion fails
@@ -424,6 +431,16 @@ static inline bool z_zexpect(bool cond, const char *default_msg, const char *fil
  * @param ... Optional message and variables to print if the assumption fails
  */
 #define zassume_ok(cond, ...) zassume(!(cond), #cond " is non-zero", ##__VA_ARGS__)
+
+/**
+ * @brief Assume that @a cond is not 0 (failure)
+ *
+ * If the assumption fails, the test will be marked as "skipped".
+ *
+ * @param cond Condition to check
+ * @param ... Optional message and variables to print if the assumption fails
+ */
+#define zassume_not_ok(cond, ...) zassume(!!(cond), #cond " is zero", ##__VA_ARGS__)
 
 /**
  * @brief Assume that @a ptr is NULL
@@ -577,6 +594,15 @@ static inline bool z_zexpect(bool cond, const char *default_msg, const char *fil
  * @param ... Optional message and variables to print if the expectation fails
  */
 #define zexpect_ok(cond, ...) zexpect(!(cond), #cond " is non-zero", ##__VA_ARGS__)
+
+/**
+ * @brief Expect that @a cond is not 0 (failure), otherwise mark test as failed but continue its
+ * execution.
+ *
+ * @param cond Condition to check
+ * @param ... Optional message and variables to print if the expectation fails
+ */
+#define zexpect_not_ok(cond, ...) zexpect(!!(cond), #cond " is zero", ##__VA_ARGS__)
 
 /**
  * @brief Expect that @a ptr is NULL, otherwise mark test as failed but continue its execution.

--- a/tests/ztest/base/src/main.c
+++ b/tests/ztest/base/src/main.c
@@ -20,6 +20,7 @@ ZTEST(framework_tests, test_assert_tests)
 	zassert_not_null("foo", NULL);
 	zassert_equal(1, 1);
 	zassert_equal_ptr(NULL, NULL, NULL);
+	zassert_not_ok(-EIO);
 }
 
 ZTEST(framework_tests, test_assert_mem_equal)

--- a/tests/ztest/zexpect/src/main.c
+++ b/tests/ztest/zexpect/src/main.c
@@ -59,6 +59,17 @@ ZTEST(expect, test_fail_expect_ok)
 	zexpect_ok(5);
 }
 
+ZTEST(expect, test_expect_not_ok)
+{
+	zexpect_not_ok(-EIO);
+}
+
+ZTEST_EXPECT_FAIL(expect, test_fail_expect_not_ok);
+ZTEST(expect, test_fail_expect_not_ok)
+{
+	zexpect_not_ok(0);
+}
+
 ZTEST(expect, test_expect_is_null)
 {
 	void *ptr = NULL;


### PR DESCRIPTION
Many functions return non-zero return codes on errors. I added an assert for the case, when a function is expected to fail. It is just a shorthand for `zassert_not_equal(0, ret);`, analogous to `zassert_ok`, introduced in c5d85e175fae85dce4236d20a92717e084b57709.

I also added the corresponding `zassume_nok` and `zexpect_nok`.