### PR TITLE
serial: mchp_xec: fix PM dependencies in driver

### DIFF
--- a/drivers/serial/uart_mchp_xec.c
+++ b/drivers/serial/uart_mchp_xec.c
@@ -219,7 +219,7 @@ struct uart_xec_dev_data {
 
 static const struct uart_driver_api uart_xec_driver_api;
 
-#ifdef CONFIG_PM_DEVICE
+#if defined(CONFIG_PM_DEVICE) && defined(CONFIG_UART_CONSOLE_INPUT_EXPIRED)
 static void uart_xec_pm_policy_state_lock_get(enum uart_xec_pm_policy_state_flag flag)
 {
 	if (atomic_test_and_set_bit(pm_policy_state_flag, flag) == 0) {
@@ -644,7 +644,7 @@ static int uart_xec_fifo_fill(const struct device *dev, const uint8_t *tx_data,
 	k_spinlock_key_t key = k_spin_lock(&dev_data->lock);
 
 	for (i = 0; (i < size) && (regs->LSR & LSR_THRE) != 0; i++) {
-#ifdef CONFIG_PM_DEVICE
+#if defined(CONFIG_PM_DEVICE) && defined(CONFIG_UART_CONSOLE_INPUT_EXPIRED)
 		uart_xec_pm_policy_state_lock_get(UART_XEC_PM_POLICY_STATE_TX_FLAG);
 #endif
 		regs->RTXB = tx_data[i];
@@ -933,7 +933,7 @@ static void uart_xec_isr(const struct device *dev)
 		dev_data->cb(dev, dev_data->cb_data);
 	}
 
-#ifdef CONFIG_PM_DEVICE
+#if defined(CONFIG_PM_DEVICE) && defined(CONFIG_UART_CONSOLE_INPUT_EXPIRED)
 	if (uart_xec_irq_tx_complete(dev)) {
 		uart_xec_pm_policy_state_lock_put(UART_XEC_PM_POLICY_STATE_TX_FLAG);
 	}


### PR DESCRIPTION
Implementation of PM in the driver requires PM to be enabled. This was
enabled in the SoC until now and was recently removed.

Fixes #64608

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
