### PR TITLE
sysbuild kconfig: native boards: Add option to distinguish them

### DIFF
--- a/arch/posix/Kconfig.sysbuild
+++ b/arch/posix/Kconfig.sysbuild
@@ -1,0 +1,6 @@
+# Copyright (c) 2023 Nordic Semiconductor
+#
+# SPDX-License-Identifier: Apache-2.0
+
+config NATIVE_BUILD
+	default y

--- a/boards/posix/native_posix/Kconfig.sysbuild
+++ b/boards/posix/native_posix/Kconfig.sysbuild
@@ -1,0 +1,5 @@
+# Copyright (c) 2023 Nordic Semiconductor
+#
+# SPDX-License-Identifier: Apache-2.0
+
+source "arch/posix/Kconfig.sysbuild"

--- a/boards/posix/native_sim/Kconfig.sysbuild
+++ b/boards/posix/native_sim/Kconfig.sysbuild
@@ -1,0 +1,5 @@
+# Copyright (c) 2023 Nordic Semiconductor
+#
+# SPDX-License-Identifier: Apache-2.0
+
+source "arch/posix/Kconfig.sysbuild"

--- a/boards/posix/nrf_bsim/Kconfig.sysbuild
+++ b/boards/posix/nrf_bsim/Kconfig.sysbuild
@@ -1,0 +1,5 @@
+# Copyright (c) 2023 Nordic Semiconductor
+#
+# SPDX-License-Identifier: Apache-2.0
+
+source "arch/posix/Kconfig.sysbuild"

--- a/share/sysbuild/Kconfig
+++ b/share/sysbuild/Kconfig
@@ -39,4 +39,10 @@ config WARN_DEPRECATED
 	  Print a warning when the Kconfig tree is parsed if any deprecated
 	  features are enabled.
 
+config NATIVE_BUILD
+	bool
+	help
+	  Zephyr will be built targeting the host system for debug and
+	  development purposes.
+
 rsource "images/Kconfig"


### PR DESCRIPTION
Inherit the NATIVE_BUILD option from Zephyr's kconfig into the sysbuild kconfig.
And set it for the native boards.
This allows treating this boards differently in the sysbuild cmake or kconfig files if needed.