### PR TITLE
kernel: mmu: fix compilation warnings when memory size is 0

### DIFF
--- a/include/zephyr/sys/mem_manage.h
+++ b/include/zephyr/sys/mem_manage.h
@@ -194,8 +194,12 @@ static inline uintptr_t z_mem_phys_addr(void *virt)
 #if CONFIG_KERNEL_VM_BASE != 0
 		 (addr >= CONFIG_KERNEL_VM_BASE) &&
 #endif
+#if (CONFIG_KERNEL_VM_BASE + CONFIG_KERNEL_VM_SIZE) != 0
 		 (addr < (CONFIG_KERNEL_VM_BASE +
 			  (CONFIG_KERNEL_VM_SIZE))),
+#else
+		 false,
+#endif
 		 "address %p not in permanent mappings", virt);
 #else
 	/* Should be identity-mapped */
@@ -203,8 +207,12 @@ static inline uintptr_t z_mem_phys_addr(void *virt)
 #if CONFIG_SRAM_BASE_ADDRESS != 0
 		 (addr >= CONFIG_SRAM_BASE_ADDRESS) &&
 #endif
+#if (CONFIG_SRAM_BASE_ADDRESS + (CONFIG_SRAM_SIZE * 1024UL)) != 0
 		 (addr < (CONFIG_SRAM_BASE_ADDRESS +
 			  (CONFIG_SRAM_SIZE * 1024UL))),
+#else
+		 false,
+#endif
 		 "physical address 0x%lx not in RAM",
 		 (unsigned long)addr);
 #endif /* CONFIG_MMU */
@@ -227,8 +235,12 @@ static inline void *z_mem_virt_addr(uintptr_t phys)
 #if CONFIG_SRAM_BASE_ADDRESS != 0
 		 (phys >= CONFIG_SRAM_BASE_ADDRESS) &&
 #endif
+#if (CONFIG_SRAM_BASE_ADDRESS + (CONFIG_SRAM_SIZE * 1024UL)) != 0
 		 (phys < (CONFIG_SRAM_BASE_ADDRESS +
 			  (CONFIG_SRAM_SIZE * 1024UL))),
+#else
+		 false,
+#endif
 		 "physical address 0x%lx not in RAM", (unsigned long)phys);
 #endif
 


### PR DESCRIPTION
When these memory sizes are defined to be zero, the assertions test will be comparing an unsigned int against zero which result in compilation warning, and will be raised to error in Twister.

Fix them with more conditional compilations, see also #63080

fixes #64633