### PR TITLE
lwm2m: Add shell support for deleting object and resource instances

### DIFF
--- a/doc/connectivity/networking/api/lwm2m.rst
+++ b/doc/connectivity/networking/api/lwm2m.rst
@@ -717,7 +717,10 @@ required actions from the server side.
             -t   Write value as time_t
 
     create  :create PATH
-            Create object instance
+            Create object or resource instance
+
+    delete  :delete PATH
+            Delete object or resource instance
 
     cache   :cache PATH NUM
             Enable data cache for resource

--- a/subsys/net/lib/lwm2m/lwm2m_shell.c
+++ b/subsys/net/lib/lwm2m/lwm2m_shell.c
@@ -39,7 +39,8 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 	"-sX\tWrite value as intX_t\n" \
 	"-f \tWrite value as float\n" \
 	"-t \tWrite value as time_t\n"
-#define LWM2M_HELP_CREATE "create PATH\nCreate object instance\n"
+#define LWM2M_HELP_CREATE "create PATH\nCreate object or resource instance\n"
+#define LWM2M_HELP_DELETE "delete PATH\nDelete object or resource instance\n"
 #define LWM2M_HELP_START "start EP_NAME [BOOTSTRAP FLAG]\n" \
 	"Start the LwM2M RD (Registration / Discovery) Client\n" \
 	"-b \tSet the bootstrap flag (default 0)\n"
@@ -371,10 +372,9 @@ static int cmd_write(const struct shell *sh, size_t argc, char **argv)
 	return 0;
 }
 
-static int cmd_create(const struct shell *sh, size_t argc, char **argv)
+static int cmd_create_or_delete(const struct shell *sh, bool delete, size_t argc, char **argv)
 {
 	struct lwm2m_obj_path path;
-	struct lwm2m_engine_obj_inst *obj_inst;
 	int ret;
 
 	if (argc < 2) {
@@ -389,20 +389,46 @@ static int cmd_create(const struct shell *sh, size_t argc, char **argv)
 		return -ENOEXEC;
 	}
 
-	if (path.level != LWM2M_PATH_LEVEL_OBJECT_INST) {
-		shell_error(sh, "path is not an object instance\n");
-		shell_help(sh);
-		return -EINVAL;
+	if (delete) {
+		switch (path.level) {
+		case LWM2M_PATH_LEVEL_RESOURCE_INST:
+			ret = lwm2m_delete_res_inst(&path);
+			break;
+		case LWM2M_PATH_LEVEL_OBJECT_INST:
+			ret = lwm2m_delete_object_inst(&path);
+			break;
+		default:
+			return -ENOEXEC;
+		}
+	} else {
+		switch (path.level) {
+		case LWM2M_PATH_LEVEL_RESOURCE_INST:
+			ret = lwm2m_create_res_inst(&path);
+			break;
+		case LWM2M_PATH_LEVEL_OBJECT_INST:
+			ret = lwm2m_create_object_inst(&path);
+			break;
+		default:
+			return -ENOEXEC;
+		}
 	}
 
-	ret = lwm2m_create_obj_inst(path.obj_id, path.obj_inst_id, &obj_inst);
 	if (ret < 0) {
-		shell_error(sh, "Failed to create object instance %d/%d, ret=%d", path.obj_id,
-			    path.obj_inst_id, ret);
+		shell_error(sh, "operation failed, %d\n", ret);
 		return -ENOEXEC;
 	}
 
 	return 0;
+}
+
+static int cmd_create(const struct shell *sh, size_t argc, char **argv)
+{
+	return cmd_create_or_delete(sh, false, argc, argv);
+}
+
+static int cmd_delete(const struct shell *sh, size_t argc, char **argv)
+{
+	return cmd_create_or_delete(sh, true, argc, argv);
 }
 
 static int cmd_start(const struct shell *sh, size_t argc, char **argv)
@@ -595,6 +621,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_CMD_ARG(read, NULL, LWM2M_HELP_READ, cmd_read, 2, 1),
 	SHELL_CMD_ARG(write, NULL, LWM2M_HELP_WRITE, cmd_write, 3, 1),
 	SHELL_CMD_ARG(create, NULL, LWM2M_HELP_CREATE, cmd_create, 2, 0),
+	SHELL_CMD_ARG(delete, NULL, LWM2M_HELP_DELETE, cmd_delete, 2, 0),
 	SHELL_CMD_ARG(cache, NULL, LWM2M_HELP_CACHE, cmd_cache, 3, 0),
 	SHELL_CMD_ARG(start, NULL, LWM2M_HELP_START, cmd_start, 2, 2),
 	SHELL_CMD_ARG(stop, NULL, LWM2M_HELP_STOP, cmd_stop, 1, 1),


### PR DESCRIPTION
Extend the previous support of creating object instances by allowing creation of resource instances as well.
Similarly, add support for deleting.