### PR TITLE
tests: drivers: serial: async: Add support for STM32H735G-DK Discover…

### DIFF
--- a/tests/drivers/uart/uart_async_api/boards/stm32h735g_disco.conf
+++ b/tests/drivers/uart/uart_async_api/boards/stm32h735g_disco.conf
@@ -1,0 +1,1 @@
+CONFIG_DCACHE=n

--- a/tests/drivers/uart/uart_async_api/boards/stm32h735g_disco.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/stm32h735g_disco.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021 STMicroelectronics
+ * Copyright (c) 2023 Benjamin Deuter
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+dut: &uart7 {
+	dmas = <&dmamux1 2 80 STM32_DMA_PERIPH_TX>,
+		<&dmamux1 3 79 STM32_DMA_PERIPH_RX>;
+	dma-names = "tx", "rx";
+    pinctrl-0 = <&uart7_tx_pf7 &uart7_rx_pf6>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+	status = "okay";
+};
+
+&dma1 {
+	status = "okay";
+};
+
+&dma2 {
+	status = "okay";
+};
+
+&dmamux1 {
+	status = "okay";
+};


### PR DESCRIPTION
…y kit

When connecting a UART from pin PF7 to PF6, the test uart_async_api passes now.