### PR TITLE
doc: guidelines: fix title level

### DIFF
--- a/doc/contribute/guidelines.rst
+++ b/doc/contribute/guidelines.rst
@@ -1028,7 +1028,7 @@ support for the old one is not a treewide change. Deprecation and removal of
 such APIs, however, are treewide changes.
 
 Specialized driver requirements
-===============================
+*******************************
 
 Drivers for standalone devices should use the Zephyr bus APIs (SPI, I2C...)
 whenever possible so that the device can be used with any SoC from any vendor


### PR DESCRIPTION
Specialized driver requirements should have been one level up, it now nests under "treewide".