### PR TITLE
dts: bindings: modem: ppp: add optional power and reset pins

### DIFF
--- a/dts/bindings/modem/zephyr,gsm-ppp.yaml
+++ b/dts/bindings/modem/zephyr,gsm-ppp.yaml
@@ -6,3 +6,10 @@ description: GSM PPP modem
 compatible: "zephyr,gsm-ppp"
 
 include: uart-device.yaml
+
+properties:
+  mdm-power-gpios:
+    type: phandle-array
+
+  mdm-reset-gpios:
+    type: phandle-array


### PR DESCRIPTION
The user can configure optional reset and on pins for the generic gsm-ppp device.
There's already a condition check in `modem_cellular.c` that checks if those pins have been defined to use them.