### PR TITLE
boards: arm: adafruit_feather_nrf52840: add voltage divider for battery

### DIFF
--- a/boards/arm/adafruit_feather_nrf52840/adafruit_feather_nrf52840.dts
+++ b/boards/arm/adafruit_feather_nrf52840/adafruit_feather_nrf52840.dts
@@ -47,6 +47,13 @@
 		};
 	};
 
+	vbatt {
+		compatible = "voltage-divider";
+		io-channels = <&adc 5>;
+		output-ohms = <100000>;
+		full-ohms = <(100000 + 100000)>;
+	};
+
 	/* These aliases are provided for compatibility with samples */
 	aliases {
 		led0 = &led0;


### PR DESCRIPTION
This allows firmware to read the voltage for LiPoly battery.

Schematic:
https://learn.adafruit.com/introducing-the-adafruit-nrf52840-feather/downloads