### PR TITLE
[Backport v2.7-branch] kernel shell, stacks shell commands: always use k_thread_foreach_unlocked

### DIFF
--- a/subsys/shell/modules/kernel_service.c
+++ b/subsys/shell/modules/kernel_service.c
@@ -140,7 +140,12 @@ static int cmd_kernel_threads(const struct shell *shell,
 
 	shell_print(shell, "Scheduler: %u since last call", sys_clock_elapsed());
 	shell_print(shell, "Threads:");
+
+#ifdef CONFIG_SMP
+	k_thread_foreach_unlocked(shell_tdata_dump, (void *)shell);
+#else
 	k_thread_foreach(shell_tdata_dump, (void *)shell);
+#endif
 	return 0;
 }
 
@@ -184,7 +189,12 @@ static int cmd_kernel_stacks(const struct shell *shell,
 
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
+
+#ifdef CONFIG_SMP
+	k_thread_foreach_unlocked(shell_stack_dump, (void *)shell);
+#else
 	k_thread_foreach(shell_stack_dump, (void *)shell);
+#endif
 
 	/* Placeholder logic for interrupt stack until we have better
 	 * kernel support, including dumping arch-specific exception-related

--- a/subsys/shell/modules/kernel_service.c
+++ b/subsys/shell/modules/kernel_service.c
@@ -141,11 +141,12 @@ static int cmd_kernel_threads(const struct shell *shell,
 	shell_print(shell, "Scheduler: %u since last call", sys_clock_elapsed());
 	shell_print(shell, "Threads:");
 
-#ifdef CONFIG_SMP
+	/*
+	 * Use the unlocked version as the callback itself might call
+	 * arch_irq_unlock.
+	 */
 	k_thread_foreach_unlocked(shell_tdata_dump, (void *)shell);
-#else
-	k_thread_foreach(shell_tdata_dump, (void *)shell);
-#endif
+
 	return 0;
 }
 
@@ -190,11 +191,11 @@ static int cmd_kernel_stacks(const struct shell *shell,
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-#ifdef CONFIG_SMP
+	/*
+	 * Use the unlocked version as the callback itself might call
+	 * arch_irq_unlock.
+	 */
 	k_thread_foreach_unlocked(shell_stack_dump, (void *)shell);
-#else
-	k_thread_foreach(shell_stack_dump, (void *)shell);
-#endif
 
 	/* Placeholder logic for interrupt stack until we have better
 	 * kernel support, including dumping arch-specific exception-related


### PR DESCRIPTION
call k_thread_foreach_unlocked to avoid assertions caused by calling shell_print while holding a global lock

Fixes #32145