### PR TITLE
Modem cellular patch initialization

### DIFF
--- a/drivers/modem/Kconfig.cellular
+++ b/drivers/modem/Kconfig.cellular
@@ -30,4 +30,8 @@ config MODEM_CELLULAR_APN
 	string "APN"
 	default "internet"
 
+config MODEM_CELLULAR_PERIODIC_SCRIPT_MS
+	int "Periodic script interval in milliseconds"
+	default 2000
+
 endif


### PR DESCRIPTION
The initialization of multiple modems fail due to incorrectly setting up CMUX, and failing to properly check the network registration status. This PR fixes the CMUX initialization, and adds polling of the network registration status.