### PR TITLE
modem modules: Add experimental tag

### DIFF
--- a/doc/develop/api/overview.rst
+++ b/doc/develop/api/overview.rst
@@ -233,6 +233,10 @@ between major releases are available in the :ref:`zephyr_release_notes`.
      - Stable
      - 1.11
 
+   * - :ref:`modem`
+     - Experimental
+     - 3.5
+
    * - :ref:`mqtt_socket_interface`
      - Unstable
      - 1.14

--- a/subsys/modem/Kconfig
+++ b/subsys/modem/Kconfig
@@ -3,6 +3,7 @@
 
 menuconfig MODEM_MODULES
 	bool "Modem modules"
+	select EXPERIMENTAL
 
 if MODEM_MODULES
 


### PR DESCRIPTION
The modem modules are novel and should therefore be marked experimental.