### PR TITLE
samples: ipc: openamp: fix build for IMXRT11xx

### DIFF
--- a/samples/subsys/ipc/openamp/remote/boards/mimxrt1160_evk_cm4.overlay
+++ b/samples/subsys/ipc/openamp/remote/boards/mimxrt1160_evk_cm4.overlay
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
+
 / {
 	/* Switch to lpuart2, since primary core uses lpuart1 */
 	chosen {

--- a/samples/subsys/ipc/openamp/remote/boards/mimxrt1170_evk_cm4.overlay
+++ b/samples/subsys/ipc/openamp/remote/boards/mimxrt1170_evk_cm4.overlay
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
+
 / {
 	/* Switch to lpuart2, since primary core uses lpuart1 */
 	chosen {


### PR DESCRIPTION
Fix build for IMXRT11xx SOCs. The ARM MPU header was missing for the CM4 board overlays, add the required header so the sample can build.