### PR TITLE
bluetooth: bap: Fix shift of BIS_Sync parameter of notification

### DIFF
--- a/subsys/bluetooth/audio/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/bap_broadcast_assistant.c
@@ -768,7 +768,8 @@ int bt_bap_broadcast_assistant_add_src(struct bt_conn *conn,
 
 		subgroup = net_buf_simple_add(&cp_buf, subgroup_size);
 
-		subgroup->bis_sync = param->subgroups[i].bis_sync;
+		/* The BIS Index bitfield to be sent must use BIT(0) for BIS Index 1 */
+		subgroup->bis_sync = param->subgroups[i].bis_sync >> 1;
 
 		CHECKIF(param->pa_sync == 0 && subgroup->bis_sync != 0) {
 			LOG_DBG("Only syncing to BIS is not allowed");
@@ -860,7 +861,8 @@ int bt_bap_broadcast_assistant_mod_src(struct bt_conn *conn,
 		}
 		subgroup = net_buf_simple_add(&cp_buf, subgroup_size);
 
-		subgroup->bis_sync = param->subgroups[i].bis_sync;
+		/* The BIS Index bitfield to be sent must use BIT(0) for BIS Index 1 */
+		subgroup->bis_sync = param->subgroups[i].bis_sync >> 1;
 
 		CHECKIF(param->pa_sync == 0 && subgroup->bis_sync != 0) {
 			LOG_DBG("Only syncing to BIS is not allowed");

--- a/subsys/bluetooth/audio/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/bap_scan_delegator.c
@@ -177,7 +177,7 @@ static void net_buf_put_recv_state(const struct bass_recv_state_internal *recv_s
 	for (int i = 0; i < state->num_subgroups; i++) {
 		const struct bt_bap_scan_delegator_subgroup *subgroup = &state->subgroups[i];
 
-		(void)net_buf_simple_add_le32(&read_buf, subgroup->bis_sync);
+		(void)net_buf_simple_add_le32(&read_buf, subgroup->bis_sync >> 1);
 		(void)net_buf_simple_add_u8(&read_buf, subgroup->metadata_len);
 		(void)net_buf_simple_add_mem(&read_buf, subgroup->metadata,
 					     subgroup->metadata_len);

--- a/subsys/bluetooth/audio/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/bap_scan_delegator.c
@@ -514,6 +514,10 @@ static int scan_delegator_add_source(struct bt_conn *conn,
 		}
 
 		internal_state->requested_bis_sync[i] = net_buf_simple_pull_le32(buf);
+		if (internal_state->requested_bis_sync[i] != BT_BAP_BIS_SYNC_NO_PREF) {
+			/* Received BIS Index bitfield uses BIT(0) for BIS Index 1 */
+			internal_state->requested_bis_sync[i] <<= 1;
+		}
 
 		if (internal_state->requested_bis_sync[i] &&
 		    pa_sync == BT_BAP_BASS_PA_REQ_NO_SYNC) {
@@ -670,6 +674,11 @@ static int scan_delegator_mod_src(struct bt_conn *conn,
 		old_bis_sync_req = internal_state->requested_bis_sync[i];
 
 		internal_state->requested_bis_sync[i] = net_buf_simple_pull_le32(buf);
+		if (internal_state->requested_bis_sync[i] != BT_BAP_BIS_SYNC_NO_PREF) {
+			/* Received BIS Index bitfield uses BIT(0) for BIS Index 1 */
+			internal_state->requested_bis_sync[i] <<= 1;
+		}
+
 		if (internal_state->requested_bis_sync[i] &&
 		    pa_sync == BT_BAP_BASS_PA_REQ_NO_SYNC) {
 			LOG_DBG("Cannot sync to BIS without PA");


### PR DESCRIPTION
The PTS BASS/SR/CP test cases fails because of wrong value of the BIS_Sync parameter of the Add Source and Modify Source operations and of notification of Broadcast Audio Scan Control Point.