### PR TITLE
soc/riscv/riscv-ite/it8xxx2: Support DEVNULL_REGION

### DIFF
--- a/soc/riscv/riscv-ite/it8xxx2/linker.ld
+++ b/soc/riscv/riscv-ite/it8xxx2/linker.ld
@@ -69,12 +69,18 @@
 #define SHA256_BLOCK_SIZE 0x200
 #endif
 
+#include <zephyr/linker/linker-devnull.h>
+
 MEMORY
 {
 #ifdef CONFIG_XIP
     ROM (rx)  : ORIGIN = ROM_BASE, LENGTH = ROM_SIZE
 #endif
     RAM (rwx) : ORIGIN = RAM_BASE, LENGTH = RAM_SIZE
+
+#if defined(CONFIG_LINKER_DEVNULL_MEMORY)
+    DEVNULL_ROM (rx) : ORIGIN = DEVNULL_ADDR, LENGTH = DEVNULL_SIZE
+#endif
 
     LINKER_DT_REGIONS()
 


### PR DESCRIPTION
it8xxx2 uses a custom linker script, which was not updated on dfb3674c4cb49ffa2dbdaf812dfe785bc171b025. This patch naively updates it to support DEVNULL_REGION.