### PR TITLE
drivers: regulator: axp192: fix init priority

### DIFF
--- a/boards/xtensa/m5stack_core2/Kconfig.defconfig
+++ b/boards/xtensa/m5stack_core2/Kconfig.defconfig
@@ -24,6 +24,9 @@ choice BT_HCI_BUS_TYPE
 	default BT_ESP32 if BT
 endchoice
 
+config REGULATOR_AXP192_INIT_PRIORITY
+	default 81
+
 config GPIO_HOGS_INIT_PRIORITY
 	default 82
 

--- a/drivers/regulator/Kconfig.axp192
+++ b/drivers/regulator/Kconfig.axp192
@@ -15,7 +15,7 @@ if REGULATOR_AXP192
 
 config REGULATOR_AXP192_INIT_PRIORITY
 	int "AXP192 regulator driver init priority"
-	default 76
+	default 86
 	help
 	  Init priority for the axp192 regulator driver. It must be
 	  greater than MFD_INIT_PRIORITY.


### PR DESCRIPTION
That was missed in  https://github.com/zephyrproject-rtos/zephyr/commit/66f5fce68fa1c982df1b2639c49446e3e7bf0df9 commit so let's adjust it as well.