### PR TITLE
boards: m5stack_core2: fix priorities override

### DIFF
--- a/boards/xtensa/m5stack_core2/Kconfig.defconfig
+++ b/boards/xtensa/m5stack_core2/Kconfig.defconfig
@@ -24,17 +24,8 @@ choice BT_HCI_BUS_TYPE
 	default BT_ESP32 if BT
 endchoice
 
-config MFD_INIT_PRIORITY
-	default 60
-
-config REGULATOR_AXP192_INIT_PRIORITY
-	default 76
-
-config GPIO_AXP192_INIT_PRIORITY
-	default 80
-
 config GPIO_HOGS_INIT_PRIORITY
-	default 81
+	default 82
 
 config INPUT_FT5336_INTERRUPT
 	default y if INPUT


### PR DESCRIPTION
Instead of those set, use the default ones for the MFD/REGULATOR_AXP192_INIT_PRIORITY/GPIO_AXP192_INIT_PRIORITY that are set to the 80/86/81 values correctly. Adjust the GPIO_HOGS_INIT_PRIORITY only to be executed after GPIO driver.