### PR TITLE
Bluetooth: Controller: Fix scan aux context leak

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -240,11 +240,6 @@ config BT_CTLR_CONN_ISO_AVOID_SEGMENTATION
 	  interface, the config provides a way to force the Max_PDU to Max_SDU +
 	  5 (header + offset).
 
-config BT_CTLR_ADVANCED_FEATURES
-	bool "Show advanced features"
-	help
-	  Makes advanced features visible to controller developers.
-
 choice
 	prompt "CIS Creation Policy Selection"
 	default BT_CTLR_CONN_ISO_RELIABILITY_POLICY
@@ -271,6 +266,11 @@ config BT_CTLR_TEST
 	bool "Run in-system unit tests"
 	help
 	  Run in-system unit tests
+
+config BT_CTLR_ADVANCED_FEATURES
+	bool "Show advanced features"
+	help
+	  Makes advanced features visible to controller developers.
 
 menu "Advanced features"
 	visible if BT_CTLR_ADVANCED_FEATURES

--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -961,6 +961,13 @@ config BT_CTLR_SCAN_UNRESERVED
 	  Scanner will not use time space reservation for scan window when in
 	  continuous scan mode.
 
+config BT_CTLR_EARLY_ABORT_PREVIOUS_PREPARE
+	bool "Early abort previous prepare"
+	default y
+	help
+	  Early abort previous prepare present before a short prepare is
+	  enqueued in the prepare pipeline.
+
 config BT_MAYFLY_YIELD_AFTER_CALL
 	bool "Yield from mayfly thread after first call"
 	default y

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -832,7 +832,7 @@ static void ticker_stop_op_cb(uint32_t status, void *param)
 	ARG_UNUSED(status);
 
 	LL_ASSERT(preempt_stop_req != preempt_stop_ack);
-	preempt_stop_ack++;
+	preempt_stop_ack = preempt_stop_req;
 
 	preempt_req = preempt_ack;
 }
@@ -852,7 +852,7 @@ static void ticker_start_op_cb(uint32_t status, void *param)
 	 * start operation has been handled.
 	 */
 	LL_ASSERT(preempt_start_req != preempt_start_ack);
-	preempt_start_ack++;
+	preempt_start_ack = preempt_start_req;
 }
 
 static uint32_t preempt_ticker_start(struct lll_event *first,
@@ -974,7 +974,7 @@ static void preempt_ticker_cb(uint32_t ticks_at_expire, uint32_t ticks_drift,
 	uint32_t ret;
 
 	LL_ASSERT(preempt_ack != preempt_req);
-	preempt_ack++;
+	preempt_ack = preempt_req;
 
 	mfy.param = param;
 	ret = mayfly_enqueue(TICKER_USER_ID_ULL_HIGH, TICKER_USER_ID_LLL,

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -632,6 +632,7 @@ static int is_abort_cb(void *next, void *curr, lll_prepare_cb_t *resume_cb)
 
 static void abort_cb(struct lll_prepare_param *prepare_param, void *param)
 {
+	struct event_done_extra *e;
 	int err;
 
 	/* NOTE: This is not a prepare being cancelled */
@@ -650,6 +651,9 @@ static void abort_cb(struct lll_prepare_param *prepare_param, void *param)
 	 */
 	err = lll_hfclock_off();
 	LL_ASSERT(err >= 0);
+
+	e = ull_done_extra_type_set(EVENT_DONE_EXTRA_TYPE_SCAN_AUX);
+	LL_ASSERT(e);
 
 	lll_done(param);
 }


### PR DESCRIPTION
Fix scan aux context leak under BT_CTLR_SCAN_UNRESERVED.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>