### PR TITLE
github: Add qemu_x86_64 board to api coverage

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: ["native_posix", "qemu_x86", "unit_testing"]
+        platform: ["native_posix", "qemu_x86", "qemu_x86_64", "unit_testing"]
     env:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.16.3
     steps:


### PR DESCRIPTION
Add qemu_x86_64 board to the platform matrix for api_coverage.