### PR TITLE
sparc: add SPARC dependency to SPARC_CASA

### DIFF
--- a/soc/sparc/Kconfig
+++ b/soc/sparc/Kconfig
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config SPARC_CASA
-	default y
+	default y if SPARC
 
 config SOC_SPARC_LEON
 	bool


### PR DESCRIPTION
Settings which defaults to `y` but is architecture related should have a arch dependency for safety reasons.

Thefore add `if SPARC` to the SPARC_CASA Kconfig to ensure this setting is only enabled on the sparc arch.