### PR TITLE
docs: Make edac and smbus green in API coverage

### DIFF
--- a/include/zephyr/drivers/edac.h
+++ b/include/zephyr/drivers/edac.h
@@ -16,8 +16,6 @@
 
 #include <sys/types.h>
 
-typedef void (*edac_notify_callback_f)(const struct device *dev, void *data);
-
 /**
  * @defgroup edac EDAC API
  * @ingroup io_interfaces
@@ -33,6 +31,14 @@ enum edac_error_type {
 	/** Uncorrectable error type */
 	EDAC_ERROR_TYPE_DRAM_UC = BIT(1)
 };
+
+/**
+ * @cond INTERNAL_HIDDEN
+ *
+ * For internal use only, skip these in public documentation.
+ */
+
+typedef void (*edac_notify_callback_f)(const struct device *dev, void *data);
 
 /**
  * @brief EDAC driver API
@@ -63,6 +69,10 @@ __subsystem struct edac_driver_api {
 	int (*notify_cb_set)(const struct device *dev,
 			     edac_notify_callback_f cb);
 };
+
+/**
+ * INTERNAL_HIDDEN @endcond
+ */
 
 /* Optional interfaces */
 

--- a/include/zephyr/drivers/edac.h
+++ b/include/zephyr/drivers/edac.h
@@ -74,7 +74,12 @@ __subsystem struct edac_driver_api {
  * INTERNAL_HIDDEN @endcond
  */
 
-/* Optional interfaces */
+/**
+ * @name Optional interfaces
+ * @{
+ *
+ * EDAC Optional Interfaces
+ */
 
 /**
  * @brief Set injection parameter param1
@@ -241,7 +246,14 @@ static inline int edac_inject_error_trigger(const struct device *dev)
 	return api->inject_error_trigger(dev);
 }
 
-/* Mandatory interfaces */
+/** @} */ /* End of EDAC Optional Interfaces */
+
+/**
+ * @name Mandatory interfaces
+ * @{
+ *
+ * EDAC Mandatory Interfaces
+ */
 
 /**
  * @brief Get ECC Error Log
@@ -398,8 +410,9 @@ static inline int edac_notify_callback_set(const struct device *dev,
 	return api->notify_cb_set(dev, cb);
 }
 
-/**
- * @}
- */
+
+/** @} */ /* End of EDAC Mandatory Interfaces */
+
+/** @} */ /* End of EDAC API */
 
 #endif  /* ZEPHYR_INCLUDE_DRIVERS_EDAC_H_ */

--- a/include/zephyr/drivers/smbus.h
+++ b/include/zephyr/drivers/smbus.h
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Public SMBus Driver APIs
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_SMBUS_H_
 #define ZEPHYR_INCLUDE_DRIVERS_SMBUS_H_
 


### PR DESCRIPTION
Add missing pieces and exclude internal API.