### PR TITLE
Bluetooth: shell: host: add missing conditional compile

### DIFF
--- a/subsys/bluetooth/audio/shell/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/shell/bap_broadcast_assistant.c
@@ -163,7 +163,7 @@ static void bap_broadcast_assistant_recv_state_cb(
 			}
 		}
 
-		if (per_adv_sync) {
+		if (per_adv_sync && IS_ENABLED(CONFIG_BT_PER_ADV_SYNC_TRANSFER_SENDER)) {
 			shell_print(ctx_shell, "Sending PAST");
 
 			err = bt_le_per_adv_sync_transfer(per_adv_sync,
@@ -202,7 +202,8 @@ static void bap_broadcast_assistant_recv_state_cb(
 			}
 		}
 
-		if (ext_adv != NULL && IS_ENABLED(CONFIG_BT_PER_ADV)) {
+		if (ext_adv != NULL && IS_ENABLED(CONFIG_BT_PER_ADV) &&
+		    IS_ENABLED(CONFIG_BT_PER_ADV_SYNC_TRANSFER_SENDER)) {
 			shell_print(ctx_shell, "Sending local PAST");
 
 			err = bt_le_per_adv_set_info_transfer(ext_adv, conn,

--- a/subsys/bluetooth/audio/shell/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/shell/bap_scan_delegator.c
@@ -144,6 +144,7 @@ static void pa_timer_handler(struct k_work *work)
 	}
 }
 
+#if defined(CONFIG_BT_PER_ADV_SYNC_TRANSFER_SENDER)
 static int pa_sync_past(struct bt_conn *conn,
 			struct sync_state *state,
 			uint16_t pa_interval)
@@ -167,6 +168,7 @@ static int pa_sync_past(struct bt_conn *conn,
 
 	return err;
 }
+#endif /* CONFIG_BT_PER_ADV_SYNC_TRANSFER_SENDER */
 
 static int pa_sync_no_past(struct sync_state *state,
 			    uint16_t pa_interval)
@@ -441,9 +443,11 @@ static int cmd_bap_scan_delegator_sync_pa(const struct shell *sh, size_t argc,
 		return -ENOEXEC;
 	}
 
-	if (past_preference &&
-	    state->past_avail &&
-	    state->conn != NULL) {
+	if (0) {
+#if defined(CONFIG_BT_PER_ADV_SYNC_TRANSFER_SENDER)
+	} else if (past_preference &&
+		   state->past_avail &&
+		   state->conn != NULL) {
 		shell_info(sh, "Syncing with PAST");
 
 		err = pa_sync_past(state->conn, state, state->pa_interval);
@@ -458,7 +462,7 @@ static int cmd_bap_scan_delegator_sync_pa(const struct shell *sh, size_t argc,
 
 			return -ENOEXEC;
 		}
-
+#endif /* CONFIG_BT_PER_ADV_SYNC_TRANSFER_SENDER */
 	} else {
 		shell_info(sh, "Syncing without PAST");
 		err = pa_sync_no_past(state, state->pa_interval);


### PR DESCRIPTION
There was a conditional compile misssing for the
BT_PER_ADV_SYNC_TRANSFER_SENDER, potentially leading to build failures