### PR TITLE
net: shell: Print device and wifi information for iface cmd

### DIFF
--- a/subsys/net/lib/shell/iface.c
+++ b/subsys/net/lib/shell/iface.c
@@ -243,6 +243,9 @@ static void iface_cb(struct net_if *iface, void *user_data)
 
 	PR("MTU       : %d\n", net_if_get_mtu(iface));
 	PR("Flags     : %s\n", iface_flags2str(iface));
+	PR("Device    : %s (%p)\n",
+	   net_if_get_device(iface) ? net_if_get_device(iface)->name : "<?>",
+	   net_if_get_device(iface));
 
 #if defined(CONFIG_NET_L2_ETHERNET_MGMT)
 	if (net_if_l2(iface) == &NET_L2_GET_NAME(ETHERNET)) {

--- a/subsys/net/lib/shell/net_shell.c
+++ b/subsys/net/lib/shell/net_shell.c
@@ -18,6 +18,8 @@ LOG_MODULE_REGISTER(net_shell, LOG_LEVEL_DBG);
 #include <zephyr/random/random.h>
 #include <stdlib.h>
 
+#include <zephyr/net/ethernet.h>
+
 #include "common.h"
 #include "net_shell.h"
 
@@ -142,6 +144,16 @@ const char *iface2str(struct net_if *iface, const char **extra)
 
 #ifdef CONFIG_NET_L2_ETHERNET
 	if (net_if_l2(iface) == &NET_L2_GET_NAME(ETHERNET)) {
+		struct ethernet_context *eth_ctx = net_if_l2_data(iface);
+
+		if (eth_ctx->eth_if_type == L2_ETH_IF_TYPE_WIFI) {
+			if (extra) {
+				*extra = "====";
+			}
+
+			return "WiFi";
+		}
+
 		if (extra) {
 			*extra = "========";
 		}


### PR DESCRIPTION
If the interface is WiFi one, then print information about it. Also the device information is useful to know so print device name corresponding to the network interface.