### PR TITLE
bluetooth: bas: remove select SENSOR

### DIFF
--- a/subsys/bluetooth/services/Kconfig.bas
+++ b/subsys/bluetooth/services/Kconfig.bas
@@ -5,4 +5,3 @@
 
 config BT_BAS
 	bool "GATT Battery service"
-	select SENSOR


### PR DESCRIPTION
Bluetooth battery service does not use sensor.