### PR TITLE
modules liblc3: Add missing REQUIRES_FULL_LIBC Kconfig dependency

### DIFF
--- a/modules/liblc3/Kconfig
+++ b/modules/liblc3/Kconfig
@@ -7,5 +7,6 @@ config ZEPHYR_LIBLC3_MODULE
 config LIBLC3
 	bool "liblc3 Support"
 	depends on FPU
+	select REQUIRES_FULL_LIBC
 	help
 	  This option enables the Android liblc3 library for Bluetooth LE Audio

--- a/samples/bluetooth/broadcast_audio_sink/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
+++ b/samples/bluetooth/broadcast_audio_sink/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
@@ -4,7 +4,5 @@ CONFIG_LIBLC3=y
 # The LC3 codec uses a large amount of stack. This app runs the codec in the work-queue, hence
 # inctease stack size for that thread.
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
-# LC3 lib requires floating point support in the c-lib NEWLIB is one way of getting that.
-CONFIG_NEWLIB_LIBC=y
 # Enable encryption.
 CONFIG_BT_TINYCRYPT_ECC=y

--- a/samples/bluetooth/broadcast_audio_source/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
+++ b/samples/bluetooth/broadcast_audio_source/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
@@ -6,7 +6,5 @@ CONFIG_BT_ISO_TX_MTU=40
 # The LC3 codec uses a large amount of stack. This app runs the codec in the work-queue, hence
 # inctease stack size for that thread.
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
-# LC3 lib requires floating point support in the c-lib NEWLIB is one way of getting that.
-CONFIG_NEWLIB_LIBC=y
 CONFIG_MAIN_STACK_SIZE=4096
 CONFIG_BT_TINYCRYPT_ECC=y

--- a/samples/bluetooth/tmap_bmr/boards/nrf5340dk_nrf5340_cpuapp.conf
+++ b/samples/bluetooth/tmap_bmr/boards/nrf5340dk_nrf5340_cpuapp.conf
@@ -4,5 +4,3 @@ CONFIG_LIBLC3=y
 # The LC3 codec uses a large amount of stack. This app runs the codec in the work-queue, hence
 # inctease stack size for that thread.
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
-# LC3 lib requires floating point support in the c-lib.
-CONFIG_REQUIRES_FULL_LIBC=y

--- a/samples/bluetooth/tmap_bms/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
+++ b/samples/bluetooth/tmap_bms/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
@@ -4,5 +4,3 @@ CONFIG_LIBLC3=y
 # The LC3 codec uses a large amount of stack. This app runs the codec in the work-queue, hence
 # inctease stack size for that thread.
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
-# LC3 lib requires floating point support in the c-lib.
-CONFIG_REQUIRES_FULL_LIBC=y

--- a/samples/bluetooth/tmap_bms/boards/nrf5340dk_nrf5340_cpuapp.conf
+++ b/samples/bluetooth/tmap_bms/boards/nrf5340dk_nrf5340_cpuapp.conf
@@ -4,5 +4,3 @@ CONFIG_LIBLC3=y
 # The LC3 codec uses a large amount of stack. This app runs the codec in the work-queue, hence
 # inctease stack size for that thread.
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
-# LC3 lib requires floating point support in the c-lib.
-CONFIG_REQUIRES_FULL_LIBC=y

--- a/samples/bluetooth/tmap_central/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
+++ b/samples/bluetooth/tmap_central/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
@@ -4,5 +4,3 @@ CONFIG_LIBLC3=y
 # The LC3 codec uses a large amount of stack. This app runs the codec in the work-queue, hence
 # inctease stack size for that thread.
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
-# LC3 lib requires floating point support in the c-lib.
-CONFIG_REQUIRES_FULL_LIBC=y

--- a/samples/bluetooth/tmap_central/boards/nrf5340dk_nrf5340_cpuapp.conf
+++ b/samples/bluetooth/tmap_central/boards/nrf5340dk_nrf5340_cpuapp.conf
@@ -4,5 +4,3 @@ CONFIG_LIBLC3=y
 # The LC3 codec uses a large amount of stack. This app runs the codec in the work-queue, hence
 # inctease stack size for that thread.
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
-# LC3 lib requires floating point support in the c-lib.
-CONFIG_REQUIRES_FULL_LIBC=y

--- a/samples/bluetooth/tmap_peripheral/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
+++ b/samples/bluetooth/tmap_peripheral/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
@@ -4,5 +4,3 @@ CONFIG_LIBLC3=y
 # The LC3 codec uses a large amount of stack. This app runs the codec in the work-queue, hence
 # inctease stack size for that thread.
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
-# LC3 lib requires floating point support in the c-lib.
-CONFIG_REQUIRES_FULL_LIBC=y

--- a/samples/bluetooth/tmap_peripheral/boards/nrf5340dk_nrf5340_cpuapp.conf
+++ b/samples/bluetooth/tmap_peripheral/boards/nrf5340dk_nrf5340_cpuapp.conf
@@ -4,5 +4,3 @@ CONFIG_LIBLC3=y
 # The LC3 codec uses a large amount of stack. This app runs the codec in the work-queue, hence
 # inctease stack size for that thread.
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
-# LC3 lib requires floating point support in the c-lib.
-CONFIG_REQUIRES_FULL_LIBC=y

--- a/samples/bluetooth/unicast_audio_client/boards/nrf52_bsim.conf
+++ b/samples/bluetooth/unicast_audio_client/boards/nrf52_bsim.conf
@@ -1,5 +1,3 @@
 # For LC3 the following configs are needed
 CONFIG_FPU=y
 CONFIG_LIBLC3=y
-# LC3 lib requires floating point support in the c-lib.
-CONFIG_REQUIRES_FULL_LIBC=y

--- a/samples/bluetooth/unicast_audio_client/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
+++ b/samples/bluetooth/unicast_audio_client/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
@@ -4,5 +4,3 @@ CONFIG_LIBLC3=y
 # The LC3 codec uses a large amount of stack. This app runs the codec in the work-queue, hence
 # inctease stack size for that thread.
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
-# LC3 lib requires floating point support in the c-lib.
-CONFIG_REQUIRES_FULL_LIBC=y

--- a/samples/bluetooth/unicast_audio_client/boards/nrf5340bsim_nrf5340_cpuapp.conf
+++ b/samples/bluetooth/unicast_audio_client/boards/nrf5340bsim_nrf5340_cpuapp.conf
@@ -1,8 +1,6 @@
 # For LC3 the following configs are needed
 CONFIG_FPU=y
 CONFIG_LIBLC3=y
-# LC3 lib requires floating point support in the c-lib.
-CONFIG_REQUIRES_FULL_LIBC=y
 
 CONFIG_BT_BUF_EVT_RX_SIZE=255
 CONFIG_BT_BUF_ACL_RX_SIZE=255

--- a/samples/bluetooth/unicast_audio_client/boards/nrf5340bsim_nrf5340_cpunet.conf
+++ b/samples/bluetooth/unicast_audio_client/boards/nrf5340bsim_nrf5340_cpunet.conf
@@ -4,5 +4,3 @@
 # For LC3 the following configs are needed
 CONFIG_FPU=y
 CONFIG_LIBLC3=y
-# LC3 lib requires floating point support in the c-lib.
-CONFIG_REQUIRES_FULL_LIBC=y

--- a/samples/bluetooth/unicast_audio_client/boards/nrf5340dk_nrf5340_cpuapp.conf
+++ b/samples/bluetooth/unicast_audio_client/boards/nrf5340dk_nrf5340_cpuapp.conf
@@ -4,8 +4,6 @@ CONFIG_LIBLC3=y
 # The LC3 codec uses a large amount of stack. This app runs the codec in the work-queue, hence
 # inctease stack size for that thread.
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
-# LC3 lib requires floating point support in the c-lib.
-CONFIG_REQUIRES_FULL_LIBC=y
 
 CONFIG_BT_BUF_EVT_RX_SIZE=255
 CONFIG_BT_BUF_ACL_RX_SIZE=255

--- a/samples/bluetooth/unicast_audio_server/boards/nrf52_bsim.conf
+++ b/samples/bluetooth/unicast_audio_server/boards/nrf52_bsim.conf
@@ -1,5 +1,3 @@
 # For LC3 the following configs are needed
 CONFIG_FPU=y
 CONFIG_LIBLC3=y
-# LC3 lib requires floating point support in the c-lib.
-CONFIG_REQUIRES_FULL_LIBC=y

--- a/samples/bluetooth/unicast_audio_server/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
+++ b/samples/bluetooth/unicast_audio_server/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
@@ -4,5 +4,3 @@ CONFIG_LIBLC3=y
 # The LC3 codec uses a large amount of stack. This app runs the codec in the work-queue, hence
 # inctease stack size for that thread.
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
-# LC3 lib requires floating point support in the c-lib.
-CONFIG_REQUIRES_FULL_LIBC=y

--- a/samples/bluetooth/unicast_audio_server/boards/nrf5340bsim_nrf5340_cpuapp.conf
+++ b/samples/bluetooth/unicast_audio_server/boards/nrf5340bsim_nrf5340_cpuapp.conf
@@ -1,8 +1,6 @@
 # For LC3 the following configs are needed
 CONFIG_FPU=y
 CONFIG_LIBLC3=y
-# LC3 lib requires floating point support in the c-lib.
-CONFIG_REQUIRES_FULL_LIBC=y
 
 CONFIG_BT_BUF_EVT_RX_SIZE=255
 CONFIG_BT_BUF_ACL_RX_SIZE=255

--- a/samples/bluetooth/unicast_audio_server/boards/nrf5340bsim_nrf5340_cpunet.conf
+++ b/samples/bluetooth/unicast_audio_server/boards/nrf5340bsim_nrf5340_cpunet.conf
@@ -1,5 +1,3 @@
 # For LC3 the following configs are needed
 CONFIG_FPU=y
 CONFIG_LIBLC3=y
-# LC3 lib requires floating point support in the c-lib.
-CONFIG_REQUIRES_FULL_LIBC=y

--- a/samples/bluetooth/unicast_audio_server/boards/nrf5340dk_nrf5340_cpuapp.conf
+++ b/samples/bluetooth/unicast_audio_server/boards/nrf5340dk_nrf5340_cpuapp.conf
@@ -4,8 +4,6 @@ CONFIG_LIBLC3=y
 # The LC3 codec uses a large amount of stack. This app runs the codec in the work-queue, hence
 # inctease stack size for that thread.
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
-# LC3 lib requires floating point support in the c-lib.
-CONFIG_REQUIRES_FULL_LIBC=y
 
 CONFIG_BT_BUF_EVT_RX_SIZE=255
 CONFIG_BT_BUF_ACL_RX_SIZE=255

--- a/tests/bluetooth/shell/boards/native_posix.conf
+++ b/tests/bluetooth/shell/boards/native_posix.conf
@@ -14,5 +14,3 @@ CONFIG_LIBLC3=y
 # The LC3 codec uses a large amount of stack. This app runs the codec in the work-queue, hence
 # inctease stack size for that thread.
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
-# LC3 lib requires floating point support in the c-lib.
-CONFIG_REQUIRES_FULL_LIBC=y

--- a/tests/bluetooth/shell/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
+++ b/tests/bluetooth/shell/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
@@ -4,5 +4,3 @@ CONFIG_LIBLC3=y
 # The LC3 codec uses a large amount of stack. This app runs the codec in the work-queue, hence
 # inctease stack size for that thread.
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
-# LC3 lib requires floating point support in the c-lib.
-CONFIG_REQUIRES_FULL_LIBC=y

--- a/tests/bluetooth/shell/boards/nrf5340dk_nrf5340_cpuapp.conf
+++ b/tests/bluetooth/shell/boards/nrf5340dk_nrf5340_cpuapp.conf
@@ -4,5 +4,3 @@ CONFIG_LIBLC3=y
 # The LC3 codec uses a large amount of stack. This app runs the codec in the work-queue, hence
 # inctease stack size for that thread.
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
-# LC3 lib requires floating point support in the c-lib.
-CONFIG_REQUIRES_FULL_LIBC=y

--- a/tests/bsim/bluetooth/audio_samples/unicast_audio_client/boards/nrf52_bsim.conf
+++ b/tests/bsim/bluetooth/audio_samples/unicast_audio_client/boards/nrf52_bsim.conf
@@ -3,5 +3,3 @@
 # For LC3 the following configs are needed
 CONFIG_FPU=y
 CONFIG_LIBLC3=y
-# LC3 lib requires floating point support in the c-lib.
-CONFIG_REQUIRES_FULL_LIBC=y

--- a/tests/bsim/bluetooth/audio_samples/unicast_audio_client/boards/nrf5340bsim_nrf5340_cpuapp.conf
+++ b/tests/bsim/bluetooth/audio_samples/unicast_audio_client/boards/nrf5340bsim_nrf5340_cpuapp.conf
@@ -3,8 +3,6 @@
 # For LC3 the following configs are needed
 CONFIG_FPU=y
 CONFIG_LIBLC3=y
-# LC3 lib requires floating point support in the c-lib.
-CONFIG_REQUIRES_FULL_LIBC=y
 
 CONFIG_BT_BUF_EVT_RX_SIZE=255
 CONFIG_BT_BUF_ACL_RX_SIZE=255

--- a/tests/bsim/bluetooth/audio_samples/unicast_audio_client/boards/nrf5340bsim_nrf5340_cpunet.conf
+++ b/tests/bsim/bluetooth/audio_samples/unicast_audio_client/boards/nrf5340bsim_nrf5340_cpunet.conf
@@ -3,5 +3,3 @@
 # For LC3 the following configs are needed
 CONFIG_FPU=y
 CONFIG_LIBLC3=y
-# LC3 lib requires floating point support in the c-lib.
-CONFIG_REQUIRES_FULL_LIBC=y


### PR DESCRIPTION
The LC3 codec requires floating point support in
the C library, so let's select REQUIRES_FULL_LIBC
in the module kconfig, instead of having samples
adding it to their prj.conf

Some extra info:
Today the default embedded C library is picolibc, even if REQUIRES_FULL_LIBC is not set.
REQUIRES_FULL_LIBC just prevents MINIMAL_LIBC, which is actually bigger in footprint than picolibc.