### PR TITLE
i2s: stm32h7: add i2s support for stm32h7 mcu family

### DIFF
--- a/drivers/i2s/Kconfig.stm32
+++ b/drivers/i2s/Kconfig.stm32
@@ -10,7 +10,7 @@ menuconfig I2S_STM32
 	select DMA
 	help
 	  Enable I2S support on the STM32 family of processors.
-	  (Tested on the STM32F4 series)
+	  (Tested on the STM32F4 & STM32H7 series)
 
 if I2S_STM32
 

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -467,6 +467,48 @@
 			status = "disabled";
 		};
 
+		i2s1: i2s@40013000 {
+			compatible = "st,stm32h7-i2s", "st,stm32-i2s";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40013000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00001000>,
+				 <&rcc STM32_SRC_PLL1_Q SPI123_SEL(0)>;
+			dmas = <&dmamux1 0 38 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
+				&dmamux1 1 37 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+			dma-names = "tx", "rx";
+			interrupts = <35 3>;
+			status = "disabled";
+		};
+
+		i2s2: i2s@40003800 {
+			compatible = "st,stm32h7-i2s", "st,stm32-i2s";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40003800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00004000>,
+				 <&rcc STM32_SRC_PLL1_Q SPI123_SEL(0)>;
+			dmas = <&dmamux1 0 40 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
+				&dmamux1 1 39 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+			dma-names = "tx", "rx";
+			interrupts = <36 0>;
+			status = "disabled";
+		};
+
+		i2s3: i2s@40003c00 {
+			compatible = "st,stm32h7-i2s", "st,stm32-i2s";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40003c00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00008000>,
+				 <&rcc STM32_SRC_PLL1_Q SPI123_SEL(0)>;
+			dmas = <&dmamux1 0 62 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
+				&dmamux1 1 61 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+			dma-names = "tx", "rx";
+			interrupts = <51 0>;
+			status = "disabled";
+		};
+
 		fdcan1: can@4000a000 {
 			compatible = "st,stm32h7-fdcan";
 			reg = <0x4000a000 0x400>, <0x4000ac00 0x350>;

--- a/dts/arm/st/h7/stm32h7a3.dtsi
+++ b/dts/arm/st/h7/stm32h7a3.dtsi
@@ -79,6 +79,19 @@
 			status = "disabled";
 		};
 
+		i2s6: i2s@58001400 {
+			compatible = "st,stm32h7-i2s", "st,stm32-i2s";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x58001400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB4 0x00000020>,
+				 <&rcc STM32_SRC_PLL1_Q SPI6_SEL(0)>;
+			dmas = <&dmamux2 0 12 0x20440 &dmamux2 1 11 0x20480>;
+			dma-names = "tx", "rx";
+			interrupts = <86 0>;
+			status = "disabled";
+		};
+
 		rng: rng@48021800 {
 			nist-config = <0xf00d00>;
 			health-test-magic = <0x17590abc>;

--- a/dts/bindings/i2s/st,stm32-i2s-common.yaml
+++ b/dts/bindings/i2s/st,stm32-i2s-common.yaml
@@ -1,0 +1,31 @@
+# Copyright (c) 2018, STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+# Common fields for STM32 I2S peripherals.
+
+include: [i2s-controller.yaml, pinctrl-device.yaml]
+
+properties:
+  reg:
+    required: true
+
+  interrupts:
+    required: true
+
+  dmas:
+    required: true
+
+  dma-names:
+    required: true
+
+  pinctrl-0:
+    required: true
+
+  pinctrl-names:
+    required: true
+
+  mck-enabled:
+    type: boolean
+    description: |
+      Master Clock Output function.
+      An mck pin must be listed within pinctrl-0 when enabling this property.

--- a/dts/bindings/i2s/st,stm32h7-i2s.yaml
+++ b/dts/bindings/i2s/st,stm32h7-i2s.yaml
@@ -1,8 +1,8 @@
 # Copyright (c) 2018, STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
-description: STM32 I2S controller
+description: STM32H7 I2S controller
 
-compatible: "st,stm32-i2s"
+compatible: "st,stm32h7-i2s"
 
 include: st,stm32-i2s-common.yaml


### PR DESCRIPTION
This commit modifies the I2S driver to work for STM32H7
family of MCU's. Currently only TX is working.

Tested on nucleo_stm32h743zi. Requires dma1 & dmamux1 to be enabled. For instance
```
i2s_rxtx: &i2s1 {
    pinctrl-0 = <&i2s1_ws_pa4 &i2s1_ck_pb3 &spi1_miso_pa6 &spi1_mosi_pb5>;
    pinctrl-names = "default";
    status = "okay";
};

&dma1 {
    status = "okay";
};

&dmamux1 {
    status = "okay";
};
```

I also changed the -NOSYS to -ENOTSUP even of stm32f4 family for I2S_DIR_BOTH since from what I can see configuring RX and then TX will set the mode register to only TX.
```
#define LL_I2S_MODE_MASTER_TX              (SPI_I2SCFGR_I2SCFG_1)                        /*!< Master Tx configuration */
#define LL_I2S_MODE_MASTER_RX              (SPI_I2SCFGR_I2SCFG_0 | SPI_I2SCFGR_I2SCFG_1) /*!< Master Rx configuration */
```
That's the order it's done in the i2s echo sample. I'll put that within an ifdef if you disagree.