### PR TITLE
west.yml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -282,7 +282,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 13767d0b72eb14ce42eb8aad1e5a133ef66afc54
+      revision: 4a1effbc301fc302ecbaf40d4eb2be520b53010d
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  4a1effbc301fc302ecbaf40d4eb2be520b53010d

Brings following Zephyr relevant fixes:
 - 4a1effbc zephyr: Remove deprecated ZEPHYR_TRY_MASS_ERASE option
 - 2b924da4 samples: zephyr: Use the default MCUBoot PEM key file
 - 25b7c7a8 imgtool: make "align" command line parameter optional
 - 301d5655 readme: update for next dev release
 - e0bdcdec Update version files for 2.0.0
 - 9b92ee91 boot: zephyr: add support for LPC55Sxx

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.