### PR TITLE
smbus: Remove syscalls with callbacks

### DIFF
--- a/drivers/smbus/smbus_handlers.c
+++ b/drivers/smbus/smbus_handlers.c
@@ -144,15 +144,6 @@ static inline int z_vrfy_smbus_block_pcall(const struct device *dev,
 }
 #include <syscalls/smbus_block_pcall_mrsh.c>
 
-static inline int z_vrfy_smbus_smbalert_set_cb(const struct device *dev,
-					       struct smbus_callback *cb)
-{
-	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_SMBUS));
-
-	return z_impl_smbus_smbalert_set_cb(dev, cb);
-}
-#include <syscalls/smbus_smbalert_set_cb_mrsh.c>
-
 static inline int z_vrfy_smbus_smbalert_remove_cb(const struct device *dev,
 						  struct smbus_callback *cb)
 {
@@ -161,15 +152,6 @@ static inline int z_vrfy_smbus_smbalert_remove_cb(const struct device *dev,
 	return z_impl_smbus_smbalert_remove_cb(dev, cb);
 }
 #include <syscalls/smbus_smbalert_remove_cb_mrsh.c>
-
-static inline int z_vrfy_smbus_host_notify_set_cb(const struct device *dev,
-						  struct smbus_callback *cb)
-{
-	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_SMBUS));
-
-	return z_impl_smbus_host_notify_set_cb(dev, cb);
-}
-#include <syscalls/smbus_host_notify_set_cb_mrsh.c>
 
 static inline int z_vrfy_smbus_host_notify_remove_cb(const struct device *dev,
 						     struct smbus_callback *cb)

--- a/include/zephyr/drivers/smbus.h
+++ b/include/zephyr/drivers/smbus.h
@@ -606,11 +606,8 @@ static inline int z_impl_smbus_get_config(const struct device *dev,
  * @retval -ENOSYS If function smbus_smbalert_set_cb() is not implemented
  * by the driver.
  */
-__syscall int smbus_smbalert_set_cb(const struct device *dev,
-				    struct smbus_callback *cb);
-
-static inline int z_impl_smbus_smbalert_set_cb(const struct device *dev,
-					       struct smbus_callback *cb)
+static inline int smbus_smbalert_set_cb(const struct device *dev,
+					struct smbus_callback *cb)
 {
 	const struct smbus_driver_api *api =
 		(const struct smbus_driver_api *)dev->api;
@@ -660,11 +657,8 @@ static inline int z_impl_smbus_smbalert_remove_cb(const struct device *dev,
  * @retval -ENOSYS If function smbus_host_notify_set_cb() is not implemented
  * by the driver.
  */
-__syscall int smbus_host_notify_set_cb(const struct device *dev,
-				       struct smbus_callback *cb);
-
-static inline int z_impl_smbus_host_notify_set_cb(const struct device *dev,
-						  struct smbus_callback *cb)
+static inline int smbus_host_notify_set_cb(const struct device *dev,
+					   struct smbus_callback *cb)
 {
 	const struct smbus_driver_api *api =
 		(const struct smbus_driver_api *)dev->api;

--- a/tests/drivers/smbus/smbus_api/src/test_smbus.c
+++ b/tests/drivers/smbus/smbus_api/src/test_smbus.c
@@ -45,7 +45,7 @@ ZTEST_USER(test_smbus_general, test_smbus_basic_api)
  * The test is run in userspace only if CONFIG_USERSPACE option is
  * enabled, otherwise it is the same as ZTEST()
  */
-ZTEST_USER(test_smbus_general, test_smbus_smbalert_api)
+ZTEST(test_smbus_general, test_smbus_smbalert_api)
 {
 	const struct device *const dev = DEVICE_DT_GET(DT_NODELABEL(smbus0));
 	void *dummy; /* For the dummy function pointer use this */
@@ -90,7 +90,7 @@ ZTEST_USER(test_smbus_general, test_smbus_smbalert_api)
  * The test is run in userspace only if CONFIG_USERSPACE option is
  * enabled, otherwise it is the same as ZTEST()
  */
-ZTEST_USER(test_smbus_general, test_smbus_host_notify_api)
+ZTEST(test_smbus_general, test_smbus_host_notify_api)
 {
 	const struct device *const dev = DEVICE_DT_GET(DT_NODELABEL(smbus0));
 	void *dummy; /* For the dummy function pointer use this */


### PR DESCRIPTION
Remove syscalls that allows user threads to set callbacks that will be invoked by the kernel.

Userspace is not trusted we can't allow a user thread set callbacks that will be invoked by the kernel and run with supervisor privileges.