### PR TITLE
power_domain_intel_adsp.c: revert recent INIT_PRIORITY change

### DIFF
--- a/drivers/power_domain/power_domain_intel_adsp.c
+++ b/drivers/power_domain/power_domain_intel_adsp.c
@@ -84,6 +84,6 @@ static int pd_intel_adsp_init(const struct device *dev)
 	PM_DEVICE_DT_INST_DEFINE(id, pd_intel_adsp_pm_action);				\
 	DEVICE_DT_INST_DEFINE(id, pd_intel_adsp_init, PM_DEVICE_DT_INST_GET(id),	\
 			      &pd_pg_reg##id, NULL, POST_KERNEL,			\
-			      CONFIG_POWER_DOMAIN_INIT_PRIORITY, NULL);
+			      CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
 
 DT_INST_FOREACH_STATUS_OKAY(POWER_DOMAIN_DEVICE)


### PR DESCRIPTION
This is a partial revert of one-line from commit 06cfbd4159fd ("drivers: power_domain: Introduce a gpio monitor driver") which not just introduced a new driver (no problem with that) but also changed the initialization priority of another, unrelated and existing power domain driver without even trying to compile it:

- https://github.com/zephyrproject-rtos/zephyr/pull/61166#issuecomment-1780959157

```
west config manifest.project-filter -- +sof
west update

west build -b intel_adsp_ace20_lnl modules/audio/sof/app/

ERROR: /soc/ssp@28100 POST_KERNEL 43 < /soc/dfpmccu@71b00/io0_domain  51
ERROR: /soc/ssp@29100 POST_KERNEL 44 < /soc/dfpmccu@71b00/io0_domain  51
ERROR: /soc/ssp@2a100 POST_KERNEL 45 < /soc/dfpmccu@71b00/io0_domain  51
ERROR: /soc/ssp@2b100 POST_KERNEL 46 < /soc/dfpmccu@71b00/io0_domain  51
ERROR: /soc/ssp@2c100 POST_KERNEL 47 < /soc/dfpmccu@71b00/io0_domain  51
ERROR: /soc/ssp@2d100 POST_KERNEL 48 < /soc/dfpmccu@71b00/io0_domain  51
```

Also note a reviewer (@ceolin) expressed concerns about this unrelated change but it was ignored:
- https://github.com/zephyrproject-rtos/zephyr/pull/61166#discussion_r1357908984

Using `CONFIG_KERNEL_INIT_PRIORITY_DEFAULT` here may be "bad" for some reason(s) and maybe it should be changed in the future, but it's nothing compared to breaking _compilation_ of code that has been validated for months and been released in production
(https://github.com/thesofproject/sof-bin/releases/tag/v2023.09)

So the very urgent thing is to very quickly revert to the previous state to unblock development. Then we can discuss what is the better thing to do here.