### PR TITLE
driver: timer: npcx: fix the failure of the timer_behavior testsuite

### DIFF
--- a/tests/kernel/timer/timer_behavior/Kconfig
+++ b/tests/kernel/timer/timer_behavior/Kconfig
@@ -23,6 +23,7 @@ config TIMER_TEST_PERIOD
 
 config TIMER_TEST_MAX_STDDEV
 	int "Maximum standard deviation in microseconds allowed"
+	default 33 if NPCX_ITIM_TIMER
 	default 10
 
 config TIMER_TEST_MAX_DRIFT


### PR DESCRIPTION
The `cyc_sys_announced` (tick to be announced) was updated with the current timer will cause the time drift and induce the jitter when running the timer_behavior test suite. This PR fixed it by updating it at the tick boundary). The sys_clock_set_timeout API also changed because the above modification.
Also, as the npcx event timer is running at 32768 Hz (to support the low power sleep mode), it might introduce the deviation of (+/-) 30.5 us when converting the system time to event count. This PR increases the stdev tolerance in the test's Kconfig when npcx chip is used

This PR passed the long run stress (warm reboot) on the Chromebook platform. 

Fixes #59594


