### PR TITLE
west.yml: Update hal_silabs to pull request #46 | Update to GSDK 4.3.2

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -219,7 +219,7 @@ manifest:
       groups:
         - hal
     - name: hal_silabs
-      revision: d191d981c4eb20c0c7445a4061fcdbcfa686113a
+      revision: 8bc20509e3b1dcff9a70e153110697130eb83549
       path: modules/hal/silabs
       groups:
         - hal


### PR DESCRIPTION
Update the EFR32MG24 device files inside gecko/Device/SiliconLabs/EFR32MG24 from gecko_sdk to align the codebase of hal_silabs with gecko_sdk 4.3.2.

PR in hal_silabs - https://github.com/zephyrproject-rtos/hal_silabs/pull/46