### PR TITLE
usb: device: cdc_acm: Use ZLP to detect initial host read

### DIFF
--- a/doc/connectivity/usb/device/usb_device.rst
+++ b/doc/connectivity/usb/device/usb_device.rst
@@ -175,6 +175,37 @@ CDC ACM UART as backend for a subsystem or application:
   for example see :zephyr_file:`samples/subsys/shell/shell_module`
 * ``zephyr,uart-mcumgr`` used by :zephyr:code-sample:`smp-svr` sample
 
+POSIX default tty ECHO mitigation
+---------------------------------
+
+POSIX systems, like Linux, default to enabling ECHO on tty devices. Host side
+application can disable ECHO by calling ``open()`` on the tty device and issuing
+``ioctl()`` (preferably via ``tcsetattr()``) to disable echo if it is not desired.
+Unfortunately, there is an inherent race between the ``open()`` and ``ioctl()``
+where the ECHO is enabled and any characters received (even if host application
+does not call ``read()``) will be echoed back. This issue is especially visible
+when the CDC ACM port is used without any real UART on the other side because
+there is no arbitrary delay due to baud rate.
+
+To mitigate the issue, Zephyr CDC ACM implementation arms IN endpoint with ZLP
+after device is configured. When the host reads the ZLP, which is pretty much
+the best indication that host application has opened the tty device, Zephyr will
+force :kconfig:option:`CONFIG_CDC_ACM_TX_DELAY_MS` millisecond delay before real
+payload is sent. This should allow sufficient time for first, and only first,
+application that opens the tty device to disable ECHO if ECHO is not desired.
+If ECHO is not desired at all from CDC ACM device it is best to set up udev rule
+to disable ECHO as soon as device is connected.
+
+ECHO is particurarly unwanted when CDC ACM instance is used for Zephyr shell,
+because the control characters to set color sent back to shell are interpreted
+as (invalid) command and user will see garbage as a result. While minicom does
+disable ECHO by default, on exit with reset it will restore the termios settings
+to whatever was set on entry. Therefore, if minicom is the first application to
+open the tty device, the exit with reset will enable ECHO back and thus set up
+a problem for the next application (which cannot be mitigated at Zephyr side).
+To prevent the issue it is recommended either to leave minicom without reset or
+to disable ECHO before minicom is started.
+
 DFU
 ===
 

--- a/subsys/usb/device/class/Kconfig.cdc
+++ b/subsys/usb/device/class/Kconfig.cdc
@@ -37,6 +37,13 @@ config CDC_ACM_BULK_EP_MPS
 	help
 	  CDC ACM class bulk endpoints size
 
+config CDC_ACM_TX_DELAY_MS
+	int
+	default 100
+	help
+	  Time in milliseconds to wait before sending actual payload to host.
+	  This is needed to prevent tty ECHO on Linux.
+
 config CDC_ACM_IAD
 	bool "Force using Interface Association Descriptor"
 	default y

--- a/subsys/usb/device/class/cdc_acm.c
+++ b/subsys/usb/device/class/cdc_acm.c
@@ -1029,11 +1029,6 @@ static void cdc_acm_poll_out(const struct device *dev, unsigned char c)
 {
 	struct cdc_acm_dev_data_t * const dev_data = dev->data;
 
-	if (!dev_data->configured || dev_data->suspended) {
-		LOG_INF("USB device not ready, drop data");
-		return;
-	}
-
 	dev_data->tx_ready = false;
 
 	while (!ring_buf_put(dev_data->tx_ringbuf, &c, 1)) {

--- a/subsys/usb/device/class/cdc_acm.c
+++ b/subsys/usb/device/class/cdc_acm.c
@@ -223,12 +223,27 @@ static void cdc_acm_write_cb(uint8_t ep, int size, void *priv)
 		k_work_submit_to_queue(&USB_WORK_Q, &dev_data->cb_work);
 	}
 
-	if (ring_buf_is_empty(dev_data->tx_ringbuf)) {
+	/* If size is 0, we want to schedule tx work even if ringbuf is empty to
+	 * ensure that actual payload will not be sent before initialization
+	 * timeout passes.
+	 */
+	if (ring_buf_is_empty(dev_data->tx_ringbuf) && size) {
 		LOG_DBG("tx_ringbuf is empty");
 		return;
 	}
 
-	k_work_schedule_for_queue(&USB_WORK_Q, &dev_data->tx_work, K_NO_WAIT);
+	/* If size is 0, it means that host started polling IN data because it
+	 * has read the ZLP we armed when interface was configured. This ZLP is
+	 * probably the best indication that host has started to read the data.
+	 * Wait initialization timeout before sending actual payload to make it
+	 * possible for application to disable ECHO. The echo is long known
+	 * problem related to the fact that POSIX defaults to ECHO ON and thus
+	 * every application that opens tty device (on Linux) will have ECHO
+	 * enabled in the short window between open() and ioctl() that disables
+	 * the echo (if application wishes to disable the echo).
+	 */
+	k_work_schedule_for_queue(&USB_WORK_Q, &dev_data->tx_work, size ?
+				  K_NO_WAIT : K_MSEC(CONFIG_CDC_ACM_TX_DELAY_MS));
 }
 
 static void tx_work_handler(struct k_work *work)
@@ -244,6 +259,10 @@ static void tx_work_handler(struct k_work *work)
 
 	if (usb_transfer_is_busy(ep)) {
 		LOG_DBG("Transfer is ongoing");
+		return;
+	}
+
+	if (!dev_data->configured) {
 		return;
 	}
 
@@ -375,12 +394,10 @@ static void cdc_acm_do_cb(struct cdc_acm_dev_data_t *dev_data,
 			dev_data->configured = true;
 			cdc_acm_read_cb(cfg->endpoint[ACM_OUT_EP_IDX].ep_addr, 0,
 					dev_data);
-		}
-		if (!dev_data->tx_ready) {
-			dev_data->tx_ready = true;
-			/* if wait tx irq, invoke callback */
-			if (dev_data->cb != NULL && dev_data->tx_irq_ena) {
-				k_work_submit_to_queue(&USB_WORK_Q, &dev_data->cb_work);
+			/* Queue ZLP on IN endpoint so we know when host starts polling */
+			if (!dev_data->tx_ready) {
+				usb_transfer(cfg->endpoint[ACM_IN_EP_IDX].ep_addr, NULL, 0,
+					     USB_TRANS_WRITE, cdc_acm_write_cb, dev_data);
 			}
 		}
 		break;


### PR DESCRIPTION
Queue characters in TX ring buffer regardless of interface state. Prevent ECHO on Linux by arming IN endpoint with ZLP when interface is configured and making sure that actual payload is only sent after initialization timeout. The ZLP is not visible to host side applications because the applications are really accessing tty buffer and received ZLP does not modify tty buffer in any way.

See #64024 and #54705 for related discussions.

Fixes #64023