### PR TITLE
doc: Bump to Sphinx 7.1 and RTD theme 2.0

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,8 +1,8 @@
 # DOC: used to generate docs
 
 breathe>=4.34
-sphinx~=6.2
-sphinx_rtd_theme~=1.2
+sphinx~=7.1.0
+sphinx_rtd_theme~=2.0
 sphinx-tabs
 sphinxcontrib-svg2pdfconverter
 pygments>=2.9


### PR DESCRIPTION
LIVE TEST URL: https://builds.zephyrproject.io/zephyr/pr/64724/docs/

This moves more recent versions of Sphinx and Read the Docs theme.
FWIW Sphinx 7.2.0 dropped support for Python 3.8 so we're stuck with 7.1 for now.