### PR TITLE
doc: develop: getting_started: Change ubuntu version to 20.04 LTS

### DIFF
--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -22,7 +22,7 @@ Click the operating system you are using.
 
    .. group-tab:: Ubuntu
 
-      This guide covers Ubuntu version 18.04 LTS and later.
+      This guide covers Ubuntu version 20.04 LTS and later.
 
       .. code-block:: bash
 


### PR DESCRIPTION
Ubuntu 18.04 LTS support was dropped in May 2023, therefore bump version to oldest supported LTS release