### PR TITLE
doc: gsg: Remove misleading mention of Powershell

### DIFF
--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -397,10 +397,7 @@ additional Python dependencies.
 
                .. code-block:: bat
 
-                  :: cmd.exe
                   zephyrproject\.venv\Scripts\activate.bat
-                  :: PowerShell
-                  zephyrproject\.venv\Scripts\Activate.ps1
 
                Once activated your shell will be prefixed with ``(.venv)``. The
                virtual environment can be deactivated at any time by running


### PR DESCRIPTION
While we will probably want to properly document how to use Powershell on Windows in the near future, current Getting Started Guide contained a misleading mention to activating Pythonv venv using Powershell that this commit removes.

Addresses comments raised in #64682.