### PR TITLE
tests nrf_rtc_timer: Avoid failures w NRF53_SYNC_RTC enabled

### DIFF
--- a/tests/drivers/timer/nrf_rtc_timer/prj.conf
+++ b/tests/drivers/timer/nrf_rtc_timer/prj.conf
@@ -2,6 +2,10 @@ CONFIG_ZTEST=y
 CONFIG_NRF_RTC_TIMER_USER_CHAN_COUNT=2
 CONFIG_SYS_CLOCK_TICKS_PER_SEC=32768
 
+# This test assumes it can use all configured NRF_RTC_TIMER_USER_CHAN_COUNT
+# But the sync RTC code uses one while it synchronizes. Let's just disable it.
+CONFIG_NRF53_SYNC_RTC=n
+
 # Debug build
 # CONFIG_NO_OPTIMIZATIONS=y
 # CONFIG_ZTEST_STACK_SIZE=2048


### PR DESCRIPTION
This test assumes it can use all configured
NRF_RTC_TIMER_USER_CHAN_COUNT,
But the sync RTC code uses one while it synchronizes. Let's just disable the sync rtc.

This fixes an issue where the test fails for a simulated nrf5340.

Fixes #64738