### PR TITLE
actions: manifest: Upgrade to 1.2.2

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -26,7 +26,7 @@ jobs:
           west init -l . || true
 
       - name: Manifest
-        uses: zephyrproject-rtos/action-manifest@v1.2.1
+        uses: zephyrproject-rtos/action-manifest@v1.2.2
         with:
           github-token: ${{ secrets.ZB_GITHUB_TOKEN }}
           manifest-path: 'west.yml'


### PR DESCRIPTION
Use revision 1.2.2 which comes with an additional bugfix.

See https://github.com/zephyrproject-rtos/action-manifest/pull/11.