### PR TITLE
MAINTAINERS: Add Tomasz to ACPI as collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -118,6 +118,7 @@ ACPI:
     - najumon1980
   collaborators:
     - finikorg
+    - tbursztyka
   files:
     - lib/acpi/
     - include/zephyr/acpi/


### PR DESCRIPTION
Tomasz is actively involved in Zephyr's ACPI support, so add him as a collaborator to the subsystem.