### PR TITLE
ipc: icmsg: Allow to support future versions

### DIFF
--- a/subsys/ipc/ipc_service/lib/icmsg.c
+++ b/subsys/ipc/ipc_service/lib/icmsg.c
@@ -216,7 +216,9 @@ static void mbox_callback_process(struct k_work *item)
 	} else {
 		__ASSERT_NO_MSG(state == ICMSG_STATE_BUSY);
 
-		bool endpoint_invalid = (len != sizeof(magic) || memcmp(magic, rx_buffer, len));
+		/* Allow magic number longer than sizeof(magic) for future protocol version. */
+		bool endpoint_invalid = (len < sizeof(magic) ||
+					memcmp(magic, rx_buffer, sizeof(magic)));
 
 		spsc_pbuf_free(dev_data->rx_ib, len);
 


### PR DESCRIPTION
Allow magic number to be longer than the sizeof(magic). This will allow to support future versions of the icmsg with backwards compatibility.