### PR TITLE
doc: gsg: Update Windows instructions regarding Python 3.12

### DIFF
--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -164,7 +164,12 @@ The current minimum required version for the main dependencies are:
          .. code-block:: bat
 
             choco install cmake --installargs 'ADD_CMAKE_TO_PATH=System'
-            choco install ninja gperf python git dtc-msys2 wget 7zip
+            choco install ninja gperf python311 git dtc-msys2 wget 7zip
+
+         .. warning::
+
+            As of November 2023, Python 3.12 is not recommended for Zephyr development on Windows,
+            as some required Python dependencies may be difficult to install.
 
       #. Close the window and open a new ``cmd.exe`` window **as a regular user** to continue.
 


### PR DESCRIPTION
https://builds.zephyrproject.io/zephyr/pr/64744/docs/develop/getting_started/index.html#install-dependencies

Python 3.12 is not (yet) providing a seamless experience for Windows developers. 
Update Install instructions to invite people to stick to Python 3.11 for the time being.

**Note: I successfully went through the full, updated, getting started instructions on a vanilla Win11 install**

```
OS Name:                   Microsoft Windows 11 Home
OS Version:                10.0.22631 N/A Build 22631
```

