### PR TITLE
Serial emulated UART driver adjust interrupt driven implementation

### DIFF
--- a/drivers/serial/Kconfig.emul
+++ b/drivers/serial/Kconfig.emul
@@ -12,3 +12,15 @@ config UART_EMUL
 	select EXPERIMENTAL
 	help
 	  Enable the emulated UART driver.
+
+if UART_EMUL
+
+config UART_EMUL_WORK_Q_STACK_SIZE
+	int "UART emulator work queue stack size"
+	default 2048
+
+config UART_EMUL_WORK_Q_PRIORITY
+	int "UART emulator work queue tread priority"
+	default 1
+
+endif # UART_EMUL

--- a/dts/bindings/serial/zephyr,uart-emul.yaml
+++ b/dts/bindings/serial/zephyr,uart-emul.yaml
@@ -25,3 +25,9 @@ properties:
     description: |
       Connects TX to RX internally creating a loop back connection. Useful
       for testing.
+
+  latch-buffer-size:
+    type: int
+    default: 1
+    description: |
+      Size of the virtual UART latch buffer.

--- a/tests/drivers/uart/uart_emul/src/main.c
+++ b/tests/drivers/uart/uart_emul/src/main.c
@@ -17,6 +17,8 @@
 struct uart_emul_fixture {
 	const struct device *dev;
 	uint8_t sample_data[SAMPLE_DATA_SIZE];
+	uint8_t tx_content[SAMPLE_DATA_SIZE];
+	uint8_t rx_content[SAMPLE_DATA_SIZE];
 };
 
 static void *uart_emul_setup(void)
@@ -64,19 +66,18 @@ ZTEST_F(uart_emul, test_polling_out)
 
 ZTEST_F(uart_emul, test_polling_in)
 {
-	uint8_t rx_content[SAMPLE_DATA_SIZE] = {0};
 	int rc;
 
 	uart_emul_put_rx_data(fixture->dev, fixture->sample_data, SAMPLE_DATA_SIZE);
 
 	for (size_t i = 0; i < SAMPLE_DATA_SIZE; i++) {
-		rc = uart_poll_in(fixture->dev, &rx_content[i]);
+		rc = uart_poll_in(fixture->dev, &fixture->rx_content[i]);
 		zassert_equal(rc, 0, "RX buffer should contain data");
 	}
-	zassert_mem_equal(rx_content, fixture->sample_data, SAMPLE_DATA_SIZE);
+	zassert_mem_equal(fixture->rx_content, fixture->sample_data, SAMPLE_DATA_SIZE);
 
 	/* No more data in RX buffer */
-	rc = uart_poll_in(fixture->dev, &rx_content[0]);
+	rc = uart_poll_in(fixture->dev, &fixture->rx_content[0]);
 	zassert_equal(rc, -1, "RX buffer should be empty");
 }
 
@@ -103,47 +104,45 @@ ZTEST_F(uart_emul, test_errors)
 
 static void uart_emul_isr(const struct device *dev, void *user_data)
 {
-	/* always of size SAMPLE_DATA_SIZE */
-	uint8_t *buf = user_data;
+	struct uart_emul_fixture *fixture = user_data;
 
 	while (uart_irq_update(dev) && uart_irq_is_pending(dev)) {
 		if (uart_irq_tx_ready(dev)) {
-			uart_fifo_fill(dev, buf, SAMPLE_DATA_SIZE);
+			uart_fifo_fill(dev, fixture->tx_content, SAMPLE_DATA_SIZE);
 			uart_irq_tx_disable(dev);
 		}
 
 		if (uart_irq_rx_ready(dev)) {
-			uart_fifo_read(dev, buf, SAMPLE_DATA_SIZE);
+			uart_fifo_read(dev, fixture->rx_content, SAMPLE_DATA_SIZE);
 		}
 	}
 }
 
 ZTEST_F(uart_emul, test_irq_tx)
 {
-	uint8_t tx_content[SAMPLE_DATA_SIZE] = {0};
 	size_t tx_len;
 
-	uart_irq_callback_user_data_set(fixture->dev, uart_emul_isr, fixture->sample_data);
+	uart_irq_callback_user_data_set(fixture->dev, uart_emul_isr, fixture);
 	/* enabling the tx irq will call the callback, if set */
 	uart_irq_tx_enable(fixture->dev);
 	/* allow space for work queue to run */
 	k_yield();
 
-	tx_len = uart_emul_get_tx_data(fixture->dev, tx_content, SAMPLE_DATA_SIZE);
+	tx_len = uart_emul_get_tx_data(fixture->dev, fixture->tx_content, SAMPLE_DATA_SIZE);
 	zassert_equal(tx_len, SAMPLE_DATA_SIZE, "TX buffer length does not match");
-	zassert_mem_equal(tx_content, fixture->sample_data, SAMPLE_DATA_SIZE);
+	zassert_mem_equal(fixture->tx_content, fixture->sample_data, SAMPLE_DATA_SIZE);
 
 	/* No more data in TX buffer */
-	tx_len = uart_emul_get_tx_data(fixture->dev, tx_content, sizeof(tx_content));
+	tx_len = uart_emul_get_tx_data(fixture->dev, fixture->tx_content,
+				       sizeof(fixture->tx_content));
 	zassert_equal(tx_len, 0, "TX buffer should be empty");
 }
 
 ZTEST_F(uart_emul, test_irq_rx)
 {
-	uint8_t rx_content[SAMPLE_DATA_SIZE] = {0};
 	int rc;
 
-	uart_irq_callback_user_data_set(fixture->dev, uart_emul_isr, rx_content);
+	uart_irq_callback_user_data_set(fixture->dev, uart_emul_isr, fixture);
 	uart_irq_rx_enable(fixture->dev);
 
 	/* putting rx data will call the irq callback, if enabled */
@@ -151,10 +150,10 @@ ZTEST_F(uart_emul, test_irq_rx)
 	/* allow space for work queue to run */
 	k_yield();
 
-	zassert_mem_equal(rx_content, fixture->sample_data, SAMPLE_DATA_SIZE);
+	zassert_mem_equal(fixture->rx_content, fixture->sample_data, SAMPLE_DATA_SIZE);
 
 	/* No more data in RX buffer */
-	rc = uart_poll_in(fixture->dev, &rx_content[0]);
+	rc = uart_poll_in(fixture->dev, &fixture->rx_content[0]);
 	zassert_equal(rc, -1, "RX buffer should be empty");
 
 	uart_irq_rx_disable(fixture->dev);


### PR DESCRIPTION
The emulated UART driver's interrupt driven implementation does not behave like a real UART. The individual commits go into each addition to the driver and test suite to make it behave like a real UART :)

The PR also creates a dedicated thread for the emulated UART drivers callbacks to make it possible to test different thread priorities :) This is a prerequisite for being able to use the emulated UART to unit test the modem UART backend