### PR TITLE
soc: mimx8mm6_m4: Restore linker script

### DIFF
--- a/soc/arm/nxp_imx/mimx8mm6_m4/CMakeLists.txt
+++ b/soc/arm/nxp_imx/mimx8mm6_m4/CMakeLists.txt
@@ -13,4 +13,4 @@ if(CONFIG_OPENAMP_RSC_TABLE)
   zephyr_linker_section_configure(SECTION .resource_table KEEP INPUT ".resource_table*")
 endif()
 
-set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/linker.ld CACHE INTERNAL "")
+set(SOC_LINKER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld CACHE INTERNAL "")


### PR DESCRIPTION
For this SoC, an additional section is conditionally included on top of the default linker script for Cortex-M. Set `SOC_LINKER_SCRIPT` to the local `linker.ld`.