### PR TITLE
drivers: nrf_qspi_nor: Activate QSPI peripheral when enabling XIP

### DIFF
--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -1457,6 +1457,9 @@ void z_impl_nrf_qspi_nor_xip_enable(const struct device *dev, bool enable)
 	nrf_qspi_xip_set(NRF_QSPI, enable);
 #endif
 	qspi_lock(dev);
+	if (enable) {
+		(void)nrfx_qspi_activate(false);
+	}
 	dev_data->xip_enabled = enable;
 	qspi_unlock(dev);
 


### PR DESCRIPTION
The way that the QSPI peripheral is activated has been changed in nrfx 3.2.0. Now the peripheral is not activated during the driver initialization. Instead, the driver activates the peripheral when the first operation is requested or when `nrfx_qspi_activate()` is called. In case of XIP, the latter needs to be used, as there may be no standard operation request.

Fixes #64411