### PR TITLE
kobject: coverage: Fix LCOV_EXCL warnings

### DIFF
--- a/include/zephyr/sys/internal/kobject_internal.h
+++ b/include/zephyr/sys/internal/kobject_internal.h
@@ -88,6 +88,7 @@ void k_object_init(const void *obj);
 
 
 #else
+/* LCOV_EXCL_START */
 static inline void k_object_init(const void *obj)
 {
 	ARG_UNUSED(obj);


### PR DESCRIPTION
Eliminate gcovr '(WARNING) mismatched coverage exclusion flags.' on missing LCOV_EXCL_START around k_object_init() introduced with ae265ea96e

https://github.com/zephyrproject-rtos/zephyr/pull/63153/files#diff-f9e59e5dc6e2013cdafbd498214d5243d8f9075e2136100cb34502234bc11090L212-L219