### PR TITLE
soc: arm: Fix linker.ld depreciation warning for arduino_uno_r4_minima

### DIFF
--- a/soc/arm/renesas_ra/ra4m1/CMakeLists.txt
+++ b/soc/arm/renesas_ra/ra4m1/CMakeLists.txt
@@ -1,4 +1,4 @@
 # Copyright (c) 2023 TOKITA Hiroshi <tokita.hiroshi@fujitsu.com>
 # SPDX-License-Identifier: Apache-2.0
 
-# empty
+set(SOC_LINKER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld CACHE INTERNAL "")


### PR DESCRIPTION
Fix cmake depreciation warning on pre-defined linker.id (soc/arm/renesas_ra/ra4m1/linker.ld) used for arduino_uno_r4_minima.

~~Fix build issue with linker.ld depreciated for arduino_uno_r4_minima platform and observed on
samples/synchronization/sample.kernel.synchronization after #64544.~~

see CI build failure - 
https://github.com/zephyrproject-rtos/zephyr/actions/runs/6746158923/job/18339718127?pr=64783