### PR TITLE
hwmv2: sysbuild: include HWMv2 Kconfig in sysbuild

### DIFF
--- a/share/sysbuild/CMakeLists.txt
+++ b/share/sysbuild/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Nordic Semiconductor
+# Copyright (c) 2021-2023 Nordic Semiconductor
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -19,7 +19,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake/modules)
 # List of Zephyr and sysbuild CMake modules we need for sysbuild.
 # Note: sysbuild_kconfig will internally load kconfig CMake module.
 set(zephyr_modules extensions
-    sysbuild_extensions python west root zephyr_module boards shields
+    sysbuild_extensions python west root zephyr_module boards shields hwm_v2
     sysbuild_kconfig native_simulator_sb_extensions
   )
 

--- a/share/sysbuild/Kconfig
+++ b/share/sysbuild/Kconfig
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+rsource "Kconfig.$(HWM_SCHEME)"
+
 comment "Sysbuild image configuration"
 
 osource "$(BOARD_DIR)/Kconfig.sysbuild"

--- a/share/sysbuild/Kconfig.v1
+++ b/share/sysbuild/Kconfig.v1
@@ -1,0 +1,5 @@
+# Copyright (c) 2023 Nordic Semiconductor
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Intentionally left empty as sysbuild Kconfig doesn't support hw model v1.

--- a/share/sysbuild/Kconfig.v2
+++ b/share/sysbuild/Kconfig.v2
@@ -1,0 +1,32 @@
+# Copyright (c) 2023 Nordic Semiconductor
+#
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD
+	string
+	default "$(BOARD)"
+	help
+	  This option holds the name of the board and is used to locate the files
+	  related to the board in the source tree (under boards/).
+	  The Board is the first location where we search for a linker.ld file,
+	  if not found we look for the linker file in
+	  soc/<arch>/<family>/<series>
+
+config BOARD_REVISION
+	def_string "$BOARD_REVISION"
+	help
+	  If the BOARD has a revision field set, this is the revision.
+	  Otherwise, it is the empty string. For example, if BOARD is
+	  "plank@foo", this option will be "foo". If BOARD is "plank",
+	  this option will be the empty string.
+
+config BOARD_DEPRECATED_RELEASE
+	string
+	help
+	  This hidden option is set in the board configuration and indicates
+	  the Zephyr release that the board configuration will be removed.
+	  When set, any build for that board will generate a clearly visible
+	  deprecation warning.
+
+source "boards/Kconfig.$(HWM_SCHEME)"
+source "soc/Kconfig.$(HWM_SCHEME)"


### PR DESCRIPTION
Including HWMv2 Kconfig in sysbuild allows sysbuild to introduce
configuration options or defaults based on selected board and SoC.

