### PR TITLE
bluetooth: audio: delegator: Notify state after updating BIG_Encryption

### DIFF
--- a/subsys/bluetooth/audio/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/bap_scan_delegator.c
@@ -1335,6 +1335,11 @@ int bt_bap_scan_delegator_mod_src(const struct bt_bap_scan_delegator_mod_src_par
 		state_changed = true;
 	}
 
+	if (state->encrypt_state != param->encrypt_state) {
+		state->encrypt_state = param->encrypt_state;
+		state_changed = true;
+	}
+
 	/* Verify that the BIS sync values is acceptable for the receive state */
 	for (uint8_t i = 0U; i < state->num_subgroups; i++) {
 		const uint32_t bis_sync = param->subgroups[i].bis_sync;


### PR DESCRIPTION
If the server has synchronized to the PA and detected that the BIS is encrypted, the server writes a value of 0x01 (Broadcast_Code required) to the BIG_Encryption field of the Broadcast Receive State characteristic to request a client to provide a Broadcast_Code. In PTS BASS/SR/CP/BV-14-C test case the PTS (client) expects that the new value of the Broadcast Receive State characteristicstate will be notified, so the PTS could sent Set Broadcast_Code operation to the server.