### PR TITLE
input: split npcx generic keyboard code into input_kbd_matrix.c

### DIFF
--- a/drivers/input/Kconfig.npcx
+++ b/drivers/input/Kconfig.npcx
@@ -3,7 +3,7 @@
 # Copyright (c) 2022 Nuvoton Technology Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig INPUT_NPCX_KBD
+config INPUT_NPCX_KBD
 	bool "Nuvoton NPCX embedded controller (EC) keyboard scan driver"
 	default y
 	depends on DT_HAS_NUVOTON_NPCX_KBD_ENABLED
@@ -13,26 +13,10 @@ menuconfig INPUT_NPCX_KBD
 	  This option enables the keyboard scan driver for NPCX family of
 	  processors.
 
-if  INPUT_NPCX_KBD
-
-config INPUT_NPCX_KBD_POLL_PERIOD_MS
-	int "Keyscan NPCX Poll Period"
-	default 5
-	help
-	  Defines the poll period in msecs between between matrix scans.
-
 config INPUT_NPCX_KBD_KSO_HIGH_DRIVE
 	bool "Select quasi-bidirectional buffers for KSO pins"
 	default y
+	depends on INPUT_NPCX_KBD
 	help
 	  Select quasi-bidirectional buffers for KSO pins to reduce the
 	  low-to-high transition time.
-
-config INPUT_NPCX_KBD_POLL_COL_OUTPUT_SETTLE_TIME_US
-	int "keyboard matrix poll column output settle time"
-	default 50
-	help
-	  Delay (us) between setting column output and waiting for it
-	  to settle
-
-endif # INPUT_NPCX_KBD

--- a/drivers/input/input_kbd_matrix.c
+++ b/drivers/input/input_kbd_matrix.c
@@ -1,23 +1,298 @@
 /*
+ * Copyright 2019 Intel Corporation
+ * Copyright 2022 Nuvoton Technology Corporation.
  * Copyright 2023 Google LLC
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <zephyr/device.h>
+#include <zephyr/input/input.h>
 #include <zephyr/kernel.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+
+#define LOG_LEVEL CONFIG_INPUT_LOG_LEVEL
+LOG_MODULE_REGISTER(input_kbd_matrix);
 
 #include "input_kbd_matrix.h"
 
-int input_kbd_matrix_common_init(const struct device *dev)
+#define INPUT_KBD_MATRIX_ROW_MASK UINT8_MAX
+
+void input_kbd_matrix_poll_start(const struct device *dev)
+{
+	struct input_kbd_matrix_common_data *data = dev->data;
+
+	k_sem_give(&data->poll_lock);
+}
+
+static bool input_kbd_matrix_ghosting(const struct device *dev)
+{
+	const struct input_kbd_matrix_common_config *cfg = dev->config;
+	const uint8_t *state = cfg->matrix_new_state;
+
+	/*
+	 * Matrix keyboard designs are suceptible to ghosting.
+	 * An extra key appears to be pressed when 3 keys belonging to the same
+	 * block are pressed. For example, in the following block:
+	 *
+	 * . . w . q .
+	 * . . . . . .
+	 * . . . . . .
+	 * . . m . a .
+	 *
+	 * the key m would look as pressed if the user pressed keys w, q and a
+	 * simultaneously. A block can also be formed, with not adjacent
+	 * columns.
+	 */
+	for (int c = 0; c < cfg->col_size; c++) {
+		if (!state[c]) {
+			continue;
+		}
+
+		for (int c_next = c + 1; c_next < cfg->col_size; c_next++) {
+			/*
+			 * We AND the columns to detect a "block". This is an
+			 * indication of ghosting, due to current flowing from
+			 * a key which was never pressed. In our case, current
+			 * flowing is a bit set to 1 as we flipped the bits
+			 * when the matrix was scanned. Now we OR the colums
+			 * using z&(z-1) which is non-zero only if z has more
+			 * than one bit set.
+			 */
+			uint8_t common_row_bits = state[c] & state[c_next];
+
+			if (common_row_bits & (common_row_bits - 1)) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+static bool input_kbd_matrix_scan(const struct device *dev)
 {
 	const struct input_kbd_matrix_common_config *cfg = dev->config;
 	const struct input_kbd_matrix_api *api = &cfg->api;
-	struct input_kbd_matrix_common_data *const data = dev->data;
+	int row;
+	uint8_t key_event = 0U;
+
+	for (int col = 0; col < cfg->col_size; col++) {
+		api->drive_column(dev, col);
+
+		/* Allow the matrix to stabilize before reading it */
+		k_busy_wait(cfg->settle_time_us);
+
+		row = api->read_row(dev) & INPUT_KBD_MATRIX_ROW_MASK;
+		cfg->matrix_new_state[col] = row;
+		key_event |= row;
+	}
+
+	api->drive_column(dev, INPUT_KBD_MATRIX_COLUMN_DRIVE_NONE);
+
+	return key_event != 0U;
+}
+
+static void input_kbd_matrix_update_state(const struct device *dev)
+{
+	const struct input_kbd_matrix_common_config *cfg = dev->config;
+	struct input_kbd_matrix_common_data *data = dev->data;
+	uint8_t *matrix_new_state = cfg->matrix_new_state;
+	uint32_t cycles_now = k_cycle_get_32();
+	uint8_t row_changed;
+	uint8_t deb_col;
+
+	data->scan_clk_cycle[data->scan_cycles_idx] = cycles_now;
+
+	/*
+	 * The intent of this loop is to gather information related to key
+	 * changes.
+	 */
+	for (int c = 0; c < cfg->col_size; c++) {
+		/* Check if there was an update from the previous scan */
+		row_changed = matrix_new_state[c] ^ cfg->matrix_previous_state[c];
+
+		if (!row_changed) {
+			continue;
+		}
+
+		for (int r = 0; r < cfg->row_size; r++) {
+			uint8_t cyc_idx = c * cfg->row_size + r;
+
+			/*
+			 * Index all they keys that changed for each row in
+			 * order to debounce each key in terms of it
+			 */
+			if (row_changed & BIT(r)) {
+				cfg->scan_cycle_idx[cyc_idx] = data->scan_cycles_idx;
+			}
+		}
+
+		cfg->matrix_unstable_state[c] |= row_changed;
+		cfg->matrix_previous_state[c] = matrix_new_state[c];
+	}
+
+	for (int c = 0; c < cfg->col_size; c++) {
+		deb_col = cfg->matrix_unstable_state[c];
+
+		if (!deb_col) {
+			continue;
+		}
+
+		/* Debouncing for each row key occurs here */
+		for (int r = 0; r < cfg->row_size; r++) {
+			uint8_t mask = BIT(r);
+			uint8_t row_bit = matrix_new_state[c] & mask;
+
+			/* Continue if we already debounce a key */
+			if (!(deb_col & mask)) {
+				continue;
+			}
+
+			uint8_t cyc_idx = c * cfg->row_size + r;
+			uint8_t scan_cyc_idx = cfg->scan_cycle_idx[cyc_idx];
+			uint8_t scan_clk_cycle = data->scan_clk_cycle[scan_cyc_idx];
+
+			/* Convert the clock cycle differences to usec */
+			uint32_t debt = k_cyc_to_us_floor32(cycles_now - scan_clk_cycle);
+
+			/* Does the key requires more time to be debounced? */
+			if (debt < (row_bit ? cfg->debounce_down_ms : cfg->debounce_up_ms)) {
+				/* Need more time to debounce */
+				continue;
+			}
+
+			cfg->matrix_unstable_state[c] &= ~row_bit;
+
+			/* Check if there was a change in the stable state */
+			if ((cfg->matrix_stable_state[c] & mask) == row_bit) {
+				/* Key state did not change */
+				continue;
+			}
+
+			/*
+			 * The current row has been debounced, therefore update
+			 * the stable state. Then, proceed to notify the
+			 * application about the keys pressed.
+			 */
+			cfg->matrix_stable_state[c] ^= mask;
+
+			input_report_abs(dev, INPUT_ABS_X, c, false, K_FOREVER);
+			input_report_abs(dev, INPUT_ABS_Y, r, false, K_FOREVER);
+			input_report_key(dev, INPUT_BTN_TOUCH, row_bit, true, K_FOREVER);
+		}
+	}
+}
+
+static bool input_kbd_matrix_check_key_events(const struct device *dev)
+{
+	const struct input_kbd_matrix_common_config *cfg = dev->config;
+	struct input_kbd_matrix_common_data *data = dev->data;
+	bool key_pressed;
+
+	if (++data->scan_cycles_idx >= INPUT_KBD_MATRIX_SCAN_OCURRENCES) {
+		data->scan_cycles_idx = 0U;
+	}
+
+	/* Scan the matrix */
+	key_pressed = input_kbd_matrix_scan(dev);
+
+	for (int c = 0; c < cfg->col_size; c++) {
+		LOG_DBG("U%x, P%x, N%x",
+			cfg->matrix_unstable_state[c],
+			cfg->matrix_previous_state[c],
+			cfg->matrix_new_state[c]);
+	}
+
+	/* Abort if ghosting is detected */
+	if (cfg->ghostkey_check && input_kbd_matrix_ghosting(dev)) {
+		return key_pressed;
+	}
+
+	input_kbd_matrix_update_state(dev);
+
+	return key_pressed;
+}
+
+static void input_kbd_matrix_poll(const struct device *dev)
+{
+	const struct input_kbd_matrix_common_config *cfg = dev->config;
+	k_timepoint_t poll_time_end = sys_timepoint_calc(K_MSEC(cfg->poll_timeout_ms));
+	uint32_t current_cycles;
+	uint32_t cycles_diff;
+	uint32_t wait_period_us;
+
+	while (true) {
+		uint32_t start_period_cycles = k_cycle_get_32();
+
+		if (input_kbd_matrix_check_key_events(dev)) {
+			poll_time_end = sys_timepoint_calc(K_MSEC(cfg->poll_timeout_ms));
+		} else if (sys_timepoint_expired(poll_time_end)) {
+			break;
+		}
+
+		/*
+		 * Subtract the time invested from the sleep period in order to
+		 * compensate for the time invested in debouncing a key
+		 */
+		current_cycles = k_cycle_get_32();
+		cycles_diff = current_cycles - start_period_cycles;
+		wait_period_us = cfg->poll_period_us - k_cyc_to_us_floor32(cycles_diff);
+
+		/* Wait for at least 1ms */
+		if (wait_period_us < USEC_PER_MSEC) {
+			wait_period_us = USEC_PER_MSEC;
+		}
+
+		/*
+		 * Wait period results in a larger number when current cycles
+		 * counter wrap. In this case, the whole poll period is used
+		 */
+		if (wait_period_us > cfg->poll_period_us) {
+			LOG_DBG("wait_period_us: %u", wait_period_us);
+
+			wait_period_us = cfg->poll_period_us;
+		}
+
+		/* Allow other threads to run while we sleep */
+		k_usleep(wait_period_us);
+	}
+}
+
+static void input_kbd_matrix_polling_thread(void *arg1, void *unused2, void *unused3)
+{
+	const struct device *dev = arg1;
+	const struct input_kbd_matrix_common_config *cfg = dev->config;
+	const struct input_kbd_matrix_api *api = &cfg->api;
+	struct input_kbd_matrix_common_data *data = dev->data;
+
+	ARG_UNUSED(unused2);
+	ARG_UNUSED(unused3);
+
+	while (true) {
+		api->drive_column(dev, INPUT_KBD_MATRIX_COLUMN_DRIVE_ALL);
+		api->set_detect_mode(dev, true);
+
+		k_sem_take(&data->poll_lock, K_FOREVER);
+		LOG_DBG("Start KB scan");
+
+		/* Disable interrupt of KSI pins and start polling */
+		api->set_detect_mode(dev, false);
+
+		input_kbd_matrix_poll(dev);
+	}
+}
+
+int input_kbd_matrix_common_init(const struct device *dev)
+{
+	struct input_kbd_matrix_common_data *data = dev->data;
+
+	k_sem_init(&data->poll_lock, 0, 1);
 
 	k_thread_create(&data->thread, data->thread_stack,
 			CONFIG_INPUT_KBD_MATRIX_THREAD_STACK_SIZE,
-			api->polling_thread, (void *)dev, NULL, NULL,
+			input_kbd_matrix_polling_thread, (void *)dev, NULL, NULL,
 			K_PRIO_COOP(4), 0, K_NO_WAIT);
 
 	k_thread_name_set(&data->thread, dev->name);

--- a/drivers/input/input_npcx_kbd.c
+++ b/drivers/input/input_npcx_kbd.c
@@ -12,24 +12,16 @@
 
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/pinctrl.h>
-#include <zephyr/input/input.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 
 #include <soc.h>
 #define LOG_LEVEL CONFIG_INPUT_LOG_LEVEL
 LOG_MODULE_REGISTER(input_npcx_kbd);
 
-#define KEYBOARD_COLUMN_DRIVE_ALL  -2
-#define KEYBOARD_COLUMN_DRIVE_NONE -1
-
-/* Number of tracked scan times */
-#define SCAN_OCURRENCES 30U
-
-#define KSCAN_ROW_SIZE DT_INST_PROP(0, row_size)
-#define KSCAN_COL_SIZE DT_INST_PROP(0, col_size)
-
-#define HAS_GHOSTING_ENABLED !DT_INST_PROP(0, no_ghostkey_check)
+#define ROW_SIZE DT_INST_PROP(0, row_size)
 
 /* Driver config */
 struct input_npcx_kbd_config {
@@ -44,31 +36,13 @@ struct input_npcx_kbd_config {
 	int irq;
 	/* Size of keyboard inputs-wui mapping array */
 	int wui_size;
-	uint8_t row_size;
-	uint8_t col_size;
-	uint32_t deb_time_press;
-	uint32_t deb_time_rel;
 	/* Mapping table between keyboard inputs and wui */
 	struct npcx_wui wui_maps[];
 };
 
 struct input_npcx_kbd_data {
 	struct input_kbd_matrix_common_data common;
-	int64_t poll_timeout_us;
-	uint32_t poll_period_us;
-	uint8_t matrix_stable_state[KSCAN_COL_SIZE];
-	uint8_t matrix_unstable_state[KSCAN_COL_SIZE];
-	uint8_t matrix_previous_state[KSCAN_COL_SIZE];
-	uint8_t matrix_new_state[KSCAN_COL_SIZE];
-	/* Index in to the scan_clock_cycle to indicate start of debouncing */
-	uint8_t scan_cycle_idx[KSCAN_COL_SIZE * KSCAN_ROW_SIZE];
-	struct miwu_callback ksi_callback[KSCAN_ROW_SIZE];
-	/* Track previous "elapsed clock cycles" per matrix scan. This
-	 * is used to calculate the debouncing time for every key
-	 */
-	uint8_t scan_clk_cycle[SCAN_OCURRENCES];
-	struct k_sem poll_lock;
-	uint8_t scan_cycles_idx;
+	struct miwu_callback ksi_callback[ROW_SIZE];
 };
 
 INPUT_KBD_STRUCT_CHECK(struct input_npcx_kbd_config, struct input_npcx_kbd_data);
@@ -77,40 +51,39 @@ INPUT_KBD_STRUCT_CHECK(struct input_npcx_kbd_config, struct input_npcx_kbd_data)
 static void input_npcx_kbd_ksi_isr(const struct device *dev, struct npcx_wui *wui)
 {
 	ARG_UNUSED(wui);
-	struct input_npcx_kbd_data *const data = dev->data;
 
-	k_sem_give(&data->poll_lock);
+	input_kbd_matrix_poll_start(dev);
 }
 
-static int input_npcx_kbd_resume_detection(const struct device *dev, bool resume)
+static void input_npcx_kbd_set_detect_mode(const struct device *dev, bool enabled)
 {
 	const struct input_npcx_kbd_config *const config = dev->config;
 
-	if (resume) {
+	if (enabled) {
 		irq_enable(config->irq);
 	} else {
 		irq_disable(config->irq);
 	}
-
-	return 0;
 }
 
-static int input_npcx_kbd_drive_column(const struct device *dev, int col)
+static void input_npcx_kbd_drive_column(const struct device *dev, int col)
 {
 	const struct input_npcx_kbd_config *config = dev->config;
+	const struct input_kbd_matrix_common_config *common = &config->common;
 	struct kbs_reg *const inst = config->base;
 	uint32_t mask;
 
-	if (col >= config->col_size) {
-		return -EINVAL;
+	if (col >= common->col_size) {
+		LOG_ERR("invalid column: %d", col);
+		return;
 	}
 
-	if (col == KEYBOARD_COLUMN_DRIVE_NONE) {
+	if (col == INPUT_KBD_MATRIX_COLUMN_DRIVE_NONE) {
 		/* Drive all lines to high: key detection is disabled */
 		mask = ~0;
-	} else if (col == KEYBOARD_COLUMN_DRIVE_ALL) {
+	} else if (col == INPUT_KBD_MATRIX_COLUMN_DRIVE_ALL) {
 		/* Drive all lines to low for detection any key press */
-		mask = ~(BIT(config->col_size) - 1);
+		mask = ~BIT_MASK(common->col_size);
 	} else {
 		/*
 		 * Drive one line to low for determining which key's state
@@ -123,273 +96,21 @@ static int input_npcx_kbd_drive_column(const struct device *dev, int col)
 
 	inst->KBSOUT0 = (mask & 0xFFFF);
 	inst->KBSOUT1 = ((mask >> 16) & 0x03);
-
-	return 0;
 }
 
 static int input_npcx_kbd_read_row(const struct device *dev)
 {
 	const struct input_npcx_kbd_config *config = dev->config;
+	const struct input_kbd_matrix_common_config *common = &config->common;
 	struct kbs_reg *const inst = config->base;
 	int val;
 
 	val = inst->KBSIN;
 
 	/* 1 means key pressed, otherwise means key released. */
-	val = (~val & (BIT(config->row_size) - 1));
+	val = ~val & BIT_MASK(common->row_size);
 
 	return val;
-}
-
-static bool is_matrix_ghosting(const struct device *dev, const uint8_t *state)
-{
-	const struct input_npcx_kbd_config *const config = dev->config;
-
-	/*
-	 * Matrix keyboard designs are suceptible to ghosting.
-	 * An extra key appears to be pressed when 3 keys belonging to the same
-	 * block are pressed. For example, in the following block:
-	 *
-	 * . . w . q .
-	 * . . . . . .
-	 * . . . . . .
-	 * . . m . a .
-	 *
-	 * the key m would look as pressed if the user pressed keys w, q and a
-	 * simultaneously. A block can also be formed, with not adjacent
-	 * columns.
-	 */
-	for (int c = 0; c < config->col_size; c++) {
-		if (!state[c]) {
-			continue;
-		}
-
-		for (int c_next = c + 1; c_next < config->col_size; c_next++) {
-			/*
-			 * We AND the columns to detect a "block". This is an
-			 * indication of ghosting, due to current flowing from
-			 * a key which was never pressed. In our case, current
-			 * flowing is a bit set to 1 as we flipped the bits
-			 * when the matrix was scanned. Now we OR the colums
-			 * using z&(z-1) which is non-zero only if z has more
-			 * than one bit set.
-			 */
-			uint8_t common_row_bits = state[c] & state[c_next];
-
-			if (common_row_bits & (common_row_bits - 1)) {
-				return true;
-			}
-		}
-	}
-
-	return false;
-}
-
-static bool read_keyboard_matrix(const struct device *dev, uint8_t *new_state)
-{
-	const struct input_npcx_kbd_config *const config = dev->config;
-	int row;
-	uint8_t key_event = 0U;
-
-	for (int col = 0; col < config->col_size; col++) {
-		input_npcx_kbd_drive_column(dev, col);
-
-		/* Allow the matrix to stabilize before reading it */
-		k_busy_wait(CONFIG_INPUT_NPCX_KBD_POLL_COL_OUTPUT_SETTLE_TIME_US);
-
-		row = input_npcx_kbd_read_row(dev);
-		new_state[col] = row & 0xFF;
-		key_event |= row;
-	}
-
-	input_npcx_kbd_drive_column(dev, KEYBOARD_COLUMN_DRIVE_NONE);
-
-	return key_event != 0U;
-}
-
-static void update_matrix_state(const struct device *dev, uint8_t *matrix_new_state)
-{
-	const struct input_npcx_kbd_config *const config = dev->config;
-	struct input_npcx_kbd_data *const data = dev->data;
-	uint32_t cycles_now = k_cycle_get_32();
-	uint8_t row_changed = 0U;
-	uint8_t deb_col;
-
-	data->scan_clk_cycle[data->scan_cycles_idx] = cycles_now;
-
-	/*
-	 * The intent of this loop is to gather information related to key
-	 * changes.
-	 */
-	for (int c = 0; c < config->col_size; c++) {
-		/* Check if there was an update from the previous scan */
-		row_changed = matrix_new_state[c] ^ data->matrix_previous_state[c];
-
-		if (!row_changed) {
-			continue;
-		}
-
-		for (int r = 0; r < config->row_size; r++) {
-			uint8_t cyc_idx = c * config->row_size + r;
-
-			/*
-			 * Index all they keys that changed for each row in
-			 * order to debounce each key in terms of it
-			 */
-			if (row_changed & BIT(r)) {
-				data->scan_cycle_idx[cyc_idx] = data->scan_cycles_idx;
-			}
-		}
-
-		data->matrix_unstable_state[c] |= row_changed;
-		data->matrix_previous_state[c] = matrix_new_state[c];
-	}
-
-	for (int c = 0; c < config->col_size; c++) {
-		deb_col = data->matrix_unstable_state[c];
-
-		if (!deb_col) {
-			continue;
-		}
-
-		/* Debouncing for each row key occurs here */
-		for (int r = 0; r < config->row_size; r++) {
-			uint8_t mask = BIT(r);
-			uint8_t row_bit = matrix_new_state[c] & mask;
-
-			/* Continue if we already debounce a key */
-			if (!(deb_col & mask)) {
-				continue;
-			}
-
-			uint8_t cyc_idx = c * config->row_size + r;
-			/* Convert the clock cycle differences to usec */
-			uint32_t debt = k_cyc_to_us_floor32(
-				cycles_now - data->scan_clk_cycle[data->scan_cycle_idx[cyc_idx]]);
-
-			/* Does the key requires more time to be debounced? */
-			if (debt < (row_bit ? config->deb_time_press : config->deb_time_rel)) {
-				/* Need more time to debounce */
-				continue;
-			}
-
-			data->matrix_unstable_state[c] &= ~row_bit;
-
-			/* Check if there was a change in the stable state */
-			if ((data->matrix_stable_state[c] & mask) == row_bit) {
-				/* Key state did not change */
-				continue;
-			}
-
-			/*
-			 * The current row has been debounced, therefore update
-			 * the stable state. Then, proceed to notify the
-			 * application about the keys pressed.
-			 */
-			data->matrix_stable_state[c] ^= mask;
-
-			input_report_abs(dev, INPUT_ABS_X, c, false, K_FOREVER);
-			input_report_abs(dev, INPUT_ABS_Y, r, false, K_FOREVER);
-			input_report_key(dev, INPUT_BTN_TOUCH, row_bit, true, K_FOREVER);
-		}
-	}
-}
-
-static bool check_key_events(const struct device *dev)
-{
-	const struct input_npcx_kbd_config *const config = dev->config;
-	struct input_npcx_kbd_data *const data = dev->data;
-	uint8_t *matrix_new_state = data->matrix_new_state;
-	bool key_pressed = false;
-
-	if (++data->scan_cycles_idx >= SCAN_OCURRENCES) {
-		data->scan_cycles_idx = 0U;
-	}
-
-	/* Scan the matrix */
-	key_pressed = read_keyboard_matrix(dev, matrix_new_state);
-
-	for (int c = 0; c < config->col_size; c++) {
-		LOG_DBG("U%x, P%x, N%x", data->matrix_unstable_state[c],
-			data->matrix_previous_state[c], matrix_new_state[c]);
-	}
-
-	/* Abort if ghosting is detected */
-	if (HAS_GHOSTING_ENABLED && is_matrix_ghosting(dev, matrix_new_state)) {
-		return key_pressed;
-	}
-
-	update_matrix_state(dev, matrix_new_state);
-
-	return key_pressed;
-}
-
-static void kbd_matrix_poll(const struct device *dev)
-{
-	struct input_npcx_kbd_data *const data = dev->data;
-	k_timepoint_t poll_time_end = sys_timepoint_calc(K_USEC(data->poll_timeout_us));
-	uint32_t current_cycles;
-	uint32_t cycles_diff;
-	uint32_t wait_period;
-
-	while (true) {
-		uint32_t start_period_cycles = k_cycle_get_32();
-
-		if (check_key_events(dev)) {
-			poll_time_end = sys_timepoint_calc(K_USEC(data->poll_timeout_us));
-		} else if (sys_timepoint_expired(poll_time_end)) {
-			break;
-		}
-
-		/*
-		 * Subtract the time invested from the sleep period in order to
-		 * compensate for the time invested in debouncing a key
-		 */
-		current_cycles = k_cycle_get_32();
-		cycles_diff = current_cycles - start_period_cycles;
-		wait_period = data->poll_period_us - k_cyc_to_us_floor32(cycles_diff);
-
-		/* Override wait_period in case it is less than 1 ms */
-		if (wait_period < USEC_PER_MSEC) {
-			wait_period = USEC_PER_MSEC;
-		}
-
-		/*
-		 * Wait period results in a larger number when current cycles
-		 * counter wrap. In this case, the whole poll period is used
-		 */
-		if (wait_period > data->poll_period_us) {
-			LOG_DBG("wait_period: %u", wait_period);
-
-			wait_period = data->poll_period_us;
-		}
-
-		/* Allow other threads to run while we sleep */
-		k_usleep(wait_period);
-	}
-}
-
-static void kbd_matrix_polling_thread(void *dummy1, void *dummy2, void *dummy3)
-{
-	const struct device *dev = dummy1;
-	struct input_npcx_kbd_data *const data = dev->data;
-
-	ARG_UNUSED(dummy2);
-	ARG_UNUSED(dummy3);
-
-	while (true) {
-		/* Enable interrupt of KSI pins */
-		input_npcx_kbd_resume_detection(dev, true);
-
-		input_npcx_kbd_drive_column(dev, KEYBOARD_COLUMN_DRIVE_ALL);
-		k_sem_take(&data->poll_lock, K_FOREVER);
-		LOG_DBG("Start KB scan");
-
-		/* Disable interrupt of KSI pins and start polling */
-		input_npcx_kbd_resume_detection(dev, false);
-
-		kbd_matrix_poll(dev);
-	}
 }
 
 static void input_npcx_kbd_init_ksi_wui_callback(const struct device *dev,
@@ -415,6 +136,7 @@ static int input_npcx_kbd_init(const struct device *dev)
 {
 	const struct device *clk_dev = DEVICE_DT_GET(NPCX_CLK_CTRL_NODE);
 	const struct input_npcx_kbd_config *const config = dev->config;
+	const struct input_kbd_matrix_common_config *common = &config->common;
 	struct input_npcx_kbd_data *const data = dev->data;
 	struct kbs_reg *const inst = config->base;
 	int ret;
@@ -428,6 +150,7 @@ static int input_npcx_kbd_init(const struct device *dev)
 	ret = clock_control_on(clk_dev, (clock_control_subsys_t)&config->clk_cfg);
 	if (ret < 0) {
 		LOG_ERR("Turn on KBSCAN clock fail %d", ret);
+		return -EIO;
 	}
 
 	/* Pull-up KBSIN0-7 internally */
@@ -453,10 +176,15 @@ static int input_npcx_kbd_init(const struct device *dev)
 	}
 
 	/* Drive all column lines to low for detection any key press */
-	input_npcx_kbd_drive_column(dev, KEYBOARD_COLUMN_DRIVE_NONE);
+	input_npcx_kbd_drive_column(dev, INPUT_KBD_MATRIX_COLUMN_DRIVE_NONE);
+
+	if (common->row_size != ROW_SIZE) {
+		LOG_ERR("Unexpected ROW_SIZE: %d != %d", common->row_size, ROW_SIZE);
+		return -EINVAL;
+	}
 
 	/* Configure wake-up input and callback for keyboard input signal */
-	for (int i = 0; i < config->row_size; i++) {
+	for (int i = 0; i < common->row_size; i++) {
 		input_npcx_kbd_init_ksi_wui_callback(
 				dev, &data->ksi_callback[i], &config->wui_maps[i],
 				input_npcx_kbd_ksi_isr);
@@ -469,20 +197,17 @@ static int input_npcx_kbd_init(const struct device *dev)
 		return ret;
 	}
 
-	/* Initialize semaphore used by keyboard scan task and driver */
-	k_sem_init(&data->poll_lock, 0, 1);
-
-	/* Time figures are transformed from msec to usec */
-	data->poll_period_us = (uint32_t)(CONFIG_INPUT_NPCX_KBD_POLL_PERIOD_MS * USEC_PER_MSEC);
-	data->poll_timeout_us = 100 * USEC_PER_MSEC;
-
 	return input_kbd_matrix_common_init(dev);
 }
 
 PINCTRL_DT_INST_DEFINE(0);
 
+INPUT_KBD_MATRIX_DT_INST_DEFINE(0);
+
 static const struct input_kbd_matrix_api npcx_kbd_api = {
-	.polling_thread = kbd_matrix_polling_thread,
+	.drive_column = input_npcx_kbd_drive_column,
+	.read_row = input_npcx_kbd_read_row,
+	.set_detect_mode = input_npcx_kbd_set_detect_mode,
 };
 
 static const struct input_npcx_kbd_config npcx_kbd_cfg = {
@@ -493,10 +218,6 @@ static const struct input_npcx_kbd_config npcx_kbd_cfg = {
 	.irq = DT_INST_IRQN(0),
 	.wui_size = NPCX_DT_WUI_ITEMS_LEN(0),
 	.wui_maps = NPCX_DT_WUI_ITEMS_LIST(0),
-	.row_size = KSCAN_ROW_SIZE,
-	.col_size = KSCAN_COL_SIZE,
-	.deb_time_press = DT_INST_PROP(0, debounce_down_ms),
-	.deb_time_rel = DT_INST_PROP(0, debounce_up_ms),
 };
 
 static struct input_npcx_kbd_data npcx_kbd_data;
@@ -507,3 +228,5 @@ DEVICE_DT_INST_DEFINE(0, input_npcx_kbd_init, NULL,
 
 BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 1,
 	     "only one nuvoton,npcx-kbd compatible node can be supported");
+BUILD_ASSERT(IN_RANGE(DT_INST_PROP(0, row_size), 1, 8), "invalid row-size");
+BUILD_ASSERT(IN_RANGE(DT_INST_PROP(0, col_size), 1, 18), "invalid col-size");

--- a/dts/bindings/input/kbd-matrix-common.yaml
+++ b/dts/bindings/input/kbd-matrix-common.yaml
@@ -4,3 +4,55 @@
 description: Keyboard matrix device
 
 include: base.yaml
+
+properties:
+  row-size:
+    type: int
+    required: true
+    description: |
+      The number of rows in the keyboard matrix.
+
+  col-size:
+    type: int
+    required: true
+    description: |
+      The number of column in the keyboard matrix.
+
+  poll-period-ms:
+    type: int
+    default: 5
+    description: |
+      Defines the poll period in msecs between between matrix scans. Defaults
+      to 5ms if unsepcified.
+
+  poll-timeout-ms:
+    type: int
+    default: 100
+    description: |
+      How long to wait before going from polling back to idle state. Defaults
+      to 100ms if unspecified.
+
+  debounce-down-ms:
+    type: int
+    default: 10
+    description: |
+      Debouncing time for a key press event. Defaults to 10ms if unspecified.
+
+  debounce-up-ms:
+    type: int
+    default: 20
+    description: |
+      Debouncing time for a key release event. Defaults to 20ms if unspecified.
+
+  settle-time-us:
+    type: int
+    default: 50
+    description: |
+      Delay between setting column output and reading the row values. Defaults
+      to 50us if unspecified.
+
+  no-ghostkey-check:
+    type: boolean
+    description: |
+        Ignore the ghost key checking in the driver if the diodes are used
+        in the matrix hardware.

--- a/dts/bindings/input/nuvoton,npcx-kbd.yaml
+++ b/dts/bindings/input/nuvoton,npcx-kbd.yaml
@@ -29,35 +29,3 @@ properties:
         For example the WUI mapping on 8 KSI pads would be
            wui-maps = <&wui_io30 &wui_io31 &wui_io27 &wui_io26
                        &wui_io25 &wui_io24 &wui_io23 &wui_io22>;
-
-  row-size:
-    type: int
-    default: 8
-    required: true
-    description: |
-        The row size is used in the keyboard matrix.
-        valid range: 1 - 8
-
-  col-size:
-    type: int
-    default: 18
-    required: true
-    description: |
-        The column size is used in the keyboard matrix.
-        valid range: 1 - 18
-
-  debounce-down-ms:
-    type: int
-    default: 10
-    description: Determines the time in msecs for debouncing a key press.
-
-  debounce-up-ms:
-    type: int
-    default: 20
-    description: Determines the time in msecs for debouncing a key release.
-
-  no-ghostkey-check:
-    type: boolean
-    description: |
-        Ignore the ghost key checking in the driver if the diodes are used
-        in the matrix hardware.


### PR DESCRIPTION
Continuation of https://github.com/zephyrproject-rtos/zephyr/pull/64456, this moves the common code out of the NPCX driver.

It is essentially a redesign of https://github.com/zephyrproject-rtos/zephyr/issues/52355 https://github.com/zephyrproject-rtos/zephyr/pull/42923, and very much implements the same API abstraction, but in the form of an internal support library.

I've shuffled few things from the internal proposal but that's pretty much it, and should be usable to move the ITE and MCHP drivers as well (which are still under kscan). Converting those drivers is coming next, but this is the only one I can actually test on hardware, so I'll start working on the other two once this is in.

Many thanks for @ChiHuaL for the initial design, the driver was basically already ready to be sliced apart. Good stuff.

---

Move all the generic code from the Nuvoton NPCX keyboard scanning driver into input_kbd_matrix.c. While doing that convert few configs into devicetree properties and tweak few other things to enable the generic code to support multiple instances.

This is limited to 8 rows for now, and that's fine for all the current in-tree drivers, the limit could be removed down the road but this should be fine for now, added few generic build checks to make sure a driver does not go over the limit, as well and some more implementation specific checks.