### PR TITLE
input: fix few incorrect reset pin polarity instances

### DIFF
--- a/boards/shields/g1120b0mipi/g1120b0mipi.overlay
+++ b/boards/shields/g1120b0mipi/g1120b0mipi.overlay
@@ -33,7 +33,7 @@
 		compatible = "focaltech,ft5336";
 		reg = <0x38>;
 		int-gpios = <&nxp_mipi_connector 29 GPIO_ACTIVE_LOW>;
-		reset-gpios = <&nxp_mipi_connector 28 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&nxp_mipi_connector 28 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/boards/shields/rk055hdmipi4m/rk055hdmipi4m.overlay
+++ b/boards/shields/rk055hdmipi4m/rk055hdmipi4m.overlay
@@ -30,7 +30,7 @@
 		compatible = "goodix,gt911";
 		reg = <0x5d>;
 		irq-gpios = <&nxp_mipi_connector 29 GPIO_ACTIVE_HIGH>;
-		reset-gpios = <&nxp_mipi_connector 28 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&nxp_mipi_connector 28 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/boards/shields/rk055hdmipi4ma0/rk055hdmipi4ma0.overlay
+++ b/boards/shields/rk055hdmipi4ma0/rk055hdmipi4ma0.overlay
@@ -30,7 +30,7 @@
 		compatible = "goodix,gt911";
 		reg = <0x5d>;
 		irq-gpios = <&nxp_mipi_connector 29 GPIO_ACTIVE_HIGH>;
-		reset-gpios = <&nxp_mipi_connector 28 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&nxp_mipi_connector 28 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/doc/releases/migration-guide-3.6.rst
+++ b/doc/releases/migration-guide-3.6.rst
@@ -49,5 +49,10 @@ Other Subsystems
   :kconfig:option:`CONFIG_CRC`, this was previously erroneously selected if MCUmgr was enabled,
   when for non-serial transports it was not needed.
 
+* Touchscreen drivers :dtcompatible:`focaltech,ft5336` and
+  :dtcompatible:`goodix,gt911` were using the incorrect polarity for the
+  respective ``reset-gpios``. This has been fixed so those signals now have to
+  be flagged as :c:macro:`GPIO_ACTIVE_LOW` in the devicetree.`
+
 Recommended Changes
 *******************

--- a/drivers/input/input_cst816s.c
+++ b/drivers/input/input_cst816s.c
@@ -173,12 +173,11 @@ static void cst816s_chip_reset(const struct device *dev)
 	int ret;
 
 	if (gpio_is_ready_dt(&config->rst_gpio)) {
-		ret = gpio_pin_configure_dt(&config->rst_gpio, GPIO_OUTPUT_INACTIVE);
+		ret = gpio_pin_configure_dt(&config->rst_gpio, GPIO_OUTPUT_ACTIVE);
 		if (ret < 0) {
 			LOG_ERR("Could not configure reset GPIO pin");
 			return;
 		}
-		gpio_pin_set_dt(&config->rst_gpio, 1);
 		k_msleep(CST816S_RESET_DELAY);
 		gpio_pin_set_dt(&config->rst_gpio, 0);
 		k_msleep(CST816S_WAIT_DELAY);

--- a/drivers/input/input_ft5336.c
+++ b/drivers/input/input_ft5336.c
@@ -153,8 +153,8 @@ static int ft5336_init(const struct device *dev)
 	k_work_init(&data->work, ft5336_work_handler);
 
 	if (config->reset_gpio.port != NULL) {
-		/* Enable reset GPIO, and pull down */
-		r = gpio_pin_configure_dt(&config->reset_gpio, GPIO_OUTPUT_INACTIVE);
+		/* Enable reset GPIO and assert reset */
+		r = gpio_pin_configure_dt(&config->reset_gpio, GPIO_OUTPUT_ACTIVE);
 		if (r < 0) {
 			LOG_ERR("Could not enable reset GPIO");
 			return r;
@@ -166,7 +166,7 @@ static int ft5336_init(const struct device *dev)
 		 */
 		k_sleep(K_MSEC(5));
 		/* Pull reset pin high to complete reset sequence */
-		r = gpio_pin_set_dt(&config->reset_gpio, 1);
+		r = gpio_pin_set_dt(&config->reset_gpio, 0);
 		if (r < 0) {
 			return r;
 		}

--- a/drivers/input/input_gt911.c
+++ b/drivers/input/input_gt911.c
@@ -230,7 +230,7 @@ static int gt911_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	r = gpio_pin_configure_dt(&config->rst_gpio, GPIO_OUTPUT_INACTIVE);
+	r = gpio_pin_configure_dt(&config->rst_gpio, GPIO_OUTPUT_ACTIVE);
 	if (r < 0) {
 		LOG_ERR("Could not configure reset GPIO pin");
 		return r;
@@ -253,10 +253,10 @@ static int gt911_init(const struct device *dev)
 	/* Delay at least 10 ms after power on before we configure gt911 */
 	k_sleep(K_MSEC(20));
 	/* reset the device and confgiure the addr mode0 */
-	gpio_pin_set_dt(&config->rst_gpio, 0);
+	gpio_pin_set_dt(&config->rst_gpio, 1);
 	/* hold down at least 1us, 1ms here */
 	k_sleep(K_MSEC(1));
-	gpio_pin_set_dt(&config->rst_gpio, 1);
+	gpio_pin_set_dt(&config->rst_gpio, 0);
 	/* hold down at least 5ms. This is the point the INT pin must be low. */
 	k_sleep(K_MSEC(5));
 	/* hold down 50ms to make sure the address available */


### PR DESCRIPTION
Hi, fix reset pin usage in a few input touchscreen drivers. The reset pin of these is clearly documented as active low, but the driver is currently treating it as active high.

Fixing this has the unfortunate consequence of breaking downstream boards, but that's probably better than messing future application setting the pin as active low (correctly) and then wondering why the device disappears from the bus.

Over to @danieldegrasse, who introduced reset support on both the ft5336 and gt911, I tested this on an ft5336, could you give this a run on the gt11? Sorry for missing this in the original review.