### PR TITLE
drivers: can: Fix Z_SYSCALL_OBJ->K_SYSCALL_OBJ

### DIFF
--- a/drivers/can/can_handlers.c
+++ b/drivers/can/can_handlers.c
@@ -248,7 +248,7 @@ static inline int z_vrfy_can_recover(const struct device *dev, k_timeout_t timeo
 
 static inline uint32_t z_vrfy_can_stats_get_bit_errors(const struct device *dev)
 {
-	K_OOPS(Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_CAN));
+	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_CAN));
 
 	return z_impl_can_stats_get_bit_errors(dev);
 }
@@ -256,7 +256,7 @@ static inline uint32_t z_vrfy_can_stats_get_bit_errors(const struct device *dev)
 
 static inline uint32_t z_vrfy_can_stats_get_bit0_errors(const struct device *dev)
 {
-	K_OOPS(Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_CAN));
+	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_CAN));
 
 	return z_impl_can_stats_get_bit0_errors(dev);
 }
@@ -264,7 +264,7 @@ static inline uint32_t z_vrfy_can_stats_get_bit0_errors(const struct device *dev
 
 static inline uint32_t z_vrfy_can_stats_get_bit1_errors(const struct device *dev)
 {
-	K_OOPS(Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_CAN));
+	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_CAN));
 
 	return z_impl_can_stats_get_bit1_errors(dev);
 }
@@ -272,7 +272,7 @@ static inline uint32_t z_vrfy_can_stats_get_bit1_errors(const struct device *dev
 
 static inline uint32_t z_vrfy_can_stats_get_stuff_errors(const struct device *dev)
 {
-	K_OOPS(Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_CAN));
+	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_CAN));
 
 	return z_impl_can_stats_get_stuff_errors(dev);
 }
@@ -280,7 +280,7 @@ static inline uint32_t z_vrfy_can_stats_get_stuff_errors(const struct device *de
 
 static inline uint32_t z_vrfy_can_stats_get_crc_errors(const struct device *dev)
 {
-	K_OOPS(Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_CAN));
+	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_CAN));
 
 	return z_impl_can_stats_get_crc_errors(dev);
 }
@@ -288,7 +288,7 @@ static inline uint32_t z_vrfy_can_stats_get_crc_errors(const struct device *dev)
 
 static inline uint32_t z_vrfy_can_stats_get_form_errors(const struct device *dev)
 {
-	K_OOPS(Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_CAN));
+	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_CAN));
 
 	return z_impl_can_stats_get_form_errors(dev);
 }
@@ -296,7 +296,7 @@ static inline uint32_t z_vrfy_can_stats_get_form_errors(const struct device *dev
 
 static inline uint32_t z_vrfy_can_stats_get_ack_errors(const struct device *dev)
 {
-	K_OOPS(Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_CAN));
+	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_CAN));
 
 	return z_impl_can_stats_get_ack_errors(dev);
 }
@@ -304,7 +304,7 @@ static inline uint32_t z_vrfy_can_stats_get_ack_errors(const struct device *dev)
 
 static inline uint32_t z_vrfy_can_stats_get_rx_overruns(const struct device *dev)
 {
-	K_OOPS(Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_CAN));
+	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_CAN));
 
 	return z_impl_can_stats_get_rx_overruns(dev);
 }


### PR DESCRIPTION
Fix can handler calling removed Z_SYSCALL_OBJ instead of K_SYSCALL_OBJ