### PR TITLE
Charger API Documentation Cleanup

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -840,6 +840,20 @@ Release Notes:
   labels:
     - "area: CAN"
 
+"Drivers: Charger":
+  status: maintained
+  maintainers:
+    - aaronemassey
+    - rriveramcrus
+  files:
+    - drivers/charger/
+    - dts/bindings/charger/
+    - include/zephyr/drivers/charger.h
+    - tests/drivers/charger/
+    - doc/hardware/peripherals/charger.rst
+  labels:
+    - "area: Charger"
+
 "Drivers: Clock control":
   status: maintained
   maintainers:

--- a/doc/hardware/peripherals/charger.rst
+++ b/doc/hardware/peripherals/charger.rst
@@ -17,8 +17,8 @@ measure.
 Chargers typically support multiple properties, such as temperature readings of the battery-pack
 or present-time current/voltage.
 
-Properties are fetched using a client allocated array of :c:struct:`charger_get_property`.  This
-array is then populated by values as according to its `property_type` field.
+Properties are fetched by the client one at a time using :c:func:`charger_get_prop`.
+Properties are set by the client one at a time using :c:func:`charger_set_prop`.
 
 .. _charger_api_reference:
 

--- a/doc/hardware/peripherals/charger.rst
+++ b/doc/hardware/peripherals/charger.rst
@@ -3,8 +3,7 @@
 Chargers
 ########
 
-The charger subsystem exposes an API to uniformly access battery charger devices. Currently,
-only reading data is supported.
+The charger subsystem exposes an API to uniformly access battery charger devices.
 
 Basic Operation
 ***************


### PR DESCRIPTION
During the churn of the initial Charger API PR the documentation for the charging API got stale and fell behind. This PR corrects the documentation up.