### PR TITLE
bluetooth: hci: spi: delay between header and data on send

### DIFF
--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -425,6 +425,8 @@ static int bt_spi_send(struct net_buf *buf)
 		  (header_rx[1] | header_rx[2] | header_rx[3] | header_rx[4]) == 0U) && !ret);
 
 	if (!ret) {
+		/* Delay here is rounded up to next tick */
+		k_sleep(K_USEC(DATA_DELAY_US));
 		/* Transmit the message */
 		while (true) {
 			ret = bt_spi_transceive(buf->data, buf->len,
@@ -432,6 +434,9 @@ static int bt_spi_send(struct net_buf *buf)
 			if (rx_first[0] != 0U || ret) {
 				break;
 			}
+			/* Consider increasing controller-data-delay-us
+			 * if this message is extremely common.
+			 */
 			LOG_DBG("Controller not ready for SPI transaction of %d bytes", buf->len);
 		}
 	}

--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -426,10 +426,14 @@ static int bt_spi_send(struct net_buf *buf)
 
 	if (!ret) {
 		/* Transmit the message */
-		do {
+		while (true) {
 			ret = bt_spi_transceive(buf->data, buf->len,
 						rx_first, 1);
-		} while (rx_first[0] == 0U && !ret);
+			if (rx_first[0] != 0U || ret) {
+				break;
+			}
+			LOG_DBG("Controller not ready for SPI transaction of %d bytes", buf->len);
+		}
 	}
 
 	release_cs();

--- a/dts/bindings/bluetooth/zephyr,bt-hci-spi.yaml
+++ b/dts/bindings/bluetooth/zephyr,bt-hci-spi.yaml
@@ -28,10 +28,10 @@ properties:
     type: int
     default: 20
     description:
-      Duration to delay between reading a valid header and reading the data associated
-      with that header. This delay gives the controller time to configure the SPI data
-      transaction after finishing the header transaction. Without this delay the host
-      can attempt to read before the controller is ready, resulting in empty data that
-      then needs to be read a second time. The default of 20uS was chosen as the lowest
-      delay that reliably eliminated double transmits between a nRF9160 host and a
-      nRF52832 controller.
+      Duration to delay between reading a valid header and transceiving the data
+      associated with that header. This delay gives the controller time to configure
+      the SPI data transaction after finishing the header transaction. Without this
+      delay the host can attempt to read/write before the controller is ready,
+      resulting in an ignored transaction that then needs to be performed a second time.
+      The default of 20uS was chosen as the lowest delay that reliably eliminated double
+      transactions between a nRF9160 host and a nRF52832 controller.


### PR DESCRIPTION
Add the same delay as was added in #59293, except for the host->controller path, instead of controller->host.