### PR TITLE
boards: m5stack_core2: do not use as default test platform

### DIFF
--- a/boards/xtensa/m5stack_core2/m5stack_core2.yaml
+++ b/boards/xtensa/m5stack_core2/m5stack_core2.yaml
@@ -14,7 +14,6 @@ supported:
   - pinmux
   - nvs
 testing:
-  default: true
   ignore_tags:
     - net
     - bluetooth


### PR DESCRIPTION
Only quemu boards are used as default in CI, drop the default property from this one.