### PR TITLE
sys: Add wakeup source subsystem

### DIFF
--- a/cmake/linker_script/common/common-rom.cmake
+++ b/cmake/linker_script/common/common-rom.cmake
@@ -226,3 +226,7 @@ endif()
 if(CONFIG_GNSS_SATELLITES)
   zephyr_iterable_section(NAME gnss_satellites_callback KVMA RAM_REGION GROUP RODATA_REGION SUBALIGN 4)
 endif()
+
+if(CONFIG_WAKEUP_SOURCE)
+  zephyr_iterable_section(NAME wakeup_source KVMA RAM_REGION GROUP RODATA_REGION SUBALIGN 4)
+endif()

--- a/dts/bindings/base/base.yaml
+++ b/dts/bindings/base/base.yaml
@@ -92,3 +92,11 @@ properties:
   mbox-names:
     type: string-array
     description: Provided names of mailbox / IPM channel specifiers
+
+  interrupt-gpios:
+    type: phandle-array
+    description: GPIO routed interrupts for device
+
+  interrupt-gpio-names:
+    type: string-array
+    description: Name of each GPIO routed interrupt

--- a/dts/bindings/base/pm.yaml
+++ b/dts/bindings/base/pm.yaml
@@ -16,6 +16,11 @@ properties:
       Wake up capable devices are disabled (interruptions will not wake up
       the system) by default but they can be enabled at runtime if necessary.
 
+  wakeup-source-ids:
+    type: array
+    description: |
+      Property to identify vendor specific wakeup sources.
+
   power-domain:
     type: phandle
     description: |

--- a/dts/bindings/input/gpio-keys.yaml
+++ b/dts/bindings/input/gpio-keys.yaml
@@ -47,3 +47,6 @@ child-binding:
     zephyr,code:
       type: int
       description: Key code to emit.
+    wakeup-source:
+      type: boolean
+      description: Key is capable of being used as a wakeup source

--- a/include/zephyr/devicetree/gpio.h
+++ b/include/zephyr/devicetree/gpio.h
@@ -54,6 +54,37 @@ extern "C" {
 	DT_PHANDLE_BY_IDX(node_id, gpio_pha, idx)
 
 /**
+ * @brief Get the node identifier for the controller phandle from a
+ *        gpio phandle-array property by name
+ *
+ * Example devicetree fragment:
+ *
+ *     gpio1: gpio@... { };
+ *
+ *     gpio2: gpio@... { };
+ *
+ *     n: node {
+ *             gpios = <&gpio1 10 GPIO_ACTIVE_LOW>,
+ *                     <&gpio2 30 GPIO_ACTIVE_HIGH>;
+ *             gpio-names = "foo", "bar";
+ *     };
+ *
+ * Example usage:
+ *
+ *     DT_GPIO_CTLR_BY_NAME(DT_NODELABEL(n), gpios, bar) // DT_NODELABEL(gpio2)
+ *
+ * @param node_id node identifier
+ * @param gpio_pha lowercase-and-underscores GPIO property with
+ *        type "phandle-array"
+ * @param name lowercase-and-underscores name of element in "gpio_pha"
+ * @return the node identifier for the gpio controller referenced by
+ *         name "name"
+ * @see DT_PHANDLE_BY_NAME()
+ */
+#define DT_GPIO_CTLR_BY_NAME(node_id, gpio_pha, name) \
+	DT_PHANDLE_BY_NAME(node_id, gpio_pha, name)
+
+/**
  * @brief Equivalent to DT_GPIO_CTLR_BY_IDX(node_id, gpio_pha, 0)
  * @param node_id node identifier
  * @param gpio_pha lowercase-and-underscores GPIO property with
@@ -164,6 +195,51 @@ extern "C" {
 	DT_PHA_BY_IDX(node_id, gpio_pha, idx, pin)
 
 /**
+ * @brief Get a GPIO specifier's pin cell by name
+ *
+ * This macro only works for GPIO specifiers with cells named "pin".
+ * Refer to the node's binding to check if necessary.
+ *
+ * Example devicetree fragment:
+ *
+ *     gpio1: gpio@... {
+ *             compatible = "vnd,gpio";
+ *             #gpio-cells = <2>;
+ *     };
+ *
+ *     gpio2: gpio@... {
+ *             compatible = "vnd,gpio";
+ *             #gpio-cells = <2>;
+ *     };
+ *
+ *     n: node {
+ *             gpios = <&gpio1 10 GPIO_ACTIVE_LOW>,
+ *                     <&gpio2 30 GPIO_ACTIVE_HIGH>;
+ *             gpio-names = "foo", "bar";
+ *     };
+ *
+ * Bindings fragment for the vnd,gpio compatible:
+ *
+ *     gpio-cells:
+ *       - pin
+ *       - flags
+ *
+ * Example usage:
+ *
+ *     DT_GPIO_PIN_BY_NAME(DT_NODELABEL(n), gpios, foo) // 10
+ *     DT_GPIO_PIN_BY_NAME(DT_NODELABEL(n), gpios, bar) // 30
+ *
+ * @param node_id node identifier
+ * @param gpio_pha lowercase-and-underscores GPIO property with
+ *        type "phandle-array"
+ * @param name lowercase-and-underscores name of element in "gpio_pha"
+ * @return the pin cell value in element by "name"
+ * @see DT_PHA_BY_NAME()
+ */
+#define DT_GPIO_PIN_BY_NAME(node_id, gpio_pha, name) \
+	DT_PHA_BY_NAME(node_id, gpio_pha, name, pin)
+
+/**
  * @brief Equivalent to DT_GPIO_PIN_BY_IDX(node_id, gpio_pha, 0)
  * @param node_id node identifier
  * @param gpio_pha lowercase-and-underscores GPIO property with
@@ -218,6 +294,53 @@ extern "C" {
  */
 #define DT_GPIO_FLAGS_BY_IDX(node_id, gpio_pha, idx) \
 	DT_PHA_BY_IDX_OR(node_id, gpio_pha, idx, flags, 0)
+
+
+/**
+ * @brief Get a GPIO specifier's flags cell by name
+ *
+ * This macro expects GPIO specifiers with cells named "flags".
+ * If there is no "flags" cell in the GPIO specifier, zero is returned.
+ * Refer to the node's binding to check specifier cell names if necessary.
+ *
+ * Example devicetree fragment:
+ *
+ *     gpio1: gpio@... {
+ *             compatible = "vnd,gpio";
+ *             #gpio-cells = <2>;
+ *     };
+ *
+ *     gpio2: gpio@... {
+ *             compatible = "vnd,gpio";
+ *             #gpio-cells = <2>;
+ *     };
+ *
+ *     n: node {
+ *             gpios = <&gpio1 10 GPIO_ACTIVE_LOW>,
+ *                     <&gpio2 30 GPIO_ACTIVE_HIGH>;
+ *             gpio-names = "foo", "bar";
+ *     };
+ *
+ * Bindings fragment for the vnd,gpio compatible:
+ *
+ *     gpio-cells:
+ *       - pin
+ *       - flags
+ *
+ * Example usage:
+ *
+ *     DT_GPIO_FLAGS_BY_NAME(DT_NODELABEL(n), gpios, foo) // GPIO_ACTIVE_LOW
+ *     DT_GPIO_FLAGS_BY_NAME(DT_NODELABEL(n), gpios, bar) // GPIO_ACTIVE_HIGH
+ *
+ * @param node_id node identifier
+ * @param gpio_pha lowercase-and-underscores GPIO property with
+ *        type "phandle-array"
+ * @param name lowercase-and-underscores name of element in "gpio_pha"
+ * @return the flags cell value in element by "name", or zero if there is none
+ * @see DT_PHA_BY_NAME()
+ */
+#define DT_GPIO_FLAGS_BY_NAME(node_id, gpio_pha, name) \
+	DT_PHA_BY_NAME_OR(node_id, gpio_pha, name, flags, 0)
 
 /**
  * @brief Equivalent to DT_GPIO_FLAGS_BY_IDX(node_id, gpio_pha, 0)

--- a/include/zephyr/linker/common-rom/common-rom-misc.ld
+++ b/include/zephyr/linker/common-rom/common-rom-misc.ld
@@ -67,3 +67,7 @@
 #if defined(CONFIG_GNSS_SATELLITES)
 	ITERABLE_SECTION_ROM(gnss_satellites_callback, 4)
 #endif
+
+#if defined(CONFIG_WAKEUP_SOURCE)
+	ITERABLE_SECTION_ROM(wakeup_source, 4)
+#endif

--- a/include/zephyr/sys/wakeup_source.h
+++ b/include/zephyr/sys/wakeup_source.h
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2023 Bjarki Arge Andreasen
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_SYS_WAKEUP_SOURCE_H_
+#define ZEPHYR_INCLUDE_SYS_WAKEUP_SOURCE_H_
+
+#include <zephyr/types.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/devicetree.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @defgroup sys_wakeup_source System wakeup source
+ * @ingroup os_services
+ * @{
+ */
+
+/** @cond INTERNAL_HIDDEN */
+
+/** Mutable wakeup source flags */
+struct wakeup_source_flags {
+	uint8_t enabled : 1;
+};
+
+/** Required information to enable a wakeup source */
+struct wakeup_source {
+#ifdef CONFIG_WAKEUP_SOURCE_ID_SUPPORTED
+	/** Vendor specific wakeup source identifiers */
+	const uint16_t *wakeup_ids;
+	/** Number of vendor specific wakeup source identifier */
+	uint16_t wakeup_ids_size;
+#endif
+#ifdef CONFIG_WAKEUP_SOURCE_IRQ_SUPPORTED
+	/** Wakeup interrupt numbers */
+	const uint16_t *wakeup_irq_numbers;
+	/** Number of wakeup interrupt numbers */
+	uint16_t wakeup_irq_numbers_size;
+#endif
+#ifdef CONFIG_WAKEUP_SOURCE_GPIO_SUPPORTED
+	/** Wakeup GPIOs */
+	const struct gpio_dt_spec *wakeup_gpios;
+	/** Number of wakeup GPIOs */
+	uint16_t wakeup_gpios_size;
+#endif
+	/** Name of wakeup source */
+	const char *name;
+	/** Mutable wakeup source flags */
+	struct wakeup_source_flags *flags;
+};
+
+/** Enable wakeup source by id hook */
+void z_sys_wakeup_source_enable_id(uint16_t id);
+
+/** Enable IRQ as wakeup source hook */
+void z_sys_wakeup_source_enable_irq(uint16_t irq_number);
+
+/** Enable GPIO as wakeup source hook */
+void z_sys_wakeup_source_enable_gpio(const struct gpio_dt_spec *gpio);
+
+/** Configure all enabled wakeup sources */
+void z_sys_wakeup_sources_configure(void);
+
+/** @endcond */
+
+/** Enable a wakeup source */
+void sys_wakeup_source_enable(const struct wakeup_source *ws);
+
+/** Disable a wakeup source */
+void sys_wakeup_source_disable(const struct wakeup_source *ws);
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @cond INTERNAL_HIDDEN */
+
+#define WAKEUP_SOURCE_NAME(node_id) \
+	UTIL_CAT(__wakeup_source_, DT_DEP_ORD(node_id))
+
+#define IS_WAKEUP_SOURCE(node_id) \
+	IS_ENABLED(DT_PROP(node_id, wakeup_source))
+
+#define WAKEUP_SOURCE_FOREACH_INTERNAL(node_id, fn) \
+	COND_CODE_1(IS_WAKEUP_SOURCE(node_id), (fn(node_id)), ())
+
+/** @endcond */
+
+#define WAKEUP_SOURCE_DT_GET(node_id) \
+	&WAKEUP_SOURCE_NAME(node_id)
+
+#define WAKEUP_SOURCE_FOREACH(fn) \
+	DT_FOREACH_VARGS_HELPER(WAKEUP_SOURCE_FOREACH_INTERNAL, fn)
+
+/** @cond INTERNAL_HIDDEN */
+
+#define WAKEUP_SOURCE_DEFINE_EXTERN(node_id) \
+	extern const struct wakeup_source WAKEUP_SOURCE_NAME(node_id);
+
+WAKEUP_SOURCE_FOREACH(WAKEUP_SOURCE_DEFINE_EXTERN)
+
+/** @endcond */
+
+/** @} */
+
+#endif /* ZEPHYR_INCLUDE_SYS_WAKEUP_H_ */

--- a/lib/os/poweroff.c
+++ b/lib/os/poweroff.c
@@ -5,10 +5,15 @@
 
 #include <zephyr/irq.h>
 #include <zephyr/sys/poweroff.h>
+#include <zephyr/sys/wakeup_source.h>
 
 void sys_poweroff(void)
 {
 	(void)irq_lock();
+
+#ifdef CONFIG_WAKEUP_SOURCE
+	z_sys_wakeup_sources_configure();
+#endif
 
 	z_sys_poweroff();
 }

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -1780,6 +1780,9 @@ class Node:
                                        specifier_space),
                 name=None, basename=specifier_space))
 
+        # Revert special-casing for *-gpios propreties before adding names
+        specifier_space = prop.name[:-1]
+
         _add_names(self._node, specifier_space, res)
 
         return res

--- a/soc/arm/nordic_nrf/Kconfig.defconfig
+++ b/soc/arm/nordic_nrf/Kconfig.defconfig
@@ -40,4 +40,11 @@ config GPIO
 	default y
 	depends on SPI
 
+if WAKEUP_SOURCE
+
+config WAKEUP_SOURCE_GPIO_SUPPORTED
+	default y
+
+endif # WAKEUP_SOURCE
+
 endif # SOC_FAMILY_NRF

--- a/soc/arm/nordic_nrf/common/CMakeLists.txt
+++ b/soc/arm/nordic_nrf/common/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 zephyr_library_sources_ifdef(CONFIG_SOC_FAMILY_NRF soc_nrf_common.S)
 zephyr_library_sources_ifdef(CONFIG_POWEROFF poweroff.c)
+zephyr_library_sources_ifdef(CONFIG_WAKEUP_SOURCE wakeup_source.c)
 zephyr_include_directories(.)
 
 if (CONFIG_TFM_PARTITION_PLATFORM)

--- a/soc/arm/nordic_nrf/common/wakeup_source.c
+++ b/soc/arm/nordic_nrf/common/wakeup_source.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023 Bjarki Arge Andreasen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#warning "DISCLAIMER Very naive implementation for demonstration purposes only"
+
+#include <zephyr/kernel.h>
+#include <zephyr/sys/wakeup_source.h>
+#include <hal/nrf_gpio.h>
+
+struct gpio_nrfx_cfg {
+	/* gpio_driver_config needs to be first */
+	struct gpio_driver_config common;
+	NRF_GPIO_Type *port;
+	uint32_t edge_sense;
+	uint8_t port_num;
+};
+
+void z_sys_wakeup_source_enable_gpio(const struct gpio_dt_spec *gpio)
+{
+	const struct gpio_nrfx_cfg *cfg = gpio->port->config;
+	uint32_t abs_pin = NRF_GPIO_PIN_MAP(cfg->port_num, gpio->pin);
+	nrf_gpio_pin_pull_t pull;
+	nrf_gpio_pin_sense_t sense;
+
+	if (gpio->dt_flags & GPIO_ACTIVE_LOW) {
+		sense = NRF_GPIO_PIN_SENSE_LOW;
+	} else {
+		sense = NRF_GPIO_PIN_SENSE_HIGH;
+	}
+
+	if (gpio->dt_flags & GPIO_PULL_UP) {
+		pull = NRF_GPIO_PIN_PULLUP;
+	} else if (gpio->dt_flags & GPIO_PULL_DOWN) {
+		pull = NRF_GPIO_PIN_PULLDOWN;
+	} else {
+		pull = NRF_GPIO_PIN_NOPULL;
+	}
+
+	nrf_gpio_cfg(abs_pin,
+		     NRF_GPIO_PIN_DIR_INPUT,
+		     NRF_GPIO_PIN_INPUT_CONNECT,
+		     pull,
+		     NRF_GPIO_PIN_S0S1,
+		     sense);
+}

--- a/subsys/CMakeLists.txt
+++ b/subsys/CMakeLists.txt
@@ -52,5 +52,6 @@ add_subdirectory_ifdef(CONFIG_SENSING sensing)
 add_subdirectory_ifdef(CONFIG_SETTINGS settings)
 add_subdirectory_ifdef(CONFIG_SHELL shell)
 add_subdirectory_ifdef(CONFIG_TIMING_FUNCTIONS timing)
+add_subdirectory_ifdef(CONFIG_WAKEUP_SOURCE wakeup_source)
 add_subdirectory_ifdef(CONFIG_ZBUS zbus)
 # zephyr-keep-sorted-stop

--- a/subsys/Kconfig
+++ b/subsys/Kconfig
@@ -50,6 +50,7 @@ source "subsys/usb/device/Kconfig"
 source "subsys/usb/device_next/Kconfig"
 source "subsys/usb/host/Kconfig"
 source "subsys/usb/usb_c/Kconfig"
+source "subsys/wakeup_source/Kconfig"
 source "subsys/zbus/Kconfig"
 # zephyr-keep-sorted-stop
 

--- a/subsys/wakeup_source/CMakeLists.txt
+++ b/subsys/wakeup_source/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Copyright (c) 2023 Bjarki Arge Andreasen
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+
+zephyr_library_sources(wakeup_source.c)

--- a/subsys/wakeup_source/Kconfig
+++ b/subsys/wakeup_source/Kconfig
@@ -1,0 +1,23 @@
+# Copyright (c) 2023 Bjarki Arge Andreasen
+# SPDX-License-Identifier: Apache-2.0
+
+menuconfig WAKEUP_SOURCE
+	bool "Wakeup source"
+	select EXPERIMENTAL
+
+if WAKEUP_SOURCE
+
+config WAKEUP_SOURCE_ID_SUPPORTED
+	bool
+
+config WAKEUP_SOURCE_IRQ_SUPPORTED
+	bool
+
+config WAKEUP_SOURCE_GPIO_SUPPORTED
+	bool
+
+module = WAKEUP_SOURCE
+module-str = wakeup_source
+source "subsys/logging/Kconfig.template.log_config"
+
+endif

--- a/subsys/wakeup_source/wakeup_source.c
+++ b/subsys/wakeup_source/wakeup_source.c
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2023 Bjarki Arge Andreasen
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/sys/wakeup_source.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/toolchain.h>
+
+#define WAKEUP_SOURCE_VARNAME(node_id, varname)							\
+	UTIL_CAT(UTIL_CAT(WAKEUP_SOURCE_NAME(node_id), _), varname)
+
+#define WAKEUP_SOURCE_HAS_WAKEUP_IDS(node_id)							\
+	UTIL_AND(										\
+		DT_NODE_HAS_PROP(node_id, wakeup_source_ids),					\
+		IS_ENABLED(CONFIG_WAKEUP_SOURCE_ID_SUPPORTED)					\
+	)
+
+#define WAKEUP_SOURCE_HAS_WAKEUP_IRQ_NUMBERS(node_id)						\
+	UTIL_AND(										\
+		DT_NUM_IRQS(node_id),								\
+		IS_ENABLED(CONFIG_WAKEUP_SOURCE_IRQ_SUPPORTED)					\
+	)
+
+#define WAKEUP_SOURCE_HAS_INTERRUPT_GPIOS(node_id)						\
+	DT_NODE_HAS_PROP(node_id, interrupt_gpios)
+
+#define WAKEUP_SOURCE_HAS_GPIO_KEYS_GPIOS(node_id)						\
+	UTIL_AND(										\
+		DT_NODE_HAS_COMPAT(DT_PARENT(node_id), gpio_keys),				\
+		DT_NODE_HAS_PROP(node_id, gpios)						\
+	)
+
+#define WAKEUP_SOURCE_HAS_WAKEUP_GPIOS(node_id)							\
+	UTIL_AND(										\
+		UTIL_OR(									\
+			WAKEUP_SOURCE_HAS_INTERRUPT_GPIOS(node_id),				\
+			WAKEUP_SOURCE_HAS_GPIO_KEYS_GPIOS(node_id)				\
+		),										\
+		IS_ENABLED(CONFIG_WAKEUP_SOURCE_GPIO_SUPPORTED)					\
+	)
+
+#define WAKEUP_SOURCE_COND_HAS_WAKEUP_IDS(node_id, fn)						\
+	COND_CODE_1(WAKEUP_SOURCE_HAS_WAKEUP_IDS(node_id), (fn(node_id)), ())
+
+#define WAKEUP_SOURCE_COND_HAS_WAKEUP_IRQ_NUMBERS(node_id, fn)					\
+	COND_CODE_1(WAKEUP_SOURCE_HAS_WAKEUP_IRQ_NUMBERS(node_id), (fn(node_id)), ())
+
+#define WAKEUP_SOURCE_COND_HAS_INTERRUPT_GPIOS(node_id, fn)					\
+	COND_CODE_1(WAKEUP_SOURCE_HAS_INTERRUPT_GPIOS(node_id), (fn(node_id)), ())
+
+#define WAKEUP_SOURCE_COND_HAS_GPIO_KEYS_GPIOS(node_id, fn)					\
+	COND_CODE_1(WAKEUP_SOURCE_HAS_GPIO_KEYS_GPIOS(node_id), (fn(node_id)), ())
+
+#define WAKEUP_SOURCE_COND_HAS_WAKEUP_GPIOS(node_id, fn)					\
+	COND_CODE_1(WAKEUP_SOURCE_HAS_WAKEUP_GPIOS(node_id), (fn(node_id)), ())
+
+#define WAKEUP_SOURCE_DEFINE_WAKEUP_IDS(node_id)						\
+	static const uint16_t WAKEUP_SOURCE_VARNAME(node_id, wakeup_ids)[] =			\
+		DT_PROP(node_id, wakeup_source_ids);
+
+#define WAKEUP_SOURCE_DEFINE_WAKEUP_IRQ_NUMBER_BY_IDX(idx, node_id)				\
+	DT_IRQ_BY_IDX(node_id, idx, irq)
+
+#define WAKEUP_SOURCE_DEFINE_WAKEUP_IRQ_NUMBERS(node_id)					\
+	static const uint16_t WAKEUP_SOURCE_VARNAME(node_id, wakeup_irq_numbers)[] = {		\
+		LISTIFY(									\
+			DT_NUM_IRQS(node_id),							\
+			WAKEUP_SOURCE_DEFINE_WAKEUP_IRQ_NUMBER_BY_IDX,				\
+			(,),									\
+			node_id									\
+		)										\
+	};
+
+#define WAKEUP_SOURCE_DEFINE_INTERRUPT_GPIOS_BY_IDX(idx, node_id)				\
+	GPIO_DT_SPEC_GET_BY_IDX(node_id, interrupt_gpios, idx)
+
+#define WAKEUP_SOURCE_DEFINE_INTERRUPT_GPIOS(node_id)						\
+	LISTIFY(										\
+		DT_PROP_LEN(node_id, interrupt_gpios),						\
+		WAKEUP_SOURCE_DEFINE_INTERRUPT_GPIOS_BY_IDX,					\
+		(,),										\
+		node_id										\
+	),
+
+#define WAKEUP_SOURCE_DEFINE_GPIO_KEYS_GPIOS(node_id)						\
+	GPIO_DT_SPEC_GET(node_id, gpios),
+
+#define WAKEUP_SOURCE_DEFINE_WAKEUP_GPIOS(node_id)						\
+	static const struct gpio_dt_spec WAKEUP_SOURCE_VARNAME(node_id, wakeup_gpios)[] = {	\
+		WAKEUP_SOURCE_COND_HAS_INTERRUPT_GPIOS(						\
+			node_id,								\
+			WAKEUP_SOURCE_DEFINE_INTERRUPT_GPIOS					\
+		)										\
+		WAKEUP_SOURCE_COND_HAS_GPIO_KEYS_GPIOS(						\
+			node_id,								\
+			WAKEUP_SOURCE_DEFINE_GPIO_KEYS_GPIOS					\
+		)										\
+	};
+
+#define WAKEUP_SOURCE_DEFINE_FLAGS(node_id)							\
+	static struct wakeup_source_flags WAKEUP_SOURCE_VARNAME(node_id, flags);
+
+#define WAKEUP_SOURCE_ASSIGN_WAKEUP_IDS(node_id)						\
+	.wakeup_ids = WAKEUP_SOURCE_VARNAME(node_id, wakeup_ids),				\
+	.wakeup_ids_size = ARRAY_SIZE(WAKEUP_SOURCE_VARNAME(node_id, wakeup_ids)),
+
+#define WAKEUP_SOURCE_ASSIGN_WAKEUP_IRQ_NUMBERS(node_id)					\
+	.wakeup_irq_numbers = WAKEUP_SOURCE_VARNAME(node_id, wakeup_irq_numbers),		\
+	.wakeup_irq_numbers_size =								\
+		ARRAY_SIZE(WAKEUP_SOURCE_VARNAME(node_id, wakeup_irq_numbers)),
+
+#define WAKEUP_SOURCE_ASSIGN_WAKEUP_GPIOS(node_id)						\
+	.wakeup_gpios = WAKEUP_SOURCE_VARNAME(node_id, wakeup_gpios),				\
+	.wakeup_gpios_size = ARRAY_SIZE(WAKEUP_SOURCE_VARNAME(node_id, wakeup_gpios)),
+
+#define WAKEUP_SOURCE_ASSIGN_FLAGS(node_id)							\
+	.flags = &WAKEUP_SOURCE_VARNAME(node_id, flags),
+
+#define WAKEUP_SOURCE_ASSIGN_NAME(node_id)							\
+	.name = DT_NODE_FULL_NAME(node_id),
+
+#define WAKEUP_SOURCE_DEFINE_WAKEUP_SOURCE(node_id)						\
+	const STRUCT_SECTION_ITERABLE(wakeup_source, WAKEUP_SOURCE_NAME(node_id)) = {		\
+		WAKEUP_SOURCE_COND_HAS_WAKEUP_IDS(						\
+			node_id,								\
+			WAKEUP_SOURCE_ASSIGN_WAKEUP_IDS						\
+		)										\
+		WAKEUP_SOURCE_COND_HAS_WAKEUP_IRQ_NUMBERS(					\
+			node_id,								\
+			WAKEUP_SOURCE_ASSIGN_WAKEUP_IRQ_NUMBERS					\
+		)										\
+		WAKEUP_SOURCE_COND_HAS_WAKEUP_GPIOS(						\
+			node_id,								\
+			WAKEUP_SOURCE_ASSIGN_WAKEUP_GPIOS					\
+		)										\
+		WAKEUP_SOURCE_ASSIGN_FLAGS(node_id)						\
+		WAKEUP_SOURCE_ASSIGN_NAME(node_id)						\
+	};
+
+#define WAKEUP_SOURCE_DEFINE(node_id)								\
+	WAKEUP_SOURCE_COND_HAS_WAKEUP_IDS(							\
+		node_id,									\
+		WAKEUP_SOURCE_DEFINE_WAKEUP_IDS							\
+	)											\
+	WAKEUP_SOURCE_COND_HAS_WAKEUP_IRQ_NUMBERS(						\
+		node_id,									\
+		WAKEUP_SOURCE_DEFINE_WAKEUP_IRQ_NUMBERS						\
+	)											\
+	WAKEUP_SOURCE_COND_HAS_WAKEUP_GPIOS(							\
+		node_id,									\
+		WAKEUP_SOURCE_DEFINE_WAKEUP_GPIOS						\
+	)											\
+	WAKEUP_SOURCE_DEFINE_FLAGS(node_id)							\
+	WAKEUP_SOURCE_DEFINE_WAKEUP_SOURCE(node_id)
+
+WAKEUP_SOURCE_FOREACH(WAKEUP_SOURCE_DEFINE)
+
+static bool wakeup_source_is_enabled(const struct wakeup_source *ws)
+{
+	return ws->flags->enabled;
+}
+
+void sys_wakeup_source_enable(const struct wakeup_source *ws)
+{
+	ws->flags->enabled = true;
+}
+
+void sys_wakeup_source_disable(const struct wakeup_source *ws)
+{
+	ws->flags->enabled = false;
+}
+
+static void wakeup_source_configure(const struct wakeup_source *ws)
+{
+#ifdef CONFIG_WAKEUP_SOURCE_ID_SUPPORTED
+	for (uint16_t i = 0; i < ws->wakeup_ids_size; i++) {
+		z_sys_wakeup_source_enable_id(ws->wakeup_ids[i]);
+	}
+#endif
+
+#ifdef CONFIG_WAKEUP_SOURCE_IRQ_SUPPORTED
+	for (uint16_t i = 0; i < ws->wakeup_irq_numbers_size; i++) {
+		z_sys_wakeup_source_enable_irq(ws->wakeup_irq_numbers[i]);
+	}
+#endif
+
+#ifdef CONFIG_WAKEUP_SOURCE_GPIO_SUPPORTED
+	for (uint16_t i = 0; i < ws->wakeup_gpios_size; i++) {
+		z_sys_wakeup_source_enable_gpio(&ws->wakeup_gpios[i]);
+	}
+#endif
+}
+
+void z_sys_wakeup_sources_configure(void)
+{
+	STRUCT_SECTION_FOREACH(wakeup_source, ws) {
+		if (!wakeup_source_is_enabled(ws)) {
+			continue;
+		}
+		wakeup_source_configure(ws);
+	}
+}


### PR DESCRIPTION
## Introduction
Wakeup sources are events which can wake up the system from a sleep state, like what is entered using `poweroff()`. A common wakeup source is a button press through a GPIO, or an RTC alarm raising an interrupt. Zephyr currently has no generic way of defining, enabling or disabling wakeup sources, this is what is addressed with this PR.

The PR draws heavy inspiration from Linux, see [wakeup-source.txt](https://www.kernel.org/doc/Documentation/devicetree/bindings/power/wakeup-source.txt)

## Glossary
- Wakeup source: A collection of wakeup events tied to a specific devicetree node
- Wakeup event: An event capable of  waking up the SOC from poweroff
- Poweroff: A state in which an SOC is powered down

Note: Wakeup source defined here is not the same as the `wakeup-source` binding in `pm.yaml`.

## Overview
We have the following GPIO key defined in the devicetree snippet:
```
	gpio_keys {
		compatible = "gpio-keys";
		user_button: button {
			label = "User";
			gpios = <&gpio0 10 (GPIO_ACTIVE_HIGH)>;
			zephyr,code = <INPUT_KEY_0>;
		};
	};
```
We want this GPIO key to be able to wake up the system, so we add the `wakeup-source` property to it to define it as wakeup source:
```
	gpio_keys {
		compatible = "gpio-keys";
		user_button: button {
			label = "User";
			gpios = <&gpio0 10 (GPIO_ACTIVE_HIGH)>;
			zephyr,code = <INPUT_KEY_0>;
			wakeup-source;
		};
	};
```
From the application, we want to get a handle to the wakeup source:
```
static const struct *wakeup_source user_button_ws = WAKEUP_SOURCE_DT_GET(DT_NODELABEL(user_button));
```
Lastly, we want to enable it before powering down:
```
	sys_wakeup_source_enable(user_button_ws);
	sys_poweroff();
```
Enabling the wakeup source using `wakeup_source_enable()` sets a flag indicating that is should be enabled before power off. Once `poweroff()` is called, `z_sys_wakeup_sources_configure()` is called automatically, configuring all enabled power sources.

## How does it work?
For each node which is defined as a wakeup source using the `wakeup-source` property, the following information is stored:
* Every IRQ number
* Every GPIO defined by the property `interrupt-gpios` and the `gpios` property of a `"gpio-keys"` button
* Every vendor specific wakeup source identifier, if any

These properties are stored in the following structure, which is created for each wakeup source
```
struct wakeup_source {
	/** Vendor specific wakeup source identifiers */
	uint16_t *wakeup_ids;
	/** Number of vendor specific wakeup source identifier */
	uint16_t wakeup_ids_size;
	/** Wakeup interrupt numbers */
	uint16_t *wakeup_irq_numbers;
	/** Number of wakeup interrupt numbers */
	uint16_t wakeup_irq_numbers_size;
	/** Wakeup GPIOs */
	struct gpio_dt_spec *wakeup_gpios;
	/** Number of wakeup GPIOs */
	uint16_t wakeup_gpios_size;
	/** Name of wakeup source */
	const char *name;
};
```
The wakeup subsystem will use the stored information, and track which wakeup sources the application has enabled, to then pass this information to the SOC through hooks which may be implemented by the SOC.

### Wakeup ids
The vendor may define a set of SOC specific identifiers which will be passed by the wakeup source subsystem if the wakeup source shall be enabled. The SOC may implement the hook `int z_sys_wakeup_source_enable_id(uint16_t id)` to enable this functionality,

### Wakeup GPIOs
GPIOs used by enabled wakeup sources. The SOC may implement the hook `int z_sys_wakeup_source_enable_gpio(const struct gpio_dt_spec *gpio)` to enable this functionality,

### Wakeup IRQ numbers
IRQ numbers used by enabled wakeup sources. The SOC may implement the hook `int z_sys_wakeup_source_enable_irq(uint16_t irq_number)` to enable this functionality,

## Examples of wakeup sources from devicetree nodes
### GPIO keys
```
	gpio_keys {
		compatible = "gpio-keys";
		user_button: button {
			label = "User";
			gpios = <&gpio0 10 (GPIO_ACTIVE_HIGH)>;
			zephyr,code = <INPUT_KEY_0>;
		};
	};
```
becomes:
```
const struct gpio_dt_spec __wakeup_source_0_wakeup_gpios[] = {
	{.port = __device_dts_ord, .pin = 10, dt_flags = 1},
};

const struct wakeup_source __wakeup_source_0 = {
	.wakeup_gpios = __wakeup_source_1_wakeup_gpios, 
	.wakeup_gpios_size = 1,
};
```
### Sensor with single GPIO routed interrupt
```
	&spi0 {
		sensor: bmi323@0 {
			compatible = "bosch,bmi323"
			reg = <0>;
			interrupt-gpios = <&gpio0 11 (GPIO_ACTIVE_HIGH)>;
			reset-gpios = <&gpio0 12 (GPIO_ACTIVE_LOW)>;
		};
	};
```
becomes:
```
const struct gpio_dt_spec __wakeup_source_1_wakeup_gpios[] = {
	{.port = __device_dts_ord, .pin = 11, dt_flags = 1},
};

const struct wakeup_source __wakeup_source_1 = {
	.wakeup_gpios = __wakeup_source_1_wakeup_gpios,
	.wakeup_gpios_size = 1,
};
```
### Sensor with multiple GPIO routed interrupt with specified events routed to each interrupt (using names)
```
	&spi0 {
		sensor: bmi323@0 {
			compatible = "bosch,bmi323"
			reg = <0>;
			interrupt-gpios = <&gpio0 11 (GPIO_ACTIVE_HIGH)>,
                                          <&gpio1 8 (GPIO_ACTIVE_HIGH)>;
			interrupt-gpio-names = "data_ready", "any_motion";
			reset-gpios = <&gpio0 12 (GPIO_ACTIVE_LOW)>;
		};
	};
```
becomes:
```
const struct gpio_dt_spec __wakeup_source_1_wakeup_gpios[] = {
	{.port = __device_dts_ord, .pin = 11, dt_flags = 1},
	{.port = __device_dts_ord, .pin = 8, dt_flags = 1},
};

const struct wakeup_source __wakeup_source_1 = {
	.wakeup_gpios = __wakeup_source_1_wakeup_gpios,
	.wakeup_gpios_size = 2,
};
```
### Vendor specific RTC peripheral
.dtsi
```
rtc: rtc@400e1860 {
	compatible = "atmel,sam-rtc";
	reg = <0x400e1860 0x100>;
	interrupts = <2 0>;
	wakeup-source-ids = <5>;
	alarms-count = <1>;
	status = "disabled";
};
```
.overlay
```
&rtc {
	status = "okay";
	wakeup-source;
};
```
becomes:
```
uint16_t __wakeup_source_1_wakeup_ids[] = {
	5
};

uint16_t __wakeup_source_1_wakeup_irq_numbers[] = {
	2
};

const struct wakeup_source __wakeup_source_1 = {
	.wakeup_ids = __wakeup_source_1_wakeup_ids, 
	.wakeup_ids_size = 1,
	.wakeup_irq_numbers = __wakeup_source_1_wakeup_irq_numbers, 
	.wakeup_irq_size = 1,
};
```