### PR TITLE
cmake: snippets: application requested snippets

### DIFF
--- a/cmake/modules/snippets.cmake
+++ b/cmake/modules/snippets.cmake
@@ -46,14 +46,20 @@ function(zephyr_process_snippets)
   set(snippets_py ${ZEPHYR_BASE}/scripts/snippets.py)
   set(snippets_generated ${CMAKE_BINARY_DIR}/zephyr/snippets_generated.cmake)
 
-  # Set SNIPPET_AS_LIST, removing snippets_generated.cmake if we are
-  # running cmake again and snippets are no longer requested.
+  # SNIPPET_AS_LIST from command line
   if (NOT DEFINED SNIPPET)
-    set(SNIPPET_AS_LIST "" PARENT_SCOPE)
-    file(REMOVE ${snippets_generated})
+    set(SNIPPET_AS_LIST "")
   else()
     string(REPLACE " " ";" SNIPPET_AS_LIST "${SNIPPET}")
-    set(SNIPPET_AS_LIST "${SNIPPET_AS_LIST}" PARENT_SCOPE)
+  endif()
+
+  # Export SNIPPET_AS_LIST back to calling scope
+  set(SNIPPET_AS_LIST "${SNIPPET_AS_LIST}" PARENT_SCOPE)
+
+  # Remove snippets_generated.cmake if snippets are not requested.
+  list(LENGTH SNIPPET_AS_LIST NUM_SNIPPETS)
+  if(NUM_SNIPPETS EQUAL "0")
+    file(REMOVE ${snippets_generated})
   endif()
 
   # Set SNIPPET_ROOT.

--- a/cmake/modules/snippets.cmake
+++ b/cmake/modules/snippets.cmake
@@ -53,6 +53,12 @@ function(zephyr_process_snippets)
     string(REPLACE " " ";" SNIPPET_AS_LIST "${SNIPPET}")
   endif()
 
+  # Append application requested snippets
+  if (DEFINED SNIPPET_APP)
+    string(REPLACE " " ";" SNIPPET_APP_AS_LIST "${SNIPPET_APP}")
+    list(APPEND SNIPPET_AS_LIST ${SNIPPET_APP_AS_LIST})
+  endif()
+
   # Export SNIPPET_AS_LIST back to calling scope
   set(SNIPPET_AS_LIST "${SNIPPET_AS_LIST}" PARENT_SCOPE)
 

--- a/doc/build/snippets/using.rst
+++ b/doc/build/snippets/using.rst
@@ -37,3 +37,14 @@ snippet names you want to use. For example:
 
    cmake -Sapp -Bbuild -DSNIPPET="snippet1;snippet2" [...]
    cmake --build build
+
+From application
+****************
+
+An application can request snippets directly from ``CMakeLists.txt`` with
+the ``SNIPPET_APP`` variable. These snippets are merged with those provided
+from the command line (``west build`` or ``cmake -DSNIPPET=...``).
+
+.. code-block:: cmake
+
+   set(SNIPPET_APP "snippet3;snippet4")

--- a/doc/build/snippets/writing.rst
+++ b/doc/build/snippets/writing.rst
@@ -99,7 +99,8 @@ Processing order
 ****************
 
 Snippets are processed in the order they are listed in the :makevar:`SNIPPET`
-variable, or in the order of the ``-S`` arguments if using west.
+variable, or in the order of the ``-S`` arguments if using west. Snippets
+requested by :makevar:`SNIPPET_APP` are processed after :makevar:`SNIPPET`.
 
 To apply ``bar`` after ``foo``:
 


### PR DESCRIPTION
Add a dedicated cmake variable (`SNIPPET_APP`) to allow applications to
automatically request snippets from `CMakeLists.txt`.

Applications cannot currently simply append to the `SNIPPET` variable
because of the behaviour of `zephyr_check_cache`, which automatically
drops modifications to the variable that aren't present in the cache.

`SNIPPET_APP` is therefore a cleaner alternative to:

```
list(APPEND SNIPPET "snippet3;snippet4")
set(SNIPPET ${SNIPPET} CACHE INTERNAL "" FORCE)
```