### PR TITLE
drivers: input: gpio-keys: Add wakeup-source support

### DIFF
--- a/drivers/input/input_gpio_keys.c
+++ b/drivers/input/input_gpio_keys.c
@@ -29,6 +29,7 @@ struct gpio_keys_pin_config {
 	struct gpio_dt_spec spec;
 	/** Zephyr code from devicetree */
 	uint32_t zephyr_code;
+	bool wakeup;
 };
 struct gpio_keys_config {
 	/** Debounce interval in milliseconds from devicetree */
@@ -128,6 +129,7 @@ static int gpio_keys_init(const struct device *dev)
 {
 	struct gpio_keys_pin_data *pin_data = dev->data;
 	const struct gpio_keys_config *cfg = dev->config;
+	int flags;
 	int ret;
 
 	for (int i = 0; i < cfg->num_keys; i++) {
@@ -138,7 +140,11 @@ static int gpio_keys_init(const struct device *dev)
 			return -ENODEV;
 		}
 
-		ret = gpio_pin_configure_dt(gpio, GPIO_INPUT);
+		flags = GPIO_INPUT;
+		if (cfg->pin_cfg[i].wakeup) {
+			flags |= GPIO_WAKEUP_SOURCE;
+		}
+		ret = gpio_pin_configure_dt(gpio, flags);
 		if (ret != 0) {
 			LOG_ERR("Pin %d configuration failed: %d", i, ret);
 			return ret;
@@ -174,6 +180,7 @@ static int gpio_keys_init(const struct device *dev)
 	{                                                                                          \
 		.spec = GPIO_DT_SPEC_GET(node_id, gpios),                                          \
 		.zephyr_code = DT_PROP(node_id, zephyr_code),                                      \
+		.wakeup = DT_PROP(node_id, wakeup_source),                                         \
 	}
 
 #define GPIO_KEYS_INIT(i)                                                                          \

--- a/drivers/input/input_gpio_keys.c
+++ b/drivers/input/input_gpio_keys.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Google LLC
+ * Copyright (c) 2023 Gerson Fernando Budke <nandojve@gmail.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,6 +9,9 @@
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
+#ifdef CONFIG_PINCTRL
+#include <zephyr/drivers/pinctrl.h>
+#endif
 #include <zephyr/input/input.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
@@ -31,6 +35,9 @@ struct gpio_keys_config {
 	uint32_t debounce_interval_ms;
 	const int num_keys;
 	const struct gpio_keys_pin_config *pin_cfg;
+#ifdef CONFIG_PINCTRL
+	const struct pinctrl_dev_config *pinctrl_cfg;
+#endif
 };
 
 struct gpio_keys_pin_data {
@@ -149,6 +156,13 @@ static int gpio_keys_init(const struct device *dev)
 		}
 	}
 
+#ifdef CONFIG_PINCTRL
+	ret = pinctrl_apply_state(cfg->pinctrl_cfg, PINCTRL_STATE_DEFAULT);
+	if (ret < 0 && ret != -ENOENT) {
+		return ret;
+	}
+#endif
+
 	return 0;
 }
 
@@ -163,6 +177,7 @@ static int gpio_keys_init(const struct device *dev)
 	}
 
 #define GPIO_KEYS_INIT(i)                                                                          \
+	IF_ENABLED(CONFIG_PINCTRL, (PINCTRL_DT_INST_DEFINE(i);))                                   \
 	DT_INST_FOREACH_CHILD_STATUS_OKAY(i, GPIO_KEYS_CFG_CHECK);                                 \
 	static const struct gpio_keys_pin_config gpio_keys_pin_config_##i[] = {                    \
 		DT_INST_FOREACH_CHILD_STATUS_OKAY_SEP(i, GPIO_KEYS_CFG_DEF, (,))};                 \
@@ -170,6 +185,7 @@ static int gpio_keys_init(const struct device *dev)
 		.debounce_interval_ms = DT_INST_PROP(i, debounce_interval_ms),                     \
 		.num_keys = ARRAY_SIZE(gpio_keys_pin_config_##i),                                  \
 		.pin_cfg = gpio_keys_pin_config_##i,                                               \
+		IF_ENABLED(CONFIG_PINCTRL, (.pinctrl_cfg = PINCTRL_DT_INST_DEV_CONFIG_GET(i),))    \
 	};                                                                                         \
 	static struct gpio_keys_pin_data                                                           \
 		gpio_keys_pin_data_##i[ARRAY_SIZE(gpio_keys_pin_config_##i)];                      \

--- a/dts/bindings/input/gpio-keys.yaml
+++ b/dts/bindings/input/gpio-keys.yaml
@@ -25,7 +25,7 @@ description: |
 
 compatible: "gpio-keys"
 
-include: base.yaml
+include: pinctrl-device.yaml
 
 properties:
   debounce-interval-ms:

--- a/dts/bindings/input/gpio-keys.yaml
+++ b/dts/bindings/input/gpio-keys.yaml
@@ -25,7 +25,11 @@ description: |
 
 compatible: "gpio-keys"
 
-include: pinctrl-device.yaml
+include:
+  - name: pinctrl-device.yaml
+  - name: pm.yaml
+    property-allowlist:
+      - wakeup-source
 
 properties:
   debounce-interval-ms:
@@ -47,3 +51,5 @@ child-binding:
     zephyr,code:
       type: int
       description: Key code to emit.
+    wakeup-source:
+      type: boolean

--- a/include/zephyr/drivers/gpio.h
+++ b/include/zephyr/drivers/gpio.h
@@ -144,6 +144,13 @@ extern "C" {
 #define GPIO_INT_ENABLE_DISABLE_ONLY   (1u << 27)
 #endif /* CONFIG_GPIO_ENABLE_DISABLE_INTERRUPT */
 
+/** @cond INTERNAL_HIDDEN */
+
+/** Enables pin as an wakeup-source. */
+#define GPIO_WAKEUP_SOURCE             (1U << 28)
+
+/** @endcond */
+
 #define GPIO_INT_MASK                  (GPIO_INT_DISABLE | \
 					GPIO_INT_ENABLE | \
 					GPIO_INT_LEVELS_LOGICAL | \


### PR DESCRIPTION
This introduces the wakeup-source capability to gpio-keys drivers including the missing pinctrl support. With this a GPIO driver that handles the GPIO_WAKEUP_SOURCE flag can wakeup the system.

@gmarull , @fabiobaltieri , @bjarki-trackunit 

This proposes the missing step in the GPIO driver to allow the functionality. The GPIO_WAKEUP_SOURCE flag is necessary to inform the GPIO driver that pin should be configured as a wakeup-source. The definition of an internal flag is to be compliance with the wakeup-source. In this proposal no new API is required and people can start to adapt their own drivers to use the new flag.