### PR TITLE
soc: intel_adsp: cavs: fix dts memory address format

### DIFF
--- a/dts/xtensa/intel/intel_adsp_cavs25.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs25.dtsi
@@ -98,7 +98,7 @@
 		wovcro-supported;
 	};
 
-	IMR1: memory@0xb0000000 {
+	IMR1: memory@b0000000 {
 		compatible = "intel,adsp-imr";
 		reg = <0xB0000000 DT_SIZE_M(16)>;
 		block-size = <0x1000>;

--- a/dts/xtensa/intel/intel_adsp_cavs25_tgph.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs25_tgph.dtsi
@@ -84,7 +84,7 @@
 		wovcro-supported;
 	};
 
-	IMR1: memory@0xb0000000 {
+	IMR1: memory@b0000000 {
 		compatible = "intel,adsp-imr";
 		reg = <0xB0000000 DT_SIZE_M(16)>;
 		block-size = <0x1000>;


### PR DESCRIPTION
Fix the following compilation warning:

```
Warning (unit_address_format): /memory@0xb0000000: \
    unit name should not have leading "0x"
```