### PR TITLE
doc: memory: Fix SYS_MEM_BLOCKS_DEFINE_STATIC description

### DIFF
--- a/doc/kernel/memory_management/sys_mem_blocks.rst
+++ b/doc/kernel/memory_management/sys_mem_blocks.rst
@@ -112,7 +112,7 @@ to a 4-byte boundary:
 
    SYS_MEM_BLOCKS_DEFINE(allocator, 64, 4, 4);
 
-Similarly, you can define a memory slab in private scope:
+Similarly, you can define a memory blocks allocator in private scope:
 
 .. code-block:: c
 


### PR DESCRIPTION
Fix SYS_MEM_BLOCKS_DEFINE_STATIC() description.
Use a "memory blocks allocator" instead of "slab", which is most probably was copy-pasted from
the previous "slab" chapter by mistake.