### PR TITLE
Bluetooth: audio: host: call the stream disable callback

### DIFF
--- a/tests/bluetooth/audio/ascs/src/main.c
+++ b/tests/bluetooth/audio/ascs/src/main.c
@@ -500,6 +500,7 @@ ZTEST_F(ascs_test_suite, test_cis_link_loss_in_streaming_state)
 
 	/* Expected to notify the upper layers */
 	expect_bt_bap_stream_ops_qos_set_called_once(stream);
+	expect_bt_bap_stream_ops_disabled_called_once(stream);
 	expect_bt_bap_stream_ops_released_not_called();
 
 	bt_bap_unicast_server_unregister_cb(&mock_bap_unicast_server_cb);
@@ -533,6 +534,9 @@ static void test_cis_link_loss_in_disabling_state(struct ascs_test_suite_fixture
 	}
 
 	test_ase_control_client_disable(conn, ase_id);
+
+	expect_bt_bap_stream_ops_disabled_called_once(stream);
+
 	test_mocks_reset();
 
 	/* Mock CIS disconnection */
@@ -540,6 +544,7 @@ static void test_cis_link_loss_in_disabling_state(struct ascs_test_suite_fixture
 
 	/* Expected to notify the upper layers */
 	expect_bt_bap_stream_ops_qos_set_called_once(stream);
+	expect_bt_bap_stream_ops_disabled_not_called();
 	expect_bt_bap_stream_ops_released_not_called();
 
 	bt_bap_unicast_server_unregister_cb(&mock_bap_unicast_server_cb);
@@ -594,6 +599,7 @@ ZTEST_F(ascs_test_suite, test_cis_link_loss_in_enabling_state)
 
 	if (IS_ENABLED(CONFIG_BT_ASCS_ASE_SNK)) {
 		expect_bt_bap_stream_ops_qos_set_called_once(stream);
+		expect_bt_bap_stream_ops_disabled_called_once(stream);
 	} else {
 		/* Server-initiated disable operation that shall not cause transition to QoS */
 		expect_bt_bap_stream_ops_qos_set_not_called();

--- a/tests/bluetooth/audio/ascs/src/test_ase_state_transition.c
+++ b/tests/bluetooth/audio/ascs/src/test_ase_state_transition.c
@@ -106,6 +106,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_codec_configured_to_qos_conf
 	/* Verification */
 	expect_bt_bap_unicast_server_cb_qos_called_once(stream, EMPTY);
 	expect_bt_bap_stream_ops_qos_set_called_once(stream);
+	expect_bt_bap_stream_ops_disabled_not_called();
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_client_qos_configured_to_enabling)
@@ -140,6 +141,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_enabling_to_qos_configured)
 	/* Verification */
 	expect_bt_bap_unicast_server_cb_disable_called_once(stream);
 	expect_bt_bap_stream_ops_qos_set_called_once(stream);
+	expect_bt_bap_stream_ops_disabled_called_once(stream);
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_client_qos_configured_to_releasing)
@@ -192,6 +194,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_qos_configured_to_qos_config
 	/* Verification */
 	expect_bt_bap_unicast_server_cb_qos_called_once(stream, EMPTY);
 	expect_bt_bap_stream_ops_qos_set_called_once(stream);
+	expect_bt_bap_stream_ops_disabled_not_called();
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_client_qos_configured_to_codec_configured)
@@ -243,6 +246,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_enabling_to_releasing)
 	/* Verification */
 	expect_bt_bap_unicast_server_cb_release_called_once(stream);
 	expect_bt_bap_stream_ops_released_called_once(stream);
+	expect_bt_bap_stream_ops_disabled_not_called();
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_client_enabling_to_enabling)
@@ -260,6 +264,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_enabling_to_enabling)
 	/* Verification */
 	expect_bt_bap_unicast_server_cb_metadata_called_once(stream, EMPTY, EMPTY);
 	expect_bt_bap_stream_ops_metadata_updated_called_once(stream);
+	expect_bt_bap_stream_ops_disabled_not_called();
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_client_streaming_to_releasing)
@@ -282,6 +287,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_streaming_to_releasing)
 	expect_bt_bap_unicast_server_cb_release_called_once(stream);
 	expect_bt_bap_stream_ops_stopped_called_once(stream, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 	expect_bt_bap_stream_ops_released_called_once(stream);
+	expect_bt_bap_stream_ops_disabled_not_called();
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_client_streaming_to_streaming)
@@ -300,6 +306,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_streaming_to_streaming)
 	/* Verification */
 	expect_bt_bap_unicast_server_cb_metadata_called_once(stream, EMPTY, EMPTY);
 	expect_bt_bap_stream_ops_metadata_updated_called_once(stream);
+	expect_bt_bap_stream_ops_disabled_not_called();
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_client_streaming_to_qos_configured)
@@ -319,6 +326,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_streaming_to_qos_configured)
 	expect_bt_bap_unicast_server_cb_disable_called_once(stream);
 	expect_bt_bap_stream_ops_stopped_called_once(stream, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 	expect_bt_bap_stream_ops_qos_set_called_once(stream);
+	expect_bt_bap_stream_ops_disabled_called_once(stream);
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_server_idle_to_codec_configured)
@@ -436,6 +444,7 @@ ZTEST_F(test_sink_ase_state_transition, test_server_enabling_to_releasing)
 	/* Verification */
 	expect_bt_bap_unicast_server_cb_release_called_once(stream);
 	expect_bt_bap_stream_ops_released_called_once(stream);
+	expect_bt_bap_stream_ops_disabled_not_called();
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_server_enabling_to_enabling)
@@ -459,6 +468,7 @@ ZTEST_F(test_sink_ase_state_transition, test_server_enabling_to_enabling)
 	/* Verification */
 	expect_bt_bap_unicast_server_cb_metadata_called_once(stream, EMPTY, EMPTY);
 	expect_bt_bap_stream_ops_metadata_updated_called_once(stream);
+	expect_bt_bap_stream_ops_disabled_not_called();
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_server_enabling_to_qos_configured)
@@ -478,6 +488,7 @@ ZTEST_F(test_sink_ase_state_transition, test_server_enabling_to_qos_configured)
 	/* Verification */
 	expect_bt_bap_unicast_server_cb_disable_called_once(stream);
 	expect_bt_bap_stream_ops_qos_set_called_once(stream);
+	expect_bt_bap_stream_ops_disabled_called_once(stream);
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_server_enabling_to_streaming)
@@ -500,6 +511,7 @@ ZTEST_F(test_sink_ase_state_transition, test_server_enabling_to_streaming)
 
 	/* Verification */
 	expect_bt_bap_stream_ops_started_called_once(stream);
+	expect_bt_bap_stream_ops_disabled_not_called();
 	/* XXX: unicast_server_cb->start is not called for Sink ASE */
 }
 
@@ -525,6 +537,7 @@ ZTEST_F(test_sink_ase_state_transition, test_server_streaming_to_streaming)
 	/* Verification */
 	expect_bt_bap_unicast_server_cb_metadata_called_once(stream, EMPTY, EMPTY);
 	expect_bt_bap_stream_ops_metadata_updated_called_once(stream);
+	expect_bt_bap_stream_ops_disabled_not_called();
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_server_streaming_to_qos_configured)
@@ -546,6 +559,7 @@ ZTEST_F(test_sink_ase_state_transition, test_server_streaming_to_qos_configured)
 	expect_bt_bap_unicast_server_cb_disable_called_once(stream);
 	expect_bt_bap_stream_ops_stopped_called_once(stream, BT_HCI_ERR_LOCALHOST_TERM_CONN);
 	expect_bt_bap_stream_ops_qos_set_called_once(stream);
+	expect_bt_bap_stream_ops_disabled_called_once(stream);
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_server_streaming_to_releasing)
@@ -570,6 +584,7 @@ ZTEST_F(test_sink_ase_state_transition, test_server_streaming_to_releasing)
 	expect_bt_bap_unicast_server_cb_release_called_once(stream);
 	expect_bt_bap_stream_ops_stopped_called_once(stream, BT_HCI_ERR_LOCALHOST_TERM_CONN);
 	expect_bt_bap_stream_ops_released_called_once(stream);
+	expect_bt_bap_stream_ops_disabled_not_called();
 }
 
 static void *test_source_ase_state_transition_setup(void)
@@ -623,6 +638,7 @@ ZTEST_F(test_source_ase_state_transition, test_client_codec_configured_to_qos_co
 	/* Verification */
 	expect_bt_bap_unicast_server_cb_qos_called_once(stream, EMPTY);
 	expect_bt_bap_stream_ops_qos_set_called_once(stream);
+	expect_bt_bap_stream_ops_disabled_not_called();
 }
 
 ZTEST_F(test_source_ase_state_transition, test_client_qos_configured_to_enabling)
@@ -696,6 +712,7 @@ ZTEST_F(test_source_ase_state_transition, test_client_enabling_to_streaming)
 	/* Verification */
 	expect_bt_bap_unicast_server_cb_start_called_once(stream);
 	expect_bt_bap_stream_ops_started_called_once(stream);
+	expect_bt_bap_stream_ops_disabled_not_called();
 }
 
 ZTEST_F(test_source_ase_state_transition, test_client_codec_configured_to_codec_configured)
@@ -730,6 +747,7 @@ ZTEST_F(test_source_ase_state_transition, test_client_qos_configured_to_qos_conf
 	/* Verification */
 	expect_bt_bap_unicast_server_cb_qos_called_once(stream, EMPTY);
 	expect_bt_bap_stream_ops_qos_set_called_once(stream);
+	expect_bt_bap_stream_ops_disabled_not_called();
 }
 
 ZTEST_F(test_source_ase_state_transition, test_client_qos_configured_to_codec_configured)
@@ -781,6 +799,7 @@ ZTEST_F(test_source_ase_state_transition, test_client_enabling_to_releasing)
 	/* Verification */
 	expect_bt_bap_unicast_server_cb_release_called_once(stream);
 	expect_bt_bap_stream_ops_released_called_once(stream);
+	expect_bt_bap_stream_ops_disabled_not_called();
 }
 
 ZTEST_F(test_source_ase_state_transition, test_client_enabling_to_enabling)
@@ -798,6 +817,7 @@ ZTEST_F(test_source_ase_state_transition, test_client_enabling_to_enabling)
 	/* Verification */
 	expect_bt_bap_unicast_server_cb_metadata_called_once(stream, EMPTY, EMPTY);
 	expect_bt_bap_stream_ops_metadata_updated_called_once(stream);
+	expect_bt_bap_stream_ops_disabled_not_called();
 }
 
 ZTEST_F(test_source_ase_state_transition, test_client_streaming_to_releasing)
@@ -820,6 +840,7 @@ ZTEST_F(test_source_ase_state_transition, test_client_streaming_to_releasing)
 	expect_bt_bap_unicast_server_cb_release_called_once(stream);
 	expect_bt_bap_stream_ops_stopped_called_once(stream, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 	expect_bt_bap_stream_ops_released_called_once(stream);
+	expect_bt_bap_stream_ops_disabled_not_called();
 }
 
 ZTEST_F(test_source_ase_state_transition, test_client_streaming_to_streaming)
@@ -838,6 +859,7 @@ ZTEST_F(test_source_ase_state_transition, test_client_streaming_to_streaming)
 	/* Verification */
 	expect_bt_bap_unicast_server_cb_metadata_called_once(stream, EMPTY, EMPTY);
 	expect_bt_bap_stream_ops_metadata_updated_called_once(stream);
+	expect_bt_bap_stream_ops_disabled_not_called();
 }
 
 ZTEST_F(test_source_ase_state_transition, test_client_streaming_to_disabling)
@@ -869,6 +891,8 @@ ZTEST_F(test_source_ase_state_transition, test_client_enabling_to_disabling_to_q
 
 	test_preamble_state_enabling(conn, ase_id, stream);
 	test_ase_control_client_disable(conn, ase_id);
+	expect_bt_bap_stream_ops_disabled_called_once(stream);
+
 	test_mocks_reset();
 
 	test_ase_control_client_receiver_stop_ready(conn, ase_id);
@@ -876,6 +900,7 @@ ZTEST_F(test_source_ase_state_transition, test_client_enabling_to_disabling_to_q
 	/* Verification */
 	expect_bt_bap_unicast_server_cb_stop_called_once(stream);
 	expect_bt_bap_stream_ops_qos_set_called_once(stream);
+	expect_bt_bap_stream_ops_disabled_not_called();
 }
 
 ZTEST_F(test_source_ase_state_transition, test_client_streaming_to_disabling_to_qos_configured)
@@ -891,7 +916,9 @@ ZTEST_F(test_source_ase_state_transition, test_client_streaming_to_disabling_to_
 	test_ase_control_client_disable(conn, ase_id);
 
 	/* Verify that stopped callback was called by disable */
+	expect_bt_bap_stream_ops_disabled_called_once(stream);
 	expect_bt_bap_stream_ops_stopped_called_once(stream, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+
 
 	test_mocks_reset();
 
@@ -900,6 +927,7 @@ ZTEST_F(test_source_ase_state_transition, test_client_streaming_to_disabling_to_
 	/* Verification */
 	expect_bt_bap_unicast_server_cb_stop_called_once(stream);
 	expect_bt_bap_stream_ops_qos_set_called_once(stream);
+	expect_bt_bap_stream_ops_disabled_not_called();
 }
 
 ZTEST_F(test_source_ase_state_transition, test_server_idle_to_codec_configured)
@@ -1017,6 +1045,7 @@ ZTEST_F(test_source_ase_state_transition, test_server_enabling_to_releasing)
 	/* Verification */
 	expect_bt_bap_unicast_server_cb_release_called_once(stream);
 	expect_bt_bap_stream_ops_released_called_once(stream);
+	expect_bt_bap_stream_ops_disabled_not_called();
 }
 
 ZTEST_F(test_source_ase_state_transition, test_server_enabling_to_enabling)
@@ -1040,6 +1069,7 @@ ZTEST_F(test_source_ase_state_transition, test_server_enabling_to_enabling)
 	/* Verification */
 	expect_bt_bap_unicast_server_cb_metadata_called_once(stream, EMPTY, EMPTY);
 	expect_bt_bap_stream_ops_metadata_updated_called_once(stream);
+	expect_bt_bap_stream_ops_disabled_not_called();
 }
 
 ZTEST_F(test_source_ase_state_transition, test_server_enabling_to_disabling)
@@ -1083,6 +1113,7 @@ ZTEST_F(test_source_ase_state_transition, test_server_streaming_to_streaming)
 	/* Verification */
 	expect_bt_bap_unicast_server_cb_metadata_called_once(stream, EMPTY, EMPTY);
 	expect_bt_bap_stream_ops_metadata_updated_called_once(stream);
+	expect_bt_bap_stream_ops_disabled_not_called();
 }
 
 ZTEST_F(test_source_ase_state_transition, test_server_streaming_to_disabling)
@@ -1128,4 +1159,5 @@ ZTEST_F(test_source_ase_state_transition, test_server_streaming_to_releasing)
 	expect_bt_bap_unicast_server_cb_release_called_once(stream);
 	expect_bt_bap_stream_ops_stopped_called_once(stream, BT_HCI_ERR_LOCALHOST_TERM_CONN);
 	expect_bt_bap_stream_ops_released_called_once(stream);
+	expect_bt_bap_stream_ops_disabled_not_called();
 }


### PR DESCRIPTION
Even though the ASCS Sink ASE state machine does enter the disabling state according to ASCS spec, it still makes sense to do so, as described in issue #63230

fixes #63230