### PR TITLE
doc: pdf: Use single column for the index

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -184,6 +184,7 @@ latex_elements = {
     "papersize": "a4paper",
     "maketitle": open(ZEPHYR_BASE / "doc" / "_static" / "latex" / "title.tex").read(),
     "preamble": open(ZEPHYR_BASE / "doc" / "_static" / "latex" / "preamble.tex").read(),
+    "makeindex": r"\usepackage[columns=1]{idxlayout}\makeindex",
     "fontpkg": textwrap.dedent(r"""
                                     \usepackage{noto}
                                     \usepackage{inconsolata-nerd-font}


### PR DESCRIPTION
The index at the end of the PDF document can contain pretty long strings that don't fit in the default 2-column layout.
This commit makes the index use a single-column.

Note: this relies on LaTeX package idxlayout which should already be included in the packages recommended for installation in our instructions.

## Before

<img width="827" alt="image" src="https://github.com/zephyrproject-rtos/zephyr/assets/128251/23ae2a3c-bac4-457c-84c3-4160813384e2">

## After

<img width="823" alt="image" src="https://github.com/zephyrproject-rtos/zephyr/assets/128251/0b3a6b7b-93d3-4883-815a-80158bfda79f">
