### PR TITLE
ci: assignees: do not set trivial on manifest changes

### DIFF
--- a/scripts/set_assignees.py
+++ b/scripts/set_assignees.py
@@ -70,8 +70,14 @@ def process_pr(gh, maintainer_file, number):
     all_areas = set()
     fn = list(pr.get_files())
 
+    manifest_change = False
+    for changed_file in fn:
+        if changed_file.filename in ['west.yml','submanifests/optional.yaml']:
+            manifest_change = True
+            break
+
     # one liner PRs should be trivial
-    if pr.commits == 1 and (pr.additions <= 1 and pr.deletions <= 1):
+    if pr.commits == 1 and (pr.additions <= 1 and pr.deletions <= 1) and not manifest_change:
         labels = {'trivial'}
 
     if len(fn) > 500:


### PR DESCRIPTION
manifest changes are often a oneliner change, but they are not
necessarily trivial.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
