### PR TITLE
doc: application: add missing language attribute

### DIFF
--- a/doc/develop/application/index.rst
+++ b/doc/develop/application/index.rst
@@ -521,6 +521,7 @@ Make sure to follow these steps in order.
    Structure your :file:`Kconfig` file like this:
 
    .. literalinclude:: application-kconfig.include
+      :language: kconfig
 
    .. note::
 


### PR DESCRIPTION
Make sure application-kconfig.include is properly highlighted by setting the :language: attribute.