### PR TITLE
samples/net/cloud/aws_iot_mqtt: Fix sample yaml

### DIFF
--- a/samples/net/cloud/aws_iot_mqtt/sample.yaml
+++ b/samples/net/cloud/aws_iot_mqtt/sample.yaml
@@ -4,7 +4,7 @@ sample:
 common:
   tags: net mqtt cloud
   harness: net
-  filter: CONFIG_FULL_LIBC_SUPPORTED && not CONFIG_NATIVE_LIBC
+  filter: CONFIG_FULL_LIBC_SUPPORTED and not CONFIG_NATIVE_LIBC
   extra_args: USE_DUMMY_CREDS=1
 tests:
   sample.net.cloud.aws_iot_mqtt:


### PR DESCRIPTION
The sample yaml filter syntax was incorrect.
Fix it.

