### PR TITLE
tests: Bluetooth: BAP Broadcast sink RX fail fix

### DIFF
--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
@@ -280,7 +280,11 @@ static void recv_cb(struct bt_bap_stream *stream,
 	}
 
 	if (info->flags & BT_ISO_FLAGS_ERROR) {
-		FAIL("ISO receive error\n");
+		/* Fail the test if we have not received what we expected */
+		if (!TEST_FLAG(flag_received)) {
+			FAIL("ISO receive error\n");
+		}
+
 		return;
 	}
 


### PR DESCRIPTION
Added an additional check before failing a BSIM test on ISO error, so that when we stop the broadcast source (after the sink have received the expected data), lost data does not trigger a test failure.