### PR TITLE
Tests: Replace k_current_get() with k_sched_current_thread_query() in…

### DIFF
--- a/tests/kernel/context/src/main.c
+++ b/tests/kernel/context/src/main.c
@@ -127,7 +127,7 @@ static void isr_handler(const void *data)
 
 	switch (isr_info.command) {
 	case THREAD_SELF_CMD:
-		isr_info.data = (void *)k_current_get();
+		isr_info.data = (void *)k_sched_current_thread_query();
 		break;
 
 	case EXEC_CTX_TYPE_CMD:

--- a/tests/kernel/fatal/exception/src/main.c
+++ b/tests/kernel/fatal/exception/src/main.c
@@ -56,7 +56,7 @@ void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
 		k_fatal_halt(reason);
 	}
 
-	if (k_current_get() != &alt_thread) {
+	if (k_sched_current_thread_query() != &alt_thread) {
 		printk("Wrong thread crashed\n");
 		printk("PROJECT EXECUTION FAILED\n");
 		k_fatal_halt(reason);


### PR DESCRIPTION
… ISR context

This fix repairs https://github.com/zephyrproject-rtos/zephyr/issues/62704 that caused by inrorrect using k_current_get() in ISR context.