### PR TITLE
doc: develop: update ram and rom report sample and reduce width

### DIFF
--- a/doc/develop/optimizations/tools.rst
+++ b/doc/develop/optimizations/tools.rst
@@ -33,37 +33,48 @@ Use the ``ram_report`` target with your board:
 
 which will generate something similar to the output below::
 
-    Path                                                                                    Size       %
-    ==============================================================================================================
-    ...
-    ...
-    SystemCoreClock                                                                          4     0.08%
-    _kernel                                                                                 48     0.99%
-    _sw_isr_table                                                                          384     7.94%
-    cli.10544                                                                               16     0.33%
-    gpio_initialized.9765                                                                    1     0.02%
-    on.10543                                                                                 4     0.08%
-    poll_out_lock.9764                                                                       4     0.08%
-    z_idle_threads                                                                         128     2.65%
-    z_interrupt_stacks                                                                    2048    42.36%
-    z_main_thread                                                                          128     2.65%
-    arch                                                                                     1     0.02%
-    arm                                                                                      1     0.02%
-        core                                                                                 1     0.02%
-        aarch32                                                                              1     0.02%
-            cortex_m                                                                         1     0.02%
-            mpu                                                                              1     0.02%
-                arm_mpu.c                                                                    1     0.02%
-                static_regions_num                                                           1     0.02%
-    drivers                                                                                536    11.09%
-    clock_control                                                                          100     2.07%
-        nrf_power_clock.c                                                                  100     2.07%
-        __device_clock_nrf                                                                  16     0.33%
-        data                                                                                80     1.65%
-        hfclk_users                                                                          4     0.08%
-    ...
-    ...
-
+    Path                                                                       Size    %
+    ========================================================================================
+    Root                                                                       4637 100.00%
+    ├── (hidden)                                                                  4   0.09%
+    ├── (no paths)                                                             2748  59.26%
+    │   ├── _cpus_active                                                          4   0.09%
+    │   ├── _kernel                                                              32   0.69%
+    │   ├── _sw_isr_table                                                       384   8.28%
+    │   ├── cli.1                                                                16   0.35%
+    │   ├── on.2                                                                  4   0.09%
+    │   ├── poll_out_lock.0                                                       4   0.09%
+    │   ├── z_idle_threads                                                      128   2.76%
+    │   ├── z_interrupt_stacks                                                 2048  44.17%
+    │   └── z_main_thread                                                       128   2.76%
+    ├── WORKSPACE                                                               184   3.97%
+    │   └── modules                                                             184   3.97%
+    │       └── hal                                                             184   3.97%
+    │           └── nordic                                                      184   3.97%
+    │               └── nrfx                                                    184   3.97%
+    │                   └── drivers                                             184   3.97%
+    │                       └── src                                             184   3.97%
+    │                           ├── nrfx_clock.c                                  8   0.17%
+    │                           │   └── m_clock_cb                                8   0.17%
+    │                           ├── nrfx_gpiote.c                               132   2.85%
+    │                           │   └── m_cb                                    132   2.85%
+    │                           ├── nrfx_ppi.c                                    4   0.09%
+    │                           │   └── m_channels_allocated                      4   0.09%
+    │                           └── nrfx_twim.c                                  40   0.86%
+    │                               └── m_cb                                     40   0.86%
+    └── ZEPHYR_BASE                                                            1701  36.68%
+        ├── arch                                                                  5   0.11%
+        │   └── arm                                                               5   0.11%
+        │       └── core                                                          5   0.11%
+        │           ├── mpu                                                       1   0.02%
+        │           │   └── arm_mpu.c                                             1   0.02%
+        │           │       └── static_regions_num                                1   0.02%
+        │           └── tls.c                                                     4   0.09%
+        │               └── z_arm_tls_ptr                                         4   0.09%
+        ├── drivers                                                             258   5.56%
+        │   ├── ...                                                             ...    ...%
+    ========================================================================================
+                                                                               4637
 
 Build Target: rom_report
 ========================
@@ -82,47 +93,40 @@ Use the ``rom_report`` to get the ROM report:
 
 which will generate something similar to the output below::
 
-    Path                                                                                    Size       %
-    ==============================================================================================================
-    ...
-    ...
-    CSWTCH.5                                                                                 4     0.02%
-    SystemCoreClock                                                                          4     0.02%
-    __aeabi_idiv0                                                                            2     0.01%
-    __udivmoddi4                                                                           702     3.37%
-    _sw_isr_table                                                                          384     1.85%
-    delay_machine_code.9114                                                                  6     0.03%
-    levels.8826                                                                             20     0.10%
-    mpu_config                                                                               8     0.04%
-    transitions.10558                                                                       12     0.06%
-    arch                                                                                  1194     5.74%
-    arm                                                                                   1194     5.74%
-        core                                                                              1194     5.74%
-        aarch32                                                                           1194     5.74%
-            cortex_m                                                                       852     4.09%
-            fault.c                                                                        400     1.92%
-                bus_fault.isra.0                                                            60     0.29%
-                mem_manage_fault.isra.0                                                     56     0.27%
-                usage_fault.isra.0                                                          36     0.17%
-                z_arm_fault                                                                232     1.11%
-                z_arm_fault_init                                                            16     0.08%
-            irq_init.c                                                                      24     0.12%
-                z_arm_interrupt_init                                                        24     0.12%
-            mpu                                                                            352     1.69%
-                arm_core_mpu.c                                                              56     0.27%
-                z_arm_configure_static_mpu_regions                                          56     0.27%
-                arm_mpu.c                                                                  296     1.42%
-                __init_sys_init_arm_mpu_init0                                                8     0.04%
-                arm_core_mpu_configure_static_mpu_regions                                   20     0.10%
-                arm_core_mpu_disable                                                        16     0.08%
-                arm_core_mpu_enable                                                         20     0.10%
-                arm_mpu_init                                                                92     0.44%
-                mpu_configure_regions                                                      140     0.67%
-            thread_abort.c                                                                  76     0.37%
-                z_impl_k_thread_abort
-                76     0.37%
-    ...
-    ...
+    Path                                                                       Size    %
+    ========================================================================================
+    Root                                                                      21652 100.00%
+    ├── ...                                                                     ...    ...%
+    └── ZEPHYR_BASE                                                           13378  61.79%
+        ├── arch                                                               1718   7.93%
+        │   └── arm                                                            1718   7.93%
+        │       └── core                                                       1718   7.93%
+        │           ├── cortex_m                                               1020   4.71%
+        │           │   ├── fault.c                                             620   2.86%
+        │           │   │   ├── bus_fault.constprop.0                           108   0.50%
+        │           │   │   ├── mem_manage_fault.constprop.0                    120   0.55%
+        │           │   │   ├── usage_fault.constprop.0                          84   0.39%
+        │           │   │   ├── z_arm_fault                                     292   1.35%
+        │           │   │   └── z_arm_fault_init                                 16   0.07%
+        │           │   ├── ...                                                 ...    ...%
+        ├── boards                                                               32   0.15%
+        │   └── arm                                                              32   0.15%
+        │       └── reel_board                                                   32   0.15%
+        │           └── board.c                                                  32   0.15%
+        │               ├── __init_board_reel_board_init                          8   0.04%
+        │               └── board_reel_board_init                                24   0.11%
+        ├── build                                                               194   0.90%
+        │   └── zephyr                                                          194   0.90%
+        │       ├── isr_tables.c                                                192   0.89%
+        │       │   └── _irq_vector_table                                       192   0.89%
+        │       └── misc                                                          2   0.01%
+        │           └── generated                                                 2   0.01%
+        │               └── configs.c                                             2   0.01%
+        │                   └── _ConfigAbsSyms                                    2   0.01%
+        ├── drivers                                                            6162  28.46%
+        │   ├── ...                                                             ...    ...%
+    ========================================================================================
+                                                                                    21652
 
 Build Target: puncover
 ======================


### PR DESCRIPTION
Update the sample outputs for ram and rom report commands to reflect current look&feel, and reduce the width of the output to better fit on narrow screens & PDF output.