### PR TITLE
tests: build_all: modem: Remove net tag from test suite

### DIFF
--- a/tests/drivers/build_all/modem/testcase.yaml
+++ b/tests/drivers/build_all/modem/testcase.yaml
@@ -2,7 +2,6 @@ common:
   build_only: true
   tags:
     - drivers
-    - net
     - modem
 tests:
   drivers.modem.build:


### PR DESCRIPTION
The modem drivers are not the net subsystem, and should be built by CI for pull requests. The net tag prevents CI from running the build_all, which does lead to false confidence that the changes are building :)