### PR TITLE
bluetooth: leaudio: Fix missing set of BIG_Encryption

### DIFF
--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -157,7 +157,8 @@ static void update_recv_state_big_cleared(const struct bt_bap_broadcast_sink *si
 		return;
 	}
 
-	if (recv_state->encrypt_state == BT_BAP_BIG_ENC_STATE_BCODE_REQ &&
+	if ((recv_state->encrypt_state == BT_BAP_BIG_ENC_STATE_BCODE_REQ ||
+	     recv_state->encrypt_state == BT_BAP_BIG_ENC_STATE_DEC) &&
 	    reason == BT_HCI_ERR_TERM_DUE_TO_MIC_FAIL) {
 		/* Sync failed due to bad broadcast code */
 		mod_src_param.encrypt_state = BT_BAP_BIG_ENC_STATE_BAD_CODE;


### PR DESCRIPTION
In the PTS BASS/SR/CP/BV-19-C test case a client executes Set Broadcast Code operation of Broadcast Audio Scan Control Point characteristic with Broadcast_Code set to an invalid value. After syncing to an ISO stream there is an expected failed attempt to decrypt the stream data, but the host does not set BIG_Encryption value to the expected value 0x03 (BT_BAP_BIG_ENC_STATE_BAD_CODE). Add missing BIG_Encryption state into the failing check.