### PR TITLE
Bluetooth: Mesh: make sending solicitation pdu independent on gatt proxy client 

### DIFF
--- a/doc/connectivity/bluetooth/api/mesh/proxy.rst
+++ b/doc/connectivity/bluetooth/api/mesh/proxy.rst
@@ -31,7 +31,7 @@ In the case where both GATT Proxy and Private GATT Proxy states are disabled on 
 device cannot connect to it. A node supporting the :ref:`bluetooth_mesh_od_srv` may however be
 solicited to advertise connectable advertising events without enabling the Private GATT Proxy state.
 To solicit the node, the legacy device can send a Solicitation PDU by calling the
-:func:`bt_mesh_proxy_solicit` function.  To enable this feature, the client must to be compiled with
+:func:`bt_mesh_proxy_solicit` function.  To enable this feature, the device must to be compiled with
 the :kconfig:option:`CONFIG_BT_MESH_PROXY_SOLICITATION` option set.
 
 Solicitation PDUs are non-mesh, non-connectable, undirected advertising messages containing Proxy

--- a/include/zephyr/bluetooth/mesh/proxy.h
+++ b/include/zephyr/bluetooth/mesh/proxy.h
@@ -97,9 +97,9 @@ int bt_mesh_proxy_connect(uint16_t net_idx);
  */
 int bt_mesh_proxy_disconnect(uint16_t net_idx);
 
-/** @brief Schedule advertising of Solicitation PDUs on Proxy Client .
+/** @brief Schedule advertising of Solicitation PDUs.
  *
- *  Once called Proxy Client will schedule advertising Solicitation PDUs for the amount of time
+ *  Once called, the device will schedule advertising Solicitation PDUs for the amount of time
  *  defined by @c adv_int * (@c CONFIG_BT_MESH_SOL_ADV_XMIT + 1), where @c adv_int is 20ms
  *  for Bluetooth v5.0 or higher, or 100ms otherwise.
  *

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -1442,11 +1442,10 @@ config BT_MESH_SOLICITATION
 	bool
 
 config BT_MESH_PROXY_SOLICITATION
-	bool "Proxy solicitation feature for Proxy Client support"
-	depends on BT_MESH_PROXY_CLIENT
+	bool "Proxy solicitation feature"
 	select BT_MESH_SOLICITATION
 	help
-	  This option enables support for sending Solicitation PDUs for Proxy Client.
+	  This option enables support for sending Solicitation PDUs.
 
 config BT_MESH_SOL_ADV_XMIT
 	int "Solicitation PDU retransmission count"

--- a/subsys/bluetooth/mesh/shell/od_priv_proxy.c
+++ b/subsys/bluetooth/mesh/shell/od_priv_proxy.c
@@ -15,13 +15,12 @@ static int cmd_od_priv_gatt_proxy_set(const struct shell *sh, size_t argc,
 				      char *argv[])
 {
 	uint8_t val, val_rsp;
+	uint16_t net_idx = bt_mesh_shell_target_ctx.net_idx;
+	uint16_t addr = bt_mesh_shell_target_ctx.dst;
 	int err = 0;
 
-	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_DEV(bt_mesh_shell_target_ctx.net_idx,
-							      bt_mesh_shell_target_ctx.dst);
-
 	if (argc < 2) {
-		err = bt_mesh_od_priv_proxy_cli_get(&ctx, &val_rsp);
+		err = bt_mesh_od_priv_proxy_cli_get(net_idx, addr, &val_rsp);
 	} else {
 		val = shell_strtoul(argv[1], 0, &err);
 
@@ -30,7 +29,7 @@ static int cmd_od_priv_gatt_proxy_set(const struct shell *sh, size_t argc,
 			return err;
 		}
 
-		err = bt_mesh_od_priv_proxy_cli_set(&ctx, val, &val_rsp);
+		err = bt_mesh_od_priv_proxy_cli_set(net_idx, addr, val, &val_rsp);
 	}
 
 	if (err) {

--- a/subsys/bluetooth/mesh/shell/shell.c
+++ b/subsys/bluetooth/mesh/shell/shell.c
@@ -387,6 +387,7 @@ static int cmd_proxy_disconnect(const struct shell *sh, size_t argc,
 
 	return 0;
 }
+#endif /* CONFIG_BT_MESH_PROXY_CLIENT */
 
 #if defined(CONFIG_BT_MESH_PROXY_SOLICITATION)
 static int cmd_proxy_solicit(const struct shell *sh, size_t argc,
@@ -410,7 +411,6 @@ static int cmd_proxy_solicit(const struct shell *sh, size_t argc,
 	return err;
 }
 #endif /* CONFIG_BT_MESH_PROXY_SOLICITATION */
-#endif /* CONFIG_BT_MESH_PROXY_CLIENT */
 #endif /* CONFIG_BT_MESH_SHELL_GATT_PROXY */
 
 #if defined(CONFIG_BT_MESH_SHELL_PROV)
@@ -1739,11 +1739,11 @@ SHELL_STATIC_SUBCMD_SET_CREATE(proxy_cmds,
 #if defined(CONFIG_BT_MESH_PROXY_CLIENT)
 	SHELL_CMD_ARG(connect, NULL, "<NetKeyIdx>", cmd_proxy_connect, 2, 0),
 	SHELL_CMD_ARG(disconnect, NULL, "<NetKeyIdx>", cmd_proxy_disconnect, 2, 0),
+#endif
 
 #if defined(CONFIG_BT_MESH_PROXY_SOLICITATION)
 	SHELL_CMD_ARG(solicit, NULL, "<NetKeyIdx>",
 		      cmd_proxy_solicit, 2, 0),
-#endif
 #endif
 	SHELL_SUBCMD_SET_END);
 #endif /* CONFIG_BT_MESH_SHELL_GATT_PROXY */


### PR DESCRIPTION
The mesh specification doesn't mandate to have both functionalities(sending solicitation pdu and gatt proxy client) at the same time.
PR makes them independent.