### PR TITLE
net: lwm2m: Fix core objects version reporting

### DIFF
--- a/include/zephyr/net/lwm2m.h
+++ b/include/zephyr/net/lwm2m.h
@@ -49,6 +49,7 @@
 #define LWM2M_OBJECT_PORTFOLIO_ID               16 /**< Portfolio object */
 #define LWM2M_OBJECT_BINARYAPPDATACONTAINER_ID  19 /**< Binary App Data Container object */
 #define LWM2M_OBJECT_EVENT_LOG_ID               20 /**< Event Log object */
+#define LWM2M_OBJECT_OSCORE_ID                  21 /**< OSCORE object */
 #define LWM2M_OBJECT_GATEWAY_ID                 25 /**< Gateway object */
 /* clang-format on */
 


### PR DESCRIPTION
Core objects version reporting was broken for LwM2M version 1.1, as the default object version not necessarily matches the LwM2M version. Therefore, implement a table with default object versions for particular LwM2M version, which can be looked up when determining whether it's needed to include object version or not during Registration/Discovery.

Fixes #64775