### PR TITLE
lib: os: assert: Define empty __ASSERT_UNREACHABLE when asserts not enabled

### DIFF
--- a/include/zephyr/sys/__assert.h
+++ b/include/zephyr/sys/__assert.h
@@ -141,6 +141,7 @@ void assert_post_action(const char *file, unsigned int line);
 #define __ASSERT_EVAL(expr1, expr2, test, fmt, ...) expr1
 #define __ASSERT_NO_MSG(test) { }
 #define __ASSERT_POST_ACTION() { }
+#define __ASSERT_UNREACHABLE
 #endif
 
 #endif /* ZEPHYR_INCLUDE_SYS___ASSERT_H_ */


### PR DESCRIPTION
When CONFIG_ASSERT/__ASSERT_ON is not enabled, there is no definition of
__ASSERT_UNREACHABLE, which causes build errors.

Add an empty __ASSERT_UNREACHABLE definition when
CONFIG_ASSERT/__ASSERT_ON is not enabled.

Signed-off-by: Rob Barnes <robbarnes@google.com>