### PR TITLE
tests: coredump: Enable code coverage

### DIFF
--- a/tests/subsys/debug/coredump/CMakeLists.txt
+++ b/tests/subsys/debug/coredump/CMakeLists.txt
@@ -3,6 +3,6 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(hello_world)
+project(debug_coredump)
 
 target_sources(app PRIVATE src/main.c)

--- a/tests/subsys/debug/coredump/src/main.c
+++ b/tests/subsys/debug/coredump/src/main.c
@@ -8,6 +8,23 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/debug/coredump.h>
 
+#ifdef CONFIG_COVERAGE_DUMP
+#include <zephyr/debug/gcov.h>
+#endif
+
+
+void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
+{
+	ARG_UNUSED(pEsf);
+
+	printk("%s is expected; reason = %u; halting ...\n", __func__, reason);
+
+#ifdef CONFIG_COVERAGE_DUMP
+	gcov_coverage_dump();  /* LCOV_EXCL_LINE */
+#endif
+	k_fatal_halt(reason);
+}
+
 void func_3(uint32_t *addr)
 {
 #if defined(CONFIG_BOARD_M2GL025_MIV) || \

--- a/tests/subsys/debug/coredump/testcase.yaml
+++ b/tests/subsys/debug/coredump/testcase.yaml
@@ -14,8 +14,11 @@ tests:
       type: multi_line
       regex:
         - "Coredump: (.*)"
+        - ">>> ZEPHYR FATAL ERROR "
         - "E: #CD:BEGIN#"
         - "E: #CD:5([aA])45([0-9a-fA-F]+)"
         - "E: #CD:41([0-9a-fA-F]+)"
         - "E: #CD:4([dD])([0-9a-fA-F]+)"
+        - "E: #CD:4([dD])([0-9a-fA-F]+)"
         - "E: #CD:END#"
+        - "k_sys_fatal_error_handler"


### PR DESCRIPTION
Enable code coverage reporting for debug.coredump.logging_backend test.
Extend test matching patterns and fix cmake project name.