### PR TITLE
boards: arm: Fix sensor shell sample for beagleconnect_freedom board

### DIFF
--- a/boards/arm/beagle_bcf/beagleconnect_freedom.dts
+++ b/boards/arm/beagle_bcf/beagleconnect_freedom.dts
@@ -64,18 +64,6 @@
 		#size-cells = <0>;
 		controller = <&i2c0>;
 		gpios = <&gpio0 14 GPIO_ACTIVE_HIGH>;
-
-		light: opt3001-light@44 {
-			status = "okay";
-			compatible = "ti,opt3001";
-			reg = <0x44>;
-		};
-
-		humidity: hdc2010-humidity@41 {
-			status = "okay";
-			compatible = "ti,hdc2010";
-			reg = <0x41>;
-		};
 	};
 };
 
@@ -137,6 +125,18 @@
 	mcu: msp430-usbbridge@4 {
 		compatible = "beagle,usbbridge";
 		reg = <0x4>;
+	};
+
+	light: opt3001-light@44 {
+		status = "okay";
+		compatible = "ti,opt3001";
+		reg = <0x44>;
+	};
+
+	humidity: hdc2010-humidity@41 {
+		status = "okay";
+		compatible = "ti,hdc2010";
+		reg = <0x41>;
 	};
 };
 


### PR DESCRIPTION
Commit 944ced68f5e558c9cf5e30b69b3ab8a6d7e6f15e enabled CONFIG_UART_CONSOLE=y for the beagleconnect_freedom board, which had the side effect of satisfying a required dependency for the sensor shell sample application and causing new build errors in the weekly full twister run. Fix the build errors by moving the board's light and humidity sensor nodes to be children of the I2C controller node.

cc: @Ayush1325 @jadonk 

https://github.com/zephyrproject-rtos/zephyr/actions/runs/6758835093/job/18371014455#step:14:4966