### PR TITLE
samples: fs: littlefs: sdmmc: remove fstab and fixed partition

### DIFF
--- a/samples/subsys/fs/littlefs/boards/stm32h747i_disco_m7.overlay
+++ b/samples/subsys/fs/littlefs/boards/stm32h747i_disco_m7.overlay
@@ -4,35 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &storage_partition;
-
-/ {
-	fstab {
-		compatible = "zephyr,fstab";
-		lfs1: lfs1 {
-			compatible = "zephyr,fstab,littlefs";
-			read-size = <512>;
-			prog-size = <512>;
-			cache-size = <512>;
-			lookahead-size = <4096>;
-			block-cycles = <512>;
-			partition = <&storage_partition>;
-			mount-point = "/lfsemmc";
-		};
-	};
-};
-
 &sdmmc1 {
         sdmmc {
 		compatible = "zephyr,sdmmc-disk";
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-			storage_partition: partition@0 {
-				label = "storage";
-				reg = <0x0 DT_SIZE_M(2048)>;
-			};
-		};
 	};
 };


### PR DESCRIPTION
For littleFS, the fstab entries in DTS are ignored currently. So remove the overlay entries for the same. Also fixed-partitions can't be used for sdmmc-disk. So remove the same. We just need to have sdmmc node with zephyr,sdmmc-disk compatible string to have littleFS working on disk.

build littleFS sample as follows:-

west build -p always -b stm32h747i_disco_m7 \
samples/subsys/fs/littlefs/ -- \
-DOVERLAY_CONFIG=boards/stm32h747i_disco_m7.conf \ -DCONF_FILE=prj_blk.conf