### PR TITLE
counter: nxp_s32_sys_timer: use instance-based DT macros

### DIFF
--- a/drivers/counter/counter_nxp_s32_sys_timer.c
+++ b/drivers/counter/counter_nxp_s32_sys_timer.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT nxp_s32_sys_timer
+
 #include <zephyr/drivers/counter.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/logging/log.h>
@@ -14,13 +16,8 @@
 
 LOG_MODULE_REGISTER(nxp_s32_sys_timer, CONFIG_COUNTER_LOG_LEVEL);
 
-#define SYS_TIMER_NODE(n)		DT_NODELABEL(stm##n)
 #define SYS_TIMER_MAX_VALUE		0xFFFFFFFFU
 #define SYS_TIMER_NUM_CHANNELS		4
-#define SYS_TIMER_INSTANCE_ID(n)	(n + 3 + CONFIG_NXP_S32_RTU_INDEX * 4)
-
-#define _SYS_TIMER_ISR(r, n)	RTU##r##_STM_##n##_ISR
-#define SYS_TIMER_ISR(r, n)	_SYS_TIMER_ISR(r, n)
 
 struct nxp_s32_sys_timer_chan_data {
 	counter_alarm_callback_t callback;
@@ -209,15 +206,24 @@ static const struct counter_driver_api nxp_s32_sys_timer_driver_api = {
 		.channelMode = STM_IP_CH_MODE_ONESHOT,		\
 	}
 
+#define _SYS_TIMER_ISR(r, n)	RTU##r##_STM_##n##_ISR
+#define SYS_TIMER_ISR(r, n)	_SYS_TIMER_ISR(r, n)
+
 #define SYS_TIMER_ISR_DECLARE(n)	\
 	extern void SYS_TIMER_ISR(CONFIG_NXP_S32_RTU_INDEX, n)(void)
+
+#define SYS_TIMER_HW_INSTANCE_CHECK(i, n) \
+	((DT_INST_REG_ADDR(n) == IP_STM_##i##_BASE) ? i : 0)
+
+#define SYS_TIMER_HW_INSTANCE(n) \
+	LISTIFY(__DEBRACKET STM_INSTANCE_COUNT, SYS_TIMER_HW_INSTANCE_CHECK, (|), n)
 
 #define SYS_TIMER_INIT_DEVICE(n)							\
 	SYS_TIMER_ISR_DECLARE(n);							\
 											\
 	void nxp_s32_sys_timer_##n##_callback(uint8_t chan_id)				\
 	{										\
-		const struct device *dev = DEVICE_DT_GET(SYS_TIMER_NODE(n));		\
+		const struct device *dev = DEVICE_DT_INST_GET(n);			\
 		const struct nxp_s32_sys_timer_config *config = dev->config;		\
 		struct nxp_s32_sys_timer_data *data = dev->data;			\
 		struct nxp_s32_sys_timer_chan_data *ch_data = &data->ch_data[chan_id];	\
@@ -233,12 +239,10 @@ static const struct counter_driver_api nxp_s32_sys_timer_driver_api = {
 											\
 	static int nxp_s32_sys_timer_##n##_init(const struct device *dev)		\
 	{										\
-		IRQ_CONNECT(DT_IRQN(SYS_TIMER_NODE(n)),					\
-			    DT_IRQ(SYS_TIMER_NODE(n), priority),			\
+		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority),			\
 			    SYS_TIMER_ISR(CONFIG_NXP_S32_RTU_INDEX, n),			\
-			    DEVICE_DT_GET(SYS_TIMER_NODE(n)),				\
-			    DT_IRQ(SYS_TIMER_NODE(n), flags));				\
-		irq_enable(DT_IRQN(SYS_TIMER_NODE(n)));					\
+			    DEVICE_DT_INST_GET(n), DT_INST_IRQ(n, flags));		\
+		irq_enable(DT_INST_IRQN(n));						\
 											\
 		return nxp_s32_sys_timer_init(dev);					\
 	}										\
@@ -252,19 +256,18 @@ static const struct counter_driver_api nxp_s32_sys_timer_driver_api = {
 			.flags = COUNTER_CONFIG_INFO_COUNT_UP,				\
 		},									\
 		.hw_cfg = {								\
-			.stopInDebugMode = DT_PROP(SYS_TIMER_NODE(n), freeze),		\
-			.clockPrescaler = DT_PROP(SYS_TIMER_NODE(n), prescaler) - 1,	\
+			.stopInDebugMode = DT_INST_PROP(n, freeze),			\
+			.clockPrescaler = DT_INST_PROP(n, prescaler) - 1,		\
 		},									\
 		.ch_cfg = {								\
 			LISTIFY(SYS_TIMER_NUM_CHANNELS, SYS_TIMER_CHANNEL_CFG, (,), n)	\
 		},									\
-		.instance = SYS_TIMER_INSTANCE_ID(n),					\
-		.clock_dev = DEVICE_DT_GET(DT_CLOCKS_CTLR(SYS_TIMER_NODE(n))),		\
-		.clock_subsys = (clock_control_subsys_t)				\
-				DT_CLOCKS_CELL(SYS_TIMER_NODE(n), name),		\
+		.instance = SYS_TIMER_HW_INSTANCE(n),					\
+		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),			\
+		.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),	\
 	};										\
 											\
-	DEVICE_DT_DEFINE(SYS_TIMER_NODE(n),						\
+	DEVICE_DT_INST_DEFINE(n,							\
 			 nxp_s32_sys_timer_##n##_init,					\
 			 NULL,								\
 			 &nxp_s32_sys_timer_data_##n,					\
@@ -273,18 +276,4 @@ static const struct counter_driver_api nxp_s32_sys_timer_driver_api = {
 			 CONFIG_COUNTER_INIT_PRIORITY,					\
 			 &nxp_s32_sys_timer_driver_api);
 
-#if DT_NODE_HAS_STATUS(SYS_TIMER_NODE(0), okay)
-SYS_TIMER_INIT_DEVICE(0)
-#endif
-
-#if DT_NODE_HAS_STATUS(SYS_TIMER_NODE(1), okay)
-SYS_TIMER_INIT_DEVICE(1)
-#endif
-
-#if DT_NODE_HAS_STATUS(SYS_TIMER_NODE(2), okay)
-SYS_TIMER_INIT_DEVICE(2)
-#endif
-
-#if DT_NODE_HAS_STATUS(SYS_TIMER_NODE(3), okay)
-SYS_TIMER_INIT_DEVICE(3)
-#endif
+DT_INST_FOREACH_STATUS_OKAY(SYS_TIMER_INIT_DEVICE)

--- a/soc/arm/nxp_s32/s32ze/soc.h
+++ b/soc/arm/nxp_s32/s32ze/soc.h
@@ -33,4 +33,19 @@
 #define IP_SWT_11_BASE          IP_RTU1__SWT_4_BASE
 #define IP_SWT_12_BASE          IP_SMU__SWT_BASE
 
+/* STM */
+#define IP_STM_0_BASE           IP_CE_STM_0_BASE
+#define IP_STM_1_BASE           IP_CE_STM_1_BASE
+#define IP_STM_2_BASE           IP_CE_STM_2_BASE
+#define IP_STM_3_BASE           IP_RTU0__STM_0_BASE
+#define IP_STM_4_BASE           IP_RTU0__STM_1_BASE
+#define IP_STM_5_BASE           IP_RTU0__STM_2_BASE
+#define IP_STM_6_BASE           IP_RTU0__STM_3_BASE
+#define IP_STM_7_BASE           IP_RTU1__STM_0_BASE
+#define IP_STM_8_BASE           IP_RTU1__STM_1_BASE
+#define IP_STM_9_BASE           IP_RTU1__STM_2_BASE
+#define IP_STM_10_BASE          IP_RTU1__STM_3_BASE
+#define IP_STM_11_BASE          IP_SMU__STM_0_BASE
+#define IP_STM_12_BASE          IP_SMU__STM_2_BASE
+
 #endif /* _NXP_S32_S32ZE_SOC_H_ */


### PR DESCRIPTION
At present, many of the NXP S32 shim drivers do not make use of devicetree instance-based macros because the NXP S32 HAL relies on an index-based approach, requiring knowledge of the peripheral instance index during both compilation and runtime, and this index might not align with the devicetree instance index.

The proposed solution in this patch eliminates this limitation by determining the peripheral instance index during compilation through macrobatics. Note that for some peripheral instances is needed to redefine the HAL macros of the peripheral base address, since the naming is not uniform for all instances.

```
west twister -p s32z270dc2_rtu0_r52@D --device-testing --device-serial=/dev/ttyUSB0 -T tests/drivers/counter/
INFO    - Using Ninja..
INFO    - Zephyr version: zephyr-v3.5.0-1062-gca4bb104a519
INFO    - Using 'zephyr' toolchain.
INFO    - Building initial testsuite list...
INFO    - Writing JSON report /home/user/zephyrproject/zephyr/twister-out/testplan.json
INFO    - JOBS: 8
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - Total complete:    7/   7  100%  skipped:    6, failed:    0, error:    0
INFO    - 7 test scenarios (7 test instances) selected, 6 configurations skipped (6 by static filter, 0 at runtime).
INFO    - 1 of 7 test configurations passed (100.00%), 0 failed, 0 errored, 6 skipped with 0 warnings in 49.77 seconds
INFO    - In total 10 test cases were executed, 32 skipped on 1 out of total 637 platforms (0.16%)
INFO    - 1 test configurations executed on platforms, 0 test configurations were only built.
```