### PR TITLE
watchdog: nxp_s32: get peripheral hw index at compile time 

### DIFF
--- a/samples/drivers/watchdog/sample.yaml
+++ b/samples/drivers/watchdog/sample.yaml
@@ -20,6 +20,8 @@ tests:
     platform_exclude:
       - s32z270dc2_rtu0_r52
       - s32z270dc2_rtu1_r52
+      - s32z270dc2_rtu0_r52@D
+      - s32z270dc2_rtu1_r52@D
   sample.drivers.watchdog.stm32_wwdg:
     extra_args: DTC_OVERLAY_FILE=boards/stm32_wwdg.overlay
     filter: dt_compat_enabled("st,stm32-window-watchdog")
@@ -106,3 +108,5 @@ tests:
     platform_allow:
       - s32z270dc2_rtu0_r52
       - s32z270dc2_rtu1_r52
+      - s32z270dc2_rtu0_r52@D
+      - s32z270dc2_rtu1_r52@D

--- a/soc/arm/nxp_s32/s32ze/soc.h
+++ b/soc/arm/nxp_s32/s32ze/soc.h
@@ -18,4 +18,19 @@
 /* LINFlexD*/
 #define IP_LINFLEX_12_BASE      IP_MSC_0_LIN_BASE
 
+/* SWT */
+#define IP_SWT_0_BASE           IP_CE_SWT_0_BASE
+#define IP_SWT_1_BASE           IP_CE_SWT_1_BASE
+#define IP_SWT_2_BASE           IP_RTU0__SWT_0_BASE
+#define IP_SWT_3_BASE           IP_RTU0__SWT_1_BASE
+#define IP_SWT_4_BASE           IP_RTU0__SWT_2_BASE
+#define IP_SWT_5_BASE           IP_RTU0__SWT_3_BASE
+#define IP_SWT_6_BASE           IP_RTU0__SWT_4_BASE
+#define IP_SWT_7_BASE           IP_RTU1__SWT_0_BASE
+#define IP_SWT_8_BASE           IP_RTU1__SWT_1_BASE
+#define IP_SWT_9_BASE           IP_RTU1__SWT_2_BASE
+#define IP_SWT_10_BASE          IP_RTU1__SWT_3_BASE
+#define IP_SWT_11_BASE          IP_RTU1__SWT_4_BASE
+#define IP_SWT_12_BASE          IP_SMU__SWT_BASE
+
 #endif /* _NXP_S32_S32ZE_SOC_H_ */

--- a/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -14,6 +14,8 @@ tests:
       - mec15xxevb_assy6853
       - s32z270dc2_rtu0_r52
       - s32z270dc2_rtu1_r52
+      - s32z270dc2_rtu0_r52@D
+      - s32z270dc2_rtu1_r52@D
   drivers.watchdog.stm32wwdg:
     filter: dt_compat_enabled("st,stm32-window-watchdog") or dt_compat_enabled("st,stm32-watchdog")
     extra_args: DTC_OVERLAY_FILE="boards/stm32_wwdg.overlay"
@@ -117,6 +119,8 @@ tests:
     platform_allow:
       - s32z270dc2_rtu0_r52
       - s32z270dc2_rtu1_r52
+      - s32z270dc2_rtu0_r52@D
+      - s32z270dc2_rtu1_r52@D
       - mr_canhubk3
   drivers.watchdog.mimxrt1050_evk_ti_tps382x:
     filter: dt_compat_enabled("ti,tps382x")

--- a/tests/drivers/watchdog/wdt_basic_reset_none/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_reset_none/testcase.yaml
@@ -6,6 +6,8 @@ tests:
     platform_allow:
       - s32z270dc2_rtu0_r52
       - s32z270dc2_rtu1_r52
+      - s32z270dc2_rtu0_r52@D
+      - s32z270dc2_rtu1_r52@D
     tags:
       - drivers
       - watchdog


### PR DESCRIPTION
At present, many of the NXP S32 shim drivers do not make use of devicetree instance-based macros because the NXP S32 HAL relies on an index-based approach, requiring knowledge of the peripheral instance index during both compilation and runtime, and this index might not align with the devicetree instance index.

The proposed solution in this patch eliminates this limitation by determining the peripheral instance index during compilation through macrobatics. Note that for some peripheral instances is needed to redefine the HAL macros of the peripheral base address, since the naming is not uniform for all instances.

Additionally to test these changes, add `s32z270dc2_r52` revision D board to the watchdog tests and samples Twister filters.

```
west twister -p s32z270dc2_rtu0_r52@D --device-testing --device-serial=/dev/ttyUSB0 -T tests/drivers/watchdog/ -T samples/drivers/watchdog/
INFO    - Using Ninja..
INFO    - Zephyr version: zephyr-v3.5.0-1063-gcb425fdc571c
INFO    - Using 'zephyr' toolchain.
INFO    - Building initial testsuite list...
INFO    - Writing JSON report /home/user/zephyrproject/zephyr/twister-out/testplan.json
INFO    - JOBS: 8
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - Total complete:   18/  18  100%  skipped:   17, failed:    0, error:    0
INFO    - 18 test scenarios (18 test instances) selected, 17 configurations skipped (17 by static filter, 0 at runtime).
INFO    - 1 of 18 test configurations passed (100.00%), 0 failed, 0 errored, 17 skipped with 0 warnings in 19.47 seconds
INFO    - In total 2 test cases were executed, 17 skipped on 1 out of total 637 platforms (0.16%)
INFO    - 1 test configurations executed on platforms, 0 test configurations were only built.
```