### PR TITLE
Add Support for the LPC RTC 1KHz counter

### DIFF
--- a/drivers/counter/Kconfig.mcux_lpc_rtc
+++ b/drivers/counter/Kconfig.mcux_lpc_rtc
@@ -1,9 +1,24 @@
-# Copyright (c) 2021, NXP
+# Copyright (c) 2021-23, NXP
 # SPDX-License-Identifier: Apache-2.0
 
 config COUNTER_MCUX_LPC_RTC
 	bool "MCUX LPC RTC driver"
 	default y
+	depends on DT_HAS_NXP_LPC_RTC_ENABLED || \
+		   DT_HAS_NXP_LPC_RTC_HIGHRES_ENABLED
+	help
+	  Enable the LPC rtc driver.
+
+config COUNTER_MCUX_LPC_RTC_1HZ
+	bool "MCUX LPC RTC 1Hz counter driver"
+	default y
 	depends on DT_HAS_NXP_LPC_RTC_ENABLED
 	help
-	  Enable support for LPC rtc driver.
+	  Enable support for LPC 1Hz counter.
+
+config COUNTER_MCUX_LPC_RTC_HIGHRES
+	bool "MCUX LPC RTC High Resolution counter driver"
+	default y
+	depends on DT_HAS_NXP_LPC_RTC_HIGHRES_ENABLED
+	help
+	  Enable support for LPC rtc high resolution counter.

--- a/drivers/counter/counter_mcux_lpc_rtc.c
+++ b/drivers/counter/counter_mcux_lpc_rtc.c
@@ -1,10 +1,8 @@
 /*
- * Copyright 2021-22, NXP
+ * Copyright 2021-23, NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-#define DT_DRV_COMPAT nxp_lpc_rtc
 
 #include <zephyr/drivers/counter.h>
 #include <zephyr/irq.h>
@@ -16,16 +14,71 @@ LOG_MODULE_REGISTER(mcux_rtc, CONFIG_COUNTER_LOG_LEVEL);
 
 struct mcux_lpc_rtc_data {
 	counter_alarm_callback_t alarm_callback;
+	counter_top_callback_t top_callback;
 	void *alarm_user_data;
+	void *top_user_data;
+	uint32_t value;
 };
 
 struct mcux_lpc_rtc_config {
 	struct counter_config_info info;
 	RTC_Type *base;
+	const struct device *rtc_dev;
 	void (*irq_config_func)(const struct device *dev);
 	/* Device defined as wake-up source */
 	bool wakeup_source;
 };
+
+#if CONFIG_COUNTER_MCUX_LPC_RTC_HIGHRES
+static int mcux_lpc_rtc_highres_start(const struct device *dev);
+#endif
+
+static void mcux_lpc_rtc_isr(const struct device *dev)
+{
+	const struct counter_config_info *info = dev->config;
+	const struct mcux_lpc_rtc_config *config =
+		CONTAINER_OF(info, struct mcux_lpc_rtc_config, info);
+	struct mcux_lpc_rtc_data *data = dev->data;
+	counter_alarm_callback_t cb;
+	uint32_t current = RTC_GetSecondsTimerCount(config->base);
+
+	LOG_DBG("Current time is %d ticks", current);
+
+	if ((RTC_GetStatusFlags(config->base) & RTC_CTRL_ALARM1HZ_MASK) &&
+	    (data->alarm_callback)) {
+		cb = data->alarm_callback;
+		data->alarm_callback = NULL;
+		cb(dev, 0, current, data->alarm_user_data);
+	}
+
+	if (data->top_callback) {
+		data->top_callback(dev, data->top_user_data);
+	}
+
+	/*
+	 * Clear any conditions to ack the IRQ
+	 *
+	 * callback may have already reset the alarm flag if a new
+	 * alarm value was programmed to the TAR
+	 */
+	if (RTC_GetStatusFlags(config->base) & RTC_CTRL_ALARM1HZ_MASK) {
+		RTC_ClearStatusFlags(config->base, kRTC_AlarmFlag);
+	}
+
+	/* Check if the Wake counter interrupt was set */
+	if (RTC_GetStatusFlags(config->base) & RTC_CTRL_WAKE1KHZ_MASK) {
+		RTC_ClearStatusFlags(config->base, kRTC_WakeupFlag);
+#if CONFIG_COUNTER_MCUX_LPC_RTC_HIGHRES
+		if (config->base->CTRL & RTC_CTRL_RTC1KHZ_EN_MASK) {
+			mcux_lpc_rtc_highres_start(dev);
+		}
+#endif
+	}
+}
+
+#if CONFIG_COUNTER_MCUX_LPC_RTC_1HZ
+
+#define DT_DRV_COMPAT nxp_lpc_rtc
 
 static int mcux_lpc_rtc_start(const struct device *dev)
 {
@@ -145,41 +198,6 @@ static uint32_t mcux_lpc_rtc_get_top_value(const struct device *dev)
 	return info->max_top_value;
 }
 
-static void mcux_lpc_rtc_isr(const struct device *dev)
-{
-	const struct counter_config_info *info = dev->config;
-	const struct mcux_lpc_rtc_config *config =
-		CONTAINER_OF(info, struct mcux_lpc_rtc_config, info);
-	struct mcux_lpc_rtc_data *data = dev->data;
-	counter_alarm_callback_t cb;
-	uint32_t current = mcux_lpc_rtc_read(dev);
-	uint32_t enable = (config->base->CTRL & RTC_CTRL_RTC_EN_MASK);
-
-
-	LOG_DBG("Current time is %d ticks", current);
-
-	if ((RTC_GetStatusFlags(config->base) & RTC_CTRL_ALARM1HZ_MASK) &&
-	    (data->alarm_callback)) {
-		cb = data->alarm_callback;
-		data->alarm_callback = NULL;
-		cb(dev, 0, current, data->alarm_user_data);
-	}
-
-	/*
-	 * Clear any conditions to ack the IRQ
-	 *
-	 * callback may have already reset the alarm flag if a new
-	 * alarm value was programmed to the TAR
-	 */
-	RTC_EnableTimer(config->base, false);
-	if (RTC_GetStatusFlags(config->base) & RTC_CTRL_ALARM1HZ_MASK) {
-		RTC_ClearStatusFlags(config->base, kRTC_AlarmFlag);
-	}
-	if (enable) {
-		RTC_EnableTimer(config->base, true);
-	}
-}
-
 static int mcux_lpc_rtc_init(const struct device *dev)
 {
 	const struct counter_config_info *info = dev->config;
@@ -212,11 +230,12 @@ static const struct counter_driver_api mcux_rtc_driver_api = {
 	.get_top_value = mcux_lpc_rtc_get_top_value,
 };
 
-#define COUNTER_LPC_RTC_DEVICE(id)					\
-	static void mcux_lpc_rtc_irq_config_##id(const struct device *dev);  \
-	static const struct mcux_lpc_rtc_config mcux_lpc_rtc_config_##id = { \
-		.base = (RTC_Type *)DT_INST_REG_ADDR(id),		\
-		.irq_config_func = mcux_lpc_rtc_irq_config_##id,	\
+#define COUNTER_LPC_RTC_DEVICE(id)						\
+	static void mcux_lpc_rtc_irq_config_##id(const struct device *dev);	\
+	static const struct mcux_lpc_rtc_config mcux_lpc_rtc_config_##id = {	\
+		.base = (RTC_Type *)DT_INST_REG_ADDR(id),			\
+		.irq_config_func = mcux_lpc_rtc_irq_config_##id,		\
+		.rtc_dev = DEVICE_DT_GET_OR_NULL(DT_INST_CHILD(id, rtc_highres)),	\
 		.info = {						\
 			.max_top_value = UINT32_MAX,			\
 			.freq = 1,					\
@@ -227,7 +246,7 @@ static const struct counter_driver_api mcux_rtc_driver_api = {
 	};								\
 	static struct mcux_lpc_rtc_data mcux_lpc_rtc_data_##id;		\
 	DEVICE_DT_INST_DEFINE(id, &mcux_lpc_rtc_init, NULL,		\
-				&mcux_lpc_rtc_data_##id, &mcux_lpc_rtc_config_##id.info, \
+				&mcux_lpc_rtc_data_##id, &mcux_lpc_rtc_config_##id.info,	\
 				POST_KERNEL, CONFIG_COUNTER_INIT_PRIORITY,		\
 				&mcux_rtc_driver_api);					\
 	static void mcux_lpc_rtc_irq_config_##id(const struct device *dev)	\
@@ -242,3 +261,206 @@ static const struct counter_driver_api mcux_rtc_driver_api = {
 	}
 
 DT_INST_FOREACH_STATUS_OKAY(COUNTER_LPC_RTC_DEVICE)
+#endif
+
+#if CONFIG_COUNTER_MCUX_LPC_RTC_HIGHRES
+
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT nxp_lpc_rtc_highres
+
+static int mcux_lpc_rtc_highres_start(const struct device *dev)
+{
+	const struct counter_config_info *info = dev->config;
+	const struct mcux_lpc_rtc_config *config =
+		CONTAINER_OF(info, struct mcux_lpc_rtc_config, info);
+	struct mcux_lpc_rtc_data *data = dev->data;
+
+	if (config->rtc_dev) {
+		/* We have another RTC driver enabled, check if RTC is enabled */
+		if ((config->base->CTRL & RTC_CTRL_RTC_EN_MASK) == 0) {
+			/* RTC is not enabled and we do not turn it on as it will effect
+			 * the RTC counter value thereby affecting the RTC counter drivers
+			 */
+			LOG_ERR("RTC Wake counter cannot be started as RTC is not enabled.");
+			return -EINVAL;
+		}
+	} else {
+		if ((config->base->CTRL & RTC_CTRL_RTC_EN_MASK) == 0) {
+			RTC_EnableTimer(config->base, true);
+		}
+	}
+
+	if (data->value == 0) {
+		/* Start from the max value */
+		RTC_SetWakeupCount(config->base, counter_get_top_value(dev));
+	} else {
+		RTC_SetWakeupCount(config->base, data->value);
+	}
+
+	return 0;
+}
+
+static int mcux_lpc_rtc_highres_stop(const struct device *dev)
+{
+	const struct counter_config_info *info = dev->config;
+	const struct mcux_lpc_rtc_config *config =
+		CONTAINER_OF(info, struct mcux_lpc_rtc_config, info);
+
+	config->base->CTRL &= ~RTC_CTRL_RTC1KHZ_EN_MASK;
+
+	if (config->rtc_dev == NULL) {
+		/* Disable RTC as no other driver is using it */
+		RTC_EnableTimer(config->base, false);
+	}
+
+	return 0;
+}
+
+static uint32_t mcux_lpc_rtc_highres_read(const struct device *dev)
+{
+	const struct counter_config_info *info = dev->config;
+	const struct mcux_lpc_rtc_config *config =
+		CONTAINER_OF(info, struct mcux_lpc_rtc_config, info);
+
+	uint32_t ticks = RTC_GetWakeupCount(config->base);
+
+	return ticks;
+}
+
+static int mcux_lpc_rtc_highres_set_alarm(const struct device *dev, uint8_t chan_id,
+					  const struct counter_alarm_cfg *alarm_cfg)
+{
+	return -ENOTSUP;
+}
+
+static int mcux_lpc_rtc_highres_cancel_alarm(const struct device *dev, uint8_t chan_id)
+{
+	return -ENOTSUP;
+}
+
+
+static int mcux_lpc_rtc_highres_get_value(const struct device *dev, uint32_t *ticks)
+{
+	*ticks = mcux_lpc_rtc_highres_read(dev);
+	return 0;
+}
+
+static int mcux_lpc_rtc_highres_set_top_value(const struct device *dev,
+				  const struct counter_top_cfg *cfg)
+{
+	const struct counter_config_info *info = dev->config;
+	const struct mcux_lpc_rtc_config *config =
+		CONTAINER_OF(info, struct mcux_lpc_rtc_config, info);
+	struct mcux_lpc_rtc_data *data = dev->data;
+
+	if (cfg->flags & COUNTER_TOP_CFG_DONT_RESET) {
+		return -ENOTSUP;
+	}
+
+	data->value = cfg->ticks;
+	data->top_callback = cfg->callback;
+	data->top_user_data = cfg->user_data;
+
+	if (config->base->CTRL & RTC_CTRL_RTC1KHZ_EN_MASK) {
+		return mcux_lpc_rtc_highres_start(dev);
+	}
+
+	return 0;
+}
+
+static uint32_t mcux_lpc_rtc_highres_get_pending_int(const struct device *dev)
+{
+	const struct counter_config_info *info = dev->config;
+	const struct mcux_lpc_rtc_config *config =
+		CONTAINER_OF(info, struct mcux_lpc_rtc_config, info);
+
+	return RTC_GetStatusFlags(config->base) & RTC_CTRL_WAKE1KHZ_MASK;
+}
+
+static uint32_t mcux_lpc_rtc_highres_get_top_value(const struct device *dev)
+{
+	struct mcux_lpc_rtc_data *data = dev->data;
+	const struct counter_config_info *info = dev->config;
+
+	if (data->value == 0) {
+		return info->max_top_value;
+	} else {
+		return data->value;
+	}
+}
+
+static int mcux_lpc_rtc_highres_init(const struct device *dev)
+{
+	const struct counter_config_info *info = dev->config;
+	const struct mcux_lpc_rtc_config *config =
+		CONTAINER_OF(info, struct mcux_lpc_rtc_config, info);
+
+	/* Initialize the RTC if this is only driver using it */
+	if (config->rtc_dev == NULL) {
+		RTC_Init(config->base);
+
+		/* Issue a software reset to set the registers to init state */
+		RTC_Reset(config->base);
+
+		config->irq_config_func(dev);
+	}
+
+	if (config->wakeup_source) {
+		/* Enable the bit to wakeup from Deep Power Down mode */
+		RTC_EnableWakeUpTimerInterruptFromDPD(config->base, true);
+	}
+
+	return 0;
+}
+
+static const struct counter_driver_api mcux_rtc_highres_driver_api = {
+	.start = mcux_lpc_rtc_highres_start,
+	.stop = mcux_lpc_rtc_highres_stop,
+	.get_value = mcux_lpc_rtc_highres_get_value,
+	.set_alarm = mcux_lpc_rtc_highres_set_alarm,
+	.cancel_alarm = mcux_lpc_rtc_highres_cancel_alarm,
+	.set_top_value = mcux_lpc_rtc_highres_set_top_value,
+	.get_pending_int = mcux_lpc_rtc_highres_get_pending_int,
+	.get_top_value = mcux_lpc_rtc_highres_get_top_value,
+};
+
+#define COUNTER_LPC_RTC_HIGHRES_IRQ_INIT(n)							\
+	do {											\
+		IRQ_CONNECT(DT_IRQN(DT_INST_PARENT(n)),						\
+			DT_IRQ(DT_INST_PARENT(n), priority),					\
+			mcux_lpc_rtc_isr,							\
+			DEVICE_DT_INST_GET(n), 0);						\
+		irq_enable(DT_IRQN(DT_INST_PARENT(n)));						\
+		if (DT_INST_PROP(n, wakeup_source)) {						\
+			EnableDeepSleepIRQ(DT_IRQN(DT_INST_PARENT(n)));				\
+		}										\
+	} while (false)
+
+#define COUNTER_LPC_RTC_HIGHRES_DEVICE(id)							\
+	static void mcux_lpc_rtc_highres_irq_config_##id(const struct device *dev);		\
+	static const struct mcux_lpc_rtc_config mcux_lpc_rtc_highres_config_##id = {		\
+		.base = (RTC_Type *)DT_REG_ADDR(DT_INST_PARENT(id)),				\
+		.rtc_dev = DEVICE_DT_GET_OR_NULL(DT_INST_PARENT(id)),				\
+		.irq_config_func = mcux_lpc_rtc_highres_irq_config_##id,			\
+		.info = {									\
+			.max_top_value = UINT16_MAX,						\
+			.freq = 1000,								\
+			.channels = 0,								\
+		},										\
+		.wakeup_source = DT_INST_PROP(id, wakeup_source)				\
+	};											\
+	static struct mcux_lpc_rtc_data mcux_lpc_rtc_highres_data_##id;				\
+	DEVICE_DT_INST_DEFINE(id, &mcux_lpc_rtc_highres_init, NULL,				\
+				&mcux_lpc_rtc_highres_data_##id,				\
+				&mcux_lpc_rtc_highres_config_##id.info,				\
+				POST_KERNEL, CONFIG_COUNTER_INIT_PRIORITY,			\
+				&mcux_rtc_highres_driver_api);					\
+	static void mcux_lpc_rtc_highres_irq_config_##id(const struct device *dev)		\
+	{											\
+		COND_CODE_1(IS_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(nxp_lpc_rtc)),			\
+			 (), (COUNTER_LPC_RTC_HIGHRES_IRQ_INIT(id));)				\
+	}
+
+DT_INST_FOREACH_STATUS_OKAY(COUNTER_LPC_RTC_HIGHRES_DEVICE)
+
+#endif

--- a/dts/arm/nxp/nxp_rt5xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt5xx_common.dtsi
@@ -401,6 +401,10 @@
 		reg = <0x30000 0x1000>;
 		interrupts = <32 0>;
 		status = "disabled";
+		rtc_highres: rtc_highres {
+			compatible = "nxp,lpc-rtc-highres";
+			status = "disabled";
+		};
 	};
 
 	trng: random@138000 {

--- a/dts/arm/nxp/nxp_rt6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt6xx_common.dtsi
@@ -312,6 +312,10 @@
 		reg = <0x30000 0x1000>;
 		interrupts = <32 0>;
 		status = "disabled";
+		rtc_highres: rtc_highres {
+			compatible = "nxp,lpc-rtc-highres";
+			status = "disabled";
+		};
 	};
 
 	trng: random@138000 {

--- a/dts/bindings/counter/nxp,lpc-rtc-highres.yaml
+++ b/dts/bindings/counter/nxp,lpc-rtc-highres.yaml
@@ -1,0 +1,8 @@
+# Copyright 2023, NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: Driver that uses the NXP LPC RTC High resolution counter
+
+compatible: "nxp,lpc-rtc-highres"
+
+include: base.yaml

--- a/tests/drivers/counter/counter_basic_api/boards/mimxrt685_evk_cm33_rtc_1khz.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/mimxrt685_evk_cm33_rtc_1khz.overlay
@@ -1,0 +1,7 @@
+&rtc {
+	status = "disabled";
+};
+
+&rtc_highres {
+	status = "okay";
+};

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -69,8 +69,11 @@ static const struct device *const devices[] = {
 #ifdef CONFIG_COUNTER_NXP_MRT
 	DEVS_FOR_DT_COMPAT(nxp_mrt_channel)
 #endif
-#ifdef CONFIG_COUNTER_MCUX_LPC_RTC
+#ifdef CONFIG_COUNTER_MCUX_LPC_RTC_1HZ
 	DEVS_FOR_DT_COMPAT(nxp_lpc_rtc)
+#endif
+#ifdef CONFIG_COUNTER_MCUX_LPC_RTC_HIGHRES
+	DEVS_FOR_DT_COMPAT(nxp_lpc_rtc_highres)
 #endif
 #ifdef CONFIG_COUNTER_GECKO_RTCC
 	DEVS_FOR_DT_COMPAT(silabs_gecko_rtcc)

--- a/tests/drivers/counter/counter_basic_api/testcase.yaml
+++ b/tests/drivers/counter/counter_basic_api/testcase.yaml
@@ -27,3 +27,12 @@ tests:
     timeout: 600
     extra_configs:
       - CONFIG_COUNTER_RTC_STM32_SUBSECONDS=y
+  drivers.counter.basic_api.rtc_1khz:
+    tags:
+      - drivers
+      - counter
+    depends_on: counter
+    platform_allow: mimxrt685_evk_cm33
+    timeout: 400
+    extra_args:
+      DTC_OVERLAY_FILE="boards/mimxrt685_evk_cm33_rtc_1khz.overlay"


### PR DESCRIPTION
The LPC RTC also has a 1KHz counter that can used by applications that require better resolution. Add support for this counter.