### PR TITLE
soc: arm: npcx:  move soc-specific register definitions to soc.h

### DIFF
--- a/drivers/flash/flash_npcx_fiu_qspi.c
+++ b/drivers/flash/flash_npcx_fiu_qspi.c
@@ -247,7 +247,6 @@ void qspi_npcx_fiu_mutex_unlock(const struct device *dev)
 static int qspi_npcx_fiu_init(const struct device *dev)
 {
 	const struct npcx_qspi_fiu_config *const config = dev->config;
-	struct fiu_reg *const inst = HAL_INSTANCE(dev);
 	struct npcx_qspi_fiu_data *const data = dev->data;
 	const struct device *const clk_dev = DEVICE_DT_GET(NPCX_CLK_CTRL_NODE);
 	int ret;
@@ -270,9 +269,11 @@ static int qspi_npcx_fiu_init(const struct device *dev)
 
 	/* Enable direct access for 2 external SPI devices */
 	if (config->en_direct_access_2dev) {
-		if (IS_ENABLED(CONFIG_FLASH_NPCX_FIU_SUPP_DRA_2_DEV)) {
-			inst->FIU_EXT_CFG |= BIT(NPCX_FIU_EXT_CFG_SPI1_2DEV);
-		}
+#if defined(CONFIG_FLASH_NPCX_FIU_SUPP_DRA_2_DEV)
+		struct fiu_reg *const inst = HAL_INSTANCE(dev);
+
+		inst->FIU_EXT_CFG |= BIT(NPCX_FIU_EXT_CFG_SPI1_2DEV);
+#endif
 	}
 
 	return 0;

--- a/drivers/pinctrl/pinctrl_npcx.c
+++ b/drivers/pinctrl/pinctrl_npcx.c
@@ -38,17 +38,10 @@ static const struct npcx_pwm_pinctrl_config pwm_pinctrl_cfg[] = {
 /* Pin-control local functions for peripheral devices */
 static bool npcx_periph_pinmux_has_lock(int group)
 {
-#if defined(CONFIG_SOC_SERIES_NPCX7)
-	if (group == 0x00 || (group >= 0x02 && group <= 0x04) || group == 0x06 ||
-		group == 0x0b || group == 0x0f) {
+	if ((BIT(group) & NPCX_DEVALT_LK_GROUP_MASK) != 0) {
 		return true;
 	}
-#elif defined(CONFIG_SOC_SERIES_NPCX9)
-	if (group == 0x00 || (group >= 0x02 && group <= 0x06) || group == 0x0b ||
-		group == 0x0d || (group >= 0x0f && group <= 0x12)) {
-		return true;
-	}
-#endif
+
 	return false;
 }
 

--- a/soc/arm/nuvoton_npcx/common/reg/reg_def.h
+++ b/soc/arm/nuvoton_npcx/common/reg/reg_def.h
@@ -228,49 +228,17 @@ struct scfg_reg {
 	volatile uint8_t LV_GPIO_CTL0[5];
 };
 
-/* SCFG internal inline functions for multi-registers */
-static inline uint32_t npcx_devalt_offset(uint32_t alt_no)
-{
-	return 0x010 + alt_no;
-}
-
-static inline uint32_t npcx_devalt_lk_offset(uint32_t alt_lk_no)
-{
-	return 0x210 + alt_lk_no;
-}
-
-static inline uint32_t npcx_pupd_en_offset(uint32_t pupd_en_no)
-{
-	if (IS_ENABLED(CONFIG_SOC_SERIES_NPCX7) || IS_ENABLED(CONFIG_SOC_SERIES_NPCX9)) {
-		return 0x28 + pupd_en_no;
-	} else { /* NPCX4 and later series */
-		return 0x2b + pupd_en_no;
-	}
-}
-
-static inline uint32_t npcx_lv_gpio_ctl_offset(uint32_t ctl_no)
-{
-	if (IS_ENABLED(CONFIG_SOC_SERIES_NPCX7) || IS_ENABLED(CONFIG_SOC_SERIES_NPCX9)) {
-		if (ctl_no < 5) {
-			return 0x02a + ctl_no;
-		} else {
-			return 0x026 + ctl_no - 5;
-		}
-	} else { /* NPCX4 and later series */
-		return 0x150 + ctl_no;
-	}
-}
-
 /* Macro functions for SCFG multi-registers */
-#define NPCX_DEV_CTL(base, n) (*(volatile uint8_t *)(base + n))
-#define NPCX_DEVALT(base, n) (*(volatile uint8_t *)(base + \
-						npcx_devalt_offset(n)))
-#define NPCX_DEVALT_LK(base, n) (*(volatile uint8_t *)(base + \
-						npcx_devalt_lk_offset(n)))
-#define NPCX_PUPD_EN(base, n) (*(volatile uint8_t *)(base + \
-						npcx_pupd_en_offset(n)))
-#define NPCX_LV_GPIO_CTL(base, n) (*(volatile uint8_t *)(base + \
-						npcx_lv_gpio_ctl_offset(n)))
+#define NPCX_DEV_CTL(base, n) \
+	(*(volatile uint8_t *)(base + n))
+#define NPCX_DEVALT(base, n) \
+	(*(volatile uint8_t *)(base + NPCX_DEVALT_OFFSET(n)))
+#define NPCX_DEVALT_LK(base, n) \
+	(*(volatile uint8_t *)(base + NPCX_DEVALT_LK_OFFSET(n)))
+#define NPCX_PUPD_EN(base, n) \
+	(*(volatile uint8_t *)(base + NPCX_PUPD_EN_OFFSET(n)))
+#define NPCX_LV_GPIO_CTL(base, n) \
+	(*(volatile uint8_t *)(base + NPCX_LV_GPIO_CTL_OFFSET(n)))
 
 /* SCFG register fields */
 #define NPCX_DEVCNT_F_SPI_TRIS                6
@@ -413,95 +381,21 @@ struct uart_reg {
 #define NPCX_UFRCTL_RNEMPTY_EN                6
 #define NPCX_UFRCTL_ERR_EN                    7
 
-/*
- * Multi-Input Wake-Up Unit (MIWU) device registers
- */
-
-/* MIWU internal inline functions for multi-registers */
-static inline uint32_t npcx_wkedg_offset(uint32_t group)
-{
-	if (IS_ENABLED(CONFIG_SOC_SERIES_NPCX7)) {
-		return 0x000 + (group * 2ul) + (group < 5 ? 0 : 0x1e);
-	} else { /* NPCX9 and later series */
-		return 0x000 + group * 0x10UL;
-	}
-}
-
-static inline uint32_t npcx_wkaedg_offset(uint32_t group)
-{
-	if (IS_ENABLED(CONFIG_SOC_SERIES_NPCX7)) {
-		return 0x001 + (group * 2ul) + (group < 5 ? 0 : 0x1e);
-	} else { /* NPCX9 and later series */
-		return 0x001 + group * 0x10ul;
-	}
-}
-
-static inline uint32_t npcx_wkmod_offset(uint32_t group)
-{
-	if (IS_ENABLED(CONFIG_SOC_SERIES_NPCX7)) {
-		return 0x070 + group;
-	} else { /* NPCX9 and later series */
-		return 0x002 + group * 0x10ul;
-	}
-}
-
-static inline uint32_t npcx_wkpnd_offset(uint32_t group)
-{
-	if (IS_ENABLED(CONFIG_SOC_SERIES_NPCX7)) {
-		return 0x00a + (group * 4ul) + (group < 5 ? 0 : 0x10);
-	} else { /* NPCX9 and later series */
-		return 0x003 + group * 0x10ul;
-	}
-}
-
-static inline uint32_t npcx_wkpcl_offset(uint32_t group)
-{
-	if (IS_ENABLED(CONFIG_SOC_SERIES_NPCX7)) {
-		return 0x00c + (group * 4ul) + (group < 5 ? 0 : 0x10);
-	} else { /* NPCX9 and later series */
-		return 0x004 + group * 0x10ul;
-	}
-}
-
-static inline uint32_t npcx_wken_offset(uint32_t group)
-{
-	if (IS_ENABLED(CONFIG_SOC_SERIES_NPCX7)) {
-		return 0x01e + (group * 2ul) + (group < 5 ? 0 : 0x12);
-	} else { /* NPCX9 and later series */
-		return 0x005 + group * 0x10ul;
-	}
-}
-
-static inline uint32_t npcx_wkst_offset(uint32_t group)
-{
-	/* NPCX9 and later series only */
-	return 0x006 + group * 0x10ul;
-}
-
-static inline uint32_t npcx_wkinen_offset(uint32_t group)
-{
-	if (IS_ENABLED(CONFIG_SOC_SERIES_NPCX7)) {
-		return 0x01f + (group * 2ul) + (group < 5 ? 0 : 0x12);
-	} else { /* NPCX9 and later series */
-		return 0x007 + group * 0x10ul;
-	}
-}
-
 /* Macro functions for MIWU multi-registers */
 #define NPCX_WKEDG(base, group) \
-	(*(volatile uint8_t *)(base +  npcx_wkedg_offset(group)))
+	(*(volatile uint8_t *)(base +  NPCX_WKEDG_OFFSET(group)))
 #define NPCX_WKAEDG(base, group) \
-	(*(volatile uint8_t *)(base + npcx_wkaedg_offset(group)))
+	(*(volatile uint8_t *)(base + NPCX_WKAEDG_OFFSET(group)))
 #define NPCX_WKPND(base, group) \
-	(*(volatile uint8_t *)(base + npcx_wkpnd_offset(group)))
+	(*(volatile uint8_t *)(base + NPCX_WKPND_OFFSET(group)))
 #define NPCX_WKPCL(base, group) \
-	(*(volatile uint8_t *)(base + npcx_wkpcl_offset(group)))
+	(*(volatile uint8_t *)(base + NPCX_WKPCL_OFFSET(group)))
 #define NPCX_WKEN(base, group) \
-	(*(volatile uint8_t *)(base + npcx_wken_offset(group)))
+	(*(volatile uint8_t *)(base + NPCX_WKEN_OFFSET(group)))
 #define NPCX_WKINEN(base, group) \
-	(*(volatile uint8_t *)(base + npcx_wkinen_offset(group)))
+	(*(volatile uint8_t *)(base + NPCX_WKINEN_OFFSET(group)))
 #define NPCX_WKMOD(base, group) \
-	(*(volatile uint8_t *)(base + npcx_wkmod_offset(group)))
+	(*(volatile uint8_t *)(base + NPCX_WKMOD_OFFSET(group)))
 
 /*
  * General-Purpose I/O (GPIO) device registers
@@ -582,33 +476,10 @@ struct adc_reg {
 };
 
 /* ADC internal inline functions for multi-registers */
-static inline uint32_t npcx_chndat_offset(uint32_t ch)
-{
-	return 0x40 + ch * 2;
-}
-
-static inline uint32_t npcx_thr_base(void)
-{
-	if (IS_ENABLED(CONFIG_SOC_SERIES_NPCX7)) {
-		return 0x014;
-	} else if (IS_ENABLED(CONFIG_SOC_SERIES_NPCX9)) {
-		return 0x060;
-	} else { /* NPCX4 and later series */
-		return 0x080;
-	}
-}
-
-static inline uint32_t npcx_thrctl_offset(uint32_t ctrl)
-{
-	return npcx_thr_base() + ctrl * 2;
-}
-
-#define CHNDAT(base, ch) (*(volatile uint16_t *)((base) + npcx_chndat_offset(ch)))
+#define CHNDAT(base, ch) \
+	(*(volatile uint16_t *)((base) + NPCX_CHNDAT_OFFSET(ch)))
 #define THRCTL(base, ctrl) \
-	(*(volatile uint16_t *)(base + npcx_thrctl_offset(ctrl)))
-#ifdef CONFIG_SOC_SERIES_NPCX4
-#define THEN(base) (*(volatile uint16_t *)(base + 0x90))
-#endif
+	(*(volatile uint16_t *)(base + NPCX_THRCTL_OFFSET(ctrl)))
 
 /* ADC register fields */
 #define NPCX_ATCTL_SCLKDIV_FIELD              FIELD(0, 6)
@@ -628,16 +499,6 @@ static inline uint32_t npcx_thrctl_offset(uint32_t ctrl)
 #define NPCX_ADCCNF_STOP                      11
 #define NPCX_CHNDAT_CHDAT_FIELD               FIELD(0, 10)
 #define NPCX_CHNDAT_NEW                       15
-#ifdef CONFIG_SOC_SERIES_NPCX4
-#define NPCX_THRCTL_L_H                       15
-#define NPCX_THRCTL_CHNSEL                    FIELD(10, 5)
-#define NPCX_THRCTL_THRVAL                    FIELD(0, 10)
-#else
-#define NPCX_THRCTL_THEN                      15
-#define NPCX_THRCTL_L_H                       14
-#define NPCX_THRCTL_CHNSEL                    FIELD(10, 4)
-#define NPCX_THRCTL_THRVAL                    FIELD(0, 10)
-#endif
 #define NPCX_THRCTS_ADC_WKEN                  15
 #define NPCX_THRCTS_THR3_IEN                  10
 #define NPCX_THRCTS_THR2_IEN                  9
@@ -1598,11 +1459,6 @@ struct fiu_reg {
 #define NPCX_SPI1_DEV_FOUR_BADDR_CS10    6
 #define NPCX_SPI1_DEV_FOUR_BADDR_CS11    7
 #define NPCX_SPI1_DEV_SPI1_LO_DEV_SIZE   FIELD(0, 4)
-#if defined(CONFIG_SOC_SERIES_NPCX9)
-#define NPCX_FIU_EXT_CFG_SPI1_2DEV       7
-#else
-#define NPCX_FIU_EXT_CFG_SPI1_2DEV       6
-#endif
 #define NPCX_FIU_EXT_CFG_SET_DMM_EN      2
 #define NPCX_FIU_EXT_CFG_SET_CMD_EN      1
 #define NPCX_SPI_DEV_NADDRB              FIELD(5, 3)

--- a/soc/arm/nuvoton_npcx/common/soc_clock.h
+++ b/soc/arm/nuvoton_npcx/common/soc_clock.h
@@ -42,14 +42,6 @@ struct npcx_clk_cfg {
 #define APB2DIV_VAL (DT_PROP(DT_NODELABEL(pcc), apb2_prescaler) - 1)
 /* APB3 clock divider */
 #define APB3DIV_VAL (DT_PROP(DT_NODELABEL(pcc), apb3_prescaler) - 1)
-/* APB4 clock divider if supported */
-#if DT_NODE_HAS_PROP(DT_NODELABEL(pcc), apb4_prescaler)
-#if !defined(CONFIG_SOC_SERIES_NPCX7) /* Supported in NPCX9 and later series */
-#define APB4DIV_VAL (DT_PROP(DT_NODELABEL(pcc), apb4_prescaler) - 1)
-#else
-#error "APB4 clock divider is not supported but defined in pcc node!"
-#endif /* !CONFIG_SOC_SERIES_NPCX7 */
-#endif
 
 /* Construct a uint8_t array from 'pwdwn-ctl-val' prop for PWDWN_CTL initialization. */
 #define NPCX_PWDWN_CTL_ITEMS_INIT(node, prop, idx) DT_PROP_BY_IDX(node, prop, idx),
@@ -68,12 +60,6 @@ struct npcx_clk_cfg {
  * - CORE_CLK > MAX_OFMCLK/2, AHB6DIV should be 1, else 0.
  * - CORE_CLK > MAX_OFMCLK/2, FIUDIV should be 1, else 0.
  */
-#if defined(CONFIG_SOC_SERIES_NPCX4)
-#define MAX_OFMCLK 120000000
-#else
-#define MAX_OFMCLK 100000000
-#endif /* CONFIG_SOC_SERIES_NPCX4 */
-
 /* Core domain clock */
 #define CORE_CLK (OFMCLK / DT_PROP(DT_NODELABEL(pcc), core_prescaler))
 /* Low Frequency clock */
@@ -102,14 +88,6 @@ struct npcx_clk_cfg {
 #else
 #define FIUDIV_VAL 0 /* FIU_CLK = CORE_CLK */
 #endif
-
-#if defined(CONFIG_SOC_SERIES_NPCX4)
-#if (CORE_CLK > (MAX_OFMCLK / 2))
-#define FIU1DIV_VAL 1 /* FIU1_CLK = CORE_CLK/2 */
-#else
-#define FIU1DIV_VAL 0 /* FIU1_CLK = CORE_CLK */
-#endif
-#endif /* CONFIG_SOC_SERIES_NPCX4 */
 
 /* Get APB clock freq */
 #define NPCX_APB_CLOCK(no) (APBSRC_CLK / (APB##no##DIV_VAL + 1))

--- a/soc/arm/nuvoton_npcx/npcx4/soc.h
+++ b/soc/arm/nuvoton_npcx/npcx4/soc.h
@@ -11,6 +11,45 @@
 #define __FPU_PRESENT  CONFIG_CPU_HAS_FPU
 #define __MPU_PRESENT  CONFIG_CPU_HAS_ARM_MPU
 
+/* NPCX4 SCFG multi-registers */
+#define NPCX_DEVALT_OFFSET(n)		(0x010 + n)
+#define NPCX_PUPD_EN_OFFSET(n)		(0x02b + n)
+#define NPCX_LV_GPIO_CTL_OFFSET(n)	(0x150 + n)
+#define NPCX_DEVALT_LK_OFFSET(n)	(0x210 + n)
+
+/* NPCX4 MIWU multi-registers */
+#define NPCX_WKEDG_OFFSET(n)		(0x000 + (n * 0x010))
+#define NPCX_WKAEDG_OFFSET(n)		(0x001 + (n * 0x010))
+#define NPCX_WKMOD_OFFSET(n)		(0x002 + (n * 0x010))
+#define NPCX_WKPND_OFFSET(n)		(0x003 + (n * 0x010))
+#define NPCX_WKPCL_OFFSET(n)		(0x004 + (n * 0x010))
+#define NPCX_WKEN_OFFSET(n)		(0x005 + (n * 0x010))
+#define NPCX_WKST_OFFSET(n)		(0x006 + (n * 0x010))
+#define NPCX_WKINEN_OFFSET(n)		(0x007 + (n * 0x010))
+
+/* NPCX4 ADC multi-registers */
+#define NPCX_CHNDAT_OFFSET(n)		(0x040 + n * 2)
+#define NPCX_THRCTL_OFFSET(n)		(0x080 + n * 2)
+#define NPCX_THEN_OFFSET		0x090
+#define THEN(base)			(*(volatile uint16_t *)(base + NPCX_THEN_OFFSET))
+
+/* NPCX4 ADC register fields */
+#define NPCX_THRCTL_L_H			15
+#define NPCX_THRCTL_CHNSEL		FIELD(10, 5)
+#define NPCX_THRCTL_THRVAL		FIELD(0, 10)
+
+/* NPCX4 FIU register fields */
+#define NPCX_FIU_EXT_CFG_SPI1_2DEV	6
+
+/* NPCX4 supported group mask of DEVALT_LK */
+#define NPCX_DEVALT_LK_GROUP_MASK \
+	(BIT(0) | BIT(2) | BIT(3) | BIT(4) | \
+	 BIT(5) | BIT(6) | BIT(11) | BIT(13) | \
+	 BIT(15) | BIT(16) | BIT(17) | BIT(18) | \
+	 BIT(19) | BIT(21))	/* DEVALT0_LK - DEVALTN_LK */
+
+/* NPCX4 Clock Configuration */
+#define MAX_OFMCLK 120000000
 
 #include <reg/reg_access.h>
 #include <reg/reg_def.h>
@@ -18,5 +57,17 @@
 #include <soc_clock.h>
 #include <soc_pins.h>
 #include <soc_power.h>
+
+/* NPCX4 Clock definitions */
+#if DT_NODE_HAS_PROP(DT_NODELABEL(pcc), apb4_prescaler)
+/* APB4 clock divider if supported */
+#define APB4DIV_VAL (DT_PROP(DT_NODELABEL(pcc), apb4_prescaler) - 1)
+#endif
+
+#if (CORE_CLK > (MAX_OFMCLK / 2))
+#define FIU1DIV_VAL 1 /* If CORE_CLK > MAX_OFMCLK / 2, FIU1_CLK = CORE_CLK/2 */
+#else
+#define FIU1DIV_VAL 0 /* Else, FIU1_CLK = CORE_CLK */
+#endif
 
 #endif /* _NUVOTON_NPCX_SOC_H_ */

--- a/soc/arm/nuvoton_npcx/npcx7/soc.h
+++ b/soc/arm/nuvoton_npcx/npcx7/soc.h
@@ -11,6 +11,38 @@
 #define __FPU_PRESENT  CONFIG_CPU_HAS_FPU
 #define __MPU_PRESENT  CONFIG_CPU_HAS_ARM_MPU
 
+/* NPCX7 SCFG multi-registers offset */
+#define NPCX_DEVALT_OFFSET(n)		(0x010 + n)
+#define NPCX_PUPD_EN_OFFSET(n)		(0x028 + n)
+#define NPCX_LV_GPIO_CTL_OFFSET(n)	((n < 5) ? (0x02a + n) : (0x021 + n))
+#define NPCX_DEVALT_LK_OFFSET(n)	(0x210 + n)
+
+/* NPCX7 MIWU multi-registers offset */
+#define NPCX_WKEDG_OFFSET(n)		(0x000 + (n * 2) + ((n < 5) ? 0 : 0x01e))
+#define NPCX_WKAEDG_OFFSET(n)		(0x001 + (n * 2) + ((n < 5) ? 0 : 0x01e))
+#define NPCX_WKMOD_OFFSET(n)		(0x070 + n)
+#define NPCX_WKPND_OFFSET(n)		(0x00a + (n * 4) + ((n < 5) ? 0 : 0x010))
+#define NPCX_WKPCL_OFFSET(n)		(0x00c + (n * 4) + ((n < 5) ? 0 : 0x010))
+#define NPCX_WKEN_OFFSET(n)		(0x01e + (n * 2) + ((n < 5) ? 0 : 0x012))
+#define NPCX_WKINEN_OFFSET(n)		(0x01f + (n * 2) + ((n < 5) ? 0 : 0x012))
+
+/* NPCX7 ADC multi-registers offset */
+#define NPCX_CHNDAT_OFFSET(n)		(0x040 + (n * 2))
+#define NPCX_THRCTL_OFFSET(n)		(0x014 + (n * 2))
+
+/* NPCX7 ADC register fields */
+#define NPCX_THRCTL_THEN		15
+#define NPCX_THRCTL_L_H			14
+#define NPCX_THRCTL_CHNSEL		FIELD(10, 4)
+#define NPCX_THRCTL_THRVAL		FIELD(0, 10)
+
+/* NPCX7 supported group mask of DEVALT_LK */
+#define NPCX_DEVALT_LK_GROUP_MASK \
+	(BIT(0) | BIT(2) | BIT(3) | BIT(4) | \
+	 BIT(6) | BIT(11) | BIT(15))	/* DEVALT0_LK - DEVALTF_LK */
+
+/* NPCX7 Clock configuration */
+#define MAX_OFMCLK 100000000
 
 #include <reg/reg_access.h>
 #include <reg/reg_def.h>

--- a/soc/arm/nuvoton_npcx/npcx9/soc.h
+++ b/soc/arm/nuvoton_npcx/npcx9/soc.h
@@ -11,6 +11,43 @@
 #define __FPU_PRESENT  CONFIG_CPU_HAS_FPU
 #define __MPU_PRESENT  CONFIG_CPU_HAS_ARM_MPU
 
+/* NPCX9 SCFG multi-registers */
+#define NPCX_DEVALT_OFFSET(n)		(0x010 + n)
+#define NPCX_PUPD_EN_OFFSET(n)		(0x028 + n)
+#define NPCX_LV_GPIO_CTL_OFFSET(n)	((n < 5) ? (0x02a + n) : (0x021 + n))
+#define NPCX_DEVALT_LK_OFFSET(n)	(0x210 + n)
+
+/* NPCX9 MIWU multi-registers */
+#define NPCX_WKEDG_OFFSET(n)		(0x000 + (n * 0x010))
+#define NPCX_WKAEDG_OFFSET(n)		(0x001 + (n * 0x010))
+#define NPCX_WKMOD_OFFSET(n)		(0x002 + (n * 0x010))
+#define NPCX_WKPND_OFFSET(n)		(0x003 + (n * 0x010))
+#define NPCX_WKPCL_OFFSET(n)		(0x004 + (n * 0x010))
+#define NPCX_WKEN_OFFSET(n)		(0x005 + (n * 0x010))
+#define NPCX_WKST_OFFSET(n)		(0x006 + (n * 0x010))
+#define NPCX_WKINEN_OFFSET(n)		(0x007 + (n * 0x010))
+
+/* NPCX9 ADC multi-registers */
+#define NPCX_CHNDAT_OFFSET(n)		(0x040 + (n * 2))
+#define NPCX_THRCTL_OFFSET(n)		(0x060 + (n * 2))
+
+/* NPCX9 ADC register fields */
+#define NPCX_THRCTL_THEN		15
+#define NPCX_THRCTL_L_H			14
+#define NPCX_THRCTL_CHNSEL		FIELD(10, 4)
+#define NPCX_THRCTL_THRVAL		FIELD(0, 10)
+
+/* NPCX9 FIU register fields */
+#define NPCX_FIU_EXT_CFG_SPI1_2DEV	7
+
+/* NPCX9 supported group mask of DEVALT_LK */
+#define NPCX_DEVALT_LK_GROUP_MASK \
+	(BIT(0) | BIT(2) | BIT(3) | BIT(4) | \
+	 BIT(5) | BIT(6) | BIT(11) | BIT(13) | \
+	 BIT(15) | BIT(16) | BIT(17) | BIT(18))	/* DEVALT0_LK - DEVALTJ_LK */
+
+/* NPCX9 Clock configuration and limitation */
+#define MAX_OFMCLK 100000000
 
 #include <reg/reg_access.h>
 #include <reg/reg_def.h>
@@ -18,5 +55,11 @@
 #include <soc_clock.h>
 #include <soc_pins.h>
 #include <soc_power.h>
+
+/* NPCX9 Clock definitions */
+#if DT_NODE_HAS_PROP(DT_NODELABEL(pcc), apb4_prescaler)
+/* APB4 clock divider if supported */
+#define APB4DIV_VAL (DT_PROP(DT_NODELABEL(pcc), apb4_prescaler) - 1)
+#endif
 
 #endif /* _NUVOTON_NPCX_SOC_H_ */


### PR DESCRIPTION
This PR is the second refactor PR to minimize `CONFIG_SOC_SERIES_XXXX` definitions when we introduce a new chip series. Most of them are relevant to register layouts in different npcx soc series. It moves soc-specific register definitions from `reg_def.h` to its own soc.h file. It also passed stress tests on Chromebooks and EVBs in case this PR influences the stability.