### PR TITLE
docs: rpi_pico: fix typo in SPI PIO sample

### DIFF
--- a/boards/arm/rpi_pico/doc/index.rst
+++ b/boards/arm/rpi_pico/doc/index.rst
@@ -140,7 +140,7 @@ Zephyr does not (currently) assemble PIO programs. Rather, they should be
 manually assembled and embedded in source code. An example of how this is done
 can be found at `drivers/serial/uart_rpi_pico_pio.c`.
 
-Sample:  SPI vio PIO
+Sample:  SPI via PIO
 ====================
 
 The :zephyr_file:`samples/sensor/bme280/README.rst` sample includes a


### PR DESCRIPTION
Fixes minor typo in the SPI via PIO sample documentation.