### PR TITLE
drivers ieee802154_nrf5: Fix infinite loop for simulation on stop

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -668,6 +668,7 @@ static int nrf5_stop(const struct device *dev)
 		} else {
 			LOG_WRN("Transition to radio sleep cannot be handled.");
 		}
+		Z_SPIN_DELAY(1);
 		return 0;
 	}
 #else


### PR DESCRIPTION
With CSL enabled, when nrf5_stop is called, nrf_802154_sleep_if_idle() will be called, and if the radio is busy with another task, another IEEE802154_EVENT_RX_OFF event will be pended right away, resulting in another call to nrf5_stop(), effectively busy waiting until the radio has reached idle.

In simulation, this whole operation (busy wait loop) is done without letting the CPU sleep, in an infinite loop, and therefore without letting any time pass (note that in the POSIX architecture, no time passes if the CPU does not go to sleep). And therefore the radio will never be done with whatever it is doing, resulting in the simulation being stuck in this loop.

Let's add a very minor delay to this loop, which is conditionally compiled only for the POSIX architecture. Which effectively mimics the time it takes for the CPU to loop thru, let's time pass, and allows the radio to eventually be done.