### PR TITLE
manifest: Update nrf hw models to latest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -295,7 +295,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 90f4484cbaec986ed253b4fe9649aa75e632de15
+      revision: a715dcc179f1a71f51c574165958b72fe932ae3f
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
       revision: 214f9fc1539f8e5937c0474cb6ee29b6dcb2d4b8


### PR DESCRIPTION
* Update the HW models module to a715dcc179f1a71f51c574165958b72fe932ae3f

Including the following:
* a715dcc irq_ctrl: Fix interrupt name getter
* b9e1f00 Makefile: For 5340 build both HAL versions as separate libraries
* 68aa50b Makefile: Set default target to compile and fix makefiles rules
* 0cf5ea9 nrfx_glue: Provide a stubbed NRFX_DELAY for builds without Zephyr
* b0d95c2 doc: Update required Nordic nrfx version to 3.2

Note that the only relevant change for Zephyr is 

    a715dcc irq_ctrl: Fix interrupt name getter: 

    When this function was changed to support multiple CPUs,
    the check of the interrupt number being valid was not
    updated, which resulted in it thinking too often
    the interrupt was out of range, and returning
    NULL as the interrupt name string.

    Fix it.

    This bug only affected debug logs, typically with verbosity
    set relatively high.

