### PR TITLE
net: openthread: Adding snoop entries kconfig.

### DIFF
--- a/modules/openthread/platform/openthread-core-zephyr-config.h
+++ b/modules/openthread/platform/openthread-core-zephyr-config.h
@@ -61,6 +61,18 @@
 #endif
 
 /**
+ * @def CONFIG_OPENTHREAD_TMF_ADDRESS_CACHE_MAX_SNOOP_ENTRIES
+ *
+ * The maximum number of EID-to-RLOC cache entries that can be used for
+ * "snoop optimization" where an entry is created by inspecting a received message.
+ *
+ */
+#ifdef CONFIG_OPENTHREAD_TMF_ADDRESS_CACHE_MAX_SNOOP_ENTRIES
+#define OPENTHREAD_CONFIG_TMF_ADDRESS_CACHE_MAX_SNOOP_ENTRIES                  \
+	CONFIG_OPENTHREAD_TMF_ADDRESS_CACHE_MAX_SNOOP_ENTRIES
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_LOG_PREPEND_LEVEL
  *
  * Define to prepend the log level to all log messages.

--- a/subsys/net/l2/openthread/Kconfig
+++ b/subsys/net/l2/openthread/Kconfig
@@ -289,6 +289,14 @@ config OPENTHREAD_TMF_ADDRESS_CACHE_ENTRIES
 	help
 	  The number of EID-to-RLOC cache entries.
 
+config OPENTHREAD_TMF_ADDRESS_CACHE_MAX_SNOOP_ENTRIES
+	int "The maximum number of EID-to-RLOC cache entries"
+	default 2
+	help
+	  The maximum number of EID-to-RLOC cache entries that can be used for
+	  "snoop optimization" where an entry is created by inspecting a received
+	  message.
+
 config OPENTHREAD_LOG_PREPEND_LEVEL_ENABLE
 	bool "Prepending the log level to all OpenThread log messages"
 	help


### PR DESCRIPTION
Adding missing `CONFIG_OPENTHREAD_TMF_ADDRESS_CACHE_MAX_SNOOP_ENTRIES` to thread kconfig file.