### PR TITLE
kconfig: mcuboot: Add MCUBOOT_IMGTOOL_OVERWRITE_ONLY option

### DIFF
--- a/cmake/mcuboot.cmake
+++ b/cmake/mcuboot.cmake
@@ -96,6 +96,11 @@ function(zephyr_mcuboot_tasks)
     set(imgtool_extra --key "${keyfile}" ${imgtool_extra})
   endif()
 
+  # Use overwrite-only instead of swap upgrades.
+  if(CONFIG_MCUBOOT_IMGTOOL_OVERWRITE_ONLY)
+    set(imgtool_extra --overwrite-only ${imgtool_extra})
+  endif()
+
   set(imgtool_args -- ${imgtool_extra})
 
   # Extensionless prefix of any output file.

--- a/modules/Kconfig.mcuboot
+++ b/modules/Kconfig.mcuboot
@@ -110,6 +110,12 @@ config MCUBOOT_IMGTOOL_SIGN_VERSION
 	  argument to the tool.
 	  The format is major.minor.revision+build.
 
+config MCUBOOT_IMGTOOL_OVERWRITE_ONLY
+	bool "Use overwrite-only instead of swap upgrades"
+	help
+	  If enabled, --overwrite-only option passed to imgtool to avoid
+	  adding the swap status area size when calculating overflow.
+
 config MCUBOOT_EXTRA_IMGTOOL_ARGS
 	string "Extra arguments to pass to imgtool when signing"
 	default ""
@@ -148,6 +154,7 @@ choice MCUBOOT_BOOTLOADER_MODE
 
 config MCUBOOT_BOOTLOADER_MODE_SINGLE_APP
 	bool "MCUboot has been configured for single slot execution"
+	select MCUBOOT_IMGTOOL_OVERWRITE_ONLY
 	help
 	  MCUboot will only boot slot0_partition placed application and does
 	  not care about other slots. In this mode application is not able
@@ -178,6 +185,7 @@ config MCUBOOT_BOOTLOADER_MODE_SWAP_SCRATCH
 config MCUBOOT_BOOTLOADER_MODE_OVERWRITE_ONLY
 	bool "MCUboot has been configured to just overwrite primary slot"
 	select MCUBOOT_BOOTLOADER_MODE_HAS_NO_DOWNGRADE
+	select MCUBOOT_IMGTOOL_OVERWRITE_ONLY
 	help
 	  MCUboot will take contents of secondary slot of an image and will
 	  overwrite primary slot with it.
@@ -191,6 +199,7 @@ config MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP
 	bool "MCUboot has been configured for DirectXIP operation"
 	select MCUBOOT_BOOTLOADER_MODE_HAS_NO_DOWNGRADE
 	select MCUBOOT_BOOTLOADER_NO_DOWNGRADE
+	select MCUBOOT_IMGTOOL_OVERWRITE_ONLY
 	help
 	  MCUboot expects slot0_partition and slot1_partition to exist in DT.
 	  In this mode MCUboot can boot from either partition and will
@@ -206,6 +215,7 @@ config MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP_WITH_REVERT
 	select MCUBOOT_BOOTUTIL_LIB_FOR_DIRECT_XIP
 	select MCUBOOT_BOOTLOADER_MODE_HAS_NO_DOWNGRADE
 	select MCUBOOT_BOOTLOADER_NO_DOWNGRADE
+	select MCUBOOT_IMGTOOL_OVERWRITE_ONLY
 	help
 	  MCUboot expects slot0_partition and slot1_partition to exist in DT.
 	  In this mode MCUboot will boot the application with the higher version


### PR DESCRIPTION
Add MCUBOOT_IMGTOOL_OVERWRITE_ONLY Kconfig option which passes the --overwrite-only option to imgtool to avoid adding the swap status area size when calculating overflow. It is used by non-swap update modes.