### PR TITLE
drivers: flash: stm32 ospi: add block erase

### DIFF
--- a/drivers/flash/spi_nor.h
+++ b/drivers/flash/spi_nor.h
@@ -39,6 +39,7 @@
 #define SPI_NOR_CMD_SE_4B       0x21    /* Sector erase 4 byte address*/
 #define SPI_NOR_CMD_BE_32K      0x52    /* Block erase 32KB */
 #define SPI_NOR_CMD_BE          0xD8    /* Block erase */
+#define SPI_NOR_CMD_BE_4B       0xDC    /* Block erase 4 byte address */
 #define SPI_NOR_CMD_CE          0xC7    /* Chip erase */
 #define SPI_NOR_CMD_RDID        0x9F    /* Read JEDEC ID */
 #define SPI_NOR_CMD_ULBPR       0x98    /* Global Block Protection Unlock */
@@ -62,6 +63,7 @@
 
 /* Flash octal opcodes */
 #define SPI_NOR_OCMD_SE         0x21DE  /* Octal Sector erase */
+#define SPI_NOR_OCMD_BE         0xDC23  /* Octal Block erase */
 #define SPI_NOR_OCMD_CE         0xC738  /* Octal Chip erase */
 #define SPI_NOR_OCMD_RDSR       0x05FA  /* Octal Read status register */
 #define SPI_NOR_OCMD_DTR_RD     0xEE11  /* Octal IO DTR read command */

--- a/dts/bindings/flash_controller/st,stm32-ospi-nor.yaml
+++ b/dts/bindings/flash_controller/st,stm32-ospi-nor.yaml
@@ -105,3 +105,7 @@ properties:
       * 2READ 1-2-2 (0xBB) -> 2READ 1-2-2 4B (0xBC)
       * QREAD 1-1-4 (0x6B) -> QREAD 1-1-4 4B (0x6C)
       * 4READ 1-4-4 (0xEB) -> 4READ 1-4-4 4B (0xEC)
+  block-erase-size:
+    type: int
+    description: |
+      Block erase size of the NOR-flash chip.


### PR DESCRIPTION
Add block erase to speed up erasing of larger
memory blocks. Block erase size of the NOR-flash
chip is set in dts.