### PR TITLE
nrf52_bsim: Remove nfct peripheral from DT

### DIFF
--- a/boards/posix/nrf_bsim/nrf52_bsim.dts
+++ b/boards/posix/nrf_bsim/nrf52_bsim.dts
@@ -54,6 +54,7 @@
 		/delete-node/ spi@40004000;
 		/delete-node/ spi@40023000;
 		/delete-node/ spi@4002f000;
+		/delete-node/ nfct@40005000;
 		/delete-node/ watchdog@40010000;
 		/delete-node/ acl@4001e000;
 		/delete-node/ usbd@40027000;


### PR DESCRIPTION
This board HW models do not yet support the NFCT peripheral, let's remove the DT node to avoid the driver being selected.