### PR TITLE
west.yml: MCUboot synchronization from upstream

### DIFF
--- a/tests/boot/mcuboot_recovery_retention/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/boot/mcuboot_recovery_retention/boards/nrf52840dk_nrf52840.overlay
@@ -3,6 +3,7 @@
 / {
 	chosen {
 		zephyr,boot-mode = &boot_mode0;
+		zephyr,uart-mcumgr = &cdc_acm_uart;
 	};
 };
 
@@ -13,6 +14,14 @@
 		compatible = "zephyr,retention";
 		status = "okay";
 		reg = <0x0 0x1>;
+	};
+};
+
+&zephyr_udc0 {
+	status = "okay";
+
+	cdc_acm_uart: cdc_acm_uart {
+		compatible = "zephyr,cdc-acm-uart";
 	};
 };
 

--- a/tests/boot/mcuboot_recovery_retention/boards/nrf52840dk_nrf52840_mem.overlay
+++ b/tests/boot/mcuboot_recovery_retention/boards/nrf52840dk_nrf52840_mem.overlay
@@ -26,6 +26,15 @@
 
 	chosen {
 		zephyr,boot-mode = &boot_mode0;
+		zephyr,uart-mcumgr = &cdc_acm_uart;
+	};
+};
+
+&zephyr_udc0 {
+	status = "okay";
+
+	cdc_acm_uart: cdc_acm_uart {
+		compatible = "zephyr,cdc-acm-uart";
 	};
 };
 

--- a/west.yml
+++ b/west.yml
@@ -282,7 +282,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 4a1effbc301fc302ecbaf40d4eb2be520b53010d
+      revision: 0c0470e294dcfb52aab92299356a5f3caa0aa52b
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  0c0470e294dcfb52aab92299356a5f3caa0aa52b

Brings following Zephyr relevant fixes:
 - e9fccef5 boot_serial: Fix missing response if echo command disabled
 - 013c9e76 boot: zephyr: board: various: Remove size optimisation
 - 0a8bbbf4 boot: zephyr: Fix USB configs
 - d5c963c5 boot: zephyr: serial_adapter: Add error if main thread not preemptible
 - 822b6cb7 boot: zephyr: serial_adapter: Fail if USB CDC enabled with console

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.