### PR TITLE
qemu_x86: Enable support for APIC TSC timer

### DIFF
--- a/boards/x86/qemu_x86/board.cmake
+++ b/boards/x86/qemu_x86/board.cmake
@@ -56,6 +56,9 @@ endif()
 if(CONFIG_X86_SSE4A)
   string(JOIN "," QEMU_CPU_FLAGS "${QEMU_CPU_FLAGS}" "sse4a")
 endif()
+if(CONFIG_APIC_TSC_DEADLINE_TIMER)
+  string(JOIN "," QEMU_CPU_FLAGS "${QEMU_CPU_FLAGS}" "+tsc-deadline")
+endif()
 
 set(QEMU_FLAGS_${ARCH}
   -m ${QEMU_MEMORY_SIZE_MB}

--- a/boards/x86/qemu_x86/qemu_x86_64.dts
+++ b/boards/x86/qemu_x86/qemu_x86_64.dts
@@ -5,6 +5,10 @@
 
 #include "qemu_x86.dts"
 
+&hpet {
+	status = "disabled";
+};
+
 &pcie0 {
 	smbus0: smbus0 {
 		compatible = "intel,pch-smbus";


### PR DESCRIPTION
Enable support for the APIC TSC timer. This is a draft for now, since it's unclear if the SDK or CI qemu have this feature built into them.