### PR TITLE
doc: fix typos

### DIFF
--- a/doc/develop/env_vars.rst
+++ b/doc/develop/env_vars.rst
@@ -72,7 +72,7 @@ Option 2: In all Terminals
       You can then run ``rapidee`` from your terminal to launch the program and set
       environment variables. Make sure to use the "User" environment variables area
       -- otherwise, you have to run RapidEE as administrator. Also make sure to save
-      your changes by clicking the Save button at top left before exiting.Settings
+      your changes by clicking the Save button at top left before exiting. Settings
       you make in RapidEE will be available whenever you open a new terminal window.
 
 .. _env_vars_zephyrrc:

--- a/doc/kernel/services/synchronization/mutexes.rst
+++ b/doc/kernel/services/synchronization/mutexes.rst
@@ -20,7 +20,7 @@ is referenced by its memory address.
 
 A mutex has the following key properties:
 
-* A **lock count** that indicates the number of times the mutex has be locked
+* A **lock count** that indicates the number of times the mutex has been locked
   by the thread that has locked it. A count of zero indicates that the mutex
   is unlocked.
 


### PR DESCRIPTION
Add missed "space".
Add missed "been".