### PR TITLE
Bluetooth: Controller: Reduce RTN for requested Max Transport Latency

### DIFF
--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_11_i.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_11_i.sh
@@ -46,5 +46,5 @@ Execute_AC_11_I 48_1_1 48_1_1
 Execute_AC_11_I 48_2_1 48_2_1
 Execute_AC_11_I 48_3_1 48_3_1
 Execute_AC_11_I 48_4_1 48_4_1
-# Execute_AC_11_I 48_5_1 48_5_1 # ASSERTION FAIL [c_latency <= cig->c_latency]
+Execute_AC_11_I 48_5_1 48_5_1
 Execute_AC_11_I 48_6_1 48_6_1

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_11_ii.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_11_ii.sh
@@ -50,5 +50,5 @@ Execute_AC_11_II 48_1_1 48_1_1
 Execute_AC_11_II 48_2_1 48_2_1
 Execute_AC_11_II 48_3_1 48_3_1
 Execute_AC_11_II 48_4_1 48_4_1
-# Execute_AC_11_II 48_5_1 48_5_1 # Controller assert: ASSERTION FAIL [c_latency <= cig->c_latency]
+Execute_AC_11_II 48_5_1 48_5_1
 Execute_AC_11_II 48_6_1 48_6_1

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_5.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_5.sh
@@ -46,4 +46,4 @@ Execute_AC_5 48_2_1 48_2_1
 Execute_AC_5 48_3_1 48_3_1
 Execute_AC_5 48_4_1 48_4_1
 Execute_AC_5 48_5_1 48_5_1
-# Execute_AC_5 48_6_1 48_6_1 # ASSERTION FAIL [c_latency <= cig->c_latency]
+Execute_AC_5 48_6_1 48_6_1


### PR DESCRIPTION
Add implementation to reduce CIG's CIS retransmissions so as to meet the Host requested Maximum Transport Latency.

Fixes #61692.