### PR TITLE
doc: fix link to extensions.cmake

### DIFF
--- a/doc/develop/application/index.rst
+++ b/doc/develop/application/index.rst
@@ -702,7 +702,7 @@ be useful for glue code to have access to Zephyr kernel header files.
 To make it easier to integrate third-party components, the Zephyr
 build system has defined CMake functions that give application build
 scripts access to the zephyr compiler options. The functions are
-documented and defined in :zephyr_file:`cmake/extensions.cmake`
+documented and defined in :zephyr_file:`cmake/modules/extensions.cmake`
 and follow the naming convention ``zephyr_get_<type>_<format>``.
 
 The following variables will often need to be exported to the


### PR DESCRIPTION
"cmake/extensions.cmake" does not exist. The link is broken. 
Fix it to the correct "cmake/modules/extensions.cmake".