### PR TITLE
Bluetooth: Controller: Fix ull_prepare_dequeue for skipped events

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -2065,6 +2065,8 @@ void *ull_prepare_dequeue_iter(uint8_t *idx)
 
 void ull_prepare_dequeue(uint8_t caller_id)
 {
+	void *param_normal_head = NULL;
+	void *param_normal_next = NULL;
 	void *param_resume_head = NULL;
 	void *param_resume_next = NULL;
 	struct lll_event *next;
@@ -2105,31 +2107,41 @@ void ull_prepare_dequeue(uint8_t caller_id)
 			/* The prepare element was not a resume event, it would
 			 * use the radio or was enqueued back into prepare
 			 * pipeline with a preempt timeout being set.
+			 *
+			 * Remember the first encountered and the next element
+			 * in the prepare pipeline so that we do not infinitely
+			 * loop through the resume events in prepare pipeline.
 			 */
 			if (!is_resume) {
-				break;
-			}
-
-			/* Remember the first encountered resume and the next
-			 * resume element in the prepare pipeline so that we do
-			 * not infinitely loop through the resume events in
-			 * prepare pipeline.
-			 */
-			if (!param_resume_head) {
-				param_resume_head = param;
-			} else if (!param_resume_next) {
-				param_resume_next = param;
+				if (!param_normal_head) {
+					param_normal_head = param;
+				} else if (!param_normal_next) {
+					param_normal_next = param;
+				}
+			} else {
+				if (!param_resume_head) {
+					param_resume_head = param;
+				} else if (!param_resume_next) {
+					param_resume_next = param;
+				}
 			}
 
 			/* Stop traversing the prepare pipeline when we reach
-			 * back to the first or next resume event where we
+			 * back to the first or next event where we
 			 * initially started processing the prepare pipeline.
 			 */
-			if (next->is_resume &&
-			    ((next->prepare_param.param ==
-			      param_resume_head) ||
-			     (next->prepare_param.param ==
-			      param_resume_next))) {
+			if (!next->is_aborted &&
+			    ((!next->is_resume &&
+			      ((next->prepare_param.param ==
+				param_normal_head) ||
+			       (next->prepare_param.param ==
+				param_normal_next))) ||
+			     (next->is_resume &&
+			      !param_normal_next &&
+			      ((next->prepare_param.param ==
+				param_resume_head) ||
+			       (next->prepare_param.param ==
+				param_resume_next))))) {
 				break;
 			}
 		}


### PR DESCRIPTION
Fix ull_prepare_dequeue to not skip events when preempt does not match the event in the head of the prepare queue. The head of the prepare queue does not match when
ull_prepare_dequeue has put the head of the queue to the last of the queue when it is calling lll_resume interface. This happens when there is already an active event which needs a preempt timeout to be setup and there is another non-resume event in the pipeline which now becomes the head. The fix ensure to restore the order of the events if a preempt timeout was to be setup.

Currently ull_prepare_dequeue loops through all events before stopping at the original way the queue was. This is not efficient and is a scope for improvement in future.

This reverts commit 91781306e95c ("Revert "Bluetooth: Controller: Fix ull_prepare_dequeue for skipped events"").

Maybe also observed as bug described in https://github.com/zephyrproject-rtos/zephyr/issues/67365 ?

Fixes #67365

See https://github.com/zephyrproject-rtos/zephyr/issues/67365#issuecomment-1887446534