### PR TITLE
tests: Bluetooth: Enable passing CAP AC 441 tests

### DIFF
--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_1.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_1.sh
@@ -40,8 +40,8 @@ Execute_AC_1 24_1_1
 Execute_AC_1 24_2_1
 Execute_AC_1 32_1_1
 Execute_AC_1 32_2_1
-# Execute_AC_1 441_1_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
-# Execute_AC_1 441_2_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
+Execute_AC_1 441_1_1
+Execute_AC_1 441_2_1
 Execute_AC_1 48_1_1
 Execute_AC_1 48_2_1
 Execute_AC_1 48_3_1

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_10.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_10.sh
@@ -40,8 +40,8 @@ Execute_AC_10 24_1_1
 Execute_AC_10 24_2_1
 Execute_AC_10 32_1_1
 Execute_AC_10 32_2_1
-# Execute_AC_10 441_1_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
-# Execute_AC_10 441_2_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
+Execute_AC_10 441_1_1
+Execute_AC_10 441_2_1
 Execute_AC_10 48_1_1
 Execute_AC_10 48_2_1
 Execute_AC_10 48_3_1

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_2.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_2.sh
@@ -41,8 +41,8 @@ Execute_AC_2 24_1_1
 Execute_AC_2 24_2_1
 Execute_AC_2 32_1_1
 Execute_AC_2 32_2_1
-# Execute_AC_2 441_1_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
-# Execute_AC_2 441_2_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
+Execute_AC_2 441_1_1
+Execute_AC_2 441_2_1
 Execute_AC_2 48_1_1
 Execute_AC_2 48_2_1
 Execute_AC_2 48_3_1

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_3.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_3.sh
@@ -41,8 +41,8 @@ Execute_AC_3 24_1_1 24_1_1
 Execute_AC_3 24_2_1 24_2_1
 Execute_AC_3 32_1_1 32_1_1
 Execute_AC_3 32_2_1 32_2_1
-# Execute_AC_3 441_1_1 441_1_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
-# Execute_AC_3 441_2_1 441_2_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
+Execute_AC_3 441_1_1 441_1_1
+Execute_AC_3 441_2_1 441_2_1
 Execute_AC_3 48_1_1 48_1_1
 Execute_AC_3 48_2_1 48_2_1
 Execute_AC_3 48_3_1 48_3_1

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_4.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_4.sh
@@ -38,8 +38,8 @@ Execute_AC_4 24_1_1
 Execute_AC_4 24_2_1
 Execute_AC_4 32_1_1
 Execute_AC_4 32_2_1
-# Execute_AC_4 441_1_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
-# Execute_AC_4 441_2_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
+Execute_AC_4 441_1_1
+Execute_AC_4 441_2_1
 Execute_AC_4 48_1_1
 Execute_AC_4 48_2_1
 Execute_AC_4 48_3_1

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_7_i.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_7_i.sh
@@ -40,8 +40,8 @@ Execute_AC_7_I 24_1_1 24_1_1
 Execute_AC_7_I 24_2_1 24_2_1
 Execute_AC_7_I 32_1_1 32_1_1
 Execute_AC_7_I 32_2_1 32_2_1
-# Execute_AC_7_I 441_1_1 441_1_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
-# Execute_AC_7_I 441_2_1 441_2_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
+Execute_AC_7_I 441_1_1 441_1_1
+Execute_AC_7_I 441_2_1 441_2_1
 Execute_AC_7_I 48_1_1 48_1_1
 Execute_AC_7_I 48_2_1 48_2_1
 Execute_AC_7_I 48_3_1 48_3_1


### PR DESCRIPTION
Enable some previously disabled CAP AC tests for 44.1 KHz, as they are now passing.