### PR TITLE
Provide CONCAT as a Zephyr API instead of in ARM arch

### DIFF
--- a/include/zephyr/arch/arm/asm_inline_gcc.h
+++ b/include/zephyr/arch/arm/asm_inline_gcc.h
@@ -18,6 +18,7 @@
 
 #ifndef _ASMLANGUAGE
 
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 #include <zephyr/arch/arm/exc.h>
 
@@ -68,7 +69,7 @@ static ALWAYS_INLINE unsigned int arch_irq_lock(void)
 	|| defined(CONFIG_ARMV7_A)
 	__asm__ volatile(
 		"mrs %0, cpsr;"
-		"and %0, #" TOSTR(I_BIT) ";"
+		"and %0, #" STRINGIFY(I_BIT) ";"
 		"cpsid i;"
 		: "=r" (key)
 		:

--- a/include/zephyr/arch/arm/irq.h
+++ b/include/zephyr/arch/arm/irq.h
@@ -75,14 +75,6 @@ extern void z_arm_int_exit(void);
 
 extern void z_arm_interrupt_init(void);
 
-/* macros convert value of its argument to a string */
-#define DO_TOSTR(s) #s
-#define TOSTR(s) DO_TOSTR(s)
-
-/* concatenate the values of the arguments into one */
-#define DO_CONCAT(x, y) x ## y
-#define CONCAT(x, y) DO_CONCAT(x, y)
-
 /* Flags for use with IRQ_CONNECT() */
 /**
  * Set this interrupt up as a zero-latency IRQ. If CONFIG_ZERO_LATENCY_LEVELS

--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -251,6 +251,15 @@ extern "C" {
 	})
 
 /**
+ * @brief Concatenate two tokens into one
+ *
+ * Concatenate two tokens,  @p x and @p y, into a combined token during the preprocessor pass.
+ * This can be used to, for ex., build an identifier out of two parts,
+ * where one of those parts may be, for ex, a number, another macro, or a macro argument.
+ */
+#define CONCAT(x, y) _DO_CONCAT(x, y)
+
+/**
  * @brief Value of @p x rounded up to the next multiple of @p align.
  */
 #define ROUND_UP(x, align)                                   \


### PR DESCRIPTION
Right now [include/zephyr/arch/arm/irq.h](https://github.com/zephyrproject-rtos/zephyr/blob/main/include/zephyr/arch/arm/irq.h#L79-L84) defines the macros CONCAT and TOSTR which are fully equivalent to Zephyr's [_CONCAT and STRINGIFY macros](https://github.com/zephyrproject-rtos/zephyr/blob/main/include/zephyr/toolchain/common.h#L133-L138).

This can easily confuse developers who will use these macros assuming they are provided by the OS, and result in code which is not portable between architectures.

Instead let's remove this definitions from the architecture headers, and remove the only place where TOSTR was used.
Note that all uses of CONCAT in the tree were changed to _CONCAT in https://github.com/zephyrproject-rtos/zephyr/pull/64839

Let's also provide CONCAT as a Zephyr API. (this commit can be dropped if it is too controversial). This should minimize possible issues for users due to the removal from the arm architecture.

Note this PR does not deprecate _CONCAT, but instead leaves it as an internal Zephyr macro.

----

    arm arch: Replace use of TOSTR with STRINGIFY
    
    One of the ARM architure files, defined since long ago
    TOSTR having the exact same purpose as Zephyr's STRINGIFY.
    
    Remove the use of this macro in the tree
    (only used in another ARM header file) in favour
    of STRINGIFY.

-----

    arm arch: Remove definition of CONCAT and TOSTR
    
    One of the ARM architure files, defined since long ago
    CONCAT and TOSTR having the exact same purpose as Zephyr's
    _CONCAT & STRINGIFY.
    
    This arm header file is included thru dependencies into
    almost all code built for ARM, which leads to these
    macros being usable everywhere.
    
    This can easily make developers belive the macros
    are provided by Zephyr itself, and use them, leading
    to code which is not portable between architectures.
    
    Remove this macros definitions from the architecture
    headers.

-----

    include: util: Add CONCAT as a general Zephyr utility macro
    
    Provide the CONCAT macro as a general Zephyr utility macro
    to paste two tokens during the preprocessor pass.
    
    Note that this macro is based on the _CONCAT macro defined
    in toolchain/common.h. This toolchain header needs a CONCAT
    like macro, but requires minimal include dependencies.
    So we leave _CONCAT where it is.

----

Fixes: #64841
