### PR TITLE
Llext: add a `.peek()` loader methods

### DIFF
--- a/include/zephyr/llext/buf_loader.h
+++ b/include/zephyr/llext/buf_loader.h
@@ -37,6 +37,7 @@ struct llext_buf_loader {
 /** @cond ignore */
 int llext_buf_read(struct llext_loader *ldr, void *buf, size_t len);
 int llext_buf_seek(struct llext_loader *ldr, size_t pos);
+void *llext_buf_peek(struct llext_loader *ldr, size_t pos);
 /** @endcond */
 
 /**
@@ -49,7 +50,8 @@ int llext_buf_seek(struct llext_loader *ldr, size_t pos);
 	{						\
 		.loader = {				\
 			.read = llext_buf_read,		\
-			.seek = llext_buf_seek		\
+			.seek = llext_buf_seek,		\
+			.peek = llext_buf_peek,		\
 		},					\
 		.buf = (_buf),				\
 		.len = (_buf_len),			\

--- a/include/zephyr/llext/llext.h
+++ b/include/zephyr/llext/llext.h
@@ -12,6 +12,7 @@
 #include <zephyr/llext/symbol.h>
 #include <zephyr/llext/loader.h>
 #include <sys/types.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -51,6 +52,9 @@ struct llext {
 
 	/** Lookup table of llext memory regions */
 	void *mem[LLEXT_MEM_COUNT];
+
+	/** Memory allocated on heap */
+	bool mem_on_heap[LLEXT_MEM_COUNT];
 
 	/** Total size of the llext memory usage */
 	size_t mem_size;

--- a/include/zephyr/llext/loader.h
+++ b/include/zephyr/llext/loader.h
@@ -73,7 +73,19 @@ struct llext_loader {
 	 * @retval 0 Success
 	 * @retval -errno Error reading (any errno)
 	 */
-	int (*seek)(struct llext_loader *s, size_t pos);
+	int (*seek)(struct llext_loader *ldr, size_t pos);
+
+	/**
+	 * @brief Peek at an absolute location
+	 *
+	 * Return a pointer to the buffer at specified offset.
+	 *
+	 * @param[in] ldr Loader
+	 * @param[in] pos Position to obtain a pointer to
+	 *
+	 * @retval pointer into the buffer
+	 */
+	void *(*peek)(struct llext_loader *ldr, size_t pos);
 
 	/** @cond ignore */
 	elf_ehdr_t hdr;

--- a/subsys/llext/buf_loader.c
+++ b/subsys/llext/buf_loader.c
@@ -29,3 +29,10 @@ int llext_buf_seek(struct llext_loader *l, size_t pos)
 
 	return 0;
 }
+
+void *llext_buf_peek(struct llext_loader *l, size_t pos)
+{
+	struct llext_buf_loader *buf_l = CONTAINER_OF(l, struct llext_buf_loader, loader);
+
+	return (void *)(buf_l->buf + pos);
+}

--- a/subsys/llext/llext.c
+++ b/subsys/llext/llext.c
@@ -31,6 +31,15 @@ static inline int llext_seek(struct llext_loader *l, size_t pos)
 	return l->seek(l, pos);
 }
 
+static inline void *llext_peek(struct llext_loader *l, size_t pos)
+{
+	if (l->peek) {
+		return l->peek(l, pos);
+	}
+
+	return NULL;
+}
+
 static sys_slist_t _llext_list = SYS_SLIST_STATIC_INIT(&_llext_list);
 
 sys_slist_t *llext_list(void)

--- a/subsys/llext/llext.c
+++ b/subsys/llext/llext.c
@@ -255,6 +255,14 @@ static int llext_copy_section(struct llext_loader *ldr, struct llext *ext,
 		return 0;
 	}
 
+	if (ldr->sects[sect_idx].sh_type != SHT_NOBITS) {
+		ext->mem[mem_idx] = llext_peek(ldr, ldr->sects[sect_idx].sh_offset);
+		if (ext->mem[mem_idx]) {
+			ext->mem_on_heap[mem_idx] = false;
+			return 0;
+		}
+	}
+
 	ext->mem[mem_idx] = k_heap_aligned_alloc(&llext_heap, sizeof(uintptr_t),
 						 ldr->sects[sect_idx].sh_size,
 						 K_NO_WAIT);
@@ -262,15 +270,21 @@ static int llext_copy_section(struct llext_loader *ldr, struct llext *ext,
 		return -ENOMEM;
 	}
 
-	ret = llext_seek(ldr, ldr->sects[sect_idx].sh_offset);
-	if (ret != 0) {
-		goto err;
+	if (ldr->sects[sect_idx].sh_type == SHT_NOBITS) {
+		memset(ext->mem[mem_idx], 0, ldr->sects[sect_idx].sh_size);
+	} else {
+		ret = llext_seek(ldr, ldr->sects[sect_idx].sh_offset);
+		if (ret != 0) {
+			goto err;
+		}
+
+		ret = llext_read(ldr, ext->mem[mem_idx], ldr->sects[sect_idx].sh_size);
+		if (ret != 0) {
+			goto err;
+		}
 	}
 
-	ret = llext_read(ldr, ext->mem[mem_idx], ldr->sects[sect_idx].sh_size);
-	if (ret != 0) {
-		goto err;
-	}
+	ext->mem_on_heap[mem_idx] = true;
 
 	return 0;
 
@@ -625,7 +639,7 @@ out:
 	if (ret != 0) {
 		LOG_DBG("Failed to load extension, freeing memory...");
 		for (enum llext_mem mem_idx = 0; mem_idx < LLEXT_MEM_COUNT; mem_idx++) {
-			if (ext->mem[mem_idx] != NULL) {
+			if (ext->mem_on_heap[mem_idx]) {
 				k_heap_free(&llext_heap, ext->mem[mem_idx]);
 			}
 		}
@@ -706,7 +720,7 @@ void llext_unload(struct llext *ext)
 	sys_slist_find_and_remove(&_llext_list, &ext->_llext_list);
 
 	for (int i = 0; i < LLEXT_MEM_COUNT; i++) {
-		if (ext->mem[i] != NULL) {
+		if (ext->mem_on_heap[i]) {
 			LOG_DBG("freeing memory region %d", i);
 			k_heap_free(&llext_heap, ext->mem[i]);
 			ext->mem[i] = NULL;


### PR DESCRIPTION
For a frequent case of a memory buffer it can be more optimal to just use a pointer into the buffer instead of dynamically allocating and copying large objects