### PR TITLE
net: Remove unnecessary lock

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -437,8 +437,6 @@ enum net_verdict net_if_send_data(struct net_if *iface, struct net_pkt *pkt)
 	enum net_verdict verdict = NET_OK;
 	int status = -EIO;
 
-	net_if_lock(iface);
-
 	if (!net_if_flag_is_set(iface, NET_IF_LOWER_UP) ||
 	    net_if_flag_is_set(iface, NET_IF_SUSPENDED)) {
 		/* Drop packet if interface is not up */
@@ -520,8 +518,6 @@ done:
 		/* Packet is ready to be sent by L2, let's queue */
 		net_if_queue_tx(iface, pkt);
 	}
-
-	net_if_unlock(iface);
 
 	return verdict;
 }


### PR DESCRIPTION
net: Remove unnecessary lock

The main action in this function it queueing the packet for
transmission which doesn't need a lock and interface flags use atomic
operations.

So, remove the unnecessary lock.

Signed-off-by: Chaitanya Tata <Chaitanya.Tata@nordicsemi.no>