### PR TITLE
net: lwm2m: Fix blockwise response code

### DIFF
--- a/include/zephyr/net/coap.h
+++ b/include/zephyr/net/coap.h
@@ -374,6 +374,15 @@ uint8_t coap_header_get_token(const struct coap_packet *cpkt, uint8_t *token);
 uint8_t coap_header_get_code(const struct coap_packet *cpkt);
 
 /**
+ * @brief Modifies the code of the CoAP packet.
+ *
+ * @param cpkt CoAP packet representation
+ * @param code CoAP code
+ * @return 0 on success, -EINVAL on failure
+ */
+int coap_header_set_code(const struct coap_packet *cpkt, uint8_t code);
+
+/**
  * @brief Returns the message id associated with the CoAP packet.
  *
  * @param cpkt CoAP packet representation

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -950,6 +950,16 @@ static uint8_t __coap_header_get_code(const struct coap_packet *cpkt)
 	return cpkt->data[1];
 }
 
+int coap_header_set_code(const struct coap_packet *cpkt, uint8_t code)
+{
+	if (!cpkt || !cpkt->data) {
+		return -EINVAL;
+	}
+
+	cpkt->data[1] = code;
+	return 0;
+}
+
 uint8_t coap_header_get_token(const struct coap_packet *cpkt, uint8_t *token)
 {
 	uint8_t tkl;


### PR DESCRIPTION
In CoAP blockwise the client is supposed to
respond with 2.31 Continue code on Ack. This was recently broken when Block1 parsing was moved after the initialization of reponse packet. We need separate CoAP API to modify the code of existing response.

Also Ack packet should contain the same Block1 options as the request. We can just copy the option.