### PR TITLE
doc: migration-guide: 3.6: Add note on MCUboot Kconfig

### DIFF
--- a/doc/releases/migration-guide-3.6.rst
+++ b/doc/releases/migration-guide-3.6.rst
@@ -59,6 +59,10 @@ Power Management
 Bootloader
 ==========
 
+* MCUboot's deprecated ``CONFIG_ZEPHYR_TRY_MASS_ERASE`` Kconfig option has been removed. If an
+  erase is needed when flashing MCUboot, this should now be provided directly to the ``west``
+  command e.g. ``west flash --erase``.
+
 Bluetooth
 =========
 


### PR DESCRIPTION
Adds a note about how to replicate the functionality of the now removed MCUboot mass erase Kconfig option