### PR TITLE
drivers: entropy: psa: Don't have PSA_CRYPTO_RNG depend on TF-M

### DIFF
--- a/drivers/entropy/Kconfig.psa_crypto
+++ b/drivers/entropy/Kconfig.psa_crypto
@@ -5,7 +5,6 @@
 
 config ENTROPY_PSA_CRYPTO_RNG
 	bool "PSA Crypto Random source Entropy driver"
-	depends on BUILD_WITH_TFM
 	depends on DT_HAS_ZEPHYR_PSA_CRYPTO_RNG_ENABLED
 	select ENTROPY_HAS_DRIVER
 	default y


### PR DESCRIPTION
Remove the depenency on TF-M so that this driver can be used when PSA is provided by something else than TF-M.