### PR TITLE
drivers: input: Espressif's capacitive touch sensor support

### DIFF
--- a/boards/xtensa/esp32_devkitc_wroom/esp32_devkitc_wroom.dts
+++ b/boards/xtensa/esp32_devkitc_wroom/esp32_devkitc_wroom.dts
@@ -8,6 +8,7 @@
 #include <espressif/esp32/esp32_wroom_32ue_n4.dtsi>
 #include "esp32_devkitc_wroom-pinctrl.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/input/esp32-touch-sensor-input.h>
 
 / {
 	model = "Espressif ESP32-DEVKITC-WROOM-32D";
@@ -72,6 +73,18 @@
 
 &gpio1 {
 	status = "okay";
+};
+
+&touch {
+	debounce-interval-ms = <30>;
+	href-microvolt = <2700000>;
+	lref-microvolt = <500000>;
+	href-atten-microvolt = <1000000>;
+	filter-mode = <ESP32_TOUCH_FILTER_MODE_IIR_16>;
+	filter-debounce-cnt = <1>;
+	filter-noise-thr = <ESP32_TOUCH_FILTER_NOISE_THR_4_8TH>;
+	filter-jitter-step = <4>;
+	filter-smooth-level = <ESP32_TOUCH_FILTER_SMOOTH_MODE_IIR_2>;
 };
 
 &i2c0 {

--- a/boards/xtensa/esp32_devkitc_wroom/esp32_devkitc_wroom.yaml
+++ b/boards/xtensa/esp32_devkitc_wroom/esp32_devkitc_wroom.yaml
@@ -17,6 +17,7 @@ supported:
   - spi
   - counter
   - entropy
+  - input
 testing:
   ignore_tags:
     - net

--- a/boards/xtensa/esp32_devkitc_wrover/esp32_devkitc_wrover.dts
+++ b/boards/xtensa/esp32_devkitc_wrover/esp32_devkitc_wrover.dts
@@ -8,6 +8,7 @@
 #include <espressif/esp32/esp32_wrover_e_n4r8.dtsi>
 #include "esp32_devkitc_wrover-pinctrl.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/input/esp32-touch-sensor-input.h>
 
 / {
 	model = "Espressif ESP32-DEVKITC-WROVER-E";
@@ -71,6 +72,18 @@
 
 &gpio1 {
 	status = "okay";
+};
+
+&touch {
+	debounce-interval-ms = <30>;
+	href-microvolt = <2700000>;
+	lref-microvolt = <500000>;
+	href-atten-microvolt = <1000000>;
+	filter-mode = <ESP32_TOUCH_FILTER_MODE_IIR_16>;
+	filter-debounce-cnt = <1>;
+	filter-noise-thr = <ESP32_TOUCH_FILTER_NOISE_THR_4_8TH>;
+	filter-jitter-step = <4>;
+	filter-smooth-level = <ESP32_TOUCH_FILTER_SMOOTH_MODE_IIR_2>;
 };
 
 &i2c0 {

--- a/boards/xtensa/esp32_devkitc_wrover/esp32_devkitc_wrover.yaml
+++ b/boards/xtensa/esp32_devkitc_wrover/esp32_devkitc_wrover.yaml
@@ -17,6 +17,7 @@ supported:
   - spi
   - counter
   - entropy
+  - input
 testing:
   ignore_tags:
     - net

--- a/boards/xtensa/esp32s2_saola/esp32s2_saola.dts
+++ b/boards/xtensa/esp32s2_saola/esp32s2_saola.dts
@@ -9,6 +9,7 @@
 #include <espressif/esp32s2/esp32s2_wrover_n4r2.dtsi>
 #include "esp32s2_saola-pinctrl.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/input/esp32-touch-sensor-input.h>
 
 / {
 	model = "esp32s2_saola";
@@ -55,6 +56,18 @@
 
 &gpio1 {
 	status = "okay";
+};
+
+&touch {
+	debounce-interval-ms = <30>;
+	href-microvolt = <2700000>;
+	lref-microvolt = <500000>;
+	href-atten-microvolt = <1000000>;
+	filter-mode = <ESP32_TOUCH_FILTER_MODE_IIR_16>;
+	filter-debounce-cnt = <1>;
+	filter-noise-thr = <ESP32_TOUCH_FILTER_NOISE_THR_4_8TH>;
+	filter-jitter-step = <4>;
+	filter-smooth-level = <ESP32_TOUCH_FILTER_SMOOTH_MODE_IIR_2>;
 };
 
 &timer0 {

--- a/boards/xtensa/esp32s2_saola/esp32s2_saola.yaml
+++ b/boards/xtensa/esp32s2_saola/esp32s2_saola.yaml
@@ -16,6 +16,7 @@ supported:
   - spi
   - counter
   - entropy
+  - input
 testing:
   ignore_tags:
     - net

--- a/boards/xtensa/esp32s3_devkitm/esp32s3_devkitm.dts
+++ b/boards/xtensa/esp32s3_devkitm/esp32s3_devkitm.dts
@@ -8,6 +8,7 @@
 #include <espressif/esp32s3/esp32s3_mini_n8.dtsi>
 #include "esp32s3_devkitm-pinctrl.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/input/esp32-touch-sensor-input.h>
 
 / {
 	model = "esp32s3_devkitm";
@@ -66,6 +67,18 @@
 
 &gpio1 {
 	status = "okay";
+};
+
+&touch {
+	debounce-interval-ms = <30>;
+	href-microvolt = <2700000>;
+	lref-microvolt = <500000>;
+	href-atten-microvolt = <1000000>;
+	filter-mode = <ESP32_TOUCH_FILTER_MODE_IIR_16>;
+	filter-debounce-cnt = <1>;
+	filter-noise-thr = <ESP32_TOUCH_FILTER_NOISE_THR_4_8TH>;
+	filter-jitter-step = <4>;
+	filter-smooth-level = <ESP32_TOUCH_FILTER_SMOOTH_MODE_IIR_2>;
 };
 
 &i2c0 {

--- a/boards/xtensa/esp32s3_devkitm/esp32s3_devkitm.yaml
+++ b/boards/xtensa/esp32s3_devkitm/esp32s3_devkitm.yaml
@@ -15,6 +15,7 @@ supported:
   - entropy
   - pwm
   - dma
+  - input
 testing:
   ignore_tags:
     - net

--- a/drivers/input/CMakeLists.txt
+++ b/drivers/input/CMakeLists.txt
@@ -6,6 +6,7 @@ zephyr_library_property(ALLOW_EMPTY TRUE)
 # zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_INPUT_CAP1203 input_cap1203.c)
 zephyr_library_sources_ifdef(CONFIG_INPUT_CST816S input_cst816s.c)
+zephyr_library_sources_ifdef(CONFIG_INPUT_ESP32_TOUCH_SENSOR input_esp32_touch_sensor.c)
 zephyr_library_sources_ifdef(CONFIG_INPUT_FT5336 input_ft5336.c)
 zephyr_library_sources_ifdef(CONFIG_INPUT_GPIO_KBD_MATRIX input_gpio_kbd_matrix.c)
 zephyr_library_sources_ifdef(CONFIG_INPUT_GPIO_KEYS input_gpio_keys.c)

--- a/drivers/input/Kconfig
+++ b/drivers/input/Kconfig
@@ -8,6 +8,7 @@ menu "Input drivers"
 # zephyr-keep-sorted-start
 source "drivers/input/Kconfig.cap1203"
 source "drivers/input/Kconfig.cst816s"
+source "drivers/input/Kconfig.esp32"
 source "drivers/input/Kconfig.ft5336"
 source "drivers/input/Kconfig.gpio_kbd_matrix"
 source "drivers/input/Kconfig.gpio_keys"

--- a/drivers/input/Kconfig.esp32
+++ b/drivers/input/Kconfig.esp32
@@ -1,0 +1,9 @@
+# Copyright (c) 2023 Espressif Systems (Shanghai) Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+config INPUT_ESP32_TOUCH_SENSOR
+	bool "Espressif Touch Sensor input driver"
+	default n
+	depends on DT_HAS_ESPRESSIF_ESP32_TOUCH_ENABLED
+	help
+	  Enable support for Espressif Touch Sensor input driver.

--- a/drivers/input/input_esp32_touch_sensor.c
+++ b/drivers/input/input_esp32_touch_sensor.c
@@ -1,0 +1,348 @@
+/*
+ * Copyright (c) 2023 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT espressif_esp32_touch
+
+#include <zephyr/device.h>
+#include <zephyr/input/input.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+
+#include <esp_err.h>
+#include <soc/soc_pins.h>
+#include <soc/periph_defs.h>
+#include <hal/touch_sensor_types.h>
+#include <hal/touch_sensor_hal.h>
+#include <driver/rtc_io.h>
+#include <esp_intr_alloc.h>
+
+LOG_MODULE_REGISTER(espressif_esp32_touch, CONFIG_INPUT_LOG_LEVEL);
+
+BUILD_ASSERT(!IS_ENABLED(CONFIG_COUNTER_RTC_ESP32),
+	     "Conflict detected: COUNTER_RTC_ESP32 enabled");
+
+#define ESP32_SCAN_DONE_MAX_COUNT 5
+
+#if defined(CONFIG_SOC_SERIES_ESP32)
+#define ESP32_RTC_INTR_MSK RTC_CNTL_TOUCH_INT_ST_M
+#elif defined(CONFIG_SOC_SERIES_ESP32S2) || defined(CONFIG_SOC_SERIES_ESP32S3)
+
+#define ESP32_RTC_INTR_MSK (RTC_CNTL_TOUCH_DONE_INT_ST_M |		\
+			    RTC_CNTL_TOUCH_ACTIVE_INT_ST_M |		\
+			    RTC_CNTL_TOUCH_INACTIVE_INT_ST_M |		\
+			    RTC_CNTL_TOUCH_SCAN_DONE_INT_ST_M |		\
+			    RTC_CNTL_TOUCH_TIMEOUT_INT_ST_M)
+
+#define ESP32_TOUCH_PAD_INTR_MASK (TOUCH_PAD_INTR_MASK_ACTIVE |		\
+				   TOUCH_PAD_INTR_MASK_INACTIVE |	\
+				   TOUCH_PAD_INTR_MASK_TIMEOUT |	\
+				   TOUCH_PAD_INTR_MASK_SCAN_DONE)
+
+#endif /* defined(CONFIG_SOC_SERIES_ESP32) */
+
+struct esp32_touch_sensor_channel_config {
+	int32_t channel_num;
+	int32_t channel_sens;
+	uint32_t zephyr_code;
+};
+
+struct esp32_touch_sensor_config {
+	uint32_t debounce_interval_ms;
+	int num_channels;
+	int href_microvolt_enum_idx;
+	int lref_microvolt_enum_idx;
+	int href_atten_microvolt_enum_idx;
+	int filter_mode;
+	int filter_debounce_cnt;
+	int filter_noise_thr;
+	int filter_jitter_step;
+	int filter_smooth_level;
+	const struct esp32_touch_sensor_channel_config *channel_cfg;
+	struct esp32_touch_sensor_channel_data *channel_data;
+};
+
+struct esp32_touch_sensor_channel_data {
+	const struct device *dev;
+	struct k_work_delayable work;
+	uint32_t status;
+#if defined(CONFIG_SOC_SERIES_ESP32S2) || defined(CONFIG_SOC_SERIES_ESP32S3)
+	uint32_t last_status;
+#endif /* defined(CONFIG_SOC_SERIES_ESP32S2) || defined(CONFIG_SOC_SERIES_ESP32S3) */
+};
+
+struct esp32_touch_sensor_data {
+	uint32_t rtc_intr_msk;
+};
+
+static void esp32_touch_sensor_interrupt_cb(void *arg)
+{
+	const struct device *dev = arg;
+	struct esp32_touch_sensor_data *dev_data = dev->data;
+	const struct esp32_touch_sensor_config *dev_cfg = dev->config;
+	const struct esp32_touch_sensor_channel_config *channel_cfg;
+	const int num_channels = dev_cfg->num_channels;
+	uint32_t pad_status;
+
+#if defined(CONFIG_SOC_SERIES_ESP32)
+	touch_hal_intr_clear();
+
+#elif defined(CONFIG_SOC_SERIES_ESP32S2) || defined(CONFIG_SOC_SERIES_ESP32S3)
+	static uint8_t scan_done_counter;
+
+	touch_pad_intr_mask_t intr_mask = touch_hal_read_intr_status_mask();
+
+	if (intr_mask & TOUCH_PAD_INTR_MASK_SCAN_DONE) {
+		if (++scan_done_counter == ESP32_SCAN_DONE_MAX_COUNT) {
+			touch_hal_intr_disable(TOUCH_PAD_INTR_MASK_SCAN_DONE);
+			for (int i = 0; i < num_channels; i++) {
+				channel_cfg = &dev_cfg->channel_cfg[i];
+
+				/* Set interrupt threshold */
+				uint32_t benchmark_value;
+
+				touch_hal_read_benchmark(channel_cfg->channel_num,
+					&benchmark_value);
+				touch_hal_set_threshold(channel_cfg->channel_num,
+					channel_cfg->channel_sens * benchmark_value / 100);
+			}
+		}
+		return;
+	}
+#endif /* defined(CONFIG_SOC_SERIES_ESP32) */
+
+	touch_hal_read_trigger_status_mask(&pad_status);
+#if defined(CONFIG_SOC_SERIES_ESP32)
+	touch_hal_clear_trigger_status_mask();
+#endif /* defined(CONFIG_SOC_SERIES_ESP32) */
+	for (int i = 0; i < num_channels; i++) {
+		uint32_t channel_status;
+
+		channel_cfg = &dev_cfg->channel_cfg[i];
+		channel_status = (pad_status >> channel_cfg->channel_num) & 0x01;
+
+#if defined(CONFIG_SOC_SERIES_ESP32)
+		if (channel_status != 0) {
+#elif defined(CONFIG_SOC_SERIES_ESP32S2) || defined(CONFIG_SOC_SERIES_ESP32S3)
+		uint32_t channel_num = (uint32_t)touch_hal_get_current_meas_channel();
+
+		if (channel_cfg->channel_num == channel_num) {
+#endif /* CONFIG_SOC_SERIES_ESP32 */
+			struct esp32_touch_sensor_channel_data
+				*channel_data = &dev_cfg->channel_data[i];
+
+			channel_data->status = channel_status;
+			(void)k_work_reschedule(&channel_data->work,
+						K_MSEC(dev_cfg->debounce_interval_ms));
+		}
+	}
+}
+
+static void esp32_rtc_isr(void *arg)
+{
+	uint32_t status = REG_READ(RTC_CNTL_INT_ST_REG);
+
+	if (arg != NULL) {
+		const struct device *dev = arg;
+		struct esp32_touch_sensor_data *dev_data = dev->data;
+
+		if (dev_data->rtc_intr_msk & status) {
+			esp32_touch_sensor_interrupt_cb(arg);
+		}
+	}
+
+	REG_WRITE(RTC_CNTL_INT_CLR_REG, status);
+}
+
+static esp_err_t esp32_rtc_isr_install(intr_handler_t intr_handler, const void *handler_arg)
+{
+	esp_err_t err;
+
+	REG_WRITE(RTC_CNTL_INT_ENA_REG, 0);
+	REG_WRITE(RTC_CNTL_INT_CLR_REG, UINT32_MAX);
+	err = esp_intr_alloc(ETS_RTC_CORE_INTR_SOURCE, 0, intr_handler, (void *)handler_arg, NULL);
+
+	return err;
+}
+
+/**
+ * Handle debounced touch sensor touch state.
+ */
+static void esp32_touch_sensor_change_deferred(struct k_work *work)
+{
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct esp32_touch_sensor_channel_data *channel_data =
+			CONTAINER_OF(dwork, struct esp32_touch_sensor_channel_data, work);
+	const struct device *dev = channel_data->dev;
+	const struct esp32_touch_sensor_config *dev_cfg = dev->config;
+	int key_index = channel_data - &dev_cfg->channel_data[0];
+	const struct esp32_touch_sensor_channel_config
+		*channel_cfg = &dev_cfg->channel_cfg[key_index];
+
+#if defined(CONFIG_SOC_SERIES_ESP32S2) || defined(CONFIG_SOC_SERIES_ESP32S3)
+	if (channel_data->last_status != channel_data->status) {
+#endif /* defined(CONFIG_SOC_SERIES_ESP32S2) || defined(CONFIG_SOC_SERIES_ESP32S3) */
+		input_report_key(dev, channel_cfg->zephyr_code,
+				channel_data->status, true, K_FOREVER);
+#if defined(CONFIG_SOC_SERIES_ESP32S2) || defined(CONFIG_SOC_SERIES_ESP32S3)
+		channel_data->last_status = channel_data->status;
+	}
+#endif /* defined(CONFIG_SOC_SERIES_ESP32S2) || defined(CONFIG_SOC_SERIES_ESP32S3) */
+}
+
+static int esp32_touch_sensor_init(const struct device *dev)
+{
+	struct esp32_touch_sensor_data *dev_data = dev->data;
+	const struct esp32_touch_sensor_config *dev_cfg = dev->config;
+	const int num_channels = dev_cfg->num_channels;
+
+	touch_hal_init();
+
+#if defined(CONFIG_SOC_SERIES_ESP32)
+	touch_hal_volt_t volt = {
+		.refh = dev_cfg->href_microvolt_enum_idx,
+		.refh = dev_cfg->href_microvolt_enum_idx,
+		.atten = dev_cfg->href_atten_microvolt_enum_idx
+	};
+
+	touch_hal_set_voltage(&volt);
+	touch_hal_set_fsm_mode(TOUCH_FSM_MODE_TIMER);
+#endif /* defined(CONFIG_SOC_SERIES_ESP32) */
+
+	for (int i = 0; i < num_channels; i++) {
+		struct esp32_touch_sensor_channel_data *channel_data = &dev_cfg->channel_data[i];
+		const struct esp32_touch_sensor_channel_config *channel_cfg =
+			&dev_cfg->channel_cfg[i];
+
+		if (!(channel_cfg->channel_num > 0 &&
+			channel_cfg->channel_num < SOC_TOUCH_SENSOR_NUM)) {
+			LOG_ERR("Touch %d configuration failed: "
+				"Touch channel error", i);
+			return -EINVAL;
+		}
+
+#if defined(CONFIG_SOC_SERIES_ESP32S2) || defined(CONFIG_SOC_SERIES_ESP32S3)
+		if (channel_cfg->channel_num == SOC_TOUCH_DENOISE_CHANNEL) {
+			LOG_ERR("Touch %d configuration failed: "
+				"TOUCH0 is internal denoise channel", i);
+			return -EINVAL;
+		}
+#endif  /* defined(CONFIG_SOC_SERIES_ESP32S2) || defined(CONFIG_SOC_SERIES_ESP32S3) */
+
+		gpio_num_t gpio_num = touch_sensor_channel_io_map[channel_cfg->channel_num];
+
+		rtc_gpio_init(gpio_num);
+		rtc_gpio_set_direction(gpio_num, RTC_GPIO_MODE_DISABLED);
+		rtc_gpio_pulldown_dis(gpio_num);
+		rtc_gpio_pullup_dis(gpio_num);
+
+		touch_hal_config(channel_cfg->channel_num);
+#if defined(CONFIG_SOC_SERIES_ESP32)
+		touch_hal_set_threshold(channel_cfg->channel_num, 0);
+		touch_hal_set_group_mask(BIT(channel_cfg->channel_num),
+					 BIT(channel_cfg->channel_num));
+#endif /* defined(CONFIG_SOC_SERIES_ESP32) */
+		touch_hal_set_channel_mask(BIT(channel_cfg->channel_num));
+
+		channel_data->status = 0;
+#if defined(CONFIG_SOC_SERIES_ESP32S2) || defined(CONFIG_SOC_SERIES_ESP32S3)
+		channel_data->last_status = 0;
+#endif /* defined(CONFIG_SOC_SERIES_ESP32S2) || defined(CONFIG_SOC_SERIES_ESP32S3) */
+		channel_data->dev = dev;
+
+		k_work_init_delayable(&channel_data->work, esp32_touch_sensor_change_deferred);
+	}
+
+#if defined(CONFIG_SOC_SERIES_ESP32)
+	for (int i = 0; i < num_channels; i++) {
+		const struct esp32_touch_sensor_channel_config *channel_cfg =
+			&dev_cfg->channel_cfg[i];
+		uint32_t ref_time;
+
+		ref_time = k_uptime_get_32();
+		while (!touch_hal_meas_is_done()) {
+			if (k_uptime_get_32() - ref_time > 500) {
+				return -ETIMEDOUT;
+			}
+			k_busy_wait(1000);
+		}
+		uint16_t touch_value = touch_hal_read_raw_data(channel_cfg->channel_num);
+
+		touch_hal_set_threshold(channel_cfg->channel_num,
+					touch_value * (100 - channel_cfg->channel_num) / 100);
+	}
+
+#elif defined(CONFIG_SOC_SERIES_ESP32S2) || defined(CONFIG_SOC_SERIES_ESP32S3)
+	touch_filter_config_t filter_info = {
+		.mode = dev_cfg->filter_mode,
+		.debounce_cnt = dev_cfg->filter_debounce_cnt,
+		.noise_thr = dev_cfg->filter_noise_thr,
+		.jitter_step = dev_cfg->filter_jitter_step,
+		.smh_lvl = dev_cfg->filter_smooth_level,
+	};
+	touch_hal_filter_set_config(&filter_info);
+	touch_hal_filter_enable();
+
+	touch_hal_timeout_enable();
+	touch_hal_timeout_set_threshold(SOC_TOUCH_PAD_THRESHOLD_MAX);
+#endif /* defined(CONFIG_SOC_SERIES_ESP32) */
+
+	dev_data->rtc_intr_msk = ESP32_RTC_INTR_MSK;
+	esp32_rtc_isr_install(&esp32_rtc_isr, dev);
+#if defined(CONFIG_SOC_SERIES_ESP32)
+	touch_hal_intr_enable();
+#elif defined(CONFIG_SOC_SERIES_ESP32S2) || defined(CONFIG_SOC_SERIES_ESP32S3)
+	touch_hal_intr_enable(ESP32_TOUCH_PAD_INTR_MASK);
+	touch_hal_set_fsm_mode(TOUCH_FSM_MODE_TIMER);
+#endif /* defined(CONFIG_SOC_SERIES_ESP32) */
+
+	touch_hal_start_fsm();
+
+	return 0;
+}
+
+#define ESP32_TOUCH_SENSOR_CHANNEL_CFG_INIT(node_id)						\
+	{											\
+		.channel_num  = DT_PROP(node_id, channel_num),					\
+		.channel_sens = DT_PROP(node_id, channel_sens),					\
+		.zephyr_code  = DT_PROP(node_id, zephyr_code),					\
+	}
+
+#define ESP32_TOUCH_SENSOR_INIT(inst)								\
+	static const struct esp32_touch_sensor_channel_config					\
+		esp32_touch_sensor_channel_config_##inst[] = {					\
+			DT_INST_FOREACH_CHILD_STATUS_OKAY_SEP(inst,				\
+				ESP32_TOUCH_SENSOR_CHANNEL_CFG_INIT, (,))			\
+		};										\
+												\
+	static struct esp32_touch_sensor_channel_data esp32_touch_sensor_channel_data_##inst	\
+				[ARRAY_SIZE(esp32_touch_sensor_channel_config_##inst)];		\
+												\
+	static const struct esp32_touch_sensor_config esp32_touch_sensor_config_##inst = {	\
+		.debounce_interval_ms = DT_INST_PROP(inst, debounce_interval_ms),		\
+		.num_channels = ARRAY_SIZE(esp32_touch_sensor_channel_config_##inst),		\
+		.href_microvolt_enum_idx = DT_INST_ENUM_IDX(inst, href_microvolt),		\
+		.lref_microvolt_enum_idx = DT_INST_ENUM_IDX(inst, lref_microvolt),		\
+		.href_atten_microvolt_enum_idx = DT_INST_ENUM_IDX(inst, href_atten_microvolt),	\
+		.filter_mode = DT_INST_PROP(inst, filter_mode),					\
+		.filter_debounce_cnt = DT_INST_PROP(inst, filter_debounce_cnt),			\
+		.filter_noise_thr = DT_INST_PROP(inst, filter_noise_thr),			\
+		.filter_jitter_step = DT_INST_PROP(inst, filter_jitter_step),			\
+		.filter_smooth_level = DT_INST_PROP(inst, filter_smooth_level),			\
+		.channel_cfg = esp32_touch_sensor_channel_config_##inst,			\
+		.channel_data = esp32_touch_sensor_channel_data_##inst,				\
+	};											\
+												\
+	static struct esp32_touch_sensor_data esp32_touch_sensor_data_##inst;			\
+												\
+	DEVICE_DT_INST_DEFINE(inst,								\
+			      &esp32_touch_sensor_init,						\
+			      NULL,								\
+			      &esp32_touch_sensor_data_##inst,					\
+			      &esp32_touch_sensor_config_##inst,				\
+			      POST_KERNEL, CONFIG_INPUT_INIT_PRIORITY,				\
+			      NULL);
+
+DT_INST_FOREACH_STATUS_OKAY(ESP32_TOUCH_SENSOR_INIT)

--- a/dts/bindings/input/espressif,esp32-touch-sensor.yaml
+++ b/dts/bindings/input/espressif,esp32-touch-sensor.yaml
@@ -1,0 +1,131 @@
+# Copyright (c) 2023 Espressif Systems (Shanghai) Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Zephyr input touch sensor parent node
+
+  This defines a group of touch sensors that can generate input events. Each touch
+  sensor is defined in a child node of the touch-sensor node and defines a specific key
+  code.
+
+  For example:
+
+  #include <zephyr/dt-bindings/input/input-event-codes.h>
+  #include <zephyr/dt-bindings/input/esp32-touch-sensor-input.h>
+
+  &touch {
+         compatible = "espressif,esp32-touch";
+         status = "okay";
+
+         debounce-interval-ms = <30>;
+         href-microvolt = <27000000>;
+         lref-microvolt = <500000>;
+         href-atten-microvolt = <1000000>;
+         filter-mode = <ESP32_TOUCH_FILTER_MODE_IIR_16>;
+         filter-debounce-cnt = <1>;
+         filter-noise-thr = <ESP32_TOUCH_FILTER_NOISE_THR_4_8TH>;
+         filter-jitter-step = <4>;
+         filter-smooth-level = <ESP32_TOUCH_FILTER_SMOOTH_MODE_IIR_2>;
+
+         touch_sensor_0 {
+                 channel_num = <1>;
+                 channel_sens = <20>;
+                 zephyr,code = <INPUT_KEY_0>;
+         };
+  };
+
+
+compatible: "espressif,esp32-touch"
+
+include: base.yaml
+
+properties:
+  debounce-interval-ms:
+    type: int
+    default: 30
+    description: Debouncing interval time in milliseconds.
+
+  href-microvolt:
+    type: int
+    enum:
+      - 2400000
+      - 2500000
+      - 2500000
+      - 2700000
+    default: 2700000
+    description: Touch sensor high reference voltage.
+
+  lref-microvolt:
+    type: int
+    enum:
+      - 500000
+      - 600000
+      - 700000
+      - 800000
+    default: 500000
+    description: Touch sensor low reference voltage.
+
+  href-atten-microvolt:
+    type: int
+    enum:
+      - 1500000
+      - 1000000
+      - 500000
+      - 0
+    default: 1000000
+    description: Touch sensor high reference attenuation voltage.
+
+  filter-mode:
+    type: int
+    default: 2
+    description: |
+       Touch sensor IIR filter coefficient.
+       If not specified defaults to ESP32_TOUCH_FILTER_MODE_IIR_16.
+
+  filter-debounce-cnt:
+    type: int
+    default: 1
+    description: |
+       Touch sensor debounce count.
+       If not specified defaults to 1.
+
+  filter-noise-thr:
+    type: int
+    default: 0
+    description: |
+       Touch sensor noise threshold coefficient.
+       If not specified defaults to ESP32_TOUCH_FILTER_NOISE_THR_4_8TH.
+
+  filter-jitter-step:
+    type: int
+    default: 4
+    description: |
+       Touch sensor jitter filter step size.
+       If not specified defaults to 4.
+
+  filter-smooth-level:
+    type: int
+    default: 1
+    description: |
+       Touch sensor level of filter applied on the original data against large noise interference.
+       If not specified defaults to ESP32_TOUCH_FILTER_SMOOTH_MODE_IIR_2.
+
+child-binding:
+  description: Touch sensor child node
+  properties:
+    channel-num:
+      type: int
+      required: true
+      description: Touch sensor channel number
+
+    channel-sens:
+      type: int
+      default: 20
+      description: |
+         Touch sensor channel sensibility in 100th.
+         If not specified defaults to 20.
+
+    zephyr,code:
+      type: int
+      required: true
+      description: Key code to emit.

--- a/dts/xtensa/espressif/esp32/esp32_common.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_common.dtsi
@@ -271,6 +271,14 @@
 			};
 		};
 
+		touch: touch@3ff48858 {
+			compatible = "espressif,esp32-touch";
+			reg = <0x3ff48858 0x38>;
+			interrupts = <RTC_CORE_INTR_SOURCE>;
+			interrupt-parent = <&intc>;
+			status = "disabled";
+		};
+
 		i2c0: i2c@3ff53000 {
 			compatible = "espressif,esp32-i2c";
 			#address-cells = <1>;

--- a/dts/xtensa/espressif/esp32s2/esp32s2_common.dtsi
+++ b/dts/xtensa/espressif/esp32s2/esp32s2_common.dtsi
@@ -184,6 +184,14 @@
 			ngpios = <22>;   /* 32..53 */
 		};
 
+		touch: touch@3f40885c {
+			compatible = "espressif,esp32-touch";
+			reg = <0x3f40885c 0xc0 0x3f408104 0x18>;
+			interrupts = <RTC_CORE_INTR_SOURCE>;
+			interrupt-parent = <&intc>;
+			status = "disabled";
+		};
+
 		i2c0: i2c@3f413000 {
 			compatible = "espressif,esp32-i2c";
 			#address-cells = <1>;

--- a/dts/xtensa/espressif/esp32s3/esp32s3_common.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_common.dtsi
@@ -193,6 +193,14 @@
 			};
 		};
 
+		touch: touch@6000885c {
+			compatible = "espressif,esp32-touch";
+			reg = <0x6000885c 0x88 0x60008908 0x18>;
+			interrupts = <RTC_CORE_INTR_SOURCE>;
+			interrupt-parent = <&intc>;
+			status = "disabled";
+		};
+
 		i2c0: i2c@60013000 {
 			compatible = "espressif,esp32-i2c";
 			#address-cells = <1>;

--- a/include/zephyr/dt-bindings/input/esp32-touch-sensor-input.h
+++ b/include/zephyr/dt-bindings/input/esp32-touch-sensor-input.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_INPUT_ESP32_TOUCH_SENSOR_INPUT_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_INPUT_ESP32_TOUCH_SENSOR_INPUT_H_
+
+#include <zephyr/dt-bindings/dt-util.h>
+
+/* Touch sensor IIR filter mode */
+#define ESP32_TOUCH_FILTER_MODE_IIR_4		0
+#define ESP32_TOUCH_FILTER_MODE_IIR_8		1
+#define ESP32_TOUCH_FILTER_MODE_IIR_16		2
+#define ESP32_TOUCH_FILTER_MODE_IIR_32		3
+#define ESP32_TOUCH_FILTER_MODE_IIR_64		4
+#define ESP32_TOUCH_FILTER_MODE_IIR_128		5
+#define ESP32_TOUCH_FILTER_MODE_IIR_256		6
+#define ESP32_TOUCH_FILTER_MODE_JITTER		7
+
+/* Touch sensor level of filter noise threshold coefficient*/
+#define ESP32_TOUCH_FILTER_NOISE_THR_4_8TH	0
+#define ESP32_TOUCH_FILTER_NOISE_THR_3_8TH	1
+#define ESP32_TOUCH_FILTER_NOISE_THR_2_8TH	2
+#define ESP32_TOUCH_FILTER_NOISE_THR_8_8TH	3
+
+/* Touch sensor level of filter applied on the original data */
+#define ESP32_TOUCH_FILTER_SMOOTH_MODE_OFF	0
+#define ESP32_TOUCH_FILTER_SMOOTH_MODE_IIR_2	1
+#define ESP32_TOUCH_FILTER_SMOOTH_MODE_IIR_4	2
+#define ESP32_TOUCH_FILTER_SMOOTH_MODE_IIR_8	3
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_INPUT_ESP32_TOUCH_SENSOR_INPUT_H_ */

--- a/samples/subsys/input/input_dump/boards/esp32_devkitc_wroom.overlay
+++ b/samples/subsys/input/input_dump/boards/esp32_devkitc_wroom.overlay
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/input/esp32-touch-sensor-input.h>
+
+&touch {
+	status = "okay";
+
+	touch_sensor_set: touch_sensor_0 {
+		channel-num = <9>;
+		channel-sens = <20>;
+		zephyr,code = <INPUT_KEY_0>;
+	};
+
+	touch_sensor_play: touch_sensor_1 {
+		channel-num = <8>;
+		channel-sens = <20>;
+		zephyr,code = <INPUT_KEY_1>;
+	};
+
+	touch_sensor_vol_inc: touch_sensor_2 {
+		channel-num = <6>;
+		channel-sens = <20>;
+		zephyr,code = <INPUT_KEY_2>;
+	};
+
+	touch_sensor_vol_dec: touch_sensor_3 {
+		channel-num = <4>;
+		channel-sens = <20>;
+		zephyr,code = <INPUT_KEY_3>;
+	};
+};

--- a/samples/subsys/input/input_dump/boards/esp32_devkitc_wrover.overlay
+++ b/samples/subsys/input/input_dump/boards/esp32_devkitc_wrover.overlay
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/input/esp32-touch-sensor-input.h>
+
+&touch {
+	status = "okay";
+
+	touch_sensor_set: touch_sensor_0 {
+		channel-num = <9>;
+		channel-sens = <20>;
+		zephyr,code = <INPUT_KEY_0>;
+	};
+
+	touch_sensor_play: touch_sensor_1 {
+		channel-num = <8>;
+		channel-sens = <20>;
+		zephyr,code = <INPUT_KEY_1>;
+	};
+
+	touch_sensor_vol_inc: touch_sensor_2 {
+		channel-num = <6>;
+		channel-sens = <20>;
+		zephyr,code = <INPUT_KEY_2>;
+	};
+
+	touch_sensor_vol_dec: touch_sensor_3 {
+		channel-num = <4>;
+		channel-sens = <20>;
+		zephyr,code = <INPUT_KEY_3>;
+	};
+};

--- a/samples/subsys/input/input_dump/boards/esp32s2_saola.overlay
+++ b/samples/subsys/input/input_dump/boards/esp32s2_saola.overlay
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/input/esp32-touch-sensor-input.h>
+
+&touch {
+	status = "okay";
+
+	touch_sensor_set: touch_sensor_0 {
+		channel-num = <9>;
+		channel-sens = <20>;
+		zephyr,code = <INPUT_KEY_0>;
+	};
+
+	touch_sensor_play: touch_sensor_1 {
+		channel-num = <8>;
+		channel-sens = <20>;
+		zephyr,code = <INPUT_KEY_1>;
+	};
+
+	touch_sensor_vol_inc: touch_sensor_2 {
+		channel-num = <6>;
+		channel-sens = <20>;
+		zephyr,code = <INPUT_KEY_2>;
+	};
+
+	touch_sensor_vol_dec: touch_sensor_3 {
+		channel-num = <4>;
+		channel-sens = <20>;
+		zephyr,code = <INPUT_KEY_3>;
+	};
+};

--- a/samples/subsys/input/input_dump/boards/esp32s3_devkitm.overlay
+++ b/samples/subsys/input/input_dump/boards/esp32s3_devkitm.overlay
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/input/esp32-touch-sensor-input.h>
+
+&touch {
+	status = "okay";
+
+	touch_sensor_set: touch_sensor_0 {
+		channel-num = <9>;
+		channel-sens = <20>;
+		zephyr,code = <INPUT_KEY_0>;
+	};
+
+	touch_sensor_play: touch_sensor_1 {
+		channel-num = <8>;
+		channel-sens = <20>;
+		zephyr,code = <INPUT_KEY_1>;
+	};
+
+	touch_sensor_vol_inc: touch_sensor_2 {
+		channel-num = <6>;
+		channel-sens = <20>;
+		zephyr,code = <INPUT_KEY_2>;
+	};
+
+	touch_sensor_vol_dec: touch_sensor_3 {
+		channel-num = <4>;
+		channel-sens = <20>;
+		zephyr,code = <INPUT_KEY_3>;
+	};
+};

--- a/west.yml
+++ b/west.yml
@@ -152,7 +152,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: ffbe58815808af98d1e3241defa552a0fcc6d28a
+      revision: eb7e415dc115e57afe96f552493b19d49dfc8c0e
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
The purpose of this PR is add Espressif Systems's capacitive touch sensor support to Zephyr input subsystem.
The socs covered are:
- ESP32
- ESP32S2
- ESP32S3
