### PR TITLE
doc: pdf: Add Glossary of Terms to PDF output

### DIFF
--- a/doc/index-tex.rst
+++ b/doc/index-tex.rst
@@ -24,3 +24,4 @@ Zephyr Project Documentation
    project/index.rst
    security/index.rst
    safety/index.rst
+   glossary.rst


### PR DESCRIPTION
Add the Glossary page to the PDF so that :term: roles are properly resolved.
FWIW the glossary ends up being part of the numbered sections (unlike e.g. Bibliography or Index entries) but I don't see it as a major issue.