### PR TITLE
tests: coredump: Extend backends test coverage

### DIFF
--- a/tests/subsys/debug/coredump_backends/CMakeLists.txt
+++ b/tests/subsys/debug/coredump_backends/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(hello_world)
+project(debug_coredump_backends)
 
 target_sources(app PRIVATE src/main.c)
 

--- a/tests/subsys/debug/coredump_backends/Kconfig
+++ b/tests/subsys/debug/coredump_backends/Kconfig
@@ -1,0 +1,17 @@
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+source "Kconfig.zephyr"
+
+config TEST_STORED_COREDUMP
+	bool "Expected backend has coredump storage."
+	help
+	  Set if the test expects coredump backend with storage.
+
+config TEST_STORED_DUMP_SIZE
+	int "Expected backend's coredump storage size."
+	default 0
+	help
+	  Test expects coredump backend storage with the size given.
+	  If zero, then it is ignored and not compared with the actual size.

--- a/tests/subsys/debug/coredump_backends/src/coredump_backend_empty.c
+++ b/tests/subsys/debug/coredump_backends/src/coredump_backend_empty.c
@@ -42,6 +42,9 @@ static int coredump_empty_backend_query(enum coredump_query_id query_id,
 			ret = 1;
 		}
 		break;
+	case COREDUMP_QUERY_GET_STORED_DUMP_SIZE:
+		ret = 0;
+		break;
 	default:
 		ret = -ENOTSUP;
 		break;
@@ -65,6 +68,14 @@ static int coredump_empty_backend_cmd(enum coredump_cmd_id cmd_id,
 		if (is_valid) {
 			ret = 1;
 		}
+		break;
+	case COREDUMP_CMD_INVALIDATE_STORED_DUMP:
+		is_valid = false;
+		ret = 0;
+		break;
+	case COREDUMP_CMD_ERASE_STORED_DUMP:
+		is_valid = false;
+		ret = 0;
 		break;
 	default:
 		ret = -ENOTSUP;

--- a/tests/subsys/debug/coredump_backends/src/main.c
+++ b/tests/subsys/debug/coredump_backends/src/main.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2012-2014 Wind River Systems, Inc.
+ * Copyright (c) 2020-2023, Intel Corporation.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -34,7 +35,7 @@ void dump_entry(void *p1, void *p2, void *p3)
 	irq_unlock(key);
 }
 
-static void check_errors(void)
+void check_error(void)
 {
 	int ret;
 
@@ -45,9 +46,22 @@ static void check_errors(void)
 	}
 }
 
-void test_coredump(void)
+void clear_error(void)
+{
+	int ret;
+
+	/* Clear backend error if backend supports this query */
+	ret = coredump_cmd(COREDUMP_CMD_CLEAR_ERROR, NULL);
+	if (ret != -ENOTSUP) {
+		zassert_equal(ret, 0, "Error encountered! (%d)", ret);
+	}
+}
+
+static void *raise_coredump(void)
 {
 	k_tid_t tid;
+
+	clear_error();
 
 	/* Create a thread that crashes */
 	tid = k_thread_create(&dump_thread, dump_stack,
@@ -57,28 +71,46 @@ void test_coredump(void)
 
 	k_thread_join(tid, K_FOREVER);
 
-	check_errors();
+	return &dump_thread;
 }
 
-void test_query_stored_dump(void)
+void test_has_stored_dump(bool is_expected)
 {
 	int ret;
 
 	/* Cannot proceed with previous errors */
-	check_errors();
+	check_error();
 
 	/* There should be a stored coredump now if backend has storage */
 	ret = coredump_query(COREDUMP_QUERY_HAS_STORED_DUMP, NULL);
 	if (ret == -ENOTSUP) {
-		ztest_test_skip();
-	} else if (ret == 1) {
-		check_errors();
-		ztest_test_pass();
-	} else if (ret == 0) {
-		TC_PRINT("Should have stored dump!\n");
+#ifdef CONFIG_TEST_STORED_COREDUMP
+		TC_ERROR("Can't query stored dump: unexpectedly not supported.\n");
 		ztest_test_fail();
+#else
+		TC_PRINT("Can't query stored dump: expectedly not supported.\n");
+		ztest_test_skip();
+#endif
+	} else if (ret == 1) {
+#ifdef CONFIG_TEST_STORED_COREDUMP
+		check_error();
+		zassert_true(is_expected, "Unexpected coredump found.\n");
+		ztest_test_pass();
+#else
+		TC_ERROR("Can't have a stored dump: not supported.\n");
+		ztest_test_fail();
+#endif
+	} else if (ret == 0) {
+#ifdef CONFIG_TEST_STORED_COREDUMP
+		check_error();
+		zassert_false(is_expected, "Should have stored dump!\n");
+		ztest_test_pass();
+#else
+		TC_ERROR("Can't have an empty stored dump: not supported.\n");
+		ztest_test_fail();
+#endif
 	} else {
-		TC_PRINT("Error reading stored dump! (%d)\n", ret);
+		TC_ERROR("Error reading stored dump! (%d)\n", ret);
 		ztest_test_fail();
 	}
 }
@@ -88,28 +120,162 @@ void test_verify_stored_dump(void)
 	int ret;
 
 	/* Cannot proceed with previous errors */
-	check_errors();
+	check_error();
 
 	/* There should be a stored coredump now if backend has storage */
 	ret = coredump_cmd(COREDUMP_CMD_VERIFY_STORED_DUMP, NULL);
 	if (ret == -ENOTSUP) {
-		ztest_test_skip();
-	} else if (ret == 1) {
-		check_errors();
-		ztest_test_pass();
-	} else if (ret == 0) {
-		TC_PRINT("Verification of stored dump failed!\n");
+#ifdef CONFIG_TEST_STORED_COREDUMP
+		TC_ERROR("Can't verify stored dump: unexpectedly not supported.\n");
 		ztest_test_fail();
+#else
+		TC_PRINT("Can't verify stored dump: expectedly not supported.\n");
+		ztest_test_skip();
+#endif
+	} else if (ret == 1) {
+#ifdef CONFIG_TEST_STORED_COREDUMP
+		check_error();
+		ztest_test_pass();
+#else
+		TC_ERROR("Can't have a stored dump: not supported.\n");
+		ztest_test_fail();
+#endif
+	} else if (ret == 0) {
+#ifdef CONFIG_TEST_STORED_COREDUMP
+		TC_ERROR("Verification of stored dump failed!\n");
+		ztest_test_fail();
+#else
+		TC_ERROR("Can't have a stored dump: not supported.\n");
+		ztest_test_fail();
+#endif
 	} else {
-		TC_PRINT("Error reading stored dump! (%d)\n", ret);
+		TC_ERROR("Error reading stored dump! (%d)\n", ret);
 		ztest_test_fail();
 	}
 }
 
-ZTEST(coredump_backends, test_coredump_backend) {
-	test_coredump();
-	test_query_stored_dump();
+void test_invalidate_stored_dump(void)
+{
+	int ret;
+
+	/* Cannot proceed with previous errors */
+	check_error();
+
+	/* There should be a stored coredump now if backend has storage */
+	ret = coredump_cmd(COREDUMP_CMD_INVALIDATE_STORED_DUMP, NULL);
+	if (ret == -ENOTSUP) {
+#ifdef CONFIG_TEST_STORED_COREDUMP
+		TC_ERROR("Can't invalidate stored dump: unexpectedly not supported.\n");
+		ztest_test_fail();
+#else
+		TC_PRINT("Can't invalidate stored dump: expectedly not supported.\n");
+		ztest_test_skip();
+#endif
+	} else if (ret == 0) {
+#ifdef CONFIG_TEST_STORED_COREDUMP
+		check_error();
+		ztest_test_pass();
+#else
+		TC_ERROR("Can't invalidate the stored dump: not supported.\n");
+		ztest_test_fail();
+#endif
+	} else {
+		TC_ERROR("Error invalidating stored dump! (%d)\n", ret);
+		ztest_test_fail();
+	}
+}
+
+void test_erase_stored_dump(void)
+{
+	int ret;
+
+	/* Cannot proceed with previous errors */
+	check_error();
+
+	/* There should be a stored coredump now if backend has storage */
+	ret = coredump_cmd(COREDUMP_CMD_ERASE_STORED_DUMP, NULL);
+	if (ret == -ENOTSUP) {
+#ifdef CONFIG_TEST_STORED_COREDUMP
+		TC_ERROR("Can't erase stored dump: unexpectedly not supported.\n");
+		ztest_test_fail();
+#else
+		TC_PRINT("Can't erase stored dump: expectedly not supported.\n");
+		ztest_test_skip();
+#endif
+	} else if (ret == 0) {
+#ifdef CONFIG_TEST_STORED_COREDUMP
+		check_error();
+		ztest_test_pass();
+#else
+		TC_ERROR("Can't erase the stored dump: not supported.\n");
+		ztest_test_fail();
+#endif
+	} else {
+		TC_ERROR("Error erasing stored dump! (%d)\n", ret);
+		ztest_test_fail();
+	}
+}
+
+void test_get_stored_dump_size(int size_expected)
+{
+	int ret;
+
+	/* Cannot proceed with previous errors */
+	check_error();
+
+	ret = coredump_query(COREDUMP_QUERY_GET_STORED_DUMP_SIZE, NULL);
+	if (ret == -ENOTSUP) {
+#ifdef CONFIG_TEST_STORED_COREDUMP
+		TC_ERROR("Can't query stored dump size: unexpectedly not supported.\n");
+		ztest_test_fail();
+#else
+		TC_PRINT("Can't query stored dump size: expectedly not supported.\n");
+		ztest_test_skip();
+#endif
+	} else if (ret >= 0) {
+#ifdef CONFIG_TEST_STORED_COREDUMP
+		check_error();
+		if (size_expected > 0) {
+			zassert_equal(ret, size_expected,
+				      "Coredump size %d != %d size expected.\n",
+				      ret, size_expected);
+		}
+		ztest_test_pass();
+#else
+		TC_ERROR("Can't have a stored dump: not supported.\n");
+		ztest_test_fail();
+#endif
+	} else {
+		TC_ERROR("Error reading stored dump size! (%d)\n", ret);
+		ztest_test_fail();
+	}
+}
+
+/* Excecute tests in exact sequence with the stored core dump. */
+
+ZTEST(coredump_backends, test_coredump_0_ready) {
+	check_error();
+	ztest_test_pass();
+}
+
+ZTEST(coredump_backends, test_coredump_1_stored) {
+	test_has_stored_dump(true);
+}
+
+ZTEST(coredump_backends, test_coredump_2_size) {
+	test_get_stored_dump_size(CONFIG_TEST_STORED_DUMP_SIZE);
+}
+
+ZTEST(coredump_backends, test_coredump_3_verify) {
 	test_verify_stored_dump();
 }
 
-ZTEST_SUITE(coredump_backends, NULL, NULL, NULL, NULL, NULL);
+ZTEST(coredump_backends, test_coredump_4_invalidate) {
+	test_invalidate_stored_dump();
+}
+
+ZTEST(coredump_backends, test_coredump_5_erase) {
+	test_erase_stored_dump();
+}
+
+ZTEST_SUITE(coredump_backends, NULL, raise_coredump, NULL, NULL, NULL);

--- a/tests/subsys/debug/coredump_backends/testcase.yaml
+++ b/tests/subsys/debug/coredump_backends/testcase.yaml
@@ -12,13 +12,6 @@ tests:
     platform_exclude: acrn_ehl_crb
     extra_configs:
       - CONFIG_TEST_STORED_COREDUMP=n
-    harness: console
-    harness_config:
-      type: multi_line
-      regex:
-        - "E: #CD:BEGIN#"
-        - "E: #CD:5([aA])45([0-9a-fA-F]+)"
-        - "E: #CD:END#"
   debug.coredump.backends.flash:
     filter: CONFIG_ARCH_SUPPORTS_COREDUMP
     extra_args: CONF_FILE=prj_flash_partition.conf

--- a/tests/subsys/debug/coredump_backends/testcase.yaml
+++ b/tests/subsys/debug/coredump_backends/testcase.yaml
@@ -10,6 +10,8 @@ tests:
   debug.coredump.backends.logging:
     filter: CONFIG_ARCH_SUPPORTS_COREDUMP
     platform_exclude: acrn_ehl_crb
+    extra_configs:
+      - CONFIG_TEST_STORED_COREDUMP=n
     harness: console
     harness_config:
       type: multi_line
@@ -20,6 +22,8 @@ tests:
   debug.coredump.backends.flash:
     filter: CONFIG_ARCH_SUPPORTS_COREDUMP
     extra_args: CONF_FILE=prj_flash_partition.conf
+    extra_configs:
+      - CONFIG_TEST_STORED_COREDUMP=y
     platform_allow:
       - qemu_x86
       - esp32_devkitc_wroom
@@ -30,4 +34,6 @@ tests:
   debug.coredump.backends.other:
     filter: CONFIG_ARCH_SUPPORTS_COREDUMP
     extra_args: CONF_FILE=prj_backend_other.conf
+    extra_configs:
+      - CONFIG_TEST_STORED_COREDUMP=y
     platform_exclude: acrn_ehl_crb


### PR DESCRIPTION
Extend coredump_backend tests:
 * fix COREDUMP_CMD_VERIFY_STORED_DUMP test was not executed.
 * add tests for these coredump commands:
   - COREDUMP_QUERY_GET_STORED_DUMP_SIZE,
   - COREDUMP_CMD_INVALIDATE_STORED_DUMP,
   - COREDUMP_CMD_ERASE_STORED_DUMP,
   - COREDUMP_CMD_CLEAR_ERROR.
 * extend the out-of-the-treee example 'empty' backend to execute the new tests.
 * fix the test's cmake project name.