### PR TITLE
boards: roc_rk3568: do not use as default test platform

### DIFF
--- a/boards/arm64/roc_rk3568_pc/roc_rk3568_pc.yaml
+++ b/boards/arm64/roc_rk3568_pc/roc_rk3568_pc.yaml
@@ -7,7 +7,6 @@ toolchain:
   - cross-compile
 ram: 1024
 testing:
-  default: true
   ignore_tags:
     - net
     - bluetooth

--- a/boards/arm64/roc_rk3568_pc/roc_rk3568_pc_smp.yaml
+++ b/boards/arm64/roc_rk3568_pc/roc_rk3568_pc_smp.yaml
@@ -9,7 +9,6 @@ ram: 1024
 supported:
   - smp
 testing:
-  default: true
   ignore_tags:
     - net
     - bluetooth


### PR DESCRIPTION
Only qemu boards are used as default in CI, drop the default property from this one.