### PR TITLE
Fix Kconfig dependency for ETHERNET NXP S32 NETC drivers

### DIFF
--- a/drivers/ethernet/Kconfig.nxp_s32_netc
+++ b/drivers/ethernet/Kconfig.nxp_s32_netc
@@ -1,11 +1,10 @@
-# Copyright 2022 NXP
+# Copyright 2022-2023 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig ETH_NXP_S32_NETC
 	bool "NXP S32 Ethernet Switch and Controller (NETC) driver"
 	default y
 	depends on (DT_HAS_NXP_S32_NETC_PSI_ENABLED || DT_HAS_NXP_S32_NETC_VSI_ENABLED)
-	depends on !NET_TEST
 	select MBOX
 	select MDIO if DT_HAS_NXP_S32_NETC_PSI_ENABLED
 	select NOCACHE_MEMORY if ARCH_HAS_NOCACHE_MEMORY_SUPPORT

--- a/drivers/mdio/Kconfig.nxp_s32
+++ b/drivers/mdio/Kconfig.nxp_s32
@@ -1,10 +1,11 @@
-# Copyright 2022 NXP
+# Copyright 2022-2023 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 config MDIO_NXP_S32_NETC
 	bool "NXP S32 NETC External MDIO driver"
 	default y
 	depends on DT_HAS_NXP_S32_NETC_EMDIO_ENABLED
+	depends on ETH_NXP_S32_NETC && DT_HAS_NXP_S32_NETC_PSI_ENABLED
 	select NOCACHE_MEMORY if ARCH_HAS_NOCACHE_MEMORY_SUPPORT
 	help
 	  Enable NETC External MDIO Controller driver for NXP S32 SoCs.


### PR DESCRIPTION
This PR does two things:
1. Removing unnecessary dependency on `NET_TEST` in ETHERNET NXP S32 NETC drivers. Fix https://github.com/zephyrproject-rtos/zephyr/issues/64944
```
west twister -p s32z270dc2_rtu0_r52 --disable-warnings-as-errors -v --runtime-artifact-cleanup all  -T tests/drivers/build_all/

INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - 81/92 s32z270dc2_rtu0_r52       tests/drivers/build_all/modem/drivers.modem.esp_at.async.build SKIPPED (runtime filter)
INFO    - 82/92 s32z270dc2_rtu0_r52       tests/drivers/build_all/modem/drivers.modem.quectel_bg9x.build PASSED (build)
INFO    - 83/92 s32z270dc2_rtu0_r52       tests/drivers/build_all/modem/drivers.modem.simcom_sim7080.build PASSED (build)
INFO    - 84/92 s32z270dc2_rtu0_r52       tests/drivers/build_all/modem/drivers.modem.gsm.build PASSED (build)
INFO    - 85/92 s32z270dc2_rtu0_r52       tests/drivers/build_all/modem/drivers.modem.gsm_mux.build PASSED (build)
INFO    - 86/92 s32z270dc2_rtu0_r52       tests/drivers/build_all/modem/drivers.modem.ublox_sara.build PASSED (build)
INFO    - 87/92 s32z270dc2_rtu0_r52       tests/drivers/build_all/modem/drivers.modem.esp_at.build PASSED (build)
INFO    - 88/92 s32z270dc2_rtu0_r52       tests/drivers/build_all/display/drivers.display.ili9342c.build PASSED (build)
INFO    - 89/92 s32z270dc2_rtu0_r52       tests/drivers/build_all/led_strip/drivers.led_strip.build PASSED (build)
INFO    - 90/92 s32z270dc2_rtu0_r52       tests/drivers/build_all/led/drivers.led.build      PASSED (build)
INFO    - 91/92 s32z270dc2_rtu0_r52       tests/drivers/build_all/modem/drivers.modem.build  PASSED (build)
INFO    - 92/92 s32z270dc2_rtu0_r52       tests/drivers/build_all/ethernet/net.ethernet.build PASSED (build)

INFO    - 92 test scenarios (92 test instances) selected, 81 configurations skipped (80 by static filter, 1 at runtime).
INFO    - 11 of 92 test configurations passed (100.00%), 0 failed, 0 errored, 81 skipped with 0 warnings in 120.45 seconds
```

2. Don't try to build MDIO NXP S32 NETC driver if ETHERNET NXP S32 NETC driver is not built because MDIO is currently initialized in the Ethernet driver