### PR TITLE
serial: stm32: clear state before enabling async transfer

### DIFF
--- a/drivers/serial/Kconfig.stm32
+++ b/drivers/serial/Kconfig.stm32
@@ -21,3 +21,15 @@ config UART_STM32
 	  This option enables the UART driver for STM32 family of
 	  processors.
 	  Say y if you wish to use serial port on STM32 MCU.
+
+if UART_STM32
+
+config UART_STM32_ASYNC_RESET_RX
+	bool "Reset RX state before enabling async transfer"
+	depends on UART_ASYNC_API
+	help
+	  Clear RXNE bit before enabling asynchronous transfer. It means that data
+	  stored in the RDR register. It prevents appending old data to new data
+	  when a new transfer occurs.
+
+endif # UART_STM32

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1579,6 +1579,18 @@ static int uart_stm32_async_rx_enable(const struct device *dev,
 		return -EFAULT;
 	}
 
+	/* Clear RXNE not to trigger DMA to copy data received before enabling the async
+	 * transfer. Otherwise, it would look like old and new data were received together,
+	 * because only the IDLE line (after new data) triggers IRQ to signal a new transfer.
+	 */
+#ifdef CONFIG_UART_STM32_ASYNC_RESET_RX
+#ifdef USART_SR_RXNE
+	LL_USART_ClearFlag_RXNE(config->usart);
+#else
+	LL_USART_RequestRxDataFlush(config->usart);
+#endif /* USART_SR_RXNE */
+#endif /* CONFIG_UART_STM32_ASYNC_RESET_RX */
+
 	/* Enable RX DMA requests */
 	uart_stm32_dma_rx_enable(dev);
 


### PR DESCRIPTION
Clear RXNE bit just before enabling the asynchronous transfer, not to trigger DMA to copy data received before enabling the transfer. Otherwise, it would look like old and new data were received together, because only the IDLE line (after new data) triggers IRQ to signal a new transfer.

Fixes: #64436