### PR TITLE
SMP: fixes to add support for rebooting the core.

### DIFF
--- a/arch/arm64/core/smp.c
+++ b/arch/arm64/core/smp.c
@@ -41,6 +41,10 @@ struct boot_params {
 	int cpu_num;
 };
 
+// smp_init fn pointer for turning core on/off using psci
+arch_cpustart_t fn;
+
+
 /* Offsets used in reset.S */
 BUILD_ASSERT(offsetof(struct boot_params, mpid) == BOOT_PARAM_MPID_OFFSET);
 BUILD_ASSERT(offsetof(struct boot_params, sp) == BOOT_PARAM_SP_OFFSET);
@@ -136,7 +140,6 @@ void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
 void z_arm64_secondary_start(void)
 {
 	int cpu_num = arm64_cpu_boot_params.cpu_num;
-	arch_cpustart_t fn;
 	void *arg;
 
 	__ASSERT(arm64_cpu_boot_params.mpid == MPIDR_TO_CORE(GET_MPIDR()), "");
@@ -161,9 +164,11 @@ void z_arm64_secondary_start(void)
 	irq_enable(SGI_FPU_IPI);
 #endif
 #endif
-
-	fn = arm64_cpu_boot_params.fn;
-	arg = arm64_cpu_boot_params.arg;
+	if(fn=NULL)
+	{
+	    fn = arm64_cpu_boot_params.fn;
+	    arg = arm64_cpu_boot_params.arg;
+	}
 	barrier_dsync_fence_full();
 
 	/*

--- a/arch/arm64/core/smp.c
+++ b/arch/arm64/core/smp.c
@@ -167,8 +167,9 @@ void z_arm64_secondary_start(void)
 	if(secondary_core_fn==NULL)
 	{
 	    secondary_core_fn = arm64_cpu_boot_params.fn;
-	    arg = arm64_cpu_boot_params.arg;
 	}
+	
+	arg = arm64_cpu_boot_params.arg;
 	barrier_dsync_fence_full();
 
 	/*

--- a/arch/arm64/core/smp.c
+++ b/arch/arm64/core/smp.c
@@ -41,8 +41,8 @@ struct boot_params {
 	int cpu_num;
 };
 
-// smp_init fn pointer for turning core on/off using psci
-arch_cpustart_t fn;
+// smp_init_top fn pointer for turning core on/off using psci
+arch_cpustart_t secondary_core_fn;
 
 
 /* Offsets used in reset.S */
@@ -164,9 +164,9 @@ void z_arm64_secondary_start(void)
 	irq_enable(SGI_FPU_IPI);
 #endif
 #endif
-	if(fn=NULL)
+	if(secondary_core_fn==NULL)
 	{
-	    fn = arm64_cpu_boot_params.fn;
+	    secondary_core_fn = arm64_cpu_boot_params.fn;
 	    arg = arm64_cpu_boot_params.arg;
 	}
 	barrier_dsync_fence_full();
@@ -180,7 +180,7 @@ void z_arm64_secondary_start(void)
 	barrier_dsync_fence_full();
 	sev();
 
-	fn(arg);
+	secondary_core_fn(arg);
 }
 
 #ifdef CONFIG_SMP


### PR DESCRIPTION
Currently If the secondary core is turned off using PSCI ( pm_cpu_off ) then it can't be turned on again. 

This Has been discussed in the issue https://github.com/zephyrproject-rtos/zephyr/issues/64211. 

To add this support , PSCI CPU_ON call fails because the function pointer for smp_init_top() is null. 

Added the changes so that the function pointer is not NULL and secondary cores can call z_arm64_secondary_start() again to start the core after it has been turned off. 
