### PR TITLE
bluetooth: leaudio: Termination of PA at Modify Source

### DIFF
--- a/subsys/bluetooth/audio/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/bap_scan_delegator.c
@@ -770,6 +770,20 @@ static int scan_delegator_mod_src(struct bt_conn *conn,
 
 			return err;
 		}
+	} else if (pa_sync == BT_BAP_BASS_PA_REQ_NO_SYNC &&
+		   (state->pa_sync_state == BT_BAP_PA_STATE_INFO_REQ ||
+		    state->pa_sync_state == BT_BAP_PA_STATE_SYNCED)) {
+		/* Terminate PA sync */
+		const int err = pa_sync_term_request(conn, &internal_state->state);
+
+		if (err != 0) {
+			LOG_DBG("PA sync term from %p was reject with reason %d",
+				conn, err);
+
+			return err;
+		}
+
+		state_changed = true;
 	}
 
 	/* Notify if changed */


### PR DESCRIPTION
From BASS spec:
If the PA_Sync parameter value written by the client is set to a value of 0x00 (Do not synchronize to PA) and the server is synchronized to the PA, the server shall stop synchronization with the PA and shall write a value of 0x00 (Not synchronized to PA) to the PA_Sync_State field of the Broadcast Receive State characteristic .

Fixes BASS/SR/CP/BV-12-C test case.