### PR TITLE
Kconfig: drop COMPAT_INCLUDES

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -921,14 +921,3 @@ config BOOTLOADER_BOSSA_ADAFRUIT_UF2
 endchoice
 
 endmenu
-
-menu "Compatibility"
-
-config COMPAT_INCLUDES
-	bool "Suppress warnings when using header shims"
-	default y
-	help
-	  Suppress any warnings from the pre-processor when including
-	  deprecated header files.
-
-endmenu

--- a/doc/releases/release-notes-3.6.rst
+++ b/doc/releases/release-notes-3.6.rst
@@ -110,6 +110,8 @@ Boards & SoC Support
 Build system and infrastructure
 *******************************
 
+- Dropped the ``COMPAT_INCLUDES`` option, it was unused since 3.0.
+
 Drivers and Sensors
 *******************
 


### PR DESCRIPTION
Last reference of this was dropped in 01b7800bc8, almost 2y ago.