### PR TITLE
ITE: drivers/i2c: Bug in build assert when FIFO enable

### DIFF
--- a/drivers/i2c/i2c_ite_it8xxx2.c
+++ b/drivers/i2c/i2c_ite_it8xxx2.c
@@ -1242,7 +1242,7 @@ static const struct i2c_driver_api i2c_it8xxx2_driver_api = {
  * that channel C may encounter wrong register being written due to FIFO2
  * byte counter wrong write after channel B's write operation.
  */
-BUILD_ASSERT((DT_INST_PROP(SMB_CHANNEL_C, fifo_enable) == false),
+BUILD_ASSERT((DT_PROP(DT_NODELABEL(i2c2), fifo_enable) == false),
 	     "Channel C cannot use FIFO mode.");
 #endif
 


### PR DESCRIPTION
We need to do a build assert for the fifo enable status of 'I2C2'. There is a problem with using instance to obtain property when any one I2C port is not enabled.