### PR TITLE
drivers: clock_control: stm32wba: Apply VOS range 2 when sysclock = 1…

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_wba.c
+++ b/drivers/clock_control/clock_stm32_ll_wba.c
@@ -287,7 +287,7 @@ static int get_vco_input_range(uint32_t m_div, uint32_t *range)
 
 static void set_regu_voltage(uint32_t hclk_freq)
 {
-	if (hclk_freq < MHZ(16)) {
+	if (hclk_freq <= MHZ(16)) {
 		LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE2);
 	} else {
 		LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE1);


### PR DESCRIPTION
…6MHz

When sysclock is 16MHz, we're allowed to used VOS range 2.