### PR TITLE
Npm1300 regulator soft start

### DIFF
--- a/drivers/regulator/regulator_npm1300.c
+++ b/drivers/regulator/regulator_npm1300.c
@@ -439,7 +439,7 @@ static int regulator_npm1300_set_ldsw_pin_ctrl(const struct device *dev, uint8_t
 
 	ctrl = (pin + 1U) | (inv << 3U);
 
-	return mfd_npm1300_reg_write(config->mfd, LDSW_BASE, LDSW_OFFSET_GPISEL + chan, type);
+	return mfd_npm1300_reg_write(config->mfd, LDSW_BASE, LDSW_OFFSET_GPISEL + chan, ctrl);
 }
 
 int regulator_npm1300_set_pin_ctrl(const struct device *dev, const struct gpio_dt_spec *spec,

--- a/dts/bindings/regulator/nordic,npm1300-regulator.yaml
+++ b/dts/bindings/regulator/nordic,npm1300-regulator.yaml
@@ -83,3 +83,13 @@ child-binding:
       type: phandle-array
       description: |
         Retention mode controlled by specified regulator GPIO pin.
+
+    soft-start-microamp:
+      type: int
+      enum:
+        - 10000
+        - 20000
+        - 35000
+        - 50000
+      description: |
+        Soft start current limit in microamps.


### PR DESCRIPTION
Added configuration of soft start for load switches / LDOs.
Includes a bugfix for GPIO control identified during testing this feature.