### PR TITLE
drivers: console: fix dropped characters when using debug hooks

### DIFF
--- a/drivers/console/uart_console.c
+++ b/drivers/console/uart_console.c
@@ -474,7 +474,7 @@ static void uart_console_isr(const struct device *unused, void *user_data)
 			 * The input hook indicates that no further processing
 			 * should be done by this handler.
 			 */
-			return;
+			continue;
 		}
 #endif
 


### PR DESCRIPTION
When using console debug server hooks, not all characters are processed if the server hook returns non-zero for one character while there are other characters in the buffer. This is seen when using a fast console (like USB) where multiple characters come in before the ISR is called. Fix it by continuing to process characters instead of returning from the ISR with characters still in the buffer.

Fixes: #64661