### PR TITLE
Bluetooth: fix doxygen warnings

### DIFF
--- a/include/zephyr/bluetooth/audio/bap_lc3_preset.h
+++ b/include/zephyr/bluetooth/audio/bap_lc3_preset.h
@@ -31,7 +31,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Unicast 8_1_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_8_1_1(_loc, _stream_context)                                     \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_8_1(_loc, _stream_context),                    \
@@ -41,7 +41,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Unicast 8_2_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_8_2_1(_loc, _stream_context)                                     \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_8_2(_loc, _stream_context),                    \
@@ -51,7 +51,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Unicast 16_1_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_16_1_1(_loc, _stream_context)                                    \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_16_1(_loc, _stream_context),                   \
@@ -63,7 +63,7 @@ struct bt_bap_lc3_preset {
  *  Mandatory to support as both unicast client and server
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_16_2_1(_loc, _stream_context)                                    \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_16_2(_loc, _stream_context),                   \
@@ -73,7 +73,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Unicast 24_1_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_24_1_1(_loc, _stream_context)                                    \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_24_1(_loc, _stream_context),                   \
@@ -85,7 +85,7 @@ struct bt_bap_lc3_preset {
  *  Mandatory to support as unicast server
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_24_2_1(_loc, _stream_context)                                    \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_24_2(_loc, _stream_context),                   \
@@ -95,7 +95,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Unicast 32_1_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_32_1_1(_loc, _stream_context)                                    \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_32_1(_loc, _stream_context),                   \
@@ -105,7 +105,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Unicast 32_2_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_32_2_1(_loc, _stream_context)                                    \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_32_2(_loc, _stream_context),                   \
@@ -115,7 +115,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Unicast 441_1_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_441_1_1(_loc, _stream_context)                                   \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_441_1(_loc, _stream_context),                  \
@@ -126,7 +126,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Unicast 441_2_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_441_2_1(_loc, _stream_context)                                   \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_441_2(_loc, _stream_context),                  \
@@ -137,7 +137,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Unicast 48_1_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_48_1_1(_loc, _stream_context)                                    \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_48_1(_loc, _stream_context),                   \
@@ -147,7 +147,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Unicast 48_2_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_48_2_1(_loc, _stream_context)                                    \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_48_2(_loc, _stream_context),                   \
@@ -157,7 +157,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Unicast 48_3_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_48_3_1(_loc, _stream_context)                                    \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_48_3(_loc, _stream_context),                   \
@@ -167,7 +167,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Unicast 48_4_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_48_4_1(_loc, _stream_context)                                    \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_48_4(_loc, _stream_context),                   \
@@ -177,7 +177,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Unicast 8_5_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_48_5_1(_loc, _stream_context)                                    \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_48_5(_loc, _stream_context),                   \
@@ -187,7 +187,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Unicast 48_6_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_48_6_1(_loc, _stream_context)                                    \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_48_6(_loc, _stream_context),                   \
@@ -197,7 +197,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Unicast 8_1_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 /* Following presets are for unicast high reliability audio data */
 #define BT_BAP_LC3_UNICAST_PRESET_8_1_2(_loc, _stream_context)                                     \
@@ -208,7 +208,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Unicast 8_2_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_8_2_2(_loc, _stream_context)                                     \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_8_2(_loc, _stream_context),                    \
@@ -218,7 +218,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Unicast 16_1_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_16_1_2(_loc, _stream_context)                                    \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_16_1(_loc, _stream_context),                   \
@@ -228,7 +228,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Unicast 16_2_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_16_2_2(_loc, _stream_context)                                    \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_16_2(_loc, _stream_context),                   \
@@ -238,7 +238,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Unicast 24_1_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_24_1_2(_loc, _stream_context)                                    \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_24_1(_loc, _stream_context),                   \
@@ -248,7 +248,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Unicast 24_2_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_24_2_2(_loc, _stream_context)                                    \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_24_2(_loc, _stream_context),                   \
@@ -258,7 +258,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Unicast 32_1_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_32_1_2(_loc, _stream_context)                                    \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_32_1(_loc, _stream_context),                   \
@@ -268,7 +268,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Unicast 32_2_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_32_2_2(_loc, _stream_context)                                    \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_32_2(_loc, _stream_context),                   \
@@ -278,7 +278,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Unicast 441_1_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_441_1_2(_loc, _stream_context)                                   \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_441_1(_loc, _stream_context),                  \
@@ -289,7 +289,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Unicast 441_2_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_441_2_2(_loc, _stream_context)                                   \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_441_2(_loc, _stream_context),                  \
@@ -300,7 +300,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Unicast 48_1_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_48_1_2(_loc, _stream_context)                                    \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_48_1(_loc, _stream_context),                   \
@@ -310,7 +310,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Unicast 48_2_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_48_2_2(_loc, _stream_context)                                    \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_48_2(_loc, _stream_context),                   \
@@ -320,7 +320,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Unicast 48_3_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_48_3_2(_loc, _stream_context)                                    \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_48_3(_loc, _stream_context),                   \
@@ -330,7 +330,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Unicast 48_4_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_48_4_2(_loc, _stream_context)                                    \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_48_4(_loc, _stream_context),                   \
@@ -340,7 +340,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Unicast 48_5_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_48_5_2(_loc, _stream_context)                                    \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_48_5(_loc, _stream_context),                   \
@@ -350,7 +350,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Unicast 48_6_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_48_6_2(_loc, _stream_context)                                    \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_48_6(_loc, _stream_context),                   \
@@ -360,7 +360,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Broadcast 8_1_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 /* LC3 Broadcast presets defined by table 6.4 in the BAP v1.0 specification */
 #define BT_BAP_LC3_BROADCAST_PRESET_8_1_1(_loc, _stream_context)                                   \
@@ -371,7 +371,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Broadcast 8_2_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_8_2_1(_loc, _stream_context)                                   \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_8_2(_loc, _stream_context),                    \
@@ -381,7 +381,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Broadcast 16_1_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_16_1_1(_loc, _stream_context)                                  \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_16_1(_loc, _stream_context),                   \
@@ -393,7 +393,7 @@ struct bt_bap_lc3_preset {
  *  Mandatory to support as both broadcast source and sink
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_16_2_1(_loc, _stream_context)                                  \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_16_2(_loc, _stream_context),                   \
@@ -403,7 +403,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Broadcast 24_1_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_24_1_1(_loc, _stream_context)                                  \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_24_1(_loc, _stream_context),                   \
@@ -415,7 +415,7 @@ struct bt_bap_lc3_preset {
  *  Mandatory to support as broadcast sink
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_24_2_1(_loc, _stream_context)                                  \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_24_2(_loc, _stream_context),                   \
@@ -425,7 +425,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Broadcast 32_1_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_32_1_1(_loc, _stream_context)                                  \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_32_1(_loc, _stream_context),                   \
@@ -435,7 +435,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Broadcast 32_2_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_32_2_1(_loc, _stream_context)                                  \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_32_2(_loc, _stream_context),                   \
@@ -445,7 +445,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Broadcast 441_1_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_441_1_1(_loc, _stream_context)                                 \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_441_1(_loc, _stream_context),                  \
@@ -456,7 +456,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Broadcast 441_2_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_441_2_1(_loc, _stream_context)                                 \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_441_2(_loc, _stream_context),                  \
@@ -467,7 +467,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Broadcast 48_1_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_48_1_1(_loc, _stream_context)                                  \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_48_1(_loc, _stream_context),                   \
@@ -477,7 +477,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Broadcast 48_2_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_48_2_1(_loc, _stream_context)                                  \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_48_2(_loc, _stream_context),                   \
@@ -487,7 +487,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Broadcast 48_3_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_48_3_1(_loc, _stream_context)                                  \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_48_3(_loc, _stream_context),                   \
@@ -497,7 +497,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Broadcast 48_4_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_48_4_1(_loc, _stream_context)                                  \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_48_4(_loc, _stream_context),                   \
@@ -507,7 +507,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Broadcast 48_5_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_48_5_1(_loc, _stream_context)                                  \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_48_5(_loc, _stream_context),                   \
@@ -517,7 +517,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Broadcast 48_6_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_48_6_1(_loc, _stream_context)                                  \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_48_6(_loc, _stream_context),                   \
@@ -527,7 +527,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Broadcast 8_1_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 /* Following presets are for broadcast high reliability audio data */
 #define BT_BAP_LC3_BROADCAST_PRESET_8_1_2(_loc, _stream_context)                                   \
@@ -538,7 +538,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Broadcast 8_2_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_8_2_2(_loc, _stream_context)                                   \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_8_2(_loc, _stream_context),                    \
@@ -548,7 +548,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Broadcast 16_1_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_16_1_2(_loc, _stream_context)                                  \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_16_1(_loc, _stream_context),                   \
@@ -560,7 +560,7 @@ struct bt_bap_lc3_preset {
  *  Mandatory to support as both broadcast source and sink
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_16_2_2(_loc, _stream_context)                                  \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_16_2(_loc, _stream_context),                   \
@@ -570,7 +570,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Broadcast 24_1_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_24_1_2(_loc, _stream_context)                                  \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_24_1(_loc, _stream_context),                   \
@@ -582,7 +582,7 @@ struct bt_bap_lc3_preset {
  *  Mandatory to support as broadcast sink
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_24_2_2(_loc, _stream_context)                                  \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_24_2(_loc, _stream_context),                   \
@@ -592,7 +592,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Broadcast 32_1_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_32_1_2(_loc, _stream_context)                                  \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_32_1(_loc, _stream_context),                   \
@@ -602,7 +602,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Broadcast 32_2_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_32_2_2(_loc, _stream_context)                                  \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_32_2(_loc, _stream_context),                   \
@@ -612,7 +612,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Broadcast 441_1_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_441_1_2(_loc, _stream_context)                                 \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_441_1(_loc, _stream_context),                  \
@@ -623,7 +623,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Broadcast 441_2_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_441_2_2(_loc, _stream_context)                                 \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_441_2(_loc, _stream_context),                  \
@@ -634,7 +634,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Broadcast 48_1_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_48_1_2(_loc, _stream_context)                                  \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_48_1(_loc, _stream_context),                   \
@@ -644,7 +644,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Broadcast 48_2_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_48_2_2(_loc, _stream_context)                                  \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_48_2(_loc, _stream_context),                   \
@@ -654,7 +654,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Broadcast 48_3_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_48_3_2(_loc, _stream_context)                                  \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_48_3(_loc, _stream_context),                   \
@@ -664,7 +664,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Broadcast 48_4_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_48_4_2(_loc, _stream_context)                                  \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_48_4(_loc, _stream_context),                   \
@@ -674,7 +674,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Broadcast 48_5_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_48_5_2(_loc, _stream_context)                                  \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_48_5(_loc, _stream_context),                   \
@@ -684,7 +684,7 @@ struct bt_bap_lc3_preset {
  *  @brief Helper to declare LC3 Broadcast 48_6_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_48_6_2(_loc, _stream_context)                                  \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_48_6(_loc, _stream_context),                   \

--- a/include/zephyr/bluetooth/audio/lc3.h
+++ b/include/zephyr/bluetooth/audio/lc3.h
@@ -257,7 +257,7 @@ enum bt_audio_codec_config_frame_dur {
 /**
  *  @brief Helper to declare LC3 codec capability
  *
- *  _max_frames_per_sdu value is optional and will be included only if != 1
+ *  ``_max_frames_per_sdu`` value is optional and will be included only if != 1
  */
 /* COND_CODE_1 is used to omit an LTV entry in case the _frames_per_sdu is 1.
  * COND_CODE_1 will evaluate to second argument if the flag parameter(first argument) is 1
@@ -292,8 +292,8 @@ enum bt_audio_codec_config_frame_dur {
 /**
  * @brief Helper to declare LC3 codec
  *
- * @param _freq Supported Sampling Frequencies bitfield (see BT_AUDIO_CODEC_LC3_FREQ_*)
- * @param _duration Supported Frame Durations bitfield (see BT_AUDIO_CODEC_LC3_DURATION_*)
+ * @param _freq Supported Sampling Frequencies bitfield (see ``BT_AUDIO_CODEC_LC3_FREQ_*``)
+ * @param _duration Supported Frame Durations bitfield (see ``BT_AUDIO_CODEC_LC3_DURATION_*``)
  * @param _chan_count Supported channels (see @ref BT_AUDIO_CODEC_LC3_CHAN_COUNT_SUPPORT)
  * @param _len_min Minimum number of octets supported per codec frame
  * @param _len_max Maximum number of octets supported per codec frame
@@ -311,8 +311,8 @@ enum bt_audio_codec_config_frame_dur {
 /**
  *  @brief Helper to declare LC3 codec data configuration
  *
- *  @param _freq            Sampling frequency (BT_AUDIO_CODEC_CONFIG_LC3_FREQ_*)
- *  @param _duration        Frame duration (BT_AUDIO_CODEC_CONFIG_LC3_DURATION_*)
+ *  @param _freq            Sampling frequency (``BT_AUDIO_CODEC_CONFIG_LC3_FREQ_*``)
+ *  @param _duration        Frame duration (``BT_AUDIO_CODEC_CONFIG_LC3_DURATION_*``)
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
  *  @param _len             Octets per frame (16-bit integer)
  *  @param _frames_per_sdu  Frames per SDU (8-bit integer). This value is optional and will be
@@ -343,12 +343,12 @@ enum bt_audio_codec_config_frame_dur {
 /**
  *  @brief Helper to declare LC3 codec configuration.
  *
- *  @param _freq            Sampling frequency (BT_AUDIO_CODEC_CONFIG_LC3_FREQ_*)
- *  @param _duration        Frame duration (BT_AUDIO_CODEC_CONFIG_LC3_DURATION_*)
+ *  @param _freq            Sampling frequency (``BT_AUDIO_CODEC_CONFIG_LC3_FREQ_*``)
+ *  @param _duration        Frame duration (``BT_AUDIO_CODEC_CONFIG_LC3_DURATION_*``)
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
  *  @param _len             Octets per frame (16-bit integer)
  *  @param _frames_per_sdu  Frames per SDU (8-bit integer)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_AUDIO_CODEC_LC3_CONFIG(_freq, _duration, _loc, _len, _frames_per_sdu, _stream_context)  \
 	BT_AUDIO_CODEC_CFG(                                                                        \
@@ -360,7 +360,7 @@ enum bt_audio_codec_config_frame_dur {
  *  @brief Helper to declare LC3 8.1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_AUDIO_CODEC_LC3_CONFIG_8_1(_loc, _stream_context)                                       \
 	BT_AUDIO_CODEC_LC3_CONFIG(BT_AUDIO_CODEC_CONFIG_LC3_FREQ_8KHZ,                             \
@@ -370,7 +370,7 @@ enum bt_audio_codec_config_frame_dur {
  *  @brief Helper to declare LC3 8.2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_AUDIO_CODEC_LC3_CONFIG_8_2(_loc, _stream_context)                                       \
 	BT_AUDIO_CODEC_LC3_CONFIG(BT_AUDIO_CODEC_CONFIG_LC3_FREQ_8KHZ,                             \
@@ -380,7 +380,7 @@ enum bt_audio_codec_config_frame_dur {
  *  @brief Helper to declare LC3 16.1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_AUDIO_CODEC_LC3_CONFIG_16_1(_loc, _stream_context)                                      \
 	BT_AUDIO_CODEC_LC3_CONFIG(BT_AUDIO_CODEC_CONFIG_LC3_FREQ_16KHZ,                            \
@@ -390,7 +390,7 @@ enum bt_audio_codec_config_frame_dur {
  *  @brief Helper to declare LC3 16.2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_AUDIO_CODEC_LC3_CONFIG_16_2(_loc, _stream_context)                                      \
 	BT_AUDIO_CODEC_LC3_CONFIG(BT_AUDIO_CODEC_CONFIG_LC3_FREQ_16KHZ,                            \
@@ -401,7 +401,7 @@ enum bt_audio_codec_config_frame_dur {
  *  @brief Helper to declare LC3 24.1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_AUDIO_CODEC_LC3_CONFIG_24_1(_loc, _stream_context)                                      \
 	BT_AUDIO_CODEC_LC3_CONFIG(BT_AUDIO_CODEC_CONFIG_LC3_FREQ_24KHZ,                            \
@@ -411,7 +411,7 @@ enum bt_audio_codec_config_frame_dur {
  *  @brief Helper to declare LC3 24.2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_AUDIO_CODEC_LC3_CONFIG_24_2(_loc, _stream_context)                                      \
 	BT_AUDIO_CODEC_LC3_CONFIG(BT_AUDIO_CODEC_CONFIG_LC3_FREQ_24KHZ,                            \
@@ -421,7 +421,7 @@ enum bt_audio_codec_config_frame_dur {
  *  @brief Helper to declare LC3 32.1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_AUDIO_CODEC_LC3_CONFIG_32_1(_loc, _stream_context)                                      \
 	BT_AUDIO_CODEC_LC3_CONFIG(BT_AUDIO_CODEC_CONFIG_LC3_FREQ_32KHZ,                            \
@@ -431,7 +431,7 @@ enum bt_audio_codec_config_frame_dur {
  *  @brief Helper to declare LC3 32.2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_AUDIO_CODEC_LC3_CONFIG_32_2(_loc, _stream_context)                                      \
 	BT_AUDIO_CODEC_LC3_CONFIG(BT_AUDIO_CODEC_CONFIG_LC3_FREQ_32KHZ,                            \
@@ -441,7 +441,7 @@ enum bt_audio_codec_config_frame_dur {
  *  @brief Helper to declare LC3 441.1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_AUDIO_CODEC_LC3_CONFIG_441_1(_loc, _stream_context)                                     \
 	BT_AUDIO_CODEC_LC3_CONFIG(BT_AUDIO_CODEC_CONFIG_LC3_FREQ_44KHZ,                            \
@@ -451,7 +451,7 @@ enum bt_audio_codec_config_frame_dur {
  *  @brief Helper to declare LC3 441.2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_AUDIO_CODEC_LC3_CONFIG_441_2(_loc, _stream_context)                                     \
 	BT_AUDIO_CODEC_LC3_CONFIG(BT_AUDIO_CODEC_CONFIG_LC3_FREQ_44KHZ,                            \
@@ -461,7 +461,7 @@ enum bt_audio_codec_config_frame_dur {
  *  @brief Helper to declare LC3 48.1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_AUDIO_CODEC_LC3_CONFIG_48_1(_loc, _stream_context)                                      \
 	BT_AUDIO_CODEC_LC3_CONFIG(BT_AUDIO_CODEC_CONFIG_LC3_FREQ_48KHZ,                            \
@@ -471,7 +471,7 @@ enum bt_audio_codec_config_frame_dur {
  *  @brief Helper to declare LC3 48.2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_AUDIO_CODEC_LC3_CONFIG_48_2(_loc, _stream_context)                                      \
 	BT_AUDIO_CODEC_LC3_CONFIG(BT_AUDIO_CODEC_CONFIG_LC3_FREQ_48KHZ,                            \
@@ -481,7 +481,7 @@ enum bt_audio_codec_config_frame_dur {
  *  @brief Helper to declare LC3 48.3 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_AUDIO_CODEC_LC3_CONFIG_48_3(_loc, _stream_context)                                      \
 	BT_AUDIO_CODEC_LC3_CONFIG(BT_AUDIO_CODEC_CONFIG_LC3_FREQ_48KHZ,                            \
@@ -491,7 +491,7 @@ enum bt_audio_codec_config_frame_dur {
  *  @brief Helper to declare LC3 48.4 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_AUDIO_CODEC_LC3_CONFIG_48_4(_loc, _stream_context)                                      \
 	BT_AUDIO_CODEC_LC3_CONFIG(BT_AUDIO_CODEC_CONFIG_LC3_FREQ_48KHZ,                            \
@@ -501,7 +501,7 @@ enum bt_audio_codec_config_frame_dur {
  *  @brief Helper to declare LC3 48.5 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_AUDIO_CODEC_LC3_CONFIG_48_5(_loc, _stream_context)                                      \
 	BT_AUDIO_CODEC_LC3_CONFIG(BT_AUDIO_CODEC_CONFIG_LC3_FREQ_48KHZ,                            \
@@ -511,7 +511,7 @@ enum bt_audio_codec_config_frame_dur {
  *  @brief Helper to declare LC3 48.6 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_AUDIO_CODEC_LC3_CONFIG_48_6(_loc, _stream_context)                                      \
 	BT_AUDIO_CODEC_LC3_CONFIG(BT_AUDIO_CODEC_CONFIG_LC3_FREQ_48KHZ,                            \

--- a/include/zephyr/bluetooth/gatt.h
+++ b/include/zephyr/bluetooth/gatt.h
@@ -72,7 +72,7 @@ enum bt_gatt_perm {
 
 	/** @brief Attribute prepare write permission.
 	 *
-	 *  If set, allows prepare writes with use of BT_GATT_WRITE_FLAG_PREPARE
+	 *  If set, allows prepare writes with use of ``BT_GATT_WRITE_FLAG_PREPARE``
 	 *  passed to write callback.
 	 */
 	BT_GATT_PERM_PREPARE_WRITE = BIT(6),
@@ -140,7 +140,7 @@ struct bt_gatt_attr;
  *  @param offset Offset to start reading from
  *
  *  @return Number of bytes read, or in case of an error
- *          BT_GATT_ERR() with a specific BT_ATT_ERR_* error code.
+ *          ``BT_GATT_ERR()`` with a specific ``BT_ATT_ERR_*`` error code.
  */
 typedef ssize_t (*bt_gatt_attr_read_func_t)(struct bt_conn *conn,
 					    const struct bt_gatt_attr *attr,
@@ -155,10 +155,10 @@ typedef ssize_t (*bt_gatt_attr_read_func_t)(struct bt_conn *conn,
  *  @param buf    Buffer with the data to write
  *  @param len    Number of bytes in the buffer
  *  @param offset Offset to start writing from
- *  @param flags  Flags (BT_GATT_WRITE_FLAG_*)
+ *  @param flags  Flags (``BT_GATT_WRITE_FLAG_*``)
  *
  *  @return Number of bytes written, or in case of an error
- *          BT_GATT_ERR() with a specific BT_ATT_ERR_* error code.
+ *          ``BT_GATT_ERR()`` with a specific ``BT_ATT_ERR_*`` error code.
  */
 typedef ssize_t (*bt_gatt_attr_write_func_t)(struct bt_conn *conn,
 					     const struct bt_gatt_attr *attr,
@@ -178,7 +178,7 @@ struct bt_gatt_attr {
 	uint16_t handle;
 	/** @brief Attribute permissions.
 	 *
-	 * Will be 0 if returned from bt_gatt_discover().
+	 * Will be 0 if returned from ``bt_gatt_discover()``.
 	 */
 	uint16_t perm;
 };
@@ -379,8 +379,8 @@ void bt_gatt_cb_register(struct bt_gatt_cb *cb);
 /** @brief Register GATT service.
  *
  *  Register GATT service. Applications can make use of
- *  macros such as BT_GATT_PRIMARY_SERVICE, BT_GATT_CHARACTERISTIC,
- *  BT_GATT_DESCRIPTOR, etc.
+ *  macros such as ``BT_GATT_PRIMARY_SERVICE``, ``BT_GATT_CHARACTERISTIC``,
+ *  ``BT_GATT_DESCRIPTOR``, etc.
  *
  *  When using @kconfig{CONFIG_BT_SETTINGS} then all services that should have
  *  bond configuration loaded, i.e. CCC values, must be registered before
@@ -400,7 +400,7 @@ void bt_gatt_cb_register(struct bt_gatt_cb *cb);
  *  @param svc Service containing the available attributes
  *
  *  @return 0 in case of success or negative value in case of error.
- *  @return -EAGAIN if `bt_init()` has been called but `settings_load()` hasn't yet.
+ *  @return -EAGAIN if ``bt_init()`` has been called but ``settings_load()`` hasn't yet.
  */
 int bt_gatt_service_register(struct bt_gatt_service *svc);
 
@@ -432,8 +432,8 @@ enum {
  *  @param handle Attribute handle found.
  *  @param user_data Data given.
  *
- *  @return BT_GATT_ITER_CONTINUE if should continue to the next attribute.
- *  @return BT_GATT_ITER_STOP to stop.
+ *  @return ``BT_GATT_ITER_CONTINUE`` if should continue to the next attribute.
+ *  @return ``BT_GATT_ITER_STOP`` to stop.
  */
 typedef uint8_t (*bt_gatt_attr_func_t)(const struct bt_gatt_attr *attr,
 				       uint16_t handle,
@@ -488,7 +488,7 @@ struct bt_gatt_attr *bt_gatt_attr_next(const struct bt_gatt_attr *attr);
  *
  *  Find the attribute with the matching UUID.
  *  To limit the search to a service set the attr to the service attributes and
- *  the attr_count to the service attribute count .
+ *  the ``attr_count`` to the service attribute count .
  *
  *  @param attr        Pointer to an attribute that serves as the starting point
  *                     for the search of a match for the UUID.
@@ -515,7 +515,7 @@ uint16_t bt_gatt_attr_get_handle(const struct bt_gatt_attr *attr);
  *
  * @param attr A Characteristic Attribute.
  *
- * @note The user_data of the attribute must of type @ref bt_gatt_chrc.
+ * @note The ``user_data`` of the attribute must of type @ref bt_gatt_chrc.
  *
  * @return the handle of the corresponding Characteristic Value. The value will
  *         be zero (the invalid handle) if @p attr was not a characteristic
@@ -546,7 +546,7 @@ ssize_t bt_gatt_attr_read(struct bt_conn *conn, const struct bt_gatt_attr *attr,
  *
  *  Read service attribute value from local database storing the result into
  *  buffer after encoding it.
- *  @note Only use this with attributes which user_data is a bt_uuid.
+ *  @note Only use this with attributes which ``user_data`` is a ``bt_uuid``.
  *
  *  @param conn Connection object.
  *  @param attr Attribute to read.
@@ -583,7 +583,7 @@ ssize_t bt_gatt_attr_read_service(struct bt_conn *conn,
  *
  *  Helper macro to statically define service structure array. Each element
  *  of the array is linked to the service attribute array which is also
- *  defined in this scope using _attrs_def macro.
+ *  defined in this scope using ``_attrs_def`` macro.
  *
  *  @param _name         Name of service structure array.
  *  @param _instances    Array of instances to pass as user context to the
@@ -645,7 +645,7 @@ ssize_t bt_gatt_attr_read_service(struct bt_conn *conn,
  *
  *  Read include service attribute value from local database storing the result
  *  into buffer after encoding it.
- *  @note Only use this with attributes which user_data is a bt_gatt_include.
+ *  @note Only use this with attributes which user_data is a ``bt_gatt_include``.
  *
  *  @param conn Connection object.
  *  @param attr Attribute to read.
@@ -675,7 +675,7 @@ ssize_t bt_gatt_attr_read_included(struct bt_conn *conn,
  *
  *  Read characteristic attribute value from local database storing the result
  *  into buffer after encoding it.
- *  @note Only use this with attributes which user_data is a bt_gatt_chrc.
+ *  @note Only use this with attributes which ``user_data`` is a ``bt_gatt_chrc``.
  *
  *  @param conn Connection object.
  *  @param attr Attribute to read.
@@ -705,7 +705,7 @@ ssize_t bt_gatt_attr_read_chrc(struct bt_conn *conn,
  *
  *  @param _uuid Characteristic attribute uuid.
  *  @param _props Characteristic attribute properties,
- *                a bitmap of BT_GATT_CHRC_* macros.
+ *                a bitmap of ``BT_GATT_CHRC_*`` macros.
  *  @param _perm Characteristic Attribute access permissions,
  *               a bitmap of @ref bt_gatt_perm values.
  *  @param _read Characteristic Attribute read callback


### PR DESCRIPTION
Fix doxygen warnings ("`warning: found </em> tag without matching <em>`") from building the Bluetooth API documention.