### PR TITLE
dts: arm: st: Add missing master-can-reg into stm32l496.dtsi

### DIFF
--- a/dts/arm/st/l4/stm32l496.dtsi
+++ b/dts/arm/st/l4/stm32l496.dtsi
@@ -54,6 +54,7 @@
 			interrupts = <86 0>, <87 0>, <88 0>, <89 0>;
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x04000000>; //RCC_APB1ENR1_CAN2EN
+			master-can-reg = <0x40006400>;
 			status = "disabled";
 			sample-point = <875>;
 		};


### PR DESCRIPTION
Hi,

The following patch provide the `master-can-reg` property on the `can2` node of the `stm32l496.dtsi`.
We have tested this patch on a custom board.

This property may be missing on some others stm32f1 / stm32f4 / stm32f7 dtsi.
We don't provide patch for theses SOC because we don't test platform.

William
