### PR TITLE
modules: nanopb: Add custom target for generated header files

### DIFF
--- a/modules/nanopb/nanopb.cmake
+++ b/modules/nanopb/nanopb.cmake
@@ -15,6 +15,8 @@ else()
   message(STATUS "Found protoc: ${PROTOBUF_PROTOC_EXECUTABLE}")
 endif()
 
+add_custom_target(nanopb_generated_headers)
+
 # Usage:
 #   list(APPEND CMAKE_MODULE_PATH ${ZEPHYR_BASE}/modules/nanopb)
 #   include(nanopb)
@@ -31,4 +33,11 @@ function(zephyr_nanopb_sources target)
 
   target_include_directories(${target} PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
   target_sources(${target} PRIVATE ${proto_srcs} ${proto_hdrs})
+
+  # Create unique target name for generated header list
+  string(MD5 unique_chars "${proto_hdrs}")
+  set(gen_target_name ${target}_proto_${unique_chars})
+
+  add_custom_target(${gen_target_name} DEPENDS ${proto_hdrs})
+  add_dependencies(nanopb_generated_headers ${gen_target_name})
 endfunction()

--- a/tests/modules/nanopb/CMakeLists.txt
+++ b/tests/modules/nanopb/CMakeLists.txt
@@ -17,3 +17,8 @@ zephyr_nanopb_sources(app
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})
+
+# Process our own library
+add_subdirectory(lib)
+target_include_directories(app PRIVATE lib)
+target_link_libraries(app PRIVATE mylib)

--- a/tests/modules/nanopb/lib/CMakeLists.txt
+++ b/tests/modules/nanopb/lib/CMakeLists.txt
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+
+add_library(mylib lib.c)
+
+# Demonstrate that our library includes a generated header so we need the following dependency
+add_dependencies(mylib nanopb_generated_headers)
+
+# Add include directory to find the generated headers
+target_include_directories(mylib PRIVATE ${CMAKE_BINARY_DIR})
+
+# Link against zephyr
+target_link_libraries(mylib zephyr)

--- a/tests/modules/nanopb/lib/lib.c
+++ b/tests/modules/nanopb/lib/lib.c
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2023 Basalte bv
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "lib.h"
+
+void lib_fill_message(SimpleMessage *msg)
+{
+	/* Reversed numbers */
+	for (size_t i = 0; i < sizeof(msg->buffer); ++i) {
+		msg->buffer[i] = sizeof(msg->buffer) - i;
+	}
+}

--- a/tests/modules/nanopb/lib/lib.h
+++ b/tests/modules/nanopb/lib/lib.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2023 Basalte bv
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __LIB_H_
+#define __LIB_H_
+
+#include <proto/simple.pb.h>
+
+/**
+ * Some sample library function that fills a SimpleMessage struct
+ */
+void lib_fill_message(SimpleMessage *msg);
+
+#endif

--- a/tests/modules/nanopb/src/main.c
+++ b/tests/modules/nanopb/src/main.c
@@ -14,6 +14,8 @@
 #include <proto/simple.pb.h>
 #include <proto/complex.pb.h>
 
+#include "lib.h"
+
 ZTEST(nanopb_tests, test_nanopb_simple)
 {
 	uint8_t buffer[SimpleMessage_size];
@@ -66,6 +68,17 @@ ZTEST(nanopb_tests, test_nanopb_nested)
 	zassert_equal(42, msg.nested.id);
 	zassert_true(msg.has_nested);
 	zassert_equal(0, strcmp(msg.nested.name, "Test name"));
+}
+
+ZTEST(nanopb_tests, test_nanopb_lib)
+{
+	SimpleMessage msg = SimpleMessage_init_zero;
+
+	lib_fill_message(&msg);
+
+	for (size_t i = 0; i < sizeof(msg.buffer); ++i) {
+		zassert_equal(msg.buffer[i], sizeof(msg.buffer) - i);
+	}
 }
 
 ZTEST_SUITE(nanopb_tests, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Nanopb generates header files that need to be available before being included. This isn't an issue for a target where the files were added with `zephyr_nanopb_sources`. But if another target wants to include these generated files we need a cmake dependency chain.

The `nanopb_generated_headers` custom target been added for this purpose.