### PR TITLE
Tests: Replace k_current_get() in ISR context

### DIFF
--- a/tests/kernel/context/src/main.c
+++ b/tests/kernel/context/src/main.c
@@ -127,7 +127,7 @@ static void isr_handler(const void *data)
 
 	switch (isr_info.command) {
 	case THREAD_SELF_CMD:
-		isr_info.data = (void *)k_current_get();
+		isr_info.data = (void *)k_sched_current_thread_query();
 		break;
 
 	case EXEC_CTX_TYPE_CMD:

--- a/tests/kernel/context/src/main.c
+++ b/tests/kernel/context/src/main.c
@@ -80,6 +80,13 @@ extern const int32_t z_sys_timer_irq_for_test;
 #define HAS_POWERSAVE_INSTRUCTION
 #endif
 
+/* On architectures with additional reg banks k_current_get()
+ * shows undefined behavior and returns wrong tls-pointer as
+ * reg banks may appear unsynchronized
+ */
+#if defined(CONFIG_ARC) && (CONFIG_RGF_NUM_BANKS > 1)
+#define NO_TLS_IN_EXCEPTION
+#endif
 
 
 typedef struct {
@@ -127,7 +134,11 @@ static void isr_handler(const void *data)
 
 	switch (isr_info.command) {
 	case THREAD_SELF_CMD:
+#ifdef NO_TLS_IN_EXCEPTION
 		isr_info.data = (void *)k_sched_current_thread_query();
+#else
+		isr_info.data = (void *)k_current_get();
+#endif
 		break;
 
 	case EXEC_CTX_TYPE_CMD:

--- a/tests/kernel/fatal/exception/src/main.c
+++ b/tests/kernel/fatal/exception/src/main.c
@@ -60,7 +60,7 @@ void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
 		k_fatal_halt(reason);
 	}
 
-	if (k_current_get() != &alt_thread) {
+	if (k_sched_current_thread_query() != &alt_thread) {
 		printk("Wrong thread crashed\n");
 		printk("PROJECT EXECUTION FAILED\n");
 		k_fatal_halt(reason);


### PR DESCRIPTION
This fix repairs https://github.com/zephyrproject-rtos/zephyr/issues/62705 and https://github.com/zephyrproject-rtos/zephyr/issues/62704 that caused by incorrect using k_current_get() in ISR context. The routine was replaced with k_sched_current_thread_query().