### PR TITLE
drivers: counter: nrf_timer: Add event clear to set_top_value

### DIFF
--- a/drivers/counter/counter_nrfx_timer.c
+++ b/drivers/counter/counter_nrfx_timer.c
@@ -253,6 +253,7 @@ static int set_top_value(const struct device *dev,
 
 	nrf_timer_int_disable(timer, COUNTER_TOP_INT_MASK);
 	nrf_timer_cc_set(timer, TOP_CH, cfg->ticks);
+	nrf_timer_event_clear(timer, COUNTER_TOP_EVT);
 	nrf_timer_shorts_enable(timer, COUNTER_OVERFLOW_SHORT);
 
 	data->top_cb = cfg->callback;


### PR DESCRIPTION
At present, if you want to set a periodic timer again with set_top_value, the last triggered event is not cleared. This could result in an old event being served at the next interrupt activation.

The solution proposed in this patch adds the nrf_timer_event_clear function into set_top_value to prevent this from happening in the above case.