### PR TITLE
doc: gsg: macOS: Use menuselection role

### DIFF
--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -582,6 +582,14 @@ kbd, .kbd,
     vertical-align: middle;
 }
 
+/* guilabel and menuselection tweaks */
+.rst-content .guilabel,
+.rst-content .menuselection {
+    color: var(--body-color);
+    background-color: var(--guiitems-background-color);
+    border-color: var(--guiitems-border-color);
+}
+
 /* Buttons */
 
 .btn-neutral {

--- a/doc/_static/css/dark.css
+++ b/doc/_static/css/dark.css
@@ -87,6 +87,9 @@
     --kbd-shadow-color: #1e2023;
     --kbd-text-color: #e2f2ff;
 
+    --guiitems-background-color: #303d4f;
+    --guiitems-border-color: #7fbbe3;
+
     --btn-neutral-background-color: #404040;
     --btn-neutral-hover-background-color: #505050;
     --footer-color: #aaa;

--- a/doc/_static/css/light.css
+++ b/doc/_static/css/light.css
@@ -85,6 +85,9 @@
     --kbd-shadow-color: #b0b7bf;
     --kbd-text-color: #444d56;
 
+    --guiitems-background-color: #e7f2fa;
+    --guiitems-border-color: #7fbbe3;
+
     --btn-neutral-background-color: #f3f6f6;
     --btn-neutral-hover-background-color: #e5ebeb;
     --footer-color: #808080;

--- a/doc/develop/getting_started/installation_mac.rst
+++ b/doc/develop/getting_started/installation_mac.rst
@@ -19,9 +19,9 @@ get around this issue you can take two different approaches:
   ``path/to/folder`` is the path to the enclosing folder where the executables
   you want to run are located.
 
-* Open "System Preferences" -> "Security and Privacy" -> "Privacy" and then
-  scroll down to "Developer Tools". Then unlock the lock to be able to make
-  changes and check the checkbox corresponding to your terminal emulator of
+* Open :menuselection:`System Preferences --> Security and Privacy --> Privacy`
+  and then scroll down to "Developer Tools". Then unlock the lock to be able to
+  make changes and check the checkbox corresponding to your terminal emulator of
   choice. This will apply to any executable being launched from such terminal
   program.
 


### PR DESCRIPTION
Small tweak to use Sphinx `menuselection` role and make the menu output more readable.
https://builds.zephyrproject.io/zephyr/pr/64980/docs/develop/getting_started/installation_mac.html

Used the opportunity to fix broken dark theme for menuselection and guilabel roles