### PR TITLE
docs: Better document the DMA API and expectations

### DIFF
--- a/doc/hardware/peripherals/dma.rst
+++ b/doc/hardware/peripherals/dma.rst
@@ -6,6 +6,72 @@ Direct Memory Access (DMA)
 Overview
 ********
 
+Direct Memory Access (Controller) is a commonly provided type of co-processor that can typically
+offload transferring data to and from peripherals and memory.
+
+The DMA API is not a portable API and really cannot be as each DMA has unique memory requirements,
+peripheral interactions, and features. The API in effect provides a union of all useful DMA
+functionality drivers have needed in the tree. It can still be a good abstraction, with care, for
+peripheral devices for vendors where the DMA IP might be very similar but have slight variances.
+
+Driver Implementation Expectations
+**********************************
+
+Synchronization and Ownership
++++++++++++++++++++++++++++++
+
+From an API point of view, a DMA channel is a single-owner object, meaning the drivers should not
+attempt to wrap a channel with kernel synchronization primitives such as mutexes or semaphores. If
+DMA channels require mutating shared registers, those register updates should be wrapped in a spin
+lock.
+
+This enables the entire API to be low-cost and callable from any call context, including ISRs where
+it may be very useful to start/stop/suspend/resume/reload a channel transfer.
+
+Transfer Descriptor Memory Management
++++++++++++++++++++++++++++++++++++++
+
+Drivers should not attempt to use heap allocations of any kind. If object pools are needed for
+transfer descriptors then those should be setup in a way that does not break the promise of
+ISR-allowable calls. Many drivers choose to create a simple static descriptor array per channel with
+the size of the descriptor array adjustable using Kconfig.
+
+Channel State Machine Expectations
+++++++++++++++++++++++++++++++++++
+
+DMA channels should be viewed as state machines that the DMA API provides transition events for in
+the form of API calls. Every driver is expected to maintain its own channel state tracking. The busy
+state of the channel should be inspectable at any time with :c:func:`dma_get_status()`.
+
+A diagram showing those expectated possible state transitions and their API calls is provided here
+for reference.
+
+.. graphviz::
+   :caption: DMA state finite state machine
+
+   digraph {
+       node [style=rounded];
+       edge [fontname=Courier];
+       init [shape=point];
+
+       CONFIGURED [label=Configured,shape=box];
+       RUNNING [label=Running,shape=box];
+       SUSPENDED [label=Suspended,shape=box];
+
+       init -> CONFIGURED [label=dma_config];
+
+       CONFIGURED -> RUNNING [label=dma_start];
+       CONFIGURED -> CONFIGURED [label=dma_stop];
+
+       RUNNING -> CONFIGURED [label=dma_stop];
+       RUNNING -> RUNNING [label=dma_start];
+       RUNNING -> RUNNING [label=dma_resume, headport=w];
+       RUNNING -> SUSPENDED [label=dma_suspend];
+
+       SUSPENDED -> SUSPENDED [label=dma_suspend];
+       SUSPENDED -> RUNNING [label=dma_resume];
+       SUSPENDED -> CONFIGURED [label=dma_stop];
+   }
 
 API Reference
 *************

--- a/include/zephyr/drivers/dma.h
+++ b/include/zephyr/drivers/dma.h
@@ -386,6 +386,8 @@ static inline int dma_reload(const struct device *dev, uint32_t channel,
  * Start is allowed on channels that have already been started and must report
  * success.
  *
+ * @funcprops \isr_ok
+ *
  * @param dev     Pointer to the device structure for the driver instance.
  * @param channel Numeric identification of the channel where the transfer will
  *                be processed
@@ -412,6 +414,8 @@ static inline int z_impl_dma_start(const struct device *dev, uint32_t channel)
  * Stop is allowed on channels that have already been stopped and must report
  * success.
  *
+ * @funcprops \isr_ok
+ *
  * @param dev     Pointer to the device structure for the driver instance.
  * @param channel Numeric identification of the channel where the transfer was
  *                being processed
@@ -435,6 +439,8 @@ static inline int z_impl_dma_stop(const struct device *dev, uint32_t channel)
  *
  * Implementations must check the validity of the channel state and ID passed
  * in and return -EINVAL if either are invalid.
+ *
+ * @funcprops \isr_ok
  *
  * @param dev Pointer to the device structure for the driver instance.
  * @param channel Numeric identification of the channel to suspend
@@ -462,6 +468,8 @@ static inline int z_impl_dma_suspend(const struct device *dev, uint32_t channel)
  * Implementations must check the validity of the channel state and ID passed
  * in and return -EINVAL if either are invalid.
  *
+ * @funcprops \isr_ok
+ *
  * @param dev Pointer to the device structure for the driver instance.
  * @param channel Numeric identification of the channel to resume
  *
@@ -487,6 +495,8 @@ static inline int z_impl_dma_resume(const struct device *dev, uint32_t channel)
  *
  * request DMA channel resources
  * return -EINVAL if there is no valid channel available.
+ *
+ * @funcprops \isr_ok
  *
  * @param dev Pointer to the device structure for the driver instance.
  * @param filter_param filter function parameter
@@ -530,6 +540,8 @@ static inline int z_impl_dma_request_channel(const struct device *dev,
  * @brief release DMA channel.
  *
  * release DMA channel resources
+ *
+ * @funcprops \isr_ok
  *
  * @param dev  Pointer to the device structure for the driver instance.
  * @param channel  channel number
@@ -587,6 +599,8 @@ static inline int z_impl_dma_chan_filter(const struct device *dev,
  * Implementations must check the validity of the channel ID passed in and
  * return -EINVAL if it is invalid or -ENOSYS if not supported.
  *
+ * @funcprops \isr_ok
+ *
  * @param dev     Pointer to the device structure for the driver instance.
  * @param channel Numeric identification of the channel where the transfer was
  *                being processed
@@ -616,6 +630,8 @@ static inline int dma_get_status(const struct device *dev, uint32_t channel,
  * Implementations must check the validity of the type passed in and
  * return -EINVAL if it is invalid or -ENOSYS if not supported.
  *
+ * @funcprops \isr_ok
+ *
  * @param dev     Pointer to the device structure for the driver instance.
  * @param type    Numeric identification of the attribute
  * @param value   A non-NULL pointer to the variable where the read value is to be placed
@@ -637,7 +653,7 @@ static inline int dma_get_attribute(const struct device *dev, uint32_t type, uin
 /**
  * @brief Look-up generic width index to be used in registers
  *
- * WARNING: This look-up works for most controllers, but *may* not work for
+ * @warning This look-up works for most controllers, but *may* not work for
  *          yours.  Ensure your controller expects the most common register
  *          bit values before using this convenience function.  If your
  *          controller does not support these values, you will have to write
@@ -666,7 +682,7 @@ static inline uint32_t dma_width_index(uint32_t size)
 /**
  * @brief Look-up generic burst index to be used in registers
  *
- * WARNING: This look-up works for most controllers, but *may* not work for
+ * @warning This look-up works for most controllers, but *may* not work for
  *          yours.  Ensure your controller expects the most common register
  *          bit values before using this convenience function.  If your
  *          controller does not support these values, you will have to write
@@ -693,7 +709,7 @@ static inline uint32_t dma_burst_index(uint32_t burst)
 }
 
 /**
- * Get the device tree property describing the buffer address alignment
+ * @brief Get the device tree property describing the buffer address alignment
  *
  * Useful when statically defining or allocating buffers for DMA usage where
  * memory alignment often matters.
@@ -704,7 +720,7 @@ static inline uint32_t dma_burst_index(uint32_t burst)
 #define DMA_BUF_ADDR_ALIGNMENT(node) DT_PROP(node, dma_buf_addr_alignment)
 
 /**
- * Get the device tree property describing the buffer size alignment
+ * @brief Get the device tree property describing the buffer size alignment
  *
  * Useful when statically defining or allocating buffers for DMA usage where
  * memory alignment often matters.
@@ -715,7 +731,7 @@ static inline uint32_t dma_burst_index(uint32_t burst)
 #define DMA_BUF_SIZE_ALIGNMENT(node) DT_PROP(node, dma_buf_size_alignment)
 
 /**
- * Get the device tree property describing the minimal chunk of data possible to be copied
+ * @brief Get the device tree property describing the minimal chunk of data possible to be copied
  *
  * @param node Node identifier, e.g. DT_NODELABEL(dma_0)
  * @return minimal Minimal chunk of data possible to be copied

--- a/include/zephyr/drivers/dma.h
+++ b/include/zephyr/drivers/dma.h
@@ -28,12 +28,21 @@ extern "C" {
  * @{
  */
 
+/**
+ * @brief DMA channel direction
+ */
 enum dma_channel_direction {
+	/** Memory to memory */
 	MEMORY_TO_MEMORY = 0x0,
+	/** Memory to peripheral */
 	MEMORY_TO_PERIPHERAL,
+	/** Peripheral to memory */
 	PERIPHERAL_TO_MEMORY,
+	/** Peripheral to peripheral */
 	PERIPHERAL_TO_PERIPHERAL,
+	/** Host to memory */
 	HOST_TO_MEMORY,
+	/** Memory to host */
 	MEMORY_TO_HOST,
 
 	/**
@@ -53,20 +62,31 @@ enum dma_channel_direction {
 	DMA_CHANNEL_DIRECTION_MAX = 0x7
 };
 
-/** Valid values for @a source_addr_adj and @a dest_addr_adj */
+/**
+ * @brief DMA address adjustment
+ *
+ * Valid values for @a source_addr_adj and @a dest_addr_adj
+ */
 enum dma_addr_adj {
+	/** Increment the address */
 	DMA_ADDR_ADJ_INCREMENT,
+	/** Decrement the address */
 	DMA_ADDR_ADJ_DECREMENT,
+	/** No change the address */
 	DMA_ADDR_ADJ_NO_CHANGE,
 };
 
-/* channel attributes */
+/**
+ * @brief DMA channel attributes
+ */
 enum dma_channel_filter {
 	DMA_CHANNEL_NORMAL, /* normal DMA channel */
 	DMA_CHANNEL_PERIODIC, /* can be triggered by periodic sources */
 };
 
-/* DMA attributes */
+/**
+ * @brief DMA attributes
+ */
 enum dma_attribute_type {
 	DMA_ATTR_BUFFER_ADDRESS_ALIGNMENT,
 	DMA_ATTR_BUFFER_SIZE_ALIGNMENT,
@@ -78,65 +98,73 @@ enum dma_attribute_type {
  * @struct dma_block_config
  * @brief DMA block configuration structure.
  *
- * @param source_address is block starting address at source
- * @param source_gather_interval is the address adjustment at gather boundary
- * @param dest_address is block starting address at destination
- * @param dest_scatter_interval is the address adjustment at scatter boundary
- * @param dest_scatter_count is the continuous transfer count between scatter
- *                    boundaries
- * @param source_gather_count is the continuous transfer count between gather
- *                     boundaries
- *
- * @param block_size is the number of bytes to be transferred for this block.
- *
- * @param config is a bit field with the following parts:
- *
- *     source_gather_en   [ 0 ]       - 0-disable, 1-enable.
- *     dest_scatter_en    [ 1 ]       - 0-disable, 1-enable.
- *     source_addr_adj    [ 2 : 3 ]   - 00-increment, 01-decrement,
- *                                      10-no change.
- *     dest_addr_adj      [ 4 : 5 ]   - 00-increment, 01-decrement,
- *                                      10-no change.
- *     source_reload_en   [ 6 ]       - reload source address at the end of
- *                                      block transfer
- *                                      0-disable, 1-enable.
- *     dest_reload_en     [ 7 ]       - reload destination address at the end
- *                                      of block transfer
- *                                      0-disable, 1-enable.
- *     fifo_mode_control  [ 8 : 11 ]  - How full  of the fifo before transfer
- *                                      start. HW specific.
- *     flow_control_mode  [ 12 ]      - 0-source request served upon data
- *                                        availability.
- *                                      1-source request postponed until
- *                                        destination request happens.
- *     reserved           [ 13 : 15 ]
+ * Aside from source address, destination address, and block size many of these options are hardware
+ * and driver dependent.
  */
 struct dma_block_config {
 #ifdef CONFIG_DMA_64BIT
+	/** block starting address at source */
 	uint64_t source_address;
+	/** block starting address at destination */
 	uint64_t dest_address;
 #else
+	/** block starting address at source */
 	uint32_t source_address;
+	/** block starting address at destination */
 	uint32_t dest_address;
 #endif
+	/** Address adjustment at gather boundary */
 	uint32_t source_gather_interval;
+	/** Address adjustment at scatter boundary */
 	uint32_t dest_scatter_interval;
+	/** Continuous transfer count between scatter boundaries */
 	uint16_t dest_scatter_count;
+	/** Continuous transfer count between gather boundaries */
 	uint16_t source_gather_count;
+	/** Number of bytes to be transferred for this block */
 	uint32_t block_size;
+	/** Pointer to next block in a transfer list */
 	struct dma_block_config *next_block;
+	/** Enable source gathering when set to 1 */
 	uint16_t  source_gather_en :  1;
+	/** Enable destination scattering when set to 1 */
 	uint16_t  dest_scatter_en :   1;
+	/**
+	 * Source address adjustment option
+	 *
+	 * - 0b00 increment
+	 * - 0b01 decrement
+	 * - 0b10 no change
+	 */
 	uint16_t  source_addr_adj :   2;
+	/**
+	 * Destination address adjustment
+	 *
+	 * - 0b00 increment
+	 * - 0b01 decrement
+	 * - 0b10 no change
+	 */
 	uint16_t  dest_addr_adj :     2;
+	/** Reload source address at the end of block transfer */
 	uint16_t  source_reload_en :  1;
+	/** Reload destination address at the end of block transfer */
 	uint16_t  dest_reload_en :    1;
+	/** FIFO fill before starting transfer, HW specific meaning */
 	uint16_t  fifo_mode_control : 4;
+	/**
+	 * Transfer flow control mode
+	 *
+	 * - 0b0 source request service upon data availability
+	 * - 0b1 source request postponed until destination request happens
+	 */
 	uint16_t  flow_control_mode : 1;
-	uint16_t  reserved :          3;
+
+	uint16_t  _reserved :          3;
 };
 
+/** The DMA callback event has occurred at the completion of a transfer list */
 #define DMA_STATUS_COMPLETE	0
+/** The DMA callback has occurred at the completion of a single transfer block in a transfer list */
 #define DMA_STATUS_BLOCK	1
 
 /**
@@ -151,10 +179,11 @@ struct dma_block_config {
  * @param dev           Pointer to the DMA device calling the callback.
  * @param user_data     A pointer to some user data or NULL
  * @param channel       The channel number
- * @param status        - 0-DMA_STATUS_COMPLETE buffer fully consumed
- *                      - 1-DMA_STATUS_BLOCK buffer consumption reached a configured block
+ * @param status        Status of the transfer
+ *                      - DMA_STATUS_COMPLETE buffer fully consumed
+ *                      - DMA_STATUS_BLOCK buffer consumption reached a configured block
  *                        or water mark
- *                      - a negative errno otherwise
+ *                      - A negative errno otherwise
  */
 typedef void (*dma_callback_t)(const struct device *dev, void *user_data,
 			       uint32_t channel, int status);
@@ -162,86 +191,99 @@ typedef void (*dma_callback_t)(const struct device *dev, void *user_data,
 /**
  * @struct dma_config
  * @brief DMA configuration structure.
- *
- * @param dma_slot             [ 0 : 7 ]   - which peripheral and direction
- *                                        (HW specific)
- * @param channel_direction    [ 8 : 10 ]  - 000-memory to memory,
- *                                        001-memory to peripheral,
- *                                        010-peripheral to memory,
- *                                        011-peripheral to peripheral,
- *                                        100-host to memory
- *                                        101-memory to host
- *                                        ...
- * @param complete_callback_en [ 11 ]       - 0-callback invoked at completion only
- *                                        1-callback invoked at completion of
- *                                          each block
- * @param error_callback_en    [ 12 ]      - 0-error callback enabled
- *                                        1-error callback disabled
- * @param source_handshake     [ 13 ]      - 0-HW, 1-SW
- * @param dest_handshake       [ 14 ]      - 0-HW, 1-SW
- * @param channel_priority     [ 15 : 18 ] - DMA channel priority
- * @param source_chaining_en   [ 19 ]      - enable/disable source block chaining
- *                                        0-disable, 1-enable
- * @param dest_chaining_en     [ 20 ]      - enable/disable destination block
- *                                        chaining.
- *                                        0-disable, 1-enable
- * @param linked_channel       [ 21 : 27 ] - after channel count exhaust will
- *                                        initiate a channel service request
- *                                        at this channel
- * @param cyclic               [ 28 ]      - enable/disable cyclic buffer
- *                                        0-disable, 1-enable
- * @param reserved             [ 29 : 31 ]
- * @param source_data_size    [ 0 : 15 ]   - width of source data (in bytes)
- * @param dest_data_size      [ 16 : 31 ]  - width of dest data (in bytes)
- * @param source_burst_length [ 0 : 15 ]   - number of source data units
- * @param dest_burst_length   [ 16 : 31 ]  - number of destination data units
- * @param block_count  is the number of blocks used for block chaining, this
- *     depends on availability of the DMA controller.
- * @param user_data  private data from DMA client.
- * @param dma_callback see dma_callback_t for details
  */
 struct dma_config {
+	/** Which peripheral and direction, HW specific */
 	uint32_t  dma_slot :             8;
+	/**
+	 * Direction the transfers are occurring
+	 *
+	 * - 0b000 memory to memory,
+	 * - 0b001 memory to peripheral,
+	 * - 0b010 peripheral to memory,
+	 * - 0b011 peripheral to peripheral,
+	 * - 0b100 host to memory
+	 * - 0b101 memory to host
+	 * - others hardware specific
+	 */
 	uint32_t  channel_direction :    3;
+	/**
+	 * Completion callback enable
+	 *
+	 * - 0b0 callback invoked at transfer list completion only
+	 * - 0b1 callback invoked at completion of each block
+	 */
 	uint32_t  complete_callback_en : 1;
+	/**
+	 * Error callback enable
+	 *
+	 * - 0b0 error callback enabled
+	 * - 0b1 error callback disabled
+	 */
 	uint32_t  error_callback_en :    1;
+	/**
+	 * Source handshake, HW specific
+	 *
+	 * - 0b0 HW
+	 * - 0b1 SW
+	 */
 	uint32_t  source_handshake :     1;
+	/**
+	 * Destination handshake, HW specific
+	 *
+	 * - 0b0 HW
+	 * - 0b1 SW
+	 */
 	uint32_t  dest_handshake :       1;
+	/**
+	 * Channel priority for arbitration, HW specific
+	 */
 	uint32_t  channel_priority :     4;
+	/** Source chaining enable, HW specific */
 	uint32_t  source_chaining_en :   1;
+	/** Destination chaining enable, HW specific */
 	uint32_t  dest_chaining_en :     1;
+	/** Linked channel, HW specific */
 	uint32_t  linked_channel   :     7;
+	/** Cyclic transfer list, HW specific */
 	uint32_t  cyclic :				 1;
-	uint32_t  reserved :             3;
+
+	uint32_t  _reserved :             3;
+	/** Width of source data (in bytes) */
 	uint32_t  source_data_size :    16;
+	/** Width of destination data (in bytes) */
 	uint32_t  dest_data_size :      16;
+	/** Source burst length in bytes */
 	uint32_t  source_burst_length : 16;
+	/** Destination burst length in bytes */
 	uint32_t  dest_burst_length :   16;
+	/** Number of blocks in transfer list */
 	uint32_t block_count;
+	/** Pointer to the first block in the transfer list */
 	struct dma_block_config *head_block;
+	/** Optional attached user data for callbacks */
 	void *user_data;
+	/** Optional callback for completion and error events */
 	dma_callback_t dma_callback;
 };
 
 /**
  * DMA runtime status structure
- *
- * busy 			- is current DMA transfer busy or idle
- * dir				- DMA transfer direction
- * pending_length 		- data length pending to be transferred in bytes
- * 					or platform dependent.
- * free                         - free buffer space
- * write_position               - write position in a circular dma buffer
- * read_position                - read position in a circular dma buffer
- *
  */
 struct dma_status {
+	/** Is the current DMA transfer busy or idle */
 	bool busy;
+	/** Direction fo the transfer */
 	enum dma_channel_direction dir;
+	/** Pending length to be transferred in bytes, HW specific */
 	uint32_t pending_length;
+	/** Available buffers space, HW specific */
 	uint32_t free;
+	/** Write position in circular DMA buffer, HW specific */
 	uint32_t write_position;
+	/** Read position in circular DMA buffer, HW specific */
 	uint32_t read_position;
+	/** Total copied, HW specific */
 	uint64_t total_copied;
 };
 
@@ -249,19 +291,17 @@ struct dma_status {
  * DMA context structure
  * Note: the dma_context shall be the first member
  *       of DMA client driver Data, got by dev->data
- *
- * magic			- magic code to identify the context
- * dma_channels		- dma channels
- * atomic			- driver atomic_t pointer
- *
  */
 struct dma_context {
+	/** magic code to identify the context */
 	int32_t magic;
+	/** number of dma channels */
 	int dma_channels;
+	/** atomic holding bit flags for each channel to mark as used/unused */
 	atomic_t *atomic;
 };
 
-/* magic code to identify context content */
+/** Magic code to identify context content */
 #define DMA_MAGIC 0x47494749
 
 /**


### PR DESCRIPTION
The DMA API has several expectations for drivers and callers that were underdocumented or undocumented. Better clarify the driver expectations and caller expectations.

The DMA API from the caller side is not a portable API and really cannot be as each DMA has unique properties and expectations of memory, peripheral interaction, and features. The API in effect provides a union of all useful DMA functionality drivers have needed in the tree. It can still be a good abstraction, with care, for peripheral devices for vendors or projects where the DMA IP might be very similar but have slight variances. It does however provide a way to configure and transition channel states. In most drivers today this can be done from any call context. This PR solidifies that this is meant to be possible in any call context and bugs have been filed for drivers that are not compliant.

From the driver implementation side expectations around synchronization, state transitions, and memory management for transfer descriptors is now described in documentation rather than solely from me in github review comments.