### PR TITLE
arch: move `arch_interface.h` under `zephyr/arch/` and rename `arch_start_cpu()` to `arch_cpu_start()`

### DIFF
--- a/arch/arc/core/smp.c
+++ b/arch/arc/core/smp.c
@@ -39,7 +39,7 @@ volatile char *arc_cpu_sp;
 volatile _cpu_t *_curr_cpu[CONFIG_MP_MAX_NUM_CPUS];
 
 /* Called from Zephyr initialization */
-void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
+void arch_cpu_start(int cpu_num, k_thread_stack_t *stack, int sz,
 		    arch_cpustart_t fn, void *arg)
 {
 	_curr_cpu[cpu_num] = &(_kernel.cpus[cpu_num]);
@@ -114,7 +114,7 @@ void arch_secondary_cpu_init(int cpu_num)
 			   DT_IRQ(DT_NODELABEL(ici), priority), 0);
 	irq_enable(DT_IRQN(DT_NODELABEL(ici)));
 #endif
-	/* call the function set by arch_start_cpu */
+	/* call the function set by arch_cpu_start */
 	fn = arc_cpu_init[cpu_num].fn;
 
 	fn(arc_cpu_init[cpu_num].arg);

--- a/arch/arm/core/cortex_a_r/smp.c
+++ b/arch/arm/core/cortex_a_r/smp.c
@@ -90,7 +90,7 @@ extern int z_arm_mmu_init(void);
 #endif
 
 /* Called from Zephyr initialization */
-void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz, arch_cpustart_t fn, void *arg)
+void arch_cpu_start(int cpu_num, k_thread_stack_t *stack, int sz, arch_cpustart_t fn, void *arg)
 {
 	int cpu_count, i, j;
 	uint32_t cpu_mpid = 0;

--- a/arch/arm64/core/smp.c
+++ b/arch/arm64/core/smp.c
@@ -62,7 +62,7 @@ static uint64_t cpu_map[CONFIG_MP_MAX_NUM_CPUS] = {
 extern void z_arm64_mm_init(bool is_primary_core);
 
 /* Called from Zephyr initialization */
-void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
+void arch_cpu_start(int cpu_num, k_thread_stack_t *stack, int sz,
 		    arch_cpustart_t fn, void *arg)
 {
 	int cpu_count;

--- a/arch/arm64/core/smp.c
+++ b/arch/arm64/core/smp.c
@@ -21,7 +21,7 @@
 #include <zephyr/arch/cpu.h>
 #include <zephyr/drivers/interrupt_controller/gic.h>
 #include <zephyr/drivers/pm_cpu_ops.h>
-#include <zephyr/sys/arch_interface.h>
+#include <zephyr/arch/arch_interface.h>
 #include <zephyr/sys/barrier.h>
 #include <zephyr/irq.h>
 #include "boot.h"

--- a/arch/riscv/core/pmp.c
+++ b/arch/riscv/core/pmp.c
@@ -29,7 +29,7 @@
 #include <kernel_internal.h>
 #include <zephyr/linker/linker-defs.h>
 #include <pmp.h>
-#include <zephyr/sys/arch_interface.h>
+#include <zephyr/arch/arch_interface.h>
 #include <zephyr/arch/riscv/csr.h>
 
 #define LOG_LEVEL CONFIG_MPU_LOG_LEVEL

--- a/arch/riscv/core/smp.c
+++ b/arch/riscv/core/smp.c
@@ -27,7 +27,7 @@ extern void __start(void);
 void soc_interrupt_init(void);
 #endif
 
-void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
+void arch_cpu_start(int cpu_num, k_thread_stack_t *stack, int sz,
 		    arch_cpustart_t fn, void *arg)
 {
 	riscv_cpu_init[cpu_num].fn = fn;

--- a/arch/x86/core/intel64/cpu.c
+++ b/arch/x86/core/intel64/cpu.c
@@ -138,7 +138,7 @@ struct x86_cpuboot x86_cpuboot[] = {
  * will enter the kernel at fn(arg), running on the specified stack.
  */
 
-void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
+void arch_cpu_start(int cpu_num, k_thread_stack_t *stack, int sz,
 		    arch_cpustart_t fn, void *arg)
 {
 #if CONFIG_MP_MAX_NUM_CPUS > 1

--- a/arch/xtensa/include/xtensa_internal.h
+++ b/arch/xtensa/include/xtensa_internal.h
@@ -11,7 +11,7 @@
 #include <stdint.h>
 
 #include <zephyr/arch/xtensa/exception.h>
-#include <zephyr/sys/arch_interface.h>
+#include <zephyr/arch/arch_interface.h>
 
 /**
  * @ingroup xtensa_internal_apis

--- a/doc/kernel/services/smp/smp.rst
+++ b/doc/kernel/services/smp/smp.rst
@@ -132,7 +132,7 @@ happens on a single CPU before other CPUs are brought online.
 Just before entering the application :c:func:`main` function, the kernel
 calls :c:func:`z_smp_init` to launch the SMP initialization process.  This
 enumerates over the configured CPUs, calling into the architecture
-layer using :c:func:`arch_start_cpu` for each one.  This function is
+layer using :c:func:`arch_cpu_start` for each one.  This function is
 passed a memory region to use as a stack on the foreign CPU (in
 practice it uses the area that will become that CPU's interrupt
 stack), the address of a local :c:func:`smp_init_top` callback function to

--- a/doc/kernel/services/smp/smpinit.svg
+++ b/doc/kernel/services/smp/smpinit.svg
@@ -309,7 +309,7 @@
          id="tspan3682"
          x="33.970718"
          y="46.338062"
-         style="stroke-width:0.34572953">arch_start_cpu()</tspan></text>
+         style="stroke-width:0.34572953">arch_cpu_start()</tspan></text>
     <rect
        style="fill:#ffffaa;fill-opacity:1;stroke:#000000;stroke-width:0.32675847;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect3686-7"

--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -148,6 +148,8 @@ Userspace
 Architectures
 *************
 
+* Function :c:func:`arch_start_cpu` has been renamed to :c:func:`arch_cpu_start`.
+
 * x86
 
   * Kconfigs ``CONFIG_DISABLE_SSBD`` and ``CONFIG_ENABLE_EXTENDED_IBRS``

--- a/drivers/interrupt_controller/intc_cavs.c
+++ b/drivers/interrupt_controller/intc_cavs.c
@@ -10,7 +10,7 @@
 #include <zephyr/device.h>
 #include <zephyr/irq.h>
 #include <zephyr/irq_nextlevel.h>
-#include <zephyr/sys/arch_interface.h>
+#include <zephyr/arch/arch_interface.h>
 #include "intc_cavs.h"
 
 #if defined(CONFIG_SMP) && (CONFIG_MP_MAX_NUM_CPUS > 1)

--- a/drivers/sensor/qdec_nxp_s32/qdec_nxp_s32.c
+++ b/drivers/sensor/qdec_nxp_s32/qdec_nxp_s32.c
@@ -10,7 +10,7 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/sys/arch_interface.h>
+#include <zephyr/arch/arch_interface.h>
 
 #ifndef M_PI
 #define M_PI 3.14159265358979323846

--- a/include/zephyr/arch/arch_interface.h
+++ b/include/zephyr/arch/arch_interface.h
@@ -238,7 +238,7 @@ typedef void (*arch_cpustart_t)(void *data);
  * @param fn Function to begin running on the CPU.
  * @param arg Untyped argument to be passed to "fn"
  */
-void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
+void arch_cpu_start(int cpu_num, k_thread_stack_t *stack, int sz,
 		    arch_cpustart_t fn, void *arg);
 
 /**

--- a/include/zephyr/arch/arch_interface.h
+++ b/include/zephyr/arch/arch_interface.h
@@ -24,8 +24,8 @@
  * include/kernel.h and other public headers depend on definitions in this
  * header.
  */
-#ifndef ZEPHYR_INCLUDE_SYS_ARCH_INTERFACE_H_
-#define ZEPHYR_INCLUDE_SYS_ARCH_INTERFACE_H_
+#ifndef ZEPHYR_INCLUDE_ARCH_ARCH_INTERFACE_H_
+#define ZEPHYR_INCLUDE_ARCH_ARCH_INTERFACE_H_
 
 #ifndef _ASMLANGUAGE
 #include <zephyr/toolchain.h>
@@ -1248,4 +1248,4 @@ void arch_spin_relax(void);
 
 #endif /* _ASMLANGUAGE */
 
-#endif /* ZEPHYR_INCLUDE_SYS_ARCH_INTERFACE_H_ */
+#endif /* ZEPHYR_INCLUDE_ARCH_ARCH_INTERFACE_H_ */

--- a/include/zephyr/arch/cpu.h
+++ b/include/zephyr/arch/cpu.h
@@ -9,7 +9,7 @@
 #ifndef ZEPHYR_INCLUDE_ARCH_CPU_H_
 #define ZEPHYR_INCLUDE_ARCH_CPU_H_
 
-#include <zephyr/sys/arch_interface.h>
+#include <zephyr/arch/arch_interface.h>
 
 #if defined(CONFIG_X86)
 #include <zephyr/arch/x86/arch.h>

--- a/include/zephyr/internal/syscall_handler.h
+++ b/include/zephyr/internal/syscall_handler.h
@@ -17,7 +17,7 @@
 
 #ifndef _ASMLANGUAGE
 #include <zephyr/kernel.h>
-#include <zephyr/sys/arch_interface.h>
+#include <zephyr/arch/arch_interface.h>
 #include <zephyr/sys/math_extras.h>
 #include <stdbool.h>
 #include <zephyr/logging/log.h>

--- a/include/zephyr/kernel/thread.h
+++ b/include/zephyr/kernel/thread.h
@@ -12,7 +12,7 @@
 #endif
 
 #include <zephyr/kernel/stats.h>
-#include <zephyr/sys/arch_interface.h>
+#include <zephyr/arch/arch_interface.h>
 
 /**
  * @typedef k_thread_entry_t

--- a/include/zephyr/timing/timing.h
+++ b/include/zephyr/timing/timing.h
@@ -7,7 +7,7 @@
 #ifndef ZEPHYR_INCLUDE_TIMING_TIMING_H_
 #define ZEPHYR_INCLUDE_TIMING_TIMING_H_
 
-#include <zephyr/sys/arch_interface.h>
+#include <zephyr/arch/arch_interface.h>
 #include <zephyr/timing/types.h>
 
 #ifdef __cplusplus

--- a/kernel/include/kernel_arch_interface.h
+++ b/kernel/include/kernel_arch_interface.h
@@ -9,7 +9,7 @@
  * @brief Internal kernel APIs implemented at the architecture layer.
  *
  * Not all architecture-specific defines are here, APIs that are used
- * by public functions and macros are defined in include/sys/arch_interface.h.
+ * by public functions and macros are defined in include/zephyr/arch/arch_interface.h.
  *
  * For all inline functions prototyped here, the implementation is expected
  * to be provided by arch/ARCH/include/kernel_arch_func.h
@@ -18,7 +18,7 @@
 #define ZEPHYR_KERNEL_INCLUDE_KERNEL_ARCH_INTERFACE_H_
 
 #include <zephyr/kernel.h>
-#include <zephyr/sys/arch_interface.h>
+#include <zephyr/arch/arch_interface.h>
 
 #ifndef _ASMLANGUAGE
 

--- a/kernel/smp.c
+++ b/kernel/smp.c
@@ -156,7 +156,7 @@ static void start_cpu(int id, struct cpu_start_cb *csc)
 	(void)atomic_clear(&ready_flag);
 
 	/* Power up the CPU */
-	arch_start_cpu(id, z_interrupt_stacks[id], CONFIG_ISR_STACK_SIZE,
+	arch_cpu_start(id, z_interrupt_stacks[id], CONFIG_ISR_STACK_SIZE,
 		       smp_init_top, csc);
 
 	/* Wait until the newly powered up CPU to signal that

--- a/samples/kernel/condition_variables/condvar/src/main.c
+++ b/samples/kernel/condition_variables/condvar/src/main.c
@@ -5,7 +5,6 @@
  */
 #include <zephyr/kernel.h>
 #include <zephyr/arch/cpu.h>
-#include <zephyr/sys/arch_interface.h>
 
 #define NUM_THREADS 3
 #define TCOUNT 10

--- a/samples/kernel/condition_variables/simple/src/main.c
+++ b/samples/kernel/condition_variables/simple/src/main.c
@@ -6,7 +6,6 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/arch/cpu.h>
-#include <zephyr/sys/arch_interface.h>
 
 #define NUM_THREADS 20
 #define STACK_SIZE (1024)

--- a/soc/espressif/esp32/esp32-mp.c
+++ b/soc/espressif/esp32/esp32-mp.c
@@ -243,7 +243,7 @@ IRAM_ATTR static void esp_crosscore_isr(void *arg)
 	}
 }
 
-void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
+void arch_cpu_start(int cpu_num, k_thread_stack_t *stack, int sz,
 		    arch_cpustart_t fn, void *arg)
 {
 	volatile struct cpustart_rec sr;

--- a/soc/intel/intel_adsp/common/multiprocessing.c
+++ b/soc/intel/intel_adsp/common/multiprocessing.c
@@ -107,7 +107,7 @@ __imr void z_mp_entry(void)
 	soc_mp_startup(start_rec.cpu);
 	soc_cpus_active[start_rec.cpu] = true;
 	start_rec.fn(start_rec.arg);
-	__ASSERT(false, "arch_start_cpu() handler should never return");
+	__ASSERT(false, "arch_cpu_start() handler should never return");
 }
 
 void mp_resume_entry(void)
@@ -120,7 +120,7 @@ bool arch_cpu_active(int cpu_num)
 	return soc_cpus_active[cpu_num];
 }
 
-void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
+void arch_cpu_start(int cpu_num, k_thread_stack_t *stack, int sz,
 		    arch_cpustart_t fn, void *arg)
 {
 	__ASSERT_NO_MSG(!soc_cpus_active[cpu_num]);

--- a/subsys/shell/modules/device_service.c
+++ b/subsys/shell/modules/device_service.c
@@ -12,7 +12,7 @@
 #include <zephyr/device.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/device_runtime.h>
-#include <zephyr/sys/arch_interface.h>
+#include <zephyr/arch/arch_interface.h>
 
 static const char *get_device_name(const struct device *dev,
 				   char *buf,

--- a/subsys/testsuite/include/zephyr/interrupt_util.h
+++ b/subsys/testsuite/include/zephyr/interrupt_util.h
@@ -109,7 +109,7 @@ static inline void trigger_irq(int irq)
 #include <zephyr/drivers/interrupt_controller/loapic.h>
 #define VECTOR_MASK 0xFF
 #else
-#include <zephyr/sys/arch_interface.h>
+#include <zephyr/arch/arch_interface.h>
 #define LOAPIC_ICR_IPI_TEST  0x00004000U
 #endif
 

--- a/subsys/testsuite/ztest/include/zephyr/arch/cpu.h
+++ b/subsys/testsuite/ztest/include/zephyr/arch/cpu.h
@@ -61,7 +61,7 @@ static inline bool arch_irq_unlocked(unsigned int key)
 }
 #endif /* __cplusplus */
 
-#include <zephyr/sys/arch_interface.h>
+#include <zephyr/arch/arch_interface.h>
 
 
 #endif /* ZEPHYR_SUBSYS_TESTSUITE_ZTEST_INCLUDE_ARCH_CPU_H */

--- a/tests/arch/common/timing/src/main.c
+++ b/tests/arch/common/timing/src/main.c
@@ -5,7 +5,7 @@
  */
 #include <zephyr/ztest.h>
 #include <zephyr/kernel.h>
-#include <zephyr/sys/arch_interface.h>
+#include <zephyr/arch/arch_interface.h>
 
 #if defined(CONFIG_SMP) && CONFIG_MP_MAX_NUM_CPUS > 1
 #define SMP_TEST

--- a/tests/kernel/mp/src/main.c
+++ b/tests/kernel/mp/src/main.c
@@ -76,7 +76,7 @@ FUNC_NORETURN void cpu_fn(void *arg)
  *
  * Test Procedure:
  * -# In main thread, given and set a global variable cpu_arg to 12345.
- * -# Call arch_start_cpu() with parameters
+ * -# Call arch_cpu_start() with parameters
  * -# Enter a while loop and wait for cpu_running equals to 1.
  * -# In target function, check if the address is &cpu_arg and its content
  *  equal to 12345.
@@ -94,7 +94,7 @@ FUNC_NORETURN void cpu_fn(void *arg)
  * - This test using for the platform that support MP or SMP, in our current
  *   scenario which own over two CPUs.
  *
- * @see arch_start_cpu()
+ * @see arch_cpu_start()
  */
 ZTEST(multiprocessing, test_mp_start)
 {
@@ -105,7 +105,7 @@ ZTEST(multiprocessing, test_mp_start)
 
 		cpu_arg = 12345 * i;
 
-		arch_start_cpu(i, cpu_stacks[i], CPU_STACK_SIZE, cpu_fn, &cpu_arg);
+		arch_cpu_start(i, cpu_stacks[i], CPU_STACK_SIZE, cpu_fn, &cpu_arg);
 
 		/* Wait for about 5 (500 * 10ms) seconds for CPU to start. */
 		wait_count = 500;

--- a/tests/kernel/spinlock/src/main.c
+++ b/tests/kernel/spinlock/src/main.c
@@ -122,7 +122,7 @@ static void cpu1_fn(void *p1, void *p2, void *p3)
  *
  * @ingroup kernel_spinlock_tests
  *
- * @see arch_start_cpu()
+ * @see arch_cpu_start()
  */
 ZTEST(spinlock, test_spinlock_bounce)
 {


### PR DESCRIPTION
* Move `arch_interface.h` from `include/zephyr/sys/` to `include/zephyr/arch/` as this is related to the architecture and not system.
* Rename `arch_start_cpu()` to `arch_cpu_start()` to so it is under `cpu` namespace.