### PR TITLE
Update pin control bias mode for i2c3 pins for 

### DIFF
--- a/boards/arm/cy8cproto_062_4343w/cy8cproto_062_4343w-pinctrl.dtsi
+++ b/boards/arm/cy8cproto_062_4343w/cy8cproto_062_4343w-pinctrl.dtsi
@@ -29,6 +29,17 @@
 	input-enable;
 };
 
+/* Configure pin control bias mode for i2c3 pins */
+&p6_0_scb3_i2c_scl {
+	drive-open-drain;
+	input-enable;
+};
+
+&p6_1_scb3_i2c_sda {
+	drive-open-drain;
+	input-enable;
+};
+
 &pinctrl {
 	/* Configure pin control bias mode for SDIO */
 	p2_5_sdio_clk: p2_5_sdio_clk {

--- a/dts/bindings/i2c/infineon,cat1-i2c.yaml
+++ b/dts/bindings/i2c/infineon,cat1-i2c.yaml
@@ -3,7 +3,42 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-description: Infineon CAT1 I2C
+description: |
+  Infineon CAT1 I2C driver
+
+  This driver configures the SCB as an I2C device.
+
+  Example devicetree configuration with vl53l0x Time-of-Flight (ToF)
+  ranging sensor connected on the bus:
+
+  i2c3: &scb3 {
+      compatible = "infineon,cat1-i2c";
+      status = "okay";
+
+      #address-cells = <1>;
+      #size-cells = <0>;
+
+      pinctrl-0 = <&p6_0_scb3_i2c_scl &p6_1_scb3_i2c_sda>;
+      pinctrl-names = "default";
+
+      vl53l0x@29 {
+        compatible = "st,vl53l0x";
+        reg = <0x29>;
+      };
+  };
+
+  The pinctrl nodes need to be configured as open-drain and
+  input-enable:
+
+  &p6_0_scb3_i2c_scl {
+    drive-open-drain;
+    input-enable;
+  };
+
+  &p6_1_scb3_i2c_sda {
+    drive-open-drain;
+    input-enable;
+  };
 
 compatible: "infineon,cat1-i2c"
 


### PR DESCRIPTION
1. boards: arm: CY8CPROTO-062-4343W: update bias for i2c
```
&p6_0_scb3_i2c_scl {
	drive-open-drain;
	input-enable;
};

&p6_1_scb3_i2c_sda {
	drive-open-drain;
	input-enable;
};
```
2.  Update description for Infineon CAT1 i2c binding
-- added example of usage Infineon CAT1 i2c driver
-- added note that pinctrl nodes need to be configured as open-drain and input-enable.


Reference to Discord: https://discord.com/channels/720317445772017664/931248264018296863/1171467670055555134