### PR TITLE
doc: services: pm: fix function prototype for PM device support

### DIFF
--- a/doc/services/pm/device.rst
+++ b/doc/services/pm/device.rst
@@ -146,7 +146,7 @@ support in a device driver.
     #define DT_DRV_COMPAT dummy_device
 
     static int dummy_driver_pm_action(const struct device *dev,
-                                      enum pm_device_action *action)
+                                      enum pm_device_action action)
     {
         switch (action) {
         case PM_DEVICE_ACTION_SUSPEND:


### PR DESCRIPTION
Function prototype in PM device implementation documentation had the incorrect prototype for device power management. Fix this to align with the correct prototype.