### PR TITLE
cmake: calculate the md5 sum using the built-in string command

### DIFF
--- a/share/zephyr-package/cmake/zephyr_export.cmake
+++ b/share/zephyr-package/cmake/zephyr_export.cmake
@@ -8,15 +8,7 @@
 #
 # Create the reference by running `cmake -P zephyr_export.cmake` in this directory.
 
-set(MD5_INFILE "current_path.txt")
-
-# We write CMAKE_CURRENT_LIST_DIR into MD5_INFILE, as the content of that file will be used for MD5 calculation.
-# This means we effectively get the MD5 of CMAKE_CURRENT_LIST_DIR which must be used for CMake user package registry.
-file(WRITE ${CMAKE_CURRENT_LIST_DIR}/${MD5_INFILE} ${CMAKE_CURRENT_LIST_DIR})
-execute_process(COMMAND ${CMAKE_COMMAND} -E md5sum ${CMAKE_CURRENT_LIST_DIR}/${MD5_INFILE}
-                OUTPUT_VARIABLE MD5_SUM
-)
-string(SUBSTRING ${MD5_SUM} 0 32 MD5_SUM)
+string(MD5 MD5_SUM ${CMAKE_CURRENT_LIST_DIR})
 if(WIN32)
   execute_process(COMMAND ${CMAKE_COMMAND}
                   -E  write_regv

--- a/share/zephyrunittest-package/cmake/zephyr_export.cmake
+++ b/share/zephyrunittest-package/cmake/zephyr_export.cmake
@@ -8,15 +8,7 @@
 #
 # Create the reference by running `cmake -P zephyr_export.cmake` in this directory.
 
-set(MD5_INFILE "current_path.txt")
-
-# We write CMAKE_CURRENT_LIST_DIR into MD5_INFILE, as the content of that file will be used for MD5 calculation.
-# This means we effectively get the MD5 of CMAKE_CURRENT_LIST_DIR which must be used for CMake user package registry.
-file(WRITE ${CMAKE_CURRENT_LIST_DIR}/${MD5_INFILE} ${CMAKE_CURRENT_LIST_DIR})
-execute_process(COMMAND ${CMAKE_COMMAND} -E md5sum ${CMAKE_CURRENT_LIST_DIR}/${MD5_INFILE}
-                OUTPUT_VARIABLE MD5_SUM
-)
-string(SUBSTRING ${MD5_SUM} 0 32 MD5_SUM)
+string(MD5 MD5_SUM ${CMAKE_CURRENT_LIST_DIR})
 if(WIN32)
   execute_process(COMMAND ${CMAKE_COMMAND}
                   -E  write_regv


### PR DESCRIPTION
Assuming that all supported releases require at least CMake version 3.0, we should be able to calculate the md5sum in a much simpler way using string().
https://cmake.org/cmake/help/v3.0/command/string.html

This avoids writing a temporary file into the source directory and therefore mitigates the possibility of the following warning.

```    
share/zephyr-package/cmake/zephyr_export.cmake:19 (string):
  string sub-command SUBSTRING requires four arguments.
```
Fixes #64990