### PR TITLE
samples/tests: skip samples/tests disable MPU for s32ze series

### DIFF
--- a/samples/subsys/llext/shell_loader/sample.yaml
+++ b/samples/subsys/llext/shell_loader/sample.yaml
@@ -5,7 +5,7 @@ tests:
   sample.llext.shell:
     tags: shell llext
     harness: keyboard
-    filter: not CONFIG_CPU_HAS_MMU
+    filter: not CONFIG_CPU_HAS_MMU and not CONFIG_SOC_SERIES_S32ZE_R52
     arch_allow: arm
     extra_configs:
       - CONFIG_ARM_MPU=n

--- a/tests/subsys/llext/testcase.yaml
+++ b/tests/subsys/llext/testcase.yaml
@@ -2,7 +2,7 @@ common:
   tags: llext
 tests:
   llext.simple.arm:
-    filter: not CONFIG_CPU_HAS_MMU
+    filter: not CONFIG_CPU_HAS_MMU and not CONFIG_SOC_SERIES_S32ZE_R52
     arch_allow: arm
     extra_configs:
       - CONFIG_ARM_MPU=n


### PR DESCRIPTION
On SoC series s32ze, Zephyr application cannot run with MPU disabled, skipping relevant samples/tests

```
PS D:\upstream\zephyr> west twister -p s32z270dc2_rtu0_r52 -W --short-build-path -T .\tests\subsys\llext\ -T .\samples\subsys\llext\
Renaming output directory to D:\upstream\zephyr\twister-out.9
INFO    - Using Ninja..
INFO    - Zephyr version: zephyr-v3.5.0-1015-g2b3c7d0a4d89
INFO    - Using 'zephyr' toolchain.
INFO    - Building initial testsuite list...
INFO    - Writing JSON report D:\upstream\zephyr\twister-out\testplan.json
Junction created for D:\upstream\zephyr\twister-out\twister_links\test_0 <<===>> D:\upstream\zephyr\twister-out\s32z270dc2_rtu0_r52\tests\subsys\llext\llext.simple.arm
Junction created for D:\upstream\zephyr\twister-out\twister_links\test_1 <<===>> D:\upstream\zephyr\twister-out\s32z270dc2_rtu0_r52\samples\subsys\llext\shell_loader\sample.llext.shell
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - Total complete: ←[32m   2/   2←[39m  100%  skipped: ←[33m   2←[39m, failed: ←[39m   0←[39m, error: ←[39m   0←[39m
INFO    - 2 test scenarios (2 test instances) selected, 2 configurations skipped (0 by static filter, 2 at runtime).
INFO    - 0 of 2 test configurations passed (0.00%), 0 failed, 0 errored, 2 skipped with 0 warnings in 20.01 seconds
INFO    - In total 0 test cases were executed, 2 skipped on 1 out of total 636 platforms (0.16%)
INFO    - 0 test configurations executed on platforms, 0 test configurations were only built.
INFO    - Saving reports...
INFO    - Writing JSON report D:\upstream\zephyr\twister-out\twister.json
INFO    - Writing xunit report D:\upstream\zephyr\twister-out\twister.xml...
INFO    - Writing xunit report D:\upstream\zephyr\twister-out\twister_report.xml...
INFO    - Run completed
```