### PR TITLE
drivers: nxp_s32: add missing soc.h inclusion

### DIFF
--- a/drivers/interrupt_controller/intc_eirq_nxp_s32.c
+++ b/drivers/interrupt_controller/intc_eirq_nxp_s32.c
@@ -6,6 +6,7 @@
 
 #define DT_DRV_COMPAT nxp_s32_siul2_eirq
 
+#include <soc.h>
 #include <zephyr/irq.h>
 #include <zephyr/sys/sys_io.h>
 #include <zephyr/drivers/pinctrl.h>

--- a/drivers/serial/uart_nxp_s32_linflexd.c
+++ b/drivers/serial/uart_nxp_s32_linflexd.c
@@ -6,6 +6,7 @@
 
 #define DT_DRV_COMPAT nxp_s32_linflexd
 
+#include <soc.h>
 #include <zephyr/irq.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/drivers/pinctrl.h>


### PR DESCRIPTION
Some NXP S32 shim drivers are using macros defined in soc/arm/nxp_s32/*/soc.h but not including soc.h. Those still can be built because the header file is included indirectly by some other header files. This is very fragile, it should be included directly

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/64994

```
PS D:\upstream\zephyr> west twister -p mr_canhubk3 -W -T .\tests\subsys\llext\ -T .\samples\subsys\llext\ --short-build-path
INFO    - Using Ninja..
INFO    - Zephyr version: zephyr-v3.5.0-1015-gd464c935e4ff
INFO    - Using 'zephyr' toolchain.
INFO    - Building initial testsuite list...
INFO    - Writing JSON report D:\upstream\zephyr\twister-out\testplan.json
Junction created for D:\upstream\zephyr\twister-out\twister_links\test_0 <<===>> D:\upstream\zephyr\twister-out\mr_canhubk3\tests\subsys\llext\llext.simple.arm
Junction created for D:\upstream\zephyr\twister-out\twister_links\test_1 <<===>> D:\upstream\zephyr\twister-out\mr_canhubk3\samples\subsys\llext\shell_loader\sample.llext.shell
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - Total complete: ←[32m   2/   2←[39m  100%  skipped: ←[39m   0←[39m, failed: ←[39m   0←[39m, error: ←[39m   0←[39m
INFO    - 2 test scenarios (2 test instances) selected, 0 configurations skipped (0 by static filter, 0 at runtime).
INFO    - 2 of 2 test configurations passed (100.00%), 0 failed, 0 errored, 0 skipped with 0 warnings in 63.03 seconds
INFO    - In total 1 test cases were executed, 1 skipped on 1 out of total 636 platforms (0.16%)
INFO    - 0 test configurations executed on platforms, 2 test configurations were only built.
INFO    - Saving reports...
INFO    - Writing JSON report D:\upstream\zephyr\twister-out\twister.json
INFO    - Writing xunit report D:\upstream\zephyr\twister-out\twister.xml...
INFO    - Writing xunit report D:\upstream\zephyr\twister-out\twister_report.xml...
INFO    - Run completed
```