### PR TITLE
[RFC] Add mipi_dsi_detach API

### DIFF
--- a/boards/shields/g1120b0mipi/boards/mimxrt595_evk_cm33.overlay
+++ b/boards/shields/g1120b0mipi/boards/mimxrt595_evk_cm33.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2023, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Change deep sleep config for suspend mode to keep SMARTDMA ram powered,
+ * so the SMARTDMA will continue functioning after deep sleep
+ */
+&suspend {
+	deep-sleep-config = <0xC800>,
+				<0x80030004>,
+				<0xFFFFFFFF>,
+				<0>;
+};

--- a/include/zephyr/drivers/mipi_dsi.h
+++ b/include/zephyr/drivers/mipi_dsi.h
@@ -18,6 +18,7 @@
  * @ingroup io_interfaces
  * @{
  */
+#include <errno.h>
 #include <sys/types.h>
 #include <zephyr/device.h>
 #include <zephyr/dt-bindings/mipi_dsi/mipi_dsi.h>
@@ -247,6 +248,8 @@ __subsystem struct mipi_dsi_driver_api {
 		      const struct mipi_dsi_device *mdev);
 	ssize_t (*transfer)(const struct device *dev, uint8_t channel,
 			    struct mipi_dsi_msg *msg);
+	int (*detach)(const struct device *dev, uint8_t channel,
+		      const struct mipi_dsi_device *mdev);
 };
 
 /**
@@ -341,6 +344,29 @@ ssize_t mipi_dsi_dcs_read(const struct device *dev, uint8_t channel,
  */
 ssize_t mipi_dsi_dcs_write(const struct device *dev, uint8_t channel,
 			   uint8_t cmd, const void *buf, size_t len);
+
+
+/**
+ * @brief Detach a device from the MIPI-DSI bus
+ *
+ * @param dev MIPI-DSI host device.
+ * @param channel Device channel (VID).
+ * @param mdev MIPI-DSI device description.
+ *
+ * @return 0 on success, negative on error
+ */
+static inline int mipi_dsi_detach(const struct device *dev,
+				  uint8_t channel,
+				  const struct mipi_dsi_device *mdev)
+{
+	const struct mipi_dsi_driver_api *api = (const struct mipi_dsi_driver_api *)dev->api;
+
+	if (api->detach == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->detach(dev, channel, mdev);
+}
 
 #ifdef __cplusplus
 }

--- a/samples/drivers/display/sample.yaml
+++ b/samples/drivers/display/sample.yaml
@@ -131,3 +131,14 @@ tests:
     harness: console
     harness_config:
       fixture: fixture_display
+  sample.display.g1120b0mipi:
+    platform_allow: mimxrt595_evk_cm33
+    tags: display
+    harness: console
+    extra_args: SHIELD=g1120b0mipi
+    extra_configs:
+      - CONFIG_PM=y
+      - CONFIG_PM_DEVICE=y
+      - CONFIG_IDLE_STACK_SIZE=400
+    harness_config:
+      fixture: fixture_display

--- a/soc/arm/nxp_imx/rt5xx/soc.c
+++ b/soc/arm/nxp_imx/rt5xx/soc.c
@@ -469,6 +469,17 @@ void __weak imxrt_post_init_display_interface(void)
 	/* Deassert MIPI DPHY reset. */
 	RESET_ClearPeripheralReset(kMIPI_DSI_PHY_RST_SHIFT_RSTn);
 }
+
+void __weak imxrt_deinit_display_interface(void)
+{
+	/* Assert MIPI DPHY and DSI reset */
+	RESET_SetPeripheralReset(kMIPI_DSI_PHY_RST_SHIFT_RSTn);
+	RESET_SetPeripheralReset(kMIPI_DSI_CTRL_RST_SHIFT_RSTn);
+	/* Remove clock from DPHY */
+	CLOCK_AttachClk(kNONE_to_MIPI_DPHY_CLK);
+}
+
+
 #endif
 
 /**

--- a/soc/arm/nxp_imx/rt5xx/soc.h
+++ b/soc/arm/nxp_imx/rt5xx/soc.h
@@ -80,6 +80,8 @@
 void imxrt_pre_init_display_interface(void);
 
 void imxrt_post_init_display_interface(void);
+
+void imxrt_deinit_display_interface(void);
 #endif
 
 #endif


### PR DESCRIPTION
This PR proposes a new `mipi_dsi_detach` API for the MIPI subsystem, very similar to the `mipi_dsi_detach` API currently present in Linux. The primary goal of this API is to provide power savings, by allowing the MIPI DPHY to power off when not in use. An implementation is provided for the DSI_MCUX_2L driver. Detaching the MIPI saves roughly 2mA of current consumption on the VDDCORE voltage rail in my tests.

The PR also includes the following changes:
- device level power management for the RM67162 display, so that the MIPI can be detached whenever the display enters sleep mode. This could also be added to the `blanking_on` and `blanking_off` functions for the display.
- additional overlay for the G1120B0MIPI to enable testing the display in low power modes

An alternative to this approach would be to use device level runtime power management for the MIPI DSI driver. The reason I did not take this approach was that the display controller driver itself will likely have the best awareness of when the MIPI DSI can be detached and the DPHY can be powered down, so exposing the functionality to the display controller made the most sense