### PR TITLE
boards: thingy52: add missing mpu9250 support

### DIFF
--- a/boards/arm/thingy52_nrf52832/thingy52_nrf52832.dts
+++ b/boards/arm/thingy52_nrf52832/thingy52_nrf52832.dts
@@ -91,7 +91,8 @@
 		compatible = "regulator-fixed";
 		regulator-name = "mpu-pwr-ctrl";
 		enable-gpios = <&sx1509b 8 GPIO_ACTIVE_HIGH>;
-		status = "disabled";
+		status = "okay";
+		startup-delay-us = <100000>;
 	};
 
 	mic_pwr: mic-pwr-ctrl {
@@ -170,6 +171,19 @@
 		irq-gpios = <&gpio0 22 GPIO_ACTIVE_LOW>;
 		reset-gpios = <&sx1509b 11 GPIO_ACTIVE_LOW>;
 		wake-gpios = <&sx1509b 12 GPIO_ACTIVE_LOW>;
+	};
+
+	mpu9250: mpu9250@68 {
+		compatible = "invensense,mpu9250";
+		reg = <0x68>;
+		vin-supply = <&mpu_pwr>;
+		status = "okay";
+		irq-gpios = <&gpio0 06 GPIO_ACTIVE_HIGH>;
+		gyro-sr-div = <10>;
+		gyro-dlpf = <5>;
+		gyro-fs = <250>;
+		accel-fs = <2>;
+		accel-dlpf = "5.05";
 	};
 };
 


### PR DESCRIPTION
The Thingy:52 has a mpu9250, a 9 axis motion sensor, on the I2C bus. Add the necessary description on devicetree and config the mpu_pwr regulator.

Resubmit of #64700