### PR TITLE
logging: uart: get device from dedicated `zephyr,log-uart` node

### DIFF
--- a/boards/arc/em_starterkit/em_starterkit.dts
+++ b/boards/arc/em_starterkit/em_starterkit.dts
@@ -25,6 +25,7 @@
 	chosen {
 		zephyr,sram = &dccm0;
 		zephyr,console = &uart1;
+		zephyr,log-uart = &uart1;
 		zephyr,shell-uart = &uart1;
 	};
 

--- a/boards/arc/em_starterkit/em_starterkit_em11d.dts
+++ b/boards/arc/em_starterkit/em_starterkit_em11d.dts
@@ -25,6 +25,7 @@
 	chosen {
 		zephyr,sram = &ddr0;
 		zephyr,console = &uart1;
+		zephyr,log-uart = &uart1;
 		zephyr,shell-uart = &uart1;
 	};
 

--- a/boards/arc/em_starterkit/em_starterkit_em7d.dts
+++ b/boards/arc/em_starterkit/em_starterkit_em7d.dts
@@ -25,6 +25,7 @@
 	chosen {
 		zephyr,sram = &dccm0;
 		zephyr,console = &uart1;
+		zephyr,log-uart = &uart1;
 		zephyr,shell-uart = &uart1;
 	};
 

--- a/boards/arc/em_starterkit/em_starterkit_em7d_v22.dts
+++ b/boards/arc/em_starterkit/em_starterkit_em7d_v22.dts
@@ -24,6 +24,7 @@
 	chosen {
 		zephyr,sram = &dccm0;
 		zephyr,console = &uart1;
+		zephyr,log-uart = &uart1;
 		zephyr,shell-uart = &uart1;
 	};
 

--- a/boards/arc/emsdp/emsdp.dts
+++ b/boards/arc/emsdp/emsdp.dts
@@ -23,6 +23,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 	};
 };

--- a/boards/arc/emsdp/emsdp_em4.dts
+++ b/boards/arc/emsdp/emsdp_em4.dts
@@ -21,6 +21,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 	};
 };

--- a/boards/arc/emsdp/emsdp_em5d.dts
+++ b/boards/arc/emsdp/emsdp_em5d.dts
@@ -21,6 +21,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 	};
 };

--- a/boards/arc/emsdp/emsdp_em6.dts
+++ b/boards/arc/emsdp/emsdp_em6.dts
@@ -21,6 +21,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 	};
 };

--- a/boards/arc/emsdp/emsdp_em7d.dts
+++ b/boards/arc/emsdp/emsdp_em7d.dts
@@ -21,6 +21,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 	};
 };

--- a/boards/arc/emsdp/emsdp_em7d_esp.dts
+++ b/boards/arc/emsdp/emsdp_em7d_esp.dts
@@ -21,6 +21,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 	};
 };

--- a/boards/arc/emsdp/emsdp_em9d.dts
+++ b/boards/arc/emsdp/emsdp_em9d.dts
@@ -22,6 +22,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 	};
 

--- a/boards/arc/hsdk/hsdk.dtsi
+++ b/boards/arc/hsdk/hsdk.dtsi
@@ -41,6 +41,7 @@
 	chosen {
 		zephyr,sram = &ddr0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 	};
 

--- a/boards/arc/hsdk4xd/hsdk4xd.dtsi
+++ b/boards/arc/hsdk4xd/hsdk4xd.dtsi
@@ -17,6 +17,7 @@
 	chosen {
 		zephyr,sram = &ddr0;
 		zephyr,console = &uart_dbg;
+		zephyr,log-uart = &uart_dbg;
 		zephyr,shell-uart = &uart_dbg;
 	};
 

--- a/boards/arc/iotdk/iotdk.dts
+++ b/boards/arc/iotdk/iotdk.dts
@@ -22,6 +22,7 @@
 		zephyr,sram = &dccm0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 	};
 

--- a/boards/arc/nsim/nsim-uart-hostlink.dtsi
+++ b/boards/arc/nsim/nsim-uart-hostlink.dtsi
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &hostlink;
+		zephyr,log-uart = &hostlink;
 		zephyr,shell-uart = &hostlink;
 	};
 };

--- a/boards/arc/nsim/nsim-uart-ns16550.dtsi
+++ b/boards/arc/nsim/nsim-uart-ns16550.dtsi
@@ -23,6 +23,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 	};
 };

--- a/boards/arc/qemu_arc/qemu_arc.dtsi
+++ b/boards/arc/qemu_arc/qemu_arc.dtsi
@@ -71,6 +71,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &ns16550_uart0;
+		zephyr,log-uart = &ns16550_uart0;
 		zephyr,shell-uart = &ns16550_uart0;
 		zephyr,uart-pipe = &ns16550_uart1;
 	};

--- a/boards/arm/96b_aerocore2/96b_aerocore2.dts
+++ b/boards/arm/96b_aerocore2/96b_aerocore2.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart7;
+		zephyr,log-uart = &uart7;
 		zephyr,shell-uart = &uart7;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/96b_argonkey/96b_argonkey.dts
+++ b/boards/arm/96b_argonkey/96b_argonkey.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/96b_avenger96/96b_avenger96.dts
+++ b/boards/arm/96b_avenger96/96b_avenger96.dts
@@ -20,6 +20,7 @@
 		 * 96b_avenger96_defconfig. Refer "Serial Port" section in
 		 * Zephyr board documentation.
 		 * zephyr,console = &uart7;
+		 * zephyr,log-uart = &uart7;
 		 * zephyr,shell-uart = &uart7;
 		 */
 		zephyr,flash = &retram;

--- a/boards/arm/96b_carbon/96b_carbon.dts
+++ b/boards/arm/96b_carbon/96b_carbon.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/96b_carbon_nrf51/96b_carbon_nrf51.dts
+++ b/boards/arm/96b_carbon_nrf51/96b_carbon_nrf51.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,bt-mon-uart = &uart0;
 		zephyr,sram = &sram0;

--- a/boards/arm/96b_meerkat96/96b_meerkat96.dts
+++ b/boards/arm/96b_meerkat96/96b_meerkat96.dts
@@ -16,6 +16,7 @@
 		zephyr,flash = &tcml_code;
 		zephyr,sram = &tcmu_sys;
 		zephyr,console = &uart1;
+		zephyr,log-uart = &uart1;
 		zephyr,shell-uart = &uart1;
 	};
 

--- a/boards/arm/96b_neonkey/96b_neonkey.dts
+++ b/boards/arm/96b_neonkey/96b_neonkey.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/96b_nitrogen/96b_nitrogen.dts
+++ b/boards/arm/96b_nitrogen/96b_nitrogen.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,bt-mon-uart = &uart0;
 		zephyr,bt-c2h-uart = &uart0;

--- a/boards/arm/96b_stm32_sensor_mez/96b_stm32_sensor_mez.dts
+++ b/boards/arm/96b_stm32_sensor_mez/96b_stm32_sensor_mez.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart4;
+		zephyr,log-uart = &uart4;
 		zephyr,shell-uart = &uart4;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/96b_wistrio/96b_wistrio.dts
+++ b/boards/arm/96b_wistrio/96b_wistrio.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/acn52832/acn52832.dts
+++ b/boards/arm/acn52832/acn52832.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,bt-mon-uart = &uart0;
 		zephyr,bt-c2h-uart = &uart0;

--- a/boards/arm/actinius_icarus/actinius_icarus_common.dtsi
+++ b/boards/arm/actinius_icarus/actinius_icarus_common.dtsi
@@ -12,6 +12,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 	};

--- a/boards/arm/actinius_icarus_bee/actinius_icarus_bee_common.dtsi
+++ b/boards/arm/actinius_icarus_bee/actinius_icarus_bee_common.dtsi
@@ -12,6 +12,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 	};

--- a/boards/arm/actinius_icarus_som/actinius_icarus_som_common.dtsi
+++ b/boards/arm/actinius_icarus_som/actinius_icarus_som_common.dtsi
@@ -11,6 +11,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 	};

--- a/boards/arm/actinius_icarus_som_dk/actinius_icarus_som_dk_common.dtsi
+++ b/boards/arm/actinius_icarus_som_dk/actinius_icarus_som_dk_common.dtsi
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 	};

--- a/boards/arm/adafruit_feather_m0_basic_proto/adafruit_feather_m0_basic_proto.dts
+++ b/boards/arm/adafruit_feather_m0_basic_proto/adafruit_feather_m0_basic_proto.dts
@@ -17,6 +17,7 @@
 
 	chosen {
 		zephyr,console = &sercom0;
+		zephyr,log-uart = &sercom0;
 		zephyr,shell-uart = &sercom0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/adafruit_feather_m0_lora/adafruit_feather_m0_lora.dts
+++ b/boards/arm/adafruit_feather_m0_lora/adafruit_feather_m0_lora.dts
@@ -17,6 +17,7 @@
 
 	chosen {
 		zephyr,console = &sercom0;
+		zephyr,log-uart = &sercom0;
 		zephyr,shell-uart = &sercom0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/adafruit_feather_nrf52840/adafruit_feather_nrf52840.dts
+++ b/boards/arm/adafruit_feather_nrf52840/adafruit_feather_nrf52840.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/adafruit_feather_stm32f405/adafruit_feather_stm32f405.dts
+++ b/boards/arm/adafruit_feather_stm32f405/adafruit_feather_stm32f405.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &usart3;
+		zephyr,log-uart = &usart3;
 		zephyr,shell-uart = &usart3;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/adafruit_itsybitsy_m4_express/adafruit_itsybitsy_m4_express.dts
+++ b/boards/arm/adafruit_itsybitsy_m4_express/adafruit_itsybitsy_m4_express.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &sercom3;
+		zephyr,log-uart = &sercom3;
 		zephyr,shell-uart = &sercom3;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/adafruit_itsybitsy_nrf52840/adafruit_itsybitsy_nrf52840.dts
+++ b/boards/arm/adafruit_itsybitsy_nrf52840/adafruit_itsybitsy_nrf52840.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &cdc_acm_uart0;
+		zephyr,log-uart = &cdc_acm_uart0;
 		zephyr,shell-uart = &cdc_acm_uart0;
 		zephyr,uart-mcumgr = &cdc_acm_uart0;
 		zephyr,bt-mon-uart = &cdc_acm_uart0;

--- a/boards/arm/adafruit_kb2040/adafruit_kb2040.dts
+++ b/boards/arm/adafruit_kb2040/adafruit_kb2040.dts
@@ -18,6 +18,7 @@
 		zephyr,flash = &flash0;
 		zephyr,flash-controller = &ssi;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,code-partition = &code_partition;
 	};

--- a/boards/arm/adafruit_trinket_m0/adafruit_trinket_m0.dts
+++ b/boards/arm/adafruit_trinket_m0/adafruit_trinket_m0.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &sercom0;
+		zephyr,log-uart = &sercom0;
 		zephyr,shell-uart = &sercom0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/am62x_m4/am62x_m4_phyboard_lyra.dts
+++ b/boards/arm/am62x_m4/am62x_m4_phyboard_lyra.dts
@@ -16,6 +16,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram1 = &ddr0;
 	};

--- a/boards/arm/am62x_m4/am62x_m4_sk.dts
+++ b/boards/arm/am62x_m4/am62x_m4_sk.dts
@@ -15,6 +15,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram1 = &ddr0;
 	};

--- a/boards/arm/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb.dts
+++ b/boards/arm/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb.dts
@@ -11,6 +11,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-pipe = &uart0;
 		zephyr,flash-controller = &flash;

--- a/boards/arm/apollo4p_evb/apollo4p_evb.dts
+++ b/boards/arm/apollo4p_evb/apollo4p_evb.dts
@@ -11,6 +11,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-pipe = &uart0;
 	};

--- a/boards/arm/arduino_due/arduino_due.dts
+++ b/boards/arm/arduino_due/arduino_due.dts
@@ -22,6 +22,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart;
+		zephyr,log-uart = &uart;
 		zephyr,shell-uart = &uart;
 	};
 

--- a/boards/arm/arduino_giga_r1/arduino_giga_r1_m4.dts
+++ b/boards/arm/arduino_giga_r1/arduino_giga_r1_m4.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram1;
 		zephyr,flash = &flash1;

--- a/boards/arm/arduino_giga_r1/arduino_giga_r1_m7.dts
+++ b/boards/arm/arduino_giga_r1/arduino_giga_r1_m7.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,uart-mcumgr = &usart1;
 		zephyr,bt-uart = &uart7;

--- a/boards/arm/arduino_mkrzero/arduino_mkrzero.dts
+++ b/boards/arm/arduino_mkrzero/arduino_mkrzero.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &sercom5;
+		zephyr,log-uart = &sercom5;
 		zephyr,shell-uart = &sercom5;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/arduino_nano_33_ble/arduino_nano_33_ble-common.dtsi
+++ b/boards/arm/arduino_nano_33_ble/arduino_nano_33_ble-common.dtsi
@@ -7,6 +7,7 @@
 / {
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/arduino_nano_33_iot/arduino_nano_33_iot.dts
+++ b/boards/arm/arduino_nano_33_iot/arduino_nano_33_iot.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &sercom5;
+		zephyr,log-uart = &sercom5;
 		zephyr,shell-uart = &sercom5;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/arduino_nicla_sense_me/arduino_nicla_sense_me.dts
+++ b/boards/arm/arduino_nicla_sense_me/arduino_nicla_sense_me.dts
@@ -25,6 +25,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/arduino_portenta_h7/arduino_portenta_h7_m4.dts
+++ b/boards/arm/arduino_portenta_h7/arduino_portenta_h7_m4.dts
@@ -17,6 +17,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram1;
 		zephyr,flash = &flash1;

--- a/boards/arm/arduino_portenta_h7/arduino_portenta_h7_m7.dts
+++ b/boards/arm/arduino_portenta_h7/arduino_portenta_h7_m7.dts
@@ -16,6 +16,7 @@
 	/* HW resources are split between CM7 and CM4 */
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/arduino_uno_r4/arduino_uno_r4_minima.dts
+++ b/boards/arm/arduino_uno_r4/arduino_uno_r4_minima.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &uart2;
+		zephyr,log-uart = &uart2;
 		zephyr,shell-uart = &uart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/arduino_zero/arduino_zero.dts
+++ b/boards/arm/arduino_zero/arduino_zero.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &sercom5;
+		zephyr,log-uart = &sercom5;
 		zephyr,shell-uart = &sercom5;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/arty/dts/arty_a7_arm_designstart.dtsi
+++ b/boards/arm/arty/dts/arty_a7_arm_designstart.dtsi
@@ -11,6 +11,7 @@
 / {
 	chosen {
 		zephyr,console = &uartlite0;
+		zephyr,log-uart = &uartlite0;
 		zephyr,shell-uart = &uartlite0;
 		zephyr,flash = &itcm;
 		/* Use DTCM as SRAM by default */

--- a/boards/arm/ast1030_evb/ast1030_evb.dts
+++ b/boards/arm/ast1030_evb/ast1030_evb.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &uart5;
+		zephyr,log-uart = &uart5;
 		zephyr,shell-uart = &uart5;
 		zephyr,sram = &sram0;
 	};

--- a/boards/arm/atsamc21n_xpro/atsamc21n_xpro.dts
+++ b/boards/arm/atsamc21n_xpro/atsamc21n_xpro.dts
@@ -17,6 +17,7 @@
 
 	chosen {
 		zephyr,console = &sercom4;
+		zephyr,log-uart = &sercom4;
 		zephyr,shell-uart = &sercom4;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/atsamd20_xpro/atsamd20_xpro.dts
+++ b/boards/arm/atsamd20_xpro/atsamd20_xpro.dts
@@ -17,6 +17,7 @@
 
 	chosen {
 		zephyr,console = &sercom3;
+		zephyr,log-uart = &sercom3;
 		zephyr,shell-uart = &sercom3;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/atsamd21_xpro/atsamd21_xpro.dts
+++ b/boards/arm/atsamd21_xpro/atsamd21_xpro.dts
@@ -17,6 +17,7 @@
 
 	chosen {
 		zephyr,console = &sercom3;
+		zephyr,log-uart = &sercom3;
 		zephyr,shell-uart = &sercom3;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/atsame54_xpro/atsame54_xpro.dts
+++ b/boards/arm/atsame54_xpro/atsame54_xpro.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &sercom2;
+		zephyr,log-uart = &sercom2;
 		zephyr,shell-uart = &sercom2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/atsaml21_xpro/atsaml21_xpro.dts
+++ b/boards/arm/atsaml21_xpro/atsaml21_xpro.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &sercom3;
+		zephyr,log-uart = &sercom3;
 		zephyr,shell-uart = &sercom3;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/atsamr21_xpro/atsamr21_xpro.dts
+++ b/boards/arm/atsamr21_xpro/atsamr21_xpro.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &sercom0;
+		zephyr,log-uart = &sercom0;
 		zephyr,shell-uart = &sercom0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/atsamr34_xpro/atsamr34_xpro.dts
+++ b/boards/arm/atsamr34_xpro/atsamr34_xpro.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &sercom0;
+		zephyr,log-uart = &sercom0;
 		zephyr,shell-uart = &sercom0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/az3166_iotdevkit/az3166_iotdevkit.dts
+++ b/boards/arm/az3166_iotdevkit/az3166_iotdevkit.dts
@@ -29,6 +29,7 @@
 
 	chosen {
 		zephyr,console = &usart6;
+		zephyr,log-uart = &usart6;
 		zephyr,shell-uart = &usart6;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/b_g474e_dpow1/b_g474e_dpow1.dts
+++ b/boards/arm/b_g474e_dpow1/b_g474e_dpow1.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &usart3;
+		zephyr,log-uart = &usart3;
 		zephyr,shell-uart = &usart3;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/b_l072z_lrwan1/b_l072z_lrwan1.dts
+++ b/boards/arm/b_l072z_lrwan1/b_l072z_lrwan1.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
+++ b/boards/arm/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/b_u585i_iot02a/b_u585i_iot02a.dts
+++ b/boards/arm/b_u585i_iot02a/b_u585i_iot02a.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/b_u585i_iot02a/b_u585i_iot02a_ns.dts
+++ b/boards/arm/b_u585i_iot02a/b_u585i_iot02a_ns.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/bbc_microbit/bbc_microbit.dts
+++ b/boards/arm/bbc_microbit/bbc_microbit.dts
@@ -24,6 +24,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,bt-mon-uart = &uart0;
 		zephyr,bt-c2h-uart = &uart0;

--- a/boards/arm/bbc_microbit_v2/bbc_microbit_v2.dts
+++ b/boards/arm/bbc_microbit_v2/bbc_microbit_v2.dts
@@ -24,6 +24,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,bt-mon-uart = &uart0;
 		zephyr,bt-c2h-uart = &uart0;

--- a/boards/arm/bcm958401m2/bcm958401m2.dts
+++ b/boards/arm/bcm958401m2/bcm958401m2.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &uart1;
+		zephyr,log-uart = &uart1;
 		zephyr,shell-uart = &uart1;
 		zephyr,sram = &sram0;
 	};

--- a/boards/arm/bcm958402m2_m7/bcm958402m2_m7.dts
+++ b/boards/arm/bcm958402m2_m7/bcm958402m2_m7.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart1;
+		zephyr,log-uart = &uart1;
 		zephyr,shell-uart = &uart1;
 		zephyr,sram = &sram0;
 	};

--- a/boards/arm/beagle_bcf/beagleconnect_freedom.dts
+++ b/boards/arm/beagle_bcf/beagleconnect_freedom.dts
@@ -29,6 +29,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
 		zephyr,ieee802154 = &ieee802154g;

--- a/boards/arm/bl5340_dvk/bl5340_dvk_cpuapp_common.dtsi
+++ b/boards/arm/bl5340_dvk/bl5340_dvk_cpuapp_common.dtsi
@@ -10,6 +10,7 @@
 / {
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/bl5340_dvk/bl5340_dvk_cpunet.dts
+++ b/boards/arm/bl5340_dvk/bl5340_dvk_cpunet.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/bl652_dvk/bl652_dvk.dts
+++ b/boards/arm/bl652_dvk/bl652_dvk.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/bl653_dvk/bl653_dvk.dts
+++ b/boards/arm/bl653_dvk/bl653_dvk.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/bl654_dvk/bl654_dvk.dts
+++ b/boards/arm/bl654_dvk/bl654_dvk.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/bl654_sensor_board/bl654_sensor_board.dts
+++ b/boards/arm/bl654_sensor_board/bl654_sensor_board.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/bl654_usb/bl654_usb.dts
+++ b/boards/arm/bl654_usb/bl654_usb.dts
@@ -16,6 +16,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &bl654_cdc_acm_uart;
+		zephyr,log-uart = &bl654_cdc_acm_uart;
 		zephyr,shell-uart = &bl654_cdc_acm_uart;
 		zephyr,bt-c2h-uart = &bl654_cdc_acm_uart;
 		zephyr,code-partition = &slot0_partition;

--- a/boards/arm/black_f407ve/black_f407ve.dts
+++ b/boards/arm/black_f407ve/black_f407ve.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/black_f407zg_pro/black_f407zg_pro.dts
+++ b/boards/arm/black_f407zg_pro/black_f407zg_pro.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/blackpill_f401cc/blackpill_f401cc.dts
+++ b/boards/arm/blackpill_f401cc/blackpill_f401cc.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/blackpill_f401ce/blackpill_f401ce.dts
+++ b/boards/arm/blackpill_f401ce/blackpill_f401ce.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/blackpill_f411ce/blackpill_f411ce.dts
+++ b/boards/arm/blackpill_f411ce/blackpill_f411ce.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/blueclover_plt_demo_v2_nrf52832/blueclover_plt_demo_v2_nrf52832.dts
+++ b/boards/arm/blueclover_plt_demo_v2_nrf52832/blueclover_plt_demo_v2_nrf52832.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/bt510/bt510.dts
+++ b/boards/arm/bt510/bt510.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/bt610/bt610.dts
+++ b/boards/arm/bt610/bt610.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/cc1352p1_launchxl/cc1352p1_launchxl.dts
+++ b/boards/arm/cc1352p1_launchxl/cc1352p1_launchxl.dts
@@ -29,6 +29,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,ieee802154 = &ieee802154;
 		zephyr,code-partition = &slot0_partition;

--- a/boards/arm/cc1352r1_launchxl/cc1352r1_launchxl.dts
+++ b/boards/arm/cc1352r1_launchxl/cc1352r1_launchxl.dts
@@ -31,6 +31,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,ieee802154 = &ieee802154;
 		zephyr,code-partition = &slot0_partition;

--- a/boards/arm/cc1352r_sensortag/cc1352r_sensortag.dts
+++ b/boards/arm/cc1352r_sensortag/cc1352r_sensortag.dts
@@ -37,6 +37,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,ieee802154 = &ieee802154;
 		zephyr,code-partition = &slot0_partition;

--- a/boards/arm/cc26x2r1_launchxl/cc26x2r1_launchxl.dts
+++ b/boards/arm/cc26x2r1_launchxl/cc26x2r1_launchxl.dts
@@ -31,6 +31,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,code-partition = &slot0_partition;
 	};

--- a/boards/arm/cc3220sf_launchxl/cc3220sf_launchxl.dts
+++ b/boards/arm/cc3220sf_launchxl/cc3220sf_launchxl.dts
@@ -28,6 +28,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash1;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 	};
 

--- a/boards/arm/cc3235sf_launchxl/cc3235sf_launchxl.dts
+++ b/boards/arm/cc3235sf_launchxl/cc3235sf_launchxl.dts
@@ -31,6 +31,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash1;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 	};
 

--- a/boards/arm/circuitdojo_feather_nrf9160/circuitdojo_feather_nrf9160_common.dtsi
+++ b/boards/arm/circuitdojo_feather_nrf9160/circuitdojo_feather_nrf9160_common.dtsi
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 	};

--- a/boards/arm/colibri_imx7d_m4/colibri_imx7d_m4.dts
+++ b/boards/arm/colibri_imx7d_m4/colibri_imx7d_m4.dts
@@ -23,6 +23,7 @@
 		zephyr,flash = &tcml_code;
 		zephyr,sram = &tcmu_sys;
 		zephyr,console = &uart2;
+		zephyr,log-uart = &uart2;
 		zephyr,shell-uart = &uart2;
 	};
 

--- a/boards/arm/contextualelectronics_abc/contextualelectronics_abc.dts
+++ b/boards/arm/contextualelectronics_abc/contextualelectronics_abc.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/cy8ckit_062_ble/cy8ckit_062_ble_m0_0_0_0.overlay
+++ b/boards/arm/cy8ckit_062_ble/cy8ckit_062_ble_m0_0_0_0.overlay
@@ -11,6 +11,7 @@
 
 	chosen {
 		zephyr,console = &uart5;
+		zephyr,log-uart = &uart5;
 		zephyr,shell-uart = &uart5;
 	};
 };

--- a/boards/arm/cy8ckit_062_ble/cy8ckit_062_ble_m0_1_0_0.overlay
+++ b/boards/arm/cy8ckit_062_ble/cy8ckit_062_ble_m0_1_0_0.overlay
@@ -11,6 +11,7 @@
 
 	chosen {
 		zephyr,console = &uart2;
+		zephyr,log-uart = &uart2;
 		zephyr,shell-uart = &uart2;
 	};
 };

--- a/boards/arm/cy8ckit_062_ble/cy8ckit_062_ble_m4_0_0_0.overlay
+++ b/boards/arm/cy8ckit_062_ble/cy8ckit_062_ble_m4_0_0_0.overlay
@@ -11,6 +11,7 @@
 
 	chosen {
 		zephyr,console = &uart6;
+		zephyr,log-uart = &uart6;
 		zephyr,shell-uart = &uart6;
 	};
 };

--- a/boards/arm/cy8ckit_062_wifi_bt/cy8ckit_062_wifi_bt_m0.dts
+++ b/boards/arm/cy8ckit_062_wifi_bt/cy8ckit_062_wifi_bt_m0.dts
@@ -24,6 +24,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart6;
+		zephyr,log-uart = &uart6;
 		zephyr,shell-uart = &uart6;
 	};
 

--- a/boards/arm/cy8ckit_062_wifi_bt/cy8ckit_062_wifi_bt_m4.dts
+++ b/boards/arm/cy8ckit_062_wifi_bt/cy8ckit_062_wifi_bt_m4.dts
@@ -20,6 +20,7 @@
 		zephyr,sram = &sram2;
 		zephyr,flash = &flash1;
 		zephyr,console = &uart5;
+		zephyr,log-uart = &uart5;
 		zephyr,shell-uart = &uart5;
 	};
 };

--- a/boards/arm/cy8ckit_062s4/cy8ckit_062s4_m4.dts
+++ b/boards/arm/cy8ckit_062s4/cy8ckit_062s4_m4.dts
@@ -13,6 +13,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart2;
+		zephyr,log-uart = &uart2;
 		zephyr,shell-uart = &uart2;
 	};
 

--- a/boards/arm/cy8cproto_062_4343w/cy8cproto_062_4343w.dts
+++ b/boards/arm/cy8cproto_062_4343w/cy8cproto_062_4343w.dts
@@ -23,6 +23,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart5;
+		zephyr,log-uart = &uart5;
 		zephyr,shell-uart = &uart5;
 		zephyr,bt_uart = &uart2;
 	};

--- a/boards/arm/cy8cproto_063_ble/cy8cproto_063_ble.dts
+++ b/boards/arm/cy8cproto_063_ble/cy8cproto_063_ble.dts
@@ -26,6 +26,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart5;
+		zephyr,log-uart = &uart5;
 		zephyr,shell-uart = &uart5;
 	};
 

--- a/boards/arm/da14695_dk_usb/da14695_dk_usb.dts
+++ b/boards/arm/da14695_dk_usb/da14695_dk_usb.dts
@@ -18,6 +18,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart;
+		zephyr,log-uart = &uart;
 		zephyr,shell-uart = &uart;
 		zephyr,code-partition = &slot0_partition;
 	};

--- a/boards/arm/da1469x_dk_pro/da1469x_dk_pro.dts
+++ b/boards/arm/da1469x_dk_pro/da1469x_dk_pro.dts
@@ -17,6 +17,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart;
+		zephyr,log-uart = &uart;
 		zephyr,shell-uart = &uart;
 		zephyr,code-partition = &slot0_partition;
 	};

--- a/boards/arm/degu_evk/degu_evk.dts
+++ b/boards/arm/degu_evk/degu_evk.dts
@@ -17,6 +17,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &degu_cdc_acm_uart;
+		zephyr,log-uart = &degu_cdc_acm_uart;
 		zephyr,shell-uart = &degu_cdc_acm_uart;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,ieee802154 = &ieee802154;

--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/dragino_lsn50/dragino_lsn50.dts
+++ b/boards/arm/dragino_lsn50/dragino_lsn50.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/dragino_nbsn95/dragino_nbsn95.dts
+++ b/boards/arm/dragino_nbsn95/dragino_nbsn95.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/ebyte_e73_tbb_nrf52832/ebyte_e73_tbb_nrf52832.dts
+++ b/boards/arm/ebyte_e73_tbb_nrf52832/ebyte_e73_tbb_nrf52832.dts
@@ -17,6 +17,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/efm32gg_sltb009a/efm32gg_sltb009a.dts
+++ b/boards/arm/efm32gg_sltb009a/efm32gg_sltb009a.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &usart0;
+		zephyr,log-uart = &usart0;
 		zephyr,shell-uart = &usart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/efm32gg_slwstk6121a/efm32gg_slwstk6121a.dts
+++ b/boards/arm/efm32gg_slwstk6121a/efm32gg_slwstk6121a.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &usart0;
+		zephyr,log-uart = &usart0;
 		zephyr,shell-uart = &usart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/efm32gg_stk3701a/efm32gg_stk3701a.dts
+++ b/boards/arm/efm32gg_stk3701a/efm32gg_stk3701a.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &usart4;
+		zephyr,log-uart = &usart4;
 		zephyr,shell-uart = &usart4;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/efm32hg_slstk3400a/efm32hg_slstk3400a.dts
+++ b/boards/arm/efm32hg_slstk3400a/efm32hg_slstk3400a.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/efm32pg_stk3401a/efm32pg_stk3401a_common.dtsi
+++ b/boards/arm/efm32pg_stk3401a/efm32pg_stk3401a_common.dtsi
@@ -11,6 +11,7 @@
 
 	chosen {
 		zephyr,console = &usart0;
+		zephyr,log-uart = &usart0;
 		zephyr,shell-uart = &usart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/efm32pg_stk3402a/efm32pg_stk3402a_common.dtsi
+++ b/boards/arm/efm32pg_stk3402a/efm32pg_stk3402a_common.dtsi
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &usart0;
+		zephyr,log-uart = &usart0;
 		zephyr,shell-uart = &usart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/efm32wg_stk3800/efm32wg_stk3800.dts
+++ b/boards/arm/efm32wg_stk3800/efm32wg_stk3800.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/efr32_radio/efr32_radio.dtsi
+++ b/boards/arm/efr32_radio/efr32_radio.dtsi
@@ -9,6 +9,7 @@
 / {
 	chosen {
 		zephyr,console = &usart0;
+		zephyr,log-uart = &usart0;
 		zephyr,shell-uart = &usart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/efr32_radio/efr32_radio_brd4180a.dts
+++ b/boards/arm/efr32_radio/efr32_radio_brd4180a.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &usart0;
+		zephyr,log-uart = &usart0;
 		zephyr,shell-uart = &usart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/efr32_radio/efr32_radio_brd4187c.dts
+++ b/boards/arm/efr32_radio/efr32_radio_brd4187c.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &usart0;
+		zephyr,log-uart = &usart0;
 		zephyr,shell-uart = &usart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/efr32_thunderboard/thunderboard.dtsi
+++ b/boards/arm/efr32_thunderboard/thunderboard.dtsi
@@ -10,6 +10,7 @@
 	chosen {
 		zephyr,bt-c2h-uart = &usart1;
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/efr32mg_sltb004a/efr32mg_sltb004a.dts
+++ b/boards/arm/efr32mg_sltb004a/efr32mg_sltb004a.dts
@@ -27,6 +27,7 @@
 
 	chosen {
 		zephyr,console = &usart0;
+		zephyr,log-uart = &usart0;
 		zephyr,shell-uart = &usart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/efr32xg24_dk2601b/efr32xg24_dk2601b.dts
+++ b/boards/arm/efr32xg24_dk2601b/efr32xg24_dk2601b.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &usart0;
+		zephyr,log-uart = &usart0;
 		zephyr,shell-uart = &usart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/ev11l78a/ev11l78a.dts
+++ b/boards/arm/ev11l78a/ev11l78a.dts
@@ -23,6 +23,7 @@
 
 	chosen {
 		zephyr,console = &sercom1;
+		zephyr,log-uart = &sercom1;
 		zephyr,shell-uart = &sercom1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/faze/faze.dts
+++ b/boards/arm/faze/faze.dts
@@ -20,6 +20,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 	};
 

--- a/boards/arm/frdm_k22f/frdm_k22f.dts
+++ b/boards/arm/frdm_k22f/frdm_k22f.dts
@@ -34,6 +34,7 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,console = &uart1;
+		zephyr,log-uart = &uart1;
 		zephyr,shell-uart = &uart1;
 		zephyr,uart-pipe = &uart1;
 	};

--- a/boards/arm/frdm_k64f/frdm_k64f.dts
+++ b/boards/arm/frdm_k64f/frdm_k64f.dts
@@ -25,6 +25,7 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-pipe = &uart0;
 		zephyr,canbus = &flexcan0;

--- a/boards/arm/frdm_k82f/frdm_k82f.dts
+++ b/boards/arm/frdm_k82f/frdm_k82f.dts
@@ -41,6 +41,7 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,console = &lpuart4;
+		zephyr,log-uart = &lpuart4;
 		zephyr,shell-uart = &lpuart4;
 		zephyr,uart-pipe = &lpuart4;
 	};

--- a/boards/arm/frdm_kl25z/frdm_kl25z.dts
+++ b/boards/arm/frdm_kl25z/frdm_kl25z.dts
@@ -23,6 +23,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 	};
 

--- a/boards/arm/frdm_kw41z/frdm_kw41z.dts
+++ b/boards/arm/frdm_kw41z/frdm_kw41z.dts
@@ -30,6 +30,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &lpuart0;
+		zephyr,log-uart = &lpuart0;
 		zephyr,shell-uart = &lpuart0;
 		zephyr,ieee802154 = &ieee802154;
 		zephyr,code-partition = &slot0_partition;

--- a/boards/arm/fvp_baser_aemv8r_aarch32/fvp_baser_aemv8r_aarch32.dts
+++ b/boards/arm/fvp_baser_aemv8r_aarch32/fvp_baser_aemv8r_aarch32.dts
@@ -18,6 +18,7 @@
 		zephyr,sram = &dram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 	};
 

--- a/boards/arm/gd32a503v_eval/gd32a503v_eval.dts
+++ b/boards/arm/gd32a503v_eval/gd32a503v_eval.dts
@@ -16,6 +16,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &usart0;
+		zephyr,log-uart = &usart0;
 		zephyr,shell-uart = &usart0;
 		zephyr,flash-controller = &fmc;
 	};

--- a/boards/arm/gd32e103v_eval/gd32e103v_eval.dts
+++ b/boards/arm/gd32e103v_eval/gd32e103v_eval.dts
@@ -17,6 +17,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &usart0;
+		zephyr,log-uart = &usart0;
 		zephyr,shell-uart = &usart0;
 		zephyr,flash-controller = &fmc;
 	};

--- a/boards/arm/gd32e507v_start/gd32e507v_start.dts
+++ b/boards/arm/gd32e507v_start/gd32e507v_start.dts
@@ -17,6 +17,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &usart0;
+		zephyr,log-uart = &usart0;
 		zephyr,shell-uart = &usart0;
 		zephyr,flash-controller = &fmc;
 	};

--- a/boards/arm/gd32e507z_eval/gd32e507z_eval.dts
+++ b/boards/arm/gd32e507z_eval/gd32e507z_eval.dts
@@ -17,6 +17,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &usart0;
+		zephyr,log-uart = &usart0;
 		zephyr,shell-uart = &usart0;
 	};
 

--- a/boards/arm/gd32f350r_eval/gd32f350r_eval.dts
+++ b/boards/arm/gd32f350r_eval/gd32f350r_eval.dts
@@ -16,6 +16,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &usart0;
+		zephyr,log-uart = &usart0;
 		zephyr,shell-uart = &usart0;
 		zephyr,flash-controller = &fmc;
 	};

--- a/boards/arm/gd32f403z_eval/gd32f403z_eval.dts
+++ b/boards/arm/gd32f403z_eval/gd32f403z_eval.dts
@@ -17,6 +17,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &usart0;
+		zephyr,log-uart = &usart0;
 		zephyr,shell-uart = &usart0;
 		zephyr,flash-controller = &fmc;
 	};

--- a/boards/arm/gd32f407v_start/gd32f407v_start.dts
+++ b/boards/arm/gd32f407v_start/gd32f407v_start.dts
@@ -17,6 +17,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &usart0;
+		zephyr,log-uart = &usart0;
 		zephyr,shell-uart = &usart0;
 	};
 

--- a/boards/arm/gd32f450i_eval/gd32f450i_eval.dts
+++ b/boards/arm/gd32f450i_eval/gd32f450i_eval.dts
@@ -17,6 +17,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &usart0;
+		zephyr,log-uart = &usart0;
 		zephyr,shell-uart = &usart0;
 		zephyr,flash-controller = &fmc;
 	};

--- a/boards/arm/gd32f450v_start/gd32f450v_start.dts
+++ b/boards/arm/gd32f450v_start/gd32f450v_start.dts
@@ -17,6 +17,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &usart0;
+		zephyr,log-uart = &usart0;
 		zephyr,shell-uart = &usart0;
 	};
 

--- a/boards/arm/gd32f450z_eval/gd32f450z_eval.dts
+++ b/boards/arm/gd32f450z_eval/gd32f450z_eval.dts
@@ -17,6 +17,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &usart0;
+		zephyr,log-uart = &usart0;
 		zephyr,shell-uart = &usart0;
 		zephyr,flash-controller = &fmc;
 	};

--- a/boards/arm/gd32f470i_eval/gd32f470i_eval.dts
+++ b/boards/arm/gd32f470i_eval/gd32f470i_eval.dts
@@ -17,6 +17,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &usart0;
+		zephyr,log-uart = &usart0;
 		zephyr,shell-uart = &usart0;
 		zephyr,flash-controller = &fmc;
 	};

--- a/boards/arm/gd32l233r_eval/gd32l233r_eval.dts
+++ b/boards/arm/gd32l233r_eval/gd32l233r_eval.dts
@@ -17,6 +17,7 @@
 		zephyr,sram = &sram;
 		zephyr,flash = &flash0;
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,flash-controller = &fmc;
 	};

--- a/boards/arm/google_dragonclaw/google_dragonclaw.dts
+++ b/boards/arm/google_dragonclaw/google_dragonclaw.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/google_kukui/google_kukui.dts
+++ b/boards/arm/google_kukui/google_kukui.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/hexiwear_k64/hexiwear_k64.dts
+++ b/boards/arm/hexiwear_k64/hexiwear_k64.dts
@@ -27,6 +27,7 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,bt-uart = &uart4;
 	};

--- a/boards/arm/kv260_r5/kv260_r5.dts
+++ b/boards/arm/kv260_r5/kv260_r5.dts
@@ -16,6 +16,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart1;
+		zephyr,log-uart = &uart1;
 		zephyr,shell-uart = &uart1;
 		zephyr,ocm = &ocm;
 	};

--- a/boards/arm/legend/legend.dts
+++ b/boards/arm/legend/legend.dts
@@ -14,6 +14,7 @@
 / {
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/lora_e5_dev_board/lora_e5_dev_board.dts
+++ b/boards/arm/lora_e5_dev_board/lora_e5_dev_board.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/lpcxpresso11u68/lpcxpresso11u68.dts
+++ b/boards/arm/lpcxpresso11u68/lpcxpresso11u68.dts
@@ -18,6 +18,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 	};
 
 	/* These aliases are provided for compatibility with samples. */

--- a/boards/arm/lpcxpresso51u68/lpcxpresso51u68.dts
+++ b/boards/arm/lpcxpresso51u68/lpcxpresso51u68.dts
@@ -18,6 +18,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &flexcomm0;
+		zephyr,log-uart = &flexcomm0;
 		zephyr,shell-uart = &flexcomm0;
 	};
 

--- a/boards/arm/lpcxpresso54114/lpcxpresso54114_m0.dts
+++ b/boards/arm/lpcxpresso54114/lpcxpresso54114_m0.dts
@@ -17,8 +17,9 @@
 		zephyr,sram = &sram2;
 		zephyr,flash = &sram1;
 		zephyr,code-cpu1-partition = &slot1_partition;
-		/*zephyr,console = &flexcomm0; uncomment to use console on M0  */
-		/*zephyr,shell-uart = &flexcomm0; uncomment to use shell on M0 */
+		/* zephyr,console = &flexcomm0; uncomment to use console on M0 */
+		/* zephyr,log-uart = &flexcomm0; uncomment to use log on M0 */
+		/* zephyr,shell-uart = &flexcomm0; uncomment to use shell on M0 */
 	};
 };
 

--- a/boards/arm/lpcxpresso54114/lpcxpresso54114_m4.dts
+++ b/boards/arm/lpcxpresso54114/lpcxpresso54114_m4.dts
@@ -24,6 +24,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &flexcomm0;
+		zephyr,log-uart = &flexcomm0;
 		zephyr,shell-uart = &flexcomm0;
 		zephyr,code-partition = &slot0_partition;
 	};

--- a/boards/arm/lpcxpresso55s06/lpcxpresso55s06_common.dtsi
+++ b/boards/arm/lpcxpresso55s06/lpcxpresso55s06_common.dtsi
@@ -14,6 +14,7 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,console = &flexcomm0;
+		zephyr,log-uart = &flexcomm0;
 		zephyr,shell-uart = &flexcomm0;
 		zephyr,entropy = &rng;
 		zephyr,flash-controller = &iap;

--- a/boards/arm/lpcxpresso55s16/lpcxpresso55s16_common.dtsi
+++ b/boards/arm/lpcxpresso55s16/lpcxpresso55s16_common.dtsi
@@ -14,6 +14,7 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,console = &flexcomm0;
+		zephyr,log-uart = &flexcomm0;
 		zephyr,shell-uart = &flexcomm0;
 		zephyr,entropy = &rng;
 		zephyr,canbus = &can0;

--- a/boards/arm/lpcxpresso55s28/lpcxpresso55s28.dts
+++ b/boards/arm/lpcxpresso55s28/lpcxpresso55s28.dts
@@ -26,6 +26,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &flexcomm0;
+		zephyr,log-uart = &flexcomm0;
 		zephyr,shell-uart = &flexcomm0;
 		zephyr,entropy = &rng;
 	};

--- a/boards/arm/lpcxpresso55s36/lpcxpresso55s36.dts
+++ b/boards/arm/lpcxpresso55s36/lpcxpresso55s36.dts
@@ -19,6 +19,7 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &sramx;
 		zephyr,console = &flexcomm0;
+		zephyr,log-uart = &flexcomm0;
 		zephyr,shell-uart = &flexcomm0;
 		zephyr,canbus = &can0;
 		zephyr,flash-controller = &iap;

--- a/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu0.dts
+++ b/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu0.dts
@@ -40,6 +40,7 @@
 		zephyr,code-cpu1-partition = &slot0_ns_partition;
 		zephyr,sram-cpu1-partition = &sram3;
 		zephyr,console = &flexcomm0;
+		zephyr,log-uart = &flexcomm0;
 		zephyr,shell-uart = &flexcomm0;
 		zephyr,entropy = &rng;
 	};

--- a/boards/arm/lpcxpresso55s69/lpcxpresso55s69_ns.dts
+++ b/boards/arm/lpcxpresso55s69/lpcxpresso55s69_ns.dts
@@ -31,6 +31,7 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_ns_partition;
 		zephyr,console = &flexcomm0;
+		zephyr,log-uart = &flexcomm0;
 		zephyr,shell-uart = &flexcomm0;
 		zephyr,entropy = &rng;
 	};

--- a/boards/arm/mec1501modular_assy6885/mec1501modular_assy6885.dts
+++ b/boards/arm/mec1501modular_assy6885/mec1501modular_assy6885.dts
@@ -16,6 +16,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart1;
+		zephyr,log-uart = &uart1;
 		zephyr,flash = &flash0;
 		zephyr,keyboard-scan = &kscan0;
 	};

--- a/boards/arm/mec15xxevb_assy6853/mec15xxevb_assy6853.dts
+++ b/boards/arm/mec15xxevb_assy6853/mec15xxevb_assy6853.dts
@@ -15,6 +15,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart2;
+		zephyr,log-uart = &uart2;
 		zephyr,flash = &flash0;
 		zephyr,keyboard-scan = &kscan0;
 	};

--- a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
+++ b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
@@ -17,6 +17,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart1;
+		zephyr,log-uart = &uart1;
 	};
 
 	aliases {

--- a/boards/arm/mec172xmodular_assy6930/mec172xmodular_assy6930.dts
+++ b/boards/arm/mec172xmodular_assy6930/mec172xmodular_assy6930.dts
@@ -17,6 +17,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart1;
+		zephyr,log-uart = &uart1;
 	};
 
 	aliases {

--- a/boards/arm/mercury_xu/mercury_xu.dts
+++ b/boards/arm/mercury_xu/mercury_xu.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/arm/mg100/mg100.dts
+++ b/boards/arm/mg100/mg100.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/mikroe_clicker_2/mikroe_clicker_2.dts
+++ b/boards/arm/mikroe_clicker_2/mikroe_clicker_2.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart4;
+		zephyr,log-uart = &uart4;
 		zephyr,shell-uart = &uart4;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/mikroe_mini_m4_for_stm32/mikroe_mini_m4_for_stm32.dts
+++ b/boards/arm/mikroe_mini_m4_for_stm32/mikroe_mini_m4_for_stm32.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/mimx8mm_evk/mimx8mm_evk.dts
+++ b/boards/arm/mimx8mm_evk/mimx8mm_evk.dts
@@ -22,6 +22,7 @@
 		zephyr,flash = &tcml_code;
 		zephyr,sram = &tcmu_sys;
 		zephyr,console = &uart4;
+		zephyr,log-uart = &uart4;
 		zephyr,shell-uart = &uart4;
 	};
 };

--- a/boards/arm/mimx8mm_phyboard_polis/mimx8mm_phyboard_polis.dts
+++ b/boards/arm/mimx8mm_phyboard_polis/mimx8mm_phyboard_polis.dts
@@ -25,6 +25,7 @@
 		zephyr,flash = &tcml_code;
 		zephyr,sram = &tcmu_sys;
 		zephyr,console = &uart4;
+		zephyr,log-uart = &uart4;
 		zephyr,shell-uart = &uart4;
 	};
 

--- a/boards/arm/mimx8mp_evk/mimx8mp_evk_ddr.dts
+++ b/boards/arm/mimx8mp_evk/mimx8mp_evk_ddr.dts
@@ -19,6 +19,7 @@
 		zephyr,sram = &ddr_sys;
 
 		zephyr,console = &uart4;
+		zephyr,log-uart = &uart4;
 		zephyr,shell-uart = &uart4;
 	};
 };

--- a/boards/arm/mimx8mp_evk/mimx8mp_evk_itcm.dts
+++ b/boards/arm/mimx8mp_evk/mimx8mp_evk_itcm.dts
@@ -19,6 +19,7 @@
 		zephyr,sram = &dtcm;
 
 		zephyr,console = &uart4;
+		zephyr,log-uart = &uart4;
 		zephyr,shell-uart = &uart4;
 	};
 };

--- a/boards/arm/mimx8mp_phyboard_pollux/mimx8mp_phyboard_pollux.dts
+++ b/boards/arm/mimx8mp_phyboard_pollux/mimx8mp_phyboard_pollux.dts
@@ -19,6 +19,7 @@
 		zephyr,sram = &dtcm;
 
 		zephyr,console = &uart4;
+		zephyr,log-uart = &uart4;
 		zephyr,shell-uart = &uart4;
 	};
 

--- a/boards/arm/mimx8mq_evk/mimx8mq_evk_cm4.dts
+++ b/boards/arm/mimx8mq_evk/mimx8mq_evk_cm4.dts
@@ -21,6 +21,7 @@
 		zephyr,flash = &tcml_code;
 		zephyr,sram = &tcmu_sys;
 		zephyr,console = &uart2;
+		zephyr,log-uart = &uart2;
 		zephyr,shell-uart = &uart2;
 	};
 };

--- a/boards/arm/mimxrt1010_evk/mimxrt1010_evk.dts
+++ b/boards/arm/mimxrt1010_evk/mimxrt1010_evk.dts
@@ -24,6 +24,7 @@
 		zephyr,sram = &ocram;
 		zephyr,itcm = &itcm;
 		zephyr,console = &lpuart1;
+		zephyr,log-uart = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,flash = &at25sf128a;
 	};

--- a/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
+++ b/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
@@ -23,6 +23,7 @@
 		zephyr,sram = &dtcm;
 		zephyr,itcm = &itcm;
 		zephyr,console = &lpuart1;
+		zephyr,log-uart = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,flash = &at25sf128a;
 	};

--- a/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -28,6 +28,7 @@
 		zephyr,itcm = &itcm;
 		zephyr,dtcm = &dtcm;
 		zephyr,console = &lpuart1;
+		zephyr,log-uart = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 	};
 

--- a/boards/arm/mimxrt1024_evk/mimxrt1024_evk.dts
+++ b/boards/arm/mimxrt1024_evk/mimxrt1024_evk.dts
@@ -31,6 +31,7 @@
 		zephyr,itcm = &itcm;
 		zephyr,dtcm = &dtcm;
 		zephyr,console = &lpuart1;
+		zephyr,log-uart = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,canbus = &flexcan1;
 	};

--- a/boards/arm/mimxrt1040_evk/mimxrt1040_evk.dts
+++ b/boards/arm/mimxrt1040_evk/mimxrt1040_evk.dts
@@ -26,6 +26,7 @@
 		zephyr,itcm = &itcm;
 		zephyr,dtcm = &dtcm;
 		zephyr,console = &lpuart1;
+		zephyr,log-uart = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 	};
 

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -29,6 +29,7 @@
 		zephyr,itcm = &itcm;
 		zephyr,dtcm = &dtcm;
 		zephyr,console = &lpuart1;
+		zephyr,log-uart = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,flash-controller = &s26ks512s0;
 		zephyr,flash = &s26ks512s0;

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -31,6 +31,7 @@
 		zephyr,itcm = &itcm;
 		zephyr,dtcm = &dtcm;
 		zephyr,console = &lpuart1;
+		zephyr,log-uart = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,canbus = &flexcan3;
 		zephyr,display = &lcdif;

--- a/boards/arm/mimxrt1062_fmurt6/mimxrt1062_fmurt6.dts
+++ b/boards/arm/mimxrt1062_fmurt6/mimxrt1062_fmurt6.dts
@@ -33,6 +33,7 @@
 		zephyr,itcm = &itcm;
 		zephyr,dtcm = &dtcm;
 		zephyr,console = &lpuart7;
+		zephyr,log-uart = &lpuart7;
 		zephyr,shell-uart = &lpuart7;
 		zephyr,canbus = &flexcan1;
 	};

--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -31,6 +31,7 @@
 		zephyr,itcm = &itcm;
 		zephyr,dtcm = &dtcm;
 		zephyr,console = &lpuart1;
+		zephyr,log-uart = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,canbus = &flexcan2;
 		zephyr,display = &lcdif;

--- a/boards/arm/mimxrt1160_evk/mimxrt1160_evk_cm4.dts
+++ b/boards/arm/mimxrt1160_evk/mimxrt1160_evk_cm4.dts
@@ -22,6 +22,7 @@
 		 */
 		zephyr,sram = &sram1;
 		zephyr,console = &lpuart1;
+		zephyr,log-uart = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,flash-controller = &is25wp128;
 		zephyr,flash = &is25wp128;

--- a/boards/arm/mimxrt1160_evk/mimxrt1160_evk_cm7.dts
+++ b/boards/arm/mimxrt1160_evk/mimxrt1160_evk_cm7.dts
@@ -18,6 +18,7 @@
 		zephyr,dtcm = &dtcm;
 		zephyr,itcm = &itcm;
 		zephyr,console = &lpuart1;
+		zephyr,log-uart = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,canbus = &flexcan3;
 		zephyr,flash-controller = &is25wp128;

--- a/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm4.dts
+++ b/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm4.dts
@@ -22,6 +22,7 @@
 		 */
 		zephyr,sram = &sram1;
 		zephyr,console = &lpuart1;
+		zephyr,log-uart = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,canbus = &flexcan2;
 		zephyr,flash-controller = &is25wp128;

--- a/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm7.dts
+++ b/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm7.dts
@@ -23,6 +23,7 @@
 		zephyr,dtcm = &dtcm;
 		zephyr,itcm = &itcm;
 		zephyr,console = &lpuart1;
+		zephyr,log-uart = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,canbus = &flexcan3;
 		zephyr,flash-controller = &is25wp128;

--- a/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33.dts
+++ b/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33.dts
@@ -36,6 +36,7 @@
 		zephyr,code-partition = &slot0_partition;
 		zephyr,sram = &sram0;
 		zephyr,console = &flexcomm0;
+		zephyr,log-uart = &flexcomm0;
 		zephyr,shell-uart = &flexcomm0;
 		zephyr,display = &lcdif;
 	};

--- a/boards/arm/mimxrt685_evk/mimxrt685_evk_cm33.dts
+++ b/boards/arm/mimxrt685_evk/mimxrt685_evk_cm33.dts
@@ -41,6 +41,7 @@
 		zephyr,code-partition = &slot0_partition;
 		zephyr,sram = &sram0;
 		zephyr,console = &flexcomm0;
+		zephyr,log-uart = &flexcomm0;
 		zephyr,shell-uart = &flexcomm0;
 	};
 

--- a/boards/arm/mm_feather/mm_feather.dts
+++ b/boards/arm/mm_feather/mm_feather.dts
@@ -25,6 +25,7 @@
 		zephyr,itcm = &itcm;
 		zephyr,dtcm = &dtcm;
 		zephyr,console = &lpuart1;
+		zephyr,log-uart = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,flash = &is25wp064;
 	};

--- a/boards/arm/mm_swiftio/mm_swiftio.dts
+++ b/boards/arm/mm_swiftio/mm_swiftio.dts
@@ -25,6 +25,7 @@
 		zephyr,itcm = &itcm;
 		zephyr,dtcm = &dtcm;
 		zephyr,console = &lpuart1;
+		zephyr,log-uart = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,flash = &is25wp064;
 	};

--- a/boards/arm/mps2_an385/mps2_an385.dts
+++ b/boards/arm/mps2_an385/mps2_an385.dts
@@ -21,6 +21,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-pipe = &uart1;
 		zephyr,sram = &sram0;

--- a/boards/arm/mps2_an521/mps2_an521.dts
+++ b/boards/arm/mps2_an521/mps2_an521.dts
@@ -27,6 +27,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 
 		/*

--- a/boards/arm/mps2_an521/mps2_an521_ns.dts
+++ b/boards/arm/mps2_an521/mps2_an521_ns.dts
@@ -26,6 +26,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &ram;
 		zephyr,flash = &code;

--- a/boards/arm/mps2_an521/mps2_an521_remote.dts
+++ b/boards/arm/mps2_an521/mps2_an521_remote.dts
@@ -26,6 +26,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &ram;
 		zephyr,flash = &code;

--- a/boards/arm/mps3_an547/mps3_an547.dts
+++ b/boards/arm/mps3_an547/mps3_an547.dts
@@ -26,6 +26,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &dtcm;
 		zephyr,flash = &itcm;

--- a/boards/arm/mps3_an547/mps3_an547_ns.dts
+++ b/boards/arm/mps3_an547/mps3_an547_ns.dts
@@ -25,6 +25,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &ram;
 		zephyr,flash = &code;

--- a/boards/arm/mr_canhubk3/mr_canhubk3.dts
+++ b/boards/arm/mr_canhubk3/mr_canhubk3.dts
@@ -23,6 +23,7 @@
 		zephyr,dtcm = &dtcm;
 		zephyr,code-partition = &code_partition;
 		zephyr,console = &lpuart2;
+		zephyr,log-uart = &lpuart2;
 		zephyr,shell-uart = &lpuart2;
 		zephyr,flash-controller = &mx25l6433f;
 		zephyr,canbus = &flexcan0;

--- a/boards/arm/msp_exp432p401r_launchxl/msp_exp432p401r_launchxl.dts
+++ b/boards/arm/msp_exp432p401r_launchxl/msp_exp432p401r_launchxl.dts
@@ -13,6 +13,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 	};
 };

--- a/boards/arm/npcx4m8f_evb/npcx4m8f_evb.dts
+++ b/boards/arm/npcx4m8f_evb/npcx4m8f_evb.dts
@@ -15,6 +15,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart1;
+		zephyr,log-uart = &uart1;
 		zephyr,flash = &flash0;
 		zephyr,keyboard-scan = &kscan_input;
 	};

--- a/boards/arm/npcx7m6fb_evb/npcx7m6fb_evb.dts
+++ b/boards/arm/npcx7m6fb_evb/npcx7m6fb_evb.dts
@@ -15,6 +15,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart1;
+		zephyr,log-uart = &uart1;
 		zephyr,flash = &flash0;
 		zephyr,keyboard-scan = &kscan_input;
 	};

--- a/boards/arm/npcx9m6f_evb/npcx9m6f_evb.dts
+++ b/boards/arm/npcx9m6f_evb/npcx9m6f_evb.dts
@@ -15,6 +15,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart1;
+		zephyr,log-uart = &uart1;
 		zephyr,flash = &flash0;
 		zephyr,keyboard-scan = &kscan_input;
 	};

--- a/boards/arm/nrf21540dk_nrf52840/nrf21540dk_nrf52840.dts
+++ b/boards/arm/nrf21540dk_nrf52840/nrf21540dk_nrf52840.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/nrf51_ble400/nrf51_ble400.dts
+++ b/boards/arm/nrf51_ble400/nrf51_ble400.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,bt-mon-uart = &uart0;
 		zephyr,bt-c2h-uart = &uart0;

--- a/boards/arm/nrf51_blenano/nrf51_blenano.dts
+++ b/boards/arm/nrf51_blenano/nrf51_blenano.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,bt-mon-uart = &uart0;
 		zephyr,bt-c2h-uart = &uart0;

--- a/boards/arm/nrf51_vbluno51/nrf51_vbluno51.dts
+++ b/boards/arm/nrf51_vbluno51/nrf51_vbluno51.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,bt-mon-uart = &uart0;
 		zephyr,bt-c2h-uart = &uart0;

--- a/boards/arm/nrf51dk_nrf51422/nrf51dk_nrf51422.dts
+++ b/boards/arm/nrf51dk_nrf51422/nrf51dk_nrf51422.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/nrf51dongle_nrf51422/nrf51dongle_nrf51422.dts
+++ b/boards/arm/nrf51dongle_nrf51422/nrf51dongle_nrf51422.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/nrf52832_mdk/nrf52832_mdk.dts
+++ b/boards/arm/nrf52832_mdk/nrf52832_mdk.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/nrf52833dk_nrf52820/nrf52833dk_nrf52820.dts
+++ b/boards/arm/nrf52833dk_nrf52820/nrf52833dk_nrf52820.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833.dts
+++ b/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/nrf52840_blip/nrf52840_blip.dts
+++ b/boards/arm/nrf52840_blip/nrf52840_blip.dts
@@ -18,6 +18,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
+++ b/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/nrf52840_mdk_usb_dongle/nrf52840_mdk_usb_dongle.dts
+++ b/boards/arm/nrf52840_mdk_usb_dongle/nrf52840_mdk_usb_dongle.dts
@@ -17,6 +17,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/nrf52840_papyr/nrf52840_papyr.dts
+++ b/boards/arm/nrf52840_papyr/nrf52840_papyr.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/nrf52840dk_nrf52811/nrf52840dk_nrf52811.dts
+++ b/boards/arm/nrf52840dk_nrf52811/nrf52840dk_nrf52811.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
+++ b/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/nrf52840dongle_nrf52840/nrf52840dongle_nrf52840.dts
+++ b/boards/arm/nrf52840dongle_nrf52840/nrf52840dongle_nrf52840.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &cdc_acm_uart;
+		zephyr,log-uart = &cdc_acm_uart;
 		zephyr,shell-uart = &cdc_acm_uart;
 		zephyr,uart-mcumgr = &cdc_acm_uart;
 		zephyr,bt-mon-uart = &cdc_acm_uart;

--- a/boards/arm/nrf52_adafruit_feather/nrf52_adafruit_feather.dts
+++ b/boards/arm/nrf52_adafruit_feather/nrf52_adafruit_feather.dts
@@ -21,6 +21,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/nrf52_blenano2/nrf52_blenano2.dts
+++ b/boards/arm/nrf52_blenano2/nrf52_blenano2.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,bt-mon-uart = &uart0;
 		zephyr,bt-c2h-uart = &uart0;

--- a/boards/arm/nrf52_sparkfun/nrf52_sparkfun.dts
+++ b/boards/arm/nrf52_sparkfun/nrf52_sparkfun.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,bt-mon-uart = &uart0;
 		zephyr,bt-c2h-uart = &uart0;

--- a/boards/arm/nrf52_vbluno52/nrf52_vbluno52.dts
+++ b/boards/arm/nrf52_vbluno52/nrf52_vbluno52.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,bt-mon-uart = &uart0;
 		zephyr,bt-c2h-uart = &uart0;

--- a/boards/arm/nrf52dk_nrf52805/nrf52dk_nrf52805.dts
+++ b/boards/arm/nrf52dk_nrf52805/nrf52dk_nrf52805.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/nrf52dk_nrf52810/nrf52dk_nrf52810.dts
+++ b/boards/arm/nrf52dk_nrf52810/nrf52dk_nrf52810.dts
@@ -17,6 +17,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/nrf52dk_nrf52832/nrf52dk_nrf52832.dts
+++ b/boards/arm/nrf52dk_nrf52832/nrf52dk_nrf52832.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp_common.dtsi
+++ b/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp_common.dtsi
@@ -9,6 +9,7 @@
 / {
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpunet.dts
+++ b/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpunet.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dtsi
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dtsi
@@ -10,6 +10,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpunet.dts
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpunet.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/nrf9160_innblue21/nrf9160_innblue21_common.dtsi
+++ b/boards/arm/nrf9160_innblue21/nrf9160_innblue21_common.dtsi
@@ -12,6 +12,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 	};

--- a/boards/arm/nrf9160_innblue22/nrf9160_innblue22_common.dtsi
+++ b/boards/arm/nrf9160_innblue22/nrf9160_innblue22_common.dtsi
@@ -12,6 +12,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 	};

--- a/boards/arm/nrf9160dk_nrf52840/nrf9160dk_nrf52840.dts
+++ b/boards/arm/nrf9160dk_nrf52840/nrf9160dk_nrf52840.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dtsi
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dtsi
@@ -12,6 +12,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 	};

--- a/boards/arm/nrf9161dk_nrf9161/nrf9161dk_nrf9161_common.dtsi
+++ b/boards/arm/nrf9161dk_nrf9161/nrf9161dk_nrf9161_common.dtsi
@@ -12,6 +12,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 	};

--- a/boards/arm/nucleo_c031c6/nucleo_c031c6.dts
+++ b/boards/arm/nucleo_c031c6/nucleo_c031c6.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_f030r8/nucleo_f030r8.dts
+++ b/boards/arm/nucleo_f030r8/nucleo_f030r8.dts
@@ -17,6 +17,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_f031k6/nucleo_f031k6.dts
+++ b/boards/arm/nucleo_f031k6/nucleo_f031k6.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_f042k6/nucleo_f042k6.dts
+++ b/boards/arm/nucleo_f042k6/nucleo_f042k6.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_f070rb/nucleo_f070rb.dts
+++ b/boards/arm/nucleo_f070rb/nucleo_f070rb.dts
@@ -17,6 +17,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
+++ b/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
@@ -17,6 +17,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
+++ b/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
@@ -17,6 +17,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
+++ b/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &usart3;
+		zephyr,log-uart = &usart3;
 		zephyr,shell-uart = &usart3;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_f302r8/nucleo_f302r8.dts
+++ b/boards/arm/nucleo_f302r8/nucleo_f302r8.dts
@@ -17,6 +17,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_f303k8/nucleo_f303k8.dts
+++ b/boards/arm/nucleo_f303k8/nucleo_f303k8.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_f303re/nucleo_f303re.dts
+++ b/boards/arm/nucleo_f303re/nucleo_f303re.dts
@@ -17,6 +17,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_f334r8/nucleo_f334r8.dts
+++ b/boards/arm/nucleo_f334r8/nucleo_f334r8.dts
@@ -17,6 +17,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_f401re/nucleo_f401re.dts
+++ b/boards/arm/nucleo_f401re/nucleo_f401re.dts
@@ -18,6 +18,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_f410rb/nucleo_f410rb.dts
+++ b/boards/arm/nucleo_f410rb/nucleo_f410rb.dts
@@ -17,6 +17,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_f411re/nucleo_f411re.dts
+++ b/boards/arm/nucleo_f411re/nucleo_f411re.dts
@@ -17,6 +17,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_f412zg/nucleo_f412zg.dts
+++ b/boards/arm/nucleo_f412zg/nucleo_f412zg.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &usart3;
+		zephyr,log-uart = &usart3;
 		zephyr,shell-uart = &usart3;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_f413zh/nucleo_f413zh.dts
+++ b/boards/arm/nucleo_f413zh/nucleo_f413zh.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &usart3;
+		zephyr,log-uart = &usart3;
 		zephyr,shell-uart = &usart3;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
+++ b/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &usart3;
+		zephyr,log-uart = &usart3;
 		zephyr,shell-uart = &usart3;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_f446re/nucleo_f446re.dts
+++ b/boards/arm/nucleo_f446re/nucleo_f446re.dts
@@ -17,6 +17,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_f446ze/nucleo_f446ze.dts
+++ b/boards/arm/nucleo_f446ze/nucleo_f446ze.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &usart3;
+		zephyr,log-uart = &usart3;
 		zephyr,shell-uart = &usart3;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_f746zg/nucleo_f746zg.dts
+++ b/boards/arm/nucleo_f746zg/nucleo_f746zg.dts
@@ -23,6 +23,7 @@
 
 	chosen {
 		zephyr,console = &usart3;
+		zephyr,log-uart = &usart3;
 		zephyr,shell-uart = &usart3;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_f756zg/nucleo_f756zg.dts
+++ b/boards/arm/nucleo_f756zg/nucleo_f756zg.dts
@@ -23,6 +23,7 @@
 
 	chosen {
 		zephyr,console = &usart3;
+		zephyr,log-uart = &usart3;
 		zephyr,shell-uart = &usart3;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_f767zi/nucleo_f767zi.dts
+++ b/boards/arm/nucleo_f767zi/nucleo_f767zi.dts
@@ -23,6 +23,7 @@
 
 	chosen {
 		zephyr,console = &usart3;
+		zephyr,log-uart = &usart3;
 		zephyr,shell-uart = &usart3;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_g031k8/nucleo_g031k8.dts
+++ b/boards/arm/nucleo_g031k8/nucleo_g031k8.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_g070rb/nucleo_g070rb.dts
+++ b/boards/arm/nucleo_g070rb/nucleo_g070rb.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_g071rb/nucleo_g071rb.dts
+++ b/boards/arm/nucleo_g071rb/nucleo_g071rb.dts
@@ -17,6 +17,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_g0b1re/nucleo_g0b1re.dts
+++ b/boards/arm/nucleo_g0b1re/nucleo_g0b1re.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,uart-mcumgr = &usart2;
 		zephyr,sram = &sram0;

--- a/boards/arm/nucleo_g431rb/nucleo_g431rb.dts
+++ b/boards/arm/nucleo_g431rb/nucleo_g431rb.dts
@@ -17,6 +17,7 @@
 
 	chosen {
 		zephyr,console = &lpuart1;
+		zephyr,log-uart = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_g474re/nucleo_g474re.dts
+++ b/boards/arm/nucleo_g474re/nucleo_g474re.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &lpuart1;
+		zephyr,log-uart = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_h563zi/nucleo_h563zi.dts
+++ b/boards/arm/nucleo_h563zi/nucleo_h563zi.dts
@@ -18,6 +18,7 @@
 
 	chosen {
 		zephyr,console = &usart3;
+		zephyr,log-uart = &usart3;
 		zephyr,shell-uart = &usart3;
 		zephyr,sram = &sram1;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_h723zg/nucleo_h723zg.dts
+++ b/boards/arm/nucleo_h723zg/nucleo_h723zg.dts
@@ -20,6 +20,7 @@
 
 	chosen {
 		zephyr,console = &usart3;
+		zephyr,log-uart = &usart3;
 		zephyr,shell-uart = &usart3;
 		zephyr,dtcm = &dtcm;
 		zephyr,sram = &sram0;

--- a/boards/arm/nucleo_h743zi/nucleo_h743zi.dts
+++ b/boards/arm/nucleo_h743zi/nucleo_h743zi.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &usart3;
+		zephyr,log-uart = &usart3;
 		zephyr,shell-uart = &usart3;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m4.dts
+++ b/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m4.dts
@@ -15,6 +15,7 @@
 	/* HW resources belonging to CM4 */
 	chosen {
 		zephyr,console = &uart8;
+		zephyr,log-uart = &uart8;
 		zephyr,shell-uart = &uart8;
 		zephyr,sram = &sram1;
 		zephyr,flash = &flash1;

--- a/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m7.dts
+++ b/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m7.dts
@@ -23,6 +23,7 @@
 	/* HW resources belonging to CM7 */
 	chosen {
 		zephyr,console = &usart3;
+		zephyr,log-uart = &usart3;
 		zephyr,shell-uart = &usart3;
 		zephyr,dtcm = &dtcm;
 		zephyr,sram = &sram0;

--- a/boards/arm/nucleo_h753zi/nucleo_h753zi.dts
+++ b/boards/arm/nucleo_h753zi/nucleo_h753zi.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &usart3;
+		zephyr,log-uart = &usart3;
 		zephyr,shell-uart = &usart3;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_h7a3zi_q/nucleo_h7a3zi_q.dts
+++ b/boards/arm/nucleo_h7a3zi_q/nucleo_h7a3zi_q.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &usart3;
+		zephyr,log-uart = &usart3;
 		zephyr,shell-uart = &usart3;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_l011k4/nucleo_l011k4.dts
+++ b/boards/arm/nucleo_l011k4/nucleo_l011k4.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_l031k6/nucleo_l031k6.dts
+++ b/boards/arm/nucleo_l031k6/nucleo_l031k6.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_l053r8/nucleo_l053r8.dts
+++ b/boards/arm/nucleo_l053r8/nucleo_l053r8.dts
@@ -17,6 +17,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_l073rz/nucleo_l073rz.dts
+++ b/boards/arm/nucleo_l073rz/nucleo_l073rz.dts
@@ -17,6 +17,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_l152re/nucleo_l152re.dts
+++ b/boards/arm/nucleo_l152re/nucleo_l152re.dts
@@ -17,6 +17,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_l412rb_p/nucleo_l412rb_p.dts
+++ b/boards/arm/nucleo_l412rb_p/nucleo_l412rb_p.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &lpuart1;
+		zephyr,log-uart = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_l432kc/nucleo_l432kc.dts
+++ b/boards/arm/nucleo_l432kc/nucleo_l432kc.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_l433rc_p/nucleo_l433rc_p.dts
+++ b/boards/arm/nucleo_l433rc_p/nucleo_l433rc_p.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &lpuart1;
+		zephyr,log-uart = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_l452re/nucleo_l452re_common.dtsi
+++ b/boards/arm/nucleo_l452re/nucleo_l452re_common.dtsi
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
+++ b/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
@@ -17,6 +17,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_l496zg/nucleo_l496zg.dts
+++ b/boards/arm/nucleo_l496zg/nucleo_l496zg.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &lpuart1;
+		zephyr,log-uart = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_l4a6zg/nucleo_l4a6zg.dts
+++ b/boards/arm/nucleo_l4a6zg/nucleo_l4a6zg.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &lpuart1;
+		zephyr,log-uart = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_l4r5zi/nucleo_l4r5zi.dts
+++ b/boards/arm/nucleo_l4r5zi/nucleo_l4r5zi.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &lpuart1;
+		zephyr,log-uart = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_l552ze_q/nucleo_l552ze_q.dts
+++ b/boards/arm/nucleo_l552ze_q/nucleo_l552ze_q.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &lpuart1;
+		zephyr,log-uart = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_l552ze_q/nucleo_l552ze_q_ns.dts
+++ b/boards/arm/nucleo_l552ze_q/nucleo_l552ze_q_ns.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &lpuart1;
+		zephyr,log-uart = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_u575zi_q/nucleo_u575zi_q.dts
+++ b/boards/arm/nucleo_u575zi_q/nucleo_u575zi_q.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_u5a5zj_q/nucleo_u5a5zj_q.dts
+++ b/boards/arm/nucleo_u5a5zj_q/nucleo_u5a5zj_q.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,bt-mon-uart = &lpuart1;
 		zephyr,bt-c2h-uart = &lpuart1;

--- a/boards/arm/nucleo_wba52cg/nucleo_wba52cg.dts
+++ b/boards/arm/nucleo_wba52cg/nucleo_wba52cg.dts
@@ -19,6 +19,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nucleo_wl55jc/nucleo_wl55jc.dts
+++ b/boards/arm/nucleo_wl55jc/nucleo_wl55jc.dts
@@ -17,6 +17,7 @@
 
 	chosen {
 		zephyr,console = &lpuart1;
+		zephyr,log-uart = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/numaker_pfm_m467/numaker_pfm_m467.dts
+++ b/boards/arm/numaker_pfm_m467/numaker_pfm_m467.dts
@@ -25,6 +25,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/nuvoton_pfm_m487/nuvoton_pfm_m487.dts
+++ b/boards/arm/nuvoton_pfm_m487/nuvoton_pfm_m487.dts
@@ -23,6 +23,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/olimex_lora_stm32wl_devkit/olimex_lora_stm32wl_devkit.dts
+++ b/boards/arm/olimex_lora_stm32wl_devkit/olimex_lora_stm32wl_devkit.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/olimex_stm32_e407/olimex_stm32_e407.dts
+++ b/boards/arm/olimex_stm32_e407/olimex_stm32_e407.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/olimex_stm32_h103/olimex_stm32_h103.dts
+++ b/boards/arm/olimex_stm32_h103/olimex_stm32_h103.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/olimex_stm32_h405/olimex_stm32_h405.dts
+++ b/boards/arm/olimex_stm32_h405/olimex_stm32_h405.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/olimex_stm32_h407/olimex_stm32_h407.dts
+++ b/boards/arm/olimex_stm32_h407/olimex_stm32_h407.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/olimex_stm32_p405/olimex_stm32_p405.dts
+++ b/boards/arm/olimex_stm32_p405/olimex_stm32_p405.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/olimexino_stm32/olimexino_stm32.dts
+++ b/boards/arm/olimexino_stm32/olimexino_stm32.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/pan1770_evb/pan1770_evb.dts
+++ b/boards/arm/pan1770_evb/pan1770_evb.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/pan1780_evb/pan1780_evb.dts
+++ b/boards/arm/pan1780_evb/pan1780_evb.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/pan1781_evb/pan1781_evb.dts
+++ b/boards/arm/pan1781_evb/pan1781_evb.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/pan1782_evb/pan1782_evb.dts
+++ b/boards/arm/pan1782_evb/pan1782_evb.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/pan1783_evb/pan1783_evb_cpuapp_common.dtsi
+++ b/boards/arm/pan1783_evb/pan1783_evb_cpuapp_common.dtsi
@@ -10,6 +10,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/pan1783_evb/pan1783_evb_cpunet.dts
+++ b/boards/arm/pan1783_evb/pan1783_evb_cpunet.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/pandora_stm32l475/pandora_stm32l475.dts
+++ b/boards/arm/pandora_stm32l475/pandora_stm32l475.dts
@@ -24,6 +24,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/particle_argon/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_argon/dts/mesh_feather.dtsi
@@ -25,6 +25,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram0;

--- a/boards/arm/particle_boron/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_boron/dts/mesh_feather.dtsi
@@ -25,6 +25,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram0;

--- a/boards/arm/particle_xenon/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_xenon/dts/mesh_feather.dtsi
@@ -24,6 +24,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram0;

--- a/boards/arm/pico_pi_m4/pico_pi_m4.dts
+++ b/boards/arm/pico_pi_m4/pico_pi_m4.dts
@@ -22,6 +22,7 @@
 		zephyr,flash = &tcml_code;
 		zephyr,sram = &tcmu_sys;
 		zephyr,console = &uart6;
+		zephyr,log-uart = &uart6;
 		zephyr,shell-uart = &uart6;
 	};
 };

--- a/boards/arm/pinetime_devkit0/pinetime_devkit0.dts
+++ b/boards/arm/pinetime_devkit0/pinetime_devkit0.dts
@@ -19,6 +19,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,bt-mon-uart = &uart0;
 		zephyr,bt-c2h-uart = &uart0;

--- a/boards/arm/pinnacle_100_dvk/pinnacle_100_dvk.dts
+++ b/boards/arm/pinnacle_100_dvk/pinnacle_100_dvk.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/qemu_cortex_a9/qemu_cortex_a9.dts
+++ b/boards/arm/qemu_cortex_a9/qemu_cortex_a9.dts
@@ -37,6 +37,7 @@
 		zephyr,flash      = &flash0;
 		zephyr,sram       = &sram0;
 		zephyr,console    = &uart0;
+		zephyr,log-uart   = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,ocm        = &ocm_low;
 		zephyr,uart-pipe  = &uart1;

--- a/boards/arm/qemu_cortex_m0/qemu_cortex_m0.dts
+++ b/boards/arm/qemu_cortex_m0/qemu_cortex_m0.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,bt-mon-uart = &uart0;
 		zephyr,bt-c2h-uart = &uart0;

--- a/boards/arm/qemu_cortex_m3/qemu_cortex_m3.dts
+++ b/boards/arm/qemu_cortex_m3/qemu_cortex_m3.dts
@@ -18,6 +18,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,bt-uart = &uart2;
 		zephyr,uart-pipe = &uart1;

--- a/boards/arm/qemu_cortex_r5/qemu_cortex_r5.dts
+++ b/boards/arm/qemu_cortex_r5/qemu_cortex_r5.dts
@@ -16,6 +16,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,ocm = &ocm;
 	};

--- a/boards/arm/qomu/qomu.dts
+++ b/boards/arm/qomu/qomu.dts
@@ -16,6 +16,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart1;
+		zephyr,log-uart = &uart1;
 		zephyr,shell-uart = &uart1;
 		zephyr,uart-pipe = &uart1;
 	};

--- a/boards/arm/quick_feather/quick_feather.dts
+++ b/boards/arm/quick_feather/quick_feather.dts
@@ -16,6 +16,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-pipe = &uart0;
 	};

--- a/boards/arm/rak4631_nrf52840/rak4631_nrf52840.dts
+++ b/boards/arm/rak4631_nrf52840/rak4631_nrf52840.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart1;
+		zephyr,log-uart = &uart1;
 		zephyr,shell-uart = &uart1;
 		zephyr,uart-mcumgr = &uart1;
 		zephyr,bt-mon-uart = &uart1;

--- a/boards/arm/rak5010_nrf52840/rak5010_nrf52840.dts
+++ b/boards/arm/rak5010_nrf52840/rak5010_nrf52840.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &uart1;
+		zephyr,log-uart = &uart1;
 		zephyr,shell-uart = &uart1;
 		zephyr,uart-mcumgr = &uart1;
 		zephyr,bt-mon-uart = &uart1;

--- a/boards/arm/raytac_mdbt50q_db_33_nrf52833/raytac_mdbt50q_db_33_nrf52833.dts
+++ b/boards/arm/raytac_mdbt50q_db_33_nrf52833/raytac_mdbt50q_db_33_nrf52833.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/raytac_mdbt50q_db_40_nrf52840/raytac_mdbt50q_db_40_nrf52840.dts
+++ b/boards/arm/raytac_mdbt50q_db_40_nrf52840/raytac_mdbt50q_db_40_nrf52840.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/raytac_mdbt53_db_40_nrf5340/raytac_mdbt53_db_40_nrf5340_cpuapp_common.dts
+++ b/boards/arm/raytac_mdbt53_db_40_nrf5340/raytac_mdbt53_db_40_nrf5340_cpuapp_common.dts
@@ -10,6 +10,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/raytac_mdbt53_db_40_nrf5340/raytac_mdbt53_db_40_nrf5340_cpunet.dts
+++ b/boards/arm/raytac_mdbt53_db_40_nrf5340/raytac_mdbt53_db_40_nrf5340_cpunet.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/raytac_mdbt53v_db_40_nrf5340/raytac_mdbt53v_db_40_nrf5340_cpuapp_common.dts
+++ b/boards/arm/raytac_mdbt53v_db_40_nrf5340/raytac_mdbt53v_db_40_nrf5340_cpuapp_common.dts
@@ -10,6 +10,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/raytac_mdbt53v_db_40_nrf5340/raytac_mdbt53v_db_40_nrf5340_cpunet.dts
+++ b/boards/arm/raytac_mdbt53v_db_40_nrf5340/raytac_mdbt53v_db_40_nrf5340_cpunet.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/rcar_h3_salvatorx/rcar_h3_salvatorx_cr7.dts
+++ b/boards/arm/rcar_h3_salvatorx/rcar_h3_salvatorx_cr7.dts
@@ -17,6 +17,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &scif1;
+		zephyr,log-uart = &scif1;
 		zephyr,shell-uart = &scif1;
 		zephyr,canbus = &can0;
 	};

--- a/boards/arm/rcar_h3ulcb/rcar_h3ulcb_cr7.dts
+++ b/boards/arm/rcar_h3ulcb/rcar_h3ulcb_cr7.dts
@@ -17,6 +17,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &scif1;
+		zephyr,log-uart = &scif1;
 		zephyr,shell-uart = &scif1;
 		zephyr,canbus = &can0;
 	};

--- a/boards/arm/rddrone_fmuk66/rddrone_fmuk66.dts
+++ b/boards/arm/rddrone_fmuk66/rddrone_fmuk66.dts
@@ -38,6 +38,7 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,console = &lpuart0;
+		zephyr,log-uart = &lpuart0;
 		zephyr,shell-uart = &lpuart0;
 		zephyr,uart-pipe = &lpuart0;
 		zephyr,canbus = &flexcan0;

--- a/boards/arm/reel_board/reel_board.dts
+++ b/boards/arm/reel_board/reel_board.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/reel_board/reel_board_v2.dts
+++ b/boards/arm/reel_board/reel_board_v2.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/rm1xx_dvk/rm1xx_dvk.dts
+++ b/boards/arm/rm1xx_dvk/rm1xx_dvk.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,bt-mon-uart = &uart0;
 		zephyr,bt-c2h-uart = &uart0;

--- a/boards/arm/ronoth_lodev/ronoth_lodev.dts
+++ b/boards/arm/ronoth_lodev/ronoth_lodev.dts
@@ -19,6 +19,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/rpi_pico/rpi_pico-common.dtsi
+++ b/boards/arm/rpi_pico/rpi_pico-common.dtsi
@@ -19,6 +19,7 @@
 		zephyr,flash = &flash0;
 		zephyr,flash-controller = &ssi;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,code-partition = &code_partition;
 	};

--- a/boards/arm/ruuvi_ruuvitag/ruuvi_ruuvitag.dts
+++ b/boards/arm/ruuvi_ruuvitag/ruuvi_ruuvitag.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_rtu0_r52_B.overlay
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_rtu0_r52_B.overlay
@@ -7,6 +7,7 @@
 / {
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 	};
 };

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_rtu0_r52_D.overlay
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_rtu0_r52_D.overlay
@@ -7,6 +7,7 @@
 / {
 	chosen {
 		zephyr,console = &uart9;
+		zephyr,log-uart = &uart9;
 		zephyr,shell-uart = &uart9;
 	};
 };

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_rtu1_r52.dts
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_rtu1_r52.dts
@@ -15,6 +15,7 @@
 	chosen {
 		zephyr,sram = &sram1;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,canbus = &can0;
 	};

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_rtu1_r52_B.overlay
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_rtu1_r52_B.overlay
@@ -7,6 +7,7 @@
 / {
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 	};
 };

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_rtu1_r52_D.overlay
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_rtu1_r52_D.overlay
@@ -7,6 +7,7 @@
 / {
 	chosen {
 		zephyr,console = &uart9;
+		zephyr,log-uart = &uart9;
 		zephyr,shell-uart = &uart9;
 	};
 };

--- a/boards/arm/sam4e_xpro/sam4e_xpro.dts
+++ b/boards/arm/sam4e_xpro/sam4e_xpro.dts
@@ -26,6 +26,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/sam4l_ek/sam4l_ek.dts
+++ b/boards/arm/sam4l_ek/sam4l_ek.dts
@@ -21,6 +21,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/sam4s_xplained/sam4s_xplained.dts
+++ b/boards/arm/sam4s_xplained/sam4s_xplained.dts
@@ -25,6 +25,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/sam_e70_xplained/sam_e70_xplained-common.dtsi
+++ b/boards/arm/sam_e70_xplained/sam_e70_xplained-common.dtsi
@@ -21,6 +21,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/sam_v71_xult/sam_v71_xult-common.dtsi
+++ b/boards/arm/sam_v71_xult/sam_v71_xult-common.dtsi
@@ -24,6 +24,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/scobc_module1/scobc_module1.dts
+++ b/boards/arm/scobc_module1/scobc_module1.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &uartlite0;
+		zephyr,log-uart = &uartlite0;
 		zephyr,shell-uart = &uartlite0;
 		zephyr,sram = &hrmem;
 	};

--- a/boards/arm/seeeduino_xiao/seeeduino_xiao.dts
+++ b/boards/arm/seeeduino_xiao/seeeduino_xiao.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &sercom4;
+		zephyr,log-uart = &sercom4;
 		zephyr,shell-uart = &sercom4;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/sensortile_box/sensortile_box.dts
+++ b/boards/arm/sensortile_box/sensortile_box.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/sensortile_box_pro/doc/index.rst
+++ b/boards/arm/sensortile_box_pro/doc/index.rst
@@ -234,8 +234,10 @@ There are two possible options for Zephyr console output:
    / {
        chosen {
           zephyr,console = &uart4;
+          zephyr,log-uart = &uart4;
           zephyr,shell-uart = &uart4;
           //zephyr,console = &cdc_acm_uart0;
+          //zephyr,log-uart = &cdc_acm_uart0;
           //zephyr,shell-uart = &cdc_acm_uart0;
         };
      };
@@ -261,6 +263,7 @@ There are two possible options for Zephyr console output:
    / {
        chosen {
           zephyr,console = &cdc_acm_uart0;
+          zephyr,log-uart = &cdc_acm_uart0;
         };
      };
 

--- a/boards/arm/sensortile_box_pro/sensortile_box_pro.dts
+++ b/boards/arm/sensortile_box_pro/sensortile_box_pro.dts
@@ -21,9 +21,11 @@
 		 * in sensortile_box_pro_defconfig.
 		 *
 		 * zephyr,console = &uart4;
+		 * zephyr,log-uart = &uart4;
 		 * zephyr,shell-uart = &uart4;
 		 */
 		zephyr,console = &cdc_acm_uart0;
+		zephyr,log-uart = &cdc_acm_uart0;
 		zephyr,shell-uart = &cdc_acm_uart0;
 
 		zephyr,sram = &sram0;

--- a/boards/arm/serpente/serpente.dts
+++ b/boards/arm/serpente/serpente.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &sercom2;
+		zephyr,log-uart = &sercom2;
 		zephyr,shell-uart = &sercom2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/sparkfun_pro_micro_rp2040/sparkfun_pro_micro_rp2040.dts
+++ b/boards/arm/sparkfun_pro_micro_rp2040/sparkfun_pro_micro_rp2040.dts
@@ -17,6 +17,7 @@
 		zephyr,flash = &flash0;
 		zephyr,flash-controller = &ssi;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,code-partition = &code_partition;
 	};
 

--- a/boards/arm/sparkfun_thing_plus_nrf9160/sparkfun_thing_plus_nrf9160_common.dtsi
+++ b/boards/arm/sparkfun_thing_plus_nrf9160/sparkfun_thing_plus_nrf9160_common.dtsi
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 	};

--- a/boards/arm/steval_fcu001v1/steval_fcu001v1.dts
+++ b/boards/arm/steval_fcu001v1/steval_fcu001v1.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/stm3210c_eval/stm3210c_eval.dts
+++ b/boards/arm/stm3210c_eval/stm3210c_eval.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/stm32373c_eval/stm32373c_eval.dts
+++ b/boards/arm/stm32373c_eval/stm32373c_eval.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/stm32_min_dev/stm32_min_dev.dtsi
+++ b/boards/arm/stm32_min_dev/stm32_min_dev.dtsi
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,osdp-uart = &usart2;
 		zephyr,sram = &sram0;

--- a/boards/arm/stm32f030_demo/stm32f030_demo.dts
+++ b/boards/arm/stm32f030_demo/stm32f030_demo.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/stm32f072_eval/stm32f072_eval.dts
+++ b/boards/arm/stm32f072_eval/stm32f072_eval.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/stm32f072b_disco/stm32f072b_disco.dts
+++ b/boards/arm/stm32f072b_disco/stm32f072b_disco.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/stm32f0_disco/stm32f0_disco.dts
+++ b/boards/arm/stm32f0_disco/stm32f0_disco.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/stm32f103_mini/stm32f103_mini.dts
+++ b/boards/arm/stm32f103_mini/stm32f103_mini.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/stm32f3_disco/stm32f3_disco.dts
+++ b/boards/arm/stm32f3_disco/stm32f3_disco.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/stm32f3_seco_d23/stm32f3_seco_d23.dts
+++ b/boards/arm/stm32f3_seco_d23/stm32f3_seco_d23.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;

--- a/boards/arm/stm32f401_mini/stm32f401_mini.dts
+++ b/boards/arm/stm32f401_mini/stm32f401_mini.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/stm32f411e_disco/stm32f411e_disco.dts
+++ b/boards/arm/stm32f411e_disco/stm32f411e_disco.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,uart-mcumgr = &usart2;
 		zephyr,sram = &sram0;

--- a/boards/arm/stm32f412g_disco/stm32f412g_disco.dts
+++ b/boards/arm/stm32f412g_disco/stm32f412g_disco.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
+++ b/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/stm32f469i_disco/stm32f469i_disco.dts
+++ b/boards/arm/stm32f469i_disco/stm32f469i_disco.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &usart3;
+		zephyr,log-uart = &usart3;
 		zephyr,shell-uart = &usart3;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/stm32f4_disco/stm32f4_disco.dts
+++ b/boards/arm/stm32f4_disco/stm32f4_disco.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/stm32f723e_disco/stm32f723e_disco.dts
+++ b/boards/arm/stm32f723e_disco/stm32f723e_disco.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &usart6;
+		zephyr,log-uart = &usart6;
 		zephyr,shell-uart = &usart6;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
+++ b/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
@@ -18,6 +18,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/stm32f7508_dk/stm32f7508_dk.dts
+++ b/boards/arm/stm32f7508_dk/stm32f7508_dk.dts
@@ -18,6 +18,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/stm32f769i_disco/stm32f769i_disco.dts
+++ b/boards/arm/stm32f769i_disco/stm32f769i_disco.dts
@@ -17,6 +17,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/stm32g0316_disco/stm32g0316_disco.dts
+++ b/boards/arm/stm32g0316_disco/stm32g0316_disco.dts
@@ -21,6 +21,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/stm32g071b_disco/stm32g071b_disco.dts
+++ b/boards/arm/stm32g071b_disco/stm32g071b_disco.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &usart3;
+		zephyr,log-uart = &usart3;
 		zephyr,shell-uart = &usart3;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/stm32g081b_eval/stm32g081b_eval.dts
+++ b/boards/arm/stm32g081b_eval/stm32g081b_eval.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &usart3;
+		zephyr,log-uart = &usart3;
 		zephyr,shell-uart = &usart3;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/stm32h573i_dk/stm32h573i_dk.dts
+++ b/boards/arm/stm32h573i_dk/stm32h573i_dk.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram1;
 		zephyr,flash = &flash0;

--- a/boards/arm/stm32h735g_disco/stm32h735g_disco.dts
+++ b/boards/arm/stm32h735g_disco/stm32h735g_disco.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &usart3;
+		zephyr,log-uart = &usart3;
 		zephyr,shell-uart = &usart3;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/stm32h747i_disco/stm32h747i_disco_m4.dts
+++ b/boards/arm/stm32h747i_disco/stm32h747i_disco_m4.dts
@@ -16,6 +16,7 @@
 	/* HW resources are split between CM7 and CM4 */
 	chosen {
 		/* zephyr,console = &usart1; */
+		/* zephyr,log-uart = &usart1; */
 		/* zephyr,shell-uart = &usart1; */
 		zephyr,sram = &sram1;
 		zephyr,flash = &flash1;

--- a/boards/arm/stm32h747i_disco/stm32h747i_disco_m7.dts
+++ b/boards/arm/stm32h747i_disco/stm32h747i_disco_m7.dts
@@ -17,6 +17,7 @@
 	/* HW resources are split between CM7 and CM4 */
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/stm32h7b3i_dk/stm32h7b3i_dk.dts
+++ b/boards/arm/stm32h7b3i_dk/stm32h7b3i_dk.dts
@@ -17,6 +17,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/stm32l1_disco/stm32l1_disco.dts
+++ b/boards/arm/stm32l1_disco/stm32l1_disco.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/stm32l476g_disco/stm32l476g_disco.dts
+++ b/boards/arm/stm32l476g_disco/stm32l476g_disco.dts
@@ -19,6 +19,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/stm32l496g_disco/stm32l496g_disco.dts
+++ b/boards/arm/stm32l496g_disco/stm32l496g_disco.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/stm32l4r9i_disco/stm32l4r9i_disco.dts
+++ b/boards/arm/stm32l4r9i_disco/stm32l4r9i_disco.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &usart2;
+		zephyr,log-uart = &usart2;
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/stm32l562e_dk/stm32l562e_dk.dts
+++ b/boards/arm/stm32l562e_dk/stm32l562e_dk.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/stm32l562e_dk/stm32l562e_dk_ns.dts
+++ b/boards/arm/stm32l562e_dk/stm32l562e_dk_ns.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/stm32mp157c_dk2/stm32mp157c_dk2.dts
+++ b/boards/arm/stm32mp157c_dk2/stm32mp157c_dk2.dts
@@ -21,6 +21,7 @@
 		 * stm32mp157c_dk2_defconfig "Serial Port" section in Zephyr
 		 * board documentation.
 		 * zephyr,console = &usart3;
+		 * zephyr,log-uart = &usart3;
 		 * zephyr,shell-uart = &usart3;
 		 */
 		zephyr,flash = &retram;

--- a/boards/arm/stm32vl_disco/stm32vl_disco.dts
+++ b/boards/arm/stm32vl_disco/stm32vl_disco.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/swan_r5/swan_r5.dts
+++ b/boards/arm/swan_r5/swan_r5.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &lpuart1;
+		zephyr,log-uart = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/tdk_robokit1/tdk_robokit1-common.dtsi
+++ b/boards/arm/tdk_robokit1/tdk_robokit1-common.dtsi
@@ -17,6 +17,7 @@
 
 	chosen {
 		zephyr,console = &uart2;
+		zephyr,log-uart = &uart2;
 		zephyr,shell-uart = &uart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/teensy4/teensy40.dts
+++ b/boards/arm/teensy4/teensy40.dts
@@ -26,6 +26,7 @@
 		zephyr,itcm = &itcm;
 		zephyr,dtcm = &dtcm;
 		zephyr,console = &lpuart6; /* Teensy Pins 0(RX1) 1(TX1) */
+		zephyr,log-uart = &lpuart6;
 		zephyr,shell-uart = &lpuart6;
 		zephyr,canbus = &flexcan1; /* Teensy Pins 23(CRX1) 22(CTX1) */
 	};

--- a/boards/arm/thingy52_nrf52832/thingy52_nrf52832.dts
+++ b/boards/arm/thingy52_nrf52832/thingy52_nrf52832.dts
@@ -17,6 +17,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,bt-mon-uart = &uart0;
 		zephyr,bt-c2h-uart = &uart0;

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dtsi
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dtsi
@@ -9,6 +9,7 @@
 / {
 	chosen {
 		zephyr,console = &cdc_acm_uart;
+		zephyr,log-uart = &cdc_acm_uart;
 		zephyr,shell-uart = &cdc_acm_uart;
 		zephyr,uart-mcumgr = &cdc_acm_uart;
 		zephyr,bt-mon-uart = &cdc_acm_uart;

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpunet.dts
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpunet.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/twr_ke18f/twr_ke18f.dts
+++ b/boards/arm/twr_ke18f/twr_ke18f.dts
@@ -48,6 +48,7 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,console = &lpuart0;
+		zephyr,log-uart = &lpuart0;
 		zephyr,shell-uart = &lpuart0;
 		zephyr,uart-pipe = &lpuart0;
 		zephyr,canbus = &flexcan0;

--- a/boards/arm/twr_kv58f220m/twr_kv58f220m.dts
+++ b/boards/arm/twr_kv58f220m/twr_kv58f220m.dts
@@ -32,6 +32,7 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-pipe = &uart0;
 	};

--- a/boards/arm/ubx_bmd300eval_nrf52832/ubx_bmd300eval_nrf52832.dts
+++ b/boards/arm/ubx_bmd300eval_nrf52832/ubx_bmd300eval_nrf52832.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/ubx_bmd330eval_nrf52810/ubx_bmd330eval_nrf52810.dts
+++ b/boards/arm/ubx_bmd330eval_nrf52810/ubx_bmd330eval_nrf52810.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/ubx_bmd340eval_nrf52840/ubx_bmd340eval_nrf52840.dts
+++ b/boards/arm/ubx_bmd340eval_nrf52840/ubx_bmd340eval_nrf52840.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/ubx_bmd345eval_nrf52840/ubx_bmd345eval_nrf52840.dts
+++ b/boards/arm/ubx_bmd345eval_nrf52840/ubx_bmd345eval_nrf52840.dts
@@ -17,6 +17,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/ubx_bmd360eval_nrf52811/ubx_bmd360eval_nrf52811.dts
+++ b/boards/arm/ubx_bmd360eval_nrf52811/ubx_bmd360eval_nrf52811.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/ubx_bmd380eval_nrf52840/ubx_bmd380eval_nrf52840.dts
+++ b/boards/arm/ubx_bmd380eval_nrf52840/ubx_bmd380eval_nrf52840.dts
@@ -17,6 +17,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/ubx_evkannab1_nrf52832/ubx_evkannab1_nrf52832.dts
+++ b/boards/arm/ubx_evkannab1_nrf52832/ubx_evkannab1_nrf52832.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/ubx_evkninab1_nrf52832/ubx_evkninab1_nrf52832.dts
+++ b/boards/arm/ubx_evkninab1_nrf52832/ubx_evkninab1_nrf52832.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/ubx_evkninab3_nrf52840/ubx_evkninab3_nrf52840.dts
+++ b/boards/arm/ubx_evkninab3_nrf52840/ubx_evkninab3_nrf52840.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/ubx_evkninab4_nrf52833/ubx_evkninab4_nrf52833.dts
+++ b/boards/arm/ubx_evkninab4_nrf52833/ubx_evkninab4_nrf52833.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/udoo_neo_full_m4/udoo_neo_full_m4.dts
+++ b/boards/arm/udoo_neo_full_m4/udoo_neo_full_m4.dts
@@ -39,6 +39,7 @@
 		zephyr,flash = &flash;
 		zephyr,sram = &tcmu;
 		zephyr,console = &uart5;
+		zephyr,log-uart = &uart5;
 		zephyr,shell-uart = &uart5;
 	};
 

--- a/boards/arm/usb_kw24d512/usb_kw24d512.dts
+++ b/boards/arm/usb_kw24d512/usb_kw24d512.dts
@@ -20,6 +20,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-pipe = &uart0;
 		zephyr,ieee802154 = &ieee802154;

--- a/boards/arm/v2m_beetle/v2m_beetle.dts
+++ b/boards/arm/v2m_beetle/v2m_beetle.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &uart1;
+		zephyr,log-uart = &uart1;
 		zephyr,shell-uart = &uart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/v2m_musca_b1/v2m_musca_b1.dts
+++ b/boards/arm/v2m_musca_b1/v2m_musca_b1.dts
@@ -21,6 +21,7 @@
 
 	chosen {
 		zephyr,console = &uart1;
+		zephyr,log-uart = &uart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,shell-uart = &uart1;

--- a/boards/arm/v2m_musca_b1/v2m_musca_b1_ns.dts
+++ b/boards/arm/v2m_musca_b1/v2m_musca_b1_ns.dts
@@ -18,6 +18,7 @@
 
 	chosen {
 		zephyr,console = &uart1;
+		zephyr,log-uart = &uart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,shell-uart = &uart1;

--- a/boards/arm/v2m_musca_s1/v2m_musca_s1.dts
+++ b/boards/arm/v2m_musca_s1/v2m_musca_s1.dts
@@ -21,6 +21,7 @@
 
 	chosen {
 		zephyr,console = &uart1;
+		zephyr,log-uart = &uart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &mram0;
 		zephyr,shell-uart = &uart1;

--- a/boards/arm/v2m_musca_s1/v2m_musca_s1_ns.dts
+++ b/boards/arm/v2m_musca_s1/v2m_musca_s1_ns.dts
@@ -18,6 +18,7 @@
 
 	chosen {
 		zephyr,console = &uart1;
+		zephyr,log-uart = &uart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &mram0;
 		zephyr,shell-uart = &uart1;

--- a/boards/arm/vmu_rt1170/vmu_rt1170.dts
+++ b/boards/arm/vmu_rt1170/vmu_rt1170.dts
@@ -27,6 +27,7 @@
 		zephyr,dtcm = &dtcm;
 		zephyr,itcm = &itcm;
 		zephyr,console = &lpuart1;
+		zephyr,log-uart = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,canbus = &flexcan1;
 		zephyr,flash-controller = &mx25um51345g;

--- a/boards/arm/warp7_m4/warp7_m4.dts
+++ b/boards/arm/warp7_m4/warp7_m4.dts
@@ -24,6 +24,7 @@
 		zephyr,flash = &tcml_code;
 		zephyr,sram = &tcmu_sys;
 		zephyr,console = &uart2;
+		zephyr,log-uart = &uart2;
 		zephyr,shell-uart = &uart2;
 	};
 

--- a/boards/arm/waveshare_open103z/waveshare_open103z.dts
+++ b/boards/arm/waveshare_open103z/waveshare_open103z.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,log-uart = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/arm/we_ophelia1ev_nrf52805/we_ophelia1ev_nrf52805.dts
+++ b/boards/arm/we_ophelia1ev_nrf52805/we_ophelia1ev_nrf52805.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/we_proteus2ev_nrf52832/we_proteus2ev_nrf52832.dts
+++ b/boards/arm/we_proteus2ev_nrf52832/we_proteus2ev_nrf52832.dts
@@ -12,6 +12,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/we_proteus3ev_nrf52840/we_proteus3ev_nrf52840.dts
+++ b/boards/arm/we_proteus3ev_nrf52840/we_proteus3ev_nrf52840.dts
@@ -12,6 +12,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;

--- a/boards/arm/wio_terminal/wio_terminal.dts
+++ b/boards/arm/wio_terminal/wio_terminal.dts
@@ -19,6 +19,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &wio_terminal_console;
+		zephyr,log-uart = &wio_terminal_console;
 		zephyr,shell-uart = &wio_terminal_console;
 		zephyr,code-partition = &code_partition;
 		zephyr,display = &ili9341;

--- a/boards/arm/xiao_ble/xiao_ble_common.dtsi
+++ b/boards/arm/xiao_ble/xiao_ble_common.dtsi
@@ -12,6 +12,7 @@
 / {
 	chosen {
 		zephyr,console = &usb_cdc_acm_uart;
+		zephyr,log-uart = &usb_cdc_acm_uart;
 		zephyr,shell-uart = &usb_cdc_acm_uart;
 		zephyr,uart-mcumgr = &usb_cdc_acm_uart;
 		zephyr,bt-mon-uart = &usb_cdc_acm_uart;

--- a/boards/arm/xmc45_relax_kit/xmc45_relax_kit.dts
+++ b/boards/arm/xmc45_relax_kit/xmc45_relax_kit.dts
@@ -52,6 +52,7 @@
 		zephyr,sram = &dsram1;
 		zephyr,flash = &flash0;
 		zephyr,console = &usic1ch1;
+		zephyr,log-uart = &usic1ch1;
 		zephyr,shell-uart = &usic1ch1;
 		zephyr,flash-controller = &flash_controller;
 		zephyr,code-partition = &code_partition;

--- a/boards/arm/xmc47_relax_kit/xmc47_relax_kit.dts
+++ b/boards/arm/xmc47_relax_kit/xmc47_relax_kit.dts
@@ -51,6 +51,7 @@
 		zephyr,sram = &psram1;
 		zephyr,flash = &flash0;
 		zephyr,console = &usic0ch0;
+		zephyr,log-uart = &usic0ch0;
 		zephyr,shell-uart = &usic0ch0;
 		zephyr,flash-controller = &flash_controller;
 		zephyr,code-partition = &code_partition;

--- a/boards/arm/zybo/zybo.dts
+++ b/boards/arm/zybo/zybo.dts
@@ -21,6 +21,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart1;
+		zephyr,log-uart = &uart1;
 		zephyr,shell-uart = &uart1;
 		zephyr,ocm = &ocm_high;
 	};

--- a/boards/arm64/bcm958402m2_a72/bcm958402m2_a72.dts
+++ b/boards/arm64/bcm958402m2_a72/bcm958402m2_a72.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart1;
+		zephyr,log-uart = &uart1;
 		zephyr,shell-uart = &uart1;
 		zephyr,sram = &sram0;
 	};

--- a/boards/arm64/fvp_base_revc_2xaemv8a/fvp_base_revc_2xaemv8a.dts
+++ b/boards/arm64/fvp_base_revc_2xaemv8a/fvp_base_revc_2xaemv8a.dts
@@ -20,6 +20,7 @@
 		zephyr,sram = &dram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 	};
 

--- a/boards/arm64/fvp_baser_aemv8r/fvp_baser_aemv8r.dts
+++ b/boards/arm64/fvp_baser_aemv8r/fvp_baser_aemv8r.dts
@@ -19,6 +19,7 @@
 		zephyr,sram = &dram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 	};
 

--- a/boards/arm64/intel_socfpga_agilex5_socdk/intel_socfpga_agilex5_socdk.dts
+++ b/boards/arm64/intel_socfpga_agilex5_socdk/intel_socfpga_agilex5_socdk.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &mem0;
 	};

--- a/boards/arm64/intel_socfpga_agilex_socdk/intel_socfpga_agilex_socdk.dts
+++ b/boards/arm64/intel_socfpga_agilex_socdk/intel_socfpga_agilex_socdk.dts
@@ -17,6 +17,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &mem0;
 	};

--- a/boards/arm64/khadas_edgev/khadas_edgev.dts
+++ b/boards/arm64/khadas_edgev/khadas_edgev.dts
@@ -15,6 +15,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart2;
+		zephyr,log-uart = &uart2;
 		zephyr,shell-uart = &uart2;
 	};
 

--- a/boards/arm64/mimx8mm_evk/mimx8mm_evk_a53.dts
+++ b/boards/arm64/mimx8mm_evk/mimx8mm_evk_a53.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart4;
+		zephyr,log-uart = &uart4;
 		zephyr,shell-uart = &uart4;
 		zephyr,sram = &sram0;
 	};

--- a/boards/arm64/mimx8mm_evk/mimx8mm_evk_a53_smp.dts
+++ b/boards/arm64/mimx8mm_evk/mimx8mm_evk_a53_smp.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart4;
+		zephyr,log-uart = &uart4;
 		zephyr,shell-uart = &uart4;
 		zephyr,sram = &sram0;
 	};

--- a/boards/arm64/mimx8mn_evk/mimx8mn_evk_a53.dts
+++ b/boards/arm64/mimx8mn_evk/mimx8mn_evk_a53.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart4;
+		zephyr,log-uart = &uart4;
 		zephyr,shell-uart = &uart4;
 		zephyr,sram = &sram0;
 	};

--- a/boards/arm64/mimx8mn_evk/mimx8mn_evk_a53_smp.dts
+++ b/boards/arm64/mimx8mn_evk/mimx8mn_evk_a53_smp.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart4;
+		zephyr,log-uart = &uart4;
 		zephyr,shell-uart = &uart4;
 		zephyr,sram = &sram0;
 	};

--- a/boards/arm64/mimx8mp_evk/mimx8mp_evk_a53.dts
+++ b/boards/arm64/mimx8mp_evk/mimx8mp_evk_a53.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart4;
+		zephyr,log-uart = &uart4;
 		zephyr,shell-uart = &uart4;
 		zephyr,sram = &sram0;
 	};

--- a/boards/arm64/mimx8mp_evk/mimx8mp_evk_a53_smp.dts
+++ b/boards/arm64/mimx8mp_evk/mimx8mp_evk_a53_smp.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart4;
+		zephyr,log-uart = &uart4;
 		zephyr,shell-uart = &uart4;
 		zephyr,sram = &sram0;
 	};

--- a/boards/arm64/mimx93_evk/mimx93_evk_a55.dts
+++ b/boards/arm64/mimx93_evk/mimx93_evk_a55.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &lpuart2;
+		zephyr,log-uart = &lpuart2;
 		zephyr,shell-uart = &lpuart2;
 		zephyr,sram = &sram0;
 	};

--- a/boards/arm64/mimx93_evk/mimx93_evk_a55_sof.dts
+++ b/boards/arm64/mimx93_evk/mimx93_evk_a55_sof.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &lpuart2;
+		zephyr,log-uart = &lpuart2;
 		zephyr,shell-uart = &lpuart2;
 		zephyr,sram = &sram0;
 	};

--- a/boards/arm64/nxp_ls1046ardb/nxp_ls1046ardb.dts
+++ b/boards/arm64/nxp_ls1046ardb/nxp_ls1046ardb.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &uart1;
+		zephyr,log-uart = &uart1;
 		zephyr,shell-uart = &uart1;
 		zephyr,sram = &sram0;
 	};

--- a/boards/arm64/nxp_ls1046ardb/nxp_ls1046ardb_smp_2cores.dts
+++ b/boards/arm64/nxp_ls1046ardb/nxp_ls1046ardb_smp_2cores.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &uart1;
+		zephyr,log-uart = &uart1;
 		zephyr,shell-uart = &uart1;
 		zephyr,sram = &sram0;
 	};

--- a/boards/arm64/nxp_ls1046ardb/nxp_ls1046ardb_smp_4cores.dts
+++ b/boards/arm64/nxp_ls1046ardb/nxp_ls1046ardb_smp_4cores.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &uart1;
+		zephyr,log-uart = &uart1;
 		zephyr,shell-uart = &uart1;
 		zephyr,sram = &sram0;
 	};

--- a/boards/arm64/phycore_am62x_a53/phycore_am62x_a53.dts
+++ b/boards/arm64/phycore_am62x_a53/phycore_am62x_a53.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &ddr0;
 	};

--- a/boards/arm64/qemu_cortex_a53/qemu_cortex_a53.dts
+++ b/boards/arm64/qemu_cortex_a53/qemu_cortex_a53.dts
@@ -20,6 +20,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
 		zephyr,pcie-controller = &pcie;

--- a/boards/arm64/qemu_kvm_arm64/qemu_kvm_arm64.dts
+++ b/boards/arm64/qemu_kvm_arm64/qemu_kvm_arm64.dts
@@ -21,6 +21,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
 		zephyr,pcie-controller = &pcie;

--- a/boards/arm64/rcar_h3ulcb_ca57/rcar_h3ulcb_ca57.dts
+++ b/boards/arm64/rcar_h3ulcb_ca57/rcar_h3ulcb_ca57.dts
@@ -16,6 +16,7 @@
 	chosen {
 		zephyr,sram = &ram;
 		zephyr,console = &scif2;
+		zephyr,log-uart = &scif2;
 		zephyr,shell-uart = &scif2;
 	};
 

--- a/boards/arm64/rcar_salvator_xs_m3/rcar_salvator_xs_m3.dts
+++ b/boards/arm64/rcar_salvator_xs_m3/rcar_salvator_xs_m3.dts
@@ -16,6 +16,7 @@
 	chosen {
 		zephyr,sram = &ram;
 		zephyr,console = &scif2;
+		zephyr,log-uart = &scif2;
 		zephyr,shell-uart = &scif2;
 	};
 

--- a/boards/arm64/rpi_4b/rpi_4b.dts
+++ b/boards/arm64/rpi_4b/rpi_4b.dts
@@ -21,6 +21,7 @@
 
 	chosen {
 		zephyr,console = &uart1;
+		zephyr,log-uart = &uart1;
 		zephyr,shell-uart = &uart1;
 		zephyr,sram = &sram0;
 	};

--- a/boards/arm64/xenvm/xenvm.dts
+++ b/boards/arm64/xenvm/xenvm.dts
@@ -27,6 +27,7 @@
 	chosen {
 		zephyr,sram = &ram;
 		zephyr,console = &xen_hvc;
+		zephyr,log-uart = &xen_hvc;
 	};
 
 	cpus {

--- a/boards/mips/qemu_malta/qemu_malta.dts
+++ b/boards/mips/qemu_malta/qemu_malta.dts
@@ -15,6 +15,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart2;
+		zephyr,log-uart = &uart2;
 		zephyr,shell-uart = &uart2;
 	};
 

--- a/boards/nios2/altera_max10/altera_max10.dts
+++ b/boards/nios2/altera_max10/altera_max10.dts
@@ -17,6 +17,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 	};
 };

--- a/boards/nios2/qemu_nios2/qemu_nios2.dts
+++ b/boards/nios2/qemu_nios2/qemu_nios2.dts
@@ -17,6 +17,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &ns16550_uart;
+		zephyr,log-uart = &ns16550_uart;
 		zephyr,shell-uart = &ns16550_uart;
 	};
 };

--- a/boards/posix/native_posix/native_posix.dts
+++ b/boards/posix/native_posix/native_posix.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,flash = &flash0;

--- a/boards/riscv/adp_xc7k_ae350/adp_xc7k_ae350.dts
+++ b/boards/riscv/adp_xc7k_ae350/adp_xc7k_ae350.dts
@@ -25,6 +25,7 @@
 
 	chosen {
 		zephyr,console = &uart1;
+		zephyr,log-uart = &uart1;
 		zephyr,shell-uart = &uart1;
 		zephyr,sram = &dram;
 		zephyr,flash = &mx25u16;

--- a/boards/riscv/esp32c3_devkitm/esp32c3_devkitm.dts
+++ b/boards/riscv/esp32c3_devkitm/esp32c3_devkitm.dts
@@ -17,6 +17,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/riscv/esp32c3_luatos_core/esp32c3_luatos_core.dts
+++ b/boards/riscv/esp32c3_luatos_core/esp32c3_luatos_core.dts
@@ -12,6 +12,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/riscv/esp32c3_luatos_core/esp32c3_luatos_core_usb.dts
+++ b/boards/riscv/esp32c3_luatos_core/esp32c3_luatos_core_usb.dts
@@ -12,6 +12,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &usb_serial;
+		zephyr,log-uart = &usb_serial;
 		zephyr,shell-uart = &usb_serial;
 		zephyr,flash = &flash0;
 	};

--- a/boards/riscv/gd32vf103c_starter/gd32vf103c_starter.dts
+++ b/boards/riscv/gd32vf103c_starter/gd32vf103c_starter.dts
@@ -17,6 +17,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &usart0;
+		zephyr,log-uart = &usart0;
 		zephyr,shell-uart = &usart0;
 		zephyr,flash-controller = &fmc;
 	};

--- a/boards/riscv/gd32vf103v_eval/gd32vf103v_eval.dts
+++ b/boards/riscv/gd32vf103v_eval/gd32vf103v_eval.dts
@@ -17,6 +17,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &usart0;
+		zephyr,log-uart = &usart0;
 		zephyr,shell-uart = &usart0;
 		zephyr,flash-controller = &fmc;
 	};

--- a/boards/riscv/hifive1/hifive1.dts
+++ b/boards/riscv/hifive1/hifive1.dts
@@ -23,6 +23,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &dtim;
 		zephyr,flash = &flash0;

--- a/boards/riscv/hifive1_revb/hifive1_revb.dts
+++ b/boards/riscv/hifive1_revb/hifive1_revb.dts
@@ -20,6 +20,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &dtim;
 		zephyr,flash = &flash0;

--- a/boards/riscv/hifive_unleashed/hifive_unleashed.dts
+++ b/boards/riscv/hifive_unleashed/hifive_unleashed.dts
@@ -11,6 +11,7 @@
 / {
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &ram0;
 	};

--- a/boards/riscv/hifive_unmatched/hifive_unmatched.dts
+++ b/boards/riscv/hifive_unmatched/hifive_unmatched.dts
@@ -11,6 +11,7 @@
 / {
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &l2lim;
 	};

--- a/boards/riscv/icev_wireless/icev_wireless.dts
+++ b/boards/riscv/icev_wireless/icev_wireless.dts
@@ -17,6 +17,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &usb_serial;
+		zephyr,log-uart = &usb_serial;
 		zephyr,shell-uart = &usb_serial;
 		zephyr,flash = &flash0;
 	};

--- a/boards/riscv/it82xx2_evb/it82xx2_evb.dts
+++ b/boards/riscv/it82xx2_evb/it82xx2_evb.dts
@@ -24,6 +24,7 @@
 
 	chosen {
 		zephyr,console = &uart1;
+		zephyr,log-uart = &uart1;
 		zephyr,shell-uart = &uart1;
 		zephyr,bt-uart = &uart2;
 		zephyr,sram = &sram0;

--- a/boards/riscv/it8xxx2_evb/it8xxx2_evb.dts
+++ b/boards/riscv/it8xxx2_evb/it8xxx2_evb.dts
@@ -24,6 +24,7 @@
 
 	chosen {
 		zephyr,console = &uart1;
+		zephyr,log-uart = &uart1;
 		zephyr,shell-uart = &uart1;
 		zephyr,bt-uart = &uart2;
 		zephyr,sram = &sram0;

--- a/boards/riscv/litex_vexriscv/litex_vexriscv.dts
+++ b/boards/riscv/litex_vexriscv/litex_vexriscv.dts
@@ -13,6 +13,7 @@
 	compatible = "litex,vexriscv";
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &ram0;
 	};

--- a/boards/riscv/longan_nano/longan_nano-common.dtsi
+++ b/boards/riscv/longan_nano/longan_nano-common.dtsi
@@ -9,6 +9,7 @@
 / {
 	chosen {
 		zephyr,console = &usart0;
+		zephyr,log-uart = &usart0;
 		zephyr,shell-uart = &usart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/riscv/m2gl025_miv/m2gl025_miv.dts
+++ b/boards/riscv/m2gl025_miv/m2gl025_miv.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
 		zephyr,sram = &sram0;

--- a/boards/riscv/mpfs_icicle/mpfs_icicle.dts
+++ b/boards/riscv/mpfs_icicle/mpfs_icicle.dts
@@ -21,6 +21,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram1;
 	};

--- a/boards/riscv/neorv32/neorv32.dts
+++ b/boards/riscv/neorv32/neorv32.dts
@@ -22,6 +22,7 @@
 		zephyr,flash = &imem;
 		zephyr,sram = &dmem;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-pipe = &uart0;
 	};

--- a/boards/riscv/niosv_g/niosv_g.dts
+++ b/boards/riscv/niosv_g/niosv_g.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,sram = &sram0;
 	};
 };

--- a/boards/riscv/niosv_m/niosv_m.dts
+++ b/boards/riscv/niosv_m/niosv_m.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,sram = &sram0;
 	};
 };

--- a/boards/riscv/opentitan_earlgrey/opentitan_earlgrey.dts
+++ b/boards/riscv/opentitan_earlgrey/opentitan_earlgrey.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &ram0;
 		zephyr,flash = &flash0;

--- a/boards/riscv/qemu_riscv32/qemu_riscv32.dts
+++ b/boards/riscv/qemu_riscv32/qemu_riscv32.dts
@@ -7,6 +7,7 @@
 / {
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &ram0;
 	};

--- a/boards/riscv/qemu_riscv32/qemu_riscv32_smp.dts
+++ b/boards/riscv/qemu_riscv32/qemu_riscv32_smp.dts
@@ -11,6 +11,7 @@
 / {
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &ram0;
 	};

--- a/boards/riscv/qemu_riscv32/qemu_riscv32_xip.dts
+++ b/boards/riscv/qemu_riscv32/qemu_riscv32_xip.dts
@@ -15,6 +15,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &dtim;
 		zephyr,flash = &flash0;

--- a/boards/riscv/qemu_riscv32e/qemu_riscv32e.dts
+++ b/boards/riscv/qemu_riscv32e/qemu_riscv32e.dts
@@ -12,6 +12,7 @@
 / {
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &ram0;
 	};

--- a/boards/riscv/qemu_riscv64/qemu_riscv64.dts
+++ b/boards/riscv/qemu_riscv64/qemu_riscv64.dts
@@ -8,6 +8,7 @@
 / {
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &ram0;
 	};

--- a/boards/riscv/qemu_riscv64/qemu_riscv64_smp.dts
+++ b/boards/riscv/qemu_riscv64/qemu_riscv64_smp.dts
@@ -11,6 +11,7 @@
 / {
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &ram0;
 	};

--- a/boards/riscv/rv32m1_vega/rv32m1_vega_ri5cy.dts
+++ b/boards/riscv/rv32m1_vega/rv32m1_vega_ri5cy.dts
@@ -16,6 +16,7 @@
 		zephyr,sram = &m4_dtcm;
 		zephyr,flash = &m4_flash;
 		zephyr,console = &lpuart0;
+		zephyr,log-uart = &lpuart0;
 		zephyr,shell-uart = &lpuart0;
 		zephyr,uart-pipe = &lpuart0;
 		zephyr,code-partition = &slot0_partition;

--- a/boards/riscv/rv32m1_vega/rv32m1_vega_zero_riscy.dts
+++ b/boards/riscv/rv32m1_vega/rv32m1_vega_zero_riscy.dts
@@ -16,6 +16,7 @@
 		zephyr,sram = &m0_tcm;
 		zephyr,flash = &m0_flash;
 		zephyr,console = &lpuart0;
+		zephyr,log-uart = &lpuart0;
 		zephyr,uart-pipe = &lpuart0;
 		zephyr,code-partition = &zero_riscy_code_partition;
 	};

--- a/boards/riscv/sparkfun_red_v_things_plus/sparkfun_red_v_things_plus.dts
+++ b/boards/riscv/sparkfun_red_v_things_plus/sparkfun_red_v_things_plus.dts
@@ -18,6 +18,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &dtim;
 		zephyr,flash = &flash0;

--- a/boards/riscv/stamp_c3/stamp_c3.dts
+++ b/boards/riscv/stamp_c3/stamp_c3.dts
@@ -17,6 +17,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/riscv/titanium_ti60_f225/titanium_ti60_f225.dts
+++ b/boards/riscv/titanium_ti60_f225/titanium_ti60_f225.dts
@@ -14,6 +14,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &ram0;
 	};

--- a/boards/riscv/tlsr9518adk80d/tlsr9518adk80d.dts
+++ b/boards/riscv/tlsr9518adk80d/tlsr9518adk80d.dts
@@ -69,6 +69,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &ram_dlm;
 		zephyr,flash = &flash;

--- a/boards/riscv/xiao_esp32c3/xiao_esp32c3.dts
+++ b/boards/riscv/xiao_esp32c3/xiao_esp32c3.dts
@@ -17,6 +17,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &usb_serial;
+		zephyr,log-uart = &usb_serial;
 		zephyr,shell-uart = &usb_serial;
 		zephyr,flash = &flash0;
 		zephyr,canbus = &twai;

--- a/boards/sparc/generic_leon3/generic_leon3.dts
+++ b/boards/sparc/generic_leon3/generic_leon3.dts
@@ -13,6 +13,7 @@
 	compatible = "gaisler,generic-leon3";
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &ram0;
 	};

--- a/boards/sparc/gr716a_mini/gr716a_mini.dts
+++ b/boards/sparc/gr716a_mini/gr716a_mini.dts
@@ -13,6 +13,7 @@
 	compatible = "gaisler,gr716a-mini";
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &dram;
 	};

--- a/boards/sparc/qemu_leon3/qemu_leon3.dts
+++ b/boards/sparc/qemu_leon3/qemu_leon3.dts
@@ -11,6 +11,7 @@
 / {
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &ram0;
 	};

--- a/boards/x86/acrn/acrn.dts
+++ b/boards/x86/acrn/acrn.dts
@@ -25,6 +25,7 @@
 	chosen {
 		zephyr,sram = &dram0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 	};
 };

--- a/boards/x86/intel_adl/intel_adl_crb.dts
+++ b/boards/x86/intel_adl/intel_adl_crb.dts
@@ -12,6 +12,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 	};
 

--- a/boards/x86/intel_adl/intel_adl_rvp.dts
+++ b/boards/x86/intel_adl/intel_adl_rvp.dts
@@ -12,6 +12,7 @@
 
 	chosen {
 		zephyr,console = &uart0_legacy;
+		zephyr,log-uart = &uart0_legacy;
 		zephyr,shell-uart = &uart0_legacy;
 	};
 };

--- a/boards/x86/intel_ehl/intel_ehl_crb.dts
+++ b/boards/x86/intel_ehl/intel_ehl_crb.dts
@@ -19,6 +19,7 @@
 	chosen {
 		zephyr,sram = &dram0;
 		zephyr,console = &uart2;
+		zephyr,log-uart = &uart2;
 		zephyr,shell-uart = &uart2;
 	};
 

--- a/boards/x86/intel_ehl/intel_ehl_crb_sbl.dts
+++ b/boards/x86/intel_ehl/intel_ehl_crb_sbl.dts
@@ -27,6 +27,7 @@
 	chosen {
 		zephyr,sram = &dram0;
 		zephyr,console = &uart2_fixed;
+		zephyr,log-uart = &uart2_fixed;
 		zephyr,shell-uart = &uart2_fixed;
 	};
 };

--- a/boards/x86/intel_ish/intel_ish_5_4_1.dts
+++ b/boards/x86/intel_ish/intel_ish_5_4_1.dts
@@ -15,6 +15,7 @@
 	chosen {
 		zephyr,sram = &sram;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 	};
 };

--- a/boards/x86/intel_ish/intel_ish_5_6_0.dts
+++ b/boards/x86/intel_ish/intel_ish_5_6_0.dts
@@ -15,6 +15,7 @@
 	chosen {
 		zephyr,sram = &sram;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 	};
 };

--- a/boards/x86/intel_ish/intel_ish_5_8_0.dts
+++ b/boards/x86/intel_ish/intel_ish_5_8_0.dts
@@ -15,6 +15,7 @@
 	chosen {
 		zephyr,sram = &sram;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 	};
 };

--- a/boards/x86/intel_rpl/intel_rpl_s_crb.dts
+++ b/boards/x86/intel_rpl/intel_rpl_s_crb.dts
@@ -18,6 +18,7 @@
 	chosen {
 		zephyr,sram = &dram0;
 		zephyr,console = &uart_ec_0;
+		zephyr,log-uart = &uart_ec_0;
 		zephyr,shell-uart = &uart_ec_0;
 	};
 

--- a/boards/x86/qemu_x86/qemu_x86.dts
+++ b/boards/x86/qemu_x86/qemu_x86.dts
@@ -36,6 +36,7 @@
 		zephyr,sram = &dram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,bt-uart = &uart1;
 		zephyr,uart-pipe = &uart1;

--- a/boards/x86/qemu_x86/qemu_x86_lakemont.dts
+++ b/boards/x86/qemu_x86/qemu_x86_lakemont.dts
@@ -28,6 +28,7 @@
 	chosen {
 		zephyr,sram = &dram0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 	};
 

--- a/boards/x86/up_squared/up_squared.dts
+++ b/boards/x86/up_squared/up_squared.dts
@@ -24,6 +24,7 @@
 	chosen {
 		zephyr,sram = &dram0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,bt-uart = &uart1;
 		zephyr,uart-pipe = &uart1;

--- a/boards/xtensa/esp32_devkitc_wroom/esp32_devkitc_wroom.dts
+++ b/boards/xtensa/esp32_devkitc_wroom/esp32_devkitc_wroom.dts
@@ -32,6 +32,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/xtensa/esp32_devkitc_wrover/esp32_devkitc_wrover.dts
+++ b/boards/xtensa/esp32_devkitc_wrover/esp32_devkitc_wrover.dts
@@ -32,6 +32,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/xtensa/esp32_ethernet_kit/esp32_ethernet_kit.dts
+++ b/boards/xtensa/esp32_ethernet_kit/esp32_ethernet_kit.dts
@@ -20,6 +20,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/xtensa/esp32s2_franzininho/esp32s2_franzininho.dts
+++ b/boards/xtensa/esp32s2_franzininho/esp32s2_franzininho.dts
@@ -23,6 +23,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/xtensa/esp32s2_saola/esp32s2_saola.dts
+++ b/boards/xtensa/esp32s2_saola/esp32s2_saola.dts
@@ -23,6 +23,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/xtensa/esp32s3_devkitm/esp32s3_devkitm.dts
+++ b/boards/xtensa/esp32s3_devkitm/esp32s3_devkitm.dts
@@ -21,6 +21,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/xtensa/esp32s3_luatos_core/esp32s3_luatos_core.dts
+++ b/boards/xtensa/esp32s3_luatos_core/esp32s3_luatos_core.dts
@@ -23,6 +23,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/xtensa/esp32s3_luatos_core/esp32s3_luatos_core_usb.dts
+++ b/boards/xtensa/esp32s3_luatos_core/esp32s3_luatos_core_usb.dts
@@ -23,6 +23,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &usb_serial;
+		zephyr,log-uart = &usb_serial;
 		zephyr,shell-uart = &usb_serial;
 		zephyr,flash = &flash0;
 	};

--- a/boards/xtensa/esp_wrover_kit/esp_wrover_kit.dts
+++ b/boards/xtensa/esp_wrover_kit/esp_wrover_kit.dts
@@ -30,6 +30,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
 		zephyr,display = &ili9341;

--- a/boards/xtensa/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2.dts
+++ b/boards/xtensa/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2.dts
@@ -52,6 +52,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/xtensa/intel_adsp_ace15_mtpm/intel_adsp_ace15_mtpm.dts
+++ b/boards/xtensa/intel_adsp_ace15_mtpm/intel_adsp_ace15_mtpm.dts
@@ -20,5 +20,6 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &mem_window3;
+		zephyr,log-uart = &mem_window3;
 	};
 };

--- a/boards/xtensa/intel_adsp_ace20_lnl/intel_adsp_ace20_lnl.dts
+++ b/boards/xtensa/intel_adsp_ace20_lnl/intel_adsp_ace20_lnl.dts
@@ -15,5 +15,6 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &mem_window3;
+		zephyr,log-uart = &mem_window3;
 	};
 };

--- a/boards/xtensa/intel_adsp_cavs25/intel_adsp_cavs25.dts
+++ b/boards/xtensa/intel_adsp_cavs25/intel_adsp_cavs25.dts
@@ -19,5 +19,6 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &mem_window3;
+		zephyr,log-uart = &mem_window3;
 	};
 };

--- a/boards/xtensa/intel_adsp_cavs25/intel_adsp_cavs25_tgph.dts
+++ b/boards/xtensa/intel_adsp_cavs25/intel_adsp_cavs25_tgph.dts
@@ -19,5 +19,6 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &mem_window3;
+		zephyr,log-uart = &mem_window3;
 	};
 };

--- a/boards/xtensa/m5stack_core2/m5stack_core2.dts
+++ b/boards/xtensa/m5stack_core2/m5stack_core2.dts
@@ -28,6 +28,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
 		zephyr,display = &ili9342c;

--- a/boards/xtensa/m5stickc_plus/m5stickc_plus.dts
+++ b/boards/xtensa/m5stickc_plus/m5stickc_plus.dts
@@ -25,6 +25,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
 	};

--- a/boards/xtensa/nxp_adsp_imx8m/nxp_adsp_imx8m.dts
+++ b/boards/xtensa/nxp_adsp_imx8m/nxp_adsp_imx8m.dts
@@ -17,6 +17,7 @@
 		zephyr,sram = &sram0;
 
 		zephyr,console = &uart4;
+		zephyr,log-uart = &uart4;
 		zephyr,shell-uart = &uart4;
 	};
 };

--- a/boards/xtensa/odroid_go/odroid_go.dts
+++ b/boards/xtensa/odroid_go/odroid_go.dts
@@ -16,6 +16,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
 		zephyr,display = &ili9341;

--- a/boards/xtensa/olimex_esp32_evb/olimex_esp32_evb.dts
+++ b/boards/xtensa/olimex_esp32_evb/olimex_esp32_evb.dts
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;

--- a/boards/xtensa/xiao_esp32s3/xiao_esp32s3.dts
+++ b/boards/xtensa/xiao_esp32s3/xiao_esp32s3.dts
@@ -17,6 +17,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &usb_serial;
+		zephyr,log-uart = &usb_serial;
 		zephyr,shell-uart = &usb_serial;
 		zephyr,flash = &flash0;
 	};

--- a/boards/xtensa/yd_esp32/yd_esp32.dts
+++ b/boards/xtensa/yd_esp32/yd_esp32.dts
@@ -32,6 +32,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
+		zephyr,log-uart = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
 	};

--- a/dts/arm64/nxp/nxp_mimx8mm_a53.dtsi
+++ b/dts/arm64/nxp/nxp_mimx8mm_a53.dtsi
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &uart2;
+		zephyr,log-uart = &uart2;
 		zephyr,shell-uart = &uart2;
 	};
 

--- a/dts/arm64/nxp/nxp_mimx8mn_a53.dtsi
+++ b/dts/arm64/nxp/nxp_mimx8mn_a53.dtsi
@@ -16,6 +16,7 @@
 
 	chosen {
 		zephyr,console = &uart2;
+		zephyr,log-uart = &uart2;
 		zephyr,shell-uart = &uart2;
 	};
 

--- a/samples/bluetooth/hci_uart/README.rst
+++ b/samples/bluetooth/hci_uart/README.rst
@@ -165,6 +165,7 @@ so:
    / {
       chosen {
          zephyr,console = &uart0;
+         zephyr,log-uart = &uart0;
          zephyr,shell-uart = &uart0;
          zephyr,bt-c2h-uart = &uart1;
       };
@@ -186,6 +187,7 @@ Similarly, the `zephyr,bt-uart` DTS property selects which uart to use:
    / {
       chosen {
          zephyr,console = &uart0;
+         zephyr,log-uart = &uart0;
          zephyr,shell-uart = &uart0;
          zephyr,bt-uart = &uart1;
       };

--- a/samples/bluetooth/hci_uart_async/README.rst
+++ b/samples/bluetooth/hci_uart_async/README.rst
@@ -131,6 +131,7 @@ so:
    / {
       chosen {
          zephyr,console = &uart0;
+         zephyr,log-uart = &uart0;
          zephyr,shell-uart = &uart0;
          zephyr,bt-c2h-uart = &uart1;
       };
@@ -152,6 +153,7 @@ Similarly, the `zephyr,bt-uart` DTS property selects which uart to use:
    / {
       chosen {
          zephyr,console = &uart0;
+         zephyr,log-uart = &uart0;
          zephyr,shell-uart = &uart0;
          zephyr,bt-uart = &uart1;
       };

--- a/samples/boards/arc_secure_services/em_starterkit_em7d_normal.dts
+++ b/samples/boards/arc_secure_services/em_starterkit_em7d_normal.dts
@@ -24,6 +24,7 @@
 	chosen {
 		zephyr,sram = &ddr0;
 		zephyr,console = &uart1;
+		zephyr,log-uart = &uart1;
 		zephyr,shell-uart = &uart1;
 	};
 

--- a/samples/boards/sensortile_box/app.overlay
+++ b/samples/boards/sensortile_box/app.overlay
@@ -7,6 +7,7 @@
 / {
 	chosen {
 		zephyr,console = &cdc_acm_uart0;
+		zephyr,log-uart = &cdc_acm_uart0;
 	};
 };
 

--- a/samples/boards/stm32/power_mgmt/serial_wakeup/boards/stm32l562e_dk.overlay
+++ b/samples/boards/stm32/power_mgmt/serial_wakeup/boards/stm32l562e_dk.overlay
@@ -2,6 +2,7 @@
 	chosen {
 		/* Comment out these lines to use usart1 as console/shell */
 		zephyr,console = &lpuart1;
+		zephyr,log-uart = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 	};
 };

--- a/samples/drivers/misc/grove_display/boards/serpente.overlay
+++ b/samples/drivers/misc/grove_display/boards/serpente.overlay
@@ -7,6 +7,7 @@
 / {
 	chosen {
 		zephyr,console = &sercom0;
+		zephyr,log-uart = &sercom0;
 		zephyr,shell-uart = &sercom0;
 	};
 };

--- a/samples/net/openthread/coprocessor/boards/nrf52833dk_nrf52833.overlay
+++ b/samples/net/openthread/coprocessor/boards/nrf52833dk_nrf52833.overlay
@@ -8,6 +8,7 @@
 	chosen {
 		zephyr,ot-uart = &uart0;
 		zephyr,console = &uart1;
+		zephyr,log-uart = &uart1;
 	};
 };
 

--- a/samples/net/openthread/coprocessor/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/net/openthread/coprocessor/boards/nrf52840dk_nrf52840.overlay
@@ -8,6 +8,7 @@
 	chosen {
 		zephyr,ot-uart = &uart0;
 		zephyr,console = &uart1;
+		zephyr,log-uart = &uart1;
 	};
 };
 

--- a/samples/net/openthread/coprocessor/boards/tlsr9518adk80d.overlay
+++ b/samples/net/openthread/coprocessor/boards/tlsr9518adk80d.overlay
@@ -8,6 +8,7 @@
 	chosen {
 		zephyr,ot-uart = &uart0;
 		zephyr,console = &uart1;
+		zephyr,log-uart = &uart1;
 	};
 };
 

--- a/samples/subsys/ipc/openamp/remote/boards/mimxrt1160_evk_cm4.overlay
+++ b/samples/subsys/ipc/openamp/remote/boards/mimxrt1160_evk_cm4.overlay
@@ -11,6 +11,7 @@
 	chosen {
 		zephyr,flash = &ocram;
 		zephyr,console = &lpuart2;
+		zephyr,log-uart = &lpuart2;
 		zephyr,shell-uart = &lpuart2;
 		zephyr,ipc_shm = &ocram2_overlay;
 	};

--- a/samples/subsys/ipc/openamp/remote/boards/mimxrt1170_evk_cm4.overlay
+++ b/samples/subsys/ipc/openamp/remote/boards/mimxrt1170_evk_cm4.overlay
@@ -11,6 +11,7 @@
 	chosen {
 		zephyr,flash = &ocram;
 		zephyr,console = &lpuart2;
+		zephyr,log-uart = &lpuart2;
 		zephyr,shell-uart = &lpuart2;
 		zephyr,ipc_shm = &ocram2_overlay;
 	};

--- a/samples/subsys/ipc/openamp/remote/boards/mimxrt1170_evkb_cm4.overlay
+++ b/samples/subsys/ipc/openamp/remote/boards/mimxrt1170_evkb_cm4.overlay
@@ -9,6 +9,7 @@
 	chosen {
 		zephyr,flash = &ocram;
 		zephyr,console = &lpuart2;
+		zephyr,log-uart = &lpuart2;
 		zephyr,shell-uart = &lpuart2;
 		zephyr,ipc_shm = &ocram2_overlay;
 	};

--- a/samples/subsys/logging/logger/segger_uart_rtt.overlay
+++ b/samples/subsys/logging/logger/segger_uart_rtt.overlay
@@ -3,6 +3,7 @@
 / {
 	chosen {
 		zephyr,console = &rtt0;
+		zephyr,log-uart = &rtt0;
 	};
 
 	rtt0: rtt_chan0 {

--- a/snippets/cdc-acm-console/cdc-acm-console.overlay
+++ b/snippets/cdc-acm-console/cdc-acm-console.overlay
@@ -7,6 +7,7 @@
 / {
 	chosen {
 		zephyr,console = &snippet_cdc_acm_console_uart;
+		zephyr,log-uart = &snippet_cdc_acm_console_uart;
 	};
 };
 

--- a/snippets/xen_dom0/xen_dom0.overlay
+++ b/snippets/xen_dom0/xen_dom0.overlay
@@ -11,6 +11,7 @@
 
 	chosen {
 		zephyr,console = &xen_consoleio_hvc;
+		zephyr,log-uart = &xen_consoleio_hvc;
 		zephyr,shell-uart = &xen_consoleio_hvc;
 	};
 

--- a/subsys/logging/backends/Kconfig.uart
+++ b/subsys/logging/backends/Kconfig.uart
@@ -1,9 +1,12 @@
 # Copyright (c) 2021 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+DT_CHOSEN_Z_LOG_UART := zephyr,log-uart
+
 config LOG_BACKEND_UART
 	bool "UART backend"
-	depends on UART_CONSOLE
+	depends on $(dt_chosen_enabled,$(DT_CHOSEN_Z_LOG_UART))
+	depends on SERIAL && SERIAL_HAS_DRIVER
 	default y if !SHELL_BACKEND_SERIAL && !SHELL_BACKEND_RTT
 	select LOG_OUTPUT
 	help

--- a/subsys/logging/backends/log_backend_uart.c
+++ b/subsys/logging/backends/log_backend_uart.c
@@ -24,7 +24,7 @@ LOG_MODULE_REGISTER(log_uart);
 static const char LOG_HEX_SEP[10] = "##ZLOGV1##";
 
 static const struct device *const uart_dev =
-	DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
+	DEVICE_DT_GET(DT_CHOSEN(zephyr_log_uart));
 static struct k_sem sem;
 static volatile bool in_panic;
 static bool use_async;

--- a/tests/drivers/uart/uart_async_api/boards/segger_rtt.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/segger_rtt.overlay
@@ -3,6 +3,7 @@
 / {
 	chosen {
 		zephyr,console = &rtt0;
+		zephyr,log-uart = &rtt0;
 	};
 
 	dut: rtt0: rtt_chan0 {

--- a/tests/drivers/uart/uart_mix_fifo_poll/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/drivers/uart/uart_mix_fifo_poll/boards/nrf52840dk_nrf52840.overlay
@@ -39,6 +39,7 @@
 / {
 	chosen {
 		zephyr,console = &uart1;
+		zephyr,log-uart = &uart1;
 	};
 };
 

--- a/tests/drivers/uart/uart_pm/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/drivers/uart/uart_pm/boards/nrf52840dk_nrf52840.overlay
@@ -39,6 +39,7 @@
 / {
 	chosen {
 		zephyr,console = &uart1;
+		zephyr,log-uart = &uart1;
 	};
 };
 


### PR DESCRIPTION
Changes the UART log backend to use a new dedicated `zephyr,log-uart` node instead of the chosen `zephyr,console` node, just like the `zephyr,shell-uart`.

This helps with the development of cleaner multi-instance UART log backend implementation, see #64917.

Devicetree modified using the following command, with a few exceptions:

```shell
grep -rl 'zephyr,console = ' ./ | xargs sed -i 's/\(.*\)zephyr,console = \&\(.*\)\;/\1zephyr,console = \&\2\;\n\1zephyr,log-uart = \&\2\;/'
```


The compilation of the `log_backend_uart` now depends on having an enabled serial driver & chosen `zephyr,log-uart` node in the devicetree instead of `UART_CONSOLE`

- [ ] migration notes for out-of-tree boards