### PR TITLE
modules: lvgl: add keypad input device

### DIFF
--- a/dts/bindings/input/zephyr,lvgl-keypad-input.yaml
+++ b/dts/bindings/input/zephyr,lvgl-keypad-input.yaml
@@ -1,0 +1,41 @@
+# Copyright 2023 Fabian Blatz <fabianblatz@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  LVGL keypad indev pseudo-device
+
+  Listens for input events and routes the
+  lv_indev_data_t to the underlying keypad lv_indev_t managed by LVGL.
+
+  The property input-codes can be used to setup a mapping of input codes
+  to the lvgl keys. There are lvgl keys that have a special function:
+  https://docs.lvgl.io/master/overview/indev.html#keys.
+
+  The pseudo device can be associated to a specific device to listen only
+  for events from that device. Example configuration:
+
+  #include <zephyr/dt-bindings/lvgl/lvgl.h>
+
+  keypad {
+          compatible = "zephyr,lvgl-keypad-input";
+          input = <&buttons>;
+          input-codes = <INPUT_KEY_1, INPUT_KEY_2>;
+          lvgl-codes = <LV_KEY_NEXT, LV_KEY_PREV>;
+  };
+
+compatible: "zephyr,lvgl-keypad-input"
+
+include: zephyr,lvgl-common-input.yaml
+
+properties:
+  input-codes:
+    type: array
+    required: true
+    description: |
+      Array of input event key codes (INPUT_KEY_* or INPUT_BTN_*).
+
+  lvgl-codes:
+    type: array
+    required: true
+    description: |
+      Array of mapped lvgl keys.

--- a/include/zephyr/dt-bindings/lvgl/lvgl.h
+++ b/include/zephyr/dt-bindings/lvgl/lvgl.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023 Fabian Blatz <fabianblatz@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_LVGL_LVGL_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_LVGL_LVGL_H_
+
+/* Predefined keys to control the focused object.
+ * Values taken from enum _lv_key_t in lv_group.h
+ */
+#define LV_KEY_UP        17
+#define LV_KEY_DOWN      18
+#define LV_KEY_RIGHT     19
+#define LV_KEY_LEFT      20
+#define LV_KEY_ESC       27
+#define LV_KEY_DEL       127
+#define LV_KEY_BACKSPACE 8
+#define LV_KEY_ENTER     10
+#define LV_KEY_NEXT      9
+#define LV_KEY_PREV      11
+#define LV_KEY_HOME      2
+#define LV_KEY_END       3
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_LVGL_LVGL_H_ */

--- a/modules/lvgl/CMakeLists.txt
+++ b/modules/lvgl/CMakeLists.txt
@@ -228,6 +228,7 @@ zephyr_library_sources_ifdef(CONFIG_LV_Z_POINTER_KSCAN  input/lvgl_pointer_kscan
 zephyr_library_sources_ifdef(CONFIG_LV_Z_POINTER_INPUT input/lvgl_pointer_input.c)
 zephyr_library_sources_ifdef(CONFIG_LV_Z_BUTTON_INPUT input/lvgl_button_input.c)
 zephyr_library_sources_ifdef(CONFIG_LV_Z_ENCODER_INPUT input/lvgl_encoder_input.c)
+zephyr_library_sources_ifdef(CONFIG_LV_Z_KEYPAD_INPUT input/lvgl_keypad_input.c)
 
 zephyr_library_link_libraries(LVGL)
 target_link_libraries(LVGL INTERFACE zephyr_interface)

--- a/modules/lvgl/Kconfig.input
+++ b/modules/lvgl/Kconfig.input
@@ -77,4 +77,17 @@ config LV_Z_ENCODER_INPUT_MSGQ_COUNT
 	help
 	  Size of the encoder message queue buffering input events.
 
+config LV_Z_KEYPAD_INPUT
+	bool "Input lvgl keypad"
+	default y
+	depends on INPUT
+	depends on DT_HAS_ZEPHYR_LVGL_KEYPAD_INPUT_ENABLED
+
+config LV_Z_KEYPAD_INPUT_MSGQ_COUNT
+	int "Input keypad queue message count"
+	default 4
+	depends on LV_Z_KEYPAD_INPUT
+	help
+	  Size of the keypad message queue buffering input events.
+
 endmenu

--- a/modules/lvgl/include/lvgl_keypad_input.h
+++ b/modules/lvgl/include/lvgl_keypad_input.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 Fabian Blatz <fabianblatz@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_MODULES_LVGL_LVGL_KEYPAD_INPUT_H_
+#define ZEPHYR_MODULES_LVGL_LVGL_KEYPAD_INPUT_H_
+
+#include <zephyr/device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int lvgl_keypad_input_init(const struct device *dev);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_MODULES_LVGL_LVGL_KEYPAD_INPUT_H_ */

--- a/modules/lvgl/input/lvgl_common_input.c
+++ b/modules/lvgl/input/lvgl_common_input.c
@@ -12,6 +12,7 @@
 #include "lvgl_pointer_input.h"
 #include "lvgl_button_input.h"
 #include "lvgl_encoder_input.h"
+#include "lvgl_keypad_input.h"
 
 LOG_MODULE_DECLARE(lvgl);
 
@@ -89,6 +90,10 @@ int lvgl_init_input_devices(void)
 	DT_FOREACH_STATUS_OKAY_VARGS(zephyr_lvgl_encoder_input, LV_DEV_INIT,
 				     lvgl_encoder_input_init);
 #endif /* CONFIG_LV_Z_ENCODER_INPUT */
+
+#ifdef CONFIG_LV_Z_KEYPAD_INPUT
+	DT_FOREACH_STATUS_OKAY_VARGS(zephyr_lvgl_keypad_input, LV_DEV_INIT, lvgl_keypad_input_init);
+#endif /* CONFIG_LV_Z_KEYPAD_INPUT */
 
 	return 0;
 }

--- a/modules/lvgl/input/lvgl_keypad_input.c
+++ b/modules/lvgl/input/lvgl_keypad_input.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2023 Fabian Blatz <fabianblatz@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT zephyr_lvgl_keypad_input
+
+#include "lvgl_common_input.h"
+#include "lvgl_keypad_input.h"
+#include <zephyr/sys/util.h>
+
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_DECLARE(lvgl);
+
+struct lvgl_keypad_input_config {
+	struct lvgl_common_input_config common_config; /* Needs to be first member */
+	const uint16_t *input_codes;
+	const uint16_t *lvgl_codes;
+	uint8_t num_codes;
+};
+
+static void lvgl_keypad_process_event(const struct device *dev, struct input_event *evt)
+{
+	struct lvgl_common_input_data *data = dev->data;
+	const struct lvgl_keypad_input_config *cfg = dev->config;
+	uint8_t i;
+
+	for (i = 0; i < cfg->num_codes; i++) {
+		if (evt->code == cfg->input_codes[i]) {
+			data->pending_event.key = cfg->lvgl_codes[i];
+			break;
+		}
+	}
+
+	if (i == cfg->num_codes) {
+		LOG_WRN("Ignored input event: %u", evt->code);
+		return;
+	}
+
+	data->pending_event.state = evt->value ? LV_INDEV_STATE_PR : LV_INDEV_STATE_REL;
+	if (k_msgq_put(cfg->common_config.event_msgq, &data->pending_event,
+		       K_NO_WAIT) != 0) {
+		LOG_WRN("Could not put input data into keypad queue");
+	}
+}
+
+int lvgl_keypad_input_init(const struct device *dev)
+{
+	return lvgl_input_register_driver(LV_INDEV_TYPE_KEYPAD, dev);
+}
+
+#define ASSERT_PROPERTIES(inst)                                                                    \
+	BUILD_ASSERT(DT_INST_PROP_LEN(inst, input_codes) == DT_INST_PROP_LEN(inst, lvgl_codes),    \
+		     "Property input-codes must have the same length as lvgl-codes.");
+
+#define LVGL_KEYPAD_INPUT_DEFINE(inst)                                                             \
+	ASSERT_PROPERTIES(inst);                                                                   \
+	LVGL_INPUT_DEFINE(inst, keypad, CONFIG_LV_Z_KEYPAD_INPUT_MSGQ_COUNT,                       \
+			  lvgl_keypad_process_event);                                              \
+	static const uint16_t lvgl_keypad_input_codes_##inst[] = DT_INST_PROP(inst, input_codes);  \
+	static const uint16_t lvgl_keypad_lvgl_codes_##inst[] = DT_INST_PROP(inst, lvgl_codes);    \
+	static const struct lvgl_keypad_input_config lvgl_keypad_input_config_##inst = {           \
+		.common_config.event_msgq = &LVGL_INPUT_EVENT_MSGQ(inst, keypad),                  \
+		.input_codes = lvgl_keypad_input_codes_##inst,                                     \
+		.lvgl_codes = lvgl_keypad_lvgl_codes_##inst,                                       \
+		.num_codes = DT_INST_PROP_LEN(inst, input_codes),                                  \
+	};                                                                                         \
+	static struct lvgl_common_input_data lvgl_common_input_data_##inst;                        \
+	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, &lvgl_common_input_data_##inst,                    \
+			      &lvgl_keypad_input_config_##inst, POST_KERNEL,                       \
+			      CONFIG_INPUT_INIT_PRIORITY, NULL);
+
+DT_INST_FOREACH_STATUS_OKAY(LVGL_KEYPAD_INPUT_DEFINE)

--- a/samples/subsys/display/lvgl/boards/native_posix.overlay
+++ b/samples/subsys/display/lvgl/boards/native_posix.overlay
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/lvgl/lvgl.h>
 
 / {
 	aliases {
@@ -25,16 +26,31 @@
 		button0: button0 {
 			/* gpio0 pin 0 is already aliased to led0 */
 			gpios = <&gpio0 1 GPIO_ACTIVE_HIGH>;
-			zephyr,code = <INPUT_KEY_0>;
+			zephyr,code = <INPUT_KEY_R>;
 		};
 
 		button1: button1 {
 			gpios = <&gpio0 2 GPIO_ACTIVE_HIGH>;
-			zephyr,code = <INPUT_KEY_1>;
+			zephyr,code = <INPUT_KEY_B>;
 		};
 
 		encoder_button: encoder_button {
 			gpios = <&gpio0 3 GPIO_ACTIVE_HIGH>;
+			zephyr,code = <INPUT_KEY_0>;
+		};
+
+		button_left: button_left {
+			gpios = <&gpio0 6 GPIO_ACTIVE_HIGH>;
+			zephyr,code = <INPUT_KEY_LEFT>;
+		};
+
+		button_right: button_right {
+			gpios = <&gpio0 7 GPIO_ACTIVE_HIGH>;
+			zephyr,code = <INPUT_KEY_RIGHT>;
+		};
+
+		button_enter: button_enter {
+			gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>;
 			zephyr,code = <INPUT_KEY_ENTER>;
 		};
 	};
@@ -42,24 +58,31 @@
 	lvgl_button_input {
 		compatible = "zephyr,lvgl-button-input";
 		input = <&keys>;
-		input-codes = <INPUT_KEY_1>;
+		input-codes = <INPUT_KEY_B>;
 		coordinates = <160 120>;
 	};
 
 	lvgl_encoder_input {
 		compatible = "zephyr,lvgl-encoder-input";
 		rotation-input-code = <INPUT_REL_WHEEL>;
-		button-input-code = <INPUT_KEY_ENTER>;
+		button-input-code = <INPUT_KEY_0>;
+	};
+
+	lvgl_keypad_input {
+		compatible = "zephyr,lvgl-keypad-input";
+		input = <&keys>;
+		input-codes = <INPUT_KEY_LEFT INPUT_KEY_RIGHT INPUT_KEY_ENTER>;
+		lvgl-codes = <LV_KEY_LEFT LV_KEY_RIGHT LV_KEY_ENTER>;
 	};
 };
 
 &gpio0 {
-	ngpios = <6>;
+	ngpios = <9>;
 
 	sdl_gpio {
 		status = "okay";
 		compatible = "zephyr,gpio-emul-sdl";
 		/* Skip pin 0 with the unknown code 0 */
-		scancodes = <0 21 5 30 31 32>;
+		scancodes = <0 21 5 30 31 32 80 79 40>;
 	};
 };

--- a/samples/subsys/display/lvgl/src/main.c
+++ b/samples/subsys/display/lvgl/src/main.c
@@ -42,6 +42,11 @@ static const struct device *lvgl_encoder =
 	DEVICE_DT_GET(DT_COMPAT_GET_ANY_STATUS_OKAY(zephyr_lvgl_encoder_input));
 #endif /* CONFIG_LV_Z_ENCODER_INPUT */
 
+#ifdef CONFIG_LV_Z_KEYPAD_INPUT
+static const struct device *lvgl_keypad =
+	DEVICE_DT_GET(DT_COMPAT_GET_ANY_STATUS_OKAY(zephyr_lvgl_keypad_input));
+#endif /* CONFIG_LV_Z_KEYPAD_INPUT */
+
 static void lv_btn_click_callback(lv_event_t *e)
 {
 	ARG_UNUSED(e);
@@ -95,7 +100,7 @@ int main(void)
 	lv_group_t *arc_group;
 
 	arc = lv_arc_create(lv_scr_act());
-	lv_obj_align(arc, LV_ALIGN_CENTER, 0, 0);
+	lv_obj_align(arc, LV_ALIGN_CENTER, 0, -15);
 	lv_obj_set_size(arc, 150, 150);
 
 	arc_group = lv_group_create();
@@ -103,13 +108,28 @@ int main(void)
 	lv_indev_set_group(lvgl_input_get_indev(lvgl_encoder), arc_group);
 #endif /* CONFIG_LV_Z_ENCODER_INPUT */
 
+#ifdef CONFIG_LV_Z_KEYPAD_INPUT
+	lv_obj_t *btn_matrix;
+	lv_group_t *btn_matrix_group;
+	static const char *const btnm_map[] = {"1", "2", "3", "4", ""};
+
+	btn_matrix = lv_btnmatrix_create(lv_scr_act());
+	lv_obj_align(btn_matrix, LV_ALIGN_CENTER, 0, 70);
+	lv_btnmatrix_set_map(btn_matrix, (const char **)btnm_map);
+	lv_obj_set_size(btn_matrix, 100, 50);
+
+	btn_matrix_group = lv_group_create();
+	lv_group_add_obj(btn_matrix_group, btn_matrix);
+	lv_indev_set_group(lvgl_input_get_indev(lvgl_keypad), btn_matrix_group);
+#endif /* CONFIG_LV_Z_KEYPAD_INPUT */
+
 	if (IS_ENABLED(CONFIG_LV_Z_POINTER_KSCAN) || IS_ENABLED(CONFIG_LV_Z_POINTER_INPUT)) {
 		lv_obj_t *hello_world_button;
 
 		hello_world_button = lv_btn_create(lv_scr_act());
-		lv_obj_align(hello_world_button, LV_ALIGN_CENTER, 0, 0);
+		lv_obj_align(hello_world_button, LV_ALIGN_CENTER, 0, -15);
 		lv_obj_add_event_cb(hello_world_button, lv_btn_click_callback, LV_EVENT_CLICKED,
-						NULL);
+				    NULL);
 		hello_world_label = lv_label_create(hello_world_button);
 	} else {
 		hello_world_label = lv_label_create(lv_scr_act());


### PR DESCRIPTION
PR contains implementation of the last remaining LVGL input device, the keypad. The keypad can be used to navigate between widgets. Also if a textarea is focused the keypad can be used essentially as a keyboard for inputing characters. 

The keyboard like functionality can be enabled via Kconfig. For conversion between the input-event-codes I took some inspiration from `kbd loadkeys`. They can be generated with `loadkeys us-acentos --mktable`. 

**Things that still need to be added:**
- A sample which used the new keypad input device. I'd love @kartben idea to have a GUI shell interface.

**Things that I'd love some feedback on:**

- Whats the best way of getting the LVGL codes into the device tree, instead of writing `0x10`. Including `<lvgl.h>` is possible but is it feasable?
