### PR TITLE
scripts: twister: testinstance: store run id between builds

### DIFF
--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -54,7 +54,6 @@ class TestInstance:
         self.retries = 0
 
         self.name = os.path.join(platform.name, testsuite.name)
-        self.run_id = self._get_run_id()
         self.dut = None
         if testsuite.detailed_test_id:
             self.build_dir = os.path.join(outdir, platform.name, testsuite.name)
@@ -63,6 +62,7 @@ class TestInstance:
             source_dir_rel = testsuite.source_dir_rel.rsplit(os.pardir+os.path.sep, 1)[-1]
             self.build_dir = os.path.join(outdir, platform.name, source_dir_rel, testsuite.name)
 
+        self.run_id = self._get_run_id()
         self.domains = None
 
         self.run = False
@@ -84,12 +84,22 @@ class TestInstance:
 
     def _get_run_id(self):
         """ generate run id from instance unique identifier and a random
-        number"""
-
-        hash_object = hashlib.md5(self.name.encode())
-        random_str = f"{random.getrandbits(64)}".encode()
-        hash_object.update(random_str)
-        return hash_object.hexdigest()
+        number
+        If exist, get cached run id from previous run."""
+        run_id = ""
+        run_id_file = os.path.join(self.build_dir, "run_id.txt")
+        if os.path.exists(run_id_file):
+            with open(run_id_file, "r") as fp:
+                run_id = fp.read()
+        else:
+            hash_object = hashlib.md5(self.name.encode())
+            random_str = f"{random.getrandbits(64)}".encode()
+            hash_object.update(random_str)
+            run_id = hash_object.hexdigest()
+            os.makedirs(self.build_dir, exist_ok=True)
+            with open(run_id_file, 'w+') as fp:
+                fp.write(run_id)
+        return run_id
 
     def add_missing_case_status(self, status, reason=None):
         for case in self.testcases:


### PR DESCRIPTION
**Motivation:**
Incremental builds (as much as possible) using twister.

**Challenge:**
At every cmake call from the twister, there is added `-DTC_RUNID="some_random_value"`,
which is translated into a compiler flag (for all compiler invocations).
Thus, every compilation is different (even within the same build folder, even when there was no code change!),
as the compiler's parameter changes.
This prevents incremental compilation - the build system must recompile each file when compiler invocation differs.

**Proposed solution:**
~~Keep using the Run ID feature (adding a random number at the end of the test output, which later can be verified with the expected value by twister).
Pass randomly generated value to the build system by the file i.e. store the value in the file and pass the file path to the build system via parameter
(the same as previously the random value was passed).
The test framework (ztest) takes that file path, loads file content at compilation time, and includes the random value in the test output.~~
EDIT:
Store run id value in the file (at build folder). When next twister run is executed, read that run id value from file and reuse.
This will allow keeping the same cmake arguments between runs and perform incremental build.

**Example twister call**
`./zephyr/scripts/twister --ninja --inline-logs  --outdir twister-build  --jobs 1 -T zephyr/tests/net/buf --platform nrf52840dk_nrf52840 -v -v --no-clean --device-testing --device-serial /dev/ttyACM0`

`--no-clean ` is crucial.

At the first run, there are compiled 143 files (looking at build.log).
Second run (no code change), only 14!
Previously, at every twister run, there were all files compiled (i.e. 143)