### PR TITLE
drivers: mdio: nxp_s32_netc: use instance-based DT macros

### DIFF
--- a/drivers/mdio/mdio_nxp_s32_netc.c
+++ b/drivers/mdio/mdio_nxp_s32_netc.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT nxp_s32_netc_emdio
+
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/mdio.h>
 #include <zephyr/drivers/pinctrl.h>
@@ -12,11 +14,9 @@ LOG_MODULE_REGISTER(nxp_s32_emdio, CONFIG_MDIO_LOG_LEVEL);
 
 #include <Netc_EthSwt_Ip.h>
 
-#define MDIO_NODE	DT_NODELABEL(emdio)
-#define NETC_SWT_IDX	0
-
 struct nxp_s32_mdio_config {
 	const struct pinctrl_dev_config *pincfg;
+	uint8_t instance;
 };
 
 struct nxp_s32_mdio_data {
@@ -26,11 +26,12 @@ struct nxp_s32_mdio_data {
 static int nxp_s32_mdio_read(const struct device *dev, uint8_t prtad,
 			     uint8_t regad, uint16_t *regval)
 {
+	const struct nxp_s32_mdio_config *cfg = dev->config;
 	struct nxp_s32_mdio_data *data = dev->data;
 	Std_ReturnType status;
 
 	k_mutex_lock(&data->rw_mutex, K_FOREVER);
-	status = Netc_EthSwt_Ip_ReadTrcvRegister(NETC_SWT_IDX, prtad, regad, regval);
+	status = Netc_EthSwt_Ip_ReadTrcvRegister(cfg->instance, prtad, regad, regval);
 	k_mutex_unlock(&data->rw_mutex);
 
 	return status == E_OK ? 0 : -EIO;
@@ -39,11 +40,12 @@ static int nxp_s32_mdio_read(const struct device *dev, uint8_t prtad,
 static int nxp_s32_mdio_write(const struct device *dev, uint8_t prtad,
 			      uint8_t regad, uint16_t regval)
 {
+	const struct nxp_s32_mdio_config *cfg = dev->config;
 	struct nxp_s32_mdio_data *data = dev->data;
 	Std_ReturnType status;
 
 	k_mutex_lock(&data->rw_mutex, K_FOREVER);
-	status = Netc_EthSwt_Ip_WriteTrcvRegister(NETC_SWT_IDX, prtad, regad, regval);
+	status = Netc_EthSwt_Ip_WriteTrcvRegister(cfg->instance, prtad, regad, regval);
 	k_mutex_unlock(&data->rw_mutex);
 
 	return status == E_OK ? 0 : -EIO;
@@ -78,19 +80,26 @@ static const struct mdio_driver_api nxp_s32_mdio_api = {
 	.bus_disable = nxp_s32_mdio_noop,
 };
 
-PINCTRL_DT_DEFINE(MDIO_NODE);
+#define NXP_S32_MDIO_HW_INSTANCE_CHECK(i, n) \
+	((DT_INST_REG_ADDR(n) == IP_NETC_EMDIO_##n##_BASE) ? i : 0)
 
-static struct nxp_s32_mdio_data nxp_s32_mdio0_data;
+#define NXP_S32_MDIO_HW_INSTANCE(n) \
+	LISTIFY(__DEBRACKET NETC_F1_INSTANCE_COUNT, NXP_S32_MDIO_HW_INSTANCE_CHECK, (|), n)
 
-static const struct nxp_s32_mdio_config nxp_s32_mdio0_cfg = {
-	.pincfg = PINCTRL_DT_DEV_CONFIG_GET(MDIO_NODE),
-};
+#define NXP_S32_MDIO_INSTANCE_DEFINE(n)						\
+	PINCTRL_DT_INST_DEFINE(n);						\
+	static struct nxp_s32_mdio_data nxp_s32_mdio##n##_data;			\
+	static const struct nxp_s32_mdio_config nxp_s32_mdio##n##_cfg = {	\
+		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),			\
+		.instance = NXP_S32_MDIO_HW_INSTANCE(n),			\
+	};									\
+	DEVICE_DT_INST_DEFINE(n,						\
+			      &nxp_s32_mdio_initialize,				\
+			      NULL,						\
+			      &nxp_s32_mdio##n##_data,				\
+			      &nxp_s32_mdio##n##_cfg,				\
+			      POST_KERNEL,					\
+			      CONFIG_MDIO_INIT_PRIORITY,			\
+			      &nxp_s32_mdio_api);
 
-DEVICE_DT_DEFINE(MDIO_NODE,
-		 &nxp_s32_mdio_initialize,
-		 NULL,
-		 &nxp_s32_mdio0_data,
-		 &nxp_s32_mdio0_cfg,
-		 POST_KERNEL,
-		 CONFIG_MDIO_INIT_PRIORITY,
-		 &nxp_s32_mdio_api);
+DT_INST_FOREACH_STATUS_OKAY(NXP_S32_MDIO_INSTANCE_DEFINE)

--- a/soc/arm/nxp_s32/s32ze/soc.h
+++ b/soc/arm/nxp_s32/s32ze/soc.h
@@ -48,4 +48,7 @@
 #define IP_STM_11_BASE          IP_SMU__STM_0_BASE
 #define IP_STM_12_BASE          IP_SMU__STM_2_BASE
 
+/* NETC */
+#define IP_NETC_EMDIO_0_BASE    IP_NETC__EMDIO_BASE_BASE
+
 #endif /* _NXP_S32_S32ZE_SOC_H_ */


### PR DESCRIPTION
At present, many of the NXP S32 shim drivers do not make use of devicetree instance-based macros because the NXP S32 HAL relies on an index-based approach, requiring knowledge of the peripheral instance index during both compilation and runtime, and this index might not align with the devicetree instance index.

The proposed solution in this patch eliminates this limitation by determining the peripheral instance index during compilation through macrobatics.

Note that for some peripheral instances is needed to redefine the HAL macros of the peripheral base address, since the naming is not uniform for all instances.

```
west build -p -b s32z270dc2_rtu0_r52@D samples/net/telnet/ -t flash -- \
  -DCONFIG_MDIO=y -DCONFIG_MDIO_SHELL=y -DCONFIG_NET_L2_ETHERNET=y

uart:~$ mdio read 0x7 0x2
7[2]: 0x1c
uart:~$ mdio read 0x7 0x3
7[3]: 0xc916
```