### PR TITLE
drivers: mbox: nxp_s32: use instance-based DT macros

### DIFF
--- a/drivers/mbox/mbox_nxp_s32_mru.c
+++ b/drivers/mbox/mbox_nxp_s32_mru.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT nxp_s32_mru
+
 #include <zephyr/drivers/mbox.h>
 #include <zephyr/irq.h>
 #include <zephyr/sys/util_macro.h>
@@ -19,21 +21,10 @@ LOG_MODULE_REGISTER(nxp_s32_mru);
 #define MRU_MBOX_SIZE		4
 #define MRU_CHANNEL_OFFSET	0x1000
 
-#define MRU_NODE(n)		DT_NODELABEL(mru##n)
-#define MRU_BASE(n)		((RTU_MRU_Type *)DT_REG_ADDR(MRU_NODE(n)))
-#define MRU_RX_CHANNELS(n)	DT_PROP_OR(MRU_NODE(n), rx_channels, 0)
-#define MRU_MBOX_ADDR(n, ch, mb)	\
-	(DT_REG_ADDR(MRU_NODE(n)) + ((ch + 1) * MRU_CHANNEL_OFFSET) + (MRU_MBOX_SIZE * mb))
-
 /* Utility macros to convert from GIC index to interrupt group index */
 #define _MRU_IRQ_17		MRU_IP_INT_GROUP_0
 #define _MRU_IRQ_18		MRU_IP_INT_GROUP_1
 #define MRU_INT_GROUP(irq)	_CONCAT(_MRU_IRQ_, irq)
-
-#define _CONCAT7(...)		DT_CAT7(__VA_ARGS__)
-#define MRU_ISR_FUNC(n)							\
-	_CONCAT7(Mru_Ip_RTU, CONFIG_NXP_S32_RTU_INDEX, _MRU, n, _Int,	\
-		 MRU_INT_GROUP(DT_IRQN(MRU_NODE(n))), _IRQHandler)
 
 struct nxp_s32_mru_data {
 	mbox_callback_t cb[MRU_MAX_CHANNELS];
@@ -44,6 +35,7 @@ struct nxp_s32_mru_config {
 	RTU_MRU_Type *base;
 	Mru_Ip_ConfigType hw_cfg;
 	void (*config_irq)(void);
+	uint8_t irq_group;
 };
 
 static inline bool is_rx_channel_valid(const struct device *dev, uint32_t ch)
@@ -178,6 +170,13 @@ static int nxp_s32_mru_init(const struct device *dev)
 	return 0;
 }
 
+void nxp_s32_mru_isr(const struct device *dev)
+{
+	const struct nxp_s32_mru_config *config = dev->config;
+
+	Mru_Ip_IrqHandler(config->hw_cfg.InstanceId, config->irq_group);
+}
+
 static const struct mbox_driver_api nxp_s32_mru_driver_api = {
 	.send = nxp_s32_mru_send,
 	.register_callback = nxp_s32_mru_register_callback,
@@ -186,18 +185,26 @@ static const struct mbox_driver_api nxp_s32_mru_driver_api = {
 	.set_enabled = nxp_s32_mru_set_enabled,
 };
 
-#define MRU_ISR_FUNC_DECLARE(n)		extern void MRU_ISR_FUNC(n)(void)
+#define MRU_BASE(n)		((RTU_MRU_Type *)DT_INST_REG_ADDR(n))
+#define MRU_RX_CHANNELS(n)	DT_INST_PROP_OR(n, rx_channels, 0)
+#define MRU_MBOX_ADDR(n, ch, mb)	\
+	(DT_INST_REG_ADDR(n) + ((ch + 1) * MRU_CHANNEL_OFFSET) + (MRU_MBOX_SIZE * mb))
+
+#define MRU_HW_INSTANCE_CHECK(i, n) \
+	((DT_INST_REG_ADDR(n) == IP_MRU_##i##_BASE) ? i : 0)
+
+#define MRU_HW_INSTANCE(n) \
+	LISTIFY(__DEBRACKET RTU_MRU_INSTANCE_COUNT, MRU_HW_INSTANCE_CHECK, (|), n)
 
 #define MRU_INIT_IRQ_FUNC(n)					\
-	MRU_ISR_FUNC_DECLARE(n);				\
 	static void nxp_s32_mru_##n##_init_irq(void)		\
 	{							\
-		IRQ_CONNECT(DT_IRQN(MRU_NODE(n)),		\
-			    DT_IRQ(MRU_NODE(n), priority),	\
-			    MRU_ISR_FUNC(n),			\
-			    NULL,				\
-			    DT_IRQ(MRU_NODE(n), flags));	\
-		irq_enable(DT_IRQN(MRU_NODE(n)));		\
+		IRQ_CONNECT(DT_INST_IRQN(n),			\
+			    DT_INST_IRQ(n, priority),		\
+			    nxp_s32_mru_isr,			\
+			    DEVICE_DT_INST_GET(n),		\
+			    DT_INST_IRQ(n, flags));		\
+		irq_enable(DT_INST_IRQN(n));			\
 	}
 
 #define MRU_CH_RX_CFG(i, n)								\
@@ -208,7 +215,6 @@ static const struct mbox_driver_api nxp_s32_mru_driver_api = {
 	static uint32_t nxp_s32_mru_##n##_ch_##i##_buf[MRU_MAX_MBOX_PER_CHAN];		\
 	static const Mru_Ip_ReceiveChannelType nxp_s32_mru_##n##_ch_##i##_rx_cfg = {	\
 		.ChannelId = i,								\
-		.InstanceId = n,							\
 		.ChannelIndex = i,							\
 		.NumRxMB = MRU_MAX_MBOX_PER_CHAN,					\
 		.MBAddList = nxp_s32_mru_##n##_ch_##i##_rx_mbox_addr,			\
@@ -224,7 +230,7 @@ static const struct mbox_driver_api nxp_s32_mru_driver_api = {
 #define MRU_CH_RX_LINK_CFG(i, n)							\
 	static const Mru_Ip_MBLinkReceiveChannelType					\
 	nxp_s32_mru_##n##_ch_##i##_rx_link_cfg[MRU_MAX_MBOX_PER_CHAN][MRU_MAX_INT_GROUPS] = {\
-		MRU_CH_RX_LINK_CFG_MBOX(0, n, i, MRU_INT_GROUP(DT_IRQN(MRU_NODE(n))))	\
+		MRU_CH_RX_LINK_CFG_MBOX(0, n, i, MRU_INT_GROUP(DT_INST_IRQN(n)))	\
 	}
 
 #define MRU_CH_CFG(i, n)								\
@@ -232,7 +238,7 @@ static const struct mbox_driver_api nxp_s32_mru_driver_api = {
 		.ChCFG0Add = &MRU_BASE(n)->CHXCONFIG[i].CH_CFG0,			\
 		.ChCFG0 = RTU_MRU_CH_CFG0_IE(0) | RTU_MRU_CH_CFG0_MBE0(0),		\
 		.ChCFG1Add = &MRU_BASE(n)->CHXCONFIG[i].CH_CFG1,			\
-		.ChCFG1 = RTU_MRU_CH_CFG1_MBIC0(MRU_INT_GROUP(DT_IRQN(MRU_NODE(n)))),	\
+		.ChCFG1 = RTU_MRU_CH_CFG1_MBIC0(MRU_INT_GROUP(DT_INST_IRQN(n))),	\
 		.ChMBSTATAdd = &MRU_BASE(n)->CHXCONFIG[i].CH_MBSTAT,			\
 		.NumMailbox = MRU_MAX_MBOX_PER_CHAN,					\
 		.MBLinkReceiveChCfg = nxp_s32_mru_##n##_ch_##i##_rx_link_cfg		\
@@ -242,7 +248,7 @@ static const struct mbox_driver_api nxp_s32_mru_driver_api = {
 #define MRU_CALLBACK_WRAPPER_FUNC(n)								\
 	void nxp_s32_mru_##n##_cb(uint8_t channel, const uint32_t *buf, uint8_t mbox_count)	\
 	{											\
-		const struct device *dev = DEVICE_DT_GET(MRU_NODE(n));				\
+		const struct device *dev = DEVICE_DT_INST_GET(n);				\
 		struct nxp_s32_mru_data *data = dev->data;					\
 												\
 		if (is_rx_channel_valid(dev, channel)) {					\
@@ -271,7 +277,7 @@ static const struct mbox_driver_api nxp_s32_mru_driver_api = {
 	static struct nxp_s32_mru_config nxp_s32_mru_##n##_config = {			\
 		.base = MRU_BASE(n),							\
 		.hw_cfg = {								\
-			.InstanceId = n,						\
+			.InstanceId = MRU_HW_INSTANCE(n),				\
 			.StateIndex = n,						\
 			.NumChannel = MRU_RX_CHANNELS(n),				\
 			.ChannelCfg = COND_CODE_0(MRU_RX_CHANNELS(n),			\
@@ -281,43 +287,14 @@ static const struct mbox_driver_api nxp_s32_mru_driver_api = {
 				&MRU_BASE(n)->NOTIFY1					\
 			},								\
 		},									\
+		.irq_group = MRU_INT_GROUP(DT_INST_IRQN(n)),				\
 		.config_irq = COND_CODE_0(MRU_RX_CHANNELS(n),				\
 					  (NULL), (nxp_s32_mru_##n##_init_irq)),	\
 	};										\
 											\
-	DEVICE_DT_DEFINE(MRU_NODE(n), nxp_s32_mru_init, NULL,				\
+	DEVICE_DT_INST_DEFINE(n, nxp_s32_mru_init, NULL,				\
 			&nxp_s32_mru_##n##_data, &nxp_s32_mru_##n##_config,		\
 			POST_KERNEL, CONFIG_MBOX_INIT_PRIORITY,				\
-			&nxp_s32_mru_driver_api)
+			&nxp_s32_mru_driver_api);
 
-#if DT_NODE_HAS_STATUS(MRU_NODE(0), okay)
-MRU_INSTANCE_DEFINE(0);
-#endif
-
-#if DT_NODE_HAS_STATUS(MRU_NODE(1), okay)
-MRU_INSTANCE_DEFINE(1);
-#endif
-
-#if DT_NODE_HAS_STATUS(MRU_NODE(2), okay)
-MRU_INSTANCE_DEFINE(2);
-#endif
-
-#if DT_NODE_HAS_STATUS(MRU_NODE(3), okay)
-MRU_INSTANCE_DEFINE(3);
-#endif
-
-#if DT_NODE_HAS_STATUS(MRU_NODE(4), okay)
-MRU_INSTANCE_DEFINE(4);
-#endif
-
-#if DT_NODE_HAS_STATUS(MRU_NODE(5), okay)
-MRU_INSTANCE_DEFINE(5);
-#endif
-
-#if DT_NODE_HAS_STATUS(MRU_NODE(6), okay)
-MRU_INSTANCE_DEFINE(6);
-#endif
-
-#if DT_NODE_HAS_STATUS(MRU_NODE(7), okay)
-MRU_INSTANCE_DEFINE(7);
-#endif
+DT_INST_FOREACH_STATUS_OKAY(MRU_INSTANCE_DEFINE)

--- a/soc/arm/nxp_s32/s32ze/soc.h
+++ b/soc/arm/nxp_s32/s32ze/soc.h
@@ -51,4 +51,14 @@
 /* NETC */
 #define IP_NETC_EMDIO_0_BASE    IP_NETC__EMDIO_BASE_BASE
 
+/* MRU */
+#define IP_MRU_0_BASE           IP_RTU0__MRU_0_BASE
+#define IP_MRU_1_BASE           IP_RTU0__MRU_1_BASE
+#define IP_MRU_2_BASE           IP_RTU0__MRU_2_BASE
+#define IP_MRU_3_BASE           IP_RTU0__MRU_3_BASE
+#define IP_MRU_4_BASE           IP_RTU1__MRU_0_BASE
+#define IP_MRU_5_BASE           IP_RTU1__MRU_1_BASE
+#define IP_MRU_6_BASE           IP_RTU1__MRU_2_BASE
+#define IP_MRU_7_BASE           IP_RTU1__MRU_3_BASE
+
 #endif /* _NXP_S32_S32ZE_SOC_H_ */


### PR DESCRIPTION
At present, many of the NXP S32 shim drivers do not make use of devicetree instance-based macros because the NXP S32 HAL relies on an index-based approach, requiring knowledge of the peripheral instance index during both compilation and runtime, and this index might not align with the devicetree instance index.

The proposed solution in this patch eliminates this limitation by determining the peripheral instance index during compilation through macrobatics and defining the driver's ISR within the shim driver itself.

Note that for some peripheral instances is needed to redefine the HAL macros of the peripheral base address, since the naming is not uniform for all instances.

Tested indirectly with the NETC driver using this MBOX driver:
```
west build -p -b s32z270dc2_rtu0_r52@D samples/net/telnet/ -t flash -- -DCONFIG_NET_L2_ETHERNET=y

*** Booting Zephyr OS build zephyr-v3.5.0-1236-g8c6816982563 ***

uart:~$ net ping 192.0.2.2
PING 192.0.2.2
28 bytes from 192.0.2.2 to 192.0.2.1: icmp_seq=1 ttl=64 time=0.63 ms
28 bytes from 192.0.2.2 to 192.0.2.1: icmp_seq=2 ttl=64 time=0.35 ms
28 bytes from 192.0.2.2 to 192.0.2.1: icmp_seq=3 ttl=64 time=0.35 ms
```