### PR TITLE
tests: kernel: also move the test_isr_dynamic to new ztest API

### DIFF
--- a/tests/kernel/interrupt/src/dynamic_isr.c
+++ b/tests/kernel/interrupt/src/dynamic_isr.c
@@ -73,7 +73,7 @@ ZTEST(interrupt_feature, test_isr_dynamic)
 #define TEST_IRQ_DYN_LINE 5
 #endif
 
-void test_isr_dynamic(void)
+ZTEST(interrupt_feature, test_isr_dynamic)
 {
 	int vector_num;
 
@@ -118,5 +118,6 @@ extern const void *x86_irq_args[];
 			"interrupt triggered but handler has not run(%d)",
 			handler_has_run);
 
+	irq_disable(TEST_IRQ_DYN_LINE);
 }
 #endif /* CONFIG_GEN_SW_ISR_TABLE */


### PR DESCRIPTION
The tests in this folder were ported to the new ztest api in commit b7f1e9872495ee29d223cd7b5c2f8fb5eceab2cd. However, `test_isr_dynamic` for `CONFIG_GEN_SW_ISR_TABLE=n` was somehow overlooked.