### PR TITLE
ci: doc-build: only rebase on pull requests, fix PDF generation again

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -50,6 +50,7 @@ jobs:
         fetch-depth: 0
 
     - name: Rebase
+      if: github.event_name == 'pull_request'
       continue-on-error: true
       env:
         BASE_REF: ${{ github.base_ref }}

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -161,6 +161,10 @@ jobs:
       cancel-in-progress: true
 
     steps:
+    - name: Apply container owner mismatch workaround
+      run: |
+        git config --global --add safe.directory ${GITHUB_WORKSPACE}
+
     - name: checkout
       uses: actions/checkout@v3
 


### PR DESCRIPTION
> With that in mind, I think it's fair to keep it for now and re-evaluate next time the generation fails.

https://github.com/zephyrproject-rtos/zephyr/issues/64120#issuecomment-1795876979 foreshadowing...

---

Skip the rebase on non pull request run (there's no base), apply the container fix to the workflow, this is currently failing the PDF generation. Again.