### PR TITLE
boards: beagle_bcf: Move gpio-i2c-switch to i2c bus

### DIFF
--- a/boards/arm/beagle_bcf/beagleconnect_freedom.dts
+++ b/boards/arm/beagle_bcf/beagleconnect_freedom.dts
@@ -56,15 +56,6 @@
 				<&gpio0 30 GPIO_ACTIVE_HIGH>; // SubG TX/RX 0dB
 		};
 	};
-
-	sens_i2c: sensor-switch {
-		status = "okay";
-		compatible = "gpio-i2c-switch";
-		#address-cells = <1>;
-		#size-cells = <0>;
-		controller = <&i2c0>;
-		gpios = <&gpio0 14 GPIO_ACTIVE_HIGH>;
-	};
 };
 
 &flash0 {
@@ -127,16 +118,25 @@
 		reg = <0x4>;
 	};
 
-	light: opt3001-light@44 {
+	sens_i2c: sensor-switch {
 		status = "okay";
-		compatible = "ti,opt3001";
-		reg = <0x44>;
-	};
+		compatible = "gpio-i2c-switch";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		controller = <&i2c0>;
+		gpios = <&gpio0 14 GPIO_ACTIVE_HIGH>;
 
-	humidity: hdc2010-humidity@41 {
-		status = "okay";
-		compatible = "ti,hdc2010";
-		reg = <0x41>;
+		light: opt3001-light@44 {
+			status = "okay";
+			compatible = "ti,opt3001";
+			reg = <0x44>;
+		};
+
+		humidity: hdc2010-humidity@41 {
+			status = "okay";
+			compatible = "ti,hdc2010";
+			reg = <0x41>;
+		};
 	};
 };
 


### PR DESCRIPTION
https://github.com/zephyrproject-rtos/zephyr/pull/64881 breaks https://github.com/zephyrproject-rtos/zephyr/pull/64693 

Instead of reverting, I thought it might be better to move the whole switch to i2c.