### PR TITLE
zbus: Fix parameter order of net buf pool fixed define

### DIFF
--- a/subsys/zbus/zbus.c
+++ b/subsys/zbus/zbus.c
@@ -29,8 +29,8 @@ static inline struct net_buf *_zbus_create_net_buf(struct net_buf_pool *pool, si
 #else
 
 NET_BUF_POOL_FIXED_DEFINE(_zbus_msg_subscribers_pool,
-			  (CONFIG_ZBUS_MSG_SUBSCRIBER_NET_BUF_STATIC_DATA_SIZE),
 			  (CONFIG_ZBUS_MSG_SUBSCRIBER_NET_BUF_POOL_SIZE),
+			  (CONFIG_ZBUS_MSG_SUBSCRIBER_NET_BUF_STATIC_DATA_SIZE),
 			  sizeof(struct zbus_channel *), NULL);
 
 static inline struct net_buf *_zbus_create_net_buf(struct net_buf_pool *pool, size_t size,


### PR DESCRIPTION
Fixed order of pool-size and data-size parameters  in use of `NET_BUF_POOL_FIXED_DEFINE()`

`NET_BUF_POOL_FIXED_DEFINE` [(declared here)](https://github.com/zephyrproject-rtos/zephyr/blob/main/include/zephyr/net/buf.h#L1124) specifies count and then data size. The current usage of this macro specifies data size and then count.