### PR TITLE
net: wifi: Pass psk and sae as const

### DIFF
--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -302,11 +302,11 @@ struct wifi_connect_req_params {
 	/** SSID length */
 	uint8_t ssid_length; /* Max 32 */
 	/** Pre-shared key */
-	uint8_t *psk;
+	const uint8_t *psk;
 	/** Pre-shared key length */
 	uint8_t psk_length; /* Min 8 - Max 64 */
 	/** SAE password (same as PSK but with no length restrictions), optional */
-	uint8_t *sae_password;
+	const uint8_t *sae_password;
 	/** SAE password length */
 	uint8_t sae_password_length; /* No length restrictions */
 	/** Frequency band */


### PR DESCRIPTION
There shouldn't be any reason to be able to modify the passed psk, and having this non-const gives application warnings if passing a constant string.