### PR TITLE
riscv: FPU trap: catch fused multiply-add instructions

### DIFF
--- a/arch/riscv/core/isr.S
+++ b/arch/riscv/core/isr.S
@@ -187,10 +187,23 @@ SECTION_FUNC(exception.entry, _isr_wrapper)
 1:
 #endif
 	andi t0, t2, 0x7f	/* keep only the opcode bits */
+	/*
+	 * Major FP opcodes:
+	 * 0000111 = LOAD-FP
+	 * 0100111 = STORE-FP
+	 * 1000011 = MADD
+	 * 1000111 = MSUB
+	 * 1001011 = NMSUB
+	 * 1001111 = NMADD
+	 * 1010011 = OP-FP
+	 */
 	xori t1, t0, 0b1010011	/* OP-FP */
 	beqz t1, is_fp
-	ori  t0, t0, 0b0100000
-	xori t1, t0, 0b0100111	/* LOAD-FP / STORE-FP */
+	ori  t1, t0, 0b0100000
+	xori t1, t1, 0b0100111	/* LOAD-FP / STORE-FP */
+	beqz t1, is_fp
+	ori  t1, t0, 0b0001100
+	xori t1, t1, 0b1001111	/* MADD / MSUB / NMSUB / NMADD */
 	beqz t1, is_fp
 	/*
 	 * The FRCSR, FSCSR, FRRM, FSRM, FSRMI, FRFLAGS, FSFLAGS and FSFLAGSI

--- a/tests/arch/riscv/fpu_sharing/src/main.c
+++ b/tests/arch/riscv/fpu_sharing/src/main.c
@@ -417,6 +417,34 @@ ZTEST(riscv_fpu_sharing, test_fp_insn_trap)
 		     "got %#llx instead", buf64);
 #endif
 #endif /* CONFIG_RISCV_ISA_EXT_C */
+
+	/* MADD major opcode space */
+	reg = 3579;
+	TEST_TRAP("fcvt.s.w fa1, %0");
+	TEST_TRAP("fmadd.s fa0, fa1, fa1, fa1");
+	TEST_TRAP("fcvt.w.s %0, fa0");
+	zassert_true(reg == 12812820, "got %ld instead", reg);
+
+	/* NMSUB major opcode space */
+	reg = 1234;
+	TEST_TRAP("fcvt.s.w fa1, %0");
+	TEST_TRAP("fmsub.s fa0, fa1, fa1, fa0");
+	TEST_TRAP("fcvt.w.s %0, fa0");
+	zassert_true(reg == -11290064, "got %ld instead", reg);
+
+	/* NMSUB major opcode space */
+	reg = -23;
+	TEST_TRAP("fcvt.s.w fa1, %0");
+	TEST_TRAP("fnmsub.s fa0, fa1, fa1, fa0");
+	TEST_TRAP("fcvt.w.s %0, fa0");
+	zassert_true(reg == -11290593, "got %ld instead", reg);
+
+	/* NMADD major opcode space */
+	reg = 765;
+	TEST_TRAP("fcvt.s.w fa1, %0");
+	TEST_TRAP("fnmadd.s fa0, fa1, fa1, fa1");
+	TEST_TRAP("fcvt.w.s %0, fa0");
+	zassert_true(reg == -585990, "got %ld instead", reg);
 }
 
 ZTEST_SUITE(riscv_fpu_sharing, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
The FMADD, FMSUB, FNMSUB and FNMADD instructions occupy major opcode
spaces of their own, separate from LOAD-FP/STORE-FP and OP-FP spaces.
Insert code to cover them.
