### PR TITLE
Introduce early print

### DIFF
--- a/arch/arm64/core/prep_c.c
+++ b/arch/arm64/core/prep_c.c
@@ -16,10 +16,13 @@
 
 #include <kernel_internal.h>
 #include <zephyr/linker/linker-defs.h>
+#include <zephyr/debug/early_print.h>
 
 extern void z_arm64_mm_init(bool is_primary_core);
 
 __weak void z_arm64_mm_init(bool is_primary_core) { }
+
+__weak void z_early_print_init(int state) { }
 
 /*
  * These simple memset/memcpy alternatives are necessary as the optimized
@@ -53,6 +56,8 @@ void z_early_memcpy(void *dst, const void *src, size_t n)
  */
 void z_arm64_prep_c(void)
 {
+	z_early_print_init(EARLY_PRINT_INIT);
+
 	/* Initialize tpidrro_el0 with our struct _cpu instance address */
 	write_tpidrro_el0((uintptr_t)&_kernel.cpus[0]);
 
@@ -63,6 +68,7 @@ void z_arm64_prep_c(void)
 	z_arm64_safe_exception_stack_init();
 #endif
 	z_arm64_mm_init(true);
+	z_early_print_init(EARLY_PRINT_MMIO_MAP);
 	z_arm64_interrupt_init();
 	z_cstart();
 

--- a/drivers/serial/Kconfig.earlyprint
+++ b/drivers/serial/Kconfig.earlyprint
@@ -1,0 +1,11 @@
+# Copyright (c) 2023 Arm Limited (or its affiliates). All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Configs list here will be included into EARLY_PRINT, see subsys/debug/Kconfig,
+# to support early print mode choices.
+
+config EARLY_PRINT_USE_UART_PL011
+	bool "Use UART PL011"
+	depends on UART_PL011
+	help
+	  Use UART PL011 to do early print

--- a/include/zephyr/debug/early_print.h
+++ b/include/zephyr/debug/early_print.h
@@ -1,0 +1,30 @@
+ /*
+  * Copyright (c) 2023 Arm Limited (or its affiliates). All rights reserved.
+  *
+  * SPDX-License-Identifier: Apache-2.0
+  */
+
+#ifndef ZEPHYR_INCLUDE_DEBUG_EARLY_PRINT_H_
+#define ZEPHYR_INCLUDE_DEBUG_EARLY_PRINT_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Define early print init stages. Different platforms might have their own demands
+ * of init stages, e.g. Arm64 with MMU using UART needs two stages init,
+ * 1) UART device early init, 2) early map for UART MMIO after MMU is enabled.
+ * Most MPU system platforms probably need only one stage, hence currently define
+ * maximum stages for the use cases that demand the most stages.
+ */
+#define EARLY_PRINT_INIT	0
+#define EARLY_PRINT_MMIO_MAP	1
+
+void z_early_print_init(int stage);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -228,6 +228,21 @@ config EARLY_CONSOLE
 	  initialize its driver earlier than normal, in order to get the stdout
 	  sent through the console at the earliest stage possible.
 
+config EARLY_PRINT
+	bool "This option enables print at the earliest stage possible"
+	help
+	  This option will enable print as early as possible, even before
+	  z_cstart(), for debugging purpose.
+
+if EARLY_PRINT
+
+choice
+	prompt "Early print mode"
+
+endchoice
+
+endif # EARLY_PRINT
+
 config ASSERT
 	bool "__ASSERT() macro"
 	default y if TEST

--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -239,6 +239,8 @@ if EARLY_PRINT
 choice
 	prompt "Early print mode"
 
+source "drivers/serial/Kconfig.earlyprint"
+
 endchoice
 
 endif # EARLY_PRINT


### PR DESCRIPTION
Introduce an early print `EARLY_PRINT` which indicates that the CPU can do printk or customized print at the very beginning stage. Introduce a Kconfig choice to support print backend selection in multi serial device cases.

Also, add the necessary function stubs so that the uart driver can easily support such a feature.
Enable early uart by implementing several necessary functions. 

Taking Arm64 as the first arch to support such a feature, handled the uart accesses with SMP in both mapped and unmapped cases.
Use `menuconfig` or `CONFIG_EARLY_PRINT=y CONFIG_EARLY_PRINT_USE_UART_PL011=y` to enable early print with pl011 uart on Arm64 platforms.

Tested with `qemu_cortex_a53`, `qemu_cortex_a53_smp`, `fvp_baser_aemv8r`, and `fvp_baser_aemv8r_smp`

NOTE: This is not an early console as there is already an [early console](https://github.com/zephyrproject-rtos/zephyr/blob/934a09550dd17406426ac92aac89761cbe506520/subsys/debug/Kconfig#L223). This is just an early print with limited features aiming at debugging at early boot stage (e.g. before `z_cstart()`)