### PR TITLE
net: iface: Introduce TX mutex locking

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -254,7 +254,9 @@ static bool net_if_tx(struct net_if *iface, struct net_pkt *pkt)
 			}
 		}
 
+		net_if_tx_lock(iface);
 		status = net_if_l2(iface)->send(iface, pkt);
+		net_if_tx_unlock(iface);
 
 		if (IS_ENABLED(CONFIG_NET_PKT_TXTIME_STATS)) {
 			uint32_t end_tick = k_cycle_get_32();
@@ -426,6 +428,7 @@ static inline void init_iface(struct net_if *iface)
 #endif
 
 	k_mutex_init(&iface->lock);
+	k_mutex_init(&iface->tx_lock);
 
 	api->init(iface);
 }

--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -534,7 +534,9 @@ static void arp_update(struct net_if *iface,
 		 * the pkt are not counted twice and the packet filter
 		 * callbacks are only called once.
 		 */
+		net_if_tx_lock(iface);
 		ret = net_if_l2(iface)->send(iface, pkt);
+		net_if_tx_unlock(iface);
 		if (ret < 0) {
 			net_pkt_unref(pkt);
 		}


### PR DESCRIPTION
A recent iface lock removal in ed17320c3d2e43c76b09dc359d3b371e9d23732d exposed issues with concurrent access on TX to drivers that are not re-entrant.

Reverting that commit does not really solve the problem, as it would still exist if multiple Traffic Class queues are in use.

Therefore, introduce a separate mutex for TX data path, protecting the L2/driver from concurrent transfers from several threads.