### PR TITLE
boards: nxp: doc: Fix typo in imx8mn_evk board specs

### DIFF
--- a/boards/arm64/mimx8mn_evk/doc/index.rst
+++ b/boards/arm64/mimx8mn_evk/doc/index.rst
@@ -7,7 +7,7 @@ Overview
 ********
 
 i.MX8M Nano LPDDR4 EVK board is based on NXP i.MX8M Nano applications
-processor, composed of a quad Cortex®-A53 cluster and a single Cortex®-M47 core.
+processor, composed of a quad Cortex®-A53 cluster and a single Cortex®-M7 core.
 Zephyr OS is ported to run on the Cortex®-A53 core.
 
 - Board features:


### PR DESCRIPTION
The M core on this board is an M7, not M47.

Fixes #65047.