### PR TITLE
drivers: timeaware_gpio: Fix include path

### DIFF
--- a/drivers/misc/timeaware_gpio/timeaware_gpio_intel.c
+++ b/drivers/misc/timeaware_gpio/timeaware_gpio_intel.c
@@ -12,7 +12,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/misc/timeaware_gpio/timeaware_gpio.h>
 #include <zephyr/devicetree.h>
-#include <zephyr/syscall_handler.h>
+#include <zephyr/internal/syscall_handler.h>
 
 /* TGPIO Register offsets */
 #define ART_L           0x00 /* ART lower 32 bit reg */

--- a/include/zephyr/drivers/misc/timeaware_gpio/timeaware_gpio.h
+++ b/include/zephyr/drivers/misc/timeaware_gpio/timeaware_gpio.h
@@ -24,7 +24,7 @@
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <zephyr/device.h>
-#include <zephyr/syscall_handler.h>
+#include <zephyr/internal/syscall_handler.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Fixes CI after syscall_handler changes path.