### PR TITLE
drivers: sensor: adxl367: use explicit conditions

### DIFF
--- a/drivers/sensor/adxl367/adxl367.c
+++ b/drivers/sensor/adxl367/adxl367.c
@@ -46,13 +46,13 @@ static int adxl367_setup_activity_detection(const struct device *dev,
 					  FIELD_PREP(ADXL367_ACT_INACT_CTL_ACT_EN_MSK, th->enable) |
 					  FIELD_PREP(ADXL367_ACT_INACT_CTL_ACT_REF_MSK,
 						     th->referenced));
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 
 	ret = data->hw_tf->write_reg_mask(dev, ADXL367_THRESH_ACT_H, ADXL367_THRESH_H_MSK,
 					  FIELD_PREP(ADXL367_THRESH_H_MSK, th->value >> 6));
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 
@@ -84,13 +84,13 @@ static int adxl367_setup_inactivity_detection(const struct device *dev,
 						     th->enable) |
 					  FIELD_PREP(ADXL367_ACT_INACT_CTL_INACT_REF_MSK,
 						     th->referenced));
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 
 	ret = data->hw_tf->write_reg_mask(dev, ADXL367_THRESH_INACT_H, ADXL367_THRESH_H_MSK,
 					  FIELD_PREP(ADXL367_THRESH_H_MSK, th->value >> 6));
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 
@@ -117,7 +117,7 @@ static int adxl367_set_op_mode(const struct device *dev,
 	ret = data->hw_tf->write_reg_mask(dev, ADXL367_POWER_CTL,
 					  ADXL367_POWER_CTL_MEASURE_MSK,
 					  FIELD_PREP(ADXL367_POWER_CTL_MEASURE_MSK, op_mode));
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 
@@ -259,7 +259,7 @@ static int adxl367_set_inactivity_time(const struct device *dev,
 	struct adxl367_data *data = dev->data;
 
 	ret = data->hw_tf->write_reg(dev, ADXL367_TIME_INACT_H, time >> 8);
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 
@@ -281,13 +281,13 @@ int adxl367_self_test(const struct device *dev)
 	uint8_t read_val[2];
 
 	ret = adxl367_set_op_mode(dev, ADXL367_MEASURE);
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 
 	ret = data->hw_tf->write_reg_mask(dev, ADXL367_SELF_TEST, ADXL367_SELF_TEST_ST_MSK,
 				    FIELD_PREP(ADXL367_SELF_TEST_ST_MSK, 1));
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 
@@ -295,21 +295,21 @@ int adxl367_self_test(const struct device *dev)
 	k_sleep(K_MSEC(40));
 
 	ret = data->hw_tf->read_reg_multiple(dev, ADXL367_X_DATA_H, read_val, 2);
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 
 	x_axis_1 = ((int16_t)read_val[0] << 6) + (read_val[1] >> 2);
 
 	/* extend sign to 16 bits */
-	if (x_axis_1 & BIT(13)) {
+	if ((x_axis_1 & BIT(13)) != 0) {
 		x_axis_1 |= GENMASK(15, 14);
 	}
 
 	ret = data->hw_tf->write_reg_mask(dev, ADXL367_SELF_TEST,
 					  ADXL367_SELF_TEST_ST_FORCE_MSK,
 					  FIELD_PREP(ADXL367_SELF_TEST_ST_FORCE_MSK, 1));
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 
@@ -317,18 +317,18 @@ int adxl367_self_test(const struct device *dev)
 	k_sleep(K_MSEC(40));
 
 	ret = data->hw_tf->read_reg_multiple(dev, ADXL367_X_DATA_H, read_val, 2);
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 
 	x_axis_2 = ((int16_t)read_val[0] << 6) + (read_val[1] >> 2);
 
 	/* extend sign to 16 bits */
-	if (x_axis_2 & BIT(13))
+	if ((x_axis_2 & BIT(13)) != 0)
 		x_axis_2 |= GENMASK(15, 14);
 
 	ret = adxl367_set_op_mode(dev, ADXL367_STANDBY);
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 
@@ -336,7 +336,7 @@ int adxl367_self_test(const struct device *dev)
 					  ADXL367_SELF_TEST_ST_MSK,
 					  FIELD_PREP(ADXL367_SELF_TEST_ST_FORCE_MSK, 0) |
 					  FIELD_PREP(ADXL367_SELF_TEST_ST_MSK, 0));
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 
@@ -395,7 +395,7 @@ int adxl367_set_fifo_sample_sets_nb(const struct device *dev,
 					  ADXL367_FIFO_CONTROL_FIFO_SAMPLES_MSK,
 					  FIELD_PREP(ADXL367_FIFO_CONTROL_FIFO_SAMPLES_MSK,
 					  fifo_samples_msb));
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 
@@ -478,7 +478,7 @@ int adxl367_set_fifo_format(const struct device *dev,
 				    ADXL367_FIFO_CONTROL,
 				    ADXL367_FIFO_CONTROL_FIFO_CHANNEL_MSK,
 				    FIELD_PREP(ADXL367_FIFO_CONTROL_FIFO_CHANNEL_MSK, format));
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 
@@ -551,17 +551,17 @@ int adxl367_fifo_setup(const struct device *dev,
 	int ret;
 
 	ret = adxl367_set_fifo_mode(dev, mode);
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 
 	ret = adxl367_set_fifo_format(dev, format);
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 
 	ret = adxl367_set_fifo_sample_sets_nb(dev, sets_nb);
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 
@@ -581,13 +581,13 @@ static int adxl367_reset(const struct device *dev)
 	struct adxl367_data *data = dev->data;
 
 	ret = adxl367_set_op_mode(dev, ADXL367_STANDBY);
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 
 	/* Writing code 0x52 resets the device */
 	ret = data->hw_tf->write_reg(dev, ADXL367_SOFT_RESET, ADXL367_RESET_CODE);
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 
@@ -614,19 +614,19 @@ int adxl367_get_accel_data(const struct device *dev,
 	uint8_t reg_data, nready = 1U;
 	struct adxl367_data *data = dev->data;
 
-	while (nready) {
+	while (nready != 0) {
 		ret = data->hw_tf->read_reg(dev, ADXL367_STATUS, &reg_data);
-		if (ret) {
+		if (ret != 0) {
 			return ret;
 		}
 
-		if (reg_data & ADXL367_STATUS_DATA_RDY) {
+		if ((reg_data & ADXL367_STATUS_DATA_RDY) != 0) {
 			nready = 0U;
 		}
 	}
 
 	ret = data->hw_tf->read_reg_multiple(dev, ADXL367_X_DATA_H, xyz_values, 6);
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 
@@ -636,15 +636,15 @@ int adxl367_get_accel_data(const struct device *dev,
 	accel_data->z = ((int16_t)xyz_values[4] << 6) + (xyz_values[5] >> 2);
 
 	/* extend sign to 16 bits */
-	if (accel_data->x & BIT(13)) {
+	if ((accel_data->x & BIT(13)) != 0) {
 		accel_data->x |= GENMASK(15, 14);
 	}
 
-	if (accel_data->y & BIT(13)) {
+	if ((accel_data->y & BIT(13)) != 0) {
 		accel_data->y |= GENMASK(15, 14);
 	}
 
-	if (accel_data->z & BIT(13)) {
+	if ((accel_data->z & BIT(13)) != 0) {
 		accel_data->z |= GENMASK(15, 14);
 	}
 
@@ -667,25 +667,25 @@ int adxl367_get_temp_data(const struct device *dev, int16_t *raw_temp)
 	uint8_t reg_data, nready = 1U;
 	struct adxl367_data *data = dev->data;
 
-	while (nready) {
+	while (nready != 0) {
 		ret = data->hw_tf->read_reg(dev, ADXL367_STATUS, &reg_data);
-		if (ret) {
+		if (ret != 0) {
 			return ret;
 		}
 
-		if (reg_data & ADXL367_STATUS_DATA_RDY) {
+		if ((reg_data & ADXL367_STATUS_DATA_RDY) != 0) {
 			nready = 0U;
 		}
 	}
 
 	ret = data->hw_tf->read_reg_multiple(dev, ADXL367_TEMP_H, temp, 2);
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 
 	*raw_temp = ((int16_t)temp[0] << 6) + (temp[1] >> 2);
 	/* extend sign to 16 bits */
-	if (*raw_temp & BIT(13)) {
+	if ((*raw_temp & BIT(13)) != 0) {
 		*raw_temp |= GENMASK(15, 14);
 	}
 
@@ -785,7 +785,7 @@ static int adxl367_sample_fetch(const struct device *dev,
 	int ret;
 
 	ret = adxl367_get_accel_data(dev, &data->sample);
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 
@@ -856,16 +856,16 @@ static int adxl367_probe(const struct device *dev)
 	int ret;
 
 	ret = adxl367_reset(dev);
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 
 	ret = data->hw_tf->read_reg(dev, ADXL367_DEVID, &dev_id);
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 	ret = data->hw_tf->read_reg(dev, ADXL367_PART_ID, &part_id);
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 
@@ -879,47 +879,47 @@ static int adxl367_probe(const struct device *dev)
 	data->act_proc_mode = ADXL367_LOOPED;
 
 	ret = adxl367_self_test(dev);
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 
 	ret = adxl367_temp_read_en(dev, cfg->temp_en);
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 
 	ret = adxl367_set_autosleep(dev, cfg->autosleep);
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 
 	ret = adxl367_set_low_noise(dev, cfg->low_noise);
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 
 	ret = adxl367_setup_activity_detection(dev, &cfg->activity_th);
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 
 	ret = adxl367_setup_inactivity_detection(dev, &cfg->inactivity_th);
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 
 	ret = adxl367_set_activity_time(dev, cfg->activity_time);
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 
 	ret = adxl367_set_inactivity_time(dev, cfg->inactivity_time);
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 
 	ret = adxl367_set_output_rate(dev, cfg->odr);
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 
@@ -927,17 +927,17 @@ static int adxl367_probe(const struct device *dev)
 				 cfg->fifo_config.fifo_format,
 				 cfg->fifo_config.fifo_read_mode,
 				 cfg->fifo_config.fifo_samples);
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 
 	ret = adxl367_set_op_mode(dev, cfg->op_mode);
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 
 	ret = adxl367_set_range(dev, data->range);
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 
@@ -950,7 +950,7 @@ static int adxl367_init(const struct device *dev)
 	const struct adxl367_dev_config *cfg = dev->config;
 
 	ret = cfg->bus_init(dev);
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Failed to initialize sensor bus\n");
 		return ret;
 	}

--- a/drivers/sensor/adxl367/adxl367_i2c.c
+++ b/drivers/sensor/adxl367/adxl367_i2c.c
@@ -23,7 +23,7 @@ static int adxl367_bus_access(const struct device *dev, uint8_t reg,
 {
 	const struct adxl367_dev_config *config = dev->config;
 
-	if (reg & ADXL367_READ) {
+	if ((reg & ADXL367_READ) != 0) {
 		return i2c_burst_read_dt(&config->i2c,
 					 ADXL367_TO_REG(reg),
 					 (uint8_t *) data, length);
@@ -70,7 +70,7 @@ int adxl367_i2c_reg_write_mask(const struct device *dev,
 	uint8_t tmp;
 
 	ret = adxl367_i2c_reg_read(dev, reg_addr, &tmp);
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 

--- a/drivers/sensor/adxl367/adxl367_spi.c
+++ b/drivers/sensor/adxl367/adxl367_spi.c
@@ -24,7 +24,7 @@ static int adxl367_bus_access(const struct device *dev, uint8_t reg,
 	const struct adxl367_dev_config *config = dev->config;
 	uint8_t rw_reg, addr_reg;
 
-	if (reg & ADXL367_READ) {
+	if ((reg & ADXL367_READ) != 0) {
 		rw_reg = ADXL367_SPI_READ_REG;
 	} else {
 		rw_reg = ADXL367_SPI_WRITE_REG;
@@ -49,7 +49,7 @@ static int adxl367_bus_access(const struct device *dev, uint8_t reg,
 		.buffers = buf,
 	};
 
-	if (reg & ADXL367_READ) {
+	if ((reg & ADXL367_READ) != 0) {
 		const struct spi_buf_set rx = {
 			.buffers = buf,
 			.count = 3
@@ -97,7 +97,7 @@ int adxl367_spi_reg_write_mask(const struct device *dev,
 	uint8_t tmp;
 
 	ret = adxl367_spi_reg_read(dev, reg_addr, &tmp);
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 


### PR DESCRIPTION
Make the adxl367 compliant with the Zephyr code guidelines by using explicit conditions.