### PR TITLE
net: lib: coap: coap_server: Allow clients to refresh observe requests

### DIFF
--- a/include/zephyr/net/coap.h
+++ b/include/zephyr/net/coap.h
@@ -935,11 +935,32 @@ bool coap_remove_observer(struct coap_resource *resource,
 			  struct coap_observer *observer);
 
 /**
+ * @brief Returns the observer that matches address @a addr
+ * and has token @a token.
+ *
+ * @param observers Pointer to the array of observers
+ * @param len Size of the array of observers
+ * @param addr Address of the endpoint observing a resource
+ * @param token Pointer to the token
+ * @param token_len Length of valid bytes in the token
+ *
+ * @return A pointer to a observer if a match is found, NULL
+ * otherwise.
+ */
+struct coap_observer *coap_find_observer(
+	struct coap_observer *observers, size_t len,
+	const struct sockaddr *addr,
+	const uint8_t *token, uint8_t token_len);
+
+/**
  * @brief Returns the observer that matches address @a addr.
  *
  * @param observers Pointer to the array of observers
  * @param len Size of the array of observers
  * @param addr Address of the endpoint observing a resource
+ *
+ * @note The function coap_find_observer() should be preferred
+ * if both the observer's address and token are known.
  *
  * @return A pointer to a observer if a match is found, NULL
  * otherwise.
@@ -955,6 +976,9 @@ struct coap_observer *coap_find_observer_by_addr(
  * @param len Size of the array of observers
  * @param token Pointer to the token
  * @param token_len Length of valid bytes in the token
+ *
+ * @note The function coap_find_observer() should be preferred
+ * if both the observer's address and token are known.
  *
  * @return A pointer to a observer if a match is found, NULL
  * otherwise.

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -1913,6 +1913,28 @@ static bool sockaddr_equal(const struct sockaddr *a,
 	return false;
 }
 
+struct coap_observer *coap_find_observer(
+	struct coap_observer *observers, size_t len,
+	const struct sockaddr *addr,
+	const uint8_t *token, uint8_t token_len)
+{
+	if (token_len == 0U || token_len > COAP_TOKEN_MAX_LEN) {
+		return NULL;
+	}
+
+	for (size_t i = 0; i < len; i++) {
+		struct coap_observer *o = &observers[i];
+
+		if (o->tkl == token_len &&
+		    memcmp(o->token, token, token_len) == 0 &&
+		    sockaddr_equal(&o->addr, addr)) {
+			return o;
+		}
+	}
+
+	return NULL;
+}
+
 struct coap_observer *coap_find_observer_by_addr(
 	struct coap_observer *observers, size_t len,
 	const struct sockaddr *addr)


### PR DESCRIPTION
A CoAP client can re-issue an observe request (same endpoint and token) to refresh it's subscription. No new observer should be registered in this case.