### PR TITLE
drivers: can: mcan: remove software RTR filtering

### DIFF
--- a/doc/releases/migration-guide-3.6.rst
+++ b/doc/releases/migration-guide-3.6.rst
@@ -53,6 +53,10 @@ Device Drivers and Device Tree
         };
     };
 
+* The Bosch M_CAN CAN FD controller driver backend no longer supports software-based filtering of
+  Remote Transmission Request (RTR) frames. Applications can still filter on RTR/non-RTR frames in
+  their receive callback functions as needed.
+
 Power Management
 ================
 

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -672,16 +672,6 @@ static void can_mcan_get_message(const struct device *dev, uint16_t fifo_offset,
 			flags = cbs->std[filt_idx].flags;
 		}
 
-		if (((frame.flags & CAN_FRAME_RTR) == 0U && (flags & CAN_FILTER_DATA) == 0U) ||
-		    ((frame.flags & CAN_FRAME_RTR) != 0U && (flags & CAN_FILTER_RTR) == 0U)) {
-			/* RTR bit does not match filter, drop frame */
-			err = can_mcan_write_reg(dev, fifo_ack_reg, get_idx);
-			if (err != 0) {
-				return;
-			}
-			goto ack;
-		}
-
 		if (((frame.flags & CAN_FRAME_FDF) != 0U && (flags & CAN_FILTER_FDF) == 0U) ||
 		    ((frame.flags & CAN_FRAME_FDF) == 0U && (flags & CAN_FILTER_FDF) != 0U)) {
 			/* FDF bit does not match filter, drop frame */
@@ -1122,9 +1112,9 @@ int can_mcan_add_rx_filter(const struct device *dev, can_rx_callback_t callback,
 
 #ifdef CONFIG_CAN_FD_MODE
 	if ((filter->flags &
-	     ~(CAN_FILTER_IDE | CAN_FILTER_DATA | CAN_FILTER_RTR | CAN_FILTER_FDF)) != 0U) {
+	     ~(CAN_FILTER_IDE | CAN_FILTER_DATA | CAN_FILTER_FDF)) != 0U) {
 #else  /* CONFIG_CAN_FD_MODE */
-	if ((filter->flags & ~(CAN_FILTER_IDE | CAN_FILTER_DATA | CAN_FILTER_RTR)) != 0U) {
+	if ((filter->flags & ~(CAN_FILTER_IDE | CAN_FILTER_DATA)) != 0U) {
 #endif /* !CONFIG_CAN_FD_MODE */
 		LOG_ERR("unsupported CAN filter flags 0x%02x", filter->flags);
 		return -ENOTSUP;


### PR DESCRIPTION
Remove software-based filtering of Remote Transmission Request (RTR) frames. Not all CAN controllers support RTR filtering and not supporting it is allowed by the CAN API and API testing.
    
Applications can still filter on RTR/non-RTR frames in their receive callback functions as needed.    

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>