### PR TITLE
docs: services tracing: Replace references to native_posix

### DIFF
--- a/doc/services/tracing/index.rst
+++ b/doc/services/tracing/index.rst
@@ -181,7 +181,7 @@ The following backends are currently supported:
 
 * UART
 * USB
-* File (Using native posix port)
+* File (Using the native port/with POSIX architecture based targets)
 * RTT (With SystemView)
 * RAM (buffer to be retrieved by a debugger)
 


### PR DESCRIPTION
Let's replace the references to native_posix.

Background: during this release native_sim is replacing native_posix as the main host test/development platform.