### PR TITLE
cleanup driver test tags

### DIFF
--- a/samples/boards/stm32/power_mgmt/adc/sample.yaml
+++ b/samples/boards/stm32/power_mgmt/adc/sample.yaml
@@ -3,7 +3,7 @@ sample:
 tests:
   sample.boards.stm32.power_mgmt.adc:
     tags:
-      - ADC
+      - adc
       - power
     harness: console
     harness_config:

--- a/samples/drivers/adc/sample.yaml
+++ b/samples/drivers/adc/sample.yaml
@@ -2,7 +2,8 @@ sample:
   name: ADC driver sample
 tests:
   sample.drivers.adc:
-    tags: ADC
+    tags:
+      - adc
     depends_on: adc
     platform_allow:
       - nucleo_l073rz

--- a/samples/drivers/clock_control_litex/sample.yaml
+++ b/samples/drivers/clock_control_litex/sample.yaml
@@ -4,7 +4,5 @@ tests:
   sample.driver.clock_control_litex:
     platform_allow: litex_vexriscv
     tags:
-      - clock
-      - litex
-      - vexriscv
+      - clock_control
       - mmcm

--- a/samples/drivers/soc_flash_nrf/sample.yaml
+++ b/samples/drivers/soc_flash_nrf/sample.yaml
@@ -10,8 +10,7 @@ tests:
       - nrf52dk_nrf52832
     tags:
       - flash
-      - nrf52
-      - nrf9160
+      - drivers
     harness: console
     harness_config:
       fixture: external_flash

--- a/tests/drivers/build_all/adc/testcase.yaml
+++ b/tests/drivers/build_all/adc/testcase.yaml
@@ -9,53 +9,30 @@ tests:
     platform_allow:
       - native_posix
       - native_posix_64
-    tags:
-      - adc_mcp302x
-      - adc_lmp90xxx
-      - adc_ads1x1x
-      - adc_ads1119
-      - adc_ads1112
-      - adc_ads114s08
-      - adc_emul
-      - adc_max1125x
-      - adc_ltc2451
     extra_args: "CONFIG_GPIO=y"
   drivers.adc.cc32xx.build:
     platform_allow: cc3220sf_launchxl
-    tags: adc_cc32xx
   drivers.adc.ite.it8xxx2.build:
     platform_allow: it8xxx2_evb
-    tags: adc_ite_it8xxx2
   drivers.adc.mcux.adc12.build:
     platform_allow: twr_ke18f
-    tags: adc_mcux_adc12
   drivers.adc.mcux.adc16.build:
     platform_allow: frdm_k22f
-    tags: adc_mcux_adc16
   drivers.adc.mcux.lpadc.build:
     platform_allow: lpcxpresso55s28
-    tags: adc_mcux_lpadc
   drivers.adc.npcx.build:
     platform_allow: npcx7m6fb_evb
-    tags: adc_npcx
   drivers.adc.nrf.build:
     platform_allow: nrf51dk_nrf51422
-    tags: adc_nrfx_adc
   drivers.adc.nrf.saadc.build:
     platform_allow: nrf21540dk_nrf52840
-    tags: adc_nrfx_saadc
   drivers.adc.sam0.build:
     platform_allow: atsame54_xpro
-    tags: adc_sam0
   drivers.adc.sam.afec.build:
     platform_allow: sam_e70_xplained
-    tags: adc_sam_afec
   drivers.adc.stm32.build:
     platform_allow: disco_l475_iot1
-    tags: adc_stm32
   drivers.adc.xec.build:
     platform_allow: mec15xxevb_assy6853
-    tags: adc_xec
   drivers.adc.test.build:
     platform_allow: qemu_cortex_m3
-    tags: adc_test

--- a/tests/drivers/build_all/dac/testcase.yaml
+++ b/tests/drivers/build_all/dac/testcase.yaml
@@ -7,23 +7,12 @@ tests:
   drivers.dac.build:
     # will cover I2C, SPI based drivers
     platform_allow: native_posix
-    tags:
-      - dac_dacx0508
-      - dac_dacx3608
-      - dac_mcp4725
-      - dac_mcp4728
-      - dac_ltc1660
-      - dac_ltc1665
     extra_args: "CONFIG_GPIO=y"
   drivers.dac.mcux.build:
     platform_allow: frdm_k22f
-    tags: dac_mcux
   drivers.dac.mcux32.build:
     platform_allow: twr_ke18f
-    tags: dac_mcux32
   drivers.dac.sam0.build:
     platform_allow: atsamd21_xpro
-    tags: dac_sam0
   drivers.dac.stm32.build:
     platform_allow: nucleo_f091rc
-    tags: dac_stm32

--- a/tests/drivers/build_all/i2c/testcase.yaml
+++ b/tests/drivers/build_all/i2c/testcase.yaml
@@ -7,5 +7,4 @@ tests:
   drivers.i2c.build:
     # will cover drivers without in-tree boards
     platform_allow: qemu_cortex_m3
-    tags: i2c_xilinx_axi
     extra_args: "CONFIG_I2C=y"

--- a/tests/drivers/build_all/pwm/testcase.yaml
+++ b/tests/drivers/build_all/pwm/testcase.yaml
@@ -6,73 +6,51 @@ common:
 tests:
   drivers.pwm.cc13xx_cc26xx_timer.build:
     platform_allow: cc1352p1_launchxl
-    tags: pwm_cc13xx_cc26xx_timer
   drivers.pwm.gecko.build:
     platform_allow: efr32_radio_brd4250b
-    tags: pwm_gecko
   drivers.pwm.imx.build:
     platform_allow: colibri_imx7d_m4
-    tags: pwm_imx
   drivers.pwm.litex.build:
     platform_allow: litex_vexriscv
-    tags: pwm_litex
   drivers.pwm.mcux.ftm.build:
     platform_allow: frdm_k22f
-    tags: pwm_mcux_ftm
   drivers.pwm.mcux.pwt.build:
     platform_allow: twr_ke18f
-    tags: pwm_mcux_pwt
     extra_configs:
       - CONFIG_PWM_CAPTURE=y
   drivers.pwm.mcux.tpm.build:
     platform_allow: frdm_kw41z
-    tags: pwm_mcux_tpm
   drivers.pwm.mcux.build:
     platform_allow: mimxrt1064_evk
-    tags: pwm_mcux
   drivers.pwm.mcux.sctimer.build:
     platform_allow: mimxrt685_evk_cm33
-    tags: pwm_mcux_sctimer
   drivers.pwm.rv32m1.tpm.build:
     platform_allow: rv32m1_vega_ri5cy
-    tags: pwm_rv32m1_tpm
   drivers.pwm.sifive.build:
     platform_allow: hifive1_revb
-    tags: pwm_sifive
   drivers.pwm.npcx.build:
     platform_allow: npcx7m6fb_evb
-    tags: pwm_npcx
   drivers.pwm.nrf.sw.build:
     platform_allow: nrf51dk_nrf51422
-    tags: pwm_nrf5_sw
   drivers.pwm.nrf.build:
     platform_allow: nrf52840dk_nrf52840
-    tags: pwm_nrfx
   drivers.pwm.pca9685.build:
     platform_allow: nrf52840dk_nrf52840
     extra_args: SHIELD=adafruit_pca9685
-    tags: pwm_pca9685
   drivers.pwm.sam0.tcc.build:
     platform_allow: atsame54_xpro
-    tags: pwm_sam0_tcc
   drivers.pwm.build.sam:
     platform_allow:
       - sam_e70_xplained
       - sam_v71b_xult
-    tags: pwm_sam
   drivers.pwm.stm32.build:
     platform_allow: disco_l475_iot1
-    tags: pwm_stm32
   drivers.pwm.xec.build:
     platform_allow: mec15xxevb_assy6853
-    tags: pwm_xec
   drivers.pwm.build.xlnx:
     platform_allow: arty_a7_arm_designstart_m1
-    tags: pwm_xlnx_axi_timer
   drivers.pwm.build.test:
     platform_allow: qemu_cortex_m3
-    tags: pwm_test
   drivers.pwm.max31790.build:
     platform_allow: nucleo_f429zi
     extra_args: DTC_OVERLAY_FILE=max31790.overlay
-    tags: pwm_max31790

--- a/tests/drivers/build_all/uart/testcase.yaml
+++ b/tests/drivers/build_all/uart/testcase.yaml
@@ -7,6 +7,5 @@ tests:
   drivers.uart.build:
     # will cover drivers without in-tree boards
     platform_allow: qemu_cortex_m3
-    tags: uart_cdns
     extra_configs:
       - CONFIG_SERIAL=y

--- a/tests/drivers/build_all/watchdog/testcase.yaml
+++ b/tests/drivers/build_all/watchdog/testcase.yaml
@@ -1,9 +1,10 @@
 common:
   build_only: true
-  tags: drivers watchdog
+  tags:
+    - drivers
+    - watchdog
 tests:
   drivers.watchdog.build:
     # will cover drivers without in-tree boards
     platform_allow: qemu_cortex_m3
-    tags: wdt_xilinx_axi
     extra_args: "CONFIG_WATCHDOG=y"

--- a/tests/drivers/clock_control/adsp_clock/testcase.yaml
+++ b/tests/drivers/clock_control/adsp_clock/testcase.yaml
@@ -2,7 +2,7 @@ tests:
   drivers.clock.adsp_clock_control:
     tags:
       - drivers
-      - clock
+      - clock_control
     platform_allow: intel_adsp_cavs25
     integration_platforms:
       - intel_adsp_cavs25

--- a/tests/drivers/clock_control/clock_control_api/testcase.yaml
+++ b/tests/drivers/clock_control/clock_control_api/testcase.yaml
@@ -2,7 +2,7 @@ tests:
   drivers.clock.clock_control_nrf5:
     tags:
       - drivers
-      - cloc
+      - clock_control
     platform_allow:
       - nrf51dk_nrf51422
       - nrf52dk_nrf52832
@@ -13,7 +13,7 @@ tests:
   drivers.clock.clock_control_nrf5_lfclk_rc:
     tags:
       - drivers
-      - clock
+      - clock_control
     platform_allow:
       - nrf51dk_nrf51422
       - nrf52dk_nrf52832

--- a/tests/drivers/clock_control/nrf_clock_calibration/testcase.yaml
+++ b/tests/drivers/clock_control/nrf_clock_calibration/testcase.yaml
@@ -2,7 +2,7 @@ tests:
   drivers.clock.nrf5_clock_calibration:
     tags:
       - drivers
-      - clock
+      - clock_control
     platform_allow:
       - nrf51dk_nrf51422
       - nrf52dk_nrf52832

--- a/tests/drivers/clock_control/nrf_lf_clock_start/testcase.yaml
+++ b/tests/drivers/clock_control/nrf_lf_clock_start/testcase.yaml
@@ -1,7 +1,7 @@
 common:
   tags:
     - drivers
-    - clock
+    - clock_control
   integration_platforms:
     - nrf51dk_nrf51422
 tests:

--- a/tests/drivers/clock_control/nrf_onoff_and_bt/testcase.yaml
+++ b/tests/drivers/clock_control/nrf_onoff_and_bt/testcase.yaml
@@ -2,7 +2,7 @@ tests:
   drivers.clock.nrf_onoff_and_bt:
     tags:
       - drivers
-      - clock
+      - clock_control
     platform_allow:
       - nrf51dk_nrf51422
       - nrf52dk_nrf52832

--- a/tests/drivers/clock_control/onoff/testcase.yaml
+++ b/tests/drivers/clock_control/onoff/testcase.yaml
@@ -2,7 +2,7 @@ tests:
   drivers.clock.clock_control_onoff:
     tags:
       - drivers
-      - clock
+      - clock_control
     platform_allow:
       - nrf51dk_nrf51422
       - nrf52dk_nrf52832

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_core/testcase.yaml
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_core/testcase.yaml
@@ -6,7 +6,8 @@
 # - add the fixture in map file
 common:
   timeout: 5
-  tags: clock-control
+  tags:
+    - clock_control
 tests:
   drivers.clock.stm32_clock_configuration.common_core.l4_l5.sysclksrc_pll_48_msi_4:
     extra_args:


### PR DESCRIPTION
- tests: adc: cleanup test tags
- tests: pwm:  cleanup test tags
- tests: watchdog: cleanup test tags
- tests: i2c: cleanup test tags
- tests: dac: cleanup test tags
- tests: uart: cleanup test tags
- tests: clock_control: cleanup test tags and unify them
