### PR TITLE
samples: sockets: echo_client: assume connected without connmgr

### DIFF
--- a/samples/net/sockets/echo_client/src/echo-client.c
+++ b/samples/net/sockets/echo_client/src/echo-client.c
@@ -320,6 +320,7 @@ int main(void)
 		 * app only after we have a connection, then we can start
 		 * it right away.
 		 */
+		connected = true;
 		k_sem_give(&run_app);
 	}
 


### PR DESCRIPTION
When connection manager (`CONFIG_NET_CONNECTION_MANAGER`) is disabled,
application starts right away. Scenario that it covers is when static
networking is used, like with emulators (QEMU, Native Sim, ...).

Since `connected` flag was not set in such scenario, the internal loop
inside `start_client()` has ended up early and `stop_udp_and_tcp()` was called
quickly after starting TCP and UDP clients.

Set `connected = true`, when connection manager is disabled, so that it is
assumed that connection is working for the whole duration of the
echo-client sample.