### PR TITLE
drivers: clock_control: stm32f7: plli2s enablement

### DIFF
--- a/drivers/clock_control/clock_stm32f2_f4_f7.c
+++ b/drivers/clock_control/clock_stm32f2_f4_f7.c
@@ -101,7 +101,8 @@ void config_pll_sysclock(void)
 __unused
 void config_plli2s(void)
 {
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32f4_plli2s_clock)
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32f4_plli2s_clock) || \
+	DT_HAS_COMPAT_STATUS_OKAY(st_stm32f7_plli2s_clock)
 	LL_RCC_PLLI2S_ConfigDomain_I2S(get_pll_source(),
 				       pllm(STM32_PLLI2S_M_DIVISOR),
 				       STM32_PLLI2S_N_MULTIPLIER,

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -86,6 +86,12 @@
 			compatible = "st,stm32f7-pll-clock";
 			status = "disabled";
 		};
+
+		plli2s: plli2s {
+			#clock-cells = <0>;
+			compatible = "st,stm32f7-plli2s-clock";
+			status = "disabled";
+		};
 	};
 
 	soc {

--- a/dts/bindings/clock/st,stm32f7-plli2s-clock.yaml
+++ b/dts/bindings/clock/st,stm32f7-plli2s-clock.yaml
@@ -1,0 +1,42 @@
+# Copyright (c) 2023, Linaro ltd
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  STM32F7 PLL I2S node binding:
+
+  Takes same input as Main PLL. PLLM factor and PLL source are common with Main PLL
+
+  1 output clocks supported, the frequency can be computed with the following formula:
+
+    f(PLL_R) = f(VCO clock) / PLLR  --> PLLI2S
+
+      with f(VCO clock) = f(PLL clock input) × (PLLNI2S / PLLM)
+
+
+compatible: "st,stm32f7-plli2s-clock"
+
+include: [clock-controller.yaml, base.yaml]
+
+properties:
+  "#clock-cells":
+    const: 0
+
+  mul-n:
+    type: int
+    required: true
+    description: |
+        PLLI2S multiplication factor for VCO
+        Valid range may vary between parts: 50 - 432 , 192 - 432
+
+  div-r:
+    type: int
+    required: true
+    description: |
+        PLLI2S division factor for I2S Clocks
+    enum:
+      - 2
+      - 3
+      - 4
+      - 5
+      - 6
+      - 7

--- a/include/zephyr/drivers/clock_control/stm32_clock_control.h
+++ b/include/zephyr/drivers/clock_control/stm32_clock_control.h
@@ -147,7 +147,8 @@
 #define STM32_PLL_FRACN_VALUE	DT_PROP_OR(DT_NODELABEL(pll), fracn, 1)
 #endif
 
-#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(plli2s), st_stm32f4_plli2s_clock, okay)
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(plli2s), st_stm32f4_plli2s_clock, okay) || \
+	DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(plli2s), st_stm32f7_plli2s_clock, okay)
 #define STM32_PLLI2S_ENABLED	1
 #define STM32_PLLI2S_M_DIVISOR		STM32_PLL_M_DIVISOR
 #define STM32_PLLI2S_N_MULTIPLIER	DT_PROP(DT_NODELABEL(plli2s), mul_n)


### PR DESCRIPTION
Mimicking the efforts to bring stm32f4 plli2s configuration into dts. This commit enables plli2s configuration in the dts for stm32f7.