### PR TITLE
samples: compression: exclude esp32s3 board from testing

### DIFF
--- a/samples/compression/lz4/sample.yaml
+++ b/samples/compression/lz4/sample.yaml
@@ -22,3 +22,4 @@ tests:
     tags:
       - compression
       - lz4
+    platform_exclude: esp32s3_devkitm_appcpu


### PR DESCRIPTION
esp32s3_devkitm_appcpu has not enough RAM memory to support this test. Therefore we can exclude this from testing.