### PR TITLE
libc: Add GCC fno-builtin-malloc flag to common stdlib compilation

### DIFF
--- a/arch/posix/CMakeLists.txt
+++ b/arch/posix/CMakeLists.txt
@@ -94,12 +94,12 @@ elseif (CONFIG_NATIVE_LIBRARY)
 
     # Do not use the C library from this compiler/host,
     # but still use the basic compiler headers
-    # -fno-builtin to avoid the compiler using builtin replacements for std library functions
+    # no_builtin to avoid the compiler using builtin replacements for std library functions
     zephyr_compile_options(
       -nostdinc
       -isystem ${COMPILER_OWN_INCLUDE_PATH}
       $<TARGET_PROPERTY:compiler,freestanding>
-      -fno-builtin
+      $<TARGET_PROPERTY:compiler,no_builtin>
     )
   endif()
 endif()

--- a/cmake/compiler/arcmwdt/compiler_flags.cmake
+++ b/cmake/compiler/arcmwdt/compiler_flags.cmake
@@ -206,3 +206,6 @@ endif()
 
 # Remove after testing that -Wshadow works
 set_compiler_property(PROPERTY warning_shadow_variables)
+
+set_compiler_property(PROPERTY no_builtin -fno-builtin)
+set_compiler_property(PROPERTY no_builtin_malloc -fno-builtin-malloc)

--- a/cmake/compiler/compiler_flags_template.cmake
+++ b/cmake/compiler/compiler_flags_template.cmake
@@ -133,3 +133,7 @@ set_compiler_property(PROPERTY no_global_merge)
 
 # Compiler flag for warning about shadow variables
 set_compiler_property(PROPERTY warning_shadow_variables)
+
+# Compiler flags to avoid recognizing built-in functions
+set_compiler_property(PROPERTY no_builtin)
+set_compiler_property(PROPERTY no_builtin_malloc)

--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -227,3 +227,6 @@ set_compiler_property(PROPERTY no_position_independent
 set_compiler_property(PROPERTY no_global_merge "")
 
 set_compiler_property(PROPERTY warning_shadow_variables -Wshadow)
+
+set_compiler_property(PROPERTY no_builtin -fno-builtin)
+set_compiler_property(PROPERTY no_builtin_malloc -fno-builtin-malloc)

--- a/lib/libc/common/CMakeLists.txt
+++ b/lib/libc/common/CMakeLists.txt
@@ -6,3 +6,6 @@ zephyr_library_sources_ifdef(CONFIG_COMMON_LIBC_ABORT source/stdlib/abort.c)
 zephyr_library_sources_ifdef(CONFIG_COMMON_LIBC_TIME source/time/time.c)
 zephyr_library_sources_ifdef(CONFIG_COMMON_LIBC_MALLOC source/stdlib/malloc.c)
 zephyr_library_sources_ifdef(CONFIG_COMMON_LIBC_STRNLEN source/string/strnlen.c)
+
+# Prevent compiler from optimizing calloc into an infinite recursive call
+zephyr_library_cc_option(-fno-builtin-malloc)

--- a/lib/libc/common/CMakeLists.txt
+++ b/lib/libc/common/CMakeLists.txt
@@ -8,4 +8,4 @@ zephyr_library_sources_ifdef(CONFIG_COMMON_LIBC_MALLOC source/stdlib/malloc.c)
 zephyr_library_sources_ifdef(CONFIG_COMMON_LIBC_STRNLEN source/string/strnlen.c)
 
 # Prevent compiler from optimizing calloc into an infinite recursive call
-zephyr_library_cc_option(-fno-builtin-malloc)
+zephyr_library_compile_options($<TARGET_PROPERTY:compiler,no_builtin_malloc>)

--- a/lib/libc/minimal/CMakeLists.txt
+++ b/lib/libc/minimal/CMakeLists.txt
@@ -7,7 +7,7 @@ zephyr_library()
 set(GEN_DIR ${ZEPHYR_BINARY_DIR}/include/generated)
 set(STRERROR_TABLE_H ${GEN_DIR}/libc/minimal/strerror_table.h)
 
-zephyr_library_cc_option(-fno-builtin)
+zephyr_library_compile_options($<TARGET_PROPERTY:compiler,no_builtin>)
 
 zephyr_library_sources(
   source/stdlib/atoi.c

--- a/modules/openthread/CMakeLists.txt
+++ b/modules/openthread/CMakeLists.txt
@@ -547,7 +547,8 @@ target_compile_definitions(ot-config INTERFACE
 # libraries do not include this header. So we add the defines to all
 # OpenThread files through the gcc flag -imacros instead.
 target_compile_options(ot-config INTERFACE
-    $<TARGET_PROPERTY:zephyr_interface,INTERFACE_COMPILE_OPTIONS> -fno-builtin
+    $<TARGET_PROPERTY:zephyr_interface,INTERFACE_COMPILE_OPTIONS>
+    $<TARGET_PROPERTY:compiler,no_builtin>
     -imacros ${AUTOCONF_H}
 )
 
@@ -600,7 +601,8 @@ endif()
 
 if(CONFIG_OPENTHREAD_SETTINGS_RAM)
   target_compile_options(openthread-platform-utils PRIVATE
-    $<TARGET_PROPERTY:zephyr_interface,INTERFACE_COMPILE_OPTIONS> -fno-builtin)
+    $<TARGET_PROPERTY:zephyr_interface,INTERFACE_COMPILE_OPTIONS>
+    $<TARGET_PROPERTY:compiler,no_builtin>)
   add_dependencies(openthread-platform-utils syscall_list_h_target)
 
   list(APPEND ot_libs openthread-platform-utils-static)


### PR DESCRIPTION
This prevents the compiler from optimizing calloc into an infinite recursive call.

For example a call to malloc + memset zero at GCC -O2 will be replaced by a call to calloc.
This causes infinite recursion if the function being implemented *is* calloc.

fno-builtin-malloc forces the compiler to avoid this optimization.

This can be tested by adding this patch to the hello_world sample:
```
diff --git a/samples/hello_world/src/main.c b/samples/hello_world/src/main.c
index 2758d75d3f..5841ae99e4 100644
--- a/samples/hello_world/src/main.c
+++ b/samples/hello_world/src/main.c
@@ -5,9 +5,12 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 
 int main(void)
 {
        printf("Hello World! %s\n", CONFIG_BOARD);
+       printf("%p\n", calloc(1, 1));
+       printf("done\n");
        return 0;
 }
```
and building on a QEMU board with optimization -O2:
```
west build -b qemu_cortex_a53 samples/hello_world -t run  -- -DCONFIG_SPEED_OPTIMIZATIONS=y
```

Output before fix:
```
*** Booting Zephyr OS build zephyr-v3.5.0-1326-g4f7f12bdbf69 ***
Hello World! qemu_cortex_a53
```
Output after fix:
```
*** Booting Zephyr OS build zephyr-v3.5.0-1326-g4f7f12bdbf69 ***
Hello World! qemu_cortex_a53
0x4005e890
done
```

Fixes: #64941