### PR TITLE
scripts: twister: config_parser: copy common values

### DIFF
--- a/scripts/pylib/twister/twisterlib/config_parser.py
+++ b/scripts/pylib/twister/twisterlib/config_parser.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2018-2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+import copy
 import scl
 import warnings
 from typing import Union
@@ -176,7 +177,8 @@ class TwisterConfigParser:
                     {"CONF_FILE", "OVERLAY_CONFIG", "DTC_OVERLAY_FILE"}, v
                 )
             else:
-                d[k] = v
+                # Copy common value to avoid mutating it with test specific values below
+                d[k] = copy.copy(v)
 
         for k, v in self.scenarios[name].items():
             if k == "extra_args":


### PR DESCRIPTION
Create copys of the common configuration values when constructing test scenarios, to avoid mutating the common value with test specific appends.

Without this change, `app.uart` depends on `ble,uart`, while `app.wifi` depends on `ble,uart,wifi`.
```
common:
  depends_on:
    - ble
tests:
  app.uart:
    depends_on:
      - uart
  app.wifi:
    depends_on:
      - wifi
```