### PR TITLE
ci: compliance: undef list few configs used in optional modules

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -643,6 +643,8 @@ flagged.
         "BTTESTER_LOG_LEVEL",  # Used in tests/bluetooth/tester
         "BTTESTER_LOG_LEVEL_DBG",  # Used in tests/bluetooth/tester
         "CDC_ACM_PORT_NAME_",
+        "CHRE",  # Optional module
+        "CHRE_LOG_LEVEL_DBG",  # Optional module
         "CLOCK_STM32_SYSCLK_SRC_",
         "CMU",
         "COMPILER_RT_RTLIB",
@@ -689,6 +691,7 @@ flagged.
         "PEDO_THS_MIN",
         "REG1",
         "REG2",
+        "RIMAGE_SIGNING_SCHEMA",  # Optional module
         "SAMPLE_MODULE_LOG_LEVEL",  # Used as an example in samples/subsys/logging
         "SAMPLE_MODULE_LOG_LEVEL_DBG",  # Used in tests/subsys/logging/log_api
         "LOG_BACKEND_MOCK_OUTPUT_DEFAULT", #Referenced in tests/subsys/logging/log_syst


### PR DESCRIPTION
Would it be a better idea to define them in `modules/`?

---

The Kconfig check fails when running the script locally for undefined symbols if the checkout does not include optional modules (the default behavior). Add these symbol to the Kconfig undef list.