### PR TITLE
drivers: virtualization: Map ivshmem-v2 sections individually

### DIFF
--- a/drivers/ethernet/eth_ivshmem.c
+++ b/drivers/ethernet/eth_ivshmem.c
@@ -297,14 +297,15 @@ int eth_ivshmem_initialize(const struct device *dev)
 	}
 	dev_data->peer_id = (id == 0) ? 1 : 0;
 
-	bool tx_buffer_first = id == 0;
-	uintptr_t output_section_addr;
+	uintptr_t output_sections[2];
 	size_t output_section_size = ivshmem_get_output_mem_section(
-		cfg_data->ivshmem, 0, &output_section_addr);
+		cfg_data->ivshmem, 0, &output_sections[0]);
+	ivshmem_get_output_mem_section(
+		cfg_data->ivshmem, 1, &output_sections[1]);
 
 	res = eth_ivshmem_queue_init(
-		&dev_data->ivshmem_queue, output_section_addr,
-		output_section_size, tx_buffer_first);
+		&dev_data->ivshmem_queue, output_sections[id],
+		output_sections[dev_data->peer_id], output_section_size);
 	if (res != 0) {
 		LOG_ERR("Failed to init ivshmem queue");
 		return res;

--- a/drivers/ethernet/eth_ivshmem_priv.h
+++ b/drivers/ethernet/eth_ivshmem_priv.h
@@ -40,8 +40,8 @@ struct eth_ivshmem_queue {
 };
 
 int eth_ivshmem_queue_init(
-		struct eth_ivshmem_queue *q, uintptr_t shmem,
-		size_t shmem_section_size, bool tx_buffer_first);
+		struct eth_ivshmem_queue *q, uintptr_t tx_shmem,
+		uintptr_t rx_shmem, size_t shmem_section_size);
 void eth_ivshmem_queue_reset(struct eth_ivshmem_queue *q);
 int eth_ivshmem_queue_tx_get_buff(struct eth_ivshmem_queue *q, void **data, size_t len);
 int eth_ivshmem_queue_tx_commit_buff(struct eth_ivshmem_queue *q);

--- a/drivers/ethernet/eth_ivshmem_queue.c
+++ b/drivers/ethernet/eth_ivshmem_queue.c
@@ -28,8 +28,8 @@ static int tx_clean_used(struct eth_ivshmem_queue *q);
 static int get_rx_avail_desc_idx(struct eth_ivshmem_queue *q, uint16_t *avail_desc_idx);
 
 int eth_ivshmem_queue_init(
-		struct eth_ivshmem_queue *q, uintptr_t shmem,
-		size_t shmem_section_size, bool tx_buffer_first)
+		struct eth_ivshmem_queue *q, uintptr_t tx_shmem,
+		uintptr_t rx_shmem, size_t shmem_section_size)
 {
 	memset(q, 0, sizeof(*q));
 
@@ -44,14 +44,8 @@ int eth_ivshmem_queue_init(
 	q->desc_max_len = vring_desc_len;
 	q->vring_data_max_len = shmem_section_size - vring_header_size;
 	q->vring_header_size = vring_header_size;
-
-	if (tx_buffer_first) {
-		q->tx.shmem = (void *)shmem;
-		q->rx.shmem = (void *)(shmem + shmem_section_size);
-	} else {
-		q->rx.shmem = (void *)shmem;
-		q->tx.shmem = (void *)(shmem + shmem_section_size);
-	}
+	q->tx.shmem = (void *)tx_shmem;
+	q->rx.shmem = (void *)rx_shmem;
 
 	/* Init vrings */
 	vring_init(&q->tx.vring, vring_desc_len, q->tx.shmem, ETH_IVSHMEM_VRING_ALIGNMENT);

--- a/drivers/virtualization/Kconfig
+++ b/drivers/virtualization/Kconfig
@@ -66,4 +66,10 @@ config IVSHMEM_V2
 	  Enable ivshmem-v2 support.
 	  ivshmem-v2 is primarily used for IPC in the Jailhouse hypervisor.
 
+config IVSHMEM_V2_MAX_PEERS
+	int "Maximum number of ivshmem-v2 peers"
+	depends on IVSHMEM_V2
+	default 2
+	range 2 65536
+
 endif # VIRTUALIZATION

--- a/drivers/virtualization/virt_ivshmem.h
+++ b/drivers/virtualization/virt_ivshmem.h
@@ -57,9 +57,10 @@ struct ivshmem {
 	bool ivshmem_v2;
 	uint32_t max_peers;
 	size_t rw_section_size;
-	size_t rw_section_offset;
 	size_t output_section_size;
-	size_t output_section_offset;
+	uintptr_t state_table_shmem;
+	uintptr_t rw_section_shmem;
+	uintptr_t output_section_shmem[CONFIG_IVSHMEM_V2_MAX_PEERS];
 #endif
 };
 

--- a/include/zephyr/drivers/virtualization/ivshmem.h
+++ b/include/zephyr/drivers/virtualization/ivshmem.h
@@ -84,6 +84,12 @@ __subsystem struct ivshmem_driver_api {
 /**
  * @brief Get the inter-VM shared memory
  *
+ * Note: This API is not supported for ivshmem-v2, as
+ * the R/W and R/O areas may not be mapped contiguously.
+ * For ivshmem-v2, use the ivshmem_get_rw_mem_section,
+ * ivshmem_get_output_mem_section and ivshmem_get_state
+ * APIs to access the shared memory.
+ *
  * @param dev Pointer to the device structure for the driver instance
  * @param memmap A pointer to fill in with the memory address
  *


### PR DESCRIPTION
Recent changes to the arm64 MMU code (https://github.com/zephyrproject-rtos/zephyr/commit/c9b534c4ebca8c3d02bc7d783c79771f1409d096) mean that you can no longer map R/O memory as R/W.
Mapping R/W memory now causes a cache invalidation instruction (DC IVAC) that requires write permissions or else a fault is generated. Modify ivshmem-v2 to map each R/O and R/W section individually.

The eth_ivshmem driver assumed the ivshmem-v2 output sections would be mapped contiguously, which is no longer true. Modify eth_ivshmem to treat each output section independently.

Further discussion: https://github.com/zephyrproject-rtos/zephyr/pull/64779#issuecomment-1792980385

If these changes are accepted, could they please be backported to v3.5-branch?

CC: @carlocaione @xakep-amatop

Fixes: #65894