### PR TITLE
dts: pinctrl: kinetis: make slew-rate optional

### DIFF
--- a/dts/bindings/pinctrl/nxp,kinetis-pinctrl.yaml
+++ b/dts/bindings/pinctrl/nxp,kinetis-pinctrl.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NXP
+# Copyright (c) 2022-2023, NXP
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
@@ -63,7 +63,6 @@ child-binding:
           0 DSE_0- low drive strength when pin is configured as output
           1 DSE_1- high drive strength when pin is configured as output
       slew-rate:
-        required: true
         type: string
         enum:
           - "fast"


### PR DESCRIPTION
`slew-rate` property is not supported on Kinetis KE series and its value have no effect on these devices (see https://github.com/zephyrproject-rtos/zephyr/blob/main/soc/arm/nxp_kinetis/common/pinctrl_soc.h#L38), so this property should not be always required.

We are also planning to reuse the Kinetis pin control binding and associated driver for NXP S32K1xx devices, which doesn't support setting the slew-rate rate as well.