### PR TITLE
gpio_emul: Add Open Drain and Open Source Flags

### DIFF
--- a/drivers/gpio/gpio_emul.c
+++ b/drivers/gpio/gpio_emul.c
@@ -416,14 +416,6 @@ static int gpio_emul_pin_configure(const struct device *port, gpio_pin_t pin,
 	k_spinlock_key_t key;
 	int rv;
 
-	if (flags & GPIO_OPEN_DRAIN) {
-		return -ENOTSUP;
-	}
-
-	if (flags & GPIO_OPEN_SOURCE) {
-		return -ENOTSUP;
-	}
-
 	if ((config->common.port_pin_mask & BIT(pin)) == 0) {
 		return -EINVAL;
 	}

--- a/dts/bindings/test/vnd,pinctrl-test.yaml
+++ b/dts/bindings/test/vnd,pinctrl-test.yaml
@@ -47,6 +47,8 @@ child-binding:
         property-allowlist:
           - bias-pull-down
           - bias-pull-up
+          - drive-open-drain
+          - drive-open-source
 
     properties:
       pins:


### PR DESCRIPTION
Useful for testing GPIO configuration and keeping better parity with real GPIO drivers. Will allow applications which make use of these flags to be tested on x86 platforms with fewer changes.