### PR TITLE
lorawan: callback registration API cleanup

### DIFF
--- a/doc/releases/migration-guide-3.6.rst
+++ b/doc/releases/migration-guide-3.6.rst
@@ -73,6 +73,14 @@ Bluetooth
   been renamed, from ``samples/bluetooth/hci_rpmsg`` to
   ``samples/bluetooth/hci_ipc``.
 
+LoRaWAN
+=======
+
+* The API to register a callback to provide battery level information to the LoRaWAN stack has been
+  renamed from ``lorawan_set_battery_level_callback`` to
+  :c:func:`lorawan_register_battery_level_callback` and the return type is now ``void``. This
+  is more consistent with similar functions for downlink and data rate changed callbacks.
+
 Networking
 ==========
 

--- a/include/zephyr/lorawan/lorawan.h
+++ b/include/zephyr/lorawan/lorawan.h
@@ -187,10 +187,8 @@ struct lorawan_downlink_cb {
  * Should no callback be provided the lorawan backend will report 255.
  *
  * @param battery_lvl_cb Pointer to the battery level function
- *
- * @return 0 if successful, negative errno code if failure
  */
-int lorawan_set_battery_level_callback(uint8_t (*battery_lvl_cb)(void));
+void lorawan_register_battery_level_callback(uint8_t (*battery_lvl_cb)(void));
 
 /**
  * @brief Register a callback to be run on downlink packets

--- a/include/zephyr/lorawan/lorawan.h
+++ b/include/zephyr/lorawan/lorawan.h
@@ -175,20 +175,32 @@ struct lorawan_downlink_cb {
 };
 
 /**
- * @brief Add battery level callback function.
+ * @brief Defines the battery level callback handler function signature.
+ *
+ * @retval 0      if the node is connected to an external power source
+ * @retval 1..254 battery level, where 1 is the minimum and 254 is the maximum value
+ * @retval 255    if the node was not able to measure the battery level
+ */
+typedef uint8_t (*lorawan_battery_level_cb_t)(void);
+
+/**
+ * @brief Defines the datarate changed callback handler function signature.
+ *
+ * @param dr Updated datarate.
+ */
+typedef void (*lorawan_dr_changed_cb_t)(enum lorawan_datarate dr);
+
+/**
+ * @brief Register a battery level callback function.
  *
  * Provide the LoRaWAN stack with a function to be called whenever a battery
- * level needs to be read. As per LoRaWAN specification the callback needs to
- * return "0:      node is connected to an external power source,
- *         1..254: battery level, where 1 is the minimum and 254 is the maximum
- *                 value,
- *         255: the node was not able to measure the battery level"
+ * level needs to be read.
  *
  * Should no callback be provided the lorawan backend will report 255.
  *
- * @param battery_lvl_cb Pointer to the battery level function
+ * @param cb Pointer to the battery level function
  */
-void lorawan_register_battery_level_callback(uint8_t (*battery_lvl_cb)(void));
+void lorawan_register_battery_level_callback(lorawan_battery_level_cb_t cb);
 
 /**
  * @brief Register a callback to be run on downlink packets
@@ -203,12 +215,9 @@ void lorawan_register_downlink_callback(struct lorawan_downlink_cb *cb);
  * The callback is called once upon successfully joining a network and again
  * each time the datarate changes due to ADR.
  *
- * The callback function takes one parameter:
- *	- dr - updated datarate
- *
- * @param dr_cb Pointer to datarate update callback
+ * @param cb Pointer to datarate update callback
  */
-void lorawan_register_dr_changed_callback(void (*dr_cb)(enum lorawan_datarate));
+void lorawan_register_dr_changed_callback(lorawan_dr_changed_cb_t cb);
 
 /**
  * @brief Join the LoRaWAN network

--- a/subsys/lorawan/lorawan.c
+++ b/subsys/lorawan/lorawan.c
@@ -621,15 +621,9 @@ out:
 	return ret;
 }
 
-int lorawan_set_battery_level_callback(uint8_t (*battery_lvl_cb)(void))
+void lorawan_register_battery_level_callback(uint8_t (*battery_lvl_cb)(void))
 {
-	if (battery_lvl_cb == NULL) {
-		return -EINVAL;
-	}
-
 	get_battery_level_user = battery_lvl_cb;
-
-	return 0;
 }
 
 void lorawan_register_downlink_callback(struct lorawan_downlink_cb *cb)

--- a/subsys/lorawan/lorawan.c
+++ b/subsys/lorawan/lorawan.c
@@ -72,8 +72,8 @@ static LoRaMacEventInfoStatus_t last_mlme_indication_status;
 
 static LoRaMacRegion_t selected_region = DEFAULT_LORAWAN_REGION;
 
-static uint8_t (*get_battery_level_user)(void);
-static void (*dr_change_cb)(enum lorawan_datarate dr);
+static lorawan_battery_level_cb_t battery_level_cb;
+static lorawan_dr_changed_cb_t dr_changed_cb;
 
 /* implementation required by the soft-se (software secure element) */
 void BoardGetUniqueId(uint8_t *id)
@@ -83,11 +83,11 @@ void BoardGetUniqueId(uint8_t *id)
 
 static uint8_t get_battery_level(void)
 {
-	if (get_battery_level_user != NULL) {
-		return get_battery_level_user();
+	if (battery_level_cb != NULL) {
+		return battery_level_cb();
+	} else {
+		return 255;
 	}
-
-	return 255;
 }
 
 static void mac_process_notify(void)
@@ -105,8 +105,8 @@ static void datarate_observe(bool force_notification)
 	if ((mib_req.Param.ChannelsDatarate != current_datarate) ||
 	    (force_notification)) {
 		current_datarate = mib_req.Param.ChannelsDatarate;
-		if (dr_change_cb) {
-			dr_change_cb(current_datarate);
+		if (dr_changed_cb != NULL) {
+			dr_changed_cb(current_datarate);
 		}
 		LOG_INF("Datarate changed: DR_%d", current_datarate);
 	}
@@ -621,9 +621,9 @@ out:
 	return ret;
 }
 
-void lorawan_register_battery_level_callback(uint8_t (*battery_lvl_cb)(void))
+void lorawan_register_battery_level_callback(lorawan_battery_level_cb_t cb)
 {
-	get_battery_level_user = battery_lvl_cb;
+	battery_level_cb = cb;
 }
 
 void lorawan_register_downlink_callback(struct lorawan_downlink_cb *cb)
@@ -631,9 +631,9 @@ void lorawan_register_downlink_callback(struct lorawan_downlink_cb *cb)
 	sys_slist_append(&dl_callbacks, &cb->node);
 }
 
-void lorawan_register_dr_changed_callback(void (*cb)(enum lorawan_datarate))
+void lorawan_register_dr_changed_callback(lorawan_dr_changed_cb_t cb)
 {
-	dr_change_cb = cb;
+	dr_changed_cb = cb;
 }
 
 int lorawan_start(void)


### PR DESCRIPTION
This PR introduces `typedef`s for callbacks to avoid duplicating the function signature in several places. In addition to that, the function `lorawan_set_battery_level_callback` is renamed to `lorawan_register_battery_level_callback` to be consistent with other similar functions.

This is a preparation for adding another call back to notify a change of the LoRaWAN class, which will be required for upcoming class B support.