### PR TITLE
arch: riscv: fix hangup in boot if hart0 is not boot hart

### DIFF
--- a/arch/riscv/core/smp.c
+++ b/arch/riscv/core/smp.c
@@ -16,7 +16,7 @@ volatile struct {
 	void *arg;
 } riscv_cpu_init[CONFIG_MP_MAX_NUM_CPUS];
 
-volatile uintptr_t riscv_cpu_wake_flag;
+volatile uintptr_t __noinit riscv_cpu_wake_flag;
 volatile uintptr_t riscv_cpu_boot_flag;
 volatile void *riscv_cpu_sp;
 


### PR DESCRIPTION
This patch changes the section of riscv_cpu_wake_flag variable to noinit from bss to fix hangup of RISC-V multicore boot if hart0 is not boot hart (CONFIG_RV_BOOT_HART != 0).

Current boot sequence initializes a riscv_cpu_wake_flag to -1 but this variable is unintentionally changed to 0 by boot hart. This is because the variable is placed in bss section so this patch changes the section of the variable to noinit.