### PR TITLE
samples: Add encryption support to broadcast audio source

### DIFF
--- a/samples/bluetooth/broadcast_audio_source/Kconfig
+++ b/samples/bluetooth/broadcast_audio_source/Kconfig
@@ -20,6 +20,20 @@ config BAP_BROADCAST_24_2_1
 
 endchoice
 
+config ENABLE_BROADCAST_CODE
+	bool "Enable Broadcast code"
+	default n
+	help
+		Enable encryption and use of broadcast code string.
+
+config BROADCAST_CODE_STRING
+	string "Broadcast code string"
+	default "Zephyr Broadcast Code"
+	depends on ENABLE_BROADCAST_CODE
+	help
+		Broadcast code of target broadcast device. If not empty string, source device
+		will broadcast the specified broadcast code.
+
 config ENABLE_LC3
 	bool "Enable the LC3 codec"
 	# By default let's enable it in the platforms we know are capable of supporting it

--- a/samples/bluetooth/broadcast_audio_source/src/main.c
+++ b/samples/bluetooth/broadcast_audio_source/src/main.c
@@ -230,7 +230,14 @@ static int setup_broadcast_source(struct bt_bap_broadcast_source **source)
 	create_param.params_count = ARRAY_SIZE(subgroup_param);
 	create_param.params = subgroup_param;
 	create_param.qos = &preset_active.qos;
+#if defined(CONFIG_ENABLE_BROADCAST_CODE)
+	create_param.encryption = true;
+	memset(create_param.broadcast_code, 0, BT_AUDIO_BROADCAST_CODE_SIZE);
+	memcpy(create_param.broadcast_code, CONFIG_BROADCAST_CODE_STRING,
+		   MIN(strlen(CONFIG_BROADCAST_CODE_STRING), BT_AUDIO_BROADCAST_CODE_SIZE));
+#else
 	create_param.encryption = false;
+#endif
 	create_param.packing = BT_ISO_PACKING_SEQUENTIAL;
 
 	printk("Creating broadcast source with %zu subgroups with %zu streams\n",


### PR DESCRIPTION
Add support for broadcast code and encryption
from Kconfig.