### PR TITLE
RFC: Breaking API change: drivers: can: remove CAN_FILTER_FDF flag

### DIFF
--- a/doc/releases/migration-guide-3.6.rst
+++ b/doc/releases/migration-guide-3.6.rst
@@ -175,6 +175,10 @@ Device Drivers and Device Tree
   * The main Kconfig option was renamed from ``CONFIG_CAN_NATIVE_POSIX_LINUX`` to
     :kconfig:option:`CONFIG_CAN_NATIVE_LINUX`.
 
+* The ``CAN_FILTER_FDF`` flag for filtering classic CAN/CAN FD frames was removed since no known CAN
+  controllers implement support for this. Applications can still filter on classic CAN/CAN FD frames
+  in their receive callback functions as needed.
+
 * The io-channel cells of the following devicetree bindings were reduced from 2 (``positive`` and
   ``negative``) to the common ``input``, making it possible to use the various ADC DT macros with TI
   LMP90xxx ADC devices:

--- a/drivers/can/can_loopback.c
+++ b/drivers/can/can_loopback.c
@@ -176,12 +176,7 @@ static int can_loopback_add_rx_filter(const struct device *dev, can_rx_callback_
 
 	LOG_DBG("Setting filter ID: 0x%x, mask: 0x%x", filter->id, filter->mask);
 
-#ifdef CONFIG_CAN_FD_MODE
-	if ((filter->flags & ~(CAN_FILTER_IDE | CAN_FILTER_DATA |
-							CAN_FILTER_RTR | CAN_FILTER_FDF)) != 0) {
-#else
 	if ((filter->flags & ~(CAN_FILTER_IDE | CAN_FILTER_DATA | CAN_FILTER_RTR)) != 0) {
-#endif
 		LOG_ERR("unsupported CAN filter flags 0x%02x", filter->flags);
 		return -ENOTSUP;
 	}

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -682,16 +682,6 @@ static void can_mcan_get_message(const struct device *dev, uint16_t fifo_offset,
 			goto ack;
 		}
 
-		if (((frame.flags & CAN_FRAME_FDF) != 0U && (flags & CAN_FILTER_FDF) == 0U) ||
-		    ((frame.flags & CAN_FRAME_FDF) == 0U && (flags & CAN_FILTER_FDF) != 0U)) {
-			/* FDF bit does not match filter, drop frame */
-			err = can_mcan_write_reg(dev, fifo_ack_reg, get_idx);
-			if (err != 0) {
-				return;
-			}
-			goto ack;
-		}
-
 		data_length = can_dlc_to_bytes(frame.dlc);
 		if (data_length <= sizeof(frame.data)) {
 			if ((frame.flags & CAN_FRAME_RTR) == 0U) {
@@ -1120,12 +1110,7 @@ int can_mcan_add_rx_filter(const struct device *dev, can_rx_callback_t callback,
 		return -EINVAL;
 	}
 
-#ifdef CONFIG_CAN_FD_MODE
-	if ((filter->flags &
-	     ~(CAN_FILTER_IDE | CAN_FILTER_DATA | CAN_FILTER_RTR | CAN_FILTER_FDF)) != 0U) {
-#else  /* CONFIG_CAN_FD_MODE */
 	if ((filter->flags & ~(CAN_FILTER_IDE | CAN_FILTER_DATA | CAN_FILTER_RTR)) != 0U) {
-#endif /* !CONFIG_CAN_FD_MODE */
 		LOG_ERR("unsupported CAN filter flags 0x%02x", filter->flags);
 		return -ENOTSUP;
 	}

--- a/drivers/can/can_native_linux.c
+++ b/drivers/can/can_native_linux.c
@@ -198,12 +198,7 @@ static int can_native_linux_add_rx_filter(const struct device *dev, can_rx_callb
 	LOG_DBG("Setting filter ID: 0x%x, mask: 0x%x", filter->id,
 		filter->mask);
 
-#ifdef CONFIG_CAN_FD_MODE
-	if ((filter->flags & ~(CAN_FILTER_IDE | CAN_FILTER_DATA |
-							CAN_FILTER_RTR | CAN_FILTER_FDF)) != 0) {
-#else
 	if ((filter->flags & ~(CAN_FILTER_IDE | CAN_FILTER_DATA | CAN_FILTER_RTR)) != 0) {
-#endif
 		LOG_ERR("unsupported CAN filter flags 0x%02x", filter->flags);
 		return -ENOTSUP;
 	}

--- a/drivers/can/can_nxp_s32_canxl.c
+++ b/drivers/can/can_nxp_s32_canxl.c
@@ -511,11 +511,7 @@ static int can_nxp_s32_add_rx_filter(const struct device *dev,
 	uint32_t mask;
 
 	__ASSERT_NO_MSG(callback != NULL);
-#if defined(CONFIG_CAN_FD_MODE)
-	if ((filter->flags & ~(CAN_FILTER_IDE | CAN_FILTER_DATA | CAN_FILTER_FDF)) != 0) {
-#else
 	if ((filter->flags & ~(CAN_FILTER_IDE | CAN_FILTER_DATA)) != 0) {
-#endif
 		LOG_ERR("unsupported CAN filter flags 0x%02x", filter->flags);
 		return -ENOTSUP;
 	}
@@ -565,8 +561,7 @@ static int can_nxp_s32_add_rx_filter(const struct device *dev,
 	can_nxp_s32_config_rx_fifo_filter(dev, mb_indx);
 #else
 	data->rx_cbs[alloc].rx_info = (Canexcel_Ip_DataInfoType) {
-		.frame = !!(filter->flags & CAN_FILTER_FDF) ?
-				CANEXCEL_FD_FRAME : CANEXCEL_CLASIC_FRAME,
+		.frame = CANEXCEL_CLASIC_FRAME,
 		.idType = !!(filter->flags & CAN_FILTER_IDE) ?
 				CANEXCEL_MSG_ID_EXT : CANEXCEL_MSG_ID_STD,
 		.dataLength = CAN_NXP_S32_DATA_LENGTH,

--- a/drivers/can/can_shell.c
+++ b/drivers/can/can_shell.c
@@ -812,9 +812,6 @@ static int cmd_can_filter_add(const struct shell *sh, size_t argc, char **argv)
 			filter.flags |= CAN_FILTER_IDE;
 			max_id = CAN_MAX_EXT_ID;
 			argidx++;
-		} else if (strcmp(argv[argidx], "-f") == 0) {
-			filter.flags |= CAN_FILTER_FDF;
-			argidx++;
 		} else if (strcmp(argv[argidx], "-r") == 0) {
 			filter.flags |= CAN_FILTER_RTR;
 			argidx++;
@@ -878,14 +875,13 @@ static int cmd_can_filter_add(const struct shell *sh, size_t argc, char **argv)
 	}
 
 	shell_print(sh, "adding filter with %s (%d-bit) CAN ID 0x%0*x, "
-		    "CAN ID mask 0x%0*x, data frames %d, RTR frames %d, CAN FD frames %d",
+		    "CAN ID mask 0x%0*x, data frames %d, RTR frames %d",
 		    (filter.flags & CAN_FILTER_IDE) != 0 ? "extended" : "standard",
 		    (filter.flags & CAN_FILTER_IDE) != 0 ? 29 : 11,
 		    (filter.flags & CAN_FILTER_IDE) != 0 ? 8 : 3, filter.id,
 		    (filter.flags & CAN_FILTER_IDE) != 0 ? 8 : 3, filter.mask,
 		    (filter.flags & CAN_FILTER_DATA) != 0 ? 1 : 0,
-		    (filter.flags & CAN_FILTER_RTR) != 0 ? 1 : 0,
-		    (filter.flags & CAN_FILTER_FDF) != 0 ? 1 : 0);
+		    (filter.flags & CAN_FILTER_RTR) != 0 ? 1 : 0);
 
 	err = can_add_rx_filter_msgq(dev, &can_shell_rx_msgq, &filter);
 	if (err < 0) {
@@ -1003,12 +999,11 @@ SHELL_DYNAMIC_CMD_CREATE(dsub_can_device_name_mode, cmd_can_device_name_mode);
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_can_filter_cmds,
 	SHELL_CMD_ARG(add, &dsub_can_device_name,
 		"Add rx filter\n"
-		"Usage: can filter add <device> [-e] [-f] [-r] [-R] <CAN ID> [CAN ID mask]\n"
+		"Usage: can filter add <device> [-e] [-r] [-R] <CAN ID> [CAN ID mask]\n"
 		"-e  use extended (29-bit) CAN ID/CAN ID mask\n"
-		"-f  match CAN FD format frames\n"
 		"-r  also match Remote Transmission Request (RTR) frames\n"
 		"-R  only match Remote Transmission Request (RTR) frames",
-		cmd_can_filter_add, 3, 5),
+		cmd_can_filter_add, 3, 4),
 	SHELL_CMD_ARG(remove, &dsub_can_device_name,
 		"Remove rx filter\n"
 		"Usage: can filter remove <device> <filter_id>",

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -209,9 +209,6 @@ struct can_frame {
 /** Filter matches data frames */
 #define CAN_FILTER_DATA BIT(2)
 
-/** Filter matches CAN FD frames (FDF) */
-#define CAN_FILTER_FDF BIT(3)
-
 /** @} */
 
 /**
@@ -1626,16 +1623,6 @@ static inline bool can_frame_matches_filter(const struct can_frame *frame,
 
 	if ((frame->flags & CAN_FRAME_RTR) != 0 && (filter->flags & CAN_FILTER_RTR) == 0) {
 		/* Remote transmission request (RTR) frame, non-RTR filter */
-		return false;
-	}
-
-	if ((frame->flags & CAN_FRAME_FDF) != 0 && (filter->flags & CAN_FILTER_FDF) == 0) {
-		/* CAN FD format frame, classic format filter */
-		return false;
-	}
-
-	if ((frame->flags & CAN_FRAME_FDF) == 0 && (filter->flags & CAN_FILTER_FDF) != 0) {
-		/* Classic frame, CAN FD format filter */
 		return false;
 	}
 

--- a/include/zephyr/net/socketcan_utils.h
+++ b/include/zephyr/net/socketcan_utils.h
@@ -95,7 +95,6 @@ static inline void socketcan_to_can_filter(const struct socketcan_filter *sfilte
 	zfilter->flags |= (sfilter->can_id & BIT(31)) != 0 ? CAN_FILTER_IDE : 0;
 	zfilter->id = sfilter->can_id & BIT_MASK(29);
 	zfilter->mask = sfilter->can_mask & BIT_MASK(29);
-	zfilter->flags |= (sfilter->flags & CANFD_FDF) != 0 ? CAN_FILTER_FDF : 0;
 
 	if ((sfilter->can_mask & BIT(30)) == 0) {
 		zfilter->flags |= CAN_FILTER_DATA | CAN_FILTER_RTR;
@@ -127,10 +126,6 @@ static inline void socketcan_from_can_filter(const struct can_filter *zfilter,
 	if ((zfilter->flags & (CAN_FILTER_DATA | CAN_FILTER_RTR)) !=
 		(CAN_FILTER_DATA | CAN_FILTER_RTR)) {
 		sfilter->can_mask |= BIT(30);
-	}
-
-	if ((zfilter->flags & CAN_FILTER_FDF) != 0) {
-		sfilter->flags |= CANFD_FDF;
 	}
 }
 

--- a/subsys/canbus/isotp/isotp.c
+++ b/subsys/canbus/isotp/isotp.c
@@ -54,9 +54,7 @@ static inline void prepare_filter(struct can_filter *filter, struct isotp_msg_id
 {
 	filter->id = addr->ext_id;
 	filter->mask = mask;
-	filter->flags = CAN_FILTER_DATA |
-			((addr->flags & ISOTP_MSG_IDE) != 0 ? CAN_FILTER_IDE : 0) |
-			((addr->flags & ISOTP_MSG_FDF) != 0 ? CAN_FILTER_FDF : 0);
+	filter->flags = CAN_FILTER_DATA | ((addr->flags & ISOTP_MSG_IDE) != 0 ? CAN_FILTER_IDE : 0);
 }
 
 /*

--- a/tests/drivers/can/api/src/canfd.c
+++ b/tests/drivers/can/api/src/canfd.c
@@ -66,7 +66,7 @@ static void rx_std_callback_fd_1(const struct device *dev, struct can_frame *fra
 
 	assert_frame_equal(frame, &test_std_fdf_frame_1, 0);
 	zassert_equal(dev, can_dev, "CAN device does not match");
-	zassert_equal_ptr(filter, &test_std_fdf_filter_1, "filter does not match");
+	zassert_equal_ptr(filter, &test_std_filter_1, "filter does not match");
 
 	k_sem_give(&rx_callback_sem);
 }
@@ -78,7 +78,7 @@ static void rx_std_callback_fd_2(const struct device *dev, struct can_frame *fra
 
 	assert_frame_equal(frame, &test_std_fdf_frame_2, 0);
 	zassert_equal(dev, can_dev, "CAN device does not match");
-	zassert_equal_ptr(filter, &test_std_fdf_filter_2, "filter does not match");
+	zassert_equal_ptr(filter, &test_std_filter_2, "filter does not match");
 
 	k_sem_give(&rx_callback_sem);
 }
@@ -252,7 +252,7 @@ ZTEST(canfd, test_send_receive_classic)
  */
 ZTEST(canfd, test_send_receive_fd)
 {
-	send_receive(&test_std_fdf_filter_1, &test_std_fdf_filter_2,
+	send_receive(&test_std_filter_1, &test_std_filter_2,
 		     &test_std_fdf_frame_1, &test_std_fdf_frame_2);
 }
 
@@ -261,7 +261,7 @@ ZTEST(canfd, test_send_receive_fd)
  */
 ZTEST(canfd, test_send_receive_mixed)
 {
-	send_receive(&test_std_fdf_filter_1, &test_std_filter_2,
+	send_receive(&test_std_filter_1, &test_std_filter_2,
 		     &test_std_fdf_frame_1, &test_std_frame_2);
 }
 
@@ -292,7 +292,7 @@ static void check_filters_preserved_between_modes(can_mode_t first, can_mode_t s
 
 	/* Add classic CAN and CAN FD filter */
 	filter_id_1 = add_rx_msgq(can_dev, &test_std_filter_1);
-	filter_id_2 = add_rx_msgq(can_dev, &test_std_fdf_filter_2);
+	filter_id_2 = add_rx_msgq(can_dev, &test_std_filter_2);
 
 	/* Verify classic filter in first mode */
 	send_test_frame(can_dev, &test_std_frame_1);

--- a/tests/drivers/can/api/src/common.c
+++ b/tests/drivers/can/api/src/common.c
@@ -219,26 +219,6 @@ const struct can_filter test_std_some_filter = {
 };
 
 /**
- * @brief Standard (11-bit) CAN FD ID filter 1. This filter matches
- * ``test_std_fdf_frame_1``.
- */
-const struct can_filter test_std_fdf_filter_1 = {
-	.flags = CAN_FILTER_DATA | CAN_FILTER_FDF,
-	.id = TEST_CAN_STD_ID_1,
-	.mask = CAN_STD_ID_MASK
-};
-
-/**
- * @brief Standard (11-bit) CAN FD ID filter 2. This filter matches
- * ``test_std_fdf_frame_2``.
- */
-const struct can_filter test_std_fdf_filter_2 = {
-	.flags = CAN_FILTER_DATA | CAN_FILTER_FDF,
-	.id = TEST_CAN_STD_ID_2,
-	.mask = CAN_STD_ID_MASK
-};
-
-/**
  * @brief Assert that two CAN frames are equal given a CAN ID mask.
  *
  * @param frame1  First CAN frame.

--- a/tests/drivers/can/api/src/common.h
+++ b/tests/drivers/can/api/src/common.h
@@ -98,13 +98,13 @@ extern const struct can_frame test_std_fdf_frame_2;
 
 /**
  * @brief Standard (11-bit) CAN ID filter 1. This filter matches
- * ``test_std_frame_1``.
+ * ``test_std_frame_1`` and ``test_std_fdf_frame_1``.
  */
 extern const struct can_filter test_std_filter_1;
 
 /**
  * @brief Standard (11-bit) CAN ID filter 2. This filter matches
- * ``test_std_frame_2``.
+ * ``test_std_frame_2`` and ``test_std_fdf_frame_2``.
  */
 extern const struct can_filter test_std_filter_2;
 
@@ -161,18 +161,6 @@ extern const struct can_filter test_ext_rtr_filter_1;
  * ``TEST_CAN_SOME_STD_ID``.
  */
 extern const struct can_filter test_std_some_filter;
-
-/**
- * @brief Standard (11-bit) CAN FD ID filter 1. This filter matches
- * ``test_std_fdf_frame_1``.
- */
-extern const struct can_filter test_std_fdf_filter_1;
-
-/**
- * @brief Standard (11-bit) CAN FD ID filter 2. This filter matches
- * ``test_std_fdf_frame_2``.
- */
-extern const struct can_filter test_std_fdf_filter_2;
 
 /**
  * @brief Assert that two CAN frames are equal given a CAN ID mask.

--- a/tests/drivers/can/api/src/utilities.c
+++ b/tests/drivers/can/api/src/utilities.c
@@ -120,18 +120,8 @@ ZTEST(can_utilities, test_can_frame_matches_filter)
 	zassert_false(can_frame_matches_filter(&test_ext_frame_1, &test_ext_rtr_filter_1));
 
 	/* CAN FD format frames and filters */
-	zassert_true(can_frame_matches_filter(&test_std_fdf_frame_1, &test_std_fdf_filter_1));
-	zassert_true(can_frame_matches_filter(&test_std_fdf_frame_2, &test_std_fdf_filter_2));
-	zassert_false(can_frame_matches_filter(&test_std_fdf_frame_1, &test_std_fdf_filter_2));
-	zassert_false(can_frame_matches_filter(&test_std_fdf_frame_2, &test_std_fdf_filter_1));
-
-	/* CAN FD format frames and classic filters */
-	zassert_false(can_frame_matches_filter(&test_std_fdf_frame_1, &test_std_filter_1));
-	zassert_false(can_frame_matches_filter(&test_std_fdf_frame_2, &test_std_filter_2));
-
-	/* Classic format frames and CAN FD format filters */
-	zassert_false(can_frame_matches_filter(&test_std_frame_1, &test_std_fdf_filter_1));
-	zassert_false(can_frame_matches_filter(&test_std_frame_2, &test_std_fdf_filter_2));
+	zassert_true(can_frame_matches_filter(&test_std_fdf_frame_1, &test_std_filter_1));
+	zassert_true(can_frame_matches_filter(&test_std_fdf_frame_2, &test_std_filter_2));
 }
 
 ZTEST_SUITE(can_utilities, NULL, NULL, NULL, NULL, NULL);

--- a/tests/subsys/canbus/isotp/conformance/src/main.c
+++ b/tests/subsys/canbus/isotp/conformance/src/main.c
@@ -306,8 +306,7 @@ static int add_rx_msgq(uint32_t id, uint32_t mask)
 {
 	int filter_id;
 	struct can_filter filter = {
-		.flags = CAN_FILTER_DATA | ((id > 0x7FF) ? CAN_FILTER_IDE : 0) |
-			 (IS_ENABLED(CONFIG_TEST_USE_CAN_FD_MODE) ? CAN_FILTER_FDF : 0),
+		.flags = CAN_FILTER_DATA | ((id > 0x7FF) ? CAN_FILTER_IDE : 0),
 		.id = id,
 		.mask = mask
 	};


### PR DESCRIPTION
Remove the CAN_FILTER_FDF flag for filtering on classic CAN/CAN FD frames as it is not supported natively by any known CAN controller.
    
Applications can still filter on classic CAN/CAN FD frames in their receive callback functions as needed.
    
Fixes: #64554
RFC issue: #65109

~Note: This currently includes the changes from #65058 in order to remove the mix of software and hardware filtering in the Bosch M_CAN backend completely, which is what led to #64554.~