### PR TITLE
doc: migration-guide: 3.6: Fix spurious character

### DIFF
--- a/doc/releases/migration-guide-3.6.rst
+++ b/doc/releases/migration-guide-3.6.rst
@@ -91,7 +91,7 @@ Other Subsystems
 * Touchscreen drivers :dtcompatible:`focaltech,ft5336` and
   :dtcompatible:`goodix,gt911` were using the incorrect polarity for the
   respective ``reset-gpios``. This has been fixed so those signals now have to
-  be flagged as :c:macro:`GPIO_ACTIVE_LOW` in the devicetree.`
+  be flagged as :c:macro:`GPIO_ACTIVE_LOW` in the devicetree.
 
 Recommended Changes
 *******************


### PR DESCRIPTION
Fixes a spurious tilde character at the end of a change