### PR TITLE
usb: device: cdc_acm: Do not log dropped characters

### DIFF
--- a/subsys/usb/device/class/cdc_acm.c
+++ b/subsys/usb/device/class/cdc_acm.c
@@ -1033,7 +1033,7 @@ static void cdc_acm_poll_out(const struct device *dev, unsigned char c)
 
 	while (!ring_buf_put(dev_data->tx_ringbuf, &c, 1)) {
 		if (k_is_in_isr() || !dev_data->flow_ctrl) {
-			LOG_INF("Ring buffer full, discard %c", c);
+			LOG_WRN_ONCE("Ring buffer full, discard data");
 			break;
 		}
 


### PR DESCRIPTION
Generating separate log entry at INFO level for every single character dropped is excessive and leads to log flood. Logging dropped character in no way helps end user and is really a delayed performance killer that triggers when CDC ACM buffer gets full.

If user does not want to lose outgoing characters then the solution is to enable hardware flow control which properly blocks in the case the output buffer is full.