### PR TITLE
Modem backend uart optimize

### DIFF
--- a/include/zephyr/modem/backend/uart.h
+++ b/include/zephyr/modem/backend/uart.h
@@ -31,7 +31,8 @@ struct modem_backend_uart_isr {
 struct modem_backend_uart_async {
 	uint8_t *receive_bufs[2];
 	uint32_t receive_buf_size;
-	struct ring_buf receive_rdb[2];
+	struct ring_buf receive_rb;
+	struct k_spinlock receive_rb_lock;
 	uint8_t *transmit_buf;
 	uint32_t transmit_buf_size;
 	struct k_work rx_disabled_work;

--- a/subsys/modem/backends/modem_backend_uart_async.c
+++ b/subsys/modem/backends/modem_backend_uart_async.c
@@ -17,15 +17,6 @@ LOG_MODULE_DECLARE(modem_backend_uart);
 #define MODEM_BACKEND_UART_ASYNC_STATE_RX_BUF0_USED_BIT       (2)
 #define MODEM_BACKEND_UART_ASYNC_STATE_RX_BUF1_USED_BIT       (3)
 
-static void modem_backend_uart_async_flush(struct modem_backend_uart *backend)
-{
-	uint8_t c;
-
-	while (uart_fifo_read(backend->uart, &c, 1) > 0) {
-		continue;
-	}
-}
-
 static bool modem_backend_uart_async_is_closed(struct modem_backend_uart *backend)
 {
 	if (!atomic_test_bit(&backend->async.state,
@@ -142,7 +133,6 @@ static int modem_backend_uart_async_open(void *data)
 	int ret;
 
 	atomic_set(&backend->async.state, 0);
-	modem_backend_uart_async_flush(backend);
 	ring_buf_reset(&backend->async.receive_rb);
 
 	/* Reserve receive buffer 0 */


### PR DESCRIPTION
Optimizes the UART async modem backend to properly open/close the pipe. The current implementation does not perform the required cleanup before indicating that the pipe is in fact closed, which is now determined by:
* UART RX is disabled
* both UART RX buffers are released
* TX is done
Before this patch, it only checked for RX disabled.

This PR also removes the work item used to delegate the pipe closed indication as this is already (and should be) delegated to other threads by the modem modules using the pipe. This avoids double work (work queue item delegating to another work queu item)