### PR TITLE
dts: bindings: max20335-charger/bq24190: make constant-charge-current/voltage properties required

### DIFF
--- a/dts/bindings/charger/maxim,max20335-charger.yaml
+++ b/dts/bindings/charger/maxim,max20335-charger.yaml
@@ -6,3 +6,10 @@ description: Maxim MAX20335 battery charger
 include: battery.yaml
 
 compatible: "maxim,max20335-charger"
+
+properties:
+  constant-charge-current-max-microamp:
+    required: true
+
+  constant-charge-voltage-max-microvolt:
+    required: true

--- a/dts/bindings/charger/ti,bq24190.yaml
+++ b/dts/bindings/charger/ti,bq24190.yaml
@@ -6,3 +6,10 @@ description: Texas Instruments family of BQ24190 of charging ICs
 include: [battery.yaml, i2c-device.yaml]
 
 compatible: "ti,bq24190"
+
+properties:
+  constant-charge-current-max-microamp:
+    required: true
+
+  constant-charge-voltage-max-microvolt:
+    required: true


### PR DESCRIPTION
There are no default values for those properties in the driver so let's make them required.