### PR TITLE
net: buf: Preserve data pointer in destroy callback

### DIFF
--- a/include/zephyr/net/buf.h
+++ b/include/zephyr/net/buf.h
@@ -1358,6 +1358,13 @@ static inline void net_buf_destroy(struct net_buf *buf)
 {
 	struct net_buf_pool *pool = net_buf_pool_get(buf->pool_id);
 
+	if (buf->__buf) {
+		if (!(buf->flags & NET_BUF_EXTERNAL_DATA)) {
+			pool->alloc->cb->unref(buf, buf->__buf);
+		}
+		buf->__buf = NULL;
+	}
+
 	k_lifo_put(&pool->free, buf);
 }
 

--- a/subsys/net/buf.c
+++ b/subsys/net/buf.c
@@ -221,17 +221,6 @@ static uint8_t *data_ref(struct net_buf *buf, uint8_t *data)
 	return pool->alloc->cb->ref(buf, data);
 }
 
-static void data_unref(struct net_buf *buf, uint8_t *data)
-{
-	struct net_buf_pool *pool = net_buf_pool_get(buf->pool_id);
-
-	if (buf->flags & NET_BUF_EXTERNAL_DATA) {
-		return;
-	}
-
-	pool->alloc->cb->unref(buf, data);
-}
-
 #if defined(CONFIG_NET_BUF_LOG)
 struct net_buf *net_buf_alloc_len_debug(struct net_buf_pool *pool, size_t size,
 					k_timeout_t timeout, const char *func,
@@ -482,11 +471,6 @@ void net_buf_unref(struct net_buf *buf)
 
 		if (--buf->ref > 0) {
 			return;
-		}
-
-		if (buf->__buf) {
-			data_unref(buf, buf->__buf);
-			buf->__buf = NULL;
 		}
 
 		buf->data = NULL;


### PR DESCRIPTION
The use case is to have a netbuf pool that is used exclusively with net_buf_alloc_with_data() where the destroy callback takes care of freeing the actual data.