### PR TITLE
toolchain: llvm: use the "none" vendor triplet

### DIFF
--- a/cmake/toolchain/llvm/target.cmake
+++ b/cmake/toolchain/llvm/target.cmake
@@ -16,7 +16,7 @@ if("${ARCH}" STREQUAL "arm")
   elseif(DEFINED CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
     # ARMV7_M_ARMV8_M_MAINLINE means that ARMv7-M or backward compatible ARMv8-M
     # processor is used.
-    set(triple armv7m-cros-eabi)
+    set(triple armv7m-none-eabi)
   elseif(DEFINED CONFIG_ARMV6_M_ARMV8_M_BASELINE)
     # ARMV6_M_ARMV8_M_BASELINE means that ARMv6-M or ARMv8-M supporting the
     # Baseline implementation processor is used.


### PR DESCRIPTION
This was submitted with "cros" in 77dde5dc9f, it was meant to be "none".