### PR TITLE
soc: arm: nordic_nrf: Imply XIP instead of select

### DIFF
--- a/soc/arm/nordic_nrf/nrf51/Kconfig.series
+++ b/soc/arm/nordic_nrf/nrf51/Kconfig.series
@@ -9,7 +9,7 @@ config SOC_SERIES_NRF51X
 	select ARM
 	select CPU_CORTEX_M0
 	select SOC_FAMILY_NRF
-	select XIP
+	imply XIP
 	select HAS_NRFX
 	select HAS_SEGGER_RTT if ZEPHYR_SEGGER_MODULE
 	select HAS_POWEROFF

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.series
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.series
@@ -10,7 +10,7 @@ config SOC_SERIES_NRF52X
 	select CPU_CORTEX_M4
 	select CPU_HAS_ARM_MPU
 	select SOC_FAMILY_NRF
-	select XIP
+	imply XIP
 	select HAS_NRFX
 	select HAS_NORDIC_DRIVERS
 	select HAS_SEGGER_RTT if ZEPHYR_SEGGER_MODULE

--- a/soc/arm/nordic_nrf/nrf53/Kconfig.series
+++ b/soc/arm/nordic_nrf/nrf53/Kconfig.series
@@ -11,7 +11,7 @@ config SOC_SERIES_NRF53X
 	select CPU_CORTEX_M_HAS_DWT
 	select CPU_HAS_ARM_MPU
 	select SOC_FAMILY_NRF
-	select XIP
+	imply XIP
 	select HAS_NRFX
 	select HAS_NORDIC_DRIVERS
 	select HAS_SEGGER_RTT if ZEPHYR_SEGGER_MODULE

--- a/soc/arm/nordic_nrf/nrf91/Kconfig.series
+++ b/soc/arm/nordic_nrf/nrf91/Kconfig.series
@@ -13,7 +13,7 @@ config SOC_SERIES_NRF91X
 	select CPU_HAS_FPU
 	select ARMV8_M_DSP
 	select SOC_FAMILY_NRF
-	select XIP
+	imply XIP
 	select HAS_NRFX
 	select HAS_SEGGER_RTT if ZEPHYR_SEGGER_MODULE
 	select HAS_POWEROFF


### PR DESCRIPTION
This allows XIP to be disabled for applications that execute in RAM, which do not need XIP support from flash