### PR TITLE
tests: logging: update the name of the UART log backend used in the test

### DIFF
--- a/tests/subsys/logging/log_core_additional/src/log_test.c
+++ b/tests/subsys/logging/log_core_additional/src/log_test.c
@@ -376,7 +376,7 @@ ZTEST(test_log_core_additional, test_log_timestamping)
  * @addtogroup logging
  */
 
-#define UART_BACKEND "log_backend_uart"
+#define UART_BACKEND "log_backend_uart0"
 ZTEST(test_log_core_additional, test_multiple_backends)
 {
 	int cnt;


### PR DESCRIPTION
Following #64917, the name of the UART log backend(s) are now defined to be `log_backend_uart##idx`, update the name used in the test to look for `log_backend_uart0`, which is the name of the UART logging backend when using the default
`zephyr,console` node.

```
(.venv) ycsin@LAPTOP-ROG:~/zephyrproject$ west build -b m2gl025_miv -p auto -t run -T zephyr/tests/subsys/logging/log_core_additional/logging.async
-- west build: making build dir /home/ycsin/zephyrproject/build pristine
-- west build: generating a build system
Loading Zephyr default modules (Zephyr base).
-- Application: /home/ycsin/zephyrproject/zephyr/tests/subsys/logging/log_core_additional
-- CMake version: 3.27.7
-- Found Python3: /home/ycsin/zephyrproject/.venv/bin/python3 (found suitable version "3.10.12", minimum required is "3.8") found components: Interpreter 
-- Cache files will be written to: /home/ycsin/.cache/zephyr
-- Zephyr version: 3.5.99 (/home/ycsin/zephyrproject/zephyr)
-- Found west (found suitable version "1.2.0", minimum required is "0.14.0")
-- Board: m2gl025_miv
-- ZEPHYR_TOOLCHAIN_VARIANT not set, trying to locate Zephyr SDK
-- Found host-tools: zephyr 0.16.3 (/home/ycsin/zephyr-sdk-0.16.3)
-- Found toolchain: zephyr 0.16.3 (/home/ycsin/zephyr-sdk-0.16.3)
-- Found Dtc: /home/ycsin/zephyr-sdk-0.16.3/sysroots/x86_64-pokysdk-linux/usr/bin/dtc (found suitable version "1.6.0", minimum required is "1.4.6") 
-- Found BOARD.dts: /home/ycsin/zephyrproject/zephyr/boards/riscv/m2gl025_miv/m2gl025_miv.dts
-- Generated zephyr.dts: /home/ycsin/zephyrproject/build/zephyr/zephyr.dts
-- Generated devicetree_generated.h: /home/ycsin/zephyrproject/build/zephyr/include/generated/devicetree_generated.h
-- Including generated dts.cmake file: /home/ycsin/zephyrproject/build/zephyr/dts.cmake
Parsing /home/ycsin/zephyrproject/zephyr/Kconfig
Loaded configuration '/home/ycsin/zephyrproject/zephyr/boards/riscv/m2gl025_miv/m2gl025_miv_defconfig'
Merged configuration '/home/ycsin/zephyrproject/zephyr/tests/subsys/logging/log_core_additional/prj.conf'
Configuration saved to '/home/ycsin/zephyrproject/build/zephyr/.config'
Kconfig header saved to '/home/ycsin/zephyrproject/build/zephyr/include/generated/autoconf.h'
-- Found GnuLd: /home/ycsin/zephyr-sdk-0.16.3/riscv64-zephyr-elf/bin/../lib/gcc/riscv64-zephyr-elf/12.2.0/../../../../riscv64-zephyr-elf/bin/ld.bfd (found version "2.38") 
-- The C compiler identification is GNU 12.2.0
-- The CXX compiler identification is GNU 12.2.0
-- The ASM compiler identification is GNU
-- Found assembler: /home/ycsin/zephyr-sdk-0.16.3/riscv64-zephyr-elf/bin/riscv64-zephyr-elf-gcc
-- Configuring done (9.8s)
-- Generating done (0.0s)
-- Build files have been written to: /home/ycsin/zephyrproject/build
-- west build: running target run
[1/112] Preparing syscall dependency handling

[2/112] Generating include/generated/version.h
-- Zephyr version: 3.5.99 (/home/ycsin/zephyrproject/zephyr), build: zephyr-v3.5.0-1408-g8acd50187d68
[111/112] Linking C executable zephyr/zephyr.elf
Memory region         Used Size  Region Size  %age Used
             ROM:       62676 B       256 KB     23.91%
             RAM:       14700 B       256 KB      5.61%
        IDT_LIST:          0 GB         2 KB      0.00%
[111/112] cd /home/ycsin/zephyrproject/build && /usr/bin/renode --disable-xwt --port -2 --pid-file re....elf; include @/home/ycsin/zephyrproject/zephyr/boards/riscv/m2gl025_miv/support/m2gl025_miv.resc; s'
00:23:39.8891 [INFO] Loaded monitor commands from: /opt/renode/scripts/monitor.py
00:23:39.9687 [INFO] Including script: /home/ycsin/zephyrproject/zephyr/boards/riscv/m2gl025_miv/support/m2gl025_miv.resc
00:23:40.0081 [INFO] System bus created.
00:23:41.5613 [INFO] sysbus: Loading segment of 62532 bytes length at 0x80000000.
00:23:41.5756 [INFO] sysbus: Loading segment of 140 bytes length at 0x8000F444.
00:23:41.5757 [INFO] sysbus: Loading segment of 4 bytes length at 0x8000F4D0.
00:23:41.5758 [INFO] sysbus: Loading segment of 14560 bytes length at 0x80040000.
00:23:41.6006 [INFO] cpu: Setting PC value to 0x80000000.
00:23:41.6721 [INFO] Mi-V: Machine started.
00:23:41.7621 [WARNING] plic: Unhandled write to offset 0x200000, value 0x0.
00:23:41.7716 [WARNING] uart: Unhandled write to offset 0xC. Unhandled bits: [0] when writing value 0x1. Tags: BIT8 (0x1).
00:23:41.7876 [INFO] uart: [host: 0.82s (+0.82s)|virt: 3.8ms (+3.8ms)] *** Booting Zephyr OS build zephyr-v3.5.0-1408-g8acd50187d68 ***
00:23:41.7905 [INFO] uart: [host: 0.82s (+2.9ms)|virt: 4.9ms (+1.1ms)] Running TESTSUITE test_log_core_additional
00:23:41.7941 [INFO] uart: [host: 0.83s (+3.64ms)|virt: 5.7ms (+0.8ms)] ===================================================================
00:23:41.7952 [INFO] uart: [host: 0.83s (+1.14ms)|virt: 6.1ms (+0.4ms)] START - test_log_backend
00:23:41.7988 [INFO] uart: [host: 0.83s (+3.52ms)|virt: 7.2ms (+1.1ms)]  PASS - test_log_backend in 0.001 seconds
00:23:41.8003 [INFO] uart: [host: 0.83s (+1.55ms)|virt: 7.9ms (+0.7ms)] ===================================================================
00:23:41.8015 [INFO] uart: [host:  0.83s (+1.1ms)|virt: 8.3ms (+0.4ms)] START - test_log_domain_id
00:23:41.8241 [INFO] uart: [host: 0.86s (+22.61ms)|virt: 14.6ms (+6.3ms)] [00:00:00.000,000] [0m<inf> log_test: info message for domain id test[0m
00:23:41.8285 [INFO] uart: [host:  0.86s (+4.47ms)|virt:   15.6ms (+1ms)]  PASS - test_log_domain_id in 0.007 seconds
00:23:41.8296 [INFO] uart: [host:  0.86s (+1.23ms)|virt: 16.3ms (+0.7ms)] ===================================================================
00:23:41.8306 [INFO] uart: [host:  0.86s (+0.94ms)|virt: 16.8ms (+0.5ms)] START - test_log_early_logging
00:23:41.8319 [INFO] uart: [host:  0.87s (+1.32ms)|virt: 17.5ms (+0.7ms)] Create log message before backend active
00:23:41.8509 [INFO] uart: [host: 0.88s (+18.83ms)|virt: 27.4ms (+9.9ms)] Activate backend with context PASS - test_log_early_logging in 0.010 seconds
00:23:41.8525 [INFO] uart: [host:  0.89s (+1.58ms)|virt: 28.2ms (+0.8ms)] ===================================================================
00:23:41.8533 [INFO] uart: [host:  0.89s (+0.95ms)|virt: 28.6ms (+0.4ms)] START - test_log_generic
00:23:41.8737 [INFO] uart: [host: 0.91s (+20.35ms)|virt: 39.4ms (+10.8ms)]  PASS - test_log_generic in 0.011 seconds
00:23:41.8754 [INFO] uart: [host:  0.91s (+1.65ms)|virt:  40.2ms (+0.8ms)] ===================================================================
00:23:41.8763 [INFO] uart: [host:  0.91s (+0.98ms)|virt:  40.6ms (+0.4ms)] START - test_log_msg_create
00:23:41.8948 [INFO] uart: [host:  0.93s (+18.5ms)|virt: 50.9ms (+10.3ms)]  PASS - test_log_msg_create in 0.010 seconds
00:23:41.8962 [INFO] uart: [host:  0.93s (+1.51ms)|virt:  51.7ms (+0.8ms)] ===================================================================
00:23:41.8971 [INFO] uart: [host:  0.93s (+0.83ms)|virt:  52.1ms (+0.4ms)] START - test_log_severity
00:23:41.9136 [INFO] uart: [host: 0.95s (+16.46ms)|virt:  60.6ms (+8.5ms)]  PASS - test_log_severity in 0.008 seconds
00:23:41.9150 [INFO] uart: [host:  0.95s (+1.49ms)|virt:  61.4ms (+0.8ms)] ===================================================================
00:23:41.9156 [INFO] uart: [host:  0.95s (+0.64ms)|virt:  61.7ms (+0.3ms)] START - test_log_sync
00:23:41.9165 [INFO] uart: [host:  0.95s (+0.83ms)|virt:  62.2ms (+0.5ms)] Logging synchronously
00:23:41.9180 [INFO] uart: [host:  0.95s (+1.42ms)|virt:    63ms (+0.8ms)]  SKIP - test_log_sync in 0.001 seconds
00:23:41.9201 [INFO] uart: [host:  0.95s (+1.97ms)|virt:  63.8ms (+0.8ms)] ===================================================================
00:23:41.9214 [INFO] uart: [host:  0.95s (+1.28ms)|virt:  64.2ms (+0.4ms)] START - test_log_thread
00:23:41.9266 [INFO] uart: [host:  0.96s (+5.39ms)|virt:    65.2ms (+1ms)]  SKIP - test_log_thread in 0.001 seconds
00:23:41.9288 [INFO] uart: [host:  0.96s (+1.83ms)|virt:    66ms (+0.8ms)] ===================================================================
00:23:41.9305 [INFO] uart: [host:  0.96s (+2.01ms)|virt:  66.4ms (+0.4ms)] START - test_log_timestamping
00:23:41.9320 [INFO] uart: [host:  0.97s (+1.46ms)|virt:    67ms (+0.6ms)] Register timestamp function
00:23:41.9504 [INFO] uart: [host: 0.98s (+18.49ms)|virt:  75.2ms (+8.2ms)]  PASS - test_log_timestamping in 0.009 seconds
00:23:41.9523 [INFO] uart: [host:  0.99s (+1.86ms)|virt:    76ms (+0.8ms)] ===================================================================
00:23:41.9535 [INFO] uart: [host:  0.99s (+1.19ms)|virt:  76.5ms (+0.5ms)] START - test_multiple_backends
00:23:41.9569 [INFO] uart: [host:  0.99s (+3.32ms)|virt:  78.1ms (+1.6ms)] Test multiple backends PASS - test_multiple_backends in 0.001 seconds
00:23:41.9585 [INFO] uart: [host:  0.99s (+1.67ms)|virt:  78.9ms (+0.8ms)] ===================================================================
00:23:41.9599 [INFO] uart: [host:  0.99s (+1.34ms)|virt:  79.5ms (+0.6ms)] TESTSUITE test_log_core_additional succeeded
00:23:41.9612 [INFO] uart: [host:   0.99s (+1.4ms)|virt:    80ms (+0.5ms)] 
00:23:41.9626 [INFO] uart: [host:     1s (+1.37ms)|virt:  80.5ms (+0.5ms)] ------ TESTSUITE SUMMARY START ------
00:23:41.9646 [INFO] uart: [host:     1s (+0.13ms)|virt:     80.5ms (+0s)] 
00:23:41.9699 [INFO] uart: [host:     1s (+7.06ms)|virt:  83.1ms (+2.6ms)] SUITE PASS - 100.00% [test_log_core_additional]: pass = 8, fail = 0, skip = 2, total = 10 duration = 0.059 seconds
00:23:41.9735 [INFO] uart: [host:  1.01s (+3.64ms)|virt:  84.3ms (+1.2ms)]  - PASS - [test_log_core_additional.test_log_backend] duration = 0.001 seconds
00:23:41.9761 [INFO] uart: [host:  1.01s (+2.61ms)|virt:  85.5ms (+1.2ms)]  - PASS - [test_log_core_additional.test_log_domain_id] duration = 0.007 seconds
00:23:41.9806 [INFO] uart: [host:  1.01s (+4.54ms)|virt:  86.7ms (+1.2ms)]  - PASS - [test_log_core_additional.test_log_early_logging] duration = 0.010 seconds
00:23:41.9830 [INFO] uart: [host:  1.02s (+2.41ms)|virt:  87.9ms (+1.2ms)]  - PASS - [test_log_core_additional.test_log_generic] duration = 0.011 seconds
00:23:41.9855 [INFO] uart: [host:  1.02s (+2.56ms)|virt:  89.2ms (+1.3ms)]  - PASS - [test_log_core_additional.test_log_msg_create] duration = 0.010 seconds
00:23:41.9877 [INFO] uart: [host:  1.02s (+2.13ms)|virt:  90.4ms (+1.2ms)]  - PASS - [test_log_core_additional.test_log_severity] duration = 0.008 seconds
00:23:41.9900 [INFO] uart: [host:  1.02s (+2.23ms)|virt:  91.5ms (+1.1ms)]  - SKIP - [test_log_core_additional.test_log_sync] duration = 0.001 seconds
00:23:41.9940 [INFO] uart: [host:  1.03s (+4.14ms)|virt:  92.7ms (+1.2ms)]  - SKIP - [test_log_core_additional.test_log_thread] duration = 0.001 seconds
00:23:41.9958 [INFO] uart: [host:   1.03s (+1.8ms)|virt:  93.9ms (+1.2ms)]  - PASS - [test_log_core_additional.test_log_timestamping] duration = 0.009 seconds
00:23:41.9986 [INFO] uart: [host:  1.03s (+2.77ms)|virt:  95.2ms (+1.3ms)]  - PASS - [test_log_core_additional.test_multiple_backends] duration = 0.001 seconds
00:23:41.9989 [INFO] uart: [host:  1.03s (+0.17ms)|virt:     95.2ms (+0s)] 
00:23:41.9998 [INFO] uart: [host:  1.03s (+1.05ms)|virt:  95.7ms (+0.5ms)] ------ TESTSUITE SUMMARY END ------
00:23:41.9999 [INFO] uart: [host:    1.03s (+80µs)|virt:     95.7ms (+0s)] 
00:23:42.0015 [INFO] uart: [host:  1.03s (+1.52ms)|virt:  96.5ms (+0.8ms)] ===================================================================
00:23:42.0023 [INFO] uart: [host:  1.04s (+0.88ms)|virt:  96.9ms (+0.4ms)] PROJECT EXECUTION SUCCESSFUL
```