### PR TITLE
tests: build_all: input: unify the gpio definitions

### DIFF
--- a/tests/drivers/build_all/input/app.overlay
+++ b/tests/drivers/build_all/input/app.overlay
@@ -74,7 +74,7 @@
 				reset-gpios = <&test_gpio 1 0>;
 			};
 
-			cst816s: cst816s@2 {
+			cst816s@2 {
 				compatible = "hynitron,cst816s";
 				reg = <0x2>;
 				irq-gpios = <&test_gpio 0 0>;

--- a/tests/drivers/build_all/input/app.overlay
+++ b/tests/drivers/build_all/input/app.overlay
@@ -70,28 +70,28 @@
 			gt911@1 {
 				compatible = "goodix,gt911";
 				reg = <0x1>;
-				irq-gpios = <&gpio0 0 0>;
-				reset-gpios = <&gpio0 0 0>;
+				irq-gpios = <&test_gpio 0 0>;
+				reset-gpios = <&test_gpio 1 0>;
 			};
 
 			cst816s: cst816s@2 {
 				compatible = "hynitron,cst816s";
 				reg = <0x2>;
-				irq-gpios = <&gpio0 0 0>;
-				rst-gpios = <&gpio0 0 0>;
+				irq-gpios = <&test_gpio 0 0>;
+				rst-gpios = <&test_gpio 1 0>;
 			};
 
 			cap1203@3 {
 				compatible = "microchip,cap1203";
 				reg = <0x3>;
-				int-gpios = <&gpio0 0 0>;
+				int-gpios = <&test_gpio 0 0>;
 				input-codes = <0 1 2>;
 			};
 
 			stmpe811@4 {
 				compatible = "st,stmpe811";
 				reg = <0x4>;
-				int-gpios = <&gpio0 0 0>;
+				int-gpios = <&test_gpio 0 0>;
 				panel-driver-settling-time-us = <10>;
 				touch-detect-delay-us = <10>;
 				touch-average-control = <1>;


### PR DESCRIPTION
Clean up few build all device instances to use the test_gpio node and different gpio numbers. Makes them somewhat more representative of what an actual instance would look like.