### PR TITLE
drivers: i3c: add additional variable for num xfer for i3c

### DIFF
--- a/drivers/i3c/i3c_cdns.c
+++ b/drivers/i3c/i3c_cdns.c
@@ -431,6 +431,7 @@ struct cdns_i3c_cmd {
 	uint32_t cmd0;
 	uint32_t cmd1;
 	uint32_t len;
+	uint32_t *num_xfer;
 	void *buf;
 	uint32_t error;
 };
@@ -1022,6 +1023,8 @@ static int cdns_i3c_do_ccc(const struct device *dev, struct i3c_ccc_payload *pay
 		dcmd->buf = payload->ccc.data;
 		dcmd->len = payload->ccc.data_len;
 		dcmd->cmd0 |= CMD0_FIFO_PL_LEN(payload->ccc.data_len);
+		/* write the address of num_xfer which is to be updated upon message completion */
+		dcmd->num_xfer = &(payload->ccc.num_xfer);
 	} else if (payload->targets.num_targets > 0) {
 		dcmd->buf = payload->targets.payloads[0].data;
 		dcmd->len = payload->targets.payloads[0].data_len;
@@ -1030,6 +1033,8 @@ static int cdns_i3c_do_ccc(const struct device *dev, struct i3c_ccc_payload *pay
 		if (payload->targets.payloads[0].rnw) {
 			dcmd->cmd0 |= CMD0_FIFO_RNW;
 		}
+		/* write the address of num_xfer which is to be updated upon message completion */
+		dcmd->num_xfer = &(payload->targets.payloads[0].num_xfer);
 		idx++;
 	}
 	num_cmds++;
@@ -1055,6 +1060,11 @@ static int cdns_i3c_do_ccc(const struct device *dev, struct i3c_ccc_payload *pay
 
 			cmd->buf = tgt_payload->data;
 			cmd->len = tgt_payload->data_len;
+			/*
+			 * write the address of num_xfer which is to be updated upon message
+			 * completion
+			 */
+			cmd->num_xfer = &(tgt_payload->num_xfer);
 
 			idx++;
 		}
@@ -1288,6 +1298,9 @@ static void cdns_i3c_complete_transfer(const struct device *dev)
 		/* Read any rx data into buffer */
 		if (cmd->cmd0 & CMD0_FIFO_RNW) {
 			rx = MIN(CMDR_XFER_BYTES(cmdr), cmd->len);
+			if (cmd->num_xfer != NULL) {
+				*cmd->num_xfer = rx;
+			}
 			ret = cdns_i3c_read_rx_fifo(config, cmd->buf, rx);
 		}
 
@@ -1421,6 +1434,9 @@ static int cdns_i3c_i2c_transfer(const struct device *dev, struct i3c_i2c_device
 		if ((msgs[i].flags & I2C_MSG_RW_MASK) == I2C_MSG_READ) {
 			cmd->cmd0 |= CMD0_FIFO_RNW;
 		}
+
+		/* i2c transfers are a don't care for num_xfer */
+		cmd->num_xfer = NULL;
 	}
 
 	data->xfer.ret = -ETIMEDOUT;
@@ -1732,6 +1748,9 @@ static int cdns_i3c_transfer(const struct device *dev, struct i3c_device_desc *t
 		} else {
 			send_broadcast = true;
 		}
+
+		/* write the address of num_xfer which is to be updated upon message completion */
+		cmd->num_xfer = &(msgs[i].num_xfer);
 	}
 
 	data->xfer.ret = -ETIMEDOUT;

--- a/drivers/i3c/i3c_mcux.c
+++ b/drivers/i3c/i3c_mcux.c
@@ -1131,6 +1131,9 @@ static int mcux_i3c_transfer(const struct device *dev,
 			goto out_xfer_i3c_stop_unlock;
 		}
 
+		/* write back the total number of bytes transferred */
+		msgs[i].num_xfer = ret;
+
 		if (emit_stop) {
 			/* After a STOP, send broadcast header before next msg */
 			send_broadcast = true;
@@ -1371,6 +1374,9 @@ static int mcux_i3c_do_ccc(const struct device *dev,
 
 			goto out_ccc_stop;
 		}
+
+		/* write back the total number of bytes transferred */
+		payload->ccc.num_xfer = ret;
 	}
 
 	/* Wait for controller to say the operation is done */
@@ -1402,6 +1408,9 @@ static int mcux_i3c_do_ccc(const struct device *dev,
 
 				goto out_ccc_stop;
 			}
+
+			/* write back the total number of bytes transferred */
+			tgt_payload->num_xfer = ret;
 		}
 	}
 

--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 Intel Corporation
+ * Copyright 2023 Meta Platforms, Inc. and its affiliates
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -468,6 +469,15 @@ struct i3c_msg {
 
 	/** Length of buffer in bytes */
 	uint32_t		len;
+
+	/**
+	 * Total number of bytes transferred
+	 *
+	 * A Target can issue an EoD or the Controller can abort a transfer
+	 * before the length of the buffer. It is expected for the driver to
+	 * write to this after the transfer.
+	 */
+	uint32_t		num_xfer;
 
 	/** Flags for this message */
 	uint8_t			flags;

--- a/include/zephyr/drivers/i3c/ccc.h
+++ b/include/zephyr/drivers/i3c/ccc.h
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 Intel Corporation
+ * Copyright 2023 Meta Platforms, Inc. and its affiliates
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -248,6 +249,15 @@ struct i3c_ccc_target_payload {
 
 	/** Length in bytes for @p data. */
 	size_t data_len;
+
+	/**
+	 * Total number of bytes transferred
+	 *
+	 * A Target can issue an EoD or the Controller can abort a transfer
+	 * before the length of the buffer. It is expected for the driver to
+	 * write to this after the transfer.
+	 */
+	size_t num_xfer;
 };
 
 /**
@@ -270,6 +280,14 @@ struct i3c_ccc_payload {
 
 		/** Length in bytes for optional data array. */
 		size_t data_len;
+
+		/**
+		 * Total number of bytes transferred
+		 *
+		 * A Controller can abort a transfer before the length of the buffer.
+		 * It is expected for the driver to write to this after the transfer.
+		 */
+		size_t num_xfer;
 	} ccc;
 
 	struct {


### PR DESCRIPTION
With I3C, when a controller does a read whether, through a private transfer
or a CCC, the target is responsible for issuing the End of Data through the
T bit, but the way the API is currently implemented, there is no way to
communicate this back up. For example, if a controller tries to read 100
Bytes (where the controller is to do an abort after 100 (or 101 bytes))
from a Target and the Target gives the EoD at the 42nd Byte, then there is
no way to currently know where the EoD occurred and how far it can be read
up to in the provided buffers.
    
This implements a num_xfer for `i3c_msg` and `i3c_ccc_payload` which the
driver is responsible for writing the total number of bytes transfered.

Fixes #65099