### PR TITLE
ipc: pbuf: fix incorrect doxygen group

### DIFF
--- a/include/zephyr/ipc/pbuf.h
+++ b/include/zephyr/ipc/pbuf.h
@@ -16,7 +16,8 @@ extern "C" {
 
 /**
  * @brief Packed buffer API
- * @ingroup kernel_apis
+ * @defgroup pbuf Packed Buffer API
+ * @ingroup ipc
  * @{
  */
 


### PR DESCRIPTION
The ipc/pbuf was tagged as kernel API, which is not correct. As this is for IPC, move it under IPC doxygen group and also give it its own subgroup. So now the packed buffer API appears under IPC in API doc.