### PR TITLE
drivers: i2s: mcux_flexcomm: Change LOG_INF to LOG_DBG in init

### DIFF
--- a/drivers/i2s/i2s_mcux_flexcomm.c
+++ b/drivers/i2s/i2s_mcux_flexcomm.c
@@ -901,7 +901,7 @@ static int i2s_mcux_init(const struct device *dev)
 	data->tx.state = I2S_STATE_NOT_READY;
 	data->rx.state = I2S_STATE_NOT_READY;
 
-	LOG_INF("Device %s inited", dev->name);
+	LOG_DBG("Device %s inited", dev->name);
 
 	return 0;
 }


### PR DESCRIPTION
Reduce log verboseness during init.