### PR TITLE
drivers: dma: mcux_lpc: support channel priority

### DIFF
--- a/drivers/dma/dma_mcux_lpc.c
+++ b/drivers/dma/dma_mcux_lpc.c
@@ -583,6 +583,7 @@ static int dma_mcux_lpc_configure(const struct device *dev, uint32_t channel,
 	} else {
 		DMA_DisableChannelPeriphRq(p_handle->base, p_handle->channel);
 	}
+	DMA_SetChannelPriority(p_handle->base, p_handle->channel, config->channel_priority);
 
 	data->busy = false;
 	if (config->dma_callback) {


### PR DESCRIPTION
Set DMA channel priority in dma_mcux_lpc_configure().