### PR TITLE
logging: backend: uart: improve compatibility, increase test coverage and minor ROM optimizations

### DIFF
--- a/subsys/logging/backends/log_backend_uart.c
+++ b/subsys/logging/backends/log_backend_uart.c
@@ -28,7 +28,7 @@ struct lbu_data {
 
 struct lbu_cb_ctx {
 	const struct log_output *output;
-	const struct device *device;
+	const struct device *uart_dev;
 	struct lbu_data *data;
 };
 
@@ -78,7 +78,7 @@ static int char_out(uint8_t *data, size_t length, void *ctx)
 	int err;
 	const struct lbu_cb_ctx *cb_ctx = ctx;
 	struct lbu_data *lb_data = cb_ctx->data;
-	const struct device *uart_dev = cb_ctx->device;
+	const struct device *uart_dev = cb_ctx->uart_dev;
 
 	if (pm_device_runtime_is_enabled(uart_dev) && !k_is_in_isr()) {
 		if (pm_device_runtime_get(uart_dev) < 0) {
@@ -142,7 +142,7 @@ static int format_set(const struct log_backend *const backend, uint32_t log_type
 static void log_backend_uart_init(struct log_backend const *const backend)
 {
 	const struct lbu_cb_ctx *ctx = backend->cb->ctx;
-	const struct device *uart_dev = ctx->device;
+	const struct device *uart_dev = ctx->uart_dev;
 	struct lbu_data *data = ctx->data;
 
 	__ASSERT_NO_MSG(device_is_ready(uart_dev));
@@ -180,7 +180,7 @@ static void panic(struct log_backend const *const backend)
 {
 	const struct lbu_cb_ctx *ctx = backend->cb->ctx;
 	struct lbu_data *data = ctx->data;
-	const struct device *uart_dev = ctx->device;
+	const struct device *uart_dev = ctx->uart_dev;
 
 	/* Ensure that the UART device is in active mode */
 #if defined(CONFIG_PM_DEVICE_RUNTIME)
@@ -238,7 +238,7 @@ const struct log_backend_api log_backend_uart_api = {
                                                                                                    \
 	static const struct lbu_cb_ctx lbu_cb_ctx##__VA_ARGS__ = {                                 \
 		.output = &lbu_output##__VA_ARGS__,                                                \
-		.device = DEVICE_DT_GET(node_id),                                                  \
+		.uart_dev = DEVICE_DT_GET(node_id),                                                \
 		.data = &lbu_data##__VA_ARGS__,                                                    \
 	};                                                                                         \
                                                                                                    \

--- a/subsys/logging/backends/log_backend_uart.c
+++ b/subsys/logging/backends/log_backend_uart.c
@@ -227,28 +227,28 @@ const struct log_backend_api log_backend_uart_api = {
 	.format_set = format_set,
 };
 
-#define LBU_DEFINE(node_id, idx)                                                                   \
-	static uint8_t lbu_buffer_##idx[CONFIG_LOG_BACKEND_UART_BUFFER_SIZE];                      \
-	LOG_OUTPUT_DEFINE(lbu_output_##idx, char_out, lbu_buffer_##idx,                            \
+#define LBU_DEFINE(node_id, ...)                                                                   \
+	static uint8_t lbu_buffer##__VA_ARGS__[CONFIG_LOG_BACKEND_UART_BUFFER_SIZE];               \
+	LOG_OUTPUT_DEFINE(lbu_output##__VA_ARGS__, char_out, lbu_buffer##__VA_ARGS__,              \
 			  CONFIG_LOG_BACKEND_UART_BUFFER_SIZE);                                    \
                                                                                                    \
-	static struct lbu_data lbu_data_##idx = {                                                  \
+	static struct lbu_data lbu_data##__VA_ARGS__ = {                                           \
 		.log_format_current = CONFIG_LOG_BACKEND_UART_OUTPUT_DEFAULT,                      \
 	};                                                                                         \
                                                                                                    \
-	static const struct lbu_cb_ctx lbu_cb_ctx_##idx = {                                        \
-		.output = &lbu_output_##idx,                                                       \
+	static const struct lbu_cb_ctx lbu_cb_ctx##__VA_ARGS__ = {                                 \
+		.output = &lbu_output##__VA_ARGS__,                                                \
 		.device = DEVICE_DT_GET(node_id),                                                  \
-		.data = &lbu_data_##idx,                                                           \
+		.data = &lbu_data##__VA_ARGS__,                                                    \
 	};                                                                                         \
                                                                                                    \
-	LOG_BACKEND_DEFINE(log_backend_uart##idx, log_backend_uart_api,                            \
+	LOG_BACKEND_DEFINE(log_backend_uart##__VA_ARGS__, log_backend_uart_api,                    \
 			   IS_ENABLED(CONFIG_LOG_BACKEND_UART_AUTOSTART),                          \
-			   (void *)&lbu_cb_ctx_##idx);
+			   (void *)&lbu_cb_ctx##__VA_ARGS__);
 
 #if DT_HAS_CHOSEN(zephyr_log_uart)
 #define LBU_PHA_FN(node_id, prop, idx) LBU_DEFINE(DT_PHANDLE_BY_IDX(node_id, prop, idx), idx)
 DT_FOREACH_PROP_ELEM_SEP(DT_CHOSEN(zephyr_log_uart), uarts, LBU_PHA_FN, ());
 #else
-LBU_DEFINE(DT_CHOSEN(zephyr_console), 0);
+LBU_DEFINE(DT_CHOSEN(zephyr_console));
 #endif

--- a/tests/subsys/logging/log_backend_uart/testcase.yaml
+++ b/tests/subsys/logging/log_backend_uart/testcase.yaml
@@ -6,7 +6,9 @@ common:
     - logging
     - backend
     - uart
-  platform_allow: qemu_x86
+  filter: CONFIG_UART_CONSOLE
+  integration_platforms:
+    - qemu_x86
 tests:
   logging.backend.uart.single:
     extra_args: DTC_OVERLAY_FILE="./single.overlay"


### PR DESCRIPTION
- Fixes CI and improves the UART log backend compatibility with out-of-tree applications post #64917.
- Increases test coverage of `subsys/logging/log_backend_uart`.
- Optimized `log_backend_uart` to save 1 pointer size in ROM.
- Changes `struct device *device` to `struct device *uart_dev`

fixes #65151

__

```
(.venv) ycsin@LAPTOP-ROG:~/zephyrproject$ twister -i -T zephyr/tests/subsys/logging/log_backend_uart/ -T zephyr/tests/subsys/logging/log_core_additional/
INFO    - Using Ninja..
INFO    - Zephyr version: zephyr-v3.5.0-1408-gfdff4ea27362
INFO    - Using 'zephyr' toolchain.
INFO    - Selecting default platforms per test case
INFO    - Building initial testsuite list...
INFO    - Writing JSON report /home/ycsin/zephyrproject/twister-out/testplan.json
INFO    - JOBS: 8
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - Total complete:  205/ 205  100%  skipped:  103, failed:    0, error:    0
INFO    - 5 test scenarios (205 test instances) selected, 103 configurations skipped (97 by static filter, 6 at runtime).
INFO    - 102 of 205 test configurations passed (100.00%), 0 failed, 0 errored, 103 skipped with 0 warnings in 865.56 seconds
INFO    - In total 480 test cases were executed, 1246 skipped on 41 out of total 639 platforms (6.42%)
INFO    - 102 test configurations executed on platforms, 0 test configurations were only built.
INFO    - Saving reports...
INFO    - Writing JSON report /home/ycsin/zephyrproject/twister-out/twister.json
INFO    - Writing xunit report /home/ycsin/zephyrproject/twister-out/twister.xml...
INFO    - Writing xunit report /home/ycsin/zephyrproject/twister-out/twister_report.xml...
INFO    - Run completed
```