### PR TITLE
logging: printk: Fix userspace issue

### DIFF
--- a/include/zephyr/logging/log_msg.h
+++ b/include/zephyr/logging/log_msg.h
@@ -679,11 +679,11 @@ __syscall void z_log_msg_static_create(const void *source,
  *
  * @param ap Variable list of string arguments.
  */
-__syscall void z_log_msg_runtime_vcreate(uint8_t domain_id, const void *source,
-					  uint8_t level, const void *data,
-					  size_t dlen, uint32_t package_flags,
-					  const char *fmt,
-					  va_list ap);
+void z_log_msg_runtime_vcreate(uint8_t domain_id, const void *source,
+				uint8_t level, const void *data,
+				size_t dlen, uint32_t package_flags,
+				const char *fmt,
+				va_list ap);
 
 /** @brief Create message at runtime.
  *

--- a/subsys/logging/Kconfig.processing
+++ b/subsys/logging/Kconfig.processing
@@ -7,6 +7,7 @@ if !LOG_MODE_MINIMAL
 
 config LOG_PRINTK
 	bool "Process printk messages"
+	depends on !USERSPACE
 	default y if PRINTK
 	help
 	  If enabled, printk messages are redirected to the logging subsystem.

--- a/subsys/logging/log_msg.c
+++ b/subsys/logging/log_msg.c
@@ -281,7 +281,7 @@ static inline void z_vrfy_z_log_msg_static_create(const void *source,
 #include <syscalls/z_log_msg_static_create_mrsh.c>
 #endif
 
-void z_impl_z_log_msg_runtime_vcreate(uint8_t domain_id, const void *source,
+void z_log_msg_runtime_vcreate(uint8_t domain_id, const void *source,
 				uint8_t level, const void *data, size_t dlen,
 				uint32_t package_flags, const char *fmt, va_list ap)
 {
@@ -330,15 +330,3 @@ void z_impl_z_log_msg_runtime_vcreate(uint8_t domain_id, const void *source,
 		z_log_msg_finalize(msg, source, desc, data);
 	}
 }
-
-#ifdef CONFIG_USERSPACE
-static inline void z_vrfy_z_log_msg_runtime_vcreate(uint8_t domain_id,
-				const void *source,
-				uint8_t level, const void *data, size_t dlen,
-				uint32_t package_flags, const char *fmt, va_list ap)
-{
-	return z_impl_z_log_msg_runtime_vcreate(domain_id, source, level, data,
-						dlen, package_flags, fmt, ap);
-}
-#include <syscalls/z_log_msg_runtime_vcreate_mrsh.c>
-#endif


### PR DESCRIPTION
The syscall needed by CONFIG_LOG_PRINTK is completely problematic, it does
not check ANY parameter that is given and it uses variadic argument
that are not copied / checked before being used in the implementation,
instead it just pass a pointer to user stack with unknown data that is
blindly consumed by the kernel.
