### PR TITLE
can't set alarm after alarm cancel for rpi_pico counter

### DIFF
--- a/drivers/counter/counter_rpi_pico_timer.c
+++ b/drivers/counter/counter_rpi_pico_timer.c
@@ -106,6 +106,11 @@ static int counter_rpi_pico_timer_set_alarm(const struct device *dev, uint8_t id
 
 static int counter_rpi_pico_timer_cancel_alarm(const struct device *dev, uint8_t id)
 {
+	struct counter_rpi_pico_timer_data *data = dev->data;
+	struct counter_rpi_pico_timer_ch_data *chdata = &data->ch_data[id];
+
+	chdata->callback = NULL;
+	chdata->user_data = NULL;
 	hardware_alarm_cancel(id);
 
 	return 0;


### PR DESCRIPTION
for rpi_pico counter,  cancelling alarm  prevents from setting alarm again.
alarm setting function checks channel callback and if callback is registered it returns -EBUSY.
but alarm cancel function doesn't clear callback function. this prevents from alarm setting after alarm cancel. 