### PR TITLE
modules: canopennode: use zephyr/dsp/types.h for float32_t/float64_t

### DIFF
--- a/modules/canopennode/CO_driver_target.h
+++ b/modules/canopennode/CO_driver_target.h
@@ -22,6 +22,7 @@ extern "C" {
 #include <zephyr/types.h>
 #include <zephyr/device.h>
 #include <zephyr/toolchain.h>
+#include <zephyr/dsp/types.h> /* float32_t, float64_t */
 
 /* Use static variables instead of calloc() */
 #define CO_USE_GLOBALS
@@ -46,11 +47,12 @@ extern "C" {
 #endif
 
 typedef bool          bool_t;
-typedef float         float32_t;
-typedef long double   float64_t;
 typedef char          char_t;
 typedef unsigned char oChar_t;
 typedef unsigned char domain_t;
+
+BUILD_ASSERT(sizeof(float32_t) >= 4);
+BUILD_ASSERT(sizeof(float64_t) >= 8);
 
 typedef struct canopen_rx_msg {
 	uint8_t data[8];


### PR DESCRIPTION
Include the zephyr/dsp/types.h header for float32_t/float64_t type definitions to avoid conflicts with other subsystems including this header.

Add compile-time asserts to ensure the typedefs meet the requirements of the CANopenNode module.

Fixes: #63896