### PR TITLE
gpio-kbd-matrix: add drive column and direct access support

### DIFF
--- a/drivers/input/input_gpio_kbd_matrix.c
+++ b/drivers/input/input_gpio_kbd_matrix.c
@@ -30,6 +30,8 @@ struct gpio_kbd_matrix_config {
 struct gpio_kbd_matrix_data {
 	struct input_kbd_matrix_common_data common;
 	uint32_t last_col_state;
+	bool direct_read;
+	bool direct_write;
 };
 
 INPUT_KBD_STRUCT_CHECK(struct gpio_kbd_matrix_config,
@@ -48,6 +50,19 @@ static void gpio_kbd_matrix_drive_column(const struct device *dev, int col)
 		state = BIT_MASK(common->col_size);
 	} else {
 		state = BIT(col);
+	}
+
+	if (data->direct_write) {
+		const struct gpio_dt_spec *gpio0 = &cfg->col_gpio[0];
+		gpio_port_pins_t gpio_mask;
+		gpio_port_value_t gpio_val;
+
+		gpio_mask = BIT_MASK(common->col_size) << gpio0->pin;
+		gpio_val = state << gpio0->pin;
+
+		gpio_port_set_masked(gpio0->port, gpio_mask, gpio_val);
+
+		return;
 	}
 
 	for (int i = 0; i < common->col_size; i++) {
@@ -71,7 +86,17 @@ static int gpio_kbd_matrix_read_row(const struct device *dev)
 {
 	const struct gpio_kbd_matrix_config *cfg = dev->config;
 	const struct input_kbd_matrix_common_config *common = &cfg->common;
+	struct gpio_kbd_matrix_data *data = dev->data;
 	int val = 0;
+
+	if (data->direct_read) {
+		const struct gpio_dt_spec *gpio0 = &cfg->row_gpio[0];
+		gpio_port_value_t gpio_val;
+
+		gpio_port_get(gpio0->port, &gpio_val);
+
+		return (gpio_val >> gpio0->pin) & BIT_MASK(common->row_size);
+	}
 
 	for (int i = 0; i < common->row_size; i++) {
 		const struct gpio_dt_spec *gpio = &cfg->row_gpio[i];
@@ -102,10 +127,27 @@ static void gpio_kbd_matrix_set_detect_mode(const struct device *dev, bool enabl
 	}
 }
 
+static bool gpio_kbd_matrix_is_gpio_coherent(
+		const struct gpio_dt_spec *gpio, int gpio_count)
+{
+	const struct gpio_dt_spec *gpio0 = &gpio[0];
+
+	for (int i = 1; i < gpio_count; i++) {
+		if (gpio[i].port != gpio0->port ||
+		    gpio[i].dt_flags != gpio0->dt_flags ||
+		    gpio[i].pin != gpio0->pin + i) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
 static int gpio_kbd_matrix_init(const struct device *dev)
 {
 	const struct gpio_kbd_matrix_config *cfg = dev->config;
 	const struct input_kbd_matrix_common_config *common = &cfg->common;
+	struct gpio_kbd_matrix_data *data = dev->data;
 	int ret;
 	int i;
 
@@ -151,6 +193,17 @@ static int gpio_kbd_matrix_init(const struct device *dev)
 			return ret;
 		}
 	}
+
+	data->direct_read = gpio_kbd_matrix_is_gpio_coherent(
+			cfg->row_gpio, common->row_size);
+
+	if (cfg->col_drive_inactive) {
+		data->direct_write = gpio_kbd_matrix_is_gpio_coherent(
+				cfg->col_gpio, common->col_size);
+	}
+
+	LOG_DBG("direct_read: %d direct_write: %d",
+		data->direct_read, data->direct_write);
 
 	gpio_kbd_matrix_set_detect_mode(dev, true);
 

--- a/dts/bindings/input/gpio-kbd-matrix.yaml
+++ b/dts/bindings/input/gpio-kbd-matrix.yaml
@@ -39,5 +39,12 @@ properties:
     required: true
     description: |
       GPIO for the keyboard matrix columns, supports up to 32 different GPIOs.
-      The pins will be driven according to the GPIO_ACTIVE_HIGH or
-      GPIO_ACTIVE_LOW flags when selected, high impedance when not selected.
+      When unselected, this pin will be either driven to inactive state or
+      configured to high impedance (input) depending on the col-drive-inactive
+      property.
+
+  col-drive-inactive:
+    type: boolean
+    description: |
+      If enabled, unselected column GPIOs will be driven to inactive state.
+      Default to configure unselected column GPIOs to high impedance.


### PR DESCRIPTION
Add an option to select the drive mode of unselected columns and some optimization for the row/col access. I'll put together a document with the various configuration options for this driver once I'm done adding features. :-)

Still only tested on a dev board with jumper wires, seems to be working fine.

---

Add an option to drive inactive columns to inactive state rather than
high impedance. This is useful if the matrix has isolation diodes for
every key, as it allows the matrix to stabilize faster and the API for
changing the pin value is more efficient than the one to change the pin
configuration.

---

When the matrix is connected to consecutive pins on the same port, it's
possible to read the whole row or set the whole column in a single
operation. Fror the column, this is only possible if the matrix is
configured for driving unselected column, as there's no API to configure
multiple pins at the same time at the moment.

This is more efficient than checking the pins individually, and it's
particularly useful if the row or columns are driven from a GPIO port
expander.

Add some code to detect the condition and enable it automatically as
long as the hw configuration supports it.