### PR TITLE
linker: allow tagging variables with __nocache_noinit and update Bosch M_CAN driver to use it

### DIFF
--- a/include/zephyr/drivers/can/can_mcan.h
+++ b/include/zephyr/drivers/can/can_mcan.h
@@ -640,7 +640,7 @@ enum can_mcan_psr_lec {
  */
 #define CAN_MCAN_DT_MRAM_DEFINE(node_id, _name)                                                    \
 	BUILD_ASSERT(CAN_MCAN_DT_MRAM_OFFSET(node_id) == 0, "offset must be 0");                   \
-	static char __noinit __nocache __aligned(4) _name[CAN_MCAN_DT_MRAM_ELEMENTS_SIZE(node_id)];
+	static char __nocache_noinit __aligned(4) _name[CAN_MCAN_DT_MRAM_ELEMENTS_SIZE(node_id)];
 
 /**
  * @brief Assert that the Message RAM configuration meets the Bosch M_CAN IP core restrictions

--- a/include/zephyr/linker/section_tags.h
+++ b/include/zephyr/linker/section_tags.h
@@ -49,8 +49,10 @@
 
 #if defined(CONFIG_NOCACHE_MEMORY)
 #define __nocache __in_section_unique(_NOCACHE_SECTION_NAME)
+#define __nocache_noinit __nocache
 #else
 #define __nocache
+#define __nocache_noinit __noinit
 #endif /* CONFIG_NOCACHE_MEMORY */
 
 #if defined(CONFIG_KERNEL_COHERENCE)


### PR DESCRIPTION
- Allow tagging variables with `__nocach_noinit`. With `CONFIG_NOCACHE_MEMORY=y`, this will resolve to `__nocache`, which implies `__noinit`. With `CONFIG_NOCACHE_MEMORY=n`, this simply resolves to `__noinit`.
- Use `__nocache_noinit` for the Bosch M_CAN MRAM data variables on SoCs without dedicated MRAM.

Fixes: #64691