### PR TITLE
modules: add heatshrink as external module

### DIFF
--- a/doc/develop/manifest/external/heatshrink.rst
+++ b/doc/develop/manifest/external/heatshrink.rst
@@ -1,0 +1,39 @@
+.. _external_module_heatshrink:
+
+Heatshrink
+##########
+
+Introduction
+************
+
+`Heatshrink`_ is a data compression/decompression library optimized for
+very low memory environments. It uses `LZSS`_ encoding with a small sliding
+window, making it suitable for memory-constrained microcontrollers.
+
+Heatshrink is used by the Delta Firmware Update subsystem to decompress
+bsdiff delta patches on-target.
+
+Heatshrink is licensed under the ISC license.
+
+Usage with Zephyr
+*****************
+
+To pull in heatshrink as a Zephyr :ref:`module <modules>`, either add it
+as a West project in the :file:`west.yaml` file or pull it in by adding a
+submanifest (e.g. ``zephyr/submanifests/heatshrink.yaml``) file with the
+following content and run ``west update``:
+
+.. code-block:: yaml
+
+   manifest:
+     projects:
+       - name: heatshrink
+         url: https://github.com/kickmaker/heatshrink
+         revision: c47356093c4ea079749214de2864186a578668a0
+         path: modules/lib/heatshrink
+
+Reference
+*********
+
+.. _Heatshrink:
+   https://github.com/atomicobject/heatshrink


### PR DESCRIPTION
## Origin

Name of project hosting the original open source code
[heatshrink: data compression/decompression library.](https://github.com/kickmaker/heatshrink)

## Issue
#61822 

## Purpose

Heatshrink is a data compression/decompression library for embedded/real-time systems.

## Mode of integration

As external module, as described in [heatshrink: zephyr-integration.](https://github.com/kickmaker/heatshrink#zephyr-integration-getting-started) 

## Maintainership

@RomainPelletant 
@ClovisCorde

## Pull Request

this PR

## Description

[See the heatshrink API.](https://kickmaker.github.io/heatshrink/)

The primary functionality of heatshrink is to compress and decompress data.
Heatshrink is chosen because it has a small footprint memory (unlinke LZ4).

## Dependencies

No dependencies.

## Revision

c47356093c4ea079749214de2864186a578668a0
(https://github.com/kickmaker/heatshrink contains modification for zephyr)

## License

Please use an SPDX identifier (https://spdx.org/licenses/), such as
``BSD-3-Clause``

ISC License

