### PR TITLE
drivers: bluetooth: hci: Introduce ST SPI protocol V2

### DIFF
--- a/boards/arm/b_l4s5i_iot01a/Kconfig.defconfig
+++ b/boards/arm/b_l4s5i_iot01a/Kconfig.defconfig
@@ -34,9 +34,6 @@ choice BT_HCI_BUS_TYPE
 	default BT_SPI
 endchoice
 
-config BT_SPI_BLUENRG
-	default y
-
 config BT_BLUENRG_ACI
 	default y
 # Disable Flow control

--- a/boards/arm/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
+++ b/boards/arm/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
@@ -152,7 +152,7 @@
 		   <&gpioe 0 GPIO_ACTIVE_LOW>;
 
 	spbtle-rf@0 {
-		compatible = "zephyr,bt-hci-spi";
+		compatible = "zephyr,bt-hci-spi", "st,hci-spi-v1";
 		reg = <0>;
 		reset-gpios = <&gpioa 8 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 		irq-gpios = <&gpioe 6 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;

--- a/boards/arm/disco_l475_iot1/Kconfig.defconfig
+++ b/boards/arm/disco_l475_iot1/Kconfig.defconfig
@@ -34,9 +34,6 @@ choice BT_HCI_BUS_TYPE
 	default BT_SPI
 endchoice
 
-config BT_SPI_BLUENRG
-	default y
-
 config BT_BLUENRG_ACI
 	default y
 # Disable Flow control

--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -191,7 +191,7 @@
 		   <&gpioe 0 GPIO_ACTIVE_LOW>;
 
 	spbtle-rf@0 {
-		compatible = "zephyr,bt-hci-spi";
+		compatible = "zephyr,bt-hci-spi", "st,hci-spi-v1";
 		reg = <0>;
 		reset-gpios = <&gpioa 8 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 		irq-gpios = <&gpioe 6 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;

--- a/boards/arm/sensortile_box/Kconfig.defconfig
+++ b/boards/arm/sensortile_box/Kconfig.defconfig
@@ -8,11 +8,27 @@ if BOARD_SENSORTILE_BOX
 config BOARD
 	default "sensortile_box"
 
-if SPI
+if BT
+
+config SPI
+	default y
+
+choice BT_HCI_BUS_TYPE
+	default BT_SPI
+endchoice
+
+config BT_BLUENRG_ACI
+	default y
+# Disable Flow control
+config BT_HCI_ACL_FLOW_CONTROL
+	default n
+config BT_HCI_VS_EXT
+	default n
+
+endif # BT
 
 config SPI_STM32_INTERRUPT
 	default y
-
-endif # SPI
+	depends on SPI
 
 endif # BOARD_SENSORTILE_BOX

--- a/boards/arm/sensortile_box/sensortile_box.dts
+++ b/boards/arm/sensortile_box/sensortile_box.dts
@@ -161,6 +161,24 @@
 	};
 };
 
+&spi2 {
+	pinctrl-0 = <&spi2_sck_pd1 &spi2_miso_pd3 &spi2_mosi_pc3>;
+	pinctrl-names = "default";
+	status = "okay";
+	cs-gpios = <&gpiod 0 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+	spbtle_1s_sensortile_box: spbtle-1s@0 {
+		compatible = "zephyr,bt-hci-spi", "st,hci-spi-v2";
+		reg = <0>;
+		reset-gpios = <&gpioa 8 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+		irq-gpios = <&gpiod 4 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
+		spi-max-frequency = <1000000>;
+		spi-cpha;
+		spi-hold-cs;
+		controller-data-delay-us = <0>;
+		reset-assert-duration-ms = <6>;
+	};
+};
+
 &spi3 {
 	pinctrl-0 = <&spi3_nss_pa15 &spi3_sck_pb3
 		     &spi3_miso_pb4 &spi3_mosi_pb5>;

--- a/boards/arm/sensortile_box/sensortile_box.yaml
+++ b/boards/arm/sensortile_box/sensortile_box.yaml
@@ -9,6 +9,7 @@ toolchain:
 supported:
   - pwm
   - spi
+  - ble
   - i2c
   - gpio
   - usb device

--- a/boards/arm/stm32l562e_dk/Kconfig.defconfig
+++ b/boards/arm/stm32l562e_dk/Kconfig.defconfig
@@ -17,9 +17,6 @@ choice BT_HCI_BUS_TYPE
 	default BT_SPI
 endchoice
 
-config BT_SPI_BLUENRG
-	default y
-
 config BT_BLUENRG_ACI
 	default y
 

--- a/boards/arm/stm32l562e_dk/stm32l562e_dk_common.dtsi
+++ b/boards/arm/stm32l562e_dk/stm32l562e_dk_common.dtsi
@@ -115,7 +115,7 @@
 	status = "okay";
 
 	spbtle-rf@0 {
-		compatible = "zephyr,bt-hci-spi";
+		compatible = "zephyr,bt-hci-spi", "st,hci-spi-v1";
 		reg = <0>;
 		irq-gpios = <&gpiog 6 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		reset-gpios = <&gpiog 8 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;

--- a/boards/shields/x_nucleo_idb05a1/Kconfig.defconfig
+++ b/boards/shields/x_nucleo_idb05a1/Kconfig.defconfig
@@ -12,9 +12,6 @@ choice BT_HCI_BUS_TYPE
 	default BT_SPI
 endchoice
 
-config BT_SPI_BLUENRG
-	default y
-
 config BT_BLUENRG_ACI
 	default y
 # Disable Flow control

--- a/boards/shields/x_nucleo_idb05a1/x_nucleo_idb05a1.overlay
+++ b/boards/shields/x_nucleo_idb05a1/x_nucleo_idb05a1.overlay
@@ -8,7 +8,7 @@
 	cs-gpios = <&arduino_header 1 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;	      /* A1 */
 
 	spbtle_rf_x_nucleo_idb05a1: spbtle-rf@0 {
-		compatible = "zephyr,bt-hci-spi";
+		compatible = "zephyr,bt-hci-spi", "st,hci-spi-v1";
 		reg = <0>;
 		reset-gpios = <&arduino_header 13 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>; /* D7 */
 		irq-gpios = <&arduino_header 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;  /* A0 */

--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -125,12 +125,6 @@ config BT_BLUENRG_ACI
 	  Enable support for devices compatible with the BlueNRG Bluetooth
 	  Stack. Current driver supports: ST BLUENRG-MS.
 
-config BT_SPI_BLUENRG
-	bool "Compatibility with BlueNRG-based devices"
-	help
-	  Enable support for devices compatible with the BlueNRG Bluetooth
-	  Stack. Current driver supports: ST BLUENRG-MS.
-
 endif # BT_SPI
 
 config BT_STM32_IPM_RX_STACK_SIZE

--- a/dts/bindings/bluetooth/st,hci-spi-v1.yaml
+++ b/dts/bindings/bluetooth/st,hci-spi-v1.yaml
@@ -1,0 +1,6 @@
+# Copyright (c) 2023, STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+description: STMicroelectronics SPI protocol V1 compatible with BlueNRG-MS devices
+
+compatible: "st,hci-spi-v1"

--- a/dts/bindings/bluetooth/st,hci-spi-v2.yaml
+++ b/dts/bindings/bluetooth/st,hci-spi-v2.yaml
@@ -1,0 +1,6 @@
+# Copyright (c) 2023, STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+description: STMicroelectronics SPI protocol V2 compatible with BlueNRG-1 and successor devices
+
+compatible: "st,hci-spi-v2"


### PR DESCRIPTION
Update structure of spi.c to have a better and cleaner separation
between STMicroelectronics and Zephyr SPI protocol.

Update existing boards according to the new DTS approach.

Remove BT_SPI_BLUENRG as it is become redundant according to
the new changes.

Introduce STMicroelectronics SPI protocol V2 which is used in BlueNRG-1
and successor devices.

Add "st,hci-spi-v2.yaml" and use compatible property to enable
the protocol for the required boards.

Add BLE support for SensorTile.box board.

The new changes have been tested on 96b_carbon, disco_l475_iot1, b_l4s5i_iot01a,
stm32l562e_dk, x_nucleo_idb05a1, and sensortile_box boards.
