### PR TITLE
soc: nxp_s32: include device headers in soc.h

### DIFF
--- a/drivers/ethernet/eth_nxp_s32_netc.c
+++ b/drivers/ethernet/eth_nxp_s32_netc.c
@@ -18,7 +18,7 @@ LOG_MODULE_REGISTER(nxp_s32_eth);
 #include <zephyr/net/phy.h>
 #include <ethernet/eth_stats.h>
 
-#include <S32Z2.h>
+#include <soc.h>
 #include <Netc_Eth_Ip.h>
 #include <Netc_Eth_Ip_Irq.h>
 #include <Netc_EthSwt_Ip.h>

--- a/drivers/ethernet/eth_nxp_s32_netc_psi.c
+++ b/drivers/ethernet/eth_nxp_s32_netc_psi.c
@@ -18,7 +18,7 @@ LOG_MODULE_REGISTER(nxp_s32_eth_psi);
 #include <zephyr/net/phy.h>
 #include <ethernet/eth_stats.h>
 
-#include <S32Z2.h>
+#include <soc.h>
 #include <Netc_Eth_Ip.h>
 #include <Netc_Eth_Ip_Irq.h>
 #include <Netc_EthSwt_Ip.h>

--- a/drivers/ethernet/eth_nxp_s32_netc_vsi.c
+++ b/drivers/ethernet/eth_nxp_s32_netc_vsi.c
@@ -18,7 +18,7 @@ LOG_MODULE_REGISTER(nxp_s32_eth_vsi);
 #include <zephyr/net/phy.h>
 #include <ethernet/eth_stats.h>
 
-#include <S32Z2.h>
+#include <soc.h>
 #include <Netc_Eth_Ip.h>
 #include <Netc_Eth_Ip_Irq.h>
 #include <Netc_EthSwt_Ip.h>

--- a/soc/arm/nxp_s32/common/osif.c
+++ b/soc/arm/nxp_s32/common/osif.c
@@ -4,14 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <soc.h>
 #include <OsIf.h>
 #include <OsIf_Cfg_TypesDef.h>
-
-#if defined(CONFIG_SOC_S32Z27_R52)
-#include <S32Z2_MSCM.h>
-#elif defined(CONFIG_SOC_S32K344)
-#include <S32K344_MSCM.h>
-#endif
 
 /* Required by OsIf timer initialization but not used with Zephyr, so no values configured */
 static const OsIf_ConfigType osif_config;

--- a/soc/arm/nxp_s32/s32ze/soc.h
+++ b/soc/arm/nxp_s32/s32ze/soc.h
@@ -10,6 +10,12 @@
 /* Do not let CMSIS to handle GIC */
 #define __GIC_PRESENT 0
 
+#if defined(CONFIG_SOC_S32Z27_R52)
+#include <S32Z2.h>
+#else
+#error "SoC not supported"
+#endif
+
 /* Aliases for peripheral base addresses */
 
 /* SIUL2 */


### PR DESCRIPTION
To simplify the inclusion of device headers in common code for NXP S32 devices, make sure all SoCs are including their respective device headers. This PR adds the missing headers for S32Z/E and update the affected code to include `soc.h`.