### PR TITLE
ci: compliance: only run sorted check on text files

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1174,6 +1174,11 @@ class KeepSorted(ComplianceTest):
     MARKER = "zephyr-keep-sorted"
 
     def check_file(self, file, fp):
+        mime_type = magic.from_file(file, mime=True)
+
+        if not mime_type.startswith("text/"):
+            return
+
         lines = []
         in_block = False
 


### PR DESCRIPTION
Hit https://github.com/zephyrproject-rtos/zephyr/pull/64101, tested against it.

---

The sorted check code crashes on binary files. Add a check on file type and only process text ones.