### PR TITLE
native_sim build: Fix for APPLICATION_BINARY_DIR!=CMAKE_BINARY_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1762,7 +1762,7 @@ if(CONFIG_BUILD_OUTPUT_EXE)
       COMMENT "Building native simulator runner, and linking final executable"
       COMMAND
       ${MAKE} -f ${ZEPHYR_BASE}/scripts/native_simulator/Makefile all --warn-undefined-variables
-        -r NSI_CONFIG_FILE=${CMAKE_BINARY_DIR}/zephyr/NSI/nsi_config
+        -r NSI_CONFIG_FILE=${APPLICATION_BINARY_DIR}/zephyr/NSI/nsi_config
       # nsi_config is created by the board cmake file
       DEPENDS ${logical_target_for_zephyr_elf}
       BYPRODUCTS ${KERNEL_EXE_NAME}

--- a/boards/posix/common/natsim_config.cmake
+++ b/boards/posix/common/natsim_config.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-set(zephyr_build_path ${CMAKE_BINARY_DIR}/zephyr)
+set(zephyr_build_path ${APPLICATION_BINARY_DIR}/zephyr)
 get_property(CCACHE GLOBAL PROPERTY RULE_LAUNCH_COMPILE)
 
 target_link_options(native_simulator INTERFACE


### PR DESCRIPTION
In some cases, the APPLICATION_BINARY_DIR does not match the CMAKE_BINARY_DIR, in those cases the native simulator build would not find the zephyr elf file.
Fix it by using the correct variable.