### PR TITLE
BlueNRG: allow setting public address

### DIFF
--- a/doc/releases/migration-guide-3.6.rst
+++ b/doc/releases/migration-guide-3.6.rst
@@ -52,6 +52,11 @@ Device Drivers and Device Tree
             drdy-pin = <2>;
         };
     };
+* The optional :c:func:`setup()` function in the Bluetooth HCI driver API (enabled through
+  :kconfig:option:`CONFIG_BT_HCI_SETUP`) has gained a function parameter of type
+  :c:struct:`bt_hci_setup_params`. By default, the struct is empty, but drivers can opt-in to
+  :kconfig:option:`CONFIG_BT_HCI_SET_PUBLIC_ADDR` if they support setting the controller's public
+  identity address, which will then be passed in the ``public_addr`` field.
 
   (:github:`62994`)
 

--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -120,6 +120,7 @@ config BT_SPI_INIT_PRIORITY
 
 config BT_BLUENRG_ACI
 	bool "ACI message with with BlueNRG-based devices"
+	select BT_HCI_SET_PUBLIC_ADDR
 	help
 	  Enable support for devices compatible with the BlueNRG Bluetooth
 	  Stack. Current driver supports: ST BLUENRG-MS.

--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -164,6 +164,16 @@ config BT_DRIVER_QUIRK_NO_AUTO_DLE
 	  This has to be enabled when the BLE controller connected is Zephyr
 	  open source controller.
 
+config BT_HCI_SET_PUBLIC_ADDR
+	bool
+	select BT_HCI_SETUP
+	help
+	  Pass the controller's public address to the HCI driver in setup()
+
+	  This option should be enabled by drivers for controllers that support setting the
+	  public identity through vendor-specific commands. They can then implement the
+	  setup() HCI driver API function and get the address to set from the public_addr field.
+
 config BT_HCI_SETUP
 	bool
 	help

--- a/drivers/bluetooth/hci/h4.c
+++ b/drivers/bluetooth/hci/h4.c
@@ -529,8 +529,10 @@ static int h4_open(void)
 }
 
 #if defined(CONFIG_BT_HCI_SETUP)
-static int h4_setup(void)
+static int h4_setup(const struct bt_hci_setup_params *params)
 {
+	ARG_UNUSED(params);
+
 	/* Extern bt_h4_vnd_setup function.
 	 * This function executes vendor-specific commands sequence to
 	 * initialize BT Controller before BT Host executes Reset sequence.

--- a/drivers/bluetooth/hci/hci_psoc6_bless.c
+++ b/drivers/bluetooth/hci/hci_psoc6_bless.c
@@ -196,8 +196,9 @@ static int psoc6_bless_send(struct net_buf *buf)
 	return 0;
 }
 
-static int psoc6_bless_setup(void)
+static int psoc6_bless_setup(const struct bt_hci_setup_params *params)
 {
+	ARG_UNUSED(params);
 	struct net_buf *buf;
 	int err;
 	uint8_t *addr = (uint8_t *)&SFLASH_BLE_DEVICE_ADDRESS[0];

--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -95,15 +95,10 @@ static uint8_t attempts;
 
 #if defined(CONFIG_BT_BLUENRG_ACI)
 #define BLUENRG_ACI_WRITE_CONFIG_DATA       BT_OP(BT_OGF_VS, 0x000C)
-#define BLUENRG_ACI_WRITE_CONFIG_CMD_LL     0x2C
-#define BLUENRG_ACI_LL_MODE                 0x01
+#define BLUENRG_CONFIG_LL_ONLY_OFFSET       0x2C
+#define BLUENRG_CONFIG_LL_ONLY_LEN          0x01
 
-struct bluenrg_aci_cmd_ll_param {
-    uint8_t cmd;
-    uint8_t length;
-    uint8_t value;
-};
-static int bt_spi_send_aci_config_data_controller_mode(void);
+static int bt_spi_send_aci_config(uint8_t offset, const uint8_t *value, size_t value_len);
 #endif /* CONFIG_BT_BLUENRG_ACI */
 
 static const struct spi_dt_spec bus = SPI_DT_SPEC_INST_GET(
@@ -154,13 +149,16 @@ static bool bt_spi_handle_vendor_evt(uint8_t *msg)
 	bool handled = false;
 
 	switch (bt_spi_get_evt(msg)) {
-	case EVT_BLUE_INITIALIZED:
+	case EVT_BLUE_INITIALIZED: {
 		k_sem_give(&sem_initialised);
 #if defined(CONFIG_BT_BLUENRG_ACI)
 		/* force BlueNRG to be on controller mode */
-		bt_spi_send_aci_config_data_controller_mode();
+		uint8_t data = 1;
+
+		bt_spi_send_aci_config(BLUENRG_CONFIG_LL_ONLY_OFFSET, &data, 1);
 #endif
 		handled = true;
+	}
 	default:
 		break;
 	}
@@ -224,25 +222,23 @@ static bool exit_irq_high_loop(void)
 #endif /* CONFIG_BT_SPI_BLUENRG */
 
 #if defined(CONFIG_BT_BLUENRG_ACI)
-static int bt_spi_send_aci_config_data_controller_mode(void)
+static int bt_spi_send_aci_config(uint8_t offset, const uint8_t *value, size_t value_len)
 {
-	struct bluenrg_aci_cmd_ll_param *param;
 	struct net_buf *buf;
+	uint8_t *cmd_data;
+	size_t data_len = 2 + value_len;
 
-	buf = bt_hci_cmd_create(BLUENRG_ACI_WRITE_CONFIG_DATA, sizeof(*param));
+	buf = bt_hci_cmd_create(BLUENRG_ACI_WRITE_CONFIG_DATA, data_len);
 	if (!buf) {
 		return -ENOBUFS;
 	}
 
-	param = net_buf_add(buf, sizeof(*param));
-	param->cmd = BLUENRG_ACI_WRITE_CONFIG_CMD_LL;
-	param->length = 0x1;
-	/* Force BlueNRG-MS roles to Link Layer only mode */
-	param->value = BLUENRG_ACI_LL_MODE;
+	cmd_data = net_buf_add(buf, data_len);
+	cmd_data[0] = offset;
+	cmd_data[1] = value_len;
+	memcpy(&cmd_data[2], value, value_len);
 
-	bt_hci_cmd_send(BLUENRG_ACI_WRITE_CONFIG_DATA, buf);
-
-	return 0;
+	return bt_hci_cmd_send(BLUENRG_ACI_WRITE_CONFIG_DATA, buf);
 }
 #endif /* CONFIG_BT_BLUENRG_ACI */
 

--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -95,6 +95,8 @@ static uint8_t attempts;
 
 #if defined(CONFIG_BT_BLUENRG_ACI)
 #define BLUENRG_ACI_WRITE_CONFIG_DATA       BT_OP(BT_OGF_VS, 0x000C)
+#define BLUENRG_CONFIG_PUBADDR_OFFSET       0x00
+#define BLUENRG_CONFIG_PUBADDR_LEN          0x06
 #define BLUENRG_CONFIG_LL_ONLY_OFFSET       0x2C
 #define BLUENRG_CONFIG_LL_ONLY_LEN          0x01
 
@@ -239,6 +241,27 @@ static int bt_spi_send_aci_config(uint8_t offset, const uint8_t *value, size_t v
 	memcpy(&cmd_data[2], value, value_len);
 
 	return bt_hci_cmd_send(BLUENRG_ACI_WRITE_CONFIG_DATA, buf);
+}
+
+int bt_spi_bluenrg_setup(const struct bt_hci_setup_params *params)
+{
+	int ret;
+	const bt_addr_t addr = params->public_addr;
+
+	if (bt_addr_eq(&addr, BT_ADDR_NONE) || bt_addr_eq(&addr, BT_ADDR_ANY)) {
+		return -EINVAL;
+	}
+
+	ret = bt_spi_send_aci_config(
+		BLUENRG_CONFIG_PUBADDR_OFFSET,
+		addr.val, sizeof(addr.val));
+
+	if (ret != 0) {
+		LOG_ERR("Failed to set BlueNRG public address (%d)", ret);
+		return ret;
+	}
+
+	return 0;
 }
 #endif /* CONFIG_BT_BLUENRG_ACI */
 
@@ -516,6 +539,7 @@ static const struct bt_hci_driver drv = {
 	.bus		= BT_HCI_DRIVER_BUS_SPI,
 #if defined(CONFIG_BT_BLUENRG_ACI)
 	.quirks		= BT_QUIRK_NO_RESET,
+	.setup          = bt_spi_bluenrg_setup,
 #endif /* CONFIG_BT_BLUENRG_ACI */
 	.open		= bt_spi_open,
 	.send		= bt_spi_send,

--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -340,6 +340,12 @@ void bt_id_get(bt_addr_le_t *addrs, size_t *count);
  * If an insufficient amount of identities were recovered the app may then
  * call bt_id_create() to create new ones.
  *
+ * If supported by the HCI driver (indicated by setting
+ * @kconfig{CONFIG_BT_HCI_SET_PUBLIC_ADDR}), the first call to this function can be
+ * used to set the controller's public identity address. This call must happen
+ * before calling bt_enable(). Subsequent calls always add/generate random
+ * static addresses.
+ *
  * @param addr Address to use for the new identity. If NULL or initialized
  *             to BT_ADDR_LE_ANY the stack will generate a new random
  *             static address for the identity and copy it to the given

--- a/include/zephyr/drivers/bluetooth/hci_driver.h
+++ b/include/zephyr/drivers/bluetooth/hci_driver.h
@@ -139,6 +139,16 @@ enum bt_hci_driver_bus {
 	BT_HCI_DRIVER_BUS_IPM           = 9,
 };
 
+#if defined(CONFIG_BT_HCI_SETUP) || defined(__DOXYGEN__)
+struct bt_hci_setup_params {
+	/** The public identity address to give to the controller. This field is used when the
+	 *  driver selects @kconfig{CONFIG_BT_HCI_SET_PUBLIC_ADDR} to indicate that it supports
+	 *  setting the controller's public address.
+	 */
+	bt_addr_t public_addr;
+};
+#endif
+
 /**
  * @brief Abstraction which represents the HCI transport to the controller.
  *
@@ -213,7 +223,7 @@ struct bt_hci_driver {
 	 *
 	 * @return 0 on success or negative error number on failure.
 	 */
-	int (*setup)(void);
+	int (*setup)(const struct bt_hci_setup_params *params);
 #endif /* defined(CONFIG_BT_HCI_SETUP) || defined(__DOXYGEN__)*/
 };
 

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3634,9 +3634,19 @@ static void hci_vs_init(void)
 static int hci_init(void)
 {
 	int err;
+
 #if defined(CONFIG_BT_HCI_SETUP)
+	struct bt_hci_setup_params setup_params = { 0 };
+
+	bt_addr_copy(&setup_params.public_addr, BT_ADDR_ANY);
+#if defined(CONFIG_BT_HCI_SET_PUBLIC_ADDR)
+	if (bt_dev.id_count > 0 && bt_dev.id_addr[BT_ID_DEFAULT].type == BT_ADDR_LE_PUBLIC) {
+		bt_addr_copy(&setup_params.public_addr, &bt_dev.id_addr[BT_ID_DEFAULT].a);
+	}
+#endif /* defined(CONFIG_BT_HCI_SET_PUBLIC_ADDR) */
+
 	if (bt_dev.drv->setup) {
-		err = bt_dev.drv->setup();
+		err = bt_dev.drv->setup(&setup_params);
 		if (err) {
 			return err;
 		}

--- a/tests/bluetooth/host/id/bt_id_create/Kconfig
+++ b/tests/bluetooth/host/id/bt_id_create/Kconfig
@@ -1,0 +1,11 @@
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+config SELECT_BT_HCI_SET_PUBLIC_ADDR
+	bool "dummy kconfig"
+	select BT_HCI_SET_PUBLIC_ADDR
+	help
+	  dummy kconfig
+
+source "Kconfig.zephyr"

--- a/tests/bluetooth/host/id/bt_id_create/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/id/bt_id_create/src/test_suite_invalid_inputs.c
@@ -93,6 +93,10 @@ ZTEST(bt_id_create_invalid_inputs, test_public_address)
 {
 	int err;
 
+	if (IS_ENABLED(CONFIG_BT_HCI_SET_PUBLIC_ADDR)) {
+		ztest_test_skip();
+	}
+
 	err = bt_id_create(BT_LE_ADDR, NULL);
 
 	zassert_true(err == -EINVAL, "Unexpected error code '%d' was returned", err);

--- a/tests/bluetooth/host/id/bt_id_create/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_id_create/testcase.yaml
@@ -5,6 +5,12 @@ common:
 tests:
   bluetooth.host.bt_id_create.default:
     type: unit
+  bluetooth.host.bt_id_create.bt_set_public_addr:
+    type: unit
+    extra_configs:
+      - CONFIG_BT_SMP=y
+      - CONFIG_BT_PRIVACY=y
+      - CONFIG_SELECT_BT_HCI_SET_PUBLIC_ADDR=y
   bluetooth.host.bt_id_create.bt_privacy_enabled:
     type: unit
     extra_configs:


### PR DESCRIPTION
The zephyr bluetooth stack expects the controller to know its public address, if any. At least for BlueNRG, the public address is forgotten with every reset/power cycle, so there needs to be a way to set it from within zephyr. This is accomplished using the `Aci_Hal_Write_Config_Data` HCI command, as described in [PM0237].

[PM0237]: https://www.st.com/resource/en/programming_manual/pm0237-bluenrg-bluenrgms-stacks-programming-guidelines-stmicroelectronics.pdf