### PR TITLE
boards: stm32h747i_disco: Add Segger JLink support

### DIFF
--- a/boards/arm/stm32h747i_disco/board.cmake
+++ b/boards/arm/stm32h747i_disco/board.cmake
@@ -1,11 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_BOARD_STM32H747I_DISCO_M7)
+board_runner_args(jlink "--device=STM32H747ZI_M7")
 board_runner_args(openocd "--config=${BOARD_DIR}/support/openocd_stm32h747i_disco_m7.cfg")
 board_runner_args(openocd --target-handle=_CHIPNAME.cpu0)
 elseif(CONFIG_BOARD_STM32H747I_DISCO_M4)
+board_runner_args(jlink "--device=STM32H747ZI_M4")
 board_runner_args(openocd "--config=${BOARD_DIR}/support/openocd_stm32h747i_disco_m4.cfg")
 board_runner_args(openocd --target-handle=_CHIPNAME.cpu1)
 endif()
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)


### PR DESCRIPTION
Add configuration lines to be able to use the jlink debugger with this board.  The disco board leaves the debug lines tri-stated until connecting to stlink, so it is safe to just plug in the jlink and use it.