### PR TITLE
tests: coredump: Remove matching pattern

### DIFF
--- a/tests/subsys/debug/coredump/testcase.yaml
+++ b/tests/subsys/debug/coredump/testcase.yaml
@@ -14,7 +14,6 @@ tests:
       type: multi_line
       regex:
         - "Coredump: (.*)"
-        - ">>> ZEPHYR FATAL ERROR "
         - "E: #CD:BEGIN#"
         - "E: #CD:5([aA])45([0-9a-fA-F]+)"
         - "E: #CD:41([0-9a-fA-F]+)"


### PR DESCRIPTION
Remove regex check for "ZEPHYR FATAL ERROR" string. On xtensa architectures the string "ZEPHYR FATAL ERROR"
comes after the coredump itself. The ordered regex will incorrectly fail for this arch.
Also remove a comment based on this check in `fatal.c`
