### PR TITLE
driver: serial: stm32u5: DMAT Errata behavior valid only on some SoCs

### DIFF
--- a/drivers/serial/Kconfig.stm32
+++ b/drivers/serial/Kconfig.stm32
@@ -21,3 +21,18 @@ config UART_STM32
 	  This option enables the UART driver for STM32 family of
 	  processors.
 	  Say y if you wish to use serial port on STM32 MCU.
+
+if UART_STM32
+
+config UART_STM32U5_ERRATA_DMAT
+	bool
+	default y
+	depends on SOC_STM32U575XX || SOC_STM32U585XX || \
+		   SOC_STM32H562XX || SOC_STM32H563XX || SOC_STM32H573XX
+	help
+	  Handles erratum "USART does not generate DMA requests after
+	  setting/clearing DMAT bit".
+	  Seen in Errata Sheet 0499 § 2.19.2 and §2.20.1 for stm32u57x/u58x,
+	          Errata Sheet 0565 § 2.14.1 and §2.15.1 for stm32h56x/h57x
+
+endif

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1309,7 +1309,7 @@ static inline void uart_stm32_dma_tx_enable(const struct device *dev)
 
 static inline void uart_stm32_dma_tx_disable(const struct device *dev)
 {
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32u5_dma)
+#ifdef CONFIG_UART_STM32U5_ERRATA_DMAT
 	ARG_UNUSED(dev);
 
 	/*
@@ -1321,7 +1321,7 @@ static inline void uart_stm32_dma_tx_disable(const struct device *dev)
 	const struct uart_stm32_config *config = dev->config;
 
 	LL_USART_DisableDMAReq_TX(config->usart);
-#endif /* ! st_stm32u5_dma */
+#endif
 }
 
 static inline void uart_stm32_dma_rx_enable(const struct device *dev)
@@ -1614,9 +1614,9 @@ static int uart_stm32_async_tx_abort(const struct device *dev)
 		data->dma_tx.counter = tx_buffer_length - stat.pending_length;
 	}
 
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32u5_dma)
+#ifdef CONFIG_UART_STM32U5_ERRATA_DMAT
 	dma_suspend(data->dma_tx.dma_dev, data->dma_tx.dma_channel);
-#endif /* st_stm32u5_dma */
+#endif
 	dma_stop(data->dma_tx.dma_dev, data->dma_tx.dma_channel);
 	async_evt_tx_abort(data);
 


### PR DESCRIPTION
Workaround for DMAT errata was applied on all SoCs declaring STM32U5 DMA compatible.
This errata has been fixed in later SoCs revisions and should not be applied anymore as this can cause compatibility issues with power mgmt (can not enter STOP1 in some cases).

Declare a specific Kconfig symbol to restrict the workaround only to the set of SoCs impacted by the issue and requiring workaround.

Note that I preferred using Kconfig over device tree since it doesn't feel right to declare a compatible on a silicon bug base.