### PR TITLE
Bluetooth bsim docs: Miscellaneous updates

### DIFF
--- a/boards/posix/doc/bsim_boards_design.rst
+++ b/boards/posix/doc/bsim_boards_design.rst
@@ -3,20 +3,26 @@
 Bsim boards
 ###########
 
-This page covers the design, architecture and rationale, of the
-:ref:`nrf52_bsim<nrf52_bsim>`, :ref:`nrf5340bsim<nrf5340bsim>` and other similar bsim boards.
-Particular details on the nRF52 and nRF5340 simulation boards, including how to use them,
-can be found in their respective documentation.
-These boards are postfixed with `_bsim` as they use BabbleSim_
-(shortened bsim).
+**Available bsim boards**
 
-These boards use the `native simulator`_ and the :ref:`POSIX architecture<Posix arch>` to build
-and execute the embedded code natively on Linux.
+* :ref:`Simulated nRF52833 (nrf52_bsim)<nrf52_bsim>`
+* :ref:`Simulated nRF5340 (nrf5340bsim)<nrf5340bsim>`
 
-.. contents::
+.. contents:: Table of contents
    :depth: 2
    :backlinks: entry
    :local:
+
+This page covers the design, architecture and rationale, of the
+nrf5x_bsim boards and other similar bsim boards.
+These boards are postfixed with `_bsim` as they use BabbleSim_
+(shortened bsim), to simulate the radio environment.
+These boards use the `native simulator`_ and the :ref:`POSIX architecture<Posix arch>` to build
+and execute the embedded code natively on Linux.
+
+Particular details on the :ref:`nRF52<nrf52_bsim>` and :ref:`nRF5340<nrf5340bsim>`
+simulation boards, including how to use them,
+can be found in their respective documentation.
 
 .. _BabbleSim:
    https://BabbleSim.github.io
@@ -54,6 +60,9 @@ without the need for real HW, and in a deterministic/reproducible fashion.
 
 Unlike :ref:`native_sim <native_sim>`, bsim boards do not interact directly with any host
 peripherals, and their execution is independent of the host load, or timing.
+
+These boards are also designed to be used as prototyping and development environments,
+which can help developing applications or communication stacks.
 
 .. _bsim_boards_tests:
 
@@ -120,35 +129,37 @@ Layering: Zephyr's arch, soc and board layers
 
 The basic architecture layering of these boards is as follows:
 
+- The `native simulator`_ runner is used to execute the code in your host.
 - The architecture, SOC and board components of Zephyr are replaced with
   simulation specific ones.
 - The architecture (arch) is the Zephyr :ref:`POSIX architecture<Posix arch>`
   layer.
-  The SOC layer is the soc_inf layer. And the board layer is dependent on
+  The SOC layer is `inf_clock`. And the board layer is dependent on
   the specific device we are simulating.
 - The POSIX architecture provides an adaptation from the Zephyr arch API
-  (which handles mostly the thread context switching) to the Linux kernel.
+  (which handles mostly the thread context switching) to the native simulator
+  CPU thread emulation.
   See :ref:`POSIX arch architecture<posix_arch_architecture>`
-- The soc_inf layer provides the overall CPU "simulation" and the handling of
-  control between the "CPU simulation" (Zephyr threads) and the HW models thread
-  ( See `Threading`_ )
+- The SOC `inf_clock` layer provides an adaptation to the native simulator CPU "simulation"
+  and the handling of control between the "CPU simulation" (Zephyr threads) and the
+  HW models thread ( See `Threading`_ ).
 - The board layer provides all SOC/ IC specific content, including
-  (or linking to) HW models, IRQ handling, busy wait API
-  (see :ref:`posix_busy_wait<posix_busy_wait>`), and Zephyr's printk backend.
+  selecting the HW models which are built in the native simulator runner context, IRQ handling,
+  busy wait API (see :ref:`posix_busy_wait<posix_busy_wait>`), and Zephyr's printk backend.
   Note that in a normal Zephyr target interrupt handling and a custom busy wait
   would be provided by the SOC layer, but abusing Zephyr's layering, and for the
-  soc_inf layer to be generic, these were delegated to the board.
+  `inf_clock` layer to be generic, these were delegated to the board.
   The board layer provides other test specific
   functionality like bs_tests hooks, trace control, etc, and
-  by means of the native simulator, provides the :c:func:`main` entry point for the linux
+  by means of the native simulator, provides the :c:func:`main` entry point for the Linux
   program, command line argument handling, and the overall time scheduling of
   the simulated device.
-  Note that the POSIX arch and soc_inf expect a set of APIs being provided by
+  Note that the POSIX arch and `inf_clock` soc expect a set of APIs being provided by
   the board. This includes the busy wait API, a basic tracing API, the interrupt
   controller and interrupt handling APIs, :c:func:`posix_exit`,
-  and :c:func:`posix_get_hw_cycle` (see posix_board_if.h and posix_soc_if.h ).
+  and :c:func:`posix_get_hw_cycle` (see :file:`posix_board_if.h` and :file:`posix_soc_if.h`).
 
-.. figure:: layering.svg
+.. figure:: layering_natsim.svg
     :align: center
     :alt: Zephyr layering in native & bsim builds
     :figclass: align-center
@@ -161,7 +172,7 @@ Important limitations
 
 All native and bsim boards share the same set of
 :ref:`important limitations which<posix_arch_limitations>`
-are inherited from the POSIX arch and soc_inf design.
+are inherited from the POSIX arch and `inf_clock` design.
 
 .. _Threading:
 
@@ -228,7 +239,7 @@ can use to exchange data.
 About using Zephyr APIs
 =======================
 
-Note that even though bsim board code is linked with the Zephyr kernel,
+Note that even though part of the bsim board code is linked with the Zephyr kernel,
 one should in general not call Zephyr APIs from the board code itself.
 In particular, one should not call Zephyr APIs from the original/HW models
 thread as the Zephyr code would be called from the wrong context,
@@ -242,13 +253,14 @@ which relies on the bs_trace API. Instead, for tracing the bs_trace API
 should be used directly.
 The same applies to other Zephyr APIs, including the entropy API, etc.
 
-posix_print backend
-===================
+posix_print and nsi_print backends
+==================================
 
-The bsim board provides a backend for the posix_print API which is expected by the posix ARCH
-and soc inf (POSIX) code.
-It simply routes the printk strings to the bs_trace bsim API.
-Any message printed to the posix_print API, which is also the default printk backend,
+The bsim board provides a backend for the ``posix_print`` API which is expected by the posix
+ARCH and `inf_clock` code, and for the ``nsi_print`` API expected by the native simulator.
+
+These simply route this API calls into the ``bs_trace`` bsim API.
+Any message printed to these APIs, and by extension by default to Zephyr's ``printk``,
 will be printed to the console (stdout) together with all other device messages.
 
 .. _bsim_boards_bs_tests:
@@ -271,12 +283,12 @@ callbacks are assigned to the respective hooks.
 There is a set of one time hooks at different levels of initialization of the HW
 and Zephyr OS, a hook to process possible command line arguments, and, a hook
 that can be used to sniff or capture interrupts.
-bs_tests also provides a hook which will be called from the embedded application
+`bs_tests` also provides a hook which will be called from the embedded application
 :c:func:`main`, but this will only work if the main application supports it,
 that is, if the main app is a version for simulation which calls
 :c:func:`bst_main` when running in the bsim board.
 
-Apart from these hooks, the bs_tests system provides facilities to build a
+Apart from these hooks, the `bs_tests` system provides facilities to build a
 dedicated test "task". This will be executed in the HW models thread context,
 but will have access to all SW variables. This task will be driven with a
 special timer which can be configured to produce either periodic or one time
@@ -286,12 +298,16 @@ at specific points in time. This can be combined with Babblesim's tb_defs macros
 to build quite complex test tasks which can wait for a given amount of time,
 for conditions to be fulfilled, etc.
 
-Note: When writing the tests with bs_tests one needs to be aware that other
+Note when writing the tests with `bs_tests` one needs to be aware that other
 bs tests will probably be built with the same application, and that therefore
 the tests should not be registering initialization or callback functions using
 NATIVE_TASKS or Zephyr's PRE/POST kernel driver initialization APIs as this
 will execute even if the test is not selected.
-Instead the equivalent bs_tests provided hooks should be used.
+Instead the equivalent `bs_tests` provided hooks should be used.
+
+Note also that, for AMP targets like the :ref:`nrf5340bsim <nrf5340bsim>`, each embedded MCU has
+its own separate `bs_tests` built with that MCU. You can select if and what test is used
+for each MCU separatedly with the command line options.
 
 Command line argument parsing
 =============================

--- a/boards/posix/doc/layering_natsim.svg
+++ b/boards/posix/doc/layering_natsim.svg
@@ -1,0 +1,582 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="6.3138824in"
+   height="4.6508102in"
+   viewBox="0 0 454.59963 334.8581"
+   xml:space="preserve"
+   color-interpolation-filters="sRGB"
+   class="st9"
+   version="1.1"
+   id="svg152"
+   sodipodi:docname="layering_natsim.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:v="http://schemas.microsoft.com/visio/2003/SVGExtensions/"><defs
+   id="defs156" /><sodipodi:namedview
+   id="namedview154"
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1.0"
+   inkscape:pageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:document-units="in"
+   showgrid="false"
+   inkscape:zoom="1.8759819"
+   inkscape:cx="453.09606"
+   inkscape:cy="251.8681"
+   inkscape:window-width="2399"
+   inkscape:window-height="1422"
+   inkscape:window-x="161"
+   inkscape:window-y="0"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="svg152"
+   showguides="false" />
+	<v:documentProperties
+   v:langID="1033"
+   v:metric="true"
+   v:viewMarkup="false">
+		<v:userDefs>
+			<v:ud
+   v:nameU="msvSubprocessMaster"
+   v:prompt=""
+   v:val="VT4(Rectangle)" />
+			<v:ud
+   v:nameU="msvNoAutoConnect"
+   v:val="VT0(1):26" />
+		</v:userDefs>
+	</v:documentProperties>
+
+	<style
+   type="text/css"
+   id="style2">
+	<![CDATA[
+		.st1 {fill:#fff2cc;stroke:#000000;stroke-linecap:round;stroke-linejoin:round;stroke-width:0.75}
+		.st2 {fill:#000000;font-family:Arial;font-size:0.916672em}
+		.st3 {fill:#ebf1df;stroke:#000000;stroke-linecap:round;stroke-linejoin:round;stroke-width:0.75}
+		.st4 {font-size:1em}
+		.st5 {fill:#fcebdd;stroke:#000000;stroke-linecap:round;stroke-linejoin:round;stroke-width:0.75}
+		.st6 {fill:#dbeef3;stroke:#000000;stroke-linecap:round;stroke-linejoin:round;stroke-width:0.75}
+		.st7 {fill:none;stroke:none;stroke-linecap:round;stroke-linejoin:round;stroke-width:0.75}
+		.st8 {fill:#000000;font-family:Arial;font-size:1.16666em}
+		.st9 {fill:none;fill-rule:evenodd;font-size:12px;overflow:visible;stroke-linecap:square;stroke-miterlimit:3}
+	]]>
+	</style>
+
+	<g
+   id="shape1-1"
+   v:mID="1"
+   v:groupContext="shape"
+   transform="translate(0.375,-40.164514)">
+			<title
+   id="title6">Sheet.1</title>
+			<desc
+   id="desc8">CPU/SOC</desc>
+			<v:textBlock
+   v:margins="rect(4,4,4,4)"
+   v:tabSpace="42.5197" />
+			<v:textRect
+   cx="42.5197"
+   cy="243.78"
+   width="85.04"
+   height="42.5197" />
+			<rect
+   x="0"
+   y="222.52"
+   width="85.039398"
+   height="42.519699"
+   class="st1"
+   id="rect10" />
+			<text
+   x="17.459999"
+   y="247.08"
+   class="st2"
+   v:langID="6153"
+   id="text12"><v:paragraph
+   v:horizAlign="1" /><v:tabList />CPU/SOC</text>		</g><g
+   id="shape2-4"
+   v:mID="2"
+   v:groupContext="shape"
+   transform="translate(88.249,-40.164514)">
+			<title
+   id="title15">Sheet.2</title>
+			<desc
+   id="desc17">HW peripherals</desc>
+			<v:textBlock
+   v:margins="rect(4,4,4,4)"
+   v:tabSpace="42.5197" />
+			<v:textRect
+   cx="48.189"
+   cy="243.78"
+   width="96.38"
+   height="42.5197" />
+			<rect
+   x="0"
+   y="222.52"
+   width="96.377998"
+   height="42.519699"
+   class="st1"
+   id="rect19" />
+			<text
+   x="10.29"
+   y="247.08"
+   class="st2"
+   v:langID="6153"
+   id="text21"><v:paragraph
+   v:horizAlign="1" /><v:tabList />HW peripherals</text>		</g><g
+   id="shape3-7"
+   v:mID="3"
+   v:groupContext="shape"
+   transform="translate(99.5878,-85.518914)">
+			<title
+   id="title24">Sheet.3</title>
+			<desc
+   id="desc26">Drivers</desc>
+			<v:textBlock
+   v:margins="rect(4,4,4,4)"
+   v:tabSpace="42.5197" />
+			<v:textRect
+   cx="42.5197"
+   cy="225.354"
+   width="85.04"
+   height="79.3701" />
+			<path
+   d="M 0,265.04 H 85.04 V 185.67 H 28.68 l -0.33,25.51 H 0 Z"
+   class="st3"
+   id="path28" />
+			<text
+   x="25.1"
+   y="228.64999"
+   class="st2"
+   v:langID="6153"
+   id="text30"><v:paragraph
+   v:horizAlign="1" /><v:tabList />Drivers</text>		</g><g
+   id="shape4-10"
+   v:mID="4"
+   v:groupContext="shape"
+   transform="translate(0.375,-85.518914)">
+			<title
+   id="title33">Sheet.4</title>
+			<desc
+   id="desc35">Architecture/SOC dependent layer</desc>
+			<v:textBlock
+   v:margins="rect(4,4,4,4)"
+   v:tabSpace="42.5197" />
+			<v:textRect
+   cx="48.189"
+   cy="248.031"
+   width="96.38"
+   height="34.0157" />
+			<rect
+   x="0"
+   y="231.024"
+   width="96.377998"
+   height="34.015701"
+   class="st3"
+   id="rect37" />
+			<text
+   x="5.4000001"
+   y="244.73"
+   class="st2"
+   v:langID="6153"
+   id="text41"><v:paragraph
+   v:horizAlign="1" /><v:tabList />Architecture/SOC <tspan
+   x="8.7399998"
+   dy="1.2em"
+   class="st4"
+   id="tspan39">dependent layer</tspan></text>		</g><g
+   id="shape5-14"
+   v:mID="5"
+   v:groupContext="shape"
+   transform="translate(0.375,-122.36901)">
+			<title
+   id="title44">Sheet.5</title>
+			<desc
+   id="desc46">Zephyr Kernel</desc>
+			<v:textBlock
+   v:margins="rect(4,4,4,4)"
+   v:tabSpace="42.5197" />
+			<v:textRect
+   cx="62.3622"
+   cy="243.78"
+   width="124.73"
+   height="42.5197" />
+			<path
+   d="M 0,265.04 H 96.38 V 245.2 h 28.34 V 222.52 H 85.04 0 Z"
+   class="st3"
+   id="path48" />
+			<text
+   x="45.240002"
+   y="240.48"
+   class="st2"
+   v:langID="6153"
+   id="text52"><v:paragraph
+   v:horizAlign="1" /><v:tabList />Zephyr<v:lf /><tspan
+   x="46.459999"
+   dy="1.2em"
+   class="st4"
+   id="tspan50">Kernel</tspan></text>		</g><g
+   id="shape6-18"
+   v:mID="6"
+   v:groupContext="shape"
+   transform="translate(0.375,-167.72401)">
+			<title
+   id="title55">Sheet.6</title>
+			<desc
+   id="desc57">Application</desc>
+			<v:textBlock
+   v:margins="rect(4,4,4,4)"
+   v:tabSpace="42.5197" />
+			<v:textRect
+   cx="92.126"
+   cy="248.031"
+   width="184.26"
+   height="34.0157" />
+			<rect
+   x="0"
+   y="231.024"
+   width="184.252"
+   height="34.015701"
+   class="st3"
+   id="rect59" />
+			<text
+   x="65.220001"
+   y="251.33"
+   class="st2"
+   v:langID="6153"
+   id="text61"><v:paragraph
+   v:horizAlign="1" /><v:tabList />Application</text>		</g><g
+   id="shape7-21"
+   v:mID="7"
+   v:groupContext="shape"
+   transform="translate(235.32842,69.443566)">
+			<title
+   id="title64">Sheet.7</title>
+			<desc
+   id="desc66">Host OS Kernel (i.e. Linux)</desc>
+			<v:textBlock
+   v:margins="rect(4,4,4,4)"
+   v:tabSpace="42.5197" />
+			<v:textRect
+   cx="92.126"
+   cy="243.78"
+   width="184.26"
+   height="42.5197" />
+			<rect
+   x="0"
+   y="222.52"
+   width="184.252"
+   height="42.519699"
+   class="st5"
+   id="rect68" />
+			<text
+   x="26.709999"
+   y="247.08"
+   class="st2"
+   v:langID="6153"
+   id="text70"><v:paragraph
+   v:horizAlign="1" /><v:tabList />Host OS Kernel (i.e. Linux)</text>		</g><g
+   id="shape7-21-9"
+   v:mID="7"
+   v:groupContext="shape"
+   transform="translate(235.45556,12.948706)"><title
+     id="title64-1">Sheet.7</title><desc
+     id="desc66-9">Host OS Kernel (i.e. Linux)</desc><v:textBlock
+     v:margins="rect(4,4,4,4)"
+     v:tabSpace="42.5197" /><v:textRect
+     cx="92.126"
+     cy="243.78"
+     width="184.26"
+     height="42.5197" /><rect
+     x="-0.049123723"
+     y="222.47089"
+     width="184.35025"
+     height="32.092358"
+     class="st5"
+     id="rect68-6"
+     style="fill:#fff2cc;fill-opacity:1" /><text
+     x="18.341778"
+     y="241.86397"
+     class="st2"
+     v:langID="6153"
+     id="text70-9">Overall scheduler &amp; entry point<v:paragraph
+   v:horizAlign="1" /><v:tabList /></text></g><rect
+   x="333.7178"
+   y="186.94901"
+   width="84.767006"
+   height="42.519699"
+   class="st6"
+   id="rect77"
+   style="fill:#fff2cc;fill-opacity:1" /><rect
+   x="235.46994"
+   y="186.96338"
+   width="93.858994"
+   height="42.490963"
+   class="st6"
+   id="rect77-8"
+   style="fill:#fff2cc;fill-opacity:1;stroke:#000000;stroke-width:0.739883;stroke-linecap:round;stroke-linejoin:round" /><text
+   x="342.66565"
+   y="198.60941"
+   class="st2"
+   v:langID="6153"
+   id="text83"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:11.0001px;font-family:Arial;-inkscape-font-specification:'Arial, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#000000"><v:paragraph
+     v:horizAlign="1" /><v:tabList /><v:newlineChar /><tspan
+     sodipodi:role="line"
+     id="tspan78481"
+     x="342.66565"
+     y="198.60941" /></text><text
+   x="304.9386"
+   y="204.15433"
+   class="st2"
+   v:langID="6153"
+   id="text83-3"
+   style="font-size:11.0001px;font-family:Arial;fill:#000000"><tspan
+     sodipodi:role="line"
+     id="tspan13646"
+     x="281.68155"
+     y="204.15433"
+     style="text-align:center;text-anchor:middle"><v:paragraph
+       v:horizAlign="1" /><v:tabList /><v:newlineChar /><tspan
+       x="281.68155"
+       class="st4"
+       id="tspan79-1"
+       style="text-align:center;text-anchor:middle">CPU</tspan></tspan><tspan
+     sodipodi:role="line"
+     id="tspan13648"
+     x="281.68155"
+     y="217.90445"
+     style="text-align:center;text-anchor:middle"><tspan
+       x="281.68155"
+       class="st4"
+       id="tspan13650"
+       style="text-align:center;text-anchor:middle">emulation</tspan></tspan></text><g
+   id="shape8-24-8"
+   v:mID="8"
+   v:groupContext="shape"
+   transform="translate(234.2348,-77.446018)"><title
+     id="title73-4">Sheet.8</title><desc
+     id="desc75-7">HW models / host HW API adaptation</desc><v:textBlock
+     v:margins="rect(4,4,4,4)"
+     v:tabSpace="42.5197" /><v:textRect
+     cx="48.189"
+     cy="243.78"
+     width="96.38"
+     height="42.5197" /><rect
+     x="-0.040226944"
+     y="222.47978"
+     height="33.858395"
+     class="st6"
+     id="rect77-2"
+     width="96.488426" /><text
+     x="49.548149"
+     y="236.54758"
+     class="st2"
+     v:langID="6153"
+     id="text83-4"><tspan
+       sodipodi:role="line"
+       id="tspan3759"
+       x="49.548149"
+       y="236.54758"
+       style="text-align:center;text-anchor:middle">POSIX arch<v:paragraph
+   v:horizAlign="1" /><v:tabList /><v:newlineChar /></tspan><tspan
+       sodipodi:role="line"
+       id="tspan3761"
+       x="49.548149"
+       y="250.29765"
+       style="text-align:center;text-anchor:middle">and SOC</tspan></text></g><g
+   id="shape9-29"
+   v:mID="9"
+   v:groupContext="shape"
+   transform="translate(333.4458,-86.115614)">
+			<title
+   id="title86">Sheet.9</title>
+			<desc
+   id="desc88">Drivers</desc>
+			<v:textBlock
+   v:margins="rect(4,4,4,4)"
+   v:tabSpace="42.5197" />
+			<v:textRect
+   cx="42.5197"
+   cy="225.354"
+   width="85.04"
+   height="79.3701" />
+			<path
+   d="M 0,265.04 H 85.04 V 185.67 H 28.68 l -0.33,25.51 H 0 Z"
+   class="st6"
+   id="path90" />
+			<text
+   x="25.1"
+   y="235.25"
+   class="st2"
+   v:langID="6153"
+   id="text92"><v:paragraph
+   v:horizAlign="1" /><v:tabList /><v:newlineChar />Drivers</text>		</g><g
+   id="shape11-36"
+   v:mID="11"
+   v:groupContext="shape"
+   transform="translate(234.2328,-122.96601)">
+			<title
+   id="title106">Sheet.11</title>
+			<desc
+   id="desc108">Zephyr Kernel</desc>
+			<v:textBlock
+   v:margins="rect(4,4,4,4)"
+   v:tabSpace="42.5197" />
+			<v:textRect
+   cx="62.3622"
+   cy="243.78"
+   width="124.73"
+   height="42.5197" />
+			<path
+   d="M 0,265.04 H 96.38 V 245.2 h 28.34 V 222.52 H 85.04 0 Z"
+   class="st3"
+   id="path110" />
+			<text
+   x="45.240002"
+   y="240.48"
+   class="st2"
+   v:langID="6153"
+   id="text114"><v:paragraph
+   v:horizAlign="1" /><v:tabList />Zephyr<v:lf /><tspan
+   x="46.459999"
+   dy="1.2em"
+   class="st4"
+   id="tspan112">Kernel</tspan></text>		</g><g
+   id="shape12-40"
+   v:mID="12"
+   v:groupContext="shape"
+   transform="translate(234.2328,-168.32001)">
+			<title
+   id="title117">Sheet.12</title>
+			<desc
+   id="desc119">Application</desc>
+			<v:textBlock
+   v:margins="rect(4,4,4,4)"
+   v:tabSpace="42.5197" />
+			<v:textRect
+   cx="92.126"
+   cy="248.031"
+   width="184.26"
+   height="34.0157" />
+			<rect
+   x="0"
+   y="231.024"
+   width="184.252"
+   height="34.015701"
+   class="st3"
+   id="rect121" />
+			<text
+   x="65.220001"
+   y="251.33"
+   class="st2"
+   v:langID="6153"
+   id="text123"><v:paragraph
+   v:horizAlign="1" /><v:tabList />Application</text>		</g><g
+   id="shape13-43"
+   v:mID="13"
+   v:groupContext="shape"
+   transform="translate(23.7608,-220.16501)">
+			<title
+   id="title126">Sheet.13</title>
+			<desc
+   id="desc128">Normal Zephyr layering</desc>
+			<v:textBlock
+   v:margins="rect(4,4,4,4)"
+   v:tabSpace="42.5197" />
+			<v:textRect
+   cx="67.3228"
+   cy="250.866"
+   width="134.65"
+   height="28.3465" />
+			<rect
+   x="0"
+   y="236.69299"
+   width="134.646"
+   height="28.3465"
+   class="st7"
+   id="rect130" />
+			<text
+   x="21.030001"
+   y="246.67"
+   class="st8"
+   v:langID="6153"
+   id="text134"><v:paragraph
+   v:horizAlign="1" /><v:tabList />Normal Zephyr <tspan
+   x="42.810001"
+   dy="1.2em"
+   class="st4"
+   id="tspan132">layering</tspan></text>		</g><rect
+   style="fill:none;fill-opacity:1;stroke:#8b0c0c;stroke-width:0.814956;stroke-linejoin:round;stroke-miterlimit:8;stroke-dasharray:2.44487, 2.44487;stroke-dashoffset:0;stroke-opacity:1"
+   id="rect27201"
+   width="232.53108"
+   height="102.18562"
+   x="221.62726"
+   y="184.2868"
+   ry="8.8151979" /><rect
+   style="fill:none;fill-opacity:1;stroke:#8b0c0c;stroke-width:0.947936;stroke-linejoin:round;stroke-miterlimit:8;stroke-dasharray:2.84381, 2.84381;stroke-dashoffset:0;stroke-opacity:1"
+   id="rect27201-3"
+   width="232.45898"
+   height="138.29732"
+   x="221.6633"
+   y="43.277798"
+   ry="11.93043" /><text
+   xml:space="preserve"
+   style="font-style:normal;font-weight:normal;font-size:10px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.75"
+   x="290.12436"
+   y="282.03317"
+   id="text40992"><tspan
+     sodipodi:role="line"
+     id="tspan40990"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#800000;stroke-width:0.75"
+     x="290.12436"
+     y="282.03317">native simulator runner context</tspan></text><text
+   xml:space="preserve"
+   style="font-style:normal;font-weight:normal;font-size:10px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.75"
+   x="264.2746"
+   y="56.450466"
+   id="text40992-8"><tspan
+     sodipodi:role="line"
+     id="tspan40990-0"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#800000;stroke-width:0.75"
+     x="264.2746"
+     y="56.450466">Embedded CPU SW (Zephyr) context</tspan></text>
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-weight:normal;font-size:14px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.75"
+   x="327.66986"
+   y="12.855812"
+   id="text63528"><tspan
+     sodipodi:role="line"
+     id="tspan63526"
+     style="font-size:14px;text-align:center;text-anchor:middle;stroke-width:0.75"
+     x="327.66986"
+     y="12.855812">native_sim &amp; _bsim</tspan><tspan
+     sodipodi:role="line"
+     style="font-size:14px;text-align:center;text-anchor:middle;stroke-width:0.75"
+     x="327.66986"
+     y="30.355812"
+     id="tspan63530">boards Zephyr layering</tspan></text><text
+   xml:space="preserve"
+   style="font-style:normal;font-weight:normal;font-size:10px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.75"
+   x="376.02158"
+   y="198.70131"
+   id="text81644"><tspan
+     sodipodi:role="line"
+     id="tspan81642"
+     style="font-size:10px;text-align:center;text-anchor:middle;stroke-width:0.75"
+     x="376.02158"
+     y="198.70131">HW models /</tspan><tspan
+     sodipodi:role="line"
+     style="font-size:10px;text-align:center;text-anchor:middle;stroke-width:0.75"
+     x="376.02158"
+     y="211.20131"
+     id="tspan81646">Host API</tspan><tspan
+     sodipodi:role="line"
+     style="font-size:10px;text-align:center;text-anchor:middle;stroke-width:0.75"
+     x="376.02158"
+     y="223.70131"
+     id="tspan81648">adaptation</tspan></text></svg>

--- a/boards/posix/nrf_bsim/doc/nrf5340bsim.rst
+++ b/boards/posix/nrf_bsim/doc/nrf5340bsim.rst
@@ -28,28 +28,25 @@ core on the simulated nRF5340 SOC.
 
 These boards include models of some of the nRF5340 SOC peripherals:
 
-* Radio
-* Timers
 * AAR (Accelerated Address Resolver)
 * AES CCM & AES ECB encryption HW
 * CLOCK (Clock control)
 * DPPI (Distributed Programmable Peripheral Interconnect)
 * EGU (Event Generator Unit)
 * FICR (Factory Information Configuration Registers)
+* IPC (Interprocessor communication)
+* MUTEX (Mutual exclusive peripheral)
 * NVMC (Non-Volatile Memory Controller / Flash)
+* RADIO
 * RNG (Random Number Generator)
 * RTC (Real Time Counter)
 * TEMP (Temperature sensor)
+* TIMER
 * UICR (User Information Configuration Registers)
 
 and will use the same drivers as the nrf5340dk targets for these.
 For more information on what is modelled to which level of detail,
 check the `HW models implementation status`_.
-
-.. note::
-
-   The IPC and MUTEX peripherals are not yet present in these models. Therefore communication
-   between the cores using Zephyr's IPC driver is not yet possible.
 
 Note that unlike a real nrf5340 device, the nrf5340bsim boards have unlimited RAM and flash for
 code.

--- a/doc/connectivity/bluetooth/bluetooth-dev.rst
+++ b/doc/connectivity/bluetooth/bluetooth-dev.rst
@@ -34,7 +34,7 @@ There are 4 possible hardware setups to use with Zephyr and Bluetooth:
 #. Embedded
 #. QEMU with an external Controller
 #. :ref:`native_sim <native_sim>` with an external Controller
-#. Simulated nRF52 with BabbleSim
+#. Simulated nRF5x with BabbleSim
 
 Embedded
 ========
@@ -137,32 +137,35 @@ Refer to :ref:`bluetooth_qemu_native` for full instructions on how to build and
 run an application with a physical controller. For the virtual controller refer
 to :ref:`bluetooth_virtual_posix`.
 
-Simulated nRF52 with BabbleSim
+Simulated nRF5x with BabbleSim
 ==============================
 
 .. note::
    This is currently only available on GNU/Linux
 
-The :ref:`nrf52_bsim board <nrf52_bsim>`, is a simulated target board
-which emulates the necessary peripherals of a nrf52 SOC to be able to develop
+The :ref:`nrf52_bsim <nrf52_bsim>` and :ref:`nrf5340bsim <nrf5340bsim>` boards,
+are simulated target boards
+which emulate the necessary peripherals of a nRF52/53 SOC to be able to develop
 and test BLE applications.
-This board, uses:
+These boards, use:
 
-   * `BabbleSim`_ to simulate the nrf52 modem and the radio environment.
-   * The POSIX arch to emulate the processor.
-   * `Models of the nrf52 HW <https://github.com/BabbleSim/ext_NRF52_hw_models/>`_
+   * `BabbleSim`_ to simulate the nRF5x modem and the radio environment.
+   * The POSIX arch and native simulator to emulate the processor, and run natively on your host.
+   * `Models of the nrf5x HW <https://github.com/BabbleSim/ext_NRF_hw_models/>`_
 
 Just like with the :ref:`native_sim <native_sim>` target, the build result is a normal Linux
 executable.
 You can find more information on how to run simulations with one or several
-devices in
-:ref:`this board's documentation <nrf52bsim_build_and_run>`
+devices in either of :ref:`these boards's documentation <nrf52bsim_build_and_run>`.
 
-Currently, only :ref:`Combined builds
+With the :ref:`nrf52_bsim <nrf52_bsim>`, only :ref:`Combined builds
 <bluetooth-build-types>` are possible, as this board does not yet have
 any models of a UART, or USB which could be used for an HCI interface towards
 another real or simulated device.
 
+With the :ref:`nrf5340bsim <nrf5340bsim>`, you can build with either, both controller and host
+on its network core, or, with the network core running only the controller, the application
+core running the host and your application, and the HCI transport over IPC.
 
 Initialization
 **************

--- a/doc/develop/test/bsim.rst
+++ b/doc/develop/test/bsim.rst
@@ -12,7 +12,7 @@ including the BLE stack, 802.15.4, and some of the networking stack.
 BabbleSim_ is a physical layer simulator, which in combination with the Zephyr
 :ref:`bsim boards<bsim boards>`
 can be used to simulate a network of BLE and 15.4 devices.
-When we build Zephyr targeting an :ref:`nrf52_bsim<nrf52_bsim>` board we produce a Linux
+When we build Zephyr targeting a :ref:`bsim board<bsim boards>` we produce a Linux
 executable, which includes the application, Zephyr OS, and models of the HW.
 
 When there is radio activity, this Linux executable will connect to the BabbleSim Phy simulation
@@ -21,8 +21,9 @@ to simulate the radio channel.
 In the BabbleSim documentation you can find more information on how to
 `get <https://babblesim.github.io/fetching.html>`_ and
 `build <https://babblesim.github.io/building.html>`_ the simulator.
-In the :ref:`nrf52_bsim<nrf52_bsim>` board documentation you can find more information about how
-to build Zephyr targeting that particular board, and a few examples.
+In the :ref:`nrf52_bsim<nrf52_bsim>` and :ref:`nrf5340bsim<nrf5340bsim>` boards documentation
+you can find more information about how to build Zephyr targeting thesee particular boards,
+and a few examples.
 
 Types of tests
 **************
@@ -31,7 +32,7 @@ Tests without radio activity: bsim tests with twister
 -----------------------------------------------------
 
 The :ref:`bsim boards<bsim boards>` can be used without radio activity, and in that case, it is not
-necessary to connect them to a phyisical layer simulation. Thanks to this, this target boards can
+necessary to connect them to a physical layer simulation. Thanks to this, these target boards can
 be used just like :ref:`native_sim<native_sim>` with :ref:`twister <twister_script>`,
 to run all standard Zephyr twister tests, but with models of a real SOC HW, and their drivers.
 
@@ -62,8 +63,8 @@ found in the :ref:`bsim boards tests section<bsim_boards_tests>`.
 Test coverage and BabbleSim
 ***************************
 
-As the :ref:`nrf52_bsim<nrf52_bsim>` is based on the POSIX architecture, you can easily collect test
-coverage information.
+As the :ref:`nrf52_bsim<nrf52_bsim>` and :ref:`nrf5340bsim<nrf5340bsim>` boards are based on the
+POSIX architecture, you can easily collect test coverage information.
 
 You can use the script :code:`tests/bsim/generate_coverage_report.sh` to generate an html
 coverage report from tests.


### PR DESCRIPTION
A set of updates to the bluetooth & bsim related docs:

----

    boards nrf5340_bsim doc: IPC and MUTEX peripherals are now supported
    
    Update this board docs to reflect that these 2 peripherals
    are now supported.

-----

    bsim boards doc: Update general bsim boards documentation
    
    Polish and correct the documentation to reflect the use
    of the native_simulator, and the fact that we have
    now more than one bsim board in tree.

----

    bluetooth dev doc: Update with nrf5340bsim info
    
    Now that we also have this target board, we have
    some more options.
    Update the docs to reflect these.

----

    doc/develop/test/bsim: Update with nrf5340bsim info
    
    Update this page to account for the fact that now
    we have several bsim boards in tree.

-----

Doc preview in: https://builds.zephyrproject.io/zephyr/pr/65188/docs/index.html
    
