### PR TITLE
zbus: make ZBUS_CHANNEL_DECLARE compatible with C++

### DIFF
--- a/include/zephyr/zbus/zbus.h
+++ b/include/zephyr/zbus/zbus.h
@@ -304,6 +304,7 @@ struct zbus_channel_observation {
 	static struct zbus_channel_data _CONCAT(_zbus_chan_data_, _name) = {                       \
 		.observers_start_idx = -1, .observers_end_idx = -1};                               \
 	static K_MUTEX_DEFINE(_CONCAT(_zbus_mutex_, _name));                                       \
+	IF_ENABLED(CONFIG_CPP, (extern))                                                           \
 	const STRUCT_SECTION_ITERABLE(zbus_channel, _name) = {                                     \
 		ZBUS_CHANNEL_NAME_INIT(_name) /* Maybe removed */                                  \
 			.message = &_CONCAT(_zbus_message_, _name),                                \


### PR DESCRIPTION
The current implementation of ZBUS_CHAN_DECLARE is not compatible with C++. It fixes the bug by conditionally adding the extern keyword at the channel definition, which will work for both C++.

Fixes #65137