### PR TITLE
ci: testplan: fix mcumgr path

### DIFF
--- a/scripts/ci/tags.yaml
+++ b/scripts/ci/tags.yaml
@@ -72,7 +72,7 @@ cmsis_dsp:
 
 mcumgr:
   files:
-    - subsys/mcumgr/
+    - subsys/mgmt/mcumgr/
     - tests/subsys/mgmt/mcumgr/
     - samples/subsys/mgmt/mcumgr/
     - include/zephyr/mgmt/mcumgr/


### PR DESCRIPTION
fix path for mcumgr in tags.yaml, we were skipping tests due to wrong
path.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
