### PR TITLE
doc: doxygen: move mpsc and spsc under data structure API group

### DIFF
--- a/include/zephyr/sys/mpsc_pbuf.h
+++ b/include/zephyr/sys/mpsc_pbuf.h
@@ -19,7 +19,7 @@ extern "C" {
 /**
  * @brief Multi producer, single consumer packet buffer API
  * @defgroup mpsc_buf MPSC (Multi producer, single consumer) packet buffer API
- * @ingroup kernel_apis
+ * @ingroup datastructure_apis
  * @{
  */
 

--- a/include/zephyr/sys/spsc_pbuf.h
+++ b/include/zephyr/sys/spsc_pbuf.h
@@ -16,11 +16,12 @@ extern "C" {
 
 /**
  * @brief Single producer, single consumer packet buffer API
- * @ingroup kernel_apis
+ * @defgroup spsc_buf SPSC (Single producer, single consumer) packet buffer API
+ * @ingroup datastructure_apis
  * @{
  */
 
-/**@defgroup SPSC_PBUF_FLAGS MPSC packet buffer flags
+/**@defgroup SPSC_PBUF_FLAGS SPSC packet buffer flags
  * @{
  */
 


### PR DESCRIPTION
Both MPSC and SPSC should be under data structure API group instead of kernel API group. So move them, and fix some doxygen cosmetic grouping issues for SPSC.