### PR TITLE
drivers: gnss: Fix nano parameter not being checked in __ASSERT

### DIFF
--- a/drivers/gnss/gnss_parse.c
+++ b/drivers/gnss/gnss_parse.c
@@ -26,7 +26,7 @@ int gnss_parse_dec_to_nano(const char *str, int64_t *nano)
 	int64_t increment;
 
 	__ASSERT(str != NULL, "str argument must be provided");
-	__ASSERT(str != NULL, "nano argument must be provided");
+	__ASSERT(nano != NULL, "nano argument must be provided");
 
 	/* Find decimal */
 	while (str[pos] != '\0') {


### PR DESCRIPTION
              str is being checked instead of nano

_Originally posted by @michael-whg in https://github.com/zephyrproject-rtos/zephyr/pull/61073#discussion_r1393471924_
            