### PR TITLE
doc: extensions: kconfig: allow paste event to trigger search

### DIFF
--- a/doc/_extensions/zephyr/kconfig/static/kconfig.mjs
+++ b/doc/_extensions/zephyr/kconfig/static/kconfig.mjs
@@ -491,7 +491,7 @@ function setupKconfigSearch() {
             doSearchFromURL();
 
             /* install event listeners */
-            input.addEventListener('keyup', () => {
+            input.addEventListener('input', () => {
                 searchOffset = 0;
                 doSearch();
             });


### PR DESCRIPTION
The "keyup" event is not triggered when pasting with mouse (right click, paste) or when pasting on a phone/tablet.
