### PR TITLE
mgmt: mcumgr: transport: shell: fix compilation error

### DIFF
--- a/include/zephyr/shell/shell_uart.h
+++ b/include/zephyr/shell/shell_uart.h
@@ -7,11 +7,47 @@
 #ifndef SHELL_UART_H__
 #define SHELL_UART_H__
 
+#include <zephyr/drivers/serial/uart_async_rx.h>
+#include <zephyr/device.h>
+#include <zephyr/mgmt/mcumgr/transport/smp_shell.h>
+#include <zephyr/sys/ring_buffer.h>
+#include <zephyr/sys/atomic.h>
 #include <zephyr/shell/shell.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+struct shell_uart_common {
+	const struct device *dev;
+	shell_transport_handler_t handler;
+	void *context;
+	bool blocking_tx;
+#ifdef CONFIG_MCUMGR_TRANSPORT_SHELL
+	struct smp_shell_data smp;
+#endif /* CONFIG_MCUMGR_TRANSPORT_SHELL */
+};
+
+struct shell_uart_int_driven {
+	struct shell_uart_common common;
+	struct ring_buf tx_ringbuf;
+	struct ring_buf rx_ringbuf;
+	struct k_timer dtr_timer;
+	atomic_t tx_busy;
+};
+
+struct shell_uart_async {
+	struct shell_uart_common common;
+	struct k_sem tx_sem;
+	struct uart_async_rx async_rx;
+	atomic_t pending_rx_req;
+};
+
+struct shell_uart_polling {
+	struct shell_uart_common common;
+	struct ring_buf rx_ringbuf;
+	struct k_timer rx_timer;
+};
 
 /**
  * @brief This function provides pointer to the shell UART backend instance.

--- a/subsys/mgmt/mcumgr/transport/src/smp_shell.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp_shell.c
@@ -64,8 +64,9 @@ extern struct shell_transport shell_transport_uart;
 static void smp_shell_input_timeout_handler(struct k_timer *timer)
 {
 	ARG_UNUSED(timer);
-	struct shell_uart *sh_uart = (struct shell_uart *)shell_transport_uart.ctx;
-	struct smp_shell_data *const data = &sh_uart->ctrl_blk->smp;
+	struct shell_uart_int_driven *sh_uart =
+		(struct shell_uart_int_driven *)shell_transport_uart.ctx;
+	struct smp_shell_data *const data = &sh_uart->common.smp;
 
 	atomic_clear_bit(&data->esc_state, ESC_MCUMGR_PKT_1);
 	atomic_clear_bit(&data->esc_state, ESC_MCUMGR_PKT_2);

--- a/subsys/shell/backends/shell_uart.c
+++ b/subsys/shell/backends/shell_uart.c
@@ -43,37 +43,6 @@ LOG_MODULE_REGISTER(shell_uart);
 		(CONFIG_SHELL_BACKEND_SERIAL_ASYNC_RX_BUFFER_SIZE + \
 		 UART_ASYNC_RX_BUF_OVERHEAD))
 
-struct shell_uart_common {
-	const struct device *dev;
-	shell_transport_handler_t handler;
-	void *context;
-	bool blocking_tx;
-#ifdef CONFIG_MCUMGR_TRANSPORT_SHELL
-	struct smp_shell_data smp;
-#endif /* CONFIG_MCUMGR_TRANSPORT_SHELL */
-};
-
-struct shell_uart_int_driven {
-	struct shell_uart_common common;
-	struct ring_buf tx_ringbuf;
-	struct ring_buf rx_ringbuf;
-	struct k_timer dtr_timer;
-	atomic_t tx_busy;
-};
-
-struct shell_uart_async {
-	struct shell_uart_common common;
-	struct k_sem tx_sem;
-	struct uart_async_rx async_rx;
-	atomic_t pending_rx_req;
-};
-
-struct shell_uart_polling {
-	struct shell_uart_common common;
-	struct ring_buf rx_ringbuf;
-	struct k_timer rx_timer;
-};
-
 static uint8_t __noinit async_rx_data[ASYNC_RX_BUF_SIZE];
 static uint8_t __noinit rx_ringbuf_data[CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE];
 static uint8_t __noinit tx_ringbuf_data[CONFIG_SHELL_BACKEND_SERIAL_TX_RING_BUFFER_SIZE];


### PR DESCRIPTION
#63967 removed the struct declaration required by
`smp_shell_input_timeout_handler`, update the function accordingly so that it compiles.

```
(.venv) ycsin@LAPTOP-ROG:~/zephyrproject$ twister -i -p nrf52840dk_nrf52840 -T zephyr/tests/subsys/mgmt/mcumgr/all_options/
Renaming output directory to /home/ycsin/zephyrproject/twister-out.4
INFO    - Using Ninja..
INFO    - Zephyr version: zephyr-v3.5.0-1511-g56f73bde0fb0
INFO    - Using 'zephyr' toolchain.
INFO    - Building initial testsuite list...
INFO    - Writing JSON report /home/ycsin/zephyrproject/twister-out/testplan.json
INFO    - JOBS: 6
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - Total complete:    2/   2  100%  skipped:    0, failed:    0, error:    0
INFO    - 2 test scenarios (2 test instances) selected, 0 configurations skipped (0 by static filter, 0 at runtime).
INFO    - 2 of 2 test configurations passed (100.00%), 0 failed, 0 errored, 0 skipped with 0 warnings in 62.37 seconds
INFO    - In total 0 test cases were executed, 2 skipped on 1 out of total 641 platforms (0.16%)
INFO    - 0 test configurations executed on platforms, 2 test configurations were only built.
INFO    - Saving reports...
INFO    - Writing JSON report /home/ycsin/zephyrproject/twister-out/twister.json
INFO    - Writing xunit report /home/ycsin/zephyrproject/twister-out/twister.xml...
INFO    - Writing xunit report /home/ycsin/zephyrproject/twister-out/twister_report.xml...
INFO    - Run completed
```

fixes #65218