### PR TITLE
cmake: modules: Add zephyr_library_add_dependencies extension

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -528,6 +528,10 @@ function(zephyr_library_cc_option)
   endforeach()
 endfunction()
 
+function(zephyr_library_add_dependencies)
+  add_dependencies(${ZEPHYR_CURRENT_LIBRARY} ${ARGN})
+endfunction()
+
 # Add the existing CMake library 'library' to the global list of
 # Zephyr CMake libraries. This is done automatically by the
 # constructor but must be called explicitly on CMake libraries that do
@@ -1819,6 +1823,12 @@ function(zephyr_linker_sources_ifdef feature_toggle)
   endif()
 endfunction()
 
+function(zephyr_library_add_dependencies_ifdef feature_toggle)
+  if(${${feature_toggle}})
+    zephyr_library_add_dependencies(${ARGN})
+  endif()
+endfunction()
+
 macro(list_append_ifdef feature_toggle list)
   if(${${feature_toggle}})
     list(APPEND ${list} ${ARGN})
@@ -1962,6 +1972,12 @@ endfunction()
 function(zephyr_linker_sources_ifndef feature_toggle)
   if(NOT ${feature_toggle})
     zephyr_linker_sources(${ARGN})
+  endif()
+endfunction()
+
+function(zephyr_library_add_dependencies_ifndef feature_toggle)
+  if(NOT ${feature_toggle})
+    zephyr_library_add_dependencies(${ARGN})
   endif()
 endfunction()
 

--- a/modules/hal_rpi_pico/CMakeLists.txt
+++ b/modules/hal_rpi_pico/CMakeLists.txt
@@ -42,7 +42,7 @@ if(CONFIG_HAS_RPI_PICO)
       BUILD_ALWAYS TRUE
       )
 
-      add_dependencies(${ZEPHYR_CURRENT_LIBRARY} second_stage_bootloader)
+      zephyr_library_add_dependencies(second_stage_bootloader)
       zephyr_library_sources(${rp2_bootloader_asm})
   endif()
 

--- a/subsys/bindesc/CMakeLists.txt
+++ b/subsys/bindesc/CMakeLists.txt
@@ -66,7 +66,7 @@ if(CONFIG_BINDESC_DEFINE_BUILD_TIME)
       bindesc_time_force_rebuild
       COMMAND ${CMAKE_COMMAND} ${CMAKE_BINARY_DIR}
     )
-    add_dependencies(${ZEPHYR_CURRENT_LIBRARY} bindesc_time_force_rebuild)
+    zephyr_library_add_dependencies(bindesc_time_force_rebuild)
   endif()
 endif()
 


### PR DESCRIPTION
Add a CMake zephyr library extension for `add_dependencies`, similar to the `target_<func>` functions.
This avoids using `${ZEPHYR_CURRENT_LIBRARY}` directly.