### PR TITLE
shell: backends: uart: add public function to access smp shell data

### DIFF
--- a/include/zephyr/shell/shell_uart.h
+++ b/include/zephyr/shell/shell_uart.h
@@ -7,6 +7,7 @@
 #ifndef SHELL_UART_H__
 #define SHELL_UART_H__
 
+#include <zephyr/mgmt/mcumgr/transport/smp_shell.h>
 #include <zephyr/shell/shell.h>
 
 #ifdef __cplusplus
@@ -22,6 +23,13 @@ extern "C" {
  * @returns Pointer to the shell instance.
  */
 const struct shell *shell_backend_uart_get_ptr(void);
+
+/**
+ * @brief This function provides pointer to the smp shell data of the UART shell transport.
+ *
+ * @returns Pointer to the smp shell data.
+ */
+struct smp_shell_data *shell_uart_smp_shell_data_get_ptr(void);
 
 #ifdef __cplusplus
 }

--- a/subsys/mgmt/mcumgr/transport/src/smp_shell.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp_shell.c
@@ -59,13 +59,10 @@ enum smp_shell_mcumgr_state {
 };
 
 #ifdef CONFIG_MCUMGR_TRANSPORT_SHELL_INPUT_TIMEOUT
-extern struct shell_transport shell_transport_uart;
-
 static void smp_shell_input_timeout_handler(struct k_timer *timer)
 {
 	ARG_UNUSED(timer);
-	struct shell_uart *sh_uart = (struct shell_uart *)shell_transport_uart.ctx;
-	struct smp_shell_data *const data = &sh_uart->ctrl_blk->smp;
+	struct smp_shell_data *const data = shell_uart_smp_shell_data_get_ptr();
 
 	atomic_clear_bit(&data->esc_state, ESC_MCUMGR_PKT_1);
 	atomic_clear_bit(&data->esc_state, ESC_MCUMGR_PKT_2);

--- a/subsys/shell/backends/shell_uart.c
+++ b/subsys/shell/backends/shell_uart.c
@@ -554,6 +554,10 @@ static int read(const struct shell_transport *transport,
 #ifdef CONFIG_MCUMGR_TRANSPORT_SHELL
 static void update(const struct shell_transport *transport)
 {
+	/*
+	 * This is dependent on the fact that `struct shell_uart_common`
+	 * is always the first member, regardless of the UART configuration
+	 */
 	struct shell_uart_common *sh_uart = (struct shell_uart_common *)transport->ctx;
 
 	smp_shell_process(&sh_uart->smp);
@@ -582,6 +586,15 @@ SHELL_DEFINE(shell_uart, CONFIG_SHELL_PROMPT_UART, &shell_transport_uart,
 	     CONFIG_SHELL_BACKEND_SERIAL_LOG_MESSAGE_QUEUE_SIZE,
 	     CONFIG_SHELL_BACKEND_SERIAL_LOG_MESSAGE_QUEUE_TIMEOUT,
 	     SHELL_FLAG_OLF_CRLF);
+
+#ifdef CONFIG_MCUMGR_TRANSPORT_SHELL
+struct smp_shell_data *shell_uart_smp_shell_data_get_ptr(void)
+{
+	struct shell_uart_common *common = (struct shell_uart_common *)shell_transport_uart.ctx;
+
+	return &common->smp;
+}
+#endif
 
 static int enable_shell_uart(void)
 {


### PR DESCRIPTION
#63967 removed the struct declaration required by
`smp_shell_input_timeout_handler`. Create a public function in the `shell_uart.c` for it to get the pointer to the `smp_shell_data` and fix the compilation error.

```
(.venv) ycsin@LAPTOP-ROG:~/zephyrproject$ twister -i -p nrf52840dk_nrf52840 -T zephyr/tests/subsys/mgmt/mcumgr/all_options/
Renaming output directory to /home/ycsin/zephyrproject/twister-out.4
INFO    - Using Ninja..
INFO    - Zephyr version: zephyr-v3.5.0-1511-g56f73bde0fb0
INFO    - Using 'zephyr' toolchain.
INFO    - Building initial testsuite list...
INFO    - Writing JSON report /home/ycsin/zephyrproject/twister-out/testplan.json
INFO    - JOBS: 6
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - Total complete:    2/   2  100%  skipped:    0, failed:    0, error:    0
INFO    - 2 test scenarios (2 test instances) selected, 0 configurations skipped (0 by static filter, 0 at runtime).
INFO    - 2 of 2 test configurations passed (100.00%), 0 failed, 0 errored, 0 skipped with 0 warnings in 47.10 seconds
INFO    - In total 0 test cases were executed, 2 skipped on 1 out of total 641 platforms (0.16%)
INFO    - 0 test configurations executed on platforms, 2 test configurations were only built.
INFO    - Saving reports...
INFO    - Writing JSON report /home/ycsin/zephyrproject/twister-out/twister.json
INFO    - Writing xunit report /home/ycsin/zephyrproject/twister-out/twister.xml...
INFO    - Writing xunit report /home/ycsin/zephyrproject/twister-out/twister_report.xml...
INFO    - Run completed
```

fixes #65218