### PR TITLE
zbus: fix warning messages when mixing C and C++ files

### DIFF
--- a/include/zephyr/zbus/zbus.h
+++ b/include/zephyr/zbus/zbus.h
@@ -148,6 +148,12 @@ struct zbus_channel_observation {
 	const struct zbus_observer *const obs;
 };
 
+#ifdef __cplusplus
+#define _ZBUS_CPP_EXTERN extern
+#else
+#define _ZBUS_CPP_EXTERN
+#endif /* __cplusplus */
+
 #if defined(CONFIG_ZBUS_ASSERT_MOCK)
 #define _ZBUS_ASSERT(_cond, _fmt, ...)                                                             \
 	do {                                                                                       \
@@ -304,8 +310,7 @@ struct zbus_channel_observation {
 	static struct zbus_channel_data _CONCAT(_zbus_chan_data_, _name) = {                       \
 		.observers_start_idx = -1, .observers_end_idx = -1};                               \
 	static K_MUTEX_DEFINE(_CONCAT(_zbus_mutex_, _name));                                       \
-	IF_ENABLED(CONFIG_CPP, (extern))                                                           \
-	const STRUCT_SECTION_ITERABLE(zbus_channel, _name) = {                                     \
+	_ZBUS_CPP_EXTERN const STRUCT_SECTION_ITERABLE(zbus_channel, _name) = {                    \
 		ZBUS_CHANNEL_NAME_INIT(_name) /* Maybe removed */                                  \
 			.message = &_CONCAT(_zbus_message_, _name),                                \
 		.message_size = sizeof(_type), .user_data = _user_data, .validator = (_validator), \


### PR DESCRIPTION
> [!Note]
> This commit improves solution #65196 by removing warnings that happen in some circumstances. 

After some further investigation, I could find the current solution to enable zbus channels (by using ZBUS_CHAN_DECLARE) to be used in C++ files, which generates a warning when we mix C and C++ code. This fixes the issue by using an approach to add the extern keyword only when the file is being compiled with a C++ compiler.
