### PR TITLE
linker: common-rom-logging: Use DEVNULL_REGION only if it exists

### DIFF
--- a/include/zephyr/linker/common-rom/common-rom-logging.ld
+++ b/include/zephyr/linker/common-rom/common-rom-logging.ld
@@ -2,7 +2,7 @@
 
 #include <zephyr/linker/iterable_sections.h>
 
-#ifdef CONFIG_LOG_FMT_SECTION_STRIP
+#if defined(CONFIG_LOG_FMT_SECTION_STRIP) && defined(DEVNULL_REGION)
 	SECTION_PROLOGUE(log_strings,(COPY),SUBALIGN(4))
 	{
 		Z_LINK_ITERABLE(log_strings);


### PR DESCRIPTION
Log string removal is by default enabled for RISCV and Cortex-M and support is added to the default linker template. However, if SoC is not using default linker template then DEVNULL_REGION is not defined. In that case string removal cannot be used.

Fixes #65192.