### PR TITLE
USB docs and samples: Replace native_posix w native_sim 

### DIFF
--- a/boards/posix/native_sim/doc/index.rst
+++ b/boards/posix/native_sim/doc/index.rst
@@ -390,7 +390,7 @@ The following peripherals are currently provided with this board:
 **USB controller**
   It's possible to use the Virtual USB controller working over USB/IP
   protocol. More information can be found in
-  :ref:`Testing USB over USP/IP in native_posix <testing_USB_native_posix>`.
+  :ref:`Testing USB over USP/IP in native_sim <testing_USB_native_sim>`.
 
 **Display driver**
   A display driver is provided that creates a window on the host machine to

--- a/doc/connectivity/usb/device/usb_device.rst
+++ b/doc/connectivity/usb/device/usb_device.rst
@@ -445,14 +445,14 @@ the vendor requests:
 The class driver waits for the :makevar:`USB_DC_CONFIGURED` device status code
 before transmitting any data.
 
-.. _testing_USB_native_posix:
+.. _testing_USB_native_sim:
 
-Testing over USPIP in native_posix
-***********************************
+Testing over USPIP in native_sim
+********************************
 
 A virtual USB controller implemented through USBIP might be used to test the USB
 device stack. Follow the general build procedure to build the USB sample for
-the native_posix configuration.
+the :ref:`native_sim <native_sim>` configuration.
 
 Run built sample with:
 

--- a/samples/subsys/usb/cdc_acm/sample.yaml
+++ b/samples/subsys/usb/cdc_acm/sample.yaml
@@ -41,4 +41,4 @@ tests:
     arch_allow: posix
     build_only: true
     integration_platforms:
-      - native_posix
+      - native_sim

--- a/samples/subsys/usb/console/sample.yaml
+++ b/samples/subsys/usb/console/sample.yaml
@@ -6,9 +6,6 @@ tests:
       - usb_device
       - usb_cdc
     tags: usb
-    platform_exclude:
-      - native_posix
-      - native_posix_64
     harness: console
     harness_config:
       fixture: fixture_usb_cdc

--- a/samples/subsys/usb/hid/sample.yaml
+++ b/samples/subsys/usb/hid/sample.yaml
@@ -17,6 +17,8 @@ tests:
     platform_allow:
       - native_posix
       - native_posix_64
+      - native_sim
+      - native_sim_64
     build_only: true
     integration_platforms:
-      - native_posix
+      - native_sim


### PR DESCRIPTION
In the docs replace references to native_posix with native_sim
For tests and samples that today have test filters for native_posix, add filters for native_sim.
Switch the default test platform to native_sim from native_posix

Background: during this release native_sim is replacing native_posix as the main host test/development platform.

Doc preview in: https://builds.zephyrproject.io/zephyr/pr/65227/docs/index.html
