### PR TITLE
drivers: stm32: use IF_ENABLED() macro in config structs

### DIFF
--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -688,20 +688,6 @@ static const struct dma_driver_api dma_funcs = {
 	.get_status	 = dma_stm32_get_status,
 };
 
-#ifdef CONFIG_DMAMUX_STM32
-#define DMA_STM32_OFFSET_INIT(index)			\
-	.offset = DT_INST_PROP(index, dma_offset),
-#else
-#define DMA_STM32_OFFSET_INIT(index)
-#endif /* CONFIG_DMAMUX_STM32 */
-
-#ifdef CONFIG_DMA_STM32_V1
-#define DMA_STM32_MEM2MEM_INIT(index)					\
-	.support_m2m = DT_INST_PROP(index, st_mem2mem),
-#else
-#define DMA_STM32_MEM2MEM_INIT(index)
-#endif /* CONFIG_DMA_STM32_V1 */					\
-
 #define DMA_STM32_INIT_DEV(index)					\
 static struct dma_stm32_stream						\
 	dma_stm32_streams_##index[DMA_STM32_##index##_STREAM_COUNT];	\
@@ -711,10 +697,12 @@ const struct dma_stm32_config dma_stm32_config_##index = {		\
 		    .enr = DT_INST_CLOCKS_CELL(index, bits) },		\
 	.config_irq = dma_stm32_config_irq_##index,			\
 	.base = DT_INST_REG_ADDR(index),				\
-	DMA_STM32_MEM2MEM_INIT(index)					\
+	IF_ENABLED(CONFIG_DMA_STM32_V1,					\
+		(.support_m2m = DT_INST_PROP(index, st_mem2mem),))	\
 	.max_streams = DMA_STM32_##index##_STREAM_COUNT,		\
 	.streams = dma_stm32_streams_##index,				\
-	DMA_STM32_OFFSET_INIT(index)					\
+	IF_ENABLED(CONFIG_DMAMUX_STM32,					\
+		(.offset = DT_INST_PROP(index, dma_offset),))		\
 };									\
 									\
 static struct dma_stm32_data dma_stm32_data_##index = {			\

--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -489,30 +489,12 @@ static void i2c_stm32_irq_config_func_##index(const struct device *dev)	\
 
 #endif /* CONFIG_I2C_STM32_INTERRUPT */
 
-#if CONFIG_I2C_STM32_BUS_RECOVERY
-#define I2C_STM32_SCL_INIT(n) .scl = GPIO_DT_SPEC_INST_GET_OR(n, scl_gpios, {0}),
-#define I2C_STM32_SDA_INIT(n) .sda = GPIO_DT_SPEC_INST_GET_OR(n, sda_gpios, {0}),
-#else
-#define I2C_STM32_SCL_INIT(n)
-#define I2C_STM32_SDA_INIT(n)
-#endif /* CONFIG_I2C_STM32_BUS_RECOVERY */
-
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_i2c_v2)
-#define DEFINE_TIMINGS(index)						\
-	static const uint32_t i2c_timings_##index[] =			\
-		DT_INST_PROP_OR(index, timings, {});
-#define USE_TIMINGS(index)						\
-	.timings = (const struct i2c_config_timing *) i2c_timings_##index, \
-	.n_timings = ARRAY_SIZE(i2c_timings_##index),
-#else /* V2 */
-#define DEFINE_TIMINGS(index)
-#define USE_TIMINGS(index)
-#endif /* V2 */
-
 #define STM32_I2C_INIT(index)						\
 STM32_I2C_IRQ_HANDLER_DECL(index);					\
 									\
-DEFINE_TIMINGS(index)							\
+IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(st_stm32_i2c_v2),			\
+	(static const uint32_t i2c_timings_##index[] =			\
+		DT_INST_PROP_OR(index, timings, {});))			\
 									\
 PINCTRL_DT_INST_DEFINE(index);						\
 									\
@@ -526,9 +508,12 @@ static const struct i2c_stm32_config i2c_stm32_cfg_##index = {		\
 	STM32_I2C_IRQ_HANDLER_FUNCTION(index)				\
 	.bitrate = DT_INST_PROP(index, clock_frequency),		\
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),			\
-	I2C_STM32_SCL_INIT(index)					\
-	I2C_STM32_SDA_INIT(index)					\
-	USE_TIMINGS(index)						\
+	IF_ENABLED(CONFIG_I2C_STM32_BUS_RECOVERY,			\
+		(.scl =	GPIO_DT_SPEC_INST_GET_OR(index, scl_gpios, {0}),\
+		 .sda = GPIO_DT_SPEC_INST_GET_OR(index, sda_gpios, {0}),))\
+	IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(st_stm32_i2c_v2),		\
+		(.timings = (const struct i2c_config_timing *) i2c_timings_##index,\
+		 .n_timings = ARRAY_SIZE(i2c_timings_##index),))	\
 };									\
 									\
 static struct i2c_stm32_data i2c_stm32_dev_data_##index;		\

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -1120,14 +1120,6 @@ static void spi_stm32_irq_config_func_##id(const struct device *dev)		\
 #define SPI_DMA_STATUS_SEM(id)
 #endif
 
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_spi_subghz)
-#define STM32_SPI_USE_SUBGHZSPI_NSS_CONFIG(id)				\
-	.use_subghzspi_nss = DT_INST_PROP_OR(				\
-			id, use_subghzspi_nss, false),
-#else
-#define STM32_SPI_USE_SUBGHZSPI_NSS_CONFIG(id)
-#endif
-
 
 
 #define STM32_SPI_INIT(id)						\
@@ -1144,7 +1136,9 @@ static const struct spi_stm32_config spi_stm32_cfg_##id = {		\
 	.pclk_len = DT_INST_NUM_CLOCKS(id),				\
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(id),			\
 	STM32_SPI_IRQ_HANDLER_FUNC(id)					\
-	STM32_SPI_USE_SUBGHZSPI_NSS_CONFIG(id)				\
+	IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(st_stm32_spi_subghz),	\
+		(.use_subghzspi_nss =					\
+			DT_INST_PROP_OR(id, use_subghzspi_nss, false),))\
 };									\
 									\
 static struct spi_stm32_data spi_stm32_dev_data_##id = {		\


### PR DESCRIPTION
Use the IF_ENABLED() macro to increase readability in some of the STM32 drivers.

Fixes #62962