### PR TITLE
CODEOWNERS: cleanup and remove duplicates

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,7 +11,12 @@
 # add others as needed.
 
 # Do not use wildcard on all source yet
-# *                                        @galak @nashif
+#
+# +++++++++++ NOTE ++++++++++++++++
+#
+# Please use the MAINTAINERS file to add yourself in an area or to add a new
+# component or code. This file is going to be deprecated and currently only had
+# entries that are not covered by the MAINTAINERS file.
 
 /soc/arm/aspeed/                          @aspeeddylan
 /soc/arm/atmel_sam/common/*_sam4l_*.c     @nandojve

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,23 +13,6 @@
 # Do not use wildcard on all source yet
 # *                                        @galak @nashif
 
-/.github/				  @nashif @stephanosio
-/.github/workflows/                       @galak @nashif
-/MAINTAINERS.yml                          @MaureenHelm
-/arch/arc/                                @abrodkin @ruuddw @evgeniy-paltsev
-/arch/arm/                                @MaureenHelm @galak @ioannisg
-/arch/arm/core/cortex_m/cmse/             @ioannisg
-/arch/arm/include/cortex_m/cmse.h         @ioannisg
-/arch/arm/core/cortex_a_r/                @MaureenHelm @galak @ioannisg @bbolen @stephanosio
-/arch/arm64/                              @carlocaione
-/arch/arm64/core/cortex_r/                @povergoing
-/arch/arm64/core/xen/                     @lorc @firscity
-/arch/common/                             @ioannisg @andyross
-/arch/mips/                               @frantony
-/soc/arc/snps_*/                          @abrodkin @ruuddw @evgeniy-paltsev
-/soc/nios2/                               @nashif
-/soc/arm/                                 @MaureenHelm @galak @ioannisg
-/soc/arm/arm/mps2/                        @fvincenzo
 /soc/arm/aspeed/                          @aspeeddylan
 /soc/arm/atmel_sam/common/*_sam4l_*.c     @nandojve
 /soc/arm/atmel_sam/sam3x/                 @ioannisg
@@ -38,18 +21,9 @@
 /soc/arm/atmel_sam/sam4s/                 @fallrisk
 /soc/arm/atmel_sam/same70/                @nandojve
 /soc/arm/atmel_sam/samv71/                @nandojve
-/soc/arm/cypress/                         @ifyall @npal-cy
 /soc/arm/bcm*/                            @sbranden
-/soc/arm/gigadevice/                      @nandojve
 /soc/arm/infineon_cat1/                   @ifyall @npal-cy
 /soc/arm/infineon_xmc/                    @parthitce
-/soc/arm/nxp*/                            @mmahadevan108 @dleach02
-/soc/arm/nxp_s32/                         @manuargue
-/soc/arm/nordic_nrf/                      @anangl
-/soc/arm/nuvoton_npcx/                    @MulinChao @ChiHuaL
-/soc/arm/nuvoton_numicro/                 @ssekar15
-/soc/arm/quicklogic_eos_s3/               @fkokosinski @kgugala
-/soc/arm/rpi_pico/                        @yonsch
 /soc/arm/silabs_exx32/efm32pg1b/          @rdmeneze
 /soc/arm/silabs_exx32/efr32mg21/          @l-alfred
 /soc/arm/st_stm32/                        @erwango
@@ -63,37 +37,11 @@
 /soc/arm/xilinx_zynq7000/                 @ibirnbaum
 /soc/arm/xilinx_zynqmp/                   @stephanosio
 /soc/arm/renesas_rcar/                    @aaillet
-/soc/arm64/                               @carlocaione
-/soc/arm64/qemu_cortex_a53/               @carlocaione
-/soc/arm64/bcm_vk/                        @abhishek-brcm
-/soc/arm64/nxp_layerscape/                @JiafeiPan
-/soc/arm64/xenvm/                         @lorc @firscity
-/soc/arm64/nxp_imx/                       @MrVan @JiafeiPan
-/soc/arm64/arm/                           @povergoing
-/soc/arm64/arm/fvp_aemv8a/                @carlocaione
-/soc/arm64/intel_socfpga/*                @siclim
-/soc/arm64/renesas_rcar/                  @lorc @xakep-amatop
-/soc/Kconfig                              @tejlmand @galak @nashif @nordicjm
-/submanifests/*                           @mbolivar-ampere
-/arch/x86/                                @jhedberg @nashif
-/arch/nios2/                              @nashif
-/arch/posix/                              @aescolar @daor-oti
-/arch/riscv/                              @kgugala @pgielda
-/soc/mips/                                @frantony
-/soc/posix/                               @aescolar @daor-oti
-/soc/riscv/                               @kgugala @pgielda
 /soc/riscv/openisa*/                      @dleach02
 /soc/riscv/riscv-privileged/andes_v5/      @cwshu @kevinwang821020 @jimmyzhe
 /soc/riscv/riscv-privileged/neorv32/       @henrikbrixandersen
 /soc/riscv/riscv-privileged/gd32vf103/     @soburi
 /soc/riscv/riscv-privileged/niosv/         @sweeaun
-/soc/x86/                                 @dcpleung @nashif
-/arch/xtensa/                             @dcpleung @andyross @nashif
-/soc/xtensa/                              @dcpleung @andyross @nashif
-/arch/sparc/                              @julius-barendt
-/soc/sparc/                               @julius-barendt
-/boards/arc/                              @abrodkin @ruuddw @evgeniy-paltsev
-/boards/arm/                              @MaureenHelm @galak
 /boards/arm/96b_argonkey/                 @avisconti
 /boards/arm/96b_avenger96/                @Mani-Sadhasivam
 /boards/arm/96b_carbon/                   @idlethread
@@ -102,7 +50,6 @@
 /boards/arm/96b_neonkey/                  @Mani-Sadhasivam
 /boards/arm/96b_stm32_sensor_mez/         @Mani-Sadhasivam
 /boards/arm/96b_wistrio/                  @Mani-Sadhasivam
-/boards/arm/arduino_due/                  @ioannisg
 /boards/arm/acn52832/                     @sven-hm
 /boards/arm/arduino_mkrzero/              @soburi
 /boards/arm/bbc_microbit_v2/              @LingaoM
@@ -168,15 +115,7 @@
 /boards/arm/rcar_*/                       @aaillet
 /boards/arm/ubx_bmd345eval_nrf52840/      @Navin-Sankar @brec-u-blox
 /boards/arm/nrf5340_audio_dk_nrf5340      @koffes @alexsven @erikrobstad @rick1082 @gWacey
-/boards/common/                           @mbolivar-ampere
-/boards/deprecated.cmake                  @tejlmand
-/boards/mips/                             @frantony
-/boards/nios2/                            @nashif
-/boards/nios2/altera_max10/               @nashif
 /boards/arm/stm32_min_dev/                @sidcha
-/boards/posix/                            @aescolar @daor-oti
-/boards/posix/nrf52_bsim/                 @aescolar @wopu-ot
-/boards/riscv/                            @kgugala @pgielda
 /boards/riscv/rv32m1_vega/                @dleach02
 /boards/riscv/adp_xc7k_ae350/             @cwshu @kevinwang821020 @jimmyzhe
 /boards/riscv/longan_nano/                @soburi
@@ -184,16 +123,11 @@
 /boards/riscv/niosv*/                     @sweeaun
 /boards/riscv/sparkfun_red_v_things_plus/ @soburi
 /boards/riscv/stamp_c3/                   @soburi
-/boards/shields/                          @erwango
 /boards/shields/atmel_rf2xx/              @nandojve
 /boards/shields/esp_8266/                 @nandojve
 /boards/shields/inventek_eswifi/          @nandojve
-/boards/x86/                              @dcpleung @nashif
-/boards/x86/acrn/                         @enjiamai
-/boards/xtensa/                           @nashif @dcpleung
 /boards/xtensa/odroid_go/                 @ydamigos
 /boards/xtensa/nxp_adsp_imx8/             @iuliana-prodan @dbaluta
-/boards/sparc/                            @julius-barendt
 /boards/arm64/qemu_cortex_a53/            @carlocaione
 /boards/arm64/bcm958402m2_a72/            @abhishek-brcm
 /boards/arm64/mimx8mm_evk/                @MrVan @JiafeiPan
@@ -207,25 +141,13 @@
 /boards/arm64/intel_socfpga_agilex_socdk/ @siclim @ngboonkhai
 /boards/arm64/intel_socfpga_agilex5_socdk/ @chongteikheng
 /boards/arm64/rcar_*/                     @lorc @xakep-amatop
-/boards/Kconfig                           @tejlmand @galak @nashif @nordicjm
 # All cmake related files
-/cmake/                                   @tejlmand @nashif
-/cmake/*/arcmwdt/                         @abrodkin @evgeniy-paltsev @tejlmand
-/CMakeLists.txt                           @tejlmand @nashif
-/doc/                                     @carlescufi
 /doc/develop/tools/coccinelle.rst                @himanshujha199640 @JuliaLawall
 /doc/services/device_mgmt/smp_protocol.rst  @de-nordic @nordicjm
 /doc/services/device_mgmt/smp_groups/       @de-nordic @nordicjm
 /doc/services/sensing/                      @lixuzha @ghu0510 @qianruh
 /doc/CMakeLists.txt                       @carlescufi
 /doc/_scripts/                            @carlescufi
-/doc/connectivity/bluetooth/                    @alwa-nordic @jhedberg @Vudentz
-/doc/connectivity/networking/conn_mgr     @carlescufi @glarsennordic
-/doc/build/dts/                          @galak @mbolivar-ampere
-/doc/build/sysbuild/                      @tejlmand @nordicjm
-/doc/hardware/peripherals/canbus/                    @alexanderwachter @henrikbrixandersen
-/doc/security/                            @ceolin @d3zd3z
-/drivers/debug/                           @nashif
 /drivers/*/*sam4l*                        @nandojve
 /drivers/*/*cc13xx_cc26xx*                @bwitherspoon
 /drivers/*/*gd32*                         @nandojve
@@ -239,7 +161,6 @@
 /drivers/*/*ifx_cat1*                     @ifyall @npal-cy
 /drivers/*/*neorv32*                      @henrikbrixandersen
 /drivers/*/*_s32*                         @manuargue
-/drivers/adc/                             @anangl
 /drivers/adc/adc_ads1x1x.c                @XenuIsWatching
 /drivers/adc/adc_stm32.c                  @cybertale
 /drivers/adc/adc_rpi_pico.c               @soburi
@@ -252,16 +173,12 @@
 /drivers/bbram/*                          @yperess @sjg20 @jackrosenthal
 /drivers/bluetooth/                       @alwa-nordic @jhedberg @Vudentz
 /drivers/bluetooth/hci/hci_esp32.c        @sylvioalves
-/drivers/cache/                           @carlocaione
-/drivers/syscon/                          @carlocaione @yperess
-/drivers/can/                             @alexanderwachter @henrikbrixandersen
 /drivers/can/*mcp2515*                    @karstenkoenig
 /drivers/can/*rcar*                       @aaillet
 /drivers/clock_control/*agilex*           @siclim @gdengi
 /drivers/clock_control/*nrf*              @nordic-krch
 /drivers/clock_control/*esp32*            @extremegtx @sylvioalves
 /drivers/clock_control/*cpg_mssr*         @aaillet
-/drivers/counter/                         @nordic-krch
 /drivers/console/ipm_console.c            @finikorg
 /drivers/console/semihost_console.c       @luozhongyao
 /drivers/console/jailhouse_debug_console.c @MrVan
@@ -273,7 +190,6 @@
 /drivers/crypto/*nrf_ecb*                 @maciekfabia @anangl
 /drivers/display/*rm68200*                @mmahadevan108
 /drivers/display/display_ili9342c.*       @extremegtx
-/drivers/dac/                             @martinjaeger
 /drivers/dac/*ad56xx*                     @benediktibk
 /drivers/dac/dac_ad5592.c                 @bbilas
 /drivers/dai/                             @kv2019i @marcinszkudlinski @abonislawski
@@ -290,15 +206,11 @@
 /drivers/dma/*intel_adsp*                 @teburd @abonislawski
 /drivers/dma/*rpi_pico*                   @soburi
 /drivers/dma/*xmc4xxx*                    @talih0
-/drivers/edac/                            @finikorg
-/drivers/eeprom/                          @henrikbrixandersen
 /drivers/eeprom/eeprom_stm32.c            @KwonTae-young
 /drivers/entropy/*b91*                    @andy-liu-telink
 /drivers/entropy/*bt_hci*                 @JordanYates
 /drivers/entropy/*rv32m1*                 @dleach02
 /drivers/entropy/*litex*                  @mateusz-holenko @kgugala @pgielda
-/drivers/espi/                            @albertofloyd @franciscomunoz @sjvasanth1
-/drivers/ethernet/                        @tbursztyka @jukkar
 /drivers/ethernet/*dwmac*                 @npitre
 /drivers/ethernet/*stm32*                 @Nukersson @lochej
 /drivers/ethernet/*w5500*                 @parthitce
@@ -309,17 +221,13 @@
 /drivers/ethernet/*lan865x*               @lmajewski
 /drivers/ethernet/phy/                    @rlubos @tbursztyka @arvinf @jukkar
 /drivers/ethernet/phy/*adin2111*          @GeorgeCGV
-/drivers/mdio/                            @rlubos @tbursztyka @arvinf
 /drivers/mdio/*adin2111*                  @GeorgeCGV
-/drivers/flash/                           @nashif @de-nordic
 /drivers/flash/*stm32_qspi*               @lmajewski
 /drivers/flash/*b91*                      @andy-liu-telink
 /drivers/flash/*cadence*                  @ngboonkhai
 /drivers/flash/*cc13xx_cc26xx*            @pepe2k
 /drivers/flash/*nrf*                      @de-nordic
 /drivers/flash/*esp32*                    @sylvioalves
-/drivers/fpga/                            @tgorochowik @kgugala
-/drivers/gpio/                            @mnkp
 /drivers/gpio/*b91*                       @andy-liu-telink
 /drivers/gpio/*lmp90xxx*                  @henrikbrixandersen
 /drivers/gpio/*nct38xx*                   @MulinChao @ChiHuaL
@@ -334,7 +242,6 @@
 /drivers/gpio/*pcal64xxa*                 @benediktibk
 /drivers/gpio/gpio_altera_pio.c           @shilinte
 /drivers/gpio/gpio_ad5592.c               @bbilas
-/drivers/hwinfo/                          @alexanderwachter
 /drivers/i2c/i2c_common.c                 @sjg20
 /drivers/i2c/i2c_emul.c                   @sjg20
 /drivers/i2c/i2c_ite_enhance.c            @GTLin08
@@ -349,7 +256,6 @@
 /drivers/i2s/*litex*                      @mateusz-holenko @kgugala @pgielda
 /drivers/i2s/i2s_ll_stm32*                @avisconti
 /drivers/i2s/*nrfx*                       @anangl
-/drivers/i3c/                             @dcpleung
 /drivers/i3c/i3c_cdns.c                   @XenuIsWatching
 /drivers/ieee802154/                      @rlubos @tbursztyka @jukkar @fgrandel
 /drivers/ieee802154/*b91*                 @andy-liu-telink
@@ -370,33 +276,22 @@
 /drivers/ipm/ipm_stm32_hsem.c             @cameled
 /drivers/ipm/ipm_esp32.c                  @uLipe
 /drivers/ipm/ipm_ivshmem.c                @uLipe
-/drivers/kscan/                           @VenkatKotakonda @franciscomunoz @sjvasanth1
 /drivers/kscan/*xec*                      @franciscomunoz @sjvasanth1
 /drivers/kscan/*ft5336*                   @MaureenHelm
 /drivers/kscan/*ht16k33*                  @henrikbrixandersen
-/drivers/led/                             @Mani-Sadhasivam
 /drivers/led_strip/                       @mbolivar-ampere
-/drivers/lora/                            @Mani-Sadhasivam
-/drivers/mbox/                            @carlocaione
 /drivers/mfd/mfd_ad5592.c                 @bbilas
 /drivers/mfd/mfd_max20335.c               @bbilas
-/drivers/misc/                            @tejlmand
 /drivers/misc/ft8xx/                      @hubertmis
-/drivers/mm/                              @dcpleung
 /drivers/modem/hl7800.c                   @rerickson1
 /drivers/modem/simcom-sim7080.c           @lgehreke
 /drivers/modem/simcom-sim7080.h           @lgehreke
 /drivers/modem/Kconfig.hl7800             @rerickson1
 /drivers/modem/Kconfig.simcom-sim7080     @lgehreke
-/drivers/pcie/                            @dcpleung @nashif @jhedberg
-/drivers/peci/                            @albertofloyd @franciscomunoz @sjvasanth1
-/drivers/pinctrl/                         @gmarull
 /drivers/pinctrl/*esp32*                  @sylvioalves
 /drivers/pinctrl/*it8xxx2*                @ite
-/drivers/pm_cpu_ops/                      @carlocaione @gdengi
 /drivers/pm_cpu_ops/psci_shell.c          @nbalabak @gdengi
 /drivers/power_domain/                    @ceolin
-/drivers/ps2/                             @franciscomunoz @sjvasanth1
 /drivers/ps2/*xec*                        @franciscomunoz @sjvasanth1
 /drivers/ps2/*npcx*                       @MulinChao @ChiHuaL
 /drivers/pwm/*b91*                        @andy-liu-telink
@@ -418,10 +313,8 @@
 /drivers/regulator/regulator_pca9420.c    @danieldegrasse
 /drivers/regulator/regulator_rpi_pico.c   @soburi
 /drivers/regulator/regulator_shell.c      @danieldegrasse
-/drivers/reset/                           @andrei-edward-popa
 /drivers/reset/reset_intel_socfpga.c      @nbalabak
 /drivers/reset/Kconfig.intel_socfpga      @nbalabak
-/drivers/sensor/                          @MaureenHelm
 /drivers/sensor/ams_iAQcore/              @alexanderwachter
 /drivers/sensor/ens210/                   @alexanderwachter
 /drivers/sensor/grow_r502a/               @DineshDK03
@@ -452,29 +345,19 @@
 /drivers/serial/*numicro*                 @ssekar15
 /drivers/serial/*apbuart*                 @julius-barendt
 /drivers/serial/*rcar*                    @aaillet
-/drivers/serial/Kconfig.test              @str4t0m
-/drivers/serial/serial_test.c             @str4t0m
 /drivers/serial/Kconfig.xen               @lorc @firscity
 /drivers/serial/uart_hvc_xen.c            @lorc @firscity
 /drivers/serial/uart_hvc_xen_consoleio.c  @lorc @firscity
 /drivers/serial/Kconfig.it8xxx2           @GTLin08
 /drivers/serial/uart_ite_it8xxx2.c        @GTLin08
 /drivers/serial/*intel_lw*                @shilinte
-/drivers/smbus/                           @finikorg
-/drivers/sip_svc/                         @maheshraotm
-/drivers/disk/                            @jfischer-no
 /drivers/disk/sdmmc_sdhc.h                @JunYangNXP
 /drivers/disk/sdmmc_stm32.c               @anthonybrandon
-/drivers/net/                             @rlubos @tbursztyka @jukkar
 /drivers/ptp_clock/                       @tbursztyka @jukkar
-/drivers/spi/                             @tbursztyka
 /drivers/spi/*b91*                        @andy-liu-telink
 /drivers/spi/spi_rv32m1_lpspi*            @karstenkoenig
 /drivers/spi/*esp32*                      @sylvioalves
 /drivers/spi/*pl022*                      @soburi
-/drivers/sdhc/                            @danieldegrasse
-/drivers/timer/*apic*                     @dcpleung @nashif
-/drivers/timer/apic_tsc.c                 @andyross
 /drivers/timer/*arm_arch*                 @carlocaione
 /drivers/timer/*cortex_m_systick*         @anangl
 /drivers/timer/*altera_avalon*            @nashif
@@ -494,10 +377,7 @@
 /drivers/timer/*rv32m1_lptmr*             @mbolivar
 /drivers/timer/*nrf_rtc*                  @anangl
 /drivers/timer/*hpet*                     @dcpleung
-/drivers/usb/                             @jfischer-no
 /drivers/usb/device/usb_dc_stm32.c        @ydamigos @loicpoulain
-/drivers/usb_c/                           @sambhurst
-/drivers/video/                           @loicpoulain
 /drivers/i2c/*b91*                        @andy-liu-telink
 /drivers/i2c/i2c_ll_stm32*                @ydamigos
 /drivers/i2c/i2c_rv32m1_lpi2c*            @henrikbrixandersen
@@ -505,7 +385,6 @@
 /drivers/i2c/i2c_dw*                      @dcpleung
 /drivers/i2c/*tca954x*                    @kurddt
 /drivers/*/*xec*                          @franciscomunoz @albertofloyd @sjvasanth1
-/drivers/w1/                              @str4t0m
 /drivers/watchdog/*gecko*                 @oanerer
 /drivers/watchdog/*sifive*                @katsuster
 /drivers/watchdog/wdt_handlers.c          @dcpleung @nashif
@@ -516,12 +395,10 @@
 /drivers/watchdog/*rpi_pico*              @thedjnK
 /drivers/watchdog/*dw*                    @softwarecki
 /drivers/watchdog/*ifx*                   @sreeramIfx
-/drivers/wifi/                            @rlubos @tbursztyka @jukkar
 /drivers/wifi/esp_at/                     @mniestroj
 /drivers/wifi/eswifi/                     @loicpoulain @nandojve
 /drivers/wifi/winc1500/                   @kludentwo
 /drivers/virtualization/		  @tbursztyka
-/drivers/xen/                             @lorc @firscity
 /dts/arc/                                 @abrodkin @ruuddw @iriszzw @evgeniy-paltsev
 /dts/arm/acsip/                           @NorthernDean
 /dts/arm/aspeed/                          @aspeeddylan
@@ -537,7 +414,6 @@
 /dts/arm/gigadevice/                      @nandojve
 /dts/arm/infineon/xmc4*                   @parthitce @ifyall @npal-cy
 /dts/arm/infineon/psoc6/                  @ifyall @npal-cy
-/dts/arm64/                               @carlocaione
 /dts/arm64/armv8-r.dtsi                   @povergoing
 /dts/arm64/intel/*intel_socfpga*          @siclim
 /dts/arm64/nxp/                           @JiafeiPan
@@ -564,7 +440,6 @@
 /dts/arm/silabs/efm32pg1b*                @rdmeneze
 /dts/arm/silabs/efr32mg21*                @l-alfred
 /dts/arm/silabs/efr32fg13*                @yonsch
-/dts/riscv/                               @kgugala @pgielda
 /dts/riscv/ite/                           @ite
 /dts/riscv/microchip/microchip-miv.dtsi   @galak
 /dts/riscv/openisa/rv32m1*                @dleach02
@@ -577,13 +452,10 @@
 /dts/arm/armv7-r.dtsi                     @bbolen @stephanosio
 /dts/arm/xilinx/                          @bbolen @stephanosio
 /dts/arm/renesas/rcar/                    @aaillet
-/dts/x86/                                 @jhedberg
 /dts/xtensa/xtensa.dtsi                   @ydamigos
 /dts/xtensa/intel/                        @dcpleung
 /dts/xtensa/espressif/                    @sylvioalves
 /dts/xtensa/nxp/                          @iuliana-prodan @dbaluta
-/dts/sparc/                               @julius-barendt
-/dts/bindings/                            @galak
 /dts/bindings/can/                        @alexanderwachter @henrikbrixandersen
 /dts/bindings/i2c/zephyr*i2c-emul*.yaml   @sjg20
 /dts/bindings/adc/st*stm32-adc.yaml       @cybertale
@@ -615,7 +487,6 @@
 /dts/bindings/ethernet/*gem.yaml          @ibirnbaum
 /dts/bindings/auxdisplay/*pt6314.yaml     @xingrz
 /dts/bindings/auxdisplay/*                 @thedjnK
-/dts/posix/                               @aescolar @daor-oti
 /dts/bindings/sensor/*bme680*             @BoschSensortec
 /dts/bindings/sensor/*ina23*              @bbilas
 /dts/bindings/sensor/st*                  @avisconti
@@ -630,343 +501,3 @@
 /dts/bindings/gpio/*ads114s0x*            @benediktibk
 /dts/bindings/pwm/*max31790*              @benediktibk
 /dts/bindings/dac/*ad56*                  @benediktibk
-/dts/common/                              @galak
-/include/                                 @nashif @carlescufi @galak @MaureenHelm
-/include/zephyr/drivers/*/*litex*                @mateusz-holenko @kgugala @pgielda
-/include/zephyr/drivers/adc.h                    @anangl
-/include/zephyr/drivers/adc/ads114s0x.h   @benediktibk
-/include/zephyr/drivers/auxdisplay.h       @thedjnK
-/include/zephyr/drivers/can.h                    @alexanderwachter @henrikbrixandersen
-/include/zephyr/drivers/can/                     @alexanderwachter @henrikbrixandersen
-/include/zephyr/drivers/counter.h                @nordic-krch
-/include/zephyr/drivers/dac.h                    @martinjaeger
-/include/zephyr/drivers/espi.h                   @albertofloyd @franciscomunoz @sjvasanth1
-/include/zephyr/drivers/bluetooth/               @alwa-nordic @jhedberg @Vudentz
-/include/zephyr/drivers/flash.h                  @nashif @carlescufi @galak @MaureenHelm @de-nordic
-/include/zephyr/drivers/i2c_emul.h               @sjg20
-/include/zephyr/drivers/i3c.h                    @dcpleung
-/include/zephyr/drivers/i3c/                     @dcpleung
-/include/zephyr/drivers/led/ht16k33.h            @henrikbrixandersen
-/include/zephyr/drivers/interrupt_controller/    @dcpleung @nashif
-/include/zephyr/drivers/interrupt_controller/gic.h @stephanosio
-/include/zephyr/drivers/modem/hl7800.h           @rerickson1
-/include/zephyr/drivers/pcie/                    @dcpleung
-/include/zephyr/drivers/hwinfo.h                 @alexanderwachter
-/include/zephyr/drivers/led.h                    @Mani-Sadhasivam
-/include/zephyr/drivers/led_strip.h              @mbolivar-ampere
-/include/zephyr/drivers/sensor.h                 @MaureenHelm
-/include/zephyr/drivers/smbus.h                  @finikorg
-/include/zephyr/drivers/spi.h                    @tbursztyka
-/include/zephyr/drivers/sip_svc/                 @maheshraotm
-/include/zephyr/drivers/lora.h                   @Mani-Sadhasivam
-/include/zephyr/drivers/peci.h                   @albertofloyd @franciscomunoz @sjvasanth1
-/include/zephyr/drivers/pm_cpu_ops.h             @carlocaione
-/include/zephyr/drivers/pm_cpu_ops/              @carlocaione
-/include/zephyr/drivers/w1.h                     @str4t0m
-/include/zephyr/drivers/pwm/max31790.h           @benediktibk
-/include/zephyr/app_memory/                      @dcpleung
-/include/zephyr/arch/arc/                        @abrodkin @ruuddw @evgeniy-paltsev
-/include/zephyr/arch/arc/arch.h                  @abrodkin @ruuddw @evgeniy-paltsev
-/include/zephyr/arch/arc/v2/irq.h                @abrodkin @ruuddw @evgeniy-paltsev
-/include/zephyr/arch/arm                         @MaureenHelm @galak @ioannisg
-/include/zephyr/arch/arm/cortex_a_r/             @stephanosio
-/include/zephyr/arch/arm64/                      @carlocaione
-/include/zephyr/arch/arm64/cortex_r/             @povergoing
-/include/zephyr/arch/arm/irq.h                   @carlocaione
-/include/zephyr/arch/mips/                       @frantony
-/include/zephyr/arch/nios2/                      @nashif
-/include/zephyr/arch/nios2/arch.h                @nashif
-/include/zephyr/arch/posix/                      @aescolar @daor-oti
-/include/zephyr/arch/riscv/                      @kgugala @pgielda
-/include/zephyr/arch/x86/                        @jhedberg @dcpleung
-/include/zephyr/arch/common/                     @andyross @nashif
-/include/zephyr/arch/xtensa/                     @andyross @dcpleung
-/include/zephyr/arch/sparc/                      @julius-barendt
-/include/zephyr/sys/atomic.h                     @andyross
-/include/zephyr/bluetooth/                       @alwa-nordic @jhedberg @Vudentz @sjanc
-/include/zephyr/bluetooth/audio/                 @jhedberg @Vudentz @Thalley
-/include/zephyr/cache.h                          @carlocaione @andyross
-/include/zephyr/canbus/                          @alexanderwachter @henrikbrixandersen
-/include/zephyr/tracing/                         @nashif
-/include/zephyr/debug/                           @nashif
-/include/zephyr/debug/coredump.h                 @dcpleung
-/include/zephyr/debug/gdbstub.h                  @ceolin
-/include/zephyr/device.h                         @tbursztyka @nashif
-/include/zephyr/devicetree.h                     @galak
-/include/zephyr/devicetree/can.h                 @henrikbrixandersen
-/include/zephyr/dt-bindings/clock/kinetis_mcg.h  @henrikbrixandersen
-/include/zephyr/dt-bindings/clock/kinetis_scg.h  @henrikbrixandersen
-/include/zephyr/dt-bindings/ethernet/xlnx_gem.h  @ibirnbaum
-/include/zephyr/dt-bindings/pcie/                @dcpleung
-/include/zephyr/dt-bindings/pinctrl/esp*         @sylvioalves
-/include/zephyr/dt-bindings/pwm/*it8xxx2*        @RuibinChang
-/include/zephyr/dt-bindings/usb/usb.h            @galak
-/include/zephyr/dt-bindings/adc/ads114s0x_adc.h  @benediktibk
-/include/zephyr/drivers/emul.h                   @sjg20
-/include/zephyr/data/                            @d3zd3z
-/include/zephyr/fs/                              @nashif @de-nordic
-/include/zephyr/init.h                           @nashif @andyross
-/include/zephyr/irq.h                            @dcpleung @nashif @andyross
-/include/zephyr/irq_offload.h                    @dcpleung @nashif @andyross
-/include/zephyr/kernel.h                         @dcpleung @nashif @andyross
-/include/zephyr/kernel_version.h                 @dcpleung @nashif @andyross
-/include/zephyr/linker/app_smem*.ld              @dcpleung @nashif
-/include/zephyr/linker/                          @dcpleung @nashif @andyross
-/include/zephyr/logging/                         @nordic-krch
-/include/zephyr/lorawan/lorawan.h                @Mani-Sadhasivam
-/include/zephyr/mgmt/osdp.h                      @sidcha
-/include/zephyr/mgmt/mcumgr/                     @nordicjm
-/include/zephyr/net/                             @rlubos @tbursztyka @jukkar
-/include/zephyr/net/buf.h                        @jhedberg @tbursztyka @rlubos @jukkar
-/include/zephyr/net/coap*.h                      @rlubos
-/include/zephyr/net/conn_mgr*.h                  @rlubos @glarsennordic @jukkar
-/include/zephyr/net/gptp.h                       @rlubos @jukkar @fgrandel
-/include/zephyr/net/ieee802154*.h                @rlubos @tbursztyka @jukkar @fgrandel
-/include/zephyr/net/lwm2m*.h                     @rlubos
-/include/zephyr/net/mqtt.h                       @rlubos
-/include/zephyr/net/mqtt_sn.h                    @rlubos @BeckmaR
-/include/zephyr/net/net_pkt_filter.h             @npitre
-/include/zephyr/posix/                           @cfreidt
-/include/zephyr/pm/pm.h                          @nashif @ceolin
-/include/zephyr/drivers/ptp_clock.h              @tbursztyka @jukkar
-/include/zephyr/rtio/                            @teburd
-/include/zephyr/sensing/                           @lixuzha @ghu0510 @qianruh
-/include/zephyr/shared_irq.h                     @dcpleung @nashif @andyross
-/include/zephyr/shell/                           @jakub-uC @nordic-krch
-/include/zephyr/shell/shell_mqtt.h               @ycsin
-/include/zephyr/sw_isr_table.h                   @dcpleung @nashif @andyross
-/include/zephyr/sd/                              @danieldegrasse
-/include/zephyr/sip_svc/                         @maheshraotm
-/include/zephyr/sys_clock.h                      @dcpleung @nashif @andyross
-/include/zephyr/sys/sys_io.h                     @dcpleung @nashif @andyross
-/include/zephyr/sys/kobject.h                    @dcpleung @nashif
-/include/zephyr/toolchain.h                      @dcpleung @andyross @nashif
-/include/zephyr/toolchain/                       @dcpleung @nashif @andyross
-/include/zephyr/zephyr.h                         @dcpleung @nashif @andyross
-/kernel/                                  @dcpleung @nashif @andyross
-/lib/cpp/                                 @stephanosio
-/lib/smf/                                 @sambhurst
-/lib/util/                                @carlescufi @jakub-uC
-/lib/util/fnmatch/                        @carlescufi @jakub-uC
-/lib/open-amp/                            @arnopo
-/lib/os/                                  @dcpleung @nashif @andyross
-/lib/os/cbprintf_packaged.c               @npitre
-/lib/os/json.c                            @d3zd3z
-/lib/posix/                               @cfriedt
-/lib/posix/getopt/                        @jakub-uC
-/subsys/portability/                      @nashif
-/subsys/sensing/                            @lixuzha @ghu0510 @qianruh
-/lib/libc/                                @nashif
-/lib/libc/arcmwdt/                        @abrodkin @ruuddw @evgeniy-paltsev
-/misc/                                    @tejlmand
-/modules/                                 @nashif
-/modules/canopennode/                     @henrikbrixandersen
-/modules/mbedtls/                         @ceolin @d3zd3z
-/modules/hal_gigadevice/                  @nandojve
-/modules/hal_nordic/nrf_802154/           @jciupis
-/modules/trusted-firmware-m/              @microbuilder
-/kernel/device.c                          @andyross @nashif
-/kernel/idle.c                            @andyross @nashif
-/samples/                                 @nashif
-/samples/application_development/sysbuild/      @tejlmand @nordicjm
-/samples/basic/minimal/                   @carlescufi
-/samples/basic/servo_motor/boards/*microbit* @jhe
-/samples/bluetooth/                       @jhedberg @Vudentz @alwa-nordic @sjanc
-/samples/compression/                     @Navin-Sankar
-/samples/drivers/can/                     @alexanderwachter @henrikbrixandersen
-/samples/drivers/clock_control_litex/     @mateusz-holenko @kgugala @pgielda
-/samples/drivers/eeprom/                  @henrikbrixandersen
-/samples/drivers/ht16k33/                 @henrikbrixandersen
-/samples/drivers/lora/                    @Mani-Sadhasivam
-/samples/drivers/smbus/                   @finikorg
-/samples/subsys/lorawan/                  @Mani-Sadhasivam
-/samples/modules/canopennode/             @henrikbrixandersen
-/samples/net/                             @rlubos @tbursztyka @jukkar
-/samples/net/cloud/tagoio_http_post/      @nandojve
-/samples/net/dns_resolve/                 @rlubos @tbursztyka @jukkar
-/samples/net/gptp/                        @rlubos @jukkar @fgrandel
-/samples/net/lwm2m_client/                @rlubos
-/samples/net/mqtt_publisher/              @rlubos
-/samples/net/mqtt_sn_publisher/           @rlubos @BeckmaR
-/samples/net/sockets/coap_*/              @rlubos
-/samples/net/sockets/                     @rlubos @tbursztyka @jukkar
-/samples/sensor/                          @MaureenHelm
-/samples/shields/                         @avisconti
-/samples/subsys/ipc/ipc_service/icmsg     @emob-nordic
-/samples/subsys/logging/                  @nordic-krch @jakub-uC
-/samples/subsys/logging/syst/             @dcpleung
-/samples/subsys/shell/                    @jakub-uC @nordic-krch @gdengi
-/samples/subsys/sip_svc/                  @maheshraotm
-/samples/subsys/mgmt/mcumgr/              @de-nordic @nordicjm
-/samples/subsys/mgmt/updatehub/           @nandojve @otavio
-/samples/subsys/mgmt/osdp/                @sidcha
-/samples/subsys/usb/                      @jfischer-no
-/samples/subsys/usb_c/                    @sambhurst
-/samples/subsys/pm/                       @nashif @ceolin
-/samples/subsys/sensing/                  @lixuzha @ghu0510 @qianruh
-/samples/tfm_integration/                 @microbuilder
-/samples/userspace/                       @dcpleung @nashif
-/scripts/release/bug_bash.py              @cfriedt
-/scripts/coccicheck                       @himanshujha199640 @JuliaLawall
-/scripts/coccinelle/                      @himanshujha199640 @JuliaLawall
-/scripts/coredump/                        @dcpleung
-/scripts/footprint/                       @nashif
-/scripts/kconfig/                         @ulfalizer
-/scripts/logging/dictionary/              @dcpleung
-/scripts/native_simulator/                @aescolar
-/scripts/pylib/twister/expr_parser.py     @nashif
-/scripts/schemas/twister/                 @nashif
-/scripts/build/gen_app_partitions.py            @dcpleung @nashif
-scripts/build/gen_image_info.py           @tejlmand
-/scripts/get_maintainer.py                @nashif
-/scripts/dts/                             @mbolivar-ampere @galak
-/scripts/release/                         @nashif
-/scripts/ci/                              @nashif
-/scripts/ci/check_compliance.py           @nashif @carlescufi
-/arch/x86/gen_gdt.py                      @dcpleung @nashif
-/arch/x86/gen_idt.py                      @dcpleung @nashif
-/scripts/build/gen_kobject_list.py        @dcpleung @nashif
-/scripts/build/gen_kobject_placeholders.py      @dcpleung
-/scripts/build/gen_syscalls.py            @dcpleung @nashif
-/scripts/list_boards.py                   @mbolivar-ampere
-/scripts/build/process_gperf.py           @dcpleung @nashif
-/scripts/build/gen_relocate_app.py        @dcpleung
-/scripts/generate_usb_vif/                @madhurimaparuchuri
-/scripts/requirements*.txt                @mbolivar-ampere @galak @nashif
-/scripts/tests/build/test_subfolder_list.py @rmstoi
-/scripts/tracing/                         @nashif
-/scripts/pylib/twister/                   @nashif
-/scripts/twister                          @nashif
-/scripts/series-push-hook.sh              @erwango
-/scripts/utils/pinctrl_nrf_migrate.py     @gmarull
-/scripts/utils/migrate_mcumgr_kconfigs.py @de-nordic
-/scripts/west_commands/                   @mbolivar-ampere
-/scripts/west_commands/blobs.py           @carlescufi
-/scripts/west_commands/fetchers/          @carlescufi
-/scripts/west_commands/runners/gd32isp.py @mbolivar-ampere @nandojve
-/scripts/west_commands/tests/test_gd32isp.py @mbolivar-ampere @nandojve
-/scripts/west-commands.yml                @mbolivar-ampere
-/scripts/zephyr_module.py                 @tejlmand
-/scripts/build/uf2conv.py                 @petejohanson
-/scripts/build/user_wordsize.py           @cfriedt
-/scripts/valgrind.supp                    @aescolar @daor-oti
-/share/sysbuild/                          @tejlmand @nordicjm
-/share/zephyr-package/                    @tejlmand
-/share/zephyrunittest-package/            @tejlmand
-/subsys/bluetooth/                        @alwa-nordic @jhedberg @Vudentz
-/subsys/bluetooth/audio/                  @jhedberg @Vudentz @Thalley @sjanc
-/subsys/bluetooth/controller/             @carlescufi @cvinayak @thoh-ot @kruithofa
-/subsys/bluetooth/host/                   @alwa-nordic @jhedberg @Vudentz @sjanc
-/subsys/bluetooth/mesh/                   @jhedberg @PavelVPV @Vudentz @LingaoM
-/subsys/canbus/                           @alexanderwachter @henrikbrixandersen
-/subsys/debug/                            @nashif
-/subsys/debug/coredump/                   @dcpleung
-/subsys/debug/gdbstub/                    @ceolin
-/subsys/debug/gdbstub.c                   @ceolin
-/subsys/dfu/                              @de-nordic @nordicjm
-/subsys/disk/                             @jfischer-no
-/subsys/dsp/                              @yperess
-/subsys/tracing/                          @nashif
-/subsys/debug/asan_hacks.c                @aescolar @daor-oti
-/subsys/demand_paging/                    @dcpleung @nashif
-/subsys/emul/                             @sjg20
-/subsys/fb/                               @jfischer-no
-/subsys/fs/                               @nashif
-/subsys/fs/nvs/                           @Laczen
-/subsys/ipc/                              @carlocaione
-/subsys/ipc/ipc_service/*/*icmsg*         @emob-nordic
-/subsys/jwt/                              @d3zd3z
-/subsys/logging/                          @nordic-krch
-/subsys/logging/backends/log_backend_net.c @nordic-krch @rlubos @jukkar
-/subsys/lorawan/                          @Mani-Sadhasivam
-/subsys/mgmt/ec_host_cmd/                 @jettr
-/subsys/mgmt/mcumgr/                      @carlescufi @de-nordic @nordicjm
-/subsys/mgmt/hawkbit/                     @Navin-Sankar
-/subsys/mgmt/updatehub/                   @nandojve @otavio
-/subsys/mgmt/osdp/                        @sidcha
-/subsys/modbus/                           @jfischer-no
-/subsys/net/buf.c                         @jhedberg @tbursztyka @rlubos @jukkar
-/subsys/net/conn_mgr/                     @rlubos @glarsennordic @jukkar
-/subsys/net/ip/                           @rlubos @tbursztyka @jukkar
-/subsys/net/lib/                          @rlubos @tbursztyka @jukkar
-/subsys/net/lib/dns/                      @rlubos @tbursztyka @cfriedt @jukkar
-/subsys/net/lib/lwm2m/                    @rlubos
-/subsys/net/lib/config/                   @rlubos @tbursztyka @jukkar
-/subsys/net/lib/mqtt/                     @rlubos
-/subsys/net/lib/mqtt_sn/                  @rlubos @BeckmaR
-/subsys/net/lib/coap/                     @rlubos
-/subsys/net/lib/sockets/socketpair.c      @cfriedt
-/subsys/net/lib/sockets/                  @rlubos @tbursztyka @jukkar
-/subsys/net/lib/tls_credentials/          @rlubos
-/subsys/net/l2/                           @rlubos @tbursztyka @jukkar
-/subsys/net/l2/ethernet/gptp/             @rlubos @jukkar @fgrandel
-/subsys/net/l2/ieee802154/                @rlubos @tbursztyka @jukkar @fgrandel
-/subsys/net/l2/canbus/                    @alexanderwachter
-/subsys/net/pkt_filter/                   @npitre
-/subsys/net/*/openthread/                 @rlubos
-/subsys/pm/                               @nashif @ceolin
-/subsys/random/                           @dleach02
-/subsys/shell/                            @jakub-uC @nordic-krch
-/subsys/shell/backends/shell_mqtt.c       @ycsin
-/subsys/sd/                               @danieldegrasse
-/subsys/sip_svc/                          @maheshraotm
-/subsys/task_wdt/                         @martinjaeger
-/subsys/testsuite/                        @nashif
-/subsys/testsuite/ztest/*/ztress*         @nordic-krch
-/subsys/timing/                           @nashif @dcpleung
-/subsys/usb/                              @jfischer-no
-/subsys/usb/usb_c/                        @sambhurst
-/tests/                                   @nashif
-/tests/arch/arm/                          @ioannisg @stephanosio
-/tests/benchmarks/cmsis_dsp/              @stephanosio
-/tests/boards/native_posix/               @aescolar @daor-oti
-/tests/bluetooth/                         @alwa-nordic @jhedberg @Vudentz @sjanc
-/tests/bluetooth/audio/                   @jhedberg @Vudentz @wopu-ot @Thalley
-/tests/bluetooth/controller/              @cvinayak @thoh-ot @kruithofa @erbr-ot @sjanc @ppryga
-/tests/bsim/bluetooth/                    @alwa-nordic @jhedberg @Vudentz @wopu-ot
-/tests/bsim/bluetooth/audio/              @jhedberg @Vudentz @wopu-ot @Thalley
-/tests/bsim/bluetooth/mesh/               @jhedberg @Vudentz @wopu-ot @PavelVPV
-/tests/bluetooth/mesh_shell/              @jhedberg @Vudentz @sjanc @PavelVPV
-/tests/bluetooth/tester/                  @alwa-nordic @jhedberg @Vudentz @sjanc
-/tests/posix/                             @cfriedt
-/tests/crypto/                            @ceolin
-/tests/crypto/mbedtls/                    @nashif @ceolin @d3zd3z
-/tests/drivers/can/                       @alexanderwachter @henrikbrixandersen
-/tests/drivers/counter/                   @nordic-krch
-/tests/drivers/eeprom/                    @henrikbrixandersen @sjg20
-/tests/drivers/flash_simulator/           @de-nordic
-/tests/drivers/gpio/                      @mnkp
-/tests/drivers/hwinfo/                    @alexanderwachter
-/tests/drivers/smbus/                     @finikorg
-/tests/drivers/spi/                       @tbursztyka
-/tests/drivers/uart/uart_async_api/       @anangl
-/tests/drivers/w1/                        @str4t0m
-/tests/kernel/                            @dcpleung @andyross @nashif
-/tests/lib/                               @nashif
-/tests/lib/cmsis_dsp/                     @stephanosio
-/tests/lib/json/                          @d3zd3z
-/tests/net/                               @rlubos @tbursztyka @jukkar
-/tests/net/buf/                           @jhedberg @tbursztyka @jukkar
-/tests/net/conn_mgr_monitor/              @rlubos @glarsennordic @jukkar
-/tests/net/conn_mgr_conn/                 @rlubos @glarsennordic @jukkar
-/tests/net/ieee802154/l2/                 @rlubos @tbursztyka @jukkar @fgrandel
-/tests/net/lib/                           @rlubos @tbursztyka @jukkar
-/tests/net/lib/http_header_fields/        @rlubos @tbursztyka @jukkar
-/tests/net/lib/mqtt_packet/               @rlubos
-/tests/net/lib/mqtt_sn_packet/            @rlubos @BeckmaR
-/tests/net/lib/mqtt_sn_client/            @rlubos @BeckmaR
-/tests/net/lib/coap/                      @rlubos
-/tests/net/npf/                           @npitre
-/tests/net/socket/socketpair/             @cfriedt
-/tests/net/socket/                        @rlubos @tbursztyka @jukkar
-/tests/subsys/debug/coredump/             @dcpleung
-/tests/subsys/fs/                         @nashif @de-nordic
-/tests/subsys/jwt/                        @d3zd3z
-/tests/subsys/mgmt/mcumgr/                @de-nordic @nordicjm
-/tests/subsys/sd/                         @danieldegrasse
-/tests/subsys/rtio/                       @teburd
-/tests/subsys/shell/                      @jakub-uC @nordic-krch
-# Get all docs reviewed
-*.rst                                     @nashif
-/doc/kernel/                              @andyross @nashif
-*posix*.rst                               @aescolar @daor-oti

--- a/doc/contribute/guidelines.rst
+++ b/doc/contribute/guidelines.rst
@@ -651,8 +651,8 @@ workflow here:
    request for the ``main`` branch. The title and message from your commit
    message should appear as well.
 
-#. GitHub will assign one or more suggested reviewers (based on the
-   CODEOWNERS file in the repo). If you are a project member, you can
+#. A bot will assign one or more suggested reviewers (based on the
+   MAINTAINERS file in the repo). If you are a project member, you can
    select additional reviewers now too.
 
 #. Click on the submit button and your pull request is sent and awaits

--- a/doc/project/dev_env_and_tools.rst
+++ b/doc/project/dev_env_and_tools.rst
@@ -20,10 +20,11 @@ and linked to any relevant :ref:`bug or feature tracking issues<bug_reporting>`
 
 The Zephyr project uses GitHub for code reviews and Git tree management. When
 submitting a change or an enhancement to any Zephyr component, a developer
-should use GitHub. GitHub automatically assigns a responsible reviewer on a
-component basis, as defined in the :zephyr_file:`CODEOWNERS` file stored with the code
-tree in the Zephyr project repository. A limited set of release managers are
-allowed to merge a pull request into the main branch once reviews are complete.
+should use GitHub. GitHub Actions automatically assigns a responsible reviewer
+on a component basis, as defined in the :zephyr_file:`MAINTAINERS.yml` file
+stored with the code tree in the Zephyr project repository. A limited set of
+release managers are allowed to merge a pull request into the main branch once
+reviews are complete.
 
 .. _review_time:
 


### PR DESCRIPTION
Remove anything that would be covered by MAINTAINERS.yml leaving only
mostly instances that are not covered.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
