### PR TITLE
tests: drivers: dma: Refactor tests to use data relocation

### DIFF
--- a/tests/drivers/dma/chan_blen_transfer/CMakeLists.txt
+++ b/tests/drivers/dma/chan_blen_transfer/CMakeLists.txt
@@ -6,3 +6,5 @@ project(chan_blen_transfer)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})
+
+zephyr_code_relocate(FILES src/test_dma.c LOCATION ${CONFIG_DMA_LOOP_TRANSFER_RELOCATE_SECTION}_RODATA_BSS)

--- a/tests/drivers/dma/chan_blen_transfer/Kconfig
+++ b/tests/drivers/dma/chan_blen_transfer/Kconfig
@@ -13,10 +13,10 @@ config DMA_TRANSFER_CHANNEL_NR_1
 	int "second DMA channel to use"
 	default 1
 
-config DMA_LOOP_TRANSFER_SRAM_SECTION
+config DMA_LOOP_TRANSFER_RELOCATE_SECTION
 	string "the section to place the memory buffers."
-	depends on NOCACHE_MEMORY
-	default ".nocache"
+	depends on CODE_DATA_RELOCATION
+	default "RAM"
 
 config DMA_LOOP_TRANSFER_NUMBER_OF_DMAS
 	int "Number of DMAs to test"

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_h743zi.conf
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_h743zi.conf
@@ -5,7 +5,8 @@ CONFIG_DMA_LOOP_TRANSFER_NUMBER_OF_DMAS=2
 # Required by BDMA which only has access to
 # a NOCACHE SRAM4 section. All other DMAs also
 # has access to this section.
-CONFIG_DMA_LOOP_TRANSFER_SRAM_SECTION="SRAM4.dma"
+CONFIG_CODE_DATA_RELOCATION=y
+CONFIG_DMA_LOOP_TRANSFER_RELOCATE_SECTION="SRAM4"
 
 # Required for SRAM4 to be non-cachable
 CONFIG_NOCACHE_MEMORY=y

--- a/tests/drivers/dma/chan_blen_transfer/src/test_dma.c
+++ b/tests/drivers/dma/chan_blen_transfer/src/test_dma.c
@@ -22,16 +22,8 @@
 
 #define RX_BUFF_SIZE (48)
 
-#ifdef CONFIG_NOCACHE_MEMORY
-static __aligned(32) char tx_data[RX_BUFF_SIZE] __used
-	__attribute__((__section__(CONFIG_DMA_LOOP_TRANSFER_SRAM_SECTION)));
-static const char TX_DATA[] = "It is harder to be kind than to be wise........";
-static __aligned(32) char rx_data[RX_BUFF_SIZE] __used
-	__attribute__((__section__(CONFIG_DMA_LOOP_TRANSFER_SRAM_SECTION".dma")));
-#else
-static const char tx_data[] = "It is harder to be kind than to be wise........";
-static char rx_data[RX_BUFF_SIZE] = { 0 };
-#endif
+static __aligned(32) const char tx_data[] = "It is harder to be kind than to be wise........";
+static __aligned(32) char rx_data[RX_BUFF_SIZE] = { 0 };
 
 static void test_done(const struct device *dma_dev, void *arg,
 		      uint32_t id, int status)
@@ -52,10 +44,6 @@ static int test_task(const struct device *dma, uint32_t chan_id, uint32_t blen)
 		TC_PRINT("dma controller device is not ready\n");
 		return TC_FAIL;
 	}
-
-#ifdef CONFIG_NOCACHE_MEMORY
-	memcpy(tx_data, TX_DATA, sizeof(TX_DATA));
-#endif
 
 	dma_cfg.channel_direction = MEMORY_TO_MEMORY;
 	dma_cfg.source_data_size = 1U;

--- a/tests/drivers/dma/loop_transfer/CMakeLists.txt
+++ b/tests/drivers/dma/loop_transfer/CMakeLists.txt
@@ -6,3 +6,5 @@ project(loop_transfer)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})
+
+zephyr_code_relocate(FILES src/test_dma_loop.c LOCATION ${CONFIG_DMA_LOOP_TRANSFER_RELOCATE_SECTION}_RODATA_BSS)

--- a/tests/drivers/dma/loop_transfer/Kconfig
+++ b/tests/drivers/dma/loop_transfer/Kconfig
@@ -9,10 +9,10 @@ config DMA_LOOP_TRANSFER_CHANNEL_NR
 	int "DMA channel to use"
 	default 0
 
-config DMA_LOOP_TRANSFER_SRAM_SECTION
+config DMA_LOOP_TRANSFER_RELOCATE_SECTION
 	string "the section to place the memory buffers."
-	depends on NOCACHE_MEMORY
-	default ".nocache"
+	depends on CODE_DATA_RELOCATION
+	default "RAM"
 
 config DMA_LOOP_TRANSFER_NUMBER_OF_DMAS
 	int "Number of DMAs to test"

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_h743zi.conf
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_h743zi.conf
@@ -4,7 +4,8 @@ CONFIG_DMA_LOOP_TRANSFER_NUMBER_OF_DMAS=2
 # Required by BDMA which only has access to
 # a NOCACHE SRAM4 section. All other DMAs also
 # has access to this section.
-CONFIG_DMA_LOOP_TRANSFER_SRAM_SECTION="SRAM4.dma"
+CONFIG_CODE_DATA_RELOCATION=y
+CONFIG_DMA_LOOP_TRANSFER_RELOCATE_SECTION="SRAM4"
 
 # Required for SRAM4 to be non-cachable
 CONFIG_NOCACHE_MEMORY=y

--- a/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
+++ b/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
@@ -33,16 +33,8 @@
 
 #define TRANSFER_LOOPS (4)
 
-#if CONFIG_NOCACHE_MEMORY
-static __aligned(32) uint8_t tx_data[CONFIG_DMA_LOOP_TRANSFER_SIZE] __used
-	__attribute__((__section__(CONFIG_DMA_LOOP_TRANSFER_SRAM_SECTION)));
-static __aligned(32) uint8_t rx_data[TRANSFER_LOOPS][CONFIG_DMA_LOOP_TRANSFER_SIZE] __used
-	__attribute__((__section__(CONFIG_DMA_LOOP_TRANSFER_SRAM_SECTION".dma")));
-#else
-/* this src memory shall be in RAM to support usingas a DMA source pointer.*/
-static uint8_t tx_data[CONFIG_DMA_LOOP_TRANSFER_SIZE];
-static __aligned(16) uint8_t rx_data[TRANSFER_LOOPS][CONFIG_DMA_LOOP_TRANSFER_SIZE] = { { 0 } };
-#endif
+static __aligned(32) uint8_t tx_data[CONFIG_DMA_LOOP_TRANSFER_SIZE];
+static __aligned(32) uint8_t rx_data[TRANSFER_LOOPS][CONFIG_DMA_LOOP_TRANSFER_SIZE] = { { 0 } };
 
 volatile uint32_t transfer_count;
 volatile uint32_t done;


### PR DESCRIPTION
Eliminates dma tests' dependency on CONFIG_NOCACHE_MEMORY=y for configuring dma data linker sections. This allows optionally relocating dma source and destination data to sram or other custom linker section on boards that don't support dma access to flash.