### PR TITLE
dts: arm: rpi_pico: Add compat string to rp2040

### DIFF
--- a/dts/arm/rpi_pico/rp2040.dtsi
+++ b/dts/arm/rpi_pico/rp2040.dtsi
@@ -34,6 +34,8 @@
 	};
 
 	soc {
+		compatible = "raspberrypi,rp2040", "simple-bus";
+
 		sram0: memory@20000000 {
 			compatible = "mmio-sram";
 			reg = <0x20000000 DT_SIZE_K(264)>;


### PR DESCRIPTION
This commit adds compatible string to the `rp2040` SoC node.