### PR TITLE
arch: arm: Use returned reason from secure fault handle function

### DIFF
--- a/arch/arm/core/cortex_m/fault.c
+++ b/arch/arm/core/cortex_m/fault.c
@@ -863,7 +863,7 @@ static uint32_t fault_handle(z_arch_esf_t *esf, int fault, bool *recoverable)
 		break;
 #if defined(CONFIG_ARM_SECURE_FIRMWARE)
 	case 7:
-		secure_fault(esf);
+		reason = secure_fault(esf);
 		break;
 #endif /* CONFIG_ARM_SECURE_FIRMWARE */
 	case 12:


### PR DESCRIPTION
Use the returned reason from the secure fault handle function. I see no reason why this was ignored, and it is used in the hardfault handler.