### PR TITLE
doc: Fix occurrences of repeated words

### DIFF
--- a/doc/build/cmake/index.rst
+++ b/doc/build/cmake/index.rst
@@ -108,7 +108,7 @@ Devicetree
    :ref:`dt-guide`.
 
 Kconfig
-   :file:`Kconfig` files define available configuration options for for the
+   :file:`Kconfig` files define available configuration options for the
    target architecture, SoC, board, and application, as well as dependencies
    between options.
 

--- a/doc/build/dts/intro-syntax-structure.rst
+++ b/doc/build/dts/intro-syntax-structure.rst
@@ -370,7 +370,7 @@ curious about details, see the devicetree specification.
 Additional notes on the above:
 
 - The values in the ``phandle``, ``phandles``, and ``phandle-array`` types are
-  are described further in :ref:`dt-phandles`
+  described further in :ref:`dt-phandles`
 
 - Boolean properties are true if present. They should not have a value.
   A boolean property is only false if it is completely missing in the DTS.

--- a/doc/build/kconfig/setting.rst
+++ b/doc/build/kconfig/setting.rst
@@ -373,5 +373,4 @@ The :ref:`kconfig_tips_and_tricks` page has some tips for writing Kconfig
 files.
 
 The :zephyr_file:`kconfiglib.py <scripts/kconfig/kconfiglib.py>` docstring
-docstring (at the top of the file) goes over how symbol values are calculated
-in detail.
+(at the top of the file) goes over how symbol values are calculated in detail.

--- a/doc/connectivity/bluetooth/api/gatt.rst
+++ b/doc/connectivity/bluetooth/api/gatt.rst
@@ -56,7 +56,7 @@ respective operations.
   thus it is not recommended to block for long periods of time in them.
 
 Attribute value changes can be notified using :c:func:`bt_gatt_notify` API,
-alternatively there is :c:func:`bt_gatt_notify_cb` where is is possible to
+alternatively there is :c:func:`bt_gatt_notify_cb` where it is possible to
 pass a callback to be called when it is necessary to know the exact instant when
 the data has been transmitted over the air. Indications are supported by
 :c:func:`bt_gatt_indicate` API.

--- a/doc/connectivity/bluetooth/api/shell/cap.rst
+++ b/doc/connectivity/bluetooth/api/shell/cap.rst
@@ -14,7 +14,7 @@ Using the CAP Acceptor
 ======================
 
 When the Bluetooth stack has been initialized (:code:`bt init`), the Acceptor can be registered by
-by calling :code:`cap_acceptor init`, which will register the CAS and CSIS services, as well as
+calling :code:`cap_acceptor init`, which will register the CAS and CSIS services, as well as
 register callbacks.
 
 .. code-block:: console

--- a/doc/connectivity/bluetooth/api/shell/csip.rst
+++ b/doc/connectivity/bluetooth/api/shell/csip.rst
@@ -14,7 +14,7 @@ or a laptop. The client is able to lock and release members of a coordinated
 set. While the coordinated set is locked, no other clients may lock the set.
 
 To lock a set, the client must connect to each of the set members it wants to
-lock. This implementation will always try to to connect to all the members of
+lock. This implementation will always try to connect to all the members of
 the set, and at the same time. Thus if the set size is 3, then
 :code:`BT_MAX_CONN` shall be at least 3.
 

--- a/doc/connectivity/bluetooth/api/shell/mcp.rst
+++ b/doc/connectivity/bluetooth/api/shell/mcp.rst
@@ -27,8 +27,7 @@ Also note that this documentation does not list all shell commands, it
 just shows examples of some of them. The set of commands is
 explorable from the mcc shell and the mpl shell, by typing :code:`mcc`
 or :code:`mpl` and pressing TAB.  A help text for each command can be
-found by doing :code:`mcc <command> help` or or :code:`mpl <command>
-help`.
+found by doing :samp:`mcc {<command>} help` or :samp:`mpl {<command>} help`.
 
 Overview
 ********

--- a/doc/connectivity/bluetooth/api/shell/tmap.rst
+++ b/doc/connectivity/bluetooth/api/shell/tmap.rst
@@ -10,7 +10,7 @@ Using the TMAP Shell
 ********************
 
 When the Bluetooth stack has been initialized (:code:`bt init`), the TMAS can be registered by
-by calling :code:`tmap init`.
+calling :code:`tmap init`.
 
 .. code-block:: console
 

--- a/doc/connectivity/bluetooth/bluetooth-tools.rst
+++ b/doc/connectivity/bluetooth/bluetooth-tools.rst
@@ -212,7 +212,7 @@ To connect your application to the Android Emulator follow the next steps:
 
     #. Build your Zephyr application and disable the HCI ACL flow
        control (i.e. ``CONFIG_BT_HCI_ACL_FLOW_CONTROL=n``) as the
-       the virtual controller from android does not support it at the moment.
+       virtual controller from android does not support it at the moment.
 
     #. Install Android Emulator version >= 33.1.4.0. The easiest way to do this is by installing
        the latest `Android Studio Preview`_ version.

--- a/doc/connectivity/networking/api/lwm2m.rst
+++ b/doc/connectivity/networking/api/lwm2m.rst
@@ -478,7 +478,7 @@ Support for time series data
 LwM2M version 1.1 adds support for SenML CBOR and SenML JSON data formats. These data formats add
 support for time series data. Time series formats can be used for READ, NOTIFY and SEND operations.
 When data cache is enabled for a resource, each write will create a timestamped entry in a cache,
-and its content is then returned as a content in in READ, NOTIFY or SEND operation for a given
+and its content is then returned as a content in READ, NOTIFY or SEND operation for a given
 resource.
 
 Data cache is only supported for resources with a fixed data size.

--- a/doc/connectivity/networking/conn_mgr/main.rst
+++ b/doc/connectivity/networking/conn_mgr/main.rst
@@ -421,7 +421,7 @@ There are a few actions related to connectivity that are (by default at least) p
 
    By default, Connection Manager will automatically take any bound iface admin-down if it has given up on associating.
 
-   Applications can disable this for all ifaces by disabling the :kconfig:option:`CONFIG_NET_CONNECTION_MANAGER_AUTO_IF_DOWN` Kconfig option, or for individual ifaces by setting the :c:enumerator:`~conn_mgr_if_flag.CONN_MGR_IF_NO_AUTO_DOWN` connectivity flag with with :c:func:`conn_mgr_if_set_flag`.
+   Applications can disable this for all ifaces by disabling the :kconfig:option:`CONFIG_NET_CONNECTION_MANAGER_AUTO_IF_DOWN` Kconfig option, or for individual ifaces by setting the :c:enumerator:`~conn_mgr_if_flag.CONN_MGR_IF_NO_AUTO_DOWN` connectivity flag with :c:func:`conn_mgr_if_set_flag`.
 
 .. _conn_mgr_control_api:
 

--- a/doc/develop/getting_started/installation_linux.rst
+++ b/doc/develop/getting_started/installation_linux.rst
@@ -303,7 +303,7 @@ toolchains for all Zephyr target architectures, and does not require any extra
 flags when building applications or running tests. In addition to
 cross-compilers, the Zephyr SDK also provides prebuilt host tools. It is,
 however, possible to build without the SDK's toolchain by using another
-toolchain as as described in the :ref:`toolchains` section.
+toolchain as described in the :ref:`toolchains` section.
 
 As already noted above, the SDK also includes prebuilt host tools.  To use the
 SDK's prebuilt host tools with a toolchain from another source, you must set the

--- a/doc/develop/languages/c/newlib.rst
+++ b/doc/develop/languages/c/newlib.rst
@@ -31,7 +31,7 @@ The Newlib full variant (:file:`libc.a` and :file:`libm.a`) is the most capable
 variant of the Newlib available in the Zephyr SDK, and supports almost all
 standard C library features. It is optimized for performance (prefers
 performance over code size) and its footprint is significantly larger than the
-the nano variant.
+nano variant.
 
 This variant can be enabled by selecting the
 :kconfig:option:`CONFIG_NEWLIB_LIBC` and de-selecting the

--- a/doc/develop/west/manifest.rst
+++ b/doc/develop/west/manifest.rst
@@ -1124,7 +1124,7 @@ recursively update the project's Git submodules whenever it updates the project
 itself. If it's ``false`` or missing, it has no effect.
 
 For example, let's say you have a source code repository ``foo``, which has
-some submodules, and you want ``west update`` to keep all of them them in sync,
+some submodules, and you want ``west update`` to keep all of them in sync,
 along with another project named ``bar`` in the same workspace.
 
 You can do that with this manifest file:
@@ -2050,7 +2050,7 @@ The ultimate outcomes of resolving manifest imports are:
   in the top-level file with those defined in imported files
 
 - a set of extension commands, which are drawn from the ``west-commands``
-  keys in in the top-level file and any imported files
+  keys in the top-level file and any imported files
 
 - a ``group-filter`` list, which is produced by combining the top-level and any
   imported filters

--- a/doc/develop/west/release-notes.rst
+++ b/doc/develop/west/release-notes.rst
@@ -669,7 +669,7 @@ The developer-visible changes to the :ref:`west-apis` are:
 
 West now requires Python 3.6 or later. Additionally, some features may rely on
 Python dictionaries being insertion-ordered; this is only an implementation
-detail in CPython 3.6, but is is part of the language specification as of
+detail in CPython 3.6, but it is part of the language specification as of
 Python 3.7.
 
 v0.6.3

--- a/doc/develop/west/sign.rst
+++ b/doc/develop/west/sign.rst
@@ -40,7 +40,7 @@ Notes on the above commands:
 
 - ``YOUR_BOARD`` should be changed to match your board
 - The ``CONFIG_MCUBOOT_SIGNATURE_KEY_FILE`` value is the insecure default
-  provided and used by by MCUboot for development and testing
+  provided and used by MCUboot for development and testing
 - You can change the ``hello_world`` application directory to any other
   application that can be loaded by MCUboot, such as the :zephyr:code-sample:`smp-svr` sample.
 

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -89,7 +89,7 @@ Glossary of Terms
 
    system power state
       System power states describe the power consumption of the system as a
-      whole. System power states are are represented by :c:enum:`pm_state`.
+      whole. System power states are represented by :c:enum:`pm_state`.
 
    west
       A multi-repo meta-tool developed for the Zephyr project. See :ref:`west`.

--- a/doc/hardware/peripherals/auxdisplay.rst
+++ b/doc/hardware/peripherals/auxdisplay.rst
@@ -9,7 +9,7 @@ Overview
 Auxiliary Displays are text-based displays that have simple interfaces for
 displaying textual, numeric or alphanumeric data, as opposed to the
 :ref:`display_api`, auxiliary displays do not support custom
-graphical output to displays (and and most often monochrome), the most
+graphical output to displays (and most often monochrome), the most
 advanced custom feature supported is generation of custom characters.
 These inexpensive displays are commonly found with various configurations
 and sizes, a common display size is 16 characters by 2 lines.

--- a/doc/hardware/peripherals/bc12.rst
+++ b/doc/hardware/peripherals/bc12.rst
@@ -74,7 +74,7 @@ Charging port mode is used by the application when the USB port is configured as
 a downstream facing port, i.e. a USB host port. For charging port mode, the
 BC1.2 driver powers up the detection chip and configures the charger type
 specified by a devicetree property. If the driver supports detection of plug and
-and unplug events, the BC1.2 driver notifies the callback registered with
+unplug events, the BC1.2 driver notifies the callback registered with
 ``bc12_set_result_cb()`` to indicate the current connection state of the
 portable device partner.
 

--- a/doc/kernel/services/synchronization/events.rst
+++ b/doc/kernel/services/synchronization/events.rst
@@ -33,10 +33,10 @@ conditions of multiple threads waiting on the event object. All threads whose
 match conditions have been met are made active at the same time.
 
 Threads may wait on one or more events. They may either wait for all of the
-the requested events, or for any of them. Furthermore, threads making a wait
-request have the option of resetting the current set of events tracked by the
-event object prior to waiting. Care must be taken with this option when
-multiple threads wait on the same event object.
+requested events, or for any of them. Furthermore, threads making a wait request
+have the option of resetting the current set of events tracked by the event
+object prior to waiting. Care must be taken with this option when multiple
+threads wait on the same event object.
 
 .. note::
     The kernel does allow an ISR to query an event object, however the ISR must

--- a/doc/services/device_mgmt/smp_groups/smp_group_1.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_1.rst
@@ -3,7 +3,7 @@
 Application/software image management group
 ###########################################
 
-Application/software image management management group defines following commands:
+Application/software image management group defines following commands:
 
 .. table::
     :align: center
@@ -75,7 +75,7 @@ Get state of images request header fields:
     | ``0``  | ``1``        |  ``0``         |
     +--------+--------------+----------------+
 
-The command sends sends empty CBOR map as data.
+The command sends an empty CBOR map as data.
 
 .. _mcumgr_smp_protocol_op_1_grp_1_cmd_0:
 

--- a/doc/services/device_mgmt/smp_groups/smp_group_3.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_3.rst
@@ -333,7 +333,7 @@ Commit settings request header fields:
     | ``2``  | ``3``        | ``2``          |
     +--------+--------------+----------------+
 
-The command sends sends empty CBOR map as data.
+The command sends an empty CBOR map as data.
 
 Commit settings response
 ========================
@@ -409,7 +409,7 @@ Load settings request header fields:
     | ``0``  | ``3``        | ``3``          |
     +--------+--------------+----------------+
 
-The command sends sends empty CBOR map as data.
+The command sends an empty CBOR map as data.
 
 Load settings response
 ======================
@@ -479,7 +479,7 @@ Save settings request header fields:
     | ``2``  | ``3``        | ``3``          |
     +--------+--------------+----------------+
 
-The command sends sends empty CBOR map as data.
+The command sends an empty CBOR map as data.
 
 Save settings response
 ======================

--- a/doc/services/sensing/index.rst
+++ b/doc/services/sensing/index.rst
@@ -197,7 +197,7 @@ Sensor Sample Value
   The ``header`` defines a **base_timestamp**, and
   each element in the **readings[]** array defines **timestamp_delta**.
 
-  The **timestamp_delta** is is in relation to the previous **readings** (or the **base_timestamp**)
+  The **timestamp_delta** is in relation to the previous **readings** (or the **base_timestamp**)
 
   For example:
 


### PR DESCRIPTION
Another round of repeated words cleanup. 
This commit tries to keep the diff minimal and line wrapping was mostly left intact in the touched files, as having them consistent across the documentation is probably the topic of a future tree-wide cleanup (or not)