### PR TITLE
net: tcp: Rework data queueing

### DIFF
--- a/include/zephyr/net/net_pkt.h
+++ b/include/zephyr/net/net_pkt.h
@@ -1707,6 +1707,13 @@ int net_pkt_alloc_buffer_debug(struct net_pkt *pkt,
 	net_pkt_alloc_buffer_debug(_pkt, _size, _proto, _timeout,	\
 				   __func__, __LINE__)
 
+int net_pkt_alloc_buffer_raw_debug(struct net_pkt *pkt, size_t size,
+				   k_timeout_t timeout,
+				   const char *caller, int line);
+#define net_pkt_alloc_buffer_raw(_pkt, _size, _timeout)	\
+	net_pkt_alloc_buffer_raw_debug(_pkt, _size, _timeout,	\
+				       __func__, __LINE__)
+
 struct net_pkt *net_pkt_alloc_with_buffer_debug(struct net_if *iface,
 						size_t size,
 						sa_family_t family,
@@ -1819,6 +1826,24 @@ int net_pkt_alloc_buffer(struct net_pkt *pkt,
 			 size_t size,
 			 enum net_ip_protocol proto,
 			 k_timeout_t timeout);
+#endif
+
+/**
+ * @brief Allocate buffer for a net_pkt, of specified size, w/o any additional
+ *        preconditions
+ *
+ * @details: The actual buffer size may be larger than requested one if fixed
+ *           size buffers are in use.
+ *
+ * @param pkt     The network packet requiring buffer to be allocated.
+ * @param size    The size of buffer being requested.
+ * @param timeout Maximum time to wait for an allocation.
+ *
+ * @return 0 on success, negative errno code otherwise.
+ */
+#if !defined(NET_PKT_DEBUG_ENABLED)
+int net_pkt_alloc_buffer_raw(struct net_pkt *pkt, size_t size,
+			     k_timeout_t timeout);
 #endif
 
 /**

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -1197,6 +1197,67 @@ int net_pkt_alloc_buffer(struct net_pkt *pkt,
 	return 0;
 }
 
+
+#if NET_LOG_LEVEL >= LOG_LEVEL_DBG
+int net_pkt_alloc_buffer_raw_debug(struct net_pkt *pkt, size_t size,
+				   k_timeout_t timeout, const char *caller,
+				   int line)
+#else
+int net_pkt_alloc_buffer_raw(struct net_pkt *pkt, size_t size,
+			     k_timeout_t timeout)
+#endif
+{
+	struct net_buf_pool *pool = NULL;
+	struct net_buf *buf;
+
+	if (size == 0) {
+		return 0;
+	}
+
+	if (k_is_in_isr()) {
+		timeout = K_NO_WAIT;
+	}
+
+	NET_DBG("Data allocation size %zu", size);
+
+	if (pkt->context) {
+		pool = get_data_pool(pkt->context);
+	}
+
+	if (!pool) {
+		pool = pkt->slab == &tx_pkts ? &tx_bufs : &rx_bufs;
+	}
+
+#if NET_LOG_LEVEL >= LOG_LEVEL_DBG
+	buf = pkt_alloc_buffer(pool, size, timeout, caller, line);
+#else
+	buf = pkt_alloc_buffer(pool, size, timeout);
+#endif
+
+	if (!buf) {
+#if NET_LOG_LEVEL >= LOG_LEVEL_DBG
+		NET_ERR("Data buffer (%zd) allocation failed (%s:%d)",
+			size, caller, line);
+#else
+		NET_ERR("Data buffer (%zd) allocation failed.", size);
+#endif
+		return -ENOMEM;
+	}
+
+	net_pkt_append_buffer(pkt, buf);
+
+#if IS_ENABLED(CONFIG_NET_BUF_FIXED_DATA_SIZE)
+	/* net_buf allocators shrink the buffer size to the requested size.
+	 * We don't want this behavior here, so restore the real size of the
+	 * last fragment.
+	 */
+	buf = net_buf_frag_last(buf);
+	buf->size = CONFIG_NET_BUF_DATA_SIZE;
+#endif
+
+	return 0;
+}
+
 #if NET_LOG_LEVEL >= LOG_LEVEL_DBG
 static struct net_pkt *pkt_alloc(struct k_mem_slab *slab, k_timeout_t timeout,
 				 const char *caller, int line)

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -638,6 +638,8 @@ static int tcp_conn_close(struct tcp *conn, int status)
 				       status, conn->recv_user_data);
 	}
 
+	k_sem_give(&conn->tx_sem);
+
 	return tcp_conn_unref(conn);
 }
 

--- a/subsys/net/ip/tcp.h
+++ b/subsys/net/ip/tcp.h
@@ -31,6 +31,7 @@
 extern "C" {
 #endif
 
+#include <errno.h>
 #include <sys/types.h>
 
 /**
@@ -72,18 +73,7 @@ int net_tcp_listen(struct net_context *context);
  */
 int net_tcp_accept(struct net_context *context, net_tcp_accept_cb_t cb,
 			void *user_data);
-/**
- * @brief Enqueue data for transmission
- *
- * @param context	Network context
- * @param buf		Pointer to the data
- * @param len		Number of bytes
- * @param msghdr	Data for a vector array operation
- *
- * @return 0 if ok, < 0 if error
- */
-int net_tcp_queue(struct net_context *context, const void *buf, size_t len,
-		  const struct msghdr *msghdr);
+
 /* TODO: split into 2 functions, conn -> context, queue -> send? */
 
 /* The following functions are provided solely for the compatibility
@@ -112,7 +102,6 @@ void net_tcp_init(void);
 #define net_tcp_init(...)
 #endif
 int net_tcp_update_recv_wnd(struct net_context *context, int32_t delta);
-int net_tcp_queue_data(struct net_context *context, struct net_pkt *pkt);
 int net_tcp_finalize(struct net_pkt *pkt, bool force_chksum);
 
 #if defined(CONFIG_NET_TEST_PROTOCOL)

--- a/subsys/net/ip/tcp_internal.h
+++ b/subsys/net/ip/tcp_internal.h
@@ -283,21 +283,27 @@ struct net_tcp_hdr *net_tcp_input(struct net_pkt *pkt,
 #endif
 
 /**
- * @brief Enqueue a single packet for transmission
+ * @brief Enqueue data for transmission
  *
- * @param context TCP context
- * @param pkt Packet
+ * @param context	Network context
+ * @param data		Pointer to the data
+ * @param len		Number of bytes
+ * @param msg		Data for a vector array operation
  *
  * @return 0 if ok, < 0 if error
  */
 #if defined(CONFIG_NET_NATIVE_TCP)
-int net_tcp_queue_data(struct net_context *context, struct net_pkt *pkt);
+int net_tcp_queue(struct net_context *context, const void *data, size_t len,
+		  const struct msghdr *msg);
 #else
-static inline int net_tcp_queue_data(struct net_context *context,
-				     struct net_pkt *pkt)
+static inline int net_tcp_queue(struct net_context *context, const void *data,
+				size_t len, const struct msghdr *msg)
 {
 	ARG_UNUSED(context);
-	ARG_UNUSED(pkt);
+	ARG_UNUSED(data);
+	ARG_UNUSED(len);
+	ARG_UNUSED(msg);
+
 	return -EPROTONOSUPPORT;
 }
 #endif

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -2230,10 +2230,9 @@ static ssize_t send_tls(struct tls_context *ctx, const void *buf,
 			timeout_ms = timeout_to_ms(&timeout);
 			ret = wait_for_reason(ctx->sock, timeout_ms, ret);
 			if (ret != 0) {
-				/* Retry. */
+				errno = -ret;
 				break;
 			}
-
 		} else {
 			(void)tls_mbedtls_reset(ctx);
 			errno = EIO;


### PR DESCRIPTION
Rework how data is queued for the TCP connections:
  * net_context no longer allocates net_pkt for TCP connections. This
    was not only inefficient (net_context has no knowledge of the TX
    window size), but also error-prone in certain configurations (for
    example when IP fragmentation was enabled, net_context may attempt
    to allocate enormous packet, instead of letting the data be fragmented
    for the TCP stream).
  * Instead, implement already defined `net_tcp_queue()` API, which
    takes raw buffer and length. This allows to take TX window into
    account and also better manage the allocated net_buf's (like for
    example avoid allocation if there's still room in the buffer). In
    result, the TCP stack will not only no longer exceed the TX window,
    but also prevent empty gaps in allocated net_buf's, which should
    lead to less out-of-mem issues with the stack.
  * As net_pkt-based `net_tcp_queue_data()` is no longer in use, it was
    removed.