### PR TITLE
tfm: Fix include order between platform_ns and tfm_api_ns libraries

### DIFF
--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -435,8 +435,8 @@ if (CONFIG_BUILD_WITH_TFM)
 
   else()
     zephyr_library_link_libraries(
-      ${TFM_API_NS_PATH}
       ${PLATFORM_NS_FILE}
+      ${TFM_API_NS_PATH}
       )
   endif()
 


### PR DESCRIPTION
Fix include order between platform_ns and tfm_api_ns libraries. platform_ns functions may depend on tfm_api_ns.
This would typically be platform specific IOCTL services added to the platform_ns library requiring the tfm_platform_ioctl from the TF-M platform partition exposed in tfm_platform_api.c