### PR TITLE
pm: device_runtime: release power domain multiple times

### DIFF
--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -91,8 +91,9 @@ int pm_device_action_run(const struct device *dev,
 	}
 
 	pm->state = action_target_state[action];
-	/* Power up failure flag is no longer relevant */
+	/* Power up flags are no longer relevant */
 	if (action == PM_DEVICE_ACTION_TURN_OFF) {
+		atomic_clear_bit(&pm->flags, PM_DEVICE_FLAG_PD_CLAIMED);
 		atomic_clear_bit(&pm->flags, PM_DEVICE_FLAG_TURN_ON_FAILED);
 	}
 

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -227,7 +227,7 @@ int pm_device_runtime_put(const struct device *dev)
 	 * Now put the domain
 	 */
 	if ((ret == 0) &&
-	    atomic_test_and_clear_bit(&dev->pm->flags, PM_DEVICE_FLAG_PD_CLAIMED)) {
+	    atomic_test_bit(&dev->pm->flags, PM_DEVICE_FLAG_PD_CLAIMED)) {
 		ret = pm_device_runtime_put(PM_DOMAIN(dev->pm));
 	}
 	SYS_PORT_TRACING_FUNC_EXIT(pm, device_runtime_put, dev, ret);

--- a/tests/subsys/pm/device_power_domains/prj.conf
+++ b/tests/subsys/pm/device_power_domains/prj.conf
@@ -1,7 +1,6 @@
 # Copyright (c) 2022, Commonwealth Scientific and Industrial Research
 # Organisation (CSIRO) ABN 41 687 119 230.
 CONFIG_ZTEST=y
-CONFIG_PM=y
 CONFIG_PM_DEVICE=y
 CONFIG_PM_DEVICE_RUNTIME=y
 CONFIG_PM_DEVICE_POWER_DOMAIN=y

--- a/tests/subsys/pm/device_power_domains/src/main.c
+++ b/tests/subsys/pm/device_power_domains/src/main.c
@@ -111,6 +111,24 @@ ZTEST(device_power_domain, test_device_power_domain)
 	pm_device_state_get(reg_chained, &state);
 	zassert_equal(PM_DEVICE_STATE_OFF, state, "");
 
+	/* Directly request the supported device multiple times */
+	pm_device_runtime_get(dev);
+	pm_device_runtime_get(dev);
+	/* Directly release the supported device the first time, check all still powered */
+	pm_device_runtime_put(dev);
+	zassert_true(pm_device_is_powered(dev), "");
+	pm_device_state_get(dev, &state);
+	zassert_equal(PM_DEVICE_STATE_ACTIVE, state, "");
+	pm_device_state_get(reg_1, &state);
+	zassert_equal(PM_DEVICE_STATE_ACTIVE, state, "");
+	/* Directly release the supported device the second time, check all off */
+	pm_device_runtime_put(dev);
+	zassert_false(pm_device_is_powered(dev), "");
+	pm_device_state_get(dev, &state);
+	zassert_equal(PM_DEVICE_STATE_OFF, state, "");
+	pm_device_state_get(reg_1, &state);
+	zassert_equal(PM_DEVICE_STATE_SUSPENDED, state, "");
+
 	TC_PRINT("DONE\n");
 }
 


### PR DESCRIPTION
Enable the automatic power domain management to release the domain as
many times as it was claimed, instead of only once.

This fixes the domain being permanently enabled if the supported device
is claimed more than once.