### PR TITLE
Add support for I3C hw block on S32Z27

### DIFF
--- a/boards/arm/s32z270dc2_r52/doc/index.rst
+++ b/boards/arm/s32z270dc2_r52/doc/index.rst
@@ -53,6 +53,8 @@ The boards support the following hardware features:
 +-----------+------------+-------------------------------------+
 | CANEXCEL  | on-chip    | can                                 |
 +-----------+------------+-------------------------------------+
+| I3C       | on-chip    | i3c                                 |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not currently supported by the port.
 
@@ -138,6 +140,14 @@ which supports CAN 2.0 and CAN FD protocol.
 
 CAN driver supports classic (CAN 2.0) and CAN FD mode. Remote transmission request is
 not supported as this feature is not available on NXP S32 CANXL HAL.
+
+Improved Inter-Integrated Circuit (I3C)
+=======================================
+
+.. warning::
+   Due to internal structural issues, I3C mode functionality is not guaranteed on this
+   platform, so do not use the I3C driver to communicate with I3C devices. Legacy I2C
+   mode is fully functional as specified.
 
 Programming and Debugging
 *************************

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_r52-pinctrl-common.dtsi
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_r52-pinctrl-common.dtsi
@@ -85,4 +85,14 @@
 			output-enable;
 		};
 	};
+
+	i3c2_default: i3c2_default {
+		group1 {
+			pinmux = <(PJ11_I3C_2_SDA0_I | PJ11_I3C_2_SDA0_O)>,
+				<(PJ10_I3C_2_SCL_I | PJ10_I3C_2_SCL_O)>;
+			input-enable;
+			output-enable;
+			drive-open-drain;
+		};
+	};
 };

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_r52.dtsi
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_r52.dtsi
@@ -49,3 +49,22 @@
 	bus-speed-data = <1000000>;
 	sample-point-data = <875>;
 };
+
+&i3c2 {
+	pinctrl-0 = <&i3c2_default>;
+	pinctrl-names = "default";
+	i2c-scl-hz = <400000>;
+	i3c-od-scl-hz = <2500000>;
+	i3c-scl-hz = <12500000>;
+	status = "okay";
+
+	eeprom0: eeprom@500000000000000010 {
+		compatible = "atmel,at24";
+		reg = <0x50 0x00 0x00000010>;
+		status = "okay";
+		size = <128>;
+		pagesize = <8>;
+		address-width = <8>;
+		timeout = <5>;
+	};
+};

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_rtu0_r52.dts
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_rtu0_r52.dts
@@ -19,6 +19,7 @@
 
 	aliases {
 		watchdog0 = &swt0;
+		eeprom-0 = &eeprom0;
 	};
 };
 

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_rtu0_r52.yaml
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_rtu0_r52.yaml
@@ -16,4 +16,6 @@ supported:
   - can
   - spi
   - counter
+  - i2c
+  - eeprom
 vendor: nxp

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_rtu0_r52_D.yaml
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_rtu0_r52_D.yaml
@@ -16,4 +16,6 @@ supported:
   - can
   - spi
   - counter
+  - i2c
+  - eeprom
 vendor: nxp

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_rtu1_r52.dts
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_rtu1_r52.dts
@@ -21,6 +21,7 @@
 
 	aliases {
 		watchdog0 = &swt0;
+		eeprom-0 = &eeprom0;
 	};
 };
 

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_rtu1_r52.yaml
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_rtu1_r52.yaml
@@ -16,4 +16,6 @@ supported:
   - can
   - spi
   - counter
+  - i2c
+  - eeprom
 vendor: nxp

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_rtu1_r52_D.yaml
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_rtu1_r52_D.yaml
@@ -16,4 +16,6 @@ supported:
   - can
   - spi
   - counter
+  - i2c
+  - eeprom
 vendor: nxp

--- a/drivers/eeprom/Kconfig
+++ b/drivers/eeprom/Kconfig
@@ -67,7 +67,8 @@ config EEPROM_AT24
 	bool "Atmel AT24 (and compatible) I2C EEPROM support"
 	default y
 	depends on DT_HAS_ATMEL_AT24_ENABLED
-	select I2C
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ATMEL_AT24),i2c)
+	select I3C if $(dt_compat_on_bus,$(DT_COMPAT_ATMEL_AT24),i3c)
 	select EEPROM_AT2X
 	help
 	  Enable support for Atmel AT24 (and compatible) I2C EEPROMs.

--- a/drivers/i3c/Kconfig.nxp
+++ b/drivers/i3c/Kconfig.nxp
@@ -17,3 +17,13 @@ config I3C_MCUX
 	default y
 	help
 	  Enable mcux I3C driver.
+
+if I3C_MCUX
+
+config I3C_MCUX_DO_NOT_CHANGE_CLOCK_CONFIG
+	bool
+	help
+	  Hidden option indicates that the driver will not touch to
+	  clock configuration for I3C functionality.
+
+endif

--- a/drivers/i3c/Kconfig.nxp
+++ b/drivers/i3c/Kconfig.nxp
@@ -22,6 +22,7 @@ if I3C_MCUX
 
 config I3C_MCUX_DO_NOT_CHANGE_CLOCK_CONFIG
 	bool
+	default y if SOC_SERIES_S32ZE_R52
 	help
 	  Hidden option indicates that the driver will not touch to
 	  clock configuration for I3C functionality.

--- a/dts/arm/nxp/nxp_s32z27x_r52.dtsi
+++ b/dts/arm/nxp/nxp_s32z27x_r52.dtsi
@@ -716,5 +716,35 @@
 			interrupt-names = "rx_tx", "error";
 			clocks = <&clock NXP_S32_P5_CANXL_PE_CLK>;
 		};
+
+		i3c0: i3c@401d0000 {
+			compatible = "nxp,mcux-i3c";
+			reg = <0x401d0000 0x10000>;
+			#address-cells = <3>;
+			#size-cells = <0>;
+			interrupts = <GIC_SPI 252 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_P0_REG_INTF_CLK>;
+			status = "disabled";
+		};
+
+		i3c1: i3c@409d0000 {
+			compatible = "nxp,mcux-i3c";
+			reg = <0x409d0000 0x10000>;
+			#address-cells = <3>;
+			#size-cells = <0>;
+			interrupts = <GIC_SPI 253 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_P1_REG_INTF_CLK>;
+			status = "disabled";
+		};
+
+		i3c2: i3c@421d0000 {
+			compatible = "nxp,mcux-i3c";
+			reg = <0x421d0000 0x10000>;
+			#address-cells = <3>;
+			#size-cells = <0>;
+			interrupts = <GIC_SPI 254 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_P4_REG_INTF_CLK>;
+			status = "disabled";
+		};
 	};
 };

--- a/dts/bindings/i3c/nxp,mcux-i3c.yaml
+++ b/dts/bindings/i3c/nxp,mcux-i3c.yaml
@@ -25,17 +25,14 @@ properties:
   clk-divider:
     type: int
     description: Main clock divider for I3C
-    required: true
 
   clk-divider-tc:
     type: int
     description: TC clock divider for I3C
-    required: true
 
   clk-divider-slow:
     type: int
     description: Slow clock divider for I3C
-    required: true
 
   disable-open-drain-high-pp:
     type: boolean

--- a/tests/drivers/eeprom/api/testcase.yaml
+++ b/tests/drivers/eeprom/api/testcase.yaml
@@ -14,6 +14,10 @@ tests:
       - qemu_x86
       - nucleo_l152re
       - nucleo_l073rz
+      - s32z270dc2_rtu0_r52
+      - s32z270dc2_rtu1_r52
+      - s32z270dc2_rtu0_r52@D
+      - s32z270dc2_rtu1_r52@D
     integration_platforms:
       - qemu_x86
   drivers.eeprom.api.w_at2x_emul:

--- a/west.yml
+++ b/west.yml
@@ -193,7 +193,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 2a294b540c09b36f7cddece44d25628bfde5970e
+      revision: pull/310/head
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
This adds support for I3C hw block on S32Z27, reuse mcux i3c shim driver. Due to internal stuctural issues, I3C mode functionality is not guaranteed on this platform, so do not use the I3C driver to communicate with I3C devices. Legacy I2C mode is fully
functional as specified.

Tested on s32z270dc2 boards with `tests\drivers\eeprom\api`