### PR TITLE
drivers: flash: spi_nor: boot into DPD

### DIFF
--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -1359,6 +1359,16 @@ static int spi_nor_pm_control(const struct device *dev, enum pm_device_action ac
 	case PM_DEVICE_ACTION_TURN_ON:
 		/* Coming out of power off */
 		rc = spi_nor_configure(dev);
+#ifndef CONFIG_SPI_NOR_IDLE_IN_DPD
+		if (rc == 0) {
+			/* Move to DPD, the correct device state
+			 * for PM_DEVICE_STATE_SUSPENDED
+			 */
+			acquire_device(dev);
+			rc = enter_dpd(dev);
+			release_device(dev);
+		}
+#endif /* CONFIG_SPI_NOR_IDLE_IN_DPD */
 		break;
 	case PM_DEVICE_ACTION_TURN_OFF:
 		break;


### PR DESCRIPTION
Boot into the deep power down state when `SPI_NOR_IDLE_IN_DPD` is not enabled. DPD is the correct hardware state for the `SUSPENDED` software state. Without this change, it takes a cycle of `SUSPENDED->ACTIVE->SUSPENDED` to get to the low power state.

This does not change the behaviour of the driver when runtime PM is not enabled, as `pm_device_driver_init` immediately runs the `PM_DEVICE_ACTION_RESUME` action after this change, which brings the device out of DPD.