### PR TITLE
Bluetooth: Host: Add LE Power Control Request Procedure APIs

### DIFF
--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -571,6 +571,35 @@ struct bt_hci_rp_read_tx_power_level {
 	int8_t   tx_power_level;
 } __packed;
 
+#define BT_HCI_LE_TX_POWER_PHY_1M               0x01
+#define BT_HCI_LE_TX_POWER_PHY_2M               0x02
+#define BT_HCI_LE_TX_POWER_PHY_CODED_S8         0x03
+#define BT_HCI_LE_TX_POWER_PHY_CODED_S2         0x04
+#define BT_HCI_OP_LE_ENH_READ_TX_POWER_LEVEL    BT_OP(BT_OGF_LE, 0x0076)
+struct bt_hci_cp_le_read_tx_power_level {
+	uint16_t handle;
+	uint8_t  phy;
+} __packed;
+
+struct bt_hci_rp_le_read_tx_power_level {
+	uint8_t  status;
+	uint16_t handle;
+	uint8_t  phy;
+	int8_t   current_tx_power_level;
+	int8_t   max_tx_power_level;
+} __packed;
+
+#define BT_HCI_OP_LE_READ_REMOTE_TX_POWER_LEVEL	BT_OP(BT_OGF_LE, 0x0077)
+
+#define BT_HCI_LE_TX_POWER_REPORT_DISABLE       0x00
+#define BT_HCI_LE_TX_POWER_REPORT_ENABLE        0x01
+#define BT_HCI_OP_LE_SET_TX_POWER_REPORT_ENABLE BT_OP(BT_OGF_LE, 0x007A)
+struct bt_hci_cp_le_set_tx_power_report_enable {
+	uint16_t handle;
+	uint8_t  local_enable;
+	uint8_t  remote_enable;
+} __packed;
+
 #define BT_HCI_CTL_TO_HOST_FLOW_DISABLE         0x00
 #define BT_HCI_CTL_TO_HOST_FLOW_ENABLE          0x01
 #define BT_HCI_OP_SET_CTL_TO_HOST_FLOW          BT_OP(BT_OGF_BASEBAND, 0x0031)
@@ -2903,6 +2932,26 @@ struct bt_hci_evt_le_req_peer_sca_complete {
 	uint8_t  status;
 	uint16_t handle;
 	uint8_t  sca;
+} __packed;
+
+/** Reason for Transmit power reporting.
+ */
+/* Local Transmit power changed. */
+#define	BT_HCI_LE_TX_POWER_REPORT_REASON_LOCAL_CHANGED         0x00
+/* Remote Transmit power changed. */
+#define	BT_HCI_LE_TX_POWER_REPORT_REASON_REMOTE_CHANGED        0x01
+/* HCI_LE_Read_Remote_Transmit_Power_Level command completed. */
+#define	BT_HCI_LE_TX_POWER_REPORT_REASON_READ_REMOTE_COMPLETED 0x02
+
+#define BT_HCI_EVT_LE_TRANSMIT_POWER_REPORT     0x21
+struct bt_hci_evt_le_transmit_power_report {
+	uint8_t	 status;
+	uint16_t handle;
+	uint8_t  reason;
+	uint8_t  phy;
+	int8_t   tx_power_level;
+	uint8_t  tx_power_level_flag;
+	int8_t   delta;
 } __packed;
 
 #define BT_HCI_EVT_LE_BIGINFO_ADV_REPORT        0x22

--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -175,6 +175,14 @@ config BT_SCA_UPDATE
 	depends on !BT_CTLR || BT_CTLR_SCA_UPDATE_SUPPORT
 	help
 	  Enable support for Bluetooth 5.1 Sleep Clock Accuracy Update Procedure
+
+config BT_TRANSMIT_POWER_CONTROL
+	bool "LE Power Control"
+	depends on !BT_CTLR || BT_CTLR_LE_POWER_CONTROL_SUPPORT
+	help
+	  Enable support for LE Power Control Request feature that is defined in the
+	  Bluetooth Core specification, Version 5.4 | Vol 6, Part B, Section 4.6.31.
+
 endif # BT_CONN
 
 rsource "Kconfig.iso"

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -101,6 +101,9 @@ config BT_CTLR_READ_ISO_LINK_QUALITY_SUPPORT
 		   BT_CTLR_PERIPHERAL_ISO_SUPPORT
 	bool
 
+config BT_CTLR_LE_POWER_CONTROL_SUPPORT
+	bool
+
 config BT_CTLR
 	bool "Bluetooth Controller"
 	help
@@ -483,6 +486,14 @@ config BT_CTLR_CONN_RSSI
 	default y if BT_HCI_RAW
 	help
 	  Enable connection RSSI measurement.
+
+config BT_CTLR_LE_POWER_CONTROL
+	bool "LE Power Control Request Feature"
+	depends on BT_CTLR_LE_POWER_CONTROL_SUPPORT
+	default y if BT_TRANSMIT_POWER_CONTROL
+	help
+	  Enable support for LE Power Control Request feature that is defined in the
+	  Bluetooth Core specification, Version 5.4 | Vol 6, Part B, Section 4.6.31.
 
 endif # BT_CONN
 

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -364,6 +364,9 @@ void notify_le_phy_updated(struct bt_conn *conn);
 
 bool le_param_req(struct bt_conn *conn, struct bt_le_conn_param *param);
 
+void notify_tx_power_report(struct bt_conn *conn,
+			    struct bt_conn_le_tx_power_report report);
+
 #if defined(CONFIG_BT_SMP)
 /* If role specific LTK is present */
 bool bt_conn_ltk_present(const struct bt_conn *conn);

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2399,6 +2399,33 @@ int bt_hci_register_vnd_evt_cb(bt_hci_vnd_evt_cb_t cb)
 }
 #endif /* CONFIG_BT_HCI_VS_EVT_USER */
 
+#if defined(CONFIG_BT_TRANSMIT_POWER_CONTROL)
+void bt_hci_le_transmit_power_report(struct net_buf *buf)
+{
+	struct bt_hci_evt_le_transmit_power_report *evt;
+	struct bt_conn_le_tx_power_report report;
+	struct bt_conn *conn;
+
+	evt = net_buf_pull_mem(buf, sizeof(*evt));
+	conn = bt_conn_lookup_handle(sys_le16_to_cpu(evt->handle), BT_CONN_TYPE_LE);
+	if (!conn) {
+		LOG_ERR("Unknown conn handle 0x%04X for transmit power report",
+		       sys_le16_to_cpu(evt->handle));
+		return;
+	}
+
+	report.reason = evt->reason;
+	report.phy = evt->phy;
+	report.tx_power_level = evt->tx_power_level;
+	report.tx_power_level_flag = evt->tx_power_level_flag;
+	report.delta = evt->delta;
+
+	notify_tx_power_report(conn, report);
+
+	bt_conn_unref(conn);
+}
+#endif /* CONFIG_BT_TRANSMIT_POWER_CONTROL */
+
 static const struct event_handler vs_events[] = {
 #if defined(CONFIG_BT_DF_VS_CL_IQ_REPORT_16_BITS_IQ_SAMPLES)
 	EVENT_HANDLER(BT_HCI_EVT_VS_LE_CONNECTIONLESS_IQ_REPORT,
@@ -2544,6 +2571,10 @@ static const struct event_handler meta_events[] = {
 	EVENT_HANDLER(BT_HCI_EVT_LE_CTE_REQUEST_FAILED, bt_hci_le_df_cte_req_failed,
 		      sizeof(struct bt_hci_evt_le_cte_req_failed)),
 #endif /* CONFIG_BT_DF_CONNECTION_CTE_REQ */
+#if defined(CONFIG_BT_TRANSMIT_POWER_CONTROL)
+	EVENT_HANDLER(BT_HCI_EVT_LE_TRANSMIT_POWER_REPORT, bt_hci_le_transmit_power_report,
+		      sizeof(struct bt_hci_evt_le_transmit_power_report)),
+#endif /* CONFIG_BT_TRANSMIT_POWER_CONTROL */
 #if defined(CONFIG_BT_PER_ADV_SYNC_RSP)
 	EVENT_HANDLER(BT_HCI_EVT_LE_PER_ADVERTISING_REPORT_V2, bt_hci_le_per_adv_report_v2,
 		      sizeof(struct bt_hci_evt_le_per_advertising_report_v2)),
@@ -3088,6 +3119,9 @@ static int le_set_event_mask(void)
 		    (BT_FEAT_LE_PHY_2M(bt_dev.le.features) ||
 		     BT_FEAT_LE_PHY_CODED(bt_dev.le.features))) {
 			mask |= BT_EVT_MASK_LE_PHY_UPDATE_COMPLETE;
+		}
+		if (IS_ENABLED(CONFIG_BT_TRANSMIT_POWER_CONTROL)) {
+			mask |= BT_EVT_MASK_LE_TRANSMIT_POWER_REPORTING;
 		}
 	}
 

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -99,10 +99,14 @@ static const char *phy2str(uint8_t phy)
 {
 	switch (phy) {
 	case 0: return "No packets";
-	case BT_GAP_LE_PHY_1M: return "LE 1M";
-	case BT_GAP_LE_PHY_2M: return "LE 2M";
-	case BT_GAP_LE_PHY_CODED: return "LE Coded";
-	default: return "Unknown";
+	case BT_GAP_LE_PHY_1M:
+		return "LE 1M";
+	case BT_GAP_LE_PHY_2M:
+		return "LE 2M";
+	case BT_GAP_LE_PHY_CODED:
+		return "LE Coded";
+	default:
+		return "Unknown";
 	}
 }
 #endif

--- a/tests/bluetooth/shell/testcase.yaml
+++ b/tests/bluetooth/shell/testcase.yaml
@@ -22,6 +22,13 @@ tests:
     tags: bluetooth
     harness: keyboard
     min_flash: 145
+  bluetooth.shell.power_control_request:
+    extra_configs:
+      - CONFIG_BT_TRANSMIT_POWER_CONTROL=y
+      - CONFIG_BT_CTLR=n
+    platform_allow:
+      - native_posix
+    build_only: true
   bluetooth.shell.cdc_acm:
     extra_args:
       - OVERLAY_CONFIG=cdc_acm.conf


### PR DESCRIPTION
This commit adds the LE API's for the LE Power Control Request Feature in Zephyr.

The support of feature is provided with the controller-based feature selection with BT_CTLR_LE_POWER_CONTROL_SUPPORT and is selectable via BT_TRANSMIT_POWER_CONTROL.

With the new APIs, the applications will:
get improved reading of local and remote tx power
be aware of changes in remote or local tx power

Defined HCI commands in Core Spec v5.4:
7.8.117 LE Enhanced Read Transmit Power Level command: improvement to existing local tx power reading.
7.8.118 LE Read Remote Transmit Power Level command: Remote tx power is read through an event (LE Transmit Power Reporting) 7.8.121 LE Set Transmit Power Reporting Enable command: Enables local or remote tx power reporting to monitor changes in tx power 7.7.65.33 LE Transmit Power Reporting event

Note: to utilize the Feature fully, Nordic-LL-only vendor-specific commands are needed. These will not be added in RTOS zephyr but instead implemented in a maintainable way in sdk.