### PR TITLE
drivers: intc: plic: Fix memory-mapped register offset calculation

### DIFF
--- a/drivers/interrupt_controller/intc_plic.c
+++ b/drivers/interrupt_controller/intc_plic.c
@@ -59,16 +59,21 @@ struct plic_config {
 static uint32_t save_irq;
 static const struct device *save_dev;
 
-static inline uint32_t local_irq_to_reg_offset(uint32_t local_irq)
+static inline uint32_t local_irq_to_reg_index(uint32_t local_irq)
 {
 	return local_irq >> LOG2(PLIC_REG_SIZE);
+}
+
+static inline uint32_t local_irq_to_reg_offset(uint32_t local_irq)
+{
+	return local_irq_to_reg_index(local_irq) * sizeof(uint32_t);
 }
 
 static inline uint32_t get_plic_enabled_size(const struct device *dev)
 {
 	const struct plic_config *config = dev->config;
 
-	return local_irq_to_reg_offset(config->num_irqs) + 1;
+	return local_irq_to_reg_index(config->num_irqs) + 1;
 }
 
 static inline mem_addr_t get_claim_complete_addr(const struct device *dev)

--- a/drivers/interrupt_controller/intc_plic.c
+++ b/drivers/interrupt_controller/intc_plic.c
@@ -71,14 +71,14 @@ static inline uint32_t get_plic_enabled_size(const struct device *dev)
 	return local_irq_to_reg_offset(config->num_irqs) + 1;
 }
 
-static inline uint32_t get_claim_complete_offset(const struct device *dev)
+static inline mem_addr_t get_claim_complete_addr(const struct device *dev)
 {
 	const struct plic_config *config = dev->config;
 
 	return config->reg + PLIC_REG_REGS_CLAIM_COMPLETE_OFFSET;
 }
 
-static inline uint32_t get_threshold_priority_offset(const struct device *dev)
+static inline mem_addr_t get_threshold_priority_addr(const struct device *dev)
 {
 	const struct plic_config *config = dev->config;
 
@@ -240,7 +240,7 @@ const struct device *riscv_plic_get_dev(void)
 static void plic_irq_handler(const struct device *dev)
 {
 	const struct plic_config *config = dev->config;
-	mem_addr_t claim_complete_addr = get_claim_complete_offset(dev);
+	mem_addr_t claim_complete_addr = get_claim_complete_addr(dev);
 	struct _isr_table_entry *ite;
 	int edge_irq;
 
@@ -305,7 +305,7 @@ static int plic_init(const struct device *dev)
 	const struct plic_config *config = dev->config;
 	mem_addr_t en_addr = config->irq_en;
 	mem_addr_t prio_addr = config->prio;
-	mem_addr_t thres_prio_addr = get_threshold_priority_offset(dev);
+	mem_addr_t thres_prio_addr = get_threshold_priority_addr(dev);
 
 	/* Ensure that all interrupts are disabled initially */
 	for (uint32_t i = 0; i < get_plic_enabled_size(dev); i++) {

--- a/drivers/interrupt_controller/intc_plic.c
+++ b/drivers/interrupt_controller/intc_plic.c
@@ -45,6 +45,12 @@
 #define PLIC_REG_SIZE 32
 #define PLIC_REG_MASK BIT_MASK(LOG2(PLIC_REG_SIZE))
 
+#ifdef CONFIG_TEST_INTC_PLIC
+#define INTC_PLIC_STATIC
+#else
+#define INTC_PLIC_STATIC static inline
+#endif
+
 typedef void (*riscv_plic_irq_config_func_t)(void);
 struct plic_config {
 	mem_addr_t prio;
@@ -59,12 +65,12 @@ struct plic_config {
 static uint32_t save_irq;
 static const struct device *save_dev;
 
-static inline uint32_t local_irq_to_reg_index(uint32_t local_irq)
+INTC_PLIC_STATIC uint32_t local_irq_to_reg_index(uint32_t local_irq)
 {
 	return local_irq >> LOG2(PLIC_REG_SIZE);
 }
 
-static inline uint32_t local_irq_to_reg_offset(uint32_t local_irq)
+INTC_PLIC_STATIC uint32_t local_irq_to_reg_offset(uint32_t local_irq)
 {
 	return local_irq_to_reg_index(local_irq) * sizeof(uint32_t);
 }

--- a/tests/drivers/interrupt_controller/intc_plic/CMakeLists.txt
+++ b/tests/drivers/interrupt_controller/intc_plic/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(intc_plic)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/drivers/interrupt_controller/intc_plic/Kconfig
+++ b/tests/drivers/interrupt_controller/intc_plic/Kconfig
@@ -1,0 +1,10 @@
+# Copyright (c) 2023 Antmicro
+# SPDX-License-Identifier: Apache-2.0
+
+config TEST_INTC_PLIC
+	bool
+	default y
+	help
+	   Declare some intc_plic.c functions in the global scope for verification.
+
+source "Kconfig"

--- a/tests/drivers/interrupt_controller/intc_plic/prj.conf
+++ b/tests/drivers/interrupt_controller/intc_plic/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/tests/drivers/interrupt_controller/intc_plic/src/main.c
+++ b/tests/drivers/interrupt_controller/intc_plic/src/main.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023 Antmicro
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+#include <zephyr/ztest.h>
+
+uint32_t local_irq_to_reg_index(uint32_t local_irq);
+uint32_t local_irq_to_reg_offset(uint32_t local_irq);
+
+ZTEST_SUITE(intc_plic, NULL, NULL, NULL, NULL, NULL);
+
+/* Test calculating the register index from a local IRQ number */
+ZTEST(intc_plic, test_local_irq_to_reg_index)
+{
+	zassert_equal(0, local_irq_to_reg_index(0x1f));
+	zassert_equal(1, local_irq_to_reg_index(0x20));
+	zassert_equal(1, local_irq_to_reg_index(0x3f));
+	zassert_equal(2, local_irq_to_reg_index(0x40));
+}
+
+/* Test calculating the register offset from a local IRQ number */
+ZTEST(intc_plic, test_local_irq_to_reg_offset)
+{
+	zassert_equal(0, local_irq_to_reg_offset(0x1f));
+	zassert_equal(4, local_irq_to_reg_offset(0x20));
+	zassert_equal(4, local_irq_to_reg_offset(0x3f));
+	zassert_equal(8, local_irq_to_reg_offset(0x40));
+}

--- a/tests/drivers/interrupt_controller/intc_plic/testcase.yaml
+++ b/tests/drivers/interrupt_controller/intc_plic/testcase.yaml
@@ -1,0 +1,7 @@
+tests:
+  drivers.interrupt_controller.intc_plic:
+    tags:
+      - drivers
+      - interrupt
+      - plic
+    platform_allow: qemu_riscv64


### PR DESCRIPTION
This MR fixes register offset calculation in the PLIC driver.

https://github.com/zephyrproject-rtos/zephyr/commit/ffb8f31bffd39b3a21e99e31deb7555d0585d81c removed a pointer-arithmetic-induced multiplication of the calculated register offset. As a result the register offsets are 4 times too small. For example, riscv_plic_irq_enable(10251) with 2nd level interrupts enabled and the default 8-bit size currently writes to offset 0x1 instead of 0x4.

Only interrupt numbers above 0x1f are affected.

Fixes: #65321