### PR TITLE
MAINTAINERS: add the PLIC interrupt controller driver to the RISC-V area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2290,6 +2290,7 @@ RISCV arch:
     - soc/riscv/
     - tests/arch/riscv/
     - doc/hardware/arch/risc-v.rst
+    - drivers/interrupt_controller/intc_plic.c
   labels:
     - "area: RISCV"
 


### PR DESCRIPTION
This PR adds the RISC-V Platform-Level Interrupt Controller driver to the RISC-V area of maintenance. This is done so that PRs that are introducing changes to the PLIC driver won't be missed by RISC-V arch maintainers.

An example of a PR that would not be otherwise tagged: https://github.com/zephyrproject-rtos/zephyr/pull/65283.