### PR TITLE
drivers: watchdog: wdt_nrfx: Remove config field from config structure

### DIFF
--- a/drivers/watchdog/wdt_nrfx.c
+++ b/drivers/watchdog/wdt_nrfx.c
@@ -20,37 +20,32 @@ struct wdt_nrfx_data {
 };
 
 struct wdt_nrfx_config {
-	nrfx_wdt_t	  wdt;
-	nrfx_wdt_config_t config;
+	nrfx_wdt_t wdt;
 };
 
 static int wdt_nrf_setup(const struct device *dev, uint8_t options)
 {
 	const struct wdt_nrfx_config *config = dev->config;
-	struct wdt_nrfx_data *data = dev->data;
-	uint32_t behaviour;
+	const struct wdt_nrfx_data *data = dev->data;
+	nrfx_err_t err_code;
 
-	/* Activate all available options. Run in all cases. */
-	behaviour = NRF_WDT_BEHAVIOUR_RUN_SLEEP_MASK | NRF_WDT_BEHAVIOUR_RUN_HALT_MASK;
+	nrfx_wdt_config_t wdt_config = {
+		.reload_value = data->m_timeout
+	};
 
-	/* Deactivate running in sleep mode. */
-	if (options & WDT_OPT_PAUSE_IN_SLEEP) {
-		behaviour &= ~NRF_WDT_BEHAVIOUR_RUN_SLEEP_MASK;
+	if (!(options & WDT_OPT_PAUSE_IN_SLEEP)) {
+		wdt_config.behaviour |= NRF_WDT_BEHAVIOUR_RUN_SLEEP_MASK;
 	}
 
-	/* Deactivate running when debugger is attached. */
-	if (options & WDT_OPT_PAUSE_HALTED_BY_DBG) {
-		behaviour &= ~NRF_WDT_BEHAVIOUR_RUN_HALT_MASK;
+	if (!(options & WDT_OPT_PAUSE_HALTED_BY_DBG)) {
+		wdt_config.behaviour |= NRF_WDT_BEHAVIOUR_RUN_HALT_MASK;
 	}
 
-	nrf_wdt_behaviour_set(config->wdt.p_reg, behaviour);
-	/* The watchdog timer is driven by the LFCLK clock running at 32768 Hz.
-	 * The timeout value given in milliseconds needs to be converted here
-	 * to watchdog ticks.*/
-	nrf_wdt_reload_value_set(
-		config->wdt.p_reg,
-		(uint32_t)(((uint64_t)data->m_timeout * 32768U)
-			   / 1000));
+	err_code = nrfx_wdt_reconfigure(&config->wdt, &wdt_config);
+
+	if (err_code != NRFX_SUCCESS) {
+		return -EBUSY;
+	}
 
 	nrfx_wdt_enable(&config->wdt);
 
@@ -162,8 +157,8 @@ static void wdt_event_handler(const struct device *dev, uint32_t requests)
 		IRQ_CONNECT(DT_IRQN(WDT(idx)), DT_IRQ(WDT(idx), priority),     \
 			    nrfx_isr, nrfx_wdt_##idx##_irq_handler, 0);	       \
 		err_code = nrfx_wdt_init(&config->wdt,			       \
-				 &config->config,			       \
-				 wdt_##idx##_event_handler);		       \
+					 NULL,				       \
+					 wdt_##idx##_event_handler);	       \
 		if (err_code != NRFX_SUCCESS) {				       \
 			return -EBUSY;					       \
 		}							       \
@@ -175,11 +170,6 @@ static void wdt_event_handler(const struct device *dev, uint32_t requests)
 	};								       \
 	static const struct wdt_nrfx_config wdt_##idx##z_config = {	       \
 		.wdt = NRFX_WDT_INSTANCE(idx),				       \
-		.config = {						       \
-			.behaviour = NRF_WDT_BEHAVIOUR_RUN_SLEEP_MASK |	       \
-				     NRF_WDT_BEHAVIOUR_RUN_HALT_MASK,	       \
-			.reload_value   = 2000,				       \
-		}							       \
 	};								       \
 	DEVICE_DT_DEFINE(WDT(idx),					       \
 			    wdt_##idx##_init,				       \


### PR DESCRIPTION
The field config of `nrfx_wdt_config_t` type is redundant in device config structure. Instead of that local variable is used in the setup function.