### PR TITLE
tfm: Change default TF-M model for profile small to match profile conf

### DIFF
--- a/modules/trusted-firmware-m/Kconfig.tfm
+++ b/modules/trusted-firmware-m/Kconfig.tfm
@@ -302,6 +302,7 @@ endif # TFM_BL2
 
 choice TFM_MODEL
 	prompt "TF-M Firmware Framework model"
+	default TFM_SFN if TFM_PROFILE_TYPE_SMALL
 	default TFM_IPC
 	help
 	  The Firmware Framework M (FF-M) provides different programming models


### PR DESCRIPTION
Change the default TF-M model for small profile to match the configuration set in the profile small configuration file. Otherwise we would be overriding the profile default.