### PR TITLE
west.yml: update modules/hal/stm32/hal_stm32 for stm32h503

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -229,7 +229,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 89ef0a3383edebf661073073bcdf6e2836fe90ee
+      revision: af2d314b6f7f87cfa8365009497132468ca3a686
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Update the stm32h5xx/drivers/include/
to enable the SAI, DelayBlock and DCACHE only if the instance exists in the soc. 
Which is not the case for stm32h503x device 

https://github.com/zephyrproject-rtos/hal_stm32/pull/181/

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/65280


This will avoid compilation issue when building a stm32h503 board:
- `error: unknown type name 'DCACHE_TypeDef'`
- `error: unknown type name 'DLYB_TypeDef'`
- `error: unknown type name 'SAI_Block_TypeDef'`

