### PR TITLE
usb: device_next: add SetFeature(TEST_MODE) support

### DIFF
--- a/include/zephyr/drivers/usb/udc.h
+++ b/include/zephyr/drivers/usb/udc.h
@@ -217,7 +217,7 @@ typedef int (*udc_event_cb_t)(const struct device *dev,
  * @brief UDC driver API
  * This is the mandatory API any USB device controller driver needs to expose
  * with exception of:
- *   device_speed() used by udc_device_speed(), not required for FS only devices
+ *   device_speed(), test_mode() are only required for HS controllers
  */
 struct udc_api {
 	enum udc_bus_speed (*device_speed)(const struct device *dev);
@@ -239,6 +239,8 @@ struct udc_api {
 	int (*host_wakeup)(const struct device *dev);
 	int (*set_address)(const struct device *dev,
 			   const uint8_t addr);
+	int (*test_mode)(const struct device *dev,
+			 const uint8_t mode, const bool dryrun);
 	int (*enable)(const struct device *dev);
 	int (*disable)(const struct device *dev);
 	int (*init)(const struct device *dev);
@@ -442,6 +444,42 @@ static inline int udc_set_address(const struct device *dev, const uint8_t addr)
 	api->lock(dev);
 	ret = api->set_address(dev, addr);
 	api->unlock(dev);
+
+	return ret;
+}
+
+/**
+ * @brief Enable Test Mode.
+ *
+ * For compliance testing, high-speed controllers must support test modes.
+ * A particular test is enabled by a SetFeature(TEST_MODE) request.
+ * To disable a test mode, device needs to be power cycled.
+ *
+ * @param[in] dev    Pointer to device struct of the driver instance
+ * @param[in] mode   Test mode
+ * @param[in] dryrun Verify that a particular mode can be enabled, but do not
+ *                   enable test mode
+ *
+ * @return 0 on success, all other values should be treated as error.
+ * @retval -ENOTSUP Test mode is not supported
+ */
+static inline int udc_test_mode(const struct device *dev,
+				const uint8_t mode, const bool dryrun)
+{
+	const struct udc_api *api = dev->api;
+	int ret;
+
+	if (!udc_is_enabled(dev)) {
+		return -EPERM;
+	}
+
+	if (api->test_mode != NULL) {
+		api->lock(dev);
+		ret = api->test_mode(dev, mode, dryrun);
+		api->unlock(dev);
+	} else {
+		ret = -ENOTSUP;
+	}
 
 	return ret;
 }

--- a/include/zephyr/drivers/usb/udc.h
+++ b/include/zephyr/drivers/usb/udc.h
@@ -40,6 +40,8 @@ struct udc_device_caps {
 	uint32_t rwup : 1;
 	/** Controller performs status OUT stage automatically */
 	uint32_t out_ack : 1;
+	/** Controller expects device address to be set before status stage */
+	uint32_t addr_before_status : 1;
 	/** Maximum packet size for control endpoint */
 	enum udc_mps0 mps0 : 2;
 };

--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -134,8 +134,8 @@ struct usbd_ch9_data {
 	uint32_t ep_halt;
 	/** USB device stack selected configuration */
 	uint8_t configuration;
-	/** Indicate new device address */
-	bool new_address;
+	/** Post status stage work required, e.g. set new device address */
+	bool post_status;
 	/** Array to track interfaces alternate settings */
 	uint8_t alternate[USBD_NUMOF_INTERFACES_MAX];
 };

--- a/subsys/usb/device_next/usbd_ch9.c
+++ b/subsys/usb/device_next/usbd_ch9.c
@@ -25,6 +25,9 @@ LOG_MODULE_REGISTER(usbd_ch9, CONFIG_USBD_LOG_LEVEL);
 #define CTRL_AWAIT_SETUP_DATA		0
 #define CTRL_AWAIT_STATUS_STAGE		1
 
+#define SF_TEST_MODE_SELECTOR(wIndex)		((uint8_t)((wIndex) >> 8))
+#define SF_TEST_LOWER_BYTE(wIndex)		((uint8_t)(wIndex))
+
 static bool reqtype_is_to_host(const struct usb_setup_packet *const setup)
 {
 	return setup->wLength && USB_REQTYPE_GET_DIR(setup->bmRequestType);
@@ -49,15 +52,26 @@ static int ch9_get_ctrl_type(struct usbd_contex *const uds_ctx)
 static int post_status_stage(struct usbd_contex *const uds_ctx)
 {
 	struct usb_setup_packet *setup = usbd_get_setup_pkt(uds_ctx);
-	int ret;
+	int ret = 0;
 
-	ret = udc_set_address(uds_ctx->dev, setup->wValue);
-	if (ret) {
-		LOG_ERR("Failed to set device address 0x%x", setup->wValue);
-		return ret;
+	if (setup->bRequest == USB_SREQ_SET_ADDRESS) {
+		ret = udc_set_address(uds_ctx->dev, setup->wValue);
+		if (ret) {
+			LOG_ERR("Failed to set device address 0x%x", setup->wValue);
+		}
 	}
 
-	uds_ctx->ch9_data.new_address = false;
+	if (setup->bRequest == USB_SREQ_SET_FEATURE &&
+	    setup->wValue == USB_SFS_TEST_MODE) {
+		uint8_t mode = SF_TEST_MODE_SELECTOR(setup->wIndex);
+
+		ret = udc_test_mode(uds_ctx->dev, mode, false);
+		if (ret) {
+			LOG_ERR("Failed to enable TEST_MODE %u", mode);
+		}
+	}
+
+	uds_ctx->ch9_data.post_status = false;
 
 	return ret;
 }
@@ -92,7 +106,7 @@ static int sreq_set_address(struct usbd_contex *const uds_ctx)
 			return ret;
 		}
 	} else {
-		uds_ctx->ch9_data.new_address = true;
+		uds_ctx->ch9_data.post_status = true;
 	}
 
 	if (usbd_state_is_address(uds_ctx) && setup->wValue == 0) {
@@ -256,6 +270,27 @@ static int sreq_clear_feature(struct usbd_contex *const uds_ctx)
 	return ret;
 }
 
+static int set_feature_test_mode(struct usbd_contex *const uds_ctx)
+{
+	struct usb_setup_packet *setup = usbd_get_setup_pkt(uds_ctx);
+	uint8_t mode = SF_TEST_MODE_SELECTOR(setup->wIndex);
+
+	if (setup->RequestType.recipient != USB_REQTYPE_RECIPIENT_DEVICE ||
+	    SF_TEST_LOWER_BYTE(setup->wIndex) != 0) {
+		errno = -ENOTSUP;
+		return 0;
+	}
+
+	if (udc_test_mode(uds_ctx->dev, mode, true) != 0) {
+		errno = -ENOTSUP;
+		return 0;
+	}
+
+	uds_ctx->ch9_data.post_status = true;
+
+	return 0;
+}
+
 static int sreq_set_feature(struct usbd_contex *const uds_ctx)
 {
 	struct usb_setup_packet *setup = usbd_get_setup_pkt(uds_ctx);
@@ -268,9 +303,13 @@ static int sreq_set_feature(struct usbd_contex *const uds_ctx)
 		return 0;
 	}
 
+	if (unlikely(setup->wValue == USB_SFS_TEST_MODE)) {
+		return set_feature_test_mode(uds_ctx);
+	}
+
 	/*
-	 * TEST_MODE is not supported yet, other are not specified
-	 * in default state, treat as error.
+	 * Other request behavior is not specified in the default state, treat
+	 * as an error.
 	 */
 	if (usbd_state_is_default(uds_ctx)) {
 		errno = -EPERM;
@@ -836,8 +875,8 @@ int usbd_handle_ctrl_xfer(struct usbd_contex *const uds_ctx,
 
 		if (ch9_get_ctrl_type(uds_ctx) == CTRL_AWAIT_STATUS_STAGE) {
 			LOG_INF("s-(out)-status finished");
-			if (unlikely(uds_ctx->ch9_data.new_address)) {
-				return post_status_stage(uds_ctx);
+			if (unlikely(uds_ctx->ch9_data.post_status)) {
+				ret = post_status_stage(uds_ctx);
 			}
 		} else {
 			LOG_WRN("Awaited s-(out)-status not finished");


### PR DESCRIPTION
Add support to set device address directly, required for #64943 
Add SetFeature(TEST_MODE) support, can be used for #64943 but depend on the first patch.