### PR TITLE
doc: application: Fix application build comment

### DIFF
--- a/doc/_extensions/zephyr/application.py
+++ b/doc/_extensions/zephyr/application.py
@@ -415,7 +415,7 @@ class ZephyrAppCommandsDirective(Directive):
                                               cmake_args, source_dir))
         if not compact:
             content.extend(['',
-                            '# Now run ninja on the generated build system:'])
+                            '# Now run the build tool on the generated build system:'])
 
         if 'build' in goals:
             content.append('{}{}{}'.format(generator, tool_build_dir,


### PR DESCRIPTION
Fix the application build comment to make it valid for both ninja and make build tools. 
It generated the wrong "ninja" comment for "make".