### PR TITLE
tfm: Change SFN and FP_HARDABI dependency

### DIFF
--- a/arch/arm/core/Kconfig
+++ b/arch/arm/core/Kconfig
@@ -271,7 +271,6 @@ config FP_HARDABI
 	# TF-M build system does not build the NS app and libraries correctly with Hard ABI.
 	# This limitation should be removed in the next TF-M synchronization.
 	depends on !TFM_BUILD_NS
-	depends on !(BUILD_WITH_TFM && !TFM_IPC)
 	help
 	  This option selects the Floating point ABI in which hardware floating
 	  point instructions are generated and uses FPU-specific calling

--- a/modules/trusted-firmware-m/Kconfig.tfm
+++ b/modules/trusted-firmware-m/Kconfig.tfm
@@ -323,6 +323,7 @@ config TFM_IPC
 
 config TFM_SFN
 	bool "SFN model"
+	depends on !FP_HARDABI
 	help
 	  Use the SFN Model as the SPM backend for the PSA API.
 	  The SFN model supports the SFN Partition model, and isolation level 1.


### PR DESCRIPTION
TF-M only suports floating point in IPC model, not the SFN model. Since floating point is a basic feature of the architecture and TF-M has the limitation it makes more sense for the dependency to exist in TF-M and and limit the TF-M model choice instead of limiting the option to enable floating point.