### PR TITLE
arm: nxp_mpu: enable module's clock only when needed

### DIFF
--- a/arch/arm/core/mpu/nxp_mpu.c
+++ b/arch/arm/core/mpu/nxp_mpu.c
@@ -37,8 +37,10 @@ static uint8_t static_regions_num;
 /* Global MPU configuration at system initialization. */
 static void mpu_init(void)
 {
+#if defined(CONFIG_SOC_FAMILY_KINETIS)
 	/* Enable clock for the Memory Protection Unit (MPU). */
 	CLOCK_EnableClock(kCLOCK_Sysmpu0);
+#endif
 }
 
 /**


### PR DESCRIPTION
NXP SYSMPU is used in other SoCs besides the Kinetis series. For devices like S32K1xx, its bus interface clock lacks of clock gating and it's driven by the system clock. Hence, only enable the module clock for the Kinetis series.
This PR is in the context of bring up support for S32K1xx devices.