### PR TITLE
drivers: drop few redundant guard around pm_policy_state_lock_*

### DIFF
--- a/drivers/display/display_rm67162.c
+++ b/drivers/display/display_rm67162.c
@@ -434,18 +434,14 @@ static int rm67162_write(const struct device *dev, const uint16_t x,
 	 * give to the TE semaphore) before sending the frame
 	 */
 	if (config->te_gpio.port != NULL) {
-		if (IS_ENABLED(CONFIG_PM)) {
-			/* Block sleep state until next TE interrupt
-			 * so we can send frame during that interval
-			 */
-			pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE,
-						PM_ALL_SUBSTATES);
-		}
+		/* Block sleep state until next TE interrupt so we can send
+		 * frame during that interval
+		 */
+		pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE,
+					 PM_ALL_SUBSTATES);
 		k_sem_take(&data->te_sem, K_FOREVER);
-		if (IS_ENABLED(CONFIG_PM)) {
-			pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_IDLE,
-						PM_ALL_SUBSTATES);
-		}
+		pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_IDLE,
+					 PM_ALL_SUBSTATES);
 	}
 	src = buf;
 	first_cmd = true;

--- a/drivers/dma/dma_mcux_smartdma.c
+++ b/drivers/dma/dma_mcux_smartdma.c
@@ -148,12 +148,12 @@ static int dma_mcux_smartdma_start(const struct device *dev, uint32_t channel)
 {
 	const struct dma_mcux_smartdma_config *config = dev->config;
 
-#ifdef CONFIG_PM
 	/* Block PM transition until DMA completes */
 	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
-#endif
+
 	/* Kick off SMARTDMA */
 	config->base->CTRL = SMARTDMA_MAGIC | SMARTDMA_BOOT;
+
 	return 0;
 }
 
@@ -162,12 +162,13 @@ static int dma_mcux_smartdma_stop(const struct device *dev, uint32_t channel)
 {
 	ARG_UNUSED(dev);
 	ARG_UNUSED(channel);
+
 	/* Stop DMA  */
 	SMARTDMA_Reset();
-#ifdef CONFIG_PM
+
 	/* Release PM lock */
 	pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
-#endif
+
 	return 0;
 }
 
@@ -195,10 +196,9 @@ static void dma_mcux_smartdma_irq(const struct device *dev)
 	if (data->callback) {
 		data->callback(dev, data->user_data, 0, 0);
 	}
-#ifdef CONFIG_PM
+
 	/* Release PM lock */
 	pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
-#endif
 }
 
 /**

--- a/drivers/eeprom/eeprom_mchp_xec.c
+++ b/drivers/eeprom/eeprom_mchp_xec.c
@@ -241,9 +241,8 @@ static int eeprom_xec_read(const struct device *dev, off_t offset,
 	}
 
 	k_mutex_lock(&data->lock_mtx, K_FOREVER);
-#ifdef CONFIG_PM_DEVICE
 	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
-#endif
+
 	/* EEPROM HW READ */
 	for (chunk_idx = 0; chunk_idx < len; chunk_idx += XEC_EEPROM_TRANSFER_SIZE_READ) {
 		if ((len-chunk_idx) < XEC_EEPROM_TRANSFER_SIZE_READ) {
@@ -252,9 +251,7 @@ static int eeprom_xec_read(const struct device *dev, off_t offset,
 		eeprom_xec_data_read_32_bytes(regs, &data_buf[chunk_idx],
 						chunk_size, (offset+chunk_idx));
 	}
-#ifdef CONFIG_PM_DEVICE
 	pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
-#endif
 	k_mutex_unlock(&data->lock_mtx);
 
 	return 0;
@@ -280,9 +277,8 @@ static int eeprom_xec_write(const struct device *dev, off_t offset,
 	}
 
 	k_mutex_lock(&data->lock_mtx, K_FOREVER);
-#ifdef CONFIG_PM_DEVICE
 	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
-#endif
+
 	/* EEPROM HW WRITE */
 	for (chunk_idx = 0; chunk_idx < len; chunk_idx += XEC_EEPROM_TRANSFER_SIZE_WRITE) {
 		if ((len-chunk_idx) < XEC_EEPROM_TRANSFER_SIZE_WRITE) {
@@ -291,9 +287,8 @@ static int eeprom_xec_write(const struct device *dev, off_t offset,
 		eeprom_xec_data_write_32_bytes(regs, &data_buf[chunk_idx],
 							chunk_size, (offset+chunk_idx));
 	}
-#ifdef CONFIG_PM_DEVICE
+
 	pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
-#endif
 	k_mutex_unlock(&data->lock_mtx);
 
 	return 0;

--- a/drivers/kscan/kscan_mchp_xec.c
+++ b/drivers/kscan/kscan_mchp_xec.c
@@ -373,9 +373,8 @@ void polling_task(const struct device *dev, void *dummy2, void *dummy3)
 		drive_keyboard_column(dev, KEYBOARD_COLUMN_DRIVE_ALL);
 
 		k_sem_take(&data->poll_lock, K_FOREVER);
-#ifdef CONFIG_PM_DEVICE
 		pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
-#endif
+
 		uint32_t start_poll_cycles = k_cycle_get_32();
 
 		while (atomic_get(&data->enable_scan) == 1U) {
@@ -416,9 +415,8 @@ void polling_task(const struct device *dev, void *dummy2, void *dummy3)
 			/* Allow other threads to run while we sleep */
 			k_usleep(wait_period);
 		}
-#ifdef CONFIG_PM_DEVICE
+
 		pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
-#endif
 	}
 }
 

--- a/drivers/sensor/mchp_tach_xec/tach_mchp_xec.c
+++ b/drivers/sensor/mchp_tach_xec/tach_mchp_xec.c
@@ -58,9 +58,8 @@ int tach_xec_sample_fetch(const struct device *dev, enum sensor_channel chan)
 	struct tach_regs * const tach = cfg->regs;
 	uint8_t poll_count = 0;
 
-#ifdef CONFIG_PM_DEVICE
 	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
-#endif
+
 	while (poll_count < PIN_STS_TIMEOUT) {
 		/* See whether internal counter is already latched */
 		if (tach->STATUS & MCHP_TACH_STS_CNT_RDY) {
@@ -74,9 +73,9 @@ int tach_xec_sample_fetch(const struct device *dev, enum sensor_channel chan)
 		/* Allow other threads to run while we sleep */
 		k_usleep(USEC_PER_MSEC);
 	}
-#ifdef CONFIG_PM_DEVICE
+
 	pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
-#endif
+
 	if (poll_count == PIN_STS_TIMEOUT) {
 		return -EINVAL;
 	}


### PR DESCRIPTION
The pm_policy_state_lock_put and pm_policy_state_lock_put functions already become a no-op if CONFIG_PM is not enabled. Drop the guards around it in few different drivers.