### PR TITLE
doc: migration-guide: annotate various entry with the PR numbers

### DIFF
--- a/doc/releases/migration-guide-3.6.rst
+++ b/doc/releases/migration-guide-3.6.rst
@@ -26,7 +26,7 @@ Optional Modules
 The following modules have been made optional and are not downloaded with `west update` by default
 anymore:
 
-* ``canopennode``
+* ``canopennode`` (:github:`64139`)
 
 To enable them again use the ``west config manifest.project-filter -- +<module
 name>`` command, or ``west config manifest.group-filter -- +optional`` to
@@ -53,6 +53,8 @@ Device Drivers and Device Tree
         };
     };
 
+  (:github:`62994`)
+
 Power Management
 ================
 
@@ -61,7 +63,7 @@ Bootloader
 
 * MCUboot's deprecated ``CONFIG_ZEPHYR_TRY_MASS_ERASE`` Kconfig option has been removed. If an
   erase is needed when flashing MCUboot, this should now be provided directly to the ``west``
-  command e.g. ``west flash --erase``.
+  command e.g. ``west flash --erase``. (:github:`64703`)
 
 Bluetooth
 =========
@@ -71,15 +73,15 @@ Bluetooth
   :kconfig:option:`CONFIG_BT_HCI_IPC`, and the ``zephyr,bt-hci-rpmsg-ipc``
   Devicetree chosen is now ``zephyr,bt-hci-ipc``. The existing sample has also
   been renamed, from ``samples/bluetooth/hci_rpmsg`` to
-  ``samples/bluetooth/hci_ipc``.
+  ``samples/bluetooth/hci_ipc``. (:github:`64391`)
 * The BT GATT callback list, appended to by :c:func:`bt_gatt_cb_register`, is no longer
   cleared on :c:func:`bt_enable`. Callbacks can now be registered before the initial
   call to :c:func:`bt_enable`, and should no longer be re-registered after a :c:func:`bt_disable`
-  :c:func:`bt_enable` cycle.
+  :c:func:`bt_enable` cycle. (:github:`63693`)
 * The Bluetooth Mesh ``model`` declaration has been changed to add prefix ``const``.
   The ``model->user_data``, ``model->elem_idx`` and ``model->mod_idx`` field has been changed to
   the new runtime structure, replaced by ``model->rt->user_data``, ``model->rt->elem_idx`` and
-  ``model->rt->mod_idx`` separately.
+  ``model->rt->mod_idx`` separately. (:github:`65152`)
 
 LoRaWAN
 =======
@@ -88,6 +90,7 @@ LoRaWAN
   renamed from ``lorawan_set_battery_level_callback`` to
   :c:func:`lorawan_register_battery_level_callback` and the return type is now ``void``. This
   is more consistent with similar functions for downlink and data rate changed callbacks.
+  (:github:`65103`)
 
 Networking
 ==========
@@ -96,18 +99,19 @@ Networking
   :c:func:`coap_remove_observer` now returns a result if the observer was removed. This
   change is used by the newly introduced :ref:`coap_server_interface` subsystem. Also, the
   ``request`` argument for :c:func:`coap_well_known_core_get` is made ``const``.
+  (:github:`64265`)
 
 Other Subsystems
 ================
 
 * MCUmgr applications that make use of serial transports (shell or UART) must now select
   :kconfig:option:`CONFIG_CRC`, this was previously erroneously selected if MCUmgr was enabled,
-  when for non-serial transports it was not needed.
+  when for non-serial transports it was not needed. (:github:`64078`)
 
 * Touchscreen drivers :dtcompatible:`focaltech,ft5336` and
   :dtcompatible:`goodix,gt911` were using the incorrect polarity for the
   respective ``reset-gpios``. This has been fixed so those signals now have to
-  be flagged as :c:macro:`GPIO_ACTIVE_LOW` in the devicetree.
+  be flagged as :c:macro:`GPIO_ACTIVE_LOW` in the devicetree. (:github:`64800`)
 
 Recommended Changes
 *******************


### PR DESCRIPTION
Add a PR number reference to the input touchscreen polarity change entry.