### PR TITLE
include: arm: nxp_mpu: remove redundant HAL include

### DIFF
--- a/include/zephyr/arch/arm/mpu/nxp_mpu.h
+++ b/include/zephyr/arch/arm/mpu/nxp_mpu.h
@@ -8,10 +8,6 @@
 
 #ifndef _ASMLANGUAGE
 
-#include <fsl_common.h>
-
-#define NXP_MPU_BASE SYSMPU_BASE
-
 #define NXP_MPU_REGION_NUMBER 12
 
 /* Bus Master User Mode Access */


### PR DESCRIPTION
The inclusion of `fsl_common.h` solely for defining `NXP_MPU_BASE` is redundant, as this symbol is not used. Consequently, this unnecessary inclusion leads to the pervasive inclusion of HAL headers through kernel headers. The needed HAL definitions are already included into the NXP MPU driver implementation via the SoC header.