### PR TITLE
input: kbd_matrix: add pm_policy_state_lock guards

### DIFF
--- a/drivers/input/input_kbd_matrix.c
+++ b/drivers/input/input_kbd_matrix.c
@@ -12,6 +12,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/pm/policy.h>
 
 #define LOG_LEVEL CONFIG_INPUT_LOG_LEVEL
 LOG_MODULE_REGISTER(input_kbd_matrix);
@@ -274,12 +275,17 @@ static void input_kbd_matrix_polling_thread(void *arg1, void *unused2, void *unu
 		api->set_detect_mode(dev, true);
 
 		k_sem_take(&data->poll_lock, K_FOREVER);
+
+		pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+
 		LOG_DBG("Start KB scan");
 
 		/* Disable interrupt of KSI pins and start polling */
 		api->set_detect_mode(dev, false);
 
 		input_kbd_matrix_poll(dev);
+
+		pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
 	}
 }
 


### PR DESCRIPTION
Hi, bumped into this while migrating the [XEC](https://github.com/zephyrproject-rtos/zephyr/blob/main/drivers/kscan/kscan_mchp_xec.c#L377) keyboard driver, figured it deserves its own PR. Is there any reasons not to add the locks here at library level? Or make an option for this... not super confident about the potential side effects of doing this but I can't think of a reason not to, I guess it'll just delay the system potentially shutting down if a cat is sitting on the keyboard or something.

---

Add a pair of pm_policy_state_lock guards around the polling function to prevent the system from suspending while scanning the keyboard.