### PR TITLE
x86: Fix build when optimizations are disabled

### DIFF
--- a/arch/x86/core/intel64/cpu.c
+++ b/arch/x86/core/intel64/cpu.c
@@ -141,6 +141,7 @@ struct x86_cpuboot x86_cpuboot[] = {
 void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
 		    arch_cpustart_t fn, void *arg)
 {
+#if CONFIG_MP_MAX_NUM_CPUS > 1
 	uint8_t vector = ((unsigned long) x86_ap_start) >> 12;
 	uint8_t apic_id;
 
@@ -166,6 +167,13 @@ void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
 
 	while (x86_cpuboot[cpu_num].ready == 0) {
 	}
+#else
+	ARG_UNUSED(cpu_num);
+	ARG_UNUSED(stack);
+	ARG_UNUSED(sz);
+	ARG_UNUSED(fn);
+	ARG_UNUSED(arg);
+#endif
 }
 
 /* Per-CPU initialization, C domain. On the first CPU, z_x86_prep_c is the


### PR DESCRIPTION
When building without optimizations and with only one core the linker does not throw away arch_start_cpu and we get an undefined reference to x86_ap_start