### PR TITLE
lib/os/cbprintf: Picolibc doesn't support several cbprintf options

### DIFF
--- a/lib/os/Kconfig.cbprintf
+++ b/lib/os/Kconfig.cbprintf
@@ -90,6 +90,7 @@ config CBPRINTF_FP_A_SUPPORT
 config CBPRINTF_FP_ALWAYS_A
 	bool "Select %a format for all floating point specifications"
 	select CBPRINTF_FP_A_SUPPORT
+	depends on !PICOLIBC
 	help
 	  The %a format for floats requires significantly less code than the
 	  standard decimal representations (%f, %e, %g).  Selecting this
@@ -103,10 +104,12 @@ config CBPRINTF_FP_ALWAYS_A
 config CBPRINTF_N_SPECIFIER
 	bool "Support %n specifications"
 	depends on CBPRINTF_COMPLETE
+	depends on !PICOLIBC
 	default y
 	help
 	  If selected %n can be used to determine the number of characters
 	  emitted.  If enabled there is a small increase in code size.
+	  Picolibc does not support this feature for security reasons.
 
 # 180: 18% / 138 B (180 / 80) [NANO]
 config CBPRINTF_LIBC_SUBSTS
@@ -119,6 +122,9 @@ config CBPRINTF_LIBC_SUBSTS
 
 	  When used with CBPRINTF_NANO this increases the implementation code
 	  size by a small amount.
+
+	  When used with picolibc, this option generates cbprintf-compatible
+	  functions using stdio, effectively inverting the sense above.
 
 module = CBPRINTF_PACKAGE
 module-str = cbprintf_package


### PR DESCRIPTION
 * Picolibc doesn't provide the %a-only mode.

 * On advice from security experts, who report numerous vulnerabilities caused by %n in printf specifiers, picolibc never supports this feature.

 * Picolibc doesn't use cbprintf for C-library compatible functions.