### PR TITLE
STM32 UART: Request RX data flush on async_rx_enable

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1579,6 +1579,13 @@ static int uart_stm32_async_rx_enable(const struct device *dev,
 		return -EFAULT;
 	}
 
+	/* Flush RX data buffer */
+#ifdef USART_SR_RXNE
+	LL_USART_ClearFlag_RXNE(config->usart);
+#else
+	LL_USART_RequestRxDataFlush(config->usart);
+#endif /* USART_SR_RXNE */
+
 	/* Enable RX DMA requests */
 	uart_stm32_dma_rx_enable(dev);
 


### PR DESCRIPTION
When enabling async RX the first time after boot, there is an additional byte received with the first RX_DATA_RDY event, which seems to be caused by the RX data not being flushed before enabling the UART RX DMA.

Adding a request to flush the RX data register before enabling the RX DMA, solves the issue.

Potentially fixes #64436

To recreate the issue, connect the RX and TX UART pins on a b_u585i_iot02a board, and use the following overlay:
```
/*
 * Pins 2 and 3 must be connected to each other on the STMOD+1 connector to
 * loopback RX/TX.
 */

/ {
	aliases {
		test-uart = &usart2;
	};
};

&gpioh {
	misc_fixed_usart2 {
		gpio-hog;
		gpios = <13 GPIO_ACTIVE_HIGH>;
		output-high;
	};
};

&gpdma1 {
	status = "okay";
};

&usart2 {
	pinctrl-0 = <&usart2_tx_pa2 &usart2_rx_pa3 &usart2_rts_pa1 &usart2_cts_pa0>;
	pinctrl-names = "default";
	current-speed = <115200>;
	/* hw-flow-control; */

	dmas = <&gpdma1 0 27 STM32_DMA_PERIPH_TX
		&gpdma1 1 26 STM32_DMA_PERIPH_RX>;
	dma-names = "tx", "rx";

	status = "okay";
};
```
and add the following Kconfig options:
```
CONFIG_SERIAL=y
CONFIG_UART_ASYNC_API=y
```
Then build and run this application:
```
#include <stdio.h>
#include <string.h>
#include <zephyr/kernel.h>
#include <zephyr/drivers/uart.h>

static const struct device *uart = DEVICE_DT_GET(DT_ALIAS(test_uart));
static uint8_t rx_buf1[16];
static uint8_t rx_buf2[16];
static uint8_t rx_buf3[16];
static size_t rx_buf3_len;

static void uart_async_event_handler(const struct device *dev,
				     struct uart_event *evt, void *user_data)
{
	switch (evt->type) {
	case UART_RX_BUF_REQUEST:
		uart_rx_buf_rsp(uart, rx_buf2, sizeof(rx_buf2));
		break;

	case UART_RX_RDY:
		rx_buf3_len = evt->data.rx.len;
		memcpy(rx_buf3, &evt->data.rx.buf[evt->data.rx.offset], evt->data.rx.len);
		break;

	default:
		break;
	}
}

int main(void)
{
	uint8_t data[] = {1,2,3,4};

	uart_callback_set(uart, uart_async_event_handler, NULL);
	uart_rx_enable(uart, rx_buf1, sizeof(rx_buf1), 30000);
	uart_tx(uart, data, sizeof(data), 1000);
	k_msleep(100);
	printf("Transmitted: %u\n", sizeof(data));
	printf("Received: %u\n", rx_buf3_len);
	return 0;
}
```
You will see the following output without this PR
```
*** Booting Zephyr OS build zephyr-v3.5.0-1188-g97654a5e092e ***
Transmitted: 4
Received: 5
```
Compared to this if the fix in this PR is added
```
*** Booting Zephyr OS build zephyr-v3.5.0-1188-g97654a5e092e ***
Transmitted: 4
Received: 4
```

