### PR TITLE
net: Fix CMakeLists

### DIFF
--- a/drivers/modem/CMakeLists.txt
+++ b/drivers/modem/CMakeLists.txt
@@ -12,33 +12,30 @@ zephyr_library_sources_ifdef(CONFIG_MODEM_IFACE_UART_ASYNC modem_iface_uart_asyn
 zephyr_library_sources_ifdef(CONFIG_MODEM_CMD_HANDLER modem_cmd_handler.c)
 zephyr_library_sources_ifdef(CONFIG_MODEM_SOCKET modem_socket.c)
 
+zephyr_library_include_directories(${ZEPHYR_BASE}/subsys/net/ip)
+zephyr_library_include_directories(${ZEPHYR_BASE}/subsys/net/lib/sockets)
+
 if(CONFIG_MODEM_UBLOX_SARA)
-	zephyr_library_include_directories(${ZEPHYR_BASE}/subsys/net/ip)
 	zephyr_library_sources(ublox-sara-r4.c)
 endif()
 
 if(CONFIG_MODEM_QUECTEL_BG9X)
-	zephyr_library_include_directories(${ZEPHYR_BASE}/subsys/net/ip)
 	zephyr_library_sources(quectel-bg9x.c)
 endif()
 
 if(CONFIG_MODEM_WNCM14A2A)
-	zephyr_library_include_directories(${ZEPHYR_BASE}/subsys/net/ip)
 	zephyr_library_sources(wncm14a2a.c)
 endif()
 
 if(CONFIG_MODEM_GSM_PPP)
-	zephyr_library_include_directories(${ZEPHYR_BASE}/subsys/net/ip)
 	zephyr_library_sources(gsm_ppp.c)
 endif()
 
 if (CONFIG_MODEM_HL7800)
-  zephyr_library_include_directories(${ZEPHYR_BASE}/subsys/net/ip)
   zephyr_library_sources(hl7800.c)
 endif()
 
 if (CONFIG_MODEM_SIM7080)
-	zephyr_library_include_directories(${ZEPHYR_BASE}/subsys/net/ip)
 	zephyr_library_sources(simcom-sim7080.c)
 endif()
 

--- a/drivers/wifi/eswifi/CMakeLists.txt
+++ b/drivers/wifi/eswifi/CMakeLists.txt
@@ -5,6 +5,7 @@ if(CONFIG_WIFI_ESWIFI)
   zephyr_library_include_directories(
   # IP headers
   ${ZEPHYR_BASE}/subsys/net/ip
+  ${ZEPHYR_BASE}/subsys/net/lib/sockets
   )
 
   zephyr_library_sources(

--- a/drivers/wifi/simplelink/CMakeLists.txt
+++ b/drivers/wifi/simplelink/CMakeLists.txt
@@ -3,6 +3,7 @@
 if(CONFIG_WIFI_SIMPLELINK)
   zephyr_library_include_directories(
     ${ZEPHYR_BASE}/subsys/net/lib/tls_credentials
+    ${ZEPHYR_BASE}/subsys/net/lib/sockets
     )
   zephyr_library_sources(
     simplelink_support.c

--- a/subsys/mgmt/updatehub/CMakeLists.txt
+++ b/subsys/mgmt/updatehub/CMakeLists.txt
@@ -23,3 +23,5 @@ zephyr_library_sources_ifdef(CONFIG_USERSPACE updatehub_handlers.c)
 zephyr_include_directories(
   ${ZEPHYR_BASE}/subsys/mgmt/updatehub/include
 )
+
+zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)

--- a/subsys/net/lib/sockets/CMakeLists.txt
+++ b/subsys/net/lib/sockets/CMakeLists.txt
@@ -5,37 +5,37 @@ zephyr_syscall_header(
   ${ZEPHYR_BASE}/include/zephyr/net/socket_select.h
 )
 
-zephyr_include_directories(.)
+zephyr_library_include_directories(.)
 
-zephyr_sources(
+zephyr_library_sources(
   getaddrinfo.c
   sockets.c
   sockets_select.c
 )
 
 if(NOT CONFIG_NET_SOCKETS_OFFLOAD)
-zephyr_sources(
+zephyr_library_sources(
   getnameinfo.c
   sockets_misc.c
   )
 endif()
 
-zephyr_sources_ifdef(CONFIG_NET_SOCKETS_CAN                sockets_can.c)
-zephyr_sources_ifdef(CONFIG_NET_SOCKETS_PACKET             sockets_packet.c)
-zephyr_sources_ifdef(CONFIG_NET_SOCKETS_SOCKOPT_TLS        sockets_tls.c)
-zephyr_sources_ifdef(CONFIG_NET_SOCKETS_OFFLOAD            socket_offload.c)
-zephyr_sources_ifdef(CONFIG_NET_SOCKETS_OFFLOAD_DISPATCHER socket_dispatcher.c)
-zephyr_sources_ifdef(CONFIG_NET_SOCKETS_OBJ_CORE           socket_obj_core.c)
+zephyr_library_sources_ifdef(CONFIG_NET_SOCKETS_CAN                sockets_can.c)
+zephyr_library_sources_ifdef(CONFIG_NET_SOCKETS_PACKET             sockets_packet.c)
+zephyr_library_sources_ifdef(CONFIG_NET_SOCKETS_SOCKOPT_TLS        sockets_tls.c)
+zephyr_library_sources_ifdef(CONFIG_NET_SOCKETS_OFFLOAD            socket_offload.c)
+zephyr_library_sources_ifdef(CONFIG_NET_SOCKETS_OFFLOAD_DISPATCHER socket_dispatcher.c)
+zephyr_library_sources_ifdef(CONFIG_NET_SOCKETS_OBJ_CORE           socket_obj_core.c)
 
 if(CONFIG_NET_SOCKETS_NET_MGMT)
-  zephyr_sources(sockets_net_mgmt.c)
-  zephyr_include_directories(${ZEPHYR_BASE}/subsys/net/ip)
+  zephyr_library_sources(sockets_net_mgmt.c)
+  zephyr_library_include_directories(${ZEPHYR_BASE}/subsys/net/ip)
 endif()
 
 if(CONFIG_SOCKS)
-  zephyr_include_directories(${ZEPHYR_BASE}/subsys/net/lib/socks)
+  zephyr_library_include_directories(${ZEPHYR_BASE}/subsys/net/lib/socks)
 endif()
 
-zephyr_sources_ifdef(CONFIG_NET_SOCKETPAIR socketpair.c)
+zephyr_library_sources_ifdef(CONFIG_NET_SOCKETPAIR socketpair.c)
 
-zephyr_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)
+zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -847,13 +847,13 @@ ssize_t zsock_sendto_ctx(struct net_context *ctx, const void *buf, size_t len,
 ssize_t z_impl_zsock_sendto(int sock, const void *buf, size_t len, int flags,
 			   const struct sockaddr *dest_addr, socklen_t addrlen)
 {
-	int ret;
+	int bytes_sent;
 
-	ret = VTABLE_CALL(sendto, sock, buf, len, flags, dest_addr, addrlen);
+	bytes_sent = VTABLE_CALL(sendto, sock, buf, len, flags, dest_addr, addrlen);
 
-	sock_obj_core_update_send_stats(sock, ret);
+	sock_obj_core_update_send_stats(sock, bytes_sent);
 
-	return ret;
+	return bytes_sent;
 }
 
 #ifdef CONFIG_USERSPACE
@@ -932,13 +932,13 @@ ssize_t zsock_sendmsg_ctx(struct net_context *ctx, const struct msghdr *msg,
 
 ssize_t z_impl_zsock_sendmsg(int sock, const struct msghdr *msg, int flags)
 {
-	int ret;
+	int bytes_sent;
 
-	ret = VTABLE_CALL(sendmsg, sock, msg, flags);
+	bytes_sent = VTABLE_CALL(sendmsg, sock, msg, flags);
 
-	sock_obj_core_update_send_stats(sock, ret);
+	sock_obj_core_update_send_stats(sock, bytes_sent);
 
-	return ret;
+	return bytes_sent;
 }
 
 #ifdef CONFIG_USERSPACE
@@ -1498,13 +1498,13 @@ ssize_t zsock_recvfrom_ctx(struct net_context *ctx, void *buf, size_t max_len,
 ssize_t z_impl_zsock_recvfrom(int sock, void *buf, size_t max_len, int flags,
 			     struct sockaddr *src_addr, socklen_t *addrlen)
 {
-	int ret;
+	int bytes_received;
 
-	ret = VTABLE_CALL(recvfrom, sock, buf, max_len, flags, src_addr, addrlen);
+	bytes_received = VTABLE_CALL(recvfrom, sock, buf, max_len, flags, src_addr, addrlen);
 
-	sock_obj_core_update_recv_stats(sock, ret);
+	sock_obj_core_update_recv_stats(sock, bytes_received);
 
-	return ret;
+	return bytes_received;
 }
 
 #ifdef CONFIG_USERSPACE

--- a/subsys/net/lib/tls_credentials/CMakeLists.txt
+++ b/subsys/net/lib/tls_credentials/CMakeLists.txt
@@ -1,15 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_include_directories(.)
+zephyr_library_include_directories(.)
 
-zephyr_sources_ifdef(CONFIG_TLS_CREDENTIALS_BACKEND_VOLATILE
+zephyr_library_sources_ifdef(CONFIG_TLS_CREDENTIALS_BACKEND_VOLATILE
   tls_credentials.c
   tls_credentials_digest_raw.c
 )
-zephyr_sources_ifdef(CONFIG_TLS_CREDENTIALS_BACKEND_PROTECTED_STORAGE
+zephyr_library_sources_ifdef(CONFIG_TLS_CREDENTIALS_BACKEND_PROTECTED_STORAGE
   tls_credentials_trusted.c
   tls_credentials_digest_raw.c
 )
-zephyr_sources_ifdef(CONFIG_TLS_CREDENTIALS_SHELL
+zephyr_library_sources_ifdef(CONFIG_TLS_CREDENTIALS_SHELL
   tls_credentials_shell.c
 )
+
+zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)


### PR DESCRIPTION
Fix the CMakeLists of the tls_credentials and sockets folder to link/interface to the net library instead of the zephyr library. This fixes issues where some files are not found in the link interface when compiling the sources in this folder.

Fixes #65322