### PR TITLE
ci: do not mark coverity issues as stale

### DIFF
--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -24,5 +24,5 @@ jobs:
         stale-issue-label: 'Stale'
         stale-pr-label: 'Stale'
         exempt-pr-labels: 'Blocked,In progress'
-        exempt-issue-labels: 'In progress,Enhancement,Feature,Feature Request,RFC,Meta,Process'
+        exempt-issue-labels: 'In progress,Enhancement,Feature,Feature Request,RFC,Meta,Process,Coverity'
         operations-per-run: 400


### PR DESCRIPTION
Coverity issues need to be resolved and closed by owners, not by the
bot. Other wise we will continue scanning them and reporting them over
and over.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
