### PR TITLE
Bluetooth: Mesh: Make element as rodata

### DIFF
--- a/doc/releases/migration-guide-3.6.rst
+++ b/doc/releases/migration-guide-3.6.rst
@@ -82,6 +82,9 @@ Bluetooth
   The ``model->user_data``, ``model->elem_idx`` and ``model->mod_idx`` field has been changed to
   the new runtime structure, replaced by ``model->rt->user_data``, ``model->rt->elem_idx`` and
   ``model->rt->mod_idx`` separately. (:github:`65152`)
+* The Bluetooth Mesh ``element`` declaration has been changed to add prefix ``const``.
+  The ``elem->addr`` field has been changed to the new runtime structure, replaced by
+  ``elem->rt->addr``. (:github:`65388`)
 
 LoRaWAN
 =======

--- a/include/zephyr/bluetooth/mesh/access.h
+++ b/include/zephyr/bluetooth/mesh/access.h
@@ -145,19 +145,23 @@ extern "C" {
  *  @param _mods      Array of models.
  *  @param _vnd_mods  Array of vendor models.
  */
-#define BT_MESH_ELEM(_loc, _mods, _vnd_mods)        \
-{                                                   \
-	.loc              = (_loc),                 \
-	.model_count      = ARRAY_SIZE(_mods),      \
-	.vnd_model_count  = ARRAY_SIZE(_vnd_mods),  \
-	.models           = (_mods),                \
-	.vnd_models       = (_vnd_mods),            \
+#define BT_MESH_ELEM(_loc, _mods, _vnd_mods)				\
+{									\
+	.rt		  = &(struct bt_mesh_elem_rt_ctx) { 0 },	\
+	.loc              = (_loc),					\
+	.model_count      = ARRAY_SIZE(_mods),				\
+	.vnd_model_count  = ARRAY_SIZE(_vnd_mods),			\
+	.models           = (_mods),					\
+	.vnd_models       = (_vnd_mods),				\
 }
 
 /** Abstraction that describes a Mesh Element */
 struct bt_mesh_elem {
-	/** Unicast Address. Set at runtime during provisioning. */
-	uint16_t addr;
+	/** Mesh Element runtime information */
+	struct bt_mesh_elem_rt_ctx {
+		/** Unicast Address. Set at runtime during provisioning. */
+		uint16_t addr;
+	} * const rt;
 
 	/** Location Descriptor (GATT Bluetooth Namespace Descriptors) */
 	const uint16_t loc;
@@ -1001,7 +1005,7 @@ static inline bool bt_mesh_model_pub_is_retransmission(const struct bt_mesh_mode
  *
  *  @return Pointer to the element that the given model belongs to.
  */
-struct bt_mesh_elem *bt_mesh_model_elem(const struct bt_mesh_model *mod);
+const struct bt_mesh_elem *bt_mesh_model_elem(const struct bt_mesh_model *mod);
 
 /** @brief Find a SIG model.
  *
@@ -1147,7 +1151,7 @@ struct bt_mesh_comp {
 	uint16_t vid; /**< Version ID */
 
 	size_t elem_count; /**< The number of elements in this device. */
-	struct bt_mesh_elem *elem; /**< List of elements. */
+	const struct bt_mesh_elem *elem; /**< List of elements. */
 };
 
 /** Composition data page 2 record. */

--- a/include/zephyr/bluetooth/mesh/access.h
+++ b/include/zephyr/bluetooth/mesh/access.h
@@ -30,13 +30,8 @@
 #define BT_MESH_MODEL_UUIDS_UNASSIGNED()
 #endif
 
-#ifdef CONFIG_BT_MESH_MODEL_EXTENSIONS
 #define BT_MESH_MODEL_RUNTIME_INIT(_user_data)			\
-	.rt = (void *)(void *[]){ NULL, NULL, (_user_data) },
-#else
-#define BT_MESH_MODEL_RUNTIME_INIT(_user_data)			\
-	.rt = (void *)(void *[]){ NULL, (_user_data) },
-#endif
+	.rt = &(struct bt_mesh_model_rt_ctx){ .user_data = (_user_data) },
 
 /**
  * @brief Access layer
@@ -890,7 +885,7 @@ struct bt_mesh_model {
 	};
 
 	/* Model runtime information */
-	struct {
+	struct bt_mesh_model_rt_ctx {
 		uint8_t  elem_idx;   /* Belongs to Nth element */
 		uint8_t  mod_idx;    /* Is the Nth model in the element */
 		uint16_t flags;      /* Model flags for internal bookkeeping */

--- a/include/zephyr/bluetooth/mesh/health_srv.h
+++ b/include/zephyr/bluetooth/mesh/health_srv.h
@@ -219,7 +219,7 @@ struct bt_mesh_health_srv {
  *
  *  @return 0 on success, or (negative) error code otherwise.
  */
-int bt_mesh_health_srv_fault_update(struct bt_mesh_elem *elem);
+int bt_mesh_health_srv_fault_update(const struct bt_mesh_elem *elem);
 
 /** @cond INTERNAL_HIDDEN */
 extern const struct bt_mesh_model_op bt_mesh_health_srv_op[];

--- a/samples/bluetooth/mesh/src/main.c
+++ b/samples/bluetooth/mesh/src/main.c
@@ -257,7 +257,7 @@ static const struct bt_mesh_model models[] = {
 		      NULL),
 };
 
-static struct bt_mesh_elem elements[] = {
+static const struct bt_mesh_elem elements[] = {
 	BT_MESH_ELEM(0, models, BT_MESH_MODEL_NONE),
 };
 

--- a/samples/bluetooth/mesh_demo/src/main.c
+++ b/samples/bluetooth/mesh_demo/src/main.c
@@ -86,7 +86,7 @@ static int vnd_button_pressed(const struct bt_mesh_model *model,
 {
 	printk("src 0x%04x\n", ctx->addr);
 
-	if (ctx->addr == bt_mesh_model_elem(model)->addr) {
+	if (ctx->addr == bt_mesh_model_elem(model)->rt->addr) {
 		return 0;
 	}
 
@@ -105,7 +105,7 @@ static const struct bt_mesh_model vnd_models[] = {
 	BT_MESH_MODEL_VND(BT_COMP_ID_LF, MOD_LF, vnd_ops, NULL, NULL),
 };
 
-static struct bt_mesh_elem elements[] = {
+static const struct bt_mesh_elem elements[] = {
 	BT_MESH_ELEM(0, root_models, vnd_models),
 };
 

--- a/samples/bluetooth/mesh_provisioner/src/main.c
+++ b/samples/bluetooth/mesh_provisioner/src/main.c
@@ -59,7 +59,7 @@ static const struct bt_mesh_model root_models[] = {
 	BT_MESH_MODEL_HEALTH_CLI(&health_cli),
 };
 
-static struct bt_mesh_elem elements[] = {
+static const struct bt_mesh_elem elements[] = {
 	BT_MESH_ELEM(0, root_models, BT_MESH_MODEL_NONE),
 };
 

--- a/samples/boards/nrf/mesh/onoff-app/src/main.c
+++ b/samples/boards/nrf/mesh/onoff-app/src/main.c
@@ -236,7 +236,7 @@ const struct bt_mesh_model *mod_srv_sw[] = {
  * Root and Secondary Element Declarations
  */
 
-static struct bt_mesh_elem elements[] = {
+static const struct bt_mesh_elem elements[] = {
 	BT_MESH_ELEM(0, root_models, BT_MESH_MODEL_NONE),
 	BT_MESH_ELEM(0, secondary_0_models, BT_MESH_MODEL_NONE),
 	BT_MESH_ELEM(0, secondary_1_models, BT_MESH_MODEL_NONE),
@@ -289,7 +289,7 @@ static int gen_onoff_get(const struct bt_mesh_model *model,
 	struct led_onoff_state *onoff_state = model->rt->user_data;
 
 	printk("addr 0x%04x onoff 0x%02x\n",
-	       bt_mesh_model_elem(model)->addr, onoff_state->current);
+	       bt_mesh_model_elem(model)->rt->addr, onoff_state->current);
 	bt_mesh_model_msg_init(&msg, BT_MESH_MODEL_OP_GEN_ONOFF_STATUS);
 	net_buf_simple_add_u8(&msg, onoff_state->current);
 
@@ -310,7 +310,7 @@ static int gen_onoff_set_unack(const struct bt_mesh_model *model,
 
 	onoff_state->current = net_buf_simple_pull_u8(buf);
 	printk("addr 0x%02x state 0x%02x\n",
-	       bt_mesh_model_elem(model)->addr, onoff_state->current);
+	       bt_mesh_model_elem(model)->rt->addr, onoff_state->current);
 
 	gpio_pin_set_dt(&onoff_state->led_device, onoff_state->current);
 
@@ -361,7 +361,7 @@ static int gen_onoff_status(const struct bt_mesh_model *model,
 	state = net_buf_simple_pull_u8(buf);
 
 	printk("Node 0x%04x OnOff status from 0x%04x with state 0x%02x\n",
-	       bt_mesh_model_elem(model)->addr, ctx->addr, state);
+	       bt_mesh_model_elem(model)->rt->addr, ctx->addr, state);
 
 	return 0;
 }

--- a/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
+++ b/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
@@ -63,7 +63,7 @@ struct vendor_state vnd_user_data;
 
 /* Definitions of models user data (End) */
 
-static struct bt_mesh_elem elements[];
+static const struct bt_mesh_elem elements[];
 
 /* message handlers (Start) */
 
@@ -3190,7 +3190,7 @@ const struct bt_mesh_model s0_models[] = {
 		      NULL),
 };
 
-static struct bt_mesh_elem elements[] = {
+static const struct bt_mesh_elem elements[] = {
 	BT_MESH_ELEM(0, root_models, vnd_models),
 	BT_MESH_ELEM(0, s0_models, BT_MESH_MODEL_NONE),
 };

--- a/samples/boards/reel_board/mesh_badge/src/mesh.c
+++ b/samples/boards/reel_board/mesh_badge/src/mesh.c
@@ -187,7 +187,7 @@ static int gen_onoff_get(const struct bt_mesh_model *model,
 	struct led_onoff_state *state = model->rt->user_data;
 
 	printk("addr 0x%04x onoff 0x%02x\n",
-	       bt_mesh_model_elem(model)->addr, state->current);
+	       bt_mesh_model_elem(model)->rt->addr, state->current);
 	bt_mesh_model_msg_init(&msg, BT_MESH_MODEL_OP_GEN_ONOFF_STATUS);
 	net_buf_simple_add_u8(&msg, state->current);
 
@@ -229,7 +229,7 @@ static int gen_onoff_set_unack(const struct bt_mesh_model *model,
 	state->last_msg_timestamp = now;
 
 	printk("addr 0x%02x state 0x%02x\n",
-	       bt_mesh_model_elem(model)->addr, state->current);
+	       bt_mesh_model_elem(model)->rt->addr, state->current);
 
 	if (set_led_state(state->dev_id, onoff)) {
 		printk("Failed to set led state\n");
@@ -404,7 +404,7 @@ static int vnd_hello(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *
 
 	printk("Hello message from 0x%04x\n", ctx->addr);
 
-	if (ctx->addr == bt_mesh_model_elem(model)->addr) {
+	if (ctx->addr == bt_mesh_model_elem(model)->rt->addr) {
 		printk("Ignoring message from self\n");
 		return 0;
 	}
@@ -431,7 +431,7 @@ static int vnd_baduser(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx
 
 	printk("\"Bad user\" message from 0x%04x\n", ctx->addr);
 
-	if (ctx->addr == bt_mesh_model_elem(model)->addr) {
+	if (ctx->addr == bt_mesh_model_elem(model)->rt->addr) {
 		printk("Ignoring message from self\n");
 		return 0;
 	}
@@ -455,7 +455,7 @@ static int vnd_heartbeat(const struct bt_mesh_model *model,
 	uint8_t init_ttl, hops;
 
 	/* Ignore messages from self */
-	if (ctx->addr == bt_mesh_model_elem(model)->addr) {
+	if (ctx->addr == bt_mesh_model_elem(model)->rt->addr) {
 		return 0;
 	}
 
@@ -495,7 +495,7 @@ static const struct bt_mesh_model vnd_models[] = {
 	BT_MESH_MODEL_VND(BT_COMP_ID_LF, MOD_LF, vnd_ops, &vnd_pub, NULL),
 };
 
-static struct bt_mesh_elem elements[] = {
+static const struct bt_mesh_elem elements[] = {
 	BT_MESH_ELEM(0, root_models, vnd_models),
 };
 
@@ -638,12 +638,12 @@ void mesh_start(void)
 
 bool mesh_is_initialized(void)
 {
-	return elements[0].addr != BT_MESH_ADDR_UNASSIGNED;
+	return elements[0].rt->addr != BT_MESH_ADDR_UNASSIGNED;
 }
 
 uint16_t mesh_get_addr(void)
 {
-	return elements[0].addr;
+	return elements[0].rt->addr;
 }
 
 int mesh_init(void)

--- a/subsys/bluetooth/mesh/access.h
+++ b/subsys/bluetooth/mesh/access.h
@@ -20,7 +20,7 @@ enum {
 	BT_MESH_MOD_DATA_PENDING = BIT(5),
 };
 
-void bt_mesh_elem_register(struct bt_mesh_elem *elem, uint8_t count);
+void bt_mesh_elem_register(const struct bt_mesh_elem *elem, uint8_t count);
 
 uint8_t bt_mesh_elem_count(void);
 size_t bt_mesh_comp_page_size(uint8_t page);
@@ -29,7 +29,7 @@ size_t bt_mesh_metadata_page_0_size(void);
 int bt_mesh_metadata_get_page_0(struct net_buf_simple *buf, size_t offset);
 
 /* Find local element based on unicast address */
-struct bt_mesh_elem *bt_mesh_elem_find(uint16_t addr);
+const struct bt_mesh_elem *bt_mesh_elem_find(uint16_t addr);
 
 bool bt_mesh_has_addr(uint16_t addr);
 bool bt_mesh_model_has_key(const struct bt_mesh_model *mod, uint16_t key);
@@ -43,7 +43,7 @@ uint16_t *bt_mesh_model_find_group(const struct bt_mesh_model **mod, uint16_t ad
 const uint8_t **bt_mesh_model_find_uuid(const struct bt_mesh_model **mod, const uint8_t *uuid);
 
 void bt_mesh_model_foreach(void (*func)(const struct bt_mesh_model *mod,
-					struct bt_mesh_elem *elem,
+					const struct bt_mesh_elem *elem,
 					bool vnd, bool primary,
 					void *user_data),
 			   void *user_data);

--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -86,7 +86,7 @@ static int dev_comp_data_get(const struct bt_mesh_model *model,
 	return err;
 }
 
-static const struct bt_mesh_model *get_model(struct bt_mesh_elem *elem,
+static const struct bt_mesh_model *get_model(const struct bt_mesh_elem *elem,
 				       struct net_buf_simple *buf, bool *vnd)
 {
 	if (buf->len < 4) {
@@ -94,7 +94,7 @@ static const struct bt_mesh_model *get_model(struct bt_mesh_elem *elem,
 
 		id = net_buf_simple_pull_le16(buf);
 
-		LOG_DBG("ID 0x%04x addr 0x%04x", id, elem->addr);
+		LOG_DBG("ID 0x%04x addr 0x%04x", id, elem->rt->addr);
 
 		*vnd = false;
 
@@ -105,7 +105,7 @@ static const struct bt_mesh_model *get_model(struct bt_mesh_elem *elem,
 		company = net_buf_simple_pull_le16(buf);
 		id = net_buf_simple_pull_le16(buf);
 
-		LOG_DBG("Company 0x%04x ID 0x%04x addr 0x%04x", company, id, elem->addr);
+		LOG_DBG("Company 0x%04x ID 0x%04x addr 0x%04x", company, id, elem->rt->addr);
 
 		*vnd = true;
 
@@ -336,7 +336,7 @@ static int app_key_update(const struct bt_mesh_model *model,
 }
 
 static void mod_app_key_del(const struct bt_mesh_model *mod,
-			    struct bt_mesh_elem *elem, bool vnd, bool primary,
+			    const struct bt_mesh_elem *elem, bool vnd, bool primary,
 			    void *user_data)
 {
 	uint16_t *app_idx = user_data;
@@ -696,7 +696,7 @@ static int mod_pub_get(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx
 {
 	uint16_t elem_addr, pub_addr = 0U;
 	const struct bt_mesh_model *mod;
-	struct bt_mesh_elem *elem;
+	const struct bt_mesh_elem *elem;
 	uint8_t *mod_id, status;
 	bool vnd;
 
@@ -749,7 +749,7 @@ static int mod_pub_set(const struct bt_mesh_model *model,
 	uint8_t retransmit, status, pub_ttl, pub_period, cred_flag;
 	uint16_t elem_addr, pub_addr, pub_app_idx;
 	const struct bt_mesh_model *mod;
-	struct bt_mesh_elem *elem;
+	const struct bt_mesh_elem *elem;
 	uint8_t *mod_id;
 	bool vnd;
 
@@ -847,7 +847,7 @@ static int mod_pub_va_set(const struct bt_mesh_model *model,
 	uint16_t elem_addr, pub_app_idx;
 	uint16_t pub_addr = 0U;
 	const struct bt_mesh_model *mod;
-	struct bt_mesh_elem *elem;
+	const struct bt_mesh_elem *elem;
 	const uint8_t *uuid;
 	uint8_t *mod_id;
 	bool vnd;
@@ -949,7 +949,7 @@ static int mod_sub_add(const struct bt_mesh_model *model,
 {
 	uint16_t elem_addr, sub_addr;
 	const struct bt_mesh_model *mod;
-	struct bt_mesh_elem *elem;
+	const struct bt_mesh_elem *elem;
 	uint8_t *mod_id;
 	uint8_t status;
 	uint16_t *entry;
@@ -1027,7 +1027,7 @@ static int mod_sub_del(const struct bt_mesh_model *model,
 {
 	uint16_t elem_addr, sub_addr;
 	const struct bt_mesh_model *mod;
-	struct bt_mesh_elem *elem;
+	const struct bt_mesh_elem *elem;
 	uint8_t *mod_id;
 	uint16_t *match;
 	uint8_t status;
@@ -1109,7 +1109,7 @@ static int mod_sub_overwrite(const struct bt_mesh_model *model,
 {
 	uint16_t elem_addr, sub_addr;
 	const struct bt_mesh_model *mod;
-	struct bt_mesh_elem *elem;
+	const struct bt_mesh_elem *elem;
 	uint8_t *mod_id;
 	uint8_t status;
 	bool vnd;
@@ -1179,7 +1179,7 @@ static int mod_sub_del_all(const struct bt_mesh_model *model,
 			   struct net_buf_simple *buf)
 {
 	const struct bt_mesh_model *mod;
-	struct bt_mesh_elem *elem;
+	const struct bt_mesh_elem *elem;
 	uint16_t elem_addr;
 	uint8_t *mod_id;
 	uint8_t status;
@@ -1269,7 +1269,7 @@ static int mod_sub_get(const struct bt_mesh_model *model,
 	NET_BUF_SIMPLE_DEFINE(msg, BT_MESH_TX_SDU_MAX);
 	struct mod_sub_list_ctx visit_ctx;
 	const struct bt_mesh_model *mod;
-	struct bt_mesh_elem *elem;
+	const struct bt_mesh_elem *elem;
 	uint16_t addr, id;
 
 	addr = net_buf_simple_pull_le16(buf);
@@ -1324,7 +1324,7 @@ static int mod_sub_get_vnd(const struct bt_mesh_model *model,
 	NET_BUF_SIMPLE_DEFINE(msg, BT_MESH_TX_SDU_MAX);
 	struct mod_sub_list_ctx visit_ctx;
 	const struct bt_mesh_model *mod;
-	struct bt_mesh_elem *elem;
+	const struct bt_mesh_elem *elem;
 	uint16_t company, addr, id;
 
 	addr = net_buf_simple_pull_le16(buf);
@@ -1383,7 +1383,7 @@ static int mod_sub_va_add(const struct bt_mesh_model *model,
 	const struct bt_mesh_va *va;
 	uint16_t elem_addr, sub_addr = BT_MESH_ADDR_UNASSIGNED;
 	const struct bt_mesh_model *mod;
-	struct bt_mesh_elem *elem;
+	const struct bt_mesh_elem *elem;
 	const uint8_t *uuid;
 	uint8_t *mod_id;
 	uint16_t *group_entry;
@@ -1485,7 +1485,7 @@ static int mod_sub_va_del(const struct bt_mesh_model *model,
 	const struct bt_mesh_va *va;
 	uint16_t elem_addr, sub_addr = BT_MESH_ADDR_UNASSIGNED;
 	const struct bt_mesh_model *mod;
-	struct bt_mesh_elem *elem;
+	const struct bt_mesh_elem *elem;
 	const uint8_t *uuid;
 	uint8_t *mod_id;
 	const uint8_t **label_match;
@@ -1569,7 +1569,7 @@ static int mod_sub_va_overwrite(const struct bt_mesh_model *model,
 	const struct bt_mesh_va *va;
 	uint16_t elem_addr, sub_addr = BT_MESH_ADDR_UNASSIGNED;
 	const struct bt_mesh_model *mod;
-	struct bt_mesh_elem *elem;
+	const struct bt_mesh_elem *elem;
 	const uint8_t *uuid;
 	uint8_t *mod_id;
 	uint8_t status;
@@ -1848,7 +1848,7 @@ static int mod_app_bind(const struct bt_mesh_model *model,
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_MOD_APP_STATUS, 9);
 	uint16_t elem_addr, key_app_idx;
 	const struct bt_mesh_model *mod;
-	struct bt_mesh_elem *elem;
+	const struct bt_mesh_elem *elem;
 	uint8_t *mod_id, status;
 	bool vnd;
 
@@ -1912,7 +1912,7 @@ static int mod_app_unbind(const struct bt_mesh_model *model,
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_MOD_APP_STATUS, 9);
 	uint16_t elem_addr, key_app_idx;
 	const struct bt_mesh_model *mod;
-	struct bt_mesh_elem *elem;
+	const struct bt_mesh_elem *elem;
 	uint8_t *mod_id, status;
 	bool vnd;
 
@@ -1974,7 +1974,7 @@ static int mod_app_get(const struct bt_mesh_model *model,
 				  BT_MESH_MODEL_BUF_LEN(OP_SIG_MOD_APP_LIST,
 							9 + KEY_LIST_LEN)));
 	const struct bt_mesh_model *mod;
-	struct bt_mesh_elem *elem;
+	const struct bt_mesh_elem *elem;
 	uint8_t *mod_id, status;
 	uint16_t elem_addr;
 	bool vnd;
@@ -2529,7 +2529,7 @@ const struct bt_mesh_model_cb bt_mesh_cfg_srv_cb = {
 	.init = cfg_srv_init,
 };
 
-static void mod_reset(const struct bt_mesh_model *mod, struct bt_mesh_elem *elem,
+static void mod_reset(const struct bt_mesh_model *mod, const struct bt_mesh_elem *elem,
 		      bool vnd, bool primary, void *user_data)
 {
 	size_t clear_count;

--- a/subsys/bluetooth/mesh/health_srv.c
+++ b/subsys/bluetooth/mesh/health_srv.c
@@ -384,7 +384,7 @@ static int health_pub_update(const struct bt_mesh_model *mod)
 	return 0;
 }
 
-int bt_mesh_health_srv_fault_update(struct bt_mesh_elem *elem)
+int bt_mesh_health_srv_fault_update(const struct bt_mesh_elem *elem)
 {
 	const struct bt_mesh_model *mod;
 

--- a/subsys/bluetooth/mesh/main.c
+++ b/subsys/bluetooth/mesh/main.c
@@ -419,7 +419,7 @@ bool bt_mesh_is_provisioned(void)
 	return atomic_test_bit(bt_mesh.flags, BT_MESH_VALID);
 }
 
-static void model_suspend(const struct bt_mesh_model *mod, struct bt_mesh_elem *elem,
+static void model_suspend(const struct bt_mesh_model *mod, const struct bt_mesh_elem *elem,
 			  bool vnd, bool primary, void *user_data)
 {
 	if (mod->pub && mod->pub->update) {
@@ -463,7 +463,7 @@ int bt_mesh_suspend(void)
 	return 0;
 }
 
-static void model_resume(const struct bt_mesh_model *mod, struct bt_mesh_elem *elem,
+static void model_resume(const struct bt_mesh_model *mod, const struct bt_mesh_elem *elem,
 			  bool vnd, bool primary, void *user_data)
 {
 	if (mod->pub && mod->pub->update) {
@@ -552,7 +552,7 @@ int bt_mesh_init(const struct bt_mesh_prov *prov,
 	return 0;
 }
 
-static void model_start(const struct bt_mesh_model *mod, struct bt_mesh_elem *elem,
+static void model_start(const struct bt_mesh_model *mod, const struct bt_mesh_elem *elem,
 			bool vnd, bool primary, void *user_data)
 {
 	if (mod->cb && mod->cb->start) {

--- a/subsys/bluetooth/mesh/op_agg_cli.c
+++ b/subsys/bluetooth/mesh/op_agg_cli.c
@@ -205,7 +205,7 @@ void bt_mesh_op_agg_cli_timeout_set(int32_t timeout)
 
 int bt_mesh_op_agg_cli_send(const struct bt_mesh_model *model, struct net_buf_simple *msg)
 {
-	uint16_t src = bt_mesh_model_elem(model)->addr;
+	uint16_t src = bt_mesh_model_elem(model)->rt->addr;
 
 	if (net_buf_simple_tailroom(&srcs) < 2) {
 		return -ENOMEM;

--- a/subsys/bluetooth/mesh/shell/shell.c
+++ b/subsys/bluetooth/mesh/shell/shell.c
@@ -1070,7 +1070,7 @@ static int cmd_rpl_clear(const struct shell *sh, size_t argc, char *argv[])
 }
 
 #if defined(CONFIG_BT_MESH_SHELL_HEALTH_SRV_INSTANCE)
-static struct bt_mesh_elem *primary_element(void)
+static const struct bt_mesh_elem *primary_element(void)
 {
 	const struct bt_mesh_comp *comp = bt_mesh_comp_get();
 
@@ -1085,7 +1085,7 @@ static int cmd_add_fault(const struct shell *sh, size_t argc, char *argv[])
 {
 	uint8_t fault_id;
 	uint8_t i;
-	struct bt_mesh_elem *elem;
+	const struct bt_mesh_elem *elem;
 	int err = 0;
 
 	elem = primary_element();
@@ -1138,7 +1138,7 @@ static int cmd_del_fault(const struct shell *sh, size_t argc, char *argv[])
 {
 	uint8_t fault_id;
 	uint8_t i;
-	struct bt_mesh_elem *elem;
+	const struct bt_mesh_elem *elem;
 	int err = 0;
 
 	elem = primary_element();

--- a/subsys/bluetooth/mesh/shell/utils.c
+++ b/subsys/bluetooth/mesh/shell/utils.c
@@ -60,7 +60,7 @@ int bt_mesh_shell_mdl_print_all(const struct shell *sh, uint16_t mod_id)
 		if (mod) {
 			shell_print(sh,
 				    "Client model instance found at addr 0x%.4X. Element index: %d",
-				    comp->elem[i].addr, mod->rt->elem_idx);
+				    comp->elem[i].rt->addr, mod->rt->elem_idx);
 		}
 	}
 

--- a/tests/bluetooth/mesh/basic/src/main.c
+++ b/tests/bluetooth/mesh/basic/src/main.c
@@ -114,7 +114,7 @@ static const struct bt_mesh_model vnd_models[] = {
 	BT_MESH_MODEL_VND(BT_COMP_ID_LF, 0x4321, vnd_ops, &vnd_pub2, NULL),
 };
 
-static struct bt_mesh_elem elements[] = {
+static const struct bt_mesh_elem elements[] = {
 	BT_MESH_ELEM(0, root_models, vnd_models),
 };
 

--- a/tests/bluetooth/mesh_shell/src/main.c
+++ b/tests/bluetooth/mesh_shell/src/main.c
@@ -107,7 +107,7 @@ static const struct bt_mesh_model root_models[] = {
 #endif
 };
 
-static struct bt_mesh_elem elements[] = {
+static const struct bt_mesh_elem elements[] = {
 	BT_MESH_ELEM(0, root_models, BT_MESH_MODEL_NONE),
 };
 

--- a/tests/bluetooth/tester/src/btp_mesh.c
+++ b/tests/bluetooth/tester/src/btp_mesh.c
@@ -1096,7 +1096,7 @@ static const struct bt_mesh_model vnd_models[] = {
 			  NULL),
 };
 
-static struct bt_mesh_elem elements[] = {
+static const struct bt_mesh_elem elements[] = {
 	BT_MESH_ELEM(0, root_models, vnd_models),
 };
 
@@ -1739,7 +1739,7 @@ static uint8_t model_send(const void *cmd, uint16_t cmd_len,
 
 	/* Lookup source address */
 	for (int i = 0; i < ARRAY_SIZE(model_bound); i++) {
-		if (bt_mesh_model_elem(model_bound[i].model)->addr == src) {
+		if (bt_mesh_model_elem(model_bound[i].model)->rt->addr == src) {
 			model = model_bound[i].model;
 			ctx.app_idx = model_bound[i].appkey_idx;
 

--- a/tests/bsim/bluetooth/mesh/src/mesh_test.c
+++ b/tests/bsim/bluetooth/mesh/src/mesh_test.c
@@ -204,7 +204,7 @@ static const struct bt_mesh_model vnd_models[] = {
 
 const struct bt_mesh_model *test_vnd_model = &vnd_models[0];
 
-static struct bt_mesh_elem elems[] = {
+static const struct bt_mesh_elem elems[] = {
 	BT_MESH_ELEM(0, models, vnd_models),
 };
 

--- a/tests/bsim/bluetooth/mesh/src/test_access.c
+++ b/tests/bsim/bluetooth/mesh/src/test_access.c
@@ -225,7 +225,7 @@ static const struct bt_mesh_model models_ne[] = {
 
 static const struct bt_mesh_model vnd_models[] = {};
 
-static struct bt_mesh_elem elems[] = {
+static const struct bt_mesh_elem elems[] = {
 	BT_MESH_ELEM(0, models, vnd_models),
 	BT_MESH_ELEM(1, models_ne, vnd_models),
 };

--- a/tests/bsim/bluetooth/mesh/src/test_beacon.c
+++ b/tests/bsim/bluetooth/mesh/src/test_beacon.c
@@ -79,7 +79,7 @@ static struct bt_mesh_priv_beacon_cli priv_beacon_cli;
 
 static const struct bt_mesh_comp prb_comp = {
 	.elem =
-		(struct bt_mesh_elem[]){
+		(const struct bt_mesh_elem[]){
 			BT_MESH_ELEM(1,
 				     MODEL_LIST(BT_MESH_MODEL_CFG_SRV,
 						BT_MESH_MODEL_CFG_CLI(&cfg_cli),

--- a/tests/bsim/bluetooth/mesh/src/test_blob.c
+++ b/tests/bsim/bluetooth/mesh/src/test_blob.c
@@ -233,7 +233,7 @@ static struct bt_mesh_sar_cfg_cli sar_cfg_cli;
 
 static const struct bt_mesh_comp srv_comp = {
 	.elem =
-		(struct bt_mesh_elem[]){
+		(const struct bt_mesh_elem[]){
 			BT_MESH_ELEM(1,
 				     MODEL_LIST(BT_MESH_MODEL_CFG_SRV,
 						BT_MESH_MODEL_CFG_CLI(&cfg_cli),
@@ -247,7 +247,7 @@ static const struct bt_mesh_comp srv_comp = {
 
 static const struct bt_mesh_comp cli_comp = {
 	.elem =
-		(struct bt_mesh_elem[]){
+		(const struct bt_mesh_elem[]){
 			BT_MESH_ELEM(1,
 				     MODEL_LIST(BT_MESH_MODEL_CFG_SRV,
 						BT_MESH_MODEL_CFG_CLI(&cfg_cli),
@@ -275,7 +275,7 @@ static const struct bt_mesh_model_op model_op1[] = {
 
 static const struct bt_mesh_comp none_rsp_srv_comp = {
 	.elem =
-		(struct bt_mesh_elem[]){
+		(const struct bt_mesh_elem[]){
 			BT_MESH_ELEM(1,
 				     MODEL_LIST(BT_MESH_MODEL_CFG_SRV,
 						BT_MESH_MODEL_CFG_CLI(&cfg_cli),
@@ -1328,7 +1328,7 @@ static const struct bt_mesh_model_op model_op2[] = {
  */
 static const struct bt_mesh_comp srv_broken_comp = {
 	.elem =
-		(struct bt_mesh_elem[]){
+		(const struct bt_mesh_elem[]){
 			BT_MESH_ELEM(1,
 				     MODEL_LIST(BT_MESH_MODEL_CFG_SRV,
 						BT_MESH_MODEL_CFG_CLI(&cfg_cli),

--- a/tests/bsim/bluetooth/mesh/src/test_cdp1.c
+++ b/tests/bsim/bluetooth/mesh/src/test_cdp1.c
@@ -81,7 +81,7 @@ static const struct bt_mesh_model models_vnd1[] = {
 			     &test_model_vnd1_cb),
 };
 
-static struct bt_mesh_elem elems[] = {
+static const struct bt_mesh_elem elems[] = {
 	BT_MESH_ELEM(0, models_1, models_vnd1),
 	BT_MESH_ELEM(1, models_2, BT_MESH_MODEL_NONE),
 	BT_MESH_ELEM(2, models_3, BT_MESH_MODEL_NONE),

--- a/tests/bsim/bluetooth/mesh/src/test_dfu.c
+++ b/tests/bsim/bluetooth/mesh/src/test_dfu.c
@@ -290,7 +290,7 @@ static struct bt_mesh_dfu_srv dfu_srv = BT_MESH_DFU_SRV_INIT(&dfu_handlers, dfu_
 
 static const struct bt_mesh_comp dist_comp = {
 	.elem =
-		(struct bt_mesh_elem[]){
+		(const struct bt_mesh_elem[]){
 			BT_MESH_ELEM(1,
 				     MODEL_LIST(BT_MESH_MODEL_CFG_SRV,
 						BT_MESH_MODEL_CFG_CLI(&cfg_cli),
@@ -304,7 +304,7 @@ static const struct bt_mesh_comp dist_comp = {
 
 static const struct bt_mesh_comp dist_comp_self_update = {
 	.elem =
-		(struct bt_mesh_elem[]){
+		(const struct bt_mesh_elem[]){
 			BT_MESH_ELEM(1,
 				     MODEL_LIST(BT_MESH_MODEL_CFG_SRV,
 						BT_MESH_MODEL_CFG_CLI(&cfg_cli),
@@ -325,7 +325,7 @@ static const struct bt_mesh_model_op model_dummy_op[] = {
 
 static const struct bt_mesh_comp target_comp = {
 	.elem =
-		(struct bt_mesh_elem[]){
+		(const struct bt_mesh_elem[]){
 			BT_MESH_ELEM(1,
 				     MODEL_LIST(BT_MESH_MODEL_CFG_SRV,
 						BT_MESH_MODEL_CFG_CLI(&cfg_cli),
@@ -941,7 +941,7 @@ static struct bt_mesh_dfu_cli dfu_cli = BT_MESH_DFU_CLI_INIT(&dfu_cli_cb);
 
 static const struct bt_mesh_comp cli_comp = {
 	.elem =
-		(struct bt_mesh_elem[]){
+		(const struct bt_mesh_elem[]){
 			BT_MESH_ELEM(1,
 				     MODEL_LIST(BT_MESH_MODEL_CFG_SRV,
 						BT_MESH_MODEL_CFG_CLI(&cfg_cli),
@@ -1326,7 +1326,7 @@ static const struct bt_mesh_model_op model_caps_op1[] = {
 
 static const struct bt_mesh_comp srv_caps_broken_comp = {
 	.elem =
-		(struct bt_mesh_elem[]){
+		(const struct bt_mesh_elem[]){
 			BT_MESH_ELEM(1,
 				     MODEL_LIST(BT_MESH_MODEL_CFG_SRV,
 						BT_MESH_MODEL_CFG_CLI(&cfg_cli),
@@ -1357,7 +1357,7 @@ static const struct bt_mesh_model_op model_caps_op2[] = {
 
 static const struct bt_mesh_comp broken_target_comp = {
 	.elem =
-		(struct bt_mesh_elem[]){
+		(const struct bt_mesh_elem[]){
 			BT_MESH_ELEM(1,
 				     MODEL_LIST(BT_MESH_MODEL_CFG_SRV,
 						BT_MESH_MODEL_CFG_CLI(&cfg_cli),
@@ -1389,7 +1389,7 @@ static const struct bt_mesh_model_op model_update_get_op1[] = {
 
 static const struct bt_mesh_comp srv_update_get_broken_comp = {
 	.elem =
-		(struct bt_mesh_elem[]){
+		(const struct bt_mesh_elem[]){
 			BT_MESH_ELEM(1,
 				     MODEL_LIST(BT_MESH_MODEL_CFG_SRV,
 						BT_MESH_MODEL_CFG_CLI(&cfg_cli),
@@ -1422,7 +1422,7 @@ static const struct bt_mesh_model_op model_update_apply_op1[] = {
 
 static const struct bt_mesh_comp srv_update_apply_broken_comp = {
 	.elem =
-		(struct bt_mesh_elem[]){
+		(const struct bt_mesh_elem[]){
 			BT_MESH_ELEM(1,
 				     MODEL_LIST(BT_MESH_MODEL_CFG_SRV,
 						BT_MESH_MODEL_CFG_CLI(&cfg_cli),

--- a/tests/bsim/bluetooth/mesh/src/test_lcd.c
+++ b/tests/bsim/bluetooth/mesh/src/test_lcd.c
@@ -107,7 +107,7 @@ static struct bt_mesh_cfg_cli cfg_cli;
 static struct bt_mesh_large_comp_data_cli lcd_cli;
 
 /* Creates enough composition data to send a max SDU comp status message + 1 byte */
-static struct bt_mesh_elem elements_1[] = {
+static const struct bt_mesh_elem elements_1[] = {
 	BT_MESH_ELEM(1,
 		     MODEL_LIST(BT_MESH_MODEL_CFG_SRV,
 				BT_MESH_MODEL_CFG_CLI(&cfg_cli),
@@ -118,7 +118,7 @@ static struct bt_mesh_elem elements_1[] = {
 };
 
 /* Creates enough metadata to send a max SDU metadata status message + 1 byte */
-static struct bt_mesh_elem elements_2[] = {
+static const struct bt_mesh_elem elements_2[] = {
 	BT_MESH_ELEM(1,
 		     MODEL_LIST(BT_MESH_MODEL_CFG_SRV,
 				BT_MESH_MODEL_CFG_CLI(&cfg_cli),

--- a/tests/bsim/bluetooth/mesh/src/test_op_agg.c
+++ b/tests/bsim/bluetooth/mesh/src/test_op_agg.c
@@ -119,7 +119,7 @@ const struct bt_mesh_model_op _dummy_vnd_mod_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static struct bt_mesh_elem elements[] = {BT_MESH_ELEM(
+static const struct bt_mesh_elem elements[] = {BT_MESH_ELEM(
 	0,
 	MODEL_LIST(BT_MESH_MODEL_CFG_SRV, BT_MESH_MODEL_CFG_CLI(&cfg_cli), BT_MESH_MODEL_OP_AGG_SRV,
 		   BT_MESH_MODEL_OP_AGG_CLI),

--- a/tests/bsim/bluetooth/mesh/src/test_provision.c
+++ b/tests/bsim/bluetooth/mesh/src/test_provision.c
@@ -118,7 +118,7 @@ static struct bt_mesh_rpr_cli rpr_cli = {
 
 static const struct bt_mesh_comp rpr_cli_comp = {
 	.elem =
-		(struct bt_mesh_elem[]){
+		(const struct bt_mesh_elem[]){
 			BT_MESH_ELEM(1,
 				     MODEL_LIST(BT_MESH_MODEL_CFG_SRV,
 						BT_MESH_MODEL_CFG_CLI(&(struct bt_mesh_cfg_cli){}),
@@ -130,7 +130,7 @@ static const struct bt_mesh_comp rpr_cli_comp = {
 
 static const struct bt_mesh_comp rpr_srv_comp = {
 	.elem =
-		(struct bt_mesh_elem[]){
+		(const struct bt_mesh_elem[]){
 			BT_MESH_ELEM(1,
 				     MODEL_LIST(BT_MESH_MODEL_CFG_SRV,
 						BT_MESH_MODEL_RPR_SRV),
@@ -141,7 +141,7 @@ static const struct bt_mesh_comp rpr_srv_comp = {
 
 static const struct bt_mesh_comp rpr_cli_srv_comp = {
 	.elem =
-		(struct bt_mesh_elem[]){
+		(const struct bt_mesh_elem[]){
 			BT_MESH_ELEM(1,
 				     MODEL_LIST(BT_MESH_MODEL_CFG_SRV,
 						BT_MESH_MODEL_CFG_CLI(&(struct bt_mesh_cfg_cli){}),
@@ -182,7 +182,7 @@ const struct bt_mesh_model_cb mock_model_cb = {
 
 static const struct bt_mesh_comp rpr_srv_comp_unresponsive = {
 	.elem =
-		(struct bt_mesh_elem[]){
+		(const struct bt_mesh_elem[]){
 			BT_MESH_ELEM(1,
 				     MODEL_LIST(BT_MESH_MODEL_CFG_SRV,
 						BT_MESH_MODEL_CB(IMPOSTER_MODEL_ID,
@@ -221,7 +221,7 @@ static const struct bt_mesh_comp2 comp_p2_2 = {.record_cnt = 2, .record = comp_r
 
 static const struct bt_mesh_comp rpr_srv_comp_2_elem = {
 	.elem =
-		(struct bt_mesh_elem[]){
+		(const struct bt_mesh_elem[]){
 			BT_MESH_ELEM(1,
 				     MODEL_LIST(BT_MESH_MODEL_CFG_SRV,
 						BT_MESH_MODEL_RPR_SRV),

--- a/tests/bsim/bluetooth/mesh/src/test_sar.c
+++ b/tests/bsim/bluetooth/mesh/src/test_sar.c
@@ -131,7 +131,7 @@ static const struct bt_mesh_model_op _dummy_vnd_mod_op[] = {
 
 uint16_t dummy_keys[CONFIG_BT_MESH_MODEL_KEY_COUNT] = { 0 };
 
-static struct bt_mesh_elem elements[] = {BT_MESH_ELEM(
+static const struct bt_mesh_elem elements[] = {BT_MESH_ELEM(
 	0,
 	MODEL_LIST(BT_MESH_MODEL_CFG_SRV,
 		   BT_MESH_MODEL_CFG_CLI(&cfg_cli),


### PR DESCRIPTION
the reason is that the Mesh Profile clearly stipulates that Mesh nodes cannot change their own element definitions.