### PR TITLE
drivers: eth_nxp_s32_netc: si: use instance-based DT macros

### DIFF
--- a/drivers/ethernet/eth_nxp_s32_netc_priv.h
+++ b/drivers/ethernet/eth_nxp_s32_netc_priv.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 NXP
+ * Copyright 2022-2023 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -78,15 +78,22 @@
 		mac_addr[5] = (id + n) & 0xff;				\
 	} while (0)
 
-#define NETC_GENERATE_MAC_ADDRESS(node, n)					\
+#define NETC_GENERATE_MAC_ADDRESS(n)						\
 	static void nxp_s32_eth##n##_generate_mac(uint8_t mac_addr[6])		\
 	{									\
-		COND_CODE_1(DT_PROP(node, zephyr_random_mac_address),		\
+		COND_CODE_1(DT_INST_PROP(n, zephyr_random_mac_address),		\
 			(_NETC_GENERATE_MAC_ADDRESS_RANDOM),			\
-			(COND_CODE_0(DT_NODE_HAS_PROP(node, local_mac_address),	\
+			(COND_CODE_0(DT_INST_NODE_HAS_PROP(n, local_mac_address),\
 				(_NETC_GENERATE_MAC_ADDRESS_UNIQUE(n)),		\
 				(ARG_UNUSED(mac_addr)))));			\
 	}
+
+#define NETC_SI_NXP_S32_HW_INSTANCE_CHECK(i, n) \
+	((DT_INST_REG_ADDR(n) == IP_NETC__ENETC0_SI##i##_BASE) ? i : 0)
+
+#define NETC_SI_NXP_S32_HW_INSTANCE(n)					\
+	LISTIFY(__DEBRACKET FEATURE_NETC_ETH_NUMBER_OF_CTRLS,		\
+			NETC_SI_NXP_S32_HW_INSTANCE_CHECK, (|), n)
 
 /* Helper macros to concatenate tokens that require further expansions */
 #define _CONCAT3(a, b, c)	DT_CAT3(a, b, c)
@@ -127,5 +134,6 @@ enum ethernet_hw_caps nxp_s32_eth_get_capabilities(const struct device *dev);
 void nxp_s32_eth_mcast_cb(struct net_if *iface, const struct net_addr *addr, bool is_joined);
 int nxp_s32_eth_set_config(const struct device *dev, enum ethernet_config_type type,
 			   const struct ethernet_config *config);
+extern void Netc_Eth_Ip_MSIX_Rx(uint8_t si_idx);
 
 #endif /* ZEPHYR_DRIVERS_ETHERNET_ETH_NXP_S32_NETC_PRIV_H_ */

--- a/drivers/ethernet/eth_nxp_s32_netc_psi.c
+++ b/drivers/ethernet/eth_nxp_s32_netc_psi.c
@@ -1,8 +1,10 @@
 /*
- * Copyright 2022 NXP
+ * Copyright 2022-2023 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#define DT_DRV_COMPAT nxp_s32_netc_psi
 
 #define LOG_LEVEL CONFIG_ETHERNET_LOG_LEVEL
 #include <zephyr/logging/log.h>
@@ -26,9 +28,6 @@ LOG_MODULE_REGISTER(nxp_s32_eth_psi);
 #include "eth.h"
 #include "eth_nxp_s32_netc_priv.h"
 
-#define PSI_NODE	DT_COMPAT_GET_ANY_STATUS_OKAY(nxp_s32_netc_psi)
-#define PHY_NODE	DT_PHANDLE(PSI_NODE, phy_handle)
-#define INIT_VSIS	DT_NODE_HAS_PROP(PSI_NODE, vsis)
 #define TX_RING_IDX	1
 #define RX_RING_IDX	0
 
@@ -206,19 +205,6 @@ static void nxp_s32_eth_iface_init(struct net_if *iface)
 	}
 }
 
-static void nxp_s32_eth0_rx_callback(const uint8_t unused, const uint8_t ring)
-{
-	const struct device *dev = DEVICE_DT_GET(PSI_NODE);
-	const struct nxp_s32_eth_config *cfg = dev->config;
-	struct nxp_s32_eth_data *ctx = dev->data;
-
-	ARG_UNUSED(unused);
-
-	if (ring == cfg->rx_ring_idx) {
-		k_sem_give(&ctx->rx_sem);
-	}
-}
-
 static const struct ethernet_api nxp_s32_eth_api = {
 	.iface_api.init = nxp_s32_eth_iface_init,
 	.get_capabilities = nxp_s32_eth_get_capabilities,
@@ -238,22 +224,22 @@ BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(nxp_s32_netc_psi) == 1, "Only one PSI enabl
 				| NETC_F3_PSICFGR0_SIVC_SVLAN_BIT),		\
 	}
 
-#define NETC_VSI_RX_MSG_BUF(node, prop, idx)							\
+#define NETC_VSI_RX_MSG_BUF(node, prop, idx, n)							\
 	BUILD_ASSERT((DT_PROP_BY_IDX(node, prop, idx) > NETC_ETH_IP_PSI_INDEX)			\
 		&& (DT_PROP_BY_IDX(node, prop, idx) <= FEATURE_NETC_ETH_NUM_OF_VIRTUAL_CTRLS),	\
 		"Invalid VSI index");								\
 	static Netc_Eth_Ip_VsiToPsiMsgType							\
-	_CONCAT3(nxp_s32_eth0_vsi, DT_PROP_BY_IDX(node, prop, idx), _rx_msg_buf)		\
+	_CONCAT3(nxp_s32_eth##n##_vsi, DT_PROP_BY_IDX(node, prop, idx), _rx_msg_buf)		\
 		__aligned(FEATURE_NETC_ETH_VSI_MSG_ALIGNMENT)
 
-#define NETC_VSI_RX_MSG_BUF_ARRAY(node, prop, idx)						\
+#define NETC_VSI_RX_MSG_BUF_ARRAY(node, prop, idx, n)						\
 	[DT_PROP_BY_IDX(node, prop, idx) - 1] =							\
-		&_CONCAT3(nxp_s32_eth0_vsi, DT_PROP_BY_IDX(node, prop, idx), _rx_msg_buf)
+		&_CONCAT3(nxp_s32_eth##n##_vsi, DT_PROP_BY_IDX(node, prop, idx), _rx_msg_buf)
 
-#define NETC_SWITCH_PORT_CFG(_, __)						\
+#define NETC_SWITCH_PORT_CFG(_, n)						\
 	{									\
-		.ePort = &nxp_s32_eth0_switch_port_egress_cfg,			\
-		.iPort = &nxp_s32_eth0_switch_port_ingress_cfg,			\
+		.ePort = &nxp_s32_eth##n##_switch_port_egress_cfg,		\
+		.iPort = &nxp_s32_eth##n##_switch_port_ingress_cfg,		\
 		.EthSwtPortMacLayerPortEnable = true,				\
 		.EthSwtPortMacLayerSpeed = ETHTRCV_BAUD_RATE_1000MBIT,		\
 		.EthSwtPortMacLayerDuplexMode = NETC_ETHSWT_PORT_FULL_DUPLEX,	\
@@ -261,155 +247,181 @@ BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(nxp_s32_netc_psi) == 1, "Only one PSI enabl
 		.EthSwtPortPruningEnable = true,				\
 	}
 
-static Netc_Eth_Ip_StateType nxp_s32_eth0_state;
+#define PHY_NODE(n)	DT_INST_PHANDLE(n, phy_handle)
+#define INIT_VSIS(n)	DT_INST_NODE_HAS_PROP(n, vsis)
 
-static Netc_Eth_Ip_MACFilterHashTableEntryType
-nxp_s32_eth0_mac_filter_hash_table[CONFIG_ETH_NXP_S32_MAC_FILTER_TABLE_SIZE];
+#define NETC_PSI_INSTANCE_DEFINE(n)							\
+void nxp_s32_eth_psi##n##_rx_event(uint8_t chan, const uint32_t *buf, uint8_t buf_size)	\
+{											\
+	ARG_UNUSED(chan);								\
+	ARG_UNUSED(buf);								\
+	ARG_UNUSED(buf_size);								\
+											\
+	Netc_Eth_Ip_MSIX_Rx(NETC_SI_NXP_S32_HW_INSTANCE(n));				\
+}											\
+											\
+static void nxp_s32_eth##n##_rx_callback(const uint8_t unused, const uint8_t ring)	\
+{											\
+	const struct device *dev = DEVICE_DT_INST_GET(n);				\
+	const struct nxp_s32_eth_config *cfg = dev->config;				\
+	struct nxp_s32_eth_data *ctx = dev->data;					\
+											\
+	ARG_UNUSED(unused);								\
+											\
+	if (ring == cfg->rx_ring_idx) {							\
+		k_sem_give(&ctx->rx_sem);						\
+	}										\
+}											\
+											\
+static Netc_Eth_Ip_StateType nxp_s32_eth##n##_state;					\
+static Netc_Eth_Ip_MACFilterHashTableEntryType						\
+nxp_s32_eth##n##_mac_filter_hash_table[CONFIG_ETH_NXP_S32_MAC_FILTER_TABLE_SIZE];	\
+											\
+NETC_TX_RING(n, 0, NETC_MIN_RING_LEN, NETC_MIN_RING_BUF_SIZE);				\
+NETC_TX_RING(n, TX_RING_IDX,								\
+	CONFIG_ETH_NXP_S32_TX_RING_LEN, CONFIG_ETH_NXP_S32_TX_RING_BUF_SIZE);		\
+NETC_RX_RING(n, RX_RING_IDX,								\
+	CONFIG_ETH_NXP_S32_RX_RING_LEN, CONFIG_ETH_NXP_S32_RX_RING_BUF_SIZE);		\
+											\
+static const Netc_Eth_Ip_RxRingConfigType nxp_s32_eth##n##_rxring_cfg[1] = {		\
+	{										\
+		.RingDesc = nxp_s32_eth##n##_rxring0_desc,				\
+		.Buffer = nxp_s32_eth##n##_rxring0_buf,					\
+		.ringSize = CONFIG_ETH_NXP_S32_RX_RING_LEN,				\
+		.maxRingSize = CONFIG_ETH_NXP_S32_RX_RING_LEN,				\
+		.bufferLen = CONFIG_ETH_NXP_S32_TX_RING_BUF_SIZE,			\
+		.maxBuffLen = CONFIG_ETH_NXP_S32_TX_RING_BUF_SIZE,			\
+		.TimerThreshold = CONFIG_ETH_NXP_S32_RX_IRQ_TIMER_THRESHOLD,		\
+		.PacketsThreshold = CONFIG_ETH_NXP_S32_RX_IRQ_PACKET_THRESHOLD,		\
+		.Callback = nxp_s32_eth##n##_rx_callback,				\
+	}										\
+};											\
+											\
+static const Netc_Eth_Ip_TxRingConfigType nxp_s32_eth##n##_txring_cfg[2] = {		\
+	{										\
+		.RingDesc = nxp_s32_eth##n##_txring0_desc,				\
+		.Buffer = nxp_s32_eth##n##_txring0_buf,					\
+		.ringSize = NETC_MIN_RING_LEN,						\
+		.maxRingSize = NETC_MIN_RING_LEN,					\
+		.bufferLen = NETC_MIN_RING_BUF_SIZE,					\
+		.maxBuffLen = NETC_MIN_RING_BUF_SIZE,					\
+	},										\
+	{										\
+		.RingDesc = nxp_s32_eth##n##_txring1_desc,				\
+		.Buffer = nxp_s32_eth##n##_txring1_buf,					\
+		.ringSize = CONFIG_ETH_NXP_S32_TX_RING_LEN,				\
+		.maxRingSize = CONFIG_ETH_NXP_S32_TX_RING_LEN,				\
+		.bufferLen = CONFIG_ETH_NXP_S32_TX_RING_BUF_SIZE,			\
+		.maxBuffLen = CONFIG_ETH_NXP_S32_TX_RING_BUF_SIZE,			\
+	}										\
+};											\
+											\
+static const Netc_Eth_Ip_GeneralSIConfigType						\
+nxp_s32_eth##n##_psi_cfg[FEATURE_NETC_ETH_NUMBER_OF_CTRLS] = {				\
+	[NETC_SI_NXP_S32_HW_INSTANCE(n)] = {						\
+		.siId = NETC_SI_NXP_S32_HW_INSTANCE(n),					\
+		.enableSi = true,							\
+		.NumberOfRxBDR = 1,							\
+		.NumberOfTxBDR = 2,							\
+		.SIVlanControl = (NETC_F3_PSICFGR0_SIVC_CVLAN_BIT			\
+				| NETC_F3_PSICFGR0_SIVC_SVLAN_BIT),			\
+	},										\
+	COND_CODE_1(INIT_VSIS(n),							\
+		(DT_INST_FOREACH_PROP_ELEM_SEP(n, vsis, NETC_VSI_GENERAL_CFG, (,))),	\
+		(EMPTY))								\
+};											\
+											\
+COND_CODE_1(INIT_VSIS(n),								\
+	(DT_INST_FOREACH_PROP_ELEM_SEP_VARGS(n, vsis, NETC_VSI_RX_MSG_BUF, (;), n)),	\
+	(EMPTY));									\
+											\
+static const Netc_Eth_Ip_EnetcGeneralConfigType nxp_s32_eth##n##_enetc_general_cfg = {	\
+	.numberOfConfiguredSis = FEATURE_NETC_ETH_NUMBER_OF_CTRLS,			\
+	.stationInterfaceGeneralConfig = &nxp_s32_eth##n##_psi_cfg,			\
+	IF_ENABLED(CONFIG_NET_PROMISCUOUS_MODE,						\
+		(.maskMACPromiscuousMulticastEnable = (uint16_t)true,			\
+		.maskMACPromiscuousUnicastEnable = (uint16_t)true,))			\
+	.RxVsiMsgCmdToPsi = {								\
+		COND_CODE_1(INIT_VSIS(n),						\
+			(DT_INST_FOREACH_PROP_ELEM_SEP_VARGS(n, vsis,			\
+				NETC_VSI_RX_MSG_BUF_ARRAY, (,), n)),			\
+			(EMPTY))							\
+	},										\
+};											\
+											\
+static const Netc_Eth_Ip_StationInterfaceConfigType nxp_s32_eth##n##_si_cfg = {		\
+	.NumberOfRxBDR = 1,								\
+	.NumberOfTxBDR = 2,								\
+	.txMruMailboxAddr = NULL,							\
+	.rxMruMailboxAddr = (uint32_t *)MRU_MBOX_ADDR(DT_DRV_INST(n), rx),		\
+	.siMsgMruMailboxAddr = COND_CODE_1(INIT_VSIS(n),				\
+		((uint32_t *)MRU_MBOX_ADDR(DT_DRV_INST(n), vsi_msg)), (NULL)),		\
+	.RxInterrupts = (uint32_t)true,							\
+	.TxInterrupts = (uint32_t)false,						\
+	.MACFilterTableMaxNumOfEntries = CONFIG_ETH_NXP_S32_MAC_FILTER_TABLE_SIZE,	\
+};											\
+											\
+static uint8_t nxp_s32_eth##n##_switch_vlandr2dei_cfg[NETC_ETHSWT_NUMBER_OF_DR];	\
+static Netc_EthSwt_Ip_PortIngressType nxp_s32_eth##n##_switch_port_ingress_cfg;		\
+static Netc_EthSwt_Ip_PortEgressType nxp_s32_eth##n##_switch_port_egress_cfg = {	\
+	.vlanDrToDei = &nxp_s32_eth##n##_switch_vlandr2dei_cfg,				\
+};											\
+static Netc_EthSwt_Ip_PortType nxp_s32_eth##n##_switch_ports_cfg[NETC_ETHSWT_NUMBER_OF_PORTS] = {\
+	LISTIFY(NETC_ETHSWT_NUMBER_OF_PORTS, NETC_SWITCH_PORT_CFG, (,), n)		\
+};											\
+											\
+static const Netc_EthSwt_Ip_ConfigType nxp_s32_eth##n##_switch_cfg = {			\
+	.port = &nxp_s32_eth##n##_switch_ports_cfg,					\
+	.EthSwtArlTableEntryTimeout = NETC_SWITCH_PORT_AGING,				\
+	.netcClockFrequency = DT_INST_PROP(n, clock_frequency),				\
+	.MacLearningOption = ETHSWT_MACLEARNINGOPTION_HWDISABLED,			\
+	.MacForwardingOption = ETHSWT_NO_FDB_LOOKUP_FLOOD_FRAME,			\
+	.Timer1588ClkSrc = ETHSWT_REFERENCE_CLOCK_DISABLED,				\
+};											\
+											\
+PINCTRL_DT_INST_DEFINE(n);								\
+											\
+NETC_GENERATE_MAC_ADDRESS(n)								\
+											\
+static const struct nxp_s32_eth_config nxp_s32_eth##n##_config = {			\
+	.netc_cfg = {									\
+		.SiType = NETC_ETH_IP_PHYSICAL_SI,					\
+		.siConfig = &nxp_s32_eth##n##_si_cfg,					\
+		.generalConfig = &nxp_s32_eth##n##_enetc_general_cfg,			\
+		.stateStructure = &nxp_s32_eth##n##_state,				\
+		.paCtrlRxRingConfig = &nxp_s32_eth##n##_rxring_cfg,			\
+		.paCtrlTxRingConfig = &nxp_s32_eth##n##_txring_cfg,			\
+	},										\
+	.si_idx = NETC_SI_NXP_S32_HW_INSTANCE(n),					\
+	.port_idx = NETC_SWITCH_PORT_IDX,						\
+	.tx_ring_idx = TX_RING_IDX,							\
+	.rx_ring_idx = RX_RING_IDX,							\
+	.msix = {									\
+		NETC_MSIX(DT_DRV_INST(n), rx, nxp_s32_eth_psi##n##_rx_event),		\
+		COND_CODE_1(INIT_VSIS(n),						\
+			(NETC_MSIX(DT_DRV_INST(n), vsi_msg, Netc_Eth_Ip_MSIX_SIMsgEvent)),\
+			(EMPTY))							\
+	},										\
+	.mac_filter_hash_table = &nxp_s32_eth##n##_mac_filter_hash_table[0],		\
+	.generate_mac = nxp_s32_eth##n##_generate_mac,					\
+	.phy_dev = DEVICE_DT_GET(PHY_NODE(n)),						\
+	.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),					\
+};											\
+											\
+static struct nxp_s32_eth_data nxp_s32_eth##n##_data = {				\
+	.mac_addr = DT_INST_PROP_OR(n, local_mac_address, {0}),				\
+};											\
+											\
+ETH_NET_DEVICE_DT_INST_DEFINE(n,							\
+			nxp_s32_eth_initialize,						\
+			NULL,								\
+			&nxp_s32_eth##n##_data,						\
+			&nxp_s32_eth##n##_config,					\
+			CONFIG_ETH_INIT_PRIORITY,					\
+			&nxp_s32_eth_api,						\
+			NET_ETH_MTU);							\
 
-NETC_TX_RING(0, 0, NETC_MIN_RING_LEN, NETC_MIN_RING_BUF_SIZE);
-NETC_TX_RING(0, TX_RING_IDX,
-	     CONFIG_ETH_NXP_S32_TX_RING_LEN, CONFIG_ETH_NXP_S32_TX_RING_BUF_SIZE);
-NETC_RX_RING(0, RX_RING_IDX,
-	     CONFIG_ETH_NXP_S32_RX_RING_LEN, CONFIG_ETH_NXP_S32_RX_RING_BUF_SIZE);
-
-static const Netc_Eth_Ip_RxRingConfigType nxp_s32_eth0_rxring_cfg[1] = {
-	{
-		.RingDesc = nxp_s32_eth0_rxring0_desc,
-		.Buffer = nxp_s32_eth0_rxring0_buf,
-		.ringSize = CONFIG_ETH_NXP_S32_RX_RING_LEN,
-		.maxRingSize = CONFIG_ETH_NXP_S32_RX_RING_LEN,
-		.bufferLen = CONFIG_ETH_NXP_S32_TX_RING_BUF_SIZE,
-		.maxBuffLen = CONFIG_ETH_NXP_S32_TX_RING_BUF_SIZE,
-		.TimerThreshold = CONFIG_ETH_NXP_S32_RX_IRQ_TIMER_THRESHOLD,
-		.PacketsThreshold = CONFIG_ETH_NXP_S32_RX_IRQ_PACKET_THRESHOLD,
-		.Callback = nxp_s32_eth0_rx_callback,
-	}
-};
-
-static const Netc_Eth_Ip_TxRingConfigType nxp_s32_eth0_txring_cfg[2] = {
-	{
-		.RingDesc = nxp_s32_eth0_txring0_desc,
-		.Buffer = nxp_s32_eth0_txring0_buf,
-		.ringSize = NETC_MIN_RING_LEN,
-		.maxRingSize = NETC_MIN_RING_LEN,
-		.bufferLen = NETC_MIN_RING_BUF_SIZE,
-		.maxBuffLen = NETC_MIN_RING_BUF_SIZE,
-	},
-	{
-		.RingDesc = nxp_s32_eth0_txring1_desc,
-		.Buffer = nxp_s32_eth0_txring1_buf,
-		.ringSize = CONFIG_ETH_NXP_S32_TX_RING_LEN,
-		.maxRingSize = CONFIG_ETH_NXP_S32_TX_RING_LEN,
-		.bufferLen = CONFIG_ETH_NXP_S32_TX_RING_BUF_SIZE,
-		.maxBuffLen = CONFIG_ETH_NXP_S32_TX_RING_BUF_SIZE,
-	}
-};
-
-static const Netc_Eth_Ip_GeneralSIConfigType
-nxp_s32_eth0_psi_cfg[FEATURE_NETC_ETH_NUMBER_OF_CTRLS] = {
-	[NETC_ETH_IP_PSI_INDEX] = {
-		.siId = NETC_ETH_IP_PSI_INDEX,
-		.enableSi = true,
-		.NumberOfRxBDR = 1,
-		.NumberOfTxBDR = 2,
-		.SIVlanControl = (NETC_F3_PSICFGR0_SIVC_CVLAN_BIT
-				| NETC_F3_PSICFGR0_SIVC_SVLAN_BIT),
-	},
-	COND_CODE_1(INIT_VSIS,
-		(DT_FOREACH_PROP_ELEM_SEP(PSI_NODE, vsis, NETC_VSI_GENERAL_CFG, (,))),
-		(EMPTY))
-};
-
-COND_CODE_1(INIT_VSIS,
-	(DT_FOREACH_PROP_ELEM_SEP(PSI_NODE, vsis, NETC_VSI_RX_MSG_BUF, (;))),
-	(EMPTY));
-
-static const Netc_Eth_Ip_EnetcGeneralConfigType nxp_s32_eth0_enetc_general_cfg = {
-	.numberOfConfiguredSis = FEATURE_NETC_ETH_NUMBER_OF_CTRLS,
-	.stationInterfaceGeneralConfig = &nxp_s32_eth0_psi_cfg,
-#if defined(CONFIG_NET_PROMISCUOUS_MODE)
-	.maskMACPromiscuousMulticastEnable = (uint16_t)true,
-	.maskMACPromiscuousUnicastEnable = (uint16_t)true,
-#endif
-	.RxVsiMsgCmdToPsi = {
-		COND_CODE_1(INIT_VSIS,
-			(DT_FOREACH_PROP_ELEM_SEP(PSI_NODE, vsis,
-				NETC_VSI_RX_MSG_BUF_ARRAY, (,))),
-			(EMPTY))
-	},
-};
-
-static const Netc_Eth_Ip_StationInterfaceConfigType nxp_s32_eth0_si_cfg = {
-	.NumberOfRxBDR = 1,
-	.NumberOfTxBDR = 2,
-	.txMruMailboxAddr = NULL,
-	.rxMruMailboxAddr = (uint32_t *)MRU_MBOX_ADDR(PSI_NODE, rx),
-	.siMsgMruMailboxAddr = COND_CODE_1(INIT_VSIS,
-		((uint32_t *)MRU_MBOX_ADDR(PSI_NODE, vsi_msg)), (NULL)),
-	.RxInterrupts = (uint32_t)true,
-	.TxInterrupts = (uint32_t)false,
-	.MACFilterTableMaxNumOfEntries = CONFIG_ETH_NXP_S32_MAC_FILTER_TABLE_SIZE,
-};
-
-static uint8_t nxp_s32_eth0_switch_vlandr2dei_cfg[NETC_ETHSWT_NUMBER_OF_DR];
-static Netc_EthSwt_Ip_PortIngressType nxp_s32_eth0_switch_port_ingress_cfg;
-static Netc_EthSwt_Ip_PortEgressType nxp_s32_eth0_switch_port_egress_cfg = {
-	.vlanDrToDei = &nxp_s32_eth0_switch_vlandr2dei_cfg,
-};
-static Netc_EthSwt_Ip_PortType nxp_s32_eth0_switch_ports_cfg[NETC_ETHSWT_NUMBER_OF_PORTS] = {
-	LISTIFY(NETC_ETHSWT_NUMBER_OF_PORTS, NETC_SWITCH_PORT_CFG, (,))
-};
-
-static const Netc_EthSwt_Ip_ConfigType nxp_s32_eth0_switch_cfg = {
-	.port = &nxp_s32_eth0_switch_ports_cfg,
-	.EthSwtArlTableEntryTimeout = NETC_SWITCH_PORT_AGING,
-	.netcClockFrequency = DT_PROP(PSI_NODE, clock_frequency),
-	.MacLearningOption = ETHSWT_MACLEARNINGOPTION_HWDISABLED,
-	.MacForwardingOption = ETHSWT_NO_FDB_LOOKUP_FLOOD_FRAME,
-	.Timer1588ClkSrc = ETHSWT_REFERENCE_CLOCK_DISABLED,
-};
-
-PINCTRL_DT_DEFINE(PSI_NODE);
-
-NETC_GENERATE_MAC_ADDRESS(PSI_NODE, 0)
-
-static const struct nxp_s32_eth_config nxp_s32_eth0_config = {
-	.netc_cfg = {
-		.SiType = NETC_ETH_IP_PHYSICAL_SI,
-		.siConfig = &nxp_s32_eth0_si_cfg,
-		.generalConfig = &nxp_s32_eth0_enetc_general_cfg,
-		.stateStructure = &nxp_s32_eth0_state,
-		.paCtrlRxRingConfig = &nxp_s32_eth0_rxring_cfg,
-		.paCtrlTxRingConfig = &nxp_s32_eth0_txring_cfg,
-	},
-	.si_idx = NETC_ETH_IP_PSI_INDEX,
-	.port_idx = NETC_SWITCH_PORT_IDX,
-	.tx_ring_idx = TX_RING_IDX,
-	.rx_ring_idx = RX_RING_IDX,
-	.msix = {
-		NETC_MSIX(PSI_NODE, rx, Netc_Eth_Ip_0_MSIX_RxEvent),
-		COND_CODE_1(INIT_VSIS,
-			(NETC_MSIX(PSI_NODE, vsi_msg, Netc_Eth_Ip_MSIX_SIMsgEvent)),
-			(EMPTY))
-	},
-	.mac_filter_hash_table = &nxp_s32_eth0_mac_filter_hash_table[0],
-	.generate_mac = nxp_s32_eth0_generate_mac,
-	.phy_dev = DEVICE_DT_GET(PHY_NODE),
-	.pincfg = PINCTRL_DT_DEV_CONFIG_GET(PSI_NODE),
-};
-
-static struct nxp_s32_eth_data nxp_s32_eth0_data = {
-	.mac_addr = DT_PROP_OR(PSI_NODE, local_mac_address, {0}),
-};
-
-ETH_NET_DEVICE_DT_DEFINE(PSI_NODE,
-			nxp_s32_eth_initialize,
-			NULL,
-			&nxp_s32_eth0_data,
-			&nxp_s32_eth0_config,
-			CONFIG_ETH_INIT_PRIORITY,
-			&nxp_s32_eth_api,
-			NET_ETH_MTU);
+DT_INST_FOREACH_STATUS_OKAY(NETC_PSI_INSTANCE_DEFINE)
 
 static int nxp_s32_eth_switch_init(void)
 {

--- a/drivers/ethernet/eth_nxp_s32_netc_vsi.c
+++ b/drivers/ethernet/eth_nxp_s32_netc_vsi.c
@@ -1,8 +1,10 @@
 /*
- * Copyright 2022 NXP
+ * Copyright 2022-2023 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#define DT_DRV_COMPAT nxp_s32_netc_vsi
 
 #define LOG_LEVEL CONFIG_ETHERNET_LOG_LEVEL
 #include <zephyr/logging/log.h>
@@ -26,7 +28,6 @@ LOG_MODULE_REGISTER(nxp_s32_eth_vsi);
 #include "eth.h"
 #include "eth_nxp_s32_netc_priv.h"
 
-#define VSI_NODE(n)	DT_NODELABEL(enetc_vsi##n)
 #define TX_RING_IDX	0
 #define RX_RING_IDX	0
 
@@ -83,11 +84,16 @@ static const struct ethernet_api nxp_s32_eth_api = {
 BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(nxp_s32_netc_vsi) == 1, "Only one VSI enabled supported");
 
 #define NETC_VSI_INSTANCE_DEFINE(n)								\
-	NETC_GENERATE_MAC_ADDRESS(VSI_NODE(n), n)						\
+	NETC_GENERATE_MAC_ADDRESS(n)								\
+												\
+	void nxp_s32_eth_vsi##n##_rx_event(uint8_t chan, const uint32_t *buf, uint8_t buf_size)	\
+	{											\
+		Netc_Eth_Ip_MSIX_Rx(NETC_SI_NXP_S32_HW_INSTANCE(n));				\
+	}											\
 												\
 	static void nxp_s32_eth##n##_rx_callback(const uint8_t unused, const uint8_t ring)	\
 	{											\
-		const struct device *dev = DEVICE_DT_GET(VSI_NODE(n));				\
+		const struct device *dev = DEVICE_DT_INST_GET(n);				\
 		const struct nxp_s32_eth_config *cfg = dev->config;				\
 		struct nxp_s32_eth_data *ctx = dev->data;					\
 												\
@@ -135,7 +141,7 @@ BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(nxp_s32_netc_vsi) == 1, "Only one VSI enabl
 		.NumberOfRxBDR = 1,								\
 		.NumberOfTxBDR = 1,								\
 		.txMruMailboxAddr = NULL,							\
-		.rxMruMailboxAddr = (uint32_t *)MRU_MBOX_ADDR(VSI_NODE(n), rx),			\
+		.rxMruMailboxAddr = (uint32_t *)MRU_MBOX_ADDR(DT_DRV_INST(n), rx),		\
 		.RxInterrupts = (uint32_t)true,							\
 		.TxInterrupts = (uint32_t)false,						\
 		.MACFilterTableMaxNumOfEntries = CONFIG_ETH_NXP_S32_MAC_FILTER_TABLE_SIZE,	\
@@ -143,7 +149,7 @@ BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(nxp_s32_netc_vsi) == 1, "Only one VSI enabl
 	};											\
 												\
 	static struct nxp_s32_eth_data nxp_s32_eth##n##_data = {				\
-		.mac_addr = DT_PROP_OR(VSI_NODE(n), local_mac_address, {0}),			\
+		.mac_addr = DT_INST_PROP_OR(n, local_mac_address, {0}),				\
 	};											\
 												\
 	static const struct nxp_s32_eth_config nxp_s32_eth##n##_cfg = {				\
@@ -154,49 +160,23 @@ BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(nxp_s32_netc_vsi) == 1, "Only one VSI enabl
 			.paCtrlRxRingConfig = &nxp_s32_eth##n##_rxring_cfg,			\
 			.paCtrlTxRingConfig = &nxp_s32_eth##n##_txring_cfg,			\
 		},										\
-		.si_idx = n,									\
+		.si_idx = NETC_SI_NXP_S32_HW_INSTANCE(n),					\
 		.tx_ring_idx = TX_RING_IDX,							\
 		.rx_ring_idx = RX_RING_IDX,							\
 		.msix = {									\
-			NETC_MSIX(VSI_NODE(n), rx, Netc_Eth_Ip_##n##_MSIX_RxEvent),		\
+			NETC_MSIX(DT_DRV_INST(n), rx, nxp_s32_eth_vsi##n##_rx_event),		\
 		},										\
 		.mac_filter_hash_table = &nxp_s32_eth##n##_mac_filter_hash_table[0],		\
 		.generate_mac = nxp_s32_eth##n##_generate_mac,					\
 	};											\
 												\
-	ETH_NET_DEVICE_DT_DEFINE(VSI_NODE(n),							\
+	ETH_NET_DEVICE_DT_INST_DEFINE(n,							\
 				nxp_s32_eth_initialize_common,					\
 				NULL,								\
 				&nxp_s32_eth##n##_data,						\
 				&nxp_s32_eth##n##_cfg,						\
 				CONFIG_ETH_NXP_S32_VSI_INIT_PRIORITY,				\
 				&nxp_s32_eth_api,						\
-				NET_ETH_MTU)
+				NET_ETH_MTU);
 
-#if DT_NODE_HAS_STATUS(VSI_NODE(1), okay)
-NETC_VSI_INSTANCE_DEFINE(1);
-#endif
-
-#if DT_NODE_HAS_STATUS(VSI_NODE(2), okay)
-NETC_VSI_INSTANCE_DEFINE(2);
-#endif
-
-#if DT_NODE_HAS_STATUS(VSI_NODE(3), okay)
-NETC_VSI_INSTANCE_DEFINE(3);
-#endif
-
-#if DT_NODE_HAS_STATUS(VSI_NODE(4), okay)
-NETC_VSI_INSTANCE_DEFINE(4);
-#endif
-
-#if DT_NODE_HAS_STATUS(VSI_NODE(5), okay)
-NETC_VSI_INSTANCE_DEFINE(5);
-#endif
-
-#if DT_NODE_HAS_STATUS(VSI_NODE(6), okay)
-NETC_VSI_INSTANCE_DEFINE(6);
-#endif
-
-#if DT_NODE_HAS_STATUS(VSI_NODE(7), okay)
-NETC_VSI_INSTANCE_DEFINE(7);
-#endif
+DT_INST_FOREACH_STATUS_OKAY(NETC_VSI_INSTANCE_DEFINE)

--- a/west.yml
+++ b/west.yml
@@ -193,7 +193,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 1b2f3608ab0d5f2cf2a4c2973ae9f6353fb43e72
+      revision: cbf2cd1f099585eeef2cdb0c68d72e9e67e89c24
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
At present, many of the NXP S32 shim drivers do not make use of devicetree instance-based macros because the NXP S32 HAL relies on an index-based approach, requiring knowledge of the peripheral instance index during both compilation and runtime, and this index might not align with the devicetree instance index.

The proposed solution in this patch eliminates this limitation by determining the peripheral instance index during compilation through macrobatics.

```
west build -p -b s32z270dc2_rtu0_r52 samples\boards\nxp_s32\netc

[00:00:00.051,000] <inf> phy_mii: PHY (7) ID 1CC916

[00:00:00.052,000] <inf> nxp_s32_eth_psi: SI0 MAC: 00:00:00:01:02:00
*** Booting Zephyr OS build zephyr-v3.5.0-2534-g8ccae9fff76a ***
[00:00:00.052,000] <inf> shell_telnet: Telnet shell backend initialized
[00:00:00.052,000] <inf> nxp_s32_netc_sample: Starting sample
[00:00:00.052,000] <inf> nxp_s32_netc_sample: Waiting for iface 1 to come up
[00:00:07.595,000] <inf> phy_mii: PHY (7) Link speed 1000 Mb, full duplex

[00:00:07.595,000] <inf> nxp_s32_netc_sample: Configuring iface 1 (0x3180b718)
[00:00:07.595,000] <inf> nxp_s32_netc_sample: IPv6 address: 2001:db8::1
[00:00:07.595,000] <inf> nxp_s32_netc_sample: IPv4 address: 192.0.2.1
uart:~$ net ping 2001:db8::3
PING 2001:db8::3
8 bytes from 2001:db8::3 to 2001:db8::1: icmp_seq=1 ttl=64 time=0.31 ms
8 bytes from 2001:db8::3 to 2001:db8::1: icmp_seq=2 ttl=64 time=0.30 ms
8 bytes from 2001:db8::3 to 2001:db8::1: icmp_seq=3 ttl=64 time=0.30 ms
uart:~$ net ping 192.0.2.3
PING 192.0.2.3
28 bytes from 192.0.2.3 to 192.0.2.1: icmp_seq=1 ttl=64 time=0.32 ms
28 bytes from 192.0.2.3 to 192.0.2.1: icmp_seq=2 ttl=64 time=0.32 ms
28 bytes from 192.0.2.3 to 192.0.2.1: icmp_seq=3 ttl=64 time=0.33 ms
uart:~$
```


```
west build -p -b s32z270dc2_rtu0_r52 samples\boards\nxp_s32\netc -T sample.boards.nxp_s32.netc.vsi_and_psi

[00:00:00.052,000] <inf> phy_mii: PHY (7) ID 1CC916

[00:00:00.053,000] <inf> nxp_s32_eth_psi: SI0 MAC: 00:00:00:01:02:00
[00:00:00.053,000] <inf> nxp_s32_eth_vsi: SI1 MAC: 00:00:00:01:02:11
*** Booting Zephyr OS build zephyr-v3.5.0-2534-g8ccae9fff76a ***
[00:00:00.053,000] <inf> shell_telnet: Telnet shell backend initialized
[00:00:00.053,000] <inf> nxp_s32_netc_sample: Starting sample
[00:00:00.053,000] <inf> nxp_s32_netc_sample: Waiting for iface 1 to come up
[00:00:07.596,000] <inf> phy_mii: PHY (7) Link speed 1000 Mb, full duplex

[00:00:07.596,000] <inf> nxp_s32_netc_sample: Configuring iface 1 (0x3183a9d4)
[00:00:07.596,000] <inf> nxp_s32_netc_sample: IPv6 address: 2001:db8::1
[00:00:07.596,000] <inf> nxp_s32_netc_sample: IPv4 address: 192.0.2.1
[00:00:07.596,000] <inf> nxp_s32_netc_sample: Configuring iface 2 (0x3183aa14)
[00:00:07.596,000] <inf> nxp_s32_netc_sample: IPv6 address: 2001:db8::2
[00:00:07.596,000] <inf> nxp_s32_netc_sample: IPv4 address: 192.0.2.2
uart:~$ net ping 192.0.2.3
PING 192.0.2.3
28 bytes from 192.0.2.3 to 192.0.2.1: icmp_seq=1 ttl=64 time=0.32 ms
28 bytes from 192.0.2.3 to 192.0.2.1: icmp_seq=2 ttl=64 time=0.32 ms
28 bytes from 192.0.2.3 to 192.0.2.1: icmp_seq=3 ttl=64 time=0.32 ms
uart:~$ net ping 2001:db8::3
PING 2001:db8::3
8 bytes from 2001:db8::3 to 2001:db8::2: icmp_seq=1 ttl=64 time=0.31 ms
8 bytes from 2001:db8::3 to 2001:db8::2: icmp_seq=2 ttl=64 time=0.30 ms
8 bytes from 2001:db8::3 to 2001:db8::2: icmp_seq=3 ttl=64 time=0.30 ms
uart:~$
```

