### PR TITLE
soc: intel_adsp: call framework callback function for restore

### DIFF
--- a/soc/xtensa/intel_adsp/ace/power.c
+++ b/soc/xtensa/intel_adsp/ace/power.c
@@ -149,6 +149,7 @@ static ALWAYS_INLINE void _restore_core_context(void)
 }
 
 void dsp_restore_vector(void);
+void mp_resume_entry(void);
 
 void power_gate_entry(uint32_t core_id)
 {
@@ -179,6 +180,10 @@ void power_gate_exit(void)
 	cpu_early_init();
 	sys_cache_data_flush_and_invd_all();
 	_restore_core_context();
+
+	/* Secondary core is resumed by set_dx */
+	if (arch_proc_id())
+		mp_resume_entry();
 }
 
 __asm__(".align 4\n\t"

--- a/soc/xtensa/intel_adsp/cavs/power.c
+++ b/soc/xtensa/intel_adsp/cavs/power.c
@@ -52,6 +52,7 @@ LOG_MODULE_REGISTER(soc);
  * @biref FW entry point called by ROM during normal boot flow
  */
 extern void rom_entry(void);
+void mp_resume_entry(void);
 
 struct core_state {
 	uint32_t a0;
@@ -104,6 +105,10 @@ void power_gate_exit(void)
 	cpu_early_init();
 	sys_cache_data_flush_and_invd_all();
 	_restore_core_context();
+
+	/* Secondary core is resumed by set_dx */
+	if (arch_proc_id())
+		mp_resume_entry();
 }
 
 __asm__(".align 4\n\t"

--- a/soc/xtensa/intel_adsp/common/multiprocessing.c
+++ b/soc/xtensa/intel_adsp/common/multiprocessing.c
@@ -110,6 +110,11 @@ __imr void z_mp_entry(void)
 	__ASSERT(false, "arch_start_cpu() handler should never return");
 }
 
+void mp_resume_entry(void)
+{
+	start_rec.fn(start_rec.arg);
+}
+
 bool arch_cpu_active(int cpu_num)
 {
 	return soc_cpus_active[cpu_num];


### PR DESCRIPTION
Sof will use smp utility in framework and call framework callback function to complete secondary cpu restore.

This PR align with https://github.com/zephyrproject-rtos/zephyr/pull/64755 and https://github.com/zephyrproject-rtos/sof/pull/32