### PR TITLE
modules: lvgl: Force fullsize render buffer on full refresh

### DIFF
--- a/modules/lvgl/Kconfig.memory
+++ b/modules/lvgl/Kconfig.memory
@@ -40,6 +40,7 @@ config LV_Z_MEM_POOL_SIZE
 
 config LV_Z_VDB_SIZE
 	int "Rendering buffer size"
+	default 100 if LV_Z_FULL_REFRESH
 	default 10
 	range 1 100
 	help


### PR DESCRIPTION
Changes the default of `LV_Z_VDB_SIZE` to 100 percent if `LV_Z_FULL_REFRESH` is set. Reason is that LVGL will reset the full refresh flag if the buffer is not equal to the screen size:

[https://github.com/zephyrproject-rtos/lvgl/blob/7c61a4cec26402d20c845c95dcad0e39dcd319f8/src/hal/lv_hal_disp.c#L198](https://github.com/zephyrproject-rtos/lvgl/blob/7c61a4cec26402d20c845c95dcad0e39dcd319f8/src/hal/lv_hal_disp.c#L198)

Issue was first discovered in: [https://github.com/zephyrproject-rtos/zephyr/discussions/65087#discussioncomment-7579563](https://github.com/zephyrproject-rtos/zephyr/discussions/65087#discussioncomment-7579563)