### PR TITLE
modules: openthread: platform: radio: Rename missed type

### DIFF
--- a/modules/openthread/platform/radio.c
+++ b/modules/openthread/platform/radio.c
@@ -1431,7 +1431,7 @@ otError otPlatRadioConfigureEnhAckProbing(otInstance *aInstance, otLinkMetrics a
 
 	header_ie_len = set_vendor_ie_header_lm(aLinkMetrics.mLqi, aLinkMetrics.mLinkMargin,
 						aLinkMetrics.mRssi, header_ie_buf);
-	config.ack_ie.header_ie = (struct ieee802154_ie_header *)header_ie_buf;
+	config.ack_ie.header_ie = (struct ieee802154_header_ie *)header_ie_buf;
 	result = radio_api->configure(radio_dev, IEEE802154_CONFIG_ENH_ACK_HEADER_IE, &config);
 
 	return result ? OT_ERROR_FAILED : OT_ERROR_NONE;


### PR DESCRIPTION
Fixes an issue whereby a rename of a variable type has been forgotten in an instance, which now uses the correct type name