### PR TITLE
drivers: modem: fix for possible non-null terminated string

### DIFF
--- a/drivers/modem/simcom-sim7080.c
+++ b/drivers/modem/simcom-sim7080.c
@@ -1466,7 +1466,7 @@ static int parse_cgnsinf(char *gps_buf)
 	gnss_data.run_status = 1;
 	gnss_data.fix_status = 1;
 
-	strncpy(gnss_data.utc, utc, sizeof(gnss_data.utc));
+	strncpy(gnss_data.utc, utc, sizeof(gnss_data.utc) - 1);
 
 	ret = gnss_split_on_dot(lat, &number, &fraction);
 	if (ret != 0) {


### PR DESCRIPTION
Fix handling of strncpy in cgnsinf parsing function to avoid potentially getting a non-null terminated string.
Fixes #58573 / CID: 248403