### PR TITLE
drivers: i2s: i2s_nrfx: Introduce support for new instance in I2S driver

### DIFF
--- a/drivers/i2s/Kconfig.nrfx
+++ b/drivers/i2s/Kconfig.nrfx
@@ -6,6 +6,7 @@ menuconfig I2S_NRFX
 	default y
 	depends on DT_HAS_NORDIC_NRF_I2S_ENABLED
 	select NRFX_I2S0 if HAS_HW_NRF_I2S0
+	select NRFX_I2S20 if HAS_HW_NRF_I2S20
 	select PINCTRL
 	help
 	  Enable support for nrfx I2S driver for nRF MCU series.

--- a/drivers/i2s/i2s_nrfx.c
+++ b/drivers/i2s/i2s_nrfx.c
@@ -955,5 +955,10 @@ static const struct i2s_driver_api i2s_nrf_drv_api = {
 			 POST_KERNEL, CONFIG_I2S_INIT_PRIORITY,		     \
 			 &i2s_nrf_drv_api);
 
-/* Existing SoCs only have one I2S instance. */
+#ifdef CONFIG_HAS_HW_NRF_I2S0
 I2S_NRFX_DEVICE(0);
+#endif
+
+#ifdef CONFIG_HAS_HW_NRF_I2S20
+I2S_NRFX_DEVICE(20);
+#endif

--- a/modules/hal_nordic/nrfx/Kconfig
+++ b/modules/hal_nordic/nrfx/Kconfig
@@ -82,6 +82,11 @@ config NRFX_I2S0
 	depends on $(dt_nodelabel_has_compat,i2s0,$(DT_COMPAT_NORDIC_NRF_I2S))
 	select NRFX_I2S
 
+config NRFX_I2S20
+	bool "I2S20 driver instance"
+	depends on $(dt_nodelabel_has_compat,i2s20,$(DT_COMPAT_NORDIC_NRF_I2S))
+	select NRFX_I2S
+
 config NRFX_IPC
 	bool "IPC driver"
 	depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_IPC))

--- a/modules/hal_nordic/nrfx/nrfx_config.h
+++ b/modules/hal_nordic/nrfx/nrfx_config.h
@@ -141,6 +141,9 @@
 #ifdef CONFIG_NRFX_I2S0
 #define NRFX_I2S0_ENABLED 1
 #endif
+#ifdef CONFIG_NRFX_I2S20
+#define NRFX_I2S20_ENABLED 1
+#endif
 
 #ifdef CONFIG_NRFX_IPC
 #define NRFX_IPC_ENABLED 1

--- a/soc/arm/nordic_nrf/Kconfig.peripherals
+++ b/soc/arm/nordic_nrf/Kconfig.peripherals
@@ -75,6 +75,9 @@ config HAS_HW_NRF_GPIOTE
 config HAS_HW_NRF_I2S0
 	def_bool $(dt_nodelabel_enabled_with_compat,i2s0,$(DT_COMPAT_NORDIC_NRF_I2S))
 
+config HAS_HW_NRF_I2S20
+	def_bool $(dt_nodelabel_enabled_with_compat,i2s20,$(DT_COMPAT_NORDIC_NRF_I2S))
+
 config HAS_HW_NRF_IPC
 	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_IPC))
 


### PR DESCRIPTION
Introducing support for additional instance in the I2S driver