### PR TITLE
ARC: MWDT: Force cleanup .device_states section

### DIFF
--- a/arch/arc/core/prep_c.c
+++ b/arch/arc/core/prep_c.c
@@ -23,7 +23,6 @@
 #include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 
-
 /* XXX - keep for future use in full-featured cache APIs */
 #if 0
 /**
@@ -67,6 +66,21 @@ static void invalidate_dcache(void)
 }
 #endif
 
+#ifdef __CCAC__
+extern char __device_states_start[];
+extern char __device_states_end[];
+/**
+ * @brief Clear device_states section
+ *
+ * This routine clears the device_states section,
+ * as MW compiler marks the section with NOLOAD flag.
+ */
+static void dev_state_zero(void)
+{
+	z_early_memset(__device_states_start, 0, __device_states_end - __device_states_start);
+}
+#endif
+
 extern FUNC_NORETURN void z_cstart(void);
 /**
  * @brief Prepare to and run C code
@@ -77,6 +91,9 @@ extern FUNC_NORETURN void z_cstart(void);
 void _PrepC(void)
 {
 	z_bss_zero();
+#ifdef __CCAC__
+	dev_state_zero();
+#endif
 	z_data_copy();
 	z_cstart();
 	CODE_UNREACHABLE;


### PR DESCRIPTION
This PR fixes https://github.com/zephyrproject-rtos/zephyr/issues/64268

MWDT supposes .device_states section as BSS because .device_states variables defined as uninitialized. This causes the section marked as NOLOAD section and OpenOCD does not take it in account while flashing it into board memory. Finally .device_states variables becomes initialized with garbage from RAM.

In this PR it's suggested to clean .device_states in early init stage.