### PR TITLE
drivers: timer: counter: nrfx_rtc: Switch to use HALY instead of HAL

### DIFF
--- a/drivers/counter/counter_nrfx_rtc.c
+++ b/drivers/counter/counter_nrfx_rtc.c
@@ -9,6 +9,7 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/nrf_clock_control.h>
 #endif
+#include <haly/nrfy_rtc.h>
 #include <zephyr/sys/atomic.h>
 #ifdef DPPI_PRESENT
 #include <nrfx_dppi.h>
@@ -77,7 +78,7 @@ static int start(const struct device *dev)
 {
 	const struct counter_nrfx_config *config = dev->config;
 
-	nrf_rtc_task_trigger(config->rtc, NRF_RTC_TASK_START);
+	nrfy_rtc_task_trigger(config->rtc, NRF_RTC_TASK_START);
 
 	return 0;
 }
@@ -86,7 +87,7 @@ static int stop(const struct device *dev)
 {
 	const struct counter_nrfx_config *config = dev->config;
 
-	nrf_rtc_task_trigger(config->rtc, NRF_RTC_TASK_STOP);
+	nrfy_rtc_task_trigger(config->rtc, NRF_RTC_TASK_STOP);
 
 	return 0;
 }
@@ -95,7 +96,7 @@ static uint32_t read(const struct device *dev)
 {
 	const struct counter_nrfx_config *config = dev->config;
 
-	return nrf_rtc_counter_get(config->rtc);
+	return nrfy_rtc_counter_get(config->rtc);
 }
 
 static int get_value(const struct device *dev, uint32_t *ticks)
@@ -157,7 +158,7 @@ static void set_cc_int_pending(const struct device *dev, uint8_t chan)
 	struct counter_nrfx_data *data = dev->data;
 
 	atomic_or(&data->ipend_adj, BIT(chan));
-	NRFX_IRQ_PENDING_SET(NRFX_IRQ_NUMBER_GET(config->rtc));
+	NRFY_IRQ_PENDING_SET(NRFX_IRQ_NUMBER_GET(config->rtc));
 }
 
 /** @brief Handle case when CC value equals COUNTER+1.
@@ -180,12 +181,12 @@ static void handle_next_tick_case(const struct device *dev, uint8_t chan,
 	struct counter_nrfx_data *data = dev->data;
 
 	val = ticks_add(dev, val, 1, data->top);
-	nrf_rtc_cc_set(config->rtc, chan, val);
+	nrfy_rtc_cc_set(config->rtc, chan, val);
 	atomic_or(&data->ipend_adj, CC_ADJ_MASK(chan));
-	if (nrf_rtc_counter_get(config->rtc) != now) {
+	if (nrfy_rtc_counter_get(config->rtc) != now) {
 		set_cc_int_pending(dev, chan);
 	} else {
-		nrf_rtc_int_enable(config->rtc, NRF_RTC_CHANNEL_INT_MASK(chan));
+		nrfy_rtc_int_enable(config->rtc, NRF_RTC_CHANNEL_INT_MASK(chan));
 	}
 }
 
@@ -240,8 +241,8 @@ static int set_cc(const struct device *dev, uint8_t chan, uint32_t val,
 			"Expected that CC interrupt is disabled.");
 
 	evt = NRF_RTC_CHANNEL_EVENT_ADDR(chan);
-	top =  data->top;
-	now = nrf_rtc_counter_get(rtc);
+	top = data->top;
+	now = nrfy_rtc_counter_get(rtc);
 
 	/* First take care of a risk of an event coming from CC being set to
 	 * next tick. Reconfigure CC to future (now tick is the furthest
@@ -249,17 +250,17 @@ static int set_cc(const struct device *dev, uint8_t chan, uint32_t val,
 	 * (half of 32k tick) and clean potential event. After that time there
 	 * is no risk of unwanted event.
 	 */
-	prev_val = nrf_rtc_cc_get(rtc, chan);
-	nrf_rtc_event_clear(rtc, evt);
-	nrf_rtc_cc_set(rtc, chan, now);
-	nrf_rtc_event_enable(rtc, int_mask);
+	prev_val = nrfy_rtc_cc_get(rtc, chan);
+	nrfy_rtc_event_clear(rtc, evt);
+	nrfy_rtc_cc_set(rtc, chan, now);
+	nrfy_rtc_event_enable(rtc, int_mask);
 
 	if (ticks_sub(dev, prev_val, now, top) == 1) {
 		NRFX_DELAY_US(15);
-		nrf_rtc_event_clear(rtc, evt);
+		nrfy_rtc_event_clear(rtc, evt);
 	}
 
-	now = nrf_rtc_counter_get(rtc);
+	now = nrfy_rtc_counter_get(rtc);
 
 	if (absolute) {
 		val = skip_zero_on_custom_top(val, top);
@@ -289,8 +290,8 @@ static int set_cc(const struct device *dev, uint8_t chan, uint32_t val,
 		 */
 		handle_next_tick_case(dev, chan, now, val);
 	} else {
-		nrf_rtc_cc_set(rtc, chan, val);
-		now = nrf_rtc_counter_get(rtc);
+		nrfy_rtc_cc_set(rtc, chan, val);
+		now = nrfy_rtc_counter_get(rtc);
 
 		/* decrement value to detect also case when val == read(dev).
 		 * Otherwise, condition would need to include comparing diff
@@ -318,7 +319,7 @@ static int set_cc(const struct device *dev, uint8_t chan, uint32_t val,
 			 */
 			handle_next_tick_case(dev, chan, now, val);
 		} else {
-			nrf_rtc_int_enable(rtc, int_mask);
+			nrfy_rtc_int_enable(rtc, int_mask);
 		}
 	}
 
@@ -353,9 +354,8 @@ static void disable(const struct device *dev, uint8_t chan)
 	NRF_RTC_Type *rtc = config->rtc;
 	nrf_rtc_event_t evt = NRF_RTC_CHANNEL_EVENT_ADDR(chan);
 
-	nrf_rtc_int_disable(rtc, NRF_RTC_CHANNEL_INT_MASK(chan));
-	nrf_rtc_event_disable(rtc, NRF_RTC_CHANNEL_INT_MASK(chan));
-	nrf_rtc_event_clear(rtc, evt);
+	nrfy_rtc_event_int_disable(rtc, NRF_RTC_CHANNEL_INT_MASK(chan));
+	nrfy_rtc_event_clear(rtc, evt);
 	config->ch_data[chan].callback = NULL;
 }
 
@@ -379,7 +379,7 @@ static int ppi_setup(const struct device *dev, uint8_t chan)
 		return 0;
 	}
 
-	nrf_rtc_event_enable(rtc, NRF_RTC_CHANNEL_INT_MASK(chan));
+	nrfy_rtc_event_enable(rtc, NRF_RTC_CHANNEL_INT_MASK(chan));
 #ifdef DPPI_PRESENT
 	result = nrfx_dppi_channel_alloc(&data->ppi_ch);
 	if (result != NRFX_SUCCESS) {
@@ -387,15 +387,15 @@ static int ppi_setup(const struct device *dev, uint8_t chan)
 		return -ENODEV;
 	}
 
-	nrf_rtc_subscribe_set(rtc, NRF_RTC_TASK_CLEAR, data->ppi_ch);
-	nrf_rtc_publish_set(rtc, evt, data->ppi_ch);
+	nrfy_rtc_subscribe_set(rtc, NRF_RTC_TASK_CLEAR, data->ppi_ch);
+	nrfy_rtc_publish_set(rtc, evt, data->ppi_ch);
 	(void)nrfx_dppi_channel_enable(data->ppi_ch);
 #else /* DPPI_PRESENT */
 	uint32_t evt_addr;
 	uint32_t task_addr;
 
-	evt_addr = nrf_rtc_event_address_get(rtc, evt);
-	task_addr = nrf_rtc_task_address_get(rtc, NRF_RTC_TASK_CLEAR);
+	evt_addr = nrfy_rtc_event_address_get(rtc, evt);
+	task_addr = nrfy_rtc_task_address_get(rtc, NRF_RTC_TASK_CLEAR);
 
 	result = nrfx_ppi_channel_alloc(&data->ppi_ch);
 	if (result != NRFX_SUCCESS) {
@@ -420,13 +420,13 @@ static void ppi_free(const struct device *dev, uint8_t chan)
 	if (!nrfx_config->use_ppi) {
 		return;
 	}
-	nrf_rtc_event_disable(rtc, NRF_RTC_CHANNEL_INT_MASK(chan));
+	nrfy_rtc_event_disable(rtc, NRF_RTC_CHANNEL_INT_MASK(chan));
 #ifdef DPPI_PRESENT
 	nrf_rtc_event_t evt = NRF_RTC_CHANNEL_EVENT_ADDR(chan);
 
 	(void)nrfx_dppi_channel_disable(ppi_ch);
-	nrf_rtc_subscribe_clear(rtc, NRF_RTC_TASK_CLEAR);
-	nrf_rtc_publish_clear(rtc, evt);
+	nrfy_rtc_subscribe_clear(rtc, NRF_RTC_TASK_CLEAR);
+	nrfy_rtc_publish_clear(rtc, evt);
 	(void)nrfx_dppi_channel_free(ppi_ch);
 #else /* DPPI_PRESENT */
 	(void)nrfx_ppi_channel_disable(ppi_ch);
@@ -457,16 +457,16 @@ static int set_fixed_top_value(const struct device *dev,
 		return -EINVAL;
 	}
 
-	nrf_rtc_int_disable(rtc, NRF_RTC_INT_OVERFLOW_MASK);
+	nrfy_rtc_int_disable(rtc, NRF_RTC_INT_OVERFLOW_MASK);
 	data->top_cb = cfg->callback;
 	data->top_user_data = cfg->user_data;
 
 	if (!(cfg->flags & COUNTER_TOP_CFG_DONT_RESET)) {
-		nrf_rtc_task_trigger(rtc, NRF_RTC_TASK_CLEAR);
+		nrfy_rtc_task_trigger(rtc, NRF_RTC_TASK_CLEAR);
 	}
 
 	if (cfg->callback) {
-		nrf_rtc_int_enable(rtc, NRF_RTC_INT_OVERFLOW_MASK);
+		nrfy_rtc_int_enable(rtc, NRF_RTC_INT_OVERFLOW_MASK);
 	}
 
 	return 0;
@@ -494,7 +494,7 @@ static int set_top_value(const struct device *dev,
 		}
 	}
 
-	nrf_rtc_int_disable(rtc, NRF_RTC_CHANNEL_INT_MASK(top_ch));
+	nrfy_rtc_int_disable(rtc, NRF_RTC_CHANNEL_INT_MASK(top_ch));
 
 	if (IS_PPI_WRAP(dev)) {
 		if ((dev_data->top == NRF_RTC_COUNTER_MAX) &&
@@ -509,19 +509,19 @@ static int set_top_value(const struct device *dev,
 	dev_data->top_cb = cfg->callback;
 	dev_data->top_user_data = cfg->user_data;
 	dev_data->top = cfg->ticks;
-	nrf_rtc_cc_set(rtc, top_ch, cfg->ticks);
+	nrfy_rtc_cc_set(rtc, top_ch, cfg->ticks);
 
 	if (!(cfg->flags & COUNTER_TOP_CFG_DONT_RESET)) {
-		nrf_rtc_task_trigger(rtc, NRF_RTC_TASK_CLEAR);
+		nrfy_rtc_task_trigger(rtc, NRF_RTC_TASK_CLEAR);
 	} else if (read(dev) >= cfg->ticks) {
 		err = -ETIME;
 		if (cfg->flags & COUNTER_TOP_CFG_RESET_WHEN_LATE) {
-			nrf_rtc_task_trigger(rtc, NRF_RTC_TASK_CLEAR);
+			nrfy_rtc_task_trigger(rtc, NRF_RTC_TASK_CLEAR);
 		}
 	}
 
 	if (cfg->callback || sw_wrap_required(dev)) {
-		nrf_rtc_int_enable(rtc, NRF_RTC_CHANNEL_INT_MASK(top_ch));
+		nrfy_rtc_int_enable(rtc, NRF_RTC_CHANNEL_INT_MASK(top_ch));
 	}
 
 	return err;
@@ -546,9 +546,9 @@ static int init_rtc(const struct device *dev, uint32_t prescaler)
 	z_nrf_clock_control_lf_on(CLOCK_CONTROL_NRF_LF_START_NOWAIT);
 #endif
 
-	nrf_rtc_prescaler_set(rtc, prescaler);
+	nrfy_rtc_prescaler_set(rtc, prescaler);
 
-	NRFX_IRQ_ENABLE(NRFX_IRQ_NUMBER_GET(rtc));
+	NRFY_IRQ_ENABLE(NRFX_IRQ_NUMBER_GET(rtc));
 
 	data->top = NRF_RTC_COUNTER_MAX;
 	err = set_top_value(dev, &top_cfg);
@@ -593,14 +593,14 @@ static void top_irq_handle(const struct device *dev)
 		  NRF_RTC_EVENT_OVERFLOW :
 		  NRF_RTC_CHANNEL_EVENT_ADDR(counter_get_num_of_channels(dev));
 
-	if (nrf_rtc_event_check(rtc, top_evt)) {
-		nrf_rtc_event_clear(rtc, top_evt);
+	uint32_t event_mask = nrfy_rtc_events_process(rtc, NRFY_EVENT_TO_INT_BITMASK(top_evt));
 
+	if (event_mask & NRFY_EVENT_TO_INT_BITMASK(top_evt)) {
 		/* Perform manual clear if custom top value is used and PPI
 		 * clearing is not used.
 		 */
 		if (!IS_FIXED_TOP(dev) && !IS_PPI_WRAP(dev)) {
-			nrf_rtc_task_trigger(rtc, NRF_RTC_TASK_CLEAR);
+			nrfy_rtc_task_trigger(rtc, NRF_RTC_TASK_CLEAR);
 		}
 
 		if (cb) {
@@ -617,24 +617,24 @@ static void alarm_irq_handle(const struct device *dev, uint32_t chan)
 	NRF_RTC_Type *rtc = config->rtc;
 	nrf_rtc_event_t evt = NRF_RTC_CHANNEL_EVENT_ADDR(chan);
 	uint32_t int_mask = NRF_RTC_CHANNEL_INT_MASK(chan);
-	bool hw_irq_pending = nrf_rtc_event_check(rtc, evt) &&
-			      nrf_rtc_int_enable_check(rtc, int_mask);
+
+	bool hw_irq_pending = nrfy_rtc_events_process(rtc, NRFY_EVENT_TO_INT_BITMASK(evt)) &
+			      nrfy_rtc_int_enable_check(rtc, NRFY_EVENT_TO_INT_BITMASK(evt));
 	bool sw_irq_pending = data->ipend_adj & BIT(chan);
 
 	if (hw_irq_pending || sw_irq_pending) {
 		struct counter_nrfx_ch_data *chdata;
 		counter_alarm_callback_t cb;
 
-		nrf_rtc_event_clear(rtc, evt);
 		atomic_and(&data->ipend_adj, ~BIT(chan));
-		nrf_rtc_int_disable(rtc, int_mask);
+		nrfy_rtc_int_disable(rtc, int_mask);
 
 		chdata = &config->ch_data[chan];
 		cb = chdata->callback;
 		chdata->callback = NULL;
 
 		if (cb) {
-			uint32_t cc = nrf_rtc_cc_get(rtc, chan);
+			uint32_t cc = nrfy_rtc_cc_get(rtc, chan);
 
 			if (data->ipend_adj & CC_ADJ_MASK(chan)) {
 				cc = ticks_sub(dev, cc, 1, data->top);


### PR DESCRIPTION
NRFX has introduced HALY software layer which is a superset of HAL
and aggregates some hardware registers manipulations in a single
function calls.

Quote from nrfx changelog:

"HALY is an extension of the HAL layer that aggregates basic hardware
use cases within single functions. Now it is used instead of HAL
in the corresponding drivers."

This commit zephyr's driver to be aligned with the approach used
in nrfx, where drivers has been switched to use HALY instead of HAL.