### PR TITLE
west.yaml: Update LittleFS to version 2.8.1 from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -269,7 +269,7 @@ manifest:
       path: modules/fs/littlefs
       groups:
         - fs
-      revision: ca583fd297ceb48bced3c2548600dc615d67af24
+      revision: 408c16a909dd6cf128874a76f21c793798c9e423
     - name: loramac-node
       revision: 842413c5fb98707eb5f26e619e8e792453877897
       path: modules/lib/loramac-node


### PR DESCRIPTION
The commit shifts sha of Zephyr LittleFS fork to revision that includes merge of tag v2.8.1 from upstream:
https://github.com/littlefs-project/littlefs/releases/tag/v2.8.1

Fixes #65392