### PR TITLE
tests: coredump: Adjust logging backend to xtensa

### DIFF
--- a/boards/xtensa/qemu_xtensa/Kconfig.board
+++ b/boards/xtensa/qemu_xtensa/Kconfig.board
@@ -7,9 +7,11 @@ config BOARD_QEMU_XTENSA
 	bool "Xtensa emulation using QEMU"
 	depends on SOC_XTENSA_DC233C
 	select QEMU_TARGET
+	select ARCH_SUPPORTS_COREDUMP
 
 config BOARD_QEMU_XTENSA_MMU
 	bool "Xtensa emulation using QEMU with MMU"
 	depends on SOC_XTENSA_DC233C
 	select QEMU_TARGET
+	select ARCH_SUPPORTS_COREDUMP
 	select XTENSA_MMU

--- a/tests/subsys/debug/coredump/src/main.c
+++ b/tests/subsys/debug/coredump/src/main.c
@@ -31,6 +31,7 @@ void func_3(uint32_t *addr)
 	defined(CONFIG_BOARD_HIFIVE1) || \
 	defined(CONFIG_BOARD_LONGAN_NANO) || \
 	defined(CONFIG_BOARD_LONGAN_NANO_LITE) || \
+	defined(CONFIG_BOARD_QEMU_XTENSA) || \
 	defined(CONFIG_SOC_FAMILY_INTEL_ADSP)
 	ARG_UNUSED(addr);
 	/* Call k_panic() directly so Renode doesn't pause execution.

--- a/tests/subsys/debug/coredump/testcase.yaml
+++ b/tests/subsys/debug/coredump/testcase.yaml
@@ -31,6 +31,8 @@ tests:
     filter: CONFIG_ARCH_SUPPORTS_COREDUMP
     arch_allow:
       - xtensa
+    integration_platforms:
+      - qemu_xtensa
     harness: console
     harness_config:
       type: multi_line

--- a/tests/subsys/debug/coredump/testcase.yaml
+++ b/tests/subsys/debug/coredump/testcase.yaml
@@ -7,8 +7,30 @@ tests:
     platform_exclude: acrn_ehl_crb
     arch_exclude:
       - posix
+      - xtensa
     integration_platforms:
       - qemu_x86
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - "Coredump: (.*)"
+        - ">>> ZEPHYR FATAL ERROR "
+        - "E: #CD:BEGIN#"
+        - "E: #CD:5([aA])45([0-9a-fA-F]+)"
+        - "E: #CD:41([0-9a-fA-F]+)"
+        - "E: #CD:4([dD])([0-9a-fA-F]+)"
+        - "E: #CD:4([dD])([0-9a-fA-F]+)"
+        - "E: #CD:END#"
+        - "k_sys_fatal_error_handler"
+
+  debug.coredump.logging_backend_xtensa:
+    tags: coredump
+    ignore_faults: true
+    ignore_qemu_crash: true
+    filter: CONFIG_ARCH_SUPPORTS_COREDUMP
+    arch_allow:
+      - xtensa
     harness: console
     harness_config:
       type: multi_line
@@ -20,4 +42,5 @@ tests:
         - "E: #CD:4([dD])([0-9a-fA-F]+)"
         - "E: #CD:4([dD])([0-9a-fA-F]+)"
         - "E: #CD:END#"
+        - ">>> ZEPHYR FATAL ERROR "
         - "k_sys_fatal_error_handler"


### PR DESCRIPTION
* Adjust tests/subsys/debug/coredump logging backend's output matching pattern to Xtensa fatal error handler's different call sequence.
* Enable coredump on qemu_xtensa and qemu_xtensa_mmu.

Follow-up for #65181