### PR TITLE
xtensa: remove unused z_mp_entry declaration

### DIFF
--- a/arch/xtensa/core/crt1.S
+++ b/arch/xtensa/core/crt1.S
@@ -23,7 +23,6 @@
 
 .global __start
 .type	z_cstart, @function
-.type	z_mp_entry, @function
 
 #ifdef CONFIG_XTENSA_MMU
 .type	z_xtensa_mmu_init, @function


### PR DESCRIPTION
z_mp_entry has been removed from Xtensa architecture. So there is no need for a function declaration. Remove it.