### PR TITLE
driver: adc: stm32: support dma for devices without dmamux

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -1521,39 +1521,39 @@ static void adc_stm32_irq_init(void)
 #define ADC_STM32_IRQ_CONFIG(index)
 #define ADC_STM32_IRQ_FUNC(index)					\
 	.irq_cfg_func = adc_stm32_irq_init,
-#define ADC_DMA_CHANNEL(id, dir, DIR, src, dest)
+#define ADC_DMA_CHANNEL(id, src, dest)
 
 #elif defined(CONFIG_ADC_STM32_DMA) /* !CONFIG_ADC_STM32_SHARED_IRQS */
 
-#define ADC_DMA_CHANNEL_INIT(index, name, dir_cap, src_dev, dest_dev)			\
+#define ADC_DMA_CHANNEL_INIT(index, src_dev, dest_dev)					\
 	.dma = {									\
-		.dma_dev = DEVICE_DT_GET(STM32_DMA_CTLR(index, name)),			\
-		.channel = DT_INST_DMAS_CELL_BY_NAME(index, name, channel),		\
+		.dma_dev = DEVICE_DT_GET(DT_INST_DMAS_CTLR_BY_IDX(index, 0)),		\
+		.channel = STM32_DMA_SLOT_BY_IDX(index, 0, channel),			\
 		.dma_cfg = {								\
-			.dma_slot = STM32_DMA_SLOT(index, name, slot),			\
+			.dma_slot = STM32_DMA_SLOT_BY_IDX(index, 0, slot),		\
 			.channel_direction = STM32_DMA_CONFIG_DIRECTION(		\
-				STM32_DMA_CHANNEL_CONFIG(index, name)),			\
+				STM32_DMA_CHANNEL_CONFIG_BY_IDX(index, 0)),		\
 			.source_data_size = STM32_DMA_CONFIG_##src_dev##_DATA_SIZE(	\
-				STM32_DMA_CHANNEL_CONFIG(index, name)),			\
+				STM32_DMA_CHANNEL_CONFIG_BY_IDX(index, 0)),		\
 			.dest_data_size = STM32_DMA_CONFIG_##dest_dev##_DATA_SIZE(	\
-				STM32_DMA_CHANNEL_CONFIG(index, name)),			\
+				STM32_DMA_CHANNEL_CONFIG_BY_IDX(index, 0)),		\
 			.source_burst_length = 1,       /* SINGLE transfer */		\
 			.dest_burst_length = 1,         /* SINGLE transfer */		\
 			.channel_priority = STM32_DMA_CONFIG_PRIORITY(			\
-				STM32_DMA_CHANNEL_CONFIG(index, name)),			\
+				STM32_DMA_CHANNEL_CONFIG_BY_IDX(index, 0)),		\
 			.dma_callback = dma_callback,					\
 			.block_count = 2,						\
 		},									\
 		.src_addr_increment = STM32_DMA_CONFIG_##src_dev##_ADDR_INC(		\
-			STM32_DMA_CHANNEL_CONFIG(index, name)),				\
+			STM32_DMA_CHANNEL_CONFIG_BY_IDX(index, 0)),			\
 		.dst_addr_increment = STM32_DMA_CONFIG_##dest_dev##_ADDR_INC(		\
-			STM32_DMA_CHANNEL_CONFIG(index, name)),				\
+			STM32_DMA_CHANNEL_CONFIG_BY_IDX(index, 0)),			\
 	}
 
-#define ADC_DMA_CHANNEL(id, dir, DIR, src, dest)					\
-	COND_CODE_1(DT_INST_DMAS_HAS_NAME(id, dir),					\
-		    (ADC_DMA_CHANNEL_INIT(id, dir, DIR, src, dest)),			\
-		    (EMPTY))
+#define ADC_DMA_CHANNEL(id, src, dest)							\
+	COND_CODE_1(DT_INST_DMAS_HAS_IDX(id, 0),					\
+			(ADC_DMA_CHANNEL_INIT(id, src, dest)),				\
+			(/* Required for other adc instances without dma */))
 
 #define ADC_STM32_IRQ_CONFIG(index)					\
 static void adc_stm32_cfg_func_##index(void){ EMPTY }
@@ -1572,7 +1572,7 @@ static void adc_stm32_cfg_func_##index(void)				\
 }
 #define ADC_STM32_IRQ_FUNC(index)					\
 	.irq_cfg_func = adc_stm32_cfg_func_##index,
-#define ADC_DMA_CHANNEL(id, dir, DIR, src, dest)
+#define ADC_DMA_CHANNEL(id, src, dest)
 
 #endif /* CONFIG_ADC_STM32_DMA && CONFIG_ADC_STM32_SHARED_IRQS */
 
@@ -1605,7 +1605,7 @@ static struct adc_stm32_data adc_stm32_data_##index = {			\
 	ADC_CONTEXT_INIT_TIMER(adc_stm32_data_##index, ctx),		\
 	ADC_CONTEXT_INIT_LOCK(adc_stm32_data_##index, ctx),		\
 	ADC_CONTEXT_INIT_SYNC(adc_stm32_data_##index, ctx),		\
-	ADC_DMA_CHANNEL(index, dmamux, NULL, PERIPHERAL, MEMORY)	\
+	ADC_DMA_CHANNEL(index, PERIPHERAL, MEMORY)			\
 };									\
 									\
 PM_DEVICE_DT_INST_DEFINE(index, adc_stm32_pm_action);			\

--- a/include/zephyr/drivers/dma/dma_stm32.h
+++ b/include/zephyr/drivers/dma/dma_stm32.h
@@ -33,8 +33,10 @@
 /* macro for dma slot (only for dma-v1 or dma-v2 types) */
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_dma_v2bis)
 #define STM32_DMA_SLOT(id, dir, slot) 0
+#define STM32_DMA_SLOT_BY_IDX(id, idx, slot)
 #else
 #define STM32_DMA_SLOT(id, dir, slot) DT_INST_DMAS_CELL_BY_NAME(id, dir, slot)
+#define STM32_DMA_SLOT_BY_IDX(id, idx, slot) DT_INST_DMAS_CELL_BY_IDX(id, idx, slot)
 #endif
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_dma_v2) || \
@@ -50,6 +52,8 @@
 		DT_INST_DMAS_CTLR_BY_NAME(id, dir)
 #define STM32_DMA_CHANNEL_CONFIG(id, dir)					\
 		DT_INST_DMAS_CELL_BY_NAME(id, dir, channel_config)
+#define STM32_DMA_CHANNEL_CONFIG_BY_IDX(id, idx)				\
+		DT_INST_DMAS_CELL_BY_IDX(id, idx, channel_config)
 
 /* macros for channel-config */
 /* direction defined on bits 6-7 */

--- a/tests/drivers/adc/adc_dma/boards/nucleo_l476rg.conf
+++ b/tests/drivers/adc/adc_dma/boards/nucleo_l476rg.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2023 Hein Wessels, Nobleo Technology
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_ADC_STM32_DMA=y
+CONFIG_ADC_ASYNC=y

--- a/tests/drivers/adc/adc_dma/boards/nucleo_l476rg.overlay
+++ b/tests/drivers/adc/adc_dma/boards/nucleo_l476rg.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2023 Hein Wessels, Nobleo Technology
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&adc1 {
+	dmas = < &dma1 1 0 (STM32_DMA_PERIPH_RX |  STM32_DMA_MEM_16BITS | STM32_DMA_PERIPH_16BITS) >;
+	dma-names = "dma";
+
+	#address-cells = <1>;
+	#size-cells = <0>;
+};
+
+test_dma: &dma1 {
+    status = "okay";
+};

--- a/tests/drivers/adc/adc_dma/src/test_adc.c
+++ b/tests/drivers/adc/adc_dma/src/test_adc.c
@@ -61,6 +61,17 @@
 #define ADC_2ND_CHANNEL_ID 7
 #define ALIGNMENT 32
 
+#elif defined(CONFIG_BOARD_NUCLEO_L476RG)
+
+#define ADC_DEVICE_NODE DT_INST(0, st_stm32_adc)
+#define ADC_RESOLUTION 12
+#define ADC_GAIN ADC_GAIN_1
+#define ADC_REFERENCE ADC_REF_INTERNAL
+#define ADC_ACQUISITION_TIME ADC_ACQ_TIME_DEFAULT
+#define ADC_1ST_CHANNEL_ID 1
+#define ADC_2ND_CHANNEL_ID 7
+#define ALIGNMENT 32
+
 #endif
 
 /* Invalid value that is not supposed to be written by the driver. It is used


### PR DESCRIPTION
Previously the STM32 DMA driver was dependent on a very specific
name for the DMA in the DTS. This hidden requirement has caused
a bit of confusion. This commit changes the driver to instead
always use the first DMA listed in the ADC node's dma property.

Also, updates the dma code in the ADC driver to support the STM32L4 (and likely more other mcus)

Fixes: #65387