### PR TITLE
soc: arm: nxp_imx: rt11xx: add support for CONFIG_ETH_MCUX_RMII_EXT_CLK

### DIFF
--- a/boards/arm/vmu_rt1170/vmu_rt1170-pinctrl.dtsi
+++ b/boards/arm/vmu_rt1170/vmu_rt1170-pinctrl.dtsi
@@ -38,8 +38,9 @@
 		group3 {
 			pinmux = <&iomuxc_gpio_disp_b1_11_enet_1g_ref_clk1>;
 			drive-strength = "high";
-			slew-rate = "slow";
+			slew-rate = "fast";
 			input-enable;
+			bias-pull-down;
 		};
 	};
 

--- a/soc/arm/nxp_imx/rt/soc_rt11xx.c
+++ b/soc/arm/nxp_imx/rt/soc_rt11xx.c
@@ -402,9 +402,15 @@ static ALWAYS_INLINE void clock_init(void)
 	rootCfg.mux = kCLOCK_ENET1_ClockRoot_MuxSysPll1Div2;
 	rootCfg.div = 10;
 	CLOCK_SetRootClock(kCLOCK_Root_Enet1, &rootCfg);
+#if CONFIG_ETH_MCUX_RMII_EXT_CLK
+	/* Set ENET_REF_CLK as an input driven by PHY */
+	IOMUXC_GPR->GPR4 &= ~IOMUXC_GPR_GPR4_ENET_REF_CLK_DIR(0x01U);
+	IOMUXC_GPR->GPR4 |= IOMUXC_GPR_GPR4_ENET_TX_CLK_SEL(0x1U);
+#else
 	/* Set ENET_REF_CLK as an output driven by ENET1_CLK_ROOT */
 	IOMUXC_GPR->GPR4 |= (IOMUXC_GPR_GPR4_ENET_REF_CLK_DIR(0x01U) |
 		IOMUXC_GPR_GPR4_ENET_TX_CLK_SEL(0x1U));
+#endif
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(enet1g), okay)
 	/*
@@ -414,9 +420,15 @@ static ALWAYS_INLINE void clock_init(void)
 	rootCfg.mux = kCLOCK_ENET2_ClockRoot_MuxSysPll1Div2;
 	rootCfg.div = 10;
 	CLOCK_SetRootClock(kCLOCK_Root_Enet2, &rootCfg);
+#if CONFIG_ETH_MCUX_RMII_EXT_CLK
+	/* Set ENET1G_REF_CLK as an input driven by PHY */
+	IOMUXC_GPR->GPR5 &= ~IOMUXC_GPR_GPR5_ENET1G_REF_CLK_DIR(0x01U);
+	IOMUXC_GPR->GPR5 |= IOMUXC_GPR_GPR5_ENET1G_TX_CLK_SEL(0x1U);
+#else
 	/* Set ENET1G_REF_CLK as an output driven by ENET2_CLK_ROOT */
 	IOMUXC_GPR->GPR5 |= (IOMUXC_GPR_GPR5_ENET1G_REF_CLK_DIR(0x01U) |
 		IOMUXC_GPR_GPR5_ENET1G_TX_CLK_SEL(0x1U));
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
For boards with a PHY that's provides the ENET_REF_CLK 50Mhz clock.
Add support CONFIG_ETH_MCUX_RMII_EXT_CLK by setting ENET_REF_CLK as an input during rt11xx clock initialization.