### PR TITLE
compiler/gcc: _FORTIFY_SOURCE=1 doesn't mean compile-time only checks

### DIFF
--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -169,9 +169,11 @@ endif()
 
 if(NOT CONFIG_NO_OPTIMIZATIONS)
   # _FORTIFY_SOURCE: Detect common-case buffer overflows for certain functions
-  # _FORTIFY_SOURCE=1 : Compile-time checks (requires -O1 at least)
-  # _FORTIFY_SOURCE=2 : Additional lightweight run-time checks
-  set_compiler_property(PROPERTY security_fortify_compile_time _FORTIFY_SOURCE=1)
+  # _FORTIFY_SOURCE=1 : Loose checking (use wide bounds checks)
+  # _FORTIFY_SOURCE=2 : Tight checking (use narrow bounds checks)
+  # GCC always does compile-time bounds checking for string/mem functions, so
+  # there's no additional value to set here
+  set_compiler_property(PROPERTY security_fortify_compile_time)
   set_compiler_property(PROPERTY security_fortify_run_time _FORTIFY_SOURCE=2)
 endif()
 

--- a/scripts/footprint/fpdiff.py
+++ b/scripts/footprint/fpdiff.py
@@ -15,7 +15,7 @@
 #    ./scripts/footprint/fpdiff.py ram1.json ram2.json
 
 from anytree.importer import DictImporter
-from anytree import PreOrderIter
+from anytree import PreOrderIter, AnyNode
 from anytree.search  import find
 
 import colorama
@@ -46,7 +46,10 @@ def main():
 
     for idx, ch in enumerate(data1['symbols']['children']):
         root1 = importer.import_(ch)
-        root2 = importer.import_(data2['symbols']['children'][idx])
+        if idx >= len(data2['symbols']['children']):
+            root2 = AnyNode(identifier=None)
+        else:
+            root2 = importer.import_(data2['symbols']['children'][idx])
         print(f"{root1.name}\n+++++++++++++++++++++")
 
         for node in PreOrderIter(root1):


### PR DESCRIPTION
_FORTIFY_SOURCE=1 differs from _FORTIFY_SOURCE=2 only in the bounds checking mode that it uses.

With _FORTIFY_SOURCE=1, bounds checks are 'loose', allowing access to the whole underlying object, not just the subset referenced in the expression (e.g, the bounds of a struct member is the whole struct, not just the member).

With _FORTIFY_SOURCE=2, bounds checks are strict, meaning that the bounds of an expression are limited to the referenced value.

Both of these perform their checks at runtime, calling _chk_fail if the bounds check fails. That's done in the __*_chk functions included in the C library. These are always called when _FORTIFY_SOURCE > 0, unless the compiler replaces the call with inline code.

GCC already does all of the compile-time bounds checking for string and mem functions when not using -ffreestanding, so there's nothing we need to add for that to work. That means the security_fortify_compile_time property should be empty.