### PR TITLE
drivers: wifi: airoc: drop default shell and sysworkq stack sizes

### DIFF
--- a/drivers/wifi/infineon/Kconfig.airoc
+++ b/drivers/wifi/infineon/Kconfig.airoc
@@ -17,14 +17,6 @@ menuconfig WIFI_AIROC
 
 if WIFI_AIROC
 
-if SHELL
-config SHELL_STACK_SIZE
-	default 4096
-endif # SHELL
-
-config SYSTEM_WORKQUEUE_STACK_SIZE
-	default 4096
-
 config AIROC_WIFI_EVENT_TASK_STACK_SIZE
 	int "Event Task Stack Size"
 	default 4096


### PR DESCRIPTION
Those configuration settings should never be part of driver Kconfig file.
Drop them, since they can easily result in Kconfig symbol circular
dependency error.