### PR TITLE
drivers: adc: tla2021: Raise default initialization priority

### DIFF
--- a/drivers/adc/Kconfig.tla2021
+++ b/drivers/adc/Kconfig.tla2021
@@ -13,7 +13,7 @@ if ADC_TLA2021
 
 config ADC_TLA2021_INIT_PRIORITY
 	int "Priority for the driver initialization"
-	default ADC_INIT_PRIORITY
+	default 80
 	help
 	  Fine tune the priority for the driver initialization. Make sure it's
 	  higher (-> lower priority) than I2C_INIT_PRIORITY.


### PR DESCRIPTION
The TLA2021 driver depends on it's i2c controller and therefore needs to be initialized later. ADC_INIT_PRIORITY by default equals KERNEL_INIT_PRIORITY_DEVICE which should be used by independent devices. Using this by default causing projects to fail where this driver is enabled implicitly through board configuration and the priority is not explicitly set.