### PR TITLE
MAINTAINERS/CODEOWNERS: add Nuvoton collaborators and update NPCX boards' folders

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2499,8 +2499,8 @@ Nuvoton NPCX Platforms:
     - MulinChao
     - ChiHuaL
   collaborators:
-    - MulinChao
-    - ChiHuaL
+    - TomChang19
+    - alvsun
     - sjg20
     - keith-zephyr
     - jackrosenthal


### PR DESCRIPTION
Add Nuvoton guys, TomChang19 and alvsun, to collaborators of Nuvoton NPCX Platforms and update NPCX boards' folders.