### PR TITLE
native boards: Annotate posix_exit() & nsi_exit() as noreturn

### DIFF
--- a/arch/posix/core/nsi_compat/nsi_compat.c
+++ b/arch/posix/core/nsi_compat/nsi_compat.c
@@ -13,6 +13,8 @@
  */
 
 #include <zephyr/arch/posix/posix_trace.h>
+#include <zephyr/toolchain.h>
+#include "posix_board_if.h"
 
 void nsi_print_error_and_exit(const char *format, ...)
 {
@@ -41,9 +43,8 @@ void nsi_print_trace(const char *format, ...)
 	va_end(variable_args);
 }
 
-void nsi_exit(int exit_code)
+FUNC_NORETURN void nsi_exit(int exit_code)
 {
-	extern void posix_exit(int exit_code);
-
 	posix_exit(exit_code);
+	CODE_UNREACHABLE;
 }

--- a/scripts/native_simulator/common/src/include/nsi_main.h
+++ b/scripts/native_simulator/common/src/include/nsi_main.h
@@ -7,6 +7,8 @@
 #ifndef NSI_COMMON_SRC_INCL_NSI_MAIN_H
 #define NSI_COMMON_SRC_INCL_NSI_MAIN_H
 
+#include "nsi_utils.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -31,7 +33,7 @@ int nsi_exit_inner(int exit_code);
  *            Note that other components may have requested a different
  *            exit code which may have precedence if it was !=0
  */
-void nsi_exit(int exit_code);
+NSI_FUNC_NORETURN void nsi_exit(int exit_code);
 
 #ifdef __cplusplus
 }

--- a/scripts/native_simulator/common/src/include/nsi_utils.h
+++ b/scripts/native_simulator/common/src/include/nsi_utils.h
@@ -25,4 +25,8 @@
 #define NSI_ARG_UNUSED(x) (void)(x)
 #endif
 
+#define NSI_CODE_UNREACHABLE __builtin_unreachable()
+
+#define NSI_FUNC_NORETURN __attribute__((__noreturn__))
+
 #endif /* NSI_COMMON_SRC_INCL_NSI_UTILS_H */

--- a/scripts/native_simulator/common/src/main.c
+++ b/scripts/native_simulator/common/src/main.c
@@ -44,7 +44,7 @@ int nsi_exit_inner(int exit_code)
 	return max_exit_code;
 }
 
-void nsi_exit(int exit_code)
+NSI_FUNC_NORETURN void nsi_exit(int exit_code)
 {
 	exit(nsi_exit_inner(exit_code));
 }

--- a/soc/posix/inf_clock/posix_board_if.h
+++ b/soc/posix/inf_clock/posix_board_if.h
@@ -7,6 +7,7 @@
 #define _POSIX_CORE_BOARD_PROVIDED_IF_H
 
 #include <zephyr/types.h>
+#include <zephyr/toolchain.h>
 
 /*
  * This file lists the functions the posix "inf_clock" soc
@@ -22,7 +23,7 @@ extern "C" {
 #endif
 
 void posix_irq_handler(void);
-void posix_exit(int exit_code);
+FUNC_NORETURN void posix_exit(int exit_code);
 uint64_t posix_get_hw_cycle(void);
 void posix_cpu_hold(uint32_t usec_to_waste);
 


### PR DESCRIPTION
Annotate posix_exit() and nsi_exit() as noreturn
mainly to ease the life of static analysis tools.
