### PR TITLE
AArch32-R SMP fixes

### DIFF
--- a/arch/arm/core/cortex_a_r/reset.S
+++ b/arch/arm/core/cortex_a_r/reset.S
@@ -203,12 +203,14 @@ EL1_Reset_Handler:
 #if CONFIG_MP_MAX_NUM_CPUS > 1
     get_cpu_id r1
 
+2:
     ldrex r2, [r0, #BOOT_PARAM_MPID_OFFSET]
     cmp r2, #-1
     bne 1f
     strex r3, r1, [r0, #BOOT_PARAM_MPID_OFFSET]
     cmp r3, #0
     beq _primary_core
+    b 2b
 
 1:
     dmb ld

--- a/arch/arm/core/cortex_a_r/smp.c
+++ b/arch/arm/core/cortex_a_r/smp.c
@@ -223,7 +223,7 @@ static void broadcast_ipi(unsigned int ipi)
 		uint32_t target_mpidr = cpu_map[i];
 		uint8_t aff0;
 
-		if (mpidr == target_mpidr || mpidr == INV_MPID) {
+		if (mpidr == target_mpidr || target_mpidr == INV_MPID) {
 			continue;
 		}
 


### PR DESCRIPTION
Fix two potential issues noticed while bringing up multi-core Cortex-R52 virtual machine models with Zephyr.

1) Exclusive monitor getting cleared on first pass through LDREX/STREX pair on first CPU would result in no boot CPU being elected, all CPUs making themselves secondary, and no forward progress. This can happen under some debug conditions, as well as when Zephyr runs only on a subset of cores in a shareability domain, and possibly in other cases.

2) IPIs were being sent to invalid MPIDR 0xFFFFFFFF by accident. This had no negative effect but was visible in I/O trace logs. The explicit check for invalid MPIDR was checking the wrong variable.