### PR TITLE
net: mqtt-sn: Improve support for wildcard subscriptions

### DIFF
--- a/include/zephyr/net/mqtt_sn.h
+++ b/include/zephyr/net/mqtt_sn.h
@@ -397,6 +397,19 @@ int mqtt_sn_publish(struct mqtt_sn_client *client, enum mqtt_sn_qos qos,
  */
 int mqtt_sn_input(struct mqtt_sn_client *client);
 
+/**
+ * @brief Get topic name by topic ID.
+ *
+ * @param[in] client The MQTT-SN client that uses this topic.
+ * @param[in] id Topic identifier.
+ * @param[out] topic_name Will be assigned to topic name.
+ *
+ * @return 0 on success, -ENOENT if topic ID doesn't exist,
+ * or -EINVAL on invalid arguments.
+ */
+int mqtt_sn_get_topic_name(struct mqtt_sn_client *client, uint16_t id,
+			   struct mqtt_sn_data *topic_name);
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/net/lib/mqtt_sn/mqtt_sn.c
+++ b/subsys/net/lib/mqtt_sn/mqtt_sn.c
@@ -949,6 +949,8 @@ static void handle_register(struct mqtt_sn_client *client, struct mqtt_sn_param_
 	topic->topic_id = p->topic_id;
 	topic->type = MQTT_SN_TOPIC_TYPE_NORMAL;
 
+	sys_slist_append(&client->topic, &topic->next);
+
 	response.params.regack.ret_code = MQTT_SN_CODE_ACCEPTED;
 	response.params.regack.topic_id = p->topic_id;
 	response.params.regack.msg_id = p->msg_id;

--- a/subsys/net/lib/mqtt_sn/mqtt_sn.c
+++ b/subsys/net/lib/mqtt_sn/mqtt_sn.c
@@ -1224,3 +1224,22 @@ int mqtt_sn_input(struct mqtt_sn_client *client)
 	/* Should be zero */
 	return -client->rx.len;
 }
+
+int mqtt_sn_get_topic_name(struct mqtt_sn_client *client, uint16_t id,
+			   struct mqtt_sn_data *topic_name)
+{
+	struct mqtt_sn_topic *topic;
+
+	if (!client || !topic_name) {
+		return -EINVAL;
+	}
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&client->topic, topic, next) {
+		if (topic->topic_id == id) {
+			topic_name->data = (const uint8_t *)topic->name;
+			topic_name->size = topic->namelen;
+			return 0;
+		}
+	}
+	return -ENOENT;
+}


### PR DESCRIPTION
Currently MQTT-SN library supports wildcard subscriptions, but the user cannot get the string topic name from the library for the incoming published message. The user only knows topic ID of the incoming message.

- Add a function to MQTT-SN library API to get topic name by topic ID from the internal topics list.

- Fix handling incoming REGISTER messages:
When a client uses wildcard subscription and a new message is
published to the matching topic for the first time, the gateway
sends REGISTER message to the client, containing the exact
topic name and a new topic ID.
This change fixes adding these topic ID and name to the internal
topics list.