### PR TITLE
Lwm2m interoperability tests

### DIFF
--- a/tests/net/lib/lwm2m/interop/README.md
+++ b/tests/net/lib/lwm2m/interop/README.md
@@ -172,9 +172,9 @@ Tests are written from test spec;
 |LightweightM2M-1.1-int-281 - Partially Successful Read-Composite Operation|:white_check_mark:| |
 |LightweightM2M-1.1-int-301 - Observation and Notification of parameter values|:white_check_mark:| |
 |LightweightM2M-1.1-int-302 - Cancel Observations using Reset Operation|:white_check_mark:| |
-|LightweightM2M-1.1-int-303 - Cancel observations using Observe with Cancel parameter|:large_orange_diamond:|Leshan only supports passive cancelling|
+|LightweightM2M-1.1-int-303 - Cancel observations using Observe with Cancel parameter|:white_check_mark:||
 |LightweightM2M-1.1-int-304 - Observe-Composite Operation|:white_check_mark:| |
-|LightweightM2M-1.1-int-305 - Cancel Observation-Composite Operation|:large_orange_diamond:|Leshan only supports passive cancelling|
+|LightweightM2M-1.1-int-305 - Cancel Observation-Composite Operation|:white_check_mark:| |
 |LightweightM2M-1.1-int-306 – Send Operation|:white_check_mark:|[~~#64290~~](https://github.com/zephyrproject-rtos/zephyr/issues/64290)|
 |LightweightM2M-1.1-int-307 – Muting Send|:white_check_mark:| |
 |LightweightM2M-1.1-int-308 - Observe-Composite and Creating Object Instance|:white_check_mark:|[~~#64634~~](https://github.com/zephyrproject-rtos/zephyr/issues/64634)|

--- a/tests/net/lib/lwm2m/interop/README.md
+++ b/tests/net/lib/lwm2m/interop/README.md
@@ -167,7 +167,7 @@ Tests are written from test spec;
 |LightweightM2M-1.1-int-256 - Write Operation Failure|:white_check_mark:| |
 |LightweightM2M-1.1-int-257 - Write-Composite Operation|:white_check_mark:| |
 |LightweightM2M-1.1-int-260 - Discover Command|:white_check_mark:| |
-|LightweightM2M-1.1-int-261 - Write-Attribute Operation on a multiple resource|:large_orange_diamond:|Leshan don't allow writing attributes to resource instance|
+|LightweightM2M-1.1-int-261 - Write-Attribute Operation on a multiple resource|:white_check_mark:| |
 |LightweightM2M-1.1-int-280 - Successful Read-Composite Operation|:white_check_mark:| |
 |LightweightM2M-1.1-int-281 - Partially Successful Read-Composite Operation|:white_check_mark:| |
 |LightweightM2M-1.1-int-301 - Observation and Notification of parameter values|:white_check_mark:| |

--- a/tests/net/lib/lwm2m/interop/README.md
+++ b/tests/net/lib/lwm2m/interop/README.md
@@ -160,7 +160,7 @@ Tests are written from test spec;
 |LightweightM2M-1.1-int-232 - Querying basic information in SenML CBOR format|:white_check_mark:| |
 |LightweightM2M-1.1-int-233 - Setting basic information in SenML CBOR format|:white_check_mark:| |
 |LightweightM2M-1.1-int-234 - Setting basic information in SenML JSON format|:white_check_mark:| |
-|LightweightM2M-1.1-int-235 - Read-Composite Operation on root path|:large_orange_diamond:|Root Path is not yet supported by Leshan.|
+|LightweightM2M-1.1-int-235 - Read-Composite Operation on root path|:white_check_mark:| |
 |LightweightM2M-1.1-int-236 - Read-Composite - Partial Presence|:white_check_mark:| |
 |LightweightM2M-1.1-int-237 - Read on Object without specifying Content-Type|:white_check_mark:| |
 |LightweightM2M-1.1-int-241 - Executable Resource: Rebooting the device|:white_check_mark:| |

--- a/tests/net/lib/lwm2m/interop/pytest/leshan.py
+++ b/tests/net/lib/lwm2m/interop/pytest/leshan.py
@@ -389,6 +389,9 @@ class Leshan:
         return self.post(f'/clients/{endpoint}/{path}/observe', data="")
 
     def cancel_observe(self, endpoint: str, path: str):
+        return self.delete_raw(f'/clients/{endpoint}/{path}/observe?active')
+
+    def passive_cancel_observe(self, endpoint: str, path: str):
         return self.delete_raw(f'/clients/{endpoint}/{path}/observe')
 
     def composite_observe(self, endpoint: str, paths: list[str]):
@@ -398,6 +401,10 @@ class Leshan:
         return self.parse_composite(payload)
 
     def cancel_composite_observe(self, endpoint: str, paths: list[str]):
+        paths = [path if path.startswith('/') else '/' + path for path in paths]
+        return self.delete_raw(f'/clients/{endpoint}/composite/observe?paths=' + ','.join(paths) + '&active')
+
+    def passive_cancel_composite_observe(self, endpoint: str, paths: list[str]):
         paths = [path if path.startswith('/') else '/' + path for path in paths]
         return self.delete_raw(f'/clients/{endpoint}/composite/observe?paths=' + ','.join(paths))
 

--- a/tests/net/lib/lwm2m/interop/pytest/leshan.py
+++ b/tests/net/lib/lwm2m/interop/pytest/leshan.py
@@ -62,9 +62,9 @@ class Leshan:
         resp = self._s.get(f'{self.api_url}{path}', params=params, timeout=self.timeout)
         return Leshan.handle_response(resp)
 
-    def put_raw(self, path: str, data: str | dict | None = None, headers: dict | None = None):
+    def put_raw(self, path: str, data: str | dict | None = None, headers: dict | None = None, params: dict | None = None):
         """Send HTTP PUT query without any default parameters"""
-        resp = self._s.put(f'{self.api_url}{path}', data=data, headers=headers, timeout=self.timeout)
+        resp = self._s.put(f'{self.api_url}{path}', data=data, headers=headers, params=params, timeout=self.timeout)
         return Leshan.handle_response(resp)
 
     def put(self, path: str, data: str | dict, uri_options: str = ''):
@@ -107,6 +107,21 @@ class Leshan:
             kind = 'resourceInstance'
         rid = path.split('/')[-1]
         return self.put(f'/clients/{endpoint}/{path}', self._define_resource(rid, value, kind))
+
+    def write_attributes(self, endpoint: str, path: str, attributes: dict):
+        """Send LwM2M Write-Attributes to given path
+            example:
+                leshan.write_attributes(endpoint, '1/2/3, {'pmin': 10, 'pmax': 40})
+        """
+        return self.put_raw(f'/clients/{endpoint}/{path}/attributes', params=attributes)
+
+    def remove_attributes(self, endpoint: str, path: str, attributes: list):
+        """Send LwM2M Write-Attributes to given path
+            example:
+                leshan.remove_attributes(endpoint, '1/2/3, ['pmin', 'pmax'])
+        """
+        attrs = '&'.join(attributes)
+        return self.put_raw(f'/clients/{endpoint}/{path}/attributes?'+ attrs)
 
     def update_obj_instance(self, endpoint: str, path: str, resources: dict):
         """Update object instance"""

--- a/tests/net/lib/lwm2m/interop/pytest/leshan.py
+++ b/tests/net/lib/lwm2m/interop/pytest/leshan.py
@@ -271,6 +271,10 @@ class Leshan:
                 raise RuntimeError(f'No content received')
             payload = payload['content']
         for path, content in payload.items():
+            if path == "/":
+                for obj in content['objects']:
+                    data.update(cls._decode_obj(obj))
+                continue
             keys = [int(key) for key in path.lstrip("/").split('/')]
             if len(keys) == 1:
                 data.update(cls._decode_obj(content))

--- a/tests/net/lib/lwm2m/interop/pytest/pytest.ini
+++ b/tests/net/lib/lwm2m/interop/pytest/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')

--- a/tests/net/lib/lwm2m/interop/pytest/test_lwm2m.py
+++ b/tests/net/lib/lwm2m/interop/pytest/test_lwm2m.py
@@ -367,9 +367,12 @@ def test_LightweightM2M_1_1_int_234(shell: Shell, leshan: Leshan, endpoint: str)
     """LightweightM2M-1.1-int-234 - Setting basic information in SenML JSON format"""
     setting_basic_senml(shell, leshan, endpoint, 'SENML_JSON')
 
-@pytest.mark.skip("Leshan does not allow reading root path")
-def test_LightweightM2M_1_1_int_235():
+def test_LightweightM2M_1_1_int_235(leshan: Leshan, endpoint: str):
     """LightweightM2M-1.1-int-235 - Read-Composite Operation on root path"""
+    resp = leshan.composite_read(endpoint, ['/'])
+    expected_keys = [16, 1, 3, 5]
+    missing_keys = [key for key in expected_keys if key not in resp.keys()]
+    assert len(missing_keys) == 0
 
 def test_LightweightM2M_1_1_int_236(shell: Shell, leshan: Leshan, endpoint: str):
     """LightweightM2M-1.1-int-236 - Read-Composite - Partial Presence"""

--- a/tests/net/lib/lwm2m/interop/pytest/test_lwm2m.py
+++ b/tests/net/lib/lwm2m/interop/pytest/test_lwm2m.py
@@ -532,7 +532,6 @@ def test_LightweightM2M_1_1_int_301(shell: Shell, leshan: Leshan, endpoint: str)
     leshan.cancel_observe(endpoint, '3/0/7')
     leshan.remove_attributes(endpoint, '3/0/7', ['pmin', 'pmax'])
 
-@pytest.mark.slow
 def test_LightweightM2M_1_1_int_302(shell: Shell, dut: DeviceAdapter, leshan: Leshan, endpoint: str):
     """LightweightM2M-1.1-int-302 - Cancel Observations using Reset Operation"""
     leshan.observe(endpoint, '3/0/7')
@@ -541,15 +540,32 @@ def test_LightweightM2M_1_1_int_302(shell: Shell, dut: DeviceAdapter, leshan: Le
         shell.exec_command('lwm2m write /3/0/7/0 -u32 4000')
         data =  events.next_event('NOTIFICATION')
         assert data[3][0][7][0] == 4000
-    leshan.cancel_observe(endpoint, '3/0/7')
+    leshan.passive_cancel_observe(endpoint, '3/0/7')
     shell.exec_command('lwm2m write /3/0/7/0 -u32 3000')
     dut.readlines_until(regex=r'.*Observer removed for 3/0/7')
     with leshan.get_event_stream(endpoint) as events:
         shell.exec_command('lwm2m write /3/0/8/0 -u32 100')
         data =  events.next_event('NOTIFICATION')
         assert data[3][0][8][0] == 100
-    leshan.cancel_observe(endpoint, '3/0/8')
+    leshan.passive_cancel_observe(endpoint, '3/0/8')
     shell.exec_command('lwm2m write /3/0/8/0 -u32 50')
+    dut.readlines_until(regex=r'.*Observer removed for 3/0/8')
+
+def test_LightweightM2M_1_1_int_303(shell: Shell, dut: DeviceAdapter, leshan: Leshan, endpoint: str):
+    """LightweightM2M-1.1-int-303 - Cancel observations using Observe with Cancel parameter"""
+    leshan.observe(endpoint, '3/0/7')
+    leshan.observe(endpoint, '3/0/8')
+    with leshan.get_event_stream(endpoint) as events:
+        shell.exec_command('lwm2m write /3/0/7/0 -u32 4000')
+        data =  events.next_event('NOTIFICATION')
+        assert data[3][0][7][0] == 4000
+    leshan.cancel_observe(endpoint, '3/0/7')
+    dut.readlines_until(regex=r'.*Observer removed for 3/0/7')
+    with leshan.get_event_stream(endpoint) as events:
+        shell.exec_command('lwm2m write /3/0/8/0 -u32 100')
+        data =  events.next_event('NOTIFICATION')
+        assert data[3][0][8][0] == 100
+    leshan.cancel_observe(endpoint, '3/0/8')
     dut.readlines_until(regex=r'.*Observer removed for 3/0/8')
 
 @pytest.mark.slow
@@ -583,6 +599,14 @@ def test_LightweightM2M_1_1_int_304(shell: Shell, leshan: Leshan, endpoint: str)
     shell.exec_command('lwm2m write 1/0/2 -u32 1')
     shell.exec_command('lwm2m write 1/0/3 -u32 10')
     leshan.remove_attributes(endpoint, '1/0/1', ['pmin', 'pmax'])
+
+def test_LightweightM2M_1_1_int_305(dut: DeviceAdapter, leshan: Leshan, endpoint: str):
+    """LightweightM2M-1.1-int-305 - Cancel Observation-Composite Operation"""
+    leshan.composite_observe(endpoint, ['/1/0/1', '/3/0/11/0', '/3/0/16'])
+    leshan.cancel_composite_observe(endpoint, ['/1/0/1', '/3/0/11/0', '/3/0/16'])
+    dut.readlines_until(regex=r'.*Observer removed for 1/0/1')
+    dut.readlines_until(regex=r'.*Observer removed for 3/0/11/0')
+    dut.readlines_until(regex=r'.*Observer removed for 3/0/16')
 
 def test_LightweightM2M_1_1_int_306(shell: Shell, dut: DeviceAdapter, leshan: Leshan, endpoint: str):
     """LightweightM2M-1.1-int-306 - Send Operation"""

--- a/tests/net/lib/lwm2m/interop/pytest/test_lwm2m.py
+++ b/tests/net/lib/lwm2m/interop/pytest/test_lwm2m.py
@@ -51,6 +51,7 @@ def test_LightweightM2M_1_1_int_104(shell: Shell, dut: DeviceAdapter, leshan: Le
     leshan.execute(endpoint, '1/0/8')
     dut.readlines_until(regex='.*net_lwm2m_rd_client: Update Done', timeout=5.0)
 
+@pytest.mark.slow
 def test_LightweightM2M_1_1_int_107(shell: Shell, dut: DeviceAdapter, leshan: Leshan, endpoint: str):
     """LightweightM2M-1.1-int-107 - Extending the lifetime of a registration"""
     leshan.write(endpoint, '1/0/1', 120)
@@ -66,6 +67,7 @@ def test_LightweightM2M_1_1_int_108(leshan, endpoint):
     """LightweightM2M-1.1-int-108 - Turn on Queue Mode"""
     assert leshan.get(f'/clients/{endpoint}')["queuemode"]
 
+@pytest.mark.slow
 def test_LightweightM2M_1_1_int_109(shell: Shell, dut: DeviceAdapter, leshan: Leshan, endpoint: str):
     """LightweightM2M-1.1-int-109 - Behavior in Queue Mode"""
     logger.debug('Wait for Queue RX OFF')
@@ -500,6 +502,7 @@ def test_LightweightM2M_1_1_int_281(shell: Shell, leshan: Leshan, endpoint: str)
 # Information Reporting Interface [300-399]
 #
 
+@pytest.mark.slow
 def test_LightweightM2M_1_1_int_301(shell: Shell, leshan: Leshan, endpoint: str):
     """LightweightM2M-1.1-int-301 - Observation and Notification of parameter values"""
     pwr_src = leshan.read(endpoint, '3/0/6')
@@ -527,6 +530,7 @@ def test_LightweightM2M_1_1_int_301(shell: Shell, leshan: Leshan, endpoint: str)
         assert (start + 15) <= time.time() + 1 # Allow 1 second slack. (pMinx + pMax=15)
     leshan.cancel_observe(endpoint, '3/0/7')
 
+@pytest.mark.slow
 def test_LightweightM2M_1_1_int_302(shell: Shell, dut: DeviceAdapter, leshan: Leshan, endpoint: str):
     """LightweightM2M-1.1-int-302 - Cancel Observations using Reset Operation"""
     leshan.observe(endpoint, '3/0/7')
@@ -546,6 +550,7 @@ def test_LightweightM2M_1_1_int_302(shell: Shell, dut: DeviceAdapter, leshan: Le
     shell.exec_command('lwm2m write /3/0/8/0 -u32 50')
     dut.readlines_until(regex=r'.*Observer removed for 3/0/8')
 
+@pytest.mark.slow
 def test_LightweightM2M_1_1_int_304(shell: Shell, leshan: Leshan, endpoint: str):
     """LightweightM2M-1.1-int-304 - Observe-Composite Operation"""
     assert leshan.put_raw(f'/clients/{endpoint}/1/0/1/attributes?pmin=30')['status'] == 'CHANGED(204)'
@@ -590,6 +595,8 @@ def test_LightweightM2M_1_1_int_307(shell: Shell, dut: DeviceAdapter, leshan: Le
     shell.exec_command('lwm2m send /3/0')
     dut.readlines_until(regex=r'.*SEND status: 0', timeout=5.0)
 
+
+@pytest.mark.slow
 def test_LightweightM2M_1_1_int_308(shell: Shell, dut: DeviceAdapter, leshan: Leshan, endpoint: str):
     """LightweightM2M-1.1-int-308 - Observe-Composite and Creating Object Instance"""
     shell.exec_command('lwm2m delete /16/0')
@@ -631,6 +638,7 @@ def test_LightweightM2M_1_1_int_308(shell: Shell, dut: DeviceAdapter, leshan: Le
     shell.exec_command('lwm2m write 1/0/2 -u32 1')
     shell.exec_command('lwm2m write 1/0/3 -u32 10')
 
+@pytest.mark.slow
 def test_LightweightM2M_1_1_int_309(shell: Shell, dut: DeviceAdapter, leshan: Leshan, endpoint: str):
     """LightweightM2M-1.1-int-309 - Observe-Composite and Deleting Object Instance"""
     shell.exec_command('lwm2m delete /16/0')
@@ -673,6 +681,7 @@ def test_LightweightM2M_1_1_int_309(shell: Shell, dut: DeviceAdapter, leshan: Le
     shell.exec_command('lwm2m write 1/0/2 -u32 1')
     shell.exec_command('lwm2m write 1/0/3 -u32 10')
 
+@pytest.mark.slow
 def test_LightweightM2M_1_1_int_310(shell: Shell, leshan: Leshan, endpoint: str):
     """LightweightM2M-1.1-int-310 - Observe-Composite and modification of parameter values"""
     # Need to use Configuration C.1


### PR DESCRIPTION
This PR implements previously missing testcases that were not supported by Leshan.

Now Leshan support is added, see https://github.com/eclipse-leshan/leshan/issues/1537

Now we can pass all LwM2M interoperability tests in range 100 - 399.

To run these tests, you need to fetch latest Leshan `.jar` file. Easiest is to rebuild the existing `net-tools` docker image without cache `docker build --no-cache -t net-tools .`
