### PR TITLE
input: gpio_kbd_matrix: drop redundant gpio_kbd_matrix_set_detect_mode

### DIFF
--- a/drivers/input/input_gpio_kbd_matrix.c
+++ b/drivers/input/input_gpio_kbd_matrix.c
@@ -205,8 +205,6 @@ static int gpio_kbd_matrix_init(const struct device *dev)
 	LOG_DBG("direct_read: %d direct_write: %d",
 		data->direct_read, data->direct_write);
 
-	gpio_kbd_matrix_set_detect_mode(dev, true);
-
 	return input_kbd_matrix_common_init(dev);
 }
 


### PR DESCRIPTION
This is called already as soon as the polling thread starts, so the call in the gpio init function is harmless but redundant, drop it.