### PR TITLE
boards: nrf52840dk_nrf52840: Fix reserved GPIO lines

### DIFF
--- a/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
+++ b/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
@@ -149,18 +149,18 @@
 
 &gpio0 {
 	status = "okay";
-	gpio-reserved-ranges = <0 11>, <17 7>, <26 6>;
-	gpio-line-names = "", "", "", "", "", "", "", "",
-		"", "", "", "BUTTON1", "BUTTON2", "LED1", "LED2", "LED3",
-		"LED4", "", "", "", "", "", "", "",
-		"BUTTON3", "BUTTON4", "", "", "", "", "", "";
+	gpio-reserved-ranges = <0 2>, <6 1>, <8 3>, <17 7>;
+	gpio-line-names = "XL1", "XL2", "AREF", "A0", "A1", "RTS", "TXD",
+		"CTS", "RXD", "NFC1", "NFC2", "BUTTON1", "BUTTON2", "LED1",
+		"LED2", "LED3", "LED4", "QSPI CS", "RESET", "QSPI CLK",
+		"QSPI DIO0", "QSPI DIO1", "QSPI DIO2", "QSPI DIO3","BUTTON3",
+		"BUTTON4", "SDA", "SCL", "A2", "A3", "A4", "A5";
 };
 
 &gpio1 {
 	status = "okay";
-	gpio-reserved-ranges = <0 1>, <9 1>, <12 4>;
 	gpio-line-names = "", "D0", "D1", "D2", "D3", "D4", "D5", "D6",
-		"D7", "", "D8", "D9", "", "", "", "";
+		"D7", "", "D8", "D9", "D10", "D11", "D12", "D13";
 };
 
 &uart0 {


### PR DESCRIPTION
This is a follow-up to commit 7a83724e0f18d7f2400517407150f9e9a1ecd6e6.

There is no reason to mark that many GPIO lines as reserved on this board. And doing so causes several existing tests to fail as they are configured to use some of those now unavailable GPIO lines.

Limit reservation to the lines that actually cannot be used as GPIOs without changes in the default configuration of the board or its physical modification (via solder bridges), i.e.:
- XL1 and XL2 (connections for the 32.768 kHz crystal)
- NFC1 and NFC2 (NFC antenna connections)
- RESET
- TXD and RXD (lines used by the console UART)
- QSPI lines: CS, CLK, and DIO0-3

Provide names for all the GPIO lines that are described on the board. Even for the reserved ones, so that it is clear why they are reserved.

Fixes #65475.