### PR TITLE
Check if device is ready before taking interface up

### DIFF
--- a/include/zephyr/net/dummy.h
+++ b/include/zephyr/net/dummy.h
@@ -31,6 +31,12 @@ struct dummy_api {
 
 	/** Send a network packet */
 	int (*send)(const struct device *dev, struct net_pkt *pkt);
+
+	/** Start the device. Called when the bound network interface is brought up. */
+	int (*start)(const struct device *dev);
+
+	/** Stop the device. Called when the bound network interface is taken down. */
+	int (*stop)(const struct device *dev);
 };
 
 /* Make sure that the network interface API is properly setup inside

--- a/subsys/net/l2/dummy/dummy.c
+++ b/subsys/net/l2/dummy/dummy.c
@@ -45,9 +45,31 @@ static inline int dummy_send(struct net_if *iface, struct net_pkt *pkt)
 	return ret;
 }
 
+static inline int dummy_enable(struct net_if *iface, bool state)
+{
+	int ret = 0;
+	const struct dummy_api *api = net_if_get_device(iface)->api;
+
+	if (!api) {
+		return -ENOENT;
+	}
+
+	if (!state) {
+		if (api->stop) {
+			ret = api->stop(net_if_get_device(iface));
+		}
+	} else {
+		if (api->start) {
+			ret = api->start(net_if_get_device(iface));
+		}
+	}
+
+	return ret;
+}
+
 static enum net_l2_flags dummy_flags(struct net_if *iface)
 {
 	return NET_L2_MULTICAST;
 }
 
-NET_L2_INIT(DUMMY_L2, dummy_recv, dummy_send, NULL, dummy_flags);
+NET_L2_INIT(DUMMY_L2, dummy_recv, dummy_send, dummy_enable, dummy_flags);


### PR DESCRIPTION
Change the `net_if_up()` to check if the network device is ready or not. It if the device is not ready, then do not take the interface up as we cannot send or receive from the corresponding network interface anyway.

Fixes #65423 