### PR TITLE
drivers: net: lan8651: Provide fixes for OA TC6 LAN865x driver

### DIFF
--- a/drivers/ethernet/eth_lan865x.c
+++ b/drivers/ethernet/eth_lan865x.c
@@ -373,16 +373,16 @@ static void lan865x_read_chunks(const struct device *dev)
 	k_sem_take(&ctx->tx_rx_sem, K_FOREVER);
 	pkt = net_pkt_rx_alloc(K_MSEC(cfg->timeout));
 	if (!pkt) {
-		LOG_ERR("OA RX: Could not allocate packet!");
 		k_sem_give(&ctx->tx_rx_sem);
+		LOG_ERR("OA RX: Could not allocate packet!");
 		return;
 	}
 
 	ret = oa_tc6_read_chunks(tc6, pkt);
-	k_sem_give(&ctx->tx_rx_sem);
 	if (ret < 0) {
 		eth_stats_update_errors_rx(ctx->iface);
 		net_pkt_unref(pkt);
+		k_sem_give(&ctx->tx_rx_sem);
 		return;
 	}
 
@@ -392,6 +392,7 @@ static void lan865x_read_chunks(const struct device *dev)
 		LOG_ERR("OA RX: Could not process packet (%d)!", ret);
 		net_pkt_unref(pkt);
 	}
+	k_sem_give(&ctx->tx_rx_sem);
 }
 
 static void lan865x_int_thread(const struct device *dev)

--- a/drivers/ethernet/eth_lan865x.c
+++ b/drivers/ethernet/eth_lan865x.c
@@ -577,8 +577,8 @@ static const struct ethernet_api lan865x_api_func = {
 	static struct lan865x_data lan865x_data_##inst = {                                         \
 		.mac_address = DT_INST_PROP(inst, local_mac_address),                              \
 		.tx_rx_sem =                                                                       \
-			Z_SEM_INITIALIZER((lan865x_data_##inst).tx_rx_sem, 1, UINT_MAX),           \
-		.int_sem = Z_SEM_INITIALIZER((lan865x_data_##inst).int_sem, 0, UINT_MAX),          \
+			Z_SEM_INITIALIZER((lan865x_data_##inst).tx_rx_sem, 1, 1),                  \
+		.int_sem = Z_SEM_INITIALIZER((lan865x_data_##inst).int_sem, 0, 1),                 \
 		.tc6 = &oa_tc6_##inst                                                              \
 	};                                                                                         \
 												   \

--- a/drivers/ethernet/eth_lan865x.c
+++ b/drivers/ethernet/eth_lan865x.c
@@ -435,23 +435,7 @@ static void lan865x_int_thread(const struct device *dev)
 			lan865x_read_chunks(dev);
 		}
 
-		if (tc6->exst) {
-			/*
-			 * Just clear any pending interrupts - data RX will be served
-			 * earlier.
-			 * The RESETC is handled separately as it requires LAN865x device
-			 * configuration.
-			 */
-			oa_tc6_reg_read(tc6, OA_STATUS0, &sts);
-			if (sts != 0) {
-				oa_tc6_reg_write(tc6, OA_STATUS0, sts);
-			}
-
-			oa_tc6_reg_read(tc6, OA_STATUS1, &sts);
-			if (sts != 0) {
-				oa_tc6_reg_write(tc6, OA_STATUS1, sts);
-			}
-		}
+		oa_tc6_check_status(tc6);
 	}
 }
 

--- a/drivers/ethernet/eth_lan865x.c
+++ b/drivers/ethernet/eth_lan865x.c
@@ -408,7 +408,8 @@ static void lan865x_int_thread(const struct device *dev)
 				oa_tc6_reg_write(tc6, OA_STATUS0, sts);
 				lan865x_default_config(dev, ctx->silicon_rev);
 				oa_tc6_reg_read(tc6, OA_CONFIG0, &val);
-				oa_tc6_reg_write(tc6, OA_CONFIG0, OA_CONFIG0_SYNC | val);
+				val |= OA_CONFIG0_SYNC | OA_CONFIG0_RFA_ZARFE;
+				oa_tc6_reg_write(tc6, OA_CONFIG0, val);
 				lan865x_mac_rxtx_control(dev, LAN865x_MAC_TXRX_ON);
 
 				ctx->reset = true;

--- a/drivers/ethernet/eth_lan865x.c
+++ b/drivers/ethernet/eth_lan865x.c
@@ -426,7 +426,9 @@ static void lan865x_int_thread(const struct device *dev)
 		 * The IRQ_N is asserted when RCA becomes > 0, so update its value
 		 * before reading chunks.
 		 */
-		oa_tc6_update_buf_info(tc6);
+		if (oa_tc6_update_buf_info(tc6) < 0) {
+			continue;
+		}
 
 		while (tc6->rca > 0) {
 			lan865x_read_chunks(dev);

--- a/drivers/ethernet/oa_tc6.c
+++ b/drivers/ethernet/oa_tc6.c
@@ -135,23 +135,30 @@ int oa_tc6_reg_write(struct oa_tc6 *tc6, const uint32_t reg, uint32_t val)
 	return ret;
 }
 
-int oa_tc6_set_protected_ctrl(struct oa_tc6 *tc6, bool prote)
+int oa_tc6_reg_rmw(struct oa_tc6 *tc6, const uint32_t reg,
+		   uint32_t mask, uint32_t val)
 {
-	uint32_t val;
+	uint32_t tmp;
 	int ret;
 
-	ret = oa_tc6_reg_read(tc6, OA_CONFIG0, &val);
+	ret = oa_tc6_reg_read(tc6, reg, &tmp);
 	if (ret < 0) {
 		return ret;
 	}
 
-	if (prote) {
-		val |= OA_CONFIG0_PROTE;
-	} else {
-		val &= ~OA_CONFIG0_PROTE;
+	tmp &= ~mask;
+
+	if (val) {
+		tmp |= val;
 	}
 
-	ret = oa_tc6_reg_write(tc6, OA_CONFIG0, val);
+	return oa_tc6_reg_write(tc6, reg, tmp);
+}
+
+int oa_tc6_set_protected_ctrl(struct oa_tc6 *tc6, bool prote)
+{
+	int ret = oa_tc6_reg_rmw(tc6, OA_CONFIG0, OA_CONFIG0_PROTE,
+				 prote ? OA_CONFIG0_PROTE : 0);
 	if (ret < 0) {
 		return ret;
 	}

--- a/drivers/ethernet/oa_tc6.c
+++ b/drivers/ethernet/oa_tc6.c
@@ -175,6 +175,10 @@ int oa_tc6_send_chunks(struct oa_tc6 *tc6, struct net_pkt *pkt)
 	uint8_t chunks, i;
 	int ret;
 
+	if (len == 0) {
+		return -ENODATA;
+	}
+
 	chunks = len / tc6->cps;
 	if (len % tc6->cps) {
 		chunks++;

--- a/drivers/ethernet/oa_tc6.c
+++ b/drivers/ethernet/oa_tc6.c
@@ -237,6 +237,26 @@ int oa_tc6_update_buf_info(struct oa_tc6 *tc6)
 	tc6->rca = FIELD_GET(OA_BUFSTS_RCA, val);
 	tc6->txc = FIELD_GET(OA_BUFSTS_TXC, val);
 
+	/*
+	 * There is a mismatch in the max value of RBA(RCA) and TXC provided by the
+	 * OA TC6 standard.
+	 *
+	 * The OA_BUFSTS register has 8 bits for RBA(RCA) and TXC (max value is 0x30)
+	 *
+	 * However, with footer, the RBA(RCA) and TXC are saturated to 0x1F maximal
+	 * value (due to 32 bit constrain of footer size).
+	 *
+	 * To avoid any issues, the number read directly from OA_BUFSTS is saturated
+	 * as well.
+	 */
+	if (tc6->rca >= OA_TC6_FTR_RCA_MAX) {
+		tc6->rca = OA_TC6_FTR_RCA_MAX;
+	}
+
+	if (tc6->txc >= OA_TC6_FTR_TXC_MAX) {
+		tc6->txc = OA_TC6_FTR_TXC_MAX;
+	}
+
 	return 0;
 }
 

--- a/drivers/ethernet/oa_tc6.c
+++ b/drivers/ethernet/oa_tc6.c
@@ -223,6 +223,32 @@ int oa_tc6_send_chunks(struct oa_tc6 *tc6, struct net_pkt *pkt)
 	return 0;
 }
 
+int oa_tc6_check_status(struct oa_tc6 *tc6)
+{
+	uint32_t sts;
+
+	if (tc6->exst) {
+		/*
+		 * Just clear any pending interrupts.
+		 * The RESETC is handled separately as it requires per
+		 * device configuration.
+		 */
+		oa_tc6_reg_read(tc6, OA_STATUS0, &sts);
+		if (sts != 0) {
+			oa_tc6_reg_write(tc6, OA_STATUS0, sts);
+			LOG_WRN("EXST: OA_STATUS0: 0x%x", sts);
+		}
+
+		oa_tc6_reg_read(tc6, OA_STATUS1, &sts);
+		if (sts != 0) {
+			oa_tc6_reg_write(tc6, OA_STATUS1, sts);
+			LOG_WRN("EXST: OA_STATUS1: 0x%x", sts);
+		}
+	}
+
+	return 0;
+}
+
 static void oa_tc6_update_status(struct oa_tc6 *tc6, uint32_t ftr)
 {
 	tc6->exst = FIELD_GET(OA_DATA_FTR_EXST, ftr);

--- a/drivers/ethernet/oa_tc6.c
+++ b/drivers/ethernet/oa_tc6.c
@@ -175,7 +175,10 @@ int oa_tc6_send_chunks(struct oa_tc6 *tc6, struct net_pkt *pkt)
 	uint8_t chunks, i;
 	int ret;
 
-	chunks = (len / tc6->cps) + 1;
+	chunks = len / tc6->cps;
+	if (len % tc6->cps) {
+		chunks++;
+	}
 
 	/* Check if LAN865x has any free internal buffer space */
 	if (chunks > tc6->txc) {

--- a/drivers/ethernet/oa_tc6.h
+++ b/drivers/ethernet/oa_tc6.h
@@ -230,4 +230,20 @@ int oa_tc6_read_status(struct oa_tc6 *tc6, uint32_t *ftr);
  * @return 0 if successful, <0 otherwise.
  */
 int oa_tc6_update_buf_info(struct oa_tc6 *tc6);
+
+/**
+ * @brief Read, modify and write control register from OA TC6 device
+ *
+ * @param tc6 OA TC6 specific data
+ *
+ * @param reg register to modify
+ *
+ * @param mask bit mask for modified register
+ *
+ * @param value to be stored in the register
+ *
+ * @return 0 if successful, <0 otherwise.
+ */
+int oa_tc6_reg_rmw(struct oa_tc6 *tc6, const uint32_t reg,
+		   uint32_t mask, uint32_t val);
 #endif /* OA_TC6_CFG_H__ */

--- a/drivers/ethernet/oa_tc6.h
+++ b/drivers/ethernet/oa_tc6.h
@@ -21,6 +21,7 @@
 #define OA_RESET_SWRESET              BIT(0)
 #define OA_CONFIG0                    MMS_REG(0x0, 0x004)
 #define OA_CONFIG0_SYNC               BIT(15)
+#define OA_CONFIG0_RFA_ZARFE          BIT(12)
 #define OA_CONFIG0_PROTE              BIT(5)
 #define OA_STATUS0                    MMS_REG(0x0, 0x008)
 #define OA_STATUS0_RESETC             BIT(6)

--- a/drivers/ethernet/oa_tc6.h
+++ b/drivers/ethernet/oa_tc6.h
@@ -77,6 +77,8 @@
 #define OA_TC6_HDR_SIZE		      4
 #define OA_TC6_FTR_SIZE		      4
 #define OA_TC6_BUF_ALLOC_TIMEOUT      K_MSEC(10)
+#define OA_TC6_FTR_RCA_MAX	      GENMASK(4, 0)
+#define OA_TC6_FTR_TXC_MAX	      GENMASK(4, 0)
 
 /**
  * @brief OA TC6 data.

--- a/drivers/ethernet/oa_tc6.h
+++ b/drivers/ethernet/oa_tc6.h
@@ -249,4 +249,13 @@ int oa_tc6_update_buf_info(struct oa_tc6 *tc6);
  */
 int oa_tc6_reg_rmw(struct oa_tc6 *tc6, const uint32_t reg,
 		   uint32_t mask, uint32_t val);
+
+/**
+ * @brief Check the status of OA TC6 device
+ *
+ * @param tc6 OA TC6 specific data
+ *
+ * @return 0 if successful, <0 otherwise.
+ */
+int oa_tc6_check_status(struct oa_tc6 *tc6);
 #endif /* OA_TC6_CFG_H__ */


### PR DESCRIPTION
This patch set provides fixes for LAN865x OA TC6 driver as a follow up of https://github.com/zephyrproject-rtos/zephyr/pull/63614

Most notable fixes:
- Improve stability with refactoring and proper configuration of semaphores
- Avoid sending extra chunk when packet size equals to multiple size of chunks
- Add and use RMW operation
- Add saturation code for RCA and TXC when read from OA_BUFSTS register
- Add return code check in interrupt thread to avoid using stalled RCA and TXC data
- Do not send chunk when no data provided.
- Use ZARFE bit from OA_CONFIG to avoid fragments with packet header

