### PR TITLE
twister: pytest: Add --pytest-args to Twister command line

### DIFF
--- a/doc/develop/test/pytest.rst
+++ b/doc/develop/test/pytest.rst
@@ -56,6 +56,16 @@ Pytest scans the given locations looking for tests, following its default
 `discovery rules <https://docs.pytest.org/en/7.1.x/explanation/goodpractices.html#conventions-for-python-test-discovery>`_
 One can also pass some extra arguments to the pytest from yaml file using ``pytest_args`` keyword
 under ``harness_config``, e.g.: ``pytest_args: [‘-k=test_method’, ‘--log-level=DEBUG’]``.
+There is also an option to pass ``--pytest-args`` through Twister command line parameters.
+This can be particularly useful when one wants to select a specific testcase from a test suite.
+For instance, one can use a command:
+
+.. code-block:: console
+
+   $ ./scripts/twister --platform native_sim -T samples/subsys/testsuite/pytest/shell \
+   -s samples/subsys/testsuite/pytest/shell/sample.pytest.shell \
+   --pytest-args='-k test_shell_print_version'
+
 
 Helpers & fixtures
 ==================

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -216,6 +216,11 @@ Artificially long but functional example:
         and 'fifo_loop' is a name of a function found in main.c without test prefix.
         """)
 
+    parser.add_argument("--pytest-args",
+        help="""Pass additional arguments to the pytest subprocess. This parameter
+        will override the pytest_args from the harness_config in YAML file.
+        """)
+
     valgrind_asan_group.add_argument(
         "--enable-valgrind", action="store_true",
         help="""Run binary through valgrind and check for several memory access


### PR DESCRIPTION
Extend Twister command line with --pytest-args. This parameter is passed to pytest subprocess and used only for pytest harness.
Find feature request here: https://github.com/zephyrproject-rtos/zephyr/issues/58288#issuecomment-1805755362

Added unit tests and updated documentation.

With that change now it is possible to filter only one testcase from pytest script, one can try with command:
```
./zephyr/scripts/twister -vv -T zephyr/samples/subsys/testsuite/pytest/shell -p native_sim --pytest-args='-k test_shell_print_version'
```
