### PR TITLE
drivers: can_sam0: added clock configuration for SAME5x devices

### DIFF
--- a/drivers/can/can_sam0.c
+++ b/drivers/can/can_sam0.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2022 Vestas Wind Systems A/S
  * Copyright (c) 2021 Alexander Wachter
  * Copyright (c) 2022 Kamil Serwus
+ * Copyright (c) 2023 Sebastian Schlupp
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -95,7 +96,13 @@ static int can_sam0_get_core_clock(const struct device *dev, uint32_t *rate)
 	const struct can_mcan_config *mcan_cfg = dev->config;
 	const struct can_sam0_config *sam_cfg = mcan_cfg->custom;
 
+#if defined(CONFIG_SOC_SERIES_SAME51) || defined(CONFIG_SOC_SERIES_SAME54)
+	/*DFFL has to be used as clock source for the ATSAME51/54 family of SoCs*/
+	*rate = SOC_ATMEL_SAM0_DFLL48_FREQ_HZ / (sam_cfg->divider);
+#elif defined(CONFIG_SOC_SERIES_SAMC21)
+	/*OSC48M has to be used as clock source for the ATSAMC21 family of SoCs*/
 	*rate = SOC_ATMEL_SAM0_OSC48M_FREQ_HZ / (sam_cfg->divider);
+#endif
 
 	return 0;
 }
@@ -103,9 +110,17 @@ static int can_sam0_get_core_clock(const struct device *dev, uint32_t *rate)
 static void can_sam0_clock_enable(const struct can_sam0_config *cfg)
 {
 	/* Enable the GLCK7 with DIV*/
+#if defined(CONFIG_SOC_SERIES_SAME51) || defined(CONFIG_SOC_SERIES_SAME54)
+	/*DFFL has to be used as clock source for the ATSAME51/54 family of SoCs*/
+	GCLK->GENCTRL[7].reg = GCLK_GENCTRL_SRC(GCLK_GENCTRL_SRC_DFLL)
+			     | GCLK_GENCTRL_DIV(cfg->divider)
+			     | GCLK_GENCTRL_GENEN;
+#elif defined(CONFIG_SOC_SERIES_SAMC21)
+	/*OSC48M has to be used as clock source for the ATSAMC21 family of SoCs*/
 	GCLK->GENCTRL[7].reg = GCLK_GENCTRL_SRC(GCLK_GENCTRL_SRC_OSC48M)
 			     | GCLK_GENCTRL_DIV(cfg->divider)
 			     | GCLK_GENCTRL_GENEN;
+#endif
 
 	/* Route channel */
 	GCLK->PCHCTRL[cfg->gclk_core_id].reg = GCLK_PCHCTRL_GEN_GCLK7

--- a/dts/arm/atmel/same5x.dtsi
+++ b/dts/arm/atmel/same5x.dtsi
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Stephanos Ioannidis <root@stephanos.io>
+ * Copyright (c) 2023 Sebastian Schlupp
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -24,6 +25,34 @@
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
+		};
+
+		can0: can@42000000 {
+			compatible = "atmel,sam0-can";
+			reg = <0x42000000 0x400>;
+			interrupts = <78 0>, <78 0>;
+			interrupt-names = "LINE_0", "LINE_1";
+			clocks = <&gclk 27>, <&mclk 0x10 17>;
+			clock-names = "GCLK", "MCLK";
+			bosch,mram-cfg = <0x0 128 64 64 64 64 32 32>;
+			divider = <12>;
+			sample-point = <875>;
+			sample-point-data = <875>;
+			status = "disabled";
+		};
+
+		can1: can@42000400 {
+			compatible = "atmel,sam0-can";
+			reg = <0x42000400 0x400>;
+			interrupts = <79 0>, <79 0>;
+			interrupt-names = "LINE_0", "LINE_1";
+			clocks = <&gclk 28>, <&mclk 0x10 18>;
+			clock-names = "GCLK", "MCLK";
+			bosch,mram-cfg = <0x0 128 64 64 64 64 32 32>;
+			divider = <12>;
+			sample-point = <875>;
+			sample-point-data = <875>;
+			status = "disabled";
 		};
 	};
 };

--- a/soc/arm/atmel_sam0/same51/soc.h
+++ b/soc/arm/atmel_sam0/same51/soc.h
@@ -37,6 +37,7 @@
 #include "../common/atmel_sam0_dt.h"
 
 #define SOC_ATMEL_SAM0_OSC32K_FREQ_HZ 32768
+#define SOC_ATMEL_SAM0_DFLL48_FREQ_HZ 48000000
 
 /** Processor Clock (HCLK) Frequency */
 #define SOC_ATMEL_SAM0_HCLK_FREQ_HZ CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC

--- a/soc/arm/atmel_sam0/same54/soc.h
+++ b/soc/arm/atmel_sam0/same54/soc.h
@@ -36,6 +36,7 @@
 #include "../common/atmel_sam0_dt.h"
 
 #define SOC_ATMEL_SAM0_OSC32K_FREQ_HZ 32768
+#define SOC_ATMEL_SAM0_DFLL48_FREQ_HZ 48000000
 
 /** Processor Clock (HCLK) Frequency */
 #define SOC_ATMEL_SAM0_HCLK_FREQ_HZ CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC


### PR DESCRIPTION
drivers: can_sam0: added clock configuration for SAME5x devices

also modified the following to support CAN:
soc: same51 and same54: added DFLL48 frequency information
dts: arm: atmel: added can peripherals to same5x.dtsi

Signed-off-by: Sebastian Schlupp <sebastian.schlupp@gmail.com>