### PR TITLE
Bluetooth: audio: ascs: Remove spurious error message

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -944,7 +944,6 @@ static void ascs_iso_disconnected(struct bt_iso_chan *chan, uint8_t reason)
 	struct bt_bap_iso *iso = CONTAINER_OF(chan, struct bt_bap_iso, chan);
 
 	if (iso->rx.ep == NULL && iso->tx.ep == NULL) {
-		LOG_ERR("iso %p not bound with ep", chan);
 		return;
 	}
 


### PR DESCRIPTION
This removes spurious error message printed when CIS has been disconnected and it was not used by any of the endpoints. This case is valid and may happen on Connection Timeout when the controller reports ACL Disconnection first.
When the CIS Disconnection is reported after, the ASE is already in idle state and the referenece to CIS has been already removed (on ACL disconnection).

Fixes: #64896