### PR TITLE
Change cortex_m_systick idle timer dependency tree

### DIFF
--- a/drivers/timer/Kconfig.cortex_m_systick
+++ b/drivers/timer/Kconfig.cortex_m_systick
@@ -48,6 +48,7 @@ config CORTEX_M_SYSTICK_IDLE_TIMER
 	default $(dt_chosen_enabled,$(DT_CHOSEN_IDLE_TIMER))
 	depends on COUNTER
 	depends on TICKLESS_KERNEL
+	depends on PM
 	help
 	  There are chips e.g. STMFX family that use SysTick as a system timer,
 	  but SysTick is not clocked in low power mode. These chips usually have

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -22,6 +22,7 @@
 / {
 	chosen {
 		zephyr,flash-controller = &flash;
+		zephyr,cortex-m-idle-timer = &rtc;
 	};
 
 	cpus {


### PR DESCRIPTION
Enable the Cortex-m systick idle timer only if power management is on.

It allows setting RTC as the systick idle timer chosen node in dts.