### PR TITLE
drivers: tsl2561: Fix type

### DIFF
--- a/drivers/sensor/tsl2561/tsl2561.c
+++ b/drivers/sensor/tsl2561/tsl2561.c
@@ -136,7 +136,7 @@ static int tsl2561_sample_fetch(const struct device *dev, enum sensor_channel ch
 	const struct tsl2561_config *config = dev->config;
 	struct tsl2561_data *data = dev->data;
 	uint8_t bytes[2];
-	uint8_t ret;
+	int ret;
 
 	if (chan != SENSOR_CHAN_ALL && chan != SENSOR_CHAN_LIGHT) {
 		LOG_ERR("Unsupported sensor channel");


### PR DESCRIPTION
Use int as correct type, fixes also warning comparing uint8_t < 0.