### PR TITLE
sys: util: make CONCAT macro supporting variable arguments concatenation

### DIFF
--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -269,13 +269,18 @@ extern "C" {
 	})
 
 /**
- * @brief Concatenate two tokens into one
+ * @brief Concatenate input arguments
  *
- * Concatenate two tokens,  @p x and @p y, into a combined token during the preprocessor pass.
- * This can be used to, for ex., build an identifier out of two parts,
+ * Concatenate provided tokens into a combined token during the preprocessor pass.
+ * This can be used to, for ex., build an identifier out of multiple parts,
  * where one of those parts may be, for ex, a number, another macro, or a macro argument.
+ *
+ * @param ... Tokens to concatencate
+ *
+ * @return Concatenated token.
  */
-#define CONCAT(x, y) _DO_CONCAT(x, y)
+#define CONCAT(...) \
+	UTIL_CAT(_CONCAT_, NUM_VA_ARGS_LESS_1(__VA_ARGS__))(__VA_ARGS__)
 
 /**
  * @brief Value of @p x rounded up to the next multiple of @p align.

--- a/include/zephyr/sys/util_internal.h
+++ b/include/zephyr/sys/util_internal.h
@@ -116,6 +116,15 @@
 #define UTIL_EXPAND(...) __VA_ARGS__
 #define UTIL_REPEAT(...) UTIL_LISTIFY(__VA_ARGS__)
 
+#define _CONCAT_0(arg, ...) arg
+#define _CONCAT_1(arg, ...) UTIL_CAT(arg, _CONCAT_0(__VA_ARGS__))
+#define _CONCAT_2(arg, ...) UTIL_CAT(arg, _CONCAT_1(__VA_ARGS__))
+#define _CONCAT_3(arg, ...) UTIL_CAT(arg, _CONCAT_2(__VA_ARGS__))
+#define _CONCAT_4(arg, ...) UTIL_CAT(arg, _CONCAT_3(__VA_ARGS__))
+#define _CONCAT_5(arg, ...) UTIL_CAT(arg, _CONCAT_4(__VA_ARGS__))
+#define _CONCAT_6(arg, ...) UTIL_CAT(arg, _CONCAT_5(__VA_ARGS__))
+#define _CONCAT_7(arg, ...) UTIL_CAT(arg, _CONCAT_6(__VA_ARGS__))
+
 /* Implementation details for NUM_VA_ARGS_LESS_1 */
 #define NUM_VA_ARGS_LESS_1_IMPL(				\
 	_ignored,						\

--- a/tests/unit/util/main.c
+++ b/tests/unit/util/main.c
@@ -717,4 +717,40 @@ ZTEST(util, test_mem_xor_128)
 	zassert_mem_equal(expected_result, dst, 16);
 }
 
+ZTEST(util, test_CONCAT)
+{
+#define _CAT_PART1 1
+#define CAT_PART1 _CAT_PART1
+#define _CAT_PART2 2
+#define CAT_PART2 _CAT_PART2
+#define _CAT_PART3 3
+#define CAT_PART3 _CAT_PART3
+#define _CAT_PART4 4
+#define CAT_PART4 _CAT_PART4
+#define _CAT_PART5 5
+#define CAT_PART5 _CAT_PART5
+#define _CAT_PART6 6
+#define CAT_PART6 _CAT_PART6
+#define _CAT_PART7 7
+#define CAT_PART7 _CAT_PART7
+#define _CAT_PART8 8
+#define CAT_PART8 _CAT_PART8
+
+	zassert_equal(CONCAT(CAT_PART1), 1);
+	zassert_equal(CONCAT(CAT_PART1, CAT_PART2), 12);
+	zassert_equal(CONCAT(CAT_PART1, CAT_PART2, CAT_PART3), 123);
+	zassert_equal(CONCAT(CAT_PART1, CAT_PART2, CAT_PART3, CAT_PART4), 1234);
+	zassert_equal(CONCAT(CAT_PART1, CAT_PART2, CAT_PART3, CAT_PART4, CAT_PART5), 12345);
+	zassert_equal(CONCAT(CAT_PART1, CAT_PART2, CAT_PART3, CAT_PART4, CAT_PART5, CAT_PART6),
+			123456);
+	zassert_equal(CONCAT(CAT_PART1, CAT_PART2, CAT_PART3, CAT_PART4,
+			     CAT_PART5, CAT_PART6, CAT_PART7),
+			1234567);
+	zassert_equal(CONCAT(CAT_PART1, CAT_PART2, CAT_PART3, CAT_PART4,
+			     CAT_PART5, CAT_PART6, CAT_PART7, CAT_PART8),
+			12345678);
+
+	zassert_equal(CONCAT(CAT_PART1, CONCAT(CAT_PART2, CAT_PART3)), 123);
+}
+
 ZTEST_SUITE(util, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Modified `CONCAT` to accept up to 8 arguments which are concatenated.

Currently there are various options for concatenation:
- `UTIL_CAT` or `CONCAT` from `sys/util.h`
-  `_CONCAT` from `toolchain/common.h`

Next step would be to unify usage across the repo. Ideally, with the version that supports multiple arguments to avoid harder to read `CAT(a, CAT(b, c))` phrases.

PR based on #65514