### PR TITLE
drivers: ieee802154: support Key Identifier Mode > 1

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -781,25 +781,17 @@ static void nrf5_iface_init(struct net_if *iface)
 #if defined(CONFIG_NRF_802154_ENCRYPTION)
 static void nrf5_config_mac_keys(struct ieee802154_key *mac_keys)
 {
-	static nrf_802154_key_id_t stored_key_ids[NRF_802154_SECURITY_KEY_STORAGE_SIZE];
-	static uint8_t stored_ids[NRF_802154_SECURITY_KEY_STORAGE_SIZE];
-	uint8_t i;
+	nrf_802154_security_key_remove_all();
 
-	for (i = 0; i < NRF_802154_SECURITY_KEY_STORAGE_SIZE && stored_key_ids[i].p_key_id; i++) {
-		nrf_802154_security_key_remove(&stored_key_ids[i]);
-		stored_key_ids[i].p_key_id = NULL;
-	}
-
-	i = 0;
-	for (struct ieee802154_key *keys = mac_keys; keys->key_value
-			&& i < NRF_802154_SECURITY_KEY_STORAGE_SIZE; keys++, i++) {
+	for (uint8_t i = 0; mac_keys->key_value
+			&& i < NRF_802154_SECURITY_KEY_STORAGE_SIZE; mac_keys++, i++) {
 		nrf_802154_key_t key = {
-			.value.p_cleartext_key = keys->key_value,
-			.id.mode = keys->key_id_mode,
-			.id.p_key_id = &(keys->key_index),
+			.value.p_cleartext_key = mac_keys->key_value,
+			.id.mode = mac_keys->key_id_mode,
+			.id.p_key_id = mac_keys->key_id,
 			.type = NRF_802154_KEY_CLEARTEXT,
 			.frame_counter = 0,
-			.use_global_frame_counter = !(keys->frame_counter_per_key),
+			.use_global_frame_counter = !(mac_keys->frame_counter_per_key),
 		};
 
 		__ASSERT_EVAL((void)nrf_802154_security_key_store(&key),
@@ -807,10 +799,6 @@ static void nrf5_config_mac_keys(struct ieee802154_key *mac_keys)
 			err == NRF_802154_SECURITY_ERROR_NONE ||
 			err == NRF_802154_SECURITY_ERROR_ALREADY_PRESENT,
 			"Storing key failed, err: %d", err);
-
-		stored_ids[i] = *key.id.p_key_id;
-		stored_key_ids[i].mode = key.id.mode;
-		stored_key_ids[i].p_key_id = &stored_ids[i];
 	};
 }
 #endif /* CONFIG_NRF_802154_ENCRYPTION */

--- a/include/zephyr/net/ieee802154_radio.h
+++ b/include/zephyr/net/ieee802154_radio.h
@@ -592,11 +592,16 @@ struct ieee802154_filter {
  * IEEE802154_CONFIG_MAC_KEYS.
  */
 struct ieee802154_key {
+	/** Key material */
 	uint8_t *key_value;
+	/** Initial value of frame counter associated with the key, see section 9.4.3 */
 	uint32_t key_frame_counter;
+	/** Indicates if per-key frame counter should be used, see section 9.4.3 */
 	bool frame_counter_per_key;
+	/** Key Identifier Mode, see section 9.4.2.3, Table 9-7 */
 	uint8_t key_id_mode;
-	uint8_t key_index;
+	/** Key Identifier, see section 9.4.4 */
+	uint8_t *key_id;
 };
 
 /** IEEE 802.15.4 Transmission mode. */

--- a/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_spinel_backend_ipc.c
+++ b/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_spinel_backend_ipc.c
@@ -9,6 +9,7 @@
 #include <zephyr/device.h>
 #include <zephyr/logging/log.h>
 
+#include "nrf_802154.h"
 #include "nrf_802154_spinel_backend_callouts.h"
 #include "nrf_802154_serialization_error.h"
 #include "../../spinel_base/spinel.h"
@@ -74,7 +75,7 @@ nrf_802154_ser_err_t nrf_802154_backend_init(void)
 #define SEND_THREAD_STACK_SIZE 1024
 
 /* Make the ring buffer long enough to hold all notifications that the driver can produce */
-#define RING_BUFFER_LEN (CONFIG_NRF_802154_RX_BUFFERS + 10)
+#define RING_BUFFER_LEN (NRF_802154_MAX_PENDING_NOTIFICATIONS + 1)
 
 static K_SEM_DEFINE(send_sem, 0, RING_BUFFER_LEN);
 K_THREAD_STACK_DEFINE(send_thread_stack, SEND_THREAD_STACK_SIZE);


### PR DESCRIPTION
IEEE 802.15.4-2020 defines four possible values for Key Identifier Mode field of the Auxiliary Security Header. The current ieee802154 driver API only supports two of them: b00 and b01. This commit adds support for the two remaining Key Identifier Mode values. It's done by replacing a field that can only hold Key Index into a field that can holds a pointer to the entire Key Identifier field.

See IEEE 802.15.4-2020, sections 9.4.2.3 and 9.4.4 for further reference.