### PR TITLE
boards: lpcxpresso55Sxx: Make Jlink a default runner.

### DIFF
--- a/boards/arm/lpcxpresso55s06/board.cmake
+++ b/boards/arm/lpcxpresso55s06/board.cmake
@@ -8,5 +8,5 @@
 board_runner_args(linkserver  "--device=LPC55S06:LPCXpresso55S06")
 board_runner_args(jlink "--device=LPC55S06" "--reset-after-load")
 
-include(${ZEPHYR_BASE}/boards/common/linkserver.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/linkserver.board.cmake)

--- a/boards/arm/lpcxpresso55s16/board.cmake
+++ b/boards/arm/lpcxpresso55s16/board.cmake
@@ -9,6 +9,6 @@ board_runner_args(linkserver  "--device=LPC55S16:LPCXpresso55S16")
 board_runner_args(jlink "--device=LPC55S16" "--reset-after-load")
 board_runner_args(pyocd "--target=lpc55s16")
 
-include(${ZEPHYR_BASE}/boards/common/linkserver.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/linkserver.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/lpcxpresso55s28/board.cmake
+++ b/boards/arm/lpcxpresso55s28/board.cmake
@@ -4,8 +4,10 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+board_runner_args(linkserver  "--device=LPC55S28:LPCXpresso55S28")
 board_runner_args(pyocd "--target=lpc55s28")
 board_runner_args(jlink "--device=LPC55S28" "--reset-after-load")
 
-include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/linkserver.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/lpcxpresso55s36/board.cmake
+++ b/boards/arm/lpcxpresso55s36/board.cmake
@@ -8,6 +8,6 @@ board_runner_args(linkserver  "--device=LPC55S36:LPCXpresso55S36")
 board_runner_args(jlink "--device=LPC55S36" "--reset-after-load")
 board_runner_args(pyocd "--target=lpc55s36")
 
-include(${ZEPHYR_BASE}/boards/common/linkserver.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/linkserver.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)


### PR DESCRIPTION
Make Jlink a default runner for lpcxpresso55Sxx.

The LinkServer runner command line tool does not support .hex flashing. 
This feature is planned for LinkServer v1.6 (July 2024).