### PR TITLE
input: kbd_matrix: add a input_kbd_matrix_drive_column_hook option

### DIFF
--- a/drivers/input/Kconfig.kbd_matrix
+++ b/drivers/input/Kconfig.kbd_matrix
@@ -20,4 +20,11 @@ config INPUT_KBD_MATRIX_16_BIT_ROW
 	  Use a 16 bit type for the internal structure, allow using a matrix
 	  with up to 16 rows if the driver supports it.
 
+config INPUT_KBD_DRIVE_COLUMN_HOOK
+	bool
+	help
+	  Call an application specific hook after the driver specific
+	  drive_column implementation. The application must implement the
+	  input_kbd_matrix_drive_column_hook function.
+
 endif # INPUT_KBD_MATRIX

--- a/include/zephyr/input/input_kbd_matrix.h
+++ b/include/zephyr/input/input_kbd_matrix.h
@@ -238,6 +238,21 @@ struct input_kbd_matrix_common_data {
  */
 void input_kbd_matrix_poll_start(const struct device *dev);
 
+#ifdef CONFIG_INPUT_KBD_DRIVE_COLUMN_HOOK
+/**
+ * @brief Drive column hook
+ *
+ * This can be implemented by the application to handle column selection
+ * quirks. Called after the driver specific drive_column function.
+ *
+ * @param dev Keyboard matrix device instance.
+ * @param col The column to drive, or
+ *      @ref INPUT_KBD_MATRIX_COLUMN_DRIVE_NONE or
+ *      @ref INPUT_KBD_MATRIX_COLUMN_DRIVE_ALL.
+ */
+void input_kbd_matrix_drive_column_hook(const struct device *dev, int col);
+#endif
+
 /**
  * @brief Common function to initialize a keyboard matrix device at init time.
  *


### PR DESCRIPTION
Once upon a time, we decided to put a chip in the middle of our keyboard matrix lines and invert one of those. This means that for the keyboard scan driver to work correctly in our setup, one of the column line has to be configured as GPIO and be driven in push-pull mode. I was hoping I'd be able to find a less quirky solution by just adding a flip mask to the driver set column, but that seems to be problematic with different reasons in different devices (lack of push-pull capability to name one).

Anyway, this feature is really application specific and I don't think it makes much sense to merge the workaround code upstream, but  I have to deal with it somehow so at least I need a hook to fix that on our application. I'm proposing to add a known function protected by a hidden Kconfig entry that can be enabled by an application to implement that, so at least it's minimally intrusive to the upstream code base.

The matching application side change I want to use with this is something like this https://chromium-review.googlesource.com/c/chromiumos/platform/ec/+/5049863

Not thrilled to add this, but I'm short of options. On the bright side though, this can be reused for writing driver test using emulated gpios down the road.

---

Add an option to call an application specific hook when setting the column to scan. This makes it possible to handle application specific quirks.