### PR TITLE
board: riscv: qemu: MAX_IRQ_PER_AGGREGATOR should be 1024

### DIFF
--- a/soc/riscv/riscv-privileged/virt/Kconfig.defconfig.series
+++ b/soc/riscv/riscv-privileged/virt/Kconfig.defconfig.series
@@ -21,6 +21,9 @@ config RISCV_HAS_PLIC
 config RISCV_GP
 	default y
 
+config 2ND_LEVEL_INTERRUPT_BITS
+	default 10
+
 config 2ND_LVL_ISR_TBL_OFFSET
 	default 12
 
@@ -28,7 +31,7 @@ config 2ND_LVL_INTR_00_OFFSET
 	default 11
 
 config MAX_IRQ_PER_AGGREGATOR
-	default 52
+	default 1024
 
 config NUM_IRQS
 	default 1035

--- a/tests/drivers/build_all/interrupt_controller/intc_plic/testcase.yaml
+++ b/tests/drivers/build_all/interrupt_controller/intc_plic/testcase.yaml
@@ -14,7 +14,8 @@ tests:
     extra_args:
       DTC_OVERLAY_FILE="./app.multi_instance.overlay"
     extra_configs:
-      - CONFIG_NUM_IRQS=116
+      - CONFIG_NUM_IRQS=2059
+      - CONFIG_2ND_LEVEL_INTERRUPT_BITS=11
       - CONFIG_MULTI_LEVEL_INTERRUPTS=y
       - CONFIG_DYNAMIC_INTERRUPTS=y
       - CONFIG_NUM_2ND_LEVEL_AGGREGATORS=2


### PR DESCRIPTION
`MAX_IRQ_PER_AGGREGATOR` should be 1024 following the changes made in:
https://github.com/zephyrproject-rtos/zephyr/pull/63496