### PR TITLE
samples: subsys: nvs on stm32 nucleo_g431 requires 6kB for storage partitions

### DIFF
--- a/samples/subsys/nvs/boards/nucleo_g431rb.overlay
+++ b/samples/subsys/nvs/boards/nucleo_g431rb.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2023 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &storage_partition;
+
+&flash0 {
+	partitions {
+		/* Set 6KB of storage at the end of 128KB flash */
+		storage_partition: partition@1e800 {
+			label = "storage";
+			reg = <0x0001e800 DT_SIZE_K(6)>;
+		};
+	};
+};


### PR DESCRIPTION
Add the overlay for running the samples/subsys/nvs/ application on the nucleo_g31rb. 
Define a 6kB storage_partition at the end of the 128kB flash.

Fixes the error on flash when running the sample
$ west build -p auto -b nucleo_g431rb samples/subsys/nvs/

Completes the https://github.com/zephyrproject-rtos/zephyr/pull/60910