### PR TITLE
drivers: i2c: STM32 i2c target - secondary i2c address being routed to primary callbacks

### DIFF
--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -125,8 +125,8 @@ static void stm32_i2c_slave_event(const struct device *dev)
 	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 	const struct i2c_target_callbacks *slave_cb;
-	struct i2c_target_config *slave_cfg;
-
+	struct i2c_target_config *slave_cfg = data->slave_cfg;
+	
 	if (data->slave_cfg->flags != I2C_TARGET_FLAGS_ADDR_10_BITS) {
 		uint8_t slave_address;
 

--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -143,8 +143,7 @@ static void stm32_i2c_slave_event(const struct device *dev)
 			return;
 		}
 	}
-
-	slave_cfg = data->slave_cfg;
+	/* slave_cfg has been arbitrated above - now safe to pickup the associated callbacks */
 	slave_cb = slave_cfg->callbacks;
 
 	if (LL_I2C_IsActiveFlag_TXIS(i2c)) {

--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -125,8 +125,8 @@ static void stm32_i2c_slave_event(const struct device *dev)
 	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 	const struct i2c_target_callbacks *slave_cb;
-	struct i2c_target_config *slave_cfg = data->slave_cfg;
-	
+	struct i2c_target_config *slave_cfg;
+
 	if (data->slave_cfg->flags != I2C_TARGET_FLAGS_ADDR_10_BITS) {
 		uint8_t slave_address;
 


### PR DESCRIPTION
Fixes the secondary target address / configuration being ignored by the i2c_ll_stm32_v2.c driver in stm32_i2c_slave_event()
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/65527