### PR TITLE
drivers: serial: stm32u5: Serial wakeup is based on autonomous capability

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1279,7 +1279,8 @@ static void uart_stm32_isr(const struct device *dev)
 	uart_stm32_err_check(dev);
 #endif /* CONFIG_UART_ASYNC_API */
 
-#ifdef CONFIG_PM
+#if defined(CONFIG_PM) && defined(IS_UART_WAKEUP_FROMSTOP_INSTANCE) \
+	&& defined(USART_CR3_WUFIE)
 	if (LL_USART_IsEnabledIT_WKUP(config->usart) &&
 		LL_USART_IsActiveFlag_WKUP(config->usart)) {
 
@@ -2017,13 +2018,14 @@ static int uart_stm32_init(const struct device *dev)
 		 * CONFIG_PM_DEVICE=n : Always active
 		 * CONFIG_PM_DEVICE=y : Controlled by pm_device_wakeup_enable()
 		 */
-
+#ifdef USART_CR3_WUFIE
 		LL_USART_Disable(config->usart);
 		LL_USART_SetWKUPType(config->usart, LL_USART_WAKEUP_ON_RXNE);
 		LL_USART_EnableIT_WKUP(config->usart);
 		LL_USART_ClearFlag_WKUP(config->usart);
-		LL_USART_EnableInStopMode(config->usart);
 		LL_USART_Enable(config->usart);
+#endif
+		LL_USART_EnableInStopMode(config->usart);
 
 		if (config->wakeup_line != STM32_EXTI_LINE_NONE) {
 			/* Prepare the WAKEUP with the expected EXTI line */

--- a/samples/boards/stm32/power_mgmt/serial_wakeup/boards/b_u585i_iot02a.overlay
+++ b/samples/boards/stm32/power_mgmt/serial_wakeup/boards/b_u585i_iot02a.overlay
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&cpu0{
+	/* USART Wakeup requires automatic HSI16 switch on in deepsleep mode
+	 * which isn't possible in Stop Mode 2.
+	 * Remove Stop Mode 2 from supported modes
+	 */
+	cpu-power-states = <&stop0 &stop1>;
+};
+
+&usart1 {
+	/* Set domain clock to HSI to allow wakeup from Stop mode */
+	clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00004000>,
+		 <&rcc STM32_SRC_HSI16 USART1_SEL(2)>;
+
+	/* Configure device as wakeup source */
+	wakeup-source;
+
+	/* Configure sleep pinctrl configuration which will be used when
+	 * device is not configured as wakeup source by the application.
+	 * This use case is only applicable in PM_DEVICE mode.
+	 */
+	pinctrl-1 = <&analog_pa9 &analog_pa10>;
+	pinctrl-names = "default", "sleep";
+};
+
+&clk_hsi {
+	/* Make sure HSI is enabled */
+	status = "okay";
+};


### PR DESCRIPTION
On some devices such as STM32U5, there is no UART WKUP dedicated registers as the hardware block has an integrated autonomous wakeup capability. Hence it's capable to wake up the device from stop modes (down to Stop 1).

This behavior relies on RCC UESM bit which is enabled by default at reset and not modified today in drivers.
Since driver will not compile otherwise, remain in this simple configuration. This might be changed later on, if a need is seen to disable UESM bit.