### PR TITLE
drivers: intc: plic: add shell cmd to get irq stats for debugging

### DIFF
--- a/drivers/interrupt_controller/CMakeLists.txt
+++ b/drivers/interrupt_controller/CMakeLists.txt
@@ -42,4 +42,11 @@ if(CONFIG_INTEL_VTD_ICTL)
   zephyr_library_include_directories(${ZEPHYR_BASE}/arch/x86/include)
 endif()
 
+if(CONFIG_PLIC_SHELL)
+  message(WARNING "
+      WARNING:  `CONFIG_PLIC_SHELL` is enabled.
+      This can use quite a bit of RAM (PLICs * IRQs * sizeof(uint16_t))"
+  )
+endif()
+
 zephyr_library_include_directories(${ZEPHYR_BASE}/arch/common/include)

--- a/drivers/interrupt_controller/Kconfig.plic
+++ b/drivers/interrupt_controller/Kconfig.plic
@@ -10,3 +10,14 @@ config PLIC
 	help
 	  Platform Level Interrupt Controller provides support
 	  for external interrupt lines defined by the RISC-V SoC.
+
+if PLIC
+
+config PLIC_SHELL
+	bool "PLIC shell commands"
+	depends on SHELL
+	help
+	  Enable additional shell commands useful for debugging.
+	  Caution: This can use quite a bit of RAM (PLICs * IRQs * sizeof(uint16_t)).
+
+endif # PLIC

--- a/drivers/interrupt_controller/intc_plic.c
+++ b/drivers/interrupt_controller/intc_plic.c
@@ -271,8 +271,9 @@ static void plic_irq_handler(const struct device *dev)
 	 * If the IRQ is out of range, call z_irq_spurious.
 	 * A call to z_irq_spurious will not return.
 	 */
-	if (local_irq == 0U || local_irq >= config->num_irqs)
+	if (local_irq == 0U || local_irq >= config->num_irqs) {
 		z_irq_spurious(NULL);
+	}
 
 	edge_irq = riscv_plic_is_edge_irq(dev, local_irq);
 
@@ -281,8 +282,9 @@ static void plic_irq_handler(const struct device *dev)
 	 * to indicate to the PLIC controller that the IRQ has been handled
 	 * for edge triggered interrupts.
 	 */
-	if (edge_irq)
+	if (edge_irq != 0) {
 		sys_write32(local_irq, claim_complete_addr);
+	}
 
 	const uint32_t parent_irq = COND_CODE_1(IS_ENABLED(CONFIG_DYNAMIC_INTERRUPTS),
 						(z_get_sw_isr_irq_from_device(dev)), (0U));
@@ -300,8 +302,9 @@ static void plic_irq_handler(const struct device *dev)
 	 * PLIC controller that the IRQ has been handled
 	 * for level triggered interrupts.
 	 */
-	if (!edge_irq)
+	if (edge_irq == 0) {
 		sys_write32(local_irq, claim_complete_addr);
+	}
 }
 
 /**


### PR DESCRIPTION
Introduced `CONFIG_PLIC_SHELL` to enable the build of shell debugging command to get the hit count of each interrupt controller's IRQ line. This is especially useful when working with dynamically installed ISRs, which will be the case for `plic_sw`.

Example usage:

```
uart:~$ plic stats get interrupt-controller@c000000
   IRQ        Hits
==================
    10         177

uart:~$ plic stats get interrupt-controller@c000000
   IRQ        Hits
==================
    10         236

uart:~$ plic stats clear interrupt-controller@c000000
Cleared stats of interrupt-controller@c000000.

uart:~$ plic stats get interrupt-controller@c000000
   IRQ        Hits
==================
    10          90

```