### PR TITLE
drivers/sensor: lsm6dsv16x: fix DT configuration read for int1/int2

### DIFF
--- a/drivers/sensor/lsm6dsv16x/lsm6dsv16x.c
+++ b/drivers/sensor/lsm6dsv16x/lsm6dsv16x.c
@@ -923,6 +923,7 @@ static int lsm6dsv16x_init(const struct device *dev)
 	.trig_enabled = true,						\
 	.int1_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, int1_gpios, { 0 }),	\
 	.int2_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, int2_gpios, { 0 }),	\
+	.drdy_pulsed = DT_INST_PROP(inst, drdy_pulsed),                 \
 	.drdy_pin = DT_INST_PROP(inst, drdy_pin)
 #else
 #define LSM6DSV16X_CFG_IRQ(inst)
@@ -938,8 +939,9 @@ static int lsm6dsv16x_init(const struct device *dev)
 	.accel_range = DT_INST_PROP(inst, accel_range),			\
 	.gyro_odr = DT_INST_PROP(inst, gyro_odr),			\
 	.gyro_range = DT_INST_PROP(inst, gyro_range),			\
-	.drdy_pulsed = DT_INST_PROP(inst, drdy_pulsed),                 \
-	LSM6DSV16X_CFG_IRQ(inst)
+	IF_ENABLED(UTIL_OR(DT_INST_NODE_HAS_PROP(inst, int1_gpios),	\
+			   DT_INST_NODE_HAS_PROP(inst, int2_gpios)),	\
+		   (LSM6DSV16X_CFG_IRQ(inst)))
 
 #define LSM6DSV16X_CONFIG_SPI(inst)					\
 	{								\


### PR DESCRIPTION
Since lsm6dsv16x may be multi-instantiated, triggers must be enabled and configured on DT basis and not only thru CONFIG_LSM6DSV16X_TRIGGER macro; if either int1-gpios of int2-gpios (or both) are configured in DT, the flag trig_enable is set to 'true' for that instance. The previous implentation was lacking the check of those two Device Tree properties, so trig_enabled was always true for all instances.