### PR TITLE
dt-bindings: sensor: fix typos in ST sensors comment

### DIFF
--- a/dts/bindings/sensor/st,iis2dlpc-common.yaml
+++ b/dts/bindings/sensor/st,iis2dlpc-common.yaml
@@ -3,10 +3,10 @@
 
 description: |
     When setting the odr property in a .dts or .dtsi file you may include
-    st_iis2dlpc.h and use the macros defined there.
+    iis2dlpc.h and use the macros defined there.
 
     Example:
-    #include <zephyr/dt-bindings/sensor/st_iis2dlpc.h>
+    #include <zephyr/dt-bindings/sensor/iis2dlpc.h>
 
     iis2dlpc: iis2dlpc@0 {
       ...

--- a/dts/bindings/sensor/st,iis2iclx-common.yaml
+++ b/dts/bindings/sensor/st,iis2iclx-common.yaml
@@ -3,10 +3,10 @@
 
 description: |
     When setting the range, odr properties in a .dts or .dtsi file you may
-    include st_iis2iclx.h and use the macros defined there.
+    include iis2iclx.h and use the macros defined there.
 
     Example:
-    #include <zephyr/dt-bindings/sensor/st_iis2iclx.h>
+    #include <zephyr/dt-bindings/sensor/iis2iclx.h>
 
     iis2iclx: iis2iclx@0 {
       ...

--- a/dts/bindings/sensor/st,ism330dhcx-common.yaml
+++ b/dts/bindings/sensor/st,ism330dhcx-common.yaml
@@ -3,10 +3,10 @@
 
 description: |
     When setting the accel-odr and gyro-odr properties in a .dts or .dtsi file you may include
-    st_ism330dhcx.h and use the macros defined there.
+    ism330dhcx.h and use the macros defined there.
 
     Example:
-    #include <zephyr/dt-bindings/sensor/st_ism330dhcx.h>
+    #include <zephyr/dt-bindings/sensor/ism330dhcx.h>
 
     ism330dhcx: ism330dhcx@0 {
       ...

--- a/dts/bindings/sensor/st,lis2dh-common.yaml
+++ b/dts/bindings/sensor/st,lis2dh-common.yaml
@@ -3,10 +3,10 @@
 
 description: |
     When setting the int1-gpio-config/int2-gpio-config and anym-mode properties
-    in a .dts or .dtsi file you may include st_lis2dh.h and use the macros defined there.
+    in a .dts or .dtsi file you may include lis2dh.h and use the macros defined there.
 
     Example:
-    #include <zephyr/dt-bindings/sensor/st_lis2dh.h>
+    #include <zephyr/dt-bindings/sensor/lis2dh.h>
 
     lis2dh: lis2dh@0 {
       ...

--- a/dts/bindings/sensor/st,lis2ds12-common.yaml
+++ b/dts/bindings/sensor/st,lis2ds12-common.yaml
@@ -3,10 +3,10 @@
 
 description: |
     When setting the odr and power-mode properties in a .dts or .dtsi file you may include
-    st_lis2ds12.h and use the macros defined there.
+    lis2ds12.h and use the macros defined there.
 
     Example:
-    #include <zephyr/dt-bindings/sensor/st_lis2ds12.h>
+    #include <zephyr/dt-bindings/sensor/lis2ds12.h>
 
     lis2ds12: lis2ds12@0 {
       ...

--- a/dts/bindings/sensor/st,lis2dw12-common.yaml
+++ b/dts/bindings/sensor/st,lis2dw12-common.yaml
@@ -3,10 +3,10 @@
 
 description: |
     When setting the odr property in a .dts or .dtsi file you may include
-    st_lis2dw12.h and use the macros defined there.
+    lis2dw12.h and use the macros defined there.
 
     Example:
-    #include <zephyr/dt-bindings/sensor/st_lis2dw12.h>
+    #include <zephyr/dt-bindings/sensor/lis2dw12.h>
 
     lis2dw12: lis2dw12@0 {
       ...

--- a/dts/bindings/sensor/st,lps22df-common.yaml
+++ b/dts/bindings/sensor/st,lps22df-common.yaml
@@ -3,10 +3,10 @@
 
 description: |
     When setting the odr, lpf, avg properties in a .dts or .dtsi file
-    you may include st_lps22df.h and use the macros defined there.
+    you may include lps22df.h and use the macros defined there.
 
     Example:
-    #include <zephyr/dt-bindings/sensor/st_lps22df.h>
+    #include <zephyr/dt-bindings/sensor/lps22df.h>
 
     lps22df@5d {
       ...

--- a/dts/bindings/sensor/st,lps22hh-common.yaml
+++ b/dts/bindings/sensor/st,lps22hh-common.yaml
@@ -3,10 +3,10 @@
 
 description: |
     When setting the odr property in a .dts or .dtsi file you may include
-    st_lps22hh.h and use the macros defined there.
+    lps22hh.h and use the macros defined there.
 
     Example:
-    #include <zephyr/dt-bindings/sensor/st_lps22hh.h>
+    #include <zephyr/dt-bindings/sensor/lps22hh.h>
 
     lps22hh: lps22hh@0 {
       ...

--- a/dts/bindings/sensor/st,lsm6dso-common.yaml
+++ b/dts/bindings/sensor/st,lsm6dso-common.yaml
@@ -3,11 +3,11 @@
 
 description: |
     When setting the accel-pm, accel-range, accel-odr, gyro-pm, gyro-range,
-    gyro-odr properties in a .dts or .dtsi file you may include st_lsm6dso.h
+    gyro-odr properties in a .dts or .dtsi file you may include lsm6dso.h
     and use the macros defined there.
 
     Example:
-    #include <zephyr/dt-bindings/sensor/st_lsm6dso.h>
+    #include <zephyr/dt-bindings/sensor/lsm6dso.h>
 
     lsm6dso: lsm6dso@0 {
       ...

--- a/dts/bindings/sensor/st,lsm6dso16is-common.yaml
+++ b/dts/bindings/sensor/st,lsm6dso16is-common.yaml
@@ -3,11 +3,11 @@
 
 description: |
     When setting the accel-range, accel-odr, gyro-range, gyro-odr properties in
-    a .dts or .dtsi file you may include st_lsm6dso16is.h and use the macros
+    a .dts or .dtsi file you may include lsm6dso16is.h and use the macros
     defined there.
 
     Example:
-    #include <zephyr/dt-bindings/sensor/st_lsm6dso16is.h>
+    #include <zephyr/dt-bindings/sensor/lsm6dso16is.h>
 
     lsm6dso16is: lsm6dso16is@0 {
       ...

--- a/dts/bindings/sensor/st,lsm6dsv16x-common.yaml
+++ b/dts/bindings/sensor/st,lsm6dsv16x-common.yaml
@@ -3,11 +3,11 @@
 
 description: |
     When setting the accel-range, accel-odr, gyro-range, gyro-odr properties in
-    a .dts or .dtsi file you may include st_lsm6dsv16x.h and use the macros
+    a .dts or .dtsi file you may include lsm6dsv16x.h and use the macros
     defined there.
 
     Example:
-    #include <zephyr/dt-bindings/sensor/st_lsm6dsv16x.h>
+    #include <zephyr/dt-bindings/sensor/lsm6dsv16x.h>
 
     lsm6dsv16x: lsm6dsv16x@0 {
       ...


### PR DESCRIPTION
Fix dt-binding wrong filename in dts comment for ST sensors.