### PR TITLE
tests: drivers: flash: Fix a few test scenarios on nRF52840 DK

### DIFF
--- a/tests/drivers/flash/common/boards/nrf52840dk_mx25r_high_perf.overlay
+++ b/tests/drivers/flash/common/boards/nrf52840dk_mx25r_high_perf.overlay
@@ -1,5 +1,9 @@
 /delete-node/ &qspi;
 
+&gpio0 {
+	gpio-reserved-ranges = <0 2>, <6 1>, <8 3>, <18 6>;
+};
+
 &spi2 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";

--- a/tests/drivers/flash/common/testcase.yaml
+++ b/tests/drivers/flash/common/testcase.yaml
@@ -21,7 +21,7 @@ tests:
       - OVERLAY_CONFIG=boards/nrf52840_flash_qspi.conf
       - DTC_OVERLAY_FILE=boards/nrf52840dk_mx25l51245g.overlay
     harness_config:
-      fixture: external_flash
+      fixture: external_flash_mx25l51245g
     integration_platforms:
       - nrf52840dk_nrf52840
   drivers.flash.common.soc_flash_nrf:
@@ -78,11 +78,15 @@ tests:
     extra_args:
       - OVERLAY_CONFIG=boards/nrf52840dk_flash_spi.conf
       - DTC_OVERLAY_FILE=boards/nrf52840dk_spi_nor.overlay
+    harness_config:
+      fixture: external_flash_mx25v1635f
   drivers.flash.common.spi_nor_wp_hold:
     platform_allow: nrf52840dk_nrf52840
     extra_args:
       - OVERLAY_CONFIG=boards/nrf52840dk_flash_spi.conf
       - DTC_OVERLAY_FILE=boards/nrf52840dk_spi_nor_wp_hold.overlay
+    harness_config:
+      fixture: external_flash_mx25v1635f
   drivers.flash.common.sam0:
     platform_allow:
       - atsamd20_xpro


### PR DESCRIPTION
- tests: drivers: flash: Update nrf52840dk_mx25r_high_perf.overlay
- tests: drivers: flash: Use fixtures for tests requiring external chips

See the commit messages for details.

Fixes #62676.