### PR TITLE
tfm: Remove FP limitations

### DIFF
--- a/arch/arm/core/Kconfig
+++ b/arch/arm/core/Kconfig
@@ -276,8 +276,6 @@ config FP_HARDABI
 	  point instructions are generated and uses FPU-specific calling
 	  conventions.
 
-	  Note: When building with TF-M enabled only the IPC mode is supported.
-
 config FP_SOFTABI
 	bool "Floating point Soft ABI"
 	help

--- a/arch/arm/core/Kconfig
+++ b/arch/arm/core/Kconfig
@@ -268,9 +268,6 @@ choice
 
 config FP_HARDABI
 	bool "Floating point Hard ABI"
-	# TF-M build system does not build the NS app and libraries correctly with Hard ABI.
-	# This limitation should be removed in the next TF-M synchronization.
-	depends on !TFM_BUILD_NS
 	help
 	  This option selects the Floating point ABI in which hardware floating
 	  point instructions are generated and uses FPU-specific calling

--- a/modules/trusted-firmware-m/Kconfig.tfm
+++ b/modules/trusted-firmware-m/Kconfig.tfm
@@ -324,7 +324,6 @@ config TFM_IPC
 
 config TFM_SFN
 	bool "SFN model"
-	depends on !FP_HARDABI
 	help
 	  Use the SFN Model as the SPM backend for the PSA API.
 	  The SFN model supports the SFN Partition model, and isolation level 1.


### PR DESCRIPTION
~~Draft: Checking how many of TF-Ms boards needs to be fixed tfm_ns executable for FP flags.~~

None appears to be built that does not have FP support in NS application.