### PR TITLE
tests/kernel/mem_protect/mem_map: Reduce printf size for qemu_x86_tiny

### DIFF
--- a/tests/kernel/mem_protect/mem_map/testcase.yaml
+++ b/tests/kernel/mem_protect/mem_map/testcase.yaml
@@ -7,7 +7,9 @@ tests:
   kernel.memory_protection.mem_map:
     filter: CONFIG_MMU and not CONFIG_X86_64
     extra_sections: _TRANSPLANTED_FUNC
-    extra_args: CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=0
+    extra_configs:
+      - CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=0
+      - CONFIG_CBPRINTF_REDUCED_INTEGRAL=y
     platform_exclude: qemu_x86_64
     integration_platforms:
       - qemu_x86

--- a/tests/subsys/logging/log_backend_uart/testcase.yaml
+++ b/tests/subsys/logging/log_backend_uart/testcase.yaml
@@ -12,5 +12,9 @@ common:
 tests:
   logging.backend.uart.single:
     extra_args: DTC_OVERLAY_FILE="./single.overlay"
+    extra_configs:
+      - CONFIG_CBPRINTF_REDUCED_INTEGRAL=y
   logging.backend.uart.multi:
     extra_args: DTC_OVERLAY_FILE="./multi.overlay"
+    extra_configs:
+      - CONFIG_CBPRINTF_REDUCED_INTEGRAL=y


### PR DESCRIPTION
When using picolibc before 1.8.5, the only way to get 'long long' support was to use the full version, including floating point support. This is too large for this testcase.

Reduce the size of the printf code by switching to the version without 64-bit integer support. This allows the tests to pass when using older picolibc versions, such as that included with SDK version 0.16.3.

Closes: #65509
Closes: #65511 