### PR TITLE
kernel: mm: only include demand_paging.h if needed

### DIFF
--- a/arch/x86/core/userspace.c
+++ b/arch/x86/core/userspace.c
@@ -11,6 +11,10 @@
 #include <ksched.h>
 #include <x86_mmu.h>
 
+#ifdef CONFIG_DEMAND_PAGING
+#include <zephyr/kernel/mm/demand_paging.h>
+#endif
+
 #ifndef CONFIG_X86_KPTI
 /* Update the to the incoming thread's page table, and update the location of
  * the privilege elevation stack.

--- a/include/zephyr/kernel/mm.h
+++ b/include/zephyr/kernel/mm.h
@@ -14,7 +14,6 @@
 #endif
 
 #include <zephyr/kernel/internal/mm.h>
-#include <zephyr/kernel/mm/demand_paging.h>
 
 /**
  * @brief Kernel Memory Management

--- a/include/zephyr/kernel/thread.h
+++ b/include/zephyr/kernel/thread.h
@@ -8,7 +8,7 @@
 #define ZEPHYR_INCLUDE_KERNEL_THREAD_H_
 
 #ifdef CONFIG_DEMAND_PAGING_THREAD_STATS
-#include <zephyr/kernel/mm.h>
+#include <zephyr/kernel/mm/demand_paging.h>
 #endif
 
 #include <zephyr/kernel/stats.h>

--- a/include/zephyr/sys/arch_interface.h
+++ b/include/zephyr/sys/arch_interface.h
@@ -517,6 +517,8 @@ static inline unsigned int arch_num_cpus(void);
  */
 
 #ifdef CONFIG_USERSPACE
+#include <zephyr/arch/syscall.h>
+
 /**
  * Invoke a system call with 0 arguments.
  *

--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -20,6 +20,10 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
+#ifdef CONFIG_DEMAND_PAGING
+#include <zephyr/kernel/mm/demand_paging.h>
+#endif
+
 /*
  * General terminology:
  * - A page frame is a page-sized physical memory region in RAM. It is a

--- a/kernel/paging/statistics.c
+++ b/kernel/paging/statistics.c
@@ -8,7 +8,7 @@
 #include <kernel_internal.h>
 #include <zephyr/internal/syscall_handler.h>
 #include <zephyr/toolchain.h>
-#include <zephyr/kernel/mm.h>
+#include <zephyr/kernel/mm/demand_paging.h>
 
 extern struct k_mem_paging_stats_t paging_stats;
 

--- a/subsys/demand_paging/backing_store/backing_store_qemu_x86_tiny.c
+++ b/subsys/demand_paging/backing_store/backing_store_qemu_x86_tiny.c
@@ -20,6 +20,7 @@
 #include <kernel_arch_interface.h>
 #include <zephyr/linker/linker-defs.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/kernel/mm/demand_paging.h>
 
 void *location_to_flash(uintptr_t location)
 {

--- a/subsys/demand_paging/backing_store/ram.c
+++ b/subsys/demand_paging/backing_store/ram.c
@@ -8,6 +8,7 @@
 #include <mmu.h>
 #include <string.h>
 #include <kernel_arch_interface.h>
+#include <zephyr/kernel/mm/demand_paging.h>
 
 /*
  * TODO:

--- a/subsys/demand_paging/eviction/nru.c
+++ b/subsys/demand_paging/eviction/nru.c
@@ -10,6 +10,8 @@
 #include <kernel_arch_interface.h>
 #include <zephyr/init.h>
 
+#include <zephyr/kernel/mm/demand_paging.h>
+
 /* The accessed and dirty states of each page frame are used to create
  * a hierarchy with a numerical value. When evicting a page, try to evict
  * page with the highest value (we prefer clean, not accessed pages).

--- a/tests/kernel/fatal/exception/src/main.c
+++ b/tests/kernel/fatal/exception/src/main.c
@@ -18,6 +18,10 @@
 #include "test_syscalls.h"
 #endif
 
+#if defined(CONFIG_DEMAND_PAGING)
+#include <zephyr/kernel/mm/demand_paging.h>
+#endif
+
 #if defined(CONFIG_X86) && defined(CONFIG_X86_MMU)
 #define STACKSIZE (8192)
 #else

--- a/tests/kernel/mem_protect/demand_paging/src/main.c
+++ b/tests/kernel/mem_protect/demand_paging/src/main.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/ztest.h>
 #include <zephyr/kernel/mm.h>
+#include <zephyr/kernel/mm/demand_paging.h>
 #include <zephyr/timing/timing.h>
 #include <mmu.h>
 #include <zephyr/linker/sections.h>


### PR DESCRIPTION
This moves including of demand_paging.h out of kernel/mm.h,
so that users of demand paging APIs must include the header
explicitly. Since the main user is kernel itself, we can be
more discipline about header inclusion.