### PR TITLE
boards: dts: add missing code partition into ESP32 based boards

### DIFF
--- a/boards/riscv/esp32c3_devkitm/esp32c3_devkitm.dts
+++ b/boards/riscv/esp32c3_devkitm/esp32c3_devkitm.dts
@@ -19,6 +19,7 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	aliases {

--- a/boards/riscv/esp32c3_luatos_core/esp32c3_luatos_core.dts
+++ b/boards/riscv/esp32c3_luatos_core/esp32c3_luatos_core.dts
@@ -14,5 +14,6 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 };

--- a/boards/riscv/icev_wireless/icev_wireless.dts
+++ b/boards/riscv/icev_wireless/icev_wireless.dts
@@ -19,6 +19,7 @@
 		zephyr,console = &usb_serial;
 		zephyr,shell-uart = &usb_serial;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	aliases {

--- a/boards/riscv/stamp_c3/stamp_c3.dts
+++ b/boards/riscv/stamp_c3/stamp_c3.dts
@@ -19,6 +19,7 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	aliases {

--- a/boards/riscv/xiao_esp32c3/xiao_esp32c3.dts
+++ b/boards/riscv/xiao_esp32c3/xiao_esp32c3.dts
@@ -19,6 +19,7 @@
 		zephyr,console = &usb_serial;
 		zephyr,shell-uart = &usb_serial;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 		zephyr,canbus = &twai;
 	};
 

--- a/boards/xtensa/esp32_devkitc_wroom/esp32_devkitc_wroom.dts
+++ b/boards/xtensa/esp32_devkitc_wroom/esp32_devkitc_wroom.dts
@@ -34,6 +34,7 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 };
 

--- a/boards/xtensa/esp32_devkitc_wrover/esp32_devkitc_wrover.dts
+++ b/boards/xtensa/esp32_devkitc_wrover/esp32_devkitc_wrover.dts
@@ -34,6 +34,7 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 };
 

--- a/boards/xtensa/esp32_ethernet_kit/esp32_ethernet_kit.dts
+++ b/boards/xtensa/esp32_ethernet_kit/esp32_ethernet_kit.dts
@@ -22,6 +22,7 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 };
 

--- a/boards/xtensa/esp32s2_franzininho/esp32s2_franzininho.dts
+++ b/boards/xtensa/esp32s2_franzininho/esp32s2_franzininho.dts
@@ -25,6 +25,7 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds {

--- a/boards/xtensa/esp32s2_lolin_mini/esp32s2_lolin_mini.dts
+++ b/boards/xtensa/esp32s2_lolin_mini/esp32s2_lolin_mini.dts
@@ -25,6 +25,7 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds {

--- a/boards/xtensa/esp32s2_saola/esp32s2_saola.dts
+++ b/boards/xtensa/esp32s2_saola/esp32s2_saola.dts
@@ -25,6 +25,7 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	gpio_keys {

--- a/boards/xtensa/esp32s3_devkitm/esp32s3_devkitm.dts
+++ b/boards/xtensa/esp32s3_devkitm/esp32s3_devkitm.dts
@@ -23,6 +23,7 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	aliases {

--- a/boards/xtensa/esp32s3_luatos_core/esp32s3_luatos_core.dts
+++ b/boards/xtensa/esp32s3_luatos_core/esp32s3_luatos_core.dts
@@ -25,5 +25,6 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 };

--- a/boards/xtensa/esp_wrover_kit/esp_wrover_kit.dts
+++ b/boards/xtensa/esp_wrover_kit/esp_wrover_kit.dts
@@ -32,6 +32,7 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 		zephyr,display = &ili9341;
 	};
 

--- a/boards/xtensa/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2.dts
+++ b/boards/xtensa/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2.dts
@@ -54,6 +54,7 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 };
 

--- a/boards/xtensa/heltec_wireless_stick_lite_v3/heltec_wireless_stick_lite_v3.dts
+++ b/boards/xtensa/heltec_wireless_stick_lite_v3/heltec_wireless_stick_lite_v3.dts
@@ -71,6 +71,7 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 };
 

--- a/boards/xtensa/m5stack_atoms3/m5stack_atoms3.dts
+++ b/boards/xtensa/m5stack_atoms3/m5stack_atoms3.dts
@@ -19,6 +19,7 @@
 		zephyr,console = &usb_serial;
 		zephyr,shell-uart = &usb_serial;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 		zephyr,display = &st7789v;
 	};
 

--- a/boards/xtensa/m5stickc_plus/m5stickc_plus.dts
+++ b/boards/xtensa/m5stickc_plus/m5stickc_plus.dts
@@ -27,6 +27,7 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds {

--- a/boards/xtensa/odroid_go/odroid_go.dts
+++ b/boards/xtensa/odroid_go/odroid_go.dts
@@ -18,6 +18,7 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 		zephyr,display = &ili9341;
 	};
 

--- a/boards/xtensa/olimex_esp32_evb/olimex_esp32_evb.dts
+++ b/boards/xtensa/olimex_esp32_evb/olimex_esp32_evb.dts
@@ -19,6 +19,7 @@
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	aliases {

--- a/boards/xtensa/xiao_esp32s3/xiao_esp32s3.dts
+++ b/boards/xtensa/xiao_esp32s3/xiao_esp32s3.dts
@@ -19,6 +19,7 @@
 		zephyr,console = &usb_serial;
 		zephyr,shell-uart = &usb_serial;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	aliases {

--- a/boards/xtensa/yd_esp32/yd_esp32.dts
+++ b/boards/xtensa/yd_esp32/yd_esp32.dts
@@ -34,6 +34,7 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 };
 


### PR DESCRIPTION
zephyr,code-partition added to ESP32 based boards dts files