### PR TITLE
doc: zbus: add missing timeout arg for zbus_chan_add/rm_obs funcs

### DIFF
--- a/doc/services/zbus/index.rst
+++ b/doc/services/zbus/index.rst
@@ -763,9 +763,9 @@ following example illustrates the runtime registration usage.
     void thread_entry(void) {
             // ...
             /* Adding the observer to channel chan1 */
-            zbus_chan_add_obs(&chan1, &my_listener);
+            zbus_chan_add_obs(&chan1, &my_listener, K_NO_WAIT);
             /* Removing the observer from channel chan1 */
-            zbus_chan_rm_obs(&chan1, &my_listener);
+            zbus_chan_rm_obs(&chan1, &my_listener, K_NO_WAIT);
 
 
 Samples


### PR DESCRIPTION
zbus_chan_add_obs and zbus_chan_rm_obs functions require a timeout as their third arg.