### PR TITLE
userspace: Additional checks in K_SYSCALL_MEMORY

### DIFF
--- a/include/zephyr/internal/syscall_handler.h
+++ b/include/zephyr/internal/syscall_handler.h
@@ -413,8 +413,9 @@ int k_usermode_string_copy(char *dst, const char *src, size_t maxlen);
  *       functionality in the Zephyr tree.
  */
 #define K_SYSCALL_MEMORY(ptr, size, write) \
-	K_SYSCALL_VERIFY_MSG(arch_buffer_validate((void *)ptr, size, write) \
-			     == 0, \
+	K_SYSCALL_VERIFY_MSG((size >= 0) && !Z_DETECT_POINTER_OVERFLOW(ptr, size) \
+			     && (arch_buffer_validate((void *)ptr, size, write) \
+			     == 0), \
 			     "Memory region %p (size %zu) %s access denied", \
 			     (void *)(ptr), (size_t)(size), \
 			     write ? "write" : "read")


### PR DESCRIPTION
This macros needed additional checks before invoking arch_buffer_validate.

- size can not be less then 0. Some functions invoke this macro using signed type which will be promote to unsigned when invoking  arch_buffer_validate. We need to do an early check.
- We need to check for possible overflow, since a malicious user application could use a negative number that would be promoted to a big value that would cause a integer overflow when adding it to the buffer address, leading to invalid checks.