### PR TITLE
drivers: eth_mcus: Conditionally wrap IPV4/6 code

### DIFF
--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -1163,6 +1163,7 @@ static int eth_init(const struct device *dev)
 	return 0;
 }
 
+#if defined(CONFIG_NET_NATIVE_IPV4) || defined(CONFIG_NET_NATIVE_IPV6)
 static void net_if_mcast_cb(struct net_if *iface,
 			    const struct net_addr *addr,
 			    bool is_joined)
@@ -1185,15 +1186,18 @@ static void net_if_mcast_cb(struct net_if *iface,
 		ENET_LeaveMulticastGroup(context->base, mac_addr.addr);
 	}
 }
+#endif /* CONFIG_NET_NATIVE_IPV4 || CONFIG_NET_NATIVE_IPV6 */
 
 static void eth_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct eth_context *context = dev->data;
 
+#if defined(CONFIG_NET_NATIVE_IPV4) || defined(CONFIG_NET_NATIVE_IPV6)
 	static struct net_if_mcast_monitor mon;
 
 	net_if_mcast_mon_register(&mon, iface, net_if_mcast_cb);
+#endif /* CONFIG_NET_NATIVE_IPV4 || CONFIG_NET_NATIVE_IPV6 */
 
 	net_if_set_link_addr(iface, context->mac_addr,
 			     sizeof(context->mac_addr),


### PR DESCRIPTION
Regression failure introduced problem where driver code was not properly wrapping code that only existed when compiled for IPv4/v6 applications.

Fixes #65549