### PR TITLE
boards: arm: rpi_pico: add pyocd runner configuration

### DIFF
--- a/boards/arm/rpi_pico/board.cmake
+++ b/boards/arm/rpi_pico/board.cmake
@@ -27,8 +27,10 @@ board_runner_args(openocd --cmd-pre-init "set_adapter_speed_if_not_set 2000")
 
 board_runner_args(jlink "--device=RP2040_M0_0")
 board_runner_args(uf2 "--board-id=RPI-RP2")
+board_runner_args(pyocd "--target=rp2040")
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/uf2.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/blackmagicprobe.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)


### PR DESCRIPTION
Adding configuration for support pyocd.

---

Raspberry Pi Pico already has configuration by open source solution with OpenOCD for debugging, but the zephyr-sdk currently contains OpenOCD v0.11, which does not support Raspberry Pi Pico.

I added support for PyOCD that can be used alternatively.

The Raspberry Pi Pico manual describes a way of t using OpenOCD, so I do not change the current default of using OpenOCD.
