### PR TITLE
driver: display: sdl: Introduce SDL_DISPLAY_ZOOM_PCT option to help screen readability

### DIFF
--- a/drivers/display/Kconfig.sdl
+++ b/drivers/display/Kconfig.sdl
@@ -39,4 +39,11 @@ choice SDL_DISPLAY_DEFAULT_PIXEL_FORMAT
 
 endchoice
 
+config SDL_DISPLAY_ZOOM_PCT
+	int "Default zoom percentage"
+	default 100
+	range 10 10000
+	help
+	  SDL window zoom percentage to adjust readability on small screens
+
 endif # SDL_DISPLAY

--- a/drivers/display/display_sdl.c
+++ b/drivers/display/display_sdl.c
@@ -54,8 +54,10 @@ static int sdl_display_init(const struct device *dev)
 #endif /* SDL_DISPLAY_DEFAULT_PIXEL_FORMAT */
 		;
 
-	int rc = sdl_display_init_bottom(config->height, config->width, &disp_data->window,
-					 &disp_data->renderer, &disp_data->texture);
+	int rc = sdl_display_init_bottom(config->height, config->width,
+					 CONFIG_SDL_DISPLAY_ZOOM_PCT,
+					 &disp_data->window, &disp_data->renderer,
+					 &disp_data->texture);
 
 	if (rc != 0) {
 		LOG_ERR("Failed to create SDL display");

--- a/drivers/display/display_sdl_bottom.c
+++ b/drivers/display/display_sdl_bottom.c
@@ -11,12 +11,12 @@
 #include <SDL.h>
 #include "nsi_tracing.h"
 
-int sdl_display_init_bottom(uint16_t height, uint16_t width,
+int sdl_display_init_bottom(uint16_t height, uint16_t width, uint16_t zoom_pct,
 			    void **window, void **renderer, void **texture)
 {
 	*window = SDL_CreateWindow("Zephyr Display", SDL_WINDOWPOS_UNDEFINED,
-				   SDL_WINDOWPOS_UNDEFINED, width,
-				   height, SDL_WINDOW_SHOWN);
+				   SDL_WINDOWPOS_UNDEFINED, width * zoom_pct / 100,
+				   height * zoom_pct / 100, SDL_WINDOW_SHOWN);
 	if (*window == NULL) {
 		nsi_print_warning("Failed to create SDL window: %s", SDL_GetError());
 		return -1;

--- a/drivers/display/display_sdl_bottom.h
+++ b/drivers/display/display_sdl_bottom.h
@@ -20,7 +20,7 @@ extern "C" {
 
 /* Note: None of these functions are public interfaces. But internal to the SDL display driver */
 
-int sdl_display_init_bottom(uint16_t height, uint16_t width,
+int sdl_display_init_bottom(uint16_t height, uint16_t width, uint16_t zoom_pct,
 			    void **window, void **renderer, void **texture);
 void sdl_display_write_bottom(const uint16_t height, const uint16_t width,
 			      const uint16_t x, const uint16_t y,


### PR DESCRIPTION
Hi,

When rendering very low-DPI SDL displays on high-DPI screens, this new configuration item allow to set a zoom factor for the overall Window.