### PR TITLE
boards: riscv: hifive_unmatched: add Renode simulation support

### DIFF
--- a/boards/riscv/hifive_unmatched/board.cmake
+++ b/boards/riscv/hifive_unmatched/board.cmake
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
+set(SUPPORTED_EMU_PLATFORMS renode)
+set(RENODE_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/support/hifive_unmatched.resc)
+set(RENODE_UART sysbus.uart0)
+
 set(OPENOCD_USE_LOAD_IMAGE NO)
 
 board_runner_args(openocd "--config=${BOARD_DIR}/support/openocd_hifive_unmatched.cfg")

--- a/boards/riscv/hifive_unmatched/support/hifive_unmatched.resc
+++ b/boards/riscv/hifive_unmatched/support/hifive_unmatched.resc
@@ -1,0 +1,25 @@
+:description: This script is prepared to run Zephyr on SiFive-FU740 board.
+:name: SiFive-FU740
+
+$name?="SiFive-FU740"
+
+using sysbus
+mach create $name
+
+set platform
+"""
+using "platforms/cpus/sifive-fu740.repl"
+
+clint:
+    frequency: 10000000
+"""
+
+machine LoadPlatformDescriptionFromString $platform
+machine PyDevFromFile @scripts/pydev/flipflop.py 0x10000000 0x100 True
+showAnalyzer uart0
+
+macro reset
+"""
+    sysbus LoadELF $bin
+"""
+runMacro $reset


### PR DESCRIPTION
Add Renode simulation support for `hifive_unmatched`, the script is basically copied over from `hifive_unleashed`, with very minor edits.