### PR TITLE
drivers: i2c: stm32: Fix routing of secondary target address

### DIFF
--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -142,9 +142,19 @@ static void stm32_i2c_slave_event(const struct device *dev)
 			__ASSERT_NO_MSG(0);
 			return;
 		}
+	} else {
+		/* On STM32 the LL_I2C_GetAddressMatchCode & (ISR register) returns
+		 * only 7bits of address match so 10 bit dual addressing is broken.
+		 * Revert to assuming single address match.
+		 */
+		if (data->slave_cfg != NULL) {
+			slave_cfg = data->slave_cfg;
+		} else {
+			__ASSERT_NO_MSG(0);
+			return;
+		}
 	}
 
-	slave_cfg = data->slave_cfg;
 	slave_cb = slave_cfg->callbacks;
 
 	if (LL_I2C_IsActiveFlag_TXIS(i2c)) {


### PR DESCRIPTION
Fixes the routing of the events associated with a secondary i2c target address being routed to the primary config.
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/65527
