### PR TITLE
drivers: console: uart_mcumgr: Skip reading FIFO during setup

### DIFF
--- a/drivers/console/uart_mcumgr.c
+++ b/drivers/console/uart_mcumgr.c
@@ -228,15 +228,8 @@ static void uart_mcumgr_setup(const struct device *uart)
 #else
 static void uart_mcumgr_setup(const struct device *uart)
 {
-	uint8_t c;
-
 	uart_irq_rx_disable(uart);
 	uart_irq_tx_disable(uart);
-
-	/* Drain the fifo */
-	while (uart_fifo_read(uart, &c, 1)) {
-		continue;
-	}
 
 	uart_irq_callback_set(uart, uart_mcumgr_isr);
 


### PR DESCRIPTION
Drops calling the UART FIFO read function during the setup function (when not in async mode) which could cause issues on some devices since this function is not called in an ISR.