### PR TITLE
boards: nrf9131ek and nrf9161dk: update readme to emphasize nr-plus

### DIFF
--- a/boards/arm/nrf9131ek_nrf9131/doc/index.rst
+++ b/boards/arm/nrf9131ek_nrf9131/doc/index.rst
@@ -6,7 +6,8 @@ nRF9131 EK
 Overview
 ********
 
-The nRF9131 EK (PCA10165) is a single-board evaluation kit for the nRF9131 SiP for LTE-M and NB-IoT.
+The nRF9131 EK (PCA10165) is a single-board evaluation kit for the nRF9131 SiP
+for DECT NR+ and LTE-M/NB-IoT with GNSS.
 The nrf9131ek_nrf9131 board configuration provides support for the Nordic Semiconductor nRF9131 ARM
 Cortex-M33F CPU with ARMv8-M Security Extension and the following devices:
 

--- a/boards/arm/nrf9161dk_nrf9161/doc/index.rst
+++ b/boards/arm/nrf9161dk_nrf9161/doc/index.rst
@@ -7,7 +7,7 @@ Overview
 ********
 
 The nRF9161 DK (PCA10153) is a single-board development kit for evaluation and
-development on the nRF9161 SiP for LTE-M and NB-IoT. The nrf9161dk_nrf9161
+development on the nRF9161 SiP for DECT NR+ and LTE-M/NB-IoT with GNSS. The nrf9161dk_nrf9161
 board configuration provides support for the Nordic Semiconductor nRF9161 ARM
 Cortex-M33F CPU with ARMv8-M Security Extension and the following devices:
 


### PR DESCRIPTION
This patch changes readme files of nRF91x1 dev kits to highlight their added NR+ feature.