### PR TITLE
drivers: i2c: stm32: fix compilation for PM_DEVICE_RUNTIME

### DIFF
--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -62,20 +62,19 @@ int i2c_stm32_runtime_configure(const struct device *dev, uint32_t config)
 {
 	const struct i2c_stm32_config *cfg = dev->config;
 	struct i2c_stm32_data *data = dev->data;
+	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 	I2C_TypeDef *i2c = cfg->i2c;
 	uint32_t i2c_clock = 0U;
 	int ret;
 
 	if (IS_ENABLED(STM32_I2C_DOMAIN_CLOCK_SUPPORT) && (cfg->pclk_len > 1)) {
-		if (clock_control_get_rate(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-					   (clock_control_subsys_t)&cfg->pclken[1],
+		if (clock_control_get_rate(clk, (clock_control_subsys_t)&cfg->pclken[1],
 					   &i2c_clock) < 0) {
 			LOG_ERR("Failed call clock_control_get_rate(pclken[1])");
 			return -EIO;
 		}
 	} else {
-		if (clock_control_get_rate(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-					   (clock_control_subsys_t) &cfg->pclken[0],
+		if (clock_control_get_rate(clk, (clock_control_subsys_t)&cfg->pclken[0],
 					   &i2c_clock) < 0) {
 			LOG_ERR("Failed call clock_control_get_rate(pclken[0])");
 			return -EIO;


### PR DESCRIPTION
Added clk variable which is needed when CONFIG_PM_DEVICE_RUNTIME is enabled.

Fixing the following compilation error:
```
zephyr/drivers/i2c/i2c_ll_stm32.c
zephyr/drivers/i2c/i2c_ll_stm32.c: In function 'i2c_stm32_runtime_configure':
zephyr/drivers/i2c/i2c_ll_stm32.c:90:32: error: 'clk' undeclared (first use in this function)
   90 |         ret = clock_control_on(clk, (clock_control_subsys_t)&cfg->pclken[0]);
```