### PR TITLE
boards: sam_e70_xplained: added default pin config for additional 3 qdecs

### DIFF
--- a/boards/arm/sam_e70_xplained/sam_e70_xplained-pinctrl.dtsi
+++ b/boards/arm/sam_e70_xplained/sam_e70_xplained-pinctrl.dtsi
@@ -83,6 +83,27 @@
 		};
 	};
 
+	tc1_qdec_default: tc1_qdec_default {
+		group1 {
+			pinmux = <PC23B_TC1_TIOA3>,
+				 <PC24B_TC1_TIOB3>;
+		};
+	};
+
+	tc2_qdec_default: tc2_qdec_default {
+		group1 {
+			pinmux = <PC5B_TC2_TIOA6>,
+				 <PC6B_TC2_TIOB6>;
+		};
+	};
+
+	tc3_qdec_default: tc3_qdec_default {
+		group1 {
+			pinmux = <PE0B_TC3_TIOA9>,
+				 <PE1B_TC3_TIOB9>;
+		};
+	};
+
 	twihs0_default: twihs0_default {
 		group1 {
 			pinmux = <PA4A_TWI0_TWCK>,

--- a/boards/arm/sam_e70_xplained/sam_e70_xplained.dts
+++ b/boards/arm/sam_e70_xplained/sam_e70_xplained.dts
@@ -23,3 +23,27 @@
 	pinctrl-0 = <&tc0_qdec_default>;
 	pinctrl-names = "default";
 };
+
+&tc1 {
+	status = "disabled";
+	compatible = "atmel,sam-tc-qdec";
+
+	pinctrl-0 = <&tc1_qdec_default>;
+	pinctrl-names = "default";
+};
+
+&tc2 {
+	status = "disabled";
+	compatible = "atmel,sam-tc-qdec";
+
+	pinctrl-0 = <&tc2_qdec_default>;
+	pinctrl-names = "default";
+};
+
+&tc3 {
+	status = "disabled";
+	compatible = "atmel,sam-tc-qdec";
+
+	pinctrl-0 = <&tc3_qdec_default>;
+	pinctrl-names = "default";
+};


### PR DESCRIPTION
this is relates to [issue #65610](https://github.com/zephyrproject-rtos/zephyr/issues/65610)