### PR TITLE
boards: Use unique names for boards in the YAML files

### DIFF
--- a/boards/arc/emsdp/emsdp.yaml
+++ b/boards/arc/emsdp/emsdp.yaml
@@ -1,5 +1,5 @@
 identifier: emsdp
-name: EM Software Development Platform
+name: EM Software Development Platform (EM11D)
 type: mcu
 arch: arc
 toolchain:

--- a/boards/arc/emsdp/emsdp_em4.yaml
+++ b/boards/arc/emsdp/emsdp_em4.yaml
@@ -1,5 +1,5 @@
 identifier: emsdp_em4
-name: EM Software Development Platform
+name: EM Software Development Platform (EM4)
 type: mcu
 arch: arc
 toolchain:

--- a/boards/arc/emsdp/emsdp_em5d.yaml
+++ b/boards/arc/emsdp/emsdp_em5d.yaml
@@ -1,5 +1,5 @@
 identifier: emsdp_em5d
-name: EM Software Development Platform
+name: EM Software Development Platform (EM5D)
 type: mcu
 arch: arc
 toolchain:

--- a/boards/arc/emsdp/emsdp_em6.yaml
+++ b/boards/arc/emsdp/emsdp_em6.yaml
@@ -1,5 +1,5 @@
 identifier: emsdp_em6
-name: EM Software Development Platform
+name: EM Software Development Platform (EM6)
 type: mcu
 arch: arc
 toolchain:

--- a/boards/arc/emsdp/emsdp_em7d.yaml
+++ b/boards/arc/emsdp/emsdp_em7d.yaml
@@ -1,5 +1,5 @@
 identifier: emsdp_em7d
-name: EM Software Development Platform
+name: EM Software Development Platform (EM7D)
 type: mcu
 arch: arc
 toolchain:

--- a/boards/arc/emsdp/emsdp_em7d_esp.yaml
+++ b/boards/arc/emsdp/emsdp_em7d_esp.yaml
@@ -1,5 +1,5 @@
 identifier: emsdp_em7d_esp
-name: EM Software Development Platform
+name: EM Software Development Platform (EM7D_ESP)
 type: mcu
 arch: arc
 toolchain:

--- a/boards/arc/emsdp/emsdp_em9d.yaml
+++ b/boards/arc/emsdp/emsdp_em9d.yaml
@@ -1,5 +1,5 @@
 identifier: emsdp_em9d
-name: EM Software Development Platform
+name: EM Software Development Platform (EM9D)
 type: mcu
 arch: arc
 toolchain:

--- a/boards/arc/nsim/nsim_em7d_v22.yaml
+++ b/boards/arc/nsim/nsim_em7d_v22.yaml
@@ -1,5 +1,5 @@
 identifier: nsim_em7d_v22
-name: EM Nsim simulator
+name: EM nSIM simulator (EM7D_v22)
 type: sim
 simulation: nsim
 simulation_exec: nsimdrv

--- a/boards/arc/nsim/nsim_hs5x_smp_12cores.yaml
+++ b/boards/arc/nsim/nsim_hs5x_smp_12cores.yaml
@@ -1,5 +1,5 @@
 identifier: nsim_hs5x_smp_12cores
-name: Multi-core HS5x nSIM simulator
+name: Multi-core HS5x nSIM simulator (12 cores)
 type: sim
 simulation: mdb-nsim
 simulation_exec: mdb

--- a/boards/arc/nsim/nsim_hs6x_smp_12cores.yaml
+++ b/boards/arc/nsim/nsim_hs6x_smp_12cores.yaml
@@ -1,5 +1,5 @@
 identifier: nsim_hs6x_smp_12cores
-name: Multi-core HS6x nSIM simulator
+name: Multi-core HS6x nSIM simulator (12 cores)
 type: sim
 simulation: mdb-nsim
 simulation_exec: mdb

--- a/boards/arc/nsim/nsim_hs_flash_xip.yaml
+++ b/boards/arc/nsim/nsim_hs_flash_xip.yaml
@@ -1,5 +1,5 @@
 identifier: nsim_hs_flash_xip
-name: HS nSIM simulator
+name: HS nSIM simulator (FLASH XIP)
 type: sim
 simulation: nsim
 simulation_exec: nsimdrv

--- a/boards/arc/nsim/nsim_hs_sram.yaml
+++ b/boards/arc/nsim/nsim_hs_sram.yaml
@@ -1,5 +1,5 @@
 identifier: nsim_hs_sram
-name: HS nSIM simulator
+name: HS nSIM simulator (SRAM)
 type: sim
 simulation: nsim
 simulation_exec: nsimdrv

--- a/boards/arc/nsim/nsim_sem_mpu_stack_guard.yaml
+++ b/boards/arc/nsim/nsim_sem_mpu_stack_guard.yaml
@@ -1,5 +1,5 @@
 identifier: nsim_sem_mpu_stack_guard
-name: SEM Nsim simulator
+name: SEM nSIM simulator (stack guard)
 type: sim
 arch: arc
 simulation: nsim

--- a/boards/arc/qemu_arc/qemu_arc_hs6x.yaml
+++ b/boards/arc/qemu_arc/qemu_arc_hs6x.yaml
@@ -1,5 +1,5 @@
 identifier: qemu_arc_hs6x
-name: QEMU Emulation for ARC HS
+name: QEMU Emulation for ARC HS6x
 type: qemu
 simulation: qemu
 arch: arc

--- a/boards/arc/qemu_arc/qemu_arc_hs_xip.yaml
+++ b/boards/arc/qemu_arc/qemu_arc_hs_xip.yaml
@@ -1,5 +1,5 @@
 identifier: qemu_arc_hs_xip
-name: QEMU Emulation for ARC HS
+name: QEMU Emulation for ARC HS (XIP)
 type: qemu
 simulation: qemu
 arch: arc

--- a/boards/arm/fvp_baser_aemv8r_aarch32/fvp_baser_aemv8r_aarch32_smp.yaml
+++ b/boards/arm/fvp_baser_aemv8r_aarch32/fvp_baser_aemv8r_aarch32_smp.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 identifier: fvp_baser_aemv8r_aarch32_smp
-name: FVP Emulation FVP_BaseR_AEMv8R AArch32
+name: FVP Emulation FVP_BaseR_AEMv8R AArch32 (SMP)
 arch: arm
 type: sim
 toolchain:

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_rtu0_r52_D.yaml
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_rtu0_r52_D.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 identifier: s32z270dc2_rtu0_r52@D
-name: NXP X-S32Z270-DC (DC2) on RTU0 Cortex-R52 cores
+name: NXP X-S32Z270-DC (DC2) on RTU0 Cortex-R52 cores (rev. D)
 type: mcu
 arch: arm
 ram: 1024

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_rtu1_r52_D.yaml
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_rtu1_r52_D.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 identifier: s32z270dc2_rtu1_r52@D
-name: NXP X-S32Z270-DC (DC2) on RTU1 Cortex-R52 cores
+name: NXP X-S32Z270-DC (DC2) on RTU1 Cortex-R52 cores (rev. D)
 type: mcu
 arch: arm
 ram: 1024

--- a/boards/arm64/fvp_base_revc_2xaemv8a/fvp_base_revc_2xaemv8a_smp_ns.yaml
+++ b/boards/arm64/fvp_base_revc_2xaemv8a/fvp_base_revc_2xaemv8a_smp_ns.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 identifier: fvp_base_revc_2xaemv8a_smp_ns
-name: FVP Emulation FVP_Base_RevC-2xAEMvA
+name: FVP Emulation FVP_Base_RevC-2xAEMvA (SMP)
 arch: arm64
 type: sim
 toolchain:

--- a/boards/arm64/fvp_baser_aemv8r/fvp_baser_aemv8r_smp.yaml
+++ b/boards/arm64/fvp_baser_aemv8r/fvp_baser_aemv8r_smp.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 identifier: fvp_baser_aemv8r_smp
-name: FVP Emulation FVP_BaseR_AEMv8R
+name: FVP Emulation FVP_BaseR_AEMv8R (SMP)
 arch: arm64
 type: sim
 toolchain:

--- a/boards/mips/qemu_malta/qemu_malta.yaml
+++ b/boards/mips/qemu_malta/qemu_malta.yaml
@@ -1,5 +1,5 @@
 identifier: qemu_malta
-name: QEMU emulation for MIPS
+name: QEMU emulation for MIPS (little endian)
 type: qemu
 simulation: qemu
 arch: mips

--- a/boards/mips/qemu_malta/qemu_malta_be.yaml
+++ b/boards/mips/qemu_malta/qemu_malta_be.yaml
@@ -1,5 +1,5 @@
 identifier: qemu_malta_be
-name: QEMU emulation for MIPS
+name: QEMU emulation for MIPS (big endian)
 type: qemu
 simulation: qemu
 arch: mips


### PR DESCRIPTION
There are duplicated names specified in per-board YAML files. This change will allow distinguishing boards in software that presents the pretty names and not the raw names of boards.