### PR TITLE
posix: sys: fix missing include to `_timeval.h` in native_sim

### DIFF
--- a/include/zephyr/posix/sys/select.h
+++ b/include/zephyr/posix/sys/select.h
@@ -6,8 +6,8 @@
 #ifndef ZEPHYR_INCLUDE_POSIX_SYS_SELECT_H_
 #define ZEPHYR_INCLUDE_POSIX_SYS_SELECT_H_
 
+#include <zephyr/net/socket_types.h>
 #include <zephyr/net/socket_select.h>
-#include <sys/_timeval.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
`zephyr/net/socket_types.h` file also includes `_timeval.h`, but it uses correct path/filename depending on configuration.