### PR TITLE
valgrind: Update `POSIX soc no cpu cleanup` suppression

### DIFF
--- a/scripts/valgrind.supp
+++ b/scripts/valgrind.supp
@@ -18,7 +18,7 @@
 {
    POSIX soc no cpu cleanup
    Memcheck:Leak
-   match-leak-kinds: reachable
+   match-leak-kinds: reachable,possible
    ...
    fun:posix_boot_cpu
    ...


### PR DESCRIPTION
Add `possible` to match-leak-kinds to prevent false positives caused by POSIX soc no cpu cleanup.

The leak can be reproduced by adding CONFIG_NETWORKING=y to tests/lib/cpp/libcxx/prj.conf and run twister:
twister -p native_sim -s tests/lib/cpp/libcxx/cpp.libcxx.host --enable-valgrind