### PR TITLE
subsys: zbus: add MULTITHREADING dependency

### DIFF
--- a/subsys/zbus/Kconfig
+++ b/subsys/zbus/Kconfig
@@ -3,6 +3,7 @@
 
 menuconfig ZBUS
 	bool "Zbus support"
+	depends on MULTITHREADING
 	help
 	  Enables support for Zephyr message bus.
 


### PR DESCRIPTION
Zbus uses mutexes internally that are available only when MULTITHREADING is enabled so add it to fix the following error:

<pre>
/opt/zephyr-sdk-0.16.3/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/../../../../arm-zephyr-eabi/bin/ld.bfd: zephyr/subsys/zbus/libsubsys__zbus.a(zbus.c.obj): in function `k_mutex_init':
/builds/zephyr/mcuboot/zephyr/include/generated/syscalls/kernel.h:969: undefined reference to `z_impl_k_mutex_init'
</pre>