### PR TITLE
drivers: gpio: xlnx_axi: fix polling mode

### DIFF
--- a/drivers/gpio/gpio_xlnx_axi.c
+++ b/drivers/gpio/gpio_xlnx_axi.c
@@ -260,39 +260,26 @@ static int gpio_xlnx_axi_pin_interrupt_configure(const struct device *dev, gpio_
 
 	irq_unlock(key);
 	return 0;
-#else
-	ARG_UNUSED(dev);
-	ARG_UNUSED(pin);
-	ARG_UNUSED(mode);
-	ARG_UNUSED(trig);
-
-	return -ENOTSUP;
-#endif
 }
+#endif
 
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(interrupts)
 static int gpio_xlnx_axi_manage_callback(const struct device *dev, struct gpio_callback *callback,
 					 bool set)
 {
-#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(interrupts)
 	struct gpio_xlnx_axi_data *data = dev->data;
 
 	return gpio_manage_callback(&data->callbacks, callback, set);
-#else
-	ARG_UNUSED(dev);
-	ARG_UNUSED(callback);
-	ARG_UNUSED(set);
-
-	return -ENOTSUP;
-#endif
 }
+#endif
 
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(interrupts)
 /**
  * Returns the pins on this devices channel which changed and also have an interrupt enabled on that
  * pin. Also clears the pending interrupt for that channel.
  */
 static uint32_t gpio_xlnx_axi_get_pending_int(const struct device *dev)
 {
-#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(interrupts)
 	const struct gpio_xlnx_axi_config *config = dev->config;
 	struct gpio_xlnx_axi_data *data = dev->data;
 	const uint32_t chan_mask = BIT(config->channel);
@@ -328,12 +315,8 @@ static uint32_t gpio_xlnx_axi_get_pending_int(const struct device *dev)
 
 	irq_unlock(key);
 	return interrupts;
-#else
-	ARG_UNUSED(dev);
-
-	return 0;
-#endif
 }
+#endif
 
 #if DT_ANY_INST_HAS_PROP_STATUS_OKAY(interrupts)
 static void gpio_xlnx_axi_isr(const struct device *dev)


### PR DESCRIPTION
Fix compiler errors and warnings that are issued when compiling this driver for use without the optional interrupt facilities.

When interrupts are not enabled for any instance of this device, there's currently a compiler error in gpio_xlnx_axi_pin_interrupt_configure due to the function's header being located within the ifdef-block for interrupt-driven operation.

Fully encapsulate the interrupt-related functions gpio_xlnx_axi_pin_interrupt_configure, gpio_xlnx_axi_manage_callback and gpio_xlnx_axi_get_pending_int with ifdefs checking for interrupt mode in order to remove compiler warnings caused by those functions being always present so far, while not being used in the API function pointer table when all instances of this GPIO controller are operating in polling mode. This circumstance causes a "declared, but not used" compiler warning for each of those functions.