### PR TITLE
samples: chre: Fix format strings for size_t types

### DIFF
--- a/samples/modules/chre/src/main.cpp
+++ b/samples/modules/chre/src/main.cpp
@@ -37,12 +37,12 @@ int main(void)
 		k_msleep(100);
 	}
 	printk("Starting EchoApp... %s\n", boolToString(eventLoop.startNanoapp(echo_app)));
-	printk("Nanoapp count=%u\n", eventLoop.getNanoappCount());
+	printk("Nanoapp count=%zu\n", eventLoop.getNanoappCount());
 	printk("Finding instance ID... %s\n", boolToString(eventLoop.findNanoappInstanceIdByAppId(1, &instanceId)));
-	printk("Nanoapp count=%u\n", eventLoop.getNanoappCount());
+	printk("Nanoapp count=%zu\n", eventLoop.getNanoappCount());
 	printk("Instance ID: %u\n", instanceId);
 
-	printk("Sending event %u...\n", eventLoop.getNanoappCount());
+	printk("Sending event %zu...\n", eventLoop.getNanoappCount());
 	eventLoop.postEventOrDie(CHRE_EVENT_MESSAGE_FROM_HOST, nullptr, [](uint16_t eventType, void *eventData) {
 		printk("Event (%u) complete!\n", eventType);
 	});


### PR DESCRIPTION
The correct printf format specifier for size_t is %zu. Without this change the sample generates warnings like this:

warning: format '%u' expects argument of type 'unsigned int', but argument 2 has type 'size_t' {aka 'long unsigned int'} [-Wformat=]