### PR TITLE
Bluetooth: Mesh: allocate tx buffer number in Host to send max size mesh provisioning frame over gatt

### DIFF
--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -33,6 +33,7 @@ config BT_BUF_ACL_TX_SIZE
 config BT_BUF_ACL_TX_COUNT
 	int "Number of outgoing ACL data buffers"
 	default 7 if BT_HCI_RAW
+	default 4 if BT_MESH_GATT
 	default 3
 	range 1 255
 	help


### PR DESCRIPTION
Since sending of public key was moved into system
work (https://github.com/zephyrproject-rtos/zephyr/pull/62331) it uses the same context as a Host Tx buffer
allocator for gatt sending. Host cannot wait for
free buffer anymore. Mesh requires 4 buffers
to send max size frame(public key) during
provisioning.

PR fixes broken PTS test: MESH/NODE/MPS/BV-10-C