### PR TITLE
tests: build_all: sensor: fix i2c duplicate address

### DIFF
--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -854,7 +854,7 @@ test_i2c_lps22df: lps22df@79 {
 	avg = <LPS22DF_DT_AVG_128_SAMPLES>;
 };
 
-test_i2c_hs300x: hs300x@79 {
+test_i2c_hs300x: hs300x@7a {
 	compatible = "renesas,hs300x";
-	reg = <0x79>;
+	reg = <0x7a>;
 };


### PR DESCRIPTION
Fix address for hs300x driver in dts file for test.