### PR TITLE
twister: tests: Refactor and expand testing scopes

### DIFF
--- a/tests/test_config.yaml
+++ b/tests/test_config.yaml
@@ -10,6 +10,9 @@ levels:
       - kernel.timer.behavior
       - arch.interrupt
       - boards.*
+      - drivers.gpio.1pin
+      - drivers.console.uart
+      - drivers.entropy
   - name: acceptance
     description: >
       More coverage

--- a/tests/test_config.yaml
+++ b/tests/test_config.yaml
@@ -13,7 +13,7 @@ levels:
   - name: acceptance
     description: >
       More coverage
+    inherits:
+      - smoke
     adds:
       - kernel.*
-      - arch.interrupt
-      - boards.*


### PR DESCRIPTION
Minor changes to the test_config.yaml. Switch to inheritance instead of repeating the scope and extend the scope with some generic driver tests