### PR TITLE
Bluetooth: Mesh: Add randomization to PB-ADV

### DIFF
--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -231,6 +231,13 @@ config BT_MESH_PB_ADV_RETRANS_TIMEOUT
 	help
 	  Timeout value of retransmit provisioning PDUs.
 
+config BT_MESH_PB_ADV_DELAYABLE_ADV_COUNT
+	int "Number of randomly delayed generic provisioning PDUs"
+	default 4
+	help
+	  The maximum number of generic provisioning PDUs that can be delayed at
+	  the same time.
+
 endif # BT_MESH_PB_ADV
 
 if BT_CONN

--- a/tests/bsim/bluetooth/mesh/src/test_provision.c
+++ b/tests/bsim/bluetooth/mesh/src/test_provision.c
@@ -657,7 +657,7 @@ static void test_device_pb_adv_reprovision(void)
 	for (int i = 0; i < PROV_REPROV_COUNT; i++) {
 		/* Keep a long timeout so the prov multi case has time to finish: */
 		LOG_INF("Dev prov loop #%d, waiting for prov ...\n", i);
-		ASSERT_OK(k_sem_take(&prov_sem, K_SECONDS(20)));
+		ASSERT_OK(k_sem_take(&prov_sem, K_SECONDS(25)));
 	}
 
 	PASS();


### PR DESCRIPTION
Add randomization to PB-ADV to follow the shall statement regrading randomization and spacing Generic Provisioning PDUs and Acks (MshPRT v1.1, section 5.3.3).