### PR TITLE
sensor: mchp_tach_xec: drop PM_DEVICE guards

### DIFF
--- a/drivers/sensor/mchp_tach_xec/tach_mchp_xec.c
+++ b/drivers/sensor/mchp_tach_xec/tach_mchp_xec.c
@@ -22,9 +22,7 @@
 #include <zephyr/logging/log.h>
 
 #include <zephyr/pm/device.h>
-#ifdef CONFIG_PM_DEVICE
 #include <zephyr/pm/policy.h>
-#endif
 
 LOG_MODULE_REGISTER(tach_xec, CONFIG_SENSOR_LOG_LEVEL);
 


### PR DESCRIPTION
Repro: `west build -p -b mec15xxevb_assy6853 -T samples/sensor/sensor_shell/sample.sensor.shell`

---

These are not needed and are now causing build errors since the pm_device calls are always there and need the header to become a no-op.