### PR TITLE
drivers: console: Small Kconfig fixes for Xtensa

### DIFF
--- a/drivers/console/Kconfig
+++ b/drivers/console/Kconfig
@@ -222,6 +222,7 @@ endif # UART_MCUMGR
 config XTENSA_SIM_CONSOLE
 	bool "Use Xtensa simulator console"
 	depends on SIMULATOR_XTENSA
+	depends on !WINSTREAM_CONSOLE
 	select CONSOLE_HAS_DRIVER
 	default y
 	help

--- a/drivers/console/Kconfig
+++ b/drivers/console/Kconfig
@@ -341,6 +341,7 @@ config EFI_CONSOLE
 config WINSTREAM_CONSOLE
 	bool "Use Winstream console"
 	depends on WINSTREAM
+	select CONSOLE_HAS_DRIVER
 	help
 	  Use winstream as a console.
 


### PR DESCRIPTION
- Fix dependencies for simulator console and winstream 
- Selects CONSOLE_HAS_DRIVER when using winstream console