### PR TITLE
posix: pthread: implement pthread_atfork()

### DIFF
--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -17,7 +17,7 @@ multiple processes.
    :header: API, Supported
    :widths: 50,10
 
-    pthread_atfork(),
+    pthread_atfork(),yes
     pthread_attr_destroy(),yes
     pthread_attr_getdetachstate(),yes
     pthread_attr_getschedparam(),yes

--- a/include/zephyr/posix/pthread.h
+++ b/include/zephyr/posix/pthread.h
@@ -473,6 +473,7 @@ int pthread_key_create(pthread_key_t *key,
 int pthread_key_delete(pthread_key_t key);
 int pthread_setspecific(pthread_key_t key, const void *value);
 void *pthread_getspecific(pthread_key_t key);
+int pthread_atfork(void (*prepare)(void), void (*parent)(void), void (*child)(void));
 
 /* Glibc / Oracle Extension Functions */
 

--- a/lib/posix/pthread.c
+++ b/lib/posix/pthread.c
@@ -954,6 +954,15 @@ int pthread_getname_np(pthread_t thread, char *name, size_t len)
 #endif
 }
 
+int pthread_atfork(void (*prepare)(void), void (*parent)(void), void (*child)(void))
+{
+	ARG_UNUSED(prepare);
+	ARG_UNUSED(parent);
+	ARG_UNUSED(child);
+
+	return ENOSYS;
+}
+
 static int posix_thread_pool_init(void)
 {
 	size_t i;

--- a/tests/posix/headers/src/pthread_h.c
+++ b/tests/posix/headers/src/pthread_h.c
@@ -60,7 +60,7 @@ ZTEST(posix_headers, test_pthread_h)
 	/* pthread_rwlock_t lock = PTHREAD_RWLOCK_INITIALIZER; */ /* not implemented */
 
 	if (IS_ENABLED(CONFIG_POSIX_API)) {
-		/* zassert_not_null(pthread_atfork); */ /* not implemented */
+		zassert_not_null(pthread_atfork);
 		zassert_not_null(pthread_attr_destroy);
 		zassert_not_null(pthread_attr_getdetachstate);
 		/* zassert_not_null(pthread_attr_getguardsize); */ /* not implemented */


### PR DESCRIPTION
pthread_atfork() is required by the POSIX_THREADS_BASE Option Group as detailed in Section E.1 of IEEE-1003.1-2017.

The POSIX_THREADS_BASE Option Group is required for PSE51, PSE52, PSE53, and PSE54 conformance, and is otherwise mandatory for any POSIX conforming system as per Section A.2.1.3 of IEEE-1003-1.2017.

Since Zephyr does not yet support processes and (by extension) fork(), this implementation includes a deviation and should be categorized as producing undefined behaviour.

Fixes #59934