### PR TITLE
tests: posix: headers: ensure defined constants are tested

### DIFF
--- a/include/zephyr/posix/pthread.h
+++ b/include/zephyr/posix/pthread.h
@@ -30,6 +30,7 @@ extern "C" {
 #define PTHREAD_PROCESS_SHARED  1
 
 /* Pthread cancellation */
+#define PTHREAD_CANCELED        ((void *)-1)
 #define _PTHREAD_CANCEL_POS	0
 #define PTHREAD_CANCEL_ENABLE	(0U << _PTHREAD_CANCEL_POS)
 #define PTHREAD_CANCEL_DISABLE	BIT(_PTHREAD_CANCEL_POS)

--- a/include/zephyr/posix/pthread.h
+++ b/include/zephyr/posix/pthread.h
@@ -30,10 +30,9 @@ extern "C" {
 #define PTHREAD_PROCESS_SHARED  1
 
 /* Pthread cancellation */
-#define PTHREAD_CANCELED        ((void *)-1)
-#define _PTHREAD_CANCEL_POS	0
-#define PTHREAD_CANCEL_ENABLE	(0U << _PTHREAD_CANCEL_POS)
-#define PTHREAD_CANCEL_DISABLE	BIT(_PTHREAD_CANCEL_POS)
+#define PTHREAD_CANCELED       ((void *)-1)
+#define PTHREAD_CANCEL_ENABLE  0
+#define PTHREAD_CANCEL_DISABLE 1
 
 /* Passed to pthread_once */
 #define PTHREAD_ONCE_INIT                                                                          \

--- a/lib/posix/pthread.c
+++ b/lib/posix/pthread.c
@@ -25,8 +25,7 @@ LOG_MODULE_REGISTER(pthread, CONFIG_PTHREAD_LOG_LEVEL);
 #define DYNAMIC_STACK_SIZE 0
 #endif
 
-#define PTHREAD_INIT_FLAGS	PTHREAD_CANCEL_ENABLE
-#define PTHREAD_CANCELED	((void *) -1)
+#define PTHREAD_INIT_FLAGS PTHREAD_CANCEL_ENABLE
 
 enum posix_thread_qid {
 	/* ready to be started via pthread_create() */

--- a/lib/posix/pthread.c
+++ b/lib/posix/pthread.c
@@ -16,6 +16,7 @@
 #include <zephyr/sys/atomic.h>
 #include <zephyr/posix/pthread.h>
 #include <zephyr/sys/slist.h>
+#include <zephyr/sys/util.h>
 
 LOG_MODULE_REGISTER(pthread, CONFIG_PTHREAD_LOG_LEVEL);
 
@@ -24,6 +25,8 @@ LOG_MODULE_REGISTER(pthread, CONFIG_PTHREAD_LOG_LEVEL);
 #else
 #define DYNAMIC_STACK_SIZE 0
 #endif
+
+#define _pthread_cancel_pos LOG2(PTHREAD_CANCEL_DISABLE)
 
 #define PTHREAD_INIT_FLAGS PTHREAD_CANCEL_ENABLE
 
@@ -406,7 +409,7 @@ int pthread_create(pthread_t *th, const pthread_attr_t *_attr, void *(*threadrou
 		sys_dlist_append(&run_q, &t->q_node);
 		t->qid = POSIX_THREAD_RUN_Q;
 		t->detachstate = attr->detachstate;
-		if ((BIT(_PTHREAD_CANCEL_POS) & attr->flags) != 0) {
+		if ((BIT(_pthread_cancel_pos) & attr->flags) != 0) {
 			t->cancel_state = PTHREAD_CANCEL_ENABLE;
 		}
 		t->cancel_pending = false;

--- a/lib/posix/pthread.c
+++ b/lib/posix/pthread.c
@@ -135,6 +135,11 @@ pthread_t pthread_self(void)
 	return mark_pthread_obj_initialized(bit);
 }
 
+int pthread_equal(pthread_t pt1, pthread_t pt2)
+{
+	return (pt1 == pt2);
+}
+
 static bool is_posix_policy_prio_valid(uint32_t priority, int policy)
 {
 	if (priority >= sched_get_priority_min(policy) &&
@@ -964,10 +969,4 @@ static int posix_thread_pool_init(void)
 
 	return 0;
 }
-
-int pthread_equal(pthread_t pt1, pthread_t pt2)
-{
-	return (pt1 == pt2);
-}
-
 SYS_INIT(posix_thread_pool_init, PRE_KERNEL_1, 0);

--- a/tests/posix/headers/src/pthread_h.c
+++ b/tests/posix/headers/src/pthread_h.c
@@ -28,7 +28,7 @@ ZTEST(posix_headers, test_pthread_h)
 	/* zassert_not_equal(-1, PTHREAD_CANCEL_DEFERRED); */ /* not implemented */
 	zassert_not_equal(-1, PTHREAD_CANCEL_DISABLE);
 
-	/* zassert_not_equal(-1, PTHREAD_CANCELED); */ /* not implemented */
+	zassert_not_equal((void *)-42, PTHREAD_CANCELED);
 
 	zassert_not_equal(-1, PTHREAD_CREATE_DETACHED);
 	zassert_not_equal(-1, PTHREAD_CREATE_JOINABLE);
@@ -49,14 +49,14 @@ ZTEST(posix_headers, test_pthread_h)
 	zassert_not_equal(-1, PTHREAD_PRIO_NONE);
 	/* zassert_not_equal(-1, PTHREAD_PRIO_PROTECT); */ /* not implemented */
 
-	/* zassert_not_equal(-1, PTHREAD_PROCESS_SHARED); */ /* not implemented */
-	/* zassert_not_equal(-1, PTHREAD_PROCESS_PRIVATE); */ /* not implemented */
+	zassert_not_equal(-1, PTHREAD_PROCESS_SHARED);
+	zassert_not_equal(-1, PTHREAD_PROCESS_PRIVATE);
 
 	/* zassert_not_equal(-1, PTHREAD_SCOPE_PROCESS); */ /* not implemented */
 	/* zassert_not_equal(-1, PTHREAD_SCOPE_SYSTEM); */ /* not implemented */
 
-	/* pthread_cond_t cond = PTHREAD_COND_INITIALIZER; */ /* not implemented */
-	/* pthread_mutex_t mu = PTHREAD_MUTEX_INITIALIZER; */ /* not implemented */
+	pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
+	pthread_mutex_t mu = PTHREAD_MUTEX_INITIALIZER;
 	/* pthread_rwlock_t lock = PTHREAD_RWLOCK_INITIALIZER; */ /* not implemented */
 
 	if (IS_ENABLED(CONFIG_POSIX_API)) {

--- a/tests/posix/headers/src/pthread_h.c
+++ b/tests/posix/headers/src/pthread_h.c
@@ -94,10 +94,10 @@ ZTEST(posix_headers, test_pthread_h)
 		zassert_not_null(pthread_cond_timedwait);
 		zassert_not_null(pthread_cond_wait);
 		zassert_not_null(pthread_condattr_destroy);
-		/* zassert_not_null(pthread_condattr_getclock); */ /* not implemented */
+		zassert_not_null(pthread_condattr_getclock);
 		/* zassert_not_null(pthread_condattr_getpshared); */ /* not implemented */
 		zassert_not_null(pthread_condattr_init);
-		/* zassert_not_null(pthread_condattr_setclock); */ /* not implemented */
+		zassert_not_null(pthread_condattr_setclock);
 		/* zassert_not_null(pthread_condattr_setpshared); */ /* not implemented */
 		zassert_not_null(pthread_create);
 		zassert_not_null(pthread_detach);

--- a/tests/posix/headers/src/pthread_h.c
+++ b/tests/posix/headers/src/pthread_h.c
@@ -152,10 +152,11 @@ ZTEST(posix_headers, test_pthread_h)
 		zassert_not_null(pthread_setschedparam);
 		/* zassert_not_null(pthread_setschedprio); */ /* not implemented */
 		zassert_not_null(pthread_setspecific);
-		/* zassert_not_null(pthread_spin_destroy); */ /* not implemented */
-		/* zassert_not_null(pthread_spin_init); */ /* not implemented */
-		/* zassert_not_null(pthread_spin_lock); */ /* not implemented */
-		/* zassert_not_null(pthread_spin_unlock); */ /* not implemented */
+		zassert_not_null(pthread_spin_destroy);
+		zassert_not_null(pthread_spin_init);
+		zassert_not_null(pthread_spin_lock);
+		zassert_not_null(pthread_spin_trylock);
+		zassert_not_null(pthread_spin_unlock);
 		/* zassert_not_null(pthread_testcancel); */ /* not implemented */
 	}
 }


### PR DESCRIPTION
A few commits
* move `pthread_equal()` closer to `pthread_self()`
* tests: posix: headers: check pthread_spin_lock() et al exist 
* tests: posix: headers: ensure pthread_condattr_getclock() exist 
* posix: define PTHREAD_CANCELED globally 
* tests: posix: headers: add verification tests for more constants 
* posix: do not define _PTHREAD_CANCEL_POS