### PR TITLE
posix: pthread: support for pthread_setcanceltype() 

### DIFF
--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -61,7 +61,7 @@ multiple processes.
     pthread_once(),yes
     pthread_self(),yes
     pthread_setcancelstate(),yes
-    pthread_setcanceltype(),
+    pthread_setcanceltype(),yes
     pthread_setspecific(),yes
     pthread_sigmask(),
     pthread_testcancel(),

--- a/include/zephyr/posix/pthread.h
+++ b/include/zephyr/posix/pthread.h
@@ -33,6 +33,8 @@ extern "C" {
 #define PTHREAD_CANCELED       ((void *)-1)
 #define PTHREAD_CANCEL_ENABLE  0
 #define PTHREAD_CANCEL_DISABLE 1
+#define PTHREAD_CANCEL_DEFERRED     0
+#define PTHREAD_CANCEL_ASYNCHRONOUS 1
 
 /* Passed to pthread_once */
 #define PTHREAD_ONCE_INIT                                                                          \
@@ -452,6 +454,7 @@ int pthread_detach(pthread_t thread);
 int pthread_create(pthread_t *newthread, const pthread_attr_t *attr,
 		   void *(*threadroutine)(void *), void *arg);
 int pthread_setcancelstate(int state, int *oldstate);
+int pthread_setcanceltype(int type, int *oldtype);
 int pthread_attr_setschedparam(pthread_attr_t *attr,
 			       const struct sched_param *schedparam);
 int pthread_setschedparam(pthread_t pthread, int policy,

--- a/lib/posix/posix_internal.h
+++ b/lib/posix/posix_internal.h
@@ -38,6 +38,7 @@ struct posix_thread {
 
 	/* Pthread cancellation */
 	uint8_t cancel_state;
+	uint8_t cancel_type;
 	bool cancel_pending;
 
 	/* Detach state */

--- a/lib/posix/pthread.c
+++ b/lib/posix/pthread.c
@@ -501,6 +501,34 @@ int pthread_setcancelstate(int state, int *oldstate)
 }
 
 /**
+ * @brief Set cancelability Type.
+ *
+ * See IEEE 1003.1
+ */
+int pthread_setcanceltype(int type, int *oldtype)
+{
+	k_spinlock_key_t key;
+	struct posix_thread *t;
+
+	if (type != PTHREAD_CANCEL_DEFERRED && type != PTHREAD_CANCEL_ASYNCHRONOUS) {
+		LOG_ERR("Invalid pthread cancel type %d", type);
+		return EINVAL;
+	}
+
+	t = to_posix_thread(pthread_self());
+	if (t == NULL) {
+		return EINVAL;
+	}
+
+	key = k_spin_lock(&pthread_pool_lock);
+	*oldtype = t->cancel_type;
+	t->cancel_type = type;
+	k_spin_unlock(&pthread_pool_lock, key);
+
+	return 0;
+}
+
+/**
  * @brief Cancel execution of a thread.
  *
  * See IEEE 1003.1

--- a/tests/posix/headers/src/pthread_h.c
+++ b/tests/posix/headers/src/pthread_h.c
@@ -23,9 +23,10 @@ ZTEST(posix_headers, test_pthread_h)
 {
 	zassert_not_equal(-1, PTHREAD_BARRIER_SERIAL_THREAD);
 
-	/* zassert_not_equal(-1, PTHREAD_CANCEL_ASYNCHRONOUS); */ /* not implemented */
+	zassert_not_equal(-1, PTHREAD_CANCEL_ASYNCHRONOUS);
+	zassert_not_equal(-1, PTHREAD_CANCEL_DEFERRED);
+
 	zassert_not_equal(-1, PTHREAD_CANCEL_ENABLE);
-	/* zassert_not_equal(-1, PTHREAD_CANCEL_DEFERRED); */ /* not implemented */
 	zassert_not_equal(-1, PTHREAD_CANCEL_DISABLE);
 
 	zassert_not_equal((void *)-42, PTHREAD_CANCELED);
@@ -146,8 +147,8 @@ ZTEST(posix_headers, test_pthread_h)
 		zassert_not_null(pthread_rwlockattr_init);
 		/* zassert_not_null(pthread_rwlockattr_setpshared); */ /* not implemented */
 		zassert_not_null(pthread_self);
-		/* zassert_not_null(pthread_setcancelstate); */ /* not implemented */
-		/* zassert_not_null(pthread_setcanceltype); */ /* not implemented */
+		zassert_not_null(pthread_setcancelstate);
+		zassert_not_null(pthread_setcanceltype);
 		/* zassert_not_null(pthread_setconcurrency); */ /* not implemented */
 		zassert_not_null(pthread_setschedparam);
 		/* zassert_not_null(pthread_setschedprio); */ /* not implemented */


### PR DESCRIPTION
`pthread_setcanceltype()` is required by the POSIX_THREADS_BASE Option Group as detailed in Section E.1 of IEEE-1003.1-2017.

The POSIX_THREADS_BASE Option Group is required for PSE51, PSE52, PSE53, and PSE54 conformance, and is otherwise mandatory for any POSIX conforming system as per Section A.2.1.3 of IEEE-1003-1.2017.

Fixes #59945

Note: pthread cancellation is still basically synchronous, so cancel type has no effect.