### PR TITLE
posix: pthread: implement pthread_getconcurrency()

### DIFF
--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -99,8 +99,8 @@ This table lists service support status in Zephyr:
 
     pthread_attr_getstack(),yes
     pthread_attr_setstack(),yes
-    pthread_getconcurrency(),
-    pthread_setconcurrency()
+    pthread_getconcurrency(),yes
+    pthread_setconcurrency(),yes
 
 .. _posix_option_group_c_lang_support:
 

--- a/include/zephyr/posix/pthread.h
+++ b/include/zephyr/posix/pthread.h
@@ -477,6 +477,8 @@ int pthread_key_delete(pthread_key_t key);
 int pthread_setspecific(pthread_key_t key, const void *value);
 void *pthread_getspecific(pthread_key_t key);
 int pthread_atfork(void (*prepare)(void), void (*parent)(void), void (*child)(void));
+int pthread_getconcurrency(void);
+int pthread_setconcurrency(int new_level);
 
 /* Glibc / Oracle Extension Functions */
 

--- a/tests/posix/common/src/pthread.c
+++ b/tests/posix/common/src/pthread.c
@@ -882,3 +882,26 @@ ZTEST(posix_apis, test_pthread_join_detached)
 	/* need to allow this thread to be clean-up by the recycler */
 	k_msleep(500);
 }
+
+ZTEST(posix_apis, test_pthread_set_get_concurrency)
+{
+	/* EINVAL if the value specified by new_level is negative */
+	zassert_equal(EINVAL, pthread_setconcurrency(-42));
+
+	/*
+	 * Note: the special value 0 indicates the implementation will
+	 * maintain the concurrency level at its own discretion.
+	 *
+	 * pthread_getconcurrency() should return a value of 0 on init.
+	 */
+	zassert_equal(0, pthread_getconcurrency());
+
+	for (int i = 0; i <= CONFIG_MP_MAX_NUM_CPUS; ++i) {
+		zassert_ok(pthread_setconcurrency(i));
+		/* verify parameter is saved */
+		zassert_equal(i, pthread_getconcurrency());
+	}
+
+	/* EAGAIN if the a system resource to be exceeded */
+	zassert_equal(EAGAIN, pthread_setconcurrency(CONFIG_MP_MAX_NUM_CPUS + 1));
+}

--- a/tests/posix/headers/src/pthread_h.c
+++ b/tests/posix/headers/src/pthread_h.c
@@ -104,7 +104,7 @@ ZTEST(posix_headers, test_pthread_h)
 		zassert_not_null(pthread_detach);
 		zassert_not_null(pthread_equal);
 		zassert_not_null(pthread_exit);
-		/* zassert_not_null(pthread_getconcurrency); */ /* not implemented */
+		zassert_not_null(pthread_getconcurrency);
 		/* zassert_not_null(pthread_getcpuclockid); */ /* not implemented */
 		zassert_not_null(pthread_getschedparam);
 		zassert_not_null(pthread_getspecific);
@@ -149,7 +149,7 @@ ZTEST(posix_headers, test_pthread_h)
 		zassert_not_null(pthread_self);
 		zassert_not_null(pthread_setcancelstate);
 		zassert_not_null(pthread_setcanceltype);
-		/* zassert_not_null(pthread_setconcurrency); */ /* not implemented */
+		zassert_not_null(pthread_setconcurrency);
 		zassert_not_null(pthread_setschedparam);
 		/* zassert_not_null(pthread_setschedprio); */ /* not implemented */
 		zassert_not_null(pthread_setspecific);


### PR DESCRIPTION
Zephyr must support all functionality of the `XSI_THREADS_EXT` subprofiling option group in order to claim it supports that subprofiling option group.

The XSI_THREADS_EXT option group is required for PSE51, PSE52, PSE53, and PSE54 Application Environment Profiles.

The `XSI_THREADS_EXT` option group is critical to be able to run POSIX threads with statically allocated thread stacks, which has been a feature of the implementation since it was initially added.
    
The `pthread_getconcurrency()` and `pthread_setconcurrency()` functions are the only remaining, unimplemented functions of the XSI_THREADS_EXT option group, as per IEEE 1003.1-2017.
    
Implement `pthread_getconcurrency()` and `pthread_setconcurrency()` via the more "posixly correct" interpretation of the specification.
    
I.e. as the pthread_t:k_thread relationship is 1:1 and not M:N, Zephyr does not support multiplexing of user threads on top of schedulable kernel entities (i.e. "user threads" are directly mapped to native threads, just like linuxthreads or NPTL are in Linux).

For that reason, to be "posixly correct", we should save the provided value via `pthread_setconcurrency()`, in the absence of errors, and also return that same value back via `pthread_getconcurrency()`, even though that serves zero purpose in Zephyr for the foreseeable future.
    
Note: the specification also states
> an implementation can always ignore any calls to pthread_setconcurrency() and return a constant for pthread_getconcurrency().

For that reason, the implementation may be revisited at a later time when when considering optimizations and when there is a better system in place for documenting deviations.

Any such optimization should be explicitly controlled via Kconfig.
    
See https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_getconcurrency.html for additional info