### PR TITLE
ITE: drivers/gpio: Correct the wake up control input

### DIFF
--- a/drivers/gpio/gpio_ite_it8xxx2.c
+++ b/drivers/gpio/gpio_ite_it8xxx2.c
@@ -149,7 +149,7 @@ static const struct {
 	[IT8XXX2_IRQ_WU63] = {BIT(3), 6, BIT(3)},
 	[IT8XXX2_IRQ_WU64] = {BIT(4), 6, BIT(4)},
 	[IT8XXX2_IRQ_WU65] = {BIT(5), 6, BIT(5)},
-	[IT8XXX2_IRQ_WU65] = {BIT(6), 6, BIT(6)},
+	[IT8XXX2_IRQ_WU66] = {BIT(6), 6, BIT(6)},
 	[IT8XXX2_IRQ_WU67] = {BIT(7), 6, BIT(7)},
 	[IT8XXX2_IRQ_WU70] = {BIT(0), 7, BIT(0)},
 	[IT8XXX2_IRQ_WU71] = {BIT(1), 7, BIT(1)},


### PR DESCRIPTION
The wake-up control input is IT8XXX2_IRQ_WU66.

Testing the wake-up functionality on GPF6 is normal.