### PR TITLE
west.yml: Update hal_silabs to pull request #47 | Update to GSDK 4.3.2

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -219,7 +219,7 @@ manifest:
       groups:
         - hal
     - name: hal_silabs
-      revision: 72a67203f0b37dc2c12bfae5ddf05c991c0ab0a4
+      revision: 7a6ba7ce989c3c466b4cb450e44858a3bb0a949a
       path: modules/hal/silabs
       groups:
         - hal


### PR DESCRIPTION
Update the EFR32BG22 device files inside gecko/Device/SiliconLabs/EFR32BG22 from gecko_sdk to align the codebase of hal_silabs with gecko_sdk 4.3.2.

PR in hal_silabs - https://github.com/zephyrproject-rtos/hal_silabs/pull/47