### PR TITLE
bluetooth: hci: spi: fix coverity errors

### DIFF
--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -185,7 +185,7 @@ config BT_DRV_TX_STACK_SIZE
 
 config BT_DRV_RX_STACK_SIZE
 	int
-	default 512 if BT_SPI
+	default 640 if BT_SPI
 	default BT_RX_STACK_SIZE if (BT_H4 || BT_HCI_RAW_H4)
 	default BT_STM32_IPM_RX_STACK_SIZE if BT_STM32_IPM
 	default 256

--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -493,7 +493,10 @@ static int bt_spi_open(void)
 	}
 
 	/* Enable the interrupt line */
-	gpio_pin_interrupt_configure_dt(&irq_gpio, GPIO_INT_EDGE_TO_ACTIVE);
+	err = gpio_pin_interrupt_configure_dt(&irq_gpio, GPIO_INT_EDGE_TO_ACTIVE);
+	if (err) {
+		return err;
+	}
 
 	/* Take BLE out of reset */
 	k_sleep(K_MSEC(DT_INST_PROP_OR(0, reset_assert_duration_ms, 0)));


### PR DESCRIPTION
Increase the SPI RX driver stack size by 128 bytes in response to
coverity overflow detection. Overflows have previously been observed
on real hardware at the default stack size of 512.

Handle the GPIO module failing to configure the interrupt line.

Fixes #65583