### PR TITLE
tests: btp_mcp: Fix dead code warning

### DIFF
--- a/tests/bluetooth/tester/src/btp_mcp.c
+++ b/tests/bluetooth/tester/src/btp_mcp.c
@@ -302,7 +302,6 @@ static void mcc_discover_cb(struct bt_conn *conn, int err)
 {
 	if (err) {
 		LOG_DBG("Discovery failed (%d)", err);
-		return;
 	}
 
 	btp_send_mcp_found_ev(conn, err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);


### PR DESCRIPTION
Remove return statement preventing to return error code.