### PR TITLE
lib: Make OSDP slab init safer

### DIFF
--- a/subsys/mgmt/osdp/src/osdp.c
+++ b/subsys/mgmt/osdp/src/osdp.c
@@ -156,8 +156,7 @@ static struct osdp *osdp_build_ctx(struct osdp_channel *channel)
 			SET_FLAG(pd, PD_FLAG_PKT_SKIP_MARK);
 		}
 		memcpy(&pd->channel, channel, sizeof(struct osdp_channel));
-		k_mem_slab_init(&pd->cmd.slab,
-				pd->cmd.slab_buf, sizeof(struct osdp_cmd),
+		k_mem_slab_init(&pd->cmd.slab, pd->cmd.slab_buf, sizeof(union osdp_ephemeral_data),
 				CONFIG_OSDP_PD_COMMAND_QUEUE_SIZE);
 	}
 	return ctx;


### PR DESCRIPTION
slab_buff size is calculated basing on size of osdp_ephemeral_data union so it is safer to use same structure for slab init. Changes in osdp_event or osd_cmd structures can cause crashes without this.