### PR TITLE
drivers: intc: stm32: fix a minor copy paste error

### DIFF
--- a/include/zephyr/drivers/interrupt_controller/exti_stm32.h
+++ b/include/zephyr/drivers/interrupt_controller/exti_stm32.h
@@ -49,7 +49,7 @@ enum stm32_exti_trigger {
 	STM32_EXTI_TRIG_RISING  = 0x1,
 	/* trigger on falling edge */
 	STM32_EXTI_TRIG_FALLING = 0x2,
-	/* trigger on falling edge */
+	/* trigger on both rising & falling edge */
 	STM32_EXTI_TRIG_BOTH = 0x3,
 };
 


### PR DESCRIPTION
The description of `STM32_EXTI_TRIG_FALLING` got copied into the `STM32_EXTI_TRIG_BOTH` as well, fix that.