### PR TITLE
Modem pipe add TRANSMIT_IDLE event

### DIFF
--- a/include/zephyr/modem/backend/uart.h
+++ b/include/zephyr/modem/backend/uart.h
@@ -43,6 +43,7 @@ struct modem_backend_uart {
 	const struct device *uart;
 	struct modem_pipe pipe;
 	struct k_work receive_ready_work;
+	struct k_work transmit_idle_work;
 
 	union {
 		struct modem_backend_uart_isr isr;

--- a/include/zephyr/modem/pipe.h
+++ b/include/zephyr/modem/pipe.h
@@ -25,6 +25,7 @@ extern "C" {
 enum modem_pipe_event {
 	MODEM_PIPE_EVENT_OPENED = 0,
 	MODEM_PIPE_EVENT_RECEIVE_READY,
+	MODEM_PIPE_EVENT_TRANSMIT_IDLE,
 	MODEM_PIPE_EVENT_CLOSED,
 };
 
@@ -73,7 +74,8 @@ struct modem_pipe {
 	enum modem_pipe_state state;
 	struct k_mutex lock;
 	struct k_condvar condvar;
-	bool receive_ready_pending;
+	uint8_t receive_ready_pending : 1;
+	uint8_t transmit_idle_pending : 1;
 };
 
 /**
@@ -212,6 +214,15 @@ void modem_pipe_notify_closed(struct modem_pipe *pipe);
  * @note Invoked from instance which initialized the pipe instance
  */
 void modem_pipe_notify_receive_ready(struct modem_pipe *pipe);
+
+/**
+ * @brief Notify user of pipe that pipe has no more data to transmit
+ *
+ * @param pipe Pipe instance
+ *
+ * @note Invoked from instance which initialized the pipe instance
+ */
+void modem_pipe_notify_transmit_idle(struct modem_pipe *pipe);
 
 /**
  * @endcond

--- a/subsys/modem/backends/modem_backend_tty.c
+++ b/subsys/modem/backends/modem_backend_tty.c
@@ -73,8 +73,11 @@ static int modem_backend_tty_open(void *data)
 static int modem_backend_tty_transmit(void *data, const uint8_t *buf, size_t size)
 {
 	struct modem_backend_tty *backend = (struct modem_backend_tty *)data;
+	int ret;
 
-	return write(backend->tty_fd, buf, size);
+	ret = write(backend->tty_fd, buf, size);
+	modem_pipe_notify_transmit_idle(&backend->pipe);
+	return ret;
 }
 
 static int modem_backend_tty_receive(void *data, uint8_t *buf, size_t size)

--- a/subsys/modem/backends/modem_backend_uart.c
+++ b/subsys/modem/backends/modem_backend_uart.c
@@ -22,6 +22,14 @@ static void modem_backend_uart_receive_ready_handler(struct k_work *item)
 	modem_pipe_notify_receive_ready(&backend->pipe);
 }
 
+static void modem_backend_uart_transmit_idle_handler(struct k_work *item)
+{
+	struct modem_backend_uart *backend =
+		CONTAINER_OF(item, struct modem_backend_uart, transmit_idle_work);
+
+	modem_pipe_notify_transmit_idle(&backend->pipe);
+}
+
 struct modem_pipe *modem_backend_uart_init(struct modem_backend_uart *backend,
 					   const struct modem_backend_uart_config *config)
 {
@@ -35,6 +43,7 @@ struct modem_pipe *modem_backend_uart_init(struct modem_backend_uart *backend,
 	memset(backend, 0x00, sizeof(*backend));
 	backend->uart = config->uart;
 	k_work_init(&backend->receive_ready_work, modem_backend_uart_receive_ready_handler);
+	k_work_init(&backend->transmit_idle_work, modem_backend_uart_transmit_idle_handler);
 
 #ifdef CONFIG_MODEM_BACKEND_UART_ASYNC
 	if (modem_backend_uart_async_is_supported(backend)) {

--- a/subsys/modem/backends/modem_backend_uart_async.c
+++ b/subsys/modem/backends/modem_backend_uart_async.c
@@ -44,6 +44,7 @@ static void modem_backend_uart_async_event_handler(const struct device *dev,
 	case UART_TX_DONE:
 		atomic_clear_bit(&backend->async.state,
 				 MODEM_BACKEND_UART_ASYNC_STATE_TRANSMITTING_BIT);
+		k_work_submit(&backend->transmit_idle_work);
 
 		break;
 
@@ -51,6 +52,7 @@ static void modem_backend_uart_async_event_handler(const struct device *dev,
 		LOG_WRN("Transmit aborted");
 		atomic_clear_bit(&backend->async.state,
 				 MODEM_BACKEND_UART_ASYNC_STATE_TRANSMITTING_BIT);
+		k_work_submit(&backend->transmit_idle_work);
 
 		break;
 

--- a/subsys/modem/backends/modem_backend_uart_isr.c
+++ b/subsys/modem/backends/modem_backend_uart_isr.c
@@ -56,6 +56,7 @@ static void modem_backend_uart_isr_irq_handler_transmit_ready(struct modem_backe
 
 	if (ring_buf_is_empty(&backend->isr.transmit_rb) == true) {
 		uart_irq_tx_disable(backend->uart);
+		k_work_submit(&backend->transmit_idle_work);
 		return;
 	}
 

--- a/subsys/modem/modem_pipe.c
+++ b/subsys/modem/modem_pipe.c
@@ -21,6 +21,7 @@ void modem_pipe_init(struct modem_pipe *pipe, void *data, struct modem_pipe_api 
 	pipe->user_data = NULL;
 	pipe->state = MODEM_PIPE_STATE_CLOSED;
 	pipe->receive_ready_pending = false;
+	pipe->transmit_idle_pending = true;
 
 	k_mutex_init(&pipe->lock);
 	k_condvar_init(&pipe->condvar);
@@ -82,6 +83,10 @@ void modem_pipe_attach(struct modem_pipe *pipe, modem_pipe_api_callback callback
 		pipe->callback(pipe, MODEM_PIPE_EVENT_RECEIVE_READY, pipe->user_data);
 	}
 
+	if (pipe->transmit_idle_pending && (pipe->callback != NULL)) {
+		pipe->callback(pipe, MODEM_PIPE_EVENT_TRANSMIT_IDLE, pipe->user_data);
+	}
+
 	k_mutex_unlock(&pipe->lock);
 }
 
@@ -97,6 +102,7 @@ int modem_pipe_transmit(struct modem_pipe *pipe, const uint8_t *buf, size_t size
 	}
 
 	ret = pipe->api->transmit(pipe->data, buf, size);
+	pipe->transmit_idle_pending = false;
 	k_mutex_unlock(&pipe->lock);
 	return ret;
 }
@@ -179,6 +185,7 @@ void modem_pipe_notify_opened(struct modem_pipe *pipe)
 
 	if (pipe->callback != NULL) {
 		pipe->callback(pipe, MODEM_PIPE_EVENT_OPENED, pipe->user_data);
+		pipe->callback(pipe, MODEM_PIPE_EVENT_TRANSMIT_IDLE, pipe->user_data);
 	}
 
 	k_condvar_signal(&pipe->condvar);
@@ -190,6 +197,7 @@ void modem_pipe_notify_closed(struct modem_pipe *pipe)
 	k_mutex_lock(&pipe->lock, K_FOREVER);
 	pipe->state = MODEM_PIPE_STATE_CLOSED;
 	pipe->receive_ready_pending = false;
+	pipe->transmit_idle_pending = true;
 
 	if (pipe->callback != NULL) {
 		pipe->callback(pipe, MODEM_PIPE_EVENT_CLOSED, pipe->user_data);
@@ -207,6 +215,19 @@ void modem_pipe_notify_receive_ready(struct modem_pipe *pipe)
 
 	if (pipe->callback != NULL) {
 		pipe->callback(pipe, MODEM_PIPE_EVENT_RECEIVE_READY, pipe->user_data);
+	}
+
+	k_mutex_unlock(&pipe->lock);
+}
+
+void modem_pipe_notify_transmit_idle(struct modem_pipe *pipe)
+{
+	k_mutex_lock(&pipe->lock, K_FOREVER);
+
+	pipe->transmit_idle_pending = true;
+
+	if (pipe->callback != NULL) {
+		pipe->callback(pipe, MODEM_PIPE_EVENT_TRANSMIT_IDLE, pipe->user_data);
 	}
 
 	k_mutex_unlock(&pipe->lock);

--- a/tests/subsys/modem/backends/tty/src/main.c
+++ b/tests/subsys/modem/backends/tty/src/main.c
@@ -22,7 +22,8 @@
 
 #define TEST_MODEM_BACKEND_TTY_PIPE_EVENT_OPENED_BIT (0)
 #define TEST_MODEM_BACKEND_TTY_PIPE_EVENT_RRDY_BIT   (1)
-#define TEST_MODEM_BACKEND_TTY_PIPE_EVENT_CLOSED_BIT (2)
+#define TEST_MODEM_BACKEND_TTY_PIPE_EVENT_TIDLE_BIT  (2)
+#define TEST_MODEM_BACKEND_TTY_PIPE_EVENT_CLOSED_BIT (3)
 
 #define TEST_MODEM_BACKEND_TTY_OP_DELAY (K_MSEC(1000))
 
@@ -70,6 +71,10 @@ static void modem_pipe_callback_handler(struct modem_pipe *pipe, enum modem_pipe
 
 	case MODEM_PIPE_EVENT_RECEIVE_READY:
 		atomic_set_bit(&tty_pipe_events, TEST_MODEM_BACKEND_TTY_PIPE_EVENT_RRDY_BIT);
+		break;
+
+	case MODEM_PIPE_EVENT_TRANSMIT_IDLE:
+		atomic_set_bit(&tty_pipe_events, TEST_MODEM_BACKEND_TTY_PIPE_EVENT_TIDLE_BIT);
 		break;
 
 	case MODEM_PIPE_EVENT_CLOSED:
@@ -122,9 +127,13 @@ static void test_modem_backend_tty_teardown(void *f)
 /*************************************************************************************************/
 ZTEST(modem_backend_tty_suite, test_close_open)
 {
+	bool result;
+
 	zassert_ok(modem_pipe_close(tty_pipe), "Failed to close pipe");
 	zassert_ok(modem_pipe_close(tty_pipe), "Pipe should already be closed");
 	zassert_ok(modem_pipe_open(tty_pipe), "Failed to open pipe");
+	result = atomic_test_bit(&tty_pipe_events, TEST_MODEM_BACKEND_TTY_PIPE_EVENT_TIDLE_BIT);
+	zassert_true(result, "Transmit idle event should be set");
 	zassert_ok(modem_pipe_open(tty_pipe), "Pipe should already be open");
 }
 
@@ -172,11 +181,18 @@ ZTEST(modem_backend_tty_suite, test_transmit)
 {
 	int ret;
 	char msg[] = "Test me buddy 2";
+	bool result;
+
+	result = atomic_test_bit(&tty_pipe_events, TEST_MODEM_BACKEND_TTY_PIPE_EVENT_TIDLE_BIT);
+	zassert_false(result, "Transmit idle event should not be set");
 
 	ret = modem_pipe_transmit(tty_pipe, msg, sizeof(msg));
 	zassert_true(ret == sizeof(msg), "Failed to transmit using pipe");
 
 	k_sleep(TEST_MODEM_BACKEND_TTY_OP_DELAY);
+
+	result = atomic_test_bit(&tty_pipe_events, TEST_MODEM_BACKEND_TTY_PIPE_EVENT_TIDLE_BIT);
+	zassert_true(result, "Transmit idle event should be set");
 
 	ret = read(primary_fd, buffer1, sizeof(buffer1));
 	zassert_true(ret == sizeof(msg), "Read incorrect number of bytes");

--- a/tests/subsys/modem/modem_pipe/CMakeLists.txt
+++ b/tests/subsys/modem/modem_pipe/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Copyright (c) 2023 Trackunit Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(modem_pipe_test)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/subsys/modem/modem_pipe/prj.conf
+++ b/tests/subsys/modem/modem_pipe/prj.conf
@@ -1,0 +1,8 @@
+# Copyright (c) 2023 Trackunit Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_NO_OPTIMIZATIONS=y
+CONFIG_MODEM_MODULES=y
+CONFIG_MODEM_PIPE=y
+CONFIG_EVENTS=y
+CONFIG_ZTEST=y

--- a/tests/subsys/modem/modem_pipe/src/main.c
+++ b/tests/subsys/modem/modem_pipe/src/main.c
@@ -1,0 +1,401 @@
+/*
+ * Copyright (c) 2023 Trackunit Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*************************************************************************************************/
+/*                                        Dependencies                                           */
+/*************************************************************************************************/
+#include <zephyr/kernel.h>
+#include <zephyr/modem/pipe.h>
+#include <zephyr/ztest.h>
+#include <zephyr/sys/atomic.h>
+#include <string.h>
+
+#define TEST_MODEM_PIPE_EVENT_OPENED_BIT        0
+#define TEST_MODEM_PIPE_EVENT_TRANSMIT_IDLE_BIT 1
+#define TEST_MODEM_PIPE_EVENT_RECEIVE_READY_BIT 2
+#define TEST_MODEM_PIPE_EVENT_CLOSED_BIT        3
+#define TEST_MODEM_PIPE_NOTIFY_TIMEOUT          K_MSEC(10)
+#define TEST_MODEM_PIPE_WAIT_TIMEOUT            K_MSEC(20)
+
+/*************************************************************************************************/
+/*                                   Fake modem_pipe backend                                     */
+/*************************************************************************************************/
+struct modem_backend_fake {
+	struct modem_pipe pipe;
+
+	struct k_work_delayable opened_dwork;
+	struct k_work_delayable transmit_idle_dwork;
+	struct k_work_delayable closed_dwork;
+
+	const uint8_t *transmit_buffer;
+	size_t transmit_buffer_size;
+
+	uint8_t *receive_buffer;
+	size_t receive_buffer_size;
+
+	uint8_t synchronous : 1;
+	uint8_t open_called : 1;
+	uint8_t transmit_called : 1;
+	uint8_t receive_called : 1;
+	uint8_t close_called : 1;
+};
+
+static void modem_backend_fake_opened_handler(struct k_work *item)
+{
+	struct k_work_delayable *dwork = k_work_delayable_from_work(item);
+	struct modem_backend_fake *backend =
+		CONTAINER_OF(dwork, struct modem_backend_fake, opened_dwork);
+
+	modem_pipe_notify_opened(&backend->pipe);
+}
+
+static int modem_backend_fake_open(void *data)
+{
+	struct modem_backend_fake *backend = data;
+
+	backend->open_called = true;
+
+	if (backend->synchronous) {
+		modem_pipe_notify_opened(&backend->pipe);
+	} else {
+		k_work_schedule(&backend->opened_dwork, TEST_MODEM_PIPE_NOTIFY_TIMEOUT);
+	}
+
+	return 0;
+}
+
+static void modem_backend_fake_transmit_idle_handler(struct k_work *item)
+{
+	struct k_work_delayable *dwork = k_work_delayable_from_work(item);
+	struct modem_backend_fake *backend =
+		CONTAINER_OF(dwork, struct modem_backend_fake, transmit_idle_dwork);
+
+	modem_pipe_notify_transmit_idle(&backend->pipe);
+}
+
+static int modem_backend_fake_transmit(void *data, const uint8_t *buf, size_t size)
+{
+	struct modem_backend_fake *backend = data;
+
+	backend->transmit_called = true;
+	backend->transmit_buffer = buf;
+	backend->transmit_buffer_size = size;
+
+	if (backend->synchronous) {
+		modem_pipe_notify_transmit_idle(&backend->pipe);
+	} else {
+		k_work_schedule(&backend->transmit_idle_dwork, TEST_MODEM_PIPE_NOTIFY_TIMEOUT);
+	}
+
+	return size;
+}
+
+static int modem_backend_fake_receive(void *data, uint8_t *buf, size_t size)
+{
+	struct modem_backend_fake *backend = data;
+
+	backend->receive_called = true;
+	backend->receive_buffer = buf;
+	backend->receive_buffer_size = size;
+	return size;
+}
+
+static void modem_backend_fake_closed_handler(struct k_work *item)
+{
+	struct k_work_delayable *dwork = k_work_delayable_from_work(item);
+	struct modem_backend_fake *backend =
+		CONTAINER_OF(dwork, struct modem_backend_fake, closed_dwork);
+
+	modem_pipe_notify_closed(&backend->pipe);
+}
+
+static int modem_backend_fake_close(void *data)
+{
+	struct modem_backend_fake *backend = data;
+
+	backend->close_called = true;
+
+	if (backend->synchronous) {
+		modem_pipe_notify_closed(&backend->pipe);
+	} else {
+		k_work_schedule(&backend->closed_dwork, TEST_MODEM_PIPE_NOTIFY_TIMEOUT);
+	}
+
+	return 0;
+}
+
+static struct modem_pipe_api modem_backend_fake_api = {
+	.open = modem_backend_fake_open,
+	.transmit = modem_backend_fake_transmit,
+	.receive = modem_backend_fake_receive,
+	.close = modem_backend_fake_close,
+};
+
+static struct modem_pipe *modem_backend_fake_init(struct modem_backend_fake *backend)
+{
+	k_work_init_delayable(&backend->opened_dwork,
+			      modem_backend_fake_opened_handler);
+	k_work_init_delayable(&backend->transmit_idle_dwork,
+			      modem_backend_fake_transmit_idle_handler);
+	k_work_init_delayable(&backend->closed_dwork,
+			      modem_backend_fake_closed_handler);
+
+	modem_pipe_init(&backend->pipe, backend, &modem_backend_fake_api);
+	return &backend->pipe;
+}
+
+static void modem_backend_fake_reset(struct modem_backend_fake *backend)
+{
+	backend->transmit_buffer = NULL;
+	backend->transmit_buffer_size = 0;
+	backend->receive_buffer = NULL;
+	backend->transmit_buffer_size = 0;
+	backend->open_called = false;
+	backend->transmit_called = false;
+	backend->receive_called = false;
+	backend->close_called = false;
+}
+
+static void modem_backend_fake_set_sync(struct modem_backend_fake *backend, bool sync)
+{
+	backend->synchronous = sync;
+}
+
+/*************************************************************************************************/
+/*                                          Instances                                            */
+/*************************************************************************************************/
+static struct modem_backend_fake test_backend;
+static struct modem_pipe *test_pipe;
+static uint32_t test_user_data;
+static atomic_t test_state;
+static uint8_t test_buffer[4];
+static size_t test_buffer_size = sizeof(test_buffer);
+
+/*************************************************************************************************/
+/*                                          Callbacks                                            */
+/*************************************************************************************************/
+static void modem_pipe_fake_handler(struct modem_pipe *pipe, enum modem_pipe_event event,
+				    void *user_data)
+{
+	__ASSERT(pipe == test_pipe, "Incorrect pipe provided with callback");
+	__ASSERT(user_data == (void *)&test_user_data, "Incorrect user data ptr");
+
+	switch (event) {
+	case MODEM_PIPE_EVENT_OPENED:
+		atomic_set_bit(&test_state, TEST_MODEM_PIPE_EVENT_OPENED_BIT);
+		break;
+
+	case MODEM_PIPE_EVENT_RECEIVE_READY:
+		atomic_set_bit(&test_state, TEST_MODEM_PIPE_EVENT_RECEIVE_READY_BIT);
+		break;
+
+	case MODEM_PIPE_EVENT_TRANSMIT_IDLE:
+		atomic_set_bit(&test_state, TEST_MODEM_PIPE_EVENT_TRANSMIT_IDLE_BIT);
+		break;
+
+	case MODEM_PIPE_EVENT_CLOSED:
+		atomic_set_bit(&test_state, TEST_MODEM_PIPE_EVENT_CLOSED_BIT);
+		break;
+	}
+}
+
+static void test_reset(void)
+{
+	modem_backend_fake_reset(&test_backend);
+	atomic_set(&test_state, 0);
+}
+
+static void *modem_backend_fake_setup(void)
+{
+	test_pipe = modem_backend_fake_init(&test_backend);
+	return NULL;
+}
+
+static void modem_backend_fake_before(void *f)
+{
+	modem_backend_fake_set_sync(&test_backend, false);
+	modem_pipe_attach(test_pipe, modem_pipe_fake_handler, &test_user_data);
+	test_reset();
+}
+
+static void modem_backend_fake_after(void *f)
+{
+	__ASSERT(modem_pipe_close(test_pipe) == 0, "Failed to close pipe");
+	modem_pipe_release(test_pipe);
+}
+
+/* Opening pipe shall raise events OPENED and TRANSMIT_IDLE */
+static void test_pipe_open(void)
+{
+	zassert_ok(modem_pipe_open(test_pipe), "Failed to open pipe");
+	zassert_true(test_backend.open_called, "open was not called");
+	zassert_equal(atomic_get(&test_state),
+		      BIT(TEST_MODEM_PIPE_EVENT_OPENED_BIT) |
+		      BIT(TEST_MODEM_PIPE_EVENT_TRANSMIT_IDLE_BIT),
+		      "Unexpected state %u", atomic_get(&test_state));
+}
+
+/* Re-opening pipe shall have no effect */
+static void test_pipe_reopen(void)
+{
+	zassert_ok(modem_pipe_open(test_pipe), "Failed to re-open pipe");
+	zassert_false(test_backend.open_called, "open was called");
+	zassert_equal(atomic_get(&test_state), 0,
+		      "Unexpected state %u", atomic_get(&test_state));
+}
+
+/* Closing pipe shall raise event CLOSED */
+static void test_pipe_close(void)
+{
+	zassert_ok(modem_pipe_close(test_pipe), "Failed to close pipe");
+	zassert_true(test_backend.close_called, "close was not called");
+	zassert_equal(atomic_get(&test_state), BIT(TEST_MODEM_PIPE_EVENT_CLOSED_BIT),
+		      "Unexpected state %u", atomic_get(&test_state));
+}
+
+/* Re-closing pipe shall have no effect */
+static void test_pipe_reclose(void)
+{
+	zassert_ok(modem_pipe_close(test_pipe), "Failed to re-close pipe");
+	zassert_false(test_backend.close_called, "close was called");
+	zassert_equal(atomic_get(&test_state), 0,
+		      "Unexpected state %u", atomic_get(&test_state));
+}
+
+static void test_pipe_async_transmit(void)
+{
+	zassert_equal(modem_pipe_transmit(test_pipe, test_buffer, test_buffer_size),
+		      test_buffer_size, "Failed to transmit");
+	zassert_true(test_backend.transmit_called, "transmit was not called");
+	zassert_equal(test_backend.transmit_buffer, test_buffer, "Incorrect buffer");
+	zassert_equal(test_backend.transmit_buffer_size, test_buffer_size,
+		      "Incorrect buffer size");
+	zassert_equal(atomic_get(&test_state), 0, "Unexpected state %u",
+		      atomic_get(&test_state));
+	k_sleep(TEST_MODEM_PIPE_WAIT_TIMEOUT);
+	zassert_equal(atomic_get(&test_state), BIT(TEST_MODEM_PIPE_EVENT_TRANSMIT_IDLE_BIT),
+		      "Unexpected state %u", atomic_get(&test_state));
+}
+
+static void test_pipe_sync_transmit(void)
+{
+	zassert_equal(modem_pipe_transmit(test_pipe, test_buffer, test_buffer_size),
+		      test_buffer_size, "Failed to transmit");
+	zassert_true(test_backend.transmit_called, "transmit was not called");
+	zassert_equal(test_backend.transmit_buffer, test_buffer, "Incorrect buffer");
+	zassert_equal(test_backend.transmit_buffer_size, test_buffer_size,
+		      "Incorrect buffer size");
+	zassert_equal(atomic_get(&test_state), BIT(TEST_MODEM_PIPE_EVENT_TRANSMIT_IDLE_BIT),
+		      "Unexpected state %u", atomic_get(&test_state));
+}
+
+static void test_pipe_attach_receive_not_ready_transmit_idle(void)
+{
+	modem_pipe_attach(test_pipe, modem_pipe_fake_handler, &test_user_data);
+	zassert_equal(atomic_get(&test_state), BIT(TEST_MODEM_PIPE_EVENT_TRANSMIT_IDLE_BIT),
+		      "Unexpected state %u", atomic_get(&test_state));
+}
+
+static void test_pipe_attach_receive_ready_transmit_idle(void)
+{
+	modem_pipe_attach(test_pipe, modem_pipe_fake_handler, &test_user_data);
+	zassert_equal(atomic_get(&test_state),
+		      BIT(TEST_MODEM_PIPE_EVENT_TRANSMIT_IDLE_BIT) |
+		      BIT(TEST_MODEM_PIPE_EVENT_RECEIVE_READY_BIT),
+		      "Unexpected state %u", atomic_get(&test_state));
+}
+
+static void test_pipe_receive(void)
+{
+	zassert_equal(modem_pipe_receive(test_pipe, test_buffer, test_buffer_size),
+		      test_buffer_size, "Failed to receive");
+	zassert_true(test_backend.receive_called, "receive was not called");
+	zassert_equal(test_backend.receive_buffer, test_buffer, "Incorrect buffer");
+	zassert_equal(test_backend.receive_buffer_size, test_buffer_size,
+		      "Incorrect buffer size");
+	zassert_equal(atomic_get(&test_state), 0, "Unexpected state %u",
+		      atomic_get(&test_state));
+}
+
+static void test_pipe_notify_receive_ready(void)
+{
+	modem_pipe_notify_receive_ready(test_pipe);
+	zassert_equal(atomic_get(&test_state), BIT(TEST_MODEM_PIPE_EVENT_RECEIVE_READY_BIT),
+		      "Unexpected state %u", atomic_get(&test_state));
+}
+
+ZTEST(modem_pipe, test_async_open_close)
+{
+	test_pipe_open();
+	test_reset();
+	test_pipe_reopen();
+	test_reset();
+	test_pipe_close();
+	test_reset();
+	test_pipe_reclose();
+}
+
+ZTEST(modem_pipe, test_sync_open_close)
+{
+	modem_backend_fake_set_sync(&test_backend, true);
+	test_pipe_open();
+	test_reset();
+	test_pipe_reopen();
+	test_reset();
+	test_pipe_close();
+	test_reset();
+	test_pipe_reclose();
+}
+
+ZTEST(modem_pipe, test_async_transmit)
+{
+	test_pipe_open();
+	test_reset();
+	test_pipe_async_transmit();
+}
+
+ZTEST(modem_pipe, test_sync_transmit)
+{
+	modem_backend_fake_set_sync(&test_backend, true);
+	test_pipe_open();
+	test_reset();
+	test_pipe_sync_transmit();
+}
+
+ZTEST(modem_pipe, test_attach)
+{
+	test_pipe_open();
+
+	/*
+	 * Attaching pipe shall reinvoke TRANSMIT IDLE, but not RECEIVE READY as
+	 * receive is not ready.
+	 */
+	test_reset();
+	test_pipe_attach_receive_not_ready_transmit_idle();
+
+	/*
+	 * Notify receive ready and expect receive ready to be re-invoked every
+	 * time the pipe is attached to.
+	 */
+	test_reset();
+	test_pipe_notify_receive_ready();
+	test_reset();
+	test_pipe_attach_receive_ready_transmit_idle();
+	test_reset();
+	test_pipe_attach_receive_ready_transmit_idle();
+
+	/*
+	 * Receiving data from the pipe shall clear the receive ready state, stopping
+	 * the invocation of receive ready on attach.
+	 */
+	test_reset();
+	test_pipe_receive();
+	test_reset();
+	test_pipe_attach_receive_not_ready_transmit_idle();
+}
+
+ZTEST_SUITE(modem_pipe, NULL, modem_backend_fake_setup, modem_backend_fake_before,
+	    modem_backend_fake_after, NULL);

--- a/tests/subsys/modem/modem_pipe/testcase.yaml
+++ b/tests/subsys/modem/modem_pipe/testcase.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2023 Trackunit Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+tests:
+  modem.modem_pipe:
+    tags: modem_pipe
+    harness: ztest
+    platform_allow: native_sim


### PR DESCRIPTION
This PR adds the notification `TRANSMIT_IDLE` which will be sent by modem backends once they have sent all data passed through the `modem_pipe_transmit` API. This will allow users of the modem_pipe to synchronize the `modem_pipe_transmit` calls more efficiently.

Currently, we are stuck in a loop like this while transmitting data through a `modem_pipe` until all data has been transmitted:
1. Transmit data using `modem_pipe_transmit()` until it returns 0 (its internal buffer is full)
2. Yield for "some time"
3. Go to step 1

To underline how inefficient the current approach is, while performing the transmit throughput test which is part of the cellular_modem sample, it completely starves the logging thread until all bytes have been transmitted...

This blind and continuous call to `modem_pipe_transmit()` before it is ready to accept new data has no utility, and is therefore wasted. The only current way to diminish the wasted calls is to yield for longer between each call to `modem_pipe_transmit()`, but this hurts throughput.

With the `TRANSMIT_IDLE` event, we can synchronize the transmit with the modem backend by waiting once the `modem_pipe_transmit()` returns 0:
1. Transmit data using `modem_pipe_transmit()` until it returns 0 (its internal buffer is full)
2. Wait for `TRANSMIT_IDLE` event
3. Go to step 1

This results in only one potentially "wasted" call to `modem_pipe_transmit()` if its internal buffer is completely filled, which we can't avoid in any case.

This PR also adds a test suite for the `modem_pipe` module, and implementations of the `TRANSMIT_IDLE` events for the existing modem backends; UART and TTY.

After extending the CMUX and PPP modem modules to utilize the TRANSMIT_IDLE event (future PR), the max CPU utilization of the system work queue thread (which all modem modules run in) went down to 5% from 36%, while reducing the throughput by 12%. The logging is now unblocked while running the throughput test as well :)