### PR TITLE
drivers: net: oa tc6: lan865x: Add support for PLCA configuration from the user program

### DIFF
--- a/drivers/ethernet/eth_lan865x.c
+++ b/drivers/ethernet/eth_lan865x.c
@@ -124,6 +124,8 @@ static int lan865x_gpio_reset(const struct device *dev)
 	struct lan865x_data *ctx = dev->data;
 
 	ctx->reset = false;
+	ctx->tc6->protected = false;
+
 	/* Perform (GPIO based) HW reset */
 	/* assert RESET_N low for 10 µs (5 µs min) */
 	gpio_pin_set_dt(&cfg->reset, 1);

--- a/drivers/ethernet/eth_lan865x.c
+++ b/drivers/ethernet/eth_lan865x.c
@@ -121,7 +121,9 @@ static int lan865x_wait_for_reset(const struct device *dev)
 static int lan865x_gpio_reset(const struct device *dev)
 {
 	const struct lan865x_config *cfg = dev->config;
+	struct lan865x_data *ctx = dev->data;
 
+	ctx->reset = false;
 	/* Perform (GPIO based) HW reset */
 	/* assert RESET_N low for 10 µs (5 µs min) */
 	gpio_pin_set_dt(&cfg->reset, 1);
@@ -507,8 +509,6 @@ static int lan865x_init(const struct device *dev)
 				K_PRIO_COOP(CONFIG_ETH_LAN865X_IRQ_THREAD_PRIO),
 				0, K_NO_WAIT);
 	k_thread_name_set(ctx->tid_int, "lan865x_interrupt");
-
-	ctx->reset = false;
 
 	/* Perform HW reset - 'rst-gpios' required property set in DT */
 	if (!gpio_is_ready_dt(&cfg->reset)) {

--- a/drivers/ethernet/eth_lan865x.c
+++ b/drivers/ethernet/eth_lan865x.c
@@ -337,11 +337,11 @@ static int lan865x_default_config(const struct device *dev, uint8_t silicon_rev)
 	if (ret < 0)
 		return ret;
 
-	if (cfg->plca_enable) {
-		ret = lan865x_config_plca(dev, cfg->plca_node_id,
-					  cfg->plca_node_count,
-					  cfg->plca_burst_count,
-					  cfg->plca_burst_timer);
+	if (cfg->plca->enable) {
+		ret = lan865x_config_plca(dev, cfg->plca->node_id,
+					  cfg->plca->node_count,
+					  cfg->plca->burst_count,
+					  cfg->plca->burst_timer);
 		if (ret < 0) {
 			return ret;
 		}
@@ -552,17 +552,21 @@ static const struct ethernet_api lan865x_api_func = {
 };
 
 #define LAN865X_DEFINE(inst)                                                                       \
+	static struct lan865x_config_plca lan865x_config_plca_##inst = {                           \
+		.node_id = DT_INST_PROP(inst, plca_node_id),                                       \
+		.node_count = DT_INST_PROP(inst, plca_node_count),                                 \
+		.burst_count = DT_INST_PROP(inst, plca_burst_count),                               \
+		.burst_timer = DT_INST_PROP(inst, plca_burst_timer),                               \
+		.to_timer = DT_INST_PROP(inst, plca_to_timer),                                     \
+		.enable = DT_INST_PROP(inst, plca_enable),                                         \
+	};                                                                                         \
+												   \
 	static const struct lan865x_config lan865x_config_##inst = {                               \
 		.spi = SPI_DT_SPEC_INST_GET(inst, SPI_WORD_SET(8), 0),                             \
 		.interrupt = GPIO_DT_SPEC_INST_GET(inst, int_gpios),                               \
 		.reset = GPIO_DT_SPEC_INST_GET(inst, rst_gpios),                                   \
 		.timeout = CONFIG_ETH_LAN865X_TIMEOUT,                                             \
-		.plca_node_id = DT_INST_PROP(inst, plca_node_id),                                  \
-		.plca_node_count = DT_INST_PROP(inst, plca_node_count),                            \
-		.plca_burst_count = DT_INST_PROP(inst, plca_burst_count),                          \
-		.plca_burst_timer = DT_INST_PROP(inst, plca_burst_timer),                          \
-		.plca_to_timer = DT_INST_PROP(inst, plca_to_timer),                                \
-		.plca_enable = DT_INST_PROP(inst, plca_enable),                                    \
+		.plca = &lan865x_config_plca_##inst,                                               \
 	};                                                                                         \
 												   \
 	struct oa_tc6 oa_tc6_##inst = {                                                            \

--- a/drivers/ethernet/eth_lan865x_priv.h
+++ b/drivers/ethernet/eth_lan865x_priv.h
@@ -38,6 +38,15 @@
 /* Memory Map Sector (MMS) 10 (0xA) */
 #define LAN865x_DEVID MMS_REG(0xA, 0x094)
 
+struct lan865x_config_plca {
+	bool enable : 1; /* 1 - PLCA enable, 0 - CSMA/CD enable */
+	uint8_t node_id  /* PLCA node id range: 0 to 254 */;
+	uint8_t node_count;  /* PLCA node count range: 1 to 255 */
+	uint8_t burst_count;  /* PLCA burst count range: 0x0 to 0xFF */
+	uint8_t burst_timer;  /* PLCA burst timer */
+	uint8_t to_timer;  /* PLCA TO value */
+};
+
 struct lan865x_config {
 	struct spi_dt_spec spi;
 	struct gpio_dt_spec interrupt;
@@ -45,12 +54,7 @@ struct lan865x_config {
 	int32_t timeout;
 
 	/* PLCA */
-	bool plca_enable : 1; /* 1 - PLCA enable, 0 - CSMA/CD enable */
-	uint8_t plca_node_id  /* PLCA node id range: 0 to 254 */;
-	uint8_t plca_node_count;  /* PLCA node count range: 1 to 255 */
-	uint8_t plca_burst_count;  /* PLCA burst count range: 0x0 to 0xFF */
-	uint8_t plca_burst_timer;  /* PLCA burst timer */
-	uint8_t plca_to_timer;  /* PLCA TO value */
+	struct lan865x_config_plca *plca;
 
 	/* MAC */
 	bool tx_cut_through_mode; /* 1 - tx cut through, 0 - Store and forward */

--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -196,6 +196,7 @@ enum ethernet_config_type {
 	ETHERNET_CONFIG_TYPE_PRIORITY_QUEUES_NUM,
 	ETHERNET_CONFIG_TYPE_FILTER,
 	ETHERNET_CONFIG_TYPE_PORTS_NUM,
+	ETHERNET_CONFIG_TYPE_T1S_PARAM,
 };
 
 enum ethernet_qav_param_type {
@@ -206,7 +207,53 @@ enum ethernet_qav_param_type {
 	ETHERNET_QAV_PARAM_TYPE_STATUS,
 };
 
+enum ethernet_t1s_param_type {
+	ETHERNET_T1S_PARAM_TYPE_PLCA_CONFIG,
+};
+
 /** @endcond */
+struct ethernet_t1s_param {
+	/** Type of T1S parameter */
+	enum ethernet_t1s_param_type type;
+	union {
+		/* PLCA is the Physical Layer (PHY) Collision
+		 * Avoidance technique employed with multidrop
+		 * 10Base-T1S standard.
+		 *
+		 * The PLCA parameters are described in standard [1]
+		 * as registers in memory map 4 (MMS = 4) (point 9.6).
+		 *
+		 * IDVER	(PLCA ID Version)
+		 * CTRL0	(PLCA Control 0)
+		 * CTRL1	(PLCA Control 1)
+		 * STATUS	(PLCA Status)
+		 * TOTMR	(PLCA TO Control)
+		 * BURST	(PLCA Burst Control)
+		 *
+		 * Those registers are implemented by each OA TC6
+		 * compliant vendor (like for e.g. LAN865x - e.g. [2]).
+		 *
+		 * Documents:
+		 * [1] - "OPEN Alliance 10BASE-T1x MAC-PHY Serial
+		 *       Interface" (ver. 1.1)
+		 * [2] - "DS60001734C" - LAN865x data sheet
+		 */
+		struct {
+			/** T1S PLCA enabled */
+			bool enable;
+			/** T1S PLCA node id range: 0 to 254 */
+			uint8_t node_id;
+			/** T1S PLCA node count range: 1 to 255 */
+			uint8_t node_count;
+			/** T1S PLCA burst count range: 0x0 to 0xFF */
+			uint8_t burst_count;
+			/** T1S PLCA burst timer */
+			uint8_t burst_timer;
+			/** T1S PLCA TO value */
+			uint8_t to_timer;
+		} plca;
+	};
+};
 
 struct ethernet_qav_param {
 	/** ID of the priority queue to use */
@@ -404,6 +451,7 @@ struct ethernet_config {
 
 		struct net_eth_addr mac_address;
 
+		struct ethernet_t1s_param t1s_param;
 		struct ethernet_qav_param qav_param;
 		struct ethernet_qbv_param qbv_param;
 		struct ethernet_qbu_param qbu_param;

--- a/include/zephyr/net/ethernet_mgmt.h
+++ b/include/zephyr/net/ethernet_mgmt.h
@@ -51,6 +51,7 @@ enum net_request_ethernet_cmd {
 	NET_REQUEST_ETHERNET_CMD_GET_QBV_PARAM,
 	NET_REQUEST_ETHERNET_CMD_GET_QBU_PARAM,
 	NET_REQUEST_ETHERNET_CMD_GET_TXTIME_PARAM,
+	NET_REQUEST_ETHERNET_CMD_SET_T1S_PARAM,
 };
 
 #define NET_REQUEST_ETHERNET_SET_AUTO_NEGOTIATION			\
@@ -128,6 +129,11 @@ NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_ETHERNET_GET_QBU_PARAM);
 
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_ETHERNET_GET_TXTIME_PARAM);
 
+#define NET_REQUEST_ETHERNET_SET_T1S_PARAM				\
+	(_NET_ETHERNET_BASE | NET_REQUEST_ETHERNET_CMD_SET_T1S_PARAM)
+
+NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_ETHERNET_SET_T1S_PARAM);
+
 struct net_eth_addr;
 struct ethernet_qav_param;
 struct ethernet_qbv_param;
@@ -152,6 +158,7 @@ struct ethernet_req_params {
 		struct ethernet_qbv_param qbv_param;
 		struct ethernet_qbu_param qbu_param;
 		struct ethernet_txtime_param txtime_param;
+		struct ethernet_t1s_param t1s_param;
 
 		int priority_queues_num;
 		int ports_num;

--- a/subsys/net/l2/ethernet/ethernet_mgmt.c
+++ b/subsys/net/l2/ethernet/ethernet_mgmt.c
@@ -192,6 +192,14 @@ static int ethernet_set_config(uint32_t mgmt_request,
 
 		config.promisc_mode = params->promisc_mode;
 		type = ETHERNET_CONFIG_TYPE_PROMISC_MODE;
+	} else if (mgmt_request == NET_REQUEST_ETHERNET_SET_T1S_PARAM) {
+		if (net_if_is_up(iface)) {
+			return -EACCES;
+		}
+
+		memcpy(&config.t1s_param, &params->t1s_param,
+		       sizeof(struct ethernet_t1s_param));
+		type = ETHERNET_CONFIG_TYPE_T1S_PARAM;
 	} else {
 		return -EINVAL;
 	}
@@ -224,6 +232,9 @@ NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_ETHERNET_SET_TXTIME_PARAM,
 				  ethernet_set_config);
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_ETHERNET_SET_PROMISC_MODE,
+				  ethernet_set_config);
+
+NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_ETHERNET_SET_T1S_PARAM,
 				  ethernet_set_config);
 
 static int ethernet_get_config(uint32_t mgmt_request,


### PR DESCRIPTION
This patch set adds support for adjusting from the user Zephyr program the PLCA configuration of LAN865x.

To achieve this goal some generic code has been added to core ethernet structures (so one can proceed in a similar way to
adjusting MAC address or QVA parameters).

Additionally, some LAN865x patches to allow resetting this IC - not only after power up - are added; e.g. protected control transmission as well as some cleanups .

This patch set shall be applied on top of: https://github.com/zephyrproject-rtos/zephyr/pull/65507

Code with example user program code (echo-server.c) to change PLCA parameters: https://github.com/lmajewski/zephyr/commits/t1s-lan8651-plca-adj-example

