### PR TITLE
tests: modem: backend: Add fixture to test suite

### DIFF
--- a/tests/subsys/modem/backends/uart/boards/b_u585i_iot02a.overlay
+++ b/tests/subsys/modem/backends/uart/boards/b_u585i_iot02a.overlay
@@ -1,34 +1,11 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 /*
- * Pins 2 and 3 must be connected to each other on the STMOD+1 connector to
- * loopback RX/TX.
+ * The Arduino D0 and D1 must be connected to each other to loopback RX/TX.
  */
 
-/ {
-	aliases {
-		test-uart = &usart2;
-	};
-};
-
-&gpioh {
-	misc_fixed_usart2 {
-		gpio-hog;
-		gpios = <13 GPIO_ACTIVE_HIGH>;
-		output-high;
-	};
-};
-
-&gpdma1 {
-	status = "okay";
-};
-
-&usart2 {
-	pinctrl-0 = <&usart2_tx_pa2 &usart2_rx_pa3 &usart2_rts_pa1 &usart2_cts_pa0>;
-	pinctrl-names = "default";
-	current-speed = <115200>;
-
-	dmas = <&gpdma1 0 27 STM32_DMA_PERIPH_TX
-		&gpdma1 1 26 STM32_DMA_PERIPH_RX>;
+dut: &usart3 {
+	dmas = <&gpdma1 0 29 STM32_DMA_PERIPH_TX
+		&gpdma1 1 28 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
-
-	status = "okay";
 };

--- a/tests/subsys/modem/backends/uart/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/tests/subsys/modem/backends/uart/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,37 +1,31 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 /*
- * Pins P1.10 and P1.11 must be connected to each other to loopback RX/TX.
+ * Pins P0.4 and P0.5 must be connected to each other to loopback RX/TX.
  */
 
-/ {
-	aliases {
-		test-uart = &uart1;
-	};
-};
-
-&uart1 {
-	status = "okay";
-	current-speed = <115200>;
-	pinctrl-0 = <&uart1_default>;
-	pinctrl-1 = <&uart1_sleep>;
-	hw-flow-control;
-	pinctrl-names = "default", "sleep";
-};
-
 &pinctrl {
-	uart1_default: uart1_default {
+	uart1_default_alt: uart1_default_alt {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 1, 11)>;
-		};
-		group2 {
-			psels = <NRF_PSEL(UART_RX, 1, 10)>;
+			psels = <NRF_PSEL(UART_TX, 0, 4)>,
+				<NRF_PSEL(UART_RX, 0, 5)>;
 		};
 	};
 
-	uart1_sleep: uart1_sleep {
+	uart1_sleep_alt: uart1_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 1, 10)>,
-				<NRF_PSEL(UART_RX, 1, 11)>;
+			psels = <NRF_PSEL(UART_TX, 0, 4)>,
+				<NRF_PSEL(UART_RX, 0, 5)>;
 			low-power-enable;
 		};
 	};
+};
+
+dut: &uart1 {
+	compatible = "nordic,nrf-uarte";
+	current-speed = <115200>;
+	status = "okay";
+	pinctrl-0 = <&uart1_default_alt>;
+	pinctrl-1 = <&uart1_sleep_alt>;
+	pinctrl-names = "default", "sleep";
 };

--- a/tests/subsys/modem/backends/uart/src/main.c
+++ b/tests/subsys/modem/backends/uart/src/main.c
@@ -28,7 +28,7 @@
 /*************************************************************************************************/
 /*                                          Mock pipe                                            */
 /*************************************************************************************************/
-static const struct device *uart = DEVICE_DT_GET(DT_ALIAS(test_uart));
+static const struct device *uart = DEVICE_DT_GET(DT_NODELABEL(dut));
 static struct modem_backend_uart uart_backend;
 static struct modem_pipe *pipe;
 K_SEM_DEFINE(receive_ready_sem, 0, 1);

--- a/tests/subsys/modem/backends/uart/testcase.yaml
+++ b/tests/subsys/modem/backends/uart/testcase.yaml
@@ -1,21 +1,19 @@
 # Copyright (c) 2023 Trackunit Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+common:
+  harness: ztest
+  harness_config:
+    fixture: gpio_loopback
+  platform_allow:
+    - b_u585i_iot02a
+    - nrf5340dk_nrf5340_cpuapp
+
 tests:
   modem.backends.uart.async:
-    tags: modem_backend
-    harness: ztest
-    platform_allow:
-      - b_u585i_iot02a
-      - nrf5340dk_nrf5340_cpuapp
     extra_configs:
       - CONFIG_UART_ASYNC_API=y
 
   modem.backends.uart.isr:
-    tags: modem_backend
-    harness: ztest
-    platform_allow:
-      - b_u585i_iot02a
-      - nrf5340dk_nrf5340_cpuapp
     extra_configs:
       - CONFIG_UART_INTERRUPT_DRIVEN=y


### PR DESCRIPTION
The tests in this testcase require physical modification of the boards to be performed. This is now documented using the `fixture: gpio_loopback` and `notes:` properties.

Fixes: #65559 