### PR TITLE
net: tls_credentials: Add missing include dir for PSA API

### DIFF
--- a/subsys/net/lib/tls_credentials/CMakeLists.txt
+++ b/subsys/net/lib/tls_credentials/CMakeLists.txt
@@ -15,3 +15,9 @@ zephyr_library_sources_ifdef(CONFIG_TLS_CREDENTIALS_SHELL
 )
 
 zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)
+
+if (CONFIG_TLS_CREDENTIALS_BACKEND_PROTECTED_STORAGE AND CONFIG_BUILD_WITH_TFM)
+  target_include_directories(${ZEPHYR_CURRENT_LIBRARY} PRIVATE
+    $<TARGET_PROPERTY:tfm,TFM_BINARY_DIR>/install/interface/include
+  )
+endif()


### PR DESCRIPTION
Protected credential storage makes use of the PSA API, therefore it must be present in the library include path. This was missed during the recent CMakeLists.txt rework of this library.

Fixes #65664