### PR TITLE
soc: mimx9: Remove SAI and EDMA static mappings

### DIFF
--- a/soc/arm64/nxp_imx/mimx9/mmu_regions.c
+++ b/soc/arm64/nxp_imx/mimx9/mmu_regions.c
@@ -51,21 +51,6 @@ static const struct arm_mmu_region mmu_regions[] = {
 			      DT_REG_SIZE(DT_NODELABEL(mu2_a)),
 			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS),
 
-	MMU_REGION_FLAT_ENTRY("SAI3",
-			      DT_REG_ADDR(DT_NODELABEL(sai3)),
-			      DT_REG_SIZE(DT_NODELABEL(sai3)),
-			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS),
-
-	MMU_REGION_FLAT_ENTRY("EDMA2_CH0",
-			      DT_REG_ADDR(DT_NODELABEL(edma2_ch0)),
-			      DT_REG_SIZE(DT_NODELABEL(edma2_ch0)),
-			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS),
-
-	MMU_REGION_FLAT_ENTRY("EDMA2_CH1",
-			      DT_REG_ADDR(DT_NODELABEL(edma2_ch1)),
-			      DT_REG_SIZE(DT_NODELABEL(edma2_ch1)),
-			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS),
-
 	MMU_REGION_FLAT_ENTRY("OUTBOX",
 			      DT_REG_ADDR(DT_NODELABEL(outbox)),
 			      DT_REG_SIZE(DT_NODELABEL(outbox)),


### PR DESCRIPTION
With the introduction of the SAI and EDMA drivers, there's
no longer a need to map the MMIOs using the mmu_regions.c
method since this is taken care of by the drivers via
device_map(). As such, remove entries for EDMA and SAI from
mmu_regions.c.