### PR TITLE
include: drivers: dai: Align DAI direction with SOF direction

### DIFF
--- a/include/zephyr/drivers/dai.h
+++ b/include/zephyr/drivers/dai.h
@@ -64,10 +64,10 @@ enum dai_type {
  * @brief DAI Direction
  */
 enum dai_dir {
-	/** Receive data */
-	DAI_DIR_RX = 1,
 	/** Transmit data */
-	DAI_DIR_TX,
+	DAI_DIR_TX = 0,
+	/** Receive data */
+	DAI_DIR_RX,
 	/** Both receive and transmit data */
 	DAI_DIR_BOTH,
 };


### PR DESCRIPTION
Currently, DAI_DIR_TX and DAI_DIR_RX have different values from SOF_IPC_STREAM_PLAYBACK and SOF_IPC_STREAM_CAPTURE. Since SOF performs no conversion from one encoding to another this may lead DAI operations performed on the wrong directions.

Since it's much easier to just change the values for DAI_DIR_TX and DAI_DIR_RX rather than try to perform a conversion from one format to another on SOF side, this commit changes DAI_DIR_TX to 0 (equal to SOF_IPC_STREAM_PLAYBACK) and DAI_DIR_RX to 1 (equal to SOF_IPC_STREAM_CAPTURE).