### PR TITLE
drivers: cellular: add rssi / modem information

### DIFF
--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -7,6 +7,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/cellular.h>
 #include <zephyr/modem/chat.h>
 #include <zephyr/modem/cmux.h>
 #include <zephyr/modem/pipe.h>
@@ -24,6 +25,13 @@ LOG_MODULE_REGISTER(modem_cellular, CONFIG_MODEM_LOG_LEVEL);
 
 #define MODEM_CELLULAR_PERIODIC_SCRIPT_TIMEOUT \
 	K_MSEC(CONFIG_MODEM_CELLULAR_PERIODIC_SCRIPT_MS)
+
+#define MODEM_CELLULAR_DATA_IMEI_LEN         (15)
+#define MODEM_CELLULAR_DATA_MODEL_ID_LEN     (64)
+#define MODEM_CELLULAR_DATA_IMSI_LEN         (22)
+#define MODEM_CELLULAR_DATA_ICCID_LEN        (22)
+#define MODEM_CELLULAR_DATA_MANUFACTURER_LEN (64)
+#define MODEM_CELLULAR_DATA_FW_VERSION_LEN   (64)
 
 enum modem_cellular_state {
 	MODEM_CELLULAR_STATE_IDLE = 0,
@@ -83,11 +91,16 @@ struct modem_cellular_data {
 	uint8_t *chat_argv[32];
 
 	/* Status */
-	uint8_t imei[15];
-	uint8_t hwinfo[64];
 	uint8_t registration_status_gsm;
 	uint8_t registration_status_gprs;
 	uint8_t registration_status_lte;
+	int8_t rssi;
+	uint8_t imei[MODEM_CELLULAR_DATA_IMEI_LEN];
+	uint8_t model_id[MODEM_CELLULAR_DATA_MODEL_ID_LEN];
+	uint8_t imsi[MODEM_CELLULAR_DATA_IMSI_LEN];
+	uint8_t iccid[MODEM_CELLULAR_DATA_ICCID_LEN];
+	uint8_t manufacturer[MODEM_CELLULAR_DATA_MANUFACTURER_LEN];
+	uint8_t fw_version[MODEM_CELLULAR_DATA_FW_VERSION_LEN];
 
 	/* PPP */
 	struct modem_ppp *ppp;
@@ -117,6 +130,7 @@ struct modem_cellular_config {
 	const struct modem_chat_script *init_chat_script;
 	const struct modem_chat_script *dial_chat_script;
 	const struct modem_chat_script *periodic_chat_script;
+	const struct modem_chat_script *get_signal_chat_script;
 };
 
 static const char *modem_cellular_state_str(enum modem_cellular_state state)
@@ -275,13 +289,7 @@ static void modem_cellular_chat_on_imei(struct modem_chat *chat, char **argv, ui
 		return;
 	}
 
-	if (strlen(argv[1]) != 15) {
-		return;
-	}
-
-	for (uint8_t i = 0; i < 15; i++) {
-		data->imei[i] = argv[1][i] - '0';
-	}
+	strncpy(data->imei, argv[1], sizeof(data->imei));
 }
 
 static void modem_cellular_chat_on_cgmm(struct modem_chat *chat, char **argv, uint16_t argc,
@@ -293,7 +301,74 @@ static void modem_cellular_chat_on_cgmm(struct modem_chat *chat, char **argv, ui
 		return;
 	}
 
-	strncpy(data->hwinfo, argv[1], sizeof(data->hwinfo) - 1);
+	strncpy(data->model_id, argv[1], sizeof(data->model_id));
+}
+
+static void modem_cellular_chat_on_cgmi(struct modem_chat *chat, char **argv, uint16_t argc,
+					void *user_data)
+{
+	struct modem_cellular_data *data = (struct modem_cellular_data *)user_data;
+
+	if (argc != 2) {
+		return;
+	}
+
+	strncpy(data->manufacturer, argv[1], sizeof(data->manufacturer));
+}
+
+static void modem_cellular_chat_on_cgmr(struct modem_chat *chat, char **argv, uint16_t argc,
+					void *user_data)
+{
+	struct modem_cellular_data *data = (struct modem_cellular_data *)user_data;
+
+	if (argc != 2) {
+		return;
+	}
+
+	strncpy(data->fw_version, argv[1], sizeof(data->fw_version));
+}
+
+static void modem_cellular_chat_on_csq(struct modem_chat *chat, char **argv, uint16_t argc,
+				       void *user_data)
+{
+	uint8_t rssi;
+
+	/* AT+CSQ returns a response +CSQ: <rssi>,<ber> where:
+	 * - rssi is a integer from 0 to 31 whose values describes a signal strength
+	 *   between -113 dBm for 0 and -51dbM for 31 or unknown for 99
+	 * - ber is an integer from 0 to 7 that describes the error rate, it can also
+	 *   be 99 for an unknown error rate
+	 */
+	struct modem_cellular_data *data = (struct modem_cellular_data *)user_data;
+
+	if (argc != 3) {
+		return;
+	}
+
+	/* Read rssi */
+	rssi = atoi(argv[1]);
+
+	if (rssi == 99) {
+		return;
+	}
+
+	data->rssi = (-113 + (2 * rssi));
+}
+
+static void modem_cellular_chat_on_imsi(struct modem_chat *chat, char **argv, uint16_t argc,
+					void *user_data)
+{
+	struct modem_cellular_data *data = (struct modem_cellular_data *)user_data;
+
+	strncpy(data->imsi, (char *)argv[1], sizeof(data->imsi));
+}
+
+static void modem_cellular_chat_on_iccid(struct modem_chat *chat, char **argv, uint16_t argc,
+					 void *user_data)
+{
+	struct modem_cellular_data *data = (struct modem_cellular_data *)user_data;
+
+	strncpy(data->iccid, (char *)argv[1], sizeof(data->iccid));
 }
 
 static bool modem_cellular_is_registered(struct modem_cellular_data *data)
@@ -345,6 +420,11 @@ MODEM_CHAT_MATCHES_DEFINE(allow_match,
 
 MODEM_CHAT_MATCH_DEFINE(imei_match, "", "", modem_cellular_chat_on_imei);
 MODEM_CHAT_MATCH_DEFINE(cgmm_match, "", "", modem_cellular_chat_on_cgmm);
+MODEM_CHAT_MATCH_DEFINE(csq_match, "+CSQ: ", ",", modem_cellular_chat_on_csq);
+MODEM_CHAT_MATCH_DEFINE(cimi_match, "", "", modem_cellular_chat_on_imsi);
+MODEM_CHAT_MATCH_DEFINE(ccid_match, "+QCCID: ", "", modem_cellular_chat_on_iccid);
+MODEM_CHAT_MATCH_DEFINE(cgmi_match, "", "", modem_cellular_chat_on_cgmi);
+MODEM_CHAT_MATCH_DEFINE(cgmr_match, "", "", modem_cellular_chat_on_cgmr);
 
 MODEM_CHAT_MATCHES_DEFINE(unsol_matches,
 			  MODEM_CHAT_MATCH("+CREG: ", ",", modem_cellular_chat_on_cxreg),
@@ -1330,6 +1410,14 @@ MODEM_CHAT_SCRIPT_CMDS_DEFINE(quectel_bg95_init_chat_script_cmds,
 			      MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMM", cgmm_match),
 			      MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMI", cgmi_match),
+			      MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMR", cgmr_match),
+			      MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CIMI", cimi_match),
+			      MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+QCCID", ccid_match),
+			      MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
 			      MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT+CMUX=0,0,5,127", 300));
 
 MODEM_CHAT_SCRIPT_DEFINE(quectel_bg95_init_chat_script, quectel_bg95_init_chat_script_cmds,
@@ -1349,29 +1437,45 @@ MODEM_CHAT_SCRIPT_DEFINE(quectel_bg95_dial_chat_script, quectel_bg95_dial_chat_s
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(quectel_bg95_periodic_chat_script_cmds,
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CREG?", ok_match),
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CEREG?", ok_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGREG?", ok_match));
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGREG?", ok_match),
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CSQ", csq_match));
 
 MODEM_CHAT_SCRIPT_DEFINE(quectel_bg95_periodic_chat_script,
 			 quectel_bg95_periodic_chat_script_cmds, abort_matches,
 			 modem_cellular_chat_callback_handler, 4);
+
+MODEM_CHAT_SCRIPT_CMDS_DEFINE(quectel_bg95_get_signal_chat_script_cmds,
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CSQ", csq_match));
+
+MODEM_CHAT_SCRIPT_DEFINE(quectel_bg95_get_signal_chat_script,
+			 quectel_bg95_get_signal_chat_script_cmds, abort_matches,
+			 modem_cellular_chat_callback_handler, 4);
 #endif
 
 #if DT_HAS_COMPAT_STATUS_OKAY(quectel_eg25_g)
-MODEM_CHAT_SCRIPT_CMDS_DEFINE(quectel_eg25_g_init_chat_script_cmds,
-			      MODEM_CHAT_SCRIPT_CMD_RESP("ATE0", ok_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CFUN=4", ok_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CMEE=1", ok_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CREG=1", ok_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGREG=1", ok_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CEREG=1", ok_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CREG?", ok_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CEREG?", ok_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGREG?", ok_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGSN", imei_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMM", cgmm_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT+CMUX=0,0,5,127,10,3,30,10,2",
-							      100));
+MODEM_CHAT_SCRIPT_CMDS_DEFINE(
+	quectel_eg25_g_init_chat_script_cmds, MODEM_CHAT_SCRIPT_CMD_RESP("ATE0", ok_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CFUN=4", ok_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CMEE=1", ok_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CREG=1", ok_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGREG=1", ok_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CEREG=1", ok_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CREG?", ok_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CEREG?", ok_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGREG?", ok_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGSN", imei_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMM", cgmm_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMI", cgmi_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMR", cgmr_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CIMI", cimi_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT+QCCID", ccid_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT+CMUX=0,0,5,127,10,3,30,10,2", 100));
 
 MODEM_CHAT_SCRIPT_DEFINE(quectel_eg25_g_init_chat_script, quectel_eg25_g_init_chat_script_cmds,
 			 abort_matches, modem_cellular_chat_callback_handler, 10);
@@ -1390,10 +1494,18 @@ MODEM_CHAT_SCRIPT_DEFINE(quectel_eg25_g_dial_chat_script, quectel_eg25_g_dial_ch
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(quectel_eg25_g_periodic_chat_script_cmds,
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CREG?", ok_match),
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CEREG?", ok_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGREG?", ok_match));
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGREG?", ok_match),
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CSQ", csq_match));
 
 MODEM_CHAT_SCRIPT_DEFINE(quectel_eg25_g_periodic_chat_script,
 			 quectel_eg25_g_periodic_chat_script_cmds, abort_matches,
+			 modem_cellular_chat_callback_handler, 4);
+
+MODEM_CHAT_SCRIPT_CMDS_DEFINE(quectel_eg25_g_get_signal_chat_script_cmds,
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CSQ", csq_match));
+
+MODEM_CHAT_SCRIPT_DEFINE(quectel_eg25_g_get_signal_chat_script,
+			 quectel_eg25_g_get_signal_chat_script_cmds, abort_matches,
 			 modem_cellular_chat_callback_handler, 4);
 #endif
 
@@ -1657,7 +1769,8 @@ MODEM_CHAT_SCRIPT_DEFINE(telit_me910g1_periodic_chat_script,
 		.shutdown_time_ms = 5000,                                                          \
 		.init_chat_script = &quectel_bg95_init_chat_script,                                \
 		.dial_chat_script = &quectel_bg95_dial_chat_script,                                \
-		.periodic_chat_script = &quectel_bg95_periodic_chat_script,                        \
+		.periodic_chat_script = &_CONCAT(DT_DRV_COMPAT, _periodic_chat_script),            \
+		.get_signal_chat_script = &_CONCAT(DT_DRV_COMPAT, _get_signal_chat_script),        \
 	};                                                                                         \
                                                                                                    \
 	PM_DEVICE_DT_INST_DEFINE(inst, modem_cellular_pm_action);                                  \
@@ -1686,6 +1799,7 @@ MODEM_CHAT_SCRIPT_DEFINE(telit_me910g1_periodic_chat_script,
 		.init_chat_script = &quectel_eg25_g_init_chat_script,                              \
 		.dial_chat_script = &quectel_eg25_g_dial_chat_script,                              \
 		.periodic_chat_script = &_CONCAT(DT_DRV_COMPAT, _periodic_chat_script),            \
+		.get_signal_chat_script = &_CONCAT(DT_DRV_COMPAT, _get_signal_chat_script),        \
 	};                                                                                         \
                                                                                                    \
 	PM_DEVICE_DT_INST_DEFINE(inst, modem_cellular_pm_action);                                  \
@@ -1861,3 +1975,70 @@ DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_SWIR_HL7800)
 #define DT_DRV_COMPAT telit_me910g1
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_TELIT_ME910G1)
 #undef DT_DRV_COMPAT
+
+int cellular_get_modem_info(const struct device *dev, enum cellular_modem_info_type type,
+			    char *info, size_t size)
+{
+	int ret = 0;
+	struct modem_cellular_data *data = (struct modem_cellular_data *)dev->data;
+
+	switch (type) {
+	case CELLULAR_MODEM_INFO_IMEI:
+		strncpy(info, &data->imei[0], MIN(size, sizeof(data->imei)));
+		break;
+	case CELLULAR_MODEM_INFO_SIM_IMSI:
+		strncpy(info, &data->imsi[0], MIN(size, sizeof(data->imsi)));
+		break;
+	case CELLULAR_MODEM_INFO_SIM_ICCID:
+		strncpy(info, &data->iccid[0], MIN(size, sizeof(data->iccid)));
+		break;
+	case CELLULAR_MODEM_INFO_MANUFACTURER:
+		strncpy(info, &data->manufacturer[0], MIN(size, sizeof(data->manufacturer)));
+		break;
+	case CELLULAR_MODEM_INFO_FW_VERSION:
+		strncpy(info, &data->fw_version[0], MIN(size, sizeof(data->fw_version)));
+		break;
+	case CELLULAR_MODEM_INFO_MODEL_ID:
+		strncpy(info, &data->model_id[0], MIN(size, sizeof(data->model_id)));
+		break;
+	default:
+		ret = -ENODATA;
+		break;
+	}
+
+	return ret;
+}
+
+int cellular_get_signal(const struct device *dev, const enum cellular_signal_type type,
+			int16_t *value)
+{
+	int ret;
+	struct modem_cellular_data *data = (struct modem_cellular_data *)dev->data;
+	const struct modem_cellular_config *config = (struct modem_cellular_config *)dev->config;
+
+	if (config->get_signal_chat_script == NULL) {
+		return -ENOTSUP;
+	}
+
+	if ((data->state != MODEM_CELLULAR_STATE_AWAIT_REGISTERED) &&
+	    (data->state != MODEM_CELLULAR_STATE_CARRIER_ON)) {
+		return -ENODATA;
+	}
+
+	ret = modem_chat_run_script(&data->chat, config->get_signal_chat_script);
+	if (ret != 0) {
+		return ret;
+	}
+
+	switch (type) {
+	case CELLULAR_SIGNAL_RSSI: {
+		*value = data->rssi;
+	} break;
+	case CELLULAR_SIGNAL_RSRP:
+		return -ENOTSUP;
+	case CELLULAR_SIGNAL_RSRQ:
+		return -ENOTSUP;
+	}
+
+	return ret;
+}

--- a/include/zephyr/drivers/cellular.h
+++ b/include/zephyr/drivers/cellular.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2023 Bjarki Arge Andreasen
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file drivers/cellular.h
+ * @brief Public cellular network API
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_CELLULAR_H_
+#define ZEPHYR_INCLUDE_DRIVERS_CELLULAR_H_
+
+/**
+ * @brief Cellular interface
+ * @defgroup cellular_interface Cellular Interface
+ * @ingroup io_interfaces
+ * @{
+ */
+
+#include <zephyr/types.h>
+#include <zephyr/device.h>
+#include <errno.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Cellular access technologies */
+enum cellular_access_technology {
+	CELLULAR_ACCESS_TECHNOLOGY_GSM = 0,
+	CELLULAR_ACCESS_TECHNOLOGY_GPRS,
+	CELLULAR_ACCESS_TECHNOLOGY_UMTS,
+	CELLULAR_ACCESS_TECHNOLOGY_EDGE,
+	CELLULAR_ACCESS_TECHNOLOGY_LTE,
+	CELLULAR_ACCESS_TECHNOLOGY_LTE_CAT_M1,
+	CELLULAR_ACCESS_TECHNOLOGY_LTE_CAT_M2,
+	CELLULAR_ACCESS_TECHNOLOGY_NB_IOT,
+};
+
+/** Cellular network structure */
+struct cellular_network {
+	/** Cellular access technology */
+	enum cellular_access_technology technology;
+	/**
+	 * List of bands, as defined by the specified cellular access technology,
+	 * to enables. All supported bands are enabled if none are provided.
+	 */
+	uint16_t *bands;
+	/** Size of bands */
+	uint16_t size;
+};
+
+/**
+ * @brief Configure cellular networks for the device
+ *
+ * @details Cellular network devices support at least one cellular access technology.
+ * Each cellular access technology defines a set of bands, of which the cellular device
+ * will support all or a subset of.
+ *
+ * The cellular device can only use one cellular network technology at a time. It must
+ * exclusively use the cellular network configurations provided, and will prioritize
+ * the cellular network configurations in the order they are provided in case there are
+ * multiple (the first cellular network configuration has the highest priority).
+ *
+ * @param dev Cellular network device instance.
+ * @param networks List of cellular network configurations to apply.
+ * @param size Size of list of cellular network configurations.
+ *
+ * @retval 0 if successful.
+ * @retval -EINVAL if any provided cellular network configuration is invalid or unsupported.
+ * @retval -ENOTSUP if API is not supported by cellular network device.
+ * @retval Negative errno-code otherwise.
+ */
+int cellular_configure_networks(const struct device *dev, const struct cellular_network *networks,
+				uint8_t size);
+
+/**
+ * @brief Get supported cellular networks for the device
+ *
+ * @param dev Cellular network device instance
+ * @param networks Pointer to list of supported cellular network configurations.
+ * @param size Size of list of cellular network configurations.
+ *
+ * @retval 0 if successful.
+ * @retval -ENOTSUP if API is not supported by cellular network device.
+ * @retval Negative errno-code otherwise.
+ */
+int cellular_get_supported_networks(const struct device *dev,
+				    const struct cellular_network **networks, uint8_t *size);
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_CELLULAR_H_ */

--- a/include/zephyr/drivers/cellular.h
+++ b/include/zephyr/drivers/cellular.h
@@ -52,6 +52,28 @@ struct cellular_network {
 	uint16_t size;
 };
 
+enum cellular_signal_type {
+	CELLULAR_SIGNAL_RSSI,
+	CELLULAR_SIGNAL_RSRP,
+	CELLULAR_SIGNAL_RSRQ,
+};
+
+/** Cellular modem info type */
+enum cellular_modem_info_type {
+	/** International Mobile Equipment Identity */
+	CELLULAR_MODEM_INFO_IMEI,
+	/** Modem model ID */
+	CELLULAR_MODEM_INFO_MODEL_ID,
+	/** Modem manufacturer */
+	CELLULAR_MODEM_INFO_MANUFACTURER,
+	/** Modem fw version */
+	CELLULAR_MODEM_INFO_FW_VERSION,
+	/** International Mobile Subscriber Identity */
+	CELLULAR_MODEM_INFO_SIM_IMSI,
+	/** Integrated Circuit Card Identification Number (SIM) */
+	CELLULAR_MODEM_INFO_SIM_ICCID,
+};
+
 /**
  * @brief Configure cellular networks for the device
  *
@@ -89,6 +111,37 @@ int cellular_configure_networks(const struct device *dev, const struct cellular_
  */
 int cellular_get_supported_networks(const struct device *dev,
 				    const struct cellular_network **networks, uint8_t *size);
+
+/**
+ * @brief Get signal for the device
+ *
+ * @param dev Cellular network device instance
+ * @param type Type of the signal information requested
+ * @param value Signal strength destination (one of RSSI, RSRP, RSRQ)
+ *
+ * @retval 0 if successful.
+ * @retval -ENOTSUP if API is not supported by cellular network device.
+ * @retval -ENODATA if device is not in a state where signal can be polled
+ * @retval Negative errno-code otherwise.
+ */
+int cellular_get_signal(const struct device *dev, const enum cellular_signal_type type,
+			int16_t *value);
+
+/**
+ * @brief Get modem info for the device
+ *
+ * @param dev Cellular network device instance
+ * @param type Type of the modem info requested
+ * @param info Info string destination
+ * @param size Info string size
+ *
+ * @retval 0 if successful.
+ * @retval -ENOTSUP if API is not supported by cellular network device.
+ * @retval -ENODATA if modem does not provide info requested
+ * @retval Negative errno-code from chat module otherwise.
+ */
+int cellular_get_modem_info(const struct device *dev, const enum cellular_modem_info_type type,
+			    char *info, size_t size);
 
 #ifdef __cplusplus
 }

--- a/samples/net/cellular_modem/src/main.c
+++ b/samples/net/cellular_modem/src/main.c
@@ -13,6 +13,8 @@
 #include <zephyr/pm/device_runtime.h>
 #include <string.h>
 
+#include <zephyr/drivers/cellular.h>
+
 #define SAMPLE_TEST_ENDPOINT_HOSTNAME		("test-endpoint.com")
 #define SAMPLE_TEST_ENDPOINT_UDP_ECHO_PORT	(7780)
 #define SAMPLE_TEST_ENDPOINT_UDP_RECEIVE_PORT	(7781)
@@ -41,6 +43,48 @@ static void init_sample_test_packet(void)
 {
 	for (size_t i = 0; i < sizeof(sample_test_packet); i++) {
 		sample_test_packet[i] = sample_prng_random();
+	}
+}
+
+static void print_cellular_info(void)
+{
+	int rc;
+	int16_t rssi;
+	char buffer[64];
+
+	rc = cellular_get_signal(modem, CELLULAR_SIGNAL_RSSI, &rssi);
+	if (!rc) {
+		printk("RSSI %d\n", rssi);
+	}
+
+	rc = cellular_get_modem_info(modem, CELLULAR_MODEM_INFO_IMEI, &buffer[0], sizeof(buffer));
+	if (!rc) {
+		printk("IMEI: %s\n", buffer);
+	}
+	rc = cellular_get_modem_info(modem, CELLULAR_MODEM_INFO_MODEL_ID, &buffer[0],
+				     sizeof(buffer));
+	if (!rc) {
+		printk("MODEL_ID: %s\n", buffer);
+	}
+	rc = cellular_get_modem_info(modem, CELLULAR_MODEM_INFO_MANUFACTURER, &buffer[0],
+				     sizeof(buffer));
+	if (!rc) {
+		printk("MANUFACTURER: %s\n", buffer);
+	}
+	rc = cellular_get_modem_info(modem, CELLULAR_MODEM_INFO_SIM_IMSI, &buffer[0],
+				     sizeof(buffer));
+	if (!rc) {
+		printk("SIM_IMSI: %s\n", buffer);
+	}
+	rc = cellular_get_modem_info(modem, CELLULAR_MODEM_INFO_SIM_ICCID, &buffer[0],
+				     sizeof(buffer));
+	if (!rc) {
+		printk("SIM_ICCID: %s\n", buffer);
+	}
+	rc = cellular_get_modem_info(modem, CELLULAR_MODEM_INFO_FW_VERSION, &buffer[0],
+				     sizeof(buffer));
+	if (!rc) {
+		printk("FW_VERSION: %s\n", buffer);
 	}
 }
 
@@ -263,6 +307,9 @@ int main(void)
 	ret = net_mgmt_event_wait_on_iface(net_if_get_default(),
 					   NET_EVENT_DNS_SERVER_ADD, &raised_event, &info,
 					   &info_len, K_SECONDS(10));
+
+	printk("Retrieving cellular info\n");
+	print_cellular_info();
 
 	printk("Performing DNS lookup of %s\n", SAMPLE_TEST_ENDPOINT_HOSTNAME);
 	ret = sample_dns_request();


### PR DESCRIPTION
Hello, this PR is an effort to bring a method to pull things like RSSI or modem / SIM information from an app. 
It leverages the new periodic script and the begining of the cellular API implemented by @bjarki-trackunit . 
The PR right now is not in a mergeable state but I'd be keen for maintainers to have a look at it and start a conversation around the fundamentals of it:
- does it fit in the architecture ? 
- are there shortcomings I'm not aware of ?
- is it too early for a PR like this ?