### PR TITLE
MAINTAINERS: Better match for POSIX area documentation

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -473,7 +473,7 @@ CMSIS API layer:
     - include/zephyr/portability/cmsis*
     - samples/subsys/portability/cmsis_rtos_v*/
     - tests/subsys/portability/cmsis_rtos_v*/
-    - doc/services/portability/
+    - doc/services/portability/cmsis*
   labels:
     - "area: CMSIS API Layer"
     - "area: Portability"
@@ -2248,6 +2248,7 @@ POSIX API layer:
     - tests/posix/
     - samples/posix/
     - tests/lib/fdtable/
+    - doc/services/portability/posix/
   labels:
     - "area: POSIX"
 

--- a/doc/_scripts/redirects.py
+++ b/doc/_scripts/redirects.py
@@ -71,7 +71,6 @@ REDIRECTS = [
     ('guides/pm/power_domain', 'services/pm/power_domain'),
     ('guides/pm/system', 'services/pm/system'),
     ('guides/portability/index', 'services/portability/index'),
-    ('guides/portability/posix', 'services/portability/posix/index'),
     ('guides/porting/arch', 'hardware/porting/arch'),
     ('guides/porting/board_porting', 'hardware/porting/board_porting'),
     ('guides/porting/index', 'hardware/porting/index'),
@@ -165,4 +164,5 @@ REDIRECTS = [
     ('reference/util/index', 'kernel/util/index'),
     ('samples/drivers/kscan_touch', 'samples/subsys/input/input'),
     ('samples/net/cloud/google_iot_mqtt', 'samples/net/cloud'),
+    ('services/portability/posix', 'services/portability/posix/index'),
 ]


### PR DESCRIPTION
Fixed `services/portability` patterns to make sure POSIX docs ends up in POSIX area, not CMSIS.

Bonus commit: fixed broken redirect entry which would have only worked for really old versions of the doc, not ex. 3.5 that has `services/portability/posix` url.