### PR TITLE
check_init_priorities fix for native simulator targets & enable tests for native_sim

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1751,7 +1751,6 @@ if(CONFIG_BUILD_OUTPUT_EXE)
       post_build_byproducts
       ${KERNEL_EXE_NAME}
       )
-    set(BYPRODUCT_KERNEL_EXE_NAME "${PROJECT_BINARY_DIR}/${KERNEL_EXE_NAME}" CACHE FILEPATH "Kernel exe file" FORCE)
   else()
     if(CMAKE_GENERATOR STREQUAL "Unix Makefiles")
       set(MAKE "${CMAKE_MAKE_PROGRAM}" CACHE FILEPATH "cmake defined make")
@@ -1768,6 +1767,7 @@ if(CONFIG_BUILD_OUTPUT_EXE)
       BYPRODUCTS ${KERNEL_EXE_NAME}
     )
   endif()
+  set(BYPRODUCT_KERNEL_EXE_NAME "${PROJECT_BINARY_DIR}/${KERNEL_EXE_NAME}" CACHE FILEPATH "Kernel exe file" FORCE)
 endif()
 
 if(CONFIG_BUILD_OUTPUT_INFO_HEADER)
@@ -1784,21 +1784,32 @@ if(CONFIG_BUILD_OUTPUT_INFO_HEADER)
     )
 endif()
 
-if(CONFIG_CHECK_INIT_PRIORITIES)
-  list(APPEND
-    post_build_commands
-    COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/check_init_priorities.py
-      --elf-file=${ZEPHYR_BINARY_DIR}/${KERNEL_ELF_NAME}
-    )
-endif()
-
 if(NOT CMAKE_C_COMPILER_ID STREQUAL "ARMClang")
+  set(check_init_priorities_input
+      $<IF:$<TARGET_EXISTS:native_runner_executable>,${BYPRODUCT_KERNEL_EXE_NAME},${BYPRODUCT_KERNEL_ELF_NAME}>
+  )
+  set(check_init_priorities_command
+      ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/check_init_priorities.py
+      --elf-file=${check_init_priorities_input}
+  )
+  set(check_init_priorities_dependencies
+      ${logical_target_for_zephyr_elf}
+      $<$<TARGET_EXISTS:native_runner_executable>:native_runner_executable>
+  )
+
+  if(CONFIG_CHECK_INIT_PRIORITIES)
+    add_custom_target(
+      check_init_priorities
+      ALL
+      COMMAND ${check_init_priorities_command}
+      DEPENDS ${check_init_priorities_dependencies}
+    )
+  endif()
+
   add_custom_target(
     initlevels
-    COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/check_init_priorities.py
-      --elf-file=${ZEPHYR_BINARY_DIR}/${KERNEL_ELF_NAME}
-      --initlevels
-    DEPENDS ${logical_target_for_zephyr_elf}
+    COMMAND ${check_init_priorities_command} --initlevels
+    DEPENDS ${check_init_priorities_dependencies}
     USES_TERMINAL
   )
 endif()

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -777,7 +777,9 @@ config BUILD_OUTPUT_STRIP_PATHS
 config CHECK_INIT_PRIORITIES
 	bool "Build time initialization priorities check"
 	default y
-	depends on !NATIVE_LIBRARY
+	# If we are building a native_simulator target, we can only check the init priorities
+	# if we are building the final output but we are not assembling several images together
+	depends on !(NATIVE_LIBRARY && (!BUILD_OUTPUT_EXE || NATIVE_SIMULATOR_EXTRA_IMAGE_PATHS != ""))
 	depends on "$(ZEPHYR_TOOLCHAIN_VARIANT)" != "armclang"
 	help
 	  Check the build for initialization priority issues by comparing the

--- a/tests/misc/check_init_priorities/CMakeLists.txt
+++ b/tests/misc/check_init_priorities/CMakeLists.txt
@@ -8,10 +8,12 @@ set(output_file ${PROJECT_BINARY_DIR}/check_init_priorities_output.txt)
 add_custom_command(
 	COMMENT "Running check_init_priorities.py"
 	OUTPUT ${output_file}
-	DEPENDS ${BYPRODUCT_KERNEL_ELF_NAME}
+	DEPENDS
+	  ${logical_target_for_zephyr_elf}
+	  $<$<TARGET_EXISTS:native_runner_executable>:native_runner_executable>
 	COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/check_init_priorities.py
+	  --elf-file=$<IF:$<TARGET_EXISTS:native_runner_executable>,${BYPRODUCT_KERNEL_EXE_NAME},${BYPRODUCT_KERNEL_ELF_NAME}>
 	  --verbose
-	  --elf-file=${ZEPHYR_BINARY_DIR}/${KERNEL_ELF_NAME}
 	  --output ${output_file}
 	  --always-succeed
 	COMMAND ${PYTHON_EXECUTABLE} ${APPLICATION_SOURCE_DIR}/validate_check_init_priorities_output.py

--- a/tests/misc/check_init_priorities/boards/native_posix.overlay
+++ b/tests/misc/check_init_priorities/boards/native_posix.overlay
@@ -4,35 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	test_gpio_0: gpio@ffff {
-		gpio-controller;
-		#gpio-cells = <0x2>;
-		compatible = "vnd,gpio-device";
-		status = "okay";
-		reg = <0xffff 0x1000>;
-	};
-
-	test_i2c: i2c@11112222 {
-		#address-cells = <1>;
-		#size-cells = <0>;
-		compatible = "vnd,i2c";
-		status = "okay";
-		reg = <0x11112222 0x1000>;
-		clock-frequency = <100000>;
-
-		test_dev_a: test-i2c-dev@10 {
-			compatible = "vnd,i2c-device";
-			status = "okay";
-			reg = <0x10>;
-			supply-gpios = <&test_gpio_0 1 0>;
-		};
-
-		test_dev_b: test-i2c-dev@11 {
-			compatible = "vnd,i2c-device";
-			status = "okay";
-			reg = <0x11>;
-			supply-gpios = <&test_gpio_0 2 0>;
-		};
-	};
-};
+#include "native_sim.overlay"

--- a/tests/misc/check_init_priorities/boards/native_sim.overlay
+++ b/tests/misc/check_init_priorities/boards/native_sim.overlay
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	test_gpio_0: gpio@ffff {
+		gpio-controller;
+		#gpio-cells = <0x2>;
+		compatible = "vnd,gpio-device";
+		status = "okay";
+		reg = <0xffff 0x1000>;
+	};
+
+	test_i2c: i2c@11112222 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "vnd,i2c";
+		status = "okay";
+		reg = <0x11112222 0x1000>;
+		clock-frequency = <100000>;
+
+		test_dev_a: test-i2c-dev@10 {
+			compatible = "vnd,i2c-device";
+			status = "okay";
+			reg = <0x10>;
+			supply-gpios = <&test_gpio_0 1 0>;
+		};
+
+		test_dev_b: test-i2c-dev@11 {
+			compatible = "vnd,i2c-device";
+			status = "okay";
+			reg = <0x11>;
+			supply-gpios = <&test_gpio_0 2 0>;
+		};
+	};
+};

--- a/tests/misc/check_init_priorities/boards/native_sim_64.overlay
+++ b/tests/misc/check_init_priorities/boards/native_sim_64.overlay
@@ -3,4 +3,4 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include "native_posix.overlay"
+#include "native_sim.overlay"

--- a/tests/misc/check_init_priorities/testcase.yaml
+++ b/tests/misc/check_init_priorities/testcase.yaml
@@ -3,6 +3,10 @@
 tests:
   init.check_init_priorities:
     build_only: true
-    platform_allow: native_posix native_posix_64
+    platform_allow:
+      - native_sim
+      - native_sim_64
+      - native_posix
     integration_platforms:
+      - native_sim
       - native_posix

--- a/tests/misc/check_init_priorities/validate_check_init_priorities_output.py
+++ b/tests/misc/check_init_priorities/validate_check_init_priorities_output.py
@@ -34,6 +34,8 @@ if sorted(REFERENCE_OUTPUT) != sorted(output):
     print()
     print("got:")
     print("\n".join(sorted(output)))
+    print("TEST FAILED")
     sys.exit(1)
 
+print("TEST PASSED")
 sys.exit(0)


### PR DESCRIPTION
Fix the init_priorities related cmake targets so they also work with native_simulator based build targets.
Mostly this consists of pointing to the right file (final build result instead of intermediate elf library)
and setting the dependency to that final build result.

Note that for the native_simulator based targets the init priorities check can only be run on build
if we are building the final image (not just a partial prelinked library),
and we are not assembling several images together into one executable.

Fix its test (tests/misc/check_init_priorities:) for the native_simulator, and add it as a default test target.
Also be a bit clearer in stdout about the test having passed or not.

