### PR TITLE
Bluetooth: Mesh: Fix atomic primitive usage and settings scheduling

### DIFF
--- a/subsys/bluetooth/mesh/va.c
+++ b/subsys/bluetooth/mesh/va.c
@@ -306,6 +306,10 @@ void bt_mesh_va_clear(void)
 {
 	int i;
 
+	if (CONFIG_BT_MESH_LABEL_COUNT == 0) {
+		return;
+	}
+
 	for (i = 0; i < ARRAY_SIZE(virtual_addrs); i++) {
 		if (virtual_addrs[i].ref) {
 			virtual_addrs[i].ref = 0U;


### PR DESCRIPTION
This PR fixes the following issues:
- atomic_*_bit functions work with atomic_t arg as with array, therefore the atomic variable should be declared using ATOMIC_DEFINE.
  - Coverity-CID: 333358
  - Fixes #65588
- Return earlier in `bt_mesh_va_clear` to avoid unnecessary triggering of storing mesh settings when `CONFIG_BT_MESH_LABEL_COUNT` == 0.