### PR TITLE
 Add recvmsg() and pktinfo support

### DIFF
--- a/include/zephyr/net/net_context.h
+++ b/include/zephyr/net/net_context.h
@@ -332,6 +332,9 @@ __net_socket struct net_context {
 #if defined(CONFIG_NET_IPV4_MAPPING_TO_IPV6)
 		bool ipv6_v6only;
 #endif
+#if defined(CONFIG_NET_CONTEXT_RECV_PKTINFO)
+		bool recv_pktinfo;
+#endif
 	} options;
 
 	/** Protocol (UDP, TCP or IEEE 802.3 protocol value) */
@@ -1102,6 +1105,7 @@ enum net_context_option {
 	NET_OPT_REUSEADDR	= 9,
 	NET_OPT_REUSEPORT	= 10,
 	NET_OPT_IPV6_V6ONLY	= 11,
+	NET_OPT_RECV_PKTINFO    = 12,
 };
 
 /**

--- a/include/zephyr/net/socket.h
+++ b/include/zephyr/net/socket.h
@@ -57,6 +57,9 @@ struct zsock_pollfd {
 
 /** zsock_recv: Read data without removing it from socket input queue */
 #define ZSOCK_MSG_PEEK 0x02
+/** zsock_recvmsg: Control data buffer too small.
+ */
+#define ZSOCK_MSG_CTRUNC 0x08
 /** zsock_recv: return the real length of the datagram, even when it was longer
  *  than the passed buffer
  */
@@ -979,6 +982,8 @@ static inline char *inet_ntop(sa_family_t family, const void *src, char *dst,
 
 /** POSIX wrapper for @ref ZSOCK_MSG_PEEK */
 #define MSG_PEEK ZSOCK_MSG_PEEK
+/** POSIX wrapper for @ref ZSOCK_MSG_CTRUNC */
+#define MSG_CTRUNC ZSOCK_MSG_CTRUNC
 /** POSIX wrapper for @ref ZSOCK_MSG_TRUNC */
 #define MSG_TRUNC ZSOCK_MSG_TRUNC
 /** POSIX wrapper for @ref ZSOCK_MSG_DONTWAIT */

--- a/include/zephyr/net/socket.h
+++ b/include/zephyr/net/socket.h
@@ -467,6 +467,20 @@ __syscall ssize_t zsock_recvfrom(int sock, void *buf, size_t max_len,
 				 socklen_t *addrlen);
 
 /**
+ * @brief Receive a message from an arbitrary network address
+ *
+ * @details
+ * @rst
+ * See `POSIX.1-2017 article
+ * <http://pubs.opengroup.org/onlinepubs/9699919799/functions/recvmsg.html>`__
+ * for normative description.
+ * This function is also exposed as ``recvmsg()``
+ * if :kconfig:option:`CONFIG_NET_SOCKETS_POSIX_NAMES` is defined.
+ * @endrst
+ */
+__syscall ssize_t zsock_recvmsg(int sock, struct msghdr *msg, int flags);
+
+/**
  * @brief Receive data from a connected peer
  *
  * @details
@@ -860,6 +874,12 @@ static inline ssize_t recvfrom(int sock, void *buf, size_t max_len, int flags,
 			       struct sockaddr *src_addr, socklen_t *addrlen)
 {
 	return zsock_recvfrom(sock, buf, max_len, flags, src_addr, addrlen);
+}
+
+/** POSIX wrapper for @ref zsock_recvmsg */
+static inline ssize_t recvmsg(int sock, struct msghdr *msg, int flags)
+{
+	return zsock_recvmsg(sock, msg, flags);
 }
 
 /** POSIX wrapper for @ref zsock_poll */

--- a/include/zephyr/net/socket.h
+++ b/include/zephyr/net/socket.h
@@ -1095,9 +1095,32 @@ struct ifreq {
 /** sockopt: Set or receive the Type-Of-Service value for an outgoing packet. */
 #define IP_TOS 1
 
+/** sockopt: Pass an IP_PKTINFO ancillary message that contains a
+ *  pktinfo structure that supplies some information about the
+ *  incoming packet.
+ */
+#define IP_PKTINFO 8
+
+struct in_pktinfo {
+	unsigned int   ipi_ifindex;  /* Interface index */
+	struct in_addr ipi_spec_dst; /* Local address */
+	struct in_addr ipi_addr;     /* Header Destination address */
+};
+
 /* Socket options for IPPROTO_IPV6 level */
 /** sockopt: Don't support IPv4 access (ignored, for compatibility) */
 #define IPV6_V6ONLY 26
+
+/** sockopt: Pass an IPV6_RECVPKTINFO ancillary message that contains a
+ *  in6_pktinfo structure that supplies some information about the
+ *  incoming packet. See RFC 3542.
+ */
+#define IPV6_RECVPKTINFO 49
+
+struct in6_pktinfo {
+	struct in6_addr ipi6_addr;    /* src/dst IPv6 address */
+	unsigned int    ipi6_ifindex; /* send/recv interface index */
+};
 
 /** sockopt: Set or receive the traffic class value for an outgoing packet. */
 #define IPV6_TCLASS 67

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -737,6 +737,14 @@ config NET_CONTEXT_REUSEPORT
 	  Allow to set the SO_REUSEPORT flag on a socket. This enables multiple
 	  sockets to bind to the same local IP address and port combination.
 
+config NET_CONTEXT_RECV_PKTINFO
+	bool "Add receive PKTINFO support to net_context"
+	depends on NET_UDP
+	help
+	  Allow to set the IP_PKTINFO or IPV6_RECVPKTINFO flags on a socket.
+	  This way user can get extra information about the received data in the
+	  socket.
+
 config NET_TEST
 	bool "Network Testing"
 	help

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -72,6 +72,7 @@ extern const char *net_context_state(struct net_context *context);
 extern bool net_context_is_reuseaddr_set(struct net_context *context);
 extern bool net_context_is_reuseport_set(struct net_context *context);
 extern bool net_context_is_v6only_set(struct net_context *context);
+extern bool net_context_is_recv_pktinfo_set(struct net_context *context);
 extern void net_pkt_init(void);
 extern void net_tc_tx_init(void);
 extern void net_tc_rx_init(void);
@@ -91,6 +92,11 @@ static inline bool net_context_is_reuseaddr_set(struct net_context *context)
 	return false;
 }
 static inline bool net_context_is_reuseport_set(struct net_context *context)
+{
+	ARG_UNUSED(context);
+	return false;
+}
+static inline bool net_context_is_recv_pktinfo_set(struct net_context *context)
 {
 	ARG_UNUSED(context);
 	return false;

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -909,19 +909,17 @@ ssize_t zsock_sendmsg_ctx(struct net_context *ctx, const struct msghdr *msg,
 	while (1) {
 		status = net_context_sendmsg(ctx, msg, flags, NULL, timeout, NULL);
 		if (status < 0) {
+			status = send_check_and_wait(ctx, status,
+						     buf_timeout,
+						     timeout, &retry_timeout);
 			if (status < 0) {
-				status = send_check_and_wait(ctx, status,
-							     buf_timeout,
-							     timeout, &retry_timeout);
-				if (status < 0) {
-					return status;
-				}
-
-				/* Update the timeout value in case loop is repeated. */
-				timeout = sys_timepoint_timeout(end);
-
-				continue;
+				return status;
 			}
+
+			/* Update the timeout value in case loop is repeated. */
+			timeout = sys_timepoint_timeout(end);
+
+			continue;
 		}
 
 		break;

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -1684,11 +1684,13 @@ ssize_t zsock_recvfrom_ctx(struct net_context *ctx, void *buf, size_t max_len,
 		return zsock_recv_dgram(ctx, NULL, buf, max_len, flags, src_addr, addrlen);
 	} else if (sock_type == SOCK_STREAM) {
 		return zsock_recv_stream(ctx, NULL, buf, max_len, flags);
-	} else {
-		__ASSERT(0, "Unknown socket type");
 	}
 
-	return 0;
+	__ASSERT(0, "Unknown socket type");
+
+	errno = ENOTSUP;
+
+	return -1;
 }
 
 ssize_t z_impl_zsock_recvfrom(int sock, void *buf, size_t max_len, int flags,

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -2757,6 +2757,23 @@ int zsock_setsockopt_ctx(struct net_context *ctx, int level, int optname,
 			}
 
 			break;
+
+		case IP_PKTINFO:
+			if (IS_ENABLED(CONFIG_NET_IPV4) &&
+			    IS_ENABLED(CONFIG_NET_CONTEXT_RECV_PKTINFO)) {
+				ret = net_context_set_option(ctx,
+							     NET_OPT_RECV_PKTINFO,
+							     optval,
+							     optlen);
+				if (ret < 0) {
+					errno  = -ret;
+					return -1;
+				}
+
+				return 0;
+			}
+
+			break;
 		}
 
 		break;
@@ -2776,6 +2793,23 @@ int zsock_setsockopt_ctx(struct net_context *ctx, int level, int optname,
 			}
 
 			return 0;
+
+		case IPV6_RECVPKTINFO:
+			if (IS_ENABLED(CONFIG_NET_IPV6) &&
+			    IS_ENABLED(CONFIG_NET_CONTEXT_RECV_PKTINFO)) {
+				ret = net_context_set_option(ctx,
+							     NET_OPT_RECV_PKTINFO,
+							     optval,
+							     optlen);
+				if (ret < 0) {
+					errno  = -ret;
+					return -1;
+				}
+
+				return 0;
+			}
+
+			break;
 
 		case IPV6_TCLASS:
 			if (IS_ENABLED(CONFIG_NET_CONTEXT_DSCP_ECN)) {

--- a/subsys/net/lib/sockets/sockets_internal.h
+++ b/subsys/net/lib/sockets/sockets_internal.h
@@ -70,6 +70,7 @@ struct socket_op_vtable {
 	int (*setsockopt)(void *obj, int level, int optname,
 			  const void *optval, socklen_t optlen);
 	ssize_t (*sendmsg)(void *obj, const struct msghdr *msg, int flags);
+	ssize_t (*recvmsg)(void *obj, struct msghdr *msg, int flags);
 	int (*getpeername)(void *obj, struct sockaddr *addr,
 			   socklen_t *addrlen);
 	int (*getsockname)(void *obj, struct sockaddr *addr,

--- a/tests/net/socket/tcp/prj.conf
+++ b/tests/net/socket/tcp/prj.conf
@@ -52,3 +52,7 @@ CONFIG_NET_CONTEXT_SNDBUF=y
 #CONFIG_LOG_MODE_DEFERRED=y
 #CONFIG_NET_LOG=y
 #CONFIG_NET_TCP_LOG_LEVEL_DBG=y
+
+# Because of userspace and recvmsg() we need some extra heap in order to
+# copy the iovec in the recvmsg tests.
+CONFIG_HEAP_MEM_POOL_SIZE=512

--- a/tests/net/socket/udp/src/main.c
+++ b/tests/net/socket/udp/src/main.c
@@ -783,8 +783,8 @@ ZTEST(net_socket_udp, test_09_so_rcvtimeo)
 	uint32_t start_time, time_diff;
 
 	struct timeval optval = {
-		.tv_sec = 2,
-		.tv_usec = 500000,
+		.tv_sec = 0,
+		.tv_usec = 300000,
 	};
 
 	prepare_sock_udp_v4(MY_IPV4_ADDR, 55555, &sock1, &bind_addr4);
@@ -800,7 +800,7 @@ ZTEST(net_socket_udp, test_09_so_rcvtimeo)
 			sizeof(optval));
 	zassert_equal(rv, 0, "setsockopt failed (%d)", errno);
 
-	optval.tv_usec = 0;
+	optval.tv_usec = 400000;
 	rv = setsockopt(sock2, SOL_SOCKET, SO_RCVTIMEO, &optval,
 			sizeof(optval));
 	zassert_equal(rv, 0, "setsockopt failed (%d)", errno);
@@ -814,7 +814,7 @@ ZTEST(net_socket_udp, test_09_so_rcvtimeo)
 
 	zassert_equal(recved, -1, "Unexpected return code");
 	zassert_equal(errno, EAGAIN, "Unexpected errno value: %d", errno);
-	zassert_true(time_diff >= 2500, "Expected timeout after 2500ms but "
+	zassert_true(time_diff >= 300, "Expected timeout after 300ms but "
 			"was %dms", time_diff);
 
 	start_time = k_uptime_get_32();
@@ -824,7 +824,7 @@ ZTEST(net_socket_udp, test_09_so_rcvtimeo)
 
 	zassert_equal(recved, -1, "Unexpected return code");
 	zassert_equal(errno, EAGAIN, "Unexpected errno value: %d", errno);
-	zassert_true(time_diff >= 2000, "Expected timeout after 2000ms but "
+	zassert_true(time_diff >= 400, "Expected timeout after 400ms but "
 			"was %dms", time_diff);
 
 	rv = close(sock1);

--- a/tests/net/socket/udp/testcase.yaml
+++ b/tests/net/socket/udp/testcase.yaml
@@ -16,3 +16,6 @@ tests:
   net.socket.udp.ipv6_fragment:
     extra_configs:
       - CONFIG_NET_IPV6_FRAGMENT=y
+  net.socket.udp.pktinfo:
+    extra_configs:
+      - CONFIG_NET_CONTEXT_RECV_PKTINFO=y


### PR DESCRIPTION
This PR adds support for `recvmsg()` socket call. It also adds support for `IP_PKTINFO` and `IPV6_RECVPKTINFO` socket options. Tests for both of these features are also added.

Fixes #36415
