### PR TITLE
drivers: rtc: stm32: Fixes RTC issues related to device runtime pm (previous pr #62910)

### DIFF
--- a/drivers/rtc/rtc_ll_stm32.c
+++ b/drivers/rtc/rtc_ll_stm32.c
@@ -139,7 +139,6 @@ static int rtc_stm32_init(const struct device *dev)
 	k_mutex_init(&data->lock);
 
 	/* Enable Backup access */
-	z_stm32_hsem_lock(CFG_HW_RCC_SEMID, HSEM_LOCK_DEFAULT_RETRY);
 #if defined(PWR_CR_DBP) || defined(PWR_CR1_DBP) || defined(PWR_DBPCR_DBP) || defined(PWR_DBPR_DBP)
 	LL_PWR_EnableBkUpAccess();
 #endif /* PWR_CR_DBP || PWR_CR1_DBP || PWR_DBPR_DBP */
@@ -149,6 +148,8 @@ static int rtc_stm32_init(const struct device *dev)
 		LOG_ERR("clock configure failed\n");
 		return -EIO;
 	}
+
+	z_stm32_hsem_lock(CFG_HW_RCC_SEMID, HSEM_LOCK_DEFAULT_RETRY);
 
 	LL_RCC_EnableRTC();
 

--- a/drivers/rtc/rtc_ll_stm32.c
+++ b/drivers/rtc/rtc_ll_stm32.c
@@ -181,6 +181,10 @@ static int rtc_stm32_init(const struct device *dev)
 
 	err = rtc_stm32_configure(dev);
 
+#if defined(PWR_CR_DBP) || defined(PWR_CR1_DBP) || defined(PWR_DBPCR_DBP) || defined(PWR_DBPR_DBP)
+	LL_PWR_DisableBkUpAccess();
+#endif /* PWR_CR_DBP || PWR_CR1_DBP || PWR_DBPR_DBP */
+
 	return err;
 }
 
@@ -208,10 +212,18 @@ static int rtc_stm32_set_time(const struct device *dev, const struct rtc_time *t
 	}
 
 	LOG_INF("Setting clock");
+
+#if defined(PWR_CR_DBP) || defined(PWR_CR1_DBP) || defined(PWR_DBPCR_DBP) || defined(PWR_DBPR_DBP)
+	LL_PWR_EnableBkUpAccess();
+#endif /* PWR_CR_DBP || PWR_CR1_DBP || PWR_DBPR_DBP */
+
 	LL_RTC_DisableWriteProtection(RTC);
 
 	err = rtc_stm32_enter_initialization_mode(true);
 	if (err) {
+#if defined(PWR_CR_DBP) || defined(PWR_CR1_DBP) || defined(PWR_DBPCR_DBP) || defined(PWR_DBPR_DBP)
+		LL_PWR_DisableBkUpAccess();
+#endif /* PWR_CR_DBP || PWR_CR1_DBP || PWR_DBPR_DBP */
 		k_mutex_unlock(&data->lock);
 		return err;
 	}
@@ -236,6 +248,10 @@ static int rtc_stm32_set_time(const struct device *dev, const struct rtc_time *t
 	rtc_stm32_leave_initialization_mode();
 
 	LL_RTC_EnableWriteProtection(RTC);
+
+#if defined(PWR_CR_DBP) || defined(PWR_CR1_DBP) || defined(PWR_DBPCR_DBP) || defined(PWR_DBPR_DBP)
+	LL_PWR_DisableBkUpAccess();
+#endif /* PWR_CR_DBP || PWR_CR1_DBP || PWR_DBPR_DBP */
 
 	k_mutex_unlock(&data->lock);
 
@@ -350,11 +366,19 @@ static int rtc_stm32_set_calibration(const struct device *dev, int32_t calibrati
 		return -EIO;
 	}
 
+#if defined(PWR_CR_DBP) || defined(PWR_CR1_DBP) || defined(PWR_DBPCR_DBP) || defined(PWR_DBPR_DBP)
+	LL_PWR_EnableBkUpAccess();
+#endif /* PWR_CR_DBP || PWR_CR1_DBP || PWR_DBPR_DBP */
+
 	LL_RTC_DisableWriteProtection(RTC);
 
 	MODIFY_REG(RTC->CALR, RTC_CALR_CALP | RTC_CALR_CALM, calp | calm);
 
 	LL_RTC_EnableWriteProtection(RTC);
+
+#if defined(PWR_CR_DBP) || defined(PWR_CR1_DBP) || defined(PWR_DBPCR_DBP) || defined(PWR_DBPR_DBP)
+	LL_PWR_DisableBkUpAccess();
+#endif /* PWR_CR_DBP || PWR_CR1_DBP || PWR_DBPR_DBP */
 
 	return 0;
 }


### PR DESCRIPTION
@erwango @FRASTM 
(I made some mistakes when I was updating the old PR and created this new one)

When device runtime pm is enabled, Backup Domain protection is active most of the time. RTC driver need this protection to be disabled in order to set the time or calibration. Commit in this PR disables the protection in set time and set calibration functions.
In addition, another commit fixes the recently added WAIT macro which makes the set time and set calibration functions nonworking when device runtime is enabled.

I divided the original commit into 3 commits as @faloj suggested.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/62843