### PR TITLE
boards: xtensa/esp32_ethernet_kit: disable SPIRAM when MCUBOOT

### DIFF
--- a/boards/xtensa/esp32_ethernet_kit/Kconfig.defconfig
+++ b/boards/xtensa/esp32_ethernet_kit/Kconfig.defconfig
@@ -8,7 +8,7 @@ config BOARD
 	depends on BOARD_ESP32_ETHERNET_KIT
 
 config ESP_SPIRAM
-	default y
+	default y if !MCUBOOT
 
 choice SPIRAM_TYPE
 	default SPIRAM_TYPE_ESPPSRAM64


### PR DESCRIPTION
Without this patch, `west build -b esp32_ethernet_kit bootloader/mcuboot/boot/zephyr -p` fails with
```
(heap_caps.c.obj):(._k_heap.static._spiram_heap_+0x4): undefined reference to `_spiram_heap_start'
```