### PR TITLE
posix: pthread: implement pthread_cleanup_push() / pop()

### DIFF
--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -32,8 +32,8 @@ multiple processes.
     pthread_barrierattr_init(),yes
     pthread_barrierattr_setpshared(),yes
     pthread_cancel(),yes
-    pthread_cleanup_pop(),
-    pthread_cleanup_push(),
+    pthread_cleanup_pop(),yes
+    pthread_cleanup_push(),yes
     pthread_cond_broadcast(),yes
     pthread_cond_destroy(),yes
     pthread_cond_init(),yes

--- a/include/zephyr/posix/pthread.h
+++ b/include/zephyr/posix/pthread.h
@@ -480,6 +480,18 @@ int pthread_atfork(void (*prepare)(void), void (*parent)(void), void (*child)(vo
 int pthread_getconcurrency(void);
 int pthread_setconcurrency(int new_level);
 
+void __z_pthread_cleanup_push(void *cleanup[3], void (*routine)(void *arg), void *arg);
+void __z_pthread_cleanup_pop(int execute);
+
+#define pthread_cleanup_push(_rtn, _arg)                                                           \
+	do /* enforce '{'-like behaviour */ {                                                      \
+		void *_z_pthread_cleanup[3];                                                       \
+		__z_pthread_cleanup_push(_z_pthread_cleanup, _rtn, _arg)
+
+#define pthread_cleanup_pop(_ex)                                                                   \
+		__z_pthread_cleanup_pop(_ex);                                                      \
+	} /* enforce '}'-like behaviour */ while (0)
+
 /* Glibc / Oracle Extension Functions */
 
 /**

--- a/lib/posix/posix_internal.h
+++ b/lib/posix/posix_internal.h
@@ -24,6 +24,9 @@
 struct posix_thread {
 	struct k_thread thread;
 
+	/* List nodes for pthread_cleanup_push() / pthread_cleanup_pop() */
+	sys_slist_t cleanup_list;
+
 	/* List node for ready_q, run_q, or done_q */
 	sys_dnode_t q_node;
 

--- a/tests/posix/common/src/pthread.c
+++ b/tests/posix/common/src/pthread.c
@@ -905,3 +905,33 @@ ZTEST(posix_apis, test_pthread_set_get_concurrency)
 	/* EAGAIN if the a system resource to be exceeded */
 	zassert_equal(EAGAIN, pthread_setconcurrency(CONFIG_MP_MAX_NUM_CPUS + 1));
 }
+
+static void cleanup_handler(void *arg)
+{
+	bool *boolp = (bool *)arg;
+
+	*boolp = true;
+}
+
+static void *test_pthread_cleanup_entry(void *arg)
+{
+	bool executed[2] = {0};
+
+	pthread_cleanup_push(cleanup_handler, &executed[0]);
+	pthread_cleanup_push(cleanup_handler, &executed[1]);
+	pthread_cleanup_pop(false);
+	pthread_cleanup_pop(true);
+
+	zassert_true(executed[0]);
+	zassert_false(executed[1]);
+
+	return NULL;
+}
+
+ZTEST(posix_apis, test_pthread_cleanup)
+{
+	pthread_t th;
+
+	zassert_ok(pthread_create(&th, NULL, test_pthread_cleanup_entry, NULL));
+	zassert_ok(pthread_join(th, NULL));
+}


### PR DESCRIPTION
`pthread_cleanup_push()` and `pthread_cleanup_pop()` are required by the POSIX_THREADS_BASE Option Group as detailed in Section E.1 of IEEE-1003.1-2017.

The POSIX_THREADS_BASE Option Group is required for PSE51, PSE52, PSE53, and PSE54 conformance, and is otherwise mandatory for any POSIX conforming system as per Section A.2.1.3 of IEEE-1003-1.2017.

Fixes #59940
Fixes #59941

See also https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_cleanup_pop.html