### PR TITLE
MAINTAINERS: ensure the bot tags posix rather than cmsis

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -473,7 +473,7 @@ CMSIS API layer:
     - include/zephyr/portability/cmsis*
     - samples/subsys/portability/cmsis_rtos_v*/
     - tests/subsys/portability/cmsis_rtos_v*/
-    - doc/services/portability/
+    - doc/services/portability/cmsis*
   labels:
     - "area: CMSIS API Layer"
     - "area: Portability"
@@ -2248,6 +2248,7 @@ POSIX API layer:
     - tests/posix/
     - samples/posix/
     - tests/lib/fdtable/
+    - doc/services/portability/posix/
   labels:
     - "area: POSIX"
 


### PR DESCRIPTION
Previously, a large number of pull requests involving documentation were being tagged as related to CMSIS rather than POSIX because the CMSIS files blanketed all of `doc/services/portability/` in `MAINTAINERS.yml`.

Be more specific about which sections of the documentation belong to CMSIS and which belong to POSIX.