### PR TITLE
input: kbd_matrix: add actual-key-mask support

### DIFF
--- a/drivers/input/input_kbd_matrix.c
+++ b/drivers/input/input_kbd_matrix.c
@@ -94,6 +94,11 @@ static bool input_kbd_matrix_scan(const struct device *dev)
 		k_busy_wait(cfg->settle_time_us);
 
 		row = api->read_row(dev);
+
+		if (cfg->actual_key_mask != NULL) {
+			row &= cfg->actual_key_mask[col];
+		}
+
 		cfg->matrix_new_state[col] = row;
 		key_event |= row;
 	}

--- a/dts/bindings/input/kbd-matrix-common.yaml
+++ b/dts/bindings/input/kbd-matrix-common.yaml
@@ -49,6 +49,14 @@ properties:
       Delay between setting column output and reading the row values. Defaults
       to 50us if unspecified.
 
+  actual-key-mask:
+    type: array
+    description:
+      Keyboard scanning mask. For each keyboard column, specify which
+      keyboard rows actually exist. Can be used to avoid triggering the ghost
+      detection on non existing keys. No masking by default, any combination is
+      valid.
+
   no-ghostkey-check:
     type: boolean
     description: |

--- a/include/zephyr/input/input_kbd_matrix.h
+++ b/include/zephyr/input/input_kbd_matrix.h
@@ -88,6 +88,7 @@ struct input_kbd_matrix_common_config {
 	uint32_t debounce_up_ms;
 	uint32_t settle_time_us;
 	bool ghostkey_check;
+	const kbd_row_t *actual_key_mask;
 
 	/* extra data pointers */
 	kbd_row_t *matrix_stable_state;
@@ -108,6 +109,12 @@ struct input_kbd_matrix_common_config {
 #define INPUT_KBD_MATRIX_DT_DEFINE_ROW_COL(node_id, _row_size, _col_size) \
 	BUILD_ASSERT(IN_RANGE(_row_size, 1, INPUT_KBD_MATRIX_ROW_BITS), "invalid row-size"); \
 	BUILD_ASSERT(IN_RANGE(_col_size, 1, UINT8_MAX), "invalid col-size"); \
+	IF_ENABLED(DT_NODE_HAS_PROP(node_id, actual_key_mask), ( \
+	BUILD_ASSERT(DT_PROP_LEN(node_id, actual_key_mask) == _col_size, \
+		     "actual-key-mask size does not match the number of columns"); \
+	static const kbd_row_t INPUT_KBD_MATRIX_DATA_NAME(node_id, actual_key_mask)[_col_size] = \
+		DT_PROP(node_id, actual_key_mask); \
+	)) \
 	static kbd_row_t INPUT_KBD_MATRIX_DATA_NAME(node_id, stable_state)[_col_size]; \
 	static kbd_row_t INPUT_KBD_MATRIX_DATA_NAME(node_id, unstable_state)[_col_size]; \
 	static kbd_row_t INPUT_KBD_MATRIX_DATA_NAME(node_id, previous_state)[_col_size]; \
@@ -159,6 +166,9 @@ struct input_kbd_matrix_common_config {
 		.debounce_up_ms = DT_PROP(node_id, debounce_up_ms), \
 		.settle_time_us = DT_PROP(node_id, settle_time_us), \
 		.ghostkey_check = !DT_PROP(node_id, no_ghostkey_check), \
+		IF_ENABLED(DT_NODE_HAS_PROP(node_id, actual_key_mask), ( \
+		.actual_key_mask = INPUT_KBD_MATRIX_DATA_NAME(node_id, actual_key_mask), \
+		)) \
 		\
 		.matrix_stable_state = INPUT_KBD_MATRIX_DATA_NAME(node_id, stable_state), \
 		.matrix_unstable_state = INPUT_KBD_MATRIX_DATA_NAME(node_id, unstable_state), \

--- a/tests/drivers/build_all/input/app.overlay
+++ b/tests/drivers/build_all/input/app.overlay
@@ -33,6 +33,7 @@
 			col-gpios = <&test_gpio 2 GPIO_ACTIVE_LOW>,
 				    <&test_gpio 3 GPIO_ACTIVE_LOW>,
 				    <&test_gpio 4 GPIO_ACTIVE_LOW>;
+			actual-key-mask = <0x0f 0x0a 0x0b>;
 		};
 
 		qdec-gpio {


### PR DESCRIPTION
Add an optional actual-key-mask property to filter out key combinations that are not implemented in the actual keyboard matrix.