### PR TITLE
tests: Update posix common test for Xtensa

### DIFF
--- a/tests/posix/common/src/mutex.c
+++ b/tests/posix/common/src/mutex.c
@@ -17,6 +17,7 @@ static K_THREAD_STACK_DEFINE(stack, STACK_SIZE);
 
 pthread_mutex_t mutex1;
 pthread_mutex_t mutex2;
+pthread_mutex_t mutex;
 
 void *normal_mutex_entry(void *p1)
 {
@@ -213,12 +214,12 @@ static void timespec_add_ms(struct timespec *ts, uint32_t ms)
 static void *test_mutex_timedlock_fn(void *arg)
 {
 	struct timespec time_point;
-	pthread_mutex_t *mutex = (pthread_mutex_t *)arg;
+	pthread_mutex_t *mtx = (pthread_mutex_t *)arg;
 
 	zassume_ok(clock_gettime(CLOCK_MONOTONIC, &time_point));
 	timespec_add_ms(&time_point, TIMEDLOCK_TIMEOUT_MS);
 
-	return INT_TO_POINTER(pthread_mutex_timedlock(mutex, &time_point));
+	return INT_TO_POINTER(pthread_mutex_timedlock(mtx, &time_point));
 }
 
 /** @brief Test to verify @ref pthread_mutex_timedlock returns ETIMEDOUT */
@@ -226,7 +227,6 @@ ZTEST(posix_apis, test_mutex_timedlock)
 {
 	void *ret;
 	pthread_t th;
-	pthread_t mutex;
 	pthread_attr_t attr;
 
 	zassert_ok(pthread_attr_init(&attr));

--- a/tests/posix/common/src/pthread.c
+++ b/tests/posix/common/src/pthread.c
@@ -53,6 +53,8 @@ static int barrier_failed;
 static int barrier_done[N_THR_E];
 static int barrier_return[N_THR_E];
 
+static uint32_t param;
+
 /* First phase bounces execution between two threads using a condition
  * variable, continuously testing that no other thread is mucking with
  * the protected state.  This ends with all threads going back to
@@ -827,15 +829,14 @@ static void *fun(void *arg)
 ZTEST(posix_apis, test_pthread_dynamic_stacks)
 {
 	pthread_t th;
-	uint32_t x = 0;
 
 	if (!IS_ENABLED(CONFIG_DYNAMIC_THREAD)) {
 		ztest_test_skip();
 	}
 
-	zassert_ok(pthread_create(&th, NULL, fun, &x));
+	zassert_ok(pthread_create(&th, NULL, fun, &param));
 	zassert_ok(pthread_join(th, NULL));
-	zassert_equal(BIOS_FOOD, x);
+	zassert_equal(BIOS_FOOD, param);
 }
 
 static void *non_null_retval(void *arg)


### PR DESCRIPTION
Updates the posix common test so that it will pass on Xtensa SMP boards such as intel_adsp_ace15_mtpm. This involves ensuring that a newly created thread does not attempt access/modify the stack of a thread that is currently running on a different CPU.