### PR TITLE
net: mgmt: Fix net_mgmt callback list corruption

### DIFF
--- a/subsys/net/ip/net_mgmt.c
+++ b/subsys/net/ip/net_mgmt.c
@@ -240,12 +240,14 @@ static int mgmt_event_wait_call(struct net_if *iface,
 	net_mgmt_add_event_callback(&sync);
 
 	ret = k_sem_take(sync.sync_call, timeout);
+
+	net_mgmt_del_event_callback(&sync);
+
 	if (ret < 0) {
 		if (ret == -EAGAIN) {
 			ret = -ETIMEDOUT;
 		}
 
-		net_mgmt_del_event_callback(&sync);
 		return ret;
 	}
 


### PR DESCRIPTION
The net_mgmt APIs `net_mgmt_event_wait_...` add a stack-allocated callback to the list of callbacks, but don't delete it once before the function returns. This results in a memory access error if that net_mgmt event later occurs.

This change *always* removes the net_mgmt callback after the wait is complete.