### PR TITLE
drivers: sensor: lsm6dsv16x: fix gyro range

### DIFF
--- a/drivers/sensor/lsm6dsv16x/lsm6dsv16x.c
+++ b/drivers/sensor/lsm6dsv16x/lsm6dsv16x.c
@@ -83,8 +83,9 @@ static int lsm6dsv16x_accel_range_to_fs_val(int32_t range)
 	return -EINVAL;
 }
 
-static const uint16_t lsm6dsv16x_gyro_fs_map[] = {250, 125, 500, 0, 1000, 0, 2000};
-static const uint16_t lsm6dsv16x_gyro_fs_sens[] = {2, 1, 4, 0, 8, 0, 16};
+static const uint16_t lsm6dsv16x_gyro_fs_map[] = {125, 250, 500, 1000, 2000, 0,   0,
+						  0,   0,   0,   0,    0,    4000};
+static const uint16_t lsm6dsv16x_gyro_fs_sens[] = {1, 2, 4, 8, 16, 0, 0, 0, 0, 0, 0, 0, 32};
 
 static int lsm6dsv16x_gyro_range_to_fs_val(int32_t range)
 {


### PR DESCRIPTION
The [DTS bindings](https://github.com/zephyrproject-rtos/zephyr/blob/main/dts/bindings/sensor/st%2Clsm6dsv16x-common.yaml#L117) define `gyro-range` to be this:

```
  gyro-range:
    type: int
    default: 0
    description: |
      Range in dps. Default is power-up configuration.

      - 0x0 # LSM6DSV16X_DT_FS_125DPS  (4.375 mdps/LSB)
      - 0x1 # LSM6DSV16X_DT_FS_250DPS  (8.75 mdps/LSB)
      - 0x2 # LSM6DSV16X_DT_FS_500DPS  (17.50 mdps/LSB)
      - 0x3 # LSM6DSV16X_DT_FS_1000DPS (35 mdps/LSB)
      - 0x4 # LSM6DSV16X_DT_FS_2000DPS (70 mdps/LSB)
      - 0xc # LSM6DSV16X_DT_FS_4000DPS (140 mdps/LSB)
```

According to the datasheet, this looks correct:
<img width="716" alt="image" src="https://github.com/zephyrproject-rtos/zephyr/assets/1169132/1f0d7b0e-4023-4a87-8491-91c2b58864d7">


However, the order of the values in the driver's `lsm6dsv16x_gyro_fs_map` doesn't match these ranges.  e.g., setting `gyro-range = <1>` in the DTS sets the range to 125 dps rather than 250dps.

This PR updates both the `lsm6dsv16x_gyro_fs_map` as well as the sensitivity table `lsm6dsv16x_gyro_fs_sens` to match [DS13476 - Rev 5](https://www.st.com/resource/en/datasheet/lsm6dsv.pdf) of the LSM6DSV specification.

This was tested by setting various values for `gyro-range` in the DT and verifying the gyro output saturated at the correct range.
