### PR TITLE
scripts/checkpatch: add `__unused` to the `$Attribute` list

### DIFF
--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -389,6 +389,7 @@ our $Attribute	= qr{
 			__always_unused|
 			__noreturn|
 			__used|
+			__unused|
 			__cold|
 			__pure|
 			__noclone|


### PR DESCRIPTION
Add `__unused` to the `$Attribute` family along with its `__maybe_unused`, `__always_unused` & `__used` brothers, so that:

```c
__unused int ret;
```

is recognized as variable declaration, and doesn't raise `LINE_SPACING` warning in CI.