### PR TITLE
MAINTAINERS: Add more collaborators for Ambiq platforms

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -222,6 +222,8 @@ Ambiq Platforms:
   collaborators:
     - tgorochowik
     - msobkowski
+    - aaronyegx
+    - RichardSWheatley
   files:
     - soc/arm/ambiq/
     - boards/arm/apollo*/
@@ -3271,6 +3273,8 @@ West:
   collaborators:
     - tgorochowik
     - msobkowski
+    - aaronyegx
+    - RichardSWheatley
   files:
     - modules/hal_ambiq/
   labels:


### PR DESCRIPTION
We contributed some codes (soc/board/drivers) based on Ambiq platforms to Zephyr.
https://github.com/zephyrproject-rtos/zephyr/pull/62321 https://github.com/zephyrproject-rtos/zephyr/pull/62567 https://github.com/zephyrproject-rtos/zephyr/pull/63026 https://github.com/zephyrproject-rtos/zephyr/pull/63766 https://github.com/zephyrproject-rtos/zephyr/pull/63097 https://github.com/zephyrproject-rtos/zephyr/pull/62118 https://github.com/zephyrproject-rtos/zephyr/pull/61923
We added Ambiq engineers responsible for maintaining Zephyr on Ambiq platforms.