### PR TITLE
soc: nxp_s32: cmsis rtos v2 adaptation

### DIFF
--- a/soc/arm/nxp_s32/common/cmsis_rtos_v2_adapt.h
+++ b/soc/arm/nxp_s32/common/cmsis_rtos_v2_adapt.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_SOC_ARM_NXP_S32_COMMON_CMSIS_RTOS_V2_ADAPT_H_
+#define ZEPHYR_SOC_ARM_NXP_S32_COMMON_CMSIS_RTOS_V2_ADAPT_H_
+
+/*
+ * The HAL is defining these symbols already. To avoid interference
+ * between HAL and the CMSIS RTOS wrapper, redefine them under an enum.
+ */
+#undef TRUE
+#undef FALSE
+
+enum { FALSE, TRUE};
+
+#endif /* ZEPHYR_SOC_ARM_NXP_S32_COMMON_CMSIS_RTOS_V2_ADAPT_H_ */

--- a/soc/arm/nxp_s32/s32k3/soc.h
+++ b/soc/arm/nxp_s32/s32k3/soc.h
@@ -10,12 +10,7 @@
 #include <S32K344.h>
 
 #if defined(CONFIG_CMSIS_RTOS_V2)
-/*
- * The HAL is defining these symbols already. To avoid redefinitions,
- * let CMSIS RTOS wrapper define them.
- */
-#undef TRUE
-#undef FALSE
+#include <cmsis_rtos_v2_adapt.h>
 #endif
 
 /* Aliases for peripheral base addresses */

--- a/soc/arm/nxp_s32/s32ze/soc.h
+++ b/soc/arm/nxp_s32/s32ze/soc.h
@@ -16,6 +16,10 @@
 #error "SoC not supported"
 #endif
 
+#if defined(CONFIG_CMSIS_RTOS_V2)
+#include <cmsis_rtos_v2_adapt.h>
+#endif
+
 /* Aliases for peripheral base addresses */
 
 /* SIUL2 */


### PR DESCRIPTION
There are symbols are both defined by the NXP S32 HAL and the CMSIS RTOS V2 wrapper, to avoid interference
between them, redefine the symbols under an enum.

This fixes #65715

```
python scripts/twister --inline-logs --clobber-output --ninja -v  -p mr_canhubk3 --build-only -T tests/subsys/portability/cmsis_rtos_v2
-T samples/subsys/portability/cmsis_rtos_v2/timer_synchronization
-T samples/subsys/portability/cmsis_rtos_v2/philosophers
-T tests/subsys/portability/cmsis_rtos_v2
-T samples/subsys/portability/cmsis_rtos_v2/timer_synchronization

ZEPHYR_BASE unset, using "/home/jenkins/workspace/WeeklyTestsDev@2/zephyr"
Deleting output directory /home/jenkins/workspace/WeeklyTestsDev@2/zephyr/twister-out
INFO    - Using Ninja..
INFO    - Zephyr version: c7021e598033
INFO    - Using 'zephyr' toolchain.
INFO    - Building initial testsuite list...
INFO    - Writing JSON report /home/jenkins/workspace/WeeklyTestsDev@2/zephyr/twister-out/testplan.json
INFO    - JOBS: 12
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - 1/5 mr_canhubk3               samples/subsys/portability/cmsis_rtos_v2/philosophers/sample.portability.cmsis_rtos_v2.philosopher.semaphores PASSED (build)
INFO    - 2/5 mr_canhubk3               samples/subsys/portability/cmsis_rtos_v2/philosophers/sample.portability.cmsis_rtos_v2.philosopher PASSED (build)
INFO    - 3/5 mr_canhubk3               samples/subsys/portability/cmsis_rtos_v2/philosophers/sample.portability.cmsis_rtos_v2.philosopher.same_prio PASSED (build)
INFO    - 4/5 mr_canhubk3               samples/subsys/portability/cmsis_rtos_v2/timer_synchronization/sample.portability.cmsis_rtos_v2.timer_synchronization PASSED (build)
INFO    - 5/5 mr_canhubk3               tests/subsys/portability/cmsis_rtos_v2/portability.cmsis_rtos_v2 PASSED (build)
 
INFO    - 5 test scenarios (5 test instances) selected, 0 configurations skipped (0 by static filter, 0 at runtime).
INFO    - 5 of 5 test configurations passed (100.00%), 0 failed, 0 errored, 0 skipped with 0 warnings in 42.60 seconds
INFO    - 0 test configurations executed on platforms, 5 test configurations were only built.
INFO    - Saving reports...
INFO    - Writing JSON report /home/jenkins/workspace/WeeklyTestsDev@2/zephyr/twister-out/twister.json
INFO    - Writing xunit report /home/jenkins/workspace/WeeklyTestsDev@2/zephyr/twister-out/twister.xml...
INFO    - Writing xunit report /home/jenkins/workspace/WeeklyTestsDev@2/zephyr/twister-out/twister_report.xml...
INFO    - Run completed
```

```
python scripts/twister --inline-logs --clobber-output --ninja -v  -p s32z270dc2_rtu0_r52 --build-only -T tests/subsys/portability/cmsis_rtos_v2
-T samples/subsys/portability/cmsis_rtos_v2/timer_synchronization
-T samples/subsys/portability/cmsis_rtos_v2/philosophers
-T tests/subsys/portability/cmsis_rtos_v2
-T samples/subsys/portability/cmsis_rtos_v2/timer_synchronization

ZEPHYR_BASE unset, using "/home/jenkins/workspace/WeeklyTestsDev@2/zephyr"
Deleting output directory /home/jenkins/workspace/WeeklyTestsDev@2/zephyr/twister-out
INFO    - Using Ninja..
INFO    - Zephyr version: c7021e598033
INFO    - Using 'zephyr' toolchain.
INFO    - Building initial testsuite list...
INFO    - Writing JSON report /home/jenkins/workspace/WeeklyTestsDev@2/zephyr/twister-out/testplan.json
INFO    - JOBS: 12
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - 1/5 s32z270dc2_rtu0_r52       samples/subsys/portability/cmsis_rtos_v2/philosophers/sample.portability.cmsis_rtos_v2.philosopher PASSED (build)
INFO    - 2/5 s32z270dc2_rtu0_r52       samples/subsys/portability/cmsis_rtos_v2/philosophers/sample.portability.cmsis_rtos_v2.philosopher.same_prio PASSED (build)
INFO    - 3/5 s32z270dc2_rtu0_r52       samples/subsys/portability/cmsis_rtos_v2/timer_synchronization/sample.portability.cmsis_rtos_v2.timer_synchronization PASSED (build)
INFO    - 4/5 s32z270dc2_rtu0_r52       samples/subsys/portability/cmsis_rtos_v2/philosophers/sample.portability.cmsis_rtos_v2.philosopher.semaphores PASSED (build)
INFO    - 5/5 s32z270dc2_rtu0_r52       tests/subsys/portability/cmsis_rtos_v2/portability.cmsis_rtos_v2 PASSED (build)
 
INFO    - 5 test scenarios (5 test instances) selected, 0 configurations skipped (0 by static filter, 0 at runtime).
INFO    - 5 of 5 test configurations passed (100.00%), 0 failed, 0 errored, 0 skipped with 0 warnings in 113.37 seconds
INFO    - 0 test configurations executed on platforms, 5 test configurations were only built.
INFO    - Saving reports...
INFO    - Writing JSON report /home/jenkins/workspace/WeeklyTestsDev@2/zephyr/twister-out/twister.json
INFO    - Writing xunit report /home/jenkins/workspace/WeeklyTestsDev@2/zephyr/twister-out/twister.xml...
INFO    - Writing xunit report /home/jenkins/workspace/WeeklyTestsDev@2/zephyr/twister-out/twister_report.xml...
INFO    - Run completed
```