### PR TITLE
shell: fix state_collect when input consisting solely of spaces

### DIFF
--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -959,6 +959,18 @@ static inline int ascii_filter(const char data)
 	}
 }
 
+/* Functions returns true if all characters in buf are space ' ' */
+static bool util_is_all_space(const char *buf, uint16_t len)
+{
+	for (uint16_t i = 0; i < len; i++) {
+		if (buf[i] != ' ') {
+			return false;
+		}
+	}
+
+	return true;
+}
+
 static void state_collect(const struct shell *sh)
 {
 	size_t count = 0;
@@ -1000,7 +1012,11 @@ static void state_collect(const struct shell *sh)
 		switch (sh->ctx->receive_state) {
 		case SHELL_RECEIVE_DEFAULT:
 			if (process_nl(sh, data)) {
-				if (!sh->ctx->cmd_buff_len) {
+				uint16_t cmd_buff_len = sh->ctx->cmd_buff_len;
+
+				if ((cmd_buff_len == 0) ||
+					(util_is_all_space(sh->ctx->cmd_buff, cmd_buff_len)
+					 == true)) {
 					history_mode_exit(sh);
 					z_cursor_next_line_move(sh);
 				} else {


### PR DESCRIPTION
Addresses an issue where input consisting only of spaces (' ') and pressing enter leads to a crash during command execution in execute(). To resolve this, we've introduced util_is_all_space() to check if sh->ctx->cmd_buff contains only spaces.

As for reference when system crashed
![screenshot_2023-11-24](https://github.com/zephyrproject-rtos/zephyr/assets/50133174/946a327f-9307-46df-ab4e-68d029405735)
