### PR TITLE
[RFC] drivers: add interrupt controller API public header

### DIFF
--- a/drivers/interrupt_controller/CMakeLists.txt
+++ b/drivers/interrupt_controller/CMakeLists.txt
@@ -2,6 +2,7 @@
 
 zephyr_library()
 zephyr_library_property(ALLOW_EMPTY TRUE)
+zephyr_library_sources_ifdef(CONFIG_USERSPACE               intc_handlers.c)
 zephyr_library_sources_ifdef(CONFIG_ARCV2_INTERRUPT_UNIT    intc_arcv2_irq_unit.c)
 zephyr_library_sources_ifdef(CONFIG_CAVS_ICTL               intc_cavs.c)
 zephyr_library_sources_ifdef(CONFIG_DW_ICTL                 intc_dw.c)

--- a/include/zephyr/drivers/interrupt_controller.h
+++ b/include/zephyr/drivers/interrupt_controller.h
@@ -1,0 +1,354 @@
+/*
+ * Copyright (c) 2023 Meta
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_INTERRUPT_CONTORLLER_H_
+#define ZEPHYR_INCLUDE_DRIVERS_INTERRUPT_CONTORLLER_H_
+
+/**
+ * @brief Interrupt Controller Interface
+ * @defgroup interrupt_controller Interrupt Controller Interface
+ * @ingroup io_interfaces
+ * @{
+ */
+
+#include <errno.h>
+
+#include <zephyr/types.h>
+#include <zephyr/device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Enable IRQ */
+typedef int (*intc_irq_enable_t)(const struct device *dev, uint32_t irq);
+
+/* Disable IRQ */
+typedef int (*intc_irq_disable_t)(const struct device *dev, uint32_t irq);
+
+/* Configure IRQ */
+typedef int (*intc_irq_configure_t)(const struct device *dev, uint32_t irq, unsigned int priority,
+				    uint32_t flags);
+
+/* Check if an IRQ is enabled */
+typedef bool (*intc_irq_is_enabled_t)(const struct device *dev, uint32_t irq);
+
+/* Check if an IRQ is pending */
+typedef bool (*intc_irq_is_pending_t)(const struct device *dev, uint32_t irq);
+
+/* Set the interrupt service routine for an IRQ, similar to dynamic_connect */
+typedef int (*intc_irq_set_isr_t)(const struct device *dev, uint32_t irq, uint32_t priority,
+				  void *routine, void *data, uint32_t flags);
+
+/* Remove the interrupt service routine for an IRQ */
+typedef int (*intc_irq_unset_isr_t)(const struct device *dev, uint32_t irq);
+
+/* Enter the interrupt service routine of an IRQ */
+typedef void (*intc_irq_enter_isr_t)(const struct device *dev, uint32_t irq);
+
+/* Signal end-of-interrupt */
+typedef void (*intc_irq_eoi_t)(const struct device *dev, uint32_t irq);
+
+/* Set IRQ affinity for SMP */
+typedef int (*intc_irq_set_affinity_t)(const struct device *dev, uint32_t irq, uint32_t cpumask);
+
+/* Get the IRQ that's currently active */
+typedef uint64_t (*intc_get_active_irq_t)(const struct device *dev);
+
+/* Get the controller of the IRQ that's currently active */
+typedef const struct device *(*intc_get_active_dev_t)(const struct device *dev);
+
+__subsystem struct interrupt_controller_driver_api {
+	intc_irq_enable_t intc_irq_enable;
+	intc_irq_disable_t intc_irq_disable;
+	intc_irq_configure_t intc_irq_configure;
+	intc_irq_is_enabled_t intc_irq_is_enabled;
+	intc_irq_is_pending_t intc_irq_is_pending;
+	intc_irq_set_isr_t intc_irq_set_isr;
+	intc_irq_unset_isr_t intc_irq_unset_isr;
+	intc_irq_enter_isr_t intc_irq_enter_isr;
+	intc_irq_eoi_t intc_irq_eoi;
+#if CONFIG_SMP
+	intc_irq_set_affinity_t intc_irq_set_affinity;
+#endif /* CONFIG_SMP */
+	intc_get_active_irq_t intc_get_active_irq;
+	intc_get_active_dev_t intc_get_active_dev;
+};
+
+/**
+ * @brief Enable an IRQ
+ *
+ * @param dev Interrupt controller device for the IRQ
+ * @param irq Zephyr-encoded IRQ number
+ *
+ * @retval 0 if success, -errno otherwise
+ */
+__syscall int intc_irq_enable(const struct device *dev, uint32_t irq);
+
+static inline int z_impl_intc_irq_enable(const struct device *dev, uint32_t irq)
+{
+	const struct interrupt_controller_driver_api *api =
+		(const struct interrupt_controller_driver_api *)dev->api;
+
+	if (api->intc_irq_enable == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->intc_irq_enable(dev, irq);
+}
+
+/**
+ * @brief Disable an IRQ
+ *
+ * @param dev Interrupt controller device for the IRQ
+ * @param irq Zephyr-encoded IRQ number
+ *
+ * @retval 0 if success, -errno otherwise
+ */
+__syscall int intc_irq_disable(const struct device *dev, uint32_t irq);
+
+static inline int z_impl_intc_irq_disable(const struct device *dev, uint32_t irq)
+{
+	const struct interrupt_controller_driver_api *api =
+		(const struct interrupt_controller_driver_api *)dev->api;
+
+	if (api->intc_irq_disable == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->intc_irq_disable(dev, irq);
+}
+
+/**
+ * @brief Configure an IRQ with priority and flags
+ *
+ * @param dev Interrupt controller device for the IRQ
+ * @param irq Zephyr-encoded IRQ number
+ * @param priority Priority for the IRQ
+ * @param flags Architecture-dependent configuration flags
+ *
+ * @retval 0 if success, -errno otherwise
+ */
+__syscall int intc_irq_configure(const struct device *dev, uint32_t irq, unsigned int priority,
+				 uint32_t flags);
+
+static inline int z_impl_intc_irq_configure(const struct device *dev, uint32_t irq,
+					    unsigned int priority, uint32_t flags)
+{
+	const struct interrupt_controller_driver_api *api =
+		(const struct interrupt_controller_driver_api *)dev->api;
+
+	if (api->intc_irq_configure == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->intc_irq_configure(dev, irq, priority, flags);
+}
+
+/**
+ * @brief Check if an IRQ is enabled
+ *
+ * @param dev Interrupt controller device for the IRQ
+ * @param irq Zephyr-encoded IRQ number
+ *
+ * @retval true if the IRQ is enabled, false otherwise
+ */
+__syscall bool intc_irq_is_enabled(const struct device *dev, uint32_t irq);
+
+static inline bool z_impl_intc_is_enabled(const struct device *dev, uint32_t irq)
+{
+	const struct interrupt_controller_driver_api *api =
+		(const struct interrupt_controller_driver_api *)dev->api;
+
+	if (api->intc_irq_is_enabled == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->intc_irq_is_enabled(dev, irq);
+}
+
+/**
+ * @brief Check if an IRQ is pending
+ *
+ * @param dev Interrupt controller device for the IRQ
+ * @param irq Zephyr-encoded IRQ number
+ *
+ * @retval true if the IRQ is pending, false otherwise
+ */
+__syscall bool intc_irq_is_pending(const struct device *dev, uint32_t irq);
+
+static inline bool z_impl_intc_is_pending(const struct device *dev, uint32_t irq)
+{
+	const struct interrupt_controller_driver_api *api =
+		(const struct interrupt_controller_driver_api *)dev->api;
+
+	if (api->intc_irq_is_pending == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->intc_irq_is_pending(dev, irq);
+}
+
+/**
+ * @brief Set isr for the IRQ
+ *
+ * @param dev Interrupt controller device for the IRQ
+ * @param irq Zephyr-encoded IRQ number
+ * @param priority Interrupt priority
+ * @param routine Service routine for the IRQ
+ * @param data Data to be passed into the interrupt service routine
+ * @param flags Architecture-dependent configuration flags
+ *
+ * @retval 0 if success, -errno otherwise
+ */
+__syscall int intc_irq_set_isr(const struct device *dev, uint32_t irq, uint32_t priority,
+			       void *routine, void *data, uint32_t flags);
+
+static inline int z_impl_intc_irq_set_isr(const struct device *dev, uint32_t irq, uint32_t priority,
+					  void *routine, void *data, uint32_t flags)
+{
+	const struct interrupt_controller_driver_api *api =
+		(const struct interrupt_controller_driver_api *)dev->api;
+
+	if (api->intc_irq_set_isr == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->intc_irq_set_isr(dev, irq, priority, routine, data, flags);
+}
+
+/**
+ * @brief Unset isr for the IRQ
+ *
+ * @param dev Interrupt controller device for the IRQ
+ * @param irq Zephyr-encoded IRQ number
+ *
+ * @retval 0 if success, -errno otherwise
+ */
+__syscall int intc_irq_unset_isr(const struct device *dev, uint32_t irq);
+
+static inline int z_impl_intc_irq_unset_isr(const struct device *dev, uint32_t irq)
+{
+	const struct interrupt_controller_driver_api *api =
+		(const struct interrupt_controller_driver_api *)dev->api;
+
+	if (api->intc_irq_unset_isr == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->intc_irq_unset_isr(dev, irq);
+}
+
+/**
+ * @brief Invoke an IRQ's interrupt service routine
+ *
+ * @param dev Interrupt controller device for the IRQ
+ * @param irq Zephyr-encoded IRQ number
+ */
+__syscall void intc_irq_enter_isr(const struct device *dev, uint32_t irq);
+
+static inline void z_impl_intc_irq_enter_isr(const struct device *dev, uint32_t irq)
+{
+	const struct interrupt_controller_driver_api *api =
+		(const struct interrupt_controller_driver_api *)dev->api;
+
+	if (api->intc_irq_enter_isr != NULL) {
+		api->intc_irq_enter_isr(dev, irq);
+	}
+}
+
+/**
+ * @brief Signal end-of-interrupt
+ *
+ * @param dev Interrupt controller device for the IRQ
+ * @param irq Zephyr-encoded IRQ number
+ */
+__syscall void intc_irq_eoi(const struct device *dev, uint32_t irq);
+
+static inline void z_impl_intc_irq_eoi(const struct device *dev, uint32_t irq)
+{
+	const struct interrupt_controller_driver_api *api =
+		(const struct interrupt_controller_driver_api *)dev->api;
+
+	if (api->intc_irq_eoi != NULL) {
+		api->intc_irq_eoi(dev, irq);
+	}
+}
+
+/**
+ * @brief Set CPU affinity mask for an IRQ
+ *
+ * Avaialble when CONFIG_SMP is enabled
+ *
+ * @param dev Interrupt controller device for the IRQ
+ * @param irq Zephyr-encoded IRQ number
+ * @param cpu_mask Bitmask to specific which cores can handle IRQ
+ */
+__syscall void intc_irq_set_affinity(const struct device *dev, uint32_t irq, uint32_t cpu_mask);
+#if CONFIG_SMP
+static inline void z_impl_irq_set_affinity(const struct device *dev, uint32_t irq,
+					   uint32_t cpu_mask)
+{
+	const struct interrupt_controller_driver_api *api =
+		(const struct interrupt_controller_driver_api *)dev->api;
+
+	if (api->intc_irq_set_affinity != NULL) {
+		api->intc_irq_set_affinity(dev, irq);
+	}
+}
+#endif /* CONFIG_SMP */
+
+/**
+ * @brief Get active IRQ of an interrupt controller
+ *
+ * @param dev Interrupt controller device
+ *
+ * @retval Active IRQ number
+ */
+__syscall uint64_t intc_get_active_irq(const struct device *dev);
+
+static inline uint64_t z_impl_intc_get_active_irq(const struct device *dev)
+{
+	const struct interrupt_controller_driver_api *api =
+		(const struct interrupt_controller_driver_api *)dev->api;
+
+	if (api->intc_get_active_irq == NULL) {
+		return 0;
+	}
+
+	return api->intc_get_active_irq(dev);
+}
+
+/**
+ * @brief Get the interrupt controller that has an active interrupt
+ *
+ * @retval Interrupt controller that has an active interrupt
+ */
+__syscall const struct device *intc_get_active_dev(const struct device *dev);
+
+static const struct device *z_impl_intc_get_active_dev(const struct device *dev)
+{
+	const struct interrupt_controller_driver_api *api =
+		(const struct interrupt_controller_driver_api *)dev->api;
+
+	if (api->intc_get_active_dev == NULL) {
+		return NULL;
+	}
+
+	return api->intc_get_active_dev(dev);
+}
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#include <syscalls/interrupt_controller.h>
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_INTERRUPT_CONTORLLER_H_ */


### PR DESCRIPTION
This RFC is proposing an unified device API for the [interrupt-controller driver](https://github.com/zephyrproject-rtos/zephyr/tree/main/drivers/interrupt_controller).

The list of APIs in this RFC aims to cover as much as possible of what our existing in-tree driver requires, comments are welcomed.

___

# List of interrupt controllers and their public APIs

> [!NOTE]
> WIP - CI is expected to fail

- `intc_arcv2_irq_unit` - no public API
- `intc_cavs` - `irq_nextlevel.h`
  - [x] void enable(*dev, unsigned int irq)
  - [x] void disable(*dev, unsigned int irq)
  - [x] unsigned int get_state(*dev) - true if has enabled IRQ, can use `irq_is_pending`
  - [x] void set_priority(*dev, unsigned int irq, unsigned int prio, uint32_t flags) - use `configure`
  - [x] int get_line_state(*dev, unsigned int irq) - equivalent to `is_enabled()`

- `intc_dw_ace`
  - [x] void enable(*dev, uint32_t irq)
  - [x] void disable(*dev, uint32_t irq)
  - [x] int is_enabled(*dev, unsigned int irq)
  - [x] int connect_dynamic(*dev, unsigned int irq, unsigned int priority, void (*routine)(const void *parameter), const void *parameter, uint32_t flags) - equivalent to `set_callback`

- `intc_dw` - same as `intc_cavs`

- `intc_eirq_nxp_s32`
  - [x] void enable(*dev, uint8_t line, Siul2_Icu_Ip_EdgeType edge_type) - should be equivalent to `enable` + `configure`
  - [x] void disable(*dev, uint8_t line)
  - [x] int set_callback(*dev, uint8_t line, eirq_nxp_s32_callback_t cb, uint8_t pin, void *arg)
  - [x] void unset_callback(*dev, uint8_t line)
  - [x] uint32_t get_pending(*dev) - `irq_is_pending`

- `intc_esp32` - unlike anything else

- `intc_esp32c3`
  - [ ] void initialize(void)
  - [ ] int alloc(int source, int flags, isr_handler_t handler, void *arg, void **ret_handle)
  - [x] int enable(int source)
  - [x] int disable(int source)
  - [ ] uint32_t get_enabled_intmask(int status_mask_number)

- `exti_stm32`
  - [x] void enable(int line)
  - [x] void disable(int line)
  - [x] void set_trigger_type(int line, int type) - use `configure`
  - [x] int set_callback(int line, stm32_exti_callback_t cb, void *data)
  - [x] void unset_callback(int line)

- `exti_gd2`
  - [x] void enable(int line)
  - [x] void disable(int line)
  - [x] void set_trigger_type(int line, int type) - use `configure`
  - [x] int configure(uint8_t line, gd32_exti_cb_t cb, void *user)

- `intc_gic`
  - [x] void enable(unsigned int irq)
  - [x] void disable(unsigned int irq)
  - [x] bool is_enabled(unsigned int irq)
  - [x] bool is_pending(unsigned int irq)
  - [ ] void clear_pending(unsigned int irq)
  - [x] void set_priority(unsigned int irq, unsigned int prio, unsigned int flags) - use `configure`
  - [x] int get_active(void) - `get_active_irq`
  - [x] void eoi(unsigned int irq)
  - [ ] void secondary_init(void) [SMP only]
  - [ ] void raise_sgi(unsigned int sgi_id, uint64_t target_aff, uint16_t target_list)

- `gicv3_its` - see `gicv3_its.h`, unlike anything else

- `intc_gicv3` - same as `intc_gic`

- `intc_intel_vtd` - see `intel_vtd.h`, unlike anything else

- `intc_ioapic`
  - [ ] uint32_t num_rtes(void)
  - [x] void irq_enable(unsigned int irq)
  - [x] void irq_disable(unsigned int irq)
  - [ ] void int_vec_set(unsigned int irq, unsigned int vector)
  - [ ] void irq_set(unsigned int irq, unsigned int vector, uint32_t flags)

- `intc_irqmp`
  - [x] void enable(unsigned int line)
  - [x] void disable(unsigned int line)
  - [x] int is_enabled(unsigned int source)

- `intc_ite_it8xxx*`
  - [x] void enable(unsigned int irq)
  - [x] void disable(unsigned int irq)
  - [x] void irq_polarity_set(unsigned int irq, unsigned int flags) [trigger type] - use `configure`
  - [x] int is_enable(unsigned int irq)

- `intc_loapic`
  - [x] void enable(unsigned int irq)
  - [x] void disable(unsigned int irq)
  - [ ] others aren't common

- `intc_mchp_ecia_xec` - unlike anything else

- `intc_miwu` - same as `intc_cavs`

- `intc_nuclei_eclic` [CLIC]
  - [x] void enable(unsigned int irq)
  - [x] void disable(unsigned int irq)
  - [x] int is_enabled(unsigned int irq)
  - [x] void priority_set(uint32_t irq, uint32_t pri, uint32_t flags) - use `configure`

- `intc_nxp_pint`
  - [x] int enable(uint8_t irq, enum nxp_pint_trigger trigger)
  - [x] void disable(uint8_t irq)
  - [x] int callback(uint8_t irq, nxp_pint_cb_t cb, void *data)
  - [x] void unset_callback(uint8_t irq)

- `intc_plic`
  - [x] void enable(unsigned int irq)
  - [x] void disable(unsigned int irq)
  - [x] int is_enabled(unsigned int irq)
  - [x] void set_priority(uint32_t irq, uint32_t prio) - use `configure`
  - [x] uint32_t get_active_irq(void)
  - [x] dev *get_active_dev(void)

- `intc_ra_icu`
  - [x] int connect_dynamic(unsigned int irq, unsigned int priority, void (*routine)(const void *parameter), const void *parameter, uint32_t flags) - use `set_callback`
  - [ ] not sure what others do, see `intc_ra_icu.h`

- `intc_rv32m1_intmux` - same as `intc_cavs`

- `intc_sam0_eic` - probably can combine `port` & `pin`
  - [x] int enable(int port, int pin)
  - [x] int disable(int port, int pin)
  - [ ] uint32_t interrupt_pending(int port) - similar to `is_pending`
  - [ ] int release/acquire - not sure what they do

- `intc_shared_irq` - `shared_irq.h`
  - [x] int isr_register(const struct device *dev, isr_t isr_func, const struct device *isr_dev) - `set_callback`
  - [x] int enable(dev, isr_dev)
  - [x] int disable(dev, isr_dev)

- `intc_system_apic`
  - [x] void arch_irq_enable(uint32_t irq)
  - [x] void arch_irq_disable(uint32_t irq)

- `intc_vexriscv_litex`
  - [x] void enable(unsigned int irq)
  - [x] void disable(unsigned int irq)
  - [x] int is_enabled(unsigned int irq)

- `intc_vim`
  - [x] uint32_t irq_get_active(void)
  - [x] void irq_eoi(unsigned int irq)
  - [ ] void init(void)
  - [x] void priority_set(unsigned int irq, unsigned int prio, uint32_t flags) - use `configure`
  - [x] void enable(unsigned int irq)
  - [x] void disable(unsigned int irq)
  - [x] int is_enabled(unsigned int irq)
  - [x] void enter_irq(int irq)

- `intc_wkpu_nxp_s32`
  - [x] void unset_callback(const struct device *dev, uint8_t line)
  - [x] int set_callback(const struct device *dev, uint8_t line, wkpu_nxp_s32_callback_t cb, uint8_t pin, void *arg)
  - [x] void enable(const struct device *dev, uint8_t line, Wkpu_Ip_EdgeType edge_type) - use `enable` + `configure`
  - [x] void disable(const struct device *dev, uint8_t line)
  - [x] uint64_t get_pending(const struct device *dev) - use `get_active_irq`

- `intc_xmc4xxx` - tied to GPIO
  - [x] enable(int port_id, int pin, enum gpio_int_mode mode, enum gpio_int_trig trig, void (*fn)(const struct device *, int), void *user_data) - use `enable` + `configure` + `set_callback`
  - [x] int disable(int port_id, int pin)

- `wuc_ite_it8xxx2`
  - [x] void enable(const struct device *dev, uint8_t mask)
  - [x] void disable(const struct device *dev, uint8_t mask)
  - [ ] void clear_status(const struct device *dev, uint8_t mask)
  - [x] void set_polarity(const struct device *dev, uint8_t mask, uint32_t flags) - use `configure`
