### PR TITLE
Fix STM32 ADC PM

### DIFF
--- a/samples/boards/stm32/power_mgmt/adc/boards/nucleo_wba52cg.overlay
+++ b/samples/boards/stm32/power_mgmt/adc/boards/nucleo_wba52cg.overlay
@@ -10,3 +10,17 @@
 		io-channels = <&adc4 8>;
 	};
 };
+
+&adc4 {
+    pinctrl-0 = <&adc4_in8_pa1>;
+    #address-cells = <1>;
+    #size-cells = <0>;
+
+    channel@8 {
+        reg = <8>;
+        zephyr,gain = "ADC_GAIN_1";
+        zephyr,reference = "ADC_REF_INTERNAL";
+        zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+        zephyr,resolution = <12>;
+    };
+};


### PR DESCRIPTION
Add a locking mechanism for STM32 ADC to prevent entering PM while measurement is in progress. This prevents blocking the driver in an indeterminate state.
Also complete the STM32WBA overlay of the ADC PM sample to make it usable.