### PR TITLE
Support attributes for direct ISRs

### DIFF
--- a/boards/posix/common/irq/board_irq.h
+++ b/boards/posix/common/irq/board_irq.h
@@ -60,9 +60,9 @@ void posix_irq_priority_set(unsigned int irq, unsigned int prio,
  * All pre/post irq work of the interrupt is handled in the board
  * posix_irq_handler() both for direct and normal interrupts together
  */
-#define ARCH_ISR_DIRECT_DECLARE(name) \
+#define ARCH_ISR_DIRECT_DECLARE(name, ...) \
 	static inline int name##_body(void); \
-	int name(void) \
+	__VA_ARGS__ int name(void) \
 	{ \
 		int check_reschedule; \
 		check_reschedule = name##_body(); \

--- a/include/zephyr/arch/arc/v2/irq.h
+++ b/include/zephyr/arch/arc/v2/irq.h
@@ -122,9 +122,9 @@ extern void arch_isr_direct_header(void);
  * Scheduling can not be done in direct isr. If required, please use kernel
  * aware interrupt handling
  */
-#define ARCH_ISR_DIRECT_DECLARE(name) \
+#define ARCH_ISR_DIRECT_DECLARE(name, ...) \
 	static inline int name##_body(void); \
-	__attribute__ ((_ARC_DIRECT_ISR_FUNC_ATTRIBUTE))void name(void) \
+	__VA_ARGS__ __attribute__ ((_ARC_DIRECT_ISR_FUNC_ATTRIBUTE))void name(void) \
 	{ \
 		ISR_DIRECT_HEADER(); \
 		name##_body(); \

--- a/include/zephyr/arch/arm/irq.h
+++ b/include/zephyr/arch/arm/irq.h
@@ -166,11 +166,11 @@ static inline void arch_isr_direct_footer(int maybe_swap)
 	}
 }
 
-#define ARCH_ISR_DIRECT_DECLARE(name) \
+#define ARCH_ISR_DIRECT_DECLARE(name, ...) \
 	static inline int name##_body(void); \
 	_Pragma("GCC diagnostic push") \
 	_Pragma("GCC diagnostic ignored \"-Wattributes\"") \
-	__attribute__ ((interrupt ("IRQ"))) void name(void) \
+	__VA_ARGS__ __attribute__ ((interrupt("IRQ"))) void name(void) \
 	{ \
 		int check_reschedule; \
 		ISR_DIRECT_HEADER(); \

--- a/include/zephyr/arch/riscv/irq.h
+++ b/include/zephyr/arch/riscv/irq.h
@@ -92,9 +92,9 @@ static inline void arch_isr_direct_footer(int swap)
 /*
  * TODO: Add support for rescheduling
  */
-#define ARCH_ISR_DIRECT_DECLARE(name) \
+#define ARCH_ISR_DIRECT_DECLARE(name, ...) \
 	static inline int name##_body(void); \
-	__attribute__ ((interrupt)) void name(void) \
+	__VA_ARGS__ __attribute__ ((interrupt)) void name(void) \
 	{ \
 		ISR_DIRECT_HEADER(); \
 		name##_body(); \

--- a/include/zephyr/arch/x86/ia32/arch.h
+++ b/include/zephyr/arch/x86/ia32/arch.h
@@ -320,9 +320,9 @@ static inline void arch_isr_direct_footer(int swap)
 	}
 }
 
-#define ARCH_ISR_DIRECT_DECLARE(name) \
+#define ARCH_ISR_DIRECT_DECLARE(name, ...) \
 	static inline int name##_body(void); \
-	__attribute__ ((interrupt)) void name(void *stack_frame) \
+	__VA_ARGS__ __attribute__ ((interrupt)) void name(void *stack_frame) \
 	{ \
 		ARG_UNUSED(stack_frame); \
 		int check_reschedule; \

--- a/include/zephyr/irq.h
+++ b/include/zephyr/irq.h
@@ -201,8 +201,9 @@ irq_disconnect_dynamic(unsigned int irq, unsigned int priority,
  *      }
  *
  * @param name symbol name of the ISR
+ * @param ...  attributes to add to the isr
  */
-#define ISR_DIRECT_DECLARE(name) ARCH_ISR_DIRECT_DECLARE(name)
+#define ISR_DIRECT_DECLARE(name, ...) ARCH_ISR_DIRECT_DECLARE(name, __VA_ARGS__)
 
 /**
  * @brief Lock interrupts.


### PR DESCRIPTION
In order to add function attributes, e.g. a section I want the ISR to be linked into, I added variadic arguments to the `ISR_DIRECT_DECLARE` macro and all its architecture specific versions.

Like this I can just write

```
ISR_DIRECT_DECLARE(my_isr, __attribute__((section(".itcm"))))
{...}
```

At the same time the original usage without this attribute is not broken.

If anyone can think of a better, cleaner method to achieve this, I'm happy to adjust this PR.

closes #65701 