### PR TITLE
ci: hotfix: Use latest version of greetings action

### DIFF
--- a/.github/workflows/greet_first_time_contributor.yml
+++ b/.github/workflows/greet_first_time_contributor.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: zephyrproject-rtos/action-first-interaction@v1.1.1-zephyr-4
+      - uses: zephyrproject-rtos/action-first-interaction@v1.1.1-zephyr-5
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
This fixes a bug with the action's Docker container apparently not being able to run Node correctly anymore...

DNM until https://github.com/zephyrproject-rtos/action-first-interaction/pull/6 is merged and v1.1.1-zephyr-5 tagged