### PR TITLE
x86: Only enable EFI_CONSOLE if UART console is not enabled

### DIFF
--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -472,7 +472,7 @@ config X86_EFI_CONSOLE
 	bool
 	depends on X86_EFI && X86_64 && !X86_VERY_EARLY_CONSOLE
 	select EFI_CONSOLE
-	default y
+	default y if !UART_CONSOLE
 	help
 	  This enables the use of the UEFI console device as the
 	  Zephyr printk handler.  It requires that no interferences


### PR DESCRIPTION
Most x86 build configurations enable the UART console. Since EFI console has also defaulted to enabled, this means that the EFI covers the early part of the boot until UART takes over.

This is all fine, except that enabling EFI console has the effect of disabling PRINTK_SYNC. This in turn has the effect of causing garbled output over UART, which has led to several bug reports on x86 platforms (in particular on up_squared).

Since EFI console should really only be used for early platform bringup and debugging purposes, it's not really ideal to unconditionally have it enabled by default. Instead, change the default enabling to be conditional to the UART console being disabled.

Fixes #54861
Fixes #55071