### PR TITLE
tests/bsim/compile: Add option to pass extra cmake arguments

### DIFF
--- a/tests/bsim/compile.source
+++ b/tests/bsim/compile.source
@@ -19,6 +19,7 @@ function _compile(){
 
   local cmake_args="${cmake_args:-"-DCONFIG_COVERAGE=y \
     -DCMAKE_EXPORT_COMPILE_COMMANDS=ON"}"
+  local cmake_extra_args="${cmake_extra_args:-""}"
   local ninja_args="${ninja_args:-""}"
   local cc_flags="${cc_flags:-"-Werror"}"
 
@@ -47,7 +48,7 @@ function _compile(){
   fi
   local cmake_cmd+=( -DOVERLAY_CONFIG="${conf_overlay}" \
             ${modules_arg} \
-            ${cmake_args} -DCMAKE_C_FLAGS=\"${cc_flags}\")
+            ${cmake_args} -DCMAKE_C_FLAGS=\"${cc_flags}\" ${cmake_extra_args})
   if [ -v sysbuild ]; then
     local cmake_cmd+=( -DAPP_DIR=${app_root}/${app} ${ZEPHYR_BASE}/share/sysbuild/)
   else


### PR DESCRIPTION
Add an extra optional input to the script which can be used to pass more options to cmake.
Background: With sysbuild needing to pass extra options is quite normal. Users would normally want to add options, without necessarily wanting to change the default cmake_args, so this new options provides that.