### PR TITLE
twister: add --aggressive-no-clean option

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -453,6 +453,15 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
              "faster compilation since builds will be incremental.")
 
     parser.add_argument(
+        "--aggressive-no-clean", action="store_true",
+        help="Re-use the outdir before building and do not re-run cmake. Will result in "
+             "much faster compilation since builds will be incremental. This option might "
+             " result in build failures and inconsistencies if dependencies change or when "
+             " applied on a significantly changed code base. Use on your own "
+             " risk. It is recommended to only use this option for local "
+             " development and when testing localized change in a subsystem.")
+
+    parser.add_argument(
         '--detailed-test-id', action='store_true',
         help="Include paths to tests' locations in tests' names. Names will follow "
              "PATH_TO_TEST/SCENARIO_NAME schema "
@@ -739,6 +748,9 @@ def parse_arguments(parser, args, options = None):
 
     if options.show_footprint or options.compare_report:
         options.enable_size_report = True
+
+    if options.aggressive_no_clean:
+        options.no_clean = True
 
     if options.coverage:
         options.enable_coverage = True

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -1244,12 +1244,17 @@ class TwisterRunner:
                 instance.filter_stages = []
                 if instance.testsuite.filter:
                     instance.filter_stages = self.get_cmake_filter_stages(instance.testsuite.filter, expr_parser.reserved.keys())
+
                 if test_only and instance.run:
                     pipeline.put({"op": "run", "test": instance})
                 elif instance.filter_stages and "full" not in instance.filter_stages:
                     pipeline.put({"op": "filter", "test": instance})
                 else:
-                    pipeline.put({"op": "cmake", "test": instance})
+                    cache_file = os.path.join(instance.build_dir, "CMakeCache.txt")
+                    if os.path.exists(cache_file) and self.env.options.aggressive_no_clean:
+                        pipeline.put({"op": "build", "test": instance})
+                    else:
+                        pipeline.put({"op": "cmake", "test": instance})
 
 
     def pipeline_mgr(self, pipeline, done_queue, lock, results):

--- a/scripts/tests/twister/test_runner.py
+++ b/scripts/tests/twister/test_runner.py
@@ -2540,11 +2540,11 @@ def test_twisterrunner_add_tasks_to_queue(
         return [filter]
 
     instances = {
-        'dummy1': mock.Mock(run=True, retries=0, status='passed'),
-        'dummy2': mock.Mock(run=True, retries=0, status='skipped'),
-        'dummy3': mock.Mock(run=True, retries=0, status='filtered'),
-        'dummy4': mock.Mock(run=True, retries=0, status='error'),
-        'dummy5': mock.Mock(run=True, retries=0, status='failed')
+        'dummy1': mock.Mock(run=True, retries=0, status='passed', build_dir="/tmp"),
+        'dummy2': mock.Mock(run=True, retries=0, status='skipped', build_dir="/tmp"),
+        'dummy3': mock.Mock(run=True, retries=0, status='filtered', build_dir="/tmp"),
+        'dummy4': mock.Mock(run=True, retries=0, status='error', build_dir="/tmp"),
+        'dummy5': mock.Mock(run=True, retries=0, status='failed', build_dir="/tmp")
     }
     instances['dummy4'].testsuite.filter = 'some'
     instances['dummy5'].testsuite.filter = 'full'


### PR DESCRIPTION
Useful option during development and when applying smaller change to the
code and verifying changes using tests. This works fine as long as no
dependencies or major changes are done, i.e. when editing few files and
in a subsystem. Use with caution and use on your own risk :-)

When building multiple tests, this provide significant boost, up to 300%
faster than when rebuilding everything from scratch or when re-running
cmake every single time.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
