### PR TITLE
drivers: eth: phy: Remove syscall from phy API

### DIFF
--- a/doc/releases/migration-guide-3.6.rst
+++ b/doc/releases/migration-guide-3.6.rst
@@ -299,6 +299,11 @@ Networking
   The IPv6 hop limit value is also changed so that unicast and multicast packets can have a
   different one. (:github:`65886`)
 
+* The Ethernet phy APIs defined in ``<zephyr/net/phy.h>`` are removed from syscall list.
+  The APIs were marked as callable from usermode but in practice this does not work as the device
+  cannot be accessed from usermode thread. This means that the API calls will need to made
+  from supervisor mode thread.
+
 Other Subsystems
 ================
 

--- a/include/zephyr/net/phy.h
+++ b/include/zephyr/net/phy.h
@@ -110,11 +110,8 @@ __subsystem struct ethphy_driver_api {
  * @retval -EIO If communication with PHY failed.
  * @retval -ENOTSUP If not supported.
  */
-__syscall int phy_configure_link(const struct device *dev,
-				 enum phy_link_speed speeds);
-
-static inline int z_impl_phy_configure_link(const struct device *dev,
-					    enum phy_link_speed speeds)
+static inline int phy_configure_link(const struct device *dev,
+				     enum phy_link_speed speeds)
 {
 	const struct ethphy_driver_api *api =
 		(const struct ethphy_driver_api *)dev->api;
@@ -135,11 +132,8 @@ static inline int z_impl_phy_configure_link(const struct device *dev,
  * @retval 0 If successful.
  * @retval -EIO If communication with PHY failed.
  */
-__syscall int phy_get_link_state(const struct device *dev,
-				 struct phy_link_state *state);
-
-static inline int z_impl_phy_get_link_state(const struct device *dev,
-					    struct phy_link_state *state)
+static inline int phy_get_link_state(const struct device *dev,
+				     struct phy_link_state *state)
 {
 	const struct ethphy_driver_api *api =
 		(const struct ethphy_driver_api *)dev->api;
@@ -161,13 +155,9 @@ static inline int z_impl_phy_get_link_state(const struct device *dev,
  * @retval 0 If successful.
  * @retval -ENOTSUP If not supported.
  */
-__syscall int phy_link_callback_set(const struct device *dev,
-				    phy_callback_t callback,
-				    void *user_data);
-
-static inline int z_impl_phy_link_callback_set(const struct device *dev,
-					       phy_callback_t callback,
-					       void *user_data)
+static inline int phy_link_callback_set(const struct device *dev,
+					phy_callback_t callback,
+					void *user_data)
 {
 	const struct ethphy_driver_api *api =
 		(const struct ethphy_driver_api *)dev->api;
@@ -187,11 +177,8 @@ static inline int z_impl_phy_link_callback_set(const struct device *dev,
  * @retval 0 If successful.
  * @retval -EIO If communication with PHY failed.
  */
-__syscall int phy_read(const struct device *dev, uint16_t reg_addr,
-		       uint32_t *value);
-
-static inline int z_impl_phy_read(const struct device *dev, uint16_t reg_addr,
-				  uint32_t *value)
+static inline int phy_read(const struct device *dev, uint16_t reg_addr,
+			   uint32_t *value)
 {
 	const struct ethphy_driver_api *api =
 		(const struct ethphy_driver_api *)dev->api;
@@ -211,11 +198,8 @@ static inline int z_impl_phy_read(const struct device *dev, uint16_t reg_addr,
  * @retval 0 If successful.
  * @retval -EIO If communication with PHY failed.
  */
-__syscall int phy_write(const struct device *dev, uint16_t reg_addr,
-			uint32_t value);
-
-static inline int z_impl_phy_write(const struct device *dev, uint16_t reg_addr,
-				   uint32_t value)
+static inline int phy_write(const struct device *dev, uint16_t reg_addr,
+			    uint32_t value)
 {
 	const struct ethphy_driver_api *api =
 		(const struct ethphy_driver_api *)dev->api;
@@ -231,7 +215,5 @@ static inline int z_impl_phy_write(const struct device *dev, uint16_t reg_addr,
 /**
  * @}
  */
-
-#include <syscalls/phy.h>
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_PHY_H_ */


### PR DESCRIPTION
No point marking the phy API to be callable from usermode, the device cannot be accessed from usermode anyway so this is pointless. User can call the phy API from supervisor mode thread just fine.