### PR TITLE
soc: esp32: call reset cause reason init

### DIFF
--- a/soc/riscv/espressif_esp32/esp32c3/soc.c
+++ b/soc/riscv/espressif_esp32/esp32c3/soc.c
@@ -30,6 +30,8 @@
 #include "bootloader_init.h"
 #endif /* CONFIG_MCUBOOT */
 
+extern void esp_reset_reason_init(void);
+
 /*
  * This is written in C rather than assembly since, during the port bring up,
  * Zephyr is being booted by the Espressif bootloader.  With it, the C stack
@@ -55,6 +57,8 @@ void __attribute__((section(".iram1"))) __esp_platform_start(void)
 
 	/* Disable normal interrupts. */
 	csr_read_clear(mstatus, MSTATUS_MIE);
+
+	esp_reset_reason_init();
 
 #ifdef CONFIG_MCUBOOT
 	/* MCUboot early initialisation.

--- a/soc/xtensa/espressif_esp32/esp32/soc.c
+++ b/soc/xtensa/espressif_esp32/esp32/soc.c
@@ -41,6 +41,7 @@
 #include <zephyr/sys/printk.h>
 
 extern void z_cstart(void);
+extern void esp_reset_reason_init(void);
 
 #ifdef CONFIG_ESP32_NETWORK_CORE
 extern const unsigned char esp32_net_fw_array[];
@@ -118,6 +119,8 @@ void __attribute__((section(".iram1"))) __esp_platform_start(void)
 	 * arch_kernel_init() is invoked.
 	 */
 	__asm__ volatile("wsr.MISC0 %0; rsync" : : "r"(&_kernel.cpus[0]));
+
+	esp_reset_reason_init();
 
 #ifdef CONFIG_MCUBOOT
 	/* MCUboot early initialisation. */

--- a/soc/xtensa/espressif_esp32/esp32s2/soc.c
+++ b/soc/xtensa/espressif_esp32/esp32s2/soc.c
@@ -37,6 +37,7 @@
 #endif /* CONFIG_MCUBOOT */
 
 extern void rtc_clk_cpu_freq_set_xtal(void);
+extern void esp_reset_reason_init(void);
 
 #if CONFIG_ESP_SPIRAM
 extern int _ext_ram_bss_start;
@@ -90,6 +91,8 @@ void __attribute__((section(".iram1"))) __esp_platform_start(void)
 	 * arch_kernel_init() is invoked.
 	 */
 	__asm__ volatile("wsr.MISC0 %0; rsync" : : "r"(&_kernel.cpus[0]));
+
+	esp_reset_reason_init();
 
 #ifdef CONFIG_MCUBOOT
 	/* MCUboot early initialisation. */

--- a/soc/xtensa/espressif_esp32/esp32s3/soc.c
+++ b/soc/xtensa/espressif_esp32/esp32s3/soc.c
@@ -47,6 +47,7 @@ extern int _ext_ram_bss_end;
 #endif
 
 extern void z_cstart(void);
+extern void esp_reset_reason_init(void);
 
 #ifdef CONFIG_SOC_ESP32S3_PROCPU
 extern const unsigned char esp32s3_appcpu_fw_array[];
@@ -183,6 +184,8 @@ void IRAM_ATTR __esp_platform_start(void)
 	wdt_hal_write_protect_disable(&rtc_wdt_ctx);
 	wdt_hal_disable(&rtc_wdt_ctx);
 	wdt_hal_write_protect_enable(&rtc_wdt_ctx);
+
+	esp_reset_reason_init();
 
 	esp_clk_init();
 

--- a/west.yml
+++ b/west.yml
@@ -152,7 +152,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: b3cb13f06586543ae1d156dc3e84b2fd3dc2f1fb
+      revision: ca3be152414bb269647806c4d3091e04168d1add
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
Reset cause reason was not initalized properly, making hwinfo feature not to work as expected.

Fixes #65634