### PR TITLE
drivers: adc: stm32 adc fixing calibration for the stm32F1 serie

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -1360,6 +1360,7 @@ static int adc_stm32_init(const struct device *dev)
 
 #if defined(HAS_CALIBRATION)
 	adc_stm32_calibrate(dev);
+	LL_ADC_REG_SetTriggerSource(adc, LL_ADC_REG_TRIG_SOFTWARE);
 #endif /* HAS_CALIBRATION */
 
 	adc_context_unlock_unconditionally(&data->ctx);


### PR DESCRIPTION
Configure the sw trigger just after calibration on the ADC of the stm32F1 serie

So the conversion can start on regular channel on the software control bit.

Without this trigger the conversion is never started (no ADC irq). For example running the tests/drivers/adc/adc_api/ on the nucleo_f103rb, testcase is stuck in the adc_context_wait_for_completion() as follows:
```
Running TESTSUITE adc_basic
===================================================================
START - test_adc_asynchronous_call

    Assertion failed at WEST_TOPDIR/zephyr/tests/drivers/adc/adc_api/s)
k_poll failed with error -11
 FAIL - test_adc_asynchronous_call in 1.015 seconds
===================================================================
START - test_adc_invalid_request
```

That configuration was missing on  when refactoring the calibration in PR https://github.com/zephyrproject-rtos/zephyr/pull/64191