### PR TITLE
kernel: mmu: Fix static analysis issue

### DIFF
--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -781,10 +781,13 @@ void z_phys_map(uint8_t **virt_ptr, uintptr_t phys, size_t size, uint32_t flags)
 		 * Basically if either end of region is within
 		 * virtual memory space, we need to mark the bits.
 		 */
-		if (((dest_addr >= Z_VIRT_RAM_START) &&
-		     (dest_addr < Z_VIRT_RAM_END)) ||
-		    (((dest_addr + aligned_size) >= Z_VIRT_RAM_START) &&
-		     ((dest_addr + aligned_size) < Z_VIRT_RAM_END))) {
+
+		if (IN_RANGE(aligned_phys,
+			      (uintptr_t)Z_VIRT_RAM_START,
+			      (uintptr_t)(Z_VIRT_RAM_END - 1)) ||
+		    IN_RANGE(aligned_phys + aligned_size - 1,
+			      (uintptr_t)Z_VIRT_RAM_START,
+			      (uintptr_t)(Z_VIRT_RAM_END - 1))) {
 			uint8_t *adjusted_start = MAX(dest_addr, Z_VIRT_RAM_START);
 			uint8_t *adjusted_end = MIN(dest_addr + aligned_size,
 						    Z_VIRT_RAM_END);


### PR DESCRIPTION
Instead of performing a set of relative address comparisons using pointers of type 'uint8_t *', we leverage the existing IN_RANGE() macro and perform the comparisons using 'uintptr_t'.

Fixes #65375