### PR TITLE
docs: posix: move pthread_attr_getguardsize() to POSIX_THREADS_EXT

### DIFF
--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -66,6 +66,22 @@ multiple processes.
     pthread_sigmask(),
     pthread_testcancel(),
 
+.. _posix_option_group_posix_threads_ext:
+
+POSIX_THREADS_EXT
+=================
+
+This table lists service support status in Zephyr:
+
+.. csv-table:: POSIX_THREADS_EXT
+   :header: API, Supported
+   :widths: 50,10
+
+    pthread_attr_getguardsize(),
+    pthread_attr_setguardsize(),
+    pthread_mutexattr_gettype(),yes
+    pthread_mutexattr_settype(),yes
+
 .. _posix_option_group_xsi_thread_ext:
 
 XSI_THREAD_EXT
@@ -81,9 +97,7 @@ This table lists service support status in Zephyr:
    :header: API, Supported
    :widths: 50,10
 
-    pthread_attr_getguardsize(),
     pthread_attr_getstack(),yes
-    pthread_attr_setguardsize(),
     pthread_attr_setstack(),yes
     pthread_getconcurrency(),
     pthread_setconcurrency()

--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -82,10 +82,10 @@ This table lists service support status in Zephyr:
     pthread_mutexattr_gettype(),yes
     pthread_mutexattr_settype(),yes
 
-.. _posix_option_group_xsi_thread_ext:
+.. _posix_option_group_xsi_threads_ext:
 
-XSI_THREAD_EXT
-==============
+XSI_THREADS_EXT
+===============
 
 The XSI_THREADS_EXT option group is required because it provides
 functions to control a thread's stack. This is considered useful for any
@@ -93,7 +93,7 @@ real-time application.
 
 This table lists service support status in Zephyr:
 
-.. csv-table:: XSI_THREAD_EXT
+.. csv-table:: XSI_THREADS_EXT
    :header: API, Supported
    :widths: 50,10
 


### PR DESCRIPTION
`pthread_attr_getguardsize()` and `pthread_attr_setguardsize()` are part of POSIX_THREADS_EXT in IEEE 1003.1-2017.

Also correct typo by renaming `XSI_THREAD_EXT` to `XSI_THREADS_EXT`

<img width="730" alt="Screenshot 2023-11-24 at 9 20 36 PM" src="https://github.com/zephyrproject-rtos/zephyr/assets/983494/ac2b2638-90ec-4582-abf7-195f0b9fa707">
<img width="612" alt="Screenshot 2023-11-23 at 10 20 39 PM" src="https://github.com/zephyrproject-rtos/zephyr/assets/983494/ecebab50-781c-4cd9-9fe0-a07ff420061d">

Fixes #65768