### PR TITLE
drivers: eth_esp32: allow selecting ref clk source

### DIFF
--- a/drivers/ethernet/eth_esp32.c
+++ b/drivers/ethernet/eth_esp32.c
@@ -17,6 +17,7 @@
 #include <esp_mac.h>
 #include <hal/emac_hal.h>
 #include <hal/emac_ll.h>
+#include <soc/rtc.h>
 
 #include "eth.h"
 
@@ -223,8 +224,19 @@ int eth_esp32_initialize(const struct device *dev)
 
 	if (strcmp(phy_connection_type, "rmii") == 0) {
 		emac_hal_iomux_init_rmii();
+#if DT_INST_NODE_HAS_PROP(0, ref_clk_output_gpios)
+		BUILD_ASSERT(DT_INST_GPIO_PIN(0, ref_clk_output_gpios) == 16 ||
+			DT_INST_GPIO_PIN(0, ref_clk_output_gpios) == 17,
+			"Only GPIO16/17 are allowed as a GPIO REF_CLK source!");
+		int ref_clk_gpio = DT_INST_GPIO_PIN(0, ref_clk_output_gpios);
+
+		emac_hal_iomux_rmii_clk_output(ref_clk_gpio);
+		emac_ll_clock_enable_rmii_output(dev_data->hal.ext_regs);
+		rtc_clk_apll_enable(true, 0, 0, 6, 2);
+#else
 		emac_hal_iomux_rmii_clk_input();
 		emac_ll_clock_enable_rmii_input(dev_data->hal.ext_regs);
+#endif
 	} else if (strcmp(phy_connection_type, "mii") == 0) {
 		emac_hal_iomux_init_mii();
 		emac_ll_clock_enable_mii(dev_data->hal.ext_regs);

--- a/dts/bindings/ethernet/espressif,esp32-eth.yaml
+++ b/dts/bindings/ethernet/espressif,esp32-eth.yaml
@@ -14,3 +14,8 @@ properties:
 
   phy-connection-type:
     default: "rmii"
+
+  ref-clk-output-gpios:
+    type: phandle-array
+    description: |
+      GPIO to output RMII Clock.

--- a/west.yml
+++ b/west.yml
@@ -152,7 +152,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: ca3be152414bb269647806c4d3091e04168d1add
+      revision: ffbe58815808af98d1e3241defa552a0fcc6d28a
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
In case of boards where REF_CLK signal is not connected to the GPIO0 by default add the possibility to use the optional GPIO16/GPIO17 as a REF CLK source.