### PR TITLE
drivers: intc: plic: set edge-triggered register address using compat

### DIFF
--- a/dts/riscv/andes/andes_v5_ae350.dtsi
+++ b/dts/riscv/andes/andes_v5_ae350.dtsi
@@ -167,7 +167,7 @@
 		ranges;
 
 		plic0: interrupt-controller@e4000000 {
-			compatible = "sifive,plic-1.0.0";
+			compatible = "sifive,plic-1.0.0", "andestech,nceplic100";
 			#address-cells = <1>;
 			#interrupt-cells = <2>;
 			interrupt-controller;


### PR DESCRIPTION
Define the edge-trigger register base address based on whether the PLIC node in the devicetree has an additional compatible that supports edge-triggered interrupt.

Limited the implementation to Andes NCEPLIC100 only, updated the devicetree binding of `andes_v5_ae350` accordingly.

**Caveat**: Per-instance trigger register address isn't supported, if one of the PLIC instances has `"andestech,plic"`, it assumes that all PLIC instances have the same type

Fixes #64675