### PR TITLE
drivers: ethernet: esp32: fix Kconfig

### DIFF
--- a/drivers/ethernet/Kconfig.esp32
+++ b/drivers/ethernet/Kconfig.esp32
@@ -5,7 +5,9 @@
 
 menuconfig ETH_ESP32
 	bool "ESP32 Ethernet driver"
+	default y
 	depends on SOC_SERIES_ESP32
+	depends on DT_HAS_ESPRESSIF_ESP32_ETH_ENABLED
 	select MDIO
 	help
 	  Enable ESP32 Ethernet driver.


### PR DESCRIPTION
Add the missing dependency of the node status value and enable the driver by default when they are met.