### PR TITLE
drivers: mdio: esp32: add dependency of node status

### DIFF
--- a/drivers/mdio/Kconfig.esp32
+++ b/drivers/mdio/Kconfig.esp32
@@ -3,7 +3,8 @@
 
 config MDIO_ESP32
 	bool "ESP32 MDIO driver"
-	depends on SOC_SERIES_ESP32
 	default y
+	depends on SOC_SERIES_ESP32
+	depends on DT_HAS_ESPRESSIF_ESP32_MDIO_ENABLED
 	help
 	  Enable ESP32 MCU Family MDIO driver.


### PR DESCRIPTION
MDIO driver should be available and enabled only when mdio node has status okay.