### PR TITLE
soc: riscv: privileged: Conditionally override arch_cpu_idle()

### DIFF
--- a/soc/riscv/riscv-privileged/common/CMakeLists.txt
+++ b/soc/riscv/riscv-privileged/common/CMakeLists.txt
@@ -3,8 +3,9 @@
 zephyr_include_directories(.)
 
 zephyr_sources(
-  idle.c
   soc_irq.S
   soc_common_irq.c
   vector.S
   )
+
+zephyr_sources_ifdef(CONFIG_RISCV_HAS_CPU_IDLE idle.c)

--- a/soc/riscv/riscv-privileged/efinix-sapphire/Kconfig.defconfig.series
+++ b/soc/riscv/riscv-privileged/efinix-sapphire/Kconfig.defconfig.series
@@ -11,6 +11,7 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 
 config RISCV_HAS_CPU_IDLE
 	bool
+	default y
 
 config RISCV_SOC_INTERRUPT_INIT
 	bool


### PR DESCRIPTION
The current configuration comes with a common [family-level implementation](https://github.com/zephyrproject-rtos/zephyr/blob/20979f80a659c9734c2c13a68c4cb85a29e21f77/soc/riscv/riscv-privileged/common/idle.c#L31-L34) of `arch_cpu_idle()` for the whole riscv-privileged family, utilizing the `WFI` instruction to place the CPU into a light sleep state. This is based on the assumption that it will be awakened later by interrupts such as SYSTICK. However, this approach is not always effective, especially in scenarios where SYSTICK is not a valid wake source.

As discussed in #65090, this behavior should be determined by the existing `CONFIG_RISCV_HAS_CPU_IDLE` option. Accordingly, this commit configures `idle.c` at the family-level to be built conditional on this option. CPUs that do not enable this option will fallback to a generic [arch-level implementation](https://github.com/zephyrproject-rtos/zephyr/blob/20979f80a659c9734c2c13a68c4cb85a29e21f77/arch/riscv/core/cpu_idle.c#L20-L23).

The `Kconfig`s for existing CPUs have also been modified to maintain the existing behavior.
