### PR TITLE
drivers: serial: ra: Add support interrupt-driven mode

### DIFF
--- a/boards/arm/arduino_uno_r4/arduino_uno_r4_minima_defconfig
+++ b/boards/arm/arduino_uno_r4/arduino_uno_r4_minima_defconfig
@@ -10,6 +10,7 @@ CONFIG_BUILD_OUTPUT_HEX=y
 
 # enable uart driver
 CONFIG_SERIAL=y
+CONFIG_UART_INTERRUPT_DRIVEN=y
 
 # enable console
 CONFIG_CONSOLE=y

--- a/drivers/interrupt_controller/intc_ra_icu.c
+++ b/drivers/interrupt_controller/intc_ra_icu.c
@@ -121,5 +121,4 @@ int ra_icu_irq_disconnect_dynamic(unsigned int irq, unsigned int priority,
 	return 0;
 }
 
-DEVICE_DT_INST_DEFINE(0, NULL, NULL, NULL, NULL, PRE_KERNEL_1, CONFIG_INTC_INIT_PRIORITY,
-		      NULL);
+DEVICE_DT_INST_DEFINE(0, NULL, NULL, NULL, NULL, PRE_KERNEL_1, CONFIG_INTC_INIT_PRIORITY, NULL);

--- a/drivers/interrupt_controller/intc_ra_icu.c
+++ b/drivers/interrupt_controller/intc_ra_icu.c
@@ -104,5 +104,23 @@ int ra_icu_irq_connect_dynamic(unsigned int irq, unsigned int priority,
 	return irqn;
 }
 
+int ra_icu_irq_disconnect_dynamic(unsigned int irq, unsigned int priority,
+				  void (*routine)(const void *parameter), const void *parameter,
+				  uint32_t flags)
+{
+	int irqn = irq;
+
+	if (irq == RA_ICU_IRQ_UNSPECIFIED) {
+		return -EINVAL;
+	}
+
+	irq_disable(irqn);
+	sys_write32(0, IELSRn_REG(irqn));
+	z_isr_install(irqn, z_irq_spurious, NULL);
+	z_arm_irq_priority_set(irqn, 0, 0);
+
+	return 0;
+}
+
 DEVICE_DT_INST_DEFINE(0, NULL, NULL, NULL, NULL, PRE_KERNEL_1, CONFIG_INTC_INIT_PRIORITY,
 		      NULL);

--- a/drivers/interrupt_controller/intc_ra_icu.c
+++ b/drivers/interrupt_controller/intc_ra_icu.c
@@ -99,7 +99,6 @@ int ra_icu_irq_connect_dynamic(unsigned int irq, unsigned int priority,
 	z_isr_install(irqn, routine, parameter);
 	z_arm_irq_priority_set(irqn, priority, flags);
 	ra_icu_irq_configure(event, intcfg);
-	irq_enable(irqn);
 
 	return irqn;
 }

--- a/drivers/serial/uart_ra.c
+++ b/drivers/serial/uart_ra.c
@@ -182,40 +182,35 @@ struct uart_ra_data {
 #define LSR_PNUM_POS (8)
 #define LSR_PNUM_LEN (5)
 
-static uint8_t uart_ra_read_8(const struct device *dev,
-			   uint32_t offs)
+static uint8_t uart_ra_read_8(const struct device *dev, uint32_t offs)
 {
 	const struct uart_ra_cfg *config = dev->config;
 
 	return sys_read8(config->regs + offs);
 }
 
-static void uart_ra_write_8(const struct device *dev,
-			    uint32_t offs, uint8_t value)
+static void uart_ra_write_8(const struct device *dev, uint32_t offs, uint8_t value)
 {
 	const struct uart_ra_cfg *config = dev->config;
 
 	sys_write8(value, config->regs + offs);
 }
 
-static uint16_t uart_ra_read_16(const struct device *dev,
-				uint32_t offs)
+static uint16_t uart_ra_read_16(const struct device *dev, uint32_t offs)
 {
 	const struct uart_ra_cfg *config = dev->config;
 
 	return sys_read16(config->regs + offs);
 }
 
-static void uart_ra_write_16(const struct device *dev,
-			     uint32_t offs, uint16_t value)
+static void uart_ra_write_16(const struct device *dev, uint32_t offs, uint16_t value)
 {
 	const struct uart_ra_cfg *config = dev->config;
 
 	sys_write16(value, config->regs + offs);
 }
 
-static void uart_ra_set_baudrate(const struct device *dev,
-				 uint32_t baud_rate)
+static void uart_ra_set_baudrate(const struct device *dev, uint32_t baud_rate)
 {
 	struct uart_ra_data *data = dev->data;
 	uint8_t reg_val;
@@ -310,8 +305,7 @@ static int uart_ra_err_check(const struct device *dev)
 	return errors;
 }
 
-static int uart_ra_configure(const struct device *dev,
-			     const struct uart_config *cfg)
+static int uart_ra_configure(const struct device *dev, const struct uart_config *cfg)
 {
 	struct uart_ra_data *data = dev->data;
 
@@ -369,8 +363,7 @@ static int uart_ra_configure(const struct device *dev,
 }
 
 #ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
-static int uart_ra_config_get(const struct device *dev,
-			      struct uart_config *cfg)
+static int uart_ra_config_get(const struct device *dev, struct uart_config *cfg)
 {
 	struct uart_ra_data *data = dev->data;
 
@@ -423,15 +416,12 @@ static int uart_ra_init(const struct device *dev)
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 
-static bool uart_ra_irq_is_enabled(const struct device *dev,
-				   uint32_t irq)
+static bool uart_ra_irq_is_enabled(const struct device *dev, uint32_t irq)
 {
 	return uart_ra_read_8(dev, SCR) & irq;
 }
 
-static int uart_ra_fifo_fill(const struct device *dev,
-			     const uint8_t *tx_data,
-			     int len)
+static int uart_ra_fifo_fill(const struct device *dev, const uint8_t *tx_data, int len)
 {
 	struct uart_ra_data *data = dev->data;
 	uint8_t reg_val;
@@ -456,8 +446,7 @@ static int uart_ra_fifo_fill(const struct device *dev,
 	return 1;
 }
 
-static int uart_ra_fifo_read(const struct device *dev, uint8_t *rx_data,
-			     const int size)
+static int uart_ra_fifo_read(const struct device *dev, uint8_t *rx_data, const int size)
 {
 	uint8_t data;
 
@@ -584,8 +573,7 @@ static int uart_ra_irq_update(const struct device *dev)
 	return 1;
 }
 
-static void uart_ra_irq_callback_set(const struct device *dev,
-				     uart_irq_callback_user_data_t cb,
+static void uart_ra_irq_callback_set(const struct device *dev, uart_irq_callback_user_data_t cb,
 				     void *cb_data)
 {
 	struct uart_ra_data *data = dev->data;

--- a/drivers/serial/uart_ra.c
+++ b/drivers/serial/uart_ra.c
@@ -340,8 +340,6 @@ static int uart_ra_init(const struct device *dev)
 		return ret;
 	}
 
-	DEVICE_MMIO_MAP(dev, K_MEM_CACHE_NONE);
-
 	ret = uart_ra_configure(dev, &data->current_config);
 	if (ret != 0) {
 		return ret;
@@ -360,7 +358,7 @@ static const struct uart_driver_api uart_ra_driver_api = {
 };
 
 /* Device Instantiation */
-#define UART_RCAR_INIT_CFG(n)                                                                      \
+#define UART_RA_INIT_CFG(n)                                                                        \
 	PINCTRL_DT_DEFINE(DT_INST_PARENT(n));                                                      \
 	static const struct uart_ra_cfg uart_ra_cfg_##n = {                                        \
 		.regs = DT_REG_ADDR(DT_INST_PARENT(n)),                                            \
@@ -370,8 +368,8 @@ static const struct uart_driver_api uart_ra_driver_api = {
 		.pcfg = PINCTRL_DT_DEV_CONFIG_GET(DT_INST_PARENT(n)),                              \
 	}
 
-#define UART_RCAR_INIT(n)							\
-	UART_RCAR_INIT_CFG(n);                                                  \
+#define UART_RA_INIT(n)							\
+	UART_RA_INIT_CFG(n);                                                  \
 										\
 	static struct uart_ra_data uart_ra_data_##n = {				\
 		.current_config = {						\
@@ -392,4 +390,4 @@ static const struct uart_driver_api uart_ra_driver_api = {
 			      &uart_ra_driver_api);				\
 										\
 
-DT_INST_FOREACH_STATUS_OKAY(UART_RCAR_INIT)
+DT_INST_FOREACH_STATUS_OKAY(UART_RA_INIT)

--- a/include/zephyr/drivers/interrupt_controller/intc_ra_icu.h
+++ b/include/zephyr/drivers/interrupt_controller/intc_ra_icu.h
@@ -35,4 +35,8 @@ extern int ra_icu_irq_connect_dynamic(unsigned int irq, unsigned int priority,
 				      void (*routine)(const void *parameter), const void *parameter,
 				      uint32_t flags);
 
+extern int ra_icu_irq_disconnect_dynamic(unsigned int irq, unsigned int priority,
+					 void (*routine)(const void *parameter),
+					 const void *parameter, uint32_t flags);
+
 #endif /* ZEPHYR_DRIVERS_INTERRUPT_CONTROLLER_INTC_RA_ICU_H_ */


### PR DESCRIPTION
Added support interrupt-driven mode for Renesas RA series UART.

And fix also minor naming issues.