### PR TITLE
boards: arm: arduino_uno_r4: add Arduino connector for minima/wifi

### DIFF
--- a/boards/arduino/uno_r4/arduino_uno_r4_minima.dts
+++ b/boards/arduino/uno_r4/arduino_uno_r4_minima.dts
@@ -21,4 +21,33 @@
 	aliases {
 		led0 = &led;
 	};
+
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &ioport0 14 0>,   /* A0 */
+			   <1 0 &ioport0 0 0>,    /* A1 */
+			   <2 0 &ioport0 1 0>,    /* A2 */
+			   <3 0 &ioport0 2 0>,    /* A3 */
+			   <4 0 &ioport1 1 0>,    /* A4 */
+			   <5 0 &ioport1 0 0>,    /* A5 */
+			   <6 0 &ioport3 1 0>,    /* D0 */
+			   <7 0 &ioport3 2 0>,    /* D1 */
+			   <8 0 &ioport1 5 0>,    /* D2 */
+			   <9 0 &ioport1 4 0>,    /* D3 */
+			   <10 0 &ioport1 3 0>,   /* D4 */
+			   <11 0 &ioport1 2 0>,   /* D5 */
+			   <12 0 &ioport1 6 0>,   /* D6 */
+			   <13 0 &ioport1 7 0>,   /* D7 */
+			   <14 0 &ioport3 4 0>,   /* D8 */
+			   <15 0 &ioport3 3 0>,   /* D9 */
+			   <16 0 &ioport1 12 0>,  /* D10 */
+			   <17 0 &ioport1 9 0>,   /* D11 */
+			   <18 0 &ioport1 10 0>,  /* D12 */
+			   <19 0 &ioport1 11 0>,  /* D13 */
+			   <20 0 &ioport1 1 0>,   /* D14 */
+			   <21 0 &ioport1 0 0>;   /* D15 */
+	};
 };

--- a/boards/arduino/uno_r4/arduino_uno_r4_wifi.dts
+++ b/boards/arduino/uno_r4/arduino_uno_r4_wifi.dts
@@ -21,4 +21,33 @@
 	aliases {
 		led0 = &led;
 	};
+
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &ioport0 14 0>,   /* A0 */
+			   <1 0 &ioport0 0 0>,    /* A1 */
+			   <2 0 &ioport0 1 0>,    /* A2 */
+			   <3 0 &ioport0 2 0>,    /* A3 */
+			   <4 0 &ioport1 1 0>,    /* A4 */
+			   <5 0 &ioport1 0 0>,    /* A5 */
+			   <6 0 &ioport3 1 0>,    /* D0 */
+			   <7 0 &ioport3 2 0>,    /* D1 */
+			   <8 0 &ioport1 4 0>,    /* D2 */
+			   <9 0 &ioport1 5 0>,    /* D3 */
+			   <10 0 &ioport1 6 0>,   /* D4 */
+			   <11 0 &ioport1 7 0>,   /* D5 */
+			   <12 0 &ioport1 11 0>,  /* D6 */
+			   <13 0 &ioport1 12 0>,  /* D7 */
+			   <14 0 &ioport3 4 0>,   /* D8 */
+			   <15 0 &ioport3 3 0>,   /* D9 */
+			   <16 0 &ioport1 3 0>,   /* D10 */
+			   <17 0 &ioport4 11 0>,  /* D11 */
+			   <18 0 &ioport4 10 0>,  /* D12 */
+			   <19 0 &ioport1 2 0>,   /* D13 */
+			   <20 0 &ioport1 1 0>,   /* D14 */
+			   <21 0 &ioport1 0 0>;   /* D15 */
+	};
 };


### PR DESCRIPTION
Add a Arduino connector node to arduino_uno_r4_minima.dts.

---
And fix some wrong configuration about GPIO.

- The ioport2 has a configuration for nonexistent irq9. Removed it.
- The macro resolving will fail with gpio nodes with no `interrupt_names` definition.

