### PR TITLE
Interrupt controller DT macros and GPIO IRQ utilities

### DIFF
--- a/boards/posix/native_sim/native_sim.dts
+++ b/boards/posix/native_sim/native_sim.dts
@@ -170,6 +170,8 @@
 		low-level;
 		gpio-controller;
 		#gpio-cells = <2>;
+		interrupt-controller;
+		#interrupt-cells = <2>;
 	};
 
 	zephyr_udc0: udc0 {

--- a/doc/build/dts/macros.bnf
+++ b/doc/build/dts/macros.bnf
@@ -40,8 +40,10 @@ node-macro =/ %s"DT_N" path-id %s"_IRQ_NUM"
 node-macro =/ %s"DT_N" path-id %s"_IRQ_IDX_" DIGIT "_EXISTS"
 node-macro =/ %s"DT_N" path-id %s"_IRQ_IDX_" DIGIT
               %s"_VAL_" dt-name [ %s"_EXISTS" ]
+node-macro =/ %s"DT_N" path-id %s"_CONTROLLER"
 node-macro =/ %s"DT_N" path-id %s"_IRQ_NAME_" dt-name
               %s"_VAL_" dt-name [ %s"_EXISTS" ]
+node-macro =/ %s"DT_N" path-id %s"_IRQ_NAME_" dt-name "_CONTROLLER"
 ; The ranges property is also special.
 node-macro =/ %s"DT_N" path-id %s"_RANGES_NUM"
 node-macro =/ %s"DT_N" path-id %s"_RANGES_IDX_" DIGIT "_EXISTS"

--- a/doc/hardware/gpio_irq/index.rst
+++ b/doc/hardware/gpio_irq/index.rst
@@ -1,0 +1,287 @@
+.. _gpio_irq_api:
+
+GPIO interrupt requests
+#######################
+
+Overview
+********
+
+Devices may generate interrupt requests which are routed from device to SOC
+through GPIO pins.
+
+The following example shows an I2C attached sensor which can generate an
+interrupt on a pin which is connected to the GPIO controller ``gpio0``'s
+pin 2 in the devicetree.
+
+.. code-block:: devicetree
+
+   #include <zephyr/dt-bindings/gpio/gpio.h>
+   #include <zephyr/dt-bindings/interrupt-controller/irq.h>
+
+   &i2c0 {
+           sensor: sensor@21 {
+                   compatible = "vnd,sensor";
+                   reg = <0x21>;
+                   interrupt-parent = <&gpio0>;
+                   interrupts = <2 (IRQ_TYPE_EDGE_FALLING | GPIO_PULL_UP)>;
+                   status = "okay";
+           };
+   };
+
+GPIO controllers, like ``gpio0``, may double as interrupt controllers.
+Interrupt controllers configure interrupt sources, which could be a level
+change on a GPIO pin, and invoke interrupts when the interrupt source is
+triggered.
+
+Devicetree layout
+*****************
+
+This sections covers a variaty of GPIO IRQ layouts in the devicetree.
+
+Multiple GPIO controllers
+=========================
+
+A single device may be connected to multiple GPIO controllers, in which case
+the ``interrupts-extended`` property is used.
+
+.. code-block:: devicetree
+
+   #include <zephyr/dt-bindings/gpio/gpio.h>
+   #include <zephyr/dt-bindings/interrupt-controller/irq.h>
+
+   &i2c0 {
+           sensor: sensor@21 {
+                   compatible = "vnd,sensor";
+                   reg = <0x21>;
+                   interrupts-extended = <&gpio0 2 (IRQ_TYPE_EDGE_FALLING | GPIO_PULL_UP)>,
+                                         <&gpio1 4 (IRQ_TYPE_EDGE_FALLING | GPIO_PULL_UP)>;
+                   status = "okay";
+           };
+   };
+
+Mapping GPIO interrupt lines
+============================
+
+Devices may contain multiple interrupt lines, of which some may be
+optional, which can be routed to the GPIO controller(s).
+
+Using interrupt line indexes
+----------------------------
+
+In case there is one or more obligatory interrupt lines, either followed by
+a single or zero optional interrupt lines, the index of the interrupt lines
+within the ``interrupts`` or ``interrupts-extended`` property can be used.
+
+In the following example, the first interrupt line (index 0) is obligatory,
+the second (index 1) is optional. The bindings file will define which
+interrupt index is mapped to which interrupt line:
+
+.. code-block:: yaml
+
+   compatible: "vnd,sensor"
+
+   include: sensor-device.yaml
+
+   interrupts:
+     description: |
+       Interrupt line(s) connected to the INT1 and optional INT2 interrupt lines.
+       The first interrupt line is INT1, the second is INT2.
+
+In the following devicetree snippet, INT1 is connected to ``gpio0`` pin 2,
+and INT2 is connected to ``gpio1`` pin 4:
+
+.. code-block:: devicetree
+
+   #include <zephyr/dt-bindings/gpio/gpio.h>
+   #include <zephyr/dt-bindings/interrupt-controller/irq.h>
+
+   &i2c0 {
+           sensor: sensor@21 {
+                   compatible = "vnd,sensor";
+                   reg = <0x21>;
+                   interrupts-extended = <&gpio0 2 (IRQ_TYPE_EDGE_FALLING | GPIO_PULL_UP)>,
+                                         <&gpio1 4 (IRQ_TYPE_EDGE_FALLING | GPIO_PULL_UP)>;
+                   status = "okay";
+           };
+   };
+
+Using interrupt line names
+--------------------------
+
+The interrupt lines within the ``interrupts`` and ``interrupts-extended``
+properties can mapped to a name, which can be used by drivers to identify
+the connected interrupt lines.
+
+In the following example, the DRDY line is obligatory, and the interrupt
+lines INT1 and INT2 are optional. The bindings file will define which
+interrupt name is mapped to which interrupt line:
+
+.. code-block:: yaml
+
+   compatible: "vnd,sensor"
+
+   include: sensor-device.yaml
+
+   interrupts:
+     description: |
+       Interrupt line(s) connected to the DRDY, and optional INT1 and INT2
+       interrupt lines. The interrupt lines are mapped to the names "drdy",
+       "int1" and "int2".
+
+In the following devicetree snippet, DRDY is connected to ``gpio0`` pin 2,
+and INT2 is connected to ``gpio1`` pin 4:
+
+.. code-block:: devicetree
+
+   #include <zephyr/dt-bindings/gpio/gpio.h>
+   #include <zephyr/dt-bindings/interrupt-controller/irq.h>
+
+   &i2c0 {
+           sensor: sensor@21 {
+                   compatible = "vnd,sensor";
+                   reg = <0x21>;
+                   interrupts-extended = <&gpio0 2 (IRQ_TYPE_EDGE_FALLING | GPIO_PULL_UP)>,
+                                         <&gpio1 4 (IRQ_TYPE_EDGE_FALLING | GPIO_PULL_UP)>;
+                   interrupt-names = "drdy", "int2";
+                   status = "okay";
+           };
+   };
+
+GPIO IRQ device driver example
+******************************
+
+This example is based on the following devicetree snippet:
+
+.. code-block:: devicetree
+
+   #include <zephyr/dt-bindings/gpio/gpio.h>
+   #include <zephyr/dt-bindings/interrupt-controller/irq.h>
+
+   &i2c0 {
+           sensor: sensor@21 {
+                   compatible = "vnd,sensor";
+                   reg = <0x21>;
+                   interrupts-extended = <&gpio0 2 (IRQ_TYPE_EDGE_FALLING | GPIO_PULL_UP)>,
+                                         <&gpio1 4 (IRQ_TYPE_EDGE_FALLING | GPIO_PULL_UP)>;
+                   interrupt-names = "drdy", "int2";
+                   status = "okay";
+           };
+   };
+
+The DRDY line is obligatory, and the interrupt lines INT1 and INT2 are
+optional.
+
+The example device driver gets the interrupt specifications from the
+devicetree, and configures and enables all connected interrupt lines on init
+(for the provided devicetree snippet, only DRDY and INT2 are connected).
+
+.. code-block:: c
+
+   #include <zephyr/kernel.h>
+   #include <zephyr/drivers/sensor.h>
+   #include <zephyr/drivers/gpio/gpio_irq.h>
+
+   #define DT_DRV_COMPAT vnd_sensor
+
+   struct vnd_sensor_config {
+           struct gpio_irq_dt_spec drdy_irq_spec;
+           struct gpio_irq_dt_spec int1_irq_spec;
+           struct gpio_irq_dt_spec int2_irq_spec;
+   };
+
+   struct vnd_sensor_data {
+           struct gpio_irq drdy_irq;
+           struct gpio_irq int1_irq;
+           struct gpio_irq int2_irq;
+   };
+
+   static void vnd_sensor_drdy_callback(struct gpio_irq *irq)
+   {
+           struct vnd_sensor_data *data = CONTAINER_OF(irq, struct vnd_sensor_data, drdy_irq);
+   }
+
+   static void vnd_sensor_int1_callback(struct gpio_irq *irq)
+   {
+           struct vnd_sensor_data *data = CONTAINER_OF(irq, struct vnd_sensor_data, int1_irq);
+   }
+
+   static void vnd_sensor_int2_callback(struct gpio_irq *irq)
+   {
+           struct vnd_sensor_data *data = CONTAINER_OF(irq, struct vnd_sensor_data, int2_irq);
+   }
+
+   static int vnd_sensor_init(const struct device *dev)
+   {
+           const struct vnd_sensor_config *config = dev->config;
+           struct vnd_sensor_data *data = dev->data;
+           int ret;
+
+           /*
+            * The sensor's interrupt lines must be configured before requesting, and thus
+            * enabling, the interrupt request(s), to match the interrupt request flags
+            * defined in the devicetree.
+            *
+            * The flags are found in the struct gpio_irq_dt_spec irq_flags member.
+            *
+            *     if (config->drdy_irq_spec.irq_flags & IRQ_TYPE_EDGE_RISING) {
+            *             ...
+            *     }
+            *
+            * If the sensor's interrupt lines can not be configured, simply validate
+            * that the interrupt request flags match the configuration of the sensor's
+            * interrupt lines.
+            *
+            *     if (config->drdy_irq_spec.irq_flags != IRQ_TYPE_EDGE_RISING) {
+            *             return -EPERM;
+            *     }
+            */
+
+           /*
+            * IRQ is configured and enabled when requested.
+            * DRDY is obligatory so no need to check if interrupt line is connected.
+            */
+           ret = gpio_irq_request_dt(&config->drdy_irq_spec, &data->drdy_irq,
+                                     vnd_sensor_drdy_callback);
+           if (ret < 0) {
+                   return ret;
+           }
+
+           /* Remember to check if interrupt line is connected if it's optional */
+           if (gpio_irq_dt_spec_exists(&config->int1_irq_spec)) {
+                   ret = gpio_irq_request_dt(&config->int1_irq_spec, &data->int1_irq,
+                                             vnd_sensor_int1_callback);
+                   if (ret < 0) {
+                           return ret;
+                   }
+           }
+
+           if (gpio_irq_dt_spec_exists(&config->int2_irq_spec)) {
+                   ret = gpio_irq_request_dt(&config->int2_irq_spec, &data->int2_irq,
+                                             vnd_sensor_int2_callback);
+                   if (ret < 0) {
+                      return ret;
+                   }
+           }
+
+           return 0;
+   }
+
+   #define VND_SENSOR_DEVICE(inst)                                                      \
+           static struct vnd_sensor_data vnd_sensor_data##inst;                         \
+           static const struct vnd_sensor_config vnd_sensor_config##inst = {            \
+                   .drdy_irq_spec = GPIO_IRQ_DT_INST_SPEC_GET_BY_NAME(inst, drdy),      \
+                   .int1_irq_spec = GPIO_IRQ_DT_INST_SPEC_GET_OPT_BY_NAME(inst, int1),  \
+                   .int2_irq_spec = GPIO_IRQ_DT_INST_SPEC_GET_OPT_BY_NAME(inst, int2),  \
+           };                                                                           \
+                                                                                        \
+           SENSOR_DEVICE_DT_INST_DEFINE(inst, vnd_sensor_init, NULL,                    \
+                                        &vnd_sensor_data##inst,                         \
+                                        &vnd_sensor_config##inst, POST_KERNEL, 99,      \
+                                        NULL);
+
+   DT_INST_FOREACH_STATUS_OKAY(VND_SENSOR_DEVICE)
+
+GPIO IRQ API
+************
+
+.. doxygengroup:: gpio_irq

--- a/doc/hardware/index.rst
+++ b/doc/hardware/index.rst
@@ -10,6 +10,7 @@ Hardware Support
    barriers/index.rst
    cache/index.rst
    emulator/index.rst
+   gpio_irq/index.rst
    peripherals/index.rst
    pinctrl/index.rst
    porting/index

--- a/drivers/gpio/CMakeLists.txt
+++ b/drivers/gpio/CMakeLists.txt
@@ -90,6 +90,7 @@ zephyr_library_sources_ifdef(CONFIG_GPIO_BCM2711    gpio_bcm2711.c)
 zephyr_library_sources_ifdef(CONFIG_GPIO_RA         gpio_ra.c)
 zephyr_library_sources_ifdef(CONFIG_GPIO_RZT2M    gpio_rzt2m.c)
 zephyr_library_sources_ifdef(CONFIG_GPIO_AMBIQ      gpio_ambiq.c)
+zephyr_library_sources_ifdef(CONFIG_GPIO_IRQ        gpio_irq.c)
 
 if (CONFIG_GPIO_EMUL_SDL)
   zephyr_library_sources(gpio_emul_sdl.c)

--- a/drivers/gpio/Kconfig
+++ b/drivers/gpio/Kconfig
@@ -86,6 +86,11 @@ config GPIO_ENABLE_DISABLE_INTERRUPT
 	  on/off the interrupt signal without changing other registers, such as
 	  pending register, etc. The driver must implement it to work.
 
+config GPIO_IRQ
+	bool "GPIO IRQ utilities"
+	default y
+	select EXPERIMENTAL
+
 
 source "drivers/gpio/Kconfig.ad5592"
 

--- a/drivers/gpio/gpio_irq.c
+++ b/drivers/gpio/gpio_irq.c
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2023 Bjarki Arge Andreasen
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/gpio/gpio_irq.h>
+
+static void gpio_irq_callback_handler(const struct device *port,
+				      struct gpio_callback *cb,
+				      gpio_port_pins_t pins)
+{
+	ARG_UNUSED(pins);
+
+	struct gpio_irq *irq =
+		CONTAINER_OF(cb, struct gpio_irq, nested_callback);
+
+	irq->handler(irq);
+}
+
+int gpio_irq_request(const struct device *controller,
+		     gpio_pin_t irq_pin,
+		     gpio_dt_flags_t irq_flags,
+		     struct gpio_irq *irq,
+		     gpio_irq_callback_handler_t handler)
+{
+	gpio_flags_t gpio_flags;
+
+	irq->controller = controller;
+	irq->irq_pin = irq_pin;
+	irq->irq_flags = irq_flags;
+	irq->handler = handler;
+
+	if (!device_is_ready(controller)) {
+		return -ENODEV;
+	}
+
+	if (!IRQ_TYPE_IS_VALID(irq_flags)) {
+		return -EINVAL;
+	}
+
+	gpio_flags = irq_flags & (~IRQ_TYPE_MASK);
+	if (gpio_pin_configure(controller, irq_pin, GPIO_INPUT) < 0) {
+		return -EINVAL;
+	}
+
+	gpio_init_callback(&irq->nested_callback, gpio_irq_callback_handler, BIT(irq_pin));
+	if (gpio_add_callback(controller, &irq->nested_callback) < 0) {
+		return -EINVAL;
+	}
+
+	if (gpio_irq_enable(irq) < 0) {
+		(void)gpio_remove_callback(controller, &irq->nested_callback);
+		return -EAGAIN;
+	}
+
+	return 0;
+}
+
+bool gpio_irq_dt_spec_exists(const struct gpio_irq_dt_spec *spec)
+{
+	return (spec->controller != NULL);
+}
+
+int gpio_irq_request_dt(const struct gpio_irq_dt_spec *spec,
+			struct gpio_irq *irq,
+			gpio_irq_callback_handler_t handler)
+{
+	return gpio_irq_request(spec->controller, spec->irq_pin, spec->irq_flags, irq, handler);
+}
+
+int gpio_irq_release(struct gpio_irq *irq)
+{
+	(void)gpio_irq_disable(irq);
+	return gpio_remove_callback(irq->controller, &irq->nested_callback);
+}
+
+int gpio_irq_enable(struct gpio_irq *irq)
+{
+	gpio_flags_t gpio_flags = GPIO_INT_ENABLE;
+
+	if (IRQ_TYPE_IS_EDGE_TRIGGERED(irq->irq_flags)) {
+		gpio_flags |= GPIO_INT_EDGE;
+	}
+
+	if (IRQ_TYPE_IS_ACTIVE_HIGH(irq->irq_flags)) {
+		gpio_flags |= GPIO_INT_HIGH_1;
+	}
+
+	if (IRQ_TYPE_IS_ACTIVE_LOW(irq->irq_flags)) {
+		gpio_flags |= GPIO_INT_LOW_0;
+	}
+
+	return gpio_pin_interrupt_configure(irq->controller, irq->irq_pin, gpio_flags);
+}
+
+int gpio_irq_disable(struct gpio_irq *irq)
+{
+	return gpio_pin_interrupt_configure(irq->controller, irq->irq_pin, GPIO_INT_DISABLE);
+}

--- a/dts/bindings/gpio/zephyr,gpio-emul.yaml
+++ b/dts/bindings/gpio/zephyr,gpio-emul.yaml
@@ -5,7 +5,7 @@ description: GPIO Emulator
 
 compatible: "zephyr,gpio-emul"
 
-include: [gpio-controller.yaml, base.yaml]
+include: [gpio-controller.yaml, interrupt-controller.yaml, base.yaml]
 
 properties:
   reg:
@@ -32,4 +32,8 @@ properties:
 
 gpio-cells:
   - pin
+  - flags
+
+interrupt-cells:
+  - irq
   - flags

--- a/dts/bindings/test/vnd,gpio-intc-device.yaml
+++ b/dts/bindings/test/vnd,gpio-intc-device.yaml
@@ -1,0 +1,29 @@
+# Copyright (c) 2023 Bjarki Arge Andreasen
+# SPDX-License-Identifier: Apache-2.0
+
+description: Test GPIO with INTC node
+
+compatible: "vnd,gpio-intc-device"
+
+include:
+  - gpio-controller.yaml
+  - interrupt-controller.yaml
+  - base.yaml
+
+properties:
+  reg:
+    required: true
+
+  "#gpio-cells":
+    const: 2
+
+  "#interrupt-cells":
+    const: 2
+
+gpio-cells:
+  - pin
+  - flags
+
+interrupt-cells:
+  - pin
+  - flags

--- a/dts/bindings/test/vnd,interrupt-holder-extended.yaml
+++ b/dts/bindings/test/vnd,interrupt-holder-extended.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2023 Bjarki Arge Andreasen
+# SPDX-License-Identifier: Apache-2.0
+
+description: Test Interrupt Controller with extended interrupts
+
+compatible: "vnd,interrupt-holder-extended"
+
+include: [base.yaml]
+
+properties:
+  interrupts-extended:
+    required: true
+
+  interrupt-names:
+    required: true

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -2400,6 +2400,140 @@
 #define DT_IRQ(node_id, cell) DT_IRQ_BY_IDX(node_id, 0, cell)
 
 /**
+ * @brief Get an interrupt specifier's interrupt controller by index
+ *
+ * @code{.dts}
+ *     gpio0: gpio0 {
+ *             interrupt-controller;
+ *             #interrupt-cells = <2>;
+ *     };
+ *
+ *     foo: foo {
+ *             interrupt-parent = <&gpio0>;
+ *             interrupts = <1 1>, <2 2>;
+ *     };
+ *
+ *     bar: bar {
+ *             interrupts-extended = <&gpio0 3 3>, <&pic0 4>;
+ *     };
+ *
+ *     pic0: pic0 {
+ *             interrupt-controller;
+ *             #interrupt-cells = <1>;
+ *
+ *             qux: qux {
+ *                     interrupts = <5>, <6>;
+ *                     interrupt-names = "int1", "int2";
+ *             };
+ *     };
+ * @endcode
+ *
+ * Example usage:
+ *
+ *     DT_IRQ_INTC_BY_IDX(DT_NODELABEL(foo), 0) // &gpio0
+ *     DT_IRQ_INTC_BY_IDX(DT_NODELABEL(foo), 1) // &gpio0
+ *     DT_IRQ_INTC_BY_IDX(DT_NODELABEL(bar), 0) // &gpio0
+ *     DT_IRQ_INTC_BY_IDX(DT_NODELABEL(bar), 1) // &pic0
+ *     DT_IRQ_INTC_BY_IDX(DT_NODELABEL(qux), 0) // &pic0
+ *     DT_IRQ_INTC_BY_IDX(DT_NODELABEL(qux), 1) // &pic0
+ *
+ * @param node_id node identifier
+ * @param idx interrupt specifier's index
+ * @return node_id of interrupt specifier's interrupt controller
+ */
+#define DT_IRQ_INTC_BY_IDX(node_id, idx) \
+	DT_CAT4(node_id, _IRQ_IDX_, idx, _CONTROLLER)
+
+/**
+ * @brief Get an interrupt specifier's interrupt controller by name
+ *
+ * @code{.dts}
+ *     gpio0: gpio0 {
+ *             interrupt-controller;
+ *             #interrupt-cells = <2>;
+ *     };
+ *
+ *     foo: foo {
+ *             interrupt-parent = <&gpio0>;
+ *             interrupts = <1 1>, <2 2>;
+ *             interrupt-names = "int1", "int2";
+ *     };
+ *
+ *     bar: bar {
+ *             interrupts-extended = <&gpio0 3 3>, <&pic0 4>;
+ *             interrupt-names = "int1", "int2";
+ *     };
+ *
+ *     pic0: pic0 {
+ *             interrupt-controller;
+ *             #interrupt-cells = <1>;
+ *
+ *             qux: qux {
+ *                     interrupts = <5>, <6>;
+ *                     interrupt-names = "int1", "int2";
+ *             };
+ *     };
+ * @endcode
+ *
+ * Example usage:
+ *
+ *     DT_IRQ_INTC_BY_NAME(DT_NODELABEL(foo), int1) // &gpio0
+ *     DT_IRQ_INTC_BY_NAME(DT_NODELABEL(foo), int2) // &gpio0
+ *     DT_IRQ_INTC_BY_NAME(DT_NODELABEL(bar), int1) // &gpio0
+ *     DT_IRQ_INTC_BY_NAME(DT_NODELABEL(bar), int2) // &pic0
+ *     DT_IRQ_INTC_BY_NAME(DT_NODELABEL(qux), int1) // &pic0
+ *     DT_IRQ_INTC_BY_NAME(DT_NODELABEL(qux), int2) // &pic0
+ *
+ * @param node_id node identifier
+ * @param name interrupt specifier's name
+ * @return node_id of interrupt specifier's interrupt controller
+ */
+#define DT_IRQ_INTC_BY_NAME(node_id, name) \
+	DT_CAT4(node_id, _IRQ_NAME_, name, _CONTROLLER)
+
+/**
+ * @brief Get an interrupt specifier's interrupt controller
+ * @note Equivalent to DT_IRQ_INTC_BY_IDX(node_id, 0)
+ *
+ * @code{.dts}
+ *     gpio0: gpio0 {
+ *             interrupt-controller;
+ *             #interrupt-cells = <2>;
+ *     };
+ *
+ *     foo: foo {
+ *             interrupt-parent = <&gpio0>;
+ *             interrupts = <1 1>;
+ *     };
+ *
+ *     bar: bar {
+ *             interrupts-extended = <&gpio0 3 3>;
+ *     };
+ *
+ *     pic0: pic0 {
+ *             interrupt-controller;
+ *             #interrupt-cells = <1>;
+ *
+ *             qux: qux {
+ *                     interrupts = <5>;
+ *             };
+ *     };
+ * @endcode
+ *
+ * Example usage:
+ *
+ *     DT_IRQ_INTC(DT_NODELABEL(foo)) // &gpio0
+ *     DT_IRQ_INTC(DT_NODELABEL(bar)) // &gpio0
+ *     DT_IRQ_INTC(DT_NODELABEL(qux)) // &pic0
+ *
+ * @param node_id node identifier
+ * @return node_id of interrupt specifier's interrupt controller
+ * @see DT_IRQ_INTC_BY_IDX()
+ */
+#define DT_IRQ_INTC(node_id) \
+	DT_IRQ_INTC_BY_IDX(node_id, 0)
+
+/**
  * @cond INTERNAL_HIDDEN
  */
 
@@ -3844,6 +3978,34 @@
  */
 #define DT_INST_IRQ_BY_IDX(inst, idx, cell) \
 	DT_IRQ_BY_IDX(DT_DRV_INST(inst), idx, cell)
+
+/**
+ * @brief Get a `DT_DRV_COMPAT` interrupt specifier's interrupt controller by index
+ * @param inst instance number
+ * @param idx interrupt specifier's index
+ * @return node_id of interrupt specifier's interrupt controller
+ */
+#define DT_INST_IRQ_INTC_BY_IDX(inst, idx) \
+	DT_IRQ_INTC_BY_IDX(DT_DRV_INST(inst), idx)
+
+/**
+ * @brief Get a `DT_DRV_COMPAT` interrupt specifier's interrupt controller by name
+ * @param inst instance number
+ * @param name interrupt specifier's name
+ * @return node_id of interrupt specifier's interrupt controller
+ */
+#define DT_INST_IRQ_INTC_BY_NAME(inst, name) \
+	DT_IRQ_INTC_BY_NAME(DT_DRV_INST(inst), name)
+
+/**
+ * @brief Get a `DT_DRV_COMPAT` interrupt specifier's interrupt controller
+ * @note Equivalent to DT_INST_IRQ_INTC_BY_IDX(node_id, 0)
+ * @param inst instance number
+ * @return node_id of interrupt specifier's interrupt controller
+ * @see DT_INST_IRQ_INTC_BY_IDX()
+ */
+#define DT_INST_IRQ_INTC(inst) \
+	DT_INST_IRQ_INTC_BY_IDX(inst, 0)
 
 /**
  * @brief Get a `DT_DRV_COMPAT` interrupt specifier value by name

--- a/include/zephyr/drivers/gpio/gpio_irq.h
+++ b/include/zephyr/drivers/gpio/gpio_irq.h
@@ -1,0 +1,325 @@
+/*
+ * Copyright (c) 2023 Bjarki Arge Andreasen
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_GPIO_GPIO_IRQ_H_
+#define ZEPHYR_INCLUDE_DRIVERS_GPIO_GPIO_IRQ_H_
+
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/dt-bindings/interrupt-controller/irq.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief GPIO IRQ utilities
+ * @defgroup gpio_irq GPIO IRQ
+ * @ingroup gpio_interface
+ * @{
+ */
+
+/** @cond INTERNAL_HIDDEN */
+
+/**
+ * @brief Get GPIO interrupt controller device by idx
+ * @note Validates interrupt controller is also a GPIO controller
+ */
+#define GPIO_IRQ_DT_INTC_BY_IDX(node_id, idx)					\
+	IF_ENABLED(								\
+		DT_NODE_HAS_PROP(						\
+			DT_IRQ_INTC_BY_IDX(node_id, idx),			\
+			gpio_controller						\
+		),								\
+		(DEVICE_DT_GET(DT_IRQ_INTC_BY_IDX(node_id, idx)))		\
+	)
+
+/**
+ * @brief Get GPIO interrupt controller device by name
+ * @note Validates interrupt controller is also a GPIO controller
+ */
+#define GPIO_IRQ_DT_INTC_BY_NAME(node_id, name)					\
+	IF_ENABLED(								\
+		DT_NODE_HAS_PROP(						\
+			DT_IRQ_INTC_BY_NAME(node_id, name),			\
+			gpio_controller						\
+		),								\
+		(DEVICE_DT_GET(DT_IRQ_INTC_BY_NAME(node_id, name)))		\
+	)
+
+/** @endcond */
+
+/**
+ * @brief Get IRQ devicetree specifier by node identifier and idx
+ *
+ * @code{.dts}
+ *     #include <zephyr/dt-bindings/interrupt-controller/irq.h>
+ *
+ *     foo: foo {
+ *             interrupts-extended =
+ *                     <&gpio0 0 IRQ_TYPE_EDGE_BOTH>,
+ *                     <&gpio1 1 (IRQ_TYPE_LEVEL_HIGH | GPIO_PULL_DOWN)>;
+ *     };
+ * @endcode
+ *
+ * Example usage:
+ *
+ *     const struct gpio_irq_dt_spec spec0 =
+ *             GPIO_IRQ_DT_SPEC_GET_BY_IDX(DT_NODELABEL(foo), 0);
+ *
+ *     const struct gpio_irq_dt_spec spec1 =
+ *             GPIO_IRQ_DT_SPEC_GET_BY_IDX(DT_NODELABEL(foo), 1);
+ *
+ * Becomes:
+ *
+ *     const struct gpio_irq_dt_spec spec0 = {
+ *             .controller = DEVICE_DT_GET(DT_NODELABEL(gpio0)),
+ *             .irq_pin = 0,
+ *             .irq_flags = IRQ_TYPE_EDGE_BOTH,
+ *     };
+ *
+ *     const struct gpio_irq_dt_spec spec1 = {
+ *             .controller = DEVICE_DT_GET(DT_NODELABEL(gpio1)),
+ *             .irq_pin = 1,
+ *             .irq_flags = (IRQ_TYPE_LEVEL_HIGH | GPIO_PULL_DOWN),
+ *     };
+ */
+#define GPIO_IRQ_DT_SPEC_GET_BY_IDX(node_id, idx)				\
+	{									\
+		.controller = GPIO_IRQ_DT_INTC_BY_IDX(node_id, idx),		\
+		.irq_pin = DT_IRQ_BY_IDX(node_id, idx, irq),			\
+		.irq_flags = DT_IRQ_BY_IDX(node_id, idx, flags),		\
+	}
+
+/**
+ * @brief Get IRQ devicetree specifier by node identifier and idx if IRQ exists
+ * @note Identical to GPIO_IRQ_DT_SPEC_GET_BY_IDX(node_id, 0) if IRQ exists
+ * @see GPIO_IRQ_DT_SPEC_GET_BY_IDX()
+ */
+#define GPIO_IRQ_DT_SPEC_GET_OPT_BY_IDX(node_id, idx)			\
+	COND_CODE_1(								\
+		DT_IRQ_HAS_IDX(node_id, idx),					\
+		(GPIO_IRQ_DT_SPEC_GET_BY_IDX(node_id, idx)),			\
+		({})								\
+	)
+
+/**
+ * @brief Get IRQ devicetree specifier by node identifier and name
+ *
+ * @code{.dts}
+ *     foo: foo {
+ *             interrupt-parent = <&gpio0>
+ *             interrupts = <0 IRQ_TYPE_EDGE_BOTH>,
+ *                          <1 (IRQ_TYPE_LEVEL_HIGH | GPIO_PULL_DOWN)>;
+ *             interrupt-names = "bar", "baz";
+ *     };
+ * @endcode
+ *
+ * Example usage:
+ *
+ *     const struct gpio_irq_dt_spec spec0 =
+ *             GPIO_IRQ_DT_SPEC_GET_BY_NAME(DT_NODELABEL(foo), bar);
+ *
+ *     const struct gpio_irq_dt_spec spec1 =
+ *             GPIO_IRQ_DT_SPEC_GET_BY_NAME(DT_NODELABEL(foo), baz);
+ *
+ * Becomes:
+ *
+ *     const struct gpio_irq_dt_spec spec0 = {
+ *             .controller = DEVICE_DT_GET(DT_NODELABEL(gpio0)),
+ *             .irq_pin = 0,
+ *             .irq_flags = IRQ_TYPE_EDGE_BOTH,
+ *     };
+ *
+ *     const struct gpio_irq_dt_spec spec1 = {
+ *             .controller = DEVICE_DT_GET(DT_NODELABEL(gpio0)),
+ *             .irq_pin = 1,
+ *             .irq_flags = (IRQ_TYPE_LEVEL_HIGH | GPIO_PULL_DOWN),
+ *     };
+ */
+#define GPIO_IRQ_DT_SPEC_GET_BY_NAME(node_id, name)				\
+	{									\
+		.controller = GPIO_IRQ_DT_INTC_BY_NAME(node_id, name),		\
+		.irq_pin = DT_IRQ_BY_NAME(node_id, name, irq),			\
+		.irq_flags = DT_IRQ_BY_NAME(node_id, name, flags),		\
+	}
+
+/**
+ * @brief Get IRQ devicetree specifier by node identifier and name if IRQ exists
+ * @note Identical to GPIO_IRQ_DT_SPEC_GET_BY_NAME(node_id, 0) if IRQ exists
+ * @see GPIO_IRQ_DT_SPEC_GET_BY_NAME()
+ */
+#define GPIO_IRQ_DT_SPEC_GET_OPT_BY_NAME(node_id, name)			\
+	COND_CODE_1(								\
+		DT_IRQ_HAS_NAME(node_id, name),					\
+		(GPIO_IRQ_DT_SPEC_GET_BY_NAME(node_id, name)),			\
+		({})								\
+	)
+
+/**
+ * @brief Get the first IRQ devicetree specifier by node identifier
+ * @note Identical to GPIO_IRQ_DT_SPEC_GET_BY_IDX(node_id, 0)
+ * @see GPIO_IRQ_DT_SPEC_GET_BY_IDX()
+ */
+#define GPIO_IRQ_DT_SPEC_GET(node_id) \
+	GPIO_IRQ_DT_SPEC_GET_BY_IDX(node_id, 0)
+
+/**
+ * @brief Get first IRQ devicetree specifier by node identifier if IRQ exists
+ * @note Identical to GPIO_IRQ_DT_SPEC_GET_OPT_BY_IDX(node_id, 0)
+ * @see GPIO_IRQ_DT_SPEC_GET_OPT_BY_IDX()
+ */
+#define GPIO_IRQ_DT_SPEC_GET_OPT(node_id) \
+	GPIO_IRQ_DT_SPEC_GET_OPT_BY_IDX(node_id, 0)
+
+/**
+ * @brief Get IRQ devicetree specifier by DT_DRV_COMPAT instance and idx
+ * @see GPIO_IRQ_DT_SPEC_GET_BY_IDX()
+ */
+#define GPIO_IRQ_DT_INST_SPEC_GET_BY_IDX(inst, idx) \
+	GPIO_IRQ_DT_SPEC_GET_BY_IDX(DT_DRV_INST(inst), idx)
+
+/**
+ * @brief Get IRQ devicetree specifier by DT_DRV_COMPAT instance and idx if IRQ exists
+ * @see GPIO_IRQ_DT_SPEC_GET_OPT_BY_IDX()
+ */
+#define GPIO_IRQ_DT_INST_SPEC_GET_OPT_BY_IDX(inst, idx) \
+	GPIO_IRQ_DT_SPEC_GET_OPT_BY_IDX(DT_DRV_INST(inst), idx)
+
+/**
+ * @brief Get IRQ devicetree specifier by DT_DRV_COMPAT instance and name
+ * @see GPIO_IRQ_DT_SPEC_GET_BY_NAME()
+ */
+#define GPIO_IRQ_DT_INST_SPEC_GET_BY_NAME(inst, name) \
+	GPIO_IRQ_DT_SPEC_GET_BY_NAME(DT_DRV_INST(inst), name)
+
+/**
+ * @brief Get IRQ devicetree specifier by DT_DRV_COMPAT instance and name if IRQ exists
+ * @see GPIO_IRQ_DT_SPEC_GET_OPT_BY_NAME()
+ */
+#define GPIO_IRQ_DT_INST_SPEC_GET_OPT_BY_NAME(inst, name) \
+	GPIO_IRQ_DT_SPEC_GET_OPT_BY_NAME(DT_DRV_INST(inst), name)
+
+/**
+ * @brief Get the first IRQ devicetree specifier by DT_DRV_COMPAT instance
+ * @see GPIO_IRQ_DT_SPEC_GET()
+ */
+#define GPIO_IRQ_DT_INST_SPEC_GET(inst) \
+	GPIO_IRQ_DT_SPEC_GET(DT_DRV_INST(inst))
+
+/**
+ * @brief Get first IRQ devicetree specifier by DT_DRV_COMPAT instance if IRQ exists
+ * @see GPIO_IRQ_DT_SPEC_GET_OPT()
+ */
+#define GPIO_IRQ_DT_INST_SPEC_GET_OPT(inst) \
+	GPIO_IRQ_DT_SPEC_GET_OPT(DT_DRV_INST(inst))
+
+/** @cond INTERNAL_HIDDEN */
+
+/** GPIO IRQ devicetree specifier */
+struct gpio_irq_dt_spec {
+	/** GPIO port which acts as interrupt controller */
+	const struct device *controller;
+	/** GPIO pin which will trigger interrupt request */
+	uint16_t irq_pin;
+	/**
+	 * IRQ and GPIO flags. The lowest 4 bits are the IRQ_TYPE_ trigger
+	 * flags, the remaining 12 bits are GPIO flags.
+	 */
+	uint16_t irq_flags;
+};
+
+struct gpio_irq;
+
+/** IRQ callback handler */
+typedef void (*gpio_irq_callback_handler_t)(struct gpio_irq *irq);
+
+/** GPIO IRQ structure */
+struct gpio_irq {
+	/** GPIO port which acts as interrupt controller */
+	const struct device *controller;
+	/** The nested callback structure used by the GPIO controller */
+	struct gpio_callback nested_callback;
+	/** The IRQ callback handler */
+	gpio_irq_callback_handler_t handler;
+	/** GPIO pin which will trigger IRQ */
+	gpio_pin_t irq_pin;
+	/** IRQ and GPIO flags */
+	gpio_dt_flags_t irq_flags;
+};
+
+/** @endcond */
+
+/**
+ * @brief Request and enable GPIO IRQ
+ * @param controller GPIO port which the GPIO pin belongs to
+ * @param irq_pin GPIO pin which will trigger interrupt request
+ * @param irq_flags IRQ_TYPE_* and GPIO_* configuration flags
+ * @param irq Destination for GPIO IRQ data
+ * @param handler handler which is called on interrupt request
+ * @retval 0 if successful
+ * @retval -errno code if failure
+ * @note The irq data structure must be valid until released
+ */
+int gpio_irq_request(const struct device *controller,
+		     gpio_pin_t irq_pin,
+		     gpio_dt_flags_t irq_flags,
+		     struct gpio_irq *irq,
+		     gpio_irq_callback_handler_t handler);
+
+/**
+ * @brief Test if a GPIO IRQ DT spec exists
+ * @param spec GPIO IRQ devicetree specifier
+ * @retval true if set
+ */
+bool gpio_irq_dt_spec_exists(const struct gpio_irq_dt_spec *spec);
+
+/**
+ * @brief Request and enable GPIO IRQ from DT GPIO IRQ specifier
+ * @param spec GPIO IRQ devicetree specifier
+ * @param irq Destination for GPIO IRQ data
+ * @param handler handler which is called on interrupt request
+ * @retval 0 if successful
+ * @retval -errno code if failure
+ * @note The irq data structure must be valid until released
+ */
+int gpio_irq_request_dt(const struct gpio_irq_dt_spec *spec,
+			struct gpio_irq *irq,
+			gpio_irq_callback_handler_t handler);
+
+/**
+ * @brief Disable and release GPIO IRQ
+ * @param irq GPIO IRQ to release
+ * @retval 0 if successful
+ * @retval -errno code if failure
+ * @note The irq must have been previously requested
+ * @see gpio_irq_request()
+ */
+int gpio_irq_release(struct gpio_irq *irq);
+
+/**
+ * @brief Enable GPIO IRQ
+ * @param irq GPIO IRQ to enable
+ * @retval 0 if successful
+ * @retval -errno code if failure
+ */
+int gpio_irq_enable(struct gpio_irq *irq);
+
+/**
+ * @brief Disable GPIO IRQ
+ * @param irq GPIO IRQ to disable
+ * @retval 0 if successful
+ * @retval -errno code if failure
+ */
+int gpio_irq_disable(struct gpio_irq *irq);
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_GPIO_GPIO_IRQ_H_ */

--- a/include/zephyr/dt-bindings/interrupt-controller/irq.h
+++ b/include/zephyr/dt-bindings/interrupt-controller/irq.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023 Bjarki Arge Andreasen
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_INTERRUPT_CONTROLLER_IRQ_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_INTERRUPT_CONTROLLER_IRQ_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* IRQ_TYPE flags */
+#define IRQ_TYPE_EDGE_RISING  (1U << 0)
+#define IRQ_TYPE_EDGE_FALLING (1U << 1)
+#define IRQ_TYPE_EDGE_BOTH    (IRQ_TYPE_EDGE_FALLING | IRQ_TYPE_EDGE_RISING)
+#define IRQ_TYPE_LEVEL_HIGH   (1U << 2)
+#define IRQ_TYPE_LEVEL_LOW    (1U << 3)
+#define IRQ_TYPE_MASK         (IRQ_TYPE_EDGE_BOTH | IRQ_TYPE_LEVEL_HIGH | IRQ_TYPE_LEVEL_LOW)
+
+/* Test if IRQ_TYPE flags are valid */
+#define IRQ_TYPE_IS_VALID(flags)                               \
+	(((flags & IRQ_TYPE_MASK) == IRQ_TYPE_EDGE_RISING)  || \
+	 ((flags & IRQ_TYPE_MASK) == IRQ_TYPE_EDGE_FALLING) || \
+	 ((flags & IRQ_TYPE_MASK) == IRQ_TYPE_EDGE_BOTH)    || \
+	 ((flags & IRQ_TYPE_MASK) == IRQ_TYPE_LEVEL_HIGH)   || \
+	 ((flags & IRQ_TYPE_MASK) == IRQ_TYPE_LEVEL_LOW))
+
+/* Test if IRQ_TYPE flags dictate edge triggered IRQ */
+#define IRQ_TYPE_IS_EDGE_TRIGGERED(flags) \
+	(flags & IRQ_TYPE_EDGE_BOTH)
+
+/* Test if IRQ_TYPE flags dictate level triggered IRQ */
+#define IRQ_TYPE_IS_LEVEL_TRIGGERED(flags) \
+	(flags & (IRQ_TYPE_LEVEL_HIGH | IRQ_TYPE_LEVEL_LOW))
+
+/* Test if IRQ_TYPE flags dictate active high IRQ polarity */
+#define IRQ_TYPE_IS_ACTIVE_HIGH(flags) \
+	(flags & (IRQ_TYPE_EDGE_RISING | IRQ_TYPE_LEVEL_HIGH))
+
+/* Test if IRQ_TYPE flags dictate active low IRQ polarity */
+#define IRQ_TYPE_IS_ACTIVE_LOW(flags) \
+	(flags & (IRQ_TYPE_EDGE_FALLING | IRQ_TYPE_LEVEL_LOW))
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_INTERRUPT_CONTROLLER_IRQ_H_ */

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -477,6 +477,13 @@ def write_interrupts(node):
                 name_vals.append((name_macro, f"DT_{idx_macro}"))
                 name_vals.append((name_macro + "_EXISTS", 1))
 
+        idx_controller_macro = f"{path_id}_IRQ_IDX_{i}_CONTROLLER"
+        idx_controller_path = f"DT_{irq.controller.z_path_id}"
+        idx_vals.append((idx_controller_macro, idx_controller_path))
+        if irq.name:
+            name_controller_macro = f"{path_id}_IRQ_NAME_{str2ident(irq.name)}_CONTROLLER"
+            name_vals.append((name_controller_macro, f"DT_{idx_controller_macro}"))
+
     for macro, val in idx_vals:
         out_dt_define(macro, val)
     for macro, val in name_vals:

--- a/tests/drivers/gpio/gpio_irq/CMakeLists.txt
+++ b/tests/drivers/gpio/gpio_irq/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright (c) 2023 Bjarki Arge Andreasen
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(gpio_irq)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/drivers/gpio/gpio_irq/boards/native_sim.overlay
+++ b/tests/drivers/gpio/gpio_irq/boards/native_sim.overlay
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023 Bjarki Arge Andreasen
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/interrupt-controller/irq.h>
+
+/ {
+	/* Additional interrupt controller */
+	gpio1: gpio@900 {
+		status = "okay";
+		compatible = "zephyr,gpio-emul";
+		reg = <0x900 0x4>;
+		rising-edge;
+		falling-edge;
+		high-level;
+		low-level;
+		gpio-controller;
+		#gpio-cells = <2>;
+		interrupt-controller;
+		#interrupt-cells = <2>;
+	};
+
+	dut0: dut0 {
+		compatible = "vnd,interrupt-holder";
+		interrupt-parent = <&gpio0>;
+		interrupts = <4 (IRQ_TYPE_EDGE_BOTH)>,
+			     <5 (GPIO_PULL_UP | IRQ_TYPE_EDGE_FALLING)>;
+		interrupt-names = "err", "stat";
+	};
+
+	dut1: dut1 {
+		compatible = "vnd,interrupt-holder-extended";
+		interrupts-extended = <&gpio0 3 IRQ_TYPE_EDGE_RISING>,
+				      <&gpio1 6 (GPIO_PULL_DOWN | IRQ_TYPE_LEVEL_HIGH)>;
+		interrupt-names = "drdy", "int1";
+	};
+};

--- a/tests/drivers/gpio/gpio_irq/boards/native_sim_64.overlay
+++ b/tests/drivers/gpio/gpio_irq/boards/native_sim_64.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2023 Bjarki Arge Andreasen
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "native_sim.overlay"

--- a/tests/drivers/gpio/gpio_irq/prj.conf
+++ b/tests/drivers/gpio/gpio_irq/prj.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2023 Bjarki Arge Andreasen
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ZTEST=y
+CONFIG_GPIO=y
+CONFIG_GPIO_IRQ=y

--- a/tests/drivers/gpio/gpio_irq/src/main.c
+++ b/tests/drivers/gpio/gpio_irq/src/main.c
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) 2023 Bjarki Arge Andreasen
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/gpio/gpio_irq.h>
+#include <zephyr/drivers/gpio/gpio_emul.h>
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+
+#define TEST_DUT0_IRQ0_INTC  (DEVICE_DT_GET(DT_NODELABEL(gpio0)))
+#define TEST_DUT0_IRQ0_PIN   (4)
+#define TEST_DUT0_IRQ0_FLAGS (IRQ_TYPE_EDGE_BOTH)
+
+#define TEST_DUT0_IRQ1_INTC  (DEVICE_DT_GET(DT_NODELABEL(gpio0)))
+#define TEST_DUT0_IRQ1_PIN   (5)
+#define TEST_DUT0_IRQ1_FLAGS (GPIO_PULL_UP | IRQ_TYPE_EDGE_FALLING)
+
+#define TEST_DUT1_IRQ_DRDY_INTC  (DEVICE_DT_GET(DT_NODELABEL(gpio0)))
+#define TEST_DUT1_IRQ_DRDY_PIN   (3)
+#define TEST_DUT1_IRQ_DRDY_FLAGS (IRQ_TYPE_EDGE_RISING)
+
+#define TEST_DUT1_IRQ_INT1_INTC  (DEVICE_DT_GET(DT_NODELABEL(gpio1)))
+#define TEST_DUT1_IRQ_INT1_PIN   (6)
+#define TEST_DUT1_IRQ_INT1_FLAGS (GPIO_PULL_DOWN | IRQ_TYPE_LEVEL_HIGH)
+
+const struct gpio_irq_dt_spec dut0_irq0 =
+	GPIO_IRQ_DT_SPEC_GET(DT_NODELABEL(dut0));
+
+const struct gpio_irq_dt_spec dut0_irq0_opt =
+	GPIO_IRQ_DT_SPEC_GET_OPT(DT_NODELABEL(dut0));
+
+const struct gpio_irq_dt_spec dut0_irq1 =
+	GPIO_IRQ_DT_SPEC_GET_BY_IDX(DT_NODELABEL(dut0), 1);
+
+const struct gpio_irq_dt_spec dut0_irq1_opt =
+	GPIO_IRQ_DT_SPEC_GET_OPT_BY_IDX(DT_NODELABEL(dut0), 1);
+
+const struct gpio_irq_dt_spec dut0_irq2_opt =
+	GPIO_IRQ_DT_SPEC_GET_OPT_BY_IDX(DT_NODELABEL(dut0), 2);
+
+const struct gpio_irq_dt_spec dut1_irq_drdy =
+	GPIO_IRQ_DT_SPEC_GET_BY_NAME(DT_NODELABEL(dut1), drdy);
+
+const struct gpio_irq_dt_spec dut1_irq_int1 =
+	GPIO_IRQ_DT_SPEC_GET_BY_NAME(DT_NODELABEL(dut1), int1);
+
+const struct gpio_irq_dt_spec dut1_irq_int1_opt =
+	GPIO_IRQ_DT_SPEC_GET_OPT_BY_NAME(DT_NODELABEL(dut1), int1);
+
+const struct gpio_irq_dt_spec dut1_irq_int2_opt =
+	GPIO_IRQ_DT_SPEC_GET_OPT_BY_NAME(DT_NODELABEL(dut1), int2);
+
+#define DT_DRV_COMPAT vnd_interrupt_holder
+const struct gpio_irq_dt_spec dut0_inst0_irq0 =
+	GPIO_IRQ_DT_INST_SPEC_GET(0);
+
+const struct gpio_irq_dt_spec dut0_inst0_irq0_opt =
+	GPIO_IRQ_DT_INST_SPEC_GET_OPT(0);
+
+const struct gpio_irq_dt_spec dut0_inst0_irq1 =
+	GPIO_IRQ_DT_INST_SPEC_GET_BY_IDX(0, 1);
+
+const struct gpio_irq_dt_spec dut0_inst0_irq1_opt =
+	GPIO_IRQ_DT_INST_SPEC_GET_OPT_BY_IDX(0, 1);
+
+const struct gpio_irq_dt_spec dut0_inst0_irq2_opt =
+	GPIO_IRQ_DT_INST_SPEC_GET_OPT_BY_IDX(0, 2);
+#undef DT_DRV_COMPAT
+
+#define DT_DRV_COMPAT vnd_interrupt_holder_extended
+const struct gpio_irq_dt_spec dut1_inst0_irq_drdy =
+	GPIO_IRQ_DT_INST_SPEC_GET_BY_NAME(0, drdy);
+
+const struct gpio_irq_dt_spec dut1_inst0_irq_int1 =
+	GPIO_IRQ_DT_INST_SPEC_GET_BY_NAME(0, int1);
+
+const struct gpio_irq_dt_spec dut1_inst0_irq_int1_opt =
+	GPIO_IRQ_DT_INST_SPEC_GET_OPT_BY_NAME(0, int1);
+
+const struct gpio_irq_dt_spec dut1_inst0_irq_int2_opt =
+	GPIO_IRQ_DT_INST_SPEC_GET_OPT_BY_NAME(0, int2);
+#undef DT_DRV_COMPAT
+
+static struct gpio_irq test_irq;
+static K_SEM_DEFINE(test_irq_called, 1, 1);
+
+static void gpio_irq_callback_handler(struct gpio_irq *irq)
+{
+	__ASSERT(irq == &test_irq, "Incorrect irq passed to callback");
+	k_sem_give(&test_irq_called);
+}
+
+ZTEST(gpio_irq, test_validate_gpio_irq_dt_spec_get_macros)
+{
+	zassert_equal(dut0_irq0.controller, TEST_DUT0_IRQ0_INTC,
+		      "Incorrect interrupt controller");
+	zassert_equal(dut0_irq0.irq_pin, TEST_DUT0_IRQ0_PIN,
+		      "Incorrect pin");
+	zassert_equal(dut0_irq0.irq_flags, TEST_DUT0_IRQ0_FLAGS,
+		      "Incorrect flags");
+
+	zassert_equal(dut0_irq1.controller, TEST_DUT0_IRQ1_INTC,
+		      "Incorrect interrupt controller");
+	zassert_equal(dut0_irq1.irq_pin, TEST_DUT0_IRQ1_PIN,
+		      "Incorrect pin");
+	zassert_equal(dut0_irq1.irq_flags, TEST_DUT0_IRQ1_FLAGS,
+		      "Incorrect flags");
+
+	zassert_equal(dut1_irq_drdy.controller, TEST_DUT1_IRQ_DRDY_INTC,
+		      "Incorrect interrupt controller");
+	zassert_equal(dut1_irq_drdy.irq_pin, TEST_DUT1_IRQ_DRDY_PIN,
+		      "Incorrect pin");
+	zassert_equal(dut1_irq_drdy.irq_flags, TEST_DUT1_IRQ_DRDY_FLAGS,
+		      "Incorrect flags");
+
+	zassert_equal(dut1_irq_int1.controller, TEST_DUT1_IRQ_INT1_INTC,
+		      "Incorrect interrupt controller");
+	zassert_equal(dut1_irq_int1.irq_pin, TEST_DUT1_IRQ_INT1_PIN,
+		      "Incorrect pin");
+	zassert_equal(dut1_irq_int1.irq_flags, TEST_DUT1_IRQ_INT1_FLAGS,
+		      "Incorrect flags");
+}
+
+ZTEST(gpio_irq, test_request_irq)
+{
+	int ret;
+
+	ret = gpio_irq_request_dt(&dut0_irq0, &test_irq, gpio_irq_callback_handler);
+	zassert_ok(ret, "Failed to request GPIO, ret %i", ret);
+
+	k_sem_reset(&test_irq_called);
+	gpio_emul_input_set(TEST_DUT0_IRQ0_INTC, TEST_DUT0_IRQ0_PIN, 0);
+	gpio_emul_input_set(TEST_DUT0_IRQ0_INTC, TEST_DUT0_IRQ0_PIN, 1);
+	ret = k_sem_take(&test_irq_called, K_MSEC(100));
+	zassert_ok(ret, "IRQ calllback not called after request, ret %i", ret);
+
+	ret = gpio_irq_disable(&test_irq);
+	zassert_ok(ret, "Failed to disable IRQ, ret %i", ret);
+
+	k_sem_reset(&test_irq_called);
+	gpio_emul_input_set(TEST_DUT0_IRQ0_INTC, TEST_DUT0_IRQ0_PIN, 0);
+	ret = k_sem_take(&test_irq_called, K_MSEC(100));
+	zassert_equal(ret, -EAGAIN, "IRQ calllback called after disabled, ret %i", ret);
+
+	ret = gpio_irq_enable(&test_irq);
+	zassert_ok(ret, "Failed to enable IRQ, %i", ret);
+
+	k_sem_reset(&test_irq_called);
+	gpio_emul_input_set(TEST_DUT0_IRQ0_INTC, TEST_DUT0_IRQ0_PIN, 1);
+	ret = k_sem_take(&test_irq_called, K_MSEC(100));
+	zassert_ok(ret, "IRQ calllback not called while IRQ enabled after enable, ret %i", ret);
+
+	ret = gpio_irq_release(&test_irq);
+	zassert_ok(ret, "Failed to release IRQ, ret %i", ret);
+
+	k_sem_reset(&test_irq_called);
+	gpio_emul_input_set(TEST_DUT0_IRQ0_INTC, TEST_DUT0_IRQ0_PIN, 1);
+	ret = k_sem_take(&test_irq_called, K_MSEC(100));
+	zassert_equal(ret, -EAGAIN, "IRQ calllback called after IRQ released, ret %i", ret);
+}
+
+static const struct gpio_irq_dt_spec zero_dt_spec;
+
+ZTEST(gpio_irq, test_validate_gpio_irq_dt_spec_get_OPT_macros)
+{
+	zassert_mem_equal(&dut0_irq0, &dut0_irq0_opt,
+			  sizeof(struct gpio_irq_dt_spec),
+			  "Optional GPIO IRQ DT spec not equal");
+
+	zassert_mem_equal(&dut0_irq1, &dut0_irq1_opt,
+			  sizeof(struct gpio_irq_dt_spec),
+			  "Optional GPIO IRQ DT spec not equal");
+
+	zassert_mem_equal(&dut0_irq2_opt, &zero_dt_spec,
+			  sizeof(struct gpio_irq_dt_spec),
+			  "Optional GPIO IRQ DT spec should be zero");
+
+	zassert_mem_equal(&dut1_irq_int1, &dut1_irq_int1_opt,
+			  sizeof(struct gpio_irq_dt_spec),
+			  "Optional GPIO IRQ DT spec not equal");
+
+	zassert_mem_equal(&dut1_irq_int2_opt, &zero_dt_spec,
+			  sizeof(struct gpio_irq_dt_spec),
+			  "Optional GPIO IRQ DT spec should be zero");
+}
+
+ZTEST(gpio_irq, test_validate_gpio_irq_dt_inst_spec_get_macros)
+{
+	zassert_mem_equal(&dut0_irq0, &dut0_inst0_irq0,
+			  sizeof(struct gpio_irq_dt_spec),
+			  "instance not equal to node");
+
+	zassert_mem_equal(&dut0_irq0_opt, &dut0_inst0_irq0_opt,
+			  sizeof(struct gpio_irq_dt_spec),
+			  "instance not equal to node");
+
+	zassert_mem_equal(&dut0_irq1, &dut0_inst0_irq1,
+			  sizeof(struct gpio_irq_dt_spec),
+			  "instance not equal to node");
+
+	zassert_mem_equal(&dut0_irq1_opt, &dut0_inst0_irq1_opt,
+			  sizeof(struct gpio_irq_dt_spec),
+			  "instance not equal to node");
+
+	zassert_mem_equal(&dut0_irq2_opt, &dut0_inst0_irq2_opt,
+			  sizeof(struct gpio_irq_dt_spec),
+			  "instance not equal to node");
+
+	zassert_mem_equal(&dut0_irq0, &dut0_inst0_irq0,
+			  sizeof(struct gpio_irq_dt_spec),
+			  "instance not equal to node");
+
+	zassert_mem_equal(&dut1_irq_drdy, &dut1_inst0_irq_drdy,
+			  sizeof(struct gpio_irq_dt_spec),
+			  "instance not equal to node");
+
+	zassert_mem_equal(&dut1_irq_int1, &dut1_inst0_irq_int1,
+			  sizeof(struct gpio_irq_dt_spec),
+			  "instance not equal to node");
+
+	zassert_mem_equal(&dut1_irq_int1_opt, &dut1_inst0_irq_int1_opt,
+			  sizeof(struct gpio_irq_dt_spec),
+			  "instance not equal to node");
+
+	zassert_mem_equal(&dut1_irq_int2_opt, &dut1_inst0_irq_int2_opt,
+			  sizeof(struct gpio_irq_dt_spec),
+			  "instance not equal to node");
+}
+
+ZTEST(gpio_irq, test_validate_gpio_irq_dt_spec_exists)
+{
+	zassert_true(gpio_irq_dt_spec_exists(&dut0_irq0), "");
+	zassert_true(gpio_irq_dt_spec_exists(&dut0_irq1), "");
+	zassert_false(gpio_irq_dt_spec_exists(&dut0_irq2_opt), "");
+	zassert_true(gpio_irq_dt_spec_exists(&dut1_irq_drdy), "");
+	zassert_true(gpio_irq_dt_spec_exists(&dut1_irq_int1), "");
+	zassert_false(gpio_irq_dt_spec_exists(&dut1_irq_int2_opt), "");
+}
+
+ZTEST(gpio_irq, test_fail_to_request_non_existent_irq)
+{
+	int ret;
+
+	ret = gpio_irq_request_dt(&dut0_irq2_opt, &test_irq,
+				  gpio_irq_callback_handler);
+	zassert_equal(ret, -ENODEV, "Should have failed to request IRQ");
+}
+
+ZTEST_SUITE(gpio_irq, NULL, NULL, NULL, NULL, NULL);

--- a/tests/drivers/gpio/gpio_irq/testcase.yaml
+++ b/tests/drivers/gpio/gpio_irq/testcase.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) 2023 Bjarki Arge Andreasen
+# SPDX-License-Identifier: Apache-2.0
+
+tests:
+  drivers.gpio.irq:
+    tags:
+      - drivers
+      - gpio
+      - irq
+    depends_on: gpio
+    platform_allow:
+      - native_sim
+      - native_sim_64
+    integration_platforms:
+      - native_sim
+      - native_sim_64

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -203,6 +203,16 @@
 			status = "okay";
 		};
 
+		test_gpio_4: gpio@1234abcd {
+			compatible = "vnd,gpio-intc-device";
+			reg = <0x1234abcd 0x500>;
+			gpio-controller;
+			#gpio-cells = <0x2>;
+			interrupt-controller;
+			#interrupt-cells = <0x2>;
+			status = "okay";
+		};
+
 		test_i2c: i2c@11112222 {
 			#address-cells = < 1 >;
 			#size-cells = < 0 >;
@@ -429,6 +439,15 @@
 			interrupts = <30 3 40 5 60 7>;
 			interrupt-parent = <&test_intc>;
 			interrupt-names = "err", "stat", "done";
+		};
+
+		/* there should only be one of these */
+		test_irq_extended: interrupt-holder-extended {
+			compatible = "vnd,interrupt-holder-extended";
+			status = "okay";
+			interrupts-extended = <&test_intc 70 7>,
+					      <&test_gpio_4 30 3>;
+			interrupt-names = "int1", "int2";
 		};
 
 		test_fixed_clk: test-fixed-clock {

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -21,12 +21,14 @@
 #define TEST_ARRAYS	DT_NODELABEL(test_arrays)
 #define TEST_PH	DT_NODELABEL(test_phandles)
 #define TEST_IRQ	DT_NODELABEL(test_irq)
+#define TEST_IRQ_EXT	DT_NODELABEL(test_irq_extended)
 #define TEST_TEMP	DT_NODELABEL(test_temp_sensor)
 #define TEST_REG	DT_NODELABEL(test_reg)
 #define TEST_VENDOR	DT_NODELABEL(test_vendor)
 #define TEST_MODEL	DT_NODELABEL(test_vendor)
 #define TEST_ENUM_0	DT_NODELABEL(test_enum_0)
 #define TEST_64BIT	DT_NODELABEL(test_reg_64)
+#define TEST_INTC	DT_NODELABEL(test_intc)
 
 #define TEST_I2C DT_NODELABEL(test_i2c)
 #define TEST_I2C_DEV DT_PATH(test, i2c_11112222, test_i2c_dev_10)
@@ -44,6 +46,7 @@
 
 #define TEST_GPIO_1 DT_NODELABEL(test_gpio_1)
 #define TEST_GPIO_2 DT_NODELABEL(test_gpio_2)
+#define TEST_GPIO_4 DT_NODELABEL(test_gpio_4)
 
 #define TEST_GPIO_HOG_1 DT_PATH(test, gpio_deadbeef, test_gpio_hog_1)
 #define TEST_GPIO_HOG_2 DT_PATH(test, gpio_deadbeef, test_gpio_hog_2)
@@ -3147,6 +3150,33 @@ ZTEST(devicetree_api, test_reset)
 
 	/* DT_INST_RESET_ID */
 	zassert_equal(DT_INST_RESET_ID(0), 10, "");
+}
+
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT vnd_interrupt_holder_extended
+ZTEST(devicetree_api, test_interrupt_controller)
+{
+	/* DT_IRQ_INTC_BY_IDX */
+	zassert_true(DT_SAME_NODE(DT_IRQ_INTC_BY_IDX(TEST_IRQ_EXT, 0), TEST_INTC), "");
+	zassert_true(DT_SAME_NODE(DT_IRQ_INTC_BY_IDX(TEST_IRQ_EXT, 1), TEST_GPIO_4), "");
+
+	/* DT_IRQ_INTC_BY_NAME */
+	zassert_true(DT_SAME_NODE(DT_IRQ_INTC_BY_NAME(TEST_IRQ_EXT, int1), TEST_INTC), "");
+	zassert_true(DT_SAME_NODE(DT_IRQ_INTC_BY_NAME(TEST_IRQ_EXT, int2), TEST_GPIO_4), "");
+
+	/* DT_IRQ_INTC */
+	zassert_true(DT_SAME_NODE(DT_IRQ_INTC(TEST_IRQ_EXT), TEST_INTC), "");
+
+	/* DT_INST_IRQ_INTC_BY_IDX */
+	zassert_true(DT_SAME_NODE(DT_INST_IRQ_INTC_BY_IDX(0, 0), TEST_INTC), "");
+	zassert_true(DT_SAME_NODE(DT_INST_IRQ_INTC_BY_IDX(0, 1), TEST_GPIO_4), "");
+
+	/* DT_INST_IRQ_INTC_BY_NAME */
+	zassert_true(DT_SAME_NODE(DT_INST_IRQ_INTC_BY_NAME(0, int1), TEST_INTC), "");
+	zassert_true(DT_SAME_NODE(DT_INST_IRQ_INTC_BY_NAME(0, int2), TEST_GPIO_4), "");
+
+	/* DT_INST_IRQ_INTC */
+	zassert_true(DT_SAME_NODE(DT_INST_IRQ_INTC(0), TEST_INTC), "");
 }
 
 ZTEST_SUITE(devicetree_api, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
### Introduction
Implement interrupt-controller related macros to get the handle to an interrupt specifier's interrupt controller as described in [Devicetree specification v0.4](https://github.com/devicetree-org/devicetree-specification/releases/tag/v0.4) section 2.4.1, and add the utilities and macros required to use the devicetree specification.

### What will it solve
The following example shows how we currently configure GPIO routed interrupts in-tree for the ST LIS2DH, which generates two pin routed interrupts:
```
#include <zephyr/dt-bindings/gpio/gpio.h>
#include <zephyr/dt-bindings/sensor/lis2dh.h>

&i2c0 {
	sensor: lis2dh {
		compatible = "st,lis2dh";
		irq-gpios = <&gpio0 1 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>,
		            <&gpio0 2 GPIO_ACTIVE_HIGH>;
		int1-gpio-config = LIS2DH_DT_GPIO_INT_EDGE_RISING;
		int2-gpio-config = LIS2DH_DT_GPIO_INT_EDGE_RISING;
	};
};
```
This solution is not optimal, as it is not generic, and does not follow the devicetree specification 2.4.1. This results in custom bindings required to configure the interrupt lines, and makes it near impossible to create subsystems and other utilities which interact with interrupt generating devices generically (like a wakeup source subsystem, or generic utilities for interacting with interrupt requests)

### What does the solution look like
Using the properties for interrupt generating devices defined in the devicetree specification, the same sensor will take one of the following forms:
```
#include <zephyr/dt-bindings/gpio/gpio.h>
#include <zephyr/dt-bindings/interrupt-controller/irq.h>

&i2c0 {
	sensor: lis2dh {
		compatible = "st,lis2dh";
		interrupt-parent = <&gpio0>,
		interrupts = <1 (IRQ_TYPE_EDGE_RISING | GPIO_PULL_UP)>,
		             <2 IRQ_TYPE_EDGE_RISING>;
	};
};
```
or
```
#include <zephyr/dt-bindings/gpio/gpio.h>
#include <zephyr/dt-bindings/interrupt-controller/irq.h>

&i2c0 {
	sensor: lis2dh {
		compatible = "st,lis2dh";
		interrupts-extended = <&gpio0 1 (IRQ_TYPE_EDGE_RISING | GPIO_PULL_UP)>,
		                      <&gpio0 2 IRQ_TYPE_EDGE_RISING>;
	};
};
```
This is compatible with the Linux binding for the same sensor [st-sensors.yaml](https://www.kernel.org/doc/Documentation/devicetree/bindings/iio/st%2Cst-sensors.yaml)

Note: this also allows us to exchange the GPIO controller for a programmable interrupt controller potentially in the future like:
```
	&i2c0 {
		sensor: lis2dh {
			compatible = "st,lis2dh";
			interrupt-parent = <&pic0>,
			interrupts = <1 (IRQ_TYPE_EDGE_RISING | GPIO_PULL_UP)>,
			             <2 IRQ_TYPE_EDGE_RISING>;
		};
	};
```

### How will drivers use the new macros
Drivers will get a GPIO IRQ specification from the devicetree using a variation of `GPIO_IRQ_DT_SPEC_GET()` which initializes a `struct gpio_irq_dt_spec`, similar to how `GPIO_DT_SPEC_GET()` works.

```
struct foo_config {
	struct gpio_irq_dt_spec irq_spec;
};

const struct foo_config##inst = {
	.irq_spec = GPIO_IRQ_DT_SPEC_GET(inst),
};
```

Drivers will then utilize the `gpio_irq` utilities to configure a GPIO PIN as an interrupt as described by the spec.
```
struct foo_data {
	struct gpio_irq irq;
};

void foo_irq_handler(struct gpio_irq *irq)
{
	struct foo_data *data = CONTAINER_OF(irq, struct foo_data, irq);
	...
}

void foo_init(const struct device *dev)
{
	const struct foo_config *config = dev->config;
	struct foo_data *data = dev->data;

	/* Configure interrupt generating device to follow irq spec from devicetree */
	if (config->irq_spec.flags & IRQ_TYPE_EDGE_RISING) {
		...
	} else if (config->irq_spec.flags & IRQ_TYPE_EDGE_FALLING)
		...
	}

	/* Set pin interrupt and enable it according to irq spec from devicetree */
	gpio_irq_request_dt(&config->irq_spec, &data->irq, foo_irq_handler);
}
```

The `struct gpio_irq` instance is used to further interact with the GPIO pin interrupt
```
int foo_resume(const struct device *dev)
{
	struct foo_data *data = dev->data;

	return gpio_irq_enable(&data->irq);
}

int foo_suspend(const struct device *dev)
{
	struct foo_data *data = dev->data;

	return gpio_irq_disable(&data->irq);
}
```

### Preemptive Q&A
#### What happens to `GPIO_ACTIVE_LOW` and `GPIO_INT_LEVELS_LOGICAL`
These flags are no longer useful as the `IRQ_TYPE_*` flags completely cover the information the GPIO flags where conveying. 
#### Can we still use generic and vendor specific `GPIO_*` flags like `GPIO_PULL_UP`?
Yes! except for the first 4 flags which configure GPIO output and logical states, which are now illegal, and are replaced by the 
new `IRQ_TYPE_*` flags.
#### Could we not just reuse `struct gpio_dt_spec`?
Technically yes, the layout of the structure is identical, but, this would be unsafe as it would indicate that the `struct gpio_irq_dt_spec` and `struct gpio_dt_spec` are interchangeable, which they are not. For `struct gpio_irq_dt_spec`, we enforce that the `controller`(`port`) is in fact also an interrupt controller, and we enforce that the `irq`(`pin`) is in fact from an interrupts property.
