### PR TITLE
Setup USB clock and pinctrl for SAML21-derrived boards

### DIFF
--- a/boards/arm/atsaml21_xpro/atsaml21_xpro-pinctrl.dtsi
+++ b/boards/arm/atsaml21_xpro/atsaml21_xpro-pinctrl.dtsi
@@ -56,4 +56,11 @@
 				 <PB23D_SERCOM5_PAD3>;
 		};
 	};
+
+	usb0_default: usb0_default {
+		group1 {
+			pinmux = <PA24G_USB_DM>,
+				 <PA25G_USB_DP>;
+		};
+	};
 };

--- a/boards/arm/atsaml21_xpro/atsaml21_xpro.dts
+++ b/boards/arm/atsaml21_xpro/atsaml21_xpro.dts
@@ -141,4 +141,7 @@
 
 zephyr_udc0: &usb0 {
 	status = "okay";
+
+	pinctrl-0 = <&usb0_default>;
+	pinctrl-names = "default";
 };

--- a/boards/arm/atsamr34_xpro/atsamr34_xpro-pinctrl.dtsi
+++ b/boards/arm/atsamr34_xpro/atsamr34_xpro-pinctrl.dtsi
@@ -34,4 +34,11 @@
 				 <PB23D_SERCOM5_PAD3>;
 		};
 	};
+
+	usb0_default: usb0_default {
+		group1 {
+			pinmux = <PA24G_USB_DM>,
+				 <PA25G_USB_DP>;
+		};
+	};
 };

--- a/boards/arm/atsamr34_xpro/atsamr34_xpro.dts
+++ b/boards/arm/atsamr34_xpro/atsamr34_xpro.dts
@@ -121,4 +121,7 @@
 
 zephyr_udc0: &usb0 {
 	status = "okay";
+
+	pinctrl-0 = <&usb0_default>;
+	pinctrl-names = "default";
 };

--- a/soc/arm/atmel_sam0/common/soc_saml2x.c
+++ b/soc/arm/atmel_sam0/common/soc_saml2x.c
@@ -215,6 +215,18 @@ static inline void gclk_main_configure(void)
 	GCLK->GENCTRL[0].bit.SRC = GCLK_GENCTRL_SRC_DFLL48M_Val;
 }
 
+#if !CONFIG_USB_DC_SAM0
+#define gclk_usb_configure()
+#else
+static inline void gclk_usb_configure(void)
+{
+	GCLK->GENCTRL[2].reg = 0
+		| GCLK_GENCTRL_SRC_DFLL48M
+		| GCLK_GENCTRL_DIV(1)
+		| GCLK_GENCTRL_GENEN;
+}
+#endif
+
 #if !CONFIG_ADC_SAM0
 #define gclk_adc_configure()
 #else
@@ -255,5 +267,6 @@ void z_arm_platform_init(void)
 	flash_waitstates_init();
 	pm_init();
 	gclk_main_configure();
+	gclk_usb_configure();
 	gclk_adc_configure();
 }


### PR DESCRIPTION
This patch resolves issues with USB Device mode on SAML21-derrived boards, including ATSAML21-XPRO and ATSAMLR34-XPRO (and tested on both with [`.../samples/subsys/usb/hid/`](https://github.com/zephyrproject-rtos/zephyr/tree/main/samples/subsys/usb/hid))

cc: @astonkov, @nandojve (apologies for the delay!)

Fixes #63369