### PR TITLE
dts: rp2040: Fix num-irq-priority-bits

### DIFF
--- a/dts/arm/rpi_pico/rp2040.dtsi
+++ b/dts/arm/rpi_pico/rp2040.dtsi
@@ -255,5 +255,5 @@
 };
 
 &nvic {
-	arm,num-irq-priority-bits = <3>;
+	arm,num-irq-priority-bits = <2>;
 };


### PR DESCRIPTION
The number of IRQ priority bits was incorrectly set to 3 instead of 2, which is the correct number for Cortex-M0+.

Fixes #65623