### PR TITLE
samples: disable usermode for ip_k66f

### DIFF
--- a/samples/net/sockets/net_mgmt/sample.yaml
+++ b/samples/net/sockets/net_mgmt/sample.yaml
@@ -17,3 +17,5 @@ tests:
     tags: userspace
     extra_configs:
       - CONFIG_USERSPACE=y
+    platform_exclude:
+      - ip_k66f


### PR DESCRIPTION
in ip_k66f platfrom, we using rtt as debug port,
which is conflicted with usermode. see below:

warning: LOG_PRINTK (defined at subsys/logging/Kconfig.processing:8) has direct dependencies !USERSPACE && !LOG_MODE_MINIMAL && LOG with value n, but is currently being y-selected by the following symbols:
 - LOG_BACKEND_RTT_FORCE_PRINTK (defined at subsys/logging/backends/Kconfig.rtt:103), with value y, direct dependencies LOG_BACKEND_RTT && !LOG_FRONTEND_ONLY && !LOG_MODE_MINIMAL && LOG (value: y), and select condition LOG_BACKEND_RTT && !LOG_FRONTEND_ONLY && !LOG_MODE_MINIMAL && LOG (value: y)