### PR TITLE
modules: hal_nordic: nrf_802154: lengthen serialization ring buffer

### DIFF
--- a/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_spinel_backend_ipc.c
+++ b/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_spinel_backend_ipc.c
@@ -71,8 +71,10 @@ nrf_802154_ser_err_t nrf_802154_backend_init(void)
 }
 
 /* Send packet thread details */
-#define RING_BUFFER_LEN 16
 #define SEND_THREAD_STACK_SIZE 1024
+
+/* Make the ring buffer long enough to hold all notifications that the driver can produce */
+#define RING_BUFFER_LEN (CONFIG_NRF_802154_RX_BUFFERS + 10)
 
 static K_SEM_DEFINE(send_sem, 0, RING_BUFFER_LEN);
 K_THREAD_STACK_DEFINE(send_thread_stack, SEND_THREAD_STACK_SIZE);


### PR DESCRIPTION
This commit increases the length of ring buffer that holds serialized nRF 802.15.4 API calls so that it can simultaneously store all notifications the driver is capable of issuing. Currently that's not the case, which creates a possibility of the serialization buffers running out while the driver is issuing notifications.