### PR TITLE
Add USART PINCTRL configuration for brd4180a and brd4187c 

### DIFF
--- a/boards/arm/efr32_radio/efr32_radio_brd4180a-pinctrl.dtsi
+++ b/boards/arm/efr32_radio/efr32_radio_brd4180a-pinctrl.dtsi
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2023 Antmicro <www.antmicro.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <arm/silabs/gpio_gecko.h>
+#include <dt-bindings/pinctrl/gecko-pinctrl.h>
+
+&pinctrl {
+	usart0_default: usart0_default {
+		group1 {
+			psels = <GECKO_PSEL(UART_TX, A, 5)>,
+				<GECKO_PSEL(UART_RX, A, 6)>,
+				<GECKO_LOC(UART, 0)>;
+		};
+	};
+};

--- a/boards/arm/efr32_radio/efr32_radio_brd4180a.dts
+++ b/boards/arm/efr32_radio/efr32_radio_brd4180a.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 #include <silabs/efr32mg21a020f1024im32.dtsi>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include "efr32_radio_brd4180a-pinctrl.dtsi"
 
 / {
 	model = "Silicon Labs BRD4180A (Mighty Gecko Radio Board)";
@@ -65,8 +66,8 @@
 
 &usart0 {
 	current-speed = <115200>;
-	location-rx = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(6)>;
-	location-tx = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(5)>;
+	pinctrl-0 = <&usart0_default>;
+	pinctrl-names = "default";
 	status = "okay";
 };
 

--- a/boards/arm/efr32_radio/efr32_radio_brd4187c-pinctrl.dtsi
+++ b/boards/arm/efr32_radio/efr32_radio_brd4187c-pinctrl.dtsi
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2023 Antmicro <www.antmicro.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <arm/silabs/gpio_gecko.h>
+#include <dt-bindings/pinctrl/gecko-pinctrl.h>
+
+&pinctrl {
+	usart0_default: usart0_default {
+		group1 {
+			psels = <GECKO_PSEL(UART_TX, A, 8)>,
+				<GECKO_PSEL(UART_RX, A, 9)>,
+				<GECKO_LOC(UART, 0)>;
+		};
+	};
+};

--- a/boards/arm/efr32_radio/efr32_radio_brd4187c.dts
+++ b/boards/arm/efr32_radio/efr32_radio_brd4187c.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 #include <silabs/efr32mg24b220f1536im48.dtsi>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include "efr32_radio_brd4187c-pinctrl.dtsi"
 
 / {
 	model = "Silicon Labs BRD4187C (Mighty Gecko Radio Board)";
@@ -67,8 +68,8 @@
 
 &usart0 {
 	current-speed = <115200>;
-	location-rx = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(9)>;
-	location-tx = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(8)>;
+	pinctrl-0 = <&usart0_default>;
+	pinctrl-names = "default";
 	status = "okay";
 };
 


### PR DESCRIPTION
https://github.com/zephyrproject-rtos/zephyr/commit/ad788ad51173c08dc237653df132d500b0e40d26 switched to `PINCTRL` in `efr32_radio_brd4180a`and `efr32_radio_brd4187c` boards, but no configuration was provided. This commits adds it.