### PR TITLE
samples: sensor: hts221 has no trigger on stm32u585 disco kit

### DIFF
--- a/samples/sensor/hts221/sample.yaml
+++ b/samples/sensor/hts221/sample.yaml
@@ -23,3 +23,5 @@ tests:
   sample.sensor.hts221.trigger:
     extra_configs:
       - CONFIG_HTS221_TRIGGER_OWN_THREAD=y
+    platform_exclude:
+      - b_u585i_iot02a


### PR DESCRIPTION
The b_u585i_iot02a stm32 board has no HTS221 DRDY pin to trig the HTS221 relative humidity and temperature sensor.
 So that sample.sensor.hts221.trigger is not applicable.


- <img width="434" alt="HTS221_stm32u5" src="https://github.com/zephyrproject-rtos/zephyr/assets/51417392/89598f44-c65a-4a96-bb2d-718aa4fca6f1">


Testcase samples/sensor/hts221/sample.sensor.hts221 is PASSED
```
*** Booting Zephyr OS build zephyr-v3.5.0-1908-g723b6eab641e ***
Observation:1
Temperature:26.4 C
Relative Humidity:38.5%
```
Testcase samples/sensor/hts221/sample.sensor.hts221.trigger  is skipped
