### PR TITLE
drivers: spi: set STM32 SPI transfer size when available

### DIFF
--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -908,7 +908,7 @@ static int transceive_dma(const struct device *dev,
 			 k_yield());
 #else
 		/* wait until spi is no more busy (spi TX fifo is really empty) */
-		while (ll_func_spi_dma_busy(spi) == 0) {
+		while (ll_func_spi_dma_complete(spi) == 0) {
 		}
 #endif
 

--- a/drivers/spi/spi_ll_stm32.h
+++ b/drivers/spi/spi_ll_stm32.h
@@ -82,7 +82,7 @@ static inline uint32_t ll_func_dma_get_reg_addr(SPI_TypeDef *spi, uint32_t locat
 }
 
 /* checks that DMA Tx packet is fully transmitted over the SPI */
-static inline uint32_t ll_func_spi_dma_busy(SPI_TypeDef *spi)
+static inline uint32_t ll_func_spi_dma_complete(SPI_TypeDef *spi)
 {
 #ifdef LL_SPI_SR_TXC
 	return LL_SPI_IsActiveFlag_TXC(spi);

--- a/drivers/spi/spi_ll_stm32.h
+++ b/drivers/spi/spi_ll_stm32.h
@@ -81,11 +81,19 @@ static inline uint32_t ll_func_dma_get_reg_addr(SPI_TypeDef *spi, uint32_t locat
 #endif /* st_stm32h7_spi */
 }
 
-/* checks that DMA Tx packet is fully transmitted over the SPI */
-static inline uint32_t ll_func_spi_dma_complete(SPI_TypeDef *spi)
+/* checks that DMA Tx packet is fully transmitted over the SPI.
+ *
+ * partial_transfer_size should be set if TSIZE is in use and will be reloaded from TSER at the end
+ * of this transfer to start another transfer in the same transaction.
+ */
+static inline uint32_t ll_func_spi_dma_complete(SPI_TypeDef *spi, bool partial_transfer_size)
 {
 #ifdef LL_SPI_SR_TXC
-	return LL_SPI_IsActiveFlag_TXC(spi);
+	if (partial_transfer_size) {
+		return LL_SPI_IsActiveFlag_TSER(spi);
+	} else {
+		return LL_SPI_IsActiveFlag_TXC(spi);
+	}
 #else
 	/* the SPI Tx empty and busy flags are needed */
 	return (LL_SPI_IsActiveFlag_TXE(spi) &&


### PR DESCRIPTION
This ensures the CS pin is deasserted immediately after the transfer by hardware, instead of only ~microseconds later by software.

We have an SPI slave device (ESP32 running esp-hosted) that can't handle more than a couple microseconds wait between end of data and de-assert of CS, otherwise it interprets the (fixed-length) data as one transaction and the de-assert of CS as another, empty, transaction. Luckily, stm32h7 offers the `TSIZE` register, which can automatically de-assert CS once the target number of bytes has been transferred, it just needs to be used.