### PR TITLE
doc: release: 3.6: Add notes on changes

### DIFF
--- a/doc/releases/release-notes-3.6.rst
+++ b/doc/releases/release-notes-3.6.rst
@@ -110,7 +110,7 @@ Boards & SoC Support
 Build system and infrastructure
 *******************************
 
-- Dropped the ``COMPAT_INCLUDES`` option, it was unused since 3.0.
+* Dropped the ``COMPAT_INCLUDES`` option, it was unused since 3.0.
 
 Drivers and Sensors
 *******************

--- a/doc/releases/release-notes-3.6.rst
+++ b/doc/releases/release-notes-3.6.rst
@@ -112,6 +112,8 @@ Build system and infrastructure
 
 * Dropped the ``COMPAT_INCLUDES`` option, it was unused since 3.0.
 
+* Fixed an issue whereby board revision ``0`` did not include overlay files for that revision.
+
 Drivers and Sensors
 *******************
 

--- a/doc/releases/release-notes-3.6.rst
+++ b/doc/releases/release-notes-3.6.rst
@@ -255,6 +255,9 @@ Libraries / Subsystems
   * Implemented datetime functionality in MCUmgr OS management group, this makes use of the RTC
     driver API.
 
+  * Fixes an issue in MCUmgr console UART input whereby the FIFO would be read outside of an ISR,
+    which is not supported in the next USB stack.
+
 * File systems
 
 * Modem modules

--- a/doc/releases/release-notes-3.6.rst
+++ b/doc/releases/release-notes-3.6.rst
@@ -63,6 +63,9 @@ Boards & SoC Support
 
 * Made these changes in other SoC series:
 
+  * Nordic SoCs now imply :kconfig:option:`CONFIG_XIP` instead of selecting it, this allows for
+    creating RAM-based applicatins by disabling it.
+
 * Added support for these ARC boards:
 
 * Added support for these ARM boards:


### PR DESCRIPTION
    doc: release: 3.6: Fix wrong list character
    
    Fixes wrongly using a dash instead of an asterisk for a list


    doc: release: 3.6: Add note on fixed board revision 0
    
    Adds a note that board revision 0 now correctly has the overlay
    file included


    doc: release: 3.6: Add note on Nordic implying XIP
    
    Adds a note that nordic SoCs now imply the XIP Kconfig option
    instead of selecting it


    doc: release: 3.6: Add note on fixed MCUmgr UART console FIFO
    
    Adds a note that the UART FIFO is no longer read when the driver
    is configured
