### PR TITLE
soc: power: stm32l4+: Configure SRAM3 Retention in STOP2 mode

### DIFF
--- a/dts/bindings/power/stm32,stm32l4-power.yaml
+++ b/dts/bindings/power/stm32,stm32l4-power.yaml
@@ -1,0 +1,10 @@
+compatible: "stm32,stm32l4-power"
+
+include: zephyr,power-state.yaml
+
+properties:
+  sram-retention:
+    type: boolean
+    description: |
+      SRAM retention during low power mode if true
+      SRAM content is lost during low power mode if false

--- a/soc/arm/st_stm32/stm32l4/power.c
+++ b/soc/arm/st_stm32/stm32l4/power.c
@@ -43,7 +43,11 @@ void set_mode_stop(uint8_t substate_id)
 		break;
 	case 3: /* this corresponds to the STOP2 mode: */
 #ifdef PWR_CR1_RRSTP
+#if IS_ENABLED(DT_PROP(DT_PHANDLE_BY_IDX(DT_NODELABEL(cpu0), cpu_power_states, 2), sram_retention))
+		LL_PWR_EnableSRAM3Retention();
+#else
 		LL_PWR_DisableSRAM3Retention();
+#endif /* IS_ENABLED */
 #endif /* PWR_CR1_RRSTP */
 		/* enter STOP2 mode */
 		LL_PWR_SetPowerMode(LL_PWR_MODE_STOP2);


### PR DESCRIPTION
This commit adds a sram-retention property that defines the behavior of the SRAM3 retention in STOP2 mode.

Thanks, @FRASTM, for the guidance.

Fixes: #64323