### PR TITLE
drivers: intc_ioapic: Fix get_vtd()

### DIFF
--- a/arch/x86/core/pcie.c
+++ b/arch/x86/core/pcie.c
@@ -162,7 +162,6 @@ void pcie_conf_write(pcie_bdf_t bdf, unsigned int reg, uint32_t data)
 #ifdef CONFIG_INTEL_VTD_ICTL
 
 #include <zephyr/drivers/interrupt_controller/intel_vtd.h>
-#include <zephyr/arch/x86/acpi.h>
 
 static const struct device *const vtd = DEVICE_DT_GET_ONE(intel_vt_d);
 

--- a/drivers/interrupt_controller/intc_ioapic.c
+++ b/drivers/interrupt_controller/intc_ioapic.c
@@ -125,13 +125,16 @@ static const struct device *const vtd =
 	DEVICE_DT_GET_OR_NULL(DT_INST(0, intel_vt_d));
 static uint16_t ioapic_id;
 
-
 static bool get_vtd(void)
 {
-	union acpi_dmar_id *dmar_id;
+	union acpi_dmar_id dmar_id;
 	int inst_cnt;
 
-	if (vtd != NULL) {
+	if (!device_is_ready(vtd)) {
+		return false;
+	}
+
+	if (ioapic_id != 0) {
 		return true;
 	}
 
@@ -140,9 +143,9 @@ static bool get_vtd(void)
 		return false;
 	}
 
-	ioapic_id = dmar_id->raw;
+	ioapic_id = dmar_id.raw;
 
-	return vtd == NULL ? false : true;
+	return true;
 }
 #endif /* CONFIG_INTEL_VTD_ICTL && !INTEL_VTD_ICTL_XAPIC_PASSTHROUGH */
 


### PR DESCRIPTION
Function acpi_drhd_get() gets pointer to union acpi_dmar_id and set its fields.