### PR TITLE
tests/gpio_basic_api: Do not assume both edge interrupt capability

### DIFF
--- a/tests/drivers/gpio/gpio_basic_api/src/test_config_trigger.c
+++ b/tests/drivers/gpio/gpio_basic_api/src/test_config_trigger.c
@@ -40,6 +40,12 @@ ZTEST(after_flash_gpio_config_trigger, test_gpio_config_twice_trigger)
 
 	/* 2. Enable PIN callback as both edges */
 	ret = gpio_pin_interrupt_configure(dev, PIN_IN, GPIO_INT_EDGE_BOTH);
+	if (ret == -ENOTSUP) {
+		TC_PRINT("Both edge GPIO interrupt not supported.\n");
+		gpio_remove_callback(dev, &drv_data->gpio_cb);
+		ztest_test_skip();
+		return;
+	}
 	zassert_ok(ret, "enable callback failed");
 
 	/* 3. Configure PIN_OUT as open drain, internal pull-up (may trigger
@@ -87,6 +93,12 @@ ZTEST(after_flash_gpio_config_trigger, test_gpio_config_trigger)
 
 	/* 2. Enable PIN callback as both edges */
 	ret = gpio_pin_interrupt_configure(dev, PIN_IN, GPIO_INT_EDGE_BOTH);
+	if (ret == -ENOTSUP) {
+		TC_PRINT("Both edge GPIO interrupt not supported.\n");
+		gpio_remove_callback(dev, &drv_data->gpio_cb);
+		ztest_test_skip();
+		return;
+	}
 	zassert_ok(ret, "enable callback failed");
 
 	/* 3. Configure PIN_OUT as open drain, internal pull-up (may trigger


### PR DESCRIPTION
The glitch subtest assumed the driver can be configured to generate interrupt on both falling and rising edge. Not all GPIO hardware/drivers may be able to do this. Now skip the subtest if `GPIO_INT_EDGE_BOTH` can not be configured.