### PR TITLE
boards: mimxrt101x_evk: add boot and slot partitions

### DIFF
--- a/boards/arm/mimxrt1010_evk/mimxrt1010_evk.dts
+++ b/boards/arm/mimxrt1010_evk/mimxrt1010_evk.dts
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2023 TiaC Systems
- * Copyright (c) 2019, NXP
+ * Copyright 2019,2023 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -26,6 +26,8 @@
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,flash = &at25sf128a;
+		zephyr,flash-controller = &at25sf128a;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds {
@@ -93,6 +95,30 @@ arduino_serial: &lpuart1 {};
 		spi-max-frequency = <133000000>;
 		status = "okay";
 		jedec-id = [1f 89 01];
+		erase-block-size = <4096>;
+		write-block-size = <1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			boot_partition: partition@0 {
+				label = "mcuboot";
+				reg = <0x00000000 DT_SIZE_K(64)>;
+			};
+			slot0_partition: partition@10000 {
+				label = "image-0";
+				reg = <0x00010000 DT_SIZE_M(7)>;
+			};
+			slot1_partition: partition@710000 {
+				label = "image-1";
+				reg = <0x00710000 DT_SIZE_M(7)>;
+			};
+			storage_partition: partition@E10000 {
+				label = "storage";
+				reg = <0x00E10000 DT_SIZE_K(1984)>;
+			};
+		};
 	};
 };
 

--- a/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
+++ b/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NXP
+ * Copyright 2019,2023 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -20,11 +20,13 @@
 	};
 
 	chosen {
-		zephyr,sram = &dtcm;
+		zephyr,sram = &ocram;
 		zephyr,itcm = &itcm;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,flash = &at25sf128a;
+		zephyr,flash-controller = &at25sf128a;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds {
@@ -81,14 +83,39 @@ arduino_serial: &lpuart4 {
 };
 
 &flexspi {
+	status = "okay";
 	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(16)>;
 	at25sf128a: at25sf128a@0 {
 		compatible = "nxp,imx-flexspi-nor";
-		size = <134217728>;
+		size = <DT_SIZE_M(16 * 8)>;
 		reg = <0>;
 		spi-max-frequency = <133000000>;
 		status = "okay";
 		jedec-id = [1f 89 01];
+		erase-block-size = <4096>;
+		write-block-size = <1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			boot_partition: partition@0 {
+				label = "mcuboot";
+				reg = <0x00000000 DT_SIZE_K(64)>;
+			};
+			slot0_partition: partition@10000 {
+				label = "image-0";
+				reg = <0x00010000 DT_SIZE_M(7)>;
+			};
+			slot1_partition: partition@710000 {
+				label = "image-1";
+				reg = <0x00710000 DT_SIZE_M(7)>;
+			};
+			storage_partition: partition@E10000 {
+				label = "storage";
+				reg = <0x00E10000 DT_SIZE_K(1984)>;
+			};
+		};
 	};
 };
 


### PR DESCRIPTION
Add boot and slot partitions for mimxrt1010_evk and mimxrt1015_evk.
Enable MCUBoot & Flash support for them.