### PR TITLE
input: kbd_matrix: various debouncing related fixes

### DIFF
--- a/drivers/input/input_kbd_matrix.c
+++ b/drivers/input/input_kbd_matrix.c
@@ -162,7 +162,7 @@ static void input_kbd_matrix_update_state(const struct device *dev)
 				continue;
 			}
 
-			cfg->matrix_unstable_state[c] &= ~row_bit;
+			cfg->matrix_unstable_state[c] &= ~mask;
 
 			/* Check if there was a change in the stable state */
 			if ((cfg->matrix_stable_state[c] & mask) == row_bit) {

--- a/drivers/input/input_kbd_matrix.c
+++ b/drivers/input/input_kbd_matrix.c
@@ -154,10 +154,10 @@ static void input_kbd_matrix_update_state(const struct device *dev)
 			uint8_t scan_clk_cycle = data->scan_clk_cycle[scan_cyc_idx];
 
 			/* Convert the clock cycle differences to usec */
-			uint32_t debt = k_cyc_to_us_floor32(cycles_now - scan_clk_cycle);
+			uint32_t deb_t_us = k_cyc_to_us_floor32(cycles_now - scan_clk_cycle);
 
 			/* Does the key requires more time to be debounced? */
-			if (debt < (row_bit ? cfg->debounce_down_ms : cfg->debounce_up_ms)) {
+			if (deb_t_us < (row_bit ? cfg->debounce_down_us : cfg->debounce_up_us)) {
 				/* Need more time to debounce */
 				continue;
 			}

--- a/drivers/input/input_kbd_matrix.c
+++ b/drivers/input/input_kbd_matrix.c
@@ -151,7 +151,7 @@ static void input_kbd_matrix_update_state(const struct device *dev)
 
 			uint8_t cyc_idx = c * cfg->row_size + r;
 			uint8_t scan_cyc_idx = cfg->scan_cycle_idx[cyc_idx];
-			uint8_t scan_clk_cycle = data->scan_clk_cycle[scan_cyc_idx];
+			uint32_t scan_clk_cycle = data->scan_clk_cycle[scan_cyc_idx];
 
 			/* Convert the clock cycle differences to usec */
 			uint32_t deb_t_us = k_cyc_to_us_floor32(cycles_now - scan_clk_cycle);

--- a/include/zephyr/input/input_kbd_matrix.h
+++ b/include/zephyr/input/input_kbd_matrix.h
@@ -205,7 +205,7 @@ struct input_kbd_matrix_common_config {
  */
 struct input_kbd_matrix_common_data {
 	/* Track previous cycles, used for debouncing. */
-	uint8_t scan_clk_cycle[INPUT_KBD_MATRIX_SCAN_OCURRENCES];
+	uint32_t scan_clk_cycle[INPUT_KBD_MATRIX_SCAN_OCURRENCES];
 	uint8_t scan_cycles_idx;
 
 	struct k_sem poll_lock;

--- a/include/zephyr/input/input_kbd_matrix.h
+++ b/include/zephyr/input/input_kbd_matrix.h
@@ -84,8 +84,8 @@ struct input_kbd_matrix_common_config {
 	uint8_t col_size;
 	uint32_t poll_period_us;
 	uint32_t poll_timeout_ms;
-	uint32_t debounce_down_ms;
-	uint32_t debounce_up_ms;
+	uint32_t debounce_down_us;
+	uint32_t debounce_up_us;
 	uint32_t settle_time_us;
 	bool ghostkey_check;
 
@@ -155,8 +155,8 @@ struct input_kbd_matrix_common_config {
 		.col_size = _col_size, \
 		.poll_period_us = DT_PROP(node_id, poll_period_ms) * USEC_PER_MSEC, \
 		.poll_timeout_ms = DT_PROP(node_id, poll_timeout_ms), \
-		.debounce_down_ms = DT_PROP(node_id, debounce_down_ms), \
-		.debounce_up_ms = DT_PROP(node_id, debounce_up_ms), \
+		.debounce_down_us = DT_PROP(node_id, debounce_down_ms) * USEC_PER_MSEC, \
+		.debounce_up_us = DT_PROP(node_id, debounce_up_ms) * USEC_PER_MSEC, \
 		.settle_time_us = DT_PROP(node_id, settle_time_us), \
 		.ghostkey_check = !DT_PROP(node_id, no_ghostkey_check), \
 		\


### PR DESCRIPTION
Various fixes related to the debouncing features found while writing a test for it:
- Fix a debouncing timing unit mismatch when comparing us to ms.
- Fix a type mismatch on cycle count causing a comparisson to always be false
- Fix an incorrect clear mask causing the unstable bit to never be cleared on key release