### PR TITLE
arch: riscv: Add support for custom SOC IPI, per-core init

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -112,6 +112,16 @@ config RISCV_SOC_HAS_CUSTOM_SYS_IO
 	  the RISC-V SoC needs to do something different and more than reading and
 	  writing the registers.
 
+config RISCV_SOC_HAS_CUSTOM_SMP_IPI
+	bool
+	select SCHED_IPI_SUPPORTED
+	help
+	  Hidden option to allow SoC to overwrite SMP IPI implementation
+	  Enable this hidden option and do the following:
+	  - implement arch_smp_init() which registers a custom SW IRQ handler
+	  - implement arch_sched_directed_ipi()
+	  - implement arch_flush_fpu_ipi()
+
 config RISCV_SOC_CONTEXT_SAVE
 	bool "SOC-based context saving in IRQ handlers"
 	select RISCV_SOC_OFFSETS

--- a/include/zephyr/platform/hooks.h
+++ b/include/zephyr/platform/hooks.h
@@ -53,6 +53,14 @@ void soc_early_init_hook(void);
  */
 void soc_late_init_hook(void);
 
+/**
+ * @brief SoC per-core initialization during SMP bringup
+ *
+ * This hook is implemented by the SoC and can be used to perform any
+ * SoC-specific per-core initialization during SMP bringup
+ */
+void soc_smp_per_core_init_hook(void);
+
 /*
  * @brief Board hook executed before the kernel starts.
  *

--- a/kernel/Kconfig.init
+++ b/kernel/Kconfig.init
@@ -32,6 +32,11 @@ config SOC_LATE_INIT_HOOK
 	help
 	  Run a late SoC initialization hook.
 
+config SOC_SMP_PER_CORE_INIT_HOOK
+	bool "Per-core initialization during SMP bringup SoC hook"
+	help
+	  Per-core initialization during SMP bringup SoC hook
+
 config BOARD_EARLY_INIT_HOOK
 	bool "Run early board hook"
 	help


### PR DESCRIPTION
Allow RISCV SOC implementation to define its own custom:
- IPI implementation (e.g. Andes usage of PLIC for IPI)
- per-core init (e.g. per-core PMA implementation)

Signed-off-by: Maxim Adelman <imax@meta.com>