### PR TITLE
sensors: Sensor channel DT child nodes

### DIFF
--- a/boards/shields/ti_bp_bassensorsmkii/ti_bp_bassensorsmkii.overlay
+++ b/boards/shields/ti_bp_bassensorsmkii/ti_bp_bassensorsmkii.overlay
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/sensor/channel.h>
+#include <zephyr/dt-bindings/sensor/field.h>
+
 / {
 	aliases {
 		accel0 = &bmi160_ti_bp_bassensorsmkii;
@@ -14,9 +17,11 @@
 
 &arduino_i2c {
 	bmi160_ti_bp_bassensorsmkii: bmi160@69 {
-		compatible = "bosch,bmi160";
+        compatible = "bosch,bmi160";
 		reg = <0x69>;
 		int-gpios = <&arduino_header 8 GPIO_ACTIVE_HIGH>;
+
+        #include <sensor/bosch/bosch_bmi160.dtsi>
 	};
 
 	opt3001_ti_bp_bassensorsmkii: opt3001@44 {

--- a/dts/bindings/sensor/sensor-channel.yaml
+++ b/dts/bindings/sensor/sensor-channel.yaml
@@ -1,0 +1,53 @@
+# Copyright (c) 2022 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Properties for sensor channels, where a sensor channel is considered a grouping
+# of sensor fields, and a sensor field is a scalar measurement of a physical
+# phenomenom. A channel then is a vector of fields. A sensor a vector of channels.
+#
+# A channel might also be a channel from a sensor hub like device and optionally
+# enable with additional configuration options for a particular device.
+
+description: Sensor Channel
+
+include: base.yaml
+
+properties:
+  channel-index:
+    type: int
+    required: true
+    description: |
+      The numerical index in an array of channels the sensor provides. For
+      example the 0th channel may be the accelerometer channel, the 1st may be
+      a gyro, and 3rd may be a magnetometer. Some devices may group several
+      channels together and in Zephyr those would be fields in a channel rather
+      than individual channels. Each channel might typically come with its own ability
+      to set sensitivity, odr, and so on.
+
+  channel-type:
+    type: int
+    required: true
+    description: |
+      The type of physical sensing information provided by this channel. It
+      can be used to identify a channel of data from a sensor that provides
+      for example acceleration, rotational velocity, magnetic field strength,
+      light intensity, and more.
+
+      The channel type identifiers are defined in C and are extensible.
+
+  channel-fields:
+    type: array
+    description: |
+      A sensor channel may itself be representative of a multi-dimensional
+      array containing relative data about a particular physical measurement.
+      This may be the filtered frequencies of light in a spectrometer, the
+      euclidean alignment of mems sensors for x, y, z, or a simple array of
+      values for things like ToF sensors with 1 or 2 dimensional arrays readings.
+
+      Each field is given by a pair (Field Descriptor, Length) to signify the channel
+      produces fields with a particular meaning and N of them.
+
+      Example fields usages
+
+      channel-fields: <SENSOR_FIELD_XYZ 1>

--- a/dts/bindings/sensor/zephyr,sensor-channel.yaml
+++ b/dts/bindings/sensor/zephyr,sensor-channel.yaml
@@ -1,0 +1,9 @@
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: Zephyr Sensor Device
+
+compatible: "zephyr,sensor-channel"
+
+include: sensor-channel.yaml

--- a/dts/sensor/bosch/bosch_bmi160.dtsi
+++ b/dts/sensor/bosch/bosch_bmi160.dtsi
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+accel {
+    compatible = "zephyr,sensor-channel";
+    channel-index = <0>;
+    channel-type = <SENSOR_CHANNEL_ACCELERATION>;
+    channel-fields = <SENSOR_FIELD_X_AXIS SENSOR_FIELD_Y_AXIS SENSOR_FIELD_Z_AXIS>;
+};
+
+gyro {
+    compatible = "zephyr,sensor-channel";
+    channel-index = <0>;
+    channel-type = <SENSOR_CHANNEL_ROTATIONAL_VELOCITY>;
+    channel-fields = <SENSOR_FIELD_X_AXIS SENSOR_FIELD_Y_AXIS SENSOR_FIELD_Z_AXIS>;
+};

--- a/include/zephyr/dt-bindings/sensor/channel.h
+++ b/include/zephyr/dt-bindings/sensor/channel.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_CHANNEL_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_CHANNEL_H_
+
+/** Acceleration.  */
+#define SENSOR_CHANNEL_ACCELERATION 0
+
+/** Rotational velocity. */
+#define SENSOR_CHANNEL_ROTATIONAL_VELOCITY 1
+
+/** Magnetic field strength. */
+#define SENSOR_CHANNEL_MAGNETIC_FIELD 2
+
+/** Temperature. */
+#define SENSOR_CHANNEL_TEMPERATURE 3
+
+/** Pressure. */
+#define SENSOR_CHANNEL_PRESSURE 4
+
+/** Humidity. */
+#define SENSOR_CHANNEL_HUMIDITY 5
+
+/** Light. */
+#define SENSOR_CHANNEL_LIGHT 6
+
+/** Altitude. */
+#define SENSOR_CHAN_ALTITUDE 7
+
+/** Particulate Matter */
+#define SENSOR_CHANNEL_PM 8
+
+/** Distance. From sensor to target, in meters */
+#define SENSOR_CHANNEL_DISTANCE 9
+
+/** CO2 level, in parts per million (ppm) **/
+#define SENSOR_CHANNEL_CO2 10
+
+/** VOC level, in parts per billion (ppb) **/
+#define SENSOR_CHANNEL_VOC 11
+
+/** Gas sensor resistance in ohms. */
+#define SENSOR_CHANNEL_GAS_RES 12
+
+/** Voltage **/
+#define SENSOR_CHANNEL_VOLTAGE 13
+
+/** Current **/
+#define SENSOR_CHANNEL_CURRENT 14
+
+/** Power in watts **/
+#define SENSOR_CHANNEL_POWER 15
+
+/** Resistance **/
+#define SENSOR_CHANNEL_RESISTANCE 16
+
+/** Angular rotation */
+#define SENSOR_CHANNEL_ROTATION 17
+
+/** Position change on the X axis, in points. */
+#define SENSOR_CHANNEL_POSITION 18
+
+/** Revolutions per minute, in RPM. */
+#define SENSOR_CHANNEL_RPM 19
+
+/**
+ * Number of all common sensor channels.
+ */
+#define SENSOR_CHANNEL_COMMON_COUNT 20
+
+/**
+ * This and higher values are sensor specific.
+ * Refer to the sensor header file.
+ */
+#define SENSOR_CHANNEL_PRIV_START SENSOR_CHANNEL_COMMON_COUNT
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_CHANNEL_H_ */
+

--- a/include/zephyr/dt-bindings/sensor/field.h
+++ b/include/zephyr/dt-bindings/sensor/field.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_FIELD_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_FIELD_H_
+
+/** X euclidean axis. */
+#define	SENSOR_FIELD_X_AXIS 0
+
+/** Y euclidean axis. */
+#define SENSOR_FIELD_Y_AXIS 1
+
+/** Z euclidean axis. */
+#define SENSOR_FIELD_Z_AXIS 2
+
+/** On-die (e.g. on die temperature). */
+#define SENSOR_FIELD_DIE 3
+
+/** Ambient. */
+#define SENSOR_FIELD_AMBIENT 4
+
+/** IR EM frequency range. */
+#define SENSOR_FIELD_IR_LIGHT 5
+
+/** Visible EM frequency range. */
+#define SENSOR_FIELD_VISIBLE_LIGHT 6
+
+/** Ultra violet EM frequency range. */
+#define SENSOR_FIELD_UV_LIGHT 7
+
+/** 1 micrometer particulate. */
+#define SENSOR_FIELD_1_0_PARTICULATE 8
+
+/** 2.5 micrometer particulate. */
+#define SENSOR_FIELD_2_5_PARTICULATE 9
+
+/** 10 micrometer particulate. */
+#define SENSOR_FIELD_10_PARTICULATE 10
+
+/**
+ * Number of all common sensor fields.
+ */
+#define SENSOR_FIELD_COMMON_COUNT 11
+
+/**
+ * This and higher values are sensor specific.
+ * Refer to the sensor header file.
+ */
+#define SENSOR_FIELD_PRIV_START SENSOR_FIELD_COMMON_COUNT
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_FIELD_H_ */


### PR DESCRIPTION
A rough, WIP, idea of maybe describing sensor channels as child nodes of a sensor. Original idea was from @MaureenHelm

Some nice attributes of this... it maybe better matches up with what the sensor subsystem needs (a channel rather than sensor in terminology). It enables possibly adding optional channels of information for devices that represent sensor hubs like bosch's bhi260ap which has many potential channels of information.

A single numerical value could represent a channel, and the information about that channel could be obtained perhaps using DT macros statically without any allocation or C calls involved

Related Issues/PRs
#64478
#63830 
#61163 