### PR TITLE
drivers: entropy: stm32: Retarget missing LL RNG calls

### DIFF
--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -36,6 +36,14 @@
 
 #if defined(RNG_CR_CONDRST)
 #define STM32_CONDRST_SUPPORT
+
+/* These calls are named differently in the STM32L4 LL RNG driver */
+#if defined(STM32L4)
+#define LL_RNG_EnableCondReset(x) LL_RNG_SetConditioningResetBit(x)
+#define LL_RNG_DisableCondReset(x) LL_RNG_ResetConditioningResetBit(x)
+#define LL_RNG_IsEnabledCondReset(x) LL_RNG_IsResetConditioningBitSet(x)
+#endif
+
 #endif
 
 /*


### PR DESCRIPTION
The STM32 entropy driver makes calls to a few LL RNG functions that for some reason, are named differently in the STM32L4-series driver for the LL RNG.

Namely, they are related to setting/clearing/checking the "conditioning soft reset" bit of the RNG control register.

Without this fix, attempting to build a project with the RNG enabled on a STM32L4-based target will result in link-time errors related to these renamed function calls.

This fix simply adds preprocessor aliases to retarget the function calls so it matches the renamed functions in the L4-series LL RNG API.