### PR TITLE
drivers: ethernet: eth_sam_gmac: Fix ptp adjust

### DIFF
--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -2439,7 +2439,7 @@ static int ptp_clock_sam_gmac_adjust(const struct device *dev, int increment)
 	const struct eth_sam_dev_cfg *const cfg = ptp_context->eth_dev->config;
 	Gmac *gmac = cfg->regs;
 
-	if ((increment <= -NSEC_PER_SEC) || (increment >= NSEC_PER_SEC)) {
+	if ((increment <= -(int)NSEC_PER_SEC) || (increment >= (int)NSEC_PER_SEC)) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
NSEC_PER_SEC is an unsigned literal which will promote variable increment to unsigned for the comparison operation, thus returning -EINVAL for negative increment values.

For positive increment, -NSEC_PER_SEC becomes a large unsigned value which will also return -EINVAL.

Fix by casting NSEC_PER_SEC to an int.