### PR TITLE
doc: porting/arch: misc fixes

### DIFF
--- a/boards/nios2/altera_max10/doc/index.rst
+++ b/boards/nios2/altera_max10/doc/index.rst
@@ -240,7 +240,7 @@ You will see output similar to the following:
    (gdb) c
    Continuing.
 
-   Breakpoint 2, _Cstart () at /projects/zephyr/kernel/init.c:348
+   Breakpoint 2, z_cstart () at /projects/zephyr/kernel/init.c:348
    348     {
    (gdb)
 

--- a/doc/hardware/porting/arch.rst
+++ b/doc/hardware/porting/arch.rst
@@ -537,22 +537,21 @@ account storage for TLS and ASLR random offsets.
 
 .. code-block:: none
 
-	+---------------------+ <- thread.stack_obj
-	| Reserved Memory     | } K_(THREAD|KERNEL)_STACK_RESERVED
-	+---------------------+
-	| Carved-out memory   |
-	|.....................| <- thread.stack_info.start
-	| Unused stack buffer |
-	|                     |
-	|.....................| <- thread's current stack pointer
-	| Used stack buffer   |
-	|                     |
-	|.....................| <- Initial stack pointer. Computable
-	| ASLR Random offset  |      with thread.stack_info.delta
-	+---------------------| <- thread.userspace_local_data
-	| Thread-local data   |
-	+---------------------+ <- thread.stack_info.start +
-	                             thread.stack_info.size
+   +---------------------+ <- thread.stack_obj
+   | Reserved Memory     | } K_(THREAD|KERNEL)_STACK_RESERVED
+   +---------------------+
+   | Carved-out memory   |
+   |.....................| <- thread.stack_info.start
+   | Unused stack buffer |
+   |                     |
+   |.....................| <- thread's current stack pointer
+   | Used stack buffer   |
+   |                     |
+   |.....................| <- Initial stack pointer. Computable
+   | ASLR Random offset  |      with thread.stack_info.delta
+   +---------------------| <- thread.userspace_local_data
+   | Thread-local data   |
+   +---------------------+ <- thread.stack_info.start + thread.stack_info.size
 
 
 At present, Zephyr does not support stacks that grow upward.

--- a/doc/hardware/porting/arch.rst
+++ b/doc/hardware/porting/arch.rst
@@ -61,9 +61,9 @@ Common steps for all architectures:
 * If running an :abbr:`XIP (eXecute-In-Place)` kernel, copy initialized data
   from ROM to RAM.
 * If not using an ELF loader, zero the BSS section.
-* Jump to :code:`_Cstart()`, the early kernel initialization
+* Jump to :code:`z_cstart()`, the early kernel initialization
 
-  * :code:`_Cstart()` is responsible for context switching out of the fake
+  * :code:`z_cstart()` is responsible for context switching out of the fake
     context running at startup into the main thread.
 
 Some examples of architecture-specific steps that have to be taken:

--- a/doc/hardware/porting/arch.rst
+++ b/doc/hardware/porting/arch.rst
@@ -47,6 +47,16 @@ some are optional:
 * **Linker scripts and toolchains**: architecture-specific details will most
   likely be needed in the build system and when linking the image (required).
 
+* **Memory Management and Memory Mapping**: for architecture-specific details
+  on supporting memory management and memory mapping.
+
+* **Stack Objects**: for architecture-specific details on memory protection
+  hardware regarding stack objects.
+
+* **User Mode Threads**: for supporting threads in user mode.
+
+* **GDB Stub**: for supporting GDB stub to enable remote debugging.
+
 Early Boot Sequence
 *******************
 
@@ -467,8 +477,8 @@ be derived from the linker scripts of other architectures. Some sections might
 be specific to the new architecture, for example the SCB section on ARM and the
 IDT section on x86.
 
-Memory Management
-*****************
+Memory Management and Memory Mapping
+************************************
 
 If the target platform enables paging and requires drivers to memory-map
 their I/O regions, :kconfig:option:`CONFIG_MMU` needs to be enabled and the

--- a/kernel/include/kernel_arch_interface.h
+++ b/kernel/include/kernel_arch_interface.h
@@ -560,7 +560,7 @@ int arch_printk_char_out(int c);
 /**
  * Architecture-specific kernel initialization hook
  *
- * This function is invoked near the top of _Cstart, for additional
+ * This function is invoked near the top of z_cstart, for additional
  * architecture-specific setup before the rest of the kernel is brought up.
  */
 static inline void arch_kernel_init(void);


### PR DESCRIPTION
* doc: porting/arch: add missing sections to overview list
* doc: fixed already renamed _Cstart to z_cstart
* doc: porting/arch: fixed missing stack object memory map