### PR TITLE
posix: pthread: fix warning about uninitialized variable

### DIFF
--- a/lib/posix/pthread.c
+++ b/lib/posix/pthread.c
@@ -468,7 +468,7 @@ int pthread_create(pthread_t *th, const pthread_attr_t *_attr, void *(*threadrou
 
 int pthread_getconcurrency(void)
 {
-	int ret;
+	int ret = 0;
 
 	K_SPINLOCK(&pthread_pool_lock) {
 		ret = pthread_concurrency;


### PR DESCRIPTION
Initialize `ret` to zero. I don't think there is any way out of this function without it being initialized, so IMHO it's a false positive.