### PR TITLE
scripts/pylib/twister/twisterlib: Support multiple `--pytest-args`

### DIFF
--- a/doc/develop/test/pytest.rst
+++ b/doc/develop/test/pytest.rst
@@ -67,6 +67,8 @@ For instance, one can use a command:
    --pytest-args='-k test_shell_print_version'
 
 
+Note that ``--pytest-args`` can be passed multiple times to pass several arguments to the pytest.
+
 Helpers & fixtures
 ==================
 

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -216,7 +216,8 @@ Artificially long but functional example:
         and 'fifo_loop' is a name of a function found in main.c without test prefix.
         """)
 
-    parser.add_argument("--pytest-args",
+    parser.add_argument(
+        "--pytest-args", action="append",
         help="""Pass additional arguments to the pytest subprocess. This parameter
         will override the pytest_args from the harness_config in YAML file.
         """)

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -326,15 +326,6 @@ class Pytest(Harness):
         command.extend([os.path.normpath(os.path.join(
             self.source_dir, os.path.expanduser(os.path.expandvars(src)))) for src in pytest_root])
 
-        if handler.options.pytest_args:
-            command.append(handler.options.pytest_args)
-            if pytest_args_yaml:
-                logger.warning(f'The pytest_args ({handler.options.pytest_args}) specified '
-                               'in the command line will override the pytest_args defined '
-                               f'in the YAML file {pytest_args_yaml}')
-        else:
-            command.extend(pytest_args_yaml)
-
         if pytest_dut_scope:
             command.append(f'--dut-scope={pytest_dut_scope}')
 
@@ -354,6 +345,16 @@ class Pytest(Harness):
             command.append('--device-type=custom')
         else:
             raise PytestHarnessException(f'Handling of handler {handler.type_str} not implemented yet')
+
+        if handler.options.pytest_args:
+            command.extend(handler.options.pytest_args)
+            if pytest_args_yaml:
+                logger.warning(f'The pytest_args ({handler.options.pytest_args}) specified '
+                               'in the command line will override the pytest_args defined '
+                               f'in the YAML file {pytest_args_yaml}')
+        else:
+            command.extend(pytest_args_yaml)
+
         return command
 
     def _generate_parameters_for_hardware(self, handler: Handler):

--- a/scripts/tests/twister/pytest_integration/test_harness_pytest.py
+++ b/scripts/tests/twister/pytest_integration/test_harness_pytest.py
@@ -71,12 +71,13 @@ def test_pytest_command_extra_args(testinstance: TestInstance):
 def test_pytest_command_extra_args_in_options(testinstance: TestInstance):
     pytest_harness = Pytest()
     pytest_args_from_yaml = '-k test_from_yaml'
-    pytest_args_from_cmd = '-k test_from_cmd'
+    pytest_args_from_cmd = ['-k', 'test_from_cmd']
     testinstance.testsuite.harness_config['pytest_args'] = [pytest_args_from_yaml]
     testinstance.handler.options.pytest_args = pytest_args_from_cmd
     pytest_harness.configure(testinstance)
     command = pytest_harness.generate_command()
-    assert pytest_args_from_cmd in command
+    assert pytest_args_from_cmd[0] in command
+    assert pytest_args_from_cmd[1] in command
     assert pytest_args_from_yaml not in command
 
 


### PR DESCRIPTION
One can not even replace sucessfully pytest basic sample `pytest-args` with command line "--pytest-args", as all it does is to append a single string to current list of commands, making it impossible to send several arguments.

This patch fixes that by allowing several instances of `--pytest-args` to compose the whole list of arguments to be passed to pytest.