### PR TITLE
doc: native_sim: add link of known issues

### DIFF
--- a/boards/posix/native_sim/doc/index.rst
+++ b/boards/posix/native_sim/doc/index.rst
@@ -44,6 +44,8 @@ Important limitations
 ``native_sim`` is based on the :ref:`POSIX architecture<Posix arch>`, and therefore
 :ref:`its limitations <posix_arch_limitations>` and considerations apply to it.
 
+Until https://github.com/zephyrproject-rtos/zephyr/issues/6044 is resolved, some limitations exist with current implementation.
+
 .. _native_sim_how_to_use:
 
 How to use it


### PR DESCRIPTION
Known issues of current native_sim implementation is added to limitations section so that to reduce confusions.