### PR TITLE
subsys: testsuite: coverage: allow access to gcov internals

### DIFF
--- a/subsys/testsuite/CMakeLists.txt
+++ b/subsys/testsuite/CMakeLists.txt
@@ -6,5 +6,6 @@ if(CONFIG_TEST)
   zephyr_include_directories(${ZEPHYR_BASE}/subsys/testsuite/include)
 endif()
 add_subdirectory_ifdef(CONFIG_COVERAGE_GCOV coverage)
+zephyr_include_directories_ifdef(CONFIG_COVERAGE_GCOV ${zephyr_BASE}/subsys/testsuite/coverage)
 
 zephyr_library_sources_ifdef(CONFIG_TEST_BUSY_SIM busy_sim/busy_sim.c)

--- a/subsys/testsuite/coverage/coverage.c
+++ b/subsys/testsuite/coverage/coverage.c
@@ -84,7 +84,7 @@ static inline void write_u32(void *buffer, size_t *off, uint32_t v)
 	*off = *off + sizeof(uint32_t);
 }
 
-size_t calculate_buff_size(struct gcov_info *info)
+size_t gcov_calculate_buff_size(struct gcov_info *info)
 {
 	uint32_t iter;
 	uint32_t iter_1;
@@ -266,7 +266,7 @@ void gcov_coverage_dump(void)
 	while (gcov_list) {
 
 		dump_on_console_start(gcov_list->filename);
-		size = calculate_buff_size(gcov_list);
+		size = gcov_calculate_buff_size(gcov_list);
 
 		buffer = k_heap_alloc(&gcov_heap, size, K_NO_WAIT);
 		if (CONFIG_COVERAGE_GCOV_HEAP_SIZE > 0 && !buffer) {
@@ -294,6 +294,11 @@ coverage_dump_end:
 	return;
 }
 
+struct gcov_info *gcov_get_list_head(void)
+{
+	/* Locking someway before getting this is recommended. */
+	return gcov_info_head;
+}
 
 /* Initialize the gcov by calling the required constructors */
 void gcov_static_init(void)

--- a/subsys/testsuite/coverage/coverage.h
+++ b/subsys/testsuite/coverage/coverage.h
@@ -117,4 +117,12 @@ struct gcov_info {
 
 };
 
+/*
+ * These functions are in the header for easy access for external interface
+ * reporting since they aren't useful without the structs in this header.
+ */
+struct gcov_info *gcov_get_list_head(void);
+size_t gcov_populate_buffer(uint8_t *buffer, struct gcov_info *info);
+size_t gcov_calculate_buff_size(struct gcov_info *info);
+
 #endif /* _COVERAGE_H_ */


### PR DESCRIPTION
This allows external applications wishing to report coverage data over different interfaces the ability to do so by exposing the gcov list. Follow on commits will test it in the shell, when the PR lands and also add something to choose the output mechanism via Kconfig.