### PR TITLE
kernel: timeout: fix issue with z_timeout_expires

### DIFF
--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -190,7 +190,7 @@ k_ticks_t z_timeout_expires(const struct _timeout *timeout)
 	k_ticks_t ticks = 0;
 
 	K_SPINLOCK(&timeout_lock) {
-		ticks = curr_tick + timeout_rem(timeout);
+		ticks = curr_tick + timeout_rem(timeout) + elapsed();
 	}
 
 	return ticks;


### PR DESCRIPTION
- issue found with Ztest case of test_thread_timeout_remaining_expires on Intel ISH platform when adjust CONFIG_SYS_CLOCK_TICKS_PER_SEC to 10k.
- timeout_rem() return exact remaining ticks which is calibrated by decrease elapsed(), as behavior in z_add_timeout, z_timeout_expires should get expire ticks to be timeout using current tick as base, so need get exact current ticks by plus elasped().