### PR TITLE
mr_canhubk3: change SPI and WD_FS26 init priority

### DIFF
--- a/boards/arm/mr_canhubk3/Kconfig.defconfig
+++ b/boards/arm/mr_canhubk3/Kconfig.defconfig
@@ -13,6 +13,19 @@ config UART_CONSOLE
 
 endif # SERIAL
 
+if SPI
+
+config SPI_INIT_PRIORITY
+	default 50
+
+if WDT_NXP_FS26
+
+config WDT_NXP_FS26_INIT_PRIORITY
+	default 51
+
+endif # WDT_NXP_FS26
+endif # SPI
+
 if CAN
 
 config GPIO


### PR DESCRIPTION
Changes the FS26 watchdog init priority to avoid boot-looping. 
Requires SPI priority to be changed as well.