### PR TITLE
console: uart: cleanup device runtime PM checks

### DIFF
--- a/drivers/console/uart_console.c
+++ b/drivers/console/uart_console.c
@@ -87,13 +87,11 @@ static int console_out(int c)
 
 #endif  /* CONFIG_UART_CONSOLE_DEBUG_SERVER_HOOKS */
 
-	if (pm_device_runtime_is_enabled(uart_console_dev)) {
-		if (pm_device_runtime_get(uart_console_dev) < 0) {
-			/* Enabling the UART instance has failed but this
-			 * function MUST return the byte output.
-			 */
-			return c;
-		}
+	if (pm_device_runtime_get(uart_console_dev) < 0) {
+		/* Enabling the UART instance has failed but this
+		 * function MUST return the byte output.
+		 */
+		return c;
 	}
 
 	if ('\n' == c) {
@@ -101,10 +99,8 @@ static int console_out(int c)
 	}
 	uart_poll_out(uart_console_dev, c);
 
-	if (pm_device_runtime_is_enabled(uart_console_dev)) {
-		/* As errors cannot be returned, ignore the return value */
-		(void)pm_device_runtime_put(uart_console_dev);
-	}
+	/* As errors cannot be returned, ignore the return value */
+	(void)pm_device_runtime_put(uart_console_dev);
 
 	return c;
 }


### PR DESCRIPTION
`pm_device_runtime_get` and `pm_device_runtime_put` have returned `0` when device runtime PM is not enabled since #56222. Manually checking the state is no longer required.

Additionally, the functions have been able to run in an ISR context since #60785, which removed the need to special case `k_is_in_isr()`.