### PR TITLE
driver: intc: plic: fix trigger type register bit calculation

### DIFF
--- a/drivers/interrupt_controller/intc_plic.c
+++ b/drivers/interrupt_controller/intc_plic.c
@@ -139,7 +139,7 @@ static int riscv_plic_is_edge_irq(const struct device *dev, uint32_t local_irq)
 	const struct plic_config *config = dev->config;
 	mem_addr_t trig_addr = config->trig + local_irq_to_reg_offset(local_irq);
 
-	return sys_read32(trig_addr) & BIT(local_irq);
+	return sys_read32(trig_addr) & BIT(local_irq & PLIC_REG_MASK);
 }
 
 static void plic_irq_enable_set_state(uint32_t irq, bool enable)


### PR DESCRIPTION
The current IRQ bit position calculation for the trigger type register is wrong according to the datasheets, the fix opts for bit mask instead of modulo, as the former is faster.

[**Telink B91 Reference Manual**](http://wiki.telink-semi.cn/doc/ds/DS-TLSR9518-E_Datasheet%20for%20Telink%20Multi-Standard%20Wireless%20SoC%20TLSR9518.pdf)

![image](https://github.com/zephyrproject-rtos/zephyr/assets/1563974/2fe11397-1019-48a6-9115-4f8529bcea51)

[**Andes AX45MP Reference Manual**](https://www.andestech.com/wp-content/uploads/AX45MP-1C-Rev.-5.0.0-Datasheet.pdf)

![image](https://github.com/zephyrproject-rtos/zephyr/assets/1563974/6cfe13b0-ddd4-4e32-9a7a-ec6bc7727b37)
![image](https://github.com/zephyrproject-rtos/zephyr/assets/1563974/c9779c42-96f9-4103-b8cc-555429bed54a)

fixes #65846