### PR TITLE
serial: stm32: do not clear TC flag in async mode

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1257,7 +1257,6 @@ static void uart_stm32_isr(const struct device *dev)
 			LL_USART_IsActiveFlag_TC(config->usart)) {
 
 		LL_USART_DisableIT_TC(config->usart);
-		LL_USART_ClearFlag_TC(config->usart);
 		/* Generate TX_DONE event when transmission is done */
 		async_evt_tx_done(data);
 


### PR DESCRIPTION
The Transfer Complete flag (TC) is used to check if a transfer is complete. This mechanism is used before suspending the UART module to make sure that all data are sent before the suspend procedure.

The UART ISR clears this flag after completion of a async transfer which causes a hang during UART device suspend setup.

There is just no need to clear this flag in ISR, it is cleared every time we start a new async transfer.