### PR TITLE
Refactor context options setting and getting

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -1408,6 +1408,10 @@ static int get_context_priority(struct net_context *context,
 	return get_uint8_option(context->options.priority,
 				value, len);
 #else
+	ARG_UNUSED(context);
+	ARG_UNUSED(value);
+	ARG_UNUSED(len);
+
 	return -ENOTSUP;
 #endif
 }
@@ -1432,6 +1436,10 @@ static int get_context_proxy(struct net_context *context,
 
 	return 0;
 #else
+	ARG_UNUSED(context);
+	ARG_UNUSED(value);
+	ARG_UNUSED(len);
+
 	return -ENOTSUP;
 #endif
 }
@@ -1443,6 +1451,10 @@ static int get_context_txtime(struct net_context *context,
 	return get_bool_option(context->options.txtime,
 			       value, len);
 #else
+	ARG_UNUSED(context);
+	ARG_UNUSED(value);
+	ARG_UNUSED(len);
+
 	return -ENOTSUP;
 #endif
 }
@@ -1459,6 +1471,10 @@ static int get_context_rcvtimeo(struct net_context *context,
 
 	return 0;
 #else
+	ARG_UNUSED(context);
+	ARG_UNUSED(value);
+	ARG_UNUSED(len);
+
 	return -ENOTSUP;
 #endif
 }
@@ -1475,6 +1491,10 @@ static int get_context_sndtimeo(struct net_context *context,
 
 	return 0;
 #else
+	ARG_UNUSED(context);
+	ARG_UNUSED(value);
+	ARG_UNUSED(len);
+
 	return -ENOTSUP;
 #endif
 }
@@ -1486,6 +1506,10 @@ static int get_context_rcvbuf(struct net_context *context,
 	return get_uint16_option(context->options.rcvbuf,
 				 value, len);
 #else
+	ARG_UNUSED(context);
+	ARG_UNUSED(value);
+	ARG_UNUSED(len);
+
 	return -ENOTSUP;
 #endif
 }
@@ -1497,6 +1521,10 @@ static int get_context_sndbuf(struct net_context *context,
 	return get_uint16_option(context->options.sndbuf,
 				 value, len);
 #else
+	ARG_UNUSED(context);
+	ARG_UNUSED(value);
+	ARG_UNUSED(len);
+
 	return -ENOTSUP;
 #endif
 }
@@ -1508,6 +1536,10 @@ static int get_context_dscp_ecn(struct net_context *context,
 	return get_uint8_option(context->options.dscp_ecn,
 				value, len);
 #else
+	ARG_UNUSED(context);
+	ARG_UNUSED(value);
+	ARG_UNUSED(len);
+
 	return -ENOTSUP;
 #endif
 }
@@ -1519,6 +1551,10 @@ static int get_context_reuseaddr(struct net_context *context,
 	return get_bool_option(context->options.reuseaddr,
 			       value, len);
 #else
+	ARG_UNUSED(context);
+	ARG_UNUSED(value);
+	ARG_UNUSED(len);
+
 	return -ENOTSUP;
 #endif
 }
@@ -1530,6 +1566,10 @@ static int get_context_reuseport(struct net_context *context,
 	return get_bool_option(context->options.reuseport,
 			       value, len);
 #else
+	ARG_UNUSED(context);
+	ARG_UNUSED(value);
+	ARG_UNUSED(len);
+
 	return -ENOTSUP;
 #endif
 }
@@ -2541,6 +2581,10 @@ static int set_context_priority(struct net_context *context,
 #if defined(CONFIG_NET_CONTEXT_PRIORITY)
 	return set_uint8_option(&context->options.priority, value, len);
 #else
+	ARG_UNUSED(context);
+	ARG_UNUSED(value);
+	ARG_UNUSED(len);
+
 	return -ENOTSUP;
 #endif
 }
@@ -2551,6 +2595,10 @@ static int set_context_txtime(struct net_context *context,
 #if defined(CONFIG_NET_CONTEXT_TXTIME)
 	return set_bool_option(&context->options.txtime, value, len);
 #else
+	ARG_UNUSED(context);
+	ARG_UNUSED(value);
+	ARG_UNUSED(len);
+
 	return -ENOTSUP;
 #endif
 }
@@ -2574,6 +2622,10 @@ static int set_context_proxy(struct net_context *context,
 
 	return 0;
 #else
+	ARG_UNUSED(context);
+	ARG_UNUSED(value);
+	ARG_UNUSED(len);
+
 	return -ENOTSUP;
 #endif
 }
@@ -2590,6 +2642,10 @@ static int set_context_rcvtimeo(struct net_context *context,
 
 	return 0;
 #else
+	ARG_UNUSED(context);
+	ARG_UNUSED(value);
+	ARG_UNUSED(len);
+
 	return -ENOTSUP;
 #endif
 }
@@ -2606,6 +2662,10 @@ static int set_context_sndtimeo(struct net_context *context,
 
 	return 0;
 #else
+	ARG_UNUSED(context);
+	ARG_UNUSED(value);
+	ARG_UNUSED(len);
+
 	return -ENOTSUP;
 #endif
 }
@@ -2616,6 +2676,10 @@ static int set_context_rcvbuf(struct net_context *context,
 #if defined(CONFIG_NET_CONTEXT_RCVBUF)
 	return set_uint16_option(&context->options.rcvbuf, value, len);
 #else
+	ARG_UNUSED(context);
+	ARG_UNUSED(value);
+	ARG_UNUSED(len);
+
 	return -ENOTSUP;
 #endif
 }
@@ -2626,6 +2690,10 @@ static int set_context_sndbuf(struct net_context *context,
 #if defined(CONFIG_NET_CONTEXT_SNDBUF)
 	return set_uint16_option(&context->options.sndbuf, value, len);
 #else
+	ARG_UNUSED(context);
+	ARG_UNUSED(value);
+	ARG_UNUSED(len);
+
 	return -ENOTSUP;
 #endif
 }
@@ -2636,6 +2704,10 @@ static int set_context_dscp_ecn(struct net_context *context,
 #if defined(CONFIG_NET_CONTEXT_DSCP_ECN)
 	return set_uint8_option(&context->options.dscp_ecn, value, len);
 #else
+	ARG_UNUSED(context);
+	ARG_UNUSED(value);
+	ARG_UNUSED(len);
+
 	return -ENOTSUP;
 #endif
 }
@@ -2646,6 +2718,10 @@ static int set_context_reuseaddr(struct net_context *context,
 #if defined(CONFIG_NET_CONTEXT_REUSEADDR)
 	return set_bool_option(&context->options.reuseaddr, value, len);
 #else
+	ARG_UNUSED(context);
+	ARG_UNUSED(value);
+	ARG_UNUSED(len);
+
 	return -ENOTSUP;
 #endif
 }
@@ -2656,6 +2732,10 @@ static int set_context_reuseport(struct net_context *context,
 #if defined(CONFIG_NET_CONTEXT_REUSEPORT)
 	return set_bool_option(&context->options.reuseport, value, len);
 #else
+	ARG_UNUSED(context);
+	ARG_UNUSED(value);
+	ARG_UNUSED(len);
+
 	return -ENOTSUP;
 #endif
 }

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -1352,18 +1352,61 @@ unlock:
 	return ret;
 }
 
+__maybe_unused static int get_bool_option(bool option, int *value, size_t *len)
+{
+	if (value == NULL) {
+		return -EINVAL;
+	}
+
+	if (len != NULL) {
+		if (*len != sizeof(int)) {
+			return -EINVAL;
+		}
+
+		*len = sizeof(int);
+	}
+
+	*((int *)value) = (int)option;
+
+	return 0;
+}
+
+__maybe_unused static int get_uint8_option(uint8_t option, uint8_t *value, size_t *len)
+{
+	if (value == NULL) {
+		return -EINVAL;
+	}
+
+	*value = option;
+
+	if (len != NULL) {
+		*len = sizeof(uint8_t);
+	}
+
+	return 0;
+}
+
+__maybe_unused static int get_uint16_option(uint16_t option, int *value, size_t *len)
+{
+	if (value == NULL) {
+		return -EINVAL;
+	}
+
+	*value = option;
+
+	if (len != NULL) {
+		*len = sizeof(int);
+	}
+
+	return 0;
+}
 
 static int get_context_priority(struct net_context *context,
 				void *value, size_t *len)
 {
 #if defined(CONFIG_NET_CONTEXT_PRIORITY)
-	*((uint8_t *)value) = context->options.priority;
-
-	if (len) {
-		*len = sizeof(uint8_t);
-	}
-
-	return 0;
+	return get_uint8_option(context->options.priority,
+				value, len);
 #else
 	return -ENOTSUP;
 #endif
@@ -1397,13 +1440,8 @@ static int get_context_txtime(struct net_context *context,
 			      void *value, size_t *len)
 {
 #if defined(CONFIG_NET_CONTEXT_TXTIME)
-	*((bool *)value) = context->options.txtime;
-
-	if (len) {
-		*len = sizeof(bool);
-	}
-
-	return 0;
+	return get_bool_option(context->options.txtime,
+			       value, len);
 #else
 	return -ENOTSUP;
 #endif
@@ -1445,12 +1483,8 @@ static int get_context_rcvbuf(struct net_context *context,
 			      void *value, size_t *len)
 {
 #if defined(CONFIG_NET_CONTEXT_RCVBUF)
-	*((int *)value) = context->options.rcvbuf;
-
-	if (len) {
-		*len = sizeof(int);
-	}
-	return 0;
+	return get_uint16_option(context->options.rcvbuf,
+				 value, len);
 #else
 	return -ENOTSUP;
 #endif
@@ -1460,12 +1494,8 @@ static int get_context_sndbuf(struct net_context *context,
 				void *value, size_t *len)
 {
 #if defined(CONFIG_NET_CONTEXT_SNDBUF)
-	*((int *)value) = context->options.sndbuf;
-
-	if (len) {
-		*len = sizeof(int);
-	}
-	return 0;
+	return get_uint16_option(context->options.sndbuf,
+				 value, len);
 #else
 	return -ENOTSUP;
 #endif
@@ -1475,13 +1505,8 @@ static int get_context_dscp_ecn(struct net_context *context,
 				void *value, size_t *len)
 {
 #if defined(CONFIG_NET_CONTEXT_DSCP_ECN)
-	*((int *)value) = context->options.dscp_ecn;
-
-	if (len) {
-		*len = sizeof(int);
-	}
-
-	return 0;
+	return get_uint8_option(context->options.dscp_ecn,
+				value, len);
 #else
 	return -ENOTSUP;
 #endif
@@ -1491,23 +1516,8 @@ static int get_context_reuseaddr(struct net_context *context,
 				 void *value, size_t *len)
 {
 #if defined(CONFIG_NET_CONTEXT_REUSEADDR)
-	if (!value || !len) {
-		return -EINVAL;
-	}
-
-	if (*len != sizeof(int)) {
-		return -EINVAL;
-	}
-
-	if (context->options.reuseaddr == true) {
-		*((int *)value) = (int) true;
-	} else {
-		*((int *)value) = (int) false;
-	}
-
-	*len = sizeof(int);
-
-	return 0;
+	return get_bool_option(context->options.reuseaddr,
+			       value, len);
 #else
 	return -ENOTSUP;
 #endif
@@ -1517,23 +1527,8 @@ static int get_context_reuseport(struct net_context *context,
 				void *value, size_t *len)
 {
 #if defined(CONFIG_NET_CONTEXT_REUSEPORT)
-	if (!value || !len) {
-		return -EINVAL;
-	}
-
-	if (*len != sizeof(int)) {
-		return -EINVAL;
-	}
-
-	if (context->options.reuseport == true) {
-		*((int *)value) = (int) true;
-	} else {
-		*((int *)value) = (int) false;
-	}
-
-	*len = sizeof(int);
-
-	return 0;
+	return get_bool_option(context->options.reuseport,
+			       value, len);
 #else
 	return -ENOTSUP;
 #endif
@@ -1543,23 +1538,8 @@ static int get_context_ipv6_v6only(struct net_context *context,
 				   void *value, size_t *len)
 {
 #if defined(CONFIG_NET_IPV4_MAPPING_TO_IPV6)
-	if (!value || !len) {
-		return -EINVAL;
-	}
-
-	if (*len != sizeof(int)) {
-		return -EINVAL;
-	}
-
-	if (context->options.ipv6_v6only == true) {
-		*((int *)value) = (int) true;
-	} else {
-		*((int *)value) = (int) false;
-	}
-
-	*len = sizeof(int);
-
-	return 0;
+	return get_bool_option(context->options.ipv6_v6only,
+			       value, len);
 #else
 	ARG_UNUSED(context);
 	ARG_UNUSED(value);
@@ -1573,23 +1553,8 @@ static int get_context_recv_pktinfo(struct net_context *context,
 				    void *value, size_t *len)
 {
 #if defined(CONFIG_NET_CONTEXT_RECV_PKTINFO)
-	if (!value || !len) {
-		return -EINVAL;
-	}
-
-	if (*len != sizeof(int)) {
-		return -EINVAL;
-	}
-
-	if (context->options.recv_pktinfo == true) {
-		*((int *)value) = (int) true;
-	} else {
-		*((int *)value) = (int) false;
-	}
-
-	*len = sizeof(int);
-
-	return 0;
+	return get_bool_option(context->options.recv_pktinfo,
+			       value, len);
 #else
 	ARG_UNUSED(context);
 	ARG_UNUSED(value);
@@ -2028,7 +1993,7 @@ static int context_sendto(struct net_context *context,
 	 */
 	if (msghdr && msghdr->msg_control && msghdr->msg_controllen) {
 		if (IS_ENABLED(CONFIG_NET_CONTEXT_TXTIME)) {
-			bool is_txtime;
+			int is_txtime;
 
 			get_context_txtime(context, &is_txtime, NULL);
 			if (is_txtime) {
@@ -2536,11 +2501,11 @@ static int set_context_txtime(struct net_context *context,
 			      const void *value, size_t len)
 {
 #if defined(CONFIG_NET_CONTEXT_TXTIME)
-	if (len > sizeof(bool)) {
+	if (len != sizeof(int)) {
 		return -EINVAL;
 	}
 
-	context->options.txtime = *((bool *)value);
+	context->options.txtime = !!*((int *)value);
 
 	return 0;
 #else

--- a/tests/net/socket/udp/src/main.c
+++ b/tests/net/socket/udp/src/main.c
@@ -731,7 +731,7 @@ ZTEST(net_socket_udp, test_08_so_txtime)
 	struct sockaddr_in6 bind_addr6;
 	int sock1, sock2, rv;
 	socklen_t optlen;
-	bool optval;
+	int optval;
 
 	prepare_sock_udp_v4(MY_IPV4_ADDR, 55555, &sock1, &bind_addr4);
 	prepare_sock_udp_v6(MY_IPV6_ADDR, 55555, &sock2, &bind_addr6);
@@ -1039,7 +1039,7 @@ ZTEST_USER(net_socket_udp, test_18_v6_sendmsg_with_txtime)
 {
 	int rv;
 	int client_sock;
-	bool optval;
+	int optval;
 	net_time_t txtime;
 	struct sockaddr_in6 client_addr;
 	struct msghdr msg;


### PR DESCRIPTION
Unify storing and loading of context options. Previously there were multiple functions doing the same thing. Fixed issue when getting txtime option (bool vs int variable).

Currently the code expects this:
* for bool value in options, user is expected to supply int variable and setting len sizeof(int)
* for uint8_t value, user is expected to supply uint8_t variable and setting len sizeof(uint8_t)
* for uint16_t value, user is expected to supply int variable and setting len sizeof(int)
