### PR TITLE
native boards: Minor docs improvements

### DIFF
--- a/boards/posix/doc/arch_soc.rst
+++ b/boards/posix/doc/arch_soc.rst
@@ -169,6 +169,24 @@ In the previous example, modifying the code as follows would work:
     #endif
    }
 
+.. _posix_arch_unsupported:
+
+Significant unsupported features
+********************************
+
+Currently, these are the most significant features which are not supported in this architecture:
+
+* :ref:`User mode/userspace <usermode_api>`: When building for these targets,
+  :kconfig:option:`CONFIG_USERSPACE` will always be disabled,
+  and all calls into the kernel will be done as normal calls.
+
+* Stack checks: :kconfig:option:`CONFIG_HW_STACK_PROTECTION`,
+  :kconfig:option:`CONFIG_STACK_CANARIES`, and
+  :kconfig:option:`CONFIG_THREAD_ANALYZER`.
+  This is due to how Zephyr allocated threads' stacks are not `actually` being used like they are
+  in other architectures. Check
+  :ref:`the architecture section's architecture layer paragraph <posix_arch_design_archl>`
+  for more information.
 
 .. _posix_arch_rationale:
 
@@ -293,6 +311,8 @@ Architecture and design
 
     Zephyr layering when built against an embedded target (left), and
     targeting a POSIX arch based board (right)
+
+.. _posix_arch_design_archl:
 
 Arch layer
 ==========

--- a/boards/posix/doc/bsim_boards_design.rst
+++ b/boards/posix/doc/bsim_boards_design.rst
@@ -167,12 +167,15 @@ The basic architecture layering of these boards is as follows:
     Overall architecture in a Zephyr application in an embedded target vs a bsim
     target
 
-Important limitations
-=====================
+Important limitations and unsupported features
+==============================================
 
 All native and bsim boards share the same set of
 :ref:`important limitations which<posix_arch_limitations>`
 are inherited from the POSIX arch and `inf_clock` design.
+
+Similarly, they inherit the POSIX architecture
+:ref:`unsupported features set <posix_arch_unsupported>`.
 
 .. _Threading:
 

--- a/boards/posix/native_sim/doc/index.rst
+++ b/boards/posix/native_sim/doc/index.rst
@@ -38,11 +38,17 @@ Please check the
 
 .. _nativesim_important_limitations:
 
-Important limitations
-*********************
+Important limitations and unsupported features
+**********************************************
 
 ``native_sim`` is based on the :ref:`POSIX architecture<Posix arch>`, and therefore
 :ref:`its limitations <posix_arch_limitations>` and considerations apply to it.
+
+Similarly, it inherits the POSIX architecture
+:ref:`unsupported features set <posix_arch_unsupported>`.
+
+Note that some drivers may have limitations, or may not support their whole driver API optional
+functionality.
 
 .. _native_sim_how_to_use:
 

--- a/boards/posix/native_sim/doc/index.rst
+++ b/boards/posix/native_sim/doc/index.rst
@@ -412,6 +412,8 @@ The following peripherals are currently provided with this board:
 
   .. code-block:: console
 
+     $ sudo dpkg --add-architecture i386
+     $ sudo apt update
      $ sudo apt-get install pkg-config libsdl2-dev:i386
      $ export PKG_CONFIG_PATH=/usr/lib/i386-linux-gnu/pkgconfig
 
@@ -595,6 +597,8 @@ these commands:
 
 .. code-block:: console
 
+   $ sudo dpkg --add-architecture i386
+   $ sudo apt update
    $ sudo apt-get install pkg-config libfuse-dev:i386
    $ export PKG_CONFIG_PATH=/usr/lib/i386-linux-gnu/pkgconfig
 


### PR DESCRIPTION
    boards native: Add not supported features
    
    Add a section with the most significant not supported features.

----

    native_sim: Improve instructions for i386 packages
    
    To the instructions that install "foreign architecture" (i386)
    packages on a x86-64 system, add the commands to ensure
    the architecture is added if it wasn't already.

Fixes: #65565