### PR TITLE
doc: doxygen: fix remaining warnings with Doxygen v1.9.1

### DIFF
--- a/include/zephyr/bluetooth/audio/cap.h
+++ b/include/zephyr/bluetooth/audio/cap.h
@@ -427,7 +427,7 @@ struct bt_cap_initiator_broadcast_create_param {
  * @brief Create a Common Audio Profile broadcast source.
  *
  * Create a new audio broadcast source with one or more audio streams.
- * * *
+ *
  * @note @kconfig{CONFIG_BT_CAP_INITIATOR} and
  * @kconfig{CONFIG_BT_BAP_BROADCAST_SOURCE} must be enabled for this function
  * to be enabled.
@@ -493,7 +493,7 @@ int bt_cap_initiator_broadcast_audio_update(struct bt_cap_broadcast_source *broa
  */
 int bt_cap_initiator_broadcast_audio_stop(struct bt_cap_broadcast_source *broadcast_source);
 
-/*
+/**
  * @brief Delete Common Audio Profile broadcast source
  *
  * This can only be done after the broadcast source has been stopped by calling

--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -35,27 +35,34 @@ extern "C" {
  *   - 1: I3C Controller capable
  *   - 2: Reserved
  *   - 3: Reserved
+ *   .
  * - BCR[5]: Advanced Capabilities
  *   - 0: Does not support optional advanced capabilities.
  *   - 1: Supports optional advanced capabilities which
  *        can be viewed via GETCAPS CCC.
- * - BCR[4}: Virtual Target Support
+ *   .
+ * - BCR[4]: Virtual Target Support
  *   - 0: Is not a virtual target.
  *   - 1: Is a virtual target.
+ *   .
  * - BCR[3]: Offline Capable
  *   - 0: Will always response to I3C commands.
  *   - 1: Will not always response to I3C commands.
+ *   .
  * - BCR[2]: IBI Payload
  *   - 0: No data bytes following the accepted IBI.
  *   - 1: One data byte (MDB, Mandatory Data Byte) follows
  *        the accepted IBI. Additional data bytes may also
  *        follows.
+ *   .
  * - BCR[1]: IBI Request Capable
  *   - 0: Not capable
  *   - 1: Capable
+ *   .
  * - BCR[0]: Max Data Speed Limitation
  *   - 0: No Limitation
  *   - 1: Limitation obtained via GETMXDS CCC.
+ *   .
  *
  * @{
  */

--- a/include/zephyr/drivers/interrupt_controller/intc_esp32.h
+++ b/include/zephyr/drivers/interrupt_controller/intc_esp32.h
@@ -249,7 +249,7 @@ int esp_intr_get_intno(struct intr_handle_data_t *handle);
  * @brief Disable the interrupt associated with the handle
  *
  * @note
- * 1. For local interrupts (ESP_INTERNAL_* sources), this function has to be called on the
+ * 1. For local interrupts (``ESP_INTERNAL_*`` sources), this function has to be called on the
  * CPU the interrupt is allocated on. Other interrupts have no such restriction.
  * 2. When several handlers sharing a same interrupt source, interrupt status bits, which are
  * handled in the handler to be disabled, should be masked before the disabling, or handled
@@ -266,7 +266,7 @@ int esp_intr_disable(struct intr_handle_data_t *handle);
 /**
  * @brief Enable the interrupt associated with the handle
  *
- * @note For local interrupts (ESP_INTERNAL_* sources), this function has to be called on the
+ * @note For local interrupts (``ESP_INTERNAL_*`` sources), this function has to be called on the
  *       CPU the interrupt is allocated on. Other interrupts have no such restriction.
  *
  * @param handle The handle, as obtained by esp_intr_alloc or esp_intr_alloc_intrstatus

--- a/include/zephyr/drivers/rtc/maxim_ds3231.h
+++ b/include/zephyr/drivers/rtc/maxim_ds3231.h
@@ -15,7 +15,7 @@
  *
  * The core Zephyr API to this device is as a counter, with the
  * following limitations:
- * * counter_read() and counter_*_alarm() cannot be invoked from
+ * * ``counter_read()`` and ``counter_*_alarm()`` cannot be invoked from
  *   interrupt context, as they require communication with the device
  *   over an I2C bus.
  * * many other counter APIs, such as start/stop/set_top_value are not


### PR DESCRIPTION
Fix remaining Doxygen warnings when using Doxygen v1.9.1. Please see commit logs for further details.