### PR TITLE
soc: arm: nordic_nrf: Remove deprecated GPREGRET Kconfig option

### DIFF
--- a/doc/releases/migration-guide-3.6.rst
+++ b/doc/releases/migration-guide-3.6.rst
@@ -14,6 +14,12 @@ the :ref:`release notes<zephyr_3.6>`.
 Required changes
 ****************
 
+Boards
+======
+
+  * The deprecated Nordic SoC Kconfig option ``NRF_STORE_REBOOT_TYPE_GPREGRET`` has been removed,
+    applications that use this should switch to using the :ref:`boot_mode_api` instead.
+
 Kernel
 ======
 

--- a/soc/arm/nordic_nrf/Kconfig
+++ b/soc/arm/nordic_nrf/Kconfig
@@ -167,17 +167,4 @@ config NRF_TRACE_PORT
 	  Unit) for tracing using a hardware probe. If disabled, the trace
 	  pins will be used as GPIO.
 
-config NRF_STORE_REBOOT_TYPE_GPREGRET
-	bool "Set GPREGRET to reboot type (DEPRECATED)"
-	depends on SOC_SERIES_NRF51X || SOC_SERIES_NRF52X
-	depends on REBOOT
-	depends on !RETENTION_BOOT_MODE
-	select DEPRECATED
-	help
-	  If this option is enabled, then the parameter supplied to the
-	  sys_reboot() function will be set in the GPREGRET register.
-
-	  This has been replaced with the bootmode part of the retention
-	  subsystem, which should be used instead.
-
 endif # SOC_FAMILY_NRF

--- a/soc/arm/nordic_nrf/nrf51/soc.c
+++ b/soc/arm/nordic_nrf/nrf51/soc.c
@@ -21,19 +21,6 @@
 #define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
 LOG_MODULE_REGISTER(soc);
 
-#ifdef CONFIG_NRF_STORE_REBOOT_TYPE_GPREGRET
-/* Overrides the weak ARM implementation:
- * Set general purpose retention register and reboot
- * This is deprecated and has been replaced with the boot mode retention
- * subsystem
- */
-void sys_arch_reboot(int type)
-{
-	nrf_power_gpregret_set(NRF_POWER, 0, (uint8_t)type);
-	NVIC_SystemReset();
-}
-#endif
-
 #define DELAY_CALL_OVERHEAD_US 2
 
 void arch_busy_wait(uint32_t time_us)

--- a/soc/arm/nordic_nrf/nrf52/soc.c
+++ b/soc/arm/nordic_nrf/nrf52/soc.c
@@ -23,19 +23,6 @@
 #define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
 LOG_MODULE_REGISTER(soc);
 
-#ifdef CONFIG_NRF_STORE_REBOOT_TYPE_GPREGRET
-/* Overrides the weak ARM implementation:
- * Set general purpose retention register and reboot
- * This is deprecated and has been replaced with the boot mode retention
- * subsystem
- */
-void sys_arch_reboot(int type)
-{
-	nrf_power_gpregret_set(NRF_POWER, 0, (uint8_t)type);
-	NVIC_SystemReset();
-}
-#endif
-
 static int nordicsemi_nrf52_init(void)
 {
 #ifdef CONFIG_NRF_ENABLE_ICACHE


### PR DESCRIPTION
    soc: arm: nordic_nrf: Remove deprecated GPREGRET Kconfig option
    
    Removes the Kconfig NRF_STORE_REBOOT_TYPE_GPREGRET which was
    deprecated in zephyr 3.4


    doc: migration-guide: 3.6: Add note on nrf Kconfig removal
    
    Adds a note on a now removed Nordic GPREGRET Kconfig which was
    deprecated in Zephyr 3.4
