### PR TITLE
maintainers: remove cfriedt as ti collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2864,7 +2864,6 @@ TI SimpleLink Platforms:
     - vaishnavachath
   collaborators:
     - vanti
-    - cfriedt
   files:
     - boards/arm/cc13*/
     - boards/arm/cc26*/
@@ -3486,8 +3485,6 @@ West:
   status: maintained
   maintainers:
     - vaishnavachath
-  collaborators:
-    - cfriedt
   files: []
   labels:
     - "platform: TI"


### PR DESCRIPTION
Just in an effort to reduce notifications in areas that I'm not super actively involved in. I was getting a lot of false positive notifications for sensors.

Feel free to ping me for individual reviews on simplelink parts or TI HAL or radio drivers.