### PR TITLE
release_notes: native_sim replaces native_posix

### DIFF
--- a/doc/releases/release-notes-3.6.rst
+++ b/doc/releases/release-notes-3.6.rst
@@ -293,5 +293,10 @@ Documentation
 Tests and Samples
 *****************
 
+* :ref:`native_sim<native_sim>` has replaced :ref:`native_posix<native_posix>` as the default
+  test platform.
+  :ref:`native_posix<native_posix>` remains supported and used in testing but will be deprecated
+  in a future release.
+
 * Fixed an issue in :zephyr:code-sample:`smp-svr` sample whereby if USB was already initialised,
   application would fail to boot properly.


### PR DESCRIPTION
Note that native_sim is replacing native_posix as default test platform.

Technically this is true only after https://github.com/zephyrproject-rtos/zephyr/pull/65866 is merged