### PR TITLE
doc: release: 3.6: Add new R-Car Gen4 SoC series

### DIFF
--- a/doc/releases/release-notes-3.6.rst
+++ b/doc/releases/release-notes-3.6.rst
@@ -59,6 +59,8 @@ Boards & SoC Support
 
 * Added support for these SoC series:
 
+  * Added support for Renesas R-Car Gen4 series
+
 * Removed support for these SoC series:
 
 * Made these changes in other SoC series:
@@ -66,6 +68,8 @@ Boards & SoC Support
 * Added support for these ARC boards:
 
 * Added support for these ARM boards:
+
+  * Added support for Renesas R-Car Spider board CR52: ``rcar_spider_cr52``
 
 * Added support for these ARM64 boards:
 
@@ -121,6 +125,8 @@ Drivers and Sensors
 
 * Clock control
 
+  * Renesas R-Car clock control driver now supports Gen4 SoCs
+
 * Counter
 
 * DAC
@@ -141,6 +147,8 @@ Drivers and Sensors
 
 * GPIO
 
+  * Renesas R-Car GPIO driver now supports Gen4 SoCs
+
 * I2C
 
 * I2S
@@ -158,6 +166,8 @@ Drivers and Sensors
 * ACPI
 
 * Pin control
+
+  * Renesas R-Car pinctrl driver now supports Gen4 SoCs
 
 * PWM
 


### PR DESCRIPTION
Added support to R-Car Gen4 SoCs & boards
Existing drivers now supports Gen4 SoCs