### PR TITLE
drivers: serial: stm32: Enable basic RX/TX FIFO

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1963,6 +1963,27 @@ static int uart_stm32_registers_configure(const struct device *dev)
 	}
 #endif
 
+#if defined(CONFIG_PM) && defined(IS_UART_WAKEUP_FROMSTOP_INSTANCE)
+	if (config->wakeup_source) {
+		/* Enable ability to wakeup device in Stop mode
+		 * Effect depends on CONFIG_PM_DEVICE status:
+		 * CONFIG_PM_DEVICE=n : Always active
+		 * CONFIG_PM_DEVICE=y : Controlled by pm_device_wakeup_enable()
+		 */
+#ifdef USART_CR3_WUFIE
+		LL_USART_SetWKUPType(config->usart, LL_USART_WAKEUP_ON_RXNE);
+		LL_USART_EnableIT_WKUP(config->usart);
+		LL_USART_ClearFlag_WKUP(config->usart);
+#endif
+		LL_USART_EnableInStopMode(config->usart);
+
+		if (config->wakeup_line != STM32_EXTI_LINE_NONE) {
+			/* Prepare the WAKEUP with the expected EXTI line */
+			LL_EXTI_EnableIT_0_31(BIT(config->wakeup_line));
+		}
+	}
+#endif /* CONFIG_PM */
+
 	LL_USART_Enable(config->usart);
 
 #ifdef USART_ISR_TEACK
@@ -2016,29 +2037,6 @@ static int uart_stm32_init(const struct device *dev)
 	defined(CONFIG_UART_ASYNC_API)
 	config->irq_config_func(dev);
 #endif /* CONFIG_PM || CONFIG_UART_INTERRUPT_DRIVEN || CONFIG_UART_ASYNC_API */
-
-#if defined(CONFIG_PM) && defined(IS_UART_WAKEUP_FROMSTOP_INSTANCE)
-	if (config->wakeup_source) {
-		/* Enable ability to wakeup device in Stop mode
-		 * Effect depends on CONFIG_PM_DEVICE status:
-		 * CONFIG_PM_DEVICE=n : Always active
-		 * CONFIG_PM_DEVICE=y : Controlled by pm_device_wakeup_enable()
-		 */
-#ifdef USART_CR3_WUFIE
-		LL_USART_Disable(config->usart);
-		LL_USART_SetWKUPType(config->usart, LL_USART_WAKEUP_ON_RXNE);
-		LL_USART_EnableIT_WKUP(config->usart);
-		LL_USART_ClearFlag_WKUP(config->usart);
-		LL_USART_Enable(config->usart);
-#endif
-		LL_USART_EnableInStopMode(config->usart);
-
-		if (config->wakeup_line != STM32_EXTI_LINE_NONE) {
-			/* Prepare the WAKEUP with the expected EXTI line */
-			LL_EXTI_EnableIT_0_31(BIT(config->wakeup_line));
-		}
-	}
-#endif /* CONFIG_PM */
 
 #ifdef CONFIG_UART_ASYNC_API
 	return uart_stm32_async_init(dev);

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1957,6 +1957,12 @@ static int uart_stm32_registers_configure(const struct device *dev)
 	}
 #endif
 
+#ifdef USART_CR1_FIFOEN
+	if (config->fifo_enable) {
+		LL_USART_EnableFIFO(config->usart);
+	}
+#endif
+
 	LL_USART_Enable(config->usart);
 
 #ifdef USART_ISR_TEACK
@@ -2335,6 +2341,7 @@ static const struct uart_stm32_config uart_stm32_cfg_##index = {	\
 	.de_assert_time = DT_INST_PROP(index, de_assert_time),		\
 	.de_deassert_time = DT_INST_PROP(index, de_deassert_time),	\
 	.de_invert = DT_INST_PROP(index, de_invert),			\
+	.fifo_enable = DT_INST_PROP(index, fifo_enable),		\
 	STM32_UART_IRQ_HANDLER_FUNC(index)				\
 	STM32_UART_PM_WAKEUP(index)					\
 };									\

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1634,7 +1634,7 @@ static int uart_stm32_async_tx_abort(const struct device *dev)
 		data->dma_tx.counter = tx_buffer_length - stat.pending_length;
 	}
 
-#ifdef CONFIG_UART_STM32U5_ERRATA_DMAT
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32u5_dma)
 	dma_suspend(data->dma_tx.dma_dev, data->dma_tx.dma_channel);
 #endif
 	dma_stop(data->dma_tx.dma_dev, data->dma_tx.dma_channel);

--- a/drivers/serial/uart_stm32.h
+++ b/drivers/serial/uart_stm32.h
@@ -49,6 +49,8 @@ struct uart_stm32_config {
 	uint8_t de_deassert_time;
 	/* enable de pin inversion */
 	bool de_invert;
+	/* enable fifo */
+	bool fifo_enable;
 	/* pin muxing */
 	const struct pinctrl_dev_config *pcfg;
 #if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API) || \

--- a/dts/bindings/serial/st,stm32-uart-base.yaml
+++ b/dts/bindings/serial/st,stm32-uart-base.yaml
@@ -86,3 +86,13 @@ properties:
     description: |
       Invert the binary logic of the de pin. When enabled, physical logic levels are inverted and
       we use 1=Low, 0=High instead of 1=High, 0=Low.
+
+  fifo-enable:
+    type: boolean
+    description: |
+      Enables transmit and receive FIFO using default FIFO confugration (typically threasholds
+      set to 1/8).
+      In TX, FIFO allows to work in burst mode, easing scheduling of loaded applications. It also
+      allows more reliable communication with UART devices sensitive to variation of inter-frames
+      delays.
+      In RX, FIFO reduces overrun occurences.

--- a/tests/drivers/uart/uart_async_api/boards/nucleo_wba52cg.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/nucleo_wba52cg.overlay
@@ -8,6 +8,7 @@ dut: &lpuart1 {
 	dmas = <&gpdma1 0 16 STM32_DMA_PERIPH_TX
 		&gpdma1 1 15 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
+	fifo-enable;
 };
 
 &gpdma1 {


### PR DESCRIPTION
On most STM32, a FIFO mode is available on U(S)ART blocks.
FIFO mode consists in a TX and RX FIFOs, each one 8 frames deep.

By enabling FIFO mode, both FIFOs will be used, using default threshold configuration.
No other change is made to the driver. 
In this case:
- TXE flag stands for TXFNF (TX empty become TXFIFO not full) 
- RXNE flag stands for RXFNE (RX not empty become RX Fifo not empty)
- same for matching interrupts

This has the following benefits:
In TX, FIFO allows to work in burst mode, easing scheduling of loaded applications. It also allows more reliable communication with UART devices sensitive to variation of inter-frames delays.
In RX, FIFO reduces overrun occurences.