### PR TITLE
drivers: regulator: fixed: Removed pin state setting from init

### DIFF
--- a/drivers/regulator/regulator_fixed.c
+++ b/drivers/regulator/regulator_fixed.c
@@ -84,12 +84,8 @@ static const struct regulator_driver_api regulator_fixed_api = {
 static int regulator_fixed_init(const struct device *dev)
 {
 	const struct regulator_fixed_config *cfg = dev->config;
-	bool init_enabled;
-	int ret;
 
 	regulator_common_data_init(dev);
-
-	init_enabled = regulator_common_is_init_enabled(dev);
 
 	if (cfg->enable.port != NULL) {
 		if (!gpio_is_ready_dt(&cfg->enable)) {
@@ -97,20 +93,14 @@ static int regulator_fixed_init(const struct device *dev)
 			return -ENODEV;
 		}
 
-		if (init_enabled) {
-			ret = gpio_pin_configure_dt(&cfg->enable, GPIO_OUTPUT_ACTIVE);
-			if (ret < 0) {
-				return ret;
-			}
-		} else {
-			ret = gpio_pin_configure_dt(&cfg->enable, GPIO_OUTPUT_INACTIVE);
-			if (ret < 0) {
-				return ret;
-			}
+		int ret = gpio_pin_configure_dt(&cfg->enable, GPIO_OUTPUT);
+
+		if (ret < 0) {
+			return ret;
 		}
 	}
 
-	return regulator_common_init(dev, init_enabled);
+	return regulator_common_init(dev, false);
 }
 
 #define REGULATOR_FIXED_DEFINE(inst)                                              \


### PR DESCRIPTION
The setting of initial state is handled by the common driver, which calls the enable function for any regulator that has regulator-boot-on set, and is not already enabled.