### PR TITLE
posix: pthread: add logging to pthread key

### DIFF
--- a/lib/posix/key.c
+++ b/lib/posix/key.c
@@ -7,6 +7,7 @@
 #include "posix_internal.h"
 
 #include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/posix/pthread.h>
 #include <zephyr/posix/pthread_key.h>
 #include <zephyr/sys/bitarray.h>
@@ -16,6 +17,8 @@ struct pthread_key_data {
 	sys_snode_t node;
 	pthread_thread_data thread_data;
 };
+
+LOG_MODULE_REGISTER(pthread_key, CONFIG_PTHREAD_KEY_LOG_LEVEL);
 
 static struct k_spinlock pthread_key_lock;
 
@@ -50,16 +53,19 @@ static pthread_key_obj *get_posix_key(pthread_key_t key)
 
 	/* if the provided cond does not claim to be initialized, its invalid */
 	if (!is_pthread_obj_initialized(key)) {
+		LOG_ERR("Key is uninitialized (%x)", key);
 		return NULL;
 	}
 
 	/* Mask off the MSB to get the actual bit index */
 	if (sys_bitarray_test_bit(&posix_key_bitarray, bit, &actually_initialized) < 0) {
+		LOG_ERR("Key is invalid (%x)", key);
 		return NULL;
 	}
 
 	if (actually_initialized == 0) {
 		/* The cond claims to be initialized but is actually not */
+		LOG_ERR("Key claims to be initialized (%x)", key);
 		return NULL;
 	}
 
@@ -110,6 +116,7 @@ int pthread_key_create(pthread_key_t *key,
 	sys_slist_init(&(new_key->key_data_l));
 
 	new_key->destructor = destructor;
+	LOG_DBG("Initialized key %p (%x)", new_key, *key);
 
 	return 0;
 }
@@ -146,6 +153,7 @@ int pthread_key_delete(pthread_key_t key)
 
 		/* Deallocate the object's memory */
 		k_free((void *)key_data);
+		LOG_DBG("Freed key data %p for key %x in thread %x", key_data, key, pthread_self());
 	}
 
 	bit = posix_key_to_offset(key_obj);
@@ -153,6 +161,8 @@ int pthread_key_delete(pthread_key_t key)
 	__ASSERT_NO_MSG(ret == 0);
 
 	k_spin_unlock(&pthread_key_lock, key_key);
+
+	LOG_DBG("Deleted key %p (%x)", key_obj, key);
 
 	return 0;
 }
@@ -194,6 +204,8 @@ int pthread_setspecific(pthread_key_t key, const void *value)
 				 * associate thread specific data
 				 */
 				thread_spec_data->spec_data = (void *)value;
+				LOG_DBG("Paired key %x to value %p for thread %x", key, value,
+					pthread_self());
 				goto out;
 			}
 	}
@@ -202,9 +214,13 @@ int pthread_setspecific(pthread_key_t key, const void *value)
 		key_data = k_malloc(sizeof(struct pthread_key_data));
 
 		if (key_data == NULL) {
+			LOG_ERR("Failed to allocate key data for key %x", key);
 			retval = ENOMEM;
 			goto out;
 		}
+
+		LOG_DBG("Allocated key data %p for key %x in thread %x", key_data, key,
+			pthread_self());
 
 		/* Associate thread specific data, initialize new key */
 		key_data->thread_data.key = key_obj;
@@ -215,6 +231,8 @@ int pthread_setspecific(pthread_key_t key, const void *value)
 
 		/* Append new key data to the key object's list */
 		sys_slist_append(&(key_obj->key_data_l), (sys_snode_t *)key_data);
+
+		LOG_DBG("Paired key %x to value %p for thread %x", key, value, pthread_self());
 	}
 
 out:

--- a/lib/posix/key.c
+++ b/lib/posix/key.c
@@ -204,20 +204,17 @@ int pthread_setspecific(pthread_key_t key, const void *value)
 		if (key_data == NULL) {
 			retval = ENOMEM;
 			goto out;
-
-		} else {
-			/* Associate thread specific data, initialize new key */
-			key_data->thread_data.key = key_obj;
-			key_data->thread_data.spec_data = (void *)value;
-
-			/* Append new thread key data to thread's key list */
-			sys_slist_append((&thread->key_list),
-				(sys_snode_t *)(&key_data->thread_data));
-
-			/* Append new key data to the key object's list */
-			sys_slist_append(&(key_obj->key_data_l),
-					(sys_snode_t *)key_data);
 		}
+
+		/* Associate thread specific data, initialize new key */
+		key_data->thread_data.key = key_obj;
+		key_data->thread_data.spec_data = (void *)value;
+
+		/* Append new thread key data to thread's key list */
+		sys_slist_append((&thread->key_list), (sys_snode_t *)(&key_data->thread_data));
+
+		/* Append new key data to the key object's list */
+		sys_slist_append(&(key_obj->key_data_l), (sys_snode_t *)key_data);
 	}
 
 out:


### PR DESCRIPTION
To align with other POSIX areas, add logging to facilitate better error reporting and diagnostics.