### PR TITLE
net: tcp: Fix possible race between TCP work items and context unref 

### DIFF
--- a/subsys/net/ip/tcp_private.h
+++ b/subsys/net/ip/tcp_private.h
@@ -274,6 +274,7 @@ struct tcp { /* TCP connection */
 	struct k_work_delayable timewait_timer;
 	struct k_work_delayable persist_timer;
 	struct k_work_delayable ack_timer;
+	struct k_work conn_release;
 
 	union {
 		/* Because FIN and establish timers are never happening

--- a/tests/net/socket/tcp/src/main.c
+++ b/tests/net/socket/tcp/src/main.c
@@ -2189,6 +2189,10 @@ static void test_ioctl_fionread_common(int af)
 		zassert_ok(ioctl(fd[i], ZFD_IOCTL_FIONREAD, &avail));
 		zassert_equal(0, avail, "exp: %d: act: %d", 0, avail);
 	}
+
+	close(fd[SERVER]);
+	close(fd[CLIENT]);
+	close(fd[ACCEPT]);
 }
 
 ZTEST(net_socket_tcp, test_ioctl_fionread_v4)

--- a/tests/net/socket/tcp/src/main.c
+++ b/tests/net/socket/tcp/src/main.c
@@ -1060,12 +1060,10 @@ ZTEST(net_socket_tcp, test_connect_timeout)
 
 	test_close(c_sock);
 
-	/* If we have preemptive option set, then sleep here in order to allow
-	 * other part of the system to run and update itself.
+	/* Sleep here in order to allow other part of the system to run and
+	 * update itself.
 	 */
-	if (IS_ENABLED(CONFIG_NET_TC_THREAD_PREEMPTIVE)) {
-		k_sleep(K_MSEC(10));
-	}
+	k_sleep(K_MSEC(10));
 
 	/* After the client socket closing, the context count should be 0 */
 	net_context_foreach(calc_net_context, &count_after);

--- a/tests/net/tcp/src/main.c
+++ b/tests/net/tcp/src/main.c
@@ -1718,6 +1718,9 @@ static void check_rst_succeed(struct net_context *ctx,
 
 	net_context_put(ctx);
 	net_context_put(accepted_ctx);
+
+	/* Let other threads run (so the TCP context is actually freed) */
+	k_msleep(10);
 }
 
 ZTEST(net_tcp, test_client_invalid_rst)


### PR DESCRIPTION
Fix the possible race between TCP work items already scheduled for
execution, and tcp_conn_unref(), by moving the actual TCP context
releasing to the workqueue itself. That way we can be certain, that when
the work items are cancelled, they won't execute. It could be the case,
that the work item was already being processed by the work queue, so
clearing the context could lead to a crash.

Remove the comments around the mutex lock in the work handlers regarding
the race, as it's not the case anymore. I've kept the locks however, as
they do make sense in those places.

Fixes #59752