### PR TITLE
dts: arm: nxp: rt1015: correct FlexRAM bank allocation

### DIFF
--- a/dts/arm/nxp/nxp_rt1015.dtsi
+++ b/dts/arm/nxp/nxp_rt1015.dtsi
@@ -8,10 +8,13 @@
 #include <nxp/nxp_rt10xx.dtsi>
 
 &flexram {
-	flexram,num-ram-banks = <4>;
-	/* default fuse */
+	flexram,num-ram-banks = <5>;
+	/* Note: RT1015 has five flexram banks, but only 4 of the 5 can
+	 * be used at the same time, for a total of 128KB of RAM.
+	 */
 	flexram,bank-spec = <FLEXRAM_OCRAM>,
 			     <FLEXRAM_OCRAM>,
+			     <FLEXRAM_DTCM>,
 			     <FLEXRAM_DTCM>,
 			     <FLEXRAM_ITCM>;
 };
@@ -25,7 +28,7 @@
 };
 
 &dtcm {
-	reg = <0x20000000 DT_SIZE_K(32)>;
+	reg = <0x20000000 DT_SIZE_K(64)>;
 };
 
 &ocram {


### PR DESCRIPTION
Although the RT1015 only supports 128 KB of FlexRAM being used at once, the default fusemap overallocates 160KB of FlexRAM. The JLink flashloader algorithm appears to rely on the 64KB of DTCM in the default fusemap being configured. Reducing the DTCM allocation resulted in JLink failing to flash the SOC.

To resolve this, utilize the default fusemap of {O, O, D, D, I} for the RT1015 FlexRAM setup. Add a note about the restrictions on using overallocated FlexRAM to the SOC DTSI.

Fixes #65889