### PR TITLE
MAINTAINERS: fix missing asterisk for STM32 driver matching

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2806,7 +2806,7 @@ STM32 Platforms:
     - drivers/*/*stm32*.c
     - drivers/*/*stm32*.h
     - drivers/*/*/*stm32*
-    - drivers/*/*stm32
+    - drivers/*/*stm32*
     - dts/arm/st/
     - dts/bindings/*/*stm32*
     - soc/arm/st_stm32/


### PR DESCRIPTION
There is a missing asterisk for one of the driver matching pattern for STM32. So fix that.