### PR TITLE
tests: cpp: Exclude cpp2B testcase for xt-clang toolchain

### DIFF
--- a/tests/lib/cpp/cxx/testcase.yaml
+++ b/tests/lib/cpp/cxx/testcase.yaml
@@ -60,6 +60,8 @@ tests:
       - CONFIG_STD_CPP20=y
   cpp.main.cpp2B:
     arch_exclude: posix
+    toolchain_exclude:
+      - xt-clang
     build_only: true
     extra_configs:
       - CONFIG_STD_CPP2B=y


### PR DESCRIPTION
c++2B standard is not supported for xt clang compiler so
exclude cpp2B testcase for xt-clang toolchain.

Signed-off-by: Aastha Grover <aastha.grover@intel.com>
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
