### PR TITLE
xcc/cmake: don't discard stderr; don't (ever!) use ERROR_QUIET

### DIFF
--- a/cmake/compiler/xcc/generic.cmake
+++ b/cmake/compiler/xcc/generic.cmake
@@ -18,12 +18,12 @@ endif()
 execute_process(
   COMMAND ${CMAKE_C_COMPILER} --version
   RESULT_VARIABLE ret
-  OUTPUT_QUIET
-  ERROR_QUIET
+  OUTPUT_VARIABLE stdoutput
   )
 if(ret)
   message(FATAL_ERROR "Executing the below command failed. Are permissions set correctly?
-'${CMAKE_C_COMPILER} --version'
+  ${CMAKE_C_COMPILER} --version
+  ${stdoutput}
 "
     )
 endif()


### PR DESCRIPTION
Remove ERROR_QUIET which is a bad idea 99.9% of the time. When any program makes the effort of using stderr, we _really_ don't want to lose those error messages.

Using ERROR_QUIET in XCC is even worse because of how high maintenance XCC is; see another example in 4cba9e6d425e ("cmake: warn the user that the toolchain cache hides errors")

No one expects error messages to be silently discarded and especially not people not familiar with CMake (= most people); so hiding the following error stalled progress for a couple days:

```
Error: there is no Xtensa core registered as the default.

You need to either specify the name of a registered Xtensa core (with
the --xtensa-core option or the XTENSA_CORE environment variable) or
specify a different registry of Xtensa cores (with the --xtensa-system
option or the XTENSA_SYSTEM environment variable).

Executing the below command failed.  Are permissions set correctly?
```

Also capture stdout and print it on failure because you never know.

Indent the ` ${CMAKE_C_COMPILER} --version` line in the error message so CMake does not split that line.