### PR TITLE
drivers: gpio: Add Ambiq GPIO driver

### DIFF
--- a/boards/arm/apollo4p_evb/apollo4p_evb.dts
+++ b/boards/arm/apollo4p_evb/apollo4p_evb.dts
@@ -21,6 +21,8 @@
 		led0 = &led0;
 		led1 = &led1;
 		led2 = &led2;
+		sw0 = &button0;
+		sw1 = &button1;
 	};
 
 	leds {
@@ -39,6 +41,17 @@
 		};
 	};
 
+	buttons {
+		compatible = "gpio-keys";
+		button0: button_0 {
+			gpios = <&gpio0_31 18 GPIO_ACTIVE_LOW>;
+			label = "BTN0";
+		};
+		button1: button_1 {
+			gpios = <&gpio0_31 19 GPIO_ACTIVE_LOW>;
+			label = "BTN1";
+		};
+	};
 };
 
 &uart0 {

--- a/boards/arm/apollo4p_evb/apollo4p_evb.dts
+++ b/boards/arm/apollo4p_evb/apollo4p_evb.dts
@@ -6,6 +6,7 @@
 / {
 	model = "Ambiq Apollo4 Plus evaluation board";
 	compatible = "ambiq,apollo4p_evb";
+
 	chosen {
 		zephyr,itcm = &tcm;
 		zephyr,sram = &sram0;
@@ -14,9 +15,30 @@
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-pipe = &uart0;
 	};
+
 	aliases {
 		watchdog0 = &wdt0;
+		led0 = &led0;
+		led1 = &led1;
+		led2 = &led2;
 	};
+
+	leds {
+		compatible = "gpio-leds";
+		led0: led_0 {
+			gpios = <&gpio0_31 30 GPIO_ACTIVE_LOW>;
+			label = "LED 0";
+		};
+		led1: led_1 {
+			gpios = <&gpio64_95 26 GPIO_ACTIVE_LOW>;
+			label = "LED 1";
+		};
+		led2: led_2 {
+			gpios = <&gpio96_127 1 GPIO_ACTIVE_LOW>;
+			label = "LED 2";
+		};
+	};
+
 };
 
 &uart0 {

--- a/boards/arm/apollo4p_evb/apollo4p_evb.dts
+++ b/boards/arm/apollo4p_evb/apollo4p_evb.dts
@@ -55,3 +55,19 @@
 	pinctrl-names = "default";
 	status = "okay";
 };
+
+&gpio0_31 {
+	status = "okay";
+};
+
+&gpio32_63 {
+	status = "okay";
+};
+
+&gpio64_95 {
+	status = "okay";
+};
+
+&gpio96_127 {
+	status = "okay";
+};

--- a/drivers/gpio/CMakeLists.txt
+++ b/drivers/gpio/CMakeLists.txt
@@ -89,6 +89,7 @@ zephyr_library_sources_ifdef(CONFIG_GPIO_ALTERA_PIO gpio_altera_pio.c)
 zephyr_library_sources_ifdef(CONFIG_GPIO_BCM2711    gpio_bcm2711.c)
 zephyr_library_sources_ifdef(CONFIG_GPIO_RA         gpio_ra.c)
 zephyr_library_sources_ifdef(CONFIG_GPIO_RZT2M    gpio_rzt2m.c)
+zephyr_library_sources_ifdef(CONFIG_GPIO_AMBIQ      gpio_ambiq.c)
 
 if (CONFIG_GPIO_EMUL_SDL)
   zephyr_library_sources(gpio_emul_sdl.c)

--- a/drivers/gpio/Kconfig
+++ b/drivers/gpio/Kconfig
@@ -236,4 +236,6 @@ source "drivers/gpio/Kconfig.ra"
 
 source "drivers/gpio/Kconfig.rzt2m"
 
+source "drivers/gpio/Kconfig.ambiq"
+
 endif # GPIO

--- a/drivers/gpio/Kconfig.ambiq
+++ b/drivers/gpio/Kconfig.ambiq
@@ -1,0 +1,14 @@
+# Ambiq SDK GPIO
+#
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+config GPIO_AMBIQ
+	bool "AMBIQ GPIO driver"
+	default y
+	depends on DT_HAS_AMBIQ_GPIO_ENABLED
+	select AMBIQ_HAL
+	help
+	  Enable driver for Ambiq gpio.

--- a/drivers/gpio/gpio_ambiq.c
+++ b/drivers/gpio/gpio_ambiq.c
@@ -253,8 +253,6 @@ static int ambiq_gpio_pin_interrupt_configure(const struct device *dev, gpio_pin
 		pincfg.GP.cfg_b.eIntDir = AM_HAL_GPIO_PIN_INTDIR_NONE;
 		ret = am_hal_gpio_pinconfig(gpio_pin, pincfg);
 
-		irq_disable(dev_cfg->irq_num);
-
 		k_spinlock_key_t key = k_spin_lock(&data->lock);
 
 		ret = am_hal_gpio_interrupt_irq_status_get(dev_cfg->irq_num, false, &int_status);

--- a/drivers/gpio/gpio_ambiq.c
+++ b/drivers/gpio/gpio_ambiq.c
@@ -1,0 +1,354 @@
+/*
+ * Copyright (c) 2023 Antmicro <www.antmicro.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT ambiq_gpio
+
+#include <errno.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/gpio/gpio_utils.h>
+#include <zephyr/irq.h>
+#include <zephyr/spinlock.h>
+
+#include <am_mcu_apollo.h>
+
+typedef void (*ambiq_gpio_cfg_func_t)(void);
+
+struct ambiq_gpio_config {
+	struct gpio_driver_config common;
+	uint32_t base;
+	uint32_t pin_offset;
+	uint32_t irq_num;
+	ambiq_gpio_cfg_func_t cfg_func;
+	uint8_t ngpios;
+};
+
+struct ambiq_gpio_data {
+	struct gpio_driver_data common;
+	sys_slist_t cb;
+	struct k_spinlock lock;
+};
+
+static int ambiq_gpio_pin_configure(const struct device *dev, gpio_pin_t pin, gpio_flags_t flags)
+{
+	const struct ambiq_gpio_config *const dev_cfg = dev->config;
+
+	pin += dev_cfg->pin_offset;
+
+	am_hal_gpio_pincfg_t pincfg = am_hal_gpio_pincfg_default;
+
+	if (flags & GPIO_INPUT) {
+		pincfg = am_hal_gpio_pincfg_input;
+		if (flags & GPIO_PULL_UP) {
+			pincfg.GP.cfg_b.ePullup = AM_HAL_GPIO_PIN_PULLUP_50K;
+		} else if (flags & GPIO_PULL_DOWN) {
+			pincfg.GP.cfg_b.ePullup = AM_HAL_GPIO_PIN_PULLDOWN_50K;
+		}
+	}
+	if (flags & GPIO_OUTPUT) {
+		if (flags & GPIO_SINGLE_ENDED) {
+			if (flags & GPIO_LINE_OPEN_DRAIN) {
+				pincfg.GP.cfg_b.eGPOutCfg = AM_HAL_GPIO_PIN_OUTCFG_OPENDRAIN;
+			}
+		} else {
+			pincfg.GP.cfg_b.eGPOutCfg = AM_HAL_GPIO_PIN_OUTCFG_PUSHPULL;
+		}
+	}
+	if (flags & GPIO_DISCONNECTED) {
+		pincfg = am_hal_gpio_pincfg_disabled;
+	}
+
+	if (flags & GPIO_OUTPUT_INIT_HIGH) {
+		pincfg.GP.cfg_b.eCEpol = AM_HAL_GPIO_PIN_CEPOL_ACTIVEHIGH;
+		am_hal_gpio_state_write(pin, AM_HAL_GPIO_OUTPUT_SET);
+
+	} else if (flags & GPIO_OUTPUT_INIT_LOW) {
+		pincfg.GP.cfg_b.eCEpol = AM_HAL_GPIO_PIN_CEPOL_ACTIVELOW;
+		am_hal_gpio_state_write(pin, AM_HAL_GPIO_OUTPUT_CLEAR);
+	}
+
+	am_hal_gpio_pinconfig(pin, pincfg);
+
+	return 0;
+}
+
+#ifdef CONFIG_GPIO_GET_CONFIG
+static int ambiq_gpio_get_config(const struct device *dev, gpio_pin_t pin, gpio_flags_t *out_flags)
+{
+	const struct ambiq_gpio_config *const dev_cfg = dev->config;
+	am_hal_gpio_pincfg_t pincfg;
+
+	pin += dev_cfg->pin_offset;
+
+	am_hal_gpio_pinconfig_get(pin, &pincfg);
+
+	if (pincfg.GP.cfg_b.eGPOutCfg == AM_HAL_GPIO_PIN_OUTCFG_DISABLE &&
+	    pincfg.GP.cfg_b.eGPInput == AM_HAL_GPIO_PIN_INPUT_NONE) {
+		*out_flags = GPIO_DISCONNECTED;
+	}
+	if (pincfg.GP.cfg_b.eGPInput == AM_HAL_GPIO_PIN_INPUT_ENABLE) {
+		*out_flags = GPIO_INPUT;
+		if (pincfg.GP.cfg_b.ePullup == AM_HAL_GPIO_PIN_PULLUP_50K) {
+			*out_flags |= GPIO_PULL_UP;
+		} else if (pincfg.GP.cfg_b.ePullup == AM_HAL_GPIO_PIN_PULLDOWN_50K) {
+			*out_flags |= GPIO_PULL_DOWN;
+		}
+	}
+	if (pincfg.GP.cfg_b.eGPOutCfg == AM_HAL_GPIO_PIN_OUTCFG_PUSHPULL) {
+		*out_flags = GPIO_OUTPUT | GPIO_PUSH_PULL;
+		if (pincfg.GP.cfg_b.eCEpol == AM_HAL_GPIO_PIN_CEPOL_ACTIVEHIGH) {
+			*out_flags |= GPIO_OUTPUT_HIGH;
+		} else if (pincfg.GP.cfg_b.eCEpol == AM_HAL_GPIO_PIN_CEPOL_ACTIVELOW) {
+			*out_flags |= GPIO_OUTPUT_LOW;
+		}
+	}
+	if (pincfg.GP.cfg_b.eGPOutCfg == AM_HAL_GPIO_PIN_OUTCFG_OPENDRAIN) {
+		*out_flags = GPIO_OUTPUT | GPIO_OPEN_DRAIN;
+		if (pincfg.GP.cfg_b.eCEpol == AM_HAL_GPIO_PIN_CEPOL_ACTIVEHIGH) {
+			*out_flags |= GPIO_OUTPUT_HIGH;
+		} else if (pincfg.GP.cfg_b.eCEpol == AM_HAL_GPIO_PIN_CEPOL_ACTIVELOW) {
+			*out_flags |= GPIO_OUTPUT_LOW;
+		}
+	}
+
+	return 0;
+}
+#endif
+
+#ifdef CONFIG_GPIO_GET_DIRECTION
+static int ambiq_gpio_port_get_direction(const struct device *dev, gpio_port_pins_t map,
+					 gpio_port_pins_t *inputs, gpio_port_pins_t *outputs)
+{
+	const struct ambiq_gpio_config *const dev_cfg = dev->config;
+	am_hal_gpio_pincfg_t pincfg;
+	gpio_port_pins_t ip = 0;
+	gpio_port_pins_t op = 0;
+
+	if (inputs != NULL) {
+		for (int i = 0; i < dev_cfg->ngpios; i++) {
+			if ((map >> i) & 1) {
+				am_hal_gpio_pinconfig_get(i + dev_cfg->pin_offset, &pincfg);
+				if (pincfg.GP.cfg_b.eGPInput == AM_HAL_GPIO_PIN_INPUT_ENABLE) {
+					ip |= BIT(i);
+				}
+			}
+		}
+		*inputs = ip;
+	}
+	if (outputs != NULL) {
+		for (int i = 0; i < dev_cfg->ngpios; i++) {
+			if ((map >> i) & 1) {
+				am_hal_gpio_pinconfig_get(i + dev_cfg->pin_offset, &pincfg);
+				if (pincfg.GP.cfg_b.eGPOutCfg == AM_HAL_GPIO_PIN_OUTCFG_PUSHPULL ||
+				    pincfg.GP.cfg_b.eGPOutCfg == AM_HAL_GPIO_PIN_OUTCFG_OPENDRAIN) {
+					op |= BIT(i);
+				}
+			}
+		}
+		*outputs = op;
+	}
+
+	return 0;
+}
+#endif
+
+static int ambiq_gpio_port_get_raw(const struct device *dev, gpio_port_value_t *value)
+{
+	const struct ambiq_gpio_config *const dev_cfg = dev->config;
+
+	*value = (*AM_HAL_GPIO_RDn(dev_cfg->pin_offset));
+
+	return 0;
+}
+
+static int ambiq_gpio_port_set_masked_raw(const struct device *dev, gpio_port_pins_t mask,
+					  gpio_port_value_t value)
+{
+	const struct ambiq_gpio_config *const dev_cfg = dev->config;
+
+	for (int i = 0; i < dev_cfg->ngpios; i++) {
+		if ((mask >> i) & 1) {
+			am_hal_gpio_state_write(i + dev_cfg->pin_offset, ((value >> i) & 1));
+		}
+	}
+
+	return 0;
+}
+
+static int ambiq_gpio_port_set_bits_raw(const struct device *dev, gpio_port_pins_t pins)
+{
+	const struct ambiq_gpio_config *const dev_cfg = dev->config;
+
+	for (int i = 0; i < dev_cfg->ngpios; i++) {
+		if ((pins >> i) & 1) {
+			am_hal_gpio_state_write(i + dev_cfg->pin_offset, AM_HAL_GPIO_OUTPUT_SET);
+		}
+	}
+
+	return 0;
+}
+
+static int ambiq_gpio_port_clear_bits_raw(const struct device *dev, gpio_port_pins_t pins)
+{
+	const struct ambiq_gpio_config *const dev_cfg = dev->config;
+
+	for (int i = 0; i < dev_cfg->ngpios; i++) {
+		if ((pins >> i) & 1) {
+			am_hal_gpio_state_write(i + dev_cfg->pin_offset, AM_HAL_GPIO_OUTPUT_CLEAR);
+		}
+	}
+
+	return 0;
+}
+
+static int ambiq_gpio_port_toggle_bits(const struct device *dev, gpio_port_pins_t pins)
+{
+	const struct ambiq_gpio_config *const dev_cfg = dev->config;
+
+	for (int i = 0; i < dev_cfg->ngpios; i++) {
+		if ((pins >> i) & 1) {
+			am_hal_gpio_state_write(i + dev_cfg->pin_offset, AM_HAL_GPIO_OUTPUT_TOGGLE);
+		}
+	}
+
+	return 0;
+}
+
+static void ambiq_gpio_isr(const struct device *dev)
+{
+	struct ambiq_gpio_data *const data = dev->data;
+	const struct ambiq_gpio_config *const dev_cfg = dev->config;
+
+	uint32_t int_status;
+
+	am_hal_gpio_interrupt_irq_status_get(dev_cfg->irq_num, false, &int_status);
+	am_hal_gpio_interrupt_irq_clear(dev_cfg->irq_num, int_status);
+
+	gpio_fire_callbacks(&data->cb, dev, int_status);
+}
+
+static int ambiq_gpio_pin_interrupt_configure(const struct device *dev, gpio_pin_t pin,
+					      enum gpio_int_mode mode, enum gpio_int_trig trig)
+{
+	const struct ambiq_gpio_config *const dev_cfg = dev->config;
+	struct ambiq_gpio_data *const data = dev->data;
+
+	am_hal_gpio_pincfg_t pincfg;
+	int gpio_pin = pin + dev_cfg->pin_offset;
+	uint32_t int_status;
+	int ret;
+
+	ret = am_hal_gpio_pinconfig_get(gpio_pin, &pincfg);
+
+	if (mode == GPIO_INT_MODE_DISABLED) {
+		pincfg.GP.cfg_b.eIntDir = AM_HAL_GPIO_PIN_INTDIR_NONE;
+		ret = am_hal_gpio_pinconfig(gpio_pin, pincfg);
+
+		irq_disable(dev_cfg->irq_num);
+
+		k_spinlock_key_t key = k_spin_lock(&data->lock);
+
+		ret = am_hal_gpio_interrupt_irq_status_get(dev_cfg->irq_num, false, &int_status);
+		ret = am_hal_gpio_interrupt_irq_clear(dev_cfg->irq_num, int_status);
+		ret = am_hal_gpio_interrupt_control(AM_HAL_GPIO_INT_CHANNEL_0,
+						    AM_HAL_GPIO_INT_CTRL_INDV_DISABLE,
+						    (void *)&gpio_pin);
+		k_spin_unlock(&data->lock, key);
+
+	} else {
+		if (mode == GPIO_INT_MODE_LEVEL) {
+			return -ENOTSUP;
+		}
+		switch (trig) {
+		case GPIO_INT_TRIG_LOW:
+			pincfg.GP.cfg_b.eIntDir = AM_HAL_GPIO_PIN_INTDIR_HI2LO;
+			break;
+		case GPIO_INT_TRIG_HIGH:
+			pincfg.GP.cfg_b.eIntDir = AM_HAL_GPIO_PIN_INTDIR_LO2HI;
+			break;
+		case GPIO_INT_TRIG_BOTH:
+			return -ENOTSUP;
+		}
+		ret = am_hal_gpio_pinconfig(gpio_pin, pincfg);
+
+		irq_enable(dev_cfg->irq_num);
+
+		k_spinlock_key_t key = k_spin_lock(&data->lock);
+
+		ret = am_hal_gpio_interrupt_irq_status_get(dev_cfg->irq_num, false, &int_status);
+		ret = am_hal_gpio_interrupt_irq_clear(dev_cfg->irq_num, int_status);
+		ret = am_hal_gpio_interrupt_control(AM_HAL_GPIO_INT_CHANNEL_0,
+						    AM_HAL_GPIO_INT_CTRL_INDV_ENABLE,
+						    (void *)&gpio_pin);
+		k_spin_unlock(&data->lock, key);
+	}
+	return ret;
+}
+
+static int ambiq_gpio_manage_callback(const struct device *dev, struct gpio_callback *callback,
+				      bool set)
+{
+	struct ambiq_gpio_data *const data = dev->data;
+
+	return gpio_manage_callback(&data->cb, callback, set);
+}
+
+static int ambiq_gpio_init(const struct device *port)
+{
+	const struct ambiq_gpio_config *const dev_cfg = port->config;
+
+	NVIC_ClearPendingIRQ(dev_cfg->irq_num);
+
+	dev_cfg->cfg_func();
+
+	return 0;
+}
+
+static const struct gpio_driver_api ambiq_gpio_drv_api = {
+	.pin_configure = ambiq_gpio_pin_configure,
+#ifdef CONFIG_GPIO_GET_CONFIG
+	.pin_get_config = ambiq_gpio_get_config,
+#endif
+	.port_get_raw = ambiq_gpio_port_get_raw,
+	.port_set_masked_raw = ambiq_gpio_port_set_masked_raw,
+	.port_set_bits_raw = ambiq_gpio_port_set_bits_raw,
+	.port_clear_bits_raw = ambiq_gpio_port_clear_bits_raw,
+	.port_toggle_bits = ambiq_gpio_port_toggle_bits,
+	.pin_interrupt_configure = ambiq_gpio_pin_interrupt_configure,
+	.manage_callback = ambiq_gpio_manage_callback,
+#ifdef CONFIG_GPIO_GET_DIRECTION
+	.port_get_direction = ambiq_gpio_port_get_direction,
+#endif
+};
+
+#define AMBIQ_GPIO_DEFINE(n)                                                                       \
+	static struct ambiq_gpio_data ambiq_gpio_data_##n;                                         \
+	static void ambiq_gpio_cfg_func_##n(void);                                                 \
+                                                                                                   \
+	static const struct ambiq_gpio_config ambiq_gpio_config_##n = {                            \
+		.common =                                                                          \
+			{                                                                          \
+				.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(n),               \
+			},                                                                         \
+		.base = DT_REG_ADDR(DT_INST_PARENT(n)),                                            \
+		.pin_offset = DT_INST_REG_ADDR(n),                                                 \
+		.ngpios = DT_INST_PROP(n, ngpios),                                                 \
+		.irq_num = DT_INST_IRQN(n),                                                        \
+		.cfg_func = ambiq_gpio_cfg_func_##n};                                              \
+	static void ambiq_gpio_cfg_func_##n(void)                                                  \
+	{                                                                                          \
+                                                                                                   \
+		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority), ambiq_gpio_isr,             \
+			    DEVICE_DT_INST_GET(n), 0);                                             \
+                                                                                                   \
+		return;                                                                            \
+	};                                                                                         \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(n, &ambiq_gpio_init, NULL, &ambiq_gpio_data_##n,                     \
+			      &ambiq_gpio_config_##n, PRE_KERNEL_1, CONFIG_GPIO_INIT_PRIORITY,     \
+			      &ambiq_gpio_drv_api);
+
+DT_INST_FOREACH_STATUS_OKAY(AMBIQ_GPIO_DEFINE)

--- a/dts/arm/ambiq/ambiq_apollo4p.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo4p.dtsi
@@ -210,40 +210,57 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 
-			gpio0_31: gpio0_31@0 {
+			gpio: gpio@40010000 {
 				compatible = "ambiq,gpio";
-				gpio-controller;
+				gpio-map-mask = <0xffffffe0 0xffffffc0>;
+				gpio-map-pass-thru = <0x1f 0x3f>;
+				gpio-map = <
+					0x00 0x0 &gpio0_31 0x0 0x0
+					0x20 0x0 &gpio32_63 0x0 0x0
+					0x40 0x0 &gpio64_95 0x0 0x0
+					0x60 0x0 &gpio96_127 0x0 0x0
+				>;
+				reg = <0x40010000>;
 				#gpio-cells = <2>;
-				reg = <0>;
-				interrupts = <56 0>;
-				status = "disabled";
-			};
+				#address-cells = <1>;
+				#size-cells = <0>;
+				ranges;
 
-			gpio32_63: gpio32_63@20 {
-				compatible = "ambiq,gpio";
-				gpio-controller;
-				#gpio-cells = <2>;
-				reg = <32>;
-				interrupts = <57 0>;
-				status = "disabled";
-			};
+				gpio0_31: gpio0_31@0 {
+					compatible = "ambiq,gpio-bank";
+					gpio-controller;
+					#gpio-cells = <2>;
+					reg = <0>;
+					interrupts = <56 0>;
+					status = "disabled";
+				};
 
-			gpio64_95: gpio64_95@40 {
-				compatible = "ambiq,gpio";
-				gpio-controller;
-				#gpio-cells = <2>;
-				reg = <64>;
-				interrupts = <58 0>;
-				status = "disabled";
-			};
+				gpio32_63: gpio32_63@80 {
+					compatible = "ambiq,gpio-bank";
+					gpio-controller;
+					#gpio-cells = <2>;
+					reg = <0x80>;
+					interrupts = <57 0>;
+					status = "disabled";
+				};
 
-			gpio96_127: gpio96_127@60 {
-				compatible = "ambiq,gpio";
-				gpio-controller;
-				#gpio-cells = <2>;
-				reg = <96>;
-				interrupts = <59 0>;
-				status = "disabled";
+				gpio64_95: gpio64_95@100 {
+					compatible = "ambiq,gpio-bank";
+					gpio-controller;
+					#gpio-cells = <2>;
+					reg = <0x100>;
+					interrupts = <58 0>;
+					status = "disabled";
+				};
+
+				gpio96_127: gpio96_127@180 {
+					compatible = "ambiq,gpio-bank";
+					gpio-controller;
+					#gpio-cells = <2>;
+					reg = <0x180>;
+					interrupts = <59 0>;
+					status = "disabled";
+				};
 			};
 		};
 

--- a/dts/arm/ambiq/ambiq_apollo4p.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo4p.dtsi
@@ -3,6 +3,7 @@
 #include <arm/armv7-m.dtsi>
 #include <mem.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 
 / {
 	clocks {
@@ -206,6 +207,44 @@
 		pinctrl: pin-controller@40010000 {
 			compatible = "ambiq,apollo4-pinctrl";
 			reg = <0x40010000 0x800>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			gpio0_31: gpio0_31@0 {
+				compatible = "ambiq,gpio";
+				gpio-controller;
+				#gpio-cells = <2>;
+				reg = <0>;
+				interrupts = <56 0>;
+				status = "disabled";
+			};
+
+			gpio32_63: gpio32_63@20 {
+				compatible = "ambiq,gpio";
+				gpio-controller;
+				#gpio-cells = <2>;
+				reg = <32>;
+				interrupts = <57 0>;
+				status = "disabled";
+			};
+
+			gpio64_95: gpio64_95@40 {
+				compatible = "ambiq,gpio";
+				gpio-controller;
+				#gpio-cells = <2>;
+				reg = <64>;
+				interrupts = <58 0>;
+				status = "disabled";
+			};
+
+			gpio96_127: gpio96_127@60 {
+				compatible = "ambiq,gpio";
+				gpio-controller;
+				#gpio-cells = <2>;
+				reg = <96>;
+				interrupts = <59 0>;
+				status = "disabled";
+			};
 		};
 
 		wdt0: watchdog@40024000 {

--- a/dts/bindings/gpio/ambiq,gpio-bank.yaml
+++ b/dts/bindings/gpio/ambiq,gpio-bank.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# Copyright (c) 2023 Ambiq Micro Inc. <www.ambiq.com>
+# SPDX-License-Identifier: Apache-2.0
+
+description: Ambiq GPIO bank node
+
+compatible: "ambiq,gpio-bank"
+
+include: [gpio-controller.yaml, base.yaml]
+
+properties:
+  reg:
+    required: true
+    description: |
+      This property indicates the register address offset of each GPIO child node
+      under the "ambiq,gpio" parent node. The register address of pin described in
+      gpio-cells can be obtained by: base address + child address offset + (pin << 2).
+
+  "#gpio-cells":
+    const: 2
+
+gpio-cells:
+  - pin
+  - flags

--- a/dts/bindings/gpio/ambiq,gpio.yaml
+++ b/dts/bindings/gpio/ambiq,gpio.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: Apache-2.0
+
+description: Ambiq GPIO
+
+compatible: "ambiq,gpio"
+
+include: [gpio-controller.yaml, base.yaml]
+
+properties:
+  reg:
+    required: true
+    description: GPIO pin offset
+
+  "#gpio-cells":
+    const: 2
+
+gpio-cells:
+  - pin
+  - flags

--- a/dts/bindings/gpio/ambiq,gpio.yaml
+++ b/dts/bindings/gpio/ambiq,gpio.yaml
@@ -1,20 +1,84 @@
-# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# Copyright (c) 2023 Ambiq Micro Inc. <www.ambiq.com>
 # SPDX-License-Identifier: Apache-2.0
 
-description: Ambiq GPIO
+description: |
+    Ambiq GPIO provides the GPIO pin mapping for GPIO child nodes.
+
+    The Ambiq Apollo4x soc designs a single GPIO port with 128 pins.
+    It uses 128 continuous 32-bit registers to configure the GPIO pins.
+    This binding provides a pin mapping to solve the limitation of the maximum
+    32 pins handling in GPIO driver API.
+
+    The Ambiq Apollo4x soc should define one "ambiq,gpio" parent node in soc
+    devicetree and some child nodes which are compatible with "ambiq,gpio-bank"
+    under this parent node.
+
+    Here is an example of how a "ambiq,gpio" node can be used with the combined
+    gpio child nodes:
+
+    gpio: gpio@40010000 {
+      compatible = "ambiq,gpio";
+      gpio-map-mask = <0xffffffe0 0xffffffc0>;
+      gpio-map-pass-thru = <0x1f 0x3f>;
+      gpio-map = <
+        0x00 0x0 &gpio0_31 0x0 0x0
+        0x20 0x0 &gpio32_63 0x0 0x0
+        0x40 0x0 &gpio64_95 0x0 0x0
+        0x60 0x0 &gpio96_127 0x0 0x0
+      >;
+      reg = <0x40010000>;
+      #gpio-cells = <2>;
+      #address-cells = <1>;
+      #size-cells = <0>;
+      ranges;
+
+      gpio0_31: gpio0_31@0 {
+        compatible = "ambiq,gpio-bank";
+        gpio-controller;
+        #gpio-cells = <2>;
+        reg = <0>;
+        interrupts = <56 0>;
+        status = "disabled";
+      };
+
+      gpio32_63: gpio32_63@80 {
+        compatible = "ambiq,gpio-bank";
+        gpio-controller;
+        #gpio-cells = <2>;
+        reg = <0x80>;
+        interrupts = <57 0>;
+        status = "disabled";
+      };
+
+      gpio64_95: gpio64_95@100 {
+        compatible = "ambiq,gpio-bank";
+        gpio-controller;
+        #gpio-cells = <2>;
+        reg = <0x100>;
+        interrupts = <58 0>;
+        status = "disabled";
+      };
+
+      gpio96_127: gpio96_127@180 {
+        compatible = "ambiq,gpio-bank";
+        gpio-controller;
+        #gpio-cells = <2>;
+        reg = <0x180>;
+        interrupts = <59 0>;
+        status = "disabled";
+      };
+    };
+
+    In the above example, the gpio@40010000 is a "ambiq,gpio" parent node which
+    provides the base register address 0x40010000. It has four "ambiq,gpio-bank"
+    child nodes. Each of them covers 32 pins (the default value of "ngpios"
+    property is 32). The "reg" property of child nodes defines the register
+    address offset. The register address of pin described in gpio-cells can be
+    obtained by: base address + child address offset + (pin << 2). For example:
+    the address of pin 20 of gpio32_63@80 node is (0x40010000 + 0x80 + (20 << 2))
+    = 0x400100D0 and the real GPIO pin number of this pin in soc is (20 + 32)
+    = 52.
 
 compatible: "ambiq,gpio"
 
-include: [gpio-controller.yaml, base.yaml]
-
-properties:
-  reg:
-    required: true
-    description: GPIO pin offset
-
-  "#gpio-cells":
-    const: 2
-
-gpio-cells:
-  - pin
-  - flags
+include: [gpio-nexus.yaml, base.yaml]


### PR DESCRIPTION
This PR adds the Ambiq GPIO driver, as well as instances in the SoC dtsi file, enabling it on the apollo4p_evb board.
It also adds support for LEDs and buttons.
Most of the driver code are picked from another long-delayed PR https://github.com/zephyrproject-rtos/zephyr/pull/61157, which includes the general Ambiq GPIO driver and Ambiq connecter/header for shield boards. This PR only includes the general GPIO driver in order to move forward the GPIO driver implementation to completion.
We updated the Ambiq GPIO instance by using GPIO maps in devicetree to include all GPIOs, which was suggested in the https://github.com/zephyrproject-rtos/zephyr/pull/61157#issuecomment-1679490658 and https://github.com/zephyrproject-rtos/zephyr/pull/61157#discussion_r1393267928, also updated the GPIO driver accordingly.

Tested the following samples on apollo4p_evb:
- samples/basic/blinky.
- samples/basic/threads.
- samples/basic/button.