### PR TITLE
twister: runner: add tfm_merged.hex in post process

### DIFF
--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -749,6 +749,7 @@ class ProjectBuilder(FilterBuilder):
         logger.debug("Cleaning up {}".format(self.instance.build_dir))
         allow = [
             os.path.join('zephyr', '.config'),
+            os.path.join('zephyr', 'tfm_merged.hex'),
             'handler.log',
             'build.log',
             'device.log',


### PR DESCRIPTION
tfm_merged.hex is the final hex used in tfm

accroding to https://docs.zephyrproject.org/latest/samples/tfm_integration/tfm_ipc/README.html