### PR TITLE
net: lib: coap: Translate handler errors to CoAP response codes

### DIFF
--- a/subsys/net/lib/coap/coap_server.c
+++ b/subsys/net/lib/coap/coap_server.c
@@ -220,6 +220,19 @@ static int coap_server_process(int sock_fd)
 					      COAP_SERVICE_RESOURCE_COUNT(service),
 					      options, opt_num, &client_addr, client_addr_len);
 
+		/* Translate errors to response codes */
+		switch (ret) {
+		case -ENOENT:
+			ret = COAP_RESPONSE_CODE_NOT_FOUND;
+			break;
+		case -ENOTSUP:
+			ret = COAP_RESPONSE_CODE_BAD_REQUEST;
+			break;
+		case -EPERM:
+			ret = COAP_RESPONSE_CODE_NOT_ALLOWED;
+			break;
+		}
+
 		/* Shortcut for replying a code without a body */
 		if (ret > 0 && type == COAP_TYPE_CON) {
 			/* Minimal sized ack buffer */


### PR DESCRIPTION
The CoAP request handler returns errno codes in the following cases:
* ENOENT if no handler found; respond with 4.04
* ENOTSUP if an unknown request code received; respond with 4.00
* EPERM no handler found for the method; respond with 4.05