### PR TITLE
drivers: net: T1s lan8651 fixes: stall of transmission and SYNC=0 handling

### DIFF
--- a/drivers/ethernet/Kconfig.lan865x
+++ b/drivers/ethernet/Kconfig.lan865x
@@ -6,6 +6,7 @@ menuconfig ETH_LAN865X
 	default y
 	depends on DT_HAS_MICROCHIP_LAN865X_ENABLED
 	select SPI
+	select NET_L2_ETHERNET_MGMT
 	help
 	  The LAN865X is a low power, 10BASE-T1S transceiver compliant with
 	  the IEEE® 802.3cg-2019™ Ethernet standard for long reach, 10

--- a/drivers/ethernet/eth_lan865x.c
+++ b/drivers/ethernet/eth_lan865x.c
@@ -425,6 +425,7 @@ static void lan865x_int_thread(const struct device *dev)
 	struct lan865x_data *ctx = dev->data;
 	struct oa_tc6 *tc6 = ctx->tc6;
 	uint32_t sts, val, ftr;
+	int ret;
 
 	while (true) {
 		k_sem_take(&ctx->int_sem, K_FOREVER);
@@ -459,7 +460,10 @@ static void lan865x_int_thread(const struct device *dev)
 			lan865x_read_chunks(dev);
 		} while (tc6->rca > 0);
 
-		oa_tc6_check_status(tc6);
+		ret = oa_tc6_check_status(tc6);
+		if (ret == -EIO) {
+			lan865x_gpio_reset(dev);
+		}
 	}
 }
 

--- a/drivers/ethernet/eth_lan865x.c
+++ b/drivers/ethernet/eth_lan865x.c
@@ -449,16 +449,15 @@ static void lan865x_int_thread(const struct device *dev)
 		}
 
 		/*
-		 * The IRQ_N is asserted when RCA becomes > 0, so update its value
-		 * before reading chunks.
+		 * The IRQ_N is asserted when RCA becomes > 0. As described in
+		 * OPEN Alliance 10BASE-T1x standard it is deasserted when first
+		 * data header is received by LAN865x.
+		 *
+		 * Hence, it is mandatory to ALWAYS read at least one data chunk!
 		 */
-		if (oa_tc6_update_buf_info(tc6) < 0) {
-			continue;
-		}
-
-		while (tc6->rca > 0) {
+		do {
 			lan865x_read_chunks(dev);
-		}
+		} while (tc6->rca > 0);
 
 		oa_tc6_check_status(tc6);
 	}

--- a/drivers/ethernet/oa_tc6.c
+++ b/drivers/ethernet/oa_tc6.c
@@ -197,7 +197,7 @@ int oa_tc6_send_chunks(struct oa_tc6 *tc6, struct net_pkt *pkt)
 			FIELD_PREP(OA_DATA_HDR_SWO, 0);
 
 		if (i == 1) {
-			hdr |=	FIELD_PREP(OA_DATA_HDR_SV, 1);
+			hdr |= FIELD_PREP(OA_DATA_HDR_SV, 1);
 		}
 
 		if (i == chunks) {

--- a/drivers/ethernet/oa_tc6.c
+++ b/drivers/ethernet/oa_tc6.c
@@ -227,6 +227,11 @@ int oa_tc6_check_status(struct oa_tc6 *tc6)
 {
 	uint32_t sts;
 
+	if (!tc6->sync) {
+		LOG_ERR("SYNC: Configuration lost, reset IC!");
+		return -EIO;
+	}
+
 	if (tc6->exst) {
 		/*
 		 * Just clear any pending interrupts.

--- a/drivers/ethernet/oa_tc6.c
+++ b/drivers/ethernet/oa_tc6.c
@@ -351,7 +351,7 @@ int oa_tc6_read_chunks(struct oa_tc6 *tc6, struct net_pkt *pkt)
 		}
 
 		if (!FIELD_GET(OA_DATA_FTR_DV, ftr)) {
-			LOG_ERR("OA RX: Data chunk not valid, skip!");
+			LOG_DBG("OA RX: Data chunk not valid, skip!");
 			goto unref_buf;
 		}
 

--- a/drivers/ethernet/oa_tc6.h
+++ b/drivers/ethernet/oa_tc6.h
@@ -226,15 +226,6 @@ int oa_tc6_chunk_spi_transfer(struct oa_tc6 *tc6, uint8_t *buf_rx, uint8_t *buf_
 int oa_tc6_read_status(struct oa_tc6 *tc6, uint32_t *ftr);
 
 /**
- * @brief Read from OA TC6 device and update buffer information
- *
- * @param tc6 OA TC6 specific data
- *
- * @return 0 if successful, <0 otherwise.
- */
-int oa_tc6_update_buf_info(struct oa_tc6 *tc6);
-
-/**
  * @brief Read, modify and write control register from OA TC6 device
  *
  * @param tc6 OA TC6 specific data


### PR DESCRIPTION
This patch set provides following improvements:

- The IRQ handling code has been rewritten to fix "stall" issue when long-time tests were performed. The problem was with not deasserted IRQ line as reading OA_BUFSTS is NOT causing the LAN865x (or any other OA TC6 compliant device) to do it.
- Code cleanup
- Handling the (very rare) case when SYNC bit in OA_CONFIG0 is cleared. In this case - the LAN865x is reset and re-configured.