### PR TITLE
device: add braces around dev/dev_rw initializer

### DIFF
--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -974,7 +974,10 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
 		Z_INIT_ENTRY_NAME(DEVICE_NAME_GET(dev_id)) = {                                     \
 			.init_fn = {COND_CODE_1(Z_DEVICE_IS_MUTABLE(node_id), (.dev_rw), (.dev)) = \
 					    (init_fn_)},                                           \
-			.dev = &DEVICE_NAME_GET(dev_id),                                           \
+			{                                                                          \
+				COND_CODE_1(Z_DEVICE_IS_MUTABLE(node_id), (.dev_rw), (.dev)) =     \
+					&DEVICE_NAME_GET(dev_id),                                  \
+			},                                                                         \
 	}
 
 /**

--- a/include/zephyr/init.h
+++ b/include/zephyr/init.h
@@ -205,10 +205,7 @@ struct init_entry {
 #define SYS_INIT_NAMED(name, init_fn_, level, prio)                            \
 	static const Z_DECL_ALIGN(struct init_entry)                           \
 		Z_INIT_ENTRY_SECTION(level, prio, 0) __used __noasan           \
-		Z_INIT_ENTRY_NAME(name) = {                                    \
-			.init_fn = {.sys = (init_fn_)},                        \
-			.dev = NULL,                                           \
-	}
+		Z_INIT_ENTRY_NAME(name) = {.init_fn = {.sys = (init_fn_)}}
 
 /** @} */
 


### PR DESCRIPTION
See
- https://github.com/zephyrproject-rtos/zephyr/pull/62998/files/7a8e56ab21221c31a501e60b47c40035aa92af7a#r1408574214 
- https://github.com/zephyrproject-rtos/zephyr/pull/62998/files/7a8e56ab21221c31a501e60b47c40035aa92af7a#r1408993003 
- https://godbolt.org/z/Whf44q63s

---

The init_entry struct got modified to add a union with a non const dev pointer in afc59112a9. Some old compiler (such as GCC 4) seems to require a pair of brackets to correctly initialize the field in the union. Add those brackets to the initializers in device.h and init.h to maintain compatibility.