### PR TITLE
boards nrf5340bsim_cpuapp: Define chosen entropy source

### DIFF
--- a/boards/posix/nrf_bsim/nrf5340bsim_nrf5340_cpuapp.dts
+++ b/boards/posix/nrf_bsim/nrf5340bsim_nrf5340_cpuapp.dts
@@ -45,6 +45,7 @@
 	};
 
 	chosen {
+		zephyr,entropy = &rng_hci;
 		zephyr,flash = &flash0;
 		zephyr,bt-hci-ipc = &ipc0;
 		nordic,802154-spinel-ipc = &ipc0;


### PR DESCRIPTION
Override the chosen entropy source irrespectively of what the SOC may chose.
This is to avoid problems as the SOC may select the cryptocell, but we do not support it in the simulated target.