### PR TITLE
[WIP] posix: implement kill() and signal()

### DIFF
--- a/include/zephyr/posix/posix_types.h
+++ b/include/zephyr/posix/posix_types.h
@@ -21,6 +21,13 @@
 extern "C" {
 #endif
 
+#define _z_sighdlr void (*)(int)
+#define Z_SIG_DFL  ((_z_sighdlr)0)
+#define Z_SIG_IGN  ((_z_sighdlr)1)
+#define Z_SIG_ERR  ((_z_sighdlr)-1)
+
+typedef pid_t z_pid_t;
+
 #ifndef __useconds_t_defined
 typedef unsigned long useconds_t;
 #endif

--- a/include/zephyr/posix/signal.h
+++ b/include/zephyr/posix/signal.h
@@ -49,12 +49,17 @@ extern "C" {
 #define SIGRTMAX (SIGRTMIN + CONFIG_POSIX_RTSIG_MAX)
 #define _NSIG (SIGRTMAX + 1)
 
+#define SIG_DFL Z_SIG_DFL
+#define SIG_IGN Z_SIG_IGN
+#define SIG_ERR Z_SIG_ERR
+
 BUILD_ASSERT(CONFIG_POSIX_RTSIG_MAX >= 0);
 
 typedef struct {
 	unsigned long sig[DIV_ROUND_UP(_NSIG, BITS_PER_LONG)];
 } sigset_t;
 
+int kill(pid_t pid, int sig);
 char *strsignal(int signum);
 int sigemptyset(sigset_t *set);
 int sigfillset(sigset_t *set);
@@ -89,6 +94,12 @@ struct sigevent {
 	void (*sigev_notify_function)(union sigval val);
 	pthread_attr_t *sigev_notify_attributes;
 };
+
+typedef void (*sighandler_t)(int sig);
+sighandler_t signal(int sig, sighandler_t handler);
+int kill(pid_t pid, int sig);
+pid_t getpid(void);
+pid_t getppid(void);
 
 #ifdef __cplusplus
 }

--- a/lib/posix/CMakeLists.txt
+++ b/lib/posix/CMakeLists.txt
@@ -13,6 +13,9 @@ if(CONFIG_POSIX_API)
 endif()
 
 if(CONFIG_POSIX_SIGNAL)
+  zephyr_syscall_header(
+    ${ZEPHYR_BASE}/lib/posix/posix_internal.h
+  )
   set(STRSIGNAL_TABLE_H ${GEN_DIR}/posix/strsignal_table.h)
 
   add_custom_command(

--- a/lib/posix/Kconfig.signal
+++ b/lib/posix/Kconfig.signal
@@ -23,4 +23,35 @@ config POSIX_SIGNAL_STRING_DESC
 	  Use full description for the strsignal API.
 	  Will use 256 bytes of ROM.
 
+config POSIX_SIGNAL_DEFAULT_PID
+	int "Default system-wide process identifier (PID)"
+	range 2 2147483647
+	default 2
+	help
+	  To maintain compatibility with some other POSIX operating systems, a PID of zero is used to
+	  indicate that the process exists in another namespace. PID zero is also used by the
+	  scheduler in some cases. PID one is usually reserved for the init process.
+
+	  Other (positive) PID values are fair to use here.
+
+config POSIX_SIGNAL_DEFAULT_PARENT_PID
+	int ""
+	default 0
+	help
+	  To maintain compatibility with some other POSIX operating systems, a PID of zero is used to
+	  indicate that the process exists in another namespace. PID one is reserved for the init
+	  process.
+
+config POSIX_SIGNAL_ONE_HANDLER
+	bool "Only reserve space for one signal handler"
+	help
+	  Typically POSIX systems can support installing many signal handlers for different signals
+	  simultaneously.
+
+	  This does, however, consume memory. In the interest of reducing memory usage, only allow
+	  installing one user-specified signal handler for all signals.
+
 endif
+
+TYPE = POSIX_SIGNAL
+source "lib/posix/Kconfig.template.with_logging"

--- a/lib/posix/posix_internal.h
+++ b/lib/posix/posix_internal.h
@@ -85,4 +85,85 @@ struct posix_thread *to_posix_thread(pthread_t pth);
 /* get and possibly initialize a posix_mutex */
 struct k_mutex *to_posix_mutex(pthread_mutex_t *mu);
 
+typedef int32_t z_pid_t;
+
+/**
+ * @brief Get the process identifier (PID) of the calling process.
+ *
+ * @return The current PID
+ */
+__syscall z_pid_t z_getpid(void);
+
+/**
+ * @brief Grant a thread signal-related permissions
+ *
+ * Grant @p tid permission to
+ * - change the global process identifier (PID)
+ * - install signal handlers
+ * - send signals
+ *
+ * @param tid the thread identifier for which permission should be granted
+ */
+void z_thread_access_grant_signal_mgmt(k_tid_t tid);
+
+/**
+ * @brief Set the global process identifier
+ *
+ * Set the global process identifier.
+ *
+ * In the case that @ref CONFIG_USERSPACE is selected, and the calling thread is not running in
+ * kernel mode, @ref z_thread_access_grant_signal_mgmt must be called in advance to grant the
+ * calling thread permission.
+ *
+ * @note Valid @p pid values lie in the range `[2,INT32_MAX]` for compatibility with other POSIX
+ * systems.
+ *
+ * @param pid The desired process identifier
+ * @retval 0 on success
+ * @retval -EINVAL if @p pid is invalid
+ * @retval -EPERM if the calling thread lacks permission
+ */
+__syscall int z_pid_set(z_pid_t pid);
+
+/**
+ * @brief Send a signal to a process
+ *
+ * In the case that @ref CONFIG_USERSPACE is selected, and the calling thread is not running in
+ * kernel mode, @ref z_thread_access_grant_signal_mgmt must be called in advance to grant the
+ * calling thread permission.
+ *
+ * @param pid The desired process to signal
+ * @param sig The desired signal to send
+ * @retval 0 on success
+ * @retval -EINVAL if @p pid is invalid
+ * @retval -EPERM if the calling thread lacks permission
+ *
+ * @see <a href="https://pubs.opengroup.org/onlinepubs/9699919799/functions/kill.html">kill</a>
+ */
+__syscall int z_kill(z_pid_t pid, int sig);
+
+/**
+ * @brief Manage signal handlers for the calling process
+ *
+ * Prior to calling, the user should populate @p func with the desired signal handler to install.
+ *
+ * Upon success, the location pointed to by @p func will contain the previous value of the signal
+ * handler for @p sig.
+ *
+ * @note In the case that @ref CONFIG_USERSPACE is selected, and the calling thread is not running
+ * in kernel mode, @ref z_thread_access_grant_signal_mgmt must be called in advance to grant the
+ * calling thread permission.
+ *
+ * @param sig The desired signal to handle
+ * @param[inout] func The desired signal handler to use (and where the old)
+ * @retval 0 on success
+ * @retval -EINVAL if @p sig is invalid
+ * @retval -EPERM if the calling thread lacks permission
+ *
+ * @see <a href="https://pubs.opengroup.org/onlinepubs/9699919799/functions/signal.html">signal</a>
+ */
+__syscall int z_signal(int sig, sighandler_t *func);
+
+#include <syscalls/posix_internal.h>
+
 #endif

--- a/lib/posix/signal.c
+++ b/lib/posix/signal.c
@@ -4,17 +4,43 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "posix/strsignal_table.h"
+#include "posix_internal.h"
 
 #include <errno.h>
+#include <limits.h>
 #include <stdio.h>
 
+#include <zephyr/logging/log.h>
 #include <zephyr/posix/signal.h>
+#include <zephyr/internal/syscall_handler.h>
+
+#ifdef CONFIG_POSIX_SIGNAL_ONE_HANDLER
+#define _n_sig_handlers 1
+#else
+#define _n_sig_handlers (_NSIG - 1)
+#endif
 
 #define SIGNO_WORD_IDX(_signo) (signo / BITS_PER_LONG)
 #define SIGNO_WORD_BIT(_signo) (signo & BIT_MASK(LOG2(BITS_PER_LONG)))
 
+#define _z_min_app_pid 2
+
+LOG_MODULE_REGISTER(posix_signal, CONFIG_POSIX_SIGNAL_LOG_LEVEL);
+
 BUILD_ASSERT(CONFIG_POSIX_LIMITS_RTSIG_MAX >= 0);
 BUILD_ASSERT(CONFIG_POSIX_RTSIG_MAX >= CONFIG_POSIX_LIMITS_RTSIG_MAX);
+
+static z_pid_t z_signal_pid = CONFIG_POSIX_SIGNAL_DEFAULT_PID;
+BUILD_ASSERT(CONFIG_POSIX_SIGNAL_DEFAULT_PID >= 2);
+BUILD_ASSERT(CONFIG_POSIX_SIGNAL_DEFAULT_PID <= INT32_MAX);
+static struct k_spinlock z_signal_lock;
+static sigset_t z_signal_sigset;
+/* arbitrary kernel object that can have permissions checked */
+K_SEM_DEFINE(z_signal_obj, 1, 1);
+static sighandler_t z_signal_handler_user[_n_sig_handlers];
+static void z_signal_handler_default(int sig);
+static void z_signal_work_handler(struct k_work *work);
+static K_WORK_DEFINE(z_signal_work, z_signal_work_handler);
 
 static inline bool signo_valid(int signo)
 {
@@ -99,4 +125,330 @@ char *strsignal(int signum)
 	snprintf(buf, sizeof(buf), "Signal %d", signum);
 
 	return buf;
+}
+
+void z_thread_access_grant_signal_mgmt(k_tid_t tid)
+{
+	k_thread_access_grant(tid, &z_signal_obj);
+}
+
+int z_impl_z_pid_set(z_pid_t pid)
+{
+	if (pid < _z_min_app_pid || pid == CONFIG_POSIX_SIGNAL_DEFAULT_PARENT_PID) {
+		return -EINVAL;
+	}
+
+	if (pid == CONFIG_POSIX_SIGNAL_DEFAULT_PARENT_PID) {
+		return -EINVAL;
+	}
+
+	K_SPINLOCK(&z_signal_lock)
+	{
+		z_signal_pid = pid;
+	}
+
+	return 0;
+}
+
+#ifdef CONFIG_USERSPACE
+int z_vrfy_z_pid_set(z_pid_t pid)
+{
+	if (!K_SYSCALL_OBJ(&z_signal_obj, K_OBJ_TYPE_SEM_ID)) {
+		return -EPERM;
+	}
+
+	return z_impl_z_pid_set(pid);
+}
+#include <syscalls/z_pid_set_mrsh.c>
+#endif
+
+static struct k_object *find_kobject_by_pid(z_pid_t pid)
+{
+	if (pid == -1) {
+		/* all processes (minus some system processes) */
+		return (struct k_object *)&z_signal_obj;
+	} else if (pid < 0) {
+		/* a specific process group */
+		return NULL;
+	} else if (pid == z_signal_pid) {
+		/* the exact process id */
+		return (struct k_object *)&z_signal_obj;
+	} else {
+		return NULL;
+	}
+}
+
+static int z_schedule_signal(struct k_object *obj, int sig)
+{
+	int ret;
+
+	/*
+	 * Currently, we only support one PID object. For process groups or all processes (minus
+	 * system processes) we would need to loop through a list. That is not yet supported.
+	 */
+	__ASSERT_NO_MSG(obj == (struct k_object *)&z_signal_obj);
+
+	ret = sigaddset(&z_signal_sigset, sig);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = k_work_submit(&z_signal_work);
+	if (ret < 0) {
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+int z_impl_z_kill(z_pid_t pid, int sig)
+{
+	int ret;
+	struct k_object *obj;
+
+	ret = 0;
+	K_SPINLOCK(&z_signal_lock)
+	{
+		obj = find_kobject_by_pid(pid);
+		if (obj == NULL) {
+			ret = -ESRCH;
+			K_SPINLOCK_BREAK;
+		}
+
+		ret = 0;
+		if (sig == 0) {
+			K_SPINLOCK_BREAK;
+		}
+
+		ret = z_schedule_signal(obj, sig);
+	}
+
+	return ret;
+}
+
+#ifdef CONFIG_USERSPACE
+int z_vrfy_z_kill(z_pid_t pid, int sig)
+{
+	if (!K_SYSCALL_OBJ(&z_signal_obj, K_OBJ_SEM)) {
+		return -EPERM;
+	}
+
+	return z_impl_z_kill(pid, sig);
+}
+#include <syscalls/z_kill_mrsh.c>
+#endif
+
+int kill(pid_t pid, int sig)
+{
+	int ret;
+
+	ret = z_kill(pid, sig);
+	if (ret < 0) {
+		errno = -ret;
+		return -1;
+	}
+
+	return 0;
+}
+
+static inline sighandler_t *get_sig_handler_loc(int sig)
+{
+	if (IS_ENABLED(CONFIG_POSIX_SIGNAL_ONE_HANDLER)) {
+		return &z_signal_handler_user[0];
+	} else {
+		__ASSERT_NO_MSG(sig >= 1);
+		__ASSERT_NO_MSG(sig - 1 < ARRAY_SIZE(z_signal_handler_user));
+		return &z_signal_handler_user[sig - 1];
+	}
+}
+
+int z_impl_z_signal(int sig, sighandler_t *func)
+{
+	sighandler_t tmp;
+	sighandler_t *handler;
+
+	if (!signo_valid(sig)) {
+		return -EINVAL;
+	}
+
+	if (*func == SIG_ERR) {
+		return -EINVAL;
+	}
+
+	/* signals that cannot be caught or ignored */
+	if (*func != SIG_DFL && (sig == SIGKILL || sig == SIGSTOP)) {
+		return -EINVAL;
+	}
+
+	K_SPINLOCK(&z_signal_lock)
+	{
+		handler = get_sig_handler_loc(sig);
+		tmp = *handler;
+		*handler = *func;
+		*func = tmp;
+	}
+
+	return 0;
+}
+
+#ifdef CONFIG_USERSPACE
+int z_vrfy_z_signal(int sig, sighandler_t *func)
+{
+	K_OOPS(K_SYSCALL_MEMORY_WRITE(func, sizeof(*func)));
+
+	if (!K_SYSCALL_OBJ(&z_signal_obj, K_OBJ_SEM)) {
+		return -EPERM;
+	}
+
+	return z_impl_z_signal(sig, func);
+}
+#include <syscalls/z_signal_mrsh.c>
+#endif
+
+sighandler_t signal(int sig, sighandler_t func)
+{
+	int ret;
+	sighandler_t old = func;
+
+	ret = z_signal(sig, &old);
+	if (ret < 0) {
+		errno = -ret;
+		return SIG_ERR;
+	}
+
+	return old;
+}
+
+int z_impl_z_getpid(void)
+{
+	z_pid_t pid;
+
+	K_SPINLOCK(&z_signal_lock)
+	{
+		pid = z_signal_pid;
+	}
+
+	return pid;
+}
+
+#ifdef CONFIG_USERSPACE
+int z_vrfy_z_getpid(void)
+{
+	return z_impl_z_getpid();
+}
+#include <syscalls/z_getpid_mrsh.c>
+#endif
+
+pid_t getpid(void)
+{
+	return z_getpid();
+}
+
+pid_t getppid(void)
+{
+	BUILD_ASSERT(CONFIG_POSIX_SIGNAL_DEFAULT_PARENT_PID != CONFIG_POSIX_SIGNAL_DEFAULT_PID);
+	return CONFIG_POSIX_SIGNAL_DEFAULT_PARENT_PID;
+}
+
+static char get_action_for_signal(int sig)
+{
+	switch (sig) {
+	case SIGABRT:
+	case SIGBUS:
+	case SIGFPE:
+	case SIGILL:
+	case SIGQUIT:
+	case SIGSEGV:
+	case SIGSYS:
+	case SIGTRAP:
+	case SIGXCPU:
+	case SIGXFSZ:
+		return 'T';
+	case SIGALRM:
+	case SIGHUP:
+	case SIGINT:
+	case SIGKILL:
+	case SIGPIPE:
+	case SIGTERM:
+	case SIGUSR1:
+	case SIGUSR2:
+	case SIGPOLL:
+	case SIGPROF:
+	case SIGVTALRM:
+		return 'A';
+	/* 'I' merged with default */
+	case SIGSTOP:
+	case SIGTSTP:
+	case SIGTTIN:
+	case SIGTTOU:
+		return 'S';
+	case SIGCONT:
+		return 'C';
+	case SIGCHLD:
+	case SIGURG:
+	default:
+		return 'I';
+	}
+}
+
+/*
+ * Default signal handler does little other than printing signal info.
+ */
+static void z_signal_handler_default(int sig)
+{
+	const char *tail_matter;
+
+	switch (get_action_for_signal(sig)) {
+	case 'T':
+		tail_matter = "Would terminate abnormally";
+		break;
+	case 'A':
+		tail_matter = "Would terminate abnormally with actions";
+		break;
+	case 'S':
+		tail_matter = "Would stop";
+		break;
+	case 'C':
+		tail_matter = "Would continue";
+		break;
+	case 'I':
+	default:
+		tail_matter = "Ignoring";
+		break;
+	}
+
+	LOG_DBG("PID %08x: Received signal %d ('%s'). %s", getpid(), sig, strsignal(sig),
+		tail_matter);
+}
+
+static void z_signal_work_handler(struct k_work *work)
+{
+	int ret;
+	sighandler_t handler;
+
+	ARG_UNUSED(work);
+
+	for (int sig = 1; sig < _NSIG; ++sig) {
+		ret = sigismember(&z_signal_sigset, sig);
+		__ASSERT_NO_MSG(ret >= 0);
+		if (ret == 0) {
+			continue;
+		}
+
+		ret = sigdelset(&z_signal_sigset, sig);
+		__ASSERT_NO_MSG(ret == 0);
+
+		handler = *get_sig_handler_loc(sig);
+
+		if (handler == SIG_IGN) {
+			continue;
+		}
+
+		if (handler == SIG_DFL) {
+			z_signal_handler_default(sig);
+			continue;
+		}
+
+		handler(sig);
+	}
 }

--- a/tests/posix/common/src/signal.c
+++ b/tests/posix/common/src/signal.c
@@ -326,5 +326,6 @@ ZTEST(signal, test_permissions)
 {
 	k_thread_user_mode_enter(test_permissions_entry, NULL, NULL, NULL);
 }
+#endif
 
 ZTEST_SUITE(signal, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Currently Zephyr has no concept of processes or process identifiers (PIDs). However, both kill() and signal() are requirements of the POSIX_SIGNALS option group as per IEEE 1003.1-2017.

The POSIX_SIGNALS option group is a requirement of PSE51, PSE52, PSE53, and PSE54 Appplication Environment Profiles.

The `kill()` and `signal()` functions deal with signal delivery and management with process-wide granularity.

With the approximation that that Zephyr runs as a single-process application, we can restrict kill() and signal() to operate on one group of signals.

Permissions must be granted to userspace threads if they are to register signal handlers, send signals, or adjust the one global PID value.