### PR TITLE
tests: net: lib: coap: issue in twister

### DIFF
--- a/tests/net/lib/coap_server/common/testcase.yaml
+++ b/tests/net/lib/coap_server/common/testcase.yaml
@@ -8,4 +8,5 @@ common:
     - native_sim
 
 tests:
-  net.coap.server.common: {}
+  net.coap.server.common:
+    harness: coap


### PR DESCRIPTION
due to this PR:
net: lib: coap: Service support #64265
we exclude :
nucleo_f207zg, nucleo_f429zi, nucleo_f746zg, nucleo_h743zi stm32h573i_dk ,stm32h735g_disco, nucleo_f207zg