### PR TITLE
[RFC] risc-v: drivers: intc_plic: enabled interrupts to be handled by all cores

### DIFF
--- a/drivers/interrupt_controller/intc_plic.c
+++ b/drivers/interrupt_controller/intc_plic.c
@@ -134,7 +134,17 @@ static inline mem_addr_t get_claim_complete_addr(const struct device *dev)
 {
 	const struct plic_config *config = dev->config;
 
-	return config->reg + CONTEXT_CLAIM;
+	/*
+	 * We want to return the claim complete addr for the hart's context.
+	 * We are making a few assumptions here:
+	 * 1. for hart 0, return the first context claim complete.
+	 * 2. for any other hart, we assume they have two privileged mode contexts
+	 * which are contiguous, where the m mode context is first.
+	 * We return the m mode context.
+	 */
+
+	return config->reg + get_first_context(arch_proc_id()) * CONTEXT_SIZE +
+	       CONTEXT_CLAIM;
 }
 
 


### PR DESCRIPTION
This patch set is to fix an issue #65489.
The problem to fix is that the first context of the PLIC was hardcoded into the driver. The side effect of that was to disable other cores in a multi-core complex from handling interrupts.

The solution presented here started off life as a cut and past from what is done in Linux, however A slightly more elegant solution raised its head during the process: basically, We know how many CPU's will be associated with a Zephyr application prior to compile time. Also, if its an SMP set up we have a mapping of the hartid to the cpu right from the  start.

We can leverage this list of CPU's to enable only the contexts of the harts that are required to run in Zephyr, allowing Zephyr to also play nicely in an AMP setup.