### PR TITLE
modem: add optional pins to zephyr,gsm-ppp.yaml

### DIFF
--- a/dts/bindings/modem/zephyr,gsm-ppp.yaml
+++ b/dts/bindings/modem/zephyr,gsm-ppp.yaml
@@ -6,3 +6,10 @@ description: GSM PPP modem
 compatible: "zephyr,gsm-ppp"
 
 include: uart-device.yaml
+
+properties:
+  mdm-power-gpios:
+    type: phandle-array
+
+  mdm-reset-gpios:
+    type: phandle-array


### PR DESCRIPTION
As can be seen in modem_cellular.c, a device compatible with zephyr,gsm-ppp can have power and reset pins. However these didn't exist in its .yaml bindings file, and thus couldn't be added.

![image](https://github.com/zephyrproject-rtos/zephyr/assets/73964476/49c42832-012a-43a8-bb6b-71f6dba959d6)
