### PR TITLE
net: sockets: Add additional checks to recvmsg()

### DIFF
--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -1748,6 +1748,11 @@ ssize_t zsock_recvmsg_ctx(struct net_context *ctx, struct msghdr *msg,
 		return -1;
 	}
 
+	if (msg->msg_iov == NULL) {
+		errno = ENOMEM;
+		return -1;
+	}
+
 	for (i = 0; i < msg->msg_iovlen; i++) {
 		max_len += msg->msg_iov[i].iov_len;
 	}
@@ -1787,6 +1792,11 @@ ssize_t z_vrfy_zsock_recvmsg(int sock, struct msghdr *msg, int flags)
 
 	if (msg == NULL) {
 		errno = EINVAL;
+		return -1;
+	}
+
+	if (msg->msg_iov == NULL) {
+		errno = ENOMEM;
 		return -1;
 	}
 

--- a/tests/net/socket/udp/src/main.c
+++ b/tests/net/socket/udp/src/main.c
@@ -1415,7 +1415,7 @@ ZTEST_USER(net_socket_udp, test_26_recvmsg_invalid)
 	msg.msg_control = &cmsgbuf.buf;
 
 	ret = recvmsg(0, &msg, 0);
-	zassert_true(ret < 0, "recvmsg() succeed");
+	zassert_true(ret < 0 && errno == ENOMEM, "Wrong errno (%d)", errno);
 
 	msg.msg_iov = io_vector;
 	msg.msg_iovlen = 1;
@@ -1462,6 +1462,11 @@ static void comm_sendmsg_recvmsg(int client_sock,
 
 	sent = sendmsg(client_sock, client_msg, 0);
 	zassert_true(sent > 0, "sendmsg failed, %s (%d)", strerror(errno), -errno);
+
+	/* One negative test with invalid msg_iov */
+	memset(msg, 0, sizeof(*msg));
+	recved = recvmsg(server_sock, msg, 0);
+	zassert_true(recved < 0 && errno == ENOMEM, "Wrong errno (%d)", errno);
 
 	for (i = 0, len = 0; i < client_msg->msg_iovlen; i++) {
 		len += client_msg->msg_iov[i].iov_len;


### PR DESCRIPTION
Add extra checks that make sure that msg_iov is set as we cannot receive anything if receive buffers are not set.