### PR TITLE
drivers: sensor: lis3mdl: modified driver to support SINGLE sample mode

### DIFF
--- a/drivers/sensor/lis3mdl/lis3mdl.c
+++ b/drivers/sensor/lis3mdl/lis3mdl.c
@@ -68,6 +68,19 @@ int lis3mdl_sample_fetch(const struct device *dev, enum sensor_channel chan)
 
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL);
 
+	/* If in single mode, the sensor needs to be brought back out of
+	 * IDLE before each sensor read
+	 */
+	if (drv_data->single_mode) {
+		uint8_t chip_cfg[2];
+		chip_cfg[0] = LIS3MDL_REG_CTRL3;
+		chip_cfg[1] = LIS3MDL_MD_SINGLE;
+		if (i2c_write_dt(&config->i2c, chip_cfg, 2) < 0) {
+			LOG_DBG("Failed to set SINGLE mode.");
+			return -EIO;
+		}
+	}
+
 	/* fetch magnetometer sample */
 	if (i2c_burst_read_dt(&config->i2c, LIS3MDL_REG_SAMPLE_START,
 			      (uint8_t *)buf, 8) < 0) {
@@ -105,6 +118,7 @@ static const struct sensor_driver_api lis3mdl_driver_api = {
 int lis3mdl_init(const struct device *dev)
 {
 	const struct lis3mdl_config *config = dev->config;
+	struct lis3mdl_data *drv_data = dev->data;
 	uint8_t chip_cfg[6];
 	uint8_t id, idx;
 
@@ -136,11 +150,15 @@ int lis3mdl_init(const struct device *dev)
 		return -EINVAL;
 	}
 
+	/* Check if single mode should be set */
+	drv_data->single_mode = lis3mdl_odr_bits[idx] & LIS3MDL_FAST_ODR_MASK ?
+		      false : true;
+
 	/* Configure sensor */
 	chip_cfg[0] = LIS3MDL_REG_CTRL1;
 	chip_cfg[1] = LIS3MDL_TEMP_EN_MASK | lis3mdl_odr_bits[idx];
 	chip_cfg[2] = LIS3MDL_FS_IDX << LIS3MDL_FS_SHIFT;
-	chip_cfg[3] = LIS3MDL_MD_CONTINUOUS;
+	chip_cfg[3] = drv_data->single_mode ? LIS3MDL_MD_SINGLE : LIS3MDL_MD_CONTINUOUS;
 	chip_cfg[4] = ((lis3mdl_odr_bits[idx] & LIS3MDL_OM_MASK) >>
 		       LIS3MDL_OM_SHIFT) << LIS3MDL_OMZ_SHIFT;
 	chip_cfg[5] = LIS3MDL_BDU_EN;

--- a/drivers/sensor/lis3mdl/lis3mdl.c
+++ b/drivers/sensor/lis3mdl/lis3mdl.c
@@ -73,8 +73,10 @@ int lis3mdl_sample_fetch(const struct device *dev, enum sensor_channel chan)
 	 */
 	if (drv_data->single_mode) {
 		uint8_t chip_cfg[2];
+		
 		chip_cfg[0] = LIS3MDL_REG_CTRL3;
 		chip_cfg[1] = LIS3MDL_MD_SINGLE;
+		
 		if (i2c_write_dt(&config->i2c, chip_cfg, 2) < 0) {
 			LOG_DBG("Failed to set SINGLE mode.");
 			return -EIO;

--- a/drivers/sensor/lis3mdl/lis3mdl.h
+++ b/drivers/sensor/lis3mdl/lis3mdl.h
@@ -110,6 +110,7 @@ static const uint16_t lis3mdl_magn_gain[] = {
 };
 
 struct lis3mdl_data {
+	bool single_mode;
 	int16_t x_sample;
 	int16_t y_sample;
 	int16_t z_sample;


### PR DESCRIPTION
Previous implementations of this driver included incorrect support for single mode, where the driver would select SINGLE mode for FAST sampling modes and CONTINUOUS for regular sampling modes. In the datasheet for the LIS3MDL, it specifies the opposite of this.

When in SINGLE sampling mode, the LIS3MDL returns to IDLE mode after each sample (i.e., each time a sample is wanted from the sensor, the sensor must be put back into SINGLE mode to trigger a new measurement). The old driver was not placing the sensor back into SINGLE mode and the first sensor reading (from startup) was returned repeatively. This has been corrected by checking if the sensor is in single mode on each sample fetch and setting the relevant control bit to trigger a new measurement. The previous fix to this was to set the sensor into CONTINUOUS mode regardless of control bits, but this new driver allows both SINGLE and CONTINUOUS modes.