### PR TITLE
net: lib: coap: Add support to query CoAP service running state

### DIFF
--- a/include/zephyr/net/coap_service.h
+++ b/include/zephyr/net/coap_service.h
@@ -57,7 +57,9 @@ struct coap_service {
 };
 
 #define __z_coap_service_define(_name, _host, _port, _flags, _res_begin, _res_end)		\
-	static struct coap_service_data coap_service_data_##_name;				\
+	static struct coap_service_data coap_service_data_##_name = {				\
+		.sock_fd = -1,									\
+	};											\
 	const STRUCT_SECTION_ITERABLE(coap_service, _name) = {					\
 		.name = STRINGIFY(_name),							\
 		.host = _host,									\

--- a/include/zephyr/net/coap_service.h
+++ b/include/zephyr/net/coap_service.h
@@ -199,7 +199,7 @@ struct coap_service {
  * @param service Pointer to CoAP service
  * @retval 0 in case of success.
  * @retval -EALREADY in case of an already running service.
- * @retval -ENOMEM in case the server has no available context.
+ * @retval -ENOTSUP in case the server has no valid host and port configuration.
  */
 int coap_service_start(const struct coap_service *service);
 

--- a/include/zephyr/net/coap_service.h
+++ b/include/zephyr/net/coap_service.h
@@ -215,6 +215,18 @@ int coap_service_start(const struct coap_service *service);
 int coap_service_stop(const struct coap_service *service);
 
 /**
+ * @brief Query the provided @p service running state.
+ *
+ * @note This function is suitable for a @p service defined with @ref COAP_SERVICE_DEFINE.
+ *
+ * @param service Pointer to CoAP service
+ * @retval 1 if the service is running
+ * @retval 0 if the service is stopped
+ * @retval negative in case of an error.
+ */
+int coap_service_is_running(const struct coap_service *service);
+
+/**
  * @brief Send a CoAP message from the provided @p service .
  *
  * @note This function is suitable for a @p service defined with @ref COAP_SERVICE_DEFINE.

--- a/subsys/net/lib/coap/coap_server.c
+++ b/subsys/net/lib/coap/coap_server.c
@@ -694,9 +694,6 @@ static void coap_server_thread(void *p1, void *p2, void *p3)
 	}
 
 	COAP_SERVICE_FOREACH(svc) {
-		/* Init all file descriptors to -1 */
-		svc->data->sock_fd = -1;
-
 		if (svc->flags & COAP_SERVICE_AUTOSTART) {
 			ret = coap_service_start(svc);
 			if (ret < 0) {

--- a/subsys/net/lib/coap/coap_server.c
+++ b/subsys/net/lib/coap/coap_server.c
@@ -470,6 +470,24 @@ end:
 	return ret;
 }
 
+int coap_service_is_running(const struct coap_service *service)
+{
+	int ret;
+
+	if (!coap_service_in_section(service)) {
+		__ASSERT_NO_MSG(false);
+		return -EINVAL;
+	}
+
+	k_mutex_lock(&lock, K_FOREVER);
+
+	ret = (service->data->sock_fd < 0) ? 0 : 1;
+
+	k_mutex_unlock(&lock);
+
+	return ret;
+}
+
 int coap_service_send(const struct coap_service *service, const struct coap_packet *cpkt,
 		      const struct sockaddr *addr, socklen_t addr_len)
 {


### PR DESCRIPTION
Make sure the socket file descriptor is initialised to `-1` and add an API function to query the CoAP service running state.