### PR TITLE
west.yml: hal stm32: bridge critical gaps between upstream CubeH5 repo & Zephyr HAL H5 module

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -229,7 +229,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: af2d314b6f7f87cfa8365009497132468ca3a686
+      revision: fa44367c3f350b40706026e19ce37330a86fa5cf
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
H5 Cube files first introduced in the hal_stm32 Zephyr repo were not the exact files released in v1.0.0 in the upstream GitHub repo.

The gap was not bridged in the subsequent update to v1.1.0.

This patch fixes the problem & brings CubeH5 module in the hal_stm32 Zephyr repo up to date with the upstream CubeH5 repo.