### PR TITLE
twister: qemu: Fix race condition at QEMUHandler

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -988,6 +988,7 @@ class QEMUHandler(Handler):
         self.thread.daemon = True
         logger.debug("Spawning QEMUHandler Thread for %s" % self.name)
         self.thread.start()
+        thread_max_time = time.time() + self.get_test_timeout()
         if sys.stdout.isatty():
             subprocess.call(["stty", "sane"], stdin=sys.stdout)
 
@@ -1019,8 +1020,8 @@ class QEMUHandler(Handler):
                 self.returncode = proc.returncode
             # Need to wait for harness to finish processing
             # output from QEMU. Otherwise it might miss some
-            # error messages.
-            self.thread.join(0)
+            # messages.
+            self.thread.join(max(thread_max_time - time.time(), 0))
             if self.thread.is_alive():
                 logger.debug("Timed out while monitoring QEMU output")
 


### PR DESCRIPTION
A race condition was possible at QEMUHandler which didn't wait for its harness thread to complete causing false negatives and test suite retries, for example when the console harness has got rather long output from a test application to check for patterns.