### PR TITLE
tests: zbus: replacing K_NO_WAIT with K_FOREVER in integration tests

### DIFF
--- a/tests/subsys/zbus/integration/src/main.c
+++ b/tests/subsys/zbus/integration/src/main.c
@@ -40,7 +40,7 @@ static void core_thread(void)
 
 			struct sensor_data_msg data;
 
-			zbus_chan_read(&sensor_data_chan, &data, K_NO_WAIT);
+			zbus_chan_read(&sensor_data_chan, &data, K_FOREVER);
 
 			struct net_pkt_msg pkt = {.total = data.a + data.b};
 
@@ -66,8 +66,7 @@ static void net_thread(void)
 	while (1) {
 		if (!zbus_sub_wait(&net_sub, &chan, K_FOREVER)) {
 			count_net++;
-
-			zbus_chan_read(&net_pkt_chan, &pkt, K_NO_WAIT);
+			zbus_chan_read(&net_pkt_chan, &pkt, K_FOREVER);
 
 			LOG_DBG("[Net] Total %d", pkt.total);
 


### PR DESCRIPTION
The zbus_chan_read with K_NO_WAIT was generating a fail in the qemu_riscv32_smp board. This fix replaces the K_NO_WAIT with a K_FOREVER on the test, which would not affect the test execution for other platforms/boards.