### PR TITLE
drivers: sensor: vl53l1x: support for multiple sensors (i2c reconfigure)

### DIFF
--- a/drivers/sensor/vl53l1x/Kconfig
+++ b/drivers/sensor/vl53l1x/Kconfig
@@ -29,4 +29,17 @@ config VL53L1X_XSHUT
 	  Enable to use the xshut pin on the VL53L1X. If not, the pin should be
 	  connected to VDD.
 
+config VL53L1X_RECONFIGURE_ADDRESS
+	bool "Support reconfigurable sensor address"
+	depends on VL53L1X
+	help
+	  Enable support for reconfiguring the sensor address at runtime.
+	  When this option is enabled, all sensors declared in the device tree
+	  must have an xshut-gpio property.
+
+	  All sensors are disabled during initialization. When reading the first
+	  value from a sensor, it is powered up and its I2C address is reconfigured
+	  from the manufacturer default (0x29) to the address specified in the
+	  device tree.
+
 endif # VL53L1X

--- a/drivers/sensor/vl53l1x/vl53l1_platform.c
+++ b/drivers/sensor/vl53l1x/vl53l1_platform.c
@@ -33,7 +33,7 @@ VL53L1_Error VL53L1_WriteMulti(VL53L1_Dev_t *pdev, uint16_t reg,
 
 	memcpy(&buffer[2], pdata, count);
 
-	status_int = i2c_write_dt(pdev->i2c, buffer, count + 2);
+	status_int = i2c_write(pdev->i2c, buffer, count + 2, pdev->I2cDevAddr);
 
 	if (status_int < 0) {
 		status = VL53L1_ERROR_CONTROL_INTERFACE;
@@ -51,7 +51,7 @@ VL53L1_Error VL53L1_ReadMulti(VL53L1_Dev_t *pdev, uint16_t reg,
 
 	reg = sys_cpu_to_be16(reg);
 
-	status_int = i2c_write_read_dt(pdev->i2c, (uint8_t *)(&reg), 2, pdata, count);
+	status_int = i2c_write_read(pdev->i2c, pdev->I2cDevAddr, (uint8_t *)(&reg), 2, pdata, count);
 
 	if (status_int < 0) {
 		status = VL53L1_ERROR_CONTROL_INTERFACE;

--- a/drivers/sensor/vl53l1x/vl53l1_platform.c
+++ b/drivers/sensor/vl53l1x/vl53l1_platform.c
@@ -51,7 +51,8 @@ VL53L1_Error VL53L1_ReadMulti(VL53L1_Dev_t *pdev, uint16_t reg,
 
 	reg = sys_cpu_to_be16(reg);
 
-	status_int = i2c_write_read(pdev->i2c, pdev->I2cDevAddr, (uint8_t *)(&reg), 2, pdata, count);
+	status_int = i2c_write_read(pdev->i2c, pdev->I2cDevAddr,
+			(uint8_t *)(&reg), 2, pdata, count);
 
 	if (status_int < 0) {
 		status = VL53L1_ERROR_CONTROL_INTERFACE;

--- a/drivers/sensor/vl53l1x/vl53l1_platform_user_data.h
+++ b/drivers/sensor/vl53l1x/vl53l1_platform_user_data.h
@@ -27,7 +27,8 @@ typedef struct {
 	/*!< New data ready poll duration in ms - for debug */
 	uint32_t new_data_ready_poll_duration_ms;
 	/*!< I2C device handle */
-	const struct i2c_dt_spec *i2c;
+	uint8_t I2cDevAddr;      /* i2c device address user specific field */
+	const struct device *i2c;
 } VL53L1_Dev_t;
 
 


### PR DESCRIPTION
The current driver for the VL53L1X does not include any functionality to reconfigure the I2C addresses of the sensors, for use with multiple chips. It is based on a similar setup included in the VL53L0X sensor driver. By setting the new
CONFIG_VL53L1X_RECONFIGURE_ADDRESS option, sensors can be specified in the device tree with their intended new address, and the driver will set this up automatically.

The new driver also moves the gpio_pin_interrupt_configure call from vl53l1x_sample_fetch to vl53l1x_init_interrupt. By calling it once per sample, the interrupt was correctly configured on the first sensor fetch, however on the second sensor fetch the already initialised gpio would return an EBUSY error code and the program would exit.