### PR TITLE
samples/spi_flash: Verify that sector is erased

### DIFF
--- a/samples/drivers/spi_flash/src/main.c
+++ b/samples/drivers/spi_flash/src/main.c
@@ -33,6 +33,7 @@
 void single_sector_test(const struct device *flash_dev)
 {
 	const uint8_t expected[] = { 0x55, 0xaa, 0x66, 0x99 };
+	const uint8_t erased[sizeof(expected)] = { 0xff, 0xff, 0xff, 0xff };
 	const size_t len = sizeof(expected);
 	uint8_t buf[sizeof(expected)];
 	int rc;
@@ -54,6 +55,18 @@ void single_sector_test(const struct device *flash_dev)
 		printf("Flash erase failed! %d\n", rc);
 	} else {
 		printf("Flash erase succeeded!\n");
+	}
+
+	/* Check that the bytes we will later write has the erase value. */
+	rc = flash_read(flash_dev, SPI_FLASH_TEST_REGION_OFFSET, buf, len);
+	if (rc != 0) {
+		printf("Flash read failed! %d\n", rc);
+		return;
+	}
+	if (memcmp(erased, buf, sizeof(buf)) != 0) {
+		printf("Flash erase did not erase flash.\n");
+		printf(" Read expected ff ff ff ff, but got %02x %02x %02x %02x\n",
+		       buf[0], buf[1], buf[2], buf[3]);
 	}
 
 	printf("\nTest 2: Flash write\n");


### PR DESCRIPTION
Edit: Updated the description to match the commit message.

samples/spi_flash: Verify that bytes are written by the sample

Before this commit, the sample did the sequence:
- 1a. Erase a sector
- 2a. Write 4 bytes of the sector with known values
- 3a. Read back the 4 bytes and check that the values match with the
    values written in 2.

This commit adds the additional step 1b between steps 1a and 2a above.
The updated sequence is:
- 1a. Erase a sector
- 1b. Read back the 4 bytes which will later be written in step 2a and
    make sure that they have the erased state.
- 2a. Write 4 bytes of the sector with known values
- 3a. Read back the 4 bytes and check that the values match with the
    values written in 2.
    
The purpose of step 1b above is to catch the case when the expected 4
byte values for some reason are already present in the flash, combined
with the SPI/flash driver failing to properly erase/write in step 1a/2a.


This was the original PR description:
~~After calling flash_erase(), make it probable that the sector was actually erased.
It will catch the cases where you have run the sample previously and then something has broken in the SPI driver or flash subsystem but the sample still reports everything is all right.~~