### PR TITLE
lib/posix: Initialise variable

### DIFF
--- a/lib/posix/pthread.c
+++ b/lib/posix/pthread.c
@@ -468,7 +468,7 @@ int pthread_create(pthread_t *th, const pthread_attr_t *_attr, void *(*threadrou
 
 int pthread_getconcurrency(void)
 {
-	int ret;
+	int ret = 0;
 
 	K_SPINLOCK(&pthread_pool_lock) {
 		ret = pthread_concurrency;


### PR DESCRIPTION
In a seemingly false positive case, compiler complain about variable possibly being not initialised when returned. Initialise it and make silly compiler happy.

One can see such issue at https://github.com/zephyrproject-rtos/zephyr/actions/runs/7012140425/job/19076172796#step:13:1386