### PR TITLE
shell: Add synchronization for prompt-string access in shell

### DIFF
--- a/include/zephyr/shell/shell.h
+++ b/include/zephyr/shell/shell.h
@@ -26,6 +26,10 @@
 extern "C" {
 #endif
 
+#ifndef CONFIG_SHELL_PROMPT_BUFF_SIZE
+#define CONFIG_SHELL_PROMPT_BUFF_SIZE 0
+#endif
+
 #ifndef CONFIG_SHELL_CMD_BUFF_SIZE
 #define CONFIG_SHELL_CMD_BUFF_SIZE 0
 #endif
@@ -779,7 +783,11 @@ enum shell_signal {
  * @brief Shell instance context.
  */
 struct shell_ctx {
-	const char *prompt; /*!< shell current prompt. */
+#if defined(CONFIG_SHELL_PROMPT_CHANGE) && CONFIG_SHELL_PROMPT_CHANGE
+	char prompt[CONFIG_SHELL_PROMPT_BUFF_SIZE]; /*!< shell current prompt. */
+#else
+	const char *prompt;
+#endif
 
 	enum shell_state state; /*!< Internal module state.*/
 	enum shell_receive_state receive_state;/*!< Escape sequence indicator.*/

--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -55,6 +55,24 @@ config SHELL_BACKSPACE_MODE_DELETE
 	  Some terminals send code: 0x08 (backspace) other 0x7F (delete). When
 	  this option is set shell will expect 0x7F for backspace key.
 
+config SHELL_PROMPT_CHANGE
+	bool "Allow prompt change in runtime"
+	default y if !SHELL_MINIMAL
+	help
+	  Allow for the modification of the shell prompt at runtime.
+	  Enabling this will allocate additional RAM memory where
+	  the string of the prompt will be stored.
+
+config SHELL_PROMPT_BUFF_SIZE
+	int "Shell prompt buffer size"
+	depends on SHELL_PROMPT_CHANGE
+	range 2 40
+	default 10 if SHELL_MINIMAL
+	default 20
+	help
+	  Maximum prompt size in bytes. One byte is reserved for the string
+	  terminator character.
+
 config SHELL_CMD_BUFF_SIZE
 	int "Shell command buffer size"
 	default 128 if SHELL_MINIMAL


### PR DESCRIPTION
Resolved a data race in shell.c by copying the user-provided prompt-string into a private buffer within the shell, ensuring proper synchronization with the shell-thread.

Fixes: #64972