### PR TITLE
bluetooth: Add CPF attribute to BAS battery level.

### DIFF
--- a/subsys/bluetooth/services/bas.c
+++ b/subsys/bluetooth/services/bas.c
@@ -47,6 +47,17 @@ static ssize_t read_blvl(struct bt_conn *conn,
 				 sizeof(lvl8));
 }
 
+/* Constant values from the Assigned Numbers specification:
+ * https://www.bluetooth.com/wp-content/uploads/Files/Specification/Assigned_Numbers.pdf?id=89
+ */
+static const struct bt_gatt_cpf level_cpf = {
+	.format = 0x04,        /* uint8 */
+	.exponent = 0x0,
+	.unit = 0x27AD,        /* Percentage */
+	.name_space = 0x01,    /* Bluetooth SIG */
+	.description = 0x0106, /* "main" */
+};
+
 BT_GATT_SERVICE_DEFINE(bas,
 	BT_GATT_PRIMARY_SERVICE(BT_UUID_BAS),
 	BT_GATT_CHARACTERISTIC(BT_UUID_BAS_BATTERY_LEVEL,
@@ -55,6 +66,7 @@ BT_GATT_SERVICE_DEFINE(bas,
 			       &battery_level),
 	BT_GATT_CCC(blvl_ccc_cfg_changed,
 		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE),
+	BT_GATT_CPF(&level_cpf),
 );
 
 static int bas_init(void)


### PR DESCRIPTION
BAS v1.1, section 3.1.2.1 notes that a CPF should be added if the device has more that one instance of the Battery Service, so add one with the `main` description so that apps can add additional Battery Level services with other descriptions, e.g. `auxiliary`.

We intend to use this in ZMK so we can properly report battery level from secondary connected devices for our "split keyboard" support. I've done testing on Linux, W11, and macOS, and all three so far seem happy to still pick up and report the "main" battery levels, even when an additional Battery Service is added with levels with other CPF description values.