### PR TITLE
RISCV: Support the riscv CMO extension

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -346,6 +346,14 @@ config GEN_IRQ_VECTOR_TABLE
 config ARCH_HAS_SINGLE_THREAD_SUPPORT
 	default y if !SMP
 
+config CBOM_ICACHE_SUPPORTED
+	bool
+	depends on RISCV_ISA_EXT_ZICBOM && ICACHE
+
+config CBOM_DCACHE_SUPPORTED
+	bool
+	depends on RISCV_ISA_EXT_ZICBOM && DCACHE
+
 rsource "Kconfig.isa"
 rsource "Kconfig.core"
 

--- a/arch/riscv/Kconfig.isa
+++ b/arch/riscv/Kconfig.isa
@@ -146,3 +146,26 @@ config RISCV_ISA_EXT_ZBS
 	  The Zbs instructions can be used for single-bit instructions that
 	  provide a mechanism to set, clear, invert, or extract a single bit in
 	  a register.
+
+config RISCV_ISA_EXT_ZICBOM
+	bool
+	help
+	  (Zicbom) - Standard Extension for Cache Management
+
+	  The Zicbom extension defines a set of cache-block management instructions:
+	  CBO.INVAL, CBO.CLEAN, and CBO.FLUSH.
+
+config RISCV_ISA_EXT_ZICBOZ
+	bool
+	help
+	  (Zicboz) - Standard Extension for Cache Zero Operation
+
+	  The Zicboz extension defines a cache-block zero instruction: CBO.ZERO.
+
+config RISCV_ISA_EXT_ZICBOP
+	bool
+	help
+	  (Zicbop) - Standard Extension for Cache Prefetch Operation
+
+	  The Zicbop extension defines a set of cache-block prefetch instructions:
+	  PREFETCH.R, PREFETCH.W, and PREFETCH.I.

--- a/arch/riscv/core/smp.c
+++ b/arch/riscv/core/smp.c
@@ -71,6 +71,9 @@ void arch_secondary_cpu_init(int hartid)
 #ifdef CONFIG_RISCV_PMP
 	z_riscv_pmp_init();
 #endif
+#if defined(CONFIG_ARCH_CACHE)
+	z_riscv_cache_init();
+#endif
 #ifdef CONFIG_SMP
 	irq_enable(RISCV_IRQ_MSOFT);
 #endif

--- a/arch/riscv/include/kernel_arch_func.h
+++ b/arch/riscv/include/kernel_arch_func.h
@@ -16,6 +16,7 @@
 #define ZEPHYR_ARCH_RISCV_INCLUDE_KERNEL_ARCH_FUNC_H_
 
 #include <kernel_arch_data.h>
+#include <zephyr/cache.h>
 #include <pmp.h>
 
 #ifdef __cplusplus
@@ -52,6 +53,9 @@ static ALWAYS_INLINE void arch_kernel_init(void)
 #endif
 #ifdef CONFIG_RISCV_PMP
 	z_riscv_pmp_init();
+#endif
+#if defined(CONFIG_ARCH_CACHE)
+	z_riscv_cache_init();
 #endif
 }
 

--- a/cmake/compiler/gcc/target_riscv.cmake
+++ b/cmake/compiler/gcc/target_riscv.cmake
@@ -69,5 +69,17 @@ if(CONFIG_RISCV_ISA_EXT_ZBS)
     string(CONCAT riscv_march ${riscv_march} "_zbs")
 endif()
 
+if(CONFIG_RISCV_ISA_EXT_ZICBOM)
+    string(CONCAT riscv_march ${riscv_march} "_zicbom")
+endif()
+
+if(CONFIG_RISCV_ISA_EXT_ZICBOZ)
+    string(CONCAT riscv_march ${riscv_march} "_zicboz")
+endif()
+
+if(CONFIG_RISCV_ISA_EXT_ZICBOP)
+    string(CONCAT riscv_march ${riscv_march} "_zicbop")
+endif()
+
 list(APPEND TOOLCHAIN_C_FLAGS -mabi=${riscv_mabi} -march=${riscv_march})
 list(APPEND TOOLCHAIN_LD_FLAGS NO_SPLIT -mabi=${riscv_mabi} -march=${riscv_march})

--- a/include/zephyr/arch/cache.h
+++ b/include/zephyr/arch/cache.h
@@ -23,6 +23,8 @@
 #include <zephyr/arch/arm64/cache.h>
 #elif defined(CONFIG_XTENSA)
 #include <zephyr/arch/xtensa/cache.h>
+#elif defined(CONFIG_RISCV)
+#include <zephyr/arch/riscv/cache.h>
 #endif
 
 #if defined(CONFIG_DCACHE) || defined(__DOXYGEN__)

--- a/include/zephyr/arch/riscv/cache.h
+++ b/include/zephyr/arch/riscv/cache.h
@@ -1,0 +1,309 @@
+/*
+ * Copyright 2023 Andestech
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/arch/riscv/csr.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/barrier.h>
+
+static struct k_spinlock cache_lock;
+
+#ifdef CONFIG_DCACHE
+static ALWAYS_INLINE size_t arch_dcache_line_size_get(void)
+{
+	size_t dcache_line_size = 0;
+
+#if (CONFIG_DCACHE_LINE_SIZE != 0)
+	dcache_line_size = CONFIG_DCACHE_LINE_SIZE;
+#elif DT_NODE_HAS_PROP(DT_PATH(cpus, cpu_0), d_cache_line_size)
+	dcache_line_size =
+		DT_PROP(DT_PATH(cpus, cpu_0), "d_cache_line_size");
+#else
+	dcache_line_size = 0;
+#endif
+
+	return dcache_line_size;
+}
+
+static ALWAYS_INLINE void arch_dcache_enable(void)
+{
+	/* nothing */
+}
+
+static ALWAYS_INLINE void arch_dcache_disable(void)
+{
+	/* nothing */
+}
+
+static ALWAYS_INLINE int arch_dcache_flush_all(void)
+{
+	return -ENOTSUP;
+}
+
+static ALWAYS_INLINE int arch_dcache_invd_all(void)
+{
+	return -ENOTSUP;
+}
+
+static ALWAYS_INLINE int arch_dcache_flush_and_invd_all(void)
+{
+	return -ENOTSUP;
+}
+
+#ifndef CONFIG_CBOM_DCACHE_SUPPORTED
+static ALWAYS_INLINE int arch_dcache_flush_range(void *start_addr, size_t size)
+{
+	return -ENOTSUP;
+}
+
+static ALWAYS_INLINE int arch_dcache_invd_range(void *start_addr, size_t size)
+{
+	return -ENOTSUP;
+}
+
+static ALWAYS_INLINE int arch_dcache_flush_and_invd_range(void *start_addr, size_t size)
+{
+	return -ENOTSUP;
+}
+
+#else
+static ALWAYS_INLINE int arch_dcache_flush_range(void *start_addr, size_t size)
+{
+	unsigned long last_byte, align_addr;
+	size_t line_size;
+	k_spinlock_key_t key;
+
+	line_size = arch_dcache_line_size_get();
+
+	if (line_size == 0) {
+		return -ENOTSUP;
+	}
+
+	key = k_spin_lock(&cache_lock);
+	last_byte = (unsigned long)start_addr + size - 1;
+
+	for (align_addr = ROUND_DOWN(start_addr, line_size); align_addr <= last_byte;
+			align_addr += line_size) {
+		cbo_clean(align_addr);
+	}
+
+	k_spin_unlock(&cache_lock, key);
+
+	return 0;
+}
+
+static ALWAYS_INLINE int arch_dcache_invd_range(void *start_addr, size_t size)
+{
+	unsigned long last_byte, align_addr;
+	size_t line_size;
+	k_spinlock_key_t key;
+
+	line_size = arch_dcache_line_size_get();
+
+	if (line_size == 0) {
+		return -ENOTSUP;
+	}
+
+	key = k_spin_lock(&cache_lock);
+	last_byte = (unsigned long)start_addr + size - 1;
+
+	for (align_addr = ROUND_DOWN(start_addr, line_size); align_addr <= last_byte;
+		align_addr += line_size) {
+
+		cbo_inval(align_addr);
+	}
+
+	k_spin_unlock(&cache_lock, key);
+
+	return 0;
+}
+
+static ALWAYS_INLINE int arch_dcache_flush_and_invd_range(void *start_addr, size_t size)
+{
+	unsigned long last_byte, align_addr;
+	size_t line_size;
+	k_spinlock_key_t key;
+
+	line_size = arch_dcache_line_size_get();
+
+	if (line_size == 0) {
+		return -ENOTSUP;
+	}
+
+	key = k_spin_lock(&cache_lock);
+	last_byte = (unsigned long)start_addr + size - 1;
+
+	for (align_addr = ROUND_DOWN(start_addr, line_size); align_addr <= last_byte;
+		align_addr += line_size) {
+
+		cbo_flush(align_addr);
+	}
+
+	k_spin_unlock(&cache_lock, key);
+
+	return 0;
+}
+#endif
+#endif
+
+#ifdef CONFIG_ICACHE
+static ALWAYS_INLINE size_t arch_icache_line_size_get(void)
+{
+	size_t icache_line_size = 0;
+
+#if (CONFIG_ICACHE_LINE_SIZE != 0)
+	icache_line_size = CONFIG_ICACHE_LINE_SIZE;
+#elif DT_NODE_HAS_PROP(DT_PATH(cpus, cpu_0), i_cache_line_size)
+	icache_line_size =
+		DT_PROP(DT_PATH(cpus, cpu_0), "i_cache_line_size");
+#else
+	icache_line_size = 0;
+#endif
+
+	return icache_line_size;
+}
+
+static ALWAYS_INLINE void arch_icache_enable(void)
+{
+	/* nothing */
+}
+
+
+static ALWAYS_INLINE void arch_icache_disable(void)
+{
+	/* nothing */
+}
+
+static ALWAYS_INLINE int arch_icache_flush_all(void)
+{
+	return -ENOTSUP;
+}
+
+static ALWAYS_INLINE int arch_icache_invd_all(void)
+{
+	return -ENOTSUP;
+}
+
+static ALWAYS_INLINE int arch_icache_flush_and_invd_all(void)
+{
+	return -ENOTSUP;
+}
+
+#ifndef CONFIG_CBOM_ICACHE_SUPPORTED
+static ALWAYS_INLINE int arch_icache_flush_range(void *start_addr, size_t size)
+{
+	return -ENOTSUP;
+}
+
+static ALWAYS_INLINE int arch_icache_invd_range(void *start_addr, size_t size)
+{
+	return -ENOTSUP;
+}
+
+static ALWAYS_INLINE int arch_icache_flush_and_invd_range(void *start_addr, size_t size)
+{
+	return -ENOTSUP;
+}
+
+#else
+static ALWAYS_INLINE int arch_icache_flush_range(void *start_addr, size_t size)
+{
+	unsigned long last_byte, align_addr;
+	size_t line_size;
+	k_spinlock_key_t key;
+
+	line_size = arch_icache_line_size_get();
+
+	if (line_size == 0) {
+		return -ENOTSUP;
+	}
+
+	key = k_spin_lock(&cache_lock);
+	last_byte = (unsigned long)start_addr + size - 1;
+
+	for (align_addr = ROUND_DOWN(start_addr, line_size); align_addr <= last_byte;
+		align_addr += line_size) {
+
+		cbo_clean(align_addr);
+	}
+
+	k_spin_unlock(&cache_lock, key);
+
+	return 0;
+}
+
+static ALWAYS_INLINE int arch_icache_invd_range(void *start_addr, size_t size)
+{
+	unsigned long last_byte, align_addr;
+	size_t line_size;
+	k_spinlock_key_t key;
+
+	line_size = arch_icache_line_size_get();
+
+	if (line_size == 0) {
+		return -ENOTSUP;
+	}
+
+	key = k_spin_lock(&cache_lock);
+	last_byte = (unsigned long)start_addr + size - 1;
+
+	for (align_addr = ROUND_DOWN(start_addr, line_size); align_addr <= last_byte;
+		align_addr += line_size) {
+
+		cbo_inval(align_addr);
+	}
+
+	k_spin_unlock(&cache_lock, key);
+
+	return 0;
+}
+
+static ALWAYS_INLINE int arch_icache_flush_and_invd_range(void *start_addr, size_t size)
+{
+	unsigned long last_byte, align_addr;
+	size_t line_size;
+	k_spinlock_key_t key;
+
+	line_size = arch_icache_line_size_get();
+
+	if (line_size == 0) {
+		return -ENOTSUP;
+	}
+
+	key = k_spin_lock(&cache_lock);
+	last_byte = (unsigned long)start_addr + size - 1;
+
+	for (align_addr = ROUND_DOWN(start_addr, line_size); align_addr <= last_byte;
+		align_addr += line_size) {
+
+		cbo_flush(align_addr);
+	}
+
+	k_spin_unlock(&cache_lock, key);
+
+	return 0;
+}
+#endif /* CONFIG_CBOM_ICACHE_SUPPORTED */
+#endif /* CONFIG_ICACHE */
+
+extern void __soc_cache_init(void);
+void __weak __soc_cache_init(void) {}
+
+static ALWAYS_INLINE int z_riscv_cache_init(void)
+{
+	unsigned long reg_val = 0;
+
+	__soc_cache_init();
+
+#ifdef CONFIG_RISCV_ISA_EXT_ZICBOM
+	reg_val = reg_val | (GENMASK(6, 4));
+#endif
+#ifdef CONFIG_RISCV_ISA_EXT_ZICBOZ
+	reg_val = reg_val | BIT(7);
+#endif
+	csr_set(menvcfg, reg_val);
+
+	return 0;
+}

--- a/include/zephyr/arch/riscv/csr.h
+++ b/include/zephyr/arch/riscv/csr.h
@@ -234,3 +234,18 @@
 })
 
 #endif /* CSR_H_ */
+
+#define cbo_flush(addr)						\
+({								\
+	__asm__ volatile("cbo.flush 0(%0);":: "r" (addr):);	\
+})
+
+#define cbo_clean(addr)						\
+({								\
+	__asm__ volatile("cbo.clean 0(%0);":: "r" (addr):);	\
+})
+
+#define cbo_inval(addr)						\
+({								\
+	__asm__ volatile("cbo.inval 0(%0);":: "r" (addr):);	\
+})


### PR DESCRIPTION
We implement the arch cache driver in RISCV to support the CMO extension, and also add some Kconfig to config the extension.
And this implenmentation has been verifide by running the "test/kernel/cache" testcase on generic qemu_riscv32(the riscv qemu in Zephyr has not supported CMO extension yet) which was compiled with generic prebuild riscv32 gcc toolchain(the riscv toolchain in Zephyr has not supported CMO extension yet).
The prebuild riscv toolchain is from: https://github.com/stnolting/riscv-gcc-prebuilt.
