### PR TITLE
Twister: runner: Option to filter test/sample projects post build

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -114,6 +114,13 @@ Artificially long but functional example:
         help="Run only those tests that failed the previous twister run "
              "invocation.")
 
+    case_select.add_argument(
+        "--dyn-filter",
+        action="store",
+        choices=["changed_src"],
+        nargs="+",
+        help="Run only the test-/sample-projects that have changed .c/.h file dependencies.")
+
     case_select.add_argument("--list-tests", action="store_true",
                              help="""List of all sub-test functions recursively found in
         all --testsuite-root arguments. Note different sub-tests can share

--- a/scripts/tests/twister/test_runner.py
+++ b/scripts/tests/twister/test_runner.py
@@ -1507,6 +1507,7 @@ def test_projectbuilder_process(
 
     pb = ProjectBuilder(instance_mock, env_mock, mocked_jobserver)
     pb.options = mock.Mock()
+    pb.options.dyn_filter = ['dummy_arg1', 'dummy_arg2']
     pb.options.coverage = options_coverage
     pb.options.prep_artifacts_for_testing = options_prep_artifacts
     pb.options.runtime_artifact_cleanup = options_runtime_artifacts


### PR DESCRIPTION
Added a the possibility to only run test/sample projects if the source code of their ninja dependencies has changed in relation to the merge base with the main branch. This has to happen post build, when the ninja dependencies are available.

This is an implementation that addresses the following issue: #64313 