### PR TITLE
drivers: can: native_posix_linux: add embedded libc support

### DIFF
--- a/boards/posix/native_sim/doc/index.rst
+++ b/boards/posix/native_sim/doc/index.rst
@@ -605,7 +605,7 @@ host libC (:kconfig:option:`CONFIG_EXTERNAL_LIBC`):
 
      adc, ADC emul, :kconfig:option:`CONFIG_ADC_EMUL`, all
      bluetooth, userchan, :kconfig:option:`CONFIG_BT_USERCHAN`, host libC
-     can, can native posix, :kconfig:option:`CONFIG_CAN_NATIVE_POSIX_LINUX`, host libC
+     can, can native posix, :kconfig:option:`CONFIG_CAN_NATIVE_POSIX_LINUX`, all
      console backend, POSIX arch console, :kconfig:option:`CONFIG_POSIX_ARCH_CONSOLE`, all
      display, display SDL, :kconfig:option:`CONFIG_SDL_DISPLAY`, all
      entropy, native posix entropy, :kconfig:option:`CONFIG_FAKE_ENTROPY_NATIVE_POSIX`, all

--- a/drivers/can/CMakeLists.txt
+++ b/drivers/can/CMakeLists.txt
@@ -20,22 +20,6 @@ zephyr_library_sources_ifdef(CONFIG_CAN_STM32H7_FDCAN can_stm32h7_fdcan.c)
 zephyr_library_sources_ifdef(CONFIG_CAN_TCAN4X5X     can_tcan4x5x.c)
 zephyr_library_sources_ifdef(CONFIG_CAN_RCAR         can_rcar.c)
 zephyr_library_sources_ifdef(CONFIG_CAN_NUMAKER      can_numaker.c)
-
-if(CONFIG_CAN_NATIVE_POSIX_LINUX)
-  if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL Linux)
-    zephyr_library_include_directories(${ZEPHYR_BASE}/subsys/net/l2)
-    zephyr_library_compile_definitions(NO_POSIX_CHEATS)
-    zephyr_library_compile_definitions(_BSD_SOURCE)
-    zephyr_library_compile_definitions(_DEFAULT_SOURCE)
-    zephyr_library_sources(
-      can_native_posix_linux.c
-      can_native_posix_linux_socketcan.c
-    )
-  else()
-    message(FATAL_ERROR "CONFIG_CAN_NATIVE_POSIX_LINUX only available on Linux")
-  endif()
-endif()
-
 zephyr_library_sources_ifdef(CONFIG_CAN_SJA1000      can_sja1000.c)
 zephyr_library_sources_ifdef(CONFIG_CAN_ESP32_TWAI   can_esp32_twai.c)
 zephyr_library_sources_ifdef(CONFIG_CAN_KVASER_PCI   can_kvaser_pci.c)
@@ -43,5 +27,23 @@ zephyr_library_sources_ifdef(CONFIG_CAN_KVASER_PCI   can_kvaser_pci.c)
 zephyr_library_sources_ifdef(CONFIG_USERSPACE        can_handlers.c)
 zephyr_library_sources_ifdef(CONFIG_CAN_SHELL        can_shell.c)
 zephyr_library_sources_ifdef(CONFIG_CAN_NXP_S32_CANXL    can_nxp_s32_canxl.c)
+
+if(CONFIG_CAN_NATIVE_POSIX_LINUX)
+  if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL Linux)
+    zephyr_library_include_directories(${ZEPHYR_BASE}/subsys/net/l2)
+    zephyr_library_sources(can_native_posix_linux.c)
+
+    if (CONFIG_NATIVE_APPLICATION)
+      set_source_files_properties(can_native_posix_linux_socketcan.c
+        PROPERTIES COMPILE_DEFINITIONS
+        "NO_POSIX_CHEATS;_BSD_SOURCE;_DEFAULT_SOURCE")
+      zephyr_library_sources(can_native_posix_linux_socketcan.c)
+    else()
+      target_sources(native_simulator INTERFACE can_native_posix_linux_socketcan.c)
+    endif()
+  else()
+    message(FATAL_ERROR "CONFIG_CAN_NATIVE_POSIX_LINUX only available on Linux")
+  endif()
+endif()
 
 add_subdirectory(transceiver)

--- a/drivers/can/Kconfig.native_posix_linux
+++ b/drivers/can/Kconfig.native_posix_linux
@@ -7,6 +7,7 @@ config CAN_NATIVE_POSIX_LINUX
 	bool "Native Linux SocketCAN Driver"
 	default y
 	depends on DT_HAS_ZEPHYR_NATIVE_POSIX_LINUX_CAN_ENABLED
+	depends on ARCH_POSIX
 	help
 	  Enable native Linux SocketCAN Driver
 

--- a/drivers/can/can_native_posix_linux_socketcan.c
+++ b/drivers/can/can_native_posix_linux_socketcan.c
@@ -27,6 +27,7 @@
 #include <sys/socket.h>
 #include <sys/select.h>
 #include <net/if.h>
+#include <linux/if.h>
 #include <linux/can.h>
 #include <linux/can/raw.h>
 #else

--- a/drivers/can/can_native_posix_linux_socketcan.c
+++ b/drivers/can/can_native_posix_linux_socketcan.c
@@ -149,18 +149,6 @@ ssize_t linux_socketcan_write_data(int fd, void *buf, size_t buf_len)
 	return write(fd, buf, buf_len);
 }
 
-int linux_socketcan_setsockopt(int fd, int level, int optname,
-			       const void *optval, socklen_t optlen)
-{
-	return setsockopt(fd, level, optname, optval, optlen);
-}
-
-int linux_socketcan_getsockopt(int fd, int level, int optname,
-			       void *optval, socklen_t *optlen)
-{
-	return getsockopt(fd, level, optname, optval, optlen);
-}
-
 int linux_socketcan_set_mode_fd(int fd, bool mode_fd)
 {
 	int opt = mode_fd ? 1 : 0;

--- a/drivers/can/can_native_posix_linux_socketcan.h
+++ b/drivers/can/can_native_posix_linux_socketcan.h
@@ -21,12 +21,6 @@ ssize_t linux_socketcan_read_data(int fd, void *buf, size_t buf_len, bool *msg_c
 
 ssize_t linux_socketcan_write_data(int fd, void *buf, size_t buf_len);
 
-int linux_socketcan_setsockopt(int fd, int level, int optname, const void *optval,
-			       socklen_t optlen);
-
-int linux_socketcan_getsockopt(int fd, int level, int optname, void *optval,
-			       socklen_t *optlen);
-
 int linux_socketcan_set_mode_fd(int fd, bool mode_fd);
 
 #endif /* ZEPHYR_DRIVERS_CAN_NATIVE_POSIX_LINUX_SOCKETCAN_H_ */

--- a/tests/drivers/build_all/can/boards/native_posix.overlay
+++ b/tests/drivers/build_all/can/boards/native_posix.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2023 Vestas Wind Systems A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "native_sim.overlay"

--- a/tests/drivers/build_all/can/boards/native_posix_64.overlay
+++ b/tests/drivers/build_all/can/boards/native_posix_64.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2023 Vestas Wind Systems A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "native_posix.overlay"

--- a/tests/drivers/build_all/can/boards/native_sim.overlay
+++ b/tests/drivers/build_all/can/boards/native_sim.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2023 Vestas Wind Systems A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&can_loopback0 {
+	status = "disabled";
+};
+
+&can0 {
+	status = "okay";
+};

--- a/tests/drivers/build_all/can/boards/native_sim_64.overlay
+++ b/tests/drivers/build_all/can/boards/native_sim_64.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2023 Vestas Wind Systems A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "native_sim.overlay"

--- a/tests/drivers/build_all/can/testcase.yaml
+++ b/tests/drivers/build_all/can/testcase.yaml
@@ -19,3 +19,9 @@ tests:
   drivers.can.build_all.mcp251xfd:
     extra_args: SHIELD=mikroe_mcp2518fd_click
     platform_allow: lpcxpresso55s28
+  drivers.can.build_all.native_posix_linux:
+    platform_allow:
+      - native_posix
+      - native_posix_64
+      - native_sim
+      - native_sim_64


### PR DESCRIPTION
Add support for compiling the native POSIX Linux (SocketCAN) driver with an embedded C-library. Add build-only test for the native POSIX Linux (SocketCAN) driver.