### PR TITLE
dts: boards: mercury_xu: Select shell-uart

### DIFF
--- a/boards/arm/mercury_xu/mercury_xu.dts
+++ b/boards/arm/mercury_xu/mercury_xu.dts
@@ -13,6 +13,7 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};


### PR DESCRIPTION
Select shell-uart for mercury_xu, to use shell_module sample.