### PR TITLE
net: l2: ethernet: Fix error handling after ARP prepare 

### DIFF
--- a/subsys/net/lib/shell/ping.c
+++ b/subsys/net/lib/shell/ping.c
@@ -104,7 +104,6 @@ static int handle_ipv6_echo_reply(struct net_icmp_ctx *ctx,
 		ping_done(&ping_ctx);
 	}
 
-	net_pkt_unref(pkt);
 	return 0;
 }
 #else
@@ -179,7 +178,6 @@ static int handle_ipv4_echo_reply(struct net_icmp_ctx *ctx,
 		ping_done(&ping_ctx);
 	}
 
-	net_pkt_unref(pkt);
 	return 0;
 }
 #else


### PR DESCRIPTION
This PR fixes the error handling bug in `ethernet_send()`, after ARP request has already been prepared (all cases, not only TX errors), which could lead to ARP packet leaks. 

Plus one trivial fix for ping handlers I've spotted when testing the change (IMO it didn't merit a separate PR, but I can do that if requested).