### PR TITLE
can: mcp251xfd: fix compilation

### DIFF
--- a/drivers/can/can_mcp251xfd.c
+++ b/drivers/can/can_mcp251xfd.c
@@ -1769,7 +1769,7 @@ static const struct can_driver_api mcp251xfd_api_funcs = {
 		MCP251XFD_SET_CLOCK(inst)                                                          \
 	};                                                                                         \
                                                                                                    \
-	CAN_DEVICE_DT_INST_DEFINE(inst, &mcp251xfd_init, NULL, &mcp251xfd_data_##inst,             \
+	CAN_DEVICE_DT_INST_DEFINE(inst, mcp251xfd_init, NULL, &mcp251xfd_data_##inst,             \
 				  &mcp251xfd_config_##inst, POST_KERNEL, CONFIG_CAN_INIT_PRIORITY, \
 				  &mcp251xfd_api_funcs);
 


### PR DESCRIPTION
Either switching to CAN_DEVICE_DT_INST_DEFINE with [1] missed updating mcp251xfd or missed in merge. Fix using function pointer for init in mcp251xfd.

[1]: https://github.com/zephyrproject-rtos/zephyr/pull/62925

drivers/can/can_mcp251xfd.c:1772:41: error: lvalue required as unary '&' operand
 1772 |         CAN_DEVICE_DT_INST_DEFINE(inst, &mcp251xfd_init, NULL, &mcp251xfd_data_##inst,