### PR TITLE
twister: Add target reports in json format

### DIFF
--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -232,7 +232,7 @@ class Reporting:
         with open(filename, 'wb') as report:
             report.write(result)
 
-    def json_report(self, filename, version="NA"):
+    def json_report(self, filename, version="NA", platform=None):
         logger.info(f"Writing JSON report {filename}")
         report = {}
         report["environment"] = {"os": os.name,
@@ -244,6 +244,8 @@ class Reporting:
         suites = []
 
         for instance in self.instances.values():
+            if platform and platform != instance.platform.name:
+                continue
             suite = {}
             handler_log = os.path.join(instance.build_dir, "handler.log")
             pytest_log = os.path.join(instance.build_dir, "twister_harness.log")
@@ -543,6 +545,9 @@ class Reporting:
         for platform in platforms:
             if suffix:
                 filename = os.path.join(outdir,"{}_{}.xml".format(platform, suffix))
+                json_platform_file = os.path.join(outdir,"{}_{}.json".format(platform, suffix))
             else:
                 filename = os.path.join(outdir,"{}.xml".format(platform))
+                json_platform_file = os.path.join(outdir,"{}.json".format(platform))
             self.xunit_report(json_file, filename, platform, full_report=True)
+            self.json_report(json_platform_file, version=self.env.version, platform=platform)


### PR DESCRIPTION
Using --platform-reports will also generate json reports with results from a single platform. Needed for on-target results publishing process.