### PR TITLE
Implement daisy chaining for BD8LB600FS

### DIFF
--- a/drivers/gpio/gpio_bd8lb600fs.c
+++ b/drivers/gpio/gpio_bd8lb600fs.c
@@ -230,6 +230,11 @@ static int bd8lb600fs_init(const struct device *dev)
 		return -ENODEV;
 	}
 
+	if (!gpio_is_ready_dt(&config->gpio_reset)) {
+		LOG_ERR("%s: reset GPIO is not ready", dev->name);
+		return -ENODEV;
+	}
+
 	int result = k_mutex_init(&drv_data->lock);
 
 	if (result != 0) {

--- a/dts/bindings/gpio/rohm,bd8lb600fs.yaml
+++ b/dts/bindings/gpio/rohm,bd8lb600fs.yaml
@@ -6,6 +6,8 @@
 
 description: |
     This is a representation of the Rohm BD8LB600FS SPI Gpio Expander.
+    Multiple instances may be daisy chained, which can be configured
+    via the number of supported GPIOs.
 
 compatible: "rohm,bd8lb600fs"
 
@@ -18,13 +20,15 @@ properties:
   ngpios:
     type: int
     required: true
-    const: 8
-    description: Number of gpios supported
+    description: |
+      Number of pins for the expander. This must be a multiple of 8.
+      The number of pins also defines how many devices are daisy chained.
+      Set to 8 for one instance without daisy chaining.
 
   reset-gpios:
     type: phandle-array
     required: true
-    description: "GPIO for reset"
+    description: GPIO for reset
 
 gpio-cells:
   - pin


### PR DESCRIPTION
This implements the daisy chain feature of the low side switch BD8LB600FS. The daisy chaining is in hardware achieved via connecting the MISO and MOSI lines of multiple instances of the IC in a row. It is implemented in the driver through a variable number of GPIOs on one instance. Therefore, one device tree instance of the IC will handle multiple daisy chained physical instances.