### PR TITLE
drivers: nxp_enet: simplify driver header

### DIFF
--- a/drivers/mdio/mdio_nxp_enet.c
+++ b/drivers/mdio/mdio_nxp_enet.c
@@ -228,18 +228,20 @@ static void nxp_enet_mdio_post_module_reset_init(const struct device *dev)
 }
 
 void nxp_enet_mdio_callback(const struct device *dev,
-				enum nxp_enet_callback_reason event)
+				enum nxp_enet_callback_reason event, void *cb_data)
 {
 	struct nxp_enet_mdio_data *data = dev->data;
 
+	ARG_UNUSED(cb_data);
+
 	switch (event) {
-	case nxp_enet_module_reset:
+	case NXP_ENET_MODULE_RESET:
 		nxp_enet_mdio_post_module_reset_init(dev);
 		break;
-	case nxp_enet_interrupt:
+	case NXP_ENET_INTERRUPT:
 		nxp_enet_mdio_isr_cb(dev);
 		break;
-	case nxp_enet_interrupt_enabled:
+	case NXP_ENET_INTERRUPT_ENABLED:
 		data->interrupt_up = true;
 		break;
 	default:

--- a/drivers/ptp_clock/ptp_clock_nxp_enet.c
+++ b/drivers/ptp_clock/ptp_clock_nxp_enet.c
@@ -153,12 +153,12 @@ static int ptp_clock_nxp_enet_rate_adjust(const struct device *dev,
 
 void nxp_enet_ptp_clock_callback(const struct device *dev,
 			enum nxp_enet_callback_reason event,
-			union nxp_enet_ptp_data *ptp_data)
+			void *data)
 {
 	const struct ptp_clock_nxp_enet_config *config = dev->config;
 	struct ptp_clock_nxp_enet_data *data = dev->data;
 
-	if (event == nxp_enet_module_reset) {
+	if (event == NXP_ENET_MODULE_RESET) {
 		enet_ptp_config_t ptp_config;
 		uint32_t enet_ref_pll_rate;
 		uint8_t ptp_multicast[6] = { 0x01, 0x1B, 0x19, 0x00, 0x00, 0x00 };
@@ -181,9 +181,9 @@ void nxp_enet_ptp_clock_callback(const struct device *dev,
 				      &ptp_config);
 	}
 
-	if (ptp_data != NULL) {
+	if (data != NULL) {
 		/* Share the mutex with mac driver */
-		ptp_data->for_mac.ptp_mutex = &data->ptp_mutex;
+		*(struct k_mutex *)data = &data->ptp_mutex;
 	}
 }
 

--- a/include/zephyr/drivers/ethernet/eth_nxp_enet.h
+++ b/include/zephyr/drivers/ethernet/eth_nxp_enet.h
@@ -29,27 +29,37 @@ extern "C" {
  * Interrupt enable: The driver's relevant interrupt was enabled in NVIC
  */
 enum nxp_enet_callback_reason {
-	nxp_enet_module_reset,
-	nxp_enet_interrupt,
-	nxp_enet_interrupt_enabled,
+	NXP_ENET_MODULE_RESET,
+	NXP_ENET_INTERRUPT,
+	NXP_ENET_INTERRUPT_ENABLED,
 };
 
-struct nxp_enet_ptp_data_for_mac {
-	struct k_mutex *ptp_mutex;
+enum nxp_enet_driver {
+	NXP_ENET_MAC,
+	NXP_ENET_MDIO,
+	NXP_ENET_PTP_CLOCK,
 };
 
-union nxp_enet_ptp_data {
-	struct nxp_enet_ptp_data_for_mac for_mac;
-};
-
-/* Calback for mdio device called from mac driver */
-void nxp_enet_mdio_callback(const struct device *mdio_dev,
-		enum nxp_enet_callback_reason event);
-
-void nxp_enet_ptp_clock_callback(const struct device *dev,
+extern void nxp_enet_mdio_callback(const struct device *mdio_dev,
 		enum nxp_enet_callback_reason event,
-		union nxp_enet_ptp_data *ptp_data);
+		void *data);
 
+extern void nxp_enet_ptp_clock_callback(const struct device *dev,
+		enum nxp_enet_callback_reason event,
+		void *data);
+
+/*
+ * Internal implementation, inter-driver communication function
+ *
+ * dev: target device to call back
+ * dev_type: which driver to call back
+ * event: reason/cause of callback
+ * data: opaque data, will be interpreted based on reason and target driver
+ */
+extern void nxp_enet_driver_cb(const struct device *dev,
+				enum nxp_enet_driver dev_type,
+				enum nxp_enet_callback_reason event,
+				void *data);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Simplify the driver header implementation, so that the inter-driver architecture is cleaner and there are not structs and unions different per each situation, and make just one function for the enet module drivers to call on each other. Also, capitalize existing enums.