### PR TITLE
cmake/compiler/: drop ERROR_QUIET when looking for compiler --version

### DIFF
--- a/cmake/compiler/arcmwdt/generic.cmake
+++ b/cmake/compiler/arcmwdt/generic.cmake
@@ -17,12 +17,12 @@ execute_process(
   COMMAND ${CMAKE_C_COMPILER} --version
   RESULT_VARIABLE ret
   OUTPUT_VARIABLE full_version_output
-  ERROR_QUIET
   )
 
 if(ret)
   message(FATAL_ERROR "Executing the below command failed. Are permissions set correctly?
-  '${CMAKE_C_COMPILER} --version'"
+  '${CMAKE_C_COMPILER} --version'
+  ${full_version_output}"
   )
 else()
   set(ARCMWDT_MIN_REQUIRED_VERS "2022.09")

--- a/cmake/compiler/armclang/generic.cmake
+++ b/cmake/compiler/armclang/generic.cmake
@@ -28,13 +28,13 @@ endif()
 execute_process(
   COMMAND ${CMAKE_C_COMPILER} --version
   RESULT_VARIABLE ret
-  OUTPUT_QUIET
-  ERROR_QUIET
+  OUTPUT_VARIABLE stdoutput
   )
 
 if(ret)
   message(FATAL_ERROR "Executing the below command failed. "
   "Are permissions set correctly? '${CMAKE_C_COMPILER} --version' "
+  "${stdoutput}"
   "And is the license setup correctly ?"
   )
 endif()

--- a/cmake/compiler/gcc/generic.cmake
+++ b/cmake/compiler/gcc/generic.cmake
@@ -18,12 +18,12 @@ endif()
 execute_process(
   COMMAND ${CMAKE_C_COMPILER} --version
   RESULT_VARIABLE ret
-  OUTPUT_QUIET
-  ERROR_QUIET
+  OUTPUT_VARIABLE stdoutput
   )
 if(ret)
   message(FATAL_ERROR "Executing the below command failed. Are permissions set correctly?
-'${CMAKE_C_COMPILER} --version'
+  ${CMAKE_C_COMPILER} --version
+  ${stdoutput}
 "
     )
 endif()


### PR DESCRIPTION
Commit 40c2e08e8211 ("xcc/cmake: don't discard stderr; don't (ever!) use ERROR_QUIET") fixed xcc but the corresponding code is duplicated. Fix the duplicates too.

See that commit for the issue description, longer commit message and rationale.