### PR TITLE
devicetree: remove label property accessors

### DIFF
--- a/doc/releases/migration-guide-3.6.rst
+++ b/doc/releases/migration-guide-3.6.rst
@@ -66,6 +66,52 @@ Device Drivers and Device Tree
 
   (:github:`62994`)
 
+* Various deprecated macros related to the deprecated devicetree label property
+  were removed. These are listed in the following table. The table also
+  provides replacements.
+
+  However, if you are still using code like
+  ``device_get_binding(DT_LABEL(node_id))``, consider replacing it with
+  something like ``DEVICE_DT_GET(node_id)`` instead. The ``DEVICE_DT_GET()``
+  macro avoids run-time string comparisons, and is also safer because it will
+  fail the build if the device does not exist.
+
+  .. list-table::
+     :header-rows: 1
+
+     * - Removed macro
+       - Replacement
+
+     * - ``DT_GPIO_LABEL(node_id, gpio_pha)``
+       - ``DT_PROP(DT_GPIO_CTLR(node_id, gpio_pha), label)``
+
+     * - ``DT_GPIO_LABEL_BY_IDX(node_id, gpio_pha, idx)``
+       - ``DT_PROP(DT_GPIO_CTLR_BY_IDX(node_id, gpio_pha, idx), label)``
+
+     * - ``DT_INST_GPIO_LABEL(inst, gpio_pha)``
+       - ``DT_PROP(DT_GPIO_CTLR(DT_DRV_INST(inst), gpio_pha), label)``
+
+     * - ``DT_INST_GPIO_LABEL_BY_IDX(inst, gpio_pha, idx)``
+       - ``DT_PROP(DT_GPIO_CTLR_BY_IDX(DT_DRV_INST(inst), gpio_pha, idx), label)``
+
+     * - ``DT_SPI_DEV_CS_GPIOS_LABEL(spi_dev)``
+       - ``DT_PROP(DT_SPI_DEV_CS_GPIOS_CTLR(spi_dev), label)``
+
+     * - ``DT_INST_SPI_DEV_CS_GPIOS_LABEL(inst)``
+       - ``DT_PROP(DT_SPI_DEV_CS_GPIOS_CTLR(DT_DRV_INST(inst)), label)``
+
+     * - ``DT_LABEL(node_id)``
+       - ``DT_PROP(node_id, label)``
+
+     * - ``DT_BUS_LABEL(node_id)``
+       - ``DT_PROP(DT_BUS(node_id), label)``
+
+     * - ``DT_INST_LABEL(inst)``
+       - ``DT_INST_PROP(inst, label)``
+
+     * - ``DT_INST_BUS_LABEL(inst)``
+       - ``DT_PROP(DT_BUS(DT_DRV_INST(inst)), label)``
+
 Power Management
 ================
 

--- a/dts/bindings/test/vnd,non-deprecated-label.yaml
+++ b/dts/bindings/test/vnd,non-deprecated-label.yaml
@@ -1,0 +1,14 @@
+# Copyright 2023 Ampere Computing
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  This can be used when we need a label property in tests without risk
+  of generating deprecation warnings, which are errors in some
+  configurations.
+
+compatible: vnd,non-deprecated-label
+
+properties:
+  label:
+    type: string
+    required: true

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -779,17 +779,6 @@
 		    (DT_PROP(node_id, prop)), (default_value))
 
 /**
- * @deprecated Use DT_PROP(node_id, label)
- * @brief Equivalent to DT_PROP(node_id, label)
- *
- * This is a convenience for the Zephyr device API, which uses label
- * properties as device_get_binding() arguments.
- * @param node_id node identifier
- * @return node's label property value
- */
-#define DT_LABEL(node_id) DT_PROP(node_id, label) __DEPRECATED_MACRO
-
-/**
  * @brief Get a property value's index into its enumeration values
  *
  * The return values start at zero.
@@ -3261,16 +3250,6 @@
 #define DT_BUS(node_id) DT_CAT(node_id, _BUS)
 
 /**
- * @deprecated If used to obtain a device instance with device_get_binding,
- * consider using @c DEVICE_DT_GET(DT_BUS(node)).
- *
- * @brief Node's bus controller's `label` property
- * @param node_id node identifier
- * @return the label property of the node's bus controller DT_BUS(node)
- */
-#define DT_BUS_LABEL(node_id) DT_PROP(DT_BUS(node_id), label) __DEPRECATED_MACRO
-
-/**
  * @brief Is a node on a bus of a given type?
  *
  * Example devicetree overlay:
@@ -3580,14 +3559,6 @@
  */
 #define DT_INST_PROP_LEN_OR(inst, prop, default_value) \
 	DT_PROP_LEN_OR(DT_DRV_INST(inst), prop, default_value)
-
-/**
- * @deprecated Use DT_INST_PROP(inst, label)
- * @brief Get a `DT_DRV_COMPAT` instance's `label` property
- * @param inst instance number
- * @return instance's label property value
- */
-#define DT_INST_LABEL(inst) DT_INST_PROP(inst, label) __DEPRECATED_MACRO
 
 /**
  * @brief Get a `DT_DRV_COMPAT` instance's string property's value as a
@@ -3913,16 +3884,6 @@
  * @return node identifier for the instance's bus node
  */
 #define DT_INST_BUS(inst) DT_BUS(DT_DRV_INST(inst))
-
-/**
- * @deprecated If used to obtain a device instance with device_get_binding,
- * consider using @c DEVICE_DT_GET(DT_INST_BUS(inst)).
- *
- * @brief Get a `DT_DRV_COMPAT`'s bus node's label property
- * @param inst instance number
- * @return the label property of the instance's bus controller
- */
-#define DT_INST_BUS_LABEL(inst) DT_BUS_LABEL(DT_DRV_INST(inst)) __DEPRECATED_MACRO
 
 /**
  * @brief Test if a `DT_DRV_COMPAT`'s bus type is a given type

--- a/include/zephyr/devicetree/gpio.h
+++ b/include/zephyr/devicetree/gpio.h
@@ -66,60 +66,6 @@ extern "C" {
 	DT_GPIO_CTLR_BY_IDX(node_id, gpio_pha, 0)
 
 /**
- * @deprecated If used to obtain a device instance with device_get_binding,
- * consider using @c DEVICE_DT_GET(DT_GPIO_CTLR_BY_IDX(node, gpio_pha, idx)).
- *
- * @brief Get a label property from a gpio phandle-array property
- *        at an index
- *
- * It's an error if the GPIO controller node referenced by the phandle
- * in node_id's "gpio_pha" property at index "idx" has no label
- * property.
- *
- * Example devicetree fragment:
- *
- *     gpio1: gpio@... {
- *             label = "GPIO_1";
- *     };
- *
- *     gpio2: gpio@... {
- *             label = "GPIO_2";
- *     };
- *
- *     n: node {
- *             gpios = <&gpio1 10 GPIO_ACTIVE_LOW>,
- *                     <&gpio2 30 GPIO_ACTIVE_HIGH>;
- *     };
- *
- * Example usage:
- *
- *     DT_GPIO_LABEL_BY_IDX(DT_NODELABEL(n), gpios, 1) // "GPIO_2"
- *
- * @param node_id node identifier
- * @param gpio_pha lowercase-and-underscores GPIO property with
- *        type "phandle-array"
- * @param idx logical index into "gpio_pha"
- * @return the label property of the node referenced at index "idx"
- * @see DT_PHANDLE_BY_IDX()
- */
-#define DT_GPIO_LABEL_BY_IDX(node_id, gpio_pha, idx) \
-	DT_PROP(DT_GPIO_CTLR_BY_IDX(node_id, gpio_pha, idx), label) __DEPRECATED_MACRO
-
-/**
- * @deprecated If used to obtain a device instance with device_get_binding,
- * consider using @c DEVICE_DT_GET(DT_GPIO_CTLR(node, gpio_pha)).
- *
- * @brief Equivalent to DT_GPIO_LABEL_BY_IDX(node_id, gpio_pha, 0)
- * @param node_id node identifier
- * @param gpio_pha lowercase-and-underscores GPIO property with
- *        type "phandle-array"
- * @return the label property of the node referenced at index 0
- * @see DT_GPIO_LABEL_BY_IDX()
- */
-#define DT_GPIO_LABEL(node_id, gpio_pha) \
-	DT_GPIO_LABEL_BY_IDX(node_id, gpio_pha, 0) __DEPRECATED_MACRO
-
-/**
  * @brief Get a GPIO specifier's pin cell at an index
  *
  * This macro only works for GPIO specifiers with cells named "pin".
@@ -361,34 +307,6 @@ extern "C" {
 #define DT_GPIO_HOG_FLAGS_BY_IDX(node_id, idx) \
 	COND_CODE_1(IS_ENABLED(DT_CAT4(node_id, _GPIO_HOGS_IDX_, idx, _VAL_flags_EXISTS)), \
 		    (DT_CAT4(node_id, _GPIO_HOGS_IDX_, idx, _VAL_flags)), (0))
-
-/**
- * @deprecated If used to obtain a device instance with device_get_binding,
- * consider using @c DEVICE_DT_GET(DT_INST_GPIO_CTLR_BY_IDX(node, gpio_pha, idx)).
- *
- * @brief Get a label property from a DT_DRV_COMPAT instance's GPIO
- *        property at an index
- * @param inst DT_DRV_COMPAT instance number
- * @param gpio_pha lowercase-and-underscores GPIO property with
- *        type "phandle-array"
- * @param idx logical index into "gpio_pha"
- * @return the label property of the node referenced at index "idx"
- */
-#define DT_INST_GPIO_LABEL_BY_IDX(inst, gpio_pha, idx) \
-	DT_GPIO_LABEL_BY_IDX(DT_DRV_INST(inst), gpio_pha, idx) __DEPRECATED_MACRO
-
-/**
- * @deprecated If used to obtain a device instance with device_get_binding,
- * consider using @c DEVICE_DT_GET(DT_INST_GPIO_CTLR(node, gpio_pha)).
- *
- * @brief Equivalent to DT_INST_GPIO_LABEL_BY_IDX(inst, gpio_pha, 0)
- * @param inst DT_DRV_COMPAT instance number
- * @param gpio_pha lowercase-and-underscores GPIO property with
- *        type "phandle-array"
- * @return the label property of the node referenced at index 0
- */
-#define DT_INST_GPIO_LABEL(inst, gpio_pha) \
-	DT_INST_GPIO_LABEL_BY_IDX(inst, gpio_pha, 0) __DEPRECATED_MACRO
 
 /**
  * @brief Get a DT_DRV_COMPAT instance's GPIO specifier's pin cell value

--- a/include/zephyr/devicetree/spi.h
+++ b/include/zephyr/devicetree/spi.h
@@ -151,47 +151,6 @@ extern "C" {
 	DT_GPIO_CTLR_BY_IDX(DT_BUS(spi_dev), cs_gpios, DT_REG_ADDR(spi_dev))
 
 /**
- * @deprecated If used to obtain a device instance with device_get_binding,
- * consider using @c DEVICE_DT_GET(DT_SPI_DEV_CS_GPIOS_CTLR(node)).
- *
- * @brief Get a SPI device's chip select GPIO controller's label property
- *
- * Example devicetree fragment:
- *
- *     gpio1: gpio@... {
- *             label = "GPIO_1";
- *     };
- *
- *     gpio2: gpio@... {
- *             label = "GPIO_2";
- *     };
- *
- *     spi1: spi@... {
- *             compatible = "vnd,spi";
- *             cs-gpios = <&gpio1 10 GPIO_ACTIVE_LOW>,
- *                        <&gpio2 20 GPIO_ACTIVE_LOW>;
- *
- *             a: spi-dev-a@0 {
- *                     reg = <0>;
- *             };
- *
- *             b: spi-dev-b@1 {
- *                     reg = <1>;
- *             };
- *     };
- *
- * Example usage:
- *
- *     DT_SPI_DEV_CS_GPIOS_LABEL(DT_NODELABEL(a)) // "GPIO_1"
- *     DT_SPI_DEV_CS_GPIOS_LABEL(DT_NODELABEL(b)) // "GPIO_2"
- *
- * @param spi_dev a SPI device node identifier
- * @return label property of spi_dev's chip select GPIO controller
- */
-#define DT_SPI_DEV_CS_GPIOS_LABEL(spi_dev) \
-	DT_GPIO_LABEL_BY_IDX(DT_BUS(spi_dev), cs_gpios, DT_REG_ADDR(spi_dev)) __DEPRECATED_MACRO
-
-/**
  * @brief Get a SPI device's chip select GPIO pin number
  *
  * It's an error if the GPIO specifier for spi_dev's entry in its
@@ -271,19 +230,6 @@ extern "C" {
  */
 #define DT_INST_SPI_DEV_CS_GPIOS_CTLR(inst) \
 	DT_SPI_DEV_CS_GPIOS_CTLR(DT_DRV_INST(inst))
-
-/**
- * @deprecated If used to obtain a device instance with device_get_binding,
- * consider using @c DEVICE_DT_GET(DT_INST_SPI_DEV_CS_GPIOS_CTLR(node)).
- *
- * @brief Get GPIO controller name for a SPI device instance
- * This is equivalent to DT_SPI_DEV_CS_GPIOS_LABEL(DT_DRV_INST(inst)).
- * @param inst DT_DRV_COMPAT instance number
- * @return label property of the instance's chip select GPIO controller
- * @see DT_SPI_DEV_CS_GPIOS_LABEL()
- */
-#define DT_INST_SPI_DEV_CS_GPIOS_LABEL(inst) \
-	DT_SPI_DEV_CS_GPIOS_LABEL(DT_DRV_INST(inst)) __DEPRECATED_MACRO
 
 /**
  * @brief Equivalent to DT_SPI_DEV_CS_GPIOS_PIN(DT_DRV_INST(inst)).

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -49,13 +49,16 @@
 		};
 
 		test_phandles: phandle-holder-0 {
+                        /*
+                         * There should only be one vnd,phandle-holder in the entire DTS.
+                         */
 			compatible = "vnd,phandle-holder";
 			/*
 			 * At least one of these phandles must refer to
 			 * test_gpio_1, or dependency ordinal tests may fail.
 			 */
 			ph = <&test_gpio_1>;
-			phs = <&test_gpio_1 &test_gpio_2 &test_i2c>;
+			phs = <&test_i2c &test_spi>;
 			phs-or = <&test_enum_default_0 &test_enum_default_1>;
 			gpios = <&test_gpio_1 10 20>, <&test_gpio_2 30 40>;
 			pha-gpios = <&test_gpio_1 50 60>, <0>, <&test_gpio_3 70>, <&test_gpio_2 80 90>;
@@ -126,7 +129,6 @@
 			reg = < 0x0 0x1000 >;
 			interrupts = <3 1>;
 			#gpio-cells = < 0x2 >;
-			label = "TEST_GPIO_0";
 			status = "disabled";
 		};
 
@@ -157,6 +159,7 @@
 			label = "TEST_GPIO_1";
 			interrupts = <4 3>;
 			status = "okay";
+                        ngpios = <100>;
 
 			test_gpio_hog_1 {
 				gpio-hog;
@@ -182,6 +185,7 @@
 			interrupts = <5 2>;
 			label = "TEST_GPIO_2";
 			status = "okay";
+                        ngpios = <200>;
 
 			test_gpio_hog_3 {
 				gpio-hog;
@@ -697,4 +701,9 @@
 			reg-names = "test_name";
 		};
 	};
+
+        non-deprecated-label {
+                compatible = "vnd,non-deprecated-label";
+                label = "FOO";
+        };
 };

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -4,21 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* Override __DEPRECATED_MACRO so we don't get twister failures for
- * deprecated macros:
- * - DT_LABEL
- * - DT_BUS_LABEL
- * - DT_SPI_DEV_CS_GPIOS_LABEL
- * - DT_GPIO_LABEL
- * - DT_GPIO_LABEL_BY_IDX
- * - DT_INST_LABEL
- * - DT_INST_BUS_LABEL
- * - DT_INST_SPI_DEV_CS_GPIOS_LABEL
- * - DT_INST_GPIO_LABEL
- * - DT_INST_GPIO_LABEL_BY_IDX
- */
-#define __DEPRECATED_MACRO
-
 #include <zephyr/ztest.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/device.h>
@@ -109,12 +94,11 @@
 
 ZTEST(devicetree_api, test_path_props)
 {
-	zassert_true(!strcmp(DT_LABEL(TEST_DEADBEEF), "TEST_GPIO_1"), "");
 	zassert_equal(DT_NUM_REGS(TEST_DEADBEEF), 1, "");
 	zassert_equal(DT_REG_ADDR(TEST_DEADBEEF), 0xdeadbeef, "");
 	zassert_equal(DT_REG_SIZE(TEST_DEADBEEF), 0x1000, "");
 	zassert_equal(DT_PROP(TEST_DEADBEEF, gpio_controller), 1, "");
-	zassert_equal(DT_PROP(TEST_DEADBEEF, ngpios), 32, "");
+	zassert_equal(DT_PROP(TEST_DEADBEEF, ngpios), 100, "");
 	zassert_true(!strcmp(DT_PROP(TEST_DEADBEEF, status), "okay"), "");
 	zassert_equal(DT_PROP_LEN(TEST_DEADBEEF, compatible), 1, "");
 	zassert_true(!strcmp(DT_PROP_BY_IDX(TEST_DEADBEEF, compatible, 0),
@@ -125,7 +109,7 @@ ZTEST(devicetree_api, test_path_props)
 	zassert_true(DT_SAME_NODE(TEST_ABCD1234, TEST_GPIO_2), "");
 	zassert_equal(DT_NUM_REGS(TEST_ABCD1234), 2, "");
 	zassert_equal(DT_PROP(TEST_ABCD1234, gpio_controller), 1, "");
-	zassert_equal(DT_PROP(TEST_ABCD1234, ngpios), 32, "");
+	zassert_equal(DT_PROP(TEST_ABCD1234, ngpios), 200, "");
 	zassert_true(!strcmp(DT_PROP(TEST_ABCD1234, status), "okay"), "");
 	zassert_equal(DT_PROP_LEN(TEST_ABCD1234, compatible), 1, "");
 	zassert_equal(DT_PROP_LEN_OR(TEST_ABCD1234, compatible, 4), 1, "");
@@ -141,7 +125,7 @@ ZTEST(devicetree_api, test_alias_props)
 	zassert_equal(DT_REG_SIZE(TEST_ALIAS), 0x1000, "");
 	zassert_true(DT_SAME_NODE(TEST_ALIAS, TEST_GPIO_1), "");
 	zassert_equal(DT_PROP(TEST_ALIAS, gpio_controller), 1, "");
-	zassert_equal(DT_PROP(TEST_ALIAS, ngpios), 32, "");
+	zassert_equal(DT_PROP(TEST_ALIAS, ngpios), 100, "");
 	zassert_true(!strcmp(DT_PROP(TEST_ALIAS, status), "okay"), "");
 	zassert_equal(DT_PROP_LEN(TEST_ALIAS, compatible), 1, "");
 	zassert_true(!strcmp(DT_PROP_BY_IDX(TEST_ALIAS, compatible, 0),
@@ -153,9 +137,8 @@ ZTEST(devicetree_api, test_nodelabel_props)
 	zassert_equal(DT_NUM_REGS(TEST_NODELABEL), 1, "");
 	zassert_equal(DT_REG_ADDR(TEST_NODELABEL), 0xdeadbeef, "");
 	zassert_equal(DT_REG_SIZE(TEST_NODELABEL), 0x1000, "");
-	zassert_true(!strcmp(DT_LABEL(TEST_NODELABEL), "TEST_GPIO_1"), "");
 	zassert_equal(DT_PROP(TEST_NODELABEL, gpio_controller), 1, "");
-	zassert_equal(DT_PROP(TEST_NODELABEL, ngpios), 32, "");
+	zassert_equal(DT_PROP(TEST_NODELABEL, ngpios), 100, "");
 	zassert_true(!strcmp(DT_PROP(TEST_NODELABEL, status), "okay"), "");
 	zassert_equal(DT_PROP_LEN(TEST_NODELABEL, compatible), 1, "");
 	zassert_true(!strcmp(DT_PROP_BY_IDX(TEST_NODELABEL, compatible, 0),
@@ -167,8 +150,6 @@ ZTEST(devicetree_api, test_nodelabel_props)
 #define DT_DRV_COMPAT vnd_gpio_device
 ZTEST(devicetree_api, test_inst_props)
 {
-	const char *label_startswith = "TEST_GPIO_";
-
 	/*
 	 * Careful:
 	 *
@@ -192,8 +173,6 @@ ZTEST(devicetree_api, test_inst_props)
 	zassert_equal(DT_INST_PROP_LEN(0, compatible), 1, "");
 	zassert_true(!strcmp(DT_INST_PROP_BY_IDX(0, compatible, 0),
 			     "vnd,gpio-device"), "");
-	zassert_true(!strncmp(label_startswith, DT_INST_LABEL(0),
-			      strlen(label_startswith)), "");
 }
 
 #undef DT_DRV_COMPAT
@@ -349,16 +328,6 @@ ZTEST(devicetree_api, test_has_status)
 
 ZTEST(devicetree_api, test_bus)
 {
-	/* common prefixes of expected labels: */
-	const char *i2c_bus = "TEST_I2C_CTLR";
-	const char *i2c_dev = "TEST_I2C_DEV";
-	const char *i3c_bus = "TEST_I3C_CTLR";
-	const char *i3c_dev = "TEST_I3C_DEV";
-	const char *i3c_i2c_bus = "TEST_I3C_CTLR";
-	const char *i3c_i2c_dev = "TEST_I3C_I2C_DEV";
-	const char *spi_bus = "TEST_SPI_CTLR";
-	const char *spi_dev = "TEST_SPI_DEV";
-	const char *gpio = "TEST_GPIO_";
 	int pin, flags;
 
 	zassert_true(DT_SAME_NODE(TEST_I3C_BUS, TEST_I3C), "");
@@ -396,9 +365,6 @@ ZTEST(devicetree_api, test_bus)
 		     DT_SAME_NODE(CTLR_NODE, DT_NODELABEL(test_gpio_2)), "");
 #undef CTLR_NODE
 
-	zassert_true(!strncmp(gpio, DT_INST_SPI_DEV_CS_GPIOS_LABEL(0),
-			      strlen(gpio)), "");
-
 	pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(0);
 	zassert_true((pin == 0x10) || (pin == 0x30), "");
 
@@ -413,8 +379,6 @@ ZTEST(devicetree_api, test_bus)
 	zassert_equal(DT_ON_BUS(TEST_I2C_DEV, i3c), 0, "");
 	zassert_equal(DT_ON_BUS(TEST_I2C_DEV, spi), 0, "");
 
-	zassert_true(!strcmp(DT_BUS_LABEL(TEST_I2C_DEV), "TEST_I2C_CTLR"), "");
-
 #undef DT_DRV_COMPAT
 #define DT_DRV_COMPAT vnd_spi_device
 	zassert_equal(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT), 2, "");
@@ -426,10 +390,6 @@ ZTEST(devicetree_api, test_bus)
 	zassert_equal(DT_ANY_INST_ON_BUS_STATUS_OKAY(spi), 1, "");
 	zassert_equal(DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c), 0, "");
 	zassert_equal(DT_ANY_INST_ON_BUS_STATUS_OKAY(i3c), 0, "");
-
-	zassert_true(!strncmp(spi_dev, DT_INST_LABEL(0), strlen(spi_dev)), "");
-	zassert_true(!strncmp(spi_bus, DT_INST_BUS_LABEL(0), strlen(spi_bus)),
-		     "");
 
 #undef DT_DRV_COMPAT
 #define DT_DRV_COMPAT vnd_i2c_device
@@ -443,10 +403,6 @@ ZTEST(devicetree_api, test_bus)
 	zassert_equal(DT_ANY_INST_ON_BUS_STATUS_OKAY(i3c), 0, "");
 	zassert_equal(DT_ANY_INST_ON_BUS_STATUS_OKAY(spi), 0, "");
 
-	zassert_true(!strncmp(i2c_dev, DT_INST_LABEL(0), strlen(i2c_dev)), "");
-	zassert_true(!strncmp(i2c_bus, DT_INST_BUS_LABEL(0), strlen(i2c_bus)),
-		     "");
-
 #undef DT_DRV_COMPAT
 #define DT_DRV_COMPAT vnd_i3c_device
 	zassert_equal(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT), 1, "");
@@ -459,10 +415,6 @@ ZTEST(devicetree_api, test_bus)
 	zassert_equal(DT_ANY_INST_ON_BUS_STATUS_OKAY(i3c), 1, "");
 	zassert_equal(DT_ANY_INST_ON_BUS_STATUS_OKAY(spi), 0, "");
 
-	zassert_true(!strncmp(i3c_dev, DT_INST_LABEL(0), strlen(i3c_dev)), "");
-	zassert_true(!strncmp(i3c_bus, DT_INST_BUS_LABEL(0), strlen(i3c_bus)),
-		     "");
-
 #undef DT_DRV_COMPAT
 #define DT_DRV_COMPAT vnd_i3c_i2c_device
 	zassert_equal(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT), 1, "");
@@ -474,10 +426,6 @@ ZTEST(devicetree_api, test_bus)
 	zassert_equal(DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c), 1, "");
 	zassert_equal(DT_ANY_INST_ON_BUS_STATUS_OKAY(i3c), 1, "");
 	zassert_equal(DT_ANY_INST_ON_BUS_STATUS_OKAY(spi), 0, "");
-
-	zassert_true(!strncmp(i3c_i2c_dev, DT_INST_LABEL(0), strlen(i3c_i2c_dev)), "");
-	zassert_true(!strncmp(i3c_i2c_bus, DT_INST_BUS_LABEL(0), strlen(i3c_i2c_bus)),
-		     "");
 
 #undef DT_DRV_COMPAT
 
@@ -799,27 +747,16 @@ ZTEST(devicetree_api, test_irq)
 }
 
 struct gpios_struct {
-	const char *name;
 	gpio_pin_t pin;
 	gpio_flags_t flags;
 };
 
-/* Helper macro that UTIL_LISTIFY can use and produces an element with comma */
-#define DT_PROP_ELEM_BY_PHANDLE(idx, node_id, ph_prop, prop) \
-	DT_PROP_BY_PHANDLE_IDX(node_id, ph_prop, idx, prop)
-#define DT_PHANDLE_LISTIFY(node_id, ph_prop, prop) \
-	{ \
-	  LISTIFY(DT_PROP_LEN(node_id, ph_prop), \
-		  DT_PROP_ELEM_BY_PHANDLE, (,), \
-		  node_id, \
-		  ph_prop, \
-		  label) \
-	}
+#define CLOCK_FREQUENCY_AND_COMMA(node_id, prop, idx) \
+	DT_PROP_BY_PHANDLE_IDX(node_id, prop, idx, clock_frequency),
 
 /* Helper macro that UTIL_LISTIFY can use and produces an element with comma */
 #define DT_GPIO_ELEM(idx, node_id, prop) \
 	{ \
-		DT_PROP(DT_PHANDLE_BY_IDX(node_id, prop, idx), label), \
 		DT_PHA_BY_IDX(node_id, prop, idx, pin),\
 		DT_PHA_BY_IDX(node_id, prop, idx, flags),\
 	}
@@ -831,8 +768,8 @@ struct gpios_struct {
 #define DT_DRV_COMPAT vnd_phandle_holder
 ZTEST(devicetree_api, test_phandles)
 {
-	const char *ph_label = DT_PROP_BY_PHANDLE(TEST_PH, ph, label);
-	const char *phs_labels[] = DT_PHANDLE_LISTIFY(TEST_PH, phs, label);
+	bool gpio_controller = DT_PROP_BY_PHANDLE(TEST_PH, ph, gpio_controller);
+	size_t phs_freqs[] = { DT_FOREACH_PROP_ELEM(TEST_PH, phs, CLOCK_FREQUENCY_AND_COMMA) };
 	struct gpios_struct gps[] = DT_GPIO_LISTIFY(TEST_PH, gpios);
 
 	/* phandle */
@@ -843,33 +780,34 @@ ZTEST(devicetree_api, test_phandles)
 	zassert_true(DT_SAME_NODE(DT_PROP_BY_IDX(TEST_PH, ph, 0),
 				  DT_NODELABEL(test_gpio_1)), "");
 	/* DT_PROP_BY_PHANDLE */
-	zassert_true(!strcmp(ph_label, "TEST_GPIO_1"), "");
+	zassert_equal(gpio_controller, true, "");
 
 	/* phandles */
 	zassert_true(DT_NODE_HAS_PROP(TEST_PH, phs), "");
-	zassert_equal(ARRAY_SIZE(phs_labels), 3, "");
-	zassert_equal(DT_PROP_LEN(TEST_PH, phs), 3, "");
+	zassert_equal(ARRAY_SIZE(phs_freqs), 2, "");
+	zassert_equal(DT_PROP_LEN(TEST_PH, phs), 2, "");
 	zassert_true(DT_SAME_NODE(DT_PROP_BY_IDX(TEST_PH, phs, 1),
-				  DT_NODELABEL(test_gpio_2)), "");
+				  TEST_SPI), "");
 
-	/* DT_PROP_BY_PHANDLE_IDX */
-	zassert_true(!strcmp(DT_PROP_BY_PHANDLE_IDX(TEST_PH, phs, 0, label),
-			     "TEST_GPIO_1"), "");
-	zassert_true(!strcmp(DT_PROP_BY_PHANDLE_IDX(TEST_PH, phs, 1, label),
-			     "TEST_GPIO_2"), "");
-	zassert_true(!strcmp(DT_PROP_BY_PHANDLE_IDX(TEST_PH, phs, 2, label),
-			     "TEST_I2C_CTLR"), "");
-	zassert_true(!strcmp(phs_labels[0], "TEST_GPIO_1"), "");
-	zassert_true(!strcmp(phs_labels[1], "TEST_GPIO_2"), "");
-	zassert_true(!strcmp(phs_labels[2], "TEST_I2C_CTLR"), "");
+	/* DT_FOREACH_PROP_ELEM on a phandles type property */
+	zassert_equal(phs_freqs[0], 100000, "");
+	zassert_equal(phs_freqs[1], 2000000, "");
+
+	/* DT_PROP_BY_PHANDLE_IDX on a phandles type property */
+	zassert_equal(DT_PROP_BY_PHANDLE_IDX(TEST_PH, phs, 0, clock_frequency),
+		      100000, "");
+	zassert_equal(DT_PROP_BY_PHANDLE_IDX(TEST_PH, phs, 1, clock_frequency),
+		      2000000, "");
+
+	/* DT_PROP_BY_PHANDLE_IDX on a phandle-array type property */
 	zassert_equal(DT_PROP_BY_PHANDLE_IDX(TEST_PH, gpios, 0,
-					     gpio_controller), 1, "");
+					     ngpios), 100, "");
 	zassert_equal(DT_PROP_BY_PHANDLE_IDX(TEST_PH, gpios, 1,
-					     gpio_controller), 1, "");
-	zassert_true(!strcmp(DT_PROP_BY_PHANDLE_IDX(TEST_PH, gpios, 0, label),
-			     "TEST_GPIO_1"), "");
-	zassert_true(!strcmp(DT_PROP_BY_PHANDLE_IDX(TEST_PH, gpios, 1, label),
-			     "TEST_GPIO_2"), "");
+					     ngpios), 200, "");
+	zassert_true(!strcmp(DT_PROP_BY_PHANDLE_IDX(TEST_PH, gpios, 0, status),
+			     "okay"), "");
+	zassert_true(!strcmp(DT_PROP_BY_PHANDLE_IDX(TEST_PH, gpios, 1, status),
+			     "okay"), "");
 
 	/* DT_PROP_BY_PHANDLE_IDX_OR */
 	zassert_true(!strcmp(DT_PROP_BY_PHANDLE_IDX_OR(TEST_PH, phs_or, 0,
@@ -943,11 +881,9 @@ ZTEST(devicetree_api, test_phandles)
 	zassert_true(DT_SAME_NODE(DT_PHANDLE_BY_NAME(TEST_PH, foos, b_c), TEST_GPIO_2), "");
 
 	/* array initializers */
-	zassert_true(!strcmp(gps[0].name, "TEST_GPIO_1"), "");
 	zassert_equal(gps[0].pin, 10, "");
 	zassert_equal(gps[0].flags, 20, "");
 
-	zassert_true(!strcmp(gps[1].name, "TEST_GPIO_2"), "");
 	zassert_equal(gps[1].pin, 30, "");
 	zassert_equal(gps[1].flags, 40, "");
 
@@ -955,31 +891,23 @@ ZTEST(devicetree_api, test_phandles)
 	zassert_equal(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT), 1, "");
 
 	/* DT_INST_PROP_BY_PHANDLE */
-	zassert_true(!strcmp(DT_INST_PROP_BY_PHANDLE(0, ph, label),
-			     "TEST_GPIO_1"), "");
-
-	zassert_true(!strcmp(ph_label, "TEST_GPIO_1"), "");
+	zassert_equal(DT_INST_PROP_BY_PHANDLE(0, ph, ngpios), 100, "");
 
 	/* DT_INST_PROP_BY_PHANDLE_IDX */
-	zassert_true(!strcmp(DT_INST_PROP_BY_PHANDLE_IDX(0, phs, 0, label),
-			     "TEST_GPIO_1"), "");
-	zassert_true(!strcmp(DT_INST_PROP_BY_PHANDLE_IDX(0, phs, 1, label),
-			     "TEST_GPIO_2"), "");
-	zassert_true(!strcmp(DT_INST_PROP_BY_PHANDLE_IDX(0, phs, 2, label),
-			     "TEST_I2C_CTLR"), "");
-	zassert_true(!strcmp(phs_labels[0], "TEST_GPIO_1"), "");
-	zassert_true(!strcmp(phs_labels[1], "TEST_GPIO_2"), "");
-	zassert_true(!strcmp(phs_labels[2], "TEST_I2C_CTLR"), "");
+	zassert_equal(DT_INST_PROP_BY_PHANDLE_IDX(0, phs, 0, clock_frequency),
+		      100000, "");
+	zassert_equal(DT_INST_PROP_BY_PHANDLE_IDX(0, phs, 1, clock_frequency),
+		      2000000, "");
 	zassert_equal(DT_INST_PROP_BY_PHANDLE_IDX(0, gpios, 0,
 					     gpio_controller),
 		      1, "");
 	zassert_equal(DT_INST_PROP_BY_PHANDLE_IDX(0, gpios, 1,
 					     gpio_controller),
 		      1, "");
-	zassert_true(!strcmp(DT_INST_PROP_BY_PHANDLE_IDX(0, gpios, 0, label),
-			     "TEST_GPIO_1"), "");
-	zassert_true(!strcmp(DT_INST_PROP_BY_PHANDLE_IDX(0, gpios, 1, label),
-			     "TEST_GPIO_2"), "");
+	zassert_equal(DT_INST_PROP_BY_PHANDLE_IDX(0, gpios, 0, ngpios),
+		      100, "");
+	zassert_equal(DT_INST_PROP_BY_PHANDLE_IDX(0, gpios, 1, ngpios),
+		      200, "");
 
 	/* DT_INST_PROP_HAS_IDX */
 	zassert_true(DT_INST_PROP_HAS_IDX(0, gpios, 0), "");
@@ -1054,15 +982,6 @@ ZTEST(devicetree_api, test_gpio)
 	zassert_true(!strcmp(TO_STRING(DT_GPIO_CTLR(TEST_PH, gpios)),
 			     TO_STRING(DT_NODELABEL(test_gpio_1))), "");
 
-	/* DT_GPIO_LABEL_BY_IDX */
-	zassert_true(!strcmp(DT_GPIO_LABEL_BY_IDX(TEST_PH, gpios, 0),
-			     "TEST_GPIO_1"), "");
-	zassert_true(!strcmp(DT_GPIO_LABEL_BY_IDX(TEST_PH, gpios, 1),
-			     "TEST_GPIO_2"), "");
-
-	/* DT_GPIO_LABEL */
-	zassert_true(!strcmp(DT_GPIO_LABEL(TEST_PH, gpios), "TEST_GPIO_1"), "");
-
 	/* DT_GPIO_PIN_BY_IDX */
 	zassert_equal(DT_GPIO_PIN_BY_IDX(TEST_PH, gpios, 0), 10, "");
 	zassert_equal(DT_GPIO_PIN_BY_IDX(TEST_PH, gpios, 1), 30, "");
@@ -1096,15 +1015,6 @@ ZTEST(devicetree_api, test_gpio)
 
 	/* DT_INST */
 	zassert_equal(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT), 1, "");
-
-	/* DT_INST_GPIO_LABEL_BY_IDX */
-	zassert_true(!strcmp(DT_INST_GPIO_LABEL_BY_IDX(0, gpios, 0),
-			     "TEST_GPIO_1"), "");
-	zassert_true(!strcmp(DT_INST_GPIO_LABEL_BY_IDX(0, gpios, 1),
-			     "TEST_GPIO_2"), "");
-
-	/* DT_INST_GPIO_LABEL */
-	zassert_true(!strcmp(DT_INST_GPIO_LABEL(0, gpios), "TEST_GPIO_1"), "");
 
 	/* DT_INST_GPIO_PIN_BY_IDX */
 	zassert_equal(DT_INST_GPIO_PIN_BY_IDX(0, gpios, 0), 10, "");
@@ -1633,10 +1543,9 @@ ZTEST(devicetree_api, test_foreach_prop_elem)
 		DT_FOREACH_PROP_ELEM(TEST_PH, phs, PATH_COMMA)
 	};
 
-	zassert_equal(ARRAY_SIZE(array_phs), 3, "");
-	zassert_true(!strcmp(array_phs[0], DT_NODE_PATH(TEST_GPIO_1)), "");
-	zassert_true(!strcmp(array_phs[1], DT_NODE_PATH(TEST_GPIO_2)), "");
-	zassert_true(!strcmp(array_phs[2], DT_NODE_PATH(TEST_I2C)), "");
+	zassert_equal(ARRAY_SIZE(array_phs), 2, "");
+	zassert_true(!strcmp(array_phs[0], DT_NODE_PATH(TEST_I2C)), "");
+	zassert_true(!strcmp(array_phs[1], DT_NODE_PATH(TEST_SPI)), "");
 
 #undef PATH_COMMA
 
@@ -1753,7 +1662,6 @@ static int test_gpio_init(const struct device *dev)
 	return 0;
 }
 
-#define INST(num) DT_INST(num, vnd_gpio_device)
 #undef DT_DRV_COMPAT
 #define DT_DRV_COMPAT vnd_gpio_device
 
@@ -1761,28 +1669,27 @@ static const struct gpio_driver_api test_api;
 
 #define TEST_GPIO_INIT(num)					\
 	static struct test_gpio_data gpio_data_##num = {	\
-		.is_gpio_ctlr = DT_PROP(INST(num),		\
-					gpio_controller),	\
+		.is_gpio_ctlr = DT_INST_PROP(num,		\
+					     gpio_controller),	\
 	};							\
 	static const struct test_gpio_info gpio_info_##num = {	\
-		.reg_addr = DT_REG_ADDR(INST(num)),		\
-		.reg_len = DT_REG_SIZE(INST(num)),		\
+		.reg_addr = DT_INST_REG_ADDR(num),		\
+		.reg_len = DT_INST_REG_SIZE(num),		\
 	};							\
-	DEVICE_DT_DEFINE(INST(num),				\
-			    test_gpio_init,			\
-			    NULL,				\
-			    &gpio_data_##num,			\
-			    &gpio_info_##num,			\
-			    POST_KERNEL,			\
-			    CONFIG_APPLICATION_INIT_PRIORITY,	\
-			    &test_api);
+	DEVICE_DT_INST_DEFINE(num,				\
+			      test_gpio_init,			\
+			      NULL,				\
+			      &gpio_data_##num,			\
+			      &gpio_info_##num,			\
+			      POST_KERNEL,			\
+			      CONFIG_APPLICATION_INIT_PRIORITY,	\
+			      &test_api);
 
 DT_INST_FOREACH_STATUS_OKAY(TEST_GPIO_INIT)
 
 ZTEST(devicetree_api, test_devices)
 {
-	const struct device *devs[3];
-	int i = 0;
+	const struct device *devs[2] = { DEVICE_DT_INST_GET(0), DEVICE_DT_INST_GET(1) };
 	const struct device *dev_abcd;
 	struct test_gpio_data *data_dev0;
 	struct test_gpio_data *data_dev1;
@@ -1790,25 +1697,11 @@ ZTEST(devicetree_api, test_devices)
 
 	zassert_equal(DT_NUM_INST_STATUS_OKAY(vnd_gpio_device), 2, "");
 
-	devs[i] = device_get_binding(DT_LABEL(INST(0)));
-	if (devs[i]) {
-		i++;
-	}
-	devs[i] = device_get_binding(DT_LABEL(INST(1)));
-	if (devs[i]) {
-		i++;
-	}
-	devs[i] = device_get_binding(DT_LABEL(INST(2)));
-	if (devs[i]) {
-		i++;
-	}
-
 	data_dev0 = devs[0]->data;
 	data_dev1 = devs[1]->data;
 
 	zassert_not_null(devs[0], "");
 	zassert_not_null(devs[1], "");
-	zassert_true(devs[2] == NULL, "");
 
 	zassert_true(data_dev0->is_gpio_ctlr, "");
 	zassert_true(data_dev1->is_gpio_ctlr, "");
@@ -1833,8 +1726,6 @@ ZTEST(devicetree_api, test_cs_gpios)
 	zassert_equal(DT_DEP_ORD(DT_SPI_DEV_CS_GPIOS_CTLR(TEST_SPI_DEV_0)),
 		      DT_DEP_ORD(DT_NODELABEL(test_gpio_1)),
 		     "dev 0 cs gpio controller");
-	zassert_true(!strcmp(DT_SPI_DEV_CS_GPIOS_LABEL(TEST_SPI_DEV_0),
-			     "TEST_GPIO_1"), "");
 	zassert_equal(DT_SPI_DEV_CS_GPIOS_PIN(TEST_SPI_DEV_0), 0x10, "");
 	zassert_equal(DT_SPI_DEV_CS_GPIOS_FLAGS(TEST_SPI_DEV_0), 0x20, "");
 }
@@ -2777,9 +2668,9 @@ ZTEST(devicetree_api, test_fixed_partitions)
 	zassert_false(DT_HAS_FIXED_PARTITION_LABEL(test_partition_3));
 	zassert_false(DT_NODE_EXISTS(DT_NODE_BY_FIXED_PARTITION_LABEL(test_partition_3)));
 
-	/* There is a node with `label = "TEST_GPIO_0"`, but it is not a fixed partition. */
-	zassert_false(DT_HAS_FIXED_PARTITION_LABEL(TEST_GPIO_0));
-	zassert_false(DT_NODE_EXISTS(DT_NODE_BY_FIXED_PARTITION_LABEL(TEST_GPIO_0)));
+	/* There is a node with `label = "FOO"`, but it is not a fixed partition. */
+	zassert_false(DT_HAS_FIXED_PARTITION_LABEL(FOO));
+	zassert_false(DT_NODE_EXISTS(DT_NODE_BY_FIXED_PARTITION_LABEL(FOO)));
 
 	/* Test DT_MTD_FROM_FIXED_PARTITION. */
 	zassert_true(DT_NODE_EXISTS(DT_MTD_FROM_FIXED_PARTITION(TEST_PARTITION_0)));


### PR DESCRIPTION
These were first deprecated in v3.2. We have kept support for them for as long as we can, but now their presence is causing CI failures in some configurations. Specifically, using the deprecated 'label' property is causing a warning which is promoted to an error in some twister runs. This is blocking other forward progress in the devicetree API.

I tried to rework the tests to avoid this, but it was too much effort for the time I had to work on the task. Removing the APIs is therefore unfortunately the best way forward to unblocking other work.

Re-work the test suite a bit to maintain coverage where we are using the label property to test other macros.

Add a migration guide section to help with the transition.