### PR TITLE
cmake: drop ERROR_QUIET in python.cmake

### DIFF
--- a/cmake/modules/python.cmake
+++ b/cmake/modules/python.cmake
@@ -31,7 +31,6 @@ if(NOT Python3_EXECUTABLE)
                                  "import sys; sys.stdout.write('.'.join([str(x) for x in sys.version_info[:2]]))"
                          RESULT_VARIABLE result
                          OUTPUT_VARIABLE version
-                         ERROR_QUIET
                          OUTPUT_STRIP_TRAILING_WHITESPACE)
 
        if(version VERSION_LESS PYTHON_MINIMUM_REQUIRED)


### PR DESCRIPTION
ERROR_QUIET should be used only when the command is actually expected to fail, otherwise discarding stderr can be extremely time-consuming. See recent example of time lost in commit 40c2e08e8211 ("xcc/cmake: don't discard stderr; don't (ever!) use ERROR_QUIET")

If some Python interpreter cannot even evaluate `sys.version_info[:2]`, then we definitely don't want to hide what its stderr says about that.


Fixes commit 94de3e9f60dc ("cmake: FindPython3: Adjust python3 program search")