### PR TITLE
[Backport v3.5-branch] driver: intc: plic: fix trigger type register bit calculation

### DIFF
--- a/drivers/interrupt_controller/intc_plic.c
+++ b/drivers/interrupt_controller/intc_plic.c
@@ -70,7 +70,7 @@ static int riscv_plic_is_edge_irq(uint32_t irq)
 	volatile uint32_t *trig = (volatile uint32_t *)PLIC_EDGE_TRIG_TYPE;
 
 	trig += (irq >> PLIC_EDGE_TRIG_SHIFT);
-	return *trig & BIT(irq);
+	return *trig & BIT(irq & BIT_MASK(PLIC_EDGE_TRIG_SHIFT));
 }
 
 /**


### PR DESCRIPTION
Manual backport of https://github.com/zephyrproject-rtos/zephyr/commit/e6f77f9b735e67d38e8b8625fc2bdba1948e71ac from #65847

Fixes #65846
Fixes #65956