### PR TITLE
exclude `ucans32k1sic` from some userspace tests due to lack of MPU regions

### DIFF
--- a/samples/userspace/prod_consumer/sample.yaml
+++ b/samples/userspace/prod_consumer/sample.yaml
@@ -15,3 +15,5 @@ tests:
     filter: CONFIG_ARCH_HAS_USERSPACE
     arch_exclude:
       - posix
+    platform_exclude:
+      - ucans32k1sic

--- a/samples/userspace/shared_mem/sample.yaml
+++ b/samples/userspace/shared_mem/sample.yaml
@@ -20,5 +20,6 @@ tests:
       - twr_ke18f
       - cy8cproto_062_4343w
       - cy8cproto_063_ble
+      - ucans32k1sic
     extra_configs:
       - CONFIG_TEST_HW_STACK_PROTECTION=n

--- a/subsys/testsuite/Kconfig
+++ b/subsys/testsuite/Kconfig
@@ -143,7 +143,7 @@ config TEST_ENABLE_USERSPACE
 config TEST_USERSPACE_WITHOUT_HW_STACK_PROTECTION
 	bool "Run User Mode tests without additionally enabling stack protection"
 	depends on TEST_ENABLE_USERSPACE
-	default y if SOC_SERIES_KINETIS_KE1XF
+	default y if SOC_SERIES_KINETIS_KE1XF || SOC_SERIES_S32K1XX
 	help
 	  A HW platform might not have sufficient MPU/MMU capabilities to support
 	  running all test cases with User Mode and HW Stack Protection features

--- a/tests/kernel/fatal/exception/testcase.yaml
+++ b/tests/kernel/fatal/exception/testcase.yaml
@@ -3,7 +3,9 @@ common:
 tests:
   kernel.common.stack_protection:
     extra_args: CONF_FILE=prj.conf
-    platform_exclude: twr_ke18f
+    platform_exclude:
+      - twr_ke18f
+      - ucans32k1sic
     filter: CONFIG_ARCH_HAS_STACK_PROTECTION
     arch_exclude:
       - posix
@@ -19,7 +21,9 @@ tests:
       - memory_protection
   kernel.common.stack_protection_arm_fpu_sharing:
     extra_args: CONF_FILE=prj_arm_fpu_sharing.conf
-    platform_exclude: twr_ke18f
+    platform_exclude:
+      - twr_ke18f
+      - ucans32k1sic
     arch_allow: arm
     filter: CONFIG_ARCH_HAS_STACK_PROTECTION and CONFIG_ARMV7_M_ARMV8_M_FP
     tags:

--- a/tests/kernel/fatal/exception/testcase.yaml
+++ b/tests/kernel/fatal/exception/testcase.yaml
@@ -43,8 +43,9 @@ tests:
       - mps2_an385
   kernel.common.stack_sentinel:
     extra_args: CONF_FILE=sentinel.conf
-    # FIXME: See issue #39948
-    platform_exclude: qemu_cortex_a9
+    platform_exclude:
+      - qemu_cortex_a9 # FIXME: See issue #39948
+      - hifive1        # FIXME: See issue #66070
     tags: kernel
     integration_platforms:
       - qemu_x86

--- a/tests/kernel/mem_protect/mem_protect/testcase.yaml
+++ b/tests/kernel/mem_protect/mem_protect/testcase.yaml
@@ -9,7 +9,9 @@ tests:
     filter: CONFIG_ARCH_HAS_USERSPACE
     arch_exclude:
       - posix
-    platform_exclude: twr_ke18f
+    platform_exclude:
+      - twr_ke18f
+      - ucans32k1sic
     extra_args:
       - CONFIG_TEST_HW_STACK_PROTECTION=n
       - CONFIG_MINIMAL_LIBC=y

--- a/tests/kernel/mem_protect/protection/testcase.yaml
+++ b/tests/kernel/mem_protect/protection/testcase.yaml
@@ -1,6 +1,8 @@
 tests:
   kernel.memory_protection.protection:
-    platform_exclude: twr_ke18f
+    platform_exclude:
+      - twr_ke18f
+      - ucans32k1sic
     filter: CONFIG_SRAM_REGION_PERMISSIONS
     tags:
       - kernel

--- a/tests/kernel/mem_protect/userspace/testcase.yaml
+++ b/tests/kernel/mem_protect/userspace/testcase.yaml
@@ -12,6 +12,8 @@ tests:
     extra_configs:
       - CONFIG_TEST_HW_STACK_PROTECTION=n
       - CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=0
+    platform_exclude:
+      - ucans32k1sic
   kernel.memory_protection.userspace.gap_filling.arc:
     filter: CONFIG_ARCH_HAS_USERSPACE and CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS
     arch_allow: arc

--- a/tests/kernel/threads/tls/testcase.yaml
+++ b/tests/kernel/threads/tls/testcase.yaml
@@ -16,6 +16,8 @@ tests:
       CONFIG_TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE
     arch_exclude:
       - posix
+    platform_exclude:
+      - ucans32k1sic
     # ARCMWDT can't handle THREAD_LOCAL_STORAGE with USERSPACE, see #52570 for details
     toolchain_exclude: arcmwdt
     extra_configs:


### PR DESCRIPTION
`ucans32k1sic` board have an NXP MPU with 8 configurable regions, of which five of them are already used by the static MPU configuration. These tests are failing due to lack of MPU regions or free partition slots available, even when hw stack protection is disabled when building with userspace support.

This issue is also present for some of the NXP Kinetis boards that posses the same MPU implementation (e.g. `twr_ke18f`), see:
- https://github.com/zephyrproject-rtos/zephyr/issues/16229#issuecomment-495947933
- https://github.com/zephyrproject-rtos/zephyr/issues/18885
