### PR TITLE
Add I2C and SPI support for NXP UCANS32K1SIC board

### DIFF
--- a/boards/arm/ucans32k1sic/doc/index.rst
+++ b/boards/arm/ucans32k1sic/doc/index.rst
@@ -47,6 +47,7 @@ SYSMPU        on-chip     mpu
 PORT          on-chip     pinctrl
 GPIO          on-chip     gpio
 LPUART        on-chip     serial
+LPI2C         on-chip     i2c
 ============  ==========  ================================
 
 The default configuration can be found in the Kconfig file

--- a/boards/arm/ucans32k1sic/doc/index.rst
+++ b/boards/arm/ucans32k1sic/doc/index.rst
@@ -48,6 +48,7 @@ PORT          on-chip     pinctrl
 GPIO          on-chip     gpio
 LPUART        on-chip     serial
 LPI2C         on-chip     i2c
+LPSPI         on-chip     spi
 ============  ==========  ================================
 
 The default configuration can be found in the Kconfig file

--- a/boards/arm/ucans32k1sic/ucans32k1sic-pinctrl.dtsi
+++ b/boards/arm/ucans32k1sic/ucans32k1sic-pinctrl.dtsi
@@ -27,4 +27,14 @@
 			drive-strength = "low";
 		};
 	};
+
+	lpspi0_default: lpspi0_default {
+		group0 {
+			pinmux = <LPSPI0_SCK_PTB2>,
+				<LPSPI0_SIN_PTB3>,
+				<LPSPI0_SOUT_PTB4>,
+				<LPSPI0_PCS0_PTB5>;
+			drive-strength = "low";
+		};
+	};
 };

--- a/boards/arm/ucans32k1sic/ucans32k1sic-pinctrl.dtsi
+++ b/boards/arm/ucans32k1sic/ucans32k1sic-pinctrl.dtsi
@@ -20,4 +20,11 @@
 			drive-strength = "low";
 		};
 	};
+
+	lpi2c0_default: lpi2c0_default {
+		group1 {
+			pinmux = <LPI2C0_SDA_PTA2>, <LPI2C0_SCL_PTA3>;
+			drive-strength = "low";
+		};
+	};
 };

--- a/boards/arm/ucans32k1sic/ucans32k1sic.dts
+++ b/boards/arm/ucans32k1sic/ucans32k1sic.dts
@@ -98,3 +98,9 @@
 	sda-gpios = <&gpioa 2 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 };
+
+&lpspi0 {
+	pinctrl-0 = <&lpspi0_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/boards/arm/ucans32k1sic/ucans32k1sic.dts
+++ b/boards/arm/ucans32k1sic/ucans32k1sic.dts
@@ -27,6 +27,7 @@
 		led1 = &led1_green;
 		led2 = &led1_blue;
 		sw0 = &button_3;
+		i2c-0 = &lpi2c0;
 	};
 
 	leds {
@@ -87,5 +88,13 @@
 	pinctrl-0 = <&lpuart1_default>;
 	pinctrl-names = "default";
 	current-speed = <115200>;
+	status = "okay";
+};
+
+&lpi2c0 {
+	pinctrl-0 = <&lpi2c0_default>;
+	pinctrl-names = "default";
+	scl-gpios = <&gpioa 3 GPIO_ACTIVE_HIGH>;
+	sda-gpios = <&gpioa 2 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 };

--- a/boards/arm/ucans32k1sic/ucans32k1sic.yaml
+++ b/boards/arm/ucans32k1sic/ucans32k1sic.yaml
@@ -15,3 +15,4 @@ supported:
   - gpio
   - uart
   - pinctrl
+  - i2c

--- a/boards/arm/ucans32k1sic/ucans32k1sic.yaml
+++ b/boards/arm/ucans32k1sic/ucans32k1sic.yaml
@@ -16,3 +16,4 @@ supported:
   - uart
   - pinctrl
   - i2c
+  - spi

--- a/dts/arm/nxp/nxp_s32k146.dtsi
+++ b/dts/arm/nxp/nxp_s32k146.dtsi
@@ -33,6 +33,8 @@
 	};
 };
 
+/delete-node/ &lpi2c1;
+
 &nvic {
 	arm,num-irq-priority-bits = <4>;
 };

--- a/dts/arm/nxp/nxp_s32k146.dtsi
+++ b/dts/arm/nxp/nxp_s32k146.dtsi
@@ -51,3 +51,11 @@
 &lpuart2 {
 	clocks = <&clock NXP_S32_LPUART2_CLK>;
 };
+
+&lpspi1 {
+	clocks = <&clock NXP_S32_LPSPI1_CLK>;
+};
+
+&lpspi2 {
+	clocks = <&clock NXP_S32_LPSPI2_CLK>;
+};

--- a/dts/arm/nxp/nxp_s32k1xx.dtsi
+++ b/dts/arm/nxp/nxp_s32k1xx.dtsi
@@ -44,6 +44,34 @@
 			status = "disabled";
 		};
 
+		lpspi0: spi@4002c000 {
+			compatible = "nxp,imx-lpspi";
+			reg = <0x4002c000 0x1000>;
+			interrupts = <26 0>;
+			clocks = <&clock NXP_S32_LPSPI0_CLK>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+		};
+
+		lpspi1: spi@4002d000 {
+			compatible = "nxp,imx-lpspi";
+			reg = <0x4002d000 0x1000>;
+			interrupts = <27 0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+		};
+
+		lpspi2: spi@4002e000 {
+			compatible = "nxp,imx-lpspi";
+			reg = <0x4002e000 0x1000>;
+			interrupts = <28 0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+		};
+
 		porta: pinmux@40049000 {
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x40049000 0x1000>;

--- a/dts/arm/nxp/nxp_s32k1xx.dtsi
+++ b/dts/arm/nxp/nxp_s32k1xx.dtsi
@@ -6,6 +6,7 @@
 
 #include <mem.h>
 #include <arm/armv7-m.dtsi>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
 	cpus {
@@ -78,6 +79,27 @@
 			reg = <0x40064000 0x1000>, <0x40065000 0x1000>;
 			#clock-cells = <1>;
 			status = "okay";
+		};
+
+		lpi2c0: i2c@40066000 {
+			compatible = "nxp,imx-lpi2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40066000 0x1000>;
+			interrupts = <24 0>;
+			clocks = <&clock NXP_S32_LPI2C0_CLK>;
+			status = "disabled";
+		};
+
+		lpi2c1: i2c@40067000 {
+			compatible = "nxp,imx-lpi2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40067000 0x1000>;
+			interrupts = <25 0>;
+			status = "disabled";
 		};
 
 		lpuart0: uart@4006a000 {

--- a/soc/arm/nxp_s32/s32k1/Kconfig.series
+++ b/soc/arm/nxp_s32/s32k1/Kconfig.series
@@ -15,5 +15,6 @@ config SOC_SERIES_S32K1XX
 	select CLOCK_CONTROL
 	select HAS_MCUX_LPUART
 	select HAS_MCUX_LPI2C
+	select HAS_MCUX_LPSPI
 	help
 	  Enable support for NXP S32K1XX MCU series.

--- a/soc/arm/nxp_s32/s32k1/Kconfig.series
+++ b/soc/arm/nxp_s32/s32k1/Kconfig.series
@@ -14,5 +14,6 @@ config SOC_SERIES_S32K1XX
 	select MPU_ALLOW_FLASH_WRITE if !XIP
 	select CLOCK_CONTROL
 	select HAS_MCUX_LPUART
+	select HAS_MCUX_LPI2C
 	help
 	  Enable support for NXP S32K1XX MCU series.

--- a/tests/drivers/spi/spi_loopback/boards/ucans32k1sic.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/ucans32k1sic.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Short P1.3 (SPI0/MISO) with P1.4 (SPI0/MOSI) */
+
+&lpspi0 {
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <500000>;
+	};
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <9000000>;
+	};
+};


### PR DESCRIPTION
Add I2C and SPI support for NXP UCANS32K1SIC board.

```
west twister -p ucans32k1sic --device-testing --device-serial=/dev/ttyUSB_ucans32k1sic -v \
  --fixture gpio_loopback --fixture spi_loopback -T tests/drivers/eeprom/api -T tests/drivers/spi

INFO    - Using Ninja..
INFO    - Zephyr version: zephyr-v3.5.0-2438-g8cc54e54e794
INFO    - Using 'zephyr' toolchain.
...
INFO    - 25 test scenarios (25 test instances) selected, 22 configurations skipped (18 by static filter, 4 at runtime).
INFO    - 3 of 25 test configurations passed (100.00%), 0 failed, 0 errored, 22 skipped with 0 warnings in 46.01 seconds
INFO    - In total 9 test cases were executed, 54 skipped on 1 out of total 650 platforms (0.15%)
INFO    - 3 test configurations executed on platforms, 0 test configurations were only built.
```
