### PR TITLE
scripts/build: make struct_tags.json deterministic

### DIFF
--- a/scripts/build/parse_syscalls.py
+++ b/scripts/build/parse_syscalls.py
@@ -84,6 +84,9 @@ def analyze_headers(include_dir, scan_dir, file_list):
     if scan_dir:
         multiple_directories |= set(scan_dir)
 
+    # Convert to a list to keep the output deterministic
+    multiple_directories = sorted(multiple_directories)
+
     # Look for source files under various directories.
     # Due to "syscalls/*.h" being included unconditionally in various
     # other header files. We must generate the associated syscall


### PR DESCRIPTION
It's not good to see struct_tags.json change from one build to the next when nothing changes.

Python's sets are not deterministic, see long story for older commit f896fc2306a0 ("scripts: gen_handles: Sort the device handles")

Simply convert multiple_directories to a sorted list before using it.

Fixes commit 80e78208e6cd ("kernel: syscalls: no need to include all syscalls in binary")