### PR TITLE
net: gptp: fix announce message len

### DIFF
--- a/subsys/net/l2/ethernet/gptp/gptp_messages.h
+++ b/subsys/net/l2/ethernet/gptp/gptp_messages.h
@@ -68,7 +68,7 @@ extern "C" {
 #define GPTP_ANNOUNCE_LEN(pkt) \
 	(sizeof(struct gptp_hdr) + sizeof(struct gptp_announce) \
 	 + ntohs(GPTP_ANNOUNCE(pkt)->tlv.len) \
-	 - sizeof(struct gptp_path_trace_tlv) + 4)
+	 - sizeof(struct gptp_path_trace_tlv))
 
 #define GPTP_CHECK_LEN(pkt, len) \
 	((GPTP_PACKET_LEN(pkt) != len) && (GPTP_VALID_LEN(pkt, len)))


### PR DESCRIPTION
This PR addresses the wrong gPTP announce message length issue [#65902](https://github.com/zephyrproject-rtos/zephyr/issues/65902#issue-2015954321).

**Issue:** Device warns for invalid gptp_announce message length:

**Invalid length for ANNOUNCE packet should have 68 bytes but has 64 bytes**

We found out that the issue is at [#define GPTP_ANNOUNCE_LEN(pkt)](https://github.com/zephyrproject-rtos/zephyr/blob/9521371157c23e70cfb58b6a76aa9b65c93868a9/subsys/net/l2/ethernet/gptp/gptp_messages.h#L68). **4 bytes** are already taken into consideration in the pkg length and it is not needed to add it again


```
#define GPTP_ANNOUNCE_LEN(pkt) \
	(sizeof(struct gptp_hdr) + sizeof(struct gptp_announce) \
	 + ntohs(GPTP_ANNOUNCE(pkt)->tlv.len) \
	 - sizeof(struct gptp_path_trace_tlv) + 4)
```





TLV is a variable length based on the 802.1AS-2011 but in Zephyr it is fixed to  [12 bytes.](https://github.com/zephyrproject-rtos/zephyr/blob/9521371157c23e70cfb58b6a76aa9b65c93868a9/subsys/net/l2/ethernet/gptp/gptp_messages.h#L152)
![tvl](https://github.com/zephyrproject-rtos/zephyr/assets/28357816/7fec8594-d969-46ae-94ff-caae7f7f458f)


```
struct gptp_path_trace_tlv {
	/** TLV type: 0x8. */
	uint16_t type;

	/** Length. Number of TLVs * 8 bytes. */
	uint16_t len;

	/** ClockIdentity array of the successive time-aware systems. */
	uint8_t  path_sequence[1][8];
} __packed;
```
**Solution**: For us removing +4 from GPTP_ANNOUNCE_LEN solved the issue. The devices could then successfully receive the announce messages. 

gPTP announce messages wireshark log:
[gPTP-Master-Ethertap-log291123.zip](https://github.com/zephyrproject-rtos/zephyr/files/13521828/gPTP-Master-Ethertap-log291123.zip)
