### PR TITLE
doc: Document cbprintf packaging limitation

### DIFF
--- a/doc/services/formatted_output.rst
+++ b/doc/services/formatted_output.rst
@@ -180,6 +180,10 @@ Limitations and recommendations
   static packaging is possible and it will append all detected strings. Character pointer
   used for ``%p`` will be considered as string pointer. Copying from unexpected location
   can have serious consequences (e.g., memory fault or security violation).
+* Packaging does not support string with precision specifier, e.g. ``%.10s``. That is because
+  packaging looks only at argument types. Using this parameter will result in appending
+  whole string to the message (until null termination) which may lead to exceeded message
+  size or fault if string is not null terminated.
 
 API Reference
 *************

--- a/doc/services/logging/index.rst
+++ b/doc/services/logging/index.rst
@@ -760,6 +760,8 @@ The are following recommendations:
   format specifier and it points to a transient string.
 * It is recommended to cast character pointer to non character pointer
   (e.g., ``void *``) when it is used with ``%p`` format specifier.
+* It is recommended to not use strings with precision specifiers, e.g ``%.10s`` because
+  it is not supported by the cbprintf packaging.
 
 .. code-block:: c
 


### PR DESCRIPTION
Document that string with precision specifier is not correctly handled and shall be avoided.

Reported by #/57867.