### PR TITLE
elf_parser.py: make dependency graph output deterministic

### DIFF
--- a/scripts/build/elf_parser.py
+++ b/scripts/build/elf_parser.py
@@ -24,6 +24,9 @@ class _Symbol:
         self.sym = sym
         self.data = self.elf.symbol_data(sym)
 
+    def __lt__(self, other):
+        return self.sym.entry.st_value < other.sym.entry.st_value
+
     def _data_native_read(self, offset):
         (format, size) = self.elf.native_struct_format
         return struct.unpack(format, self.data[offset:offset + size])[0]
@@ -238,8 +241,8 @@ class ZephyrElf:
             self.devices.append(Device(self, sym))
         self._object_find_named('__device_', _on_device)
 
-        # Sort the device array by address for handle calculation
-        self.devices = sorted(self.devices, key = lambda k: k.sym.entry.st_value)
+        # Sort the device array by address (st_value) for handle calculation
+        self.devices = sorted(self.devices)
 
         # Assign handles to the devices
         for idx, dev in enumerate(self.devices):

--- a/scripts/build/elf_parser.py
+++ b/scripts/build/elf_parser.py
@@ -283,6 +283,6 @@ class ZephyrElf:
                 )
             dot.node(str(dev.ordinal), text)
         for dev in self.devices:
-            for sup in dev.devs_supports:
+            for sup in sorted(dev.devs_supports):
                 dot.edge(str(dev.ordinal), str(sup.ordinal))
         return dot


### PR DESCRIPTION
2 commits. Main one:

Python's sets are not deterministic.

`devices` were already sorted but `dev_supports` is still a
non-deterministic set. Sort dev_supports to make the graph output
deterministic.

Fixes commit https://github.com/zephyrproject-rtos/zephyr/commit/29942475c5ce4c9f1d7a76273912777445f7d429 ("scripts: gen_handles: output dependency graph")

It is quite ironic that this initial and non-deterministic graph commit
was concurrent with and slightly delayed other commit
https://github.com/zephyrproject-rtos/zephyr/commit/f896fc2306a07c5fda4d9105182a57b20541cd50 ("scripts: gen_handles: Sort the device handles") which
fixed another, similar non-determinism issue in the same area. A true
"whack-a-mole"!