### PR TITLE
hda: separation of l1 settings to power manager

### DIFF
--- a/drivers/dma/dma_intel_adsp_hda.c
+++ b/drivers/dma/dma_intel_adsp_hda.c
@@ -182,9 +182,7 @@ int intel_adsp_hda_dma_host_reload(const struct device *dev, uint32_t channel,
 	__ASSERT(channel < cfg->dma_channels, "Channel does not exist");
 
 #if CONFIG_DMA_INTEL_ADSP_HDA_TIMING_L1_EXIT
-#if CONFIG_SOC_SERIES_INTEL_ACE
-	ACE_DfPMCCH.svcfg |= ADSP_FORCE_DECOUPLED_HDMA_L1_EXIT_BIT;
-#endif
+	intel_adsp_force_dmi_l0_state();
 	switch (cfg->direction) {
 	case HOST_TO_MEMORY:
 		; /* Only statements can be labeled in C, a declaration is not valid */
@@ -464,9 +462,7 @@ void intel_adsp_hda_dma_isr(void)
 	}
 
 	if (clear_l1_exit) {
-#if CONFIG_SOC_SERIES_INTEL_ACE
-		ACE_DfPMCCH.svcfg &= ~(ADSP_FORCE_DECOUPLED_HDMA_L1_EXIT_BIT);
-#endif
+		intel_adsp_allow_dmi_l1_state();
 	}
 #endif
 }

--- a/soc/xtensa/intel_adsp/common/include/intel_adsp_hda.h
+++ b/soc/xtensa/intel_adsp/common/include/intel_adsp_hda.h
@@ -10,6 +10,7 @@
 #include <zephyr/device.h>
 #include <adsp_shim.h>
 #include <adsp_memory.h>
+#include <adsp_shim.h>
 
 /**
  * @brief HDA stream functionality for Intel ADSP
@@ -439,6 +440,20 @@ static inline void intel_adsp_hda_disable_buffer_interrupt(uint32_t base, uint32
 							   uint32_t sid)
 {
 	*DGCS(base, regblock_size, sid) &= ~DGCS_BSCIE;
+}
+
+static inline void intel_adsp_force_dmi_l0_state(void)
+{
+#ifdef CONFIG_SOC_SERIES_INTEL_ACE
+	ACE_DfPMCCH.svcfg |= ADSP_FORCE_DECOUPLED_HDMA_L1_EXIT_BIT;
+#endif
+}
+
+static inline void intel_adsp_allow_dmi_l1_state(void)
+{
+#ifdef CONFIG_SOC_SERIES_INTEL_ACE
+	ACE_DfPMCCH.svcfg &= ~(ADSP_FORCE_DECOUPLED_HDMA_L1_EXIT_BIT);
+#endif
 }
 
 /**


### PR DESCRIPTION
Separating two new functions force and allow l1 to have the current state with separated functions in the power manager so that SOF can call these functions via IPC DMI_FORCE_L1_EXIT. Change related to the addition of a new parameter to force DMI L1 exit on IPC request.

Associated with: https://github.com/thesofproject/sof/pull/8561/files