### PR TITLE
boards nrf5340bsim_cpuapp: Select approprite 802154 radio in DT

### DIFF
--- a/boards/posix/nrf_bsim/nrf5340bsim_nrf5340_cpuapp.dts
+++ b/boards/posix/nrf_bsim/nrf5340bsim_nrf5340_cpuapp.dts
@@ -49,6 +49,7 @@
 		zephyr,flash = &flash0;
 		zephyr,bt-hci-ipc = &ipc0;
 		nordic,802154-spinel-ipc = &ipc0;
+		zephyr,ieee802154 = &ieee802154;
 	};
 
 	soc {


### PR DESCRIPTION
Set the chosen 802154 radio in DT for the
nrf5340bsim_nrf5340_cpuapp so we can build with the radio driver built into the net core.