### PR TITLE
manifest: Update nrf hw models to latest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -295,7 +295,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: a715dcc179f1a71f51c574165958b72fe932ae3f
+      revision: 9b985ea6bc237b6ae06f48eb228f2ac7f6e3b96b
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
       revision: 214f9fc1539f8e5937c0474cb6ee29b6dcb2d4b8


### PR DESCRIPTION
Update the HW models module to 9b985ea6bc237b6ae06f48eb228f2ac7f6e3b96b

Including the following:
* 9b985ea nrf_ccm: Add RATEOVERRIDE subscribe support
* 8592230 nrf_hack: Add comments
* 5775f4c docs: Very minor typo and grammar fixes