### PR TITLE
boards: arm: apollo4p_evb: Add internal pullups to buttons and LEDs

### DIFF
--- a/boards/arm/apollo4p_evb/apollo4p_evb.dts
+++ b/boards/arm/apollo4p_evb/apollo4p_evb.dts
@@ -28,15 +28,15 @@
 	leds {
 		compatible = "gpio-leds";
 		led0: led_0 {
-			gpios = <&gpio0_31 30 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio0_31 30 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "LED 0";
 		};
 		led1: led_1 {
-			gpios = <&gpio64_95 26 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio64_95 26 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "LED 1";
 		};
 		led2: led_2 {
-			gpios = <&gpio96_127 1 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio96_127 1 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "LED 2";
 		};
 	};
@@ -44,11 +44,11 @@
 	buttons {
 		compatible = "gpio-keys";
 		button0: button_0 {
-			gpios = <&gpio0_31 18 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio0_31 18 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "BTN0";
 		};
 		button1: button_1 {
-			gpios = <&gpio0_31 19 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio0_31 19 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "BTN1";
 		};
 	};


### PR DESCRIPTION
The LEDs and buttons on the evb need internal pullups.

The previous merge of the apollo4p_evb did not pass the samples/basic/buttons examples.
the apollo4p_evb uses internal pullups and not board populated pullups with the active low configuration.