### PR TITLE
Updated sensor adxl345 driver to support configuration via device tree and interrupt trigges.

### DIFF
--- a/drivers/sensor/adxl345/CMakeLists.txt
+++ b/drivers/sensor/adxl345/CMakeLists.txt
@@ -6,3 +6,4 @@
 zephyr_library()
 
 zephyr_library_sources(adxl345.c)
+zephyr_library_sources_ifdef(CONFIG_ADXL345_TRIGGER adxl345_trigger.c)

--- a/drivers/sensor/adxl345/Kconfig
+++ b/drivers/sensor/adxl345/Kconfig
@@ -11,3 +11,45 @@ config ADXL345
 	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ADI_ADXL345),spi)
 	help
 	  Enable driver for ADXL345 Three-Axis Digital Accelerometer.
+
+if ADXL345
+
+choice ADXL345_TRIGGER_MODE
+	prompt "Trigger mode"
+	default ADXL345_TRIGGER_NONE
+	help
+	  Specify the type of triggering used by the driver.
+
+config ADXL345_TRIGGER_NONE
+	bool "No trigger"
+
+config ADXL345_TRIGGER_GLOBAL_THREAD
+	bool "Use global thread"
+	depends on GPIO
+	select ADXL345_TRIGGER
+
+config ADXL345_TRIGGER_OWN_THREAD
+	bool "Use own thread"
+	depends on GPIO
+	select ADXL345_TRIGGER
+
+endchoice
+
+config ADXL345_TRIGGER
+	bool
+
+config CONFIG_ADXL345_THREAD_PRIORITY
+	int "Thread priority"
+	depends on ADXL345_TRIGGER_OWN_THREAD && ADXL345_TRIGGER
+	default 10
+	help
+	  Priority of thread used by the driver to handle interrupts.
+
+config CONFIG_ADXL345_THREAD_STACK_SIZE
+	int "Thread stack size"
+	depends on ADXL345_TRIGGER_OWN_THREAD && ADXL345_TRIGGER
+	default 1024
+	help
+	  Stack size of thread used by the driver to handle interrupts.
+
+endif # ADXL345

--- a/drivers/sensor/adxl345/adxl345.c
+++ b/drivers/sensor/adxl345/adxl345.c
@@ -6,7 +6,7 @@
 
 #define DT_DRV_COMPAT adi_adxl345
 
-#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/sensor/adxl345.h>
 #include <zephyr/init.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/i2c.h>
@@ -63,22 +63,20 @@ static int adxl345_reg_access_spi(const struct device *dev, uint8_t cmd, uint8_t
 }
 #endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(spi) */
 
-static int adxl345_reg_access(const struct device *dev, uint8_t cmd, uint8_t addr,
-				     uint8_t *data, size_t len)
+static int adxl345_reg_access(const struct device *dev, uint8_t cmd, uint8_t addr, uint8_t *data,
+			      size_t len)
 {
 	const struct adxl345_dev_config *cfg = dev->config;
 
 	return cfg->reg_access(dev, cmd, addr, data, len);
 }
 
-static int adxl345_reg_write(const struct device *dev, uint8_t addr, uint8_t *data,
-				    uint8_t len)
+static int adxl345_reg_write(const struct device *dev, uint8_t addr, uint8_t *data, uint8_t len)
 {
 	return adxl345_reg_access(dev, ADXL345_WRITE_CMD, addr, data, len);
 }
 
-static int adxl345_reg_read(const struct device *dev, uint8_t addr, uint8_t *data,
-				   uint8_t len)
+static int adxl345_reg_read(const struct device *dev, uint8_t addr, uint8_t *data, uint8_t len)
 {
 	return adxl345_reg_access(dev, ADXL345_READ_CMD, addr, data, len);
 }
@@ -93,8 +91,7 @@ int adxl345_reg_read_byte(const struct device *dev, uint8_t addr, uint8_t *buf)
 	return adxl345_reg_read(dev, addr, buf, 1);
 }
 
-int adxl345_reg_write_mask(const struct device *dev, uint8_t reg_addr, uint32_t mask,
-					 uint8_t data)
+int adxl345_reg_write_mask(const struct device *dev, uint8_t reg_addr, uint32_t mask, uint8_t data)
 {
 	int ret;
 	uint8_t tmp;

--- a/drivers/sensor/adxl345/adxl345.c
+++ b/drivers/sensor/adxl345/adxl345.c
@@ -63,7 +63,7 @@ static int adxl345_reg_access_spi(const struct device *dev, uint8_t cmd, uint8_t
 }
 #endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(spi) */
 
-static inline int adxl345_reg_access(const struct device *dev, uint8_t cmd, uint8_t addr,
+static int adxl345_reg_access(const struct device *dev, uint8_t cmd, uint8_t addr,
 				     uint8_t *data, size_t len)
 {
 	const struct adxl345_dev_config *cfg = dev->config;
@@ -71,29 +71,29 @@ static inline int adxl345_reg_access(const struct device *dev, uint8_t cmd, uint
 	return cfg->reg_access(dev, cmd, addr, data, len);
 }
 
-static inline int adxl345_reg_write(const struct device *dev, uint8_t addr, uint8_t *data,
+static int adxl345_reg_write(const struct device *dev, uint8_t addr, uint8_t *data,
 				    uint8_t len)
 {
 	return adxl345_reg_access(dev, ADXL345_WRITE_CMD, addr, data, len);
 }
 
-static inline int adxl345_reg_read(const struct device *dev, uint8_t addr, uint8_t *data,
+static int adxl345_reg_read(const struct device *dev, uint8_t addr, uint8_t *data,
 				   uint8_t len)
 {
 	return adxl345_reg_access(dev, ADXL345_READ_CMD, addr, data, len);
 }
 
-static inline int adxl345_reg_write_byte(const struct device *dev, uint8_t addr, uint8_t val)
+int adxl345_reg_write_byte(const struct device *dev, uint8_t addr, uint8_t val)
 {
 	return adxl345_reg_write(dev, addr, &val, 1);
 }
 
-static inline int adxl345_reg_read_byte(const struct device *dev, uint8_t addr, uint8_t *buf)
+int adxl345_reg_read_byte(const struct device *dev, uint8_t addr, uint8_t *buf)
 {
 	return adxl345_reg_read(dev, addr, buf, 1);
 }
 
-static inline int adxl345_reg_write_mask(const struct device *dev, uint8_t reg_addr, uint32_t mask,
+int adxl345_reg_write_mask(const struct device *dev, uint8_t reg_addr, uint32_t mask,
 					 uint8_t data)
 {
 	int ret;

--- a/drivers/sensor/adxl345/adxl345.c
+++ b/drivers/sensor/adxl345/adxl345.c
@@ -380,11 +380,11 @@ static int adxl345_attr_set(const struct device *dev, enum sensor_channel chan,
 	}
 	case SENSOR_ATTR_ACTIVE_THRESH: {
 		int16_t milli_g = sensor_ms2_to_ug(val) / 1000;
-		return adxl345_reg_write_byte(dev, ADXL345_THRESH_ACT_REG, milli_g * 2 / 128);
+		return adxl345_reg_write_byte(dev, ADXL345_THRESH_ACT_REG, milli_g * 2 / 125);
 	}
 	case SENSOR_ATTR_INACTIVE_THRESH: {
 		int16_t milli_g = sensor_ms2_to_ug(val) / 1000;
-		return adxl345_reg_write_byte(dev, ADXL345_THRESH_INACT_REG, milli_g * 2 / 128);
+		return adxl345_reg_write_byte(dev, ADXL345_THRESH_INACT_REG, milli_g * 2 / 125);
 	}
 	case SENSOR_ATTR_INACTIVE_TIME: {
 		uint16_t milli_seconds = (((int64_t)val->val1) * 1000) + (val->val2 / 1000);

--- a/drivers/sensor/adxl345/adxl345.c
+++ b/drivers/sensor/adxl345/adxl345.c
@@ -63,23 +63,20 @@ static int adxl345_reg_access_spi(const struct device *dev, uint8_t cmd, uint8_t
 }
 #endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(spi) */
 
-static inline int adxl345_reg_access(const struct device *dev, uint8_t cmd, uint8_t addr,
-				     uint8_t *data, size_t len)
+static inline int adxl345_reg_access(const struct device *dev, uint8_t cmd, uint8_t addr, uint8_t *data,
+			      size_t len)
 {
 	const struct adxl345_dev_config *cfg = dev->config;
 
 	return cfg->reg_access(dev, cmd, addr, data, len);
 }
 
-static inline int adxl345_reg_write(const struct device *dev, uint8_t addr, uint8_t *data,
-				    uint8_t len)
+static inline int adxl345_reg_write(const struct device *dev, uint8_t addr, uint8_t *data, uint8_t len)
 {
-
 	return adxl345_reg_access(dev, ADXL345_WRITE_CMD, addr, data, len);
 }
 
-static inline int adxl345_reg_read(const struct device *dev, uint8_t addr, uint8_t *data,
-				   uint8_t len)
+static inline int adxl345_reg_read(const struct device *dev, uint8_t addr, uint8_t *data, uint8_t len)
 {
 	return adxl345_reg_access(dev, ADXL345_READ_CMD, addr, data, len);
 }
@@ -95,7 +92,7 @@ static inline int adxl345_reg_read_byte(const struct device *dev, uint8_t addr, 
 }
 
 static inline int adxl345_reg_write_mask(const struct device *dev, uint8_t reg_addr, uint32_t mask,
-					 uint8_t data)
+				  uint8_t data)
 {
 	int ret;
 	uint8_t tmp;

--- a/drivers/sensor/adxl345/adxl345.h
+++ b/drivers/sensor/adxl345/adxl345.h
@@ -163,6 +163,10 @@ struct adxl345_dev_data {
 	const struct sensor_trigger *drdy_trigger;
 	sensor_trigger_handler_t waterfall_handler;
 	const struct sensor_trigger *waterfall_trigger;
+	sensor_trigger_handler_t active_handler;
+	const struct sensor_trigger *active_trigger;
+	sensor_trigger_handler_t inactive_handler;
+	const struct sensor_trigger *inactive_trigger;
 
 	const struct device *dev;
 

--- a/drivers/sensor/adxl345/adxl345.h
+++ b/drivers/sensor/adxl345/adxl345.h
@@ -212,6 +212,10 @@ struct adxl345_dev_config {
 int adxl345_init_interrupt(const struct device *dev);
 int adxl345_trigger_set(const struct device *dev, const struct sensor_trigger *trig,
 			sensor_trigger_handler_t handle);
+
+int adxl345_reg_read_byte(const struct device *dev, uint8_t addr, uint8_t *buf);
+int adxl345_reg_write_mask(const struct device *dev, uint8_t reg_addr, uint32_t mask, uint8_t data);
+int adxl345_reg_write_byte(const struct device *dev, uint8_t addr, uint8_t val);
 #endif
 
 #endif /* ZEPHYR_DRIVERS_SENSOR_ADX345_ADX345_H_ */

--- a/drivers/sensor/adxl345/adxl345.h
+++ b/drivers/sensor/adxl345/adxl345.h
@@ -161,8 +161,9 @@ struct adxl345_dev_data {
 
 	sensor_trigger_handler_t drdy_handler;
 	const struct sensor_trigger *drdy_trigger;
-	sensor_trigger_handler_t single_tap_handler;
-	const struct sensor_trigger *single_tap_trigger;
+	sensor_trigger_handler_t waterfall_handler;
+	const struct sensor_trigger *waterfall_trigger;
+
 	const struct device *dev;
 
 #if defined(CONFIG_ADXL345_TRIGGER_OWN_THREAD)
@@ -205,11 +206,8 @@ struct adxl345_dev_config {
 
 #ifdef CONFIG_ADXL345_TRIGGER
 int adxl345_init_interrupt(const struct device *dev);
-int adxl345_reg_read_byte(const struct device *dev, uint8_t addr, uint8_t *buf);
-int adxl345_reg_write_mask(const struct device *dev, uint8_t reg_addr, uint32_t mask, uint8_t data);
-
 int adxl345_trigger_set(const struct device *dev, const struct sensor_trigger *trig,
-			sensor_trigger_handler_t handler);
+			sensor_trigger_handler_t handle);
 #endif
 
 #endif /* ZEPHYR_DRIVERS_SENSOR_ADX345_ADX345_H_ */

--- a/drivers/sensor/adxl345/adxl345.h
+++ b/drivers/sensor/adxl345/adxl345.h
@@ -151,6 +151,7 @@ struct adxl345_dev_data {
 	int16_t bufy[ADXL345_MAX_FIFO_SIZE];
 	int16_t bufz[ADXL345_MAX_FIFO_SIZE];
 
+	uint16_t odr_frequency;
 	enum adxl345_odr odr;
 	enum adxl345_range range;
 	enum adxl345_fifo fifo_mode;
@@ -203,9 +204,9 @@ struct adxl345_dev_config {
 #endif
 
 	bool low_power;
-	enum adxl345_odr odr;
-	enum adxl345_range range;
-	enum adxl345_fifo fifo_mode;
+	uint16_t odr;
+	uint8_t range;
+	uint8_t fifo_mode;
 };
 
 #ifdef CONFIG_ADXL345_TRIGGER

--- a/drivers/sensor/adxl345/adxl345.h
+++ b/drivers/sensor/adxl345/adxl345.h
@@ -154,6 +154,7 @@ struct adxl345_dev_data {
 	enum adxl345_odr odr;
 	enum adxl345_range range;
 	enum adxl345_fifo fifo_mode;
+	uint16_t scale_factor;
 
 #if defined(CONFIG_ADXL345_TRIGGER)
 	struct gpio_callback gpio_cb;

--- a/drivers/sensor/adxl345/adxl345.h
+++ b/drivers/sensor/adxl345/adxl345.h
@@ -7,6 +7,7 @@
 #ifndef ZEPHYR_DRIVERS_SENSOR_ADX345_ADX345_H_
 #define ZEPHYR_DRIVERS_SENSOR_ADX345_ADX345_H_
 
+#include <zephyr/drivers/sensor.h>
 #include <zephyr/types.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
@@ -19,32 +20,129 @@
 #include <zephyr/sys/util.h>
 
 /* ADXL345 communication commands */
-#define ADXL345_WRITE_CMD          0x00
-#define ADXL345_READ_CMD           0x80
-#define ADXL345_MULTIBYTE_FLAG     0x40
+#define ADXL345_WRITE_CMD      0x00
+#define ADXL345_READ_CMD       0x80
+#define ADXL345_MULTIBYTE_FLAG 0x40
 
 /* Registers */
-#define ADXL345_DEVICE_ID_REG      0x00
-#define ADXL345_RATE_REG           0x2c
-#define ADXL345_POWER_CTL_REG      0x2d
-#define ADXL345_DATA_FORMAT_REG    0x31
-#define ADXL345_X_AXIS_DATA_0_REG  0x32
-#define ADXL345_FIFO_CTL_REG       0x38
-#define ADXL345_FIFO_STATUS_REG    0x39
+// ADXL345 DEVICE_ID register
+#define ADXL345_DEVICE_ID_REG   0x00
+#define ADXL345_DEVICE_ID_VALUE 0b11100101
 
-#define ADXL345_PART_ID            0xe5
+// ADXL345 THRESH_TAP register
+#define ADXL345_THRESH_TAP_REG 0x1D
 
-#define ADXL345_RANGE_2G           0x0
-#define ADXL345_RANGE_4G           0x1
-#define ADXL345_RANGE_8G           0x2
-#define ADXL345_RANGE_16G          0x3
-#define ADXL345_RATE_25HZ          0x8
-#define ADXL345_ENABLE_MEASURE_BIT (1 << 3)
-#define ADXL345_FIFO_STREAM_MODE   (1 << 7)
-#define ADXL345_FIFO_COUNT_MASK    0x3f
-#define ADXL345_COMPLEMENT         0xfc00
+// ADXL345 DUR register
+#define ADXL345_DUR_REG 0x21
 
-#define ADXL345_MAX_FIFO_SIZE      32
+// ADXL345 THRESH_ACT register
+#define ADXL345_THRESH_ACT_REG 0x24
+
+// ADXL345 THRESH_INACT register
+#define ADXL345_THRESH_INACT_REG 0x25
+
+// ADXL345 TIME_INACT register
+#define ADXL345_TIME_INACT_REG 0x26
+
+// ADXL345 ACT_INACT_CTL register
+#define ADXL345_ACT_INACT_CTL_REG                0x27
+#define ADXL345_ACT_INACT_CTL_ACT_DECOUPLE_MSK   BIT(7)
+#define ADXL345_ACT_INACT_CTL_ACT_AXIS_MSK       GENMASK(6, 4)
+#define ADXL345_ACT_INACT_CTL_INACT_DECOUPLE_MSK BIT(3)
+#define ADXL345_ACT_INACT_CTL_INACT_AXIS_MSK     GENMASK(2, 0)
+
+// ADXL345 THRESH_FF register
+#define ADXL345_THRESH_FF_REG 0x28
+// ADXL345 TIME_FF register
+#define ADXL345_TIME_FF_REG   0x29
+
+// ADXL345 TAP_AXES register
+#define ADXL345_TAP_AXES_REG          0x2A
+#define ADXL345_TAP_AXES_TAP_AXIS_MSK GENMASK(2, 0)
+
+// ADXL345 BW_RATE register
+#define ADXL345_BW_RATE_REG           0x2C
+#define ADXL345_BW_RATE_RATE_MSK      GENMASK(3, 0)
+#define ADXL345_BW_RATE_LOW_POWER_MSK BIT(4)
+
+// ADXL345 POWER_CTL register
+#define ADXL345_POWER_CTL_REG             0x2D
+#define ADXL345_POWER_CTL_REG_MEASURE_BIT BIT(3)
+#define ADXL345_POWER_CTL_LINK_BIT        BIT(5)
+
+// ADXL345 INT_ENABLE register
+#define ADXL345_INT_ENABLE_REG            0x2E
+#define ADXL345_INT_ENABLE_WATERMARK_BIT  BIT(1)
+#define ADXL345_INT_ENABLE_FREE_FALL_BIT  BIT(2)
+#define ADXL345_INT_ENABLE_INACTIVE_BIT   BIT(3)
+#define ADXL345_INT_ENABLE_ACTIVE_BIT     BIT(4)
+#define ADXL345_INT_ENABLE_DOUBLE_TAP_BIT BIT(5)
+#define ADXL345_INT_ENABLE_SINGLE_TAP_BIT BIT(6)
+#define ADXL345_INT_ENABLE_DATA_READY_BIT BIT(7)
+
+// ADXL345 INT_SOURCE register
+#define ADXL345_INT_SOURCE_REG            0x30
+#define ADXL345_INT_SOURCE_WATERMARK_BIT  BIT(1)
+#define ADXL345_INT_SOURCE_FREE_FALL_BIT  BIT(2)
+#define ADXL345_INT_SOURCE_INACTIVE_BIT   BIT(3)
+#define ADXL345_INT_SOURCE_ACTIVE_BIT     BIT(4)
+#define ADXL345_INT_SOURCE_DOUBLE_TAP_BIT BIT(5)
+#define ADXL345_INT_SOURCE_SINGLE_TAP_BIT BIT(6)
+#define ADXL345_INT_SOURCE_DATA_READY_BIT BIT(7)
+
+// ADXL345 DATA_FORMAT register
+#define ADXL345_DATA_FORMAT_REG       0x31
+#define ADXL345_DATA_FORMAT_RANGE_MSK GENMASK(1, 0)
+
+// ADXL345 DATAX0, etc registers
+#define ADXL345_X_AXIS_DATA_0_REG 0x32
+
+// ADXL345 FIFO_CTL register
+#define ADXL345_FIFO_CTL_REG        0x38
+#define ADXL345_FIFO_CTL_FIFO_MSK   GENMASK(7, 6)
+#define ADXL345_FIFO_CTL_SAMPLE_MSK GENMASK(4, 0)
+
+// ADXL345 FIFO_STATUS register
+#define ADXL345_FIFO_STATUS_REG 0x39
+
+/* Sensor properties definitions */
+// ADXL345 FIFO size
+#define ADXL345_MAX_FIFO_SIZE 32
+#define ADXL345_COMPLEMENT    0xfc00
+
+// ADXL345 supported sampling frequencies
+enum adxl345_odr {
+	ADXL345_ODR_6P25HZ = BIT(2) | BIT(1),
+	ADXL345_ODR_12P5HZ = BIT(2) | BIT(1) | BIT(0),
+	ADXL345_ODR_25HZ = BIT(3),
+	ADXL345_ODR_50HZ = BIT(3) | BIT(0),
+	ADXL345_ODR_100HZ = BIT(3) | BIT(1),
+	ADXL345_ODR_200HZ = BIT(3) | BIT(2),
+	ADXL345_ODR_400HZ = BIT(3) | BIT(2) | BIT(0),
+};
+
+// ADXL345 supported sampling ranges
+enum adxl345_range {
+	ADXL345_2G_RANGE = 0,
+	ADXL345_4G_RANGE = BIT(0),
+	ADXL345_8G_RANGE = BIT(1),
+	ADXL345_16G_RANGE = BIT(1) | BIT(0),
+};
+
+// ADXL345 supported fifo modes
+enum adxl345_fifo {
+	ADXL345_FIFO_BYPASS = 0,
+	ADXL345_FIFO_FIFO = BIT(6),
+	ADXL345_FIFO_STREAM = BIT(7),
+	ADXL345_FIFO_TRIGGER = GENMASK(7, 6),
+};
+
+// ADXL345 sample
+struct adxl345_sample {
+	int16_t x;
+	int16_t y;
+	int16_t z;
+};
 
 struct adxl345_dev_data {
 	unsigned int sample_number;
@@ -52,12 +150,28 @@ struct adxl345_dev_data {
 	int16_t bufx[ADXL345_MAX_FIFO_SIZE];
 	int16_t bufy[ADXL345_MAX_FIFO_SIZE];
 	int16_t bufz[ADXL345_MAX_FIFO_SIZE];
-};
 
-struct adxl345_sample {
-	int16_t x;
-	int16_t y;
-	int16_t z;
+	enum adxl345_odr odr;
+	enum adxl345_range range;
+	enum adxl345_fifo fifo_mode;
+
+#if defined(CONFIG_ADXL345_TRIGGER)
+	struct gpio_callback gpio_cb;
+
+	sensor_trigger_handler_t drdy_handler;
+	const struct sensor_trigger *drdy_trigger;
+	sensor_trigger_handler_t single_tap_handler;
+	const struct sensor_trigger *single_tap_trigger;
+	const struct device *dev;
+
+#if defined(CONFIG_ADXL345_TRIGGER_OWN_THREAD)
+	K_KERNEL_STACK_MEMBER(thread_stack, CONFIG_ADXL345_THREAD_STACK_SIZE);
+	struct k_sem gpio_sem;
+	struct k_thread thread;
+#elif defined(CONFIG_ADXL345_TRIGGER_GLOBAL_THREAD)
+	struct k_work work;
+#endif
+#endif /* CONFIG_ADXL345_TRIGGER */
 };
 
 union adxl345_bus {
@@ -70,13 +184,31 @@ union adxl345_bus {
 };
 
 typedef bool (*adxl345_bus_is_ready_fn)(const union adxl345_bus *bus);
-typedef int (*adxl345_reg_access_fn)(const struct device *dev, uint8_t cmd,
-				     uint8_t reg_addr, uint8_t *data, size_t length);
+typedef int (*adxl345_reg_access_fn)(const struct device *dev, uint8_t cmd, uint8_t reg_addr,
+				     uint8_t *data, size_t length);
 
 struct adxl345_dev_config {
 	const union adxl345_bus bus;
 	adxl345_bus_is_ready_fn bus_is_ready;
 	adxl345_reg_access_fn reg_access;
+
+#ifdef CONFIG_ADXL345_TRIGGER
+	struct gpio_dt_spec interrupt;
+#endif
+
+	bool low_power;
+	enum adxl345_odr odr;
+	enum adxl345_range range;
+	enum adxl345_fifo fifo_mode;
 };
+
+#ifdef CONFIG_ADXL345_TRIGGER
+int adxl345_init_interrupt(const struct device *dev);
+int adxl345_reg_read_byte(const struct device *dev, uint8_t addr, uint8_t *buf);
+int adxl345_reg_write_mask(const struct device *dev, uint8_t reg_addr, uint32_t mask, uint8_t data);
+
+int adxl345_trigger_set(const struct device *dev, const struct sensor_trigger *trig,
+			sensor_trigger_handler_t handler);
+#endif
 
 #endif /* ZEPHYR_DRIVERS_SENSOR_ADX345_ADX345_H_ */

--- a/drivers/sensor/adxl345/adxl345_trigger.c
+++ b/drivers/sensor/adxl345/adxl345_trigger.c
@@ -18,53 +18,6 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(ADXL345, CONFIG_SENSOR_LOG_LEVEL);
 
-static inline int adxl345_reg_access(const struct device *dev, uint8_t cmd, uint8_t addr,
-				     uint8_t *data, size_t len)
-{
-	const struct adxl345_dev_config *cfg = dev->config;
-
-	return cfg->reg_access(dev, cmd, addr, data, len);
-}
-
-static inline int adxl345_reg_write(const struct device *dev, uint8_t addr, uint8_t *data,
-				    uint8_t len)
-{
-	return adxl345_reg_access(dev, ADXL345_WRITE_CMD, addr, data, len);
-}
-
-static inline int adxl345_reg_read(const struct device *dev, uint8_t addr, uint8_t *data,
-				   uint8_t len)
-{
-	return adxl345_reg_access(dev, ADXL345_READ_CMD, addr, data, len);
-}
-
-static inline int adxl345_reg_write_byte(const struct device *dev, uint8_t addr, uint8_t val)
-{
-	return adxl345_reg_write(dev, addr, &val, 1);
-}
-
-static inline int adxl345_reg_read_byte(const struct device *dev, uint8_t addr, uint8_t *buf)
-{
-	return adxl345_reg_read(dev, addr, buf, 1);
-}
-
-static inline int adxl345_reg_write_mask(const struct device *dev, uint8_t reg_addr, uint32_t mask,
-					 uint8_t data)
-{
-	int ret;
-	uint8_t tmp;
-
-	ret = adxl345_reg_read_byte(dev, reg_addr, &tmp);
-	if (ret != 0) {
-		return ret;
-	}
-
-	tmp &= ~mask;
-	tmp |= data;
-
-	return adxl345_reg_write_byte(dev, reg_addr, tmp);
-}
-
 static void adxl345_thread_cb(const struct device *dev)
 {
 	struct adxl345_dev_data *drv_data = dev->data;

--- a/drivers/sensor/adxl345/adxl345_trigger.c
+++ b/drivers/sensor/adxl345/adxl345_trigger.c
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <sys/errno.h>
+#define DT_DRV_COMPAT adi_adxl345
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/sensor.h>
+
+#include "adxl345.h"
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(ADXL345, CONFIG_SENSOR_LOG_LEVEL);
+
+static void adxl345_thread_cb(const struct device *dev)
+{
+	LOG_INF("NEW ADXL TRIGGER RECEIVED");
+	const struct adxl345_dev_config *cfg = dev->config;
+	struct adxl345_dev_data *drv_data = dev->data;
+	uint8_t status;
+	int rc;
+
+	// Read and clear the interrupt status
+	rc = adxl345_reg_read_byte(drv_data->dev, ADXL345_INT_SOURCE, &status);
+	if (0 != rc) {
+		return;
+	}
+
+	if (NULL != drv_data->drdy_handler) {
+		if (FIELD_GET(ADXL345_INT_SOURCE_DATA_RDY_MSK, status) != 0) {
+			drv_data->drdy_handler(dev, drv_data->drdy_trigger);
+		}
+	}
+
+	rc = gpio_pin_interrupt_configure_dt(&cfg->interrupt, GPIO_INT_EDGE_TO_ACTIVE);
+	__ASSERT(ret == 0, "Interrupt configuration failed");
+}
+
+static void adxl345_gpio_callback(const struct device *dev, struct gpio_callback *cb, uint32_t pins)
+{
+	struct adxl345_dev_data *drv_data = CONTAINER_OF(cb, struct adxl345_dev_data, gpio_cb);
+
+#if defined(CONFIG_ADXL345_TRIGGER_OWN_THREAD)
+	k_sem_give(&drv_data->gpio_sem);
+#elif defined(CONFIG_ADXL345_TRIGGER_GLOBAL_THREAD)
+	k_work_submit(&drv_data->work);
+#endif
+}
+
+#if defined(CONFIG_ADXL345_TRIGGER_OWN_THREAD)
+static void adxl345_thread(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	struct adxl345_dev_data *drv_data = p1;
+
+	while (true) {
+		k_sem_take(&drv_data->gpio_sem, K_FOREVER);
+		adxl345_thread_cb(drv_data->dev);
+	}
+}
+#elif defined(CONFIG_ADXL345_TRIGGER_GLOBAL_THREAD)
+static void adxl345_work_cb(struct k_work *work)
+{
+	struct adxl345_dev_data *drv_data = CONTAINER_OF(work, struct adxl345_dev_data, work);
+	adxl345_thread_cb(drv_data->dev);
+}
+#endif
+
+int adxl345_trigger_set(const struct device *dev, const struct sensor_trigger *trig,
+			sensor_trigger_handler_t handler)
+{
+	const struct adxl345_dev_config *cfg = dev->config;
+	struct adxl345_dev_data *drv_data = dev->data;
+	uint8_t int_mask = 0, status = 0;
+	int rc;
+
+	if (!cfg->interrupt.port) {
+		return -ENOTSUP;
+	}
+
+	if (NULL == handler) {
+		return -EINVAL;
+	}
+
+	rc = gpio_pin_interrupt_configure_dt(&cfg->interrupt, GPIO_INT_DISABLE);
+	if (0 != rc) {
+		return rc;
+	}
+
+	switch (trig->type) {
+	case SENSOR_TRIG_DATA_READY: {
+		drv_data->drdy_handler = handler;
+		drv_data->drdy_trigger = trig;
+		int_mask = ADXL345_INT_ENABLE_DATA_RDY_MSK;
+		break;
+	}
+	case SENSOR_TRIG_TAP: {
+		drv_data->single_tap_handler = handler;
+		drv_data->single_tap_trigger = trig;
+		int_mask = ADXL345_INT_ENABLE_SINGLE_TAP_MSK;
+		adxl345_reg_write_mask(dev, ADXL345_DUR, 0xFF, 1);
+		adxl345_reg_write_mask(dev, ADXL345_THRESH_TAP, 0xFF, 1);
+		adxl345_reg_write_mask(dev, ADXL345_TAP_AXES, 0b111, 0b111);
+
+		int_mask = ADXL345_INT_ENABLE_SINGLE_TAP_MSK;
+
+		break;
+	}
+	default:
+		LOG_ERR("Unsupported sensor trigger");
+		return -ENOTSUP;
+	}
+
+	rc = adxl345_reg_write_mask(dev, ADXL345_INT_MAP, 0xFF, 0xFF);
+	if (0 != rc) {
+		return rc;
+	}
+
+	rc = adxl345_reg_write_mask(dev, ADXL345_INT_ENABLE, int_mask, int_mask);
+	if (0 != rc) {
+		return rc;
+	}
+
+	rc = adxl345_reg_read_byte(dev, ADXL345_INT_SOURCE, &status);
+	if (0 != rc) {
+		return rc;
+	}
+
+	rc = gpio_pin_interrupt_configure_dt(&cfg->interrupt, GPIO_INT_EDGE_TO_ACTIVE);
+
+	return rc;
+}
+
+int adxl345_init_interrupt(const struct device *dev)
+{
+	const struct adxl345_dev_config *cfg = dev->config;
+	struct adxl345_dev_data *drv_data = dev->data;
+	int rc;
+
+	if (NULL == cfg->interrupt.port) {
+		LOG_ERR("No GPIO port defined in devicetree file");
+		return -ENOTSUP;
+	}
+
+	if (false == gpio_is_ready_dt(&cfg->interrupt)) {
+		LOG_ERR("GPIO port %s not ready", cfg->interrupt.port->name);
+		return -EINVAL;
+	}
+
+	rc = gpio_pin_configure_dt(&cfg->interrupt, GPIO_INPUT);
+	if (0 != rc) {
+		return rc;
+	}
+
+	gpio_init_callback(&drv_data->gpio_cb, adxl345_gpio_callback, BIT(cfg->interrupt.pin));
+
+	rc = gpio_add_callback(cfg->interrupt.port, &drv_data->gpio_cb);
+	if (0 != rc) {
+		LOG_ERR("Failed to set gpio callback!");
+		return rc;
+	}
+
+	// enable interrupt only when at least one trigger is configured
+
+	drv_data->dev = dev;
+
+#if defined(CONFIG_ADXL345_TRIGGER_OWN_THREAD)
+	// TODO: validate return code of thread creation
+	k_sem_init(&drv_data->gpio_sem, 0, K_SEM_MAX_LIMIT);
+
+	k_thread_create(&drv_data->thread, drv_data->thread_stack, CONFIG_ADXL345_THREAD_STACK_SIZE,
+			(k_thread_entry_t)adxl345_thread, drv_data, NULL, NULL,
+			K_PRIO_COOP(CONFIG_ADXL345_THREAD_PRIORITY), 0, K_NO_WAIT);
+#elif defined(CONFIG_ADXL345_TRIGGER_GLOBAL_THREAD)
+	drv_data->work.handler = adxl345_work_cb;
+#endif
+
+	return 0;
+}

--- a/drivers/sensor/adxl345/adxl345_trigger.c
+++ b/drivers/sensor/adxl345/adxl345_trigger.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <sys/errno.h>
 #define DT_DRV_COMPAT adi_adxl345
 
 #include <zephyr/device.h>

--- a/dts/bindings/sensor/adi,adxl345-common.yaml
+++ b/dts/bindings/sensor/adi,adxl345-common.yaml
@@ -22,7 +22,7 @@ properties:
 
   range:
     type: int
-    default: 3
+    default: 16
     description: |
       Accelerometer sampling range in G
     enum:

--- a/dts/bindings/sensor/adi,adxl345-common.yaml
+++ b/dts/bindings/sensor/adi,adxl345-common.yaml
@@ -1,0 +1,53 @@
+# Copyright (c) 2020 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: Apache-2.0
+
+description: ADXL345 3-axis I2C accelerometer
+
+include: [sensor-device.yaml]
+
+properties:
+  odr:
+    type: int
+    default: 100
+    description: |
+          Accelerometer sampling frequency (ODR). Default is 100Hz.
+    enum:
+      - 6
+      - 12
+      - 25
+      - 50
+      - 100
+      - 200
+      - 400
+
+  range:
+    type: int
+    default: 3
+    description: |
+      Accelerometer sampling range in G
+    enum:
+      - 2
+      - 4
+      - 8
+      - 16
+
+  fifo:
+    type: int
+    default: 0
+    description: |
+      Accelerometer fifo mode
+      0 - Bypass(no FIFO mode)
+      1 - FIFO
+      2 - Stream
+      3 - Trigger (not supported yet)
+    enum:
+      - 0
+      - 1
+      - 2
+        
+  int1-gpios:
+    type: phandle-array
+    description: |
+      The INT1 signal defaults to active high as produced by the
+      sensor.  The property value should ensure the flags properly
+      describe the signal that is presented to the driver.

--- a/dts/bindings/sensor/adi,adxl345-i2c.yaml
+++ b/dts/bindings/sensor/adi,adxl345-i2c.yaml
@@ -5,4 +5,4 @@ description: ADXL345 3-axis I2C accelerometer
 
 compatible: "adi,adxl345"
 
-include: [sensor-device.yaml, i2c-device.yaml]
+include: [i2c-device.yaml, "adi,adxl345-common.yaml"]

--- a/dts/bindings/sensor/adi,adxl345-spi.yaml
+++ b/dts/bindings/sensor/adi,adxl345-spi.yaml
@@ -5,4 +5,4 @@ description: ADXL345 3-axis accelerometer with SPI connection
 
 compatible: "adi,adxl345"
 
-include: [sensor-device.yaml, spi-device.yaml]
+include: [spi-device.yaml, "adi,adxl345-common.yaml"]

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -349,6 +349,32 @@ enum sensor_attribute {
 	 */
 	SENSOR_ATTR_PRIV_START = SENSOR_ATTR_COMMON_COUNT,
 
+
+	/**
+	 * Threshold in milli G to identify an active movement
+	 */
+	SENSOR_ATTR_ACTIVE_THRESH,
+
+	/**
+	 * Threshold in milli G to identify an inactive movement
+	 */
+	SENSOR_ATTR_INACTIVE_THRESH,
+
+	/**
+	 * Threshold in milliseconds to identify an inactive movement
+	 */
+	SENSOR_ATTR_INACTIVE_TIME,
+
+	/**
+	 * Amount of samples in the FIFO to trigger interrupt if exceeds
+	 */
+	SENSOR_ATTR_WATERFALL_LEVEL,
+
+	/**
+	 *  Various accelerator sensors have the attribute to link active and inactive movements
+	 */
+	SENSOR_ATTR_LINK_MOVEMENT,
+
 	/**
 	 * Maximum value describing a sensor attribute type.
 	 */

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -349,32 +349,6 @@ enum sensor_attribute {
 	 */
 	SENSOR_ATTR_PRIV_START = SENSOR_ATTR_COMMON_COUNT,
 
-
-	/**
-	 * Threshold in milli G to identify an active movement
-	 */
-	SENSOR_ATTR_ACTIVE_THRESH,
-
-	/**
-	 * Threshold in milli G to identify an inactive movement
-	 */
-	SENSOR_ATTR_INACTIVE_THRESH,
-
-	/**
-	 * Threshold in milliseconds to identify an inactive movement
-	 */
-	SENSOR_ATTR_INACTIVE_TIME,
-
-	/**
-	 * Amount of samples in the FIFO to trigger interrupt if exceeds
-	 */
-	SENSOR_ATTR_WATERFALL_LEVEL,
-
-	/**
-	 *  Various accelerator sensors have the attribute to link active and inactive movements
-	 */
-	SENSOR_ATTR_LINK_MOVEMENT,
-
 	/**
 	 * Maximum value describing a sensor attribute type.
 	 */

--- a/include/zephyr/drivers/sensor/adxl345.h
+++ b/include/zephyr/drivers/sensor/adxl345.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023 Andreas Karner
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_ADXL345_H_
+#define ZEPHYR_INCLUDE_DRIVERS_SENSOR_ADXL345_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <zephyr/drivers/sensor.h>
+
+/**
+ * @brief Custom trigger values for the adxl345 accelerometer
+ */
+enum sensor_trigger_type_adxl345 {
+	/**
+	 * Threshold in m/s2 to identify an active movement
+	 */
+	SENSOR_ATTR_ACTIVE_THRESH,
+
+	/**
+	 * Threshold in m/s2 to identify an inactive movement
+	 */
+	SENSOR_ATTR_INACTIVE_THRESH,
+
+	/**
+	 * Threshold in seconds to identify an inactive movement
+	 */
+	SENSOR_ATTR_INACTIVE_TIME,
+
+	/**
+	 * Amount of samples in the FIFO to trigger interrupt if exceeds
+	 */
+	SENSOR_ATTR_WATERFALL_LEVEL,
+
+	/**
+	 *  Various accelerator sensors have the attribute to link active and inactive movements
+	 */
+	SENSOR_ATTR_LINK_MOVEMENT,
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_ADXL345_H_ */


### PR DESCRIPTION
Rewritten adxl345 sensor code to support devicetree parameters and interrupt triggers. I have tested the code with an nrf52840-dk and a adxl345 connected via I2C. Unfortunately, there is a lot of noise due to bad formatting. But I am not sure why? I have used the newest clandg version and the proper plugin for vscode.