### PR TITLE
drivers: dma_mcux_lpc: Call callback only when provided

### DIFF
--- a/drivers/dma/dma_mcux_lpc.c
+++ b/drivers/dma/dma_mcux_lpc.c
@@ -93,7 +93,9 @@ static void nxp_lpc_dma_callback(dma_handle_t *handle, void *param,
 
 	data->busy = DMA_ChannelIsBusy(data->dma_handle.base, channel);
 
-	data->dma_callback(data->dev, data->user_data, channel, ret);
+	if (data->dma_callback) {
+		data->dma_callback(data->dev, data->user_data, channel, ret);
+	}
 }
 
 /* Handles DMA interrupts and dispatches to the individual channel */


### PR DESCRIPTION
Add a check to ensure the dma_callback is provided before calling the callback function.