### PR TITLE
boards: arm: apollo4p_blue_kxr_evb: Enable LED/Button

### DIFF
--- a/boards/arm/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb.dts
+++ b/boards/arm/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb.dts
@@ -86,3 +86,19 @@
 	pinctrl-names = "default";
 	status = "okay";
 };
+
+&gpio0_31 {
+	status = "okay";
+};
+
+&gpio32_63 {
+	status = "okay";
+};
+
+&gpio64_95 {
+	status = "okay";
+};
+
+&gpio96_127 {
+	status = "okay";
+};

--- a/boards/arm/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb.dts
+++ b/boards/arm/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb.dts
@@ -17,6 +17,25 @@
 	};
 	aliases {
 		watchdog0 = &wdt0;
+		led0 = &led0;
+		led1 = &led1;
+		led2 = &led2;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		led0: led_0 {
+			gpios = <&gpio0_31 30 GPIO_ACTIVE_LOW>;
+			label = "LED 0";
+		};
+		led1: led_1 {
+			gpios = <&gpio0_31 16 GPIO_ACTIVE_LOW>;
+			label = "LED 1";
+		};
+		led2: led_2 {
+			gpios = <&gpio64_95 27 GPIO_ACTIVE_LOW>;
+			label = "LED 2";
+		};
 	};
 
 };

--- a/boards/arm/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb.dts
+++ b/boards/arm/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb.dts
@@ -6,6 +6,7 @@
 / {
 	model = "Ambiq Apollo4 Blue Plus KXR evaluation board";
 	compatible = "ambiq,apollo4p_blue_kxr_evb";
+
 	chosen {
 		zephyr,itcm = &tcm;
 		zephyr,sram = &sram0;
@@ -15,11 +16,14 @@
 		zephyr,uart-pipe = &uart0;
 		zephyr,flash-controller = &flash;
 	};
+
 	aliases {
 		watchdog0 = &wdt0;
 		led0 = &led0;
 		led1 = &led1;
 		led2 = &led2;
+		sw0 = &button0;
+		sw1 = &button1;
 	};
 
 	leds {
@@ -38,6 +42,17 @@
 		};
 	};
 
+	buttons {
+		compatible = "gpio-keys";
+		button0: button_0 {
+			gpios = <&gpio0_31 17 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "BTN0";
+		};
+		button1: button_1 {
+			gpios = <&gpio0_31 19 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "BTN1";
+		};
+	};
 };
 
 &uart0 {

--- a/dts/arm/ambiq/ambiq_apollo4p_blue.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo4p_blue.dtsi
@@ -4,6 +4,7 @@
 #include <mem.h>
 #include <freq.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 
 / {
 	clocks {
@@ -226,6 +227,61 @@
 		pinctrl: pin-controller@40010000 {
 			compatible = "ambiq,apollo4-pinctrl";
 			reg = <0x40010000 0x800>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			gpio: gpio@40010000 {
+				compatible = "ambiq,gpio";
+				gpio-map-mask = <0xffffffe0 0xffffffc0>;
+				gpio-map-pass-thru = <0x1f 0x3f>;
+				gpio-map = <
+					0x00 0x0 &gpio0_31 0x0 0x0
+					0x20 0x0 &gpio32_63 0x0 0x0
+					0x40 0x0 &gpio64_95 0x0 0x0
+					0x60 0x0 &gpio96_127 0x0 0x0
+				>;
+				reg = <0x40010000>;
+				#gpio-cells = <2>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				ranges;
+
+				gpio0_31: gpio0_31@0 {
+					compatible = "ambiq,gpio-bank";
+					gpio-controller;
+					#gpio-cells = <2>;
+					reg = <0>;
+					interrupts = <56 0>;
+					status = "disabled";
+				};
+
+				gpio32_63: gpio32_63@80 {
+					compatible = "ambiq,gpio-bank";
+					gpio-controller;
+					#gpio-cells = <2>;
+					reg = <0x80>;
+					interrupts = <57 0>;
+					status = "disabled";
+				};
+
+				gpio64_95: gpio64_95@100 {
+					compatible = "ambiq,gpio-bank";
+					gpio-controller;
+					#gpio-cells = <2>;
+					reg = <0x100>;
+					interrupts = <58 0>;
+					status = "disabled";
+				};
+
+				gpio96_127: gpio96_127@180 {
+					compatible = "ambiq,gpio-bank";
+					gpio-controller;
+					#gpio-cells = <2>;
+					reg = <0x180>;
+					interrupts = <59 0>;
+					status = "disabled";
+				};
+			};
 		};
 
 		wdt0: watchdog@40024000 {


### PR DESCRIPTION
This PR adds GPIO instances for the Apollo4 Blue SOC and enables the LED/Buttons for apollo4p_blue_kxr_evb.

Test passed on the below samples:
-samples/basic/blinky
-samples/basic/button
-samples/basic/threads