### PR TITLE
twister: Improve recording at Harness

### DIFF
--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -478,21 +478,30 @@ harness_config: <harness configuration options>
     type: <one_line|multi_line> (required)
         Depends on the regex string to be matched
 
-
-    record: <recording options>
-      regex: <expression> (required)
-        Any string that the particular test case prints to record test
-        results.
-
-    regex: <expression> (required)
-        Any string that the particular test case prints to confirm test
-        runs as expected.
+    regex: <list of regular expressions> (required)
+        Strings with regular expressions to match with the test's output
+        to confirm the test runs as expected.
 
     ordered: <True|False> (default False)
         Check the regular expression strings in orderly or randomly fashion
 
     repeat: <integer>
         Number of times to validate the repeated regex expression
+
+    record: <recording options> (optional)
+      regex: <regular expression> (required)
+        The regular experssion with named subgroups to match data fields
+        at the test's output lines where the test provides some custom data
+        for further analysis. These records will be written into the build
+        directory 'recording.csv' file as well as 'recording' property
+        of the test suite object in 'twister.json'.
+
+        For example, to extract three data fields 'metric', 'cycles', 'nanoseconds':
+
+        .. code-block:: yaml
+
+          record:
+            regex: "(?P<metric>.*):(?P<cycles>.*) cycles, (?P<nanoseconds>.*) ns"
 
     fixture: <expression>
         Specify a test case dependency on an external device(e.g., sensor),

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -100,12 +100,19 @@ class Handler:
 
     def record(self, harness):
         if harness.recording:
+            if self.instance.recording is None:
+                self.instance.recording = harness.recording.copy()
+            else:
+                self.instance.recording.extend(harness.recording)
+
             filename = os.path.join(self.build_dir, "recording.csv")
             with open(filename, "at") as csvfile:
-                cw = csv.writer(csvfile, harness.fieldnames, lineterminator=os.linesep)
-                cw.writerow(harness.fieldnames)
-                for instance in harness.recording:
-                    cw.writerow(instance)
+                cw = csv.DictWriter(csvfile,
+                                    fieldnames = harness.recording[0].keys(),
+                                    lineterminator = os.linesep,
+                                    quoting = csv.QUOTE_NONNUMERIC)
+                cw.writeheader()
+                cw.writerows(harness.recording)
 
     def terminate(self, proc):
         terminate_process(proc)

--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -345,6 +345,10 @@ class Reporting:
                 testcases.append(testcase)
 
             suite['testcases'] = testcases
+
+            if instance.recording is not None:
+                suite['recording'] = instance.recording
+
             suites.append(suite)
 
         report["testsuites"] = suites

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -48,6 +48,7 @@ class TestInstance:
         self.reason = "Unknown"
         self.metrics = dict()
         self.handler = None
+        self.recording = None
         self.outdir = outdir
         self.execution_time = 0
         self.build_time = 0

--- a/scripts/schemas/twister/testsuite-schema.yaml
+++ b/scripts/schemas/twister/testsuite-schema.yaml
@@ -122,7 +122,7 @@ mapping:
             mapping:
               "regex":
                 type: str
-                required: false
+                required: true
       "min_ram":
         type: int
         required: false
@@ -326,7 +326,7 @@ mapping:
                 mapping:
                   "regex":
                     type: str
-                    required: false
+                    required: true
           "min_ram":
             type: int
             required: false

--- a/scripts/tests/twister/test_harness.py
+++ b/scripts/tests/twister/test_harness.py
@@ -43,6 +43,8 @@ def gtest():
     mock_testsuite.detailed_test_id = True
     mock_testsuite.id = "id"
     mock_testsuite.testcases = []
+    mock_testsuite.harness_config = {}
+
     instance = TestInstance(testsuite=mock_testsuite, platform=mock_platform, outdir="")
 
     harness = Gtest()


### PR DESCRIPTION
The Console Harness is able to parse its log with patterns to compose extracted fields into records in 'recording.csv' file in the test's build directory. This feature allows to extract custom test results like performance counters.
Now with this change the extracted records are also written into 'twister.json' as a part of each test suite object. This makes easier to store all the data collected by the test for its further processing.

Other improvements:
 - compile parsing pattern only once instead of at each input line;
 - quote fields in '.csv' to avoid unexpected field separators;
 - make 'regex' a required schema field of 'harness_config';
 - Twister documentation update.

At the moment the recording feature is used by [tests/benchmarks/latency_measure](https://github.com/zephyrproject-rtos/zephyr/tree/main/tests/benchmarks/latency_measure).
With this change the resulting `twister.json` has testcases with `recording` like:

```
    "testsuites":[
        {
            "name":"tests/benchmarks/latency_measure/benchmark.kernel.latency",
            "arch":"x86",
            "platform":"qemu_x86",
            "path":"tests/benchmarks/latency_measure",
            "run_id":"43863c0059faa2d9609b5aa5e595412b",
            "runnable":true,
            "retries":0,
            "status":"passed",
            "execution_time":"2.45",
            "build_time":"7.93",
            "testcases":[
                {
                    "identifier":"benchmark.kernel.latency",
                    "execution_time":"2.44",
                    "status":"passed"
                }
             "recording":[
                {
                     "metric":"Preemptive threads ctx switch via k_yield (K -> K)",
                      "cycles":"22207",
                      "nanoseconds":"22207"
                },
                {
                     "metric":"Cooperative threads ctx switch via k_yield (K -> K)",
                     "cycles":"22111",
                     "nanoseconds":"22111"
                },
                {
                     "metric":"Switch from ISR back to interrupted thread",
                     "cycles":"895",
                     "nanoseconds":"895"
                },
...
```
its corresponding `recordings.csv`:
```
"metric","cycles","nanoseconds"
"Preemptive threads ctx switch via k_yield (K -> K)","22207","22207"
"Cooperative threads ctx switch via k_yield (K -> K)","22111","22111"
"Switch from ISR back to interrupted thread","895","895"
...
```