### PR TITLE
drivers: bluetooth: hci: handle event with high priority flag

### DIFF
--- a/drivers/bluetooth/hci/h4.c
+++ b/drivers/bluetooth/hci/h4.c
@@ -346,7 +346,8 @@ static inline void read_payload(void)
 		bt_recv_prio(buf);
 	}
 
-	if (evt_flags & BT_HCI_EVT_FLAG_RECV) {
+	if ((evt_flags & BT_HCI_EVT_FLAG_RECV) ||
+	    !IS_ENABLED(CONFIG_BT_RECV_BLOCKING)) {
 		LOG_DBG("Putting buf %p to rx fifo", buf);
 		net_buf_put(&rx.fifo, buf);
 	}


### PR DESCRIPTION
Make sure that events flagged as high priority are handled when `CONFIG_BT_RECV_BLOCKING` is not defined.

Fixes  #65892.