### PR TITLE
posix: pthread: implement pthread_sigmask()

### DIFF
--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -63,7 +63,7 @@ multiple processes.
     pthread_setcancelstate(),yes
     pthread_setcanceltype(),yes
     pthread_setspecific(),yes
-    pthread_sigmask(),
+    pthread_sigmask(),yes
     pthread_testcancel(),
 
 .. _posix_option_group_posix_threads_ext:

--- a/include/zephyr/posix/signal.h
+++ b/include/zephyr/posix/signal.h
@@ -12,7 +12,6 @@
 extern "C" {
 #endif
 
-#ifdef CONFIG_POSIX_SIGNAL
 #define SIGHUP    1  /**< Hangup */
 #define SIGINT    2  /**< Interrupt */
 #define SIGQUIT   3  /**< Quit */
@@ -45,23 +44,16 @@ extern "C" {
 /* 30 not used */
 #define SIGSYS    31 /**< Bad system call */
 
+#define RTSIG_MAX CONFIG_POSIX_RTSIG_MAX
 #define SIGRTMIN 32
-#define SIGRTMAX (SIGRTMIN + CONFIG_POSIX_RTSIG_MAX)
+#define SIGRTMAX (SIGRTMIN + RTSIG_MAX)
 #define _NSIG (SIGRTMAX + 1)
 
-BUILD_ASSERT(CONFIG_POSIX_RTSIG_MAX >= 0);
+BUILD_ASSERT(RTSIG_MAX >= 0);
 
 typedef struct {
 	unsigned long sig[DIV_ROUND_UP(_NSIG, BITS_PER_LONG)];
 } sigset_t;
-
-char *strsignal(int signum);
-int sigemptyset(sigset_t *set);
-int sigfillset(sigset_t *set);
-int sigaddset(sigset_t *set, int signo);
-int sigdelset(sigset_t *set, int signo);
-int sigismember(const sigset_t *set, int signo);
-#endif /* CONFIG_POSIX_SIGNAL */
 
 #ifndef SIGEV_NONE
 #define SIGEV_NONE 1
@@ -89,6 +81,15 @@ struct sigevent {
 	void (*sigev_notify_function)(union sigval val);
 	pthread_attr_t *sigev_notify_attributes;
 };
+
+#ifdef CONFIG_POSIX_SIGNAL
+char *strsignal(int signum);
+int sigemptyset(sigset_t *set);
+int sigfillset(sigset_t *set);
+int sigaddset(sigset_t *set, int signo);
+int sigdelset(sigset_t *set, int signo);
+int sigismember(const sigset_t *set, int signo);
+#endif /* CONFIG_POSIX_SIGNAL */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/posix/signal.h
+++ b/include/zephyr/posix/signal.h
@@ -67,6 +67,16 @@ typedef struct {
 #define SIGEV_THREAD 3
 #endif
 
+#ifndef SIG_BLOCK
+#define SIG_BLOCK 0
+#endif
+#ifndef SIG_SETMASK
+#define SIG_SETMASK 1
+#endif
+#ifndef SIG_UNBLOCK
+#define SIG_UNBLOCK 2
+#endif
+
 typedef int	sig_atomic_t;		/* Atomic entity type (ANSI) */
 
 union sigval {
@@ -89,6 +99,8 @@ int sigfillset(sigset_t *set);
 int sigaddset(sigset_t *set, int signo);
 int sigdelset(sigset_t *set, int signo);
 int sigismember(const sigset_t *set, int signo);
+
+int pthread_sigmask(int how, const sigset_t *ZRESTRICT set, sigset_t *ZRESTRICT oset);
 #endif /* CONFIG_POSIX_SIGNAL */
 
 #ifdef __cplusplus

--- a/lib/posix/Kconfig.signal
+++ b/lib/posix/Kconfig.signal
@@ -23,7 +23,7 @@ endif
 config POSIX_RTSIG_MAX
 	int "Maximum number of realtime signals"
 	default 31 if POSIX_SIGNAL
-	default 0 if !POSIX_SIGNAL
+	default 0
 	help
 	  Define the maximum number of realtime signals (RTSIG_MAX).
 	  The range of realtime signals is [SIGRTMIN .. (SIGRTMIN+RTSIG_MAX)]

--- a/lib/posix/Kconfig.signal
+++ b/lib/posix/Kconfig.signal
@@ -9,12 +9,6 @@ config POSIX_SIGNAL
 	  Enable support for POSIX signal APIs.
 
 if POSIX_SIGNAL
-config POSIX_RTSIG_MAX
-	int "Maximum number of realtime signals"
-	default 31
-	help
-	  Define the maximum number of realtime signals (RTSIG_MAX).
-	  The range of realtime signals is [SIGRTMIN .. (SIGRTMIN+RTSIG_MAX)]
 
 config POSIX_SIGNAL_STRING_DESC
 	bool "Use full description for the strsignal API"
@@ -24,3 +18,12 @@ config POSIX_SIGNAL_STRING_DESC
 	  Will use 256 bytes of ROM.
 
 endif
+
+# needed outside of if clause above to define constants & types in signal.h
+config POSIX_RTSIG_MAX
+	int "Maximum number of realtime signals"
+	default 31 if POSIX_SIGNAL
+	default 0 if !POSIX_SIGNAL
+	help
+	  Define the maximum number of realtime signals (RTSIG_MAX).
+	  The range of realtime signals is [SIGRTMIN .. (SIGRTMIN+RTSIG_MAX)]

--- a/lib/posix/posix_internal.h
+++ b/lib/posix/posix_internal.h
@@ -12,6 +12,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/posix/pthread.h>
+#include <zephyr/posix/signal.h>
 #include <zephyr/sys/dlist.h>
 #include <zephyr/sys/slist.h>
 
@@ -38,6 +39,9 @@ struct posix_thread {
 
 	/* Exit status */
 	void *retval;
+
+	/* Signal mask */
+	sigset_t sigset;
 
 	/* Pthread cancellation */
 	uint8_t cancel_state;

--- a/tests/posix/common/src/pthread.c
+++ b/tests/posix/common/src/pthread.c
@@ -10,10 +10,6 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/ztest.h>
 
-#ifndef min
-#define min(a, b) ((a) < (b)) ? (a) : (b)
-#endif
-
 #define N_THR_E 3
 #define N_THR_T 4
 #define BOUNCES 64
@@ -402,8 +398,7 @@ ZTEST(posix_apis, test_pthread_execution)
 	zassert_false(ret, "Get thread name failed!");
 
 	/* TESTPOINT: Thread names match */
-	ret = strncmp(thr_name, thr_name_buf, min(strlen(thr_name),
-						  strlen(thr_name_buf)));
+	ret = strncmp(thr_name, thr_name_buf, MIN(strlen(thr_name), strlen(thr_name_buf)));
 	zassert_false(ret, "Thread names don't match!");
 
 	while (!bounce_test_done()) {

--- a/tests/posix/headers/src/signal_h.c
+++ b/tests/posix/headers/src/signal_h.c
@@ -24,7 +24,7 @@ ZTEST(posix_headers, test_signal_h)
 	/* zassert_not_equal(-1, SIG_HOLD); */ /* not implemented */
 	/* zassert_not_equal(-1, SIG_IGN); */ /* not implemented */
 
-	/* zassert_not_equal((sig_atomic_t)-1, (sig_atomic_t)0); */ /* not implemented */
+	zassert_not_equal((sig_atomic_t)-1, (sig_atomic_t)0);
 	/* zassert_not_equal((pid_t)-1, (pid_t)0); */ /* not implemented */
 
 	zassert_not_equal(-1, offsetof(struct sigevent, sigev_notify));
@@ -40,12 +40,12 @@ ZTEST(posix_headers, test_signal_h)
 	zassert_not_equal(-1, offsetof(union sigval, sival_int));
 	zassert_not_equal(-1, offsetof(union sigval, sival_ptr));
 
-	/* zassert_not_equal(-1, RTSIG_MAX); */ /* not implemented */
-	/* zassert_true(SIGRTMAX - SIGRTMIN >= RTSIG_MAX); */ /* not implemented */
+	zassert_not_equal(-1, RTSIG_MAX);
+	zassert_true(SIGRTMAX - SIGRTMIN >= RTSIG_MAX);
 
-	/* zassert_not_equal(-1, SIG_BLOCK); */ /* not implemented */
-	/* zassert_not_equal(-1, SIG_UNBLOCK); */ /* not implemented */
-	/* zassert_not_equal(-1, SIG_SETMASK); */ /* not implemented */
+	zassert_not_equal(-1, SIG_BLOCK);
+	zassert_not_equal(-1, SIG_UNBLOCK);
+	zassert_not_equal(-1, SIG_SETMASK);
 
 	/* zassert_not_equal(-1, SA_NOCLDSTOP); */ /* not implemented */
 	/* zassert_not_equal(-1, SA_ONSTACK); */ /* not implemented */
@@ -164,6 +164,7 @@ ZTEST(posix_headers, test_signal_h)
 	zassert_not_null(sigdelset);
 	zassert_not_null(sigismember);
 	zassert_not_null(strsignal);
+	zassert_not_null(pthread_sigmask);
 #endif /* CONFIG_POSIX_SIGNAL */
 
 	if (IS_ENABLED(CONFIG_POSIX_API)) {
@@ -172,7 +173,6 @@ ZTEST(posix_headers, test_signal_h)
 		/* zassert_not_null(psiginfo); */ /* not implemented */
 		/* zassert_not_null(psignal); */ /* not implemented */
 		/* zassert_not_null(pthread_kill); */ /* not implemented */
-		/* zassert_not_null(pthread_sigmask); */ /* not implemented */
 		/* zassert_not_null(raise); */ /* not implemented */
 		/* zassert_not_null(sigaction); */ /* not implemented */
 		/* zassert_not_null(sigaltstack); */ /* not implemented */


### PR DESCRIPTION
`pthread_sigmask()` is required by the POSIX_THREADS_BASE Option Group as detailed in Section E.1 of IEEE-1003.1-2017.

The POSIX_THREADS_BASE Option Group is required for PSE51, PSE52, PSE53, and PSE54 conformance, and is otherwise mandatory for any POSIX conforming system as per Section A.2.1.3 of IEEE-1003-1.2017.

Currently, setting a pthread signal mask has no effect.

Fixes #59944