### PR TITLE
dts: bindings: ethernet: esp32: remove default phy conn type

### DIFF
--- a/dts/bindings/ethernet/espressif,esp32-eth.yaml
+++ b/dts/bindings/ethernet/espressif,esp32-eth.yaml
@@ -12,9 +12,6 @@ properties:
   phy-handle:
     required: true
 
-  phy-connection-type:
-    default: "rmii"
-
   ref-clk-output-gpios:
     type: phandle-array
     description: |


### PR DESCRIPTION
That's already harcoded in the driver so there is no need to do that in the bindings.

Signed-off-by: Bartosz Bilas <bartosz.bilas@hotmail.com>