### PR TITLE
drivers: wifi: esp32: Mute implicit function declaration warning

### DIFF
--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -236,19 +236,19 @@ out:
 static void esp_wifi_handle_connect_event(void)
 {
 	esp32_data.state = ESP32_STA_CONNECTED;
-	if (IS_ENABLED(CONFIG_ESP32_WIFI_STA_AUTO_DHCPV4)) {
-		net_dhcpv4_start(esp32_wifi_iface);
-	} else {
-		wifi_mgmt_raise_connect_result_event(esp32_wifi_iface, 0);
-	}
+#if defined(CONFIG_ESP32_WIFI_STA_AUTO_DHCPV4)
+	net_dhcpv4_start(esp32_wifi_iface);
+#else
+	wifi_mgmt_raise_connect_result_event(esp32_wifi_iface, 0);
+#endif
 }
 
 static void esp_wifi_handle_disconnect_event(void)
 {
 	if (esp32_data.state == ESP32_STA_CONNECTED) {
-		if (IS_ENABLED(CONFIG_ESP32_WIFI_STA_AUTO_DHCPV4)) {
-			net_dhcpv4_stop(esp32_wifi_iface);
-		}
+#if defined(CONFIG_ESP32_WIFI_STA_AUTO_DHCPV4)
+		net_dhcpv4_stop(esp32_wifi_iface);
+#endif
 		wifi_mgmt_raise_disconnect_result_event(esp32_wifi_iface, 0);
 	} else {
 		wifi_mgmt_raise_disconnect_result_event(esp32_wifi_iface, -1);


### PR DESCRIPTION
Building the esp32 Wi-Fi driver with a IPv6 only config produces two compiler warnings.
```
[279/421] Building C object zephyr/drivers/wifi/CMakeFiles/drivers__wifi.dir/esp32/src/esp_wifi_drv.c.obj
zephyr/drivers/wifi/esp32/src/esp_wifi_drv.c: In function 'esp_wifi_handle_connect_event':
zephyr/drivers/wifi/esp32/src/esp_wifi_drv.c:240:17: warning: implicit declaration of function 'net_dhcpv4_start' [-Wimplicit-function-declaration]
  240 |                 net_dhcpv4_start(esp32_wifi_iface);
      |                 ^~~~~~~~~~~~~~~~
zephyr/drivers/wifi/esp32/src/esp_wifi_drv.c: In function 'esp_wifi_handle_disconnect_event':
zephyr/drivers/wifi/esp32/src/esp_wifi_drv.c:250:25: warning: implicit declaration of function 'net_dhcpv4_stop' [-Wimplicit-function-declaration]
  250 |                         net_dhcpv4_stop(esp32_wifi_iface);
      |                         ^~~~~~~~~~~~~~~

```
 
This change mutes the `function declaration warning`, the compiler was emitting when compiling the esp32 Wi-Fi driver with IPv4 disabled. The reason for the warning was, that the `net_dhcpv4_start()` function was visible during compile time, even when IPv4 was disabled.

