### PR TITLE
net: ipv6: Silently drop unwanted NA messages

### DIFF
--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -1818,7 +1818,12 @@ static int handle_na_input(struct net_icmp_ctx *ctx,
 	}
 
 	if (!handle_na_neighbor(pkt, na_hdr, tllao_offset)) {
-		goto drop;
+		/* Update the statistics but silently drop NA msg if the sender
+		 * is not known or if there was an error in the message.
+		 * Returning <0 will cause error message to be printed which
+		 * is too much for this non error.
+		 */
+		net_stats_update_ipv6_nd_drop(net_pkt_iface(pkt));
 	}
 
 	return 0;


### PR DESCRIPTION
Silently drop the IPv6 Neighbor Advertisement if we receive it for an unknown neighbor or if there some some issue in the packet. Returning error here would cause the ICMP module to print an actual error which just pollutes the log without any apparent benefit.

Fixes #66063