### PR TITLE
dts: arm: stm32f7 vref calibration address fixed

### DIFF
--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -861,7 +861,7 @@
 
 	vref: vref {
 		compatible = "st,stm32-vref";
-		vrefint-cal-addr = <0x1FFF7A2A>;
+		vrefint-cal-addr = <0x1FF0F44A>;
 		vrefint-cal-mv = <3300>;
 		io-channels = <&adc1 17>;
 		status = "disabled";

--- a/dts/arm/st/f7/stm32f723.dtsi
+++ b/dts/arm/st/f7/stm32f723.dtsi
@@ -51,6 +51,11 @@
 		};
 	};
 
+	vref: vref {
+		compatible = "st,stm32-vref";
+		vrefint-cal-addr = <0x1FF07A2A>;
+	};
+
 	die_temp: dietemp {
 		ts-cal1-addr = <0x1FF07A2C>;
 		ts-cal2-addr = <0x1FF07A2E>;


### PR DESCRIPTION
The vrefint-cal-addr is <0x1FF07A2A> for the stm32F722-F723 soc serie. 
This PR set the correct value for the stm32F7 devices.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/66049 