### PR TITLE
Corrects RAM size of CY8CPROTO-062-4343W PSoC6 eval board.

### DIFF
--- a/boards/arm/cy8cproto_062_4343w/cy8cproto_062_4343w.yaml
+++ b/boards/arm/cy8cproto_062_4343w/cy8cproto_062_4343w.yaml
@@ -7,7 +7,7 @@ identifier: cy8cproto_062_4343w
 name: CY8CPROTO-062-4343W PSoC 6 Wi-Fi BT Prototyping Kit
 type: mcu
 arch: arm
-ram: 288
+ram: 1024
 flash: 2048
 toolchain:
   - zephyr


### PR DESCRIPTION
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/60876

Signed-off-by: Manuel Loew <manuel.loew.infineon@gmail.com>