### PR TITLE
doc: blobs: fix double 'command'

### DIFF
--- a/doc/contribute/bin_blobs.rst
+++ b/doc/contribute/bin_blobs.rst
@@ -43,7 +43,7 @@ Fetching blobs
 ==============
 
 Blobs are fetched from official third-party sources by the :ref:`west blobs
-command <west-blobs>` command.
+<west-blobs>` command.
 
 The blobs themselves must be specified in the :ref:`module.yml
 <modules-bin-blobs>` files included in separate Zephyr :ref:`module repositories


### PR DESCRIPTION
Fix double 'command' in the "Fetching blobs" chapter.