### PR TITLE
tests: acpi: Fix getting APIC id

### DIFF
--- a/tests/arch/x86/info/src/acpi.c
+++ b/tests/arch/x86/info/src/acpi.c
@@ -130,7 +130,7 @@ void acpi(void)
 		for (int i = 0; i < nr_cpus; ++i) {
 			struct acpi_madt_local_apic *cpu = acpi_local_apic_get(i);
 
-			printk("\tCPU #%d: APIC ID 0x%02x\n", i, cpu[i].Id);
+			printk("\tCPU #%d: APIC ID 0x%02x\n", i, cpu->Id);
 		}
 	}
 


### PR DESCRIPTION
Fixes accessing wrong memory.

Fixes: #66085