### PR TITLE
intel_adsp: ace: dynamic clock switching

### DIFF
--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -16,7 +16,7 @@
 			device_type = "cpu";
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <0>;
-			cpu-power-states = <&d0i3 &d3>;
+			cpu-power-states = <&active &d0i3 &d3>;
 			i-cache-line-size = <64>;
 			d-cache-line-size = <64>;
 		};
@@ -25,17 +25,23 @@
 			device_type = "cpu";
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <1>;
-			cpu-power-states = <&d0i3 &d3>;
+			cpu-power-states = <&active &d0i3 &d3>;
 		};
 
 		cpu2: cpu@2 {
 			device_type = "cpu";
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <2>;
-			cpu-power-states = <&d0i3 &d3>;
+			cpu-power-states = <&active &d0i3 &d3>;
 		};
 
 		power-states {
+			active: active {
+				compatible = "zephyr,power-state";
+				power-state-name = "active";
+				min-residency-us = <0>;
+				exit-latency-us = <0>;
+			};
 			d0i3: idle {
 				compatible = "zephyr,power-state";
 				power-state-name = "runtime-idle";

--- a/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
@@ -16,7 +16,7 @@
 			device_type = "cpu";
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <0>;
-			cpu-power-states = <&d0i3 &d3>;
+			cpu-power-states = <&active &d0i3 &d3>;
 			i-cache-line-size = <64>;
 			d-cache-line-size = <64>;
 		};
@@ -25,31 +25,37 @@
 			device_type = "cpu";
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <1>;
-			cpu-power-states = <&d0i3 &d3>;
+			cpu-power-states = <&active &d0i3 &d3>;
 		};
 
 		cpu2: cpu@2 {
 			device_type = "cpu";
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <2>;
-			cpu-power-states = <&d0i3 &d3>;
+			cpu-power-states = <&active &d0i3 &d3>;
 		};
 
 		cpu3: cpu@3 {
 			device_type = "cpu";
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <3>;
-			cpu-power-states = <&d0i3 &d3>;
+			cpu-power-states = <&active &d0i3 &d3>;
 		};
 
 		cpu4: cpu@4 {
 			device_type = "cpu";
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <4>;
-			cpu-power-states = <&d0i3 &d3>;
+			cpu-power-states = <&active &d0i3 &d3>;
 		};
 
 		power-states {
+			active: active {
+				compatible = "zephyr,power-state";
+				power-state-name = "active";
+				min-residency-us = <0>;
+				exit-latency-us = <0>;
+			};
 			d0i3: idle {
 				compatible = "zephyr,power-state";
 				power-state-name = "runtime-idle";

--- a/include/zephyr/pm/state.h
+++ b/include/zephyr/pm/state.h
@@ -154,6 +154,14 @@ struct pm_state_info {
 	 * @note 0 means that this property is not available for this state.
 	 */
 	uint32_t exit_latency_us;
+
+#ifdef CONFIG_PM_STATE_CUSTOM_DATA
+	/**
+	 * Target specific custom data. Support for runtime customization of
+	 * a particular idle state.
+	 */
+	const void *custom_data;
+#endif
 };
 
 /** @cond INTERNAL_HIDDEN */
@@ -341,6 +349,39 @@ struct pm_state_info {
 uint8_t pm_state_cpu_get_all(uint8_t cpu, const struct pm_state_info **states);
 
 /**
+ * @brief Set state's custom data.
+ *
+ * This routine sets the custom data for @a state thread to @ value.
+ *
+ * Custom data is not used by the subsystem itself, and is freely available
+ * for a SoC to use as it sees fit. It can be used to SoCs expose a way to
+ * applications customize a state behavior.
+ *
+ * @note @kconfig{CONFIG_PM_STATE_CUSTOM_DATA} must be set for this function
+ * to be effective.
+ *
+ * @param state Power state.
+ * @param substate_id Substate id. It can be @c PM_ALL_SUBSTATES.
+ * @param data New custom data value.
+ */
+void pm_state_custom_data_set(enum pm_state state, uint8_t substate_id, const void *data);
+
+/**
+ * @brief Get current state's custom data.
+ *
+ * This routine returns the custom data for the given state.
+ *
+ * @note @kconfig{CONFIG_PM_STATE_CUSTOM_DATA} must be set for this function
+ * to be effective.
+ *
+ * @param state Power state.
+ * @param substate_id Substate id.
+ *
+ * @return Current custom data value.
+ */
+void *pm_state_custom_data_get(enum pm_state state, uint8_t substate_id);
+
+/**
  * @}
  */
 
@@ -352,6 +393,22 @@ static inline uint8_t pm_state_cpu_get_all(uint8_t cpu, const struct pm_state_in
 	ARG_UNUSED(states);
 
 	return 0;
+}
+
+static inline void pm_state_custom_data_set(enum pm_state state,
+				    uint8_t substate_id, const void *data)
+{
+	ARG_UNUSED(state);
+	ARG_UNUSED(substate_id);
+	ARG_UNUSED(data);
+}
+
+static inline void *pm_state_custom_data_get(enum pm_state state, uint8_t substate_id)
+{
+	ARG_UNUSED(state);
+	ARG_UNUSED(substate_id);
+
+	return NULL;
 }
 
 #endif /* CONFIG_PM */

--- a/soc/intel/intel_adsp/Kconfig
+++ b/soc/intel/intel_adsp/Kconfig
@@ -129,4 +129,13 @@ config ADSP_IDLE_CLOCK_GATING
 	  (wait for interrupt) during idle, the clock can be gated (however, this
 	  does not mean that this will happen).
 
+config ADSP_DYNAMIC_CLOCK_SWITCHING
+	bool "DSP clock switching in Idle"
+	depends on PM_STATE_CUSTOM_DATA
+	help
+	  When true, the firmware will slow down the clock if all cores are in an idle
+	  state. This dynamic clock change aims to reduce energy consumption when the DSP
+	  is idle, with minimal impact on the time required to resume full operation. It
+	  ensures that power savings are maximized while maintaining responsiveness.
+
 endif # SOC_FAMILY_INTEL_ADSP

--- a/soc/intel/intel_adsp/ace/include/pm_data.h
+++ b/soc/intel/intel_adsp/ace/include/pm_data.h
@@ -1,0 +1,73 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (c) 2024 Intel Corporation
+ *
+ * Author: Tomasz Leman <tomasz.m.leman@intel.com>
+ */
+
+#ifndef __INTEL_PM_DATA_H__
+#define __INTEL_PM_DATA_H__
+
+#include <zephyr/sys/atomic.h>
+#include <zephyr/sys/__assert.h>
+
+/**
+ * @brief Structure to represent Intel platform-specific power management data.
+ *
+ * This structure contains data used for customization of power state operations
+ * on Intel platforms.
+ */
+struct intel_adsp_ace_pm_data {
+	/**
+	 * @brief Reference counter for lock of clock switching operation.
+	 *
+	 * This atomic variable ensures thread-safe increments and decrements
+	 * of the lock count, which is critical for managing clock switching
+	 * in a multi-core environment.
+	 */
+	atomic_t clock_switch_lock_refcount;
+};
+
+/**
+ * @brief Increment the clock switch lock reference counter.
+ *
+ * This function atomically increments the reference counter for the clock switch lock. It is used
+ * to prevent clock switching operations that change the current DSP clock when a core becomes
+ * active. The function returns true if this is the first core to request the lock, indicating that
+ * the clock switching operation was previously not locked.
+ *
+ * @param data Pointer to the intel_adsp_ace_pm_data struct containing the lock reference counter.
+ * @return True if this is the first increment operation, false otherwise.
+ */
+static ALWAYS_INLINE bool intel_adsp_acquire_clock_switch_lock(struct intel_adsp_ace_pm_data *data)
+{
+	if (data)
+		return atomic_inc(&data->clock_switch_lock_refcount) == 0;
+
+	return false;
+}
+
+/**
+ * @brief Decrement the clock switch lock reference counter.
+ *
+ * This function atomically decrements the reference counter for the clock switch lock. It allows
+ * clock switching operations to proceed when the last active core no longer needs the clock to be
+ * stable. The function returns true if this is the first core to request the lock, indicating that
+ * the clock switching operation was previously not locked.
+ *
+ * @param data Pointer to the intel_adsp_ace_pm_data struct containing the lock reference counter.
+ * @return True if this is the last decrement operation, false otherwise.
+ */
+static ALWAYS_INLINE bool intel_adsp_release_clock_switch_lock(struct intel_adsp_ace_pm_data *data)
+{
+	if (data) {
+		atomic_t old_value = atomic_dec(&data->clock_switch_lock_refcount);
+
+		__ASSERT(old_value > 0, "Unbalanced clock switching lock use!");
+		return old_value == 1;
+	}
+
+	return false;
+}
+
+#endif /* __INTEL_PM_DATA_H__ */

--- a/soc/intel/intel_adsp/ace/multiprocessing.c
+++ b/soc/intel/intel_adsp/ace/multiprocessing.c
@@ -18,6 +18,7 @@
 #include <adsp_ipc_regs.h>
 #include <adsp_memory.h>
 #include <adsp_interrupt.h>
+#include <pm_data.h>
 #include <zephyr/irq.h>
 #include <zephyr/cache.h>
 
@@ -162,6 +163,12 @@ void soc_start_core(int cpu_num)
 	if (retry == 0) {
 		__ASSERT(false, "%s secondary core has not powered up", __func__);
 	}
+#if CONFIG_ADSP_DYNAMIC_CLOCK_SWITCHING
+	/* Clock switching lock needs to be incremented for each active core.
+	 * This increment is specifically for the secondary cores.
+	 */
+	intel_adsp_acquire_clock_switch_lock(pm_state_custom_data_get(PM_STATE_ACTIVE, 0));
+#endif /* CONFIG_ADSP_DYNAMIC_CLOCK_SWITCHING */
 }
 
 void soc_mp_startup(uint32_t cpu)

--- a/soc/intel/intel_adsp/ace/power.c
+++ b/soc/intel/intel_adsp/ace/power.c
@@ -19,6 +19,7 @@
 #include <zephyr/drivers/mm/mm_drv_intel_adsp_mtl_tlb.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include <mem_window.h>
+#include <pm_data.h>
 
 #define LPSRAM_MAGIC_VALUE      0x13579BDF
 #define LPSCTL_BATTR_MASK       GENMASK(16, 12)
@@ -439,11 +440,25 @@ void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 #endif /* CONFIG_PM */
 
 #ifdef CONFIG_ARCH_CPU_IDLE_CUSTOM
+#if CONFIG_ADSP_DYNAMIC_CLOCK_SWITCHING
+static struct k_spinlock idle_lock;
+#endif
 
 __no_optimization
 void arch_cpu_idle(void)
 {
 	uint32_t cpu = arch_proc_id();
+#if CONFIG_ADSP_DYNAMIC_CLOCK_SWITCHING
+	k_spinlock_key_t k;
+	struct intel_adsp_ace_pm_data *data =
+		(struct intel_adsp_ace_pm_data *) pm_state_custom_data_get(PM_STATE_ACTIVE, 0);
+
+	k = k_spin_lock(&idle_lock);
+	if (data && intel_adsp_release_clock_switch_lock(data))
+		soc_adsp_clock_idle_entry();
+
+	k_spin_unlock(&idle_lock, k);
+#endif /* CONFIG_ADSP_DYNAMIC_CLOCK_SWITCHING */
 
 	sys_trace_idle();
 
@@ -456,6 +471,13 @@ void arch_cpu_idle(void)
 	}
 
 	__asm__ volatile ("waiti 0");
+#if CONFIG_ADSP_DYNAMIC_CLOCK_SWITCHING
+	k = k_spin_lock(&idle_lock);
+	if (data && intel_adsp_acquire_clock_switch_lock(data))
+		soc_adsp_clock_idle_exit();
+
+	k_spin_unlock(&idle_lock, k);
+#endif /* CONFIG_ADSP_DYNAMIC_CLOCK_SWITCHING */
 }
 
 #endif /* CONFIG_ARCH_CPU_IDLE_CUSTOM */

--- a/soc/intel/intel_adsp/cavs/include/pm_data.h
+++ b/soc/intel/intel_adsp/cavs/include/pm_data.h
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (c) 2024 Intel Corporation
+ *
+ * Author: Tomasz Leman <tomasz.m.leman@intel.com>
+ */
+
+#ifndef __INTEL_PM_DATA_H__
+#define __INTEL_PM_DATA_H__
+
+/* Currently, this header file serves only as a placeholder. This is intended to avoid a situation
+ * where including this header would need to be conditional with an ifdef.
+ */
+
+#endif /* __INTEL_PM_DATA_H__ */

--- a/soc/intel/intel_adsp/common/boot.c
+++ b/soc/intel/intel_adsp/common/boot.c
@@ -9,11 +9,13 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/kernel.h>
 #include <zephyr/init.h>
+#include <zephyr/pm/state.h>
 #include <soc_util.h>
 #include <zephyr/cache.h>
 #include <adsp_shim.h>
 #include <adsp_memory.h>
 #include <cpu_init.h>
+#include <pm_data.h>
 #include "manifest.h"
 
 /* Important note about linkage:
@@ -154,6 +156,12 @@ __imr void boot_core0(void)
 	parse_manifest();
 	sys_cache_data_flush_all();
 
+#if CONFIG_ADSP_DYNAMIC_CLOCK_SWITCHING
+	/* Clock switching lock needs to be incremented for each active core.
+	 * This increment is specifically for the primary core.
+	 */
+	intel_adsp_acquire_clock_switch_lock(pm_state_custom_data_get(PM_STATE_ACTIVE, 0));
+#endif /* CONFIG_ADSP_DYNAMIC_CLOCK_SWITCHING */
 	xtensa_vecbase_lock();
 
 	/* Zephyr! */

--- a/soc/intel/intel_adsp/common/include/soc.h
+++ b/soc/intel/intel_adsp/common/include/soc.h
@@ -57,4 +57,28 @@ static ALWAYS_INLINE void z_idelay(int n)
 	}
 }
 
+#ifdef CONFIG_ADSP_DYNAMIC_CLOCK_SWITCHING
+/**
+ * @brief Reduces the clock frequency when the DSP enters idle state.
+ *
+ * This function is intended to be called when the DSP core is about to enter
+ * an idle state. It checks if the current clock frequency is not already at its
+ * lowest setting and, if not, reduces it to the lowest frequency to save power.
+ *
+ * @see soc_adsp_clock_idle_exit()
+ */
+void soc_adsp_clock_idle_entry(void);
+
+/**
+ * @brief Restores the clock frequency when the DSP exits idle state.
+ *
+ * This function should be called when the DSP core exits an idle state. It checks
+ * if the clock frequency was previously reduced by adsp_clock_idle_entry. If so,
+ * it restores the clock frequency to its previous setting.
+ *
+ * @see soc_adsp_clock_idle_entry()
+ */
+void soc_adsp_clock_idle_exit(void);
+#endif /* CONFIG_ADSP_DYNAMIC_CLOCK_SWITCHING */
+
 #endif /* ZEPHYR_SOC_INTEL_ADSP_COMMON_SOC_H_ */

--- a/subsys/pm/Kconfig
+++ b/subsys/pm/Kconfig
@@ -44,6 +44,12 @@ config PM_NEED_ALL_DEVICES_IDLE
 	  When this option is enabled, check that no devices are busy before
 	  entering into system low power mode.
 
+config PM_STATE_CUSTOM_DATA
+	bool "Power state custom data"
+	help
+	  This option enables to set a custom data pointer to a specific power state
+	  which can be accessed using the pm_state_custom_data_xxx() APIs.
+
 choice PM_POLICY
 	prompt "Idle State Power Management Policy"
 	default PM_POLICY_DEFAULT

--- a/subsys/pm/state.c
+++ b/subsys/pm/state.c
@@ -6,6 +6,7 @@
  */
 
 #include <zephyr/pm/state.h>
+#include <zephyr/pm/policy.h>
 #include <zephyr/toolchain.h>
 
 BUILD_ASSERT(DT_NODE_EXISTS(DT_PATH(cpus)),
@@ -65,4 +66,36 @@ uint8_t pm_state_cpu_get_all(uint8_t cpu, const struct pm_state_info **states)
 	*states = cpus_states[cpu];
 
 	return states_per_cpu[cpu];
+}
+
+void pm_state_custom_data_set(enum pm_state state, uint8_t substate_id,
+			      const void *data)
+{
+#ifdef CONFIG_PM_STATE_CUSTOM_DATA
+	for (int16_t i = 0; i < ARRAY_SIZE(cpus_states); i++) {
+		struct pm_state_info *state_info = cpus_states[i];
+
+		if ((state_info->state == state) &&
+		    ((state_info->substate_id == substate_id)) ||
+		    (substate_id == PM_ALL_SUBSTATES)) {
+			state_info->custom_data = data;
+		}
+	}
+#endif
+}
+
+void *pm_state_custom_data_get(enum pm_state state, uint8_t substate_id)
+{
+#ifdef CONFIG_PM_STATE_CUSTOM_DATA
+	for (int16_t i = 0; i < ARRAY_SIZE(cpus_states); i++) {
+		struct pm_state_info *state_info = cpus_states[i];
+
+		if ((state_info->state == state) &&
+		    (state_info->substate_id == substate_id)) {
+			return state_info->custom_data;
+		}
+	}
+#endif
+
+	return NULL;
 }

--- a/subsys/pm/state.c
+++ b/subsys/pm/state.c
@@ -8,6 +8,7 @@
 #include <zephyr/pm/state.h>
 #include <zephyr/pm/policy.h>
 #include <zephyr/toolchain.h>
+#include <zephyr/arch/arch_inlines.h>
 
 BUILD_ASSERT(DT_NODE_EXISTS(DT_PATH(cpus)),
 	     "cpus node not defined in Devicetree");
@@ -87,8 +88,13 @@ void pm_state_custom_data_set(enum pm_state state, uint8_t substate_id,
 void *pm_state_custom_data_get(enum pm_state state, uint8_t substate_id)
 {
 #ifdef CONFIG_PM_STATE_CUSTOM_DATA
-	for (int16_t i = 0; i < ARRAY_SIZE(cpus_states); i++) {
-		struct pm_state_info *state_info = cpus_states[i];
+	unsigned int num_cpu_states;
+	const struct pm_state_info *cpu_states;
+
+	num_cpu_states = pm_state_cpu_get_all(arch_proc_id(), &cpu_states);
+
+	for (int i = num_cpu_states - 1; i >= 0; i--) {
+		const struct pm_state_info *state_info = &cpu_states[i];
 
 		if ((state_info->state == state) &&
 		    (state_info->substate_id == substate_id)) {


### PR DESCRIPTION
This pull request introduces a series of enhancements to the power management capabilities of the Intel ADSP platforms. The changes include the implementation of dynamic clock switching, which allows the DSP to adjust its clock frequency based on the idle state of the cores, thereby reducing power consumption during idle periods.

Depends on:

- [x] https://github.com/zephyrproject-rtos/zephyr/pull/64468
- [ ] https://github.com/zephyrproject-rtos/zephyr/pull/66295

Here you can check SOF part of this feature: https://github.com/thesofproject/sof/pull/8423
