### PR TITLE
boards: mimxrt101x_evk: add chosen dtcm

### DIFF
--- a/boards/arm/mimxrt1010_evk/mimxrt1010_evk.dts
+++ b/boards/arm/mimxrt1010_evk/mimxrt1010_evk.dts
@@ -23,6 +23,7 @@
 	chosen {
 		zephyr,sram = &ocram;
 		zephyr,itcm = &itcm;
+		zephyr,dtcm = &dtcm;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,flash = &at25sf128a;

--- a/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
+++ b/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
@@ -22,6 +22,7 @@
 	chosen {
 		zephyr,sram = &ocram;
 		zephyr,itcm = &itcm;
+		zephyr,dtcm = &dtcm;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,flash = &at25sf128a;


### PR DESCRIPTION
Add the chosen dtcm memory region for mimxrt1010_evk and mimxrt1015_evk.
To be consistent with other rt10xx platforms.