### PR TITLE
Fix/add net_context option setters and getters API docs

### DIFF
--- a/include/zephyr/net/net_context.h
+++ b/include/zephyr/net/net_context.h
@@ -349,12 +349,12 @@ __net_socket struct net_context {
 	/** IPv6 hop limit or IPv4 ttl for packets sent via this context. */
 	union {
 		struct {
-			uint8_t ipv6_hop_limit;
-			uint8_t ipv6_mcast_hop_limit;
+			uint8_t ipv6_hop_limit;       /**< IPv6 hop limit */
+			uint8_t ipv6_mcast_hop_limit; /**< IPv6 multicast hop limit */
 		};
 		struct {
-			uint8_t ipv4_ttl;
-			uint8_t ipv4_mcast_ttl;
+			uint8_t ipv4_ttl;       /**< IPv4 TTL */
+			uint8_t ipv4_mcast_ttl; /**< IPv4 multicast TTL */
 		};
 	};
 
@@ -698,44 +698,119 @@ static inline void net_context_bind_iface(struct net_context *context,
 	net_context_set_iface(context, iface);
 }
 
+/**
+ * @brief Get IPv4 TTL (time-to-live) value for this context.
+ *
+ * @details This function returns the IPv4 TTL (time-to-live) value that is
+ *          set to this context.
+ *
+ * @param context Network context.
+ *
+ * @return IPv4 TTL value
+ */
 static inline uint8_t net_context_get_ipv4_ttl(struct net_context *context)
 {
 	return context->ipv4_ttl;
 }
 
+/**
+ * @brief Set IPv4 TTL (time-to-live) value for this context.
+ *
+ * @details This function sets the IPv4 TTL (time-to-live) value for
+ *          this context.
+ *
+ * @param context Network context.
+ * @param ttl IPv4 time-to-live value.
+ */
 static inline void net_context_set_ipv4_ttl(struct net_context *context,
 					    uint8_t ttl)
 {
 	context->ipv4_ttl = ttl;
 }
 
+/**
+ * @brief Get IPv4 multicast TTL (time-to-live) value for this context.
+ *
+ * @details This function returns the IPv4 multicast TTL (time-to-live) value
+ *          that is set to this context.
+ *
+ * @param context Network context.
+ *
+ * @return IPv4 multicast TTL value
+ */
 static inline uint8_t net_context_get_ipv4_mcast_ttl(struct net_context *context)
 {
 	return context->ipv4_mcast_ttl;
 }
 
+/**
+ * @brief Set IPv4 multicast TTL (time-to-live) value for this context.
+ *
+ * @details This function sets the IPv4 multicast TTL (time-to-live) value for
+ *          this context.
+ *
+ * @param context Network context.
+ * @param ttl IPv4 multicast time-to-live value.
+ */
 static inline void net_context_set_ipv4_mcast_ttl(struct net_context *context,
 						  uint8_t ttl)
 {
 	context->ipv4_mcast_ttl = ttl;
 }
 
+/**
+ * @brief Get IPv6 hop limit value for this context.
+ *
+ * @details This function returns the IPv6 hop limit value that is set to this
+ *          context.
+ *
+ * @param context Network context.
+ *
+ * @return IPv6 hop limit value
+ */
 static inline uint8_t net_context_get_ipv6_hop_limit(struct net_context *context)
 {
 	return context->ipv6_hop_limit;
 }
 
+/**
+ * @brief Set IPv6 hop limit value for this context.
+ *
+ * @details This function sets the IPv6 hop limit value for this context.
+ *
+ * @param context Network context.
+ * @param hop_limit IPv6 hop limit value.
+ */
 static inline void net_context_set_ipv6_hop_limit(struct net_context *context,
 						  uint8_t hop_limit)
 {
 	context->ipv6_hop_limit = hop_limit;
 }
 
+/**
+ * @brief Get IPv6 multicast hop limit value for this context.
+ *
+ * @details This function returns the IPv6 multicast hop limit value
+ *          that is set to this context.
+ *
+ * @param context Network context.
+ *
+ * @return IPv6 multicast hop limit value
+ */
 static inline uint8_t net_context_get_ipv6_mcast_hop_limit(struct net_context *context)
 {
 	return context->ipv6_mcast_hop_limit;
 }
 
+/**
+ * @brief Set IPv6 multicast hop limit value for this context.
+ *
+ * @details This function sets the IPv6 multicast hop limit value for
+ *          this context.
+ *
+ * @param context Network context.
+ * @param hop_limit IPv6 multicast hop limit value.
+ */
 static inline void net_context_set_ipv6_mcast_hop_limit(struct net_context *context,
 							uint8_t hop_limit)
 {

--- a/include/zephyr/net/net_context.h
+++ b/include/zephyr/net/net_context.h
@@ -300,6 +300,7 @@ __net_socket struct net_context {
 		uint8_t priority;
 #endif
 #if defined(CONFIG_NET_CONTEXT_TXTIME)
+		/** When to send the packet out */
 		bool txtime;
 #endif
 #if defined(CONFIG_SOCKS)
@@ -310,30 +311,42 @@ __net_socket struct net_context {
 		} proxy;
 #endif
 #if defined(CONFIG_NET_CONTEXT_RCVTIMEO)
+		/** Receive timeout */
 		k_timeout_t rcvtimeo;
 #endif
 #if defined(CONFIG_NET_CONTEXT_SNDTIMEO)
+		/** Send timeout */
 		k_timeout_t sndtimeo;
 #endif
 #if defined(CONFIG_NET_CONTEXT_RCVBUF)
+		/** Receive buffer maximum size */
 		uint16_t rcvbuf;
 #endif
 #if defined(CONFIG_NET_CONTEXT_SNDBUF)
+		/** Send buffer maximum size */
 		uint16_t sndbuf;
 #endif
 #if defined(CONFIG_NET_CONTEXT_DSCP_ECN)
+		/**
+		 * DSCP (Differentiated Services Code point) and
+		 * ECN (Explicit Congestion Notification) values.
+		 */
 		uint8_t dscp_ecn;
 #endif
 #if defined(CONFIG_NET_CONTEXT_REUSEADDR)
+		/** Re-use address (SO_REUSEADDR) flag on a socket. */
 		bool reuseaddr;
 #endif
 #if defined(CONFIG_NET_CONTEXT_REUSEPORT)
+		/** Re-use port (SO_REUSEPORT) flag on a socket. */
 		bool reuseport;
 #endif
 #if defined(CONFIG_NET_IPV4_MAPPING_TO_IPV6)
+		/** Support v4-mapped-on-v6 addresses */
 		bool ipv6_v6only;
 #endif
 #if defined(CONFIG_NET_CONTEXT_RECV_PKTINFO)
+		/** Receive network packet information in recvmsg() call */
 		bool recv_pktinfo;
 #endif
 	} options;
@@ -360,11 +373,19 @@ __net_socket struct net_context {
 	};
 
 #if defined(CONFIG_SOCKS)
+	/** Is socks proxy enabled */
 	bool proxy_enabled;
 #endif
 
 };
 
+/**
+ * @brief Is this context used or not.
+ *
+ * @param context Network context.
+ *
+ * @return True if the context is currently in use, False otherwise.
+ */
 static inline bool net_context_is_used(struct net_context *context)
 {
 	NET_ASSERT(context);
@@ -372,6 +393,13 @@ static inline bool net_context_is_used(struct net_context *context)
 	return context->flags & NET_CONTEXT_IN_USE;
 }
 
+/**
+ * @brief Is this context bound to a network interface.
+ *
+ * @param context Network context.
+ *
+ * @return True if the context is bound to network interface, False otherwise.
+ */
 static inline bool net_context_is_bound_to_iface(struct net_context *context)
 {
 	NET_ASSERT(context);

--- a/include/zephyr/net/net_context.h
+++ b/include/zephyr/net/net_context.h
@@ -303,6 +303,7 @@ __net_socket struct net_context {
 		bool txtime;
 #endif
 #if defined(CONFIG_SOCKS)
+		/** Socks proxy address */
 		struct {
 			struct sockaddr addr;
 			socklen_t addrlen;
@@ -817,16 +818,20 @@ static inline void net_context_set_ipv6_mcast_hop_limit(struct net_context *cont
 	context->ipv6_mcast_hop_limit = hop_limit;
 }
 
+/**
+ * @brief Enable or disable socks proxy support for this context.
+ *
+ * @details This function either enables or disables socks proxy support for
+ *          this context.
+ *
+ * @param context Network context.
+ * @param enable Enable socks proxy or disable it.
+ */
 #if defined(CONFIG_SOCKS)
 static inline void net_context_set_proxy_enabled(struct net_context *context,
 						 bool enable)
 {
 	context->proxy_enabled = enable;
-}
-
-static inline bool net_context_is_proxy_enabled(struct net_context *context)
-{
-	return context->proxy_enabled;
 }
 #else
 static inline void net_context_set_proxy_enabled(struct net_context *context,
@@ -835,7 +840,24 @@ static inline void net_context_set_proxy_enabled(struct net_context *context,
 	ARG_UNUSED(context);
 	ARG_UNUSED(enable);
 }
+#endif
 
+/**
+ * @brief Is socks proxy support enabled or disabled for this context.
+ *
+ * @details This function returns current socks proxy status for
+ *          this context.
+ *
+ * @param context Network context.
+ *
+ * @return True if socks proxy is enabled for this context, False otherwise
+ */
+#if defined(CONFIG_SOCKS)
+static inline bool net_context_is_proxy_enabled(struct net_context *context)
+{
+	return context->proxy_enabled;
+}
+#else
 static inline bool net_context_is_proxy_enabled(struct net_context *context)
 {
 	return false;


### PR DESCRIPTION
Various net_context API functions and variables were missing doxygen documentation.
