### PR TITLE
doc: sphinx: Load Read The Docs theme as a Sphinx extension

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -8,8 +8,6 @@ import re
 import textwrap
 
 from sphinx.cmd.build import get_parser
-import sphinx_rtd_theme
-
 
 args = get_parser().parse_args()
 ZEPHYR_BASE = Path(__file__).resolve().parents[1]
@@ -69,6 +67,7 @@ release = version
 
 extensions = [
     "breathe",
+    "sphinx_rtd_theme",
     "sphinx.ext.todo",
     "sphinx.ext.extlinks",
     "sphinx.ext.autodoc",
@@ -136,7 +135,6 @@ rst_epilog = """
 # -- Options for HTML output ----------------------------------------------
 
 html_theme = "sphinx_rtd_theme"
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 html_theme_options = {
     "logo_only": True,
     "prev_next_buttons_location": None


### PR DESCRIPTION
This commit loads the RTD theme as a Sphinx extension, which has the benefit of going through said extension's "setup" method, effectively setting useful settings such as default permalink icon (moving away from the default, not so pretty, "¶").

build: https://builds.zephyrproject.io/zephyr/pr/66103/docs/

