### PR TITLE
boards: nrf_bsim: enable verbose log options

### DIFF
--- a/boards/posix/nrf_bsim/Kconfig.defconfig
+++ b/boards/posix/nrf_bsim/Kconfig.defconfig
@@ -81,6 +81,26 @@ choice LOG_MODE
 	default LOG_MODE_IMMEDIATE
 endchoice
 
+# Since flash & ram is "free", we can also include the function names
+# in all logging levels.
+config LOG_FUNC_NAME_PREFIX_ERR
+	default y
+
+config LOG_FUNC_NAME_PREFIX_WRN
+	default y
+
+config LOG_FUNC_NAME_PREFIX_INF
+	default y
+
+config LOG_FUNC_NAME_PREFIX_DBG
+	default y
+
+config LOG_THREAD_ID_PREFIX
+	default y
+
+config THREAD_NAME
+	default y
+
 endif # LOG
 
 if CONSOLE

--- a/samples/boards/nrf/nrf53_sync_rtc/sample.yaml
+++ b/samples/boards/nrf/nrf53_sync_rtc/sample.yaml
@@ -19,7 +19,7 @@ tests:
       type: multi_line
       ordered: false
       regex:
-        - "main: Synchronization using mbox driver"
-        - "sync_rtc: Updated timestamp to synchronized RTC by .* ticks"
-        - "main: IPC send at .* ticks"
-        - "main: Local timestamp: .*, application core timestamp:"
+        - "Synchronization using mbox driver"
+        - "Updated timestamp to synchronized RTC by .* ticks"
+        - "IPC send at .* ticks"
+        - "Local timestamp: .*, application core timestamp:"


### PR DESCRIPTION
Function and thread names are great for debugging.