### PR TITLE
boards: arm: rzt2m_starterkit: fix documentation rendering

### DIFF
--- a/boards/arm/rzt2m_starterkit/doc/index.rst
+++ b/boards/arm/rzt2m_starterkit/doc/index.rst
@@ -1,7 +1,7 @@
 .. _rzt2m_starterkit:
 
 Renesas Starter Kit+ for RZ/T2M
-===============================
+###############################
 
 Overview
 ********


### PR DESCRIPTION
As reported in #66094, the documentation used section headers wrongly.

According to the template here: https://github.com/zephyrproject-rtos/zephyr/blob/main/doc/templates/board.tmpl
the top section should be using `#` headline, and no other section should be using `#`.
Fixes #66094.

FYI @nordicjm @tgorochowik 