### PR TITLE
dfu: boot: mcuboot_shell: Prevent erasing MCUboot/app flash areas

### DIFF
--- a/doc/releases/release-notes-3.6.rst
+++ b/doc/releases/release-notes-3.6.rst
@@ -272,8 +272,11 @@ Libraries / Subsystems
   * Implemented datetime functionality in MCUmgr OS management group, this makes use of the RTC
     driver API.
 
-  * Fixes an issue in MCUmgr console UART input whereby the FIFO would be read outside of an ISR,
+  * Fixed an issue in MCUmgr console UART input whereby the FIFO would be read outside of an ISR,
     which is not supported in the next USB stack.
+
+  * Fixed an issue whereby the ``mcuboot erase`` DFU shell command could be used to erase the
+    MCUboot or currently running application slot.
 
 * File systems
 


### PR DESCRIPTION
    Prevents the user from potentially bricking a device by erasing
    the MCUboot or currently running application flash areas with the
    mcuboot erase command


Fixes #60443