### PR TITLE
net: tcp: Improve thread safety of the TCP stack

### DIFF
--- a/subsys/net/ip/tcp_private.h
+++ b/subsys/net/ip/tcp_private.h
@@ -197,7 +197,8 @@ struct tcp_mss_option {
 };
 
 enum tcp_state {
-	TCP_LISTEN = 1,
+	TCP_UNUSED = 0,
+	TCP_LISTEN,
 	TCP_SYN_SENT,
 	TCP_SYN_RECEIVED,
 	TCP_ESTABLISHED,


### PR DESCRIPTION
Improve thread safety of the TCP stack by eliminating race between TCP input thread and TCP workqueue. Additionally, fix the thread-safety issue with the connection module. Please see the details in the commit messages.

Those race conditions are rather hard to trigger in a regular environment, but a malicious device could easily perform an attack by flooding the network with crafted packets. The test scenario here was as follows:
* TCP client just establishes a TCP connection with the server, and waits for the connection to close (reset)
* A malfunctioning TCP server, accepts the connection and then floods the client with the stream of RST packets. The first one triggers the client to close the connection, while still having to process the remaining incoming RST duplicates.

W/o those fixes, this ended with an almost immediate crash. With the TCP fix only, it usually took a few hundreds of connection attempts to crash (it is quite random). With both fixes included, no crash was observed yet.