### PR TITLE
tests/thread_apis: Allow 20µs slop in k_busy_wait test

### DIFF
--- a/kernel/busy_wait.c
+++ b/kernel/busy_wait.c
@@ -21,13 +21,7 @@ void z_impl_k_busy_wait(uint32_t usec_to_wait)
 	arch_busy_wait(usec_to_wait);
 #elif defined(CONFIG_SYS_CLOCK_EXISTS)
 	uint32_t start_cycles = k_cycle_get_32();
-
-	/* use 64-bit math to prevent overflow when multiplying */
-	uint32_t cycles_to_wait = (uint32_t)(
-		(uint64_t)usec_to_wait *
-		(uint64_t)sys_clock_hw_cycles_per_sec() /
-		(uint64_t)USEC_PER_SEC
-	);
+	uint32_t cycles_to_wait = k_us_to_cyc_ceil32(usec_to_wait);
 
 	for (;;) {
 		uint32_t current_cycles = k_cycle_get_32();

--- a/tests/kernel/threads/thread_apis/src/main.c
+++ b/tests/kernel/threads/thread_apis/src/main.c
@@ -572,7 +572,13 @@ ZTEST(threads_lifecycle, test_k_busy_wait)
 
 	/* execution_cycles increases correctly */
 	dt = test_stats.execution_cycles - cycles;
-	zassert_true(dt >= k_us_to_cyc_floor64(100));
+
+	/* execution cycles may not increase by the full 100µs as the
+	 * system may be doing something else during the busy
+	 * wait. Experimentally, we see at least 80% of the cycles
+	 * consumed in the busy wait loop on current test targets.
+	 */
+	zassert_true(dt >= k_us_to_cyc_floor64(80));
 }
 
 static void tp_entry(void *p1, void *p2, void *p3)


### PR DESCRIPTION
When testing k_busy_wait(100), don't require that at least 100µs of CPU time be consumed by the thread itself; some of that time may be used elsewhere in the system. Instead, just make sure that at least 80µs is accounted to the thread and allow 20µs to get used elsewhere.

This series also has a patch to remove an open-coded time conversion in z_impl_k_busy_wait; I can pull that out separately if desired.

Closes: #65976 