### PR TITLE
Bluetooth: VCP: Vol rend: Add check before notification log

### DIFF
--- a/subsys/bluetooth/audio/vcp_vol_rend.c
+++ b/subsys/bluetooth/audio/vcp_vol_rend.c
@@ -97,7 +97,7 @@ static void notify_work_reschedule(struct bt_vcp_vol_rend *inst, enum vol_rend_n
 	if (err < 0) {
 		LOG_ERR("Failed to reschedule %s notification err %d", vol_rend_notify_str(notify),
 			err);
-	} else {
+	} else if (!K_TIMEOUT_EQ(delay, K_NO_WAIT)) {
 		LOG_DBG("%s notification scheduled in %dms", vol_rend_notify_str(notify),
 			k_ticks_to_ms_floor32(k_work_delayable_remaining_get(&inst->notify_work)));
 	}


### PR DESCRIPTION
To avoid having "notification scheduled in 0ms" in the log, check to verify that the delay is not K_NO_WAIT.