### PR TITLE
[RFC] Use Twister to build BabbleSim tests

### DIFF
--- a/boards/posix/nrf_bsim/nrf52_bsim.yaml
+++ b/boards/posix/nrf_bsim/nrf52_bsim.yaml
@@ -13,3 +13,4 @@ testing:
     - uart
 supported:
   - gpio
+  - netif

--- a/samples/net/sockets/echo_server/sample.yaml
+++ b/samples/net/sockets/echo_server/sample.yaml
@@ -74,7 +74,9 @@ tests:
     platform_allow: frdm_k64f
   sample.net.sockets.echo_server.nrf_802154:
     extra_args: OVERLAY_CONFIG="overlay-802154.conf"
-    platform_allow: nrf52840dk_nrf52840
+    platform_allow:
+      - nrf52840dk_nrf52840
+      - nrf52_bsim
   sample.net.sockets.echo_server.b91_802154:
     extra_args: OVERLAY_CONFIG="overlay-802154.conf"
     platform_allow: tlsr9518adk80d
@@ -93,6 +95,13 @@ tests:
       - openthread
     platform_allow: nrf52840dk_nrf52840
     filter: CONFIG_FULL_LIBC_SUPPORTED and not CONFIG_NATIVE_LIBC
+  sample.net.sockets.echo_server.bsim_openthread:
+    extra_args: OVERLAY_CONFIG="overlay-ot.conf"
+    slow: true
+    tags:
+      - net
+      - openthread
+    platform_allow: nrf52_bsim
   sample.net.sockets.echo_server.b91_openthread:
     extra_args: OVERLAY_CONFIG="overlay-ot.conf"
     slow: true

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -1052,7 +1052,33 @@ class ProjectBuilder(FilterBuilder):
         return self.run_cmake(args,filter_stages)
 
     def build(self):
-        return self.run_build(['--build', self.build_dir])
+        build_result = self.run_build(['--build', self.build_dir])
+        if 'BSIM_OUT_PATH' in self.platform.env:
+            self._copy_bsim_executable()
+        return build_result
+
+    def _copy_bsim_executable(self):
+        """
+        Copying application executable to BabbleSim bin directory is necessary
+        to run more complex tests which require simulate more than one device.
+        """
+        original_app_path: str = os.path.join(self.build_dir, 'zephyr', 'zephyr.exe')
+        if not os.path.exists(original_app_path):
+            logger.warning('Cannot copy bsim exe - cannot find original executable.')
+            return
+
+        bsim_out_path: str = os.getenv('BSIM_OUT_PATH', '')
+        if not bsim_out_path:
+            logger.warning('Cannot copy bsim exe - BSIM_OUT_PATH not provided.')
+            return
+
+        new_app_name: str = self.instance.name
+        new_app_name = new_app_name.replace(os.path.sep, '_').replace('.', '_')
+        new_app_name = f'bs_{new_app_name}'
+
+        new_app_path: str = os.path.join(bsim_out_path, 'bin', new_app_name)
+        logger.debug(f'Copying executable from {original_app_path} to {new_app_path}')
+        shutil.copy(original_app_path, new_app_path)
 
     def run(self):
 

--- a/tests/bsim/bluetooth/host/att/eatt/testcase.yaml
+++ b/tests/bsim/bluetooth/host/att/eatt/testcase.yaml
@@ -1,0 +1,17 @@
+common:
+  platform_allow:
+    - nrf52_bsim
+  integration_platforms:
+    - nrf52_bsim
+  build_only: true
+  tags: bluetooth
+
+tests:
+  bluetooth.eatt.autoconnect:
+    extra_args: CONF_FILE=prj_autoconnect.conf
+  bluetooth.eatt.collision:
+    extra_args: CONF_FILE=prj_collision.conf
+  bluetooth.eatt.lowres:
+    extra_args: CONF_FILE=prj_lowres.conf
+  bluetooth.eatt.multiple_conn:
+    extra_args: CONF_FILE=prj_multiple_conn.conf

--- a/tests/bsim/bluetooth/host/att/eatt/tests_scripts/autoconnect.sh
+++ b/tests/bsim/bluetooth/host/att/eatt/tests_scripts/autoconnect.sh
@@ -4,16 +4,25 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
+if [ $# -ge 1 ]; then
+  if grep -Eiq "(--build|-b)" <<< $1 ; then
+    ${ZEPHYR_BASE}/scripts/twister -v -p ${BOARD} \
+      -T tests/bsim/bluetooth/host/att/eatt \
+      -s tests/bsim/bluetooth/host/att/eatt/bluetooth.eatt.autoconnect
+    shift
+  fi
+fi
+
 simulation_id="connection"
 verbosity_level=2
 EXECUTE_TIMEOUT=120
 
 cd ${BSIM_OUT_PATH}/bin
 
-Execute ./bs_${BOARD}_tests_bsim_bluetooth_host_att_eatt_prj_autoconnect_conf \
+Execute ./bs_${BOARD}_tests_bsim_bluetooth_host_att_eatt_bluetooth_eatt_autoconnect \
   -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central_autoconnect
 
-Execute ./bs_${BOARD}_tests_bsim_bluetooth_host_att_eatt_prj_autoconnect_conf \
+Execute ./bs_${BOARD}_tests_bsim_bluetooth_host_att_eatt_bluetooth_eatt_autoconnect \
   -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral_autoconnect
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \

--- a/tests/bsim/bluetooth/host/att/eatt/tests_scripts/collision.sh
+++ b/tests/bsim/bluetooth/host/att/eatt/tests_scripts/collision.sh
@@ -10,10 +10,10 @@ EXECUTE_TIMEOUT=120
 
 cd ${BSIM_OUT_PATH}/bin
 
-Execute ./bs_${BOARD}_tests_bsim_bluetooth_host_att_eatt_prj_collision_conf \
+Execute ./bs_${BOARD}_tests_bsim_bluetooth_host_att_eatt_bluetooth_eatt_collision \
   -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central
 
-Execute ./bs_${BOARD}_tests_bsim_bluetooth_host_att_eatt_prj_collision_conf \
+Execute ./bs_${BOARD}_tests_bsim_bluetooth_host_att_eatt_bluetooth_eatt_collision \
   -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \

--- a/tests/bsim/bluetooth/host/att/eatt/tests_scripts/lowres.sh
+++ b/tests/bsim/bluetooth/host/att/eatt/tests_scripts/lowres.sh
@@ -4,16 +4,26 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
+if [ $# -ge 1 ]; then
+  if grep -Eiq "(--build|-b)" <<< $1 ; then
+    ${ZEPHYR_BASE}/scripts/twister -v -p ${BOARD} \
+      -T tests/bsim/bluetooth/host/att/eatt \
+      -s tests/bsim/bluetooth/host/att/eatt/bluetooth.eatt.autoconnect \
+      -s tests/bsim/bluetooth/host/att/eatt/bluetooth.eatt.lowres
+    shift
+  fi
+fi
+
 simulation_id="lowres"
 verbosity_level=2
 EXECUTE_TIMEOUT=20
 
 cd ${BSIM_OUT_PATH}/bin
 
-Execute ./bs_${BOARD}_tests_bsim_bluetooth_host_att_eatt_prj_autoconnect_conf \
+Execute ./bs_${BOARD}_tests_bsim_bluetooth_host_att_eatt_bluetooth_eatt_autoconnect \
   -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central_lowres
 
-Execute ./bs_${BOARD}_tests_bsim_bluetooth_host_att_eatt_prj_lowres_conf \
+Execute ./bs_${BOARD}_tests_bsim_bluetooth_host_att_eatt_bluetooth_eatt_lowres \
   -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral_lowres
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \

--- a/tests/bsim/bluetooth/host/att/eatt/tests_scripts/multiple_conn.sh
+++ b/tests/bsim/bluetooth/host/att/eatt/tests_scripts/multiple_conn.sh
@@ -10,10 +10,10 @@ EXECUTE_TIMEOUT=120
 
 cd ${BSIM_OUT_PATH}/bin
 
-Execute ./bs_${BOARD}_tests_bsim_bluetooth_host_att_eatt_prj_multiple_conn_conf \
+Execute ./bs_${BOARD}_tests_bsim_bluetooth_host_att_eatt_bluetooth_eatt_multiple_conn \
   -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central
 
-Execute ./bs_${BOARD}_tests_bsim_bluetooth_host_att_eatt_prj_multiple_conn_conf \
+Execute ./bs_${BOARD}_tests_bsim_bluetooth_host_att_eatt_bluetooth_eatt_multiple_conn \
   -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \

--- a/tests/bsim/bluetooth/host/att/eatt/tests_scripts/reconfigure.sh
+++ b/tests/bsim/bluetooth/host/att/eatt/tests_scripts/reconfigure.sh
@@ -10,10 +10,10 @@ EXECUTE_TIMEOUT=120
 
 cd ${BSIM_OUT_PATH}/bin
 
-Execute ./bs_${BOARD}_tests_bsim_bluetooth_host_att_eatt_prj_autoconnect_conf \
+Execute ./bs_${BOARD}_tests_bsim_bluetooth_host_att_eatt_bluetooth_eatt_autoconnect \
   -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central_reconfigure
 
-Execute ./bs_${BOARD}_tests_bsim_bluetooth_host_att_eatt_prj_autoconnect_conf \
+Execute ./bs_${BOARD}_tests_bsim_bluetooth_host_att_eatt_bluetooth_eatt_autoconnect \
   -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral_reconfigure
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \

--- a/tests/bsim/bluetooth/ll/bis/testcase.yaml
+++ b/tests/bsim/bluetooth/ll/bis/testcase.yaml
@@ -1,0 +1,34 @@
+common:
+  build_only: true
+  tags: bluetooth
+
+tests:
+  bluetooth.ll.bis:
+    platform_allow:
+      - nrf52_bsim
+      - nrf5340bsim_nrf5340_cpunet
+    integration_platforms:
+      - nrf52_bsim
+      - nrf5340bsim_nrf5340_cpunet
+  bluetooth.ll.bis_nrf5340_cpuapp:
+    sysbuild: true
+    platform_allow:
+      - nrf5340bsim_nrf5340_cpuapp
+    integration_platforms:
+      - nrf5340bsim_nrf5340_cpuapp
+  bluetooth.ll.bis_ticker_expire_info:
+    extra_args: OVERLAY_CONFIG=overlay-ticker_expire_info.conf
+    platform_allow:
+      - nrf52_bsim
+      - nrf5340bsim_nrf5340_cpunet
+    integration_platforms:
+      - nrf52_bsim
+      - nrf5340bsim_nrf5340_cpunet
+  bluetooth.ll.bis_vs_dp:
+    extra_args: CONF_FILE=prj_vs_dp.conf
+    platform_allow:
+      - nrf52_bsim
+      - nrf5340bsim_nrf5340_cpunet
+    integration_platforms:
+      - nrf52_bsim
+      - nrf5340bsim_nrf5340_cpunet

--- a/tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso.sh
+++ b/tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso.sh
@@ -10,12 +10,19 @@ simulation_id="broadcast_iso"
 verbosity_level=2
 EXECUTE_TIMEOUT=30
 
+if [[ "${BOARD}" == "nrf5340bsim_nrf5340_cpuapp" ]]
+then
+  app_exe="bs_${BOARD}_tests_bsim_bluetooth_ll_bis_bluetooth_ll_bis_nrf5340_cpuapp"
+else
+  app_exe="bs_${BOARD}_tests_bsim_bluetooth_ll_bis_bluetooth_ll_bis"
+fi
+
 cd ${BSIM_OUT_PATH}/bin
 
-Execute ./bs_${BOARD}_tests_bsim_bluetooth_ll_bis_prj_conf \
+Execute "./$app_exe" \
   -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=receive
 
-Execute ./bs_${BOARD}_tests_bsim_bluetooth_ll_bis_prj_conf \
+Execute "./$app_exe" \
   -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=broadcast
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \

--- a/tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_ticker_expire_info.sh
+++ b/tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_ticker_expire_info.sh
@@ -12,10 +12,10 @@ EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 
-Execute ./bs_${BOARD}_tests_bsim_bluetooth_ll_bis_prj_conf_overlay-ticker_expire_info_conf \
+Execute ./bs_${BOARD}_tests_bsim_bluetooth_ll_bis_bluetooth_ll_bis_ticker_expire_info \
   -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=receive
 
-Execute ./bs_${BOARD}_tests_bsim_bluetooth_ll_bis_prj_conf_overlay-ticker_expire_info_conf \
+Execute ./bs_${BOARD}_tests_bsim_bluetooth_ll_bis_bluetooth_ll_bis_ticker_expire_info \
   -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=broadcast
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \

--- a/tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_vs_dp.sh
+++ b/tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_vs_dp.sh
@@ -12,10 +12,10 @@ EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 
-Execute ./bs_${BOARD}_tests_bsim_bluetooth_ll_bis_prj_vs_dp_conf \
+Execute ./bs_${BOARD}_tests_bsim_bluetooth_ll_bis_bluetooth_ll_bis_vs_dp \
   -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=receive_vs_dp
 
-Execute ./bs_${BOARD}_tests_bsim_bluetooth_ll_bis_prj_conf \
+Execute ./bs_${BOARD}_tests_bsim_bluetooth_ll_bis_bluetooth_ll_bis \
   -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=broadcast
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \

--- a/tests/bsim/bsim_test_config.yaml
+++ b/tests/bsim/bsim_test_config.yaml
@@ -1,0 +1,42 @@
+levels:
+  - name: bsim
+    description: >
+      A plan to be used for all bsim tests
+    inherits:
+      - bsim_bluetooth_eatt
+      - bsim_bluetooth_bis
+      - bsim_net
+
+  - name: bsim_bluetooth
+    description: >
+      A plan to be used for bsim bluetooth tests
+    inherits:
+      - bsim_bluetooth_eatt
+      - bsim_bluetooth_bis
+
+  - name: bsim_bluetooth_eatt
+    description: >
+      A plan to be used for bsim bluetooth eatt tests
+    adds:
+      - bluetooth.eatt.autoconnect
+      - bluetooth.eatt.collision
+      - bluetooth.eatt.lowres
+      - bluetooth.eatt.multiple_conn
+
+  - name: bsim_bluetooth_bis
+    description: >
+      A plan to be used for bsim bluetooth bis tests
+    adds:
+      - bluetooth.ll.bis
+      - bluetooth.ll.bis_nrf5340_cpuapp
+      - bluetooth.ll.bis_ticker_expire_info
+      - bluetooth.ll.bis_vs_dp
+
+  - name: bsim_net
+    description: >
+      A plan to be used for bsim net tests
+    adds:
+      - sample.net.sockets.echo_server.nrf_802154
+      - net.sockets.echo_test_802154_bsim
+      - sample.net.sockets.echo_server.bsim_openthread
+      - net.sockets.echo_test_ot_bsim

--- a/tests/bsim/net/sockets/echo_test/testcase.yaml
+++ b/tests/bsim/net/sockets/echo_test/testcase.yaml
@@ -1,0 +1,13 @@
+common:
+  platform_allow:
+    - nrf52_bsim
+  integration_platforms:
+    - nrf52_bsim
+  build_only: true
+  tags: bluetooth
+
+tests:
+  net.sockets.echo_test_802154_bsim:
+    extra_args: OVERLAY_CONFIG="overlay-802154.conf"
+  net.sockets.echo_test_ot_bsim:
+    extra_args: OVERLAY_CONFIG="overlay-ot.conf"

--- a/tests/bsim/net/sockets/echo_test/tests_scripts/echo_test_802154.sh
+++ b/tests/bsim/net/sockets/echo_test/tests_scripts/echo_test_802154.sh
@@ -13,15 +13,26 @@ verbosity_level=2
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
+if [ $# -ge 1 ]; then
+  if grep -Eiq "(--build|-b)" <<< $1 ; then
+    ${ZEPHYR_BASE}/scripts/twister -v -p ${BOARD} \
+      -T tests/bsim/net/sockets/echo_test \
+      -s tests/bsim/net/sockets/echo_test/net.sockets.echo_test_802154_bsim \
+      -T samples/net/sockets/echo_server \
+      -s samples/net/sockets/echo_server/sample.net.sockets.echo_server.nrf_802154
+    shift
+  fi
+fi
+
 EXECUTE_TIMEOUT=100
 
 cd ${BSIM_OUT_PATH}/bin
 
-Execute ./bs_${BOARD}_tests_bsim_net_sockets_echo_test_prj_conf_overlay-802154_conf \
+Execute ./bs_${BOARD}_tests_bsim_net_sockets_echo_test_net_sockets_echo_test_802154_bsim \
   -v=${verbosity_level} -s=${simulation_id} -d=0 -RealEncryption=1 \
   -testid=echo_client
 
-Execute ./bs_${BOARD}_samples_net_sockets_echo_server_prj_conf_overlay-802154_conf\
+Execute ./bs_${BOARD}_samples_net_sockets_echo_server_sample_net_sockets_echo_server_nrf_802154\
   -v=${verbosity_level} -s=${simulation_id} -d=1 -RealEncryption=1 \
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \

--- a/tests/bsim/net/sockets/echo_test/tests_scripts/echo_test_ot.sh
+++ b/tests/bsim/net/sockets/echo_test/tests_scripts/echo_test_ot.sh
@@ -13,15 +13,26 @@ verbosity_level=2
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
+if [ $# -ge 1 ]; then
+  if grep -Eiq "(--build|-b)" <<< $1 ; then
+    ${ZEPHYR_BASE}/scripts/twister -v -p ${BOARD} \
+      -T tests/bsim/net/sockets/echo_test \
+      -s tests/bsim/net/sockets/echo_test/net.sockets.echo_test_ot_bsim \
+      -T samples/net/sockets/echo_server \
+      -s samples/net/sockets/echo_server/sample.net.sockets.echo_server.bsim_openthread
+    shift
+  fi
+fi
+
 EXECUTE_TIMEOUT=100
 
 cd ${BSIM_OUT_PATH}/bin
 
-Execute ./bs_${BOARD}_tests_bsim_net_sockets_echo_test_prj_conf_overlay-ot_conf \
+Execute ./bs_${BOARD}_tests_bsim_net_sockets_echo_test_net_sockets_echo_test_ot_bsim \
   -v=${verbosity_level} -s=${simulation_id} -start_offset=2e6 -d=0 -RealEncryption=1 \
   -testid=echo_client
 
-Execute ./bs_${BOARD}_samples_net_sockets_echo_server_prj_conf_overlay-ot_conf\
+Execute ./bs_${BOARD}_samples_net_sockets_echo_server_sample_net_sockets_echo_server_bsim_openthread\
   -v=${verbosity_level} -s=${simulation_id} -d=1 -RealEncryption=1 \
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \


### PR DESCRIPTION
To make it easier to manage scope of applications which should be built and to make it easier to assign tests to platform scope, this PR shows how building of BabbleSim test applications could looks like. This solution assumes that execution of tests will be still performed in bash scripts, but at least building could be executed by Twister.

First commit contains changes in Twister which are necessary to copy built binaries to `${BSIM_OUT_PATH}/bin` directory. I think that this is most discussable part of whole idea - I'm not 100% sure, that Twister should have such parts dedicated only to one simulator. On the other hand there are a lot of logic dedicated only to QEMU emulator in Twister. At this moment I propose to recognize if target platform is BabbleSim hardware model by checking `'BSIM_OUT_PATH' in self.platform.env`. In this PR I would like to only show the general idea.

To test:

1. To build and run only one test (`host/att/eatt/tests_scripts/autoconnect.sh` on `nrf52_bsim`):
```
# by Twister
./scripts/twister -vv --inline-logs -p nrf52_bsim -T tests/bsim/bluetooth/host/att/eatt -s tests/bsim/bluetooth/host/att/eatt/bluetooth.eatt.autoconnect
./tests/bsim/bluetooth/host/att/eatt/tests_scripts/autoconnect.sh

# by west
west build -p -b nrf52_bsim tests/bsim/bluetooth/host/att/eatt --test-item bluetooth.eatt.autoconnect
cp build/zephyr/zephyr.exe ${BSIM_OUT_PATH}/bin/bs_nrf52_bsim_tests_bsim_bluetooth_host_att_eatt_bluetooth_eatt_autoconnect
./tests/bsim/bluetooth/host/att/eatt/tests_scripts/autoconnect.sh
```
2. To build and run more tests (`host/att/eatt` and `ll/bis` on `nrf52_bsim` and `nrf5340bsim_nrf5340_cpu*`):
```
./scripts/twister -vv --inline-logs --integration -T tests/bsim/bluetooth/host/att/eatt -T tests/bsim/bluetooth/ll/bis

export WORK_DIR=${ZEPHYR_BASE}/bsim_out
mkdir -p ${WORK_DIR}
export SEARCH_PATH="tests/bsim/bluetooth/host/att/eatt tests/bsim/bluetooth/ll/bis"
export RESULTS_FILE=${WORK_DIR}/results_nrf52_bsim.xml
BOARD=nrf52_bsim ./tests/bsim/run_parallel.sh
export SEARCH_PATH="tests/bsim/bluetooth/ll/bis"
export RESULTS_FILE=${WORK_DIR}/results_nrf5340bsim_nrf5340_cpunet.xml
BOARD=nrf5340bsim_nrf5340_cpunet ./tests/bsim/run_parallel.sh
export TESTS_LIST="tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso.sh"
export RESULTS_FILE=${WORK_DIR}/results_nrf5340bsim_nrf5340_cpuapp.xml
BOARD=nrf5340bsim_nrf5340_cpuapp ./tests/bsim/run_parallel.sh
export TESTS_LIST=""
```
3. To build and run net tests:
```
./scripts/twister -vv --inline-logs -p nrf52_bsim --test-config tests/bsim/bsim_test_config.yaml --level=bsim_net

export WORK_DIR=${ZEPHYR_BASE}/bsim_out
mkdir -p ${WORK_DIR}
export SEARCH_PATH=tests/bsim/net
export RESULTS_FILE=${WORK_DIR}/results_nrf52_bsim.xml
BOARD=nrf52_bsim ./tests/bsim/run_parallel.sh
```