### PR TITLE
doc: fix using out of tree build directory

### DIFF
--- a/doc/_extensions/zephyr/gh_utils.py
+++ b/doc/_extensions/zephyr/gh_utils.py
@@ -53,7 +53,7 @@ sys.path.insert(0, str(SCRIPTS))
 
 from get_maintainer import Maintainers
 
-MAINTAINERS : Final[Maintainers] = Maintainers()
+MAINTAINERS : Final[Maintainers] = Maintainers(filename=f"{ZEPHYR_BASE}/MAINTAINERS.yml")
 
 
 __version__ = "0.1.0"

--- a/scripts/get_maintainer.py
+++ b/scripts/get_maintainer.py
@@ -175,12 +175,12 @@ class Maintainers:
             the top-level directory of the Git repository is used, and must
             exist.
         """
-        self._toplevel = pathlib.Path(_git("rev-parse", "--show-toplevel"))
-
-        if filename is None:
-            self.filename = self._toplevel / "MAINTAINERS.yml"
-        else:
+        if (filename is not None) and (pathlib.Path(filename).exists()):
             self.filename = pathlib.Path(filename)
+            self._toplevel = self.filename.parent
+        else:
+            self._toplevel = pathlib.Path(_git("rev-parse", "--show-toplevel"))
+            self.filename = self._toplevel / "MAINTAINERS.yml"
 
         self.areas = {}
         for area_name, area_dict in _load_maintainers(self.filename).items():


### PR DESCRIPTION
Building doc with an out of tree build directory is broken due to the need to use git to find path to MAINTAINERS.yml. This basically restricts the build directory to be always under Zephyr root. So fix that.