### PR TITLE
Create a handler for enabling and disabling charging

### DIFF
--- a/doc/hardware/peripherals/charger.rst
+++ b/doc/hardware/peripherals/charger.rst
@@ -8,6 +8,11 @@ The charger subsystem exposes an API to uniformly access battery charger devices
 Basic Operation
 ***************
 
+Initiating a Charge Cycle
+=========================
+
+A charge cycle is initiated or terminated using :c:func:`charger_charge_enable`.
+
 Properties
 ==========
 

--- a/drivers/charger/charger_handlers.c
+++ b/drivers/charger/charger_handlers.c
@@ -36,3 +36,12 @@ static inline int z_vrfy_charger_set_prop(const struct device *dev, const charge
 }
 
 #include <syscalls/charger_set_prop_mrsh.c>
+
+static inline int z_vrfy_charger_charge_enable(const struct device *dev, const bool enable)
+{
+	K_OOPS(K_SYSCALL_DRIVER_CHARGER(dev, charge_enable));
+
+	return z_impl_charger_charge_enable(dev, enable);
+}
+
+#include <syscalls/charger_charge_enable_mrsh.c>

--- a/drivers/charger/charger_max20335.c
+++ b/drivers/charger/charger_max20335.c
@@ -235,15 +235,6 @@ static int max20335_set_prop(const struct device *dev, charger_prop_t prop,
 			     const union charger_propval *val)
 {
 	switch (prop) {
-	case CHARGER_PROP_STATUS:
-		switch (val->status) {
-		case CHARGER_STATUS_CHARGING:
-			return max20335_set_enabled(dev, true);
-		case CHARGER_STATUS_NOT_CHARGING:
-			return max20335_set_enabled(dev, false);
-		default:
-			return -ENOTSUP;
-		}
 	case CHARGER_PROP_CONSTANT_CHARGE_CURRENT_UA:
 		return max20335_set_constant_charge_current(dev,
 							    val->const_charge_current_ua);
@@ -253,7 +244,6 @@ static int max20335_set_prop(const struct device *dev, charger_prop_t prop,
 	default:
 		return -ENOTSUP;
 	}
-
 }
 
 static int max20335_init(const struct device *dev)
@@ -270,6 +260,7 @@ static int max20335_init(const struct device *dev)
 static const struct charger_driver_api max20335_driver_api = {
 	.get_property = max20335_get_prop,
 	.set_property = max20335_set_prop,
+	.charge_enable = max20335_set_enabled,
 };
 
 #define MAX20335_DEFINE(inst)									\

--- a/drivers/charger/emul_sbs_charger.c
+++ b/drivers/charger/emul_sbs_charger.c
@@ -25,10 +25,20 @@ struct sbs_charger_emul_cfg {
 	uint16_t addr;
 };
 
+/** Run-time data used by the emulator */
+struct sbs_charger_emul_data {
+	uint16_t reg_charger_mode;
+};
+
 static int emul_sbs_charger_reg_write(const struct emul *target, int reg, int val)
 {
+	struct sbs_charger_emul_data *data = target->data;
+
 	LOG_INF("write %x = %x", reg, val);
 	switch (reg) {
+	case SBS_CHARGER_REG_CHARGER_MODE:
+		data->reg_charger_mode = val;
+		break;
 	default:
 		LOG_ERR("Unknown write %x", reg);
 		return -EIO;
@@ -132,10 +142,12 @@ static int emul_sbs_sbs_charger_init(const struct emul *target, const struct dev
  * Main instantiation macro. SBS Charger Emulator only implemented for I2C
  */
 #define SBS_CHARGER_EMUL(n)                                                                        \
+	static struct sbs_charger_emul_data sbs_charger_emul_data_##n;                             \
+                                                                                                   \
 	static const struct sbs_charger_emul_cfg sbs_charger_emul_cfg_##n = {                      \
 		.addr = DT_INST_REG_ADDR(n),                                                       \
 	};                                                                                         \
-	EMUL_DT_INST_DEFINE(n, emul_sbs_sbs_charger_init, NULL, &sbs_charger_emul_cfg_##n,         \
-			    &sbs_charger_emul_api_i2c, NULL)
+	EMUL_DT_INST_DEFINE(n, emul_sbs_sbs_charger_init, &sbs_charger_emul_data_##n,              \
+			    &sbs_charger_emul_cfg_##n, &sbs_charger_emul_api_i2c, NULL)
 
 DT_INST_FOREACH_STATUS_OKAY(SBS_CHARGER_EMUL)

--- a/drivers/charger/sbs_charger.c
+++ b/drivers/charger/sbs_charger.c
@@ -66,6 +66,20 @@ static int sbs_cmd_reg_update(const struct device *dev, uint8_t reg_addr, uint16
 	return sbs_cmd_reg_write(dev, reg_addr, new_val);
 }
 
+static int sbs_charger_charge_enable(const struct device *dev, const bool enable)
+{
+	uint16_t reg_val;
+
+	if (!enable) {
+		reg_val = SBS_CHARGER_MODE_INHIBIT_CHARGE;
+	} else {
+		reg_val = 0;
+	}
+
+	return sbs_cmd_reg_update(dev, SBS_CHARGER_REG_CHARGER_MODE,
+				  SBS_CHARGER_MODE_INHIBIT_CHARGE, reg_val);
+}
+
 static int sbs_charger_get_prop(const struct device *dev, const charger_prop_t prop,
 				union charger_propval *val)
 {
@@ -123,18 +137,7 @@ static int sbs_charger_get_prop(const struct device *dev, const charger_prop_t p
 static int sbs_charger_set_prop(const struct device *dev, const charger_prop_t prop,
 				const union charger_propval *val)
 {
-	uint16_t reg_val = 0;
-
-	switch (prop) {
-	case CHARGER_PROP_STATUS:
-		if (val->status != CHARGER_STATUS_CHARGING) {
-			reg_val = SBS_CHARGER_MODE_INHIBIT_CHARGE;
-		}
-		return sbs_cmd_reg_update(dev, SBS_CHARGER_REG_CHARGER_MODE,
-					  SBS_CHARGER_MODE_INHIBIT_CHARGE, reg_val);
-	default:
-		return -ENOTSUP;
-	}
+	return -ENOTSUP;
 }
 
 /**
@@ -157,6 +160,7 @@ static int sbs_charger_init(const struct device *dev)
 static const struct charger_driver_api sbs_charger_driver_api = {
 	.get_property = &sbs_charger_get_prop,
 	.set_property = &sbs_charger_set_prop,
+	.charge_enable = &sbs_charger_charge_enable,
 };
 
 #define SBS_CHARGER_INIT(inst)                                                                     \

--- a/include/zephyr/drivers/charger.h
+++ b/include/zephyr/drivers/charger.h
@@ -221,6 +221,14 @@ typedef int (*charger_set_property_t)(const struct device *dev, const charger_pr
 				      const union charger_propval *val);
 
 /**
+ * @typedef charger_charge_enable_t
+ * @brief Callback API enabling or disabling a charge cycle.
+ *
+ * See charger_charge_enable() for argument description
+ */
+typedef int (*charger_charge_enable_t)(const struct device *dev, const bool enable);
+
+/**
  * @brief Charging device API
  *
  * Caching is entirely on the onus of the client
@@ -228,6 +236,7 @@ typedef int (*charger_set_property_t)(const struct device *dev, const charger_pr
 __subsystem struct charger_driver_api {
 	charger_get_property_t get_property;
 	charger_set_property_t set_property;
+	charger_charge_enable_t charge_enable;
 };
 
 /**
@@ -270,6 +279,25 @@ static inline int z_impl_charger_set_prop(const struct device *dev, const charge
 	const struct charger_driver_api *api = (const struct charger_driver_api *)dev->api;
 
 	return api->set_property(dev, prop, val);
+}
+
+/**
+ * @brief Enable or disable a charge cycle
+ *
+ * @param dev Pointer to the battery charger device
+ * @param enable true enables a charge cycle, false disables a charge cycle
+ *
+ * @retval 0 if successful
+ * @retval -EIO if communication with the charger failed
+ * @retval -EINVAL if the conditions for initiating charging are invalid
+ */
+__syscall int charger_charge_enable(const struct device *dev, const bool enable);
+
+static inline int z_impl_charger_charge_enable(const struct device *dev, const bool enable)
+{
+	const struct charger_driver_api *api = (const struct charger_driver_api *)dev->api;
+
+	return api->charge_enable(dev, enable);
 }
 
 /**

--- a/samples/charger/src/main.c
+++ b/samples/charger/src/main.c
@@ -45,7 +45,7 @@ int main(void)
 
 		val.status = CHARGER_STATUS_CHARGING;
 
-		ret = charger_set_prop(chgdev, CHARGER_PROP_STATUS, &val);
+		ret = charger_charge_enable(chgdev, true);
 		if (ret == -ENOTSUP) {
 			printk("Enabling charge not supported, assuming auto charge enable\n");
 			continue;

--- a/tests/drivers/charger/sbs_charger/src/test_sbs_charger.c
+++ b/tests/drivers/charger/sbs_charger/src/test_sbs_charger.c
@@ -64,14 +64,11 @@ ZTEST_USER_F(sbs_charger, test_set_prop_failed_returns_negative)
 	zassert_equal(ret, -ENOTSUP, "Setting bad property %d has a good status.", prop);
 }
 
-ZTEST_USER_F(sbs_charger, test_set_prop_success_returns_zero)
+ZTEST_USER_F(sbs_charger, test_charge_enable_success_returns_zero)
 {
-	union charger_propval val = {.status = CHARGER_STATUS_NOT_CHARGING};
-	charger_prop_t prop = CHARGER_PROP_STATUS;
+	int ret = charger_charge_enable(fixture->dev, true);
 
-	int ret = charger_set_prop(fixture->dev, prop, &val);
-
-	zassert_equal(ret, 0, "Setting good property %d has a good status.", prop);
+	zassert_equal(ret, 0, "Enabling charge has a good status.");
 }
 
 ZTEST_SUITE(sbs_charger, NULL, sbs_charger_setup, NULL, NULL, NULL);


### PR DESCRIPTION
A dedicated handler for enabling and disabling a charge cycle was suggested by @bjarki-trackunit here (https://github.com/zephyrproject-rtos/zephyr/pull/65101#discussion_r1391973446)

This pull request creates the handler and updates existing clients of the charger API in `drivers/charger` to make use of the new handler.