### PR TITLE
Bluetooth: Host: Use uint16_t replace uint32_t for interval

### DIFF
--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -746,7 +746,7 @@ struct bt_le_adv_param {
 	 * in Bluetooth Core Spec 5.2, section 7.8.5)
 	 * Range: 0x0020 to 0x4000
 	 */
-	uint32_t interval_min;
+	uint16_t interval_min;
 
 	/** Maximum Advertising Interval (N * 0.625 milliseconds)
 	 * Minimum Advertising Interval shall be less than or equal to the
@@ -755,7 +755,7 @@ struct bt_le_adv_param {
 	 * in Bluetooth Core Spec 5.2, section 7.8.5)
 	 * Range: 0x0020 to 0x4000
 	 */
-	uint32_t interval_max;
+	uint16_t interval_max;
 
 	/**
 	 * @brief Directed advertising to peer


### PR DESCRIPTION
Advertising interval range 0x0020-0x4000, uint16_t suitable.