### PR TITLE
shell: fix shell instance name typo

### DIFF
--- a/subsys/shell/shell_cmds.c
+++ b/subsys/shell/shell_cmds.c
@@ -231,7 +231,7 @@ static int cmd_backends(const struct shell *sh, size_t argc, char **argv)
 
 	shell_print(sh, "Active shell backends:");
 	STRUCT_SECTION_FOREACH(shell, obj) {
-		shell_print(sh, "  %2d. :%s (%s)", cnt++, obj->ctx->prompt, sh->name);
+		shell_print(sh, "  %2d. :%s (%s)", cnt++, obj->ctx->prompt, obj->name);
 	}
 
 	return 0;


### PR DESCRIPTION
Fixing typo from the original implementation in 44705b698c725166834f19d6fd5db2804f9a0d60, which resulted in the name of current shell instance getting print over and over again.

I'm working on getting the `shell_uart` multi-instance, this sc was before this patch:

<img width="567" alt="Screenshot 2023-12-04 at 10 58 00 PM" src="https://github.com/zephyrproject-rtos/zephyr/assets/1563974/3227daa7-056c-4713-a67f-4e398c3fa36b">

after:

<img width="575" alt="Screenshot 2023-12-05 at 5 57 55 PM" src="https://github.com/zephyrproject-rtos/zephyr/assets/1563974/7c36c9c4-0f31-4cc5-b9f6-1da3441d446c">

