### PR TITLE
native_simulator: Allow to pass extra options for localizing symbols

### DIFF
--- a/arch/posix/CMakeLists.txt
+++ b/arch/posix/CMakeLists.txt
@@ -22,6 +22,11 @@ endif()
 #  RUNNER_LINK_LIBRARIES:
 #      Extra libraries to link with the runner
 #      For ex. set_property(TARGET native_simulator APPEND PROPERTY RUNNER_LINK_LIBRARIES "mylib.a")
+#  LOCALIZE_EXTRA_OPTIONS:
+#      Extra options to be passed to objcopy when localizing each Zephyr MCU image symbols
+#      This can be used to hide symbols a library may have set as visible outside of
+#      itself once the MCU image has been assembled.
+#      For ex. set_property(TARGET native_simulator APPEND PROPERTY LOCALIZE_EXTRA_OPTIONS "--localize-symbol=spinel*")
 #  Note: target_link_libraries() cannot be used on this library at this point.
 #        target_link_libraries() updates INTERFACE_LINK_LIBRARIES but wrapping it with extra
 #        information. This means we cannot directly pass it to the native_simulator runner build.
@@ -30,6 +35,7 @@ endif()
 #        We use target_link_options() instead
 add_library(native_simulator INTERFACE)
 set_property(TARGET native_simulator PROPERTY RUNNER_LINK_LIBRARIES "")
+set_property(TARGET native_simulator PROPERTY LOCALIZE_EXTRA_OPTIONS "")
 
 set(NSI_DIR ${ZEPHYR_BASE}/scripts/native_simulator CACHE PATH "Path to the native simulator")
 

--- a/boards/posix/common/natsim_config.cmake
+++ b/boards/posix/common/natsim_config.cmake
@@ -20,7 +20,7 @@ set(nsi_config_content
   "NSI_EXTRA_LIBS:=$<JOIN:$<TARGET_PROPERTY:native_simulator,RUNNER_LINK_LIBRARIES>,\ >"
   "NSI_PATH:=${NSI_DIR}/"
   "NSI_N_CPUS:=${CONFIG_NATIVE_SIMULATOR_NUMBER_MCUS}"
-  "NSI_LOCALIZE_OPTIONS:=--localize-symbol=CONFIG_*"
+  "NSI_LOCALIZE_OPTIONS:=--localize-symbol=CONFIG_* $<JOIN:$<TARGET_PROPERTY:native_simulator,LOCALIZE_EXTRA_OPTIONS>,\ >"
 )
 
 string(REPLACE ";" "\n" nsi_config_content "${nsi_config_content}")


### PR DESCRIPTION
Some libraries (like Openthread's spinel code) define their API as externally linkable. This will make those symbols remain as externally linkable by default after the Zephyr build has produced the native simulator library (MCU code).
When building an AMP native_simulator executable with several MCUs each including these, the linker will see those symbols as still linkable and duplicated, and throw an error.

So let's give the option for users/developers of those libraries to define extra symbols they want
to localize before assembling the final executable.