### PR TITLE
soc: stm32: add Kconfig-selectable cache enables

### DIFF
--- a/soc/arm/st_stm32/stm32f7/soc.c
+++ b/soc/arm/st_stm32/stm32f7/soc.c
@@ -30,12 +30,12 @@ static int st_stm32f7_init(void)
 	/* Enable ART Flash cache accelerator */
 	LL_FLASH_EnableART();
 
-	SCB_EnableICache();
+	if (IS_ENABLED(CONFIG_ICACHE)) {
+		SCB_EnableICache();
+	}
 
 	if (IS_ENABLED(CONFIG_DCACHE)) {
-		if (!(SCB->CCR & SCB_CCR_DC_Msk)) {
-			SCB_EnableDCache();
-		}
+		SCB_EnableDCache();
 	}
 
 	/* Update CMSIS SystemCoreClock variable (HCLK) */

--- a/soc/arm/st_stm32/stm32h7/soc_m7.c
+++ b/soc/arm/st_stm32/stm32h7/soc_m7.c
@@ -54,12 +54,12 @@ static int stm32h7_m4_wakeup(void)
  */
 static int stm32h7_init(void)
 {
-	SCB_EnableICache();
+	if (IS_ENABLED(CONFIG_ICACHE)) {
+		SCB_EnableICache();
+	}
 
 	if (IS_ENABLED(CONFIG_DCACHE)) {
-		if (!(SCB->CCR & SCB_CCR_DC_Msk)) {
-			SCB_EnableDCache();
-		}
+		SCB_EnableDCache();
 	}
 
 	/* Update CMSIS SystemCoreClock variable (HCLK) */


### PR DESCRIPTION
The instruction cache in the STM32H7 was enabled regardless of the value assigned via Kconfig to the CONFIG_ICACHE parameter. Add the missing conditional check.

Remove a redundant low-level check on DCache being already enabled, since it is also performed inside the SCB_EnableDCache function.

I also applied the same patch to the F7, according to @FRASTM suggestion.

~In the same spirit, I applied Kconfig-selectable cache enables to other STM32 targets using LL_ICACHE and LL_FLASH HAL APIs. If this is not desired/useful I will drop the relevant patches.~