### PR TITLE
cmake: Add support for file suffixes

### DIFF
--- a/cmake/modules/configuration_files.cmake
+++ b/cmake/modules/configuration_files.cmake
@@ -27,6 +27,9 @@ include_guard(GLOBAL)
 
 include(extensions)
 
+# Merge in variables from other sources (e.g. sysbuild)
+zephyr_get(FILE_SUFFIX SYSBUILD GLOBAL)
+
 zephyr_get(APPLICATION_CONFIG_DIR)
 if(DEFINED APPLICATION_CONFIG_DIR)
   string(CONFIGURE ${APPLICATION_CONFIG_DIR} APPLICATION_CONFIG_DIR)
@@ -41,7 +44,7 @@ endif()
 
 zephyr_get(CONF_FILE SYSBUILD LOCAL)
 if(NOT DEFINED CONF_FILE)
-  zephyr_file(CONF_FILES ${APPLICATION_CONFIG_DIR} KCONF CONF_FILE NAMES "prj.conf" REQUIRED)
+  zephyr_file(CONF_FILES ${APPLICATION_CONFIG_DIR} KCONF CONF_FILE NAMES "prj.conf" SUFFIX ${FILE_SUFFIX} REQUIRED)
   zephyr_file(CONF_FILES ${APPLICATION_CONFIG_DIR}/boards KCONF CONF_FILE)
 else()
   string(CONFIGURE "${CONF_FILE}" CONF_FILE_EXPANDED)
@@ -70,12 +73,12 @@ To change CONF_FILE, use the CONF_FILE variable." ${CONF_FILE_FORCE_CACHE})
 # The CONF_FILE variable is now set to its final value.
 zephyr_boilerplate_watch(CONF_FILE)
 
-zephyr_file(CONF_FILES ${APPLICATION_CONFIG_DIR}/boards DTS APP_BOARD_DTS)
+zephyr_file(CONF_FILES ${APPLICATION_CONFIG_DIR}/boards DTS APP_BOARD_DTS SUFFIX ${FILE_SUFFIX})
 
 zephyr_get(DTC_OVERLAY_FILE SYSBUILD LOCAL)
 if(NOT DEFINED DTC_OVERLAY_FILE)
   zephyr_file(CONF_FILES ${APPLICATION_CONFIG_DIR} DTS DTC_OVERLAY_FILE
-              NAMES "${APP_BOARD_DTS};${BOARD}.overlay;app.overlay")
+              NAMES "${APP_BOARD_DTS};${BOARD}.overlay;app.overlay" SUFFIX ${FILE_SUFFIX})
 endif()
 
 set(DTC_OVERLAY_FILE ${DTC_OVERLAY_FILE} CACHE STRING "If desired, you can \
@@ -86,6 +89,9 @@ DTC_OVERLAY_FILE=\"dts1.overlay dts2.overlay\"")
 
 # The DTC_OVERLAY_FILE variable is now set to its final value.
 zephyr_boilerplate_watch(DTC_OVERLAY_FILE)
+
+# Watch the FILE_SUFFIX variable for changes too
+zephyr_boilerplate_watch(FILE_SUFFIX)
 
 zephyr_get(EXTRA_CONF_FILE SYSBUILD LOCAL VAR EXTRA_CONF_FILE OVERLAY_CONFIG MERGE REVERSE)
 zephyr_get(EXTRA_DTC_OVERLAY_FILE SYSBUILD LOCAL MERGE REVERSE)

--- a/cmake/modules/configuration_files.cmake
+++ b/cmake/modules/configuration_files.cmake
@@ -90,9 +90,6 @@ DTC_OVERLAY_FILE=\"dts1.overlay dts2.overlay\"")
 # The DTC_OVERLAY_FILE variable is now set to its final value.
 zephyr_boilerplate_watch(DTC_OVERLAY_FILE)
 
-# Watch the FILE_SUFFIX variable for changes too
-zephyr_boilerplate_watch(FILE_SUFFIX)
-
 zephyr_get(EXTRA_CONF_FILE SYSBUILD LOCAL VAR EXTRA_CONF_FILE OVERLAY_CONFIG MERGE REVERSE)
 zephyr_get(EXTRA_DTC_OVERLAY_FILE SYSBUILD LOCAL MERGE REVERSE)
 zephyr_get(DTS_EXTRA_CPPFLAGS SYSBUILD LOCAL MERGE REVERSE)

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -2574,6 +2574,10 @@ Relative paths are only allowed with `-D${ARGV1}=<path>`")
           if(EXISTS ${test_file})
             list(APPEND ${FILE_DTS} ${test_file})
 
+            if(DEFINED FILE_BUILD)
+              set(deprecated_file_found y)
+            endif()
+
             if(FILE_NAMES)
               break()
             endif()
@@ -2601,6 +2605,11 @@ Relative paths are only allowed with `-D${ARGV1}=<path>`")
 
           if(EXISTS ${test_file})
             list(APPEND ${FILE_KCONF} ${test_file})
+
+            if(DEFINED FILE_BUILD)
+              set(deprecated_file_found y)
+            endif()
+
             if(FILE_NAMES)
               break()
             endif()
@@ -2621,6 +2630,11 @@ Relative paths are only allowed with `-D${ARGV1}=<path>`")
               "No ${not_found} file(s) was found in the ${FILE_CONF_FILES} folder(s), "
               "please read the Zephyr documentation on application development."
       )
+    endif()
+
+    if(deprecated_file_found)
+      message(DEPRECATION "prj_<build>.conf was deprecated after Zephyr 3.5,"
+                          " you should switch to using -DFILE_SUFFIX instead")
     endif()
   endif()
 endfunction()
@@ -4279,7 +4293,7 @@ function(zephyr_linker_dts_section)
 
   if(DTS_SECTION_UNPARSED_ARGUMENTS)
     message(FATAL_ERROR "zephyr_linker_dts_section(${ARGV0} ...) given unknown "
-            "arguments: ${DTS_SECTION_UNPARSED_ARGUMENTS}"
+	    "arguments: ${DTS_SECTION_UNPARSED_ARGUMENTS}"
     )
   endif()
 

--- a/cmake/modules/kconfig.cmake
+++ b/cmake/modules/kconfig.cmake
@@ -84,7 +84,7 @@ if(EXTRA_CONF_FILE)
   string(REPLACE " " ";" EXTRA_CONF_FILE_AS_LIST "${EXTRA_CONF_FILE_EXPANDED}")
 endif()
 
-zephyr_file(CONF_FILES ${BOARD_EXTENSION_DIRS} KCONF board_extension_conf_files)
+zephyr_file(CONF_FILES ${BOARD_EXTENSION_DIRS} KCONF board_extension_conf_files SUFFIX ${FILE_SUFFIX})
 
 # DTS_ROOT_BINDINGS is a semicolon separated list, this causes
 # problems when invoking kconfig_target since semicolon is a special

--- a/doc/build/sysbuild/index.rst
+++ b/doc/build/sysbuild/index.rst
@@ -651,6 +651,74 @@ configuration files for ``my_sample`` will be ignored.
 This give you full control on how images are configured when integrating those
 with ``application``.
 
+.. _sysbuild_file_suffixes:
+
+Sysbuild file suffix support
+----------------------------
+
+File suffix support through the makevar:`FILE_SUFFIX` is supported in sysbuild
+(see :ref:`application-file-suffixes` for details on this feature in applications). For sysbuild,
+a globally provided option will be passed down to all images. In addition, the image configuration
+file will have this value applied and used (instead of the build type) if the file exists.
+
+Given the example project:
+
+.. code-block:: none
+
+   <home>/application
+   ├── CMakeLists.txt
+   ├── prj.conf
+   ├── sysbuild.conf
+   ├── sysbuild_test_key.conf
+   └── sysbuild
+       ├── mcuboot.conf
+       ├── mcuboot_max_log.conf
+       └── my_sample.conf
+
+* If ``FILE_SUFFIX`` is not defined and both ``mcuboot`` and ``my_sample`` images are included,
+  ``mcuboot`` will use the ``mcuboot.conf`` Kconfig fragment file and ``my_sample`` will use the
+  ``my_sample.conf`` Kconfig fragment file. Sysbuild itself will use the ``sysbuild.conf``
+  Kconfig fragment file.
+
+* If ``FILE_SUFFIX`` is set to ``max_log`` and both ``mcuboot`` and ``my_sample`` images are
+  included, ``mcuboot`` will use the ``mcuboot_max_log.conf`` Kconfig fragment file and
+  ``my_sample`` will use the ``my_sample.conf`` Kconfig fragment file (as it will fallback to the
+  file without the suffix). Sysbuild itself will use the ``sysbuild.conf`` Kconfig fragment file
+  (as it will fallback to the file without the suffix).
+
+* If ``FILE_SUFFIX`` is set to ``test_key`` and both ``mcuboot`` and ``my_sample`` images are
+  included, ``mcuboot`` will use the ``mcuboot.conf`` Kconfig fragment file and
+  ``my_sample`` will use the ``my_sample.conf`` Kconfig fragment file (as it will fallback to the
+  files without the suffix). Sysbuild itself will use the ``sysbuild_test_key.conf`` Kconfig
+  fragment file. This can be used to apply a different sysbuild configuration, for example to use
+  a different signing key in MCUboot and when signing the main application.
+
+The ``FILE_SUFFIX`` can also be applied only to single images by prefixing the variable with the
+image name:
+
+.. tabs::
+
+   .. group-tab:: ``west build``
+
+      .. zephyr-app-commands::
+         :tool: west
+         :app: file_suffix_example
+         :board: reel_board
+         :goals: build
+         :west-args: --sysbuild
+         :gen-args: -DSB_CONFIG_BOOTLOADER_MCUBOOT=y -Dmcuboot_FILE_SUFFIX="max_log"
+         :compact:
+
+   .. group-tab:: ``cmake``
+
+      .. zephyr-app-commands::
+         :tool: cmake
+         :app: share/sysbuild
+         :board: reel_board
+         :goals: build
+         :gen-args: -DAPP_DIR=<app_dir> -DSB_CONFIG_BOOTLOADER_MCUBOOT=y -Dmcuboot_FILE_SUFFIX="max_log"
+         :compact:
+
 .. _sysbuild_zephyr_application_dependencies:
 
 Adding dependencies among Zephyr applications

--- a/doc/develop/application/index.rst
+++ b/doc/develop/application/index.rst
@@ -445,6 +445,10 @@ should know about.
 * :makevar:`EXTRA_ZEPHYR_MODULES`: Like :makevar:`ZEPHYR_MODULES`, except these
   will be added to the list of modules found via west, instead of replacing it.
 
+* :makevar:`FILE_SUFFIX`: Optional suffix for filenames that will be added to Kconfig
+  fragments and devicetree overlays (if these files exists, otherwise will fallback to
+  the name without the prefix). See :ref:`application-file-suffixes` for details.
+
 .. note::
 
    You can use a :ref:`cmake_build_config_package` to share common settings for
@@ -680,6 +684,51 @@ Devicetree Overlays
 ===================
 
 See :ref:`set-devicetree-overlays`.
+
+.. _application-file-suffixes:
+
+File Suffixes
+=============
+
+Zephyr applications might want to have a single code base with multiple configurations for
+different build/product variants which would necessitate different Kconfig options and devicetree
+configuration. In order to better configure this, Zephyr provides a :makevar:`FILE_SUFFIX` option
+when configuring applications that can be automatically appended to filenames. This is applied to
+Kconfig fragments and board overlays but with a fallback so that if such files do not exist, the
+files without these suffixes will be used instead.
+
+Given the following example project layout:
+
+.. code-block:: none
+
+   <app>
+   ├── CMakeLists.txt
+   ├── prj.conf
+   ├── prj_mouse.conf
+   ├── boards
+   │   ├── native_posix.overlay
+   │   └── qemu_cortex_m3_mouse.overlay
+   └── src
+       └── main.c
+
+* If this is built normally without ``FILE_SUFFIX`` being defined for ``native_posix`` then
+  ``prj.conf`` and ``boards/native_posix.overlay`` will be used.
+
+* If this is build normally without ``FILE_SUFFIX`` being defined for ``qemu_cortex_m3`` then
+  ``prj.conf`` will be used, no application devicetree overlay will be used.
+
+* If this is built with ``FILE_SUFFIX`` set to ``mouse`` for ``native_posix`` then
+  ``prj_mouse.conf`` and ``boards/native_posix.overlay`` will be used (there is no
+  ``native_posix_mouse.overlay`` file so it falls back to ``native_posix.overlay``).
+
+* If this is build with ``FILE_SUFFIX`` set to ``mouse`` for ``qemu_cortex_m3`` then
+  ``prj_mouse.conf`` will be used and ``boards/qemu_cortex_m3_mouse.overlay`` will be used.
+
+.. note::
+
+   When ``CONF_FILE`` is set in the form of ``prj_X.conf`` then the ``X`` will be used as the
+   build type. If this is combined with ``FILE_SUFFIX`` then the file suffix option will take
+   priority over the build type.
 
 Application-Specific Code
 *************************

--- a/doc/releases/migration-guide-3.6.rst
+++ b/doc/releases/migration-guide-3.6.rst
@@ -36,6 +36,9 @@ Build System
   ``target_compile_definitions(app PRIVATE _POSIX_C_SOURCE=200809L)`` to your application
   or ``zephyr_library_compile_definitions(_POSIX_C_SOURCE=200809L)`` to your library.
 
+* Build type by setting ``CONF_FILE`` to ``prj_<build>.conf`` is now deprecated, users should
+  instead use the new ``-DFILE_SUFFIX`` feature :ref:`application-file-suffixes`.
+
 Kernel
 ======
 

--- a/doc/releases/release-notes-3.6.rst
+++ b/doc/releases/release-notes-3.6.rst
@@ -183,6 +183,8 @@ Build system and infrastructure
   application Kconfig fragment file names and devicetree overlay file names, see
   :ref:`application-file-suffixes` and :ref:`sysbuild_file_suffixes` for details.
 
+* Deprecated ``CONF_FILE`` ``prj_<build>.conf`` build type.
+
 Drivers and Sensors
 *******************
 

--- a/doc/releases/release-notes-3.6.rst
+++ b/doc/releases/release-notes-3.6.rst
@@ -179,6 +179,10 @@ Build system and infrastructure
 * Added support for sysbuild setting a signing script (``SIGNING_SCRIPT``), see
   :ref:`west-extending-signing` for details.
 
+* Added support for ``FILE_SUFFIX`` in the build system which allows for adding suffixes to
+  application Kconfig fragment file names and devicetree overlay file names, see
+  :ref:`application-file-suffixes` and :ref:`sysbuild_file_suffixes` for details.
+
 Drivers and Sensors
 *******************
 

--- a/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
@@ -268,14 +268,12 @@ function(ExternalZephyrProject_Add)
       )
     endif()
 
-     # Check for sysbuild related configuration fragments.
-     # The contents of these are appended to the image existing configuration
-     # when user is not specifying custom fragments.
-    if(NOT "${CONF_FILE_BUILD_TYPE}" STREQUAL "")
-      set(sysbuild_image_conf_fragment ${sysbuild_image_conf_dir}/${ZBUILD_APPLICATION}_${CONF_FILE_BUILD_TYPE}.conf)
-    else()
-      set(sysbuild_image_conf_fragment ${sysbuild_image_conf_dir}/${ZBUILD_APPLICATION}.conf)
-    endif()
+    # Check for sysbuild related configuration fragments.
+    # The contents of these are appended to the image existing configuration
+    # when user is not specifying custom fragments.
+    zephyr_file(CONF_FILES ${sysbuild_image_conf_dir} KCONF sysbuild_image_conf_fragment
+                NAMES ${ZBUILD_APPLICATION}.conf SUFFIX ${FILE_SUFFIX}
+    )
 
     if (NOT (${ZBUILD_APPLICATION}_OVERLAY_CONFIG OR ${ZBUILD_APPLICATION}_EXTRA_CONF_FILE)
         AND EXISTS ${sysbuild_image_conf_fragment}


### PR DESCRIPTION
    cmake: Add function for file suffix checking/appending
    
    Adds a function that can be used to check if a file suffix is
    supplied and, if so, will update a variable with these filenames


    cmake: Add support for file suffixes
    
    Adds support for configuration files to use file suffixes

Alternative to #65561