### PR TITLE
llext: Some misc llext fixes

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3975,6 +3975,7 @@ zbus:
     - teburd
   collaborators:
     - lyakh
+    - pillo79
   files:
     - samples/subsys/llext/
     - include/zephyr/llext/

--- a/include/zephyr/llext/llext.h
+++ b/include/zephyr/llext/llext.h
@@ -58,8 +58,11 @@ struct llext {
 	/** Memory allocated on heap */
 	bool mem_on_heap[LLEXT_MEM_COUNT];
 
-	/** Total size of the llext memory usage */
-	size_t mem_size;
+	/** Size of each stored section */
+	size_t mem_size[LLEXT_MEM_COUNT];
+
+	/** Total llext allocation size */
+	size_t alloc_size;
 
 	/*
 	 * These are all global symbols in the extension, all of them don't

--- a/include/zephyr/llext/llext.h
+++ b/include/zephyr/llext/llext.h
@@ -121,7 +121,7 @@ struct llext_load_param {
  *
  * @param[in] loader An extension loader that provides input data and context
  * @param[in] name A string identifier for the extension
- * @param[out] ext A pointer to a statically allocated llext struct
+ * @param[out] ext This will hold the pointer to the llext struct
  * @param[in] ldr_parm Loader parameters
  *
  * @retval 0 Success

--- a/subsys/llext/llext.c
+++ b/subsys/llext/llext.c
@@ -11,6 +11,7 @@
 #include <zephyr/llext/loader.h>
 #include <zephyr/llext/llext.h>
 #include <zephyr/kernel.h>
+#include <zephyr/cache.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(llext, CONFIG_LLEXT_LOG_LEVEL);
@@ -775,6 +776,15 @@ static int llext_link(struct llext_loader *ldr, struct llext *ext, bool do_local
 			arch_elf_relocate(&rel, op_loc, link_addr);
 		}
 	}
+
+#ifdef CONFIG_CACHE_MANAGEMENT
+	/* Make sure changes to ext sections are flushed to RAM */
+	for (i = 0; i < LLEXT_MEM_COUNT; ++i) {
+		if (ext->mem[i]) {
+			arch_dcache_flush_range(ext->mem[i], ext->mem_size[i]);
+		}
+	}
+#endif
 
 	return 0;
 }

--- a/subsys/llext/llext.c
+++ b/subsys/llext/llext.c
@@ -894,6 +894,8 @@ int llext_load(struct llext_loader *ldr, const char *name, struct llext **ext,
 	int ret;
 	elf_ehdr_t ehdr;
 
+	*ext = llext_by_name(name);
+
 	k_mutex_lock(&llext_lock, K_FOREVER);
 
 	if (*ext) {

--- a/subsys/llext/llext.c
+++ b/subsys/llext/llext.c
@@ -302,6 +302,7 @@ static int llext_copy_section(struct llext_loader *ldr, struct llext *ext,
 	if (!ldr->sects[sect_idx].sh_size) {
 		return 0;
 	}
+	ext->mem_size[mem_idx] = ldr->sects[sect_idx].sh_size;
 
 	if (ldr->sects[sect_idx].sh_type != SHT_NOBITS &&
 	    IS_ENABLED(CONFIG_LLEXT_STORAGE_WRITABLE)) {
@@ -318,7 +319,7 @@ static int llext_copy_section(struct llext_loader *ldr, struct llext *ext,
 	if (!ext->mem[mem_idx]) {
 		return -ENOMEM;
 	}
-	ext->mem_size += ldr->sects[sect_idx].sh_size;
+	ext->alloc_size += ldr->sects[sect_idx].sh_size;
 
 	if (ldr->sects[sect_idx].sh_type == SHT_NOBITS) {
 		memset(ext->mem[mem_idx], 0, ldr->sects[sect_idx].sh_size);
@@ -431,7 +432,7 @@ static int llext_allocate_symtab(struct llext_loader *ldr, struct llext *ext)
 		return -ENOMEM;
 	}
 	memset(sym_tab->syms, 0, syms_size);
-	ext->mem_size += syms_size;
+	ext->alloc_size += syms_size;
 
 	return 0;
 }
@@ -801,7 +802,7 @@ static int do_llext_load(struct llext_loader *ldr, struct llext *ext,
 	memset(ldr->sect_map, 0, sect_map_sz);
 
 	ldr->sect_cnt = ldr->hdr.e_shnum;
-	ext->mem_size += sect_map_sz;
+	ext->alloc_size += sect_map_sz;
 
 	LOG_DBG("Finding ELF tables...");
 	ret = llext_find_tables(ldr);

--- a/subsys/llext/shell.c
+++ b/subsys/llext/shell.c
@@ -81,9 +81,20 @@ static void llext_name_get(size_t idx, struct shell_static_entry *entry)
 	entry->syntax = cmd.ext ? cmd.ext->name : NULL;
 	entry->help = NULL;
 	entry->subcmd = NULL;
+	entry->handler = NULL;
+	entry->args.mandatory = 0;
+	entry->args.optional = 0;
 }
-
 SHELL_DYNAMIC_CMD_CREATE(msub_llext_name, llext_name_get);
+
+static void llext_name_arg_get(size_t idx, struct shell_static_entry *entry)
+{
+	llext_name_get(idx, entry);
+	if (entry->syntax) {
+		entry->args.mandatory = 1;
+	}
+}
+SHELL_DYNAMIC_CMD_CREATE(msub_llext_name_arg, llext_name_arg_get);
 
 struct llext_shell_list {
 	const struct shell *sh;
@@ -175,12 +186,11 @@ static int cmd_llext_call_fn(const struct shell *sh, size_t argc, char *argv[])
 /* clang-format off */
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_llext,
 	SHELL_CMD(list, NULL, LLEXT_LIST_HELP, cmd_llext_list),
-	SHELL_CMD_ARG(load_hex, NULL, LLEXT_LOAD_HEX_HELP, cmd_llext_load_hex,
-		3, 0),
+	SHELL_CMD_ARG(load_hex, NULL, LLEXT_LOAD_HEX_HELP, cmd_llext_load_hex, 3, 0),
 	SHELL_CMD_ARG(unload, &msub_llext_name, LLEXT_UNLOAD_HELP, cmd_llext_unload, 2, 0),
 	SHELL_CMD_ARG(list_symbols, &msub_llext_name, LLEXT_LIST_SYMBOLS_HELP,
 		      cmd_llext_list_symbols, 2, 0),
-	SHELL_CMD_ARG(call_fn, &msub_llext_name, LLEXT_CALL_FN_HELP,
+	SHELL_CMD_ARG(call_fn, &msub_llext_name_arg, LLEXT_CALL_FN_HELP,
 		      cmd_llext_call_fn, 3, 0),
 
 	SHELL_SUBCMD_SET_END

--- a/subsys/llext/shell.c
+++ b/subsys/llext/shell.c
@@ -93,7 +93,7 @@ static int llext_shell_list_cb(struct llext *ext, void *arg)
 {
 	struct llext_shell_list *sl = arg;
 
-	shell_print(sl->sh, "| %16s | %12d |", ext->name, ext->mem_size);
+	shell_print(sl->sh, "| %16s | %12d |", ext->name, ext->alloc_size);
 	return 0;
 }
 


### PR DESCRIPTION
* 35d0dd7c661823f671ba71400ca1b76a6604da7f fixes an issue with the shell (and other users) where the `ext` parameter to `llext_load()` had to be initalized exactly to NULL for the first call, or with a pointer to the correct `struct llext` being requested in case of multiple users. Adding a search in the llext list makes this API more robust, covering the case of multiple different users.
* 3d8b406285bde88ace4c992920daa86420183536 and 653f1537d4dbc3bbd4150abb3ade4d01e66650c9 fix the issue I have been having in the last month - random crashes at function call time, with the CPU reporting undefined instructions and all types of exceptions. This was related to the Cortex-M7 data cache not being flushed after performing loads and relocations. Fix this by forcing a dcache flush on arches enabling `CONFIG_CACHE_MANAGEMENT` API. 
* 0b703040e09a03d96ccc3fe0b532ed1c9c751e8f fixes issues with the dynamic shell command implementations.
* 898adfb1427c54366925341f76f16ab1395e79cd adds me as a collaborator in the llext area, as I will be involved for a lot more.