### PR TITLE
tests: Bluetooth: add missing param to testlib

### DIFF
--- a/tests/bluetooth/common/testlib/include/testlib/att_read.h
+++ b/tests/bluetooth/common/testlib/include/testlib/att_read.h
@@ -24,8 +24,8 @@ int bt_testlib_att_read_by_handle_sync(struct net_buf_simple *result_data, uint1
 				       uint16_t offset);
 
 int bt_testlib_gatt_long_read(struct net_buf_simple *result_data, uint16_t *result_size,
-			      struct bt_conn *conn, enum bt_att_chan_opt bearer, uint16_t handle,
-			      uint16_t offset);
+			      uint16_t *result_att_mtu, struct bt_conn *conn,
+			      enum bt_att_chan_opt bearer, uint16_t handle, uint16_t offset);
 
 int bt_testlib_gatt_discover_primary(uint16_t *result_handle, uint16_t *result_end_handle,
 				     struct bt_conn *conn, const struct bt_uuid *uuid,

--- a/tests/bluetooth/common/testlib/src/att_read.c
+++ b/tests/bluetooth/common/testlib/src/att_read.c
@@ -169,8 +169,8 @@ int bt_testlib_att_read_by_handle_sync(struct net_buf_simple *result_data, uint1
 }
 
 int bt_testlib_gatt_long_read(struct net_buf_simple *result_data, uint16_t *result_size,
-			      struct bt_conn *conn, enum bt_att_chan_opt bearer, uint16_t handle,
-			      uint16_t offset)
+			      uint16_t *result_att_mtu, struct bt_conn *conn,
+			      enum bt_att_chan_opt bearer, uint16_t handle, uint16_t offset)
 {
 	int err;
 	uint16_t _result_data_size = 0;

--- a/tests/bsim/bluetooth/host/att/long_read/main.c
+++ b/tests/bsim/bluetooth/host/att/long_read/main.c
@@ -144,7 +144,7 @@ static void test_long_read(enum bt_att_chan_opt bearer, uint16_t chrc_value_hand
 		NET_BUF_SIMPLE_DEFINE(attr_value_buf, BT_ATT_MAX_ATTRIBUTE_LEN);
 
 		/* Perform the whole long read operation. */
-		EXPECT_ZERO(bt_testlib_gatt_long_read(&attr_value_buf, NULL, conn, bearer,
+		EXPECT_ZERO(bt_testlib_gatt_long_read(&attr_value_buf, NULL, NULL, conn, bearer,
 						      chrc_value_handle, 0));
 
 		/* Parse the read attribute value to verify the


### PR DESCRIPTION
The lib was refactored, but CI didn't run the tests that used it for some reason.
A parameter was forgotten.