### PR TITLE
soc: arm: nxp_s32: s32k1: unselect CPU_HAS_xCACHE

### DIFF
--- a/soc/arm/nxp_s32/s32k1/Kconfig.soc
+++ b/soc/arm/nxp_s32/s32k1/Kconfig.soc
@@ -20,48 +20,36 @@ config SOC_S32K142
 	select CPU_CORTEX_M4
 	select CPU_CORTEX_M_HAS_DWT
 	select CPU_HAS_FPU
-	select CPU_HAS_DCACHE
-	select CPU_HAS_ICACHE
 
 config SOC_S32K142W
 	bool "S32K142W"
 	select CPU_CORTEX_M4
 	select CPU_CORTEX_M_HAS_DWT
 	select CPU_HAS_FPU
-	select CPU_HAS_DCACHE
-	select CPU_HAS_ICACHE
 
 config SOC_S32K144
 	bool "S32K144"
 	select CPU_CORTEX_M4
 	select CPU_CORTEX_M_HAS_DWT
 	select CPU_HAS_FPU
-	select CPU_HAS_DCACHE
-	select CPU_HAS_ICACHE
 
 config SOC_S32K144W
 	bool "S32K144W"
 	select CPU_CORTEX_M4
 	select CPU_CORTEX_M_HAS_DWT
 	select CPU_HAS_FPU
-	select CPU_HAS_DCACHE
-	select CPU_HAS_ICACHE
 
 config SOC_S32K146
 	bool "S32K146"
 	select CPU_CORTEX_M4
 	select CPU_CORTEX_M_HAS_DWT
 	select CPU_HAS_FPU
-	select CPU_HAS_DCACHE
-	select CPU_HAS_ICACHE
 
 config SOC_S32K148
 	bool "S32K148"
 	select CPU_CORTEX_M4
 	select CPU_CORTEX_M_HAS_DWT
 	select CPU_HAS_FPU
-	select CPU_HAS_DCACHE
-	select CPU_HAS_ICACHE
 
 endchoice
 


### PR DESCRIPTION
Following changes in #64978, align `CPU_HAS_xCACHE` symbols with the CMSIS feature definitions in the device headers so that both have the same value.

Fixes #66147