### PR TITLE
include: drivers: display: verify if optional API is implemented

### DIFF
--- a/drivers/display/display_max7219.c
+++ b/drivers/display/display_max7219.c
@@ -139,20 +139,6 @@ static inline void skip_pixel(uint8_t *mask, uint8_t *data, const uint8_t **buf,
 	}
 }
 
-static int max7219_blanking_on(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return -ENOTSUP;
-}
-
-static int max7219_blanking_off(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return -ENOTSUP;
-}
-
 static int max7219_write(const struct device *dev, const uint16_t x, const uint16_t y,
 			 const struct display_buffer_descriptor *desc, const void *buf)
 {
@@ -213,25 +199,6 @@ static int max7219_write(const struct device *dev, const uint16_t x, const uint1
 	return 0;
 }
 
-static int max7219_read(const struct device *dev, const uint16_t x, const uint16_t y,
-			const struct display_buffer_descriptor *desc, void *buf)
-{
-	ARG_UNUSED(dev);
-	ARG_UNUSED(x);
-	ARG_UNUSED(y);
-	ARG_UNUSED(desc);
-	ARG_UNUSED(buf);
-
-	return -ENOTSUP;
-}
-
-static void *max7219_get_framebuffer(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return NULL;
-}
-
 static int max7219_set_brightness(const struct device *dev, const uint8_t brightness)
 {
 	int ret;
@@ -247,14 +214,6 @@ static int max7219_set_brightness(const struct device *dev, const uint8_t bright
 	}
 
 	return 0;
-}
-
-static int max7219_set_contrast(const struct device *dev, const uint8_t contrast)
-{
-	ARG_UNUSED(dev);
-	ARG_UNUSED(contrast);
-
-	return -ENOTSUP;
 }
 
 static int max7219_set_pixel_format(const struct device *dev,
@@ -296,13 +255,8 @@ static void max7219_get_capabilities(const struct device *dev, struct display_ca
 }
 
 static const struct display_driver_api max7219_api = {
-	.blanking_on = max7219_blanking_on,
-	.blanking_off = max7219_blanking_off,
 	.write = max7219_write,
-	.read = max7219_read,
-	.get_framebuffer = max7219_get_framebuffer,
 	.set_brightness = max7219_set_brightness,
-	.set_contrast = max7219_set_contrast,
 	.get_capabilities = max7219_get_capabilities,
 	.set_pixel_format = max7219_set_pixel_format,
 	.set_orientation = max7219_set_orientation,

--- a/include/zephyr/drivers/display.h
+++ b/include/zephyr/drivers/display.h
@@ -260,6 +260,7 @@ static inline int display_write(const struct device *dev, const uint16_t x,
  * @param buf Pointer to buffer array
  *
  * @retval 0 on success else negative errno code.
+ * @retval -ENOSYS if not implemented.
  */
 static inline int display_read(const struct device *dev, const uint16_t x,
 			       const uint16_t y,
@@ -268,6 +269,10 @@ static inline int display_read(const struct device *dev, const uint16_t x,
 {
 	struct display_driver_api *api =
 		(struct display_driver_api *)dev->api;
+
+	if (api->read == NULL) {
+		return -ENOSYS;
+	}
 
 	return api->read(dev, x, y, desc, buf);
 }
@@ -285,6 +290,10 @@ static inline void *display_get_framebuffer(const struct device *dev)
 {
 	struct display_driver_api *api =
 		(struct display_driver_api *)dev->api;
+
+	if (api->get_framebuffer == NULL) {
+		return NULL;
+	}
 
 	return api->get_framebuffer(dev);
 }
@@ -306,11 +315,16 @@ static inline void *display_get_framebuffer(const struct device *dev)
  * @param dev Pointer to device structure
  *
  * @retval 0 on success else negative errno code.
+ * @retval -ENOSYS if not implemented.
  */
 static inline int display_blanking_on(const struct device *dev)
 {
 	struct display_driver_api *api =
 		(struct display_driver_api *)dev->api;
+
+	if (api->blanking_on == NULL) {
+		return -ENOSYS;
+	}
 
 	return api->blanking_on(dev);
 }
@@ -325,11 +339,16 @@ static inline int display_blanking_on(const struct device *dev)
  * @param dev Pointer to device structure
  *
  * @retval 0 on success else negative errno code.
+ * @retval -ENOSYS if not implemented.
  */
 static inline int display_blanking_off(const struct device *dev)
 {
 	struct display_driver_api *api =
 		(struct display_driver_api *)dev->api;
+
+	if (api->blanking_off == NULL) {
+		return -ENOSYS;
+	}
 
 	return api->blanking_off(dev);
 }
@@ -344,12 +363,17 @@ static inline int display_blanking_off(const struct device *dev)
  * @param brightness Brightness in steps of 1/256
  *
  * @retval 0 on success else negative errno code.
+ * @retval -ENOSYS if not implemented.
  */
 static inline int display_set_brightness(const struct device *dev,
 					 uint8_t brightness)
 {
 	struct display_driver_api *api =
 		(struct display_driver_api *)dev->api;
+
+	if (api->set_brightness == NULL) {
+		return -ENOSYS;
+	}
 
 	return api->set_brightness(dev, brightness);
 }
@@ -364,11 +388,16 @@ static inline int display_set_brightness(const struct device *dev,
  * @param contrast Contrast in steps of 1/256
  *
  * @retval 0 on success else negative errno code.
+ * @retval -ENOSYS if not implemented.
  */
 static inline int display_set_contrast(const struct device *dev, uint8_t contrast)
 {
 	struct display_driver_api *api =
 		(struct display_driver_api *)dev->api;
+
+	if (api->set_contrast == NULL) {
+		return -ENOSYS;
+	}
 
 	return api->set_contrast(dev, contrast);
 }
@@ -396,6 +425,7 @@ static inline void display_get_capabilities(const struct device *dev,
  * @param pixel_format Pixel format to be used by display
  *
  * @retval 0 on success else negative errno code.
+ * @retval -ENOSYS if not implemented.
  */
 static inline int
 display_set_pixel_format(const struct device *dev,
@@ -403,6 +433,10 @@ display_set_pixel_format(const struct device *dev,
 {
 	struct display_driver_api *api =
 		(struct display_driver_api *)dev->api;
+
+	if (api->set_pixel_format == NULL) {
+		return -ENOSYS;
+	}
 
 	return api->set_pixel_format(dev, pixel_format);
 }
@@ -414,6 +448,7 @@ display_set_pixel_format(const struct device *dev,
  * @param orientation Orientation to be used by display
  *
  * @retval 0 on success else negative errno code.
+ * @retval -ENOSYS if not implemented.
  */
 static inline int display_set_orientation(const struct device *dev,
 					  const enum display_orientation


### PR DESCRIPTION
Pretty much every display driver contains several functions like this one:

static int otm8009a_set_contrast(const struct device *dev, uint8_t contrast)
{
	return -ENOTSUP;
}

Let the driver API return -ENOTSUP instead.

The pull request also contains a commit where one driver is cleaned up.
If the change is good for merge, I intend to cleanup the rest of the display drivers as well.

