### PR TITLE
soc: arm: nxp_s32: s32k1: improve code cache init

### DIFF
--- a/soc/arm/nxp_s32/s32k1/Kconfig.soc
+++ b/soc/arm/nxp_s32/s32k1/Kconfig.soc
@@ -20,36 +20,42 @@ config SOC_S32K142
 	select CPU_CORTEX_M4
 	select CPU_CORTEX_M_HAS_DWT
 	select CPU_HAS_FPU
+	select HAS_MCUX_CACHE
 
 config SOC_S32K142W
 	bool "S32K142W"
 	select CPU_CORTEX_M4
 	select CPU_CORTEX_M_HAS_DWT
 	select CPU_HAS_FPU
+	select HAS_MCUX_CACHE
 
 config SOC_S32K144
 	bool "S32K144"
 	select CPU_CORTEX_M4
 	select CPU_CORTEX_M_HAS_DWT
 	select CPU_HAS_FPU
+	select HAS_MCUX_CACHE
 
 config SOC_S32K144W
 	bool "S32K144W"
 	select CPU_CORTEX_M4
 	select CPU_CORTEX_M_HAS_DWT
 	select CPU_HAS_FPU
+	select HAS_MCUX_CACHE
 
 config SOC_S32K146
 	bool "S32K146"
 	select CPU_CORTEX_M4
 	select CPU_CORTEX_M_HAS_DWT
 	select CPU_HAS_FPU
+	select HAS_MCUX_CACHE
 
 config SOC_S32K148
 	bool "S32K148"
 	select CPU_CORTEX_M4
 	select CPU_CORTEX_M_HAS_DWT
 	select CPU_HAS_FPU
+	select HAS_MCUX_CACHE
 
 endchoice
 
@@ -430,5 +436,10 @@ config NXP_S32_FLASH_CONFIG_FDPROT
 	  devices. For program flash only devices, this byte is reserved.
 
 endif # NXP_S32_FLASH_CONFIG
+
+config NXP_S32_ENABLE_CODE_CACHE
+	bool "Code cache"
+	default y
+	depends on HAS_MCUX_CACHE
 
 endif # SOC_SERIES_S32K1XX

--- a/soc/arm/nxp_s32/s32k1/soc.c
+++ b/soc/arm/nxp_s32/s32k1/soc.c
@@ -63,7 +63,7 @@ static int soc_init(void)
 	IP_MPU->CESR = tmp;
 #endif /* !CONFIG_ARM_MPU */
 
-#if defined(CONFIG_DCACHE) && defined(CONFIG_ICACHE)
+#if defined(CONFIG_HAS_MCUX_CACHE) && defined(CONFIG_NXP_S32_ENABLE_CODE_CACHE)
 	/* Invalidate all ways */
 	IP_LMEM->PCCCR |= LMEM_PCCCR_INVW1_MASK | LMEM_PCCCR_INVW0_MASK;
 	IP_LMEM->PCCCR |= LMEM_PCCCR_GO_MASK;

--- a/soc/arm/nxp_s32/s32k1/soc.c
+++ b/soc/arm/nxp_s32/s32k1/soc.c
@@ -15,6 +15,10 @@
 #include <cmsis_core.h>
 #include <OsIf.h>
 
+#if defined(CONFIG_HAS_MCUX_CACHE)
+#include <fsl_cache.h>
+#endif
+
 #if defined(CONFIG_WDOG_INIT)
 #define WDOG_UPDATE_KEY    0xD928C520U
 
@@ -64,17 +68,7 @@ static int soc_init(void)
 #endif /* !CONFIG_ARM_MPU */
 
 #if defined(CONFIG_HAS_MCUX_CACHE) && defined(CONFIG_NXP_S32_ENABLE_CODE_CACHE)
-	/* Invalidate all ways */
-	IP_LMEM->PCCCR |= LMEM_PCCCR_INVW1_MASK | LMEM_PCCCR_INVW0_MASK;
-	IP_LMEM->PCCCR |= LMEM_PCCCR_GO_MASK;
-
-	/* Wait until the command completes */
-	while (IP_LMEM->PCCCR & LMEM_PCCCR_GO_MASK) {
-		;
-	}
-
-	/* Enable cache */
-	IP_LMEM->PCCCR |= (LMEM_PCCCR_ENCACHE_MASK);
+	L1CACHE_EnableCodeCache();
 	barrier_isync_fence_full();
 #endif
 

--- a/west.yml
+++ b/west.yml
@@ -193,7 +193,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: d0c424e1c6ef0acac3099a07280a46a24951a47a
+      revision: 1b2f3608ab0d5f2cf2a4c2973ae9f6353fb43e72
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
This is a follow up for the changes just merged as a hotfix in #66148.

Currently, Code Cache cannot be enabled because its initialization is guarded by Kconfig options which depend on CPU core caches and this is not the case for S32K1xx devices. Hence, introduce a SoC-specific Kconfig option, selected by default, to enable it.

Additionally, use the HAL cache driver to initialize the Code Cache.