### PR TITLE
drivers: clock_control: smartbond: Fix rc32k calibration

### DIFF
--- a/drivers/clock_control/clock_control_smartbond.c
+++ b/drivers/clock_control/clock_control_smartbond.c
@@ -73,8 +73,8 @@ static void smartbond_start_rc32k(void)
 {
 	if ((CRG_TOP->CLK_RC32K_REG & CRG_TOP_CLK_RC32K_REG_RC32K_ENABLE_Msk) == 0) {
 		CRG_TOP->CLK_RC32K_REG |= CRG_TOP_CLK_RC32K_REG_RC32K_ENABLE_Msk;
-		lpc_clock_state.rc32k_started = true;
 	}
+	lpc_clock_state.rc32k_started = true;
 	if (!lpc_clock_state.rc32k_ready && (CALIBRATION_INTERVAL > 0)) {
 		if (!k_work_is_pending(&calibration_work.work)) {
 			k_work_schedule(&calibration_work,


### PR DESCRIPTION
If RC32K oscillator was on during startup, calibration work was never going to actually calibrate this oscillator. It happen because lpc_clock_state.rc32k_started was only set when oscillator was turned on after if was turned off.

Now lpc_clock_state.rc32k_started is also set when rc32k is already started (possible during boot).