### PR TITLE
boards: mimxrt1040_evk: add LinkServer and Pyocd

### DIFF
--- a/boards/arm/mimxrt1040_evk/board.cmake
+++ b/boards/arm/mimxrt1040_evk/board.cmake
@@ -5,5 +5,9 @@
 #
 
 board_runner_args(jlink "--device=MIMXRT1042XXX6B")
+board_runner_args(linkserver "--device=MIMXRT1042xxxxB:MIMXRT1040-EVK")
+board_runner_args(pyocd "--target=MIMXRT1042XJM5B")
 
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/linkserver.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)


### PR DESCRIPTION
Add LinkServer and Pyocd runners for the MIMXRT1040-EVK board.