### PR TITLE
net: lwm2m: Remove dependency on firmware update pull Kconfig

### DIFF
--- a/include/zephyr/net/lwm2m.h
+++ b/include/zephyr/net/lwm2m.h
@@ -551,7 +551,6 @@ void lwm2m_firmware_set_cancel_cb_inst(uint16_t obj_inst_id, lwm2m_engine_user_c
  */
 lwm2m_engine_user_cb_t lwm2m_firmware_get_cancel_cb_inst(uint16_t obj_inst_id);
 
-#if defined(CONFIG_LWM2M_FIRMWARE_UPDATE_PULL_SUPPORT) || defined(__DOXYGEN__)
 /**
  * @brief Set data callback to handle firmware update execute events.
  *
@@ -588,8 +587,6 @@ void lwm2m_firmware_set_update_cb_inst(uint16_t obj_inst_id, lwm2m_engine_execut
  */
 lwm2m_engine_execute_cb_t lwm2m_firmware_get_update_cb_inst(uint16_t obj_inst_id);
 #endif
-#endif
-
 
 #if defined(CONFIG_LWM2M_SWMGMT_OBJ_SUPPORT) || defined(__DOXYGEN__)
 


### PR DESCRIPTION
In the LwM2M client firmware update object code, there are functions whose headers are only visible when `CONFIG_LWM2M_FIRMWARE_UPDATE_PULL_SUPPORT` is selected. However these functions are used outside the scope of the firmware update pull functionality.

For example `lwm2m_firmware_set_update_cb()` is used in

https://github.com/zephyrproject-rtos/zephyr/blob/bf652b20a9de36c95e24b41128a42d960e92dfbd/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c#L335-L338

Same with `lwm2m_firmware_get_update_cb()`, `lwm2m_firmware_set_update_cb_inst()` and `lwm2m_firmware_get_update_cb_inst()`.

This change allows to disable `CONFIG_LWM2M_FIRMWARE_UPDATE_PULL_SUPPORT` while still being able to use the firmware update object. This also saves some bytes in case pull support is not needed.