### PR TITLE
native_posix related cleanup

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -140,7 +140,7 @@ config ARCH_POSIX
 	select NATIVE_BUILD
 	select HAS_COVERAGE_SUPPORT
 	select BARRIER_OPERATIONS_BUILTIN
-	# native_posix gets its memory cleared on entry by the host OS
+	# POSIX arch based targets get their memory cleared on entry by the host OS
 	select SKIP_BSS_CLEAR
 	help
 	  POSIX (native) architecture

--- a/drivers/sensor/akm09918c/Kconfig
+++ b/drivers/sensor/akm09918c/Kconfig
@@ -16,4 +16,4 @@ config EMUL_AKM09918C
 	depends on EMUL
 	help
 	  Enable the hardware emulator for the AKM09918C. Doing so allows exercising
-	  sensor APIs for this magnetometer in native_posix and qemu.
+	  sensor APIs for this magnetometer in native_sim and qemu.

--- a/drivers/sensor/icm42688/Kconfig
+++ b/drivers/sensor/icm42688/Kconfig
@@ -19,7 +19,7 @@ config EMUL_ICM42688
 	depends on EMUL
 	help
 	  Enable the hardware emulator for the ICM42688. Doing so allows exercising
-	  sensor APIs for this IMU in native_posix and qemu.
+	  sensor APIs for this IMU in native_sim and qemu.
 
 config ICM42688_DECODER
 	bool "ICM42688 decoder logic"

--- a/drivers/serial/Kconfig.native_posix
+++ b/drivers/serial/Kconfig.native_posix
@@ -1,14 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config UART_NATIVE_POSIX
-	bool "UART driver for native_posix"
+	bool "UART driver for native_sim/posix"
 	default y
 	depends on DT_HAS_ZEPHYR_NATIVE_POSIX_UART_ENABLED
 	select SERIAL_HAS_DRIVER
 	help
 	  This enables a UART driver for the POSIX ARCH with up to 2 UARTs.
 	  For the first UART port, the driver can be configured
-	  to either connect to the terminal from which native_posix was run, or into
+	  to either connect to the terminal from which the executable was run, or into
 	  one dedicated pseudoterminal for that UART.
 
 if UART_NATIVE_POSIX
@@ -22,14 +22,14 @@ config NATIVE_UART_0_ON_OWN_PTY
 	help
 	  Connect this UART to its own pseudoterminal. This is the preferred
 	  option for users who want to use Zephyr's shell.
-	  Moreover this option does not conflict with any other native_posix
-	  backend which may use the calling shell standard input/output.
+	  Moreover this option does not conflict with any other native
+	  backend which may use the invoking shell standard input/output.
 
 config NATIVE_UART_0_ON_STDINOUT
 	bool "Connect the UART to the invoking shell stdin/stdout"
 	help
 	  Connect this UART to the stdin & stdout of the calling shell/terminal
-	  which invoked the native_posix executable. This is good enough for
+	  which invoked the native executable. This is good enough for
 	  automated testing, or when feeding from a file/pipe.
 	  Note that other, non UART messages, will also be printed to the
 	  terminal.
@@ -60,7 +60,7 @@ config NATIVE_UART_AUTOATTACH_DEFAULT_CMD
 	string "Default command to attach the UART to a new terminal"
 	default "xterm -e screen %s &"
 	help
-	  If the native_posix executable is called with the --attach_uart
+	  If the native executable is called with the --attach_uart
 	  command line option, this will be the default command which will be
 	  run to attach a new terminal to the 1st UART.
 	  Note that this command must have one, and only one, '%s' as

--- a/drivers/serial/uart_native_tty.c
+++ b/drivers/serial/uart_native_tty.c
@@ -6,9 +6,9 @@
  * command line options or at runtime.
  *
  * To learn more see Native TTY section at:
- * https://docs.zephyrproject.org/latest/boards/posix/native_posix/doc/index.html
+ * https://docs.zephyrproject.org/latest/boards/posix/native_sim/doc/index.html
  * or
- * ${ZEPHYR_BASE}/boards/posix/native_posix/doc/index.rst
+ * ${ZEPHYR_BASE}/boards/posix/native_sim/doc/index.rst
  *
  * Copyright (c) 2023 Marko Sagadin
  * SPDX-License-Identifier: Apache-2.0

--- a/drivers/timer/Kconfig.native_posix
+++ b/drivers/timer/Kconfig.native_posix
@@ -4,12 +4,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config NATIVE_POSIX_TIMER
-	bool "(POSIX) native_posix timer driver"
+	bool "(POSIX) native_sim/posix timer driver"
 	default y
 	depends on BOARD_NATIVE_POSIX
 	select TICKLESS_CAPABLE
 	select TIMER_HAS_64BIT_CYCLE_COUNTER
 	select SYSTEM_TIMER_HAS_DISABLE_SUPPORT
 	help
-	  This module implements a kernel device driver for the native_posix HW timer
+	  This module implements a kernel device driver for the native_sim/posix HW timer
 	  model

--- a/drivers/timer/native_posix_timer.c
+++ b/drivers/timer/native_posix_timer.c
@@ -5,7 +5,7 @@
  */
 
 /**
- * Driver for the timer model of the POSIX native_posix board
+ * Driver for the timer model of the POSIX native_sim/posix board
  * It provides the interfaces required by the kernel and the sanity testcases
  * It also provides a custom k_busy_wait() which can be used with the
  * POSIX arch and InfClock SOC

--- a/include/zephyr/drivers/adc/adc_emul.h
+++ b/include/zephyr/drivers/adc/adc_emul.h
@@ -38,7 +38,7 @@ extern "C" {
  *   function which will be used to obtain voltage on emulated ADC input
  *
  * An example of an appropriate Device Tree overlay file is in
- * tests/drivers/adc/adc_api/boards/native_posix.overlay
+ * tests/drivers/adc/adc_api/boards/native_sim.overlay
  *
  * An example of using emulated ADC backend API is in the file
  * tests/drivers/adc/adc_emul/src/main.c

--- a/soc/posix/inf_clock/posix_native_task.h
+++ b/soc/posix/inf_clock/posix_native_task.h
@@ -16,8 +16,8 @@ extern "C" {
 /**
  * NATIVE_TASK
  *
- * For native_posix, register a function to be called at particular moments
- * during the native_posix execution.
+ * For native targets (POSIX arch based), register a function to be called at particular moments
+ * during the native target execution.
  *
  * There is 5 choices for when the function will be called (level):
  * * PRE_BOOT_1: Will be called before the command line parameters are parsed,


### PR DESCRIPTION
Trivial changes replacing native_posix mentions with either native_sim or a more general description.

Background: This is related to the transition from native_posix to native_sim ( https://github.com/zephyrproject-rtos/zephyr/issues/65059 )