### PR TITLE
input: gpio_kbd_matrix: do not enable interrupt if there's no callbacks

### DIFF
--- a/drivers/input/input_gpio_kbd_matrix.c
+++ b/drivers/input/input_gpio_kbd_matrix.c
@@ -143,6 +143,10 @@ static void gpio_kbd_matrix_set_detect_mode(const struct device *dev, bool enabl
 		return;
 	}
 
+	if (cfg->gpio_cb == NULL) {
+		return;
+	}
+
 	for (int i = 0; i < common->row_size; i++) {
 		const struct gpio_dt_spec *gpio = &cfg->row_gpio[i];
 


### PR DESCRIPTION
Caught while writing a test for the driver, test PR coming next.

---

Change the gpio_kbd_matrix_set_detect_mode to skip setting gpio interrupts if we don't have callbacks configured. This is the case if the driver is running in poll or scan mode.