### PR TITLE
scripts: zspdx: Include modules as packages in zephyr.spdx

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1622,18 +1622,20 @@ if(CONFIG_BUILD_OUTPUT_BIN AND CONFIG_BUILD_OUTPUT_UF2)
 endif()
 
 if(CONFIG_BUILD_OUTPUT_META)
+  set(KERNEL_META_PATH  ${PROJECT_BINARY_DIR}/${KERNEL_META_NAME} CACHE INTERNAL "")
+
   list(APPEND
     post_build_commands
     COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/zephyr_module.py
             ${WEST_ARG}
             ${ZEPHYR_MODULES_ARG}
             ${EXTRA_ZEPHYR_MODULES_ARG}
-            --meta-out ${KERNEL_META_NAME}
+            --meta-out ${KERNEL_META_PATH}
             $<$<BOOL:${CONFIG_BUILD_OUTPUT_META_STATE_PROPAGATE}>:--meta-state-propagate>
   )
   list(APPEND
     post_build_byproducts
-    ${KERNEL_META_NAME}
+    ${KERNEL_META_PATH}
   )
 endif()
 

--- a/doc/develop/west/zephyr-cmds.rst
+++ b/doc/develop/west/zephyr-cmds.rst
@@ -89,6 +89,8 @@ To use this command:
    This step ensures the build directory contains CMake metadata required for
    SPDX document generation.
 
+#. Enable :file:`CONFIG_BUILD_OUTPUT_META` in your project.
+
 #. Build your application using this pre-created build directory, like so:
 
    .. code-block:: bash


### PR DESCRIPTION
The current zephyr.spdx does not contain the modules included in the build. This commit split the zephyr-sources package into multiple packages, one for each modules found by zephyr_module.py.

This PR is related to issue https://github.com/zephyrproject-rtos/zephyr/issues/53479

I run the following example:
```shell
west spdx --init -d build
west build -b frdm_k64f samples/net/cloud/mqtt_azure
west spdx -d build
``` 

This is the new output:
[zephyr.spdx.txt](https://github.com/zephyrproject-rtos/zephyr/files/13565052/zephyr.spdx.txt)

All modules reported by zephyr_module.py are included in the SPDX, so there are some package with no source file. Should we remove these empty packages (no associated source code) from the SPDX file ?
