### PR TITLE
tests: benchmark: Add case for object core stats

### DIFF
--- a/tests/benchmarks/app_kernel/testcase.yaml
+++ b/tests/benchmarks/app_kernel/testcase.yaml
@@ -10,9 +10,25 @@ tests:
     integration_platforms:
       - mps2_an385
       - qemu_x86
+  benchmark.kernel.application.objcore.stats:
+    integration_platforms:
+      - mps2_an385
+      - qemu_x86
+    extra_configs:
+      - CONFIG_OBJ_CORE=y
+      - CONFIG_OBJ_CORE_STATS=y
   benchmark.kernel.application.user:
     extra_args: CONF_FILE=prj_user.conf
     filter: CONFIG_ARCH_HAS_USERSPACE
     integration_platforms:
       - qemu_x86
       - qemu_cortex_a53
+  benchmark.kernel.application.user.objcore.stats:
+    extra_args: CONF_FILE=prj_user.conf
+    filter: CONFIG_ARCH_HAS_USERSPACE
+    integration_platforms:
+      - qemu_x86
+      - qemu_cortex_a53
+    extra_configs:
+      - CONFIG_OBJ_CORE=y
+      - CONFIG_OBJ_CORE_STATS=y

--- a/tests/benchmarks/latency_measure/testcase.yaml
+++ b/tests/benchmarks/latency_measure/testcase.yaml
@@ -21,6 +21,27 @@ tests:
         - "PROJECT EXECUTION SUCCESSFUL"
 
 
+  benchmark.kernel.latency.objcore.stats:
+    # FIXME: no DWT and no RTC_TIMER for qemu_cortex_m0
+    platform_exclude:
+      - qemu_cortex_m0
+      - m2gl025_miv
+    filter: CONFIG_PRINTK and not CONFIG_SOC_FAMILY_STM32
+    harness: console
+    integration_platforms:
+      - qemu_x86
+      - qemu_arc_em
+    extra_configs:
+      - CONFIG_OBJ_CORE=y
+      - CONFIG_OBJ_CORE_STATS=y
+    harness_config:
+      type: one_line
+      record:
+        regex: "(?P<metric>.*):(?P<cycles>.*) cycles ,(?P<nanoseconds>.*) ns"
+      regex:
+        - "PROJECT EXECUTION SUCCESSFUL"
+
+
   # Cortex-M has 24bit systick, so default 1 TICK per seconds
   # is achievable only if frequency is below 0x00FFFFFF (around 16MHz)
   # 20 Ticks per secondes allows a frequency up to 335544300Hz (335MHz)
@@ -47,6 +68,27 @@ tests:
     integration_platforms:
       - qemu_x86
       - qemu_cortex_a53
+    harness_config:
+      type: one_line
+      record:
+        regex: "(?P<metric>.*):(?P<cycles>.*) cycles ,(?P<nanoseconds>.*) ns"
+      regex:
+        - "PROJECT EXECUTION SUCCESSFUL"
+
+  # Obtain the benchmark results with object core statistics enabled for
+  # various user thread / kernel thread configurations on platforms that
+  # support user space
+  benchmark.user.latency.objcore.stats:
+    filter: CONFIG_ARCH_HAS_USERSPACE
+    timeout: 300
+    extra_args: CONF_FILE=prj_user.conf
+    harness: console
+    integration_platforms:
+      - qemu_x86
+      - qemu_cortex_a53
+    extra_configs:
+      - CONFIG_OBJ_CORE=y
+      - CONFIG_OBJ_CORE_STATS=y
     harness_config:
       type: one_line
       record:


### PR DESCRIPTION
Updates both the app_kernel and latency_measure testcase.yaml files to include a scenario involving object core statistics. This can then be used to determine (post-execution) the performance cost of using this feature by comparing its results to the scenario where it is not enabled.