### PR TITLE
kernel: Update k_sleep() and k_usleep() return values

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -467,8 +467,9 @@ __syscall int k_thread_join(struct k_thread *thread, k_timeout_t timeout);
  *
  * @param timeout Desired duration of sleep.
  *
- * @return Zero if the requested time has elapsed or the number of milliseconds
- * left to sleep, if thread was woken up by \ref k_wakeup call.
+ * @return Zero if the requested time has elapsed or if the thread was woken up
+ * by the \ref k_wakeup call, the time left to sleep rounded up to the nearest
+ * millisecond.
  */
 __syscall int32_t k_sleep(k_timeout_t timeout);
 
@@ -479,8 +480,9 @@ __syscall int32_t k_sleep(k_timeout_t timeout);
  *
  * @param ms Number of milliseconds to sleep.
  *
- * @return Zero if the requested time has elapsed or the number of milliseconds
- * left to sleep, if thread was woken up by \ref k_wakeup call.
+ * @return Zero if the requested time has elapsed or if the thread was woken up
+ * by the \ref k_wakeup call, the time left to sleep rounded up to the nearest
+ * millisecond.
  */
 static inline int32_t k_msleep(int32_t ms)
 {
@@ -499,8 +501,9 @@ static inline int32_t k_msleep(int32_t ms)
  *
  * @param us Number of microseconds to sleep.
  *
- * @return Zero if the requested time has elapsed or the number of microseconds
- * left to sleep, if thread was woken up by \ref k_wakeup call.
+ * @return Zero if the requested time has elapsed or if the thread was woken up
+ * by the \ref k_wakeup call, the time left to sleep rounded up to the nearest
+ * microsecond.
  */
 __syscall int32_t k_usleep(int32_t us);
 

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1590,7 +1590,7 @@ int32_t z_impl_k_sleep(k_timeout_t timeout)
 
 	ticks = z_tick_sleep(ticks);
 
-	int32_t ret = k_ticks_to_ms_floor64(ticks);
+	int32_t ret = k_ticks_to_ms_ceil64(ticks);
 
 	SYS_PORT_TRACING_FUNC_EXIT(k_thread, sleep, timeout, ret);
 
@@ -1614,9 +1614,11 @@ int32_t z_impl_k_usleep(int us)
 	ticks = k_us_to_ticks_ceil64(us);
 	ticks = z_tick_sleep(ticks);
 
-	SYS_PORT_TRACING_FUNC_EXIT(k_thread, usleep, us, k_ticks_to_us_floor64(ticks));
+	int32_t ret = k_ticks_to_us_ceil64(ticks);
 
-	return k_ticks_to_us_floor64(ticks);
+	SYS_PORT_TRACING_FUNC_EXIT(k_thread, usleep, us, ret);
+
+	return ret;
 }
 
 #ifdef CONFIG_USERSPACE


### PR DESCRIPTION
Updates both the k_sleep() and k_usleep() return values so that if the thread was woken up prematurely, they will return the time left to sleep rounded up to the nearest millisecond (for k_sleep) or microsecond (for k_usleep) instead of rounding down. This removes ambiguity should there be a non-zero number of remaining ticks that correlate to a time of less than 1 millisecond or 1 microsecond.

Fixes #66145