### PR TITLE
renode: Allow extend RENODE_TEST_FLAGS

### DIFF
--- a/cmake/emu/renode.cmake
+++ b/cmake/emu/renode.cmake
@@ -39,6 +39,7 @@ set(RENODE_TEST_FLAGS
   --variable UART:${RENODE_UART}
   --variable KEYWORDS:${ZEPHYR_BASE}/tests/robot/common.robot
   --results-dir ${APPLICATION_BINARY_DIR}
+  $$RENODE_TEST_FLAGS
   )
 
 add_custom_target(run_renode_test

--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -1306,6 +1306,15 @@ It's also possible to run it by `west` directly, with:
 
    $ ROBOT_FILES=shell_module.robot west build -p -b hifive1 -s samples/subsys/shell/shell_module -t run_renode_test
 
+It is possible to extend ``renode-test`` extra arguments passing the ``RENODE_TEST_FLAGS``. For
+instance, to select a tagged test to be excluded:
+
+.. code-block:: bash
+
+   $ RENODE_TEST_FLAGS="--exclude EXCLUDE" ROBOT_FILES=shell_module.robot west build -p -b hifive1 -s samples/subsys/shell/shell_module -t run_renode_test
+
+This can be used with twister in the same way.
+
 Writing Robot tests
 ===================
 


### PR DESCRIPTION
When running renode using twister or west is not possible to pass flags to renode-test application. This injects from a environment variable arguments defined by the user to tune renode-test application.

CC: @otavio