### PR TITLE
mgmt: ec_host_cmd: add PM for SPI STM32 backend

### DIFF
--- a/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_spi_stm32.c
+++ b/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_spi_stm32.c
@@ -15,6 +15,7 @@
 LOG_MODULE_REGISTER(host_cmd_spi, CONFIG_EC_HC_LOG_LEVEL);
 
 #include <stm32_ll_spi.h>
+#include <zephyr/device.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/dma/dma_stm32.h>
 #include <zephyr/drivers/dma.h>
@@ -23,6 +24,9 @@ LOG_MODULE_REGISTER(host_cmd_spi, CONFIG_EC_HC_LOG_LEVEL);
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/mgmt/ec_host_cmd/backend.h>
 #include <zephyr/mgmt/ec_host_cmd/ec_host_cmd.h>
+#include <zephyr/pm/policy.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/sys/atomic.h>
 #include <zephyr/sys/time_units.h>
 
 /* The default compatible string of a SPI devicetree node has to be replaced with the one
@@ -159,6 +163,9 @@ struct ec_host_cmd_spi_ctx {
 	struct dma_stream *dma_tx;
 	enum spi_host_command_state state;
 	int prepare_rx_later;
+#ifdef CONFIG_PM
+	ATOMIC_DEFINE(pm_policy_lock_on, 1);
+#endif /* CONFIG_PM */
 };
 
 static const uint8_t out_preamble[4] = {
@@ -259,6 +266,32 @@ static int expected_size(const struct ec_host_cmd_request_header *header)
 
 	return sizeof(*header) + header->data_len;
 }
+
+#ifdef CONFIG_PM
+static void ec_host_cmd_pm_policy_state_lock_get(struct ec_host_cmd_spi_ctx *hc_spi)
+{
+	if (!atomic_test_and_set_bit(hc_spi->pm_policy_lock_on, 0)) {
+		pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+	}
+}
+
+static void ec_host_cmd_pm_policy_state_lock_put(struct ec_host_cmd_spi_ctx *hc_spi)
+{
+	if (atomic_test_and_clear_bit(hc_spi->pm_policy_lock_on, 0)) {
+		pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+	}
+}
+#else
+static inline void ec_host_cmd_pm_policy_state_lock_get(struct ec_host_cmd_spi_ctx *hc_spi)
+{
+	ARG_UNUSED(hc_spi);
+}
+
+static void ec_host_cmd_pm_policy_state_lock_put(struct ec_host_cmd_spi_ctx *hc_spi)
+{
+	ARG_UNUSED(hc_spi);
+}
+#endif /* CONFIG_PM */
 
 static void dma_callback(const struct device *dev, void *arg, uint32_t channel, int status)
 {
@@ -588,8 +621,10 @@ void gpio_cb_nss(const struct device *port, struct gpio_callback *cb, gpio_port_
 	SPI_TypeDef *spi = cfg->spi;
 	int ret;
 
-	/* CS deasserted. Setup fo the next transaction */
+	/* CS deasserted. Setup for the next transaction */
 	if (gpio_pin_get(hc_spi->cs.port, hc_spi->cs.pin)) {
+		ec_host_cmd_pm_policy_state_lock_put(hc_spi);
+
 		/* CS asserted during processing a command. Prepare for receiving after
 		 * sending response.
 		 */
@@ -616,6 +651,8 @@ void gpio_cb_nss(const struct device *port, struct gpio_callback *cb, gpio_port_
 		int exp_size;
 
 		hc_spi->state = SPI_HOST_CMD_STATE_RECEIVING;
+		/* Don't allow system to suspend until the end of transfer. */
+		ec_host_cmd_pm_policy_state_lock_get(hc_spi);
 
 		/* Set TX register to send status */
 		tx_status(spi, EC_SPI_RECEIVING);
@@ -744,6 +781,74 @@ struct ec_host_cmd_backend *ec_host_cmd_backend_get_spi(struct gpio_dt_spec *cs)
 
 	return &ec_host_cmd_spi;
 }
+
+#ifdef CONFIG_PM_DEVICE
+static int ec_host_cmd_spi_stm32_pm_action(const struct device *dev,
+					   enum pm_device_action action)
+{
+	const struct ec_host_cmd_backend *backend = (struct ec_host_cmd_backend *)dev->data;
+	struct ec_host_cmd_spi_ctx *hc_spi = (struct ec_host_cmd_spi_ctx *)backend->ctx;
+	const struct ec_host_cmd_spi_cfg *cfg = hc_spi->spi_config;
+	int err;
+
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
+		/* Set pins to active state */
+		err = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
+		if (err < 0) {
+			return err;
+		}
+
+		/* Enable device clock */
+		err = clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
+				       (clock_control_subsys_t)&cfg->pclken[0]);
+		if (err < 0) {
+			return err;
+		}
+		/* Enable CS interrupts. */
+		gpio_pin_interrupt_configure_dt(&hc_spi->cs, GPIO_INT_EDGE_BOTH);
+
+		break;
+	case PM_DEVICE_ACTION_SUSPEND:
+#ifdef SPI_SR_BSY
+		/* Wait 10ms for the end of transaction to prevent corruption of the last
+		 * transfer
+		 */
+		WAIT_FOR((LL_SPI_IsActiveFlag_BSY(cfg->spi) == 0), 10 * USEC_PER_MSEC, NULL);
+#endif
+		/* Disable unnecessary interrupts. */
+		gpio_pin_interrupt_configure_dt(&hc_spi->cs, GPIO_INT_DISABLE);
+
+		/* Stop device clock. */
+		err = clock_control_off(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
+					(clock_control_subsys_t)&cfg->pclken[0]);
+		if (err != 0) {
+			return err;
+		}
+
+		/* Move pins to sleep state */
+		err = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_SLEEP);
+		if ((err < 0) && (err != -ENOENT)) {
+			/* If returning -ENOENT, no pins where defined for sleep mode. */
+			return err;
+		}
+
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+#endif /* CONFIG_PM_DEVICE */
+
+PM_DEVICE_DT_DEFINE(DT_CHOSEN(zephyr_host_cmd_spi_backend), ec_host_cmd_spi_stm32_pm_action);
+
+DEVICE_DT_DEFINE(DT_CHOSEN(zephyr_host_cmd_spi_backend),
+		 NULL,
+		 PM_DEVICE_DT_GET(DT_CHOSEN(zephyr_host_cmd_spi_backend)),
+		 &ec_host_cmd_spi, NULL,
+		 PRE_KERNEL_1, CONFIG_EC_HOST_CMD_INIT_PRIORITY, NULL);
 
 #ifdef CONFIG_EC_HOST_CMD_INITIALIZE_AT_BOOT
 static int host_cmd_init(void)


### PR DESCRIPTION
The SPI STM32 Host Command backend doesn't use general SPI driver, so it has to implement Power Management on its own.

The suspend procedure includes: setting pins to the sleep state, disabling device clock and disabling CS pin interrupt.