### PR TITLE
samples: logging: disable usermode for ip_k66f

### DIFF
--- a/samples/subsys/logging/logger/sample.yaml
+++ b/samples/subsys/logging/logger/sample.yaml
@@ -32,6 +32,12 @@ tests:
   sample.logger.usermode:
     integration_platforms:
       - mps2_an385
+    platform_exclude:
+      - ip_k66f
+      - bl652_dvk
+      - bl654_dvk
+      - decawave_dwm1001_dev
+      - segger_trb_stm32f407
     arch_exclude:
       - posix
     tags:


### PR DESCRIPTION
    in ip_k66f platfrom, we using rtt as debug port,
    which is conflicted with usermode. same with
    #163e9ba9a356e1a891dafd1c9c76449c3e4c913f