### PR TITLE
tests: subsys: llext configure test image writable for stm32

### DIFF
--- a/tests/subsys/llext/testcase.yaml
+++ b/tests/subsys/llext/testcase.yaml
@@ -3,12 +3,19 @@ common:
 tests:
   llext.simple.arm:
     filter: not CONFIG_CPU_HAS_MMU and not CONFIG_SOC_SERIES_S32ZE_R52
+      and not CONFIG_SOC_FAMILY_STM32
     arch_allow: arm
     extra_configs:
       - CONFIG_ARM_MPU=n
     # Broken platforms
     platform_exclude:
       - nuvoton_pfm_m487 # See #63167
+  llext.simple.arm.stm32:
+    filter: not CONFIG_CPU_HAS_MMU and CONFIG_SOC_FAMILY_STM32
+    arch_allow: arm
+    extra_configs:
+      - CONFIG_ARM_MPU=n
+      - CONFIG_CACHE_MANAGEMENT=y
   llext.simple.xtensa:
     arch_allow: xtensa
     extra_configs:


### PR DESCRIPTION
Set the CONFIG_LLEXT_STORAGE_WRITABLE especially for stm32H7 and stm32F7 platforms,
to have the elf module not defined as const (see issues/64581) else will the test fail in ARM fault

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/64581



running the tests/subsys/llext  on a stm32h7 platform:
`$ west build -p auto -b stm32h747i_disco_m7 tests/subsys/llext/`
```

[00:00:00.834,000] <inf> llext: Loaded extension hello                          
[00:00:00.840,000] <err> os: ***** MPU FAULT *****                              
[00:00:00.845,000] <err> os:   Instruction Access Violation                     
[00:00:00.851,000] <err> os: r0/a1:  0x2400349d  r1/a2:  0x0800b4a5  r2/a3:  0x0
[00:00:00.860,000] <err> os: r3/a4:  0x00000000 r12/ip:  0x08002bd9 r14/lr:  0xf
[00:00:00.869,000] <err> os:  xpsr:  0x61000000                                 
[00:00:00.874,000] <err> os: Faulting instruction address (r15/pc): 0x2400349c  
[00:00:00.882,000] <err> os: >>> ZEPHYR FATAL ERROR 0: CPU exception on CPU 0   
[00:00:00.890,000] <err> os: Current thread: 0x240000c8 (test_llext_simple)     
[00:00:00.897,000] <err> os: Halting system  
```
