### PR TITLE
tests: testinstance: enforce utf-8 write

### DIFF
--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -276,7 +276,7 @@ class TestInstance:
         if content:
             os.makedirs(subdir, exist_ok=True)
             file = os.path.join(subdir, "testsuite_extra.conf")
-            with open(file, "w") as f:
+            with open(file, "w", encoding='utf-8') as f:
                 f.write(content)
 
         return content


### PR DESCRIPTION
as in windows platfrom the format by default is not utf-8, and we will see below error

Traceback (most recent call last):
  File "...zephyr\scripts\twister", line 211, in <module>
    ret = main(options)
          ^^^^^^^^^^^^^
  File "...scripts/pylib/twister\twisterlib\twister_main.py",
    tplan.load()
  File "...scripts/pylib/twister\twisterlib\testplan.py",
    self.load_from_file(last_run, filter_platform=connected_list)
  File "...scripts/pylib/twister\twisterlib\testplan.py",
    instance.create_overlay(platform, self.options.enable_asan,
        self.options.enable_ubsan, self.options.enable_coverage,
        self.options.coverage_platform)
  File "...scripts/pylib/twister\twisterlib\testinstance.py"
    f.write(content)
 UnicodeEncodeError: 'gbk' codec can't encode character '\xf8'
 in position 64: illegal multibyte sequence