### PR TITLE
shell: correct z_shell_spaces_trim when len equal to zero

### DIFF
--- a/subsys/shell/shell_utils.c
+++ b/subsys/shell/shell_utils.c
@@ -428,7 +428,7 @@ void z_shell_spaces_trim(char *str)
 	uint16_t len = z_shell_strlen(str);
 	uint16_t shift = 0U;
 
-	if (!str) {
+	if (len == 0U) {
 		return;
 	}
 


### PR DESCRIPTION
Addresses a potential issue when the string contains only '\0', which results in z_shell_strlen(str) returning len as 0.
Since the for-loop expects len >= 1, the function now immediately returns when len == 0.
As the null check for 'str' is already handled inside z_shell_strlen(),
an additional check for 'str' is not needed.
