### PR TITLE
west.yml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -282,7 +282,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 05d11942774fc15b90af101232ec5305051216ec
+      revision: 212997395ed34ff1721f5f4461b800e81abeb68d
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  212997395ed34ff1721f5f4461b800e81abeb68d

Brings following Zephyr relevant fixes:
 - 21299739 zephyr: firmware/single_loader: Fix compile warning
 - a88e2293 zephyr: sysflash: Fix if condition for zephyr applications
 - 2a74a2b5 zephyr: io: add 'io_led_set()'
 - 8c6c6701 zephyr: io: include 'bootutil_log.h' and declare log module membership
 - d99154f4 zephyr: rename 'led_init()' to 'io_led_init()'
 - c43a20fd boot: zephyr: add support for mimxrt1040_evk

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.

Fixes #66248