### PR TITLE
drivers: pwm: mcux_ftm: check against period cycles overflow

### DIFF
--- a/drivers/pwm/pwm_mcux_ftm.c
+++ b/drivers/pwm/pwm_mcux_ftm.c
@@ -78,6 +78,11 @@ static int mcux_ftm_set_cycles(const struct device *dev, uint32_t channel,
 		return -ENOTSUP;
 	}
 
+	if (period_cycles > UINT16_MAX) {
+		LOG_ERR("Period cycles must be less or equal than %u", UINT16_MAX);
+		return -EINVAL;
+	}
+
 	if (channel >= config->channel_count) {
 		LOG_ERR("Invalid channel");
 		return -ENOTSUP;


### PR DESCRIPTION
The FTM counter modulo register (MOD) holds a 16-bit value, but PWM set_cycles API allows to set 32-bit values for the period cycles.

Fixes #66226 