### PR TITLE
Bluetooth: Mesh: Change no-opcode error message log level and allow custom RPL use settings work

### DIFF
--- a/subsys/bluetooth/mesh/access.c
+++ b/subsys/bluetooth/mesh/access.c
@@ -1424,7 +1424,7 @@ static int element_model_recv(struct bt_mesh_msg_ctx *ctx, struct net_buf_simple
 
 	op = find_op(elem, opcode, &model);
 	if (!op) {
-		LOG_ERR("No OpCode 0x%08x for elem 0x%02x", opcode, elem->rt->addr);
+		LOG_DBG("No OpCode 0x%08x for elem 0x%02x", opcode, elem->rt->addr);
 		return ACCESS_STATUS_WRONG_OPCODE;
 	}
 

--- a/subsys/bluetooth/mesh/settings.c
+++ b/subsys/bluetooth/mesh/settings.c
@@ -186,8 +186,7 @@ static void store_pending(struct k_work *work)
 {
 	LOG_DBG("");
 
-	if (IS_ENABLED(CONFIG_BT_MESH_RPL_STORAGE_MODE_SETTINGS) &&
-	    atomic_test_and_clear_bit(pending_flags, BT_MESH_SETTINGS_RPL_PENDING)) {
+	if (atomic_test_and_clear_bit(pending_flags, BT_MESH_SETTINGS_RPL_PENDING)) {
 		bt_mesh_rpl_pending_store(BT_MESH_ADDR_ALL_NODES);
 	}
 


### PR DESCRIPTION
This PR changes 2 things:
- Allows a custom RPL use pending mechanism and the mesh settings work to store pending RPL entries. `bt_mesh_rpl_pending_store` is a public API and should be implemented anyway. The custom RPL implementation has to trigger settings with the `BT_MESH_SETTINGS_RPL_PENDING` flag to ask the mesh settings work to call `bt_mesh_rpl_pending_store`.
- Converts no opcode error in the access layer to debug log. This error message may confuse when `CONFIG_BT_MESH_ACCESS_LAYER_MSG` is enabled and all messages are processed by the callback anyway.
This error message also confuses when a node is subscribed to the same address as it publishes to, which makes it generating the error message every time it publishes a message.