### PR TITLE
RT500 runtime power optimizations

### DIFF
--- a/boards/arm/mimxrt595_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt595_evk/CMakeLists.txt
@@ -6,6 +6,7 @@
 
 zephyr_library()
 zephyr_library_sources(board.c)
+zephyr_library_include_directories(.)
 
 if(CONFIG_NXP_IMX_RT5XX_BOOT_HEADER)
   if(NOT DEFINED CONFIG_BOARD_MIMXRT595_EVK)

--- a/boards/arm/mimxrt595_evk/board.h
+++ b/boards/arm/mimxrt595_evk/board.h
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2023 NXP
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define POWER_PROFILE_FRO192M_900MV 0xFF
+#define POWER_PROFILE_FRO96M_800MV  0x1
+#define POWER_PROFILE_AFTER_BOOT    0x0
+
+__ramfunc int32_t power_manager_set_profile(uint32_t power_profile);

--- a/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33.dts
+++ b/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33.dts
@@ -238,7 +238,8 @@ arduino_serial: &flexcomm12 {
 			regulator-boot-on;
 			nxp,mode0-microvolt = <1100000>;
 			nxp,mode1-microvolt = <600000>;
-			nxp,mode2-microvolt = <0>;
+			nxp,mode2-microvolt = <900000>;
+			nxp,mode3-microvolt = <800000>;
 		};
 
 		pca9420_sw2: BUCK2 {
@@ -246,7 +247,7 @@ arduino_serial: &flexcomm12 {
 			nxp,mode0-microvolt = <1800000>;
 			nxp,mode1-microvolt = <1800000>;
 			nxp,mode2-microvolt = <1800000>;
-
+			nxp,mode3-microvolt = <1800000>;
 		};
 
 		pca9420_ldo1: LDO1 {
@@ -254,6 +255,7 @@ arduino_serial: &flexcomm12 {
 			nxp,mode0-microvolt = <1800000>;
 			nxp,mode1-microvolt = <1800000>;
 			nxp,mode2-microvolt = <1800000>;
+			nxp,mode3-microvolt = <1800000>;
 		};
 
 		pca9420_ldo2: LDO2 {
@@ -261,6 +263,7 @@ arduino_serial: &flexcomm12 {
 			nxp,mode0-microvolt = <3300000>;
 			nxp,mode1-microvolt = <3300000>;
 			nxp,mode2-microvolt = <3300000>;
+			nxp,mode3-microvolt = <3300000>;
 		};
 	};
 };

--- a/soc/arm/nxp_imx/rt5xx/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/rt5xx/Kconfig.defconfig.series
@@ -1,6 +1,6 @@
 # i.MX RT5XX series configuration options
 
-# Copyright (c) 2022-2023, NXP
+# Copyright (c) 2022-2024, NXP
 # SPDX-License-Identifier: Apache-2.0
 
 if SOC_SERIES_IMX_RT5XX
@@ -11,8 +11,10 @@ config SOC_SERIES
 config ROM_START_OFFSET
 	default 0x1200 if NXP_IMX_RT5XX_BOOT_HEADER
 
+# The PVT Sensor uses IRQ #75.  For more details, see
+# https://www.nxp.com/design/design-center/software/embedded-software/application-software-packs/application-software-pack-dynamic-voltage-scaling-using-pvt-sensor:APP-SW-PACK-DVS-PVT-SENSOR
 config NUM_IRQS
-	default 74
+	default 76
 
 config ZTEST_NO_YIELD
 	default y if (PM && ZTEST)


### PR DESCRIPTION
Power profiles enable the app to dynamically switch modes and support
DVFS.  These profiles leverage the PCA9420 PMIC to change the VDDCORE
voltage, and optimize power consumption.  Two runtime profiles are
provided for the application:
* main_clk sourced from FRO192M, VDDCORE at 0.9 V
* main_clk sourced from FRO96M,  VDDCORE at 0.8 V

Both profiles use the FRO, and the FRO is retrimmed with the target
frequency when switching profiles.