### PR TITLE
MAINTAINERS: add the `Enclustra Platforms` area of maintenance

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3563,6 +3563,17 @@ STM32 Platforms:
     STM32 SOCs, dts files and related drivers. ST nucleo, disco and eval
     boards.
 
+Enclustra Platforms:
+  status: maintained
+  maintainers:
+    - fkokosinski
+  collaborators:
+    - tgorochowik
+  files:
+    - boards/enclustra/
+  labels:
+    - "platform: Enclustra"
+
 Espressif Platforms:
   status: maintained
   maintainers:

--- a/boards/enclustra/mercury_xu/mercury_xu.dts
+++ b/boards/enclustra/mercury_xu/mercury_xu.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "Mercury XU";
-	compatible = "xlnx,zynqmp";
+	compatible = "enclustra,mercury_xu";
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/enclustra/mercury_xu/mercury_xu.yaml
+++ b/boards/enclustra/mercury_xu/mercury_xu.yaml
@@ -6,4 +6,4 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
-vendor: xlnx
+vendor: enclustra


### PR DESCRIPTION
This PR:

1. Changes the vendor of this board from Xilinx to Enclustra. It also adds the `enclustra` vendor prefix to avoid potential name collisions in the future. See Enclustra Mercury XU and Mercury+ XU SoMs: https://www.enclustra.com/en/products/system-on-chip-modules/.
2. Adds the `Enclustra Platforms` area of maintenance, and assigns a maintainer and a collaborator to it.

These changes are needed so that the `mercury_xu` board is covered by at least one area of maintenance.