### PR TITLE
samples: boards: stm32 backup sram can clear its content at powerOn

### DIFF
--- a/samples/boards/stm32/backup_sram/README.rst
+++ b/samples/boards/stm32/backup_sram/README.rst
@@ -13,6 +13,12 @@ This example shows how to define a variable on the Backup SRAM. Each time the
 application runs the current value is displayed and then incremented by one. If
 VBAT is preserved, the incremented value will be shown on the next power-cycle.
 
+On stm32F2x or stm32F446 or stm32F7x or stm32F405-based
+(STM32F405/415, STM32F407/417, STM32F427/437, STM32F429/439)
+the BackUp SRAM is not cleared when the VBAT is off but when the protection level
+changes from 1 to 0. However there is a flag BACKUP_RESET_AT_POWER_ON to force
+resetting the content of the BackUp SRAM at power ON (whatever the Vbat).
+
 .. note::
 
     On most boards VBAT is typically connected to VDD thanks to a jumper.

--- a/samples/boards/stm32/backup_sram/boards/nucleo_f429zi.overlay
+++ b/samples/boards/stm32/backup_sram/boards/nucleo_f429zi.overlay
@@ -1,0 +1,9 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2023 STMicroelectronics
+ */
+
+&backup_sram{
+	status = "okay";
+};

--- a/samples/boards/stm32/backup_sram/boards/nucleo_f746zg.overlay
+++ b/samples/boards/stm32/backup_sram/boards/nucleo_f746zg.overlay
@@ -1,0 +1,9 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2023 STMicroelectronics
+ */
+
+&backup_sram{
+	status = "okay";
+};

--- a/samples/boards/stm32/backup_sram/src/main.c
+++ b/samples/boards/stm32/backup_sram/src/main.c
@@ -7,10 +7,21 @@
 #include <zephyr/device.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
+#include <stm32_ll_rcc.h>
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_backup_sram)
 #define BACKUP_DEV_COMPAT st_stm32_backup_sram
 #endif
+
+/*
+ * On stm32F2x or stm32F446 or stm32F7x or stm32F405-based
+ * (STM32F405/415, STM32F407/417, STM32F427/437, STM32F429/439)
+ * the BackUp SRAM is not resetted when the VBAT is off
+ * but when the protection level changes from 1 to 0
+ * we add a flag to force resetting the content at power ON.
+ * Flag must be 1 to clear the backup data on powerOn (whatever Vbat)
+ */
+#define BACKUP_RESET_AT_POWER_ON 0
 
 /** Value stored in backup SRAM. */
 __stm32_backup_sram_section uint32_t backup_value;
@@ -18,6 +29,13 @@ __stm32_backup_sram_section uint32_t backup_value;
 int main(void)
 {
 	const struct device *const dev = DEVICE_DT_GET_ONE(BACKUP_DEV_COMPAT);
+
+#if BACKUP_RESET_AT_POWER_ON
+	if (LL_RCC_IsActiveFlag_BORRST()) {
+		backup_value = 0;
+		LL_RCC_ClearResetFlags();
+	}
+#endif /* BACKUP_RESET_AT_POWER_ON */
 
 	if (!device_is_ready(dev)) {
 		printk("ERROR: BackUp SRAM device is not ready\n");


### PR DESCRIPTION
Depending on the stm32 device, the content of the backup SRAM is not cleared when Vbat is off. This PR adds a flag to force clearing content of the backup SRAM when powering On (whatever the Vbat)



Add the sample for running on stm32f429zi and stm32f746zg
$ west build -p auto -b nucleo_f429zi samples/boards/stm32/backup_sram/ 


- BACKUP_RESET_AT_POWER_ON  flag is not set:

```
*** Booting Zephyr OS build zephyr-v3.5.0-2679-g86b754def5da ***                
Current value in backup SRAM (0x40024000): 2145115318                           
Next reported value should be: 2145115319                                       
Keep VBAT power source and reset the board now!   
```   

- BACKUP_RESET_AT_POWER_ON  flag is  set:

```
 *** Booting Zephyr OS build zephyr-v3.5.0-2679-gadcd49cc7e8d ***
Current value in backup SRAM (0x40024000): 0
Next reported value should be: 1
Keep VBAT power source and reset the board now!
```


