### PR TITLE
drivers: sdhc: imx_usdhc: explicitly set host_io fields, add fallthrough to switch statement

### DIFF
--- a/drivers/sdhc/imx_usdhc.c
+++ b/drivers/sdhc/imx_usdhc.c
@@ -1031,7 +1031,15 @@ static int imx_usdhc_init(const struct device *dev)
 	}
 	data->dev = dev;
 	k_mutex_init(&data->access_mutex);
-	memset(&data->host_io, 0, sizeof(data->host_io));
+	/* Setup initial host IO values */
+	data->host_io.clock = 0;
+	data->host_io.bus_mode = SDHC_BUSMODE_PUSHPULL;
+	data->host_io.power_mode = SDHC_POWER_OFF;
+	data->host_io.bus_width = SDHC_BUS_WIDTH1BIT;
+	data->host_io.timing = SDHC_TIMING_LEGACY;
+	data->host_io.driver_type = SD_DRIVER_TYPE_B;
+	data->host_io.signal_voltage = SD_VOL_3_3_V;
+
 	return k_sem_init(&data->transfer_sem, 0, 1);
 }
 

--- a/drivers/sdhc/imx_usdhc.c
+++ b/drivers/sdhc/imx_usdhc.c
@@ -404,6 +404,7 @@ static int imx_usdhc_set_io(const struct device *dev, struct sdhc_io *ios)
 		case SDHC_TIMING_DDR52:
 			/* Enable DDR mode */
 			USDHC_EnableDDRMode(cfg->base, true, 0);
+			__fallthrough;
 		case SDHC_TIMING_SDR12:
 		case SDHC_TIMING_SDR25:
 			pinctrl_apply_state(cfg->pincfg, PINCTRL_STATE_SLOW);


### PR DESCRIPTION
This PR contains the following fixes for the imx_usdhc driver:

drivers: sdhc: imx_usdhc: add explicit fallthrough to I/O timing setup

DDR50/DDR52 modes should use PINCTRL_STATE_SLOW (50MHz), so the lack of a
break statement after enabling DDR mode is expected. Add an explicit
__fallthrough to resolve the issue flagged by coverity scan

Fixes #65324

drivers: sdhc: imx_usdhc: explicitly set host_io fields

Explicitly set host_io fields, instead of using memset(). This way the
fields should have values that are defined in the enum types for each
field.

Fixes #63130