### PR TITLE
modem: cmux: Patch resync mechanism

### DIFF
--- a/subsys/modem/modem_cmux.c
+++ b/subsys/modem/modem_cmux.c
@@ -548,10 +548,16 @@ static void modem_cmux_on_frame(struct modem_cmux *cmux)
 	modem_cmux_on_dlci_frame(cmux);
 }
 
+static void modem_cmux_transmit_resync(struct modem_cmux *cmux)
+{
+	static const uint8_t resync[3] = {0xF9, 0xF9, 0xF9};
+
+	modem_pipe_transmit(cmux->pipe, resync, sizeof(resync));
+}
+
 static void modem_cmux_process_received_byte(struct modem_cmux *cmux, uint8_t byte)
 {
 	uint8_t fcs;
-	static const uint8_t resync[3] = {0xF9, 0xF9, 0xF9};
 
 	switch (cmux->receive_state) {
 	case MODEM_CMUX_RECEIVE_STATE_SOF:
@@ -560,10 +566,7 @@ static void modem_cmux_process_received_byte(struct modem_cmux *cmux, uint8_t by
 			break;
 		}
 
-		/* Send resync flags */
-		modem_pipe_transmit(cmux->pipe, resync, sizeof(resync));
-
-		/* Await resync flags */
+		modem_cmux_transmit_resync(cmux);
 		cmux->receive_state = MODEM_CMUX_RECEIVE_STATE_RESYNC_0;
 		break;
 
@@ -578,6 +581,7 @@ static void modem_cmux_process_received_byte(struct modem_cmux *cmux, uint8_t by
 		if (byte == 0xF9) {
 			cmux->receive_state = MODEM_CMUX_RECEIVE_STATE_RESYNC_2;
 		} else {
+			modem_cmux_transmit_resync(cmux);
 			cmux->receive_state = MODEM_CMUX_RECEIVE_STATE_RESYNC_0;
 		}
 
@@ -587,6 +591,7 @@ static void modem_cmux_process_received_byte(struct modem_cmux *cmux, uint8_t by
 		if (byte == 0xF9) {
 			cmux->receive_state = MODEM_CMUX_RECEIVE_STATE_RESYNC_3;
 		} else {
+			modem_cmux_transmit_resync(cmux);
 			cmux->receive_state = MODEM_CMUX_RECEIVE_STATE_RESYNC_0;
 		}
 


### PR DESCRIPTION
The CMUX resync mechanism can get stuck between states MODEM_CMUX_RECEIVE_STATE_RESYNC_0 and
MODEM_CMUX_RECEIVE_STATE_RESYNC_1 if the resync flags, which are sent only once in state MODEM_CMUX_RECEIVE_STATE_SOF, are not responded to, or the response is lost.

This patch ensures resync flags are sent from states MODEM_CMUX_RECEIVE_STATE_SOF, MODEM_CMUX_RECEIVE_STATE_RESYNC_1 and MODEM_CMUX_RECEIVE_STATE_RESYNC_2 if its determined that the resync flags are not being responded to.
