### PR TITLE
sensors: Add bandwidth, self_test attributes

### DIFF
--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -337,6 +337,10 @@ enum sensor_attribute {
 
 	/** Hardware batch duration in ticks */
 	SENSOR_ATTR_BATCH_DURATION,
+	/** Control a sensor's self-test feature. */
+	SENSOR_ATTR_SELF_TEST,
+	/** Control a sensor's bandwidth and/or filtering settings. */
+	SENSOR_ATTR_BANDWIDTH,
 
 	/**
 	 * Number of all common sensor attributes.


### PR DESCRIPTION
I'd like to propose adding two new common sensor attributes to `sensor.h`. These could arguably be squeezed into other attributes, but I think these are common enough to warrant having their own.

  * `SENSOR_ATTR_SELF_TEST` - Many sensors have on-board self test functions that can stimulate the sensor with a known input, allowing driver to determine calibration info.

  * `SENSOR_ATTR_BANDWIDTH` - Many sensors (especially motion sensors) have bandwidth and filtering settings to control sample processing/conditioning. This is usually independent of the sampling frequency (aka output data rate)