### PR TITLE
timer: ambiq_stimer:  fixing disabling tickless not working issue

### DIFF
--- a/drivers/timer/ambiq_stimer.c
+++ b/drivers/timer/ambiq_stimer.c
@@ -142,7 +142,10 @@ static int stimer_init(void)
 	irq_enable(TIMER_IRQ);
 
 	am_hal_stimer_int_enable(AM_HAL_STIMER_INT_COMPAREA);
-
+	/* Start timer with period CYC_PER_TICK if tickless is not enabled */
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		am_hal_stimer_compare_delta_set(0, CYC_PER_TICK);
+	}
 	return 0;
 }
 


### PR DESCRIPTION
There's an issue with ambiq_stimer driver: disabling CONFIG_TICKLESS_KERNEL the OS tick is not work

Verified with test sample: zephyr\tests\kernel\timer\timer_api after disabling CONFIG_TICKLESS_KERNEL 

Fail sympton is, the sample only prints banner and do not print following test logs.

Root cause is OS tick is not correctly generated, Fix is in init function, start stimer with period CYC_PER_TICK if tickless is not enabled.