### PR TITLE
drivers: i2c: i2c_ambiq: fixing error in bitrate setting

### DIFF
--- a/drivers/i2c/i2c_ambiq.c
+++ b/drivers/i2c/i2c_ambiq.c
@@ -139,7 +139,7 @@ static int i2c_ambiq_init(const struct device *dev)
 
 	ret = config->pwr_func();
 
-	ret = i2c_ambiq_configure(dev, I2C_MODE_CONTROLLER | I2C_SPEED_SET(bitrate_cfg));
+	ret = i2c_ambiq_configure(dev, I2C_MODE_CONTROLLER | bitrate_cfg);
 
 	ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
 


### PR DESCRIPTION
During init i2c_ambiq device, the bitrate calculation is not correct, results in incorrect  device speed, or failed to configure i2c device if clock-frequency is set to higher than I2C_BITRATE_STANDARD

This issue is found while using this device on apollo4p_evb board, fail sympton is as below:
1. When configuring clock-frequency = <I2C_BITRATE_STANDARD>, the real clock on board measured through Salea is around 400k
2. When configuring clock-frequency = <I2C_BITRATE_FAST>, the I2C device is failed to initialize.
