### PR TITLE
linker: Generate snippets files for dtcm and itcm

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -1169,6 +1169,8 @@ endfunction(zephyr_check_compiler_flag_hardcoded)
 #    DATA_SECTIONS Inside the RAMABLE_REGION GROUP, initialized.
 #    RAMFUNC_SECTION Inside the RAMFUNC RAMABLE_REGION GROUP, not initialized.
 #    NOCACHE_SECTION Inside the NOCACHE section
+#    ITCM_SECTION  Inside the itcm section.
+#    DTCM_SECTION  Inside the dtcm data section.
 #    SECTIONS      Near the end of the file. Don't use this when linking into
 #                  RAMABLE_REGION, use RAM_SECTIONS instead.
 #    PINNED_RODATA Similar to RODATA but pinned in memory.
@@ -1183,8 +1185,9 @@ endfunction(zephyr_check_compiler_flag_hardcoded)
 # Use NOINIT, RWDATA, and RODATA unless they don't work for your use case.
 #
 # When placing into NOINIT, RWDATA, RODATA, ROM_START, RAMFUNC_SECTION,
-# NOCACHE_SECTION the contents of the files will be placed inside
-# an output section, so assume the section definition is already present, e.g.:
+# NOCACHE_SECTION, DTCM_SECTION or ITCM_SECTION the contents of the files will
+# be placed inside an output section, so assume the section definition is
+# already present, e.g.:
 #    _mysection_start = .;
 #    KEEP(*(.mysection));
 #    _mysection_end = .;
@@ -1219,6 +1222,8 @@ function(zephyr_linker_sources location)
   set(rodata_path        "${snippet_base}/snippets-rodata.ld")
   set(ramfunc_path       "${snippet_base}/snippets-ramfunc-section.ld")
   set(nocache_path       "${snippet_base}/snippets-nocache-section.ld")
+  set(itcm_path          "${snippet_base}/snippets-itcm-section.ld")
+  set(dtcm_path          "${snippet_base}/snippets-dtcm-section.ld")
 
   set(pinned_ram_sections_path  "${snippet_base}/snippets-pinned-ram-sections.ld")
   set(pinned_data_sections_path "${snippet_base}/snippets-pinned-data-sections.ld")
@@ -1236,6 +1241,8 @@ function(zephyr_linker_sources location)
     file(WRITE ${rodata_path} "")
     file(WRITE ${ramfunc_path} "")
     file(WRITE ${nocache_path} "")
+    file(WRITE ${itcm_path} "")
+    file(WRITE ${dtcm_path} "")
     file(WRITE ${pinned_ram_sections_path} "")
     file(WRITE ${pinned_data_sections_path} "")
     file(WRITE ${pinned_rodata_path} "")
@@ -1261,6 +1268,10 @@ function(zephyr_linker_sources location)
     set(snippet_path "${ramfunc_path}")
   elseif("${location}" STREQUAL "NOCACHE_SECTION")
     set(snippet_path "${nocache_path}")
+  elseif("${location}" STREQUAL "ITCM_SECTION")
+    set(snippet_path "${itcm_path}")
+  elseif("${location}" STREQUAL "DTCM_SECTION")
+    set(snippet_path "${dtcm_path}")
   elseif("${location}" STREQUAL "PINNED_RAM_SECTIONS")
     set(snippet_path "${pinned_ram_sections_path}")
   elseif("${location}" STREQUAL "PINNED_DATA_SECTIONS")

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -1269,8 +1269,20 @@ function(zephyr_linker_sources location)
   elseif("${location}" STREQUAL "NOCACHE_SECTION")
     set(snippet_path "${nocache_path}")
   elseif("${location}" STREQUAL "ITCM_SECTION")
+    dt_has_chosen(HAS_ITCM PROPERTY "zephyr,itcm")
+    if(NOT HAS_ITCM)
+      message(FATAL_ERROR "Trying to link snippet into itcm but no itcm available. "
+              "Add `zephyr,itcm` to the device tree if supported on your device or choose another "
+              "location.")
+    endif()
     set(snippet_path "${itcm_path}")
   elseif("${location}" STREQUAL "DTCM_SECTION")
+    dt_has_chosen(HAS_DTCM PROPERTY "zephyr,dtcm")
+    if(NOT HAS_DTCM)
+      message(FATAL_ERROR "Trying to link snippet into dtcm but no dtcm available. "
+              "Add `zephyr,dtcm` to the device tree if supported on your device or choose another "
+              "location.")
+    endif()
     set(snippet_path "${dtcm_path}")
   elseif("${location}" STREQUAL "PINNED_RAM_SECTIONS")
     set(snippet_path "${pinned_ram_sections_path}")

--- a/include/zephyr/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/zephyr/arch/arm/cortex_m/scripts/linker.ld
@@ -396,6 +396,11 @@ GROUP_START(ITCM)
 		__itcm_start = .;
 		*(.itcm)
 		*(".itcm.*")
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function. */
+#include <snippets-itcm-section.ld>
+
 		__itcm_end = .;
 	} GROUP_LINK_IN(ITCM AT> ROMABLE_REGION)
 
@@ -430,6 +435,11 @@ GROUP_START(DTCM)
 		__dtcm_data_start = .;
 		*(.dtcm_data)
 		*(".dtcm_data.*")
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function. */
+#include <snippets-dtcm-section.ld>
+
 		__dtcm_data_end = .;
 	} GROUP_LINK_IN(DTCM AT> ROMABLE_REGION)
 

--- a/include/zephyr/arch/riscv/common/linker.ld
+++ b/include/zephyr/arch/riscv/common/linker.ld
@@ -328,6 +328,11 @@ GROUP_START(ITCM)
 		__itcm_start = .;
 		*(.itcm)
 		*(".itcm.*")
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function. */
+#include <snippets-itcm-section.ld>
+
 		__itcm_end = .;
 	} GROUP_LINK_IN(ITCM AT> ROMABLE_REGION)
 
@@ -362,6 +367,11 @@ GROUP_START(DTCM)
 		__dtcm_data_start = .;
 		*(.dtcm_data)
 		*(".dtcm_data.*")
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function. */
+#include <snippets-dtcm-section.ld>
+
 		__dtcm_data_end = .;
 	} GROUP_LINK_IN(DTCM AT> ROMABLE_REGION)
 

--- a/soc/riscv/andes_v5/ae350/linker.ld
+++ b/soc/riscv/andes_v5/ae350/linker.ld
@@ -323,6 +323,11 @@ GROUP_START(ITCM)
 		__itcm_start = .;
 		*(.itcm)
 		*(".itcm.*")
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function. */
+#include <snippets-itcm-section.ld>
+
 		__itcm_end = .;
 	} GROUP_LINK_IN(ITCM AT> ROMABLE_REGION)
 
@@ -357,6 +362,11 @@ GROUP_START(DTCM)
 		__dtcm_data_start = .;
 		*(.dtcm_data)
 		*(".dtcm_data.*")
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function. */
+#include <snippets-dtcm-section.ld>
+
 		__dtcm_data_end = .;
 	} GROUP_LINK_IN(DTCM AT> ROMABLE_REGION)
 


### PR DESCRIPTION
This PR allows to link  code and data  blocks, e.g. the vector table, into the tightly coupled memory (itcm and dtcm, resp. ilm and dlm) using the cmake function `zephyr_linker_sources`.