### PR TITLE
drivers: serial: pl011: Fix bug in support of Ambiq UART

### DIFF
--- a/drivers/serial/uart_pl011_ambiq.h
+++ b/drivers/serial/uart_pl011_ambiq.h
@@ -11,6 +11,7 @@
 #include <zephyr/kernel.h>
 
 #include "uart_pl011_registers.h"
+#include <am_mcu_apollo.h>
 
 #define PWRCTRL_MAX_WAIT_US 5
 
@@ -61,7 +62,7 @@ static inline int clk_enable_ambiq_uart(const struct device *dev, uint32_t clk)
 		uint32_t addr = DT_REG_ADDR(DT_INST_PHANDLE(n, ambiq_pwrcfg)) +                    \
 				DT_INST_PHA(n, ambiq_pwrcfg, offset);                              \
 		sys_write32((sys_read32(addr) | DT_INST_PHA(n, ambiq_pwrcfg, mask)), addr);        \
-		k_busy_wait(PWRCTRL_MAX_WAIT_US);                                                  \
+		am_hal_delay_us(PWRCTRL_MAX_WAIT_US);                                              \
 		return 0;                                                                          \
 	}
 


### PR DESCRIPTION
Ambiq UART requires specific busy wait during initialization for propagating powering control registers, original k_busy_wait() used here generated a dead loop because k_busy_wait() relays on timer, who's driver is initialized after UART(UART init in PRE_KERNEL_1, timer init in PRE_KERNEL_2), use delay function in Ambiq HAL to replace k_busy_wait() is much suitable here.

This issue impacts the OS's normal startup in apollo4p SOC