### PR TITLE
mgmt/osdp: Fix compilation when CONFIG_OSDP_SC_ENABLED enabled

### DIFF
--- a/samples/subsys/mgmt/osdp/control_panel/prj_sc.conf
+++ b/samples/subsys/mgmt/osdp/control_panel/prj_sc.conf
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2020 Siddharth Chandrasekaran <siddharth@embedjournal.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_PRINTK=y
+CONFIG_LOG=y
+CONFIG_GPIO=y
+
+# OSDP config
+CONFIG_OSDP=y
+CONFIG_OSDP_MODE_CP=y
+
+# Secure Channel
+CONFIG_ENTROPY_GENERATOR=y
+CONFIG_OSDP_SC_ENABLED=y
+
+CONFIG_OSDP_LOG_LEVEL=4

--- a/samples/subsys/mgmt/osdp/control_panel/sample.yaml
+++ b/samples/subsys/mgmt/osdp/control_panel/sample.yaml
@@ -1,12 +1,18 @@
 sample:
   description: OSDP Control Panel Sample
   name: osdp
+common:
+  tags: osdp
+  depends_on: gpio
+  filter: dt_enabled_alias_with_parent_compat("led0", "gpio-leds") and
+          dt_chosen_enabled("zephyr,osdp-uart") and CONFIG_SERIAL
+  harness: osdp
+  integration_platforms:
+    - stm32_min_dev_black
 tests:
   sample.mgmt.osdp.control_panel:
-    tags: osdp
-    depends_on: gpio
-    filter: dt_enabled_alias_with_parent_compat("led0", "gpio-leds") and
-            dt_chosen_enabled("zephyr,osdp-uart") and CONFIG_SERIAL
-    harness: osdp
-    integration_platforms:
-      - stm32_min_dev_black
+    extra_args: CONF_FILE=prj.conf
+
+  sample.mgmt.osdp.control_panel_sc:
+    build_only: true
+    extra_args: CONF_FILE=prj_sc.conf

--- a/samples/subsys/mgmt/osdp/peripheral_device/prj_sc.conf
+++ b/samples/subsys/mgmt/osdp/peripheral_device/prj_sc.conf
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2020 Siddharth Chandrasekaran <siddharth@embedjournal.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_PRINTK=y
+CONFIG_LOG=y
+CONFIG_GPIO=y
+
+# OSDP config
+CONFIG_OSDP=y
+CONFIG_OSDP_MODE_PD=y
+
+# Secure Channel
+CONFIG_ENTROPY_GENERATOR=y
+CONFIG_OSDP_SC_ENABLED=y
+
+CONFIG_OSDP_LOG_LEVEL=4

--- a/samples/subsys/mgmt/osdp/peripheral_device/sample.yaml
+++ b/samples/subsys/mgmt/osdp/peripheral_device/sample.yaml
@@ -1,12 +1,18 @@
 sample:
   description: OSDP Peripheral Device Sample
   name: osdp
+common:
+  tags: osdp
+  depends_on: gpio
+  filter: dt_enabled_alias_with_parent_compat("led0", "gpio-leds") and
+          dt_chosen_enabled("zephyr,osdp-uart") and CONFIG_SERIAL
+  harness: osdp
+  integration_platforms:
+    - stm32_min_dev_black
 tests:
   sample.mgmt.osdp.peripheral_device:
-    tags: osdp
-    depends_on: gpio
-    filter: dt_enabled_alias_with_parent_compat("led0", "gpio-leds") and
-            dt_chosen_enabled("zephyr,osdp-uart") and CONFIG_SERIAL
-    harness: osdp
-    integration_platforms:
-      - stm32_min_dev_black
+    extra_args: CONF_FILE=prj.conf
+
+  sample.mgmt.osdp.peripheral_device_sc:
+    build_only: true
+    extra_args: CONF_FILE=prj_sc.conf

--- a/subsys/mgmt/osdp/src/osdp_phy.c
+++ b/subsys/mgmt/osdp/src/osdp_phy.c
@@ -193,8 +193,7 @@ int osdp_phy_packet_finalize(struct osdp_pd *pd, uint8_t *buf,
 	uint8_t *data;
 	int i, data_len;
 
-	if (sc_is_active(pd) &&
-	    (pkt->control & PKT_CONTROL_SCB) && pkt->data[1] >= SCS_15)
+	if (sc_is_active(pd) && (pkt->control & PKT_CONTROL_SCB) && pkt->data[1] >= SCS_15) {
 		if (pkt->data[1] == SCS_17 || pkt->data[1] == SCS_18) {
 			/**
 			 * Only the data portion of message (after id byte)

--- a/subsys/mgmt/osdp/src/osdp_phy.c
+++ b/subsys/mgmt/osdp/src/osdp_phy.c
@@ -191,7 +191,7 @@ int osdp_phy_packet_finalize(struct osdp_pd *pd, uint8_t *buf,
 
 #ifdef CONFIG_OSDP_SC_ENABLED
 	uint8_t *data;
-	int i, data_len;
+	int data_len;
 
 	if (sc_is_active(pd) && (pkt->control & PKT_CONTROL_SCB) && pkt->data[1] >= SCS_15) {
 		if (pkt->data[1] == SCS_17 || pkt->data[1] == SCS_18) {

--- a/subsys/mgmt/osdp/src/osdp_sc.c
+++ b/subsys/mgmt/osdp/src/osdp_sc.c
@@ -25,7 +25,7 @@ static const uint8_t osdp_scbk_default[16] = {
 static void osdp_memzero(void *mem, size_t size)
 {
 	size_t i;
-	volatile uin8_t *p = mem;
+	volatile uint8_t *p = mem;
 
 	for (i = 0; i < size; i++) {
 		p[i] = 0;


### PR DESCRIPTION
The 2 issues were found after CONFIG_OSDP_SC_ENABLED was enabled:
- missing curly brace after if
- typo in type name