### PR TITLE
tests: fatal: Add message explaining OOPS

### DIFF
--- a/tests/kernel/fatal/message_capture/src/main.c
+++ b/tests/kernel/fatal/message_capture/src/main.c
@@ -28,6 +28,8 @@ void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
 		k_fatal_halt(reason);
 	}
 
+	printk("Fatal error expected as part of test case.\n");
+
 	expected_reason = -1;
 }
 


### PR DESCRIPTION
Add message explaining the cause of the OOPS like it is done in many other cases.