### PR TITLE
doc: pyocd: Add CMSIS DAP Onboard Debug Probe support

### DIFF
--- a/doc/develop/flash_debug/host-tools.rst
+++ b/doc/develop/flash_debug/host-tools.rst
@@ -321,6 +321,8 @@ Started Guide. pyOCD includes support for Zephyr RTOS-awareness.
 
 These debug host tools are compatible with the following debug probes:
 
+- :ref:`lpclink2-cmsis-onboard-debug-probe`
+- :ref:`mcu-link-cmsis-onboard-debug-probe`
 - :ref:`opensda-daplink-onboard-debug-probe`
 - :ref:`stlink-v21-onboard-debug-probe`
 


### PR DESCRIPTION
Add the CMSIS DAP Onboard Debug Probes to the list of supported probes by pyOCD.