### PR TITLE
include/zephyr/net: Add 'brief' to group description

### DIFF
--- a/include/zephyr/net/wifi.h
+++ b/include/zephyr/net/wifi.h
@@ -12,7 +12,7 @@
 
 /**
  * @defgroup wifi_mgmt Wi-Fi Management
- * Wi-Fi Management API.
+ * @brief Wi-Fi Management API.
  * @ingroup networking
  * @{
  */


### PR DESCRIPTION
So it doesn't extend previous directive.

This is cherry-picked from #61994 as that PR might take some time to get merged and the change makes sense.
FYI @edersondisouza 