### PR TITLE
modules: lvgl: support link mem pool to customer section

### DIFF
--- a/modules/lvgl/Kconfig.memory
+++ b/modules/lvgl/Kconfig.memory
@@ -38,6 +38,15 @@ config LV_Z_MEM_POOL_SIZE
 	help
 	  Size of the memory pool in bytes
 
+config LV_Z_MEMORY_POOL_CUSTOM_SECTION
+	bool "Link lvgl memory pool to custom section"
+	depends on LV_Z_MEM_POOL_SYS_HEAP
+	help
+	  Place LVGL memory pool in custom section, with tag ".lvgl_heap".
+	  This can be used by custom linker scripts to relocate the LVGL
+	  memory pool to a custom location, such as tightly coupled or
+	  external memory.
+
 config LV_Z_VDB_SIZE
 	int "Rendering buffer size"
 	default 100 if LV_Z_FULL_REFRESH

--- a/modules/lvgl/lvgl_mem.c
+++ b/modules/lvgl/lvgl_mem.c
@@ -10,7 +10,12 @@
 #include <zephyr/init.h>
 #include <zephyr/sys/sys_heap.h>
 
-static char lvgl_heap_mem[CONFIG_LV_Z_MEM_POOL_SIZE] __aligned(8);
+static char lvgl_heap_mem[CONFIG_LV_Z_MEM_POOL_SIZE]
+#ifdef CONFIG_LV_Z_MEMORY_POOL_CUSTOM_SECTION
+	Z_GENERIC_SECTION(.lvgl_heap)
+#endif
+		__aligned(8);
+
 static struct sys_heap lvgl_heap;
 static struct k_spinlock lvgl_heap_lock;
 


### PR DESCRIPTION
Add a Kconfig LV_Z_MEMORY_POOL_CUSTOM_SECTION to support change the lvgl heap pool to a custom section ".lvgl_heap".