### PR TITLE
boards: arm: change display driver to ltdc on stm32f429i_disc1

### DIFF
--- a/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
+++ b/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
@@ -20,7 +20,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,ccm = &ccm0;
-		zephyr,display = &ili9341;
+		zephyr,display = &ltdc;
 	};
 
 	sdram2: sdram@d0000000 {


### PR DESCRIPTION
Change display driver to ltdc on stm32f429i_disc1 board.