### PR TITLE
Remove (optional) dummy functions for the display API

### DIFF
--- a/drivers/display/display_hx8394.c
+++ b/drivers/display/display_hx8394.c
@@ -415,21 +415,6 @@ static int hx8394_write(const struct device *dev, const uint16_t x,
 	return 0;
 }
 
-static int hx8394_read(const struct device *dev, const uint16_t x,
-			const uint16_t y,
-			const struct display_buffer_descriptor *desc,
-			void *buf)
-{
-	LOG_WRN("Read not implemented");
-	return -ENOTSUP;
-}
-
-static void *hx8394_get_framebuffer(const struct device *dev)
-{
-	LOG_WRN("Direct framebuffer access not implemented");
-	return NULL;
-}
-
 static int hx8394_blanking_off(const struct device *dev)
 {
 	const struct hx8394_config *config = dev->config;
@@ -450,20 +435,6 @@ static int hx8394_blanking_on(const struct device *dev)
 	} else {
 		return -ENOTSUP;
 	}
-}
-
-static int hx8394_set_brightness(const struct device *dev,
-				  const uint8_t brightness)
-{
-	LOG_WRN("Set brightness not implemented");
-	return -ENOTSUP;
-}
-
-static int hx8394_set_contrast(const struct device *dev,
-				const uint8_t contrast)
-{
-	LOG_WRN("Set contrast not implemented");
-	return -ENOTSUP;
 }
 
 static int hx8394_set_pixel_format(const struct device *dev,
@@ -526,10 +497,6 @@ static const struct display_driver_api hx8394_api = {
 	.blanking_on = hx8394_blanking_on,
 	.blanking_off = hx8394_blanking_off,
 	.write = hx8394_write,
-	.read = hx8394_read,
-	.get_framebuffer = hx8394_get_framebuffer,
-	.set_brightness = hx8394_set_brightness,
-	.set_contrast = hx8394_set_contrast,
 	.get_capabilities = hx8394_get_capabilities,
 	.set_pixel_format = hx8394_set_pixel_format,
 	.set_orientation = hx8394_set_orientation,

--- a/drivers/display/display_intel_multibootfb.c
+++ b/drivers/display/display_intel_multibootfb.c
@@ -26,33 +26,6 @@ struct framebuf_dev_data {
 	uint32_t pitch;
 };
 
-static int framebuf_blanking_on(const struct device *dev)
-{
-	return -ENOTSUP;
-}
-
-static int framebuf_blanking_off(const struct device *dev)
-{
-	return -ENOTSUP;
-}
-
-static void *framebuf_get_framebuffer(const struct device *dev)
-{
-	return NULL;
-}
-
-static int framebuf_set_brightness(const struct device *dev,
-				   const uint8_t brightness)
-{
-	return -ENOTSUP;
-}
-
-static int framebuf_set_contrast(const struct device *dev,
-				 const uint8_t contrast)
-{
-	return -ENOTSUP;
-}
-
 static int framebuf_set_pixel_format(const struct device *dev,
 				     const enum display_pixel_format format)
 {
@@ -133,13 +106,8 @@ static int framebuf_read(const struct device *dev, const uint16_t x,
 }
 
 const struct display_driver_api framebuf_display_api = {
-	.blanking_on = framebuf_blanking_on,
-	.blanking_off = framebuf_blanking_off,
 	.write = framebuf_write,
 	.read = framebuf_read,
-	.get_framebuffer = framebuf_get_framebuffer,
-	.set_brightness = framebuf_set_brightness,
-	.set_contrast = framebuf_set_contrast,
 	.get_capabilities = framebuf_get_capabilities,
 	.set_pixel_format = framebuf_set_pixel_format,
 	.set_orientation = framebuf_set_orientation

--- a/drivers/display/display_mcux_elcdif.c
+++ b/drivers/display/display_mcux_elcdif.c
@@ -211,27 +211,6 @@ static int mcux_elcdif_write(const struct device *dev, const uint16_t x,
 	return ret;
 }
 
-static int mcux_elcdif_read(const struct device *dev, const uint16_t x,
-			    const uint16_t y,
-			    const struct display_buffer_descriptor *desc,
-			    void *buf)
-{
-	LOG_ERR("Read not implemented");
-	return -ENOTSUP;
-}
-
-static void *mcux_elcdif_get_framebuffer(const struct device *dev)
-{
-	/*
-	 * Direct FB access is not available. If the user wants to set
-	 * the framebuffer directly, they must provide a buffer to
-	 * `display_write` equal in size to the connected display,
-	 * with coordinates [0,0]
-	 */
-	LOG_ERR("Direct framebuffer access not available");
-	return NULL;
-}
-
 static int mcux_elcdif_display_blanking_off(const struct device *dev)
 {
 	const struct mcux_elcdif_config *config = dev->config;
@@ -244,20 +223,6 @@ static int mcux_elcdif_display_blanking_on(const struct device *dev)
 	const struct mcux_elcdif_config *config = dev->config;
 
 	return gpio_pin_set_dt(&config->backlight_gpio, 0);
-}
-
-static int mcux_elcdif_set_brightness(const struct device *dev,
-				      const uint8_t brightness)
-{
-	LOG_WRN("Set brightness not implemented");
-	return -ENOTSUP;
-}
-
-static int mcux_elcdif_set_contrast(const struct device *dev,
-				    const uint8_t contrast)
-{
-	LOG_ERR("Set contrast not implemented");
-	return -ENOTSUP;
 }
 
 static int mcux_elcdif_set_pixel_format(const struct device *dev,
@@ -368,10 +333,6 @@ static const struct display_driver_api mcux_elcdif_api = {
 	.blanking_on = mcux_elcdif_display_blanking_on,
 	.blanking_off = mcux_elcdif_display_blanking_off,
 	.write = mcux_elcdif_write,
-	.read = mcux_elcdif_read,
-	.get_framebuffer = mcux_elcdif_get_framebuffer,
-	.set_brightness = mcux_elcdif_set_brightness,
-	.set_contrast = mcux_elcdif_set_contrast,
 	.get_capabilities = mcux_elcdif_get_capabilities,
 	.set_pixel_format = mcux_elcdif_set_pixel_format,
 	.set_orientation = mcux_elcdif_set_orientation,

--- a/drivers/display/display_nrf_led_matrix.c
+++ b/drivers/display/display_nrf_led_matrix.c
@@ -188,12 +188,6 @@ static int api_set_brightness(const struct device *dev,
 	return 0;
 }
 
-static int api_set_contrast(const struct device *dev,
-			    const uint8_t contrast)
-{
-	return -ENOTSUP;
-}
-
 static int api_set_pixel_format(const struct device *dev,
 				const enum display_pixel_format format)
 {
@@ -279,22 +273,12 @@ static int api_write(const struct device *dev,
 	return 0;
 }
 
-static int api_read(const struct device *dev,
-		    const uint16_t x, const uint16_t y,
-		    const struct display_buffer_descriptor *desc,
-		    void *buf)
-{
-	return -ENOTSUP;
-}
-
 const struct display_driver_api driver_api = {
 	.blanking_on = api_blanking_on,
 	.blanking_off = api_blanking_off,
 	.write = api_write,
-	.read = api_read,
 	.get_framebuffer = api_get_framebuffer,
 	.set_brightness = api_set_brightness,
-	.set_contrast = api_set_contrast,
 	.get_capabilities = api_get_capabilities,
 	.set_pixel_format = api_set_pixel_format,
 	.set_orientation = api_set_orientation,

--- a/drivers/display/display_otm8009a.c
+++ b/drivers/display/display_otm8009a.c
@@ -586,25 +586,9 @@ static int otm8009a_write(const struct device *dev, uint16_t x, uint16_t y,
 	return -ENOTSUP;
 }
 
-static int otm8009a_read(const struct device *dev, uint16_t x, uint16_t y,
-			 const struct display_buffer_descriptor *desc, void *buf)
-{
-	return -ENOTSUP;
-}
-
-static void *otm8009a_get_framebuffer(const struct device *dev)
-{
-	return NULL;
-}
-
 static int otm8009a_set_brightness(const struct device *dev, uint8_t brightness)
 {
 	return otm8009a_dcs_write(dev, MIPI_DCS_SET_DISPLAY_BRIGHTNESS, &brightness, 1);
-}
-
-static int otm8009a_set_contrast(const struct device *dev, uint8_t contrast)
-{
-	return -ENOTSUP;
 }
 
 static void otm8009a_get_capabilities(const struct device *dev,
@@ -621,29 +605,12 @@ static void otm8009a_get_capabilities(const struct device *dev,
 	capabilities->current_orientation = data->orientation;
 }
 
-static int otm8009a_set_pixel_format(const struct device *dev,
-				     enum display_pixel_format pixel_format)
-{
-	return -ENOTSUP;
-}
-
-static int otm8009a_set_orientation(const struct device *dev,
-				    enum display_orientation orientation)
-{
-	return -ENOTSUP;
-}
-
 static const struct display_driver_api otm8009a_api = {
 	.blanking_on = otm8009a_blanking_on,
 	.blanking_off = otm8009a_blanking_off,
 	.write = otm8009a_write,
-	.read = otm8009a_read,
-	.get_framebuffer = otm8009a_get_framebuffer,
 	.set_brightness = otm8009a_set_brightness,
-	.set_contrast = otm8009a_set_contrast,
 	.get_capabilities = otm8009a_get_capabilities,
-	.set_pixel_format = otm8009a_set_pixel_format,
-	.set_orientation = otm8009a_set_orientation,
 };
 
 static int otm8009a_init(const struct device *dev)

--- a/drivers/display/display_rm67162.c
+++ b/drivers/display/display_rm67162.c
@@ -512,20 +512,6 @@ static int rm67162_blanking_on(const struct device *dev)
 	}
 }
 
-static int rm67162_set_brightness(const struct device *dev,
-				  const uint8_t brightness)
-{
-	LOG_WRN("Set brightness not implemented");
-	return -ENOTSUP;
-}
-
-static int rm67162_set_contrast(const struct device *dev,
-				const uint8_t contrast)
-{
-	LOG_ERR("Set contrast not implemented");
-	return -ENOTSUP;
-}
-
 static int rm67162_set_pixel_format(const struct device *dev,
 				    const enum display_pixel_format pixel_format)
 {
@@ -595,8 +581,6 @@ static const struct display_driver_api rm67162_api = {
 	.blanking_off = rm67162_blanking_off,
 	.get_capabilities = rm67162_get_capabilities,
 	.write = rm67162_write,
-	.set_brightness = rm67162_set_brightness,
-	.set_contrast = rm67162_set_contrast,
 	.set_pixel_format = rm67162_set_pixel_format,
 	.set_orientation = rm67162_set_orientation,
 };

--- a/drivers/display/display_rm68200.c
+++ b/drivers/display/display_rm68200.c
@@ -102,21 +102,6 @@ static int rm68200_write(const struct device *dev, const uint16_t x,
 	return 0;
 }
 
-static int rm68200_read(const struct device *dev, const uint16_t x,
-			const uint16_t y,
-			const struct display_buffer_descriptor *desc,
-			void *buf)
-{
-	LOG_ERR("Read not implemented");
-	return -ENOTSUP;
-}
-
-static void *rm68200_get_framebuffer(const struct device *dev)
-{
-	LOG_ERR("Direct framebuffer access not implemented");
-	return NULL;
-}
-
 static int rm68200_blanking_off(const struct device *dev)
 {
 	const struct rm68200_config *config = dev->config;
@@ -137,20 +122,6 @@ static int rm68200_blanking_on(const struct device *dev)
 	} else {
 		return -ENOTSUP;
 	}
-}
-
-static int rm68200_set_brightness(const struct device *dev,
-				  const uint8_t brightness)
-{
-	LOG_WRN("Set brightness not implemented");
-	return -ENOTSUP;
-}
-
-static int rm68200_set_contrast(const struct device *dev,
-				const uint8_t contrast)
-{
-	LOG_ERR("Set contrast not implemented");
-	return -ENOTSUP;
 }
 
 static int rm68200_set_pixel_format(const struct device *dev,
@@ -192,10 +163,6 @@ static const struct display_driver_api rm68200_api = {
 	.blanking_on = rm68200_blanking_on,
 	.blanking_off = rm68200_blanking_off,
 	.write = rm68200_write,
-	.read = rm68200_read,
-	.get_framebuffer = rm68200_get_framebuffer,
-	.set_brightness = rm68200_set_brightness,
-	.set_contrast = rm68200_set_contrast,
 	.get_capabilities = rm68200_get_capabilities,
 	.set_pixel_format = rm68200_set_pixel_format,
 	.set_orientation = rm68200_set_orientation,

--- a/drivers/display/display_sdl.c
+++ b/drivers/display/display_sdl.c
@@ -269,11 +269,6 @@ static int sdl_display_read(const struct device *dev, const uint16_t x,
 				       disp_data->renderer, buf, desc->pitch);
 }
 
-static void *sdl_display_get_framebuffer(const struct device *dev)
-{
-	return NULL;
-}
-
 static int sdl_display_blanking_off(const struct device *dev)
 {
 	struct sdl_display_data *disp_data = dev->data;
@@ -297,18 +292,6 @@ static int sdl_display_blanking_on(const struct device *dev)
 
 	sdl_display_blanking_on_bottom(disp_data->renderer);
 	return 0;
-}
-
-static int sdl_display_set_brightness(const struct device *dev,
-		const uint8_t brightness)
-{
-	return -ENOTSUP;
-}
-
-static int sdl_display_set_contrast(const struct device *dev,
-		const uint8_t contrast)
-{
-	return -ENOTSUP;
 }
 
 static void sdl_display_get_capabilities(
@@ -361,9 +344,6 @@ static const struct display_driver_api sdl_display_api = {
 	.blanking_off = sdl_display_blanking_off,
 	.write = sdl_display_write,
 	.read = sdl_display_read,
-	.get_framebuffer = sdl_display_get_framebuffer,
-	.set_brightness = sdl_display_set_brightness,
-	.set_contrast = sdl_display_set_contrast,
 	.get_capabilities = sdl_display_get_capabilities,
 	.set_pixel_format = sdl_display_set_pixel_format,
 };

--- a/drivers/display/display_st7735r.c
+++ b/drivers/display/display_st7735r.c
@@ -159,15 +159,6 @@ static int st7735r_blanking_off(const struct device *dev)
 	return st7735r_transmit(dev, ST7735R_CMD_DISP_ON, NULL, 0);
 }
 
-static int st7735r_read(const struct device *dev,
-			const uint16_t x,
-			const uint16_t y,
-			const struct display_buffer_descriptor *desc,
-			void *buf)
-{
-	return -ENOTSUP;
-}
-
 static int st7735r_set_mem_area(const struct device *dev,
 				const uint16_t x, const uint16_t y,
 				const uint16_t w, const uint16_t h)
@@ -265,23 +256,6 @@ static int st7735r_write(const struct device *dev,
 out:
 	spi_release_dt(&config->bus);
 	return ret;
-}
-
-static void *st7735r_get_framebuffer(const struct device *dev)
-{
-	return NULL;
-}
-
-static int st7735r_set_brightness(const struct device *dev,
-				  const uint8_t brightness)
-{
-	return -ENOTSUP;
-}
-
-static int st7735r_set_contrast(const struct device *dev,
-				const uint8_t contrast)
-{
-	return -ENOTSUP;
 }
 
 static void st7735r_get_capabilities(const struct device *dev,
@@ -548,10 +522,6 @@ static const struct display_driver_api st7735r_api = {
 	.blanking_on = st7735r_blanking_on,
 	.blanking_off = st7735r_blanking_off,
 	.write = st7735r_write,
-	.read = st7735r_read,
-	.get_framebuffer = st7735r_get_framebuffer,
-	.set_brightness = st7735r_set_brightness,
-	.set_contrast = st7735r_set_contrast,
 	.get_capabilities = st7735r_get_capabilities,
 	.set_pixel_format = st7735r_set_pixel_format,
 	.set_orientation = st7735r_set_orientation,

--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -141,15 +141,6 @@ static int st7789v_blanking_off(const struct device *dev)
 	return 0;
 }
 
-static int st7789v_read(const struct device *dev,
-			const uint16_t x,
-			const uint16_t y,
-			const struct display_buffer_descriptor *desc,
-			void *buf)
-{
-	return -ENOTSUP;
-}
-
 static void st7789v_set_mem_area(const struct device *dev, const uint16_t x,
 				 const uint16_t y, const uint16_t w, const uint16_t h)
 {
@@ -202,23 +193,6 @@ static int st7789v_write(const struct device *dev,
 	}
 
 	return 0;
-}
-
-static void *st7789v_get_framebuffer(const struct device *dev)
-{
-	return NULL;
-}
-
-static int st7789v_set_brightness(const struct device *dev,
-			   const uint8_t brightness)
-{
-	return -ENOTSUP;
-}
-
-static int st7789v_set_contrast(const struct device *dev,
-			 const uint8_t contrast)
-{
-	return -ENOTSUP;
 }
 
 static void st7789v_get_capabilities(const struct device *dev,
@@ -413,10 +387,6 @@ static const struct display_driver_api st7789v_api = {
 	.blanking_on = st7789v_blanking_on,
 	.blanking_off = st7789v_blanking_off,
 	.write = st7789v_write,
-	.read = st7789v_read,
-	.get_framebuffer = st7789v_get_framebuffer,
-	.set_brightness = st7789v_set_brightness,
-	.set_contrast = st7789v_set_contrast,
 	.get_capabilities = st7789v_get_capabilities,
 	.set_pixel_format = st7789v_set_pixel_format,
 	.set_orientation = st7789v_set_orientation,

--- a/drivers/display/display_stm32_ltdc.c
+++ b/drivers/display/display_stm32_ltdc.c
@@ -86,33 +86,11 @@ struct display_stm32_ltdc_config {
 	const struct pinctrl_dev_config *pctrl;
 };
 
-static int stm32_ltdc_blanking_on(const struct device *dev)
-{
-	return -ENOTSUP;
-}
-
-static int stm32_ltdc_blanking_off(const struct device *dev)
-{
-	return -ENOTSUP;
-}
-
 static void *stm32_ltdc_get_framebuffer(const struct device *dev)
 {
 	struct display_stm32_ltdc_data *data = dev->data;
 
 	return (void *) data->frame_buffer;
-}
-
-static int stm32_ltdc_set_brightness(const struct device *dev,
-				const uint8_t brightness)
-{
-	return -ENOTSUP;
-}
-
-static int stm32_ltdc_set_contrast(const struct device *dev,
-				const uint8_t contrast)
-{
-	return -ENOTSUP;
 }
 
 static int stm32_ltdc_set_pixel_format(const struct device *dev,
@@ -379,13 +357,9 @@ static int stm32_ltdc_pm_action(const struct device *dev,
 #endif /* CONFIG_PM_DEVICE */
 
 static const struct display_driver_api stm32_ltdc_display_api = {
-	.blanking_on = stm32_ltdc_blanking_on,
-	.blanking_off = stm32_ltdc_blanking_off,
 	.write = stm32_ltdc_write,
 	.read = stm32_ltdc_read,
 	.get_framebuffer = stm32_ltdc_get_framebuffer,
-	.set_brightness = stm32_ltdc_set_brightness,
-	.set_contrast = stm32_ltdc_set_contrast,
 	.get_capabilities = stm32_ltdc_get_capabilities,
 	.set_pixel_format = stm32_ltdc_set_pixel_format,
 	.set_orientation = stm32_ltdc_set_orientation


### PR DESCRIPTION
The display API does now [1] return error codes for non-mandatory callbacks, so there is no need to implement dummy functions just to return -ENOTSUP.

[1] https://github.com/zephyrproject-rtos/zephyr/pull/66149#event-11180122714