### PR TITLE
samples: drivers: spi_flash: Add nordic,qspi-nor to test filter

### DIFF
--- a/boards/arm/bl5340_dvk/bl5340_dvk_cpuapp_ns.dts
+++ b/boards/arm/bl5340_dvk/bl5340_dvk_cpuapp_ns.dts
@@ -17,11 +17,6 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_ns_partition;
 	};
-
-	/* Aliases for deleted nodes must be removed */
-	aliases {
-		/delete-property/ spi-flash0;
-	};
 };
 
 zephyr_udc0: &usbd {

--- a/boards/arm/bt610/bt610.dts
+++ b/boards/arm/bt610/bt610.dts
@@ -77,6 +77,7 @@
 		mcuboot-button0 = &button1;
 		mcuboot-led0 = &led1;
 		watchdog0 = &wdt0;
+		spi-flash0 = &mx25r64;
 	};
 
 	mag1: mag_1 {

--- a/boards/arm/mg100/mg100.dts
+++ b/boards/arm/mg100/mg100.dts
@@ -65,6 +65,7 @@
 		mcuboot-button0 = &button1;
 		mcuboot-led0 = &led1;
 		watchdog0 = &wdt0;
+		spi-flash0 = &mx25r64;
 	};
 };
 

--- a/boards/arm/pinnacle_100_dvk/pinnacle_100_dvk.dts
+++ b/boards/arm/pinnacle_100_dvk/pinnacle_100_dvk.dts
@@ -81,6 +81,7 @@
 		mcuboot-button0 = &button1;
 		mcuboot-led0 = &led1;
 		watchdog0 = &wdt0;
+		spi-flash0 = &mx25r64;
 	};
 };
 

--- a/boards/arm/ubx_bmd340eval_nrf52840/ubx_bmd340eval_nrf52840.dts
+++ b/boards/arm/ubx_bmd340eval_nrf52840/ubx_bmd340eval_nrf52840.dts
@@ -129,6 +129,7 @@
 		sw2 = &button2;
 		sw3 = &button3;
 		watchdog0 = &wdt0;
+		spi-flash0 = &mx25r64;
 	};
 };
 

--- a/boards/arm/ubx_bmd345eval_nrf52840/ubx_bmd345eval_nrf52840.dts
+++ b/boards/arm/ubx_bmd345eval_nrf52840/ubx_bmd345eval_nrf52840.dts
@@ -141,6 +141,7 @@
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
 		watchdog0 = &wdt0;
+		spi-flash0 = &mx25r64;
 	};
 };
 

--- a/boards/arm/ubx_bmd380eval_nrf52840/ubx_bmd380eval_nrf52840.dts
+++ b/boards/arm/ubx_bmd380eval_nrf52840/ubx_bmd380eval_nrf52840.dts
@@ -90,6 +90,7 @@
 		sw2 = &button2;
 		sw3 = &button3;
 		watchdog0 = &wdt0;
+		spi-flash0 = &mx25r64;
 	};
 };
 

--- a/samples/drivers/spi_flash/README.rst
+++ b/samples/drivers/spi_flash/README.rst
@@ -15,8 +15,13 @@ savings is correctly implemented.
 Building and Running
 ********************
 
-The application will build only for a target that has a :ref:`devicetree
-<dt-guide>` entry with ``jedec,spi-nor`` as a compatible.
+The application will build only for a target that has a :ref:`devicetree <dt-guide>`
+``spi-flash0`` alias that refers to an entry with one of the following bindings as a compatible:
+
+* :dtcompatible:`jedec,spi-nor`,
+* :dtcompatible:`st,stm32-qspi-nor`,
+* :dtcompatible:`st,stm32-ospi-nor`,
+* :dtcompatible:`nordic,qspi-nor`.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/drivers/spi_flash

--- a/samples/drivers/spi_flash/sample.yaml
+++ b/samples/drivers/spi_flash/sample.yaml
@@ -7,6 +7,7 @@ tests:
       - flash
     filter: dt_compat_enabled("jedec,spi-nor") or dt_compat_enabled("st,stm32-qspi-nor")
       or dt_compat_enabled("st,stm32-ospi-nor")
+      or (dt_compat_enabled("nordic,qspi-nor") and CONFIG_NORDIC_QSPI_NOR)
     platform_exclude: hifive_unmatched
     harness: console
     harness_config:


### PR DESCRIPTION
When commit 5b4f4253c1962b85720f0c4d9833b80db5548a08 introduced "nordic,qspi-nor" dts binding the sample wasn't aligned to the change. From that moment the sample started to be filtered out by the Twister.

The patch adds Nordic's compatible to the test filter.