### PR TITLE
soc: arm: atmel_sam: Add custom sys_arch_reboot using RSTC

### DIFF
--- a/soc/arm/atmel_sam/common/CMakeLists.txt
+++ b/soc/arm/atmel_sam/common/CMakeLists.txt
@@ -4,6 +4,7 @@ zephyr_include_directories(.)
 zephyr_library_sources_ifndef(CONFIG_SOC_SERIES_SAM4L soc_pmc.c)
 zephyr_library_sources_ifndef(CONFIG_SOC_SERIES_SAM4L soc_gpio.c)
 zephyr_library_sources_ifndef(CONFIG_SOC_SERIES_SAM4L soc_supc.c)
+zephyr_library_sources_ifndef(CONFIG_SOC_SERIES_SAM4L soc_power.c)
 zephyr_library_sources_ifndef(CONFIG_SOC_SERIES_SAM4L soc_poweroff.c)
 
 zephyr_library_sources_ifdef(CONFIG_SOC_SERIES_SAM4L soc_sam4l_pm.c)

--- a/soc/arm/atmel_sam/common/soc_power.c
+++ b/soc/arm/atmel_sam/common/soc_power.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023 Basalte bv
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define SAM_DT_RSTC_DRIVER DT_INST(0, atmel_sam_rstc)
+
+#include <zephyr/kernel.h>
+#if defined(CONFIG_REBOOT)
+#include <zephyr/sys/reboot.h>
+#endif
+
+#if defined(CONFIG_REBOOT)
+#if DT_NODE_HAS_STATUS(SAM_DT_RSTC_DRIVER, okay)
+
+void sys_arch_reboot(int type)
+{
+	Rstc *regs = (Rstc *)DT_REG_ADDR(SAM_DT_RSTC_DRIVER);
+
+	switch (type) {
+	case SYS_REBOOT_COLD:
+		regs->RSTC_CR = RSTC_CR_KEY_PASSWD
+			      | RSTC_CR_PROCRST
+#if defined(CONFIG_SOC_SERIES_SAM3X) || defined(CONFIG_SOC_SERIES_SAM4S) || \
+	defined(CONFIG_SOC_SERIES_SAM4E)
+			      | RSTC_CR_PERRST
+#endif /* CONFIG_SOC_SERIES_SAM3X || CONFIG_SOC_SERIES_SAM4S || CONFIG_SOC_SERIES_SAM4E */
+			      ;
+		break;
+	default:
+		break;
+	}
+}
+
+#endif /* DT_NODE_HAS_STATUS */
+#endif /* CONFIG_REBOOT */


### PR DESCRIPTION
The previous implementation of the sys_arch_reboot function for the Atmel SAM series was using NVIC_SystemReset. This caused a reboot time of around 20 seconds on a SAM4SA16CA, which is now reduced by directly writing to the
reset controller control register (RSTC_CR).