### PR TITLE
dts: arm: ambiq: Add SoC compat string

### DIFF
--- a/dts/arm/ambiq/ambiq_apollo4p.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo4p.dtsi
@@ -43,6 +43,8 @@
 	};
 
 	soc {
+		compatible = "ambiq,apollo4p", "ambiq,apollo4x", "simple-bus";
+
 		pwrcfg: pwrcfg@40021000 {
 			compatible = "ambiq,pwrctrl";
 			reg = <0x40021000 0x400>;

--- a/dts/arm/ambiq/ambiq_apollo4p_blue.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo4p_blue.dtsi
@@ -48,6 +48,8 @@
 	};
 
 	soc {
+		compatible = "ambiq,apollo4p-blue", "ambiq,apollo4x", "simple-bus";
+
 		flash: flash-controller@18000 {
 			compatible = "ambiq,flash-controller";
 			reg = <0x00018000 0x1e8000>;


### PR DESCRIPTION
Add `compatible` node to Ambiq SoCs, along with secondary common compat, since they share many similarities.