### PR TITLE
CAP Commander volume mute change

### DIFF
--- a/doc/connectivity/bluetooth/api/shell/cap.rst
+++ b/doc/connectivity/bluetooth/api/shell/cap.rst
@@ -172,7 +172,8 @@ command also needs to be called.
 When connected
 --------------
 
-Discovering CAS and CSIS on a device:
+Discovering CAS and CSIS on a device
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: console
 
@@ -180,7 +181,8 @@ Discovering CAS and CSIS on a device:
    discovery completed with CSIS
 
 
-Setting the volume on all connected devices:
+Setting the volume on all connected devices
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: console
 
@@ -196,9 +198,10 @@ Setting the volume on all connected devices:
    VCP vol_set done
    Volume change completed
 
-
-Setting the volume offset on one or more connected devices. The offsets are set by connection index,
-so connection index 0 gets the first offset, and index 1 gets the second offset, etc.:
+Setting the volume offset on one or more devices
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The offsets are set by connection index, so connection index 0 gets the first offset,
+and index 1 gets the second offset, etc.:
 
 .. code-block:: console
 
@@ -228,3 +231,37 @@ so connection index 0 gets the first offset, and index 1 gets the second offset,
    VOCS inst 0x20014188 offset 15
    Offset set for inst 0x20014188
    Volume offset change completed
+
+Setting the volume mute on all connected devices
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: console
+
+   uart:~$ bt connect <device A>
+   Connected: <device A>
+   uart:~$ cap_commander discover
+   discovery completed with CSIS
+   uart:~$ vcp_vol_ctlr discover
+   VCP discover done with 1 VOCS and 1 AICS
+   uart:~$
+   uart:~$ bt connect <device B>
+   Connected: <device B>
+   uart:~$ cap_commander discover
+   discovery completed with CSIS
+   uart:~$ vcp_vol_ctlr discover
+   VCP discover done with 1 VOCS and 1 AICS
+   uart:~$
+   uart:~$ cap_commander change_volume_mute 1
+   Setting volume mute to 1 on 2 connections
+   VCP volume 100, mute 1
+   VCP mute done
+   VCP volume 100, mute 1
+   VCP mute done
+   Volume mute change completed
+   uart:~$ cap_commander change_volume_mute 0
+   Setting volume mute to 0 on 2 connections
+   VCP volume 100, mute 0
+   VCP unmute done
+   VCP volume 100, mute 0
+   VCP unmute done
+   Volume mute change completed

--- a/include/zephyr/bluetooth/audio/cap.h
+++ b/include/zephyr/bluetooth/audio/cap.h
@@ -669,6 +669,18 @@ struct bt_cap_commander_cb {
 	 */
 	void (*volume_changed)(struct bt_conn *conn, int err);
 
+	/**
+	 * @brief Callback for bt_cap_commander_change_volume_mute_state().
+	 *
+	 * @param conn           Pointer to the connection where the error
+	 *                       occurred. NULL if @p err is 0 or if cancelled by
+	 *                       bt_cap_commander_cancel()
+	 * @param err            0 on success, BT_GATT_ERR() with a
+	 *                       specific ATT (BT_ATT_ERR_*) error code or -ECANCELED if cancelled
+	 *                       by bt_cap_commander_cancel().
+	 */
+	void (*volume_mute_changed)(struct bt_conn *conn, int err);
+
 #if defined(CONFIG_BT_VCP_VOL_CTLR_VOCS)
 	/**
 	 * @brief Callback for bt_cap_commander_change_volume_offset().

--- a/subsys/bluetooth/audio/cap_common.c
+++ b/subsys/bluetooth/audio/cap_common.c
@@ -122,6 +122,7 @@ static bool active_proc_is_commander(void)
 	switch (active_proc.proc_type) {
 	case BT_CAP_COMMON_PROC_TYPE_VOLUME_CHANGE:
 	case BT_CAP_COMMON_PROC_TYPE_VOLUME_OFFSET_CHANGE:
+	case BT_CAP_COMMON_PROC_TYPE_VOLUME_MUTE_CHANGE:
 		return true;
 	default:
 		return false;

--- a/subsys/bluetooth/audio/cap_internal.h
+++ b/subsys/bluetooth/audio/cap_internal.h
@@ -38,6 +38,7 @@ enum bt_cap_common_proc_type {
 	BT_CAP_COMMON_PROC_TYPE_STOP,
 	BT_CAP_COMMON_PROC_TYPE_VOLUME_CHANGE,
 	BT_CAP_COMMON_PROC_TYPE_VOLUME_OFFSET_CHANGE,
+	BT_CAP_COMMON_PROC_TYPE_VOLUME_MUTE_CHANGE,
 };
 
 enum bt_cap_common_subproc_type {
@@ -74,6 +75,9 @@ struct bt_cap_commander_proc_param {
 		struct {
 			uint8_t volume;
 		} change_volume;
+		struct {
+			bool mute;
+		} change_mute;
 #endif /* CONFIG_BT_VCP_VOL_CTLR */
 #if defined(CONFIG_BT_VCP_VOL_CTLR_VOCS)
 		struct {

--- a/tests/bluetooth/audio/cap_commander/src/main.c
+++ b/tests/bluetooth/audio/cap_commander/src/main.c
@@ -654,3 +654,216 @@ ZTEST_F(cap_commander_test_suite, test_commander_change_volume_offset_inval_para
 	err = bt_cap_commander_change_volume_offset(&param);
 	zassert_equal(-EINVAL, err, "Unexpected return value %d", err);
 }
+
+ZTEST_F(cap_commander_test_suite, test_commander_change_volume_mute_state)
+{
+	union bt_cap_set_member members[ARRAY_SIZE(fixture->conns)];
+	const struct bt_cap_commander_change_volume_mute_state_param param = {
+		.type = BT_CAP_SET_TYPE_AD_HOC,
+		.members = members,
+		.count = ARRAY_SIZE(fixture->conns),
+		.mute = true,
+	};
+	int err;
+
+	for (size_t i = 0U; i < ARRAY_SIZE(members); i++) {
+		members[i].member = &fixture->conns[i];
+	}
+
+	err = bt_cap_commander_register_cb(&mock_cap_commander_cb);
+	zassert_equal(0, err, "Unexpected return value %d", err);
+
+	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
+		struct bt_vcp_vol_ctlr *vol_ctlr; /* We don't care about this */
+
+		err = bt_cap_commander_discover(&fixture->conns[i]);
+		zassert_equal(0, err, "Unexpected return value %d", err);
+
+		err = bt_vcp_vol_ctlr_discover(&fixture->conns[i], &vol_ctlr);
+		zassert_equal(0, err, "Unexpected return value %d", err);
+	}
+
+	err = bt_cap_commander_change_volume_mute_state(&param);
+	zassert_equal(0, err, "Unexpected return value %d", err);
+
+	zexpect_call_count("bt_cap_commander_cb.volume_mute_changed", 1,
+			   mock_cap_commander_volume_mute_changed_cb_fake.call_count);
+}
+
+ZTEST_F(cap_commander_test_suite, test_commander_change_volume_mute_state_double)
+{
+	union bt_cap_set_member members[ARRAY_SIZE(fixture->conns)];
+	const struct bt_cap_commander_change_volume_mute_state_param param = {
+		.type = BT_CAP_SET_TYPE_AD_HOC,
+		.members = members,
+		.count = ARRAY_SIZE(fixture->conns),
+		.mute = true,
+	};
+	int err;
+
+	for (size_t i = 0U; i < ARRAY_SIZE(members); i++) {
+		members[i].member = &fixture->conns[i];
+	}
+
+	err = bt_cap_commander_register_cb(&mock_cap_commander_cb);
+	zassert_equal(0, err, "Unexpected return value %d", err);
+
+	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
+		struct bt_vcp_vol_ctlr *vol_ctlr; /* We don't care about this */
+
+		err = bt_cap_commander_discover(&fixture->conns[i]);
+		zassert_equal(0, err, "Unexpected return value %d", err);
+
+		err = bt_vcp_vol_ctlr_discover(&fixture->conns[i], &vol_ctlr);
+		zassert_equal(0, err, "Unexpected return value %d", err);
+	}
+
+	err = bt_cap_commander_change_volume_mute_state(&param);
+	zassert_equal(0, err, "Unexpected return value %d", err);
+
+	zexpect_call_count("bt_cap_commander_cb.volume_mute_changed", 1,
+			   mock_cap_commander_volume_mute_changed_cb_fake.call_count);
+
+	/* Verify that it still works as expected if we set the same value twice */
+	err = bt_cap_commander_change_volume_mute_state(&param);
+	zassert_equal(0, err, "Unexpected return value %d", err);
+
+	zexpect_call_count("bt_cap_commander_cb.volume_mute_changed", 2,
+			   mock_cap_commander_volume_mute_changed_cb_fake.call_count);
+}
+
+ZTEST_F(cap_commander_test_suite, test_commander_change_volume_mute_state_inval_param_null)
+{
+	int err;
+
+	err = bt_cap_commander_change_volume_mute_state(NULL);
+	zassert_equal(-EINVAL, err, "Unexpected return value %d", err);
+}
+
+ZTEST_F(cap_commander_test_suite, test_commander_change_volume_mute_state_inval_param_null_members)
+{
+	const struct bt_cap_commander_change_volume_mute_state_param param = {
+		.type = BT_CAP_SET_TYPE_AD_HOC,
+		.members = NULL,
+		.count = ARRAY_SIZE(fixture->conns),
+		.mute = true,
+	};
+	int err;
+
+	err = bt_cap_commander_change_volume_mute_state(&param);
+	zassert_equal(-EINVAL, err, "Unexpected return value %d", err);
+}
+
+ZTEST_F(cap_commander_test_suite, test_commander_change_volume_mute_state_inval_param_null_member)
+{
+	union bt_cap_set_member members[ARRAY_SIZE(fixture->conns)];
+	const struct bt_cap_commander_change_volume_mute_state_param param = {
+		.type = BT_CAP_SET_TYPE_AD_HOC,
+		.members = members,
+		.count = ARRAY_SIZE(fixture->conns),
+		.mute = true,
+	};
+	int err;
+
+	for (size_t i = 0U; i < ARRAY_SIZE(members) - 1; i++) {
+		members[i].member = &fixture->conns[i];
+	}
+	members[ARRAY_SIZE(members) - 1].member = NULL;
+
+	err = bt_cap_commander_change_volume_mute_state(&param);
+	zassert_equal(-EINVAL, err, "Unexpected return value %d", err);
+}
+
+ZTEST_F(cap_commander_test_suite, test_commander_change_volume_mute_state_inval_missing_cas)
+{
+	union bt_cap_set_member members[ARRAY_SIZE(fixture->conns)];
+	const struct bt_cap_commander_change_volume_mute_state_param param = {
+		.type = BT_CAP_SET_TYPE_AD_HOC,
+		.members = members,
+		.count = ARRAY_SIZE(fixture->conns),
+		.mute = true,
+	};
+	int err;
+
+	for (size_t i = 0U; i < ARRAY_SIZE(members); i++) {
+		members[i].member = &fixture->conns[i];
+	}
+
+	err = bt_cap_commander_register_cb(&mock_cap_commander_cb);
+	zassert_equal(0, err, "Unexpected return value %d", err);
+
+	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
+		struct bt_vcp_vol_ctlr *vol_ctlr; /* We don't care about this */
+
+		err = bt_vcp_vol_ctlr_discover(&fixture->conns[i], &vol_ctlr);
+		zassert_equal(0, err, "Unexpected return value %d", err);
+	}
+
+	err = bt_cap_commander_change_volume_mute_state(&param);
+	zassert_equal(-EINVAL, err, "Unexpected return value %d", err);
+}
+
+ZTEST_F(cap_commander_test_suite, test_commander_change_volume_mute_state_inval_missing_vcs)
+{
+	union bt_cap_set_member members[ARRAY_SIZE(fixture->conns)];
+	const struct bt_cap_commander_change_volume_mute_state_param param = {
+		.type = BT_CAP_SET_TYPE_AD_HOC,
+		.members = members,
+		.count = ARRAY_SIZE(fixture->conns),
+		.mute = true,
+	};
+	int err;
+
+	for (size_t i = 0U; i < ARRAY_SIZE(members); i++) {
+		members[i].member = &fixture->conns[i];
+	}
+
+	err = bt_cap_commander_register_cb(&mock_cap_commander_cb);
+	zassert_equal(0, err, "Unexpected return value %d", err);
+
+	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
+		err = bt_cap_commander_discover(&fixture->conns[i]);
+		zassert_equal(0, err, "Unexpected return value %d", err);
+	}
+
+	err = bt_cap_commander_change_volume_mute_state(&param);
+	zassert_equal(-EINVAL, err, "Unexpected return value %d", err);
+}
+
+ZTEST_F(cap_commander_test_suite, test_commander_change_volume_mute_state_inval_param_zero_count)
+{
+	union bt_cap_set_member members[ARRAY_SIZE(fixture->conns)];
+	const struct bt_cap_commander_change_volume_mute_state_param param = {
+		.type = BT_CAP_SET_TYPE_AD_HOC,
+		.members = members,
+		.count = 0U,
+		.mute = true,
+	};
+	int err;
+
+	for (size_t i = 0U; i < ARRAY_SIZE(members); i++) {
+		members[i].member = &fixture->conns[i];
+	}
+
+	err = bt_cap_commander_change_volume_mute_state(&param);
+	zassert_equal(-EINVAL, err, "Unexpected return value %d", err);
+}
+
+ZTEST_F(cap_commander_test_suite, test_commander_change_volume_mute_state_inval_param_inval_count)
+{
+	union bt_cap_set_member members[ARRAY_SIZE(fixture->conns)];
+	const struct bt_cap_commander_change_volume_mute_state_param param = {
+		.type = BT_CAP_SET_TYPE_AD_HOC,
+		.members = members,
+		.count = CONFIG_BT_MAX_CONN + 1,
+		.mute = true,
+	};
+	int err;
+
+	for (size_t i = 0U; i < ARRAY_SIZE(members); i++) {
+		members[i].member = &fixture->conns[i];
+	}
+
+	err = bt_cap_commander_change_volume_mute_state(&param);
+	zassert_equal(-EINVAL, err, "Unexpected return value %d", err);
+}

--- a/tests/bluetooth/audio/cap_commander/uut/vcp.c
+++ b/tests/bluetooth/audio/cap_commander/uut/vcp.c
@@ -43,6 +43,24 @@ int bt_vcp_vol_ctlr_set_vol(struct bt_vcp_vol_ctlr *vol_ctlr, uint8_t volume)
 	return 0;
 }
 
+int bt_vcp_vol_ctlr_mute(struct bt_vcp_vol_ctlr *vol_ctlr)
+{
+	if (vcp_cb != NULL && vcp_cb->mute != NULL) {
+		vcp_cb->mute(vol_ctlr, 0);
+	}
+
+	return 0;
+}
+
+int bt_vcp_vol_ctlr_unmute(struct bt_vcp_vol_ctlr *vol_ctlr)
+{
+	if (vcp_cb != NULL && vcp_cb->unmute != NULL) {
+		vcp_cb->unmute(vol_ctlr, 0);
+	}
+
+	return 0;
+}
+
 int bt_vcp_vol_ctlr_discover(struct bt_conn *conn, struct bt_vcp_vol_ctlr **vol_ctlr)
 {
 	for (size_t i = 0; i < ARRAY_SIZE(vol_ctlrs); i++) {

--- a/tests/bluetooth/audio/mocks/include/cap_commander.h
+++ b/tests/bluetooth/audio/mocks/include/cap_commander.h
@@ -18,6 +18,7 @@ void mock_cap_commander_cleanup(void);
 DECLARE_FAKE_VOID_FUNC(mock_cap_commander_discovery_complete_cb, struct bt_conn *, int,
 		       const struct bt_csip_set_coordinator_csis_inst *);
 DECLARE_FAKE_VOID_FUNC(mock_cap_commander_volume_changed_cb, struct bt_conn *, int);
+DECLARE_FAKE_VOID_FUNC(mock_cap_commander_volume_mute_changed_cb, struct bt_conn *, int);
 DECLARE_FAKE_VOID_FUNC(mock_cap_commander_volume_offset_changed_cb, struct bt_conn *, int);
 
 #endif /* MOCKS_CAP_COMMANDER_H_ */

--- a/tests/bluetooth/audio/mocks/src/cap_commander.c
+++ b/tests/bluetooth/audio/mocks/src/cap_commander.c
@@ -12,18 +12,21 @@
 #define FFF_FAKES_LIST(FAKE)                                                                       \
 	FAKE(mock_cap_commander_discovery_complete_cb)                                             \
 	FAKE(mock_cap_commander_volume_changed_cb)                                                 \
+	FAKE(mock_cap_commander_volume_mute_changed_cb)                                            \
 	FAKE(mock_cap_commander_volume_offset_changed_cb)
 
 DEFINE_FAKE_VOID_FUNC(mock_cap_commander_discovery_complete_cb, struct bt_conn *, int,
 		      const struct bt_csip_set_coordinator_csis_inst *);
 
 DEFINE_FAKE_VOID_FUNC(mock_cap_commander_volume_changed_cb, struct bt_conn *, int);
+DEFINE_FAKE_VOID_FUNC(mock_cap_commander_volume_mute_changed_cb, struct bt_conn *, int);
 DEFINE_FAKE_VOID_FUNC(mock_cap_commander_volume_offset_changed_cb, struct bt_conn *, int);
 
 const struct bt_cap_commander_cb mock_cap_commander_cb = {
 	.discovery_complete = mock_cap_commander_discovery_complete_cb,
 #if defined(CONFIG_BT_VCP_VOL_CTLR)
 	.volume_changed = mock_cap_commander_volume_changed_cb,
+	.volume_mute_changed = mock_cap_commander_volume_mute_changed_cb,
 #if defined(CONFIG_BT_VCP_VOL_CTLR_VOCS)
 	.volume_offset_changed = mock_cap_commander_volume_offset_changed_cb,
 #endif /* CONFIG_BT_VCP_VOL_CTLR */

--- a/tests/bsim/bluetooth/audio/src/cap_commander_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_commander_test.c
@@ -24,6 +24,7 @@ CREATE_FLAG(flag_cas_discovered);
 CREATE_FLAG(flag_vcs_discovered);
 CREATE_FLAG(flag_mtu_exchanged);
 CREATE_FLAG(flag_volume_changed);
+CREATE_FLAG(flag_volume_mute_changed);
 CREATE_FLAG(flag_volume_offset_changed);
 
 static void cap_discovery_complete_cb(struct bt_conn *conn, int err,
@@ -60,6 +61,16 @@ static void cap_volume_changed_cb(struct bt_conn *conn, int err)
 	SET_FLAG(flag_volume_changed);
 }
 
+static void cap_volume_mute_changed_cb(struct bt_conn *conn, int err)
+{
+	if (err != 0) {
+		FAIL("Failed to change volume for conn %p: %d\n", conn, err);
+		return;
+	}
+
+	SET_FLAG(flag_volume_mute_changed);
+}
+
 static void cap_volume_offset_changed_cb(struct bt_conn *conn, int err)
 {
 	if (err != 0) {
@@ -73,6 +84,7 @@ static void cap_volume_offset_changed_cb(struct bt_conn *conn, int err)
 static struct bt_cap_commander_cb cap_cb = {
 	.discovery_complete = cap_discovery_complete_cb,
 	.volume_changed = cap_volume_changed_cb,
+	.volume_mute_changed = cap_volume_mute_changed_cb,
 	.volume_offset_changed = cap_volume_offset_changed_cb,
 };
 
@@ -270,6 +282,34 @@ static void test_change_volume(void)
 	printk("Volume changed to %u\n", param.volume);
 }
 
+static void test_change_volume_mute(bool mute)
+{
+	union bt_cap_set_member members[CONFIG_BT_MAX_CONN];
+	const struct bt_cap_commander_change_volume_mute_state_param param = {
+		.type = BT_CAP_SET_TYPE_AD_HOC,
+		.members = members,
+		.count = connected_conn_cnt,
+		.mute = mute,
+	};
+	int err;
+
+	printk("Changing volume mute state to %d\n", param.mute);
+	UNSET_FLAG(flag_volume_mute_changed);
+
+	for (size_t i = 0U; i < param.count; i++) {
+		param.members[i].member = connected_conns[i];
+	}
+
+	err = bt_cap_commander_change_volume_mute_state(&param);
+	if (err != 0) {
+		FAIL("Failed to change volume: %d\n", err);
+		return;
+	}
+
+	WAIT_FOR_FLAG(flag_volume_mute_changed);
+	printk("Volume mute state changed to %d\n", param.mute);
+}
+
 static void test_change_volume_offset(void)
 {
 	struct bt_cap_commander_change_volume_offset_member_param member_params[CONFIG_BT_MAX_CONN];
@@ -319,6 +359,9 @@ static void test_main_cap_commander_capture_and_render(void)
 	if (IS_ENABLED(CONFIG_BT_CSIP_SET_COORDINATOR)) {
 		if (IS_ENABLED(CONFIG_BT_VCP_VOL_CTLR)) {
 			test_change_volume();
+
+			test_change_volume_mute(true);
+			test_change_volume_mute(false);
 
 			if (IS_ENABLED(CONFIG_BT_VCP_VOL_CTLR_VOCS)) {
 				test_change_volume_offset();


### PR DESCRIPTION
Implements and tests the CAP Commander procedure "Change Volume Mute State". 

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/66165