### PR TITLE
subsys: pm: Move settting timeout to after suspending devices

### DIFF
--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -197,17 +197,6 @@ bool pm_system_suspend(int32_t ticks)
 		return false;
 	}
 
-	if (ticks != K_TICKS_FOREVER) {
-		/*
-		 * We need to set the timer to interrupt a little bit early to
-		 * accommodate the time required by the CPU to fully wake up.
-		 */
-		sys_clock_set_timeout(ticks -
-		     k_us_to_ticks_ceil32(
-			     z_cpus_pm_state[id].exit_latency_us),
-				     true);
-	}
-
 #if defined(CONFIG_PM_DEVICE) && !defined(CONFIG_PM_DEVICE_RUNTIME_EXCLUSIVE)
 	if (atomic_sub(&_cpus_active, 1) == 1) {
 		if (z_cpus_pm_state[id].state != PM_STATE_RUNTIME_IDLE) {
@@ -222,6 +211,18 @@ bool pm_system_suspend(int32_t ticks)
 		}
 	}
 #endif
+
+	if (ticks != K_TICKS_FOREVER) {
+		/*
+		 * We need to set the timer to interrupt a little bit early to
+		 * accommodate the time required by the CPU to fully wake up.
+		 */
+		sys_clock_set_timeout(ticks -
+		     k_us_to_ticks_ceil32(
+			     z_cpus_pm_state[id].exit_latency_us),
+				     true);
+	}
+
 	/*
 	 * This function runs with interruptions locked but it is
 	 * expected the SoC to unlock them in


### PR DESCRIPTION
pm_suspend_devices() could return an error. Set timeout using sys_clock_set_timeout() to after this error is handled so that we have the accurate power state when calling the timeout function. This is useful in cases where we wish to compensate the system timer for certain power modes.