### PR TITLE
doc: doxygen: move float_apis group into correct place

### DIFF
--- a/include/zephyr/arch/x86/ia32/arch.h
+++ b/include/zephyr/arch/x86/ia32/arch.h
@@ -397,18 +397,6 @@ static ALWAYS_INLINE unsigned int arch_irq_lock(void)
  */
 #define NANO_SOFT_IRQ	((unsigned int) (-1))
 
-/**
- * @defgroup float_apis Floating Point APIs
- * @ingroup kernel_apis
- * @{
- */
-
-struct k_thread;
-
-/**
- * @}
- */
-
 #ifdef CONFIG_X86_ENABLE_TSS
 extern struct task_state_segment _main_tss;
 #endif

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -5965,6 +5965,12 @@ __syscall void k_str_out(char *c, size_t n);
 #endif
 
 /**
+ * @defgroup float_apis Floating Point APIs
+ * @ingroup kernel_apis
+ * @{
+ */
+
+/**
  * @brief Disable preservation of floating point context information.
  *
  * This routine informs the kernel that the specified thread
@@ -6025,6 +6031,10 @@ __syscall int k_float_disable(struct k_thread *thread);
  *         -EINVAL  If the floating point enabling could not be performed.
  */
 __syscall int k_float_enable(struct k_thread *thread, unsigned int options);
+
+/**
+ * @}
+ */
 
 /**
  * @brief Get the runtime statistics of a thread


### PR DESCRIPTION
The float_apis group is incorrectly placed in x86/32 header. This should be in kernel.h enclosing k_float_* functions. So move it.