### PR TITLE
doc: pm: nrf target does not enable PM

### DIFF
--- a/doc/services/pm/system.rst
+++ b/doc/services/pm/system.rst
@@ -24,7 +24,6 @@ The following diagram describes system power management:
 Some handful examples using different power management features:
 
 * :zephyr_file:`samples/boards/stm32/power_mgmt/blinky/`
-* :zephyr_file:`samples/boards/nrf/system_off/`
 * :zephyr_file:`samples/boards/esp32/deep_sleep/`
 * :zephyr_file:`samples/subsys/pm/device_pm/`
 * :zephyr_file:`tests/subsys/pm/power_mgmt/`


### PR DESCRIPTION
samples/boards/nrf/system_off does not enable CONFIG_PM so it should not be listed as an example in system power management documentation.