### PR TITLE
pm: device_runtime: don't assert in ISR put

### DIFF
--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -214,8 +214,6 @@ int pm_device_runtime_put(const struct device *dev)
 {
 	int ret;
 
-	__ASSERT(!k_is_in_isr(), "use pm_device_runtime_put_async() in ISR");
-
 	if (dev->pm == NULL) {
 		return 0;
 	}


### PR DESCRIPTION
Don't assert that `pm_device_runtime_get` is not running in an ISR context, as `runtime_suspend` properly handles that condition.