### PR TITLE
driver: crypto: SHA: npcx: fix SHA driver for npcx4 QS chip

### DIFF
--- a/dts/arm/nuvoton/npcx/npcx4.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx4.dtsi
@@ -291,8 +291,8 @@
 
 		sha0: sha@13c {
 			compatible = "nuvoton,npcx-sha";
-			reg = <0x13c 0x3c>;
-			context-buffer-size = <228>;
+			reg = <0x148 0x4c>;
+			context-buffer-size = <240>;
 			status = "disabled";
 		};
 


### PR DESCRIPTION
The commit fixes the SHA driver because the ROM API has the following changes from ES to QS chip:
1. base addres: from 0x13c -> 0x148
2. required SHA context buffer size : from 228 -> 240 bytes

This change also adds a check for the pre-allocated buffer size of the SHA context when the driver initiliazes.