### PR TITLE
rtio: Fix i2c implementation

### DIFF
--- a/drivers/i2c/CMakeLists.txt
+++ b/drivers/i2c/CMakeLists.txt
@@ -6,10 +6,7 @@ zephyr_library()
 
 zephyr_library_sources(i2c_common.c)
 
-if(CONFIG_I2C_RTIO)
-zephyr_library_sources(i2c_rtio.c)
-zephyr_library_sources_ifdef(CONFIG_I2C_SAM_TWIHS    i2c_sam_twihs_rtio.c)
-else()
+zephyr_library_sources_ifdef(CONFIG_I2C_RTIO i2c_rtio.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_SHELL		i2c_shell.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_BITBANG		i2c_bitbang.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_TELINK_B91		i2c_b91.c)
@@ -29,7 +26,11 @@ zephyr_library_sources_ifdef(CONFIG_I2C_EMUL		i2c_emul.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_NRFX_TWI	i2c_nrfx_twi.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_NRFX_TWIM	i2c_nrfx_twim.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_SAM_TWI		i2c_sam_twi.c)
-zephyr_library_sources_ifdef(CONFIG_I2C_SAM_TWIHS    i2c_sam_twihs.c)
+if(CONFIG_RTIO)
+  zephyr_library_sources_ifdef(CONFIG_I2C_SAM_TWIHS    i2c_sam_twihs_rtio.c)
+else()
+  zephyr_library_sources_ifdef(CONFIG_I2C_SAM_TWIHS    i2c_sam_twihs.c)
+endif()
 zephyr_library_sources_ifdef(CONFIG_I2C_SAM_TWIM	i2c_sam4l_twim.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_SBCON		i2c_sbcon.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_SIFIVE		i2c_sifive.c)
@@ -65,7 +66,6 @@ zephyr_library_sources_ifdef(CONFIG_I2C_STM32_V2
 	i2c_ll_stm32_v2.c
 	i2c_ll_stm32.c
 	)
-endif()
 
 zephyr_library_sources_ifdef(CONFIG_I2C_TEST		i2c_test.c)
 

--- a/drivers/i2c/i2c_rtio.c
+++ b/drivers/i2c/i2c_rtio.c
@@ -26,7 +26,7 @@ struct rtio_sqe *i2c_rtio_copy(struct rtio *r,
 		sqe = rtio_sqe_acquire(r);
 
 		if (sqe == NULL) {
-			rtio_spsc_drop_all(r->sq);
+			rtio_sqe_drop_all(r);
 			return NULL;
 		}
 

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -972,7 +972,7 @@ static inline int i2c_transfer_signal(const struct device *dev,
  */
 static inline void i2c_iodev_submit(struct rtio_iodev_sqe *iodev_sqe)
 {
-	const struct i2c_dt_spec *dt_spec = iodev_sqe->sqe->iodev->data;
+	const struct i2c_dt_spec *dt_spec = (const struct i2c_dt_spec *)iodev_sqe->sqe.iodev->data;
 	const struct device *dev = dt_spec->bus;
 	const struct i2c_driver_api *api = (const struct i2c_driver_api *)dev->api;
 


### PR DESCRIPTION
- Allow non RTIO i2c drivers to be intermixed with RTIO drivers
- Remove reference to rtio_spsc_drop_all()
- Fix impllicit cast which throws an error with more restrictive compile flags