### PR TITLE
modules: hal_nordic: nRF 802.15.4 customizable asserts

### DIFF
--- a/modules/hal_nordic/Kconfig
+++ b/modules/hal_nordic/Kconfig
@@ -205,12 +205,38 @@ endif
 
 endmenu # NRF_802154_SER_HOST || NRF_802154_SER_RADIO
 
+if NRF_802154_RADIO_DRIVER || NRF_802154_SERIALIZATION
+
 config NRF_802154_CARRIER_FUNCTIONS
 	bool "nRF 802.15.4 carrier functions"
-	depends on NRF_802154_RADIO_DRIVER || NRF_802154_SERIALIZATION
 	help
 	  This option enables functions such as modulated carrier and continuous carrier.
 	  If this option is modified on a multicore SoC, its remote counterpart must be set to the exact same value.
+
+choice NRF_802154_ASSERT_CHOICE
+	prompt "nRF 802.15.4 assert implementation"
+	default NRF_802154_ASSERT_ZEPHYR_MINIMAL
+
+config NRF_802154_ASSERT_ZEPHYR_MINIMAL
+	bool "nRF 802.15.4 minimal assertions"
+	help
+	  This option provides minimal run-time checking of the nRF 802.15.4 Radio Driver's operation,
+	  even if kernel-wide CONFIG_ASSERT is disabled. In case of an abnormal condition the function
+	  `nrf_802154_assert_handler()` is called. File and line debug information are not provided
+	  to save memory of the image file. Default implementation of the `nrf_802154_assert_handler`
+	  involves a call to `k_panic`/`k_oops` and allows further tweaking of the behavior.
+	  You can also provide your own implementation of `nrf_802154_assert_handler`.
+
+config NRF_802154_ASSERT_ZEPHYR
+	bool "nRF 802.15.4 Radio Driver assertions as Zephyr's standard __ASERT_NO_MSG"
+	help
+	  The run-time checking of the nRF 802.15.4 Radio Driver depends fully on the configuration
+	  of the `__ASSERT_NO_MSG` macro, including the ability to completely turn off the run-time
+	  checking.
+
+endchoice # NRF_802154_ASSERT_CHOICE
+
+endif # NRF_802154_RADIO_DRIVER || NRF_802154_SERIALIZATION
 
 endmenu # HAS_NORDIC_DRIVERS
 

--- a/modules/hal_nordic/nrf_802154/CMakeLists.txt
+++ b/modules/hal_nordic/nrf_802154/CMakeLists.txt
@@ -95,6 +95,11 @@ endif()
 
 if (CONFIG_NRF_802154_RADIO_DRIVER OR CONFIG_NRF_802154_SERIALIZATION)
   target_compile_definitions(zephyr-802154-interface INTERFACE NRF_802154_ENERGY_DETECTED_VERSION=1)
+  if (CONFIG_NRF_802154_ASSERT_ZEPHYR OR CONFIG_NRF_802154_ASSERT_ZEPHYR_MINIMAL)
+    target_include_directories(zephyr-802154-interface INTERFACE include)
+    target_compile_definitions(zephyr-802154-interface INTERFACE NRF_802154_PLATFORM_ASSERT_INCLUDE=\"nrf_802154_assert_zephyr.h\")
+    target_sources(nrf-802154-platform PRIVATE nrf_802154_assert_handler.c)
+  endif()
 endif()
 
 set(NRF52_SERIES  ${CONFIG_SOC_SERIES_NRF52X})

--- a/modules/hal_nordic/nrf_802154/include/nrf_802154_assert_zephyr.h
+++ b/modules/hal_nordic/nrf_802154/include/nrf_802154_assert_zephyr.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023, Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef NRF_802154_ASSERT_ZEPHYR_H__
+#define NRF_802154_ASSERT_ZEPHYR_H__
+
+#if defined(CONFIG_NRF_802154_ASSERT_ZEPHYR)
+
+#include <zephyr/sys/__assert.h>
+
+#define NRF_802154_ASSERT(condition) __ASSERT_NO_MSG(condition)
+
+#elif defined(CONFIG_NRF_802154_ASSERT_ZEPHYR_MINIMAL)
+
+extern void nrf_802154_assert_handler(void);
+
+#define NRF_802154_ASSERT(condition) \
+	do {                             \
+		if (!(condition)) {          \
+			nrf_802154_assert_handler(); \
+		}                            \
+	} while (0)
+
+#endif /* CONFIG_NRF_802154_ASSERT_ZEPHYR_MINIMAL */
+
+#endif /* NRF_802154_ASSERT_ZEPHYR_H__*/

--- a/modules/hal_nordic/nrf_802154/nrf_802154_assert_handler.c
+++ b/modules/hal_nordic/nrf_802154/nrf_802154_assert_handler.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include "nrf_802154_assert_zephyr.h"
+
+#if defined(CONFIG_NRF_802154_ASSERT_ZEPHYR_MINIMAL)
+
+__weak void nrf_802154_assert_handler(void)
+{
+#ifdef CONFIG_USERSPACE
+	/* User threads aren't allowed to induce kernel panics; generate
+	 * an oops instead.
+	 */
+	if (k_is_user_context()) {
+		k_oops();
+	}
+#endif
+
+	k_panic();
+}
+
+#endif /* CONFIG_NRF_802154_ASSERT_ZEPHYR_MINIMAL */


### PR DESCRIPTION
Content already reviewed by some individuals here
https://github.com/nrfconnect/sdk-zephyr/pull/1411
https://github.com/nrfconnect/sdk-zephyr/pull/1411/commits/67b4158ed10892e49449b7a296395fddcefb0606


Recent nRF 802.15.4 Radio Driver provides assert abstraction layer. The assert abstraction layer is implemented in Zephyr in following ways depending on the `NRF_802154_ASSERT_CHOICE` Kconfig choice.

`NRF_802154_ASSERT_ZEPHYR_MINIMAL` (default) gives ability to still perform run-time checking of the nRF 802.15.4 Radio Driver operation with minimum memory overhead and configurable behavior on fault detection regardless of the `CONFIG_ASSERT` Kconfig option value.

`NRF_802154_ASSERT_ZEPHYR` gives ability to use asserts provided and configurable by Zephyr including the ability to turn off the run-time checking of the nRF 802.15.4 Radio Driver operation.