### PR TITLE
Bluetooth: has: Check writable preset support on preset registration

### DIFF
--- a/subsys/bluetooth/audio/has.c
+++ b/subsys/bluetooth/audio/has.c
@@ -1501,6 +1501,12 @@ int bt_has_preset_register(const struct bt_has_preset_register_param *param)
 		return -EALREADY;
 	}
 
+	CHECKIF(!IS_ENABLED(CONFIG_BT_HAS_PRESET_NAME_DYNAMIC) &&
+		(param->properties & BT_HAS_PROP_WRITABLE) > 0) {
+		LOG_ERR("Writable presets are not supported");
+		return -ENOTSUP;
+	}
+
 	preset = preset_alloc(param->index, param->properties, param->name, param->ops);
 	if (preset == NULL) {
 		return -ENOMEM;


### PR DESCRIPTION
This fixes issue where API use is able to register writable preset even if the CONFIG_BT_HAS_PRESET_NAME_DYNAMIC Kconfig option was disabled.