### PR TITLE
unifiy prep_c naming across architectures

### DIFF
--- a/arch/arc/core/prep_c.c
+++ b/arch/arc/core/prep_c.c
@@ -88,7 +88,7 @@ extern FUNC_NORETURN void z_cstart(void);
  * This routine prepares for the execution of and runs C code.
  */
 
-void _PrepC(void)
+void z_prep_c(void)
 {
 	z_bss_zero();
 #ifdef __CCAC__

--- a/arch/arc/core/reset.S
+++ b/arch/arc/core/reset.S
@@ -40,7 +40,7 @@ GTEXT(__start)
  *
  * Locking interrupts prevents anything from interrupting the CPU.
  *
- * When these steps are completed, jump to _PrepC(), which will finish setting
+ * When these steps are completed, jump to z_prep_c(), which will finish setting
  * up the system for running C code.
  */
 
@@ -202,4 +202,4 @@ _master_core_startup:
 	jl z_arc_firq_stack_set
 #endif
 
-	j _PrepC
+	j z_prep_c

--- a/arch/arc/include/vector_table.h
+++ b/arch/arc/include/vector_table.h
@@ -46,7 +46,7 @@ GTEXT(__ev_div_zero)
 GTEXT(__ev_dc_error)
 GTEXT(__ev_maligned)
 
-GTEXT(_PrepC)
+GTEXT(z_prep_c)
 GTEXT(_isr_wrapper)
 
 #else

--- a/arch/arm/core/cortex_a_r/prep_c.c
+++ b/arch/arm/core/cortex_a_r/prep_c.c
@@ -145,7 +145,7 @@ extern FUNC_NORETURN void z_cstart(void);
  * This routine prepares for the execution of and runs C code.
  *
  */
-void z_arm_prep_c(void)
+void z_prep_c(void)
 {
 	/* Initialize tpidruro with our struct _cpu instance address */
 	write_tpidruro((uintptr_t)&_kernel.cpus[0]);

--- a/arch/arm/core/cortex_a_r/reset.S
+++ b/arch/arm/core/cortex_a_r/reset.S
@@ -42,7 +42,7 @@ GTEXT(z_arm_platform_init)
  * and interrupts are disabled. The processor architectural registers are in
  * an indeterminate state.
  *
- * When these steps are completed, jump to z_arm_prep_c(), which will finish
+ * When these steps are completed, jump to z_prep_c(), which will finish
  * setting up the system for running C code.
  *
  */
@@ -229,7 +229,7 @@ EL1_Reset_Handler:
 _primary_core:
 #endif
 
-    ldr r4, =z_arm_prep_c
+    ldr r4, =z_prep_c
     ldr r5, =(z_arm_fiq_stack + CONFIG_ARMV7_FIQ_STACK_SIZE)
     ldr r6, =(z_interrupt_stacks + CONFIG_ISR_STACK_SIZE)
     ldr r7, =(z_arm_abort_stack + CONFIG_ARMV7_EXCEPTION_STACK_SIZE)

--- a/arch/arm/core/cortex_a_r/vector_table.h
+++ b/arch/arm/core/cortex_a_r/vector_table.h
@@ -40,7 +40,7 @@ GTEXT(z_arm_data_abort)
 GTEXT(z_arm_pendsv)
 GTEXT(z_arm_reserved)
 
-GTEXT(z_arm_prep_c)
+GTEXT(z_prep_c)
 GTEXT(_isr_wrapper)
 
 #else /* _ASMLANGUAGE */

--- a/arch/arm/core/cortex_m/prep_c.c
+++ b/arch/arm/core/cortex_m/prep_c.c
@@ -179,7 +179,7 @@ extern FUNC_NORETURN void z_cstart(void);
  * This routine prepares for the execution of and runs C code.
  *
  */
-void z_arm_prep_c(void)
+void z_prep_c(void)
 {
 	relocate_vector_table();
 #if defined(CONFIG_CPU_HAS_FPU)

--- a/arch/arm/core/cortex_m/reset.S
+++ b/arch/arm/core/cortex_m/reset.S
@@ -53,7 +53,7 @@ GTEXT(arch_pm_s2ram_resume)
  * MSP is to be set up to point to the one-and-only interrupt stack during
  * later boot. That would not be possible if in use for running C code.
  *
- * When these steps are completed, jump to z_arm_prep_c(), which will finish
+ * When these steps are completed, jump to z_prep_c(), which will finish
  * setting up the system for running C code.
  *
  */
@@ -163,7 +163,7 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,__start)
 
     /*
      * 'bl' jumps the furthest of the branch instructions that are
-     * supported on all platforms. So it is used when jumping to z_arm_prep_c
+     * supported on all platforms. So it is used when jumping to z_prep_c
      * (even though we do not intend to return).
      */
-    bl z_arm_prep_c
+    bl z_prep_c

--- a/arch/arm/core/cortex_m/vector_table.h
+++ b/arch/arm/core/cortex_m/vector_table.h
@@ -50,7 +50,7 @@ GTEXT(z_arm_debug_monitor)
 GTEXT(z_arm_pendsv)
 GTEXT(z_arm_exc_spurious)
 
-GTEXT(z_arm_prep_c)
+GTEXT(z_prep_c)
 #if defined(CONFIG_GEN_ISR_TABLES)
 GTEXT(_isr_wrapper)
 #endif /* CONFIG_GEN_ISR_TABLES */

--- a/arch/arm64/core/prep_c.c
+++ b/arch/arm64/core/prep_c.c
@@ -51,7 +51,7 @@ void z_early_memcpy(void *dst, const void *src, size_t n)
  * This routine prepares for the execution of and runs C code.
  *
  */
-void z_arm64_prep_c(void)
+void z_prep_c(void)
 {
 	/* Initialize tpidrro_el0 with our struct _cpu instance address */
 	write_tpidrro_el0((uintptr_t)&_kernel.cpus[0]);

--- a/arch/arm64/core/prep_c.c
+++ b/arch/arm64/core/prep_c.c
@@ -64,8 +64,8 @@ void z_prep_c(void)
 #endif
 	z_arm64_mm_init(true);
 	z_arm64_interrupt_init();
-	z_cstart();
 
+	z_cstart();
 	CODE_UNREACHABLE;
 }
 

--- a/arch/arm64/core/reset.S
+++ b/arch/arm64/core/reset.S
@@ -188,7 +188,7 @@ primary_core:
 #endif
 	/* load primary stack and entry point */
 	ldr	x24, =(z_interrupt_stacks + __z_interrupt_stack_SIZEOF)
-	ldr	x25, =z_arm64_prep_c
+	ldr	x25, =z_prep_c
 boot:
 	/* Prepare for calling C code */
 	bl	__reset_prep_c
@@ -248,4 +248,4 @@ switch_el:
 	msr	DAIFClr, #(DAIFCLR_ABT_BIT)
 	isb
 
-	ret	x25  /* either z_arm64_prep_c or z_arm64_secondary_prep_c */
+	ret	x25  /* either z_prep_c or z_arm64_secondary_prep_c */

--- a/arch/mips/core/prep_c.c
+++ b/arch/mips/core/prep_c.c
@@ -42,7 +42,7 @@ static void interrupt_init(void)
  * @return N/A
  */
 
-void _PrepC(void)
+void z_prep_c(void)
 {
 	z_bss_zero();
 

--- a/arch/mips/core/reset.S
+++ b/arch/mips/core/reset.S
@@ -11,7 +11,7 @@
 
 GTEXT(__initialize)
 GTEXT(__stack)
-GTEXT(_PrepC)
+GTEXT(z_prep_c)
 
 /*
  * Remainder of asm-land initialization code before we can jump into
@@ -52,6 +52,6 @@ aa_loop:
 	/*
 	 * Jump into C domain.
 	 */
-	la v0, _PrepC
+	la v0, z_prep_c
 	jal v0
 	nop /* delay slot */

--- a/arch/nios2/core/crt0.S
+++ b/arch/nios2/core/crt0.S
@@ -12,7 +12,7 @@ GTEXT(__start)
 GTEXT(__reset)
 
 /* imports */
-GTEXT(_PrepC)
+GTEXT(z_prep_c)
 GTEXT(z_interrupt_stacks)
 
 	/* Allow use of r1/at (the assembler temporary register) in this
@@ -140,7 +140,7 @@ SECTION_FUNC(TEXT, __start)
 	 * GH-1821
 	 */
 
-	/* Jump into C domain. _PrepC zeroes BSS, copies rw data into RAM,
+	/* Jump into C domain. z_prep_c zeroes BSS, copies rw data into RAM,
 	 * and then enters z_cstart */
-	call _PrepC
+	call z_prep_c
 

--- a/arch/nios2/core/prep_c.c
+++ b/arch/nios2/core/prep_c.c
@@ -28,7 +28,7 @@
  * This routine prepares for the execution of and runs C code.
  */
 
-void _PrepC(void)
+void z_prep_c(void)
 {
 	z_bss_zero();
 	z_data_copy();

--- a/arch/riscv/core/prep_c.c
+++ b/arch/riscv/core/prep_c.c
@@ -27,7 +27,7 @@
  * This routine prepares for the execution of and runs C code.
  */
 
-void _PrepC(void)
+void z_prep_c(void)
 {
 	z_bss_zero();
 	z_data_copy();

--- a/arch/riscv/core/reset.S
+++ b/arch/riscv/core/reset.S
@@ -16,7 +16,7 @@ GTEXT(__initialize)
 GTEXT(__reset)
 
 /* imports */
-GTEXT(_PrepC)
+GTEXT(z_prep_c)
 GTEXT(riscv_cpu_wake_flag)
 GTEXT(riscv_cpu_sp)
 GTEXT(z_riscv_secondary_cpu_init)
@@ -86,10 +86,10 @@ aa_loop:
 #endif
 
 	/*
-	 * Jump into C domain. _PrepC zeroes BSS, copies rw data into RAM,
+	 * Jump into C domain. z_prep_c zeroes BSS, copies rw data into RAM,
 	 * and then enters kernel z_cstart
 	 */
-	call _PrepC
+	call z_prep_c
 
 boot_secondary_core:
 #if CONFIG_MP_MAX_NUM_CPUS > 1

--- a/arch/sparc/core/prep_c.c
+++ b/arch/sparc/core/prep_c.c
@@ -17,7 +17,7 @@
  * This routine prepares for the execution of and runs C code.
  */
 
-void _PrepC(void)
+void z_prep_c(void)
 {
 	z_data_copy();
 	z_cstart();

--- a/arch/sparc/core/reset_trap.S
+++ b/arch/sparc/core/reset_trap.S
@@ -48,7 +48,7 @@ SECTION_FUNC(TEXT, __sparc_trap_reset)
 	call	z_bss_zero
 	 nop
 
-	call    _PrepC
+	call    z_prep_c
 	 nop
 
 /* We halt the system by generating a "trap in trap" condition. */

--- a/arch/x86/core/common.S
+++ b/arch/x86/core/common.S
@@ -17,7 +17,7 @@
          * contains MULTIBOOT_EAX_MAGIC and EBX points to a valid 'struct
          * multiboot_info'; otherwise EBX is just junk. Check EAX early
 	 * before it's clobbered and leave a sentinel (0) in EBX if invalid.
-	 * The valid in EBX will be the argument to z_x86_prep_c(), so the
+	 * The valid in EBX will be the argument to z_prep_c(), so the
 	 * subsequent code must, of course, be sure to preserve it meanwhile.
 	 */
 

--- a/arch/x86/core/ia32/crt0.S
+++ b/arch/x86/core/ia32/crt0.S
@@ -28,7 +28,7 @@
 	GTEXT(__start)
 
 	/* externs */
-	GTEXT(z_x86_prep_c)
+	GTEXT(z_prep_c)
 	GTEXT(z_bss_zero)
 	GTEXT(z_data_copy)
 
@@ -287,7 +287,7 @@ __csSet:
 	/* pointer to multiboot info, or NULL */
 	movl	%ebx, __x86_boot_arg_t_arg_OFFSET(%ebp)
 	pushl	$x86_cpu_boot_arg
-	call	z_x86_prep_c	/* enter kernel; never returns */
+	call	z_prep_c	/* enter kernel; never returns */
 
 #if defined(CONFIG_X86_SSE)
 

--- a/arch/x86/core/intel64/cpu.c
+++ b/arch/x86/core/intel64/cpu.c
@@ -110,7 +110,7 @@ struct x86_cpuboot x86_cpuboot[] = {
 			Z_KERNEL_STACK_SIZE_ADJUST(CONFIG_ISR_STACK_SIZE),
 		.stack_size =
 			Z_KERNEL_STACK_SIZE_ADJUST(CONFIG_ISR_STACK_SIZE),
-		.fn = z_x86_prep_c,
+		.fn = z_prep_c,
 		.arg = &x86_cpu_boot_arg,
 	},
 #if CONFIG_MP_MAX_NUM_CPUS > 1
@@ -176,7 +176,7 @@ void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
 #endif
 }
 
-/* Per-CPU initialization, C domain. On the first CPU, z_x86_prep_c is the
+/* Per-CPU initialization, C domain. On the first CPU, z_prep_c is the
  * next step. For other CPUs it is probably smp_init_top().
  */
 FUNC_NORETURN void z_x86_cpu_init(struct x86_cpuboot *cpuboot)

--- a/arch/x86/core/prep_c.c
+++ b/arch/x86/core/prep_c.c
@@ -21,7 +21,7 @@ __pinned_data x86_boot_arg_t x86_cpu_boot_arg;
  * CPU for SMP systems.
  */
 __boot_func
-FUNC_NORETURN void z_x86_prep_c(void *arg)
+FUNC_NORETURN void z_prep_c(void *arg)
 {
 	x86_boot_arg_t *cpu_arg = arg;
 

--- a/arch/x86/core/prep_c.c
+++ b/arch/x86/core/prep_c.c
@@ -78,4 +78,5 @@ FUNC_NORETURN void z_x86_prep_c(void *arg)
 #endif
 
 	z_cstart();
+	CODE_UNREACHABLE;
 }

--- a/arch/x86/include/kernel_arch_func.h
+++ b/arch/x86/include/kernel_arch_func.h
@@ -37,7 +37,7 @@ static inline bool arch_is_in_isr(void)
 
 struct multiboot_info;
 
-extern FUNC_NORETURN void z_x86_prep_c(void *arg);
+extern FUNC_NORETURN void z_prep_c(void *arg);
 
 #ifdef CONFIG_X86_VERY_EARLY_CONSOLE
 /* Setup ultra-minimal serial driver for printk() */

--- a/boards/nios2/altera_max10/doc/index.rst
+++ b/boards/nios2/altera_max10/doc/index.rst
@@ -233,7 +233,7 @@ You will see output similar to the following:
    Listening on port 3335 for connection from GDB: accepted
    isr_tables_syms () at /projects/zephyr/arch/common/isr_tables.c:63
    63      GEN_ABSOLUTE_SYM(__ISR_LIST_SIZEOF, sizeof(struct _isr_list));
-   (gdb) b _PrepC
+   (gdb) b z_prep_c
    Breakpoint 1 at 0xdf0: file /projects/zephyr/arch/nios2/core/prep_c.c, line 36.
    (gdb) b z_cstart
    Breakpoint 2 at 0x1254: file /projects/zephyr/kernel/init.c, line 348.

--- a/doc/services/debugging/gdbstub.rst
+++ b/doc/services/debugging/gdbstub.rst
@@ -149,7 +149,7 @@ for its implementation as a Twister test.
          #1  0x00105068 in gdb_init (arg=0x0) at <ZEPHYR_BASE>/subsys/debug/gdbstub.c:833
          #2  0x00109d6f in z_sys_init_run_level (level=0x1) at <ZEPHYR_BASE>/kernel/device.c:72
          #3  0x0010a40b in z_cstart () at <ZEPHYR_BASE>/kernel/init.c:423
-         #4  0x00105383 in z_x86_prep_c (arg=0x9500) at <ZEPHYR_BASE>/arch/x86/core/prep_c.c:58
+         #4  0x00105383 in z_prep_c (arg=0x9500) at <ZEPHYR_BASE>/arch/x86/core/prep_c.c:58
          #5  0x001000a9 in __csSet () at <ZEPHYR_BASE>/arch/x86/core/ia32/crt0.S:273
 
    #. Use command ``list`` to show the source code and surroundings where


### PR DESCRIPTION
Part of a larger effort to unify naming and workflows across architectures to make debugging and documentation easier.

No functional changes.

- arch: _PrepC -> z_prep_c
- arch: arm: z_arm64_prep_c -> z_prep_c
- x86: add CODE_UNREACHABLE after z_cstart
- arch: x86: z_x86_prep_c -> z_prep_c
- arch: arm: z_arm_prep_c -> z_prep_c
