### PR TITLE
drivers: intc: manage multi-level interrupt configs

### DIFF
--- a/drivers/interrupt_controller/Kconfig.clic
+++ b/drivers/interrupt_controller/Kconfig.clic
@@ -5,5 +5,6 @@ config NUCLEI_ECLIC
 	bool "Enhanced Core Local Interrupt Controller (ECLIC)"
 	default y
 	depends on DT_HAS_NUCLEI_ECLIC_ENABLED
+	select MULTI_LEVEL_INTERRUPTS
 	help
 	  Interrupt controller for Nuclei SoC core.

--- a/drivers/interrupt_controller/Kconfig.multilevel
+++ b/drivers/interrupt_controller/Kconfig.multilevel
@@ -18,6 +18,7 @@ config MULTI_LEVEL_INTERRUPTS
 	  by the hardware. (The term "aggregator" here means "interrupt
 	  controller".)
 
+if MULTI_LEVEL_INTERRUPTS
 config 1ST_LEVEL_INTERRUPT_BITS
 	int "Total number of first level interrupt bits"
 	range 1 32
@@ -29,7 +30,6 @@ config 1ST_LEVEL_INTERRUPT_BITS
 config MAX_IRQ_PER_AGGREGATOR
 	int "Max IRQs per interrupt aggregator"
 	default 0
-	depends on MULTI_LEVEL_INTERRUPTS
 
 	help
 	  The maximum number of interrupt inputs to any aggregator in the
@@ -37,7 +37,6 @@ config MAX_IRQ_PER_AGGREGATOR
 
 config 2ND_LEVEL_INTERRUPTS
 	bool "Second-level interrupt support"
-	depends on MULTI_LEVEL_INTERRUPTS
 	help
 	  Second level interrupts are used to increase the number of
 	  addressable interrupts in a system.
@@ -142,3 +141,5 @@ aggregator = 6
 rsource "Kconfig.multilevel.aggregator_template"
 aggregator = 7
 rsource "Kconfig.multilevel.aggregator_template"
+
+endif

--- a/include/zephyr/irq_multilevel.h
+++ b/include/zephyr/irq_multilevel.h
@@ -19,6 +19,7 @@
 extern "C" {
 #endif
 
+#if defined(CONFIG_MULTI_LEVEL_INTERRUPTS) || defined(__DOXYGEN__)
 /**
  * @brief Return IRQ level
  * This routine returns the interrupt level number of the provided interrupt.
@@ -165,6 +166,7 @@ static inline unsigned int irq_parent_level_3(unsigned int irq)
 		BIT_MASK(CONFIG_2ND_LEVEL_INTERRUPT_BITS);
 }
 
+#endif /* CONFIG_MULTI_LEVEL_INTERRUPTS */
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/irq_nextlevel.h
+++ b/include/zephyr/irq_nextlevel.h
@@ -15,6 +15,7 @@
 extern "C" {
 #endif
 
+#if defined(CONFIG_MULTI_LEVEL_INTERRUPTS) || defined(__DOXYGEN__)
 /**
  * @cond INTERNAL_HIDDEN
  *
@@ -134,6 +135,7 @@ static inline unsigned int irq_line_is_enabled_next_level(const struct device *d
 	return api->intr_get_line_state(dev, irq);
 }
 
+#endif /* CONFIG_MULTI_LEVEL_INTERRUPTS */
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Multilevel interrupt configs are leaking into every single build without
this option being enabled, so guard the Kconfig and include files to
avoid this.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
