### PR TITLE
include: arm: mpu: add missing RAM NOCACHE region define for armv8-r

### DIFF
--- a/include/zephyr/arch/arm/mpu/arm_mpu_v8.h
+++ b/include/zephyr/arch/arm/mpu/arm_mpu_v8.h
@@ -220,7 +220,14 @@
 		.mair_idx = MPU_MAIR_INDEX_SRAM,			    \
 		.r_limit = limit - 1,  /* Region Limit */		    \
 	}
-
+#define REGION_RAM_NOCACHE_ATTR(limit)					    \
+	{								    \
+		.rbar = NOT_EXEC |					    \
+			P_RW_U_NA_Msk | NON_SHAREABLE_Msk, /* AP, XN, SH */ \
+		/* Cache-ability */					    \
+		.mair_idx = MPU_MAIR_INDEX_SRAM_NOCACHE,		    \
+		.r_limit = limit - 1,  /* Region Limit */		    \
+	}
 #if defined(CONFIG_MPU_ALLOW_FLASH_WRITE)
 /* Note that the access permissions allow for un-privileged writes, contrary
  * to ARMv7-M where un-privileged code has Read-Only permissions.


### PR DESCRIPTION
Add missing define for a non-cacheable RAM region for MPU on armv8-r aarch32