### PR TITLE
manifest: update hal_nxp for s32k3 lpspi.

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -193,7 +193,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: cbf2cd1f099585eeef2cdb0c68d72e9e67e89c24
+      revision: 2a294b540c09b36f7cddece44d25628bfde5970e
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Update hal_nxp to remove S32K3X4-0P55A-1P55A-ERRATA by disabling FSL_FEATURE_LPSPI_HAS_ERRATA_050456.
This allows for lpspi to work correctly on mr_canhubk3.