### PR TITLE
sys: arch_interface: fix doc in arch_user_mode_enter

### DIFF
--- a/include/zephyr/sys/arch_interface.h
+++ b/include/zephyr/sys/arch_interface.h
@@ -800,7 +800,7 @@ int arch_buffer_validate(void *addr, size_t size, int write);
 size_t arch_virt_region_align(uintptr_t phys, size_t size);
 
 /**
- * Perform a one-way transition from supervisor to kernel mode.
+ * Perform a one-way transition from supervisor to user mode.
  *
  * Implementations of this function must do the following:
  *


### PR DESCRIPTION
The transition is to USER mode, and not kernel mode.