### PR TITLE
kernel: Tweak k_pipe_put() API to use 'const' with data parameter

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -4968,7 +4968,7 @@ __syscall int k_pipe_alloc_init(struct k_pipe *pipe, size_t size);
  * @retval -EAGAIN Waiting period timed out; between zero and @a min_xfer
  *                 minus one data bytes were written.
  */
-__syscall int k_pipe_put(struct k_pipe *pipe, void *data,
+__syscall int k_pipe_put(struct k_pipe *pipe, const void *data,
 			 size_t bytes_to_write, size_t *bytes_written,
 			 size_t min_xfer, k_timeout_t timeout);
 

--- a/kernel/pipes.c
+++ b/kernel/pipes.c
@@ -377,9 +377,9 @@ static size_t pipe_write(struct k_pipe *pipe, sys_dlist_t *src_list,
 	return num_bytes_written;
 }
 
-int z_impl_k_pipe_put(struct k_pipe *pipe, void *data, size_t bytes_to_write,
-		     size_t *bytes_written, size_t min_xfer,
-		      k_timeout_t timeout)
+int z_impl_k_pipe_put(struct k_pipe *pipe, const void *data,
+		      size_t bytes_to_write, size_t *bytes_written,
+		      size_t min_xfer, k_timeout_t timeout)
 {
 	struct _pipe_desc  pipe_desc[2];
 	struct _pipe_desc  isr_desc;
@@ -445,7 +445,7 @@ int z_impl_k_pipe_put(struct k_pipe *pipe, void *data, size_t bytes_to_write,
 
 	src_desc = k_is_in_isr() ? &isr_desc : &_current->pipe_desc;
 
-	src_desc->buffer        = data;
+	src_desc->buffer        = (unsigned char *)data;
 	src_desc->bytes_to_xfer = bytes_to_write;
 	src_desc->thread        = _current;
 	sys_dlist_append(&src_list, &src_desc->node);
@@ -513,17 +513,17 @@ int z_impl_k_pipe_put(struct k_pipe *pipe, void *data, size_t bytes_to_write,
 }
 
 #ifdef CONFIG_USERSPACE
-int z_vrfy_k_pipe_put(struct k_pipe *pipe, void *data, size_t bytes_to_write,
-		     size_t *bytes_written, size_t min_xfer,
-		      k_timeout_t timeout)
+int z_vrfy_k_pipe_put(struct k_pipe *pipe, const void *data,
+		      size_t bytes_to_write, size_t *bytes_written,
+		      size_t min_xfer, k_timeout_t timeout)
 {
 	K_OOPS(K_SYSCALL_OBJ(pipe, K_OBJ_PIPE));
 	K_OOPS(K_SYSCALL_MEMORY_WRITE(bytes_written, sizeof(*bytes_written)));
 	K_OOPS(K_SYSCALL_MEMORY_READ((void *)data, bytes_to_write));
 
-	return z_impl_k_pipe_put((struct k_pipe *)pipe, (void *)data,
-				bytes_to_write, bytes_written, min_xfer,
-				timeout);
+	return z_impl_k_pipe_put((struct k_pipe *)pipe, data,
+				 bytes_to_write, bytes_written, min_xfer,
+				 timeout);
 }
 #include <syscalls/k_pipe_put_mrsh.c>
 #endif

--- a/tests/kernel/pipe/pipe_api/src/test_pipe_contexts.c
+++ b/tests/kernel/pipe/pipe_api/src/test_pipe_contexts.c
@@ -353,6 +353,8 @@ ZTEST(pipe_api, test_half_pipe_put_get)
 	size_t rd_byte = 0;
 	int ret;
 
+	memset(rx_data, 0, sizeof(rx_data));
+
 	/* TESTPOINT: min_xfer > bytes_to_read */
 	ret = k_pipe_put(&kpipe, &rx_data[0], 1, &rd_byte, 24, K_NO_WAIT);
 	zassert_true(ret == -EINVAL);


### PR DESCRIPTION
In the function _k_pipe_put()_, the _data_ parameter, which points to a buffer that is written to the pipe, now uses the `const` keyword. Internally, that pointer is cast to drop the 'const' to work with the common code that both _k_pipe_put()_ and _k_pipe_get()_ share as it is known that k_pipe_put() will take a path where the contents of that buffer will not be modified.

Fixes #53946