### PR TITLE
include: arch: arm: Fix arch_curr_cpu() for Cortex-M

### DIFF
--- a/include/zephyr/arch/arm/arch_inlines.h
+++ b/include/zephyr/arch/arm/arch_inlines.h
@@ -8,14 +8,24 @@
 #define ZEPHYR_INCLUDE_ARCH_ARM_AARCH32_ARCH_INLINES_H
 
 #include <zephyr/kernel_structs.h>
+#if defined(CONFIG_CPU_AARCH32_CORTEX_R) || defined(CONFIG_CPU_AARCH32_CORTEX_A)
 #include <zephyr/arch/arm/cortex_a_r/lib_helpers.h>
 #include <zephyr/arch/arm/cortex_a_r/tpidruro.h>
 
 static ALWAYS_INLINE _cpu_t *arch_curr_cpu(void)
 {
-	/* Dummy implementation always return the first cpu */
 	return (_cpu_t *)(read_tpidruro() & TPIDRURO_CURR_CPU);
 }
+#else
+
+#ifndef CONFIG_SMP
+static ALWAYS_INLINE _cpu_t *arch_curr_cpu(void)
+{
+	/* Dummy implementation always return the first cpu */
+	return &_kernel.cpus[0];
+}
+#endif
+#endif
 
 static ALWAYS_INLINE uint32_t arch_proc_id(void)
 {


### PR DESCRIPTION
Currently, the `arch_curr_cpu()` implementation always uses the TPIDRURO register, even on Cortex-M CPUs where such a register is not available, causing a CPU fault.

For instance, on Cortex-M board `b_u585i_iot02a`, if this patch is applied to `sample/hello_world`:

(compiled with: `$ west build -p always -b b_u585i_iot02a samples/hello_world/ -t flash`)

```
 #include <stdio.h>
 
 int main(void)
 {
        printf("Hello World! %s\n", CONFIG_BOARD);
+       printf("arch_proc_id = %d\n", arch_proc_id());
        return 0;
 }
```

Call to `arch_proc_id()` will generate an illegal instruction due to the use of TPIDRURO mv instr:

```
Program received signal SIGINT, Interrupt.
arch_system_halt (reason=33) at /home/gromero/zephyrproject/zephyr/kernel/fatal.c:32
32		for (;;) {
(gdb) bt
#0  arch_system_halt (reason=33) at /home/gromero/zephyrproject/zephyr/kernel/fatal.c:32
#1  0x08002e00 in k_sys_fatal_error_handler (reason=<optimized out>, esf=esf@entry=0x20000ac0 <z_interrupt_stacks+1984>) at /home/gromero/zephyrproject/zephyr/kernel/fatal.c:46
#2  0x080017be in z_fatal_error (reason=<optimized out>, esf=esf@entry=0x20000ac0 <z_interrupt_stacks+1984>) at /home/gromero/zephyrproject/zephyr/kernel/fatal.c:122
#3  0x0800278e in z_arm_fatal_error (reason=<optimized out>, esf=esf@entry=0x20000ac0 <z_interrupt_stacks+1984>) at /home/gromero/zephyrproject/zephyr/arch/arm/core/fatal.c:73
#4  0x08000596 in z_arm_fault (msp=<optimized out>, psp=<optimized out>, exc_return=<optimized out>, callee_regs=<optimized out>) at /home/gromero/zephyrproject/zephyr/arch/arm/core/cortex_m/fault.c:1157
#5  0x08000654 in z_arm_usage_fault () at /home/gromero/zephyrproject/zephyr/arch/arm/core/cortex_m/fault_s.S:102
#6  <signal handler called>
#7  read_tpidruro () at /home/gromero/zephyrproject/zephyr/include/zephyr/arch/arm/cortex_a_r/lib_helpers.h:75
#8  arch_curr_cpu () at /home/gromero/zephyrproject/zephyr/include/zephyr/arch/arm/arch_inlines.h:17
#9  arch_proc_id () at /home/gromero/zephyrproject/zephyr/include/zephyr/arch/arm/arch_inlines.h:26
#10 main () at /home/gromero/zephyrproject/zephyr/samples/hello_world/src/main.c:13
(gdb) frame 7
#7  read_tpidruro () at /home/gromero/zephyrproject/zephyr/include/zephyr/arch/arm/cortex_a_r/lib_helpers.h:75
75	MAKE_REG_HELPER(tpidruro,    0, 13, 0, 3);
(gdb) disas
Dump of assembler code for function main:
   0x08000234 <+0>:	push	{r3, lr}
   0x08000236 <+2>:	ldr	r1, [pc, #28]	; (0x8000254 <main+32>)
   0x08000238 <+4>:	ldr	r0, [pc, #28]	; (0x8000258 <main+36>)
   0x0800023a <+6>:	bl	0x80020dc <printf>
=> 0x0800023e <+10>:			; <UNDEFINED> instruction: 0xee1d3f70
   0x08000242 <+14>:	bic.w	r3, r3, #3
   0x08000246 <+18>:	ldrb	r1, [r3, #16]
   0x08000248 <+20>:	ldr	r0, [pc, #16]	; (0x800025c <main+40>)
   0x0800024a <+22>:	bl	0x80020dc <printf>
   0x0800024e <+26>:	movs	r0, #0
   0x08000250 <+28>:	pop	{r3, pc}
   0x08000252 <+30>:	nop
   0x08000254 <+32>:	subs	r0, #2
   0x08000256 <+34>:	lsrs	r0, r0, #32
   0x08000258 <+36>:	subs	r0, #17
   0x0800025a <+38>:	lsrs	r0, r0, #32
   0x0800025c <+40>:	subs	r0, #34	; 0x22
   0x0800025e <+42>:	lsrs	r0, r0, #32
End of assembler dump.
(gdb)
``` 
This commit fixes it by reverting to the use of generic kernel struct to obtain the current cpu instead of using the TPIDRURO register on Cortex-M CPUs.