### PR TITLE
xtensa: mmu: Fix partition permission

### DIFF
--- a/arch/xtensa/core/ptables.c
+++ b/arch/xtensa/core/ptables.c
@@ -928,8 +928,9 @@ int arch_mem_domain_partition_remove(struct k_mem_domain *domain,
 int arch_mem_domain_partition_add(struct k_mem_domain *domain,
 				uint32_t partition_id)
 {
-	uint32_t ring = domain->arch.asid == 0 ? Z_XTENSA_KERNEL_RING : Z_XTENSA_USER_RING;
 	struct k_mem_partition *partition = &domain->partitions[partition_id];
+	uint32_t ring = K_MEM_PARTITION_IS_USER(partition->attr) ? Z_XTENSA_USER_RING :
+			Z_XTENSA_KERNEL_RING;
 
 	return update_region(domain->arch.ptables, partition->start,
 			     partition->size, ring, partition->attr, 0);

--- a/include/zephyr/arch/xtensa/xtensa_mmu.h
+++ b/include/zephyr/arch/xtensa/xtensa_mmu.h
@@ -14,16 +14,22 @@
 #define Z_XTENSA_MMU_CACHED_WB BIT(2)
 #define Z_XTENSA_MMU_CACHED_WT BIT(3)
 
+/* This bit is used in the HW. We just use it to know
+ * which ring pte entries should use.
+ */
+#define Z_XTENSA_MMU_USER BIT(4)
+
 #define K_MEM_PARTITION_IS_EXECUTABLE(attr)	(((attr) & Z_XTENSA_MMU_X) != 0)
 #define K_MEM_PARTITION_IS_WRITABLE(attr)	(((attr) & Z_XENSA_MMU_W) != 0)
+#define K_MEM_PARTITION_IS_USER(attr)	(((attr) & Z_XTENSA_MMU_USER) != 0)
 
 /* Read-Write access permission attributes */
 #define K_MEM_PARTITION_P_RW_U_RW ((k_mem_partition_attr_t) \
-			{Z_XTENSA_MMU_W})
+			{Z_XTENSA_MMU_W | Z_XTENSA_MMU_USER})
 #define K_MEM_PARTITION_P_RW_U_NA ((k_mem_partition_attr_t) \
 			{0})
 #define K_MEM_PARTITION_P_RO_U_RO ((k_mem_partition_attr_t) \
-			{0})
+			{Z_XTENSA_MMU_USER})
 #define K_MEM_PARTITION_P_RO_U_NA ((k_mem_partition_attr_t) \
 			{0})
 #define K_MEM_PARTITION_P_NA_U_NA ((k_mem_partition_attr_t) \


### PR DESCRIPTION
The ring field in the pte mapping a memory partition should be based in the partition attribute and not in the domain asid that is used only to set the ASID (in RASID) position for user ring.