### PR TITLE
sys: Modify ATOMIC_BITMAP_SIZE macro: num_bits = 0

### DIFF
--- a/include/zephyr/sys/atomic.h
+++ b/include/zephyr/sys/atomic.h
@@ -87,7 +87,7 @@ extern "C" {
  *
  * @param num_bits Number of bits.
  */
-#define ATOMIC_BITMAP_SIZE(num_bits) (1 + ((num_bits) - 1) / ATOMIC_BITS)
+#define ATOMIC_BITMAP_SIZE(num_bits) (ROUND_UP(num_bits, ATOMIC_BITS) / ATOMIC_BITS)
 
 /**
  * @brief Define an array of atomic variables.


### PR DESCRIPTION
The macro returned the wrong value for any case in which num_bits<=0, due to a signed/unsigned division. The num_bits=0 case was hit using static analysis in a Nordic Semiconductor SDK case.

Fixes #66356