### PR TITLE
mem_mgnt: Add reallocation method

### DIFF
--- a/include/zephyr/mem_mgmt/mem_attr_heap.h
+++ b/include/zephyr/mem_mgmt/mem_attr_heap.h
@@ -64,6 +64,27 @@ void *mem_attr_heap_alloc(uint32_t attr, size_t bytes);
 void *mem_attr_heap_aligned_alloc(uint32_t attr, size_t align, size_t bytes);
 
 /**
+ * @brief Expand the size of an existing allocation.
+ *
+ * Returns a pointer to a new memory region with the same contents, but different
+ * allocated size. If the existing allocation can be expanded in place,
+ * the returned pointer will be identical.
+ *
+ * @note The return of a NULL on failure is a different behavior than
+ * POSIX realloc(), which specifies that the original pointer will be
+ * returned (i.e. it is not possible to safely detect realloc()
+ * failure in POSIX, but it is here).
+ *
+ * @param block block to reallocate, must be a pointer to a block allocated by
+ *	  @ref mem_attr_heap_alloc.
+ * @param bytes requested size of the allocation in bytes.
+ *
+ * @retval ptr a valid pointer to the allocated memory.
+ * @retval NULL if no memory block with that size is available.
+ */
+void *mem_attr_heap_realloc(void *block, size_t bytes);
+
+/**
  * @brief Free the allocated memory
  *
  * Used to free the passed block of memory that must be the return value of a

--- a/include/zephyr/sys/multi_heap.h
+++ b/include/zephyr/sys/multi_heap.h
@@ -132,6 +132,27 @@ void *sys_multi_heap_alloc(struct sys_multi_heap *mheap, void *cfg, size_t bytes
 void *sys_multi_heap_aligned_alloc(struct sys_multi_heap *mheap,
 				   void *cfg, size_t align, size_t bytes);
 
+
+/**
+ * @brief Expand the size of an existing allocation
+ *
+ * Returns a pointer to a new memory region with the same contents, but different
+ * allocated size. If the existing allocation can be expanded in place,
+ * the returned pointer will be identical.
+ *
+ * @note It should not be assumed that the returned block is located in the
+ * same sys_heap as the original allocation. If allocation within the same
+ * sys_heap fails, allocation in another sys_heap matching the configuration
+ * pointer is attempted.
+ *
+ * @param mheap Multi heap pointer
+ * @param cfg Opaque configuration parameter, as for sys_multi_heap_fn_t
+ * @param block Block to reallocate, must be a pointer to a block allocated by sys_multi_heap_alloc
+ * @param bytes Requested size of the allocation, in bytes
+ * @return A valid pointer to heap memory, or NULL if no memory is available
+ */
+void *sys_multi_heap_realloc(struct sys_multi_heap *mheap, void *cfg, void *block, size_t bytes);
+
 /**
  * @brief Get a specific heap for provided address
  *

--- a/subsys/mem_mgmt/mem_attr_heap.c
+++ b/subsys/mem_mgmt/mem_attr_heap.c
@@ -8,6 +8,7 @@
 #include <zephyr/device.h>
 #include <zephyr/sys/sys_heap.h>
 #include <zephyr/mem_mgmt/mem_attr.h>
+#include <zephyr/mem_mgmt/mem_attr_heap.h>
 #include <zephyr/sys/multi_heap.h>
 #include <zephyr/dt-bindings/memory-attr/memory-attr.h>
 #include <zephyr/dt-bindings/memory-attr/memory-attr-sw.h>
@@ -70,6 +71,16 @@ void *mem_attr_heap_aligned_alloc(uint32_t attr, size_t align, size_t bytes)
 {
 	return sys_multi_heap_aligned_alloc(&mah_data.multi_heap,
 					    (void *)(long) attr, align, bytes);
+}
+
+void *mem_attr_heap_realloc(void *addr, size_t bytes)
+{
+	const struct mem_attr_region_t *region;
+
+	region = mem_attr_heap_get_region(addr);
+
+	return sys_multi_heap_realloc(&mah_data.multi_heap, (void *)(long)region->dt_attr, addr,
+				      bytes);
 }
 
 const struct mem_attr_region_t *mem_attr_heap_get_region(void *addr)

--- a/tests/subsys/mem_mgmt/mem_attr_heap/src/main.c
+++ b/tests/subsys/mem_mgmt/mem_attr_heap/src/main.c
@@ -49,6 +49,19 @@ ZTEST(mem_attr_heap, test_mem_attr_heap)
 		      "Memory allocated from the wrong region");
 
 	/*
+	 * Try to reallocate slightly larger.
+	 */
+	block = mem_attr_heap_realloc(block, 0x200);
+	zassert_not_null(block, "Failed to reallocate memory");
+
+	/*
+	 * Check that the reallocated memory has the same attributes.
+	 */
+	region = mem_attr_heap_get_region(block);
+	zassert_equal(region->dt_addr, ADDR_MEM_CACHE_SW,
+		      "Memory reallocated should have the same attribute");
+
+	/*
 	 * Allocate 0x100 bytes of non-cacheable memory.
 	 */
 	block = mem_attr_heap_alloc(DT_MEM_SW_ALLOC_NON_CACHE, 0x100);


### PR DESCRIPTION
To leverage the newly added mem_mgnt subsystem for LVGL an implementation of realloc is needed.
This PR implements the reallocation first in the multi_heap and based on that finally in the mem_attr_heap.