### PR TITLE
scripts: ci: guideline_check: support other repos

### DIFF
--- a/scripts/ci/guideline_check.py
+++ b/scripts/ci/guideline_check.py
@@ -11,13 +11,6 @@ from unidiff import PatchSet
 if "ZEPHYR_BASE" not in os.environ:
     exit("$ZEPHYR_BASE environment variable undefined.")
 
-repository_path = os.environ['ZEPHYR_BASE']
-
-sh_special_args = {
-    '_tty_out': False,
-    '_cwd': repository_path
-}
-
 coccinelle_scripts = ["/scripts/coccinelle/reserved_names.cocci",
                       "/scripts/coccinelle/same_identifier.cocci",
                       #"/scripts/coccinelle/identifier_length.cocci",
@@ -38,7 +31,9 @@ def parse_coccinelle(contents: str, violations: dict):
 
 def parse_args():
     parser = argparse.ArgumentParser(
-        description="Check if change requires full twister", allow_abbrev=False)
+        description="Check commits against Cocccinelle rules", allow_abbrev=False)
+    parser.add_argument('-r', "--repository", required=False,
+                        help="Path to repository")
     parser.add_argument('-c', '--commits', default=None,
                         help="Commit range in the form: a..b")
     parser.add_argument("-o", "--output", required=False,
@@ -50,6 +45,16 @@ def main():
     args = parse_args()
     if not args.commits:
         exit("missing commit range")
+
+    if args.repository is None:
+        repository_path = os.environ['ZEPHYR_BASE']
+    else:
+        repository_path = args.repository
+
+    sh_special_args = {
+        '_tty_out': False,
+        '_cwd': repository_path
+    }
 
     # pylint does not like the 'sh' library
     # pylint: disable=too-many-function-args,unexpected-keyword-arg


### PR DESCRIPTION
The CI script is useful in downstream repositories that wish to enforce Zephyr coding standards.
Adding this option lets the check be run against an alternate repo, without needing to copy files from Zephyr.