### PR TITLE
mgmt: mcumgr: callback: Add op to receive callback

### DIFF
--- a/include/zephyr/mgmt/mcumgr/mgmt/callbacks.h
+++ b/include/zephyr/mgmt/mcumgr/mgmt/callbacks.h
@@ -251,6 +251,9 @@ struct mgmt_evt_op_cmd_arg {
 	uint8_t id;
 
 	union {
+		/** #mcumgr_op_t used in #MGMT_EVT_OP_CMD_RECV */
+		uint8_t op;
+
 		/** #mcumgr_err_t, used in #MGMT_EVT_OP_CMD_DONE */
 		int err;
 

--- a/subsys/mgmt/mcumgr/smp/src/smp.c
+++ b/subsys/mgmt/mcumgr/smp/src/smp.c
@@ -203,7 +203,7 @@ static int smp_handle_single_payload(struct smp_streamer *cbuf, const struct smp
 #if defined(CONFIG_MCUMGR_SMP_COMMAND_STATUS_HOOKS)
 		cmd_recv.group = req_hdr->nh_group;
 		cmd_recv.id = req_hdr->nh_id;
-		cmd_recv.err = MGMT_ERR_EOK;
+		cmd_recv.op = req_hdr->nh_op;
 
 		/* Send request to application to check if handler should run or not. */
 		status = mgmt_callback_notify(MGMT_EVT_OP_CMD_RECV, &cmd_recv, sizeof(cmd_recv),


### PR DESCRIPTION
Adds the operation supplied by the client to the MCUmgr command received callback