### PR TITLE
ipc_service: Separate RPMsg's physical&virtual address

### DIFF
--- a/dts/bindings/ipc/zephyr,ipc-openamp-static-vrings.yaml
+++ b/dts/bindings/ipc/zephyr,ipc-openamp-static-vrings.yaml
@@ -1,4 +1,5 @@
 # Copyright (c) 2021 Carlo Caione <ccaione@baylibre.com>
+# Copyright (c) 2023 Ambiq Micro Inc. <www.ambiq.com>
 # SPDX-License-Identifier: Apache-2.0
 
 description: OpenAMP (RPMsg with static VRINGs) backend
@@ -17,9 +18,17 @@ properties:
       - remote
 
   memory-region:
-    description: phandle to the shared memory region
+    description: |
+      phandle to the shared memory region, start address should be physical
+      address
     required: true
     type: phandle
+
+  virtual-addr:
+    description: |
+      Shared memory region's virtual address, if this field is not filled,
+      virtual address is same as memory-region's start(physical) address
+    type: int
 
   mboxes:
     description: phandle to the MBOX controller (TX and RX are required)

--- a/subsys/ipc/ipc_service/lib/ipc_static_vrings.c
+++ b/subsys/ipc/ipc_service/lib/ipc_static_vrings.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Carlo Caione <ccaione@baylibre.com>
+ * Copyright (c) 2023 Ambiq Micro Inc. <www.ambiq.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -168,7 +169,6 @@ int ipc_static_vrings_init(struct ipc_static_vrings *vr, unsigned int role)
 
 	vr->shm_device.name = SHM_DEVICE_NAME;
 	vr->shm_device.num_regions = 1;
-	vr->shm_physmap[0] = vr->shm_addr;
 
 	metal_io_init(vr->shm_device.regions, (void *) vr->shm_addr,
 		      vr->shm_physmap, vr->shm_size, -1, 0, NULL);


### PR DESCRIPTION
There's some device's physical&virtual addresses are different. use the DT to configure different addresses, if they are same, user can eliminate this new parameter(virtual-addr) in DT(this logic is target to do backward compliance).

For example:

ipc0: ipc0 {
compatible = "zephyr,ipc-openamp-static-vrings";
memory-region = <&sram_ipc0>;
virtual-addr = <0x1d1bdd9c>;
mboxes = <&mbox 0>, <&mbox 1>;
mbox-names = "tx", "rx";
role = "host";
zephyr,priority = <1 PRIO_PREEMPT>;
zephyr,buffer-size = <512>;
status = "okay";
};