### PR TITLE
boards: arm: Add RTC clock source for mikroe_mini_m4_for_stm32

### DIFF
--- a/boards/arm/mikroe_mini_m4_for_stm32/mikroe_mini_m4_for_stm32.dts
+++ b/boards/arm/mikroe_mini_m4_for_stm32/mikroe_mini_m4_for_stm32.dts
@@ -38,6 +38,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	clock-frequency = <DT_FREQ_M(16)>;
 	status = "okay";
@@ -97,5 +101,11 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &cryp {
+	status = "okay";
+};
+
+&rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };


### PR DESCRIPTION
The `mikroe_mini_m4_for_stm32` board doesn't have its RTC node enabled, and is failing the following test:

`tests/benchmarks/footprints/benchmark.kernel.footprints.pm`

This board seems to have been missed out from 44b8370, let's enable the rtc & clk_lsi here.

Fixes #66360