### PR TITLE
xtensa: fix toolchain detection

### DIFF
--- a/include/zephyr/toolchain.h
+++ b/include/zephyr/toolchain.h
@@ -38,15 +38,15 @@
  * and therefore this header is not meant to exist in-tree
  */
 #include <toolchain/other.h>
-#elif defined(__XCC__)
+#elif defined(__XCC__) && !defined(__llvm__)
 #include <zephyr/toolchain/xcc.h>
 #elif defined(__CCAC__)
 #include <zephyr/toolchain/mwdt.h>
 #elif defined(__ARMCOMPILER_VERSION)
 #include <zephyr/toolchain/armclang.h>
-#elif defined(__llvm__) || (defined(_LINKER) && defined(__LLD_LINKER_CMD__))
+#elif (defined(__llvm__) && defined(__XCC__)) || (defined(_LINKER) && defined(__LLD_LINKER_CMD__))
 #include <zephyr/toolchain/llvm.h>
-#elif defined(__GNUC__) || (defined(_LINKER) && defined(__GCC_LINKER_CMD__))
+#elif (defined(__GNUC__) && !defined(__XCC__)) || (defined(_LINKER) && defined(__GCC_LINKER_CMD__))
 #include <zephyr/toolchain/gcc.h>
 #else
 #error "Invalid/unknown toolchain configuration"


### PR DESCRIPTION
Currently xtensa compiler is identified checking for:
- __XCC__ for xcc
- __llvm__ for llvm
- __GNUC__ for gcc

However that detection logic fails with xt-clang which defines all above 3 macros.

In fact:
- __XCC__ but no __llvm__ would identify the old xt-xcc.
- __XCC__ and __llvm__ would identify xt-clang.
- __GNUC__ but no __XCC__ should identify gcc.

Not sure why, but xt-clang must be defining __GNUC__ for backward compatibility.