### PR TITLE
doc: connectivity: networking: api: Add doxygengroup for coap_mgmt

### DIFF
--- a/doc/connectivity/networking/api/coap_server.rst
+++ b/doc/connectivity/networking/api/coap_server.rst
@@ -281,3 +281,4 @@ API Reference
 *************
 
 .. doxygengroup:: coap_service
+.. doxygengroup:: coap_mgmt


### PR DESCRIPTION
Make sure the CoAP event doxygen is added to the documentation.