### PR TITLE
boards: hifive_unmatched: add renode simulation

### DIFF
--- a/boards/riscv/hifive_unmatched/hifive_unmatched.yaml
+++ b/boards/riscv/hifive_unmatched/hifive_unmatched.yaml
@@ -5,6 +5,8 @@ arch: riscv64
 toolchain:
   - zephyr
 ram: 3840
+simulation: renode
+simulation_exec: renode
 testing:
   ignore_tags:
     - net

--- a/samples/subsys/fs/fs_sample/sample.yaml
+++ b/samples/subsys/fs/fs_sample/sample.yaml
@@ -43,6 +43,8 @@ tests:
     integration_platforms:
       - frdm_k64f
   sample.filesystem.ext2:
+    simulation_exclude:
+      - renode
     extra_args: CONF_FILE="prj_ext.conf"
     platform_allow: hifive_unmatched bl5340_dvk_cpuapp
   sample.filesystem.fat_fs.stm32h747i_disco_m7_sdmmc:

--- a/tests/drivers/memc/ram/testcase.yaml
+++ b/tests/drivers/memc/ram/testcase.yaml
@@ -21,6 +21,8 @@ tests:
     integration_platforms:
       - sam4s_xplained
   drivers.memc.sifive_ddr:
+    simulation_exclude:
+      - renode
     tags:
       - drivers
       - memc

--- a/tests/subsys/fs/ext2/testcase.yaml
+++ b/tests/subsys/fs/ext2/testcase.yaml
@@ -19,6 +19,8 @@ tests:
       - EXTRA_DTC_OVERLAY_FILE="ramdisk_big.overlay"
 
   filesystem.ext2.sdcard:
+    simulation_exclude:
+      - renode
     platform_allow:
       - hifive_unmatched
       - bl5340_dvk_cpuapp


### PR DESCRIPTION
Changes to this file were missed out from the original PR #65564 that added Renode support for this board, add them here so that it gets ran in CI.

```
(.venv) ycsin@LAPTOP-ROG:~/zephyrproject$ twister -p hifive_unmatched -T zephyr/samples/subsys/shell/shell_module/
INFO    - Using Ninja..
INFO    - Zephyr version: zephyr-v3.5.0-2855-gee2ac818fa4e
INFO    - Using 'zephyr' toolchain.
INFO    - Building initial testsuite list...
INFO    - Writing JSON report /home/ycsin/zephyrproject/twister-out/testplan.json
INFO    - JOBS: 6
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - Total complete:    7/   7  100%  skipped:    3, failed:    0, error:    0
INFO    - 7 test scenarios (7 test instances) selected, 3 configurations skipped (2 by static filter, 1 at runtime).
INFO    - 4 of 7 test configurations passed (100.00%), 0 failed, 0 errored, 3 skipped with 0 warnings in 43.95 seconds
INFO    - In total 0 test cases were executed, 7 skipped on 1 out of total 654 platforms (0.15%)
INFO    - 0 test configurations executed on platforms, 4 test configurations were only built.
INFO    - Saving reports...
INFO    - Writing JSON report /home/ycsin/zephyrproject/twister-out/twister.json
INFO    - Writing xunit report /home/ycsin/zephyrproject/twister-out/twister.xml...
INFO    - Writing xunit report /home/ycsin/zephyrproject/twister-out/twister_report.xml...
```