### PR TITLE
tests: timer_api: Use busy slew threshold when checking remaining ticks 

### DIFF
--- a/tests/kernel/timer/timer_api/src/main.c
+++ b/tests/kernel/timer/timer_api/src/main.c
@@ -723,9 +723,11 @@ ZTEST_USER(timer_api, test_timer_remaining)
 	 * than expected on systems where the requested microsecond
 	 * delay cannot be exactly represented as an integer number of
 	 * ticks.
+	 * As above, use higher tolerance on platforms where the clock used
+	 * by the kernel timer and the one used for busy-waiting may be skewed.
 	 */
-	zassert_true(((int64_t)exp_ticks - (int64_t)now) <= (dur_ticks / 2) + 1,
-		     NULL);
+	zassert_true(((int64_t)exp_ticks - (int64_t)now)
+		     <= (dur_ticks / 2) + 1 + slew_ticks, NULL);
 }
 
 ZTEST_USER(timer_api, test_timeout_abs)

--- a/tests/kernel/timer/timer_api/src/main.c
+++ b/tests/kernel/timer/timer_api/src/main.c
@@ -45,8 +45,8 @@ struct timer_data {
  * between the two clocks.  Produce a maximum error for a given
  * duration in microseconds.
  */
-#define BUSY_SLEW_THRESHOLD_TICKS(_us)				\
-	k_us_to_ticks_ceil32((_us) * BUSY_TICK_SLEW_PPM		\
+#define BUSY_SLEW_THRESHOLD_TICKS(_us)					\
+	k_us_to_ticks_ceil32((_us) * (uint64_t)BUSY_TICK_SLEW_PPM	\
 			     / PPM_DIVISOR)
 
 static void duration_expire(struct k_timer *timer);


### PR DESCRIPTION
On Nordic SoCs, the clock that drives the system timer and the one that is used in busy-waiting may be significantly skewed, so the test cases that compare durations derived from those two clocks need to take into
 account a proper threshold. After the `z_timeout_expires` function was
 corrected in 3d29c9fe546cd42554becee9dddcbe2e9e73d5cc, it turned out that the threshold was missing in one check and the related test case
 started to fail on nRF platforms. This patch adds that threshold there.

Fixes #66075.

On the occasion, the threshold calculation is corrected to prevent 32-bit integer overflows.