### PR TITLE
Bluetooth: Mesh:  Add disabling/enabling GATT services to suspend/resume

### DIFF
--- a/subsys/bluetooth/mesh/proxy_srv.c
+++ b/subsys/bluetooth/mesh/proxy_srv.c
@@ -975,6 +975,8 @@ static void svc_reg_work_handler(struct k_work *work)
 
 int bt_mesh_proxy_gatt_enable(void)
 {
+	int err;
+
 	LOG_DBG("");
 
 	if (!bt_mesh_is_provisioned()) {
@@ -986,7 +988,13 @@ int bt_mesh_proxy_gatt_enable(void)
 	}
 
 	svc_reg_attempts = PROXY_SVC_REG_ATTEMPTS;
-	return k_work_schedule(&svc_reg_work, PROXY_SVC_INIT_TIMEOUT);
+	err = k_work_schedule(&svc_reg_work, PROXY_SVC_INIT_TIMEOUT);
+	if (err < 0) {
+		LOG_ERR("Enabling GATT proxy failed (err %d)", err);
+		return err;
+	}
+
+	return 0;
 }
 
 void bt_mesh_proxy_gatt_disconnect(void)

--- a/tests/bsim/bluetooth/mesh/CMakeLists.txt
+++ b/tests/bsim/bluetooth/mesh/CMakeLists.txt
@@ -9,6 +9,7 @@ target_sources(app PRIVATE
  src/main.c
  src/mesh_test.c
  src/friendship_common.c
+ src/gatt_common.c
 )
 
 if(CONFIG_BT_MESH_V1d1)

--- a/tests/bsim/bluetooth/mesh/CMakeLists.txt
+++ b/tests/bsim/bluetooth/mesh/CMakeLists.txt
@@ -46,6 +46,7 @@ elseif(CONFIG_BT_MESH_GATT_PROXY)
 
  target_sources(app PRIVATE
   src/test_advertiser.c
+  src/test_suspend.c
  )
 
  if(CONFIG_BT_MESH_V1d1)

--- a/tests/bsim/bluetooth/mesh/compile.sh
+++ b/tests/bsim/bluetooth/mesh/compile.sh
@@ -35,5 +35,7 @@ app=tests/bsim/bluetooth/mesh \
   conf_file=prj_mesh1d1.conf conf_overlay="overlay_gatt.conf;overlay_psa.conf" compile
 app=tests/bsim/bluetooth/mesh \
   conf_file=prj_mesh1d1.conf conf_overlay="overlay_low_lat.conf;overlay_psa.conf" compile
+app=tests/bsim/bluetooth/mesh \
+  conf_file=prj_mesh1d1.conf conf_overlay="overlay_gatt.conf;overlay_low_lat.conf" compile
 
 wait_for_background_jobs

--- a/tests/bsim/bluetooth/mesh/src/gatt_common.c
+++ b/tests/bsim/bluetooth/mesh/src/gatt_common.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "gatt_common.h"
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(gatt_common);
+
+void bt_mesh_test_parse_mesh_gatt_preamble(struct net_buf_simple *buf)
+{
+	ASSERT_EQUAL(0x0201, net_buf_simple_pull_be16(buf));
+	/* flags */
+	(void)net_buf_simple_pull_u8(buf);
+	ASSERT_EQUAL(0x0303, net_buf_simple_pull_be16(buf));
+}
+
+void bt_mesh_test_parse_mesh_pb_gatt_service(struct net_buf_simple *buf)
+{
+	/* MshPRT Figure 7.1: PB-GATT Advertising Data */
+	/* mesh provisioning service */
+	ASSERT_EQUAL(0x2718, net_buf_simple_pull_be16(buf));
+	ASSERT_EQUAL(0x1516, net_buf_simple_pull_be16(buf));
+	/* mesh provisioning service */
+	ASSERT_EQUAL(0x2718, net_buf_simple_pull_be16(buf));
+}
+
+void bt_mesh_test_parse_mesh_proxy_service(struct net_buf_simple *buf)
+{
+	/* MshPRT Figure 7.2: Advertising with Network ID (Identification Type 0x00) */
+	/* mesh proxy service */
+	ASSERT_EQUAL(0x2818, net_buf_simple_pull_be16(buf));
+	ASSERT_EQUAL(0x0c16, net_buf_simple_pull_be16(buf));
+	/* mesh proxy service */
+	ASSERT_EQUAL(0x2818, net_buf_simple_pull_be16(buf));
+	/* network ID */
+	ASSERT_EQUAL(0x00, net_buf_simple_pull_u8(buf));
+}

--- a/tests/bsim/bluetooth/mesh/src/gatt_common.h
+++ b/tests/bsim/bluetooth/mesh/src/gatt_common.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "mesh_test.h"
+
+enum bt_mesh_test_gatt_service {
+	MESH_SERVICE_PROVISIONING,
+	MESH_SERVICE_PROXY,
+};
+
+struct bt_mesh_test_gatt {
+	uint8_t transmits; /* number of frame (pb gatt or proxy beacon) transmits */
+	int64_t interval;  /* interval of transmitted frames */
+	enum bt_mesh_test_gatt_service service;
+};
+
+struct bt_mesh_test_adv {
+	uint8_t retr;     /* number of retransmits of adv frame */
+	int64_t interval; /* interval of transmitted frames */
+};
+
+void bt_mesh_test_parse_mesh_gatt_preamble(struct net_buf_simple *buf);
+void bt_mesh_test_parse_mesh_pb_gatt_service(struct net_buf_simple *buf);
+void bt_mesh_test_parse_mesh_proxy_service(struct net_buf_simple *buf);

--- a/tests/bsim/bluetooth/mesh/src/main.c
+++ b/tests/bsim/bluetooth/mesh/src/main.c
@@ -19,6 +19,7 @@ extern struct bst_test_list *test_sar_pst_install(struct bst_test_list *test);
 #endif /* defined(CONFIG_BT_MESH_V1d1) */
 #elif defined(CONFIG_BT_MESH_GATT_PROXY)
 extern struct bst_test_list *test_adv_install(struct bst_test_list *test);
+extern struct bst_test_list *test_suspend_install(struct bst_test_list *test);
 #if defined(CONFIG_BT_MESH_V1d1)
 extern struct bst_test_list *test_beacon_install(struct bst_test_list *tests);
 #endif /* defined(CONFIG_BT_MESH_V1d1) */
@@ -59,6 +60,7 @@ bst_test_install_t test_installers[] = {
 #endif /* defined(CONFIG_BT_MESH_V1d1) */
 #elif defined(CONFIG_BT_MESH_GATT_PROXY)
 	test_adv_install,
+	test_suspend_install,
 #if defined(CONFIG_BT_MESH_V1d1)
 	test_beacon_install,
 #endif /* defined(CONFIG_BT_MESH_V1d1) */

--- a/tests/bsim/bluetooth/mesh/src/mesh_test.c
+++ b/tests/bsim/bluetooth/mesh/src/mesh_test.c
@@ -7,6 +7,7 @@
 #include "argparse.h"
 #include <bs_pc_backchannel.h>
 #include "mesh/crypto.h"
+#include <zephyr/bluetooth/hci.h>
 
 #define LOG_MODULE_NAME mesh_test
 
@@ -545,6 +546,50 @@ uint16_t bt_mesh_test_own_addr_get(uint16_t start_addr)
 {
 	return start_addr + get_device_nbr();
 }
+
+void bt_mesh_test_send_over_adv(void *data, size_t len)
+{
+	struct bt_mesh_adv *adv = bt_mesh_adv_create(BT_MESH_ADV_DATA, BT_MESH_ADV_TAG_LOCAL,
+						     BT_MESH_TRANSMIT(0, 20), K_NO_WAIT);
+	net_buf_simple_add_mem(&adv->b, data, len);
+	bt_mesh_adv_send(adv, NULL, NULL);
+}
+
+int bt_mesh_test_wait_for_packet(bt_le_scan_cb_t scan_cb, struct k_sem *observer_sem, uint16_t wait)
+{
+	struct bt_le_scan_param scan_param = {
+		.type       = BT_HCI_LE_SCAN_PASSIVE,
+		.options    = BT_LE_SCAN_OPT_NONE,
+		.interval   = BT_MESH_ADV_SCAN_UNIT(1000),
+		.window     = BT_MESH_ADV_SCAN_UNIT(1000)
+	};
+	int err;
+	int returned_value = 0;
+
+	err = bt_le_scan_start(&scan_param, scan_cb);
+	if (err && err != -EALREADY) {
+		LOG_ERR("Starting scan failed (err %d)", err);
+		return err;
+	}
+
+	err = k_sem_take(observer_sem, K_SECONDS(wait));
+	if (err == -EAGAIN) {
+		LOG_WRN("Taking sem timed out (err %d)", err);
+		returned_value = -EAGAIN;
+	} else if (err) {
+		LOG_ERR("Taking sem failed (err %d)", err);
+		return err;
+	}
+
+	err = bt_le_scan_stop();
+	if (err && err != -EALREADY) {
+		LOG_ERR("Stopping scan failed (err %d)", err);
+		return err;
+	}
+
+	return returned_value;
+}
+
 
 #if defined(CONFIG_BT_MESH_SAR_CFG)
 void bt_mesh_test_sar_conf_set(struct bt_mesh_sar_tx *tx_set, struct bt_mesh_sar_rx *rx_set)

--- a/tests/bsim/bluetooth/mesh/src/mesh_test.h
+++ b/tests/bsim/bluetooth/mesh/src/mesh_test.h
@@ -23,6 +23,7 @@
 
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/mesh.h>
+#include <mesh/adv.h>
 
 #define TEST_MOD_ID 0x8888
 #define TEST_MSG_OP_1  BT_MESH_MODEL_OP_1(0x0f)
@@ -201,6 +202,13 @@ int bt_mesh_test_send_ra(uint16_t addr, uint8_t *data, size_t len,
 void bt_mesh_test_ra_cb_setup(void (*cb)(uint8_t *, size_t));
 
 uint16_t bt_mesh_test_own_addr_get(uint16_t start_addr);
+
+void bt_mesh_test_send_over_adv(void *data, size_t len);
+/* Wait for a packet (i. e. an advertisement or a GATT frame) sent by a device.
+ * `scan_cb` is triggered if the packet is received, and must release `observer_sem` when finished.
+ */
+int bt_mesh_test_wait_for_packet(bt_le_scan_cb_t scan_cb, struct k_sem *observer_sem,
+				 uint16_t wait);
 
 #if defined(CONFIG_BT_MESH_SAR_CFG)
 void bt_mesh_test_sar_conf_set(struct bt_mesh_sar_tx *tx_set, struct bt_mesh_sar_rx *rx_set);

--- a/tests/bsim/bluetooth/mesh/src/test_suspend.c
+++ b/tests/bsim/bluetooth/mesh/src/test_suspend.c
@@ -16,11 +16,16 @@ LOG_MODULE_REGISTER(test_suspend, LOG_LEVEL_INF);
 
 #define WAIT_TIME        60 /* seconds */
 #define SUSPEND_DURATION 15 /* seconds */
-#define NUM_PUB           4 /* Times the transmitter will publish per interval. */
+#define NUM_PUB           4 /* Times the DUT will publish per interval. */
 
 #define TEST_MODEL_ID_1 0x2a2a
 #define TEST_MODEL_ID_2 0x2b2b
 #define TEST_MESSAGE_OP 0x1f
+
+enum dut_mesh_status {
+	DUT_SUSPENDED,
+	DUT_RUNNING,
+};
 
 static int model_1_init(const struct bt_mesh_model *model);
 static int model_2_init(const struct bt_mesh_model *model);
@@ -28,23 +33,23 @@ static int model_2_init(const struct bt_mesh_model *model);
 static uint8_t app_key[16] = {0xaa};
 static uint8_t net_key[16] = {0xcc};
 
-static const struct bt_mesh_test_cfg tx_cfg = {
+static const struct bt_mesh_test_cfg dut_cfg = {
 	.addr = 0x00a0,
 	.dev_key = {0x01},
 };
-static const struct bt_mesh_test_cfg rx_cfg = {
+static const struct bt_mesh_test_cfg tester_cfg = {
 	.addr = 0x00b0,
 	.dev_key = {0x02},
 };
 
 static struct bt_mesh_prov prov;
 static struct k_sem publish_sem;
-static bool suspended;
+static enum dut_mesh_status dut_status;
 
 static int model_1_update(const struct bt_mesh_model *model)
 {
 	model->pub->msg->data[1]++;
-	LOG_INF("Model 1 publishing..., n: %d", model->pub->msg->data[1]);
+	LOG_DBG("Model 1 publishing..., n: %d", model->pub->msg->data[1]);
 	k_sem_give(&publish_sem);
 	return 0;
 }
@@ -53,16 +58,32 @@ static int msg_handler(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx
 			    struct net_buf_simple *buf)
 {
 	static uint8_t prev_num;
+	static int64_t uptime;
 	uint8_t num = net_buf_simple_pull_u8(buf);
 
-	LOG_INF("Received msg, n: %d", num);
+	LOG_DBG("Received msg, n: %d", num);
 
 	/* Ensure that payload changes. */
 	ASSERT_TRUE(prev_num != num);
 	prev_num = num;
 
-	/* Ensure that no message is received while Mesh is suspended or disabled. */
-	ASSERT_FALSE_MSG(suspended, "Received publication while Mesh is suspended.");
+	/* Ensure that no message is received while Mesh is suspended or disabled.
+	 * A publication may be sent just before DUT is suspended, which is ignored.
+	 */
+	if ((dut_status == DUT_SUSPENDED) && !(num == (NUM_PUB + 1))) {
+		if (SUSPEND_DURATION * 1000ll <= k_uptime_delta(&uptime)) {
+			dut_status = DUT_RUNNING;
+			LOG_DBG("Suspend duration passed. Setting status to %d.", dut_status);
+		} else {
+			FAIL("Received publication while Mesh is suspended.");
+		}
+	}
+
+	if (num == NUM_PUB) {
+		dut_status = DUT_SUSPENDED;
+		LOG_DBG("Expected number of pubs received. Setting status to %d.", dut_status);
+		uptime = k_uptime_get();
+	}
 
 	k_sem_give(&publish_sem);
 	return 0;
@@ -83,42 +104,42 @@ static const struct bt_mesh_model_op model_op_1[] = {BT_MESH_MODEL_OP_END};
 static const struct bt_mesh_model_op model_op_2[] = {{TEST_MESSAGE_OP, 0, msg_handler},
 						     BT_MESH_MODEL_OP_END};
 
-static struct bt_mesh_cfg_cli cfg_cli_tx;
-static struct bt_mesh_model tx_models[] = {
+static struct bt_mesh_cfg_cli cfg_cli_dut;
+static struct bt_mesh_model dut_models[] = {
 	BT_MESH_MODEL_CFG_SRV,
-	BT_MESH_MODEL_CFG_CLI(&cfg_cli_tx),
+	BT_MESH_MODEL_CFG_CLI(&cfg_cli_dut),
 	BT_MESH_MODEL_CB(TEST_MODEL_ID_1, model_op_1, &model_1_pub, NULL, &model_1_cb),
 };
 
-static struct bt_mesh_elem tx_elems[] = {
-	BT_MESH_ELEM(0, tx_models, BT_MESH_MODEL_NONE),
+static struct bt_mesh_elem dut_elems[] = {
+	BT_MESH_ELEM(0, dut_models, BT_MESH_MODEL_NONE),
 };
 
-static const struct bt_mesh_comp tx_comp = {
+static const struct bt_mesh_comp dut_comp = {
 	.cid = TEST_VND_COMPANY_ID,
 	.vid = 0xeeee,
 	.pid = 0xaaaa,
-	.elem = tx_elems,
-	.elem_count = ARRAY_SIZE(tx_elems),
+	.elem = dut_elems,
+	.elem_count = ARRAY_SIZE(dut_elems),
 };
 
-static struct bt_mesh_cfg_cli cfg_cli_rx;
-static struct bt_mesh_model rx_models[] = {
+static struct bt_mesh_cfg_cli cfg_cli_tester;
+static struct bt_mesh_model tester_models[] = {
 	BT_MESH_MODEL_CFG_SRV,
-	BT_MESH_MODEL_CFG_CLI(&cfg_cli_rx),
+	BT_MESH_MODEL_CFG_CLI(&cfg_cli_tester),
 	BT_MESH_MODEL_CB(TEST_MODEL_ID_2, model_op_2, NULL, NULL, &model_2_cb),
 };
 
-static struct bt_mesh_elem rx_elems[] = {
-	BT_MESH_ELEM(0, rx_models, BT_MESH_MODEL_NONE),
+static struct bt_mesh_elem tester_elems[] = {
+	BT_MESH_ELEM(0, tester_models, BT_MESH_MODEL_NONE),
 };
 
-static const struct bt_mesh_comp rx_comp = {
+static const struct bt_mesh_comp tester_comp = {
 	.cid = TEST_VND_COMPANY_ID,
 	.vid = 0xbaaa,
 	.pid = 0xb000,
-	.elem = rx_elems,
-	.elem_count = ARRAY_SIZE(rx_elems),
+	.elem = tester_elems,
+	.elem_count = ARRAY_SIZE(tester_elems),
 };
 
 static int model_1_init(const struct bt_mesh_model *model)
@@ -134,7 +155,7 @@ static int model_2_init(const struct bt_mesh_model *model)
 	return 0;
 }
 
-static void provision_and_configure(struct bt_mesh_test_cfg cfg, bool rx)
+static void provision_and_configure(struct bt_mesh_test_cfg cfg, bool tester)
 {
 	int err;
 	uint8_t status;
@@ -146,8 +167,8 @@ static void provision_and_configure(struct bt_mesh_test_cfg cfg, bool rx)
 		FAIL("AppKey add failed (err %d, status %u)", err, status);
 	}
 
-	const struct bt_mesh_test_cfg *pcfg = rx ? &rx_cfg : &tx_cfg;
-	uint16_t model_id = rx ? TEST_MODEL_ID_2 : TEST_MODEL_ID_1;
+	const struct bt_mesh_test_cfg *pcfg = tester ? &tester_cfg : &dut_cfg;
+	uint16_t model_id = tester ? TEST_MODEL_ID_2 : TEST_MODEL_ID_1;
 
 	err = bt_mesh_cfg_cli_mod_app_bind(0, pcfg->addr, pcfg->addr, 0, model_id, &status);
 	if (err || status) {
@@ -156,7 +177,7 @@ static void provision_and_configure(struct bt_mesh_test_cfg cfg, bool rx)
 }
 
 struct bt_mesh_cfg_cli_mod_pub pub_params = {
-	.addr = rx_cfg.addr,
+	.addr = tester_cfg.addr,
 	.uuid = NULL,
 	.cred_flag = false,
 	.app_idx = 0,
@@ -165,19 +186,18 @@ struct bt_mesh_cfg_cli_mod_pub pub_params = {
 	.transmit = 0,
 };
 
-static void test_tx_suspend_resume(void)
+static void dut_pub_common(bool disable_bt)
 {
 	bt_mesh_test_cfg_set(NULL, WAIT_TIME);
-	bt_mesh_device_setup(&prov, &tx_comp);
-	provision_and_configure(tx_cfg, 0);
+	bt_mesh_device_setup(&prov, &dut_comp);
+	provision_and_configure(dut_cfg, 0);
 
 	k_sem_init(&publish_sem, 0, 1);
-	suspended = false;
 	uint8_t status;
 	int err;
 
-	err = bt_mesh_cfg_cli_mod_pub_set(0, tx_cfg.addr, tx_cfg.addr, TEST_MODEL_ID_1, &pub_params,
-					  &status);
+	err = bt_mesh_cfg_cli_mod_pub_set(0, dut_cfg.addr, dut_cfg.addr, TEST_MODEL_ID_1,
+					&pub_params, &status);
 	if (err || status) {
 		FAIL("Mod pub set failed (err %d, status %u)", err, status);
 	}
@@ -187,15 +207,19 @@ static void test_tx_suspend_resume(void)
 		ASSERT_OK_MSG(k_sem_take(&publish_sem, K_SECONDS(30)), "Pub timed out");
 	}
 
-	ASSERT_OK(bt_mesh_suspend());
-	suspended = true;
-	LOG_INF("Mesh suspended.");
+	ASSERT_OK_MSG(bt_mesh_suspend(), "Failed to suspend Mesh.");
+
+	if (disable_bt) {
+		ASSERT_OK_MSG(bt_disable(), "Failed to disable Bluetooth.");
+	}
 
 	k_sleep(K_SECONDS(SUSPEND_DURATION));
 
-	ASSERT_OK(bt_mesh_resume());
-	suspended = false;
-	LOG_INF("Mesh resumed.");
+	if (disable_bt) {
+		ASSERT_OK_MSG(bt_enable(NULL), "Failed to enable Bluetooth.");
+	}
+
+	ASSERT_OK_MSG(bt_mesh_resume(), "Failed to resume Mesh.");
 
 	for (int i = 0; i < NUM_PUB; i++) {
 		ASSERT_OK_MSG(k_sem_take(&publish_sem, K_SECONDS(30)), "Pub timed out");
@@ -204,81 +228,27 @@ static void test_tx_suspend_resume(void)
 	/* Allow publishing to finish before suspending. */
 	k_sleep(K_MSEC(100));
 	ASSERT_OK(bt_mesh_suspend());
+}
 
+static void test_dut_suspend_resume(void)
+{
+	dut_pub_common(false);
 	PASS();
 }
 
-static void test_rx_suspend_resume(void)
+static void test_dut_suspend_disable_resume(void)
 {
-	bt_mesh_test_cfg_set(NULL, WAIT_TIME);
-	bt_mesh_device_setup(&prov, &rx_comp);
-	provision_and_configure(rx_cfg, 1);
-	k_sem_init(&publish_sem, 0, 1);
-
-	/* Receive messages before and after suspending. A publication may get lost
-	 * when suspending immeditiately after publication, thus the "-1".
-	 */
-	for (int i = 0; i < NUM_PUB * 2 - 1; i++) {
-		ASSERT_OK_MSG(k_sem_take(&publish_sem, K_SECONDS(30)), "Receiver timed out");
-	}
-
+	dut_pub_common(true);
 	PASS();
 }
 
-static void test_tx_suspend_disable_resume(void)
+static void test_tester_pub(void)
 {
 	bt_mesh_test_cfg_set(NULL, WAIT_TIME);
-	bt_mesh_device_setup(&prov, &tx_comp);
-	provision_and_configure(tx_cfg, 0);
-
+	bt_mesh_device_setup(&prov, &tester_comp);
+	provision_and_configure(tester_cfg, 1);
 	k_sem_init(&publish_sem, 0, 1);
-	suspended = false;
-	uint8_t status;
-	int err;
-
-	err = bt_mesh_cfg_cli_mod_pub_set(0, tx_cfg.addr, tx_cfg.addr, TEST_MODEL_ID_1, &pub_params,
-					  &status);
-	if (err || status) {
-		FAIL("Mod pub set failed (err %d, status %u)", err, status);
-	}
-
-	/* Wait until node has published before suspending. */
-	for (int i = 0; i < NUM_PUB; i++) {
-		ASSERT_OK_MSG(k_sem_take(&publish_sem, K_SECONDS(30)), "Pub timed out");
-	}
-
-	ASSERT_OK(bt_mesh_suspend());
-	suspended = true;
-	LOG_INF("Mesh suspended.");
-
-	ASSERT_OK(bt_disable());
-	LOG_INF("Bluetooth disabled.");
-
-	k_sleep(K_SECONDS(SUSPEND_DURATION));
-
-	ASSERT_OK(bt_enable(NULL));
-	LOG_INF("Bluetooth enabled.");
-
-	ASSERT_OK(bt_mesh_resume());
-	suspended = false;
-	LOG_INF("Mesh resumed.");
-
-	for (int i = 0; i < NUM_PUB; i++) {
-		ASSERT_OK_MSG(k_sem_take(&publish_sem, K_SECONDS(30)), "Pub timed out");
-	}
-
-	/* Allow publishing to finish before suspending. */
-	k_sleep(K_MSEC(100));
-	ASSERT_OK(bt_mesh_suspend());
-	PASS();
-}
-
-static void test_rx_suspend_disable_resume(void)
-{
-	bt_mesh_test_cfg_set(NULL, WAIT_TIME);
-	bt_mesh_device_setup(&prov, &rx_comp);
-	provision_and_configure(rx_cfg, 1);
-	k_sem_init(&publish_sem, 0, 1);
+	dut_status = DUT_RUNNING;
 
 	/* Receive messages before and after suspending. A publication may get lost
 	 * when suspending immeditiately after publication, thus the "-1".
@@ -297,11 +267,12 @@ static void test_rx_suspend_disable_resume(void)
 	}
 
 static const struct bst_test_instance test_suspend[] = {
-	TEST_CASE(tx, suspend_resume, "tx suspend resume"),
-	TEST_CASE(tx, suspend_disable_resume, "tx suspend, disable resume"),
+	TEST_CASE(dut, suspend_resume,
+			 "Suspend and resume Mesh while publishing periodically"),
+	TEST_CASE(dut, suspend_disable_resume,
+			 "Suspend and resume Mesh (and disable/enable BT) while publishing periodically"),
 
-	TEST_CASE(rx, suspend_resume, "rx suspend resume"),
-	TEST_CASE(rx, suspend_disable_resume, "rx suspend, disable resume"),
+	TEST_CASE(tester, pub, "Scan and verify behavior of periodic publishing adv"),
 
 	BSTEST_END_MARKER};
 

--- a/tests/bsim/bluetooth/mesh/tests_scripts/suspend/gatt_suspend_disable_resume.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/suspend/gatt_suspend_disable_resume.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Copyright 2023 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
+
+# Test that GATT advertisement is stopped when suspending Mesh and disabling
+# Bluetooth, and that it is started again when Bluetooth is re-enabled and Mesh is resumed.
+#
+# Test procedure:
+# 0. DUT (Device 0) initializes the Mesh stack, and starts provisioning procedure using
+#    bt_mesh_prov_enable(BT_MESH_PROV_GATT).
+# 1. Tester (Device 1) observes PB-GATT advs, and will fail the test if the expected
+#    amount of advs is not received.
+# 2. DUT is provisioned, and Tester observes GATT proxy advs.
+# 3. DUT notifies the Tester that it will be suspended, and Tester observes for advs after a
+#    brief delay. Receiving an adv while DUT is suspended will cause the test to fail.
+# 4. After a delay, the DUT resumes and notifies the Tester, which checks that the
+#    advertising resumes.
+
+overlay=overlay_gatt_conf
+RunTest mesh_gatt_suspend_disable_resume \
+	suspend_dut_gatt_suspend_disable_resume suspend_tester_gatt
+
+conf=prj_mesh1d1_conf
+overlay="overlay_gatt_conf_overlay_low_lat_conf"
+RunTest mesh_gatt_suspend_disable_resume_low_lat \
+	suspend_dut_gatt_suspend_disable_resume suspend_tester_gatt
+
+conf=prj_mesh1d1_conf
+overlay=overlay_gatt_conf
+RunTest mesh_gatt_suspend_disable_resume_1d1 \
+	suspend_dut_gatt_suspend_disable_resume suspend_tester_gatt
+
+conf=prj_mesh1d1_conf
+overlay="overlay_gatt_conf_overlay_psa_conf"
+RunTest mesh_gatt_suspend_disable_resume_psa \
+	suspend_dut_gatt_suspend_disable_resume suspend_tester_gatt

--- a/tests/bsim/bluetooth/mesh/tests_scripts/suspend/gatt_suspend_resume.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/suspend/gatt_suspend_resume.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Copyright 2023 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
+
+# Test that GATT advertisement is stopped when suspending Mesh, and that it is started again
+# when Mesh is resumed.
+#
+# Test procedure:
+# 0. DUT (Device 0) initializes the Mesh stack, and starts provisioning procedure using
+#    bt_mesh_prov_enable(BT_MESH_PROV_GATT).
+# 1. Tester (Device 1) observes PB-GATT advs, and will fail the test if the expected
+#    amount of advs is not received.
+# 2. DUT is provisioned, and Tester observes GATT proxy advs.
+# 3. DUT notifies the Tester that it will be suspended, and Tester observes for advs after a
+#    brief delay. Receiving an adv while DUT is suspended will cause the test to fail.
+# 4. After a delay, the DUT resumes and notifies the Tester, which checks that the
+#    advertising resumes.
+
+overlay=overlay_gatt_conf
+RunTest mesh_gatt_suspend_resume \
+	suspend_dut_gatt_suspend_resume suspend_tester_gatt
+
+conf=prj_mesh1d1_conf
+overlay="overlay_gatt_conf_overlay_low_lat_conf"
+RunTest mesh_gatt_suspend_resume_low_lat \
+	suspend_dut_gatt_suspend_resume suspend_tester_gatt
+
+conf=prj_mesh1d1_conf
+overlay=overlay_gatt_conf
+RunTest mesh_gatt_suspend_resume_1d1 \
+	suspend_dut_gatt_suspend_resume suspend_tester_gatt
+
+conf=prj_mesh1d1_conf
+overlay="overlay_gatt_conf_overlay_psa_conf"
+RunTest mesh_gatt_suspend_resume_psa \
+	suspend_dut_gatt_suspend_resume suspend_tester_gatt

--- a/tests/bsim/bluetooth/mesh/tests_scripts/suspend/suspend_disable_resume.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/suspend/suspend_disable_resume.sh
@@ -17,17 +17,17 @@ source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
 #   Check that publication resumes.
 
 RunTest mesh_suspend_disable_resume \
-	suspend_tx_suspend_disable_resume suspend_rx_suspend_disable_resume
+	suspend_dut_suspend_disable_resume suspend_tester_pub
 
 conf=prj_mesh1d1_conf
 RunTest mesh_suspend_disable_resume_1d1 \
-	suspend_tx_suspend_disable_resume suspend_rx_suspend_disable_resume
+	suspend_dut_suspend_disable_resume suspend_tester_pub
 
 overlay=overlay_low_lat_conf
 RunTest mesh_suspend_disable_resume_low_lat \
-	suspend_tx_suspend_disable_resume suspend_rx_suspend_disable_resume
+	suspend_dut_suspend_disable_resume suspend_tester_pub
 
 conf=prj_mesh1d1_conf
 overlay=overlay_psa_conf
 RunTest mesh_suspend_disable_resume_psa \
-	suspend_tx_suspend_disable_resume suspend_rx_suspend_disable_resume
+	suspend_dut_suspend_disable_resume suspend_tester_pub

--- a/tests/bsim/bluetooth/mesh/tests_scripts/suspend/suspend_resume.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/suspend/suspend_resume.sh
@@ -16,17 +16,17 @@ source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
 # 3. Resume Mesh a specified time after suspension. Check that publication resumes.
 
 RunTest mesh_suspend_resume \
-	suspend_tx_suspend_resume suspend_rx_suspend_resume
+	suspend_dut_suspend_resume suspend_tester_pub
 
 conf=prj_mesh1d1_conf
 RunTest mesh_suspend_resume_1d1 \
-	suspend_tx_suspend_resume suspend_rx_suspend_resume
+	suspend_dut_suspend_resume suspend_tester_pub
 
 overlay=overlay_low_lat_conf
 RunTest mesh_suspend_resume_low_lat \
-	suspend_tx_suspend_resume suspend_rx_suspend_resume
+	suspend_dut_suspend_resume suspend_tester_pub
 
 conf=prj_mesh1d1_conf
 overlay=overlay_psa_conf
 RunTest mesh_suspend_resume_psa \
-	suspend_tx_suspend_resume suspend_rx_suspend_resume
+	suspend_dut_suspend_resume suspend_tester_pub


### PR DESCRIPTION
PR contains four commits:

- Extracts some GATT related logic from `test_advertiser.c` bsim test into a common file. 
- Refactors `test_suspend.c` by reusing a RX test config. 
- Disables/enables PB-GATT and GATT proxy advs when suspending/resuming Mesh. 
- Adds tests to `test_suspend.c` to check that GATT advs stop when suspending Mesh, and that they start again when resuming Mesh. 