### PR TITLE
samples: Bluetooth: Mesh: remove nrf53_ns settings related workaround

### DIFF
--- a/samples/bluetooth/mesh/boards/nrf5340dk_nrf5340_cpuapp_ns.conf
+++ b/samples/bluetooth/mesh/boards/nrf5340dk_nrf5340_cpuapp_ns.conf
@@ -2,7 +2,3 @@
 CONFIG_BT_HOST_CRYPTO=n
 # The option adds GATT caching feature that is based on TinyCrypt.
 CONFIG_BT_GATT_CACHING=n
-
-# Known issue: non secure platforms do not work with settings subsystem.
-CONFIG_SETTINGS=n
-CONFIG_BT_SETTINGS=n

--- a/samples/bluetooth/mesh_demo/boards/nrf5340dk_nrf5340_cpuapp_ns.conf
+++ b/samples/bluetooth/mesh_demo/boards/nrf5340dk_nrf5340_cpuapp_ns.conf
@@ -2,7 +2,3 @@
 CONFIG_BT_HOST_CRYPTO=n
 # The option adds GATT caching feature that is based on TinyCrypt.
 CONFIG_BT_GATT_CACHING=n
-
-# Known issue: non secure platforms do not work with settings subsystem.
-CONFIG_SETTINGS=n
-CONFIG_BT_SETTINGS=n

--- a/samples/bluetooth/mesh_provisioner/boards/nrf5340dk_nrf5340_cpuapp_ns.conf
+++ b/samples/bluetooth/mesh_provisioner/boards/nrf5340dk_nrf5340_cpuapp_ns.conf
@@ -1,6 +1,2 @@
 # The option adds TinyCrypt based bt_rand.
 CONFIG_BT_HOST_CRYPTO=n
-
-# Known issue: non secure platforms do not work with settings subsystem.
-CONFIG_SETTINGS=n
-CONFIG_BT_SETTINGS=n


### PR DESCRIPTION
The issue with non secure storage system has been fixed in nrf53_ns platform: https://github.com/zephyrproject-rtos/zephyr/issues/59376 No need workarounds anymore.