### PR TITLE
boards: nxp: Switch MCUBoot FW Update mode to Swap & Move

### DIFF
--- a/boards/arm/frdm_k22f/frdm_k22f.dts
+++ b/boards/arm/frdm_k22f/frdm_k22f.dts
@@ -205,27 +205,20 @@ zephyr_udc0: &usbotg {
 			reg = <0x00000000 0x00010000>;
 			read-only;
 		};
+		/* Note slot 0 has one additional sector,
+		 * this is intended for use with the swap move algorithm
+		 */
 		slot0_partition: partition@10000 {
 			label = "image-0";
-			reg = <0x00010000 0x00020000>;
+			reg = <0x00010000 0x00028800>;
 		};
-		slot1_partition: partition@30000 {
+		slot1_partition: partition@38800 {
 			label = "image-1";
-			reg = <0x00030000 0x00020000>;
+			reg = <0x00038800 0x00028000>;
 		};
-		scratch_partition: partition@50000 {
-			label = "image-scratch";
-			reg = <0x00050000 0x00010000>;
-		};
-
-		/*
-		 * The flash starting at 0x00060000 and ending at
-		 * 0x0007ffff (sectors 16-31) is reserved for use
-		 * by the application.
-		 */
-		storage_partition: partition@60000 {
+		storage_partition: partition@60800 {
 			label = "storage";
-			reg = <0x00060000 0x00020000>;
+			reg = <0x00060800 0x0001f800>;
 		};
 
 	};

--- a/boards/arm/frdm_k64f/frdm_k64f.dts
+++ b/boards/arm/frdm_k64f/frdm_k64f.dts
@@ -234,28 +234,20 @@ zephyr_udc0: &usbotg {
 			reg = <0x00000000 0x00010000>;
 			read-only;
 		};
-
-		/*
-		 * The flash starting at 0x00010000 and ending at
-		 * 0x0001ffff (sectors 16-31) is reserved for use
-		 * by the application.
+		/* Note slot 0 has one additional sector,
+		 * this is intended for use with the swap move algorithm
 		 */
-		storage_partition: partition@1e000 {
-			label = "storage";
-			reg = <0x0001e000 0x00002000>;
-		};
-
-		slot0_partition: partition@20000 {
+		slot0_partition: partition@10000 {
 			label = "image-0";
-			reg = <0x00020000 0x00060000>;
+			reg = <0x00010000 0x00069000>;
 		};
-		slot1_partition: partition@80000 {
+		slot1_partition: partition@79000 {
 			label = "image-1";
-			reg = <0x00080000 0x00060000>;
+			reg = <0x00079000 0x00068000>;
 		};
-		scratch_partition: partition@e0000 {
-			label = "image-scratch";
-			reg = <0x000e0000 0x00020000>;
+		storage_partition: partition@e1000 {
+			label = "storage";
+			reg = <0x000e1000 0x0001f000>;
 		};
 	};
 };

--- a/boards/arm/frdm_k82f/frdm_k82f.dts
+++ b/boards/arm/frdm_k82f/frdm_k82f.dts
@@ -161,21 +161,20 @@
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(48)>;
 		};
-		storage_partition: partition@c000 {
-			label = "storage";
-			reg = <0xc000 DT_SIZE_K(32)>;
-		};
-		slot0_partition: partition@14000 {
+		/* Note slot 0 has one additional sector,
+		 * this is intended for use with the swap move algorithm
+		 */
+		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x14000 DT_SIZE_K(80)>;
+			reg = <0xc000 DT_SIZE_K(100)>;
 		};
-		slot1_partition: partition@28000 {
+		slot1_partition: partition@25000 {
 			label = "image-1";
-			reg = <0x28000 DT_SIZE_K(80)>;
+			reg = <0x25000 DT_SIZE_K(96)>;
 		};
-		scratch_partition: partition@3c000 {
-			label = "image-scratch";
-			reg = <0x3c000 DT_SIZE_K(16)>;
+		storage_partition: partition@3d000 {
+			label = "storage";
+			reg = <0x3d000 DT_SIZE_K(12)>;
 		};
 	};
 };

--- a/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -112,21 +112,20 @@ arduino_serial: &lpuart2 {
 				label = "mcuboot";
 				reg = <0x00000000 DT_SIZE_K(64)>;
 			};
+			/* Note slot 0 has one additional sector,
+			 * this is intended for use with the swap move algorithm
+			 */
 			slot0_partition: partition@10000 {
 				label = "image-0";
-				reg = <0x00010000 DT_SIZE_M(3)>;
+				reg = <0x00010000 (DT_SIZE_M(3) + DT_SIZE_K(4))>;
 			};
-			slot1_partition: partition@310000 {
+			slot1_partition: partition@311000 {
 				label = "image-1";
-				reg = <0x00310000 DT_SIZE_M(3)>;
+				reg = <0x00311000 DT_SIZE_M(3)>;
 			};
-			scratch_partition: partition@610000 {
-				label = "image-scratch";
-				reg = <0x00610000 DT_SIZE_K(128)>;
-			};
-			storage_partition: partition@630000 {
+			storage_partition: partition@611000 {
 				label = "storage";
-				reg = <0x00630000 DT_SIZE_K(1856)>;
+				reg = <0x00611000 DT_SIZE_K(1980)>;
 			};
 		};
 	};

--- a/boards/arm/mimxrt1024_evk/mimxrt1024_evk.dts
+++ b/boards/arm/mimxrt1024_evk/mimxrt1024_evk.dts
@@ -70,25 +70,20 @@
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
 		};
-
+		/* Note slot 0 has one additional sector,
+		 * this is intended for use with the swap move algorithm
+		 */
 		slot0_partition: partition@10000 {
 			label = "image-0";
-			reg = <0x00010000 DT_SIZE_K(1920)>;
+			reg = <0x00010000 DT_SIZE_K(1924)>;
 		};
-
-		slot1_partition: partition@1f0000 {
+		slot1_partition: partition@1f1000 {
 			label = "image-1";
-			reg = <0x001F0000 DT_SIZE_K(1920)>;
+			reg = <0x001F1000 DT_SIZE_K(1920)>;
 		};
-
-		storage_partition: partition@3d0000 {
+		storage_partition: partition@3d1000 {
 			label = "storage";
-			reg = <0x003D0000 DT_SIZE_K(128)>;
-		};
-
-		scratch_partition: partition@3f0000 {
-			label = "image-scratch";
-			reg = <0x003f0000 DT_SIZE_K(64)>;
+			reg = <0x003D1000 DT_SIZE_K(188)>;
 		};
 	};
 };

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -154,21 +154,20 @@ arduino_serial: &lpuart3 {
 				label = "mcuboot";
 				reg = <0x00000000 DT_SIZE_K(256)>;
 			};
+			/* Note slot 0 has one additional sector,
+			 * this is intended for use with the swap move algorithm
+			 */
 			slot0_partition: partition@40000 {
 				label = "image-0";
-				reg = <0x00040000 DT_SIZE_M(3)>;
+				reg = <0x00040000 (DT_SIZE_M(3) + DT_SIZE_K(4))>;
 			};
-			slot1_partition: partition@340000 {
+			slot1_partition: partition@341000 {
 				label = "image-1";
-				reg = <0x00340000 DT_SIZE_M(3)>;
+				reg = <0x00341000 DT_SIZE_M(3)>;
 			};
-			scratch_partition: partition@640000 {
-				label = "image-scratch";
-				reg = <0x00640000 DT_SIZE_K(768)>;
-			};
-			storage_partition: partition@700000 {
+			storage_partition: partition@641000 {
 				label = "storage";
-				reg = <0x00700000 DT_SIZE_M(57)>;
+				reg = <0x00641000 (DT_SIZE_M(57) + DT_SIZE_K(764))>;
 			};
 		};
 	};

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.dts
@@ -41,21 +41,20 @@
 				label = "mcuboot";
 				reg = <0x00000000 DT_SIZE_K(64)>;
 			};
+			/* Note slot 0 has one additional sector,
+			 * this is intended for use with the swap move algorithm
+			 */
 			slot0_partition: partition@10000 {
 				label = "image-0";
-				reg = <0x00010000 DT_SIZE_M(3)>;
+				reg = <0x00010000 (DT_SIZE_M(3) + DT_SIZE_K(4))>;
 			};
-			slot1_partition: partition@310000 {
+			slot1_partition: partition@311000 {
 				label = "image-1";
-				reg = <0x00310000 DT_SIZE_M(3)>;
+				reg = <0x00311000 DT_SIZE_M(3)>;
 			};
-			scratch_partition: partition@610000 {
-				label = "image-scratch";
-				reg = <0x00610000 DT_SIZE_K(128)>;
-			};
-			storage_partition: partition@630000 {
+			storage_partition: partition@611000 {
 				label = "storage";
-				reg = <0x00630000 DT_SIZE_K(1856)>;
+				reg = <0x00611000 DT_SIZE_K(1980)>;
 			};
 		};
 	};

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -143,21 +143,20 @@ arduino_serial: &lpuart3 {
 				label = "mcuboot";
 				reg = <0x00000000 DT_SIZE_K(64)>;
 			};
+			/* Note slot 0 has one additional sector,
+			 * this is intended for use with the swap move algorithm
+			 */
 			slot0_partition: partition@10000 {
 				label = "image-0";
-				reg = <0x00010000 DT_SIZE_M(3)>;
+				reg = <0x00010000 (DT_SIZE_M(3) + DT_SIZE_K(4))>;
 			};
-			slot1_partition: partition@310000 {
+			slot1_partition: partition@311000 {
 				label = "image-1";
-				reg = <0x00310000 DT_SIZE_M(3)>;
+				reg = <0x00311000 DT_SIZE_M(3)>;
 			};
-			scratch_partition: partition@610000 {
-				label = "image-scratch";
-				reg = <0x00610000 DT_SIZE_K(128)>;
-			};
-			storage_partition: partition@630000 {
+			storage_partition: partition@611000 {
 				label = "storage";
-				reg = <0x00630000 DT_SIZE_K(1856)>;
+				reg = <0x00611000 DT_SIZE_K(1980)>;
 			};
 		};
 	};

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk_hyperflash.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk_hyperflash.dts
@@ -53,21 +53,20 @@
 				label = "mcuboot";
 				reg = <0x00000000 DT_SIZE_K(256)>;
 			};
+			/* Note slot 0 has one additional sector,
+			 * this is intended for use with the swap move algorithm
+			 */
 			slot0_partition: partition@40000 {
 				label = "image-0";
-				reg = <0x00040000 DT_SIZE_M(3)>;
+				reg = <0x00040000 (DT_SIZE_M(3) + DT_SIZE_K(4))>;
 			};
-			slot1_partition: partition@340000 {
+			slot1_partition: partition@341000 {
 				label = "image-1";
-				reg = <0x00340000 DT_SIZE_M(3)>;
+				reg = <0x00341000 DT_SIZE_M(3)>;
 			};
-			scratch_partition: partition@640000 {
-				label = "image-scratch";
-				reg = <0x00640000 DT_SIZE_K(768)>;
-			};
-			storage_partition: partition@700000 {
+			storage_partition: partition@641000 {
 				label = "storage";
-				reg = <0x00700000 DT_SIZE_M(57)>;
+				reg = <0x00641000 (DT_SIZE_M(57) + DT_SIZE_K(764))>;
 			};
 		};
 	};

--- a/boards/arm/mimxrt1062_fmurt6/mimxrt1062_fmurt6.dts
+++ b/boards/arm/mimxrt1062_fmurt6/mimxrt1062_fmurt6.dts
@@ -223,13 +223,9 @@
 				label = "image-1";
 				reg = <0x00340000 DT_SIZE_M(3)>;
 			};
-			scratch_partition: partition@640000 {
-				label = "image-scratch";
-				reg = <0x00640000 DT_SIZE_K(768)>;
-			};
-			storage_partition: partition@700000 {
+			storage_partition: partition@640000 {
 				label = "storage";
-				reg = <0x00700000 DT_SIZE_M(557)>;
+				reg = <0x00640000 (DT_SIZE_M(557) + DT_SIZE_K(768))>;
 			};
 		};
 	};

--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -207,17 +207,16 @@ arduino_i2c: &lpi2c1 {};
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
 		};
+		/* Note slot 0 has one additional sector,
+		 * this is intended for use with the swap move algorithm
+		 */
 		slot0_partition: partition@10000 {
 			label = "image-0";
-			reg = <0x00010000 DT_SIZE_K(1984)>;
+			reg = <0x00010000 DT_SIZE_K(2016)>;
 		};
-		slot1_partition: partition@200000 {
+		slot1_partition: partition@208000 {
 			label = "image-1";
-			reg = <0x00200000 DT_SIZE_K(1984)>;
-		};
-		scratch_partition: partition@3f0000 {
-			label = "image-scratch";
-			reg = <0x003f0000 DT_SIZE_K(64)>;
+			reg = <0x00208000 DT_SIZE_K(2012)>;
 		};
 	};
 };

--- a/boards/arm/mimxrt1160_evk/mimxrt1160_evk.dtsi
+++ b/boards/arm/mimxrt1160_evk/mimxrt1160_evk.dtsi
@@ -119,13 +119,9 @@
 				label = "image-1";
 				reg = <0x00321000 0x300000>;
 			};
-			scratch_partition: partition@621000 {
-				label = "image-scratch";
-				reg = <0x00621000 DT_SIZE_K(128)>;
-			};
-			storage_partition: partition@641000 {
+			storage_partition: partition@621000 {
 				label = "storage";
-				reg = <0x00641000 DT_SIZE_K(1856)>;
+				reg = <0x00621000 DT_SIZE_K(1984)>;
 			};
 		};
 	};

--- a/boards/arm/mimxrt1170_evk/mimxrt1170_evk.dtsi
+++ b/boards/arm/mimxrt1170_evk/mimxrt1170_evk.dtsi
@@ -193,13 +193,9 @@
 				label = "image-1";
 				reg = <0x00321000 0x300000>;
 			};
-			scratch_partition: partition@621000 {
-				label = "image-scratch";
-				reg = <0x00621000 DT_SIZE_K(128)>;
-			};
-			storage_partition: partition@641000 {
+			storage_partition: partition@621000 {
 				label = "storage";
-				reg = <0x00641000 DT_SIZE_K(1856)>;
+				reg = <0x00621000 DT_SIZE_K(1984)>;
 			};
 		};
 	};

--- a/boards/arm/mimxrt1170_evk/mimxrt1170_evkb_cm4.dts
+++ b/boards/arm/mimxrt1170_evk/mimxrt1170_evkb_cm4.dts
@@ -58,13 +58,9 @@
 				label = "image-1";
 				reg = <0x00321000 0x300000>;
 			};
-			scratch_partition: partition@621000 {
-				label = "image-scratch";
-				reg = <0x00621000 DT_SIZE_K(128)>;
-			};
-			storage_partition: partition@641000 {
+			storage_partition: partition@621000 {
 				label = "storage";
-				reg = <0x00641000 DT_SIZE_K(1856)>;
+				reg = <0x00621000 DT_SIZE_K(1984)>;
 			};
 		};
 	};

--- a/boards/arm/mimxrt1170_evk/mimxrt1170_evkb_cm7.dts
+++ b/boards/arm/mimxrt1170_evk/mimxrt1170_evkb_cm7.dts
@@ -59,13 +59,9 @@
 				label = "image-1";
 				reg = <0x00321000 0x300000>;
 			};
-			scratch_partition: partition@621000 {
-				label = "image-scratch";
-				reg = <0x00621000 DT_SIZE_K(128)>;
-			};
-			storage_partition: partition@641000 {
+			storage_partition: partition@621000 {
 				label = "storage";
-				reg = <0x00641000 DT_SIZE_K(1856)>;
+				reg = <0x00621000 DT_SIZE_K(1984)>;
 			};
 		};
 	};


### PR DESCRIPTION
Switch the default MCUBoot FW Update mode from Swap & Scratch to more preferable Swap & Move for the rest of NXP MCUs. Other NXP MCU platforms have been already switched. 
Delete the scratch partition. Save RAM & ROM.