### PR TITLE
Bluetooth: has: Fix control point error return code

### DIFF
--- a/subsys/bluetooth/audio/has.c
+++ b/subsys/bluetooth/audio/has.c
@@ -1396,6 +1396,8 @@ static uint8_t handle_control_point_op(struct bt_conn *conn, struct net_buf_simp
 	case BT_HAS_OP_WRITE_PRESET_NAME:
 		if (IS_ENABLED(CONFIG_BT_HAS_PRESET_NAME_DYNAMIC)) {
 			return handle_write_preset_name(conn, buf);
+		} else {
+			return BT_HAS_ERR_WRITE_NAME_NOT_ALLOWED;
 		}
 		break;
 	case BT_HAS_OP_SET_ACTIVE_PRESET:


### PR DESCRIPTION
This fixes the return error code for Preset Write operation that shall be returned when preset is not writable (or disabled via Kconfig like in this case).

As per HAS_v1.0; 3.2.2.3 Write Preset Name operation "If the Writable bit in the Properties field of the preset record which is identified by the Index parameter is set to 0b0, then the server shall return an ATT_ERROR_RSP PDU to the ATT_WRITE_REQ PDU with the Error Code parameter set to Write Name Not Allowed."