### PR TITLE
drivers: net: loopback: Do not change the original pkt

### DIFF
--- a/drivers/net/loopback.c
+++ b/drivers/net/loopback.c
@@ -110,26 +110,6 @@ static int loopback_send(const struct device *dev, struct net_pkt *pkt)
 		return -ENODATA;
 	}
 
-	/* We need to swap the IP addresses because otherwise
-	 * the packet will be dropped.
-	 */
-
-	if (net_pkt_family(pkt) == AF_INET6) {
-		struct in6_addr addr;
-
-		net_ipv6_addr_copy_raw((uint8_t *)&addr, NET_IPV6_HDR(pkt)->src);
-		net_ipv6_addr_copy_raw(NET_IPV6_HDR(pkt)->src,
-				       NET_IPV6_HDR(pkt)->dst);
-		net_ipv6_addr_copy_raw(NET_IPV6_HDR(pkt)->dst, (uint8_t *)&addr);
-	} else {
-		struct in_addr addr;
-
-		net_ipv4_addr_copy_raw((uint8_t *)&addr, NET_IPV4_HDR(pkt)->src);
-		net_ipv4_addr_copy_raw(NET_IPV4_HDR(pkt)->src,
-				       NET_IPV4_HDR(pkt)->dst);
-		net_ipv4_addr_copy_raw(NET_IPV4_HDR(pkt)->dst, (uint8_t *)&addr);
-	}
-
 	/* We should simulate normal driver meaning that if the packet is
 	 * properly sent (which is always in this driver), then the packet
 	 * must be dropped. This is very much needed for TCP packets where
@@ -139,6 +119,21 @@ static int loopback_send(const struct device *dev, struct net_pkt *pkt)
 	if (!cloned) {
 		res = -ENOMEM;
 		goto out;
+	}
+
+	/* We need to swap the IP addresses because otherwise
+	 * the packet will be dropped.
+	 */
+	if (net_pkt_family(pkt) == AF_INET6) {
+		net_ipv6_addr_copy_raw(NET_IPV6_HDR(cloned)->src,
+				       NET_IPV6_HDR(pkt)->dst);
+		net_ipv6_addr_copy_raw(NET_IPV6_HDR(cloned)->dst,
+				       NET_IPV6_HDR(pkt)->src);
+	} else {
+		net_ipv4_addr_copy_raw(NET_IPV4_HDR(cloned)->src,
+				       NET_IPV4_HDR(pkt)->dst);
+		net_ipv4_addr_copy_raw(NET_IPV4_HDR(cloned)->dst,
+				       NET_IPV4_HDR(pkt)->src);
 	}
 
 	res = net_recv_data(net_pkt_iface(cloned), cloned);


### PR DESCRIPTION
When we are sending a network pkt, do not tweak the original packet but the cloned one. The original behavior is ok too, but logically we should adjust the cloned packet only that is being received by the stack. This also means that we avoid one extra copy to tmp variable when sending the packet.