### PR TITLE
modules: mbedtls: Remove check_config.h

### DIFF
--- a/modules/mbedtls/configs/config-tls-generic.h
+++ b/modules/mbedtls/configs/config-tls-generic.h
@@ -486,19 +486,4 @@
 #include CONFIG_MBEDTLS_USER_CONFIG_FILE
 #endif
 
-#if !defined(CONFIG_MBEDTLS_PSA_CRYPTO_C)
-/* When PSA API is used the checking header is included over the chain:
- * |-psa/crypto.h
- * |-psa/crypto_platform.h
- * |-mbedtls/build_info.h
- * |-mbedtls/check_config.h
- * If include this header here then PSA API will be in semiconfigured state
- * without considering dependencies from mbedtls/config_psa.h.
- * mbedtls/config_psa.h should be included right after config-tls-generic.h before checking.
- * Formally, all settings are correct but mbedtls library cannot be built.
- * The behavior was introduced after adding mbedTLS 3.4.0
- */
-#include "mbedtls/check_config.h"
-#endif
-
 #endif /* MBEDTLS_CONFIG_H */


### PR DESCRIPTION
build_info.h of mbedtls includes the config file for mbedtls but also includes check_config.h so its not needed to have it in the config file