### PR TITLE
net: tcp: Fix deadlock with tcp_conn_close()

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -714,15 +714,11 @@ static void tcp_conn_release(struct k_work *work)
 
 	k_mutex_lock(&tcp_lock, K_FOREVER);
 
-	/* If there is any pending data, pass that to application */
+	/* Application is no longer there, unref any remaining packets on the
+	 * fifo (although there shouldn't be any at this point.)
+	 */
 	while ((pkt = k_fifo_get(&conn->recv_data, K_NO_WAIT)) != NULL) {
-		if (net_context_packet_received(
-			    (struct net_conn *)conn->context->conn_handler,
-			    pkt, NULL, NULL, conn->recv_user_data) ==
-		    NET_DROP) {
-			/* Application is no longer there, unref the pkt */
-			tcp_pkt_unref(pkt);
-		}
+		tcp_pkt_unref(pkt);
 	}
 
 	k_mutex_lock(&conn->lock, K_FOREVER);

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -3392,12 +3392,7 @@ out:
 		goto next_state;
 	}
 
-	/* Make sure we close the connection only once by checking connection
-	 * state.
-	 */
-	if (do_close && conn->state != TCP_UNUSED && conn->state != TCP_CLOSED) {
-		tcp_conn_close(conn, close_status);
-	} else if (conn->context) {
+	if (conn->context) {
 		/* If the conn->context is not set, then the connection was
 		 * already closed.
 		 */
@@ -3421,6 +3416,13 @@ out:
 			/* Application is no longer there, unref the pkt */
 			tcp_pkt_unref(recv_pkt);
 		}
+	}
+
+	/* Make sure we close the connection only once by checking connection
+	 * state.
+	 */
+	if (do_close && conn->state != TCP_UNUSED && conn->state != TCP_CLOSED) {
+		tcp_conn_close(conn, close_status);
 	}
 
 	return verdict;


### PR DESCRIPTION
The issue was spotted when working on further TLS tests. A possible deadlock was introduced with https://github.com/zephyrproject-rtos/zephyr/commit/4ab2dded8d1318e3e3a1b1df00637187e46ccc83 (probably not that easy to trigger given it was not caught by any of the existing tests).

Additionally remove some pointless code spotted when investigating the issue (note that [deadlock was triggered elsewhere](https://github.com/zephyrproject-rtos/zephyr/blob/main/subsys/net/ip/tcp.c#L826), not in the callback call removed in this PR).