### PR TITLE
input: kbd_matrix: add actual key mask runtime control

### DIFF
--- a/drivers/input/Kconfig.kbd_matrix
+++ b/drivers/input/Kconfig.kbd_matrix
@@ -27,6 +27,13 @@ config INPUT_KBD_MATRIX_16_BIT_ROW
 	  Use a 16 bit type for the internal structure, allow using a matrix
 	  with up to 16 rows if the driver supports it.
 
+config INPUT_KBD_ACTUAL_KEY_MASK_DYNAMIC
+	bool "Allow runtime changes to the actual key mask"
+	help
+	  If enabled, the actual key mask data is stored in RAM, and a
+	  input_kbd_matrix_actual_key_mask_set() function is available to
+	  change the content at runtime.
+
 config INPUT_SHELL_KBD_MATRIX_STATE
 	bool "Input kbd_matrix_state shell command"
 	depends on INPUT_SHELL

--- a/drivers/input/input_kbd_matrix.c
+++ b/drivers/input/input_kbd_matrix.c
@@ -323,3 +323,19 @@ int input_kbd_matrix_common_init(const struct device *dev)
 
 	return 0;
 }
+
+#if CONFIG_INPUT_KBD_ACTUAL_KEY_MASK_DYNAMIC
+int input_kbd_matrix_actual_key_mask_set(const struct device *dev,
+					  uint8_t row, uint8_t col, bool enabled)
+{
+	const struct input_kbd_matrix_common_config *cfg = dev->config;
+
+	if (row >= cfg->row_size || col >= cfg->col_size) {
+		return -EINVAL;
+	}
+
+	WRITE_BIT(cfg->actual_key_mask[col], row, enabled);
+
+	return 0;
+}
+#endif

--- a/include/zephyr/input/input_kbd_matrix.h
+++ b/include/zephyr/input/input_kbd_matrix.h
@@ -38,6 +38,31 @@ typedef uint8_t kbd_row_t;
 #define PRIkbdrow "%02x"
 #endif
 
+#if CONFIG_INPUT_KBD_ACTUAL_KEY_MASK_DYNAMIC
+#define INPUT_KBD_ACTUAL_KEY_MASK_CONST
+/**
+ * @brief Enables or disables a specific row, column combination in the actual
+ * key mask.
+ *
+ * This allows enabling or disabling spcific row, column combination in the
+ * actual key mask in runtime. It can be useful if some of the keys are not
+ * present in some configuration, and the specific configuration is determined
+ * in runtime. Requires CONFIG_INPUT_KBD_ACTUAL_KEY_MASK_DYNAMIC=y.
+ *
+ * @param dev Pointer to the keyboard matrix device.
+ * @param row The matrix row to enable or disable.
+ * @param col The matrix column to enable or disable.
+ * @param enabled Whether the specificied row, col has to be enabled or disabled.
+ *
+ * @retval 0 If the change is successful.
+ * @retval -errno Negative errno if row or col are out of range for the device.
+ */
+int input_kbd_matrix_actual_key_mask_set(const struct device *dev,
+					  uint8_t row, uint8_t col, bool enabled);
+#else
+#define INPUT_KBD_ACTUAL_KEY_MASK_CONST const
+#endif
+
 /** Maximum number of rows */
 #define INPUT_KBD_MATRIX_ROW_BITS NUM_BITS(kbd_row_t)
 
@@ -90,7 +115,7 @@ struct input_kbd_matrix_common_config {
 	uint32_t debounce_up_us;
 	uint32_t settle_time_us;
 	bool ghostkey_check;
-	const kbd_row_t *actual_key_mask;
+	INPUT_KBD_ACTUAL_KEY_MASK_CONST kbd_row_t *actual_key_mask;
 
 	/* extra data pointers */
 	kbd_row_t *matrix_stable_state;
@@ -114,8 +139,9 @@ struct input_kbd_matrix_common_config {
 	IF_ENABLED(DT_NODE_HAS_PROP(node_id, actual_key_mask), ( \
 	BUILD_ASSERT(DT_PROP_LEN(node_id, actual_key_mask) == _col_size, \
 		     "actual-key-mask size does not match the number of columns"); \
-	static const kbd_row_t INPUT_KBD_MATRIX_DATA_NAME(node_id, actual_key_mask)[_col_size] = \
-		DT_PROP(node_id, actual_key_mask); \
+	static INPUT_KBD_ACTUAL_KEY_MASK_CONST kbd_row_t \
+		INPUT_KBD_MATRIX_DATA_NAME(node_id, actual_key_mask)[_col_size] = \
+			DT_PROP(node_id, actual_key_mask); \
 	)) \
 	static kbd_row_t INPUT_KBD_MATRIX_DATA_NAME(node_id, stable_state)[_col_size]; \
 	static kbd_row_t INPUT_KBD_MATRIX_DATA_NAME(node_id, unstable_state)[_col_size]; \

--- a/include/zephyr/input/input_kbd_matrix.h
+++ b/include/zephyr/input/input_kbd_matrix.h
@@ -38,7 +38,7 @@ typedef uint8_t kbd_row_t;
 #define PRIkbdrow "%02x"
 #endif
 
-#if CONFIG_INPUT_KBD_ACTUAL_KEY_MASK_DYNAMIC
+#if defined(CONFIG_INPUT_KBD_ACTUAL_KEY_MASK_DYNAMIC) || defined(__DOXYGEN__)
 #define INPUT_KBD_ACTUAL_KEY_MASK_CONST
 /**
  * @brief Enables or disables a specific row, column combination in the actual
@@ -47,7 +47,8 @@ typedef uint8_t kbd_row_t;
  * This allows enabling or disabling spcific row, column combination in the
  * actual key mask in runtime. It can be useful if some of the keys are not
  * present in some configuration, and the specific configuration is determined
- * in runtime. Requires CONFIG_INPUT_KBD_ACTUAL_KEY_MASK_DYNAMIC=y.
+ * in runtime. Requires @kconfig{CONFIG_INPUT_KBD_ACTUAL_KEY_MASK_DYNAMIC} to
+ * be enabled.
  *
  * @param dev Pointer to the keyboard matrix device.
  * @param row The matrix row to enable or disable.
@@ -276,12 +277,13 @@ struct input_kbd_matrix_common_data {
  */
 void input_kbd_matrix_poll_start(const struct device *dev);
 
-#ifdef CONFIG_INPUT_KBD_DRIVE_COLUMN_HOOK
+#if defined(CONFIG_INPUT_KBD_DRIVE_COLUMN_HOOK) || defined(__DOXYGEN__)
 /**
  * @brief Drive column hook
  *
  * This can be implemented by the application to handle column selection
- * quirks. Called after the driver specific drive_column function.
+ * quirks. Called after the driver specific drive_column function. Requires
+ * @kconfig{CONFIG_INPUT_KBD_DRIVE_COLUMN_HOOK} to be enabled.
  *
  * @param dev Keyboard matrix device instance.
  * @param col The column to drive, or

--- a/tests/drivers/input/kbd_matrix/testcase.yaml
+++ b/tests/drivers/input/kbd_matrix/testcase.yaml
@@ -17,6 +17,10 @@ tests:
   input.input_kbd_matrix.actual_key_mask:
     extra_args:
       - EXTRA_DTC_OVERLAY_FILE=actual-key-mask.overlay
+  input.input_kbd_matrix.actual_key_mask_dynamic:
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE=actual-key-mask.overlay
+      - CONFIG_INPUT_KBD_ACTUAL_KEY_MASK_DYNAMIC=y
   input.input_kbd_matrix.row_16_bit:
     extra_args:
       - CONFIG_INPUT_KBD_MATRIX_16_BIT_ROW=y


### PR DESCRIPTION
Add an option to enable a input_kbd_matrix_actual_key_mask_set API to enable or disable keys dynamically in the mask. This can be useful if the exact key mask is determined in runtime and the device is using a single firmware for multiple matrix configurations.