### PR TITLE
net: Add fallback macro for nef_if_mon functions

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -1001,6 +1001,10 @@ void net_if_mcast_monitor(struct net_if *iface,
 
 	k_mutex_unlock(&lock);
 }
+#else
+#define net_if_mcast_mon_register(...)
+#define net_if_mcast_mon_unregister(...)
+#define net_if_mcast_monitor(...)
 #endif
 
 #if defined(CONFIG_NET_NATIVE_IPV6)


### PR DESCRIPTION
Add empty macro for net_if_mon functions if they are not otherwise defined, like the other functions in the net_if.c file have.