### PR TITLE
boards: arm: Add RTC clock source for 96b_aerocore2 and az3166_iotdevkit

### DIFF
--- a/boards/arm/96b_aerocore2/96b_aerocore2.dts
+++ b/boards/arm/96b_aerocore2/96b_aerocore2.dts
@@ -42,6 +42,10 @@
 
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	clock-frequency = <DT_FREQ_M(24)>;
 	status = "okay";
@@ -177,6 +181,12 @@ zephyr_udc0: &usbotg_fs {
 	pinctrl-names = "default";
 	st,adc-clock-source = <SYNC>;
 	st,adc-prescaler = <2>;
+	status = "okay";
+};
+
+&rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/az3166_iotdevkit/az3166_iotdevkit.dts
+++ b/boards/arm/az3166_iotdevkit/az3166_iotdevkit.dts
@@ -205,3 +205,9 @@
 		pinctrl-names = "default";
 	};
 };
+
+&rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
+	status = "okay";
+};


### PR DESCRIPTION
The `96b_aerocore2`  and az3166_iotdevkit boards doesn't have its RTC node enabled, and they are failing the following test:
`tests/benchmarks/footprints/benchmark.kernel.footprints.pm` 
--> Enabled RTC node for that platform.

This PR completes the https://github.com/zephyrproject-rtos/zephyr/pull/66359


to fix https://github.com/zephyrproject-rtos/zephyr/issues/66360