### PR TITLE
net: Add Kconfig for net buf alignment

### DIFF
--- a/include/zephyr/net/buf.h
+++ b/include/zephyr/net/buf.h
@@ -28,7 +28,11 @@ extern "C" {
  */
 
 /* Alignment needed for various parts of the buffer definition */
+#if CONFIG_NET_BUF_ALIGNMENT == 0
 #define __net_buf_align __aligned(sizeof(void *))
+#else
+#define __net_buf_align __aligned(CONFIG_NET_BUF_ALIGNMENT)
+#endif
 
 /**
  *  @brief Define a net_buf_simple stack variable.

--- a/subsys/net/Kconfig
+++ b/subsys/net/Kconfig
@@ -51,6 +51,16 @@ config NET_BUF_POOL_USAGE
 	  * total size of the pool is calculated
 	  * pool name is stored and can be shown in debugging prints
 
+config NET_BUF_ALIGNMENT
+	int "Network buffer alignment restriction"
+	default 0
+	help
+	  Alignment restriction for network buffers. This is useful for
+	  some hardware IP with DMA that requires the buffers to be aligned
+	  to a certain byte boundary, or dealing with cache line restrictions.
+	  Default value of 0 means the alignment will be the size of a void pointer,
+	  any other value will force the alignment of a net buffer in bytes.
+
 endif # NET_BUF
 
 config NETWORKING


### PR DESCRIPTION
Add a NET_BUF_ALIGNMENT kconfig to make net buffer alignment configurable.