### PR TITLE
Revert "boards: arm: Fix sensor shell sample for beagleconnect_freedo…

### DIFF
--- a/boards/arm/beagle_bcf/beagleconnect_freedom.dts
+++ b/boards/arm/beagle_bcf/beagleconnect_freedom.dts
@@ -64,6 +64,18 @@
 		#size-cells = <0>;
 		controller = <&i2c0>;
 		gpios = <&gpio0 14 GPIO_ACTIVE_HIGH>;
+
+		light: opt3001-light@44 {
+			status = "okay";
+			compatible = "ti,opt3001";
+			reg = <0x44>;
+		};
+
+		humidity: hdc2010-humidity@41 {
+			status = "okay";
+			compatible = "ti,hdc2010";
+			reg = <0x41>;
+		};
 	};
 };
 
@@ -125,18 +137,6 @@
 	mcu: msp430-usbbridge@4 {
 		compatible = "beagle,usbbridge";
 		reg = <0x4>;
-	};
-
-	light: opt3001-light@44 {
-		status = "okay";
-		compatible = "ti,opt3001";
-		reg = <0x44>;
-	};
-
-	humidity: hdc2010-humidity@41 {
-		status = "okay";
-		compatible = "ti,hdc2010";
-		reg = <0x41>;
 	};
 };
 


### PR DESCRIPTION
…m board"

This reverts commit 3769938e785b09cff9ebb604a371100d1bfcf257.

Now that gpio_i2c_switch is upstream, this hack should be removed. This had the unintended effect of disabling the on-board sensors. The issue was that the board was merged before this driver was upstream, resulting in the issue this commit "fixed".

This revert also does not move the bus driver under the controller used by the driver as the sensor bus I2C driver is not an I2C peripheral.

See:
* https://github.com/zephyrproject-rtos/zephyr/pull/64881
* https://github.com/zephyrproject-rtos/zephyr/pull/64693
* https://github.com/zephyrproject-rtos/zephyr/pull/65031