### PR TITLE
twister: support lcov > 2.0

### DIFF
--- a/scripts/pylib/twister/twisterlib/coverage.py
+++ b/scripts/pylib/twister/twisterlib/coverage.py
@@ -138,6 +138,20 @@ class Lcov(CoverageTool):
         super().__init__()
         self.ignores = []
         self.output_formats = "lcov,html"
+        self.version = self.get_version()
+
+    def get_version(self):
+        try:
+            result = subprocess.run(['lcov', '--version'],
+                                    stdout=subprocess.PIPE,
+                                    stderr=subprocess.PIPE,
+                                    text=True, check=True)
+            version_output = result.stdout.strip().replace('lcov: LCOV version ', '')
+            return version_output
+        except subprocess.CalledProcessError as e:
+            logger.error(f"Unsable to determine lcov version: {e}")
+
+        return ""
 
     def add_ignore_file(self, pattern):
         self.ignores.append('*' + pattern + '*')
@@ -145,51 +159,75 @@ class Lcov(CoverageTool):
     def add_ignore_directory(self, pattern):
         self.ignores.append('*/' + pattern + '/*')
 
+    @staticmethod
+    def run_command(cmd, coveragelog):
+        cmd_str = " ".join(cmd)
+        logger.debug(f"Running {cmd_str}...")
+        return subprocess.call(cmd, stdout=coveragelog)
+
     def _generate(self, outdir, coveragelog):
         coveragefile = os.path.join(outdir, "coverage.info")
         ztestfile = os.path.join(outdir, "ztest.info")
+        if self.version.startswith("2"):
+            branch_coverage = "branch_coverage=1"
+            ignore_errors = [
+                         "--ignore-errors", "inconsistent,inconsistent",
+                         "--ignore-errors", "negative,negative",
+                         "--ignore-errors", "unused,unused",
+                         "--ignore-errors", "empty,empty",
+                         "--ignore-errors", "mismatch,mismatch"
+                         ]
+        else:
+            branch_coverage = "lcov_branch_coverage=1"
+            ignore_errors = []
+
         cmd = ["lcov", "--gcov-tool", str(self.gcov_tool),
                          "--capture", "--directory", outdir,
-                         "--rc", "lcov_branch_coverage=1",
+                         "--rc", branch_coverage,
                          "--output-file", coveragefile]
-        cmd_str = " ".join(cmd)
-        logger.debug(f"Running {cmd_str}...")
-        subprocess.call(cmd, stdout=coveragelog)
+        cmd = cmd + ignore_errors
+        self.run_command(cmd, coveragelog)
         # We want to remove tests/* and tests/ztest/test/* but save tests/ztest
-        subprocess.call(["lcov", "--gcov-tool", self.gcov_tool, "--extract",
+        cmd = ["lcov", "--gcov-tool", self.gcov_tool, "--extract",
                          coveragefile,
                          os.path.join(self.base_dir, "tests", "ztest", "*"),
                          "--output-file", ztestfile,
-                         "--rc", "lcov_branch_coverage=1"], stdout=coveragelog)
+                         "--rc", branch_coverage]
+
+        cmd = cmd + ignore_errors
+        self.run_command(cmd, coveragelog)
 
         if os.path.exists(ztestfile) and os.path.getsize(ztestfile) > 0:
-            subprocess.call(["lcov", "--gcov-tool", self.gcov_tool, "--remove",
+            cmd = ["lcov", "--gcov-tool", self.gcov_tool, "--remove",
                              ztestfile,
                              os.path.join(self.base_dir, "tests/ztest/test/*"),
                              "--output-file", ztestfile,
-                             "--rc", "lcov_branch_coverage=1"],
-                            stdout=coveragelog)
+                             "--rc", branch_coverage]
+            cmd = cmd + ignore_errors
+            self.run_command(cmd, coveragelog)
+
             files = [coveragefile, ztestfile]
         else:
             files = [coveragefile]
 
         for i in self.ignores:
-            subprocess.call(
-                ["lcov", "--gcov-tool", self.gcov_tool, "--remove",
-                 coveragefile, i, "--output-file",
-                 coveragefile, "--rc", "lcov_branch_coverage=1"],
-                stdout=coveragelog)
+            cmd = ["lcov", "--gcov-tool", self.gcov_tool, "--remove",
+                 coveragefile, i,
+                 "--output-file", coveragefile,
+                 "--rc", branch_coverage]
+            cmd = cmd + ignore_errors
+            self.run_command(cmd, coveragelog)
 
         if 'html' not in self.output_formats.split(','):
             return 0
 
         # The --ignore-errors source option is added to avoid it exiting due to
         # samples/application_development/external_lib/
-        return subprocess.call(["genhtml", "--legend", "--branch-coverage",
-                                "--ignore-errors", "source",
+        cmd = ["genhtml", "--legend", "--branch-coverage",
                                 "-output-directory",
-                                os.path.join(outdir, "coverage")] + files,
-                               stdout=coveragelog)
+                                os.path.join(outdir, "coverage")] + files
+        cmd = cmd + ignore_errors
+        return self.run_command(cmd, coveragelog)
 
 
 class Gcovr(CoverageTool):


### PR DESCRIPTION
Support lcov > 2.0 tool which has strict error checking and some new
configuration options deprecating syntax used in 1.4 versions.

Fixes #62202

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
