### PR TITLE
dts: mdio-controller: add property for MDC frequency

### DIFF
--- a/dts/bindings/mdio/mdio-controller.yaml
+++ b/dts/bindings/mdio/mdio-controller.yaml
@@ -22,3 +22,12 @@ properties:
       When present, the SMA suppresses the 32-bit preamble and transmits
       MDIO frames with only 1 preamble bit. By default, the MDIO frame
       always has 32 bits of preamble as defined in the IEEE 802.3 specs.
+
+  clock-frequency:
+    type: int
+    default: 2500000
+    description: |
+      Some MDIO controllers have the ability to configure the MDC frequency.
+      If present, this property may be used to specify the MDC frequency based
+      on what the PHYs connected to the mdio bus can support. Default of 2.5MHz
+      is the standard and should supported by all PHYs.


### PR DESCRIPTION
Add a property to the mdio controller binding to describe the MDC frequency of a controller