### PR TITLE
drivers: nxp_enet: Improve readability within the driver

### DIFF
--- a/include/zephyr/drivers/ethernet/eth_nxp_enet.h
+++ b/include/zephyr/drivers/ethernet/eth_nxp_enet.h
@@ -44,9 +44,13 @@ extern void nxp_enet_mdio_callback(const struct device *mdio_dev,
 		enum nxp_enet_callback_reason event,
 		void *data);
 
+#ifdef CONFIG_PTP_CLOCK_NXP_ENET
 extern void nxp_enet_ptp_clock_callback(const struct device *dev,
 		enum nxp_enet_callback_reason event,
 		void *data);
+#else
+#define nxp_enet_ptp_clock_callback(...)
+#endif
 
 /*
  * Internal implementation, inter-driver communication function


### PR DESCRIPTION
Part of the issue with eth_mcux was the bloated source code making it slightly more difficult to maintain. A big part of the mess is already addressed by the initial merge point of the driver compared to eth_mcux, but some functions I did not clean up in the rx/tx code paths initially. So here I cleaned the rest of it up to make sure the community can test that for sure cleanup does not break anything for anyone (it should be functionally the same) before deprecating the old driver. 

This PR should make the source more readable and easy to understand, to avoid confusing code paths and conditional compilation messes that could lead to bugs being introduced.