### PR TITLE
kernel: mmu: mitigate range check overflow issue

### DIFF
--- a/kernel/include/mmu.h
+++ b/kernel/include/mmu.h
@@ -186,7 +186,8 @@ static inline void *z_page_frame_to_virt(struct z_page_frame *pf)
 static inline bool z_is_page_frame(uintptr_t phys)
 {
 	z_assert_phys_aligned(phys);
-	return (phys >= Z_PHYS_RAM_START) && (phys < Z_PHYS_RAM_END);
+	return IN_RANGE(phys, (uintptr_t)Z_PHYS_RAM_START,
+			(uintptr_t)(Z_PHYS_RAM_END - 1));
 }
 
 static inline struct z_page_frame *z_phys_to_page_frame(uintptr_t phys)
@@ -206,7 +207,12 @@ static inline void z_mem_assert_virtual_region(uint8_t *addr, size_t size)
 		 "unaligned size %zu", size);
 	__ASSERT(!Z_DETECT_POINTER_OVERFLOW(addr, size),
 		 "region %p size %zu zero or wraps around", addr, size);
-	__ASSERT(addr >= Z_VIRT_RAM_START && addr + size < Z_VIRT_RAM_END,
+	__ASSERT(IN_RANGE((uintptr_t)addr,
+			  (uintptr_t)Z_VIRT_RAM_START,
+			  ((uintptr_t)Z_VIRT_RAM_END - 1)) &&
+		 IN_RANGE(((uintptr_t)addr + size - 1),
+			  (uintptr_t)Z_VIRT_RAM_START,
+			  ((uintptr_t)Z_VIRT_RAM_END - 1)),
 		 "invalid virtual address region %p (%zu)", addr, size);
 }
 


### PR DESCRIPTION
It is possible that address + size will overflow the available address space and the pointer wraps around back to zero. Some of these have been fixed in previous commits. This fixes the remaining ones with regard to Z_PHYS_RAM_START/_END, and Z_VIRT_RAM_START/_END.

Fixes #65542