### PR TITLE
posix: pthread_once: simplify and reduce size of pthread_once_t

### DIFF
--- a/include/zephyr/posix/pthread.h
+++ b/include/zephyr/posix/pthread.h
@@ -37,10 +37,7 @@ extern "C" {
 #define PTHREAD_CANCEL_ASYNCHRONOUS 1
 
 /* Passed to pthread_once */
-#define PTHREAD_ONCE_INIT                                                                          \
-	{                                                                                          \
-		1, 0                                                                               \
-	}
+#define PTHREAD_ONCE_INIT {0}
 
 /* The minimum allowable stack size */
 #define PTHREAD_STACK_MIN Z_KERNEL_STACK_SIZE_ADJUST(0)

--- a/include/zephyr/posix/pthread_key.h
+++ b/include/zephyr/posix/pthread_key.h
@@ -19,8 +19,7 @@ extern "C" {
 #ifdef CONFIG_PTHREAD_IPC
 
 typedef struct {
-	int is_initialized;
-	int init_executed;
+	char flag;
 } pthread_once_t;
 #endif
 

--- a/lib/libc/common/include/machine/_threads.h
+++ b/lib/libc/common/include/machine/_threads.h
@@ -11,18 +11,14 @@
 extern "C" {
 #endif
 
-#define ONCE_FLAG_INIT                                                                             \
-	{                                                                                          \
-		1, 0                                                                               \
-	}
+#define ONCE_FLAG_INIT {0}
 
 typedef int cnd_t;
 typedef int mtx_t;
 typedef int thrd_t;
 typedef int tss_t;
 typedef struct {
-	int is_initialized;
-	int init_executed;
+	char flag;
 } once_flag;
 
 #ifdef __cplusplus

--- a/lib/posix/pthread.c
+++ b/lib/posix/pthread.c
@@ -708,12 +708,16 @@ int pthread_once(pthread_once_t *once, void (*init_func)(void))
 {
 	__unused int ret;
 
+	if (init_func == NULL) {
+		return EINVAL;
+	}
+
 	ret = k_mutex_lock(&pthread_once_lock, K_FOREVER);
 	__ASSERT_NO_MSG(ret == 0);
 
-	if (once->is_initialized != 0 && once->init_executed == 0) {
+	if (once->flag == 0) {
 		init_func();
-		once->init_executed = 1;
+		once->flag = 1;
 	}
 
 	ret = k_mutex_unlock(&pthread_once_lock);

--- a/tests/posix/common/src/pthread.c
+++ b/tests/posix/common/src/pthread.c
@@ -478,7 +478,7 @@ ZTEST(posix_apis, test_pthread_errors_errno)
 		      "cancel NULL error");
 	zassert_equal(pthread_join(PTHREAD_INVALID, NULL), ESRCH,
 		      "join with NULL has error");
-	zassert_false(pthread_once(&key, NULL),
+	zassert_equal(pthread_once(&key, NULL), EINVAL,
 		      "pthread dynamic package initialization error");
 	zassert_equal(pthread_getschedparam(PTHREAD_INVALID, &policy, &param), ESRCH,
 		      "get schedparam with NULL error");


### PR DESCRIPTION
Since pthread_once() is both the initializer and executor of pthread_once_t, it can have maximally two states.

It does not make sense to use 64 bits to manage 2 possible states.

Use the ANSI equivalent of a bool in the implementation rather than 2 ints.