### PR TITLE
[RFC] twister: implement `simulation_exclude` filter 

### DIFF
--- a/scripts/pylib/twister/twisterlib/config_parser.py
+++ b/scripts/pylib/twister/twisterlib/config_parser.py
@@ -70,6 +70,7 @@ class TwisterConfigParser:
                        "platform_exclude": {"type": "set"},
                        "platform_allow": {"type": "set"},
                        "platform_key": {"type": "list", "default": []},
+                       "simulation_exclude": {"type": "list", "default": []},
                        "toolchain_exclude": {"type": "set"},
                        "toolchain_allow": {"type": "set"},
                        "filter": {"type": "str"},

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -219,7 +219,8 @@ class TestInstance:
 
         target_ready = bool(self.testsuite.type == "unit" or \
                         self.platform.type == "native" or \
-                        self.platform.simulation in SUPPORTED_SIMS or \
+                        (self.platform.simulation in SUPPORTED_SIMS and \
+                         self.platform.simulation not in self.testsuite.simulation_exclude) or \
                         filter == 'runnable')
 
         # check if test is runnable in pytest

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -58,7 +58,7 @@ class Filters:
     TESTSUITE = 'testsuite filter'
     # filters in the testplan yaml definition
     TESTPLAN = 'testplan filter'
-    # filters realted to platform definition
+    # filters related to platform definition
     PLATFORM = 'Platform related filter'
     # in case a test suite was quarantined.
     QUARANTINE = 'Quarantine filter'

--- a/scripts/schemas/twister/testsuite-schema.yaml
+++ b/scripts/schemas/twister/testsuite-schema.yaml
@@ -145,6 +145,7 @@ mapping:
         required: false
         sequence:
           - type: str
+            enum: ["mcu", "qemu", "sim", "unit", "native"]
       "platform_key":
         required: false
         type: seq

--- a/scripts/schemas/twister/testsuite-schema.yaml
+++ b/scripts/schemas/twister/testsuite-schema.yaml
@@ -157,6 +157,24 @@ mapping:
         required: false
         sequence:
           - type: str
+      "simulation_exclude":
+        type: seq
+        required: false
+        sequence:
+          - type: str
+            enum:
+              [
+                "qemu",
+                "simics",
+                "xt-sim",
+                "renode",
+                "nsim",
+                "mdb-nsim",
+                "tsim",
+                "armfvp",
+                "native",
+                "custom",
+              ]
       "tags":
         type: any
         required: false
@@ -356,6 +374,24 @@ mapping:
             matching: "all"
             sequence:
               - type: str
+          "simulation_exclude":
+            type: seq
+            required: false
+            sequence:
+              - type: str
+                enum:
+                  [
+                    "qemu",
+                    "simics",
+                    "xt-sim",
+                    "renode",
+                    "nsim",
+                    "mdb-nsim",
+                    "tsim",
+                    "armfvp",
+                    "native",
+                    "custom",
+                  ]
           "tags":
             type: any
             required: false

--- a/scripts/twister
+++ b/scripts/twister
@@ -90,6 +90,9 @@ pairs:
   platform_exclude: <list of platforms>
     Set of platforms that this test case should not run on.
 
+  simulation_exclude: <list of simulators>
+    Set of simulators that this test case should not run on.
+
   extra_sections: <list of extra binary sections>
     When computing sizes, twister will report errors if it finds
     extra, unexpected sections in the Zephyr binary unless they are named

--- a/tests/kernel/timer/timer_behavior/testcase.yaml
+++ b/tests/kernel/timer/timer_behavior/testcase.yaml
@@ -6,17 +6,8 @@ tests:
     min_ram: 16
     platform_type:
       - mcu
-    # Really want to exclude renode not the physical boards, but no good
-    # way of doing so at the moment.
-    platform_exclude:
-      - hifive1
-      - tflite-micro
-      - it8xxx2_evb
-      - m2gl025_miv
-      - mpfs_icicle
-      - hifive_unleashed
-      - mps2_an385
-      - mps2_an521_ns
+    simulation_exclude:
+      - renode
   kernel.timer.timer_behavior_external:
     filter: dt_compat_enabled("test-kernel-timer-behavior-external")
     harness: pytest


### PR DESCRIPTION
This PR attempts to solve the dilemma when a physical board can pass a testcase but its simulator couldn't.

See:

https://github.com/zephyrproject-rtos/zephyr/blob/bd227e19cff9855355468974f1f984ed88f2cf3d/tests/kernel/timer/timer_behavior/testcase.yaml#L9-L19

and https://github.com/zephyrproject-rtos/zephyr/pull/66369#issuecomment-1849703114

The issue that I'm trying to solve in this PR is related to `renode`, but this patch should apply to other mcu-simulator as well