### PR TITLE
rimage: pre-process .toml files with cc -E

### DIFF
--- a/boards/common/intel_adsp.board.cmake
+++ b/boards/common/intel_adsp.board.cmake
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-board_runner_args(intel_adsp "--default-key=${RIMAGE_SIGN_KEY}")
-
-board_finalize_runner_args(intel_adsp)

--- a/boards/xtensa/intel_adsp_ace15_mtpm/board.cmake
+++ b/boards/xtensa/intel_adsp_ace15_mtpm/board.cmake
@@ -6,4 +6,4 @@ board_set_rimage_target(mtl)
 
 set(RIMAGE_SIGN_KEY "otc_private_key_3k.pem" CACHE STRING "default in ace15_mtpm/board.cmake")
 
-include(${ZEPHYR_BASE}/boards/common/intel_adsp.board.cmake)
+board_finalize_runner_args(intel_adsp)

--- a/boards/xtensa/intel_adsp_cavs25/board.cmake
+++ b/boards/xtensa/intel_adsp_cavs25/board.cmake
@@ -17,4 +17,4 @@ if(CONFIG_BOARD_INTEL_ADSP_CAVS25_TGPH)
 board_set_rimage_target(tgl-h)
 endif()
 
-include(${ZEPHYR_BASE}/boards/common/intel_adsp.board.cmake)
+board_finalize_runner_args(intel_adsp)

--- a/boards/xtensa/intel_adsp_cavs25/doc/intel_adsp_generic.rst
+++ b/boards/xtensa/intel_adsp_cavs25/doc/intel_adsp_generic.rst
@@ -143,12 +143,10 @@ undocumented rimage precedence rules it's best to use only one way at a time.
   ``boards/my/board/board.cmake``, see example in
   ``soc/xtensa/intel_adsp/common/CMakeLists.txt``
 
-For backwards compatibility reasons, you can also pass rimage parameters like
-the path to the tool binary as arguments to
-``west flash`` if the flash target exists for your board. To see a list
-of all arguments to the Intel ADSP runner, run the following after you have
-built the binary. There are multiple arguments related to signing, including a
-key argument.
+Starting with Zephyr 3.6.0, ``west flash`` does not invoke ``west sign``
+anymore and you cannot pass rimage parameters to ``west flash`` anymore. To
+see an up-to-date list of all arguments to the Intel ADSP runner, run the
+following after you have built the binary:
 
 .. code-block:: console
 

--- a/scripts/west_commands/runners/intel_adsp.py
+++ b/scripts/west_commands/runners/intel_adsp.py
@@ -4,6 +4,7 @@
 
 '''Runner for flashing with the Intel ADSP boards.'''
 
+import argparse
 import os
 import sys
 import re
@@ -14,11 +15,12 @@ from runners.core import ZephyrBinaryRunner, RunnerCaps
 from zephyr_ext_common import ZEPHYR_BASE
 
 DEFAULT_CAVSTOOL='soc/xtensa/intel_adsp/tools/cavstool_client.py'
-DEFAULT_SOF_MOD_DIR=os.path.join(ZEPHYR_BASE, '../modules/audio/sof')
-DEFAULT_RIMAGE_TOOL=shutil.which('rimage')
-DEFAULT_CONFIG_DIR=os.path.join(DEFAULT_SOF_MOD_DIR, 'tools/rimage/config')
-DEFAULT_KEY_DIR=os.path.join(DEFAULT_SOF_MOD_DIR, 'keys')
 
+class SignParamError(argparse.Action):
+    'User-friendly feedback when trying to sign with west flash'
+    def __call__(self, parser, namespace, values, option_string=None):
+        parser.error(f'Cannot use "west flash {option_string} ..." any more. ' +
+                     '"west sign" is now called from CMake, see "west sign -h"')
 
 class IntelAdspBinaryRunner(ZephyrBinaryRunner):
     '''Runner front-end for the intel ADSP boards.'''
@@ -26,32 +28,19 @@ class IntelAdspBinaryRunner(ZephyrBinaryRunner):
     def __init__(self,
                  cfg,
                  remote_host,
-                 rimage_tool,
-                 config_dir,
-                 default_key,
-                 key,
                  pty,
                  tool_opt,
-                 do_sign,
                  ):
         super().__init__(cfg)
 
         self.remote_host = remote_host
-        self.rimage_tool = rimage_tool
-        self.config_dir = config_dir
         self.bin_fw = os.path.join(cfg.build_dir, 'zephyr', 'zephyr.ri')
 
         self.cavstool = os.path.join(ZEPHYR_BASE, DEFAULT_CAVSTOOL)
         self.platform = os.path.basename(cfg.board_dir)
         self.pty = pty
 
-        if key:
-            self.key = key
-        else:
-            self.key = os.path.join(DEFAULT_KEY_DIR, default_key)
-
         self.tool_opt_args = tool_opt
-        self.do_sign = do_sign
 
     @classmethod
     def name(cls):
@@ -65,17 +54,13 @@ class IntelAdspBinaryRunner(ZephyrBinaryRunner):
     def do_add_parser(cls, parser):
         parser.add_argument('--remote-host',
                             help='hostname of the remote targeting ADSP board')
-        parser.add_argument('--rimage-tool', default=DEFAULT_RIMAGE_TOOL,
-                            help='path to the rimage tool')
-        parser.add_argument('--config-dir', default=DEFAULT_CONFIG_DIR,
-                            help='path to the toml config file')
-        parser.add_argument('--default-key',
-                            help='the default basename of the key store in board.cmake')
-        parser.add_argument('--key',
-                            help='specify where the signing key is')
         parser.add_argument('--pty', nargs='?', const="remote-host", type=str,
                             help=''''Capture the output of cavstool.py running on --remote-host \
                             and stream it remotely to west's standard output.''')
+
+        for old_sign_param in [ '--rimage-tool', '--config-dir', '--default-key', '--key']:
+            parser.add_argument(old_sign_param, action=SignParamError,
+                            help='do not use, "west sign" is now called from CMake, see "west sign -h"')
 
     @classmethod
     def tool_opt_help(cls) -> str:
@@ -84,34 +69,14 @@ class IntelAdspBinaryRunner(ZephyrBinaryRunner):
 
     @classmethod
     def do_create(cls, cfg, args):
-        # We now have `west flash` -> `west build` -> `west sign` so
-        # `west flash` -> `west sign` is not needed anymore; it's also
-        # slower because not concurrent. However, for backwards
-        # compatibility keep signing here if some explicit rimage
-        # --option was passed. Some of these options may differ from the
-        # current `west sign` configuration; we take "precedence" by
-        # running last.
-        do_sign = (
-            args.rimage_tool != DEFAULT_RIMAGE_TOOL or
-            args.config_dir != DEFAULT_CONFIG_DIR or
-            args.key is not None
-        )
         return IntelAdspBinaryRunner(cfg,
                                     remote_host=args.remote_host,
-                                    rimage_tool=args.rimage_tool,
-                                    config_dir=args.config_dir,
-                                    default_key=args.default_key,
-                                    key=args.key,
                                     pty=args.pty,
                                     tool_opt=args.tool_opt,
-                                    do_sign=do_sign,
                                     )
 
     def do_run(self, command, **kwargs):
         self.logger.info('Starting Intel ADSP runner')
-
-        if self.do_sign:
-            self.sign(**kwargs)
 
         if re.search("intel_adsp", self.platform):
             self.require(self.cavstool)
@@ -120,17 +85,8 @@ class IntelAdspBinaryRunner(ZephyrBinaryRunner):
             self.logger.error("No suitable platform for running")
             sys.exit(1)
 
-    def sign(self, **kwargs):
-        path_opt = ['-p', f'{self.rimage_tool}'] if self.rimage_tool else []
-        sign_cmd = (
-            ['west', 'sign', '-d', f'{self.cfg.build_dir}', '-t', 'rimage']
-            + path_opt + ['-D', f'{self.config_dir}', '--', '-k', f'{self.key}']
-        )
-        self.logger.info(" ".join(sign_cmd))
-        self.check_call(sign_cmd)
-
     def flash(self, **kwargs):
-        # Generate a hash string for appending to the sending ri file
+        'Generate a hash string for appending to the sending ri file'
         hash_object = hashlib.md5(self.bin_fw.encode())
         random_str = f"{random.getrandbits(64)}".encode()
         hash_object.update(random_str)

--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -34,9 +34,11 @@ In the simplest usage, run this from your build directory:
 
    west sign -t your_tool -- ARGS_FOR_YOUR_TOOL
 
-The "ARGS_FOR_YOUR_TOOL" value can be any additional
-arguments you want to pass to the tool, such as the location of a
-signing key etc.
+The "ARGS_FOR_YOUR_TOOL" value can be any additional arguments you want to
+pass to the tool, such as the location of a signing key etc. Depending on
+which sort of ARGS_FOR_YOUR_TOOLS you use, the `--` separator/sentinel may
+not always be required. To avoid ambiguity and having to find and
+understand POSIX 12.2 Guideline 10, always use `--`.
 
 See tool-specific help below for details.'''
 

--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -420,11 +420,26 @@ class ImgtoolSigner(Signer):
 
 class RimageSigner(Signer):
 
+    def rimage_config_dir(self):
+        'Returns the rimage/config/ directory with the highest precedence'
+        args = self.command.args
+        if args.tool_data:
+            conf_dir = pathlib.Path(args.tool_data)
+        elif self.cmake_cache.get('RIMAGE_CONFIG_PATH'):
+            conf_dir = pathlib.Path(self.cmake_cache['RIMAGE_CONFIG_PATH'])
+        else:
+            conf_dir = self.sof_src_dir / 'tools' / 'rimage' / 'config'
+        self.command.dbg(f'rimage config directory={conf_dir}')
+        return conf_dir
+
     def sign(self, command, build_dir, build_conf, formats):
+        self.command = command
         args = command.args
 
         b = pathlib.Path(build_dir)
+        self.build_dir = b
         cache = CMakeCache.from_build_dir(build_dir)
+        self.cmake_cache = cache
 
         # Warning: RIMAGE_TARGET in Zephyr is a duplicate of
         # CONFIG_RIMAGE_SIGNING_SCHEMA in SOF.
@@ -481,8 +496,6 @@ class RimageSigner(Signer):
 
         #### -c sof/rimage/config/signing_schema.toml  ####
 
-        cmake_toml = target + '.toml'
-
         if not args.quiet:
             log.inf('Signing with tool {}'.format(tool_path))
 
@@ -492,19 +505,8 @@ class RimageSigner(Signer):
         except ValueError: # sof is the manifest
             sof_src_dir = pathlib.Path(manifest.manifest_path()).parent
 
-        if '-c' in args.tool_args:
-            # Precedence to the arguments passed after '--': west sign ...  -- -c ...
-            if args.tool_data:
-                log.wrn('--tool-data ' + args.tool_data + ' ignored, overridden by: -- -c ... ')
-            conf_dir = None
-        elif args.tool_data:
-            conf_dir = pathlib.Path(args.tool_data)
-        elif cache.get('RIMAGE_CONFIG_PATH'):
-            conf_dir = pathlib.Path(cache['RIMAGE_CONFIG_PATH'])
-        else:
-            conf_dir = sof_src_dir / 'tools' / 'rimage' / 'config'
+        self.sof_src_dir = sof_src_dir
 
-        conf_path_cmd = ['-c', str(conf_dir / cmake_toml)] if conf_dir else []
 
         log.inf('Signing for SOC target ' + target)
 
@@ -545,8 +547,12 @@ class RimageSigner(Signer):
             cmake_default_key = cache.get('RIMAGE_SIGN_KEY', 'key placeholder from sign.py')
             extra_ri_args += [ '-k', str(sof_src_dir / 'keys' / cmake_default_key) ]
 
+        if args.tool_data and '-c' in args.tool_args:
+            log.wrn('--tool-data ' + args.tool_data + ' ignored! Overridden by: -- -c ... ')
+
         if '-c' not in sign_config_extra_args + args.tool_args:
-            extra_ri_args += conf_path_cmd
+            conf_dir = self.rimage_config_dir()
+            extra_ri_args += ['-c', str(conf_dir / (target + '.toml'))]
 
         # Warning: while not officially supported (yet?), the rimage --option that is last
         # on the command line currently wins in case of duplicate options. So pay

--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -535,7 +535,8 @@ class RimageSigner(Signer):
 
         sign_base = [tool_path]
 
-        # Sub-command arg '-q' takes precedence over west '-v'
+        # Align rimage verbosity.
+        # Sub-command arg 'west sign -q' takes precedence over west '-v'
         if not args.quiet and args.verbose:
             sign_base += ['-v'] * args.verbose
 
@@ -562,8 +563,7 @@ class RimageSigner(Signer):
         sign_base += (['-o', out_bin] + sign_config_extra_args +
                       extra_ri_args + args.tool_args + components)
 
-        if not args.quiet:
-            log.inf(quote_sh_list(sign_base))
+        command.inf(quote_sh_list(sign_base))
         subprocess.check_call(sign_base)
 
         if no_manifest:


### PR DESCRIPTION
5 commits, main ones:

- Remove `west sign` from intel_adsp `west flash`

- Add .toml pre-processing. Should supersede https://github.com/zephyrproject-rtos/zephyr/pull/65411. Depends on https://github.com/thesofproject/sof/pull/8602 to make an actual difference in SOF.