### PR TITLE
cmake: toolchain: enable newlib for cross-compile

### DIFF
--- a/cmake/toolchain/cross-compile/generic.cmake
+++ b/cmake/toolchain/cross-compile/generic.cmake
@@ -29,3 +29,5 @@ set(LINKER ld)
 set(BINTOOLS gnu)
 
 message(STATUS "Found toolchain: cross-compile (${CROSS_COMPILE})")
+
+set(TOOLCHAIN_HAS_NEWLIB ON CACHE BOOL "True if toolchain supports newlib")


### PR DESCRIPTION
In lib/libc/Kconfig, CONFIG_NEWLIB_LIBC depends on CONFIG_NEWLIB_LIBC_SUPPORTED which depends on "$(TOOLCHAIN_HAS_NEWLIB)" = "y", so in order to we can enable CONFIG_NEWLIB_LIBC in case of using cross-compile, set "TOOLCHAIN_HAS_NEWLIB" in cross-compile generic.cmake.