### PR TITLE
sample: ipc: Fix openamp rsc table sample & documentation

### DIFF
--- a/samples/subsys/ipc/openamp_rsc_table/README.rst
+++ b/samples/subsys/ipc/openamp_rsc_table/README.rst
@@ -18,69 +18,89 @@ a Linux kernel OS on the main processor and a Zephyr application on
 the co-processor.
 
 Building the application
-*************************
+************************
 
 Zephyr
--------
+======
 
 .. zephyr-app-commands::
    :zephyr-app: samples/subsys/ipc/openamp_rsc_table
    :goals: test
 
-Linux
-------
+Running the client sample
+*************************
 
-Enable SAMPLE_RPMSG_CLIENT configuration to build and install
-the rpmsg_client_sample.ko module on the target.
+Linux setup
+===========
 
-Running the sample
-*******************
+Enable ``SAMPLE_RPMSG_CLIENT`` configuration to build the :file:`rpmsg_client_sample.ko` module.
 
-Zephyr console
----------------
+Zephyr setup
+============
 
-Open a serial terminal (minicom, putty, etc.) and connect the board with the
-following settings:
-
-- Speed: 115200
-- Data: 8 bits
-- Parity: None
-- Stop bits: 1
-
-Reset the board.
+Open a serial terminal (minicom, putty, etc.) and connect to the board using default serial port settings.
 
 Linux console
----------------
+=============
 
-Open a Linux shell (minicom, ssh, etc.) and insert a module into the Linux Kernel
+Open a Linux shell (minicom, ssh, etc.) and insert the ``rpmsg_client_sample`` module into the Linux Kernel.
+Right after, logs should be displayed to notify channel creation/destruction and incoming message.
 
 .. code-block:: console
 
    root@linuxshell: insmod rpmsg_client_sample.ko
+   [   44.625407] rpmsg_client_sample virtio0.rpmsg-client-sample.-1.1024: new channel: 0x401 -> 0x400!
+   [   44.631401] rpmsg_client_sample virtio0.rpmsg-client-sample.-1.1024: incoming msg 1 (src: 0x400)
+   [   44.640614] rpmsg_client_sample virtio0.rpmsg-client-sample.-1.1024: incoming msg 2 (src: 0x400)
+   ...
+   [   45.152269] rpmsg_client_sample virtio0.rpmsg-client-sample.-1.1024: incoming msg 99 (src: 0x400)
+   [   45.157678] rpmsg_client_sample virtio0.rpmsg-client-sample.-1.1024: incoming msg 100 (src: 0x400)
+   [   45.158822] rpmsg_client_sample virtio0.rpmsg-client-sample.-1.1024: goodbye!
+   [   45.159741] virtio_rpmsg_bus virtio0: destroying channel rpmsg-client-sample addr 0x400
+   [   45.160856] rpmsg_client_sample virtio0.rpmsg-client-sample.-1.1024: rpmsg sample client driver is removed
 
-Result on Zephyr console on boot
---------------------------------
 
-The following message will appear on the corresponding Zephyr console:
+Zephyr console
+==============
+
+For each message received, its content is displayed as shown down below then sent back to Linux.
 
 .. code-block:: console
 
-   ***** Booting Zephyr OS v#.##.#-####-g########## *****
-   Starting application thread!
+   *** Booting Zephyr OS build zephyr-v#.#.#-####-g########## ***
+   Starting application threads!
 
-   OpenAMP demo started
-   Remote core received message 1: hello world!
-   Remote core received message 2: hello world!
-   Remote core received message 3: hello world!
+   OpenAMP[remote] Linux responder demo started
+
+   OpenAMP[remote] Linux sample client responder started
+
+   OpenAMP[remote] Linux TTY responder started
+   [Linux sample client] incoming msg 1: hello world!
+   [Linux sample client] incoming msg 2: hello world!
    ...
-   Remote core received message 100: hello world!
-   OpenAMP demo ended.
+   [Linux sample client] incoming msg 99: hello world!
+   [Linux sample client] incoming msg 100: hello world!
+   OpenAMP Linux sample client responder ended
 
 
-rpmsg TTY demo on Linux console
--------------------------------
+Running the rpmsg TTY demo
+**************************
 
-On the Linux console send a message to Zephyr which answers with the "TTY <add>" prefix.
+Linux setup
+===========
+
+Enable ``RPMSG_TTY`` in the kernel configuration.
+
+Zephyr setup
+============
+
+Open a serial terminal (minicom, putty, etc.) and connect to the board using default serial port settings.
+
+Linux console
+=============
+
+Open a Linux shell (minicom, ssh, etc.) and print the messages coming through the rpmsg-tty endpoint created during the sample initialization.
+On the Linux console, send a message to Zephyr which answers with the :samp:`TTY {<addr>}:` prefix.
 <addr> corresponds to the Zephyr rpmsg-tty endpoint address:
 
 .. code-block:: console
@@ -88,3 +108,20 @@ On the Linux console send a message to Zephyr which answers with the "TTY <add>"
    $> cat /dev/ttyRPMSG0 &
    $> echo "Hello Zephyr" >/dev/ttyRPMSG0
    TTY 0x0401: Hello Zephyr
+
+Zephyr console
+==============
+
+On the Zephyr console, the received message is displayed as shown below, then sent back to Linux.
+
+.. code-block:: console
+
+   *** Booting Zephyr OS build zephyr-v#.#.#-####-g########## ***
+   Starting application threads!
+
+   OpenAMP[remote] Linux responder demo started
+
+   OpenAMP[remote] Linux sample client responder started
+
+   OpenAMP[remote] Linux TTY responder started
+   [Linux TTY] incoming msg: Hello Zephyr

--- a/samples/subsys/ipc/openamp_rsc_table/src/main_remote.c
+++ b/samples/subsys/ipc/openamp_rsc_table/src/main_remote.c
@@ -291,6 +291,8 @@ void app_rpmsg_client_sample(void *arg1, void *arg2, void *arg3)
 	while (msg_cnt < 100) {
 		k_sem_take(&data_sc_sem,  K_FOREVER);
 		msg_cnt++;
+		printk("[Linux sample client] incoming msg %d: %.*s\n", msg_cnt, sc_msg.len,
+		       (char *)sc_msg.data);
 		rpmsg_send(&sc_ept, sc_msg.data, sc_msg.len);
 	}
 	rpmsg_destroy_ept(&sc_ept);
@@ -309,7 +311,7 @@ void app_rpmsg_tty(void *arg1, void *arg2, void *arg3)
 
 	k_sem_take(&data_tty_sem,  K_FOREVER);
 
-	printk("\r\nOpenAMP[remote] Linux tty responder started\r\n");
+	printk("\r\nOpenAMP[remote] Linux TTY responder started\r\n");
 
 	tty_ept.priv = &tty_msg;
 	ret = rpmsg_create_ept(&tty_ept, rpdev, "rpmsg-tty",
@@ -319,6 +321,7 @@ void app_rpmsg_tty(void *arg1, void *arg2, void *arg3)
 	while (tty_ept.addr !=  RPMSG_ADDR_ANY) {
 		k_sem_take(&data_tty_sem,  K_FOREVER);
 		if (tty_msg.len) {
+			printk("[Linux TTY] incoming msg: %.*s", tty_msg.len, (char *)tty_msg.data);
 			snprintf(tx_buff, 13, "TTY 0x%04x: ", tty_ept.addr);
 			memcpy(&tx_buff[12], tty_msg.data, tty_msg.len);
 			rpmsg_send(&tty_ept, tx_buff, tty_msg.len + 12);
@@ -342,7 +345,7 @@ void rpmsg_mng_task(void *arg1, void *arg2, void *arg3)
 	unsigned int len;
 	int ret = 0;
 
-	printk("\r\nOpenAMP[remote]  linux responder demo started\r\n");
+	printk("\r\nOpenAMP[remote] Linux responder demo started\r\n");
 
 	/* Initialize platform */
 	ret = platform_init();

--- a/samples/subsys/ipc/openamp_rsc_table/src/main_remote.c
+++ b/samples/subsys/ipc/openamp_rsc_table/src/main_remote.c
@@ -321,7 +321,7 @@ void app_rpmsg_tty(void *arg1, void *arg2, void *arg3)
 		if (tty_msg.len) {
 			snprintf(tx_buff, 13, "TTY 0x%04x: ", tty_ept.addr);
 			memcpy(&tx_buff[12], tty_msg.data, tty_msg.len);
-			rpmsg_send(&tty_ept, tx_buff, tty_msg.len + 13);
+			rpmsg_send(&tty_ept, tx_buff, tty_msg.len + 12);
 			rpmsg_release_rx_buffer(&tty_ept, tty_msg.data);
 		}
 		tty_msg.len = 0;


### PR DESCRIPTION
Hello everyone,

While testing the openamp rsc table sample I noticed a little glitch in the Linux logs for the TTY responder as shown down below.

```
TTY 0x0401: Hello Zephyr�
```

The zephyr sample was sending a buffer with one extra character compared to what is supposed to be sent.

```
TTY 0x0401: Hello Zephyr
```

Then I compare the logs from both Linux & Zephyr while executing the sample to what the documentation shows and I notice that the documentation was not accurate. Thus I decided to add logs to stick with it and update the documentation to reflect reality.

It was tested on a Renesas spider board while developing it's (downstream) openamp driver !