### PR TITLE
drivers: interrupt_controller: changes in shared irq

### DIFF
--- a/doc/releases/migration-guide-3.6.rst
+++ b/doc/releases/migration-guide-3.6.rst
@@ -112,6 +112,7 @@ Device Drivers and Device Tree
             drdy-pin = <2>;
         };
     };
+
 * The optional :c:func:`setup()` function in the Bluetooth HCI driver API (enabled through
   :kconfig:option:`CONFIG_BT_HCI_SETUP`) has gained a function parameter of type
   :c:struct:`bt_hci_setup_params`. By default, the struct is empty, but drivers can opt-in to
@@ -292,6 +293,13 @@ Device Drivers and Device Tree
   * ``CONFIG_GPIO_RA`` -> :kconfig:option:`CONFIG_GPIO_RENESAS_RA`
   * ``CONFIG_PINCTRL_RA`` -> :kconfig:option:`CONFIG_PINCTRL_RENESAS_RA`
   * ``CONFIG_UART_RA`` -> :kconfig:option:`CONFIG_UART_RENESAS_RA`
+
+* The function signature of the ``isr_t`` callback function passed to the ``shared_irq``
+  interrupt controller driver API via :c:func:`shared_irq_isr_register()` has changed.
+  The callback now takes an additional `irq_number` parameter. Out-of-tree users of
+  this API will need to be updated.
+
+  (:github:`66427`)
 
 Power Management
 ================

--- a/drivers/interrupt_controller/intc_shared_irq.c
+++ b/drivers/interrupt_controller/intc_shared_irq.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Intel Corporation.
+ * Copyright (c) 2015 - 2023 Intel Corporation.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -125,7 +125,7 @@ void shared_irq_isr(const struct device *dev)
 
 	for (i = 0U; i < config->client_count; i++) {
 		if (clients->client[i].isr_dev) {
-			clients->client[i].isr_func(clients->client[i].isr_dev);
+			clients->client[i].isr_func(clients->client[i].isr_dev, config->irq_num);
 		}
 	}
 }

--- a/include/zephyr/shared_irq.h
+++ b/include/zephyr/shared_irq.h
@@ -1,7 +1,7 @@
 /* shared_irq - Shared interrupt driver */
 
 /*
- * Copyright (c) 2015 Intel corporation
+ * Copyright (c) 2015 - 2023 Intel corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -14,7 +14,7 @@
 extern "C" {
 #endif
 
-typedef int (*isr_t)(const struct device *dev);
+typedef int (*isr_t)(const struct device *dev, unsigned int irq_number);
 
 /* driver API definition */
 typedef int (*shared_irq_register_t)(const struct device *dev,


### PR DESCRIPTION
Updated the shared IRQ handler function in the shared interrupt controller drivers to include support for the 'irq_number' parameter. When a single driver manages multiple shared IRQs, it becomes challenging to determine which IRQ line is invoking the handler. Therefore, I've introduced an option to share the IRQ number to address this issue.

Signed-off-by: Navinkumar Balabakthan [navinkumar.balabakthan@intel.com](mailto:navinkumar.balabakthan@intel.com)