### PR TITLE
arch: xtensa: check for xt-clang instead of xcc-clang

### DIFF
--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -173,7 +173,7 @@ endif # XTENSA_MMU
 
 config XTENSA_SYSCALL_USE_HELPER
 	bool "Use userspace syscall helper"
-	default y if "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "xcc-clang"
+	default y if "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "xt-clang"
 	depends on USERSPACE
 	help
 	  Use syscall helpers for passing more then 3 arguments.


### PR DESCRIPTION
Check against new variant name. xcc-clang usage is deprecated.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
