### PR TITLE
dts: riscv: Fix a typo in riscv,isa for mpfs

### DIFF
--- a/dts/riscv/microchip/mpfs.dtsi
+++ b/dts/riscv/microchip/mpfs.dtsi
@@ -19,7 +19,7 @@
 			compatible = "riscv";
 			device_type = "cpu";
 			reg = < 0x0 >;
-			riscv,isa = "rv64imac_zicsr_zfencei";
+			riscv,isa = "rv64imac_zicsr_zifencei";
 			hlic0: interrupt-controller {
 				compatible = "riscv,cpu-intc";
 				#address-cells = <0>;


### PR DESCRIPTION
The RISC-V ISA extension is called `Zifencei` instead of `Zfencei`.