### PR TITLE
kernel: cmake: fix k_sleep compilation error for single thread

### DIFF
--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -59,6 +59,7 @@ list(APPEND kernel_files
   mem_slab.c
   thread.c
   version.c
+  sched.c
   )
 
 if(CONFIG_MULTITHREADING)
@@ -72,7 +73,6 @@ list(APPEND kernel_files
   stack.c
   system_work_q.c
   work.c
-  sched.c
   condvar.c
   )
 


### PR DESCRIPTION
Fix k_sleep compilation error: [build] ... syscalls/kernel.h:135: undefined reference to `z_impl_k_sleep', for single thread applications (CONFIG_MULTITHREADING = n). 
The shed.c contains source code which must be present also in single thread applications.