### PR TITLE
Bluetooth: ATT: remove queuing support for TX

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -445,7 +445,7 @@ static void state_transition_work_handler(struct k_work *work)
 	/* Notify ASE state */
 	if (ase->conn != NULL) {
 		err = ase_state_notify(ase);
-		if (err == -ENOMEM) {
+		if (err == -EDEADLK) {
 			struct bt_conn_info info;
 			uint32_t retry_delay_ms;
 

--- a/subsys/bluetooth/audio/has.c
+++ b/subsys/bluetooth/audio/has.c
@@ -476,7 +476,7 @@ static void notify_work_handler(struct k_work *work)
 
 		err = bt_gatt_notify(client->conn, active_preset_index_attr,
 				     &active_index, sizeof(active_index));
-		if (err == -ENOMEM) {
+		if (err == -EDEADLK) {
 			atomic_set_bit(client->context->flags, FLAG_ACTIVE_INDEX_CHANGED);
 			notify_work_reschedule(client, K_USEC(BT_AUDIO_NOTIFY_RETRY_DELAY_US));
 		} else if (err < 0) {

--- a/subsys/bluetooth/audio/mcs.c
+++ b/subsys/bluetooth/audio/mcs.c
@@ -931,6 +931,7 @@ static void notify(const struct bt_uuid *uuid, const void *data, uint16_t len)
 {
 	int err = bt_gatt_notify_uuid(NULL, uuid, mcs.attrs, data, len);
 
+	/* FIXME: EDEADLK here, what can we do about it? */
 	if (err) {
 		if (err == -ENOTCONN) {
 			LOG_DBG("Notification error: ENOTCONN (%d)", err);

--- a/subsys/bluetooth/audio/pacs.c
+++ b/subsys/bluetooth/audio/pacs.c
@@ -663,6 +663,7 @@ static int pac_notify_loc(struct bt_conn *conn, enum bt_audio_dir dir)
 
 	err = pacs_gatt_notify(conn, uuid, pacs_svc.attrs, &location_le, sizeof(location_le));
 	if (err != 0 && err != -ENOTCONN) {
+		/* FIXME: EDEADLK here, what can we do about it? */
 		LOG_WRN("PACS notify_loc failed: %d", err);
 		return err;
 	}
@@ -748,6 +749,7 @@ static int supported_contexts_notify(struct bt_conn *conn)
 	err = pacs_gatt_notify(conn, BT_UUID_PACS_SUPPORTED_CONTEXT, pacs_svc.attrs,
 				  &context, sizeof(context));
 	if (err != 0 && err != -ENOTCONN) {
+		/* FIXME: EDEADLK here, what can we do about it? */
 		LOG_WRN("Supported Audio Contexts notify failed: %d", err);
 
 		return err;

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -38,6 +38,7 @@ config BT_HCI_HOST
 	default y
 	depends on !BT_HCI_RAW
 	select POLL
+	select EVENTS
 
 
 config BT_HCI_TX_STACK_SIZE

--- a/subsys/bluetooth/host/Kconfig.gatt
+++ b/subsys/bluetooth/host/Kconfig.gatt
@@ -30,6 +30,20 @@ config BT_ATT_RETRY_ON_SEC_ERR
 	  If an ATT request fails due to insufficient security, the host will
 	  try to elevate the security level and retry the ATT request.
 
+config BT_GATT_TX_QUEUE
+	bool "Allow queuing of GATT operations"
+	default y if BT_GATT_CLIENT
+	select BT_LONG_WQ
+	help
+	  The ATT API is non-blocking. The GATT API is blocking.
+
+	  But in order to avoid deadlocks, the GATT API will not block when
+	  invoked from the system workqueue or the Bluetooth RX thread.
+
+	  This option makes GATT queue the operation and retry when resources
+	  are available. As this is done from the so-called "long workqueue",
+	  then it is safe to block.
+
 config BT_EATT
 	bool "Enhanced ATT Bearers support [EXPERIMENTAL]"
 	depends on BT_L2CAP_ECRED

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -106,7 +106,6 @@ struct bt_att_chan {
 	struct bt_l2cap_le_chan	chan;
 	ATOMIC_DEFINE(flags, ATT_NUM_FLAGS);
 	struct bt_att_req	*req;
-	struct k_fifo		tx_queue;
 	struct k_work_delayable	timeout_work;
 	sys_snode_t		node;
 };
@@ -131,17 +130,23 @@ static uint16_t bt_att_mtu(struct bt_att_chan *chan)
 	return MIN(chan->chan.rx.mtu, chan->chan.tx.mtu);
 }
 
+enum {
+	EVT_ATT_SENT = 0,
+};
+
 /* ATT connection specific data */
 struct bt_att {
 	struct bt_conn		*conn;
 	/* Shared request queue */
 	sys_slist_t		reqs;
-	struct k_fifo		tx_queue;
 #if CONFIG_BT_ATT_PREPARE_COUNT > 0
 	sys_slist_t		prep_queue;
 #endif
 	/* Contains bt_att_chan instance(s) */
 	sys_slist_t		chans;
+	/* MTU of largest chan */
+	uint16_t                mtu;
+	struct k_event		events;
 #if defined(CONFIG_BT_EATT)
 	struct {
 		struct k_work_delayable connection_work;
@@ -277,7 +282,7 @@ static int chan_send(struct bt_att_chan *chan, struct net_buf *buf)
 
 	if (!atomic_test_bit(chan->flags, ATT_CONNECTED)) {
 		LOG_ERR("ATT channel not connected");
-		return -EINVAL;
+		return -ENOTCONN;
 	}
 
 	if (IS_ENABLED(CONFIG_BT_EATT) && hdr->code == BT_ATT_OP_MTU_REQ &&
@@ -296,7 +301,11 @@ static int chan_send(struct bt_att_chan *chan, struct net_buf *buf)
 		/* Check if sent is pending already, if it does it cannot be
 		 * modified so the operation will need to be queued.
 		 */
+		/* FIXME: so notifications can't be sent on EATT chan w/ a
+		 * pending req? that's not legal.
+		 */
 		if (atomic_test_bit(chan->flags, ATT_PENDING_SENT)) {
+			LOG_DBG("already pending chan %p", chan);
 			return -EAGAIN;
 		}
 
@@ -319,7 +328,10 @@ static int chan_send(struct bt_att_chan *chan, struct net_buf *buf)
 		 */
 		err = bt_l2cap_chan_send(&chan->chan.chan, buf);
 		if (err < 0) {
-			data->att_chan = prev_chan;
+			if (err == -ENOBUFS) {
+				LOG_ERR("Ran out of TX buffers or contexts.");
+			}
+			data->att_chan = prev_chan; /* FIXME: What's this about? */
 			atomic_clear_bit(chan->flags, ATT_PENDING_SENT);
 			data->err = err;
 
@@ -348,19 +360,25 @@ static int chan_send(struct bt_att_chan *chan, struct net_buf *buf)
 	net_buf_simple_save(&buf->b, &state);
 
 	data->att_chan = chan;
+	atomic_set_bit(chan->flags, ATT_PENDING_SENT);
 
 	err = bt_l2cap_send(chan->att->conn, BT_L2CAP_CID_ATT, buf);
-	if (err) {
+	if (err < 0) {
 		if (err == -ENOBUFS) {
 			LOG_ERR("Ran out of TX buffers or contexts.");
 		}
+
 		/* In case of an error has occurred restore the buffer state */
 		net_buf_simple_restore(&buf->b, &state);
-		data->att_chan = prev_chan;
+		data->att_chan = prev_chan; /* FIXME: what's this */
 		data->err = err;
+		atomic_clear_bit(chan->flags, ATT_PENDING_SENT);
+
+		return err;
 	}
 
-	return err;
+	/* We don't expose the L2CAP number-of-sent-bytes return to the ATT caller. */
+	return 0;
 }
 
 static bool att_chan_matches_chan_opt(struct bt_att_chan *chan, enum bt_att_chan_opt chan_opt)
@@ -375,40 +393,6 @@ static bool att_chan_matches_chan_opt(struct bt_att_chan *chan, enum bt_att_chan
 		return (chan_opt & BT_ATT_CHAN_OPT_ENHANCED_ONLY);
 	} else {
 		return (chan_opt & BT_ATT_CHAN_OPT_UNENHANCED_ONLY);
-	}
-}
-
-static struct net_buf *get_first_buf_matching_chan(struct k_fifo *fifo, struct bt_att_chan *chan)
-{
-	if (IS_ENABLED(CONFIG_BT_EATT)) {
-		struct k_fifo skipped;
-		struct net_buf *buf;
-		struct net_buf *ret = NULL;
-		struct bt_att_tx_meta_data *meta;
-
-		k_fifo_init(&skipped);
-
-		while ((buf = net_buf_get(fifo, K_NO_WAIT))) {
-			meta = bt_att_get_tx_meta_data(buf);
-			if (!ret &&
-			    att_chan_matches_chan_opt(chan, meta->chan_opt)) {
-				ret = buf;
-			} else {
-				net_buf_put(&skipped, buf);
-			}
-		}
-
-		__ASSERT_NO_MSG(k_fifo_is_empty(fifo));
-
-		while ((buf = net_buf_get(&skipped, K_NO_WAIT))) {
-			net_buf_put(fifo, buf);
-		}
-
-		__ASSERT_NO_MSG(k_fifo_is_empty(&skipped));
-
-		return ret;
-	} else {
-		return net_buf_get(fifo, K_NO_WAIT);
 	}
 }
 
@@ -443,26 +427,6 @@ static struct bt_att_req *get_first_req_matching_chan(sys_slist_t *reqs, struct 
 	} else {
 		return NULL;
 	}
-}
-
-static int process_queue(struct bt_att_chan *chan, struct k_fifo *queue)
-{
-	struct net_buf *buf;
-	int err;
-
-	buf = get_first_buf_matching_chan(queue, chan);
-	if (buf) {
-		err = bt_att_chan_send(chan, buf);
-		if (err) {
-			/* Push it back if it could not be send */
-			k_queue_prepend(&queue->_queue, buf);
-			return err;
-		}
-
-		return 0;
-	}
-
-	return -ENOENT;
 }
 
 /* Send requests without taking tx_sem */
@@ -504,7 +468,6 @@ static void bt_att_sent(struct bt_l2cap_chan *ch)
 {
 	struct bt_att_chan *chan = ATT_CHAN(ch);
 	struct bt_att *att = chan->att;
-	int err;
 
 	LOG_DBG("chan %p", chan);
 
@@ -514,6 +477,10 @@ static void bt_att_sent(struct bt_l2cap_chan *ch)
 		LOG_DBG("Ignore sent on detached ATT chan");
 		return;
 	}
+
+	/* Signal other threads that are waiting on resources */
+	k_event_post(&att->events, BIT(EVT_ATT_SENT));
+	k_event_clear(&att->events, BIT(EVT_ATT_SENT));
 
 	/* Process pending requests first since they require a response they
 	 * can only be processed one at time while if other queues were
@@ -531,14 +498,7 @@ static void bt_att_sent(struct bt_l2cap_chan *ch)
 		sys_slist_prepend(&att->reqs, node);
 	}
 
-	/* Process channel queue */
-	err = process_queue(chan, &chan->tx_queue);
-	if (!err) {
-		return;
-	}
-
-	/* Process global queue */
-	(void)process_queue(chan, &att->tx_queue);
+	/* TODO: notify/unblock GATT/application */
 }
 
 static void chan_rebegin_att_timeout(struct bt_att_tx_meta_data *user_data)
@@ -561,25 +521,22 @@ static void chan_rebegin_att_timeout(struct bt_att_tx_meta_data *user_data)
 	}
 }
 
-static void chan_req_notif_sent(struct bt_att_tx_meta_data *user_data)
+static void chan_req_notif_sent(struct bt_att_tx_meta_data *data)
 {
-	struct bt_att_tx_meta_data *data = user_data;
 	struct bt_att_chan *chan = data->att_chan;
-	struct bt_conn *conn = chan->att->conn;
 	bt_gatt_complete_func_t func = data->func;
-	uint16_t attr_count = data->attr_count;
-	void *ud = data->user_data;
 
 	LOG_DBG("chan %p CID 0x%04X", chan, chan->chan.tx.cid);
 
-	if (!atomic_test_bit(chan->flags, ATT_CONNECTED)) {
+	if (!atomic_test_bit(chan->flags, ATT_CONNECTED) ||
+	    chan->att == NULL) {
 		LOG_ERR("ATT channel not connected");
 		return;
 	}
 
 	if (func) {
-		for (uint16_t i = 0; i < attr_count; i++) {
-			func(conn, ud);
+		for (uint16_t i = 0; i < data->attr_count; i++) {
+			func(chan->att->conn, data->user_data);
 		}
 	}
 }
@@ -594,6 +551,17 @@ static void att_on_sent_cb(struct bt_att_tx_meta_data *meta)
 		LOG_ERR("Got err %d, not calling ATT cb", meta->err);
 		return;
 	}
+
+	/* Clear that bit first, as the EATT/L2CAP CoC callback will come
+	 * later, when we receive the num complete packets event from the
+	 * controller.
+	 *
+	 * The issue arises if we receive an ATT response from the
+	 * peer before the NCP event.
+	 *
+	 * TODO: rework l2cap so we have a single codepath for UATT & EATT.
+	 */
+	atomic_clear_bit(meta->att_chan->flags, ATT_PENDING_SENT);
 
 	if (!bt_att_is_enhanced(meta->att_chan)) {
 		/* For EATT, L2CAP will call it after the SDU is fully sent. */
@@ -672,47 +640,35 @@ static int bt_att_chan_send(struct bt_att_chan *chan, struct net_buf *buf)
 	LOG_DBG("chan %p flags %lu code 0x%02x", chan, atomic_get(chan->flags),
 		((struct bt_att_hdr *)buf->data)->code);
 
-	if (IS_ENABLED(CONFIG_BT_EATT) &&
-	    !att_chan_matches_chan_opt(chan, bt_att_get_tx_meta_data(buf)->chan_opt)) {
-		return -EINVAL;
+	if (IS_ENABLED(CONFIG_BT_EATT)) {
+		enum bt_att_chan_opt opt = bt_att_get_tx_meta_data(buf)->chan_opt;
+
+		if (!att_chan_matches_chan_opt(chan, opt)) {
+			LOG_DBG("chan %p doesn't match opts 0x%x", chan, opt);
+
+			return -EINVAL;
+		}
 	}
 
 	return chan_send(chan, buf);
-}
-
-static void att_send_process(struct bt_att *att)
-{
-	struct bt_att_chan *chan, *tmp, *prev = NULL;
-	int err = 0;
-
-	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&att->chans, chan, tmp, node) {
-		if (err == -ENOENT && prev &&
-		    (bt_att_is_enhanced(chan) == bt_att_is_enhanced(prev))) {
-			/* If there was nothing to send for the previous channel and the current
-			 * channel has the same "enhancedness", there will be nothing to send for
-			 * this channel either.
-			 */
-			continue;
-		}
-
-		err = process_queue(chan, &att->tx_queue);
-		if (!err) {
-			/* Success */
-			return;
-		}
-
-		prev = chan;
-	}
 }
 
 static void bt_att_chan_send_rsp(struct bt_att_chan *chan, struct net_buf *buf)
 {
 	int err;
 
+	/* FIXME: this cannot fail if the response is an error response. But it
+	 * does: we almost always get called from the RX thread, and since we
+	 * removed the ATT TXq, chances are we are going to get a EAGAIN or
+	 * EDEADLK.
+	 *
+	 * In that case, maybe a static per-chan error buffer would help.
+	 * We can also "just accept" that this channel will get an ATT timeout.
+	 */
 	err = chan_send(chan, buf);
 	if (err) {
-		/* Responses need to be sent back using the same channel */
-		net_buf_put(&chan->tx_queue, buf);
+		LOG_ERR("Failed to send response on chan %p. err %d", chan, err);
+		net_buf_unref(buf);
 	}
 }
 
@@ -729,6 +685,7 @@ static void send_err_rsp(struct bt_att_chan *chan, uint8_t req, uint16_t handle,
 
 	buf = bt_att_chan_create_pdu(chan, BT_ATT_OP_ERROR_RSP, sizeof(*rsp));
 	if (!buf) {
+		LOG_ERR("Failed to allocate error buffer");
 		return;
 	}
 
@@ -2906,9 +2863,9 @@ struct net_buf *bt_att_create_rsp_pdu(struct bt_att_chan *chan, uint8_t op, size
 
 static void att_reset(struct bt_att *att)
 {
+#if CONFIG_BT_ATT_PREPARE_COUNT > 0
 	struct net_buf *buf;
 
-#if CONFIG_BT_ATT_PREPARE_COUNT > 0
 	/* Discard queued buffers */
 	while ((buf = net_buf_slist_get(&att->prep_queue))) {
 		net_buf_unref(buf);
@@ -2920,10 +2877,6 @@ static void att_reset(struct bt_att *att)
 
 	(void)k_work_cancel_delayable_sync(&att->eatt.connection_work, &sync);
 #endif /* CONFIG_BT_EATT */
-
-	while ((buf = net_buf_get(&att->tx_queue, K_NO_WAIT))) {
-		net_buf_unref(buf);
-	}
 
 	/* Notify pending requests */
 	while (!sys_slist_is_empty(&att->reqs)) {
@@ -2949,16 +2902,9 @@ static void att_reset(struct bt_att *att)
 
 static void att_chan_detach(struct bt_att_chan *chan)
 {
-	struct net_buf *buf;
-
 	LOG_DBG("chan %p", chan);
 
 	sys_slist_find_and_remove(&chan->att->chans, &chan->node);
-
-	/* Release pending buffers */
-	while ((buf = net_buf_get(&chan->tx_queue, K_NO_WAIT))) {
-		net_buf_unref(buf);
-	}
 
 	if (chan->req) {
 		/* Notify outstanding request */
@@ -3005,8 +2951,6 @@ static void att_chan_attach(struct bt_att *att, struct bt_att_chan *chan)
 	LOG_DBG("att %p chan %p flags %lu", att, chan, atomic_get(chan->flags));
 
 	if (sys_slist_is_empty(&att->chans)) {
-		/* Init general queues when attaching the first channel */
-		k_fifo_init(&att->tx_queue);
 #if CONFIG_BT_ATT_PREPARE_COUNT > 0
 		sys_slist_init(&att->prep_queue);
 #endif
@@ -3080,6 +3024,7 @@ static uint8_t att_req_retry(struct bt_att_chan *att_chan)
 	}
 
 	if (chan_send(att_chan, buf)) {
+		LOG_ERR("failed to retry sending buf %p", buf);
 		net_buf_unref(buf);
 		return BT_ATT_ERR_UNLIKELY;
 	}
@@ -3228,7 +3173,6 @@ static struct bt_att_chan *att_chan_new(struct bt_att *att, atomic_val_t flags)
 
 	(void)memset(chan, 0, sizeof(*chan));
 	chan->chan.chan.ops = &ops;
-	k_fifo_init(&chan->tx_queue);
 	atomic_set(chan->flags, flags);
 	chan->att = att;
 	att_chan_attach(att, chan);
@@ -3312,6 +3256,7 @@ static int bt_att_accept(struct bt_conn *conn, struct bt_l2cap_chan **ch)
 	att->conn = conn;
 	sys_slist_init(&att->reqs);
 	sys_slist_init(&att->chans);
+	k_event_init(&att->events);
 
 #if defined(CONFIG_BT_EATT)
 	k_work_init_delayable(&att->eatt.connection_work,
@@ -3695,6 +3640,9 @@ static void att_chan_mtu_updated(struct bt_att_chan *updated_chan)
 	struct bt_att_chan *chan, *tmp;
 	uint16_t max_tx = 0, max_rx = 0;
 
+	/* Store ATT instance's global TX MTU */
+	att->mtu = MAX(att->mtu, updated_chan->chan.tx.mtu);
+
 	/* Get maximum MTU's of other channels */
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&att->chans, chan, tmp, node) {
 		if (chan == updated_chan) {
@@ -3749,23 +3697,176 @@ void bt_att_req_free(struct bt_att_req *req)
 	k_mem_slab_free(&req_slab, (void *)req);
 }
 
-int bt_att_send(struct bt_conn *conn, struct net_buf *buf)
+static struct bt_att_chan *get_first_available_chan(struct bt_att *att, struct net_buf *buf)
+{
+	struct bt_att_chan *chan;
+	struct bt_att_chan *tmp;
+	enum bt_att_chan_opt opt = bt_att_get_tx_meta_data(buf)->chan_opt;
+
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&att->chans, chan, tmp, node) {
+		/* If there is an ongoing transaction, do not use the channel */
+		if (chan->req) {
+			LOG_DBG("Request already pending on chan %p", chan);
+			continue;
+		}
+
+		if (bt_att_mtu(chan) < buf->len) {
+			LOG_DBG("MTU too small: chan %p mtu %d requested %d",
+				chan, bt_att_mtu(chan), buf->len);
+			continue;
+		}
+		/* TODO: allow notifications */
+		/* if (is_att_req(buf) && atomic_test_bit(chan->flags, ATT_PENDING_SENT)) { */
+		if (atomic_test_bit(chan->flags, ATT_PENDING_SENT)) {
+			LOG_DBG("Channel busy: chan %p", chan);
+			continue;
+		}
+
+		if (!att_chan_matches_chan_opt(chan, opt)) {
+			bool eatt = bt_att_is_enhanced(chan);
+			LOG_DBG("chan %p [%s] doesn't match buf preference: 0x%x",
+				chan, eatt ? "Eatt" : "Uatt", opt);
+			continue;
+		}
+
+		LOG_DBG("Got channel: chan %p", chan);
+
+		return chan;
+	}
+
+	return NULL;
+}
+
+int bt_att_send_nonblocking(struct bt_conn *conn, struct net_buf *buf)
 {
 	struct bt_att *att;
+	struct bt_att_chan *avail_att_chan;
 
 	__ASSERT_NO_MSG(conn);
 	__ASSERT_NO_MSG(buf);
 
 	att = att_get(conn);
 	if (!att) {
-		net_buf_unref(buf);
 		return -ENOTCONN;
 	}
 
-	net_buf_put(&att->tx_queue, buf);
-	att_send_process(att);
+	if (att->mtu < buf->len) {
+		LOG_ERR("MTU too small: %d < %d", att->mtu, buf->len);
+		return -EMSGSIZE;
+	}
 
-	return 0;
+	avail_att_chan = get_first_available_chan(att, buf);
+	if (!avail_att_chan) {
+		LOG_DBG("no available bearer for len %d on conn %p", buf->len, conn);
+		return -EAGAIN;
+	}
+
+	return bt_att_chan_send(avail_att_chan, buf);
+}
+
+/* TODO: kconfig this */
+#define SEND_RETRIES 100
+#define RETRY_TIMEOUT K_SECONDS(1)
+
+static bool should_retry(int err)
+{
+	/* Is this error going away if we wait a bit? */
+	return (err == -ENOMEM) || (err == -EAGAIN) || (err == -ENOBUFS);
+}
+
+static int wait_for_att_sent(struct bt_conn *conn)
+{
+	struct bt_att *att = att_get(conn);
+
+	if (!att) {
+		return -ENOTCONN;
+	}
+
+	LOG_DBG("waiting for att_sent");
+
+	uint32_t events = k_event_wait(&att->events, BIT(EVT_ATT_SENT), false, RETRY_TIMEOUT);
+
+	if (events) {
+		LOG_DBG("got att_sent event");
+
+		return 0;
+	}
+
+	LOG_DBG("timed out waiting");
+
+	return -ETIMEDOUT;
+}
+
+int bt_att_send(struct bt_conn *conn, struct net_buf *buf)
+{
+	int err;
+	int t;
+
+	__ASSERT_NO_MSG(buf->data);
+
+	/* Attempt to send right away */
+	err = bt_att_send_nonblocking(conn, buf);
+
+	/* Attempt was succesful. Buffer ownership has been transferred to lower
+	 * layers.
+	 */
+	if (!err) {
+		return 0;
+	}
+
+	/* If we can't block, skip the rest of the fn */
+	if (!bt_can_block()) {
+		/* TODO: we could probably still allow queuing but make GATT pay
+		 * for it: w/ a kconfig, GATT spins up a workqueue just for
+		 * TXing.
+		 *
+		 * It seems this will be necessary (at least temporarily) as a
+		 * bunch of apps/tests depend on being able to queue
+		 * notifications from the syswq.
+		 *
+		 * As an optimization, we could use the long_wq we already have
+		 * plus a k_sched_lock() around the ATT API.
+		 */
+		LOG_ERR("Failed to send: %d . This context cannot block", err);
+		err = -EDEADLK;
+		goto cleanup;
+	}
+
+	/* Blocking retries */
+	int64_t start_time = k_uptime_get();
+
+	for (t = 0; t < SEND_RETRIES; t++) {
+		err = bt_att_send_nonblocking(conn, buf);
+		LOG_DBG("att-send-complete: buf %p err %d", buf, err);
+
+		if (!err) {
+			return 0; /* buffer was sent */
+		}
+
+		if (should_retry(err)) {
+			__ASSERT_NO_MSG(buf->data);
+			wait_for_att_sent(conn);
+		} else {
+			goto cleanup; /* more explicit than `break` */
+		}
+	}
+
+	if (t >= SEND_RETRIES) {
+		LOG_ERR("Failed to send after %d tries (waited %dms)",
+			SEND_RETRIES, k_uptime_get() - start_time);
+		err = -ETIMEDOUT;
+	}
+
+cleanup:
+	/* We have to unref `buf` in case of error: lower layers only take
+	 * ownership if they return successfully.
+	 */
+	net_buf_unref(buf);
+
+	/* Give a chance to other threads to run */
+	k_yield();
+
+	return err;
 }
 
 int bt_att_req_send(struct bt_conn *conn, struct bt_att_req *req)

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3742,6 +3742,17 @@ int bt_send(struct net_buf *buf)
 	return bt_dev.drv->send(buf);
 }
 
+bool bt_can_block(void)
+{
+	k_tid_t tid = k_current_get();
+
+#if defined(CONFIG_BT_RECV_WORKQ_BT)
+	return (tid != &bt_workq.thread) && (tid != &k_sys_work_q.thread);
+#else
+	return (tid != &k_sys_work_q.thread);
+#endif
+}
+
 static const struct event_handler prio_events[] = {
 	EVENT_HANDLER(BT_HCI_EVT_CMD_COMPLETE, hci_cmd_complete,
 		      sizeof(struct bt_hci_evt_cmd_complete)),

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -520,3 +520,5 @@ void bt_hci_le_df_cte_req_failed(struct net_buf *buf);
 
 void bt_hci_le_per_adv_subevent_data_request(struct net_buf *buf);
 void bt_hci_le_per_adv_response_report(struct net_buf *buf);
+
+bool bt_can_block(void);

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -2016,6 +2016,7 @@ static int l2cap_chan_le_send(struct bt_l2cap_le_chan *ch,
 
 	/* Set a callback if there is no data left in the buffer */
 	if (buf == seg || !buf->len) {
+		/* TODO: call `cb` on `buf` destroy instead of num complete packets */
 		err = bt_l2cap_send_cb(ch->chan.conn, ch->tx.cid, seg,
 				       l2cap_chan_sdu_sent,
 				       l2cap_tx_meta_data(buf));

--- a/tests/bsim/bluetooth/host/att/eatt_notif/src/client_test.c
+++ b/tests/bsim/bluetooth/host/att/eatt_notif/src/client_test.c
@@ -119,16 +119,14 @@ void send_notification(void)
 	const uint8_t sample_dat = SAMPLE_DATA;
 	int err;
 
-	do {
-		err = bt_gatt_notify(g_conn, local_attr, &sample_dat, sizeof(sample_dat));
-		if (!err) {
-			return;
-		} else if (err != -ENOMEM) {
-			printk("GATT notify failed (err %d)\n", err);
-			return;
-		}
-		k_sleep(K_TICKS(1));
-	} while (err == -ENOMEM);
+	err = bt_gatt_notify(g_conn, local_attr, &sample_dat, sizeof(sample_dat));
+	if (!err) {
+		printk("GATT notify ok\n");
+		return;
+	} else {
+		FAIL("GATT notify failed (err %d)\n", err);
+		return;
+	}
 }
 
 static uint8_t discover_func(struct bt_conn *conn,


### PR DESCRIPTION
Having queuing support in too many layers of the stack is hard to reason
about. The application (GATT or above) should either be doing the queuing
or the blocking.