### PR TITLE
cmake: remove deprecated XCC_USE_CLANG

### DIFF
--- a/cmake/modules/FindDeprecated.cmake
+++ b/cmake/modules/FindDeprecated.cmake
@@ -37,26 +37,6 @@ if("${Deprecated_FIND_COMPONENTS}" STREQUAL "")
   message(WARNING "find_package(Deprecated) missing required COMPONENTS keyword")
 endif()
 
-if("XCC_USE_CLANG" IN_LIST Deprecated_FIND_COMPONENTS)
-  list(REMOVE_ITEM Deprecated_FIND_COMPONENTS XCC_USE_CLANG)
-  # This code was deprecated after Zephyr v3.0.0
-  # Keep XCC_USE_CLANG behaviour for a while.
-  if(NOT DEFINED ZEPHYR_TOOLCHAIN_VARIANT)
-    set(ZEPHYR_TOOLCHAIN_VARIANT $ENV{ZEPHYR_TOOLCHAIN_VARIANT})
-  endif()
-
-  if ("${ZEPHYR_TOOLCHAIN_VARIANT}" STREQUAL "xcc"
-      AND "$ENV{XCC_USE_CLANG}" STREQUAL "1")
-    set(ZEPHYR_TOOLCHAIN_VARIANT xt-clang CACHE STRING "Zephyr toolchain variant" FORCE)
-    message(DEPRECATION "XCC_USE_CLANG is deprecated. Please set ZEPHYR_TOOLCHAIN_VARIANT to 'xt-clang'")
-  endif()
-
-  if("${ZEPHYR_TOOLCHAIN_VARIANT}" STREQUAL "xcc-clang")
-    set(ZEPHYR_TOOLCHAIN_VARIANT xt-clang CACHE STRING "Zephyr toolchain variant" FORCE)
-    message(DEPRECATION "ZEPHYR_TOOLCHAIN_VARIANT 'xcc-clang' is deprecated. Please set ZEPHYR_TOOLCHAIN_VARIANT to 'xt-clang'")
-  endif()
-endif()
-
 if("CROSS_COMPILE" IN_LIST Deprecated_FIND_COMPONENTS)
   list(REMOVE_ITEM Deprecated_FIND_COMPONENTS CROSS_COMPILE)
   # This code was deprecated after Zephyr v3.1.0

--- a/cmake/modules/FindHostTools.cmake
+++ b/cmake/modules/FindHostTools.cmake
@@ -48,7 +48,7 @@ if(HostTools_FOUND)
   return()
 endif()
 
-find_package(Deprecated COMPONENTS XCC_USE_CLANG CROSS_COMPILE)
+find_package(Deprecated COMPONENTS CROSS_COMPILE)
 
 find_package(Zephyr-sdk 0.16)
 

--- a/doc/develop/toolchains/cadence_xcc.rst
+++ b/doc/develop/toolchains/cadence_xcc.rst
@@ -68,7 +68,3 @@ Cadence Tensilica Xtensa C/C++ Compiler (XCC)
 
           # Linux
           export XCC_NO_G_FLAG=1
-
-   * Also note that setting :envvar:`XCC_USE_CLANG` to ``1`` and
-     :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to ``xcc`` is deprecated.
-     Set :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to ``xt-clang`` instead.


### PR DESCRIPTION
This was deprecated in 3.0, so remove it now and remove all docs related
to it.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
