### PR TITLE
board: arm: stm32f429i_disc1: flashing

### DIFF
--- a/boards/arm/stm32f429i_disc1/board.cmake
+++ b/boards/arm/stm32f429i_disc1/board.cmake
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(stm32cubeprogrammer "--erase" "--port=swd" "--reset-mode=hw")
 board_runner_args(jlink "--device=STM32F429ZI" "--speed=4000")
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/stm32f429i_disc1/doc/index.rst
+++ b/boards/arm/stm32f429i_disc1/doc/index.rst
@@ -161,6 +161,14 @@ This interface is supported by the openocd version included in Zephyr SDK.
 Flashing an application to STM32F429I-DISC1
 -------------------------------------------
 
+The board is configured to be flashed using west OpenOCD runner.
+Alternatively, you can use `STM32CubeProgrammer`_ (after installing it) using the ``--runner``
+(or ``-r``) option:
+
+.. code-block:: console
+
+   $ west flash --runner stm32cubeprogrammer
+
 First, connect the STM32F429I-DISC1 Discovery kit to your host computer using
 the USB port to prepare it for flashing. Then build and flash your application.
 
@@ -206,3 +214,6 @@ You can debug an application in the usual way.  Here is an example for the
 
 .. _STM32F429 Reference Manual:
    https://www.st.com/content/ccc/resource/technical/document/reference_manual/3d/6d/5a/66/b4/99/40/d4/DM00031020.pdf/files/DM00031020.pdf/jcr:content/translations/en.DM00031020.pdf
+
+.. _STM32CubeProgrammer:
+   https://www.st.com/en/development-tools/stm32cubeprog.html

--- a/boards/arm/stm32f429i_disc1/support/openocd.cfg
+++ b/boards/arm/stm32f429i_disc1/support/openocd.cfg
@@ -1,4 +1,11 @@
-source [find board/st_nucleo_f4.cfg]
+source [find interface/stlink-dap.cfg]
+
+transport select "dapdirect_swd"
+
+set CHIPNAME STM32F429ZITx
+set BOARDNAME STM32F429I-DISC1
+
+source [find target/stm32f4x.cfg]
 
 $_TARGETNAME configure -event gdb-attach {
 	echo "Debugger attaching: halting execution"


### PR DESCRIPTION
This patch adds the possibility to flash stm32f429i_disc1 board using STM32CubeProgrammer.
Also it fixes the configuration of OpenOCD, that was not working when used with the on-board ST-Linkv2 debug probe.