### PR TITLE
xtensa: fix xtensa_cas() to be config-independent

### DIFF
--- a/include/zephyr/arch/xtensa/atomic_xtensa.h
+++ b/include/zephyr/arch/xtensa/atomic_xtensa.h
@@ -5,6 +5,8 @@
 #ifndef ZEPHYR_INCLUDE_ATOMIC_XTENSA_H_
 #define ZEPHYR_INCLUDE_ATOMIC_XTENSA_H_
 
+#include <xtensa/hal.h>
+
 /* Included from <sys/atomic.h> */
 
 /* Recent GCC versions actually do have working atomics support on
@@ -32,10 +34,7 @@ static ALWAYS_INLINE
 atomic_val_t xtensa_cas(atomic_t *addr, atomic_val_t oldval,
 			atomic_val_t newval)
 {
-	__asm__ volatile("wsr %1, SCOMPARE1; s32c1i %0, %2, 0"
-			 : "+r"(newval), "+r"(oldval) : "r"(addr) : "memory");
-
-	return newval; /* got swapped with the old memory by s32c1i */
+	return xthal_compare_and_set((int32_t *)addr, oldval, newval);
 }
 
 static ALWAYS_INLINE


### PR DESCRIPTION
Not all configs have the register SCOMPARE1.
Let's use xthal_compare_and_set() to prevent build failure on configs where register SCOMPARE1 is missing.