### PR TITLE
net: lib: lwm2m: use correct format specifier for LOG_ERR

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_obj_device.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_device.c
@@ -261,7 +261,7 @@ static int lwm2m_obj_device_settings_set(const char *name, size_t len,
 
 	if (settings_name_steq(name, ERROR_LIST_KEY, &next) && !next) {
 		if (len > sizeof(error_code_list)) {
-			LOG_ERR("Error code list too large: %u", len);
+			LOG_ERR("Error code list too large: %zu", len);
 			return -EINVAL;
 		}
 


### PR DESCRIPTION
Use correct format specifier for LOG_ERR in lwm2m_obj_device.c. The previously used format specifier of %u was correct for 32 bit systems but would produce a build warning for 64 bit systems.

Fixes #66441