### PR TITLE
Add cache enable option

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -962,6 +962,20 @@ config EXTERNAL_CACHE
 
 endchoice
 
+config DCACHE_AUTO_ENABLE
+	bool "Automatically enable data cache during startup"
+	default y
+	depends on DCACHE
+	help
+	  Automatically enable the data cache during startup
+
+config ICACHE_AUTO_ENABLE
+	bool "Automatically enable instruction cache during startup"
+	default y
+	depends on ICACHE
+	help
+	  Automatically enable the instruction cache during startup
+
 endmenu
 
 config ARCH

--- a/arch/arc/core/cache.c
+++ b/arch/arc/core/cache.c
@@ -218,8 +218,9 @@ int arch_icache_flush_and_invd_range(void *addr, size_t size)
 
 static int init_dcache(void)
 {
-
-	arch_dcache_enable();
+	if (IS_ENABLED(CONFIG_DCACHE_AUTO_ENABLE)) {
+		arch_dcache_enable();
+	}
 
 #if defined(CONFIG_DCACHE_LINE_SIZE_DETECT)
 	init_dcache_line_size();

--- a/soc/arm/atmel_sam/same70/soc.c
+++ b/soc/arm/atmel_sam/same70/soc.c
@@ -226,15 +226,12 @@ static ALWAYS_INLINE void clock_init(void)
 
 void z_arm_platform_init(void)
 {
-	if (IS_ENABLED(CONFIG_CACHE_MANAGEMENT) && IS_ENABLED(CONFIG_ICACHE)) {
+	if (IS_ENABLED(CONFIG_ICACHE_AUTO_ENABLE)) {
 		SCB_EnableICache();
-	} else {
-		SCB_DisableICache();
 	}
-	if (IS_ENABLED(CONFIG_CACHE_MANAGEMENT) && IS_ENABLED(CONFIG_DCACHE)) {
+
+	if (IS_ENABLED(CONFIG_DCACHE_AUTO_ENABLE)) {
 		SCB_EnableDCache();
-	} else {
-		SCB_DisableDCache();
 	}
 
 	/*

--- a/soc/arm/atmel_sam/samv71/soc.c
+++ b/soc/arm/atmel_sam/samv71/soc.c
@@ -226,15 +226,12 @@ static ALWAYS_INLINE void clock_init(void)
 
 void z_arm_platform_init(void)
 {
-	if (IS_ENABLED(CONFIG_CACHE_MANAGEMENT) && IS_ENABLED(CONFIG_ICACHE)) {
+	if (IS_ENABLED(CONFIG_ICACHE_AUTO_ENABLE)) {
 		SCB_EnableICache();
-	} else {
-		SCB_DisableICache();
 	}
-	if (IS_ENABLED(CONFIG_CACHE_MANAGEMENT) && IS_ENABLED(CONFIG_DCACHE)) {
+
+	if (IS_ENABLED(CONFIG_DCACHE_AUTO_ENABLE)) {
 		SCB_EnableDCache();
-	} else {
-		SCB_DisableDCache();
 	}
 
 	/*

--- a/soc/arm/nxp_imx/rt/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt/Kconfig.soc
@@ -834,16 +834,4 @@ config SECOND_CORE_MCUX
 	  generated header specifying the VMA and LMA of each memory section
 	  to load
 
-config IMXRT1XXX_CODE_CACHE
-	bool "Code cache"
-	default y
-	help
-	  Enable Code cache at boot for IMXRT1xxx series
-
-config IMXRT1XXX_DATA_CACHE
-	bool "Data cache"
-	default y
-	help
-	  Enable Data cache at boot for IMXRT1xxx series
-
 endif # SOC_SERIES_IMX_RT

--- a/soc/arm/nxp_imx/rt/soc_rt10xx.c
+++ b/soc/arm/nxp_imx/rt/soc_rt10xx.c
@@ -326,9 +326,7 @@ static int imxrt_init(void)
 	}
 
 	if (IS_ENABLED(CONFIG_DCACHE_AUTO_ENABLE)) {
-		if ((SCB->CCR & SCB_CCR_DC_Msk) == 0) {
-			SCB_EnableDCache();
-		}
+		SCB_EnableDCache();
 	}
 
 	/* Initialize system clock */

--- a/soc/arm/nxp_imx/rt/soc_rt10xx.c
+++ b/soc/arm/nxp_imx/rt/soc_rt10xx.c
@@ -318,19 +318,14 @@ void imxrt_audio_codec_pll_init(uint32_t clock_name, uint32_t clk_src,
 
 static int imxrt_init(void)
 {
-#ifndef CONFIG_IMXRT1XXX_CODE_CACHE
-	/* SystemInit enables code cache, disable it here */
-	SCB_DisableICache();
-#else
-	/* z_arm_init_arch_hw_at_boot() disables code cache if CONFIG_ARCH_CACHE is enabled,
-	 * enable it here.
-	 */
 	if (IS_ENABLED(CONFIG_ICACHE_AUTO_ENABLE)) {
 		SCB_EnableICache();
+	} else {
+		/* SystemInit enables code cache, disable it here */
+		SCB_DisableICache();
 	}
-#endif
 
-	if (IS_ENABLED(CONFIG_IMXRT1XXX_DATA_CACHE) && IS_ENABLED(CONFIG_DCACHE_AUTO_ENABLE)) {
+	if (IS_ENABLED(CONFIG_DCACHE_AUTO_ENABLE)) {
 		if ((SCB->CCR & SCB_CCR_DC_Msk) == 0) {
 			SCB_EnableDCache();
 		}

--- a/soc/arm/nxp_imx/rt/soc_rt10xx.c
+++ b/soc/arm/nxp_imx/rt/soc_rt10xx.c
@@ -325,15 +325,15 @@ static int imxrt_init(void)
 	/* z_arm_init_arch_hw_at_boot() disables code cache if CONFIG_ARCH_CACHE is enabled,
 	 * enable it here.
 	 */
-	SCB_EnableICache();
+	if (IS_ENABLED(CONFIG_ICACHE_AUTO_ENABLE)) {
+		SCB_EnableICache();
+	}
 #endif
 
-	if (IS_ENABLED(CONFIG_IMXRT1XXX_DATA_CACHE)) {
+	if (IS_ENABLED(CONFIG_IMXRT1XXX_DATA_CACHE) && IS_ENABLED(CONFIG_DCACHE_AUTO_ENABLE)) {
 		if ((SCB->CCR & SCB_CCR_DC_Msk) == 0) {
 			SCB_EnableDCache();
 		}
-	} else {
-		SCB_DisableDCache();
 	}
 
 	/* Initialize system clock */

--- a/soc/arm/nxp_imx/rt/soc_rt11xx.c
+++ b/soc/arm/nxp_imx/rt/soc_rt11xx.c
@@ -680,15 +680,15 @@ static int imxrt_init(void)
 	/* z_arm_init_arch_hw_at_boot() disables code cache if CONFIG_ARCH_CACHE is enabled,
 	 * enable it here.
 	 */
-	SCB_EnableICache();
+	if (IS_ENABLED(CONFIG_ICACHE_AUTO_ENABLE)) {
+		SCB_EnableICache();
+	}
 #endif
 
-	if (IS_ENABLED(CONFIG_IMXRT1XXX_DATA_CACHE)) {
+	if (IS_ENABLED(CONFIG_IMXRT1XXX_DATA_CACHE) && IS_ENABLED(CONFIG_DCACHE_AUTO_ENABLE)) {
 		if ((SCB->CCR & SCB_CCR_DC_Msk) == 0) {
 			SCB_EnableDCache();
 		}
-	} else {
-		SCB_DisableDCache();
 	}
 #endif
 

--- a/soc/arm/nxp_imx/rt/soc_rt11xx.c
+++ b/soc/arm/nxp_imx/rt/soc_rt11xx.c
@@ -673,19 +673,14 @@ static int imxrt_init(void)
 
 
 #if defined(CONFIG_SOC_MIMXRT1176_CM7) || defined(CONFIG_SOC_MIMXRT1166_CM7)
-#ifndef CONFIG_IMXRT1XXX_CODE_CACHE
-	/* SystemInit enables code cache, disable it here */
-	SCB_DisableICache();
-#else
-	/* z_arm_init_arch_hw_at_boot() disables code cache if CONFIG_ARCH_CACHE is enabled,
-	 * enable it here.
-	 */
 	if (IS_ENABLED(CONFIG_ICACHE_AUTO_ENABLE)) {
 		SCB_EnableICache();
+	} else {
+		/* SystemInit enables code cache, disable it here */
+		SCB_DisableICache();
 	}
-#endif
 
-	if (IS_ENABLED(CONFIG_IMXRT1XXX_DATA_CACHE) && IS_ENABLED(CONFIG_DCACHE_AUTO_ENABLE)) {
+	if (IS_ENABLED(CONFIG_DCACHE_AUTO_ENABLE)) {
 		if ((SCB->CCR & SCB_CCR_DC_Msk) == 0) {
 			SCB_EnableDCache();
 		}

--- a/soc/arm/nxp_imx/rt/soc_rt11xx.c
+++ b/soc/arm/nxp_imx/rt/soc_rt11xx.c
@@ -681,9 +681,7 @@ static int imxrt_init(void)
 	}
 
 	if (IS_ENABLED(CONFIG_DCACHE_AUTO_ENABLE)) {
-		if ((SCB->CCR & SCB_CCR_DC_Msk) == 0) {
-			SCB_EnableDCache();
-		}
+		SCB_EnableDCache();
 	}
 #endif
 

--- a/soc/arm/nxp_kinetis/kv5x/Kconfig.soc
+++ b/soc/arm/nxp_kinetis/kv5x/Kconfig.soc
@@ -57,12 +57,4 @@ config SOC_PART_NUMBER_KINETIS_KV5X
 	  number selection choice defines the default value for this
 	  string.
 
-config KINETIS_KV5X_ENABLE_CODE_CACHE
-	bool "Code cache"
-	default y
-
-config KINETIS_KV5X_ENABLE_DATA_CACHE
-	bool "Data cache"
-	default y
-
 endif # SOC_SERIES_KINETIS_KV5X

--- a/soc/arm/nxp_kinetis/kv5x/soc.c
+++ b/soc/arm/nxp_kinetis/kv5x/soc.c
@@ -90,14 +90,15 @@ static int kv5x_init(void)
 	/* Initialize system clocks and PLL */
 	clk_init();
 
-#ifndef CONFIG_KINETIS_KV5X_ENABLE_CODE_CACHE
-	/* SystemInit will have enabled the code cache. Disable it here */
-	SCB_DisableICache();
-#endif
-#ifndef CONFIG_KINETIS_KV5X_ENABLE_DATA_CACHE
-	/* SystemInit will have enabled the data cache. Disable it here */
-	SCB_DisableDCache();
-#endif
+	if (!IS_ENABLED(CONFIG_ICACHE_AUTO_ENABLE)) {
+		/* SystemInit will have enabled the code cache. Disable it here */
+		SCB_DisableICache();
+	}
+
+	if (!IS_ENABLED(CONFIG_DCACHE_AUTO_ENABLE)) {
+		/* SystemInit will have enabled the data cache. Disable it here */
+		SCB_DisableDCache();
+	}
 
 	return 0;
 }

--- a/soc/arm/nxp_s32/s32k3/soc.c
+++ b/soc/arm/nxp_s32/s32k3/soc.c
@@ -55,9 +55,7 @@ static int soc_init(void)
 	}
 
 	if (IS_ENABLED(CONFIG_DCACHE_AUTO_ENABLE)) {
-		if (!(SCB->CCR & SCB_CCR_DC_Msk)) {
-			SCB_EnableDCache();
-		}
+		SCB_EnableDCache();
 	}
 
 	OsIf_Init(NULL);

--- a/soc/arm/nxp_s32/s32k3/soc.c
+++ b/soc/arm/nxp_s32/s32k3/soc.c
@@ -50,9 +50,11 @@ const struct ivt ivt_header __attribute__((section(".ivt_header"))) = {
 
 static int soc_init(void)
 {
-	SCB_EnableICache();
+	if (IS_ENABLED(CONFIG_ICACHE_AUTO_ENABLE)) {
+		SCB_EnableICache();
+	}
 
-	if (IS_ENABLED(CONFIG_DCACHE)) {
+	if (IS_ENABLED(CONFIG_DCACHE_AUTO_ENABLE)) {
 		if (!(SCB->CCR & SCB_CCR_DC_Msk)) {
 			SCB_EnableDCache();
 		}

--- a/soc/arm/st_stm32/stm32f7/soc.c
+++ b/soc/arm/st_stm32/stm32f7/soc.c
@@ -30,11 +30,11 @@ static int st_stm32f7_init(void)
 	/* Enable ART Flash cache accelerator */
 	LL_FLASH_EnableART();
 
-	if (IS_ENABLED(CONFIG_ICACHE)) {
+	if (IS_ENABLED(CONFIG_ICACHE_AUTO_ENABLE)) {
 		SCB_EnableICache();
 	}
 
-	if (IS_ENABLED(CONFIG_DCACHE)) {
+	if (IS_ENABLED(CONFIG_DCACHE_AUTO_ENABLE)) {
 		SCB_EnableDCache();
 	}
 

--- a/soc/arm/st_stm32/stm32h7/soc_m7.c
+++ b/soc/arm/st_stm32/stm32h7/soc_m7.c
@@ -54,11 +54,11 @@ static int stm32h7_m4_wakeup(void)
  */
 static int stm32h7_init(void)
 {
-	if (IS_ENABLED(CONFIG_ICACHE)) {
+	if (IS_ENABLED(CONFIG_ICACHE_AUTO_ENABLE)) {
 		SCB_EnableICache();
 	}
 
-	if (IS_ENABLED(CONFIG_DCACHE)) {
+	if (IS_ENABLED(CONFIG_DCACHE_AUTO_ENABLE)) {
 		SCB_EnableDCache();
 	}
 


### PR DESCRIPTION
Currently some soc init procedures automatically enable the data and instruction caches. As somebody might want to disable the caches intentionally I added a Kconfig option which allows this selection. The default is automatic activation, therefore no change to the current behavior.

The already existing configs DCACHE and ICACHE are kept in place, as one might want to disable or enable the caches manually, but does not want the startup routines to do so automatically.

This is based upon the already merged PR #66140.