### PR TITLE
Bluetooth: Host: add hci error to errno translation for INVALID_PARAM

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -338,6 +338,8 @@ int bt_hci_cmd_send_sync(uint16_t opcode, struct net_buf *buf,
 		switch (status) {
 		case BT_HCI_ERR_CONN_LIMIT_EXCEEDED:
 			return -ECONNREFUSED;
+		case BT_HCI_ERR_INVALID_PARAM:
+			return -EINVAL;
 		case BT_HCI_ERR_INSUFFICIENT_RESOURCES:
 			return -ENOMEM;
 		default:


### PR DESCRIPTION
when checking return values of functions like bt_le_scan_start, one would assume to get -EINVAL when supplying Invalid parameters. the current implementation just spits out -EIO, which can be very misleading.