### PR TITLE
drivers: entropy: entropy_esp32.c: remove not necessary cast

### DIFF
--- a/drivers/entropy/entropy_esp32.c
+++ b/drivers/entropy/entropy_esp32.c
@@ -44,7 +44,7 @@ static int entropy_esp32_get_entropy(const struct device *dev, uint8_t *buf,
 				     uint16_t len)
 {
 	assert(buf != NULL);
-	uint8_t *buf_bytes = (uint8_t *)buf;
+	uint8_t *buf_bytes = buf;
 
 	while (len > 0) {
 		uint32_t word = entropy_esp32_get_u32();


### PR DESCRIPTION
This cast already has the correct type on both sides, so it can be removed.