### PR TITLE
cmake: linker: remove unused symbols __tls_start,end,size

### DIFF
--- a/cmake/linker_script/common/thread-local-storage.cmake
+++ b/cmake/linker_script/common/thread-local-storage.cmake
@@ -35,9 +35,5 @@ if(CONFIG_THREAD_LOCAL_STORAGE)
 #	PROVIDE(__tbss_size = SIZEOF(tbss));
 #	PROVIDE(__tbss_end = __tbss_start + __tbss_size);
 #	PROVIDE(__tbss_align = ALIGNOF(tbss));
-#
-#	PROVIDE(__tls_start = __tdata_start);
-#	PROVIDE(__tls_end = __tbss_end);
-#	PROVIDE(__tls_size = __tbss_end - __tdata_start);
 
 endif()

--- a/include/zephyr/linker/linker-defs.h
+++ b/include/zephyr/linker/linker-defs.h
@@ -259,9 +259,6 @@ extern char __tbss_start[];
 extern char __tbss_end[];
 extern char __tbss_size[];
 extern char __tbss_align[];
-extern char __tls_start[];
-extern char __tls_end[];
-extern char __tls_size[];
 #endif /* CONFIG_THREAD_LOCAL_STORAGE */
 
 #ifdef CONFIG_LINKER_USE_BOOT_SECTION

--- a/include/zephyr/linker/thread-local-storage.ld
+++ b/include/zephyr/linker/thread-local-storage.ld
@@ -33,8 +33,4 @@
 	PROVIDE(__tbss_end = __tbss_start + __tbss_size);
 	PROVIDE(__tbss_align = ALIGNOF(tbss));
 
-	PROVIDE(__tls_start = __tdata_start);
-	PROVIDE(__tls_end = __tbss_end);
-	PROVIDE(__tls_size = __tbss_end - __tdata_start);
-
 #endif /* CONFIG_THREAD_LOCAL_STORAGE */


### PR DESCRIPTION
The linker variables __tls_start, __tls_end and __tls_size are not used in the zephyr project, so remove them for now.