### PR TITLE
lib: libc: minimal: proper cast to "(char *)" from "(const char *)"

### DIFF
--- a/lib/libc/minimal/source/string/strerror.c
+++ b/lib/libc/minimal/source/string/strerror.c
@@ -28,7 +28,7 @@ char *strerror(int errnum)
 		return (char *)sys_errlist[errnum];
 	}
 
-	return "";
+	return (char *) "";
 }
 
 /*


### PR DESCRIPTION
The string "" is of type '(const char *)', so add a cast over to '(char *)' to clean up source code.

The change to stdout_console.c is purely cosmetic and just results in more compact written code.