### PR TITLE
manifest: hal_openisa: update revision for double promotion fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -198,7 +198,7 @@ manifest:
       groups:
         - hal
     - name: hal_openisa
-      revision: d1e61c0c654d8ca9e73d27fca3a7eb3b7881cb6a
+      revision: eabd530a64d71de91d907bad257cd61aacf607bc
       path: modules/hal/openisa
       groups:
         - hal


### PR DESCRIPTION
Update hal_openisa, this is needed for the double promotion fix

see: https://github.com/zephyrproject-rtos/zephyr/pull/57154