### PR TITLE
manifest: wurthelektronik: update revision for double promotion fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -244,7 +244,7 @@ manifest:
       groups:
         - hal
     - name: hal_wurthelektronik
-      revision: 24ca9873c3d608fad1fea0431836bc8f144c132e
+      revision: e5bcb2eac1bb9639ce13b4dafc78eb254e014342
       path: modules/hal/wurthelektronik
       groups:
         - hal


### PR DESCRIPTION
Update wurtheletronik, this is needed for the double promotion fix

see: https://github.com/zephyrproject-rtos/zephyr/pull/57154