### PR TITLE
boards: arm: nrf5340dk_nrf5340: Add SPI to supported peripherals

### DIFF
--- a/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpuapp.yaml
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpuapp.yaml
@@ -18,4 +18,5 @@ supported:
   - usb_device
   - netif:openthread
   - gpio
+  - spi
 vendor: nordic

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpuapp_ns.yaml
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpuapp_ns.yaml
@@ -16,4 +16,5 @@ supported:
   - usb_device
   - netif:openthread
   - gpio
+  - spi
 vendor: nordic


### PR DESCRIPTION
The target has board configuration for spi_flash sample but bacause of the lack of SPI mentioned in supported peripherals Twister is filtering out the target for sample.drivers.spi.flash test.