### PR TITLE
Bluetooth: Clarify when the sent callback is issued

### DIFF
--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -569,8 +569,10 @@ struct bt_bap_stream_ops {
 	/**
 	 * @brief Stream audio HCI sent callback
 	 *
-	 * If this callback is provided it will be called whenever a SDU has been completely sent,
-	 * or otherwise flushed due to transmission issues.
+	 * This callback will be called once the controller marks the SDU
+	 * as completed. When the controller does so is implementation
+	 * dependent. It could be after the SDU is enqueued for transmission,
+	 * or after it is sent on air or flushed.
 	 *
 	 * This callback is only used if the ISO data path is HCI.
 	 *

--- a/include/zephyr/bluetooth/iso.h
+++ b/include/zephyr/bluetooth/iso.h
@@ -663,8 +663,10 @@ struct bt_iso_chan_ops {
 
 	/** @brief Channel sent callback
 	 *
-	 *  If this callback is provided it will be called whenever a SDU has
-	 *  been completely sent.
+	 *  This callback will be called once the controller marks the SDU
+	 *  as completed. When the controller does so is implementation
+	 *  dependent. It could be after the SDU is enqueued for transmission,
+	 *  or after it is sent on air or flushed.
 	 *
 	 *  @param chan The channel which has sent data.
 	 */

--- a/include/zephyr/bluetooth/l2cap.h
+++ b/include/zephyr/bluetooth/l2cap.h
@@ -346,8 +346,10 @@ struct bt_l2cap_chan_ops {
 
 	/** @brief Channel sent callback
 	 *
-	 *  If this callback is provided it will be called whenever a SDU has
-	 *  been completely sent.
+	 *  This callback will be called once the controller marks the SDU
+	 *  as completed. When the controller does so is implementation
+	 *  dependent. It could be after the SDU is enqueued for transmission,
+	 *  or after it is sent on air.
 	 *
 	 *  @param chan The channel which has sent data.
 	 */


### PR DESCRIPTION
The timing of the sent callback shouldn't be used to determine when something is sent on air. The callback is issued after the controller has raised the HCI event "Number Of Completed Packets". The timing of this event is dependent on the implementation.