### PR TITLE
llext: fix: use Cache API-defined cache flush functions

### DIFF
--- a/subsys/llext/Kconfig
+++ b/subsys/llext/Kconfig
@@ -3,6 +3,7 @@
 
 menuconfig LLEXT
 	bool "Linkable loadable extensions"
+	select CACHE_MANAGEMENT if DCACHE
 	help
 	  Enable the linkable loadable extension subsystem
 

--- a/subsys/llext/llext.c
+++ b/subsys/llext/llext.c
@@ -781,7 +781,7 @@ static int llext_link(struct llext_loader *ldr, struct llext *ext, bool do_local
 	/* Make sure changes to ext sections are flushed to RAM */
 	for (i = 0; i < LLEXT_MEM_COUNT; ++i) {
 		if (ext->mem[i]) {
-			arch_dcache_flush_range(ext->mem[i], ext->mem_size[i]);
+			sys_cache_data_flush_range(ext->mem[i], ext->mem_size[i]);
 		}
 	}
 #endif


### PR DESCRIPTION
#66144 added cache management handling to the llext subsystem, but used arch-specific function calls which were not defined on every supported target.

* Fix it to use the Cache API-defined function names.
* Automatically enable `CACHE_MANAGEMENT` on targets requiring it.

Fixes #66382.