### PR TITLE
net: lib: coap: Change coap_pending_init()

### DIFF
--- a/doc/releases/migration-guide-3.6.rst
+++ b/doc/releases/migration-guide-3.6.rst
@@ -221,6 +221,12 @@ Networking
   subsystem. The ``CONFIG_COAP_OBSERVER_EVENTS`` configuration option has been removed.
   (:github:`65936`)
 
+* The CoAP public API function :c:func:`coap_pending_init` has changed. The parameter
+  ``retries`` is replaced with a pointer to :c:struct:`coap_transmission_parameters`. This allows to
+  specify retransmission parameters of the confirmable message. It is safe to pass a NULL pointer to
+  use default values.
+  (:github:`66482`)
+
 * The IGMP multicast library now supports IGMPv3. This results in a minor change to the existing
   api. The :c:func:`net_ipv4_igmp_join` now takes an additional argument of the type
   ``const struct igmp_param *param``. This allows IGMPv3 to exclude/include certain groups of

--- a/doc/releases/release-notes-3.6.rst
+++ b/doc/releases/release-notes-3.6.rst
@@ -213,6 +213,11 @@ Networking
 
   * Emit observer/service network events using the Network Event subsystem.
 
+  * Added new API functions:
+
+    * :c:func:`coap_get_transmission_parameters`
+    * :c:func:`coap_set_transmission_parameters`
+
 * Connection Manager:
 
 * DHCP:

--- a/include/zephyr/net/coap.h
+++ b/include/zephyr/net/coap.h
@@ -310,6 +310,18 @@ typedef int (*coap_reply_t)(const struct coap_packet *response,
 			    const struct sockaddr *from);
 
 /**
+ * @brief CoAP transmission parameters.
+ */
+struct coap_transmission_parameters {
+	/**  Initial ACK timeout. Value is used as a base value to retry pending CoAP packets. */
+	uint32_t ack_timeout;
+	/** Set CoAP retry backoff factor. A value of 200 means a factor of 2.0. */
+	uint16_t coap_backoff_percent;
+	/** Maximum number of retransmissions. */
+	uint8_t max_retransmission;
+};
+
+/**
  * @brief Represents a request awaiting for an acknowledgment (ACK).
  */
 struct coap_pending {
@@ -320,6 +332,7 @@ struct coap_pending {
 	uint8_t *data;        /**< User allocated buffer */
 	uint16_t len;         /**< Length of the CoAP packet */
 	uint8_t retries;      /**< Number of times the request has been sent */
+	struct coap_transmission_parameters params; /**< Transmission parameters */
 };
 
 /**
@@ -989,14 +1002,15 @@ void coap_reply_init(struct coap_reply *reply,
  * confirmation message, initialized with data from @a request
  * @param request Message waiting for confirmation
  * @param addr Address to send the retransmission
- * @param retries Maximum number of retransmissions of the message.
+ * @param params Pointer to the CoAP transmission parameters struct,
+ * or NULL to use default values
  *
  * @return 0 in case of success or negative in case of error.
  */
 int coap_pending_init(struct coap_pending *pending,
 		      const struct coap_packet *request,
 		      const struct sockaddr *addr,
-		      uint8_t retries);
+		      const struct coap_transmission_parameters *params);
 
 /**
  * @brief Returns the next available pending struct, that can be used
@@ -1133,18 +1147,6 @@ int coap_resource_notify(struct coap_resource *resource);
  * otherwise
  */
 bool coap_request_is_observe(const struct coap_packet *request);
-
-/**
- * @brief CoAP transmission parameters.
- */
-struct coap_transmission_parameters {
-	/**  Initial AKC timeout. Value is used as a base value to retry pending CoAP packets. */
-	uint32_t ack_timeout;
-	/** Set CoAP retry backoff factor. A value of 200 means a factor of 2.0. */
-	uint16_t coap_backoff_percent;
-	/** Maximum number of retransmissions. */
-	uint8_t max_retransmission;
-};
 
 /**
  * @brief Get currently active CoAP transmission parameters.

--- a/include/zephyr/net/coap_client.h
+++ b/include/zephyr/net/coap_client.h
@@ -83,7 +83,6 @@ struct coap_client_internal_request {
 	uint32_t offset;
 	uint32_t last_id;
 	uint8_t request_tkl;
-	uint8_t retry_count;
 	bool request_ongoing;
 	struct coap_block_context recv_blk_ctx;
 	struct coap_block_context send_blk_ctx;
@@ -131,12 +130,12 @@ int coap_client_init(struct coap_client *client, const char *info);
  * @param sock Open socket file descriptor.
  * @param addr the destination address of the request, NULL if socket is already connected.
  * @param req CoAP request structure
- * @param retries How many times to retry or -1 to use default.
+ * @param params Pointer to transmission parameters structure or NULL to use default values.
  * @return zero when operation started successfully or negative error code otherwise.
  */
 
 int coap_client_req(struct coap_client *client, int sock, const struct sockaddr *addr,
-		    struct coap_client_request *req, int retries);
+		    struct coap_client_request *req, struct coap_transmission_parameters *params);
 
 /**
  * @}

--- a/subsys/net/lib/coap/coap_server.c
+++ b/subsys/net/lib/coap/coap_server.c
@@ -542,6 +542,8 @@ int coap_service_send(const struct coap_service *service, const struct coap_pack
 	 * try to send.
 	 */
 	if (coap_header_get_type(cpkt) == COAP_TYPE_CON) {
+		struct coap_transmission_parameters params;
+
 		struct coap_pending *pending = coap_pending_next_unused(service->data->pending,
 									MAX_PENDINGS);
 
@@ -550,8 +552,9 @@ int coap_service_send(const struct coap_service *service, const struct coap_pack
 			goto send;
 		}
 
-		ret = coap_pending_init(pending, cpkt, addr,
-					CONFIG_COAP_SERVICE_PENDING_RETRANSMITS);
+		params = coap_get_transmission_parameters();
+		params.max_retransmission = CONFIG_COAP_SERVICE_PENDING_RETRANSMITS;
+		ret = coap_pending_init(pending, cpkt, addr, &params);
 		if (ret < 0) {
 			LOG_WRN("Failed to init pending message for %s (%d)", service->name, ret);
 			goto send;

--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -654,8 +654,7 @@ int lwm2m_init_message(struct lwm2m_message *msg)
 		goto cleanup;
 	}
 
-	r = coap_pending_init(msg->pending, &msg->cpkt, &msg->ctx->remote_addr,
-			      CONFIG_COAP_MAX_RETRANSMIT);
+	r = coap_pending_init(msg->pending, &msg->cpkt, &msg->ctx->remote_addr, NULL);
 	if (r < 0) {
 		LOG_ERR("Unable to initialize a pending "
 			"retransmission (err:%d).",
@@ -2594,8 +2593,7 @@ static int lwm2m_response_promote_to_con(struct lwm2m_message *msg)
 		return -ENOMEM;
 	}
 
-	ret = coap_pending_init(msg->pending, &msg->cpkt, &msg->ctx->remote_addr,
-				CONFIG_COAP_MAX_RETRANSMIT);
+	ret = coap_pending_init(msg->pending, &msg->cpkt, &msg->ctx->remote_addr, NULL);
 	if (ret < 0) {
 		LOG_ERR("Unable to initialize a pending "
 			"retransmission (err:%d).",

--- a/tests/net/lib/coap/src/main.c
+++ b/tests/net/lib/coap/src/main.c
@@ -779,7 +779,7 @@ ZTEST(coap, test_retransmit_second_round)
 	zassert_not_null(pending, "No free pending");
 
 	r = coap_pending_init(pending, &cpkt, (struct sockaddr *) &dummy_addr,
-			      CONFIG_COAP_MAX_RETRANSMIT);
+			      NULL);
 	zassert_equal(r, 0, "Could not initialize packet");
 
 	/* We "send" the packet the first time here */

--- a/tests/net/lib/coap/src/main.c
+++ b/tests/net/lib/coap/src/main.c
@@ -1718,4 +1718,57 @@ ZTEST(coap, test_coap_packet_set_path)
 						  COAP_OPTION_URI_PATH);
 }
 
+ZTEST(coap, test_transmission_parameters)
+{
+	struct coap_packet cpkt;
+	struct coap_pending *pending;
+	struct coap_transmission_parameters params;
+	uint8_t *data = data_buf[0];
+	int r;
+	uint16_t id;
+
+	params = coap_get_transmission_parameters();
+	zassert_equal(params.ack_timeout, CONFIG_COAP_INIT_ACK_TIMEOUT_MS, "Wrong ACK timeout");
+	zassert_equal(params.coap_backoff_percent, CONFIG_COAP_BACKOFF_PERCENT,
+		      "Wrong backoff percent");
+	zassert_equal(params.max_retransmission, CONFIG_COAP_MAX_RETRANSMIT,
+		      "Wrong max retransmission value");
+
+	params.ack_timeout = 1000;
+	params.coap_backoff_percent = 150;
+	params.max_retransmission = 2;
+
+	coap_set_transmission_parameters(&params);
+
+	id = coap_next_id();
+
+	r = coap_packet_init(&cpkt, data, COAP_BUF_SIZE, COAP_VERSION_1,
+			     COAP_TYPE_CON, 0, coap_next_token(),
+			     COAP_METHOD_GET, id);
+	zassert_equal(r, 0, "Could not initialize packet");
+
+	pending = coap_pending_next_unused(pendings, NUM_PENDINGS);
+	zassert_not_null(pending, "No free pending");
+
+	params.ack_timeout = 3000;
+	params.coap_backoff_percent = 250;
+	params.max_retransmission = 3;
+
+	r = coap_pending_init(pending, &cpkt, (struct sockaddr *) &dummy_addr,
+			      &params);
+	zassert_equal(r, 0, "Could not initialize packet");
+
+	zassert_equal(pending->params.ack_timeout, 3000, "Wrong ACK timeout");
+	zassert_equal(pending->params.coap_backoff_percent, 250, "Wrong backoff percent");
+	zassert_equal(pending->params.max_retransmission, 3, "Wrong max retransmission value");
+
+	r = coap_pending_init(pending, &cpkt, (struct sockaddr *) &dummy_addr,
+			      NULL);
+	zassert_equal(r, 0, "Could not initialize packet");
+
+	zassert_equal(pending->params.ack_timeout, 1000, "Wrong ACK timeout");
+	zassert_equal(pending->params.coap_backoff_percent, 150, "Wrong backoff percent");
+	zassert_equal(pending->params.max_retransmission, 2, "Wrong max retransmission value");
+}
+
 ZTEST_SUITE(coap, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Replace function parameter 'retries' with pointer to structure holding coap transmission parameters. This allows setting the retransmission parameters individually for each pending request.

Add coap transmission parameters to coap_pending structure.

Update migration guide and release notes.