### PR TITLE
tests: Bluetooth: shell: Fix connection reference leak

### DIFF
--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -2843,10 +2843,8 @@ static int cmd_connect_le(const struct shell *sh, size_t argc, char *argv[])
 					BT_GAP_SCAN_FAST_INTERVAL,
 					BT_GAP_SCAN_FAST_INTERVAL);
 
-	err = bt_conn_le_create(
-		&addr, create_params,
-		BT_LE_CONN_PARAM(BT_GAP_INIT_CONN_INT_MIN, BT_GAP_INIT_CONN_INT_MIN, 0, 400),
-		&conn);
+	err = bt_conn_le_create(&addr, create_params, BT_LE_CONN_PARAM_DEFAULT,
+				&conn);
 	if (err) {
 		shell_error(sh, "Connection failed (%d)", err);
 		return -ENOEXEC;

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -694,8 +694,6 @@ static void connected(struct bt_conn *conn, uint8_t err)
 		}
 	}
 
-	default_conn = bt_conn_ref(conn);
-
 done:
 	/* clear connection reference for sec mode 3 pairing */
 	if (pairing_conn) {


### PR DESCRIPTION
This fixes regression introduced in recently.
Redundant connection reference is taken twice in connected()
callback. The redunant reference was then not returned, and
as a result we had a leak.