### PR TITLE
scripts: twister: coverage: deal with multiple function definitions

### DIFF
--- a/scripts/pylib/twister/twisterlib/coverage.py
+++ b/scripts/pylib/twister/twisterlib/coverage.py
@@ -220,12 +220,16 @@ class Gcovr(CoverageTool):
 
         excludes = Gcovr._interleave_list("-e", self.ignores)
 
+        # Different ifdef-ed implementations of the same function should not be
+        # in conflict treated by GCOVR as separate objects for coverage statistics.
+        mode_options = ["--merge-mode-functions=separate"]
+
         # We want to remove tests/* and tests/ztest/test/* but save tests/ztest
         cmd = ["gcovr", "-r", self.base_dir,
                "--gcov-ignore-parse-errors=negative_hits.warn_once_per_file",
                "--gcov-executable", str(self.gcov_tool),
                "-e", "tests/*"]
-        cmd += excludes + ["--json", "-o", coveragefile, outdir]
+        cmd += excludes + mode_options + ["--json", "-o", coveragefile, outdir]
         cmd_str = " ".join(cmd)
         logger.debug(f"Running {cmd_str}...")
         subprocess.call(cmd, stdout=coveragelog)
@@ -233,7 +237,7 @@ class Gcovr(CoverageTool):
         subprocess.call(["gcovr", "-r", self.base_dir, "--gcov-executable",
                          self.gcov_tool, "-f", "tests/ztest", "-e",
                          "tests/ztest/test/*", "--json", "-o", ztestfile,
-                         outdir], stdout=coveragelog)
+                         outdir] + mode_options, stdout=coveragelog)
 
         if os.path.exists(ztestfile) and os.path.getsize(ztestfile) > 0:
             files = [coveragefile, ztestfile]
@@ -256,7 +260,7 @@ class Gcovr(CoverageTool):
         }
         gcovr_options = self._flatten_list([report_options[r] for r in self.output_formats.split(',')])
 
-        return subprocess.call(["gcovr", "-r", self.base_dir] + gcovr_options + tracefiles,
+        return subprocess.call(["gcovr", "-r", self.base_dir] + mode_options + gcovr_options + tracefiles,
                                stdout=coveragelog)
 
 


### PR DESCRIPTION
Keep definitions instead of abort report creation.

The issue is occurs e.g for file [zephyr/lib/os/sem.c](https://github.com/zephyrproject-rtos/zephyr/blob/main/lib/os/sem.c)
which has conditionally multiple definitions of  sys_sem_init function.
As different test can be configured to use different version of that function, gcovr is not able to prepare coverage properly.
It fails with message:
```
AssertionError: Got function sys_sem_init on multiple lines: 48, 109.
You can run gcovr with --merge-mode-functions=MERGE_MODE.
The available values for MERGE_MODE are described in the documentation.
```

Unfortunately, that breaks gcovr processing and no report is generated.

Regarding solution, suggested option merge-mode-functions solved the issue.
Possible values are:
https://gcovr.com/en/6.0/manpage.html#cmdoption-gcovr-merge-mode-functions
`separate` seems to be the most generic, allowing to show different versions of function.

However to benefit from that option, there is needed this change to be released:
https://github.com/gcovr/gcovr/pull/844