### PR TITLE
dtlib: Allow deleting the root node

### DIFF
--- a/scripts/dts/python-devicetree/src/devicetree/dtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/dtlib.py
@@ -166,7 +166,13 @@ class Node:
         return prop
 
     def _del(self) -> None:
-        # Removes the node from the tree
+        # Removes the node from the tree. When called on the root node,
+        # this method will leave it empty but still part of the tree.
+
+        if self.parent is None:
+            self.nodes.clear()
+            self.props.clear()
+            return
         self.parent.nodes.pop(self.name)  # type: ignore
 
     def __str__(self):

--- a/scripts/dts/python-devicetree/tests/test_dtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_dtlib.py
@@ -912,6 +912,15 @@ def test_deletion():
 /dts-v1/;
 
 / {
+	x = "foo";
+	sub0 {
+		x = "bar";
+	};
+};
+
+/delete-node/ &{/};
+
+/ {
 	sub1 {
 		x = < 1 >;
 		sub2 {
@@ -939,6 +948,29 @@ def test_deletion():
 	sub1 {
 		x = < 0x1 >;
 	};
+};
+""")
+
+    verify_parse("""
+/dts-v1/;
+
+/ {
+	x: x = < &sub >, &sub;
+
+	sub1 {
+		x = < &sub >, &sub;
+	};
+	sub2: sub2 {
+		x = < &sub >, &sub;
+	};
+};
+
+/delete-node/ &{/};
+""",
+"""
+/dts-v1/;
+
+/ {
 };
 """)
 


### PR DESCRIPTION
Previously, dtlib would fail to parse the following:
```
/delete-node/ &{/};
```
This is accepted by dtc, so dtlib should be aligned.

The expected behavior is that the contents of the "deleted" root node are emptied, but the node itself remains in the tree. This means that it's possible to put that statement at the end of a DTS file and still get a valid output. A small test case for this scenario is included.