### PR TITLE
twister: fix hardware map hardware detection

### DIFF
--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -287,7 +287,7 @@ class HardwareMap:
         serial_devices = list_ports.comports()
         logger.info("Scanning connected hardware...")
         for d in serial_devices:
-            if d.manufacturer in self.manufacturer:
+            if d.manufacturer.casefold() in [m.casefold() for m in self.manufacturer]:
 
                 # TI XDS110 can have multiple serial devices for a single board
                 # assume endpoint 0 is the serial, skip all others


### PR DESCRIPTION
NXP boards with CMSID-DAP are not detected by twister --generate-hardware-map, because serial device name 'mbed' is compared with upper case 'MBED' in a list of supported manufacturers. Fix it by making the comparison case-insensitive.
Tested using mimxrt1020_evk.

Fixes #63765