### PR TITLE
ARCMWDT: Add headers for POSIX compatibility

### DIFF
--- a/lib/libc/arcmwdt/include/errno.h
+++ b/lib/libc/arcmwdt/include/errno.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 1984-1999, 2012 Wind River Systems, Inc.
+ * Copyright (c) 2023 Synopsys
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief System error numbers
+ */
+
+#ifndef LIB_LIBC_ARCMWDT_INCLUDE_ERRNO_H_
+#define LIB_LIBC_ARCMWDT_INCLUDE_ERRNO_H_
+
+#include_next <errno.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* MWDT supports range of error codes (ref. $(METAWARE_ROOT)/arc/lib/src/inc/errno.h)
+ * Add unsupported only
+ */
+#ifndef ENODATA
+#define ENODATA 86
+#endif
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* LIB_LIBC_ARCMWDT_INCLUDE_ERRNO_H_ */

--- a/lib/libc/arcmwdt/include/limits.h
+++ b/lib/libc/arcmwdt/include/limits.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2023 Synopsys
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef LIB_LIBC_ARCMWDT_INCLUDE_LIMITS_H_
+#define LIB_LIBC_ARCMWDT_INCLUDE_LIMITS_H_
+
+#include_next <limits.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define PATH_MAX 256
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LIB_LIBC_ARCMWDT_INCLUDE_LIMITS_H_ */


### PR DESCRIPTION
Add ENODATA errno code, wich is not presented in ARCMWDT headers. Add PATH_MAX define