### PR TITLE
tests: net: socket: tcp: Fix build for nrf5340dk_nrf5340_cpuapp_ns

### DIFF
--- a/tests/net/socket/tcp/prj.conf
+++ b/tests/net/socket/tcp/prj.conf
@@ -57,3 +57,6 @@ CONFIG_NET_CONTEXT_SNDBUF=y
 # Because of userspace and recvmsg() we need some extra heap in order to
 # copy the iovec in the recvmsg tests.
 CONFIG_HEAP_MEM_POOL_SIZE=512
+
+# If using TF-M, disable the BL2 bootloader to save flash-space for the test.
+CONFIG_TFM_BL2=n


### PR DESCRIPTION
Fix build for nrf5340dk_nrf5340_cpuapp_ns.
Test takes up almost all of the flash, leaving no room for the image to be signed. Disable the bootloader to free up flash-usage.

Fixes: #66469