### PR TITLE
soc: arm: atmel_sam: Rework clock initialization

### DIFF
--- a/soc/arm/atmel_sam/common/soc_pmc.h
+++ b/soc/arm/atmel_sam/common/soc_pmc.h
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2016 Piotr Mienkowski
+ * Copyright (c) 2023 Basalte bv
+ *
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,7 +13,11 @@
 #ifndef _ATMEL_SAM_SOC_PMC_H_
 #define _ATMEL_SAM_SOC_PMC_H_
 
+#include <stdbool.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/util.h>
 #include <zephyr/types.h>
+#include <soc.h>
 
 /**
  * @brief Enable the clock of specified peripheral module.
@@ -34,5 +40,484 @@ void soc_pmc_peripheral_disable(uint32_t id);
  * @return     1 if peripheral is enabled, 0 otherwise
  */
 uint32_t soc_pmc_peripheral_is_enabled(uint32_t id);
+
+#if !defined(CONFIG_SOC_SERIES_SAM4L)
+
+enum soc_pmc_fast_rc_freq {
+#if defined(CKGR_MOR_MOSCRCF_4_MHz)
+	SOC_PMC_FAST_RC_FREQ_4MHZ = CKGR_MOR_MOSCRCF_4_MHz,
+#endif
+#if defined(CKGR_MOR_MOSCRCF_8_MHz)
+	SOC_PMC_FAST_RC_FREQ_8MHZ = CKGR_MOR_MOSCRCF_8_MHz,
+#endif
+#if defined(CKGR_MOR_MOSCRCF_12_MHz)
+	SOC_PMC_FAST_RC_FREQ_12MHZ = CKGR_MOR_MOSCRCF_12_MHz,
+#endif
+};
+
+enum soc_pmc_mck_src {
+#if defined(PMC_MCKR_CSS_SLOW_CLK)
+	SOC_PMC_MCK_SRC_SLOW_CLK = PMC_MCKR_CSS_SLOW_CLK,
+#endif
+#if defined(PMC_MCKR_CSS_MAIN_CLK)
+	SOC_PMC_MCK_SRC_MAIN_CLK = PMC_MCKR_CSS_MAIN_CLK,
+#endif
+#if defined(PMC_MCKR_CSS_PLLA_CLK)
+	SOC_PMC_MCK_SRC_PLLA_CLK = PMC_MCKR_CSS_PLLA_CLK,
+#endif
+#if defined(PMC_MCKR_CSS_PLLB_CLK)
+	SOC_PMC_MCK_SRC_PLLB_CLK = PMC_MCKR_CSS_PLLB_CLK,
+#endif
+#if defined(PMC_MCKR_CSS_UPLL_CLK)
+	SOC_PMC_MCK_SRC_UPLL_CLK = PMC_MCKR_CSS_UPLL_CLK,
+#endif
+};
+
+/**
+ * @brief Set the prescaler of the Master clock.
+ *
+ * @param prescaler the prescaler value.
+ */
+static ALWAYS_INLINE void soc_pmc_mck_set_prescaler(uint32_t prescaler)
+{
+	uint32_t reg_val;
+
+	switch (prescaler) {
+	case 1:
+		reg_val = PMC_MCKR_PRES_CLK_1;
+		break;
+	case 2:
+		reg_val = PMC_MCKR_PRES_CLK_2;
+		break;
+	case 4:
+		reg_val = PMC_MCKR_PRES_CLK_4;
+		break;
+	case 8:
+		reg_val = PMC_MCKR_PRES_CLK_8;
+		break;
+	case 16:
+		reg_val = PMC_MCKR_PRES_CLK_16;
+		break;
+	case 32:
+		reg_val = PMC_MCKR_PRES_CLK_32;
+		break;
+	case 64:
+		reg_val = PMC_MCKR_PRES_CLK_64;
+		break;
+	case 3:
+		reg_val = PMC_MCKR_PRES_CLK_3;
+		break;
+	default:
+		__ASSERT(false, "Invalid MCK prescaler");
+		reg_val = PMC_MCKR_PRES_CLK_1;
+		break;
+	}
+
+	PMC->PMC_MCKR = (PMC->PMC_MCKR & (~PMC_MCKR_PRES_Msk)) | reg_val;
+
+	while (!(PMC->PMC_SR & PMC_SR_MCKRDY)) {
+	}
+}
+
+#if defined(CONFIG_SOC_SERIES_SAME70) || defined(CONFIG_SOC_SERIES_SAMV71)
+
+/**
+ * @brief Set the divider of the Master clock.
+ *
+ * @param divider the divider value.
+ */
+static ALWAYS_INLINE void soc_pmc_mck_set_divider(uint32_t divider)
+{
+	uint32_t reg_val;
+
+	switch (divider) {
+	case 1:
+		reg_val = PMC_MCKR_MDIV_EQ_PCK;
+		break;
+	case 2:
+		reg_val = PMC_MCKR_MDIV_PCK_DIV2;
+		break;
+	case 3:
+		reg_val = PMC_MCKR_MDIV_PCK_DIV3;
+		break;
+	case 4:
+		reg_val = PMC_MCKR_MDIV_PCK_DIV4;
+		break;
+	default:
+		__ASSERT(false, "Invalid MCK divider");
+		reg_val = PMC_MCKR_MDIV_EQ_PCK;
+		break;
+	}
+
+	PMC->PMC_MCKR = (PMC->PMC_MCKR & (~PMC_MCKR_MDIV_Msk)) | reg_val;
+
+	while (!(PMC->PMC_SR & PMC_SR_MCKRDY)) {
+	}
+}
+
+#endif /* CONFIG_SOC_SERIES_SAME70 || CONFIG_SOC_SERIES_SAMV71 */
+
+/**
+ * @brief Set the source of the Master clock.
+ *
+ * @param source the source identifier.
+ */
+static ALWAYS_INLINE void soc_pmc_mck_set_source(enum soc_pmc_mck_src source)
+{
+	PMC->PMC_MCKR = (PMC->PMC_MCKR & (~PMC_MCKR_CSS_Msk)) | (uint32_t)source;
+
+	while (!(PMC->PMC_SR & PMC_SR_MCKRDY)) {
+	}
+}
+
+/**
+ * @brief Switch main clock source selection to internal fast RC.
+ *
+ * @param freq the internal fast RC desired frequency 4/8/12MHz.
+ */
+static ALWAYS_INLINE void soc_pmc_switch_mainck_to_fastrc(enum soc_pmc_fast_rc_freq freq)
+{
+	/* Enable Fast RC oscillator but DO NOT switch to RC now */
+	PMC->CKGR_MOR |= CKGR_MOR_KEY_PASSWD | CKGR_MOR_MOSCRCEN;
+
+	/* Wait for the Fast RC to stabilize */
+	while (!(PMC->PMC_SR & PMC_SR_MOSCRCS)) {
+	}
+
+	/* Change Fast RC oscillator frequency */
+	PMC->CKGR_MOR = (PMC->CKGR_MOR & ~CKGR_MOR_MOSCRCF_Msk)
+		      | CKGR_MOR_KEY_PASSWD
+		      | (uint32_t)freq;
+
+	/* Wait for the Fast RC to stabilize */
+	while (!(PMC->PMC_SR & PMC_SR_MOSCRCS)) {
+	}
+
+	/* Switch to Fast RC */
+	PMC->CKGR_MOR = (PMC->CKGR_MOR & ~CKGR_MOR_MOSCSEL)
+		      | CKGR_MOR_KEY_PASSWD;
+}
+
+/**
+ * @brief Enable internal fast RC oscillator.
+ *
+ * @param freq the internal fast RC desired frequency 4/8/12MHz.
+ */
+static ALWAYS_INLINE void soc_pmc_osc_enable_fastrc(enum soc_pmc_fast_rc_freq freq)
+{
+	/* Enable Fast RC oscillator but DO NOT switch to RC */
+	PMC->CKGR_MOR |= CKGR_MOR_KEY_PASSWD | CKGR_MOR_MOSCRCEN;
+
+	/* Wait for the Fast RC to stabilize */
+	while (!(PMC->PMC_SR & PMC_SR_MOSCRCS)) {
+	}
+
+	/* Change Fast RC oscillator frequency */
+	PMC->CKGR_MOR = (PMC->CKGR_MOR & ~CKGR_MOR_MOSCRCF_Msk)
+		      | CKGR_MOR_KEY_PASSWD
+		      | (uint32_t)freq;
+
+	/* Wait for the Fast RC to stabilize */
+	while (!(PMC->PMC_SR & PMC_SR_MOSCRCS)) {
+	}
+}
+
+/**
+ * @brief Disable internal fast RC oscillator.
+ */
+static ALWAYS_INLINE void soc_pmc_osc_disable_fastrc(void)
+{
+	/* Disable Fast RC oscillator */
+	PMC->CKGR_MOR = (PMC->CKGR_MOR & ~CKGR_MOR_MOSCRCEN & ~CKGR_MOR_MOSCRCF_Msk)
+		      | CKGR_MOR_KEY_PASSWD;
+}
+
+/**
+ * @brief Check if the internal fast RC is ready.
+ *
+ * @return true if internal fast RC is ready, false otherwise
+ */
+static ALWAYS_INLINE bool soc_pmc_osc_is_ready_fastrc(void)
+{
+	return (PMC->PMC_SR & PMC_SR_MOSCRCS);
+}
+
+/**
+ * @brief Enable the external crystal oscillator.
+ *
+ * @param xtal_startup_time crystal start-up time, in number of slow clocks.
+ */
+static ALWAYS_INLINE void soc_pmc_osc_enable_main_xtal(uint32_t xtal_startup_time)
+{
+	uint32_t mor = PMC->CKGR_MOR;
+
+	mor &= ~(CKGR_MOR_MOSCXTBY | CKGR_MOR_MOSCXTEN);
+	mor |= CKGR_MOR_KEY_PASSWD | CKGR_MOR_MOSCXTEN | CKGR_MOR_MOSCXTST(xtal_startup_time);
+
+	PMC->CKGR_MOR = mor;
+
+	/* Wait the main Xtal to stabilize */
+	while (!(PMC->PMC_SR & PMC_SR_MOSCXTS)) {
+	}
+}
+
+/**
+ * @brief Bypass the external crystal oscillator.
+ */
+static ALWAYS_INLINE void soc_pmc_osc_bypass_main_xtal(void)
+{
+	uint32_t mor = PMC->CKGR_MOR;
+
+	mor &= ~(CKGR_MOR_MOSCXTBY | CKGR_MOR_MOSCXTEN);
+	mor |= CKGR_MOR_KEY_PASSWD | CKGR_MOR_MOSCXTBY;
+
+	/* Enable Crystal oscillator but DO NOT switch now. Keep MOSCSEL to 0 */
+	PMC->CKGR_MOR = mor;
+	/* The MOSCXTS in PMC_SR is automatically set */
+}
+
+/**
+ * @brief Disable the external crystal oscillator.
+ */
+static ALWAYS_INLINE void soc_pmc_osc_disable_main_xtal(void)
+{
+	uint32_t mor = PMC->CKGR_MOR;
+
+	mor &= ~(CKGR_MOR_MOSCXTBY | CKGR_MOR_MOSCXTEN);
+
+	PMC->CKGR_MOR = CKGR_MOR_KEY_PASSWD | mor;
+}
+
+/**
+ * @brief Check if the external crystal oscillator is bypassed.
+ *
+ * @return true if external crystal oscillator is bypassed, false otherwise
+ */
+static ALWAYS_INLINE bool soc_pmc_osc_is_bypassed_main_xtal(void)
+{
+	return (PMC->CKGR_MOR & CKGR_MOR_MOSCXTBY);
+}
+
+/**
+ * @brief Check if the external crystal oscillator is ready.
+ *
+ * @return true if external crystal oscillator is ready, false otherwise
+ */
+static ALWAYS_INLINE bool soc_pmc_osc_is_ready_main_xtal(void)
+{
+	return (PMC->PMC_SR & PMC_SR_MOSCXTS);
+}
+
+/**
+ * @brief Switch main clock source selection to external crystal oscillator.
+ *
+ * @param bypass select bypass or xtal
+ * @param xtal_startup_time crystal start-up time, in number of slow clocks
+ */
+static ALWAYS_INLINE void soc_pmc_switch_mainck_to_xtal(bool bypass, uint32_t xtal_startup_time)
+{
+	soc_pmc_osc_enable_main_xtal(xtal_startup_time);
+
+	/* Enable Main Xtal oscillator */
+	if (bypass) {
+		PMC->CKGR_MOR = (PMC->CKGR_MOR & ~CKGR_MOR_MOSCXTEN)
+			      | CKGR_MOR_KEY_PASSWD
+			      | CKGR_MOR_MOSCXTBY
+			      | CKGR_MOR_MOSCSEL;
+	} else {
+		PMC->CKGR_MOR = (PMC->CKGR_MOR & ~CKGR_MOR_MOSCXTBY)
+			      | CKGR_MOR_KEY_PASSWD
+			      | CKGR_MOR_MOSCXTEN
+			      | CKGR_MOR_MOSCXTST(xtal_startup_time);
+
+		/* Wait for the Xtal to stabilize */
+		while (!(PMC->PMC_SR & PMC_SR_MOSCXTS)) {
+		}
+
+		PMC->CKGR_MOR |= CKGR_MOR_KEY_PASSWD | CKGR_MOR_MOSCSEL;
+	}
+}
+
+/**
+ * @brief Disable the external crystal oscillator.
+ *
+ * @param bypass select bypass or xtal
+ */
+static ALWAYS_INLINE void soc_pmc_osc_disable_xtal(bool bypass)
+{
+	/* Disable xtal oscillator */
+	if (bypass) {
+		PMC->CKGR_MOR = (PMC->CKGR_MOR & ~CKGR_MOR_MOSCXTBY)
+			      | CKGR_MOR_KEY_PASSWD;
+	} else {
+		PMC->CKGR_MOR = (PMC->CKGR_MOR & ~CKGR_MOR_MOSCXTEN)
+			      | CKGR_MOR_KEY_PASSWD;
+	}
+}
+
+/**
+ * @brief Check if the main clock is ready. Depending on MOSCEL, main clock can be one
+ * of external crystal, bypass or internal RC.
+ *
+ * @return true if main clock is ready, false otherwise
+ */
+static ALWAYS_INLINE bool soc_pmc_osc_is_ready_mainck(void)
+{
+	return PMC->PMC_SR & PMC_SR_MOSCSELS;
+}
+
+/**
+ * @brief Enable Wait Mode.
+ */
+static ALWAYS_INLINE void soc_pmc_enable_waitmode(void)
+{
+	PMC->PMC_FSMR |= PMC_FSMR_LPM;
+}
+
+/**
+ * @brief Enable Clock Failure Detector.
+ */
+static ALWAYS_INLINE void soc_pmc_enable_clock_failure_detector(void)
+{
+	uint32_t mor = PMC->CKGR_MOR;
+
+	PMC->CKGR_MOR = CKGR_MOR_KEY_PASSWD | CKGR_MOR_CFDEN | mor;
+}
+
+/**
+ * @brief Disable Clock Failure Detector.
+ */
+static ALWAYS_INLINE void soc_pmc_disable_clock_failure_detector(void)
+{
+	uint32_t mor = PMC->CKGR_MOR & (~CKGR_MOR_CFDEN);
+
+	PMC->CKGR_MOR = CKGR_MOR_KEY_PASSWD | mor;
+}
+
+#if defined(PMC_MCKR_CSS_PLLA_CLK)
+
+/**
+ * @brief Disable the PLLA clock.
+ */
+static ALWAYS_INLINE void soc_pmc_disable_pllack(void)
+{
+	PMC->CKGR_PLLAR = CKGR_PLLAR_ONE | CKGR_PLLAR_MULA(0);
+}
+
+/**
+ * @brief Enable the PLLA clock.
+ *
+ * @param mula PLLA multiplier
+ * @param pllacount PLLA lock counter, in number of slow clocks
+ * @param diva PLLA Divider
+ */
+static ALWAYS_INLINE void soc_pmc_enable_pllack(uint32_t mula, uint32_t pllacount, uint32_t diva)
+{
+	__ASSERT(diva > 0, "Invalid PLLA divider");
+
+	/* first disable the PLL to unlock the lock */
+	soc_pmc_disable_pllack();
+
+	PMC->CKGR_PLLAR = CKGR_PLLAR_ONE
+			| CKGR_PLLAR_DIVA(diva)
+			| CKGR_PLLAR_PLLACOUNT(pllacount)
+			| CKGR_PLLAR_MULA(mula);
+
+	while ((PMC->PMC_SR & PMC_SR_LOCKA) == 0) {
+	}
+}
+
+/**
+ * @brief Check if the PLLA is locked.
+ *
+ * @return true if PLLA is locked, false otherwise
+ */
+static ALWAYS_INLINE bool soc_pmc_is_locked_pllack(void)
+{
+	return (PMC->PMC_SR & PMC_SR_LOCKA);
+}
+
+#endif /* PMC_MCKR_CSS_PLLA_CLK */
+
+#if defined(PMC_MCKR_CSS_PLLB_CLK)
+
+/**
+ * @brief Disable the PLLB clock.
+ */
+static ALWAYS_INLINE void soc_pmc_disable_pllbck(void)
+{
+	PMC->CKGR_PLLBR = CKGR_PLLBR_MULB(0);
+}
+
+/**
+ * @brief Enable the PLLB clock.
+ *
+ * @param mulb PLLB multiplier
+ * @param pllbcount PLLB lock counter, in number of slow clocks
+ * @param divb PLLB Divider
+ */
+static ALWAYS_INLINE void soc_pmc_enable_pllbck(uint32_t mulb, uint32_t pllbcount, uint32_t divb)
+{
+	__ASSERT(divb > 0, "Invalid PLLB divider");
+
+	/* first disable the PLL to unlock the lock */
+	soc_pmc_disable_pllbck();
+
+	PMC->CKGR_PLLBR = CKGR_PLLBR_DIVB(divb)
+			| CKGR_PLLBR_PLLBCOUNT(pllbcount)
+			| CKGR_PLLBR_MULB(mulb);
+
+	while ((PMC->PMC_SR & PMC_SR_LOCKB) == 0) {
+	}
+}
+
+/**
+ * @brief Check if the PLLB is locked.
+ *
+ * @return true if PLLB is locked, false otherwise
+ */
+static ALWAYS_INLINE bool soc_pmc_is_locked_pllbck(void)
+{
+	return (PMC->PMC_SR & PMC_SR_LOCKB);
+}
+
+#endif /* PMC_MCKR_CSS_PLLB_CLK */
+
+#if defined(PMC_MCKR_CSS_UPLL_CLK)
+
+/**
+ * @brief Enable the UPLL clock.
+ */
+static ALWAYS_INLINE void soc_pmc_enable_upllck(uint32_t upllcount)
+{
+	PMC->CKGR_UCKR = CKGR_UCKR_UPLLCOUNT(upllcount)
+		       | CKGR_UCKR_UPLLEN;
+
+	/* Wait UTMI PLL Lock Status */
+	while (!(PMC->PMC_SR & PMC_SR_LOCKU)) {
+	}
+}
+
+/**
+ * @brief Disable the UPLL clock.
+ */
+static ALWAYS_INLINE void soc_pmc_disable_upllck(void)
+{
+	PMC->CKGR_UCKR &= ~CKGR_UCKR_UPLLEN;
+}
+
+/**
+ * @brief Check if the UPLL is locked.
+ *
+ * @return true if UPLL is locked, false otherwise
+ */
+static ALWAYS_INLINE bool soc_pmc_is_locked_upllck(void)
+{
+	return (PMC->PMC_SR & PMC_SR_LOCKU);
+}
+
+#endif /* PMC_MCKR_CSS_UPLL_CLK */
+
+#endif /* !CONFIG_SOC_SERIES_SAM4L */
 
 #endif /* _ATMEL_SAM_SOC_PMC_H_ */

--- a/soc/arm/atmel_sam/sam3x/soc.c
+++ b/soc/arm/atmel_sam/sam3x/soc.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2013-2015 Wind River Systems, Inc.
  * Copyright (c) 2016 Intel Corporation.
  * Copyright (c) 2023 Gerson Fernando Budke <nandojve@gmail.com>
+ * Copyright (c) 2023 Basalte bv
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -14,25 +15,9 @@
  * for the Atmel SAM3X series processor.
  */
 
-#include <zephyr/kernel.h>
-#include <zephyr/device.h>
-#include <zephyr/init.h>
 #include <soc.h>
-
-/*
- * PLL clock = Main * (MULA + 1) / DIVA
- *
- * By default, MULA == 6, DIVA == 1.
- * With main crystal running at 12 MHz,
- * PLL = 12 * (6 + 1) / 1 = 84 MHz
- *
- * With Processor Clock prescaler at 1
- * Processor Clock (HCLK) = 84 MHz.
- */
-#define PMC_CKGR_PLLAR_MULA	\
-	(CKGR_PLLAR_MULA(CONFIG_SOC_ATMEL_SAM3X_PLLA_MULA))
-#define PMC_CKGR_PLLAR_DIVA	\
-	(CKGR_PLLAR_DIVA(CONFIG_SOC_ATMEL_SAM3X_PLLA_DIVA))
+#include <soc_pmc.h>
+#include <soc_supc.h>
 
 /**
  * @brief Setup various clocks on SoC at boot time.
@@ -42,158 +27,34 @@
  */
 static ALWAYS_INLINE void clock_init(void)
 {
-	uint32_t reg_val;
+	/* Switch the main clock to the internal OSC with 12MHz */
+	soc_pmc_switch_mainck_to_fastrc(SOC_PMC_FAST_RC_FREQ_12MHZ);
 
-#ifdef CONFIG_SOC_ATMEL_SAM3X_EXT_SLCK
-	/* Switch slow clock to the external 32 kHz crystal oscillator */
-	SUPC->SUPC_CR = SUPC_CR_KEY_PASSWD | SUPC_CR_XTALSEL;
+	/* Switch MCK (Master Clock) to the main clock */
+	soc_pmc_mck_set_source(SOC_PMC_MCK_SRC_MAIN_CLK);
 
-	/* Wait for oscillator to be stabilized */
-	while (!(SUPC->SUPC_SR & SUPC_SR_OSCSEL)) {
-		;
-	}
-#endif /* CONFIG_SOC_ATMEL_SAM3X_EXT_SLCK */
+	EFC0->EEFC_FMR = EEFC_FMR_FWS(0);
+	EFC1->EEFC_FMR = EEFC_FMR_FWS(0);
 
-#ifdef CONFIG_SOC_ATMEL_SAM3X_EXT_MAINCK
-	/*
-	 * Setup main external crystal oscillator
-	 */
+	soc_pmc_enable_clock_failure_detector();
 
-	/* Start the external crystal oscillator */
-	PMC->CKGR_MOR =   CKGR_MOR_KEY_PASSWD
-			/* Fast RC Oscillator Frequency is at 4 MHz (default) */
-			| CKGR_MOR_MOSCRCF_4_MHz
-			/* We select maximum setup time. While start up time
-			 * could be shortened this optimization is not deemed
-			 * critical now.
-			 */
-			| CKGR_MOR_MOSCXTST(0xFFu)
-			/* RC OSC must stay on */
-			| CKGR_MOR_MOSCRCEN
-			| CKGR_MOR_MOSCXTEN;
-
-	/* Wait for oscillator to be stabilized */
-	while (!(PMC->PMC_SR & PMC_SR_MOSCXTS)) {
-		;
+	if (IS_ENABLED(CONFIG_SOC_ATMEL_SAM3X_EXT_SLCK)) {
+		soc_supc_slow_clock_select_crystal_osc();
 	}
 
-	/* Select the external crystal oscillator as the main clock source */
-	PMC->CKGR_MOR =   CKGR_MOR_KEY_PASSWD
-			| CKGR_MOR_MOSCRCF_4_MHz
-			| CKGR_MOR_MOSCSEL
-			| CKGR_MOR_MOSCXTST(0xFFu)
-			| CKGR_MOR_MOSCRCEN
-			| CKGR_MOR_MOSCXTEN;
+	if (IS_ENABLED(CONFIG_SOC_ATMEL_SAM3X_EXT_MAINCK)) {
+		/*
+		 * Setup main external crystal oscillator.
+		 */
 
-	/* Wait for external oscillator to be selected */
-	while (!(PMC->PMC_SR & PMC_SR_MOSCSELS)) {
-		;
+		/* We select maximum setup time.
+		 * While start up time could be shortened
+		 * this optimization is not deemed
+		 * critical now.
+		 */
+		soc_pmc_switch_mainck_to_xtal(false, 0xff);
 	}
 
-	/* Turn off RC OSC, not used any longer, to save power */
-	PMC->CKGR_MOR =   CKGR_MOR_KEY_PASSWD
-			| CKGR_MOR_MOSCSEL
-			| CKGR_MOR_MOSCXTST(0xFFu)
-			| CKGR_MOR_MOSCXTEN;
-
-	/* Wait for RC OSC to be turned off */
-	while (PMC->PMC_SR & PMC_SR_MOSCRCS) {
-		;
-	}
-
-#ifdef CONFIG_SOC_ATMEL_SAM3X_WAIT_MODE
-	/*
-	 * Instruct CPU to enter Wait mode instead of Sleep mode to
-	 * keep Processor Clock (HCLK) and thus be able to debug
-	 * CPU using JTAG
-	 */
-	PMC->PMC_FSMR |= PMC_FSMR_LPM;
-#endif
-#else
-	/*
-	 * Setup main fast RC oscillator
-	 */
-
-	/*
-	 * NOTE: MOSCRCF must be changed only if MOSCRCS is set in the PMC_SR
-	 * register, should normally be the case here
-	 */
-	while (!(PMC->PMC_SR & PMC_SR_MOSCRCS)) {
-		;
-	}
-
-	/* Set main fast RC oscillator to 12 MHz */
-	PMC->CKGR_MOR =   CKGR_MOR_KEY_PASSWD
-			| CKGR_MOR_MOSCRCF_12_MHz
-			| CKGR_MOR_MOSCRCEN;
-
-	/* Wait for oscillator to be stabilized */
-	while (!(PMC->PMC_SR & PMC_SR_MOSCRCS)) {
-		;
-	}
-#endif /* CONFIG_SOC_ATMEL_SAM3X_EXT_MAINCK */
-
-	/*
-	 * Setup PLLA
-	 */
-
-	/* Switch MCK (Master Clock) to the main clock first */
-	reg_val = PMC->PMC_MCKR & ~PMC_MCKR_CSS_Msk;
-	PMC->PMC_MCKR = reg_val | PMC_MCKR_CSS_MAIN_CLK;
-
-	/* Wait for clock selection to complete */
-	while (!(PMC->PMC_SR & PMC_SR_MCKRDY)) {
-		;
-	}
-
-	/* Setup PLLA */
-	PMC->CKGR_PLLAR =   CKGR_PLLAR_ONE
-			  | PMC_CKGR_PLLAR_MULA
-			  | CKGR_PLLAR_PLLACOUNT(0x3Fu)
-			  | PMC_CKGR_PLLAR_DIVA;
-
-	/*
-	 * NOTE: Both MULA and DIVA must be set to a value greater than 0 or
-	 * otherwise PLL will be disabled. In this case we would get stuck in
-	 * the following loop.
-	 */
-
-	/* Wait for PLL lock */
-	while (!(PMC->PMC_SR & PMC_SR_LOCKA)) {
-		;
-	}
-
-	/*
-	 * Final setup of the Master Clock
-	 */
-
-	/*
-	 * NOTE: PMC_MCKR must not be programmed in a single write operation.
-	 * If CSS or PRES are modified we must wait for MCKRDY bit to be
-	 * set again.
-	 */
-
-	/* Setup prescaler - PLLA Clock / Processor Clock (HCLK) */
-	reg_val = PMC->PMC_MCKR & ~PMC_MCKR_PRES_Msk;
-	PMC->PMC_MCKR = reg_val | PMC_MCKR_PRES_CLK_1;
-
-	/* Wait for Master Clock setup to complete */
-	while (!(PMC->PMC_SR & PMC_SR_MCKRDY)) {
-		;
-	}
-
-	/* Finally select PLL as Master Clock source */
-	reg_val = PMC->PMC_MCKR & ~PMC_MCKR_CSS_Msk;
-	PMC->PMC_MCKR = reg_val | PMC_MCKR_CSS_PLLA_CLK;
-
-	/* Wait for Master Clock setup to complete */
-	while (!(PMC->PMC_SR & PMC_SR_MCKRDY)) {
-		;
-	}
-}
-
-void z_arm_platform_init(void)
-{
 	/*
 	 * Set FWS (Flash Wait State) value before increasing Master Clock
 	 * (MCK) frequency.
@@ -203,6 +64,49 @@ void z_arm_platform_init(void)
 	EFC0->EEFC_FMR = EEFC_FMR_FWS(4);
 	EFC1->EEFC_FMR = EEFC_FMR_FWS(4);
 
+	/*
+	 * Setup PLLA
+	 */
+
+	/*
+	 * PLL clock = Main * (MULA + 1) / DIVA
+	 *
+	 * By default, MULA == 6, DIVA == 1.
+	 * With main crystal running at 12 MHz,
+	 * PLL = 12 * (6 + 1) / 1 = 84 MHz
+	 *
+	 * With Processor Clock prescaler at 1
+	 * Processor Clock (HCLK) = 84 MHz.
+	 */
+	soc_pmc_enable_pllack(CONFIG_SOC_ATMEL_SAM3X_PLLA_MULA, 0x3Fu,
+			      CONFIG_SOC_ATMEL_SAM3X_PLLA_DIVA);
+
+	/*
+	 * Final setup of the Master Clock
+	 */
+
+	/* prescaler has to be set before PLL lock */
+	soc_pmc_mck_set_prescaler(1);
+
+	/* Select PLL as Master Clock source. */
+	soc_pmc_mck_set_source(SOC_PMC_MCK_SRC_PLLA_CLK);
+
+	/* Disable internal fast RC if we have an external crystal oscillator */
+	if (IS_ENABLED(CONFIG_SOC_ATMEL_SAM3X_EXT_MAINCK)) {
+		soc_pmc_osc_disable_fastrc();
+	}
+}
+
+void z_arm_platform_init(void)
+{
+	if (IS_ENABLED(CONFIG_SOC_ATMEL_SAM3X_WAIT_MODE)) {
+		/*
+		 * Instruct CPU to enter Wait mode instead of Sleep mode to
+		 * keep Processor Clock (HCLK) and thus be able to debug
+		 * CPU using JTAG.
+		 */
+		soc_pmc_enable_waitmode();
+	}
 	/* Setup system clocks */
 	clock_init();
 }

--- a/soc/arm/atmel_sam/sam4e/soc.c
+++ b/soc/arm/atmel_sam/sam4e/soc.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2016 Intel Corporation.
  * Copyright (c) 2017 Justin Watson
  * Copyright (c) 2019-2023 Gerson Fernando Budke <nandojve@gmail.com>
+ * Copyright (c) 2023 Basalte bv
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -15,9 +16,9 @@
  * for the Atmel SAM4E series processor.
  */
 
-#include <zephyr/device.h>
-#include <zephyr/init.h>
 #include <soc.h>
+#include <soc_pmc.h>
+#include <soc_supc.h>
 
 /**
  * @brief Setup various clock on SoC at boot time.
@@ -29,158 +30,33 @@
  */
 static ALWAYS_INLINE void clock_init(void)
 {
-	uint32_t reg_val;
+	/* Switch the main clock to the internal OSC with 12MHz */
+	soc_pmc_switch_mainck_to_fastrc(SOC_PMC_FAST_RC_FREQ_12MHZ);
 
-#ifdef CONFIG_SOC_ATMEL_SAM4E_EXT_SLCK
-	/* Switch slow clock to the external 32 KHz crystal oscillator. */
-	SUPC->SUPC_CR = SUPC_CR_KEY_PASSWD | SUPC_CR_XTALSEL_CRYSTAL_SEL;
+	/* Switch MCK (Master Clock) to the main clock */
+	soc_pmc_mck_set_source(SOC_PMC_MCK_SRC_MAIN_CLK);
 
-	/* Wait for oscillator to be stabilized. */
-	while (!(SUPC->SUPC_SR & SUPC_SR_OSCSEL)) {
-		;
+	EFC->EEFC_FMR = EEFC_FMR_FWS(0);
+
+	soc_pmc_enable_clock_failure_detector();
+
+	if (IS_ENABLED(CONFIG_SOC_ATMEL_SAM4E_EXT_SLCK)) {
+		soc_supc_slow_clock_select_crystal_osc();
 	}
 
-#endif /* CONFIG_SOC_ATMEL_SAM4E_EXT_SLCK */
+	if (IS_ENABLED(CONFIG_SOC_ATMEL_SAM4E_EXT_MAINCK)) {
+		/*
+		 * Setup main external crystal oscillator.
+		 */
 
-#ifdef CONFIG_SOC_ATMEL_SAM4E_EXT_MAINCK
-	/*
-	 * Setup main external crystal oscillator.
-	 */
-
-	/* Start the external crystal oscillator. */
-	PMC->CKGR_MOR = CKGR_MOR_KEY_PASSWD
-			/* Fast RC oscillator frequency is at 4 MHz. */
-			| CKGR_MOR_MOSCRCF_4_MHz
-			/*
-			 * We select maximum setup time. While start up time
-			 * could be shortened this optimization is not deemed
-			 * critical right now.
-			 */
-			| CKGR_MOR_MOSCXTST(0xFFu)
-			/* RC oscillator must stay on. */
-			| CKGR_MOR_MOSCRCEN
-			| CKGR_MOR_MOSCXTEN;
-
-	/* Wait for oscillator to be stabilized. */
-	while (!(PMC->PMC_SR & PMC_SR_MOSCXTS)) {
-		;
+		/* We select maximum setup time.
+		 * While start up time could be shortened
+		 * this optimization is not deemed
+		 * critical now.
+		 */
+		soc_pmc_switch_mainck_to_xtal(false, 0xff);
 	}
 
-	/* Select the external crystal oscillator as the main clock source. */
-	PMC->CKGR_MOR = CKGR_MOR_KEY_PASSWD
-			| CKGR_MOR_MOSCRCF_4_MHz
-			| CKGR_MOR_MOSCRCEN
-			| CKGR_MOR_MOSCXTEN
-			| CKGR_MOR_MOSCXTST(0xFFu)
-			| CKGR_MOR_MOSCSEL;
-
-	/* Wait for external oscillator to be selected. */
-	while (!(PMC->PMC_SR & PMC_SR_MOSCSELS)) {
-		;
-	}
-
-	/* Turn off RC oscillator, not used any longer, to save power */
-	PMC->CKGR_MOR = CKGR_MOR_KEY_PASSWD
-			| CKGR_MOR_MOSCSEL
-			| CKGR_MOR_MOSCXTST(0xFFu)
-			| CKGR_MOR_MOSCXTEN;
-
-	/* Wait for the RC oscillator to be turned off. */
-	while (PMC->PMC_SR & PMC_SR_MOSCRCS) {
-		;
-	}
-
-#ifdef CONFIG_SOC_ATMEL_SAM4E_WAIT_MODE
-	/*
-	 * Instruct CPU to enter Wait mode instead of Sleep mode to
-	 * keep Processor Clock (HCLK) and thus be able to debug
-	 * CPU using JTAG.
-	 */
-	PMC->PMC_FSMR |= PMC_FSMR_LPM;
-#endif
-#else
-	/* Setup main fast RC oscillator. */
-
-	/*
-	 * NOTE: MOSCRCF must be changed only if MOSCRCS is set in the PMC_SR
-	 * register, should normally be the case.
-	 */
-	while (!(PMC->PMC_SR & PMC_SR_MOSCRCS)) {
-		;
-	}
-
-	/* Set main fast RC oscillator to 12 MHz. */
-	PMC->CKGR_MOR = CKGR_MOR_KEY_PASSWD
-			| CKGR_MOR_MOSCRCF_12_MHz
-			| CKGR_MOR_MOSCRCEN;
-
-	/* Wait for RC oscillator to stabilize. */
-	while (!(PMC->PMC_SR & PMC_SR_MOSCRCS)) {
-		;
-	}
-#endif /* CONFIG_SOC_ATMEL_SAM4E_EXT_MAINCK */
-
-	/*
-	 * Setup PLLA
-	 */
-
-	/* Switch MCK (Master Clock) to the main clock first. */
-	reg_val = PMC->PMC_MCKR & ~PMC_MCKR_CSS_Msk;
-	PMC->PMC_MCKR = reg_val | PMC_MCKR_CSS_MAIN_CLK;
-
-	/* Wait for clock selection to complete. */
-	while (!(PMC->PMC_SR & PMC_SR_MCKRDY)) {
-		;
-	}
-
-	/* Setup PLLA. */
-	PMC->CKGR_PLLAR = CKGR_PLLAR_ONE
-			  | CKGR_PLLAR_MULA(CONFIG_SOC_ATMEL_SAM4E_PLLA_MULA)
-			  | CKGR_PLLAR_PLLACOUNT(0x3Fu)
-			  | CKGR_PLLAR_DIVA(CONFIG_SOC_ATMEL_SAM4E_PLLA_DIVA);
-
-	/*
-	 * NOTE: Both MULA and DIVA must be set to a value greater than 0 or
-	 * otherwise PLL will be disabled. In this case we would get stuck in
-	 * the following loop.
-	 */
-
-	/* Wait for PLL lock. */
-	while (!(PMC->PMC_SR & PMC_SR_LOCKA)) {
-		;
-	}
-
-	/*
-	 * Final setup of the Master Clock
-	 */
-
-	/*
-	 * NOTE: PMC_MCKR must not be programmed in a single write operation.
-	 * If CSS or PRES are modified we must wait for MCKRDY bit to be
-	 * set again.
-	 */
-
-	/* Setup prescaler - PLLA Clock / Processor Clock (HCLK). */
-	reg_val = PMC->PMC_MCKR & ~PMC_MCKR_PRES_Msk;
-	PMC->PMC_MCKR = reg_val | PMC_MCKR_PRES_CLK_1;
-
-	/* Wait for Master Clock setup to complete */
-	while (!(PMC->PMC_SR & PMC_SR_MCKRDY)) {
-		;
-	}
-
-	/* Finally select PLL as Master Clock source. */
-	reg_val = PMC->PMC_MCKR & ~PMC_MCKR_CSS_Msk;
-	PMC->PMC_MCKR = reg_val | PMC_MCKR_CSS_PLLA_CLK;
-
-	/* Wait for Master Clock setup to complete. */
-	while (!(PMC->PMC_SR & PMC_SR_MCKRDY)) {
-		;
-	}
-}
-
-void z_arm_platform_init(void)
-{
 	/*
 	 * Set FWS (Flash Wait State) value before increasing Master Clock
 	 * (MCK) frequency. Look at table 44.73 in the SAM4E datasheet.
@@ -191,6 +67,38 @@ void z_arm_platform_init(void)
 	 */
 	EFC->EEFC_FMR = EEFC_FMR_FWS(5);
 
+	/*
+	 * Setup PLLA
+	 */
+	soc_pmc_enable_pllack(CONFIG_SOC_ATMEL_SAM4E_PLLA_MULA, 0x3Fu,
+			      CONFIG_SOC_ATMEL_SAM4E_PLLA_DIVA);
+
+	/*
+	 * Final setup of the Master Clock
+	 */
+
+	/* prescaler has to be set before PLL lock */
+	soc_pmc_mck_set_prescaler(1);
+
+	/* Select PLL as Master Clock source. */
+	soc_pmc_mck_set_source(SOC_PMC_MCK_SRC_PLLA_CLK);
+
+	/* Disable internal fast RC if we have an external crystal oscillator */
+	if (IS_ENABLED(CONFIG_SOC_ATMEL_SAM4E_EXT_MAINCK)) {
+		soc_pmc_osc_disable_fastrc();
+	}
+}
+
+void z_arm_platform_init(void)
+{
+	if (IS_ENABLED(CONFIG_SOC_ATMEL_SAM4E_WAIT_MODE)) {
+		/*
+		 * Instruct CPU to enter Wait mode instead of Sleep mode to
+		 * keep Processor Clock (HCLK) and thus be able to debug
+		 * CPU using JTAG.
+		 */
+		soc_pmc_enable_waitmode();
+	}
 	/* Setup system clocks. */
 	clock_init();
 }

--- a/soc/arm/atmel_sam/sam4s/soc.c
+++ b/soc/arm/atmel_sam/sam4s/soc.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2016 Intel Corporation.
  * Copyright (c) 2017 Justin Watson
  * Copyright (c) 2023 Gerson Fernando Budke <nandojve@gmail.com>
+ * Copyright (c) 2023 Basalte bv
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -15,9 +16,9 @@
  * for the Atmel SAM4S series processor.
  */
 
-#include <zephyr/device.h>
-#include <zephyr/init.h>
 #include <soc.h>
+#include <soc_pmc.h>
+#include <soc_supc.h>
 
 /**
  * @brief Setup various clock on SoC at boot time.
@@ -29,158 +30,36 @@
  */
 static ALWAYS_INLINE void clock_init(void)
 {
-	uint32_t reg_val;
+	/* Switch the main clock to the internal OSC with 12MHz */
+	soc_pmc_switch_mainck_to_fastrc(SOC_PMC_FAST_RC_FREQ_12MHZ);
 
-#ifdef CONFIG_SOC_ATMEL_SAM4S_EXT_SLCK
-	/* Switch slow clock to the external 32 KHz crystal oscillator. */
-	SUPC->SUPC_CR = SUPC_CR_KEY_PASSWD | SUPC_CR_XTALSEL_CRYSTAL_SEL;
+	/* Switch MCK (Master Clock) to the main clock */
+	soc_pmc_mck_set_source(SOC_PMC_MCK_SRC_MAIN_CLK);
 
-	/* Wait for oscillator to be stabilized. */
-	while (!(SUPC->SUPC_SR & SUPC_SR_OSCSEL)) {
-		;
-	}
-
-#endif /* CONFIG_SOC_ATMEL_SAM4S_EXT_SLCK */
-
-#ifdef CONFIG_SOC_ATMEL_SAM4S_EXT_MAINCK
-	/*
-	 * Setup main external crystal oscillator.
-	 */
-
-	/* Start the external crystal oscillator. */
-	PMC->CKGR_MOR = CKGR_MOR_KEY_PASSWD
-			/* Fast RC oscillator frequency is at 4 MHz. */
-			| CKGR_MOR_MOSCRCF_4_MHz
-			/*
-			 * We select maximum setup time. While start up time
-			 * could be shortened this optimization is not deemed
-			 * critical right now.
-			 */
-			| CKGR_MOR_MOSCXTST(0xFFu)
-			/* RC oscillator must stay on. */
-			| CKGR_MOR_MOSCRCEN
-			| CKGR_MOR_MOSCXTEN;
-
-	/* Wait for oscillator to be stabilized. */
-	while (!(PMC->PMC_SR & PMC_SR_MOSCXTS)) {
-		;
-	}
-
-	/* Select the external crystal oscillator as the main clock source. */
-	PMC->CKGR_MOR = CKGR_MOR_KEY_PASSWD
-			| CKGR_MOR_MOSCRCF_4_MHz
-			| CKGR_MOR_MOSCRCEN
-			| CKGR_MOR_MOSCXTEN
-			| CKGR_MOR_MOSCXTST(0xFFu)
-			| CKGR_MOR_MOSCSEL;
-
-	/* Wait for external oscillator to be selected. */
-	while (!(PMC->PMC_SR & PMC_SR_MOSCSELS)) {
-		;
-	}
-
-	/* Turn off RC oscillator, not used any longer, to save power */
-	PMC->CKGR_MOR = CKGR_MOR_KEY_PASSWD
-			| CKGR_MOR_MOSCSEL
-			| CKGR_MOR_MOSCXTST(0xFFu)
-			| CKGR_MOR_MOSCXTEN;
-
-	/* Wait for the RC oscillator to be turned off. */
-	while (PMC->PMC_SR & PMC_SR_MOSCRCS) {
-		;
-	}
-
-#ifdef CONFIG_SOC_ATMEL_SAM4S_WAIT_MODE
-	/*
-	 * Instruct CPU to enter Wait mode instead of Sleep mode to
-	 * keep Processor Clock (HCLK) and thus be able to debug
-	 * CPU using JTAG.
-	 */
-	PMC->PMC_FSMR |= PMC_FSMR_LPM;
+	EFC0->EEFC_FMR = EEFC_FMR_FWS(0);
+#if defined(ID_EFC1)
+	EFC1->EEFC_FMR = EEFC_FMR_FWS(0);
 #endif
-#else
-	/* Setup main fast RC oscillator. */
 
-	/*
-	 * NOTE: MOSCRCF must be changed only if MOSCRCS is set in the PMC_SR
-	 * register, should normally be the case.
-	 */
-	while (!(PMC->PMC_SR & PMC_SR_MOSCRCS)) {
-		;
+	soc_pmc_enable_clock_failure_detector();
+
+	if (IS_ENABLED(CONFIG_SOC_ATMEL_SAM4S_EXT_SLCK)) {
+		soc_supc_slow_clock_select_crystal_osc();
 	}
 
-	/* Set main fast RC oscillator to 12 MHz. */
-	PMC->CKGR_MOR = CKGR_MOR_KEY_PASSWD
-			| CKGR_MOR_MOSCRCF_12_MHz
-			| CKGR_MOR_MOSCRCEN;
+	if (IS_ENABLED(CONFIG_SOC_ATMEL_SAM4S_EXT_MAINCK)) {
+		/*
+		 * Setup main external crystal oscillator.
+		 */
 
-	/* Wait for RC oscillator to stabilize. */
-	while (!(PMC->PMC_SR & PMC_SR_MOSCRCS)) {
-		;
-	}
-#endif /* CONFIG_SOC_ATMEL_SAM4S_EXT_MAINCK */
-
-	/*
-	 * Setup PLLA
-	 */
-
-	/* Switch MCK (Master Clock) to the main clock first. */
-	reg_val = PMC->PMC_MCKR & ~PMC_MCKR_CSS_Msk;
-	PMC->PMC_MCKR = reg_val | PMC_MCKR_CSS_MAIN_CLK;
-
-	/* Wait for clock selection to complete. */
-	while (!(PMC->PMC_SR & PMC_SR_MCKRDY)) {
-		;
+		/* We select maximum setup time.
+		 * While start up time could be shortened
+		 * this optimization is not deemed
+		 * critical now.
+		 */
+		soc_pmc_switch_mainck_to_xtal(false, 0xff);
 	}
 
-	/* Setup PLLA. */
-	PMC->CKGR_PLLAR = CKGR_PLLAR_ONE
-			  | CKGR_PLLAR_MULA(CONFIG_SOC_ATMEL_SAM4S_PLLA_MULA)
-			  | CKGR_PLLAR_PLLACOUNT(0x3Fu)
-			  | CKGR_PLLAR_DIVA(CONFIG_SOC_ATMEL_SAM4S_PLLA_DIVA);
-
-	/*
-	 * NOTE: Both MULA and DIVA must be set to a value greater than 0 or
-	 * otherwise PLL will be disabled. In this case we would get stuck in
-	 * the following loop.
-	 */
-
-	/* Wait for PLL lock. */
-	while (!(PMC->PMC_SR & PMC_SR_LOCKA)) {
-		;
-	}
-
-	/*
-	 * Final setup of the Master Clock
-	 */
-
-	/*
-	 * NOTE: PMC_MCKR must not be programmed in a single write operation.
-	 * If CSS or PRES are modified we must wait for MCKRDY bit to be
-	 * set again.
-	 */
-
-	/* Setup prescaler - PLLA Clock / Processor Clock (HCLK). */
-	reg_val = PMC->PMC_MCKR & ~PMC_MCKR_PRES_Msk;
-	PMC->PMC_MCKR = reg_val | PMC_MCKR_PRES_CLK_1;
-
-	/* Wait for Master Clock setup to complete */
-	while (!(PMC->PMC_SR & PMC_SR_MCKRDY)) {
-		;
-	}
-
-	/* Finally select PLL as Master Clock source. */
-	reg_val = PMC->PMC_MCKR & ~PMC_MCKR_CSS_Msk;
-	PMC->PMC_MCKR = reg_val | PMC_MCKR_CSS_PLLA_CLK;
-
-	/* Wait for Master Clock setup to complete. */
-	while (!(PMC->PMC_SR & PMC_SR_MCKRDY)) {
-		;
-	}
-}
-
-void z_arm_platform_init(void)
-{
 	/*
 	 * Set FWS (Flash Wait State) value before increasing Master Clock
 	 * (MCK) frequency. Look at table 44.73 in the SAM4S datasheet.
@@ -188,9 +67,44 @@ void z_arm_platform_init(void)
 	 * hurt lower clock frequencies. However, a high frequency with too
 	 * few read cycles could cause flash read problems. FWS 5 (6 cycles)
 	 * is the safe setting for all of this SoCs usable frequencies.
-	 * TODO: Add code to handle SAM4SD devices that have 2 EFCs.
 	 */
 	EFC0->EEFC_FMR = EEFC_FMR_FWS(5);
+#if defined(ID_EFC1)
+	EFC1->EEFC_FMR = EEFC_FMR_FWS(5);
+#endif
+
+	/*
+	 * Setup PLLA
+	 */
+	soc_pmc_enable_pllack(CONFIG_SOC_ATMEL_SAM4S_PLLA_MULA, 0x3Fu,
+			      CONFIG_SOC_ATMEL_SAM4S_PLLA_DIVA);
+
+	/*
+	 * Final setup of the Master Clock
+	 */
+
+	/* prescaler has to be set before PLL lock */
+	soc_pmc_mck_set_prescaler(1);
+
+	/* Select PLL as Master Clock source. */
+	soc_pmc_mck_set_source(SOC_PMC_MCK_SRC_PLLA_CLK);
+
+	/* Disable internal fast RC if we have an external crystal oscillator */
+	if (IS_ENABLED(CONFIG_SOC_ATMEL_SAM4S_EXT_MAINCK)) {
+		soc_pmc_osc_disable_fastrc();
+	}
+}
+
+void z_arm_platform_init(void)
+{
+	if (IS_ENABLED(CONFIG_SOC_ATMEL_SAM4S_WAIT_MODE)) {
+		/*
+		 * Instruct CPU to enter Wait mode instead of Sleep mode to
+		 * keep Processor Clock (HCLK) and thus be able to debug
+		 * CPU using JTAG.
+		 */
+		soc_pmc_enable_waitmode();
+	}
 
 	/* Setup system clocks. */
 	clock_init();

--- a/soc/arm/atmel_sam/same70/soc.c
+++ b/soc/arm/atmel_sam/same70/soc.c
@@ -17,40 +17,13 @@
 #include <zephyr/cache.h>
 #include <zephyr/arch/cache.h>
 #include <soc.h>
+#include <soc_pmc.h>
+#include <soc_supc.h>
 #include <cmsis_core.h>
 #include <zephyr/logging/log.h>
 
 #define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
 LOG_MODULE_REGISTER(soc);
-
-/* Power Manager Controller */
-
-/*
- * PLL clock = Main * (MULA + 1) / DIVA
- *
- * By default, MULA == 24, DIVA == 1.
- * With main crystal running at 12 MHz,
- * PLL = 12 * (24 + 1) / 1 = 300 MHz
- *
- * With Processor Clock prescaler at 1
- * Processor Clock (HCLK)=300 MHz.
- */
-#define PMC_CKGR_PLLAR_MULA	\
-	(CKGR_PLLAR_MULA(CONFIG_SOC_ATMEL_SAME70_PLLA_MULA))
-#define PMC_CKGR_PLLAR_DIVA	\
-	(CKGR_PLLAR_DIVA(CONFIG_SOC_ATMEL_SAME70_PLLA_DIVA))
-
-#if CONFIG_SOC_ATMEL_SAME70_MDIV == 1
-#define SOC_ATMEL_SAME70_MDIV PMC_MCKR_MDIV_EQ_PCK
-#elif CONFIG_SOC_ATMEL_SAME70_MDIV == 2
-#define SOC_ATMEL_SAME70_MDIV PMC_MCKR_MDIV_PCK_DIV2
-#elif CONFIG_SOC_ATMEL_SAME70_MDIV == 3
-#define SOC_ATMEL_SAME70_MDIV PMC_MCKR_MDIV_PCK_DIV3
-#elif CONFIG_SOC_ATMEL_SAME70_MDIV == 4
-#define SOC_ATMEL_SAME70_MDIV PMC_MCKR_MDIV_PCK_DIV4
-#else
-#error "Invalid CONFIG_SOC_ATMEL_SAME70_MDIV define value"
-#endif
 
 /**
  * @brief Setup various clocks on SoC at boot time.
@@ -60,174 +33,89 @@ LOG_MODULE_REGISTER(soc);
  */
 static ALWAYS_INLINE void clock_init(void)
 {
-	uint32_t reg_val;
+	/* Switch the main clock to the internal OSC with 12MHz */
+	soc_pmc_switch_mainck_to_fastrc(SOC_PMC_FAST_RC_FREQ_12MHZ);
 
-#ifdef CONFIG_SOC_ATMEL_SAME70_EXT_SLCK
-	/* Switch slow clock to the external 32 kHz crystal oscillator */
-	SUPC->SUPC_CR = SUPC_CR_KEY_PASSWD | SUPC_CR_XTALSEL;
+	/* Switch MCK (Master Clock) to the main clock */
+	soc_pmc_mck_set_source(SOC_PMC_MCK_SRC_MAIN_CLK);
 
-	/* Wait for oscillator to be stabilized */
-	while (!(SUPC->SUPC_SR & SUPC_SR_OSCSEL)) {
-		;
-	}
-#endif /* CONFIG_SOC_ATMEL_SAME70_EXT_SLCK */
+	EFC->EEFC_FMR = EEFC_FMR_FWS(0) | EEFC_FMR_CLOE;
 
-#ifdef CONFIG_SOC_ATMEL_SAME70_EXT_MAINCK
-	/*
-	 * Setup main external crystal oscillator if not already done
-	 * by a previous program i.e. bootloader
-	 */
+	soc_pmc_enable_clock_failure_detector();
 
-	if (!(PMC->CKGR_MOR & CKGR_MOR_MOSCSEL_Msk)) {
-		/* Start the external crystal oscillator */
-		PMC->CKGR_MOR =   CKGR_MOR_KEY_PASSWD
-				/* We select maximum setup time.
-				 * While start up time could be shortened
-				 * this optimization is not deemed
-				 * critical now.
-				 */
-				| CKGR_MOR_MOSCXTST(0xFFu)
-				/* RC OSC must stay on */
-				| CKGR_MOR_MOSCRCEN
-				| CKGR_MOR_MOSCXTEN;
-
-		/* Wait for oscillator to be stabilized */
-		while (!(PMC->PMC_SR & PMC_SR_MOSCXTS)) {
-			;
-		}
-
-		/* Select the external crystal oscillator as main clock */
-		PMC->CKGR_MOR =   CKGR_MOR_KEY_PASSWD
-				| CKGR_MOR_MOSCSEL
-				| CKGR_MOR_MOSCXTST(0xFFu)
-				| CKGR_MOR_MOSCRCEN
-				| CKGR_MOR_MOSCXTEN;
-
-		/* Wait for external oscillator to be selected */
-		while (!(PMC->PMC_SR & PMC_SR_MOSCSELS)) {
-			;
-		}
+	if (IS_ENABLED(CONFIG_SOC_ATMEL_SAME70_EXT_SLCK)) {
+		soc_supc_slow_clock_select_crystal_osc();
 	}
 
-	/* Turn off RC OSC, not used any longer, to save power */
-	PMC->CKGR_MOR =   CKGR_MOR_KEY_PASSWD
-			| CKGR_MOR_MOSCSEL
-			| CKGR_MOR_MOSCXTST(0xFFu)
-			| CKGR_MOR_MOSCXTEN;
 
-	/* Wait for RC OSC to be turned off */
-	while (PMC->PMC_SR & PMC_SR_MOSCRCS) {
-		;
+	if (IS_ENABLED(CONFIG_SOC_ATMEL_SAME70_EXT_MAINCK)) {
+		/*
+		 * Setup main external crystal oscillator.
+		 */
+
+		/* We select maximum setup time.
+		 * While start up time could be shortened
+		 * this optimization is not deemed
+		 * critical now.
+		 */
+		soc_pmc_switch_mainck_to_xtal(false, 0xff);
 	}
-
-#ifdef CONFIG_SOC_ATMEL_SAME70_WAIT_MODE
-	/*
-	 * Instruct CPU to enter Wait mode instead of Sleep mode to
-	 * keep Processor Clock (HCLK) and thus be able to debug
-	 * CPU using JTAG
-	 */
-	PMC->PMC_FSMR |= PMC_FSMR_LPM;
-#endif
-#else
-	/* Attempt to change main fast RC oscillator frequency */
 
 	/*
-	 * NOTE: MOSCRCF must be changed only if MOSCRCS is set in the PMC_SR
-	 * register, should normally be the case here
+	 * Set FWS (Flash Wait State) value before increasing Master Clock
+	 * (MCK) frequency.
+	 * TODO: set FWS based on the actual MCK frequency and VDDIO value
+	 * rather than maximum supported 150 MHz at standard VDDIO=2.7V
 	 */
-	while (!(PMC->PMC_SR & PMC_SR_MOSCRCS)) {
-		;
-	}
-
-	/* Set main fast RC oscillator to 12 MHz */
-	PMC->CKGR_MOR =   CKGR_MOR_KEY_PASSWD
-			| CKGR_MOR_MOSCRCF_12_MHz
-			| CKGR_MOR_MOSCRCEN;
-
-	/* Wait for oscillator to be stabilized */
-	while (!(PMC->PMC_SR & PMC_SR_MOSCRCS)) {
-		;
-	}
-#endif /* CONFIG_SOC_ATMEL_SAME70_EXT_MAINCK */
+	EFC->EEFC_FMR = EEFC_FMR_FWS(5) | EEFC_FMR_CLOE;
 
 	/*
 	 * Setup PLLA
 	 */
 
-	/* Switch MCK (Master Clock) to the main clock first */
-	reg_val = PMC->PMC_MCKR & ~PMC_MCKR_CSS_Msk;
-	PMC->PMC_MCKR = reg_val | PMC_MCKR_CSS_MAIN_CLK;
-
-	/* Wait for clock selection to complete */
-	while (!(PMC->PMC_SR & PMC_SR_MCKRDY)) {
-		;
-	}
-
-	/* Setup PLLA */
-	PMC->CKGR_PLLAR =   CKGR_PLLAR_ONE
-			  | PMC_CKGR_PLLAR_MULA
-			  | CKGR_PLLAR_PLLACOUNT(0x3Fu)
-			  | PMC_CKGR_PLLAR_DIVA;
-
 	/*
-	 * NOTE: Both MULA and DIVA must be set to a value greater than 0 or
-	 * otherwise PLL will be disabled. In this case we would get stuck in
-	 * the following loop.
+	 * PLL clock = Main * (MULA + 1) / DIVA
+	 *
+	 * By default, MULA == 24, DIVA == 1.
+	 * With main crystal running at 12 MHz,
+	 * PLL = 12 * (24 + 1) / 1 = 300 MHz
+	 *
+	 * With Processor Clock prescaler at 1
+	 * Processor Clock (HCLK)=300 MHz.
 	 */
+	soc_pmc_enable_pllack(CONFIG_SOC_ATMEL_SAME70_PLLA_MULA, 0x3Fu,
+			      CONFIG_SOC_ATMEL_SAME70_PLLA_DIVA);
 
-	/* Wait for PLL lock */
-	while (!(PMC->PMC_SR & PMC_SR_LOCKA)) {
-		;
-	}
 
-	/* Setup UPLL */
-	PMC->CKGR_UCKR = CKGR_UCKR_UPLLCOUNT(0x3Fu) | CKGR_UCKR_UPLLEN;
-
-	/* Wait for PLL lock */
-	while (!(PMC->PMC_SR & PMC_SR_LOCKU)) {
-		;
-	}
+	soc_pmc_enable_upllck(0x3Fu);
 
 	/*
 	 * Final setup of the Master Clock
 	 */
 
-	/*
-	 * NOTE: PMC_MCKR must not be programmed in a single write operation.
-	 * If CSS, MDIV or PRES are modified we must wait for MCKRDY bit to be
-	 * set again.
-	 */
+	/* Setting PLLA as MCK, first prescaler, then divider and source last */
+	soc_pmc_mck_set_prescaler(1);
+	soc_pmc_mck_set_divider(CONFIG_SOC_ATMEL_SAME70_MDIV);
+	soc_pmc_mck_set_source(SOC_PMC_MCK_SRC_PLLA_CLK);
 
-	/* Setup prescaler - PLLA Clock / Processor Clock (HCLK) */
-	reg_val = PMC->PMC_MCKR & ~PMC_MCKR_PRES_Msk;
-	PMC->PMC_MCKR = reg_val | PMC_MCKR_PRES_CLK_1;
 
-	/* Wait for Master Clock setup to complete */
-	while (!(PMC->PMC_SR & PMC_SR_MCKRDY)) {
-		;
-	}
-
-	/* Setup divider - Processor Clock (HCLK) / Master Clock (MCK) */
-	reg_val = PMC->PMC_MCKR & ~PMC_MCKR_MDIV_Msk;
-	PMC->PMC_MCKR = reg_val | SOC_ATMEL_SAME70_MDIV;
-
-	/* Wait for Master Clock setup to complete */
-	while (!(PMC->PMC_SR & PMC_SR_MCKRDY)) {
-		;
-	}
-
-	/* Finally select PLL as Master Clock source */
-	reg_val = PMC->PMC_MCKR & ~PMC_MCKR_CSS_Msk;
-	PMC->PMC_MCKR = reg_val | PMC_MCKR_CSS_PLLA_CLK;
-
-	/* Wait for Master Clock setup to complete */
-	while (!(PMC->PMC_SR & PMC_SR_MCKRDY)) {
-		;
+	/* Disable internal fast RC if we have an external crystal oscillator */
+	if (IS_ENABLED(CONFIG_SOC_ATMEL_SAME70_EXT_MAINCK)) {
+		soc_pmc_osc_disable_fastrc();
 	}
 }
 
 void z_arm_platform_init(void)
 {
+	if (IS_ENABLED(CONFIG_SOC_ATMEL_SAME70_WAIT_MODE)) {
+		/*
+		 * Instruct CPU to enter Wait mode instead of Sleep mode to
+		 * keep Processor Clock (HCLK) and thus be able to debug
+		 * CPU using JTAG.
+		 */
+		soc_pmc_enable_waitmode();
+	}
+
 	/*
 	 * DTCM is enabled by default at reset, therefore we have to disable
 	 * it first to get the caches into a state where then the
@@ -241,14 +129,6 @@ void z_arm_platform_init(void)
 	 */
 	sys_cache_instr_enable();
 	sys_cache_data_enable();
-
-	/*
-	 * Set FWS (Flash Wait State) value before increasing Master Clock
-	 * (MCK) frequency.
-	 * TODO: set FWS based on the actual MCK frequency and VDDIO value
-	 * rather than maximum supported 150 MHz at standard VDDIO=2.7V
-	 */
-	EFC->EEFC_FMR = EEFC_FMR_FWS(5) | EEFC_FMR_CLOE;
 
 	/* Setup system clocks */
 	clock_init();

--- a/soc/arm/atmel_sam/samv71/soc.c
+++ b/soc/arm/atmel_sam/samv71/soc.c
@@ -23,35 +23,6 @@
 #define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
 LOG_MODULE_REGISTER(soc);
 
-/* Power Manager Controller */
-
-/*
- * PLL clock = Main * (MULA + 1) / DIVA
- *
- * By default, MULA == 24, DIVA == 1.
- * With main crystal running at 12 MHz,
- * PLL = 12 * (24 + 1) / 1 = 300 MHz
- *
- * With Processor Clock prescaler at 1
- * Processor Clock (HCLK)=300 MHz.
- */
-#define PMC_CKGR_PLLAR_MULA	\
-	(CKGR_PLLAR_MULA(CONFIG_SOC_ATMEL_SAMV71_PLLA_MULA))
-#define PMC_CKGR_PLLAR_DIVA	\
-	(CKGR_PLLAR_DIVA(CONFIG_SOC_ATMEL_SAMV71_PLLA_DIVA))
-
-#if CONFIG_SOC_ATMEL_SAMV71_MDIV == 1
-#define SOC_ATMEL_SAMV71_MDIV PMC_MCKR_MDIV_EQ_PCK
-#elif CONFIG_SOC_ATMEL_SAMV71_MDIV == 2
-#define SOC_ATMEL_SAMV71_MDIV PMC_MCKR_MDIV_PCK_DIV2
-#elif CONFIG_SOC_ATMEL_SAMV71_MDIV == 3
-#define SOC_ATMEL_SAMV71_MDIV PMC_MCKR_MDIV_PCK_DIV3
-#elif CONFIG_SOC_ATMEL_SAMV71_MDIV == 4
-#define SOC_ATMEL_SAMV71_MDIV PMC_MCKR_MDIV_PCK_DIV4
-#else
-#error "Invalid CONFIG_SOC_ATMEL_SAMV71_MDIV define value"
-#endif
-
 /**
  * @brief Setup various clocks on SoC at boot time.
  *
@@ -60,174 +31,88 @@ LOG_MODULE_REGISTER(soc);
  */
 static ALWAYS_INLINE void clock_init(void)
 {
-	uint32_t reg_val;
+	/* Switch the main clock to the internal OSC with 12MHz */
+	soc_pmc_switch_mainck_to_fastrc(SOC_PMC_FAST_RC_FREQ_12MHZ);
 
-#ifdef CONFIG_SOC_ATMEL_SAMV71_EXT_SLCK
-	/* Switch slow clock to the external 32 kHz crystal oscillator */
-	SUPC->SUPC_CR = SUPC_CR_KEY_PASSWD | SUPC_CR_XTALSEL;
+	/* Switch MCK (Master Clock) to the main clock */
+	soc_pmc_mck_set_source(SOC_PMC_MCK_SRC_MAIN_CLK);
 
-	/* Wait for oscillator to be stabilized */
-	while (!(SUPC->SUPC_SR & SUPC_SR_OSCSEL)) {
-		;
-	}
-#endif /* CONFIG_SOC_ATMEL_SAMV71_EXT_SLCK */
+	EFC->EEFC_FMR = EEFC_FMR_FWS(0) | EEFC_FMR_CLOE;
 
-#ifdef CONFIG_SOC_ATMEL_SAMV71_EXT_MAINCK
-	/*
-	 * Setup main external crystal oscillator if not already done
-	 * by a previous program i.e. bootloader
-	 */
+	soc_pmc_enable_clock_failure_detector();
 
-	if (!(PMC->CKGR_MOR & CKGR_MOR_MOSCSEL_Msk)) {
-		/* Start the external crystal oscillator */
-		PMC->CKGR_MOR =   CKGR_MOR_KEY_PASSWD
-				/* We select maximum setup time.
-				 * While start up time could be shortened
-				 * this optimization is not deemed
-				 * critical now.
-				 */
-				| CKGR_MOR_MOSCXTST(0xFFu)
-				/* RC OSC must stay on */
-				| CKGR_MOR_MOSCRCEN
-				| CKGR_MOR_MOSCXTEN;
-
-		/* Wait for oscillator to be stabilized */
-		while (!(PMC->PMC_SR & PMC_SR_MOSCXTS)) {
-			;
-		}
-
-		/* Select the external crystal oscillator as main clock */
-		PMC->CKGR_MOR =   CKGR_MOR_KEY_PASSWD
-				| CKGR_MOR_MOSCSEL
-				| CKGR_MOR_MOSCXTST(0xFFu)
-				| CKGR_MOR_MOSCRCEN
-				| CKGR_MOR_MOSCXTEN;
-
-		/* Wait for external oscillator to be selected */
-		while (!(PMC->PMC_SR & PMC_SR_MOSCSELS)) {
-			;
-		}
+	if (IS_ENABLED(CONFIG_SOC_ATMEL_SAMV71_EXT_SLCK)) {
+		soc_supc_slow_clock_select_crystal_osc();
 	}
 
-	/* Turn off RC OSC, not used any longer, to save power */
-	PMC->CKGR_MOR =   CKGR_MOR_KEY_PASSWD
-			| CKGR_MOR_MOSCSEL
-			| CKGR_MOR_MOSCXTST(0xFFu)
-			| CKGR_MOR_MOSCXTEN;
 
-	/* Wait for RC OSC to be turned off */
-	while (PMC->PMC_SR & PMC_SR_MOSCRCS) {
-		;
+	if (IS_ENABLED(CONFIG_SOC_ATMEL_SAMV71_EXT_MAINCK)) {
+		/*
+		 * Setup main external crystal oscillator.
+		 */
+
+		/* We select maximum setup time.
+		 * While start up time could be shortened
+		 * this optimization is not deemed
+		 * critical now.
+		 */
+		soc_pmc_switch_mainck_to_xtal(false, 0xff);
 	}
-
-#ifdef CONFIG_SOC_ATMEL_SAMV71_WAIT_MODE
-	/*
-	 * Instruct CPU to enter Wait mode instead of Sleep mode to
-	 * keep Processor Clock (HCLK) and thus be able to debug
-	 * CPU using JTAG
-	 */
-	PMC->PMC_FSMR |= PMC_FSMR_LPM;
-#endif
-#else
-	/* Attempt to change main fast RC oscillator frequency */
 
 	/*
-	 * NOTE: MOSCRCF must be changed only if MOSCRCS is set in the PMC_SR
-	 * register, should normally be the case here
+	 * Set FWS (Flash Wait State) value before increasing Master Clock
+	 * (MCK) frequency.
+	 * TODO: set FWS based on the actual MCK frequency and VDDIO value
+	 * rather than maximum supported 150 MHz at standard VDDIO=2.7V
 	 */
-	while (!(PMC->PMC_SR & PMC_SR_MOSCRCS)) {
-		;
-	}
-
-	/* Set main fast RC oscillator to 12 MHz */
-	PMC->CKGR_MOR =   CKGR_MOR_KEY_PASSWD
-			| CKGR_MOR_MOSCRCF_12_MHz
-			| CKGR_MOR_MOSCRCEN;
-
-	/* Wait for oscillator to be stabilized */
-	while (!(PMC->PMC_SR & PMC_SR_MOSCRCS)) {
-		;
-	}
-#endif /* CONFIG_SOC_ATMEL_SAMV71_EXT_MAINCK */
+	EFC->EEFC_FMR = EEFC_FMR_FWS(5) | EEFC_FMR_CLOE;
 
 	/*
 	 * Setup PLLA
 	 */
 
-	/* Switch MCK (Master Clock) to the main clock first */
-	reg_val = PMC->PMC_MCKR & ~PMC_MCKR_CSS_Msk;
-	PMC->PMC_MCKR = reg_val | PMC_MCKR_CSS_MAIN_CLK;
-
-	/* Wait for clock selection to complete */
-	while (!(PMC->PMC_SR & PMC_SR_MCKRDY)) {
-		;
-	}
-
-	/* Setup PLLA */
-	PMC->CKGR_PLLAR =   CKGR_PLLAR_ONE
-			  | PMC_CKGR_PLLAR_MULA
-			  | CKGR_PLLAR_PLLACOUNT(0x3Fu)
-			  | PMC_CKGR_PLLAR_DIVA;
-
 	/*
-	 * NOTE: Both MULA and DIVA must be set to a value greater than 0 or
-	 * otherwise PLL will be disabled. In this case we would get stuck in
-	 * the following loop.
+	 * PLL clock = Main * (MULA + 1) / DIVA
+	 *
+	 * By default, MULA == 24, DIVA == 1.
+	 * With main crystal running at 12 MHz,
+	 * PLL = 12 * (24 + 1) / 1 = 300 MHz
+	 *
+	 * With Processor Clock prescaler at 1
+	 * Processor Clock (HCLK)=300 MHz.
 	 */
+	soc_pmc_enable_pllack(CONFIG_SOC_ATMEL_SAMV71_PLLA_MULA, 0x3Fu,
+			      CONFIG_SOC_ATMEL_SAMV71_PLLA_DIVA);
 
-	/* Wait for PLL lock */
-	while (!(PMC->PMC_SR & PMC_SR_LOCKA)) {
-		;
-	}
 
-	/* Setup UPLL */
-	PMC->CKGR_UCKR = CKGR_UCKR_UPLLCOUNT(0x3Fu) | CKGR_UCKR_UPLLEN;
-
-	/* Wait for PLL lock */
-	while (!(PMC->PMC_SR & PMC_SR_LOCKU)) {
-		;
-	}
+	soc_pmc_enable_upllck(0x3Fu);
 
 	/*
 	 * Final setup of the Master Clock
 	 */
 
-	/*
-	 * NOTE: PMC_MCKR must not be programmed in a single write operation.
-	 * If CSS, MDIV or PRES are modified we must wait for MCKRDY bit to be
-	 * set again.
-	 */
+	/* Setting PLLA as MCK, first prescaler, then divider and source last */
+	soc_pmc_mck_set_prescaler(1);
+	soc_pmc_mck_set_divider(CONFIG_SOC_ATMEL_SAMV71_MDIV);
+	soc_pmc_mck_set_source(SOC_PMC_MCK_SRC_PLLA_CLK);
 
-	/* Setup prescaler - PLLA Clock / Processor Clock (HCLK) */
-	reg_val = PMC->PMC_MCKR & ~PMC_MCKR_PRES_Msk;
-	PMC->PMC_MCKR = reg_val | PMC_MCKR_PRES_CLK_1;
-
-	/* Wait for Master Clock setup to complete */
-	while (!(PMC->PMC_SR & PMC_SR_MCKRDY)) {
-		;
-	}
-
-	/* Setup divider - Processor Clock (HCLK) / Master Clock (MCK) */
-	reg_val = PMC->PMC_MCKR & ~PMC_MCKR_MDIV_Msk;
-	PMC->PMC_MCKR = reg_val | SOC_ATMEL_SAMV71_MDIV;
-
-	/* Wait for Master Clock setup to complete */
-	while (!(PMC->PMC_SR & PMC_SR_MCKRDY)) {
-		;
-	}
-
-	/* Finally select PLL as Master Clock source */
-	reg_val = PMC->PMC_MCKR & ~PMC_MCKR_CSS_Msk;
-	PMC->PMC_MCKR = reg_val | PMC_MCKR_CSS_PLLA_CLK;
-
-	/* Wait for Master Clock setup to complete */
-	while (!(PMC->PMC_SR & PMC_SR_MCKRDY)) {
-		;
+	/* Disable internal fast RC if we have an external crystal oscillator */
+	if (IS_ENABLED(CONFIG_SOC_ATMEL_SAMV71_EXT_MAINCK)) {
+		soc_pmc_osc_disable_fastrc();
 	}
 }
 
 void z_arm_platform_init(void)
 {
+	if (IS_ENABLED(CONFIG_SOC_ATMEL_SAMV71_WAIT_MODE)) {
+		/*
+		 * Instruct CPU to enter Wait mode instead of Sleep mode to
+		 * keep Processor Clock (HCLK) and thus be able to debug
+		 * CPU using JTAG.
+		 */
+		soc_pmc_enable_waitmode();
+	}
+
 	/*
 	 * DTCM is enabled by default at reset, therefore we have to disable
 	 * it first to get the caches into a state where then the
@@ -241,14 +126,6 @@ void z_arm_platform_init(void)
 	 */
 	sys_cache_instr_enable();
 	sys_cache_data_enable();
-
-	/*
-	 * Set FWS (Flash Wait State) value before increasing Master Clock
-	 * (MCK) frequency.
-	 * TODO: set FWS based on the actual MCK frequency and VDDIO value
-	 * rather than maximum supported 150 MHz at standard VDDIO=2.7V
-	 */
-	EFC->EEFC_FMR = EEFC_FMR_FWS(5) | EEFC_FMR_CLOE;
 
 	/* Setup system clocks */
 	clock_init();


### PR DESCRIPTION
Start the clock initialization with resetting first to the MAIN clock, same as the reset value.
This fixes the issue of re-initialising the fast clock, for example after the bootloader.