### PR TITLE
[v2.7] toolchain: Move extra warning options to toolchain abstraction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,6 +162,13 @@ zephyr_compile_options(${OPTIMIZATION_FLAG})
 # @Intent: Obtain compiler specific flags related to C++ that are not influenced by kconfig
 zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:$<TARGET_PROPERTY:compiler-cpp,required>>)
 
+# Extra warnings options for twister run
+if (CONFIG_COMPILER_WARNINGS_AS_ERRORS)
+  zephyr_compile_options($<$<COMPILE_LANGUAGE:C>:$<TARGET_PROPERTY:compiler,warnings_as_errors>>)
+  zephyr_compile_options($<$<COMPILE_LANGUAGE:ASM>:$<TARGET_PROPERTY:asm,warnings_as_errors>>)
+  zephyr_link_libraries($<TARGET_PROPERTY:linker,warnings_as_errors>)
+endif()
+
 # @Intent: Obtain compiler specific flags for compiling under different ISO standards of C++
 if(CONFIG_CPLUSPLUS)
   # From kconfig choice, pick a single dialect.

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -305,8 +305,12 @@ config NO_OPTIMIZATIONS
 	help
 	  Compiler optimizations will be set to -O0 independently of other
 	  options.
-
 endchoice
+
+config COMPILER_WARNINGS_AS_ERRORS
+	bool "Treat warnings as errors"
+	help
+	  Turn on "warning as error" toolchain flags
 
 config COMPILER_COLOR_DIAGNOSTICS
 	bool "Enable colored diganostics"

--- a/cmake/compiler/arcmwdt/compiler_flags.cmake
+++ b/cmake/compiler/arcmwdt/compiler_flags.cmake
@@ -132,6 +132,10 @@ set_property(TARGET compiler-cpp PROPERTY dialect_cpp2a "")
 set_property(TARGET compiler-cpp PROPERTY dialect_cpp20 "")
 set_property(TARGET compiler-cpp PROPERTY dialect_cpp2b "")
 
+# Flags for set extra warnigs (ARCMWDT asm can't recognize --fatal-warnings. Skip it)
+set_property(TARGET compiler PROPERTY warnings_as_errors -Werror)
+set_property(TARGET asm PROPERTY warnings_as_errors -Werror)
+
 # Disable exeptions flag in C++
 set_property(TARGET compiler-cpp PROPERTY no_exceptions "-fno-exceptions")
 

--- a/cmake/compiler/compiler_flags_template.cmake
+++ b/cmake/compiler/compiler_flags_template.cmake
@@ -65,6 +65,10 @@ set_property(TARGET compiler-cpp PROPERTY dialect_cpp2a)
 set_property(TARGET compiler-cpp PROPERTY dialect_cpp20)
 set_property(TARGET compiler-cpp PROPERTY dialect_cpp2b)
 
+# Extra warnings options for twister run
+set_property(TARGET compiler PROPERTY warnings_as_errors)
+set_property(TARGET asm PROPERTY warnings_as_errors)
+
 # Flag for disabling exeptions in C++
 set_property(TARGET compiler-cpp PROPERTY no_exceptions)
 

--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -137,6 +137,10 @@ set_property(TARGET compiler-cpp PROPERTY dialect_cpp20 "-std=c++20"
 set_property(TARGET compiler-cpp PROPERTY dialect_cpp2b "-std=c++2b"
   "-Wno-register" "-Wno-volatile")
 
+# Flags for set extra warnigs (ARCMWDT asm can't recognize --fatal-warnings. Skip it)
+set_property(TARGET compiler PROPERTY warnings_as_errors -Werror)
+set_property(TARGET asm PROPERTY warnings_as_errors -Werror)
+
 # Disable exeptions flag in C++
 set_property(TARGET compiler-cpp PROPERTY no_exceptions "-fno-exceptions")
 

--- a/cmake/linker/arcmwdt/linker_flags.cmake
+++ b/cmake/linker/arcmwdt/linker_flags.cmake
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Extra warnings options for twister run
+set_property(TARGET linker PROPERTY warnings_as_errors -Wl,--fatal-warnings)

--- a/cmake/linker/ld/clang/linker_flags.cmake
+++ b/cmake/linker/ld/clang/linker_flags.cmake
@@ -3,6 +3,9 @@ if (NOT CONFIG_COVERAGE_GCOV)
   set_property(TARGET linker PROPERTY coverage --coverage)
 endif()
 
+# Extra warnings options for twister run
+set_property(TARGET linker PROPERTY ld_extra_warning_options -Wl,--fatal-warnings)
+
 # ld/clang linker flags for sanitizing.
 check_set_linker_property(TARGET linker APPEND PROPERTY sanitize_address -fsanitize=address)
 

--- a/cmake/linker/ld/gcc/linker_flags.cmake
+++ b/cmake/linker/ld/gcc/linker_flags.cmake
@@ -7,6 +7,9 @@ if (NOT CONFIG_COVERAGE_GCOV)
   set_property(TARGET linker PROPERTY coverage -lgcov)
 endif()
 
+# Extra warnings options for twister run
+set_property(TARGET linker PROPERTY warnings_as_errors -Wl,--fatal-warnings)
+
 # ld/gcc linker flags for sanitizing.
 check_set_linker_property(TARGET linker APPEND PROPERTY sanitize_address -lasan)
 check_set_linker_property(TARGET linker APPEND PROPERTY sanitize_address -fsanitize=address)

--- a/cmake/linker/linker_flags_template.cmake
+++ b/cmake/linker/linker_flags_template.cmake
@@ -14,3 +14,6 @@ check_set_linker_property(TARGET linker APPEND PROPERTY sanitize_undefined)
 # If memory reporting is a post build command, please use
 # cmake/bintools/bintools.cmake insted.
 check_set_linker_property(TARGET linker PROPERTY memusage)
+
+# Extra warnings options for twister run
+set_property(TARGET linker PROPERTY warnings_as_errors)

--- a/include/toolchain/gcc.h
+++ b/include/toolchain/gcc.h
@@ -48,8 +48,9 @@
 #endif
 
 
+#undef BUILD_ASSERT /* clear out common version */
 /* C++11 has static_assert built in */
-#ifdef __cplusplus
+#if defined(__cplusplus) && (__cplusplus >= 201103L)
 #define BUILD_ASSERT(EXPR, MSG...) static_assert(EXPR, "" MSG)
 
 /*

--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -2017,21 +2017,17 @@ class CMake():
     def run_cmake(self, args=[]):
 
         if self.warnings_as_errors:
-            ldflags = "-Wl,--fatal-warnings"
-            cflags = "-Werror"
-            aflags = "-Wa,--fatal-warnings"
+            warnings_as_errors = 'y'
             gen_defines_args = "--edtlib-Werror"
         else:
-            ldflags = cflags = aflags = ""
+            warnings_as_errors = 'n'
             gen_defines_args = ""
 
         logger.debug("Running cmake on %s for %s" % (self.source_dir, self.platform.name))
         cmake_args = [
             f'-B{self.build_dir}',
             f'-S{self.source_dir}',
-            f'-DEXTRA_CFLAGS="{cflags}"',
-            f'-DEXTRA_AFLAGS="{aflags}',
-            f'-DEXTRA_LDFLAGS="{ldflags}"',
+            f'-DCONFIG_COMPILER_WARNINGS_AS_ERRORS={warnings_as_errors}',
             f'-DEXTRA_GEN_DEFINES_ARGS={gen_defines_args}',
             f'-G{self.generator}'
         ]


### PR DESCRIPTION
Backport of #53305
Fixes #66500
**Note: Compliance failure is a false positive (those lines are not modified with this commit)**

Move extra warning option from generic twister script into compiler-dependent config files. ARCMWDT compiler doesn't support extra warning options ex. "-Wl,--fatal-warnings". To avoid build fails flag "disable_warnings_as_errors" should be passed to twister.

This allows all warning messages and make atomatic test useles.
