### PR TITLE
drivers: spi: stm32h7: Use FIFO, transferSize and EOT

### DIFF
--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -508,6 +508,15 @@ static void spi_stm32_isr(const struct device *dev)
 	SPI_TypeDef *spi = cfg->spi;
 	int err;
 
+	/* Some spurious interrupts are triggered when SPI is not enabled; ignore them.
+	 * Do it only when fifo is enabled to leave non-fifo functionality untouched for now
+	 */
+	if (cfg->fifo_enabled) {
+		if (!LL_SPI_IsEnabled(spi)) {
+			return;
+		}
+	}
+
 	err = spi_stm32_get_err(spi);
 	if (err) {
 		spi_stm32_complete(dev, err);

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -1146,7 +1146,9 @@ static void spi_stm32_irq_config_func_##id(const struct device *dev)		\
 #define SPI_DMA_STATUS_SEM(id)
 #endif
 
-
+#define SPI_SUPPORTS_FIFO(id)	DT_INST_NODE_HAS_PROP(id, fifo_enable)
+#define SPI_GET_FIFO_PROP(id)	DT_INST_PROP(id, fifo_enable)
+#define SPI_FIFO_ENABLED(id)	COND_CODE_1(SPI_SUPPORTS_FIFO(id), (SPI_GET_FIFO_PROP(id)), (0))
 
 #define STM32_SPI_INIT(id)						\
 STM32_SPI_IRQ_HANDLER_DECL(id);						\
@@ -1161,6 +1163,7 @@ static const struct spi_stm32_config spi_stm32_cfg_##id = {		\
 	.pclken = pclken_##id,						\
 	.pclk_len = DT_INST_NUM_CLOCKS(id),				\
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(id),			\
+	.fifo_enabled = SPI_FIFO_ENABLED(id),				\
 	STM32_SPI_IRQ_HANDLER_FUNC(id)					\
 	IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(st_stm32_spi_subghz),	\
 		(.use_subghzspi_nss =					\

--- a/drivers/spi/spi_ll_stm32.h
+++ b/drivers/spi/spi_ll_stm32.h
@@ -34,6 +34,7 @@ struct spi_stm32_config {
 #endif
 	size_t pclk_len;
 	const struct stm32_pclken *pclken;
+	bool fifo_enabled;
 };
 
 #ifdef CONFIG_SPI_STM32_DMA

--- a/dts/bindings/spi/st,stm32h7-spi.yaml
+++ b/dts/bindings/spi/st,stm32h7-spi.yaml
@@ -27,3 +27,7 @@ properties:
     description: |
       (Master SS Idleness) minimum clock inserted between
       start and first data transaction.
+
+  fifo-enable:
+    type: boolean
+    description: Enable the SPI FIFO usage for performance improvement.


### PR DESCRIPTION
Use the SPI FIFO for better performance (see #63173 and #66595)

Set the transfer size in SPI H7 and check EOT instead of TXC to be sure the transaction has finished. This requires to enable/disable extra interrupts.

This is very important as otherwise SPI seems to operate in "continuous mode", which produces several SCK cycles after the last frame has been sent/received. However, with TSIZE != 0, the transaction size is known before starting to send anything, which makes the SPI peripheral to stop producing the above mentioned spurious clock cycles.

**The spurious SCK cycles problem is not detected by the spi_loopback tests**; a logic analyzer is required to see the signals and verify the extra SCK cycles are there.

At the time this PR is opened, it's unclear why this clock cycles are generated if TSIZE is not set, or why they are generated only if the FIFO capabilities are used (if the non-fifo shift functions are used, this problem doesn't arise).

Fixes #66326

Related to #65802


Test plan
=========
Run all the spi_loppback tests, with and without DMA/IRQs enabled, and with and without enabling the FIFO usage. That is:

Connect an STM32H7 board to the PC with pins D11 and D12 connected.

Open a minicom or equivalent terminal to read the test report.

Execute the following commands both with and without `fifo-enabled;` in the `spi1` node in the `nucleo-h743/53` dts files and the `stm32-16bits.overlay` one:

```
rm -rf ~/zephyrproject/zephyr/build
west build -p auto -b nucleo_h753zi tests/drivers/spi/spi_loopback
west flash

rm -rf ~/zephyrproject/zephyr/build
west build -p auto -b nucleo_h753zi -T tests/drivers/spi/spi_loopback/drivers.spi.stm32_spi_16bits_frames.loopback
west flash

rm -rf ~/zephyrproject/zephyr/build
west build -p auto -b nucleo_h753zi -T tests/drivers/spi/spi_loopback/drivers.spi.stm32_spi_dma.loopback
west flash

rm -rf ~/zephyrproject/zephyr/build
west build -p auto -b nucleo_h753zi -T tests/drivers/spi/spi_loopback/drivers.spi.stm32_spi_16bits_frames_dma.loopback
west flash

rm -rf ~/zephyrproject/zephyr/build
west build -p auto -b nucleo_h753zi -T tests/drivers/spi/spi_loopback/drivers.spi.stm32_spi_dma_no_nocache.loopback
west flash

rm -rf ~/zephyrproject/zephyr/build
west build -p auto -b nucleo_h753zi -T tests/drivers/spi/spi_loopback/drivers.spi.stm32_spi_16bits_frames_dma_no_nocache.loopback
west flash

rm -rf ~/zephyrproject/zephyr/build
west build -p auto -b nucleo_h753zi -T tests/drivers/spi/spi_loopback/drivers.spi.stm32_spi_interrupt.loopback
west flash




rm -rf ~/zephyrproject/zephyr/build
west build -p auto -b nucleo_h743zi tests/drivers/spi/spi_loopback
west flash

rm -rf ~/zephyrproject/zephyr/build
west build -p auto -b nucleo_h743zi -T tests/drivers/spi/spi_loopback/drivers.spi.stm32_spi_16bits_frames.loopback
west flash

rm -rf ~/zephyrproject/zephyr/build
west build -p auto -b nucleo_h743zi -T tests/drivers/spi/spi_loopback/drivers.spi.stm32_spi_dma.loopback
west flash

rm -rf ~/zephyrproject/zephyr/build
west build -p auto -b nucleo_h743zi -T tests/drivers/spi/spi_loopback/drivers.spi.stm32_spi_16bits_frames_dma.loopback
west flash

rm -rf ~/zephyrproject/zephyr/build
west build -p auto -b nucleo_h743zi -T tests/drivers/spi/spi_loopback/drivers.spi.stm32_spi_dma_no_nocache.loopback
west flash

rm -rf ~/zephyrproject/zephyr/build
west build -p auto -b nucleo_h743zi -T tests/drivers/spi/spi_loopback/drivers.spi.stm32_spi_16bits_frames_dma_no_nocache.loopback
west flash

rm -rf ~/zephyrproject/zephyr/build
west build -p auto -b nucleo_h753zi -T tests/drivers/spi/spi_loopback/drivers.spi.stm32_spi_interrupt.loopback
west flash
```
Also, as the error mentioned above is not detected by the spi_loopback tests, inspect the signals (with and without irqs enabled) with a logic analyzer, and verify the extra clock cycles are not generated.

Below you can find the captures obtained, with an extra test suggested by @GeorgeCGV that is not part of the current spi_loopback tests, but it's worth to consider to add it as it helps to detect this problem.

The test, adapted to the spi_loopback tests setup, is: 

```
static __aligned(32) uint8_t tx_data2[36] __NOCACHE;
static __aligned(32) uint8_t rx_data2[36] __NOCACHE;

static int spi_complete_multiple2(struct spi_dt_spec *spec)
{
	int ret;

	for (unsigned i = 0; i < sizeof(tx_data2); ++i) {
		tx_data2[i] = i;
	}

	for(unsigned len = 2; len <= sizeof(tx_data2); len += 2) {
		(void)memset(rx_data2, 0, sizeof(rx_data2));

		struct spi_buf tx_buf = { .buf = tx_data2, .len = len };
		struct spi_buf rx_buf = { .buf = rx_data2, .len = len };
		const struct spi_buf_set tx = { .buffers = &tx_buf, .count = 1U };
		const struct spi_buf_set rx = { .buffers = &rx_buf, .count = 1U };

		ret = spi_transceive_dt(spec, &tx, &rx);
		if (ret) {
			LOG_ERR("Code %d, len %u", ret, len);
			continue;
		}

		if (memcmp(tx_data2, rx_data2, len)) {
			LOG_ERR("Buffer contents are different, rx&tx len %u", len);
		}

		memset(rx_data2, 0, 36);
	}

	return 0;
}
```
Notice that the lengths sent need to be a multiple of 2, or the 16 bits frame tests will fail.

This test, called _spi_complete_multiple2_, is executed in second place. Below there is a code snippet that shows it:

```
[...]
if (spi_complete_multiple(&spi_fast) || spi_complete_multiple2(&spi_fast) ||
	    spi_complete_loop(&spi_fast) ||
[...]
```

And the obtained captures, which can be opened with Logic II, are below:

[new_captures.zip](https://github.com/zephyrproject-rtos/zephyr/files/13663861/new_captures.zip)
