### PR TITLE
drivers: usb: usb_dc_kinetis: fix k_heap_alloc wait duration

### DIFF
--- a/drivers/usb/device/usb_dc_kinetis.c
+++ b/drivers/usb/device/usb_dc_kinetis.c
@@ -354,7 +354,7 @@ int usb_dc_ep_configure(const struct usb_dc_ep_cfg_data * const cfg)
 	(void)memset(&bdt[idx_even], 0, sizeof(struct buf_descriptor));
 	(void)memset(&bdt[idx_odd], 0, sizeof(struct buf_descriptor));
 
-	block->data = k_heap_alloc(&ep_buf_pool, cfg->ep_mps * 2U, K_MSEC(10));
+	block->data = k_heap_alloc(&ep_buf_pool, cfg->ep_mps * 2U, K_NO_WAIT);
 	if (block->data != NULL) {
 		(void)memset(block->data, 0, cfg->ep_mps * 2U);
 	} else {


### PR DESCRIPTION
Change k_heap_alloc wait duration to K_NO_WAIT in kinetis USB driver, since the usb_dc_ep_configure function may be called from an ISR context, where only K_NO_WAIT would be allowed as a duration for this function.

Fixes #66507