### PR TITLE
tests: Fix bias adjustment in latency_measure

### DIFF
--- a/tests/benchmarks/latency_measure/src/mutex_lock_unlock.c
+++ b/tests/benchmarks/latency_measure/src/mutex_lock_unlock.c
@@ -91,7 +91,6 @@ int mutex_lock_unlock(uint32_t num_iterations, uint32_t options)
 	k_thread_start(&start_thread);
 
 	cycles = timestamp.cycles;
-	cycles -= timestamp_overhead_adjustment(options, options);
 	k_sem_give(&pause_sem);
 
 	snprintf(description, sizeof(description),
@@ -101,7 +100,6 @@ int mutex_lock_unlock(uint32_t num_iterations, uint32_t options)
 			false, "");
 
 	cycles = timestamp.cycles;
-	cycles -= timestamp_overhead_adjustment(options, options);
 
 	snprintf(description, sizeof(description),
 		 "Unlock a mutex from %s thread",

--- a/tests/benchmarks/latency_measure/src/sema_test_signal_release.c
+++ b/tests/benchmarks/latency_measure/src/sema_test_signal_release.c
@@ -253,7 +253,6 @@ int sema_test_signal(uint32_t num_iterations, uint32_t options)
 	/* 5. Retrieve the number of cycles spent giving the semaphore */
 
 	cycles = timestamp.cycles;
-	cycles -= timestamp_overhead_adjustment(options, options);
 
 	snprintf(description, sizeof(description),
 		 "Give a semaphore (no waiters) from %s thread",
@@ -273,7 +272,6 @@ int sema_test_signal(uint32_t num_iterations, uint32_t options)
 	/* 9. Retrieve the number of cycles spent taking the semaphore */
 
 	cycles = timestamp.cycles;
-	cycles -= timestamp_overhead_adjustment(options, options);
 
 	snprintf(description, sizeof(description),
 		 "Take a semaphore (no blocking) from %s thread",


### PR DESCRIPTION
Updates the non-blocking semaphore and mutex benchmark sub-tests in the latency_measure benchmark to remove the timestamp bias adjustment. As the timestamps are not sampled during each iteration of those sub-tests, there is no need to correct for any bias from the sampling.

Fixes #66481