### PR TITLE
drivers: update stm32 display driver

### DIFF
--- a/boards/arm/stm32h747i_disco/CMakeLists.txt
+++ b/boards/arm/stm32h747i_disco/CMakeLists.txt
@@ -1,0 +1,9 @@
+#
+# Copyright 2023 BrainCo Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Add custom linker section to relocate framebuffers to PSRAM
+zephyr_linker_sources_ifdef(CONFIG_LV_Z_VBD_CUSTOM_SECTION
+  SECTIONS dc_ram.ld)

--- a/boards/arm/stm32h747i_disco/dc_ram.ld
+++ b/boards/arm/stm32h747i_disco/dc_ram.ld
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2023 BrainCo Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(sdram2), okay)
+GROUP_START(SDRAM2)
+
+	SECTION_PROLOGUE(_STM32_SDRAM2_SECTION_NAME, (NOLOAD),)
+	{
+		*(.lvgl_buf)
+	} GROUP_LINK_IN(SDRAM2)
+
+GROUP_END(SDRAM2)
+#endif

--- a/boards/shields/st_b_lcd40_dsi1_mb1166/Kconfig.defconfig
+++ b/boards/shields/st_b_lcd40_dsi1_mb1166/Kconfig.defconfig
@@ -1,0 +1,42 @@
+# Copyright (c) 2023 BrainCo Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+if SHIELD_ST_B_LCD40_DSI1_MB1166
+
+# Double frame buffer maintained by lvgl.
+if LVGL
+
+config STM32_LTDC_FB_NUM
+	default 0
+
+config INPUT
+	default y
+
+config LV_Z_VDB_SIZE
+	default 100
+
+config LV_Z_DOUBLE_VDB
+	default y
+
+config LV_Z_VBD_CUSTOM_SECTION
+	default y
+
+config LV_Z_FULL_REFRESH
+	default y
+
+config LV_Z_BITS_PER_PIXEL
+	default 32
+
+config LV_DPI_DEF
+	default 128
+
+config LV_Z_FLUSH_THREAD
+	default y
+
+choice LV_COLOR_DEPTH
+	default LV_COLOR_DEPTH_32
+endchoice
+
+endif # LVGL
+
+endif # SHIELD_ST_B_LCD40_DSI1_MB1166

--- a/boards/shields/st_b_lcd40_dsi1_mb1166/boards/stm32h747i_disco_m7.overlay
+++ b/boards/shields/st_b_lcd40_dsi1_mb1166/boards/stm32h747i_disco_m7.overlay
@@ -7,9 +7,20 @@
 #include <zephyr/dt-bindings/display/panel.h>
 
 / {
+	lvgl_pointer {
+		compatible = "zephyr,lvgl-pointer-input";
+		input = <&ft5336>;
+		invert-y;
+	};
+
 	chosen {
 		zephyr,display = &ltdc;
 	};
+};
+
+&sdram2 {
+	/* Frame buffer memory cache will cause screen flickering. */
+	zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE) )>;
 };
 
 &ltdc {
@@ -71,4 +82,16 @@
 	data-lanes = <2>;
 	pixel-format = <MIPI_DSI_PIXFMT_RGB888>;
 	rotation = <90>;
+};
+
+&i2c4 {
+	pinctrl-0 = <&i2c4_scl_pd12 &i2c4_sda_pd13>;
+	pinctrl-names = "default";
+	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
+
+	ft5336: ft5336@38 {
+		compatible = "focaltech,ft5336";
+		reg = <0x38>;
+	};
 };

--- a/drivers/display/Kconfig.stm32_ltdc
+++ b/drivers/display/Kconfig.stm32_ltdc
@@ -11,6 +11,8 @@ menuconfig STM32_LTDC
 	help
 	  Enable driver for STM32 LCT-TFT display controller periheral.
 
+if STM32_LTDC
+
 choice STM32_LTDC_PIXEL_FORMAT
 	prompt "Color pixel format"
 	default STM32_LTDC_RGB565
@@ -37,3 +39,23 @@ config STM32_LTDC_RGB565
 	  (2 bytes per pixel)
 
 endchoice
+
+config STM32_LTDC_FB_NUM
+	int "Frame buffer number"
+	default 1
+	range 0 2
+	help
+	  STM32 LTDC frame buffer number config:
+	    - 0 frame buffer maintained by application, must write with full screen pixels.
+	    - 1 single frame buffer in stm32 ltdc driver.
+	    - 2 double frame buffer in stm32 ltdc driver.
+
+config STM32_LTDC_DISABLE_FMC_BANK1
+	bool "Disable FMC bank1 for STM32F7/H7 series"
+	depends on SOC_SERIES_STM32H7X || SOC_SERIES_STM32F7X
+	default y
+	help
+	  Disable FMC bank1 if not used to prevent speculative read accesses.
+	  Refer to AN4861 "4.6 Special recommendations for Cortex-M7 (STM32F7/H7)".
+
+endif # STM32_LTDC

--- a/drivers/display/display_otm8009a.c
+++ b/drivers/display/display_otm8009a.c
@@ -324,7 +324,7 @@ static int otm8009a_configure(const struct device *dev)
 
 	/* not documented */
 	buf[0] = 0x00;
-	ret = otm8009a_mcs_write(dev, OTM8009A_MCS_NO_DOC2, buf, 3);
+	ret = otm8009a_mcs_write(dev, OTM8009A_MCS_NO_DOC2, buf, 1);
 	if (ret < 0) {
 		return ret;
 	}

--- a/drivers/display/display_stm32_ltdc.c
+++ b/drivers/display/display_stm32_ltdc.c
@@ -57,13 +57,13 @@ LOG_MODULE_REGISTER(display_stm32_ltdc, CONFIG_DISPLAY_LOG_LEVEL);
 #if defined(CONFIG_HAS_CMSIS_CORE_M)
 #include <cmsis_core.h>
 
-#if __DCACHE_PRESENT == 1
+#if defined(CONFIG_DCACHE)
 #define CACHE_INVALIDATE(addr, size)	SCB_InvalidateDCache_by_Addr((addr), (size))
 #define CACHE_CLEAN(addr, size)		SCB_CleanDCache_by_Addr((addr), (size))
 #else
 #define CACHE_INVALIDATE(addr, size)
 #define CACHE_CLEAN(addr, size)		barrier_dsync_fence_full();
-#endif /* __DCACHE_PRESENT == 1 */
+#endif /* CONFIG_DCACHE */
 
 #else
 #define CACHE_INVALIDATE(addr, size)
@@ -75,6 +75,10 @@ struct display_stm32_ltdc_data {
 	enum display_pixel_format current_pixel_format;
 	uint8_t current_pixel_size;
 	uint8_t *frame_buffer;
+	uint32_t frame_buffer_len;
+	const uint8_t *pend_buf;
+	const uint8_t *front_buf;
+	struct k_sem sem;
 };
 
 struct display_stm32_ltdc_config {
@@ -84,13 +88,26 @@ struct display_stm32_ltdc_config {
 	struct gpio_dt_spec bl_ctrl_gpio;
 	struct stm32_pclken pclken;
 	const struct pinctrl_dev_config *pctrl;
+	void (*irq_config_func)(const struct device *dev);
 };
 
-static void *stm32_ltdc_get_framebuffer(const struct device *dev)
+static void stm32_ltdc_global_isr(const struct device *dev)
 {
 	struct display_stm32_ltdc_data *data = dev->data;
 
-	return (void *) data->frame_buffer;
+	if (__HAL_LTDC_GET_FLAG(&data->hltdc, LTDC_FLAG_LI) &&
+	    __HAL_LTDC_GET_IT_SOURCE(&data->hltdc, LTDC_IT_LI)) {
+		if (data->front_buf != data->pend_buf) {
+			data->front_buf = data->pend_buf;
+
+			LTDC_LAYER(&data->hltdc, LTDC_LAYER_1)->CFBAR = (uint32_t)data->front_buf;
+			__HAL_LTDC_RELOAD_CONFIG(&data->hltdc);
+
+			k_sem_give(&data->sem);
+		}
+
+		__HAL_LTDC_CLEAR_FLAG(&data->hltdc, LTDC_FLAG_LI);
+	}
 }
 
 static int stm32_ltdc_set_pixel_format(const struct device *dev,
@@ -161,20 +178,59 @@ static int stm32_ltdc_write(const struct device *dev, const uint16_t x,
 {
 	const struct display_stm32_ltdc_config *config = dev->config;
 	struct display_stm32_ltdc_data *data = dev->data;
-	uint8_t *dst = data->frame_buffer;
+	uint8_t *dst = NULL;
+	const uint8_t *pend_buf = NULL;
 	const uint8_t *src = buf;
 	uint16_t row;
 
-	/* dst = pointer to upper left pixel of the rectangle to be updated in frame buffer */
-	dst += (x * data->current_pixel_size);
-	dst += (y * config->width * data->current_pixel_size);
+	if ((x == 0) && (y == 0) &&
+	    (desc->width == config->width) &&
+	    (desc->height ==  config->height) &&
+	    (desc->pitch == desc->width)) {
+		/* Use buf as ltdc frame buffer directly if it length same as ltdc frame buffer. */
+		pend_buf = buf;
+	} else {
+		if (CONFIG_STM32_LTDC_FB_NUM == 0)  {
+			LOG_ERR("Partial write requires internal frame buffer");
+			return -ENOTSUP;
+		}
 
-	for (row = 0; row < desc->height; row++) {
-		(void) memcpy(dst, src, desc->width * data->current_pixel_size);
-		CACHE_CLEAN(dst, desc->width * data->current_pixel_size);
-		dst += (config->width * data->current_pixel_size);
-		src += (desc->pitch * data->current_pixel_size);
+		dst = data->frame_buffer;
+
+		if (CONFIG_STM32_LTDC_FB_NUM == 2) {
+			if (data->front_buf == data->frame_buffer) {
+				dst = data->frame_buffer + data->frame_buffer_len;
+			}
+
+			memcpy(dst, data->front_buf, data->frame_buffer_len);
+		}
+
+		pend_buf = dst;
+
+		/* dst = pointer to upper left pixel of the rectangle
+		 *       to be updated in frame buffer.
+		 */
+		dst += (x * data->current_pixel_size);
+		dst += (y * config->width * data->current_pixel_size);
+
+		for (row = 0; row < desc->height; row++) {
+			(void) memcpy(dst, src, desc->width * data->current_pixel_size);
+			CACHE_CLEAN(dst, desc->width * data->current_pixel_size);
+			dst += (config->width * data->current_pixel_size);
+			src += (desc->pitch * data->current_pixel_size);
+		}
+
 	}
+
+	if (data->front_buf == pend_buf) {
+		return 0;
+	}
+
+	k_sem_reset(&data->sem);
+
+	data->pend_buf = pend_buf;
+
+	k_sem_take(&data->sem, K_FOREVER);
 
 	return 0;
 }
@@ -187,7 +243,7 @@ static int stm32_ltdc_read(const struct device *dev, const uint16_t x,
 	const struct display_stm32_ltdc_config *config = dev->config;
 	struct display_stm32_ltdc_data *data = dev->data;
 	uint8_t *dst = buf;
-	const uint8_t *src = data->frame_buffer;
+	const uint8_t *src = data->front_buf;
 	uint16_t row;
 
 	/* src = pointer to upper left pixel of the rectangle to be read from frame buffer */
@@ -283,18 +339,40 @@ static int stm32_ltdc_init(const struct device *dev)
 	data->current_pixel_format = DISPLAY_INIT_PIXEL_FORMAT;
 	data->current_pixel_size = STM32_LTDC_INIT_PIXEL_SIZE;
 
+	k_sem_init(&data->sem, 0, 1);
+
+	config->irq_config_func(dev);
+
+#ifdef CONFIG_STM32_LTDC_DISABLE_FMC_BANK1
+	/* Clear MBKEN and MTYP[1:0] bits. */
+#ifdef CONFIG_SOC_SERIES_STM32F7X
+	FMC_Bank1->BTCR[0] &= ~(0x0000000D);
+#else /* CONFIG_SOC_SERIES_STM32H7X */
+	FMC_Bank1_R->BTCR[0] &= ~(0x0000000D);
+#endif
+#endif /* CONFIG_STM32_LTDC_DISABLE_FMC_BANK1 */
+
 	/* Initialise the LTDC peripheral */
 	err = HAL_LTDC_Init(&data->hltdc);
 	if (err != HAL_OK) {
 		return err;
 	}
 
-	/* Configure layer 0 (only one layer is used) */
+	/* Configure layer 1 (only one layer is used) */
 	/* LTDC starts fetching pixels and sending them to display after this call */
-	err = HAL_LTDC_ConfigLayer(&data->hltdc, &data->hltdc.LayerCfg[0], 0);
+	err = HAL_LTDC_ConfigLayer(&data->hltdc, &data->hltdc.LayerCfg[0], LTDC_LAYER_1);
 	if (err != HAL_OK) {
 		return err;
 	}
+
+	/* Disable layer 2, since it not used */
+	__HAL_LTDC_LAYER_DISABLE(&data->hltdc, LTDC_LAYER_2);
+
+	/* Set the line interrupt position */
+	LTDC->LIPCR = 0U;
+
+	__HAL_LTDC_CLEAR_FLAG(&data->hltdc, LTDC_FLAG_LI);
+	__HAL_LTDC_ENABLE_IT(&data->hltdc, LTDC_IT_LI);
 
 	return 0;
 }
@@ -359,7 +437,6 @@ static int stm32_ltdc_pm_action(const struct device *dev,
 static const struct display_driver_api stm32_ltdc_display_api = {
 	.write = stm32_ltdc_write,
 	.read = stm32_ltdc_read,
-	.get_framebuffer = stm32_ltdc_get_framebuffer,
 	.get_capabilities = stm32_ltdc_get_capabilities,
 	.set_pixel_format = stm32_ltdc_set_pixel_format,
 	.set_orientation = stm32_ltdc_set_orientation
@@ -388,16 +465,30 @@ static const struct display_driver_api stm32_ltdc_display_api = {
 #define STM32_LTDC_DEVICE_PINCTRL_GET(n) PINCTRL_DT_INST_DEV_CONFIG_GET(n)
 #endif
 
+#define STM32_LTDC_FRAME_BUFFER_LEN(inst)							\
+	(STM32_LTDC_INIT_PIXEL_SIZE * DT_INST_PROP(inst, height) * DT_INST_PROP(inst, width))	\
+
 #define STM32_LTDC_DEVICE(inst)									\
 	STM32_LTDC_DEVICE_PINCTRL_INIT(inst);							\
 	PM_DEVICE_DT_INST_DEFINE(inst, stm32_ltdc_pm_action);					\
+	static void stm32_ltdc_irq_config_func_##inst(const struct device *dev)			\
+	{											\
+		IRQ_CONNECT(DT_INST_IRQN(inst),							\
+			    DT_INST_IRQ(inst, priority),					\
+			    stm32_ltdc_global_isr,						\
+			    DEVICE_DT_INST_GET(inst),						\
+			    0);									\
+		irq_enable(DT_INST_IRQN(inst));							\
+	}											\
 	/* frame buffer aligned to cache line width for optimal cache flushing */		\
 	FRAME_BUFFER_SECTION static uint8_t __aligned(32)					\
-				frame_buffer_##inst[STM32_LTDC_INIT_PIXEL_SIZE *		\
-						DT_INST_PROP(inst, height) *			\
-						DT_INST_PROP(inst, width)];			\
+				frame_buffer_##inst[CONFIG_STM32_LTDC_FB_NUM *			\
+							STM32_LTDC_FRAME_BUFFER_LEN(inst)];	\
 	static struct display_stm32_ltdc_data stm32_ltdc_data_##inst = {			\
 		.frame_buffer = frame_buffer_##inst,						\
+		.frame_buffer_len = STM32_LTDC_FRAME_BUFFER_LEN(inst),				\
+		.front_buf = frame_buffer_##inst,						\
+		.pend_buf = frame_buffer_##inst,						\
 		.hltdc = {									\
 			.Instance = (LTDC_TypeDef *) DT_INST_REG_ADDR(inst),			\
 			.Init = {								\
@@ -492,6 +583,7 @@ static const struct display_driver_api stm32_ltdc_display_api = {
 			.bus = DT_INST_CLOCKS_CELL(inst, bus)					\
 		},										\
 		.pctrl = STM32_LTDC_DEVICE_PINCTRL_GET(inst),					\
+		.irq_config_func = stm32_ltdc_irq_config_func_##inst,				\
 	};											\
 	DEVICE_DT_INST_DEFINE(inst,								\
 			&stm32_ltdc_init,							\


### PR DESCRIPTION
Introduce frame buffer config to stm32 ltdc driver, line interrupt is added to sync frame buffer update. Also, FMC bank1 is disabled, more refer `AN4861 4.6 Special recommendations for Cortex-M7 (STM32F7/H7)`.

After compared with STM32CubeH7, their have some different implement in SDRAM, OTM8009A, LTDC and DSI driver. List them in here, so we can recheck it now.

Their still have some problem:
   1. LVGL music demo have some small white rantagle block.
       Update(2023/12/16): Looks caused by SDRAM2 memory attribute. Render looks good, if remove SDRAM2 memory attribute with `/delete-property/ zephyr,memory-attr;`.

  2. When updating a larger area, the diagonal lines of the screen drawn not properly.
      Not fix in this PR.


