### PR TITLE
drivers: adc: stm32 adc support h7 dual core lines

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -567,7 +567,8 @@ static int adc_stm32_calibrate(const struct device *dev)
 	adc_stm32_calibration_start(dev);
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32f1_adc) */
 
-#ifdef CONFIG_SOC_SERIES_STM32H7X
+#if defined(CONFIG_SOC_SERIES_STM32H7X) && \
+	defined(CONFIG_CPU_CORTEX_M7)
 	/*
 	 * To ensure linearity the factory calibration values
 	 * should be loaded on initialization.


### PR DESCRIPTION
For STM32H7 dual core lines, M4 can not access to linear calib addr ADC_LINEAR_CALIB_REG_1_ADDR.