### PR TITLE
intel_adsp: lnl: add missing definition for lnl

### DIFF
--- a/soc/xtensa/intel_adsp/ace/include/intel_ace20_lnl/adsp_shim.h
+++ b/soc/xtensa/intel_adsp/ace/include/intel_ace20_lnl/adsp_shim.h
@@ -170,4 +170,6 @@ struct ace_dfpmccu {
 #define GENO_MDIVOSEL           BIT(1)
 #define GENO_DIOPTOSEL          BIT(2)
 
+#define ADSP_FORCE_DECOUPLED_HDMA_L1_EXIT_BIT BIT(1)
+
 #endif /* ZEPHYR_SOC_INTEL_ADSP_SHIM_H_ */


### PR DESCRIPTION
Definition of ADSP_FORCE_DECOUPLED_HDMA_L1_EXIT_BIT,
which is used in the intel_adsp_force_dmi_l0_state function,
is missing.
