### PR TITLE
sysbuild: kconfig: Unset shield config value variable

### DIFF
--- a/share/sysbuild/cmake/modules/sysbuild_kconfig.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_kconfig.cmake
@@ -67,6 +67,9 @@ if(DEFINED BOARD_REVISION)
   set(BOARD_REVISION_CONFIG "${CMAKE_CURRENT_BINARY_DIR}/empty.conf")
 endif()
 
+# Unset shield configuration files if set to prevent including in sysbuild
+set(shield_conf_files)
+
 list(APPEND ZEPHYR_KCONFIG_MODULES_DIR BOARD=${BOARD})
 set(KCONFIG_NAMESPACE SB_CONFIG)
 


### PR DESCRIPTION
Fixes an issue with shields that have Kconfig file fragments when being used with sysbuild, they would be loaded into sysbuild itself which would then fail because it does not have the Kconfig tree that zephyr applications have

Fixes #66560