### PR TITLE
doc: Clean up wrong c function links

### DIFF
--- a/doc/kernel/services/interrupts.rst
+++ b/doc/kernel/services/interrupts.rst
@@ -554,7 +554,7 @@ This is an array of struct z_shared_isr_table_entry:
     };
 
 This table keeps track of the registered clients for each of the interrupt
-lines. Whenever an interrupt line becomes shared, c:func:`z_shared_isr` will
+lines. Whenever an interrupt line becomes shared, :c:func:`z_shared_isr` will
 replace the currently registered ISR in _sw_isr_table. This special ISR will
 iterate through the list of registered clients and invoke the ISRs.
 

--- a/doc/services/rtio/index.rst
+++ b/doc/services/rtio/index.rst
@@ -178,7 +178,7 @@ by calling :c:func:`rtio_sqe_rx_buf` like so:
   }
 
 Finally, the consumer will be able to access the allocated buffer via
-c:func:`rtio_cqe_get_mempool_buffer`.
+:c:func:`rtio_cqe_get_mempool_buffer`.
 
 .. code-block:: C
 

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -418,7 +418,7 @@ typedef int (*sensor_channel_get_t)(const struct device *dev,
  * @brief Decodes a single raw data buffer
  *
  * Data buffers are provided on the @ref rtio context that's supplied to
- * c:func:`sensor_read`.
+ * @ref sensor_read.
  */
 struct sensor_decoder_api {
 	/**


### PR DESCRIPTION
Resolve wrong documentation c function links for:
- irq: z_shared_isr
- rtio: rtio_cqe_get_mempool_buffer
- sensor: sensor_read