### PR TITLE
Cleanup cache initialization

### DIFF
--- a/arch/arc/core/cache.c
+++ b/arch/arc/core/cache.c
@@ -218,8 +218,7 @@ int arch_icache_flush_and_invd_range(void *addr, size_t size)
 
 static int init_dcache(void)
 {
-
-	arch_dcache_enable();
+	sys_cache_data_enable();
 
 #if defined(CONFIG_DCACHE_LINE_SIZE_DETECT)
 	init_dcache_line_size();

--- a/arch/arm/core/cortex_m/scb.c
+++ b/arch/arm/core/cortex_m/scb.c
@@ -21,6 +21,7 @@
 #include <cmsis_core.h>
 #include <zephyr/linker/linker-defs.h>
 #include <zephyr/cache.h>
+#include <zephyr/arch/cache.h>
 
 #if defined(CONFIG_CPU_HAS_NXP_MPU)
 #include <fsl_sysmpu.h>
@@ -120,15 +121,27 @@ void z_arm_init_arch_hw_at_boot(void)
 	 * reset it to a known clean state.
 	 */
 	if (SCB->CCR & SCB_CCR_DC_Msk) {
-		sys_cache_data_disable();
+		/*
+		 * Do not use sys_cache_data_disable at this point, but instead
+		 * the architecture specific function. This ensures that the
+		 * cache is disabled although CONFIG_CACHE_MANAGEMENT might be
+		 * disabled.
+		 */
+		SCB_DisableDCache();
 	} else {
-		sys_cache_data_invd_all();
+		SCB_InvalidateDCache();
 	}
 #endif /* CONFIG_DCACHE */
 
 #if defined(CONFIG_ICACHE)
-	/* Reset I-Cache settings. */
-	sys_cache_instr_disable();
+	/*
+	 * Reset I-Cache settings.
+	 * Do not use sys_cache_data_disable at this point, but instead
+	 * the architecture specific function. This ensures that the
+	 * cache is disabled although CONFIG_CACHE_MANAGEMENT might be
+	 * disabled.
+	 */
+	SCB_DisableICache();
 #endif /* CONFIG_ICACHE */
 #endif /* CONFIG_ARCH_CACHE */
 

--- a/soc/arm/atmel_sam/same70/Kconfig.series
+++ b/soc/arm/atmel_sam/same70/Kconfig.series
@@ -14,6 +14,7 @@ config SOC_SERIES_SAME70
 	select CPU_HAS_ICACHE
 	select CPU_HAS_DCACHE
 	select SOC_FAMILY_SAM
+	select INIT_ARCH_HW_AT_BOOT
 	select PLATFORM_SPECIFIC_INIT
 	select ASF
 	select HAS_SWO

--- a/soc/arm/atmel_sam/samv71/Kconfig.series
+++ b/soc/arm/atmel_sam/samv71/Kconfig.series
@@ -14,6 +14,7 @@ config SOC_SERIES_SAMV71
 	select CPU_HAS_ICACHE
 	select CPU_HAS_DCACHE
 	select SOC_FAMILY_SAM
+	select INIT_ARCH_HW_AT_BOOT
 	select PLATFORM_SPECIFIC_INIT
 	select ASF
 	select HAS_SWO

--- a/soc/arm/nxp_imx/rt/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt/Kconfig.soc
@@ -834,16 +834,4 @@ config SECOND_CORE_MCUX
 	  generated header specifying the VMA and LMA of each memory section
 	  to load
 
-config IMXRT1XXX_CODE_CACHE
-	bool "Code cache"
-	default y
-	help
-	  Enable Code cache at boot for IMXRT1xxx series
-
-config IMXRT1XXX_DATA_CACHE
-	bool "Data cache"
-	default y
-	help
-	  Enable Data cache at boot for IMXRT1xxx series
-
 endif # SOC_SERIES_IMX_RT

--- a/soc/arm/nxp_imx/rt/soc_rt10xx.c
+++ b/soc/arm/nxp_imx/rt/soc_rt10xx.c
@@ -10,6 +10,7 @@
 #include <soc.h>
 #include <zephyr/linker/sections.h>
 #include <zephyr/linker/linker-defs.h>
+#include <zephyr/cache.h>
 #include <fsl_clock.h>
 #ifdef CONFIG_NXP_IMX_RT_BOOT_HEADER
 #include <fsl_flexspi_nor_boot.h>
@@ -318,23 +319,8 @@ void imxrt_audio_codec_pll_init(uint32_t clock_name, uint32_t clk_src,
 
 static int imxrt_init(void)
 {
-#ifndef CONFIG_IMXRT1XXX_CODE_CACHE
-	/* SystemInit enables code cache, disable it here */
-	SCB_DisableICache();
-#else
-	/* z_arm_init_arch_hw_at_boot() disables code cache if CONFIG_ARCH_CACHE is enabled,
-	 * enable it here.
-	 */
-	SCB_EnableICache();
-#endif
-
-	if (IS_ENABLED(CONFIG_IMXRT1XXX_DATA_CACHE)) {
-		if ((SCB->CCR & SCB_CCR_DC_Msk) == 0) {
-			SCB_EnableDCache();
-		}
-	} else {
-		SCB_DisableDCache();
-	}
+	sys_cache_instr_enable();
+	sys_cache_data_enable();
 
 	/* Initialize system clock */
 	clock_init();

--- a/soc/arm/nxp_imx/rt/soc_rt11xx.c
+++ b/soc/arm/nxp_imx/rt/soc_rt11xx.c
@@ -10,6 +10,7 @@
 #include <soc.h>
 #include <zephyr/linker/sections.h>
 #include <zephyr/linker/linker-defs.h>
+#include <zephyr/cache.h>
 #include <fsl_clock.h>
 #include <fsl_gpc.h>
 #include <fsl_pmu.h>
@@ -673,23 +674,8 @@ static int imxrt_init(void)
 
 
 #if defined(CONFIG_SOC_MIMXRT1176_CM7) || defined(CONFIG_SOC_MIMXRT1166_CM7)
-#ifndef CONFIG_IMXRT1XXX_CODE_CACHE
-	/* SystemInit enables code cache, disable it here */
-	SCB_DisableICache();
-#else
-	/* z_arm_init_arch_hw_at_boot() disables code cache if CONFIG_ARCH_CACHE is enabled,
-	 * enable it here.
-	 */
-	SCB_EnableICache();
-#endif
-
-	if (IS_ENABLED(CONFIG_IMXRT1XXX_DATA_CACHE)) {
-		if ((SCB->CCR & SCB_CCR_DC_Msk) == 0) {
-			SCB_EnableDCache();
-		}
-	} else {
-		SCB_DisableDCache();
-	}
+	sys_cache_instr_enable();
+	sys_cache_data_enable();
 #endif
 
 	/* Initialize system clock */

--- a/soc/arm/nxp_kinetis/kv5x/Kconfig.soc
+++ b/soc/arm/nxp_kinetis/kv5x/Kconfig.soc
@@ -57,12 +57,4 @@ config SOC_PART_NUMBER_KINETIS_KV5X
 	  number selection choice defines the default value for this
 	  string.
 
-config KINETIS_KV5X_ENABLE_CODE_CACHE
-	bool "Code cache"
-	default y
-
-config KINETIS_KV5X_ENABLE_DATA_CACHE
-	bool "Data cache"
-	default y
-
 endif # SOC_SERIES_KINETIS_KV5X

--- a/soc/arm/nxp_kinetis/kv5x/soc.c
+++ b/soc/arm/nxp_kinetis/kv5x/soc.c
@@ -11,6 +11,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/init.h>
+#include <zephyr/cache.h>
 #include <fsl_common.h>
 #include <fsl_clock.h>
 
@@ -90,14 +91,8 @@ static int kv5x_init(void)
 	/* Initialize system clocks and PLL */
 	clk_init();
 
-#ifndef CONFIG_KINETIS_KV5X_ENABLE_CODE_CACHE
-	/* SystemInit will have enabled the code cache. Disable it here */
-	SCB_DisableICache();
-#endif
-#ifndef CONFIG_KINETIS_KV5X_ENABLE_DATA_CACHE
-	/* SystemInit will have enabled the data cache. Disable it here */
-	SCB_DisableDCache();
-#endif
+	sys_cache_instr_enable();
+	sys_cache_data_enable();
 
 	return 0;
 }

--- a/soc/arm/nxp_s32/s32k3/soc.c
+++ b/soc/arm/nxp_s32/s32k3/soc.c
@@ -7,6 +7,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/init.h>
+#include <zephyr/cache.h>
 
 #include <cmsis_core.h>
 #include <OsIf.h>
@@ -50,13 +51,8 @@ const struct ivt ivt_header __attribute__((section(".ivt_header"))) = {
 
 static int soc_init(void)
 {
-	SCB_EnableICache();
-
-	if (IS_ENABLED(CONFIG_DCACHE)) {
-		if (!(SCB->CCR & SCB_CCR_DC_Msk)) {
-			SCB_EnableDCache();
-		}
-	}
+	sys_cache_instr_enable();
+	sys_cache_data_enable();
 
 	OsIf_Init(NULL);
 

--- a/soc/arm/st_stm32/stm32f7/soc.c
+++ b/soc/arm/st_stm32/stm32f7/soc.c
@@ -12,6 +12,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/init.h>
+#include <zephyr/cache.h>
 #include <soc.h>
 
 #include <cmsis_core.h>
@@ -30,13 +31,8 @@ static int st_stm32f7_init(void)
 	/* Enable ART Flash cache accelerator */
 	LL_FLASH_EnableART();
 
-	if (IS_ENABLED(CONFIG_ICACHE)) {
-		SCB_EnableICache();
-	}
-
-	if (IS_ENABLED(CONFIG_DCACHE)) {
-		SCB_EnableDCache();
-	}
+	sys_cache_instr_enable();
+	sys_cache_data_enable();
 
 	/* Update CMSIS SystemCoreClock variable (HCLK) */
 	/* At reset, system core clock is set to 16 MHz from HSI */

--- a/soc/arm/st_stm32/stm32h7/soc_m7.c
+++ b/soc/arm/st_stm32/stm32h7/soc_m7.c
@@ -12,6 +12,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/init.h>
+#include <zephyr/cache.h>
 #include <soc.h>
 #include <stm32_ll_bus.h>
 #include <stm32_ll_pwr.h>
@@ -54,13 +55,8 @@ static int stm32h7_m4_wakeup(void)
  */
 static int stm32h7_init(void)
 {
-	if (IS_ENABLED(CONFIG_ICACHE)) {
-		SCB_EnableICache();
-	}
-
-	if (IS_ENABLED(CONFIG_DCACHE)) {
-		SCB_EnableDCache();
-	}
+	sys_cache_instr_enable();
+	sys_cache_data_enable();
 
 	/* Update CMSIS SystemCoreClock variable (HCLK) */
 	/* At reset, system core clock is set to 64 MHz from HSI */


### PR DESCRIPTION
Data and instruction cache initialization is currently a little bit messy. This PR aims at unifying the available config options and providing a more consistent approach on cache activation.

This is a follow up to #66443.

Open is to check where the caches were automatically enabled previously (SystemInit, Hal, ...) and disabling them directly after.
- [ ] soc_rt10xx.c
- [ ] soc_rt11xx.c
- [ ] kv5x/soc.c
- [x] same70/soc.c
- [x] samv71/soc.c