### PR TITLE
ipc_service: open-amp: Fix libmetal shared memory registration

### DIFF
--- a/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.c
+++ b/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.c
@@ -555,6 +555,7 @@ static int open(const struct device *instance)
 
 	data->vr.notify_cb = virtio_notify_cb;
 	data->vr.priv = (void *) conf;
+	data->vr.shm_device.name = instance->name;
 
 	err = ipc_static_vrings_init(&data->vr, conf->role);
 	if (err != 0) {

--- a/subsys/ipc/ipc_service/lib/ipc_static_vrings.c
+++ b/subsys/ipc/ipc_service/lib/ipc_static_vrings.c
@@ -7,7 +7,7 @@
 #include <zephyr/ipc/ipc_static_vrings.h>
 #include <zephyr/cache.h>
 
-#define SHM_DEVICE_NAME		"sram0.shm"
+#define SHM_DEVICE_DEFAULT_NAME		"sram0.shm"
 
 #define RPMSG_VQ_0		(0) /* TX virtqueue queue index */
 #define RPMSG_VQ_1		(1) /* RX virtqueue queue index */
@@ -88,7 +88,7 @@ static int libmetal_setup(struct ipc_static_vrings *vr)
 		return err;
 	}
 
-	err = metal_device_open("generic", SHM_DEVICE_NAME, &device);
+	err = metal_device_open("generic", vr->shm_device.name, &device);
 	if (err != 0) {
 		return err;
 	}
@@ -166,7 +166,8 @@ int ipc_static_vrings_init(struct ipc_static_vrings *vr, unsigned int role)
 		return -EINVAL;
 	}
 
-	vr->shm_device.name = SHM_DEVICE_NAME;
+	if (!vr->shm_device.name)
+		vr->shm_device.name = SHM_DEVICE_DEFAULT_NAME;
 	vr->shm_device.num_regions = 1;
 	vr->shm_physmap[0] = vr->shm_addr;
 


### PR DESCRIPTION
When using multiple instances of IPC static vring, each instance should register its shared memory with a unique name. Instead of a predefined default name, the name of the ipc instance is reused for the metal device name.