### PR TITLE
test: mcuboot: enable test on rt1010/1015/1040 and k22f/82f platforms

### DIFF
--- a/tests/boot/test_mcuboot/testcase.yaml
+++ b/tests/boot/test_mcuboot/testcase.yaml
@@ -13,9 +13,14 @@ tests:
   bootloader.mcuboot:
     tags: mcuboot
     platform_allow:
+      - frdm_k22f
       - frdm_k64f
+      - frdm_k82f
+      - mimxrt1010_evk
+      - mimxrt1015_evk
       - mimxrt1020_evk
       - mimxrt1024_evk
+      - mimxrt1040_evk
       - mimxrt1050_evk
       - mimxrt1060_evk
       - mimxrt1064_evk


### PR DESCRIPTION
Enable mcuboot test for mimxrt1010/1015/1040 and frdm_k22f/82f boards