### PR TITLE
retention: Increase read size variables to 16-bit

### DIFF
--- a/doc/releases/release-notes-3.6.rst
+++ b/doc/releases/release-notes-3.6.rst
@@ -316,6 +316,9 @@ Libraries / Subsystems
 
 * Retention
 
+  * Fixed issue whereby :kconfig:option:`CONFIG_RETENTION_BUFFER_SIZE` values over 256 would cause
+    an infinite loop due to use of 8-bit variables.
+
 * Binary descriptors
 
 * POSIX API

--- a/subsys/retention/retention.c
+++ b/subsys/retention/retention.c
@@ -96,7 +96,7 @@ static int retention_checksum(const struct device *dev, uint32_t *output)
 		*output = 0;
 
 		while (pos < end) {
-			uint8_t read_size = MIN((end - pos), sizeof(buffer));
+			uint16_t read_size = MIN((end - pos), sizeof(buffer));
 
 			rc = retained_mem_read(config->parent, pos, buffer, read_size);
 
@@ -188,7 +188,7 @@ int retention_is_valid(const struct device *dev)
 		off_t pos = 0;
 
 		while (pos < config->prefix_len) {
-			uint8_t read_size = MIN((config->prefix_len - pos), sizeof(buffer));
+			uint16_t read_size = MIN((config->prefix_len - pos), sizeof(buffer));
 
 			rc = retained_mem_read(config->parent, (config->offset + pos), buffer,
 					       read_size);


### PR DESCRIPTION
    Increases 2 variables to be 16-bits instead of 8-bits to allow
    for target read sizes, this would only be an issue if someone
    changed the default retention block size from the default value
    of 16 to a value over 256
