### PR TITLE
net: lib: coap: Use coap_transmission_parameters in coap_server

### DIFF
--- a/doc/connectivity/networking/api/coap_server.rst
+++ b/doc/connectivity/networking/api/coap_server.rst
@@ -97,7 +97,7 @@ The following is an example of a CoAP resource registered with our service:
         coap_packet_append_payload(&response, (uint8_t *)msg, sizeof(msg));
 
         /* Send to response back to the client */
-        return coap_resource_send(resource, &response, addr, addr_len);
+        return coap_resource_send(resource, &response, addr, addr_len, NULL);
     }
 
     static int my_put(struct coap_resource *resource, struct coap_packet *request,
@@ -178,7 +178,7 @@ of CoAP services. An example using a temperature sensor can look like:
         coap_packet_append_payload_marker(&response);
         coap_packet_append_payload(&response, (uint8_t *)payload, strlen(payload));
 
-        return coap_resource_send(resource, &response, addr, addr_len);
+        return coap_resource_send(resource, &response, addr, addr_len, NULL);
     }
 
     static int temp_get(struct coap_resource *resource, struct coap_packet *request,

--- a/doc/releases/migration-guide-3.6.rst
+++ b/doc/releases/migration-guide-3.6.rst
@@ -242,6 +242,10 @@ Networking
   use default values.
   (:github:`66482`)
 
+* The CoAP public API functions :c:func:`coap_service_send` and :c:func:`coap_resource_send` have
+  changed. An additional parameter pointer to :c:struct:`coap_transmission_parameters` has been
+  added. It is safe to pass a NULL pointer to use default values. (:github:`66540`)
+
 * The IGMP multicast library now supports IGMPv3. This results in a minor change to the existing
   api. The :c:func:`net_ipv4_igmp_join` now takes an additional argument of the type
   ``const struct igmp_param *param``. This allows IGMPv3 to exclude/include certain groups of

--- a/include/zephyr/net/coap_service.h
+++ b/include/zephyr/net/coap_service.h
@@ -235,10 +235,12 @@ int coap_service_is_running(const struct coap_service *service);
  * @param cpkt CoAP Packet to send
  * @param addr Peer address
  * @param addr_len Peer address length
+ * @param params Pointer to transmission parameters structure or NULL to use default values.
  * @return 0 in case of success or negative in case of error.
  */
 int coap_service_send(const struct coap_service *service, const struct coap_packet *cpkt,
-		      const struct sockaddr *addr, socklen_t addr_len);
+		      const struct sockaddr *addr, socklen_t addr_len,
+		      const struct coap_transmission_parameters *params);
 
 /**
  * @brief Send a CoAP message from the provided @p resource .
@@ -249,10 +251,12 @@ int coap_service_send(const struct coap_service *service, const struct coap_pack
  * @param cpkt CoAP Packet to send
  * @param addr Peer address
  * @param addr_len Peer address length
+ * @param params Pointer to transmission parameters structure or NULL to use default values.
  * @return 0 in case of success or negative in case of error.
  */
 int coap_resource_send(const struct coap_resource *resource, const struct coap_packet *cpkt,
-		       const struct sockaddr *addr, socklen_t addr_len);
+		       const struct sockaddr *addr, socklen_t addr_len,
+		       const struct coap_transmission_parameters *params);
 
 /**
  * @brief Parse a CoAP observe request for the provided @p resource .

--- a/samples/net/sockets/coap_server/src/core.c
+++ b/samples/net/sockets/coap_server/src/core.c
@@ -45,7 +45,7 @@ static int core_get(struct coap_resource *resource,
 		return r;
 	}
 
-	r = coap_resource_send(resource, &response, addr, addr_len);
+	r = coap_resource_send(resource, &response, addr, addr_len, NULL);
 
 	return r;
 }

--- a/samples/net/sockets/coap_server/src/large.c
+++ b/samples/net/sockets/coap_server/src/large.c
@@ -87,7 +87,7 @@ static int large_get(struct coap_resource *resource,
 		memset(&ctx, 0, sizeof(ctx));
 	}
 
-	r = coap_resource_send(resource, &response, addr, addr_len);
+	r = coap_resource_send(resource, &response, addr, addr_len, NULL);
 
 	return r;
 }
@@ -167,7 +167,7 @@ static int large_update_put(struct coap_resource *resource,
 		return r;
 	}
 
-	r = coap_resource_send(resource, &response, addr, addr_len);
+	r = coap_resource_send(resource, &response, addr, addr_len, NULL);
 
 	return r;
 }
@@ -239,7 +239,7 @@ static int large_create_post(struct coap_resource *resource,
 		return r;
 	}
 
-	r = coap_resource_send(resource, &response, addr, addr_len);
+	r = coap_resource_send(resource, &response, addr, addr_len, NULL);
 
 	return r;
 }

--- a/samples/net/sockets/coap_server/src/location_query.c
+++ b/samples/net/sockets/coap_server/src/location_query.c
@@ -59,7 +59,7 @@ static int location_query_post(struct coap_resource *resource,
 		}
 	}
 
-	r = coap_resource_send(resource, &response, addr, addr_len);
+	r = coap_resource_send(resource, &response, addr, addr_len, NULL);
 
 	return r;
 }

--- a/samples/net/sockets/coap_server/src/observer.c
+++ b/samples/net/sockets/coap_server/src/observer.c
@@ -80,7 +80,7 @@ static int send_notification_packet(struct coap_resource *resource,
 
 	k_work_reschedule(&obs_work, K_SECONDS(5));
 
-	r = coap_resource_send(resource, &response, addr, addr_len);
+	r = coap_resource_send(resource, &response, addr, addr_len, NULL);
 
 	return r;
 }

--- a/samples/net/sockets/coap_server/src/query.c
+++ b/samples/net/sockets/coap_server/src/query.c
@@ -89,7 +89,7 @@ static int query_get(struct coap_resource *resource,
 		return r;
 	}
 
-	r = coap_resource_send(resource, &response, addr, addr_len);
+	r = coap_resource_send(resource, &response, addr, addr_len, NULL);
 
 	return r;
 }

--- a/samples/net/sockets/coap_server/src/separate.c
+++ b/samples/net/sockets/coap_server/src/separate.c
@@ -43,7 +43,7 @@ static int separate_get(struct coap_resource *resource,
 		return r;
 	}
 
-	r = coap_resource_send(resource, &response, addr, addr_len);
+	r = coap_resource_send(resource, &response, addr, addr_len, NULL);
 	if (r < 0) {
 		return r;
 	}
@@ -86,7 +86,7 @@ static int separate_get(struct coap_resource *resource,
 		return r;
 	}
 
-	r = coap_resource_send(resource, &response, addr, addr_len);
+	r = coap_resource_send(resource, &response, addr, addr_len, NULL);
 
 	return r;
 }

--- a/samples/net/sockets/coap_server/src/test.c
+++ b/samples/net/sockets/coap_server/src/test.c
@@ -73,7 +73,7 @@ static int piggyback_get(struct coap_resource *resource,
 		return r;
 	}
 
-	r = coap_resource_send(resource, &response, addr, addr_len);
+	r = coap_resource_send(resource, &response, addr, addr_len, NULL);
 
 	return r;
 }
@@ -113,7 +113,7 @@ static int test_del(struct coap_resource *resource,
 		return r;
 	}
 
-	r = coap_resource_send(resource, &response, addr, addr_len);
+	r = coap_resource_send(resource, &response, addr, addr_len, NULL);
 
 	return r;
 }
@@ -160,7 +160,7 @@ static int test_put(struct coap_resource *resource,
 		return r;
 	}
 
-	r = coap_resource_send(resource, &response, addr, addr_len);
+	r = coap_resource_send(resource, &response, addr, addr_len, NULL);
 
 	return r;
 }
@@ -221,7 +221,7 @@ static int test_post(struct coap_resource *resource,
 		}
 	}
 
-	r = coap_resource_send(resource, &response, addr, addr_len);
+	r = coap_resource_send(resource, &response, addr, addr_len, NULL);
 
 	return r;
 }

--- a/subsys/net/lib/coap/Kconfig
+++ b/subsys/net/lib/coap/Kconfig
@@ -202,12 +202,6 @@ config COAP_SERVICE_PENDING_MESSAGES
 	help
 	  Maximum number of pending CoAP messages to retransmit per active service.
 
-config COAP_SERVICE_PENDING_RETRANSMITS
-	int "CoAP retransmit count"
-	default 2
-	help
-	  Maximum number of retries to send a pending message.
-
 config COAP_SERVICE_OBSERVERS
 	int "CoAP service observers"
 	default 3


### PR DESCRIPTION
Update `coap_service_send` and `coap_resource_send` to take an optional pointer argument to the newly introduced `coap_transmission_parameters`.

Depends on #66482