### PR TITLE
doc: kernel: services: data_passing: mailboxes: remove extra period

### DIFF
--- a/doc/kernel/services/data_passing/mailboxes.rst
+++ b/doc/kernel/services/data_passing/mailboxes.rst
@@ -420,7 +420,7 @@ The receiving thread must then respond as follows:
   the data into the message buffer and deletes the message.
 
 * If the message descriptor size is non-zero and the receiving thread does *not*
-  want to retrieve the data, the thread must call :c:func:`k_mbox_data_get`.
+  want to retrieve the data, the thread must call :c:func:`k_mbox_data_get`
   and specify a message buffer of ``NULL``. The mailbox deletes
   the message without copying the data.
 


### PR DESCRIPTION
Removed extra period after 'k_mbox_data_get()' in the 'Retrieving Data Later Using a Message Buffer' section, third bullet point. This helps documentation clarity.

#66016