### PR TITLE
doc: remove explicit libpython3.8-dev from Ubuntu deps

### DIFF
--- a/doc/develop/getting_started/installation_linux.rst
+++ b/doc/develop/getting_started/installation_linux.rst
@@ -78,7 +78,7 @@ need one.
 
          sudo apt-get install --no-install-recommends git cmake ninja-build gperf \
            ccache dfu-util device-tree-compiler wget \
-           python3-dev python3-pip python3-setuptools python3-tk python3-wheel xz-utils file libpython3.8-dev \
+           python3-dev python3-pip python3-setuptools python3-tk python3-wheel xz-utils file \
            make gcc gcc-multilib g++-multilib libsdl2-dev libmagic1
 
    .. group-tab:: Fedora


### PR DESCRIPTION
Having libpython3.8-dev explicitly mentioned causes issues if "python3-dev" pulls a Python version that's not 3.8. What's more, python3-dev already pulls the correct "versionless" libpython3-dev anyway.

Fixes #66461