### PR TITLE
cmake: mcuboot: set align to 1 for overwrite only mode

### DIFF
--- a/cmake/mcuboot.cmake
+++ b/cmake/mcuboot.cmake
@@ -98,7 +98,7 @@ function(zephyr_mcuboot_tasks)
 
   # Use overwrite-only instead of swap upgrades.
   if(CONFIG_MCUBOOT_IMGTOOL_OVERWRITE_ONLY)
-    set(imgtool_extra --overwrite-only ${imgtool_extra})
+    set(imgtool_extra --overwrite-only --align 1 ${imgtool_extra})
   endif()
 
   set(imgtool_args -- ${imgtool_extra})


### PR DESCRIPTION
Set align to 1 for CONFIG_MCUBOOT_IMGTOOL_OVERWRITE_ONLY, used by non-swap update modes.
Fix imgtool error message for devices with write size > 32B.