### PR TITLE
bluetooth: shell: Set QoS to server preferred values

### DIFF
--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -1923,6 +1923,71 @@ static void stream_stopped_cb(struct bt_bap_stream *stream, uint8_t reason)
 #endif /* CONFIG_BT_BAP_BROADCAST_SINK */
 }
 
+static void stream_configured_cb(struct bt_bap_stream *stream,
+				      const struct bt_audio_codec_qos_pref *pref)
+{
+	struct bt_audio_codec_qos _qos;
+	struct shell_stream *sh_stream = shell_stream_from_bap_stream(stream);
+
+	/* Since the preferred QoS dont hold all values, copy over all initial values*/
+	memcpy(&_qos, &sh_stream->qos, sizeof(_qos));
+
+	_qos.framing = !pref->unframed_supported;
+
+	if (pref->rtn > BT_ISO_CONNECTED_RTN_MAX) {
+		shell_print(ctx_shell, "Invalid Retranmission Number (value = %u)", pref->rtn);
+		return;
+	}
+	_qos.rtn = pref->rtn;
+
+	if (!IN_RANGE(pref->latency, BT_ISO_LATENCY_MIN, BT_ISO_LATENCY_MAX)) {
+		shell_print(ctx_shell, "Invalid Latency (value = %u)", pref->latency);
+		return;
+	}
+	_qos.latency = pref->latency;
+
+	if (pref->pd_max > BT_AUDIO_PD_MAX) {
+		shell_print(ctx_shell, "Invalid Presentation delay Max (value = %u)",
+			    pref->pd_max);
+		return;
+	}
+
+	if (pref->pd_min > pref->pd_max) {
+		shell_print(ctx_shell, "Min Presentation Delay is larger than Max (%u > %u)",
+			    pref->pd_min, pref->pd_max);
+		return;
+	}
+
+	if (pref->pref_pd_max > BT_AUDIO_PD_MAX) {
+		shell_print(ctx_shell, "Invalid Preferred Presentation Delay Max (value = %u)",
+			    pref->pref_pd_max);
+		return;
+	}
+
+	if (pref->pref_pd_min > pref->pref_pd_max) {
+		shell_print(ctx_shell, "Preferred Min Presentation Delay larger than Max "
+			    "(%u > %u)", pref->pref_pd_min, pref->pref_pd_max);
+		return;
+	}
+
+	if (pref->pd_min > pref->pref_pd_min) {
+		shell_print(ctx_shell, "Preferred Min Presentation Delay lower than supported Min "
+			    "(%u > %u)", pref->pd_min, pref->pref_pd_min);
+		return;
+	}
+
+	if (pref->pref_pd_max > pref->pd_max) {
+		shell_print(ctx_shell, "Preferred Max Presentation Delay larger than supported Max "
+			    "(%u > %u)", pref->pref_pd_max, pref->pd_max);
+		return;
+	}
+
+	/* Just choose the largest preferred PD, since our presets are defaulted to high values */
+	_qos.pd = pref->pd_max;
+
+	memcpy(&sh_stream->qos, &_qos, sizeof(_qos));
+}
+
 #if defined(CONFIG_BT_BAP_UNICAST)
 static void stream_released_cb(struct bt_bap_stream *stream)
 {
@@ -1985,6 +2050,7 @@ static struct bt_bap_stream_ops stream_ops = {
 #if defined(CONFIG_LIBLC3) && defined(CONFIG_BT_AUDIO_TX)
 	.sent = sdu_sent_cb,
 #endif
+	.configured = stream_configured_cb,
 };
 
 #if defined(CONFIG_BT_BAP_BROADCAST_SOURCE)


### PR DESCRIPTION
Registred the configured callback for bt_bap_stream_ops, and in this made the shell choose the QoS parameters from the server. This is necessary as the cmd_stream_qos that allows user settings to a stream can only be used if a cmd_qos was previously successfull. However for a server that does not support the QoS parameters in the hardcoded presets being set in cmd_config it was never possible to successfully call cmd_qos.