### PR TITLE
twister: coverage: Fix LCOV arbitrary path prefixes

### DIFF
--- a/scripts/pylib/twister/twisterlib/coverage.py
+++ b/scripts/pylib/twister/twisterlib/coverage.py
@@ -224,6 +224,7 @@ class Lcov(CoverageTool):
         # The --ignore-errors source option is added to avoid it exiting due to
         # samples/application_development/external_lib/
         cmd = ["genhtml", "--legend", "--branch-coverage",
+                                "--prefix", self.base_dir,
                                 "-output-directory",
                                 os.path.join(outdir, "coverage")] + files
         cmd = cmd + ignore_errors


### PR DESCRIPTION
In some cases `genhtml` incorrectly built reports from LCOV coverage data using full path for some of the source files and arbitrary relative paths for other files.
This fix adds `--prefix` parameter to shorten paths explicitly relative to the `ZEPHYR_BASE` directory.

For example, the issue observed with `./scripts/twister -vv -j 1 -p unit_testing  --coverage --coverage-tool lcov -T tests/unit/base64` which composed HTML report

before the fix:
```
/home/rootroot/zephyrproject/zephyr/lib/os	
include/zephyr	
ztest/include/zephyr	
ztest/src	
```
and after the fix:
```
lib/os	
subsys/testsuite/include/zephyr	
subsys/testsuite/ztest/include/zephyr	
subsys/testsuite/ztest/src	
```