### PR TITLE
input: kbd_matrix: make the thread priority configurable

### DIFF
--- a/drivers/input/Kconfig.kbd_matrix
+++ b/drivers/input/Kconfig.kbd_matrix
@@ -14,6 +14,13 @@ config INPUT_KBD_MATRIX_THREAD_STACK_SIZE
 	help
 	  Size of the stack used for the keyboard matrix thread.
 
+
+config INPUT_KBD_MATRIX_THREAD_PRIORITY
+	int "Priority for the keyboard matrix thread"
+	default 0
+	help
+	  Priority level of the keyboard matrix thread.
+
 config INPUT_KBD_MATRIX_16_BIT_ROW
 	bool "16 bit row size support"
 	help

--- a/drivers/input/input_kbd_matrix.c
+++ b/drivers/input/input_kbd_matrix.c
@@ -310,7 +310,7 @@ int input_kbd_matrix_common_init(const struct device *dev)
 	k_thread_create(&data->thread, data->thread_stack,
 			CONFIG_INPUT_KBD_MATRIX_THREAD_STACK_SIZE,
 			input_kbd_matrix_polling_thread, (void *)dev, NULL, NULL,
-			K_PRIO_COOP(4), 0, K_NO_WAIT);
+			CONFIG_INPUT_KBD_MATRIX_THREAD_PRIORITY, 0, K_NO_WAIT);
 
 	k_thread_name_set(&data->thread, dev->name);
 


### PR DESCRIPTION
Add a config entry for the keyboard matrix thread priority. This changes the current default, but that was pretty much an arbitrary numbe anyay and the exact one should be picked the application so it should be alright to do so.