### PR TITLE
modules: hal_silabs: Add Proprietary TRX example

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -219,7 +219,7 @@ manifest:
       groups:
         - hal
     - name: hal_silabs
-      revision: b11b29167f3f9a0fd0c34a8eeeb36b0c1d218917
+      revision: pull/49/head
       path: modules/hal/silabs
       groups:
         - hal


### PR DESCRIPTION
Add Proprietary TRX example to show SiliconLabs radio board capabilities.