### PR TITLE
More misc gpio keyboard fixes

### DIFF
--- a/drivers/input/input_gpio_kbd_matrix.c
+++ b/drivers/input/input_gpio_kbd_matrix.c
@@ -132,7 +132,6 @@ static void gpio_kbd_matrix_set_detect_mode(const struct device *dev, bool enabl
 {
 	const struct gpio_kbd_matrix_config *cfg = dev->config;
 	const struct input_kbd_matrix_common_config *common = &cfg->common;
-	gpio_flags_t flags = enabled ? GPIO_INT_EDGE_BOTH : GPIO_INT_DISABLE;
 	int ret;
 
 	if (cfg->idle_poll_dwork != NULL) {
@@ -149,6 +148,7 @@ static void gpio_kbd_matrix_set_detect_mode(const struct device *dev, bool enabl
 
 	for (int i = 0; i < common->row_size; i++) {
 		const struct gpio_dt_spec *gpio = &cfg->row_gpio[i];
+		gpio_flags_t flags = enabled ? GPIO_INT_EDGE_TO_ACTIVE : GPIO_INT_DISABLE;
 
 		ret = gpio_pin_interrupt_configure_dt(gpio, flags);
 		if (ret != 0) {

--- a/drivers/input/input_kbd_matrix.c
+++ b/drivers/input/input_kbd_matrix.c
@@ -291,6 +291,13 @@ static void input_kbd_matrix_polling_thread(void *arg1, void *unused2, void *unu
 		input_kbd_matrix_drive_column(dev, INPUT_KBD_MATRIX_COLUMN_DRIVE_ALL);
 		api->set_detect_mode(dev, true);
 
+		/* Check the rows again after enabling the interrupt to catch
+		 * any potential press since the last read.
+		 */
+		if (api->read_row(dev) != 0) {
+			input_kbd_matrix_poll_start(dev);
+		}
+
 		k_sem_take(&data->poll_lock, K_FOREVER);
 		LOG_DBG("scan start");
 


### PR DESCRIPTION
Change the interrupt setup from both edge to edge to active. Edge to active is all was needed anyway and it makes this compatible with gpio controller that only support single edge interrupt.

---

Fix a possible race condition in the GPIO keyboard matrix driver where a key would get pressed between the last read and reenabling the (edge sensitive) interrupt and the even would be lost.

The window for this to happen is very narrow and had to artificially add a sleep to reproduce it.