### PR TITLE
tests: unit: Fix Power-of-Two test build issue

### DIFF
--- a/tests/unit/pot/prj.conf
+++ b/tests/unit/pot/prj.conf
@@ -2,3 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 CONFIG_ZTEST=y
+
+CONFIG_CPP=y


### PR DESCRIPTION
Fix linker error for the PoT test build with code coverage.

Observed with `./scripts/twister -vv -j 1 -p unit_testing  --coverage --coverage-tool lcov -T tests/unit/pot` as

build.log
```
...
[14/14] Linking CXX executable testbinary
FAILED: testbinary 
: && /usr/bin/gcc -m32 -gdwarf-4 -T /foo/zephyr/subsys/testsuite/include/zephyr/ztest_unittest.ld 
...
/usr/bin/ld: CMakeFiles/testbinary.dir/log2.cpp.obj:(.data.rel.local.DW.ref.__gxx_personality_v0[DW.ref.__gxx_personality_v0]+0x0): undefined reference to `__gxx_personality_v0'
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```
