### PR TITLE
input: npcx_kbd: clear pending interrupts before reenabling detection

### DIFF
--- a/drivers/input/input_npcx_kbd.c
+++ b/drivers/input/input_npcx_kbd.c
@@ -57,8 +57,13 @@ static void npcx_kbd_ksi_isr(const struct device *dev, struct npcx_wui *wui)
 static void npcx_kbd_set_detect_mode(const struct device *dev, bool enabled)
 {
 	const struct npcx_kbd_config *const config = dev->config;
+	const struct input_kbd_matrix_common_config *common = &config->common;
 
 	if (enabled) {
+		for (int i = 0; i < common->row_size; i++) {
+			npcx_miwu_irq_get_and_clear_pending(&config->wui_maps[i]);
+		}
+
 		irq_enable(config->irq);
 	} else {
 		irq_disable(config->irq);


### PR DESCRIPTION
The driver right now re-enters polling mode a couple times after the matrix has been detected as stable as the key interrupt is still pending and fires again once detection is reenabled.

Clear pending WUI interrupts before reenabling key press detection to avoid that.