### PR TITLE
mgmt: fs_mgmt: clear lock before return

### DIFF
--- a/subsys/mgmt/mcumgr/grp/fs_mgmt/src/fs_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/fs_mgmt/src/fs_mgmt.c
@@ -255,6 +255,7 @@ static int fs_mgmt_file_download(struct smp_streamer *ctxt)
 
 		if (status != MGMT_CB_OK) {
 			if (status == MGMT_CB_ERROR_RC) {
+				k_sem_give(&fs_mgmt_ctxt.lock_sem);
 				return err_rc;
 			}
 
@@ -404,6 +405,7 @@ static int fs_mgmt_file_upload(struct smp_streamer *ctxt)
 
 		if (status != MGMT_CB_OK) {
 			if (status == MGMT_CB_ERROR_RC) {
+				k_sem_give(&fs_mgmt_ctxt.lock_sem);
 				return err_rc;
 			}
 


### PR DESCRIPTION
Not clearing that lock lead to the fs_mgmt commands being useless, after the mgmt callback returned `MGMT_CB_ERROR_RC` once, since the lock is now occupied and never cleared.

Fixes #66581