### PR TITLE
Add support for GPIO pins to Wakeup the system

### DIFF
--- a/drivers/gpio/gpio_ambiq.c
+++ b/drivers/gpio/gpio_ambiq.c
@@ -279,6 +279,8 @@ static int ambiq_gpio_pin_interrupt_configure(const struct device *dev, gpio_pin
 			 * ERR008: GPIO: Dual-edge interrupts are not vectoring
 			 */
 			return -ENOTSUP;
+		default:
+			return -EINVAL;
 		}
 		ret = am_hal_gpio_pinconfig(gpio_pin, pincfg);
 

--- a/drivers/gpio/gpio_eos_s3.c
+++ b/drivers/gpio/gpio_eos_s3.c
@@ -311,6 +311,8 @@ static int gpio_eos_s3_pin_interrupt_configure(const struct device *dev,
 				break;
 			case GPIO_INT_TRIG_BOTH:
 				return -ENOTSUP;
+			default:
+				return -EINVAL;
 			}
 		}
 

--- a/drivers/gpio/gpio_mcp23xxx.c
+++ b/drivers/gpio/gpio_mcp23xxx.c
@@ -323,6 +323,9 @@ static int mcp23xxx_pin_interrupt_configure(const struct device *dev, gpio_pin_t
 			/* can't happen */
 			ret = -ENOTSUP;
 			goto done;
+		default:
+			ret = -EINVAL;
+			goto done;
 		}
 		break;
 
@@ -343,6 +346,9 @@ static int mcp23xxx_pin_interrupt_configure(const struct device *dev, gpio_pin_t
 			drv_data->rising_edge_ints |= BIT(pin);
 			drv_data->falling_edge_ints |= BIT(pin);
 			break;
+		default:
+			ret = -EINVAL;
+			goto done;
 		}
 		break;
 	}

--- a/drivers/gpio/gpio_mcux.c
+++ b/drivers/gpio/gpio_mcux.c
@@ -205,6 +205,8 @@ static uint32_t get_port_pcr_irqc_value_from_flags(const struct device *dev,
 			case GPIO_INT_TRIG_BOTH:
 				port_interrupt = kPORT_InterruptEitherEdge;
 				break;
+			default:
+				return -EINVAL;
 			}
 		}
 	}

--- a/drivers/gpio/gpio_mcux_lpc.c
+++ b/drivers/gpio/gpio_mcux_lpc.c
@@ -260,7 +260,7 @@ static int gpio_mcux_lpc_pint_interrupt_cfg(const struct device *dev,
 	}
 
 	/* PINT treats GPIO pins as continuous. Each port has 32 pins */
-	ret = nxp_pint_pin_enable((port * 32) + pin, interrupt_mode);
+	ret = nxp_pint_pin_enable((port * 32) + pin, interrupt_mode, (trig & GPIO_INT_WAKEUP));
 	if (ret < 0) {
 		return ret;
 	}

--- a/drivers/gpio/gpio_numicro.c
+++ b/drivers/gpio/gpio_numicro.c
@@ -200,6 +200,8 @@ static int gpio_numicro_pin_interrupt_configure(const struct device *dev,
 		case GPIO_INT_TRIG_BOTH:
 			int_level = BIT(pin) | BIT(pin + 16);
 			break;
+		default:
+			return -EINVAL;
 		}
 	}
 

--- a/drivers/gpio/gpio_psoc6.c
+++ b/drivers/gpio/gpio_psoc6.c
@@ -171,6 +171,8 @@ static int gpio_psoc6_pin_interrupt_configure(const struct device *dev,
 		case GPIO_INT_TRIG_LOW:
 			lv_trg = CY_GPIO_INTR_FALLING;
 			break;
+		default:
+			return -EINVAL;
 		}
 	}
 

--- a/drivers/gpio/gpio_rt1718s_port.c
+++ b/drivers/gpio/gpio_rt1718s_port.c
@@ -255,6 +255,9 @@ static int gpio_rt1718s_pin_interrupt_configure(const struct device *dev, gpio_p
 		case GPIO_INT_TRIG_LOW:
 			new_reg_mask8 = (reg_mask8 | mask_fall) & ~mask_rise;
 			break;
+		default:
+			ret = -EINVAL;
+			goto done;
 		}
 
 		ret = rt1718s_reg_burst_read(config->rt1718s_dev, RT1718S_REG_ALERT_MASK,

--- a/drivers/gpio/gpio_rv32m1.c
+++ b/drivers/gpio/gpio_rv32m1.c
@@ -64,6 +64,8 @@ static uint32_t get_port_pcr_irqc_value_from_flags(const struct device *dev,
 			case GPIO_INT_TRIG_BOTH:
 				port_interrupt = kPORT_InterruptEitherEdge;
 				break;
+			default:
+				return -EINVAL;
 			}
 		}
 	}

--- a/drivers/gpio/gpio_sedi.c
+++ b/drivers/gpio/gpio_sedi.c
@@ -244,6 +244,8 @@ static int gpio_sedi_interrupt_configure(const struct device *dev,
 			pin_config.interrupt_mode =
 				SEDI_GPIO_INT_MODE_BOTH_EDGE;
 			break;
+		default:
+			return -EINVAL;
 		}
 	}
 	/* Configure interrupt mode */

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -623,8 +623,6 @@ static int gpio_stm32_pin_interrupt_configure(const struct device *dev,
 		goto exit;
 	}
 
-	gpio_stm32_enable_int(cfg->port, pin);
-
 	switch (trig) {
 	case GPIO_INT_TRIG_LOW:
 		edge = STM32_EXTI_TRIG_FALLING;
@@ -635,7 +633,12 @@ static int gpio_stm32_pin_interrupt_configure(const struct device *dev,
 	case GPIO_INT_TRIG_BOTH:
 		edge = STM32_EXTI_TRIG_BOTH;
 		break;
+	default:
+		err = -EINVAL;
+		goto exit;
 	}
+
+	gpio_stm32_enable_int(cfg->port, pin);
 
 	stm32_exti_trigger(pin, edge);
 

--- a/include/zephyr/drivers/gpio.h
+++ b/include/zephyr/drivers/gpio.h
@@ -783,6 +783,8 @@ enum gpio_int_trig {
 	GPIO_INT_TRIG_HIGH = GPIO_INT_HIGH_1,
 	/* Trigger detection on pin rising or falling edge. */
 	GPIO_INT_TRIG_BOTH = GPIO_INT_LOW_0 | GPIO_INT_HIGH_1,
+	/* Trigger a system wakup. */
+	GPIO_INT_TRIG_WAKE = GPIO_INT_WAKEUP,
 };
 
 __subsystem struct gpio_driver_api {
@@ -909,7 +911,7 @@ static inline int z_impl_gpio_pin_interrupt_configure(const struct device *port,
 		flags ^= (GPIO_INT_LOW_0 | GPIO_INT_HIGH_1);
 	}
 
-	trig = (enum gpio_int_trig)(flags & (GPIO_INT_LOW_0 | GPIO_INT_HIGH_1));
+	trig = (enum gpio_int_trig)(flags & (GPIO_INT_LOW_0 | GPIO_INT_HIGH_1 | GPIO_INT_WAKEUP));
 #ifdef CONFIG_GPIO_ENABLE_DISABLE_INTERRUPT
 	mode = (enum gpio_int_mode)(flags & (GPIO_INT_EDGE | GPIO_INT_DISABLE | GPIO_INT_ENABLE |
 					     GPIO_INT_ENABLE_DISABLE_ONLY));

--- a/include/zephyr/drivers/interrupt_controller/nxp_pint.h
+++ b/include/zephyr/drivers/interrupt_controller/nxp_pint.h
@@ -50,8 +50,9 @@ typedef void (*nxp_pint_cb_t) (uint8_t pin, void *user);
  * @param pin: pin to use as interrupt source
  *     0-64, corresponding to GPIO0 pin 1 - GPIO1 pin 31)
  * @param trigger: one of nxp_pint_trigger flags
+ * @param wake: indicates if the pin should wakeup the system
  */
-int nxp_pint_pin_enable(uint8_t pin, enum nxp_pint_trigger trigger);
+int nxp_pint_pin_enable(uint8_t pin, enum nxp_pint_trigger trigger, bool wake);
 
 
 /**

--- a/include/zephyr/dt-bindings/gpio/gpio.h
+++ b/include/zephyr/dt-bindings/gpio/gpio.h
@@ -81,6 +81,10 @@
 
 /* Note: Bits 15 downto 8 are reserved for SoC specific flags. */
 
+/** Configures GPIO interrupt to wakeup the system from low power mode.
+ */
+#define GPIO_INT_WAKEUP         (1u << 28)
+
 /**
  * @}
  */


### PR DESCRIPTION
This change allows configuring the individual GPIO pins as a WAKEUP source. This is useful in SoC's where there is a separate interrupt available for a subset of the GPIO pins which can be used to wakeup the system.