### PR TITLE
bluetooth: shell: match cmd_conn_phy_update conditions

### DIFF
--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -3244,7 +3244,7 @@ static int cmd_conn_phy_update(const struct shell *sh, size_t argc,
 }
 #endif
 
-#if defined(CONFIG_BT_CENTRAL)
+#if defined(CONFIG_BT_CENTRAL) || defined(CONFIG_BT_BROADCASTER)
 static int cmd_chan_map(const struct shell *sh, size_t argc, char *argv[])
 {
 	uint8_t chan_map[5] = {};


### PR DESCRIPTION
The condition for channel-map are CONFIG_BT_CENTRAL || CONFIG_BT_BROADCASTER, change the corresponding handler ifdef so that it's included in the build if CONFIG_BT_BROADCASTER is enabled but CONFIG_BT_CENTRAL is not.