### PR TITLE
Support FlexTimer on NXP UCANS32K1SIC board

### DIFF
--- a/boards/arm/ucans32k1sic/doc/index.rst
+++ b/boards/arm/ucans32k1sic/doc/index.rst
@@ -49,6 +49,7 @@ GPIO          on-chip     gpio
 LPUART        on-chip     serial
 LPI2C         on-chip     i2c
 LPSPI         on-chip     spi
+FTM           on-chip     pwm
 ============  ==========  ================================
 
 The default configuration can be found in the Kconfig file
@@ -67,15 +68,30 @@ children nodes with the desired pinmux configuration to the singleton node
 LEDs
 ----
 
-The UCANS32K1SIC board has one user RGB LED:
+The UCANS32K1SIC board has one user RGB LED that can be used either as a GPIO
+LED or as a PWM LED.
 
-=======================  ==============  =====
-Devicetree node          Label           Pin
-=======================  ==============  =====
-led0 / led1_red          LED1_RGB_RED    PTD15
-led1 / led1_green        LED1_RGB_GREEN  PTD16
-led2 / led1_blue         LED1_RGB_BLUE   PTD0
-=======================  ==============  =====
+.. table:: RGB LED as GPIO LED
+   :widths: auto
+
+   ===============  ================  ===============  =====
+   Devicetree node  Devicetree alias  Label            Pin
+   ===============  ================  ===============  =====
+   led1_red         led0              LED1_RGB_RED     PTD15
+   led1_green       led1              LED1_RGB_GREEN   PTD16
+   led1_blue        led2              LED1_RGB_BLUE    PTD0
+   ===============  ================  ===============  =====
+
+.. table:: RGB LED as PWM LED
+   :widths: auto
+
+   ===============  ========================  ==================  ================
+   Devicetree node  Devicetree alias          Label               Pin
+   ===============  ========================  ==================  ================
+   led1_red_pwm     pwm-led0 / red-pwm-led    LED1_RGB_RED_PWM    PTD15 / FTM0_CH0
+   led1_green_pwm   pwm-led1 / green-pwm-led  LED1_RGB_GREEN_PWM  PTD16 / FTM0_CH1
+   led1_blue_pwm    pwm-led2 / blue-pwm-led   LED1_RGB_BLUE_PWM   PTD0 / FTM0_CH2
+   ===============  ========================  ==================  ================
 
 The user can control the LEDs in any way. An output of ``0`` illuminates the LED.
 

--- a/boards/arm/ucans32k1sic/ucans32k1sic-pinctrl.dtsi
+++ b/boards/arm/ucans32k1sic/ucans32k1sic-pinctrl.dtsi
@@ -37,4 +37,27 @@
 			drive-strength = "low";
 		};
 	};
+
+	ftm0_default: ftm0_default {
+		group0 {
+			pinmux = <FTM0_CH0_PTD15>,
+				<FTM0_CH1_PTD16>,
+				<FTM0_CH2_PTD0>;
+			drive-strength = "low";
+		};
+	};
+
+	ftm1_default: ftm1_default {
+		group0 {
+			pinmux = <FTM1_CH1_PTA1>;
+			drive-strength = "low";
+		};
+	};
+
+	ftm2_default: ftm2_default {
+		group0 {
+			pinmux = <FTM2_CH1_PTA0>;
+			drive-strength = "low";
+		};
+	};
 };

--- a/boards/arm/ucans32k1sic/ucans32k1sic.dts
+++ b/boards/arm/ucans32k1sic/ucans32k1sic.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 #include <arm/nxp/nxp_s32k146.dtsi>
 #include "ucans32k1sic-pinctrl.dtsi"
 
@@ -26,6 +27,13 @@
 		led0 = &led1_red;
 		led1 = &led1_green;
 		led2 = &led1_blue;
+		pwm-led0 = &led1_red_pwm;
+		pwm-led1 = &led1_green_pwm;
+		pwm-led2 = &led1_blue_pwm;
+		red-pwm-led = &led1_red_pwm;
+		green-pwm-led = &led1_green_pwm;
+		blue-pwm-led = &led1_blue_pwm;
+		pwm-0 = &ftm0;
 		sw0 = &button_3;
 		i2c-0 = &lpi2c0;
 	};
@@ -44,6 +52,23 @@
 		led1_blue: led_2 {
 			gpios = <&gpiod 0 GPIO_ACTIVE_LOW>;
 			label = "LED1_RGB_BLUE";
+		};
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+
+		led1_red_pwm: led_pwm_0 {
+			pwms = <&ftm0 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+			label = "LED1_RGB_RED_PWM";
+		};
+		led1_green_pwm: led_pwm_1 {
+			pwms = <&ftm0 1 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+			label = "LED1_RGB_GREEN_PWM";
+		};
+		led1_blue_pwm: led_pwm_2 {
+			pwms = <&ftm0 2 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+			label = "LED1_RGB_BLUE_PWM";
 		};
 	};
 
@@ -102,5 +127,30 @@
 &lpspi0 {
 	pinctrl-0 = <&lpspi0_default>;
 	pinctrl-names = "default";
+	status = "okay";
+};
+
+&ftm0 {
+	compatible = "nxp,kinetis-ftm-pwm";
+	pinctrl-0 = <&ftm0_default>;
+	pinctrl-names = "default";
+	prescaler = <128>;
+	#pwm-cells = <3>;
+	status = "okay";
+};
+
+&ftm1 {
+	compatible = "nxp,kinetis-ftm-pwm";
+	pinctrl-0 = <&ftm1_default>;
+	pinctrl-names = "default";
+	#pwm-cells = <3>;
+	status = "okay";
+};
+
+&ftm2 {
+	compatible = "nxp,kinetis-ftm-pwm";
+	pinctrl-0 = <&ftm2_default>;
+	pinctrl-names = "default";
+	#pwm-cells = <3>;
 	status = "okay";
 };

--- a/boards/arm/ucans32k1sic/ucans32k1sic.yaml
+++ b/boards/arm/ucans32k1sic/ucans32k1sic.yaml
@@ -17,3 +17,4 @@ supported:
   - pinctrl
   - i2c
   - spi
+  - pwm

--- a/drivers/pwm/pwm_mcux_ftm.c
+++ b/drivers/pwm/pwm_mcux_ftm.c
@@ -383,11 +383,24 @@ static void mcux_ftm_capture_second_edge(const struct device *dev, uint32_t chan
 	}
 }
 
-static void mcux_ftm_isr(const struct device *dev)
+static bool mcux_ftm_handle_overflow(const struct device *dev)
 {
 	const struct mcux_ftm_config *config = dev->config;
 	struct mcux_ftm_data *data = dev->data;
-	bool overflow = false;
+
+	if (FTM_GetStatusFlags(config->base) & kFTM_TimeOverflowFlag) {
+		data->overflows++;
+		FTM_ClearStatusFlags(config->base, kFTM_TimeOverflowFlag);
+		return true;
+	}
+
+	return false;
+}
+
+static void mcux_ftm_irq_handler(const struct device *dev, uint32_t chan_start, uint32_t chan_end)
+{
+	const struct mcux_ftm_config *config = dev->config;
+	bool overflow;
 	uint32_t flags;
 	uint32_t irqs;
 	uint16_t cnt;
@@ -397,13 +410,9 @@ static void mcux_ftm_isr(const struct device *dev)
 	irqs = FTM_GetEnabledInterrupts(config->base);
 	cnt = config->base->CNT;
 
-	if (flags & kFTM_TimeOverflowFlag) {
-		data->overflows++;
-		overflow = true;
-		FTM_ClearStatusFlags(config->base, kFTM_TimeOverflowFlag);
-	}
+	overflow = mcux_ftm_handle_overflow(dev);
 
-	for (ch = 0; ch < MAX_CHANNELS; ch++) {
+	for (ch = chan_start; ch < chan_end; ch++) {
 		if ((flags & BIT(ch)) && (irqs & BIT(ch))) {
 			if (ch & 1) {
 				mcux_ftm_capture_second_edge(dev, ch, cnt, overflow);
@@ -496,6 +505,14 @@ static const struct pwm_driver_api mcux_ftm_driver_api = {
 #define TO_FTM_PRESCALE_DIVIDE(val) _DO_CONCAT(kFTM_Prescale_Divide_, val)
 
 #ifdef CONFIG_PWM_CAPTURE
+#if IS_EQ(DT_NUM_IRQS(DT_DRV_INST(0)), 1)
+static void mcux_ftm_isr(const struct device *dev)
+{
+	const struct mcux_ftm_config *cfg = dev->config;
+
+	mcux_ftm_irq_handler(dev, 0, cfg->channel_count);
+}
+
 #define FTM_CONFIG_FUNC(n) \
 static void mcux_ftm_config_func_##n(const struct device *dev) \
 { \
@@ -503,6 +520,49 @@ static void mcux_ftm_config_func_##n(const struct device *dev) \
 		    mcux_ftm_isr, DEVICE_DT_INST_GET(n), 0); \
 	irq_enable(DT_INST_IRQN(n)); \
 }
+#else /* Multiple interrupts */
+#define FTM_ISR_FUNC_NAME(suffix) _DO_CONCAT(mcux_ftm_isr_, suffix)
+#define FTM_ISR_FUNC(chan_start, chan_end) \
+static void mcux_ftm_isr_##chan_start##_##chan_end(const struct device *dev) \
+{ \
+	mcux_ftm_irq_handler(dev, chan_start, chan_end + 1); \
+}
+
+#define FTM_ISR_CONFIG(node_id, prop, idx) \
+do { \
+	IRQ_CONNECT(DT_IRQ_BY_IDX(node_id, idx, irq), \
+		    DT_IRQ_BY_IDX(node_id, idx, priority), \
+		    FTM_ISR_FUNC_NAME(DT_STRING_TOKEN_BY_IDX(node_id, prop, idx)), \
+		    DEVICE_DT_GET(node_id), \
+		    0); \
+	irq_enable(DT_IRQ_BY_IDX(node_id, idx, irq)); \
+} while (false);
+
+#define FTM_CONFIG_FUNC(n) \
+static void mcux_ftm_config_func_##n(const struct device *dev) \
+{ \
+	DT_INST_FOREACH_PROP_ELEM(n, interrupt_names, FTM_ISR_CONFIG) \
+}
+
+#if DT_INST_IRQ_HAS_NAME(0, overflow)
+static void mcux_ftm_isr_overflow(const struct device *dev)
+{
+	mcux_ftm_handle_overflow(dev);
+}
+#endif
+#if DT_INST_IRQ_HAS_NAME(0, 0_1)
+FTM_ISR_FUNC(0, 1)
+#endif
+#if DT_INST_IRQ_HAS_NAME(0, 2_3)
+FTM_ISR_FUNC(2, 3)
+#endif
+#if DT_INST_IRQ_HAS_NAME(0, 4_5)
+FTM_ISR_FUNC(4, 5)
+#endif
+#if DT_INST_IRQ_HAS_NAME(0, 6_7)
+FTM_ISR_FUNC(6, 7)
+#endif
+#endif /* IS_EQ(DT_NUM_IRQS(DT_DRV_INST(0)), 1) */
 #define FTM_CFG_CAPTURE_INIT(n) \
 	.irq_config_func = mcux_ftm_config_func_##n
 #define FTM_INIT_CFG(n)	FTM_DECLARE_CFG(n, FTM_CFG_CAPTURE_INIT(n))

--- a/dts/arm/nxp/nxp_s32k146.dtsi
+++ b/dts/arm/nxp/nxp_s32k146.dtsi
@@ -34,6 +34,8 @@
 };
 
 /delete-node/ &lpi2c1;
+/delete-node/ &ftm6;
+/delete-node/ &ftm7;
 
 &nvic {
 	arm,num-irq-priority-bits = <4>;

--- a/dts/arm/nxp/nxp_s32k1xx.dtsi
+++ b/dts/arm/nxp/nxp_s32k1xx.dtsi
@@ -202,5 +202,85 @@
 			nxp,kinetis-port = <&porte>;
 			status = "disabled";
 		};
+
+		ftm0: ftm@40038000 {
+			compatible = "nxp,kinetis-ftm";
+			reg = <0x40038000 0x1000>;
+			interrupts = <99 0>, <100 0>, <101 0>, <102 0>, <104 0>;
+			interrupt-names = "0-1", "2-3", "4-5", "6-7", "overflow";
+			clocks = <&clock NXP_S32_RTC_CLK>;
+			prescaler = <1>;
+			status = "disabled";
+		};
+
+		ftm1: ftm@40039000 {
+			compatible = "nxp,kinetis-ftm";
+			reg = <0x40039000 0x1000>;
+			interrupts = <105 0>, <106 0>, <107 0>, <108 0>, <110 0>;
+			interrupt-names = "0-1", "2-3", "4-5", "6-7", "overflow";
+			clocks = <&clock NXP_S32_RTC_CLK>;
+			prescaler = <1>;
+			status = "disabled";
+		};
+
+		ftm2: ftm@4003a000 {
+			compatible = "nxp,kinetis-ftm";
+			reg = <0x4003a000 0x1000>;
+			interrupts = <111 0>, <112 0>, <113 0>, <114 0>, <116 0>;
+			interrupt-names = "0-1", "2-3", "4-5", "6-7", "overflow";
+			clocks = <&clock NXP_S32_RTC_CLK>;
+			prescaler = <1>;
+			status = "disabled";
+		};
+
+		ftm3: ftm@40026000 {
+			compatible = "nxp,kinetis-ftm";
+			reg = <0x40026000 0x1000>;
+			interrupts = <117 0>, <118 0>, <119 0>, <120 0>, <122 0>;
+			interrupt-names = "0-1", "2-3", "4-5", "6-7", "overflow";
+			clocks = <&clock NXP_S32_RTC_CLK>;
+			prescaler = <1>;
+			status = "disabled";
+		};
+
+		ftm4: ftm@4006e000 {
+			compatible = "nxp,kinetis-ftm";
+			reg = <0x4006e000 0x1000>;
+			interrupts = <123 0>, <124 0>, <125 0>, <126 0>, <128 0>;
+			interrupt-names = "0-1", "2-3", "4-5", "6-7", "overflow";
+			clocks = <&clock NXP_S32_RTC_CLK>;
+			prescaler = <1>;
+			status = "disabled";
+		};
+
+		ftm5: ftm@4006f000 {
+			compatible = "nxp,kinetis-ftm";
+			reg = <0x4006f000 0x1000>;
+			interrupts = <129 0>, <130 0>, <131 0>, <132 0>, <134 0>;
+			interrupt-names = "0-1", "2-3", "4-5", "6-7", "overflow";
+			clocks = <&clock NXP_S32_RTC_CLK>;
+			prescaler = <1>;
+			status = "disabled";
+		};
+
+		ftm6: ftm@40070000 {
+			compatible = "nxp,kinetis-ftm";
+			reg = <0x40070000 0x1000>;
+			interrupts = <135 0>, <136 0>, <137 0>, <138 0>, <140 0>;
+			interrupt-names = "0-1", "2-3", "4-5", "6-7", "overflow";
+			clocks = <&clock NXP_S32_RTC_CLK>;
+			prescaler = <1>;
+			status = "disabled";
+		};
+
+		ftm7: ftm@40071000 {
+			compatible = "nxp,kinetis-ftm";
+			reg = <0x40071000 0x1000>;
+			interrupts = <141 0>, <142 0>, <143 0>, <144 0>, <146 0>;
+			interrupt-names = "0-1", "2-3", "4-5", "6-7", "overflow";
+			clocks = <&clock NXP_S32_RTC_CLK>;
+			prescaler = <1>;
+			status = "disabled";
+		};
 	};
 };

--- a/soc/arm/nxp_s32/s32k1/Kconfig.series
+++ b/soc/arm/nxp_s32/s32k1/Kconfig.series
@@ -16,5 +16,6 @@ config SOC_SERIES_S32K1XX
 	select HAS_MCUX_LPUART
 	select HAS_MCUX_LPI2C
 	select HAS_MCUX_LPSPI
+	select HAS_MCUX_FTM
 	help
 	  Enable support for NXP S32K1XX MCU series.

--- a/tests/drivers/pwm/pwm_loopback/boards/ucans32k1sic.overlay
+++ b/tests/drivers/pwm/pwm_loopback/boards/ucans32k1sic.overlay
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+
+/ {
+	pwm_loopback_0 {
+		compatible = "test-pwm-loopback";
+		pwms = <&ftm1 1 0 PWM_POLARITY_NORMAL>, /* PTB3, P1.3 */
+		       <&ftm0 4 0 PWM_POLARITY_NORMAL>; /* PTB4, P1.4 */
+	};
+};
+
+&pinctrl {
+	ftm0_loopback: ftm0_loopback {
+		group0 {
+			pinmux = <FTM0_CH4_PTB4>;
+			drive-strength = "low";
+		};
+	};
+
+	ftm1_loopback: ftm1_loopback {
+		group0 {
+			pinmux = <FTM1_CH1_PTB3>;
+			drive-strength = "low";
+		};
+	};
+};
+
+&ftm0 {
+	pinctrl-0 = <&ftm0_loopback>;
+	prescaler = <32>;
+	status = "okay";
+};
+
+&ftm1 {
+	pinctrl-0 = <&ftm1_loopback>;
+	prescaler = <128>;
+	status = "okay";
+};

--- a/west.yml
+++ b/west.yml
@@ -193,7 +193,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: ed3efff426ce56230be189d99ce985ceafece4a4
+      revision: 4605f6715c6a55121da8fcbff060e01c4383c1e9
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Add support for FlexTimer (FTM) peripheral on S32K1xx devices and enable its usage in UCANS32K1SIC board.

The PWM FTM driver interrupt handling is reworked to support also SoCs on which FTM channels and overflow notifications are routed through individual interrupt lines, as opposed to a single common OR'ed interrupt line.

```
west twister -p ucans32k1sic --device-testing --device-serial=/dev/ttyUSB0 --fixture pwm_loopback \
  -T samples/drivers/led_pwm/ -T samples/basic/blinky_pwm/ -T samples/basic/fade_led/  -T samples/basic/rgb_led/ \
  -T tests/drivers/pwm
INFO    - Using Ninja..
INFO    - Zephyr version: zephyr-v3.5.0-3222-g2ecce1b7041e
INFO    - Using 'zephyr' toolchain.
INFO    - Building initial testsuite list...
...
INFO    - 6 test scenarios (6 test instances) selected, 3 configurations skipped (3 by static filter, 0 at runtime).
INFO    - 3 of 6 test configurations passed (100.00%), 0 failed, 0 errored, 3 skipped with 0 warnings in 80.47 seconds
INFO    - In total 10 test cases were executed, 4 skipped on 1 out of total 659 platforms (0.15%)
INFO    - 3 test configurations executed on platforms, 0 test configurations were only built.

```