### PR TITLE
Revert "drivers: spi: stm32h7: Use FIFO"

### DIFF
--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -273,7 +273,7 @@ static int spi_dma_move_buffers(const struct device *dev, size_t len)
 #define SPI_STM32_TX_NOP 0x00
 
 static void spi_stm32_send_next_frame(SPI_TypeDef *spi,
-				      struct spi_stm32_data *data)
+		struct spi_stm32_data *data)
 {
 	const uint8_t frame_size = SPI_WORD_SIZE_GET(data->ctx.config->operation);
 	uint32_t tx_frame = SPI_STM32_TX_NOP;
@@ -338,52 +338,20 @@ static int spi_stm32_get_err(SPI_TypeDef *spi)
 	return 0;
 }
 
-static bool spi_stm32_can_use_fifo(void)
-{
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
-	return true;
-#else
-	/*
-	 * TODO Test the FIFO usage in other FIFO-enabled STM32 SPI devices.
-	 */
-	return false;
-#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
-}
-
-static void spi_stm32_shift_fifo(SPI_TypeDef *spi, struct spi_stm32_data *data)
-{
-	while (ll_func_rx_is_not_empty(spi)) {
-		spi_stm32_read_next_frame(spi, data);
-	}
-
-	while (ll_func_tx_is_not_full(spi) && spi_stm32_transfer_ongoing(data)) {
-		spi_stm32_send_next_frame(spi, data);
-
-		if (ll_func_rx_is_not_empty(spi)) {
-			/* Break as soon as a frame is ready to read to avoid overruns */
-			break;
-		}
-	}
-}
-
 /* Shift a SPI frame as master. */
 static void spi_stm32_shift_m(SPI_TypeDef *spi, struct spi_stm32_data *data)
 {
-	if (spi_stm32_can_use_fifo()) {
-		spi_stm32_shift_fifo(spi, data);
-	} else {
-		while (!ll_func_tx_is_not_full(spi)) {
-			/* NOP */
-		}
-
-		spi_stm32_send_next_frame(spi, data);
-
-		while (!ll_func_rx_is_not_empty(spi)) {
-			/* NOP */
-		}
-
-		spi_stm32_read_next_frame(spi, data);
+	while (!ll_func_tx_is_not_full(spi)) {
+		/* NOP */
 	}
+
+	spi_stm32_send_next_frame(spi, data);
+
+	while (!ll_func_rx_is_not_empty(spi)) {
+		/* NOP */
+	}
+
+	spi_stm32_read_next_frame(spi, data);
 }
 
 /* Shift a SPI frame as slave. */


### PR DESCRIPTION
This reverts commit bffa0c6bddbc91d39f4b01baa34e3d0595760d50.

This FIFO implementation causes a regression by which the SPI peripheral generates several spurious SCK cyles after the last data has been sent.

This has been agreed in #66503.

See also #66326 and #63173.