### PR TITLE
display: add support for LPM0XX display series by JDI

### DIFF
--- a/drivers/display/CMakeLists.txt
+++ b/drivers/display/CMakeLists.txt
@@ -23,6 +23,7 @@ zephyr_library_sources_ifdef(CONFIG_STM32_LTDC		display_stm32_ltdc.c)
 zephyr_library_sources_ifdef(CONFIG_RM68200		display_rm68200.c)
 zephyr_library_sources_ifdef(CONFIG_RM67162		display_rm67162.c)
 zephyr_library_sources_ifdef(CONFIG_HX8394		display_hx8394.c)
+zephyr_library_sources_ifdef(CONFIG_LPM0XX		display_lpm0xx.c)
 
 zephyr_library_sources_ifdef(CONFIG_MICROBIT_DISPLAY
 	mb_display.c

--- a/drivers/display/Kconfig
+++ b/drivers/display/Kconfig
@@ -40,5 +40,6 @@ source "drivers/display/Kconfig.intel_multibootfb"
 source "drivers/display/Kconfig.mcux_dcnano_lcdif"
 source "drivers/display/Kconfig.otm8009a"
 source "drivers/display/Kconfig.hx8394"
+source "drivers/display/Kconfig.lpm0xx"
 
 endif # DISPLAY

--- a/drivers/display/Kconfig.lpm0xx
+++ b/drivers/display/Kconfig.lpm0xx
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config LPM0XX
-	bool "LPM0XX Memory in Pixel display"
+	bool "LPM0XX memory display controller driver"
     default y
     depends on DT_HAS_SHARP_LPM0XX_ENABLED
 	depends on SPI
 	help
-	  Enable driver for JDI Memory in Pixel display series LPM0XXMXXXX
+	  Enable driver for sharp memory display series LPM0XXMXXXX

--- a/drivers/display/Kconfig.lpm0xx
+++ b/drivers/display/Kconfig.lpm0xx
@@ -1,0 +1,10 @@
+# Copyright (c) 2020 Rohit Gujarathi
+# SPDX-License-Identifier: Apache-2.0
+
+config LPM0XX
+	bool "LPM0XX Memory in Pixel display"
+    default y
+    depends on DT_HAS_SHARP_LPM0XX_ENABLED
+	depends on SPI
+	help
+	  Enable driver for JDI Memory in Pixel display series LPM0XXMXXXX

--- a/drivers/display/display_lpm0xx.c
+++ b/drivers/display/display_lpm0xx.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Rohit Gujarathi
-  *
+ *
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -252,15 +252,13 @@ static void lpm0xx_get_capabilities(const struct device *dev,
 	caps->screen_info = SCREEN_INFO_X_ALIGNMENT_WIDTH;
 }
 
-static int lpm0xx_set_orientation(const struct device *dev,
-				 const enum display_orientation orientation)
+static int lpm0xx_set_orientation(const struct device *dev, const enum display_orientation orientation)
 {
 	LOG_ERR("Unsupported");
 	return -ENOTSUP;
 }
 
-static int lpm0xx_set_pixel_format(const struct device *dev,
-				  const enum display_pixel_format pf)
+static int lpm0xx_set_pixel_format(const struct device *dev, const enum display_pixel_format pf)
 {
 	if (pf == PIXEL_FORMAT_RGBx_111) {
 		return 0;
@@ -356,7 +354,4 @@ static struct display_driver_api lpm0xx_driver_api = {
 	.set_orientation = lpm0xx_set_orientation,
 };
 
-DEVICE_DT_INST_DEFINE(0, lpm0xx_init, NULL,
-		      &lpm0xx_driver, NULL,
-		      POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY,
-		      &lpm0xx_driver_api);
+DEVICE_DT_INST_DEFINE(0, lpm0xx_init, NULL, &lpm0xx_driver, NULL, POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY, &lpm0xx_driver_api);

--- a/drivers/display/display_lpm0xx.c
+++ b/drivers/display/display_lpm0xx.c
@@ -1,0 +1,362 @@
+/*
+ * Copyright (c) 2020 Rohit Gujarathi
+  *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT   jdi_lpm0xx
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(lpm0xx, CONFIG_DISPLAY_LOG_LEVEL);
+
+#include <string.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/display.h>
+#include <zephyr/init.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/sys/byteorder.h>
+
+/* Supports: LPM013M126C, LPM009M360A
+ */
+
+/* Note:
+ * -> Display expects MSB first
+ */
+
+#define LPM0XX_PANEL_WIDTH   DT_INST_PROP(0, width)
+#define LPM0XX_PANEL_HEIGHT  DT_INST_PROP(0, height)
+
+#define LPM0XX_PIXELS_PER_BYTE  2U
+
+/* Adding 2 for the line number and dummy byte
+ * line_buf format for each row.
+ * +----------------+-------------------+-------------------+
+ * | dummy (8 bits) | line num (8 bits) | data (WIDTH bits) |
+ * +----------------+-------------------+-------------------+
+ * First byte is actually 6 bits and line number 10 bits, but there
+ * are actually only 176 lines so only 8 usable line bits. We thus
+ * shift 2 bits up the dummy byte.
+ */
+
+#define LPM0XX_BYTES_PER_LINE  ((LPM0XX_PANEL_WIDTH / LPM0XX_PIXELS_PER_BYTE) + 2)
+
+#define LPM0XX_BIT_FMT_OFFSET  2
+#define LPM0XX_BIT_4BIT_FMT    (0x4 << LPM0XX_BIT_FMT_OFFSET)
+
+#define LPM0XX_BIT_MODE_OFFSET 5
+#define LPM0XX_BIT_WRITECMD    (0x4 << LPM0XX_BIT_MODE_OFFSET)
+#define LPM0XX_BIT_VCOM        (0x2 << LPM0XX_BIT_MODE_OFFSET)
+#define LPM0XX_BIT_CLEAR       (0x1 << LPM0XX_BIT_MODE_OFFSET)
+
+struct lpm0xx_data {
+#if DT_INST_NODE_HAS_PROP(0, disp_en_gpios)
+	const struct device *disp_dev;
+#endif
+#if DT_INST_NODE_HAS_PROP(0, extcomin_gpios)
+	const struct device *extcomin_dev;
+#endif
+	const struct device *spi_dev;
+	struct spi_cs_control cs_ctrl;
+	struct spi_config spi_config;
+};
+
+
+#if DT_INST_NODE_HAS_PROP(0, extcomin_gpios)
+/* Driver will handle VCOM toggling */
+static void lpm0xx_vcom_toggle(void *a, void *b, void *c)
+{
+	struct lpm0xx_data *driver = (struct lpm0xx_data *)a;
+
+	while (1) {
+		gpio_pin_toggle(driver->extcomin_dev,
+		DT_INST_GPIO_PIN(0, extcomin_gpios));
+		k_msleep(1000 / (DT_INST_PROP(0, extcomin_frequency) / 2));
+		gpio_pin_toggle(driver->extcomin_dev,
+		DT_INST_GPIO_PIN(0, extcomin_gpios));
+		k_msleep(1000 / (DT_INST_PROP(0, extcomin_frequency) / 2));
+	}
+}
+
+K_THREAD_STACK_DEFINE(vcom_toggle_stack, 256);
+struct k_thread vcom_toggle_thread;
+#endif
+
+static int lpm0xx_blanking_off(const struct device *dev)
+{
+#if DT_INST_NODE_HAS_PROP(0, disp_en_gpios)
+	struct lpm0xx_data *driver = dev->data;
+
+	return gpio_pin_set(driver->disp_dev,
+			    DT_INST_GPIO_PIN(0, disp_en_gpios), 1);
+#else
+	LOG_WRN("Unsupported");
+	return -ENOTSUP;
+#endif
+}
+
+static int lpm0xx_blanking_on(const struct device *dev)
+{
+#if DT_INST_NODE_HAS_PROP(0, disp_en_gpios)
+	struct lpm0xx_data *driver = dev->data;
+
+	return gpio_pin_set(driver->disp_dev,
+			    DT_INST_GPIO_PIN(0, disp_en_gpios), 0);
+#else
+	LOG_WRN("Unsupported");
+	return -ENOTSUP;
+#endif
+}
+
+static int lpm0xx_cmd(const struct device *dev, uint8_t *buf, uint8_t len)
+{
+	struct lpm0xx_data *driver = dev->data;
+	struct spi_buf cmd_buf = { .buf = buf, .len = len };
+	struct spi_buf_set buf_set = { .buffers = &cmd_buf, .count = 1 };
+
+	return spi_write(driver->spi_dev, &driver->spi_config, &buf_set);
+}
+
+static int lpm0xx_clear(const struct device *dev)
+{
+	struct lpm0xx_data *driver = dev->data;
+	uint8_t clear_cmd[2] = { LPM0XX_BIT_CLEAR, 0 };
+	int err;
+
+	err = lpm0xx_cmd(dev, clear_cmd, sizeof(clear_cmd));
+	spi_release(driver->spi_dev, &driver->spi_config);
+
+	return err;
+}
+
+static int lpm0xx_update_display(const struct device *dev,
+				uint16_t start_line,
+				uint16_t num_lines,
+				const uint8_t *data)
+{
+	struct lpm0xx_data *driver = dev->data;
+	uint8_t write_cmd[2] = { LPM0XX_BIT_WRITECMD | LPM0XX_BIT_4BIT_FMT, 0 };
+	uint8_t ln = start_line;
+	struct spi_buf line_buf[2] = {
+		{
+			.len = sizeof(write_cmd),
+			.buf = write_cmd,
+		},
+		{
+			.len = LPM0XX_BYTES_PER_LINE - 2,
+		},
+	};
+	struct spi_buf_set line_set = {
+		.buffers = line_buf,
+		.count = ARRAY_SIZE(line_buf),
+	};
+	int err = 0;
+
+	LOG_DBG("Lines %d to %d", start_line, start_line + num_lines - 1);
+
+	/* Send each line to the screen including
+	 * the line number and dummy bits
+	 */
+	for (; ln <= start_line + num_lines - 1; ln++) {
+		write_cmd[1] = ln;
+		line_buf[1].buf = (uint8_t *)data;
+		err |= spi_write(driver->spi_dev, &driver->spi_config,
+				 &line_set);
+		data += LPM0XX_PANEL_WIDTH / LPM0XX_PIXELS_PER_BYTE;
+	}
+
+	/* Send another trailing 16 bits for the last line
+	 * These can be any bits, it does not matter
+	 * just reusing the write_cmd buffer
+	 */
+	err |= lpm0xx_cmd(dev, write_cmd, sizeof(write_cmd));
+
+	spi_release(driver->spi_dev, &driver->spi_config);
+
+	return err;
+}
+
+/* Buffer width should be equal to display width */
+static int lpm0xx_write(const struct device *dev, const uint16_t x,
+		       const uint16_t y,
+		       const struct display_buffer_descriptor *desc,
+		       const void *buf)
+{
+	LOG_DBG("X: %d, Y: %d, W: %d, H: %d", x, y, desc->width, desc->height);
+
+	if (buf == NULL) {
+		LOG_WRN("Display buffer is not available");
+		return -EINVAL;
+	}
+
+	if (desc->width != LPM0XX_PANEL_WIDTH) {
+		LOG_ERR("Width not a multiple of %d", LPM0XX_PANEL_WIDTH);
+		return -EINVAL;
+	}
+
+	if (desc->pitch != desc->width) {
+		LOG_ERR("Unsupported mode");
+		return -ENOTSUP;
+	}
+
+	if ((y + desc->height) > LPM0XX_PANEL_HEIGHT) {
+		LOG_ERR("Buffer out of bounds (height)");
+		return -EINVAL;
+	}
+
+	if (x != 0) {
+		LOG_ERR("X-coordinate has to be 0");
+		return -EINVAL;
+	}
+
+	/* Adding 1 since line numbering on the display starts with 1 */
+	return lpm0xx_update_display(dev, y + 1, desc->height, buf);
+}
+
+static int lpm0xx_read(const struct device *dev, const uint16_t x,
+		      const uint16_t y,
+		      const struct display_buffer_descriptor *desc,
+		      void *buf)
+{
+	LOG_ERR("not supported");
+	return -ENOTSUP;
+}
+
+static void *lpm0xx_get_framebuffer(const struct device *dev)
+{
+	LOG_ERR("not supported");
+	return NULL;
+}
+
+static int lpm0xx_set_brightness(const struct device *dev,
+				const uint8_t brightness)
+{
+	LOG_WRN("not supported");
+	return -ENOTSUP;
+}
+
+static int lpm0xx_set_contrast(const struct device *dev, uint8_t contrast)
+{
+	LOG_WRN("not supported");
+	return -ENOTSUP;
+}
+
+static void lpm0xx_get_capabilities(const struct device *dev,
+				   struct display_capabilities *caps)
+{
+	memset(caps, 0, sizeof(struct display_capabilities));
+	caps->x_resolution = LPM0XX_PANEL_WIDTH;
+	caps->y_resolution = LPM0XX_PANEL_HEIGHT;
+	caps->supported_pixel_formats = PIXEL_FORMAT_RGBx_111;
+	caps->current_pixel_format = PIXEL_FORMAT_RGBx_111;
+	caps->screen_info = SCREEN_INFO_X_ALIGNMENT_WIDTH;
+}
+
+static int lpm0xx_set_orientation(const struct device *dev,
+				 const enum display_orientation orientation)
+{
+	LOG_ERR("Unsupported");
+	return -ENOTSUP;
+}
+
+static int lpm0xx_set_pixel_format(const struct device *dev,
+				  const enum display_pixel_format pf)
+{
+	if (pf == PIXEL_FORMAT_RGBx_111) {
+		return 0;
+	}
+
+	LOG_ERR("not supported");
+	return -ENOTSUP;
+}
+
+static int lpm0xx_init(const struct device *dev)
+{
+	struct lpm0xx_data *driver = dev->data;
+
+	driver->spi_dev = device_get_binding(DT_INST_BUS_LABEL(0));
+	if (driver->spi_dev == NULL) {
+		LOG_ERR("Could not get SPI device for LPM0XX");
+		return -EIO;
+	}
+
+	driver->spi_config.frequency = DT_INST_PROP(0, spi_max_frequency);
+	driver->spi_config.operation = SPI_OP_MODE_MASTER |
+				       SPI_WORD_SET(8) |
+				       SPI_TRANSFER_MSB |
+				       SPI_CS_ACTIVE_HIGH |
+				       SPI_HOLD_ON_CS |
+				       SPI_LOCK_ON;
+	driver->spi_config.slave = 0;
+
+#if DT_INST_SPI_DEV_HAS_CS_GPIOS(0)
+	driver->cs_ctrl.gpio_dev = device_get_binding(
+		DT_INST_SPI_DEV_CS_GPIOS_LABEL(0));
+	if (driver->cs_ctrl.gpio_dev == NULL) {
+		LOG_ERR("Could not get SPI device for LPM0XX");
+		return -EIO;
+	}
+	driver->cs_ctrl.gpio_pin = DT_INST_SPI_DEV_CS_GPIOS_PIN(0);
+	driver->cs_ctrl.gpio_dt_flags = DT_INST_SPI_DEV_CS_GPIOS_FLAGS(0);
+	driver->cs_ctrl.delay = 0U;
+	driver->spi_config.cs = &driver->cs_ctrl;
+#endif
+
+#if DT_INST_NODE_HAS_PROP(0, disp_en_gpios)
+	driver->disp_dev = device_get_binding(
+		DT_INST_GPIO_LABEL(0, disp_en_gpios));
+	if (driver->disp_dev == NULL) {
+		LOG_ERR("Could not get DISP pin port for LPM0XX");
+		return -EIO;
+	}
+	LOG_INF("Configuring DISP pin to OUTPUT_HIGH");
+	gpio_pin_configure(driver->disp_dev,
+			   DT_INST_GPIO_PIN(0, disp_en_gpios),
+			   GPIO_OUTPUT_HIGH);
+#endif
+
+#if DT_INST_NODE_HAS_PROP(0, extcomin_gpios)
+	driver->extcomin_dev = device_get_binding(
+		DT_INST_GPIO_LABEL(0, extcomin_gpios));
+	if (driver->extcomin_dev == NULL) {
+		LOG_ERR("Could not get EXTCOMIN pin port for LPM0XX");
+		return -EIO;
+	}
+	LOG_INF("Configuring EXTCOMIN pin");
+	gpio_pin_configure(driver->extcomin_dev,
+			   DT_INST_GPIO_PIN(0, extcomin_gpios),
+			   GPIO_OUTPUT_LOW);
+
+	/* Start thread for toggling VCOM */
+	k_tid_t vcom_toggle_tid = k_thread_create(&vcom_toggle_thread,
+						  vcom_toggle_stack,
+						  K_THREAD_STACK_SIZEOF(vcom_toggle_stack),
+						  lpm0xx_vcom_toggle,
+						  driver, NULL, NULL,
+						  3, 0, K_NO_WAIT);
+	k_thread_name_set(vcom_toggle_tid, "lpm0xx_vcom");
+#endif  /* DT_INST_NODE_HAS_PROP(0, extcomin_gpios) */
+
+	/* Clear display else it shows random data */
+	return lpm0xx_clear(dev);
+}
+
+static struct lpm0xx_data lpm0xx_driver;
+
+static struct display_driver_api lpm0xx_driver_api = {
+	.blanking_on = lpm0xx_blanking_on,
+	.blanking_off = lpm0xx_blanking_off,
+	.write = lpm0xx_write,
+	.read = lpm0xx_read,
+	.get_framebuffer = lpm0xx_get_framebuffer,
+	.set_brightness = lpm0xx_set_brightness,
+	.set_contrast = lpm0xx_set_contrast,
+	.get_capabilities = lpm0xx_get_capabilities,
+	.set_pixel_format = lpm0xx_set_pixel_format,
+	.set_orientation = lpm0xx_set_orientation,
+};
+
+DEVICE_DT_INST_DEFINE(0, lpm0xx_init, NULL,
+		      &lpm0xx_driver, NULL,
+		      POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY,
+		      &lpm0xx_driver_api);

--- a/dts/bindings/display/jdi,lpm0xx.yaml
+++ b/dts/bindings/display/jdi,lpm0xx.yaml
@@ -5,7 +5,7 @@ description: JDI Memory in Pixel display controller
 
 compatible: "jdi,lpm0xx"
 
-include: spi-device.yaml
+include: [spi-device.yaml]
 
 properties:
     height:
@@ -20,7 +20,6 @@ properties:
 
     extcomin-gpios:
       type: phandle-array
-      required: false
       description: EXTCOMIN pin
 
         The EXTCOMIN pin is where a square pulse for toggling VCOM will
@@ -28,7 +27,6 @@ properties:
 
     extcomin-frequency:
       type: int
-      required: false
       description: EXTCOMIN pin toggle frequency
 
         The frequency with which the EXTCOMIN pin should be toggled. See
@@ -37,7 +35,6 @@ properties:
 
     disp-en-gpios:
       type: phandle-array
-      required: false
       description: DISPLAY pin
 
         The DISPLAY pin controls if the LCD displays memory contents or

--- a/dts/bindings/display/jdi,lpm0xx.yaml
+++ b/dts/bindings/display/jdi,lpm0xx.yaml
@@ -1,0 +1,45 @@
+# Copyright (c) 2020, Rohit Gujarathi
+# SPDX-License-Identifier: Apache-2.0
+
+description: JDI Memory in Pixel display controller
+
+compatible: "jdi,lpm0xx"
+
+include: spi-device.yaml
+
+properties:
+    height:
+      type: int
+      required: true
+      description: Height in pixel of the panel driven by the controller
+
+    width:
+      type: int
+      required: true
+      description: Width in pixel of the panel driven by the controller
+
+    extcomin-gpios:
+      type: phandle-array
+      required: false
+      description: EXTCOMIN pin
+
+        The EXTCOMIN pin is where a square pulse for toggling VCOM will
+        be given
+
+    extcomin-frequency:
+      type: int
+      required: false
+      description: EXTCOMIN pin toggle frequency
+
+        The frequency with which the EXTCOMIN pin should be toggled. See
+        datasheet of particular display. Higher frequency gives better
+        contrast while low frequency saves power.
+
+    disp-en-gpios:
+      type: phandle-array
+      required: false
+      description: DISPLAY pin
+
+        The DISPLAY pin controls if the LCD displays memory contents or
+        white screen. If defined, the pin will be set high during driver
+        initialization. display blanking apis can be used to control it.

--- a/include/zephyr/drivers/display.h
+++ b/include/zephyr/drivers/display.h
@@ -44,6 +44,7 @@ enum display_pixel_format {
 	PIXEL_FORMAT_ARGB_8888		= BIT(3), /**< 32-bit ARGB */
 	PIXEL_FORMAT_RGB_565		= BIT(4), /**< 16-bit RGB */
 	PIXEL_FORMAT_BGR_565		= BIT(5), /**< 16-bit BGR */
+	PIXEL_FORMAT_RGBx_111		= BIT(6), /* 3bpp + 1 dummy */
 };
 
 /**

--- a/samples/drivers/display/src/main.c
+++ b/samples/drivers/display/src/main.c
@@ -371,7 +371,6 @@ int main(void)
 	while (1) {
 		fill_buffer_fnc(BOTTOM_LEFT, grey_count, buf, 0, rect_w, &buf_desc);
 		display_write(display_dev, x, y, &buf_desc, buf);
-		
 		++grey_count;
 		k_msleep(grey_scale_sleep);
 #if CONFIG_TEST

--- a/samples/drivers/display/src/main.c
+++ b/samples/drivers/display/src/main.c
@@ -26,7 +26,7 @@ enum corner {
 };
 
 typedef void (*fill_buffer)(enum corner corner, uint8_t grey, uint8_t *buf,
-			    size_t buf_size);
+			    size_t x, size_t w, struct display_buffer_descriptor *buf_desc);
 
 
 #ifdef CONFIG_ARCH_POSIX
@@ -44,7 +44,7 @@ static void posix_exit_main(int exit_code)
 #endif
 
 static void fill_buffer_argb8888(enum corner corner, uint8_t grey, uint8_t *buf,
-				 size_t buf_size)
+				 size_t x, size_t w, struct display_buffer_descriptor *buf_desc)
 {
 	uint32_t color = 0;
 
@@ -63,13 +63,16 @@ static void fill_buffer_argb8888(enum corner corner, uint8_t grey, uint8_t *buf,
 		break;
 	}
 
-	for (size_t idx = 0; idx < buf_size; idx += 4) {
-		*((uint32_t *)(buf + idx)) = color;
+	for (size_t row = 0; row < buf_desc->height; row++) {
+		for (size_t col = x; col < x + w; col++) {
+			*((uint32_t *)buf + col) = color;
+		}
+		buf += buf_desc->pitch * sizeof(uint32_t);
 	}
 }
 
 static void fill_buffer_rgb888(enum corner corner, uint8_t grey, uint8_t *buf,
-			       size_t buf_size)
+			       size_t x, size_t w, struct display_buffer_descriptor *buf_desc)
 {
 	uint32_t color = 0;
 
@@ -88,10 +91,13 @@ static void fill_buffer_rgb888(enum corner corner, uint8_t grey, uint8_t *buf,
 		break;
 	}
 
-	for (size_t idx = 0; idx < buf_size; idx += 3) {
-		*(buf + idx + 0) = color >> 16;
-		*(buf + idx + 1) = color >> 8;
-		*(buf + idx + 2) = color >> 0;
+	for (size_t row = 0; row < buf_desc->height; row++) {
+		for (size_t col = x; col < x + w; col++) {
+			*(buf + 3 * col + 0) = color >> 16;
+			*(buf + 3 * col + 1) = color >> 8;
+			*(buf + 3 * col + 2) = color >> 0;
+		}
+		buf += buf_desc->pitch * 3;
 	}
 }
 
@@ -120,28 +126,72 @@ static uint16_t get_rgb565_color(enum corner corner, uint8_t grey)
 }
 
 static void fill_buffer_rgb565(enum corner corner, uint8_t grey, uint8_t *buf,
-			       size_t buf_size)
+			       size_t x, size_t w, struct display_buffer_descriptor *buf_desc)
 {
 	uint16_t color = get_rgb565_color(corner, grey);
 
-	for (size_t idx = 0; idx < buf_size; idx += 2) {
-		*(buf + idx + 0) = (color >> 8) & 0xFFu;
-		*(buf + idx + 1) = (color >> 0) & 0xFFu;
+	for (size_t row = 0; row < buf_desc->height; row++) {
+		for (size_t col = x; col < x + w; col++) {
+			*(buf + 2 * col + 0) = (color >> 8) & 0xFFu;
+			*(buf + 2 * col + 1) = (color >> 0) & 0xFFu;
+		}
+		buf += buf_desc->pitch * 2;
 	}
 }
 
 static void fill_buffer_bgr565(enum corner corner, uint8_t grey, uint8_t *buf,
-			       size_t buf_size)
+			       size_t x, size_t w, struct display_buffer_descriptor *buf_desc)
 {
 	uint16_t color = get_rgb565_color(corner, grey);
 
-	for (size_t idx = 0; idx < buf_size; idx += 2) {
-		*(uint16_t *)(buf + idx) = color;
+	for (size_t row = 0; row < buf_desc->height; row++) {
+		for (size_t col = x; col < x + w; col++) {
+			*((uint16_t *)buf + col) = color;
+		}
+
+		buf += buf_desc->pitch * 2;
+	}
+}
+
+static uint8_t get_rgbx111_color(enum corner corner, uint8_t grey)
+{
+	uint8_t color = 0;
+
+	switch (corner) {
+	case TOP_LEFT:
+		color = 0b1000;
+		break;
+	case TOP_RIGHT:
+		color = 0b0100;
+		break;
+	case BOTTOM_RIGHT:
+		color = 0b0010;
+		break;
+	case BOTTOM_LEFT:
+		/* 3bpp shifted to the left one dummy bit */
+		color = (grey % 2 == 0 ? 0b1110 : 0b0000);
+		break;
+	}
+	return color;
+}
+
+static void fill_buffer_rgbx111(enum corner corner, uint8_t grey,
+				uint8_t *buf, size_t x, size_t w,
+				struct display_buffer_descriptor *buf_desc)
+{
+	uint8_t color = get_rgbx111_color(corner, grey);
+
+	for (size_t row = 0; row < buf_desc->height; row++) {
+		for (size_t col = x; col < x + w; col += 2) {
+			*(buf + (col / 2)) = (color << 4) | color;
+		}
+		buf += buf_desc->pitch / 2;
 	}
 }
 
 static void fill_buffer_mono(enum corner corner, uint8_t grey, uint8_t *buf,
-			     size_t buf_size)
+			     size_t x, size_t w,
+			     struct display_buffer_descriptor *buf_desc)
 {
 	uint16_t color;
 
@@ -154,7 +204,12 @@ static void fill_buffer_mono(enum corner corner, uint8_t grey, uint8_t *buf,
 		break;
 	}
 
-	memset(buf, color, buf_size);
+	for (size_t row = 0; row < buf_desc->height; row++) {
+		for (size_t col = x; col < x + w; col += 8) {
+			*(buf + (col / 8)) = color;
+		}
+		buf += buf_desc->pitch / 8;
+	}
 }
 
 int main(void)
@@ -173,6 +228,7 @@ int main(void)
 	struct display_buffer_descriptor buf_desc;
 	size_t buf_size = 0;
 	fill_buffer fill_buffer_fnc = NULL;
+	size_t xoffset;
 
 	display_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
 	if (!device_is_ready(display_dev)) {
@@ -208,7 +264,11 @@ int main(void)
 		grey_scale_sleep = 100;
 	}
 
-	buf_size = rect_w * rect_h;
+	if (capabilities.screen_info & SCREEN_INFO_X_ALIGNMENT_WIDTH) {
+		buf_size = capabilities.x_resolution * rect_h;
+	} else {
+		buf_size = rect_w * rect_h;
+	}
 
 	if (buf_size < (capabilities.x_resolution * h_step)) {
 		buf_size = capabilities.x_resolution * h_step;
@@ -235,6 +295,10 @@ int main(void)
 	case PIXEL_FORMAT_MONO10:
 		fill_buffer_fnc = fill_buffer_mono;
 		buf_size /= 8;
+		break;
+	case PIXEL_FORMAT_RGBx_111:
+		fill_buffer_fnc = fill_buffer_rgbx111;
+		buf_size /= 2;
 		break;
 	default:
 		LOG_ERR("Unsupported pixel format. Aborting sample.");
@@ -267,22 +331,34 @@ int main(void)
 		display_write(display_dev, 0, idx, &buf_desc, buf);
 	}
 
-	buf_desc.pitch = rect_w;
-	buf_desc.width = rect_w;
+	if (capabilities.screen_info & SCREEN_INFO_X_ALIGNMENT_WIDTH) {
+		buf_desc.pitch = capabilities.x_resolution;
+		buf_desc.width = capabilities.x_resolution;
+		xoffset = capabilities.x_resolution - rect_w;
+	} else {
+		buf_desc.pitch = rect_w;
+		buf_desc.width = rect_w;
+		xoffset = 0;
+	}
 	buf_desc.height = rect_h;
 
-	fill_buffer_fnc(TOP_LEFT, 0, buf, buf_size);
 	x = 0;
 	y = 0;
+	fill_buffer_fnc(TOP_LEFT, 0, buf, 0, rect_w, &buf_desc);
 	display_write(display_dev, x, y, &buf_desc, buf);
 
-	fill_buffer_fnc(TOP_RIGHT, 0, buf, buf_size);
-	x = capabilities.x_resolution - rect_w;
+	if (!(capabilities.screen_info & SCREEN_INFO_X_ALIGNMENT_WIDTH)) {
+		x = capabilities.x_resolution - rect_w;
+	}
 	y = 0;
+	fill_buffer_fnc(TOP_RIGHT, 0, buf, xoffset, rect_w, &buf_desc);
 	display_write(display_dev, x, y, &buf_desc, buf);
 
-	fill_buffer_fnc(BOTTOM_RIGHT, 0, buf, buf_size);
-	x = capabilities.x_resolution - rect_w;
+	if (!(capabilities.screen_info & SCREEN_INFO_X_ALIGNMENT_WIDTH)) {
+		x = capabilities.x_resolution - rect_w;
+	} else {
+		(void)memset(buf, 0xFFu, buf_size);
+	}
 	y = capabilities.y_resolution - rect_h;
 	display_write(display_dev, x, y, &buf_desc, buf);
 
@@ -293,8 +369,9 @@ int main(void)
 	y = capabilities.y_resolution - rect_h;
 
 	while (1) {
-		fill_buffer_fnc(BOTTOM_LEFT, grey_count, buf, buf_size);
+		fill_buffer_fnc(BOTTOM_LEFT, grey_count, buf, 0, rect_w, &buf_desc);
 		display_write(display_dev, x, y, &buf_desc, buf);
+		
 		++grey_count;
 		k_msleep(grey_scale_sleep);
 #if CONFIG_TEST


### PR DESCRIPTION
display: add support for LPM0XX display series by JDI

This monitor from JDI is very similar to Sharp's LS0xx LCD, but slightly different in protocol and color format, I made some modifications, hope it will be useful.

Locally I use the Adafruit_GFX_Library library to display them well, and you can see its display effect here:

https://github.com/rhmokey/JDI

This addition entails extending the list of supported color formats to include four-bit (r, g, b, dummy) formats, with this monitor from JDI also supporting three-bit (r, g, b) and <>-bit monochrome.

I've opened this as a draft because I'd like to get your input on changes. Also, this is my first contribution to Zephyr, so I expect to mess up a few things along the way.