### PR TITLE
timer: ambiq_stimer: Correct set_timeout's delta clock calculation

### DIFF
--- a/drivers/timer/ambiq_stimer.c
+++ b/drivers/timer/ambiq_stimer.c
@@ -80,23 +80,15 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 		return;
 	}
 
+	if (ticks == K_TICKS_FOREVER) {
+		return;
+	}
+
+	ticks = MIN(MAX_TICKS, ticks);
+	/* If tick is 0, set delta cyc to MIN_DELAY to trigger tick isr asap */
+	uint32_t cyc = MAX(ticks * CYC_PER_TICK, MIN_DELAY);
+
 	k_spinlock_key_t key = k_spin_lock(&g_lock);
-
-	uint64_t now = am_hal_stimer_counter_get();
-	uint32_t adj, cyc = ticks * CYC_PER_TICK;
-
-	/* Round up to next tick boundary. */
-	adj = (uint32_t)(now - g_last_count) + (CYC_PER_TICK - 1);
-	if (cyc <= MAX_CYCLES - adj) {
-		cyc += adj;
-	} else {
-		cyc = MAX_CYCLES;
-	}
-	cyc = (cyc / CYC_PER_TICK) * CYC_PER_TICK;
-
-	if ((int32_t)(cyc + g_last_count - now) < MIN_DELAY) {
-		cyc += CYC_PER_TICK;
-	}
 
 	am_hal_stimer_compare_delta_set(0, cyc);
 


### PR DESCRIPTION
In sys_clock_set_timeout(), input "ticks" is used to compute next timeout point, Ambiq's STimer API used to sets next timeout has input parameter as ui32Delta, which inside the API is using "this value to add to the STimer counter and load into the comparator register" according to its spec, thus the this delta clock is almost equivalent to input "ticks"'s concept, and is not related to last_count, it should be computed directly from input "ticks". 

This correction fixes the test case failure at zephyr\tests\kernel\tickless\tickless_concept.
