### PR TITLE
tests: crypto: rand32: Check return code of sys_csrand_get

### DIFF
--- a/tests/crypto/rand32/src/main.c
+++ b/tests/crypto/rand32/src/main.c
@@ -90,7 +90,10 @@ ZTEST(rand32_common, test_rand32)
 	printk("Generating bulk fill cryptographically secure random numbers\n");
 
 	memset(buf, 0, sizeof(buf));
-	sys_csrand_get(buf, sizeof(buf));
+
+	int err = sys_csrand_get(buf, sizeof(buf));
+
+	zassert_true(err == 0, "sys_csrand_get returned an error");
 
 	for (rnd_cnt = 0; rnd_cnt < (N_VALUES - 1); rnd_cnt++) {
 		gen = buf[rnd_cnt];


### PR DESCRIPTION
Check the return code of sys_csrand_get when testing the function.

Ignoring it is bad practice and can also be a security issue if users copy-paste this test code.