### PR TITLE
drivers: net: T1S LAN8651fixes

### DIFF
--- a/drivers/ethernet/Kconfig.lan865x
+++ b/drivers/ethernet/Kconfig.lan865x
@@ -46,6 +46,6 @@ config ETH_LAN865X_TIMEOUT
 	help
 	  Given timeout in milliseconds. Maximum amount of time
 	  that the driver will wait from the IP stack to get
-	  a memory buffer before the Ethernet frame is dropped.
+	  a memory buffer.
 
 endif # ETH_LAN865X

--- a/drivers/ethernet/eth_lan865x.c
+++ b/drivers/ethernet/eth_lan865x.c
@@ -395,14 +395,13 @@ static void lan865x_read_chunks(const struct device *dev)
 	struct net_pkt *pkt;
 	int ret;
 
-	k_sem_take(&ctx->tx_rx_sem, K_FOREVER);
 	pkt = net_pkt_rx_alloc(K_MSEC(cfg->timeout));
 	if (!pkt) {
-		k_sem_give(&ctx->tx_rx_sem);
 		LOG_ERR("OA RX: Could not allocate packet!");
 		return;
 	}
 
+	k_sem_take(&ctx->tx_rx_sem, K_FOREVER);
 	ret = oa_tc6_read_chunks(tc6, pkt);
 	if (ret < 0) {
 		eth_stats_update_errors_rx(ctx->iface);

--- a/drivers/ethernet/eth_lan865x.c
+++ b/drivers/ethernet/eth_lan865x.c
@@ -547,6 +547,12 @@ static int lan865x_port_send(const struct device *dev, struct net_pkt *pkt)
 
 	k_sem_take(&ctx->tx_rx_sem, K_FOREVER);
 	ret = oa_tc6_send_chunks(tc6, pkt);
+
+	/* Check if rca > 0 during half-duplex TX transmission */
+	if (tc6->rca > 0) {
+		k_sem_give(&ctx->int_sem);
+	}
+
 	k_sem_give(&ctx->tx_rx_sem);
 	if (ret < 0) {
 		LOG_ERR("TX transmission error, %d", ret);


### PR DESCRIPTION
Fixes for LAN865x Zephyr driver:

- Check parity errors when footer received, before update the struct tc6
- Fix problem with lack of IRQ generation stalls in driver
- Update Kconfig description
- Increase driver's performance by optimally use locking primitives