### PR TITLE
slist find without remove #65973 

### DIFF
--- a/include/zephyr/sys/list_gen.h
+++ b/include/zephyr/sys/list_gen.h
@@ -234,6 +234,31 @@
 		return false;						 \
 	}
 
+#define Z_GENLIST_FIND(__lname, __nname)                                                 \
+	static inline bool sys_##__lname##_find(                                         \
+		sys_##__lname##_t *list, sys_##__nname##_t *node, sys_##__nname##_t **prev)        \
+	{                                                                                          \
+		sys_##__nname##_t *current = NULL;                                                 \
+		sys_##__nname##_t *previous = NULL;                                                \
+                                                                                                   \
+		Z_GENLIST_FOR_EACH_NODE(__lname, list, current) {                                  \
+			if (current == node) {                                                     \
+				if (prev != NULL) {                                                \
+					*prev = previous;                                          \
+				}                                                                  \
+				return true;                                                       \
+			}                                                                          \
+                                                                                                   \
+			previous = current;                                                        \
+		}                                                                                  \
+                                                                                                   \
+		if (prev != NULL) {                                                                \
+			*prev = previous;                                                          \
+		}                                                                                  \
+                                                                                                   \
+		return false;                                                                      \
+	}
+
 #define Z_GENLIST_LEN(__lname, __nname)                                                            \
 	static inline size_t sys_##__lname##_len(sys_##__lname##_t * list)                         \
 	{                                                                                          \

--- a/include/zephyr/sys/slist.h
+++ b/include/zephyr/sys/slist.h
@@ -421,6 +421,21 @@ static inline bool sys_slist_find_and_remove(sys_slist_t *list,
 					     sys_snode_t *node);
 
 /**
+ * @brief Find if a node is already linked in a singly linked list
+ *
+ * This and other sys_slist_*() functions are not thread safe.
+ *
+ * @param list A pointer to the list to check
+ * @param node A pointer to the node to search in the list
+ * @param[out] prev A pointer to the previous node
+ *
+ * @return true if node was found in the list, false otherwise
+ */
+static inline bool sys_slist_find(sys_slist_t *list, sys_snode_t *node,
+					    sys_snode_t **prev);
+Z_GENLIST_FIND(slist, snode)
+
+/**
  * @brief Compute the size of the given list in O(n) time
  *
  * @param list A pointer on the list

--- a/tests/unit/list/slist.c
+++ b/tests/unit/list/slist.c
@@ -184,7 +184,7 @@ static inline bool verify_tail_head(sys_slist_t *list,
  * @see sys_slist_init(), sys_slist_append(),
  * sys_slist_find_and_remove(), sys_slist_prepend(),
  * sys_slist_remove(), sys_slist_get(), sys_slist_get_not_empty(),
- * sys_slist_append_list(), sys_slist_merge_list()
+ * sys_slist_append_list(), sys_slist_merge_list(), sys_slist_find()
  */
 ZTEST(dlist_api, test_slist)
 {
@@ -201,6 +201,13 @@ ZTEST(dlist_api, test_slist)
 	zassert_true((verify_tail_head(&test_list, &test_node_1.node,
 				       &test_node_1.node, true)),
 		     "test_list head/tail are wrong");
+
+	/* Find the node 1, previous node should be null */
+	sys_snode_t *test_node_1_prev = &test_node_1.node;
+
+	zassert_true(sys_slist_find(&test_list, &test_node_1.node, &test_node_1_prev),
+		     "test_list did not find node ");
+	zassert_is_null(test_node_1_prev, "test_list previous node not null ");
 
 	/* Finding and removing node 1 */
 	sys_slist_find_and_remove(&test_list, &test_node_1.node);
@@ -257,6 +264,14 @@ ZTEST(dlist_api, test_slist)
 	zassert_true((sys_slist_peek_next_no_check(&test_node_2.node) ==
 		      &test_node_4.node),
 		     "test_list node links are wrong");
+
+    /* Find the node 4 and get the previous node*/
+	sys_snode_t *test_node_4_prev = NULL;
+
+	zassert_true(sys_slist_find(&test_list, &test_node_4.node, &test_node_4_prev),
+		     "test_list did not find node");
+	zassert_equal(&test_node_2.node, test_node_4_prev,
+		     "test_list previous node wrong ");
 
 	/* Finding and removing node 1 */
 	sys_slist_find_and_remove(&test_list, &test_node_1.node);


### PR DESCRIPTION
I added a function to check if a node is linked.
I found the idea of  @peter-mitsis great, so I try to implement it.
 "bool sys_snode_is_linked(sys_slist_t * list, sys_snode_t *node, sys_snode_t **prev);"
 

>  Thinking aloud ...
> 
> Searching for a specific node in a slist requires a linear search which is an O(N) operation. This is something that we would not want as default behaviour in sys_slist_append(). Probably not for debugging behaviour either as that linear search would come with an expected high performance penalty. I would expect the better practice would be to foist the responsibility of a search onto the caller so that the penalty is not incurred by all users of sys_slist_append()--even in a debugging scenario.
> 
> If it is done, then my preference would be for naming it something like ...
>     bool sys_snode_is_linked(sys_slist_t * list, sys_snode_t *node, sys_snode_t **prev);
> If the node does need to be removed later, it may then be done more quickly and easily without necessarily incurring the penalty of another linear search.

I think also that a linear search shouldn't be apply every time we use sys_slist_append(), and that should be used only in case to case.

My solution isn't perfect, and would like to discuss about it !

Signed-off-by: Gaetan Perrot <gaetanperrotpro@gmail.com> 

fixes https://github.com/zephyrproject-rtos/zephyr/issues/65973