### PR TITLE
arch: arm: core: mpu: Limit non-secure flash to zephyr,code-partition

### DIFF
--- a/arch/arm/core/mpu/arm_mpu_regions.c
+++ b/arch/arm/core/mpu/arm_mpu_regions.c
@@ -8,14 +8,23 @@
 #include <zephyr/arch/arm/mpu/arm_mpu.h>
 
 #include <zephyr/arch/arm/cortex_m/arm_mpu_mem_cfg.h>
+#include <zephyr/devicetree.h>
+
+#if defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
+#define FLASH_0_NODE DT_CHOSEN(zephyr_code_partition)
+#define FLASH_0_BASE DT_REG_ADDR(FLASH_0_NODE)
+#define FLASH_0_SIZE DT_REG_SIZE(FLASH_0_NODE)
+#else
+#define FLASH_0_BASE CONFIG_FLASH_BASE_ADDRESS
+#define FLASH_0_SIZE (CONFIG_FLASH_SIZE * 1024)
+#endif
 
 static const struct arm_mpu_region mpu_regions[] = {
 	/* Region 0 */
 	MPU_REGION_ENTRY("FLASH_0",
-			 CONFIG_FLASH_BASE_ADDRESS,
+			 FLASH_0_BASE,
 #if defined(CONFIG_ARMV8_M_BASELINE) || defined(CONFIG_ARMV8_M_MAINLINE)
-			 REGION_FLASH_ATTR(CONFIG_FLASH_BASE_ADDRESS, \
-				 CONFIG_FLASH_SIZE * 1024)),
+			 REGION_FLASH_ATTR(FLASH_0_BASE, FLASH_0_SIZE)),
 #else
 			 REGION_FLASH_ATTR(REGION_FLASH_SIZE)),
 #endif

--- a/arch/arm/core/mpu/arm_mpu_regions.c
+++ b/arch/arm/core/mpu/arm_mpu_regions.c
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/sys/slist.h>
 #include <zephyr/arch/arm/mpu/arm_mpu.h>
-
 #include <zephyr/arch/arm/cortex_m/arm_mpu_mem_cfg.h>
 #include <zephyr/devicetree.h>
 


### PR DESCRIPTION
Correct MPU regions configuration used in non-secure images so that the flash region allowed to be accessed is limited to area specified by the dts node chosen as `zephyr,code-partition`. Without this change, `K_SYSCALL_MEMORY_READ()` could return incorrect result saying that a particular flash area is readable while an actual attempt to read it would result in SecureFault.

Fixes #65909.