### PR TITLE
drivers: sdhc: intel_emmc_host: Fix return value

### DIFF
--- a/drivers/sdhc/intel_emmc_host.c
+++ b/drivers/sdhc/intel_emmc_host.c
@@ -1087,7 +1087,7 @@ static int emmc_set_io(const struct device *dev, struct sdhc_io *ios)
 		host_io->timing = ios->timing;
 	}
 
-	return ret;
+	return 0;
 }
 
 static int emmc_get_card_present(const struct device *dev)


### PR DESCRIPTION
Fixes uninitialized variable return by returning zero at the end of function.

Signed-off-by: Anisetti Avinash Krishna <anisetti.avinash.krishna@intel.com>