### PR TITLE
samples: hello_world_user: fail in compilation if userspace is not enabled

### DIFF
--- a/samples/userspace/hello_world_user/src/main.c
+++ b/samples/userspace/hello_world_user/src/main.c
@@ -8,6 +8,10 @@
 #include <stdio.h>
 #define USER_STACKSIZE	2048
 
+#ifndef CONFIG_USERSPACE
+#error This sample requires CONFIG_USERSPACE.
+#endif
+
 struct k_thread user_thread;
 K_THREAD_STACK_DEFINE(user_stack, USER_STACKSIZE);
 


### PR DESCRIPTION
The sample can be compiled with or without the `CONFIG_USERSPACE` symbol.
It will, however, panic if userspace is not enabled.

We can make it fail during compilation for platforms that do not support userspace.
For platforms that support userspace the assertion will still be meaningful, used to prove that userspace support actually works as expected.