### PR TITLE
posix: remove deprecated non-standard PTHREAD_MUTEX_DEFINE, etc

### DIFF
--- a/include/zephyr/posix/pthread.h
+++ b/include/zephyr/posix/pthread.h
@@ -48,18 +48,6 @@ extern "C" {
 #define PTHREAD_COND_INITIALIZER (-1)
 
 /**
- * @brief Declare a pthread condition variable
- *
- * Declaration API for a pthread condition variable.  This is not a
- * POSIX API, it's provided to better conform with Zephyr's allocation
- * strategies for kernel objects.
- *
- * @param name Symbol name of the condition variable
- * @deprecated Use @c PTHREAD_COND_INITIALIZER instead.
- */
-#define PTHREAD_COND_DEFINE(name) pthread_cond_t name = PTHREAD_COND_INITIALIZER
-
-/**
  * @brief POSIX threading compatibility API
  *
  * See IEEE 1003.1
@@ -142,18 +130,6 @@ int pthread_condattr_setclock(pthread_condattr_t *att, clockid_t clock_id);
  * Initialize a mutex with the default mutex attributes.
  */
 #define PTHREAD_MUTEX_INITIALIZER (-1)
-
-/**
- * @brief Declare a pthread mutex
- *
- * Declaration API for a pthread mutex.  This is not a POSIX API, it's
- * provided to better conform with Zephyr's allocation strategies for
- * kernel objects.
- *
- * @param name Symbol name of the mutex
- * @deprecated Use @c PTHREAD_MUTEX_INITIALIZER instead.
- */
-#define PTHREAD_MUTEX_DEFINE(name) pthread_mutex_t name = PTHREAD_MUTEX_INITIALIZER
 
 /*
  *  Mutex attributes - type

--- a/tests/posix/common/src/pthread.c
+++ b/tests/posix/common/src/pthread.c
@@ -30,12 +30,9 @@ K_THREAD_STACK_ARRAY_DEFINE(stack_1, 1, 32);
 void *thread_top_exec(void *p1);
 void *thread_top_term(void *p1);
 
-PTHREAD_MUTEX_DEFINE(lock);
-
-PTHREAD_COND_DEFINE(cvar0);
-
-PTHREAD_COND_DEFINE(cvar1);
-
+static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t cvar0 = PTHREAD_COND_INITIALIZER;
+static pthread_cond_t cvar1 = PTHREAD_COND_INITIALIZER;
 static pthread_barrier_t barrier;
 
 sem_t main_sem;


### PR DESCRIPTION
Remove the previously deprecated and non-standard macros
* PTHREAD_MUTEX_DEFINE()
* PTHREAD_COND_DEFINE()