### PR TITLE
west.yml: update hal_atmel to support sams70 soc's

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -147,7 +147,7 @@ manifest:
       groups:
         - hal
     - name: hal_atmel
-      revision: 942d664e48f7a2725933a93facc112b87b1de32b
+      revision: pull/37/head
       path: modules/hal/atmel
       groups:
         - hal


### PR DESCRIPTION
This update adds support for sams70 soc's to the hal_atmel repo.