### PR TITLE
boards: nucleo_wba52cg: Enable HSI16 clock

### DIFF
--- a/boards/arm/nucleo_wba52cg/nucleo_wba52cg.dts
+++ b/boards/arm/nucleo_wba52cg/nucleo_wba52cg.dts
@@ -59,6 +59,10 @@
 	status = "okay";
 };
 
+&clk_hsi {
+	status = "okay";
+};
+
 &pll1 {
 	div-m = <8>;
 	mul-n = <48>;


### PR DESCRIPTION
By default rng source is using HSI16 clock.
It has to be enabled on as part of board support.