### PR TITLE
arm64: smp: Fix cache operations in the SMP

### DIFF
--- a/arch/arm64/core/smp.c
+++ b/arch/arm64/core/smp.c
@@ -101,7 +101,7 @@ void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
 		/* store mpid last as this is our synchronization point */
 		arm64_cpu_boot_params.mpid = cpu_mpid;
 
-		sys_cache_data_invd_range((void *)&arm64_cpu_boot_params,
+		sys_cache_data_flush_range((void *)&arm64_cpu_boot_params,
 					  sizeof(arm64_cpu_boot_params));
 
 		if (pm_cpu_on(cpu_mpid, (uint64_t)&__start)) {


### PR DESCRIPTION
The arm64_cpu_boot_params will be read on other cores

so the sys_cache_data_flush_range function should be called to flush the data from the cache to RAM.

This ensures that other cores can access the correct data.