### PR TITLE
net: ip: dhcpv4: remove address on interface down

### DIFF
--- a/subsys/net/conn_mgr/events_handler.c
+++ b/subsys/net/conn_mgr/events_handler.c
@@ -24,7 +24,7 @@ static void conn_mgr_iface_events_handler(struct net_mgmt_event_callback *cb,
 {
 	int idx;
 
-	NET_DBG("Iface event %u received on iface %d (%p)", mgmt_event,
+	NET_DBG("%s event 0x%x received on iface %d (%p)", "Iface", mgmt_event,
 		net_if_get_by_iface(iface), iface);
 
 	if ((mgmt_event & CONN_MGR_IFACE_EVENTS_MASK) != mgmt_event) {
@@ -62,7 +62,7 @@ static void conn_mgr_ipv6_events_handler(struct net_mgmt_event_callback *cb,
 {
 	int idx;
 
-	NET_DBG("IPv6 event %u received on iface %d (%p)", mgmt_event,
+	NET_DBG("%s event 0x%x received on iface %d (%p)", "IPv6", mgmt_event,
 		net_if_get_by_iface(iface), iface);
 
 	if ((mgmt_event & CONN_MGR_IPV6_EVENTS_MASK) != mgmt_event) {
@@ -120,7 +120,7 @@ static void conn_mgr_ipv4_events_handler(struct net_mgmt_event_callback *cb,
 {
 	int idx;
 
-	NET_DBG("IPv4 event %u received on iface %d (%p)", mgmt_event,
+	NET_DBG("%s event 0x%x received on iface %d (%p)", "IPv4", mgmt_event,
 		net_if_get_by_iface(iface), iface);
 
 	if ((mgmt_event & CONN_MGR_IPV4_EVENTS_MASK) != mgmt_event) {

--- a/subsys/net/ip/dhcpv4.c
+++ b/subsys/net/ip/dhcpv4.c
@@ -1163,6 +1163,10 @@ static void dhcpv4_iface_event_handler(struct net_mgmt_event_callback *cb,
 			iface->config.dhcpv4.state = NET_DHCPV4_RENEWING;
 			NET_DBG("enter state=%s", net_dhcpv4_state_name(
 					iface->config.dhcpv4.state));
+			/* Remove any bound address as interface is gone */
+			if (!net_if_ipv4_addr_rm(iface, &iface->config.dhcpv4.requested_ip)) {
+				NET_DBG("Failed to remove addr from iface");
+			}
 		}
 	} else if (mgmt_event == NET_EVENT_IF_UP) {
 		NET_DBG("Interface %p coming up", iface);


### PR DESCRIPTION
Any received address is no longer valid once the interface goes down.
Leaving the address assigned results in the L4 interface transitioning
through the following on reconnection:
 UP: Interface is connected
 DOWN: Old address is removed by DHCP
 UP: New address is re-added by DHCP