### PR TITLE
Revert "net: gptp: Fix announce message len"

### DIFF
--- a/subsys/net/l2/ethernet/gptp/gptp_messages.h
+++ b/subsys/net/l2/ethernet/gptp/gptp_messages.h
@@ -68,7 +68,7 @@ extern "C" {
 #define GPTP_ANNOUNCE_LEN(pkt) \
 	(sizeof(struct gptp_hdr) + sizeof(struct gptp_announce) \
 	 + ntohs(GPTP_ANNOUNCE(pkt)->tlv.len) \
-	 - sizeof(struct gptp_path_trace_tlv))
+	 - sizeof(struct gptp_path_trace_tlv) + 4)
 
 #define GPTP_CHECK_LEN(pkt, len) \
 	((GPTP_PACKET_LEN(pkt) != len) && (GPTP_VALID_LEN(pkt, len)))


### PR DESCRIPTION
This reverts commit 6b644dff676e56e1402e72db8efe121c1d6b5b43.

Reason: breaks Peer-to-Peer gPTP connection. A better solution should be found to handle the optional TLV on the announce message (chapter 10.5.1 IEEE Std. 802.1AS-2011)
![10 5 1](https://github.com/zephyrproject-rtos/zephyr/assets/28357816/4b75f182-48f2-48b8-ab76-3cdbec35adaf)
