### PR TITLE
drivers: nrf_qspi_nor: Deactivate QSPI peripheral after initialization

### DIFF
--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -1090,6 +1090,10 @@ static int qspi_nor_init(const struct device *dev)
 
 	qspi_clock_div_restore();
 
+	if (!IS_ENABLED(CONFIG_NORDIC_QSPI_NOR_XIP) && nrfx_qspi_init_check()) {
+		(void)nrfx_qspi_deactivate();
+	}
+
 #ifdef CONFIG_PM_DEVICE_RUNTIME
 	int rc2 = pm_device_runtime_enable(dev);
 


### PR DESCRIPTION
This is a follow-up to commit ea1be7f242b9348863a27adb17215014f15b318a.

After the driver performs its initialization, it needs to deactivate the QSPI peripheral. Otherwise, the peripheral would unnecessarily consume power until some QSPI operation is performed (and only then it will get deactivated), what depending on the application may take a significant amount of time.