### PR TITLE
soc: stm32wba: hci_if: Implement HW_RNG_EnableClock API

### DIFF
--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -22,6 +22,7 @@
 #include <stm32_ll_bus.h>
 #include <stm32_ll_rcc.h>
 #include <stm32_ll_rng.h>
+#include <stm32_ll_pka.h>
 #include <stm32_ll_system.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/pm/device.h>
@@ -115,6 +116,10 @@ static int entropy_stm32_suspend(void)
 
 #ifdef CONFIG_SOC_SERIES_STM32WBAX
 	uint32_t wait_cycles, rng_rate;
+
+	if (LL_PKA_IsEnabled(PKA)) {
+		return 0;
+	}
 
 	if (clock_control_get_rate(dev_data->clock,
 			(clock_control_subsys_t) &dev_cfg->pclken[0],

--- a/soc/arm/st_stm32/stm32wba/hci_if/bleplat.c
+++ b/soc/arm/st_stm32/stm32wba/hci_if/bleplat.c
@@ -7,6 +7,10 @@
 #include <zephyr/irq.h>
 #include <zephyr/drivers/entropy.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/clock_control/stm32_clock_control.h>
+
+#include <stm32_ll_rng.h>
 
 #include "bleplat.h"
 #include "bpka.h"
@@ -16,7 +20,15 @@
 LOG_MODULE_REGISTER(ble_plat);
 
 RAMCFG_HandleTypeDef hramcfg_SRAM1;
-const struct device *rng_dev;
+const struct device *rng_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
+
+struct entropy_stm32_rng_dev_data {
+	RNG_TypeDef *rng;
+};
+
+struct entropy_stm32_rng_dev_cfg {
+	struct stm32_pclken *pclken;
+};
 
 void BLEPLAT_Init(void)
 {
@@ -92,9 +104,48 @@ void Error_Handler(void)
 	LOG_ERR("");
 }
 
+void enable_rng_clock(bool enable)
+{
+	const struct entropy_stm32_rng_dev_cfg *dev_cfg = rng_dev->config;
+	struct entropy_stm32_rng_dev_data *dev_data = rng_dev->data;
+	struct stm32_pclken *rng_pclken;
+	const struct device *rcc;
+	unsigned int key;
+
+	rcc = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
+	rng_pclken = (clock_control_subsys_t)&dev_cfg->pclken[0];
+
+	key = irq_lock();
+
+	/* Enable/Disable RNG clock only if not in use */
+	if (!LL_RNG_IsEnabled((RNG_TypeDef *)dev_data->rng)) {
+		if (enable) {
+			clock_control_on(rcc, rng_pclken);
+		} else {
+			clock_control_off(rcc, rng_pclken);
+		}
+	}
+
+	irq_unlock(key);
+}
+
+/* PKA IP requires RNG clock to be enabled
+ * These APIs are used by BLE controller to enable/disable RNG clock,
+ * based on PKA needs.
+ */
+void HW_RNG_DisableClock(uint8_t user_mask)
+{
+	ARG_UNUSED(user_mask);
+
+	enable_rng_clock(false);
+}
+
+void HW_RNG_EnableClock(uint8_t user_mask)
+{
+	ARG_UNUSED(user_mask);
+
+	enable_rng_clock(true);
+}
+
 /* BLE ctlr should not disable HSI on its own */
 void SCM_HSI_CLK_OFF(void) {}
-
-/* BLE ctlr should not alter RNG clocks */
-void HW_RNG_DisableClock(uint8_t) {}
-void HW_RNG_EnableClock(uint8_t) {}


### PR DESCRIPTION
STM32WBA controller uses a PKA driver to perform cyphering operations on keys. Since PKA hardware block requires RNG clock to be enabled, a synchronization with zephyr RNG driver is needed.

Use RNG enable status to check if RNG could be switched off or needs to be switched on.
Similarly in entropy driver, don't cut RNG clock if PKA is enabled.

Signed-off-by: Erwan Gouriou <erwan.gouriou@st.com>