### PR TITLE
bluetooth: audio: cap: Unicast Audio Start: Establish all CISes without waiting for Streaming notification.

### DIFF
--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -532,6 +532,17 @@ struct bt_bap_stream_ops {
 	/**
 	 * @brief Stream started callback
 	 *
+	 * Almost-started callback is called whenever an Audio Stream has been started
+	 * in terms of the CIS Establish and sending Receiver Start Ready to the remote
+	 * device, but the Streaming notification is still awaited.
+	 *
+	 * @param stream Stream object that has been started.
+	 */
+	void (*almost_started)(struct bt_bap_stream *stream);
+
+	/**
+	 * @brief Stream started callback
+	 *
 	 * Started callback is called whenever an Audio Stream has been started
 	 * and will be usable for streaming.
 	 *

--- a/subsys/bluetooth/audio/cap_internal.h
+++ b/subsys/bluetooth/audio/cap_internal.h
@@ -19,6 +19,7 @@ bool bt_cap_acceptor_ccid_exist(const struct bt_conn *conn, uint8_t ccid);
 void bt_cap_initiator_codec_configured(struct bt_cap_stream *cap_stream);
 void bt_cap_initiator_qos_configured(struct bt_cap_stream *cap_stream);
 void bt_cap_initiator_enabled(struct bt_cap_stream *cap_stream);
+void bt_cap_initiator_almost_started(struct bt_cap_stream *cap_stream);
 void bt_cap_initiator_started(struct bt_cap_stream *cap_stream);
 void bt_cap_initiator_metadata_updated(struct bt_cap_stream *cap_stream);
 void bt_cap_initiator_released(struct bt_cap_stream *cap_stream);

--- a/subsys/bluetooth/audio/cap_stream.c
+++ b/subsys/bluetooth/audio/cap_stream.c
@@ -69,6 +69,24 @@ static void cap_stream_enabled_cb(struct bt_bap_stream *bap_stream)
 	}
 }
 
+static void cap_stream_almost_started_cb(struct bt_bap_stream *bap_stream)
+{
+	struct bt_cap_stream *cap_stream = CONTAINER_OF(bap_stream,
+							struct bt_cap_stream,
+							bap_stream);
+	struct bt_bap_stream_ops *ops = cap_stream->ops;
+
+	LOG_DBG("%p", cap_stream);
+
+	if (IS_ENABLED(CONFIG_BT_CAP_INITIATOR)) {
+		bt_cap_initiator_almost_started(cap_stream);
+	}
+
+	if (ops != NULL && ops->almost_started != NULL) {
+		ops->almost_started(bap_stream);
+	}
+}
+
 static void cap_stream_metadata_updated_cb(struct bt_bap_stream *bap_stream)
 {
 	struct bt_cap_stream *cap_stream = CONTAINER_OF(bap_stream,
@@ -191,6 +209,7 @@ static struct bt_bap_stream_ops bap_stream_ops = {
 	.disabled = cap_stream_disabled_cb,
 	.released = cap_stream_released_cb,
 #endif /* CONFIG_BT_BAP_UNICAST */
+	.almost_started = cap_stream_almost_started_cb,
 	.started = cap_stream_started_cb,
 	.stopped = cap_stream_stopped_cb,
 #if defined(CONFIG_BT_AUDIO_RX)


### PR DESCRIPTION
This is an initial fix, but I would like to discuss this to make sure this solution is allowed.

If during the Unicast Audio Start procedure, after CIS Establish and Receiver Start Ready, we could establish the remaining CISes in the meantime. I found 3 use cases where this would be helpful:
- we could save some time if the remote device does not change the ASE state to the Streaming immediately,
- we would cover the use case where the remote device expects that all CISes are established before transition an ASE to the Streaming state (the PTS case),
- a callback like the proposed `almost_started` would be helpful while using the BAP API, e.g. I could fix my problem in bt tester:

https://github.com/zephyrproject-rtos/zephyr/blob/a1042c407964cd9710f544b8ba9a61c15a7de2fb/tests/bluetooth/tester/src/btp_bap.c#L2851-L2866

**Details**
In the CAP/INI/UST/BV-29-C test case ([CAP test spec](https://www.bluetooth.org/docman/handlers/DownloadDoc.ashx?doc_id=524499)) the IUT (nrf53 with Zephyr Host + Controller) has to connect to 2 Lower Tester devices and configure their ASEs to Streaming state using the Unicast Audio Start procedure. There are 2 CISes to establish, one bi-directional and one unidirectional. After configuring all ASES to Enabling state, we continue with starting the streaming here:

https://github.com/zephyrproject-rtos/zephyr/blob/a1042c407964cd9710f544b8ba9a61c15a7de2fb/subsys/bluetooth/audio/cap_initiator.c#L856

We take the first ASE stream, we establish the first CIS, then if the remote ASE is Source, we send the Receiver Start Ready. Now we wait until we get the notification of the ASE Control Point with Streaming opcode. No more CISes will be established until then.

But in the CAP/INI/UST/BV-29-C test case there is no Streaming notification. Judging from my experience with the BAP test cases, it looks like the PTS Lower Testers needs to have all CISes to be established before transition their coupled ASEs to Streaming. Until then there will be no Streaming notification.

So I was wondering if we could establish all remaining CISes without waiting for the remote ASE Source to became ready enough to send the Streaming notification?