### PR TITLE
drivers: cellular: add ldenefle to copyright

### DIFF
--- a/include/zephyr/drivers/cellular.h
+++ b/include/zephyr/drivers/cellular.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2023 Bjarki Arge Andreasen
+ * Copyright (c) 2023 Lucas Denefle
  *
  * SPDX-License-Identifier: Apache-2.0
  */


### PR DESCRIPTION
Hello, I forgot to add myself in the cellular api copyright, this PR corrects that