### PR TITLE
linkserver: nxp: add support for frdm-k64f

### DIFF
--- a/boards/arm/frdm_k64f/board.cmake
+++ b/boards/arm/frdm_k64f/board.cmake
@@ -1,8 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(jlink "--device=MK64FN1M0xxx12")
+board_runner_args(linkserver  "--device=MK64FN1M0xxx12:FRDM-K64F")
+
 board_runner_args(pyocd "--target=k64f")
 
+include(${ZEPHYR_BASE}/boards/common/linkserver.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/arm/frdm_k64f/doc/index.rst
+++ b/boards/arm/frdm_k64f/doc/index.rst
@@ -246,11 +246,23 @@ instructions to update from the CMSIS-DAP bootloader to the DAPLink bootloader.
 
    .. group-tab:: OpenSDA DAPLink Onboard (Recommended)
 
-        Install the :ref:`pyocd-debug-host-tools` and make sure they are in your search
-        path.
+	Install the :ref:`linkserver-debug-host-tools` and make sure they are in your
+	search path.  LinkServer works with the default CMSIS-DAP firmware included in
+	the on-board debugger.
 
-        Follow the instructions in :ref:`opensda-daplink-onboard-debug-probe` to program
-        the `OpenSDA DAPLink FRDM-K64F Firmware`_.
+        Linkserver is the default for this board, ``west flash`` and ``west debug`` will
+        call the linkserver runner.
+
+	.. code-block:: console
+
+	   west flash
+
+	Alternatively, pyOCD can be used to flash and debug the board by using the
+	``-r pyocd`` option with West. pyOCD is installed when you complete the
+	:ref:`gs_python_deps` step in the Getting Started Guide. The runners supported
+	by NXP are LinkServer and JLink. pyOCD is another potential option, but NXP
+	does not test or support the pyOCD runner.
+
 
    .. group-tab:: OpenSDA JLink Onboard
 
@@ -269,7 +281,7 @@ instructions to update from the CMSIS-DAP bootloader to the DAPLink bootloader.
 
         Add the arguments ``-DBOARD_FLASH_RUNNER=jlink`` and
         ``-DBOARD_DEBUG_RUNNER=jlink`` when you invoke ``west build`` to override the
-        default runner from pyOCD to J-Link:
+        default runner to J-Link:
 
         .. zephyr-app-commands::
            :zephyr-app: samples/hello_world


### PR DESCRIPTION
 - board.cmake is augmented for LinkServer
 - the board's doc file is updated as well