### PR TITLE
Add copying bsim exe in Twister

### DIFF
--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -419,7 +419,7 @@ harness: <string>
     Twister to be able to evaluate if a test passes criteria. For example, a
     keyboard harness is set on tests that require keyboard interaction to reach
     verdict on whether a test has passed or failed, however, Twister lack this
-    harness implementation at the momemnt.
+    harness implementation at the moment.
 
     Supported harnesses:
 
@@ -445,6 +445,14 @@ harness: <string>
     - net
     - bluetooth
 
+    Harness ``bsim`` is implemented in limited way - it helps only to copy the
+    final executable (``zephyr.exe``) from build directory to BabbleSim's
+    ``bin`` directory (``${BSIM_OUT_PATH}/bin``). This action is useful to allow
+    BabbleSim's tests to directly run after. By default, the executable file
+    name is (with dots and slashes replaced by underscores):
+    ``bs_<platform_name>_<test_path>_<test_scenario_name>``.
+    This name can be overridden with the ``bsim_exe_name`` option in
+    ``harness_config`` section.
 
 platform_key: <list of platform attributes>
     Often a test needs to only be built and run once to qualify as passing.
@@ -552,6 +560,11 @@ harness_config: <harness configuration options>
 
     robot_test_path: <robot file path> (default empty)
         Specify a path to a file containing a Robot Framework test suite to be run.
+
+    bsim_exe_name: <string>
+        If provided, the executable filename when copying to BabbleSim's bin
+        directory, will be ``bs_<platform_name>_<bsim_exe_name>`` instead of the
+        default based on the test path and scenario name.
 
     The following is an example yaml file with a few harness_config options.
 

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -1052,7 +1052,17 @@ class ProjectBuilder(FilterBuilder):
         return self.run_cmake(args,filter_stages)
 
     def build(self):
-        return self.run_build(['--build', self.build_dir])
+        harness = HarnessImporter.get_harness(self.instance.testsuite.harness.capitalize())
+        build_result = self.run_build(['--build', self.build_dir])
+        try:
+            harness.instance = self.instance
+            harness.build()
+        except ConfigurationError as error:
+            self.instance.status = "error"
+            self.instance.reason = str(error)
+            logger.error(self.instance.reason)
+            return
+        return build_result
 
     def run(self):
 

--- a/scripts/schemas/twister/testsuite-schema.yaml
+++ b/scripts/schemas/twister/testsuite-schema.yaml
@@ -123,6 +123,9 @@ mapping:
               "regex":
                 type: str
                 required: true
+          "bsim_exe_name":
+            type: str
+            required: false
       "min_ram":
         type: int
         required: false
@@ -327,6 +330,9 @@ mapping:
                   "regex":
                     type: str
                     required: true
+              "bsim_exe_name":
+                type: str
+                required: false
           "min_ram":
             type: int
             required: false

--- a/scripts/tests/twister/test_runner.py
+++ b/scripts/tests/twister/test_runner.py
@@ -2071,6 +2071,7 @@ def test_projectbuilder_cmake():
 
 def test_projectbuilder_build(mocked_jobserver):
     instance_mock = mock.Mock()
+    instance_mock.testsuite.harness = 'test'
     env_mock = mock.Mock()
 
     pb = ProjectBuilder(instance_mock, env_mock, mocked_jobserver)

--- a/tests/bsim/bluetooth/ll/bis/testcase.yaml
+++ b/tests/bsim/bluetooth/ll/bis/testcase.yaml
@@ -1,0 +1,42 @@
+common:
+  build_only: true
+  tags:
+    - bluetooth
+    - bsim_multi
+
+tests:
+  bluetooth.ll.bis:
+    sysbuild: true
+    platform_allow:
+      - nrf52_bsim
+      - nrf5340bsim_nrf5340_cpuapp
+      - nrf5340bsim_nrf5340_cpunet
+    integration_platforms:
+      - nrf52_bsim
+      - nrf5340bsim_nrf5340_cpuapp
+      - nrf5340bsim_nrf5340_cpunet
+    harness: bsim
+    harness_config:
+      bsim_exe_name: tests_bsim_bluetooth_ll_bis_prj_conf
+  bluetooth.ll.bis_ticker_expire_info:
+    extra_args: OVERLAY_CONFIG=overlay-ticker_expire_info.conf
+    platform_allow:
+      - nrf52_bsim
+      - nrf5340bsim_nrf5340_cpunet
+    integration_platforms:
+      - nrf52_bsim
+      - nrf5340bsim_nrf5340_cpunet
+    harness: bsim
+    harness_config:
+      bsim_exe_name: tests_bsim_bluetooth_ll_bis_prj_conf_overlay-ticker_expire_info_conf
+  bluetooth.ll.bis_vs_dp:
+    extra_args: CONF_FILE=prj_vs_dp.conf
+    platform_allow:
+      - nrf52_bsim
+      - nrf5340bsim_nrf5340_cpunet
+    integration_platforms:
+      - nrf52_bsim
+      - nrf5340bsim_nrf5340_cpunet
+    harness: bsim
+    harness_config:
+      bsim_exe_name: tests_bsim_bluetooth_ll_bis_prj_vs_dp_conf


### PR DESCRIPTION
With this PR I would like to start bigger action connected with moving building of BabbleSim tests from bash scripts to the Twister. To make it possible it is necessary to add in Twister possibility of copying executable files from Twister build directory to BabbleSim bin directory (`${BSIM_OUT_PATH}/bin`). This requirement is connected with a way how BabbleSim tests works and with expectation that all necessary executables (simulated device applications and physical layer) are stored in one place. 

I propose to add two new options to Twister .yaml file: `bsim_copy_exe` and `bsim_exe_name`. First of them can store bool value and indicates, that Twister should perform copying action or not (by default not). Second one is optional and stores information about what should be a name of copied executable in BabbleSim bin directory. When user does not provide `bsim_exe_name`, then the name of copied file is determined basing on test instance unique name.

To show how those changes can be used in practice I added one `testcase.yaml` file for `tests/bsim/bluetooth/ll/bis` test. Adding `testcase.yaml` files to the rest of bsim tests is quite demanding, and it can be realized when necessary changes in Twister will be accepted at first. So, when this PR will be merged, then next PR with adding rest of `testcase.yaml` will be opened.

To test:
```
# export ZEPHYR_BASE and BSIM_OUT_PATH variables

./scripts/twister -vv --inline-logs --integration -T tests/bsim/bluetooth/ll/bis

export WORK_DIR=${ZEPHYR_BASE}/bsim_out
mkdir -p ${WORK_DIR}
export SEARCH_PATH="tests/bsim/bluetooth/ll/bis"
export RESULTS_FILE=${WORK_DIR}/results_nrf52_bsim.xml
BOARD=nrf52_bsim ./tests/bsim/run_parallel.sh
export SEARCH_PATH="tests/bsim/bluetooth/ll/bis"
export RESULTS_FILE=${WORK_DIR}/results_nrf5340bsim_nrf5340_cpunet.xml
BOARD=nrf5340bsim_nrf5340_cpunet ./tests/bsim/run_parallel.sh
export TESTS_LIST="tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso.sh"
export RESULTS_FILE=${WORK_DIR}/results_nrf5340bsim_nrf5340_cpuapp.xml
BOARD=nrf5340bsim_nrf5340_cpuapp ./tests/bsim/run_parallel.sh
export TESTS_LIST=""
```