### PR TITLE
soc/xtensa/intel_adsp: fix interrupts typo

### DIFF
--- a/dts/xtensa/intel/intel_adsp_cavs18.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs18.dtsi
@@ -140,7 +140,7 @@
 			reg = <0x78820 0x10>;
 			interrupt-controller;
 			#interrupt-cells = <3>;
-			interrupts = <0XD 0 0>;
+			interrupts = <0xD 0 0>;
 			interrupt-parent = <&core_intc>;
 		};
 


### PR DESCRIPTION
Hex should be `0x` instead of `0X`