### PR TITLE
twister: second fix for hardware map detection

### DIFF
--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -287,7 +287,7 @@ class HardwareMap:
         serial_devices = list_ports.comports()
         logger.info("Scanning connected hardware...")
         for d in serial_devices:
-            if d.manufacturer.casefold() in [m.casefold() for m in self.manufacturer]:
+            if d.manufacturer and d.manufacturer.casefold() in [m.casefold() for m in self.manufacturer]:
 
                 # TI XDS110 can have multiple serial devices for a single board
                 # assume endpoint 0 is the serial, skip all others


### PR DESCRIPTION
When scanning ports the manufacture field is not always filled. It must be checked before using.

After merging #66491 received error when trying to generate a new hardware map:
```
File "/home/grch/zephyrproject/zephyr/scripts/pylib/twister/twisterlib/hardwaremap.py", line 290, in scan
    if d.manufacturer.casefold() in [m.casefold() for m in self.manufacturer]:
AttributeError: 'NoneType' object has no attribute 'casefold'
```
