### PR TITLE
boards: arm: enable CONFIG_USB_DC_HAS_HS_SUPPORT

### DIFF
--- a/boards/arm/nucleo_h723zg/Kconfig.defconfig
+++ b/boards/arm/nucleo_h723zg/Kconfig.defconfig
@@ -15,4 +15,8 @@ config NET_L2_ETHERNET
 
 endif # NETWORKING
 
+config USB_DC_HAS_HS_SUPPORT
+	default y
+	depends on USB_DC_STM32
+
 endif # BOARD_NUCLEO_H723ZG

--- a/boards/arm/nucleo_h7a3zi_q/Kconfig.defconfig
+++ b/boards/arm/nucleo_h7a3zi_q/Kconfig.defconfig
@@ -8,4 +8,8 @@ if BOARD_NUCLEO_H7A3ZI_Q
 config BOARD
 	default "nucleo_h7a3zi_q"
 
+config USB_DC_HAS_HS_SUPPORT
+	default y
+	depends on USB_DC_STM32
+
 endif # BOARD_NUCLEO_H7A3ZI_Q


### PR DESCRIPTION
enable CONFIG_USB_DC_HAS_HS_SUPPORT when we use OTG_HS in that case TEST_BULK_EP_MPS	(Endpoint max packet size) equal 512 and not 64
it is the case for nucleo_h723zg and for nucleo_h7a3zi_q