### PR TITLE
driver: ble: esp32: implement deinit function

### DIFF
--- a/drivers/bluetooth/hci/hci_esp32.c
+++ b/drivers/bluetooth/hci/hci_esp32.c
@@ -303,6 +303,25 @@ static int bt_esp32_ble_init(void)
 	return 0;
 }
 
+static int bt_esp32_ble_deinit(void)
+{
+	int ret;
+
+	ret = esp_bt_controller_disable();
+	if (ret) {
+		LOG_ERR("Bluetooth controller disable failed %d", ret);
+		return ret;
+	}
+
+	ret = esp_bt_controller_deinit();
+	if (ret) {
+		LOG_ERR("Bluetooth controller deinit failed %d", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
 static int bt_esp32_open(void)
 {
 	int err;
@@ -317,10 +336,25 @@ static int bt_esp32_open(void)
 	return 0;
 }
 
+static int bt_esp32_close(void)
+{
+	int err;
+
+	err = bt_esp32_ble_deinit();
+	if (err) {
+		return err;
+	}
+
+	LOG_DBG("ESP32 BT stopped");
+
+	return 0;
+}
+
 static const struct bt_hci_driver drv = {
 	.name           = "BT ESP32",
 	.open           = bt_esp32_open,
 	.send           = bt_esp32_send,
+	.close          = bt_esp32_close,
 	.bus            = BT_HCI_DRIVER_BUS_IPM,
 #if defined(CONFIG_BT_DRIVER_QUIRK_NO_AUTO_DLE)
 	.quirks         = BT_QUIRK_NO_AUTO_DLE,
@@ -329,7 +363,6 @@ static const struct bt_hci_driver drv = {
 
 static int bt_esp32_init(void)
 {
-
 	bt_hci_driver_register(&drv);
 
 	return 0;

--- a/west.yml
+++ b/west.yml
@@ -152,7 +152,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: 754be4745295a45c26d42c916a8600cdcefddd4e
+      revision: e98ce93e916eebdc4a0c5bceef864289447e3d63
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
Current ESP32 BLE interface does not allow disabling BLE. This PR adds proper deinit call.