### PR TITLE
tests: net: sockets: Extend TLS test suite (part 2)

### DIFF
--- a/include/zephyr/net/socket.h
+++ b/include/zephyr/net/socket.h
@@ -232,6 +232,14 @@ struct zsock_pollfd {
  *  connection ID, otherwise will contain the length of the CID value.
  */
 #define TLS_DTLS_PEER_CID_VALUE 17
+/** Socket option to configure DTLS socket behavior on connect().
+ *  If set, DTLS connect() will execute the handshake with the configured peer.
+ *  This is the default behavior.
+ *  Otherwise, DTLS connect() will only configure peer address (as with regular
+ *  UDP socket) and will not attempt to execute DTLS handshake. The handshake
+ *  will take place in consecutive send()/recv() call.
+ */
+#define TLS_DTLS_HANDSHAKE_ON_CONNECT 18
 
 /* Valid values for @ref TLS_PEER_VERIFY option */
 #define TLS_PEER_VERIFY_NONE 0     /**< Peer verification disabled. */

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -3352,6 +3352,21 @@ out:
 	return 0;
 }
 
+#if defined(CONFIG_NET_TEST)
+mbedtls_ssl_context *ztls_get_mbedtls_ssl_context(int fd)
+{
+	struct tls_context *ctx;
+
+	ctx = z_get_fd_obj(fd, (const struct fd_op_vtable *)
+					&tls_sock_fd_op_vtable, EBADF);
+	if (ctx == NULL) {
+		return NULL;
+	}
+
+	return &ctx->ssl;
+}
+#endif /* CONFIG_NET_TEST */
+
 static ssize_t tls_sock_read_vmeth(void *obj, void *buffer, size_t count)
 {
 	return ztls_recvfrom_ctx(obj, buffer, count, 0, NULL, 0);

--- a/tests/net/socket/tls/CMakeLists.txt
+++ b/tests/net/socket/tls/CMakeLists.txt
@@ -5,5 +5,6 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(socket_tls)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)
+target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/lib/sockets)
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})


### PR DESCRIPTION
Second batch of TLS/DTLS sockets tests, covering `poll()` functionality. This time new tests revealed some issues related to poll() processing with TLS/DTLS sockets, so the tests are accompanied with several fixes/improvements. For details, please see commit descriptions.

Resolves #47341