### PR TITLE
net: lwm2m: Deprecate lwm2m_get/set_u64

### DIFF
--- a/include/zephyr/net/lwm2m.h
+++ b/include/zephyr/net/lwm2m.h
@@ -1009,11 +1009,16 @@ int lwm2m_engine_set_u64(const char *pathstr, uint64_t value);
 /**
  * @brief Set resource (instance) value (u64)
  *
+ * @deprecated Unsigned 64bit value type does not exits.
+ *             This is internally handled as a int64_t.
+ *             Use lwm2m_set_s64() instead.
+ *
  * @param[in] path LwM2M path as a struct
  * @param[in] value u64 value
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_set_u64(const struct lwm2m_obj_path *path, uint64_t value);
 
 /**
@@ -1335,11 +1340,16 @@ int lwm2m_engine_get_u64(const char *pathstr, uint64_t *value);
 /**
  * @brief Get resource (instance) value (u64)
  *
+ * @deprecated Unsigned 64bit value type does not exits.
+ *             This is internally handled as a int64_t.
+ *             Use lwm2m_get_s64() instead.
+
  * @param[in] path LwM2M path as a struct
  * @param[out] value u64 buffer to copy data into
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_get_u64(const struct lwm2m_obj_path *path, uint64_t *value);
 
 /**

--- a/subsys/net/lib/lwm2m/lwm2m_registry.c
+++ b/subsys/net/lib/lwm2m/lwm2m_registry.c
@@ -890,7 +890,7 @@ int lwm2m_engine_set_u64(const char *pathstr, uint64_t value)
 	if (ret < 0) {
 		return ret;
 	}
-	return lwm2m_set_u64(&path, value);
+	return lwm2m_set_s64(&path, (int64_t) value);
 }
 
 int lwm2m_set_s8(const struct lwm2m_obj_path *path, int8_t value)
@@ -1378,7 +1378,7 @@ int lwm2m_engine_get_u64(const char *pathstr, uint64_t *value)
 	if (ret < 0) {
 		return ret;
 	}
-	return lwm2m_get_u64(&path, value);
+	return lwm2m_get_s64(&path, (int64_t *) value);
 }
 
 int lwm2m_get_s8(const struct lwm2m_obj_path *path, int8_t *value)

--- a/subsys/net/lib/lwm2m/lwm2m_shell.c
+++ b/subsys/net/lib/lwm2m/lwm2m_shell.c
@@ -246,14 +246,6 @@ static int cmd_read(const struct shell *sh, size_t argc, char **argv)
 			goto out;
 		}
 		shell_print(sh, "%d\n", temp);
-	} else if (strcmp(dtype, "-u64") == 0) {
-		uint64_t temp = 0;
-
-		ret = lwm2m_get_u64(&path, &temp);
-		if (ret != 0) {
-			goto out;
-		}
-		shell_print(sh, "%lld\n", temp);
 	} else if (strcmp(dtype, "-f") == 0) {
 		double temp = 0;
 
@@ -349,8 +341,6 @@ static int cmd_write(const struct shell *sh, size_t argc, char **argv)
 			ret = lwm2m_set_u16(&path, strtoul(value, &e, 10));
 		} else if (strcmp(dtype, "-u32") == 0) {
 			ret = lwm2m_set_u32(&path, strtoul(value, &e, 10));
-		} else if (strcmp(dtype, "-u64") == 0) {
-			ret = lwm2m_set_u64(&path, strtoull(value, &e, 10));
 		} else if (strcmp(dtype, "-b") == 0) {
 			ret = lwm2m_set_bool(&path, strtoul(value, &e, 10));
 		} else if (strcmp(dtype, "-t") == 0) {

--- a/tests/net/lib/lwm2m/lwm2m_registry/src/lwm2m_registry.c
+++ b/tests/net/lib/lwm2m/lwm2m_registry/src/lwm2m_registry.c
@@ -203,16 +203,6 @@ ZTEST(lwm2m_registry, test_get_set)
 	zassert_equal(strlen(buf), 0);
 }
 
-ZTEST(lwm2m_registry, test_missing_u64)
-{
-	/* This data type is missing, so use S64 resource instead */
-	uint64_t u64 = 123;
-
-	zassert_equal(lwm2m_set_u64(&LWM2M_OBJ(32768, 0, LWM2M_RES_TYPE_S64), u64), 0);
-	zassert_equal(lwm2m_get_u64(&LWM2M_OBJ(32768, 0, LWM2M_RES_TYPE_S64), &u64), 0);
-	zassert_equal(u64, 123);
-}
-
 ZTEST(lwm2m_registry, test_temp_sensor)
 {
 	int ret;


### PR DESCRIPTION
Deprecate lwm2m_set_u64() and lwm2m_get_u64 as only LWM2M_RES_TYPE_S64 exist. Unsigned variant is not defined.

Technically these might have worked OK, but it is undefined what happens to large unsigned values when those are converted to various payload formats (like CBOR) that might decode numbers differently depending of their signedness.