### PR TITLE
Add devicetree macros to get node's interrupt controller

### DIFF
--- a/doc/build/dts/macros.bnf
+++ b/doc/build/dts/macros.bnf
@@ -40,8 +40,10 @@ node-macro =/ %s"DT_N" path-id %s"_IRQ_NUM"
 node-macro =/ %s"DT_N" path-id %s"_IRQ_IDX_" DIGIT "_EXISTS"
 node-macro =/ %s"DT_N" path-id %s"_IRQ_IDX_" DIGIT
               %s"_VAL_" dt-name [ %s"_EXISTS" ]
+node-macro =/ %s"DT_N" path-id %s"_CONTROLLER"
 node-macro =/ %s"DT_N" path-id %s"_IRQ_NAME_" dt-name
               %s"_VAL_" dt-name [ %s"_EXISTS" ]
+node-macro =/ %s"DT_N" path-id %s"_IRQ_NAME_" dt-name "_CONTROLLER"
 ; The ranges property is also special.
 node-macro =/ %s"DT_N" path-id %s"_RANGES_NUM"
 node-macro =/ %s"DT_N" path-id %s"_RANGES_IDX_" DIGIT "_EXISTS"

--- a/dts/bindings/test/vnd,gpio-intc-device.yaml
+++ b/dts/bindings/test/vnd,gpio-intc-device.yaml
@@ -1,0 +1,29 @@
+# Copyright (c) 2023 Bjarki Arge Andreasen
+# SPDX-License-Identifier: Apache-2.0
+
+description: Test GPIO with INTC node
+
+compatible: "vnd,gpio-intc-device"
+
+include:
+  - gpio-controller.yaml
+  - interrupt-controller.yaml
+  - base.yaml
+
+properties:
+  reg:
+    required: true
+
+  "#gpio-cells":
+    const: 2
+
+  "#interrupt-cells":
+    const: 2
+
+gpio-cells:
+  - pin
+  - flags
+
+interrupt-cells:
+  - pin
+  - flags

--- a/dts/bindings/test/vnd,interrupt-holder-extended.yaml
+++ b/dts/bindings/test/vnd,interrupt-holder-extended.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2023 Bjarki Arge Andreasen
+# SPDX-License-Identifier: Apache-2.0
+
+description: Test Interrupt Controller with extended interrupts
+
+compatible: "vnd,interrupt-holder-extended"
+
+include: [base.yaml]
+
+properties:
+  interrupts-extended:
+    required: true
+
+  interrupt-names:
+    required: true

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -2400,6 +2400,140 @@
 #define DT_IRQ(node_id, cell) DT_IRQ_BY_IDX(node_id, 0, cell)
 
 /**
+ * @brief Get an interrupt specifier's interrupt controller by index
+ *
+ * @code{.dts}
+ *     gpio0: gpio0 {
+ *             interrupt-controller;
+ *             #interrupt-cells = <2>;
+ *     };
+ *
+ *     foo: foo {
+ *             interrupt-parent = <&gpio0>;
+ *             interrupts = <1 1>, <2 2>;
+ *     };
+ *
+ *     bar: bar {
+ *             interrupts-extended = <&gpio0 3 3>, <&pic0 4>;
+ *     };
+ *
+ *     pic0: pic0 {
+ *             interrupt-controller;
+ *             #interrupt-cells = <1>;
+ *
+ *             qux: qux {
+ *                     interrupts = <5>, <6>;
+ *                     interrupt-names = "int1", "int2";
+ *             };
+ *     };
+ * @endcode
+ *
+ * Example usage:
+ *
+ *     DT_IRQ_INTC_BY_IDX(DT_NODELABEL(foo), 0) // &gpio0
+ *     DT_IRQ_INTC_BY_IDX(DT_NODELABEL(foo), 1) // &gpio0
+ *     DT_IRQ_INTC_BY_IDX(DT_NODELABEL(bar), 0) // &gpio0
+ *     DT_IRQ_INTC_BY_IDX(DT_NODELABEL(bar), 1) // &pic0
+ *     DT_IRQ_INTC_BY_IDX(DT_NODELABEL(qux), 0) // &pic0
+ *     DT_IRQ_INTC_BY_IDX(DT_NODELABEL(qux), 1) // &pic0
+ *
+ * @param node_id node identifier
+ * @param idx interrupt specifier's index
+ * @return node_id of interrupt specifier's interrupt controller
+ */
+#define DT_IRQ_INTC_BY_IDX(node_id, idx) \
+	DT_CAT4(node_id, _IRQ_IDX_, idx, _CONTROLLER)
+
+/**
+ * @brief Get an interrupt specifier's interrupt controller by name
+ *
+ * @code{.dts}
+ *     gpio0: gpio0 {
+ *             interrupt-controller;
+ *             #interrupt-cells = <2>;
+ *     };
+ *
+ *     foo: foo {
+ *             interrupt-parent = <&gpio0>;
+ *             interrupts = <1 1>, <2 2>;
+ *             interrupt-names = "int1", "int2";
+ *     };
+ *
+ *     bar: bar {
+ *             interrupts-extended = <&gpio0 3 3>, <&pic0 4>;
+ *             interrupt-names = "int1", "int2";
+ *     };
+ *
+ *     pic0: pic0 {
+ *             interrupt-controller;
+ *             #interrupt-cells = <1>;
+ *
+ *             qux: qux {
+ *                     interrupts = <5>, <6>;
+ *                     interrupt-names = "int1", "int2";
+ *             };
+ *     };
+ * @endcode
+ *
+ * Example usage:
+ *
+ *     DT_IRQ_INTC_BY_NAME(DT_NODELABEL(foo), int1) // &gpio0
+ *     DT_IRQ_INTC_BY_NAME(DT_NODELABEL(foo), int2) // &gpio0
+ *     DT_IRQ_INTC_BY_NAME(DT_NODELABEL(bar), int1) // &gpio0
+ *     DT_IRQ_INTC_BY_NAME(DT_NODELABEL(bar), int2) // &pic0
+ *     DT_IRQ_INTC_BY_NAME(DT_NODELABEL(qux), int1) // &pic0
+ *     DT_IRQ_INTC_BY_NAME(DT_NODELABEL(qux), int2) // &pic0
+ *
+ * @param node_id node identifier
+ * @param name interrupt specifier's name
+ * @return node_id of interrupt specifier's interrupt controller
+ */
+#define DT_IRQ_INTC_BY_NAME(node_id, name) \
+	DT_CAT4(node_id, _IRQ_NAME_, name, _CONTROLLER)
+
+/**
+ * @brief Get an interrupt specifier's interrupt controller
+ * @note Equivalent to DT_IRQ_INTC_BY_IDX(node_id, 0)
+ *
+ * @code{.dts}
+ *     gpio0: gpio0 {
+ *             interrupt-controller;
+ *             #interrupt-cells = <2>;
+ *     };
+ *
+ *     foo: foo {
+ *             interrupt-parent = <&gpio0>;
+ *             interrupts = <1 1>;
+ *     };
+ *
+ *     bar: bar {
+ *             interrupts-extended = <&gpio0 3 3>;
+ *     };
+ *
+ *     pic0: pic0 {
+ *             interrupt-controller;
+ *             #interrupt-cells = <1>;
+ *
+ *             qux: qux {
+ *                     interrupts = <5>;
+ *             };
+ *     };
+ * @endcode
+ *
+ * Example usage:
+ *
+ *     DT_IRQ_INTC(DT_NODELABEL(foo)) // &gpio0
+ *     DT_IRQ_INTC(DT_NODELABEL(bar)) // &gpio0
+ *     DT_IRQ_INTC(DT_NODELABEL(qux)) // &pic0
+ *
+ * @param node_id node identifier
+ * @return node_id of interrupt specifier's interrupt controller
+ * @see DT_IRQ_INTC_BY_IDX()
+ */
+#define DT_IRQ_INTC(node_id) \
+	DT_IRQ_INTC_BY_IDX(node_id, 0)
+
+/**
  * @cond INTERNAL_HIDDEN
  */
 
@@ -3844,6 +3978,34 @@
  */
 #define DT_INST_IRQ_BY_IDX(inst, idx, cell) \
 	DT_IRQ_BY_IDX(DT_DRV_INST(inst), idx, cell)
+
+/**
+ * @brief Get a `DT_DRV_COMPAT` interrupt specifier's interrupt controller by index
+ * @param inst instance number
+ * @param idx interrupt specifier's index
+ * @return node_id of interrupt specifier's interrupt controller
+ */
+#define DT_INST_IRQ_INTC_BY_IDX(inst, idx) \
+	DT_IRQ_INTC_BY_IDX(DT_DRV_INST(inst), idx)
+
+/**
+ * @brief Get a `DT_DRV_COMPAT` interrupt specifier's interrupt controller by name
+ * @param inst instance number
+ * @param name interrupt specifier's name
+ * @return node_id of interrupt specifier's interrupt controller
+ */
+#define DT_INST_IRQ_INTC_BY_NAME(inst, name) \
+	DT_IRQ_INTC_BY_NAME(DT_DRV_INST(inst), name)
+
+/**
+ * @brief Get a `DT_DRV_COMPAT` interrupt specifier's interrupt controller
+ * @note Equivalent to DT_INST_IRQ_INTC_BY_IDX(node_id, 0)
+ * @param inst instance number
+ * @return node_id of interrupt specifier's interrupt controller
+ * @see DT_INST_IRQ_INTC_BY_IDX()
+ */
+#define DT_INST_IRQ_INTC(inst) \
+	DT_INST_IRQ_INTC_BY_IDX(inst, 0)
 
 /**
  * @brief Get a `DT_DRV_COMPAT` interrupt specifier value by name

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -477,6 +477,13 @@ def write_interrupts(node):
                 name_vals.append((name_macro, f"DT_{idx_macro}"))
                 name_vals.append((name_macro + "_EXISTS", 1))
 
+        idx_controller_macro = f"{path_id}_IRQ_IDX_{i}_CONTROLLER"
+        idx_controller_path = f"DT_{irq.controller.z_path_id}"
+        idx_vals.append((idx_controller_macro, idx_controller_path))
+        if irq.name:
+            name_controller_macro = f"{path_id}_IRQ_NAME_{str2ident(irq.name)}_CONTROLLER"
+            name_vals.append((name_controller_macro, f"DT_{idx_controller_macro}"))
+
     for macro, val in idx_vals:
         out_dt_define(macro, val)
     for macro, val in name_vals:

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -203,6 +203,16 @@
 			status = "okay";
 		};
 
+		test_gpio_4: gpio@1234abcd {
+			compatible = "vnd,gpio-intc-device";
+			reg = <0x1234abcd 0x500>;
+			gpio-controller;
+			#gpio-cells = <0x2>;
+			interrupt-controller;
+			#interrupt-cells = <0x2>;
+			status = "okay";
+		};
+
 		test_i2c: i2c@11112222 {
 			#address-cells = < 1 >;
 			#size-cells = < 0 >;
@@ -429,6 +439,15 @@
 			interrupts = <30 3 40 5 60 7>;
 			interrupt-parent = <&test_intc>;
 			interrupt-names = "err", "stat", "done";
+		};
+
+		/* there should only be one of these */
+		test_irq_extended: interrupt-holder-extended {
+			compatible = "vnd,interrupt-holder-extended";
+			status = "okay";
+			interrupts-extended = <&test_intc 70 7>,
+					      <&test_gpio_4 30 3>;
+			interrupt-names = "int1", "int2";
 		};
 
 		test_fixed_clk: test-fixed-clock {

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -21,12 +21,14 @@
 #define TEST_ARRAYS	DT_NODELABEL(test_arrays)
 #define TEST_PH	DT_NODELABEL(test_phandles)
 #define TEST_IRQ	DT_NODELABEL(test_irq)
+#define TEST_IRQ_EXT	DT_NODELABEL(test_irq_extended)
 #define TEST_TEMP	DT_NODELABEL(test_temp_sensor)
 #define TEST_REG	DT_NODELABEL(test_reg)
 #define TEST_VENDOR	DT_NODELABEL(test_vendor)
 #define TEST_MODEL	DT_NODELABEL(test_vendor)
 #define TEST_ENUM_0	DT_NODELABEL(test_enum_0)
 #define TEST_64BIT	DT_NODELABEL(test_reg_64)
+#define TEST_INTC	DT_NODELABEL(test_intc)
 
 #define TEST_I2C DT_NODELABEL(test_i2c)
 #define TEST_I2C_DEV DT_PATH(test, i2c_11112222, test_i2c_dev_10)
@@ -44,6 +46,7 @@
 
 #define TEST_GPIO_1 DT_NODELABEL(test_gpio_1)
 #define TEST_GPIO_2 DT_NODELABEL(test_gpio_2)
+#define TEST_GPIO_4 DT_NODELABEL(test_gpio_4)
 
 #define TEST_GPIO_HOG_1 DT_PATH(test, gpio_deadbeef, test_gpio_hog_1)
 #define TEST_GPIO_HOG_2 DT_PATH(test, gpio_deadbeef, test_gpio_hog_2)
@@ -3147,6 +3150,33 @@ ZTEST(devicetree_api, test_reset)
 
 	/* DT_INST_RESET_ID */
 	zassert_equal(DT_INST_RESET_ID(0), 10, "");
+}
+
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT vnd_interrupt_holder_extended
+ZTEST(devicetree_api, test_interrupt_controller)
+{
+	/* DT_IRQ_INTC_BY_IDX */
+	zassert_true(DT_SAME_NODE(DT_IRQ_INTC_BY_IDX(TEST_IRQ_EXT, 0), TEST_INTC), "");
+	zassert_true(DT_SAME_NODE(DT_IRQ_INTC_BY_IDX(TEST_IRQ_EXT, 1), TEST_GPIO_4), "");
+
+	/* DT_IRQ_INTC_BY_NAME */
+	zassert_true(DT_SAME_NODE(DT_IRQ_INTC_BY_NAME(TEST_IRQ_EXT, int1), TEST_INTC), "");
+	zassert_true(DT_SAME_NODE(DT_IRQ_INTC_BY_NAME(TEST_IRQ_EXT, int2), TEST_GPIO_4), "");
+
+	/* DT_IRQ_INTC */
+	zassert_true(DT_SAME_NODE(DT_IRQ_INTC(TEST_IRQ_EXT), TEST_INTC), "");
+
+	/* DT_INST_IRQ_INTC_BY_IDX */
+	zassert_true(DT_SAME_NODE(DT_INST_IRQ_INTC_BY_IDX(0, 0), TEST_INTC), "");
+	zassert_true(DT_SAME_NODE(DT_INST_IRQ_INTC_BY_IDX(0, 1), TEST_GPIO_4), "");
+
+	/* DT_INST_IRQ_INTC_BY_NAME */
+	zassert_true(DT_SAME_NODE(DT_INST_IRQ_INTC_BY_NAME(0, int1), TEST_INTC), "");
+	zassert_true(DT_SAME_NODE(DT_INST_IRQ_INTC_BY_NAME(0, int2), TEST_GPIO_4), "");
+
+	/* DT_INST_IRQ_INTC */
+	zassert_true(DT_SAME_NODE(DT_INST_IRQ_INTC(0), TEST_INTC), "");
 }
 
 ZTEST_SUITE(devicetree_api, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
This PR updates `gen_defines.py` to generate defines for nodes interrupt controllers, then updates `devicetree.h` with macros (`DT_INTC*`) which get the interrupt controller node.

The PR also adds tests for the new macros, and updates the dts documentation to include the new generated defines.

fixes: #66682