### PR TITLE
lib: os: cbprintf: Fix size miscalculation in cbprintf_convert

### DIFF
--- a/lib/os/cbprintf_packaged.c
+++ b/lib/os/cbprintf_packaged.c
@@ -982,9 +982,7 @@ int cbprintf_package_convert(void *in_packaged,
 				str_pos++;
 			}
 		} else {
-			if (ros_nbr && flags & CBPRINTF_PACKAGE_CONVERT_KEEP_RO_STR) {
-				str_pos += ros_nbr;
-			}
+			str_pos += ros_nbr;
 		}
 
 		bool drop_ro_str_pos = !(flags &

--- a/tests/lib/cbprintf_package/src/main.c
+++ b/tests/lib/cbprintf_package/src/main.c
@@ -893,6 +893,48 @@ ZTEST(cbprintf_package, test_cbprintf_package_convert)
 
 }
 
+ZTEST(cbprintf_package, test_cbprintf_package_convert_static)
+{
+	int slen, clen, olen;
+	static const char test_str[] = "test %s";
+	char test_str1[] = "test str1";
+	/* Store indexes of rw strings. */
+	uint32_t flags = CBPRINTF_PACKAGE_ADD_RW_STR_POS |
+			 CBPRINTF_PACKAGE_FIRST_RO_STR_CNT(0) |
+			 CBPRINTF_PACKAGE_ADD_STRING_IDXS;
+	struct test_cbprintf_covert_ctx ctx;
+
+#define TEST_FMT test_str, test_str1
+	char exp_str[256];
+
+	snprintfcb(exp_str, sizeof(exp_str), TEST_FMT);
+
+	CBPRINTF_STATIC_PACKAGE(NULL, 0, slen, CBPRINTF_PACKAGE_ALIGNMENT, flags, TEST_FMT);
+	zassert_true(slen > 0);
+
+	uint8_t __aligned(CBPRINTF_PACKAGE_ALIGNMENT) spackage[slen];
+
+	memset(&ctx, 0, sizeof(ctx));
+	memset(spackage, 0, slen);
+
+	CBPRINTF_STATIC_PACKAGE(spackage, slen, olen, CBPRINTF_PACKAGE_ALIGNMENT, flags, TEST_FMT);
+	zassert_equal(olen, slen);
+
+	uint32_t copy_flags = CBPRINTF_PACKAGE_CONVERT_RW_STR;
+
+	clen = cbprintf_package_convert(spackage, slen, NULL, 0, copy_flags, NULL, 0);
+	zassert_true(clen == slen + sizeof(test_str1) + 1/*null*/ - 2 /* arg+ro idx gone*/);
+
+	clen = cbprintf_package_convert(spackage, slen, convert_cb, &ctx, copy_flags, NULL, 0);
+	zassert_true(clen > 0);
+	zassert_true(ctx.null);
+	zassert_equal((int)ctx.offset, clen);
+
+	check_package(ctx.buf, ctx.offset, exp_str);
+#undef TEST_FMT
+
+}
+
 /**
  * @brief Log information about variable sizes and alignment.
  *


### PR DESCRIPTION
 When package contained RO string positions and flag indicates that they shall not be kept, length was miscalculated which could lead to failures (e.g. memory corruption).
