### PR TITLE
twister: coverage: Use GCOVR as default reporting tool

### DIFF
--- a/doc/develop/test/coverage.rst
+++ b/doc/develop/test/coverage.rst
@@ -142,7 +142,11 @@ or::
 
     $ twister --coverage -p native_sim -T tests/bluetooth
 
-which will produce ``twister-out/coverage/index.html`` with the report.
+which will produce ``twister-out/coverage/index.html`` report as well as
+the coverage data collected by ``gcovr`` tool in ``twister-out/coverage.json``.
+
+Other reports might be chosen with ``--coverage-tool`` and ``--coverage-formats``
+command line options.
 
 The process differs for unit tests, which are built with the host
 toolchain and require a different board::

--- a/scripts/pylib/twister/twisterlib/coverage.py
+++ b/scripts/pylib/twister/twisterlib/coverage.py
@@ -14,6 +14,12 @@ import re
 logger = logging.getLogger('twister')
 logger.setLevel(logging.DEBUG)
 
+supported_coverage_formats = {
+    "gcovr": ["html", "xml", "csv", "txt", "coveralls", "sonarqube"],
+    "lcov":  ["html", "lcov"]
+}
+
+
 class CoverageTool:
     """ Base class for every supported coverage tool
     """

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -305,7 +305,7 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
                              "This option may be used multiple times. "
                              "Default to what was selected with --platform.")
 
-    parser.add_argument("--coverage-tool", choices=['lcov', 'gcovr'], default='lcov',
+    parser.add_argument("--coverage-tool", choices=['lcov', 'gcovr'], default='gcovr',
                         help="Tool to use to generate coverage report.")
 
     parser.add_argument("--coverage-formats", action="store", default=None, # default behavior is set in run_coverage


### PR DESCRIPTION
Use GCOVR by default as the more reliable code coverage reporting tool instead of LCOV.
see https://github.com/zephyrproject-rtos/zephyr/pull/66654#issuecomment-1864455941

Additional checks for Twister command line options `--coverage-tool` and `--coverage-formats`.