### PR TITLE
Bluetooth: MICP: Add mic_ctlr_get_by_conn

### DIFF
--- a/include/zephyr/bluetooth/audio/micp.h
+++ b/include/zephyr/bluetooth/audio/micp.h
@@ -218,6 +218,20 @@ int bt_micp_mic_ctlr_conn_get(const struct bt_micp_mic_ctlr *mic_ctlr,
 			      struct bt_conn **conn);
 
 /**
+ * @brief Get the volume controller from a connection pointer
+ *
+ * Get the Volume Control Profile Volume Controller pointer from a connection pointer.
+ * Only volume controllers that have been initiated via bt_micp_mic_ctlr_discover() can be
+ * retrieved.
+ *
+ * @param conn     Connection pointer.
+ *
+ * @retval Pointer to a Microphone Control Profile Microphone Controller instance
+ * @retval NULL if @p conn is NULL or if the connection has not done discovery yet
+ */
+struct bt_micp_mic_ctlr *bt_micp_mic_ctlr_get_by_conn(const struct bt_conn *conn);
+
+/**
  * @brief Discover Microphone Control Service
  *
  * This will start a GATT discovery and setup handles and subscriptions.


### PR DESCRIPTION
Add function to get a MICP microphone controller
instance from a connection pointer. This is effectively the reverse of bt_micp_mic_ctlr_conn_get, and works similar to bt_vcp_vol_ctlr_get_by_conn.