### PR TITLE
drivers: usb_dc_rpi_pico: previously used endpoint may remain locked

### DIFF
--- a/drivers/usb/device/usb_dc_rpi_pico.c
+++ b/drivers/usb/device/usb_dc_rpi_pico.c
@@ -679,6 +679,13 @@ int usb_dc_ep_disable(const uint8_t ep)
 		return 0;
 	}
 
+	/* If this endpoint has previously been used and e.g. the host application
+	 * crashed, the endpoint may remain locked even after reconfiguration
+	 * because the write semaphore is never given back.
+	 * udc_rpi_cancel_endpoint() handles this so the endpoint can be written again.
+	 */
+	udc_rpi_cancel_endpoint(ep);
+
 	uint8_t val = *ep_state->ep_ctl & ~EP_CTRL_ENABLE_BITS;
 
 	*ep_state->ep_ctl = val;


### PR DESCRIPTION
When reconfiguring a previously used endpoint, it may still be locked when a write was taking place when e.g. the host application crashed. The call to udc_rpi_cancel_endpoint seems to do a proper cleanup of the endpoint, i.e. the write semaphore will be released. Fixes #66723.