### PR TITLE
Implement level based interrupts on ITE gpio driver

### DIFF
--- a/drivers/gpio/gpio_ite_it8xxx2_v2.c
+++ b/drivers/gpio/gpio_ite_it8xxx2_v2.c
@@ -478,18 +478,18 @@ DEVICE_DT_INST_DEFINE(inst,                                        \
 
 DT_INST_FOREACH_STATUS_OKAY(GPIO_ITE_DEV_CFG_DATA)
 
+#ifdef CONFIG_SOC_IT8XXX2_GPIO_GROUP_K_L_DEFAULT_PULL_DOWN
 static int gpio_it8xxx2_init_set(void)
 {
-	if (IS_ENABLED(CONFIG_SOC_IT8XXX2_GPIO_GROUP_K_L_DEFAULT_PULL_DOWN)) {
-		const struct device *const gpiok = DEVICE_DT_GET(DT_NODELABEL(gpiok));
-		const struct device *const gpiol = DEVICE_DT_GET(DT_NODELABEL(gpiol));
+	const struct device *const gpiok = DEVICE_DT_GET(DT_NODELABEL(gpiok));
+	const struct device *const gpiol = DEVICE_DT_GET(DT_NODELABEL(gpiol));
 
-		for (int i = 0; i < 8; i++) {
-			gpio_pin_configure(gpiok, i, GPIO_INPUT | GPIO_PULL_DOWN);
-			gpio_pin_configure(gpiol, i, GPIO_INPUT | GPIO_PULL_DOWN);
-		}
+	for (int i = 0; i < 8; i++) {
+		gpio_pin_configure(gpiok, i, GPIO_INPUT | GPIO_PULL_DOWN);
+		gpio_pin_configure(gpiol, i, GPIO_INPUT | GPIO_PULL_DOWN);
 	}
 
 	return 0;
 }
 SYS_INIT(gpio_it8xxx2_init_set, PRE_KERNEL_1, CONFIG_GPIO_INIT_PRIORITY);
+#endif /* CONFIG_SOC_IT8XXX2_GPIO_GROUP_K_L_DEFAULT_PULL_DOWN */

--- a/tests/drivers/gpio/gpio_ite_it8xxx2_v2/CMakeLists.txt
+++ b/tests/drivers/gpio/gpio_ite_it8xxx2_v2/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Copyright 2023 The ChromiumOS Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(gpio_ite_it8xxx2_v2)
+
+target_include_directories(app PRIVATE
+  include
+)
+
+zephyr_include_directories(
+  include
+  ${ZEPHYR_BASE}/soc/riscv/riscv-ite/common
+  ${ZEPHYR_BASE}/soc/riscv/riscv-ite/it8xxx2
+)
+
+target_sources(app
+  PRIVATE
+    src/main.c
+)

--- a/tests/drivers/gpio/gpio_ite_it8xxx2_v2/Kconfig
+++ b/tests/drivers/gpio/gpio_ite_it8xxx2_v2/Kconfig
@@ -1,0 +1,12 @@
+# Copyright 2023 The ChromiumOS Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+source "Kconfig.zephyr"
+
+config SOC_IT8XXX2_GPIO_GROUP_K_L_DEFAULT_PULL_DOWN
+	bool
+	default n
+config HAS_ITE_INTC
+	bool
+	default y

--- a/tests/drivers/gpio/gpio_ite_it8xxx2_v2/boards/native_sim.overlay
+++ b/tests/drivers/gpio/gpio_ite_it8xxx2_v2/boards/native_sim.overlay
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 The ChromiumOS Authors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/interrupt-controller/ite-intc.h>
+#include <zephyr/sys/util_macro.h>
+
+/ {
+        intc: interrupt-controller@f03f00 {
+                compatible = "vnd,intc";
+                #address-cells = <0>;
+                #interrupt-cells = <2>;
+                interrupt-controller;
+                reg = <0x00f03f00 0x0100>;
+        };
+
+        gpioa: gpio@f01601 {
+                compatible = "ite,it8xxx2-gpio-v2";
+                reg = <0x00f01601 1   /* GPDR (set) */
+                        0x00f01618 1   /* GPDMR (get) */
+                        0x00f01630 1   /* GPOTR */
+                        0x00f01648 1   /* P18SCR */
+                        0x00f01660 8>; /* GPCR */
+                ngpios = <8>;
+                gpio-controller;
+                interrupts = <9 IRQ_TYPE_LEVEL_HIGH
+                                2 IRQ_TYPE_LEVEL_HIGH
+                                3 IRQ_TYPE_LEVEL_HIGH
+                                4 IRQ_TYPE_LEVEL_HIGH
+                                5 IRQ_TYPE_LEVEL_HIGH
+                                6 IRQ_TYPE_LEVEL_HIGH
+                                7 IRQ_TYPE_LEVEL_HIGH
+                                8 IRQ_TYPE_LEVEL_HIGH>;
+                interrupt-parent = <&intc>;
+                wuc-base = <0xf01b20 0xf01b20 0xf01b20 0xf01b1c
+                                0xf01b1c 0xf01b1c 0xf01b1c 0xf01b24>;
+                wuc-mask = <BIT(3)   BIT(4)   BIT(5)   BIT(0)
+                                BIT(1)   BIT(2)   BIT(3)   BIT(4)  >;
+                has-volt-sel = <1 1 1 1 1 1 1 1>;
+                #gpio-cells = <2>;
+        };
+};

--- a/tests/drivers/gpio/gpio_ite_it8xxx2_v2/include/chip_chipregs.h
+++ b/tests/drivers/gpio/gpio_ite_it8xxx2_v2/include/chip_chipregs.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023 The ChromiumOS Authors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <../soc/riscv/riscv-ite/common/chip_chipregs.h>
+
+/*
+ * Macros for emulated hardware registers access.
+ */
+#undef ECREG
+#undef ECREG_u16
+#undef ECREG_u32
+#define ECREG(x)		(*((volatile unsigned char *)fake_ecreg((intptr_t)x)))
+#define ECREG_u16(x)		(*((volatile unsigned short *)fake_ecreg((intptr_t)x)))
+#define ECREG_u32(x)		(*((volatile unsigned long  *)fake_ecreg((intptr_t)x)))
+
+unsigned int *fake_ecreg(intptr_t r);
+uint8_t ite_intc_get_irq_num(void);

--- a/tests/drivers/gpio/gpio_ite_it8xxx2_v2/include/zephyr/arch/cpu.h
+++ b/tests/drivers/gpio/gpio_ite_it8xxx2_v2/include/zephyr/arch/cpu.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2023 The ChromiumOS Authors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <chip_chipregs.h>
+#include <zephyr/arch/posix/arch.h>
+
+int arch_irq_connect_dynamic(unsigned int irq, unsigned int priority,
+		    void (*routine)(const void *parameter),
+		    const void *parameter, uint32_t flags);
+int arch_irq_disconnect_dynamic(unsigned int irq, unsigned int priority,
+		       void (*routine)(const void *parameter),
+		       const void *parameter, uint32_t flags);
+typedef struct z_thread_stack_element k_thread_stack_t;

--- a/tests/drivers/gpio/gpio_ite_it8xxx2_v2/prj.conf
+++ b/tests/drivers/gpio/gpio_ite_it8xxx2_v2/prj.conf
@@ -1,0 +1,9 @@
+# Copyright 2023 The ChromiumOS Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ZTEST=y
+CONFIG_GPIO_ITE_IT8XXX2_V2=y
+CONFIG_GPIO=y
+CONFIG_DYNAMIC_INTERRUPTS=y
+CONFIG_GPIO_GET_CONFIG=y

--- a/tests/drivers/gpio/gpio_ite_it8xxx2_v2/src/main.c
+++ b/tests/drivers/gpio/gpio_ite_it8xxx2_v2/src/main.c
@@ -1,0 +1,460 @@
+/*
+ * Copyright 2023 The ChromiumOS Authors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/dt-bindings/gpio/ite-it8xxx2-gpio.h>
+#include <zephyr/fff.h>
+#include <zephyr/ztest.h>
+
+#define MY_GPIO DT_NODELABEL(gpioa)
+
+const struct device *const gpio_dev = DEVICE_DT_GET(MY_GPIO);
+static struct {
+	uint8_t fake;
+	uint8_t gpdmr;
+	uint8_t gpdr;
+	uint8_t gpotr;
+	uint8_t p18scr;
+	uint8_t wuemr, wuesr, wubemr;
+	uint8_t gpcr[DT_REG_SIZE_BY_IDX(MY_GPIO, 4)];
+	bool clear_gpcr_before_read;
+} registers;
+static int callback_called;
+static struct gpio_callback callback_struct;
+
+/* These values must match what is set in the dts overlay. */
+#define TEST_PIN  1
+#define TEST_IRQ  DT_IRQ_BY_IDX(MY_GPIO, TEST_PIN, irq)
+#define TEST_MASK DT_PROP_BY_IDX(MY_GPIO, wuc_mask, TEST_PIN)
+
+DEFINE_FFF_GLOBALS;
+
+uint8_t ite_intc_get_irq_num(void)
+{
+	return posix_get_current_irq();
+}
+
+unsigned int *fake_ecreg(intptr_t r)
+{
+	switch (r) {
+	case DT_REG_ADDR_BY_IDX(MY_GPIO, 0): /* GPDR */
+		return (unsigned int *)&registers.gpdr;
+	case DT_REG_ADDR_BY_IDX(MY_GPIO, 1): /* GPDMR */
+		return (unsigned int *)&registers.gpdmr;
+	case DT_REG_ADDR_BY_IDX(MY_GPIO, 2): /* GPOTR */
+		return (unsigned int *)&registers.gpotr;
+	case DT_REG_ADDR_BY_IDX(MY_GPIO, 3): /* P18SCR */
+		return (unsigned int *)&registers.p18scr;
+	case DT_PROP_BY_IDX(MY_GPIO, wuc_base, TEST_PIN):
+		return (unsigned int *)&registers.wuemr;
+	case DT_PROP_BY_IDX(MY_GPIO, wuc_base, TEST_PIN) + 1:
+		return (unsigned int *)&registers.wuesr;
+	case DT_PROP_BY_IDX(MY_GPIO, wuc_base, TEST_PIN) + 3:
+		return (unsigned int *)&registers.wubemr;
+	}
+	if (r >= DT_REG_ADDR_BY_IDX(MY_GPIO, 4) &&
+	    r < DT_REG_ADDR_BY_IDX(MY_GPIO, 4) + DT_REG_SIZE_BY_IDX(MY_GPIO, 4)) {
+		if (registers.clear_gpcr_before_read) {
+			registers.gpcr[r - DT_REG_ADDR_BY_IDX(MY_GPIO, 4)] = 0;
+		}
+		return (unsigned int *)&registers.gpcr[r - DT_REG_ADDR_BY_IDX(MY_GPIO, 4)];
+	}
+	zassert_unreachable("Register access: %x", r);
+	return (unsigned int *)&registers.fake;
+}
+
+static void callback(const struct device *port, struct gpio_callback *cb, gpio_port_pins_t pins)
+{
+	callback_called++;
+	zexpect_equal(pins, BIT(TEST_PIN));
+}
+
+static void before_test(void *fixture)
+{
+	callback_called = 0;
+	memset(&registers, 0, sizeof(registers));
+}
+
+static void after_test(void *fixture)
+{
+	if (callback_struct.handler != NULL) {
+		zassert_ok(gpio_remove_callback(gpio_dev, &callback_struct));
+	}
+	callback_struct.handler = NULL;
+}
+
+ZTEST_SUITE(gpio_ite_it8xxx2_v2, NULL, NULL, before_test, after_test, NULL);
+
+ZTEST(gpio_ite_it8xxx2_v2, test_get_active_high)
+{
+	zassert_true(device_is_ready(gpio_dev));
+	zassert_ok(gpio_pin_configure(gpio_dev, TEST_PIN, GPIO_INPUT | GPIO_ACTIVE_HIGH));
+	zexpect_equal(registers.gpotr, 0, "gpotr=%x", registers.gpotr);
+	zexpect_equal(registers.p18scr, 0);
+	zexpect_equal(registers.gpcr[TEST_PIN], GPCR_PORT_PIN_MODE_INPUT, "gpcr[%d]=%x", TEST_PIN,
+		      registers.gpcr[TEST_PIN]);
+	registers.gpdmr = (uint8_t)~BIT(TEST_PIN);
+	zassert_false(gpio_pin_get(gpio_dev, TEST_PIN));
+	registers.gpdmr = BIT(TEST_PIN);
+	zassert_true(gpio_pin_get(gpio_dev, TEST_PIN));
+}
+
+ZTEST(gpio_ite_it8xxx2_v2, test_get_active_low)
+{
+	zassert_true(device_is_ready(gpio_dev));
+	zassert_ok(gpio_pin_configure(gpio_dev, TEST_PIN, GPIO_INPUT | GPIO_ACTIVE_LOW));
+	zexpect_equal(registers.gpotr, 0, "gpotr=%x", registers.gpotr);
+	zexpect_equal(registers.p18scr, 0);
+	zexpect_equal(registers.gpcr[TEST_PIN], GPCR_PORT_PIN_MODE_INPUT, "gpcr[%d]=%x", TEST_PIN,
+		      registers.gpcr[TEST_PIN]);
+	registers.gpdmr = (uint8_t)~BIT(TEST_PIN);
+	zassert_true(gpio_pin_get(gpio_dev, TEST_PIN));
+	registers.gpdmr = BIT(TEST_PIN);
+	zassert_false(gpio_pin_get(gpio_dev, TEST_PIN));
+}
+
+ZTEST(gpio_ite_it8xxx2_v2, test_interrupt_edge_rising)
+{
+	zassert_true(device_is_ready(gpio_dev));
+	zassert_ok(gpio_pin_configure(gpio_dev, TEST_PIN, GPIO_INPUT | GPIO_ACTIVE_HIGH));
+
+	gpio_init_callback(&callback_struct, &callback, BIT(TEST_PIN));
+	zassert_ok(gpio_add_callback(gpio_dev, &callback_struct));
+	zassert_ok(gpio_pin_interrupt_configure(gpio_dev, TEST_PIN, GPIO_INT_EDGE_TO_ACTIVE));
+	zexpect_equal(registers.gpotr, 0, "gpotr=%x", registers.gpotr);
+	zexpect_equal(registers.p18scr, 0);
+	zexpect_equal(registers.gpcr[TEST_PIN], GPCR_PORT_PIN_MODE_INPUT, "gpcr[%d]=%x", TEST_PIN,
+		      registers.gpcr[TEST_PIN]);
+	zexpect_equal(registers.wubemr, 0, "wubemr=%x", registers.wubemr);
+	zexpect_equal(registers.wuemr, 0, "wuemr=%x", registers.wuemr);
+	zexpect_equal(registers.wuesr, TEST_MASK, "wuesr=%x", registers.wuesr);
+	registers.wuesr = 0;
+
+	registers.gpdmr = BIT(TEST_PIN);
+	/* Mock the hardware interrupt. */
+	posix_sw_set_pending_IRQ(TEST_IRQ);
+	k_sleep(K_MSEC(100));
+	zassert_equal(callback_called, 1, "callback_called=%d", callback_called);
+}
+
+ZTEST(gpio_ite_it8xxx2_v2, test_interrupt_enable_disable)
+{
+	zassert_true(device_is_ready(gpio_dev));
+	zassert_ok(gpio_pin_configure(gpio_dev, TEST_PIN, GPIO_INPUT | GPIO_ACTIVE_HIGH));
+
+	gpio_init_callback(&callback_struct, &callback, BIT(TEST_PIN));
+	zassert_ok(gpio_add_callback(gpio_dev, &callback_struct));
+	zassert_ok(gpio_pin_interrupt_configure(gpio_dev, TEST_PIN, GPIO_INT_EDGE_TO_ACTIVE));
+	zexpect_equal(registers.gpotr, 0, "gpotr=%x", registers.gpotr);
+	zexpect_equal(registers.p18scr, 0);
+	zexpect_equal(registers.gpcr[TEST_PIN], GPCR_PORT_PIN_MODE_INPUT, "gpcr[%d]=%x", TEST_PIN,
+		      registers.gpcr[TEST_PIN]);
+	zexpect_equal(registers.wubemr, 0, "wubemr=%x", registers.wubemr);
+	zexpect_equal(registers.wuemr, 0, "wuemr=%x", registers.wuemr);
+	zexpect_equal(registers.wuesr, TEST_MASK, "wuesr=%x", registers.wuesr);
+	registers.wuesr = 0;
+
+	registers.gpdmr = BIT(TEST_PIN);
+	/* Mock the hardware interrupt. */
+	posix_sw_set_pending_IRQ(TEST_IRQ);
+	k_sleep(K_MSEC(100));
+	zassert_equal(callback_called, 1, "callback_called=%d", callback_called);
+	registers.gpdmr = 0;
+
+	zassert_ok(gpio_pin_interrupt_configure(gpio_dev, TEST_PIN, GPIO_INT_MODE_DISABLED));
+	registers.gpdmr = BIT(TEST_PIN);
+	/* Mock the hardware interrupt, should be ignored */
+	posix_sw_set_pending_IRQ(TEST_IRQ);
+	k_sleep(K_MSEC(100));
+	zassert_equal(callback_called, 1, "callback_called=%d", callback_called);
+	/* Clear the missed interrupt */
+	posix_sw_clear_pending_IRQ(TEST_IRQ);
+	registers.gpdmr = 0;
+
+	zassert_ok(gpio_pin_interrupt_configure(gpio_dev, TEST_PIN, GPIO_INT_EDGE_TO_ACTIVE));
+	registers.gpdmr = BIT(TEST_PIN);
+	/* Mock the hardware interrupt */
+	posix_sw_set_pending_IRQ(TEST_IRQ);
+	k_sleep(K_MSEC(100));
+	zassert_equal(callback_called, 2, "callback_called=%d", callback_called);
+}
+
+ZTEST(gpio_ite_it8xxx2_v2, test_interrupt_edge_falling)
+{
+	zassert_true(device_is_ready(gpio_dev));
+	zassert_ok(gpio_pin_configure(gpio_dev, TEST_PIN, GPIO_INPUT | GPIO_ACTIVE_HIGH));
+
+	gpio_init_callback(&callback_struct, &callback, BIT(TEST_PIN));
+	zassert_ok(gpio_add_callback(gpio_dev, &callback_struct));
+	zassert_ok(gpio_pin_interrupt_configure(gpio_dev, TEST_PIN, GPIO_INT_EDGE_TO_INACTIVE));
+	zexpect_equal(registers.gpotr, 0, "gpotr=%x", registers.gpotr);
+	zexpect_equal(registers.p18scr, 0);
+	zexpect_equal(registers.gpcr[TEST_PIN], GPCR_PORT_PIN_MODE_INPUT, "gpcr[%d]=%x", TEST_PIN,
+		      registers.gpcr[TEST_PIN]);
+	zexpect_equal(registers.wubemr, 0, "wubemr=%x", registers.wubemr);
+	zexpect_equal(registers.wuemr, TEST_MASK, "wuemr=%x", registers.wuemr);
+	zexpect_equal(registers.wuesr, TEST_MASK, "wuesr=%x", registers.wuesr);
+	registers.wuesr = 0;
+
+	registers.gpdmr = (uint8_t)~BIT(TEST_PIN);
+	/* Mock the hardware interrupt. */
+	posix_sw_set_pending_IRQ(TEST_IRQ);
+	k_sleep(K_MSEC(100));
+	zassert_equal(callback_called, 1, "callback_called=%d", callback_called);
+}
+
+ZTEST(gpio_ite_it8xxx2_v2, test_interrupt_edge_both)
+{
+	zassert_true(device_is_ready(gpio_dev));
+	zassert_ok(gpio_pin_configure(gpio_dev, TEST_PIN, GPIO_INPUT | GPIO_ACTIVE_HIGH));
+
+	gpio_init_callback(&callback_struct, &callback, BIT(TEST_PIN));
+	zassert_ok(gpio_add_callback(gpio_dev, &callback_struct));
+	zassert_ok(gpio_pin_interrupt_configure(gpio_dev, TEST_PIN, GPIO_INT_EDGE_BOTH));
+	zexpect_equal(registers.gpotr, 0, "gpotr=%x", registers.gpotr);
+	zexpect_equal(registers.p18scr, 0);
+	zexpect_equal(registers.gpcr[TEST_PIN], GPCR_PORT_PIN_MODE_INPUT, "gpcr[%d]=%x", TEST_PIN,
+		      registers.gpcr[TEST_PIN]);
+	zexpect_equal(registers.wubemr, TEST_MASK, "wubemr=%x", registers.wubemr);
+	zexpect_equal(registers.wuemr, TEST_MASK, "wuemr=%x", registers.wuemr);
+	zexpect_equal(registers.wuesr, TEST_MASK, "wuesr=%x", registers.wuesr);
+	registers.wuesr = 0;
+
+	registers.gpdmr = BIT(TEST_PIN);
+	/* Mock the hardware interrupt. */
+	posix_sw_set_pending_IRQ(TEST_IRQ);
+	k_sleep(K_MSEC(100));
+	zassert_equal(callback_called, 1, "callback_called=%d", callback_called);
+	registers.gpdmr &= ~BIT(TEST_PIN);
+	/* Mock the hardware interrupt. */
+	posix_sw_set_pending_IRQ(TEST_IRQ);
+	k_sleep(K_MSEC(100));
+	zassert_equal(callback_called, 2, "callback_called=%d", callback_called);
+}
+
+ZTEST(gpio_ite_it8xxx2_v2, test_interrupt_level_active)
+{
+	zassert_true(device_is_ready(gpio_dev));
+	zassert_ok(gpio_pin_configure(gpio_dev, TEST_PIN, GPIO_INPUT | GPIO_ACTIVE_HIGH));
+	zassert_equal(gpio_pin_interrupt_configure(gpio_dev, TEST_PIN, GPIO_INT_LEVEL_ACTIVE),
+		      -ENOTSUP);
+	zexpect_equal(registers.gpotr, 0, "gpotr=%x", registers.gpotr);
+	zexpect_equal(registers.p18scr, 0);
+	zexpect_equal(registers.gpcr[TEST_PIN], GPCR_PORT_PIN_MODE_INPUT, "gpcr[%d]=%x", TEST_PIN,
+		      registers.gpcr[TEST_PIN]);
+	zexpect_equal(registers.wubemr, 0, "wubemr=%x", registers.wubemr);
+	zexpect_equal(registers.wuemr, 0, "wuemr=%x", registers.wuemr);
+	zexpect_equal(registers.wuesr, 0, "wuesr=%x", registers.wuesr);
+}
+
+ZTEST(gpio_ite_it8xxx2_v2, test_interrupt_level_inactive)
+{
+	zassert_true(device_is_ready(gpio_dev));
+	zassert_ok(gpio_pin_configure(gpio_dev, TEST_PIN, GPIO_INPUT | GPIO_ACTIVE_HIGH));
+	zassert_equal(gpio_pin_interrupt_configure(gpio_dev, TEST_PIN, GPIO_INT_LEVEL_INACTIVE),
+		      -ENOTSUP);
+	zexpect_equal(registers.gpotr, 0, "gpotr=%x", registers.gpotr);
+	zexpect_equal(registers.p18scr, 0);
+	zexpect_equal(registers.gpcr[TEST_PIN], GPCR_PORT_PIN_MODE_INPUT, "gpcr[%d]=%x", TEST_PIN,
+		      registers.gpcr[TEST_PIN]);
+	zexpect_equal(registers.wubemr, 0, "wubemr=%x", registers.wubemr);
+	zexpect_equal(registers.wuemr, 0, "wuemr=%x", registers.wuemr);
+	zexpect_equal(registers.wuesr, 0, "wuesr=%x", registers.wuesr);
+}
+
+ZTEST(gpio_ite_it8xxx2_v2, test_set_active_high)
+{
+	gpio_flags_t flags;
+
+	zassert_true(device_is_ready(gpio_dev));
+	zassert_ok(gpio_pin_configure(gpio_dev, TEST_PIN, GPIO_OUTPUT_INACTIVE | GPIO_ACTIVE_HIGH));
+	zexpect_equal(registers.gpotr, 0, "gpotr=%x", registers.gpotr);
+	zexpect_equal(registers.p18scr, 0);
+	zexpect_equal(registers.gpcr[TEST_PIN], GPCR_PORT_PIN_MODE_OUTPUT, "gpcr[%d]=%x", TEST_PIN,
+		      registers.gpcr[TEST_PIN]);
+
+	zexpect_equal(registers.gpdr, 0, "gpdr=%x", registers.gpdr);
+	zassert_ok(gpio_pin_set(gpio_dev, TEST_PIN, true));
+	zexpect_equal(registers.gpdr, BIT(TEST_PIN), "gpdr=%x", registers.gpdr);
+	zassert_ok(gpio_pin_set(gpio_dev, TEST_PIN, false));
+	zexpect_equal(registers.gpdr, 0, "gpdr=%x", registers.gpdr);
+	zassert_ok(gpio_port_toggle_bits(gpio_dev, BIT(TEST_PIN)));
+	zexpect_equal(registers.gpdr, BIT(TEST_PIN), "gpdr=%x", registers.gpdr);
+	registers.gpdr = 0;
+	zassert_ok(gpio_port_set_masked(gpio_dev, BIT(TEST_PIN), 255));
+	zexpect_equal(registers.gpdr, BIT(TEST_PIN), "gpdr=%x", registers.gpdr);
+	registers.gpdr = 255;
+	zassert_ok(gpio_port_set_masked(gpio_dev, BIT(TEST_PIN), 0));
+	zexpect_equal(registers.gpdr, (uint8_t)~BIT(TEST_PIN), "gpdr=%x", registers.gpdr);
+
+	registers.gpdr = BIT(TEST_PIN);
+	zassert_ok(gpio_pin_get_config(gpio_dev, TEST_PIN, &flags));
+	zexpect_equal(flags, GPIO_OUTPUT_HIGH, "flags=%x", flags);
+	registers.gpdr = 0;
+	zassert_ok(gpio_pin_get_config(gpio_dev, TEST_PIN, &flags));
+	zexpect_equal(flags, GPIO_OUTPUT_LOW, "flags=%x", flags);
+}
+
+ZTEST(gpio_ite_it8xxx2_v2, test_set_active_low)
+{
+	gpio_flags_t flags;
+
+	zassert_true(device_is_ready(gpio_dev));
+	zassert_ok(gpio_pin_configure(gpio_dev, TEST_PIN, GPIO_OUTPUT_INACTIVE | GPIO_ACTIVE_LOW));
+	zexpect_equal(registers.gpotr, 0, "gpotr=%x", registers.gpotr);
+	zexpect_equal(registers.p18scr, 0);
+	zexpect_equal(registers.gpcr[TEST_PIN], GPCR_PORT_PIN_MODE_OUTPUT, "gpcr[%d]=%x", TEST_PIN,
+		      registers.gpcr[TEST_PIN]);
+
+	zexpect_equal(registers.gpdr, BIT(TEST_PIN), "gpdr=%x", registers.gpdr);
+	zassert_ok(gpio_pin_set(gpio_dev, TEST_PIN, true));
+	zexpect_equal(registers.gpdr, 0, "gpdr=%x", registers.gpdr);
+	zassert_ok(gpio_pin_set(gpio_dev, TEST_PIN, false));
+	zexpect_equal(registers.gpdr, BIT(TEST_PIN), "gpdr=%x", registers.gpdr);
+	zassert_ok(gpio_port_toggle_bits(gpio_dev, BIT(TEST_PIN)));
+	zexpect_equal(registers.gpdr, 0, "gpdr=%x", registers.gpdr);
+	registers.gpdr = 255;
+	zassert_ok(gpio_port_set_masked(gpio_dev, BIT(TEST_PIN), 255));
+	zexpect_equal(registers.gpdr, (uint8_t)~BIT(TEST_PIN), "gpdr=%x", registers.gpdr);
+	registers.gpdr = 0;
+	zassert_ok(gpio_port_set_masked(gpio_dev, BIT(TEST_PIN), 0));
+	zexpect_equal(registers.gpdr, BIT(TEST_PIN), "gpdr=%x", registers.gpdr);
+
+	registers.gpdr = 0;
+	zassert_ok(gpio_pin_get_config(gpio_dev, TEST_PIN, &flags));
+	zexpect_equal(flags, GPIO_OUTPUT_LOW, "flags=%x", flags);
+	registers.gpdr = BIT(TEST_PIN);
+	zassert_ok(gpio_pin_get_config(gpio_dev, TEST_PIN, &flags));
+	zexpect_equal(flags, GPIO_OUTPUT_HIGH, "flags=%x", flags);
+}
+
+/* The next few tests just verify that the registers are set as expected on configure. */
+
+ZTEST(gpio_ite_it8xxx2_v2, test_open_source)
+{
+	zassert_true(device_is_ready(gpio_dev));
+	zassert_equal(gpio_pin_configure(gpio_dev, TEST_PIN, GPIO_OPEN_SOURCE), -ENOTSUP);
+	zexpect_equal(registers.gpotr, 0, "gpotr=%x", registers.gpotr);
+	zexpect_equal(registers.p18scr, 0);
+	zexpect_equal(registers.gpcr[TEST_PIN], 0, "gpcr[%d]=%x", TEST_PIN,
+		      registers.gpcr[TEST_PIN]);
+}
+
+ZTEST(gpio_ite_it8xxx2_v2, test_open_drain_output)
+{
+	gpio_flags_t flags;
+
+	zassert_true(device_is_ready(gpio_dev));
+	zassert_ok(gpio_pin_configure(gpio_dev, TEST_PIN, GPIO_OUTPUT | GPIO_OPEN_DRAIN));
+	zexpect_equal(registers.gpotr, BIT(TEST_PIN), "gpotr=%x", registers.gpotr);
+	zexpect_equal(registers.p18scr, 0);
+	zexpect_equal(registers.gpcr[TEST_PIN], GPCR_PORT_PIN_MODE_OUTPUT, "gpcr[%d]=%x", TEST_PIN,
+		      registers.gpcr[TEST_PIN]);
+
+	zassert_ok(gpio_pin_get_config(gpio_dev, TEST_PIN, &flags));
+	zexpect_equal(flags, GPIO_OUTPUT_LOW | GPIO_OPEN_DRAIN, "flags=%x", flags);
+}
+
+ZTEST(gpio_ite_it8xxx2_v2, test_pull_up_input)
+{
+	gpio_flags_t flags;
+
+	zassert_true(device_is_ready(gpio_dev));
+	zassert_ok(gpio_pin_configure(gpio_dev, TEST_PIN, GPIO_INPUT | GPIO_PULL_UP));
+	zexpect_equal(registers.gpotr, 0, "gpotr=%x", registers.gpotr);
+	zexpect_equal(registers.p18scr, 0);
+	zexpect_equal(registers.gpcr[TEST_PIN],
+		      GPCR_PORT_PIN_MODE_INPUT | GPCR_PORT_PIN_MODE_PULLUP, "gpcr[%d]=%x", TEST_PIN,
+		      registers.gpcr[TEST_PIN]);
+
+	zassert_ok(gpio_pin_get_config(gpio_dev, TEST_PIN, &flags));
+	zexpect_equal(flags, GPIO_INPUT | GPIO_PULL_UP, "flags=%x", flags);
+}
+
+ZTEST(gpio_ite_it8xxx2_v2, test_pull_down_input)
+{
+	gpio_flags_t flags;
+
+	zassert_true(device_is_ready(gpio_dev));
+	zassert_ok(gpio_pin_configure(gpio_dev, TEST_PIN, GPIO_INPUT | GPIO_PULL_DOWN));
+	zexpect_equal(registers.gpotr, 0, "gpotr=%x", registers.gpotr);
+	zexpect_equal(registers.p18scr, 0);
+	zexpect_equal(registers.gpcr[TEST_PIN],
+		      GPCR_PORT_PIN_MODE_INPUT | GPCR_PORT_PIN_MODE_PULLDOWN, "gpcr[%d]=%x",
+		      TEST_PIN, registers.gpcr[TEST_PIN]);
+
+	zassert_ok(gpio_pin_get_config(gpio_dev, TEST_PIN, &flags));
+	zexpect_equal(flags, GPIO_INPUT | GPIO_PULL_DOWN, "flags=%x", flags);
+}
+
+ZTEST(gpio_ite_it8xxx2_v2, test_disconnected_tristate_supported)
+{
+	gpio_flags_t flags;
+
+	zassert_true(device_is_ready(gpio_dev));
+	zassert_ok(gpio_pin_configure(gpio_dev, TEST_PIN, GPIO_DISCONNECTED));
+	zexpect_equal(registers.gpotr, 0, "gpotr=%x", registers.gpotr);
+	zexpect_equal(registers.p18scr, 0);
+	zexpect_equal(registers.gpcr[TEST_PIN], GPCR_PORT_PIN_MODE_TRISTATE, "gpcr[%d]=%x",
+		      TEST_PIN, registers.gpcr[TEST_PIN]);
+
+	zassert_ok(gpio_pin_get_config(gpio_dev, TEST_PIN, &flags));
+	zexpect_equal(flags, GPIO_PULL_UP | GPIO_PULL_DOWN | GPIO_INPUT | IT8XXX2_GPIO_VOLTAGE_3P3,
+		      "flags=%x", flags);
+}
+
+ZTEST(gpio_ite_it8xxx2_v2, test_disconnected_tristate_unsupported)
+{
+	registers.clear_gpcr_before_read = true;
+	zassert_true(device_is_ready(gpio_dev));
+	zassert_equal(gpio_pin_configure(gpio_dev, TEST_PIN, GPIO_DISCONNECTED), -ENOTSUP);
+	zexpect_equal(registers.gpotr, 0, "gpotr=%x", registers.gpotr);
+	zexpect_equal(registers.p18scr, 0);
+	zexpect_equal(registers.gpcr[TEST_PIN], GPCR_PORT_PIN_MODE_INPUT, "gpcr[%d]=%x", TEST_PIN,
+		      registers.gpcr[TEST_PIN]);
+}
+
+ZTEST(gpio_ite_it8xxx2_v2, test_input_1P8V)
+{
+	gpio_flags_t flags;
+
+	zassert_true(device_is_ready(gpio_dev));
+	zassert_ok(gpio_pin_configure(gpio_dev, TEST_PIN, GPIO_INPUT | IT8XXX2_GPIO_VOLTAGE_1P8));
+	zexpect_equal(registers.gpotr, 0, "gpotr=%x", registers.gpotr);
+	zexpect_equal(registers.p18scr, BIT(TEST_PIN));
+	zexpect_equal(registers.gpcr[TEST_PIN], GPCR_PORT_PIN_MODE_INPUT, "gpcr[%d]=%x", TEST_PIN,
+		      registers.gpcr[TEST_PIN]);
+
+	zassert_ok(gpio_pin_get_config(gpio_dev, TEST_PIN, &flags));
+	zexpect_equal(flags, GPIO_INPUT | IT8XXX2_GPIO_VOLTAGE_1P8, "flags=%x", flags);
+}
+
+ZTEST(gpio_ite_it8xxx2_v2, test_input_3P3V)
+{
+	gpio_flags_t flags;
+
+	zassert_true(device_is_ready(gpio_dev));
+	zassert_ok(gpio_pin_configure(gpio_dev, TEST_PIN, GPIO_INPUT | IT8XXX2_GPIO_VOLTAGE_3P3));
+	zexpect_equal(registers.gpotr, 0, "gpotr=%x", registers.gpotr);
+	zexpect_equal(registers.p18scr, 0);
+	zexpect_equal(registers.gpcr[TEST_PIN], GPCR_PORT_PIN_MODE_INPUT, "gpcr[%d]=%x", TEST_PIN,
+		      registers.gpcr[TEST_PIN]);
+
+	zassert_ok(gpio_pin_get_config(gpio_dev, TEST_PIN, &flags));
+	zexpect_equal(flags, GPIO_INPUT | IT8XXX2_GPIO_VOLTAGE_3P3, "flags=%x", flags);
+}
+
+ZTEST(gpio_ite_it8xxx2_v2, test_input_5V)
+{
+	zassert_true(device_is_ready(gpio_dev));
+	zassert_equal(gpio_pin_configure(gpio_dev, TEST_PIN, GPIO_INPUT | IT8XXX2_GPIO_VOLTAGE_5P0),
+		      -EINVAL);
+	zexpect_equal(registers.gpotr, 0, "gpotr=%x", registers.gpotr);
+	zexpect_equal(registers.p18scr, 0);
+	zexpect_equal(registers.gpcr[TEST_PIN], 0, "gpcr[%d]=%x", TEST_PIN,
+		      registers.gpcr[TEST_PIN]);
+}

--- a/tests/drivers/gpio/gpio_ite_it8xxx2_v2/testcase.yaml
+++ b/tests/drivers/gpio/gpio_ite_it8xxx2_v2/testcase.yaml
@@ -1,0 +1,14 @@
+# Copyright 2023 The ChromiumOS Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+tests:
+  gpio.gpio_ite_it8xxx2_v2:
+    tags:
+      - drivers
+      - gpio
+    depends_on: gpio
+    platform_allow:
+      - native_sim
+    integration_platforms:
+      - native_sim


### PR DESCRIPTION
Added unit test, and then added support for level based interrupts.