### PR TITLE
drivers: ethernet: enc28j60: Add DT property to set Rx filter

### DIFF
--- a/drivers/ethernet/eth_enc28j60.c
+++ b/drivers/ethernet/eth_enc28j60.c
@@ -338,6 +338,7 @@ static void eth_enc28j60_gpio_callback(const struct device *dev,
 static int eth_enc28j60_init_buffers(const struct device *dev)
 {
 	uint8_t data_estat;
+	const struct eth_enc28j60_config *config = dev->config;
 
 	/* Reception buffers initialization */
 	eth_enc28j60_set_bank(dev, ENC28J60_REG_ERXSTL);
@@ -372,7 +373,7 @@ static int eth_enc28j60_init_buffers(const struct device *dev)
 
 	eth_enc28j60_set_bank(dev, ENC28J60_REG_ERXFCON);
 	eth_enc28j60_write_reg(dev, ENC28J60_REG_ERXFCON,
-			       ENC28J60_RECEIVE_FILTERS);
+			       config->hw_rx_filter);
 
 	/* Waiting for OST */
 	/* 32 bits for this timer should be fine, rollover not an issue with initialisation */
@@ -877,6 +878,7 @@ static int eth_enc28j60_init(const struct device *dev)
 		.interrupt = GPIO_DT_SPEC_INST_GET(inst, int_gpios),                               \
 		.full_duplex = DT_INST_PROP(0, full_duplex),                                       \
 		.timeout = CONFIG_ETH_ENC28J60_TIMEOUT,                                            \
+		.hw_rx_filter = DT_INST_PROP_OR(inst, hw_rx_filter, ENC28J60_RECEIVE_FILTERS),     \
 	};                                                                                         \
                                                                                                    \
 	ETH_NET_DEVICE_DT_INST_DEFINE(inst, eth_enc28j60_init, NULL, &eth_enc28j60_runtime_##inst, \

--- a/drivers/ethernet/eth_enc28j60_priv.h
+++ b/drivers/ethernet/eth_enc28j60_priv.h
@@ -178,6 +178,9 @@
  *  - Multicast
  *  - Broadcast
  *  - CRC Check
+ *
+ * Used as default if hw-rx-filter property
+ * absent in DT
  */
 #define ENC28J60_RECEIVE_FILTERS 0xA3
 
@@ -223,6 +226,7 @@ struct eth_enc28j60_config {
 	struct gpio_dt_spec interrupt;
 	uint8_t full_duplex;
 	int32_t timeout;
+	uint8_t hw_rx_filter;
 };
 
 struct eth_enc28j60_runtime {

--- a/dts/bindings/ethernet/microchip,enc28j60.yaml
+++ b/dts/bindings/ethernet/microchip,enc28j60.yaml
@@ -21,3 +21,12 @@ properties:
     type: boolean
     description: |
       Optional feature flag - Enables full duplex reception and transmission.
+
+  hw-rx-filter:
+    type: int
+    description: |
+      Byte value written to the device's
+      ERXFCON: ETHERNET RECEIVE FILTER CONTROL REGISTER
+      Sets the devices receive packet filter, optional
+      If not set in device tree `0xA3` is used, uni, multi and broadcast
+      packets with valid CRC are accepted.


### PR DESCRIPTION
Previously this value was hard coded in the driver's header. This PR allows the value to be set from the DT. If not set uses the previous hard coded value.