### PR TITLE
drivers: i2c: i2c_dw: update DMA node access in I2C dw.

### DIFF
--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -74,9 +74,10 @@ void cb_i2c_idma_transfer(const struct device *dma, void *user_data,
 			 uint32_t channel, int status)
 {
 	const struct device *dev = (const struct device *)user_data;
+	const struct i2c_dw_rom_config * const rom = dev->config;
 	struct i2c_dw_dev_config *const dw = dev->data;
 
-	dma_stop(dw->dma_dev, channel);
+	dma_stop(rom->dma_dev, channel);
 	i2c_dw_enable_idma(dev, false);
 
 	if (status) {
@@ -104,11 +105,12 @@ inline void *i2c_dw_dr_phy_addr(const struct device *dev)
 int32_t i2c_dw_idma_rx_transfer(const struct device *dev)
 {
 	struct i2c_dw_dev_config *const dw = dev->data;
+	const struct i2c_dw_rom_config * const rom = dev->config;
 
 	struct dma_config dma_cfg = { 0 };
 	struct dma_block_config dma_block_cfg = { 0 };
 
-	if (!device_is_ready(dw->dma_dev)) {
+	if (!device_is_ready(rom->dma_dev)) {
 		LOG_DBG("DMA device is not ready");
 		return  -ENODEV;
 	}
@@ -131,12 +133,12 @@ int32_t i2c_dw_idma_rx_transfer(const struct device *dev)
 	dma_block_cfg.source_address = (uint64_t)i2c_dw_dr_phy_addr(dev);
 	dw->xfr_status = false;
 
-	if (dma_config(dw->dma_dev, DMA_INTEL_LPSS_RX_CHAN, &dma_cfg)) {
+	if (dma_config(rom->dma_dev, DMA_INTEL_LPSS_RX_CHAN, &dma_cfg)) {
 		LOG_DBG("Error transfer");
 		return  -EIO;
 	}
 
-	if (dma_start(dw->dma_dev, DMA_INTEL_LPSS_RX_CHAN)) {
+	if (dma_start(rom->dma_dev, DMA_INTEL_LPSS_RX_CHAN)) {
 		LOG_DBG("Error transfer");
 		return  -EIO;
 	}
@@ -150,12 +152,13 @@ int32_t i2c_dw_idma_rx_transfer(const struct device *dev)
 int32_t i2c_dw_idma_tx_transfer(const struct device *dev,
 				uint64_t data)
 {
+	const struct i2c_dw_rom_config * const rom = dev->config;
 	struct i2c_dw_dev_config *const dw = dev->data;
 
 	struct dma_config dma_cfg = { 0 };
 	struct dma_block_config dma_block_cfg = { 0 };
 
-	if (!device_is_ready(dw->dma_dev)) {
+	if (!device_is_ready(rom->dma_dev)) {
 		LOG_DBG("DMA device is not ready");
 		return  -ENODEV;
 	}
@@ -178,12 +181,12 @@ int32_t i2c_dw_idma_tx_transfer(const struct device *dev,
 	dma_block_cfg.dest_address = (uint64_t)i2c_dw_dr_phy_addr(dev);
 	dw->xfr_status = false;
 
-	if (dma_config(dw->dma_dev, DMA_INTEL_LPSS_TX_CHAN, &dma_cfg)) {
+	if (dma_config(rom->dma_dev, DMA_INTEL_LPSS_TX_CHAN, &dma_cfg)) {
 		LOG_DBG("Error transfer");
 		return  -EIO;
 	}
 
-	if (dma_start(dw->dma_dev, DMA_INTEL_LPSS_TX_CHAN)) {
+	if (dma_start(rom->dma_dev, DMA_INTEL_LPSS_TX_CHAN)) {
 		LOG_DBG("Error trnasfer");
 		return  -EIO;
 	}
@@ -390,8 +393,9 @@ static void i2c_dw_isr(const struct device *port)
 		uint32_t stat = sys_read32(reg_base + IDMA_REG_INTR_STS);
 
 		if (stat & IDMA_TX_RX_CHAN_MASK) {
+			const struct i2c_dw_rom_config * const rom = port->config;
 			/* Handle the DMA interrupt */
-			dma_intel_lpss_isr(dw->dma_dev);
+			dma_intel_lpss_isr(rom->dma_dev);
 
 		}
 #endif
@@ -1049,11 +1053,11 @@ static int i2c_dw_initialize(const struct device *dev)
 		pcie_set_cmd(rom->pcie->bdf, PCIE_CONF_CMDSTAT_MASTER, true);
 
 #ifdef CONFIG_I2C_DW_LPSS_DMA
-		size_t nhdls = 0;
-		const device_handle_t *hdls;
+		uintptr_t base;
 
-		hdls = device_supported_handles_get(dev, &nhdls);
-		dw->dma_dev = device_from_handle(*hdls);
+		base = DEVICE_MMIO_GET(dev) + DMA_INTEL_LPSS_OFFSET;
+		dma_intel_lpss_set_base(rom->dma_dev, base);
+		dma_intel_lpss_setup(rom->dma_dev);
 
 		/* Assign physical & virtual address to dma instance */
 		dw->phy_addr = mbar.phys_addr;
@@ -1184,6 +1188,12 @@ static int i2c_dw_initialize(const struct device *dev)
 #define I2C_CONFIG_REG_INIT(n) \
 	_CONCAT(I2C_CONFIG_REG_INIT_PCIE, DT_INST_ON_BUS(n, pcie))(n)
 
+#define I2C_CONFIG_DMA_INIT(n)						\
+	COND_CODE_1(CONFIG_I2C_DW_LPSS_DMA,				\
+	(COND_CODE_1(DT_INST_NODE_HAS_PROP(n, dmas),			\
+	(.dma_dev = DEVICE_DT_GET(DT_INST_DMAS_CTLR_BY_IDX(n, 0)),),	\
+	())), ())
+
 #define I2C_DEVICE_INIT_DW(n)                                                 \
 	PINCTRL_DW_DEFINE(n);                                                 \
 	I2C_PCIE_DEFINE(n);                                                   \
@@ -1195,6 +1205,7 @@ static int i2c_dw_initialize(const struct device *dev)
 		RESET_DW_CONFIG(n)                                            \
 		PINCTRL_DW_CONFIG(n)                                          \
 		I2C_DW_INIT_PCIE(n)                                           \
+		I2C_CONFIG_DMA_INIT(n)					      \
 	};                                                                    \
 	static struct i2c_dw_dev_config i2c_##n##_runtime;                    \
 	I2C_DEVICE_DT_INST_DEFINE(n, i2c_dw_initialize, NULL,                 \

--- a/drivers/i2c/i2c_dw.h
+++ b/drivers/i2c/i2c_dw.h
@@ -104,6 +104,10 @@ struct i2c_dw_rom_config {
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(pcie)
 	struct pcie_dev *pcie;
 #endif /* I2C_DW_PCIE_ENABLED */
+
+#ifdef CONFIG_I2C_DW_LPSS_DMA
+	const struct device *dma_dev;
+#endif
 };
 
 struct i2c_dw_dev_config {
@@ -124,7 +128,6 @@ struct i2c_dw_dev_config {
 	uint8_t			xfr_flags;
 	bool			support_hs_mode;
 #ifdef CONFIG_I2C_DW_LPSS_DMA
-	const struct device *dma_dev;
 	uintptr_t phy_addr;
 	uintptr_t base_addr;
 	/* For dma transfer */

--- a/dts/bindings/dma/intel,lpss.yaml
+++ b/dts/bindings/dma/intel,lpss.yaml
@@ -11,10 +11,5 @@ properties:
   "#dma-cells":
     const: 1
 
-  dma-parent:
-    type: phandle
-    description: |
-      Parent device for LPSS DMA to get its base address.
-
 dma-cells:
   - channel

--- a/dts/x86/intel/raptor_lake.dtsi
+++ b/dts/x86/intel/raptor_lake.dtsi
@@ -62,6 +62,12 @@
 			status = "okay";
 		};
 
+		i2c0_dma: i2c0_dma {
+			compatible = "intel,lpss";
+			#dma-cells = <1>;
+			status = "okay";
+		};
+
 		i2c0: i2c0 {
 			compatible = "snps,designware-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
@@ -71,13 +77,13 @@
 			device-id = <0x7acc>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
+			dmas = <&i2c0_dma 0>;
 
 			status = "okay";
 		};
 
-		i2c0_dma: i2c0_dma {
+		i2c1_dma: i2c1_dma {
 			compatible = "intel,lpss";
-			dma-parent = <&i2c0>;
 			#dma-cells = <1>;
 			status = "disabled";
 		};
@@ -91,13 +97,13 @@
 			device-id = <0x7acd>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
+			dmas = <&i2c1_dma 0>;
 
 			status = "disabled";
 		};
 
-		i2c1_dma: i2c1_dma {
+		i2c2_dma: i2c2_dma {
 			compatible = "intel,lpss";
-			dma-parent = <&i2c1>;
 			#dma-cells = <1>;
 			status = "disabled";
 		};
@@ -113,13 +119,13 @@
 			device-id = <0x7ace>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
+			dmas = <&i2c2_dma 0>;
 
 			status = "disabled";
 		};
 
-		i2c2_dma: i2c2_dma {
+		i2c3_dma: i2c3_dma {
 			compatible = "intel,lpss";
-			dma-parent = <&i2c2>;
 			#dma-cells = <1>;
 			status = "disabled";
 		};
@@ -133,13 +139,13 @@
 			device-id = <0x7acf>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
+			dmas = <&i2c3_dma 0>;
 
 			status = "disabled";
 		};
 
-		i2c3_dma: i2c3_dma {
+		i2c4_dma: i2c4_dma {
 			compatible = "intel,lpss";
-			dma-parent = <&i2c3>;
 			#dma-cells = <1>;
 			status = "disabled";
 		};
@@ -153,13 +159,13 @@
 			device-id = <0x7afc>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
+			dmas = <&i2c4_dma 0>;
 
 			status = "disabled";
 		};
 
-		i2c4_dma: i2c4_dma {
+		i2c5_dma: i2c5_dma {
 			compatible = "intel,lpss";
-			dma-parent = <&i2c4>;
 			#dma-cells = <1>;
 			status = "disabled";
 		};
@@ -173,13 +179,13 @@
 			device-id = <0x7afd>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
+			dmas = <&i2c5_dma 0>;
 
 			status = "disabled";
 		};
 
-		i2c5_dma: i2c5_dma {
+		i2c6_dma: i2c6_dma {
 			compatible = "intel,lpss";
-			dma-parent = <&i2c5>;
 			#dma-cells = <1>;
 			status = "disabled";
 		};
@@ -193,13 +199,13 @@
 			device-id = <0x7ada>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
+			dmas = <&i2c6_dma 0>;
 
 			status = "disabled";
 		};
 
-		i2c6_dma: i2c6_dma {
+		i2c7_dma: i2c7_dma {
 			compatible = "intel,lpss";
-			dma-parent = <&i2c6>;
 			#dma-cells = <1>;
 			status = "disabled";
 		};
@@ -213,14 +219,8 @@
 			device-id = <0x7adb>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
+			dmas = <&i2c7_dma 0>;
 
-			status = "disabled";
-		};
-
-		i2c7_dma: i2c7_dma {
-			compatible = "intel,lpss";
-			dma-parent = <&i2c7>;
-			#dma-cells = <1>;
 			status = "disabled";
 		};
 
@@ -237,7 +237,7 @@
 			clock-frequency = <100000000>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
-			status = "okay";
+			status = "disabled";
 		};
 
 		spi1: spi1 {


### PR DESCRIPTION
Update DMA and I2C to support latest LPSS DMA interface.
This PR depends on https://github.com/zephyrproject-rtos/zephyr/pull/65689

 Signed-off-by: Anisetti Avinash Krishna <anisetti.avinash.krishna@intel.com>