### PR TITLE
Tests: Bluetooth: Fix conn_stress compilation warn

### DIFF
--- a/tests/bsim/bluetooth/host/misc/conn_stress/central/src/main.c
+++ b/tests/bsim/bluetooth/host/misc/conn_stress/central/src/main.c
@@ -96,6 +96,8 @@ static struct conn_info conn_infos[CONFIG_BT_MAX_CONN] = {0};
 static uint32_t conn_interval_max, notification_size;
 static uint8_t vnd_value[CHARACTERISTIC_DATA_MAX_LEN];
 
+static const struct bt_uuid_16 ccc_uuid = BT_UUID_INIT_16(BT_UUID_GATT_CCC_VAL);
+
 void clear_info(struct conn_info *info)
 {
 	/* clear everything except the address + sub params + uuid (lifetime > connection) */
@@ -250,8 +252,8 @@ static uint8_t discover_func(struct bt_conn *conn, const struct bt_gatt_attr *at
 
 	} else if (conn_info_ref->discover_params.type == BT_GATT_DISCOVER_CHARACTERISTIC) {
 		LOG_DBG("Service Characteristic Found");
-		memcpy(&conn_info_ref->uuid, BT_UUID_GATT_CCC, sizeof(conn_info_ref->uuid));
-		conn_info_ref->discover_params.uuid = &conn_info_ref->uuid.uuid;
+
+		conn_info_ref->discover_params.uuid = &ccc_uuid.uuid;
 		conn_info_ref->discover_params.start_handle = attr->handle + 2;
 		conn_info_ref->discover_params.type = BT_GATT_DISCOVER_DESCRIPTOR;
 		conn_info_ref->subscribe_params.value_handle = bt_gatt_attr_value_handle(attr);

--- a/tests/bsim/bluetooth/host/misc/conn_stress/peripheral/src/main.c
+++ b/tests/bsim/bluetooth/host/misc/conn_stress/peripheral/src/main.c
@@ -94,6 +94,8 @@ static struct bt_uuid_128 uuid = BT_UUID_INIT_128(0);
 static struct bt_gatt_discover_params discover_params;
 static struct bt_gatt_subscribe_params subscribe_params;
 
+static const struct bt_uuid_16 ccc_uuid = BT_UUID_INIT_16(BT_UUID_GATT_CCC_VAL);
+
 static void vnd_ccc_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
 {
 	central_subscription = (value == BT_GATT_CCC_NOTIFY) ? 1 : 0;
@@ -277,8 +279,8 @@ static uint8_t discover_func(struct bt_conn *conn, const struct bt_gatt_attr *at
 
 	} else if (discover_params.type == BT_GATT_DISCOVER_CHARACTERISTIC) {
 		LOG_DBG("Service Characteristic Found");
-		memcpy(&uuid, BT_UUID_GATT_CCC, sizeof(uuid));
-		params->uuid = &uuid.uuid;
+
+		params->uuid = &ccc_uuid.uuid;
 		params->start_handle = attr->handle + 2;
 		params->type = BT_GATT_DISCOVER_DESCRIPTOR;
 		subscribe_params.value_handle = bt_gatt_attr_value_handle(attr);


### PR DESCRIPTION
On newer GCC version warnings were emitted because of a `memcpy`. The size parameter was larger than the source's size because it was using the size of the destination, which was a `bt_uuid_128` when the source is a `bt_uuid_16`.

Fix the issue by creating a new variable for CCC UUID in both the central and peripheral code. The variable need to be static because the discover parameters must remain valid until the start of the discover attribute callback.

Fix #66690