### PR TITLE
dai: nxp: sai: Add support for all synchronization modes

### DIFF
--- a/drivers/dai/nxp/sai/Kconfig.sai
+++ b/drivers/dai/nxp/sai/Kconfig.sai
@@ -27,4 +27,15 @@ config SAI_FIFO_WORD_SIZE
 		Use this to set the size (in bytes) of a SAI
 		FIFO word.
 
+config SAI_IMX93_ERRATA_051421
+	bool "Set if your SAI IP version is affected by i.MX93's ERRATA 051421"
+	default n
+	help
+		Select this if your SAI ip version is affected by
+		i.MX93's ERRATA 051421. The errata states that if
+		the SAI is FSYNC/BCLK master, one of the directions
+		is SYNC with the other, and the ASYNC direction has
+		the BYP bit toggled, the SYNC direction's BCLK won't
+		be generated properly.
+
 endif # DAI_NXP_SAI

--- a/drivers/dai/nxp/sai/sai.c
+++ b/drivers/dai/nxp/sai/sai.c
@@ -711,6 +711,10 @@ BUILD_ASSERT(IS_ENABLED(CONFIG_SAI_HAS_MCLK_CONFIG_OPTION) ||			\
 	     !DT_INST_PROP(inst, mclk_is_output),				\
 	     "SAI doesn't support MCLK config but mclk_is_output is specified");\
 										\
+BUILD_ASSERT(SAI_TX_SYNC_MODE(inst) != SAI_RX_SYNC_MODE(inst) ||		\
+	     SAI_TX_SYNC_MODE(inst) != kSAI_ModeSync,				\
+	     "transmitter and receiver can't be both SYNC with each other");	\
+										\
 static const struct dai_properties sai_tx_props_##inst = {			\
 	.fifo_address = SAI_TX_FIFO_BASE(inst),					\
 	.fifo_depth = SAI_FIFO_DEPTH(inst) * CONFIG_SAI_FIFO_WORD_SIZE,		\
@@ -743,6 +747,8 @@ static struct sai_config sai_config_##inst = {					\
 	.tx_props = &sai_tx_props_##inst,					\
 	.rx_props = &sai_rx_props_##inst,					\
 	.irq_config = irq_config_##inst,					\
+	.tx_sync_mode = SAI_TX_SYNC_MODE(inst),					\
+	.rx_sync_mode = SAI_RX_SYNC_MODE(inst),					\
 };										\
 										\
 static struct sai_data sai_data_##inst = {					\

--- a/drivers/dai/nxp/sai/sai.h
+++ b/drivers/dai/nxp/sai/sai.h
@@ -125,6 +125,18 @@ LOG_MODULE_REGISTER(nxp_dai_sai);
 #define SAI_RX_DMA_MUX(inst)\
 	FSL_FEATURE_SAI_RX_DMA_MUXn(UINT_TO_I2S(DT_INST_REG_ADDR(inst)))
 
+/* used to retrieve the synchronization mode of the transmitter. If this
+ * property is not specified, ASYNC mode will be used.
+ */
+#define SAI_TX_SYNC_MODE(inst)\
+	DT_INST_PROP_OR(inst, tx_sync_mode, kSAI_ModeAsync)
+
+/* used to retrieve the synchronization mode of the receiver. If this property
+ * is not specified, ASYNC mode will be used.
+ */
+#define SAI_RX_SYNC_MODE(inst)\
+	DT_INST_PROP_OR(inst, rx_sync_mode, kSAI_ModeAsync)
+
 /* utility macros */
 
 /* invert a clock's polarity. This works because a clock's polarity is expressed
@@ -211,6 +223,10 @@ struct sai_config {
 	const struct dai_properties *tx_props;
 	const struct dai_properties *rx_props;
 	uint32_t dai_index;
+	/* RX synchronization mode - may be SYNC or ASYNC */
+	sai_sync_mode_t rx_sync_mode;
+	/* TX synchronization mode - may be SYNC or ASYNC */
+	sai_sync_mode_t tx_sync_mode;
 	void (*irq_config)(void);
 };
 

--- a/drivers/dai/nxp/sai/sai.h
+++ b/drivers/dai/nxp/sai/sai.h
@@ -190,6 +190,22 @@ LOG_MODULE_REGISTER(nxp_dai_sai);
 	((dir) == DAI_DIR_RX ? ((UINT_TO_I2S(regmap))->RCSR & (which)) : \
 	 ((UINT_TO_I2S(regmap))->TCSR & (which)))
 
+/* used to retrieve the SYNC direction. Use this macro when you know for sure
+ * you have 1 SYNC direction with 1 ASYNC direction.
+ */
+#define SAI_TX_RX_GET_SYNC_DIR(cfg)\
+	((cfg)->tx_sync_mode == kSAI_ModeSync ? DAI_DIR_TX : DAI_DIR_RX)
+
+/* used to retrieve the ASYNC direction. Use this macro when you know for sure
+ * you have 1 SYNC direction with 1 ASYNC direction.
+ */
+#define SAI_TX_RX_GET_ASYNC_DIR(cfg)\
+	((cfg)->tx_sync_mode == kSAI_ModeAsync ? DAI_DIR_TX : DAI_DIR_RX)
+
+/* used to check if transmitter/receiver is SW enabled */
+#define SAI_TX_RX_DIR_IS_SW_ENABLED(dir, data)\
+	((dir) == DAI_DIR_TX ? data->tx_enabled : data->rx_enabled)
+
 struct sai_clock_data {
 	uint32_t *clocks;
 	uint32_t clock_num;

--- a/dts/bindings/dai/nxp,dai-sai.yaml
+++ b/dts/bindings/dai/nxp,dai-sai.yaml
@@ -58,3 +58,29 @@ properties:
       associated with the DAI whose index Linux passes to SOF
       through an IPC. If this property is not specified, the DAI
       index will be considered 0.
+  tx-sync-mode:
+    type: int
+    enum:
+      - 0
+      - 1
+    description: |
+      Use this property to specify which synchronization mode to use
+      for the transmitter. At the moment, the only supported modes are:
+        1) The transmitter is ASYNC (0)
+        2) The transmitter is in SYNC with the receiver (1)
+      If this property is not specified, the transmitter will be set to ASYNC.
+      If one side is SYNC then the other MUST be ASYNC. Failing to meet this
+      condition will result in a failed BUILD_ASSERT().
+  rx-sync-mode:
+    type: int
+    enum:
+      - 0
+      - 1
+    description: |
+      Use this property to specify which synchronization mode to use
+      for the receiver. At the moment, the only supported modes are:
+        1) The receiver is ASYNC (0)
+        2) The receiver is in SYNC with the transmitter (1)
+      If this property is not specified, the receiver will be set to ASYNC.
+      If one side is SYNC then the other MUST be ASYNC. Failing to meet this
+      condition will result in a failed BUILD_ASSERT().


### PR DESCRIPTION
Previously, we only supported RX in SYNC with TX. Since the SAI can also support ASYNC RX with ASYNC TX and ASYNC RX with SYNC TX, this patch series adds supports for these scenarios as well.

Also, due to the i.MX93 errata `ERR051421`, we need to add support for the case in which one of the directions is in SYNC with the other while the BYP bit is set for the ASYNC direction.

Below you may find some waveforms proving that BCLK uses the ASYNC direction's divided BCLK instead of the bypassed one when BYP is toggled.

DIV is 0 => RX_BCLK is half of MCLK (should be equal to MCLK or TX_BCLK)
![Screenshot from 2023-12-19 13-07-32](https://github.com/zephyrproject-rtos/zephyr/assets/26043217/7d4662e9-698d-439e-9e67-49fba7d9ae62)

(BCLK is half of MCLK's frequency, which is wrong. See commit description and comments from the code for details)

DIV is 1 => RX_BCLK is MCLK / 4 (should be equal to MCLK or TX_BCLK)
![Screenshot from 2023-12-19 13-09-51](https://github.com/zephyrproject-rtos/zephyr/assets/26043217/79ca9693-4ad7-4d2f-918d-e409a82fe922)

Note: MCLK is approximately 12.5Mhz in both scenarios.

**EDIT**: Also attaching some register dumps for:

1) First scenario
![Screenshot from 2023-12-19 11-33-30](https://github.com/zephyrproject-rtos/zephyr/assets/26043217/18a8222e-3661-4f2e-aff8-801c0a5ab22a)

2) Second scenario
![Screenshot from 2023-12-19 11-37-39](https://github.com/zephyrproject-rtos/zephyr/assets/26043217/0df27c59-f8da-4560-bfa7-47f8f11825fa)


