### PR TITLE
drivers: usb_dc_rpi_pico: starting read on transfer EPs

### DIFF
--- a/drivers/usb/device/usb_dc_rpi_pico.c
+++ b/drivers/usb/device/usb_dc_rpi_pico.c
@@ -655,9 +655,7 @@ int usb_dc_ep_enable(const uint8_t ep)
 		*ep_state->ep_ctl = val;
 	}
 
-	if (USB_EP_DIR_IS_OUT(ep) && ep != USB_CONTROL_EP_OUT &&
-	    ep_state->cb != usb_transfer_ep_callback) {
-		/* Start reading now, except for transfer managed eps */
+	if (USB_EP_DIR_IS_OUT(ep) && ep != USB_CONTROL_EP_OUT) {
 		return usb_dc_ep_start_read(ep, DATA_BUFFER_SIZE);
 	}
 


### PR DESCRIPTION
This commit partially reverts a change which was introduced in the previous commit 5b9a0e54569c8f128315de7c997f86d24ae178ee. usb_dc_ep_start_read() should also be called on transfer endpoints like it has been before, otherwise the endpoint will not be armed after it has been reconfigured.