### PR TITLE
gen_isr_tables: Add meaningful error message

### DIFF
--- a/scripts/build/gen_isr_tables.py
+++ b/scripts/build/gen_isr_tables.py
@@ -358,6 +358,10 @@ def main():
 
     for irq, flags, func, param in intlist["interrupts"]:
         if flags & ISR_FLAG_DIRECT:
+            if not vt:
+                error("Direct Interrupt %d declared with parameter 0x%x "
+                      "but no vector table in use"
+                      % (irq, param))
             if param != 0:
                 error("Direct irq %d declared, but has non-NULL parameter"
                         % irq)


### PR DESCRIPTION
When using direct isrs, a vector table is needed. However, if none is present , i.e. `CONFIG_GEN_IRQ_VECTOR_TABLE=n`, the gen_isr_tables script failed. The given error message was not helpful (`'NoneType' has no len()`). This change makes it clearer, where to look for the problem.