### PR TITLE
kernel: avoid useless context switch

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1094,7 +1094,7 @@ void z_reschedule(struct k_spinlock *lock, k_spinlock_key_t key)
 
 void z_reschedule_irqlock(uint32_t key)
 {
-	if (resched(key)) {
+	if (resched(key) && need_swap()) {
 		z_swap_irqlock(key);
 	} else {
 		irq_unlock(key);


### PR DESCRIPTION
Enhancement on void z_reschedule_irqlock(uint32_t key) to avoid useless context switch

Fixes #66299

signed-off-by: Gaetan Perrot <gaetanperrotpro@gmail.com>