### PR TITLE
drivers: pwm: stm32: Catch overflows in 2-channel capture

### DIFF
--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -732,11 +732,11 @@ static void pwm_stm32_isr(const struct device *dev)
 			/* Still waiting for a complete capture */
 			return;
 		}
+	}
 
-		if (cpt->overflows) {
-			LOG_ERR("counter overflow during PWM capture");
-			status = -ERANGE;
-		}
+	if (cpt->overflows) {
+		LOG_ERR("counter overflow during PWM capture");
+		status = -ERANGE;
 	}
 
 	if (!cpt->continuous) {


### PR DESCRIPTION
When not using 4 channel capture, overflows were never reported to the application, because the check was in the four_channel_capture_support branch.