### PR TITLE
net: buf: add function to compare data with a net_buf's content

### DIFF
--- a/include/zephyr/net/buf.h
+++ b/include/zephyr/net/buf.h
@@ -2415,6 +2415,22 @@ size_t net_buf_append_bytes(struct net_buf *buf, size_t len,
 			    net_buf_allocator_cb allocate_cb, void *user_data);
 
 /**
+ * @brief Match data with a net_buf's content
+ *
+ * @details Compare data with a content of a net_buf. Provide information about
+ * the number of bytes matching between both. If needed, traverse
+ * through multiple buffer fragments.
+ *
+ * @param buf Network buffer
+ * @param offset Starting offset to compare from
+ * @param data Data buffer for comparison
+ * @param len Number of bytes to compare
+ *
+ * @return The number of bytes compared before the first difference.
+ */
+size_t net_buf_data_match(const struct net_buf *buf, size_t offset, const void *data, size_t len);
+
+/**
  * @brief Skip N number of bytes in a net_buf
  *
  * @details Skip N number of bytes starting from fragment's offset. If the total

--- a/subsys/net/buf.c
+++ b/subsys/net/buf.c
@@ -694,3 +694,39 @@ size_t net_buf_append_bytes(struct net_buf *buf, size_t len,
 	/* Unreachable */
 	return 0;
 }
+
+size_t net_buf_data_match(const struct net_buf *buf, size_t offset, const void *data, size_t len)
+{
+	const uint8_t *dptr = data;
+	const uint8_t *bptr;
+	size_t compared = 0;
+	size_t to_compare;
+
+	if (!buf || !data) {
+		return compared;
+	}
+
+	/* find the right fragment to start comparison */
+	while (buf && offset >= buf->len) {
+		offset -= buf->len;
+		buf = buf->frags;
+	}
+
+	while (buf && len > 0) {
+		bptr = buf->data + offset;
+		to_compare = MIN(len, buf->len - offset);
+
+		for (size_t i = 0; i < to_compare; ++i) {
+			if (dptr[compared] != bptr[i]) {
+				return compared;
+			}
+			compared++;
+		}
+
+		len -= to_compare;
+		buf = buf->frags;
+		offset = 0;
+	}
+
+	return compared;
+}


### PR DESCRIPTION
This PR introduces:
- new function for comparing data under the pointer with a net_buf's content (or multiple buffers when needed), it feels like a nice improvement to be able to match some bytes without a need of temporary buffers
- unit test for the provided change