### PR TITLE
input: use K_KERNEL_STACK_SIZEOF to set the thread stack size

### DIFF
--- a/drivers/input/input_kbd_matrix.c
+++ b/drivers/input/input_kbd_matrix.c
@@ -315,7 +315,7 @@ int input_kbd_matrix_common_init(const struct device *dev)
 	k_sem_init(&data->poll_lock, 0, 1);
 
 	k_thread_create(&data->thread, data->thread_stack,
-			CONFIG_INPUT_KBD_MATRIX_THREAD_STACK_SIZE,
+			K_KERNEL_STACK_SIZEOF(data->thread_stack),
 			input_kbd_matrix_polling_thread, (void *)dev, NULL, NULL,
 			CONFIG_INPUT_KBD_MATRIX_THREAD_PRIORITY, 0, K_NO_WAIT);
 

--- a/drivers/input/linux_evdev.c
+++ b/drivers/input/linux_evdev.c
@@ -98,7 +98,7 @@ static int linux_evdev_init(const struct device *dev)
 	linux_evdev_fd = linux_evdev_open(linux_evdev_path);
 
 	k_thread_create(&linux_evdev_thread, linux_evdev_thread_stack,
-			CONFIG_ARCH_POSIX_RECOMMENDED_STACK_SIZE,
+			K_KERNEL_STACK_SIZEOF(linux_evdev_thread_stack),
 			linux_evdev_thread_fn, (void *)dev, NULL, NULL,
 			CONFIG_NATIVE_LINUX_EVDEV_THREAD_PRIORITY, 0, K_NO_WAIT);
 


### PR DESCRIPTION
Use K_KERNEL_STACK_SIZEOF instead of the config directly to set the stack size in k_thread_create() calls.

---
Not totally sure this is the actual thing coverity is complaining about but the issue is not very clear, this is the only thing I can think of, that's how other drivers do it and it's certainly not a bad idea.
