### PR TITLE
manifest: hal_nordic: update revision to have nrfx 3.3.0 release

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -183,7 +183,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 3786c55424d4d64c62dd25219de31618cef26fdf
+      revision: b55cfbbf0221d709560c2e438beef66842ada272
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
New hal_nordic revision contains nrfx 3.3.0 which adds support for nRF54H20 EngA and nRF54L15 EngA devices.