### PR TITLE
drivers: can: native_linux: coverity fixes

### DIFF
--- a/drivers/can/can_native_linux.c
+++ b/drivers/can/can_native_linux.c
@@ -292,6 +292,7 @@ static int can_native_linux_stop(const struct device *dev)
 static int can_native_linux_set_mode(const struct device *dev, can_mode_t mode)
 {
 	struct can_native_linux_data *data = dev->data;
+	int err;
 
 #ifdef CONFIG_CAN_FD_MODE
 	if ((mode & ~(CAN_MODE_LOOPBACK | CAN_MODE_FD)) != 0) {
@@ -313,7 +314,11 @@ static int can_native_linux_set_mode(const struct device *dev, can_mode_t mode)
 	data->loopback = (mode & CAN_MODE_LOOPBACK) != 0;
 
 	data->mode_fd = (mode & CAN_MODE_FD) != 0;
-	linux_socketcan_set_mode_fd(data->dev_fd, data->mode_fd);
+	err = linux_socketcan_set_mode_fd(data->dev_fd, data->mode_fd);
+	if (err != 0) {
+		LOG_ERR("failed to set mode");
+		return -EIO;
+	}
 
 	return 0;
 }

--- a/drivers/can/can_native_linux_adapt.c
+++ b/drivers/can/can_native_linux_adapt.c
@@ -55,7 +55,7 @@ int linux_socketcan_iface_open(const char *if_name)
 	(void)memset(&ifr, 0, sizeof(ifr));
 	(void)memset(&addr, 0, sizeof(addr));
 
-	strncpy(ifr.ifr_name, if_name, IFNAMSIZ);
+	strncpy(ifr.ifr_name, if_name, IFNAMSIZ - 1);
 
 	ret = ioctl(fd, SIOCGIFINDEX, (void *)&ifr);
 	if (ret < 0) {


### PR DESCRIPTION
- Check return value from linux_socketcan_set_mode_fd() function call.
- Only copy up to IFNAMSIZ - 1 number of characters of the interface name to leave room for null termination of string.

Fixes: #66798
Fixes: #66777