### PR TITLE
doc: add template for external modules

### DIFF
--- a/doc/develop/manifest/external/dummy.rst
+++ b/doc/develop/manifest/external/dummy.rst
@@ -1,0 +1,19 @@
+.. _external_module_dummy:
+
+Add Your External Module Here
+#############################
+
+Introduction
+************
+
+Short intro into the module and how it relates to Zephyr.
+
+Usage with Zephyr
+*****************
+
+How to use this module with Zephyr. Provide all the details.
+
+Reference
+*********
+
+External references and links.

--- a/doc/develop/manifest/external/external.rst.tmpl
+++ b/doc/develop/manifest/external/external.rst.tmpl
@@ -1,0 +1,19 @@
+.. _external_module_<name>:
+
+<External Module Name>
+#######################
+
+Introduction
+************
+
+Short intro into the module and how it relates to Zephyr.
+
+Usage with Zephyr
+*****************
+
+How to use this module with Zephyr. Provide all the details.
+
+Reference
+*********
+
+External references and links.

--- a/doc/develop/manifest/index.rst
+++ b/doc/develop/manifest/index.rst
@@ -53,6 +53,12 @@ file which includes them.  See :ref:`west-manifest-import` for information on
 recommended ways to do this while still inheriting the mandatory modules from
 Zephyr's :file:`west.yml`.
 
-.. rst-class:: rst-columns
+Use the template :file:`doc/develop/manifest/external/external.rst.tmpl` to add
+external modules to the list below:
 
-- TBD
+.. toctree::
+   :titlesonly:
+   :maxdepth: 1
+   :glob:
+
+   external/*


### PR DESCRIPTION
Add template for external modules. Add a module file under external/
will list the module under

https://docs.zephyrproject.org/latest/develop/manifest/index.html#external-projects-modules

which then can be referenced from within the tree where it makes sense.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
