### PR TITLE
twister: coverage: Fix device handler coverage collection mode

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -367,7 +367,7 @@ class DeviceHandler(Handler):
 
     def get_test_timeout(self):
         timeout = super().get_test_timeout()
-        if self.options.coverage:
+        if self.options.enable_coverage:
             # wait more for gcov data to be dumped on console
             timeout += 120
         return timeout
@@ -375,7 +375,7 @@ class DeviceHandler(Handler):
     def monitor_serial(self, ser, halt_event, harness):
         log_out_fp = open(self.log, "wb")
 
-        if self.options.coverage:
+        if self.options.enable_coverage:
             # Set capture_coverage to True to indicate that right after
             # test results we should get coverage data, otherwise we exit
             # from the test.

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -747,7 +747,7 @@ def test_devicehandler_monitor_serial(
     type(harness).state=mock.PropertyMock(side_effect=state_iter)
 
     handler = DeviceHandler(mocked_instance, 'build')
-    handler.options = mock.Mock(coverage=not end_by_state)
+    handler.options = mock.Mock(enable_coverage=not end_by_state)
 
     with mock.patch('builtins.open', mock.mock_open(read_data='')):
         handler.monitor_serial(ser, halt_event, harness)


### PR DESCRIPTION
Twister DeviceHandler now checks `--enable-coverage` command line argument instead of `--coverage` when it deals with device output. This resolves potential problem when only `--enable-coverage` argument is given and the coverage report is not needed. In this case the test image which is built for code coverage works slower also producing additional console output, so the additional DeviceHandler timeout still have to be applied and the output with coverage data correctly processed by Harness.