### PR TITLE
doc: posix: option groups: abbreviate c option group, add missing thread safe function table

### DIFF
--- a/doc/services/portability/posix/aep/index.rst
+++ b/doc/services/portability/posix/aep/index.rst
@@ -26,7 +26,7 @@ Minimal Realtime System Profile (PSE51)
    :widths: 50, 10, 50
 
     POSIX_C_LANG_JUMP,,
-    POSIX_C_LANG_SUPPORT, yes, :ref:`†<posix_undefined_behaviour>`
+    POSIX_C_LANG_SUPPORT, yes, :ref:`POSIX_C_LANG_SUPPORT <posix_option_group_c_lang_support>`
     POSIX_DEVICE_IO,, :ref:`†<posix_undefined_behaviour>`
     POSIX_FILE_LOCKING,,
     POSIX_SIGNALS,, :ref:`†<posix_undefined_behaviour>`
@@ -57,9 +57,6 @@ Minimal Realtime System Profile (PSE51)
     _POSIX_TIMEOUTS, 200809L, :kconfig:option:`CONFIG_PTHREAD_IPC`
     _POSIX_TIMERS, 200809L, :kconfig:option:`CONFIG_POSIX_CLOCK`
 
-.. note::
-    For PSE51 support, 44 of 75 symbols are currently implemented.
-
 .. _posix_aep_pse52:
 
 Realtime Controller System Profile (PSE52)
@@ -79,7 +76,7 @@ Realtime Controller System Profile (PSE52)
 
     POSIX_C_LANG_JUMP,,
     POSIX_C_LANG_MATH, yes,
-    POSIX_C_LANG_SUPPORT, yes, :ref:`†<posix_undefined_behaviour>`
+    POSIX_C_LANG_SUPPORT, yes, :ref:`POSIX_C_LANG_SUPPORT <posix_option_group_c_lang_support>`
     POSIX_DEVICE_IO,, :ref:`†<posix_undefined_behaviour>`
     POSIX_FD_MGMT,,
     POSIX_FILE_LOCKING,,
@@ -136,7 +133,7 @@ Dedicated Realtime System Profile (PSE53)
 
     POSIX_C_LANG_JUMP,,
     POSIX_C_LANG_MATH, yes,
-    POSIX_C_LANG_SUPPORT, yes, :ref:`†<posix_undefined_behaviour>`
+    POSIX_C_LANG_SUPPORT, yes, :ref:`POSIX_C_LANG_SUPPORT <posix_option_group_c_lang_support>`
     POSIX_DEVICE_IO,, :ref:`†<posix_undefined_behaviour>`
     POSIX_FD_MGMT,,
     POSIX_FILE_LOCKING,,

--- a/doc/services/portability/posix/aep/index.rst
+++ b/doc/services/portability/posix/aep/index.rst
@@ -25,7 +25,7 @@ Minimal Realtime System Profile (PSE51)
    :header: Symbol, Support, Remarks
    :widths: 50, 10, 50
 
-    POSIX_C_LANG_JUMP,,
+    POSIX_C_LANG_JUMP, yes, :ref:`POSIX_C_LANG_JUMP <posix_option_group_c_lang_jump>`
     POSIX_C_LANG_SUPPORT, yes, :ref:`POSIX_C_LANG_SUPPORT <posix_option_group_c_lang_support>`
     POSIX_DEVICE_IO,, :ref:`†<posix_undefined_behaviour>`
     POSIX_FILE_LOCKING,,
@@ -74,8 +74,8 @@ Realtime Controller System Profile (PSE52)
    :header: Symbol, Support, Remarks
    :widths: 50, 10, 50
 
-    POSIX_C_LANG_JUMP,,
-    POSIX_C_LANG_MATH, yes,
+    POSIX_C_LANG_JUMP, yes, :ref:`POSIX_C_LANG_JUMP <posix_option_group_c_lang_jump>`
+    POSIX_C_LANG_MATH, yes, :ref:`POSIX_C_LANG_MATH <posix_option_group_c_lang_math>`
     POSIX_C_LANG_SUPPORT, yes, :ref:`POSIX_C_LANG_SUPPORT <posix_option_group_c_lang_support>`
     POSIX_DEVICE_IO,, :ref:`†<posix_undefined_behaviour>`
     POSIX_FD_MGMT,,
@@ -131,8 +131,8 @@ Dedicated Realtime System Profile (PSE53)
    :header: Symbol, Support, Remarks
    :widths: 50, 10, 50
 
-    POSIX_C_LANG_JUMP,,
-    POSIX_C_LANG_MATH, yes,
+    POSIX_C_LANG_JUMP, yes, :ref:`POSIX_C_LANG_JUMP <posix_option_group_c_lang_jump>`
+    POSIX_C_LANG_MATH, yes, :ref:`POSIX_C_LANG_MATH <posix_option_group_c_lang_math>`
     POSIX_C_LANG_SUPPORT, yes, :ref:`POSIX_C_LANG_SUPPORT <posix_option_group_c_lang_support>`
     POSIX_DEVICE_IO,, :ref:`†<posix_undefined_behaviour>`
     POSIX_FD_MGMT,,

--- a/doc/services/portability/posix/conformance/index.rst
+++ b/doc/services/portability/posix/conformance/index.rst
@@ -14,6 +14,13 @@ As per `IEEE 1003.1-2017`, this section details Zephyr's POSIX conformance.
    Zephyr's current design, some features requiring multi-process capabilities may exhibit
    undefined behaviour, which we denote with the † (obelus) symbol.
 
+.. _posix_libc_provided:
+
+.. note::
+    Features listed in various POSIX Options or Option Groups may be provided in whole or in part
+    by a conformant C library implementation. This includes (but is not limited to) POSIX
+    Extensions to the ISO C Standard (`CX`_).
+
 .. _posix_system_interfaces:
 
 POSIX System Interfaces
@@ -143,3 +150,5 @@ XSI System Interfaces
     :ref:`_POSIX_THREAD_ATTR_STACKADDR<posix_option_thread_attr_stackaddr>`, 200809L, :kconfig:option:`CONFIG_PTHREAD`
     :ref:`_POSIX_THREAD_ATTR_STACKSIZE<posix_option_thread_attr_stacksize>`, 200809L, :kconfig:option:`CONFIG_PTHREAD`
     _POSIX_THREAD_PROCESS_SHARED, -1,
+
+.. _CX: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap01.html

--- a/doc/services/portability/posix/conformance/index.rst
+++ b/doc/services/portability/posix/conformance/index.rst
@@ -61,7 +61,7 @@ POSIX System Interfaces
     _POSIX_REALTIME_SIGNALS, -1, :ref:`†<posix_undefined_behaviour>`
     :ref:`_POSIX_SEMAPHORES<posix_option_group_semaphores>`, 200809L, :kconfig:option:`CONFIG_PTHREAD_IPC`
     :ref:`_POSIX_SPIN_LOCKS<posix_option_group_spin_locks>`, 200809L, :kconfig:option:`CONFIG_PTHREAD_SPINLOCK`
-    _POSIX_THREAD_SAFE_FUNCTIONS, 200809L,
+    :ref:`_POSIX_THREAD_SAFE_FUNCTIONS<posix_thread_safe_functions>`, -1,
     :ref:`_POSIX_THREADS<posix_option_group_threads_base>`, -1, :kconfig:option:`CONFIG_PTHREAD_IPC`
     :ref:`_POSIX_TIMEOUTS<posix_option_timeouts>`, 200809L, :kconfig:option:`CONFIG_PTHREAD_IPC`
     :ref:`_POSIX_TIMERS<posix_option_group_timers>`, 200809L, :kconfig:option:`CONFIG_POSIX_CLOCK`

--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -448,6 +448,35 @@ _POSIX_THREAD_PRIORITY_SCHEDULING
     pthread_setschedparam(),yes
     pthread_setschedprio(),yes
 
+.. _posix_thread_safe_functions:
+
+_POSIX_THREAD_SAFE_FUNCTIONS
+++++++++++++++++++++++++++++
+
+.. csv-table:: _POSIX_THREAD_SAFE_FUNCTIONS
+    :header: API, Supported
+    :widths: 50,10
+
+    asctime_r(),
+    ctime_r(),
+    flockfile(),
+    ftrylockfile(),
+    funlockfile(),
+    getc_unlocked(), yes
+    getchar_unlocked(), yes
+    getgrgid_r(),
+    getgrnam_r(),
+    getpwnam_r(),
+    getpwuid_r(),
+    gmtime_r(), yes
+    localtime_r(),
+    putc_unlocked(), yes
+    putchar_unlocked(), yes
+    rand_r(), yes
+    readdir_r(),
+    strerror_r(), yes
+    strtok_r(), yes
+
 .. _posix_option_timeouts:
 
 _POSIX_TIMEOUTS

--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -102,6 +102,38 @@ This table lists service support status in Zephyr:
     pthread_getconcurrency(),yes
     pthread_setconcurrency(),yes
 
+.. _posix_option_group_c_lang_jump:
+
+POSIX_C_LANG_JUMP
+=================
+
+The ``POSIX_C_LANG_JUMP`` Option Group is included in the ISO C standard.
+
+.. note::
+   When using Newlib, Picolibc, or other C libraries conforming to the ISO C Standard, the
+   ``POSIX_C_LANG_JUMP`` Option Group is considered supported.
+
+.. csv-table:: POSIX_C_LANG_JUMP
+   :header: API, Supported
+   :widths: 50,10
+
+    setjmp(), yes
+    longjmp(), yes
+
+.. _posix_option_group_c_lang_math:
+
+POSIX_C_LANG_MATH
+=================
+
+The ``POSIX_C_LANG_MATH`` Option Group is included in the ISO C standard.
+
+.. note::
+   When using Newlib, Picolibc, or other C libraries conforming to the ISO C Standard, the
+   ``POSIX_C_LANG_MATH`` Option Group is considered supported.
+
+Please refer to `Subprofiling Considerations`_ for details on the ``POSIX_C_LANG_MATH`` Option
+Group.
+
 .. _posix_option_group_c_lang_support:
 
 POSIX_C_LANG_SUPPORT
@@ -450,3 +482,7 @@ _XOPEN_STREAMS
     isastream(),
     putmsg(),
     putpmsg(),
+
+
+.. _Subprofiling Considerations:
+    https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_subprofiles.html

--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -107,118 +107,17 @@ This table lists service support status in Zephyr:
 POSIX_C_LANG_SUPPORT
 ====================
 
-The POSIX_C_LANG_SUPPORT option group contains the general ISO C
-Library.
+The POSIX_C_LANG_SUPPORT option group contains the general ISO C Library.
 
-.. csv-table:: POSIX_C_LANG_SUPPORT
-   :header: API, Supported
-   :widths: 50,10
+.. note::
+   When using Newlib, Picolibc, or other C libraries conforming to the ISO C Standard, the entire
+   ``POSIX_C_LANG_SUPPORT`` Option Group is considered supported.
 
-    abs(),yes
-    asctime(),
-    asctime_r(),
-    atof(),
-    atoi(),yes
-    atol(),
-    atoll(),
-    bsearch(),yes
-    calloc(),yes
-    ctime(),
-    ctime_r(),
-    difftime(),
-    div(),
-    feclearexcept(),
-    fegetenv(),
-    fegetexceptflag(),
-    fegetround(),
-    feholdexcept(),
-    feraiseexcept(),
-    fesetenv(),
-    fesetexceptflag(),
-    fesetround(),
-    fetestexcept(),
-    feupdateenv(),
-    free(),yes
-    gmtime(),yes
-    gmtime_r(),yes
-    imaxabs(),
-    imaxdiv(),
-    isalnum(),yes
-    isalpha(),yes
-    isblank(),
-    iscntrl(),yes
-    isdigit(),yes
-    isgraph(),yes
-    islower(),
-    isprint(),yes
-    ispunct(),
-    isspace(),yes
-    isupper(),yes
-    isxdigit(),yes
-    labs(),yes
-    ldiv(),
-    llabs(),yes
-    lldiv(),
-    localeconv(),
-    localtime(),yes
-    localtime_r(),
-    malloc(),yes
-    memchr(),yes
-    memcmp(),yes
-    memcpy(),yes
-    memmove(),yes
-    memset(),yes
-    mktime(),yes
-    qsort(),yes
-    rand(),yes
-    rand_r(),yes
-    realloc(),yes
-    setlocale(),
-    snprintf(),yes
-    sprintf(),yes
-    srand(),yes
-    sscanf(),
-    strcat(),yes
-    strchr(),yes
-    strcmp(),yes
-    strcoll(),
-    strcpy(),yes
-    strcspn(),yes
-    strerror(),yes
-    strerror_r(),yes
-    strftime(),
-    strlen(),yes
-    strncat(),yes
-    strncmp(),yes
-    strncpy(),yes
-    strpbrk(),
-    strrchr(),yes
-    strspn(),yes
-    strstr(),yes
-    strtod(),
-    strtof(),
-    strtoimax(),
-    strtok(),yes
-    strtok_r(),yes
-    strtol(),yes
-    strtold(),
-    strtoll(),yes
-    strtoul(),yes
-    strtoull(),yes
-    strtoumax(),
-    strxfrm(),
-    time(),yes
-    tolower(),yes
-    toupper(),yes
-    tzname(),
-    tzset(),
-    va_arg(),yes
-    va_copy(),yes
-    va_end(),yes
-    va_start(),yes
-    vsnprintf(),yes
-    vsprintf(),yes
-    vsscanf(),
+Please refer to `Subprofiling Considerations`_ for details on the ``POSIX_C_LANG_SUPPORT`` Option
+Group.
+
+For more information on developing Zephyr applications in the C programming language, please refer
+to :ref:`details<language_support>`.
 
 .. _posix_option_group_single_process:
 

--- a/doc/services/portability/posix/overview/index.rst
+++ b/doc/services/portability/posix/overview/index.rst
@@ -59,7 +59,9 @@ as part of `IEEE 1003.13-2003`_ (also known as POSIX.13-2003).
 
 POSIX.13-2003 AEP were formalized in 2003 via "Units of Functionality" but the specification is now
 inactive (for reference only). Nevertheless, the intent is still captured as part of POSIX-1.2017
-via :ref:`Options<posix_options>` and :ref:`Option Groups<posix_option_groups>`, in Appendix E.
+via :ref:`Options<posix_options>` and :ref:`Option Groups<posix_option_groups>`.
+
+For more information, please see `IEEE 1003.1-2017, Section E, Subprofiling Considerations`_.
 
 .. _posix_apps:
 
@@ -133,3 +135,5 @@ Alternatively, users may enable one of the Kconfig options below as a shortcut t
 .. _IEEE Computer Society: https://www.computer.org/
 .. _IEEE 1003.1-2017: https://standards.ieee.org/ieee/1003.1/7101/
 .. _IEEE 1003.13-2003: https://standards.ieee.org/ieee/1003.13/3322/
+.. _IEEE 1003.1-2017, Section E, Subprofiling Considerations:
+    https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_subprofiles.html


### PR DESCRIPTION
* reduce verbosity in `POSIX_C_LANG_SUPPORT` and link to details, language support page
* add missing `POSIX_C_LANG_JUMP` section
* add missing `POSIX_C_LANG_MATH` section and link to details
* add missing `_POSIX_THREAD_SAFE_FUNCTIONS`
* add clarification on POSIX API features in other C libraries