### PR TITLE
multilevel irq: output the interrupt level of a node in `gen_defines.py` and simplify multilevel `DT_IRQN`

### DIFF
--- a/doc/build/dts/macros.bnf
+++ b/doc/build/dts/macros.bnf
@@ -37,6 +37,7 @@ node-macro =/ %s"DT_N" path-id %s"_REG_NAME_" dt-name
               %s"_VAL_" ( %s"ADDRESS" / %s"SIZE")
 ; The interrupts property is also special.
 node-macro =/ %s"DT_N" path-id %s"_IRQ_NUM"
+node-macro =/ %s"DT_N" path-id %s"_IRQ_LEVEL"
 node-macro =/ %s"DT_N" path-id %s"_IRQ_IDX_" DIGIT "_EXISTS"
 node-macro =/ %s"DT_N" path-id %s"_IRQ_IDX_" DIGIT
               %s"_VAL_" dt-name [ %s"_EXISTS" ]

--- a/dts/bindings/test/vnd,cpu-intc.yaml
+++ b/dts/bindings/test/vnd,cpu-intc.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2023 Meta
+# SPDX-License-Identifier: Apache-2.0
+
+description: Test CPU Interrupt Controller
+
+compatible: "vnd,cpu-intc"
+
+include: [interrupt-controller.yaml, base.yaml]
+
+properties:
+  "#interrupt-cells":
+    const: 1
+
+interrupt-cells:
+  - irq

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -2288,6 +2288,14 @@
 #define DT_NUM_IRQS(node_id) DT_CAT(node_id, _IRQ_NUM)
 
 /**
+ * @brief Get the interrupt level for the node
+ *
+ * @param node_id node identifier
+ * @return interrupt level
+ */
+#define DT_IRQ_LEVEL(node_id) DT_CAT(node_id, _IRQ_LEVEL)
+
+/**
  * @brief Is @p idx a valid interrupt index?
  *
  * If this returns 1, then DT_IRQ_BY_IDX(node_id, idx) is valid.
@@ -3968,6 +3976,14 @@
  * @return instance's register block size
  */
 #define DT_INST_REG_SIZE(inst) DT_INST_REG_SIZE_BY_IDX(inst, 0)
+
+/**
+ * @brief Get a `DT_DRV_COMPAT` interrupt level
+ *
+ * @param inst instance number
+ * @return interrupt level
+ */
+#define DT_INST_IRQ_LEVEL(inst) DT_IRQ_LEVEL(DT_DRV_INST(inst))
 
 /**
  * @brief Get a `DT_DRV_COMPAT` interrupt specifier value at an index

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -484,6 +484,16 @@ def write_interrupts(node):
             name_controller_macro = f"{path_id}_IRQ_NAME_{str2ident(irq.name)}_CONTROLLER"
             name_vals.append((name_controller_macro, f"DT_{idx_controller_macro}"))
 
+    # Interrupt controller info
+    irqs = []
+    while node.interrupts is not None and len(node.interrupts) > 0:
+        irq = node.interrupts[0]
+        irqs.append(irq)
+        if node == irq.controller:
+            break
+        node = irq.controller
+    idx_vals.append((f"{path_id}_IRQ_LEVEL", len(irqs)))
+
     for macro, val in idx_vals:
         out_dt_define(macro, val)
     for macro, val in name_vals:

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -29,6 +29,13 @@
 		#size-cells = < 0x1 >;
 		interrupt-parent = <&test_intc>;
 
+		test_cpu_intc: interrupt-controller  {
+			compatible = "vnd,cpu-intc";
+			#address-cells = <0>;
+			#interrupt-cells = < 0x01 >;
+			interrupt-controller;
+		};
+
 		test_pinctrl: pin-controller {
 			compatible = "vnd,pinctrl";
 			test_pincfg_a: pincfg-a {};
@@ -430,6 +437,7 @@
 			interrupt-controller;
 			#interrupt-cells = <2>;
 			interrupts = <11 0>;
+			interrupt-parent = <&test_cpu_intc>;
 		};
 
 		/* there should only be one of these */

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -20,6 +20,7 @@
 #define TEST_INST	DT_INST(0, vnd_gpio_device)
 #define TEST_ARRAYS	DT_NODELABEL(test_arrays)
 #define TEST_PH	DT_NODELABEL(test_phandles)
+#define TEST_INTC	DT_NODELABEL(test_intc)
 #define TEST_IRQ	DT_NODELABEL(test_irq)
 #define TEST_IRQ_EXT	DT_NODELABEL(test_irq_extended)
 #define TEST_TEMP	DT_NODELABEL(test_temp_sensor)
@@ -657,10 +658,12 @@ ZTEST(devicetree_api, test_irq)
 	zassert_equal(DT_IRQ(TEST_I2C_BUS, priority), 2, "");
 
 	/* DT_IRQN */
-	zassert_equal(DT_IRQN(TEST_I2C_BUS), 6, "");
 	#ifndef CONFIG_MULTI_LEVEL_INTERRUPTS
+		zassert_equal(DT_IRQN(TEST_I2C_BUS), 6, "");
 		zassert_equal(DT_IRQN(DT_INST(0, DT_DRV_COMPAT)), 30, "");
 	#else
+		zassert_equal(DT_IRQN(TEST_I2C_BUS),
+			      ((6 + 1) << CONFIG_1ST_LEVEL_INTERRUPT_BITS) | 11, "");
 		zassert_equal(DT_IRQN(DT_INST(0, DT_DRV_COMPAT)),
 			      ((30 + 1) << CONFIG_1ST_LEVEL_INTERRUPT_BITS) | 11, "");
 	#endif
@@ -747,6 +750,27 @@ ZTEST(devicetree_api, test_irq)
 	zassert_true(DT_INST_IRQ_HAS_NAME(0, stat), "");
 	zassert_true(DT_INST_IRQ_HAS_NAME(0, done), "");
 	zassert_false(DT_INST_IRQ_HAS_NAME(0, alpha), "");
+}
+
+ZTEST(devicetree_api, test_irq_level)
+{
+	/* DT_IRQ_LEVEL */
+	zassert_equal(DT_IRQ_LEVEL(TEST_TEMP), 0, "");
+	zassert_equal(DT_IRQ_LEVEL(TEST_INTC), 1, "");
+	zassert_equal(DT_IRQ_LEVEL(TEST_SPI), 2, "");
+
+	/* DT_IRQ_LEVEL */
+	#undef DT_DRV_COMPAT
+	#define DT_DRV_COMPAT vnd_adc_temp_sensor
+	zassert_equal(DT_INST_IRQ_LEVEL(0), 0, "");
+
+	#undef DT_DRV_COMPAT
+	#define DT_DRV_COMPAT vnd_intc
+	zassert_equal(DT_INST_IRQ_LEVEL(1), 1, "");
+
+	#undef DT_DRV_COMPAT
+	#define DT_DRV_COMPAT vnd_spi
+	zassert_equal(DT_INST_IRQ_LEVEL(0), 2, "");
 }
 
 struct gpios_struct {

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -658,15 +658,15 @@ ZTEST(devicetree_api, test_irq)
 	zassert_equal(DT_IRQ(TEST_I2C_BUS, priority), 2, "");
 
 	/* DT_IRQN */
-	#ifndef CONFIG_MULTI_LEVEL_INTERRUPTS
-		zassert_equal(DT_IRQN(TEST_I2C_BUS), 6, "");
-		zassert_equal(DT_IRQN(DT_INST(0, DT_DRV_COMPAT)), 30, "");
-	#else
-		zassert_equal(DT_IRQN(TEST_I2C_BUS),
-			      ((6 + 1) << CONFIG_1ST_LEVEL_INTERRUPT_BITS) | 11, "");
-		zassert_equal(DT_IRQN(DT_INST(0, DT_DRV_COMPAT)),
-			      ((30 + 1) << CONFIG_1ST_LEVEL_INTERRUPT_BITS) | 11, "");
-	#endif
+#ifndef CONFIG_MULTI_LEVEL_INTERRUPTS
+	zassert_equal(DT_IRQN(TEST_I2C_BUS), 6, "");
+	zassert_equal(DT_IRQN(DT_INST(0, DT_DRV_COMPAT)), 30, "");
+#else
+	zassert_equal(DT_IRQN(TEST_I2C_BUS),
+			((6 + 1) << CONFIG_1ST_LEVEL_INTERRUPT_BITS) | 11, "");
+	zassert_equal(DT_IRQN(DT_INST(0, DT_DRV_COMPAT)),
+			((30 + 1) << CONFIG_1ST_LEVEL_INTERRUPT_BITS) | 11, "");
+#endif
 
 	/* DT_IRQN_BY_IDX */
 #ifndef CONFIG_MULTI_LEVEL_INTERRUPTS


### PR DESCRIPTION
While the devicetree has everything about the interrupt info of a node, there's no (easy) way to access that information, this results in an overly complicated and error-prone macros for the multilevel IRQ DT macro.

This PR modifies the `gen_defines.py` script to output the interrupt level of a node, added new DT macros to access those and added test for the new DT macros.

With that, the multilevel IRQ DT macros are greatly simplified, and should be good enough util a complete rewrite of our interrupt architecture finally arrives