### PR TITLE
RFC: boards: intel: Refactor (deduplicate) device tree

### DIFF
--- a/boards/x86/intel_adl/intel_adl.dts
+++ b/boards/x86/intel_adl/intel_adl.dts
@@ -10,7 +10,7 @@
 
 #define DT_DRAM_SIZE		DT_SIZE_M(2048)
 
-#include <intel/alder_lake.dtsi>
+#include <intel/x86_64.dtsi>
 
 / {
 	chosen {
@@ -21,4 +21,304 @@
 		watchdog0 = &tco_wdt;
 		sdhc0 = &emmc;
 	};
+
+	soc {
+		pwm0: pwm0@fd6d0000 {
+			compatible = "intel,blinky-pwm";
+			reg = <0xfd6d0000 0x400>;
+			reg-offset = <0x204>;
+			clock-frequency = <32768>;
+			max-pins = <1>;
+			#pwm-cells = <2>;
+
+			status = "okay";
+		};
+
+		gpio_0_b: gpio@fd6e0700 {
+			compatible = "intel,gpio";
+			reg = <0xfd6e0700 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <24>;
+			pin-offset = <0>;
+
+			status = "okay";
+		};
+
+		gpio_0_a: gpio@fd6e09a0 {
+			compatible = "intel,gpio";
+			reg = <0xfd6e09a0 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x2>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <24>;
+			pin-offset = <41>;
+
+			status = "okay";
+		};
+
+		gpio_1_s: gpio@fd6d0700 {
+			compatible = "intel,gpio";
+			reg = <0xfd6d0700 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <8>;
+			pin-offset = <0>;
+
+			status = "okay";
+		};
+
+		gpio_1_i: gpio@fd6d0780 {
+			compatible = "intel,gpio";
+			reg = <0xfd6d0780 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x1>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <19>;
+			pin-offset = <8>;
+
+			status = "okay";
+		};
+
+
+		gpio_1_h: gpio@fd6d08c0 {
+			compatible = "intel,gpio";
+			reg = <0xfd6d08c0 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x2>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <24>;
+			pin-offset = <25>;
+
+			status = "okay";
+		};
+
+		gpio_1_d: gpio@fd6d0a40 {
+			compatible = "intel,gpio";
+			reg = <0xfd6d0a40 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x3>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <20>;
+			pin-offset = <49>;
+
+			status = "okay";
+		};
+
+		gpio_4_c: gpio@fd6a0700 {
+			compatible = "intel,gpio";
+			reg = <0xfd6a0700 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <8>;
+			pin-offset = <0>;
+
+			status = "okay";
+		};
+
+		gpio_4_f: gpio@fd6a0880 {
+			compatible = "intel,gpio";
+			reg = <0xfd6a0880 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x1>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <24>;
+			pin-offset = <24>;
+
+			status = "okay";
+		};
+
+		gpio_4_e: gpio@fd6a0a70 {
+			compatible = "intel,gpio";
+			reg = <0xfd6a0a70 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x3>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <24>;
+			pin-offset = <57>;
+
+			status = "okay";
+		};
+
+		gpio_5_r: gpio@fd690700 {
+			compatible = "intel,gpio";
+			reg = <0xfd690700 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <8>;
+			pin-offset = <0>;
+
+			status = "okay";
+		};
+	};
+};
+
+&pcie0 {
+	emmc: emmc0 {
+		compatible = "intel,emmc-host";
+		vendor-id = <0x8086>;
+		device-id = <0x54C4>;
+		interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+		interrupt-parent = <&intc>;
+
+		max-bus-freq = <200000000>;
+		min-bus-freq = <400000>;
+		power-delay-ms = <500>;
+		mmc-hs400-1_8v;
+		mmc-hs200-1_8v;
+
+		mmc {
+			compatible = "zephyr,mmc-disk";
+			bus-width = <8>;
+			status = "okay";
+		};
+
+		status = "okay";
+	};
+};
+
+&smbus0 {
+	vendor-id = <0x8086>;
+	device-id = <0x54a3>;
+
+	status = "okay";
+};
+
+&uart0 {
+	vendor-id = <0x8086>;
+	device-id = <0x54a8>;
+
+	status = "disabled";
+};
+
+&uart1 {
+	vendor-id = <0x8086>;
+	device-id = <0x54A9>;
+
+	status = "disabled";
+};
+
+&uart2 {
+	vendor-id = <0x8086>;
+	device-id = <0x54C7>;
+
+	status = "disabled";
+};
+
+&spi0 {
+	vendor-id = <0x8086>;
+	device-id = <0x54aa>;
+	cs-gpios = <&gpio_4_e 10 GPIO_ACTIVE_LOW>;
+
+	status = "okay";
+};
+
+&spi1 {
+	vendor-id = <0x8086>;
+	device-id = <0x54ab>;
+	cs-gpios = <&gpio_4_f 16 GPIO_ACTIVE_LOW>;
+
+	status = "disabled";
+};
+
+&spi2 {
+	vendor-id = <0x8086>;
+	device-id = <0x54fb>;
+	cs-gpios = <&gpio_1_d 9 GPIO_ACTIVE_LOW>;
+
+	status = "disabled";
+};
+
+&i2c0 {
+	vendor-id = <0x8086>;
+	device-id = <0x54e8>;
+
+	status = "okay";
+};
+
+&i2c1 {
+	vendor-id = <0x8086>;
+	device-id = <0x54e9>;
+
+	status = "disabled";
+};
+
+&i2c2 {
+	vendor-id = <0x8086>;
+	device-id = <0x54ea>;
+
+	status = "disabled";
+};
+
+&i2c3 {
+	vendor-id = <0x8086>;
+	device-id = <0x54eb>;
+
+	status = "disabled";
+};
+
+&i2c4 {
+	vendor-id = <0x8086>;
+	device-id = <0x54c5>;
+
+	status = "disabled";
+};
+
+&i2c5 {
+	vendor-id = <0x8086>;
+	device-id = <0x54c6>;
+
+	status = "disabled";
+};
+
+&tgpio {
+	status = "okay";
+};
+
+&vtd {
+	status = "okay";
 };

--- a/boards/x86/intel_adl/intel_adl_rvp.dts
+++ b/boards/x86/intel_adl/intel_adl_rvp.dts
@@ -11,7 +11,11 @@
 	compatible = "intel,alder-lake-rvp";
 
 	chosen {
-		zephyr,console = &uart0_legacy;
-		zephyr,shell-uart = &uart0_legacy;
+		zephyr,console = &uart_legacy_0;
+		zephyr,shell-uart = &uart_legacy_0;
 	};
+};
+
+&uart_legacy_0 {
+	status = "okay";
 };

--- a/boards/x86/intel_ehl/intel_ehl_crb.dts
+++ b/boards/x86/intel_ehl/intel_ehl_crb.dts
@@ -10,7 +10,7 @@
 
 #define DT_DRAM_SIZE		DT_SIZE_M(2048)
 
-#include <intel/elkhart_lake.dtsi>
+#include <intel/x86_64.dtsi>
 
 / {
 	model = "intel_ehl_crb";
@@ -26,4 +26,530 @@
 		watchdog0 = &tco_wdt;
 		rtc = &rtc;
 	};
+
+	ibecc: ibecc {
+	       compatible = "intel,ibecc";
+	       status = "okay";
+	};
+
+	soc {
+		gpio_0_b: gpio@fd6e0700 {
+			compatible = "intel,gpio";
+			reg = <0xfd6e0700 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <24>;
+			pin-offset = <0>;
+
+			status = "okay";
+		};
+
+		gpio_0_t: gpio@fd6e08a0 {
+			compatible = "intel,gpio";
+			reg = <0xfd6e08a0 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x1>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <16>;
+			pin-offset = <26>;
+
+			status = "okay";
+		};
+
+		gpio_0_g: gpio@fd6e09a0 {
+			compatible = "intel,gpio";
+			reg = <0xfd6e09a0 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x2>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <24>;
+			pin-offset = <42>;
+
+			status = "okay";
+		};
+
+		gpio_1_v: gpio@fd6d0700 {
+			compatible = "intel,gpio";
+			reg = <0xfd6d0700 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <16>;
+			pin-offset = <0>;
+
+			status = "okay";
+		};
+
+		gpio_1_h: gpio@fd6d0800 {
+			compatible = "intel,gpio";
+			reg = <0xfd6d0800 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x1>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <24>;
+			pin-offset = <16>;
+
+			status = "okay";
+		};
+
+		gpio_1_d: gpio@fd6d0980 {
+			compatible = "intel,gpio";
+			reg = <0xfd6d0980 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x2>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <20>;
+			pin-offset = <40>;
+
+			status = "okay";
+		};
+
+		gpio_1_u: gpio@fd6d0ad0 {
+			compatible = "intel,gpio";
+			reg = <0xfd6d0ad0 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x3>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <20>;
+			pin-offset = <61>;
+
+			status = "okay";
+		};
+
+		gpio_1_vG: gpio@fd6d0c50 {
+			compatible = "intel,gpio";
+			reg = <0xfd6d0c50 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x4>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <28>;
+			pin-offset = <85>;
+
+			status = "okay";
+		};
+
+		gpio_3_s: gpio@fd6b0810 {
+			compatible = "intel,gpio";
+			reg = <0xfd6b0810 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x1>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <2>;
+			pin-offset = <17>;
+
+			status = "okay";
+		};
+
+		gpio_3_a: gpio@fd6b0830 {
+			compatible = "intel,gpio";
+			reg = <0xfd6b0830 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x2>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <24>;
+			pin-offset = <25>;
+
+			status = "okay";
+		};
+
+		gpio_3_vG: gpio@fd6b09b0 {
+			compatible = "intel,gpio";
+			reg = <0xfd6b09b0 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x3>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <4>;
+			pin-offset = <49>;
+
+			status = "okay";
+		};
+
+		gpio_4_c: gpio@fd6a0700 {
+			compatible = "intel,gpio";
+			reg = <0xfd6a0700 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <24>;
+			pin-offset = <0>;
+
+			status = "okay";
+		};
+
+		gpio_4_f: gpio@fd6a0880 {
+			compatible = "intel,gpio";
+			reg = <0xfd6a0880 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x1>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <24>;
+			pin-offset = <24>;
+
+			status = "okay";
+		};
+
+		gpio_4_e: gpio@fd6a0a70 {
+			compatible = "intel,gpio";
+			reg = <0xfd6a0a70 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x3>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <24>;
+			pin-offset = <57>;
+
+			status = "okay";
+		};
+
+		gpio_5_r: gpio@fd690700 {
+			compatible = "intel,gpio";
+			reg = <0xfd690700 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <8>;
+			pin-offset = <0>;
+
+			status = "okay";
+		};
+	};
+};
+
+&pcie0 {
+	ptm_root0: ptm_root0 {
+		compatible = "ptm-root";
+		vendor-id = <0x8086>;
+		device-id = <0x4b38>;
+
+		status = "okay";
+	};
+
+	uart_pse_0: uart_pse_0 {
+		compatible = "ns16550";
+
+		vendor-id = <0x8086>;
+		device-id = <0x4b96>;
+
+		reg-shift = <2>;
+		clock-frequency = <1843200>;
+		interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+		interrupt-parent = <&intc>;
+
+		status = "disabled";
+		current-speed = <115200>;
+	};
+
+	uart_pse_1: uart_pse_1 {
+		compatible = "ns16550";
+
+		vendor-id = <0x8086>;
+		device-id = <0x4b97>;
+
+		reg-shift = <2>;
+		clock-frequency = <1843200>;
+		interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+		interrupt-parent = <&intc>;
+
+		status = "disabled";
+		current-speed = <115200>;
+	};
+
+	uart_pse_2: uart_pse_2 {
+		compatible = "ns16550";
+
+		vendor-id = <0x8086>;
+		device-id = <0x4b98>;
+
+		reg-shift = <2>;
+		clock-frequency = <1843200>;
+		interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+		interrupt-parent = <&intc>;
+
+		status = "disabled";
+		current-speed = <115200>;
+	};
+
+	uart_pse_3: uart_pse_3 {
+		compatible = "ns16550";
+
+		vendor-id = <0x8086>;
+		device-id = <0x4b99>;
+
+		reg-shift = <2>;
+		clock-frequency = <1843200>;
+		interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+		interrupt-parent = <&intc>;
+
+		status = "disabled";
+		current-speed = <115200>;
+	};
+
+	uart_pse_4: uart_pse_4 {
+		compatible = "ns16550";
+
+		vendor-id = <0x8086>;
+		device-id = <0x4b9a>;
+
+		reg-shift = <2>;
+		clock-frequency = <1843200>;
+		interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+		interrupt-parent = <&intc>;
+
+		status = "disabled";
+		current-speed = <115200>;
+	};
+
+	uart_pse_5: uart_pse_5 {
+		compatible = "ns16550";
+
+		vendor-id = <0x8086>;
+		device-id = <0x4b9b>;
+
+		reg-shift = <2>;
+		clock-frequency = <1843200>;
+		interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+		interrupt-parent = <&intc>;
+
+		status = "disabled";
+		current-speed = <115200>;
+	};
+
+	i2c_pse_0: i2c_pse_0 {
+		compatible = "snps,designware-i2c";
+		clock-frequency = <I2C_BITRATE_STANDARD>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		vendor-id = <0x8086>;
+		device-id = <0x4bb9>;
+		interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+		interrupt-parent = <&intc>;
+
+		status = "okay";
+	};
+
+	i2c_pse_1: i2c_pse_1 {
+		compatible = "snps,designware-i2c";
+		clock-frequency = <I2C_BITRATE_STANDARD>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		vendor-id = <0x8086>;
+		device-id = <0x4bba>;
+		interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+		interrupt-parent = <&intc>;
+
+		status = "okay";
+	};
+
+	i2c_pse_2: i2c_pse_2 {
+		compatible = "snps,designware-i2c";
+		clock-frequency = <I2C_BITRATE_STANDARD>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		vendor-id = <0x8086>;
+		device-id = <0x4bbb>;
+		interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+		interrupt-parent = <&intc>;
+
+		status = "okay";
+	};
+
+	i2c_pse_3: i2c_pse_3 {
+		compatible = "snps,designware-i2c";
+		clock-frequency = <I2C_BITRATE_STANDARD>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		vendor-id = <0x8086>;
+		device-id = <0x4bbc>;
+		interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+		interrupt-parent = <&intc>;
+
+		status = "okay";
+	};
+
+	i2c_pse_4: i2c_pse_4 {
+		compatible = "snps,designware-i2c";
+		clock-frequency = <I2C_BITRATE_STANDARD>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		vendor-id = <0x8086>;
+		device-id = <0x4bbd>;
+		interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+		interrupt-parent = <&intc>;
+
+		status = "okay";
+	};
+
+	i2c_pse_5: i2c_pse_5 {
+		compatible = "snps,designware-i2c";
+		clock-frequency = <I2C_BITRATE_STANDARD>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		vendor-id = <0x8086>;
+		device-id = <0x4bbe>;
+		interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+		interrupt-parent = <&intc>;
+
+		status = "okay";
+	};
+
+	i2c_pse_6: i2c_pse_6 {
+		compatible = "snps,designware-i2c";
+		clock-frequency = <I2C_BITRATE_STANDARD>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		vendor-id = <0x8086>;
+		device-id = <0x4bbf>;
+		interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+		interrupt-parent = <&intc>;
+
+		status = "okay";
+	};
+};
+
+&uart0 {
+	vendor-id = <0x8086>;
+	device-id = <0x4b28>;
+
+	status = "okay";
+};
+
+&uart1 {
+	vendor-id = <0x8086>;
+	device-id = <0x4b29>;
+
+	status = "okay";
+};
+
+&uart2 {
+	vendor-id = <0x8086>;
+	device-id = <0x4b4d>;
+
+	status = "okay";
+};
+
+&smbus0 {
+	vendor-id = <0x8086>;
+	device-id = <0x4b23>;
+
+	status = "okay";
+};
+
+&i2c0 {
+	vendor-id = <0x8086>;
+	device-id = <0x4b78>;
+
+	status = "okay";
+};
+
+&i2c1 {
+	vendor-id = <0x8086>;
+	device-id = <0x4b79>;
+
+	status = "okay";
+};
+
+&i2c2 {
+	vendor-id = <0x8086>;
+	device-id = <0x4b7a>;
+
+	status = "okay";
+};
+
+&i2c3 {
+	vendor-id = <0x8086>;
+	device-id = <0x4b7b>;
+
+	status = "okay";
+};
+
+&i2c4 {
+	vendor-id = <0x8086>;
+	device-id = <0x4b4b>;
+
+	status = "okay";
+};
+
+&i2c5 {
+	vendor-id = <0x8086>;
+	device-id = <0x4b4c>;
+
+	status = "okay";
+};
+
+&i2c6 {
+	vendor-id = <0x8086>;
+	device-id = <0x4b44>;
+
+	status = "okay";
+};
+
+&i2c7 {
+	vendor-id = <0x8086>;
+	device-id = <0x4b45>;
+
+	status = "okay";
+};
+
+&vtd {
+	status = "okay";
 };

--- a/boards/x86/intel_rpl/intel_rpl_p_crb.dts
+++ b/boards/x86/intel_rpl/intel_rpl_p_crb.dts
@@ -9,7 +9,7 @@
 
 #define DT_DRAM_SIZE		DT_SIZE_M(2048)
 
-#include <intel/raptor_lake_p.dtsi>
+#include <intel/x86_64.dtsi>
 
 / {
 	model = "intel_rpl_p_crb";
@@ -25,4 +25,302 @@
 		watchdog0 = &tco_wdt;
 		rtc = &rtc;
 	};
+
+	soc {
+		pwm0: pwm0@fd6d0000 {
+			compatible = "intel,blinky-pwm";
+			reg = <0xfd6d0000 0x400>;
+			reg-offset = <0x204>;
+			clock-frequency = <32768>;
+			max-pins = <1>;
+			#pwm-cells = <2>;
+
+			status = "okay";
+		};
+
+		gpio_0_b: gpio@fd6e0700 {
+			compatible = "intel,gpio";
+			reg = <0xfd6e0700 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <24>;
+			pin-offset = <0>;
+
+			status = "okay";
+		};
+
+		gpio_0_t: gpio@fd6e08a0 {
+			compatible = "intel,gpio";
+			reg = <0xfd6e08a0 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x1>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <4>;
+			pin-offset = <25>;
+
+			status = "okay";
+		};
+
+		gpio_0_a: gpio@fd6e09a0 {
+			compatible = "intel,gpio";
+			reg = <0xfd6e09a0 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x2>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <24>;
+			pin-offset = <41>;
+
+			status = "okay";
+		};
+
+		gpio_1_s: gpio@fd6d0700 {
+			compatible = "intel,gpio";
+			reg = <0xfd6d0700 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <8>;
+			pin-offset = <0>;
+
+			status = "okay";
+		};
+
+		gpio_1_h: gpio@fd6d0780 {
+			compatible = "intel,gpio";
+			reg = <0xfd6d0780 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x1>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <24>;
+			pin-offset = <8>;
+
+			status = "okay";
+		};
+
+
+		gpio_1_d: gpio@fd6d0900 {
+			compatible = "intel,gpio";
+			reg = <0xfd6d0900 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x2>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <20>;
+			pin-offset = <25>;
+
+			status = "okay";
+		};
+
+		gpio_2_gpd: gpio@fd6c0700 {
+			compatible = "intel,gpio";
+			reg = <0xfd6c0700 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <12>;
+			pin-offset = <0>;
+
+			status = "okay";
+		};
+
+		gpio_4_c: gpio@fd6a0700 {
+			compatible = "intel,gpio";
+			reg = <0xfd6a0700 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <24>;
+			pin-offset = <0>;
+
+			status = "okay";
+		};
+
+		gpio_4_f: gpio@fd6a0880 {
+			compatible = "intel,gpio";
+			reg = <0xfd6a0880 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x1>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <24>;
+			pin-offset = <24>;
+
+			status = "okay";
+		};
+
+		gpio_4_e: gpio@fd6a0a70 {
+			compatible = "intel,gpio";
+			reg = <0xfd6a0a70 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x3>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <24>;
+			pin-offset = <57>;
+
+			status = "okay";
+		};
+
+		gpio_5_r: gpio@fd690700 {
+			compatible = "intel,gpio";
+			reg = <0xfd690700 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <8>;
+			pin-offset = <0>;
+
+			status = "okay";
+		};
+	};
+};
+
+&smbus0 {
+	vendor-id = <0x8086>;
+	device-id = <0x51a3>;
+
+	status = "okay";
+};
+
+&uart0 {
+	vendor-id = <0x8086>;
+	device-id = <0x51a8>;
+
+	status = "okay";
+};
+
+&uart1 {
+	vendor-id = <0x8086>;
+	device-id = <0x51A9>;
+
+	status = "disabled";
+};
+
+&spi0 {
+	vendor-id = <0x8086>;
+	device-id = <0x51aa>;
+
+	cs-gpios = <&gpio_4_e 10 GPIO_ACTIVE_LOW>;
+
+	status = "okay";
+};
+
+&spi1 {
+	vendor-id = <0x8086>;
+	device-id = <0x51ab>;
+
+	cs-gpios = <&gpio_4_f 16 GPIO_ACTIVE_LOW>;
+
+	status = "disabled";
+};
+
+&spi2 {
+	vendor-id = <0x8086>;
+	device-id = <0x51fb>;
+
+	cs-gpios = <&gpio_1_d 9 GPIO_ACTIVE_LOW>;
+
+	status = "disabled";
+};
+
+&i2c0 {
+	vendor-id = <0x8086>;
+	device-id = <0x51e8>;
+
+	status = "okay";
+};
+
+&i2c1 {
+	vendor-id = <0x8086>;
+	device-id = <0x51e9>;
+
+	status = "okay";
+};
+
+&i2c2 {
+	vendor-id = <0x8086>;
+	device-id = <0x51ea>;
+
+	status = "disabled";
+};
+
+&i2c3 {
+	vendor-id = <0x8086>;
+	device-id = <0x51eb>;
+
+	status = "disabled";
+};
+
+&i2c4 {
+	vendor-id = <0x8086>;
+	device-id = <0x51c5>;
+
+	status = "disabled";
+};
+
+&i2c5 {
+	vendor-id = <0x8086>;
+	device-id = <0x51c6>;
+
+	status = "disabled";
+};
+
+&i2c6 {
+	vendor-id = <0x8086>;
+	device-id = <0x51d8>;
+
+	status = "disabled";
+};
+
+&i2c7 {
+	vendor-id = <0x8086>;
+	device-id = <0x51d9>;
+
+	status = "disabled";
+};
+
+&tgpio {
+	status = "okay";
 };

--- a/boards/x86/intel_rpl/intel_rpl_s_crb.dts
+++ b/boards/x86/intel_rpl/intel_rpl_s_crb.dts
@@ -9,7 +9,7 @@
 
 #define DT_DRAM_SIZE		DT_SIZE_M(2048)
 
-#include <intel/raptor_lake_s.dtsi>
+#include <intel/x86_64.dtsi>
 
 / {
 	model = "intel_rpl_s_crb";
@@ -17,12 +17,413 @@
 
 	chosen {
 		zephyr,sram = &dram0;
-		zephyr,console = &uart_ec_0;
-		zephyr,shell-uart = &uart_ec_0;
+		zephyr,console = &uart_legacy_0;
+		zephyr,shell-uart = &uart_legacy_0;
 	};
 
 	aliases {
 		watchdog0 = &tco_wdt;
 		rtc = &rtc;
 	};
+
+	soc {
+		pwm0: pwm@e06a0000 {
+			compatible = "intel,blinky-pwm";
+			reg = <0xe06a0000 0x400>;
+			reg-offset = <0x304>;
+			clock-frequency = <32768>;
+			max-pins = <1>;
+			#pwm-cells = <2>;
+			status = "okay";
+		};
+
+		gpio_0_i: gpio@e06e0700 {
+			compatible = "intel,gpio";
+			reg = <0xe06e0700 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+			group-index = <0x0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			ngpios = <23>;
+			pin-offset = <0>;
+
+			status = "okay";
+		};
+
+		gpio_0_r: gpio@e06e0890 {
+			compatible = "intel,gpio";
+			reg = <0xe06e0890 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+			group-index = <0x1>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			ngpios = <22>;
+			pin-offset = <26>;
+
+			status = "okay";
+		};
+
+		gpio_0_j: gpio@e06e0a00 {
+			compatible = "intel,gpio";
+			reg = <0xe06e0a00 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+			group-index = <0x2>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			ngpios = <12>;
+			pin-offset = <49>;
+
+			status = "okay";
+		};
+
+		gpio_1_b: gpio@e06d0700 {
+			compatible = "intel,gpio";
+			reg = <0xe06d0700 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+			group-index = <0x0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			ngpios = <24>;
+			pin-offset = <0>;
+
+			status = "okay";
+		};
+
+		gpio_1_g: gpio@e06d0880 {
+			compatible = "intel,gpio";
+			reg = <0xe06d0880 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+			group-index = <0x1>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			ngpios = <8>;
+			pin-offset = <24>;
+
+			status = "okay";
+		};
+
+		gpio_1_h: gpio@e06d0900 {
+			compatible = "intel,gpio";
+			reg = <0xe06d0900 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+			group-index = <0x2>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			ngpios = <24>;
+			pin-offset = <32>;
+
+			status = "okay";
+		};
+
+		gpio_3_a: gpio@e06b0790 {
+			compatible = "intel,gpio";
+			reg = <0xe06b0790 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+			group-index = <0x1>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			ngpios = <15>;
+			pin-offset = <9>;
+
+			status = "okay";
+		};
+
+		gpio_3_c: gpio@e06b0890 {
+			compatible = "intel,gpio";
+			reg = <0xe06b0890 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+			group-index = <0x2>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			ngpios = <24>;
+			pin-offset = <25>;
+
+			status = "okay";
+		};
+
+		gpio_4_s: gpio@e06a0700 {
+			compatible = "intel,gpio";
+			reg = <0xe06a0700 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+			group-index = <0x0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			ngpios = <8>;
+			pin-offset = <0>;
+
+			status = "okay";
+		};
+
+		gpio_4_e: gpio@e06a0780 {
+			compatible = "intel,gpio";
+			reg = <0xe06a0780 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+			group-index = <0x1>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			ngpios = <22>;
+			pin-offset = <8>;
+
+			status = "okay";
+		};
+
+		gpio_4_k: gpio@e06a08f0 {
+			compatible = "intel,gpio";
+			reg = <0xe06a08f0 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+			group-index = <0x2>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			ngpios = <12>;
+			pin-offset = <25>;
+
+			status = "okay";
+		};
+
+		gpio_4_f: gpio@e06a09e0 {
+			compatible = "intel,gpio";
+			reg = <0xe06a09e0 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+			group-index = <0x3>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			ngpios = <24>;
+			pin-offset = <41>;
+
+			status = "okay";
+		};
+
+		gpio_5_d: gpio@e0690700 {
+			compatible = "intel,gpio";
+			reg = <0xe0690700 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+			group-index = <0x0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			ngpios = <24>;
+			pin-offset = <0>;
+
+			status = "okay";
+		};
+	};
+};
+
+&uart_legacy_0 {
+	status = "okay";
+};
+
+&smbus0 {
+	vendor-id = <0x8086>;
+	device-id = <0x7a23>;
+
+	status = "okay";
+};
+
+&pcie0 {
+	i2c0_dma: i2c0_dma {
+		compatible = "intel,lpss";
+		#dma-cells = <1>;
+		status = "okay";
+	};
+
+	i2c1_dma: i2c1_dma {
+		compatible = "intel,lpss";
+		#dma-cells = <1>;
+		status = "disabled";
+	};
+
+	i2c2_dma: i2c2_dma {
+		compatible = "intel,lpss";
+		#dma-cells = <1>;
+		status = "disabled";
+	};
+
+	i2c3_dma: i2c3_dma {
+		compatible = "intel,lpss";
+		#dma-cells = <1>;
+		status = "disabled";
+	};
+
+	i2c4_dma: i2c4_dma {
+		compatible = "intel,lpss";
+		#dma-cells = <1>;
+		status = "disabled";
+	};
+
+	i2c5_dma: i2c5_dma {
+		compatible = "intel,lpss";
+		#dma-cells = <1>;
+		status = "disabled";
+	};
+
+	i2c6_dma: i2c6_dma {
+		compatible = "intel,lpss";
+		#dma-cells = <1>;
+		status = "disabled";
+	};
+
+	i2c7_dma: i2c7_dma {
+		compatible = "intel,lpss";
+		#dma-cells = <1>;
+		status = "disabled";
+	};
+
+	uart0_dma: uart0_dma {
+		compatible = "intel,lpss";
+		#dma-cells = <1>;
+		status = "disabled";
+	};
+
+	uart1_dma: uart1_dma {
+		compatible = "intel,lpss";
+		#dma-cells = <1>;
+		status = "disabled";
+	};
+};
+
+&i2c0 {
+	vendor-id = <0x8086>;
+	device-id = <0x7acc>;
+
+	dmas = <&i2c0_dma 0>;
+
+	status = "okay";
+};
+
+&i2c1 {
+	vendor-id = <0x8086>;
+	device-id = <0x7acd>;
+
+	dmas = <&i2c1_dma 0>;
+
+	status = "disabled";
+};
+
+&i2c2 {
+	vendor-id = <0x8086>;
+	device-id = <0x7ace>;
+
+	dmas = <&i2c2_dma 0>;
+
+	status = "disabled";
+};
+
+&i2c3 {
+	vendor-id = <0x8086>;
+	device-id = <0x7acf>;
+
+	dmas = <&i2c3_dma 0>;
+
+	status = "disabled";
+};
+
+&i2c4 {
+	vendor-id = <0x8086>;
+	device-id = <0x7afc>;
+
+	dmas = <&i2c4_dma 0>;
+
+	status = "disabled";
+};
+
+&i2c5 {
+	vendor-id = <0x8086>;
+	device-id = <0x7afd>;
+
+	dmas = <&i2c5_dma 0>;
+
+	status = "disabled";
+};
+
+&i2c6 {
+	vendor-id = <0x8086>;
+	device-id = <0x7ada>;
+
+	dmas = <&i2c6_dma 0>;
+
+	status = "disabled";
+};
+
+&i2c7 {
+	vendor-id = <0x8086>;
+	device-id = <0x7adb>;
+
+	dmas = <&i2c7_dma 0>;
+
+	status = "disabled";
+};
+
+&uart0 {
+	vendor-id = <0x8086>;
+	device-id = <0x7aa8>;
+
+	dmas = <&uart0_dma 0>, <&uart0_dma 1>;
+	dma-names = "tx", "rx";
+
+	status = "disabled";
+};
+
+&uart1 {
+	vendor-id = <0x8086>;
+	device-id = <0x7aa9>;
+
+	dmas = <&uart1_dma 0>, <&uart1_dma 1>;
+	dma-names = "tx", "rx";
+
+	status = "disabled";
+};
+
+&uart2 {
+	vendor-id = <0x8086>;
+	device-id = <0x7afe>;
+
+	status = "disabled";
+};
+
+&spi0 {
+	vendor-id = <0x8086>;
+	device-id = <0x7aaa>;
+
+	cs-gpios = <&gpio_0_i 15 GPIO_ACTIVE_LOW>;
+
+	status = "okay";
+};
+
+&spi1 {
+	vendor-id = <0x8086>;
+	device-id = <0x7aab>;
+
+	cs-gpios = <&gpio_0_i 19 GPIO_ACTIVE_LOW>;
+
+	status = "disabled";
+};
+
+&spi2 {
+	vendor-id = <0x8086>;
+	device-id = <0x7afb>;
+
+	cs-gpios = <&gpio_0_r 12 GPIO_ACTIVE_LOW>;
+
+	status = "disabled";
+};
+
+&vtd {
+	status = "okay";
+};
+
+&tgpio {
+	status = "okay";
 };

--- a/dts/x86/intel/x86_64.dtsi
+++ b/dts/x86/intel/x86_64.dtsi
@@ -1,0 +1,287 @@
+/*
+ * Copyright (c) 2023 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "skeleton.dtsi"
+#include <zephyr/dt-bindings/interrupt-controller/intel-ioapic.h>
+#include <zephyr/dt-bindings/pcie/pcie.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+
+/ {
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu@0 {
+			compatible = "intel,x86_64";
+			device_type = "cpu";
+			d-cache-line-size = <64>;
+			reg = <0>;
+		};
+	};
+
+	dram0: memory@0 {
+		device_type = "memory";
+		reg = <0x0 DT_DRAM_SIZE>;
+	};
+
+	intc: ioapic@fec00000  {
+		compatible = "intel,ioapic";
+		#interrupt-cells = <3>;
+		#address-cells = <1>;
+		reg = <0xfec00000 0x1000>;
+		interrupt-controller;
+	};
+
+	intc_loapic: loapic@fee00000  {
+		compatible = "intel,loapic";
+		#interrupt-cells = <3>;
+		#address-cells = <1>;
+		reg = <0xfee00000 0x1000>;
+		interrupt-controller;
+	};
+
+	pcie0: pcie0 {
+		compatible = "intel,pcie";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		smbus0: smbus0 {
+			compatible = "intel,pch-smbus";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			status = "disabled";
+		};
+
+		uart0: uart0 {
+			compatible = "ns16550";
+			reg-shift = <2>;
+			clock-frequency = <1843200>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+			current-speed = <115200>;
+
+			status = "disabled";
+		};
+
+		uart1: uart1 {
+			compatible = "ns16550";
+			reg-shift = <2>;
+			clock-frequency = <1843200>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+			current-speed = <115200>;
+
+			status = "disabled";
+		};
+
+		uart2: uart2 {
+			compatible = "ns16550";
+			reg-shift = <2>;
+			clock-frequency = <1843200>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+			current-speed = <115200>;
+
+			status = "disabled";
+		};
+
+		spi0: spi0 {
+			compatible = "intel,penwell-spi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			pw,cs-mode = <0>;
+			pw,cs-output = <0>;
+			pw,fifo-depth = <64>;
+			clock-frequency = <100000000>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			status = "disabled";
+		};
+
+		spi1: spi1 {
+			compatible = "intel,penwell-spi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			pw,cs-mode = <0>;
+			pw,cs-output = <0>;
+			pw,fifo-depth = <64>;
+			clock-frequency = <100000000>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			status = "disabled";
+		};
+
+		spi2: spi2 {
+			compatible = "intel,penwell-spi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			pw,cs-mode = <0>;
+			pw,cs-output = <0>;
+			pw,fifo-depth = <64>;
+			clock-frequency = <100000000>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			status = "disabled";
+		};
+
+		i2c0: i2c0 {
+			compatible = "snps,designware-i2c";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			status = "disabled";
+		};
+
+		i2c1: i2c1 {
+			compatible = "snps,designware-i2c";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			status = "disabled";
+		};
+
+		i2c2: i2c2 {
+			compatible = "snps,designware-i2c";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			status = "disabled";
+		};
+
+		i2c3: i2c3 {
+			compatible = "snps,designware-i2c";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			status = "disabled";
+		};
+
+		i2c4: i2c4 {
+			compatible = "snps,designware-i2c";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			status = "disabled";
+		};
+
+		i2c5: i2c5 {
+			compatible = "snps,designware-i2c";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			status = "disabled";
+		};
+
+		i2c6: i2c6 {
+			compatible = "snps,designware-i2c";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			status = "disabled";
+		};
+
+		i2c7: i2c7 {
+			compatible = "snps,designware-i2c";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			status = "disabled";
+		};
+	};
+
+	soc {
+		compatible = "simple-bus";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		vtd: vtd@fed91000 {
+			compatible = "intel,vt-d";
+			reg = <0xfed91000 0x1000>;
+
+			status = "disabled";
+		};
+
+		uart_legacy_0: uart@3f8 {
+			compatible = "ns16550";
+			reg = <0x000003f8 0x100>;
+			io-mapped;
+			clock-frequency = <1843200>;
+			interrupts = <4 IRQ_TYPE_LOWEST_EDGE_RISING 3>;
+			interrupt-parent = <&intc>;
+			reg-shift = <0>;
+			io-mapped;
+
+			status = "disabled";
+		};
+
+		tgpio: tgpio@fe001200 {
+			compatible = "intel,timeaware-gpio";
+			reg = <0xfe001200 0x100>;
+			timer-clock = <19200000>;
+			max-pins = <2>;
+
+			status = "disabled";
+		};
+
+		rtc: counter: rtc@70 {
+			compatible = "motorola,mc146818";
+			reg = <0x70 0x0D 0x71 0x0D>;
+			interrupts = <8 IRQ_TYPE_LOWEST_EDGE_RISING 3>;
+			interrupt-parent = <&intc>;
+			alarms-count = <1>;
+
+			status = "okay";
+		};
+
+		hpet: hpet@fed00000 {
+			compatible = "intel,hpet";
+			reg = <0xfed00000 0x400>;
+			interrupts = <2 IRQ_TYPE_FIXED_EDGE_RISING 4>;
+			interrupt-parent = <&intc>;
+
+			status = "okay";
+		};
+
+		tco_wdt: tco_wdt@400 {
+			compatible = "intel,tco-wdt";
+			reg = <0x0400 0x20>;
+
+			status = "disabled";
+		};
+	};
+};


### PR DESCRIPTION
Create generic Intel device tree and reuse as much as possible in different Intel boards.