### PR TITLE
drivers: pinctrl: pfc_rcar: add support of voltage control to pfc driver

### DIFF
--- a/drivers/pinctrl/Kconfig.rcar
+++ b/drivers/pinctrl/Kconfig.rcar
@@ -7,3 +7,8 @@ config PINCTRL_RCAR_PFC
 	depends on DT_HAS_RENESAS_RCAR_PFC_ENABLED
 	help
 	  Enable pin controller driver for Renesas RCar SoC
+
+config PINCTRL_RCAR_VOLTAGE_CONTROL
+	bool "Voltage control functionality of Renesas R-Car PFC driver"
+	default y if SOC_SERIES_RCAR_GEN3
+	depends on PINCTRL_RCAR_PFC

--- a/dts/bindings/pinctrl/renesas,rcar-pfc.yaml
+++ b/dts/bindings/pinctrl/renesas,rcar-pfc.yaml
@@ -51,6 +51,7 @@ description: |
     - bias-pull-down
     - bias-pull-up
     - drive-strength
+    - power-source
 
     To link pin configurations with a device, use a pinctrl-N property for some
     number N, like this example you could place in your board's DTS file:
@@ -82,6 +83,7 @@ child-binding:
         - bias-pull-down
         - bias-pull-up
         - drive-strength
+        - power-source
 
   properties:
     pin:

--- a/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-rcar-common.h
+++ b/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-rcar-common.h
@@ -72,4 +72,8 @@
 #define IP2SR5(shift, func) IPnSR(2, 5, shift, func)
 #define IP3SR5(shift, func) IPnSR(3, 5, shift, func)
 
+#define PIN_VOLTAGE_NONE 0
+#define PIN_VOLTAGE_1P8V 1
+#define PIN_VOLTAGE_3P3V 2
+
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_RENESAS_PINCTRL_RCAR_COMMON_H_ */

--- a/soc/arm/renesas_rcar/common/pinctrl_rcar.h
+++ b/soc/arm/renesas_rcar/common/pinctrl_rcar.h
@@ -38,6 +38,7 @@ typedef struct pinctrl_soc_pin {
 	struct rcar_pin_func func;
 	uint8_t flags;
 	uint8_t drive_strength;
+	uint8_t voltage;
 } pinctrl_soc_pin_t;
 
 #define RCAR_IPSR(node_id) DT_PROP_BY_IDX(node_id, pin, 1)
@@ -66,6 +67,10 @@ typedef struct pinctrl_soc_pin {
 		.drive_strength =					       \
 			COND_CODE_1(DT_NODE_HAS_PROP(node_id, drive_strength), \
 				    (DT_PROP(node_id, drive_strength)), (0)),  \
+		.voltage = COND_CODE_1(DT_NODE_HAS_PROP(node_id,	       \
+							power_source),	       \
+				       (DT_PROP(node_id, power_source)),       \
+				       (PIN_VOLTAGE_NONE)),		       \
 	},
 
 /**

--- a/soc/arm64/renesas_rcar/gen3/pinctrl_soc.h
+++ b/soc/arm64/renesas_rcar/gen3/pinctrl_soc.h
@@ -37,6 +37,7 @@ typedef struct pinctrl_soc_pin {
 	struct rcar_pin_func func;
 	uint8_t flags;
 	uint8_t drive_strength;
+	uint8_t voltage;
 } pinctrl_soc_pin_t;
 
 #define RCAR_IPSR(node_id) DT_PROP_BY_IDX(node_id, pin, 1)
@@ -65,6 +66,10 @@ typedef struct pinctrl_soc_pin {
 		.drive_strength =					       \
 			COND_CODE_1(DT_NODE_HAS_PROP(node_id, drive_strength), \
 				    (DT_PROP(node_id, drive_strength)), (0)),  \
+		.voltage = COND_CODE_1(DT_NODE_HAS_PROP(node_id,	       \
+							power_source),	       \
+				       (DT_PROP(node_id, power_source)),       \
+				       (PIN_VOLTAGE_NONE)),		       \
 	},
 
 /**


### PR DESCRIPTION
Add support of voltage control to Renesas PFC driver. Voltage register mappings have been added to r8a77951 and r8a77961 SoCs.

Allow 'power-source' property for 'renesas,rcar-pfc' node. This property will be used for configuring IO voltage on appropriate pin. For now it is possible to have only two voltages: 1.8 and 3.3.

Note: it is possible to change voltage only for SD/MMC pins on r8a77951 and r8a77961 SoCs.