### PR TITLE
drivers: pcie: Remove magic number and cleanup

### DIFF
--- a/drivers/pcie/host/pcie.c
+++ b/drivers/pcie/host/pcie.c
@@ -126,7 +126,7 @@ static bool pcie_get_bar(pcie_bdf_t bdf,
 			 bool io)
 {
 	uint32_t reg = bar_index + PCIE_CONF_BAR0;
-	uint32_t cmd_reg = pcie_conf_read(bdf, PCIE_CONF_CMDSTAT);
+	uint32_t cmd_reg;
 	bool ret = false;
 #ifdef CONFIG_PCIE_CONTROLLER
 	const struct device *dev;
@@ -157,6 +157,8 @@ static bool pcie_get_bar(pcie_bdf_t bdf,
 		/* Discard on invalid flags */
 		return false;
 	}
+
+	cmd_reg = pcie_conf_read(bdf, PCIE_CONF_CMDSTAT);
 
 	/* IO/memory decode should be disabled before sizing/update BAR. */
 	pcie_conf_write(bdf, PCIE_CONF_CMDSTAT,

--- a/drivers/pcie/host/pcie.c
+++ b/drivers/pcie/host/pcie.c
@@ -159,7 +159,8 @@ static bool pcie_get_bar(pcie_bdf_t bdf,
 	}
 
 	/* IO/memory decode should be disabled before sizing/update BAR. */
-	pcie_conf_write(bdf, PCIE_CONF_CMDSTAT, cmd_reg & (~0x3));
+	pcie_conf_write(bdf, PCIE_CONF_CMDSTAT,
+			cmd_reg & (~(PCIE_CONF_CMDSTAT_IO | PCIE_CONF_CMDSTAT_MEM)));
 
 	pcie_conf_write(bdf, reg, 0xFFFFFFFFU);
 	size = pcie_conf_read(bdf, reg);


### PR DESCRIPTION
 - Use definitions instead of magic numbers.
 - Cleanup code to move reading register before actual usage