### PR TITLE
net: lib: mdns_responder: Fix interface count check

### DIFF
--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -663,7 +663,7 @@ static int init_listener(void)
 	    (iface_count > MAX_IPV4_IFACE_COUNT && MAX_IPV4_IFACE_COUNT > 0)) {
 		NET_WARN("You have %d interfaces configured but there "
 			 "are %d network interfaces in the system.",
-			 MAX(MAX_IPV6_IFACE_COUNT,
+			 MAX(MAX_IPV4_IFACE_COUNT,
 			     MAX_IPV6_IFACE_COUNT), iface_count);
 	}
 


### PR DESCRIPTION
The original idea was to check that we have enough network interfaces in the system. The check needs to verify max IPv4 and IPv6 supported interfaces instead of always checking IPv6 one.

Fixes: #66843
Coverity-CID: 334899