### PR TITLE
net: lib: sockets: Initialize iovec to 0 at start of func

### DIFF
--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -1544,15 +1544,13 @@ static ssize_t zsock_recv_stream_timed(struct net_context *ctx, struct msghdr *m
 {
 	int res;
 	k_timepoint_t end;
-	size_t recv_len = 0, iovec, available_len, max_iovlen = 0;
+	size_t recv_len = 0, iovec = 0, available_len, max_iovlen = 0;
 	const bool waitall = (flags & ZSOCK_MSG_WAITALL) == ZSOCK_MSG_WAITALL;
 
 	if (msg != NULL && buf == NULL) {
 		if (msg->msg_iovlen < 1) {
 			return -EINVAL;
 		}
-
-		iovec = 0;
 
 		buf = msg->msg_iov[iovec].iov_base;
 		available_len = msg->msg_iov[iovec].iov_len;


### PR DESCRIPTION
Make sure iovec is initialized to a value so that there is no possibility that it is accessed uninitialized.

Fixes: #66838
Coverity-CID: 334911