### PR TITLE
cmake: zephyr_linker_sources: Link each file only once

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -1158,6 +1158,8 @@ endfunction(zephyr_check_compiler_flag_hardcoded)
 #    copied/included verbatim into the given <location> in the global linker.ld.
 #    Preprocessor directives work inside <files>. Relative paths are resolved
 #    relative to the calling file, like zephyr_sources().
+#    Subsequent calls to zephyr_linker_sources with the same file(s) will remove
+#    these from the original location. Only the last call is considered.
 # <location> is one of
 #    NOINIT        Inside the noinit output section.
 #    RWDATA        Inside the data output section.
@@ -1294,6 +1296,16 @@ function(zephyr_linker_sources location)
 
     # Create strings to be written into the file
     set (include_str "/* Sort key: \"${SORT_KEY}\" */#include \"${relpath}\"")
+
+    # Remove line from other snippet file, if already used
+    get_property(old_path GLOBAL PROPERTY "snippet_files_used_${relpath}")
+    if (DEFINED old_path)
+      file(STRINGS ${old_path} lines)
+      list(FILTER lines EXCLUDE REGEX ${relpath})
+      string(REPLACE ";" "\n;" lines "${lines}") # Add newline to each line.
+      file(WRITE ${old_path} ${lines} "\n")
+    endif()
+    set_property(GLOBAL PROPERTY "snippet_files_used_${relpath}" ${snippet_path})
 
     # Add new line to existing lines, sort them, and write them back.
     file(STRINGS ${snippet_path} lines) # Get current lines (without newlines).


### PR DESCRIPTION
If an ld file is included multiple times using `zephyr_linker_sources`, only the last occurrence is actually used. Everything else is removed again from the generated snippet files.

This allows to relocate certain blocks, e.g. the vector table, in an application-specific CMakeLists.txt (or for an arch or soc), thereby solving my problem statet in #66315.

I think, this would also make  `CONFIG_SOC_IT8XXX2_EXCEPTIONS_IN_RAM `  introduced in ab2515ad267a2caac70ed19f79ab3d1967d95251 obsolete.

closes #66315