### PR TITLE
clock_control: stm32f4: add PLLR division factor

### DIFF
--- a/drivers/clock_control/clock_stm32f2_f4_f7.c
+++ b/drivers/clock_control/clock_stm32f2_f4_f7.c
@@ -56,6 +56,9 @@ uint32_t get_pllsrc_frequency(void)
 __unused
 void config_pll_sysclock(void)
 {
+#if defined(STM32_SRC_PLL_R) && STM32_PLL_R_ENABLED && defined(RCC_PLLCFGR_PLLR)
+	MODIFY_REG(RCC->PLLCFGR, RCC_PLLCFGR_PLLR, pllr(STM32_PLL_R_DIVISOR));
+#endif
 	LL_RCC_PLL_ConfigDomain_SYS(get_pll_source(),
 				    pllm(STM32_PLL_M_DIVISOR),
 				    STM32_PLL_N_MULTIPLIER,

--- a/dts/bindings/clock/st,stm32f4-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32f4-pll-clock.yaml
@@ -61,3 +61,10 @@ properties:
         Main PLL (PLL) division factor for USB OTG FS, SDMMC and random number
         generator clocks.
         Valid range: 2 - 15
+
+  div-r:
+    type: int
+    description: |
+        Main PLL (PLL) division factor for I2S and DFSDM
+        generator clocks.
+        Valid range: 2 - 7


### PR DESCRIPTION
Some STM32F4xx chips have an R division factor in PLL. Add possibility to configure that.

Even though the output from the R division is not used, it can be increased to reduce power consumption.