### PR TITLE
driver: display: sdl: Fix input together with SDL_DISPLAY_ZOOM_PCT

### DIFF
--- a/drivers/display/display_sdl_bottom.c
+++ b/drivers/display/display_sdl_bottom.c
@@ -29,6 +29,8 @@ int sdl_display_init_bottom(uint16_t height, uint16_t width, uint16_t zoom_pct,
 		return -1;
 	}
 
+	SDL_RenderSetLogicalSize(*renderer, width, height);
+
 	*texture = SDL_CreateTexture(*renderer, SDL_PIXELFORMAT_ARGB8888,
 				     SDL_TEXTUREACCESS_STATIC, width, height);
 	if (*texture == NULL) {


### PR DESCRIPTION
Using SDL_DISPLAY_ZOOM_PCT would cause mouse pointer/touch input to not click at the correct position.

Tested with:
`west build -p -b native_sim -- -DCONFIG_LV_Z_DEMO_MUSIC=y -DCONFIG_SDL_DISPLAY_ZOOM_PCT=200
`

Before you had to press in the painted are to git the play/pause buttom.
![image](https://github.com/zephyrproject-rtos/zephyr/assets/4318648/9a73c048-1afd-4ad6-bd55-78654757999b)

After this PR clicking is working as expected.
`SDL_RenderSetLogicalSize` will adjust the x, y coordinates fed to `input_sdl_touch_bottom.c` according to window size and logic window size.

Reference: https://wiki.libsdl.org/SDL2/SDL_RenderSetLogicalSize

Please give it a try yourself before merging.
Fixes touch and mouse input together with https://github.com/zephyrproject-rtos/zephyr/pull/65556
