### PR TITLE
drivers/pwm: Add driver to support RPM2PWM IP

### DIFF
--- a/drivers/pwm/Kconfig.xec
+++ b/drivers/pwm/Kconfig.xec
@@ -19,3 +19,11 @@ config PWM_BBLED_XEC
 	help
 	  Enable driver to utilize the Microchip XEC Breathing-Blinking LED
 	  as a PWM
+
+config RPM2PWM_XEC
+	bool "Microchip XEC RPM2PWM"
+	default y
+	depends on DT_HAS_MICROCHIP_XEC_RPM2PWM_ENABLED
+	select PINCTRL
+	help
+	  Enable driver to utilize RPM2PWM on the Microchip XEC IP block.

--- a/drivers/pwm/rpm2pwm_mchp_xec.c
+++ b/drivers/pwm/rpm2pwm_mchp_xec.c
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2023 Silicom Connectivity Solutions, Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+#include <errno.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/pwm.h>
+#include <zephyr/drivers/pinctrl.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/logging/log.h>
+
+#include <soc.h>
+
+LOG_MODULE_REGISTER(rpm2pwm_mchp_xec, CONFIG_PWM_LOG_LEVEL);
+
+struct rpm2pwm_regs {
+	volatile uint16_t SETTING;
+	volatile uint16_t CONFIG;
+	volatile uint8_t  DIVIDE;
+	volatile uint8_t  GAIN;
+	volatile uint8_t  SPINUP;
+	volatile uint8_t  STEP;
+	volatile uint8_t  MINDRIVE;
+	volatile uint8_t  VALIDCNT;
+	volatile uint8_t  FAILBAND;
+	volatile uint16_t TARGET;
+	volatile uint16_t TACH;
+	volatile uint8_t  PWMFREQ;
+	volatile uint8_t  STATUS;
+};
+
+struct fan_config {
+	const struct pwm_dt_spec *pwm;
+	uint8_t edges;
+};
+
+struct rpm2pwm_xec_config {
+	struct rpm2pwm_regs *const regs;
+	uint8_t pcr_idx;
+	uint8_t pcr_pos;
+	const struct pinctrl_dev_config *pcfg;
+	const struct fan_config *fan;
+};
+
+struct rpm2pwm_tach_xec_config {
+	struct device * const parent;
+};
+
+struct rpm2pwm_tach_xec_data {
+	uint16_t count;
+};
+
+struct rpm2pwm_xec_data {
+	uint32_t config;
+};
+
+int rpm2pwm_tach_xec_sample_fetch(const struct device *dev, enum sensor_channel chan)
+{
+	ARG_UNUSED(chan);
+
+	const struct rpm2pwm_tach_xec_config * const cfg = dev->config;
+	struct device * const parent = cfg->parent;
+	const struct rpm2pwm_xec_config * const parent_cfg = parent->config;
+	struct rpm2pwm_regs * const regs = parent_cfg->regs;
+
+	struct rpm2pwm_tach_xec_data * const data = dev->data;
+
+	data->count = 3932160 / (regs->TACH >> 3);
+
+	return 0;
+}
+
+static int rpm2pwm_tach_xec_channel_get(const struct device *dev,
+					enum sensor_channel chan,
+					struct sensor_value *val)
+{
+	struct rpm2pwm_tach_xec_data * const data = dev->data;
+
+	if (chan != SENSOR_CHAN_RPM) {
+		return -ENOTSUP;
+	}
+
+	val->val1 = data->count;
+	val->val2 = 0U;
+
+	return 0;
+}
+
+static const struct sensor_driver_api rpm2pwm_tach_xec_driver_api = {
+	.sample_fetch = rpm2pwm_tach_xec_sample_fetch,
+	.channel_get = rpm2pwm_tach_xec_channel_get,
+};
+
+static int rpm2pwm_tach_xec_init(const struct device *dev)
+{
+	const struct rpm2pwm_tach_xec_config *config = dev->config;
+
+	if (!device_is_ready(config->parent))
+		return -ENODEV;
+
+	return 0;
+}
+
+static int rpm2pwm_xec_set_cycles_internal(const struct device *dev, uint32_t channel,
+					   uint32_t period_count, uint32_t pulse_count,
+					   pwm_flags_t flags)
+{
+	const struct rpm2pwm_xec_config * const cfg = dev->config;
+	struct rpm2pwm_regs * const regs = cfg->regs;
+	const struct fan_config * const fan = cfg->fan;
+	uint8_t spinup;
+	uint16_t config;
+
+	spinup = regs->SPINUP;
+
+	/*
+	 * TODO: Figure out DTS flag options that are appropriate:
+	 * if (flags & RPM2PWM_XEC_FLAG_SPIN_NOKICK)
+	 */
+	spinup |= (1 << 5);
+
+	regs->SPINUP |= spinup;
+
+	config = (((fan->edges / 2) - 1) << 3);
+
+	regs->TARGET = (3932160 / pulse_count) << 3;
+
+	regs->CONFIG |= (config | 0x80);
+
+	return 0;
+}
+
+static int rpm2pwm_xec_set_cycles(const struct device *dev, uint32_t channel,
+				  uint32_t period_cycles, uint32_t pulse_cycles,
+				  pwm_flags_t flags)
+{
+	if (channel > 0) {
+		return -EIO;
+	}
+
+	rpm2pwm_xec_set_cycles_internal(dev, channel, period_cycles, pulse_cycles, flags);
+	return 0;
+}
+
+static int rpm2pwm_xec_get_cycles_per_sec(const struct device *dev,
+				      uint32_t channel, uint64_t *cycles)
+{
+	ARG_UNUSED(dev);
+
+	if (channel > 0) {
+		return -EIO;
+	}
+
+	if (cycles) {
+		/* User does not have to know about lowest clock,
+		 * the driver will select the most relevant one.
+		 */
+		*cycles = 32768;
+	}
+
+	return 0;
+}
+
+static const struct pwm_driver_api rpm2pwm_xec_driver_api = {
+	.set_cycles = rpm2pwm_xec_set_cycles,
+	.get_cycles_per_sec = rpm2pwm_xec_get_cycles_per_sec,
+};
+
+static int rpm2pwm_xec_init(const struct device *dev)
+{
+	const struct rpm2pwm_xec_config *const cfg = dev->config;
+	struct rpm2pwm_regs *const regs = cfg->regs;
+
+	int ret = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
+
+	regs->CONFIG &= ~(3 << 5);
+	regs->MINDRIVE = 0x33;
+
+	if (ret != 0) {
+		LOG_ERR("XEC RPM2PWM pinctrl init failed (%d)", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+#define XEC_RPM2PWM_CONFIG(inst)							\
+											\
+	static const struct pwm_dt_spec fan_pwm_##inst =				\
+		PWM_DT_SPEC_GET(DT_CHILD(DT_INST_CHILD(inst, fan), fan));		\
+											\
+	static const struct fan_config fan_##inst##_cfg = {				\
+		.pwm = &fan_pwm_##inst,							\
+		.edges = DT_PROP(DT_CHILD(DT_INST_CHILD(inst, fan), fan), edges),	\
+	};										\
+											\
+	static struct rpm2pwm_xec_config rpm2pwm_xec_config_##inst = {			\
+		.regs = (struct rpm2pwm_regs * const)DT_INST_REG_ADDR(inst),		\
+		.pcr_idx = (uint8_t)DT_INST_PROP_BY_IDX(inst, pcrs, 0),			\
+		.pcr_pos = (uint8_t)DT_INST_PROP_BY_IDX(inst, pcrs, 1),			\
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),				\
+		.fan = &fan_##inst##_cfg,						\
+	};
+
+#define XEC_RPM2PWM_DEVICE_INIT(index)					\
+									\
+	static struct rpm2pwm_xec_data rpm2pwm_xec_data_##index;	\
+									\
+	PINCTRL_DT_INST_DEFINE(index);					\
+									\
+	XEC_RPM2PWM_CONFIG(index);					\
+									\
+	DEVICE_DT_INST_DEFINE(index, &rpm2pwm_xec_init,			\
+			      NULL,					\
+			      &rpm2pwm_xec_data_##index,		\
+			      &rpm2pwm_xec_config_##index, POST_KERNEL,	\
+			      CONFIG_PWM_INIT_PRIORITY,			\
+			      &rpm2pwm_xec_driver_api);
+
+#define DT_DRV_COMPAT microchip_xec_rpm2pwm
+DT_INST_FOREACH_STATUS_OKAY(XEC_RPM2PWM_DEVICE_INIT)
+#undef DT_DRV_COMPAT
+
+#define XEC_RPM2PWM_TACH_CONFIG(inst)							\
+	static struct rpm2pwm_tach_xec_config rpm2pwm_tach_xec_config_##inst = {	\
+	       .parent = (struct device *const)DEVICE_DT_GET(DT_INST_PARENT(inst)),	\
+	};
+
+#define XEC_RPM2PWM_TACH_DEVICE_INIT(index)					\
+	static struct rpm2pwm_tach_xec_data rpm2pwm_tach_xec_data_##index;	\
+										\
+	XEC_RPM2PWM_TACH_CONFIG(index);						\
+										\
+	DEVICE_DT_INST_DEFINE(index, &rpm2pwm_tach_xec_init, NULL,		\
+			      &rpm2pwm_tach_xec_data_##index,			\
+			      &rpm2pwm_tach_xec_config_##index, POST_KERNEL,	\
+			      CONFIG_PWM_INIT_PRIORITY,				\
+			      &rpm2pwm_tach_xec_driver_api);
+
+#define DT_DRV_COMPAT microchip_xec_rpm2pwm_tach
+DT_INST_FOREACH_STATUS_OKAY(XEC_RPM2PWM_TACH_DEVICE_INIT)
+#undef DT_DRV_COMPAT

--- a/dts/arm/microchip/mec172x_common.dtsi
+++ b/dts/arm/microchip/mec172x_common.dtsi
@@ -631,18 +631,30 @@ tach3: tach@40006030 {
 	status = "disabled";
 };
 rpmfan0: rpmfan@4000a000 {
+	compatible = "microchip,xec-rpm2pwm";
 	reg = <0x4000a000 0x80>;
 	interrupts = <74 1>, <75 1>;
 	girqs = <17 20>, <17 21>;
 	pcrs = <3 12>;
 	status = "disabled";
+
+	rpmfantach0: rpmfan_tach0 {
+		compatible = "microchip,xec-prm2pwm-tach";
+		status = "disabled";
+	};
 };
 rpmfan1: rpmfan@4000a080 {
+	compatible = "microchip,xec-rpm2pwm";
 	reg = <0x4000a080 0x80>;
 	interrupts = <76 1>, <77 1>;
 	girqs = <17 22>, <17 23>;
 	pcrs = <4 7>;
 	status = "disabled";
+
+	rpmfantach1: rpmfan_tach1 {
+		compatible = "microchip,xec-prm2pwm-tach";
+		status = "disabled";
+	};
 };
 adc0: adc@40007c00 {
 	compatible = "microchip,xec-adc";

--- a/dts/bindings/pwm/microchip,xec-rpm2pwm-tach.yaml
+++ b/dts/bindings/pwm/microchip,xec-rpm2pwm-tach.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2023, Silicom Connectivity Solutions, Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Microchip XEC RPM2PWM Tach
+
+include: [base.yaml]
+
+compatible: "microchip,xec-rpm2pwm-tach"

--- a/dts/bindings/pwm/microchip,xec-rpm2pwm.yaml
+++ b/dts/bindings/pwm/microchip,xec-rpm2pwm.yaml
@@ -1,0 +1,86 @@
+# Copyright (c) 2023, Silicom Connectivity Solutions, Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+
+  Microchip XEC RPM2PWM
+
+  Microchip's MEC172x series of embedded controllers supports up to 2 closed loop fan controllers.
+  The fan controllers use an input tachometer reading and a target RPM to control the PWM to the
+  fans.  There are multiple fan type configurations to support fans with different numbers of poles
+  in order to read the RPM correctly, as well as options to control the fan ramp up/down and
+  startup spin control.
+
+  This driver is an initial baseline requesting review and comment on the design and feature-set.
+
+  Example DTS board configuration:
+
+  &rpmfan0 {
+          pinctrl-0 = <&gpwm0_gpio53 &gtach_gpio050>;
+          pinctrl-names = "default";
+          status = "okay";
+
+          rpmfantach0: {
+                  status = "okay";
+          }
+
+          fan {
+                  fan0: fan {
+                          pwms = <&rpmfan0 0 PWM_MSEC(30) 0>;
+                          edges = <5>;
+                  };
+          };
+  };
+
+include: [pwm-controller.yaml, base.yaml, pinctrl-device.yaml]
+
+compatible: "microchip,xec-rpm2pwm"
+
+properties:
+  reg:
+    required: true
+
+  pcrs:
+    type: array
+    required: true
+    description: RPM2PWM PCR register index and bit position
+
+  "#pwm-cells":
+    const: 3
+
+  girqs:
+    type: array
+    required: true
+    description: |
+      Array of encoded interrupt information
+
+  pinctrl-0:
+    required: true
+
+  pinctrl-names:
+    required: true
+
+child-binding:
+  child-binding:
+    properties:
+      pwms:
+        required: true
+        type: phandle-array
+        description: |
+          Reference to RPM2PWM instance.
+
+          The period field is ignored, period is fixed in hardware.  Flags
+          should be used to set the desired spin-up and update period etc.
+          of the rpm2pwm fan controller.
+
+      edges:
+        required: true
+        type: int
+        description: |
+          Number of edges on this fan that are needed to count a single
+          revolution.
+
+pwm-cells:
+  - channel
+  - period
+  - flags


### PR DESCRIPTION
The MEC172x series of Embedded Controllers from Microchip includes a block to control up to 2 fans via a closed loop tach rpm to pwm mechanism.  This (proposed) driver adds the basic functionality to support fans using this hardware.