### PR TITLE
ARC: ARCv3: enable HW prefetch and shared cache

### DIFF
--- a/arch/arc/core/reset.S
+++ b/arch/arc/core/reset.S
@@ -151,6 +151,16 @@ done_mpu_regions_reset:
 #endif
 #endif
 
+#ifdef CONFIG_ISA_ARCV3
+	/* Enable HW prefetcher if exist */
+	lr r0, [_ARC_HW_PF_BUILD]
+	breq r0, 0, hw_pf_setup_done
+	lr r1, [_ARC_HW_PF_CTRL]
+	or r1, r1, _ARC_HW_PF_CTRL_ENABLE
+	sr r1, [_ARC_HW_PF_CTRL]
+hw_pf_setup_done:
+#endif
+
 #if defined(CONFIG_SMP) || CONFIG_MP_MAX_NUM_CPUS  > 1
 	_get_cpu_id r0
 	breq r0, 0, _master_core_startup

--- a/boards/arc/nsim/haps_arcv3_init.c
+++ b/boards/arc/nsim/haps_arcv3_init.c
@@ -1,48 +1,23 @@
 /*
- * Copyright (c) 2022 Synopsys
+ * Copyright (c) 2022-2023 Synopsys
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/arch/arc/v2/aux_regs.h>
+#include <zephyr/arch/arc/cluster.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/init.h>
 
-#define ARC_CLN_MST_NOC_0_0_ADDR	292
-#define ARC_CLN_MST_NOC_0_0_SIZE	293
-
-#define ARC_CLN_MST_NOC_0_1_ADDR	2560
-#define ARC_CLN_MST_NOC_0_1_SIZE	2561
-
-#define ARC_CLN_MST_NOC_0_2_ADDR	2562
-#define ARC_CLN_MST_NOC_0_2_SIZE	2563
-
-#define ARC_CLN_MST_NOC_0_3_ADDR	2564
-#define ARC_CLN_MST_NOC_0_3_SIZE	2565
-
-#define ARC_CLN_MST_NOC_0_4_ADDR	2566
-#define ARC_CLN_MST_NOC_0_4_SIZE	2567
-
-#define ARC_CLN_PER0_BASE		2688
-#define ARC_CLN_PER0_SIZE		2689
-
-#define AUX_CLN_ADDR			0x640
-#define AUX_CLN_DATA			0x641
-
+#define DT_SRAM_NODE_ADDR		(DT_REG_ADDR(DT_CHOSEN(zephyr_sram)) / (1024 * 1024))
+#define DT_SRAM_NODE_SIZE		(DT_REG_SIZE(DT_CHOSEN(zephyr_sram)) / (1024 * 1024))
 
 static int haps_arcv3_init(void)
 {
+	arc_cln_write_reg_nolock(ARC_CLN_PER0_BASE, 0xF00);
+	arc_cln_write_reg_nolock(ARC_CLN_PER0_SIZE, 1);
 
-	z_arc_v2_aux_reg_write(AUX_CLN_ADDR, ARC_CLN_PER0_BASE);
-	z_arc_v2_aux_reg_write(AUX_CLN_DATA, 0xF00);
-	z_arc_v2_aux_reg_write(AUX_CLN_ADDR, ARC_CLN_PER0_SIZE);
-	z_arc_v2_aux_reg_write(AUX_CLN_DATA, 1);
-
-	z_arc_v2_aux_reg_write(AUX_CLN_ADDR, ARC_CLN_MST_NOC_0_0_ADDR);
-	z_arc_v2_aux_reg_write(AUX_CLN_DATA, (DT_REG_ADDR(DT_CHOSEN(zephyr_sram)) / (1024 * 1024)));
-	z_arc_v2_aux_reg_write(AUX_CLN_ADDR, ARC_CLN_MST_NOC_0_0_SIZE);
-	z_arc_v2_aux_reg_write(AUX_CLN_DATA, (DT_REG_SIZE(DT_CHOSEN(zephyr_sram)) / (1024 * 1024)));
-
+	arc_cln_write_reg_nolock(ARC_CLN_MST_NOC_0_0_ADDR, DT_SRAM_NODE_ADDR);
+	arc_cln_write_reg_nolock(ARC_CLN_MST_NOC_0_0_SIZE, DT_SRAM_NODE_SIZE);
 
 	return 0;
 }

--- a/include/zephyr/arch/arc/cluster.h
+++ b/include/zephyr/arch/arc/cluster.h
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2023 Synopsys.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief ARC Cluster registers and accessors
+ */
+
+#ifndef ZEPHYR_INCLUDE_ARCH_ARC_CLUSTER_H_
+#define ZEPHYR_INCLUDE_ARCH_ARC_CLUSTER_H_
+
+#include <zephyr/arch/arc/v2/aux_regs.h>
+#include <zephyr/sys/util_macro.h>
+
+/* Cluster AUX */
+#define _ARC_REG_CLN_BCR                        0xcf
+
+#define _ARC_CLNR_ADDR                          0x640 /* CLN address for CLNR_DATA */
+#define _ARC_CLNR_DATA                          0x641 /* CLN data indicated by CLNR_ADDR */
+#define _ARC_CLNR_DATA_NXT                      0x642 /* CLNR_DATA and then CLNR_ADDR++ */
+#define _ARC_CLNR_BCR_0                         0xF61
+#define _ARC_CLNR_BCR_1                         0xF62
+#define _ARC_CLNR_BCR_2                         0xF63
+#define _ARC_CLNR_SCM_BCR_0                     0xF64
+#define _ARC_CLNR_SCM_BCR_1                     0xF65
+
+#define _ARC_REG_CLN_BCR_VER_MAJOR_ARCV3_MIN    32    /* Minimal version of cluster in ARCv3 */
+#define _ARC_CLN_BCR_VER_MAJOR_MASK             0xff
+#define _ARC_CLNR_BCR_0_HAS_SCM                 BIT(29)
+
+/* Cluster registers (not in the AUX address space - indirect access via CLNR_ADDR + CLNR_DATA) */
+#define ARC_CLN_MST_NOC_0_BCR                   0
+#define ARC_CLN_MST_NOC_1_BCR                   1
+#define ARC_CLN_MST_NOC_2_BCR                   2
+#define ARC_CLN_MST_NOC_3_BCR                   3
+#define ARC_CLN_MST_PER_0_BCR                   16
+#define ARC_CLN_MST_PER_1_BCR                   17
+#define ARC_CLN_PER_0_BASE                      2688
+#define ARC_CLN_PER_0_SIZE                      2689
+#define ARC_CLN_PER_1_BASE                      2690
+#define ARC_CLN_PER_1_SIZE                      2691
+
+#define ARC_CLN_SCM_BCR_0                       100
+#define ARC_CLN_SCM_BCR_1                       101
+
+#define ARC_CLN_MST_NOC_0_0_ADDR                292
+#define ARC_CLN_MST_NOC_0_0_SIZE                293
+#define ARC_CLN_MST_NOC_0_1_ADDR                2560
+#define ARC_CLN_MST_NOC_0_1_SIZE                2561
+#define ARC_CLN_MST_NOC_0_2_ADDR                2562
+#define ARC_CLN_MST_NOC_0_2_SIZE                2563
+#define ARC_CLN_MST_NOC_0_3_ADDR                2564
+#define ARC_CLN_MST_NOC_0_3_SIZE                2565
+#define ARC_CLN_MST_NOC_0_4_ADDR                2566
+#define ARC_CLN_MST_NOC_0_4_SIZE                2567
+
+#define ARC_CLN_PER0_BASE                       2688
+#define ARC_CLN_PER0_SIZE                       2689
+
+#define ARC_CLN_SHMEM_ADDR                      200
+#define ARC_CLN_SHMEM_SIZE                      201
+#define ARC_CLN_CACHE_ADDR_LO0                  204
+#define ARC_CLN_CACHE_ADDR_LO1                  205
+#define ARC_CLN_CACHE_ADDR_HI0                  206
+#define ARC_CLN_CACHE_ADDR_HI1                  207
+#define ARC_CLN_CACHE_CMD                       207
+#define ARC_CLN_CACHE_CMD_OP_NOP                0b0000
+#define ARC_CLN_CACHE_CMD_OP_LOOKUP             0b0001
+#define ARC_CLN_CACHE_CMD_OP_PROBE              0b0010
+#define ARC_CLN_CACHE_CMD_OP_IDX_INV            0b0101
+#define ARC_CLN_CACHE_CMD_OP_IDX_CLN            0b0110
+#define ARC_CLN_CACHE_CMD_OP_IDX_CLN_INV        0b0111
+#define ARC_CLN_CACHE_CMD_OP_REG_INV            0b1001
+#define ARC_CLN_CACHE_CMD_OP_REG_CLN            0b1010
+#define ARC_CLN_CACHE_CMD_OP_REG_CLN_INV        0b1011
+#define ARC_CLN_CACHE_CMD_OP_ADDR_INV           0b1101
+#define ARC_CLN_CACHE_CMD_OP_ADDR_CLN           0b1110
+#define ARC_CLN_CACHE_CMD_OP_ADDR_CLN_INV       0b1111
+#define ARC_CLN_CACHE_CMD_INCR                  BIT(4)
+
+#define ARC_CLN_CACHE_STATUS                    209
+#define ARC_CLN_CACHE_STATUS_BUSY               BIT(23)
+#define ARC_CLN_CACHE_STATUS_DONE               BIT(24)
+#define ARC_CLN_CACHE_STATUS_MASK               BIT(26)
+#define ARC_CLN_CACHE_STATUS_EN                 BIT(27)
+#define ARC_CLN_CACHE_ERR                       210
+#define ARC_CLN_CACHE_ERR_ADDR0                 211
+#define ARC_CLN_CACHE_ERR_ADDR1                 212
+
+
+static inline unsigned int arc_cln_read_reg_nolock(unsigned int reg)
+{
+	z_arc_v2_aux_reg_write(_ARC_CLNR_ADDR, reg);
+	return z_arc_v2_aux_reg_read(_ARC_CLNR_DATA);
+}
+
+static inline void arc_cln_write_reg_nolock(unsigned int reg, unsigned int data)
+{
+	z_arc_v2_aux_reg_write(_ARC_CLNR_ADDR, reg);
+	z_arc_v2_aux_reg_write(_ARC_CLNR_DATA, data);
+}
+
+#endif /* ZEPHYR_INCLUDE_ARCH_ARC_CLUSTER_H_ */

--- a/include/zephyr/arch/arc/v2/aux_regs.h
+++ b/include/zephyr/arch/arc/v2/aux_regs.h
@@ -15,6 +15,8 @@
 #ifndef ZEPHYR_INCLUDE_ARCH_ARC_V2_AUX_REGS_H_
 #define ZEPHYR_INCLUDE_ARCH_ARC_V2_AUX_REGS_H_
 
+#include <zephyr/sys/util_macro.h>
+
 #define _ARC_V2_LP_START 0x002
 #define _ARC_V2_LP_END 0x003
 #define _ARC_V2_IDENTITY 0x004
@@ -173,6 +175,11 @@
 #define _ARC_V2_AGU_MOD21 0x5f5
 #define _ARC_V2_AGU_MOD22 0x5f6
 #define _ARC_V2_AGU_MOD23 0x5f7
+#define _ARC_HW_PF_BUILD 0xf70
+#define _ARC_HW_PF_CTRL 0x4f
+
+/* _ARC_HW_PF_CTRL bits */
+#define _ARC_HW_PF_CTRL_ENABLE BIT(0)
 
 /* STATUS32/STATUS32_P0 bits */
 #define _ARC_V2_STATUS32_H (1 << 0)


### PR DESCRIPTION
Enable enable HW prefetch and shared cache on boot if available.

While I'm at it cleanup ARCv3 haps setup with new cluster accessors.