### PR TITLE
twister: Fix exception when running coverage

### DIFF
--- a/scripts/pylib/twister/twisterlib/coverage.py
+++ b/scripts/pylib/twister/twisterlib/coverage.py
@@ -340,7 +340,7 @@ def run_coverage(testplan, options):
 
     logger.info("Generating coverage files...")
     coverage_tool = CoverageTool.factory(options.coverage_tool)
-    coverage_tool.gcov_tool = options.gcov_tool
+    coverage_tool.gcov_tool = str(options.gcov_tool)
     coverage_tool.base_dir = os.path.abspath(options.coverage_basedir)
     # Apply output format default
     if options.coverage_formats is not None:


### PR DESCRIPTION
Fix an exception when running coverage using gcov or llvm-cov.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/66897