### PR TITLE
soc: xtensa: esp32s2/s3: remove HEAP_MEM_POOL_ADD_SIZE_SOC

### DIFF
--- a/soc/xtensa/espressif_esp32/esp32s2/Kconfig.defconfig.series
+++ b/soc/xtensa/espressif_esp32/esp32s2/Kconfig.defconfig.series
@@ -18,9 +18,6 @@ config MP_MAX_NUM_CPUS
 config ISR_STACK_SIZE
 	default 2048
 
-config HEAP_MEM_POOL_ADD_SIZE_SOC
-	def_int 32768
-
 config ESPTOOLPY_FLASHFREQ_80M
 	default y
 

--- a/soc/xtensa/espressif_esp32/esp32s3/Kconfig.defconfig.series
+++ b/soc/xtensa/espressif_esp32/esp32s3/Kconfig.defconfig.series
@@ -6,9 +6,6 @@ if SOC_SERIES_ESP32S3
 config SOC_SERIES
 	default "esp32s3"
 
-config HEAP_MEM_POOL_ADD_SIZE_SOC
-	def_int 32768
-
 config MINIMAL_LIBC_OPTIMIZE_STRING_FOR_SIZE
 	default n
 


### PR DESCRIPTION
There is no need for this config here and it is wrongfully messing with total system heap calculation.