### PR TITLE
posix: pthread: support stack sizes larger than 65k

### DIFF
--- a/include/zephyr/posix/posix_types.h
+++ b/include/zephyr/posix/posix_types.h
@@ -38,15 +38,9 @@ typedef unsigned long timer_t;
 /* Thread attributes */
 struct pthread_attr {
 	void *stack;
-	uint16_t stacksize;
-	uint16_t guardsize;
-	int8_t priority;
-	uint8_t schedpolicy: 2;
-	uint8_t guardsize_msbit: 1;
-	bool initialized: 1;
-	bool cancelstate: 1;
-	bool detachstate: 1;
+	uint32_t details[2];
 };
+
 #if defined(CONFIG_MINIMAL_LIBC) || defined(CONFIG_PICOLIBC) || defined(CONFIG_ARMCLANG_STD_LIBC) \
 	|| defined(CONFIG_ARCMWDT_LIBC)
 typedef struct pthread_attr pthread_attr_t;

--- a/lib/posix/Kconfig.pthread
+++ b/lib/posix/Kconfig.pthread
@@ -27,9 +27,28 @@ config PTHREAD_RECYCLER_DELAY_MS
 	  Note: this option should be considered temporary and will likely be
 	  removed once a more synchronous solution is available.
 
+config POSIX_PTHREAD_ATTR_STACKSIZE_BITS
+	int "Significant bits for pthread_attr_t stacksize"
+	range 8 31
+	default 23
+	help
+	  This value plays a part in determining the maximum supported
+	  pthread_attr_t stacksize. Valid stacksizes are in the range
+	  [1, N], where N = 1 << M, and M is this configuration value.
+
+config POSIX_PTHREAD_ATTR_GUARDSIZE_BITS
+	int "Significant bits for pthread_attr_t guardsize"
+	range 1 31
+	default 9
+	help
+	  This value plays a part in determining the maximum supported
+	  pthread_attr_t guardsize. Valid guardsizes are in the range
+	  [0, N-1], where N = 1 << M, and M is this configuration value.
+
+	  Actual guardsize values may be rounded-up.
+
 config POSIX_PTHREAD_ATTR_GUARDSIZE_DEFAULT
 	int "Default size of stack guard area"
-	range 0 65536
 	default 0
 	help
 	  This is the default amount of space to reserve at the overflow end of a

--- a/lib/posix/posix_internal.h
+++ b/lib/posix/posix_internal.h
@@ -22,6 +22,18 @@
  */
 #define PTHREAD_OBJ_MASK_INIT 0x80000000
 
+struct posix_thread_attr {
+	void *stack;
+	/* the following two bitfields should combine to be 32-bits in size */
+	uint32_t stacksize : CONFIG_POSIX_PTHREAD_ATTR_STACKSIZE_BITS;
+	uint16_t guardsize : CONFIG_POSIX_PTHREAD_ATTR_GUARDSIZE_BITS;
+	int8_t priority;
+	uint8_t schedpolicy: 2;
+	bool initialized: 1;
+	bool cancelstate: 1;
+	bool detachstate: 1;
+};
+
 struct posix_thread {
 	struct k_thread thread;
 


### PR DESCRIPTION
A previous size optimization capped the `pthread_attr_t` stacksize property at 65536. Some Zephyr users felt that was not large enough for specific use cases.

Modify `struct pthread_attr` to support large stack sizes by default with the flexibility to allow users to vary the number of bits used for both stacksizes and guardsizes. Additionally, make the public definition easier to parse for non posix areas, and make a private definition that has the correct bitfields defined.

The default guardsize remains zero sinze Zephyr's stack allocators already pad stacks with a guard area based on other config parameters, and since Zephyr is already designed to support both SW and HW stack protection at the kernel layer.

Fixes #66761