### PR TITLE
twister: coverage: Remove dead code at BinaryHandler

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -326,10 +326,6 @@ class BinaryHandler(Handler):
 
         handler_time = time.time() - start_time
 
-        if self.options.coverage:
-            subprocess.call(["GCOV_PREFIX=" + self.build_dir,
-                             "gcov", self.sourcedir, "-b", "-s", self.build_dir], shell=True)
-
         # FIXME: This is needed when killing the simulator, the console is
         # garbled and needs to be reset. Did not find a better way to do that.
         if sys.stdout.isatty():

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -640,13 +640,6 @@ def test_binaryhandler_handle(
     handler._update_instance_info.assert_called_once()
     handler._final_handle_actions.assert_called_once()
 
-    if coverage:
-        call_mock.assert_any_call(
-            ['GCOV_PREFIX=build_dir', 'gcov', 'source_dir',
-             '-b', '-s', 'build_dir'],
-            shell=True
-        )
-
     if isatty:
         call_mock.assert_any_call(['stty', 'sane'], stdin=mock.ANY)
 


### PR DESCRIPTION
BinaryHandler.hanlde() method was trying to call GCOV and fails silently because of incorrect call parameters. 
Moreover, even being fixed, this call is not needed here as it attempts to find and process .gcno and .gcna files (using wrong paths) to create .gcov coverage text reports.
Currently the CoverageTool class does all data processing and report generation using GCOVR or LCOV tools instead of direct calls to GCOV.