### PR TITLE
posix: key: fix for coverity issues CID 334906 and CID 334909

### DIFF
--- a/lib/posix/key.c
+++ b/lib/posix/key.c
@@ -248,11 +248,16 @@ out:
 void *pthread_getspecific(pthread_key_t key)
 {
 	pthread_key_obj *key_obj;
-	struct posix_thread *thread = to_posix_thread(pthread_self());
+	struct posix_thread *thread;
 	pthread_thread_data *thread_spec_data;
 	void *value = NULL;
 	sys_snode_t *node_l;
 	k_spinlock_key_t key_key;
+
+	thread = to_posix_thread(pthread_self());
+	if (thread == NULL) {
+		return NULL;
+	}
 
 	key_key = k_spin_lock(&pthread_key_lock);
 
@@ -261,8 +266,6 @@ void *pthread_getspecific(pthread_key_t key)
 		k_spin_unlock(&pthread_key_lock, key_key);
 		return NULL;
 	}
-
-	node_l = sys_slist_peek_head(&(thread->key_list));
 
 	/* Traverse the list of keys set by the thread, looking for key */
 

--- a/lib/posix/key.c
+++ b/lib/posix/key.c
@@ -174,12 +174,17 @@ int pthread_key_delete(pthread_key_t key)
 int pthread_setspecific(pthread_key_t key, const void *value)
 {
 	pthread_key_obj *key_obj;
-	struct posix_thread *thread = to_posix_thread(pthread_self());
+	struct posix_thread *thread;
 	struct pthread_key_data *key_data;
 	pthread_thread_data *thread_spec_data;
 	k_spinlock_key_t key_key;
 	sys_snode_t *node_l;
 	int retval = 0;
+
+	thread = to_posix_thread(pthread_self());
+	if (thread == NULL) {
+		return EINVAL;
+	}
 
 	/* Traverse the list of keys set by the thread, looking for key.
 	 * If the key is already in the list, re-assign its value.


### PR DESCRIPTION
* remove unneeded line of code that duplicated the first part of the `SYS_SLIST_FOR_EACH_NODE()` expansion
* return `NULL` if `pthread_self()` is not a valid pthread in `pthread_getspecific()`
* return `EINVAL` if `pthread_self()` is not a valid pthread in `pthread_setspecific()`

Fixes #66839
Fixes #66840
