### PR TITLE
syscall: Fix static analysis compalins

### DIFF
--- a/include/zephyr/internal/syscall_handler.h
+++ b/include/zephyr/internal/syscall_handler.h
@@ -395,6 +395,22 @@ int k_usermode_string_copy(char *dst, const char *src, size_t maxlen);
 #define K_SYSCALL_VERIFY(expr) K_SYSCALL_VERIFY_MSG(expr, #expr)
 
 /**
+ * @brief Macro to check if size is negative
+ *
+ * K_SYSCALL_MEMORY can be called with signed/unsigned types
+ * and because of that if we check if size is greater or equal to
+ * zero, many static analyzers complain about no effect expression.
+ *
+ * @param ptr Memory area to examine
+ * @param size Size of the memory area
+ * @return true if size is valid, false otherwise
+ * @note This is an internal API. Do not use unless you are extending
+ *       functionality in the Zephyr tree.
+ */
+#define K_SYSCALL_MEMORY_SIZE_CHECK(ptr, size) \
+	(((uintptr_t)ptr + size) >= (uintptr_t)ptr)
+
+/**
  * @brief Runtime check that a user thread has read and/or write permission to
  *        a memory area
  *
@@ -413,7 +429,8 @@ int k_usermode_string_copy(char *dst, const char *src, size_t maxlen);
  *       functionality in the Zephyr tree.
  */
 #define K_SYSCALL_MEMORY(ptr, size, write) \
-	K_SYSCALL_VERIFY_MSG((size >= 0) && !Z_DETECT_POINTER_OVERFLOW(ptr, size) \
+	K_SYSCALL_VERIFY_MSG(K_SYSCALL_MEMORY_SIZE_CHECK(ptr, size) \
+			     && !Z_DETECT_POINTER_OVERFLOW(ptr, size) \
 			     && (arch_buffer_validate((void *)ptr, size, write) \
 			     == 0), \
 			     "Memory region %p (size %zu) %s access denied", \


### PR DESCRIPTION
Since K_SYSCALL_MEMORY can be called with signed/unsigned size types, if we check if size >= 0, static anlysis will complain about it when size in unsigned.

Fixes  #66856
Fixes  #66855
Fixes  #66854 
Fixes  #66853
Fixes  #66837
Fixes  #66835 
Fixes  #66801
Fixes  #66786

and many others similar issues
