### PR TITLE
lib: crc: address absence of crc4, crc4_ti in crc_types array

### DIFF
--- a/lib/crc/crc_shell.c
+++ b/lib/crc/crc_shell.c
@@ -19,9 +19,11 @@
 #include <zephyr/sys/crc.h>
 
 static const char *const crc_types[] = {
+	[CRC4] = "4",
+	[CRC4_TI] = "4_ti",
 	[CRC7_BE] = "7_be",
 	[CRC8] = "8",
-	[CRC8_CCITT] "8_ccitt",
+	[CRC8_CCITT] = "8_ccitt",
 	[CRC16] = "16",
 	[CRC16_ANSI] = "16_ansi",
 	[CRC16_CCITT] = "16_ccitt",


### PR DESCRIPTION
Added CRC4 and CRC4_TI to the supported crc_types[] array. On some SoCs, like ESP32-S3, missing values can cause hardfaults due to attempts to access the zero address.