### PR TITLE
pm: device_runtime: Add missing include to header

### DIFF
--- a/include/zephyr/pm/device_runtime.h
+++ b/include/zephyr/pm/device_runtime.h
@@ -9,6 +9,7 @@
 #define ZEPHYR_INCLUDE_PM_DEVICE_RUNTIME_H_
 
 #include <zephyr/device.h>
+#include <zephyr/kernel.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
The device_runtime header includes references to `struct device` and `k_timeout_t`, but only `zephyr/device.h` is included. `k_timeout_t` is in `zephyr/kernel.h`, so it must also be included. Without this include, the following error occurs if the source file happens to not include `zephyr/kernel.h` before `zephyr/pm/device_runtime.h`

```
In file included from /home/private/Documents/trackunit/zephyr_rtc/katja/src/main.c:1:
/home/private/Documents/trackunit/zephyr_rtc/zephyr/include/zephyr/pm/device_runtime.h:144:59: error: unknown type name 'k_timeout_t'
  144 | int pm_device_runtime_put_async(const struct device *dev, k_timeout_t delay);
```