### PR TITLE
Stm32 fix incorrect redefinition of PM symbol in defconfig file

### DIFF
--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.series
@@ -17,8 +17,14 @@ config TASK_WDT_HW_FALLBACK_DELAY
 	depends on TASK_WDT_HW_FALLBACK
 	default 200
 
-config PM
-	select COUNTER
-	select COUNTER_RTC_STM32_SUBSECONDS if DT_HAS_ST_STM32_RTC_ENABLED
+if PM
+
+config COUNTER
+	default y
+
+config COUNTER_RTC_STM32_SUBSECONDS
+	default y if DT_HAS_ST_STM32_RTC_ENABLED
+
+endif # PM
 
 endif # SOC_SERIES_STM32F4X

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.series
@@ -25,6 +25,9 @@ config COUNTER
 config COUNTER_RTC_STM32_SUBSECONDS
 	default y if DT_HAS_ST_STM32_RTC_ENABLED
 
+config IDLE_STACK_SIZE
+	default 512
+
 endif # PM
 
 endif # SOC_SERIES_STM32F4X


### PR DESCRIPTION
The defconfig.series file for the stm32f4 incorrectly redefines
the PM Kconfig in order to select two dependencies, COUNTER and
COUNTER_RTC_STM32_SUBSECONDS, instead of setting a default for
them if PM is included:
```
config PM
	select COUNTER
	select COUNTER_RTC_STM32_SUBSECONDS if DT_HAS_ST_STM32_RTC_ENABLED
```
This commit fixes the error described above by setting setting default values if PM is enabled instead:
```
if PM

config COUNTER
	default y

config COUNTER_RTC_STM32_SUBSECONDS
	default y if DT_HAS_ST_STM32_RTC_ENABLED

endif # PM
```

Without this fix, the following error occurs if PM is selected `CONFIG_PM=y`:
```
warning: PM (defined at soc/arm/silabs_exx32/efr32bg22/Kconfig.defconfig.series:18,
soc/arm/silabs_exx32/efr32bg27/Kconfig.defconfig.series:18,
soc/arm/silabs_exx32/efr32mg24/Kconfig.defconfig.series:19,
soc/arm/st_stm32/stm32f4/Kconfig.defconfig.series:20, subsys/pm/Kconfig:13) was assigned the value
'y' but got the value 'n'. Check these unsatisfied dependencies: ((SOC_SERIES_EFR32BG22 &&
SOC_FAMILY_EXX32) || (SOC_SERIES_EFR32BG27 && SOC_FAMILY_EXX32) || (SOC_SERIES_EFR32MG24 &&
SOC_FAMILY_EXX32) || SOC_SERIES_STM32F4X || (SYS_CLOCK_EXISTS && HAS_PM)) (=n).
```