### PR TITLE
Bluetooth: Shell: Fix coverity issue in cmd_adv_data

### DIFF
--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -2001,7 +2001,7 @@ static int cmd_adv_data(const struct shell *sh, size_t argc, char *argv[])
 	size_t hex_data_len;
 	size_t ad_len = 0;
 	size_t sd_len = 0;
-	size_t len = 0;
+	ssize_t len = 0;
 	bool discoverable = false;
 	size_t *data_len;
 	int err;


### PR DESCRIPTION
Fix wrong parameter type to avoid Unsigned compared against 0

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/65578