### PR TITLE
Add endian type identifiers

### DIFF
--- a/include/zephyr/types.h
+++ b/include/zephyr/types.h
@@ -38,4 +38,23 @@ extern int main(void);
 }
 #endif
 
+/*
+ * Below are truly Zephyr-specific types that should never collide with
+ * any application/library that wants zephyr/types.h.
+ */
+
+/* sparse defines __CHECKER__; see doc/develop/sca/sparse.rst */
+#ifdef __CHECKER__
+#define __bitwise	__attribute__((bitwise))
+#else
+#define __bitwise
+#endif
+
+typedef uint16_t __bitwise __le16;
+typedef uint16_t __bitwise __be16;
+typedef uint32_t __bitwise __le32;
+typedef uint32_t __bitwise __be32;
+typedef uint64_t __bitwise __le64;
+typedef uint64_t __bitwise __be64;
+
 #endif /* ZEPHYR_INCLUDE_ZEPHYR_TYPES_H_ */


### PR DESCRIPTION
- These types are defined with the bitwise attribute, which is used to restrict their use as integers.
- Used by sparse utility to make sure the variable is converted to the local processor type before other (unsafe) operations are performed on the variable
- Useful when passing around data over network, etc

See [this](https://bruceblinn.com/linuxinfo/ByteOrder.html) for more context