### PR TITLE
doc: align zephyr sdk search paths with cmake

### DIFF
--- a/doc/develop/getting_started/installation_linux.rst
+++ b/doc/develop/getting_started/installation_linux.rst
@@ -269,6 +269,7 @@ If you relocate the SDK directory, you need to re-run the setup script.
    * ``$HOME/.local/opt``
    * ``$HOME/bin``
    * ``/opt``
+   * ``/usr``
    * ``/usr/local``
 
    The Zephyr SDK bundle archive contains the ``zephyr-sdk-0.16.4`` directory and, when

--- a/doc/develop/toolchains/zephyr_sdk.rst
+++ b/doc/develop/toolchains/zephyr_sdk.rst
@@ -113,6 +113,7 @@ Zephyr SDK installation
             * ``$HOME/.local/opt``
             * ``$HOME/bin``
             * ``/opt``
+            * ``/usr``
             * ``/usr/local``
 
             The Zephyr SDK bundle archive contains the ``zephyr-sdk-0.16.4`` directory and, when
@@ -170,6 +171,7 @@ Zephyr SDK installation
             * ``$HOME/.local/opt``
             * ``$HOME/bin``
             * ``/opt``
+            * ``/usr``
             * ``/usr/local``
 
             The Zephyr SDK bundle archive contains the ``zephyr-sdk-0.16.4`` directory and, when


### PR DESCRIPTION
[FindZephyr-sdk.cmake](https://github.com/zephyrproject-rtos/zephyr/blob/main/cmake/modules/FindZephyr-sdk.cmake#L65) currently has seven search paths:
 - /usr
 - /usr/local
 - /opt
 - $ENV{HOME}
 - $ENV{HOME}/.local
 - $ENV{HOME}/.local/opt
 - $ENV{HOME}/bin)

The doc currently miss "/usr", aglin doc with CMake.