### PR TITLE
Build System: clang-format: add K_SPINLOCK to FOR_EACH

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -67,6 +67,7 @@ ForEachMacros:
   - 'Z_GENLIST_FOR_EACH_NODE_SAFE'
   - 'STRUCT_SECTION_FOREACH'
   - 'TYPE_SECTION_FOREACH'
+  - 'K_SPINLOCK'
 IfMacros:
   - 'CHECKIF'
 # Disabled for now, see bug https://github.com/zephyrproject-rtos/zephyr/issues/48520


### PR DESCRIPTION
The K_SPINLOCK is been indented wrongly by clang-format. It fixes that adding the K_SPINLOCK to the FOR_EACH section rule tells the formatter to follow the rule to indent the code.