### PR TITLE
drivers: rtc: set 'rtc_driver_api' as 'static const'

### DIFF
--- a/drivers/rtc/rtc_emul.c
+++ b/drivers/rtc/rtc_emul.c
@@ -461,7 +461,7 @@ static int rtc_emul_get_calibration(const struct device *dev, int32_t *calibrati
 }
 #endif /* CONFIG_RTC_CALIBRATION */
 
-struct rtc_driver_api rtc_emul_driver_api = {
+static const struct rtc_driver_api rtc_emul_driver_api = {
 	.set_time = rtc_emul_set_time,
 	.get_time = rtc_emul_get_time,
 #ifdef CONFIG_RTC_ALARM

--- a/drivers/rtc/rtc_fake.c
+++ b/drivers/rtc/rtc_fake.c
@@ -70,7 +70,7 @@ static void fake_rtc_reset_rule_before(const struct ztest_unit_test *test, void 
 ZTEST_RULE(fake_rtc_reset_rule, fake_rtc_reset_rule_before, NULL);
 #endif /* CONFIG_ZTEST */
 
-struct rtc_driver_api rtc_fake_driver_api = {
+static const struct rtc_driver_api rtc_fake_driver_api = {
 	.set_time = rtc_fake_set_time,
 	.get_time = rtc_fake_get_time,
 #ifdef CONFIG_RTC_ALARM

--- a/drivers/rtc/rtc_ll_stm32.c
+++ b/drivers/rtc/rtc_ll_stm32.c
@@ -390,7 +390,7 @@ static int rtc_stm32_get_calibration(const struct device *dev, int32_t *calibrat
 #endif
 #endif /* CONFIG_RTC_CALIBRATION */
 
-struct rtc_driver_api rtc_stm32_driver_api = {
+static const struct rtc_driver_api rtc_stm32_driver_api = {
 	.set_time = rtc_stm32_set_time,
 	.get_time = rtc_stm32_get_time,
 	/* RTC_ALARM not supported */

--- a/drivers/rtc/rtc_mc146818.c
+++ b/drivers/rtc/rtc_mc146818.c
@@ -495,7 +495,7 @@ static void rtc_mc146818_isr(const struct device *dev)
 #endif
 }
 
-struct rtc_driver_api rtc_mc146818_driver_api = {
+static const struct rtc_driver_api rtc_mc146818_driver_api = {
 	.set_time = rtc_mc146818_set_time,
 	.get_time = rtc_mc146818_get_time,
 #if defined(CONFIG_RTC_ALARM)

--- a/drivers/rtc/rtc_sam.c
+++ b/drivers/rtc/rtc_sam.c
@@ -645,7 +645,7 @@ static int rtc_sam_get_calibration(const struct device *dev, int32_t *calibratio
 }
 #endif /* CONFIG_RTC_CALIBRATION */
 
-static struct rtc_driver_api rtc_sam_driver_api = {
+static const struct rtc_driver_api rtc_sam_driver_api = {
 	.set_time = rtc_sam_set_time,
 	.get_time = rtc_sam_get_time,
 #ifdef CONFIG_RTC_ALARM

--- a/drivers/rtc/rtc_smartbond.c
+++ b/drivers/rtc/rtc_smartbond.c
@@ -561,7 +561,7 @@ static int rtc_smartbond_update_set_callback(const struct device *dev, rtc_updat
 }
 #endif
 
-struct rtc_driver_api rtc_smartbond_driver_api = {
+static const struct rtc_driver_api rtc_smartbond_driver_api = {
 	.get_time = rtc_smartbond_get_time,
 	.set_time = rtc_smartbond_set_time,
 #if defined(CONFIG_RTC_ALARM)


### PR DESCRIPTION
This change marks each instance of the `rtc_driver_api` as `static const`.
The rationale is that `rtc_driver_api` is used for declaring internal module interfaces and is not intended to be modified at runtime.
By using `static const`, we ensure immutability, leading to usage of only **.rodata** and a reduction in the **.data** area.