### PR TITLE
Modem patch null dereference in chat module

### DIFF
--- a/subsys/modem/modem_chat.c
+++ b/subsys/modem/modem_chat.c
@@ -60,7 +60,7 @@ static void modem_chat_log_received_command(struct modem_chat *chat)
 
 static void modem_chat_script_stop(struct modem_chat *chat, enum modem_chat_script_result result)
 {
-	if (!chat || !chat->script) {
+	if ((chat == NULL) || (chat->script == NULL)) {
 		return;
 	}
 
@@ -76,6 +76,14 @@ static void modem_chat_script_stop(struct modem_chat *chat, enum modem_chat_scri
 	/* Call back with result */
 	if (chat->script->callback != NULL) {
 		chat->script->callback(chat, result, chat->user_data);
+	}
+
+	/* Clear parse_match in case it is stored in the script being stopped */
+	if ((chat->parse_match != NULL) &&
+	    ((chat->parse_match_type == MODEM_CHAT_MATCHES_INDEX_ABORT) ||
+	     (chat->parse_match_type == MODEM_CHAT_MATCHES_INDEX_RESPONSE))) {
+		chat->parse_match = NULL;
+		chat->parse_match_len = 0;
 	}
 
 	/* Clear reference to script */
@@ -822,4 +830,8 @@ void modem_chat_release(struct modem_chat *chat)
 	chat->parse_match = NULL;
 	chat->parse_match_len = 0;
 	chat->parse_arg_len = 0;
+	chat->matches[MODEM_CHAT_MATCHES_INDEX_ABORT] = NULL;
+	chat->matches_size[MODEM_CHAT_MATCHES_INDEX_ABORT] = 0;
+	chat->matches[MODEM_CHAT_MATCHES_INDEX_RESPONSE] = NULL;
+	chat->matches_size[MODEM_CHAT_MATCHES_INDEX_RESPONSE] = 0;
 }


### PR DESCRIPTION
The chat module contains an array of three lists of matches, one of which are static, two of which are contained within the currently running script. The current match, which is an object stored in one of the three lists, is stored in its own pointer in the chat module context.

A memory error occurs when the script is stopped, while the chat module is using one of the matches stored withing the script. This commit clears the match pointer when the script is stopped if the match is stored within the script.

The lists must also be cleared when the chat module is released. This is also added in this PR