### PR TITLE
drivers: sdhc: set 'sdhc_driver_api' as 'static const'

### DIFF
--- a/drivers/sdhc/sdhc_spi.c
+++ b/drivers/sdhc/sdhc_spi.c
@@ -762,7 +762,7 @@ static int sdhc_spi_init(const struct device *dev)
 	return ret;
 }
 
-static struct sdhc_driver_api sdhc_spi_api = {
+static const struct sdhc_driver_api sdhc_spi_api = {
 	.request = sdhc_spi_request,
 	.set_io = sdhc_spi_set_io,
 	.get_host_props = sdhc_spi_get_host_props,


### PR DESCRIPTION
This change marks each instance of the `sdhc_driver_api` as `static const`. The rationale is that `sdhc_driver_api` is used for declaring internal module interfaces and is not intended to be modified at runtime. By using `static const`, we ensure immutability, leading to usage of only **.rodata** and a reduction in the **.data** area.

Additionally, it's worth noting that the directory **drivers/sdhc/sdhc_cdns/** might have been added unintentionally, as CMakeLists.txt is searching for the files located outside this directory.