### PR TITLE
libc: common: move strnlen() to posix

### DIFF
--- a/lib/libc/common/include/string.h
+++ b/lib/libc/common/include/string.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024, Meta
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_LIB_LIBC_COMMON_INCLUDE_STRING_H_
+#define ZEPHYR_LIB_LIBC_COMMON_INCLUDE_STRING_H_
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if _POSIX_C_SOURCE >= 200809L || defined(_ZEPHYR_SOURCE)
+/* Please see rule A.4 of the coding guidelines */
+size_t strnlen(const char *s, size_t maxlen);
+char *strtok_r(char *str, const char *sep, char **state);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#include_next <string.h>
+
+#endif /* ZEPHYR_LIB_LIBC_COMMON_INCLUDE_STRING_H_ */

--- a/lib/libc/newlib/CMakeLists.txt
+++ b/lib/libc/newlib/CMakeLists.txt
@@ -37,6 +37,11 @@ zephyr_compile_definitions(_ANSI_SOURCE)
 # used by the network stack
 zephyr_compile_definitions(__LINUX_ERRNO_EXTENSIONS__)
 
+# define _ZEPHYR_SOURCE so we can get POSIX extensions to ISO C declared in
+# lib/libc/common/include/string.h, to satisfy Rule A.4 of Zephyr's Coding
+# Guidelines.
+zephyr_compile_definitions(_ZEPHYR_SOURCE)
+
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
   # We are using
   # - ${CMAKE_C_LINKER_WRAPPER_FLAG}${CMAKE_LINK_LIBRARY_FLAG}c

--- a/tests/lib/c_lib/common/src/main.c
+++ b/tests/lib/c_lib/common/src/main.c
@@ -15,10 +15,6 @@
  * it guarantee that ALL functionality provided is working correctly.
  */
 
-#ifdef CONFIG_NEWLIB_LIBC
-#define _POSIX_C_SOURCE 200809
-#endif
-
 #include <zephyr/kernel.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/ztest.h>


### PR DESCRIPTION
The `strnlen()` function is POSIX. It's not part of ISO C.

Moving this function to `lib/posix` ensures that Zephyr applications may use it even when a toolchain-bundled libc does not support the POSIX API.

Fixes #66918

Depends on:
- [ ] #66998