### PR TITLE
drivers: wifi: esp_at: fix last rx data loss in Passive Receive mode

### DIFF
--- a/drivers/wifi/esp_at/esp_socket.c
+++ b/drivers/wifi/esp_at/esp_socket.c
@@ -151,8 +151,16 @@ void esp_socket_rx(struct esp_socket *sock, struct net_buf *buf,
 
 	flags = esp_socket_flags(sock);
 
+#ifdef CONFIG_WIFI_ESP_AT_PASSIVE_MODE
+	/* In Passive Receive mode, ESP modem will buffer rx data and make it still
+	 * available even though the peer has closed the connection.
+	 */
+	if (!(flags & ESP_SOCK_CONNECTED) &&
+	    !(flags & ESP_SOCK_CLOSE_PENDING)) {
+#else
 	if (!(flags & ESP_SOCK_CONNECTED) ||
 	    (flags & ESP_SOCK_CLOSE_PENDING)) {
+#endif
 		LOG_DBG("Received data on closed link %d", sock->link_id);
 		return;
 	}


### PR DESCRIPTION
In Passive Receive mode, ESP modem will buffer rx data. This PR makes the data still available to user, even though the peer has closed the socket. Otherwise, user will fail to get the last rx data when the socket is closed by the peer.

[http_get](https://github.com/zephyrproject-rtos/zephyr/tree/main/samples/net/sockets/http_get) can reproduce the issue with WiFi ESP8266 enabled plus `CONFIG_WIFI_ESP_AT_PASSIVE_MODE=y`.