### PR TITLE
tests: counter: counter_basic_api: Add support for ambiq_counter device， and fix error in driver causing test case failure

### DIFF
--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -99,6 +99,9 @@ static const struct device *const devices[] = {
 #ifdef CONFIG_COUNTER_TIMER_RPI_PICO
 	DEVS_FOR_DT_COMPAT(raspberrypi_pico_timer)
 #endif
+#ifdef CONFIG_COUNTER_AMBIQ
+	DEVS_FOR_DT_COMPAT(ambiq_counter)
+#endif
 };
 
 static const struct device *const period_devs[] = {


### PR DESCRIPTION
Alarm interrupt is disabled in cancel_alarm, we should re-enable it in set_alarm, at meanwhile, should reset the compare register in cancel_alarm to avoid the contention condition in cancel_alarm & set_alarm in short time.
This change fixes the test case failure at zephyr\tests\drivers\counter\counter_basic_api.