### PR TITLE
Support FlexCAN on NXP UCANS32K1SIC

### DIFF
--- a/boards/arm/ucans32k1sic/Kconfig.defconfig
+++ b/boards/arm/ucans32k1sic/Kconfig.defconfig
@@ -13,4 +13,11 @@ config UART_CONSOLE
 
 endif # SERIAL
 
+if CAN
+
+config GPIO
+	default y
+
+endif # CAN
+
 endif # BOARD_UCANS32K1SIC

--- a/boards/arm/ucans32k1sic/doc/index.rst
+++ b/boards/arm/ucans32k1sic/doc/index.rst
@@ -50,6 +50,7 @@ LPUART        on-chip     serial
 LPI2C         on-chip     i2c
 LPSPI         on-chip     spi
 FTM           on-chip     pwm
+FlexCAN       on-chip     can
 ============  ==========  ================================
 
 The default configuration can be found in the Kconfig file

--- a/boards/arm/ucans32k1sic/ucans32k1sic-pinctrl.dtsi
+++ b/boards/arm/ucans32k1sic/ucans32k1sic-pinctrl.dtsi
@@ -60,4 +60,18 @@
 			drive-strength = "low";
 		};
 	};
+
+	flexcan0_default: flexcan0_default {
+		group0 {
+			pinmux = <CAN0_RX_PTE4>, <CAN0_TX_PTE5>;
+			drive-strength = "low";
+		};
+	};
+
+	flexcan1_default: flexcan1_default {
+		group0 {
+			pinmux = <CAN1_RX_PTA12>, <CAN1_TX_PTA13>;
+			drive-strength = "low";
+		};
+	};
 };

--- a/boards/arm/ucans32k1sic/ucans32k1sic.dts
+++ b/boards/arm/ucans32k1sic/ucans32k1sic.dts
@@ -21,6 +21,7 @@
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,uart-pipe = &lpuart1;
+		zephyr,canbus = &flexcan0;
 	};
 
 	aliases {
@@ -80,6 +81,20 @@
 			gpios = <&gpioc 14 GPIO_ACTIVE_LOW>;
 			zephyr,code = <INPUT_KEY_0>;
 		};
+	};
+
+	can_phy0: can-phy0 {
+		compatible = "nxp,tja1463", "nxp,tja1443", "nxp,tja1153", "can-transceiver-gpio";
+		enable-gpios = <&gpioa 10 GPIO_ACTIVE_HIGH>;
+		max-bitrate = <8000000>;
+		#phy-cells = <0>;
+	};
+
+	can_phy1: can-phy1 {
+		compatible = "nxp,tja1463", "nxp,tja1443", "nxp,tja1153", "can-transceiver-gpio";
+		enable-gpios = <&gpioe 2 GPIO_ACTIVE_HIGH>;
+		max-bitrate = <8000000>;
+		#phy-cells = <0>;
 	};
 };
 
@@ -152,5 +167,27 @@
 	pinctrl-0 = <&ftm2_default>;
 	pinctrl-names = "default";
 	#pwm-cells = <3>;
+	status = "okay";
+};
+
+&flexcan0 {
+	pinctrl-0 = <&flexcan0_default>;
+	pinctrl-names = "default";
+	phys = <&can_phy0>;
+	bus-speed = <125000>;
+	sample-point = <875>;
+	bus-speed-data = <1000000>;
+	sample-point-data = <875>;
+	status = "okay";
+};
+
+&flexcan1 {
+	pinctrl-0 = <&flexcan1_default>;
+	pinctrl-names = "default";
+	phys = <&can_phy1>;
+	bus-speed = <125000>;
+	sample-point = <875>;
+	bus-speed-data = <1000000>;
+	sample-point-data = <875>;
 	status = "okay";
 };

--- a/boards/arm/ucans32k1sic/ucans32k1sic.yaml
+++ b/boards/arm/ucans32k1sic/ucans32k1sic.yaml
@@ -18,3 +18,4 @@ supported:
   - i2c
   - spi
   - pwm
+  - can

--- a/drivers/can/Kconfig.mcux
+++ b/drivers/can/Kconfig.mcux
@@ -31,8 +31,10 @@ config CAN_MCUX_FLEXCAN_WAIT_TIMEOUT
 config CAN_MAX_MB
 	int "Maximum number of message buffers for concurrent active instances"
 	default 16
-	depends on SOC_SERIES_S32K3XX
-	range 1 96
+	depends on SOC_SERIES_S32K3XX || SOC_SERIES_S32K1XX
+	range 1 96 if SOC_SERIES_S32K3XX
+	range 1 32 if SOC_SERIES_S32K1XX && !SOC_S32K142W && !SOC_S32K144W
+	range 1 64 if SOC_S32K142W || SOC_S32K144W
 	help
 	  Defines maximum number of message buffers for concurrent active instances.
 
@@ -43,6 +45,8 @@ config CAN_MAX_FILTER
 	range 1 13 if SOC_SERIES_IMX_RT && CAN_MCUX_FLEXCAN_FD
 	range 1 63 if SOC_SERIES_IMX_RT
 	range 1 96 if SOC_SERIES_S32K3XX
+	range 1 32 if SOC_SERIES_S32K1XX && !SOC_S32K142W && !SOC_S32K144W
+	range 1 64 if SOC_S32K142W || SOC_S32K144W
 	help
 	  Defines maximum number of concurrent active RX filters
 

--- a/dts/arm/nxp/nxp_s32k146.dtsi
+++ b/dts/arm/nxp/nxp_s32k146.dtsi
@@ -61,3 +61,20 @@
 &lpspi2 {
 	clocks = <&clock NXP_S32_LPSPI2_CLK>;
 };
+
+&flexcan0 {
+	interrupts = <78 0>, <79 0>, <80 0>, <81 0>, <82 0>;
+	interrupt-names = "warning", "error", "wake-up", "mb-0-15", "mb-16-31";
+};
+
+&flexcan1 {
+	interrupts = <85 0>, <86 0>, <88 0>, <89 0>;
+	interrupt-names = "warning", "error", "mb-0-15", "mb-16-31";
+	clocks = <&clock NXP_S32_FLEXCAN1_CLK>;
+};
+
+&flexcan2 {
+	interrupts = <92 0>, <93 0>, <95 0>;
+	interrupt-names = "warning", "error", "mb-0-15";
+	clocks = <&clock NXP_S32_FLEXCAN2_CLK>;
+};

--- a/dts/arm/nxp/nxp_s32k1xx.dtsi
+++ b/dts/arm/nxp/nxp_s32k1xx.dtsi
@@ -44,6 +44,28 @@
 			status = "disabled";
 		};
 
+		flexcan0: can@40024000 {
+			compatible = "nxp,flexcan-fd", "nxp,flexcan";
+			reg = <0x40024000 0x1000>;
+			clocks = <&clock NXP_S32_FLEXCAN0_CLK>;
+			clk-source = <1>;
+			status = "disabled";
+		};
+
+		flexcan1: can@40025000 {
+			compatible = "nxp,flexcan-fd", "nxp,flexcan";
+			reg = <0x40025000 0x1000>;
+			clk-source = <1>;
+			status = "disabled";
+		};
+
+		flexcan2: can@4002b000 {
+			compatible = "nxp,flexcan-fd", "nxp,flexcan";
+			reg = <0x4002b000 0x1000>;
+			clk-source = <1>;
+			status = "disabled";
+		};
+
 		lpspi0: spi@4002c000 {
 			compatible = "nxp,imx-lpspi";
 			reg = <0x4002c000 0x1000>;

--- a/soc/arm/nxp_s32/s32k1/Kconfig.series
+++ b/soc/arm/nxp_s32/s32k1/Kconfig.series
@@ -17,5 +17,6 @@ config SOC_SERIES_S32K1XX
 	select HAS_MCUX_LPI2C
 	select HAS_MCUX_LPSPI
 	select HAS_MCUX_FTM
+	select HAS_MCUX_FLEXCAN
 	help
 	  Enable support for NXP S32K1XX MCU series.

--- a/west.yml
+++ b/west.yml
@@ -193,7 +193,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 4605f6715c6a55121da8fcbff060e01c4383c1e9
+      revision: 12970d629fc900010dab5cf250be70287bf9e443
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Add support for FlexCAN on UCANS32K1SIC board.

```
west twister -p ucans32k1sic --device-testing --device-serial=/dev/ttyUSB_ucans32k1sic -v \
  -T tests/drivers/can -T tests/net/socket/can -T samples/drivers/can -T samples/net/socket/can
INFO    - Using Ninja..
INFO    - Zephyr version: zephyr-v3.5.0-3469-gaf59f9e61d0b
INFO    - Using 'zephyr' toolchain.
INFO    - Building initial testsuite list...
...
INFO    - 2/7 ucans32k1sic              tests/net/socket/can/net.socket.can                PASSED (device 9.530s)
INFO    - 3/7 ucans32k1sic              tests/drivers/can/shell/drivers.can.shell          PASSED (device 7.673s)
INFO    - 4/7 ucans32k1sic              samples/drivers/can/counter/sample.drivers.can.counter PASSED (device 5.743s)
INFO    - 5/7 ucans32k1sic              samples/drivers/can/babbling/sample.drivers.can.babbling PASSED (device 5.677s)
INFO    - 6/7 ucans32k1sic              tests/drivers/can/timing/drivers.can.timing        PASSED (device 6.341s)
INFO    - 7/7 ucans32k1sic              tests/drivers/can/api/drivers.can.api              PASSED (device 8.061s)

INFO    - 7 test scenarios (7 test instances) selected, 1 configurations skipped (1 by static filter, 0 at runtime).
INFO    - 6 of 7 test configurations passed (100.00%), 0 failed, 0 errored, 1 skipped with 0 warnings in 61.33 seconds
INFO    - In total 100 test cases were executed, 44 skipped on 1 out of total 660 platforms (0.15%)
INFO    - 6 test configurations executed on platforms, 0 test configurations were only built.
```