### PR TITLE
posix: signal: implement `sigprocmask()`

### DIFF
--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -266,7 +266,7 @@ required for error and event handling.
     sigismember(),yes
     signal(),
     sigpending(),
-    sigprocmask(),
+    sigprocmask(),yes
     igsuspend(),
     sigwait(),
     strsignal(),yes

--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -267,7 +267,7 @@ required for error and event handling.
     signal(),
     sigpending(),
     sigprocmask(),yes
-    igsuspend(),
+    sigsuspend(),
     sigwait(),
     strsignal(),yes
 

--- a/include/zephyr/posix/signal.h
+++ b/include/zephyr/posix/signal.h
@@ -99,6 +99,7 @@ int sigfillset(sigset_t *set);
 int sigaddset(sigset_t *set, int signo);
 int sigdelset(sigset_t *set, int signo);
 int sigismember(const sigset_t *set, int signo);
+int sigprocmask(int how, const sigset_t *ZRESTRICT set, sigset_t *ZRESTRICT oset);
 
 int pthread_sigmask(int how, const sigset_t *ZRESTRICT set, sigset_t *ZRESTRICT oset);
 #endif /* CONFIG_POSIX_SIGNAL */

--- a/lib/posix/signal.c
+++ b/lib/posix/signal.c
@@ -100,3 +100,21 @@ char *strsignal(int signum)
 
 	return buf;
 }
+
+int sigprocmask(int how, const sigset_t *ZRESTRICT set, sigset_t *ZRESTRICT oset)
+{
+	if (!IS_ENABLED(CONFIG_MULTITHREADING)) {
+		return pthread_sigmask(how, set, oset);
+	}
+
+	/*
+	 * Until Zephyr supports processes and specifically querying the number of active threads in
+	 * a process For more information, see
+	 * https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_sigmask.html
+	 */
+	__ASSERT(false, "In multi-threaded environments, please use pthread_sigmask() instead of "
+			"%s()", __func__);
+
+	errno = ENOSYS;
+	return -1;
+}

--- a/tests/posix/headers/src/signal_h.c
+++ b/tests/posix/headers/src/signal_h.c
@@ -164,6 +164,7 @@ ZTEST(posix_headers, test_signal_h)
 	zassert_not_null(sigdelset);
 	zassert_not_null(sigismember);
 	zassert_not_null(strsignal);
+	zassert_not_null(sigprocmask);
 	zassert_not_null(pthread_sigmask);
 #endif /* CONFIG_POSIX_SIGNAL */
 
@@ -182,7 +183,6 @@ ZTEST(posix_headers, test_signal_h)
 		/* zassert_not_null(signal); */ /* not implemented */
 		/* zassert_not_null(sigpause); */ /* not implemented */
 		/* zassert_not_null(sigpending); */ /* not implemented */
-		/* zassert_not_null(sigprocmask); */ /* not implemented */
 		/* zassert_not_null(sigqueue); */ /* not implemented */
 		/* zassert_not_null(sigrelse); */ /* not implemented */
 		/* zassert_not_null(sigset); */ /* not implemented */


### PR DESCRIPTION
Implement `sigprocmask()` by simply redirecting call to the `pthread_sigmask()` as they are identical in single threaded application.

Fixes #66928