### PR TITLE
posix: pthread: Clarify SCHED_OTHER scheduling policy

### DIFF
--- a/include/zephyr/posix/sched.h
+++ b/include/zephyr/posix/sched.h
@@ -13,9 +13,9 @@ extern "C" {
 #endif
 
 /*
- * Other mandatory scheduling policy. Must be numerically distinct. May
- * execute identically to SCHED_RR or SCHED_FIFO. For Zephyr this is a
- * pseudonym for SCHED_RR.
+ * Other mandatory scheduling policy. Must be numerically distinct.
+ * For Zephyr this policy is active when both cooperative and preemptive
+ * thread classes are allowed.
  */
 #define SCHED_OTHER 0
 

--- a/lib/posix/sched.c
+++ b/lib/posix/sched.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018-2023 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -13,12 +13,27 @@
  * @brief Get minimum priority value for a given policy
  *
  * See IEEE 1003.1
+ *
+ * @param[in] policy  Scheduling policy with Zephyr thread priority ranges:
+ *	SCHED_RR:   [0, @ref CONFIG_NUM_PREEMPT_PRIORITIES -1]
+ *	SCHED_FIFO: [ @ref CONFIG_NUM_PREEMPT_PRIORITIES,
+ *		      @ref CONFIG_NUM_COOP_PRIORITIES -1]
+ *	SCHED_OTHER: [0, @ref CONFIG_NUM_PREEMPT_PRIORITIES +
+ *			 @ref CONFIG_NUM_COOP_PRIORITIES -1]
+ *
+ * @retval -1 and errno=EINVAL for a policy which is either not supported
+ *	or not allowed with Zephyr config parameters at compile time.
  */
 int sched_get_priority_min(int policy)
 {
 	if (!valid_posix_policy(policy)) {
 		errno = EINVAL;
 		return -1;
+	}
+
+	if (IS_ENABLED(CONFIG_COOP_ENABLED) && policy == SCHED_FIFO) {
+		/* min. COOP priority is above PREEMPT level if any. */
+		return CONFIG_NUM_PREEMPT_PRIORITIES;
 	}
 
 	return 0;
@@ -28,16 +43,39 @@ int sched_get_priority_min(int policy)
  * @brief Get maximum priority value for a given policy
  *
  * See IEEE 1003.1
+ *
+ * @param[in] policy  Scheduling policy with Zephyr thread priority ranges:
+ *	SCHED_RR:   [0, @ref CONFIG_NUM_PREEMPT_PRIORITIES -1]
+ *	SCHED_FIFO: [ @ref CONFIG_NUM_PREEMPT_PRIORITIES,
+ *		      @ref CONFIG_NUM_COOP_PRIORITIES -1]
+ *	SCHED_OTHER: [0, @ref CONFIG_NUM_PREEMPT_PRIORITIES +
+ *			 @ref CONFIG_NUM_COOP_PRIORITIES -1]
+ *
+ * @retval -1 and errno=EINVAL for a policy which is either not supported
+ *	or not allowed with Zephyr config parameters at compile time.
  */
 int sched_get_priority_max(int policy)
 {
-	if (IS_ENABLED(CONFIG_COOP_ENABLED) && policy == SCHED_FIFO) {
-		return CONFIG_NUM_COOP_PRIORITIES - 1;
-	} else if (IS_ENABLED(CONFIG_PREEMPT_ENABLED) &&
-		   (policy == SCHED_RR || policy == SCHED_OTHER)) {
-		return CONFIG_NUM_PREEMPT_PRIORITIES - 1;
+	int priority_levels = 0;
+
+	if (!valid_posix_policy(policy)) {
+		errno = EINVAL;
+		return -1;
 	}
 
-	errno = EINVAL;
-	return -1;
+	if (IS_ENABLED(CONFIG_PREEMPT_ENABLED)) {
+		priority_levels += CONFIG_NUM_PREEMPT_PRIORITIES;
+	}
+
+	if (IS_ENABLED(CONFIG_COOP_ENABLED) && policy != SCHED_RR) {
+		priority_levels += CONFIG_NUM_COOP_PRIORITIES;
+	}
+
+	if (priority_levels == 0) {
+		/* Should be already eliminated at compile time. */
+		errno = EINVAL;
+		return -1;
+	}
+
+	return priority_levels - 1;    /* 0 inclusive */
 }

--- a/tests/posix/headers/src/sched_h.c
+++ b/tests/posix/headers/src/sched_h.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Meta
+ * Copyright (c) 2023 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -24,7 +25,7 @@ ZTEST(posix_headers, test_sched_h)
 	zassert_not_equal(-1, SCHED_FIFO);
 	zassert_not_equal(-1, SCHED_RR);
 	/* zassert_not_equal(-1, SCHED_SPORADIC); */ /* not implemented */
-	/* zassert_not_equal(-1, SCHED_OTHER); */ /* not implemented */
+	zassert_not_equal(-1, SCHED_OTHER);
 
 	if (IS_ENABLED(CONFIG_POSIX_API)) {
 		zassert_not_null(sched_get_priority_max);


### PR DESCRIPTION
The following scheduling scenario is now reflected as POSIX policy `SCHED_OTHER`:
when Zephyr Kconfig allows both cooperative and preemptive thread scheduling classes with application thread priority ranges either `(-CONFIG_NUM_COOP_PRIORITIES..-1)` or `(0..CONFIG_NUM_PREEMPT_PRIORITIES-1)` respectively highest to lowest, translated to POSIX thread priorities in range `(0..CONFIG_NUM_PREEMPT_PRIORITIES+CONFIG_NUM_COOP_PRIORITIES-1)` lowest to highest.

predecessor: #57161