### PR TITLE
boards: xtensa: m5stack_core2: swap-xy touch input

### DIFF
--- a/boards/xtensa/m5stack_core2/m5stack_core2.dts
+++ b/boards/xtensa/m5stack_core2/m5stack_core2.dts
@@ -46,6 +46,7 @@
 	lvgl_pointer {
 		compatible = "zephyr,lvgl-pointer-input";
 		input = <&ft5336_touch>;
+		swap-xy;
 	};
 };
 


### PR DESCRIPTION
When running the `samples/subsys/display/lvgl` sample, the on-screen button and the touch-screen inputs do not agree. Investigation shows that the orientation of the touch-input is using X and Y coordinates opposite of those used by the display.

This PR swaps the lvgl X/Y touch input coordinates for `lvgl_pointer` in the `m5stack_core2` board definition to match the orientation of the screen.