### PR TITLE
west: sign.py: add "REM" support to pass comments through cpp

### DIFF
--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -438,7 +438,12 @@ class RimageSigner(Signer):
         'Runs the C pre-processor on config_dir/toml_basename.h'
 
         compiler_path = self.cmake_cache.get("CMAKE_C_COMPILER")
-        preproc_cmd = [compiler_path, '-P', '-E', str(config_dir / (toml_basename + '.h'))]
+        preproc_cmd = [compiler_path, '-E', str(config_dir / (toml_basename + '.h'))]
+        # -P removes line markers to keep the .toml output reproducible.  To
+        # trace #includes, temporarily comment out '-P' (-f*-prefix-map
+        # unfortunately don't seem to make any difference here and they're
+        # gcc-specific)
+        preproc_cmd += ['-P']
         preproc_cmd += ['-I', str(self.sof_src_dir / 'src')]
         preproc_cmd += ['-imacros',
                         str(pathlib.Path('zephyr') / 'include' / 'generated' / 'autoconf.h')]

--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -444,6 +444,16 @@ class RimageSigner(Signer):
         # unfortunately don't seem to make any difference here and they're
         # gcc-specific)
         preproc_cmd += ['-P']
+
+        # "REM" escapes _leading_ '#' characters from cpp and allows
+        # such comments to be preserved in generated/*.toml files:
+        #
+        #      REM # my comment...
+        #
+        # Note _trailing_ '#' characters and comments are ignored by cpp
+        # and don't need any REM trick.
+        preproc_cmd += ['-DREM=']
+
         preproc_cmd += ['-I', str(self.sof_src_dir / 'src')]
         preproc_cmd += ['-imacros',
                         str(pathlib.Path('zephyr') / 'include' / 'generated' / 'autoconf.h')]

--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -442,7 +442,7 @@ class RimageSigner(Signer):
         preproc_cmd += ['-I', str(self.sof_src_dir / 'src')]
         preproc_cmd += ['-imacros',
                         str(pathlib.Path('zephyr') / 'include' / 'generated' / 'autoconf.h')]
-        preproc_cmd += ['-o', str(subdir / toml_basename)]
+        preproc_cmd += ['-o', str(subdir / 'rimage_config.toml')]
         self.command.inf(quote_sh_list(preproc_cmd))
         subprocess.run(preproc_cmd, check=True, cwd=self.build_dir)
 
@@ -573,13 +573,12 @@ class RimageSigner(Signer):
                 command.die(f"Cannot have both {toml_basename + '.h'} and {toml_basename} in {conf_dir}")
 
             if (conf_dir / (toml_basename + '.h')).exists():
-                toml_subdir = pathlib.Path('zephyr') / 'misc' / 'generated'
-                self.preprocess_toml(conf_dir, toml_basename, toml_subdir)
-                toml_dir = b / toml_subdir
+                generated_subdir = pathlib.Path('zephyr') / 'misc' / 'generated'
+                self.preprocess_toml(conf_dir, toml_basename, generated_subdir)
+                extra_ri_args += ['-c', str(b / generated_subdir / 'rimage_config.toml')]
             else:
                 toml_dir = conf_dir
-
-            extra_ri_args += ['-c', str(toml_dir / toml_basename)]
+                extra_ri_args += ['-c', str(toml_dir / toml_basename)]
 
         # Warning: while not officially supported (yet?), the rimage --option that is last
         # on the command line currently wins in case of duplicate options. So pay


### PR DESCRIPTION
3 sign.py commits. Main commit:

west: sign.py: add "REM" support to pass comments through cpp

Generated outputs can be difficult to read, preserving comments helps a
lot and they often provide good `git grep` search keywords.