### PR TITLE
dts: nxp: kw41z : fix ram size issue

### DIFF
--- a/dts/arm/nxp/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/nxp_kw41z.dtsi
@@ -32,7 +32,7 @@
 
 	sram0: memory@20000000 {
 		compatible = "mmio-sram";
-		reg = <0x20000000 DT_SIZE_K(128)>;
+		reg = <0x20000000 DT_SIZE_K(96)>;
 	};
 
 	/* Dummy pinctrl node, filled with pin mux options at board level */


### PR DESCRIPTION
frdm_kw41z ram size is 96k if base starting from 0x20000000

fixing: #66154