### PR TITLE
doc: Add note that some versions of displays are not supported

### DIFF
--- a/boards/arm/stm32h747i_disco/doc/index.rst
+++ b/boards/arm/stm32h747i_disco/doc/index.rst
@@ -172,6 +172,10 @@ command, for example:
    :shield: st_b_lcd40_dsi1_mb1166
    :goals: build flash
 
+.. note::
+   Currently only the older version MB1166-A03 is supported by Zephyr.
+   The newer version MB1166-A09 does not get initialized correctly (see :github:`60888`).
+
 Resources sharing
 =================
 

--- a/boards/shields/st_b_lcd40_dsi1_mb1166/doc/index.rst
+++ b/boards/shields/st_b_lcd40_dsi1_mb1166/doc/index.rst
@@ -9,6 +9,9 @@ Overview
 The B-LCD40-DSI1 shield provides a 4-inch WVGA TFT LCD with MIPI DSI interface
 and capacitive touch screen.
 
+.. note::
+   Currently only the older version MB1166-A03 is supported by Zephyr.
+   The newer version MB1166-A09 does not get initialized correctly (see :github:`60888`).
 
 .. figure:: image.jpg
    :alt: B-LCD40-DSI1 MB1166 Image


### PR DESCRIPTION
I just found out (the hard way) that newer/current versions of the [ST STM32H747I Discovery](https://docs.zephyrproject.org/latest/boards/arm/stm32h747i_disco/doc/index.html#st-stm32h747i-discovery) sadly come with display shields which are not supported by Zephyr. See also https://github.com/zephyrproject-rtos/zephyr/discussions/60888 where this was already discussed. I thought it might be worth to add this note to documentation as a warning / help for debugging.