### PR TITLE
drivers: flash : stm32: STM32L4P5xx fix page calculation from offset

### DIFF
--- a/drivers/flash/flash_stm32l4x.c
+++ b/drivers/flash/flash_stm32l4x.c
@@ -23,7 +23,7 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 
 #if !defined(STM32L4R5xx) && !defined(STM32L4R7xx) && !defined(STM32L4R9xx) && \
 	!defined(STM32L4S5xx) && !defined(STM32L4S7xx) && !defined(STM32L4S9xx) && \
-	!defined(STM32L4Q5xx)
+	!defined(STM32L4Q5xx) && !defined(STM32L4P5xx)
 #define STM32L4X_PAGE_SHIFT	11
 #else
 #define STM32L4X_PAGE_SHIFT	12


### PR DESCRIPTION
This fix adds the STM32L4P5xx to the list of devices that have an offset-to-page shift calculation of 12 bits. Previously, the driver would only shift the offset by 11 bits when calculating the page to erase.

This would prevent the driver from erasing the correct page.