### PR TITLE
dts-bindings: pinctrl: renesas_ra: enabled config of i/o ports 4-7

### DIFF
--- a/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-ra-common.h
+++ b/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-ra-common.h
@@ -12,7 +12,7 @@
 #define PSEL_POS   24
 #define PSEL_MASK  0x5
 #define PORT_POS   21
-#define PORT_MASK  0x3
+#define PORT_MASK  0x7
 #define PIN_POS    17
 #define PIN_MASK   0xF
 #define OPT_POS    0

--- a/soc/arm/renesas_ra/common/pinctrl_ra.h
+++ b/soc/arm/renesas_ra/common/pinctrl_ra.h
@@ -56,7 +56,8 @@ struct pinctrl_ra_pin {
 			uint8_t pin: 4;
 			uint8_t port: 3;
 			uint32_t UNUSED24: 5;
-			uint8_t port4: 3;
+			uint8_t port4: 1;
+			uint32_t UNUSED30: 2;
 		};
 	};
 };
@@ -90,4 +91,4 @@ extern int pinctrl_ra_query_config(uint32_t port, uint32_t pin,
 				       Z_PINCTRL_STATE_PIN_INIT)                                   \
 	}
 
-#endif /* ZEPHYR_SOC_ARM_RENESAS_RA_RA6E1_PINCTRL_SOC_H_ */
+#endif /* ZEPHYR_SOC_ARM_RENESAS_RA_COMMON_RA_PINCTRL_SOC_H_ */


### PR DESCRIPTION
The RA_PINCFG macro is used to generate a value that can be written directly to the pin function select register. In addition to the pin function this value also contains port and pin number information, located in bit fields that are unused by the register. The bit field used to store the port information consists of 3-bits. However, a typo in the mask definition limited the field to two bits meaning only ports 0-3 could be configured. This patch resolves the issue, allowing ports 0-7 to be configured. If the port is greater than 7 another field (port8) is used to store the additional bits. However, use of this field has not yet been implemented.