### PR TITLE
posix: updates to clock_settime() and clock tests, add array for-each macros

### DIFF
--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -203,6 +203,23 @@ extern "C" {
 	})
 
 /**
+ * @brief Iterate over members of an array using an index variable
+ *
+ * @param array the array in question
+ * @param idx name of array index variable
+ */
+#define ARRAY_FOR_EACH(array, idx) for (size_t idx = 0; (idx) < ARRAY_SIZE(array); ++(idx))
+
+/**
+ * @brief Iterate over members of an array using a pointer
+ *
+ * @param array the array in question
+ * @param ptr pointer to an element of @p array
+ */
+#define ARRAY_FOR_EACH_PTR(array, ptr)                                                             \
+	for (__typeof__(*(array)) *ptr = (array); ((ptr) - (array)) < ARRAY_SIZE(array); ++(ptr))
+
+/**
  * @brief Validate if two entities have a compatible type
  *
  * @param a the first entity to be compared

--- a/lib/posix/clock.c
+++ b/lib/posix/clock.c
@@ -92,6 +92,11 @@ int clock_settime(clockid_t clock_id, const struct timespec *tp)
 		return -1;
 	}
 
+	if (tp->tv_nsec < 0 || tp->tv_nsec >= NSEC_PER_SEC) {
+		errno = EINVAL;
+		return -1;
+	}
+
 	uint64_t elapsed_nsecs = k_ticks_to_ns_floor64(k_uptime_ticks());
 	int64_t delta = (int64_t)NSEC_PER_SEC * tp->tv_sec + tp->tv_nsec
 		- elapsed_nsecs;

--- a/tests/posix/common/src/clock.c
+++ b/tests/posix/common/src/clock.c
@@ -8,70 +8,191 @@
 #include <unistd.h>
 
 #include <zephyr/ztest.h>
+#include <zephyr/logging/log.h>
 
 #define SLEEP_SECONDS 1
 #define CLOCK_INVALID -1
 
-ZTEST(posix_apis, test_clock)
+LOG_MODULE_REGISTER(clock_test);
+
+#define _tp_op(_as, _ans, _bs, _bns, op)                                                           \
+	((_as) * NSEC_PER_SEC + (_ans)op(_bs) * NSEC_PER_SEC + (_bns))
+
+/* a == b */
+static inline bool tp_eq(time_t a_sec, int64_t a_nsec, time_t b_sec, int64_t b_nsec)
 {
-	int64_t nsecs_elapsed, secs_elapsed;
-	struct timespec ts, te;
+	return _tp_op(a_sec, a_nsec, b_sec, b_nsec, ==);
+}
 
-	printk("POSIX clock APIs\n");
+/* a < b */
+static inline bool tp_lt(time_t a_sec, int64_t a_nsec, time_t b_sec, int64_t b_nsec)
+{
+	return _tp_op(a_sec, a_nsec, b_sec, b_nsec, <);
+}
 
-	/* TESTPOINT: Pass invalid clock type */
-	zassert_equal(clock_gettime(CLOCK_INVALID, &ts), -1,
-			NULL);
+/* a > b */
+static inline bool tp_gt(time_t a_sec, int64_t a_nsec, time_t b_sec, int64_t b_nsec)
+{
+	return _tp_op(a_sec, a_nsec, b_sec, b_nsec, >);
+}
+
+/* a <= b */
+static inline bool tp_le(time_t a_sec, int64_t a_nsec, time_t b_sec, int64_t b_nsec)
+{
+	return _tp_op(a_sec, a_nsec, b_sec, b_nsec, <=);
+}
+
+/* a >= b */
+static inline bool tp_ge(time_t a_sec, int64_t a_nsec, time_t b_sec, int64_t b_nsec)
+{
+	return _tp_op(a_sec, a_nsec, b_sec, b_nsec, >=);
+}
+
+/* a - b */
+static inline int64_t tp_diff_ns(time_t a_sec, int64_t a_nsec, time_t b_sec, int64_t b_nsec)
+{
+	return _tp_op((int64_t)a_sec, a_nsec, (int64_t)b_sec, b_nsec, -);
+}
+
+/* lo <= (a - b) < hi */
+static inline bool tp_diff_in_range_ns(time_t a_sec, int64_t a_nsec, time_t b_sec, int64_t b_nsec,
+				       int64_t lo, int64_t hi)
+{
+	int64_t diff = tp_diff_ns(a_sec, a_nsec, b_sec, b_nsec);
+
+	return diff >= lo && diff < hi;
+}
+
+static inline int64_t ts_to_ns(const struct timespec *ts)
+{
+	return ts->tv_sec * NSEC_PER_SEC + ts->tv_nsec;
+}
+
+ZTEST(posix_apis, test_clock_gettime)
+{
+	clockid_t clocks[] = {
+		CLOCK_MONOTONIC,
+		CLOCK_REALTIME,
+	};
+	struct timespec ts;
+
+	/* ensure argument validation is performed */
+	errno = 0;
+	zassert_equal(clock_gettime(CLOCK_INVALID, &ts), -1);
 	zassert_equal(errno, EINVAL);
 
-	zassert_ok(clock_gettime(CLOCK_MONOTONIC, &ts));
-	zassert_ok(k_sleep(K_SECONDS(SLEEP_SECONDS)));
-	zassert_ok(clock_gettime(CLOCK_MONOTONIC, &te));
-
-	if (te.tv_nsec >= ts.tv_nsec) {
-		secs_elapsed = te.tv_sec - ts.tv_sec;
-		nsecs_elapsed = te.tv_nsec - ts.tv_nsec;
-	} else {
-		nsecs_elapsed = NSEC_PER_SEC + te.tv_nsec - ts.tv_nsec;
-		secs_elapsed = (te.tv_sec - ts.tv_sec - 1);
+	if (false) {
+		/* not hardened */
+		errno = 0;
+		zassert_equal(clock_gettime(clocks[0], NULL), -1);
+		zassert_equal(errno, EINVAL);
 	}
 
-	/*TESTPOINT: Check if POSIX clock API test passes*/
-	zassert_equal(secs_elapsed, SLEEP_SECONDS,
-			"POSIX clock API test failed");
+	/* verify that we can call clock_gettime() on supported clocks */
+	ARRAY_FOR_EACH(clocks, i)
+	{
+		ts = (struct timespec){-1, -1};
+		zassert_ok(clock_gettime(clocks[i], &ts));
+		zassert_not_equal(ts.tv_sec, -1);
+		zassert_not_equal(ts.tv_nsec, -1);
+	}
+}
 
-	printk("POSIX clock APIs test done\n");
+ZTEST(posix_apis, test_gettimeofday)
+{
+	struct timeval tv;
+	struct timespec rts;
+
+	if (false) {
+		/* not hardened */
+		errno = 0;
+		zassert_equal(gettimeofday(NULL, NULL), -1);
+		zassert_equal(errno, EINVAL);
+	}
+
+	/* Validate gettimeofday API */
+	zassert_ok(gettimeofday(&tv, NULL));
+	zassert_ok(clock_gettime(CLOCK_REALTIME, &rts));
+
+	/* TESTPOINT: Check if time obtained from
+	 * gettimeofday is same or more than obtained
+	 * from clock_gettime
+	 */
+	zassert_true(tp_ge(rts.tv_sec, rts.tv_nsec, tv.tv_sec, tv.tv_usec * NSEC_PER_USEC));
+}
+
+ZTEST(posix_apis, test_clock_setttime)
+{
+	int64_t diff_ns;
+	clockid_t clocks[] = {
+		CLOCK_MONOTONIC,
+		CLOCK_REALTIME,
+	};
+	bool settable[] = {
+		false,
+		true,
+	};
+	struct timespec ts = {0};
+
+	BUILD_ASSERT(ARRAY_SIZE(settable) == ARRAY_SIZE(clocks));
+
+	/* ensure argument validation is performed */
+	errno = 0;
+	zassert_equal(clock_settime(CLOCK_INVALID, &ts), -1);
+	zassert_equal(errno, EINVAL);
+
+	if (false) {
+		/* not hardened */
+		errno = 0;
+		zassert_equal(clock_settime(CLOCK_REALTIME, NULL), -1);
+		zassert_equal(errno, EINVAL);
+	}
+
+	/* verify nanoseconds */
+	errno = 0;
+	ts = (struct timespec){0, NSEC_PER_SEC};
+	zassert_equal(clock_settime(CLOCK_REALTIME, &ts), -1);
+	zassert_equal(errno, EINVAL);
+	errno = 0;
+	ts = (struct timespec){0, -1};
+	zassert_equal(clock_settime(CLOCK_REALTIME, &ts), -1);
+	zassert_equal(errno, EINVAL);
+
+	ARRAY_FOR_EACH(clocks, i)
+	{
+		if (!settable[i]) {
+			/* should fail attempting to set unsettable clocks */
+			errno = 0;
+			zassert_equal(clock_settime(clocks[i], &ts), -1);
+			zassert_equal(errno, EINVAL);
+			continue;
+		}
+
+		/* Set a particular time.  In this case, the output of:
+		 * `date +%s -d 2018-01-01T15:45:01Z`
+		 */
+		ts = (struct timespec){1514821501, NSEC_PER_SEC / 2U};
+		zassert_ok(clock_settime(clocks[i], &ts));
+
+		/* read-back the time */
+		zassert_ok(clock_gettime(clocks[i], &ts));
+		/* dt should be >= 0, but definitely <= 1s */
+		diff_ns = tp_diff_ns(ts.tv_sec, ts.tv_nsec, 1514821501, NSEC_PER_SEC / 2U);
+		zassert_true(diff_ns >= 0 && diff_ns <= NSEC_PER_SEC);
+	}
 }
 
 ZTEST(posix_apis, test_realtime)
 {
-	int ret;
-	struct timespec rts, mts;
-	struct timeval tv;
+	int64_t delta;
+	int64_t error;
+	int64_t last_delta = 0;
+	struct timespec rts = {0};
 
-	ret = clock_gettime(CLOCK_MONOTONIC, &mts);
-	zassert_equal(ret, 0, "Fail to get monotonic clock");
-
-	ret = clock_gettime(CLOCK_REALTIME, &rts);
-	zassert_equal(ret, 0, "Fail to get realtime clock");
-
-	/* Set a particular time.  In this case, the output of:
-	 * `date +%s -d 2018-01-01T15:45:01Z`
-	 */
-	struct timespec nts;
-	nts.tv_sec = 1514821501;
-	nts.tv_nsec = NSEC_PER_SEC / 2U;
-
-	/* TESTPOINT: Pass invalid clock type */
-	zassert_equal(clock_settime(CLOCK_INVALID, &nts), -1,
-			NULL);
-	zassert_equal(errno, EINVAL);
-
-	ret = clock_settime(CLOCK_MONOTONIC, &nts);
-	zassert_not_equal(ret, 0, "Should not be able to set monotonic time");
-
-	ret = clock_settime(CLOCK_REALTIME, &nts);
-	zassert_equal(ret, 0, "Fail to set realtime clock");
+	/* This test fails way too frequently on Qemu and POSIX platforms */
+	if (IS_ENABLED(CONFIG_QEMU_TARGET) || IS_ENABLED(CONFIG_ARCH_POSIX)) {
+		ztest_test_skip();
+	}
 
 	/*
 	 * Loop 20 times, sleeping a little bit for each, making sure
@@ -79,47 +200,25 @@ ZTEST(posix_apis, test_realtime)
 	 * catch all of the boundary conditions of the clock to make
 	 * sure there are no errors in the arithmetic.
 	 */
-	int64_t last_delta = 0;
+	zassert_ok(clock_gettime(CLOCK_REALTIME, &rts), "Fail to set realtime clock");
 	for (int i = 1; i <= 20; i++) {
-		usleep(USEC_PER_MSEC * 90U);
-		ret = clock_gettime(CLOCK_REALTIME, &rts);
-		zassert_equal(ret, 0, "Fail to read realtime clock");
+		zassert_ok(k_usleep(USEC_PER_MSEC * 90U));
+		zassert_ok(clock_gettime(CLOCK_REALTIME, &rts), "Fail to read realtime clock");
 
-		int64_t delta =
-			((int64_t)rts.tv_sec * NSEC_PER_SEC -
-			 (int64_t)nts.tv_sec * NSEC_PER_SEC) +
-			((int64_t)rts.tv_nsec - (int64_t)nts.tv_nsec);
+		delta = tp_diff_ns(rts.tv_sec, rts.tv_nsec, 0, 0);
 
 		/* Make the delta milliseconds. */
 		delta /= (NSEC_PER_SEC / 1000U);
 
 		zassert_true(delta > last_delta, "Clock moved backward");
-		int64_t error = delta - last_delta;
+		error = delta - last_delta;
 
-		/* printk("Delta %d: %lld\n", i, delta); */
+		LOG_DBG("i: %d, delta: %lld, error: %lld", i, delta, error);
 
-		/* Allow for a little drift upward, but not
-		 * downward
-		 */
+		/* Allow for a little drift upward, but not downward */
 		zassert_true(error >= 90, "Clock inaccurate %d", error);
 		zassert_true(error <= 110, "Clock inaccurate %d", error);
 
 		last_delta = delta;
 	}
-
-	/* Validate gettimeofday API */
-	ret = gettimeofday(&tv, NULL);
-	zassert_equal(ret, 0);
-
-	ret = clock_gettime(CLOCK_REALTIME, &rts);
-	zassert_equal(ret, 0);
-
-	/* TESTPOINT: Check if time obtained from
-	 * gettimeofday is same or more than obtained
-	 * from clock_gettime
-	 */
-	zassert_true(rts.tv_sec >= tv.tv_sec, "gettimeofday didn't"
-			" provide correct result");
-	zassert_true(rts.tv_nsec >= tv.tv_usec * NSEC_PER_USEC,
-			"gettimeofday didn't provide correct result");
 }


### PR DESCRIPTION
* check for invalid nsec in `clock_settime()`
* add `ARRAY_FOR_EACH()` `ARRAY_FOR_EACH_PTR()`
* skip `test_realtime` on qemu and posix platforms, because it is super flakey