### PR TITLE
cmake: sparse.template: add COMMAND_ERROR_IS_FATAL

### DIFF
--- a/cmake/sca/sparse/sparse.template
+++ b/cmake/sca/sparse/sparse.template
@@ -16,4 +16,6 @@ endforeach()
 foreach(i RANGE ${end_of_options} ${CMAKE_ARGC})
   list(APPEND ARGS ${CMAKE_ARGV${i}})
 endforeach()
-execute_process(COMMAND @CMAKE_COMMAND@ -E env REAL_CC=@CMAKE_C_COMPILER@ @SPARSE_COMPILER@ ${ARGS})
+execute_process(COMMAND @CMAKE_COMMAND@ -E env REAL_CC=@CMAKE_C_COMPILER@ @SPARSE_COMPILER@ ${ARGS}
+  COMMAND_ERROR_IS_FATAL ANY
+)


### PR DESCRIPTION
There are some situations like #67035 or #63003 where sparse aborts and returns an error code before the compiler has generated the .obj file; without any clear indication that the .obj is missing (in normal situations sparse prints warnings and _does_ creates the .obj file)

Also, builds are parallel by default and sparse runs tend to be massive walls of text which all conspires to make it totally impossible to find the relevant error message. Instead, we get an link-time error.

The only clear indication is the exit code. So catch it and abort the build ASAP thanks to COMMAND_ERROR_IS_FATAL.

More generally speaking, the default behavior of execute_process() to ignore errors is crazy. How frequently does a build system run commands that do NOT matter?