### PR TITLE
syscall_handler: Fix warnings in K_SYSCALL_MEMORY

### DIFF
--- a/include/zephyr/internal/syscall_handler.h
+++ b/include/zephyr/internal/syscall_handler.h
@@ -408,7 +408,7 @@ int k_usermode_string_copy(char *dst, const char *src, size_t maxlen);
  *       functionality in the Zephyr tree.
  */
 #define K_SYSCALL_MEMORY_SIZE_CHECK(ptr, size) \
-	(((uintptr_t)ptr + size) >= (uintptr_t)ptr)
+	(((uintptr_t)(ptr) + (size)) >= (uintptr_t)(ptr))
 
 /**
  * @brief Runtime check that a user thread has read and/or write permission to


### PR DESCRIPTION
Put parenthesis around parameters in K_SYSCALL_MEMORY_SIZE_CHECK to avoid possible warnings during the macro expansion.