### PR TITLE
posix: implement clock_getcpuclockid()

### DIFF
--- a/include/zephyr/posix/posix_types.h
+++ b/include/zephyr/posix/posix_types.h
@@ -21,6 +21,8 @@
 extern "C" {
 #endif
 
+typedef int pid_t;
+
 #ifndef __useconds_t_defined
 typedef unsigned long useconds_t;
 #endif

--- a/include/zephyr/posix/time.h
+++ b/include/zephyr/posix/time.h
@@ -69,6 +69,10 @@ extern "C" {
 #define CLOCK_REALTIME 1
 #endif
 
+#ifndef CLOCK_PROCESS_CPUTIME_ID
+#define CLOCK_PROCESS_CPUTIME_ID 2
+#endif
+
 #ifndef CLOCK_MONOTONIC
 #define CLOCK_MONOTONIC 4
 #endif
@@ -84,6 +88,7 @@ static inline int32_t _ts_to_ms(const struct timespec *to)
 
 int clock_gettime(clockid_t clock_id, struct timespec *ts);
 int clock_settime(clockid_t clock_id, const struct timespec *ts);
+int clock_getcpuclockid(pid_t pid, clockid_t *clock_id);
 /* Timer APIs */
 int timer_create(clockid_t clockId, struct sigevent *evp, timer_t *timerid);
 int timer_delete(timer_t timerid);

--- a/include/zephyr/posix/unistd.h
+++ b/include/zephyr/posix/unistd.h
@@ -51,6 +51,7 @@ extern char *optarg;
 extern int opterr, optind, optopt;
 #endif
 
+pid_t getpid(void);
 unsigned sleep(unsigned int seconds);
 int usleep(useconds_t useconds);
 

--- a/lib/posix/clock.c
+++ b/lib/posix/clock.c
@@ -10,6 +10,7 @@
 #include <errno.h>
 #include <zephyr/posix/time.h>
 #include <zephyr/posix/sys/time.h>
+#include <zephyr/posix/unistd.h>
 #include <zephyr/internal/syscall_handler.h>
 #include <zephyr/spinlock.h>
 
@@ -221,4 +222,16 @@ int gettimeofday(struct timeval *tv, void *tz)
 	tv->tv_usec = ts.tv_nsec / NSEC_PER_USEC;
 
 	return res;
+}
+
+int clock_getcpuclockid(pid_t pid, clockid_t *clock_id)
+{
+	/* We don't allow any process ID but our own.  */
+	if (pid != 0 && pid != getpid()) {
+		return EPERM;
+	}
+
+	*clock_id = CLOCK_PROCESS_CPUTIME_ID;
+
+	return 0;
 }

--- a/lib/posix/pthread.c
+++ b/lib/posix/pthread.c
@@ -15,6 +15,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/posix/pthread.h>
+#include <zephyr/posix/unistd.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
 
@@ -156,6 +157,22 @@ pthread_t pthread_self(void)
 int pthread_equal(pthread_t pt1, pthread_t pt2)
 {
 	return (pt1 == pt2);
+}
+
+pid_t getpid(void)
+{
+	/*
+	 * To maintain compatibility with some other POSIX operating systems,
+	 * a PID of zero is used to indicate that the process exists in another namespace.
+	 * PID zero is also used by the scheduler in some cases.
+	 * PID one is usually reserved for the init process.
+	 * Also note, that negative PIDs may be used by kill()
+	 * to send signals to process groups in some implementations.
+	 *
+	 * At the moment, getpid just returns an arbitrary number >= 2
+	 */
+
+	return 42;
 }
 
 static inline void __z_pthread_cleanup_init(struct __pthread_cleanup *c, void (*routine)(void *arg),

--- a/tests/posix/common/src/clock.c
+++ b/tests/posix/common/src/clock.c
@@ -213,3 +213,15 @@ ZTEST(posix_apis, test_realtime)
 		CONFIG_TEST_CLOCK_RT_ERROR_MS, lo_wm, cma, hi_wm);
 	zassert_between_inclusive(cma, lo, hi);
 }
+
+ZTEST(posix_apis, test_clock_getcpuclockid)
+{
+	int ret = 0;
+	clockid_t clock_id;
+
+	ret = clock_getcpuclockid((pid_t)0, &clock_id);
+	zassert_equal(ret, 0, "POSIX clock_getcpuclock id failed");
+
+	ret = clock_getcpuclockid((pid_t)2482, &clock_id);
+	zassert_equal(ret, EPERM, "POSIX clock_getcpuclock id failed");
+}


### PR DESCRIPTION
Patch implements clock_getcpuclockid
Fix for #59954

I have based my implementation around 
1. https://pubs.opengroup.org/onlinepubs/9699919799/functions/clock_getcpuclockid.html
2. https://www.man7.org/linux/man-pages/man3/clock_getcpuclockid.3p.html (for reference)

Since zephyr only supports single process, access is allowed for clock ID only of that process specified by its process id (pid).

