### PR TITLE
lib: support linking to POSIX API with 3rd-party libc

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -4,10 +4,10 @@
 add_compile_options($<TARGET_PROPERTY:compiler,warning_shadow_variables>)
 
 add_subdirectory(crc)
-if(NOT CONFIG_EXTERNAL_LIBC)
+if(NOT CONFIG_NATIVE_LIBC)
 add_subdirectory(libc)
-add_subdirectory(posix)
 endif()
+add_subdirectory(posix)
 add_subdirectory_ifdef(CONFIG_CPP                  cpp)
 add_subdirectory(hash)
 add_subdirectory(heap)


### PR DESCRIPTION
Previously it was not possible to link to Zephyr's POSIX API under lib/posix when building with
`CONFIG_EXTERNAL_LIBC=y`.

This small change allows that to work as expected.

Fixes #67041
Fixes #41489