### PR TITLE
soc/arm/renesas_rzt2m: set default System Clock Control register values

### DIFF
--- a/dts/arm/renesas/rz/rzt2m.dtsi
+++ b/dts/arm/renesas/rz/rzt2m.dtsi
@@ -89,6 +89,20 @@
 			reg-io-width = <4>;
 		};
 
+		sckcr: sckcr@81280004 {
+			/* System Clock Control Register*/
+			compatible = "syscon";
+			reg = <0x80280000 0x20>;
+			reg-io-width = <4>;
+		};
+
+		sckcr2: sckcr2@81280004 {
+			/* System Clock Control Register 2 */
+			compatible = "syscon";
+			reg = <0x81280004 0x1a>;
+			reg-io-width = <4>;
+		};
+
 		uart0: serial@80001000 {
 			compatible = "renesas,rzt2m-uart";
 			reg = <0x80001000 0x1000>;

--- a/soc/renesas/rzt2m/soc.c
+++ b/soc/renesas/rzt2m/soc.c
@@ -12,6 +12,8 @@
 
 static const struct device *const prcrn_dev = DEVICE_DT_GET(DT_NODELABEL(prcrn));
 static const struct device *const prcrs_dev = DEVICE_DT_GET(DT_NODELABEL(prcrs));
+static const struct device *const sckcr_dev = DEVICE_DT_GET(DT_NODELABEL(sckcr));
+static const struct device *const sckcr2_dev = DEVICE_DT_GET(DT_NODELABEL(sckcr2));
 
 void rzt2m_unlock_prcrn(uint32_t mask)
 {
@@ -55,6 +57,32 @@ void rzt2m_lock_prcrs(uint32_t mask)
 	syscon_write_reg(prcrs_dev, 0, prcrs);
 }
 
+void rzt2m_set_sckcr2(uint32_t mask)
+{
+	syscon_write_reg(sckcr2_dev, 0, mask);
+}
+
+uint32_t rzt2m_get_sckcr2(void)
+{
+	uint32_t reg;
+
+	syscon_read_reg(sckcr2_dev, 0, &reg);
+	return reg;
+}
+
+void rzt2m_set_sckcr(uint32_t mask)
+{
+	syscon_write_reg(sckcr_dev, 0, mask);
+}
+
+uint32_t rzt2m_get_sckcr(void)
+{
+	uint32_t reg;
+
+	syscon_read_reg(sckcr_dev, 0, &reg);
+	return reg;
+}
+
 void rzt2m_enable_counters(void)
 {
 	const struct device *const dev = DEVICE_DT_GET(DT_NODELABEL(gsc));
@@ -68,6 +96,23 @@ static int rzt2m_init(void)
 	 * so that device drivers can access configuration registers of peripherals.
 	 */
 	/* After the device drivers are done, lock the Protect Registers. */
+	rzt2m_unlock_prcrs(PRCRS_GPIO | PRCRS_CLK);
+	rzt2m_unlock_prcrn(PRCRN_PRC1 | PRCRN_PRC2 | PRCRN_PRC0);
+
+	/* Reset the System Clock Control Registers to default values */
+	rzt2m_set_sckcr(
+		CLMASEL |
+		PHYSEL |
+		FSELCANFD |
+		FSELXSPI0_DEFAULT |
+		FSELXSPI1_DEFAULT |
+		CKIO_DEFAULT
+	);
+
+	rzt2m_set_sckcr2(FSELCPU0_DEFAULT | FSELCPU1_DEFAULT);
+
+	rzt2m_lock_prcrs(PRCRS_GPIO | PRCRS_CLK);
+	rzt2m_lock_prcrn(PRCRN_PRC1 | PRCRN_PRC2 | PRCRN_PRC0);
 
 	rzt2m_enable_counters();
 	return 0;

--- a/soc/renesas/rzt2m/soc.h
+++ b/soc/renesas/rzt2m/soc.h
@@ -27,6 +27,30 @@
 #define PRCRN_PRC1 BIT(1)
 #define PRCRN_PRC2 BIT(2)
 
+#define SCI4ASYNCSEL BIT(31)
+#define SCI3ASYNCSEL BIT(30)
+#define SCI2ASYNCSEL BIT(29)
+#define SCI1ASYNCSEL BIT(28)
+#define SCI0ASYNCSEL BIT(27)
+#define SPI2ASYNCSEL BIT(26)
+#define SPI1ASYNCSEL BIT(25)
+#define SPI0ASYNCSEL BIT(24)
+#define CLMASEL      BIT(22)
+#define PHYSEL       BIT(21)
+#define FSELCANFD    BIT(20)
+#define DIVSELXSPI1  BIT(14)
+#define DIVSELXSPI0  BIT(6)
+
+#define CKIO_DEFAULT      BIT(17)
+#define FSELXSPI1_DEFAULT GENMASK(10, 9)
+#define FSELXSPI0_DEFAULT GENMASK(2, 1)
+
+#define SCI5ASYNCSEL     BIT(25)
+#define SPI3ASYNCSEL     BIT(24)
+#define DIVSELSUB        BIT(5)
+#define FSELCPU1_DEFAULT 0b10 << 2
+#define FSELCPU0_DEFAULT 0b10 << 0
+
 /* PRC Key Code - this value is required to allow any write operation
  * to the PRCRS / PRCRN registers.
  * See section 10.2 of the RZ/T2M User's Manual: Hardware.
@@ -37,5 +61,10 @@ void rzt2m_unlock_prcrn(uint32_t mask);
 void rzt2m_lock_prcrn(uint32_t mask);
 void rzt2m_unlock_prcrs(uint32_t mask);
 void rzt2m_lock_prcrs(uint32_t mask);
+
+void rzt2m_set_sckcr2(uint32_t mask);
+uint32_t rzt2m_get_sckcr2(void);
+void rzt2m_set_sckcr(uint32_t mask);
+uint32_t rzt2m_get_sckcr(void);
 
 #endif /* _SOC__H_ */


### PR DESCRIPTION
This PR implements the verbose setting of default clock control register values for the RZ/T2M board. Previously, those registers were not set and if on the same `debugserver` session one has launched another binary and said registers were modified, it wouldn't re-adjust later in Zephyr.

Fixes #65674 