### PR TITLE
lib: posix: tag the fallthrough case as __fallthrough

### DIFF
--- a/lib/posix/fnmatch.c
+++ b/lib/posix/fnmatch.c
@@ -44,6 +44,7 @@
 #include <string.h>
 
 #include <zephyr/posix/fnmatch.h>
+#include <zephyr/toolchain.h>
 
 #define EOS '\0'
 
@@ -243,7 +244,7 @@ static int fnmatchx(const char *pattern, const char *string, int flags, size_t r
 					--pattern;
 				}
 			}
-			/* FALLTHROUGH */
+			__fallthrough;
 		default:
 			if (c != FOLDCASE(*string++, flags)) {
 				return FNM_NOMATCH;
@@ -252,7 +253,6 @@ static int fnmatchx(const char *pattern, const char *string, int flags, size_t r
 			break;
 		}
 	}
-	/* NOTREACHED */
 }
 
 int fnmatch(const char *pattern, const char *string, int flags)


### PR DESCRIPTION
Use the __fallthrough directive on the switch fallthrough case and drop the comment instead. This informs the compiler that the fallthrough is intentional and silence any possible warning about it.

Drop the not reached case as I think that that part can actually be reached since there are breaks in some of the cases.