### PR TITLE
soc: arm: ambiq: Remove the redundant configurations

### DIFF
--- a/soc/arm/ambiq/apollo4x/Kconfig.defconfig.apollo4p
+++ b/soc/arm/ambiq/apollo4x/Kconfig.defconfig.apollo4p
@@ -7,12 +7,4 @@ if SOC_APOLLO4P
 config NUM_IRQS
 	default 83
 
-DT_NODE_SRAM := /memory@0
-
-config SRAM_NC_SIZE
-	default $(dt_node_reg_size_int,$(DT_NODE_SRAM),1,K)
-
-config SRAM_NC_BASE_ADDRESS
-	default $(dt_node_reg_addr_hex,$(DT_NODE_SRAM),1)
-
 endif # SOC_APOLLO4P

--- a/soc/arm/ambiq/apollo4x/Kconfig.defconfig.apollo4p_blue
+++ b/soc/arm/ambiq/apollo4x/Kconfig.defconfig.apollo4p_blue
@@ -7,12 +7,4 @@ if SOC_APOLLO4P_BLUE
 config NUM_IRQS
 	default 83
 
-DT_NODE_SRAM := /memory@0
-
-config SRAM_NC_SIZE
-	default $(dt_node_reg_size_int,$(DT_NODE_SRAM),1,K)
-
-config SRAM_NC_BASE_ADDRESS
-	default $(dt_node_reg_addr_hex,$(DT_NODE_SRAM),1)
-
 endif # SOC_APOLLO4P_BLUE


### PR DESCRIPTION
These non-cached SRAM size and base address configurations are not needed now.
Since the original configuration reference in Aspeed SoCs will be removed, we need to clean up these configurations in Apollo4 to dismiss the compiling errors.