### PR TITLE
modem: cmux: fix frame data length encoding

### DIFF
--- a/subsys/modem/modem_cmux.c
+++ b/subsys/modem/modem_cmux.c
@@ -232,7 +232,7 @@ static uint16_t modem_cmux_transmit_frame(struct modem_cmux *cmux,
 		byte = data_len << 1;
 		fcs = crc8(&byte, 1, MODEM_CMUX_FCS_POLYNOMIAL, fcs, true);
 		ring_buf_put(&cmux->transmit_rb, &byte, 1);
-		byte = 0x01 | (data_len >> 7);
+		byte = data_len >> 7;
 		ring_buf_put(&cmux->transmit_rb, &byte, 1);
 	} else {
 		byte = 0x01 | (data_len << 1);


### PR DESCRIPTION
In cases where the data is bigger than 127 bytes, the first bit of the second byte of the data length field used to always be set.

This is wrong as according to the 3GPP 27.010 spec only the first bit of the first byte is the EA bit; all the others denote the data length.