### PR TITLE
Bluetooth: add exit path handling

### DIFF
--- a/drivers/bluetooth/hci/h4.c
+++ b/drivers/bluetooth/hci/h4.c
@@ -529,6 +529,13 @@ static int h4_open(void)
 	return 0;
 }
 
+static int h4_close(void)
+{
+	k_thread_abort(&rx_thread_data);
+
+	return 0;
+}
+
 #if defined(CONFIG_BT_HCI_SETUP)
 static int h4_setup(const struct bt_hci_setup_params *params)
 {
@@ -550,6 +557,7 @@ static const struct bt_hci_driver drv = {
 	.name		= "H:4",
 	.bus		= BT_HCI_DRIVER_BUS_UART,
 	.open		= h4_open,
+	.close		= h4_close,
 	.send		= h4_send,
 #if defined(CONFIG_BT_HCI_SETUP)
 	.setup		= h4_setup

--- a/drivers/bluetooth/hci/h5.c
+++ b/drivers/bluetooth/hci/h5.c
@@ -768,10 +768,29 @@ static int h5_open(void)
 	return 0;
 }
 
+static void h5_deinit(void)
+{
+	k_work_cancel_delayable(&retx_work);
+	k_work_cancel_delayable(&ack_work);
+
+	k_thread_abort(&rx_thread_data);
+	k_thread_abort(&tx_thread_data);
+}
+
+static int h5_close(void)
+{
+	uart_irq_rx_disable(h5_dev);
+
+	h5_deinit();
+
+	return 0;
+}
+
 static const struct bt_hci_driver drv = {
 	.name		= "H:5",
 	.bus		= BT_HCI_DRIVER_BUS_UART,
 	.open		= h5_open,
+	.close		= h5_close,
 	.send		= h5_queue,
 };
 


### PR DESCRIPTION
When no response from the controller the host will BT_ASSERT the system which will go system reset, return on error will
result the bluetooth initialization failure and  handle exit path.