### PR TITLE
Nucleo h745zi q refactor clock config

### DIFF
--- a/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m7.dts
+++ b/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m7.dts
@@ -6,7 +6,6 @@
 
 /dts-v1/;
 #include <st/h7/stm32h745Xi_m7.dtsi>
-#include <st/h7/stm32h745zitx-pinctrl.dtsi>
 #include "nucleo_h745zi_q.dtsi"
 
 /*
@@ -63,7 +62,7 @@
 	div-m = <1>;
 	mul-n = <120>;
 	div-p = <2>;
-	div-q = <2>;
+	div-q = <8>;
 	div-r = <2>;
 	clocks = <&clk_hse>;
 	status = "okay";


### PR DESCRIPTION
Change div-q to fulfill FDCAN clock requirements
Remove included file already included by other dependency.