### PR TITLE
soc: nrf53: fix building anomaly 168 workaround

### DIFF
--- a/soc/arm/nordic_nrf/nrf53/soc_cpu_idle.h
+++ b/soc/arm/nordic_nrf/nrf53/soc_cpu_idle.h
@@ -13,12 +13,12 @@
 
 #if defined(CONFIG_SOC_NRF53_ANOMALY_168_WORKAROUND_FOR_EXECUTION_FROM_RAM)
 #define SOC_ON_EXIT_CPU_IDLE \
-	.rept 26 \
+	.rept 26; \
 	nop; \
 	.endr
 #elif defined(CONFIG_SOC_NRF53_ANOMALY_168_WORKAROUND)
 #define SOC_ON_EXIT_CPU_IDLE \
-	.rept 8 \
+	.rept 8; \
 	nop; \
 	.endr
 #endif


### PR DESCRIPTION
With GCC 12.3 and binutils 2.40, the build fails with:

```
<...>/zephyr/arch/arm/core/cortex_m/cpu_idle.S: Assembler messages:
<...>/zephyr/arch/arm/core/cortex_m/cpu_idle.S:51: Error: junk at end of line, first unrecognized character is `n'
<...>/zephyr/arch/arm/core/cortex_m/cpu_idle.S:133:   Info: macro invoked from here
```

Because the `SOC_ON_EXIT_CPU_IDLE` macro puts all the statements on a single line, there must be a semicolon after `.rept`. Presumably it works without the semicolons on some compiler, but I'm not sure which one.