### PR TITLE
posix: threads: implement pthread_testcancel()

### DIFF
--- a/include/zephyr/posix/pthread.h
+++ b/include/zephyr/posix/pthread.h
@@ -433,6 +433,7 @@ int pthread_create(pthread_t *newthread, const pthread_attr_t *attr,
 		   void *(*threadroutine)(void *), void *arg);
 int pthread_setcancelstate(int state, int *oldstate);
 int pthread_setcanceltype(int type, int *oldtype);
+void pthread_testcancel(void);
 int pthread_attr_setschedparam(pthread_attr_t *attr,
 			       const struct sched_param *schedparam);
 int pthread_setschedparam(pthread_t pthread, int policy,


### PR DESCRIPTION
`pthread_testcancel()` is critical for implementing cancellation points and checking for deferred cancellation of POSIX threads.

`pthread_testcancel()` is required by the `POSIX_THREADS_BASE` Option Group as detailed in Section E.1 of IEEE-1003.1-2017.
    
The `POSIX_THREADS_BASE` Option Group is required for PSE51, PSE52, PSE53, and PSE54 conformance and is otherwise mandatory for any POSIX conforming system as per Section A.2.1.3 of IEEE-1003-1.2017.

Additional Notes:
* finally fixed `pthread_attr_init()` and `pthread_attr_destroy()` so that they manage thread stacks
* finally embedded `struct posix_thread_attr` inside of `struct posix_thread`, which simplifies things
* it's very evident at this point that there is bitrot in `tests/posix/common/`
* created #67091 to address refactoring that suite

Fixes #59946