### PR TITLE
driver: usb: change function parameter name from class to base_class.

### DIFF
--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -703,16 +703,16 @@ int usbd_device_set_pid(struct usbd_contex *const uds_ctx,
 /**
  * @brief Set USB device descriptor code triple Base Class, SubClass, and Protocol
  *
- * @param[in] uds_ctx  Pointer to USB device support context
- * @param[in] class    bDeviceClass value
- * @param[in] subclass bDeviceSubClass value
- * @param[in] protocol bDeviceProtocol value
+ * @param[in] uds_ctx    Pointer to USB device support context
+ * @param[in] base_class bDeviceClass value
+ * @param[in] subclass   bDeviceSubClass value
+ * @param[in] protocol   bDeviceProtocol value
  *
  * @return 0 on success, other values on fail.
  */
 int usbd_device_set_code_triple(struct usbd_contex *const uds_ctx,
-				const uint8_t class, const uint8_t subclass,
-				const uint8_t protocol);
+				const uint8_t base_class,
+				const uint8_t subclass, const uint8_t protocol);
 
 /**
  * @brief Setup USB device configuration attribute Remote Wakeup

--- a/subsys/usb/device_next/usbd_device.c
+++ b/subsys/usb/device_next/usbd_device.c
@@ -81,8 +81,8 @@ set_pid_exit:
 }
 
 int usbd_device_set_code_triple(struct usbd_contex *const uds_ctx,
-				const uint8_t class, const uint8_t subclass,
-				const uint8_t protocol)
+				const uint8_t base_class,
+				const uint8_t subclass, const uint8_t protocol)
 {
 	struct usb_device_descriptor *desc = uds_ctx->desc;
 	int ret = 0;
@@ -94,7 +94,7 @@ int usbd_device_set_code_triple(struct usbd_contex *const uds_ctx,
 		goto set_code_triple_exit;
 	}
 
-	desc->bDeviceClass = class;
+	desc->bDeviceClass = base_class;
 	desc->bDeviceSubClass = subclass;
 	desc->bDeviceProtocol = protocol;
 


### PR DESCRIPTION
Change function parameter name in function usbd_device_set_code_triple from `class` to `base_class` as `class` is a keyword in C++.

Signed-off-by: Shane Snover <ssnover95@gmail.com>