### PR TITLE
drivers: ethernet: stm32: Enabling HW checksum offloading for STM32H7.

### DIFF
--- a/drivers/ethernet/Kconfig.stm32_hal
+++ b/drivers/ethernet/Kconfig.stm32_hal
@@ -137,7 +137,7 @@ config ETH_STM32_AUTO_NEGOTIATION_ENABLE
 
 config ETH_STM32_HW_CHECKSUM
 	bool "Use TX and RX hardware checksum"
-	depends on (!SOC_SERIES_STM32H7X && !SOC_SERIES_STM32H5X )
+	depends on !SOC_SERIES_STM32H5X
 	help
 	  Enable receive and transmit checksum offload to enhance throughput
 	  performances.


### PR DESCRIPTION
This change adds support for enabling ethernet MAC hardware checksum offloading for STM32H7 based devices.

In Section 58.5.9 of the STM32H7 reference manual it mentions that the STM32H7 ethernet MAC supports a Checksum Offload Module (COE).

I have tested the changes on my end where I enabled CONFIG_ETH_STM32_HW_CHECKSUM and ensured that an application that runs Zephyr on the STM32H7 can interoperate with a device with a completely different implementation. Also, I deliberately made the software not populate the IPv4 and UDP header checksum fields in their respective headers and the COE was able to populate the IPv4 and UDP header checksums.

Given that CONFIG_ETH_STM32_HW_CHECKSUM is not enabled by default application developers have the option to either enable it or disable it.