### PR TITLE
Enable tristate Kconfig options

### DIFF
--- a/subsys/Kconfig
+++ b/subsys/Kconfig
@@ -53,4 +53,14 @@ source "subsys/usb/usb_c/Kconfig"
 source "subsys/zbus/Kconfig"
 # zephyr-keep-sorted-stop
 
+config MODULES
+	bool "Make tristate Kconfig options and an 'm' selection available"
+	help
+	  Zephyr supports dynamically loadable code, e.g. using llext. Code,
+	  that can either be built as a part of the system image or as a
+	  loadable extension, can use tristate Kconfig options. For this to work
+	  the CONFIG_MODULES option must be enabled by the project. Enabling
+	  this option alone doesn't change the build on its own, it only allows
+	  using 'm' for tristate Kconfig options.
+
 endmenu

--- a/tests/subsys/llext/Kconfig
+++ b/tests/subsys/llext/Kconfig
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024 Intel Corporation.
+
+mainmenu "LLEXT functionality test"
+
+source "Kconfig.zephyr"
+
+config LLEXT_TEST_HELLO
+	tristate "llext hello test"
+	default n
+	help
+	  Set to "m" to test hello-world loading

--- a/tests/subsys/llext/hello_world/CMakeLists.txt
+++ b/tests/subsys/llext/hello_world/CMakeLists.txt
@@ -5,6 +5,8 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(hello_world)
 
+if(NOT CONFIG_MODULES OR CONFIG_LLEXT_TEST_HELLO STREQUAL "m")
+
 # TODO check which architecture is being used
 if(CONFIG_ARM)
     set(CMAKE_C_FLAGS "-mlong-calls" "-mthumb")
@@ -34,3 +36,5 @@ endif()
 set(HELLO_WORLD_LLEXT ${PROJECT_BINARY_DIR}/hello_world.llext PARENT_SCOPE)
 
 add_custom_target(hello_world DEPENDS ${PROJECT_BINARY_DIR}/hello_world.llext)
+
+endif()

--- a/tests/subsys/llext/testcase.yaml
+++ b/tests/subsys/llext/testcase.yaml
@@ -6,6 +6,8 @@ tests:
     arch_allow: arm
     extra_configs:
       - CONFIG_ARM_MPU=n
+      - CONFIG_MODULES=y
+      - CONFIG_LLEXT_TEST_HELLO=m
     # Broken platforms
     platform_exclude:
       - nuvoton_pfm_m487 # See #63167
@@ -13,6 +15,8 @@ tests:
     arch_allow: xtensa
     extra_configs:
       - CONFIG_LLEXT_STORAGE_WRITABLE=y
+      - CONFIG_MODULES=y
+      - CONFIG_LLEXT_TEST_HELLO=m
     # Broken platforms
     platform_exclude:
       - qemu_xtensa_mmu # ELF sections are read-only, and without peek() .text copy isn't executable


### PR DESCRIPTION
kconfiglib.py has a hard dependency on CONFIG_MODULES to support 'm' values for tristate Kconfig options. It's a logical companion for but can also be used with other configurations.