### PR TITLE
Bluetooth: BAP: Restrict application ASCS response codes

### DIFF
--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -183,7 +183,19 @@ enum bt_bap_ascs_reason {
 
 /** @brief Structure storing values of fields of ASE Control Point notification. */
 struct bt_bap_ascs_rsp {
-	/** @brief Value of the Response Code field. */
+	/**
+	 * @brief Value of the Response Code field.
+	 *
+	 * The following response codes are accepted:
+	 * - @ref BT_BAP_ASCS_RSP_CODE_SUCCESS
+	 * - @ref BT_BAP_ASCS_RSP_CODE_CAP_UNSUPPORTED
+	 * - @ref BT_BAP_ASCS_RSP_CODE_CONF_UNSUPPORTED
+	 * - @ref BT_BAP_ASCS_RSP_CODE_CONF_REJECTED
+	 * - @ref BT_BAP_ASCS_RSP_CODE_METADATA_UNSUPPORTED
+	 * - @ref BT_BAP_ASCS_RSP_CODE_METADATA_REJECTED
+	 * - @ref BT_BAP_ASCS_RSP_CODE_NO_MEM
+	 * - @ref BT_BAP_ASCS_RSP_CODE_UNSPECIFIED
+	 */
 	enum bt_bap_ascs_rsp_code code;
 
 	/**
@@ -198,16 +210,10 @@ struct bt_bap_ascs_rsp {
 		 * If the Response Code is one of the following:
 		 * - @ref BT_BAP_ASCS_RSP_CODE_CONF_UNSUPPORTED
 		 * - @ref BT_BAP_ASCS_RSP_CODE_CONF_REJECTED
-		 * - @ref BT_BAP_ASCS_RSP_CODE_CONF_INVALID
 		 * all values from @ref bt_bap_ascs_reason can be used.
 		 *
 		 * If the Response Code is one of the following:
 		 * - @ref BT_BAP_ASCS_RSP_CODE_SUCCESS
-		 * - @ref BT_BAP_ASCS_RSP_CODE_NOT_SUPPORTED
-		 * - @ref BT_BAP_ASCS_RSP_CODE_INVALID_LENGTH
-		 * - @ref BT_BAP_ASCS_RSP_CODE_INVALID_ASE
-		 * - @ref BT_BAP_ASCS_RSP_CODE_INVALID_ASE_STATE
-		 * - @ref BT_BAP_ASCS_RSP_CODE_INVALID_DIR
 		 * - @ref BT_BAP_ASCS_RSP_CODE_CAP_UNSUPPORTED
 		 * - @ref BT_BAP_ASCS_RSP_CODE_NO_MEM
 		 * - @ref BT_BAP_ASCS_RSP_CODE_UNSPECIFIED
@@ -221,7 +227,6 @@ struct bt_bap_ascs_rsp {
 		 * If the Response Code is one of the following:
 		 * - @ref BT_BAP_ASCS_RSP_CODE_METADATA_UNSUPPORTED
 		 * - @ref BT_BAP_ASCS_RSP_CODE_METADATA_REJECTED
-		 * - @ref BT_BAP_ASCS_RSP_CODE_METADATA_INVALID
 		 * the value of the Metadata Type shall be used.
 		 */
 		enum bt_audio_metadata_type metadata_type;


### PR DESCRIPTION
Some of the ASCS response codes should not be used by the unicast server, as those will be checked and validated by the stack.

They are kept in the enum, as the enum is also used by the unicast client.

Besides updating the documentation, this commit also adds a function to validate the response codes as well as the combination of response codes and reason/metadata values, and log a warning if the application does not adhere to the documented behavior.

A warning is used instead of an error/assert/modification of the response codes, as there may be unforseen reasons why an application provide a non-approved response code, and since it may be spec-valid, we should not fully prevent it.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/59810