### PR TITLE
tests: Bluetooth: Mesh: optimize proxy beacon test

### DIFF
--- a/tests/bsim/bluetooth/mesh/src/test_beacon.c
+++ b/tests/bsim/bluetooth/mesh/src/test_beacon.c
@@ -2011,6 +2011,8 @@ static const struct bt_mesh_test_cfg solicit_trigger_cfg = {
 static void test_tx_proxy_adv_solicit_trigger(void)
 {
 	tx_proxy_adv_common_init(PROXY_ADV_MULTI_SUBNET_COEX_WAIT_TIME, &solicit_trigger_cfg);
+	/* Disable SNB. */
+	bt_mesh_beacon_set(false);
 	ASSERT_OK_MSG(bt_mesh_subnet_add(TEST_NET_IDX2, test_net_key_2),
 		      "Failed to add second subnet");
 
@@ -2028,6 +2030,8 @@ static void test_tx_proxy_adv_solicit_trigger(void)
 static void test_rx_proxy_adv_multi_subnet_coex(void)
 {
 	rx_priv_common_init(PROXY_ADV_MULTI_SUBNET_COEX_WAIT_TIME);
+	/* Disable SNB. */
+	bt_mesh_beacon_set(false);
 	pp_netkey_ctx_init(&pp_net1);
 	pp_netkey_ctx_init(&pp_net2);
 
@@ -2071,10 +2075,10 @@ static void test_rx_proxy_adv_multi_subnet_coex(void)
 		/** The first and second subnet gets solicited. Check that
 		 *  PRIVATE_NET_ID is advertised by these subnet,
 		 */
-		{.evt_type = BEACON_TYPE_PRIVATE_NET_ID, .net_idx = 0, .evt_cnt = 9,
+		{.evt_type = BEACON_TYPE_PRIVATE_NET_ID, .net_idx = 0, .evt_cnt = 8,
 		 .time = {.after = PROXY_ADV_MULTI_CHECKPOINT_3,
 			  .before = PROXY_ADV_MULTI_CHECKPOINT_4}},
-		{.evt_type = BEACON_TYPE_PRIVATE_NET_ID, .net_idx = 1, .evt_cnt = 9,
+		{.evt_type = BEACON_TYPE_PRIVATE_NET_ID, .net_idx = 1, .evt_cnt = 8,
 		 .time = {.after = PROXY_ADV_MULTI_CHECKPOINT_3,
 			  .before = PROXY_ADV_MULTI_CHECKPOINT_4}},
 

--- a/tests/bsim/bluetooth/mesh/tests_scripts/priv_beacon/proxy_adv_multi_subnet_coex.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/priv_beacon/proxy_adv_multi_subnet_coex.sh
@@ -22,6 +22,10 @@ source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
 # window. The Mesh Protocol specification does not specify exactly the
 # timing for Proxy ADV messages.
 
+# Note 3: The proxy transmitting device mandates emitting of the secure
+# network beacons. This allows to check that proxy goes back to normal
+# behavior after device advertises the seure network beacons.
+
 # Test procedure:
 # 1. (0-20 seconds) A single subnet is active on the TX device with GATT
 #    Proxy enabled. RX device verifies that the single subnet has exclusive


### PR DESCRIPTION
Emitting network beacons in parallel to proxy functionality causes collisions. The commit disables network beacons and allows the test scenario to be more precise.