### PR TITLE
drivers: spi: set 'spi_driver_api' as 'static const'

### DIFF
--- a/drivers/spi/mspi_ambiq.c
+++ b/drivers/spi/mspi_ambiq.c
@@ -197,7 +197,7 @@ static int mspi_ambiq_release(const struct device *dev, const struct spi_config 
 	return 0;
 }
 
-static struct spi_driver_api mspi_ambiq_driver_api = {
+static const struct spi_driver_api mspi_ambiq_driver_api = {
 	.transceive = mspi_ambiq_transceive,
 	.release = mspi_ambiq_release,
 };

--- a/drivers/spi/spi_ambiq.c
+++ b/drivers/spi/spi_ambiq.c
@@ -219,7 +219,7 @@ static int spi_ambiq_release(const struct device *dev, const struct spi_config *
 	return 0;
 }
 
-static struct spi_driver_api spi_ambiq_driver_api = {
+static const struct spi_driver_api spi_ambiq_driver_api = {
 	.transceive = spi_ambiq_transceive,
 	.release = spi_ambiq_release,
 };

--- a/drivers/spi/spi_andes_atcspi200.c
+++ b/drivers/spi/spi_andes_atcspi200.c
@@ -283,7 +283,7 @@ int spi_atcspi200_init(const struct device *dev)
 	return 0;
 }
 
-static struct spi_driver_api spi_atcspi200_api = {
+static const struct spi_driver_api spi_atcspi200_api = {
 	.transceive = spi_atcspi200_transceive,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = spi_atcspi200_transceive_async,

--- a/drivers/spi/spi_b91.c
+++ b/drivers/spi/spi_b91.c
@@ -452,7 +452,7 @@ static int spi_b91_release(const struct device *dev,
 }
 
 /* SPI driver APIs structure */
-static struct spi_driver_api spi_b91_api = {
+static const struct spi_driver_api spi_b91_api = {
 	.transceive = spi_b91_transceive,
 	.release = spi_b91_release,
 #ifdef CONFIG_SPI_ASYNC

--- a/drivers/spi/spi_bitbang.c
+++ b/drivers/spi/spi_bitbang.c
@@ -247,7 +247,7 @@ int spi_bitbang_release(const struct device *dev,
 	return 0;
 }
 
-static struct spi_driver_api spi_bitbang_api = {
+static const struct spi_driver_api spi_bitbang_api = {
 	.transceive = spi_bitbang_transceive,
 	.release = spi_bitbang_release,
 #ifdef CONFIG_SPI_ASYNC

--- a/drivers/spi/spi_emul.c
+++ b/drivers/spi/spi_emul.c
@@ -109,7 +109,7 @@ int spi_emul_register(const struct device *dev, struct spi_emul *emul)
 
 /* Device instantiation */
 
-static struct spi_driver_api spi_emul_api = {
+static const struct spi_driver_api spi_emul_api = {
 	.transceive = spi_emul_io,
 };
 

--- a/drivers/spi/spi_gd32.c
+++ b/drivers/spi/spi_gd32.c
@@ -567,7 +567,7 @@ static int spi_gd32_release(const struct device *dev,
 	return 0;
 }
 
-static struct spi_driver_api spi_gd32_driver_api = {
+static const struct spi_driver_api spi_gd32_driver_api = {
 	.transceive = spi_gd32_transceive,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = spi_gd32_transceive_async,

--- a/drivers/spi/spi_gecko.c
+++ b/drivers/spi/spi_gecko.c
@@ -357,7 +357,7 @@ static int spi_gecko_release(const struct device *dev,
 }
 
 /* Device Instantiation */
-static struct spi_driver_api spi_gecko_api = {
+static const struct spi_driver_api spi_gecko_api = {
 	.transceive = spi_gecko_transceive,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = spi_gecko_transceive_async,

--- a/drivers/spi/spi_litespi.c
+++ b/drivers/spi/spi_litespi.c
@@ -160,7 +160,7 @@ static int spi_litespi_release(const struct device *dev,
 }
 
 /* Device Instantiation */
-static struct spi_driver_api spi_litespi_api = {
+static const struct spi_driver_api spi_litespi_api = {
 	.transceive = spi_litespi_transceive,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = spi_litespi_transceive_async,

--- a/drivers/spi/spi_numaker.c
+++ b/drivers/spi/spi_numaker.c
@@ -270,8 +270,10 @@ static int spi_numaker_release(const struct device *dev, const struct spi_config
 	return 0;
 }
 
-static struct spi_driver_api spi_numaker_driver_api = {.transceive = spi_numaker_transceive,
-						       .release = spi_numaker_release};
+static const struct spi_driver_api spi_numaker_driver_api = {
+	.transceive = spi_numaker_transceive,
+	.release = spi_numaker_release
+};
 
 static int spi_numaker_init(const struct device *dev)
 {

--- a/drivers/spi/spi_oc_simple.c
+++ b/drivers/spi/spi_oc_simple.c
@@ -179,7 +179,7 @@ int spi_oc_simple_release(const struct device *dev,
 	return 0;
 }
 
-static struct spi_driver_api spi_oc_simple_api = {
+static const struct spi_driver_api spi_oc_simple_api = {
 	.transceive = spi_oc_simple_transceive,
 	.release = spi_oc_simple_release,
 #ifdef CONFIG_SPI_ASYNC

--- a/drivers/spi/spi_opentitan.c
+++ b/drivers/spi/spi_opentitan.c
@@ -301,7 +301,7 @@ static int spi_opentitan_release(const struct device *dev,
 
 /* Device Instantiation */
 
-static struct spi_driver_api spi_opentitan_api = {
+static const struct spi_driver_api spi_opentitan_api = {
 	.transceive = spi_opentitan_transceive,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = spi_opentitan_transceive_async,

--- a/drivers/spi/spi_pl022.c
+++ b/drivers/spi/spi_pl022.c
@@ -886,7 +886,7 @@ static int spi_pl022_release(const struct device *dev,
 	return 0;
 }
 
-static struct spi_driver_api spi_pl022_api = {
+static const struct spi_driver_api spi_pl022_api = {
 	.transceive = spi_pl022_transceive,
 #if defined(CONFIG_SPI_ASYNC)
 	.transceive_async = spi_pl022_transceive_async,

--- a/drivers/spi/spi_rpi_pico_pio.c
+++ b/drivers/spi/spi_rpi_pico_pio.c
@@ -330,7 +330,7 @@ int spi_pico_pio_release(const struct device *dev, const struct spi_config *spi_
 	return 0;
 }
 
-static struct spi_driver_api spi_pico_pio_api = {
+static const struct spi_driver_api spi_pico_pio_api = {
 	.transceive = spi_pico_pio_transceive,
 	.release = spi_pico_pio_release,
 };

--- a/drivers/spi/spi_sifive.c
+++ b/drivers/spi/spi_sifive.c
@@ -272,7 +272,7 @@ static int spi_sifive_release(const struct device *dev,
 
 /* Device Instantiation */
 
-static struct spi_driver_api spi_sifive_api = {
+static const struct spi_driver_api spi_sifive_api = {
 	.transceive = spi_sifive_transceive,
 	.release = spi_sifive_release,
 };


### PR DESCRIPTION
This change marks each instance of the `spi_driver_api` as `static const`. The rationale is that `spi_driver_api` is used for declaring internal module interfaces and is not intended to be modified at runtime. By using `static const`, we ensure immutability, leading to usage of only **.rodata** and a reduction in the **.data** area.