### PR TITLE
doc: api/release: Change retained memory to unstable and add release notes

### DIFF
--- a/doc/develop/api/overview.rst
+++ b/doc/develop/api/overview.rst
@@ -290,7 +290,7 @@ between major releases are available in the :ref:`zephyr_release_notes`.
      - 3.1
 
    * - :ref:`retained_mem_api`
-     - Experimental
+     - Unstable
      - 3.4
 
    * - :ref:`retention_api`

--- a/doc/releases/release-notes-3.6.rst
+++ b/doc/releases/release-notes-3.6.rst
@@ -202,6 +202,10 @@ Drivers and Sensors
 
 * Retained memory
 
+  * Retained memory driver backend for registers has been added.
+
+  * Retained memory API status changed from experimental to unstable.
+
 * RTC
 
 * SDHC


### PR DESCRIPTION
    doc: api: Change retained memory status to unstable
    
    Changes the API support level of retained memory from experimental
    to unstable, now that there are 3 drivers


    doc: release: 3.6: Add retained memory changes
    
    Adds a note about a new backend and API status upgrade
