### PR TITLE
x86: ia32/gdbstub: remove dead code

### DIFF
--- a/arch/x86/core/ia32/gdbstub.c
+++ b/arch/x86/core/ia32/gdbstub.c
@@ -174,12 +174,8 @@ size_t arch_gdb_reg_readone(struct gdb_ctx *ctx, uint8_t *buf, size_t buflen,
 		 * registers instead of stopping in the middle of
 		 * "info registers all".
 		 */
-		if (buflen >= 2) {
-			memcpy(buf, "xx", 2);
-			ret = 2;
-		} else {
-			ret = 0;
-		}
+		memcpy(buf, "xx", 2);
+		ret = 2;
 	} else {
 		ret = bin2hex((const uint8_t *)&(ctx->registers[regno]),
 			      sizeof(ctx->registers[regno]),


### PR DESCRIPTION
There is logically dead code which will never run. So remove.

Fixes #66848