### PR TITLE
posix: add Kconfig and cmake for application conformance

### DIFF
--- a/lib/posix/Kconfig
+++ b/lib/posix/Kconfig
@@ -4,6 +4,7 @@
 
 menu "POSIX API Support"
 
+rsource "conformance/Kconfig"
 rsource "options/Kconfig"
 rsource "shell/Kconfig"
 

--- a/lib/posix/conformance/Kconfig
+++ b/lib/posix/conformance/Kconfig
@@ -1,0 +1,5 @@
+# Copyright (c) 2024, Fried Professional Engineering Services, Inc
+#
+# SPDX-License-Identifier: Apache-2.0
+
+rsource "application/Kconfig"

--- a/lib/posix/conformance/application/Kconfig
+++ b/lib/posix/conformance/application/Kconfig
@@ -1,0 +1,113 @@
+# Copyright (c) 2024, Friedt Professional Engineering Services, Inc
+#
+# SPDX-License-Identifier: Apache-2.0
+
+menu "Application Conformance"
+
+# The latest versions from IEEE 1003.1-2017
+config POSIX_C_SOURCE_LATEST_VERSION
+	int
+	# The required 'L' is appended by CMake if > 2
+	default 200809
+
+config XOPEN_SOURCE_LATEST_VERSION
+	int
+	default 700
+
+choice POSIX_C_SOURCE_CHOICE
+	prompt "Selection for _POSIX_C_SOURCE"
+	default POSIX_C_SOURCE_CHOICE_DEFAULT if POSIX_API
+	default POSIX_C_SOURCE_CHOICE_NONE
+	help
+	  POSIX API application conformance level.
+
+	  This Kconfig option is used by the CMake function
+	  zephyr_posix_library_compile_definitions([min]).
+
+config POSIX_C_SOURCE_CHOICE_NONE
+	bool "None"
+	help
+	  The application does not require _POSIX_C_SOURCE defined.
+
+	  This is the default.
+
+config POSIX_C_SOURCE_CHOICE_DEFAULT
+	bool "Default"
+	help
+	  This is normally the latest version specified by IEEE 1003.1.
+
+config POSIX_C_SOURCE_CHOICE_200809L
+	bool "200809L"
+	help
+	  Prefer _POSIX_C_SOURCE=200809L. This is the value specified in both
+	  IEEE Std. 1003.1-2008 and IEEE Std. 1003.1-2017.
+
+config POSIX_C_SOURCE_CHOICE_200112L
+	bool "200112L"
+	help
+	  Prefer _POSIX_C_SOURCE=200112L. This is the value specified in IEEE Std. 1003.1-2001.
+
+config POSIX_C_SOURCE_CHOICE_199506L
+	bool "199506L"
+	help
+	  Prefer _POSIX_C_SOURCE=199506L. This is the value specified in IEEE Std. 1003.1c-1995.
+
+config POSIX_C_SOURCE_CHOICE_199309L
+	bool "199309L"
+	help
+	  Prefer _POSIX_C_SOURCE=199309L. This is the value specified in IEEE Std. 1003.1b-1993.
+
+config POSIX_C_SOURCE_CHOICE_2
+	bool "2"
+	help
+	  Prefer _POSIX_C_SOURCE=2. This is the value specified in IEEE Std. 1003.2-1992.
+
+config POSIX_C_SOURCE_CHOICE_1
+	bool "1"
+	help
+	  Prefer _POSIX_C_SOURCE=1. This is the value specified in IEEE Std. 1003.1-1990.
+
+endchoice
+
+choice XOPEN_SOURCE_CHOICE
+	prompt "Selection for _XOPEN_SOURCE"
+	default XOPEN_SOURCE_CHOICE_DEFAULT if POSIX_API
+	default XOPEN_SOURCE_CHOICE_NONE
+	help
+	  X/Open application conformance level.
+
+	  This Kconfig option is used by the CMake function
+	  zephyr_xopen_library_compile_definitions([min]).
+
+config XOPEN_SOURCE_CHOICE_NONE
+	bool "None"
+	help
+	  The application does not require _XOPEN_SOURCE defined.
+
+	  This is the default.
+
+config XOPEN_SOURCE_CHOICE_DEFAULT
+	bool "Default"
+	help
+	  This is normally the latest version specified by IEEE 1003.1.
+
+config XOPEN_SOURCE_CHOICE_700
+	bool "700"
+	help
+	  Prefer _XOPEN_SOURCE=700. This is the value specified in IEEE Std. 1003.1-2008
+	  and IEEE Std. 1003.1-2017.
+
+config XOPEN_SOURCE_CHOICE_600
+	bool "600"
+	help
+	  Prefer _XOPEN_SOURCE=600. This is the value specified in IEEE Std. 1003.1-2001.
+
+config XOPEN_SOURCE_CHOICE_500
+	bool "500"
+	help
+	  Prefer _XOPEN_SOURCE=500. This includes everything up to Single Unix Specification,
+	  version 2 (SUSv2).
+
+endchoice
+
+endmenu # "Application Conformance"

--- a/samples/posix/eventfd/CMakeLists.txt
+++ b/samples/posix/eventfd/CMakeLists.txt
@@ -6,3 +6,4 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(eventfd)
 
 target_sources(app PRIVATE src/main.c)
+target_posix_library_compile_options(app)

--- a/samples/posix/gettimeofday/CMakeLists.txt
+++ b/samples/posix/gettimeofday/CMakeLists.txt
@@ -6,3 +6,4 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(gettimeofday)
 
 target_sources(app PRIVATE src/main.c)
+target_posix_library_compile_options(app)

--- a/samples/posix/uname/CMakeLists.txt
+++ b/samples/posix/uname/CMakeLists.txt
@@ -6,3 +6,4 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(posix_uname)
 
 target_sources(app PRIVATE src/main.c)
+target_posix_library_compile_options(app)

--- a/tests/posix/common/CMakeLists.txt
+++ b/tests/posix/common/CMakeLists.txt
@@ -8,5 +8,4 @@ FILE(GLOB app_sources src/*.c)
 zephyr_include_directories(${ZEPHYR_BASE}/lib/posix)
 
 target_sources(app PRIVATE ${app_sources})
-
-target_compile_options(app PRIVATE -U_POSIX_C_SOURCE -D_POSIX_C_SOURCE=200809L)
+target_posix_library_compile_options(app)

--- a/tests/posix/eventfd/CMakeLists.txt
+++ b/tests/posix/eventfd/CMakeLists.txt
@@ -6,3 +6,4 @@ project(eventfd)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})
+target_posix_library_compile_options(app)

--- a/tests/posix/fs/CMakeLists.txt
+++ b/tests/posix/fs/CMakeLists.txt
@@ -6,3 +6,4 @@ project(fs)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})
+target_posix_library_compile_options(app)

--- a/tests/posix/getopt/CMakeLists.txt
+++ b/tests/posix/getopt/CMakeLists.txt
@@ -6,3 +6,4 @@ project(getopt)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})
+target_posix_library_compile_options(app)

--- a/tests/posix/headers/CMakeLists.txt
+++ b/tests/posix/headers/CMakeLists.txt
@@ -6,3 +6,4 @@ project(posix_headers)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})
+target_posix_library_compile_options(app)

--- a/tests/posix/pthread_pressure/CMakeLists.txt
+++ b/tests/posix/pthread_pressure/CMakeLists.txt
@@ -8,3 +8,4 @@ project(pthread_pressure)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})
+target_posix_library_compile_options(app)


### PR DESCRIPTION
### TL;DR

This change reduces the manual definitions needed to build POSIX applications and libraries in Zephyr, in downstream projects, and integrated modules by using Kconfig to allow the application to more cleanly specify POSIX application conformance macros.

This is an extension of #67181 and has already been a part of the [POSIX Roadmap for LTSv3](https://github.com/zephyrproject-rtos/zephyr/issues/51211) for some time (along with adopting implementation conformance macros).

### Overview

IEEE 1003.1-2017 (and many versions preceding it) requires a conformant application to define `_POSIX_C_SOURCE` and / or `_XOPEN_SOURCE` to  specific values. This is used to ensure that the correct function prototypes are made visible to the application from the implementation.

Currently, `_POSIX_C_SOURCE=200809L` is hard-coded for at least Newlib and Picolibc in order to elicit some desired prototypes and declarations. However, since POSIX is optional in Zephyr, those application conformance macros should really not be hard-coded anywhere.

We do want to avoid exposing non-POSIX code to POSIX APIs in order to avoid potential namespace collisions and so on. Additionally, the kernel is specifically required to *not* have any extensions to the C programming language other than what is listed in Rule A.4 of the coding guidelines. In practice, we know that it's safe, since we're currently building all of Zephyr (including the kernel and core libraries) with these extensions (and in fact the entire POSIX API) already exposed. However, we should really not do that in order to be consistent with our own policies.

### User Interface

Below are some screenshots showing the `menuconfig` options.

**POSIX API Support**
<img width="669" alt="Screenshot 2024-02-01 at 7 27 36 AM" src="https://github.com/zephyrproject-rtos/zephyr/assets/983494/08a562a4-6166-49b1-8347-51343dc6bac6">

**Appplication Conformance**
<img width="670" alt="Screenshot 2024-02-01 at 7 28 07 AM" src="https://github.com/zephyrproject-rtos/zephyr/assets/983494/72f65022-fd28-42c5-9a8c-5be8ab0b5d9f">

**Selection for _POSIX_C_SOURCE**
<img width="670" alt="Screenshot 2024-02-01 at 7 27 52 AM" src="https://github.com/zephyrproject-rtos/zephyr/assets/983494/c0babf0f-0099-4aac-bae8-d4310755d62e">

**Selection for _XOPEN_SOURCE**
<img width="669" alt="Screenshot 2024-02-01 at 7 28 15 AM" src="https://github.com/zephyrproject-rtos/zephyr/assets/983494/986ddfc9-b18c-4c5a-93e9-4c38fd06439b">

**Help**
<img width="672" alt="Screenshot 2024-02-01 at 7 28 24 AM" src="https://github.com/zephyrproject-rtos/zephyr/assets/983494/326bc2f3-536c-431b-b015-6a583388310a">

### Risks (of *not* merging this PR)

There is a chance that all POSIX applications and libraries, even those downstream, will break once the hard-coded values are removed.

To make the transition easier, with this change, we provide

* `CONFIG_POSIX_C_SOURCE_CHOICE`, and
* `CONFIG_XOPEN_SOURCE_CHOICE`

That allows the user to specify the application conformance level in Zephyr's native configuration language, in a way that scales with Zephyr.

By default, the conformance level is `CONFIG_POSIX_C_SOURCE_CHOICE_NONE` (i.e. POSIX API should not be exposed to the application). The same is true for `_XOPEN_SOURCE`.

A `CONFIG_POSIX_C_SOURCE_CHOICE_LATEST` option is provided, that uses the recommended application conformance level (as required by the latest supported POSIX standard).

Individual standard application conformance levels are also provided, so that the user may choose, e.g. `CONFIG_POSIX_C_SOURCE_CHOICE_200809L`.

### POSIX Libraries and Applications

Libraries and applications that even optionally support the POSIX API should use one of the following to be consistent with the application-specified conformance level.

```cmake
# For application-facing libraries
zephyr_posix_library_compile_options([<minimum>])
zephyr_xopen_library_compile_options([<minimum>])
# For applications
target_posix_library_compile_options(<target> [<minimum>])
target_xopen_library_compile_options(<target> [<minimum>])
```

Each function supports optionally specifying a minimum conformance level. So if the user specifies `200112L` and the library requires `200809L`, the library will be compiled as `200809L`. While most of POSIX is backward-compatible, it is generally better to avoid specifying a minimum conformance level since that could potentially introduce using mixed application conformance levels ("unspecified" behaviour according to IEEE 1003.1-2017). There should only be a handful of situations where that is done as a workaround.

If the user selects no conformance option, then these cmake functions will have no effect. There is no need to guard them with any conditions.

POSIX applications that define `CONFIG_POSIX_API=y` will already be using the latest application conformance level.

With that, Zephyr libraries that support the POSIX API (even conditionally) can define the required application conformance macros with a single CMake Line.

POSIX applications and libraries may opt-out of using these helpers entirely and manage local compile options. However, again, using an inconsistent application conformance level is "unspecified" (i.e. will probably work, but no promises).

### Non-POSIX libraries that Need POSIX support

For libraries that are not application-facing, such as things built in `arch/posix`, there is absolutely no need to adopt the semantics used by application conformance macros, since those libraries are not considered part of the application (they are a platform implementation detail, insulated by the Zephyr API).

It is, however, recommended to not use global compile options, so as to avoid conflicting with the rest of the Zephyr build.

Source files may manually undefine and redefine `_POSIX_C_SOURCE` or `_XOPEN_SOURCE` explicitly as well (assuming CI compliance errors are ignored), but this option does not scale as easily.

Four cmake extensions are provided that can be used to set the conformance level via local compile options. These options do not affect global compile options.

### Deprecation Process for Hard-coded `_POSIX_C_SOURCE`?

Because POSIX is optional in Zephyr, and because `_POSIX_C_SOURCE` is choice typically made by the application, there may need to be a deprecation process for removing instances where `_POSIX_C_SOURCE` is define globally. The main reason for that, is that if we were to suddenly remove it, many applications (even out-of-tree applications) would fail to build (in fact, we are already seeing this happen today).

For that, we could follow the usual deprecation process. A good suggestion would be to surround the hard-coded value in CMake with a new Kconfig option that is already deprecated. E.g.

```diff
diff --git a/lib/posix/Kconfig.app_conf b/lib/posix/Kconfig.app_conf
index 5f072fc7f7..9c2fcda1d7 100644
--- a/lib/posix/Kconfig.app_conf
+++ b/lib/posix/Kconfig.app_conf
@@ -2,6 +2,17 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+config POSIX_AUTO_DECLARE_APP_CONFORMANCE
+	bool "Automatically declare APP Conformance"
+	select DEPRECATED
+      default y
+	help
+	  Due to _POSIX_C_SOURCE and perhaps other reserved macros being
+	  unconditionally defined within certain areas, and since POSIX
+	  support is optional within Zephyr, we must deprecate that
+	  behaviour in a graceful way, so as to not break downstream
+	  users.
+
 # The latest versions from IEEE 1003.1-2017
 config POSIX_C_SOURCE_LATEST_VERSION
 	int
@@ -15,6 +25,7 @@ config XOPEN_SOURCE_LATEST_VERSION
 choice POSIX_C_SOURCE_CHOICE
 	prompt "POSIX API application conformance"
 	default POSIX_C_SOURCE_CHOICE_DEFAULT if POSIX_API
+	default POSIX_C_SOURCE_CHOICE_DEFAULT if POSIX_AUTO_DECLARE_APP_CONFORMANCE
 	default POSIX_C_SOURCE_CHOICE_NONE
 	help
 	  POSIX API application conformance level.
@@ -69,6 +80,7 @@ endchoice
 choice XOPEN_SOURCE_CHOICE
 	prompt "POSIX X/Open application conformance"
 	default XOPEN_SOURCE_CHOICE_DEFAULT if POSIX_API
+	default XOPEN_SOURCE_CHOICE_DEFAULT if POSIX_AUTO_DECLARE_APP_CONFORMANCE
 	default XOPEN_SOURCE_CHOICE_NONE
 	help
 	  X/Open application conformance level.
```

With that, existing applications will *not* be required to immediately modify CMake or Kconfig. The `_POSIX_C_SOURCE` variable will still be globally defined (if `CONFIG_POSIX_AUTO_DECLARE_APP_CONFORMANCE` is not explicitly n-selected).

And then, subsequently, after 2 releases, the deprecated option would be removed and users  could make the recommended changes.