### PR TITLE
drivers: dma: intel-adsp-hda: add delay to stop host dma

### DIFF
--- a/drivers/dma/dma_intel_adsp_hda.c
+++ b/drivers/dma/dma_intel_adsp_hda.c
@@ -326,6 +326,14 @@ int intel_adsp_hda_dma_stop(const struct device *dev, uint32_t channel)
 
 	intel_adsp_hda_disable(cfg->base, cfg->regblock_size, channel);
 
+	/* host dma needs some cycles to completely stop */
+	if (cfg->direction == HOST_TO_MEMORY || cfg->direction == MEMORY_TO_HOST) {
+		if (!WAIT_FOR(!(*DGCS(cfg->base, cfg->regblock_size, channel) & DGCS_GBUSY), 1000,
+				  k_busy_wait(1))) {
+			return -EBUSY;
+		}
+	}
+
 	return pm_device_runtime_put(dev);
 }
 


### PR DESCRIPTION
According to hardware spec, host dma needs some delay to complete stop. In the bug the host dma is disabled in different path  in a few microseonds. The first setting disabled the host dma and called pm_device_runtime_put to power off it. The second setting found the host dma was still alive and calle pm_device_runtime_put again. This results to pm->usage checking failed.

BugLink: https://github.com/thesofproject/sof/issues/8686