### PR TITLE
drivers: ieee802154: set 'ieee802154_radio_api' as 'static const'

### DIFF
--- a/drivers/ieee802154/ieee802154_b91.c
+++ b/drivers/ieee802154/ieee802154_b91.c
@@ -617,7 +617,7 @@ static int b91_attr_get(const struct device *dev, enum ieee802154_attr attr,
 }
 
 /* IEEE802154 driver APIs structure */
-static struct ieee802154_radio_api b91_radio_api = {
+static const struct ieee802154_radio_api b91_radio_api = {
 	.iface_api.init = b91_iface_init,
 	.get_capabilities = b91_get_capabilities,
 	.cca = b91_cca,

--- a/drivers/ieee802154/ieee802154_cc1200.c
+++ b/drivers/ieee802154/ieee802154_cc1200.c
@@ -813,7 +813,7 @@ static const struct cc1200_config cc1200_config = {
 
 static struct cc1200_context cc1200_context_data;
 
-static struct ieee802154_radio_api cc1200_radio_api = {
+static const struct ieee802154_radio_api cc1200_radio_api = {
 	.iface_api.init	= cc1200_iface_init,
 
 	.get_capabilities	= cc1200_get_capabilities,

--- a/drivers/ieee802154/ieee802154_cc13xx_cc26xx.c
+++ b/drivers/ieee802154/ieee802154_cc13xx_cc26xx.c
@@ -570,7 +570,7 @@ static void ieee802154_cc13xx_cc26xx_iface_init(struct net_if *iface)
 	ieee802154_init(iface);
 }
 
-static struct ieee802154_radio_api ieee802154_cc13xx_cc26xx_radio_api = {
+static const struct ieee802154_radio_api ieee802154_cc13xx_cc26xx_radio_api = {
 	.iface_api.init = ieee802154_cc13xx_cc26xx_iface_init,
 
 	.get_capabilities = ieee802154_cc13xx_cc26xx_get_capabilities,

--- a/drivers/ieee802154/ieee802154_cc13xx_cc26xx_subg.c
+++ b/drivers/ieee802154/ieee802154_cc13xx_cc26xx_subg.c
@@ -909,7 +909,7 @@ static void ieee802154_cc13xx_cc26xx_subg_iface_init(struct net_if *iface)
 	ieee802154_init(iface);
 }
 
-static struct ieee802154_radio_api
+static const struct ieee802154_radio_api
 	ieee802154_cc13xx_cc26xx_subg_radio_api = {
 	.iface_api.init = ieee802154_cc13xx_cc26xx_subg_iface_init,
 

--- a/drivers/ieee802154/ieee802154_cc2520.c
+++ b/drivers/ieee802154/ieee802154_cc2520.c
@@ -1057,7 +1057,7 @@ static const struct cc2520_config cc2520_config = {
 
 static struct cc2520_context cc2520_context_data;
 
-static struct ieee802154_radio_api cc2520_radio_api = {
+static const struct ieee802154_radio_api cc2520_radio_api = {
 	.iface_api.init	= cc2520_iface_init,
 
 	.get_capabilities	= cc2520_get_capabilities,

--- a/drivers/ieee802154/ieee802154_dw1000.c
+++ b/drivers/ieee802154/ieee802154_dw1000.c
@@ -1659,7 +1659,7 @@ static void dwt_iface_api_init(struct net_if *iface)
 	LOG_INF("Iface initialized");
 }
 
-static struct ieee802154_radio_api dwt_radio_api = {
+static const struct ieee802154_radio_api dwt_radio_api = {
 	.iface_api.init		= dwt_iface_api_init,
 
 	.get_capabilities	= dwt_get_capabilities,

--- a/drivers/ieee802154/ieee802154_kw41z.c
+++ b/drivers/ieee802154/ieee802154_kw41z.c
@@ -1091,7 +1091,7 @@ static int kw41z_attr_get(const struct device *dev, enum ieee802154_attr attr,
 		&drv_attr.phy_supported_channels, value);
 }
 
-static struct ieee802154_radio_api kw41z_radio_api = {
+static const struct ieee802154_radio_api kw41z_radio_api = {
 	.iface_api.init	= kw41z_iface_init,
 
 	.get_capabilities	= kw41z_get_capabilities,

--- a/drivers/ieee802154/ieee802154_mcr20a.c
+++ b/drivers/ieee802154/ieee802154_mcr20a.c
@@ -1452,7 +1452,7 @@ static const struct mcr20a_config mcr20a_config = {
 
 static struct mcr20a_context mcr20a_context_data;
 
-static struct ieee802154_radio_api mcr20a_radio_api = {
+static const struct ieee802154_radio_api mcr20a_radio_api = {
 	.iface_api.init	= mcr20a_iface_init,
 
 	.get_capabilities	= mcr20a_get_capabilities,

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -1194,7 +1194,7 @@ static const struct nrf5_802154_config nrf5_radio_cfg = {
 	.irq_config_func = nrf5_irq_config,
 };
 
-static struct ieee802154_radio_api nrf5_radio_api = {
+static const struct ieee802154_radio_api nrf5_radio_api = {
 	.iface_api.init = nrf5_iface_init,
 
 	.get_capabilities = nrf5_get_capabilities,

--- a/drivers/ieee802154/ieee802154_rf2xx.c
+++ b/drivers/ieee802154/ieee802154_rf2xx.c
@@ -1084,7 +1084,7 @@ static void rf2xx_iface_init(struct net_if *iface)
 	ieee802154_init(iface);
 }
 
-static struct ieee802154_radio_api rf2xx_radio_api = {
+static const struct ieee802154_radio_api rf2xx_radio_api = {
 	.iface_api.init		= rf2xx_iface_init,
 
 	.get_capabilities	= rf2xx_get_capabilities,

--- a/drivers/ieee802154/ieee802154_uart_pipe.c
+++ b/drivers/ieee802154/ieee802154_uart_pipe.c
@@ -392,7 +392,7 @@ static void upipe_iface_init(struct net_if *iface)
 
 static struct upipe_context upipe_context_data;
 
-static struct ieee802154_radio_api upipe_radio_api = {
+static const struct ieee802154_radio_api upipe_radio_api = {
 	.iface_api.init		= upipe_iface_init,
 
 	.get_capabilities	= upipe_get_capabilities,


### PR DESCRIPTION
This change marks each instance of the `ieee802154_radio_api` as `static const`. The rationale is that `ieee802154_radio_api` is used for declaring internal module interfaces and is not intended to be modified at runtime. By using `static const`, we ensure immutability, leading to usage of only **.rodata** and a reduction in the **.data** area.