### PR TITLE
Bluetooth: controller: fix procedure collision handling

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
@@ -621,6 +621,12 @@ static void rr_st_idle(struct ll_conn *conn, uint8_t evt, void *param)
 					ctx_local->rx_opcode = PDU_DATA_LLCTRL_TYPE_UNUSED;
 				}
 
+				/*
+				 * Block/'hold back' future incompatible local procedures
+				 * in case we run a procedure with instant
+				 */
+				rr_set_collision(conn, with_instant);
+
 				/* Run remote procedure */
 				rr_act_run(conn);
 				rr_set_state(conn, RR_STATE_ACTIVE);


### PR DESCRIPTION
If an instant based remote procedure 'overtakes' a local ditto the local procedure will be 'completed' by remote rejection but collision flag would not get set ensuring that a new local conflicting procedure cannot be started before the remote is completed. This can thus lead to invalid local initiation.

Added unittest to cover case

Fix by ensuring collision flag is set also in the above mentioned scenario.