### PR TITLE
CI bsim workflow: Update changed-files action version

### DIFF
--- a/.github/workflows/bsim-tests.yaml
+++ b/.github/workflows/bsim-tests.yaml
@@ -80,7 +80,7 @@ jobs:
           west forall -c 'git reset --hard HEAD'
 
       - name: Check common triggering files
-        uses: tj-actions/changed-files@v35
+        uses: tj-actions/changed-files@v41
         id: check-common-files
         with:
           files: |
@@ -95,7 +95,7 @@ jobs:
             tests/bsim/*
 
       - name: Check if Bluethooth files changed
-        uses: tj-actions/changed-files@v35
+        uses: tj-actions/changed-files@v41
         id: check-bluetooth-files
         with:
           files: |
@@ -104,7 +104,7 @@ jobs:
             subsys/bluetooth/**
 
       - name: Check if Networking files changed
-        uses: tj-actions/changed-files@v35
+        uses: tj-actions/changed-files@v41
         id: check-networking-files
         with:
           files: |


### PR DESCRIPTION
Dependabot has foud in a fork that we are using
a too old GitHub action version, which contains this vulnerability:
https://www.cve.org/CVERecord?id=CVE-2023-51664
https://github.com/tj-actions/changed-files/security/advisories/GHSA-mcph-m25j-8j63

We do not use the output listing all changed files, so we should not be exposed, but nonetheless,
let's update it.