### PR TITLE
cmake: update description of board_runner_args() function

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -773,7 +773,7 @@ endmacro()
 #
 # Within application CMakeLists.txt files, ensure that all calls to
 # board_runner_args() are part of a macro named app_set_runner_args(),
-# like this, which is defined before including the boilerplate file:
+# like this, which is defined before calling 'find_package(Zephyr)':
 #   macro(app_set_runner_args)
 #     board_runner_args(runner "--some-app-setting=value")
 #   endmacro()


### PR DESCRIPTION
Update description of board_runner_args() function so that it is described that app_set_runner_args macro must be defined before the call to `find_package(Zephyr)`.

See also #66452