### PR TITLE
Bluetooth: CSIP: Use bt_crypto_aes_cmac instead of own

### DIFF
--- a/subsys/bluetooth/audio/csip_crypto.c
+++ b/subsys/bluetooth/audio/csip_crypto.c
@@ -11,13 +11,10 @@
  */
 #include "csip_crypto.h"
 #include <zephyr/bluetooth/crypto.h>
-#include <tinycrypt/constants.h>
-#include <tinycrypt/utils.h>
-#include <tinycrypt/aes.h>
-#include <tinycrypt/cmac_mode.h>
-#include <tinycrypt/ccm_mode.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
+
+#include "crypto/bt_crypto.h"
 
 #include "common/bt_str.h"
 
@@ -28,29 +25,6 @@ LOG_MODULE_REGISTER(bt_csip_crypto, CONFIG_BT_CSIP_SET_MEMBER_CRYPTO_LOG_LEVEL);
 #define BT_CSIP_CRYPTO_PADDING_SIZE 13
 #define BT_CSIP_PADDED_RAND_SIZE    (BT_CSIP_CRYPTO_PADDING_SIZE + BT_CSIP_CRYPTO_PRAND_SIZE)
 #define BT_CSIP_R_MASK              BIT_MASK(24) /* r is 24 bit / 3 octet */
-
-static int aes_cmac(const uint8_t key[BT_CSIP_CRYPTO_KEY_SIZE],
-		    const uint8_t *in, size_t in_len, uint8_t *out)
-{
-	struct tc_aes_key_sched_struct sched;
-	struct tc_cmac_struct state;
-
-	/* TODO: Copy of the aes_cmac from smp.c: Can we merge them? */
-
-	if (tc_cmac_setup(&state, key, &sched) == TC_CRYPTO_FAIL) {
-		return -EIO;
-	}
-
-	if (tc_cmac_update(&state, in, in_len) == TC_CRYPTO_FAIL) {
-		return -EIO;
-	}
-
-	if (tc_cmac_final(out, &state) == TC_CRYPTO_FAIL) {
-		return -EIO;
-	}
-
-	return 0;
-}
 
 int bt_csip_sih(const uint8_t sirk[BT_CSIP_SET_SIRK_SIZE], uint8_t r[BT_CSIP_CRYPTO_PRAND_SIZE],
 		uint8_t out[BT_CSIP_CRYPTO_HASH_SIZE])
@@ -130,7 +104,7 @@ static int k1(const uint8_t *n, size_t n_size,
 	LOG_DBG("BE: salt %s", bt_hex(salt, BT_CSIP_CRYPTO_SALT_SIZE));
 	LOG_DBG("BE: p %s", bt_hex(p, p_size));
 
-	err = aes_cmac(salt, n, n_size, t);
+	err = bt_crypto_aes_cmac(salt, n, n_size, t);
 
 	LOG_DBG("BE: t %s", bt_hex(t, sizeof(t)));
 
@@ -138,7 +112,7 @@ static int k1(const uint8_t *n, size_t n_size,
 		return err;
 	}
 
-	err = aes_cmac(t, p, p_size, out);
+	err = bt_crypto_aes_cmac(t, p, p_size, out);
 
 	LOG_DBG("BE: out %s", bt_hex(out, 16));
 
@@ -167,7 +141,7 @@ static int s1(const uint8_t *m, size_t m_size,
 
 	memset(zero, 0, sizeof(zero));
 
-	err = aes_cmac(zero, m, m_size, out);
+	err = bt_crypto_aes_cmac(zero, m, m_size, out);
 
 	LOG_DBG("BE: out %s", bt_hex(out, 16));
 


### PR DESCRIPTION
Instead of reimplementing the aes_cmac function, CSIP will now use the bt_crypto_aes_cmac function.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/65604