### PR TITLE
Bluetooth: BAP: Add log of err in bt_bap_stream_detach

### DIFF
--- a/subsys/bluetooth/audio/bap_stream.c
+++ b/subsys/bluetooth/audio/bap_stream.c
@@ -406,7 +406,11 @@ void bt_bap_stream_detach(struct bt_bap_stream *stream)
 	stream->ep = NULL;
 
 	if (!is_broadcast) {
-		bt_bap_stream_disconnect(stream);
+		const int err = bt_bap_stream_disconnect(stream);
+
+		if (err != 0) {
+			LOG_DBG("Failed to disconnect stream %p: %d", stream, err);
+		}
 	}
 }
 


### PR DESCRIPTION
We can't really do anything about it if it fails, so we simply log the value.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/66820