### PR TITLE
drivers: serial: ns16550: Add IOPORT_ENABLED check condition

### DIFF
--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -841,7 +841,10 @@ static int uart_ns16550_init(const struct device *dev)
 		data->async.tx_dma_params.dma_cfg.head_block =
 			&data->async.tx_dma_params.active_dma_block;
 #if defined(CONFIG_UART_NS16550_INTEL_LPSS_DMA)
-		if (!dev_cfg->io_map) {
+#if UART_NS16550_IOPORT_ENABLED
+		if (!dev_cfg->io_map)
+#endif
+		{
 			uintptr_t base;
 
 			base = DEVICE_MMIO_GET(dev) + DMA_INTEL_LPSS_OFFSET;


### PR DESCRIPTION
`io_map` check to enable LPSS DMA initialization is kept under condition IOPORT_ENABLED.
This fixes the error caused in case of no io-mapped UART instances in dts of a board because io_map variable not defined.

Signed-off-by: Anisetti Avinash Krishna <anisetti.avinash.krishna@intel.com>