### PR TITLE
drivers: usb: stm32U5 power supply of usb device controller

### DIFF
--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -217,13 +217,14 @@ static int usb_dc_stm32_clock_enable(void)
 		return -ENODEV;
 	}
 
-#ifdef PWR_USBSCR_USB33SV
+#if defined(PWR_USBSCR_USB33SV) || defined(PWR_SVMCR_USV)
+
 	/*
 	 * VDDUSB independent USB supply (PWR clock is on)
 	 * with LL_PWR_EnableVDDUSB function (higher case)
 	 */
 	LL_PWR_EnableVDDUSB();
-#endif /* PWR_USBSCR_USB33SV */
+#endif /* PWR_USBSCR_USB33SV or PWR_SVMCR_USV */
 
 	if (DT_INST_NUM_CLOCKS(0) > 1) {
 		if (clock_control_configure(clk, (clock_control_subsys_t)&pclken[1],

--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -914,13 +914,13 @@ static int priv_clock_enable(void)
 		return -ENODEV;
 	}
 
-#if defined(PWR_USBSCR_USB33SV)
+#if defined(PWR_USBSCR_USB33SV) || defined(PWR_SVMCR_USV)
 	/*
 	 * VDDUSB independent USB supply (PWR clock is on)
 	 * with LL_PWR_EnableVDDUSB function (higher case)
 	 */
 	LL_PWR_EnableVDDUSB();
-#endif /* PWR_USBSCR_USB33SV */
+#endif /* PWR_USBSCR_USB33SV or PWR_SVMCR_USV */
 #if defined(CONFIG_SOC_SERIES_STM32H7X)
 	LL_PWR_EnableUSBVoltageDetector();
 


### PR DESCRIPTION
Like the stm32h5, stm32U5 usb device has an independent power supply, but control bit is **PWR_SVMCR_USV**.
The control bit for the stm32H5 is PWR_USBSCR_USB33SV (no change)

Follows the PR #66274, and last comment, https://github.com/zephyrproject-rtos/zephyr/pull/66274#issuecomment-1866735091
