### PR TITLE
Bluetooth: Audio: fix doxygen warnings

### DIFF
--- a/include/zephyr/bluetooth/audio/gmap_lc3_preset.h
+++ b/include/zephyr/bluetooth/audio/gmap_lc3_preset.h
@@ -17,7 +17,7 @@
  *  @brief Helper to declare LC3 32_1_gr codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_GMAP_LC3_PRESET_32_1_GR(_loc, _stream_context)                                          \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_32_1(_loc, _stream_context),                   \
@@ -27,7 +27,7 @@
  *  @brief Helper to declare LC3 32_2_gr codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_GMAP_LC3_PRESET_32_2_GR(_loc, _stream_context)                                          \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_32_2(_loc, _stream_context),                   \
@@ -37,7 +37,7 @@
  *  @brief Helper to declare LC3 48_1_gr codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_GMAP_LC3_PRESET_48_1_GR(_loc, _stream_context)                                          \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_48_1(_loc, _stream_context),                   \
@@ -49,7 +49,7 @@
  *  Mandatory to support as both unicast client and server
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_GMAP_LC3_PRESET_48_2_GR(_loc, _stream_context)                                          \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_48_2(_loc, _stream_context),                   \
@@ -59,7 +59,7 @@
  *  @brief Helper to declare LC3 48_3_gr codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_GMAP_LC3_PRESET_48_3_GR(_loc, _stream_context)                                          \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_48_3(_loc, _stream_context),                   \
@@ -71,7 +71,7 @@
  *  Mandatory to support as unicast server
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_GMAP_LC3_PRESET_48_4_GR(_loc, _stream_context)                                          \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_48_4(_loc, _stream_context),                   \
@@ -81,7 +81,7 @@
  *  @brief Helper to declare LC3 16_1_gs codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_GMAP_LC3_PRESET_16_1_GS(_loc, _stream_context)                                          \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_16_1(_loc, _stream_context),                   \
@@ -91,7 +91,7 @@
  *  @brief Helper to declare LC3 16_2_gs codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_GMAP_LC3_PRESET_16_2_GS(_loc, _stream_context)                                          \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_16_2(_loc, _stream_context),                   \
@@ -101,7 +101,7 @@
  *  @brief Helper to declare LC3 32_1_gs codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_GMAP_LC3_PRESET_32_1_GS(_loc, _stream_context)                                          \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_32_1(_loc, _stream_context),                   \
@@ -111,7 +111,7 @@
  *  @brief Helper to declare LC3 32_2_gs codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_GMAP_LC3_PRESET_32_2_GS(_loc, _stream_context)                                          \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_32_2(_loc, _stream_context),                   \
@@ -121,7 +121,7 @@
  *  @brief Helper to declare LC3 48_1_gs codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_GMAP_LC3_PRESET_48_1_GS(_loc, _stream_context)                                          \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_48_1(_loc, _stream_context),                   \
@@ -131,7 +131,7 @@
  *  @brief Helper to declare LC3 48_2_gs codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_GMAP_LC3_PRESET_48_2_GS(_loc, _stream_context)                                          \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_48_2(_loc, _stream_context),                   \
@@ -143,7 +143,7 @@
  *  @brief Helper to declare LC3 48_1_g codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_GMAP_LC3_PRESET_48_1_G(_loc, _stream_context)                                           \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_48_1(_loc, _stream_context),                   \
@@ -153,7 +153,7 @@
  *  @brief Helper to declare LC3 48_2_g codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_GMAP_LC3_PRESET_48_2_G(_loc, _stream_context)                                           \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_48_2(_loc, _stream_context),                   \
@@ -163,7 +163,7 @@
  *  @brief Helper to declare LC3 48_3_g codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_GMAP_LC3_PRESET_48_3_G(_loc, _stream_context)                                           \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_48_3(_loc, _stream_context),                   \
@@ -173,7 +173,7 @@
  *  @brief Helper to declare LC3 48_4_g codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
- *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
+ *  @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)
  */
 #define BT_GMAP_LC3_PRESET_48_4_G(_loc, _stream_context)                                           \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_48_4(_loc, _stream_context),                   \


### PR DESCRIPTION
Fix doxygen warnings ("warning: found `</em>` tag without matching `<em>`") from building the Bluetooth Audio API documention.