### PR TITLE
docs: Fix rzt2m starterkit docs formatting

### DIFF
--- a/boards/arm/rzt2m_starterkit/doc/index.rst
+++ b/boards/arm/rzt2m_starterkit/doc/index.rst
@@ -22,6 +22,7 @@ Hardware
 The board utilizes the SoC of part no. R9A07G075M24GBG, with 2MB of RAM.
 
 It has several on-board memory components:
+
 * SDRAM (256MBit),
 * NOR Flash (256MBit),
 * Octa Flash (512MBit),
@@ -30,6 +31,7 @@ It has several on-board memory components:
 * I2C EEPROM (32Kbit).
 
 The communication interfaces include:
+
 * Debug interfaces (J-Link, MIPI-10, MIPI-20),
 * Ethernet,
 * CAN,
@@ -62,6 +64,7 @@ Connections and IOs
 ===================
 
 By default, the board is configured for use with:
+
 * UART0 connected to the USB serial port (pins K18, K19),
 * UART3 connected to the PMOD Header (J25, pins H16, G20),
 * LEDs defined as `led0`, `led1`, `led2` and `led3`,


### PR DESCRIPTION
Add additional new lines before bullet points. Otherwise they are not rendered as bullets.

See: https://docs.zephyrproject.org/latest/boards/arm/rzt2m_starterkit/doc/index.html