### PR TITLE
tests: net: socket: tls: Fix race on TCP socket close

### DIFF
--- a/tests/net/socket/tls/src/main.c
+++ b/tests/net/socket/tls/src/main.c
@@ -802,6 +802,10 @@ static void fake_tcp_server_work(struct k_work *work)
 	test_accept(data->sock, &new_sock, NULL, 0);
 
 	if (!data->reply) {
+		/* Add small delay to avoid race between incoming data and
+		 * sending FIN.
+		 */
+		k_msleep(10);
 		goto out;
 	}
 


### PR DESCRIPTION
One of the tests closed the underlying TCP connection right after establishing one. This caused a certain race between incoming TLS handshake data and entering FIN1 state (experienced on nrF52840), where the TLS handshake data could be received after the FIN1 state was entered, causing the server side to send RST packet. This disrupted the test flow, as graceful TCP connection teardown was expected.

Fix this, by adding a small delay for such case to avoid the race.

Fixes #66871