### PR TITLE
tests: latency_measure benchmark: Add LIFO and FIFO support

### DIFF
--- a/tests/benchmarks/latency_measure/README.rst
+++ b/tests/benchmarks/latency_measure/README.rst
@@ -8,14 +8,18 @@ including:
 * Context switch time between cooperative threads using k_yield
 * Time to switch from ISR back to interrupted thread
 * Time from ISR to executing a different thread (rescheduled)
-* Times to signal a semaphore then test that semaphore
-* Times to signal a semaphore then test that semaphore with a context switch
+* Time to signal a semaphore then test that semaphore
+* Time to signal a semaphore then test that semaphore with a context switch
 * Times to lock a mutex then unlock that mutex
 * Time it takes to create a new thread (without starting it)
 * Time it takes to start a newly created thread
 * Time it takes to suspend a thread
 * Time it takes to resume a suspended thread
 * Time it takes to abort a thread
+* Time it takes to add data to a FIFO/LIFO
+* Time it takes to retrieve data from a FIFO/LIFO
+* Time it takes to wait on a FIFO/LIFO (and context switch)
+* Time it takes to wake and switch to a thread waiting on a FIFO/LIFO
 * Measure average time to alloc memory from heap then free that memory
 
 When userspace is enabled using the prj_user.conf configuration file, this benchmark will
@@ -29,81 +33,125 @@ threads:
 
 Sample output of the benchmark (without userspace enabled)::
 
-        *** Booting Zephyr OS build v3.5.0-rc1-139-gdab69aeed11d ***
-        START - Time Measurement
-        Timing results: Clock frequency: 120 MHz
-        Preemptive threads ctx switch via k_yield (K -> K)  :     519 cycles ,     4325 ns :
-        Cooperative threads ctx switch via k_yield (K -> K) :     519 cycles ,     4325 ns :
-        Switch from ISR back to interrupted thread          :     508 cycles ,     4241 ns :
-        Switch from ISR to another thread (kernel)          :     554 cycles ,     4616 ns :
-        Create kernel thread from kernel thread             :     396 cycles ,     3308 ns :
-        Start kernel thread from kernel thread              :     603 cycles ,     5033 ns :
-        Suspend kernel thread from kernel thread            :     599 cycles ,     4992 ns :
-        Resume kernel thread from kernel thread             :     547 cycles ,     4558 ns :
-        Abort kernel thread from kernel thread              :     339 cycles ,     2825 ns :
-        Give a semaphore (no waiters) from kernel thread    :     134 cycles ,     1116 ns :
-        Take a semaphore (no blocking) from kernel thread   :      53 cycles ,      441 ns :
-        Take a semaphore (context switch K -> K)            :     689 cycles ,     5742 ns :
-        Give a semaphore (context switch K -> K)            :     789 cycles ,     6575 ns :
-        Lock a mutex from kernel thread                     :      94 cycles ,      783 ns :
-        Unlock a mutex from kernel thread                   :      24 cycles ,      200 ns :
-        Average time for heap malloc                        :     620 cycles ,     5166 ns :
-        Average time for heap free                          :     431 cycles ,     3591 ns :
+        *** Booting Zephyr OS build zephyr-v3.5.0-3537-g5dbe0ce2622d ***
+        THREAD yield.preemptive.ctx.(K -> K)                :     344 cycles ,     2866 ns :
+        THREAD yield.cooperative.ctx.(K -> K)               :     344 cycles ,     2867 ns :
+        ISR resume.interrupted.thread.kernel                :     498 cycles ,     4158 ns :
+        ISR resume.different.thread.kernel                  :     383 cycles ,     3199 ns :
+        THREAD create.kernel.from.kernel                    :     401 cycles ,     3349 ns :
+        THREAD start.kernel.from.kernel                     :     418 cycles ,     3491 ns :
+        THREAD suspend.kernel.from.kernel                   :     433 cycles ,     3616 ns :
+        THREAD resume.kernel.from.kernel                    :     351 cycles ,     2933 ns :
+        THREAD abort.kernel.from.kernel                     :     349 cycles ,     2909 ns :
+        FIFO put.immediate.kernel                           :     294 cycles ,     2450 ns :
+        FIFO get.immediate.kernel                           :     135 cycles ,     1133 ns :
+        FIFO put.alloc.immediate.kernel                     :     906 cycles ,     7550 ns :
+        FIFO get.free.immediate.kernel                      :     570 cycles ,     4750 ns :
+        FIFO get.blocking.(K -> K)                          :     545 cycles ,     4542 ns :
+        FIFO put.wake+ctx.(K -> K)                          :     675 cycles ,     5625 ns :
+        FIFO get.free.blocking.(K -> K)                     :     555 cycles ,     4625 ns :
+        FIFO put.alloc.wake+ctx.(K -> K)                    :     670 cycles ,     5583 ns :
+        LIFO put.immediate.kernel                           :     282 cycles ,     2350 ns :
+        LIFO get.immediate.kernel                           :     135 cycles ,     1133 ns :
+        LIFO put.alloc.immediate.kernel                     :     903 cycles ,     7526 ns :
+        LIFO get.free.immediate.kernel                      :     570 cycles ,     4750 ns :
+        LIFO get.blocking.(K -> K)                          :     542 cycles ,     4524 ns :
+        LIFO put.wake+ctx.(K -> K)                          :     670 cycles ,     5584 ns :
+        LIFO get.free.blocking.(K -> K)                     :     547 cycles ,     4558 ns :
+        LIFO put.alloc.wake+ctx.(K -> K)                    :     670 cycles ,     5583 ns :
+        SEMAPHORE give.immediate.kernel                     :     165 cycles ,     1375 ns :
+        SEMAPHORE take.immediate.kernel                     :      69 cycles ,      575 ns :
+        SEMAPHORE take.blocking.(K -> K)                    :     489 cycles ,     4075 ns :
+        SEMAPHORE give.wake+ctx.(K -> K)                    :     604 cycles ,     5033 ns :
+        MUTEX lock.immediate.recursive.kernel               :     115 cycles ,      958 ns :
+        MUTEX unlock.immediate.recursive.kernel             :      40 cycles ,      333 ns :
+        HEAP malloc.immediate                               :     615 cycles ,     5125 ns :
+        HEAP free.immediate                                 :     431 cycles ,     3591 ns :
         ===================================================================
         PROJECT EXECUTION SUCCESSFUL
 
 Sample output of the benchmark (with userspace enabled)::
 
-        *** Booting Zephyr OS build v3.5.0-rc1-139-gdab69aeed11d ***
-        START - Time Measurement
-        Timing results: Clock frequency: 120 MHz
-        Preemptive threads ctx switch via k_yield (K -> K)  :    1195 cycles ,     9958 ns :
-        Preemptive threads ctx switch via k_yield (U -> U)  :    1485 cycles ,    12379 ns :
-        Preemptive threads ctx switch via k_yield (K -> U)  :    1390 cycles ,    11587 ns :
-        Preemptive threads ctx switch via k_yield (U -> K)  :    1289 cycles ,    10749 ns :
-        Cooperative threads ctx switch via k_yield (K -> K) :    1185 cycles ,     9875 ns :
-        Cooperative threads ctx switch via k_yield (U -> U) :    1475 cycles ,    12295 ns :
-        Cooperative threads ctx switch via k_yield (K -> U) :    1380 cycles ,    11504 ns :
-        Cooperative threads ctx switch via k_yield (U -> K) :    1280 cycles ,    10666 ns :
-        Switch from ISR back to interrupted thread          :    1130 cycles ,     9416 ns :
-        Switch from ISR to another thread (kernel)          :    1184 cycles ,     9874 ns :
-        Switch from ISR to another thread (user)            :    1390 cycles ,    11583 ns :
-        Create kernel thread from kernel thread             :     985 cycles ,     8208 ns :
-        Start kernel thread from kernel thread              :    1275 cycles ,    10625 ns :
-        Suspend kernel thread from kernel thread            :    1220 cycles ,    10167 ns :
-        Resume kernel thread from kernel thread             :    1193 cycles ,     9942 ns :
-        Abort kernel thread from kernel thread              :    2555 cycles ,    21292 ns :
-        Create user thread from kernel thread               :     849 cycles ,     7083 ns :
-        Start user thread from kernel thread                :    6715 cycles ,    55960 ns :
-        Suspend user thread from kernel thread              :    1585 cycles ,    13208 ns :
-        Resume user thread from kernel thread               :    1383 cycles ,    11525 ns :
-        Abort user thread from kernel thread                :    2420 cycles ,    20167 ns :
-        Create user thread from user thread                 :    2110 cycles ,    17584 ns :
-        Start user thread from user thread                  :    7070 cycles ,    58919 ns :
-        Suspend user thread from user thread                :    1784 cycles ,    14874 ns :
-        Resume user thread from user thread                 :    1740 cycles ,    14502 ns :
-        Abort user thread from user thread                  :    3000 cycles ,    25000 ns :
-        Start kernel thread from user thread                :    1630 cycles ,    13583 ns :
-        Suspend kernel thread from user thread              :    1420 cycles ,    11833 ns :
-        Resume kernel thread from user thread               :    1550 cycles ,    12917 ns :
-        Abort kernel thread from user thread                :    3135 cycles ,    26125 ns :
-        Give a semaphore (no waiters) from kernel thread    :     160 cycles ,     1333 ns :
-        Take a semaphore (no blocking) from kernel thread   :      95 cycles ,      791 ns :
-        Give a semaphore (no waiters) from user thread      :     380 cycles ,     3166 ns :
-        Take a semaphore (no blocking) from user thread     :     315 cycles ,     2625 ns :
-        Take a semaphore (context switch K -> K)            :    1340 cycles ,    11167 ns :
-        Give a semaphore (context switch K -> K)            :    1460 cycles ,    12167 ns :
-        Take a semaphore (context switch K -> U)            :    1540 cycles ,    12838 ns :
-        Give a semaphore (context switch U -> K)            :    1800 cycles ,    15000 ns :
-        Take a semaphore (context switch U -> K)            :    1690 cycles ,    14084 ns :
-        Give a semaphore (context switch K -> U)            :    1650 cycles ,    13750 ns :
-        Take a semaphore (context switch U -> U)            :    1890 cycles ,    15756 ns :
-        Give a semaphore (context switch U -> U)            :    1990 cycles ,    16583 ns :
-        Lock a mutex from kernel thread                     :     105 cycles ,      875 ns :
-        Unlock a mutex from kernel thread                   :      17 cycles ,      141 ns :
-        Lock a mutex from user thread                       :     330 cycles ,     2750 ns :
-        Unlock a mutex from user thread                     :     255 cycles ,     2125 ns :
-        Average time for heap malloc                        :     606 cycles ,     5058 ns :
-        Average time for heap free                          :     422 cycles ,     3516 ns :
+        *** Booting Zephyr OS build zephyr-v3.5.0-3537-g5dbe0ce2622d ***
+        THREAD yield.preemptive.ctx.(K -> K)                :     990 cycles ,     8250 ns :
+        THREAD yield.preemptive.ctx.(U -> U)                :    1285 cycles ,    10712 ns :
+        THREAD yield.preemptive.ctx.(K -> U)                :    1178 cycles ,     9817 ns :
+        THREAD yield.preemptive.ctx.(U -> K)                :    1097 cycles ,     9145 ns :
+        THREAD yield.cooperative.ctx.(K -> K)               :     990 cycles ,     8250 ns :
+        THREAD yield.cooperative.ctx.(U -> U)               :    1285 cycles ,    10712 ns :
+        THREAD yield.cooperative.ctx.(K -> U)               :    1178 cycles ,     9817 ns :
+        THREAD yield.cooperative.ctx.(U -> K)               :    1097 cycles ,     9146 ns :
+        ISR resume.interrupted.thread.kernel                :    1120 cycles ,     9333 ns :
+        ISR resume.different.thread.kernel                  :    1010 cycles ,     8417 ns :
+        ISR resume.different.thread.user                    :    1207 cycles ,    10062 ns :
+        THREAD create.kernel.from.kernel                    :     955 cycles ,     7958 ns :
+        THREAD start.kernel.from.kernel                     :    1095 cycles ,     9126 ns :
+        THREAD suspend.kernel.from.kernel                   :    1064 cycles ,     8874 ns :
+        THREAD resume.kernel.from.kernel                    :     999 cycles ,     8333 ns :
+        THREAD abort.kernel.from.kernel                     :    2280 cycles ,    19000 ns :
+        THREAD create.user.from.kernel                      :     822 cycles ,     6855 ns :
+        THREAD start.user.from.kernel                       :    6572 cycles ,    54774 ns :
+        THREAD suspend.user.from.kernel                     :    1422 cycles ,    11857 ns :
+        THREAD resume.user.from.kernel                      :    1177 cycles ,     9812 ns :
+        THREAD abort.user.from.kernel                       :    2147 cycles ,    17897 ns :
+        THREAD create.user.from.user                        :    2105 cycles ,    17542 ns :
+        THREAD start.user.from.user                         :    6960 cycles ,    58002 ns :
+        THREAD suspend user.from.user                       :    1610 cycles ,    13417 ns :
+        THREAD resume user.from.user                        :    1565 cycles ,    13042 ns :
+        THREAD abort user.from.user                         :    2780 cycles ,    23167 ns :
+        THREAD start.kernel.from.user                       :    1482 cycles ,    12353 ns :
+        THREAD suspend.kernel.from.user                     :    1252 cycles ,    10437 ns :
+        THREAD resume.kernel.from.user                      :    1387 cycles ,    11564 ns :
+        THREAD abort.kernel.from.user                       :    2912 cycles ,    24272 ns :
+        FIFO put.immediate.kernel                           :     314 cycles ,     2624 ns :
+        FIFO get.immediate.kernel                           :     215 cycles ,     1792 ns :
+        FIFO put.alloc.immediate.kernel                     :    1025 cycles ,     8541 ns :
+        FIFO get.free.immediate.kernel                      :     655 cycles ,     5458 ns :
+        FIFO put.alloc.immediate.user                       :    1740 cycles ,    14500 ns :
+        FIFO get.free.immediate.user                        :    1410 cycles ,    11751 ns :
+        FIFO get.blocking.(K -> K)                          :    1249 cycles ,    10416 ns :
+        FIFO put.wake+ctx.(K -> K)                          :    1320 cycles ,    11000 ns :
+        FIFO get.free.blocking.(K -> K)                     :    1235 cycles ,    10292 ns :
+        FIFO put.alloc.wake+ctx.(K -> K)                    :    1355 cycles ,    11292 ns :
+        FIFO get.free.blocking.(U -> K)                     :    1750 cycles ,    14584 ns :
+        FIFO put.alloc.wake+ctx.(K -> U)                    :    1680 cycles ,    14001 ns :
+        FIFO get.free.blocking.(K -> U)                     :    1555 cycles ,    12959 ns :
+        FIFO put.alloc.wake+ctx.(U -> K)                    :    1845 cycles ,    15375 ns :
+        FIFO get.free.blocking.(U -> U)                     :    2070 cycles ,    17251 ns :
+        FIFO put.alloc.wake+ctx.(U -> U)                    :    2170 cycles ,    18084 ns :
+        LIFO put.immediate.kernel                           :     299 cycles ,     2499 ns :
+        LIFO get.immediate.kernel                           :     204 cycles ,     1708 ns :
+        LIFO put.alloc.immediate.kernel                     :    1015 cycles ,     8459 ns :
+        LIFO get.free.immediate.kernel                      :     645 cycles ,     5375 ns :
+        LIFO put.alloc.immediate.user                       :    1760 cycles ,    14668 ns :
+        LIFO get.free.immediate.user                        :    1400 cycles ,    11667 ns :
+        LIFO get.blocking.(K -> K)                          :    1234 cycles ,    10291 ns :
+        LIFO put.wake+ctx.(K -> K)                          :    1315 cycles ,    10959 ns :
+        LIFO get.free.blocking.(K -> K)                     :    1230 cycles ,    10251 ns :
+        LIFO put.alloc.wake+ctx.(K -> K)                    :    1345 cycles ,    11208 ns :
+        LIFO get.free.blocking.(U -> K)                     :    1745 cycles ,    14544 ns :
+        LIFO put.alloc.wake+ctx.(K -> U)                    :    1680 cycles ,    14000 ns :
+        LIFO get.free.blocking.(K -> U)                     :    1555 cycles ,    12958 ns :
+        LIFO put.alloc.wake+ctx.(U -> K)                    :    1855 cycles ,    15459 ns :
+        LIFO get.free.blocking.(U -> U)                     :    2070 cycles ,    17251 ns :
+        LIFO put.alloc.wake+ctx.(U -> U)                    :    2190 cycles ,    18251 ns :
+        SEMAPHORE give.immediate.kernel                     :     210 cycles ,     1750 ns :
+        SEMAPHORE take.immediate.kernel                     :     145 cycles ,     1208 ns :
+        SEMAPHORE give.immediate.user                       :     715 cycles ,     5959 ns :
+        SEMAPHORE take.immediate.user                       :     660 cycles ,     5500 ns :
+        SEMAPHORE take.blocking.(K -> K)                    :    1150 cycles ,     9584 ns :
+        SEMAPHORE give.wake+ctx.(K -> K)                    :    1279 cycles ,    10666 ns :
+        SEMAPHORE take.blocking.(K -> U)                    :    1343 cycles ,    11192 ns :
+        SEMAPHORE give.wake+ctx.(U -> K)                    :    1637 cycles ,    13645 ns :
+        SEMAPHORE take.blocking.(U -> K)                    :    1522 cycles ,    12688 ns :
+        SEMAPHORE give.wake+ctx.(K -> U)                    :    1472 cycles ,    12270 ns :
+        SEMAPHORE take.blocking.(U -> U)                    :    1715 cycles ,    14296 ns :
+        SEMAPHORE give.wake+ctx.(U -> U)                    :    1830 cycles ,    15250 ns :
+        MUTEX lock.immediate.recursive.kernel               :     150 cycles ,     1250 ns :
+        MUTEX unlock.immediate.recursive.kernel             :      57 cycles ,      475 ns :
+        MUTEX lock.immediate.recursive.user                 :     670 cycles ,     5583 ns :
+        MUTEX unlock.immediate.recursive.user               :     595 cycles ,     4959 ns :
+        HEAP malloc.immediate                               :     629 cycles ,     5241 ns :
+        HEAP free.immediate                                 :     414 cycles ,     3450 ns :
         ===================================================================
         PROJECT EXECUTION SUCCESSFUL

--- a/tests/benchmarks/latency_measure/src/fifo.c
+++ b/tests/benchmarks/latency_measure/src/fifo.c
@@ -1,0 +1,330 @@
+/*
+ * Copyright (c) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * @file measure time for various FIFO operations
+ *
+ * This file contains the tests that measures the times for the following
+ * FIFO operations from both kernel threads and user threads:
+ *  1. Immediately adding a data item to a FIFO
+ *  2. Immediately removing a data item from a FIFO
+ *  3. Immediately adding a data item to a FIFO with allocation
+ *  4. Immediately removing a data item from a FIFO with allocation
+ *  5. Blocking on removing a data item from a FIFO
+ *  6. Waking (and context switching to) a thread blocked on a FIFO via
+ *     k_fifo_put().
+ *  7. Waking (and context switching to) a thread blocked on a FIFO via
+ *     k_fifo_alloc_put().
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/timing/timing.h>
+#include "utils.h"
+#include "timing_sc.h"
+
+#define STACK_SIZE (512 + CONFIG_TEST_EXTRA_STACK_SIZE)
+
+static K_FIFO_DEFINE(fifo);
+
+BENCH_BMEM uintptr_t fifo_data[5];
+
+static void fifo_put_get_thread_entry(void *p1, void *p2, void *p3)
+{
+	uint32_t num_iterations = (uint32_t)(uintptr_t)p1;
+	uint32_t options = (uint32_t)(uintptr_t)p2;
+	timing_t start;
+	timing_t mid;
+	timing_t finish;
+	uint64_t put_sum = 0ULL;
+	uint64_t get_sum = 0ULL;
+	uintptr_t *data;
+
+	if ((options & K_USER) == 0) {
+		for (uint32_t i = 0; i < num_iterations; i++) {
+			start = timing_timestamp_get();
+
+			k_fifo_put(&fifo, fifo_data);
+
+			mid = timing_timestamp_get();
+
+			data = k_fifo_get(&fifo, K_NO_WAIT);
+
+			finish = timing_timestamp_get();
+
+			put_sum += timing_cycles_get(&start, &mid);
+			get_sum += timing_cycles_get(&mid, &finish);
+		}
+
+		timestamp.cycles = put_sum;
+		k_sem_take(&pause_sem, K_FOREVER);
+
+		timestamp.cycles = get_sum;
+		k_sem_take(&pause_sem, K_FOREVER);
+
+		put_sum = 0ULL;
+		get_sum = 0ULL;
+	}
+
+	for (uint32_t i = 0; i < num_iterations; i++) {
+		start = timing_timestamp_get();
+
+		k_fifo_alloc_put(&fifo, fifo_data);
+
+		mid = timing_timestamp_get();
+
+		data = k_fifo_get(&fifo, K_NO_WAIT);
+
+		finish = timing_timestamp_get();
+
+		put_sum += timing_cycles_get(&start, &mid);
+		get_sum += timing_cycles_get(&mid, &finish);
+	}
+
+	timestamp.cycles = put_sum;
+	k_sem_take(&pause_sem, K_FOREVER);
+
+	timestamp.cycles = get_sum;
+}
+
+int fifo_ops(uint32_t num_iterations, uint32_t options)
+{
+	int      priority;
+	uint64_t cycles;
+	char     description[80];
+
+	priority = k_thread_priority_get(k_current_get());
+
+	timing_start();
+
+	k_thread_create(&start_thread, start_stack,
+			K_THREAD_STACK_SIZEOF(start_stack),
+			fifo_put_get_thread_entry,
+			(void *)(uintptr_t)num_iterations,
+			(void *)(uintptr_t)options, NULL,
+			priority - 1, options, K_FOREVER);
+
+	k_thread_access_grant(&start_thread, &pause_sem, &fifo);
+
+	k_thread_start(&start_thread);
+
+	if ((options & K_USER) == 0) {
+		snprintf(description, sizeof(description),
+			 "FIFO put.immediate.%s",
+			 options & K_USER ? "user" : "kernel");
+
+		cycles = timestamp.cycles;
+		cycles -= timestamp_overhead_adjustment(options, options);
+		PRINT_STATS_AVG(description, (uint32_t)cycles,
+				num_iterations, false, "");
+		k_sem_give(&pause_sem);
+
+		snprintf(description, sizeof(description),
+			 "FIFO get.immediate.%s",
+			 options & K_USER ? "user" : "kernel");
+		cycles = timestamp.cycles;
+		cycles -= timestamp_overhead_adjustment(options, options);
+		PRINT_STATS_AVG(description, (uint32_t)cycles,
+				num_iterations, false, "");
+		k_sem_give(&pause_sem);
+	}
+
+	snprintf(description, sizeof(description),
+		 "FIFO put.alloc.immediate.%s",
+		 options & K_USER ? "user" : "kernel");
+
+	cycles = timestamp.cycles;
+	PRINT_STATS_AVG(description, (uint32_t)cycles,
+			num_iterations, false, "");
+	k_sem_give(&pause_sem);
+
+	snprintf(description, sizeof(description),
+		 "FIFO get.free.immediate.%s",
+		 options & K_USER ? "user" : "kernel");
+	cycles = timestamp.cycles;
+	PRINT_STATS_AVG(description, (uint32_t)cycles,
+			num_iterations, false, "");
+
+	k_thread_join(&start_thread, K_FOREVER);
+
+	timing_stop();
+
+	return 0;
+}
+
+static void alt_thread_entry(void *p1, void *p2, void *p3)
+{
+	uint32_t num_iterations = (uint32_t)(uintptr_t)p1;
+	uint32_t options = (uint32_t)(uintptr_t)p2;
+	timing_t  start;
+	timing_t  mid;
+	timing_t  finish;
+	uint64_t  sum[4] = {0ULL, 0ULL, 0ULL, 0ULL};
+	uintptr_t *data;
+	uint32_t  i;
+
+	if ((options & K_USER) == 0) {
+
+		/* Used with k_fifo_put() */
+
+		for (i = 0; i < num_iterations; i++) {
+
+			/* 1. Block waiting for data on FIFO */
+
+			start = timing_timestamp_get();
+
+			data = k_fifo_get(&fifo, K_FOREVER);
+
+			/* 3. Data obtained. */
+
+			finish = timing_timestamp_get();
+
+			mid = timestamp.sample;
+
+			sum[0] += timing_cycles_get(&start, &mid);
+			sum[1] += timing_cycles_get(&mid, &finish);
+		}
+	}
+
+	/* Used with k_fifo_alloc_put() */
+
+	for (i = 0; i < num_iterations; i++) {
+
+		/* 4. Block waiting for data on FIFO */
+
+		start = timing_timestamp_get();
+
+		data = k_fifo_get(&fifo, K_FOREVER);
+
+		/* 6. Data obtained */
+
+		finish = timing_timestamp_get();
+
+		mid = timestamp.sample;
+
+		sum[2] += timing_cycles_get(&start, &mid);
+		sum[3] += timing_cycles_get(&mid, &finish);
+	}
+
+	if ((options & K_USER) == 0) {
+		timestamp.cycles = sum[0];
+		k_sem_take(&pause_sem, K_FOREVER);
+		timestamp.cycles = sum[1];
+		k_sem_take(&pause_sem, K_FOREVER);
+	}
+
+	timestamp.cycles = sum[2];
+	k_sem_take(&pause_sem, K_FOREVER);
+	timestamp.cycles = sum[3];
+}
+
+static void start_thread_entry(void *p1, void *p2, void *p3)
+{
+	uint32_t num_iterations = (uint32_t)(uintptr_t)p1;
+	uint32_t options = (uint32_t)(uintptr_t)p2;
+	uint32_t i;
+
+	k_thread_start(&alt_thread);
+
+	if ((options & K_USER) == 0) {
+		for (i = 0; i < num_iterations; i++) {
+
+			/* 2. Add data thereby waking alt thread */
+
+			timestamp.sample = timing_timestamp_get();
+
+			k_fifo_put(&fifo, fifo_data);
+
+		}
+	}
+
+	for (i = 0; i < num_iterations; i++) {
+
+		/* 5. Add data thereby waking alt thread */
+
+		timestamp.sample = timing_timestamp_get();
+
+		k_fifo_alloc_put(&fifo, fifo_data);
+
+	}
+
+	k_thread_join(&alt_thread, K_FOREVER);
+}
+
+int fifo_blocking_ops(uint32_t num_iterations, uint32_t start_options,
+		      uint32_t alt_options)
+{
+	int      priority;
+	uint64_t cycles;
+	char     description[80];
+
+	priority = k_thread_priority_get(k_current_get());
+
+	timing_start();
+
+	k_thread_create(&start_thread, start_stack,
+			K_THREAD_STACK_SIZEOF(start_stack),
+			start_thread_entry,
+			(void *)(uintptr_t)num_iterations,
+			(void *)(uintptr_t)(start_options | alt_options), NULL,
+			priority - 1, start_options, K_FOREVER);
+
+	k_thread_create(&alt_thread, alt_stack,
+			K_THREAD_STACK_SIZEOF(alt_stack),
+			alt_thread_entry,
+			(void *)(uintptr_t)num_iterations,
+			(void *)(uintptr_t)(start_options | alt_options), NULL,
+			priority - 2, alt_options, K_FOREVER);
+
+	k_thread_access_grant(&start_thread, &alt_thread, &pause_sem, &fifo);
+	k_thread_access_grant(&alt_thread, &pause_sem, &fifo);
+
+	k_thread_start(&start_thread);
+
+	if (((start_options | alt_options) & K_USER) == 0) {
+		snprintf(description, sizeof(description),
+			 "FIFO get.blocking.(%s -> %s)",
+			 alt_options & K_USER ? "U" : "K",
+			 start_options & K_USER ? "U" : "K");
+
+		cycles = timestamp.cycles;
+		PRINT_STATS_AVG(description, (uint32_t)cycles,
+				num_iterations, false, "");
+		k_sem_give(&pause_sem);
+
+		snprintf(description, sizeof(description),
+			 "FIFO put.wake+ctx.(%s -> %s)",
+			 start_options & K_USER ? "U" : "K",
+			 alt_options & K_USER ? "U" : "K");
+		cycles = timestamp.cycles;
+		PRINT_STATS_AVG(description, (uint32_t)cycles,
+				num_iterations, false, "");
+		k_sem_give(&pause_sem);
+	}
+
+	snprintf(description, sizeof(description),
+		 "FIFO get.free.blocking.(%s -> %s)",
+		 alt_options & K_USER ? "U" : "K",
+		 start_options & K_USER ? "U" : "K");
+
+	cycles = timestamp.cycles;
+	PRINT_STATS_AVG(description, (uint32_t)cycles,
+			num_iterations, false, "");
+	k_sem_give(&pause_sem);
+
+	snprintf(description, sizeof(description),
+		 "FIFO put.alloc.wake+ctx.(%s -> %s)",
+		 start_options & K_USER ? "U" : "K",
+		 alt_options & K_USER ? "U" : "K");
+	cycles = timestamp.cycles;
+	PRINT_STATS_AVG(description, (uint32_t)cycles,
+			num_iterations, false, "");
+
+	k_thread_join(&start_thread, K_FOREVER);
+
+	timing_stop();
+
+	return 0;
+}

--- a/tests/benchmarks/latency_measure/src/heap_malloc_free.c
+++ b/tests/benchmarks/latency_measure/src/heap_malloc_free.c
@@ -63,9 +63,9 @@ void heap_malloc_free(void)
 		notes = "Memory heap too small--increase it.";
 	}
 
-	PRINT_STATS_AVG("Average time for heap malloc", sum_malloc, count,
+	PRINT_STATS_AVG("HEAP malloc.immediate", sum_malloc, count,
 			failed, notes);
-	PRINT_STATS_AVG("Average time for heap free", sum_free, count,
+	PRINT_STATS_AVG("HEAP free.immediate", sum_free, count,
 			failed, notes);
 
 	timing_stop();

--- a/tests/benchmarks/latency_measure/src/int_to_thread.c
+++ b/tests/benchmarks/latency_measure/src/int_to_thread.c
@@ -174,7 +174,7 @@ int int_to_thread(uint32_t num_iterations)
 
 	sum -= timestamp_overhead_adjustment(0, 0);
 
-	PRINT_STATS_AVG("Switch from ISR back to interrupted thread",
+	PRINT_STATS_AVG("ISR resume.interrupted.thread.kernel",
 			(uint32_t)sum, num_iterations, false, "");
 
 	/* ************** */
@@ -183,7 +183,7 @@ int int_to_thread(uint32_t num_iterations)
 
 	sum -= timestamp_overhead_adjustment(0, 0);
 
-	PRINT_STATS_AVG("Switch from ISR to another thread (kernel)",
+	PRINT_STATS_AVG("ISR resume.different.thread.kernel",
 			(uint32_t)sum, num_iterations, false, "");
 
 	/* ************** */
@@ -193,7 +193,7 @@ int int_to_thread(uint32_t num_iterations)
 
 	sum -= timestamp_overhead_adjustment(0, K_USER);
 
-	PRINT_STATS_AVG("Switch from ISR to another thread (user)",
+	PRINT_STATS_AVG("ISR resume.different.thread.user",
 			(uint32_t)sum, num_iterations, false, "");
 #endif
 

--- a/tests/benchmarks/latency_measure/src/lifo.c
+++ b/tests/benchmarks/latency_measure/src/lifo.c
@@ -1,0 +1,330 @@
+/*
+ * Copyright (c) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * @file measure time for various LIFO operations
+ *
+ * This file contains the tests that measures the times for the following
+ * LIFO operations from both kernel threads and user threads:
+ *  1. Immediately adding a data item to a LIFO
+ *  2. Immediately removing a data item from a LIFO
+ *  3. Immediately adding a data item to a LIFO with allocation
+ *  4. Immediately removing a data item from a LIFO with allocation
+ *  5. Blocking on removing a data item from a LIFO
+ *  6. Waking (and context switching to) a thread blocked on a LIFO via
+ *     k_lifo_put().
+ *  7. Waking (and context switching to) a thread blocked on a LIFO via
+ *     k_lifo_alloc_put().
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/timing/timing.h>
+#include "utils.h"
+#include "timing_sc.h"
+
+#define STACK_SIZE (512 + CONFIG_TEST_EXTRA_STACK_SIZE)
+
+static K_LIFO_DEFINE(lifo);
+
+BENCH_BMEM uintptr_t lifo_data[5];
+
+static void lifo_put_get_thread_entry(void *p1, void *p2, void *p3)
+{
+	uint32_t num_iterations = (uint32_t)(uintptr_t)p1;
+	uint32_t options = (uint32_t)(uintptr_t)p2;
+	timing_t start;
+	timing_t mid;
+	timing_t finish;
+	uint64_t put_sum = 0ULL;
+	uint64_t get_sum = 0ULL;
+	uintptr_t *data;
+
+	if ((options & K_USER) == 0) {
+		for (uint32_t i = 0; i < num_iterations; i++) {
+			start = timing_timestamp_get();
+
+			k_lifo_put(&lifo, lifo_data);
+
+			mid = timing_timestamp_get();
+
+			data = k_lifo_get(&lifo, K_NO_WAIT);
+
+			finish = timing_timestamp_get();
+
+			put_sum += timing_cycles_get(&start, &mid);
+			get_sum += timing_cycles_get(&mid, &finish);
+		}
+
+		timestamp.cycles = put_sum;
+		k_sem_take(&pause_sem, K_FOREVER);
+
+		timestamp.cycles = get_sum;
+		k_sem_take(&pause_sem, K_FOREVER);
+
+		put_sum = 0ULL;
+		get_sum = 0ULL;
+	}
+
+	for (uint32_t i = 0; i < num_iterations; i++) {
+		start = timing_timestamp_get();
+
+		k_lifo_alloc_put(&lifo, lifo_data);
+
+		mid = timing_timestamp_get();
+
+		data = k_lifo_get(&lifo, K_NO_WAIT);
+
+		finish = timing_timestamp_get();
+
+		put_sum += timing_cycles_get(&start, &mid);
+		get_sum += timing_cycles_get(&mid, &finish);
+	}
+
+	timestamp.cycles = put_sum;
+	k_sem_take(&pause_sem, K_FOREVER);
+
+	timestamp.cycles = get_sum;
+}
+
+int lifo_ops(uint32_t num_iterations, uint32_t options)
+{
+	int      priority;
+	uint64_t cycles;
+	char     description[80];
+
+	priority = k_thread_priority_get(k_current_get());
+
+	timing_start();
+
+	k_thread_create(&start_thread, start_stack,
+			K_THREAD_STACK_SIZEOF(start_stack),
+			lifo_put_get_thread_entry,
+			(void *)(uintptr_t)num_iterations,
+			(void *)(uintptr_t)options, NULL,
+			priority - 1, options, K_FOREVER);
+
+	k_thread_access_grant(&start_thread, &pause_sem, &lifo);
+
+	k_thread_start(&start_thread);
+
+	if ((options & K_USER) == 0) {
+		snprintf(description, sizeof(description),
+			 "LIFO put.immediate.%s",
+			 options & K_USER ? "user" : "kernel");
+
+		cycles = timestamp.cycles;
+		cycles -= timestamp_overhead_adjustment(options, options);
+		PRINT_STATS_AVG(description, (uint32_t)cycles,
+				num_iterations, false, "");
+		k_sem_give(&pause_sem);
+
+		snprintf(description, sizeof(description),
+			 "LIFO get.immediate.%s",
+			 options & K_USER ? "user" : "kernel");
+		cycles = timestamp.cycles;
+		cycles -= timestamp_overhead_adjustment(options, options);
+		PRINT_STATS_AVG(description, (uint32_t)cycles,
+				num_iterations, false, "");
+		k_sem_give(&pause_sem);
+	}
+
+	snprintf(description, sizeof(description),
+		 "LIFO put.alloc.immediate.%s",
+		 options & K_USER ? "user" : "kernel");
+
+	cycles = timestamp.cycles;
+	PRINT_STATS_AVG(description, (uint32_t)cycles,
+			num_iterations, false, "");
+	k_sem_give(&pause_sem);
+
+	snprintf(description, sizeof(description),
+		 "LIFO get.free.immediate.%s",
+		 options & K_USER ? "user" : "kernel");
+	cycles = timestamp.cycles;
+	PRINT_STATS_AVG(description, (uint32_t)cycles,
+			num_iterations, false, "");
+
+	k_thread_join(&start_thread, K_FOREVER);
+
+	timing_stop();
+
+	return 0;
+}
+
+static void alt_thread_entry(void *p1, void *p2, void *p3)
+{
+	uint32_t num_iterations = (uint32_t)(uintptr_t)p1;
+	uint32_t options = (uint32_t)(uintptr_t)p2;
+	timing_t  start;
+	timing_t  mid;
+	timing_t  finish;
+	uint64_t  sum[4] = {0ULL, 0ULL, 0ULL, 0ULL};
+	uintptr_t *data;
+	uint32_t  i;
+
+	if ((options & K_USER) == 0) {
+
+		/* Used with k_lifo_put() */
+
+		for (i = 0; i < num_iterations; i++) {
+
+			/* 1. Block waiting for data on LIFO */
+
+			start = timing_timestamp_get();
+
+			data = k_lifo_get(&lifo, K_FOREVER);
+
+			/* 3. Data obtained. */
+
+			finish = timing_timestamp_get();
+
+			mid = timestamp.sample;
+
+			sum[0] += timing_cycles_get(&start, &mid);
+			sum[1] += timing_cycles_get(&mid, &finish);
+		}
+	}
+
+	/* Used with k_lifo_alloc_put() */
+
+	for (i = 0; i < num_iterations; i++) {
+
+		/* 4. Block waiting for data on LIFO */
+
+		start = timing_timestamp_get();
+
+		data = k_lifo_get(&lifo, K_FOREVER);
+
+		/* 6. Data obtained */
+
+		finish = timing_timestamp_get();
+
+		mid = timestamp.sample;
+
+		sum[2] += timing_cycles_get(&start, &mid);
+		sum[3] += timing_cycles_get(&mid, &finish);
+	}
+
+	if ((options & K_USER) == 0) {
+		timestamp.cycles = sum[0];
+		k_sem_take(&pause_sem, K_FOREVER);
+		timestamp.cycles = sum[1];
+		k_sem_take(&pause_sem, K_FOREVER);
+	}
+
+	timestamp.cycles = sum[2];
+	k_sem_take(&pause_sem, K_FOREVER);
+	timestamp.cycles = sum[3];
+}
+
+static void start_thread_entry(void *p1, void *p2, void *p3)
+{
+	uint32_t num_iterations = (uint32_t)(uintptr_t)p1;
+	uint32_t options = (uint32_t)(uintptr_t)p2;
+	uint32_t i;
+
+	k_thread_start(&alt_thread);
+
+	if ((options & K_USER) == 0) {
+		for (i = 0; i < num_iterations; i++) {
+
+			/* 2. Add data thereby waking alt thread */
+
+			timestamp.sample = timing_timestamp_get();
+
+			k_lifo_put(&lifo, lifo_data);
+
+		}
+	}
+
+	for (i = 0; i < num_iterations; i++) {
+
+		/* 5. Add data thereby waking alt thread */
+
+		timestamp.sample = timing_timestamp_get();
+
+		k_lifo_alloc_put(&lifo, lifo_data);
+
+	}
+
+	k_thread_join(&alt_thread, K_FOREVER);
+}
+
+int lifo_blocking_ops(uint32_t num_iterations, uint32_t start_options,
+		      uint32_t alt_options)
+{
+	int      priority;
+	uint64_t cycles;
+	char     description[80];
+
+	priority = k_thread_priority_get(k_current_get());
+
+	timing_start();
+
+	k_thread_create(&start_thread, start_stack,
+			K_THREAD_STACK_SIZEOF(start_stack),
+			start_thread_entry,
+			(void *)(uintptr_t)num_iterations,
+			(void *)(uintptr_t)(start_options | alt_options), NULL,
+			priority - 1, start_options, K_FOREVER);
+
+	k_thread_create(&alt_thread, alt_stack,
+			K_THREAD_STACK_SIZEOF(alt_stack),
+			alt_thread_entry,
+			(void *)(uintptr_t)num_iterations,
+			(void *)(uintptr_t)(start_options | alt_options), NULL,
+			priority - 2, alt_options, K_FOREVER);
+
+	k_thread_access_grant(&start_thread, &alt_thread, &pause_sem, &lifo);
+	k_thread_access_grant(&alt_thread, &pause_sem, &lifo);
+
+	k_thread_start(&start_thread);
+
+	if (((start_options | alt_options) & K_USER) == 0) {
+		snprintf(description, sizeof(description),
+			 "LIFO get.blocking.(%s -> %s)",
+			 alt_options & K_USER ? "U" : "K",
+			 start_options & K_USER ? "U" : "K");
+
+		cycles = timestamp.cycles;
+		PRINT_STATS_AVG(description, (uint32_t)cycles,
+				num_iterations, false, "");
+		k_sem_give(&pause_sem);
+
+		snprintf(description, sizeof(description),
+			 "LIFO put.wake+ctx.(%s -> %s)",
+			 start_options & K_USER ? "U" : "K",
+			 alt_options & K_USER ? "U" : "K");
+		cycles = timestamp.cycles;
+		PRINT_STATS_AVG(description, (uint32_t)cycles,
+				num_iterations, false, "");
+		k_sem_give(&pause_sem);
+	}
+
+	snprintf(description, sizeof(description),
+		 "LIFO get.free.blocking.(%s -> %s)",
+		 alt_options & K_USER ? "U" : "K",
+		 start_options & K_USER ? "U" : "K");
+
+	cycles = timestamp.cycles;
+	PRINT_STATS_AVG(description, (uint32_t)cycles,
+			num_iterations, false, "");
+	k_sem_give(&pause_sem);
+
+	snprintf(description, sizeof(description),
+		 "LIFO put.alloc.wake+ctx.(%s -> %s)",
+		 start_options & K_USER ? "U" : "K",
+		 alt_options & K_USER ? "U" : "K");
+	cycles = timestamp.cycles;
+	PRINT_STATS_AVG(description, (uint32_t)cycles,
+			num_iterations, false, "");
+
+	k_thread_join(&start_thread, K_FOREVER);
+
+	timing_stop();
+
+	return 0;
+}

--- a/tests/benchmarks/latency_measure/src/main.c
+++ b/tests/benchmarks/latency_measure/src/main.c
@@ -46,6 +46,9 @@ extern void sema_context_switch(uint32_t num_iterations,
 				uint32_t start_options, uint32_t alt_options);
 extern int thread_ops(uint32_t num_iterations, uint32_t start_options,
 		      uint32_t alt_options);
+extern int fifo_ops(uint32_t num_iterations, uint32_t options);
+extern int fifo_blocking_ops(uint32_t num_iterations, uint32_t start_options,
+			     uint32_t alt_options);
 extern int lifo_ops(uint32_t num_iterations, uint32_t options);
 extern int lifo_blocking_ops(uint32_t num_iterations, uint32_t start_options,
 			     uint32_t alt_options);
@@ -91,6 +94,19 @@ static void test_thread(void *arg1, void *arg2, void *arg3)
 	thread_ops(NUM_ITERATIONS, K_USER, K_USER);
 	thread_ops(NUM_ITERATIONS, K_USER, 0);
 #endif
+
+	fifo_ops(NUM_ITERATIONS, 0);
+#ifdef CONFIG_USERSPACE
+	fifo_ops(NUM_ITERATIONS, K_USER);
+#endif
+
+	fifo_blocking_ops(NUM_ITERATIONS, 0, 0);
+#ifdef CONFIG_USERSPACE
+	fifo_blocking_ops(NUM_ITERATIONS, 0, K_USER);
+	fifo_blocking_ops(NUM_ITERATIONS, K_USER, 0);
+	fifo_blocking_ops(NUM_ITERATIONS, K_USER, K_USER);
+#endif
+
 
 	lifo_ops(NUM_ITERATIONS, 0);
 #ifdef CONFIG_USERSPACE

--- a/tests/benchmarks/latency_measure/src/main.c
+++ b/tests/benchmarks/latency_measure/src/main.c
@@ -12,7 +12,6 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/timestamp.h>
-#include <zephyr/app_memory/app_memdomain.h>
 #include "utils.h"
 #include "timing_sc.h"
 #include <zephyr/tc_util.h>

--- a/tests/benchmarks/latency_measure/src/main.c
+++ b/tests/benchmarks/latency_measure/src/main.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2012-2015 Wind River Systems, Inc.
- * Copyright (c) 2023 Intel Corporation.
+ * Copyright (c) 2023,2024 Intel Corporation.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -46,6 +46,9 @@ extern void sema_context_switch(uint32_t num_iterations,
 				uint32_t start_options, uint32_t alt_options);
 extern int thread_ops(uint32_t num_iterations, uint32_t start_options,
 		      uint32_t alt_options);
+extern int lifo_ops(uint32_t num_iterations, uint32_t options);
+extern int lifo_blocking_ops(uint32_t num_iterations, uint32_t start_options,
+			     uint32_t alt_options);
 extern void heap_malloc_free(void);
 
 static void test_thread(void *arg1, void *arg2, void *arg3)
@@ -87,6 +90,18 @@ static void test_thread(void *arg1, void *arg2, void *arg3)
 	thread_ops(NUM_ITERATIONS, 0, K_USER);
 	thread_ops(NUM_ITERATIONS, K_USER, K_USER);
 	thread_ops(NUM_ITERATIONS, K_USER, 0);
+#endif
+
+	lifo_ops(NUM_ITERATIONS, 0);
+#ifdef CONFIG_USERSPACE
+	lifo_ops(NUM_ITERATIONS, K_USER);
+#endif
+
+	lifo_blocking_ops(NUM_ITERATIONS, 0, 0);
+#ifdef CONFIG_USERSPACE
+	lifo_blocking_ops(NUM_ITERATIONS, 0, K_USER);
+	lifo_blocking_ops(NUM_ITERATIONS, K_USER, 0);
+	lifo_blocking_ops(NUM_ITERATIONS, K_USER, K_USER);
 #endif
 
 	sema_test_signal(NUM_ITERATIONS, 0);

--- a/tests/benchmarks/latency_measure/src/mutex_lock_unlock.c
+++ b/tests/benchmarks/latency_measure/src/mutex_lock_unlock.c
@@ -94,7 +94,7 @@ int mutex_lock_unlock(uint32_t num_iterations, uint32_t options)
 	k_sem_give(&pause_sem);
 
 	snprintf(description, sizeof(description),
-		 "Lock a mutex from %s thread",
+		 "MUTEX lock.immediate.recursive.%s",
 		 (options & K_USER) == K_USER ? "user" : "kernel");
 	PRINT_STATS_AVG(description, (uint32_t)cycles, num_iterations,
 			false, "");
@@ -102,7 +102,7 @@ int mutex_lock_unlock(uint32_t num_iterations, uint32_t options)
 	cycles = timestamp.cycles;
 
 	snprintf(description, sizeof(description),
-		 "Unlock a mutex from %s thread",
+		 "MUTEX unlock.immediate.recursive.%s",
 		 (options & K_USER) == K_USER ? "user" : "kernel");
 	PRINT_STATS_AVG(description, (uint32_t)cycles, num_iterations,
 			false, "");

--- a/tests/benchmarks/latency_measure/src/sema_test_signal_release.c
+++ b/tests/benchmarks/latency_measure/src/sema_test_signal_release.c
@@ -139,7 +139,7 @@ void sema_context_switch(uint32_t num_iterations,
 	cycles -= timestamp_overhead_adjustment(start_options, alt_options);
 
 	snprintf(description, sizeof(description),
-		 "Take a semaphore (context switch %c -> %c)",
+		 "SEMAPHORE take.blocking.(%c -> %c)",
 		 ((start_options & K_USER) == K_USER) ? 'U' : 'K',
 		 ((alt_options & K_USER) == K_USER) ? 'U' : 'K');
 	PRINT_STATS_AVG(description, (uint32_t)cycles,
@@ -155,7 +155,7 @@ void sema_context_switch(uint32_t num_iterations,
 	cycles -= timestamp_overhead_adjustment(start_options, alt_options);
 
 	snprintf(description, sizeof(description),
-		 "Give a semaphore (context switch %c -> %c)",
+		 "SEMAPHORE give.wake+ctx.(%c -> %c)",
 		 ((alt_options & K_USER) == K_USER) ? 'U' : 'K',
 		 ((start_options & K_USER) == K_USER) ? 'U' : 'K');
 	PRINT_STATS_AVG(description, (uint32_t)cycles,
@@ -255,7 +255,7 @@ int sema_test_signal(uint32_t num_iterations, uint32_t options)
 	cycles = timestamp.cycles;
 
 	snprintf(description, sizeof(description),
-		 "Give a semaphore (no waiters) from %s thread",
+		 "SEMAPHORE give.immediate.%s",
 		 (options & K_USER) == K_USER ? "user" : "kernel");
 
 	PRINT_STATS_AVG(description, (uint32_t)cycles,
@@ -274,7 +274,7 @@ int sema_test_signal(uint32_t num_iterations, uint32_t options)
 	cycles = timestamp.cycles;
 
 	snprintf(description, sizeof(description),
-		 "Take a semaphore (no blocking) from %s thread",
+		 "SEMAPHORE take.immediate.%s",
 		 (options & K_USER) == K_USER ? "user" : "kernel");
 
 	PRINT_STATS_AVG(description, (uint32_t)cycles,

--- a/tests/benchmarks/latency_measure/src/thread.c
+++ b/tests/benchmarks/latency_measure/src/thread.c
@@ -248,7 +248,7 @@ int thread_ops(uint32_t num_iterations, uint32_t start_options, uint32_t alt_opt
 		/* Only report stats if <start_thread> created <alt_thread> */
 
 		snprintf(description, sizeof(description),
-			 "Create %s thread from %s thread",
+			 "THREAD create.%s.from.%s",
 			 (alt_options & K_USER) != 0 ? "user" : "kernel",
 			 (start_options & K_USER) != 0 ? "user" : "kernel");
 
@@ -261,7 +261,7 @@ int thread_ops(uint32_t num_iterations, uint32_t start_options, uint32_t alt_opt
 	k_sem_give(&pause_sem);
 
 	snprintf(description, sizeof(description),
-		 "Start %s thread from %s thread",
+		 "THREAD start.%s.from.%s",
 		 (alt_options & K_USER) != 0 ? "user" : "kernel",
 		 (start_options & K_USER) != 0 ? "user" : "kernel");
 
@@ -273,7 +273,7 @@ int thread_ops(uint32_t num_iterations, uint32_t start_options, uint32_t alt_opt
 	k_sem_give(&pause_sem);
 
 	snprintf(description, sizeof(description),
-		 "Suspend %s thread from %s thread",
+		 "THREAD suspend.%s.from.%s",
 		 (alt_options & K_USER) != 0 ? "user" : "kernel",
 		 (start_options & K_USER) != 0 ? "user" : "kernel");
 
@@ -285,7 +285,7 @@ int thread_ops(uint32_t num_iterations, uint32_t start_options, uint32_t alt_opt
 	k_sem_give(&pause_sem);
 
 	snprintf(description, sizeof(description),
-		 "Resume %s thread from %s thread",
+		 "THREAD resume.%s.from.%s",
 		 (alt_options & K_USER) != 0 ? "user" : "kernel",
 		 (start_options & K_USER) != 0 ? "user" : "kernel");
 
@@ -297,7 +297,7 @@ int thread_ops(uint32_t num_iterations, uint32_t start_options, uint32_t alt_opt
 	k_sem_give(&pause_sem);
 
 	snprintf(description, sizeof(description),
-		 "Abort %s thread from %s thread",
+		 "THREAD abort.%s.from.%s",
 		 (alt_options & K_USER) != 0 ? "user" : "kernel",
 		 (start_options & K_USER) != 0 ? "user" : "kernel");
 

--- a/tests/benchmarks/latency_measure/src/thread_switch_yield.c
+++ b/tests/benchmarks/latency_measure/src/thread_switch_yield.c
@@ -131,7 +131,7 @@ static void thread_switch_yield_common(const char *description,
 	sum -= timestamp_overhead_adjustment(start_options, alt_options);
 
 	snprintf(summary, sizeof(summary),
-		 "%s (%c -> %c)",
+		 "%s.(%c -> %c)",
 		 description,
 		 (start_options & K_USER) == K_USER ? 'U' : 'K',
 		 (alt_options & K_USER) == K_USER ? 'U' : 'K');
@@ -148,8 +148,8 @@ void thread_switch_yield(uint32_t num_iterations, bool is_cooperative)
 				  : k_thread_priority_get(k_current_get()) - 1;
 
 	snprintf(description, sizeof(description),
-		 "%s threads ctx switch via k_yield",
-		 is_cooperative ? "Cooperative" : "Preemptive");
+		 "THREAD yield.%s.ctx",
+		 is_cooperative ? "cooperative" : "preemptive");
 
 	/* Kernel -> Kernel */
 	thread_switch_yield_common(description, num_iterations, 0, 0,

--- a/tests/benchmarks/latency_measure/src/timing_sc.c
+++ b/tests/benchmarks/latency_measure/src/timing_sc.c
@@ -11,7 +11,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/app_memory/app_memdomain.h>
 #include "utils.h"
 #include "timing_sc.h"
 

--- a/tests/benchmarks/latency_measure/src/utils.h
+++ b/tests/benchmarks/latency_measure/src/utils.h
@@ -15,6 +15,7 @@
 #include <zephyr/sys/printk.h>
 #include <stdio.h>
 #include <zephyr/timestamp.h>
+#include <zephyr/app_memory/app_memdomain.h>
 
 #define START_STACK_SIZE (512 + CONFIG_TEST_EXTRA_STACK_SIZE)
 #define ALT_STACK_SIZE   (512 + CONFIG_TEST_EXTRA_STACK_SIZE)


### PR DESCRIPTION
Updates the latency_measure benchmark to ...

1. generate LIFO and FIFO performance data
2. tweak the output so that it is easier to identify tests by object (even if sorted)
