### PR TITLE
drivers: gpio: stm32: fix init power state

### DIFF
--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -719,7 +719,9 @@ static int gpio_stm32_init(const struct device *dev)
 		return ret;
 	}
 
-	pm_device_init_suspended(dev);
+	if (IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)) {
+		pm_device_init_suspended(dev);
+	}
 	(void)pm_device_runtime_enable(dev);
 
 	return 0;


### PR DESCRIPTION
Set suspended as initial power state, only when the CONFIG_PM_DEVICE_RUNTIME config is enabled.

The initial state was incorrect, when CONFIG_PM_DEVICE=y and CONFIG_PM_DEVICE_RUNTIME=n. In that case, the power state was SUSPENDED, but the device was actually enabled.