### PR TITLE
net: openthread: add missing cmake option

### DIFF
--- a/modules/openthread/CMakeLists.txt
+++ b/modules/openthread/CMakeLists.txt
@@ -15,6 +15,7 @@ endmacro()
 set(OT_BUILD_EXECUTABLES OFF CACHE BOOL "Disable OpenThread samples")
 set(OT_BUILTIN_MBEDTLS_MANAGEMENT OFF CACHE BOOL "Use Zephyr's mbedTLS heap")
 set(OT_PLATFORM "zephyr" CACHE STRING "Zephyr as a target platform")
+set(OT_PLATFORM_POWER_CALIBRATION OFF CACHE BOOL "Use Zephyr's power calibration handled by Radio Driver")
 set(OT_THREAD_VERSION ${CONFIG_OPENTHREAD_THREAD_VERSION} CACHE STRING "User selected Thread stack version")
 set(OT_CLI_TRANSPORT "CONSOLE" CACHE STRING "Set CLI to use console interpreter")
 

--- a/modules/openthread/platform/openthread-core-zephyr-config.h
+++ b/modules/openthread/platform/openthread-core-zephyr-config.h
@@ -439,17 +439,6 @@
 #endif
 
 /**
- * @def OPENTHREAD_CONFIG_PLATFORM_POWER_CALIBRATION_ENABLE
- *
- * In Zephyr, power calibration is handled by Radio Driver, so it can't be handled on OT level.
- *
- */
-#ifndef OPENTHREAD_CONFIG_PLATFORM_POWER_CALIBRATION_ENABLE
-#define OPENTHREAD_CONFIG_PLATFORM_POWER_CALIBRATION_ENABLE 0
-#endif
-
-
-/**
  * @def OPENTHREAD_CONFIG_RADIO_STATS
  *
  * Enable support for Radio Statistics.


### PR DESCRIPTION
Added `OT_PLATFORM_POWER_CALIBRATION` and set to always off as in Zephyr power calibration is handled by Radio Driver.