### PR TITLE
drivers: plic: fix compilation warning when `PLIC_SHELL` is enabled on 64bit platform

### DIFF
--- a/drivers/interrupt_controller/intc_plic.c
+++ b/drivers/interrupt_controller/intc_plic.c
@@ -466,7 +466,7 @@ static int cmd_get_stats(const struct shell *sh, size_t argc, char *argv[])
 
 	shell_print(sh, "   IRQ\t      Hits");
 	shell_print(sh, "==================");
-	for (size_t i = 0; i < MIN(config->num_irqs, CONFIG_MAX_IRQ_PER_AGGREGATOR); i++) {
+	for (int i = 0; i < MIN(config->num_irqs, CONFIG_MAX_IRQ_PER_AGGREGATOR); i++) {
 		if (stat.irq_count[i] > min_hit) {
 			shell_print(sh, "%6d\t%10d", i, stat.irq_count[i]);
 		}

--- a/drivers/interrupt_controller/intc_plic.c
+++ b/drivers/interrupt_controller/intc_plic.c
@@ -79,7 +79,8 @@ struct plic_config {
 };
 
 struct plic_stats {
-	uint16_t *irq_count;
+	uint16_t *const irq_count;
+	const int irq_count_len;
 };
 
 struct plic_data {
@@ -455,7 +456,6 @@ static int cmd_get_stats(const struct shell *sh, size_t argc, char *argv[])
 		return ret;
 	}
 
-	const struct plic_config *config = dev->config;
 	const struct plic_data *data = dev->data;
 	struct plic_stats stat = data->stats;
 
@@ -466,7 +466,7 @@ static int cmd_get_stats(const struct shell *sh, size_t argc, char *argv[])
 
 	shell_print(sh, "   IRQ\t      Hits");
 	shell_print(sh, "==================");
-	for (int i = 0; i < MIN(config->num_irqs, CONFIG_MAX_IRQ_PER_AGGREGATOR); i++) {
+	for (int i = 0; i < stat.irq_count_len; i++) {
 		if (stat.irq_count[i] > min_hit) {
 			shell_print(sh, "%6d\t%10d", i, stat.irq_count[i]);
 		}
@@ -485,12 +485,10 @@ static int cmd_clear_stats(const struct shell *sh, size_t argc, char *argv[])
 		return ret;
 	}
 
-	const struct plic_config *config = dev->config;
 	const struct plic_data *data = dev->data;
 	struct plic_stats stat = data->stats;
 
-	memset(stat.irq_count, 0,
-	       MIN(config->num_irqs, CONFIG_MAX_IRQ_PER_AGGREGATOR) * sizeof(uint16_t));
+	memset(stat.irq_count, 0, stat.irq_count_len * sizeof(uint16_t));
 
 	shell_print(sh, "Cleared stats of %s.\n", dev->name);
 
@@ -536,15 +534,16 @@ static int cmd_plic(const struct shell *sh, size_t argc, char **argv)
 SHELL_CMD_ARG_REGISTER(plic, &plic_cmds, "PLIC shell commands",
 		       cmd_plic, 2, 0);
 
+#define PLIC_MIN_IRQ_NUM(n) MIN(DT_INST_PROP(n, riscv_ndev), CONFIG_MAX_IRQ_PER_AGGREGATOR)
 #define PLIC_INTC_IRQ_COUNT_BUF_DEFINE(n)                                                          \
-	static uint16_t local_irq_count_##n[MIN(DT_INST_PROP(n, riscv_ndev),                       \
-					      CONFIG_MAX_IRQ_PER_AGGREGATOR)];
+	static uint16_t local_irq_count_##n[PLIC_MIN_IRQ_NUM(n)];
 
 #define PLIC_INTC_DATA_INIT(n)                                                                     \
 	PLIC_INTC_IRQ_COUNT_BUF_DEFINE(n);                                                         \
 	static struct plic_data plic_data_##n = {                                                  \
 		.stats = {                                                                         \
 			.irq_count = local_irq_count_##n,                                          \
+			.irq_count_len = PLIC_MIN_IRQ_NUM(n),                                      \
 		},                                                                                 \
 	};
 

--- a/tests/drivers/build_all/interrupt_controller/intc_plic/testcase.yaml
+++ b/tests/drivers/build_all/interrupt_controller/intc_plic/testcase.yaml
@@ -10,6 +10,12 @@ common:
     - plic
 tests:
   drivers.interrupt_controller.intc_plic.build: {}
+  drivers.interrupt_controller.intc_plic.plic_shell.build:
+    tags:
+      - shell
+    extra_configs:
+      - CONFIG_SHELL=y
+      - CONFIG_PLIC_SHELL=y
   drivers.interrupt_controller.intc_plic.multi_instance.build:
     extra_args:
       DTC_OVERLAY_FILE="./app.multi_instance.overlay"


### PR DESCRIPTION
Fixed compilation warning on 64bit platform by changing the irq array iterator from `size_t` to `int`, added build-only test for `PLIC_SHELL` on 32bit & 64bit platforms