### PR TITLE
input: kbd_matrix: fail gracefully if changing an undefined key mask

### DIFF
--- a/drivers/input/input_kbd_matrix.c
+++ b/drivers/input/input_kbd_matrix.c
@@ -334,6 +334,11 @@ int input_kbd_matrix_actual_key_mask_set(const struct device *dev,
 		return -EINVAL;
 	}
 
+	if (cfg->actual_key_mask == NULL) {
+		LOG_WRN("actual-key-mask not defined for %s", dev->name);
+		return -EINVAL;
+	}
+
 	WRITE_BIT(cfg->actual_key_mask[col], row, enabled);
 
 	return 0;


### PR DESCRIPTION
Add a check to input_kbd_matrix_actual_key_mask_set() to return an error if trying to change a key mask but the device does not define a keymask in the first place.