### PR TITLE
Two minor fixes for POSIX_API kconfig and include

### DIFF
--- a/lib/posix/Kconfig.clock
+++ b/lib/posix/Kconfig.clock
@@ -5,7 +5,7 @@
 config POSIX_CLOCK
 	bool "POSIX clock, timer, and sleep APIs"
 	default y if POSIX_API
-	depends on !(ARCH_POSIX && EXTERNAL_LIBC)
+	depends on !NATIVE_LIBC
 	help
 	  This enables POSIX clock\_\*(), timer\_\*(), and \*sleep()
 	  functions.

--- a/lib/posix/getopt/getopt.c
+++ b/lib/posix/getopt/getopt.c
@@ -30,7 +30,7 @@
  */
 
 #include <string.h>
-#ifdef CONFIG_ARCH_POSIX
+#ifdef CONFIG_NATIVE_LIBC
 #include <unistd.h>
 #else
 #include <zephyr/posix/unistd.h>


### PR DESCRIPTION
lib/posix getopt: Fix include

Let's try to use the host unistd.h when building with the host library only, instead of assuming
that the native boards are always built with it.
This fixes a build error when using this code building for native boards using minimal libc.

--------

posix kconfig: Improve depends on host libC

 Improve a depends on the host libC.
It is technically correct, but NATIVE_LIBC is shorter and clearer than "ARCH_POSIX && EXTERNAL_LIBC"