### PR TITLE
dts: bindings: mcp320x: harmonize io-channel property

### DIFF
--- a/dts/bindings/adc/microchip,mcp320x-base.yaml
+++ b/dts/bindings/adc/microchip,mcp320x-base.yaml
@@ -7,4 +7,4 @@ properties:
     const: 1
 
 io-channel-cells:
-  - channel
+  - input


### PR DESCRIPTION
The rest of the ADC drivers use "input" as io-channel-cells property name, which is also assumed by the ADC DT macros. Use the same convention here to make mcp320x based devices work with the macros (and samples/drivers/adc).

Issue #67314