### PR TITLE
samples: ipc: multi_endpoint: Fix synchronisation of data receiving

### DIFF
--- a/samples/subsys/ipc/ipc_service/multi_endpoint/remote/src/main.c
+++ b/samples/subsys/ipc/ipc_service/multi_endpoint/remote/src/main.c
@@ -193,7 +193,7 @@ static void ipc1_ept_recv(const void *data, size_t len, void *priv)
 {
 	ipc1_received_data = *((uint8_t *) data);
 
-	k_sem_give(&ipc0B_data_sem);
+	k_sem_give(&ipc1_data_sem);
 }
 
 static struct ipc_ept_cfg ipc1_ept_cfg = {

--- a/samples/subsys/ipc/ipc_service/multi_endpoint/src/main.c
+++ b/samples/subsys/ipc/ipc_service/multi_endpoint/src/main.c
@@ -190,7 +190,7 @@ static void ipc1_ept_recv(const void *data, size_t len, void *priv)
 {
 	ipc1_received_data = *((uint8_t *) data);
 
-	k_sem_give(&ipc0B_data_sem);
+	k_sem_give(&ipc1_data_sem);
 }
 
 static struct ipc_ept_cfg ipc1_ept_cfg = {


### PR DESCRIPTION
The incorrect semaphore was used for the ipc1 instance to synchronise the data receiving.
This commit fixes it.