### PR TITLE
drivers: adc: mcp320x: various fixes

### DIFF
--- a/boards/shields/mikroe_adc_click/boards/lpcxpresso55s16.overlay
+++ b/boards/shields/mikroe_adc_click/boards/lpcxpresso55s16.overlay
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/adc/adc.h>
+
 /delete-node/ &mcp3204_mikroe_adc_click;
 
 &mikrobus_spi {

--- a/boards/shields/mikroe_adc_click/boards/lpcxpresso55s16.overlay
+++ b/boards/shields/mikroe_adc_click/boards/lpcxpresso55s16.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &mcp3204;
+/delete-node/ &mcp3204_mikroe_adc_click;
 
 &mikrobus_spi {
 	status = "okay";

--- a/boards/shields/mikroe_adc_click/doc/index.rst
+++ b/boards/shields/mikroe_adc_click/doc/index.rst
@@ -35,8 +35,8 @@ Set ``-DSHIELD=mikro_adc_click`` when you invoke ``west build``. For
 example:
 
 .. zephyr-app-commands::
-   :zephyr-app: test/boards/board_shell
-   :board: frdm_k64f
+   :zephyr-app: <my_app>
+   :board: lpcxpresso55s16
    :shield: mikroe_adc_click
    :goals: build
 

--- a/boards/shields/mikroe_adc_click/mikroe_adc_click.overlay
+++ b/boards/shields/mikroe_adc_click/mikroe_adc_click.overlay
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/adc/adc.h>
+
 &mikrobus_spi {
 	status = "okay";
 

--- a/doc/releases/migration-guide-3.6.rst
+++ b/doc/releases/migration-guide-3.6.rst
@@ -159,6 +159,10 @@ Device Drivers and Device Tree
   * :dtcompatible:`ti,lmp90099`
   * :dtcompatible:`ti,lmp90100`
 
+* The io-channel cells of the :dtcompatible:`microchip,mcp3204` and
+  :dtcompatible:`microchip,mcp3208` devicetree bindings were renamed from ``channel`` to the common
+  ``input``, making it possible to use the various ADC DT macros with Microchip MCP320x ADC devices.
+
 * The :dtcompatible:`st,stm32h7-fdcan` CAN controller driver now supports configuring the
   domain/kernel clock via devicetree. Previously, the driver only supported using the PLL1_Q clock
   for kernel clock, but now it defaults to the HSE clock, which is the chip default. Boards that

--- a/dts/bindings/adc/microchip,mcp320x-base.yaml
+++ b/dts/bindings/adc/microchip,mcp320x-base.yaml
@@ -7,4 +7,4 @@ properties:
     const: 1
 
 io-channel-cells:
-  - channel
+  - input

--- a/tests/drivers/build_all/adc/testcase.yaml
+++ b/tests/drivers/build_all/adc/testcase.yaml
@@ -20,6 +20,9 @@ tests:
     platform_allow: frdm_k22f
   drivers.adc.mcux.lpadc.build:
     platform_allow: lpcxpresso55s28
+  drivers.adc.mcp320x.build:
+    platform_allow: lpcxpresso55s16
+    extra_args: SHIELD=mikroe_adc_click
   drivers.adc.npcx.build:
     platform_allow: npcx7m6fb_evb
   drivers.adc.nrf.build:


### PR DESCRIPTION
This patch series contains various fixes to the MCP320x ADC driver and the associated `mikroe_adc_click` shield:
- Remove the correct nodelabel in the shield overlay for the lpcxpresso55s16 board.
- Include `zephyr/dt-bindings/adc/adc.h` in the shield DTS overlays to simplify using the shield in application overlays.
- Use the common io-channel-cells name "input" instead of "channel" in the mcp320x DTS bindings to make them work with the various ADC DT macros.
~- Add an overlay for testing `samples/drivers/adc` with the `mikroe_adc_click` shield.~
- Use a board with a mikroBUS as example in the shield documentation and update the documentation to point to another sample since the board_shell sample was removed in commit 7c85f4b2f5bea25a3c34a8f81ef6590639629434.
- Add build-only test of the mcp320x ADC driver.


~In order to support this, the build system has been modified to Include shield-specific overlays in `zephyr_file()`. Shield-specific overlays are included after any board-specific overlays.~ Deferred to https://github.com/zephyrproject-rtos/zephyr/pull/67428

Fixes: #67134