### PR TITLE
tests: drivers: bbram: add test BBRAM on twister

### DIFF
--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -272,6 +272,10 @@ stm32_lp_tick_source: &lptim1 {
 	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
 		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
+
+	backup_regs {
+		status = "okay";
+	};
 };
 
 zephyr_udc0: &usbotg_fs {

--- a/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
+++ b/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
@@ -155,6 +155,10 @@ zephyr_udc0: &usbotg_fs {
 	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
 		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
+
+	backup_regs {
+		status = "okay";
+	};
 };
 
 &rng {

--- a/boards/arm/nucleo_f303re/nucleo_f303re.dts
+++ b/boards/arm/nucleo_f303re/nucleo_f303re.dts
@@ -89,6 +89,10 @@
 	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
 		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
+
+	backup_regs {
+		status = "okay";
+	};
 };
 
 &can1 {

--- a/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
+++ b/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
@@ -160,6 +160,10 @@ zephyr_udc0: &usbotg_fs {
 	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
 		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
+
+	backup_regs {
+		status = "okay";
+	};
 };
 
 &iwdg {

--- a/boards/arm/nucleo_f746zg/nucleo_f746zg.dts
+++ b/boards/arm/nucleo_f746zg/nucleo_f746zg.dts
@@ -161,6 +161,10 @@ zephyr_udc0: &usbotg_fs {
 	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
 		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
+
+	backup_regs {
+		status = "okay";
+	};
 };
 
 &can1 {

--- a/boards/arm/nucleo_h743zi/nucleo_h743zi.dts
+++ b/boards/arm/nucleo_h743zi/nucleo_h743zi.dts
@@ -117,6 +117,10 @@ zephyr_udc0: &usbotg_fs {
 	clocks = <&rcc STM32_CLOCK_BUS_APB4 0x00010000>,
 		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
+
+	backup_regs {
+		status = "okay";
+	};
 };
 
 &i2c1 {

--- a/boards/arm/nucleo_l152re/nucleo_l152re.dts
+++ b/boards/arm/nucleo_l152re/nucleo_l152re.dts
@@ -119,6 +119,10 @@
 	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
 		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
+
+	backup_regs {
+		status = "okay";
+	};
 };
 
 &adc1 {

--- a/tests/drivers/bbram/testcase.yaml
+++ b/tests/drivers/bbram/testcase.yaml
@@ -5,25 +5,45 @@ common:
   tags:
     - drivers
     - bbram
-  build_only: true
   harness: ztest
   arch_exclude: posix
 tests:
   drivers.bbram.it8xxx2:
+    build_only: true
     filter: dt_compat_enabled("ite,it8xxx2-bbram")
     integration_platforms:
       - it82xx2_evb
   drivers.bbram.npcx:
+    build_only: true
     filter: dt_compat_enabled("nuvoton,npcx-bbram")
     integration_platforms:
       - npcx9m6f_evb
   drivers.bbram.stm32:
     extra_args: OVERLAY_CONFIG="stm32.conf"
     filter: dt_compat_enabled("st,stm32-bbram")
+    platform_allow:
+      - stm32f746g_disco
+      - nucleo_f429zi
+      - nucleo_f207zg
+      - nucleo_f303re
+      - nucleo_f746zg
+      - nucleo_h743zi
+      - nucleo_l152re
+      - disco_l475_iot1
+      - nucleo_wb55rg
     integration_platforms:
       - stm32f746g_disco
   drivers.bbram.stm32_rtc:
     extra_args: OVERLAY_CONFIG="stm32_rtc.conf"
     filter: dt_compat_enabled("st,stm32-bbram")
+    platform_allow:
+      - stm32f746g_disco
+      - nucleo_f429zi
+      - nucleo_f303re
+      - nucleo_f746zg
+      - nucleo_h743zi
+      - nucleo_l152re
+      - disco_l475_iot1
+      - nucleo_wb55rg
     integration_platforms:
       - stm32f746g_disco


### PR DESCRIPTION
add tests BBRAM on twister (on hw in CI)
add test for following boards:
nucleo_f429zi, nucleo_f207zg,nucleo_f303re,
nucleo_f746zg, nucleo_h743zi,nucleo_l152re,
disco_l475_iot1, nucleo_wb55rg