### PR TITLE
input: gpio_keys: implement polling mode support

### DIFF
--- a/dts/bindings/input/gpio-keys.yaml
+++ b/dts/bindings/input/gpio-keys.yaml
@@ -35,15 +35,23 @@ properties:
        Debouncing interval time in milliseconds.
        If not specified defaults to 30.
 
+  polling-mode:
+    type: boolean
+    description: |
+      Do not use interrupts for the key GPIOs, poll the pin periodically at the
+      specified debounce-interval-ms instead.
+
 child-binding:
   description: GPIO KEYS child node
   properties:
     gpios:
       type: phandle-array
       required: true
+
     label:
       type: string
       description: Descriptive name of the key
+
     zephyr,code:
       type: int
       description: Key code to emit.

--- a/tests/drivers/build_all/input/app.overlay
+++ b/tests/drivers/build_all/input/app.overlay
@@ -26,6 +26,16 @@
 			};
 		};
 
+		gpio-keys-polled {
+			compatible = "gpio-keys";
+			debounce-interval-ms = <30>;
+			button_0 {
+				gpios = <&test_gpio 0 0>;
+				zephyr,code = <0>;
+			};
+			polling-mode;
+		};
+
 		evdev {
 			compatible = "zephyr,native-linux-evdev";
 		};


### PR DESCRIPTION
Some MCU have limitations with GPIO interrupts. Add a polling mode to the gpio-keys driver to support those cases.

This required a bit of a refactoring of the driver data structure to add a instance wide data, and move the pin specific pointer in the config structure.

For polling, reuse the button 0 delayed work so we minimize the resource waste, the two work handler functions are only referenced when used so at least those are discarded automatically if no instance needs them.

Fix a bug in the PM structure instantiation as well.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/67049