### PR TITLE
sd: add timeout when taking SD card lock for data operations

### DIFF
--- a/subsys/sd/sd_ops.c
+++ b/subsys/sd/sd_ops.c
@@ -540,7 +540,7 @@ int card_read_blocks(struct sd_card *card, uint8_t *rbuf, uint32_t start_block, 
 		LOG_WRN("SDIO does not support MMC commands");
 		return -ENOTSUP;
 	}
-	ret = k_mutex_lock(&card->lock, K_NO_WAIT);
+	ret = k_mutex_lock(&card->lock, K_MSEC(CONFIG_SD_DATA_TIMEOUT));
 	if (ret) {
 		LOG_WRN("Could not get SD card mutex");
 		return -EBUSY;
@@ -704,7 +704,7 @@ int card_write_blocks(struct sd_card *card, const uint8_t *wbuf, uint32_t start_
 		LOG_WRN("SDIO does not support MMC commands");
 		return -ENOTSUP;
 	}
-	ret = k_mutex_lock(&card->lock, K_NO_WAIT);
+	ret = k_mutex_lock(&card->lock, K_MSEC(CONFIG_SD_DATA_TIMEOUT));
 	if (ret) {
 		LOG_WRN("Could not get SD card mutex");
 		return -EBUSY;

--- a/subsys/sd/sdio.c
+++ b/subsys/sd/sdio.c
@@ -792,7 +792,7 @@ int sdio_read_byte(struct sdio_func *func, uint32_t reg, uint8_t *val)
 		LOG_WRN("Card does not support SDIO commands");
 		return -ENOTSUP;
 	}
-	ret = k_mutex_lock(&func->card->lock, K_NO_WAIT);
+	ret = k_mutex_lock(&func->card->lock, K_MSEC(CONFIG_SD_DATA_TIMEOUT));
 	if (ret) {
 		LOG_WRN("Could not get SD card mutex");
 		return -EBUSY;
@@ -822,7 +822,7 @@ int sdio_write_byte(struct sdio_func *func, uint32_t reg, uint8_t write_val)
 		LOG_WRN("Card does not support SDIO commands");
 		return -ENOTSUP;
 	}
-	ret = k_mutex_lock(&func->card->lock, K_NO_WAIT);
+	ret = k_mutex_lock(&func->card->lock, K_MSEC(CONFIG_SD_DATA_TIMEOUT));
 	if (ret) {
 		LOG_WRN("Could not get SD card mutex");
 		return -EBUSY;
@@ -855,7 +855,7 @@ int sdio_rw_byte(struct sdio_func *func, uint32_t reg, uint8_t write_val,
 		LOG_WRN("Card does not support SDIO commands");
 		return -ENOTSUP;
 	}
-	ret = k_mutex_lock(&func->card->lock, K_NO_WAIT);
+	ret = k_mutex_lock(&func->card->lock, K_MSEC(CONFIG_SD_DATA_TIMEOUT));
 	if (ret) {
 		LOG_WRN("Could not get SD card mutex");
 		return -EBUSY;
@@ -889,7 +889,7 @@ int sdio_read_fifo(struct sdio_func *func, uint32_t reg, uint8_t *data,
 		LOG_WRN("Card does not support SDIO commands");
 		return -ENOTSUP;
 	}
-	ret = k_mutex_lock(&func->card->lock, K_NO_WAIT);
+	ret = k_mutex_lock(&func->card->lock, K_MSEC(CONFIG_SD_DATA_TIMEOUT));
 	if (ret) {
 		LOG_WRN("Could not get SD card mutex");
 		return -EBUSY;
@@ -923,7 +923,7 @@ int sdio_write_fifo(struct sdio_func *func, uint32_t reg, uint8_t *data,
 		LOG_WRN("Card does not support SDIO commands");
 		return -ENOTSUP;
 	}
-	ret = k_mutex_lock(&func->card->lock, K_NO_WAIT);
+	ret = k_mutex_lock(&func->card->lock, K_MSEC(CONFIG_SD_DATA_TIMEOUT));
 	if (ret) {
 		LOG_WRN("Could not get SD card mutex");
 		return -EBUSY;
@@ -957,7 +957,7 @@ int sdio_read_blocks_fifo(struct sdio_func *func, uint32_t reg, uint8_t *data,
 		LOG_WRN("Card does not support SDIO commands");
 		return -ENOTSUP;
 	}
-	ret = k_mutex_lock(&func->card->lock, K_NO_WAIT);
+	ret = k_mutex_lock(&func->card->lock, K_MSEC(CONFIG_SD_DATA_TIMEOUT));
 	if (ret) {
 		LOG_WRN("Could not get SD card mutex");
 		return -EBUSY;
@@ -991,7 +991,7 @@ int sdio_write_blocks_fifo(struct sdio_func *func, uint32_t reg, uint8_t *data,
 		LOG_WRN("Card does not support SDIO commands");
 		return -ENOTSUP;
 	}
-	ret = k_mutex_lock(&func->card->lock, K_NO_WAIT);
+	ret = k_mutex_lock(&func->card->lock, K_MSEC(CONFIG_SD_DATA_TIMEOUT));
 	if (ret) {
 		LOG_WRN("Could not get SD card mutex");
 		return -EBUSY;
@@ -1024,7 +1024,7 @@ int sdio_read_addr(struct sdio_func *func, uint32_t reg, uint8_t *data,
 		LOG_WRN("Card does not support SDIO commands");
 		return -ENOTSUP;
 	}
-	ret = k_mutex_lock(&func->card->lock, K_NO_WAIT);
+	ret = k_mutex_lock(&func->card->lock, K_MSEC(CONFIG_SD_DATA_TIMEOUT));
 	if (ret) {
 		LOG_WRN("Could not get SD card mutex");
 		return -EBUSY;
@@ -1058,7 +1058,7 @@ int sdio_write_addr(struct sdio_func *func, uint32_t reg, uint8_t *data,
 		LOG_WRN("Card does not support SDIO commands");
 		return -ENOTSUP;
 	}
-	ret = k_mutex_lock(&func->card->lock, K_NO_WAIT);
+	ret = k_mutex_lock(&func->card->lock, K_MSEC(CONFIG_SD_DATA_TIMEOUT));
 	if (ret) {
 		LOG_WRN("Could not get SD card mutex");
 		return -EBUSY;


### PR DESCRIPTION
Previously, if an SD I/O operation was attempted while another thread held the mutex for the SD card, the I/O operation would simply fail. Add a timeout to k_mutex_lock calls within the SD subsystem, so that multithreaded access to the SD card instead blocks until the SD card is available for I/O

Fixes #66211