### PR TITLE
manifest: bump hal_nxp revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -193,7 +193,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 12970d629fc900010dab5cf250be70287bf9e443
+      revision: 9b2693c7659f37f84bcf2604995c88f7fa5206be
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
this revision contains an usb fix that allows
tests/subsys/usb/device/usb.device to pass on lpcxpresso55s69_cpu0.

see https://github.com/zephyrproject-rtos/hal_nxp/pull/315 for more information.