### PR TITLE
modem: cmux: Retry resync periodically and block transmit

### DIFF
--- a/include/zephyr/modem/cmux.h
+++ b/include/zephyr/modem/cmux.h
@@ -135,6 +135,7 @@ struct modem_cmux {
 	/* State */
 	enum modem_cmux_state state;
 	bool flow_control_on;
+	bool out_of_sync;
 
 	/* Receive state*/
 	enum modem_cmux_receive_state receive_state;
@@ -158,6 +159,7 @@ struct modem_cmux {
 	struct k_work_delayable transmit_work;
 	struct k_work_delayable connect_work;
 	struct k_work_delayable disconnect_work;
+	struct k_work_delayable resync_work;
 
 	/* Synchronize actions */
 	struct k_event event;


### PR DESCRIPTION
This patch will block all transmit except for the resync flags, and will retry resyncing every T1 (330ms) until successful or CMUX is disconnected.