### PR TITLE
sys_init: Fix missing initializer

### DIFF
--- a/include/zephyr/init.h
+++ b/include/zephyr/init.h
@@ -202,10 +202,13 @@ struct init_entry {
  *
  * @see SYS_INIT()
  */
-#define SYS_INIT_NAMED(name, init_fn_, level, prio)                            \
-	static const Z_DECL_ALIGN(struct init_entry)                           \
-		Z_INIT_ENTRY_SECTION(level, prio, 0) __used __noasan           \
-		Z_INIT_ENTRY_NAME(name) = {.init_fn = {.sys = (init_fn_)}}
+#define SYS_INIT_NAMED(name, init_fn_, level, prio)                                                \
+	static const Z_DECL_ALIGN(struct init_entry) Z_INIT_ENTRY_SECTION(level, prio, 0)          \
+		__used __noasan                                                                    \
+		Z_INIT_ENTRY_NAME(name) = {                                                        \
+			.init_fn = {.sys = (init_fn_)},                                            \
+			.dev = NULL,                                                               \
+	}
 
 /** @} */
 


### PR DESCRIPTION
When compiling in c++ with strict warnings, the missing initializer to dev throws an error.

Fixes #67396