### PR TITLE
linkserver: nxp: enable linkserver to be the default runner

### DIFF
--- a/boards/common/linkserver.board.cmake
+++ b/boards/common/linkserver.board.cmake
@@ -1,4 +1,6 @@
 # Copyright 2023 NXP
 # SPDX-License-Identifier: Apache-2.0
 
+board_set_flasher_ifnset(linkserver)
+board_set_debugger_ifnset(linkserver)
 board_finalize_runner_args(linkserver "--dt-flash=y")


### PR DESCRIPTION
This commit selects linkserver as the flash and debug runner if none was set in the board's board.cmake file. This change will enable NXP to make linkserver the default runner for the NXP boards.