### PR TITLE
drivers: regulator: max20335: add support for ship mode

### DIFF
--- a/drivers/regulator/Kconfig.max20335
+++ b/drivers/regulator/Kconfig.max20335
@@ -10,9 +10,20 @@ config REGULATOR_MAX20335
 	help
 	  Enable the Maxim MAX20335 PMIC regulator driver
 
+if REGULATOR_MAX20335
+
+config REGULATOR_MAXIM_MAX20335_COMMON_INIT_PRIORITY
+	int "MAX20335 regulator driver init priority (common part)"
+	default 86
+	help
+	  Init priority for the Maxim MAX20335 regulator driver
+	  (common part). It must be greater than I2C and MFD init priority.
+
 config REGULATOR_MAXIM_MAX20335_INIT_PRIORITY
 	int "MAX20335 regulator driver init priority"
-	default 86
-	depends on REGULATOR_MAX20335
+	default 87
 	help
-	  Init priority for the Maxim MAX20335 regulator driver.
+	  Init priority for the Maxim MAX20335 regulator driver. It must be
+	  greater than REGULATOR_MAXIM_MAX20335_COMMON_INIT_PRIORITY
+
+endif


### PR DESCRIPTION
Allows the user to disable PMIC.