### PR TITLE
net: posix Fix name collision with __bswap

### DIFF
--- a/drivers/fpga/fpga_zynqmp.c
+++ b/drivers/fpga/fpga_zynqmp.c
@@ -293,7 +293,7 @@ static int zynqmp_fpga_load(const struct device *dev, uint32_t *image_ptr,
 	}
 
 	for (int i = 0; i < (img_size / 4); i++) {
-		*(BITSTREAM + i) = __bswap_32(*(addr + i));
+		*(BITSTREAM + i) = BSWAP_32(*(addr + i));
 	}
 
 	init_pcap(dev);

--- a/drivers/input/input_gt911.c
+++ b/drivers/input/input_gt911.c
@@ -17,9 +17,9 @@
 LOG_MODULE_REGISTER(gt911, CONFIG_INPUT_LOG_LEVEL);
 
 /* GT911 used registers */
-#define DEVICE_ID           __bswap_16(0x8140U)
-#define REG_STATUS		    __bswap_16(0x814EU)
-#define REG_FIRST_POINT		__bswap_16(0x814FU)
+#define DEVICE_ID           BSWAP_16(0x8140U)
+#define REG_STATUS		    BSWAP_16(0x814EU)
+#define REG_FIRST_POINT		BSWAP_16(0x814FU)
 
 /* REG_TD_STATUS: Touch points. */
 #define TOUCH_POINTS_MSK	0x0FU
@@ -28,7 +28,7 @@ LOG_MODULE_REGISTER(gt911, CONFIG_INPUT_LOG_LEVEL);
 #define TOUCH_STATUS_MSK    (1 << 7U)
 
 /* The GT911's config */
-#define GT911_CONFIG_REG         __bswap_16(0x8047U)
+#define GT911_CONFIG_REG         BSWAP_16(0x8047U)
 #define REG_CONFIG_VERSION GT911_CONFIG_REG
 #define REG_CONFIG_SIZE (186U)
 #define GT911_PRODUCT_ID (0x00313139U)

--- a/include/zephyr/sys/byteorder.h
+++ b/include/zephyr/sys/byteorder.h
@@ -16,22 +16,21 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/toolchain.h>
 
-/* Internal helpers only used by the sys_* APIs further below */
-#define __bswap_16(x) ((uint16_t) ((((x) >> 8) & 0xff) | (((x) & 0xff) << 8)))
-#define __bswap_24(x) ((uint32_t) ((((x) >> 16) & 0xff) | \
+#define BSWAP_16(x) ((uint16_t) ((((x) >> 8) & 0xff) | (((x) & 0xff) << 8)))
+#define BSWAP_24(x) ((uint32_t) ((((x) >> 16) & 0xff) | \
 				   (((x)) & 0xff00) | \
 				   (((x) & 0xff) << 16)))
-#define __bswap_32(x) ((uint32_t) ((((x) >> 24) & 0xff) | \
+#define BSWAP_32(x) ((uint32_t) ((((x) >> 24) & 0xff) | \
 				   (((x) >> 8) & 0xff00) | \
 				   (((x) & 0xff00) << 8) | \
 				   (((x) & 0xff) << 24)))
-#define __bswap_48(x) ((uint64_t) ((((x) >> 40) & 0xff) | \
+#define BSWAP_48(x) ((uint64_t) ((((x) >> 40) & 0xff) | \
 				   (((x) >> 24) & 0xff00) | \
 				   (((x) >> 8) & 0xff0000) | \
 				   (((x) & 0xff0000) << 8) | \
 				   (((x) & 0xff00) << 24) | \
 				   (((x) & 0xff) << 40)))
-#define __bswap_64(x) ((uint64_t) ((((x) >> 56) & 0xff) | \
+#define BSWAP_64(x) ((uint64_t) ((((x) >> 56) & 0xff) | \
 				   (((x) >> 40) & 0xff00) | \
 				   (((x) >> 24) & 0xff0000) | \
 				   (((x) >> 8) & 0xff000000) | \
@@ -222,16 +221,16 @@
 #define sys_cpu_to_le48(val) (val)
 #define sys_le64_to_cpu(val) (val)
 #define sys_cpu_to_le64(val) (val)
-#define sys_be16_to_cpu(val) __bswap_16(val)
-#define sys_cpu_to_be16(val) __bswap_16(val)
-#define sys_be24_to_cpu(val) __bswap_24(val)
-#define sys_cpu_to_be24(val) __bswap_24(val)
-#define sys_be32_to_cpu(val) __bswap_32(val)
-#define sys_cpu_to_be32(val) __bswap_32(val)
-#define sys_be48_to_cpu(val) __bswap_48(val)
-#define sys_cpu_to_be48(val) __bswap_48(val)
-#define sys_be64_to_cpu(val) __bswap_64(val)
-#define sys_cpu_to_be64(val) __bswap_64(val)
+#define sys_be16_to_cpu(val) BSWAP_16(val)
+#define sys_cpu_to_be16(val) BSWAP_16(val)
+#define sys_be24_to_cpu(val) BSWAP_24(val)
+#define sys_cpu_to_be24(val) BSWAP_24(val)
+#define sys_be32_to_cpu(val) BSWAP_32(val)
+#define sys_cpu_to_be32(val) BSWAP_32(val)
+#define sys_be48_to_cpu(val) BSWAP_48(val)
+#define sys_cpu_to_be48(val) BSWAP_48(val)
+#define sys_be64_to_cpu(val) BSWAP_64(val)
+#define sys_cpu_to_be64(val) BSWAP_64(val)
 
 #define sys_uint16_to_array(val) {		\
 	((val) & 0xff),				\
@@ -254,16 +253,16 @@
 	(((val) >> 56) & 0xff)}
 
 #else
-#define sys_le16_to_cpu(val) __bswap_16(val)
-#define sys_cpu_to_le16(val) __bswap_16(val)
-#define sys_le24_to_cpu(val) __bswap_24(val)
-#define sys_cpu_to_le24(val) __bswap_24(val)
-#define sys_le32_to_cpu(val) __bswap_32(val)
-#define sys_cpu_to_le32(val) __bswap_32(val)
-#define sys_le48_to_cpu(val) __bswap_48(val)
-#define sys_cpu_to_le48(val) __bswap_48(val)
-#define sys_le64_to_cpu(val) __bswap_64(val)
-#define sys_cpu_to_le64(val) __bswap_64(val)
+#define sys_le16_to_cpu(val) BSWAP_16(val)
+#define sys_cpu_to_le16(val) BSWAP_16(val)
+#define sys_le24_to_cpu(val) BSWAP_24(val)
+#define sys_cpu_to_le24(val) BSWAP_24(val)
+#define sys_le32_to_cpu(val) BSWAP_32(val)
+#define sys_cpu_to_le32(val) BSWAP_32(val)
+#define sys_le48_to_cpu(val) BSWAP_48(val)
+#define sys_cpu_to_le48(val) BSWAP_48(val)
+#define sys_le64_to_cpu(val) BSWAP_64(val)
+#define sys_cpu_to_le64(val) BSWAP_64(val)
 #define sys_be16_to_cpu(val) (val)
 #define sys_cpu_to_be16(val) (val)
 #define sys_be24_to_cpu(val) (val)

--- a/subsys/net/ip/utils.c
+++ b/subsys/net/ip/utils.c
@@ -539,7 +539,7 @@ uint16_t calc_chksum(uint16_t sum_in, const uint8_t *data, size_t len)
 	 * and the offset of starting
 	 */
 	if (odd_start == CHECKSUM_BIG_ENDIAN) {
-		sum = __bswap_16(sum_in);
+		sum = BSWAP_16(sum_in);
 	} else {
 		sum = sum_in;
 	}
@@ -591,7 +591,7 @@ uint16_t calc_chksum(uint16_t sum_in, const uint8_t *data, size_t len)
 	 * and the offset of starting
 	 */
 	if (odd_start == CHECKSUM_BIG_ENDIAN) {
-		return __bswap_16((uint16_t)sum);
+		return BSWAP_16((uint16_t)sum);
 	} else {
 		return sum;
 	}

--- a/subsys/shell/modules/devmem_service.c
+++ b/subsys/shell/modules/devmem_service.c
@@ -63,21 +63,13 @@ static int memory_dump(const struct shell *sh, mem_addr_t phys_addr, size_t size
 				hex_data[data_offset] = value;
 				break;
 			case 16:
-				value = sys_read16(addr + data_offset);
-				if (IS_ENABLED(CONFIG_BIG_ENDIAN)) {
-					value = __bswap_16(value);
-				}
-
+				value = sys_le16_to_cpu(sys_read16(addr + data_offset));
 				hex_data[data_offset] = (uint8_t)value;
 				value >>= 8;
 				hex_data[data_offset + 1] = (uint8_t)value;
 				break;
 			case 32:
-				value = sys_read32(addr + data_offset);
-				if (IS_ENABLED(CONFIG_BIG_ENDIAN)) {
-					value = __bswap_32(value);
-				}
-
+				value = sys_le32_to_cpu(sys_read32(addr + data_offset));
 				hex_data[data_offset] = (uint8_t)value;
 				value >>= 8;
 				hex_data[data_offset + 1] = (uint8_t)value;
@@ -192,16 +184,16 @@ static void bypass_cb(const struct shell *sh, uint8_t *recv, size_t len)
 
 		if (!littleendian) {
 			while (sum > 4) {
-				*data = __bswap_32(*data);
+				*data = BSWAP_32(*data);
 				data++;
 				sum = sum - 4;
 			}
 			if (sum % 4 == 0) {
-				*data = __bswap_32(*data);
+				*data = BSWAP_32(*data);
 			} else if (sum % 4 == 2) {
-				*data = __bswap_16(*data);
+				*data = BSWAP_16(*data);
 			} else if (sum % 4 == 3) {
-				*data = __bswap_24(*data);
+				*data = BSWAP_24(*data);
 			}
 		}
 		return;

--- a/tests/drivers/smbus/smbus_emul/src/smbus.c
+++ b/tests/drivers/smbus/smbus_emul/src/smbus.c
@@ -181,7 +181,7 @@ ZTEST(test_smbus_emul, test_proc_call)
 	zassert_ok(ret, "SMBus Proc Call failed");
 
 	/* Our emulated Proc Call swaps bytes */
-	zassert_equal(snd_word, __bswap_16(rcv_word), "Data mismatch");
+	zassert_equal(snd_word, BSWAP_16(rcv_word), "Data mismatch");
 }
 
 ZTEST(test_smbus_emul, test_block)

--- a/tests/lib/cpp/cxx/src/main.cpp
+++ b/tests/lib/cpp/cxx/src/main.cpp
@@ -17,7 +17,6 @@
 #include <zephyr/device.h>
 #include <zephyr/kernel.h>
 #include <zephyr/net/buf.h>
-/* #include <zephyr/sys/byteorder.h> conflicts with __bswapXX on native_posix */
 #include <zephyr/sys/crc.h>
 #include <zephyr/sys/crc.h>
 


### PR DESCRIPTION
__bswap in zephyr/sys/byteorder.h conflicts with __bswap in host's byteswap.h. byteswap.h from host compiler used in posix_native_64 boards causes a compilation issue.

This commit renames __bswap to __z_bswap to prevent collision.

Before this commit a compilation error can be created by adding #include <byteswap.h> to samples/net/sockets/echo/src/socket_echo.c

This does not change external API to byteorder.h, but does change internal implementation which some other source files depend on.

Fixes #44324