### PR TITLE
drivers: clock_control: clock_control_ra.c: protect register fix

### DIFF
--- a/drivers/clock_control/clock_control_ra.c
+++ b/drivers/clock_control/clock_control_ra.c
@@ -299,7 +299,7 @@ static int clock_control_ra_init(const struct device *dev)
 	}
 
 	SYSTEM_write8(MEMWAIT_OFFSET, 1);
-	SYSTEM_write16(PRCR_OFFSET, PRCR_KEY | PRCR_CLOCKS | PRCR_LOW_POWER);
+	SYSTEM_write16(PRCR_OFFSET, PRCR_KEY);
 
 	return 0;
 }


### PR DESCRIPTION
Protection for clock control and power mode registers was not being re-enabled.