### PR TITLE
boards: doc: align board ram usage with dts settings

### DIFF
--- a/boards/arm/frdm_k64f/frdm_k64f.yaml
+++ b/boards/arm/frdm_k64f/frdm_k64f.yaml
@@ -2,7 +2,7 @@ identifier: frdm_k64f
 name: NXP FRDM-K64F
 type: mcu
 arch: arm
-ram: 256
+ram: 192
 flash: 1024
 toolchain:
   - zephyr

--- a/boards/arm/frdm_kw41z/frdm_kw41z.yaml
+++ b/boards/arm/frdm_kw41z/frdm_kw41z.yaml
@@ -2,7 +2,7 @@ identifier: frdm_kw41z
 name: NXP FRDM-KW41Z
 type: mcu
 arch: arm
-ram: 128
+ram: 96
 flash: 512
 toolchain:
   - zephyr

--- a/boards/arm/lpcxpresso11u68/lpcxpresso11u68.yaml
+++ b/boards/arm/lpcxpresso11u68/lpcxpresso11u68.yaml
@@ -2,6 +2,8 @@ identifier: lpcxpresso11u68
 name: NXP LPCxpresso 11U68
 type: mcu
 arch: arm
+ram: 32
+flash: 256
 toolchain:
   - zephyr
 supported:

--- a/boards/arm/mimx8mm_evk/mimx8mm_evk.yaml
+++ b/boards/arm/mimx8mm_evk/mimx8mm_evk.yaml
@@ -8,8 +8,8 @@ identifier: mimx8mm_evk
 name: NXP i.MX8M Mini EVK
 type: mcu
 arch: arm
-ram: 32
-flash: 32
+ram: 128
+flash: 128
 toolchain:
   - zephyr
   - gnuarmemb

--- a/boards/arm/mimx8mm_phyboard_polis/mimx8mm_phyboard_polis.yaml
+++ b/boards/arm/mimx8mm_phyboard_polis/mimx8mm_phyboard_polis.yaml
@@ -8,8 +8,8 @@ identifier: mimx8mm_phyboard_polis
 name: Phyboard Polis i.MX8M Mini
 type: mcu
 arch: arm
-ram: 32
-flash: 32
+ram: 128
+flash: 128
 toolchain:
   - zephyr
   - gnuarmemb

--- a/boards/arm/mimx8mq_evk/mimx8mq_evk_cm4.yaml
+++ b/boards/arm/mimx8mq_evk/mimx8mq_evk_cm4.yaml
@@ -8,8 +8,8 @@ identifier: mimx8mq_evk_cm4
 name: NXP i.MX8MQ EVK CM4
 type: mcu
 arch: arm
-ram: 32
-flash: 32
+ram: 128
+flash: 128
 toolchain:
   - zephyr
   - gnuarmemb

--- a/boards/arm/mimxrt1010_evk/mimxrt1010_evk.yaml
+++ b/boards/arm/mimxrt1010_evk/mimxrt1010_evk.yaml
@@ -13,7 +13,7 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
-ram: 32
+ram: 64
 flash: 16384
 supported:
   - arduino_gpio

--- a/boards/arm/twr_kv58f220m/twr_kv58f220m.yaml
+++ b/boards/arm/twr_kv58f220m/twr_kv58f220m.yaml
@@ -6,7 +6,7 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
-ram: 256
+ram: 128
 flash: 1024
 supported:
   - i2c


### PR DESCRIPTION
the ram size is used in twister for case filter, so need align them with real setting.