### PR TITLE
drivers: adc: stm32: Fix race condition with internal channels

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -1087,10 +1087,6 @@ static void adc_context_on_complete(struct adc_context *ctx, int status)
 	/* Reset acquisition time used for the sequence */
 	data->acq_time_index = -1;
 
-	/* Reset internal channels */
-	LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(adc),
-				       LL_ADC_PATH_INTERNAL_NONE);
-
 #if defined(CONFIG_SOC_SERIES_STM32H7X) || defined(CONFIG_SOC_SERIES_STM32U5X)
 	/* Reset channel preselection register */
 	LL_ADC_SetChannelPreselection(adc, 0);


### PR DESCRIPTION
When using one of the internal channels (die_temp, vbat, vref) the channels are enabled in the individual drivers and disabled again whenever an adc conversion is complete.

This creates a race condition if the ADC is used from multiple threads.

This commit moves the disablig of the channels to the individual drivers.