### PR TITLE
samples: drivers: uart: native_tty: Remove superfluous cmake lines

### DIFF
--- a/samples/drivers/uart/native_tty/CMakeLists.txt
+++ b/samples/drivers/uart/native_tty/CMakeLists.txt
@@ -4,8 +4,5 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(native_tty)
 
-set(CMAKE_EXPORT_COMPILE_COMMANDS on)
-zephyr_compile_options(-fdiagnostics-color=always)
-
 file(GLOB app_sources src/main.c)
 target_sources(app PRIVATE ${app_sources})


### PR DESCRIPTION
Removes some lines that appear to have been used for debug that are not needed