### PR TITLE
cmake: modules: shields: Process shields in order

### DIFF
--- a/cmake/modules/shields.cmake
+++ b/cmake/modules/shields.cmake
@@ -79,40 +79,52 @@ foreach(root ${BOARD_ROOT})
 
       list(REMOVE_ITEM SHIELD-NOTFOUND ${s})
 
-      # Add <shield>.overlay to the shield_dts_files output variable.
-      list(APPEND
-        shield_dts_files
-        ${SHIELD_DIR_${s}}/${s}.overlay
-        )
-
-      # Add the shield's directory to the SHIELD_DIRS output variable.
-      list(APPEND
-        SHIELD_DIRS
-        ${SHIELD_DIR_${s}}
-        )
+      # Add <shield>.overlay to a temporary variable
+      set(shield_${s}_dts_file ${SHIELD_DIR_${s}}/${s}.overlay)
 
       # Search for shield/shield.conf file
       if(EXISTS ${SHIELD_DIR_${s}}/${s}.conf)
-        # Add <shield>.conf to the shield_conf_files output variable.
-        list(APPEND
-          shield_conf_files
-          ${SHIELD_DIR_${s}}/${s}.conf
-          )
+        # Add <shield>.conf to a temporary variable
+        set(shield_${s}_conf_file ${SHIELD_DIR_${s}}/${s}.conf)
       endif()
-
-      # Add board-specific .conf and .overlay files to their
-      # respective output variables.
-      zephyr_file(CONF_FILES ${SHIELD_DIR_${s}}/boards
-                  DTS   shield_dts_files
-                  KCONF shield_conf_files
-      )
-      zephyr_file(CONF_FILES ${SHIELD_DIR_${s}}/boards/${s}
-                  DTS   shield_dts_files
-                  KCONF shield_conf_files
-      )
     endforeach()
   endif()
 endforeach()
+
+# Process shields in-order
+if(DEFINED SHIELD)
+  foreach(s ${SHIELD_AS_LIST})
+    # Add <shield>.overlay to the shield_dts_files output variable.
+    list(APPEND
+      shield_dts_files
+      ${shield_${s}_dts_file}
+      )
+
+    # Add the shield's directory to the SHIELD_DIRS output variable.
+    list(APPEND
+      SHIELD_DIRS
+      ${SHIELD_DIR_${s}}
+      )
+
+    if(DEFINED shield_${s}_conf_file)
+      list(APPEND
+        shield_conf_files
+        ${shield_${s}_conf_file}
+        )
+    endif()
+
+    # Add board-specific .conf and .overlay files to their
+    # respective output variables.
+    zephyr_file(CONF_FILES ${SHIELD_DIR_${s}}/boards
+                DTS   shield_dts_files
+                KCONF shield_conf_files
+    )
+    zephyr_file(CONF_FILES ${SHIELD_DIR_${s}}/boards/${s}
+                DTS   shield_dts_files
+                KCONF shield_conf_files
+    )
+  endforeach()
+endif()
 
 # Prepare shield usage command printing.
 # This command prints all shields in the system in the following cases:

--- a/doc/releases/release-notes-3.6.rst
+++ b/doc/releases/release-notes-3.6.rst
@@ -141,6 +141,9 @@ Build system and infrastructure
 * Deprecated :kconfig:option:`CONFIG_BOOTLOADER_SRAM_SIZE`, users of this should transition to
   having RAM set up properly in their board devicetree files.
 
+* Fixed an issue whereby shields were processed in order of the root they resided in rather than
+  the order they were supplied to cmake in.
+
 Drivers and Sensors
 *******************
 


### PR DESCRIPTION
    cmake: modules: shields: Process shields in order
    
    Changes shield processing order from being on a root-by-root
    basis to being order they were supplied to cmake

    doc: release: 3.6: Add note on shield processing change
    
    Adds a note that shields are now processed in order

Fixes #67227