### PR TITLE
boards: lpcxpresso55s69: fix crystal frequency

### DIFF
--- a/boards/arm/lpcxpresso55s69/doc/index.rst
+++ b/boards/arm/lpcxpresso55s69/doc/index.rst
@@ -256,7 +256,7 @@ Dual Core samples
 System Clock
 ============
 
-The LPC55S69 SoC is configured to use PLL1 clocked from the external 24MHz
+The LPC55S69 SoC is configured to use PLL1 clocked from the external 16MHz
 crystal, running at 144MHz as a source for the system clock. When the flash
 controller is enabled, the core clock will be reduced to 96MHz. The application
 may reconfigure clocks after initialization, provided that the core clock is


### PR DESCRIPTION
this corresponds to soc/arm/nxp_lpc/lpc55xxx/soc.c:129. also, 16MHz is used on the lpc55s69-evk.