### PR TITLE
sys/util.h: Add IS_ALIGNED macro

### DIFF
--- a/drivers/crypto/crypto_intel_sha_priv.h
+++ b/drivers/crypto/crypto_intel_sha_priv.h
@@ -8,6 +8,7 @@
 #define ZEPHYR_DRIVERS_CRYPTO_CRYPTO_INTEL_SHA_PRIV_H_
 
 #include <zephyr/kernel.h>
+#include <zephyr/sys/util.h>
 #include "crypto_intel_sha_registers.h"
 
 #define SHA_HASH_DATA_BLOCK_LEN (64)
@@ -30,7 +31,6 @@
 
 #define SHA_MAX_SESSIONS 8
 
-#define IS_ALIGNED(address, alignment) (((uintptr_t)(address)) % (alignment) == 0)
 #define BYTE_SWAP32(x)                                                                             \
 	(((x >> 24) & 0x000000FF) | ((x << 24) & 0xFF000000) | ((x >> 8) & 0x0000FF00) |           \
 	 ((x << 8) & 0x00FF0000))

--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -283,6 +283,11 @@ extern "C" {
 	UTIL_CAT(_CONCAT_, NUM_VA_ARGS_LESS_1(__VA_ARGS__))(__VA_ARGS__)
 
 /**
+ * @brief Check if @p ptr is aligned to @p align alignment
+ */
+#define IS_ALIGNED(ptr, align) (((uintptr_t)(ptr)) % (align) == 0)
+
+/**
  * @brief Value of @p x rounded up to the next multiple of @p align.
  */
 #define ROUND_UP(x, align)                                   \


### PR DESCRIPTION
Add an IS_ALIGNED macro, to test if a value `x` is aligned to an alignment `align`. This has been independently defined in multiple areas throughout the tree and modules. This PR fixes only those instances where the macro name collides with the sys/util macro.