### PR TITLE
boards: arm: stm32h750b_dk: add support for display

### DIFF
--- a/boards/arm/stm32h750b_dk/Kconfig.defconfig
+++ b/boards/arm/stm32h750b_dk/Kconfig.defconfig
@@ -8,4 +8,13 @@ if BOARD_STM32H750B_DK
 config BOARD
 	default "stm32h750b_dk"
 
+if DISPLAY
+
+# MEMC needs to be enabled in order to store
+# display buffer to external SDRAM connected to FMC
+config MEMC
+	default y
+
+endif # DISPLAY
+
 endif # BOARD_STM32H750B_DK

--- a/boards/arm/stm32h750b_dk/stm32h750b_dk.dts
+++ b/boards/arm/stm32h750b_dk/stm32h750b_dk.dts
@@ -18,6 +18,7 @@
 		zephyr,shell-uart = &usart3;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,flash-controller = &mt25ql512ab1;
 	};
 
 	leds {
@@ -45,6 +46,7 @@
 		led0 = &green_led;
 		led1 = &red_led;
 		sw0 = &user_button;
+		spi-flash0 = &mt25ql512ab1;
 	};
 };
 
@@ -80,4 +82,42 @@
 	pinctrl-names = "default";
 	current-speed = <115200>;
 	status = "okay";
+};
+
+&quadspi {
+	pinctrl-names = "default";
+	pinctrl-0 = <&quadspi_clk_pf10 &quadspi_bk1_ncs_pg6
+		     &quadspi_bk1_io0_pd11 &quadspi_bk1_io1_pf9
+		     &quadspi_bk1_io2_pf7 &quadspi_bk1_io3_pf6
+		     &quadspi_bk2_io0_ph2 &quadspi_bk2_io1_ph3
+		     &quadspi_bk2_io2_pg9 &quadspi_bk2_io3_pg14>;
+	flash-id = <1>;
+	status = "okay";
+
+	mt25ql512ab1: qspi-nor-flash-1@0 {
+		compatible = "st,stm32-qspi-nor";
+		reg = <0>;
+		qspi-max-frequency = <72000000>;
+		size = <DT_SIZE_M(512)>; /* 64 MBytes */
+		spi-bus-width = <4>;
+		status = "okay";
+
+		partitions {
+			   compatible = "fixed-partitions";
+			   #address-cells = <1>;
+			   #size-cells = <1>;
+
+			   partition@0 {
+			       reg = <0x0 DT_SIZE_M(64)>;
+			   };
+		};
+	};
+
+	mt25ql512ab2: qspi-nor-flash-2@1 {
+		compatible = "st,stm32-qspi-nor";
+		reg = <1>;
+		qspi-max-frequency = <72000000>;
+		size = <DT_SIZE_M(512)>; /* 64 MBytes */
+		status = "okay";
+	};
 };

--- a/boards/arm/stm32h750b_dk/stm32h750b_dk.dts
+++ b/boards/arm/stm32h750b_dk/stm32h750b_dk.dts
@@ -19,6 +19,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,flash-controller = &mt25ql512ab1;
+		zephyr,display = &ltdc;
 	};
 
 	sdram1: sdram@c0000000 {
@@ -164,4 +165,39 @@
 			st,sdram-timing = <2 7 4 7 2 2 2>;
 		};
 	};
+};
+
+&ltdc {
+	pinctrl-0 = <&ltdc_r0_pi15 &ltdc_r1_pj0 &ltdc_r2_pj1 &ltdc_r3_ph9
+		&ltdc_r4_pj3 &ltdc_r5_pj4 &ltdc_r6_pj5 &ltdc_r7_pj6
+		&ltdc_g0_pj7 &ltdc_g1_pj8 &ltdc_g2_pj9 &ltdc_g3_pj10
+		&ltdc_g4_pj11 &ltdc_g5_pi0 &ltdc_g6_pi1 &ltdc_g7_pk2
+		&ltdc_b0_pj12 &ltdc_b1_pj13 &ltdc_b2_pj14 &ltdc_b3_pj15
+		&ltdc_b4_pk3 &ltdc_b5_pk4 &ltdc_b6_pk5 &ltdc_b7_pk6
+		&ltdc_de_pk7 &ltdc_clk_pi14 &ltdc_hsync_pi12 &ltdc_vsync_pi9>;
+	pinctrl-names = "default";
+	/* disp-on-gpios = <&gpioi 12 GPIO_ACTIVE_HIGH>; */
+	/* bl-ctrl-gpios = <&gpiok 3 GPIO_ACTIVE_HIGH>; */
+	ext-sdram = <&sdram1>;
+	status = "okay";
+
+	width = <480>;
+	height = <272>;
+	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
+	display-timings {
+		compatible = "zephyr,panel-timing";
+		de-active = <0>;
+		pixelclk-active = <0>;
+		hsync-active = <0>;
+		vsync-active = <0>;
+		hsync-len = <1>;
+		vsync-len = <10>;
+		hback-porch = <43>;
+		vback-porch = <12>;
+		hfront-porch = <8>;
+		vfront-porch = <4>;
+	};
+	def-back-color-red = <0xFF>;
+	def-back-color-green = <0xFF>;
+	def-back-color-blue = <0xFF>;
 };

--- a/boards/arm/stm32h750b_dk/stm32h750b_dk.dts
+++ b/boards/arm/stm32h750b_dk/stm32h750b_dk.dts
@@ -21,6 +21,14 @@
 		zephyr,flash-controller = &mt25ql512ab1;
 	};
 
+	sdram1: sdram@c0000000 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		device_type = "memory";
+		reg = <0xc0000000 DT_SIZE_M(16)>; /* 128Mbit */
+		zephyr,memory-region = "SDRAM1";
+		zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_RAM) )>;
+	};
+
 	leds {
 		compatible = "gpio-leds";
 		red_led: led_1 {
@@ -119,5 +127,41 @@
 		qspi-max-frequency = <72000000>;
 		size = <DT_SIZE_M(512)>; /* 64 MBytes */
 		status = "okay";
+	};
+};
+
+&fmc {
+	pinctrl-0 = <&fmc_nbl0_pe0 &fmc_nbl1_pe1
+		&fmc_sdclk_pg8 &fmc_sdnwe_ph5 &fmc_sdcke1_ph7
+		&fmc_sdne1_ph6 &fmc_sdnras_pf11 &fmc_sdncas_pg15
+		&fmc_a0_pf0 &fmc_a1_pf1 &fmc_a2_pf2 &fmc_a3_pf3 &fmc_a4_pf4
+		&fmc_a5_pf5 &fmc_a6_pf12 &fmc_a7_pf13 &fmc_a8_pf14
+		&fmc_a9_pf15 &fmc_a10_pg0 &fmc_a11_pg1
+		&fmc_a14_pg4 &fmc_a15_pg5 &fmc_d0_pd14 &fmc_d1_pd15
+		&fmc_d2_pd0 &fmc_d3_pd1 &fmc_d4_pe7 &fmc_d5_pe8 &fmc_d6_pe9
+		&fmc_d7_pe10 &fmc_d8_pe11 &fmc_d9_pe12 &fmc_d10_pe13
+		&fmc_d11_pe14 &fmc_d12_pe15 &fmc_d13_pd8 &fmc_d14_pd9
+		&fmc_d15_pd10>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	sdram {
+		status = "okay";
+		power-up-delay = <100>;
+		num-auto-refresh = <8>;
+		mode-register = <0x220>;
+		refresh-rate = <0x603>;
+		bank@1 {
+			reg = <1>;
+			st,sdram-control = <STM32_FMC_SDRAM_NC_8
+				STM32_FMC_SDRAM_NR_12
+				STM32_FMC_SDRAM_MWID_16
+				STM32_FMC_SDRAM_NB_4
+				STM32_FMC_SDRAM_CAS_3
+				STM32_FMC_SDRAM_SDCLK_PERIOD_2
+				STM32_FMC_SDRAM_RBURST_ENABLE
+				STM32_FMC_SDRAM_RPIPE_0>;
+			st,sdram-timing = <2 7 4 7 2 2 2>;
+		};
 	};
 };


### PR DESCRIPTION
Add support for display on stm32h750b_dk. `samples/drivers/display` is compiling and flashing correctly now. Still getting a white screen however, will investigate when I have some free time.
This is git based on https://github.com/zephyrproject-rtos/zephyr/pull/67120 and https://github.com/zephyrproject-rtos/zephyr/pull/67221