### PR TITLE
doc: add how to run application in QEMU on Windows

### DIFF
--- a/doc/develop/application/index.rst
+++ b/doc/develop/application/index.rst
@@ -1060,10 +1060,13 @@ for additional information on how to flash your board.
 Running in an Emulator
 ======================
 
-The kernel has built-in emulator support for QEMU (on Linux/macOS only, this
-is not yet supported on Windows). It allows you to run and test an application
-virtually, before (or in lieu of) loading and running it on actual target
-hardware. Follow these instructions to run an application via QEMU:
+Zephyr has built-in emulator support for QEMU.
+It allows you to run and test an application virtually, before
+(or in lieu of) loading and running it on actual target hardware.
+
+Check out :ref:`beyond-GSG` for additional steps needed on Windows.
+
+Follow these instructions to run an application via QEMU:
 
 #. Build your application for one of the QEMU boards, as described in
    :ref:`build_an_application`.

--- a/doc/develop/beyond-GSG.rst
+++ b/doc/develop/beyond-GSG.rst
@@ -279,6 +279,13 @@ system using `QEMU <https://www.qemu.org/>`_ when targeting either
 the x86 or ARM Cortex-M3 architectures. (QEMU is included with the Zephyr
 SDK installation.)
 
+On Windows, you need to install QEMU manually from
+`Download QEMU <https://www.qemu.org/download/#windows>`_. After installation,
+add path to QEMU installation folder to PATH environment variable.
+To enable QEMU in Test Runner (Twister) on Windows,
+:ref:`set the environment variable <env_vars>`
+``QEMU_BIN_PATH`` to the path of QEMU installation folder.
+
 For example, you can build and run the :ref:`hello_world` sample using
 the x86 emulation board configuration (``qemu_x86``), with:
 


### PR DESCRIPTION
Documentation does not describe how to run QEMU on Windows. Add description of steps needed in Beyond the Getting Started Guide and in Application Development sections.
Tested using Windows 11 and QEMU installer from https://qemu.weilnetz.de/w64/