### PR TITLE
net: lwm2m: add gateway_obj prefix check to lwm2m_message_handler

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -46,6 +46,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include "lwm2m_object.h"
 #include "lwm2m_obj_access_control.h"
 #include "lwm2m_obj_server.h"
+#include "lwm2m_obj_gateway.h"
 #include "lwm2m_rw_link_format.h"
 #include "lwm2m_rw_oma_tlv.h"
 #include "lwm2m_rw_plain_text.h"
@@ -479,7 +480,7 @@ void lwm2m_engine_context_init(struct lwm2m_ctx *client_ctx)
 }
 /* utility functions */
 
-static int coap_options_to_path(struct coap_option *opt, int options_count,
+int coap_options_to_path(struct coap_option *opt, int options_count,
 				struct lwm2m_obj_path *path)
 {
 	uint16_t len,
@@ -2266,6 +2267,15 @@ static int handle_request(struct coap_packet *request, struct lwm2m_message *msg
 	if (tkl) {
 		msg->tkl = tkl;
 		msg->token = token;
+	}
+
+	if (IS_ENABLED(CONFIG_LWM2M_GATEWAY_OBJ_SUPPORT)) {
+		r = lwm2m_gw_handle_req(msg);
+		if (r == 0) {
+			return 0;
+		} else if (r != -ENOENT) {
+			goto error;
+		}
 	}
 
 	/* parse the URL path into components */

--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.h
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.h
@@ -39,6 +39,8 @@
 #define NUM_OUTPUT_BLOCK_CONTEXT CONFIG_LWM2M_NUM_OUTPUT_BLOCK_CONTEXT
 #endif
 
+int coap_options_to_path(struct coap_option *opt, int options_count,
+				struct lwm2m_obj_path *path);
 /* LwM2M message functions */
 struct lwm2m_message *lwm2m_get_message(struct lwm2m_ctx *client_ctx);
 struct lwm2m_message *find_msg(struct coap_pending *pending, struct coap_reply *reply);

--- a/subsys/net/lib/lwm2m/lwm2m_obj_gateway.h
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_gateway.h
@@ -9,6 +9,8 @@
 #ifndef __LWM2M_OBJ_GATEWAY__
 #define __LWM2M_OBJ_GATEWAY__
 
+#include <lwm2m_object.h>
+
 /* LwM2M Gateway resource IDs */
 /* clang-format off */
 #define LWM2M_GATEWAY_DEVICE_RID             0
@@ -16,5 +18,43 @@
 #define LWM2M_GATEWAY_DEPRECATED_RID         2
 #define LWM2M_GATEWAY_IOT_DEVICE_OBJECTS_RID 3
 /* clang-format on */
+
+/**
+ * @brief A callback which handles the prefixed messages from the server.
+ *
+ * The callback gets triggered each time the prefix in front of a received lwm2m
+ * msg path matches the prefix set in the LWM2M_GATEWAY_PREFIX_RID buffer.
+ *
+ * It must handle the content of the coap message completely.
+ * In case of success the LwM2M engine will then send the formatted coap message,
+ * otherwise a coap response code is sent.
+ *
+ * Example of returning CoAP response:
+ * @code{.c}
+ * lwm2m_init_message(msg);
+ * // Write CoAP packet to msg->out.out_cpkt
+ * return 0;
+ * @endcode
+ *
+ *
+ * @return 0 if msg contains a  valid CoAP response.
+ * @return  negative error code otherwise.
+ */
+typedef int (*lwm2m_engine_gateway_msg_cb)(struct lwm2m_message *msg);
+/**
+ * @brief Register a callback which handles the prefixed messages from the server.
+ *
+ * @return 0 on success
+ * @return -ENOENT if no object instance with obj_inst_id was found
+ */
+int lwm2m_register_gw_callback(uint16_t obj_inst_id, lwm2m_engine_gateway_msg_cb cb);
+/**
+ * @brief Check if given message is handled by Gateway callback.
+ *
+ * @return 0 if msg was handled by Gateawy and contains a valid response. Negative error code
+ * otherwise.
+ * @return -ENOENT if this msg was not handled by Gateway object.
+ */
+int lwm2m_gw_handle_req(struct lwm2m_message *msg);
 
 #endif /* __LWM2M_OBJ_GATEWAY__ */


### PR DESCRIPTION
The idea of the lwm2m gateway object 25 is that messages can be forwarded from a "gateway" to a connected "childdevice". The server can reach any device managed by the gateway by prefixing the LWM2M CoAP request with the prefix announced by the object. To be able to handle these messages, a callback is implemented in the message handler which forwards these messages if required.