### PR TITLE
llext: miscellaneous fixes

### DIFF
--- a/include/zephyr/llext/elf.h
+++ b/include/zephyr/llext/elf.h
@@ -231,16 +231,16 @@ struct elf32_sym {
 struct elf64_sym {
 	/** Name of the symbol as an index into the symbol string table */
 	elf64_word st_name;
-	/** Value or location of the symbol */
-	elf64_addr st_value;
-	/** Size of the symbol */
-	elf64_xword st_size;
 	/** Symbol binding and type information */
 	unsigned char st_info;
 	/** Symbol visibility */
 	unsigned char st_other;
 	/** Symbols related section given by section header index */
 	elf64_half st_shndx;
+	/** Value or location of the symbol */
+	elf64_addr st_value;
+	/** Size of the symbol */
+	elf64_xword st_size;
 };
 
 #define SHN_UNDEF 0

--- a/include/zephyr/llext/symbol.h
+++ b/include/zephyr/llext/symbol.h
@@ -8,6 +8,7 @@
 #define ZEPHYR_LLEXT_SYMBOL_H
 
 #include <zephyr/sys/iterable_sections.h>
+#include <zephyr/toolchain.h>
 #include <stddef.h>
 
 #ifdef __cplusplus
@@ -78,8 +79,9 @@ struct llext_symtable {
 		.name = STRINGIFY(x), .addr = &x,				\
 	}
 
-#define LL_EXTENSION_SYMBOL(x) struct llext_symbol __attribute__((section(".exported_sym"), used)) \
-							symbol_##x = {STRINGIFY(x), &x}
+#define LL_EXTENSION_SYMBOL(x)							\
+	struct llext_symbol Z_GENERIC_SECTION(".exported_sym") __used		\
+		symbol_##x = {STRINGIFY(x), &x}
 
 /**
  * @brief Export a system call to a table of symbols


### PR DESCRIPTION
* 49fdda1bbef2d2d27ca6b9a290ccadbfb59006f7 fixes the incorrect layout of `struct elf64_sym` structure
* aa77728bccc8a5ca5a74cc3a63203c78325c54b2 replaces GCC-syntax attributes used in the `LL_EXTENSION_SYMBOL` macro with generic versions provided by `zephyr/toolchain.h`