### PR TITLE
Efm32 uart pinctrl

### DIFF
--- a/boards/arm/efm32gg_sltb009a/efm32gg_sltb009a-pinctrl.dtsi
+++ b/boards/arm/efm32gg_sltb009a/efm32gg_sltb009a-pinctrl.dtsi
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2024 Antmicro <www.antmicro.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <dt-bindings/pinctrl/gecko-pinctrl-s1.h>
+
+&pinctrl {
+	/* configuration for usart0 device, default state - operating as UART */
+	usart0_default: usart0_default {
+		group1 {
+			psels = <GECKO_PSEL(UART_TX, E, 0)>,
+				<GECKO_PSEL(UART_RX, E, 1)>,
+				<GECKO_LOC(UART_TX, 7)>,
+				<GECKO_LOC(UART_RX, 6)>;
+		};
+	};
+};

--- a/boards/arm/efm32gg_sltb009a/efm32gg_sltb009a.dts
+++ b/boards/arm/efm32gg_sltb009a/efm32gg_sltb009a.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 #include <silabs/efm32gg12b810f1024gm64.dtsi>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include "efm32gg_sltb009a-pinctrl.dtsi"
 
 / {
 	model = "Silicon Labs EFM32GG SLTB009A board";
@@ -57,8 +58,8 @@
 
 &usart0 {
 	current-speed = <115200>;
-	location-rx = <GECKO_LOCATION(1) GECKO_PORT_E GECKO_PIN(6)>;
-	location-tx = <GECKO_LOCATION(1) GECKO_PORT_E GECKO_PIN(7)>;
+	pinctrl-0 = <&usart0_default>;
+	pinctrl-names = "default";
 	status = "okay";
 };
 

--- a/boards/arm/efm32pg_stk3401a/efm32pg_stk3401a-pinctrl.dtsi
+++ b/boards/arm/efm32pg_stk3401a/efm32pg_stk3401a-pinctrl.dtsi
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2024 Antmicro <www.antmicro.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <dt-bindings/pinctrl/gecko-pinctrl-s1.h>
+
+&pinctrl {
+	/* configuration for usart0 device, default state - operating as UART */
+	usart0_default: usart0_default {
+		group1 {
+			psels = <GECKO_PSEL(UART_TX, A, 0)>,
+				<GECKO_PSEL(UART_RX, A, 1)>,
+				<GECKO_LOC(UART_TX, 0)>,
+				<GECKO_LOC(UART_RX, 1)>;
+		};
+	};
+};

--- a/boards/arm/efm32pg_stk3401a/efm32pg_stk3401a_common.dtsi
+++ b/boards/arm/efm32pg_stk3401a/efm32pg_stk3401a_common.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include "efm32pg_stk3401a-pinctrl.dtsi"
 
 / {
 	model = "Silicon Labs EFM32PG STK3401A board";
@@ -60,8 +61,8 @@
 
 &usart0 {
 	current-speed = <115200>;
-	location-rx = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(1)>;
-	location-tx = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(0)>;
+	pinctrl-0 = <&usart0_default>;
+	pinctrl-names = "default";
 	status = "okay";
 };
 


### PR DESCRIPTION
This PR adds pinctrl USART bindings for the `efm32gg_stlbooo9a` and `efm32pg_stk3401a`. Without this, usart driver fails to initialise and there is no stdin/stdout on serial interface