### PR TITLE
soc: sam0: samd: Fix switching between clocks

### DIFF
--- a/soc/arm/atmel_sam0/common/soc_samd2x.c
+++ b/soc/arm/atmel_sam0/common/soc_samd2x.c
@@ -38,9 +38,6 @@
 #define FUSES_OSC32K_CAL_Msk		FUSES_OSC32KCAL_Msk
 #endif
 
-#if !CONFIG_SOC_ATMEL_SAMD_OSC8M || CONFIG_SOC_ATMEL_SAMD_DEFAULT_AS_MAIN
-#define osc8m_init()
-#else
 static inline void osc8m_init(void)
 {
 	uint32_t reg;
@@ -56,8 +53,24 @@ static inline void osc8m_init(void)
 
 	while (!SYSCTRL->PCLKSR.bit.OSC8MRDY) {
 	}
+
+	/* Use 8Mhz clock as gclk_main to allow switching between clocks
+	 * when using bootloaders
+	 */
+	GCLK->GENDIV.reg = GCLK_GENDIV_ID(0)
+			 | GCLK_GENDIV_DIV(0);
+
+	while (GCLK->STATUS.bit.SYNCBUSY) {
+	}
+
+	GCLK->GENCTRL.reg = GCLK_GENCTRL_ID(0)
+			  | GCLK_GENCTRL_SRC_OSC8M
+			  | GCLK_GENCTRL_IDC
+			  | GCLK_GENCTRL_GENEN;
+
+	while (GCLK->STATUS.bit.SYNCBUSY) {
+	}
 }
-#endif
 
 #if !CONFIG_SOC_ATMEL_SAMD_OSC32K || CONFIG_SOC_ATMEL_SAMD_DEFAULT_AS_MAIN
 #define osc32k_init()


### PR DESCRIPTION
The clock z_arm_platform_init hangs switching between clocks when using MCUboot. This fixes the issue using the 8MHz internal clock as gclk_main source when configuring PLL/DFLL.

Fixes: #67220