### PR TITLE
boards: m5stack_core2: Add possibility to control 5V_BUS signal

### DIFF
--- a/boards/m5stack/m5stack_core2/Kconfig.defconfig
+++ b/boards/m5stack/m5stack_core2/Kconfig.defconfig
@@ -19,11 +19,20 @@ choice BT_HCI_BUS_TYPE
 	default BT_ESP32 if BT
 endchoice
 
-config REGULATOR_AXP192_INIT_PRIORITY
-	default 81
-
 config GPIO_HOGS_INIT_PRIORITY
-	default 82
+	default 70
+
+config MFD_INIT_PRIORITY
+	default 70
+
+config REGULATOR_AXP192_INIT_PRIORITY
+	default 71
+
+config GPIO_AXP192_INIT_PRIORITY
+	default 72
+
+config REGULATOR_FIXED_INIT_PRIORITY
+	default 75
 
 config INPUT_FT5336_INTERRUPT
 	default y if INPUT

--- a/boards/m5stack/m5stack_core2/doc/index.rst
+++ b/boards/m5stack/m5stack_core2/doc/index.rst
@@ -21,6 +21,7 @@ M5Stack Core2 features the following integrated components:
 - RTC BM8563
 - USB CP2104
 - SD-Card slot
+- Grove connector
 - IMO 6-axis IMU MPU6886
 - MIC SPM1423
 - Battery 390mAh 3,7V
@@ -50,39 +51,44 @@ of the M5Stack Core2 board.
 .. _PMU-AXP192: https://m5stack.oss-cn-shenzhen.aliyuncs.com/resource/docs/datasheet/core/AXP192_datasheet_en.pdf
 .. _VIB-1072_RFN01: https://m5stack.oss-cn-shenzhen.aliyuncs.com/resource/docs/datasheet/core/1027RFN01-33d.pdf
 
-+------------------+--------------------------------------------------------------------------+------------+
-| Key Component    | Description                                                              | Status     |
-+==================+==========================================================================+============+
-|| ESP32-D0WDQ6-V2 || This `MPU-ESP32`_ module provides complete Wi-Fi and Bluetooth          || supported |
-|| module          || functionalities and integrates a 16-MB SPI flash.                       ||           |
-+------------------+--------------------------------------------------------------------------+------------+
-|| 32.768 kHz RTC  || External precision 32.768 kHz crystal oscillator serves as a clock with || supported |
-||                 || low-power consumption while the chip is in Deep-sleep mode.             ||           |
-+------------------+--------------------------------------------------------------------------+------------+
-| Status LED       | One user LED connected to the GPIO pin.                                  | supported  |
-+------------------+--------------------------------------------------------------------------+------------+
-|| USB Port        || USB interface. Power supply for the board as well as the                || supported |
-||                 || communication interface between a computer and the board.               ||           |
-||                 || Contains: TypeC x 1, GROVE(I2C+I/O+UART) x 1                            ||           |
-+------------------+--------------------------------------------------------------------------+------------+
-| Reset button     | Reset button                                                             | supported  |
-+------------------+--------------------------------------------------------------------------+------------+
-| Power Switch     | Power on/off button.                                                     | supported  |
-+------------------+--------------------------------------------------------------------------+------------+
-|| LCD screen      || Built-in LCD TFT display \(`LCD-ILI9342C`_, 2", 320x240 px\)            || supported |
-||                 || controlled via SPI interface                                            ||           |
-+------------------+--------------------------------------------------------------------------+------------+
-| SD-Card slot     | SD-Card connection via SPI-mode.                                         | supported  |
-+------------------+--------------------------------------------------------------------------+------------+
-|| 6-axis IMU      || The `MPU-6886`_ is a 6-axis motion tracker (6DOF IMU) device that       || todo      |
-|| MPU6886         || combines a 3-axis gyroscope and a 3-axis accelerometer.                 ||           |
-||                 || For details please refer to :ref:`m5stack_core2_ext`                    ||           |
-+------------------+--------------------------------------------------------------------------+------------+
-|| Built-in        || The `SPM-1423`_ I2S driven microphone.                                  || todo      |
-|| microphone      ||                                                                         ||           |
-+------------------+--------------------------------------------------------------------------+------------+
-| Built-in speaker | 1W speaker for audio output via I2S interface.                           | todo       |
-+------------------+--------------------------------------------------------------------------+------------+
++------------------+--------------------------------------------------------------------------+-----------+
+| Key Component    | Description                                                              | Status    |
++==================+==========================================================================+===========+
+| ESP32-D0WDQ6-V2  | This `MPU-ESP32`_ module provides complete Wi-Fi and Bluetooth           | supported |
+| module           | functionalities and integrates a 16-MB SPI flash.                        |           |
++------------------+--------------------------------------------------------------------------+-----------+
+| 32.768 kHz RTC   | External precision 32.768 kHz crystal oscillator serves as a clock with  | supported |
+|                  | low-power consumption while the chip is in Deep-sleep mode.              |           |
++------------------+--------------------------------------------------------------------------+-----------+
+| Status LED       | One user LED connected to the GPIO pin.                                  | supported |
++------------------+--------------------------------------------------------------------------+-----------+
+| USB Port         | USB interface. Power supply for the board as well as the                 | supported |
+|                  | communication interface between a computer and the board.                |           |
+|                  | Contains: TypeC x 1, GROVE(I2C+I/O+UART) x 1                             |           |
++------------------+--------------------------------------------------------------------------+-----------+
+| Reset button     | Reset button                                                             | supported |
++------------------+--------------------------------------------------------------------------+-----------+
+| Power Switch     | Power on/off button.                                                     | supported |
++------------------+--------------------------------------------------------------------------+-----------+
+| LCD screen       | Built-in LCD TFT display \(`LCD-ILI9342C`_, 2", 320x240 px\)             | supported |
+|                  | controlled via SPI interface                                             |           |
++------------------+--------------------------------------------------------------------------+-----------+
+| SD-Card slot     | SD-Card connection via SPI-mode.                                         | supported |
++------------------+--------------------------------------------------------------------------+-----------+
+| 6-axis IMU       | The `MPU-6886`_ is a 6-axis motion tracker (6DOF IMU) device that        | supported |
+| MPU6886          | combines a 3-axis gyroscope and a 3-axis accelerometer.                  |           |
+|                  | For details please refer to :ref:`m5stack_core2_ext`                     |           |
++------------------+--------------------------------------------------------------------------+-----------+
+| Grove port       | Note: Grove port requires 5V to be enabled via `bus_5v` regulator        | supported |
++------------------+--------------------------------------------------------------------------+-----------+
+| Built-in         | The `SPM-1423`_ I2S driven microphone.                                   | todo      |
+| microphone       |                                                                          |           |
++------------------+--------------------------------------------------------------------------+-----------+
+| Built-in speaker | 1W speaker for audio output via I2S interface.                           | todo      |
++------------------+--------------------------------------------------------------------------+-----------+
+| Battery-support  | Power supply via battery is supported automatically. But there is no     | todo      |
+|                  | possibility to query current battery status.                             |           |
++------------------+--------------------------------------------------------------------------+-----------+
 
 Supported Features
 ==================
@@ -190,7 +196,7 @@ M5Stack Core2 debugging is not supported due to pinout limitations.
 Related Documents
 *****************
 
-- `M5StickC PLUS schematic <https://static-cdn.m5stack.com/resource/docs/products/core/m5stickc_plus/m5stickc_plus_sch_03.webp>`_ (WEBP)
+- `M5Stack-Core2 schematic <https://m5stack.oss-cn-shenzhen.aliyuncs.com/resource/docs/schematic/Core/CORE2_V1.0_SCH.pdf>`_ (PDF)
 - `ESP32-PICO-D4 Datasheet <https://www.espressif.com/sites/default/files/documentation/esp32-pico-d4_datasheet_en.pdf>`_ (PDF)
 - `M5StickC PLUS docs <https://docs.m5stack.com/en/core/m5stickc_plus>`_
 - `ESP32 Datasheet <https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf>`_ (PDF)

--- a/boards/m5stack/m5stack_core2/doc/index.rst
+++ b/boards/m5stack/m5stack_core2/doc/index.rst
@@ -90,6 +90,27 @@ of the M5Stack Core2 board.
 |                  | possibility to query current battery status.                             |           |
 +------------------+--------------------------------------------------------------------------+-----------+
 
+Power supply
+============
+M5Stack Core2 module is equipped with the feature-rich power management IC
+(:dtcompatible:`x-powers,axp192-regulator`).
+Following regulators are utilized on this module:
+
+- **vdd_mcu**:
+  Main power supply for the MCU.
+- **lcd_bg**:
+  Display backlight voltage.
+- **v_peri**:
+  Periphal supply. This regulator controls supply for the display, SD-Card.
+- **vib_motor**:
+  Vibration motor regulator.
+- **bus_5v**
+  BUS_5V supply for Grove port.
+  Note: This fixed regulator supply is disabled by default.
+
+
+These voltages can be controlled via regulator api.
+
 Supported Features
 ==================
 

--- a/boards/m5stack/m5stack_core2/m5stack_core2_esp32_procpu.dts
+++ b/boards/m5stack/m5stack_core2/m5stack_core2_esp32_procpu.dts
@@ -163,7 +163,7 @@
 			compatible = "x-powers,axp192-gpio";
 			gpio-controller;
 			#gpio-cells = <2>;
-			ngpios = <5>;
+			ngpios = <6>;
 			status = "okay";
 
 			pwr_led: axp192_gpio1 {
@@ -176,9 +176,16 @@
 			bus_pwr_en: axp192_gpio0 {
 				gpio-hog;
 				gpios = <0 0>;
-				input;
+				output-high;
+				line-name = "bus_pwr_en";
 			};
 		};
+	};
+
+	bus_5v: bus_5v {
+		compatible = "regulator-fixed";
+		regulator-name = "bus_5v";
+		enable-gpios = <&axp192_gpio 5 GPIO_ACTIVE_HIGH>;
 	};
 
 	ft5336_touch: ft5336@38 {

--- a/drivers/gpio/gpio_axp192.c
+++ b/drivers/gpio/gpio_axp192.c
@@ -75,8 +75,7 @@ static int gpio_axp192_port_clear_bits_raw(const struct device *dev, gpio_port_p
 	return gpio_axp192_port_set_masked_raw(dev, pins, 0);
 }
 
-static int gpio_axp192_configure(const struct device *dev, gpio_pin_t pin,
-					gpio_flags_t flags)
+static int gpio_axp192_configure(const struct device *dev, gpio_pin_t pin, gpio_flags_t flags)
 {
 	const struct gpio_axp192_config *config = dev->config;
 	int ret;

--- a/drivers/mfd/mfd_axp192.c
+++ b/drivers/mfd/mfd_axp192.c
@@ -22,13 +22,14 @@ LOG_MODULE_REGISTER(mfd_axp192, CONFIG_MFD_LOG_LEVEL);
 #define AXP192_REG_CHIP_ID 0x03U
 
 /* AXP192 GPIO register addresses */
-#define AXP192_GPIO0_REG_FUNC       0x90U
-#define AXP192_GPIO1_REG_FUNC       0x92U
-#define AXP192_GPIO2_REG_FUNC       0x93U
-#define AXP192_GPIO34_REG_FUNC      0x95U
-#define AXP192_GPIO012_REG_PINVAL   0x94U
-#define AXP192_GPIO34_REG_PINVAL    0x96U
-#define AXP192_GPIO012_REG_PULLDOWN 0x97U
+#define AXP192_VBUS_CFG_REG            0x30U
+#define AXP192_GPIO0_FUNC_REG          0x90U
+#define AXP192_GPIO1_FUNC_REG          0x92U
+#define AXP192_GPIO2_FUNC_REG          0x93U
+#define AXP192_GPIO34_FUNC_REG         0x95U
+#define AXP192_GPIO012_PINVAL_REG      0x94U
+#define AXP192_GPIO34_PINVAL_REG       0x96U
+#define AXP192_GPIO012_PULLDOWN_REG    0x97U
 
 /* GPIO function control parameters */
 #define AXP192_GPIO012_FUNC_VAL_OUTPUT_OD  0x00U
@@ -58,6 +59,9 @@ LOG_MODULE_REGISTER(mfd_axp192, CONFIG_MFD_LOG_LEVEL);
 	(AXP192_GPIO34_FUNC_ENA | AXP192_GPIO4_FUNC_VAL_CHARGE_CTL |                               \
 	 AXP192_GPIO4_FUNC_VAL_OUTPUT_OD | AXP192_GPIO4_FUNC_VAL_INPUT)
 
+#define AXP192_EXTEN_ENA  0x04U
+#define AXP192_EXTEN_MASK 0x04U
+
 /* Pull-Down enable parameters */
 #define AXP192_GPIO0_PULLDOWN_ENABLE 0x01U
 #define AXP192_GPIO1_PULLDOWN_ENABLE 0x02U
@@ -84,6 +88,9 @@ LOG_MODULE_REGISTER(mfd_axp192, CONFIG_MFD_LOG_LEVEL);
 #define AXP192_GPIO4_OUTPUT_VAL   0x02U
 #define AXP192_GPIO34_OUTPUT_MASK (AXP192_GPIO3_OUTPUT_VAL | AXP192_GPIO4_OUTPUT_VAL)
 
+#define AXP192_GPIO5_OUTPUT_MASK  0x04U
+#define AXP192_GPIO5_OUTPUT_VAL   0x04U
+#define AXP192_GPIO5_OUTPUT_SHIFT 3U
 struct mfd_axp192_config {
 	struct i2c_dt_spec i2c;
 };
@@ -101,27 +108,27 @@ struct mfd_axp192_func_reg_desc {
 const struct mfd_axp192_func_reg_desc gpio_reg_desc[AXP192_GPIO_MAX_NUM] = {
 	{
 		/* GPIO0 */
-		.reg = AXP192_GPIO0_REG_FUNC,
+		.reg = AXP192_GPIO0_FUNC_REG,
 		.mask = AXP192_GPIO012_FUNC_MASK,
 	},
 	{
 		/* GPIO1 */
-		.reg = AXP192_GPIO1_REG_FUNC,
+		.reg = AXP192_GPIO1_FUNC_REG,
 		.mask = AXP192_GPIO012_FUNC_MASK,
 	},
 	{
 		/* GPIO2 */
-		.reg = AXP192_GPIO2_REG_FUNC,
+		.reg = AXP192_GPIO2_FUNC_REG,
 		.mask = AXP192_GPIO012_FUNC_MASK,
 	},
 	{
 		/* GPIO3 */
-		.reg = AXP192_GPIO34_REG_FUNC,
+		.reg = AXP192_GPIO34_FUNC_REG,
 		.mask = AXP192_GPIO3_FUNC_MASK,
 	},
 	{
 		/* GPIO4 */
-		.reg = AXP192_GPIO34_REG_FUNC,
+		.reg = AXP192_GPIO34_FUNC_REG,
 		.mask = AXP192_GPIO4_FUNC_MASK,
 	},
 };
@@ -144,7 +151,6 @@ static int mfd_axp192_init(const struct device *dev)
 	if (ret < 0) {
 		return ret;
 	}
-
 	if (chip_id != AXP192_CHIP_ID) {
 		LOG_ERR("Invalid Chip detected (%d)", chip_id);
 		return -EINVAL;
@@ -164,9 +170,11 @@ int mfd_axp192_gpio_func_get(const struct device *dev, uint8_t gpio, enum axp192
 		return -EINVAL;
 	}
 
-	ret = i2c_reg_read_byte_dt(&(config->i2c), gpio_reg_desc[gpio].reg, &reg_fnc);
-	if (ret != 0) {
-		return ret;
+	if (gpio < ARRAY_SIZE(gpio_reg_desc)) {
+		ret = i2c_reg_read_byte_dt(&(config->i2c), gpio_reg_desc[gpio].reg, &reg_fnc);
+		if (ret != 0) {
+			return ret;
+		}
 	}
 
 	switch (gpio) {
@@ -245,6 +253,11 @@ int mfd_axp192_gpio_func_get(const struct device *dev, uint8_t gpio, enum axp192
 		}
 		break;
 
+	case 5U:
+		/* EXTEN is an output only pin */
+		*func = AXP192_GPIO_FUNC_OUTPUT_LOW;
+		break;
+
 	default:
 		ret = -EINVAL;
 	}
@@ -259,7 +272,7 @@ int mfd_axp192_gpio_func_ctrl(const struct device *dev, const struct device *cli
 	struct mfd_axp192_data *data = dev->data;
 	bool is_output = false;
 	int ret = 0;
-	uint8_t reg_cfg;
+	uint8_t reg_cfg = 0;
 
 	if (!AXP192_GPIO_FUNC_VALID(func)) {
 		LOG_ERR("Invalid function");
@@ -355,18 +368,25 @@ int mfd_axp192_gpio_func_ctrl(const struct device *dev, const struct device *cli
 		}
 		break;
 
+	case 5U:
+		/* EXTEN is an output only pin */
+		break;
+
 	default:
 		ret = -EINVAL;
 	}
+
 	if (ret != 0) {
 		LOG_ERR("Invalid function (0x%x) for gpio %d", func, gpio);
 		return ret;
 	}
 
-	ret = i2c_reg_update_byte_dt(&(config->i2c), gpio_reg_desc[gpio].reg,
-				     gpio_reg_desc[gpio].mask, reg_cfg);
-	if (ret != 0) {
-		return ret;
+	if (gpio < ARRAY_SIZE(gpio_reg_desc)) {
+		ret = i2c_reg_update_byte_dt(&(config->i2c), gpio_reg_desc[gpio].reg,
+					     gpio_reg_desc[gpio].mask, reg_cfg);
+		if (ret != 0) {
+			return ret;
+		}
 	}
 
 	/* Save gpio configuration state */
@@ -412,7 +432,7 @@ int mfd_axp192_gpio_pd_get(const struct device *dev, uint8_t gpio, bool *enabled
 		return -EINVAL;
 	}
 
-	ret = i2c_reg_read_byte_dt(&(config->i2c), AXP192_GPIO012_REG_PULLDOWN, &gpio_val);
+	ret = i2c_reg_read_byte_dt(&(config->i2c), AXP192_GPIO012_PULLDOWN_REG, &gpio_val);
 
 	if (ret == 0) {
 		*enabled = ((gpio_val & pd_reg_mask) != 0);
@@ -465,7 +485,7 @@ int mfd_axp192_gpio_pd_ctrl(const struct device *dev, uint8_t gpio, bool enable)
 		return -EINVAL;
 	}
 
-	ret = i2c_reg_update_byte_dt(&(config->i2c), AXP192_GPIO012_REG_PULLDOWN, reg_pd_mask,
+	ret = i2c_reg_update_byte_dt(&(config->i2c), AXP192_GPIO012_PULLDOWN_REG, reg_pd_mask,
 				     reg_pd_val);
 
 	return ret;
@@ -478,22 +498,31 @@ int mfd_axp192_gpio_read_port(const struct device *dev, uint8_t *value)
 	int ret;
 	uint8_t gpio012_val;
 	uint8_t gpio34_val;
+	uint8_t gpio5_val;
 	uint8_t gpio_input_val;
 	uint8_t gpio_output_val;
 
 	/* read gpio0-2 */
-	ret = i2c_reg_read_byte_dt(&(config->i2c), AXP192_GPIO012_REG_PINVAL, &gpio012_val);
+	ret = i2c_reg_read_byte_dt(&(config->i2c), AXP192_GPIO012_PINVAL_REG, &gpio012_val);
 	if (ret != 0) {
 		return ret;
 	}
 
 	/* read gpio3-4 */
-	ret = i2c_reg_read_byte_dt(&(config->i2c), AXP192_GPIO34_REG_PINVAL, &gpio34_val);
+	ret = i2c_reg_read_byte_dt(&(config->i2c), AXP192_GPIO34_PINVAL_REG, &gpio34_val);
 	if (ret != 0) {
 		return ret;
 	}
+
+	/* read gpio5 */
+	ret = i2c_reg_read_byte_dt(&(config->i2c), AXP192_EXTEN_DCDC2_CONTROL_REG, &gpio5_val);
+	if (ret != 0) {
+		return ret;
+	}
+
 	LOG_DBG("GPIO012 pinval-reg=0x%x", gpio012_val);
 	LOG_DBG("GPIO34 pinval-reg =0x%x", gpio34_val);
+	LOG_DBG("GPIO5 pinval-reg =0x%x", gpio5_val);
 	LOG_DBG("Output-Mask       =0x%x", data->gpio_mask_output);
 
 	gpio_input_val =
@@ -503,6 +532,8 @@ int mfd_axp192_gpio_read_port(const struct device *dev, uint8_t *value)
 
 	gpio_output_val = (gpio012_val & AXP192_GPIO012_OUTPUT_MASK);
 	gpio_output_val |= ((gpio34_val & AXP192_GPIO34_OUTPUT_MASK) << 3u);
+	gpio_output_val |=
+		(((gpio5_val & AXP192_GPIO5_OUTPUT_MASK) >> AXP192_GPIO5_OUTPUT_SHIFT) << 5u);
 
 	*value = gpio_input_val & ~(data->gpio_mask_output);
 	*value |= (gpio_output_val & data->gpio_mask_output);
@@ -519,9 +550,9 @@ int mfd_axp192_gpio_write_port(const struct device *dev, uint8_t value, uint8_t 
 
 	/* Write gpio0-2. Mask out other port pins */
 	gpio_reg_val = (value & AXP192_GPIO012_OUTPUT_MASK);
-	gpio_reg_mask = mask & AXP192_GPIO012_OUTPUT_MASK;
+	gpio_reg_mask = (mask & AXP192_GPIO012_OUTPUT_MASK);
 	if (gpio_reg_mask != 0) {
-		ret = i2c_reg_update_byte_dt(&(config->i2c), AXP192_GPIO012_REG_PINVAL,
+		ret = i2c_reg_update_byte_dt(&(config->i2c), AXP192_GPIO012_PINVAL_REG,
 					     gpio_reg_mask, gpio_reg_val);
 		if (ret != 0) {
 			return ret;
@@ -533,12 +564,24 @@ int mfd_axp192_gpio_write_port(const struct device *dev, uint8_t value, uint8_t 
 	gpio_reg_val = value >> 3U;
 	gpio_reg_mask = (mask >> 3U) & AXP192_GPIO34_OUTPUT_MASK;
 	if (gpio_reg_mask != 0) {
-		ret = i2c_reg_update_byte_dt(&(config->i2c), AXP192_GPIO34_REG_PINVAL,
+		ret = i2c_reg_update_byte_dt(&(config->i2c), AXP192_GPIO34_PINVAL_REG,
 					     gpio_reg_mask, gpio_reg_val);
 		if (ret != 0) {
 			return ret;
 		}
 		LOG_DBG("GPIO34 pinval-reg =0x%x mask=0x%x", gpio_reg_val, gpio_reg_mask);
+	}
+
+	/* Write gpio5. Mask out other port pins */
+	if ((mask & BIT(5)) != 0) {
+		gpio_reg_mask = AXP192_EXTEN_MASK;
+		gpio_reg_val = (value & BIT(5)) ? AXP192_EXTEN_ENA : 0U;
+		ret = i2c_reg_update_byte_dt(&(config->i2c), AXP192_EXTEN_DCDC2_CONTROL_REG,
+					     gpio_reg_mask, gpio_reg_val);
+		if (ret != 0) {
+			return ret;
+		}
+		LOG_DBG("GPIO5 pinval-reg =0x%x mask=0x%x\n", gpio_reg_val, gpio_reg_mask);
 	}
 
 	return 0;

--- a/drivers/regulator/regulator_axp192.c
+++ b/drivers/regulator/regulator_axp192.c
@@ -84,9 +84,9 @@ static const struct linear_range dcdc2_ranges[] = {
 };
 
 static const struct regulator_axp192_desc dcdc2_desc = {
-	.enable_reg = AXP192_REG_DCDC123_LDO23_CONTROL,
-	.enable_mask = 0x10U,
-	.enable_val = 0x10U,
+	.enable_reg = AXP192_REG_EXTEN_DCDC2_CONTROL,
+	.enable_mask = 0x01U,
+	.enable_val = 0x01U,
 	.vsel_reg = AXP192_REG_DCDC2_VOLTAGE,
 	.vsel_mask = 0x3FU,
 	.vsel_bitpos = 0U,

--- a/dts/bindings/gpio/x-powers,axp192-gpio.yaml
+++ b/dts/bindings/gpio/x-powers,axp192-gpio.yaml
@@ -1,7 +1,18 @@
 # Copyright (c) 2023 Martin Kiepfer
 # SPDX-License-Identifier: Apache-2.0
 
-description: PXA192 GPIO Controller
+description: AXP192 GPIO Controller
+
+  AX192 features 5 native GPIOs. In addition the EXTEN pin can be configured
+  to be used as an IO as well.
+
+  Pin-Mapping is as follows
+    [0] GPIO0
+    [1] GPIO1
+    [2] GPIO2
+    [3] GPIO3
+    [4] GPIO4
+    [5] EXTEN
 
 compatible: "x-powers,axp192-gpio"
 
@@ -13,7 +24,7 @@ properties:
 
   ngpios:
     required: true
-    const: 5
+    const: 6
     description: |
       Number of GPIOs available on axp192.
 

--- a/dts/bindings/mfd/x-powers,axp192.yaml
+++ b/dts/bindings/mfd/x-powers,axp192.yaml
@@ -10,3 +10,12 @@ include: i2c-device.yaml
 properties:
   reg:
     required: true
+
+  vbusen-disable:
+    type: boolean
+    description: |
+      This option will disable VBUS power control via N_VBUSEN.
+      By default VBUS power supply is chosen via N_VBUSEN pin.
+      When disabled, VBUS can by chosen automatically by the pmic
+      and there is no need by the host to control N_VBUSEN pin.
+      Please refer to datasheet for details (pin state (REG10H[7] = 1).

--- a/include/zephyr/drivers/mfd/axp192.h
+++ b/include/zephyr/drivers/mfd/axp192.h
@@ -40,23 +40,35 @@ enum axp192_gpio_func {
 /**
  * @brief Maximum number of GPIOs supported by AXP192 PMIC.
  */
-#define AXP192_GPIO_MAX_NUM 5U
+#define AXP192_GPIO_MAX_NUM 6U
 
 /**
  * @defgroup mdf_interface_axp192 MFD AXP192 interface
+ *
+ * Pins of AXP192 support several different functions. The mfd interface offers
+ * an API to configure and control these different functions.
+ *
+ * The 6 GPIOS are mapped as follows:
+ *  [0]: GPIO0
+ *  [1]: GPIO1
+ *  [2]: GPIO2
+ *  [3]: GPIO3
+ *  [4]: GPIO4
+ *  [5]: EXTEN
+ *
  * @ingroup mfd_interfaces
  * @{
  */
 
 /**
- * @brief Request a GPIO pin to be configured to a specific function. GPIO0..4
+ * @brief Request a GPIO pin to be configured to a specific function. GPIO0..5
  * of AXP192 feature various functions (see @ref axp192_gpio_func for details).
  * A GPIO can only be used by one driver instance. Subsequential calls on the
  * same GPIO will overwrite according function.
  *
  * @param dev axp192 mfd device
  * @param client_dev client device the gpio is used in
- * @param gpio GPIO to be configured (0..4)
+ * @param gpio GPIO to be configured (0..5)
  * @param func Function to be configured (see @ref axp192_gpio_func for details)
  * @retval 0 on success
  * @retval -EINVAL if an invalid GPIO number is passed
@@ -80,7 +92,7 @@ int mfd_axp192_gpio_func_get(const struct device *dev, uint8_t gpio, enum axp192
 
 /**
  * @brief Enable pull-down on specified GPIO pin. AXP192 only supports
- * pull-down on GPIO3..4. Pull-ups are not supprted.
+ * pull-down on GPIO3..5. Pull-ups are not supprted.
  *
  * @param dev axp192 mfd device
  * @param gpio GPIO to control pull-downs

--- a/tests/drivers/build_all/gpio/app.overlay
+++ b/tests/drivers/build_all/gpio/app.overlay
@@ -199,7 +199,7 @@
 					compatible = "x-powers,axp192-gpio";
 					gpio-controller;
 					#gpio-cells = <2>;
-					ngpios = <5>;
+					ngpios = <6>;
 				};
 			};
 		};


### PR DESCRIPTION
This commit fixes [#67277](https://github.com/zephyrproject-rtos/zephyr/issues/67277) and hence adds possibilityto properly utilize grove extension port on M5Stack Core2 module.

5V_BUS can be enabled via regulator bus_5v. By default this regulator is disabled.