### PR TITLE
DNM: samples: hello_world: demonstrate rule A.4 and A.5 issues

### DIFF
--- a/samples/hello_world/src/main.c
+++ b/samples/hello_world/src/main.c
@@ -4,10 +4,28 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/* Ensure that the prototype for gethostname() is visible according to IEEE 1003.1-2017 */
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE < 200112L
+#undef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200112L
+#endif
+
 #include <stdio.h>
+#include <unistd.h>
 
 int main(void)
 {
-	printf("Hello World! %s\n", CONFIG_BOARD);
+	char name[42] = {0};
+
+	/*
+	 * Note: even though the prototype compiles, we currently require CONFIG_NETWORKING=y for
+	 * the application to link successfully.
+	 *
+	 * The issue at hand is that CI warns us that defining _POSIX_C_SOURCE is forbidden
+	 * although that is required by a conformant application.
+	 */
+	(void)gethostname(name, sizeof(name));
+
+	printf("Hello World! %s\n", name);
 	return 0;
 }


### PR DESCRIPTION
This change should not be merged. It is only here to demonstrate that ./scripts/checkpatch.pl requires some refinement due to false positives in its envforcement of Coding Guideline rules A.4 and A.5.

For more information, please see #67283