### PR TITLE
drivers: adc: lmp90xxx: various fixes

### DIFF
--- a/boards/shields/lmp90100_evb/lmp90100_evb.overlay
+++ b/boards/shields/lmp90100_evb/lmp90100_evb.overlay
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
 &arduino_spi {
 	status = "okay";
 

--- a/boards/shields/lmp90100_evb/lmp90100_evb.overlay
+++ b/boards/shields/lmp90100_evb/lmp90100_evb.overlay
@@ -13,7 +13,7 @@
 		spi-max-frequency = <1000000>;
 		/* Uncomment to use IRQ instead of polling: */
 		/* drdyb-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>; */
-		#io-channel-cells = <2>;
+		#io-channel-cells = <1>;
 
 		lmp90100_gpio: gpio {
 			compatible = "ti,lmp90xxx-gpio";

--- a/doc/releases/migration-guide-3.6.rst
+++ b/doc/releases/migration-guide-3.6.rst
@@ -146,6 +146,19 @@ Device Drivers and Device Tree
   * The main Kconfig option was renamed from ``CONFIG_CAN_NATIVE_POSIX_LINUX`` to
     :kconfig:option:`CONFIG_CAN_NATIVE_LINUX`.
 
+* The io-channel cells of the following devicetree bindings were reduced from 2 (``positive`` and
+  ``negative``) to the common ``input``, making it possible to use the various ADC DT macros with TI
+  LMP90xxx ADC devices:
+
+  * :dtcompatible:`ti,lmp90077`
+  * :dtcompatible:`ti,lmp90078`
+  * :dtcompatible:`ti,lmp90079`
+  * :dtcompatible:`ti,lmp90080`
+  * :dtcompatible:`ti,lmp90097`
+  * :dtcompatible:`ti,lmp90098`
+  * :dtcompatible:`ti,lmp90099`
+  * :dtcompatible:`ti,lmp90100`
+
 Power Management
 ================
 

--- a/dts/bindings/adc/ti,lmp90xxx-base.yaml
+++ b/dts/bindings/adc/ti,lmp90xxx-base.yaml
@@ -10,8 +10,7 @@ properties:
     description: Data Ready Bar
 
   "#io-channel-cells":
-    const: 2
+    const: 1
 
 io-channel-cells:
-  - positive
-  - negative
+  - input

--- a/samples/shields/lmp90100_evb/rtd/app.overlay
+++ b/samples/shields/lmp90100_evb/rtd/app.overlay
@@ -1,9 +1,29 @@
 /*
- * Copyright (c) 2019 Vestas Wind Systems A/S
+ * Copyright (c) 2019-2024 Vestas Wind Systems A/S
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	zephyr,user {
+		io-channels = <&lmp90100_lmp90100_evb 0>;
+	};
+};
+
 &lmp90100_lmp90100_evb {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
 	rtd-current = <1000>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_EXTERNAL1";
+		zephyr,acquisition-time = <ADC_ACQ_TIME(ADC_ACQ_TIME_TICKS, 0)>;
+		zephyr,resolution = <24>;
+		zephyr,differential;
+		zephyr,input-positive = <0>;
+		zephyr,input-negative = <1>;
+	};
 };

--- a/tests/drivers/build_all/adc/boards/native_sim.overlay
+++ b/tests/drivers/build_all/adc/boards/native_sim.overlay
@@ -140,7 +140,7 @@
 				reg = <0x1>;
 				spi-max-frequency = <0>;
 				drdyb-gpios = <&test_gpio 0 0>;
-				#io-channel-cells = <2>;
+				#io-channel-cells = <1>;
 			};
 
 			test_spi_lmp90078: lmp90078@2 {
@@ -148,7 +148,7 @@
 				reg = <0x2>;
 				spi-max-frequency = <0>;
 				drdyb-gpios = <&test_gpio 0 0>;
-				#io-channel-cells = <2>;
+				#io-channel-cells = <1>;
 			};
 
 			test_spi_lmp90079: lmp90079@3 {
@@ -156,7 +156,7 @@
 				reg = <0x3>;
 				spi-max-frequency = <0>;
 				drdyb-gpios = <&test_gpio 0 0>;
-				#io-channel-cells = <2>;
+				#io-channel-cells = <1>;
 			};
 
 			test_spi_lmp90080: lmp90080@4 {
@@ -164,7 +164,7 @@
 				reg = <0x4>;
 				spi-max-frequency = <0>;
 				drdyb-gpios = <&test_gpio 0 0>;
-				#io-channel-cells = <2>;
+				#io-channel-cells = <1>;
 			};
 
 			test_spi_lmp90097: lmp90097@5 {
@@ -172,7 +172,7 @@
 				reg = <0x5>;
 				spi-max-frequency = <0>;
 				drdyb-gpios = <&test_gpio 0 0>;
-				#io-channel-cells = <2>;
+				#io-channel-cells = <1>;
 			};
 
 			test_spi_lmp90098: lmp90098@6 {
@@ -180,7 +180,7 @@
 				reg = <0x6>;
 				spi-max-frequency = <0>;
 				drdyb-gpios = <&test_gpio 0 0>;
-				#io-channel-cells = <2>;
+				#io-channel-cells = <1>;
 			};
 
 			test_spi_lmp90099: lmp90099@7 {
@@ -188,7 +188,7 @@
 				reg = <0x7>;
 				spi-max-frequency = <0>;
 				drdyb-gpios = <&test_gpio 0 0>;
-				#io-channel-cells = <2>;
+				#io-channel-cells = <1>;
 			};
 
 			test_spi_lmp90100: lmp90100@8 {
@@ -196,7 +196,7 @@
 				reg = <0x8>;
 				spi-max-frequency = <0>;
 				drdyb-gpios = <&test_gpio 0 0>;
-				#io-channel-cells = <2>;
+				#io-channel-cells = <1>;
 			};
 
 			test_spi_ads7052: ads7052@9 {


### PR DESCRIPTION
This patch series contains various fixes to the TI LMP90xxx ADC driver and the associated `lmp90100_evb` shield:
-  Use the common io-channel-cells name "input" instead of "positive" and "negative" to make this binding work with the various ADC DT macros.
- Include zephyr/dt-bindings/adc/adc.h and zephyr/dt-bindings/gpio/gpio.h in the shield DTS overlays to simplify using this shield in application overlays.
- Convert the RTD sample for the lmp90100_evb shield to use devicetree for configuring the ADC channel.