### PR TITLE
MAINTAINERS.yml: Update the Ambiq platform covered files

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -252,8 +252,10 @@ Ambiq Platforms:
     - soc/arm/ambiq/
     - boards/arm/apollo*/
     - dts/arm/ambiq/
-    - dts/bindings/*/ambiq*
-    - drivers/*/*_ambiq*
+    - dts/bindings/*/ambiq,*
+    - drivers/*/*ambiq*
+    - drivers/*/*/*ambiq*
+    - drivers/*/*/*apollo*
   labels:
     - "platform: Ambiq"
 


### PR DESCRIPTION
Current setting missed some necessary files which should be covered by Ambiq platforms. Add them in this PR.