### PR TITLE
drivers: usb_dc_native_posix: do callback for ZLPs

### DIFF
--- a/drivers/usb/device/usb_dc_native_posix.c
+++ b/drivers/usb/device/usb_dc_native_posix.c
@@ -605,14 +605,8 @@ int handle_usb_data(struct usbip_header *hdr)
 
 		LOG_HEXDUMP_DBG(ep_ctrl->buf, ep_ctrl->buf_len, ">");
 
-		/*
-		 * Call the callback only if data in usb_dc_ep_write()
-		 * is actually written to the intermediate buffer and sent.
-		 */
-		if (ep_ctrl->buf_len != 0) {
-			ep_ctrl->cb(ep, USB_DC_EP_DATA_IN);
-			usbip_ctrl.in_ep_ctrl[ep_idx].buf_len = 0;
-		}
+		ep_ctrl->cb(ep, USB_DC_EP_DATA_IN);
+		ep_ctrl->buf_len = 0;
 	}
 
 	return 0;


### PR DESCRIPTION
A Zero Length Packet can be used by higher layer stack to discover when an endpoint is being processed by the host. An example of this was introduced as part of 0127d000a287 ("usb: device: cdc_acm: Use ZLP to detect initial host read") in the CDC ACM class.

Not invoking the callback for ZLPs results in the higher layer stack not being informed when the packet is consumed. This manifests as a CDC ACM USB-IP device that cannot transmit to the host while being able to receive from the host.