### PR TITLE
dts: npcx: sha: fix the incorrect unit address

### DIFF
--- a/dts/arm/nuvoton/npcx/npcx4.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx4.dtsi
@@ -289,7 +289,7 @@
 			clocks = <&pcc NPCX_CLOCK_BUS_FIU0 NPCX_PWDWN_CTL8 6>;
 		};
 
-		sha0: sha@13c {
+		sha0: sha@148 {
 			compatible = "nuvoton,npcx-sha";
 			reg = <0x148 0x4c>;
 			context-buffer-size = <240>;


### PR DESCRIPTION
Fix the incorrect unit address of sha node from 13C to 148 to avoid the build warning.