### PR TITLE
tests: latency_measure: Adjust recording fields to the new log format

### DIFF
--- a/tests/benchmarks/latency_measure/testcase.yaml
+++ b/tests/benchmarks/latency_measure/testcase.yaml
@@ -16,7 +16,8 @@ tests:
     harness_config:
       type: one_line
       record:
-        regex: "(?P<metric>.*):(?P<cycles>.*) cycles ,(?P<nanoseconds>.*) ns"
+        regex: "(?P<object>.*)\\s(?P<action>[^\\.]*)\\.(?P<details>.*):\
+                (?P<cycles>.*) cycles ,(?P<nanoseconds>.*) ns"
       regex:
         - "PROJECT EXECUTION SUCCESSFUL"
 
@@ -37,7 +38,8 @@ tests:
     harness_config:
       type: one_line
       record:
-        regex: "(?P<metric>.*):(?P<cycles>.*) cycles ,(?P<nanoseconds>.*) ns"
+        regex: "(?P<object>.*)\\s(?P<action>[^\\.]*)\\.(?P<details>.*):\
+                (?P<cycles>.*) cycles ,(?P<nanoseconds>.*) ns"
       regex:
         - "PROJECT EXECUTION SUCCESSFUL"
 
@@ -54,7 +56,8 @@ tests:
     harness_config:
       type: one_line
       record:
-        regex: "(?P<metric>.*):(?P<cycles>.*) cycles ,(?P<nanoseconds>.*) ns"
+        regex: "(?P<object>.*)\\s(?P<action>[^\\.]*)\\.(?P<details>.*):\
+                (?P<cycles>.*) cycles ,(?P<nanoseconds>.*) ns"
       regex:
         - "PROJECT EXECUTION SUCCESSFUL"
 
@@ -71,7 +74,8 @@ tests:
     harness_config:
       type: one_line
       record:
-        regex: "(?P<metric>.*):(?P<cycles>.*) cycles ,(?P<nanoseconds>.*) ns"
+        regex: "(?P<object>.*)\\s(?P<action>[^\\.]*)\\.(?P<details>.*):\
+                (?P<cycles>.*) cycles ,(?P<nanoseconds>.*) ns"
       regex:
         - "PROJECT EXECUTION SUCCESSFUL"
 
@@ -92,7 +96,8 @@ tests:
     harness_config:
       type: one_line
       record:
-        regex: "(?P<metric>.*):(?P<cycles>.*) cycles ,(?P<nanoseconds>.*) ns"
+        regex: "(?P<object>.*)\\s(?P<action>[^\\.]*)\\.(?P<details>.*):\
+                (?P<cycles>.*) cycles ,(?P<nanoseconds>.*) ns"
       regex:
         - "PROJECT EXECUTION SUCCESSFUL"
 
@@ -112,7 +117,8 @@ tests:
     harness_config:
       type: one_line
       record:
-        regex: "(?P<metric>.*):(?P<cycles>.*) cycles ,(?P<nanoseconds>.*) ns"
+        regex: "(?P<object>.*)\\s(?P<action>[^\\.]*)\\.(?P<details>.*):\
+                (?P<cycles>.*) cycles ,(?P<nanoseconds>.*) ns"
       regex:
         - "PROJECT EXECUTION SUCCESSFUL"
 
@@ -130,6 +136,7 @@ tests:
     harness_config:
       type: one_line
       record:
-        regex: "(?P<metric>.*):(?P<cycles>.*) cycles ,(?P<nanoseconds>.*) ns"
+        regex: "(?P<object>.*)\\s(?P<action>[^\\.]*)\\.(?P<details>.*):\
+                (?P<cycles>.*) cycles ,(?P<nanoseconds>.*) ns"
       regex:
         - "PROJECT EXECUTION SUCCESSFUL"


### PR DESCRIPTION
Adjust latency_benchmark recording entries to the new log format (introduced with 8044210) where each logging entry is:

 `<object> <action>.<brief details>:<cycles>,<nanoseconds>:`

so instead of 3 datafields:

 `metric`,`cycles`,`nanoseconds`

it will be recorded as 5 data fields:

 `object`,`action`,`details`,`cycles`,`nanoseconds`

Related to:
#67180 
#67254 