### PR TITLE
shell: shell_uart: improve macro compatibility with previous version

### DIFF
--- a/doc/releases/migration-guide-3.6.rst
+++ b/doc/releases/migration-guide-3.6.rst
@@ -184,6 +184,10 @@ Shell
   * :kconfig:option:`CONFIG_W1_SHELL`
   * :kconfig:option:`CONFIG_WDT_SHELL`
 
+* The ``SHELL_UART_DEFINE`` macro now only requires a ``_name`` argument. In the meantime, the
+  macro accepts additional arguments (ring buffer TX & RX size arguments) for compatibility with
+  previous Zephyr version, but they are ignored, and will be removed in future release.
+
 Bootloader
 ==========
 

--- a/include/zephyr/shell/shell_uart.h
+++ b/include/zephyr/shell/shell_uart.h
@@ -81,7 +81,13 @@ struct shell_uart_polling {
 #define SHELL_UART_STRUCT struct shell_uart_int_driven
 #endif
 
-#define SHELL_UART_DEFINE(_name)                                                                   \
+/**
+ * @brief Macro for creating shell UART transport instance named @p _name
+ *
+ * @note Additional arguments are accepted (but ignored) for compatibility with
+ * previous Zephyr version, it will be removed in future release.
+ */
+#define SHELL_UART_DEFINE(_name, ...)                                                              \
 	static SHELL_UART_STRUCT _name##_shell_uart;                                               \
 	struct shell_transport _name = {                                                           \
 		.api = &shell_uart_transport_api,                                                  \


### PR DESCRIPTION
The `SHELL_UART_DEFINE` macro was previously `SHELL_UART_DEFINE(_name, _tx_ringbuf_size, _rx_ringbuf_size)`, before it got removed in #63967 and then reinstated in #66218 as `SHELL_UART_DEFINE(_name)`.

However its current form isn't compatible with previous Zephyr version, and would cause compilation error when an application migrates to v3.6, let's modify it to accept variable arguments for now.

This commit also restored the brief documentation for this public API.