### PR TITLE
drivers:intc_plic: fix plic PLIC_TRIG_LEVEL define mistake

### DIFF
--- a/drivers/interrupt_controller/intc_plic.c
+++ b/drivers/interrupt_controller/intc_plic.c
@@ -43,8 +43,8 @@
  * However, it is defined and supported by at least the Andes & Telink datasheet, and supported
  * in Linux's SiFive PLIC driver
  */
-#define PLIC_TRIG_LEVEL ((uint32_t)~BIT(0))
-#define PLIC_TRIG_EDGE ((uint32_t)BIT(0))
+#define PLIC_TRIG_LEVEL ((uint32_t)0)
+#define PLIC_TRIG_EDGE  ((uint32_t)1)
 #define PLIC_DRV_HAS_COMPAT(compat)                                                                \
 	DT_NODE_HAS_COMPAT(DT_COMPAT_GET_ANY_STATUS_OKAY(DT_DRV_COMPAT), compat)
 


### PR DESCRIPTION
**Describe the bug**
RISCV interrupt-controller PLIC driver each interrupt can entry once, 

because in drivers/interrupt-controller/intc_plic.c  Due to PLIC_TRIG_LEVEL define mistake case that in function plic_irq_handler no clean the claim register, the interrupt always in pending.

**Reason**
when compile c file, the BIT(n) is  `#define BIT(n)  (1UL << (n)`

the PLIC_TRIG_LEVEL is defined to `((uint32_t)~BIT(0))` it equal to 0xfffffffe, not 0

```
	if (trig_val == PLIC_TRIG_LEVEL) {
		sys_write32(local_irq, claim_complete_addr);
	}
```

it will not clean the claim register, and I have printf the PLIC_TRIG_LEVEL, it equal 0xfffffffe.

**Additional context**
In nceplic100 pdf:
http://www.andestech.com/wp-content/uploads/AX45MP-1C-Rev.-5.0.0-Datasheet.pdf
Page 277 say:
These registers are read-only and indicate the configured interrupt trigger type of interrupt sources.
Every interrupt source occupies 1 bit. There are a total of 32 registers, each 32-bit wide, for 1023
interrupt sources. The location of the interrupt trigger type bit for interrupt source n (1 ≤ n ≤ 1023)
can be determined by the following equations

| Value | Meaning |
|----------|--------------|
| 0 | Level-triggered interrupt |
| 1 | Edge-triggered interrupt |