### PR TITLE
llext: add ARCH_HAS_LLEXT_SUPPORT

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -126,6 +126,7 @@ config XTENSA
 	select ARCH_HAS_CODE_DATA_RELOCATION
 	select ARCH_HAS_TIMING_FUNCTIONS
 	select ARCH_MEM_DOMAIN_DATA if USERSPACE
+	select ARCH_HAS_LLEXT_SUPPORT if !SOC_SERIES_S32ZE_R52
 	imply ATOMIC_OPERATIONS_ARCH
 	help
 	  Xtensa architecture
@@ -629,6 +630,12 @@ config ARCH_HAS_SUSPEND_TO_RAM
 
 config ARCH_HAS_STACK_CANARIES_TLS
 	bool
+
+config ARCH_HAS_LLEXT_SUPPORT
+	bool
+	help
+	  When selected, the architecture supports dynamic extension loading
+	  via the llext subsystem.
 
 #
 # Other architecture related options

--- a/arch/arm/core/Kconfig
+++ b/arch/arm/core/Kconfig
@@ -24,6 +24,7 @@ config CPU_CORTEX_M
 	select ARCH_HAS_SUSPEND_TO_RAM
 	select ARCH_HAS_CODE_DATA_RELOCATION
 	select ARCH_SUPPORTS_ROM_START
+	select ARCH_HAS_LLEXT_SUPPORT if !SOC_SERIES_M48X
 	imply XIP
 	help
 	  This option signifies the use of a CPU of the Cortex-M family.
@@ -40,6 +41,7 @@ config CPU_AARCH32_CORTEX_R
 	select ARCH_HAS_NOCACHE_MEMORY_SUPPORT if ARM_MPU && CPU_HAS_ARM_MPU && CPU_HAS_DCACHE
 	select ARCH_SUPPORTS_ROM_START
 	select USE_SWITCH_SUPPORTED
+	select ARCH_HAS_LLEXT_SUPPORT
 	help
 	  This option signifies the use of a CPU of the Cortex-R family.
 

--- a/samples/subsys/llext/shell_loader/sample.yaml
+++ b/samples/subsys/llext/shell_loader/sample.yaml
@@ -1,3 +1,12 @@
+common:
+  tags: llext
+  arch_allow:
+    - arm
+    - xtensa
+  extra_conf_files:
+    - prj.conf
+    - ${ZEPHYR_BASE}/subsys/llext/${ARCH}-overlay.conf # arch-specific MPU disable
+  filter: CONFIG_LLEXT # only run if it was possible to enable LLEXT
 sample:
   description: Loadable extensions with shell sample
   name: Extension loader shell
@@ -5,10 +14,3 @@ tests:
   sample.llext.shell:
     tags: shell llext
     harness: keyboard
-    filter: not CONFIG_CPU_HAS_MMU and not CONFIG_SOC_SERIES_S32ZE_R52
-    arch_allow: arm
-    extra_configs:
-      - CONFIG_ARM_MPU=n
-    # Broken platforms
-    platform_exclude:
-      - nuvoton_pfm_m487 # See #63167

--- a/subsys/llext/Kconfig
+++ b/subsys/llext/Kconfig
@@ -3,6 +3,8 @@
 
 menuconfig LLEXT
 	bool "Linkable loadable extensions"
+	depends on ARCH_HAS_LLEXT_SUPPORT
+	depends on !MMU && !MPU
 	select CACHE_MANAGEMENT if DCACHE
 	help
 	  Enable the linkable loadable extension subsystem

--- a/subsys/llext/arm-overlay.conf
+++ b/subsys/llext/arm-overlay.conf
@@ -1,0 +1,1 @@
+CONFIG_ARM_MPU=n

--- a/subsys/llext/xtensa-overlay.conf
+++ b/subsys/llext/xtensa-overlay.conf
@@ -1,0 +1,1 @@
+# empty file

--- a/tests/subsys/llext/testcase.yaml
+++ b/tests/subsys/llext/testcase.yaml
@@ -1,18 +1,17 @@
 common:
   tags: llext
+  arch_allow:
+    - arm
+    - xtensa
+  extra_conf_files:
+    - prj.conf
+    - ${ZEPHYR_BASE}/subsys/llext/${ARCH}-overlay.conf # arch-specific MPU disable
+  filter: CONFIG_LLEXT # only run if it was possible to enable LLEXT
 tests:
-  llext.simple.arm:
-    filter: not CONFIG_CPU_HAS_MMU and not CONFIG_SOC_SERIES_S32ZE_R52
-    arch_allow: arm
+  llext.simple.readonly:
+    arch_exclude: xtensa # for now
     extra_configs:
-      - CONFIG_ARM_MPU=n
-    # Broken platforms
-    platform_exclude:
-      - nuvoton_pfm_m487 # See #63167
-  llext.simple.xtensa:
-    arch_allow: xtensa
+      - CONFIG_LLEXT_STORAGE_WRITABLE=n
+  llext.simple.writable:
     extra_configs:
       - CONFIG_LLEXT_STORAGE_WRITABLE=y
-    # Broken platforms
-    platform_exclude:
-      - qemu_xtensa_mmu # ELF sections are read-only, and without peek() .text copy isn't executable


### PR DESCRIPTION
The exact list of architectures supporting llext can currently be obtained only by looking at exceptions and test cases. This PR aims to centralize this by defining a new Kconfig bool, `CONFIG_ARCH_HAS_LLEXT_SUPPORT`, and enabling this for the currently supported architectures and exceptions. 

This will allow to more easily add other tests and examples, since the arch-specific code is factored out and reused. Using this capability, the "writable" test has been extended to the ARM platform.