### PR TITLE
ci: do_not_merge: check for dev and arch review labels as well

### DIFF
--- a/.github/workflows/do_not_merge.yml
+++ b/.github/workflows/do_not_merge.yml
@@ -7,12 +7,14 @@ on:
 jobs:
   do-not-merge:
     if: ${{ contains(github.event.*.labels.*.name, 'DNM') ||
-            contains(github.event.*.labels.*.name, 'TSC') }}
+            contains(github.event.*.labels.*.name, 'TSC') ||
+            contains(github.event.*.labels.*.name, 'Architecture Review') ||
+            contains(github.event.*.labels.*.name, 'dev-review') }}
     name: Prevent Merging
     runs-on: ubuntu-22.04
     steps:
       - name: Check for label
         run: |
-          echo "Pull request is labeled as 'DNM' or 'TSC'"
-          echo "This workflow fails so that the pull request cannot be merged"
+          echo "Pull request is labeled as 'DNM', 'TSC', 'Architecture Review' or 'dev-review'."
+          echo "This workflow fails so that the pull request cannot be merged."
           exit 1


### PR DESCRIPTION
Add "Architecture Review" and "dev-review" to the list of labels that block a PR from merging, less chances to merge these before discussion unintentionally.