### PR TITLE
drivers: can: bosch: mcan: use int0 and int1 as interrupt names

### DIFF
--- a/drivers/can/can_mcux_mcan.c
+++ b/drivers/can/can_mcux_mcan.c
@@ -217,17 +217,17 @@ static const struct can_mcan_ops mcux_mcan_ops = {
 									\
 	static void mcux_mcan_irq_config_##n(const struct device *dev)	\
 	{								\
-		IRQ_CONNECT(DT_INST_IRQ_BY_IDX(n, 0, irq),		\
-			    DT_INST_IRQ_BY_IDX(n, 0, priority),		\
+		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(n, int0, irq),		\
+			    DT_INST_IRQ_BY_NAME(n, int0, priority),	\
 			    can_mcan_line_0_isr,			\
 			    DEVICE_DT_INST_GET(n), 0);			\
-		irq_enable(DT_INST_IRQ_BY_IDX(n, 0, irq));		\
+		irq_enable(DT_INST_IRQ_BY_NAME(n, int0, irq));		\
 									\
-		IRQ_CONNECT(DT_INST_IRQ_BY_IDX(n, 1, irq),		\
-			    DT_INST_IRQ_BY_IDX(n, 1, priority),		\
+		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(n, int1, irq),		\
+			    DT_INST_IRQ_BY_NAME(n, int1, priority),	\
 			    can_mcan_line_1_isr,			\
 			    DEVICE_DT_INST_GET(n), 0);			\
-		irq_enable(DT_INST_IRQ_BY_IDX(n, 1, irq));		\
+		irq_enable(DT_INST_IRQ_BY_NAME(n, int1, irq));		\
 	}
 
 DT_INST_FOREACH_STATUS_OKAY(MCUX_MCAN_INIT)

--- a/drivers/can/can_numaker.c
+++ b/drivers/can/can_numaker.c
@@ -249,18 +249,18 @@ static const struct can_mcan_ops can_numaker_ops = {
 									          \
 	static void can_numaker_irq_config_func_##inst(const struct device *dev)  \
 	{                                                                         \
-		IRQ_CONNECT(DT_INST_IRQ_BY_IDX(inst, 0, irq),                     \
-				DT_INST_IRQ_BY_IDX(inst, 0, priority),            \
+		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(inst, int0, irq),                 \
+				DT_INST_IRQ_BY_NAME(inst, int0, priority),        \
 				can_mcan_line_0_isr,                              \
 				DEVICE_DT_INST_GET(inst),                         \
 				0);                                               \
-		irq_enable(DT_INST_IRQ_BY_IDX(inst, 0, irq));                     \
-		IRQ_CONNECT(DT_INST_IRQ_BY_IDX(inst, 1, irq),                     \
-				DT_INST_IRQ_BY_IDX(inst, 1, priority),            \
+		irq_enable(DT_INST_IRQ_BY_NAME(inst, int0, irq));                 \
+		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(inst, int1, irq),                 \
+				DT_INST_IRQ_BY_NAME(inst, int1, priority),        \
 				can_mcan_line_1_isr,                              \
 				DEVICE_DT_INST_GET(inst),                         \
 				0);                                               \
-		irq_enable(DT_INST_IRQ_BY_IDX(inst, 1, irq));                     \
+		irq_enable(DT_INST_IRQ_BY_NAME(inst, int1, irq));                 \
 	}                                                                         \
 										  \
 	static const struct can_numaker_config can_numaker_config_##inst = {      \

--- a/drivers/can/can_numaker.c
+++ b/drivers/can/can_numaker.c
@@ -288,7 +288,7 @@ static const struct can_mcan_ops can_numaker_ops = {
 		CAN_MCAN_DATA_INITIALIZER(&can_numaker_data_ ## inst);            \
                                                                                   \
 	CAN_DEVICE_DT_INST_DEFINE(inst,                                           \
-		&can_numaker_init,                                                \
+		can_numaker_init,                                                 \
 		NULL,                                                             \
 		&can_mcan_data_##inst,                                            \
 		&can_mcan_config_##inst,                                          \

--- a/drivers/can/can_sam.c
+++ b/drivers/can/can_sam.c
@@ -154,14 +154,14 @@ static const struct can_mcan_ops can_sam_ops = {
 static void config_can_##inst##_irq(void)                                                      \
 {                                                                                              \
 	LOG_DBG("Enable CAN##inst## IRQ");                                                     \
-	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(inst, line_0, irq),                                    \
-		    DT_INST_IRQ_BY_NAME(inst, line_0, priority), can_mcan_line_0_isr,          \
+	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(inst, int0, irq),                                      \
+		    DT_INST_IRQ_BY_NAME(inst, int0, priority), can_mcan_line_0_isr,            \
 					DEVICE_DT_INST_GET(inst), 0);                          \
-	irq_enable(DT_INST_IRQ_BY_NAME(inst, line_0, irq));                                    \
-	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(inst, line_1, irq),                                    \
-		    DT_INST_IRQ_BY_NAME(inst, line_1, priority), can_mcan_line_1_isr,          \
+	irq_enable(DT_INST_IRQ_BY_NAME(inst, int0, irq));                                      \
+	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(inst, int1, irq),                                      \
+		    DT_INST_IRQ_BY_NAME(inst, int1, priority), can_mcan_line_1_isr,            \
 					DEVICE_DT_INST_GET(inst), 0);                          \
-	irq_enable(DT_INST_IRQ_BY_NAME(inst, line_1, irq));                                    \
+	irq_enable(DT_INST_IRQ_BY_NAME(inst, int1, irq));                                      \
 }
 
 #define CAN_SAM_CFG_INST(inst)						\

--- a/drivers/can/can_sam0.c
+++ b/drivers/can/can_sam0.c
@@ -199,10 +199,10 @@ static const struct can_mcan_ops can_sam0_ops = {
 static void config_can_##inst##_irq(void)						\
 {											\
 	LOG_DBG("Enable CAN##inst## IRQ");						\
-	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(inst, line_0, irq),				\
-		    DT_INST_IRQ_BY_NAME(inst, line_0, priority), can_sam0_line_x_isr,	\
+	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(inst, int0, irq),				\
+		    DT_INST_IRQ_BY_NAME(inst, int0, priority), can_sam0_line_x_isr,	\
 					DEVICE_DT_INST_GET(inst), 0);			\
-	irq_enable(DT_INST_IRQ_BY_NAME(inst, line_0, irq));				\
+	irq_enable(DT_INST_IRQ_BY_NAME(inst, int0, irq));				\
 }
 
 #define CAN_SAM0_CFG_INST(inst)								\

--- a/drivers/can/can_stm32_fdcan.c
+++ b/drivers/can/can_stm32_fdcan.c
@@ -630,14 +630,14 @@ static const struct can_mcan_ops can_stm32fd_ops = {
 static void config_can_##inst##_irq(void)                                      \
 {                                                                              \
 	LOG_DBG("Enable CAN" #inst " IRQ");                                    \
-	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(inst, line_0, irq),                    \
-		    DT_INST_IRQ_BY_NAME(inst, line_0, priority),               \
+	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(inst, int0, irq),                      \
+		    DT_INST_IRQ_BY_NAME(inst, int0, priority),                 \
 		    can_mcan_line_0_isr, DEVICE_DT_INST_GET(inst), 0);         \
-	irq_enable(DT_INST_IRQ_BY_NAME(inst, line_0, irq));                    \
-	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(inst, line_1, irq),                    \
-		    DT_INST_IRQ_BY_NAME(inst, line_1, priority),               \
+	irq_enable(DT_INST_IRQ_BY_NAME(inst, int0, irq));                      \
+	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(inst, int1, irq),                      \
+		    DT_INST_IRQ_BY_NAME(inst, int1, priority),                 \
 		    can_mcan_line_1_isr, DEVICE_DT_INST_GET(inst), 0);         \
-	irq_enable(DT_INST_IRQ_BY_NAME(inst, line_1, irq));                    \
+	irq_enable(DT_INST_IRQ_BY_NAME(inst, int1, irq));                      \
 }
 
 #define CAN_STM32FD_CFG_INST(inst)					\

--- a/drivers/can/can_stm32h7_fdcan.c
+++ b/drivers/can/can_stm32h7_fdcan.c
@@ -233,14 +233,14 @@ static const struct can_mcan_ops can_stm32h7_ops = {
 	static void stm32h7_mcan_irq_config_##n(void)			    \
 	{								    \
 		LOG_DBG("Enable CAN inst" #n " IRQ");			    \
-		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(n, line_0, irq),	    \
-			DT_INST_IRQ_BY_NAME(n, line_0, priority),	    \
+		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(n, int0, irq),		    \
+			DT_INST_IRQ_BY_NAME(n, int0, priority),		    \
 			can_mcan_line_0_isr, DEVICE_DT_INST_GET(n), 0);	    \
-		irq_enable(DT_INST_IRQ_BY_NAME(n, line_0, irq));	    \
-		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(n, line_1, irq),	    \
-			DT_INST_IRQ_BY_NAME(n, line_1, priority),	    \
+		irq_enable(DT_INST_IRQ_BY_NAME(n, int0, irq));		    \
+		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(n, int1, irq),		    \
+			DT_INST_IRQ_BY_NAME(n, int1, priority),		    \
 			can_mcan_line_1_isr, DEVICE_DT_INST_GET(n), 0);	    \
-		irq_enable(DT_INST_IRQ_BY_NAME(n, line_1, irq));	    \
+		irq_enable(DT_INST_IRQ_BY_NAME(n, int1, irq));		    \
 	}
 
 DT_INST_FOREACH_STATUS_OKAY(CAN_STM32H7_MCAN_INIT)

--- a/dts/arm/atmel/samc21.dtsi
+++ b/dts/arm/atmel/samc21.dtsi
@@ -48,7 +48,7 @@
 			compatible = "atmel,sam0-can";
 			reg = <0x42001c00 0x100>;
 			interrupts = <15 0>;
-			interrupt-names = "LINE_0";
+			interrupt-names = "int0";
 			clocks = <&gclk 26>, <&mclk 0x10 8>;
 			clock-names = "GCLK", "MCLK";
 			bosch,mram-cfg = <0x0 28 8 3 3 0 1 1>;
@@ -62,7 +62,7 @@
 			compatible = "atmel,sam0-can";
 			reg = <0x42002000 0x100>;
 			interrupts = <16 0>;
-			interrupt-names = "LINE_0";
+			interrupt-names = "int0";
 			clocks = <&gclk 27>, <&mclk 0x10 9>;
 			clock-names = "GCLK", "MCLK";
 			bosch,mram-cfg = <0x0 28 8 3 3 0 1 1>;

--- a/dts/arm/atmel/same5x.dtsi
+++ b/dts/arm/atmel/same5x.dtsi
@@ -31,7 +31,7 @@
 			compatible = "atmel,sam0-can";
 			reg = <0x42000000 0x400>;
 			interrupts = <78 0>, <78 0>;
-			interrupt-names = "LINE_0", "LINE_1";
+			interrupt-names = "int0", "int1";
 			clocks = <&gclk 27>, <&mclk 0x10 17>;
 			clock-names = "GCLK", "MCLK";
 			bosch,mram-cfg = <0x0 128 64 64 64 64 32 32>;
@@ -45,7 +45,7 @@
 			compatible = "atmel,sam0-can";
 			reg = <0x42000400 0x400>;
 			interrupts = <79 0>, <79 0>;
-			interrupt-names = "LINE_0", "LINE_1";
+			interrupt-names = "int0", "int1";
 			clocks = <&gclk 28>, <&mclk 0x10 18>;
 			clock-names = "GCLK", "MCLK";
 			bosch,mram-cfg = <0x0 128 64 64 64 64 32 32>;

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -422,7 +422,7 @@
 			compatible = "atmel,sam-can";
 			reg = <0x40030000 0x100>;
 			interrupts = <35 0>, <36 0>;
-			interrupt-names = "LINE_0", "LINE_1";
+			interrupt-names = "int0", "int1";
 			clocks = <&pmc PMC_TYPE_PERIPHERAL 35>;
 			divider = <6>;
 			bosch,mram-cfg = <0x0 28 8 3 3 0 1 1>;
@@ -435,7 +435,7 @@
 			compatible = "atmel,sam-can";
 			reg = <0x40034000 0x100>;
 			interrupts = <37 0>, <38 0>;
-			interrupt-names = "LINE_0", "LINE_1";
+			interrupt-names = "int0", "int1";
 			clocks = <&pmc PMC_TYPE_PERIPHERAL 37>;
 			divider = <6>;
 			bosch,mram-cfg = <0x0 28 8 3 3 0 1 1>;

--- a/dts/arm/nuvoton/m46x.dtsi
+++ b/dts/arm/nuvoton/m46x.dtsi
@@ -436,7 +436,7 @@
 			reg = <0x40020000 0x200>, <0x40020200 0x1800>;
 			reg-names = "m_can", "message_ram";
 			interrupts = <112 0>, <113 0>;
-			interrupt-names = "LINE_0", "LINE_1";
+			interrupt-names = "int0", "int1";
 			resets = <&rst NUMAKER_CANFD0_RST>;
 			clocks = <&pcc NUMAKER_CANFD0_MODULE
 				  NUMAKER_CLK_CLKSEL0_CANFD0SEL_HCLK
@@ -452,7 +452,7 @@
 			reg = <0x40024000 0x200>, <0x40024200 0x1800>;
 			reg-names = "m_can", "message_ram";
 			interrupts = <114 0>, <115 0>;
-			interrupt-names = "LINE_0", "LINE_1";
+			interrupt-names = "int0", "int1";
 			resets = <&rst NUMAKER_CANFD1_RST>;
 			clocks = <&pcc NUMAKER_CANFD1_MODULE
 				  NUMAKER_CLK_CLKSEL0_CANFD1SEL_HCLK
@@ -468,7 +468,7 @@
 			reg = <0x40028000 0x200>, <0x40028200 0x1800>;
 			reg-names = "m_can", "message_ram";
 			interrupts = <120 0>, <121 0>;
-			interrupt-names = "LINE_0", "LINE_1";
+			interrupt-names = "int0", "int1";
 			resets = <&rst NUMAKER_CANFD2_RST>;
 			clocks = <&pcc NUMAKER_CANFD2_MODULE
 				  NUMAKER_CLK_CLKSEL0_CANFD2SEL_HCLK
@@ -484,7 +484,7 @@
 			reg = <0x4002c000 0x200>, <0x4002c200 0x1800>;
 			reg-names = "m_can", "message_ram";
 			interrupts = <122 0>, <123 0>;
-			interrupt-names = "LINE_0", "LINE_1";
+			interrupt-names = "int0", "int1";
 			resets = <&rst NUMAKER_CANFD3_RST>;
 			clocks = <&pcc NUMAKER_CANFD3_MODULE
 				  NUMAKER_CLK_CLKSEL0_CANFD3SEL_HCLK

--- a/dts/arm/nxp/nxp_lpc55S0x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S0x_common.dtsi
@@ -220,6 +220,7 @@
 		compatible = "nxp,lpc-mcan";
 		reg = <0x9d000 0x1000>;
 		interrupts = <43 0>, <44 0>;
+		interrupt-names = "int0", "int1";
 		clocks = <&syscon MCUX_MCAN_CLK>;
 		bosch,mram-cfg = <0x0 15 15 8 8 0 15 15>;
 		sample-point = <875>;

--- a/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
@@ -215,6 +215,7 @@
 		compatible = "nxp,lpc-mcan";
 		reg = <0x9d000 0x1000>;
 		interrupts = <43 0>, <44 0>;
+		interrupt-names = "int0", "int1";
 		clocks = <&syscon MCUX_MCAN_CLK>;
 		bosch,mram-cfg = <0x0 15 15 8 8 0 15 15>;
 		sample-point = <875>;

--- a/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
@@ -325,6 +325,7 @@
 		compatible = "nxp,lpc-mcan";
 		reg = <0x4009d000 0x1000>;
 		interrupts = <43 0>, <44 0>;
+		interrupt-names = "int0", "int1";
 		clocks = <&syscon MCUX_MCAN_CLK>;
 		bosch,mram-cfg = <0x0 15 15 8 8 0 15 15>;
 		sample-point = <875>;

--- a/dts/arm/st/g0/stm32g0b1.dtsi
+++ b/dts/arm/st/g0/stm32g0b1.dtsi
@@ -35,7 +35,7 @@
 			reg = <0x40006400 0x400>, <0x4000b400 0x350>;
 			reg-names = "m_can", "message_ram";
 			interrupts = <21 0>, <22 0>;
-			interrupt-names = "LINE_0", "LINE_1";
+			interrupt-names = "int0", "int1";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00001000>;
 			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
 			sample-point = <875>;

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -387,7 +387,7 @@
 			reg = <0x40006400 0x400>, <0x4000a400 0x350>;
 			reg-names = "m_can", "message_ram";
 			interrupts = <21 0>, <22 0>;
-			interrupt-names = "LINE_0", "LINE_1";
+			interrupt-names = "int0", "int1";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
 			sample-point = <875>;

--- a/dts/arm/st/g4/stm32g473.dtsi
+++ b/dts/arm/st/g4/stm32g473.dtsi
@@ -100,7 +100,7 @@
 			reg = <0x40006c00 0x400>, <0x4000a400 0x9f0>;
 			reg-names = "m_can", "message_ram";
 			interrupts = <88 0>, <89 0>;
-			interrupt-names = "LINE_0", "LINE_1";
+			interrupt-names = "int0", "int1";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 			bosch,mram-cfg = <0x6a0 28 8 3 3 0 3 3>;
 			sample-point = <875>;

--- a/dts/arm/st/g4/stm32g491.dtsi
+++ b/dts/arm/st/g4/stm32g491.dtsi
@@ -15,7 +15,7 @@
 			reg = <0x40006800 0x400>, <0x4000a400 0x6a0>;
 			reg-names = "m_can", "message_ram";
 			interrupts = <86 0>, <87 0>;
-			interrupt-names = "LINE_0", "LINE_1";
+			interrupt-names = "int0", "int1";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 			bosch,mram-cfg = <0x350 28 8 3 3 0 3 3>;
 			sample-point = <875>;

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -438,7 +438,7 @@
 			reg = <0x4000a400 0x400>, <0x4000ac00 0x350>;
 			reg-names = "m_can", "message_ram";
 			interrupts = <39 0>, <40 0>;
-			interrupt-names = "LINE_0", "LINE_1";
+			interrupt-names = "int0", "int1";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000200>;
 			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
 			sample-point = <875>;

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -308,7 +308,7 @@
 			reg = <0x4000a800 0x400>, <0x4000ac00 0x6a0>;
 			reg-names = "m_can", "message_ram";
 			interrupts = <109 0>, <110 0>;
-			interrupt-names = "LINE_0", "LINE_1";
+			interrupt-names = "int0", "int1";
 			/* common clock FDCAN 1 & 2 */
 			clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000200>;
 			bosch,mram-cfg = <0x350 28 8 3 3 0 3 3>;

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -514,7 +514,7 @@
 			reg-names = "m_can", "message_ram";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000100>;
 			interrupts = <19 0>, <21 0>, <63 0>;
-			interrupt-names = "LINE_0", "LINE_1", "CALIB";
+			interrupt-names = "int0", "int1", "calib";
 			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
 			sample-point = <875>;
 			sample-point-data = <875>;
@@ -527,7 +527,7 @@
 			reg-names = "m_can", "message_ram";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000100>;
 			interrupts = <20 0>, <22 0>, <63 0>;
-			interrupt-names = "LINE_0", "LINE_1", "CALIB";
+			interrupt-names = "int0", "int1", "calib";
 			bosch,mram-cfg = <0x350 28 8 3 3 0 3 3>;
 			sample-point = <875>;
 			sample-point-data = <875>;

--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -121,7 +121,7 @@
 			reg-names = "m_can", "message_ram";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000100>;
 			interrupts = <159 0>, <160 0>, <63 0>;
-			interrupt-names = "LINE_0", "LINE_1", "CALIB";
+			interrupt-names = "int0", "int1", "calib";
 			bosch,mram-cfg = <0x6a0 28 8 3 3 0 3 3>;
 			sample-point = <875>;
 			sample-point-data = <875>;

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -798,7 +798,7 @@
 			reg = <0x4000a400 0x400>, <0x4000ac00 0x350>;
 			reg-names = "m_can", "message_ram";
 			interrupts = <39 0>, <40 0>;
-			interrupt-names = "LINE_0", "LINE_1";
+			interrupt-names = "int0", "int1";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000200>;
 			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
 			sample-point = <875>;

--- a/dts/bindings/can/atmel,sam-can.yaml
+++ b/dts/bindings/can/atmel,sam-can.yaml
@@ -13,6 +13,9 @@ properties:
   interrupts:
     required: true
 
+  interrupt-names:
+    required: true
+
   clocks:
     required: true
 

--- a/dts/bindings/can/atmel,sam0-can.yaml
+++ b/dts/bindings/can/atmel,sam0-can.yaml
@@ -13,6 +13,9 @@ properties:
   interrupts:
     required: true
 
+  interrupt-names:
+    required: true
+
   clocks:
     required: true
 

--- a/dts/bindings/can/nuvoton,numaker-canfd.yaml
+++ b/dts/bindings/can/nuvoton,numaker-canfd.yaml
@@ -14,6 +14,9 @@ properties:
   interrupts:
     required: true
 
+  interrupt-names:
+    required: true
+
   resets:
     required: true
 

--- a/dts/bindings/can/nxp,lpc-mcan.yaml
+++ b/dts/bindings/can/nxp,lpc-mcan.yaml
@@ -11,5 +11,8 @@ properties:
   interrupts:
     required: true
 
+  interrupt-names:
+    required: true
+
   clocks:
     required: true

--- a/dts/bindings/can/st,stm32-fdcan.yaml
+++ b/dts/bindings/can/st,stm32-fdcan.yaml
@@ -11,6 +11,9 @@ properties:
   interrupts:
     required: true
 
+  interrupt-names:
+    required: true
+
   clocks:
     required: true
 

--- a/dts/bindings/can/st,stm32h7-fdcan.yaml
+++ b/dts/bindings/can/st,stm32h7-fdcan.yaml
@@ -13,3 +13,6 @@ properties:
 
   interrupts:
     required: true
+
+  interrupt-names:
+    required: true


### PR DESCRIPTION
- Consistently use "int0" and "int1" as interrupt names for CAN controllers based on the Bosch M_CAN IP core. This aligns with the upstream Linux bindings (https://elixir.bootlin.com/linux/latest/source/Documentation/devicetree/bindings/net/can/bosch,m_can.yaml).
- Switch to using named IRQs for the Nuvoton Numaker and NXP LPC MCAN frontends, as index-based access makes no guarantees about devicetree interrupt order.
- Make the "interrupt-names" property mandatory for drivers using named IRQs.