### PR TITLE
drivers: i2s_nrfx: Support less than block size writes

### DIFF
--- a/modules/hal_nordic/nrfx/nrfx_config_common.h
+++ b/modules/hal_nordic/nrfx/nrfx_config_common.h
@@ -18,7 +18,7 @@
 
 /** @brief Symbol specifying minor version of the nrfx API to be used. */
 #ifndef NRFX_CONFIG_API_VER_MINOR
-#define NRFX_CONFIG_API_VER_MINOR 2
+#define NRFX_CONFIG_API_VER_MINOR 3
 #endif
 
 /** @brief Symbol specifying micro version of the nrfx API to be used. */


### PR DESCRIPTION
Calling I2S write with less bytes than I2S TX memory block size makes it possible to synchronize the time when next block is used against some other, possibly externally sourced, signal. Example use case includes USB Audio where audio sink and/or source has to be synchronized USB SOF. In Asynchronous synchronization type the rate matching is achieved by varying the number of samples sent/received by 1 sample (e.g. for 48 kHz audio, 47 or 49 samples are transmitted during frame instead of 48).