### PR TITLE
drivers: mdio: nxp_enet: Fix "expected statement" clangsa error

### DIFF
--- a/drivers/mdio/mdio_nxp_enet.c
+++ b/drivers/mdio/mdio_nxp_enet.c
@@ -243,6 +243,7 @@ void nxp_enet_mdio_callback(const struct device *dev,
 		data->interrupt_up = true;
 		break;
 	default:
+		break;
 	}
 }
 


### PR DESCRIPTION
`clangsa` reports the error:

```
mdio_nxp_enet.c:245:10: error: label at end of compound statement: expected statement
```