### PR TITLE
Bluetooth: CSIP: Add bt_csip_set_member_unregister

### DIFF
--- a/include/zephyr/bluetooth/audio/csip.h
+++ b/include/zephyr/bluetooth/audio/csip.h
@@ -187,6 +187,17 @@ int bt_csip_set_member_register(const struct bt_csip_set_member_register_param *
 				struct bt_csip_set_member_svc_inst **svc_inst);
 
 /**
+ * @brief Unregister a Coordinated Set Identification Service instance.
+ *
+ * This will unregister and disable the service instance.
+ *
+ * @param svc_inst  Pointer to the registered Coordinated Set Identification Service.
+ *
+ * @return 0 if success, errno on failure.
+ */
+int bt_csip_set_member_unregister(struct bt_csip_set_member_svc_inst *svc_inst);
+
+/**
  * @brief Print the SIRK to the debug output
  *
  * @param svc_inst   Pointer to the Coordinated Set Identification Service.

--- a/subsys/bluetooth/audio/cap_acceptor.c
+++ b/subsys/bluetooth/audio/cap_acceptor.c
@@ -50,7 +50,15 @@ int bt_cap_acceptor_register(const struct bt_csip_set_member_register_param *par
 
 	err = bt_gatt_service_register(&cas);
 	if (err) {
+		const int csip_err = bt_csip_set_member_unregister(*svc_inst);
+
+		if (csip_err) {
+			LOG_ERR("Failed to unregister CSIS: %d", csip_err);
+		}
+
+		cas.attrs[1].user_data = NULL;
 		LOG_DBG("Failed to register CAS");
+
 		return err;
 	}
 

--- a/subsys/bluetooth/audio/csip_set_member.c
+++ b/subsys/bluetooth/audio/csip_set_member.c
@@ -144,9 +144,13 @@ static int notify_lock_value(const struct bt_csip_set_member_svc_inst *svc_inst,
 			      struct bt_conn *conn)
 {
 	LOG_DBG("");
-	return csip_gatt_notify_set_lock(conn, svc_inst->service_p->attrs,
-					 &svc_inst->set_lock,
-					 sizeof(svc_inst->set_lock));
+
+	if (svc_inst->service_p != NULL) {
+		return csip_gatt_notify_set_lock(conn, svc_inst->service_p->attrs,
+						 &svc_inst->set_lock, sizeof(svc_inst->set_lock));
+	} else {
+		return -EINVAL;
+	}
 }
 
 static void notify_client(struct bt_conn *conn, void *data)
@@ -723,6 +727,10 @@ BT_GATT_SERVICE_INSTANCE_DEFINE(csip_set_member_service_list, svc_insts,
 /****************************** Public API ******************************/
 void *bt_csip_set_member_svc_decl_get(const struct bt_csip_set_member_svc_inst *svc_inst)
 {
+	if (svc_inst == NULL || svc_inst->service_p == NULL) {
+		return NULL;
+	}
+
 	return svc_inst->service_p->attrs;
 }
 
@@ -937,6 +945,27 @@ int bt_csip_set_member_register(const struct bt_csip_set_member_register_param *
 	}
 
 	*svc_inst = inst;
+	return 0;
+}
+
+int bt_csip_set_member_unregister(struct bt_csip_set_member_svc_inst *svc_inst)
+{
+	int err;
+
+	CHECKIF(svc_inst == NULL) {
+		LOG_DBG("NULL svc_inst");
+		return -EINVAL;
+	}
+
+	err = bt_gatt_service_unregister(svc_inst->service_p);
+	if (err != 0) {
+		LOG_DBG("CSIS service unregister failed: %d", err);
+		return err;
+	}
+
+	(void)k_work_cancel_delayable(&svc_inst->set_lock_timer);
+	memset(svc_inst, 0, sizeof(*svc_inst));
+
 	return 0;
 }
 


### PR DESCRIPTION
Add support for unregistering a CSIS as the CSIP set member.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/64560