### PR TITLE
cmake: enhanced board entry file handling

### DIFF
--- a/cmake/modules/dts.cmake
+++ b/cmake/modules/dts.cmake
@@ -122,9 +122,16 @@ set(DTS_CMAKE                   ${PROJECT_BINARY_DIR}/dts.cmake)
 # modules.
 set(VENDOR_PREFIXES             dts/bindings/vendor-prefixes.txt)
 
-zephyr_build_string(dts_board_string BOARD ${BOARD} BOARD_IDENTIFIER ${BOARD_IDENTIFIER})
+if(NOT DEFINED DTS_SOURCE)
+  zephyr_build_string(dts_board_string BOARD ${BOARD} BOARD_IDENTIFIER ${BOARD_IDENTIFIER} MERGE)
+  foreach(str ${dts_board_string})
+    if(EXISTS ${BOARD_DIR}/${str}.dts)
+      set(DTS_SOURCE ${BOARD_DIR}/${str}.dts)
+      break()
+    endif()
+  endforeach()
+endif()
 
-set_ifndef(DTS_SOURCE ${BOARD_DIR}/${dts_board_string}.dts)
 if(EXISTS ${DTS_SOURCE})
   # We found a devicetree. Check for a board revision overlay.
   if(DEFINED BOARD_REVISION)

--- a/cmake/modules/kconfig.cmake
+++ b/cmake/modules/kconfig.cmake
@@ -74,14 +74,23 @@ else()
   set(KCONFIG_ROOT ${ZEPHYR_BASE}/Kconfig)
 endif()
 
-zephyr_build_string(config_board_string BOARD ${BOARD} BOARD_IDENTIFIER ${BOARD_IDENTIFIER})
-
 if(NOT DEFINED BOARD_DEFCONFIG)
-  set(BOARD_DEFCONFIG ${BOARD_DIR}/${config_board_string}_defconfig)
+  zephyr_file(CONF_FILES ${BOARD_DIR} DEFCONFIG BOARD_DEFCONFIG)
 endif()
-if((DEFINED BOARD_REVISION) AND EXISTS ${BOARD_DIR}/${config_board_string}_${BOARD_REVISION_STRING}.conf)
-  set_ifndef(BOARD_REVISION_CONFIG ${BOARD_DIR}/${config_board_string}_${BOARD_REVISION_STRING}.conf)
+
+if(DEFINED BOARD_REVISION)
+  zephyr_build_string(config_board_string
+                      BOARD ${BOARD}
+                      BOARD_IDENTIFIER ${BOARD_IDENTIFIER}
+                      BOARD_REVISION ${BOARD_REVISION}
+  )
+  set(board_rev_file ${config_board_string})
+  if(EXISTS ${BOARD_DIR}/${board_rev_file}.conf)
+    message(DEPRECATION "Use of '${board_rev_file}.conf' is deprecated, please switch to '${board_rev_file}_defconfig'")
+    set_ifndef(BOARD_REVISION_CONFIG ${BOARD_DIR}/${board_rev_file}.conf)
+  endif()
 endif()
+
 set(DOTCONFIG                  ${PROJECT_BINARY_DIR}/.config)
 set(PARSED_KCONFIG_SOURCES_TXT ${PROJECT_BINARY_DIR}/kconfig/sources.txt)
 


### PR DESCRIPTION
With a single board now covering what used to be several boards, and with the ability to omit SoC when building for a single SoC board, then `<board>_defconfig` and `<board>.dts` lookup is improved.

A single SoC board may prefer to keep its defconfig entry point as `<board>_defconfig` instead of `<board>_<soc>_defconfig`.

Also, a multi-SoC board / multi-core SoC board, which used to be implemented as n-boards may wish to have common `_defconfig` settings in a common `<board>_defconfig` file, and the SoC / cpuset specifics in `<board>_<soc>_defconfig` / `<board>_<soc>_<core>_defconfig`.

Such defconfig support allows also to place build variant specifics in its own `<board>_<soc>_<variant>_defconfig` file.

This commit allows multiple `_defconfigs` for a board and its identifiers.

Similar is implemented for a board's dts file.
If a `<board>_<soc>_<core>.dts` file is not found, the build system will instead use `<board>_<soc>.dts`, and finally fallback to `<board>.dts`.

This allows a board to have a shared dts file for all board identifiers which are identical while still support specific dts where required.

A dts file is a devicetree starting point and thus two dts files cannot be used in together. For such cases, an ordinary board overlay file must be used.