### PR TITLE
west.yml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -282,7 +282,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: e9131ee8b8ab9306d8f6ad410fd1e3d8a820ce10
+      revision: b994ba2ce29425587957dcbb6c96d4e1872b5737
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  b994ba2ce29425587957dcbb6c96d4e1872b5737

Brings following Zephyr relevant fixes:
 - 4d75fc8e bootutil: Fix compatible sector checking
 - 35e9931c bootutil: Add debug logging for boot status write
 - db9a7f58 boot: zephyr: cmake: Fix issue with missing dts entries
 - 8cee3550 zephyr: kconfig: make MBEDTLS_PROMPTLESS depend on MBEDTLS

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.