### PR TITLE
[RFC] Deferred device initialization

### DIFF
--- a/dts/bindings/base/base.yaml
+++ b/dts/bindings/base/base.yaml
@@ -92,3 +92,9 @@ properties:
   mbox-names:
     type: string-array
     description: Provided names of mailbox / IPM channel specifiers
+
+  zephyr,deferred-init:
+    type: boolean
+    description: |
+      Do not initialize device automatically on boot. Device should be manually
+      initialized using device_init().

--- a/include/zephyr/linker/common-rom/common-rom-kernel-devices.ld
+++ b/include/zephyr/linker/common-rom/common-rom-kernel-devices.ld
@@ -18,6 +18,9 @@
 		CREATE_OBJ_LEVEL(init, APPLICATION)
 		CREATE_OBJ_LEVEL(init, SMP)
 		__init_end = .;
+		__deferred_init_list_start = .;
+		KEEP(*(.z_deferred_init))
+		__deferred_init_list_end = .;
 	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
 	ITERABLE_SECTION_ROM_NUMERIC(device, 4)

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -36,6 +36,7 @@
 #include <zephyr/timing/timing.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/pm/device_runtime.h>
+#include <zephyr/internal/syscall_handler.h>
 LOG_MODULE_REGISTER(os, CONFIG_KERNEL_LOG_LEVEL);
 
 BUILD_ASSERT(CONFIG_MP_NUM_CPUS == CONFIG_MP_MAX_NUM_CPUS,
@@ -301,6 +302,37 @@ extern volatile uintptr_t __stack_chk_guard;
 __pinned_bss
 bool z_sys_post_kernel;
 
+static int do_device_init(const struct init_entry *entry)
+{
+	const struct device *dev = entry->dev;
+	int rc = 0;
+
+	if (entry->init_fn.dev != NULL) {
+		rc = entry->init_fn.dev(dev);
+		/* Mark device initialized. If initialization
+		 * failed, record the error condition.
+		 */
+		if (rc != 0) {
+			if (rc < 0) {
+				rc = -rc;
+			}
+			if (rc > UINT8_MAX) {
+				rc = UINT8_MAX;
+			}
+			dev->state->init_res = rc;
+		}
+	}
+
+	dev->state->initialized = true;
+
+	if (rc == 0) {
+		/* Run automatic device runtime enablement */
+		(void)pm_device_runtime_auto_enable(dev);
+	}
+
+	return rc;
+}
+
 /**
  * @brief Execute all the init entry initialization functions at a given level
  *
@@ -332,35 +364,38 @@ static void z_sys_init_run_level(enum init_level level)
 		const struct device *dev = entry->dev;
 
 		if (dev != NULL) {
-			int rc = 0;
-
-			if (entry->init_fn.dev != NULL) {
-				rc = entry->init_fn.dev(dev);
-				/* Mark device initialized. If initialization
-				 * failed, record the error condition.
-				 */
-				if (rc != 0) {
-					if (rc < 0) {
-						rc = -rc;
-					}
-					if (rc > UINT8_MAX) {
-						rc = UINT8_MAX;
-					}
-					dev->state->init_res = rc;
-				}
-			}
-
-			dev->state->initialized = true;
-
-			if (rc == 0) {
-				/* Run automatic device runtime enablement */
-				(void)pm_device_runtime_auto_enable(dev);
-			}
+			do_device_init(entry);
 		} else {
 			(void)entry->init_fn.sys();
 		}
 	}
 }
+
+
+int z_impl_device_init(const struct device *dev)
+{
+	if (dev == NULL) {
+		return -ENOENT;
+	}
+
+	STRUCT_SECTION_FOREACH_ALTERNATE(_deferred_init, init_entry, entry) {
+		if (entry->dev == dev) {
+			return do_device_init(entry);
+		}
+	}
+
+	return -ENOENT;
+}
+
+#ifdef CONFIG_USERSPACE
+static inline int z_vrfy_device_init(const struct device *dev)
+{
+	K_OOPS(K_SYSCALL_OBJ_INIT(dev, K_OBJ_ANY));
+
+	return z_impl_device_init(dev);
+}
+#include <syscalls/device_init_mrsh.c>
+#endif
 
 extern void boot_banner(void);
 

--- a/tests/kernel/device/app.overlay
+++ b/tests/kernel/device/app.overlay
@@ -52,6 +52,20 @@
 		status = "okay";
 	};
 
+	fakedeferdriver@E7000000 {
+		compatible = "fakedeferdriver";
+		reg = <0xE7000000 0x2000>;
+		status = "okay";
+		zephyr,deferred-init;
+	};
+
+	fakedeferdriver@E8000000 {
+		compatible = "fakedeferdriver";
+		reg = <0xE8000000 0x2000>;
+		status = "okay";
+		zephyr,deferred-init;
+	};
+
 	fakedomain_0: fakedomain_0 {
 		compatible = "fakedomain";
 		status = "okay";

--- a/tests/kernel/device/boards/hifive_unmatched.overlay
+++ b/tests/kernel/device/boards/hifive_unmatched.overlay
@@ -49,6 +49,20 @@
 		status = "okay";
 	};
 
+	fakedeferdriver@E7000000 {
+		compatible = "fakedeferdriver";
+		reg = <0x0 0xE7000000 0x0 0x2000>;
+		status = "okay";
+		zephyr,deferred-init;
+	};
+
+	fakedeferdriver@E8000000 {
+		compatible = "fakedeferdriver";
+		reg = <0x0 0xE8000000 0x0 0x2000>;
+		status = "okay";
+		zephyr,deferred-init;
+	};
+
 	fakedomain_0: fakedomain_0 {
 		compatible = "fakedomain";
 		status = "okay";

--- a/tests/kernel/device/dts/bindings/fakedeferdriver.yml
+++ b/tests/kernel/device/dts/bindings/fakedeferdriver.yml
@@ -1,0 +1,8 @@
+# Copyright (c) 2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+description: Properties for fake deferred driver.
+
+compatible: "fakedeferdriver"
+
+include: base.yaml


### PR DESCRIPTION
Following discussions at #64869, this PR implements [Option 1](https://github.com/zephyrproject-rtos/zephyr/issues/39896#issuecomment-1767250893) from #39896.

With this PR, a new devicetree property, `zephyr,deferred-init` can be used to make a device not be initialised during boot. The device can be initialised by calling `device_init()` from the application.

Under the hood, this PR achieves that by grouping the deferred devices intialisation code in a different ELF section. This way, there's no overhead during normal initialisation: neither memory nor processing penalty. Deferred initialisation however loops over the deferred devices and initialises the matching one, incurring some processing penalty, which is hopefully acceptable.

A new test helps showcase the new feature.

### Opens

 - Dependencies are not handled. If a non-deferred device depends on a deferred one, its initialisation will simply fail. We could A) issue warnings/errors during build or B) forcefully make all dependencies also be deferred.
 - Is the processing penalty to initialise a deferred device acceptable? If not, one thing I can think is to expose the initialiser function as non-static and providing a macro to get it and call it directly (think of `DEVICE_INIT(DT_PATH(some_node))`), but this seems way too ugly. Any ideas?
 - This PR doesn't check if a deferred device is initialised more than once - it will simply re-run the code. My reasoning is that Zephyr currently marks a device as initialised if initialisation was _attempted_, not if it _succeeded_. This behaviour is kept for deferred devices for the sake of consistency. But if someone wants to retry initialise some device, checking for attempted initialisation would prevent that.
 - This PR doesn't attempt to tackle the "device de-init" problem - only selective device init.
