### PR TITLE
posix: Adds test for clock_getcpuclockid()

### DIFF
--- a/tests/posix/common/src/clock.c
+++ b/tests/posix/common/src/clock.c
@@ -217,10 +217,11 @@ ZTEST(clock, test_realtime)
 ZTEST(clock, test_clock_getcpuclockid)
 {
 	int ret = 0;
-	clockid_t clock_id;
+	clockid_t clock_id = CLOCK_INVALID;
 
 	ret = clock_getcpuclockid((pid_t)0, &clock_id);
 	zassert_equal(ret, 0, "POSIX clock_getcpuclock id failed");
+	zassert_equal(clock_id, CLOCK_PROCESS_CPUTIME_ID, "POSIX clock_getcpuclock id failed");
 
 	ret = clock_getcpuclockid((pid_t)2482, &clock_id);
 	zassert_equal(ret, EPERM, "POSIX clock_getcpuclock id failed");

--- a/tests/posix/headers/src/unistd_h.c
+++ b/tests/posix/headers/src/unistd_h.c
@@ -342,7 +342,7 @@ ZTEST(posix_headers, test_unistd_h)
 	zassert_not_null(getopt);
 	/* zassert_not_null(getpgid); */ /* not implemented */
 	/* zassert_not_null(getpgrp); */ /* not implemented */
-	/* zassert_not_null(getpid); */ /* not implemented */
+	zassert_not_null(getpid);
 	/* zassert_not_null(getppid); */ /* not implemented */
 	/* zassert_not_null(getsid); */ /* not implemented */
 	/* zassert_not_null(getuid); */ /* not implemented */


### PR DESCRIPTION
Adds test for clock_getcpuclockid() to
make sure clock_id is equal to CLOCK_PROCESS_CPUTIME_ID after a successful call

Adds test to check getpid() function is not NULL

Fixes #59954