### PR TITLE
emul: Add stub `release` impl. for emulated SPI driver

### DIFF
--- a/drivers/spi/spi_emul.c
+++ b/drivers/spi/spi_emul.c
@@ -82,6 +82,18 @@ static int spi_emul_io(const struct device *dev, const struct spi_config *config
 }
 
 /**
+ * @brief This is a no-op stub of the SPI API's `release` method to protect drivers under test
+ *        from hitting a segmentation fault when using SPI_LOCK_ON plus spi_release()
+ */
+static int spi_emul_release(const struct device *dev, const struct spi_config *config)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(config);
+
+	return 0;
+}
+
+/**
  * Set up a new emulator and add it to the list
  *
  * @param dev SPI emulation controller device
@@ -111,6 +123,7 @@ int spi_emul_register(const struct device *dev, struct spi_emul *emul)
 
 static const struct spi_driver_api spi_emul_api = {
 	.transceive = spi_emul_io,
+	.release = spi_emul_release,
 };
 
 #define EMUL_LINK_AND_COMMA(node_id)                                                               \


### PR DESCRIPTION
`release` is a mandatory method in the `struct spi_driver_api` API but is not implemented in the SPI emulator. This can cause a test calling `spi_release()` to segfault. Add a stub implementation that just returns zero.