### PR TITLE
Fix PWM output on nucleo_f042k6 boards

### DIFF
--- a/boards/arm/nucleo_f042k6/nucleo_f042k6.dts
+++ b/boards/arm/nucleo_f042k6/nucleo_f042k6.dts
@@ -30,7 +30,7 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		green_pwm_led: green_pwm_led {
-			pwms = <&pwm3 32 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+			pwms = <&pwm3 3 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
 	};
 
@@ -66,6 +66,7 @@
 
 &timers3 {
 	status = "okay";
+	st,prescaler = <10000>;
 
 	pwm3: pwm {
 		status = "okay";


### PR DESCRIPTION
Changes:
* Fixed typo in the PWM channel number (32 -> 3)
* Added a prescaler to make the board compatible with the blinky_pwm sample

Output of the sample before the fix:
```
PWM-based blinky
Calibrating for channel 32...
[00:00:00.010,000] <err> pwm_stm32: Invalid channel (32)
[00:00:00.016,000] <err> pwm_stm32: Invalid channel (32)
[00:00:00.022,000] <err> pwm_stm32: Invalid channel (32)
[00:00:00.028,000] <err> pwm_stm32: Invalid channel (32)
[00:00:00.034,000] <err> pwm_stm32: Invalid channel (32)
[00:00:00.040,000] <err> pwm_stm32: Invalid channel (32)
Error: PWM device does not support a period at least 31250000
```
After the fix:
```
PWM-based blinky
Calibrating for channel 3...
Done calibrating; maximum/minimum periods 1000000000/7812500 nsec
```
Presence of PWM signal after the fix has been confirmed using a logic analyzer.