### PR TITLE
drivers: spi: spi_nrfx_spi: Conditional SCK pin setup.

### DIFF
--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -90,6 +90,7 @@ static int configure(const struct device *dev,
 	const struct spi_nrfx_config *dev_config = dev->config;
 	struct spi_context *ctx = &dev_data->ctx;
 	nrfx_spi_config_t config;
+	int32_t nrf_sck_pin;
 	nrfx_err_t result;
 
 	if (dev_data->initialized && spi_context_configured(ctx, spi_cfg)) {
@@ -134,8 +135,11 @@ static int configure(const struct device *dev,
 	config.mode      = get_nrf_spi_mode(spi_cfg->operation);
 	config.bit_order = get_nrf_spi_bit_order(spi_cfg->operation);
 
-	nrf_gpio_pin_write(nrf_spi_sck_pin_get(dev_config->spi.p_reg),
-			   spi_cfg->operation & SPI_MODE_CPOL ? 1 : 0);
+	nrf_sck_pin = nrf_spi_sck_pin_get(dev_config->spi.p_reg);
+	if (nrf_sck_pin >= 0) {
+		nrf_gpio_pin_write(nrf_sck_pin,
+				   spi_cfg->operation & SPI_MODE_CPOL ? 1 : 0);
+	}
 
 	if (dev_data->initialized) {
 		nrfx_spi_uninit(&dev_config->spi);

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -127,6 +127,7 @@ static int configure(const struct device *dev,
 	struct spi_context *ctx = &dev_data->ctx;
 	uint32_t max_freq = dev_config->max_freq;
 	nrfx_spim_config_t config;
+	int32_t nrfy_sck_pin;
 	nrfx_err_t result;
 
 	if (dev_data->initialized && spi_context_configured(ctx, spi_cfg)) {
@@ -184,8 +185,11 @@ static int configure(const struct device *dev,
 	config.mode      = get_nrf_spim_mode(spi_cfg->operation);
 	config.bit_order = get_nrf_spim_bit_order(spi_cfg->operation);
 
-	nrfy_gpio_pin_write(nrfy_spim_sck_pin_get(dev_config->spim.p_reg),
-			    spi_cfg->operation & SPI_MODE_CPOL ? 1 : 0);
+	nrfy_sck_pin = nrfy_spim_sck_pin_get(dev_config->spim.p_reg);
+	if (nrfy_sck_pin >= 0) {
+		nrfy_gpio_pin_write(nrfy_sck_pin,
+				    spi_cfg->operation & SPI_MODE_CPOL ? 1 : 0);
+	}
 
 	if (dev_data->initialized) {
 		nrfx_spim_uninit(&dev_config->spim);


### PR DESCRIPTION
* SPI# instances can have SCK disconnected, so only configure the SCK pin when one is connected.

I hit this when working on the ZMK upgrade to Zephyr 3.5. In particular, we often use nrf52840 SPI3, configured via pinctrl, with the SPI based ws2818 `led_strip` driver with *only* the MOSI/COPI pin set in the pinctrl setup. This worked fine on 3.2, but started faulting after the upgrade.

The NRFX API I'm calling technically returns a unsignd int, but tested showed it did return -1 in the case the SCK pin was not attached. This tracks with the documentation of [`PSEL.SCK`](https://infocenter.nordicsemi.com/index.jsp?topic=%2Fps_nrf52840%2Fspim.html&cp=5_0_0_5_24&anchor=register.PSEL.SCK) which documents that the high bit is set if the SCK line is disconnected.