### PR TITLE
boards: mimxrt1050_evk: enable linkserver support

### DIFF
--- a/boards/arm/mimxrt1050_evk/board.cmake
+++ b/boards/arm/mimxrt1050_evk/board.cmake
@@ -10,6 +10,8 @@ if(${CONFIG_BOARD_MIMXRT1050_EVK_QSPI})
     board_runner_args(pyocd "--target=mimxrt1050_quadspi")
 else()
     board_runner_args(pyocd "--target=mimxrt1050_hyperflash")
+    board_runner_args(linkserver  "--device=MIMXRT1052xxxxB:EVKB-IMXRT1050")
+    include(${ZEPHYR_BASE}/boards/common/linkserver.board.cmake)
 endif()
 
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/mimxrt1050_evk/doc/index.rst
+++ b/boards/arm/mimxrt1050_evk/doc/index.rst
@@ -322,8 +322,23 @@ however the :ref:`pyocd-debug-host-tools` do not yet support programming the
 external flashes on this board so you must reconfigure the board for one of the
 following debug probes instead.
 
-Option 1: :ref:`opensda-jlink-onboard-debug-probe` (Recommended)
-----------------------------------------------------------------
+Using LinkServer
+----------------
+
+Install the :ref:`linkserver-debug-host-tools` and make sure they are in your
+search path.  LinkServer works with the default CMSIS-DAP firmware included in
+the on-board debugger.
+
+Linkserver is the default runner. You may also se the ``-r linkserver`` option
+with West to use the LinkServer runner.
+
+.. code-block:: console
+
+   west flash
+   west debug
+
+JLink (on-board): :ref:`opensda-jlink-onboard-debug-probe`
+----------------------------------------------------------
 
 Install the :ref:`jlink-debug-host-tools` and make sure they are in your search
 path.
@@ -337,8 +352,8 @@ Follow the instructions in `Enable QSPI flash support in SEGGER JLink`_
 in order to support your EVK if you have modified it to boot from QSPI NOR
 flash as specified by NXP AN12108.
 
-Option 2: :ref:`jlink-external-debug-probe`
--------------------------------------------
+External JLink :ref:`jlink-external-debug-probe`
+------------------------------------------------
 
 Install the :ref:`jlink-debug-host-tools` and make sure they are in your search
 path.


### PR DESCRIPTION
 - adds the definitions in the board.cmake file
 - updates documentation

