### PR TITLE
Enable mailbox in Arduino Portenta H7 DTS

### DIFF
--- a/boards/arm/arduino_portenta_h7/arduino_portenta_h7-common.dtsi
+++ b/boards/arm/arduino_portenta_h7/arduino_portenta_h7-common.dtsi
@@ -116,3 +116,7 @@ zephyr_udc0: &usbotg_fs {
 	pinctrl-names = "default";
 	status = "disabled";
 };
+
+&mailbox {
+	status = "okay";
+};


### PR DESCRIPTION
The mailbox peripheral is actively accesses by stm32_hsem functions, so it should be marked as enabled in DTS.