### PR TITLE
manifest: update hal_nordic revision

### DIFF
--- a/modules/hal_nordic/nrf_802154/CMakeLists.txt
+++ b/modules/hal_nordic/nrf_802154/CMakeLists.txt
@@ -93,8 +93,6 @@ else()
   target_compile_definitions(zephyr-802154-interface INTERFACE NRF_802154_CARRIER_FUNCTIONS_ENABLED=0)
 endif()
 
-target_compile_definitions(zephyr-802154-interface INTERFACE NRF_802154_ENERGY_DETECTED_VERSION=1)
-
 if (CONFIG_NRF_802154_ASSERT_ZEPHYR OR CONFIG_NRF_802154_ASSERT_ZEPHYR_MINIMAL)
   target_include_directories(zephyr-802154-interface INTERFACE include)
   target_compile_definitions(zephyr-802154-interface INTERFACE NRF_802154_PLATFORM_ASSERT_INCLUDE=\"nrf_802154_assert_zephyr.h\")

--- a/west.yml
+++ b/west.yml
@@ -183,7 +183,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: b55cfbbf0221d709560c2e438beef66842ada272
+      revision: 64bd075a06f6a16d6ea9101cda82b41465a35211
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
This commit updates revision of hal_nordic to bring the latest changes
in the nRF IEEE 802.15.4 driver.

Signed-off-by: Andrzej Kuroś <andrzej.kuros@nordicsemi.no>