### PR TITLE
llext: rework testcases to share common config

### DIFF
--- a/samples/subsys/llext/shell_loader/sample.yaml
+++ b/samples/subsys/llext/shell_loader/sample.yaml
@@ -1,3 +1,15 @@
+common:
+  tags: llext
+  arch_allow:
+    - arm
+    - xtensa
+  extra_conf_files:
+    - prj.conf
+    - ${ZEPHYR_BASE}/subsys/llext/${ARCH}-overlay.conf # arch-specific MPU disable
+  # Broken platforms
+  filter: not CONFIG_MPU and not CONFIG_MMU and not CONFIG_SOC_SERIES_S32ZE_R52
+  platform_exclude:
+    - nuvoton_pfm_m487 # See #63167
 sample:
   description: Loadable extensions with shell sample
   name: Extension loader shell
@@ -5,10 +17,3 @@ tests:
   sample.llext.shell:
     tags: shell llext
     harness: keyboard
-    filter: not CONFIG_CPU_HAS_MMU and not CONFIG_SOC_SERIES_S32ZE_R52
-    arch_allow: arm
-    extra_configs:
-      - CONFIG_ARM_MPU=n
-    # Broken platforms
-    platform_exclude:
-      - nuvoton_pfm_m487 # See #63167

--- a/subsys/llext/arm-overlay.conf
+++ b/subsys/llext/arm-overlay.conf
@@ -1,0 +1,1 @@
+CONFIG_ARM_MPU=n

--- a/subsys/llext/xtensa-overlay.conf
+++ b/subsys/llext/xtensa-overlay.conf
@@ -1,0 +1,1 @@
+# empty file

--- a/tests/subsys/llext/testcase.yaml
+++ b/tests/subsys/llext/testcase.yaml
@@ -1,18 +1,20 @@
 common:
   tags: llext
+  arch_allow:
+    - arm
+    - xtensa
+  extra_conf_files:
+    - prj.conf
+    - ${ZEPHYR_BASE}/subsys/llext/${ARCH}-overlay.conf # arch-specific MPU disable
+  filter: not CONFIG_MPU and not CONFIG_MMU and not CONFIG_SOC_SERIES_S32ZE_R52
+  # Broken platforms
+  platform_exclude:
+    - nuvoton_pfm_m487 # See #63167
 tests:
-  llext.simple.arm:
-    filter: not CONFIG_CPU_HAS_MMU and not CONFIG_SOC_SERIES_S32ZE_R52
-    arch_allow: arm
+  llext.simple.readonly:
+    arch_exclude: xtensa # for now
     extra_configs:
-      - CONFIG_ARM_MPU=n
-    # Broken platforms
-    platform_exclude:
-      - nuvoton_pfm_m487 # See #63167
-  llext.simple.xtensa:
-    arch_allow: xtensa
+      - CONFIG_LLEXT_STORAGE_WRITABLE=n
+  llext.simple.writable:
     extra_configs:
       - CONFIG_LLEXT_STORAGE_WRITABLE=y
-    # Broken platforms
-    platform_exclude:
-      - qemu_xtensa_mmu # ELF sections are read-only, and without peek() .text copy isn't executable


### PR DESCRIPTION
This patch reworks the YAML files for the llext samples and tests to share a common restriction list. Also, using an arch-specific overlay file to disable the MPU for the ARM architecture only, there is no need to duplicate the test cases per architecture.
Use this to enable the "writable" test case for the ARM architecture.