### PR TITLE
logging: fs backend: optional append to latest file

### DIFF
--- a/subsys/logging/backends/Kconfig.fs
+++ b/subsys/logging/backends/Kconfig.fs
@@ -31,6 +31,14 @@ config LOG_BACKEND_FS_OVERWRITE
 	  When enabled backend overwrites oldest log files.
 	  In other case, when memory is full, new messages are dropped.
 
+config LOG_BACKEND_FS_APPEND_TO_NEWEST_FILE
+	bool "Append to the newest log file"
+	default y
+	help
+	  When enabled and when there is space left in the newest log file,
+	  backend appends to it.
+	  When disabled backend creates a new log file on every startup.
+
 config LOG_BACKEND_FS_FILE_PREFIX
 	string "Log file name prefix"
 	default "log."

--- a/subsys/logging/backends/log_backend_fs.c
+++ b/subsys/logging/backends/log_backend_fs.c
@@ -348,7 +348,8 @@ static int allocate_new_file(struct fs_file_t *file)
 			goto out;
 		}
 		file_size = fs_tell(file);
-		if (file_size < CONFIG_LOG_BACKEND_FS_FILE_SIZE) {
+		if (IS_ENABLED(CONFIG_LOG_BACKEND_FS_APPEND_TO_NEWEST_FILE) &&
+		    file_size < CONFIG_LOG_BACKEND_FS_FILE_SIZE) {
 			/* There is space left to log to the latest file, no need to create
 			 * a new one or delete old ones at this point.
 			 */


### PR DESCRIPTION
Make appending to the newest log file in the fs logging backend optional. By default, if there is still free space in the latest log file, the fs logging backend appends to it on startup. This is useful for saving space and avoiding the removal of older log files, if the maximum number of log files has been reached. The drawback of this behavior is, that log files that got appended can not be decoded, if the firmware has changed between startups, for instance by an update, since the log_dictionary.json used for decoding has also changed. Therefore, it may be desirable to deactivate appending to log files.