### PR TITLE
drivers: can: stm32h7: fdcan: add support for domain clock and divider

### DIFF
--- a/boards/arm/arduino_giga_r1/arduino_giga_r1_m7.dts
+++ b/boards/arm/arduino_giga_r1/arduino_giga_r1_m7.dts
@@ -139,6 +139,8 @@
 	status = "okay";
 	pinctrl-0 = <&fdcan2_tx_pb13 &fdcan2_rx_pb5>;
 	pinctrl-names = "default";
+	clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000100>,
+		 <&rcc STM32_SRC_PLL1_Q FDCAN_SEL(1)>;
 	bus-speed = <125000>;
 	bus-speed-data = <1000000>;
 };

--- a/boards/arm/arduino_portenta_h7/arduino_portenta_h7-common.dtsi
+++ b/boards/arm/arduino_portenta_h7/arduino_portenta_h7-common.dtsi
@@ -105,6 +105,8 @@
 &fdcan1 {
 	pinctrl-0 = <&fdcan1_rx_pb8 &fdcan1_tx_ph13>;
 	pinctrl-names = "default";
+	clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000100>,
+		 <&rcc STM32_SRC_PLL1_Q FDCAN_SEL(1)>;
 };
 
 &rtc {

--- a/boards/arm/nucleo_h743zi/nucleo_h743zi.dts
+++ b/boards/arm/nucleo_h743zi/nucleo_h743zi.dts
@@ -170,6 +170,8 @@ zephyr_udc0: &usbotg_fs {
 &fdcan1 {
 	pinctrl-0 = <&fdcan1_rx_pd0 &fdcan1_tx_pd1>;
 	pinctrl-names = "default";
+	clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000100>,
+		 <&rcc STM32_SRC_PLL1_Q FDCAN_SEL(1)>;
 	bus-speed = <125000>;
 	bus-speed-data = <1000000>;
 	status = "okay";

--- a/boards/arm/stm32h735g_disco/doc/index.rst
+++ b/boards/arm/stm32h735g_disco/doc/index.rst
@@ -65,7 +65,15 @@ The current Zephyr stm32h735g_disco board configuration supports the following h
 +-----------+------------+-------------------------------------+
 | ADC       | on-chip    | ADC Controller                      |
 +-----------+------------+-------------------------------------+
-
+| FDCAN1    | on-chip    | CAN-FD Controller                   |
++-----------+------------+-------------------------------------+
+| FDCAN2    | on-chip    | CAN-FD Controller                   |
++-----------+------------+-------------------------------------+
+| FDCAN2    | on-chip    | CAN-FD Controller (disabled by      |
+|           |            | default. Solder bridges SB29 and    |
+|           |            | SB30 need to be closed for FDCAN3   |
+|           |            | to work)                            |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on Zephyr porting.
 
@@ -84,6 +92,7 @@ Default Zephyr Peripheral Mapping:
 - UART_7 TX/RX : PF7/PF6 (Arduino Serial)
 - LD1 : PC2
 - LD2 : PC3
+- FDCAN1 : CAN
 
 System Clock
 ============

--- a/boards/arm/stm32h735g_disco/stm32h735g_disco.dts
+++ b/boards/arm/stm32h735g_disco/stm32h735g_disco.dts
@@ -19,6 +19,7 @@
 		zephyr,shell-uart = &usart3;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,canbus = &fdcan1;
 	};
 
 	leds {
@@ -73,6 +74,16 @@
 	div-p = <1>;
 	div-q = <4>;
 	div-r = <2>;
+	clocks = <&clk_hse>;
+	status = "okay";
+};
+
+&pll2 {
+	div-m = <5>;
+	mul-n = <80>;
+	div-p = <5>;
+	div-q = <5>;
+	div-r = <5>;
 	clocks = <&clk_hse>;
 	status = "okay";
 };
@@ -188,4 +199,47 @@
 
 &vbat {
 	status = "okay";
+};
+
+&fdcan1 {
+	pinctrl-0 = <&fdcan1_rx_ph14 &fdcan1_tx_ph13>;
+	pinctrl-names = "default";
+	clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000100>,
+		 <&rcc STM32_SRC_PLL2_Q FDCAN_SEL(2)>;
+	status = "okay";
+	bus-speed = <125000>;
+	bus-speed-data = <1000000>;
+
+	can-transceiver {
+		max-bitrate = <8000000>;
+	};
+};
+
+&fdcan2 {
+	pinctrl-0 = <&fdcan2_rx_pb5 &fdcan2_tx_pb6>;
+	pinctrl-names = "default";
+	clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000100>,
+		 <&rcc STM32_SRC_PLL2_Q FDCAN_SEL(2)>;
+	status = "okay";
+	bus-speed = <125000>;
+	bus-speed-data = <1000000>;
+
+	can-transceiver {
+		max-bitrate = <8000000>;
+	};
+};
+
+&fdcan3 {
+	pinctrl-0 = <&fdcan3_rx_pf6 &fdcan3_tx_pf7>;
+	pinctrl-names = "default";
+	clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000100>,
+		 <&rcc STM32_SRC_PLL2_Q FDCAN_SEL(2)>;
+	/* Solder bridges SB29 and SB30 need to be closed for this to work */
+	status = "disabled";
+	bus-speed = <125000>;
+	bus-speed-data = <1000000>;
+
+	can-transceiver {
+		max-bitrate = <8000000>;
+	};
 };

--- a/boards/arm/stm32h735g_disco/stm32h735g_disco.yaml
+++ b/boards/arm/stm32h735g_disco/stm32h735g_disco.yaml
@@ -15,4 +15,5 @@ supported:
   - memc
   - adc
   - counter
+  - can
 vendor: st

--- a/boards/arm/stm32h7b3i_dk/stm32h7b3i_dk.dts
+++ b/boards/arm/stm32h7b3i_dk/stm32h7b3i_dk.dts
@@ -152,6 +152,8 @@
 &fdcan1 {
 	pinctrl-0 = <&fdcan1_rx_pa11 &fdcan1_tx_pa12>;
 	pinctrl-names = "default";
+	clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000100>,
+		 <&rcc STM32_SRC_PLL1_Q FDCAN_SEL(1)>;
 	phys = <&transceiver0>;
 	bus-speed = <125000>;
 	bus-speed-data = <1000000>;

--- a/doc/releases/migration-guide-3.6.rst
+++ b/doc/releases/migration-guide-3.6.rst
@@ -159,6 +159,18 @@ Device Drivers and Device Tree
   * :dtcompatible:`ti,lmp90099`
   * :dtcompatible:`ti,lmp90100`
 
+* The :dtcompatible:`st,stm32h7-fdcan` CAN controller driver now supports configuring the
+  domain/kernel clock via devicetree. Previously, the driver only supported using the PLL1_Q clock
+  for kernel clock, but now it defaults to the HSE clock, which is the chip default. Boards that
+  use the PLL1_Q clock for FDCAN will need to override the ``clocks`` property as follows:
+
+  .. code-block:: devicetree
+
+    &fdcan1 {
+            clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000100>,
+                     <&rcc STM32_SRC_PLL1_Q FDCAN_SEL(1)>;
+    };
+
 Power Management
 ================
 

--- a/dts/bindings/can/st,stm32h7-fdcan.yaml
+++ b/dts/bindings/can/st,stm32h7-fdcan.yaml
@@ -16,3 +16,29 @@ properties:
 
   interrupt-names:
     required: true
+
+  clk-divider:
+    type: int
+    enum:
+      - 1
+      - 2
+      - 4
+      - 6
+      - 8
+      - 10
+      - 12
+      - 14
+      - 16
+      - 18
+      - 20
+      - 22
+      - 24
+      - 26
+      - 28
+      - 30
+    description: |
+      Divides the kernel clock giving the time quanta clock that is fed to the FDCAN core
+      (FDCAN_CCU->CCFG CDIV register bits). Note that the divisor is common to all
+      'st,stm32h7-fdcan' instances.
+
+      Divide by 1 is the peripherals reset value and remains set unless this property is configured.


### PR DESCRIPTION
Add support for specifying the domain/kernel clock along with a common  clock divider for the STM32H7 CAN controller driver via devicetree.
    
Previously, the driver only supported using the PLL1_Q clock for domain/kernel clock, but now the driver defaults to the HSE clock, which is the chip default. Update existing boards to continue to use the PLL1_Q clock.

Enable support for FDCAN1, FDCAN2, and FDCAN3 on the `stm32h735g_disco` board as an example of a board requiring a different FDCAN domain/kernel clock.