### PR TITLE
boards: arm: stm32u5a9j-dk: fix missing pull down on switch

### DIFF
--- a/boards/arm/stm32u5a9j_dk/stm32u5a9j_dk.dts
+++ b/boards/arm/stm32u5a9j_dk/stm32u5a9j_dk.dts
@@ -37,7 +37,7 @@
 		compatible = "gpio-keys";
 		user_button: button_0 {
 			label = "User";
-			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;
+			gpios = <&gpioc 13 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 			zephyr,code = <INPUT_KEY_0>;
 		};
 	};


### PR DESCRIPTION
Hello,

The user switch on the stm32u5a9j_dk board require a pull down on mcu side. Otherwise a short push will last longer than expected. This is mentioned in [ST um2967-discovery-kit-with-stm32u5a9nj-mcu-stmicroelectronics.pdf](https://www.st.com/resource/en/user_manual/um2967-discovery-kit-with-stm32u5a9nj-mcu-stmicroelectronics.pdf) at 12.11:

> The user button schematics have been optimized, so it is up to the user to manage the internal pull-down and
debounce filtering by software