### PR TITLE
tests: pwm: esp32/s3: add internal loopback

### DIFF
--- a/tests/drivers/pwm/pwm_loopback/boards/esp32_devkitc_wrover.overlay
+++ b/tests/drivers/pwm/pwm_loopback/boards/esp32_devkitc_wrover.overlay
@@ -19,10 +19,11 @@
 	mcpwm0_default: mcpwm0_default {
 		group1 {
 			pinmux = <MCPWM0_OUT0A_GPIO2>;
-			output-enable;
+			input-enable;
 		};
 		group2 {
-			pinmux = <MCPWM0_CAP0_GPIO4>;
+			pinmux = <MCPWM0_CAP0_GPIO2>;
+			output-enable;
 		};
 	};
 };

--- a/tests/drivers/pwm/pwm_loopback/boards/esp32s3_devkitm.overlay
+++ b/tests/drivers/pwm/pwm_loopback/boards/esp32s3_devkitm.overlay
@@ -19,10 +19,11 @@
 	mcpwm0_default: mcpwm0_default {
 		group1 {
 			pinmux = <MCPWM0_OUT0A_GPIO2>;
-			output-enable;
+			input-enable;
 		};
 		group2 {
-			pinmux = <MCPWM0_CAP0_GPIO4>;
+			pinmux = <MCPWM0_CAP0_GPIO2>;
+			output-enable;
 		};
 	};
 };


### PR DESCRIPTION
Add internal loopback for testing purposes and change wroom for wrover, which is default board
for testing.