### PR TITLE
Bluetooth: L2CAP: remove metadata requirement

### DIFF
--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -96,7 +96,7 @@ static void free_tx_meta_data(struct l2cap_tx_meta_data *data)
 
 #define l2cap_tx_meta_data(buf) (((struct l2cap_tx_meta *)net_buf_user_data(buf))->data)
 
-static sys_slist_t servers;
+static sys_slist_t servers = SYS_SLIST_STATIC_INIT(&servers);
 
 static void l2cap_tx_buf_destroy(struct bt_conn *conn, struct net_buf *buf, int err)
 {


### PR DESCRIPTION
This removes the dependency between `CONFIG_BT_ATT_TX_COUNT` and
`CONFIG_BT_L2CAP_TX_BUF_COUNT` since previously there was still a need
for an L2CAP context for every TX'd buffer.

~Stacked on https://github.com/zephyrproject-rtos/zephyr/pull/67532~