### PR TITLE
ARC: increase stacks sizes

### DIFF
--- a/arch/arc/Kconfig
+++ b/arch/arc/Kconfig
@@ -387,6 +387,7 @@ endmenu
 
 config MAIN_STACK_SIZE
 	default 4096 if 64BIT
+	default 768 if !64BIT
 
 config ISR_STACK_SIZE
 	default 4096 if 64BIT
@@ -402,6 +403,7 @@ config IPM_CONSOLE_STACK_SIZE
 
 config TEST_EXTRA_STACK_SIZE
 	default 2048 if 64BIT
+	default 128 if !64BIT
 
 config CMSIS_THREAD_MAX_STACK_SIZE
 	default 2048 if 64BIT


### PR DESCRIPTION
Some tests fail because of main stack overflow. Increase stacks sizes to make them fit to MWDT requirements.

ARCMWDT stack requirements. Examples for some failed tests on ```nsim_sem_mpu_stack_guard``` platform:
tests/kernel/cache/kernel.cache.api.minimallibc - 548
tests/kernel/msgq/msgq_api/kernel.message_queue - 548
tests/kernel/threads/thread_apis/kernel.threads.apis - 768
tests/ztest/base/testing.ztest.base.verbose_0_userspace - 610

Default stack size for main thread is 512

Observations:
Stack requirements insreased in time with new releases
CONFIG_ASSERT=y affects (increases) MW stack usage