### PR TITLE
MAINTAINERS: Update for Bluetooth host

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -356,12 +356,9 @@ Bluetooth Host:
   collaborators:
     - hermabe
     - alwa-nordic
-    - Vudentz
     - Thalley
-    - asbjornsabo
     - sjanc
     - theob-pro
-    - kruithofa
   files:
     - drivers/bluetooth/
     - subsys/bluetooth/host/

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -351,10 +351,10 @@ Bluetooth controller:
 Bluetooth Host:
   status: maintained
   maintainers:
+    - jori-nordic
     - jhedberg
   collaborators:
     - hermabe
-    - jori-nordic
     - alwa-nordic
     - Vudentz
     - Thalley


### PR DESCRIPTION
- Add myself as co-maintainer.
- Remove inactive collaborators.

See these relevant discussions: https://github.com/zephyrproject-rtos/zephyr/issues/67214 and https://github.com/zephyrproject-rtos/zephyr/issues/67250