### PR TITLE
stm32 lptim driver sleeping forever depends on SYSTEM_CLOCK_SLOPPY_IDLE

### DIFF
--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -238,10 +238,18 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 		return;
 	}
 
+	/*
+	 * When CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE = y, ticks equals to -1
+	 * is treated as a lptim off ; never waking up ; lptim not clocked anymore
+	 */
 	if (ticks == K_TICKS_FOREVER) {
 		clock_control_off(clk_ctrl, (clock_control_subsys_t) &lptim_clk[0]);
 		return;
 	}
+	/*
+	 * When CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE = n, ticks equals to INT_MAX
+	 * is treated as a maximum possible value LPTIM_MAX_TIMEBASE (16bit counter)
+	 */
 
 	/* if LPTIM clock was previously stopped, it must now be restored */
 	err = clock_control_on(clk_ctrl, (clock_control_subsys_t) &lptim_clk[0]);


### PR DESCRIPTION
The stm32 lptim driver is called by the application which wants to _sleep forever_.
It calls the  _k_msleep_ function  with a _int32_t ticks_ parameter meaning either never wakeUp or wakeUp on max possible timeout. This meaning depends on the  the SYSTEM_CLOCK_SLOPPY_IDLE

- when CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE is set, then application is supposed to call k_msleep(K_TICKS_FOREVER);  will stop lptim counting

- when CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE is not set, then application is supposed to call k_msleep(INT_MAX); and lptim will wakeUp the system at its max possible timeout value.


This PR just add comment to clarify this meaning.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/65008
