### PR TITLE
ci: use kitaware ninja with job server support

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -179,6 +179,12 @@ jobs:
           west update --path-cache /github/cache/zephyrproject 2>&1 1> west.update.log || west update --path-cache /github/cache/zephyrproject 2>&1 1> west.update.log || ( rm -rf ../modules ../bootloader ../tools && west update --path-cache /github/cache/zephyrproject)
           west forall -c 'git reset --hard HEAD'
 
+          # Hotfix until we have kitware ninja in the docker image.
+          # Needed for full functionality of the job server functionality in twister which only works with
+          # kitware supplied ninja version.
+          wget -c    https://github.com/Kitware/ninja/releases/download/v1.11.1.g95dee.kitware.jobserver-1/ninja-1.11.1.g95dee.kitware.jobserver-1_x86_64-linux-gnu.tar.gz -O - | tar xz --strip-components=1
+          sudo cp ninja /usr/local/bin
+
       - name: Check Environment
         run: |
           cmake --version


### PR DESCRIPTION
Needed for full functionality of the job server functionality in twister which
only works with kitware supplied ninja version.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
