### PR TITLE
Fix Bug in Kconfig file of icm42688 driver

### DIFF
--- a/drivers/sensor/icm42688/Kconfig
+++ b/drivers/sensor/icm42688/Kconfig
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-config ICM42688
+menuconfig ICM42688
 	bool "ICM42688 Six-Axis Motion Tracking Device"
 	default y
 	depends on DT_HAS_INVENSENSE_ICM42688_ENABLED
@@ -12,10 +12,11 @@ config ICM42688
 	help
 	  Enable driver for ICM42688 SPI-based six-axis motion tracking device.
 
+if ICM42688
+
 config EMUL_ICM42688
 	bool "Emulator for the ICM42688"
 	default y
-	depends on ICM42688
 	depends on EMUL
 	help
 	  Enable the hardware emulator for the ICM42688. Doing so allows exercising
@@ -23,13 +24,11 @@ config EMUL_ICM42688
 
 config ICM42688_DECODER
 	bool "ICM42688 decoder logic"
-	default y if ICM42688
+	default y
 	select SENSOR_ASYNC_API
 	help
 	  Compile the ICM42688 decoder API which allows decoding raw data returned
 	  from the sensor.
-
-if ICM42688
 
 choice
 	prompt "Trigger mode"


### PR DESCRIPTION
The config option of driver icm42688 appeared unexpectedly in menuconfig when the app use other sensors.The bug is fixed by slightly modifing the Kconfig file of icm42688