### PR TITLE
drivers: pinctrl: pfc_rcar: add dummy function to pinctrl driver

### DIFF
--- a/drivers/pinctrl/renesas/rcar/pfc_rcar.c
+++ b/drivers/pinctrl/renesas/rcar/pfc_rcar.c
@@ -338,7 +338,10 @@ int pinctrl_configure_pin(const pinctrl_soc_pin_t *pin)
 
 	/* Select function for pin */
 	if ((pin->flags & RCAR_PIN_FLAGS_FUNC_SET) != 0U) {
-		pfc_rcar_set_ipsr(pfc_base, &pin->func);
+
+		if ((pin->flags & RCAR_PIN_FLAGS_FUNC_DUMMY) == 0U) {
+			pfc_rcar_set_ipsr(pfc_base, &pin->func);
+		}
 
 		if (RCAR_IS_GP_PIN(pin->pin)) {
 			pfc_rcar_set_gpsr(pfc_base, pin->pin, true);

--- a/include/zephyr/drivers/pinctrl/pinctrl_rcar_common.h
+++ b/include/zephyr/drivers/pinctrl/pinctrl_rcar_common.h
@@ -27,6 +27,8 @@ struct rcar_pin_func {
 #define RCAR_PIN_FLAGS_PUD      BIT(2)
 /** Alternate function for the pin is requested */
 #define RCAR_PIN_FLAGS_FUNC_SET BIT(3)
+/** Ignore IPSR settings for alternate function pin */
+#define RCAR_PIN_FLAGS_FUNC_DUMMY BIT(4)
 
 #define RCAR_PIN_PULL_UP      (RCAR_PIN_FLAGS_PULL_SET | RCAR_PIN_FLAGS_PUEN | RCAR_PIN_FLAGS_PUD)
 #define RCAR_PIN_PULL_DOWN    (RCAR_PIN_FLAGS_PULL_SET | RCAR_PIN_FLAGS_PUEN)
@@ -52,11 +54,17 @@ typedef struct pinctrl_soc_pin {
 		((RCAR_IPSR(node_id) & 0xFU))	       \
 	}
 
+#define RCAR_PIN_IS_FUNC_DUMMY(node_id)					       \
+	((((RCAR_IPSR(node_id) >> 10U) & 0x1FU) == 0x1F) &&		       \
+	 (((RCAR_IPSR(node_id) >> 4U) & 0x1FU) == 0x1F) &&		       \
+	 ((RCAR_IPSR(node_id) & 0xFU) == 0xF))
+
 #define RCAR_PIN_FLAGS(node_id)						       \
 	DT_PROP(node_id, bias_pull_up)   * RCAR_PIN_PULL_UP |		       \
 	DT_PROP(node_id, bias_pull_down) * RCAR_PIN_PULL_DOWN |		       \
 	DT_PROP(node_id, bias_disable)   * RCAR_PIN_PULL_DISABLE |	       \
-	RCAR_HAS_IPSR(node_id) * RCAR_PIN_FLAGS_FUNC_SET
+	RCAR_HAS_IPSR(node_id) * RCAR_PIN_FLAGS_FUNC_SET |		       \
+	RCAR_PIN_IS_FUNC_DUMMY(node_id) * RCAR_PIN_FLAGS_FUNC_DUMMY
 
 #define RCAR_DT_PIN(node_id)						       \
 	{								       \

--- a/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-r8a779f0.h
+++ b/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-r8a779f0.h
@@ -275,6 +275,21 @@
 #define FUNC_TCLK1                 IP0SR1(0, 1)
 #define FUNC_HSCK2                 IP0SR1(0, 2)
 #define FUNC_GP1_01                IP0SR1(4, 0)
+
+#define FUNC_MMC_SD_CLK            IPSR_DUMMY
+#define FUNC_MMC_SD_D0             IPSR_DUMMY
+#define FUNC_MMC_SD_D1             IPSR_DUMMY
+#define FUNC_MMC_SD_D2             IPSR_DUMMY
+#define FUNC_MMC_SD_D3             IPSR_DUMMY
+#define FUNC_MMC_D4                IPSR_DUMMY
+#define FUNC_MMC_D5                IPSR_DUMMY
+#define FUNC_MMC_D6                IPSR_DUMMY
+#define FUNC_MMC_D7                IPSR_DUMMY
+#define FUNC_MMC_DS                IPSR_DUMMY
+#define FUNC_MMC_SD_CMD            IPSR_DUMMY
+#define FUNC_SD_CD                 IPSR_DUMMY
+#define FUNC_SD_WP                 IPSR_DUMMY
+
 #define FUNC_TCLK4                 IP0SR1(4, 1)
 #define FUNC_HRX2                  IP0SR1(4, 2)
 #define FUNC_GP1_02                IP0SR1(8, 0)

--- a/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-rcar-common.h
+++ b/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-rcar-common.h
@@ -82,6 +82,18 @@
 #define IP2SR7(shift, func) IPnSR(2, 7, shift, func)
 #define IP3SR7(shift, func) IPnSR(3, 7, shift, func)
 
+/**
+ * @brief Macro to define a dummy IPSR flag for a pin
+ *
+ * This macro is used to define a dummy IPSR flag for a pin in the R-Car PFC
+ * driver. It is intended for pins that do not have a specific function
+ * defined in IPSR but always act as a peripheral. The dummy IPSR flag ensures
+ * that the driver sets the 'peripheral' bit for such pins.
+ *
+ * @see RCAR_PIN_FLAGS_FUNC_DUMMY
+ */
+#define IPSR_DUMMY IPnSR(0x1f, 7, 0x1f, 0xf)
+
 #define PIN_VOLTAGE_NONE 0
 #define PIN_VOLTAGE_1P8V 1
 #define PIN_VOLTAGE_3P3V 2


### PR DESCRIPTION
Add a dummy pin function to the RCar PFC driver. It is necessary to ensure that the driver sets the 'peripheral' bit (the driver resets this bit during the first call of 'pfc_rcar_set_gpsr') for a pin that doesn't have a pin function defined in IPSR, but always acts as a 'peripheral', for example, the MMC pins on the Spider board.