### PR TITLE
drivers: adc: iadc_gecko: fix sample bits reading

### DIFF
--- a/drivers/adc/iadc_gecko.c
+++ b/drivers/adc/iadc_gecko.c
@@ -20,7 +20,7 @@ LOG_MODULE_REGISTER(iadc_gecko, CONFIG_ADC_LOG_LEVEL);
 /* Number of channels available. */
 #define GECKO_CHANNEL_COUNT	16
 #define GECKO_INTERNAL_REFERENCE_mV	1210
-#define GECKO_DATA_RES12BIT(DATA)	((DATA & 0xFFF0) >> 4);
+#define GECKO_DATA_RES12BIT(DATA)	((DATA) & 0x0FFF)
 
 struct adc_gecko_channel_config {
 	IADC_CfgAnalogGain_t gain;


### PR DESCRIPTION
The current driver initializes the IADC with the default configuration (IADC_INITSINGLE_DEFAULT), which aligns the data to the right. To correctly read the 12-bit sample, it should be masked from the right instead.