### PR TITLE
shell: Fix shell init procedure when configured as inactive on startup

### DIFF
--- a/include/zephyr/shell/shell.h
+++ b/include/zephyr/shell/shell.h
@@ -743,6 +743,7 @@ struct shell_backend_ctx_flags {
 	uint32_t cmd_ctx      :1; /*!< Shell is executing command */
 	uint32_t print_noinit :1; /*!< Print request from not initialized shell */
 	uint32_t sync_mode    :1; /*!< Shell in synchronous mode */
+	uint32_t handle_log   :1; /*!< Shell is handling logger backend */
 };
 
 BUILD_ASSERT((sizeof(struct shell_backend_ctx_flags) == sizeof(uint32_t)),
@@ -797,6 +798,9 @@ struct shell_ctx {
 
 	/** When bypass is set, all incoming data is passed to the callback. */
 	shell_bypass_cb_t bypass;
+
+	/*!< Logging level for a backend. */
+	uint32_t log_level;
 
 #if defined CONFIG_SHELL_GETOPT
 	/*!< getopt context for a shell backend. */

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1315,19 +1315,14 @@ void shell_thread(void *shell_handle, void *arg_log_backend,
 		  void *arg_log_level)
 {
 	struct shell *sh = shell_handle;
-	bool log_backend = (bool)arg_log_backend;
-	uint32_t log_level = POINTER_TO_UINT(arg_log_level);
 	int err;
+
+	z_flag_handle_log_set(sh, (bool)arg_log_backend);
+	sh->ctx->log_level = POINTER_TO_UINT(arg_log_level);
 
 	err = sh->iface->api->enable(sh->iface, false);
 	if (err != 0) {
 		return;
-	}
-
-	if (IS_ENABLED(CONFIG_SHELL_LOG_BACKEND) && log_backend
-	    && !IS_ENABLED(CONFIG_SHELL_START_OBSCURED)) {
-		z_shell_log_backend_enable(sh->log_backend, (void *)sh,
-					   log_level);
 	}
 
 	if (IS_ENABLED(CONFIG_SHELL_AUTOSTART)) {
@@ -1430,6 +1425,11 @@ int shell_start(const struct shell *sh)
 		return -ENOTSUP;
 	}
 
+	if (IS_ENABLED(CONFIG_SHELL_LOG_BACKEND) && z_flag_handle_log_get(sh)
+	    && !z_flag_obscure_get(sh)) {
+		z_shell_log_backend_enable(sh->log_backend, (void *)sh, sh->ctx->log_level);
+	}
+
 	k_mutex_lock(&sh->ctx->wr_mtx, K_FOREVER);
 
 	if (IS_ENABLED(CONFIG_SHELL_VT100_COLORS)) {
@@ -1459,6 +1459,8 @@ int shell_stop(const struct shell *sh)
 	}
 
 	state_set(sh, SHELL_STATE_INITIALIZED);
+
+	z_shell_log_backend_disable(sh->log_backend);
 
 	return 0;
 }

--- a/subsys/shell/shell_ops.h
+++ b/subsys/shell/shell_ops.h
@@ -221,6 +221,19 @@ static inline bool z_flag_sync_mode_set(const struct shell *sh, bool val)
 	return ret;
 }
 
+static inline bool z_flag_handle_log_get(const struct shell *sh)
+{
+	return sh->ctx->ctx.flags.handle_log == 1;
+}
+
+static inline bool z_flag_handle_log_set(const struct shell *sh, bool val)
+{
+	bool ret;
+
+	Z_SHELL_SET_FLAG_ATOMIC(sh, ctx, handle_log, val, ret);
+	return ret;
+}
+
 /* Function sends VT100 command to clear the screen from cursor position to
  * end of the screen.
  */


### PR DESCRIPTION
The previous behavior of the `CONFIG_SHELL_AUTOSTART` option, where setting it to 'n' disabled shell interaction at startup but kept the logger active as a shell backend, was inconsistent.
Now, when `CONFIG_SHELL_AUTOSTART` is set to 'n', both the shell and the logger are inactive at startup. Calling the `shell_star` function will activate them and print any pending logs. This change ensures a more consistent and logical behavior regarding shell and logger activity at startup.

Additionally, now when the `shell_stop` function is called, both the shell and the logger are halted.