### PR TITLE
bluetooth: hci: refactored bluetooth hci packet type indicators

### DIFF
--- a/drivers/bluetooth/hci/h4.c
+++ b/drivers/bluetooth/hci/h4.c
@@ -30,13 +30,6 @@ LOG_MODULE_REGISTER(bt_driver);
 
 #include "../util.h"
 
-#define H4_NONE 0x00
-#define H4_CMD  0x01
-#define H4_ACL  0x02
-#define H4_SCO  0x03
-#define H4_EVT  0x04
-#define H4_ISO  0x05
-
 static K_KERNEL_STACK_DEFINE(rx_thread_stack, CONFIG_BT_DRV_RX_STACK_SIZE);
 static struct k_thread rx_thread_data;
 
@@ -78,20 +71,20 @@ static inline void h4_get_type(void)
 	/* Get packet type */
 	if (uart_fifo_read(h4_dev, &rx.type, 1) != 1) {
 		LOG_WRN("Unable to read H:4 packet type");
-		rx.type = H4_NONE;
+		rx.type = BT_HCI_H4_NONE;
 		return;
 	}
 
 	switch (rx.type) {
-	case H4_EVT:
+	case BT_HCI_H4_EVT:
 		rx.remaining = sizeof(rx.evt);
 		rx.hdr_len = rx.remaining;
 		break;
-	case H4_ACL:
+	case BT_HCI_H4_ACL:
 		rx.remaining = sizeof(rx.acl);
 		rx.hdr_len = rx.remaining;
 		break;
-	case H4_ISO:
+	case BT_HCI_H4_ISO:
 		if (IS_ENABLED(CONFIG_BT_ISO)) {
 			rx.remaining = sizeof(rx.iso);
 			rx.hdr_len = rx.remaining;
@@ -100,7 +93,7 @@ static inline void h4_get_type(void)
 		__fallthrough;
 	default:
 		LOG_ERR("Unknown H:4 type 0x%02x", rx.type);
-		rx.type = H4_NONE;
+		rx.type = BT_HCI_H4_NONE;
 	}
 }
 
@@ -185,7 +178,7 @@ static inline void copy_hdr(struct net_buf *buf)
 
 static void reset_rx(void)
 {
-	rx.type = H4_NONE;
+	rx.type = BT_HCI_H4_NONE;
 	rx.remaining = 0U;
 	rx.have_hdr = false;
 	rx.hdr_len = 0U;
@@ -197,11 +190,11 @@ static struct net_buf *get_rx(k_timeout_t timeout)
 	LOG_DBG("type 0x%02x, evt 0x%02x", rx.type, rx.evt.evt);
 
 	switch (rx.type) {
-	case H4_EVT:
+	case BT_HCI_H4_EVT:
 		return bt_buf_get_evt(rx.evt.evt, rx.discardable, timeout);
-	case H4_ACL:
+	case BT_HCI_H4_ACL:
 		return bt_buf_get_rx(BT_BUF_ACL_IN, timeout);
-	case H4_ISO:
+	case BT_HCI_H4_ISO:
 		if (IS_ENABLED(CONFIG_BT_ISO)) {
 			return bt_buf_get_rx(BT_BUF_ISO_IN, timeout);
 		}
@@ -329,7 +322,7 @@ static inline void read_payload(void)
 	buf = rx.buf;
 	rx.buf = NULL;
 
-	if (rx.type == H4_EVT) {
+	if (rx.type == BT_HCI_H4_EVT) {
 		bt_buf_set_type(buf, BT_BUF_EVT);
 	} else {
 		bt_buf_set_type(buf, BT_BUF_ACL_IN);
@@ -344,16 +337,16 @@ static inline void read_payload(void)
 static inline void read_header(void)
 {
 	switch (rx.type) {
-	case H4_NONE:
+	case BT_HCI_H4_NONE:
 		h4_get_type();
 		return;
-	case H4_EVT:
+	case BT_HCI_H4_EVT:
 		get_evt_hdr();
 		break;
-	case H4_ACL:
+	case BT_HCI_H4_ACL:
 		get_acl_hdr();
 		break;
-	case H4_ISO:
+	case BT_HCI_H4_ISO:
 		if (IS_ENABLED(CONFIG_BT_ISO)) {
 			get_iso_hdr();
 			break;
@@ -391,14 +384,14 @@ static inline void process_tx(void)
 	if (!tx.type) {
 		switch (bt_buf_get_type(tx.buf)) {
 		case BT_BUF_ACL_OUT:
-			tx.type = H4_ACL;
+			tx.type = BT_HCI_H4_ACL;
 			break;
 		case BT_BUF_CMD:
-			tx.type = H4_CMD;
+			tx.type = BT_HCI_H4_CMD;
 			break;
 		case BT_BUF_ISO_OUT:
 			if (IS_ENABLED(CONFIG_BT_ISO)) {
-				tx.type = H4_ISO;
+				tx.type = BT_HCI_H4_ISO;
 				break;
 			}
 			__fallthrough;
@@ -410,7 +403,7 @@ static inline void process_tx(void)
 		bytes = uart_fifo_fill(h4_dev, &tx.type, 1);
 		if (bytes != 1) {
 			LOG_WRN("Unable to send H:4 type");
-			tx.type = H4_NONE;
+			tx.type = BT_HCI_H4_NONE;
 			return;
 		}
 	}
@@ -427,7 +420,7 @@ static inline void process_tx(void)
 	}
 
 done:
-	tx.type = H4_NONE;
+	tx.type = BT_HCI_H4_NONE;
 	net_buf_unref(tx.buf);
 	tx.buf = net_buf_get(&tx.fifo, K_NO_WAIT);
 	if (!tx.buf) {

--- a/drivers/bluetooth/hci/hci_ambiq.c
+++ b/drivers/bluetooth/hci/hci_ambiq.c
@@ -25,11 +25,6 @@ LOG_MODULE_REGISTER(bt_hci_driver);
 #define HCI_SPI_NODE DT_COMPAT_GET_ANY_STATUS_OKAY(ambiq_bt_hci_spi)
 #define SPI_DEV_NODE DT_BUS(HCI_SPI_NODE)
 
-#define HCI_CMD 0x01
-#define HCI_ACL 0x02
-#define HCI_SCO 0x03
-#define HCI_EVT 0x04
-
 /* Offset of special item */
 #define PACKET_TYPE         0
 #define PACKET_TYPE_SIZE    1
@@ -272,11 +267,11 @@ static void bt_spi_rx_thread(void *p1, void *p2, void *p3)
 			}
 
 			switch (rxmsg[PACKET_TYPE]) {
-			case HCI_EVT:
+			case BT_HCI_H4_EVT:
 				buf = bt_hci_evt_recv(&rxmsg[PACKET_TYPE + PACKET_TYPE_SIZE],
 						      (len - PACKET_TYPE_SIZE));
 				break;
-			case HCI_ACL:
+			case BT_HCI_H4_ACL:
 				buf = bt_hci_acl_recv(&rxmsg[PACKET_TYPE + PACKET_TYPE_SIZE],
 						      (len - PACKET_TYPE_SIZE));
 				break;
@@ -306,10 +301,10 @@ static int bt_hci_send(struct net_buf *buf)
 
 	switch (bt_buf_get_type(buf)) {
 	case BT_BUF_ACL_OUT:
-		net_buf_push_u8(buf, HCI_ACL);
+		net_buf_push_u8(buf, BT_HCI_H4_ACL);
 		break;
 	case BT_BUF_CMD:
-		net_buf_push_u8(buf, HCI_CMD);
+		net_buf_push_u8(buf, BT_HCI_H4_CMD);
 		break;
 	default:
 		LOG_ERR("Unsupported type");

--- a/drivers/bluetooth/hci/hci_b91.c
+++ b/drivers/bluetooth/hci/hci_b91.c
@@ -15,10 +15,6 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_hci_driver_b91);
 
-#define HCI_CMD                 0x01
-#define HCI_ACL                 0x02
-#define HCI_EVT                 0x04
-
 #define HCI_BT_B91_TIMEOUT K_MSEC(2000)
 
 static K_SEM_DEFINE(hci_send_sem, 1, 1);
@@ -148,11 +144,11 @@ static void hci_b91_host_rcv_pkt(uint8_t *data, uint16_t len)
 	len -= sizeof(pkt_indicator);
 
 	switch (pkt_indicator) {
-	case HCI_EVT:
+	case BT_HCI_H4_EVT:
 		buf = bt_b91_evt_recv(data, len);
 		break;
 
-	case HCI_ACL:
+	case BT_HCI_H4_ACL:
 		buf = bt_b91_acl_recv(data, len);
 		break;
 
@@ -186,11 +182,11 @@ static int bt_b91_send(struct net_buf *buf)
 
 	switch (bt_buf_get_type(buf)) {
 	case BT_BUF_ACL_OUT:
-		type = HCI_ACL;
+		type = BT_HCI_H4_ACL;
 		break;
 
 	case BT_BUF_CMD:
-		type = HCI_CMD;
+		type = BT_HCI_H4_CMD;
 		break;
 
 	default:

--- a/drivers/bluetooth/hci/hci_esp32.c
+++ b/drivers/bluetooth/hci/hci_esp32.c
@@ -17,12 +17,6 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_hci_driver_esp32);
 
-#define HCI_CMD                 0x01
-#define HCI_ACL                 0x02
-#define HCI_SCO                 0x03
-#define HCI_EVT                 0x04
-#define HCI_ISO                 0x05
-
 #define HCI_BT_ESP32_TIMEOUT K_MSEC(2000)
 
 static K_SEM_DEFINE(hci_send_sem, 1, 1);
@@ -196,15 +190,15 @@ static int hci_esp_host_rcv_pkt(uint8_t *data, uint16_t len)
 	remaining -= sizeof(pkt_indicator);
 
 	switch (pkt_indicator) {
-	case HCI_EVT:
+	case BT_HCI_H4_EVT:
 		buf = bt_esp_evt_recv(data, remaining);
 		break;
 
-	case HCI_ACL:
+	case BT_HCI_H4_ACL:
 		buf = bt_esp_acl_recv(data, remaining);
 		break;
 
-	case HCI_SCO:
+	case BT_HCI_H4_SCO:
 		buf = bt_esp_iso_recv(data, remaining);
 		break;
 
@@ -241,13 +235,13 @@ static int bt_esp32_send(struct net_buf *buf)
 
 	switch (bt_buf_get_type(buf)) {
 	case BT_BUF_ACL_OUT:
-		pkt_indicator = HCI_ACL;
+		pkt_indicator = BT_HCI_H4_ACL;
 		break;
 	case BT_BUF_CMD:
-		pkt_indicator = HCI_CMD;
+		pkt_indicator = BT_HCI_H4_CMD;
 		break;
 	case BT_BUF_ISO_OUT:
-		pkt_indicator = HCI_ISO;
+		pkt_indicator = BT_HCI_H4_ISO;
 		break;
 	default:
 		LOG_ERR("Unknown type %u", bt_buf_get_type(buf));

--- a/drivers/bluetooth/hci/hci_psoc6_bless.c
+++ b/drivers/bluetooth/hci/hci_psoc6_bless.c
@@ -33,11 +33,6 @@ LOG_MODULE_REGISTER(psoc6_bless);
 
 #define DT_DRV_COMPAT infineon_cat1_bless_hci
 
-#define PACKET_TYPE_HCI_COMMAND     0X1
-#define PACKET_TYPE_HCI_ACL_DATA    0x2
-#define PACKET_TYPE_HCI_SYNCHRONOUS 0X3
-#define PACKET_TYPE_HCI_EVENT       0X4
-
 #define BLE_LOCK_TMOUT_MS       (1000)
 #define BLE_THREAD_SEM_TMOUT_MS (1000)
 
@@ -112,7 +107,7 @@ static void psoc6_bless_events_handler(uint32_t eventCode, void *eventParam)
 	hci_rx = eventParam;
 
 	switch (hci_rx->packetType) {
-	case PACKET_TYPE_HCI_EVENT:
+	case BT_HCI_H4_EVT:
 		buf = bt_buf_get_evt(hci_rx->data[0], 0, K_NO_WAIT);
 		if (!buf) {
 			LOG_ERR("Failed to allocate the buffer for RX: EVENT ");
@@ -120,7 +115,7 @@ static void psoc6_bless_events_handler(uint32_t eventCode, void *eventParam)
 		}
 
 		break;
-	case PACKET_TYPE_HCI_ACL_DATA:
+	case BT_HCI_H4_ACL:
 		buf = bt_buf_get_rx(BT_BUF_ACL_IN, K_NO_WAIT);
 		if (!buf) {
 			LOG_ERR("Failed to allocate the buffer for RX: ACL ");
@@ -168,10 +163,10 @@ static int psoc6_bless_send(struct net_buf *buf)
 
 	switch (bt_buf_get_type(buf)) {
 	case BT_BUF_ACL_OUT:
-		hci_tx_pkt.packetType = PACKET_TYPE_HCI_ACL_DATA;
+		hci_tx_pkt.packetType = BT_HCI_H4_ACL;
 		break;
 	case BT_BUF_CMD:
-		hci_tx_pkt.packetType = PACKET_TYPE_HCI_COMMAND;
+		hci_tx_pkt.packetType = BT_HCI_H4_CMD;
 		break;
 	default:
 		net_buf_unref(buf);

--- a/drivers/bluetooth/hci/hci_stm32wba.c
+++ b/drivers/bluetooth/hci/hci_stm32wba.c
@@ -29,12 +29,6 @@ LOG_MODULE_REGISTER(hci_wba);
 
 static K_SEM_DEFINE(hci_sem, 1, 1);
 
-#define HCI_CMD                 0x01
-#define HCI_ACL                 0x02
-#define HCI_SCO                 0x03
-#define HCI_EVT                 0x04
-#define HCI_ISO                 0x05
-
 #define BLE_CTRLR_STACK_BUFFER_SIZE 300
 
 #define MBLOCK_COUNT	(BLE_MBLOCKS_CALC(PREP_WRITE_LIST_SIZE, \
@@ -225,14 +219,14 @@ static int receive_data(const uint8_t *data, size_t len,
 	len -= sizeof(pkt_indicator);
 
 	switch (pkt_indicator) {
-	case HCI_EVT:
+	case BT_HCI_H4_EVT:
 		buf = treat_evt(data, len);
 		break;
-	case HCI_ACL:
+	case BT_HCI_H4_ACL:
 		buf = treat_acl(data, len + 1, ext_data, ext_len);
 		break;
-	case HCI_ISO:
-	case HCI_SCO:
+	case BT_HCI_H4_ISO:
+	case BT_HCI_H4_SCO:
 		buf = treat_iso(data, len + 1, ext_data, ext_len);
 		break;
 	default:
@@ -289,13 +283,13 @@ static int bt_hci_stm32wba_send(struct net_buf *buf)
 
 	switch (bt_buf_get_type(buf)) {
 	case BT_BUF_ACL_OUT:
-		pkt_indicator = HCI_ACL;
+		pkt_indicator = BT_HCI_H4_ACL;
 		break;
 	case BT_BUF_CMD:
-		pkt_indicator = HCI_CMD;
+		pkt_indicator = BT_HCI_H4_CMD;
 		break;
 	case BT_BUF_ISO_OUT:
-		pkt_indicator = HCI_ISO;
+		pkt_indicator = BT_HCI_H4_ISO;
 		break;
 	default:
 		LOG_ERR("Unknown type %u", bt_buf_get_type(buf));

--- a/drivers/bluetooth/hci/ipc.c
+++ b/drivers/bluetooth/hci/ipc.c
@@ -18,12 +18,6 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_hci_driver);
 
-#define IPC_CMD 0x01
-#define IPC_ACL 0x02
-#define IPC_SCO 0x03
-#define IPC_EVT 0x04
-#define IPC_ISO 0x05
-
 #define IPC_BOUND_TIMEOUT_IN_MS K_MSEC(1000)
 
 static struct ipc_ept hci_ept;
@@ -218,15 +212,15 @@ static void bt_ipc_rx(const uint8_t *data, size_t len)
 	remaining -= sizeof(pkt_indicator);
 
 	switch (pkt_indicator) {
-	case IPC_EVT:
+	case BT_HCI_H4_EVT:
 		buf = bt_ipc_evt_recv(data, remaining);
 		break;
 
-	case IPC_ACL:
+	case BT_HCI_H4_ACL:
 		buf = bt_ipc_acl_recv(data, remaining);
 		break;
 
-	case IPC_ISO:
+	case BT_HCI_H4_ISO:
 		buf = bt_ipc_iso_recv(data, remaining);
 		break;
 
@@ -252,13 +246,13 @@ static int bt_ipc_send(struct net_buf *buf)
 
 	switch (bt_buf_get_type(buf)) {
 	case BT_BUF_ACL_OUT:
-		pkt_indicator = IPC_ACL;
+		pkt_indicator = BT_HCI_H4_ACL;
 		break;
 	case BT_BUF_CMD:
-		pkt_indicator = IPC_CMD;
+		pkt_indicator = BT_HCI_H4_CMD;
 		break;
 	case BT_BUF_ISO_OUT:
-		pkt_indicator = IPC_ISO;
+		pkt_indicator = BT_HCI_H4_ISO;
 		break;
 	default:
 		LOG_ERR("Unknown type %u", bt_buf_get_type(buf));

--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -21,11 +21,6 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_driver);
 
-#define HCI_CMD			0x01
-#define HCI_ACL			0x02
-#define HCI_SCO			0x03
-#define HCI_EVT			0x04
-
 /* Special Values */
 #define SPI_WRITE		0x0A
 #define SPI_READ		0x0B
@@ -189,7 +184,7 @@ static struct net_buf *bt_spi_rx_buf_construct(uint8_t *msg)
 	int len;
 
 	switch (msg[PACKET_TYPE]) {
-	case HCI_EVT:
+	case BT_HCI_H4_EVT:
 		switch (msg[EVT_HEADER_EVENT]) {
 		case BT_HCI_EVT_VENDOR:
 			/* Run event through interface handler */
@@ -220,7 +215,7 @@ static struct net_buf *bt_spi_rx_buf_construct(uint8_t *msg)
 		}
 		net_buf_add_mem(buf, &msg[1], len);
 		break;
-	case HCI_ACL:
+	case BT_HCI_H4_ACL:
 		buf = bt_buf_get_rx(BT_BUF_ACL_IN, K_FOREVER);
 		memcpy(&acl_hdr, &msg[1], sizeof(acl_hdr));
 		len = sizeof(acl_hdr) + sys_le16_to_cpu(acl_hdr.len);
@@ -317,10 +312,10 @@ static int bt_spi_send(struct net_buf *buf)
 
 	switch (bt_buf_get_type(buf)) {
 	case BT_BUF_ACL_OUT:
-		net_buf_push_u8(buf, HCI_ACL);
+		net_buf_push_u8(buf, BT_HCI_H4_ACL);
 		break;
 	case BT_BUF_CMD:
-		net_buf_push_u8(buf, HCI_CMD);
+		net_buf_push_u8(buf, BT_HCI_H4_CMD);
 		break;
 	default:
 		LOG_ERR("Unsupported type");

--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -22,20 +22,31 @@
 extern "C" {
 #endif
 
+/* Bluetooth spec v5.4 Vol 4, Part A Table 2.1: HCI packet indicators
+ * The following definitions are intended for use with the UART Transport Layer and
+ * may be reused with other transport layers if desired.
+ */
+#define BT_HCI_H4_NONE                  0x00    /* None of the known packet types */
+#define BT_HCI_H4_CMD                   0x01    /* HCI Command packet */
+#define BT_HCI_H4_ACL                   0x02    /* HCI ACL Data packet */
+#define BT_HCI_H4_SCO                   0x03    /* HCI Synchronous Data packet */
+#define BT_HCI_H4_EVT                   0x04    /* HCI Event packet */
+#define BT_HCI_H4_ISO                   0x05    /* HCI ISO Data packet */
+
 /* Special own address types for LL privacy (used in adv & scan parameters) */
-#define BT_HCI_OWN_ADDR_RPA_OR_PUBLIC  0x02
-#define BT_HCI_OWN_ADDR_RPA_OR_RANDOM  0x03
-#define BT_HCI_OWN_ADDR_RPA_MASK       0x02
+#define BT_HCI_OWN_ADDR_RPA_OR_PUBLIC   0x02
+#define BT_HCI_OWN_ADDR_RPA_OR_RANDOM   0x03
+#define BT_HCI_OWN_ADDR_RPA_MASK        0x02
 
 #define BT_HCI_PEER_ADDR_RPA_UNRESOLVED 0xfe
 #define BT_HCI_PEER_ADDR_ANONYMOUS      0xff
 
-#define BT_ENC_KEY_SIZE_MIN                     0x07
-#define BT_ENC_KEY_SIZE_MAX                     0x10
+#define BT_ENC_KEY_SIZE_MIN             0x07
+#define BT_ENC_KEY_SIZE_MAX             0x10
 
-#define BT_HCI_ADV_HANDLE_INVALID 0xff
-#define BT_HCI_SYNC_HANDLE_INVALID 0xffff
-#define BT_HCI_PAWR_SUBEVENT_MAX 128
+#define BT_HCI_ADV_HANDLE_INVALID       0xff
+#define BT_HCI_SYNC_HANDLE_INVALID      0xffff
+#define BT_HCI_PAWR_SUBEVENT_MAX        128
 
 /* Bluetooth spec v5.4 Vol 4, Part E - 5.4.3 HCI Synchronous Data Packets */
 struct bt_hci_sco_hdr {


### PR DESCRIPTION
Introduced a unified definition for HCI packet type indicators in `bluetooth/hci_types.h`.
This change streamlines the code in `drivers/bluetooth/hci/`, reducing redundancy.
Enhances maintainability and consistency across all HCI drivers.