### PR TITLE
doc: wget is required for installing Zephyr SDK on macOS

### DIFF
--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -132,7 +132,7 @@ The current minimum required version for the main dependencies are:
 
          .. code-block:: bash
 
-            brew install cmake ninja gperf python3 ccache qemu dtc libmagic
+            brew install cmake ninja gperf python3 ccache qemu dtc libmagic wget
 
       #. Add the Homebrew Python folder to the path, in order to be able to
          execute ``python`` and ``pip`` as well ``python3`` and ``pip3``.


### PR DESCRIPTION
When installing the Zephyr SDK in the second part of the getting started doc on macOS it requires wget to be installed for setup.sh, add this to the earlier homebrew install as a dependency.

Fixes #67406

