### PR TITLE
xtensa: mmu: Fix mmu initialization

### DIFF
--- a/arch/xtensa/core/mmu.c
+++ b/arch/xtensa/core/mmu.c
@@ -165,8 +165,8 @@ void xtensa_init_paging(uint32_t *l1_page)
 	 * initialization entries. Now we're flying free with our own
 	 * page table.
 	 */
-	for (int i = 0; i < 8; i++) {
-		uint32_t ixtlb = (i * 0x2000000000) | XCHAL_SPANNING_WAY;
+	for (uint32_t i = 0; i < 8; i++) {
+		uint32_t ixtlb = (i * 0x20000000) | XCHAL_SPANNING_WAY;
 
 		if (ixtlb != iitlb_pc) {
 			__asm__ volatile("iitlb %0" :: "r"(ixtlb));


### PR DESCRIPTION
The constant used to calculate TLB entries for the way six was wrong and causing an integer overflow. Consequently only the first 512MB where being unmapped from the TLB.