### PR TITLE
drivers: sensor: ina23x: Configurable voltage gain

### DIFF
--- a/drivers/sensor/ina23x/ina230.c
+++ b/drivers/sensor/ina23x/ina230.c
@@ -18,9 +18,6 @@ LOG_MODULE_REGISTER(INA230, CONFIG_SENSOR_LOG_LEVEL);
 /** @brief Calibration scaling value (value scaled by 100000) */
 #define INA230_CAL_SCALING 512ULL
 
-/** @brief The LSB value for the bus voltage register, in microvolts/LSB. */
-#define INA230_BUS_VOLTAGE_UV_LSB 1250U
-
 /** @brief The scaling for the power register. */
 #define INA230_POWER_SCALING 25
 
@@ -34,7 +31,7 @@ static int ina230_channel_get(const struct device *dev, enum sensor_channel chan
 
 	switch (chan) {
 	case SENSOR_CHAN_VOLTAGE:
-		bus_uv = data->bus_voltage * INA230_BUS_VOLTAGE_UV_LSB;
+		bus_uv = data->bus_voltage * config->voltage_lsb;
 
 		/* convert to fractional volts (units for voltage channel) */
 		val->val1 = bus_uv / 1000000U;
@@ -258,6 +255,7 @@ static const struct sensor_driver_api ina230_driver_api = {
 			(DT_INST_ENUM_IDX(inst, vshunt_conversion_time_us) << 3) |   \
 			DT_INST_ENUM_IDX(inst, adc_mode),                            \
 		.current_lsb = DT_INST_PROP(inst, current_lsb_microamps),                          \
+		.voltage_lsb = DT_INST_PROP(inst, voltage_lsb_microvolts),                         \
 		.cal = (uint16_t)((INA230_CAL_SCALING * 10000000ULL) /                             \
 				  ((uint64_t)DT_INST_PROP(inst, current_lsb_microamps) *           \
 				   DT_INST_PROP(inst, rshunt_micro_ohms))),                        \

--- a/drivers/sensor/ina23x/ina230.h
+++ b/drivers/sensor/ina23x/ina230.h
@@ -50,6 +50,7 @@ struct ina230_config {
 	struct i2c_dt_spec bus;
 	uint16_t config;
 	uint32_t current_lsb;
+	uint32_t voltage_lsb;
 	uint16_t cal;
 #ifdef CONFIG_INA230_TRIGGER
 	bool trig_enabled;

--- a/dts/bindings/sensor/ti,ina23x-common.yaml
+++ b/dts/bindings/sensor/ti,ina23x-common.yaml
@@ -24,6 +24,14 @@ properties:
       while keeping a good measurement resolution. The units are in uA/LSB
       so that low maximum currents can be measured with enough resolution.
 
+  voltage-lsb-microvolts:
+    type: int
+    default: 1250
+    description: |
+      Voltage input resolution in microvolts.
+      The default value matches ina230 and ina231.
+      Some parts with higher voltage capability (e.g. ina236) need this set.
+
   rshunt-micro-ohms:
     type: int
     required: true


### PR DESCRIPTION
Added configuration voltage gain to driver.
Allows driver to be used with ina236.