### PR TITLE
pm: Add option to have synchronous runtime power management

### DIFF
--- a/drivers/power_domain/power_domain_gpio.c
+++ b/drivers/power_domain/power_domain_gpio.c
@@ -37,7 +37,7 @@ static int pd_on_domain_visitor(const struct device *dev, void *context)
 	struct pd_visitor_context *visitor_context = context;
 
 	/* Only run action if the device is on the specified domain */
-	if (!dev->pm || (dev->pm->domain != visitor_context->domain)) {
+	if (!dev->pm || (dev->pm_base->domain != visitor_context->domain)) {
 		return 0;
 	}
 

--- a/drivers/power_domain/power_domain_gpio_monitor.c
+++ b/drivers/power_domain/power_domain_gpio_monitor.c
@@ -35,7 +35,7 @@ static int pd_on_domain_visitor(const struct device *dev, void *context)
 	struct pd_visitor_context *visitor_context = context;
 
 	/* Only run action if the device is on the specified domain */
-	if (!dev->pm || (dev->pm->domain != visitor_context->domain)) {
+	if (!dev->pm || (dev->pm_base->domain != visitor_context->domain)) {
 		return 0;
 	}
 

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -371,7 +371,9 @@ struct device_state {
 	bool initialized : 1;
 };
 
+struct pm_device_base;
 struct pm_device;
+struct pm_device_isr;
 
 #ifdef CONFIG_DEVICE_DEPS_DYNAMIC
 #define Z_DEVICE_DEPS_CONST
@@ -409,7 +411,11 @@ struct device {
 	 * Reference to the device PM resources (only available if
 	 * @kconfig{CONFIG_PM_DEVICE} is enabled).
 	 */
-	struct pm_device *pm;
+	union {
+		struct pm_device_base *pm_base;
+		struct pm_device *pm;
+		struct pm_device_isr *pm_isr;
+	};
 #endif
 };
 
@@ -885,7 +891,7 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
  * @brief Initializer for @ref device.
  *
  * @param name_ Name of the device.
- * @param pm_ Reference to @ref pm_device (optional).
+ * @param pm_ Reference to @ref pm_device_base (optional).
  * @param data_ Reference to device data.
  * @param config_ Reference to device config.
  * @param api_ Reference to device API ops.
@@ -900,7 +906,7 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
 		.state = (state_),                                             \
 		.data = (data_),                                               \
 		IF_ENABLED(CONFIG_DEVICE_DEPS, (.deps = (deps_),)) /**/        \
-		IF_ENABLED(CONFIG_PM_DEVICE, (.pm = (pm_),)) /**/              \
+		IF_ENABLED(CONFIG_PM_DEVICE, (.pm_base = (pm_),)) /**/         \
 	}
 
 /**
@@ -919,7 +925,7 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
  * software device).
  * @param dev_id Device identifier (used to name the defined @ref device).
  * @param name Name of the device.
- * @param pm Reference to @ref pm_device associated with the device.
+ * @param pm Reference to @ref pm_device_base associated with the device.
  * (optional).
  * @param data Reference to device data.
  * @param config Reference to device config.
@@ -991,7 +997,7 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
  * @param dev_id Device identifier (used to name the defined @ref device).
  * @param name Name of the device.
  * @param init_fn Device init function.
- * @param pm Reference to @ref pm_device associated with the device.
+ * @param pm Reference to @ref pm_device_base associated with the device.
  * (optional).
  * @param data Reference to device data.
  * @param config Reference to device config.

--- a/kernel/include/kernel_offsets.h
+++ b/kernel/include/kernel_offsets.h
@@ -86,7 +86,7 @@ GEN_ABSOLUTE_SYM(_DEVICE_STRUCT_PM_OFFSET,
 /* member offsets in the pm_device structure. Used in image post-processing */
 
 GEN_ABSOLUTE_SYM(_PM_DEVICE_STRUCT_FLAGS_OFFSET,
-		 offsetof(struct pm_device, flags));
+		 offsetof(struct pm_device_base, flags));
 
 GEN_ABSOLUTE_SYM(_PM_DEVICE_FLAG_PD, PM_DEVICE_FLAG_PD);
 

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -52,7 +52,7 @@ static int runtime_suspend(const struct device *dev, bool async,
 	/*
 	 * Early return if device runtime is not enabled.
 	 */
-	if (!atomic_test_bit(&pm->flags, PM_DEVICE_FLAG_RUNTIME_ENABLED)) {
+	if (!atomic_test_bit(&pm->base.flags, PM_DEVICE_FLAG_RUNTIME_ENABLED)) {
 		return 0;
 	}
 
@@ -65,30 +65,30 @@ static int runtime_suspend(const struct device *dev, bool async,
 		}
 	}
 
-	if (pm->usage == 0U) {
+	if (pm->base.usage == 0U) {
 		LOG_WRN("Unbalanced suspend");
 		ret = -EALREADY;
 		goto unlock;
 	}
 
-	pm->usage--;
-	if (pm->usage > 0U) {
+	pm->base.usage--;
+	if (pm->base.usage > 0U) {
 		goto unlock;
 	}
 
 	if (async && !k_is_pre_kernel()) {
 		/* queue suspend */
-		pm->state = PM_DEVICE_STATE_SUSPENDING;
+		pm->base.state = PM_DEVICE_STATE_SUSPENDING;
 		(void)k_work_schedule(&pm->work, delay);
 	} else {
 		/* suspend now */
-		ret = pm->action_cb(pm->dev, PM_DEVICE_ACTION_SUSPEND);
+		ret = pm->base.action_cb(pm->dev, PM_DEVICE_ACTION_SUSPEND);
 		if (ret < 0) {
-			pm->usage++;
+			pm->base.usage++;
 			goto unlock;
 		}
 
-		pm->state = PM_DEVICE_STATE_SUSPENDED;
+		pm->base.state = PM_DEVICE_STATE_SUSPENDED;
 	}
 
 unlock:
@@ -105,16 +105,16 @@ static void runtime_suspend_work(struct k_work *work)
 	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
 	struct pm_device *pm = CONTAINER_OF(dwork, struct pm_device, work);
 
-	ret = pm->action_cb(pm->dev, PM_DEVICE_ACTION_SUSPEND);
+	ret = pm->base.action_cb(pm->dev, PM_DEVICE_ACTION_SUSPEND);
 
 	(void)k_sem_take(&pm->lock, K_FOREVER);
 	if (ret < 0) {
-		pm->usage++;
-		pm->state = PM_DEVICE_STATE_ACTIVE;
+		pm->base.usage++;
+		pm->base.state = PM_DEVICE_STATE_ACTIVE;
 	} else {
-		pm->state = PM_DEVICE_STATE_SUSPENDED;
+		pm->base.state = PM_DEVICE_STATE_SUSPENDED;
 	}
-	k_event_set(&pm->event, BIT(pm->state));
+	k_event_set(&pm->event, BIT(pm->base.state));
 	k_sem_give(&pm->lock);
 
 	/*
@@ -122,11 +122,45 @@ static void runtime_suspend_work(struct k_work *work)
 	 * finishes its operation
 	 */
 	if ((ret == 0) &&
-	    atomic_test_bit(&pm->flags, PM_DEVICE_FLAG_PD_CLAIMED)) {
-		(void)pm_device_runtime_put(PM_DOMAIN(pm));
+	    atomic_test_bit(&pm->base.flags, PM_DEVICE_FLAG_PD_CLAIMED)) {
+		(void)pm_device_runtime_put(PM_DOMAIN(&pm->base));
 	}
 
 	__ASSERT(ret == 0, "Could not suspend device (%d)", ret);
+}
+
+static int get_sync_locked(const struct device *dev)
+{
+	int ret;
+	struct pm_device_isr *pm = dev->pm_isr;
+	uint32_t flags = pm->base.flags;
+
+	if (pm->base.usage == 0) {
+		if (flags & BIT(PM_DEVICE_FLAG_PD_CLAIMED)) {
+			const struct device *domain = PM_DOMAIN(&pm->base);
+
+			if (domain->pm_base->flags & PM_DEVICE_FLAG_ISR_SAFE) {
+				ret = pm_device_runtime_get(domain);
+				if (ret < 0) {
+					return ret;
+				}
+			} else {
+				return -EWOULDBLOCK;
+			}
+		}
+
+		ret = pm->base.action_cb(dev, PM_DEVICE_ACTION_RESUME);
+		if (ret < 0) {
+			return ret;
+		}
+		pm->base.state = PM_DEVICE_STATE_ACTIVE;
+	} else {
+		ret = 0;
+	}
+
+	pm->base.usage++;
+
+	return ret;
 }
 
 int pm_device_runtime_get(const struct device *dev)
@@ -143,8 +177,17 @@ int pm_device_runtime_get(const struct device *dev)
 	/*
 	 * Early return if device runtime is not enabled.
 	 */
-	if (!atomic_test_bit(&pm->flags, PM_DEVICE_FLAG_RUNTIME_ENABLED)) {
+	if (!atomic_test_bit(&pm->base.flags, PM_DEVICE_FLAG_RUNTIME_ENABLED)) {
 		return 0;
+	}
+
+	if (atomic_test_bit(&dev->pm_base->flags, PM_DEVICE_FLAG_ISR_SAFE)) {
+		struct pm_device_isr *pm_sync = dev->pm_isr;
+		k_spinlock_key_t k = k_spin_lock(&pm_sync->lock);
+
+		ret = get_sync_locked(dev);
+		k_spin_unlock(&pm_sync->lock, k);
+		goto end;
 	}
 
 	if (!k_is_pre_kernel()) {
@@ -154,7 +197,7 @@ int pm_device_runtime_get(const struct device *dev)
 		}
 	}
 
-	if (k_is_in_isr() && (pm->state == PM_DEVICE_STATE_SUSPENDING)) {
+	if (k_is_in_isr() && (pm->base.state == PM_DEVICE_STATE_SUSPENDING)) {
 		ret = -EWOULDBLOCK;
 		goto unlock;
 	}
@@ -163,31 +206,33 @@ int pm_device_runtime_get(const struct device *dev)
 	 * If the device is under a power domain, the domain has to be get
 	 * first.
 	 */
-	if (PM_DOMAIN(pm) != NULL) {
-		ret = pm_device_runtime_get(PM_DOMAIN(pm));
+	const struct device *domain = PM_DOMAIN(&pm->base);
+
+	if (domain != NULL) {
+		ret = pm_device_runtime_get(domain);
 		if (ret != 0) {
 			goto unlock;
 		}
 		/* Check if powering up this device failed */
-		if (atomic_test_bit(&pm->flags, PM_DEVICE_FLAG_TURN_ON_FAILED)) {
-			(void)pm_device_runtime_put(PM_DOMAIN(pm));
+		if (atomic_test_bit(&pm->base.flags, PM_DEVICE_FLAG_TURN_ON_FAILED)) {
+			(void)pm_device_runtime_put(domain);
 			ret = -EAGAIN;
 			goto unlock;
 		}
 		/* Power domain successfully claimed */
-		atomic_set_bit(&pm->flags, PM_DEVICE_FLAG_PD_CLAIMED);
+		atomic_set_bit(&pm->base.flags, PM_DEVICE_FLAG_PD_CLAIMED);
 	}
 
-	pm->usage++;
+	pm->base.usage++;
 
 	/*
 	 * Check if the device has a pending suspend operation (not started
 	 * yet) and cancel it. This way we avoid unnecessary operations because
 	 * the device is actually active.
 	 */
-	if ((pm->state == PM_DEVICE_STATE_SUSPENDING) &&
+	if ((pm->base.state == PM_DEVICE_STATE_SUSPENDING) &&
 		((k_work_cancel_delayable(&pm->work) & K_WORK_RUNNING) == 0)) {
-		pm->state = PM_DEVICE_STATE_ACTIVE;
+		pm->base.state = PM_DEVICE_STATE_ACTIVE;
 		goto unlock;
 	}
 
@@ -196,7 +241,7 @@ int pm_device_runtime_get(const struct device *dev)
 		 * If the device is already suspending there is
 		 * nothing else we can do but wait until it finishes.
 		 */
-		while (pm->state == PM_DEVICE_STATE_SUSPENDING) {
+		while (pm->base.state == PM_DEVICE_STATE_SUSPENDING) {
 			k_sem_give(&pm->lock);
 
 			k_event_wait(&pm->event, EVENT_MASK, true, K_FOREVER);
@@ -205,24 +250,64 @@ int pm_device_runtime_get(const struct device *dev)
 		}
 	}
 
-	if (pm->usage > 1U) {
+	if (pm->base.usage > 1U) {
 		goto unlock;
 	}
 
-	ret = pm->action_cb(pm->dev, PM_DEVICE_ACTION_RESUME);
+	ret = pm->base.action_cb(pm->dev, PM_DEVICE_ACTION_RESUME);
 	if (ret < 0) {
-		pm->usage--;
+		pm->base.usage--;
 		goto unlock;
 	}
 
-	pm->state = PM_DEVICE_STATE_ACTIVE;
+	pm->base.state = PM_DEVICE_STATE_ACTIVE;
 
 unlock:
 	if (!k_is_pre_kernel()) {
 		k_sem_give(&pm->lock);
 	}
 
+end:
 	SYS_PORT_TRACING_FUNC_EXIT(pm, device_runtime_get, dev, ret);
+
+	return ret;
+}
+
+
+static int put_sync_locked(const struct device *dev)
+{
+	int ret;
+	struct pm_device_isr *pm = dev->pm_isr;
+	uint32_t flags = pm->base.flags;
+
+	if (!(flags & BIT(PM_DEVICE_FLAG_RUNTIME_ENABLED))) {
+		return 0;
+	}
+
+	if (pm->base.usage == 0U) {
+		return -EALREADY;
+	}
+
+	pm->base.usage--;
+	if (pm->base.usage == 0U) {
+		ret = pm->base.action_cb(dev, PM_DEVICE_ACTION_SUSPEND);
+		if (ret < 0) {
+			return ret;
+		}
+		pm->base.state = PM_DEVICE_STATE_SUSPENDED;
+
+		if (flags & BIT(PM_DEVICE_FLAG_PD_CLAIMED)) {
+			const struct device *domain = PM_DOMAIN(&pm->base);
+
+			if (domain->pm_base->flags & PM_DEVICE_FLAG_ISR_SAFE) {
+				ret = put_sync_locked(domain);
+			} else {
+				ret = -EWOULDBLOCK;
+			}
+		}
+	} else {
+		ret = 0;
+	}
 
 	return ret;
 }
@@ -231,19 +316,29 @@ int pm_device_runtime_put(const struct device *dev)
 {
 	int ret;
 
-	if (dev->pm == NULL) {
+	if (dev->pm_base == NULL) {
 		return 0;
 	}
 
 	SYS_PORT_TRACING_FUNC_ENTER(pm, device_runtime_put, dev);
-	ret = runtime_suspend(dev, false, K_NO_WAIT);
 
-	/*
-	 * Now put the domain
-	 */
-	if ((ret == 0) &&
-	    atomic_test_bit(&dev->pm->flags, PM_DEVICE_FLAG_PD_CLAIMED)) {
-		ret = pm_device_runtime_put(PM_DOMAIN(dev->pm));
+	if (atomic_test_bit(&dev->pm_base->flags, PM_DEVICE_FLAG_ISR_SAFE)) {
+		struct pm_device_isr *pm_sync = dev->pm_isr;
+		k_spinlock_key_t k = k_spin_lock(&pm_sync->lock);
+
+		ret = put_sync_locked(dev);
+
+		k_spin_unlock(&pm_sync->lock, k);
+	} else {
+		ret = runtime_suspend(dev, false, K_NO_WAIT);
+
+		/*
+		 * Now put the domain
+		 */
+		if ((ret == 0) &&
+		    atomic_test_bit(&dev->pm_base->flags, PM_DEVICE_FLAG_PD_CLAIMED)) {
+			ret = pm_device_runtime_put(PM_DOMAIN(dev->pm_base));
+		}
 	}
 	SYS_PORT_TRACING_FUNC_EXIT(pm, device_runtime_put, dev, ret);
 
@@ -254,12 +349,21 @@ int pm_device_runtime_put_async(const struct device *dev, k_timeout_t delay)
 {
 	int ret;
 
-	if (dev->pm == NULL) {
+	if (dev->pm_base == NULL) {
 		return 0;
 	}
 
 	SYS_PORT_TRACING_FUNC_ENTER(pm, device_runtime_put_async, dev, delay);
-	ret = runtime_suspend(dev, true, delay);
+	if (atomic_test_bit(&dev->pm_base->flags, PM_DEVICE_FLAG_ISR_SAFE)) {
+		struct pm_device_isr *pm_sync = dev->pm_isr;
+		k_spinlock_key_t k = k_spin_lock(&pm_sync->lock);
+
+		ret = put_sync_locked(dev);
+
+		k_spin_unlock(&pm_sync->lock, k);
+	} else {
+		ret = runtime_suspend(dev, true, delay);
+	}
 	SYS_PORT_TRACING_FUNC_EXIT(pm, device_runtime_put_async, dev, delay, ret);
 
 	return ret;
@@ -268,13 +372,43 @@ int pm_device_runtime_put_async(const struct device *dev, k_timeout_t delay)
 __boot_func
 int pm_device_runtime_auto_enable(const struct device *dev)
 {
-	struct pm_device *pm = dev->pm;
+	struct pm_device_base *pm = dev->pm_base;
 
 	/* No action needed if PM_DEVICE_FLAG_RUNTIME_AUTO is not enabled */
 	if (!pm || !atomic_test_bit(&pm->flags, PM_DEVICE_FLAG_RUNTIME_AUTO)) {
 		return 0;
 	}
 	return pm_device_runtime_enable(dev);
+}
+
+static int runtime_enable_sync(const struct device *dev)
+{
+	int ret;
+	struct pm_device_isr *pm = dev->pm_isr;
+	k_spinlock_key_t k = k_spin_lock(&pm->lock);
+
+	/* Because context is locked we can access flags directly. */
+	if (pm->base.flags & BIT(PM_DEVICE_FLAG_RUNTIME_ENABLED)) {
+		ret = 0;
+		goto unlock;
+	}
+
+	if (pm->base.state == PM_DEVICE_STATE_ACTIVE) {
+		ret = pm->base.action_cb(dev, PM_DEVICE_ACTION_SUSPEND);
+		if (ret < 0) {
+			goto unlock;
+		}
+
+		pm->base.state = PM_DEVICE_STATE_SUSPENDED;
+	} else {
+		ret = 0;
+	}
+
+	pm->base.flags |= BIT(PM_DEVICE_FLAG_RUNTIME_ENABLED);
+	pm->base.usage = 0U;
+unlock:
+	k_spin_unlock(&pm->lock, k);
+	return ret;
 }
 
 int pm_device_runtime_enable(const struct device *dev)
@@ -293,11 +427,16 @@ int pm_device_runtime_enable(const struct device *dev)
 		goto end;
 	}
 
+	if (atomic_test_bit(&dev->pm_base->flags, PM_DEVICE_FLAG_ISR_SAFE)) {
+		ret = runtime_enable_sync(dev);
+		goto end;
+	}
+
 	if (!k_is_pre_kernel()) {
 		(void)k_sem_take(&pm->lock, K_FOREVER);
 	}
 
-	if (atomic_test_bit(&pm->flags, PM_DEVICE_FLAG_RUNTIME_ENABLED)) {
+	if (atomic_test_bit(&pm->base.flags, PM_DEVICE_FLAG_RUNTIME_ENABLED)) {
 		goto unlock;
 	}
 
@@ -307,17 +446,17 @@ int pm_device_runtime_enable(const struct device *dev)
 		k_work_init_delayable(&pm->work, runtime_suspend_work);
 	}
 
-	if (pm->state == PM_DEVICE_STATE_ACTIVE) {
-		ret = pm->action_cb(pm->dev, PM_DEVICE_ACTION_SUSPEND);
+	if (pm->base.state == PM_DEVICE_STATE_ACTIVE) {
+		ret = pm->base.action_cb(pm->dev, PM_DEVICE_ACTION_SUSPEND);
 		if (ret < 0) {
 			goto unlock;
 		}
-		pm->state = PM_DEVICE_STATE_SUSPENDED;
+		pm->base.state = PM_DEVICE_STATE_SUSPENDED;
 	}
 
-	pm->usage = 0U;
+	pm->base.usage = 0U;
 
-	atomic_set_bit(&pm->flags, PM_DEVICE_FLAG_RUNTIME_ENABLED);
+	atomic_set_bit(&pm->base.flags, PM_DEVICE_FLAG_RUNTIME_ENABLED);
 
 unlock:
 	if (!k_is_pre_kernel()) {
@@ -326,6 +465,34 @@ unlock:
 
 end:
 	SYS_PORT_TRACING_FUNC_EXIT(pm, device_runtime_enable, dev, ret);
+	return ret;
+}
+
+static int runtime_disable_sync(const struct device *dev)
+{
+	struct pm_device_isr *pm = dev->pm_isr;
+	int ret;
+	k_spinlock_key_t k = k_spin_lock(&pm->lock);
+
+	if (!(pm->base.flags & BIT(PM_DEVICE_FLAG_RUNTIME_ENABLED))) {
+		ret = 0;
+		goto unlock;
+	}
+
+	if (pm->base.state == PM_DEVICE_STATE_SUSPENDED) {
+		ret = pm->base.action_cb(dev, PM_DEVICE_ACTION_RESUME);
+		if (ret < 0) {
+			goto unlock;
+		}
+
+		pm->base.state = PM_DEVICE_STATE_ACTIVE;
+	} else {
+		ret = 0;
+	}
+
+	pm->base.flags &= ~BIT(PM_DEVICE_FLAG_RUNTIME_ENABLED);
+unlock:
+	k_spin_unlock(&pm->lock, k);
 	return ret;
 }
 
@@ -340,23 +507,28 @@ int pm_device_runtime_disable(const struct device *dev)
 
 	SYS_PORT_TRACING_FUNC_ENTER(pm, device_runtime_disable, dev);
 
+	if (atomic_test_bit(&dev->pm_base->flags, PM_DEVICE_FLAG_ISR_SAFE)) {
+		ret = runtime_disable_sync(dev);
+		goto end;
+	}
+
 	if (!k_is_pre_kernel()) {
 		(void)k_sem_take(&pm->lock, K_FOREVER);
 	}
 
-	if (!atomic_test_bit(&pm->flags, PM_DEVICE_FLAG_RUNTIME_ENABLED)) {
+	if (!atomic_test_bit(&pm->base.flags, PM_DEVICE_FLAG_RUNTIME_ENABLED)) {
 		goto unlock;
 	}
 
 	if (!k_is_pre_kernel()) {
-		if ((pm->state == PM_DEVICE_STATE_SUSPENDING) &&
+		if ((pm->base.state == PM_DEVICE_STATE_SUSPENDING) &&
 			((k_work_cancel_delayable(&pm->work) & K_WORK_RUNNING) == 0)) {
-			pm->state = PM_DEVICE_STATE_ACTIVE;
+			pm->base.state = PM_DEVICE_STATE_ACTIVE;
 			goto clear_bit;
 		}
 
 		/* wait until possible async suspend is completed */
-		while (pm->state == PM_DEVICE_STATE_SUSPENDING) {
+		while (pm->base.state == PM_DEVICE_STATE_SUSPENDING) {
 			k_sem_give(&pm->lock);
 
 			k_event_wait(&pm->event, EVENT_MASK, true, K_FOREVER);
@@ -366,23 +538,24 @@ int pm_device_runtime_disable(const struct device *dev)
 	}
 
 	/* wake up the device if suspended */
-	if (pm->state == PM_DEVICE_STATE_SUSPENDED) {
-		ret = pm->action_cb(pm->dev, PM_DEVICE_ACTION_RESUME);
+	if (pm->base.state == PM_DEVICE_STATE_SUSPENDED) {
+		ret = pm->base.action_cb(dev, PM_DEVICE_ACTION_RESUME);
 		if (ret < 0) {
 			goto unlock;
 		}
 
-		pm->state = PM_DEVICE_STATE_ACTIVE;
+		pm->base.state = PM_DEVICE_STATE_ACTIVE;
 	}
 
 clear_bit:
-	atomic_clear_bit(&pm->flags, PM_DEVICE_FLAG_RUNTIME_ENABLED);
+	atomic_clear_bit(&pm->base.flags, PM_DEVICE_FLAG_RUNTIME_ENABLED);
 
 unlock:
 	if (!k_is_pre_kernel()) {
 		k_sem_give(&pm->lock);
 	}
 
+end:
 	SYS_PORT_TRACING_FUNC_EXIT(pm, device_runtime_disable, dev, ret);
 
 	return ret;
@@ -390,7 +563,7 @@ unlock:
 
 bool pm_device_runtime_is_enabled(const struct device *dev)
 {
-	struct pm_device *pm = dev->pm;
+	struct pm_device_base *pm = dev->pm_base;
 
 	return pm && atomic_test_bit(&pm->flags, PM_DEVICE_FLAG_RUNTIME_ENABLED);
 }

--- a/tests/subsys/pm/device_runtime_api/Kconfig
+++ b/tests/subsys/pm/device_runtime_api/Kconfig
@@ -1,0 +1,8 @@
+# Copyright 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+source "Kconfig.zephyr"
+
+config TEST_PM_DEVICE_ISR_SAFE
+	bool "Use ISR safe PM for the test"

--- a/tests/subsys/pm/device_runtime_api/src/main.c
+++ b/tests/subsys/pm/device_runtime_api/src/main.c
@@ -141,105 +141,111 @@ ZTEST(device_runtime_api, test_api)
 	ret = pm_device_runtime_put_async(test_dev, K_NO_WAIT);
 	zassert_equal(ret, 0);
 
-	(void)pm_device_state_get(test_dev, &state);
-	zassert_equal(state, PM_DEVICE_STATE_SUSPENDING);
+	if (IS_ENABLED(CONFIG_TEST_PM_DEVICE_ISR_SAFE)) {
+		/* In sync mode async put is equivalent as normal put. */
+		(void)pm_device_state_get(test_dev, &state);
+		zassert_equal(state, PM_DEVICE_STATE_SUSPENDED);
+	} else {
+		(void)pm_device_state_get(test_dev, &state);
+		zassert_equal(state, PM_DEVICE_STATE_SUSPENDING);
 
-	/* usage: 0, -1, suspend: no (unbalanced call) */
-	ret = pm_device_runtime_put(test_dev);
-	zassert_equal(ret, -EALREADY);
+		/* usage: 0, -1, suspend: no (unbalanced call) */
+		ret = pm_device_runtime_put(test_dev);
+		zassert_equal(ret, -EALREADY);
 
-	/* usage: 0, -1, suspend: no (unbalanced call) */
-	ret = pm_device_runtime_put_async(test_dev, K_NO_WAIT);
-	zassert_equal(ret, -EALREADY);
+		/* usage: 0, -1, suspend: no (unbalanced call) */
+		ret = pm_device_runtime_put_async(test_dev, K_NO_WAIT);
+		zassert_equal(ret, -EALREADY);
 
-	/* unblock test driver and let it finish */
-	test_driver_pm_done(test_dev);
-	k_yield();
+		/* unblock test driver and let it finish */
+		test_driver_pm_done(test_dev);
+		k_yield();
 
-	(void)pm_device_state_get(test_dev, &state);
-	zassert_equal(state, PM_DEVICE_STATE_SUSPENDED);
+		(void)pm_device_state_get(test_dev, &state);
+		zassert_equal(state, PM_DEVICE_STATE_SUSPENDED);
 
-	/*** get + asynchronous put + get (while suspend still ongoing) ***/
+		/*** get + asynchronous put + get (while suspend still ongoing) ***/
 
-	/* usage: 0, +1, resume: yes */
-	ret = pm_device_runtime_get(test_dev);
-	zassert_equal(ret, 0);
+		/* usage: 0, +1, resume: yes */
+		ret = pm_device_runtime_get(test_dev);
+		zassert_equal(ret, 0);
 
-	(void)pm_device_state_get(test_dev, &state);
-	zassert_equal(state, PM_DEVICE_STATE_ACTIVE);
+		(void)pm_device_state_get(test_dev, &state);
+		zassert_equal(state, PM_DEVICE_STATE_ACTIVE);
 
-	test_driver_pm_async(test_dev);
+		test_driver_pm_async(test_dev);
 
-	/* usage: 1, -1, suspend: yes (queued) */
-	ret = pm_device_runtime_put_async(test_dev, K_NO_WAIT);
-	zassert_equal(ret, 0);
+		/* usage: 1, -1, suspend: yes (queued) */
+		ret = pm_device_runtime_put_async(test_dev, K_NO_WAIT);
+		zassert_equal(ret, 0);
 
-	(void)pm_device_state_get(test_dev, &state);
-	zassert_equal(state, PM_DEVICE_STATE_SUSPENDING);
+		(void)pm_device_state_get(test_dev, &state);
+		zassert_equal(state, PM_DEVICE_STATE_SUSPENDING);
 
-	/* let suspension start */
-	k_yield();
+		/* let suspension start */
+		k_yield();
 
-	/* create and start get_runner thread
-	 * get_runner thread is used to test synchronous path while asynchronous
-	 * is ongoing. It is important to set its priority >= to the system work
-	 * queue to make sure sync path run by the thread is forced to wait.
-	 */
-	k_thread_create(&get_runner_td, get_runner_stack,
-			K_THREAD_STACK_SIZEOF(get_runner_stack), get_runner,
-			NULL, NULL, NULL, CONFIG_SYSTEM_WORKQUEUE_PRIORITY, 0,
-			K_NO_WAIT);
-	k_yield();
+		/* create and start get_runner thread
+		 * get_runner thread is used to test synchronous path while asynchronous
+		 * is ongoing. It is important to set its priority >= to the system work
+		 * queue to make sure sync path run by the thread is forced to wait.
+		 */
+		k_thread_create(&get_runner_td, get_runner_stack,
+				K_THREAD_STACK_SIZEOF(get_runner_stack), get_runner,
+				NULL, NULL, NULL, CONFIG_SYSTEM_WORKQUEUE_PRIORITY, 0,
+				K_NO_WAIT);
+		k_yield();
 
-	/* let driver suspend to finish and wait until get_runner finishes
-	 * resuming the driver
-	 */
-	test_driver_pm_done(test_dev);
-	k_thread_join(&get_runner_td, K_FOREVER);
+		/* let driver suspend to finish and wait until get_runner finishes
+		 * resuming the driver
+		 */
+		test_driver_pm_done(test_dev);
+		k_thread_join(&get_runner_td, K_FOREVER);
 
-	(void)pm_device_state_get(test_dev, &state);
-	zassert_equal(state, PM_DEVICE_STATE_ACTIVE);
+		(void)pm_device_state_get(test_dev, &state);
+		zassert_equal(state, PM_DEVICE_STATE_ACTIVE);
 
-	/* Test if getting a device before an async operation starts does
-	 * not trigger any device pm action.
-	 */
-	size_t count = test_driver_pm_count(test_dev);
+		/* Test if getting a device before an async operation starts does
+		 * not trigger any device pm action.
+		 */
+		size_t count = test_driver_pm_count(test_dev);
 
-	ret = pm_device_runtime_put_async(test_dev, K_MSEC(10));
-	zassert_equal(ret, 0);
+		ret = pm_device_runtime_put_async(test_dev, K_MSEC(10));
+		zassert_equal(ret, 0);
 
-	(void)pm_device_state_get(test_dev, &state);
-	zassert_equal(state, PM_DEVICE_STATE_SUSPENDING);
+		(void)pm_device_state_get(test_dev, &state);
+		zassert_equal(state, PM_DEVICE_STATE_SUSPENDING);
 
-	ret = pm_device_runtime_get(test_dev);
-	zassert_equal(ret, 0);
+		ret = pm_device_runtime_get(test_dev);
+		zassert_equal(ret, 0);
 
-	/* Now lets check if the calls above have triggered a device
-	 * pm action
-	 */
-	zassert_equal(count, test_driver_pm_count(test_dev));
+		/* Now lets check if the calls above have triggered a device
+		 * pm action
+		 */
+		zassert_equal(count, test_driver_pm_count(test_dev));
 
-	/*
-	 * test if async put with a delay respects the given time.
-	 */
-	ret = pm_device_runtime_put_async(test_dev, K_MSEC(100));
+		/*
+		 * test if async put with a delay respects the given time.
+		 */
+		ret = pm_device_runtime_put_async(test_dev, K_MSEC(100));
 
-	(void)pm_device_state_get(test_dev, &state);
-	zassert_equal(state, PM_DEVICE_STATE_SUSPENDING);
+		(void)pm_device_state_get(test_dev, &state);
+		zassert_equal(state, PM_DEVICE_STATE_SUSPENDING);
 
-	k_sleep(K_MSEC(80));
+		k_sleep(K_MSEC(80));
 
-	/* It should still be suspending since we have waited less than
-	 * the delay we've set.
-	 */
-	(void)pm_device_state_get(test_dev, &state);
-	zassert_equal(state, PM_DEVICE_STATE_SUSPENDING);
+		/* It should still be suspending since we have waited less than
+		 * the delay we've set.
+		 */
+		(void)pm_device_state_get(test_dev, &state);
+		zassert_equal(state, PM_DEVICE_STATE_SUSPENDING);
 
-	k_sleep(K_MSEC(30));
+		k_sleep(K_MSEC(30));
 
-	/* Now it should be already suspended */
-	(void)pm_device_state_get(test_dev, &state);
-	zassert_equal(state, PM_DEVICE_STATE_SUSPENDED);
+		/* Now it should be already suspended */
+		(void)pm_device_state_get(test_dev, &state);
+		zassert_equal(state, PM_DEVICE_STATE_SUSPENDED);
+	}
 
 	/* Put operation should fail due the state be locked. */
 	ret = pm_device_runtime_disable(test_dev);

--- a/tests/subsys/pm/device_runtime_api/src/test_driver.c
+++ b/tests/subsys/pm/device_runtime_api/src/test_driver.c
@@ -74,11 +74,9 @@ int test_driver_init(const struct device *dev)
 	return 0;
 }
 
-#if CONFIG_TEST_PM_DEVICE_ISR_SAFE
-PM_DEVICE_ISR_SAFE_DEFINE(test_driver, test_driver_action);
-#else
-PM_DEVICE_DEFINE(test_driver, test_driver_action);
-#endif
+#define PM_DEVICE_TYPE COND_CODE_1(CONFIG_TEST_PM_DEVICE_ISR_SAFE, (PM_DEVICE_ISR_SAFE), (0))
+
+PM_DEVICE_DEFINE(test_driver, test_driver_action, PM_DEVICE_TYPE);
 
 static struct test_driver_data data;
 

--- a/tests/subsys/pm/device_runtime_api/src/test_driver.c
+++ b/tests/subsys/pm/device_runtime_api/src/test_driver.c
@@ -21,14 +21,16 @@ static int test_driver_action(const struct device *dev,
 {
 	struct test_driver_data *data = dev->data;
 
-	data->ongoing = true;
+	if (!IS_ENABLED(CONFIG_TEST_PM_DEVICE_ISR_SAFE)) {
+		data->ongoing = true;
 
-	if (data->async) {
-		k_sem_take(&data->sync, K_FOREVER);
-		data->async = false;
+		if (data->async) {
+			k_sem_take(&data->sync, K_FOREVER);
+			data->async = false;
+		}
+
+		data->ongoing = false;
 	}
-
-	data->ongoing = false;
 
 	data->count++;
 
@@ -72,7 +74,11 @@ int test_driver_init(const struct device *dev)
 	return 0;
 }
 
+#if CONFIG_TEST_PM_DEVICE_ISR_SAFE
+PM_DEVICE_ISR_SAFE_DEFINE(test_driver, test_driver_action);
+#else
 PM_DEVICE_DEFINE(test_driver, test_driver_action);
+#endif
 
 static struct test_driver_data data;
 

--- a/tests/subsys/pm/device_runtime_api/testcase.yaml
+++ b/tests/subsys/pm/device_runtime_api/testcase.yaml
@@ -3,3 +3,9 @@ tests:
     tags: pm
     integration_platforms:
       - native_sim
+  pm.device_runtime.isr_safe.api:
+    tags: pm
+    integration_platforms:
+      - native_sim
+    extra_configs:
+      - CONFIG_TEST_PM_DEVICE_ISR_SAFE=y


### PR DESCRIPTION
Current solution assumes that power management operations may be blocking, asynchronous and take unknown amount of time. Due to this assumption runtime PM API cannot be effectively used from the interrupt context. Zephyr has few driver APIs which can be used from an interrupt context (UART async and polling,  rtio work also targets asynchronous ops) and now use of runtime PM is limited in those cases. Given that In many cases suspending or resuming of a device is limited to just a few register writes having whole infrastructure with semaphore, event and work queue is like using sledgehammer to crack a nut.

Patch introduces a new type of PM device - synchronous PM. If device is specified as capable of synchronous PM operations then device runtime getting and putting is executed in the critical  section. In that case, runtime API can be used from an interrupt context. Additionally, this approach reduces RAM needed for PM device (104 -> 20 bytes of RAM on ARM Cortex-M) because PM data structure is limited and does not contain work,event and semaphore.

If driver has synchronous PM operations (like only changing pinctrl state) then PM device can be defined as
```
PM_DEVICE_SYNC_DEFINE(test_driver, test_driver_action); // instead of PM_DEVICE_DEFINE

PM_DEVICE_SYNC_DT_DEFINE(UARTE(idx), uarte_nrfx_pm_action) // instead of PM_DEVICE_DT_DEFINE
```

Runtime API stays the same. Synchronous PM device property is detected inside the API.