### PR TITLE
cmake: cache BOARD_IDENTIFIER to preserve it between CMake invocations

### DIFF
--- a/cmake/modules/boards.cmake
+++ b/cmake/modules/boards.cmake
@@ -234,6 +234,7 @@ elseif(HWMv2)
             `${BOARD}` not found. Please specify a valid board.\n"
             "Valid board identifiers for ${BOARD_NAME} are:\n${BOARD_IDENTIFIERS}\n")
     endif()
+    set(BOARD_IDENTIFIER ${BOARD_IDENTIFIER} CACHE INTERNAL "Board identifier")
   endif()
 else()
   message(FATAL_ERROR "Unknown hw model (${HWM}) for board: ${BOARD}.")


### PR DESCRIPTION
A CMake rerun would not extract or determine the BOARD_IDENTIFIER correctly because `list_boards.py` is only invoked for first CMake invocation.

Therefore cache the BOARD_IDENTIFIER so that it's preserved between CMake re-runs.