### PR TITLE
drivers: pinctrl: pfc_rcar: add mapping of memory for Spider ARM64

### DIFF
--- a/drivers/pinctrl/pfc_rcar.c
+++ b/drivers/pinctrl/pfc_rcar.c
@@ -21,19 +21,23 @@
 #if defined(CONFIG_SOC_SERIES_RCAR_GEN3)
 #define PFC_RCAR_GPSR 0x100
 #define PFC_RCAR_IPSR 0x200
-DEVICE_MMIO_TOPLEVEL_STATIC(pfc, DT_DRV_INST(0));
-static uintptr_t reg_base[1];
 #elif defined(CONFIG_SOC_SERIES_RCAR_GEN4)
 #define PFC_RCAR_GPSR 0x040
 #define PFC_RCAR_IPSR 0x060
-/* swap both arguments */
-#define PFC_REG_ADDRESS(idx, node_id) DT_REG_ADDR_BY_IDX(node_id, idx)
-static const uintptr_t reg_base[] = {
-	LISTIFY(DT_NUM_REGS(DT_DRV_INST(0)), PFC_REG_ADDRESS, (,), DT_DRV_INST(0))
-};
 #else
 #error Unsupported SoC Series
 #endif
+
+/* swap both arguments */
+#define PFC_REG_ADDRESS(idx, inst) DT_INST_REG_ADDR_BY_IDX(inst, idx)
+static uintptr_t reg_base[] = {
+	LISTIFY(DT_NUM_REGS(DT_DRV_INST(0)), PFC_REG_ADDRESS, (,), 0)
+};
+
+#define PFC_REG_SIZE(idx, inst) DT_INST_REG_SIZE_BY_IDX(inst, idx)
+static const uintptr_t __maybe_unused reg_sizes[] = {
+	LISTIFY(DT_NUM_REGS(DT_DRV_INST(0)), PFC_REG_SIZE, (,), 0)
+};
 
 #ifdef CONFIG_PINCTRL_RCAR_VOLTAGE_CONTROL
 /* POC Control Register can control IO voltage level that is supplied to the pin */
@@ -372,11 +376,12 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 	return ret;
 }
 
-#if defined(CONFIG_SOC_SERIES_RCAR_GEN3)
+#if defined(DEVICE_MMIO_IS_IN_RAM)
 __boot_func static int pfc_rcar_driver_init(void)
 {
-	DEVICE_MMIO_TOPLEVEL_MAP(pfc, K_MEM_CACHE_NONE);
-	reg_base[0] = DEVICE_MMIO_TOPLEVEL_GET(pfc);
+	for (unsigned int i = 0; i < ARRAY_SIZE(reg_base); i++) {
+		device_map(reg_base + i, reg_base[i], reg_sizes[i], K_MEM_CACHE_NONE);
+	}
 	return 0;
 }
 


### PR DESCRIPTION
Add mapping of PFC device memory for Spider ARM64. Make mapping code common for all RCar boards.