### PR TITLE
cmake: modules: extensions: include for shield-specific overlays

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -2322,7 +2322,7 @@ endfunction()
 #                     - DTS:       Overlay files (.overlay)
 #                     - Kconfig:   Config fragments (.conf)
 #                     The conf file search will return existing configuration
-#                     files for the current board.
+#                     files for the current board and shields.
 #                     CONF_FILES takes the following additional arguments:
 #                     BOARD <board>:             Find configuration files for specified board.
 #                     BOARD_REVISION <revision>: Find configuration files for specified board
@@ -2421,6 +2421,11 @@ Relative paths are only allowed with `-D${ARGV1}=<path>`")
                         BUILD ${FILE_BUILD}
     )
     list(APPEND filename_list ${filename})
+
+    foreach(shield ${SHIELD_AS_LIST})
+      list(APPEND filename_list ${shield})
+    endforeach()
+
     list(REMOVE_DUPLICATES filename_list)
 
     if(FILE_DTS)

--- a/doc/build/dts/howtos.rst
+++ b/doc/build/dts/howtos.rst
@@ -242,6 +242,8 @@ use as devicetree overlays:
    and :file:`boards/<BOARD>_<revision>.overlay` exists, it will be used.
    This file will be used in addition to :file:`boards/<BOARD>.overlay`
    if both exist.
+#. For each :ref:`shield <shields>`, if :file:`boards/<SHIELD>.overlay` exists,
+   it will be used.
 #. If one or more files have been found in the previous steps, the build system
    stops looking and just uses those files.
 #. Otherwise, if :file:`<BOARD>.overlay` exists, it will be used, and the build

--- a/samples/drivers/adc/boards/mikroe_adc_click.overlay
+++ b/samples/drivers/adc/boards/mikroe_adc_click.overlay
@@ -1,0 +1,55 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2023 Vestas Wind Systems A/S
+ */
+
+/ {
+	zephyr,user {
+		io-channels = <&mcp3204_mikroe_adc_click 0>,
+			      <&mcp3204_mikroe_adc_click 1>,
+			      <&mcp3204_mikroe_adc_click 2>,
+			      <&mcp3204_mikroe_adc_click 3>;
+	};
+};
+
+&mcp3204_mikroe_adc_click {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_EXTERNAL0";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,vref-mv = <3300>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_EXTERNAL0";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,vref-mv = <3300>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_EXTERNAL0";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,vref-mv = <3300>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@3 {
+		reg = <3>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_EXTERNAL0";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,vref-mv = <3300>;
+		zephyr,resolution = <12>;
+	};
+};


### PR DESCRIPTION
Include shield-specific overlays in zephyr_file(). Shield-specific overlays are included after any board-specific overlays.