### PR TITLE
boards: arm: nucleo_g0b1re, nucleo_g474re: list FDCAN1 as supported in the docs

### DIFF
--- a/boards/arm/nucleo_g0b1re/doc/index.rst
+++ b/boards/arm/nucleo_g0b1re/doc/index.rst
@@ -108,6 +108,8 @@ The Zephyr nucleo_g0b1re board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | die-temp  | on-chip    | die temperature sensor              |
 +-----------+------------+-------------------------------------+
+| FDCAN1    | on-chip    | CAN controller                      |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported in this Zephyr port.
 
@@ -137,6 +139,7 @@ Default Zephyr Peripheral Mapping:
 - ADC1 IN0  : PA0
 - ADC1 IN1  : PA1
 - DAC1_OUT1 : PA4
+- FDCAN1 RX/TX: PA11/PA12
 
 For more details please refer to `STM32 Nucleo-64 board User Manual`_.
 

--- a/boards/arm/nucleo_g474re/doc/index.rst
+++ b/boards/arm/nucleo_g474re/doc/index.rst
@@ -127,6 +127,8 @@ The Zephyr nucleo_g474re board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | die-temp  | on-chip    | die temperature sensor              |
 +-----------+------------+-------------------------------------+
+| FDCAN1    | on-chip    | CAN controller                      |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on this Zephyr port.
 
@@ -171,6 +173,8 @@ Default Zephyr Peripheral Mapping:
 - LD2 : PA5
 - ADC1_IN1 : PA0
 - DAC1_OUT1 : PA4
+- FDCAN1_RX: PA11
+- FDCAN1_TX: PA12
 
 System Clock
 ------------


### PR DESCRIPTION
List FDCAN1 as supported in the board documentation.
    
Fixes: #67087