### PR TITLE
cmake: add llext compilation module

### DIFF
--- a/cmake/bintools/gnu/target_bintools.cmake
+++ b/cmake/bintools/gnu/target_bintools.cmake
@@ -93,6 +93,7 @@ set_property(TARGET bintools PROPERTY strip_flag_final "")
 set_property(TARGET bintools PROPERTY strip_flag_all --strip-all)
 set_property(TARGET bintools PROPERTY strip_flag_debug --strip-debug)
 set_property(TARGET bintools PROPERTY strip_flag_dwo --strip-dwo)
+set_property(TARGET bintools PROPERTY strip_flag_remove_section -R )
 
 set_property(TARGET bintools PROPERTY strip_flag_infile "")
 set_property(TARGET bintools PROPERTY strip_flag_outfile -o )

--- a/cmake/compiler/gcc/target.cmake
+++ b/cmake/compiler/gcc/target.cmake
@@ -76,6 +76,8 @@ elseif("${ARCH}" STREQUAL "sparc")
   include(${CMAKE_CURRENT_LIST_DIR}/target_sparc.cmake)
 elseif("${ARCH}" STREQUAL "mips")
   include(${CMAKE_CURRENT_LIST_DIR}/target_mips.cmake)
+elseif("${ARCH}" STREQUAL "xtensa")
+  include(${CMAKE_CURRENT_LIST_DIR}/target_xtensa.cmake)
 endif()
 
 if(SYSROOT_DIR)

--- a/cmake/compiler/gcc/target_arm.cmake
+++ b/cmake/compiler/gcc/target_arm.cmake
@@ -41,3 +41,22 @@ endif()
 
 list(APPEND TOOLCHAIN_C_FLAGS ${ARM_C_FLAGS})
 list(APPEND TOOLCHAIN_LD_FLAGS NO_SPLIT ${ARM_C_FLAGS})
+
+# Flags not supported by llext linker
+# (regexps are supported and match whole word)
+set(LLEXT_REMOVE_FLAGS
+  -fno-pic
+  -fno-pie
+  -ffunction-sections
+  -fdata-sections
+  -g.*
+  -Os
+  -mcpu=.*
+)
+
+# Flags to be added to llext code compilation
+set(LLEXT_APPEND_FLAGS
+  -mlong-calls
+  -mthumb
+  -mcpu=cortex-m33+nodsp
+)

--- a/cmake/compiler/gcc/target_xtensa.cmake
+++ b/cmake/compiler/gcc/target_xtensa.cmake
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Flags not supported by llext linker
+# (regexps are supported and match whole word)
+set(LLEXT_REMOVE_FLAGS
+  -fno-pic
+  -fno-pie
+  -ffunction-sections
+  -fdata-sections
+  -g.*
+  -Os
+  -mcpu=.*
+)
+
+# Flags to be added to llext code compilation
+set(LLEXT_APPEND_FLAGS
+  -fPIC
+  -nostdlib
+  -nodefaultlibs
+  -shared
+)

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -4845,34 +4845,66 @@ function(add_llext_target target_name)
     DEPENDS ${output_file}
   )
 
-  # Compile the source file to an .llext file
+  # Define arch-specific flags for the supported architectures
   if(CONFIG_ARM)
     list(PREPEND LLEXT_C_FLAGS "-mlong-calls" "-mthumb")
-    add_custom_command(OUTPUT ${output_file}
-      COMMAND ${CMAKE_C_COMPILER} ${LLEXT_C_FLAGS} -c
-              -I ${ZEPHYR_BASE}/include
-              -imacros ${AUTOCONF_H}
-              -o ${output_file}
-              ${source_file}
-      DEPENDS ${source_file}
-    )
   elseif(CONFIG_XTENSA)
     list(PREPEND LLEXT_C_FLAGS "-shared" "-fPIC" "-nostdlib" "-nodefaultlibs")
+  else()
+    message(FATAL_ERROR "add_llext_target: unsupported architecture")
+  endif()
+
+  # Compile the source file to an object file using current Zephyr settings
+  # but a different set of flags
+  add_library(${target_name}_lib OBJECT ${source_file})
+  target_compile_definitions(${target_name}_lib PRIVATE
+    $<TARGET_PROPERTY:zephyr_interface,INTERFACE_COMPILE_DEFINITIONS>
+  )
+  target_compile_options(${target_name}_lib PRIVATE
+    ${LLEXT_C_FLAGS}
+    -imacros "${AUTOCONF_H}"
+  )
+  target_include_directories(${target_name}_lib PRIVATE
+    $<TARGET_PROPERTY:zephyr_interface,INTERFACE_INCLUDE_DIRECTORIES>
+    -I${PROJECT_BINARY_DIR}/include/generated
+  )
+  target_include_directories(${target_name}_lib SYSTEM PUBLIC
+    $<TARGET_PROPERTY:zephyr_interface,INTERFACE_SYSTEM_INCLUDE_DIRECTORIES>
+  )
+  add_dependencies(${target_name}_lib
+    zephyr_interface
+    zephyr_generated_headers
+  )
+
+  # Arch-specific conversion of the object file to an llext
+  if(CONFIG_ARM)
+
+    # No conversion required, simply copy the object file
+    add_custom_command(
+      OUTPUT ${output_file}
+      COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_OBJECTS:${target_name}_lib> ${output_file}
+      DEPENDS ${target_name}_lib $<TARGET_OBJECTS:${target_name}_lib>
+    )
+
+  elseif(CONFIG_XTENSA)
+
+    # Generate an intermediate file name
     get_filename_component(output_dir ${output_file} DIRECTORY)
     get_filename_component(output_name_we ${output_file} NAME_WE)
     set(pre_output_file ${output_dir}/${output_name_we}.pre.llext)
-    add_custom_command(OUTPUT ${output_file}
+
+    # Need to convert the object file to a shared library, then strip some sections
+    add_custom_command(
+      OUTPUT ${output_file}
+      BYPRODUCTS ${pre_output_file}
       COMMAND ${CMAKE_C_COMPILER} ${LLEXT_C_FLAGS}
-              -I ${ZEPHYR_BASE}/include
-              -imacros ${AUTOCONF_H}
               -o ${pre_output_file}
-              ${source_file}
+              $<TARGET_OBJECTS:${target_name}_lib>
       COMMAND ${CROSS_COMPILE}strip -R .xt.*
               -o ${output_file}
               ${pre_output_file}
-      DEPENDS ${source_file}
+      DEPENDS ${target_name}_lib $<TARGET_OBJECTS:${target_name}_lib>
     )
-  else()
-    message(FATAL_ERROR "add_llext_target: unsupported architecture")
+
   endif()
 endfunction()

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -34,6 +34,7 @@ include(CheckCXXCompilerFlag)
 # 5. Zephyr linker functions
 # 5.1. zephyr_linker*
 # 6 Function helper macros
+# 7 Linkable loadable extensions (llext)
 
 ########################################################
 # 1. Zephyr-aware extensions
@@ -4786,3 +4787,92 @@ macro(zephyr_check_flags_exclusive function prefix)
       )
   endif()
 endmacro()
+
+########################################################
+# 7. Linkable loadable extensions (llext)
+########################################################
+#
+# These functions simplify the creation and management of linkable
+# loadable extensions (llexts).
+#
+
+# Add a custom target that compiles a single source file to a .llext file.
+#
+# Output and source files must be specified using the OUTPUT and SOURCES
+# arguments. Only one source file is currently supported.
+#
+# Arch-specific flags will be added automatically. The C_FLAGS argument
+# can be used to pass additional compiler flags to the compilation of
+# the source file.
+#
+# Example usage:
+#   add_llext_target(hello_world
+#     OUTPUT  ${PROJECT_BINARY_DIR}/hello_world.llext
+#     SOURCES ${PROJECT_SOURCE_DIR}/src/llext/hello_world.c
+#     C_FLAGS -Werror
+#   )
+# will compile the source file src/llext/hello_world.c to a file
+# ${PROJECT_BINARY_DIR}/hello_world.llext, adding -Werror to the compilation.
+#
+function(add_llext_target target_name)
+  set(single_args OUTPUT)
+  set(multi_args SOURCES;C_FLAGS)
+  cmake_parse_arguments(PARSE_ARGV 1 LLEXT "${options}" "${single_args}" "${multi_args}")
+
+  # Check that the llext subsystem is enabled for this build
+  if (NOT CONFIG_LLEXT)
+    message(FATAL_ERROR "add_llext_target: CONFIG_LLEXT must be enabled")
+  endif()
+
+  # Output file must be provided
+  if(NOT LLEXT_OUTPUT)
+    message(FATAL_ERROR "add_llext_target: OUTPUT argument must be provided")
+  endif()
+
+  # Source list length must currently be 1
+  list(LENGTH LLEXT_SOURCES source_count)
+  if(NOT source_count EQUAL 1)
+    message(FATAL_ERROR "add_llext_target: only one source file is supported")
+  endif()
+
+  set(output_file ${LLEXT_OUTPUT})
+  set(source_file ${LLEXT_SOURCES})
+  get_filename_component(output_name ${output_file} NAME)
+
+  # Add user-visible target and dependency
+  add_custom_target(${target_name}
+    COMMENT "Compiling ${output_name}"
+    DEPENDS ${output_file}
+  )
+
+  # Compile the source file to an .llext file
+  if(CONFIG_ARM)
+    list(PREPEND LLEXT_C_FLAGS "-mlong-calls" "-mthumb")
+    add_custom_command(OUTPUT ${output_file}
+      COMMAND ${CMAKE_C_COMPILER} ${LLEXT_C_FLAGS} -c
+              -I ${ZEPHYR_BASE}/include
+              -imacros ${AUTOCONF_H}
+              -o ${output_file}
+              ${source_file}
+      DEPENDS ${source_file}
+    )
+  elseif(CONFIG_XTENSA)
+    list(PREPEND LLEXT_C_FLAGS "-shared" "-fPIC" "-nostdlib" "-nodefaultlibs")
+    get_filename_component(output_dir ${output_file} DIRECTORY)
+    get_filename_component(output_name_we ${output_file} NAME_WE)
+    set(pre_output_file ${output_dir}/${output_name_we}.pre.llext)
+    add_custom_command(OUTPUT ${output_file}
+      COMMAND ${CMAKE_C_COMPILER} ${LLEXT_C_FLAGS}
+              -I ${ZEPHYR_BASE}/include
+              -imacros ${AUTOCONF_H}
+              -o ${pre_output_file}
+              ${source_file}
+      COMMAND ${CROSS_COMPILE}strip -R .xt.*
+              -o ${output_file}
+              ${pre_output_file}
+      DEPENDS ${source_file}
+    )
+  else()
+    message(FATAL_ERROR "add_llext_target: unsupported architecture")
+  endif()
+endfunction()

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -4801,9 +4801,13 @@ endmacro()
 # Output and source files must be specified using the OUTPUT and SOURCES
 # arguments. Only one source file is currently supported.
 #
-# Arch-specific flags will be added automatically. The C_FLAGS argument
-# can be used to pass additional compiler flags to the compilation of
-# the source file.
+# The llext code will be compiled with mostly the same C compiler flags used
+# in the Zephyr build, but with some important modifications. The list of
+# flags to remove and flags to append is controlled respectively by the
+# LLEXT_REMOVE_FLAGS and LLEXT_APPEND_FLAGS global variables.
+
+# The C_FLAGS argument can be used to pass additional compiler flags to the
+# compilation of this particular llext.
 #
 # Example usage:
 #   add_llext_target(hello_world
@@ -4845,14 +4849,19 @@ function(add_llext_target target_name)
     DEPENDS ${output_file}
   )
 
-  # Define arch-specific flags for the supported architectures
-  if(CONFIG_ARM)
-    list(PREPEND LLEXT_C_FLAGS "-mlong-calls" "-mthumb")
-  elseif(CONFIG_XTENSA)
-    list(PREPEND LLEXT_C_FLAGS "-shared" "-fPIC" "-nostdlib" "-nodefaultlibs")
-  else()
-    message(FATAL_ERROR "add_llext_target: unsupported architecture")
-  endif()
+  # Convert the LLEXT_REMOVE_FLAGS list to a regular expression, and use it to
+  # filter out these flags from the Zephyr target settings
+  list(TRANSFORM LLEXT_REMOVE_FLAGS
+       REPLACE "(.+)" "^\\1$"
+       OUTPUT_VARIABLE llext_remove_flags_regexp
+  )
+  string(REPLACE ";" "|" llext_remove_flags_regexp "${llext_remove_flags_regexp}")
+  set(zephyr_flags
+      "$<TARGET_PROPERTY:zephyr_interface,INTERFACE_COMPILE_OPTIONS>"
+  )
+  set(zephyr_filtered_flags
+      "$<FILTER:${zephyr_flags},EXCLUDE,${llext_remove_flags_regexp}>"
+  )
 
   # Compile the source file to an object file using current Zephyr settings
   # but a different set of flags
@@ -4861,12 +4870,12 @@ function(add_llext_target target_name)
     $<TARGET_PROPERTY:zephyr_interface,INTERFACE_COMPILE_DEFINITIONS>
   )
   target_compile_options(${target_name}_lib PRIVATE
+    ${zephyr_filtered_flags}
+    ${LLEXT_APPEND_FLAGS}
     ${LLEXT_C_FLAGS}
-    -imacros "${AUTOCONF_H}"
   )
   target_include_directories(${target_name}_lib PRIVATE
     $<TARGET_PROPERTY:zephyr_interface,INTERFACE_INCLUDE_DIRECTORIES>
-    -I${PROJECT_BINARY_DIR}/include/generated
   )
   target_include_directories(${target_name}_lib SYSTEM PUBLIC
     $<TARGET_PROPERTY:zephyr_interface,INTERFACE_SYSTEM_INCLUDE_DIRECTORIES>
@@ -4897,14 +4906,19 @@ function(add_llext_target target_name)
     add_custom_command(
       OUTPUT ${output_file}
       BYPRODUCTS ${pre_output_file}
-      COMMAND ${CMAKE_C_COMPILER} ${LLEXT_C_FLAGS}
+      COMMAND ${CMAKE_C_COMPILER} ${LLEXT_APPEND_FLAGS}
               -o ${pre_output_file}
               $<TARGET_OBJECTS:${target_name}_lib>
-      COMMAND ${CROSS_COMPILE}strip -R .xt.*
-              -o ${output_file}
-              ${pre_output_file}
+      COMMAND $<TARGET_PROPERTY:bintools,strip_command>
+              $<TARGET_PROPERTY:bintools,strip_flag>
+              $<TARGET_PROPERTY:bintools,strip_flag_remove_section>.xt.*
+              $<TARGET_PROPERTY:bintools,strip_flag_infile>${pre_output_file}
+              $<TARGET_PROPERTY:bintools,strip_flag_outfile>${output_file}
+              $<TARGET_PROPERTY:bintools,strip_flag_final>
       DEPENDS ${target_name}_lib $<TARGET_OBJECTS:${target_name}_lib>
     )
 
+  else()
+    message(FATAL_ERROR "add_llext_target: unsupported architecture")
   endif()
 endfunction()

--- a/tests/subsys/llext/hello_world/CMakeLists.txt
+++ b/tests/subsys/llext/hello_world/CMakeLists.txt
@@ -7,34 +7,14 @@ project(hello_world)
 
 if(NOT CONFIG_MODULES OR CONFIG_LLEXT_TEST_HELLO STREQUAL "m")
 
-# TODO check which architecture is being used
-if(CONFIG_ARM)
-    set(CMAKE_C_FLAGS "-mlong-calls" "-mthumb")
+  set(llext_src_file ${PROJECT_SOURCE_DIR}/hello_world.c)
+  set(llext_bin_file ${PROJECT_BINARY_DIR}/hello_world.llext)
 
-    add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/hello_world.llext
-	COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS} -c
-		-I ${PROJECT_SOURCE_DIR}/../../../../include
-		-imacros${PROJECT_BINARY_DIR}/../zephyr/include/generated/autoconf.h
-		-o ${PROJECT_BINARY_DIR}/hello_world.llext
-		${PROJECT_SOURCE_DIR}/hello_world.c
-    )
-elseif(CONFIG_XTENSA)
-    set(CMAKE_C_FLAGS "-shared" "-fPIC" "-nostdlib" "-nodefaultlibs")
+  add_llext_target(hello_world
+    OUTPUT  ${llext_bin_file}
+    SOURCES ${llext_src_file}
+  )
 
-    add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/hello_world.llext
-	COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS}
-		-I ${PROJECT_SOURCE_DIR}/../../../../include
-		-imacros${PROJECT_BINARY_DIR}/../zephyr/include/generated/autoconf.h
-		-o ${PROJECT_BINARY_DIR}/hello_world.pre.llext
-		${PROJECT_SOURCE_DIR}/hello_world.c
-	COMMAND ${CROSS_COMPILE}strip -R .xt.*
-		-o ${PROJECT_BINARY_DIR}/hello_world.llext
-		${PROJECT_BINARY_DIR}/hello_world.pre.llext
-    )
-endif()
-
-set(HELLO_WORLD_LLEXT ${PROJECT_BINARY_DIR}/hello_world.llext PARENT_SCOPE)
-
-add_custom_target(hello_world DEPENDS ${PROJECT_BINARY_DIR}/hello_world.llext)
+  set(HELLO_WORLD_LLEXT ${llext_bin_file} PARENT_SCOPE)
 
 endif()


### PR DESCRIPTION
This PR abstracts the current llext compilation code used in the test to the `add_llext_target` function in the `cmake/modules/llext.cmake` module, integrating it with the current Zephyr build configuration as much as current llext code allows. 

Of course the "extension" model is designed to allow third party, independent binaries to be separately compiled and dynamically linked with the Zephyr binary at run time only. 
But having a fully integrated build of a Zephyr binary + a set of extensions has a number of advantages:

- Extensions can be built with the same compilation options of the main Zephyr binary (ABI, floating point, warnings etc), minimizing the risk of incompatibilities; 
- Extensions will be able to use all existing Zephyr macrobatics (such as devicetree or `zassert_*` macros) in their code. This will enable them to adapt to the current build requirements, and Twister tests will be able to influence test outcome from _within_ the extension code;
- @marc-hb suggested being able to build code with different licenses and distribution restrictions in the same single build, and distribute them as separate entities.

Some restrictions on the set of flags that can be used are automatically enforced. This list is expected to be reduced as the Zephyr llext linker improves.

-----
* 12cdb55e38e34ca404e821cda92f8f82f9c73be2 moves the current llext compilation code to an `add_llext_target` CMake function, so CMakeFiles for llext tests can be greatly simplified;
* 1be79094ecd041300fac9fe93578cabe2ca03b14 reworks `add_llext_target` to use a standard Zephyr library compile step for the llext object files, allowing to reuse include directories and macro definitions;
* bf2e24bf312e77e4f70543d982b024537b399624 completes the transition by moving all arch-specific flags to the cmake/compiler/ folder and reusing the toolchain compiler properties as much as possible.