### PR TITLE
cmake: fail when board identifier is applied in legacy hw model

### DIFF
--- a/cmake/modules/boards.cmake
+++ b/cmake/modules/boards.cmake
@@ -187,6 +187,13 @@ if(NOT BOARD_DIR)
   message(FATAL_ERROR "Invalid BOARD; see above.")
 endif()
 
+if(HWMv1 AND DEFINED BOARD_IDENTIFIER)
+  message(FATAL_ERROR
+          "Board '${BOARD}' does not support board identifiers, ${BOARD}${BOARD_IDENTIFIER}.\n"
+          "Please specify board without an identifier.\n"
+  )
+endif()
+
 cmake_path(IS_PREFIX ZEPHYR_BASE "${BOARD_DIR}" NORMALIZE in_zephyr_tree)
 if(NOT in_zephyr_tree)
   set(USING_OUT_OF_TREE_BOARD 1)


### PR DESCRIPTION
Board is looked up without identifier string, which means a legacy board may actually be found but later fails when board identifier is included.

Thus test for HWMv1 and fail CMake is board identifier is provided for board using HWMv1.