### PR TITLE
Bluetooth: HCI SPI: Explain how to connect a host to `hci_spi`

### DIFF
--- a/samples/bluetooth/hci_spi/README.rst
+++ b/samples/bluetooth/hci_spi/README.rst
@@ -38,3 +38,111 @@ Zephyr's Bluetooth HCI driver core; see the help associated with the
 Refer to :ref:`bluetooth-samples` for general Bluetooth information, and
 to :ref:`96b_carbon_nrf51_bluetooth` for instructions specific to the
 96Boards Carbon board.
+
+Using the controller with the Zephyr host
+=========================================
+
+This describes how to hook up a board running this sample to a board running
+an application that uses the Zephyr host.
+
+Here the example is with two nRF52840dk boards. All wires are connected to the
+same port/pin on the other side, save for the reset line, which is connected to
+a GPIO on the host and the SoC reset line on the controller.
+
+Host board
+----------
+
+On the host application, some config options need to be used to select the SPI
+driver instead of the built-in controller:
+
+.. code-block:: kconfig
+
+   CONFIG_BT_CTLR=n
+   CONFIG_BT_SPI=y
+
+A device with the `zephyr,bt-hci-spi` compatible must be present on the desired
+SPI bus node.
+
+.. code-block:: dts
+
+   &spi1 {
+      compatible = "nordic,nrf-spim";
+      status = "okay";
+      pinctrl-0 = <&spi1_default_alt>;
+      /delete-property/ pinctrl-1;
+      pinctrl-names = "default";
+
+      cs-gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
+
+      bt-controller@0 {
+         status = "okay";
+         compatible = "zephyr,bt-hci-spi";
+         reg = <0>;
+         spi-max-frequency = <2000000>;
+         /* different scheme than pinctrl: IRQ is on P1.04 */
+         irq-gpios = <&gpio1 4 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
+         reset-gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
+            reset-assert-duration-ms = <420>;
+      };
+   };
+
+And its `pinctrl` node:
+
+.. code-block:: dts
+
+   &pinctrl {
+      spi1_default_alt: spi1_default_alt {
+         group1 {
+            /* schema: (name, port, number)
+             * only change the port and number.
+             * e.g. here: SCK is on P1.08
+             */
+            psels = <NRF_PSEL(SPIM_SCK, 1, 8)>,
+               <NRF_PSEL(SPIM_MOSI, 1, 7)>,
+               <NRF_PSEL(SPIM_MISO, 1, 6)>;
+         };
+      };
+   };
+
+Controller board
+----------------
+
+A device compatible with `zephyr,bt-hci-spi-slave` has to be present on an SPI
+peripheral bus.
+
+.. code-block:: dts
+
+   &spi1 {
+      compatible = "nordic,nrf-spis";
+      status = "okay";
+      def-char = <0x00>;
+      pinctrl-0 = <&spi1_default_alt>;
+      /delete-property/ pinctrl-1;
+      pinctrl-names = "default";
+
+      bt-host@0 {
+         compatible = "zephyr,bt-hci-spi-slave";
+         reg = <0>;
+         /* different scheme than pinctrl: IRQ is on P1.04 */
+         irq-gpios = <&gpio1 4 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
+      };
+   };
+
+And the `pinctrl` node:
+
+.. code-block:: dts
+
+   &pinctrl {
+      spi1_default_alt: spi1_default_alt {
+         group1 {
+            /* schema: (name, port, number)
+             * only change the port and number.
+             * e.g. here: SCK is on P1.08
+             */
+            psels = <NRF_PSEL(SPIS_SCK, 1, 8)>,
+               <NRF_PSEL(SPIS_MOSI, 1, 7)>,
+               <NRF_PSEL(SPIS_MISO, 1, 6)>,
+               <NRF_PSEL(SPIS_CSN, 1, 5)>;
+         };
+      };
+   };

--- a/samples/bluetooth/hci_spi/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/bluetooth/hci_spi/boards/nrf52840dk_nrf52840.overlay
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	spi1_default_alt: spi1_default_alt {
+		group1 {
+			/* schema: (name, port, number)
+			 * only change the port and number.
+			 * e.g. here: SCK is on P1.08
+			 */
+			psels = <NRF_PSEL(SPIS_SCK, 1, 8)>,
+				<NRF_PSEL(SPIS_MOSI, 1, 7)>,
+				<NRF_PSEL(SPIS_MISO, 1, 6)>,
+				<NRF_PSEL(SPIS_CSN, 1, 5)>;
+		};
+	};
+};
+
+&spi1 {
+	compatible = "nordic,nrf-spis";
+	status = "okay";
+	def-char = <0x00>;
+	pinctrl-0 = <&spi1_default_alt>;
+	/delete-property/ pinctrl-1;
+	pinctrl-names = "default";
+
+
+	bt-host@0 {
+		compatible = "zephyr,bt-hci-spi-slave";
+		reg = <0>;
+		/* different scheme than pinctrl: IRQ is on P1.04 */
+		irq-gpios = <&gpio1 4 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
+	};
+};

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -47,7 +47,7 @@ config BT_HCI_TX_STACK_SIZE
 	prompt "HCI Tx thread stack size" if BT_HCI_TX_STACK_SIZE_WITH_PROMPT
 	default 512 if BT_H4
 	default 512 if BT_H5
-	default 416 if BT_SPI
+	default 1024 if BT_SPI
 	default 940 if BT_CTLR && BT_LL_SW_SPLIT && (NO_OPTIMIZATIONS || BT_ISO_BROADCAST)
 	default 1024 if BT_CTLR && BT_LL_SW_SPLIT && BT_CENTRAL
 	default 768 if BT_CTLR && BT_LL_SW_SPLIT


### PR DESCRIPTION

This explains how to connect the Zephyr host to another board running
the `hci_spi` sample.

The instructions are tailored for an nRF52840dk board, but are easily
adapted to any other board.
