### PR TITLE
net: openthread: Add new key and algorithm in PSA.

### DIFF
--- a/modules/openthread/platform/crypto_psa.c
+++ b/modules/openthread/platform/crypto_psa.c
@@ -41,6 +41,8 @@ static psa_key_type_t toPsaKeyType(otCryptoKeyType aType)
 		return PSA_KEY_TYPE_AES;
 	case OT_CRYPTO_KEY_TYPE_HMAC:
 		return PSA_KEY_TYPE_HMAC;
+	case OT_CRYPTO_KEY_TYPE_ECDSA:
+		return PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1);
 	default:
 		return PSA_KEY_TYPE_NONE;
 	}
@@ -53,6 +55,8 @@ static psa_algorithm_t toPsaAlgorithm(otCryptoKeyAlgorithm aAlgorithm)
 		return PSA_ALG_ECB_NO_PADDING;
 	case OT_CRYPTO_KEY_ALG_HMAC_SHA_256:
 		return PSA_ALG_HMAC(PSA_ALG_SHA_256);
+	case OT_CRYPTO_KEY_ALG_ECDSA:
+		return PSA_ALG_DETERMINISTIC_ECDSA(PSA_ALG_SHA_256);
 	default:
 		/*
 		 * There is currently no constant like PSA_ALG_NONE, but 0 is used
@@ -82,6 +86,10 @@ static psa_key_usage_t toPsaKeyUsage(int aUsage)
 		usage |= PSA_KEY_USAGE_SIGN_HASH;
 	}
 
+	if (aUsage & OT_CRYPTO_KEY_USAGE_VERIFY_HASH) {
+		usage |= PSA_KEY_USAGE_VERIFY_HASH;
+	}
+
 	return usage;
 }
 
@@ -89,9 +97,10 @@ static bool checkKeyUsage(int aUsage)
 {
 	/* Check if only supported flags have been passed */
 	int supported_flags = OT_CRYPTO_KEY_USAGE_EXPORT |
-			      OT_CRYPTO_KEY_USAGE_ENCRYPT |
-			      OT_CRYPTO_KEY_USAGE_DECRYPT |
-			      OT_CRYPTO_KEY_USAGE_SIGN_HASH;
+			      OT_CRYPTO_KEY_USAGE_ENCRYPT   |
+			      OT_CRYPTO_KEY_USAGE_DECRYPT   |
+			      OT_CRYPTO_KEY_USAGE_SIGN_HASH |
+				  OT_CRYPTO_KEY_USAGE_VERIFY_HASH;
 
 	return (aUsage & ~supported_flags) == 0;
 }


### PR DESCRIPTION
This commit adds new types of keys and algorithm to crypto_psa backend of openthread.

Added options:
- `OT_CRYPTO_KEY_TYPE_ECDSA`
- `OT_CRYPTO_KEY_ALG_ECDSA`
- `OT_CRYPTO_KEY_USAGE_VERIFY_HASH`