### PR TITLE
soc: arm: nxp_imx: enable CONFIG_CACHE_MANAGEMENT for RT1xxx M7 cores

### DIFF
--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
@@ -136,6 +136,11 @@ config TEST_EXTRA_STACK_SIZE
 	default 1024
 endif # MBEDTLS
 
+# Enable cache management features when using M7 core, since these parts
+# have L1 instruction and data caches that should be enabled at boot
+config CACHE_MANAGEMENT
+	default y if CPU_CORTEX_M7
+
 source "soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt*"
 
 endif # SOC_SERIES_IMX_RT


### PR DESCRIPTION
Since d992683db5 (soc: arm: replace redundant config option for caches for nxp_imx), RT1xxx series will not have cache enabled at boot unless CONFIG_CACHE_MANAGEMENT=y. Since this will improve performance, enable CONFIG_CACHE_MANAGEMENT by default.