### PR TITLE
twister: hotfix for unimplemented harnesses

### DIFF
--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -693,8 +693,12 @@ class HarnessImporter:
     @staticmethod
     def get_harness(harness_name):
         thismodule = sys.modules[__name__]
-        if harness_name:
-            harness_class = getattr(thismodule, harness_name)
-        else:
-            harness_class = getattr(thismodule, 'Test')
-        return harness_class()
+        try:
+            if harness_name:
+                harness_class = getattr(thismodule, harness_name)
+            else:
+                harness_class = getattr(thismodule, 'Test')
+            return harness_class()
+        except AttributeError as e:
+            logger.debug(f"harness {harness_name} not implemented: {e}")
+            return None

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -1055,8 +1055,9 @@ class ProjectBuilder(FilterBuilder):
         harness = HarnessImporter.get_harness(self.instance.testsuite.harness.capitalize())
         build_result = self.run_build(['--build', self.build_dir])
         try:
-            harness.instance = self.instance
-            harness.build()
+            if harness:
+                harness.instance = self.instance
+                harness.build()
         except ConfigurationError as error:
             self.instance.status = "error"
             self.instance.reason = str(error)


### PR DESCRIPTION
Harness is freeform right now in the yaml file and if the harness is not
implemented in class, things fail. While we cleanup and enforce
implementations, this should serve as a quick fix dealing with such
unimplemented harnesses.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
