### PR TITLE
soc: mimxrt595: Do not dynamically change pins in soc power driver

### DIFF
--- a/soc/arm/nxp_imx/rt5xx/power.c
+++ b/soc/arm/nxp_imx/rt5xx/power.c
@@ -16,31 +16,8 @@ LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 #define EXCLUDE_FROM_DEEPSLEEP ((const uint32_t[]) \
 					DT_PROP_OR(NODE_ID, deep_sleep_config, {}))
 
-static uint32_t isp_pin[3];
-
 /* System clock frequency. */
 extern uint32_t SystemCoreClock;
-
-__ramfunc void set_deepsleep_pin_config(void)
-{
-	/* Backup Pin configuration. */
-	isp_pin[0] = IOPCTL->PIO[1][15];
-	isp_pin[1] = IOPCTL->PIO[3][28];
-	isp_pin[2] = IOPCTL->PIO[3][29];
-
-	/* Disable ISP Pin pull-ups and input buffers to avoid current leakage */
-	IOPCTL->PIO[1][15] = 0;
-	IOPCTL->PIO[3][28] = 0;
-	IOPCTL->PIO[3][29] = 0;
-}
-
-__ramfunc void restore_deepsleep_pin_config(void)
-{
-	/* Restore the Pin configuration. */
-	IOPCTL->PIO[1][15] = isp_pin[0];
-	IOPCTL->PIO[3][28] = isp_pin[1];
-	IOPCTL->PIO[3][29] = isp_pin[2];
-}
 
 /* Invoke Low Power/System Off specific Tasks */
 void pm_state_set(enum pm_state state, uint8_t substate_id)
@@ -65,9 +42,7 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 		POWER_EnterSleep();
 		break;
 	case PM_STATE_SUSPEND_TO_IDLE:
-		set_deepsleep_pin_config();
 		POWER_EnterDeepSleep(EXCLUDE_FROM_DEEPSLEEP);
-		restore_deepsleep_pin_config();
 		break;
 	default:
 		LOG_DBG("Unsupported power state %u", state);

--- a/soc/arm/nxp_imx/rt5xx/soc.c
+++ b/soc/arm/nxp_imx/rt5xx/soc.c
@@ -530,6 +530,14 @@ static int nxp_rt500_init(void)
 	CACHE64_DisableCache(CACHE64_CTRL0);
 #endif
 
+	/* Some ROM versions may have errata leaving these pins in a non-reset state,
+	 * which can often cause power leakage on most expected board designs,
+	 * restore the reset state here and leave the pin configuration up to board/user DT
+	 */
+	IOPCTL->PIO[1][15] = 0;
+	IOPCTL->PIO[3][28] = 0;
+	IOPCTL->PIO[3][29] = 0;
+
 	return 0;
 }
 


### PR DESCRIPTION
Pin configuration is board specific and should be moved out of the soc folder to the board level.
Use pm_notifier feature to achieve this.