### PR TITLE
Bluetooth: Controller: Fix regression in BT_CTLR_USED_PPI_CHANNELS

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/nrfx_glue/bt_ctlr_used_resources.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/nrfx_glue/bt_ctlr_used_resources.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Nordic Semiconductor ASA
+ * Copyright (c) 2021-2024 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,6 +7,11 @@
 #include "../radio/radio_nrf5_resources.h"
 #include "../radio/radio_nrf5_fem.h"
 
+/* NOTE: BT_CTLR_USED_PPI_CHANNELS is defined based on PPI defines being
+ *       defined in the below PPI/DPPI resources header file. Take care to
+ *       conditionally compile them based on feature Kconfig defines in those
+ *       resources header file.
+ */
 #ifdef DPPI_PRESENT
 #include "../radio/radio_nrf5_dppi_resources.h"
 #else

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_dppi.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_dppi.h
@@ -171,6 +171,7 @@ static inline void hal_trigger_aar_ppi_config(void)
 	nrf_aar_subscribe_set(NRF_AAR, NRF_AAR_TASK_START, HAL_TRIGGER_AAR_PPI);
 }
 
+#if defined(CONFIG_BT_CTLR_PHY_CODED) && defined(CONFIG_HAS_HW_NRF_RADIO_BLE_CODED)
 /*******************************************************************************
  * Trigger Radio Rate override upon Rateboost event.
  */
@@ -179,6 +180,7 @@ static inline void hal_trigger_rateoverride_ppi_config(void)
 	nrf_radio_publish_set(NRF_RADIO, NRF_RADIO_EVENT_RATEBOOST, HAL_TRIGGER_RATEOVERRIDE_PPI);
 	nrf_ccm_subscribe_set(NRF_CCM, NRF_CCM_TASK_RATEOVERRIDE, HAL_TRIGGER_RATEOVERRIDE_PPI);
 }
+#endif /* CONFIG_BT_CTLR_PHY_CODED && CONFIG_HAS_HW_NRF_RADIO_BLE_CODED */
 
 /******************************************************************************/
 #if defined(HAL_RADIO_GPIO_HAVE_PA_PIN) || defined(HAL_RADIO_GPIO_HAVE_LNA_PIN)

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_dppi_resources.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_dppi_resources.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Nordic Semiconductor ASA
+ * Copyright (c) 2021-2024 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -61,11 +61,15 @@
  */
 #define HAL_TRIGGER_AAR_PPI 12
 
+#if defined(CONFIG_BT_CTLR_PHY_CODED) && \
+	defined(CONFIG_HAS_HW_NRF_RADIO_BLE_CODED)
 /*******************************************************************************
  * Trigger Radio Rate override upon Rateboost event.
  */
 #define HAL_TRIGGER_RATEOVERRIDE_PPI 13
+#endif /* CONFIG_BT_CTLR_PHY_CODED && CONFIG_HAS_HW_NRF_RADIO_BLE_CODED */
 
+#if defined(HAL_RADIO_GPIO_HAVE_PA_PIN) || defined(HAL_RADIO_GPIO_HAVE_LNA_PIN)
 /******************************************************************************/
 #define HAL_ENABLE_PALNA_PPI 5
 
@@ -77,6 +81,8 @@
 
 #define HAL_ENABLE_FEM_PPI 3
 #define HAL_DISABLE_FEM_PPI HAL_DISABLE_PALNA_PPI
+
+#endif /* HAL_RADIO_GPIO_HAVE_PA_PIN || HAL_RADIO_GPIO_HAVE_LNA_PIN */
 
 /******************************************************************************/
 #if !defined(CONFIG_BT_CTLR_TIFS_HW)
@@ -123,6 +129,9 @@
  */
 #define HAL_SW_SWITCH_RADIO_ENABLE_PPI_BASE 14
 
+#if defined(CONFIG_BT_CTLR_PHY_CODED) && \
+	defined(CONFIG_HAS_HW_NRF_RADIO_BLE_CODED)
+
 #define HAL_SW_SWITCH_RADIO_ENABLE_S2_PPI_BASE \
 	HAL_SW_SWITCH_RADIO_ENABLE_PPI_BASE
 
@@ -132,6 +141,8 @@
  * Note: We already have a PPI where we publish the RATEBOOST event.
  */
 #define HAL_SW_SWITCH_TIMER_S8_DISABLE_PPI HAL_TRIGGER_RATEOVERRIDE_PPI
+
+#endif /* CONFIG_BT_CTLR_PHY_CODED && CONFIG_HAS_HW_NRF_RADIO_BLE_CODED */
 
 #if defined(CONFIG_BT_CTLR_DF_PHYEND_OFFSET_COMPENSATION_ENABLE)
 /* Cancel the SW switch timer running considering PHYEND delay compensation timing:

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi.h
@@ -257,7 +257,7 @@ static inline void hal_trigger_aar_ppi_config(void)
 /*******************************************************************************
  * Trigger Radio Rate override upon Rateboost event.
  */
-#if defined(CONFIG_HAS_HW_NRF_RADIO_BLE_CODED)
+#if defined(CONFIG_BT_CTLR_PHY_CODED) && defined(CONFIG_HAS_HW_NRF_RADIO_BLE_CODED)
 static inline void hal_trigger_rateoverride_ppi_config(void)
 {
 	nrf_ppi_channel_endpoint_setup(
@@ -266,7 +266,7 @@ static inline void hal_trigger_rateoverride_ppi_config(void)
 		(uint32_t)&(NRF_RADIO->EVENTS_RATEBOOST),
 		(uint32_t)&(NRF_CCM->TASKS_RATEOVERRIDE));
 }
-#endif /* CONFIG_HAS_HW_NRF_RADIO_BLE_CODED */
+#endif /* CONFIG_BT_CTLR_PHY_CODED && CONFIG_HAS_HW_NRF_RADIO_BLE_CODED */
 
 /******************************************************************************/
 #if defined(HAL_RADIO_GPIO_HAVE_PA_PIN) || defined(HAL_RADIO_GPIO_HAVE_LNA_PIN)

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi_resources.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi_resources.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Nordic Semiconductor ASA
+ * Copyright (c) 2021-2024 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -74,12 +74,15 @@
 #define HAL_TRIGGER_AAR_PPI 23
 
 /* Trigger Radio Rate override upon Rateboost event. */
-#if defined(CONFIG_HAS_HW_NRF_RADIO_BLE_CODED)
+#if defined(CONFIG_BT_CTLR_PHY_CODED) && \
+	defined(CONFIG_HAS_HW_NRF_RADIO_BLE_CODED)
 #define HAL_TRIGGER_RATEOVERRIDE_PPI 14
-#endif /* CONFIG_HAS_HW_NRF_RADIO_BLE_CODED */
+#endif /* CONFIG_BT_CTLR_PHY_CODED && CONFIG_HAS_HW_NRF_RADIO_BLE_CODED */
 
+#if defined(HAL_RADIO_GPIO_HAVE_PA_PIN) || defined(HAL_RADIO_GPIO_HAVE_LNA_PIN)
 #define HAL_ENABLE_PALNA_PPI  15
 #define HAL_DISABLE_PALNA_PPI 16
+#endif /* HAL_RADIO_GPIO_HAVE_PA_PIN || HAL_RADIO_GPIO_HAVE_LNA_PIN */
 
 #if defined(HAL_RADIO_FEM_IS_NRF21540)
 #define HAL_ENABLE_FEM_PPI  4
@@ -143,6 +146,9 @@
 #define HAL_SW_SWITCH_RADIO_ENABLE_PPI_BASE 12
 #endif
 
+#if defined(CONFIG_BT_CTLR_PHY_CODED) && \
+	defined(CONFIG_HAS_HW_NRF_RADIO_BLE_CODED)
+
 /* Wire the SW SWITCH TIMER EVENTS_COMPARE[<cc_offset>] event
  * to RADIO TASKS_TXEN/RXEN task.
  */
@@ -152,6 +158,8 @@
  * wire the RADIO EVENTS_RATEBOOST event to SW_SWITCH_TIMER TASKS_CAPTURE task.
  */
 #define HAL_SW_SWITCH_TIMER_S8_DISABLE_PPI 19
+
+#endif /* CONFIG_BT_CTLR_PHY_CODED && CONFIG_HAS_HW_NRF_RADIO_BLE_CODED */
 
 #if defined(CONFIG_BT_CTLR_DF_PHYEND_OFFSET_COMPENSATION_ENABLE)
 /* Wire the SW SWITCH PHYEND delay compensation TIMER EVENTS_COMPARE[<cc_offset>] event to software


### PR DESCRIPTION
Fix regression in BT_CTLR_USED_PPI_CHANNELS introduced in commit e39d98302d9f ("Bluetooth: Controller: nRF53: Cleanup dppi and dppi resources file").

Fixes #67413