### PR TITLE
boards: arm: wio terminal: separate buttons and joystick definition

### DIFF
--- a/boards/arm/wio_terminal/wio_terminal.dts
+++ b/boards/arm/wio_terminal/wio_terminal.dts
@@ -48,7 +48,7 @@
 	};
 
 	/* Buttons */
-	gpio_keys {
+	buttons: buttons {
 		compatible = "gpio-keys";
 		user_button_0: button_0 {
 			label = "User Button 0";
@@ -65,6 +65,13 @@
 			gpios = <&portc 28 GPIO_ACTIVE_LOW>;
 			zephyr,code = <INPUT_KEY_2>;
 		};
+	};
+
+	/* Joystick */
+	joystick: joystick {
+		compatible = "gpio-keys";
+		polling-mode;
+		debounce-interval-ms = <100>;
 		joy_sel: joystick_selection {
 			label = "joystick selection";
 			gpios = <&portd 10 GPIO_ACTIVE_LOW>;

--- a/samples/subsys/display/lvgl/boards/wio_terminal.conf
+++ b/samples/subsys/display/lvgl/boards/wio_terminal.conf
@@ -1,0 +1,1 @@
+CONFIG_INPUT=y

--- a/samples/subsys/display/lvgl/boards/wio_terminal.overlay
+++ b/samples/subsys/display/lvgl/boards/wio_terminal.overlay
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2024 Joel Guittet
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/lvgl/lvgl.h>
+
+/ {
+	lvgl_button_input {
+		compatible = "zephyr,lvgl-button-input";
+		input = <&buttons>;
+		input-codes = <INPUT_KEY_0>;
+		coordinates = <160 120>;
+	};
+
+	lvgl_keypad_input {
+		compatible = "zephyr,lvgl-keypad-input";
+		input = <&joystick>;
+		input-codes = <INPUT_KEY_ENTER INPUT_KEY_DOWN INPUT_KEY_UP INPUT_KEY_LEFT INPUT_KEY_RIGHT>;
+		lvgl-codes = <LV_KEY_ENTER LV_KEY_DOWN LV_KEY_UP LV_KEY_LEFT LV_KEY_RIGHT>;
+	};
+};


### PR DESCRIPTION
The purpose of this separation is to avoid conflict initializing gpio-keys because button 0 and joystick up have a shared interrupt source. Joystick is now configured using polling mode option.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/67049