### PR TITLE
soc: arm: nxp_s32: s32k3: select CONFIG_CACHE_MANAGEMENT

### DIFF
--- a/soc/arm/nxp_s32/s32k3/Kconfig.defconfig.series
+++ b/soc/arm/nxp_s32/s32k3/Kconfig.defconfig.series
@@ -1,6 +1,6 @@
 # NXP S32K3XX MCU series
 
-# Copyright 2023 NXP
+# Copyright 2023-2024 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 if SOC_SERIES_S32K3XX
@@ -31,6 +31,9 @@ config NET_UDP_CHECKSUM
 	default n
 
 endif # NET_L2_ETHERNET
+
+config CACHE_MANAGEMENT
+	default y
 
 source "soc/arm/nxp_s32/s32k3/Kconfig.defconfig.s32k*"
 


### PR DESCRIPTION
Commit 447a492 switched to `sys_cache*` to enable caches at SoC init for S32K3 devices. To preserve the old behavior of enabling caches at init, is missing to select `CONFIG_CACHE_MANAGEMENT`.