### PR TITLE
boards: arm: apollo4p_blue_kxr_evb: Move the bt-spi instance to soc dts

### DIFF
--- a/boards/arm/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb.dts
+++ b/boards/arm/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb.dts
@@ -87,20 +87,9 @@
 };
 
 &iom4 {
-	compatible = "ambiq,spi";
 	pinctrl-0 = <&spi4_default>;
 	pinctrl-names = "default";
-	cs-gpios = <&gpio32_63 22 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
-	clock-frequency = <DT_FREQ_M(24)>;
 	status = "okay";
-
-	bt-hci@0 {
-		compatible = "ambiq,bt-hci-spi";
-		reg = <0>;
-		irq-gpios = <&gpio32_63 21 GPIO_ACTIVE_HIGH>;
-		reset-gpios = <&gpio32_63 23 GPIO_ACTIVE_LOW>;
-		clkreq-gpios = <&gpio32_63 20 GPIO_ACTIVE_HIGH>;
-	};
 };
 
 &mspi0 {

--- a/dts/arm/ambiq/ambiq_apollo4p_blue.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo4p_blue.dtsi
@@ -160,13 +160,25 @@
 			ambiq,pwrcfg = <&pwrcfg 0x4 0x10>;
 		};
 
-		iom4: iom@40054000 {
+		iom4: spi@40054000 {
+			/* IOM4 works as SPI and is wired internally for BLE HCI. */
+			compatible = "ambiq,spi";
 			reg = <0x40054000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			interrupts = <10 0>;
+			cs-gpios = <&gpio32_63 22 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			clock-frequency = <DT_FREQ_M(24)>;
 			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x4 0x20>;
+
+			bt-hci@0 {
+				compatible = "ambiq,bt-hci-spi";
+				reg = <0>;
+				irq-gpios = <&gpio32_63 21 GPIO_ACTIVE_HIGH>;
+				reset-gpios = <&gpio32_63 23 GPIO_ACTIVE_LOW>;
+				clkreq-gpios = <&gpio32_63 20 GPIO_ACTIVE_HIGH>;
+			};
 		};
 
 		iom5: iom@40055000 {


### PR DESCRIPTION
From the https://github.com/zephyrproject-rtos/zephyr/pull/66227#discussion_r1445354094, since the pins of bt-spi instance are wired internally in the chip, it will make sense to move the definition to soc dts so no need for every board using the chip to redefine the same.

Test passed:
-samples/bluetooth/peripheral
-samples/bluetooth/peripheral_hr
-samples/bluetooth/peripheral_accept_list
-samples/bluetooth/central_hr