### PR TITLE
ITE: Fix the leakage issue when GPE1/GPE2 is used as alternate function

### DIFF
--- a/drivers/pinctrl/pinctrl_ite_it8xxx2.c
+++ b/drivers/pinctrl/pinctrl_ite_it8xxx2.c
@@ -145,21 +145,23 @@ static int pinctrl_gpio_it8xxx2_configure_pins(const pinctrl_soc_pin_t *pins)
 	}
 
 	/*
+	 * Default input mode prevents leakage during changes to extended
+	 * setting (e.g. enabling i2c functionality on GPIO E1/E2 on IT82002)
+	 */
+	*reg_gpcr = (*reg_gpcr | GPCR_PORT_PIN_MODE_INPUT) &
+		     ~GPCR_PORT_PIN_MODE_OUTPUT;
+
+	/*
 	 * If pincfg is input, we don't need to handle
 	 * alternate function.
 	 */
 	if (IT8XXX2_DT_PINCFG_INPUT(pins->pincfg)) {
-		*reg_gpcr = (*reg_gpcr | GPCR_PORT_PIN_MODE_INPUT) &
-			     ~GPCR_PORT_PIN_MODE_OUTPUT;
 		return 0;
 	}
 
 	/*
 	 * Handle alternate function.
 	 */
-	/* Common settings for alternate function. */
-	*reg_gpcr &= ~(GPCR_PORT_PIN_MODE_INPUT |
-		       GPCR_PORT_PIN_MODE_OUTPUT);
 	/* Ensure that func3-ext setting is in default state. */
 	if (reg_func3_ext != NULL) {
 		*reg_func3_ext &= ~gpio->func3_ext_mask[pin];
@@ -167,12 +169,11 @@ static int pinctrl_gpio_it8xxx2_configure_pins(const pinctrl_soc_pin_t *pins)
 
 	switch (pins->alt_func) {
 	case IT8XXX2_ALT_FUNC_1:
-		/* Func1: Alternate function has been set above. */
+		/* Func1: Alternate function will be set below. */
 		break;
 	case IT8XXX2_ALT_FUNC_2:
-		/* Func2: WUI function: turn the pin into an input */
-		*reg_gpcr |= GPCR_PORT_PIN_MODE_INPUT;
-		break;
+		/* Func2: WUI function: pin has been set as input above.*/
+		return 0;
 	case IT8XXX2_ALT_FUNC_3:
 		/*
 		 * Func3: In addition to the alternate setting above,
@@ -193,15 +194,17 @@ static int pinctrl_gpio_it8xxx2_configure_pins(const pinctrl_soc_pin_t *pins)
 		*reg_func4_gcr |= gpio->func4_en_mask[pin];
 		break;
 	case IT8XXX2_ALT_DEFAULT:
-		*reg_gpcr = (*reg_gpcr | GPCR_PORT_PIN_MODE_INPUT) &
-			     ~GPCR_PORT_PIN_MODE_OUTPUT;
 		*reg_func3_gcr &= ~gpio->func3_en_mask[pin];
 		*reg_func4_gcr &= ~gpio->func4_en_mask[pin];
-		break;
+		return 0;
 	default:
 		LOG_ERR("This function is not supported.");
 		return -EINVAL;
 	}
+
+	/* Common settings for alternate function. */
+	*reg_gpcr &= ~(GPCR_PORT_PIN_MODE_INPUT |
+		       GPCR_PORT_PIN_MODE_OUTPUT);
 
 	return 0;
 }

--- a/dts/riscv/ite/it82xx2.dtsi
+++ b/dts/riscv/ite/it82xx2.dtsi
@@ -525,6 +525,10 @@
 					 NO_FUNC  0xf03e10 NO_FUNC  0xf02032>;
 			func3-en-mask = <0x01     0x20     0x20     0
 					 0        0x08     0        0x01    >;
+			func3-ext =     <NO_FUNC 0xf02032  0xf02032 NO_FUNC
+					 NO_FUNC NO_FUNC   NO_FUNC  NO_FUNC>;
+			func3-ext-mask = <0      0x02      0x02     0
+					  0      0         0        0       >;
 			func4-gcr =     <0xf03e13 NO_FUNC  NO_FUNC  NO_FUNC
 					 NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC >;
 			func4-en-mask = <0x01     0        0        0

--- a/soc/riscv/ite_ec/common/chip_chipregs.h
+++ b/soc/riscv/ite_ec/common/chip_chipregs.h
@@ -45,6 +45,17 @@
 #define IT8XXX2_GCTRL_BASE      0x00F02000
 #define IT8XXX2_GCTRL_EIDSR     ECREG(IT8XXX2_GCTRL_BASE + 0x31)
 
+/* --- External GPIO Control (EGPIO) --- */
+#define IT8XXX2_EGPIO_BASE      0x00F02100
+#define IT8XXX2_EGPIO_EGCR      ECREG(IT8XXX2_EGPIO_BASE + 0x04)
+
+/* EGPIO register fields */
+/*
+ * 0x04: External GPIO Control
+ * BIT(4): EXGPIO EGAD Pin Output Driving Disable
+ */
+#define IT8XXX2_EGPIO_EEPODD    BIT(4)
+
 /**
  *
  * (11xxh) Interrupt controller (INTC)

--- a/soc/riscv/ite_ec/it8xxx2/soc.c
+++ b/soc/riscv/ite_ec/it8xxx2/soc.c
@@ -287,6 +287,11 @@ static int ite_it8xxx2_init(void)
 	IT8XXX2_SMB_SFFCTL &= ~IT8XXX2_SMB_HSAPE;
 #elif CONFIG_SOC_IT8XXX2_REG_SET_V2
 	IT8XXX2_SMB_SCLKTS_BRGS &= ~IT8XXX2_SMB_PREDEN;
+	/*
+	 * Setting this bit will disable EGAD pin output driving to avoid
+	 * leakage when GPIO E1/E2 on it82002 are set to alternate function.
+	 */
+	IT8XXX2_EGPIO_EGCR |= IT8XXX2_EGPIO_EEPODD;
 #endif
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(uart1), okay)


### PR DESCRIPTION
This PR will fix the leakage issue when GPE1/GPE2 is used as I2C
The commits include:
1. Modify the sequence of pinctrl setting
2. Disable EGAD pin output of external gpio control
3. Besides, extended setting required to use i2c5