### PR TITLE
Openthread fix crypto psa import key

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -301,7 +301,7 @@ manifest:
       revision: da78aea63159771956fe0c9263f2e6985b66e9d5
       path: modules/lib/open-amp
     - name: openthread
-      revision: 4ed44bc7d58d9a98c6cca13a50d38129045ab3df
+      revision: 00076aff3ae571db7c90509ec9dc293457098c35
       path: modules/lib/openthread
     - name: percepio
       path: modules/debug/percepio


### PR DESCRIPTION
According to PSA specification in case of `PSA_KEY_TYPE_ECC_KEY_PAIR`
function `psa_import_key` takes private key from key pair as argument.
This commit adds extraction of Private key from ECDSA key pair.

Also removes not needed `otPlatCryptoEcdsaGetPublicKey`.
