### PR TITLE
west: runners: blackmagicprobe: flash hex_file

### DIFF
--- a/scripts/west_commands/runners/blackmagicprobe.py
+++ b/scripts/west_commands/runners/blackmagicprobe.py
@@ -116,6 +116,8 @@ class BlackMagicProbeRunner(ZephyrBinaryRunner):
         #
         # https://github.com/zephyrproject-rtos/zephyr/issues/50789
         self.elf_file = Path(cfg.elf_file).as_posix()
+        # hex_file for flash signed image
+        self.hex_file = Path(cfg.hex_file).as_posix()
         self.gdb_serial = blackmagicprobe_gdb_serial(gdb_serial)
         self.logger.info(f'using GDB serial: {self.gdb_serial}')
         if connect_rst:
@@ -150,8 +152,8 @@ class BlackMagicProbeRunner(ZephyrBinaryRunner):
                             help='Assert SRST during connect? (default: no)')
 
     def bmp_flash(self, command, **kwargs):
-        if self.elf_file is None:
-            raise ValueError('Cannot debug; elf file is missing')
+        if self.hex_file is None:
+            raise ValueError('Cannot flash; hex file is missing')
         command = (self.gdb +
                    ['-ex', "set confirm off",
                     '-ex', "target extended-remote {}".format(
@@ -159,7 +161,7 @@ class BlackMagicProbeRunner(ZephyrBinaryRunner):
                     self.connect_rst_enable_arg +
                    ['-ex', "monitor swdp_scan",
                     '-ex', "attach 1",
-                    '-ex', "load {}".format(self.elf_file),
+                    '-ex', "load {}".format(self.hex_file),
                     '-ex', "kill",
                     '-ex', "quit",
                     '-silent'])

--- a/scripts/west_commands/runners/blackmagicprobe.py
+++ b/scripts/west_commands/runners/blackmagicprobe.py
@@ -116,8 +116,10 @@ class BlackMagicProbeRunner(ZephyrBinaryRunner):
         #
         # https://github.com/zephyrproject-rtos/zephyr/issues/50789
         self.elf_file = Path(cfg.elf_file).as_posix()
-        # hex_file for flash signed image
-        self.hex_file = Path(cfg.hex_file).as_posix()
+        if cfg.hex_file is not None:
+            self.hex_file = Path(cfg.hex_file).as_posix()
+        else:
+            self.hex_file = None
         self.gdb_serial = blackmagicprobe_gdb_serial(gdb_serial)
         self.logger.info(f'using GDB serial: {self.gdb_serial}')
         if connect_rst:
@@ -152,8 +154,20 @@ class BlackMagicProbeRunner(ZephyrBinaryRunner):
                             help='Assert SRST during connect? (default: no)')
 
     def bmp_flash(self, command, **kwargs):
-        if self.hex_file is None:
-            raise ValueError('Cannot flash; hex file is missing')
+        # if hex file is present and signed, use it else use elf file
+        if self.hex_file:
+            split = self.hex_file.split('.')
+            # eg zephyr.signed.hex
+            if len(split) >= 3 and split[-2] == 'signed':
+                flash_file = self.hex_file
+            else:
+                flash_file = self.elf_file
+        else:
+            flash_file = self.elf_file
+
+        if flash_file is None:
+            raise ValueError('Cannot flash; elf file is missing')
+
         command = (self.gdb +
                    ['-ex', "set confirm off",
                     '-ex', "target extended-remote {}".format(
@@ -161,7 +175,7 @@ class BlackMagicProbeRunner(ZephyrBinaryRunner):
                     self.connect_rst_enable_arg +
                    ['-ex', "monitor swdp_scan",
                     '-ex', "attach 1",
-                    '-ex', "load {}".format(self.hex_file),
+                    '-ex', "load {}".format(flash_file),
                     '-ex', "kill",
                     '-ex', "quit",
                     '-silent'])

--- a/scripts/west_commands/tests/test_blackmagicprobe.py
+++ b/scripts/west_commands/tests/test_blackmagicprobe.py
@@ -11,7 +11,7 @@ import pytest
 
 from runners import blackmagicprobe
 from runners.blackmagicprobe import BlackMagicProbeRunner
-from conftest import RC_KERNEL_ELF, RC_GDB
+from conftest import RC_KERNEL_ELF, RC_KERNEL_HEX, RC_GDB
 import serial.tools.list_ports
 
 TEST_GDB_SERIAL = 'test-gdb-serial'
@@ -41,7 +41,7 @@ EXPECTED_COMMANDS = {
       '-ex', "target extended-remote {}".format(TEST_GDB_SERIAL),
       '-ex', "monitor swdp_scan",
       '-ex', "attach 1",
-      '-ex', "load {}".format(RC_KERNEL_ELF),
+      '-ex', "load {}".format(RC_KERNEL_HEX),
       '-ex', "kill",
       '-ex', "quit",
       '-silent'],),

--- a/scripts/west_commands/tests/test_blackmagicprobe.py
+++ b/scripts/west_commands/tests/test_blackmagicprobe.py
@@ -11,7 +11,7 @@ import pytest
 
 from runners import blackmagicprobe
 from runners.blackmagicprobe import BlackMagicProbeRunner
-from conftest import RC_KERNEL_ELF, RC_KERNEL_HEX, RC_GDB
+from conftest import RC_KERNEL_ELF, RC_GDB
 import serial.tools.list_ports
 
 TEST_GDB_SERIAL = 'test-gdb-serial'
@@ -41,7 +41,7 @@ EXPECTED_COMMANDS = {
       '-ex', "target extended-remote {}".format(TEST_GDB_SERIAL),
       '-ex', "monitor swdp_scan",
       '-ex', "attach 1",
-      '-ex', "load {}".format(RC_KERNEL_HEX),
+      '-ex', "load {}".format(RC_KERNEL_ELF),
       '-ex', "kill",
       '-ex', "quit",
       '-silent'],),


### PR DESCRIPTION
The 'cfg.elf_file' is not signed, so `west flash` with a sysbuild will not run the application if MCUboot image signature checking is on. 

Using the 'cfg.hex_file' for `bmp_flash` resolves since as the signed hex is used when using sysbuild. Symbols are not required for flashing so the switching from elf to hex is not an issue.

Fixes #67803