### PR TITLE
tests/kernel/context: Improve to resist parallel threads interrupting

### DIFF
--- a/tests/kernel/context/Kconfig
+++ b/tests/kernel/context/Kconfig
@@ -1,0 +1,14 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+config MAX_IDLE_WAKES
+	int "Maximum number of spurious wakes during k_cpu_idle() test"
+	default 1 if NRF53_SYNC_RTC
+	default 0
+	help
+	  The platform may have some component running in the background while the k_cpu_idle test is
+	  running causing the CPU to awake. With this option we allow for a maximum number of wakes
+	  for each 10ms idle test, which by default should be 0.
+
+# Include Zephyr's Kconfig
+source "Kconfig"

--- a/tests/kernel/context/src/main.c
+++ b/tests/kernel/context/src/main.c
@@ -213,9 +213,12 @@ void irq_enable_wrapper(int irq)
 #if defined(CONFIG_TICKLESS_KERNEL)
 static struct k_timer idle_timer;
 
+static volatile bool idle_timer_done;
+
 static void idle_timer_expiry_function(struct k_timer *timer_id)
 {
 	k_timer_stop(&idle_timer);
+	idle_timer_done = true;
 }
 
 static void _test_kernel_cpu_idle(int atomic)
@@ -224,6 +227,7 @@ static void _test_kernel_cpu_idle(int atomic)
 	unsigned int i, key;
 	uint32_t dur = k_ms_to_ticks_ceil32(10);
 	uint32_t slop = 1 + k_ms_to_ticks_ceil32(1);
+	int idle_loops;
 
 	/* Set up a time to trigger events to exit idle mode */
 	k_timer_init(&idle_timer, idle_timer_expiry_function, NULL);
@@ -231,13 +235,17 @@ static void _test_kernel_cpu_idle(int atomic)
 	for (i = 0; i < 5; i++) {
 		k_usleep(1);
 		t0 = k_uptime_ticks();
+		idle_loops = 0;
+		idle_timer_done = false;
 		k_timer_start(&idle_timer, K_TICKS(dur), K_NO_WAIT);
 		key = irq_lock();
-		if (atomic) {
-			k_cpu_atomic_idle(key);
-		} else {
-			k_cpu_idle();
-		}
+		do {
+			if (atomic) {
+				k_cpu_atomic_idle(key);
+			} else {
+				k_cpu_idle();
+			}
+		} while ((idle_loops++ < CONFIG_MAX_IDLE_WAKES) && (idle_timer_done == false));
 		dt = k_uptime_ticks() - t0;
 		zassert_true(abs((int32_t) (dt - dur)) <= slop,
 			     "Inaccurate wakeup, idled for %d ticks, expected %d",


### PR DESCRIPTION
This test assumes that nothing will wake the CPU apart from the timer set by the test.
But that is not necessarily the case.
Some other platform thread started at boot
may be waking the CPU every now and then.

Let's allow for some spurious wakes while we are testing k_cpu_idle, while at the same time ensuring we are not just busy waiting all the way.

Fixes #67477
