### PR TITLE
STM32 PWM channel timing setting at driver init

### DIFF
--- a/dts/bindings/pwm/st,stm32-pwm.yaml
+++ b/dts/bindings/pwm/st,stm32-pwm.yaml
@@ -11,6 +11,14 @@ properties:
   pinctrl-names:
     required: true
 
+  timings:
+    type: array
+    description: |
+      defines the pwm values per channel defined in pinctrl-0
+      set during driver init
+      <1 /*channel*/ PWM_USEC(10000) /*period*/ PWM_USEC(5000) /*pulse*/ 0 /*flags*/>,
+      <2 /*channel*/ PWM_USEC(10000) /*period*/ PWM_USEC(5000) /*pulse*/ 0 /*flags*/>;
+
   four-channel-capture-support:
     type: boolean
     description: |


### PR DESCRIPTION
Extending the DTS binding to allow on a channel basis:

- define the channel nr
- define the period in ns
- define the pulse in ns
- define the flag

As an example on an STM32H7, using an overlay:

`
&timers1 {
    status = "okay";
    st,prescaler = <10000>;

    pwm_1: pwm {
        status = "okay";
        pinctrl-0 = <
            /* Aout 1 -> 4 */
            &tim1_ch1_pe9
            &tim1_ch2_pe11
            &tim1_ch3_pe13
            &tim1_ch4_pe14
        >;
        pinctrl-names = "default";
        timings = <1 /*channel*/ PWM_USEC(10000) /*period*/ PWM_USEC(5000) /*pulse*/ 0 /*flags*/>,
                  <2 /*channel*/ PWM_USEC(10000) /*period*/ PWM_USEC(5000) /*pulse*/ 0 /*flags*/>,
                  <3 /*channel*/ PWM_USEC(10000) /*period*/ PWM_USEC(5000) /*pulse*/ 0 /*flags*/>,
                  <4 /*channel*/ PWM_USEC(10000) /*period*/ PWM_USEC(5000) /*pulse*/ 0 /*flags*/>;
    };
};
`
The driver parses these timings and calls pwm_set() accordingly.

Tested and validated on a custom board hosting an STM32H743.