### PR TITLE
CI bsim workflow: Add UART tests to the bsim workflow

### DIFF
--- a/.github/workflows/bsim-tests.yaml
+++ b/.github/workflows/bsim-tests.yaml
@@ -20,6 +20,8 @@ on:
       - "include/zephyr/net/openthread.h"
       - "drivers/ieee802154/**"
       - "include/zephyr/net/ieee802154*"
+      - "drivers/serial/*nrfx*"
+      - "tests/drivers/uart/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
@@ -44,6 +46,7 @@ jobs:
       bsim_bt_53_test_results_file: ./bsim_bt/53_bsim_results.xml
       bsim_bt_53split_test_results_file: ./bsim_bt/53_bsim_split_results.xml
       bsim_net_52_test_results_file: ./bsim_net/52_bsim_results.xml
+      bsim_uart_test_results_file: ./bsim_uart/uart_bsim_results.xml
     steps:
       - name: Apply container owner mismatch workaround
         run: |
@@ -116,10 +119,20 @@ jobs:
             drivers/ieee802154/**
             include/zephyr/net/ieee802154*
 
+      - name: Check if UART files changed
+        uses: tj-actions/changed-files@v41
+        id: check-uart-files
+        with:
+          files: |
+            tests/bsim/drivers/uart/**
+            drivers/serial/*nrfx*
+            tests/drivers/uart/**
+
       - name: Update BabbleSim to manifest revision
         if: >
           steps.check-bluetooth-files.outputs.any_changed == 'true'
           || steps.check-networking-files.outputs.any_changed == 'true'
+          || steps.check-uart-files.outputs.any_changed == 'true'
           || steps.check-common-files.outputs.any_changed == 'true'
         run: |
           export BSIM_VERSION=$( west list bsim -f {revision} )
@@ -163,6 +176,18 @@ jobs:
           RESULTS_FILE=${ZEPHYR_BASE}/${bsim_net_52_test_results_file} \
           SEARCH_PATH=tests/bsim/net/ tests/bsim/run_parallel.sh
 
+      - name: Run UART Tests with BSIM
+        if: steps.check-uart-files.outputs.any_changed == 'true' || steps.check-common-files.outputs.any_changed == 'true'
+        run: |
+          echo "UART: Single device tests"
+          ./scripts/twister -T tests/drivers/uart/ --force-color --inline-logs -v -M -p nrf52_bsim \
+            --fixture gpio_loopback -- -uart0_loopback
+          echo "UART: Multi device tests"
+          export ZEPHYR_BASE=${PWD}
+          WORK_DIR=${ZEPHYR_BASE}/bsim_uart nice tests/bsim/drivers/uart/compile.sh
+          RESULTS_FILE=${ZEPHYR_BASE}/${bsim_uart_test_results_file} \
+          SEARCH_PATH=tests/bsim/drivers/uart/ tests/bsim/run_parallel.sh
+
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v3
@@ -173,6 +198,9 @@ jobs:
             ./bsim_bt/53_bsim_results.xml
             ./bsim_bt/53_bsim_split_results.xml
             ./bsim_net/52_bsim_results.xml
+            ./bsim_uart/uart_bsim_results.xml
+            ./twister-out/twister.xml
+            ./twister-out/twister.json
             ${{ github.event_path }}
           if-no-files-found: warn
 

--- a/boards/posix/nrf_bsim/nrf52_bsim.yaml
+++ b/boards/posix/nrf_bsim/nrf52_bsim.yaml
@@ -10,5 +10,6 @@ toolchain:
 testing:
   ignore_tags:
     - modem
+    - bsim_skip_CI
 supported:
   - gpio

--- a/boards/posix/nrf_bsim/nrf5340bsim_nrf5340_cpuapp.yaml
+++ b/boards/posix/nrf_bsim/nrf5340bsim_nrf5340_cpuapp.yaml
@@ -12,3 +12,4 @@ testing:
     - gpio
     - modem
     - uart
+    - bsim_skip_CI

--- a/boards/posix/nrf_bsim/nrf5340bsim_nrf5340_cpunet.yaml
+++ b/boards/posix/nrf_bsim/nrf5340bsim_nrf5340_cpunet.yaml
@@ -12,3 +12,4 @@ testing:
     - gpio
     - modem
     - uart
+    - bsim_skip_CI

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -484,7 +484,11 @@ static int wait_tx_ready(const struct device *dev)
 		/* wait arbitrary time before back off. */
 		bool res;
 
+#if defined(CONFIG_ARCH_POSIX)
+		NRFX_WAIT_FOR(is_tx_ready(dev), 33, 3, res);
+#else
 		NRFX_WAIT_FOR(is_tx_ready(dev), 100, 1, res);
+#endif
 
 		if (res) {
 			key = irq_lock();
@@ -1502,7 +1506,7 @@ static void uarte_nrfx_poll_out(const struct device *dev, unsigned char c)
 			}
 
 			irq_unlock(key);
-			Z_SPIN_DELAY(2);
+			Z_SPIN_DELAY(3);
 		}
 	} else {
 		key = wait_tx_ready(dev);

--- a/tests/bsim/drivers/uart/compile.sh
+++ b/tests/bsim/drivers/uart/compile.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Copyright 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# Compile all the applications needed by all bsim UART tests
+
+#set -x #uncomment this line for debugging
+set -ue
+
+: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
+: "${BSIM_COMPONENTS_PATH:?BSIM_COMPONENTS_PATH must be defined}"
+: "${ZEPHYR_BASE:?ZEPHYR_BASE must be set to point to the zephyr root\
+ directory}"
+
+WORK_DIR="${WORK_DIR:-${ZEPHYR_BASE}/bsim_out}"
+BOARD="${BOARD:-nrf52_bsim}"
+BOARD_ROOT="${BOARD_ROOT:-${ZEPHYR_BASE}}"
+
+mkdir -p ${WORK_DIR}
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+# Placeholder, nothing yet
+# Add apps needed for multidevice UART tests here
+
+wait_for_background_jobs

--- a/tests/drivers/uart/uart_mix_fifo_poll/Kconfig
+++ b/tests/drivers/uart/uart_mix_fifo_poll/Kconfig
@@ -1,0 +1,15 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+config STRESS_TEST_REPS
+	int "Number of loops in the stress test"
+	# For the simulated devices, which are run by default in CI, we set it to less to not spend too
+	# much CI time
+	default 500 if SOC_SERIES_BSIM_NRFXX
+	default 10000
+	help
+	  For how many loops will the stress test run. The higher this number the longer the
+	  test and therefore the higher likelihood an unlikely race/event will be triggered.
+
+# Include Zephyr's Kconfig
+source "Kconfig"

--- a/tests/drivers/uart/uart_mix_fifo_poll/boards/nrf52_bsim.overlay
+++ b/tests/drivers/uart/uart_mix_fifo_poll/boards/nrf52_bsim.overlay
@@ -1,3 +1,8 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 #include "nrf52840dk_nrf52840.overlay"
+
+
+dut: &uart0 {
+	current-speed = <1000000>;
+};

--- a/tests/drivers/uart/uart_mix_fifo_poll/src/main.c
+++ b/tests/drivers/uart/uart_mix_fifo_poll/src/main.c
@@ -264,6 +264,7 @@ static void int_async_thread_func(void *p_data, void *base, void *range)
 
 			int idx = data->cnt & 0xF;
 			size_t len = (idx < BUF_SIZE / 2) ? 5 : 1; /* Try various lengths */
+			len = MIN(len, data->max - data->cnt);
 
 			data->cnt += len;
 			err = uart_tx(uart_dev, &int_async_data.buf[idx],
@@ -317,7 +318,7 @@ static void init_test_data(struct test_data *data, const uint8_t *buf, int repea
 
 ZTEST(uart_mix_fifo_poll, test_mixed_uart_access)
 {
-	int repeat = 10000;
+	int repeat = CONFIG_STRESS_TEST_REPS;
 	int err;
 	int num_of_contexts = ARRAY_SIZE(test_data);
 

--- a/tests/drivers/uart/uart_mix_fifo_poll/testcase.yaml
+++ b/tests/drivers/uart/uart_mix_fifo_poll/testcase.yaml
@@ -47,6 +47,7 @@ tests:
       - CONFIG_NRFX_TIMER2=y
       - CONFIG_UART_0_ENHANCED_POLL_OUT=n
       - CONFIG_UART_ASYNC_TX_CACHE_SIZE=2
+    tags: bsim_skip_CI # We skip a few tests to save CI time, as they give little extra coverage
 
   drivers.uart.uart_mix_poll_async_api_low_power:
     extra_configs:
@@ -58,18 +59,21 @@ tests:
       - CONFIG_UART_0_NRF_HW_ASYNC_TIMER=2
       - CONFIG_NRFX_TIMER2=y
       - CONFIG_UART_0_ENHANCED_POLL_OUT=n
+    tags: bsim_skip_CI
 
   drivers.uart.uart_mix_poll_with_ppi:
     extra_configs:
       - CONFIG_UART_INTERRUPT_DRIVEN=n
       - CONFIG_UART_ASYNC_API=n
       - CONFIG_UART_0_ENHANCED_POLL_OUT=y
+    tags: bsim_skip_CI
 
   drivers.uart.uart_mix_poll_fifo_with_ppi:
     extra_configs:
       - CONFIG_UART_INTERRUPT_DRIVEN=y
       - CONFIG_UART_0_INTERRUPT_DRIVEN=y
       - CONFIG_UART_0_ENHANCED_POLL_OUT=y
+    tags: bsim_skip_CI
 
   drivers.uart.uart_mix_poll_async_api_with_ppi:
     extra_configs:
@@ -80,6 +84,7 @@ tests:
       - CONFIG_UART_0_NRF_HW_ASYNC_TIMER=2
       - CONFIG_NRFX_TIMER2=y
       - CONFIG_UART_0_ENHANCED_POLL_OUT=y
+    tags: bsim_skip_CI
 
   drivers.uart.uart_mix_poll_async_api_with_ppi_low_power:
     extra_configs:


### PR DESCRIPTION
1) For tests/drivers/uart/uart_mix_fifo_poll, do a few changes to the test to speed it/shorten it for simulation, and filter some of the test variants for CI
2) drivers serial nrfx: Speed it up more for simulation
3) Add new workflow steps to the babblesim workflow to run also the UART tests on the nrf52_bsim.
  This commit:
    * Enables the single device tests (which we may move to the normal twister workflow once we fix the requirement for a fixture)
   * Adds as a placeholder for multidevice tests.

