### PR TITLE
manifest: bump hal_nxp revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -193,7 +193,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 9b2693c7659f37f84bcf2604995c88f7fa5206be
+      revision: pull/317/head
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
this contains a minor repository cleanup.

see https://github.com/zephyrproject-rtos/hal_nxp/pull/317 for more information.