### PR TITLE
MAINTAINERS: Add decsny as ETH/MDIO collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1164,6 +1164,8 @@ Release Notes:
 
 "Drivers: Ethernet":
   status: odd fixes
+  collaborators:
+    - decsny
   files:
     - drivers/ethernet/
     - include/zephyr/dt-bindings/ethernet/
@@ -1389,6 +1391,8 @@ Release Notes:
 
 "Drivers: MDIO":
   status: odd fixes
+  collaborators:
+    - decsny
   files:
     - doc/hardware/peripherals/mdio.rst
     - drivers/mdio/


### PR DESCRIPTION
Add myself (decsny) as ethernet/mdio collaborator.

I will clarify I am new to it, but I have taken an interest in ethernet and am currently maintaining and writing some ethernet/mdio drivers for NXP.

Seeing as how according to [this dashboard](https://kibana.zephyrproject.io/s/public/app/dashboards#/view/5d95e53f-446b-442a-86f6-3242fc0740cd?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-90d%2Fd,to:now))), I was the top ethernet collaborator in the last 3 months due to the driver I wrote, and there is currently no one maintaining or collaborating on the ethernet or mdio subsystems, I figure I will volunteer to help out a bit in this area if needed. 

And I would like to use the collaborator role to monitor the zephyr activity of the ethernet/mdio subsystems and be added as reviewer for PRs touching these areas.