### PR TITLE
code_relocation: Add NOKEEP option

### DIFF
--- a/cmake/linker/ld/target_relocation.cmake
+++ b/cmake/linker/ld/target_relocation.cmake
@@ -32,7 +32,7 @@ macro(toolchain_ld_relocation)
     -b ${MEM_RELOCATION_SRAM_BSS_LD}
     -c ${MEM_RELOCATION_CODE}
     --default_ram_region ${MEM_REGION_DEFAULT_RAM}
-    DEPENDS app kernel ${ZEPHYR_LIBS_PROPERTY}
+    DEPENDS app kernel ${ZEPHYR_LIBS_PROPERTY} ${DICT_FILE}
     )
 
   add_library(code_relocation_source_lib  STATIC ${MEM_RELOCATION_CODE})

--- a/doc/kernel/code-relocation.rst
+++ b/doc/kernel/code-relocation.rst
@@ -97,6 +97,22 @@ This section shows additional configuration options that can be set in
      zephyr_code_relocate(FILES ${sources} LOCATION SRAM)
      zephyr_code_relocate(FILES $<TARGET_PROPERTY:my_tgt,SOURCES> LOCATION SRAM)
 
+NOKEEP flag
+===========
+
+By default, all relocated functions and variables will be marked with ``KEEP()``
+when generating ``linker_relocate.ld``.  Therefore, if any input file happens to
+contain unused symbols, then they will not be discarded by the linker, even when
+it is invoked with ``--gc-sections``. If you'd like to override this behavior,
+you can pass ``NOKEEP`` to your ``zephyr_code_relocate()`` call.
+
+  .. code-block:: none
+
+     zephyr_code_relocate(FILES src/file1.c LOCATION SRAM2_TEXT NOKEEP)
+
+The example above will help ensure that any unused code found in the .text
+sections of ``file1.c`` will not stick to SRAM2.
+
 NOCOPY flag
 ===========
 

--- a/tests/application_development/code_relocation/CMakeLists.txt
+++ b/tests/application_development/code_relocation/CMakeLists.txt
@@ -37,8 +37,9 @@ zephyr_code_relocate(FILES src/test_file3.c LOCATION SRAM2_TEXT)
 zephyr_code_relocate(FILES src/test_file3.c LOCATION RAM_DATA)
 zephyr_code_relocate(FILES src/test_file3.c LOCATION SRAM2_BSS)
 
-
-zephyr_code_relocate(FILES ${ZEPHYR_BASE}/kernel/sem.c ${RAM_PHDR} LOCATION RAM)
+# Test NOKEEP support. Placing both KEEP and NOKEEP symbols in the same location
+# (this and test_file2.c in RAM) should work fine.
+zephyr_code_relocate(FILES ${ZEPHYR_BASE}/kernel/sem.c ${RAM_PHDR} LOCATION RAM NOKEEP)
 
 if (CONFIG_RELOCATE_TO_ITCM)
 zephyr_code_relocate(FILES ${ZEPHYR_BASE}/lib/libc/minimal/source/string/string.c


### PR DESCRIPTION
When using the code and data relocation feature, every relocated symbol would be marked with `KEEP()` in the generated linker script. Therefore, if any input files contained unused code, then it wouldn't be discarded by the linker, even when invoked with `--gc-sections`.

This can cause unexpected bloat, or other link-time issues stemming from some symbols being discarded and others not.

On the other hand, this behavior has been present since the feature's introduction, so it should remain default for the users who rely on it.

This patch introduces support for `zephyr_code_relocate(... NOKEEP)`. This will suppress the generation of `KEEP()` statements for all symbols in a particular library or set of files.

Much like `NOCOPY`, the `NOKEEP` flag is passed to `gen_relocate_app.py` in string form. The script is now equipped to handle multiple such flags when passed from CMake as a semicolon-separated list, like so:
```
"SRAM2:NOCOPY;NOKEEP:/path/to/file1.c;/path/to/file2.c"
```
Documentation and tests are updated here as well.