### PR TITLE
logging: Enable string stripping by default for dictionary based backends

### DIFF
--- a/subsys/logging/Kconfig.misc
+++ b/subsys/logging/Kconfig.misc
@@ -66,7 +66,7 @@ config LOG_FMT_SECTION
 
 config LOG_FMT_SECTION_STRIP
 	bool "Strip log strings from binary"
-	depends on !LOG_OUTPUT
+	depends on LOG_DICTIONARY_SUPPORT
 	depends on LOG_FMT_SECTION
 	depends on LINKER_DEVNULL_SUPPORT
 	imply LINKER_DEVNULL_MEMORY

--- a/subsys/logging/Kconfig.template.log_format_config
+++ b/subsys/logging/Kconfig.template.log_format_config
@@ -19,6 +19,8 @@ config LOG_BACKEND_$(backend)_OUTPUT_SYST
 config LOG_BACKEND_$(backend)_OUTPUT_DICTIONARY
 	bool "Dictionary"
 	select LOG_DICTIONARY_SUPPORT
+	imply LOG_FMT_SECTION
+	imply LOG_FMT_SECTION_STRIP
 	help
 	  Backend is in dictionary-based logging output mode.
 


### PR DESCRIPTION
Fixing dependency which did not allow strings stripping when LOG_OUTPUT was used which prevented that feature for all dictionary backends.

Setting string stripping to be by default enabled for all dictionary backends.