### PR TITLE
net: openthread: Print the actual assert location

### DIFF
--- a/modules/openthread/platform/misc.c
+++ b/modules/openthread/platform/misc.c
@@ -99,5 +99,10 @@ void otPlatWakeHost(void)
 
 void otPlatAssertFail(const char *aFilename, int aLineNumber)
 {
-	__ASSERT(false, "OpenThread ASSERT @ %s:%d", aFilename, aLineNumber);
+	/*
+	 * The code below is used instead of __ASSERT(false) to print the actual assert
+	 * location instead of __FILE__:__LINE__, which would point to this function.
+	 */
+	__ASSERT_PRINT("OpenThread ASSERT @ %s:%d\n", aFilename, aLineNumber);
+	__ASSERT_POST_ACTION();
 }


### PR DESCRIPTION
When OpenThread application is built with CONFIG_ASSERT and CONFIG_ASSERT_NO_MSG_INFO, OT_ASSERT() prints a location that points to the otPlatAssertFail() function instead of the code that actually failed an assertion. Example:
```
ASSERTION FAIL @ WEST_TOPDIR/zephyr/modules/openthread/platform/misc.c:36
```

This is confusing and CONFIG_ASSERT_NO_MSG_INFO sometimes cannot be disabled because of flash size limitations.

Make otPlatAssertFail() always print the actual assert location.