### PR TITLE
tests: Bluetooth: use unique IDs for l2cap bsim tests

### DIFF
--- a/tests/bsim/bluetooth/host/l2cap/credits/tests_scripts/l2cap_credits.sh
+++ b/tests/bsim/bluetooth/host/l2cap/credits/tests_scripts/l2cap_credits.sh
@@ -9,7 +9,7 @@ EXECUTE_TIMEOUT=20
 
 cd ${BSIM_OUT_PATH}/bin
 
-simulation_id=$(basename $BASH_SOURCE)
+simulation_id=bluetooth_host_l2cap_credits_prj_conf
 bsim_exe=./bs_nrf52_bsim_tests_bsim_bluetooth_host_l2cap_credits_prj_conf
 
 Execute "${bsim_exe}" -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central -rs=420
@@ -19,7 +19,7 @@ Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} -D=2 -sim_leng
 
 wait_for_background_jobs
 
-simulation_id=$(basename $BASH_SOURCE)_ecred
+simulation_id=bluetooth_host_l2cap_credits_prj_ecred_conf
 bsim_exe=./bs_nrf52_bsim_tests_bsim_bluetooth_host_l2cap_credits_prj_ecred_conf
 
 Execute "${bsim_exe}" -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central -rs=420

--- a/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/tests_scripts/l2cap_credits_seg_recv.sh
+++ b/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/tests_scripts/l2cap_credits_seg_recv.sh
@@ -19,7 +19,7 @@ Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} -D=2 -sim_leng
 
 wait_for_background_jobs
 
-simulation_id=$(basename $BASH_SOURCE)_ecred
+simulation_id=bluetooth_host_l2cap_credits_seg_recv_prj_ecred_conf
 bsim_exe=./bs_nrf52_bsim_tests_bsim_bluetooth_host_l2cap_credits_seg_recv_prj_ecred_conf
 
 Execute "${bsim_exe}" -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central -rs=420


### PR DESCRIPTION
If $BASH_SOURCE is the empty string, then those two tests end up with the same simulation ID. That's not a good time.