### PR TITLE
Bluetooth: L2CAP: stop stealing buffers from SDU pool

### DIFF
--- a/doc/releases/migration-guide-3.6.rst
+++ b/doc/releases/migration-guide-3.6.rst
@@ -241,6 +241,10 @@ Bluetooth
   Any pointer to a UUID must be prefixed with `const`, otherwise there will be a compilation warning.
   For example change ``struct bt_uuid *uuid = BT_UUID_DECLARE_16(xx)`` to
   ``const struct bt_uuid *uuid = BT_UUID_DECLARE_16(xx)``. (:github:`66136`)
+* The :c:func:`bt_l2cap_chan_send` API no longer allocates buffers from the same pool as its `buf`
+  parameter when segmenting SDUs into PDUs. In order to reproduce the previous behavior, the
+  application should register the `alloc_seg` channel callback and allocate from the same pool as
+  `buf`.
 
 * Mesh
 

--- a/include/zephyr/bluetooth/l2cap.h
+++ b/include/zephyr/bluetooth/l2cap.h
@@ -587,9 +587,10 @@ int bt_l2cap_chan_disconnect(struct bt_l2cap_chan *chan);
  *  If the application is reserving the bytes it should use the
  *  BT_L2CAP_BUF_SIZE() helper to correctly size the buffers for the for the
  *  outgoing buffer pool.
- *  When segmenting an L2CAP SDU into L2CAP PDUs the stack will first attempt
- *  to allocate buffers from the original buffer pool of the L2CAP SDU before
- *  using the stacks own buffer pool.
+ *  When segmenting an L2CAP SDU into L2CAP PDUs the stack will first attempt to
+ *  allocate buffers from the channel's `alloc_seg` callback and will fallback
+ *  on the stack's global buffer pool (sized
+ *  @kconfig{CONFIG_BT_L2CAP_TX_BUF_COUNT}).
  *
  *  @note Buffer ownership is transferred to the stack in case of success, in
  *  case of an error the caller retains the ownership of the buffer.


### PR DESCRIPTION
It seems like a nice idea at first, but leads to hard-to-debug situations for the application.

The previous behavior can be implemented by the app by defining `alloc_seg` and allocating from the same pool as `buf`.