### PR TITLE
Bluetooth: L2CAP: Prepend SDU header immediately

### DIFF
--- a/doc/releases/migration-guide-3.6.rst
+++ b/doc/releases/migration-guide-3.6.rst
@@ -245,6 +245,9 @@ Bluetooth
   parameter when segmenting SDUs into PDUs. In order to reproduce the previous behavior, the
   application should register the `alloc_seg` channel callback and allocate from the same pool as
   `buf`.
+* The :c:func:`bt_l2cap_chan_send` API now requires the application to reserve
+  enough bytes for the L2CAP headers. Call ``net_buf_reserve(buf,
+  BT_L2CAP_SDU_CHAN_SEND_RESERVE);`` at buffer allocation time to do so.
 
 * Mesh
 

--- a/include/zephyr/bluetooth/l2cap.h
+++ b/include/zephyr/bluetooth/l2cap.h
@@ -579,14 +579,12 @@ int bt_l2cap_chan_disconnect(struct bt_l2cap_chan *chan);
  *  size the buffers for the for the outgoing buffer pool.
  *
  *  When sending L2CAP data over an LE connection the application is sending
- *  L2CAP SDUs. The application can optionally reserve
+ *  L2CAP SDUs. The application shall reserve
  *  @ref BT_L2CAP_SDU_CHAN_SEND_RESERVE bytes in the buffer before sending.
- *  By reserving bytes in the buffer the stack can use this buffer as a segment
- *  directly, otherwise it will have to allocate a new segment for the first
- *  segment.
- *  If the application is reserving the bytes it should use the
- *  BT_L2CAP_BUF_SIZE() helper to correctly size the buffers for the for the
- *  outgoing buffer pool.
+ *
+ *  The application can use the BT_L2CAP_SDU_BUF_SIZE() helper to correctly size
+ *  the buffer to account for the reserved headroom.
+ *
  *  When segmenting an L2CAP SDU into L2CAP PDUs the stack will first attempt to
  *  allocate buffers from the channel's `alloc_seg` callback and will fallback
  *  on the stack's global buffer pool (sized

--- a/tests/bsim/bluetooth/host/l2cap/credits/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/credits/src/main.c
@@ -23,7 +23,8 @@ CREATE_FLAG(flag_l2cap_connected);
 #define L2CAP_MTU       (2 * SDU_LEN)
 
 /* Only one SDU transmitted or received at a time */
-NET_BUF_POOL_DEFINE(sdu_pool, 1, L2CAP_MTU, CONFIG_BT_CONN_TX_USER_DATA_SIZE, NULL);
+NET_BUF_POOL_DEFINE(sdu_pool, 1, BT_L2CAP_SDU_BUF_SIZE(L2CAP_MTU),
+		    CONFIG_BT_CONN_TX_USER_DATA_SIZE, NULL);
 
 static uint8_t tx_data[SDU_LEN];
 static uint16_t rx_cnt;

--- a/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/src/main.c
@@ -21,7 +21,8 @@ CREATE_FLAG(flag_l2cap_connected);
 #define L2CAP_MTU (2 * SDU_LEN)
 
 /* Only one SDU transmitted or received at a time */
-NET_BUF_POOL_DEFINE(sdu_pool, 1, L2CAP_MTU, CONFIG_BT_CONN_TX_USER_DATA_SIZE, NULL);
+NET_BUF_POOL_DEFINE(sdu_pool, 1, BT_L2CAP_SDU_BUF_SIZE(L2CAP_MTU),
+		    CONFIG_BT_CONN_TX_USER_DATA_SIZE, NULL);
 
 static uint8_t tx_data[SDU_LEN];
 static uint16_t rx_cnt;

--- a/tests/bsim/bluetooth/host/l2cap/general/src/main_l2cap_ecred.c
+++ b/tests/bsim/bluetooth/host/l2cap/general/src/main_l2cap_ecred.c
@@ -33,9 +33,9 @@ static const struct bt_data ad[] = {
 #define SHORT_MSG_CHAN_IDX 1
 
 NET_BUF_POOL_FIXED_DEFINE(rx_data_pool, L2CAP_CHANNELS, BT_L2CAP_BUF_SIZE(DATA_BUF_SIZE), 8, NULL);
-NET_BUF_POOL_FIXED_DEFINE(tx_data_pool_0, 1, BT_L2CAP_BUF_SIZE(DATA_MTU),
+NET_BUF_POOL_FIXED_DEFINE(tx_data_pool_0, 1, BT_L2CAP_SDU_BUF_SIZE(DATA_MTU),
 			  CONFIG_BT_CONN_TX_USER_DATA_SIZE, NULL);
-NET_BUF_POOL_FIXED_DEFINE(tx_data_pool_1, 1, BT_L2CAP_BUF_SIZE(DATA_MTU),
+NET_BUF_POOL_FIXED_DEFINE(tx_data_pool_1, 1, BT_L2CAP_SDU_BUF_SIZE(DATA_MTU),
 			  CONFIG_BT_CONN_TX_USER_DATA_SIZE, NULL);
 
 static struct bt_l2cap_server servers[SERVERS];
@@ -379,7 +379,7 @@ static void send_sdu(int iteration, int chan_idx, int bytes)
 	}
 
 	channels[chan_idx].buf = buf;
-	net_buf_reserve(buf, BT_L2CAP_CHAN_SEND_RESERVE);
+	net_buf_reserve(buf, BT_L2CAP_SDU_CHAN_SEND_RESERVE);
 	net_buf_add_mem(buf, channels[chan_idx].payload, bytes);
 
 	LOG_DBG("bt_l2cap_chan_sending ch: %i bytes: %i iteration: %i", chan_idx, bytes, iteration);


### PR DESCRIPTION
Previously it was not always possible to prepend the header.

It was not possible if the application neglected to reserve the space
for headers.  This is bad because it forces a buffer segment allocation
even if the buffer had enough room for the headers. E.g. a payload of 10
bytes in a netbuf of 30 bytes would have been segmented.

We now explicitly reject the buffer if it does not have the headroom.

This allows us to do a nice thing; simplify L2CAP segmentation.

We convert the SDU from the application into a PDU payload by
prepending the SDU header, i.e. the SDU length in the original buffer.

This PDU payload is ready to be chunked into PDUs without having to keep
track of where in the SDU we are. This has the effect of removing a
bunch of logic in the segmentation machine.