### PR TITLE
STM32 Add PM Suspend to Ram support

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -680,7 +680,7 @@ static void adc_stm32_oversampling_ratioshift(ADC_TypeDef *adc, uint32_t ratio, 
 }
 
 /*
- * Function to configure the oversampling ratio and shit using stm32 LL
+ * Function to configure the oversampling ratio and shift using stm32 LL
  * ratio is directly the sequence->oversampling (a 2^n value)
  * shift is the corresponding LL_ADC_OVS_SHIFT_RIGHT_x constant
  */
@@ -764,6 +764,10 @@ static void dma_callback(const struct device *dev, void *user_data,
 			adc_context_on_sampling_done(&data->ctx, dev);
 			pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_IDLE,
 						 PM_ALL_SUBSTATES);
+			if (IS_ENABLED(CONFIG_PM_S2RAM)) {
+				pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_RAM,
+							 PM_ALL_SUBSTATES);
+			}
 		} else if (status < 0) {
 			LOG_ERR("DMA sampling complete, but DMA reported error %d", status);
 			data->dma_error = status;
@@ -1066,6 +1070,10 @@ static void adc_stm32_isr(const struct device *dev)
 			adc_context_on_sampling_done(&data->ctx, dev);
 			pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_IDLE,
 						 PM_ALL_SUBSTATES);
+			if (IS_ENABLED(CONFIG_PM_S2RAM)) {
+				pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_RAM,
+							 PM_ALL_SUBSTATES);
+			}
 		}
 	}
 
@@ -1101,6 +1109,9 @@ static int adc_stm32_read(const struct device *dev,
 
 	adc_context_lock(&data->ctx, false, NULL);
 	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+	if (IS_ENABLED(CONFIG_PM_S2RAM)) {
+		pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
+	}
 	error = start_read(dev, sequence);
 	adc_context_release(&data->ctx, error);
 
@@ -1117,6 +1128,9 @@ static int adc_stm32_read_async(const struct device *dev,
 
 	adc_context_lock(&data->ctx, true, async);
 	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+	if (IS_ENABLED(CONFIG_PM_S2RAM)) {
+		pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
+	}
 	error = start_read(dev, sequence);
 	adc_context_release(&data->ctx, error);
 

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -417,6 +417,9 @@ static int start_pool_filling(bool wait)
 	 * rng pool is filled.
 	 */
 	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+	if (IS_ENABLED(CONFIG_PM_S2RAM)) {
+		pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
+	}
 
 	acquire_rng();
 	irq_enable(IRQN);
@@ -546,6 +549,9 @@ static void stm32_rng_isr(const void *arg)
 			irq_disable(IRQN);
 			release_rng();
 			pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+			if (IS_ENABLED(CONFIG_PM_S2RAM)) {
+				pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
+			}
 			entropy_stm32_rng_data.filling_pools = false;
 		}
 

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -701,16 +701,37 @@ static int entropy_stm32_rng_init(const struct device *dev)
 static int entropy_stm32_rng_pm_action(const struct device *dev,
 				       enum pm_device_action action)
 {
+	struct entropy_stm32_rng_dev_data *dev_data = dev->data;
+
 	int res = 0;
+
+	/* Remove warning on some platforms */
+	ARG_UNUSED(dev_data);
 
 	switch (action) {
 	case PM_DEVICE_ACTION_SUSPEND:
 		res = entropy_stm32_suspend();
 		break;
 	case PM_DEVICE_ACTION_RESUME:
-		/* Resume RNG only if it was suspended during filling pool */
-		if (entropy_stm32_rng_data.filling_pools) {
-			res = entropy_stm32_resume();
+		if (IS_ENABLED(CONFIG_PM_S2RAM)) {
+#if DT_INST_NODE_HAS_PROP(0, health_test_config)
+			entropy_stm32_resume();
+#if DT_INST_NODE_HAS_PROP(0, health_test_magic)
+			LL_RNG_SetHealthConfig(rng, DT_INST_PROP(0, health_test_magic));
+#endif /* health_test_magic */
+			if (LL_RNG_GetHealthConfig(dev_data->rng) !=
+				DT_INST_PROP_OR(0, health_test_config, 0U)) {
+				entropy_stm32_rng_init(dev);
+			} else if (!entropy_stm32_rng_data.filling_pools) {
+				/* Resume RNG only if it was suspended during filling pool */
+				entropy_stm32_suspend();
+			}
+#endif /* health_test_config */
+		} else {
+			/* Resume RNG only if it was suspended during filling pool */
+			if (entropy_stm32_rng_data.filling_pools) {
+				res = entropy_stm32_resume();
+			}
 		}
 		break;
 	default:

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -524,9 +524,11 @@ static int gpio_stm32_config(const struct device *dev,
 	}
 
 	/* Enable device clock before configuration (requires bank writes) */
-	err = pm_device_runtime_get(dev);
-	if (err < 0) {
-		return err;
+	if (((flags & GPIO_OUTPUT) != 0) || ((flags & GPIO_INPUT) != 0)) {
+		err = pm_device_runtime_get(dev);
+		if (err < 0) {
+			return err;
+		}
 	}
 
 	if ((flags & GPIO_OUTPUT) != 0) {

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -96,6 +96,9 @@ static void uart_stm32_pm_policy_state_lock_get(const struct device *dev)
 	if (!data->pm_policy_state_on) {
 		data->pm_policy_state_on = true;
 		pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+		if (IS_ENABLED(CONFIG_PM_S2RAM)) {
+			pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
+		}
 	}
 }
 
@@ -106,6 +109,9 @@ static void uart_stm32_pm_policy_state_lock_put(const struct device *dev)
 	if (data->pm_policy_state_on) {
 		data->pm_policy_state_on = false;
 		pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+		if (IS_ENABLED(CONFIG_PM_S2RAM)) {
+			pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
+		}
 	}
 }
 #endif /* CONFIG_PM */

--- a/drivers/timer/Kconfig.stm32_lptim
+++ b/drivers/timer/Kconfig.stm32_lptim
@@ -3,6 +3,8 @@
 # Copyright (c) 2019 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
+DT_CHOSEN_STDBY_TIMER := st,lptim-stdby-timer
+
 menuconfig STM32_LPTIM_TIMER
 	bool "STM32 Low Power Timer [EXPERIMENTAL]"
 	default y
@@ -55,5 +57,23 @@ config STM32_LPTIM_TICK_FREQ_RATIO_OVERRIDE
 	  To prevent misconfigurations, a dedicated check is implemented
 	  in the driver.
 	  This options allows to override this check
+
+config STM32_LPTIM_STDBY_TIMER
+	bool "Use an additional timer while entering Standby mode"
+	default $(dt_chosen_enabled,$(DT_CHOSEN_STDBY_TIMER))
+	depends on COUNTER
+	depends on TICKLESS_KERNEL
+	select EXPERIMENTAL
+	help
+	  There are chips e.g. STM32WBAX family that use LPTIM as a system timer,
+	  but LPTIM is not clocked in standby mode. These chips usually have
+	  another timer that is not stopped, but it has lower frequency e.g.
+	  RTC, thus it can't be used as a main system timer.
+
+	  Use the Standby timer for timeout (wakeup) when the system is entering
+	  Standby state.
+
+	  The chosen Standby timer node has to support setting alarm from the
+	  counter API.
 
 endif # STM32_LPTIM_TIMER

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -448,8 +448,6 @@ static int sys_clock_driver_init(void)
 	stm32_lptim_wait_ready();
 	LL_LPTIM_ClearFlag_ARROK(LPTIM);
 
-	accumulated_lptim_cnt = 0;
-
 #if !defined(CONFIG_SOC_SERIES_STM32U5X) && \
 	!defined(CONFIG_SOC_SERIES_STM32WBAX)
 	/* Enable the LPTIM counter */


### PR DESCRIPTION
This PR adds generic support for Suspend to RAM PM mode.

To that end, we use STM32 Standby mode with RAM retention (for SoC that provide it).
In low power applications, the Systick is typically given by a LPTIM. Since LPTIM is not clocked in Standby mode, before switching to this mode, we activate another clock (typically RTC) that works in Standby to play the role of Systick.
This was heavily influenced by the work in #63187 (Many thanks!).

A few peripherals (GPIO, ADC, Serial and entropy) have also been adapted to be compatible with this mode.

This other PR #67536 demonstrates the functionality on the STM32WBA series.