### PR TITLE
Bluetooth: Mesh: Fix dereferencing before null pointer check

### DIFF
--- a/subsys/bluetooth/mesh/delayable_msg.c
+++ b/subsys/bluetooth/mesh/delayable_msg.c
@@ -167,12 +167,14 @@ static bool push_msg_from_delayable_msgs(void)
 	sys_snode_t *node;
 	struct delayable_msg_chunk *chunk;
 	struct delayable_msg_ctx *msg = peek_pending_msg();
-	uint16_t len = msg->len;
+	uint16_t len;
 	int err;
 
 	if (!msg) {
 		return false;
 	}
+
+	len = msg->len;
 
 	NET_BUF_SIMPLE_DEFINE(buf, BT_MESH_TX_SDU_MAX);
 


### PR DESCRIPTION
Don't dereference pointer until it is checked on NULL.

Fixes: #66805
Coverity-CID: 338098