### PR TITLE
xtensa: intel_adsp: fix a cache handling error

### DIFF
--- a/drivers/power_domain/power_domain_intel_adsp.c
+++ b/drivers/power_domain/power_domain_intel_adsp.c
@@ -39,7 +39,7 @@ static int pd_intel_adsp_set_power_enable(struct pg_bits *bits, bool power_enabl
 		extern uint32_t g_key_read_holder;
 
 		if (bits->SPA_bit == INTEL_ADSP_HST_DOMAIN_BIT) {
-			volatile uint32_t *key_read_ptr = z_soc_uncached_ptr(&g_key_read_holder);
+			volatile uint32_t *key_read_ptr = &g_key_read_holder;
 			uint32_t key_value = *key_read_ptr;
 
 			if (key_value != INTEL_ADSP_ACE15_MAGIC_KEY)


### PR DESCRIPTION
.bss and .data are uncached in Zephyr builds for intel_adsp. No need to try to manipulate cache of objects in those sections.