### PR TITLE
modules: hal_nordic: nrfx_glue: Fix unused argument

### DIFF
--- a/modules/hal_nordic/nrfx/nrfx_glue.h
+++ b/modules/hal_nordic/nrfx/nrfx_glue.h
@@ -51,9 +51,8 @@ extern "C" {
  * @param irq_number IRQ number.
  * @param priority   Priority to be set.
  */
-#define NRFX_IRQ_PRIORITY_SET(irq_number, priority)  // Intentionally empty.
-                                                     // Priorities of IRQs are
-                                                     // set through IRQ_CONNECT.
+#define NRFX_IRQ_PRIORITY_SET(irq_number, priority)                                                \
+	/* Intentionally empty. Priorities of IRQs are set through IRQ_CONNECT. */
 
 /**
  * @brief Macro for enabling a specific IRQ.

--- a/modules/hal_nordic/nrfx/nrfx_glue.h
+++ b/modules/hal_nordic/nrfx/nrfx_glue.h
@@ -52,6 +52,7 @@ extern "C" {
  * @param priority   Priority to be set.
  */
 #define NRFX_IRQ_PRIORITY_SET(irq_number, priority)                                                \
+	ARG_UNUSED(priority)                                                                       \
 	/* Intentionally empty. Priorities of IRQs are set through IRQ_CONNECT. */
 
 /**


### PR DESCRIPTION
When compiling e.g. _samples/boards/nrf/nrfx_ with the following modification:

```cmake
target_compile_options(app PRIVATE
  -Wunused-parameter
)
```

I get the following compilation warning:

```
$ west build -b nrf52840dk_nrf52840 zephyr/samples/boards/nrf/nrfx
In file included from modules/hal/nordic/nrfx/drivers/include/nrfx_gpiote.h:38,
                 from zephyr/samples/boards/nrf/nrfx/src/main.c:9:
modules/hal/nordic/nrfx/haly/nrfy_gpiote.h: In function 'nrfy_gpiote_int_init':
modules/hal/nordic/nrfx/haly/nrfy_gpiote.h:82:64: warning: unused parameter 'irq_priority' [-Wunused-parameter]
   82 |                                              uint8_t           irq_priority,
      |                                              ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~

```

Fix it by adding `ARG_UNUSED(priority)` in `NRFX_IRQ_PRIORITY_SET()`.