### PR TITLE
pm: console: Use async runtime put to minimize resumption/suspension

### DIFF
--- a/drivers/console/uart_console.c
+++ b/drivers/console/uart_console.c
@@ -99,8 +99,11 @@ static int console_out(int c)
 	}
 	uart_poll_out(uart_console_dev, c);
 
-	/* As errors cannot be returned, ignore the return value */
-	(void)pm_device_runtime_put(uart_console_dev);
+	/* Use async put to avoid useless device suspension/resumption
+	 * when tranmiting chain of chars.
+	 * As errors cannot be returned, ignore the return value
+	 */
+	(void)pm_device_runtime_put_async(uart_console_dev, K_MSEC(1));
 
 	return c;
 }

--- a/subsys/logging/backends/log_backend_uart.c
+++ b/subsys/logging/backends/log_backend_uart.c
@@ -114,8 +114,11 @@ static int char_out(uint8_t *data, size_t length, void *ctx)
 
 	(void)err;
 cleanup:
-	/* As errors cannot be returned, ignore the return value */
-	(void)pm_device_runtime_put(uart_dev);
+	/* Use async put to avoid useless device suspension/resumption
+	 * when tranmiting chain of chars.
+	 * As errors cannot be returned, ignore the return value
+	 */
+	(void)pm_device_runtime_put_async(uart_dev, K_MSEC(1));
 
 	return length;
 }


### PR DESCRIPTION
When device runtime pm is enabled on console device, do not suspend device synchronously on each char transmission, but rather use asynchronous suspension request.
This will save useless and costly suspension/resumption procedure, which can involve uart device clock suspension but also pin configuration to sleep state (which itself involves gpio clock activation ...).

On STM32, using asynch device suspension allows to divide by 3 the transmission time of a character chain.