### PR TITLE
rtio: Fix unused argument

### DIFF
--- a/include/zephyr/rtio/rtio.h
+++ b/include/zephyr/rtio/rtio.h
@@ -699,7 +699,11 @@ static inline int rtio_block_pool_alloc(struct rtio *r, size_t min_sz,
 
 static inline void rtio_block_pool_free(struct rtio *r, void *buf, uint32_t buf_len)
 {
-#ifdef CONFIG_RTIO_SYS_MEM_BLOCKS
+#ifndef CONFIG_RTIO_SYS_MEM_BLOCKS
+	ARG_UNUSED(r);
+	ARG_UNUSED(buf);
+	ARG_UNUSED(buf_len);
+#else
 	size_t num_blks = buf_len >> r->block_pool->info.blk_sz_shift;
 
 	sys_mem_blocks_free_contiguous(r->block_pool, buf, num_blks);


### PR DESCRIPTION
When compiling e.g. _samples/sensor/bme680_ with the following modification:

```cmake
target_compile_options(app PRIVATE
  -Wunused-parameter
)
```

I get the following compilation warning:

```
$ west build -b nrf52840dk_nrf52840 zephyr/samples/sensor/bme680
In file included from zephyr/include/zephyr/drivers/sensor.h:28,
                 from zephyr/samples/sensor/bme680/src/main.c:9:
zephyr/include/zephyr/rtio/rtio.h: In function 'rtio_block_pool_free':
zephyr/include/zephyr/rtio/rtio.h:700:54: warning: unused parameter 'r' [-Wunused-parameter]
  700 | static inline void rtio_block_pool_free(struct rtio *r, void *buf, uint32_t buf_len)
      |                                         ~~~~~~~~~~~~~^
zephyr/include/zephyr/rtio/rtio.h:700:63: warning: unused parameter 'buf' [-Wunused-parameter]
  700 | static inline void rtio_block_pool_free(struct rtio *r, void *buf, uint32_t buf_len)
      |                                                         ~~~~~~^~~
zephyr/include/zephyr/rtio/rtio.h:700:77: warning: unused parameter 'buf_len' [-Wunused-parameter]
  700 | static inline void rtio_block_pool_free(struct rtio *r, void *buf, uint32_t buf_len)
      |                                                                    ~~~~~~~~~^~~~~~~
```

Align the implementation of `rtio_block_pool_free()` with `rtio_block_pool_alloc()` and add `ARG_UNUSED()` statements for the arguments.