### PR TITLE
Minor native sim related performance optimizations

### DIFF
--- a/boards/posix/native_sim/irq_handler.c
+++ b/boards/posix/native_sim/irq_handler.c
@@ -77,13 +77,20 @@ void posix_irq_handler(void)
 		return;
 	}
 
+	irq_nbr = hw_irq_ctrl_get_highest_prio_irq();
+
+	if (irq_nbr == -1) {
+		/* This is a phony interrupt during a busy wait, no need for more */
+		return;
+	}
+
 	if (_kernel.cpus[0].nested == 0) {
 		may_swap = 0;
 	}
 
 	_kernel.cpus[0].nested++;
 
-	while ((irq_nbr = hw_irq_ctrl_get_highest_prio_irq()) != -1) {
+	do {
 		int last_current_running_prio = hw_irq_ctrl_get_cur_prio();
 		int last_running_irq = currently_running_irq;
 
@@ -95,7 +102,7 @@ void posix_irq_handler(void)
 		currently_running_irq = last_running_irq;
 
 		hw_irq_ctrl_set_cur_prio(last_current_running_prio);
-	}
+	} while ((irq_nbr = hw_irq_ctrl_get_highest_prio_irq()) != -1);
 
 	_kernel.cpus[0].nested--;
 

--- a/boards/posix/nrf_bsim/irq_handler.c
+++ b/boards/posix/nrf_bsim/irq_handler.c
@@ -95,13 +95,20 @@ void posix_irq_handler(void)
 		return;
 	}
 
+	irq_nbr = hw_irq_ctrl_get_highest_prio_irq(cpu_n);
+
+	if (irq_nbr == -1) {
+		/* This is a phony interrupt during a busy wait, no need for more */
+		return;
+	}
+
 	if (_kernel.cpus[0].nested == 0) {
 		may_swap = 0;
 	}
 
 	_kernel.cpus[0].nested++;
 
-	while ((irq_nbr = hw_irq_ctrl_get_highest_prio_irq(cpu_n)) != -1) {
+	do {
 		int last_current_running_prio = hw_irq_ctrl_get_cur_prio(cpu_n);
 		int last_running_irq = currently_running_irq;
 
@@ -115,7 +122,7 @@ void posix_irq_handler(void)
 		hw_irq_ctrl_reeval_level_irq(cpu_n, irq_nbr);
 
 		hw_irq_ctrl_set_cur_prio(cpu_n, last_current_running_prio);
-	}
+	} while ((irq_nbr = hw_irq_ctrl_get_highest_prio_irq(cpu_n)) != -1);
 
 	_kernel.cpus[0].nested--;
 

--- a/scripts/native_simulator/common/src/include/nsi_hw_scheduler.h
+++ b/scripts/native_simulator/common/src/include/nsi_hw_scheduler.h
@@ -16,7 +16,11 @@ extern "C" {
 #define NSI_NEVER UINT64_MAX
 
 /* API intended for the native simulator specific embedded drivers: */
-uint64_t nsi_hws_get_time(void);
+static inline uint64_t nsi_hws_get_time(void)
+{
+	extern uint64_t nsi_simu_time;
+	return nsi_simu_time;
+}
 
 /* Internal APIs to the native_simulator and its HW models: */
 void nsi_hws_init(void);

--- a/scripts/native_simulator/common/src/main.c
+++ b/scripts/native_simulator/common/src/main.c
@@ -50,7 +50,7 @@ NSI_FUNC_NORETURN void nsi_exit(int exit_code)
 }
 
 /**
- * Run all early native_posix initialization steps, including command
+ * Run all early native simulator initialization steps, including command
  * line parsing and CPU start, until we are ready to let the HW models
  * run via hwm_one_event()
  */

--- a/scripts/native_simulator/common/src/nsi_hw_scheduler.c
+++ b/scripts/native_simulator/common/src/nsi_hw_scheduler.c
@@ -21,7 +21,7 @@
 #include "nsi_hw_scheduler.h"
 #include "nsi_hws_models_if.h"
 
-static uint64_t simu_time; /* The actual time as known by the HW models */
+uint64_t nsi_simu_time; /* The actual time as known by the HW models */
 static uint64_t end_of_time = NSI_NEVER; /* When will this device stop */
 
 extern struct nsi_hw_event_st __nsi_hw_events_start[];
@@ -74,21 +74,21 @@ static void nsi_hws_set_sig_handler(void)
 
 static void nsi_hws_sleep_until_next_event(void)
 {
-	if (next_timer_time >= simu_time) { /* LCOV_EXCL_BR_LINE */
-		simu_time = next_timer_time;
+	if (next_timer_time >= nsi_simu_time) { /* LCOV_EXCL_BR_LINE */
+		nsi_simu_time = next_timer_time;
 	} else {
 		/* LCOV_EXCL_START */
 		nsi_print_warning("next_timer_time corrupted (%"PRIu64"<= %"
 				PRIu64", timer idx=%i)\n",
 				(uint64_t)next_timer_time,
-				(uint64_t)simu_time,
+				(uint64_t)nsi_simu_time,
 				next_timer_index);
 		/* LCOV_EXCL_STOP */
 	}
 
-	if (signaled_end || (simu_time > end_of_time)) {
+	if (signaled_end || (nsi_simu_time > end_of_time)) {
 		nsi_print_trace("\nStopped at %.3Lfs\n",
-				((long double)simu_time)/1.0e6L);
+				((long double)nsi_simu_time)/1.0e6L);
 		nsi_exit(0);
 	}
 }
@@ -139,14 +139,6 @@ void nsi_hws_one_event(void)
 void nsi_hws_set_end_of_time(uint64_t new_end_of_time)
 {
 	end_of_time = new_end_of_time;
-}
-
-/**
- * Return the current simulated time as known by the device
- */
-uint64_t nsi_hws_get_time(void)
-{
-	return simu_time;
 }
 
 /**


### PR DESCRIPTION
* Minor performance optimization on the irq handler code for both the native_sim and nrf5x_bsim boards, while waking due to phony interrupts (it improves performance measurably for code which does the equivalent of `while (!condition) {k_busy_wait(1);}` for a long period of time and therefore keeps the simulated CPU waking up every µs.
* Update the native_simulator to the latest version