### PR TITLE
Native ethernet and CAN drivers, avoid using ssize

### DIFF
--- a/drivers/can/can_native_linux.c
+++ b/drivers/can/can_native_linux.c
@@ -18,6 +18,7 @@
 #include <zephyr/net/socketcan_utils.h>
 
 #include "can_native_linux_adapt.h"
+#include "nsi_host_trampolines.h"
 
 LOG_MODULE_REGISTER(can_native_linux, CONFIG_CAN_LOG_LEVEL);
 
@@ -179,7 +180,7 @@ static int can_native_linux_send(const struct device *dev, const struct can_fram
 	data->tx_callback = callback;
 	data->tx_user_data = user_data;
 
-	ret = linux_socketcan_write_data(data->dev_fd, &sframe, mtu);
+	ret = nsi_host_write(data->dev_fd, &sframe, mtu);
 	if (ret < 0) {
 		LOG_ERR("Cannot send CAN data len %d (%d)", sframe.len, -errno);
 	}

--- a/drivers/can/can_native_linux_adapt.c
+++ b/drivers/can/can_native_linux_adapt.c
@@ -113,7 +113,7 @@ int linux_socketcan_poll_data(int fd)
 	return -EAGAIN;
 }
 
-ssize_t linux_socketcan_read_data(int fd, void *buf, size_t buf_len, bool *msg_confirm)
+int linux_socketcan_read_data(int fd, void *buf, size_t buf_len, bool *msg_confirm)
 {
 	struct canfd_frame *frame = (struct canfd_frame *)buf;
 	struct msghdr msg = {0};
@@ -125,7 +125,7 @@ ssize_t linux_socketcan_read_data(int fd, void *buf, size_t buf_len, bool *msg_c
 	msg.msg_iov = &iov;
 	msg.msg_iovlen = 1;
 
-	int ret = recvmsg(fd, &msg, MSG_WAITALL);
+	int ret = (int)recvmsg(fd, &msg, MSG_WAITALL);
 
 	if (msg_confirm != NULL) {
 		*msg_confirm = (msg.msg_flags & MSG_CONFIRM) != 0;
@@ -143,11 +143,6 @@ ssize_t linux_socketcan_read_data(int fd, void *buf, size_t buf_len, bool *msg_c
 	}
 
 	return ret;
-}
-
-ssize_t linux_socketcan_write_data(int fd, void *buf, size_t buf_len)
-{
-	return write(fd, buf, buf_len);
 }
 
 int linux_socketcan_set_mode_fd(int fd, bool mode_fd)

--- a/drivers/can/can_native_linux_adapt.h
+++ b/drivers/can/can_native_linux_adapt.h
@@ -17,9 +17,7 @@ int linux_socketcan_iface_close(int fd);
 
 int linux_socketcan_poll_data(int fd);
 
-ssize_t linux_socketcan_read_data(int fd, void *buf, size_t buf_len, bool *msg_confirm);
-
-ssize_t linux_socketcan_write_data(int fd, void *buf, size_t buf_len);
+int linux_socketcan_read_data(int fd, void *buf, size_t buf_len, bool *msg_confirm);
 
 int linux_socketcan_set_mode_fd(int fd, bool mode_fd);
 

--- a/drivers/ethernet/eth_native_posix.c
+++ b/drivers/ethernet/eth_native_posix.c
@@ -35,6 +35,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <zephyr/net/lldp.h>
 
 #include "eth_native_posix_priv.h"
+#include "nsi_host_trampolines.h"
 #include "eth.h"
 
 #define NET_BUF_TIMEOUT K_MSEC(100)
@@ -193,7 +194,7 @@ static int eth_send(const struct device *dev, struct net_pkt *pkt)
 
 	LOG_DBG("Send pkt %p len %d", pkt, count);
 
-	ret = eth_write_data(ctx->dev_fd, ctx->send, count);
+	ret = nsi_host_write(ctx->dev_fd, ctx->send, count);
 	if (ret < 0) {
 		LOG_DBG("Cannot send pkt %p (%d)", pkt, ret);
 	}
@@ -321,7 +322,7 @@ static int read_data(struct eth_context *ctx, int fd)
 	int status;
 	int count;
 
-	count = eth_read_data(fd, ctx->recv, sizeof(ctx->recv));
+	count = nsi_host_read(fd, ctx->recv, sizeof(ctx->recv));
 	if (count <= 0) {
 		return 0;
 	}

--- a/drivers/ethernet/eth_native_posix_adapt.c
+++ b/drivers/ethernet/eth_native_posix_adapt.c
@@ -116,16 +116,6 @@ int eth_wait_data(int fd)
 	return -EAGAIN;
 }
 
-ssize_t eth_read_data(int fd, void *buf, size_t buf_len)
-{
-	return read(fd, buf, buf_len);
-}
-
-ssize_t eth_write_data(int fd, void *buf, size_t buf_len)
-{
-	return write(fd, buf, buf_len);
-}
-
 int eth_clock_gettime(uint64_t *second, uint32_t *nanosecond)
 {
 	struct timespec tp;

--- a/drivers/ethernet/eth_native_posix_priv.h
+++ b/drivers/ethernet/eth_native_posix_priv.h
@@ -14,8 +14,6 @@
 int eth_iface_create(const char *dev_name, const char *if_name, bool tun_only);
 int eth_iface_remove(int fd);
 int eth_wait_data(int fd);
-ssize_t eth_read_data(int fd, void *buf, size_t buf_len);
-ssize_t eth_write_data(int fd, void *buf, size_t buf_len);
 int eth_clock_gettime(uint64_t *second, uint32_t *nanosecond);
 int eth_promisc_mode(const char *if_name, bool enable);
 


### PR DESCRIPTION
In these linux/native specific drivers interface between the linux side and the Zephyr side, ssize is used.
 
ssize is a POSIX.1-2001 extension, which may or may not be provided by the embedded C library, or may be defined
to a different size in the host and embedded C library.

Three internal functions were returning ssize, and were just trampolines into the same host API, which are already provided by the native simulator, so let's just use these instead.

The other is only carrying data that fits into an int and is anyhow being cast in/to ints, so let's just
avoid the trouble by defining it as returning int.