### PR TITLE
net: sockets: prevent null pointer dereference

### DIFF
--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -684,7 +684,9 @@ int z_impl_zsock_accept(int sock, struct sockaddr *addr, socklen_t *addrlen)
 
 	new_sock = VTABLE_CALL(accept, sock, addr, addrlen);
 
-	(void)sock_obj_core_alloc_find(sock, new_sock, addr->sa_family, SOCK_STREAM);
+	if (addr) {
+		(void)sock_obj_core_alloc_find(sock, new_sock, addr->sa_family, SOCK_STREAM);
+	}
 
 	return new_sock;
 }


### PR DESCRIPTION
According to the [POSIX specification](https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/functions/accept.html), null pointer
is a valid value for the `address` argument
of the `accept` function.
This commit adds a check to prevent a null pointer
dereference inside `z_impl_zsock_accept`.