### PR TITLE
drivers: gpio: correct spelling

### DIFF
--- a/drivers/gpio/gpio_bd8lb600fs.c
+++ b/drivers/gpio/gpio_bd8lb600fs.c
@@ -86,7 +86,7 @@ static int bd8lb600fs_pin_configure(const struct device *dev, gpio_pin_t pin, gp
 	}
 
 	if (pin > 7) {
-		LOG_ERR("invalid pin nummber %i", pin);
+		LOG_ERR("invalid pin number %i", pin);
 		return -EINVAL;
 	}
 

--- a/drivers/gpio/gpio_efinix_sapphire.c
+++ b/drivers/gpio/gpio_efinix_sapphire.c
@@ -34,14 +34,14 @@ LOG_MODULE_REGISTER(gpio_efinix_sapphire);
 #define BSP_GPIO_INTERRUPT_HIGH_ENABLE 0x28
 #define BSP_GPIO_INTERRUPT_LOW_ENABLE  0x2c
 
-/* efinix sapphire specefic gpio config struct */
+/* efinix sapphire specific gpio config struct */
 struct gpio_efinix_sapphire_cfg {
 	uint32_t base_addr;
 	int n_gpios;
 	struct gpio_driver_config common;
 };
 
-/* efinix sapphire specefic gpio data struct */
+/* efinix sapphire specific gpio data struct */
 struct gpio_efinix_sapphire_data {
 	struct gpio_driver_data common;
 	const struct device *dev;
@@ -79,7 +79,7 @@ static inline void cfg_output_bit(const struct gpio_efinix_sapphire_cfg *config,
 	}
 }
 
-/* To use the controller bare minimun as IO, Peripheral has to configure, */
+/* To use the controller bare minimum as IO, Peripheral has to configure, */
 /* the Output enable register, b0 : Input, b1 : Output */
 
 static int gpio_efinix_sapphire_config(const struct device *dev, gpio_pin_t pin, gpio_flags_t flags)

--- a/drivers/gpio/gpio_tle9104.c
+++ b/drivers/gpio/gpio_tle9104.c
@@ -249,7 +249,7 @@ static int tle9104_pin_configure(const struct device *dev, gpio_pin_t pin, gpio_
 	}
 
 	if (pin >= TLE9104_GPIO_COUNT) {
-		LOG_ERR("invalid pin nummber %i", pin);
+		LOG_ERR("invalid pin number %i", pin);
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Employ a code spell checking tool to scan and correct spelling errors in all files within the drivers/gpio directory.