### PR TITLE
drivers: spi: correct spelling

### DIFF
--- a/drivers/spi/Kconfig.mcux_lpspi
+++ b/drivers/spi/Kconfig.mcux_lpspi
@@ -22,7 +22,7 @@ config SPI_MCUX_LPSPI_DMA
 
 if SPI_RTIO
 config SPI_MCUX_RTIO_SQ_SIZE
-	int "number of avialable submission queue entries"
+	int "number of available submission queue entries"
 	default 8 # sensible default that covers most common spi transactions
 	help
 	  when rtio is use with spi each driver holds a context with which blocking

--- a/drivers/spi/Kconfig.sam
+++ b/drivers/spi/Kconfig.sam
@@ -22,7 +22,7 @@ config SPI_SAM_DMA
 
 if SPI_RTIO
 config SPI_SAM_RTIO_SQ_SIZE
-	int "Number of avialable submission queue entries"
+	int "Number of available submission queue entries"
 	default 8 # Sensible default that covers most common spi transactions
 	help
 	  When RTIO is use with SPI each driver holds a context with which blocking

--- a/drivers/spi/spi_b91.c
+++ b/drivers/spi/spi_b91.c
@@ -228,7 +228,7 @@ static void spi_b91_txrx(const struct device *dev, uint32_t len)
 		BM_SET(reg_spi_fifo_state(cfg->peripheral_id), FLD_SPI_RXF_CLR);
 	}
 
-	/* wait fot SPI is ready */
+	/* wait for SPI is ready */
 	while (spi_is_busy(cfg->peripheral_id)) {
 	};
 

--- a/drivers/spi/spi_opentitan.c
+++ b/drivers/spi/spi_opentitan.c
@@ -169,7 +169,7 @@ static void spi_opentitan_xfer(const struct device *dev, const bool gpio_cs_cont
 		}
 
 		/* Keep CS asserted if another Tx segment remains or if two more Rx
-		 * segements remain (because we will handle one Rx segment after the
+		 * segments remain (because we will handle one Rx segment after the
 		 * forthcoming transaction).
 		 */
 		if (ctx->tx_count > 0 || ctx->rx_count > 1)  {

--- a/drivers/spi/spi_xec_qmspi_ldma.c
+++ b/drivers/spi/spi_xec_qmspi_ldma.c
@@ -215,7 +215,7 @@ static int qmspi_set_frequency(struct spi_qmspi_data *qdata, struct qmspi_regs *
  * SPI signalling mode: CPOL and CPHA
  * CPOL = 0 is clock idles low, 1 is clock idle high
  * CPHA = 0 Transmitter changes data on trailing of preceding clock cycle.
- *          Receiver samples data on leading edge of clock cyle.
+ *          Receiver samples data on leading edge of clock cycle.
  *        1 Transmitter changes data on leading edge of current clock cycle.
  *          Receiver samples data on the trailing edge of clock cycle.
  * SPI Mode nomenclature:
@@ -475,7 +475,7 @@ static inline int qmspi_xfr_cm_init(const struct device *dev,
  * RX data discard for certain SPI command protocols using dual/quad I/O.
  * 1. Get largest contiguous data size from SPI context.
  * 2. If the SPI TX context has a non-zero length configure Local-DMA TX
- *    channel 1 for contigous data size. If TX context has valid buffer
+ *    channel 1 for contiguous data size. If TX context has valid buffer
  *    configure channel to use context buffer with address increment.
  *    If the TX buffer pointer is NULL interpret byte length as the number
  *    of clocks to generate with output line(s) tri-stated. NOTE: The controller
@@ -487,7 +487,7 @@ static inline int qmspi_xfr_cm_init(const struct device *dev,
  *    For example, if I/O lines is 4 (quad) meaning 4 bits per clock and the
  *    user wants 7 clocks then the number of bit units is 4 * 7 = 28.
  * 3. If instead, the SPI RX context has a non-zero length configure Local-DMA
- *    RX channel 1 for the contigous data size. If RX context has a valid
+ *    RX channel 1 for the contiguous data size. If RX context has a valid
  *    buffer configure channel to use buffer with address increment else
  *    configure channel for driver data temporary buffer without address
  *    increment.
@@ -696,7 +696,7 @@ static int qmspi_xfr_start_async(const struct device *dev, const struct spi_buf_
 	return 0;
 }
 
-/* Wrapper to start asynchronous (interrupts enabled) SPI transction */
+/* Wrapper to start asynchronous (interrupts enabled) SPI transaction */
 static int qmspi_xfr_async(const struct device *dev,
 			   const struct spi_config *config,
 			   const struct spi_buf_set *tx_bufs,


### PR DESCRIPTION
Employ a code spell checking tool to scan and correct spelling errors in all files within the drivers/spi directory.