### PR TITLE
drivers: serial: correct spelling

### DIFF
--- a/drivers/serial/Kconfig.emul
+++ b/drivers/serial/Kconfig.emul
@@ -20,7 +20,7 @@ config UART_EMUL_WORK_Q_STACK_SIZE
 	default 2048
 
 config UART_EMUL_WORK_Q_PRIORITY
-	int "UART emulator work queue tread priority"
+	int "UART emulator work queue thread priority"
 	default 1
 
 endif # UART_EMUL

--- a/drivers/serial/uart_cdns.h
+++ b/drivers/serial/uart_cdns.h
@@ -122,7 +122,7 @@ struct uart_cdns_regs {
 	volatile uint32_t flow_ctrl_delay;	 /* Flow Control Delay Register */
 	volatile uint32_t rpwr;			 /* IR Minimum Received Pulse Register */
 	volatile uint32_t tpwr;			 /* IR TRansmitted Pulse Width Register */
-	volatile uint32_t tx_fifo_trigger_level; /* Transmiter FIFO trigger level */
+	volatile uint32_t tx_fifo_trigger_level; /* Transmitter FIFO trigger level */
 	volatile uint32_t rbrs;			 /* RX FIFO Byte Status Register */
 };
 

--- a/drivers/serial/uart_esp32.c
+++ b/drivers/serial/uart_esp32.c
@@ -603,7 +603,7 @@ static int uart_esp32_async_tx_abort(const struct device *dev)
 
 	err = dma_stop(config->dma_dev, config->tx_dma_channel);
 	if (err) {
-		LOG_ERR("Error stoping Tx DMA (%d)", err);
+		LOG_ERR("Error stopping Tx DMA (%d)", err);
 		goto unlock;
 	}
 
@@ -838,7 +838,7 @@ static int uart_esp32_async_rx_disable(const struct device *dev)
 
 	err = dma_stop(config->dma_dev, config->rx_dma_channel);
 	if (err) {
-		LOG_ERR("Error stoping Rx DMA (%d)", err);
+		LOG_ERR("Error stopping Rx DMA (%d)", err);
 		goto unlock;
 	}
 

--- a/drivers/serial/uart_hostlink.c
+++ b/drivers/serial/uart_hostlink.c
@@ -254,7 +254,7 @@ static void hl_static_send(size_t payload_used)
 	 * It is responsibility of debugger to set this back to HL_NOADDRESS
 	 * after receiving the packet.
 	 * Please note that we don't wait here because some implementations
-	 * use hl_blockedPeek() function as a signal that we send a messege.
+	 * use hl_blockedPeek() function as a signal that we send a message.
 	 */
 	hl_write32(&__HOSTLINK__.hdr.target2host_addr, buf_addr);
 

--- a/drivers/serial/uart_ql_usbserialport_s3b.h
+++ b/drivers/serial/uart_ql_usbserialport_s3b.h
@@ -34,8 +34,8 @@
 #define USBSERIAL_TX_FIFO_16_TO_31      (0x0B)    /* 1011 Room for 16 to 31 */
 #define USBSERIAL_TX_FIFO_8_TO_15       (0x0C)    /* 1100 Room for 8 to 15 */
 #define USBSERIAL_TX_FIFO_4_TO_7        (0x0D)    /* 1101 Room for 4 to 7 */
-#define USBSERIAL_TX_FIFO_GE_2          (0x0E)    /* 1110 Room for atleast 2 */
-#define USBSERIAL_TX_FIFO_GE_1          (0x0F)    /* 1111 Room for atleast 1 */
+#define USBSERIAL_TX_FIFO_GE_2          (0x0E)    /* 1110 Room for at least 2 */
+#define USBSERIAL_TX_FIFO_GE_1          (0x0F)    /* 1111 Room for at least 1 */
 
 struct fpga_usbserial_regs {
 	uint32_t device_id;

--- a/drivers/serial/uart_rzt2m.c
+++ b/drivers/serial/uart_rzt2m.c
@@ -376,7 +376,7 @@ static int rzt2m_uart_init(const struct device *dev)
 	config->irq_config_func(dev);
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 
-	/* Start trasmitter and receiver. */
+	/* Start transmitter and receiver. */
 	*CCR0(config->base) |= (CCR0_MASK_TE | CCR0_MASK_RE);
 	while (!(*CCR0(config->base) & CCR0_MASK_RE)) {
 	}

--- a/drivers/serial/uart_sedi.c
+++ b/drivers/serial/uart_sedi.c
@@ -92,7 +92,7 @@ struct uart_sedi_config_info {
 	/* Specifies the baudrate for the uart instance. */
 	uint32_t baud_rate;
 
-	/* Specifies the port line contorl settings */
+	/* Specifies the port line control settings */
 	sedi_uart_lc_t line_ctrl;
 
 	struct k_mutex *mutex;

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -567,7 +567,7 @@ static int uart_stm32_configure(const struct device *dev,
 
 	LL_USART_Disable(config->usart);
 
-	/* Set basic parmeters, such as data-/stop-bit, parity, and baudrate */
+	/* Set basic parameters, such as data-/stop-bit, parity, and baudrate */
 	uart_stm32_parameters_set(dev, cfg);
 
 	LL_USART_Enable(config->usart);
@@ -1913,7 +1913,7 @@ static int uart_stm32_registers_configure(const struct device *dev)
 	LL_USART_SetTransferDirection(config->usart,
 				      LL_USART_DIRECTION_TX_RX);
 
-	/* Set basic parmeters, such as data-/stop-bit, parity, and baudrate */
+	/* Set basic parameters, such as data-/stop-bit, parity, and baudrate */
 	uart_stm32_parameters_set(dev, uart_cfg);
 
 	/* Enable the single wire / half-duplex mode */


### PR DESCRIPTION
Employ a code spell checking tool to scan and correct spelling errors in all files within the drivers/serial directory.