### PR TITLE
drivers: i2c: correct spelling

### DIFF
--- a/drivers/i2c/Kconfig.dw
+++ b/drivers/i2c/Kconfig.dw
@@ -18,6 +18,6 @@ config I2C_DW_LPSS_DMA
 	select DMA
 	select DMA_INTEL_LPSS
 	help
-	  This option enables I2C DMA feature to be used for asynchrounous
-	  data transfers. All Tx operaton are done using dma channel 0 and
+	  This option enables I2C DMA feature to be used for asynchronous
+	  data transfers. All Tx operations are done using dma channel 0 and
 	  all Rx operations are done using dma channel 1.

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -187,7 +187,7 @@ int32_t i2c_dw_idma_tx_transfer(const struct device *dev,
 	}
 
 	if (dma_start(rom->dma_dev, DMA_INTEL_LPSS_TX_CHAN)) {
-		LOG_DBG("Error trnasfer");
+		LOG_DBG("Error transfer");
 		return  -EIO;
 	}
 	i2c_dw_enable_idma(dev, true);
@@ -909,7 +909,7 @@ static int i2c_dw_set_slave_mode(const struct device *dev, uint8_t addr)
 	write_tx_tl(0, reg_base);
 	write_rx_tl(0, reg_base);
 
-	LOG_DBG("I2C: Host registed as Slave Device");
+	LOG_DBG("I2C: Host registered as Slave Device");
 
 	return 0;
 }

--- a/drivers/i2c/i2c_ifx_xmc4.c
+++ b/drivers/i2c/i2c_ifx_xmc4.c
@@ -194,7 +194,7 @@ static int ifx_xmc4_i2c_transfer(const struct device *dev, struct i2c_msg *msg, 
 		XMC_I2C_CH_ClearStatusFlag(config->i2c, 0xFFFFFFFF);
 
 		if ((msg_index == 0) || (msg[msg_index].flags & I2C_MSG_RESTART)) {
-			/* Send START conditon */
+			/* Send START condition */
 			cmd_type = ((msg[msg_index].flags & I2C_MSG_RW_MASK) == I2C_MSG_READ) ?
 				XMC_I2C_CH_CMD_READ : XMC_I2C_CH_CMD_WRITE;
 
@@ -272,7 +272,7 @@ static int ifx_xmc4_i2c_transfer(const struct device *dev, struct i2c_msg *msg, 
 			}
 		}
 
-		/* Send STOP conditon */
+		/* Send STOP condition */
 		if (msg[msg_index].flags & I2C_MSG_STOP) {
 			XMC_I2C_CH_MasterStop(config->i2c);
 		}

--- a/drivers/i2c/i2c_ite_enhance.c
+++ b/drivers/i2c/i2c_ite_enhance.c
@@ -1011,7 +1011,7 @@ static void target_i2c_isr_dma(const struct device *dev,
 			&rdata, &len);
 
 		if (len > CONFIG_I2C_TARGET_IT8XXX2_MAX_BUF_SIZE) {
-			LOG_ERR("The bufffer size exceeds "
+			LOG_ERR("The buffer size exceeds "
 				"I2C_TARGET_IT8XXX2_MAX_BUF_SIZE: len=%d",
 				len);
 		} else {

--- a/drivers/i2c/i2c_ll_stm32_v1.c
+++ b/drivers/i2c/i2c_ll_stm32_v1.c
@@ -899,7 +899,7 @@ static int32_t stm32_i2c_msg_read(const struct device *dev, struct i2c_msg *msg,
 			}
 		}
 		/* ADDR must be cleared before NACK generation. Either in 2 byte reception
-		 * byte 1 will be NACK'ed and slave wont sent the last byte
+		 * byte 1 will be NACK'ed and slave won't sent the last byte
 		 */
 		LL_I2C_ClearFlag_ADDR(i2c);
 		if (len == 1U) {

--- a/drivers/i2c/i2c_npcx_controller.c
+++ b/drivers/i2c/i2c_npcx_controller.c
@@ -801,7 +801,7 @@ static void i2c_ctrl_target_isr(const struct device *dev, uint8_t status)
 		/* Clear NMATCH Bit */
 		inst->SMBST = BIT(NPCX_SMBST_NMATCH);
 
-		/* Distinguish tje direction of i2c target mode by reading XMIT bit */
+		/* Distinguish the direction of i2c target mode by reading XMIT bit */
 		if (IS_BIT_SET(inst->SMBST, NPCX_SMBST_XMIT)) {
 			/* Start transmitting data in i2c target mode */
 			data->oper_state = NPCX_I2C_WRITE_FIFO;

--- a/drivers/i2c/i2c_npcx_controller.h
+++ b/drivers/i2c/i2c_npcx_controller.h
@@ -70,7 +70,7 @@ int npcx_i2c_ctrl_transfer(const struct device *i2c_dev, struct i2c_msg *msgs,
 			      uint8_t num_msgs, uint16_t addr, uint8_t port);
 
 /**
- * @brief Toggle the SCL to generate maxmium 9 clocks until the target release
+ * @brief Toggle the SCL to generate maximum 9 clocks until the target release
  * the SDA line and send a STOP condition.
  *
  * @param i2c_dev Pointer to the device structure for i2c controller instance.


### PR DESCRIPTION
Employ a code spell checking tool to scan and correct spelling errors in all files within the drivers/i2c directory.