### PR TITLE
drivers: i2c: set 'i2c_driver_api' as 'static const'

### DIFF
--- a/drivers/i2c/gpio_i2c_switch.c
+++ b/drivers/i2c/gpio_i2c_switch.c
@@ -64,7 +64,7 @@ static int gpio_i2c_switch_transfer(const struct device *dev, struct i2c_msg *ms
 	return res;
 }
 
-const struct i2c_driver_api gpio_i2c_switch_api_funcs = {
+static const struct i2c_driver_api gpio_i2c_switch_api_funcs = {
 	.configure = gpio_i2c_switch_configure,
 	.transfer = gpio_i2c_switch_transfer,
 };

--- a/drivers/i2c/i2c_ambiq.c
+++ b/drivers/i2c/i2c_ambiq.c
@@ -152,7 +152,7 @@ static int i2c_ambiq_init(const struct device *dev)
 	return ret;
 }
 
-static struct i2c_driver_api i2c_ambiq_driver_api = {
+static const struct i2c_driver_api i2c_ambiq_driver_api = {
 	.configure = i2c_ambiq_configure,
 	.transfer = i2c_ambiq_transfer,
 };

--- a/drivers/i2c/i2c_emul.c
+++ b/drivers/i2c/i2c_emul.c
@@ -132,7 +132,7 @@ int i2c_emul_register(const struct device *dev, struct i2c_emul *emul)
 
 /* Device instantiation */
 
-static struct i2c_driver_api i2c_emul_api = {
+static const struct i2c_driver_api i2c_emul_api = {
 	.configure = i2c_emul_configure,
 	.get_config = i2c_emul_get_config,
 	.transfer = i2c_emul_transfer,

--- a/drivers/i2c/i2c_gd32.c
+++ b/drivers/i2c/i2c_gd32.c
@@ -644,7 +644,7 @@ error:
 	return err;
 }
 
-static struct i2c_driver_api i2c_gd32_driver_api = {
+static const struct i2c_driver_api i2c_gd32_driver_api = {
 	.configure = i2c_gd32_configure,
 	.transfer = i2c_gd32_transfer,
 };

--- a/drivers/i2c/i2c_gpio.c
+++ b/drivers/i2c/i2c_gpio.c
@@ -123,7 +123,7 @@ static int i2c_gpio_recover_bus(const struct device *dev)
 	return rc;
 }
 
-static struct i2c_driver_api api = {
+static const struct i2c_driver_api api = {
 	.configure = i2c_gpio_configure,
 	.transfer = i2c_gpio_transfer,
 	.recover_bus = i2c_gpio_recover_bus,

--- a/drivers/i2c/i2c_litex.c
+++ b/drivers/i2c/i2c_litex.c
@@ -108,8 +108,8 @@ static int i2c_litex_transfer(const struct device *dev,  struct i2c_msg *msgs,
 }
 
 static const struct i2c_driver_api i2c_litex_driver_api = {
-	.configure         = i2c_litex_configure,
-	.transfer          = i2c_litex_transfer,
+	.configure = i2c_litex_configure,
+	.transfer = i2c_litex_transfer,
 };
 
 /* Device Instantiation */

--- a/drivers/i2c/i2c_nios2.c
+++ b/drivers/i2c/i2c_nios2.c
@@ -152,7 +152,7 @@ static void i2c_nios2_isr(const struct device *dev)
 
 static int i2c_nios2_init(const struct device *dev);
 
-static struct i2c_driver_api i2c_nios2_driver_api = {
+static const struct i2c_driver_api i2c_nios2_driver_api = {
 	.configure = i2c_nios2_configure,
 	.transfer = i2c_nios2_transfer,
 };

--- a/drivers/i2c/i2c_sbcon.c
+++ b/drivers/i2c/i2c_sbcon.c
@@ -93,7 +93,7 @@ static int i2c_sbcon_transfer(const struct device *dev, struct i2c_msg *msgs,
 							slave_address);
 }
 
-static struct i2c_driver_api api = {
+static const struct i2c_driver_api api = {
 	.configure = i2c_sbcon_configure,
 	.transfer = i2c_sbcon_transfer,
 };

--- a/drivers/i2c/i2c_sedi.c
+++ b/drivers/i2c/i2c_sedi.c
@@ -112,8 +112,10 @@ static int i2c_sedi_api_full_io(const struct device *dev, struct i2c_msg *msgs, 
 	return ret;
 }
 
-static const struct i2c_driver_api i2c_sedi_apis = {.configure = i2c_sedi_api_configure,
-						    .transfer = i2c_sedi_api_full_io};
+static const struct i2c_driver_api i2c_sedi_apis = {
+	.configure = i2c_sedi_api_configure,
+	.transfer = i2c_sedi_api_full_io
+};
 
 #ifdef CONFIG_PM_DEVICE
 

--- a/drivers/i2c/i2c_sifive.c
+++ b/drivers/i2c/i2c_sifive.c
@@ -317,7 +317,7 @@ static int i2c_sifive_init(const struct device *dev)
 }
 
 
-static struct i2c_driver_api i2c_sifive_api = {
+static const struct i2c_driver_api i2c_sifive_api = {
 	.configure = i2c_sifive_configure,
 	.transfer = i2c_sifive_transfer,
 };

--- a/drivers/i2c/i2c_tca954x.c
+++ b/drivers/i2c/i2c_tca954x.c
@@ -151,7 +151,7 @@ static int tca954x_channel_init(const struct device *dev)
 	return 0;
 }
 
-const struct i2c_driver_api tca954x_api_funcs = {
+static const struct i2c_driver_api tca954x_api_funcs = {
 	.configure = tca954x_configure,
 	.transfer = tca954x_transfer,
 };


### PR DESCRIPTION
This change marks each instance of the `i2c_driver_api` as `static const`. The rationale is that `i2c_driver_api` is used for declaring internal module interfaces and is not intended to be modified at runtime. By using `static const`, we ensure immutability, leading to usage of only **.rodata** and a reduction in the **.data** area.