### PR TITLE
bluetooth: hci: place tx/rx message buffer in .noinit section

### DIFF
--- a/drivers/bluetooth/hci/hci_ambiq.c
+++ b/drivers/bluetooth/hci/hci_ambiq.c
@@ -52,7 +52,7 @@ LOG_MODULE_REGISTER(bt_hci_driver);
 #define SPI_MAX_TX_MSG_LEN 524
 #define SPI_MAX_RX_MSG_LEN 258
 
-static uint8_t __noinit g_hciRxMsg[SPI_MAX_RX_MSG_LEN];
+static uint8_t __noinit rxmsg[SPI_MAX_RX_MSG_LEN];
 static const struct device *spi_dev = DEVICE_DT_GET(SPI_DEV_NODE);
 static struct spi_config spi_cfg = {
 	.operation = SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB | SPI_MODE_CPOL | SPI_MODE_CPHA |
@@ -259,7 +259,7 @@ static void bt_spi_rx_thread(void *p1, void *p2, void *p3)
 
 		do {
 			/* Recevive the HCI packet via SPI */
-			ret = spi_receive_packet(&g_hciRxMsg[0], &len);
+			ret = spi_receive_packet(&rxmsg[0], &len);
 			if (ret) {
 				break;
 			}
@@ -267,22 +267,22 @@ static void bt_spi_rx_thread(void *p1, void *p2, void *p3)
 			/* Check if needs to handle the vendor specific events which are
 			 * incompatible with the standard Bluetooth HCI format.
 			 */
-			if (bt_apollo_vnd_rcv_ongoing(&g_hciRxMsg[0], len)) {
+			if (bt_apollo_vnd_rcv_ongoing(&rxmsg[0], len)) {
 				break;
 			}
 
-			switch (g_hciRxMsg[PACKET_TYPE]) {
+			switch (rxmsg[PACKET_TYPE]) {
 			case HCI_EVT:
-				buf = bt_hci_evt_recv(&g_hciRxMsg[PACKET_TYPE + PACKET_TYPE_SIZE],
+				buf = bt_hci_evt_recv(&rxmsg[PACKET_TYPE + PACKET_TYPE_SIZE],
 						      (len - PACKET_TYPE_SIZE));
 				break;
 			case HCI_ACL:
-				buf = bt_hci_acl_recv(&g_hciRxMsg[PACKET_TYPE + PACKET_TYPE_SIZE],
+				buf = bt_hci_acl_recv(&rxmsg[PACKET_TYPE + PACKET_TYPE_SIZE],
 						      (len - PACKET_TYPE_SIZE));
 				break;
 			default:
 				buf = NULL;
-				LOG_WRN("Unknown BT buf type %d", g_hciRxMsg[PACKET_TYPE]);
+				LOG_WRN("Unknown BT buf type %d", rxmsg[PACKET_TYPE]);
 				break;
 			}
 

--- a/drivers/bluetooth/hci/hci_ambiq.c
+++ b/drivers/bluetooth/hci/hci_ambiq.c
@@ -52,7 +52,7 @@ LOG_MODULE_REGISTER(bt_hci_driver);
 #define SPI_MAX_TX_MSG_LEN 524
 #define SPI_MAX_RX_MSG_LEN 258
 
-static uint8_t g_hciRxMsg[SPI_MAX_RX_MSG_LEN];
+static uint8_t __noinit g_hciRxMsg[SPI_MAX_RX_MSG_LEN];
 static const struct device *spi_dev = DEVICE_DT_GET(SPI_DEV_NODE);
 static struct spi_config spi_cfg = {
 	.operation = SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB | SPI_MODE_CPOL | SPI_MODE_CPHA |

--- a/drivers/bluetooth/hci/hci_spi_st.c
+++ b/drivers/bluetooth/hci/hci_spi_st.c
@@ -71,8 +71,8 @@ LOG_MODULE_REGISTER(bt_driver);
 	be transmitted across this HCI link
 #endif /* CONFIG_BT_L2CAP_TX_MTU > MAX_MTU */
 
-static uint8_t rxmsg[SPI_MAX_MSG_LEN];
-static uint8_t txmsg[SPI_MAX_MSG_LEN];
+static uint8_t __noinit rxmsg[SPI_MAX_MSG_LEN];
+static uint8_t __noinit txmsg[SPI_MAX_MSG_LEN];
 
 static const struct gpio_dt_spec irq_gpio = GPIO_DT_SPEC_INST_GET(0, irq_gpios);
 static const struct gpio_dt_spec rst_gpio = GPIO_DT_SPEC_INST_GET(0, reset_gpios);

--- a/drivers/bluetooth/hci/hci_stm32wba.c
+++ b/drivers/bluetooth/hci/hci_stm32wba.c
@@ -47,7 +47,7 @@ static K_SEM_DEFINE(hci_sem, 1, 1);
 
 #define DIVC(x, y)         (((x)+(y)-1)/(y))
 
-static uint32_t buffer[DIVC(BLE_DYN_ALLOC_SIZE, 4)];
+static uint32_t __noinit buffer[DIVC(BLE_DYN_ALLOC_SIZE, 4)];
 
 extern uint8_t ll_state_busy;
 

--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -71,8 +71,8 @@ LOG_MODULE_REGISTER(bt_driver);
 	be transmitted across this HCI link
 #endif /* CONFIG_BT_L2CAP_TX_MTU > MAX_MTU */
 
-static uint8_t rxmsg[SPI_MAX_MSG_LEN];
-static uint8_t txmsg[SPI_MAX_MSG_LEN];
+static uint8_t __noinit rxmsg[SPI_MAX_MSG_LEN];
+static uint8_t __noinit txmsg[SPI_MAX_MSG_LEN];
 
 static const struct gpio_dt_spec irq_gpio = GPIO_DT_SPEC_INST_GET(0, irq_gpios);
 static const struct gpio_dt_spec rst_gpio = GPIO_DT_SPEC_INST_GET(0, reset_gpios);


### PR DESCRIPTION
This change relocates the tx/rx message buffer from the `.bss` section to the `.noinit` section.
This adjustment is aimed at reducing boot time by lowering the size of the `.bss` section, without impacting the operational functionality of the buffer.