### PR TITLE
drivers: display: sdl: add SDL_DISPLAY_MONO_MSB_FIRST option

### DIFF
--- a/drivers/display/Kconfig.sdl
+++ b/drivers/display/Kconfig.sdl
@@ -46,4 +46,10 @@ config SDL_DISPLAY_ZOOM_PCT
 	help
 	  SDL window zoom percentage to adjust readability on small screens
 
+config SDL_DISPLAY_USE_HARDWARE_ACCELERATOR
+	bool "Use hardware accelerator"
+	default y
+	help
+	  Enable hardware acceleration for graphics rendering
+
 endif # SDL_DISPLAY

--- a/drivers/display/Kconfig.sdl
+++ b/drivers/display/Kconfig.sdl
@@ -52,4 +52,11 @@ config SDL_DISPLAY_USE_HARDWARE_ACCELERATOR
 	help
 	  Enable hardware acceleration for graphics rendering
 
+config SDL_DISPLAY_MONO_MSB_FIRST
+	bool "Configure bit order in monochrome formats to MSB first"
+	default y
+	help
+	  If selected, set the MSB to represent the first pixel.
+	  This applies when the pixel format is MONO01/MONO10.
+
 endif # SDL_DISPLAY

--- a/drivers/display/display_sdl.c
+++ b/drivers/display/display_sdl.c
@@ -39,7 +39,10 @@ static int sdl_display_init(const struct device *dev)
 {
 	const struct sdl_display_config *config = dev->config;
 	struct sdl_display_data *disp_data = dev->data;
+	bool use_accelerator = true;
 	LOG_DBG("Initializing display driver");
+
+	IF_DISABLED(CONFIG_SDL_DISPLAY_USE_HARDWARE_ACCELERATOR, (use_accelerator = false));
 
 	disp_data->current_pixel_format =
 #if defined(CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_RGB_888)
@@ -62,7 +65,7 @@ static int sdl_display_init(const struct device *dev)
 	}
 
 	int rc = sdl_display_init_bottom(config->height, config->width,
-					 sdl_display_zoom_pct,
+					 sdl_display_zoom_pct, use_accelerator,
 					 &disp_data->window, &disp_data->renderer,
 					 &disp_data->texture);
 

--- a/drivers/display/display_sdl.c
+++ b/drivers/display/display_sdl.c
@@ -39,6 +39,15 @@ struct sdl_display_data {
 	uint8_t *read_buf;
 };
 
+static inline uint32_t mono_pixel_order(uint32_t order)
+{
+	if (IS_ENABLED(CONFIG_SDL_DISPLAY_MONO_MSB_FIRST) == IS_ENABLED(CONFIG_LITTLE_ENDIAN)) {
+		return BIT(7 - order);
+	} else {
+		return BIT(order);
+	}
+}
+
 static int sdl_display_init(const struct device *dev)
 {
 	const struct sdl_display_config *config = dev->config;
@@ -195,7 +204,7 @@ static void sdl_display_write_mono(uint8_t *disp_buf,
 				((tile_idx * desc->pitch) + w_idx);
 			disp_buf_start = disp_buf;
 			for (h_idx = 0U; h_idx < 8; ++h_idx) {
-				if ((*byte_ptr & BIT(7-h_idx)) != 0U)  {
+				if ((*byte_ptr & mono_pixel_order(h_idx)) != 0U)  {
 					pixel = one_color;
 				} else {
 					pixel = (~one_color) & 0x00FFFFFF;
@@ -365,7 +374,7 @@ static void sdl_display_read_mono(const uint8_t *read_buf,
 				pix_ptr = (const uint32_t *)read_buf +
 					  ((tile_idx * 8 + h_idx) * desc->pitch + w_idx);
 				if ((*pix_ptr)) {
-					tile |= BIT(7 - h_idx);
+					tile |= mono_pixel_order(h_idx);
 				}
 			}
 			*buf8 = one_is_black ? ~tile : tile;
@@ -456,7 +465,7 @@ static void sdl_display_get_capabilities(
 		PIXEL_FORMAT_BGR_565;
 	capabilities->current_pixel_format = disp_data->current_pixel_format;
 	capabilities->screen_info = SCREEN_INFO_MONO_VTILED |
-		SCREEN_INFO_MONO_MSB_FIRST;
+		(IS_ENABLED(CONFIG_SDL_DISPLAY_MONO_MSB_FIRST) ? SCREEN_INFO_MONO_MSB_FIRST : 0);
 }
 
 static int sdl_display_set_pixel_format(const struct device *dev,

--- a/drivers/display/display_sdl_bottom.c
+++ b/drivers/display/display_sdl_bottom.c
@@ -12,7 +12,7 @@
 #include "nsi_tracing.h"
 
 int sdl_display_init_bottom(uint16_t height, uint16_t width, uint16_t zoom_pct,
-			    void **window, void **renderer, void **texture)
+			    bool use_accelerator, void **window, void **renderer, void **texture)
 {
 	*window = SDL_CreateWindow("Zephyr Display", SDL_WINDOWPOS_UNDEFINED,
 				   SDL_WINDOWPOS_UNDEFINED, width * zoom_pct / 100,
@@ -22,7 +22,12 @@ int sdl_display_init_bottom(uint16_t height, uint16_t width, uint16_t zoom_pct,
 		return -1;
 	}
 
-	*renderer = SDL_CreateRenderer(*window, -1, SDL_RENDERER_ACCELERATED);
+	if (use_accelerator) {
+		*renderer = SDL_CreateRenderer(*window, -1, SDL_RENDERER_ACCELERATED);
+	} else {
+		*renderer = SDL_CreateRenderer(*window, -1, SDL_RENDERER_SOFTWARE);
+	}
+
 	if (*renderer == NULL) {
 		nsi_print_warning("Failed to create SDL renderer: %s",
 				SDL_GetError());

--- a/drivers/display/display_sdl_bottom.c
+++ b/drivers/display/display_sdl_bottom.c
@@ -12,7 +12,8 @@
 #include "nsi_tracing.h"
 
 int sdl_display_init_bottom(uint16_t height, uint16_t width, uint16_t zoom_pct,
-			    bool use_accelerator, void **window, void **renderer, void **texture)
+			    bool use_accelerator, void **window, void **renderer, void **mutex,
+			    void **texture, void **read_texture)
 {
 	*window = SDL_CreateWindow("Zephyr Display", SDL_WINDOWPOS_UNDEFINED,
 				   SDL_WINDOWPOS_UNDEFINED, width * zoom_pct / 100,
@@ -34,12 +35,25 @@ int sdl_display_init_bottom(uint16_t height, uint16_t width, uint16_t zoom_pct,
 		return -1;
 	}
 
+	*mutex = SDL_CreateMutex();
+	if (*mutex == NULL) {
+		nsi_print_warning("Failed to create SDL mutex: %s", SDL_GetError());
+		return -1;
+	}
+
 	SDL_RenderSetLogicalSize(*renderer, width, height);
 
-	*texture = SDL_CreateTexture(*renderer, SDL_PIXELFORMAT_ARGB8888,
-				     SDL_TEXTUREACCESS_STATIC, width, height);
+	*texture = SDL_CreateTexture(*renderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STATIC,
+				     width, height);
 	if (*texture == NULL) {
 		nsi_print_warning("Failed to create SDL texture: %s", SDL_GetError());
+		return -1;
+	}
+
+	*read_texture = SDL_CreateTexture(*renderer, SDL_PIXELFORMAT_ARGB8888,
+					  SDL_TEXTUREACCESS_TARGET, width, height);
+	if (*texture == NULL) {
+		nsi_print_warning("Failed to create SDL texture for read: %s", SDL_GetError());
 		return -1;
 	}
 
@@ -52,15 +66,22 @@ int sdl_display_init_bottom(uint16_t height, uint16_t width, uint16_t zoom_pct,
 
 void sdl_display_write_bottom(const uint16_t height, const uint16_t width,
 			      const uint16_t x, const uint16_t y,
-			      void *renderer, void *texture,
+			      void *renderer, void *mutex, void *texture,
 			      uint8_t *buf, bool display_on)
 {
 	SDL_Rect rect;
+	int err;
 
 	rect.x = x;
 	rect.y = y;
 	rect.w = width;
 	rect.h = height;
+
+	err = SDL_TryLockMutex(mutex);
+	if (err) {
+		nsi_print_warning("Failed to lock SDL mutex: %s", SDL_GetError());
+		return;
+	}
 
 	SDL_UpdateTexture(texture, &rect, buf, 4 * rect.w);
 
@@ -69,20 +90,40 @@ void sdl_display_write_bottom(const uint16_t height, const uint16_t width,
 		SDL_RenderCopy(renderer, texture, NULL, NULL);
 		SDL_RenderPresent(renderer);
 	}
+
+	SDL_UnlockMutex(mutex);
 }
 
 int sdl_display_read_bottom(const uint16_t height, const uint16_t width,
 			    const uint16_t x, const uint16_t y,
-			    void *renderer, void *buf, uint16_t pitch)
+			    void *renderer, void *buf, uint16_t pitch,
+			    void *mutex, void *texture, void *read_texture)
 {
 	SDL_Rect rect;
+	int err;
 
 	rect.x = x;
 	rect.y = y;
 	rect.w = width;
 	rect.h = height;
 
-	return SDL_RenderReadPixels(renderer, &rect, 0, buf, pitch * 4U);
+	err = SDL_TryLockMutex(mutex);
+	if (err) {
+		nsi_print_warning("Failed to lock SDL mutex: %s", SDL_GetError());
+		return -1;
+	}
+
+	SDL_SetRenderTarget(renderer, read_texture);
+
+	SDL_RenderClear(renderer);
+	SDL_RenderCopy(renderer, texture, NULL, NULL);
+	SDL_RenderReadPixels(renderer, &rect, SDL_PIXELFORMAT_ARGB8888, buf, width * 4);
+
+	SDL_SetRenderTarget(renderer, NULL);
+
+	SDL_UnlockMutex(mutex);
+
+	return err;
 }
 
 void sdl_display_blanking_off_bottom(void *renderer, void *texture)
@@ -98,11 +139,22 @@ void sdl_display_blanking_on_bottom(void *renderer)
 	SDL_RenderPresent(renderer);
 }
 
-void sdl_display_cleanup_bottom(void **window, void **renderer, void **texture)
+void sdl_display_cleanup_bottom(void **window, void **renderer, void **mutex, void **texture,
+				void **read_texture)
 {
+	if (*read_texture != NULL) {
+		SDL_DestroyTexture(*read_texture);
+		*read_texture = NULL;
+	}
+
 	if (*texture != NULL) {
 		SDL_DestroyTexture(*texture);
 		*texture = NULL;
+	}
+
+	if (*mutex != NULL) {
+		SDL_DestroyMutex(*mutex);
+		*mutex = NULL;
 	}
 
 	if (*renderer != NULL) {

--- a/drivers/display/display_sdl_bottom.h
+++ b/drivers/display/display_sdl_bottom.h
@@ -21,17 +21,20 @@ extern "C" {
 /* Note: None of these functions are public interfaces. But internal to the SDL display driver */
 
 int sdl_display_init_bottom(uint16_t height, uint16_t width, uint16_t zoom_pct,
-			    bool use_accelerator, void **window, void **renderer, void **texture);
+			    bool use_accelerator, void **window, void **renderer, void **mutex,
+			    void **texture, void **read_texture);
 void sdl_display_write_bottom(const uint16_t height, const uint16_t width,
 			      const uint16_t x, const uint16_t y,
-			      void *renderer, void *texture,
+			      void *renderer, void *mutex, void *texture,
 			      uint8_t *buf, bool display_on);
 int sdl_display_read_bottom(const uint16_t height, const uint16_t width,
 			    const uint16_t x, const uint16_t y,
-			    void *renderer, void *buf, uint16_t pitch);
+			    void *renderer, void *buf, uint16_t pitch,
+			    void *mutex, void *texture, void **read_texture);
 void sdl_display_blanking_off_bottom(void *renderer, void *texture);
 void sdl_display_blanking_on_bottom(void *renderer);
-void sdl_display_cleanup_bottom(void **window, void **renderer, void **texture);
+void sdl_display_cleanup_bottom(void **window, void **renderer, void **mutex, void **texture,
+				void **read_texture);
 
 #ifdef __cplusplus
 }

--- a/drivers/display/display_sdl_bottom.h
+++ b/drivers/display/display_sdl_bottom.h
@@ -21,7 +21,7 @@ extern "C" {
 /* Note: None of these functions are public interfaces. But internal to the SDL display driver */
 
 int sdl_display_init_bottom(uint16_t height, uint16_t width, uint16_t zoom_pct,
-			    void **window, void **renderer, void **texture);
+			    bool use_accelerator, void **window, void **renderer, void **texture);
 void sdl_display_write_bottom(const uint16_t height, const uint16_t width,
 			      const uint16_t x, const uint16_t y,
 			      void *renderer, void *texture,

--- a/tests/drivers/display/display_read_write/CMakeLists.txt
+++ b/tests/drivers/display/display_read_write/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright 2024 (c) TOKITA Hiroshi
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+project(display_read_write)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/drivers/display/display_read_write/prj.conf
+++ b/tests/drivers/display/display_read_write/prj.conf
@@ -1,0 +1,9 @@
+# Copyright 2024 (c) TOKITA Hiroshi
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ZTEST=y
+CONFIG_DISPLAY=y
+
+CONFIG_HEAP_MEM_POOL_SIZE=16384
+
+CONFIG_LOG=y

--- a/tests/drivers/display/display_read_write/src/main.c
+++ b/tests/drivers/display/display_read_write/src/main.c
@@ -1,0 +1,268 @@
+/*
+ * Copyright 2024 (c) TOKITA Hiroshi
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/display.h>
+#include <zephyr/ztest.h>
+#include <zephyr/device.h>
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_DECLARE(display_api, CONFIG_DISPLAY_LOG_LEVEL);
+
+static const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
+static const uint32_t display_width = DT_PROP(DT_CHOSEN(zephyr_display), width);
+static const uint32_t display_height = DT_PROP(DT_CHOSEN(zephyr_display), height);
+static uint8_t disp_buffer[DT_PROP(DT_CHOSEN(zephyr_display), width) *
+			   DT_PROP(DT_CHOSEN(zephyr_display), height) * 4];
+static struct display_capabilities cfg;
+static uint8_t bpp;
+static bool is_tiled;
+
+static inline uint8_t bytes_per_pixel(enum display_pixel_format pixel_format)
+{
+	switch (pixel_format) {
+	case PIXEL_FORMAT_ARGB_8888:
+		return 4;
+	case PIXEL_FORMAT_RGB_888:
+		return 3;
+	case PIXEL_FORMAT_RGB_565:
+	case PIXEL_FORMAT_BGR_565:
+		return 2;
+	case PIXEL_FORMAT_MONO01:
+	case PIXEL_FORMAT_MONO10:
+	default:
+		return 1;
+	}
+
+	return 0;
+}
+
+static void verify_bytes_of_area(uint8_t *data, int cmp_x, int cmp_y, size_t width, size_t height)
+{
+	struct display_buffer_descriptor desc = {
+		.height = height,
+		.pitch = width,
+		.width = width,
+		.buf_size = height * width * bpp,
+	};
+
+	int err = display_read(dev, cmp_x, cmp_y, &desc, disp_buffer);
+
+	zassert_ok(err, "display_read failed");
+
+	if (is_tiled) {
+		zassert_mem_equal(data, disp_buffer, width * height / 8, NULL);
+	} else {
+		zassert_mem_equal(data, disp_buffer, width * height * bpp, NULL);
+	}
+}
+
+static void verify_background_color(int x, int y, size_t width, size_t height, uint32_t color)
+{
+	size_t buf_size = is_tiled ? (height * width / 8) : (height * width * bpp);
+	struct display_buffer_descriptor desc = {
+		.height = height,
+		.pitch = width,
+		.width = width,
+		.buf_size = buf_size,
+	};
+	uint32_t *buf32 = (void *)disp_buffer;
+	uint16_t *buf16 = (void *)disp_buffer;
+	uint8_t *buf8 = disp_buffer;
+	int err;
+
+	err = display_read(dev, x, y, &desc, disp_buffer);
+	zassert_ok(err, "display_read failed");
+
+	for (size_t i = 0; i < width * height; i++) {
+		switch (bpp) {
+		case 4:
+			zassert_equal(buf32[i], color, "@%d", i);
+			break;
+		case 2:
+			zassert_equal(buf16[i], (uint16_t)color, "@%d", i);
+			break;
+		case 1:
+			if (is_tiled) {
+				uint16_t x = i % (width);
+				uint16_t line = (i - x) / width;
+				uint16_t tile = line / 8;
+				uint16_t y = line % 8;
+
+				uint8_t *tptr = disp_buffer + (tile * width + x);
+
+				zassert_equal(!!(*tptr & BIT(y)), !!(color), "@%d", i);
+			} else {
+				zassert_equal(buf8[i], (uint8_t)color, "@%d", i);
+			}
+			break;
+		}
+	}
+}
+
+/**
+ * Fill the buffer with 0 before running tests.
+ */
+static void display_before(void *text_fixture)
+{
+	display_get_capabilities(dev, &cfg);
+	bpp = bytes_per_pixel(cfg.current_pixel_format);
+	is_tiled = ((bpp == 1) && (cfg.screen_info & SCREEN_INFO_MONO_VTILED));
+
+	struct display_buffer_descriptor desc = {
+		.height = display_height,
+		.pitch = display_width,
+		.width = display_width,
+		.buf_size = display_height * display_width * bpp,
+	};
+
+	memset(disp_buffer, 0, sizeof(disp_buffer));
+	display_write(dev, 0, 0, &desc, disp_buffer);
+}
+
+/*
+ * Verify that we can get a color of '0' from all pixels
+ * when after zeroing the buffer.
+ */
+ZTEST(display_read_write, test_clear)
+{
+	verify_background_color(0, 0, display_width, display_height, 0);
+}
+
+/*
+ * Write to the head of the buffer and check that
+ * the same value can be read.
+ */
+ZTEST(display_read_write, test_write_to_buffer_head)
+{
+	uint8_t data[4] = {0xFA, 0xAF, 0x9F, 0xFA};
+	uint8_t height = (is_tiled ? 8 : 1);
+	uint16_t width = sizeof(data) / bpp;
+	uint16_t buf_size = width * bpp;
+	struct display_buffer_descriptor desc = {
+		.height = height,
+		.pitch = width,
+		.width = width,
+		.buf_size = buf_size,
+	};
+
+	/* write data to head of buffer */
+	display_write(dev, 0, 0, &desc, data);
+
+	/* check write data and read data are same */
+	verify_bytes_of_area(data, 0, 0, width, height);
+
+	/* check remaining region still black */
+	verify_background_color(0, height, display_width, display_height - height, 0);
+	verify_background_color(width, 0, display_width - width, display_height, 0);
+}
+
+/*
+ * Write to the tail of the buffer and check that
+ * the same value can be read.
+ */
+ZTEST(display_read_write, test_write_to_buffer_tail)
+{
+	uint8_t data[4] = {0xFA, 0xAF, 0x9F, 0xFA};
+	uint16_t height = (is_tiled ? 8 : 1);
+	uint16_t width = sizeof(data) / bpp;
+	uint16_t buf_size = width * bpp;
+	struct display_buffer_descriptor desc = {
+		.height = height,
+		.pitch = width,
+		.width = width,
+		.buf_size = buf_size,
+	};
+	struct display_buffer_descriptor desc_whole = {
+		.height = display_height,
+		.pitch = display_width,
+		.width = display_width,
+		.buf_size = display_height * display_width * bpp / height,
+	};
+	int err;
+
+	/* write data to tail of buffer */
+	display_write(dev, display_width - width, display_height - height, &desc, data);
+
+	/* read entire displayed data */
+	err = display_read(dev, 0, 0, &desc_whole, disp_buffer);
+	zassert_ok(err, "display_read failed");
+
+	/* check write data and read data are same */
+	if (is_tiled) {
+		zassert_mem_equal(data,
+				  disp_buffer + (display_width * display_height / 8 - buf_size),
+				  buf_size, NULL);
+	} else {
+		zassert_mem_equal(data,
+				  disp_buffer + (display_width * display_height * bpp - buf_size),
+				  buf_size, NULL);
+	}
+
+	/* check remaining region still black */
+	verify_background_color(0, 0, display_width, display_height - height, 0);
+	verify_background_color(0, display_height - height, display_width - width, height, 0);
+}
+
+/*
+ * Verify that it will keep the drawn content even if display_read is executed
+ */
+ZTEST(display_read_write, test_read_does_not_clear_existing_buffer)
+{
+	uint8_t data[4] = {0xFA, 0xAF, 0x9F, 0xFA};
+	uint8_t height = (is_tiled ? 8 : 1);
+	uint16_t width = sizeof(data) / bpp;
+	uint16_t buf_size = width * bpp;
+	struct display_buffer_descriptor desc = {
+		.height = height,
+		.pitch = width,
+		.width = width,
+		.buf_size = buf_size,
+	};
+	struct display_buffer_descriptor desc_whole = {
+		.height = display_height,
+		.pitch = display_width,
+		.width = display_width,
+		.buf_size = display_height * display_width * bpp / height,
+	};
+	int err;
+
+	/* write data to head of buffer */
+	display_write(dev, 0, 0, &desc, data);
+
+	/* check write data and read data are same */
+	verify_bytes_of_area(data, 0, 0, width, height);
+
+	/* check remaining region still black */
+	verify_background_color(0, height, display_width, display_height - height, 0);
+	verify_background_color(width, 0, display_width - width, display_height, 0);
+
+	/* write data to tail of buffer */
+	display_write(dev, display_width - width, display_height - height, &desc, data);
+
+	/* read entire displayed data */
+	err = display_read(dev, 0, 0, &desc_whole, disp_buffer);
+	zassert_ok(err, "display_read failed");
+
+	/* checking correctly write to the tail of buffer */
+	if (is_tiled) {
+		zassert_mem_equal(data,
+				  disp_buffer + (display_width * display_height / 8 - buf_size),
+				  buf_size, NULL);
+	} else {
+		zassert_mem_equal(data,
+				  disp_buffer + (display_width * display_height * bpp - buf_size),
+				  buf_size, NULL);
+	}
+
+	/* checking if the content written before reading is kept */
+	verify_bytes_of_area(data, 0, 0, width, height);
+
+	/* checking remaining region still black */
+	verify_background_color(width, 0, display_width - width, display_height - height, 0);
+	verify_background_color(0, height, display_width - width, display_height - height, 0);
+}
+
+ZTEST_SUITE(display_read_write, NULL, NULL, display_before, NULL, NULL);

--- a/tests/drivers/display/display_read_write/testcase.yaml
+++ b/tests/drivers/display/display_read_write/testcase.yaml
@@ -1,0 +1,46 @@
+# Copyright 2024 (c) TOKITA Hiroshi
+# SPDX-License-Identifier: Apache-2.0
+
+common:
+  tags:
+    - drivers display
+  filter: dt_chosen_enabled("zephyr,display")
+  timeout: 1000
+  build_only: true # The CI environment has no display device
+tests:
+  drivers.display.read_write.sdl.argb8888:
+    filter: dt_compat_enabled("zephyr,sdl-dc")
+    platform_exclude: native_posix native_posix_64
+    extra_configs:
+      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_ARGB_8888=y
+      - CONFIG_SDL_DISPLAY_USE_HARDWARE_ACCELERATOR=n
+  drivers.display.read_write.sdl.rgb888:
+    filter: dt_compat_enabled("zephyr,sdl-dc")
+    platform_exclude: native_posix native_posix_64
+    extra_configs:
+      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_RGB_888=y
+      - CONFIG_SDL_DISPLAY_USE_HARDWARE_ACCELERATOR=n
+  drivers.display.read_write.sdl.mono01:
+    filter: dt_compat_enabled("zephyr,sdl-dc")
+    platform_exclude: native_posix native_posix_64
+    extra_configs:
+      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_MONO01=y
+      - CONFIG_SDL_DISPLAY_USE_HARDWARE_ACCELERATOR=n
+  drivers.display.read_write.sdl.mono10:
+    filter: dt_compat_enabled("zephyr,sdl-dc")
+    platform_exclude: native_posix native_posix_64
+    extra_configs:
+      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_MONO10=y
+      - CONFIG_SDL_DISPLAY_USE_HARDWARE_ACCELERATOR=n
+  drivers.display.read_write.sdl.rgb565:
+    filter: dt_compat_enabled("zephyr,sdl-dc")
+    platform_exclude: native_posix native_posix_64
+    extra_configs:
+      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_RGB_565=y
+      - CONFIG_SDL_DISPLAY_USE_HARDWARE_ACCELERATOR=n
+  drivers.display.read_write.sdl.bgr565:
+    filter: dt_compat_enabled("zephyr,sdl-dc")
+    platform_exclude: native_posix native_posix_64
+    extra_configs:
+      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_BGR_565=y
+      - CONFIG_SDL_DISPLAY_USE_HARDWARE_ACCELERATOR=n

--- a/tests/drivers/display/display_read_write/testcase.yaml
+++ b/tests/drivers/display/display_read_write/testcase.yaml
@@ -32,6 +32,20 @@ tests:
     extra_configs:
       - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_MONO10=y
       - CONFIG_SDL_DISPLAY_USE_HARDWARE_ACCELERATOR=n
+  drivers.display.read_write.sdl.mono01.lsbfirst:
+    filter: dt_compat_enabled("zephyr,sdl-dc")
+    platform_exclude: native_posix native_posix_64
+    extra_configs:
+      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_MONO01=y
+      - CONFIG_SDL_DISPLAY_USE_HARDWARE_ACCELERATOR=n
+      - CONFIG_SDL_DISPLAY_MONO_MSB_FIRST=n
+  drivers.display.read_write.sdl.mono10.lsbfirst:
+    filter: dt_compat_enabled("zephyr,sdl-dc")
+    platform_exclude: native_posix native_posix_64
+    extra_configs:
+      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_MONO10=y
+      - CONFIG_SDL_DISPLAY_USE_HARDWARE_ACCELERATOR=n
+      - CONFIG_SDL_DISPLAY_MONO_MSB_FIRST=n
   drivers.display.read_write.sdl.rgb565:
     filter: dt_compat_enabled("zephyr,sdl-dc")
     platform_exclude: native_posix native_posix_64


### PR DESCRIPTION
Added config for specifying bit order when using monochrome format.

Signed-off-by: TOKITA Hiroshi <tokita.hiroshi@gmail.com>

---

Need merge after #67447 merged.