### PR TITLE
Bluetooth: Samples: Add name check for periodic adv sync

### DIFF
--- a/samples/bluetooth/periodic_sync/Kconfig
+++ b/samples/bluetooth/periodic_sync/Kconfig
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2024 Hang Fan
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+mainmenu "Bluetooth: Periodic Advertising Sync"
+
+config PER_ADV_NAME
+	string "Target Periodic Advertising Name"
+	default ""
+	help
+	  Name of target advertising for Periodic Advertising Synchronization.
+
+source "Kconfig.zephyr"

--- a/samples/bluetooth/periodic_sync/src/main.c
+++ b/samples/bluetooth/periodic_sync/src/main.c
@@ -78,6 +78,10 @@ static void scan_recv(const struct bt_le_scan_recv_info *info,
 
 	bt_data_parse(buf, data_cb, name);
 
+	if (strlen(CONFIG_PER_ADV_NAME) > 0 && strcmp(name, CONFIG_PER_ADV_NAME) != 0) {
+		return;
+	}
+
 	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 	printk("[DEVICE]: %s, AD evt type %u, Tx Pwr: %i, RSSI %i %s "
 	       "C:%u S:%u D:%u SR:%u E:%u Prim: %s, Secn: %s, "


### PR DESCRIPTION
Add missing name check to filter the advertising we want.