### PR TITLE
tests: posix: common: split `posix_apis` into multiple testsuites

### DIFF
--- a/lib/posix/clock.c
+++ b/lib/posix/clock.c
@@ -235,3 +235,23 @@ int clock_getcpuclockid(pid_t pid, clockid_t *clock_id)
 
 	return 0;
 }
+
+#ifdef CONFIG_ZTEST
+#include <zephyr/ztest.h>
+static void reset_clock_base(void)
+{
+	K_SPINLOCK(&rt_clock_base_lock) {
+		rt_clock_base = (struct timespec){0};
+	}
+}
+
+static void clock_base_reset_rule_after(const struct ztest_unit_test *test, void *data)
+{
+	ARG_UNUSED(test);
+	ARG_UNUSED(data);
+
+	reset_clock_base();
+}
+
+ZTEST_RULE(clock_base_reset_rule, NULL, clock_base_reset_rule_after);
+#endif /* CONFIG_ZTEST */

--- a/tests/posix/common/src/_main.c
+++ b/tests/posix/common/src/_main.c
@@ -8,14 +8,12 @@
 
 extern bool fdtable_fd_is_initialized(int fd);
 
-static void *setup(void)
+ZTEST(posix_apis, test_fdtable_init)
 {
 	/* ensure that the the stdin, stdout, and stderr fdtable entries are initialized */
 	zassert_true(fdtable_fd_is_initialized(0));
 	zassert_true(fdtable_fd_is_initialized(1));
 	zassert_true(fdtable_fd_is_initialized(2));
-
-	return NULL;
 }
 
-ZTEST_SUITE(posix_apis, NULL, setup, NULL, NULL, NULL);
+ZTEST_SUITE(posix_apis, NULL, NULL, NULL, NULL, NULL);

--- a/tests/posix/common/src/clock.c
+++ b/tests/posix/common/src/clock.c
@@ -63,7 +63,7 @@ static inline bool tp_diff_in_range_ns(const struct timespec *a, const struct ti
 	return diff >= lo && diff < hi;
 }
 
-ZTEST(posix_apis, test_clock_gettime)
+ZTEST(clock, test_clock_gettime)
 {
 	struct timespec ts;
 
@@ -89,7 +89,7 @@ ZTEST(posix_apis, test_clock_gettime)
 	}
 }
 
-ZTEST(posix_apis, test_gettimeofday)
+ZTEST(clock, test_gettimeofday)
 {
 	struct timeval tv;
 	struct timespec ts;
@@ -114,7 +114,7 @@ ZTEST(posix_apis, test_gettimeofday)
 	zassert_true(tp_ge(&rts, &ts));
 }
 
-ZTEST(posix_apis, test_clock_settime)
+ZTEST(clock, test_clock_settime)
 {
 	int64_t diff_ns;
 	struct timespec ts = {0};
@@ -163,7 +163,7 @@ ZTEST(posix_apis, test_clock_settime)
 	}
 }
 
-ZTEST(posix_apis, test_realtime)
+ZTEST(clock, test_realtime)
 {
 	struct timespec then, now;
 	/*
@@ -214,7 +214,7 @@ ZTEST(posix_apis, test_realtime)
 	zassert_between_inclusive(cma, lo, hi);
 }
 
-ZTEST(posix_apis, test_clock_getcpuclockid)
+ZTEST(clock, test_clock_getcpuclockid)
 {
 	int ret = 0;
 	clockid_t clock_id;
@@ -225,3 +225,5 @@ ZTEST(posix_apis, test_clock_getcpuclockid)
 	ret = clock_getcpuclockid((pid_t)2482, &clock_id);
 	zassert_equal(ret, EPERM, "POSIX clock_getcpuclock id failed");
 }
+
+ZTEST_SUITE(clock, NULL, NULL, NULL, NULL, NULL);

--- a/tests/posix/common/src/fnmatch.c
+++ b/tests/posix/common/src/fnmatch.c
@@ -12,7 +12,7 @@
  * Adapted from
  * https://git.musl-libc.org/cgit/libc-testsuite/tree/fnmatch.c
  */
-ZTEST(posix_apis, test_fnmatch)
+ZTEST(fnmatch, test_fnmatch)
 {
 	/* Note: commented out lines indicate known problems to be addressed in #55186 */
 
@@ -82,3 +82,5 @@ ZTEST(posix_apis, test_fnmatch)
 	zassert_ok(fnmatch("a*b", "a.b", FNM_PATHNAME | FNM_PERIOD));
 	zassert_ok(fnmatch("a[.]b", "a.b", FNM_PATHNAME | FNM_PERIOD));
 }
+
+ZTEST_SUITE(fnmatch, NULL, NULL, NULL, NULL, NULL);

--- a/tests/posix/common/src/key.c
+++ b/tests/posix/common/src/key.c
@@ -74,7 +74,7 @@ static void make_keys(void)
  * multiple keys.
  */
 
-ZTEST(posix_apis, test_key_1toN_thread)
+ZTEST(key, test_key_1toN_thread)
 {
 	void *retval;
 	pthread_t newthread[N_THR];
@@ -95,7 +95,7 @@ ZTEST(posix_apis, test_key_1toN_thread)
 	zassert_ok(pthread_key_delete(key), "attempt to delete key failed");
 }
 
-ZTEST(posix_apis, test_key_Nto1_thread)
+ZTEST(key, test_key_Nto1_thread)
 {
 	pthread_t newthread;
 
@@ -113,7 +113,7 @@ ZTEST(posix_apis, test_key_Nto1_thread)
 	}
 }
 
-ZTEST(posix_apis, test_key_resource_leak)
+ZTEST(key, test_key_resource_leak)
 {
 	pthread_key_t key;
 
@@ -123,7 +123,7 @@ ZTEST(posix_apis, test_key_resource_leak)
 	}
 }
 
-ZTEST(posix_apis, test_correct_key_is_deleted)
+ZTEST(key, test_correct_key_is_deleted)
 {
 	pthread_key_t key;
 	size_t j = CONFIG_MAX_PTHREAD_KEY_COUNT - 1;
@@ -143,3 +143,5 @@ ZTEST(posix_apis, test_correct_key_is_deleted)
 		zassert_ok(pthread_key_delete(keys[i]), "failed to delete key %zu", i);
 	}
 }
+
+ZTEST_SUITE(key, NULL, NULL, NULL, NULL, NULL);

--- a/tests/posix/common/src/mqueue.c
+++ b/tests/posix/common/src/mqueue.c
@@ -17,9 +17,9 @@
 #define MESSAGE_SIZE 16
 #define MESG_COUNT_PERMQ 4
 
-char queue[16] = "server";
+static char queue[16] = "server";
 
-char send_data[MESSAGE_SIZE] = "timed data send";
+static char send_data[MESSAGE_SIZE] = "timed data send";
 
 /*
  * For platforms that select CONFIG_KERNEL_COHERENCE, the receive buffer can
@@ -28,9 +28,9 @@ char send_data[MESSAGE_SIZE] = "timed data send";
  * receiver.
  */
 
-char rec_data[MESSAGE_SIZE];
+static char rec_data[MESSAGE_SIZE];
 
-void *sender_thread(void *p1)
+static void *sender_thread(void *p1)
 {
 	mqd_t mqd;
 	struct timespec curtime;
@@ -48,7 +48,7 @@ void *sender_thread(void *p1)
 }
 
 
-void *receiver_thread(void *p1)
+static void *receiver_thread(void *p1)
 {
 	mqd_t mqd;
 	struct timespec curtime;
@@ -66,7 +66,7 @@ void *receiver_thread(void *p1)
 	return NULL;
 }
 
-ZTEST(posix_apis, test_mqueue)
+ZTEST(mqueue, test_mqueue)
 {
 	mqd_t mqd;
 	struct mq_attr attrs;
@@ -96,3 +96,5 @@ ZTEST(posix_apis, test_mqueue)
 		      "unable to close message queue descriptor.");
 	zassert_false(mq_unlink(queue), "Not able to unlink Queue");
 }
+
+ZTEST_SUITE(mqueue, NULL, NULL, NULL, NULL, NULL);

--- a/tests/posix/common/src/mutex.c
+++ b/tests/posix/common/src/mutex.c
@@ -12,9 +12,9 @@
 
 #define SLEEP_MS 100
 
-pthread_mutex_t mutex;
+static pthread_mutex_t mutex;
 
-void *normal_mutex_entry(void *p1)
+static void *normal_mutex_entry(void *p1)
 {
 	int i, rc;
 
@@ -34,7 +34,7 @@ void *normal_mutex_entry(void *p1)
 	return NULL;
 }
 
-void *recursive_mutex_entry(void *p1)
+static void *recursive_mutex_entry(void *p1)
 {
 	zassert_false(pthread_mutex_lock(&mutex), "mutex is not taken");
 	zassert_false(pthread_mutex_lock(&mutex), "mutex is not taken 2nd time");
@@ -83,7 +83,7 @@ static void test_mutex_common(int type, void *(*entry)(void *arg))
  *	    and pthread_mutex_lock are tested with mutex type being
  *	    normal.
  */
-ZTEST(posix_apis, test_mutex_normal)
+ZTEST(mutex, test_mutex_normal)
 {
 	test_mutex_common(PTHREAD_MUTEX_NORMAL, normal_mutex_entry);
 }
@@ -95,7 +95,7 @@ ZTEST(posix_apis, test_mutex_normal)
  *	    twice and unlocked for the same number of time.
  *
  */
-ZTEST(posix_apis, test_mutex_recursive)
+ZTEST(mutex, test_mutex_recursive)
 {
 	test_mutex_common(PTHREAD_MUTEX_RECURSIVE, recursive_mutex_entry);
 }
@@ -105,7 +105,7 @@ ZTEST(posix_apis, test_mutex_recursive)
  *
  * @details Exactly CONFIG_MAX_PTHREAD_MUTEX_COUNT can be in use at once.
  */
-ZTEST(posix_apis, test_mutex_resource_exhausted)
+ZTEST(mutex, test_mutex_resource_exhausted)
 {
 	size_t i;
 	pthread_mutex_t m[CONFIG_MAX_PTHREAD_MUTEX_COUNT + 1];
@@ -129,7 +129,7 @@ ZTEST(posix_apis, test_mutex_resource_exhausted)
  *
  * @details Demonstrate that mutexes may be used over and over again.
  */
-ZTEST(posix_apis, test_mutex_resource_leak)
+ZTEST(mutex, test_mutex_resource_leak)
 {
 	pthread_mutex_t m;
 
@@ -168,7 +168,7 @@ static void *test_mutex_timedlock_fn(void *arg)
 }
 
 /** @brief Test to verify @ref pthread_mutex_timedlock returns ETIMEDOUT */
-ZTEST(posix_apis, test_mutex_timedlock)
+ZTEST(mutex, test_mutex_timedlock)
 {
 	void *ret;
 	pthread_t th;
@@ -194,3 +194,5 @@ ZTEST(posix_apis, test_mutex_timedlock)
 
 	zassert_ok(pthread_mutex_destroy(&mutex));
 }
+
+ZTEST_SUITE(mutex, NULL, NULL, NULL, NULL, NULL);

--- a/tests/posix/common/src/nanosleep.c
+++ b/tests/posix/common/src/nanosleep.c
@@ -104,12 +104,12 @@ static void common_errors(int selection, clockid_t clock_id, int flags)
 	zassert_equal(req.tv_nsec, 0, "actual: %d expected: %d", req.tv_nsec, 0);
 }
 
-ZTEST(posix_apis, test_nanosleep_errors_errno)
+ZTEST(nanosleep, test_nanosleep_errors_errno)
 {
 	common_errors(SELECT_NANOSLEEP, CLOCK_REALTIME, 0);
 }
 
-ZTEST(posix_apis, test_clock_nanosleep_errors_errno)
+ZTEST(nanosleep, test_clock_nanosleep_errors_errno)
 {
 	struct timespec rem = {};
 	struct timespec req = {};
@@ -130,7 +130,7 @@ ZTEST(posix_apis, test_clock_nanosleep_errors_errno)
 }
 
 /**
- * @brief Check that a call to nanosleep has yielded executiuon for some minimum time.
+ * @brief Check that a call to nanosleep has yielded execution for some minimum time.
  *
  * Check that the actual time slept is >= the total time specified by @p s (in seconds) and
  * @p ns (in nanoseconds).
@@ -200,7 +200,7 @@ static void common_lower_bound_check(int selection, clockid_t clock_id, int flag
 	/* TODO: Upper bounds check when hr timers are available */
 }
 
-ZTEST(posix_apis, test_nanosleep_execution)
+ZTEST(nanosleep, test_nanosleep_execution)
 {
 	/* sleep for 1ns */
 	common_lower_bound_check(SELECT_NANOSLEEP, 0, 0, 0, 1);
@@ -221,7 +221,7 @@ ZTEST(posix_apis, test_nanosleep_execution)
 	common_lower_bound_check(SELECT_NANOSLEEP, 0, 0, 1, 1001);
 }
 
-ZTEST(posix_apis, test_clock_nanosleep_execution)
+ZTEST(nanosleep, test_clock_nanosleep_execution)
 {
 	struct timespec ts;
 
@@ -281,3 +281,5 @@ ZTEST(posix_apis, test_clock_nanosleep_execution)
 	common_lower_bound_check(SELECT_CLOCK_NANOSLEEP, CLOCK_REALTIME, TIMER_ABSTIME,
 				 ts.tv_sec + 2, 1001);
 }
+
+ZTEST_SUITE(nanosleep, NULL, NULL, NULL, NULL, NULL);

--- a/tests/posix/common/src/pthread.c
+++ b/tests/posix/common/src/pthread.c
@@ -21,15 +21,15 @@
 #define PRIO_INVALID -1
 #define PTHREAD_INVALID -1
 
-void *thread_top_exec(void *p1);
-void *thread_top_term(void *p1);
+static void *thread_top_exec(void *p1);
+static void *thread_top_term(void *p1);
 
 static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
 static pthread_cond_t cvar0 = PTHREAD_COND_INITIALIZER;
 static pthread_cond_t cvar1 = PTHREAD_COND_INITIALIZER;
 static pthread_barrier_t barrier;
 
-sem_t main_sem;
+static sem_t main_sem;
 
 static int bounce_failed;
 static int bounce_done[N_THR_E];
@@ -53,7 +53,7 @@ static int barrier_return[N_THR_E];
  * Test success is signaled to main() using a traditional semaphore.
  */
 
-void *thread_top_exec(void *p1)
+static void *thread_top_exec(void *p1)
 {
 	int i, j, id = (int) POINTER_TO_INT(p1);
 	int policy;
@@ -141,7 +141,7 @@ void *thread_top_exec(void *p1)
 	return NULL;
 }
 
-int bounce_test_done(void)
+static int bounce_test_done(void)
 {
 	int i;
 
@@ -158,7 +158,7 @@ int bounce_test_done(void)
 	return 1;
 }
 
-int barrier_test_done(void)
+static int barrier_test_done(void)
 {
 	int i;
 
@@ -175,7 +175,7 @@ int barrier_test_done(void)
 	return 1;
 }
 
-void *thread_top_term(void *p1)
+static void *thread_top_term(void *p1)
 {
 	pthread_t self;
 	int oldstate, policy, ret;
@@ -353,7 +353,7 @@ ZTEST(pthread, test_pthread_descriptor_leak)
 	}
 }
 
-ZTEST(posix_apis, test_sched_getparam)
+ZTEST(pthread, test_sched_getparam)
 {
 	struct sched_param param;
 	int rc = sched_getparam(0, &param);
@@ -362,7 +362,7 @@ ZTEST(posix_apis, test_sched_getparam)
 	zassert_true((rc == -1 && err == ENOSYS));
 }
 
-ZTEST(posix_apis, test_sched_getscheduler)
+ZTEST(pthread, test_sched_getscheduler)
 {
 	int rc = sched_getscheduler(0);
 	int err = errno;

--- a/tests/posix/common/src/rwlock.c
+++ b/tests/posix/common/src/rwlock.c
@@ -47,7 +47,7 @@ static void *thread_top(void *p1)
 	return NULL;
 }
 
-ZTEST(posix_apis, test_rw_lock)
+ZTEST(rwlock, test_rw_lock)
 {
 	int ret;
 	pthread_t newthread[N_THR];
@@ -116,3 +116,5 @@ ZTEST(posix_apis, test_rw_lock)
 
 	zassert_ok(pthread_rwlock_destroy(&rwlock), "Failed to destroy rwlock");
 }
+
+ZTEST_SUITE(rwlock, NULL, NULL, NULL, NULL, NULL);

--- a/tests/posix/common/src/semaphore.c
+++ b/tests/posix/common/src/semaphore.c
@@ -90,7 +90,7 @@ static void semaphore_test(sem_t *sem)
 	zassert_ok(pthread_join(thread2, NULL));
 }
 
-ZTEST(posix_apis, test_semaphore)
+ZTEST(semaphore, test_semaphore)
 {
 	sem_t sema;
 
@@ -142,7 +142,7 @@ static void *nsem_close_func(void *p)
 	return NULL;
 }
 
-ZTEST(posix_apis, test_named_semaphore)
+ZTEST(semaphore, test_named_semaphore)
 {
 	pthread_t thread1, thread2;
 	sem_t *sem1, *sem2, *different_sem1;
@@ -311,3 +311,5 @@ ZTEST(posix_apis, test_named_semaphore)
 	sem_close(sem1);
 	zassert_equal(nsem_get_list_len(), 0);
 }
+
+ZTEST_SUITE(semaphore, NULL, NULL, NULL, NULL, NULL);

--- a/tests/posix/common/src/signal.c
+++ b/tests/posix/common/src/signal.c
@@ -12,7 +12,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/ztest.h>
 
-ZTEST(posix_apis, test_signal_emptyset)
+ZTEST(signal, test_sigemptyset)
 {
 	sigset_t set;
 
@@ -27,7 +27,7 @@ ZTEST(posix_apis, test_signal_emptyset)
 	}
 }
 
-ZTEST(posix_apis, test_signal_fillset)
+ZTEST(signal, test_sigfillset)
 {
 	sigset_t set = (sigset_t){0};
 
@@ -38,7 +38,7 @@ ZTEST(posix_apis, test_signal_fillset)
 	}
 }
 
-ZTEST(posix_apis, test_signal_addset_oor)
+ZTEST(signal, test_sigaddset_oor)
 {
 	sigset_t set = (sigset_t){0};
 
@@ -52,7 +52,7 @@ ZTEST(posix_apis, test_signal_addset_oor)
 	zassert_equal(errno, EINVAL, "errno should be %s", "EINVAL");
 }
 
-ZTEST(posix_apis, test_signal_addset)
+ZTEST(signal, test_sigaddset)
 {
 	int signo;
 	sigset_t set = (sigset_t){0};
@@ -99,7 +99,7 @@ ZTEST(posix_apis, test_signal_addset)
 	}
 }
 
-ZTEST(posix_apis, test_signal_delset_oor)
+ZTEST(signal, test_sigdelset_oor)
 {
 	sigset_t set = (sigset_t){0};
 
@@ -113,7 +113,7 @@ ZTEST(posix_apis, test_signal_delset_oor)
 	zassert_equal(errno, EINVAL, "errno should be %s", "EINVAL");
 }
 
-ZTEST(posix_apis, test_signal_delset)
+ZTEST(signal, test_sigdelset)
 {
 	int signo;
 	sigset_t set = (sigset_t){0};
@@ -160,7 +160,7 @@ ZTEST(posix_apis, test_signal_delset)
 	}
 }
 
-ZTEST(posix_apis, test_signal_ismember_oor)
+ZTEST(signal, test_sigismember_oor)
 {
 	sigset_t set = {0};
 
@@ -174,7 +174,7 @@ ZTEST(posix_apis, test_signal_ismember_oor)
 	zassert_equal(errno, EINVAL, "errno should be %s", "EINVAL");
 }
 
-ZTEST(posix_apis, test_signal_ismember)
+ZTEST(signal, test_sigismember)
 {
 	sigset_t set = (sigset_t){0};
 
@@ -195,7 +195,7 @@ ZTEST(posix_apis, test_signal_ismember)
 	zassert_equal(sigismember(&set, SIGTERM), 0, "%s not expected to be member", "SIGTERM");
 }
 
-ZTEST(posix_apis, test_signal_strsignal)
+ZTEST(signal, test_signal_strsignal)
 {
 	/* Using -INT_MAX here because compiler resolves INT_MIN to (-2147483647 - 1) */
 	char buf[sizeof("RT signal -" STRINGIFY(INT_MAX))] = {0};
@@ -297,7 +297,7 @@ static void *test_sigmask_entry(void *arg)
 	return NULL;
 }
 
-ZTEST(posix_apis, test_pthread_sigmask)
+ZTEST(signal, test_pthread_sigmask)
 {
 	pthread_t th;
 
@@ -305,7 +305,7 @@ ZTEST(posix_apis, test_pthread_sigmask)
 	zassert_ok(pthread_join(th, NULL));
 }
 
-ZTEST(posix_apis, test_sigprocmask)
+ZTEST(signal, test_sigprocmask)
 {
 	if (IS_ENABLED(CONFIG_MULTITHREADING)) {
 		if (!IS_ENABLED(CONFIG_ASSERT)) {
@@ -319,3 +319,5 @@ ZTEST(posix_apis, test_sigprocmask)
 		zassert_ok(pthread_join(th, NULL));
 	}
 }
+
+ZTEST_SUITE(signal, NULL, NULL, NULL, NULL, NULL);

--- a/tests/posix/common/src/sleep.c
+++ b/tests/posix/common/src/sleep.c
@@ -24,7 +24,7 @@ static void waker_func(struct k_work *work)
 }
 K_WORK_DELAYABLE_DEFINE(waker, waker_func);
 
-ZTEST(posix_apis, test_sleep)
+ZTEST(sleep, test_sleep)
 {
 	uint32_t then;
 	uint32_t now;
@@ -55,7 +55,7 @@ ZTEST(posix_apis, test_sleep)
 	zassert_true(sleep(sleep_max_s) >= sleep_rem_s);
 }
 
-ZTEST(posix_apis, test_usleep)
+ZTEST(sleep, test_usleep)
 {
 	uint32_t then;
 	uint32_t now;
@@ -86,3 +86,5 @@ ZTEST(posix_apis, test_usleep)
 	zassert_equal(-1, usleep(USEC_PER_SEC - 1));
 	zassert_equal(EINTR, errno);
 }
+
+ZTEST_SUITE(sleep, NULL, NULL, NULL, NULL, NULL);

--- a/tests/posix/common/src/spinlock.c
+++ b/tests/posix/common/src/spinlock.c
@@ -9,7 +9,7 @@
 #include <zephyr/ztest.h>
 #include <zephyr/sys/util.h>
 
-ZTEST(posix_apis, test_spin_init_destroy)
+ZTEST(spinlock, test_spin_init_destroy)
 {
 	pthread_spinlock_t lock;
 
@@ -24,7 +24,7 @@ ZTEST(posix_apis, test_spin_init_destroy)
 	zassert_ok(pthread_spin_destroy(&lock), "pthread_spin_destroy() failed");
 }
 
-ZTEST(posix_apis, test_spin_descriptor_leak)
+ZTEST(spinlock, test_spin_descriptor_leak)
 {
 	pthread_spinlock_t lock[CONFIG_MAX_PTHREAD_SPINLOCK_COUNT];
 
@@ -47,7 +47,7 @@ ZTEST(posix_apis, test_spin_descriptor_leak)
 	}
 }
 
-ZTEST(posix_apis, test_spin_lock_unlock)
+ZTEST(spinlock, test_spin_lock_unlock)
 {
 	pthread_spinlock_t lock;
 
@@ -69,3 +69,5 @@ ZTEST(posix_apis, test_spin_lock_unlock)
 	zassert_ok(pthread_spin_destroy(&lock), "pthread_spin_init() failed");
 	zassert_equal(pthread_spin_destroy(&lock), EINVAL, "pthread_spin_unlock() did not fail");
 }
+
+ZTEST_SUITE(spinlock, NULL, NULL, NULL, NULL, NULL);

--- a/tests/posix/common/src/timer.c
+++ b/tests/posix/common/src/timer.c
@@ -95,13 +95,13 @@ void test_timer(int sigev_notify)
 		       exp_count, expected_signal_count);
 }
 
-ZTEST(posix_apis, test_timer)
+ZTEST(timer, test_timer)
 {
 	test_timer(SIGEV_SIGNAL);
 	test_timer(SIGEV_THREAD);
 }
 
-ZTEST(posix_apis, test_timer_overrun)
+ZTEST(timer, test_timer_overrun)
 {
 	timer_t timerid;
 	struct sigevent sig = { 0 };
@@ -124,3 +124,5 @@ ZTEST(posix_apis, test_timer_overrun)
 	timer_delete(timerid);
 	zassert_equal(overruns, 4, "Number of overruns is incorrect");
 }
+
+ZTEST_SUITE(timer, NULL, NULL, NULL, NULL, NULL);

--- a/tests/posix/common/src/uname.c
+++ b/tests/posix/common/src/uname.c
@@ -7,7 +7,7 @@
 #include <zephyr/ztest.h>
 #include <sys/utsname.h>
 
-ZTEST(posix_apis, test_uname)
+ZTEST(uname, test_uname)
 {
 	struct utsname info;
 
@@ -15,3 +15,5 @@ ZTEST(posix_apis, test_uname)
 	zassert_ok(strncmp(info.sysname, "Zephyr", sizeof(info.sysname)));
 	zassert_ok(strncmp(info.machine, CONFIG_ARCH, sizeof(info.machine)));
 }
+
+ZTEST_SUITE(uname, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
- Reset the `REALTIME` clock base back to 0 with `ZTEST_RULE` so that every test that depended on the wall clock has the same initial value
- Split `posix_apis` into multiple testsuites

Fixes #67091