### PR TITLE
drivers: serial: sam u(s)art: correct interpretation of RXRDY flag

### DIFF
--- a/drivers/serial/uart_sam.c
+++ b/drivers/serial/uart_sam.c
@@ -49,7 +49,7 @@ static int uart_sam_poll_in(const struct device *dev, unsigned char *c)
 	Uart * const uart = cfg->regs;
 
 	if (!(uart->UART_SR & UART_SR_RXRDY)) {
-		return -EBUSY;
+		return -1;
 	}
 
 	/* got a character */

--- a/drivers/serial/usart_sam.c
+++ b/drivers/serial/usart_sam.c
@@ -50,7 +50,7 @@ static int usart_sam_poll_in(const struct device *dev, unsigned char *c)
 	Usart * const usart = config->regs;
 
 	if (!(usart->US_CSR & US_CSR_RXRDY)) {
-		return -EBUSY;
+		return -1;
 	}
 
 	/* got a character */


### PR DESCRIPTION
The receiver ready flag of the (channel) status register for the sam controller was not being interpreted correctly for both the uart and usart implementation, according to the uart api.
Tested and confirmed using the sam4sa16ca.