### PR TITLE
shell: telnet: Don't close the connection on ENOBUFS error

### DIFF
--- a/subsys/shell/backends/shell_telnet.c
+++ b/subsys/shell/backends/shell_telnet.c
@@ -76,7 +76,7 @@ static void telnet_command_send_reply(uint8_t *msg, uint16_t len)
 		ret = net_context_send(sh_telnet->client_ctx, msg, len, telnet_sent_cb,
 				       K_FOREVER, NULL);
 
-		if (ret == -EAGAIN) {
+		if (ret == -EAGAIN || ret == -ENOBUFS) {
 			k_sleep(K_MSEC(TELNET_RETRY_SEND_SLEEP_MS));
 			continue;
 		}
@@ -206,7 +206,7 @@ static int telnet_send(void)
 				       len, telnet_sent_cb,
 				       K_FOREVER, NULL);
 
-		if (ret == -EAGAIN) {
+		if (ret == -EAGAIN || ret == -ENOBUFS) {
 			k_sleep(K_MSEC(TELNET_RETRY_SEND_SLEEP_MS));
 			continue;
 		}


### PR DESCRIPTION
If there's not enough networking buffers at certain moment, they might become available later. So instead of closing connection (and failing assertation) sleep and retry. This avoid the following assertion failure when there's much of data to send:

    net_pkt: Data buffer (1500) allocation failed.
    net_tcp: conn: 0x20076024 packet allocation failed, len=1460
    shell_telnet: Failed to send -105, shutting down
    ASSERTION FAIL [err == 0] @ WEST_TOPDIR/zephyr/subsys/shell/shell_ops.c:416
    os: r0/a1:  0x00000004  r1/a2:  0x000001a0  r2/a3:  0x00000004
    os: r3/a4:  0x20044380 r12/ip:  0x00001958 r14/lr:  0x080c9027
    os:  xpsr:  0x41000000
    os: Faulting instruction address (r15/pc): 0x0811ed26
    os: >>> ZEPHYR FATAL ERROR 4: Kernel panic on CPU 0
    os: Current thread: 0x20045100 (shell_telnet)
    os: Halting system


This is related to  PR https://github.com/zephyrproject-rtos/zephyr/pull/66287 which implemented not closing the connection if write fails due to EAGAIN.