### PR TITLE
board: arm: stm32h747i_disco: flashing using STM32CubeProgrammer

### DIFF
--- a/boards/arm/stm32h747i_disco/board.cmake
+++ b/boards/arm/stm32h747i_disco/board.cmake
@@ -9,6 +9,8 @@ board_runner_args(jlink "--device=STM32H747ZI_M4")
 board_runner_args(openocd "--config=${BOARD_DIR}/support/openocd_stm32h747i_disco_m4.cfg")
 board_runner_args(openocd --target-handle=_CHIPNAME.cpu1)
 endif()
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/stm32h747i_disco/doc/index.rst
+++ b/boards/arm/stm32h747i_disco/doc/index.rst
@@ -230,6 +230,13 @@ automatically.
 
 Zephyr flash configuration has been set to meet these default settings.
 
+Alternatively, west `STM32CubeProgrammer`_ runner can be used, after installing
+it, to flash applications for both cores. The target core is detected automatically.
+
+.. code-block:: console
+
+   $ west flash --runner stm32cubeprogrammer
+
 Flashing an application to STM32H747I M7 Core
 ---------------------------------------------
 


### PR DESCRIPTION
This patch adds the possibility to flash applications for both cores of the stm32h747i_disco board using STM32CubeProgrammer.