### PR TITLE
logging: add flag to skip source info

### DIFF
--- a/include/zephyr/logging/log_output.h
+++ b/include/zephyr/logging/log_output.h
@@ -54,6 +54,9 @@ extern "C" {
 /** @brief Flag thread id or name prefix. */
 #define LOG_OUTPUT_FLAG_THREAD			BIT(7)
 
+/** @brief Flag forcing to skip logging the source. */
+#define LOG_OUTPUT_FLAG_SKIP_SOURCE		BIT(8)
+
 /**@} */
 
 /** @brief Supported backend logging format types for use

--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -452,6 +452,7 @@ static uint32_t prefix_print(const struct log_output *output,
 	bool level_on = flags & LOG_OUTPUT_FLAG_LEVEL;
 	bool thread_on = IS_ENABLED(CONFIG_LOG_THREAD_ID_PREFIX) &&
 			 (flags & LOG_OUTPUT_FLAG_THREAD);
+	bool source_off = flags & LOG_OUTPUT_FLAG_SKIP_SOURCE;
 	const char *tag = IS_ENABLED(CONFIG_LOG) ? z_log_get_tag() : NULL;
 
 	if (IS_ENABLED(CONFIG_LOG_BACKEND_NET) &&
@@ -489,7 +490,8 @@ static uint32_t prefix_print(const struct log_output *output,
 		color_prefix(output, colors_on, level);
 	}
 
-	length += ids_print(output, level_on, func_on, thread_on, domain, source, tid, level);
+	length += ids_print(output, level_on, func_on, thread_on, domain,
+			    source_off ? NULL : source, tid, level);
 
 	return length;
 }

--- a/tests/subsys/logging/log_output/src/log_output_test.c
+++ b/tests/subsys/logging/log_output/src/log_output_test.c
@@ -247,6 +247,24 @@ ZTEST(test_log_output, test_thread_id)
 	zassert_equal(strcmp(exp_str, mock_buffer), 0);
 }
 
+ZTEST(test_log_output, test_skip_src)
+{
+	char package[256];
+	const char exp_str[] = TEST_STR "\r\n";
+	uint32_t flags = LOG_OUTPUT_FLAG_SKIP_SOURCE;
+	int err;
+
+	err = cbprintf_package(package, sizeof(package), 0, TEST_STR);
+	zassert_true(err > 0);
+
+	reset_mock_buffer();
+	log_output_process(&log_output, 0, NULL, SNAME, NULL, LOG_LEVEL_INF,
+			   package, NULL, 0, flags);
+
+	mock_buffer[mock_len] = '\0';
+	zassert_equal(strcmp(exp_str, mock_buffer), 0);
+}
+
 static void before(void *notused)
 {
 	reset_mock_buffer();


### PR DESCRIPTION
Add a flag to skip printing the source info.