### PR TITLE
dts: nrf5340: add missing `easydma-maxcnt-bits` for nrf5340_cpunet

### DIFF
--- a/dts/arm/nordic/nrf5340_cpunet.dtsi
+++ b/dts/arm/nordic/nrf5340_cpunet.dtsi
@@ -193,6 +193,7 @@
 			reg = <0x41013000 0x1000>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <19 NRF_DEFAULT_IRQ_PRIORITY>;
+			easydma-maxcnt-bits = <16>;
 			status = "disabled";
 		};
 


### PR DESCRIPTION
The required property `easydma-maxcnt-bits` was missing for nrf5340_cpunet.

The PR https://github.com/zephyrproject-rtos/zephyr/pull/54663 missed to add `easydma-maxcnt-bits` for
`i2c0: i2c@41013000` node of nrf5340_cpunet.