### PR TITLE
scripts: using extend in list_boards for variant list

### DIFF
--- a/scripts/list_boards.py
+++ b/scripts/list_boards.py
@@ -252,7 +252,7 @@ def add_args_formatting(parser):
 def variant_v2_identifiers(variant, identifier):
     identifiers = [identifier + '/' + variant.name]
     for v in variant.variants:
-        identifiers.append(variant_v2_identifiers(v, identifier + '/' + variant.name))
+        identifiers.extend(variant_v2_identifiers(v, identifier + '/' + variant.name))
     return identifiers
 
 


### PR DESCRIPTION
Using extend instead of append to correctly extend the list of valid board identifiers.