### PR TITLE
net: ip: igmp: removed compiler warning when igmpv3 is enabled

### DIFF
--- a/subsys/net/ip/igmp.c
+++ b/subsys/net/ip/igmp.c
@@ -36,9 +36,10 @@ LOG_MODULE_DECLARE(net_ipv4, CONFIG_NET_IPV4_LOG_LEVEL);
 #define IGMPV3_BLOCK_OLD_SOURCES      0x06
 
 static const struct in_addr all_systems = { { { 224, 0, 0, 1 } } };
-static const struct in_addr all_routers = { { { 224, 0, 0, 2 } } };
 #if defined(CONFIG_NET_IPV4_IGMPV3)
 static const struct in_addr igmp_multicast_addr = { { { 224, 0, 0, 22 } } };
+#else
+static const struct in_addr all_routers = { { { 224, 0, 0, 2 } } };
 #endif
 
 #define dbg_addr(action, pkt_str, src, dst)				\


### PR DESCRIPTION
Made the definition of in_addr all_routers conditional to remove compiler warning:
"warning: 'all_routers' defined but not used [-Wunused-const-variable=]"
The warning occurs when igmpv3 is enabled.