### PR TITLE
scripts: tests: blackbox noclearout mark warning removal

### DIFF
--- a/scripts/tests/twister_blackbox/conftest.py
+++ b/scripts/tests/twister_blackbox/conftest.py
@@ -23,6 +23,9 @@ sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts"))
 
 testsuite_filename_mock = mock.PropertyMock(return_value='test_data.yaml')
 
+def pytest_configure(config):
+    config.addinivalue_line("markers", "noclearout: disable the provide_out autouse fixture")
+
 @pytest.fixture(name='zephyr_base')
 def zephyr_base_directory():
     return ZEPHYR_BASE


### PR DESCRIPTION
Currently, the noclearout pytest mark generates warnings because it is not registered.
This commit adds its registration in the relevant conftest.

NOTE:
If PR https://github.com/zephyrproject-rtos/zephyr/pull/67670 is merged first, this one will probably need changes.