### PR TITLE
ace: fix DSP panic during startup

### DIFF
--- a/soc/xtensa/intel_adsp/ace/multiprocessing.c
+++ b/soc/xtensa/intel_adsp/ace/multiprocessing.c
@@ -86,11 +86,6 @@ void soc_mp_init(void)
 		IDC[i].agents[0].ipc.ctl = BIT(0); /* IPCTBIE */
 	}
 
-	int ret = pm_device_runtime_get(INTEL_ADSP_HST_DOMAIN_DEV);
-
-	ARG_UNUSED(ret);
-	__ASSERT_NO_MSG(ret == 0);
-
 	/* Set the core 0 active */
 	soc_cpus_active[0] = true;
 #if CONFIG_ACE_VERSION_1_5
@@ -99,6 +94,12 @@ void soc_mp_init(void)
 	g_key_read_holder = INTEL_ADSP_ACE15_MAGIC_KEY;
 #endif /* CONFIG_ACE_VERSION_1_5 */
 }
+
+static int host_runtime_get(void)
+{
+	return pm_device_runtime_get(INTEL_ADSP_HST_DOMAIN_DEV);
+}
+SYS_INIT(host_runtime_get, POST_KERNEL, 99);
 
 #ifdef CONFIG_ADSP_IMR_CONTEXT_SAVE
 /*


### PR DESCRIPTION
pm_device_runtime_get() must be called after pd_intel_adsp_init() is called for each device, because the latter calls
pm_device_runtime_enable(), which sets the device runtime PM use count to 0. The current wrong calling order causes a DSP panic because of an unbalanced pm_device_runtime_put(). Fix this by delaying pm_device_runtime_get() until the POST_KERNEL initialisation step.

Fixes commit c3a6274bf5e4 ("intel_adsp: ace: power: Prevent HST domain power gating")