### PR TITLE
Add SO_DOMAIN socket option support

### DIFF
--- a/include/zephyr/net/socket.h
+++ b/include/zephyr/net/socket.h
@@ -1166,7 +1166,7 @@ struct ifreq {
 /** Protocol used with the socket */
 #define SO_PROTOCOL 38
 
-/** Domain used with SOCKET (ignored, for compatibility) */
+/** Domain used with SOCKET */
 #define SO_DOMAIN 39
 
 /** Enable SOCKS5 for Socket */

--- a/subsys/net/lib/sockets/socket_obj_core.c
+++ b/subsys/net/lib/sockets/socket_obj_core.c
@@ -158,9 +158,11 @@ out:
 	return ret;
 }
 
-int sock_obj_core_alloc_find(int sock, int new_sock, int family, int type)
+int sock_obj_core_alloc_find(int sock, int new_sock, int type)
 {
 	struct net_socket_register *reg = NULL;
+	socklen_t optlen = sizeof(int);
+	int family;
 	int ret;
 
 	if (new_sock < 0) {
@@ -169,6 +171,12 @@ int sock_obj_core_alloc_find(int sock, int new_sock, int family, int type)
 
 	ret = sock_obj_core_get_reg_and_proto(sock, &reg);
 	if (ret < 0) {
+		goto out;
+	}
+
+	ret = zsock_getsockopt(sock, SOL_SOCKET, SO_DOMAIN, &family, &optlen);
+	if (ret < 0) {
+		NET_ERR("Cannot get socket domain (%d)", -errno);
 		goto out;
 	}
 

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -2447,6 +2447,18 @@ int zsock_getsockopt_ctx(struct net_context *ctx, int level, int optname,
 
 			return 0;
 		}
+
+		case SO_DOMAIN: {
+			if (*optlen != sizeof(int)) {
+				errno = EINVAL;
+				return -1;
+			}
+
+			*(int *)optval = net_context_get_family(ctx);
+
+			return 0;
+		}
+
 		break;
 
 		case SO_RCVBUF:

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -684,9 +684,7 @@ int z_impl_zsock_accept(int sock, struct sockaddr *addr, socklen_t *addrlen)
 
 	new_sock = VTABLE_CALL(accept, sock, addr, addrlen);
 
-	if (addr) {
-		(void)sock_obj_core_alloc_find(sock, new_sock, addr->sa_family, SOCK_STREAM);
-	}
+	(void)sock_obj_core_alloc_find(sock, new_sock, SOCK_STREAM);
 
 	return new_sock;
 }

--- a/subsys/net/lib/sockets/sockets_internal.h
+++ b/subsys/net/lib/sockets/sockets_internal.h
@@ -82,7 +82,7 @@ size_t msghdr_non_empty_iov_count(const struct msghdr *msg);
 #if defined(CONFIG_NET_SOCKETS_OBJ_CORE)
 int sock_obj_core_alloc(int sock, struct net_socket_register *reg,
 			int family, int type, int proto);
-int sock_obj_core_alloc_find(int sock, int new_sock, int family, int type);
+int sock_obj_core_alloc_find(int sock, int new_sock, int type);
 int sock_obj_core_dealloc(int sock);
 void sock_obj_core_update_send_stats(int sock, int bytes);
 void sock_obj_core_update_recv_stats(int sock, int bytes);
@@ -100,12 +100,10 @@ static inline int sock_obj_core_alloc(int sock,
 	return -ENOTSUP;
 }
 
-static inline int sock_obj_core_alloc_find(int sock, int new_sock,
-					   int family, int type)
+static inline int sock_obj_core_alloc_find(int sock, int new_sock, int type)
 {
 	ARG_UNUSED(sock);
 	ARG_UNUSED(new_sock);
-	ARG_UNUSED(family);
 	ARG_UNUSED(type);
 
 	return -ENOTSUP;

--- a/tests/net/socket/misc/src/main.c
+++ b/tests/net/socket/misc/src/main.c
@@ -887,4 +887,39 @@ ZTEST(socket_misc_test_suite, test_ipv4_mapped_to_ipv6_server)
 	test_ipv4_mapped_to_ipv6_server();
 }
 
+ZTEST(socket_misc_test_suite, test_so_domain_socket_option)
+{
+	int ret;
+	int sock_u;
+	int sock_t;
+	socklen_t optlen = sizeof(int);
+	int domain;
+
+	sock_t = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+	zassert_true(sock_t >= 0, "TCP socket open failed");
+	sock_u = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
+	zassert_true(sock_u >= 0, "UDP socket open failed");
+
+	ret = getsockopt(sock_t, SOL_SOCKET, SO_DOMAIN, &domain, &optlen);
+	zassert_equal(ret, 0, "getsockopt failed, %d", -errno);
+	zassert_equal(domain, AF_INET, "Mismatch domain value %d vs %d",
+		      AF_INET, domain);
+
+	ret = getsockopt(sock_u, SOL_SOCKET, SO_DOMAIN, &domain, &optlen);
+	zassert_equal(ret, 0, "getsockopt failed, %d", -errno);
+	zassert_equal(domain, AF_INET6, "Mismatch domain value %d vs %d",
+		      AF_INET6, domain);
+
+	/* setsockopt() is not supported for this option */
+	domain = AF_INET;
+	ret = setsockopt(sock_u, SOL_SOCKET, SO_DOMAIN, &domain, optlen);
+	zassert_equal(ret, -1, "setsockopt succeed");
+	zassert_equal(errno, ENOPROTOOPT, "Invalid errno %d", errno);
+
+	ret = close(sock_t);
+	zassert_equal(ret, 0, "close failed, %d", -errno);
+	ret = close(sock_u);
+	zassert_equal(ret, 0, "close failed, %d", -errno);
+}
+
 ZTEST_SUITE(socket_misc_test_suite, NULL, setup, NULL, NULL, NULL);


### PR DESCRIPTION
This is related to #67559 where we would need to know the used socket domain when user calls `accept()`. Fix also the objcore call in `accept()` so that correct socket domain is always used.
