### PR TITLE
xtensa: Minor tweak to use of rsr and wsr instructions

### DIFF
--- a/arch/xtensa/include/xtensa_asm2_s.h
+++ b/arch/xtensa/include/xtensa_asm2_s.h
@@ -371,7 +371,7 @@ _xstack_call0_\@:
 	entry a1, 16
 	mov a1, a2
 	rsr.ZSR_EPS a2
-	wsr.PS a2
+	wsr.ps a2
 	call4 _xstack_call1_\@
 	mov a2, a6		/* copy return value */
 	retw
@@ -439,7 +439,7 @@ _xstack_returned_\@:
 	rsr.ps a0
 	movi a3, PS_INTLEVEL(1)
 	or a0, a0, a3
-	wsr.PS a0
+	wsr.ps a0
 _not_l1:
 
 	/* Setting up the cross stack call below has states where the
@@ -459,7 +459,7 @@ _not_l1:
 	movi a3, ~(PS_EXCM_MASK) & ~(PS_RING_MASK)
 	and a0, a0, a3
 	wsr.ZSR_EPS a0
-	wsr.PS a0
+	wsr.ps a0
 	rsync
 
 	/* A1 already contains our saved stack, and A2 our handler.

--- a/arch/xtensa/include/xtensa_asm2_s.h
+++ b/arch/xtensa/include/xtensa_asm2_s.h
@@ -160,20 +160,20 @@
  * Does not populate or modify the PS/PC save locations.
  */
 .macro ODD_REG_SAVE
-	rsr.SAR a0
+	rsr.sar a0
 	s32i a0, a1, ___xtensa_irq_bsa_t_sar_OFFSET
 #if XCHAL_HAVE_LOOPS
-	rsr.LBEG a0
+	rsr.lbeg a0
 	s32i a0, a1, ___xtensa_irq_bsa_t_lbeg_OFFSET
-	rsr.LEND a0
+	rsr.lend a0
 	s32i a0, a1, ___xtensa_irq_bsa_t_lend_OFFSET
-	rsr.LCOUNT a0
+	rsr.lcount a0
 	s32i a0, a1, ___xtensa_irq_bsa_t_lcount_OFFSET
 #endif
 	rsr.exccause a0
 	s32i a0, a1, ___xtensa_irq_bsa_t_exccause_OFFSET
 #if XCHAL_HAVE_S32C1I
-	rsr.SCOMPARE1 a0
+	rsr.scompare1 a0
 	s32i a0, a1, ___xtensa_irq_bsa_t_scompare1_OFFSET
 #endif
 #if XCHAL_HAVE_THREADPTR && \
@@ -432,11 +432,11 @@ _xstack_returned_\@:
 	 * argument and expand two versions of this handler.  An
 	 * optimization FIXME, I guess.
 	 */
-	rsr.PS a0
+	rsr.ps a0
 	movi a3, PS_INTLEVEL_MASK
 	and a0, a0, a3
 	bnez a0, _not_l1
-	rsr.PS a0
+	rsr.ps a0
 	movi a3, PS_INTLEVEL(1)
 	or a0, a0, a3
 	wsr.PS a0
@@ -600,7 +600,7 @@ _Level\LVL\()Vector:
 	 * turned on the EXCM bit and set INTLEVEL.
 	 */
 .if \LVL == 1
-	rsr.PS a0
+	rsr.ps a0
 #ifdef CONFIG_XTENSA_MMU
 	/* TLB misses also come through level 1 interrupts.
 	 * We do not want to unconditionally unmask interrupts.
@@ -616,11 +616,11 @@ _Level\LVL\()Vector:
 	and a0, a0, a2
 	s32i a0, a1, ___xtensa_irq_bsa_t_ps_OFFSET
 .else
-	rsr.EPS\LVL a0
+	rsr.eps\LVL a0
 	s32i a0, a1, ___xtensa_irq_bsa_t_ps_OFFSET
 .endif
 
-	rsr.EPC\LVL a0
+	rsr.epc\LVL a0
 	s32i a0, a1, ___xtensa_irq_bsa_t_pc_OFFSET
 
 	/* What's happening with this jump is that the L32R


### PR DESCRIPTION
Use of the rsr.XXX and wsr.XXX instructions, where XXX is an uppercase string matching a special register, can lead compilation errors when the special register file defined in the HAL is used as the uppercase string will get converted into a number leading to malformed instructions such as ...
`    rsr.88, a0`

Converting the uppercase string to a lowercase string gets around this issue.    
