### PR TITLE
spi: stm32: spi_ll_stm32: add MSSI and MIDI support

### DIFF
--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -618,6 +618,11 @@ static int spi_stm32_configure(const struct device *dev,
 		LL_SPI_SetDataWidth(spi, LL_SPI_DATAWIDTH_16BIT);
 	}
 
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
+	LL_SPI_SetMasterSSIdleness(spi, cfg->mssi_clocks);
+	LL_SPI_SetInterDataIdleness(spi, (cfg->midi_clocks << SPI_CFG2_MIDI_Pos));
+#endif
+
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_spi_fifo)
 	ll_func_set_fifo_threshold_8bit(spi);
 #endif
@@ -1160,6 +1165,12 @@ static const struct spi_stm32_config spi_stm32_cfg_##id = {		\
 	IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(st_stm32_spi_subghz),	\
 		(.use_subghzspi_nss =					\
 			DT_INST_PROP_OR(id, use_subghzspi_nss, false),))\
+	IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi),		\
+		(.midi_clocks =						\
+			DT_INST_PROP(id, midi_clock),))			\
+	IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi),		\
+		(.mssi_clocks =						\
+			DT_INST_PROP(id, mssi_clock),))			\
 };									\
 									\
 static struct spi_stm32_data spi_stm32_dev_data_##id = {		\

--- a/drivers/spi/spi_ll_stm32.h
+++ b/drivers/spi/spi_ll_stm32.h
@@ -28,6 +28,10 @@ struct spi_stm32_config {
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_spi_subghz)
 	bool use_subghzspi_nss;
 #endif
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
+	int midi_clocks;
+	int mssi_clocks;
+#endif
 	size_t pclk_len;
 	const struct stm32_pclken *pclken;
 };

--- a/dts/bindings/spi/st,stm32h7-spi.yaml
+++ b/dts/bindings/spi/st,stm32h7-spi.yaml
@@ -12,3 +12,18 @@ description: |
 compatible: "st,stm32h7-spi"
 
 include: st,stm32-spi-common.yaml
+
+properties:
+  midi-clock:
+    type: int
+    default: 0
+    description: |
+      (Master Inter-Data Idleness) minimum clock inserted
+      between two consecutive data frames.
+
+  mssi-clock:
+    type: int
+    default: 0
+    description: |
+      (Master SS Idleness) minimum clock inserted between
+      start and first data transaction.


### PR DESCRIPTION
Hi everyone

## Adjustable Signal Flow Timing Support

STM32H7xx series mcu does support that feaute.

![image](https://github.com/zephyrproject-rtos/zephyr/assets/58497719/a4eec4d9-42e9-48f7-8918-dd026917ace7)

Several parameters can be used to optionally adjust the timing of the master transaction flow. Signal timings for the master node can be adjusted when needed. This is the case when a slave node needs a longer time to wake up from sleep mode following the setup of the SS active edge or when the slave is not able to handle a data flow that is too fast. Up to 15 additional serial clock signal periods delays can be inserted by MIDI or MSSI parameters. Data frames can be optionally interleaved by SS pulses.

Signed-off-by: Mustafa Abdullah Kus [mustafa.kus@sparsetechnology.com](mailto:mustafa.kus@sparsetechnology.com)
