### PR TITLE
boards: stm32wl: add flash partitions and fix chosen node

### DIFF
--- a/boards/arm/lora_e5_dev_board/lora_e5_dev_board.dts
+++ b/boards/arm/lora_e5_dev_board/lora_e5_dev_board.dts
@@ -17,7 +17,7 @@
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
-		zephyr,code-partition = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds {
@@ -176,6 +176,19 @@ grove_i2c: &i2c2 {};
 		#address-cells = <1>;
 		#size-cells = <1>;
 
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 DT_SIZE_K(32)>;
+			read-only;
+		};
+		slot0_partition: partition@8000 {
+			label = "image-0";
+			reg = <0x00008000 DT_SIZE_K(104)>;
+		};
+		slot1_partition: partition@22000 {
+			label = "image-1";
+			reg = <0x00022000 DT_SIZE_K(104)>;
+		};
 		/* 16KB (8x2kB pages) of storage at the end of the flash */
 		storage_partition: partition@3c000 {
 			label = "storage";

--- a/boards/arm/nucleo_wl55jc/nucleo_wl55jc.dts
+++ b/boards/arm/nucleo_wl55jc/nucleo_wl55jc.dts
@@ -20,7 +20,7 @@
 		zephyr,shell-uart = &lpuart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
-		zephyr,code-partition = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds: leds {
@@ -190,6 +190,20 @@ stm32_lp_tick_source: &lptim1 {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 DT_SIZE_K(32)>;
+			read-only;
+		};
+		slot0_partition: partition@8000 {
+			label = "image-0";
+			reg = <0x00008000 DT_SIZE_K(104)>;
+		};
+		slot1_partition: partition@22000 {
+			label = "image-1";
+			reg = <0x00022000 DT_SIZE_K(104)>;
+		};
 
 		/*
 		 * Set 16kB of storage (8x2kB pages) at the end of the 256kB of


### PR DESCRIPTION
Add flash partitions required to use the board with MCUboot.

Also fix the chosen `zephyr,code-partition` devicetree node and point it to `slot0_partition`.