### PR TITLE
MAINTAINERS: remove inactive collaborator from area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3124,7 +3124,6 @@ Intel Platforms (Xtensa):
     - marc-hb
     - kv2019i
     - ceolin
-    - aborisovich
     - tmleman
     - softwarecki
     - jxstelter


### PR DESCRIPTION
Remove inactive collaborator from Intel ADAP area.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
