### PR TITLE
ci: scripts: Add run_id and run_attempt context on upload to ES

### DIFF
--- a/scripts/ci/upload_test_results_es.py
+++ b/scripts/ci/upload_test_results_es.py
@@ -14,7 +14,7 @@ import os
 import json
 import argparse
 
-def gendata(f, index, run_date=None):
+def gendata(f, index, run_date=None, run_id=None, run_attempt=None):
     with open(f, "r") as j:
         data = json.load(j)
         for t in data['testsuites']:
@@ -25,6 +25,10 @@ def gendata(f, index, run_date=None):
             env = data['environment']
             if run_date:
                 env['run_date'] =  run_date
+            if run_id:
+                env['run_id'] =  run_id
+            if run_attempt:
+                env['run_attempt'] =  run_attempt
             t['environment'] = env
             t['component'] = main_group
             t['sub_component'] = sub_group
@@ -57,7 +61,7 @@ def main():
     if args.dry_run:
         xx = None
         for f in args.files:
-            xx = gendata(f, index_name)
+            xx = gendata(f, index_name, args.run_date, args.run_id, args.run_attempt)
         for x in xx:
             print(x)
         sys.exit(0)
@@ -74,7 +78,7 @@ def main():
         if args.run_date:
             print(f"Setting run date from command line: {args.run_date}")
         for f in args.files:
-            bulk(es, gendata(f, index_name, args.run_date))
+            bulk(es, gendata(f, index_name, args.run_date, args.run_id, args.run_attempt))
 
 
 def parse_args():
@@ -83,6 +87,10 @@ def parse_args():
     parser.add_argument('-c','--create-index', action="store_true", help='Create index.')
     parser.add_argument('-i', '--index', help='index to push to.', required=True)
     parser.add_argument('-r', '--run-date', help='Run date in ISO format', required=False)
+    parser.add_argument('--run-id', required=False,
+                        help="unique run-id (e.g. from github.run_id context)")
+    parser.add_argument('--run-attempt', required=False,
+                        help="unique run attempt number (e.g. from github.run_attempt context)")
     parser.add_argument('files', metavar='FILE', nargs='+', help='file with test data.')
 
     args = parser.parse_args()


### PR DESCRIPTION
Optionally record run-id and run-attempt github context variables as additional test suite environment properties on upload into ElasticSearch to track re-runs of CI workflows.