### PR TITLE
drivers: adc: permit use of vref_mv, even if reference == ADC_REF_INTERNAL

### DIFF
--- a/include/zephyr/drivers/adc.h
+++ b/include/zephyr/drivers/adc.h
@@ -811,7 +811,7 @@ static inline int adc_raw_to_millivolts_dt(const struct adc_dt_spec *spec,
 		return -ENOTSUP;
 	}
 
-	if (spec->channel_cfg.reference == ADC_REF_INTERNAL) {
+	if ((spec->vref_mv == 0) && (spec->channel_cfg.reference == ADC_REF_INTERNAL)) {
 		vref_mv = (int32_t)adc_ref_internal(spec->dev);
 	} else {
 		vref_mv = spec->vref_mv;


### PR DESCRIPTION
It is useful to be able to provide a `zephyr,vref-mv` property that takes a potential divider into consideration, allowing direct measurement of a voltage higher than the part's maximum, with no further conversion steps.

For example, a potential divider with a 10kOhm resistor between the signal and the ADC input, and a 1kOhm resistor between the ADC input and ground can permit measuring a voltage up to 11x higher. In this case, a `zephyr,vref-mv` value of `Vref * 11` can be given. When a call is made to `adc_raw_to_millivolts_dt()`, the "real" voltage is returned immediately.

This PR is in response to further reflection on #67634