### PR TITLE
drivers: serial: uart_mcux_lpuart: Switch to using DT_INST_IRQN_BY_IDX

### DIFF
--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -1116,7 +1116,7 @@ static const struct uart_driver_api mcux_lpuart_driver_api = {
 #ifdef CONFIG_UART_MCUX_LPUART_ISR_SUPPORT
 #define MCUX_LPUART_IRQ_INSTALL(n, i)					\
 	do {								\
-		IRQ_CONNECT(DT_INST_IRQ_BY_IDX(n, i, irq),		\
+		IRQ_CONNECT(DT_INST_IRQN_BY_IDX(n, i),			\
 			    DT_INST_IRQ_BY_IDX(n, i, priority),		\
 			    mcux_lpuart_isr, DEVICE_DT_INST_GET(n), 0);	\
 									\


### PR DESCRIPTION
After #63289, multi-level interrupts are now encoded using macro magic. This means that using the generic DT_INST_IRQ_BY_IDX() to fetch the INTID is no longer an option as the queried INTID will be the one specified through the node's `interrupts` properties. To fix this, switch to using DT_INST_IRQN_BY_IDX() which will return the correctly encoded INTID.

Below you can find `gen_isr_tables.py`'s output before and after this patch. We're interested in the second to last entry in the table.

Before:
<img width="246" alt="before" src="https://github.com/zephyrproject-rtos/zephyr/assets/26043217/0486e817-9914-4f79-9fdc-423bba887d0c">

After:
<img width="248" alt="after" src="https://github.com/zephyrproject-rtos/zephyr/assets/26043217/74f8cc01-fbd7-402c-8aa6-6f6758edf475">
