### PR TITLE
ci: pr stats: counts hours open since moving out of draft

### DIFF
--- a/scripts/ci/stats/merged_prs.py
+++ b/scripts/ci/stats/merged_prs.py
@@ -74,12 +74,19 @@ def process_pr(pr):
         prj['review_rule'] = "no"
 
 
+    created = pr.created_at
+    # if a PR was made ready for review from draft, calculate based on when it
+    # was moved out of draft.
+    for event in pr.get_issue_events():
+        if event.event == 'ready_for_review':
+            created = event.created_at
+
     # calculate time the PR was in review, hours and business days.
-    delta = pr.closed_at - pr.created_at
+    delta = pr.closed_at - created
     deltah = delta.total_seconds() / 3600
     prj['hours_open'] = deltah
 
-    dates = (pr.created_at + timedelta(idx + 1) for idx in range((pr.closed_at - pr.created_at).days))
+    dates = (created + timedelta(idx + 1) for idx in range((pr.closed_at - created).days))
 
     # Get number of business days per the guidelines, we need at least 2.
     business_days = sum(1 for day in dates if day.weekday() < 5)


### PR DESCRIPTION
if a PR was made ready for review from draft, calculate based on when it
was moved out of draft.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
