### PR TITLE
intel_adsp: check for power domain being enabled

### DIFF
--- a/soc/xtensa/intel_adsp/ace/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/ace/Kconfig.defconfig.series
@@ -14,6 +14,9 @@ config SOC_TOOLCHAIN_NAME
 config SMP
 	default y
 
+config POWER_DOMAIN
+	default y
+
 # MTL leaves the upper mapping in the same spot as cAVS, but moves the
 # lower one inexplicably.
 config XTENSA_UNCACHED_REGION


### PR DESCRIPTION
This code fails to build when power domain is not enabled.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
