### PR TITLE
fix filtering in uart_async_rx test

### DIFF
--- a/tests/drivers/uart/uart_async_rx/testcase.yaml
+++ b/tests/drivers/uart/uart_async_rx/testcase.yaml
@@ -5,10 +5,12 @@ tests:
     integration_platforms:
       - native_sim
   drivers.uart.async_rx.ztress:
-    filter: CONFIG_SERIAL
     tags: drivers uart
-    platform_allow: >
-      qemu_cortex_m3 qemu_x86 qemu_x86_64 qemu_riscv32
+    platform_allow:
+      - qemu_cortex_m3
+      - qemu_x86
+      - qemu_x86_64
+      - qemu_riscv32
     integration_platforms:
       - qemu_x86
     extra_configs:

--- a/tests/drivers/uart/uart_async_rx/testcase.yaml
+++ b/tests/drivers/uart/uart_async_rx/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   drivers.uart.async_rx:
-    filter: CONFIG_SERIAL
+    filter: CONFIG_SERIAL_HAS_DRIVER
     tags: drivers uart
     integration_platforms:
       - native_sim


### PR DESCRIPTION
- tests: uart: do not filter if we know which platforms to use
- tests: uart: do not enable serial in prj.conf
