### PR TITLE
tests: posix: shorten the filter in testcase.yaml

### DIFF
--- a/tests/posix/common/testcase.yaml
+++ b/tests/posix/common/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  filter: not (CONFIG_NATIVE_BUILD and CONFIG_EXTERNAL_LIBC)
+  filter: not CONFIG_NATIVE_LIBC
   platform_exclude:
     - native_posix
     - native_posix_64

--- a/tests/posix/eventfd/testcase.yaml
+++ b/tests/posix/eventfd/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  filter: not (CONFIG_NATIVE_BUILD and CONFIG_EXTERNAL_LIBC)
+  filter: not CONFIG_NATIVE_LIBC
   tags:
     - posix
     - eventfd

--- a/tests/posix/fs/testcase.yaml
+++ b/tests/posix/fs/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  filter: not (CONFIG_NATIVE_BUILD and CONFIG_EXTERNAL_LIBC)
+  filter: not CONFIG_NATIVE_LIBC
   arch_exclude:
     - nios2
   platform_exclude:

--- a/tests/posix/getopt/testcase.yaml
+++ b/tests/posix/getopt/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  filter: not (CONFIG_NATIVE_BUILD and CONFIG_EXTERNAL_LIBC)
+  filter: not CONFIG_NATIVE_LIBC
   tags:
     - posix
     - getopt

--- a/tests/posix/headers/testcase.yaml
+++ b/tests/posix/headers/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  filter: not (CONFIG_NATIVE_BUILD and CONFIG_EXTERNAL_LIBC)
+  filter: not CONFIG_NATIVE_LIBC
   tags:
     - posix
   min_ram: 32


### PR DESCRIPTION
Shorten the filter in `tests/posix/**/testcase.yaml`. Specifically, `CONFIG_NATIVE_LIBC` can be used in place of `CONFIG_NATIVE_BUILD` and `CONFIG_EXTERNAL_LIBC`.