### PR TITLE
driver: I2C: npcx: re-enable interrupts after bus error

### DIFF
--- a/drivers/i2c/i2c_npcx_controller.c
+++ b/drivers/i2c/i2c_npcx_controller.c
@@ -770,8 +770,15 @@ static void i2c_ctrl_target_isr(const struct device *dev, uint8_t status)
 		inst->SMBCTL2 &= ~BIT(NPCX_SMBCTL2_ENABLE);
 		inst->SMBCTL2 |= BIT(NPCX_SMBCTL2_ENABLE);
 
+		/*
+		 * Re-enable interrupts because they are turned off after the SMBus module
+		 * is reset above.
+		 */
+		inst->SMBCTL1 |= BIT(NPCX_SMBCTL1_NMINTE) | BIT(NPCX_SMBCTL1_INTEN);
 		/* End of transaction */
 		data->oper_state = NPCX_I2C_IDLE;
+
+		LOG_DBG("target: Bus error on port%02x!", data->port);
 		return;
 	}
 


### PR DESCRIPTION
When the I2C is in the target mode and encounters the bus error, the driver has to reset the bus to recover the I2C hardware. However, when the hardware is disabled, the interrupt enable bits are also cleared automatically by design. As a result, we need to enable the interrupts after resetting the I2C hardware.