### PR TITLE
posix: pthread: fix `zephyr_to_posix_priority` assert test

### DIFF
--- a/lib/posix/pthread.c
+++ b/lib/posix/pthread.c
@@ -227,7 +227,7 @@ static bool is_posix_policy_prio_valid(uint32_t priority, int policy)
 	return false;
 }
 
-static uint32_t zephyr_to_posix_priority(int32_t z_prio, int *policy)
+static int zephyr_to_posix_priority(int z_prio, int *policy)
 {
 	if (z_prio < 0) {
 		__ASSERT_NO_MSG(-z_prio <= CONFIG_NUM_COOP_PRIORITIES);
@@ -239,7 +239,7 @@ static uint32_t zephyr_to_posix_priority(int32_t z_prio, int *policy)
 	return ZEPHYR_TO_POSIX_PRIORITY(z_prio);
 }
 
-static int32_t posix_to_zephyr_priority(uint32_t priority, int policy)
+static int posix_to_zephyr_priority(int priority, int policy)
 {
 	if (policy == SCHED_FIFO) {
 		/* COOP: highest [-CONFIG_NUM_COOP_PRIORITIES, -1] lowest */
@@ -701,7 +701,7 @@ int pthread_attr_init(pthread_attr_t *_attr)
  */
 int pthread_getschedparam(pthread_t pthread, int *policy, struct sched_param *param)
 {
-	uint32_t priority;
+	int priority;
 	struct posix_thread *t;
 
 	t = to_posix_thread(pthread);

--- a/lib/posix/pthread.c
+++ b/lib/posix/pthread.c
@@ -222,7 +222,7 @@ static bool is_posix_policy_prio_valid(uint32_t priority, int policy)
 		return true;
 	}
 
-	LOG_ERR("Invalid piority %d and / or policy %d", priority, policy);
+	LOG_ERR("Invalid priority %d and / or policy %d", priority, policy);
 
 	return false;
 }
@@ -242,7 +242,7 @@ static uint32_t zephyr_to_posix_priority(int32_t z_prio, int *policy)
 static int32_t posix_to_zephyr_priority(uint32_t priority, int policy)
 {
 	if (policy == SCHED_FIFO) {
-		/* COOP: highest [CONFIG_NUM_COOP_PRIORITIES, -1] lowest */
+		/* COOP: highest [-CONFIG_NUM_COOP_PRIORITIES, -1] lowest */
 		__ASSERT_NO_MSG(priority < CONFIG_NUM_COOP_PRIORITIES);
 	} else {
 		/* PREEMPT: lowest [0, CONFIG_NUM_PREEMPT_PRIORITIES - 1] highest */

--- a/lib/posix/pthread.c
+++ b/lib/posix/pthread.c
@@ -227,7 +227,8 @@ static bool is_posix_policy_prio_valid(uint32_t priority, int policy)
 	return false;
 }
 
-static int zephyr_to_posix_priority(int z_prio, int *policy)
+/* Non-static so that they can be tested in ztest */
+int zephyr_to_posix_priority(int z_prio, int *policy)
 {
 	if (z_prio < 0) {
 		__ASSERT_NO_MSG(-z_prio <= CONFIG_NUM_COOP_PRIORITIES);
@@ -239,7 +240,8 @@ static int zephyr_to_posix_priority(int z_prio, int *policy)
 	return ZEPHYR_TO_POSIX_PRIORITY(z_prio);
 }
 
-static int posix_to_zephyr_priority(int priority, int policy)
+/* Non-static so that they can be tested in ztest */
+int posix_to_zephyr_priority(int priority, int policy)
 {
 	if (policy == SCHED_FIFO) {
 		/* COOP: highest [-CONFIG_NUM_COOP_PRIORITIES, -1] lowest */

--- a/lib/posix/pthread.c
+++ b/lib/posix/pthread.c
@@ -230,7 +230,7 @@ static bool is_posix_policy_prio_valid(uint32_t priority, int policy)
 static uint32_t zephyr_to_posix_priority(int32_t z_prio, int *policy)
 {
 	if (z_prio < 0) {
-		__ASSERT_NO_MSG(z_prio < CONFIG_NUM_COOP_PRIORITIES);
+		__ASSERT_NO_MSG(-z_prio <= CONFIG_NUM_COOP_PRIORITIES);
 	} else {
 		__ASSERT_NO_MSG(z_prio < CONFIG_NUM_PREEMPT_PRIORITIES);
 	}


### PR DESCRIPTION
If `z_prio` is negative and we want to make sure that it is
within `[-CONFIG_NUM_COOP_PRIORITIES, -1]`, we should invert
its sign and make sure that it is `<=`
`CONFIG_NUM_COOP_PRIORITIES` instead of `<`.

Changed the variable type of the priority in the args and the
return type of the conversion functions to `int`, as both
Zephyr's priority & POSIX's `sched_priority` has type `int`.

Made the conversion functions non-static and added ztests for
them to make sure that they work across the full range of
Zephyr priorities.