### PR TITLE
net: shell: Require float printf support from libc

### DIFF
--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -165,6 +165,7 @@ config NET_SHELL
 	select SHELL
 	select NET_IPV4_IGMP if NET_IPV4
 	select NET_IPV6_MLD if NET_IPV6
+	select REQUIRES_FLOAT_PRINTF
 	help
 	  Activate shell module that provides network commands like
 	  ping to the console.


### PR DESCRIPTION
Various network shell commands like ping need floating point support from libc so select the CONFIG_REQUIRES_FLOAT_PRINTF option for it.

Fixes #67601