### PR TITLE
Bluetooth: GATT: Add missing busy check for auto discover CCC

### DIFF
--- a/include/zephyr/bluetooth/gatt.h
+++ b/include/zephyr/bluetooth/gatt.h
@@ -1896,6 +1896,11 @@ struct bt_gatt_subscribe_params {
  *  Allow a pending request to resolve before retrying, or call this function
  *  outside the BT RX thread to get blocking behavior. Queue size is controlled
  *  by @kconfig{CONFIG_BT_ATT_TX_COUNT}.
+ *
+ *  @retval -EALREADY if there already exist a subscription using the @p params.
+ *
+ *  @retval -EBUSY if @p params.ccc_handle is 0 and @kconfig{CONFIG_BT_GATT_AUTO_DISCOVER_CCC} is
+ *  enabled and discovery for the @p params is already in progress.
  */
 int bt_gatt_subscribe(struct bt_conn *conn,
 		      struct bt_gatt_subscribe_params *params);

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -5294,6 +5294,13 @@ int bt_gatt_subscribe(struct bt_conn *conn,
 		return -ENOMEM;
 	}
 
+#if defined(CONFIG_BT_GATT_AUTO_DISCOVER_CCC)
+	if (params->disc_params != NULL && params->disc_params->func == gatt_ccc_discover_cb) {
+		/* Already in progress */
+		return -EBUSY;
+	}
+#endif
+
 	/* Lookup existing subscriptions */
 	SYS_SLIST_FOR_EACH_CONTAINER(&sub->list, tmp, node) {
 		/* Fail if entry already exists */


### PR DESCRIPTION
When using the auto discover CCC, and the function is called more than once with the same parameters before the previous discovery has completed, then that may cause issues when we reset the parameters when we get the response.

This commit adds a small check for the callback function which is only set to the specified function when the discovery is in progress. This way we can return an error if the application calls bt_gatt_subscribe multiple times before the previous discovery has completed, rather than asserting.