### PR TITLE
Implement TRANSMIT_IDLE event for modem CMUX module

### DIFF
--- a/subsys/modem/modem_cmux.c
+++ b/subsys/modem/modem_cmux.c
@@ -881,7 +881,7 @@ static void modem_cmux_transmit_handler(struct k_work *item)
 
 		ring_buf_get_finish(&cmux->transmit_rb, (uint32_t)ret);
 
-		if (ret == 0) {
+		if (ret < reserved_size) {
 			break;
 		}
 	}

--- a/tests/subsys/modem/modem_cmux/src/main.c
+++ b/tests/subsys/modem/modem_cmux/src/main.c
@@ -17,12 +17,16 @@
 /*************************************************************************************************/
 /*                                         Definitions                                           */
 /*************************************************************************************************/
-#define EVENT_CMUX_CONNECTED	BIT(0)
-#define EVENT_CMUX_DLCI1_OPEN	BIT(1)
-#define EVENT_CMUX_DLCI2_OPEN	BIT(2)
-#define EVENT_CMUX_DLCI1_CLOSED BIT(3)
-#define EVENT_CMUX_DLCI2_CLOSED BIT(4)
-#define EVENT_CMUX_DISCONNECTED BIT(5)
+#define EVENT_CMUX_CONNECTED		BIT(0)
+#define EVENT_CMUX_DLCI1_OPEN		BIT(1)
+#define EVENT_CMUX_DLCI2_OPEN		BIT(2)
+#define EVENT_CMUX_DLCI1_RECEIVE_READY	BIT(3)
+#define EVENT_CMUX_DLCI1_TRANSMIT_IDLE	BIT(4)
+#define EVENT_CMUX_DLCI2_RECEIVE_READY	BIT(5)
+#define EVENT_CMUX_DLCI2_TRANSMIT_IDLE	BIT(6)
+#define EVENT_CMUX_DLCI1_CLOSED		BIT(7)
+#define EVENT_CMUX_DLCI2_CLOSED		BIT(8)
+#define EVENT_CMUX_DISCONNECTED		BIT(9)
 
 /*************************************************************************************************/
 /*                                          Instances                                            */
@@ -59,6 +63,14 @@ static void test_modem_dlci1_pipe_callback(struct modem_pipe *pipe, enum modem_p
 		k_event_post(&cmux_event, EVENT_CMUX_DLCI1_OPEN);
 		break;
 
+	case MODEM_PIPE_EVENT_RECEIVE_READY:
+		k_event_post(&cmux_event, EVENT_CMUX_DLCI1_RECEIVE_READY);
+		break;
+
+	case MODEM_PIPE_EVENT_TRANSMIT_IDLE:
+		k_event_post(&cmux_event, EVENT_CMUX_DLCI1_TRANSMIT_IDLE);
+		break;
+
 	case MODEM_PIPE_EVENT_CLOSED:
 		k_event_post(&cmux_event, EVENT_CMUX_DLCI1_CLOSED);
 		break;
@@ -74,6 +86,14 @@ static void test_modem_dlci2_pipe_callback(struct modem_pipe *pipe, enum modem_p
 	switch (event) {
 	case MODEM_PIPE_EVENT_OPENED:
 		k_event_post(&cmux_event, EVENT_CMUX_DLCI2_OPEN);
+		break;
+
+	case MODEM_PIPE_EVENT_RECEIVE_READY:
+		k_event_post(&cmux_event, EVENT_CMUX_DLCI2_RECEIVE_READY);
+		break;
+
+	case MODEM_PIPE_EVENT_TRANSMIT_IDLE:
+		k_event_post(&cmux_event, EVENT_CMUX_DLCI2_TRANSMIT_IDLE);
 		break;
 
 	case MODEM_PIPE_EVENT_CLOSED:
@@ -300,6 +320,7 @@ static void test_modem_cmux_before(void *f)
 ZTEST(modem_cmux, test_modem_cmux_receive_dlci2_at)
 {
 	int ret;
+	uint32_t events;
 
 	modem_backend_mock_put(&bus_mock, cmux_frame_dlci2_at_cgdcont,
 			       sizeof(cmux_frame_dlci2_at_cgdcont));
@@ -308,6 +329,10 @@ ZTEST(modem_cmux, test_modem_cmux_receive_dlci2_at)
 			       sizeof(cmux_frame_dlci2_at_newline));
 
 	k_msleep(100);
+
+	events = k_event_test(&cmux_event, EVENT_CMUX_DLCI2_RECEIVE_READY);
+	zassert_equal(events, EVENT_CMUX_DLCI2_RECEIVE_READY,
+		      "Receive ready event not received for DLCI2 pipe");
 
 	ret = modem_pipe_receive(dlci2_pipe, buffer2, sizeof(buffer2));
 	zassert_true(ret == (sizeof(cmux_frame_data_dlci2_at_cgdcont) +
@@ -327,12 +352,17 @@ ZTEST(modem_cmux, test_modem_cmux_receive_dlci2_at)
 ZTEST(modem_cmux, test_modem_cmux_receive_dlci1_at)
 {
 	int ret;
+	uint32_t events;
 
 	modem_backend_mock_put(&bus_mock, cmux_frame_dlci1_at_at, sizeof(cmux_frame_dlci1_at_at));
 	modem_backend_mock_put(&bus_mock, cmux_frame_dlci1_at_newline,
 			       sizeof(cmux_frame_dlci1_at_newline));
 
 	k_msleep(100);
+
+	events = k_event_test(&cmux_event, EVENT_CMUX_DLCI1_RECEIVE_READY);
+	zassert_equal(events, EVENT_CMUX_DLCI1_RECEIVE_READY,
+		      "Receive ready event not received for DLCI1 pipe");
 
 	ret = modem_pipe_receive(dlci1_pipe, buffer1, sizeof(buffer1));
 	zassert_true(ret == (sizeof(cmux_frame_data_dlci1_at_at) +
@@ -352,11 +382,16 @@ ZTEST(modem_cmux, test_modem_cmux_receive_dlci1_at)
 ZTEST(modem_cmux, test_modem_cmux_receive_dlci2_ppp)
 {
 	int ret;
+	uint32_t events;
 
 	modem_backend_mock_put(&bus_mock, cmux_frame_dlci2_ppp_52, sizeof(cmux_frame_dlci2_ppp_52));
 	modem_backend_mock_put(&bus_mock, cmux_frame_dlci2_ppp_18, sizeof(cmux_frame_dlci2_ppp_18));
 
 	k_msleep(100);
+
+	events = k_event_test(&cmux_event, EVENT_CMUX_DLCI2_RECEIVE_READY);
+	zassert_equal(events, EVENT_CMUX_DLCI2_RECEIVE_READY,
+		      "Receive ready event not received for DLCI2 pipe");
 
 	ret = modem_pipe_receive(dlci2_pipe, buffer2, sizeof(buffer2));
 	zassert_true(ret == (sizeof(cmux_frame_data_dlci2_ppp_52) +
@@ -376,17 +411,25 @@ ZTEST(modem_cmux, test_modem_cmux_receive_dlci2_ppp)
 ZTEST(modem_cmux, test_modem_cmux_transmit_dlci2_ppp)
 {
 	int ret;
+	uint32_t events;
 
 	ret = modem_pipe_transmit(dlci2_pipe, cmux_frame_data_dlci2_ppp_52,
 				  sizeof(cmux_frame_data_dlci2_ppp_52));
-
 	zassert_true(ret == sizeof(cmux_frame_data_dlci2_ppp_52), "Failed to send DLCI2 PPP 52");
+
+	events = k_event_wait(&cmux_event, EVENT_CMUX_DLCI2_TRANSMIT_IDLE, false, K_MSEC(200));
+	zassert_equal(events, EVENT_CMUX_DLCI2_TRANSMIT_IDLE,
+		      "Transmit idle event not received for DLCI2 pipe");
+
+	k_event_clear(&cmux_event, EVENT_CMUX_DLCI2_TRANSMIT_IDLE);
+
 	ret = modem_pipe_transmit(dlci2_pipe, cmux_frame_data_dlci2_ppp_18,
 				  sizeof(cmux_frame_data_dlci2_ppp_18));
-
 	zassert_true(ret == sizeof(cmux_frame_data_dlci2_ppp_18), "Failed to send DLCI2 PPP 18");
 
-	k_msleep(100);
+	events = k_event_wait(&cmux_event, EVENT_CMUX_DLCI2_TRANSMIT_IDLE, false, K_MSEC(200));
+	zassert_equal(events, EVENT_CMUX_DLCI2_TRANSMIT_IDLE,
+		      "Transmit idle event not received for DLCI2 pipe");
 
 	ret = modem_backend_mock_get(&bus_mock, buffer2, sizeof(buffer2));
 	zassert_true(ret == (sizeof(cmux_frame_dlci2_ppp_52) + sizeof(cmux_frame_dlci2_ppp_18)),


### PR DESCRIPTION
* Refactor modem CMUX module to use the TRANSMIT_IDLE event to manage calls to `modem_pipe_transmit()` instead of blind polling.
* Add propagation of `TRANSMIT_IDLE` event to all DLCI channel pipes.
* Update modem CMUX test suite to implement `TRANSMIT_IDLE` event.
