### PR TITLE
scripts: set_maintainer: fix author == maintainer fallback logic

### DIFF
--- a/scripts/set_assignees.py
+++ b/scripts/set_assignees.py
@@ -146,7 +146,7 @@ def process_pr(gh, maintainer_file, number):
         log("Submitter is same as Assignee, trying to find another assignee...")
         aff = list(area_counter.keys())[0]
         for area in all_areas:
-            if area.name == aff:
+            if area == aff:
                 if len(area.maintainers) > 1:
                     assignee = area.maintainers[1]
                 else:


### PR DESCRIPTION
The "Submitter is same as Assignee" is comparing strings to <Area> and always failing the condition, fix it by dropping the ".name".

Tested with ./scripts/set_assignees.py -v -y -P 67526 (now falls back to the other maintainer as it should).