### PR TITLE
drivers: gpio_mcux_lpc: Fix xt-clang error

### DIFF
--- a/drivers/gpio/gpio_mcux_lpc.c
+++ b/drivers/gpio/gpio_mcux_lpc.c
@@ -44,7 +44,6 @@ struct gpio_mcux_lpc_config {
 	IOCON_Type *pinmux_base;
 #endif
 	uint32_t port_no;
-	clock_ip_name_t clock_ip_name;
 };
 
 struct gpio_mcux_lpc_data {
@@ -381,7 +380,6 @@ static int gpio_mcux_lpc_manage_cb(const struct device *port,
 static int gpio_mcux_lpc_init(const struct device *dev)
 {
 	const struct gpio_mcux_lpc_config *config = dev->config;
-
 	GPIO_PortInit(config->gpio_base, config->port_no);
 
 	return 0;
@@ -398,7 +396,7 @@ static const struct gpio_driver_api gpio_mcux_lpc_driver_api = {
 	.manage_callback = gpio_mcux_lpc_manage_cb,
 };
 
-static const clock_ip_name_t gpio_clock_names[] = GPIO_CLOCKS;
+
 
 #ifdef IOPCTL
 #define PINMUX_BASE	IOPCTL
@@ -429,8 +427,7 @@ static const clock_ip_name_t gpio_clock_names[] = GPIO_CLOCKS;
 		.gpio_base = GPIO,							\
 		.pinmux_base = PINMUX_BASE,						\
 		.int_source = DT_INST_ENUM_IDX(n, int_source),				\
-		.port_no = DT_INST_PROP(n, port),					\
-		.clock_ip_name = gpio_clock_names[DT_INST_PROP(n, port)],		\
+		.port_no = DT_INST_PROP(n, port)					\
 	};										\
 											\
 	static struct gpio_mcux_lpc_data gpio_mcux_lpc_data_##n;			\


### PR DESCRIPTION
Remove `gpio_clock_names` and `gpio_mcux_lpc_config->clock_ip_name` from `drivers/gpio/gpio_mcux_lpc.c`.

The `drivers/gpio/gpio_mcux_lpc.c` file did not compile with `xt-clang` `RI-2021.8-win32`, as the `gpio_clock_names` was initialised with a reference to a static const array. The `clock_ip_name` member was initialised from this variable, but it isn't used anywhere else.

Cherry-picked from https://github.com/zephyrproject-rtos/zephyr/pull/65229.