### PR TITLE
drivers: gnss: match: Change RMC/GGA sync from timeout to UTC

### DIFF
--- a/drivers/gnss/gnss_nmea0183_match.h
+++ b/drivers/gnss/gnss_nmea0183_match.h
@@ -49,11 +49,9 @@ struct gnss_nmea0183_match_data {
 	uint16_t satellites_size;
 	uint16_t satellites_length;
 #endif
-	int64_t timestamp;
-	uint16_t timeout_ms;
-	uint8_t gga_received : 1;
-	uint8_t rmc_received : 1;
-	uint8_t gsv_message_number : 6;
+	uint32_t gga_utc;
+	uint32_t rmc_utc;
+	uint8_t gsv_message_number;
 };
 
 /** GNSS NMEA0183 match configuration structure */
@@ -66,8 +64,6 @@ struct gnss_nmea0183_match_config {
 	/** Number of elements in buffer for parsed satellites */
 	uint16_t satellites_size;
 #endif
-	/** The maximum time from the first to the last NMEA0183 message of a fix */
-	uint16_t timeout_ms;
 };
 
 /**

--- a/drivers/gnss/gnss_nmea_generic.c
+++ b/drivers/gnss/gnss_nmea_generic.c
@@ -29,7 +29,6 @@ LOG_MODULE_REGISTER(gnss_nmea_generic, CONFIG_GNSS_LOG_LEVEL);
 
 struct gnss_nmea_generic_config {
 	const struct device *uart;
-	uint16_t nmea_timeout_ms;
 };
 
 struct gnss_nmea_generic_data {
@@ -83,7 +82,6 @@ static struct gnss_driver_api gnss_api = {
 
 static int gnss_nmea_generic_init_nmea0183_match(const struct device *dev)
 {
-	const struct gnss_nmea_generic_config *cfg = dev->config;
 	struct gnss_nmea_generic_data *data = dev->data;
 
 	const struct gnss_nmea0183_match_config match_config = {
@@ -92,7 +90,6 @@ static int gnss_nmea_generic_init_nmea0183_match(const struct device *dev)
 		.satellites = data->satellites,
 		.satellites_size = ARRAY_SIZE(data->satellites),
 #endif
-		.timeout_ms = cfg->nmea_timeout_ms,
 	};
 
 	return gnss_nmea0183_match_init(&data->match_data, &match_config);
@@ -163,7 +160,6 @@ static int gnss_nmea_generic_init(const struct device *dev)
 #define GNSS_NMEA_GENERIC(inst)								\
 	static struct gnss_nmea_generic_config gnss_nmea_generic_cfg_##inst = {		\
 		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),				\
-		.nmea_timeout_ms = DT_INST_PROP(inst, nmea_timeout_ms),			\
 	};										\
 											\
 	static struct gnss_nmea_generic_data gnss_nmea_generic_data_##inst;		\

--- a/drivers/gnss/gnss_quectel_lcx6g.c
+++ b/drivers/gnss/gnss_quectel_lcx6g.c
@@ -649,7 +649,6 @@ static int quectel_lcx6g_init_nmea0183_match(const struct device *dev)
 		.satellites = data->satellites,
 		.satellites_size = ARRAY_SIZE(data->satellites),
 #endif
-		.timeout_ms = 50,
 	};
 
 	return gnss_nmea0183_match_init(&data->match_data, &config);

--- a/dts/bindings/gnss/gnss-nmea-generic.yaml
+++ b/dts/bindings/gnss/gnss-nmea-generic.yaml
@@ -20,13 +20,3 @@ compatible: "gnss-nmea-generic"
 
 include:
   - uart-device.yaml
-
-properties:
-  nmea-timeout-ms:
-    type: int
-    default: 500
-    description: |
-      Synchronization timeout for NMEA sentences. The NMEA parser is expecting
-      to receive a GGA and RMC sentences within this time frame to publish a
-      location data. Set accordingly to the UART datarate and location
-      reporting frequency. Defaults to 500ms if unspecified.


### PR DESCRIPTION
Change the synchronization of RMC and GGA NMEA messages from a timeout to matching their UTC timestamps.