### PR TITLE
scripts: tests: Blackbox - make clear_log fixture autouse

### DIFF
--- a/scripts/tests/twister_blackbox/conftest.py
+++ b/scripts/tests/twister_blackbox/conftest.py
@@ -24,6 +24,7 @@ sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts"))
 testsuite_filename_mock = mock.PropertyMock(return_value='test_data.yaml')
 
 def pytest_configure(config):
+    config.addinivalue_line("markers", "noclearlog: disable the clear_log autouse fixture")
     config.addinivalue_line("markers", "noclearout: disable the provide_out autouse fixture")
 
 @pytest.fixture(name='zephyr_base')
@@ -35,8 +36,13 @@ def zephyr_base_directory():
 def zephyr_test_directory():
     return TEST_DATA
 
-@pytest.fixture
-def clear_log():
+@pytest.fixture(autouse=True)
+def clear_log(request):
+    # As this fixture is autouse, one can use the pytest.mark.noclearlog decorator
+    # in order to be sure that this fixture's code will not fire.
+    if 'noclearlog' in request.keywords:
+        return
+
     # clear_log is used by pytest fixture
     # However, clear_log_in_test is prepared to be used directly in the code, wherever required
     clear_log_in_test()

--- a/scripts/tests/twister_blackbox/test_error.py
+++ b/scripts/tests/twister_blackbox/test_error.py
@@ -39,7 +39,6 @@ class TestError:
     def teardown_class(cls):
         pass
 
-    @pytest.mark.usefixtures("clear_log")
     @pytest.mark.parametrize(
         'test, expected_exception',
         TESTDATA_1,

--- a/scripts/tests/twister_blackbox/test_printouts.py
+++ b/scripts/tests/twister_blackbox/test_printouts.py
@@ -167,7 +167,6 @@ class TestPrintOuts:
         assert expected in out
         assert str(sys_exit.value) == '0'
 
-    @pytest.mark.usefixtures("clear_log")
     @pytest.mark.parametrize(
         'test_path, test_platforms',
         TESTDATA_4,
@@ -204,7 +203,6 @@ class TestPrintOuts:
             assert False, f'No timestamp in line {err_lines}'
         assert str(sys_exit.value) == '0'
 
-    @pytest.mark.usefixtures("clear_log")
     @pytest.mark.parametrize(
         'flag',
         ['--abcd', '--1234', '-%', '-1']
@@ -226,7 +224,6 @@ class TestPrintOuts:
         else:
             assert str(sys_exit.value) == '2'
 
-    @pytest.mark.usefixtures("clear_log")
     @pytest.mark.parametrize(
         'flag',
         ['--help', '-h']

--- a/scripts/tests/twister_blackbox/test_testplan.py
+++ b/scripts/tests/twister_blackbox/test_testplan.py
@@ -53,7 +53,6 @@ class TestTestPlan:
     def teardown_class(cls):
         pass
 
-    @pytest.mark.usefixtures("clear_log")
     @pytest.mark.parametrize(
         'level, expected_tests',
         TESTDATA_1,
@@ -86,7 +85,6 @@ class TestTestPlan:
 
         assert expected_tests == len(filtered_j)
 
-    @pytest.mark.usefixtures("clear_log")
     @pytest.mark.parametrize(
         'test, expected_exception, expected_subtest_count',
         TESTDATA_2,
@@ -120,8 +118,6 @@ class TestTestPlan:
         assert str(exc.value) == '0'
         assert len(filtered_j) == expected_subtest_count
 
-
-    @pytest.mark.usefixtures("clear_log")
     @pytest.mark.parametrize(
         'filter, expected_count',
         TESTDATA_3,
@@ -152,7 +148,6 @@ class TestTestPlan:
 
         assert expected_count == len(filtered_j)
 
-    @pytest.mark.usefixtures("clear_log")
     @pytest.mark.parametrize(
         'integration, expected_count',
         TESTDATA_4,


### PR DESCRIPTION
`clear_log` fixture is used to prevent a common pytest log error, which makes logs unusable in testing.
Such a fix is useful for all tests, so it should be `autouse` by default.

NOTE:
If PR https://github.com/zephyrproject-rtos/zephyr/pull/67772 or https://github.com/zephyrproject-rtos/zephyr/pull/67613 is merged first, this one will probably need changes.