### PR TITLE
native boards: Add kconfig option to provide cmdline arguments from kconfig

### DIFF
--- a/boards/posix/common/extra_args/CMakeLists.txt
+++ b/boards/posix/common/extra_args/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if (CONFIG_NATIVE_EXTRA_CMDLINE_ARGS)
+	zephyr_library()
+	zephyr_library_sources(extra_args.c)
+endif()

--- a/boards/posix/common/extra_args/Kconfig
+++ b/boards/posix/common/extra_args/Kconfig
@@ -1,0 +1,9 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+config NATIVE_EXTRA_CMDLINE_ARGS
+	depends on ARCH_POSIX
+	string "Extra command line arguments"
+	help
+	  Extra command line options/arguments which will be handled like if they were passed to the
+	  program from the shell. These will be parsed just before the shell provided ones.

--- a/boards/posix/common/extra_args/extra_args.c
+++ b/boards/posix/common/extra_args/extra_args.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stddef.h>
+#include <ctype.h>
+#include <zephyr/toolchain.h>
+#include <posix_native_task.h>
+#include <nsi_cmdline_main_if.h>
+#include <nsi_host_trampolines.h>
+#include <nsi_tracing.h>
+
+static void remove_one_char(char *str)
+{
+	int i;
+
+	for (i = 0; str[i] != 0; i++) {
+		str[i] = str[i+1];
+	}
+}
+
+static void register_kconfig_args(void)
+{
+	static char kconfig_args[] = CONFIG_NATIVE_EXTRA_CMDLINE_ARGS;
+	int argc = 0;
+	char **argv = NULL;
+#define REALLOC_INC 100
+	int alloced = 0;
+	bool new_arg = true, literal = false, escape = false;
+
+	if (kconfig_args[0] == 0) {
+		return;
+	}
+
+	for (int i = 0; kconfig_args[i] != 0; i++) {
+		if ((literal == false) && (escape == false) && isspace(kconfig_args[i])) {
+			new_arg = true;
+			kconfig_args[i] = 0;
+			continue;
+		}
+		if ((escape == false) && (kconfig_args[i] == '\\')) {
+			escape = true;
+			remove_one_char(&kconfig_args[i]);
+			i--;
+			continue;
+		}
+		if ((escape == false) && (kconfig_args[i] == '"')) {
+			literal = !literal;
+			remove_one_char(&kconfig_args[i]);
+			i--;
+			continue;
+		}
+		escape = false;
+
+		if (new_arg) {
+			new_arg = false;
+			if (argc >= alloced) {
+				alloced += REALLOC_INC;
+				argv = nsi_host_realloc(argv, alloced*sizeof(char *));
+				if (argv == NULL) {
+					nsi_print_error_and_exit("Out of memory\n");
+				}
+			}
+			argv[argc++] = &kconfig_args[i];
+		}
+	}
+
+	nsi_register_extra_args(argc, argv);
+
+	nsi_host_free(argv);
+}
+
+NATIVE_TASK(register_kconfig_args, PRE_BOOT_1, 100);

--- a/boards/posix/native_sim/CMakeLists.txt
+++ b/boards/posix/native_sim/CMakeLists.txt
@@ -27,6 +27,10 @@ if(CONFIG_HAS_SDL)
   add_subdirectory(${ZEPHYR_BASE}/boards/${ARCH}/common/sdl/ ${CMAKE_CURRENT_BINARY_DIR}/sdl)
 endif()
 
+add_subdirectory(${ZEPHYR_BASE}/boards/${ARCH}/common/extra_args/
+	${CMAKE_CURRENT_BINARY_DIR}/extra_args
+)
+
 set(nsi_config_content
   ${nsi_config_content}
   "NSI_NATIVE=1"

--- a/boards/posix/native_sim/Kconfig
+++ b/boards/posix/native_sim/Kconfig
@@ -46,5 +46,6 @@ config NATIVE_POSIX_SLOWDOWN_TO_REAL_TIME
 	  to set the correct native_sim option (CONFIG_NATIVE_SIM_SLOWDOWN_TO_REAL_TIME)
 
 source "boards/$(ARCH)/common/sdl/Kconfig"
+source "boards/$(ARCH)/common/extra_args/Kconfig"
 
 endif # BOARD_NATIVE_SIM

--- a/boards/posix/nrf_bsim/CMakeLists.txt
+++ b/boards/posix/nrf_bsim/CMakeLists.txt
@@ -73,4 +73,8 @@ set_property(TARGET native_simulator APPEND PROPERTY RUNNER_LINK_LIBRARIES
 target_compile_options(native_simulator INTERFACE
                        "-DNSI_PRIMARY_MCU_N=${CONFIG_NATIVE_SIMULATOR_PRIMARY_MCU_INDEX}")
 
+add_subdirectory(${ZEPHYR_BASE}/boards/${ARCH}/common/extra_args/
+	${CMAKE_CURRENT_BINARY_DIR}/extra_args
+)
+
 include(../common/natsim_config.cmake)

--- a/boards/posix/nrf_bsim/Kconfig
+++ b/boards/posix/nrf_bsim/Kconfig
@@ -8,6 +8,8 @@ if SOC_SERIES_BSIM_NRFXX
 # must be read also from here.
 source "soc/arm/nordic_nrf/Kconfig.peripherals"
 
+source "boards/$(ARCH)/common/extra_args/Kconfig"
+
 endif # SOC_SERIES_BSIM_NRFXX
 
 

--- a/scripts/native_simulator/common/src/include/nsi_cmdline_main_if.h
+++ b/scripts/native_simulator/common/src/include/nsi_cmdline_main_if.h
@@ -18,6 +18,7 @@ extern "C" {
 #endif
 
 void nsi_handle_cmd_line(int argc, char *argv[]);
+void nsi_register_extra_args(int argc, char *argv[]);
 
 #ifdef __cplusplus
 }

--- a/scripts/native_simulator/common/src/include/nsi_host_trampolines.h
+++ b/scripts/native_simulator/common/src/include/nsi_host_trampolines.h
@@ -33,6 +33,7 @@ int nsi_host_open(const char *pathname, int flags);
 /* int nsi_host_printf (const char *fmt, ...); Use the nsi_tracing.h equivalents */
 long nsi_host_random(void);
 long nsi_host_read(int fd, void *buffer, unsigned long size);
+void *nsi_host_realloc(void *ptr, unsigned long size);
 void nsi_host_srandom(unsigned int seed);
 char *nsi_host_strdup(const char *s);
 long nsi_host_write(int fd, void *buffer, unsigned long size);

--- a/scripts/native_simulator/common/src/nsi_host_trampolines.c
+++ b/scripts/native_simulator/common/src/nsi_host_trampolines.c
@@ -56,6 +56,11 @@ long nsi_host_read(int fd, void *buffer, unsigned long size)
 	return read(fd, buffer, size);
 }
 
+void *nsi_host_realloc(void *ptr, unsigned long size)
+{
+	return realloc(ptr, size);
+}
+
 void nsi_host_srandom(unsigned int seed)
 {
 	srandom(seed);


### PR DESCRIPTION
Add an extra kconfig option (and related code) with which it becomes possible to define in kconfig command line options which will be parsed together with the shell provided command line options.
These kconfig provided options are parsed *before* the shell provided command line options, so they can still be overridden by the user when invoking the program.
This can be used for tests or similar apps where one would like having an easy way of switching defaults or setting options which otherwise are only accessible via the command line, but where passing command line options is not easy (for example in twister when running a run with other boards).

As part of this, update the native_simulator to align it with the latest version (which includes as a freebie a new host trampoline for realloc)