### PR TITLE
kernel: Add ROUND2_UP() and ROUND2_DOWN() macros

### DIFF
--- a/include/zephyr/linker/thread-local-storage.ld
+++ b/include/zephyr/linker/thread-local-storage.ld
@@ -24,14 +24,14 @@
 #else
 	PROVIDE(__tdata_start = ADDR(tdata));
 #endif
-	PROVIDE(__tdata_size = SIZEOF(tdata));
-	PROVIDE(__tdata_end = __tdata_start + __tdata_size);
 	PROVIDE(__tdata_align = ALIGNOF(tdata));
+	PROVIDE(__tdata_size = (SIZEOF(tdata) + __tdata_align - 1) & ~(__tdata_align - 1));
+	PROVIDE(__tdata_end = __tdata_start + __tdata_size);
 
-	PROVIDE(__tbss_start = ADDR(tbss));
-	PROVIDE(__tbss_size = SIZEOF(tbss));
-	PROVIDE(__tbss_end = __tbss_start + __tbss_size);
 	PROVIDE(__tbss_align = ALIGNOF(tbss));
+	PROVIDE(__tbss_start = ADDR(tbss));
+	PROVIDE(__tbss_size = (SIZEOF(tbss) + __tbss_align - 1) & ~(__tbss_align - 1));
+	PROVIDE(__tbss_end = __tbss_start + __tbss_size);
 
 	PROVIDE(__tls_start = __tdata_start);
 	PROVIDE(__tls_end = __tbss_end);

--- a/kernel/include/kernel_tls.h
+++ b/kernel/include/kernel_tls.h
@@ -28,10 +28,8 @@
  */
 static inline size_t z_tls_data_size(void)
 {
-	size_t tdata_size = ROUND_UP(__tdata_size, __tdata_align);
-	size_t tbss_size = ROUND_UP(__tbss_size, __tbss_align);
-
-	return tdata_size + tbss_size;
+	return (size_t)(uintptr_t)__tdata_size +
+	       (size_t)(uintptr_t)__tbss_size;
 }
 
 /**
@@ -44,15 +42,12 @@ static inline size_t z_tls_data_size(void)
  */
 static inline void z_tls_copy(char *dest)
 {
-	size_t tdata_size = (size_t)__tdata_size;
-	size_t tbss_size = (size_t)__tbss_size;
-
 	/* Copy initialized data (tdata) */
-	memcpy(dest, __tdata_start, tdata_size);
+	memcpy(dest, __tdata_start, (size_t)(uintptr_t)__tdata_size);
 
 	/* Clear BSS data (tbss) */
-	dest += ROUND_UP(tdata_size, __tdata_align);
-	memset(dest, 0, tbss_size);
+	dest += (size_t)(uintptr_t)__tdata_size;
+	memset(dest, 0, (size_t)(uintptr_t)__tbss_size);
 }
 
 #endif /* ZEPHYR_KERNEL_INCLUDE_KERNEL_TLS_H_ */


### PR DESCRIPTION
Fixes #66454

Current Summary
==============
Re-worked this PR to just update __tdata_xx and __tbss_xx linker variables instead of trying to go the ROUND_UP/ROUND_DOWN() route (whose summary follows just for reference). Instead of rounding up __tdata_size and __tbss_size at runtime each time arch_tls_stack_setup() is called, the round up calculation has been moved into the linker script thread-local-storage.ld so that we do not need to perform the calculation at runtime at all.


Old Obsolete Summary
===================
Changed to ROUND2_UP and ROUND2_DOWN() (the ALIGN_xx names were already in use in sub-modules). 

Add new macros ROUND2_UP() and ROUND2_DOWN() that are similar to ROUND_UP() and ROUND_DOWN().

The significant difference between them is that unlike the ROUND_xx() macros, the ROUND2_xx() macros are restricted to alignments that are a power of two. (The ROUND_xx() macros used to be this way, but changed to allow arbitrary integer rounding mid 2023).

Whenever the alignment is both a power of two and a constant, then there ought to be no difference in the generated code when comparing ROUND2_xx() to ROUND_xx(). However, when the alignment is both a power of two and a variable, then the ROUND2_xx() macros can be expected to generate better performing code than the generic ROUND_xx() macros.

