### PR TITLE
mgmt: mcumgr: transport: smp_udp: Fix error when message too large

### DIFF
--- a/doc/releases/release-notes-3.6.rst
+++ b/doc/releases/release-notes-3.6.rst
@@ -325,6 +325,9 @@ Libraries / Subsystems
   * Fixed an issue whereby the ``mcuboot erase`` DFU shell command could be used to erase the
     MCUboot or currently running application slot.
 
+  * Fixed an issue whereby messages that were too large to be sent over the UDP transport would
+    wrongly return :c:enum:`MGMT_ERR_EINVAL` instead of :c:enum:`MGMT_ERR_EMSGSIZE`.
+
 * File systems
 
 * Modem modules

--- a/subsys/mgmt/mcumgr/transport/src/smp_udp.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp_udp.c
@@ -111,7 +111,11 @@ static int smp_udp4_tx(struct net_buf *nb)
 	ret = sendto(smp_udp_configs.ipv4.sock, nb->data, nb->len, 0, addr, sizeof(*addr));
 
 	if (ret < 0) {
-		ret = MGMT_ERR_EINVAL;
+		if (errno == ENOMEM) {
+			ret = MGMT_ERR_EMSGSIZE;
+		} else {
+			ret = MGMT_ERR_EINVAL;
+		}
 	} else {
 		ret = MGMT_ERR_EOK;
 	}
@@ -131,7 +135,11 @@ static int smp_udp6_tx(struct net_buf *nb)
 	ret = sendto(smp_udp_configs.ipv6.sock, nb->data, nb->len, 0, addr, sizeof(*addr));
 
 	if (ret < 0) {
-		ret = MGMT_ERR_EINVAL;
+		if (errno == ENOMEM) {
+			ret = MGMT_ERR_EMSGSIZE;
+		} else {
+			ret = MGMT_ERR_EINVAL;
+		}
 	} else {
 		ret = MGMT_ERR_EOK;
 	}


### PR DESCRIPTION
    Fixes an issue whereby a message which is too large was attempted
    to be sent via the UDP transport would wrongly give an error in
    value error

Fixes #67675