### PR TITLE
tests: smp_suspend: Tweak duration and timeouts

### DIFF
--- a/tests/kernel/smp_suspend/src/main.c
+++ b/tests/kernel/smp_suspend/src/main.c
@@ -68,7 +68,7 @@ ZTEST(smp_suspend_resume, test_smp_thread_suspend_resume_stress)
 
 	k_thread_resume(&thread[0]);
 
-	for (unsigned int iteration = 0; iteration < 30; iteration++) {
+	for (unsigned int iteration = 0; iteration < 15; iteration++) {
 		k_sleep(K_MSEC(1000));
 
 		for (i = 0; i < NUM_THREADS; i++) {

--- a/tests/kernel/smp_suspend/testcase.yaml
+++ b/tests/kernel/smp_suspend/testcase.yaml
@@ -3,4 +3,5 @@ tests:
     tags:
       - kernel
       - smp
+    timeout: 600
     filter: (CONFIG_MP_MAX_NUM_CPUS > 1)


### PR DESCRIPTION
Reduces the number of seconds that the test runs to 15 seconds (down from 30 seconds). This should still be sufficient time to determine if there is anything amiss with the synchonous thread suspend/resume. Furthermore, the test itself has been tagged as being slow and its timeout increased to 10 minutes (600 seconds) as some simulators are rather slow.