### PR TITLE
docs: lwm2m: fix example x509 CA certificate resource ID

### DIFF
--- a/doc/connectivity/networking/api/lwm2m.rst
+++ b/doc/connectivity/networking/api/lwm2m.rst
@@ -450,7 +450,7 @@ An example of setting up the security object for X509 certificate mode:
 	lwm2m_set_u8(&LWM2M_OBJ(LWM2M_OBJECT_SECURITY_ID, 0, 2), LWM2M_SECURITY_CERT);
 	lwm2m_set_string(&LWM2M_OBJ(LWM2M_OBJECT_SECURITY_ID, 0, 3), certificate);
 	lwm2m_set_string(&LWM2M_OBJ(LWM2M_OBJECT_SECURITY_ID, 0, 5), key);
-	lwm2m_set_string(&LWM2M_OBJ(LWM2M_OBJECT_SECURITY_ID, 0, 5), root_ca);
+	lwm2m_set_string(&LWM2M_OBJ(LWM2M_OBJECT_SECURITY_ID, 0, 4), root_ca);
 
 Before calling :c:func:`lwm2m_rd_client_start` assign the tls_tag # where the
 LwM2M library should store the DTLS information prior to connection (normally a


### PR DESCRIPTION
The example on configuring the LWM2M client for use with x509 certificates uses the wrong resource ID (`0/0/5`) for the "Server Public Key" resource.  
[According to the OMA LWM2M object registry](https://github.com/OpenMobileAlliance/lwm2m-registry/blob/c5abc5f9cbaaa4aaab21abc90be8d2375d92bfc2/0.xml#L117), the correct ID should be `0/0/4`.  

This PR fixes that typo in the current documentation.