### PR TITLE
sensors: shell: support trigger set on more than one sensor

### DIFF
--- a/drivers/sensor/Kconfig
+++ b/drivers/sensor/Kconfig
@@ -68,6 +68,14 @@ config SENSOR_SHELL_TRIG_PRINT_TIMEOUT_MS
 	  Control the frequency of the sampling window over which the sensor
 	  interrupt handler will collect data.
 
+config SENSOR_SHELL_MAX_TRIGGER_DEVICES
+	int "Maximum number of sensor devices that can have enabled triggers in shell"
+	default 1
+	depends on SENSOR_SHELL
+	help
+	  Maximum number of sensor devices that the shell cmd can have
+	  enabled triggers for.
+
 config SENSOR_INFO
 	bool "Sensor Info iterable section"
 


### PR DESCRIPTION
Before, only one sensor device was supported. It
was possible to set a trigger on a second sensor
device, but the filtering of the channel data
would cause no channels from the new sensor
device to be read.

Also in trigger handler log of sampled data, print the sensor name and channel name (instead of channel number).