### PR TITLE
ITE: drivers/gpio: GPIO output extended setting

### DIFF
--- a/dts/bindings/gpio/ite,it8xxx2-gpio-v2.yaml
+++ b/dts/bindings/gpio/ite,it8xxx2-gpio-v2.yaml
@@ -27,6 +27,20 @@ properties:
   wuc-mask:
     type: array
 
+  keyboard-controller:
+    type: boolean
+    description: |
+      When set, this GPIO controller has pins associated with the
+      keyboard controller. In this case the reg_gpcr property is
+      overloaded and used to write the keyboard GCTRL register.
+      This setting will be found in the gpio_ite_configure function
+      when the judgment of gpio_config->ksb_ctrl is true.
+      The GPIO control register that will be set for these three
+      nodes is as follows:
+      gpioksi:  0xf01d40-0xf01d47
+      gpioksol: 0xf01d48-0xf01d4f
+      gpioksoh: 0xf01d50-0xf01d57
+
 gpio-cells:
   - pin
   - flags

--- a/dts/riscv/ite/it82xx2.dtsi
+++ b/dts/riscv/ite/it82xx2.dtsi
@@ -390,6 +390,7 @@
 				      NO_FUNC 0
 				      NO_FUNC 0>;
 			interrupt-parent = <&intc>;
+			keyboard-controller;
 			#gpio-cells = <2>;
 		};
 
@@ -411,6 +412,7 @@
 				      NO_FUNC 0
 				      NO_FUNC 0>;
 			interrupt-parent = <&intc>;
+			keyboard-controller;
 			#gpio-cells = <2>;
 		};
 
@@ -432,6 +434,7 @@
 				      NO_FUNC 0
 				      NO_FUNC 0>;
 			interrupt-parent = <&intc>;
+			keyboard-controller;
 			#gpio-cells = <2>;
 		};
 

--- a/soc/riscv/ite_ec/common/chip_chipregs.h
+++ b/soc/riscv/ite_ec/common/chip_chipregs.h
@@ -1073,6 +1073,11 @@ struct gpio_it8xxx2_regs {
 #define IT8XXX2_GPIO_GPH1VS                BIT(1)
 #define IT8XXX2_GPIO_GPH2VS                BIT(0)
 
+#define KSIX_KSOX_KBS_GPIO_MODE     BIT(7)
+#define KSIX_KSOX_GPIO_OUTPUT       BIT(6)
+#define KSIX_KSOX_GPIO_PULLUP       BIT(2)
+#define KSIX_KSOX_GPIO_PULLDOWN     BIT(1)
+
 #define GPCR_PORT_PIN_MODE_INPUT    BIT(7)
 #define GPCR_PORT_PIN_MODE_OUTPUT   BIT(6)
 #define GPCR_PORT_PIN_MODE_PULLUP   BIT(2)


### PR DESCRIPTION
gpioksi, gpioksoh and gpioksol require extended setting when used as GPIO output.