### PR TITLE
test: mcuboot: enable test on lpc55s platforms

### DIFF
--- a/tests/boot/test_mcuboot/testcase.yaml
+++ b/tests/boot/test_mcuboot/testcase.yaml
@@ -16,6 +16,11 @@ tests:
       - frdm_k22f
       - frdm_k64f
       - frdm_k82f
+      - lpcxpresso55s06
+      - lpcxpresso55s16
+      - lpcxpresso55s28
+      - lpcxpresso55s36
+      - lpcxpresso55s69_cpu0
       - mimxrt1010_evk
       - mimxrt1015_evk
       - mimxrt1020_evk


### PR DESCRIPTION
Enable mcuboot test for lpcxpresso55s06/16/28/36/69 boards.