### PR TITLE
samples: sensor: lps22hb: fix sample document

### DIFF
--- a/samples/sensor/lps22hb/README.rst
+++ b/samples/sensor/lps22hb/README.rst
@@ -1,6 +1,6 @@
 .. _lps22hb:
 
-LPS22HB: Temperature and Humidity Monitor
+LPS22HB: Temperature and Pressure Monitor
 #########################################
 
 Overview


### PR DESCRIPTION
The LPS22HB is a pressure and temperature sensor, but this sample document is wrongly mentioning "humidity".

Fix #66117