### PR TITLE
tests: posix: common: free resource in after() for timer suite

### DIFF
--- a/tests/posix/common/src/timer.c
+++ b/tests/posix/common/src/timer.c
@@ -8,6 +8,7 @@
 #include <unistd.h>
 
 #include <zephyr/ztest.h>
+#include <zephyr/logging/log.h>
 
 #define SECS_TO_SLEEP 2
 #define DURATION_SECS 1
@@ -15,19 +16,23 @@
 #define PERIOD_SECS 0
 #define PERIOD_NSECS 100000000
 
+#define TEST_SIGNAL_VAL SIGTSTP
+
+LOG_MODULE_REGISTER(timer_test);
+
 static int exp_count;
+static timer_t timerid = -1;
 
 void handler(union sigval val)
 {
-	printk("Handler Signal value :%d for %d times\n", val.sival_int,
-	       ++exp_count);
+	++exp_count;
+	LOG_DBG("Handler Signal value %d for %d times", val.sival_int, exp_count);
+	zassert_equal(val.sival_int, TEST_SIGNAL_VAL);
 }
 
 void test_timer(int sigev_notify)
 {
-	int ret;
-	struct sigevent sig = { 0 };
-	timer_t timerid;
+	struct sigevent sig = {0};
 	struct itimerspec value, ovalue;
 	struct timespec ts, te;
 	int64_t nsecs_elapsed, secs_elapsed;
@@ -35,46 +40,28 @@ void test_timer(int sigev_notify)
 	exp_count = 0;
 	sig.sigev_notify = sigev_notify;
 	sig.sigev_notify_function = handler;
-	sig.sigev_value.sival_int = 20;
-
-	if (sigev_notify == SIGEV_SIGNAL)
-		printk("POSIX timer test SIGEV_SIGNAL\n");
-	else
-		printk("POSIX timer test SIGEV_THREAD\n");
-
-	ret = timer_create(CLOCK_MONOTONIC, &sig, &timerid);
+	sig.sigev_value.sival_int = TEST_SIGNAL_VAL;
 
 	/*TESTPOINT: Check if timer is created successfully*/
-	zassert_false(ret, "POSIX timer create failed");
+	zassert_ok(timer_create(CLOCK_MONOTONIC, &sig, &timerid));
 
 	value.it_value.tv_sec = DURATION_SECS;
 	value.it_value.tv_nsec = DURATION_NSECS;
 	value.it_interval.tv_sec = PERIOD_SECS;
 	value.it_interval.tv_nsec = PERIOD_NSECS;
-	ret = timer_settime(timerid, 0, &value, &ovalue);
+	zassert_ok(timer_settime(timerid, 0, &value, &ovalue));
 	usleep(100 * USEC_PER_MSEC);
-	ret = timer_gettime(timerid, &value);
-	zassert_false(ret, "Failed to get time to expire.");
+	/*TESTPOINT: Check if timer has started successfully*/
+	zassert_ok(timer_gettime(timerid, &value));
 
-	if (ret == 0) {
-		printk("Timer fires every %d secs and  %d nsecs\n",
-		       (int) value.it_interval.tv_sec,
-		       (int) value.it_interval.tv_nsec);
-		printk("Time remaining to fire %d secs and  %d nsecs\n",
-		       (int) value.it_value.tv_sec,
-		       (int) value.it_value.tv_nsec);
-	}
+	LOG_DBG("Timer fires every %d secs and  %d nsecs", (int)value.it_interval.tv_sec,
+		(int)value.it_interval.tv_nsec);
+	LOG_DBG("Time remaining to fire %d secs and  %d nsecs", (int)value.it_value.tv_sec,
+		(int)value.it_value.tv_nsec);
 
 	clock_gettime(CLOCK_MONOTONIC, &ts);
-
-	/*TESTPOINT: Check if timer has started successfully*/
-	zassert_false(ret, "POSIX timer failed to start");
-
 	sleep(SECS_TO_SLEEP);
-
 	clock_gettime(CLOCK_MONOTONIC, &te);
-	zassert_equal(ret, 0, "Number of timer overruns is incorrect");
-	timer_delete(timerid);
 
 	if (te.tv_nsec >= ts.tv_nsec) {
 		secs_elapsed = te.tv_sec - ts.tv_sec;
@@ -95,34 +82,44 @@ void test_timer(int sigev_notify)
 		       exp_count, expected_signal_count);
 }
 
-ZTEST(timer, test_timer)
+ZTEST(timer, test_SIGEV_SIGNAL)
 {
 	test_timer(SIGEV_SIGNAL);
+}
+
+ZTEST(timer, test_SIGEV_THREAD)
+{
 	test_timer(SIGEV_THREAD);
 }
 
 ZTEST(timer, test_timer_overrun)
 {
-	timer_t timerid;
 	struct sigevent sig = { 0 };
 	struct itimerspec value;
 
 	sig.sigev_notify = SIGEV_NONE;
 
-	timer_create(CLOCK_MONOTONIC, &sig, &timerid);
+	zassert_ok(timer_create(CLOCK_MONOTONIC, &sig, &timerid));
 
 	/*Set the timer to expire every 500 milliseconds*/
 	value.it_interval.tv_sec = 0;
 	value.it_interval.tv_nsec = 500000000;
 	value.it_value.tv_sec = 0;
 	value.it_value.tv_nsec = 500000000;
-	timer_settime(timerid, 0, &value, NULL);
+	zassert_ok(timer_settime(timerid, 0, &value, NULL));
 	k_sleep(K_MSEC(2500));
 
-	int overruns = timer_getoverrun(timerid);
-
-	timer_delete(timerid);
-	zassert_equal(overruns, 4, "Number of overruns is incorrect");
+	zassert_equal(timer_getoverrun(timerid), 4, "Number of overruns is incorrect");
 }
 
-ZTEST_SUITE(timer, NULL, NULL, NULL, NULL, NULL);
+static void after(void *arg)
+{
+	ARG_UNUSED(arg);
+
+	if (timerid != -1) {
+		(void)timer_delete(timerid);
+		timerid = -1;
+	}
+}
+
+ZTEST_SUITE(timer, NULL, NULL, NULL, after, NULL);


### PR DESCRIPTION
Create a separate ZTEST_SUITE() to properly manage resources that are shared between test cases. Add some assertions where needed. By ensuring we delete any created timers in `after()` the campsite is mostly clean again.

Additionally, we don't need verbose printing in this testsuite, so change `printk()` to `LOG_DBG()`

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/67697