### PR TITLE
twister: fix build dir path for mklink

### DIFF
--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -994,7 +994,7 @@ class TestPlan:
         link_path = os.path.join(links_dir_path, link_name)
 
         if os.name == "nt":  # if OS is Windows
-            command = ["mklink", "/J", f"{link_path}", f"{instance.build_dir}"]
+            command = ["mklink", "/J", f"{link_path}", os.path.normpath(instance.build_dir)]
             subprocess.call(command, shell=True)
         else:  # for Linux and MAC OS
             os.symlink(instance.build_dir, link_path)

--- a/scripts/tests/twister/test_testplan.py
+++ b/scripts/tests/twister/test_testplan.py
@@ -1696,11 +1696,6 @@ TESTDATA_13 = [
     TESTDATA_13,
 )
 def test_testplan_create_build_dir_link(os_name):
-    testplan = TestPlan(env=mock.Mock())
-    links_dir_path = os.path.join('links', 'path')
-    instance_build_dir = os.path.join('some', 'far', 'off', 'build', 'dir')
-    instance = mock.Mock(build_dir=instance_build_dir)
-
     def mock_makedirs(path, exist_ok=False):
         assert exist_ok
         assert path == instance_build_dir
@@ -1714,14 +1709,24 @@ def test_testplan_create_build_dir_link(os_name):
         assert cmd == ['mklink', '/J', os.path.join('links', 'path', 'test_0'),
                        instance_build_dir]
 
+    def mock_join(*paths):
+        slash = "\\" if os.name == 'nt' else "/"
+        return slash.join(paths)
+
     with mock.patch('os.name', os_name), \
          mock.patch('os.symlink', side_effect=mock_symlink), \
          mock.patch('os.makedirs', side_effect=mock_makedirs), \
-         mock.patch('subprocess.call', side_effect=mock_call):
+         mock.patch('subprocess.call', side_effect=mock_call), \
+         mock.patch('os.path.join', side_effect=mock_join):
+
+        testplan = TestPlan(env=mock.Mock())
+        links_dir_path = os.path.join('links', 'path')
+        instance_build_dir = os.path.join('some', 'far', 'off', 'build', 'dir')
+        instance = mock.Mock(build_dir=instance_build_dir)
         testplan._create_build_dir_link(links_dir_path, instance)
 
-    assert instance.build_dir == os.path.join('links', 'path', 'test_0')
-    assert testplan.link_dir_counter == 1
+        assert instance.build_dir == os.path.join('links', 'path', 'test_0')
+        assert testplan.link_dir_counter == 1
 
 
 TESTDATA_14 = [


### PR DESCRIPTION
When twister is run on Windows with --short-build-path option, mklink fails to create link, because path to build dir contains forward slashes, which are not handled correctly by mklink.
Fix it by converting forward slashes to back slashes using os.path.normpath in mklink call. 
Added os.path.join mock in twister unit test to handle path join
consistently.