### PR TITLE
Demote some of Flash API syscalls to ordinary calls

### DIFF
--- a/drivers/flash/flash_handlers.c
+++ b/drivers/flash/flash_handlers.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2024 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -35,54 +36,6 @@ static inline int z_vrfy_flash_erase(const struct device *dev, off_t offset,
 	return z_impl_flash_erase((const struct device *)dev, offset, size);
 }
 #include <syscalls/flash_erase_mrsh.c>
-
-static inline size_t z_vrfy_flash_get_write_block_size(const struct device *dev)
-{
-	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_FLASH));
-	return z_impl_flash_get_write_block_size(dev);
-}
-#include <syscalls/flash_get_write_block_size_mrsh.c>
-
-static inline const struct flash_parameters *z_vrfy_flash_get_parameters(const struct device *dev)
-{
-	K_OOPS(K_SYSCALL_DRIVER_FLASH(dev, get_parameters));
-	return z_impl_flash_get_parameters(dev);
-}
-#include <syscalls/flash_get_parameters_mrsh.c>
-
-#ifdef CONFIG_FLASH_PAGE_LAYOUT
-static inline int z_vrfy_flash_get_page_info_by_offs(const struct device *dev,
-						     off_t offs,
-						     struct flash_pages_info *info)
-{
-	K_OOPS(K_SYSCALL_DRIVER_FLASH(dev, page_layout));
-	K_OOPS(K_SYSCALL_MEMORY_WRITE(info, sizeof(struct flash_pages_info)));
-	return z_impl_flash_get_page_info_by_offs((const struct device *)dev,
-						  offs,
-						  (struct flash_pages_info *)info);
-}
-#include <syscalls/flash_get_page_info_by_offs_mrsh.c>
-
-static inline int z_vrfy_flash_get_page_info_by_idx(const struct device *dev,
-						    uint32_t idx,
-						    struct flash_pages_info *info)
-{
-	K_OOPS(K_SYSCALL_DRIVER_FLASH(dev, page_layout));
-	K_OOPS(K_SYSCALL_MEMORY_WRITE(info, sizeof(struct flash_pages_info)));
-	return z_impl_flash_get_page_info_by_idx((const struct device *)dev,
-						 idx,
-						 (struct flash_pages_info *)info);
-}
-#include <syscalls/flash_get_page_info_by_idx_mrsh.c>
-
-static inline size_t z_vrfy_flash_get_page_count(const struct device *dev)
-{
-	K_OOPS(K_SYSCALL_DRIVER_FLASH(dev, page_layout));
-	return z_impl_flash_get_page_count((const struct device *)dev);
-}
-#include <syscalls/flash_get_page_count_mrsh.c>
-
-#endif /* CONFIG_FLASH_PAGE_LAYOUT */
 
 #ifdef CONFIG_FLASH_JESD216_API
 

--- a/drivers/flash/flash_page_layout.c
+++ b/drivers/flash/flash_page_layout.c
@@ -42,20 +42,20 @@ static int flash_get_page_info(const struct device *dev, off_t offs,
 	return -EINVAL; /* page at offs or idx doesn't exist */
 }
 
-int z_impl_flash_get_page_info_by_offs(const struct device *dev, off_t offs,
+int flash_get_page_info_by_offs(const struct device *dev, off_t offs,
 				       struct flash_pages_info *info)
 {
 	return flash_get_page_info(dev, offs, 0U, info);
 }
 
-int z_impl_flash_get_page_info_by_idx(const struct device *dev,
+int flash_get_page_info_by_idx(const struct device *dev,
 				      uint32_t page_index,
 				      struct flash_pages_info *info)
 {
 	return flash_get_page_info(dev, 0, page_index, info);
 }
 
-size_t z_impl_flash_get_page_count(const struct device *dev)
+size_t flash_get_page_count(const struct device *dev)
 {
 	const struct flash_driver_api *api = dev->api;
 	const struct flash_pages_layout *layout;

--- a/include/zephyr/drivers/flash.h
+++ b/include/zephyr/drivers/flash.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Nordic Semiconductor ASA
+ * Copyright (c) 2017-2024 Nordic Semiconductor ASA
  * Copyright (c) 2016 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -265,9 +265,8 @@ struct flash_pages_info {
  *
  *  @return  0 on success, -EINVAL if page of the offset doesn't exist.
  */
-__syscall int flash_get_page_info_by_offs(const struct device *dev,
-					  off_t offset,
-					  struct flash_pages_info *info);
+int flash_get_page_info_by_offs(const struct device *dev, off_t offset,
+				struct flash_pages_info *info);
 
 /**
  *  @brief  Get the size and start offset of flash page of certain index.
@@ -278,9 +277,8 @@ __syscall int flash_get_page_info_by_offs(const struct device *dev,
  *
  *  @return  0 on success, -EINVAL  if page of the index doesn't exist.
  */
-__syscall int flash_get_page_info_by_idx(const struct device *dev,
-					 uint32_t page_index,
-					 struct flash_pages_info *info);
+int flash_get_page_info_by_idx(const struct device *dev, uint32_t page_index,
+			       struct flash_pages_info *info);
 
 /**
  *  @brief  Get the total number of flash pages.
@@ -289,7 +287,7 @@ __syscall int flash_get_page_info_by_idx(const struct device *dev,
  *
  *  @return  Number of flash pages.
  */
-__syscall size_t flash_get_page_count(const struct device *dev);
+size_t flash_get_page_count(const struct device *dev);
 
 /**
  * @brief Callback type for iterating over flash pages present on a device.
@@ -395,9 +393,7 @@ static inline int z_impl_flash_read_jedec_id(const struct device *dev,
  *
  *  @return  write block size in bytes.
  */
-__syscall size_t flash_get_write_block_size(const struct device *dev);
-
-static inline size_t z_impl_flash_get_write_block_size(const struct device *dev)
+static inline size_t flash_get_write_block_size(const struct device *dev)
 {
 	const struct flash_driver_api *api =
 		(const struct flash_driver_api *)dev->api;
@@ -417,9 +413,7 @@ static inline size_t z_impl_flash_get_write_block_size(const struct device *dev)
  *  @return pointer to flash_parameters structure characteristic for
  *          the device.
  */
-__syscall const struct flash_parameters *flash_get_parameters(const struct device *dev);
-
-static inline const struct flash_parameters *z_impl_flash_get_parameters(const struct device *dev)
+static inline const struct flash_parameters *flash_get_parameters(const struct device *dev)
 {
 	const struct flash_driver_api *api =
 		(const struct flash_driver_api *)dev->api;

--- a/tests/drivers/flash/common/testcase.yaml
+++ b/tests/drivers/flash/common/testcase.yaml
@@ -29,6 +29,14 @@ tests:
     extra_args: OVERLAY_CONFIG=boards/nrf52840_flash_soc.conf
     integration_platforms:
       - nrf52840dk_nrf52840
+  # Use duplicate of above to test with CONFIG_USERSPACE=y
+  drivers.flash.common.soc_flash_nrf.userspace:
+    platform_allow: nrf52840dk_nrf52840
+    extra_args:
+      - OVERLAY_CONFIG=boards/nrf52840_flash_soc.conf
+      - CONFIG_USERSPACE=y
+    integration_platforms:
+      - nrf52840dk_nrf52840
   drivers.flash.common.default:
     filter: ((CONFIG_FLASH_HAS_DRIVER_ENABLED and not CONFIG_TRUSTED_EXECUTION_NONSECURE)
       and dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions"))


### PR DESCRIPTION
These are unlucky:
  flash_get_write_block_size
  flash_get_parameters
  flash_get_page_info_by_offs
  flash_get_page_info_by_idx
  flash_get_page_count

as they do not need to be syscalls.

This should reduce call time, as ordinary calls take less cycles to enter an exit. Also it reduces need for additional code that does the validation and marshaling.

Flash shell sample built for nrf52840dk with command:
```
west build -d builds/flash_shell_userspace -b nrf52840dk_nrf52840 zephyr/samples/drivers/flash_shell/ 
```
with demoted functions:
```
Memory region         Used Size  Region Size  %age Used
           FLASH:      113068 B         1 MB     10.78%
             RAM:       52572 B       256 KB     20.05%
        IDT_LIST:          0 GB         2 KB      0.00%


```
against originals on main at 982fc416f8df34977a720a372564b3b673e1fd1e:
```
Memory region         Used Size  Region Size  %age Used
           FLASH:      114488 B         1 MB     10.92%
             RAM:       52572 B       256 KB     20.05%
        IDT_LIST:          0 GB         2 KB      0.00%
```

Built for littlefs sample
```
west build -d builds/littlefs -b nrf52840dk_nrf52840 zephyr/samples/subsys/fs/littlefs/ -DCONFIG_USERSPACE=y
```
with changes:
```
Memory region         Used Size  Region Size  %age Used
           FLASH:       92068 B         1 MB      8.78%
             RAM:       18600 B       256 KB      7.10%
        IDT_LIST:          0 GB         2 KB      0.00%
```
and original on main:
```
Memory region         Used Size  Region Size  %age Used
           FLASH:       93176 B         1 MB      8.89%
             RAM:       18600 B       256 KB      7.10%
        IDT_LIST:          0 GB         2 KB      0.00%
```
