### PR TITLE
boards/riscv: use the same board name convention for ITE platforms

### DIFF
--- a/boards/riscv/it8xxx2_evb/it8xxx2_evb.yaml
+++ b/boards/riscv/it8xxx2_evb/it8xxx2_evb.yaml
@@ -1,5 +1,5 @@
 identifier: it8xxx2_evb
-name: it8xxx2_evb
+name: ITE IT8XXX2 EVB
 type: mcu
 arch: riscv32
 toolchain:


### PR DESCRIPTION
This PR unifies the board name convention used by ITE RISC-V platforms.