### PR TITLE
Bluetooth: Controller: Fix overflow in inputs to LL_ASSERT_OVERHEAD

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -1075,10 +1075,14 @@ static int prepare_cb(struct lll_prepare_param *p)
 #if defined(CONFIG_BT_PERIPHERAL)
 static int resume_prepare_cb(struct lll_prepare_param *p)
 {
+	uint32_t ticks_offset;
 	struct ull_hdr *ull;
+	uint32_t ticks_now;
 
 	ull = HDR_LLL2ULL(p->param);
-	p->ticks_at_expire = ticker_ticks_now_get() - lll_event_offset_get(ull);
+	ticks_offset = lll_event_offset_get(ull);
+	ticks_now = ticker_ticks_now_get();
+	p->ticks_at_expire = ticker_ticks_diff_get(ticks_now, ticks_offset);
 	p->remainder = 0;
 	p->lazy = 0;
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -1015,9 +1015,11 @@ static int prepare_cb(struct lll_prepare_param *p)
 	ticks_at_event = p->ticks_at_expire;
 	ull = HDR_LLL2ULL(lll);
 	ticks_at_event += lll_event_offset_get(ull);
+	ticks_at_event &= HAL_TICKER_CNTR_MASK;
 
 	ticks_at_start = ticks_at_event;
 	ticks_at_start += HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
+	ticks_at_start &= HAL_TICKER_CNTR_MASK;
 
 	remainder = p->remainder;
 	start_us = radio_tmr_start(1, ticks_at_start, remainder);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -298,9 +298,11 @@ static int prepare_cb(struct lll_prepare_param *p)
 	ticks_at_event = p->ticks_at_expire;
 	ull = HDR_LLL2ULL(lll);
 	ticks_at_event += lll_event_offset_get(ull);
+	ticks_at_event &= HAL_TICKER_CNTR_MASK;
 
 	ticks_at_start = ticks_at_event;
 	ticks_at_start += HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
+	ticks_at_start &= HAL_TICKER_CNTR_MASK;
 
 	remainder = p->remainder;
 	start_us = radio_tmr_start(1, ticks_at_start, remainder);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_iso.c
@@ -399,9 +399,11 @@ static int prepare_cb_common(struct lll_prepare_param *p)
 	ticks_at_event = p->ticks_at_expire;
 	ull = HDR_LLL2ULL(lll);
 	ticks_at_event += lll_event_offset_get(ull);
+	ticks_at_event &= HAL_TICKER_CNTR_MASK;
 
 	ticks_at_start = ticks_at_event;
 	ticks_at_start += HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
+	ticks_at_start &= HAL_TICKER_CNTR_MASK;
 
 	remainder = p->remainder;
 	start_us = radio_tmr_start(1U, ticks_at_start, remainder);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
@@ -200,9 +200,11 @@ static int prepare_cb(struct lll_prepare_param *p)
 	ticks_at_event = p->ticks_at_expire;
 	ull = HDR_LLL2ULL(lll);
 	ticks_at_event += lll_event_offset_get(ull);
+	ticks_at_event &= HAL_TICKER_CNTR_MASK;
 
 	ticks_at_start = ticks_at_event;
 	ticks_at_start += HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
+	ticks_at_start &= HAL_TICKER_CNTR_MASK;
 
 	remainder = p->remainder;
 	start_us = radio_tmr_start(1, ticks_at_start, remainder);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central.c
@@ -212,9 +212,11 @@ static int prepare_cb(struct lll_prepare_param *p)
 	ticks_at_event = p->ticks_at_expire;
 	ull = HDR_LLL2ULL(lll);
 	ticks_at_event += lll_event_offset_get(ull);
+	ticks_at_event &= HAL_TICKER_CNTR_MASK;
 
 	ticks_at_start = ticks_at_event;
 	ticks_at_start += HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
+	ticks_at_start &= HAL_TICKER_CNTR_MASK;
 
 	remainder = p->remainder;
 	remainder_us = radio_tmr_start(1, ticks_at_start, remainder);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
@@ -317,10 +317,12 @@ static int prepare_cb(struct lll_prepare_param *p)
 	ticks_at_event = p->ticks_at_expire;
 	ull = HDR_LLL2ULL(cig_lll);
 	ticks_at_event += lll_event_offset_get(ull);
+	ticks_at_event &= HAL_TICKER_CNTR_MASK;
 
 	ticks_at_start = ticks_at_event;
 	ticks_at_start += HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US +
 						 cis_offset_first);
+	ticks_at_start &= HAL_TICKER_CNTR_MASK;
 
 	remainder = p->remainder;
 	start_us = radio_tmr_start(1U, ticks_at_start, remainder);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral.c
@@ -271,9 +271,11 @@ static int prepare_cb(struct lll_prepare_param *p)
 	ticks_at_event = p->ticks_at_expire;
 	ull = HDR_LLL2ULL(lll);
 	ticks_at_event += lll_event_offset_get(ull);
+	ticks_at_event &= HAL_TICKER_CNTR_MASK;
 
 	ticks_at_start = ticks_at_event;
 	ticks_at_start += HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
+	ticks_at_start &= HAL_TICKER_CNTR_MASK;
 
 	remainder = p->remainder;
 	remainder_us = radio_tmr_start(0, ticks_at_start, remainder);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
@@ -279,10 +279,12 @@ static int prepare_cb(struct lll_prepare_param *p)
 	ticks_at_event = p->ticks_at_expire;
 	ull = HDR_LLL2ULL(cig_lll);
 	ticks_at_event += lll_event_offset_get(ull);
+	ticks_at_event &= HAL_TICKER_CNTR_MASK;
 
 	ticks_at_start = ticks_at_event;
 	ticks_at_start += HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US +
 						 cis_offset_first);
+	ticks_at_start &= HAL_TICKER_CNTR_MASK;
 
 	remainder = p->remainder;
 	start_us = radio_tmr_start(0U, ticks_at_start, remainder);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -325,10 +325,14 @@ static int prepare_cb(struct lll_prepare_param *p)
 
 static int resume_prepare_cb(struct lll_prepare_param *p)
 {
+	uint32_t ticks_offset;
 	struct ull_hdr *ull;
+	uint32_t ticks_now;
 
 	ull = HDR_LLL2ULL(p->param);
-	p->ticks_at_expire = ticker_ticks_now_get() - lll_event_offset_get(ull);
+	ticks_offset = lll_event_offset_get(ull);
+	ticks_now = ticker_ticks_now_get();
+	p->ticks_at_expire = ticker_ticks_diff_get(ticks_now, ticks_offset);
 	p->remainder = 0;
 	p->lazy = 0;
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -453,9 +453,11 @@ static int common_prepare_cb(struct lll_prepare_param *p, bool is_resume)
 	ticks_at_event = p->ticks_at_expire;
 	ull = HDR_LLL2ULL(lll);
 	ticks_at_event += lll_event_offset_get(ull);
+	ticks_at_event &= HAL_TICKER_CNTR_MASK;
 
 	ticks_at_start = ticks_at_event;
 	ticks_at_start += HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
+	ticks_at_start &= HAL_TICKER_CNTR_MASK;
 
 	remainder = p->remainder;
 	remainder_us = radio_tmr_start(0, ticks_at_start, remainder);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -528,9 +528,11 @@ sync_aux_prepare_done:
 	ticks_at_event = p->ticks_at_expire;
 	ull = HDR_LLL2ULL(lll_aux);
 	ticks_at_event += lll_event_offset_get(ull);
+	ticks_at_event &= HAL_TICKER_CNTR_MASK;
 
 	ticks_at_start = ticks_at_event;
 	ticks_at_start += HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
+	ticks_at_start &= HAL_TICKER_CNTR_MASK;
 
 	remainder = p->remainder;
 	remainder_us = radio_tmr_start(0, ticks_at_start, remainder);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -473,9 +473,11 @@ static int prepare_cb_common(struct lll_prepare_param *p, uint8_t chan_idx)
 	ticks_at_event = p->ticks_at_expire;
 	ull = HDR_LLL2ULL(lll);
 	ticks_at_event += lll_event_offset_get(ull);
+	ticks_at_event &= HAL_TICKER_CNTR_MASK;
 
 	ticks_at_start = ticks_at_event;
 	ticks_at_start += HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
+	ticks_at_start &= HAL_TICKER_CNTR_MASK;
 
 	remainder = p->remainder;
 	remainder_us = radio_tmr_start(0, ticks_at_start, remainder);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
@@ -340,9 +340,11 @@ static int prepare_cb_common(struct lll_prepare_param *p)
 	ticks_at_event = p->ticks_at_expire;
 	ull = HDR_LLL2ULL(lll);
 	ticks_at_event += lll_event_offset_get(ull);
+	ticks_at_event &= HAL_TICKER_CNTR_MASK;
 
 	ticks_at_start = ticks_at_event;
 	ticks_at_start += HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
+	ticks_at_start &= HAL_TICKER_CNTR_MASK;
 
 	remainder = p->remainder;
 	remainder_us = radio_tmr_start(0U, ticks_at_start, remainder);


### PR DESCRIPTION
Fix possible overflows in ticks_at_event and ticks_at_start
values that are provided as inputs to LL_ASSERT_OVERHEAD
check implementation.

Relates to commit https://github.com/zephyrproject-rtos/zephyr/commit/96c076b9c12dd49647509046b830b4a503bc807f ("Bluetooth: Controller: Add
LL_ASSERT_OVERHEAD define").

Use ticker_ticks_diff_get() in resume_cb ticks_to_expire
calculations.