### PR TITLE
net: openthread: remove unneded call to `otLinkMetricsInit`

### DIFF
--- a/modules/openthread/platform/radio.c
+++ b/modules/openthread/platform/radio.c
@@ -363,10 +363,6 @@ void platformRadioInit(void)
 
 	cfg.event_handler = handle_radio_event;
 	radio_api->configure(radio_dev, IEEE802154_CONFIG_EVENT_HANDLER, &cfg);
-
-#if defined(CONFIG_OPENTHREAD_LINK_METRICS_SUBJECT)
-	otLinkMetricsInit(DEFAULT_SENSITIVITY);
-#endif
 }
 
 void transmit_message(struct k_work *tx_job)


### PR DESCRIPTION
Platforms calculate Link Metrics values internally after using `otPlatRadioConfigureEnhAckProbing`.