### PR TITLE
net: l2: ppp: Patch L2 PPP network interface behavior

### DIFF
--- a/include/zephyr/net/ppp.h
+++ b/include/zephyr/net/ppp.h
@@ -474,6 +474,12 @@ struct ppp_context {
 	/** Current phase of PPP link */
 	enum ppp_phase phase;
 
+	/** Signal when PPP link is terminated */
+	struct k_sem wait_ppp_link_terminated;
+
+	/** Signal when PPP link is down */
+	struct k_sem wait_ppp_link_down;
+
 	/** This tells what features the PPP supports. */
 	enum net_l2_flags ppp_l2_flags;
 

--- a/subsys/net/l2/ppp/lcp.c
+++ b/subsys/net/l2/ppp/lcp.c
@@ -179,11 +179,9 @@ static void lcp_down(struct ppp_fsm *fsm)
 
 	ppp_link_down(ctx);
 
-	if (!net_if_is_carrier_ok(ctx->iface)) {
-		return;
+	if (net_if_is_carrier_ok(ctx->iface) && ctx->is_enabled) {
+		ppp_change_phase(ctx, PPP_ESTABLISH);
 	}
-
-	ppp_change_phase(ctx, PPP_ESTABLISH);
 }
 
 static void lcp_up(struct ppp_fsm *fsm)

--- a/subsys/net/l2/ppp/link.c
+++ b/subsys/net/l2/ppp/link.c
@@ -114,6 +114,8 @@ void ppp_link_authenticated(struct ppp_context *ctx)
 
 void ppp_link_terminated(struct ppp_context *ctx)
 {
+	k_sem_give(&ctx->wait_ppp_link_terminated);
+
 	if (ctx->phase == PPP_DEAD) {
 		return;
 	}
@@ -127,6 +129,8 @@ void ppp_link_terminated(struct ppp_context *ctx)
 
 void ppp_link_down(struct ppp_context *ctx)
 {
+	k_sem_give(&ctx->wait_ppp_link_down);
+
 	if (ctx->phase == PPP_DEAD) {
 		return;
 	}


### PR DESCRIPTION
### Overview

This PR adjusts the behavior of the L2 PPP subsystem as follows:
* Synchronize closing of protocols with call to net_if_down()
* Only close LCP if the carrier is present, and the network interface is down, otherwise simply reset protocols

These two changes ensure the following:
* The `struct ppp_api` `stop` API is called after L2 PPP module is completely `DEAD`
* The L2 PPP module will automatically recover a lost carrier while UP (`net_if_up()` has been called)

This fixes the following issues:
* Terminating the carrier from the `struct ppp_api` `stop` API is now possible
* The L2 PPP module will not get stuck trying to close the LCP if the carrier is not present

fixes: #67627

Tested with `gsm_modem` and `cellular_modem` samples, with a BG95 modem.

### Logs from before this PR

#### Disabling the carrier from within `struct ppp_api` `stop` API (`ppp_stop`)
```
[00:00:34.685,943] <dbg> net_l2_ppp: ppp_change_phase_debug: (net_mgmt): [0x200061e8] phase RUNNING (4) => TERMINATE (5) (lcp_close():166)
[00:00:34.686,004] <dbg> net_l2_ppp: ppp_fsm_close: (net_mgmt): [LCP/0x20006220] Current state OPENED (9)
[00:00:34.686,065] <dbg> net_l2_ppp: ppp_fsm_lower_down: (net_mgmt): [IPCP/0x200062f0] Current state OPENED (9)
[00:00:34.686,157] <dbg> net_l2_ppp: ppp_change_state_debug: (net_mgmt): [IPCP/0x200062f0] state OPENED (9) => STARTING (1) (ppp_fsm_lower_down():282)
[00:00:34.686,340] <dbg> net_l2_ppp: ppp_network_down: (net_mgmt): [0x200061e8] Proto IPv4 (0x0021) down (0)
[00:00:34.686,401] <dbg> net_l2_ppp: ppp_fsm_close: (net_mgmt): [IPCP/0x200062f0] Current state STARTING (1)
[00:00:34.686,492] <dbg> net_l2_ppp: ppp_change_state_debug: (net_mgmt): [IPCP/0x200062f0] state STARTING (1) => INITIAL (0) (ppp_fsm_close():240)
[00:00:34.686,584] <dbg> net_l2_ppp: ppp_change_phase_debug: (net_mgmt): [0x200061e8] phase TERMINATE (5) => DEAD (0) (ppp_link_down():136)
[00:00:34.686,706] <dbg> net_l2_ppp: ppp_change_state_debug: (net_mgmt): [LCP/0x20006220] state OPENED (9) => CLOSING (4) (terminate():215)
[00:00:44.686,706] <dbg> net_l2_ppp: ppp_fsm_timeout: (sysworkq): [LCP/0x20006220] Current state CLOSING (4)
[00:00:54.686,828] <dbg> net_l2_ppp: ppp_fsm_timeout: (sysworkq): [LCP/0x20006220] Current state CLOSING (4)
[00:00:54.686,950] <dbg> net_l2_ppp: ppp_change_state_debug: (sysworkq): [LCP/0x20006220] state CLOSING (4) => CLOSED (2) (ppp_fsm_timeout():136)
```
Note the timeouts while trying to close, and no LCP close request sent

#### Disabling the carrier while network interface is up and L4 is connected
```
[00:00:50.632,598] <dbg> net_l2_ppp: ppp_change_phase_debug: (net_mgmt): [0x200061e8] phase RUNNING (4) => TERMINATE (5) (lcp_close():166)
[00:00:50.632,690] <dbg> net_l2_ppp: ppp_fsm_close: (net_mgmt): [LCP/0x20006220] Current state OPENED (9)
[00:00:50.632,751] <dbg> net_l2_ppp: ppp_fsm_lower_down: (net_mgmt): [IPCP/0x200062f0] Current state OPENED (9)
[00:00:50.632,843] <dbg> net_l2_ppp: ppp_change_state_debug: (net_mgmt): [IPCP/0x200062f0] state OPENED (9) => STARTING (1) (ppp_fsm_lower_down():282)
[00:00:50.633,026] <dbg> net_l2_ppp: ppp_network_down: (net_mgmt): [0x200061e8] Proto IPv4 (0x0021) down (0)
[00:00:50.633,087] <dbg> net_l2_ppp: ppp_fsm_close: (net_mgmt): [IPCP/0x200062f0] Current state STARTING (1)
[00:00:50.633,178] <dbg> net_l2_ppp: ppp_change_state_debug: (net_mgmt): [IPCP/0x200062f0] state STARTING (1) => INITIAL (0) (ppp_fsm_close():240)
[00:00:50.633,270] <dbg> net_l2_ppp: ppp_change_phase_debug: (net_mgmt): [0x200061e8] phase TERMINATE (5) => DEAD (0) (ppp_link_down():136)
[00:00:50.633,361] <dbg> net_l2_ppp: ppp_change_state_debug: (net_mgmt): [LCP/0x20006220] state OPENED (9) => CLOSING (4) (terminate():215)
[00:01:00.633,392] <dbg> net_l2_ppp: ppp_fsm_timeout: (sysworkq): [LCP/0x20006220] Current state CLOSING (4)
[00:01:10.633,544] <dbg> net_l2_ppp: ppp_fsm_timeout: (sysworkq): [LCP/0x20006220] Current state CLOSING (4)
[00:01:10.633,636] <dbg> net_l2_ppp: ppp_change_state_debug: (sysworkq): [LCP/0x20006220] state CLOSING (4) => CLOSED (2) (ppp_fsm_timeout():136)
```
The interface is still up, it just lost the carrier, yet it just tried to close the LCP, then forcefully closed it.

#### Bring back carrier after it was lost in previous step
```
...
[00:03:30.187,316] <dbg> net_l2_ppp: fsm_recv_configure_ack: (rx_q[0]): [IPCP/0x200062f0] Current state ACK_SENT (8)
[00:03:30.187,438] <dbg> net_l2_ppp: ppp_change_state_debug: (rx_q[0]): [IPCP/0x200062f0] state ACK_SENT (8) => OPENED (9) (fsm_recv_configure_ack():713)
[00:03:30.187,530] <dbg> net_l2_ppp: ipcp_up: (rx_q[0]): PPP up with address 10.241.176.131
[00:03:30.187,622] <dbg> net_l2_ppp: ppp_change_phase_debug: (rx_q[0]): [0x200061e8] phase NETWORK (3) => RUNNING (4) (ppp_network_up():22)
[00:03:30.187,683] <dbg> net_l2_ppp: ppp_network_up: (rx_q[0]): [0x200061e8] Proto IPv4 (0x0021) up (1)
[00:03:30.187,744] <dbg> net_l2_ppp: ipcp_up: (rx_q[0]): [IPCP/0x200062f0] Current state OPENED (9)
```
The L2 PPP module is able to reestablish the session, even though that should not be possible, as it closed the LCP connection (requiring a new dial out on modems)


### Logs from after this PR

#### Disabling the carrier from within `struct ppp_api` `stop` API (`ppp_stop`)
```
[00:01:13.216,339] <dbg> net_l2_ppp: ppp_change_phase_debug: (shell_uart): [0x200061e8] phase RUNNING (4) => TERMINATE (5) (lcp_close():166)
[00:01:13.216,400] <dbg> net_l2_ppp: ppp_fsm_close: (shell_uart): [LCP/0x20006220] Current state OPENED (9)
[00:01:13.216,461] <dbg> net_l2_ppp: ppp_fsm_lower_down: (shell_uart): [IPCP/0x200062f0] Current state OPENED (9)
[00:01:13.216,552] <dbg> net_l2_ppp: ppp_change_state_debug: (shell_uart): [IPCP/0x200062f0] state OPENED (9) => STARTING (1) (ppp_fsm_lower_down():282)
[00:01:13.216,674] <dbg> net_l2_ppp: ppp_network_down: (shell_uart): [0x200061e8] Proto IPv4 (0x0021) down (0)
[00:01:13.216,705] <dbg> net_l2_ppp: ppp_fsm_close: (shell_uart): [IPCP/0x200062f0] Current state STARTING (1)
[00:01:13.216,796] <dbg> net_l2_ppp: ppp_change_state_debug: (shell_uart): [IPCP/0x200062f0] state STARTING (1) => INITIAL (0) (ppp_fsm_close():240)
[00:01:13.216,888] <dbg> net_l2_ppp: ppp_change_phase_debug: (shell_uart): [0x200061e8] phase TERMINATE (5) => DEAD (0) (ppp_link_down():136)
[00:01:13.217,010] <dbg> net_l2_ppp: ppp_send_pkt: (shell_uart): [LCP/0x20006220] Sending 6 bytes pkt 0x2000be4c (options len 11)
[00:01:13.217,041] <dbg> net_l2_ppp: net_pkt_hexdump: send L2
[00:01:13.217,102] <dbg> net_l2_ppp: net_pkt_hexdump: 0x2000be4c
                                     c0 21 05 02 00 04                                |.!....           
[00:01:13.218,688] <dbg> net_l2_ppp: ppp_change_state_debug: (shell_uart): [LCP/0x20006220] state OPENED (9) => CLOSING (4) (terminate():215)
[00:01:13.220,794] <dbg> net_l2_ppp: net_pkt_hexdump: recv L2
[00:01:13.220,855] <dbg> net_l2_ppp: net_pkt_hexdump: 0x2000bf78
                                     c0 21 06 02 00 04                                |.!....           
[00:01:13.220,947] <dbg> net_l2_ppp: ppp_fsm_input: (rx_q[0]): [LCP/0x20006220] LCP Terminate-Ack (6) id 2 payload len 0
[00:01:13.221,008] <dbg> net_l2_ppp: fsm_recv_terminate_ack: (rx_q[0]): [LCP/0x20006220] Current state CLOSING (4)
[00:01:13.221,099] <dbg> net_l2_ppp: ppp_change_state_debug: (rx_q[0]): [LCP/0x20006220] state CLOSING (4) => CLOSED (2) (fsm_recv_terminate_ack():935)
```
The LCP is now properly terminated, with an ACK from the modem.

#### Disabling the carrier while network interface is up and L4 is connected
```
[00:04:32.021,057] <dbg> net_l2_ppp: ppp_fsm_lower_down: (net_mgmt): [LCP/0x20006220] Current state OPENED (9)
[00:04:32.021,179] <dbg> net_l2_ppp: ppp_change_state_debug: (net_mgmt): [LCP/0x20006220] state OPENED (9) => STARTING (1) (ppp_fsm_lower_down():282)
[00:04:32.021,240] <dbg> net_l2_ppp: ppp_fsm_lower_down: (net_mgmt): [IPCP/0x200062f0] Current state OPENED (9)
[00:04:32.021,331] <dbg> net_l2_ppp: ppp_change_state_debug: (net_mgmt): [IPCP/0x200062f0] state OPENED (9) => STARTING (1) (ppp_fsm_lower_down():282)
[00:04:32.021,514] <dbg> net_l2_ppp: ppp_change_phase_debug: (net_mgmt): [0x200061e8] phase RUNNING (4) => TERMINATE (5) (ppp_network_down():37)
[00:04:32.021,575] <dbg> net_l2_ppp: ppp_network_down: (net_mgmt): [0x200061e8] Proto IPv4 (0x0021) down (0)
[00:04:32.021,636] <dbg> net_l2_ppp: ppp_fsm_close: (net_mgmt): [IPCP/0x200062f0] Current state STARTING (1)
[00:04:32.021,728] <dbg> net_l2_ppp: ppp_change_state_debug: (net_mgmt): [IPCP/0x200062f0] state STARTING (1) => INITIAL (0) (ppp_fsm_close():240)
[00:04:32.021,789] <dbg> net_l2_ppp: ppp_change_phase_debug: (net_mgmt): [0x200061e8] phase TERMINATE (5) => DEAD (0) (ppp_link_down():136)
```
Since there is no carrier, all protocols, including LCP are simply reset

#### Bring back carrier after it was lost in previous step
```
...
[00:07:08.907,562] <dbg> net_l2_ppp: ppp_change_state_debug: (rx_q[0]): [IPCP/0x200062f0] state ACK_SENT (8) => OPENED (9) (fsm_recv_configure_ack():713)
[00:07:08.907,653] <dbg> net_l2_ppp: ipcp_up: (rx_q[0]): PPP up with address 10.164.147.208
[00:07:08.907,745] <dbg> net_l2_ppp: ppp_change_phase_debug: (rx_q[0]): [0x200061e8] phase NETWORK (3) => RUNNING (4) (ppp_network_up():22)
[00:07:08.907,806] <dbg> net_l2_ppp: ppp_network_up: (rx_q[0]): [0x200061e8] Proto IPv4 (0x0021) up (1)
[00:07:08.907,867] <dbg> net_l2_ppp: ipcp_up: (rx_q[0]): [IPCP/0x200062f0] Current state OPENED (9)
```
The L2 PPP is restored as expected, even though it can now close LCP correctly, it did not because only the carrier was missing, the net interface is still enabled :)