### PR TITLE
cmake: zephyr_module: Rename west_arg variable to upper case

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1627,10 +1627,10 @@ if(CONFIG_BUILD_OUTPUT_META)
   list(APPEND
     post_build_commands
     COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/zephyr_module.py
-            ${WEST_ARG}
             ${ZEPHYR_MODULES_ARG}
             ${EXTRA_ZEPHYR_MODULES_ARG}
             --meta-out ${KERNEL_META_PATH}
+            --zephyr-base=${ZEPHYR_BASE}
             $<$<BOOL:${CONFIG_BUILD_OUTPUT_META_STATE_PROPAGATE}>:--meta-state-propagate>
   )
   list(APPEND

--- a/cmake/modules/zephyr_module.cmake
+++ b/cmake/modules/zephyr_module.cmake
@@ -48,17 +48,13 @@ set(cmake_modules_file ${CMAKE_BINARY_DIR}/zephyr_modules.txt)
 set(cmake_sysbuild_file ${CMAKE_BINARY_DIR}/sysbuild_modules.txt)
 set(zephyr_settings_file ${CMAKE_BINARY_DIR}/zephyr_settings.txt)
 
-if(WEST)
-  set(west_arg "--zephyr-base" ${ZEPHYR_BASE})
-endif()
-
 if(WEST OR ZEPHYR_MODULES)
   # Zephyr module uses west, so only call it if west is installed or
   # ZEPHYR_MODULES was provided as argument to CMake.
   execute_process(
     COMMAND
     ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/zephyr_module.py
-    ${west_arg}
+    --zephyr-base=${ZEPHYR_BASE}
     ${ZEPHYR_MODULES_ARG}
     ${EXTRA_ZEPHYR_MODULES_ARG}
     --kconfig-out ${kconfig_modules_file}


### PR DESCRIPTION
[8cc716792ac5aaadd9c4601607abda4504e7044c](https://github.com/zephyrproject-rtos/zephyr/commit/8cc716792ac5aaadd9c4601607abda4504e7044c) renamed this variable to lower case to indicate it's only used locally however WEST_ARG is used as a parameter of zephyr_module.py in https://github.com/zephyrproject-rtos/zephyr/blob/main/CMakeLists.txt#L1630 when CONFIG_BUILD_OUTPUT_META is enabled.