### PR TITLE
drivers: spi: fix unreliable SPI busy flag for some STM32 devices

### DIFF
--- a/drivers/spi/Kconfig.stm32
+++ b/drivers/spi/Kconfig.stm32
@@ -32,22 +32,21 @@ config SPI_STM32_USE_HW_SS
 	help
 	  Use Slave Select pin instead of software Slave Select.
 
-config SPI_STM32F7_ERRATA_BUSY
+config SPI_STM32_ERRATA_BUSY
 	bool
 	default y
-	depends on SOC_STM32F745XX || SOC_STM32F746XX || \
-		   SOC_STM32F750XX || SOC_STM32F756XX
+	depends on SOC_SERIES_STM32F7X || SOC_SERIES_STM32L4X
 	help
 	  Handles erratum "BSY bit may stay high at the end of a data
-	  transfer in Slave mode".
-	  Seen in Errata Sheet 0290 §2.11.2
+	  transfer in slave mode".
+	  Seen for instance in Errata Sheet 0290 §2.11.2
 
-if SPI_STM32F7_ERRATA_BUSY
+if SPI_STM32_ERRATA_BUSY
 
 config SPI_STM32_BUSY_FLAG_TIMEOUT
 	int "timeout in us for the STM32 busy flag workaround"
 	default 10000
 
-endif # SPI_STM32F7_ERRATA_BUSY
+endif # SPI_STM32_ERRATA_BUSY
 
 endif # SPI_STM32

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -922,7 +922,7 @@ static int transceive_dma(const struct device *dev,
 		}
 #endif
 
-#ifdef CONFIG_SPI_STM32F7_ERRATA_BUSY
+#ifdef CONFIG_SPI_STM32_ERRATA_BUSY
 		WAIT_FOR(ll_func_spi_dma_busy(spi) != 0,
 			 CONFIG_SPI_STM32_BUSY_FLAG_TIMEOUT,
 			 k_yield());


### PR DESCRIPTION
Extend the workaround for the unreliable SPI busy flag to more F7 and L4 devices, which are affected by the same erratum.

Fixes  #67739