### PR TITLE
drivers: can: add structs for common configuration and data fields

### DIFF
--- a/drivers/can/can_esp32_twai.c
+++ b/drivers/can/can_esp32_twai.c
@@ -119,7 +119,7 @@ static int can_esp32_twai_set_timing(const struct device *dev, const struct can_
 	uint8_t btr0;
 	uint8_t btr1;
 
-	if (data->started) {
+	if (data->common.started) {
 		return -EBUSY;
 	}
 
@@ -130,7 +130,7 @@ static int can_esp32_twai_set_timing(const struct device *dev, const struct can_
 	btr1 = TWAI_TIME_SEG1_PREP(timing->phase_seg1 - 1) |
 	       TWAI_TIME_SEG2_PREP(timing->phase_seg2 - 1);
 
-	if ((data->mode & CAN_MODE_3_SAMPLES) != 0) {
+	if ((data->common.mode & CAN_MODE_3_SAMPLES) != 0) {
 		btr1 |= TWAI_TIME_SAMP;
 	}
 

--- a/drivers/can/can_mcp2515.h
+++ b/drivers/can/can_mcp2515.h
@@ -22,6 +22,8 @@ struct mcp2515_tx_cb {
 };
 
 struct mcp2515_data {
+	struct can_driver_data common;
+
 	/* interrupt data */
 	struct gpio_callback int_gpio_cb;
 	struct k_thread int_thread;
@@ -38,17 +40,16 @@ struct mcp2515_data {
 	can_rx_callback_t rx_cb[CONFIG_CAN_MAX_FILTER];
 	void *cb_arg[CONFIG_CAN_MAX_FILTER];
 	struct can_filter filter[CONFIG_CAN_MAX_FILTER];
-	can_state_change_callback_t state_change_cb;
-	void *state_change_cb_data;
 
 	/* general data */
 	struct k_mutex mutex;
 	enum can_state old_state;
 	uint8_t mcp2515_mode;
-	bool started;
 };
 
 struct mcp2515_config {
+	const struct can_driver_config common;
+
 	/* spi configuration */
 	struct spi_dt_spec bus;
 
@@ -62,13 +63,7 @@ struct mcp2515_config {
 	uint8_t tq_prop;
 	uint8_t tq_bs1;
 	uint8_t tq_bs2;
-	uint32_t bus_speed;
 	uint32_t osc_freq;
-	uint16_t sample_point;
-
-	/* CAN transceiver */
-	const struct device *phy;
-	uint32_t max_bitrate;
 };
 
 /*

--- a/drivers/can/can_mcp251xfd.h
+++ b/drivers/can/can_mcp251xfd.h
@@ -478,6 +478,8 @@ struct mcp251xfd_fifo {
 };
 
 struct mcp251xfd_data {
+	struct can_driver_data common;
+
 	/* Interrupt Data */
 	struct gpio_callback int_gpio_cb;
 	struct k_thread int_thread;
@@ -486,8 +488,6 @@ struct mcp251xfd_data {
 
 	/* General */
 	enum can_state state;
-	can_state_change_callback_t state_change_cb;
-	void *state_change_cb_data;
 	struct k_mutex mutex;
 
 	/* TX Callback */
@@ -503,12 +503,9 @@ struct mcp251xfd_data {
 
 	const struct device *dev;
 
-	bool started;
 	uint8_t next_mcp251xfd_mode;
 	uint8_t current_mcp251xfd_mode;
 	int tdco;
-
-	can_mode_t mode;
 
 	struct mcp251xfd_spi_data spi_data;
 
@@ -519,11 +516,11 @@ struct mcp251xfd_timing_params {
 	uint8_t prop_seg;
 	uint8_t phase_seg1;
 	uint8_t phase_seg2;
-	uint32_t bus_speed;
-	uint16_t sample_point;
 };
 
 struct mcp251xfd_config {
+	const struct can_driver_config common;
+
 	/* spi configuration */
 	struct spi_dt_spec bus;
 	struct gpio_dt_spec int_gpio_dt;
@@ -542,10 +539,6 @@ struct mcp251xfd_config {
 #if defined(CONFIG_CAN_FD_MODE)
 	struct mcp251xfd_timing_params timing_params_data;
 #endif
-
-	/* CAN transceiver */
-	const struct device *phy;
-	uint32_t max_bitrate;
 
 	const struct device *clk_dev;
 	uint8_t clk_id;

--- a/drivers/can/can_rcar.c
+++ b/drivers/can/can_rcar.c
@@ -166,21 +166,18 @@ LOG_MODULE_REGISTER(can_rcar, CONFIG_CAN_LOG_LEVEL);
 typedef void (*init_func_t)(const struct device *dev);
 
 struct can_rcar_cfg {
+	const struct can_driver_config common;
 	uint32_t reg_addr;
 	int reg_size;
 	init_func_t init_func;
 	const struct device *clock_dev;
 	struct rcar_cpg_clk mod_clk;
 	struct rcar_cpg_clk bus_clk;
-	uint32_t bus_speed;
 	uint8_t sjw;
 	uint8_t prop_seg;
 	uint8_t phase_seg1;
 	uint8_t phase_seg2;
-	uint16_t sample_point;
 	const struct pinctrl_dev_config *pcfg;
-	const struct device *phy;
-	uint32_t max_bitrate;
 };
 
 struct can_rcar_tx_cb {
@@ -189,6 +186,7 @@ struct can_rcar_tx_cb {
 };
 
 struct can_rcar_data {
+	struct can_driver_data common;
 	struct k_mutex inst_mutex;
 	struct k_sem tx_sem;
 	struct can_rcar_tx_cb tx_cb[RCAR_CAN_FIFO_DEPTH];
@@ -199,10 +197,7 @@ struct can_rcar_data {
 	can_rx_callback_t rx_callback[CONFIG_CAN_RCAR_MAX_FILTER];
 	void *rx_callback_arg[CONFIG_CAN_RCAR_MAX_FILTER];
 	struct can_filter filter[CONFIG_CAN_RCAR_MAX_FILTER];
-	can_state_change_callback_t state_change_cb;
-	void *state_change_cb_data;
 	enum can_state state;
-	bool started;
 };
 
 static inline uint16_t can_rcar_read16(const struct can_rcar_cfg *config,
@@ -244,8 +239,8 @@ static void can_rcar_state_change(const struct device *dev, uint32_t newstate)
 {
 	const struct can_rcar_cfg *config = dev->config;
 	struct can_rcar_data *data = dev->data;
-	const can_state_change_callback_t cb = data->state_change_cb;
-	void *state_change_cb_data = data->state_change_cb_data;
+	const can_state_change_callback_t cb = data->common.state_change_cb;
+	void *state_change_cb_data = data->common.state_change_cb_user_data;
 	struct can_bus_err_cnt err_cnt;
 
 	if (data->state == newstate) {
@@ -578,12 +573,12 @@ static int can_rcar_start(const struct device *dev)
 	struct can_rcar_data *data = dev->data;
 	int ret;
 
-	if (data->started) {
+	if (data->common.started) {
 		return -EALREADY;
 	}
 
-	if (config->phy != NULL) {
-		ret = can_transceiver_enable(config->phy);
+	if (config->common.phy != NULL) {
+		ret = can_transceiver_enable(config->common.phy);
 		if (ret != 0) {
 			LOG_ERR("failed to enable CAN transceiver (err %d)", ret);
 			return ret;
@@ -598,12 +593,12 @@ static int can_rcar_start(const struct device *dev)
 	if (ret != 0) {
 		LOG_ERR("failed to enter operation mode (err %d)", ret);
 
-		if (config->phy != NULL) {
+		if (config->common.phy != NULL) {
 			/* Attempt to disable the CAN transceiver in case of error */
-			(void)can_transceiver_disable(config->phy);
+			(void)can_transceiver_disable(config->common.phy);
 		}
 	} else {
-		data->started = true;
+		data->common.started = true;
 	}
 
 	k_mutex_unlock(&data->inst_mutex);
@@ -617,7 +612,7 @@ static int can_rcar_stop(const struct device *dev)
 	struct can_rcar_data *data = dev->data;
 	int ret;
 
-	if (!data->started) {
+	if (!data->common.started) {
 		return -EALREADY;
 	}
 
@@ -630,12 +625,12 @@ static int can_rcar_stop(const struct device *dev)
 		return ret;
 	}
 
-	data->started = false;
+	data->common.started = false;
 
 	k_mutex_unlock(&data->inst_mutex);
 
-	if (config->phy != NULL) {
-		ret = can_transceiver_disable(config->phy);
+	if (config->common.phy != NULL) {
+		ret = can_transceiver_disable(config->common.phy);
 		if (ret != 0) {
 			LOG_ERR("failed to disable CAN transceiver (err %d)", ret);
 			return ret;
@@ -666,7 +661,7 @@ static int can_rcar_set_mode(const struct device *dev, can_mode_t mode)
 		return -ENOTSUP;
 	}
 
-	if (data->started) {
+	if (data->common.started) {
 		return -EBUSY;
 	}
 
@@ -689,6 +684,8 @@ static int can_rcar_set_mode(const struct device *dev, can_mode_t mode)
 	}
 
 	sys_write8(tcr, config->reg_addr + RCAR_CAN_TCR);
+
+	data->common.mode = mode;
 
 unlock:
 	k_mutex_unlock(&data->inst_mutex);
@@ -735,7 +732,7 @@ static int can_rcar_set_timing(const struct device *dev,
 	struct reg_backup regs[3] = { { RCAR_CAN_TCR, 0 }, { RCAR_CAN_TFCR, 0 }
 				      , { RCAR_CAN_RFCR, 0 } };
 
-	if (data->started) {
+	if (data->common.started) {
 		return -EBUSY;
 	}
 
@@ -781,8 +778,8 @@ static void can_rcar_set_state_change_callback(const struct device *dev,
 {
 	struct can_rcar_data *data = dev->data;
 
-	data->state_change_cb = cb;
-	data->state_change_cb_data = user_data;
+	data->common.state_change_cb = cb;
+	data->common.state_change_cb_user_data = user_data;
 }
 
 static int can_rcar_get_state(const struct device *dev, enum can_state *state,
@@ -792,7 +789,7 @@ static int can_rcar_get_state(const struct device *dev, enum can_state *state,
 	struct can_rcar_data *data = dev->data;
 
 	if (state != NULL) {
-		if (!data->started) {
+		if (!data->common.started) {
 			*state = CAN_STATE_STOPPED;
 		} else {
 			*state = data->state;
@@ -814,7 +811,7 @@ static int can_rcar_recover(const struct device *dev, k_timeout_t timeout)
 	int64_t start_time;
 	int ret;
 
-	if (!data->started) {
+	if (!data->common.started) {
 		return -ENETDOWN;
 	}
 
@@ -880,7 +877,7 @@ static int can_rcar_send(const struct device *dev, const struct can_frame *frame
 		return -ENOTSUP;
 	}
 
-	if (!data->started) {
+	if (!data->common.started) {
 		return -ENETDOWN;
 	}
 
@@ -1004,11 +1001,11 @@ static int can_rcar_init(const struct device *dev)
 
 	memset(data->rx_callback, 0, sizeof(data->rx_callback));
 	data->state = CAN_STATE_ERROR_ACTIVE;
-	data->state_change_cb = NULL;
-	data->state_change_cb_data = NULL;
+	data->common.state_change_cb = NULL;
+	data->common.state_change_cb_user_data = NULL;
 
-	if (config->phy != NULL) {
-		if (!device_is_ready(config->phy)) {
+	if (config->common.phy != NULL) {
+		if (!device_is_ready(config->common.phy)) {
 			LOG_ERR("CAN transceiver not ready");
 			return -ENODEV;
 		}
@@ -1056,9 +1053,9 @@ static int can_rcar_init(const struct device *dev)
 		return ret;
 	}
 
-	if (config->sample_point) {
-		ret = can_calc_timing(dev, &timing, config->bus_speed,
-				      config->sample_point);
+	if (config->common.sample_point) {
+		ret = can_calc_timing(dev, &timing, config->common.bus_speed,
+				      config->common.sample_point);
 		if (ret == -EINVAL) {
 			LOG_ERR("Can't find timing for given param");
 			return -EIO;
@@ -1071,7 +1068,7 @@ static int can_rcar_init(const struct device *dev)
 		timing.prop_seg = config->prop_seg;
 		timing.phase_seg1 = config->phase_seg1;
 		timing.phase_seg2 = config->phase_seg2;
-		ret = can_calc_prescaler(dev, &timing, config->bus_speed);
+		ret = can_calc_prescaler(dev, &timing, config->common.bus_speed);
 		if (ret) {
 			LOG_WRN("Bitrate error: %d", ret);
 		}
@@ -1147,7 +1144,7 @@ static int can_rcar_get_max_bitrate(const struct device *dev, uint32_t *max_bitr
 {
 	const struct can_rcar_cfg *config = dev->config;
 
-	*max_bitrate = config->max_bitrate;
+	*max_bitrate = config->common.max_bitrate;
 
 	return 0;
 }
@@ -1190,6 +1187,7 @@ static const struct can_driver_api can_rcar_driver_api = {
 	PINCTRL_DT_INST_DEFINE(n);						\
 	static void can_rcar_##n##_init(const struct device *dev);		\
 	static const struct can_rcar_cfg can_rcar_cfg_##n = {			\
+		.common = CAN_DT_DRIVER_CONFIG_INST_GET(n, 1000000),		\
 		.reg_addr = DT_INST_REG_ADDR(n),				\
 		.reg_size = DT_INST_REG_SIZE(n),				\
 		.init_func = can_rcar_##n##_init,				\
@@ -1203,15 +1201,11 @@ static const struct can_driver_api can_rcar_driver_api = {
 		.bus_clk.domain =						\
 			DT_INST_CLOCKS_CELL_BY_IDX(n, 1, domain),		\
 		.bus_clk.rate = 40000000,					\
-		.bus_speed = DT_INST_PROP(n, bus_speed),			\
 		.sjw = DT_INST_PROP(n, sjw),					\
 		.prop_seg = DT_INST_PROP_OR(n, prop_seg, 0),			\
 		.phase_seg1 = DT_INST_PROP_OR(n, phase_seg1, 0),		\
 		.phase_seg2 = DT_INST_PROP_OR(n, phase_seg2, 0),		\
-		.sample_point = DT_INST_PROP_OR(n, sample_point, 0),		\
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),			\
-		.phy = DEVICE_DT_GET_OR_NULL(DT_INST_PHANDLE(n, phys)),		\
-		.max_bitrate = DT_INST_CAN_TRANSCEIVER_MAX_BITRATE(n, 1000000),	\
 	};									\
 	static struct can_rcar_data can_rcar_data_##n;				\
 										\

--- a/include/zephyr/drivers/can/can_mcan.h
+++ b/include/zephyr/drivers/can/can_mcan.h
@@ -1061,15 +1061,10 @@ struct can_mcan_ext_filter {
  * @brief Bosch M_CAN driver internal data structure.
  */
 struct can_mcan_data {
+	struct can_driver_data common;
 	struct k_mutex lock;
 	struct k_sem tx_sem;
 	struct k_mutex tx_mtx;
-	can_state_change_callback_t state_change_cb;
-	void *state_change_cb_data;
-	bool started;
-#ifdef CONFIG_CAN_FD_MODE
-	bool fd;
-#endif /* CONFIG_CAN_FD_MODE */
 	void *custom;
 } __aligned(4);
 
@@ -1237,26 +1232,21 @@ struct can_mcan_callbacks {
  * @brief Bosch M_CAN driver internal configuration structure.
  */
 struct can_mcan_config {
+	const struct can_driver_config common;
 	const struct can_mcan_ops *ops;
 	const struct can_mcan_callbacks *callbacks;
 	uint16_t mram_elements[CAN_MCAN_MRAM_CFG_NUM_CELLS];
 	uint16_t mram_offsets[CAN_MCAN_MRAM_CFG_NUM_CELLS];
 	size_t mram_size;
-	uint32_t bus_speed;
 	uint16_t sjw;
-	uint16_t sample_point;
 	uint16_t prop_ts1;
 	uint16_t ts2;
 #ifdef CONFIG_CAN_FD_MODE
-	uint32_t bus_speed_data;
-	uint16_t sample_point_data;
 	uint8_t sjw_data;
 	uint8_t prop_ts1_data;
 	uint8_t ts2_data;
 	uint8_t tx_delay_comp_offset;
 #endif
-	const struct device *phy;
-	uint32_t max_bitrate;
 	const void *custom;
 };
 
@@ -1311,42 +1301,34 @@ struct can_mcan_config {
 #ifdef CONFIG_CAN_FD_MODE
 #define CAN_MCAN_DT_CONFIG_GET(node_id, _custom, _ops, _cbs)                                       \
 	{                                                                                          \
+		.common = CAN_DT_DRIVER_CONFIG_GET(node_id, 8000000),                              \
 		.ops = _ops,                                                                       \
 		.callbacks = _cbs,                                                                 \
 		.mram_elements = CAN_MCAN_DT_MRAM_ELEMENTS_GET(node_id),                           \
 		.mram_offsets = CAN_MCAN_DT_MRAM_OFFSETS_GET(node_id),                             \
 		.mram_size = CAN_MCAN_DT_MRAM_ELEMENTS_SIZE(node_id),                              \
-		.bus_speed = DT_PROP(node_id, bus_speed),                                          \
 		.sjw = DT_PROP(node_id, sjw),                                                      \
-		.sample_point = DT_PROP_OR(node_id, sample_point, 0),                              \
 		.prop_ts1 = DT_PROP_OR(node_id, prop_seg, 0) + DT_PROP_OR(node_id, phase_seg1, 0), \
 		.ts2 = DT_PROP_OR(node_id, phase_seg2, 0),                                         \
-		.bus_speed_data = DT_PROP(node_id, bus_speed_data),                                \
 		.sjw_data = DT_PROP(node_id, sjw_data),                                            \
-		.sample_point_data = DT_PROP_OR(node_id, sample_point_data, 0),                    \
 		.prop_ts1_data = DT_PROP_OR(node_id, prop_seg_data, 0) +                           \
 				 DT_PROP_OR(node_id, phase_seg1_data, 0),                          \
 		.ts2_data = DT_PROP_OR(node_id, phase_seg2_data, 0),                               \
 		.tx_delay_comp_offset = DT_PROP(node_id, tx_delay_comp_offset),                    \
-		.phy = DEVICE_DT_GET_OR_NULL(DT_PHANDLE(node_id, phys)),                           \
-		.max_bitrate = DT_CAN_TRANSCEIVER_MAX_BITRATE(node_id, 8000000),                   \
 		.custom = _custom,                                                                 \
 	}
 #else /* CONFIG_CAN_FD_MODE */
 #define CAN_MCAN_DT_CONFIG_GET(node_id, _custom, _ops, _cbs)                                       \
 	{                                                                                          \
+		.common = CAN_DT_DRIVER_CONFIG_GET(node_id, 8000000),                              \
 		.ops = _ops,                                                                       \
 		.callbacks = _cbs,                                                                 \
 		.mram_elements = CAN_MCAN_DT_MRAM_ELEMENTS_GET(node_id),                           \
 		.mram_offsets = CAN_MCAN_DT_MRAM_OFFSETS_GET(node_id),                             \
 		.mram_size = CAN_MCAN_DT_MRAM_ELEMENTS_SIZE(node_id),                              \
-		.bus_speed = DT_PROP(node_id, bus_speed),                                          \
 		.sjw = DT_PROP(node_id, sjw),                                                      \
-		.sample_point = DT_PROP_OR(node_id, sample_point, 0),                              \
 		.prop_ts1 = DT_PROP_OR(node_id, prop_seg, 0) + DT_PROP_OR(node_id, phase_seg1, 0), \
 		.ts2 = DT_PROP_OR(node_id, phase_seg2, 0),                                         \
-		.phy = DEVICE_DT_GET_OR_NULL(DT_PHANDLE(node_id, phys)),                           \
-		.max_bitrate = DT_CAN_TRANSCEIVER_MAX_BITRATE(node_id, 1000000),                   \
 		.custom = _custom,                                                                 \
 	}
 #endif /* !CONFIG_CAN_FD_MODE */

--- a/include/zephyr/drivers/can/can_sja1000.h
+++ b/include/zephyr/drivers/can/can_sja1000.h
@@ -102,15 +102,12 @@ typedef uint8_t (*can_sja1000_read_reg_t)(const struct device *dev, uint8_t reg)
  * @brief SJA1000 driver internal configuration structure.
  */
 struct can_sja1000_config {
+	const struct can_driver_config common;
 	can_sja1000_read_reg_t read_reg;
 	can_sja1000_write_reg_t write_reg;
-	uint32_t bitrate;
-	uint32_t sample_point;
 	uint32_t sjw;
 	uint32_t phase_seg1;
 	uint32_t phase_seg2;
-	const struct device *phy;
-	uint32_t max_bitrate;
 	uint8_t ocr;
 	uint8_t cdr;
 	const void *custom;
@@ -128,14 +125,15 @@ struct can_sja1000_config {
  */
 #define CAN_SJA1000_DT_CONFIG_GET(node_id, _custom, _read_reg, _write_reg, _ocr, _cdr)             \
 	{                                                                                          \
-		.read_reg = _read_reg, .write_reg = _write_reg,                                    \
-		.bitrate = DT_PROP(node_id, bus_speed), .sjw = DT_PROP(node_id, sjw),              \
+		.common = CAN_DT_DRIVER_CONFIG_GET(node_id, 1000000),                              \
+		.read_reg = _read_reg,                                                             \
+		.write_reg = _write_reg,                                                           \
+		.sjw = DT_PROP(node_id, sjw),                                                      \
 		.phase_seg1 = DT_PROP_OR(node_id, phase_seg1, 0),                                  \
 		.phase_seg2 = DT_PROP_OR(node_id, phase_seg2, 0),                                  \
-		.sample_point = DT_PROP_OR(node_id, sample_point, 0),                              \
-		.max_bitrate = DT_CAN_TRANSCEIVER_MAX_BITRATE(node_id, 1000000),                   \
-		.phy = DEVICE_DT_GET_OR_NULL(DT_PHANDLE(node_id, phys)),                           \
-		.ocr = _ocr, .cdr = _cdr, .custom = _custom,                                       \
+		.ocr = _ocr,                                                                       \
+		.cdr = _cdr,                                                                       \
+		.custom = _custom,                                                                 \
 	}
 
 /**
@@ -165,14 +163,11 @@ struct can_sja1000_rx_filter {
  * @brief SJA1000 driver internal data structure.
  */
 struct can_sja1000_data {
+	struct can_driver_data common;
 	ATOMIC_DEFINE(rx_allocs, CONFIG_CAN_MAX_FILTER);
 	struct can_sja1000_rx_filter filters[CONFIG_CAN_MAX_FILTER];
 	struct k_mutex mod_lock;
-	bool started;
-	can_mode_t mode;
 	enum can_state state;
-	can_state_change_callback_t state_change_cb;
-	void *state_change_cb_data;
 	struct k_sem tx_idle;
 	can_tx_callback_t tx_callback;
 	void *tx_user_data;


### PR DESCRIPTION
Add structs and initializers for common CAN controller driver configuration and data fields. Refactor all in-tree drivers to use these.

This is refactoring is a clean-up and preparation for moving some of the driver API functions to be common functions (e.g. `can_get_max_bitrate()`) and introducing new common functions (e.g. `can_get_transceiver()`, `can_get_mode()`, ...).

There are no functional changes in this PR.