### PR TITLE
xtensa: mmu: Optimize autorefill invalidation

### DIFF
--- a/arch/xtensa/include/xtensa_mmu_priv.h
+++ b/arch/xtensa/include/xtensa_mmu_priv.h
@@ -339,10 +339,11 @@ static inline void xtensa_tlb_autorefill_invalidate(void)
 		for (i = 0; i < entries; i++) {
 			uint32_t entry = way + (i << XTENSA_MMU_PTE_PPN_SHIFT);
 
-			xtensa_dtlb_entry_invalidate_sync(entry);
-			xtensa_itlb_entry_invalidate_sync(entry);
+			xtensa_dtlb_entry_invalidate(entry);
+			xtensa_itlb_entry_invalidate(entry);
 		}
 	}
+	__asm__ volatile("isync");
 }
 
 /**


### PR DESCRIPTION
There is no need to sync in every xtlb invalidation. Sync only after all tlb autofill ways invalidation.