### PR TITLE
tests: sprintf: Avoid buffer overrun

### DIFF
--- a/tests/lib/sprintf/src/main.c
+++ b/tests/lib/sprintf/src/main.c
@@ -909,10 +909,10 @@ ZTEST(sprintf, test_fwrite)
 	ret = fwrite("This 3", 0, 4, stdout);
 	zassert_equal(ret, 0, "fwrite failed!");
 
-	ret = fwrite("This 3", 4, 4, stdout);
+	ret = fwrite("This 3", 1, 4, stdout);
 	zassert_equal(ret, 4, "fwrite failed!");
 
-	ret = fwrite("This 3", 4, 4, stdin);
+	ret = fwrite("This 3", 1, 4, stdin);
 	zassert_equal(ret, 0, "fwrite failed!");
 }
 


### PR DESCRIPTION
fwrite parameters are "size_t size" and "size_t nmemb", when writing a string we should set sizeof(char) and len(string). The test is doing it wrongly and making the function read more memory than it should.