### PR TITLE
input: add a keymap driver

### DIFF
--- a/dts/bindings/input/input-keymap.yaml
+++ b/dts/bindings/input/input-keymap.yaml
@@ -1,0 +1,53 @@
+# Copyright 2024 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Row-column to key mapper
+
+  Listens for row-column events from the parent device and reports key events.
+
+  Example configuration:
+
+  #include <zephyr/dt-bindings/input/input-event-codes.h>
+  #include <zephyr/dt-bindings/input/keymap.h>
+
+  kbd {
+      ...
+      keymap {
+          compatible = "input-keymap";
+          keymap = <
+              MATRIX_KEY(0, 0, INPUT_KEY_1)
+              MATRIX_KEY(0, 1, INPUT_KEY_2)
+              MATRIX_KEY(0, 2, INPUT_KEY_3)
+              MATRIX_KEY(1, 0, INPUT_KEY_4)
+              MATRIX_KEY(1, 1, INPUT_KEY_5)
+              MATRIX_KEY(1, 2, INPUT_KEY_6)
+              MATRIX_KEY(2, 0, INPUT_KEY_7)
+              MATRIX_KEY(2, 1, INPUT_KEY_8)
+              MATRIX_KEY(2, 2, INPUT_KEY_9)
+          >;
+          row-size = <3>;
+          col-size = <3>;
+      };
+  };
+
+compatible: "input-keymap"
+
+properties:
+  keymap:
+    type: array
+    required: true
+    description: |
+      List of codes, using the MATRIX_KEY() macro.
+
+  row-size:
+    type: int
+    required: true
+    description: |
+      The number of rows in the keymap.
+
+  col-size:
+    type: int
+    required: true
+    description: |
+      The number of columns in the keymap.

--- a/include/zephyr/dt-bindings/input/input-event-codes.h
+++ b/include/zephyr/dt-bindings/input/input-event-codes.h
@@ -35,6 +35,8 @@
  * @anchor INPUT_KEY_CODES
  * @{
  */
+#define INPUT_KEY_RESERVED 0            /**< Reserved, do not use */
+
 #define INPUT_KEY_0 11                  /**< 0 Key */
 #define INPUT_KEY_1 2                   /**< 1 Key */
 #define INPUT_KEY_2 3                   /**< 2 Key */

--- a/include/zephyr/dt-bindings/input/keymap.h
+++ b/include/zephyr/dt-bindings/input/keymap.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_INPUT_KEYMAP_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_INPUT_KEYMAP_H_
+
+#define MATRIX_KEY(row, col, code) \
+	((((row) & 0xff) << 24) | (((col) & 0xff) << 16) | ((code) & 0xffff))
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_INPUT_KEYMAP_H_ */

--- a/include/zephyr/input/input_keymap.h
+++ b/include/zephyr/input/input_keymap.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_INPUT_INPUT_KEYMAP_H_
+#define ZEPHYR_INCLUDE_INPUT_INPUT_KEYMAP_H_
+
+#define MATRIX_ROW(keymap_entry) (((keymap_entry) >> 24) & 0xff)
+#define MATRIX_COL(keymap_entry) (((keymap_entry) >> 16) & 0xff)
+
+#endif /* ZEPHYR_INCLUDE_INPUT_INPUT_KEYMAP_H_ */

--- a/subsys/input/CMakeLists.txt
+++ b/subsys/input/CMakeLists.txt
@@ -5,4 +5,5 @@ zephyr_library()
 zephyr_library_sources(input.c)
 zephyr_library_sources(input_utils.c)
 
+zephyr_library_sources_ifdef(CONFIG_INPUT_KEYMAP input_keymap.c)
 zephyr_library_sources_ifdef(CONFIG_INPUT_LONGPRESS input_longpress.c)

--- a/subsys/input/Kconfig
+++ b/subsys/input/Kconfig
@@ -85,5 +85,14 @@ config INPUT_LONGPRESS
 	bool "Input longpress"
 	default y
 	depends on DT_HAS_ZEPHYR_INPUT_LONGPRESS_ENABLED
+	help
+	  Enable the input longpress driver.
+
+config INPUT_KEYMAP
+	bool "Input keymap"
+	default y
+	depends on DT_HAS_INPUT_KEYMAP_ENABLED
+	help
+	  Enable the input keymap driver.
 
 endif # INPUT

--- a/subsys/input/input_keymap.c
+++ b/subsys/input/input_keymap.c
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT input_keymap
+
+#include <zephyr/device.h>
+#include <zephyr/dt-bindings/input/keymap.h>
+#include <zephyr/input/input.h>
+#include <zephyr/input/input_keymap.h>
+#include <zephyr/kernel.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(input_keymap, CONFIG_INPUT_LOG_LEVEL);
+
+struct keymap_config {
+	const struct device *input_dev;
+	const uint16_t *codes;
+	uint32_t num_codes;
+	uint8_t row_size;
+	uint8_t col_size;
+};
+
+struct keymap_data {
+	uint32_t row;
+	uint32_t col;
+	bool pressed;
+};
+
+static void keymap_cb(const struct device *dev, struct input_event *evt)
+{
+	const struct keymap_config *cfg = dev->config;
+	struct keymap_data *data = dev->data;
+	const uint16_t *codes = cfg->codes;
+	uint32_t offset;
+
+	switch (evt->code) {
+	case INPUT_ABS_X:
+		data->col = evt->value;
+		break;
+	case INPUT_ABS_Y:
+		data->row = evt->value;
+		break;
+	case INPUT_BTN_TOUCH:
+		data->pressed = evt->value;
+		break;
+	}
+
+	if (!evt->sync) {
+		return;
+	}
+
+	if (data->row >= cfg->row_size ||
+	    data->col >= cfg->col_size) {
+		LOG_WRN("keymap event out of range: row=%u col=%u", data->row, data->col);
+		return;
+	}
+
+	offset = (data->row * cfg->col_size) + data->col;
+
+	if (offset >= cfg->num_codes || codes[offset] == 0) {
+		LOG_DBG("keymap event undefined: row=%u col=%u", data->row, data->col);
+		return;
+	}
+
+	LOG_DBG("input event: %3u %3u %d", data->row, data->col, data->pressed);
+
+	input_report_key(dev, codes[offset], data->pressed, true, K_FOREVER);
+}
+
+static int keymap_init(const struct device *dev)
+{
+	const struct keymap_config *cfg = dev->config;
+
+	if (!device_is_ready(cfg->input_dev)) {
+		LOG_ERR("input device not ready");
+		return -ENODEV;
+	}
+
+	return 0;
+}
+
+#define KEYMAP_ENTRY_OFFSET(keymap_entry, col_size) \
+	(MATRIX_ROW(keymap_entry) * col_size + MATRIX_COL(keymap_entry))
+
+#define KEYMAP_ENTRY_CODE(keymap_entry) (keymap_entry & 0xffff)
+
+#define KEYMAP_ENTRY_VALIDATE(node_id, prop, idx)			\
+	BUILD_ASSERT(MATRIX_ROW(DT_PROP_BY_IDX(node_id, prop, idx)) <	\
+		     DT_PROP(node_id, row_size), "invalid row");	\
+	BUILD_ASSERT(MATRIX_COL(DT_PROP_BY_IDX(node_id, prop, idx)) <	\
+		     DT_PROP(node_id, col_size), "invalid col");
+
+#define CODES_INIT(node_id, prop, idx) \
+	[KEYMAP_ENTRY_OFFSET(DT_PROP_BY_IDX(node_id, prop, idx), DT_PROP(node_id, col_size))] = \
+		KEYMAP_ENTRY_CODE(DT_PROP_BY_IDX(node_id, prop, idx)),
+
+#define INPUT_KEYMAP_DEFINE(inst)								\
+	static void keymap_cb_##inst(struct input_event *evt)					\
+	{											\
+		keymap_cb(DEVICE_DT_INST_GET(inst), evt);					\
+	}											\
+	INPUT_CALLBACK_DEFINE(DEVICE_DT_GET_OR_NULL(DT_INST_PARENT(inst)), keymap_cb_##inst);	\
+												\
+	DT_INST_FOREACH_PROP_ELEM(inst, keymap, KEYMAP_ENTRY_VALIDATE)				\
+												\
+	static const uint16_t keymap_codes_##inst[] = {						\
+		DT_INST_FOREACH_PROP_ELEM(inst, keymap, CODES_INIT)				\
+	};											\
+												\
+	static const struct keymap_config keymap_config_##inst = {				\
+		.input_dev = DEVICE_DT_GET(DT_INST_PARENT(inst)),				\
+		.codes = keymap_codes_##inst,							\
+		.num_codes = ARRAY_SIZE(keymap_codes_##inst),					\
+		.row_size = DT_INST_PROP(inst, row_size),					\
+		.col_size = DT_INST_PROP(inst, col_size),					\
+	};											\
+												\
+	static struct keymap_data keymap_data_##inst;						\
+												\
+	DEVICE_DT_INST_DEFINE(inst, keymap_init, NULL,						\
+			      &keymap_data_##inst, &keymap_config_##inst,			\
+			      POST_KERNEL, CONFIG_INPUT_INIT_PRIORITY, NULL);
+
+DT_INST_FOREACH_STATUS_OKAY(INPUT_KEYMAP_DEFINE)

--- a/tests/drivers/build_all/input/app.overlay
+++ b/tests/drivers/build_all/input/app.overlay
@@ -64,6 +64,13 @@
 				    <&test_gpio 3 GPIO_ACTIVE_LOW>,
 				    <&test_gpio 4 GPIO_ACTIVE_LOW>;
 			actual-key-mask = <0x0f 0x0a 0x0b>;
+
+			keymap {
+				compatible = "input-keymap";
+				keymap = <0 1 2>;
+				row-size = <2>;
+				col-size = <2>;
+			};
 		};
 
 		kbd-matrix-1 {


### PR DESCRIPTION
This allows using keyboard matrix devices with applications taking input key events. Rejects invalid entries at build time, deals with gaps in runtime.

---

Add a "input-keymap" driver to translate keyboard matrix event into key events.