### PR TITLE
boards: mimxrt1015_evk: enable support for linkserver

### DIFF
--- a/boards/arm/mimxrt1015_evk/board.cmake
+++ b/boards/arm/mimxrt1015_evk/board.cmake
@@ -1,10 +1,13 @@
 #
-# Copyright (c) 2019, NXP
+# Copyright (c) 2019, 2024 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 
 board_runner_args(pyocd "--target=mimxrt1015")
 board_runner_args(jlink "--device=MIMXRT1015")
+board_runner_args(linkserver  "--device=MIMXRT1015xxxxx:EVK-MIMXRT1015")
+
+include(${ZEPHYR_BASE}/boards/common/linkserver.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/mimxrt1015_evk/doc/index.rst
+++ b/boards/arm/mimxrt1015_evk/doc/index.rst
@@ -168,13 +168,26 @@ Configuring a Debug Probe
 =========================
 
 A debug probe is used for both flashing and debugging the board. This board is
-configured by default to use the :ref:`opensda-daplink-onboard-debug-probe`,
-however the :ref:`pyocd-debug-host-tools` do not yet support programming the
-external flashes on this board so you must reconfigure the board for one of the
-following debug probes instead.
+configured by default to use the :ref:`opensda-daplink-onboard-debug-probe`.
 
-:ref:`jlink-external-debug-probe`
--------------------------------------------
+Using LinkServer: :ref:`opensda-daplink-onboard-debug-probe`
+------------------------------------------------------------
+
+Install the :ref:`linkserver-debug-host-tools` and make sure they are in your
+search path.  LinkServer works with the default CMSIS-DAP firmware included in
+the on-board debugger.
+
+Linkserver is the default runner. You may also se the ``-r linkserver`` option
+with West to use the LinkServer runner.
+
+.. code-block:: console
+
+   west flash
+   west debug
+
+
+External JLink: :ref:`jlink-external-debug-probe`
+-------------------------------------------------
 
 Install the :ref:`jlink-debug-host-tools` and make sure they are in your search
 path.


### PR DESCRIPTION
- adds the definitions in the board.cmake file
- updates documentation