### PR TITLE
tests: drivers: can: api: add testcase for testing CANXL non RX FIFO

### DIFF
--- a/drivers/can/can_nxp_s32_canxl.c
+++ b/drivers/can/can_nxp_s32_canxl.c
@@ -50,6 +50,10 @@
 #define CAN_NXP_S32_RX_FIFO_WATERMARK 1
 #endif
 
+#if defined(CONFIG_CAN_FD_MODE) && defined(CONFIG_CAN_NXP_S32_RX_FIFO)
+#define CAN_NXP_S32_FD_MODE 1
+#endif
+
 LOG_MODULE_REGISTER(nxp_s32_canxl, CONFIG_CAN_LOG_LEVEL);
 
 #define SP_AND_TIMING_NOT_SET(inst)				\
@@ -62,7 +66,7 @@ LOG_MODULE_REGISTER(nxp_s32_canxl, CONFIG_CAN_LOG_LEVEL);
 #error You must either set a sampling-point or timings (phase-seg* and prop-seg)
 #endif
 
-#ifdef CONFIG_CAN_FD_MODE
+#ifdef CAN_NXP_S32_FD_MODE
 
 #define SP_AND_TIMING_DATA_NOT_SET(inst)			\
 	(!DT_INST_NODE_HAS_PROP(inst, sample_point_data) &&	\
@@ -91,7 +95,7 @@ struct can_nxp_s32_config {
 	uint32_t prop_seg;
 	uint32_t phase_seg1;
 	uint32_t phase_seg2;
-#ifdef CONFIG_CAN_FD_MODE
+#ifdef CAN_NXP_S32_FD_MODE
 	uint32_t sjw_data;
 	uint32_t prop_seg_data;
 	uint32_t phase_seg1_data;
@@ -140,7 +144,7 @@ struct can_nxp_s32_data {
 #endif
 
 	struct can_timing timing;
-#ifdef CONFIG_CAN_FD_MODE
+#ifdef CAN_NXP_S32_FD_MODE
 	struct can_timing timing_data;
 #endif
 	enum can_state state;
@@ -152,7 +156,7 @@ static int can_nxp_s32_get_capabilities(const struct device *dev, can_mode_t *ca
 
 	*cap = CAN_MODE_NORMAL | CAN_MODE_LOOPBACK | CAN_MODE_LISTENONLY;
 
-#if CONFIG_CAN_FD_MODE
+#ifdef CAN_NXP_S32_FD_MODE
 	*cap |= CAN_MODE_FD;
 #endif
 
@@ -309,7 +313,7 @@ static int can_nxp_s32_set_mode(const struct device *dev, can_mode_t mode)
 	if (data->common.started) {
 		return -EBUSY;
 	}
-#ifdef CONFIG_CAN_FD_MODE
+#ifdef CAN_NXP_S32_FD_MODE
 	if ((mode & ~(CAN_MODE_LOOPBACK | CAN_MODE_LISTENONLY | CAN_MODE_FD)) != 0) {
 #else
 	if ((mode & ~(CAN_MODE_LOOPBACK | CAN_MODE_LISTENONLY)) != 0) {
@@ -589,7 +593,7 @@ static int can_nxp_s32_send(const struct device *dev,
 
 	__ASSERT_NO_MSG(callback != NULL);
 
-#ifdef CONFIG_CAN_FD_MODE
+#ifdef CAN_NXP_S32_FD_MODE
 	if ((frame->flags & ~(CAN_FRAME_IDE | CAN_FRAME_FDF | CAN_FRAME_BRS)) != 0) {
 		LOG_ERR("unsupported CAN frame flags 0x%02x", frame->flags);
 		return -ENOTSUP;
@@ -624,7 +628,7 @@ static int can_nxp_s32_send(const struct device *dev,
 			LOG_ERR("DLC of %d for non-FD format frame", frame->dlc);
 			return -EINVAL;
 		}
-#ifdef CONFIG_CAN_FD_MODE
+#ifdef CAN_NXP_S32_FD_MODE
 	} else {
 		if (frame->dlc > CANFD_MAX_DLC) {
 			LOG_ERR("DLC of %d for CAN FD format frame", frame->dlc);
@@ -725,7 +729,7 @@ static int can_nxp_s32_set_timing(const struct device *dev,
 	return 0;
 }
 
-#ifdef CONFIG_CAN_FD_MODE
+#ifdef CAN_NXP_S32_FD_MODE
 static int can_nxp_s32_set_timing_data(const struct device *dev,
 			const struct can_timing *timing_data)
 {
@@ -991,7 +995,7 @@ static int can_nxp_s32_init(const struct device *dev)
 	LOG_DBG("Setting CAN bitrate %d:", config->common.bus_speed);
 	nxp_s32_zcan_timing_to_canxl_timing(&data->timing, &config->can_cfg->bitrate);
 
-#ifdef CONFIG_CAN_FD_MODE
+#ifdef CAN_NXP_S32_FD_MODE
 	data->timing_data.sjw = config->sjw_data;
 	if (config->common.sample_point_data) {
 		err = can_calc_timing_data(dev, &data->timing_data, config->common.bus_speed_data,
@@ -1093,7 +1097,7 @@ static const struct can_driver_api can_nxp_s32_driver_api = {
 		.phase_seg2 = 0x08,
 		.prescaler = 0x100
 	},
-#ifdef CONFIG_CAN_FD_MODE
+#ifdef CAN_NXP_S32_FD_MODE
 	.set_timing_data = can_nxp_s32_set_timing_data,
 	.timing_data_min = {
 		.sjw = 0x01,
@@ -1145,17 +1149,15 @@ static const struct can_driver_api can_nxp_s32_driver_api = {
 		can_nxp_s32_ctrl_callback(dev, eventType, buffIdx, canexcelState);	\
 	}
 
-#if defined(CONFIG_CAN_FD_MODE)
+#if defined(CAN_NXP_S32_FD_MODE)
 #define CAN_NXP_S32_TIMING_DATA_CONFIG(n)						\
 		.sjw_data = DT_INST_PROP(n, sjw_data),					\
 		.prop_seg_data = DT_INST_PROP_OR(n, prop_seg_data, 0),			\
 		.phase_seg1_data = DT_INST_PROP_OR(n, phase_seg1_data, 0),		\
 		.phase_seg2_data = DT_INST_PROP_OR(n, phase_seg2_data, 0),
-#define CAN_NXP_S32_FD_MODE	1
 #define CAN_NXP_S32_BRS		1
 #else
 #define CAN_NXP_S32_TIMING_DATA_CONFIG(n)
-#define CAN_NXP_S32_FD_MODE	0
 #define CAN_NXP_S32_BRS		0
 #endif
 
@@ -1190,7 +1192,7 @@ static const struct can_driver_api can_nxp_s32_driver_api = {
 							0 : CONFIG_CAN_NXP_S32_MAX_RX,	\
 		.tx_mbdesc = (uint8)CONFIG_CAN_NXP_S32_MAX_TX,				\
 		.CanxlMode = CANEXCEL_LISTEN_ONLY_MODE,					\
-		.fd_enable = (boolean)CAN_NXP_S32_FD_MODE,				\
+		.fd_enable = (boolean)IS_ENABLED(CAN_NXP_S32_FD_MODE),			\
 		.bitRateSwitch = (boolean)CAN_NXP_S32_BRS,				\
 		.ctrlOptions = (uint32)CAN_NXP_S32_CTRL_OPTIONS,			\
 		.Callback = nxp_s32_can_##n##_ctrl_callback,				\

--- a/tests/drivers/can/api/src/common.c
+++ b/tests/drivers/can/api/src/common.c
@@ -80,6 +80,7 @@ const struct can_frame test_ext_rtr_frame_1 = {
 	.data    = {0}
 };
 
+#ifdef CONFIG_CAN_FD_MODE
 /**
  * @brief Standard (11-bit) CAN ID frame 1 with CAN FD payload.
  */
@@ -107,6 +108,7 @@ const struct can_frame test_std_fdf_frame_2 = {
 		    46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60,
 		    61, 62, 63, 64 }
 };
+#endif /* CONFIG_CAN_FD_MODE */
 
 /**
  * @brief Standard (11-bit) CAN ID filter 1. This filter matches

--- a/tests/drivers/can/api/src/common.h
+++ b/tests/drivers/can/api/src/common.h
@@ -86,6 +86,7 @@ extern const struct can_frame test_std_rtr_frame_1;
  */
 extern const struct can_frame test_ext_rtr_frame_1;
 
+#ifdef CONFIG_CAN_FD_MODE
 /**
  * @brief Standard (11-bit) CAN ID frame 1 with CAN FD payload.
  */
@@ -95,6 +96,7 @@ extern const struct can_frame test_std_fdf_frame_1;
  * @brief Standard (11-bit) CAN ID frame 2 with CAN FD payload.
  */
 extern const struct can_frame test_std_fdf_frame_2;
+#endif /* CONFIG_CAN_FD_MODE */
 
 /**
  * @brief Standard (11-bit) CAN ID filter 1. This filter matches

--- a/tests/drivers/can/api/src/utilities.c
+++ b/tests/drivers/can/api/src/utilities.c
@@ -109,9 +109,11 @@ ZTEST(can_utilities, test_can_frame_matches_filter)
 	zassert_true(can_frame_matches_filter(&test_std_rtr_frame_1, &test_std_filter_1));
 	zassert_true(can_frame_matches_filter(&test_ext_rtr_frame_1, &test_ext_filter_1));
 
+#ifdef CONFIG_CAN_FD_MODE
 	/* CAN FD format frames and filters */
 	zassert_true(can_frame_matches_filter(&test_std_fdf_frame_1, &test_std_filter_1));
 	zassert_true(can_frame_matches_filter(&test_std_fdf_frame_2, &test_std_filter_2));
+#endif /* CONFIG_CAN_FD_MODE */
 }
 
 ZTEST_SUITE(can_utilities, NULL, NULL, NULL, NULL, NULL);

--- a/tests/drivers/can/api/testcase.yaml
+++ b/tests/drivers/can/api/testcase.yaml
@@ -20,3 +20,7 @@ tests:
       - esp32s2_saola
       - esp32s3_devkitm
       - xiao_esp32s3
+  drivers.can.api.nxp_s32_canxl.non_rx_fifo:
+    extra_configs:
+      - CONFIG_CAN_NXP_S32_RX_FIFO=n
+    filter: dt_compat_enabled("nxp,s32-canxl")


### PR DESCRIPTION
Add testcase for testing CANXL non RX FIFO on s32z270dc2 board

```
python3 scripts/twister -p s32z270dc2_rtu0_r52  --disable-warnings-as-errors --device-testing --device-serial=/dev/ttyUSB0 -v --west-runner trace32 --west-flash="--config=/opt/tools/trace32/config.t32" -T tests/drivers/can/api/
INFO    - Using Ninja..
INFO    - Zephyr version: 0d9bb76dd32f
INFO    - Using 'zephyr' toolchain.
INFO    - Building initial testsuite list...

Device testing on:

| Platform            | ID   | Serial device   |
|---------------------|------|-----------------|
| s32z270dc2_rtu0_r52 |      | /dev/ttyUSB0    |

INFO    - JOBS: 4
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - 2/4 s32z270dc2_rtu0_r52       tests/drivers/can/api/drivers.can.api.rtr          PASSED (device 18.347s)
INFO    - 3/4 s32z270dc2_rtu0_r52       tests/drivers/can/api/drivers.can.api              PASSED (device 17.929s)
INFO    - 4/4 s32z270dc2_rtu0_r52       tests/drivers/can/api/drivers.can.api.nxp_s32_canxl.non_rx_fifo PASSED (device 18.107s)

INFO    - 4 test scenarios (4 test instances) selected, 1 configurations skipped (1 by static filter, 0 at runtime).
INFO    - 3 of 4 test configurations passed (100.00%), 0 failed, 0 errored, 1 skipped with 0 warnings in 249.57 seconds
INFO    - In total 121 test cases were executed, 58 skipped on 1 out of total 673 platforms (0.15%)
INFO    - 3 test configurations executed on platforms, 0 test configurations were only built.

```


