### PR TITLE
scripts: board_v1_to_v2: License&copyright + SOC_SERIES fix

### DIFF
--- a/scripts/utils/board_v1_to_v2.py
+++ b/scripts/utils/board_v1_to_v2.py
@@ -156,19 +156,27 @@ def board_v1_to_v2(board_root, board, new_board, group, vendor, soc, variants):
         board_kconfig_defconfig_file.unlink()
 
     print(f"Creating or updating Kconfig.{new_board}...")
+    board_kconfig_file = new_board_path / "Kconfig.board"
+    with open(board_kconfig_file) as f:
+        for line in f.readlines():
+            if "Copyright" in line:
+                copyright = line
     new_board_kconfig_file = new_board_path / f"Kconfig.{new_board}"
-    selects = "\n\t" + "\n\t".join(["select " + setting for setting in board_soc_settings])
+    header = "# SPDX-License-Identifier: Apache-2.0\n"
+    if copyright is not None:
+        header = copyright + header
+    selects = "\n\t" + "\n\t".join(["select " + setting for setting in board_soc_settings]) + "\n"
     if not new_board_kconfig_file.exists():
         with open(new_board_kconfig_file, "w") as f:
             f.write(
-                f"config BOARD_{new_board.upper()}{selects}"
+                header +
+                f"\nconfig BOARD_{new_board.upper()}{selects}"
             )
     else:
         with open(new_board_kconfig_file, "a") as f:
             f.write(selects)
 
     print("Removing old Kconfig.board...")
-    board_kconfig_file = new_board_path / "Kconfig.board"
     board_kconfig_file.unlink()
 
     print("Conversion done!")

--- a/scripts/utils/board_v1_to_v2.py
+++ b/scripts/utils/board_v1_to_v2.py
@@ -103,8 +103,9 @@ def board_v1_to_v2(board_root, board, new_board, group, vendor, soc, variants):
 
             m = re.match(r"^CONFIG_(SOC_[A-Z0-9_]+).*$", line)
             if m:
-                board_soc_settings.append(m.group(1))
                 dropped_line = True
+                if re.match(r"(?!SERIES_).*$", str(m)):
+                    board_soc_settings.append(m.group(1))
                 continue
 
             if dropped_line and re.match(r"^$", line):


### PR DESCRIPTION
This PR is adding 2 changes:

- When creating file Kconfig.<board> a copyright is required as otherwise an issue will be reported by CI scan code tool.
Always add License (SPDX) and add the option to put a copyright.

- Don't add select CONFIG_SOC_SERIES_FOO as part of board description. It is done at soc level.