### PR TITLE
input: utils: fix kbd_matrix_state_log types

### DIFF
--- a/subsys/input/input_utils.c
+++ b/subsys/input/input_utils.c
@@ -165,7 +165,8 @@ static void kbd_matrix_state_log_entry(char *header, kbd_row_t *data)
 static void kbd_matrix_state_log(struct input_event *evt)
 {
 	const struct input_kbd_matrix_common_config *cfg;
-	static int row, col, val;
+	static uint32_t row, col;
+	static bool val;
 
 	if (kbd_matrix_state_dev == NULL || kbd_matrix_state_dev != evt->dev) {
 		return;


### PR DESCRIPTION
Change row and col static types to unsigned, this should prevent really bad things from happening if a negative number ends up there for whatever reasons without having to explicitly check for < 0.