### PR TITLE
scripts: tests: twister_blackbox: Added the ability to clear log from the code

### DIFF
--- a/scripts/tests/twister_blackbox/conftest.py
+++ b/scripts/tests/twister_blackbox/conftest.py
@@ -34,6 +34,11 @@ def zephyr_test_directory():
 
 @pytest.fixture
 def clear_log():
+    # clear_log is used by pytest fixture
+    # However, clear_log_in_test is prepared to be used directly in the code, wherever required
+    clear_log_in_test()
+
+def clear_log_in_test():
     # Required to fix the pytest logging error
     # See: https://github.com/pytest-dev/pytest/issues/5502
     loggers = [logging.getLogger()] \

--- a/scripts/tests/twister_blackbox/test_hardwaremap.py
+++ b/scripts/tests/twister_blackbox/test_hardwaremap.py
@@ -5,14 +5,13 @@
 """
 Blackbox tests for twister's command line functions
 """
-import logging
 import importlib
 import mock
 import os
 import pytest
 import sys
 
-from conftest import ZEPHYR_BASE, testsuite_filename_mock
+from conftest import ZEPHYR_BASE, testsuite_filename_mock, clear_log_in_test
 from twisterlib.testplan import TestPlan
 
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister/twisterlib"))
@@ -155,14 +154,7 @@ class TestHardwaremap:
                         os.remove(path)
 
                     assert str(sys_exit.value) == '0'
-                    loggers = [logging.getLogger()] + \
-                              list(logging.Logger.manager.loggerDict.values()) + \
-                              [logging.getLogger(name) for \
-                               name in logging.root.manager.loggerDict]
-                    for logger in loggers:
-                        handlers = getattr(logger, 'handlers', [])
-                        for handler in handlers:
-                            logger.removeHandler(handler)
+                    clear_log_in_test()
 
     @pytest.mark.parametrize(
         ('manufacturer', 'product', 'serial', 'runner'),


### PR DESCRIPTION
**clear_log** is used as a fixture by pytest. We need to be able to call it from the code level. Example of use in the file test_harwaremap.py line 157.

Sometimes it is necessary to trigger the twister several times. Then the lines in the log start to double. In the case of the second inclusion, they will be duplicated. If we turn it on a third time, there will be three, etc. That's why the **clear_log** method is useful in such cases.
E.g.:
```
INFO - Using Ninja..
INFO - Using Ninja..
INFO - Using Ninja..
INFO - Zephyr version: zephyr-v3.5.0-4117-gca8ee0e02980
INFO - Zephyr version: zephyr-v3.5.0-4117-gca8ee0e02980
INFO - Zephyr version: zephyr-v3.5.0-4117-gca8ee0e02980
INFO - Using 'zephyr' toolchain.
INFO - Using 'zephyr' toolchain.
INFO - Using 'zephyr' toolchain.
```