### PR TITLE
usbc: fix shadowed declaration build error

### DIFF
--- a/subsys/usb/usb_c/usbc_tc_src_states.c
+++ b/subsys/usb/usb_c/usbc_tc_src_states.c
@@ -257,8 +257,6 @@ void tc_attached_src_entry(void *obj)
 
 	/* Enable the VBUS sourcing by the PPC */
 	if (data->ppc != NULL) {
-		int ret;
-
 		ret = ppc_set_src_ctrl(data->ppc, true);
 		if (ret < 0 && ret != -ENOSYS) {
 			LOG_ERR("Couldn't disable PPC source");
@@ -317,8 +315,6 @@ void tc_attached_src_exit(void *obj)
 
 	/* Disable the VBUS sourcing by the PPC */
 	if (data->ppc != NULL) {
-		int ret;
-
 		ret = ppc_set_src_ctrl(data->ppc, false);
 		if (ret < 0 && ret != -ENOSYS) {
 			LOG_ERR("Couldn't disable PPC source");


### PR DESCRIPTION
Fixes:

/__w/zephyr/zephyr/subsys/usb/usb_c/usbc_tc_src_states.c:260:21: error: declaration of 'ret' shadows a previous local [-Werror=shadow]