### PR TITLE
drivers: ieee802154: fix nRF5 Rx error handling

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.h
+++ b/drivers/ieee802154/ieee802154_nrf5.h
@@ -110,6 +110,9 @@ struct nrf5_802154_data {
 	/* The last configured value of CSL phase time in nanoseconds. */
 	net_time_t csl_rx_time;
 #endif /* CONFIG_NRF_802154_SER_HOST && CONFIG_IEEE802154_CSL_ENDPOINT */
+
+	/* Indicates if RxOnWhenIdle mode is enabled. */
+	bool rx_on_when_idle;
 };
 
 #endif /* ZEPHYR_DRIVERS_IEEE802154_IEEE802154_NRF5_H_ */


### PR DESCRIPTION
The current implementation implicitly assumes that if the device is configured to have the capability of acting as a CSL endpoint then in case a delayed reception with matching ID finishes with a timeout no action is needed. This assumption is correct when RxOnWhenIdle mode is disabled because the transition to sleep is done automatically by the driver below. However, it's wrong when RxOnWhenIdle is enabled. This commit fixes that case by adding a call to event handler that notifies the higher layer about the event and allows it to transition to RxOff if needed.