### PR TITLE
github: footprint: set ZEPHYR_SDK_INSTALL_DIR after the rebase

### DIFF
--- a/.github/workflows/footprint.yml
+++ b/.github/workflows/footprint.yml
@@ -36,10 +36,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
-      - name: Environment Setup
-        run: |
-          echo "ZEPHYR_SDK_INSTALL_DIR=/opt/toolchains/zephyr-sdk-$( cat SDK_VERSION )" >> $GITHUB_ENV
-
       - name: west setup
         run: |
           west init -l . || true
@@ -56,6 +52,9 @@ jobs:
           git remote -v
           git rebase origin/${BASE_REF}
           git checkout -b this_pr
+
+          export ZEPHYR_SDK_INSTALL_DIR=/opt/toolchains/zephyr-sdk-$( cat SDK_VERSION )
+
           west update
           west build -b frdm_k64f  tests/benchmarks/footprints -t ram_report
           cp build/ram.json ram2.json


### PR DESCRIPTION
The ZEPHYR_SDK_INSTALL_DIR currently tries to read the SDK_VERSION at the PR base ref, but this has only been introduced recently. Move the ZEPHYR_SDK_INSTALL_DIR settings down as part of the build step after the rebase so the file will always be found from now, even on old PRs.