### PR TITLE
drivers: i2s_nrfx: Generate master clock if pin is connected

### DIFF
--- a/drivers/i2s/i2s_nrfx.c
+++ b/drivers/i2s/i2s_nrfx.c
@@ -524,7 +524,8 @@ static int i2s_nrfx_configure(const struct device *dev, enum i2s_dir dir,
 	 * the MCK output is used), find a suitable clock configuration for it.
 	 */
 	if (nrfx_cfg.mode == NRF_I2S_MODE_MASTER ||
-	    nrfx_cfg.mck_pin != NRF_I2S_PIN_NOT_CONNECTED) {
+	    (nrf_i2s_mck_pin_get(drv_cfg->i2s.p_reg) & I2S_PSEL_MCK_CONNECT_Msk)
+	    == I2S_PSEL_MCK_CONNECT_Connected << I2S_PSEL_MCK_CONNECT_Pos) {
 		find_suitable_clock(drv_cfg, &nrfx_cfg, i2s_cfg);
 		/* Unless the PCLK32M source is used with the HFINT oscillator
 		 * (which is always available without any additional actions),


### PR DESCRIPTION
The driver uses pinctrl to configure pins instead of nrfx I2S API. Check whether MCK pin was actually connected by pinctrl instead of comparing nrfx_cfg.mck_pin that is always NRF_I2S_PIN_NOT_CONNECTED.

This makes it possible for nRF I2S to provide master clock even when operating in I2S Slave mode.