### PR TITLE
samples: modules: tflite-micro: remove incorrect check

### DIFF
--- a/samples/modules/tflite-micro/magic_wand/src/accelerometer_handler.cpp
+++ b/samples/modules/tflite-micro/magic_wand/src/accelerometer_handler.cpp
@@ -40,13 +40,8 @@ TfLiteStatus SetupAccelerometer()
 		return kTfLiteApplicationError;
 	}
 
-	if (sensor == NULL) {
-		MicroPrintf("Failed to get accelerometer, name: %s\n",
-				    sensor->name);
-	} else {
-		MicroPrintf("Got accelerometer, name: %s\n",
-				    sensor->name);
-	}
+	MicroPrintf("Got accelerometer, name: %s\n", sensor->name);
+
 	return kTfLiteOk;
 }
 


### PR DESCRIPTION
sensor cannot be null because it is initialized with DEVICE_DT_GET_ONE, which always resolves to a device. The deleted check triggered a compiler warning ("warning: the address of '__device_dts_ord_23' will never be NULL").

Found in CI: https://github.com/zephyrproject-rtos/zephyr/actions/runs/7543234717/job/20533850675?pr=67673