### PR TITLE
net: socket_service: Fix iterable section location

### DIFF
--- a/include/zephyr/linker/common-rom/common-rom-net.ld
+++ b/include/zephyr/linker/common-rom/common-rom-net.ld
@@ -27,5 +27,5 @@
 #endif
 
 #if defined(CONFIG_NET_SOCKETS_SERVICE)
-	ITERABLE_SECTION_RAM(net_socket_service_desc, 4)
+	ITERABLE_SECTION_ROM(net_socket_service_desc, 4)
 #endif

--- a/include/zephyr/net/socket_service.h
+++ b/include/zephyr/net/socket_service.h
@@ -76,7 +76,7 @@ struct net_socket_service_desc {
 };
 
 #define __z_net_socket_svc_get_name(_svc_id) __z_net_socket_service_##_svc_id
-#define __z_net_socket_svc_get_idx(_svc_id) __z_net_socket_service_idx##_svc_id
+#define __z_net_socket_svc_get_idx(_svc_id) __z_net_socket_service_idx_##_svc_id
 #define __z_net_socket_svc_get_owner __FILE__ ":" STRINGIFY(__LINE__)
 
 extern void net_socket_service_callback(struct k_work *work);


### PR DESCRIPTION
The iterable section should be located in ROM and not RAM, this caused
crashes on multiple platforms running socket services.

Fixes #67762