### PR TITLE
samples: bluetooth: iso_receive: Allow syncing any subevent number

### DIFF
--- a/samples/bluetooth/iso_receive/src/main.c
+++ b/samples/bluetooth/iso_receive/src/main.c
@@ -277,7 +277,7 @@ static struct bt_iso_big_sync_param big_sync_param = {
 	.bis_channels = bis,
 	.num_bis = BIS_ISO_CHAN_COUNT,
 	.bis_bitfield = (BIT_MASK(BIS_ISO_CHAN_COUNT) << 1),
-	.mse = 1,
+	.mse = BT_ISO_SYNC_MSE_ANY, /* any number of subevents */
 	.sync_timeout = 100, /* in 10 ms units */
 };
 


### PR DESCRIPTION
When using softdevice controller on iso_broadcast sample, the BIG created uses more than 1 subevent. This means that when you try to use the iso_receive sample to sync it does not work.

So update the sample to use mse=0 and allow any number of subevents, making the sample more flexible and work with SDC without any changes.