### PR TITLE
manifest: Update nrf hw models to latest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -295,7 +295,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 6b6ae3652c92c95edd945dce6ad9ef9892aab89b
+      revision: d17c9d749c817d2522468fa3c0eee3705feb8951
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
       revision: da78aea63159771956fe0c9263f2e6985b66e9d5


### PR DESCRIPTION
Update the HW models module to d17c9d749c817d2522468fa3c0eee3705feb8951

Including the following:
* d17c9d7 UART: Bugfix: Support STARTRX while Rx is stopping
* d982e76 UART: Minor bugfix: Fix 2 warning messages
* eda7af9 UART: Bugfix: Handle task STOPTX while stopping
* b8ea63b UART: BugFix: Support STARTTx even if Tx is not Off
* c0d28cc nrf_common: Add replacement for nrf_dma_accessible_check()
* feb91bb nrfx_common replacement: nrfx_get_irq_number() Add missing peripherals
* c95d9af Makefile: By default lets build both 52833 and 5340 targets
* cf41110 UART: FIFO backend: Check for failure of fcntl

-----

This models' update includes fixes and additions necessary to enable the latest nrfx UART driver