### PR TITLE
boards: mps2_an385: Re-enable networking tests

### DIFF
--- a/boards/arm/mps2_an385/mps2_an385.yaml
+++ b/boards/arm/mps2_an385/mps2_an385.yaml
@@ -13,6 +13,4 @@ supported:
   - gpio
 testing:
   default: true
-  ignore_tags:
-    - net
 vendor: arm


### PR DESCRIPTION
This reverts commit 6a3612666eb35223d2732d495e3f40e9e182535d "boards: mps2_an385: Exclude platform from networking tests"

This would have found the issue described in #67762 where a network test was failing because of wrong section placement. All the simulated environments (qemu_x86 and native_sim) used in network testing missed this problem, but could have easily found if network tests would have been run in mps2_an385.