### PR TITLE
drivers: entropy: caam: Flush & disable cache

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -193,7 +193,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 9b2693c7659f37f84bcf2604995c88f7fa5206be
+      revision: 9ced572b0d6da8dab25f7f8f0c8286adc8856bfa
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Flush and disable the data cache during CAAM init operation in order to avoid the cache coherency issues of the fsl_caam driver, and revert the HAL patch that was the previous solution to avoid perpetually carrying it forward.