### PR TITLE
net: sockets: tls: Fix crashes in get DTLS CID socket options

### DIFF
--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -1769,6 +1769,10 @@ static int tls_opt_dtls_peer_connection_id_value_get(struct tls_context *context
 	int enabled = false;
 	int ret;
 
+	if (!context->is_initialized) {
+		return -ENOTCONN;
+	}
+
 	ret = mbedtls_ssl_get_peer_cid(&context->ssl, &enabled, optval, optlen);
 	if (!enabled) {
 		*optlen = 0;
@@ -1792,6 +1796,10 @@ static int tls_opt_dtls_connection_id_status_get(struct tls_context *context,
 
 	if (sizeof(int) != *optlen) {
 		return -EINVAL;
+	}
+
+	if (!context->is_initialized) {
+		return -ENOTCONN;
 	}
 
 	ret = mbedtls_ssl_get_peer_cid(&context->ssl, &enabled,


### PR DESCRIPTION
Get TLS_DTLS_CID_STATUS and TLS_DTLS_PEER_CID_VALUE utilize mbedtls_ssl_get_peer_cid, which expects that mbedtls_ssl_setup has been done.