### PR TITLE
MAINTAINERS: Create NXP Drivers group

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3170,29 +3170,42 @@ Intel Platforms (Agilex):
   labels:
     - "platform: Intel SoC FPGA Agilex"
 
-NXP Platforms (S32):
+NXP Drivers:
   status: maintained
   maintainers:
-    - manuargue
+    - dleach02
   collaborators:
-    - PetervdPerk-NXP
-    - bperseghetti
-    - Dat-NguyenDuy
+    - mmahadevan108
+    - danieldegrasse
+    - decsny
+    - manuargue
+    - dbaluta
   files:
-    - boards/arm/s32*/
-    - boards/arm/mr_canhubk3/
-    - boards/arm/ucans32k1sic/
-    - soc/arm/nxp_s32/
-    - drivers/*/*nxp_s32*
-    - dts/bindings/*/nxp,s32*
-    - samples/boards/nxp_s32/
-    - include/zephyr/dt-bindings/*/nxp-s32*
-    - include/zephyr/dt-bindings/*/nxp_s32*
-    - include/zephyr/drivers/*/*nxp_s32*
+    - drivers/*/*imx*
+    - drivers/*/*lpc*.c
+    - drivers/*/*mcux*.c
+    - drivers/*/*.mcux
+    - drivers/*/*.nxp
+    - drivers/*/*nxp*
+    - drivers/*/*kinetis*
+    - drivers/misc/*/nxp*
+    - include/zephyr/dt-bindings/*/*nxp*
+    - include/zephyr/dt-bindings/*/*mcux*
+    - include/zephyr/drivers/*/*nxp*
+    - include/zephyr/drivers/*/*mcux*
+    - arch/arm/core/mpu/nxp_mpu.c
+    - dts/bindings/*/nxp*
+  files-exclude:
+    - drivers/*/*s32*
+    - drivers/misc/*/*s32*/
+    - include/zephyr/dt-bindings/*/*s32*
+    - include/zephyr/drivers/*/*s32*
+    - dts/bindings/*/*s32*
   labels:
-    - "platform: NXP S32"
+    - "platform: NXP Drivers"
+  description: NXP Drivers
 
-NXP Platforms:
+NXP Platforms (MCUX):
   status: maintained
   maintainers:
     - dleach02
@@ -3205,24 +3218,48 @@ NXP Platforms:
     - decsny
   files:
     - boards/arm/mimx*/
-    - boards/arm/frdm_k*/
+    - boards/arm/frdm*/
     - boards/arm/lpcxpress*/
     - boards/arm/twr_*/
+    - boards/arm/vmu*/
     - soc/arm/nxp_imx/
     - soc/arm/nxp_kinetis/
     - soc/arm/nxp_lpc/
-    - drivers/*/*imx*
-    - drivers/*/*lpc*.c
-    - drivers/*/*mcux*.c
-    - drivers/*/*.mcux
-    - drivers/*/*.nxp
-    - drivers/*/*nxp*
     - dts/arm/nxp/
-    - dts/bindings/*/nxp*
     - samples/boards/nxp*/
-    - include/zephyr/dt-bindings/*/nxp*
+  files-exclude:
+    - boards/arm/*s32*/
+    - dts/arm/nxp/*s32*
+    - samples/boards/nxp_s32/
   labels:
     - "platform: NXP"
+  description: NXP Platforms supported by MCUXpresso suite
+
+NXP Platforms (S32):
+  status: maintained
+  maintainers:
+    - manuargue
+  collaborators:
+    - PetervdPerk-NXP
+    - bperseghetti
+    - Dat-NguyenDuy
+  files:
+    - boards/arm/s32*/
+    - boards/arm/mr_canhubk3/
+    - boards/arm/ucans32k1sic/
+    - boards/common/*nxp_s32*
+    - soc/arm/nxp_s32/
+    - drivers/*/*nxp_s32*
+    - drivers/misc/*nxp_s32*/
+    - dts/bindings/*/nxp,s32*
+    - dts/arm/nxp/*s32*
+    - samples/boards/nxp_s32/
+    - include/zephyr/dt-bindings/*/nxp-s32*
+    - include/zephyr/dt-bindings/*/nxp_s32*
+    - include/zephyr/drivers/*/*nxp_s32*
+  labels:
+    - "platform: NXP S32"
+  description: NXP S32 platforms and S32-specific drivers
 
 NXP Platforms (Xtensa):
   status: maintained
@@ -3235,6 +3272,7 @@ NXP Platforms (Xtensa):
     - boards/xtensa/nxp_adsp_*/
   labels:
     - "platform: NXP ADSP"
+  description: NXP Xtensa platforms
 
 Microchip MEC Platforms:
   status: maintained


### PR DESCRIPTION
Create NXP Drivers group separate from the platforms.
The idea being that currently there are two problems:

- All the Drivers drivers are falling under the responsibility
of the MCUX platforms' maintainers, some of whom do not have the
cycles or interest to maintain these things.

- The maintainers of the other platform groups do not get counted
as reviewers of the Drivers drivers that their platforms use.

So, separate all the driver files from the MCUX platforms, and add the
relevant people who have an interest in maintaining the Drivers, including:

- At least one maintainer of each platform group, and
- The NXP contributors who are highly active in maintaining
  and reviewing the NXP drivers in upstream Zephyr.

Another two problems this PR fixes:

- The platforms of the other NXP groups are still falling under the MCUX
  group. Exclude the platforms of the other NXP groups from MCUX group. MCUX
  group will still be the default group for unsorted NXP platforms.

- Add a few file paths to some of these groups to cover a few missed
  files, and add description properties of the NXP groups.