### PR TITLE
nRF: Enable new UART driver for simulated platforms

### DIFF
--- a/boards/posix/nrf_bsim/Kconfig.defconfig
+++ b/boards/posix/nrf_bsim/Kconfig.defconfig
@@ -91,7 +91,4 @@ config POSIX_ARCH_CONSOLE
 
 endif # CONSOLE
 
-config UART_NRFX_UARTE_LEGACY_SHIM
-	default y
-
 endif # SOC_SERIES_BSIM_NRFXX

--- a/west.yml
+++ b/west.yml
@@ -183,7 +183,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 64bd075a06f6a16d6ea9101cda82b41465a35211
+      revision: a5f11c33864264c60a81bf83e5d5643260296eb5
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
Enable the new UART driver for the simulated nrf52_bsim.
This PR includes:
* An update to the driver in tree so it works for simulation,
* A hal_nordic module update including 2 fixes for simulation
* Don't specifically select the old driver for the nrf52_bsim

Notes, with the new driver these test fail due to what seem like legitimate bugs in the driver. @nordic-krch is fixing the issues. Note that as the driver is not enabled now by default these are not triggered
- The BT HCI UART async  ( `tests/bsim/bluetooth/hci_uart/tests_scripts/basic_conn_split_uart_async.sh` ) 
- tests/drivers/uart/uart_mix_fifo_poll/drivers.uart.uart_mix_poll_fifo
- tests/drivers/uart/uart_mix_fifo_poll/drivers.uart.uart_mix_poll_fifo_with_ppi