### PR TITLE
init: add missing initialization of dev pointer in SYS_INIT macro

### DIFF
--- a/include/zephyr/init.h
+++ b/include/zephyr/init.h
@@ -202,10 +202,10 @@ struct init_entry {
  *
  * @see SYS_INIT()
  */
-#define SYS_INIT_NAMED(name, init_fn_, level, prio)                            \
-	static const Z_DECL_ALIGN(struct init_entry)                           \
-		Z_INIT_ENTRY_SECTION(level, prio, 0) __used __noasan           \
-		Z_INIT_ENTRY_NAME(name) = {.init_fn = {.sys = (init_fn_)}}
+#define SYS_INIT_NAMED(name, init_fn_, level, prio)                                       \
+	static const Z_DECL_ALIGN(struct init_entry)                                      \
+		Z_INIT_ENTRY_SECTION(level, prio, 0) __used __noasan                      \
+		Z_INIT_ENTRY_NAME(name) = {.init_fn = {.sys = (init_fn_)}, .dev = NULL}
 
 /** @} */
 


### PR DESCRIPTION
When the -Werror=missing-field-initializers is enabled, the compiler complains about missing initialization of dev pointer in the init_entry struct when using the SYS_INIT[_NAMED] macro. This commit adds explicit assignment of NULL to it.
It may be worth noting, that the affected code (that is using the SYS_INIT) is in c++.

```
init.h:208:74: error: missing initializer for member 'init_entry::<anonymous>' [-Werror=missing-field-initializers]
  208 |                 Z_INIT_ENTRY_NAME(name) = {.init_fn = {.sys = (init_fn_)}}
      |                                                                          ^
```