### PR TITLE
dts: mimx93_evk_a55: avoid conflict with Ethos-U NPU reserved memory

### DIFF
--- a/boards/arm64/mimx93_evk/doc/index.rst
+++ b/boards/arm64/mimx93_evk/doc/index.rst
@@ -86,14 +86,14 @@ Use U-Boot to load and kick zephyr.bin to Cortex-A55 Core1:
 
 .. code-block:: console
 
-    fatload mmc 1:1 0xc0000000 zephyr.bin; dcache flush; icache flush; dcache off; icache off; cpu 1 release 0xc0000000
+    fatload mmc 1:1 0xd0000000 zephyr.bin; dcache flush; icache flush; dcache off; icache off; cpu 1 release 0xd0000000
 
 
 Or use the following command to kick zephyr.bin to Cortex-A55 Core0:
 
 .. code-block:: console
 
-    fatload mmc 1:1 0xc0000000 zephyr.bin; dcache flush; icache flush; dcache off; icache off; go 0xc0000000
+    fatload mmc 1:1 0xd0000000 zephyr.bin; dcache flush; icache flush; dcache off; icache off; go 0xd0000000
 
 
 Use this configuration to run basic Zephyr applications and kernel tests,

--- a/boards/arm64/mimx93_evk/mimx93_evk_a55.dts
+++ b/boards/arm64/mimx93_evk/mimx93_evk_a55.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 NXP
+ * Copyright 2022,2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -25,8 +25,8 @@
 		};
 	};
 
-	sram0: memory@c0000000 {
-		reg = <0xc0000000 DT_SIZE_M(1)>;
+	sram0: memory@d0000000 {
+		reg = <0xd0000000 DT_SIZE_M(1)>;
 	};
 
 	aliases {


### PR DESCRIPTION
The DRAM range 0xc0000000~0xcfffffff is reserved for the Ethos-U NPU, so change the RAM base to 0xd0000000.