### PR TITLE
modem: ppp: Add PPP device API

### DIFF
--- a/subsys/modem/modem_ppp.c
+++ b/subsys/modem/modem_ppp.c
@@ -396,21 +396,35 @@ static void modem_ppp_ppp_api_init(struct net_if *iface)
 	net_if_flag_set(iface, NET_IF_NO_AUTO_START);
 	net_if_carrier_off(iface);
 
-	if (ppp->init_iface != NULL) {
-		ppp->init_iface(iface);
+	ppp->iface = iface;
+
+	if ((ppp->device_api == NULL) || (ppp->device_api->init == NULL)) {
+		return;
 	}
 
-	ppp->iface = iface;
+	ppp->device_api->init(ppp);
 }
 
 static int modem_ppp_ppp_api_start(const struct device *dev)
 {
-	return 0;
+	struct modem_ppp *ppp = (struct modem_ppp *)dev->data;
+
+	if ((ppp->device_api == NULL) || (ppp->device_api->start == NULL)) {
+		return 0;
+	}
+
+	return ppp->device_api->start(ppp);
 }
 
 static int modem_ppp_ppp_api_stop(const struct device *dev)
 {
-	return 0;
+	struct modem_ppp *ppp = (struct modem_ppp *)dev->data;
+
+	if ((ppp->device_api == NULL) || (ppp->device_api->stop == NULL)) {
+		return 0;
+	}
+
+	return ppp->device_api->stop(ppp);
 }
 
 static int modem_ppp_ppp_api_send(const struct device *dev, struct net_pkt *pkt)


### PR DESCRIPTION
Adds API structure to modem PPP module which forwards the network interface init, PPP start and PPP stop API calls to the device which owns the modem PPP instance.

This allows for the owning device to enable/disable the carrier and do initialization/cleanup synchronized with the network interface the modem PPP instance is bound to.

This is a step towards replacing the `ppp.c` driver (which is a L2 PPP -> UART device) with an implementation based on the modem subsystem, and fixing #18117