### PR TITLE
west.yml: Update hal_silabs to pull request #54 | Update to GSDK 4.4.0

### DIFF
--- a/dts/arm/silabs/efr32bg2x.dtsi
+++ b/dts/arm/silabs/efr32bg2x.dtsi
@@ -23,6 +23,7 @@
 			compatible = "silabs,hfxo";
 			clock-frequency = <DT_FREQ_K(38400)>;
 			ctune = <120>;
+			precision = <50>;
 		};
 	};
 

--- a/dts/arm/silabs/efr32mg24.dtsi
+++ b/dts/arm/silabs/efr32mg24.dtsi
@@ -24,6 +24,7 @@
 			compatible = "silabs,hfxo";
 			clock-frequency = <DT_FREQ_M(39)>;
 			ctune = <140>;
+			precision = <50>;
 		};
 	};
 

--- a/dts/bindings/clock/silabs,hfxo.yaml
+++ b/dts/bindings/clock/silabs,hfxo.yaml
@@ -7,3 +7,7 @@ properties:
     type: int
     required: true
     description: Load capacitance configuration
+  precision:
+    type: int
+    required: true
+    description: Precision configuration

--- a/soc/arm/silabs_exx32/common/sl_device_init_hfxo_config.h
+++ b/soc/arm/silabs_exx32/common/sl_device_init_hfxo_config.h
@@ -12,5 +12,6 @@
 #define SL_DEVICE_INIT_HFXO_MODE           cmuHfxoOscMode_Crystal
 #define SL_DEVICE_INIT_HFXO_FREQ           DT_PROP(DT_NODELABEL(clk_hfxo), clock_frequency)
 #define SL_DEVICE_INIT_HFXO_CTUNE          DT_PROP(DT_NODELABEL(clk_hfxo), ctune)
+#define SL_DEVICE_INIT_HFXO_PRECISION      DT_PROP(DT_NODELABEL(clk_hfxo), precision)
 
 #endif /* SL_DEVICE_INIT_HFXO_CONFIG_H */

--- a/west.yml
+++ b/west.yml
@@ -219,7 +219,7 @@ manifest:
       groups:
         - hal
     - name: hal_silabs
-      revision: 11ab59175a5ded618680a7692dbaae8f4fbd6325
+      revision: 2ea874714edf5ce76b7b5fd19e7fa83507e83cc2
       path: modules/hal/silabs
       groups:
         - hal


### PR DESCRIPTION
Updated the files present in device_init, hfxo_manager, power_manager and sleeptimer folder as per latest version of gecko_sdk. Also added SL_DEVICE_INIT_HFXO_PRECISION in sl_device_init_hfxo_config.

This pull request is required to align the codebase of zephyr_rtos/hal_silabs (https://github.com/zephyrproject-rtos/hal_silabs) with gecko_sdk v4.4.0 (https://github.com/SiliconLabs/gecko_sdk)

PR in hal_silabs : https://github.com/zephyrproject-rtos/hal_silabs/pull/54
