### PR TITLE
drivers: serial: nrfx_uarte: Use legacy shim by default

### DIFF
--- a/drivers/serial/Kconfig.nrfx
+++ b/drivers/serial/Kconfig.nrfx
@@ -31,9 +31,8 @@ config UART_NRFX_UARTE
 config UART_NRFX_UARTE_LEGACY_SHIM
 	bool "Legacy UARTE shim"
 	depends on UART_NRFX_UARTE
-	# New shim takes more ROM. Until it is fixed use legacy shim in memory
-	# constraint case.
-	default y if MCUBOOT
+	# New shim takes more ROM. Until it is fixed use legacy shim.
+	default y
 
 config UART_ASYNC_TX_CACHE_SIZE
 	int "TX cache buffer size"

--- a/tests/drivers/uart/uart_async_api/testcase.yaml
+++ b/tests/drivers/uart/uart_async_api/testcase.yaml
@@ -13,7 +13,6 @@ tests:
     harness_config:
       fixture: gpio_loopback
     depends_on: gpio
-    tags: bsim_skip_CI
   drivers.uart.wide:
     filter: CONFIG_SERIAL_SUPPORT_ASYNC and not CONFIG_UART_MCUX_LPUART
     harness: ztest
@@ -26,7 +25,7 @@ tests:
     platform_allow: nucleo_h743zi
     integration_platforms:
       - nucleo_h743zi
-  drivers.uart.async_api.nrf_uarte_legacy:
+  drivers.uart.async_api.nrf_uarte_new:
     platform_allow: nrf52840dk_nrf52840 nrf52_bsim
     filter: CONFIG_SERIAL_SUPPORT_ASYNC
     harness: ztest
@@ -34,7 +33,8 @@ tests:
       fixture: gpio_loopback
     depends_on: gpio
     extra_configs:
-      - CONFIG_UART_NRFX_UARTE_LEGACY_SHIM=y
+      - CONFIG_UART_NRFX_UARTE_LEGACY_SHIM=n
+    tags: bsim_skip_CI
   drivers.uart.async_api.nrf_uart:
     filter: CONFIG_SERIAL_SUPPORT_ASYNC
     harness: ztest

--- a/tests/drivers/uart/uart_mix_fifo_poll/testcase.yaml
+++ b/tests/drivers/uart/uart_mix_fifo_poll/testcase.yaml
@@ -19,6 +19,7 @@ tests:
       - CONFIG_UART_INTERRUPT_DRIVEN=n
       - CONFIG_UART_ASYNC_API=n
       - CONFIG_UART_0_ENHANCED_POLL_OUT=n
+      - CONFIG_UART_NRFX_UARTE_LEGACY_SHIM=n
     tags: bsim_skip_CI
 
   drivers.uart.uart_mix_poll_fifo:
@@ -26,6 +27,7 @@ tests:
       - CONFIG_UART_INTERRUPT_DRIVEN=y
       - CONFIG_UART_0_INTERRUPT_DRIVEN=y
       - CONFIG_UART_0_ENHANCED_POLL_OUT=n
+      - CONFIG_UART_NRFX_UARTE_LEGACY_SHIM=n
     tags: bsim_skip_CI
 
   drivers.uart.uart_mix_poll_async_api:
@@ -34,6 +36,7 @@ tests:
       - CONFIG_UART_0_INTERRUPT_DRIVEN=n
       - CONFIG_UART_0_ASYNC=y
       - CONFIG_UART_0_ENHANCED_POLL_OUT=n
+      - CONFIG_UART_NRFX_UARTE_LEGACY_SHIM=n
     tags: bsim_skip_CI
 
   drivers.uart.uart_mix_poll_async_api_const:
@@ -44,6 +47,7 @@ tests:
       - CONFIG_UART_0_ASYNC=y
       - CONFIG_UART_0_ENHANCED_POLL_OUT=n
       - CONFIG_UART_0_TX_CACHE_SIZE=2
+      - CONFIG_UART_NRFX_UARTE_LEGACY_SHIM=n
     tags: bsim_skip_CI # We skip a few tests to save CI time, as they give little extra coverage
 
   drivers.uart.uart_mix_poll_with_ppi:
@@ -51,6 +55,7 @@ tests:
       - CONFIG_UART_INTERRUPT_DRIVEN=n
       - CONFIG_UART_ASYNC_API=n
       - CONFIG_UART_0_ENHANCED_POLL_OUT=y
+      - CONFIG_UART_NRFX_UARTE_LEGACY_SHIM=n
     tags: bsim_skip_CI
 
   drivers.uart.uart_mix_poll_fifo_with_ppi:
@@ -58,6 +63,7 @@ tests:
       - CONFIG_UART_INTERRUPT_DRIVEN=y
       - CONFIG_UART_0_INTERRUPT_DRIVEN=y
       - CONFIG_UART_0_ENHANCED_POLL_OUT=y
+      - CONFIG_UART_NRFX_UARTE_LEGACY_SHIM=n
     tags: bsim_skip_CI
 
   drivers.uart.uart_mix_poll_async_api_with_ppi:
@@ -66,6 +72,7 @@ tests:
       - CONFIG_UART_0_INTERRUPT_DRIVEN=n
       - CONFIG_UART_0_ASYNC=y
       - CONFIG_UART_0_ENHANCED_POLL_OUT=y
+      - CONFIG_UART_NRFX_UARTE_LEGACY_SHIM=n
     tags: bsim_skip_CI
 
   drivers.uart.legacy.uart_mix_poll:


### PR DESCRIPTION
Fixes #67824.