### PR TITLE
drivers: modem: gsm fix rssi range

### DIFF
--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -814,7 +814,7 @@ attaching:
 		query_rssi_nolock(gsm);
 
 		if (!((gsm->minfo.mdm_rssi) && (gsm->minfo.mdm_rssi != GSM_RSSI_INVALID) &&
-			(gsm->minfo.mdm_rssi < GSM_RSSI_MAXVAL))) {
+			(gsm->minfo.mdm_rssi <= GSM_RSSI_MAXVAL))) {
 
 			LOG_DBG("Not valid RSSI, %s", "retrying...");
 			if (gsm->retries-- > 0) {


### PR DESCRIPTION
rssi 31 will be -51dBm or greater, where -51 is valid. Fix the range by allowing until -51.