### PR TITLE
drivers: can: use common accessor for getting maximum supported bitrate

### DIFF
--- a/doc/releases/migration-guide-3.6.rst
+++ b/doc/releases/migration-guide-3.6.rst
@@ -175,6 +175,15 @@ Device Drivers and Device Tree
   * The main Kconfig option was renamed from ``CONFIG_CAN_NATIVE_POSIX_LINUX`` to
     :kconfig:option:`CONFIG_CAN_NATIVE_LINUX`.
 
+* Two new structures for holding common CAN controller driver configuration (``struct
+  can_driver_config``) and data (``struct can_driver_data``) fields were introduced. Out-of-tree CAN
+  controller drivers need to be updated to use these new, common configuration and data structures
+  along with their initializer macros.
+
+* The optional ``can_get_max_bitrate_t`` CAN controller driver callback was removed in favor of a
+  common accessor function. Out-of-tree CAN controller drivers need to be updated to no longer
+  supply this callback.
+
 * The ``CAN_FILTER_FDF`` flag for filtering classic CAN/CAN FD frames was removed since no known CAN
   controllers implement support for this. Applications can still filter on classic CAN/CAN FD frames
   in their receive callback functions as needed.

--- a/drivers/can/can_esp32_twai.c
+++ b/drivers/can/can_esp32_twai.c
@@ -224,7 +224,6 @@ const struct can_driver_api can_esp32_twai_driver_api = {
 	.set_state_change_callback = can_sja1000_set_state_change_callback,
 	.get_core_clock = can_esp32_twai_get_core_clock,
 	.get_max_filters = can_sja1000_get_max_filters,
-	.get_max_bitrate = can_sja1000_get_max_bitrate,
 #ifndef CONFIG_CAN_AUTO_BUS_OFF_RECOVERY
 	.recover = can_sja1000_recover,
 #endif /* !CONFIG_CAN_AUTO_BUS_OFF_RECOVERY */

--- a/drivers/can/can_fake.c
+++ b/drivers/can/can_fake.c
@@ -15,6 +15,14 @@
 
 #define DT_DRV_COMPAT zephyr_fake_can
 
+struct fake_can_config {
+	const struct can_driver_config common;
+};
+
+struct fake_can_data {
+	struct can_driver_data common;
+};
+
 DEFINE_FAKE_VALUE_FUNC(int, fake_can_start, const struct device *);
 
 DEFINE_FAKE_VALUE_FUNC(int, fake_can_stop, const struct device *);
@@ -139,7 +147,14 @@ static const struct can_driver_api fake_can_driver_api = {
 };
 
 #define FAKE_CAN_INIT(inst)						     \
-	CAN_DEVICE_DT_INST_DEFINE(inst, NULL, NULL, NULL, NULL, POST_KERNEL, \
+	static const struct fake_can_config fake_can_config_##inst = {	     \
+		.common = CAN_DT_DRIVER_CONFIG_INST_GET(inst, 0U),	     \
+	};								     \
+									     \
+	static struct fake_can_data fake_can_data_##inst;		     \
+									     \
+	CAN_DEVICE_DT_INST_DEFINE(inst, NULL, NULL, &fake_can_data_##inst,   \
+				  &fake_can_config_##inst, POST_KERNEL,	     \
 				  CONFIG_CAN_INIT_PRIORITY,                  \
 				  &fake_can_driver_api);
 

--- a/drivers/can/can_fake.c
+++ b/drivers/can/can_fake.c
@@ -87,15 +87,6 @@ static int fake_can_get_core_clock(const struct device *dev, uint32_t *rate)
 	return 0;
 }
 
-static int fake_can_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate)
-{
-	ARG_UNUSED(dev);
-
-	*max_bitrate = 5000000;
-
-	return 0;
-}
-
 static const struct can_driver_api fake_can_driver_api = {
 	.start = fake_can_start,
 	.stop = fake_can_stop,
@@ -112,7 +103,6 @@ static const struct can_driver_api fake_can_driver_api = {
 	.set_state_change_callback = fake_can_set_state_change_callback,
 	.get_core_clock = fake_can_get_core_clock,
 	.get_max_filters = fake_can_get_max_filters,
-	.get_max_bitrate = fake_can_get_max_bitrate,
 	.timing_min = {
 		.sjw = 0x01,
 		.prop_seg = 0x01,

--- a/drivers/can/can_handlers.c
+++ b/drivers/can/can_handlers.c
@@ -48,7 +48,6 @@ static inline int z_vrfy_can_get_core_clock(const struct device *dev,
 static inline int z_vrfy_can_get_max_bitrate(const struct device *dev,
 					     uint32_t *max_bitrate)
 {
-	/* Optional API function */
 	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_CAN));
 	K_OOPS(K_SYSCALL_MEMORY_WRITE(max_bitrate, sizeof(*max_bitrate)));
 

--- a/drivers/can/can_kvaser_pci.c
+++ b/drivers/can/can_kvaser_pci.c
@@ -143,7 +143,6 @@ const struct can_driver_api can_kvaser_pci_driver_api = {
 	.set_state_change_callback = can_sja1000_set_state_change_callback,
 	.get_core_clock = can_kvaser_pci_get_core_clock,
 	.get_max_filters = can_sja1000_get_max_filters,
-	.get_max_bitrate = can_sja1000_get_max_bitrate,
 #ifndef CONFIG_CAN_AUTO_BUS_OFF_RECOVERY
 	.recover = can_sja1000_recover,
 #endif /* !CONFIG_CAN_AUTO_BUS_OFF_RECOVERY */

--- a/drivers/can/can_loopback.c
+++ b/drivers/can/can_loopback.c
@@ -28,6 +28,10 @@ struct can_loopback_filter {
 	struct can_filter filter;
 };
 
+struct can_loopback_config {
+	const struct can_driver_config common;
+};
+
 struct can_loopback_data {
 	struct can_driver_data common;
 	struct can_loopback_filter filters[CONFIG_CAN_MAX_FILTER];
@@ -446,12 +450,17 @@ static int can_loopback_init(const struct device *dev)
 	return 0;
 }
 
-#define CAN_LOOPBACK_INIT(inst)						\
-	static struct can_loopback_data can_loopback_dev_data_##inst;	\
-									\
-	CAN_DEVICE_DT_INST_DEFINE(inst, can_loopback_init, NULL,	\
-				  &can_loopback_dev_data_##inst, NULL,	\
-				  POST_KERNEL, CONFIG_CAN_INIT_PRIORITY,\
+#define CAN_LOOPBACK_INIT(inst)							\
+	static const struct can_loopback_config can_loopback_config_##inst = {	\
+		.common = CAN_DT_DRIVER_CONFIG_INST_GET(inst, 0U),		\
+	};									\
+										\
+	static struct can_loopback_data can_loopback_data_##inst;		\
+										\
+	CAN_DEVICE_DT_INST_DEFINE(inst, can_loopback_init, NULL,		\
+				  &can_loopback_data_##inst,			\
+				  &can_loopback_config_##inst,			\
+				  POST_KERNEL, CONFIG_CAN_INIT_PRIORITY,	\
 				  &can_loopback_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(CAN_LOOPBACK_INIT)

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -1183,15 +1183,6 @@ void can_mcan_set_state_change_callback(const struct device *dev,
 	data->common.state_change_cb_user_data = user_data;
 }
 
-int can_mcan_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate)
-{
-	const struct can_mcan_config *config = dev->config;
-
-	*max_bitrate = config->common.max_bitrate;
-
-	return 0;
-}
-
 /* helper function allowing mcan drivers without access to private mcan
  * definitions to set CCCR_CCE, which might be needed to disable write
  * protection for some registers.

--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -334,15 +334,6 @@ static int mcp2515_get_max_filters(const struct device *dev, bool ide)
 	return CONFIG_CAN_MAX_FILTER;
 }
 
-static int mcp2515_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate)
-{
-	const struct mcp2515_config *dev_cfg = dev->config;
-
-	*max_bitrate = dev_cfg->common.max_bitrate;
-
-	return 0;
-}
-
 static int mcp2515_set_timing(const struct device *dev,
 			      const struct can_timing *timing)
 {
@@ -930,7 +921,6 @@ static const struct can_driver_api can_api_funcs = {
 	.set_state_change_callback = mcp2515_set_state_change_callback,
 	.get_core_clock = mcp2515_get_core_clock,
 	.get_max_filters = mcp2515_get_max_filters,
-	.get_max_bitrate = mcp2515_get_max_bitrate,
 	.timing_min = {
 		.sjw = 0x1,
 		.prop_seg = 0x01,

--- a/drivers/can/can_mcp251xfd.c
+++ b/drivers/can/can_mcp251xfd.c
@@ -747,15 +747,6 @@ static int mcp251xfd_get_max_filters(const struct device *dev, bool ide)
 	return CONFIG_CAN_MAX_FILTER;
 }
 
-static int mcp251xfd_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate)
-{
-	const struct mcp251xfd_config *dev_cfg = dev->config;
-
-	*max_bitrate = dev_cfg->common.max_bitrate;
-
-	return 0;
-}
-
 #ifndef CONFIG_CAN_AUTO_BUS_OFF_RECOVERY
 static int mcp251xfd_recover(const struct device *dev, k_timeout_t timeout)
 {
@@ -1680,7 +1671,6 @@ static const struct can_driver_api mcp251xfd_api_funcs = {
 	.set_state_change_callback = mcp251xfd_set_state_change_callback,
 	.get_core_clock = mcp251xfd_get_core_clock,
 	.get_max_filters = mcp251xfd_get_max_filters,
-	.get_max_bitrate = mcp251xfd_get_max_bitrate,
 	.timing_min = {
 		.sjw = 1,
 		.prop_seg = 0,

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -158,15 +158,6 @@ static int mcux_flexcan_get_max_filters(const struct device *dev, bool ide)
 	return CONFIG_CAN_MAX_FILTER;
 }
 
-static int mcux_flexcan_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate)
-{
-	const struct mcux_flexcan_config *config = dev->config;
-
-	*max_bitrate = config->common.max_bitrate;
-
-	return 0;
-}
-
 static int mcux_flexcan_set_timing(const struct device *dev,
 				   const struct can_timing *timing)
 {
@@ -1316,7 +1307,6 @@ __maybe_unused static const struct can_driver_api mcux_flexcan_driver_api = {
 	.set_state_change_callback = mcux_flexcan_set_state_change_callback,
 	.get_core_clock = mcux_flexcan_get_core_clock,
 	.get_max_filters = mcux_flexcan_get_max_filters,
-	.get_max_bitrate = mcux_flexcan_get_max_bitrate,
 	/*
 	 * FlexCAN timing limits are specified in the "FLEXCANx_CTRL1 field
 	 * descriptions" table in the SoC reference manual.
@@ -1360,7 +1350,6 @@ static const struct can_driver_api mcux_flexcan_fd_driver_api = {
 	.set_state_change_callback = mcux_flexcan_set_state_change_callback,
 	.get_core_clock = mcux_flexcan_get_core_clock,
 	.get_max_filters = mcux_flexcan_get_max_filters,
-	.get_max_bitrate = mcux_flexcan_get_max_bitrate,
 	/*
 	 * FlexCAN FD timing limits are specified in the "CAN Bit Timing
 	 * Register (CBT)" and "CAN FD Bit Timing Register" field description

--- a/drivers/can/can_mcux_mcan.c
+++ b/drivers/can/can_mcux_mcan.c
@@ -139,7 +139,6 @@ static const struct can_driver_api mcux_mcan_driver_api = {
 	.set_state_change_callback = can_mcan_set_state_change_callback,
 	.get_core_clock = mcux_mcan_get_core_clock,
 	.get_max_filters = can_mcan_get_max_filters,
-	.get_max_bitrate = can_mcan_get_max_bitrate,
 	/*
 	 * MCUX MCAN timing limits are specified in the "Nominal bit timing and
 	 * prescaler register (NBTP)" table in the SoC reference manual.

--- a/drivers/can/can_numaker.c
+++ b/drivers/can/can_numaker.c
@@ -176,7 +176,6 @@ static const struct can_driver_api can_numaker_driver_api = {
 	.set_state_change_callback = can_mcan_set_state_change_callback,
 	.get_core_clock = can_numaker_get_core_clock,
 	.get_max_filters = can_mcan_get_max_filters,
-	.get_max_bitrate = can_mcan_get_max_bitrate,
 	.timing_min = CAN_MCAN_TIMING_MIN_INITIALIZER,
 	.timing_max = CAN_MCAN_TIMING_MAX_INITIALIZER,
 #ifdef CONFIG_CAN_FD_MODE

--- a/drivers/can/can_nxp_s32_canxl.c
+++ b/drivers/can/can_nxp_s32_canxl.c
@@ -363,15 +363,6 @@ static int can_nxp_s32_get_max_filters(const struct device *dev, bool ide)
 	return CONFIG_CAN_NXP_S32_MAX_RX;
 }
 
-static int can_nxp_s32_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate)
-{
-	const struct can_nxp_s32_config *config = dev->config;
-
-	*max_bitrate = config->common.max_bitrate;
-
-	return 0;
-}
-
 static int can_nxp_s32_get_state(const struct device *dev, enum can_state *state,
 						struct can_bus_err_cnt *err_cnt)
 {
@@ -1083,7 +1074,6 @@ static const struct can_driver_api can_nxp_s32_driver_api = {
 	.set_state_change_callback = can_nxp_s32_set_state_change_callback,
 	.get_core_clock = can_nxp_s32_get_core_clock,
 	.get_max_filters = can_nxp_s32_get_max_filters,
-	.get_max_bitrate = can_nxp_s32_get_max_bitrate,
 	.timing_min = {
 		.sjw = 0x01,
 		.prop_seg = 0x01,

--- a/drivers/can/can_rcar.c
+++ b/drivers/can/can_rcar.c
@@ -1140,15 +1140,6 @@ static int can_rcar_get_max_filters(const struct device *dev, bool ide)
 	return CONFIG_CAN_RCAR_MAX_FILTER;
 }
 
-static int can_rcar_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate)
-{
-	const struct can_rcar_cfg *config = dev->config;
-
-	*max_bitrate = config->common.max_bitrate;
-
-	return 0;
-}
-
 static const struct can_driver_api can_rcar_driver_api = {
 	.get_capabilities = can_rcar_get_capabilities,
 	.start = can_rcar_start,
@@ -1165,7 +1156,6 @@ static const struct can_driver_api can_rcar_driver_api = {
 	.set_state_change_callback = can_rcar_set_state_change_callback,
 	.get_core_clock = can_rcar_get_core_clock,
 	.get_max_filters = can_rcar_get_max_filters,
-	.get_max_bitrate = can_rcar_get_max_bitrate,
 	.timing_min = {
 		.sjw = 0x1,
 		.prop_seg = 0x00,

--- a/drivers/can/can_sam.c
+++ b/drivers/can/can_sam.c
@@ -131,7 +131,6 @@ static const struct can_driver_api can_sam_driver_api = {
 #endif /* CONFIG_CAN_AUTO_BUS_OFF_RECOVERY */
 	.get_core_clock = can_sam_get_core_clock,
 	.get_max_filters = can_mcan_get_max_filters,
-	.get_max_bitrate = can_mcan_get_max_bitrate,
 	.set_state_change_callback =  can_mcan_set_state_change_callback,
 	.timing_min = CAN_MCAN_TIMING_MIN_INITIALIZER,
 	.timing_max = CAN_MCAN_TIMING_MAX_INITIALIZER,

--- a/drivers/can/can_sam0.c
+++ b/drivers/can/can_sam0.c
@@ -176,7 +176,6 @@ static const struct can_driver_api can_sam0_driver_api = {
 #endif /* CONFIG_CAN_AUTO_BUS_OFF_RECOVERY */
 	.get_core_clock = can_sam0_get_core_clock,
 	.get_max_filters = can_mcan_get_max_filters,
-	.get_max_bitrate = can_mcan_get_max_bitrate,
 	.set_state_change_callback =  can_mcan_set_state_change_callback,
 	.timing_min = CAN_MCAN_TIMING_MIN_INITIALIZER,
 	.timing_max = CAN_MCAN_TIMING_MAX_INITIALIZER,

--- a/drivers/can/can_sja1000.c
+++ b/drivers/can/can_sja1000.c
@@ -549,15 +549,6 @@ int can_sja1000_get_max_filters(const struct device *dev, bool ide)
 	return CONFIG_CAN_MAX_FILTER;
 }
 
-int can_sja1000_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate)
-{
-	const struct can_sja1000_config *config = dev->config;
-
-	*max_bitrate = config->common.max_bitrate;
-
-	return 0;
-}
-
 static void can_sja1000_handle_receive_irq(const struct device *dev)
 {
 	struct can_sja1000_data *data = dev->data;

--- a/drivers/can/can_stm32_bxcan.c
+++ b/drivers/can/can_stm32_bxcan.c
@@ -582,15 +582,6 @@ static int can_stm32_get_core_clock(const struct device *dev, uint32_t *rate)
 	return 0;
 }
 
-static int can_stm32_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate)
-{
-	const struct can_stm32_config *config = dev->config;
-
-	*max_bitrate = config->common.max_bitrate;
-
-	return 0;
-}
-
 static int can_stm32_get_max_filters(const struct device *dev, bool ide)
 {
 	ARG_UNUSED(dev);
@@ -1102,7 +1093,6 @@ static const struct can_driver_api can_api_funcs = {
 #endif
 	.set_state_change_callback = can_stm32_set_state_change_callback,
 	.get_core_clock = can_stm32_get_core_clock,
-	.get_max_bitrate = can_stm32_get_max_bitrate,
 	.get_max_filters = can_stm32_get_max_filters,
 	.timing_min = {
 		.sjw = 0x1,

--- a/drivers/can/can_stm32_fdcan.c
+++ b/drivers/can/can_stm32_fdcan.c
@@ -590,7 +590,6 @@ static const struct can_driver_api can_stm32fd_driver_api = {
 	.recover = can_mcan_recover,
 #endif /* CONFIG_CAN_AUTO_BUS_OFF_RECOVERY */
 	.get_core_clock = can_stm32fd_get_core_clock,
-	.get_max_bitrate = can_mcan_get_max_bitrate,
 	.get_max_filters = can_mcan_get_max_filters,
 	.set_state_change_callback = can_mcan_set_state_change_callback,
 	.timing_min = CAN_MCAN_TIMING_MIN_INITIALIZER,

--- a/drivers/can/can_stm32h7_fdcan.c
+++ b/drivers/can/can_stm32h7_fdcan.c
@@ -208,7 +208,6 @@ static const struct can_driver_api can_stm32h7_driver_api = {
 	.recover = can_mcan_recover,
 #endif
 	.get_core_clock = can_stm32h7_get_core_clock,
-	.get_max_bitrate = can_mcan_get_max_bitrate,
 	.get_max_filters = can_mcan_get_max_filters,
 	.set_state_change_callback = can_mcan_set_state_change_callback,
 	/* Timing limits are per the STM32H7 Reference Manual (RM0433 Rev 7),

--- a/drivers/can/can_tcan4x5x.c
+++ b/drivers/can/can_tcan4x5x.c
@@ -729,7 +729,6 @@ static const struct can_driver_api tcan4x5x_driver_api = {
 	.set_state_change_callback = can_mcan_set_state_change_callback,
 	.get_core_clock = tcan4x5x_get_core_clock,
 	.get_max_filters = can_mcan_get_max_filters,
-	.get_max_bitrate = can_mcan_get_max_bitrate,
 	.timing_min = CAN_MCAN_TIMING_MIN_INITIALIZER,
 	.timing_max = CAN_MCAN_TIMING_MAX_INITIALIZER,
 #ifdef CONFIG_CAN_FD_MODE

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -487,12 +487,6 @@ typedef int (*can_get_core_clock_t)(const struct device *dev, uint32_t *rate);
  */
 typedef int (*can_get_max_filters_t)(const struct device *dev, bool ide);
 
-/**
- * @brief Optional callback API upon getting the maximum supported bitrate
- * See @a can_get_max_bitrate() for argument description
- */
-typedef int (*can_get_max_bitrate_t)(const struct device *dev, uint32_t *max_bitrate);
-
 __subsystem struct can_driver_api {
 	can_get_capabilities_t get_capabilities;
 	can_start_t start;
@@ -509,7 +503,6 @@ __subsystem struct can_driver_api {
 	can_set_state_change_callback_t set_state_change_callback;
 	can_get_core_clock_t get_core_clock;
 	can_get_max_filters_t get_max_filters;
-	can_get_max_bitrate_t get_max_bitrate;
 	/* Min values for the timing registers */
 	struct can_timing timing_min;
 	/* Max values for the timing registers */
@@ -829,13 +822,15 @@ __syscall int can_get_max_bitrate(const struct device *dev, uint32_t *max_bitrat
 
 static inline int z_impl_can_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate)
 {
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
+	const struct can_driver_config *common = (const struct can_driver_config *)dev->config;
 
-	if (api->get_max_bitrate == NULL) {
+	if (common->max_bitrate == 0U) {
 		return -ENOSYS;
 	}
 
-	return api->get_max_bitrate(dev, max_bitrate);
+	*max_bitrate = common->max_bitrate;
+
+	return 0;
 }
 
 /**

--- a/include/zephyr/drivers/can/can_mcan.h
+++ b/include/zephyr/drivers/can/can_mcan.h
@@ -1710,10 +1710,4 @@ int can_mcan_get_state(const struct device *dev, enum can_state *state,
 void can_mcan_set_state_change_callback(const struct device *dev,
 					can_state_change_callback_t callback, void *user_data);
 
-/**
- * @brief Bosch M_CAN driver callback API upon getting the maximum supported bitrate
- * See @a can_get_max_bitrate() for argument description
- */
-int can_mcan_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate);
-
 #endif /* ZEPHYR_INCLUDE_DRIVERS_CAN_CAN_MCAN_H_ */

--- a/include/zephyr/drivers/can/can_sja1000.h
+++ b/include/zephyr/drivers/can/can_sja1000.h
@@ -262,12 +262,6 @@ void can_sja1000_set_state_change_callback(const struct device *dev,
 int can_sja1000_get_max_filters(const struct device *dev, bool ide);
 
 /**
- * @brief SJA1000 callback API upon getting the maximum supported bitrate
- * See @a can_get_max_bitrate() for argument description
- */
-int can_sja1000_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate);
-
-/**
  * @brief SJA1000 IRQ handler callback.
  *
  * @param dev Pointer to the device structure for the driver instance.

--- a/tests/drivers/can/api/src/classic.c
+++ b/tests/drivers/can/api/src/classic.c
@@ -485,7 +485,7 @@ ZTEST(can_classic, test_set_state_change_callback)
  */
 ZTEST_USER(can_classic, test_set_bitrate_too_high)
 {
-	uint32_t max;
+	uint32_t max = 0U;
 	int err;
 
 	err = can_get_max_bitrate(can_dev, &max);


### PR DESCRIPTION
Use a common accessor for getting the maximum supported bitrate of a CAN controller.

This requires all CAN controller drivers to use the new, common configuration structure. For consistency add the new, common data structure to the one driver not using it as well.