### PR TITLE
Bluetooth: BAP: Fix issue with setting invalid iso data path

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -1917,11 +1917,7 @@ static void ase_qos(struct bt_ascs_ase *ase, uint8_t cig_id, uint8_t cis_id,
 	 * we have the ISO <-> EP coupling completed (due to setting
 	 * the CIS ID in the QoS procedure).
 	 */
-	if (ep->dir == BT_AUDIO_DIR_SINK) {
-		bt_audio_codec_cfg_to_iso_path(&ep->iso->rx.path, stream->codec_cfg);
-	} else {
-		bt_audio_codec_cfg_to_iso_path(&ep->iso->tx.path, stream->codec_cfg);
-	}
+	bt_bap_iso_configure_data_path(ep, stream->codec_cfg);
 
 	ep->cig_id = cig_id;
 	ep->cis_id = cis_id;

--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -886,7 +886,7 @@ static int bt_bap_broadcast_sink_setup_stream(struct bt_bap_broadcast_sink *sink
 	bt_bap_iso_bind_ep(iso, ep);
 
 	bt_audio_codec_qos_to_iso_qos(iso->chan.qos->rx, &sink->codec_qos);
-	bt_audio_codec_cfg_to_iso_path(iso->chan.qos->rx->path, codec_cfg);
+	bt_bap_iso_configure_data_path(ep, codec_cfg);
 
 	bt_bap_iso_unref(iso);
 

--- a/subsys/bluetooth/audio/bap_broadcast_source.c
+++ b/subsys/bluetooth/audio/bap_broadcast_source.c
@@ -288,7 +288,7 @@ static int broadcast_source_setup_stream(uint8_t index, struct bt_bap_stream *st
 	bt_bap_iso_bind_ep(iso, ep);
 
 	bt_audio_codec_qos_to_iso_qos(iso->chan.qos->tx, qos);
-	bt_audio_codec_cfg_to_iso_path(iso->chan.qos->tx->path, codec_cfg);
+	bt_bap_iso_configure_data_path(ep, codec_cfg);
 #if defined(CONFIG_BT_ISO_TEST_PARAMS)
 	iso->chan.qos->num_subevents = qos->num_subevents;
 #endif /* CONFIG_BT_ISO_TEST_PARAMS */
@@ -878,7 +878,7 @@ int bt_bap_broadcast_source_reconfig(struct bt_bap_broadcast_source *source,
 
 			iso_qos = stream->ep->iso->chan.qos->tx;
 			bt_bap_stream_attach(NULL, stream, stream->ep, codec_cfg);
-			bt_audio_codec_cfg_to_iso_path(iso_qos->path, codec_cfg);
+			bt_bap_iso_configure_data_path(stream->ep, codec_cfg);
 		}
 	}
 

--- a/subsys/bluetooth/audio/bap_iso.h
+++ b/subsys/bluetooth/audio/bap_iso.h
@@ -41,6 +41,7 @@ void bt_bap_iso_foreach(bt_bap_iso_func_t func, void *user_data);
 struct bt_bap_iso *bt_bap_iso_find(bt_bap_iso_func_t func, void *user_data);
 void bt_bap_iso_init(struct bt_bap_iso *iso, struct bt_iso_chan_ops *ops);
 void bt_bap_iso_bind_ep(struct bt_bap_iso *iso, struct bt_bap_ep *ep);
+void bt_bap_iso_configure_data_path(struct bt_bap_ep *ep, struct bt_audio_codec_cfg *codec_cfg);
 void bt_bap_iso_unbind_ep(struct bt_bap_iso *iso, struct bt_bap_ep *ep);
 struct bt_bap_ep *bt_bap_iso_get_ep(bool unicast_client, struct bt_bap_iso *iso,
 				    enum bt_audio_dir dir);

--- a/subsys/bluetooth/audio/bap_stream.c
+++ b/subsys/bluetooth/audio/bap_stream.c
@@ -31,28 +31,6 @@
 
 LOG_MODULE_REGISTER(bt_bap_stream, CONFIG_BT_BAP_STREAM_LOG_LEVEL);
 
-void bt_audio_codec_cfg_to_iso_path(struct bt_iso_chan_path *path,
-				    struct bt_audio_codec_cfg *codec_cfg)
-{
-	path->pid = codec_cfg->path_id;
-
-	if (codec_cfg->ctlr_transcode) {
-		path->format = codec_cfg->id;
-		path->cid = codec_cfg->cid;
-		path->vid = codec_cfg->vid;
-		path->delay = 0;
-		path->cc_len = codec_cfg->data_len;
-		path->cc = codec_cfg->data;
-	} else {
-		path->format = BT_HCI_CODING_FORMAT_TRANSPARENT;
-		path->cid = 0;
-		path->vid = 0;
-		path->delay = 0;
-		path->cc_len = 0;
-		path->cc = NULL;
-	}
-}
-
 #if defined(CONFIG_BT_BAP_UNICAST_CLIENT) || defined(CONFIG_BT_BAP_BROADCAST_SOURCE) ||            \
 	defined(CONFIG_BT_BAP_BROADCAST_SINK)
 void bt_audio_codec_qos_to_iso_qos(struct bt_iso_chan_io_qos *io,

--- a/subsys/bluetooth/audio/bap_stream.h
+++ b/subsys/bluetooth/audio/bap_stream.h
@@ -17,8 +17,6 @@ void bt_bap_stream_reset(struct bt_bap_stream *stream);
 void bt_bap_stream_attach(struct bt_conn *conn, struct bt_bap_stream *stream, struct bt_bap_ep *ep,
 			  struct bt_audio_codec_cfg *codec_cfg);
 
-void bt_audio_codec_cfg_to_iso_path(struct bt_iso_chan_path *path,
-				    struct bt_audio_codec_cfg *codec_cfg);
 void bt_audio_codec_qos_to_iso_qos(struct bt_iso_chan_io_qos *io,
 				   const struct bt_audio_codec_qos *codec_qos);
 

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -774,17 +774,8 @@ static void unicast_client_ep_qos_state(struct bt_bap_ep *ep, struct net_buf_sim
 		 * we have the ISO <-> EP coupling completed (due to setting
 		 * the CIS ID in the QoS procedure).
 		 */
-		if (ep->dir == BT_AUDIO_DIR_SOURCE) {
-			/* If the endpoint is a source, then we need to
-			 * configure our RX parameters
-			 */
-			bt_audio_codec_cfg_to_iso_path(&ep->iso->rx.path, stream->codec_cfg);
-		} else {
-			/* If the endpoint is a sink, then we need to
-			 * configure our TX parameters
-			 */
-			bt_audio_codec_cfg_to_iso_path(&ep->iso->tx.path, stream->codec_cfg);
-		}
+
+		bt_bap_iso_configure_data_path(ep, stream->codec_cfg);
 	}
 
 	/* Notify upper layer */


### PR DESCRIPTION
BAP would always set up the ISO data path in both directions, even for unidirectional CIS. This meant that in the unconfigured direction, the data path configuration data would all be 0, which causes issues on some controllers.

The new refactored approach implemented by this commit will always ensure that the data path is setup correctly, and that we only set the data path in one direction for unidirectional CIS.

This is building on the requirement in BAP that all streams in a unicast group shall be QoS configured at the same time. This ensures that before any streams in the CIG has been connected, they have all been configured.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/67779