### PR TITLE
tests: bsim: bluetooth: host: gatt: general: improve conn ref handling

### DIFF
--- a/tests/bsim/bluetooth/host/gatt/general/src/gatt_client_test.c
+++ b/tests/bsim/bluetooth/host/gatt/general/src/gatt_client_test.c
@@ -36,7 +36,8 @@ static void connected(struct bt_conn *conn, uint8_t err)
 
 	printk("Connected to %s\n", addr);
 
-	g_conn = conn;
+	__ASSERT_NO_MSG(g_conn == conn);
+
 	SET_FLAG(flag_is_connected);
 }
 


### PR DESCRIPTION
Improved the connection reference handling in the BabbleSim test project in the Bluetooth Host category.