### PR TITLE
MAINTAINERS: Add BeagleBoard Platforms

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -259,6 +259,20 @@ Ambiq Platforms:
   labels:
     - "platform: Ambiq"
 
+BeagleBoard Platforms:
+  status: maintained
+  maintainers:
+    - jadonk
+  collaborators:
+    - ayush1325
+    - con-pax
+    - vaishnavachath
+  files:
+    - boards/arm/beagle*/
+    - boards/riscv/beagle*/
+  labels:
+    - "platform: BeagleBoard"
+
 Benchmarks:
   status: maintained
   maintainers:


### PR DESCRIPTION
- Due to the incresing support for ZephyrRTOS in BeagleBoard boards, it would be good to have this entry.
- Was discussed in Discord when asking for help for PR review

Details about BealgeBoard boards can be found here:
- https://www.beagleboard.org
- https://docs.beagleboard.org/latest/

cc @cfriedt