### PR TITLE
cmake: improve board revision handling

### DIFF
--- a/cmake/modules/boards.cmake
+++ b/cmake/modules/boards.cmake
@@ -214,6 +214,12 @@ elseif(HWMv2)
     if(BOARD_REVISION_FORMAT STREQUAL "custom")
       include(${BOARD_DIR}/revision.cmake)
     else()
+      if(EXISTS ${BOARD_DIR}/revision.cmake)
+        message(WARNING
+          "revision.cmake ignored, revision.cmake is only used for revision format: 'custom'"
+        )
+      endif()
+
       string(TOUPPER "${BOARD_REVISION_FORMAT}" rev_format)
       if(BOARD_REVISION_EXACT)
         set(rev_exact EXACT)
@@ -226,6 +232,16 @@ elseif(HWMv2)
         ${rev_exact}
       )
     endif()
+  elseif(DEFINED BOARD_REVISION)
+    if(EXISTS ${BOARD_DIR}/revision.cmake)
+      message(WARNING
+        "revision.cmake is not used, revisions must be defined in '${BOARD_DIR}/board.yml'"
+      )
+    endif()
+
+    message(FATAL_ERROR "Invalid board revision: ${BOARD_REVISION}\n"
+                        "Board '${BOARD}' does not define any revisions."
+    )
   endif()
 
   if(BOARD_IDENTIFIERS)


### PR DESCRIPTION
In old hw model, board revisions was handled by creation of a revisions.cmake file. In the new hw model, board revisions are defined as integral part of board.yml, and revision.cmake is only needed and used for custom revision format.

Users familiar with revision.cmake in old hw model may not be aware of this difference, therefore provide warnings if developers create a revision.cmake that is ignored by the build system.

Also fail a build if users specify a board revision for a board which doesn't support revision. Such scenario can easily occur in the case where a board developer may be creating a revisions.cmake file and then try to build for a revision specified in that file.