### PR TITLE
cmake: clear BOARD_CACHE when invalid board identifier is given

### DIFF
--- a/cmake/modules/boards.cmake
+++ b/cmake/modules/boards.cmake
@@ -239,6 +239,7 @@ elseif(HWMv2)
 
     if(NOT ("${BOARD}${BOARD_IDENTIFIER}" IN_LIST BOARD_IDENTIFIERS))
       string(REPLACE ";" "\n" BOARD_IDENTIFIERS "${BOARD_IDENTIFIERS}")
+      unset(CACHED_BOARD CACHE)
       message(FATAL_ERROR "Board identifier `${BOARD_IDENTIFIER}` for board \
             `${BOARD}` not found. Please specify a valid board.\n"
             "Valid board identifiers for ${BOARD_NAME} are:\n${BOARD_IDENTIFIERS}\n")


### PR DESCRIPTION
Clear BOARD_CACHE when no or an invalid board identifier is provided on first CMake invocation.

This allows users to re-run CMake and provide a valid board identifier as well as avoiding `BOARD` to be replaced with an invalid BOARD_CACHED value.