### PR TITLE
net: dns: Fix formatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -83,6 +83,7 @@ IncludeCategories:
     Priority: 3
 IndentCaseLabels: false
 IndentWidth: 8
+IndentGotoLabels: false
 InsertBraces: true
 SpaceBeforeParens: ControlStatementsExceptControlMacros
 SortIncludes: Never

--- a/subsys/net/lib/dns/dns_internal.h
+++ b/subsys/net/lib/dns/dns_internal.h
@@ -11,10 +11,6 @@
 #include "dns_pack.h"
 
 #if defined(CONFIG_NET_TEST)
-int dns_validate_msg(struct dns_resolve_context *ctx,
-		     struct dns_msg_t *dns_msg,
-		     uint16_t *dns_id,
-		     int *query_idx,
-		     struct net_buf *dns_cname,
-		     uint16_t *query_hash);
+int dns_validate_msg(struct dns_resolve_context *ctx, struct dns_msg_t *dns_msg, uint16_t *dns_id,
+		     int *query_idx, struct net_buf *dns_cname, uint16_t *query_hash);
 #endif

--- a/subsys/net/lib/dns/dns_pack.c
+++ b/subsys/net/lib/dns/dns_pack.c
@@ -19,8 +19,7 @@ static inline uint16_t dns_strlen(const char *str)
 	return (uint16_t)strlen(str);
 }
 
-int dns_msg_pack_qname(uint16_t *len, uint8_t *buf, uint16_t size,
-		       const char *domain_name)
+int dns_msg_pack_qname(uint16_t *len, uint8_t *buf, uint16_t size, const char *domain_name)
 {
 	uint16_t dn_size;
 	uint16_t lb_start;
@@ -66,8 +65,8 @@ int dns_msg_pack_qname(uint16_t *len, uint8_t *buf, uint16_t size,
 	return 0;
 }
 
-static inline void set_dns_msg_response(struct dns_msg_t *dns_msg, int type,
-					uint16_t pos, uint16_t len)
+static inline void set_dns_msg_response(struct dns_msg_t *dns_msg, int type, uint16_t pos,
+					uint16_t len)
 {
 	dns_msg->response_type = type;
 	dns_msg->response_position = pos;
@@ -117,8 +116,7 @@ int dns_unpack_answer(struct dns_msg_t *dns_msg, int dname_ptr, uint32_t *ttl,
 
 	answer = dns_msg->msg + dns_msg->answer_offset;
 
-	dname_len = skip_fqdn(answer,
-			      dns_msg->msg_size - dns_msg->answer_offset);
+	dname_len = skip_fqdn(answer, dns_msg->msg_size - dns_msg->answer_offset);
 	if (dname_len < 0) {
 		return dname_len;
 	}
@@ -143,19 +141,16 @@ int dns_unpack_answer(struct dns_msg_t *dns_msg, int dname_ptr, uint32_t *ttl,
 	 * Cache-Flush bit (highest one).
 	 */
 	if ((dns_answer_class(dname_len, answer) &
-	     (IS_ENABLED(CONFIG_MDNS_RESOLVER) ? 0x7fff : 0xffff))
-							!= DNS_CLASS_IN) {
+	     (IS_ENABLED(CONFIG_MDNS_RESOLVER) ? 0x7fff : 0xffff)) != DNS_CLASS_IN) {
 		return -EINVAL;
 	}
 
 	/* TTL value */
 	*ttl = dns_answer_ttl(dname_len, answer);
 	len = dns_answer_rdlength(dname_len, answer);
-	pos = dns_msg->answer_offset + dname_len +
-		DNS_COMMON_UINT_SIZE + /* class length */
-		DNS_COMMON_UINT_SIZE + /* type length */
-		DNS_TTL_LEN +
-		DNS_RDLENGTH_LEN;
+	pos = dns_msg->answer_offset + dname_len + DNS_COMMON_UINT_SIZE + /* class length */
+	      DNS_COMMON_UINT_SIZE +                                      /* type length */
+	      DNS_TTL_LEN + DNS_RDLENGTH_LEN;
 	*type = dns_answer_type(dname_len, answer);
 
 	switch (*type) {
@@ -165,8 +160,7 @@ int dns_unpack_answer(struct dns_msg_t *dns_msg, int dname_ptr, uint32_t *ttl,
 		return 0;
 
 	case DNS_RR_TYPE_CNAME:
-		set_dns_msg_response(dns_msg, DNS_RESPONSE_CNAME_NO_IP,
-				     pos, len);
+		set_dns_msg_response(dns_msg, DNS_RESPONSE_CNAME_NO_IP, pos, len);
 		return 0;
 
 	default:
@@ -214,7 +208,6 @@ int dns_unpack_response_header(struct dns_msg_t *msg, int src_id)
 		break;
 	default:
 		return rc;
-
 	}
 
 	qdcount = dns_unpack_header_qdcount(dns_header);
@@ -250,8 +243,8 @@ static int dns_msg_pack_query_header(uint8_t *buf, uint16_t size, uint16_t id)
 	/* Split the following assignments just in case we need to alter
 	 * the flags in future releases
 	 */
-	*(buf + offset) = DNS_FLAGS1;		/* QR, Opcode, AA, TC and RD */
-	*(buf + offset + 1) = DNS_FLAGS2;	/* RA, Z and RCODE */
+	*(buf + offset) = DNS_FLAGS1;     /* QR, Opcode, AA, TC and RD */
+	*(buf + offset + 1) = DNS_FLAGS2; /* RA, Z and RCODE */
 
 	offset += DNS_HEADER_FLAGS_LEN;
 	/* set question counter */
@@ -268,9 +261,8 @@ static int dns_msg_pack_query_header(uint8_t *buf, uint16_t size, uint16_t id)
 	return 0;
 }
 
-int dns_msg_pack_query(uint8_t *buf, uint16_t *len, uint16_t size,
-		       uint8_t *qname, uint16_t qname_len, uint16_t id,
-		       enum dns_rr_type qtype)
+int dns_msg_pack_query(uint8_t *buf, uint16_t *len, uint16_t size, uint8_t *qname,
+		       uint16_t qname_len, uint16_t id, enum dns_rr_type qtype)
 {
 	uint16_t msg_size;
 	uint16_t offset;
@@ -352,14 +344,14 @@ int dns_unpack_response_query(struct dns_msg_t *dns_msg)
 		return -EINVAL;
 	}
 
-	dns_msg->answer_offset = dns_msg->query_offset + qname_size +
-				 DNS_QTYPE_LEN + DNS_QCLASS_LEN;
+	dns_msg->answer_offset =
+		dns_msg->query_offset + qname_size + DNS_QTYPE_LEN + DNS_QCLASS_LEN;
 
 	return 0;
 }
 
-int dns_copy_qname(uint8_t *buf, uint16_t *len, uint16_t size,
-		   struct dns_msg_t *dns_msg, uint16_t pos)
+int dns_copy_qname(uint8_t *buf, uint16_t *len, uint16_t size, struct dns_msg_t *dns_msg,
+		   uint16_t pos)
 {
 	uint16_t msg_size = dns_msg->msg_size;
 	uint8_t *msg = dns_msg->msg;
@@ -462,8 +454,8 @@ int mdns_unpack_query_header(struct dns_msg_t *msg, uint16_t *src_id)
 }
 
 /* Returns the length of the unpacked name */
-static int dns_unpack_name(const uint8_t *msg, int maxlen, const uint8_t *src,
-			   struct net_buf *buf, const uint8_t **eol)
+static int dns_unpack_name(const uint8_t *msg, int maxlen, const uint8_t *src, struct net_buf *buf,
+			   const uint8_t **eol)
 {
 	int dest_size = net_buf_tailroom(buf);
 	const uint8_t *end_of_label = NULL;
@@ -512,8 +504,7 @@ static int dns_unpack_name(const uint8_t *msg, int maxlen, const uint8_t *src,
 				return -EMSGSIZE;
 			}
 
-			if (((buf->data + label_len + 1) >=
-			     (buf->data + dest_size)) ||
+			if (((buf->data + label_len + 1) >= (buf->data + dest_size)) ||
 			    ((curr_src + label_len) >= (msg + maxlen))) {
 				return -EMSGSIZE;
 			}
@@ -540,8 +531,8 @@ static int dns_unpack_name(const uint8_t *msg, int maxlen, const uint8_t *src,
 	return buf->len;
 }
 
-int dns_unpack_query(struct dns_msg_t *dns_msg, struct net_buf *buf,
-		     enum dns_rr_type *qtype, enum dns_class *qclass)
+int dns_unpack_query(struct dns_msg_t *dns_msg, struct net_buf *buf, enum dns_rr_type *qtype,
+		     enum dns_class *qclass)
 {
 	const uint8_t *end_of_label;
 	uint8_t *dns_query;
@@ -550,17 +541,15 @@ int dns_unpack_query(struct dns_msg_t *dns_msg, struct net_buf *buf,
 
 	dns_query = dns_msg->msg + dns_msg->query_offset;
 
-	ret = dns_unpack_name(dns_msg->msg, dns_msg->msg_size, dns_query,
-			      buf, &end_of_label);
+	ret = dns_unpack_name(dns_msg->msg, dns_msg->msg_size, dns_query, buf, &end_of_label);
 	if (ret < 0) {
 		return ret;
 	}
 
 	query_type = dns_unpack_query_qtype(end_of_label);
-	if (query_type != DNS_RR_TYPE_A && query_type != DNS_RR_TYPE_AAAA
-		&& query_type != DNS_RR_TYPE_PTR
-		&& query_type != DNS_RR_TYPE_SRV
-		&& query_type != DNS_RR_TYPE_TXT) {
+	if (query_type != DNS_RR_TYPE_A && query_type != DNS_RR_TYPE_AAAA &&
+	    query_type != DNS_RR_TYPE_PTR && query_type != DNS_RR_TYPE_SRV &&
+	    query_type != DNS_RR_TYPE_TXT) {
 		return -EINVAL;
 	}
 

--- a/subsys/net/lib/dns/dns_pack.h
+++ b/subsys/net/lib/dns/dns_pack.h
@@ -17,41 +17,41 @@
 /* See RFC 1035, 4.1.1 Header section format
  * DNS Message Header is always 12 bytes
  */
-#define DNS_MSG_HEADER_SIZE	12
+#define DNS_MSG_HEADER_SIZE 12
 
 /* This is the label's length octet, see 4.1.2. Question section format */
-#define DNS_LABEL_LEN_SIZE	1
-#define DNS_POINTER_SIZE	2
-#define DNS_LABEL_MIN_SIZE	1
-#define DNS_LABEL_MAX_SIZE	63
-#define DNS_NAME_MAX_SIZE       255
-#define DNS_ANSWER_MIN_SIZE	12
-#define DNS_COMMON_UINT_SIZE	2
+#define DNS_LABEL_LEN_SIZE   1
+#define DNS_POINTER_SIZE     2
+#define DNS_LABEL_MIN_SIZE   1
+#define DNS_LABEL_MAX_SIZE   63
+#define DNS_NAME_MAX_SIZE    255
+#define DNS_ANSWER_MIN_SIZE  12
+#define DNS_COMMON_UINT_SIZE 2
 
-#define DNS_HEADER_ID_LEN	2
-#define DNS_HEADER_FLAGS_LEN	2
-#define DNS_QTYPE_LEN		2
-#define DNS_QCLASS_LEN		2
-#define DNS_QDCOUNT_LEN		2
-#define DNS_ANCOUNT_LEN		2
-#define DNS_NSCOUNT_LEN		2
-#define DNS_ARCOUNT_LEN		2
-#define DNS_TTL_LEN		4
-#define DNS_RDLENGTH_LEN	2
+#define DNS_HEADER_ID_LEN    2
+#define DNS_HEADER_FLAGS_LEN 2
+#define DNS_QTYPE_LEN        2
+#define DNS_QCLASS_LEN       2
+#define DNS_QDCOUNT_LEN      2
+#define DNS_ANCOUNT_LEN      2
+#define DNS_NSCOUNT_LEN      2
+#define DNS_ARCOUNT_LEN      2
+#define DNS_TTL_LEN          4
+#define DNS_RDLENGTH_LEN     2
 
-#define NS_CMPRSFLGS    0xc0   /* DNS name compression */
+#define NS_CMPRSFLGS 0xc0 /* DNS name compression */
 
 /* RFC 1035 '4.1.1. Header section format' defines the following flags:
  * QR, Opcode, AA, TC, RD, RA, Z and RCODE.
  * This implementation only uses RD (Recursion Desired).
  */
-#define DNS_RECURSION		1
+#define DNS_RECURSION 1
 
 /* These two defines represent the 3rd and 4th bytes of the DNS msg header.
  * See RFC 1035, 4.1.1. Header section format.
  */
-#define DNS_FLAGS1		DNS_RECURSION	/* QR, Opcode, AA, and TC = 0 */
-#define DNS_FLAGS2		0		/* RA, Z and RCODE = 0 */
+#define DNS_FLAGS1 DNS_RECURSION /* QR, Opcode, AA, and TC = 0 */
+#define DNS_FLAGS2 0             /* RA, Z and RCODE = 0 */
 
 /**
  * DNS message structure for DNS responses
@@ -81,18 +81,19 @@ struct dns_msg_t {
 	uint16_t msg_size;
 };
 
-#define DNS_MSG_INIT(b, s)	{.msg = b, .msg_size = s,	\
-				 .response_type = -EINVAL}
-
+#define DNS_MSG_INIT(b, s)                                                                         \
+	{                                                                                          \
+		.msg = b, .msg_size = s, .response_type = -EINVAL                                  \
+	}
 
 enum dns_rr_type {
 	DNS_RR_TYPE_INVALID = 0,
-	DNS_RR_TYPE_A	= 1,		/* IPv4  */
-	DNS_RR_TYPE_CNAME = 5,		/* CNAME */
-	DNS_RR_TYPE_PTR = 12,		/* PTR   */
-	DNS_RR_TYPE_TXT = 16,		/* TXT   */
-	DNS_RR_TYPE_AAAA = 28,		/* IPv6  */
-	DNS_RR_TYPE_SRV = 33,		/* SRV   */
+	DNS_RR_TYPE_A = 1,     /* IPv4  */
+	DNS_RR_TYPE_CNAME = 5, /* CNAME */
+	DNS_RR_TYPE_PTR = 12,  /* PTR   */
+	DNS_RR_TYPE_TXT = 16,  /* TXT   */
+	DNS_RR_TYPE_AAAA = 28, /* IPv6  */
+	DNS_RR_TYPE_SRV = 33,  /* SRV   */
 };
 
 enum dns_response_type {
@@ -135,9 +136,9 @@ struct dns_header {
 	 * | RA | 7 | 1 | Recursion Available. 0 := Unavailable, 1 := Available |
 	 * | RD | 8 | 1 | Recursion Desired. 0 := No Recursion, 1 := Recursion |
 	 * | TC | 9 | 1 | 0 := Not Truncated, 1 := Truncated |
-	 * | AA | 10 | 1 | Answer Authenticated / Answer Authoritative. 0 := Not Authenticated, 1 := Authenticated|
-	 * | Opcode | 11 | 4 | See @ref dns_opcode |
-	 * | QR | 15 | 1 | 0 := Query, 1 := Response |
+	 * | AA | 10 | 1 | Answer Authenticated / Answer Authoritative. 0 := Not Authenticated, 1 :=
+	 * Authenticated| | Opcode | 11 | 4 | See @ref dns_opcode | | QR | 15 | 1 | 0 := Query, 1 :=
+	 * Response |
 	 */
 	uint16_t flags;
 	/** Query count */
@@ -313,8 +314,7 @@ static inline int dns_answer_ttl(uint16_t dname_size, uint8_t *answer)
 	return ntohl(UNALIGNED_GET((uint32_t *)(answer + dname_size + 4)));
 }
 
-static inline int dns_answer_rdlength(uint16_t dname_size,
-					     uint8_t *answer)
+static inline int dns_answer_rdlength(uint16_t dname_size, uint8_t *answer)
 {
 	return ntohs(UNALIGNED_GET((uint16_t *)(answer + dname_size + 8)));
 }
@@ -330,8 +330,7 @@ static inline int dns_answer_rdlength(uint16_t dname_size,
  * @retval -ENOMEM if there is no enough space to store the resultant QNAME
  * @retval -EINVAL if an invalid parameter was passed as an argument
  */
-int dns_msg_pack_qname(uint16_t *len, uint8_t *buf, uint16_t size,
-		       const char *domain_name);
+int dns_msg_pack_qname(uint16_t *len, uint8_t *buf, uint16_t size, const char *domain_name);
 
 /**
  * @brief Unpacks an answer message
@@ -380,9 +379,8 @@ int dns_unpack_response_header(struct dns_msg_t *msg, int src_id);
  * @retval On error, a negative value is returned.
  *         See: dns_msg_pack_query_header and  dns_msg_pack_qname.
  */
-int dns_msg_pack_query(uint8_t *buf, uint16_t *len, uint16_t size,
-		       uint8_t *qname, uint16_t qname_len, uint16_t id,
-		       enum dns_rr_type qtype);
+int dns_msg_pack_query(uint8_t *buf, uint16_t *len, uint16_t size, uint8_t *qname,
+		       uint16_t qname_len, uint16_t id, enum dns_rr_type qtype);
 
 /**
  * @brief Unpacks the response's query.
@@ -417,8 +415,8 @@ int dns_unpack_response_query(struct dns_msg_t *dns_msg);
  * @retval -EINVAL if an invalid parameter was passed as an argument
  * @retval -ENOMEM if the label's size is corrupted
  */
-int dns_copy_qname(uint8_t *buf, uint16_t *len, uint16_t size,
-		   struct dns_msg_t *dns_msg, uint16_t pos);
+int dns_copy_qname(uint8_t *buf, uint16_t *len, uint16_t size, struct dns_msg_t *dns_msg,
+		   uint16_t pos);
 
 /**
  * @brief Unpacks the mDNS query. This is special version for multicast DNS
@@ -439,8 +437,7 @@ int dns_copy_qname(uint8_t *buf, uint16_t *len, uint16_t size,
  */
 int mdns_unpack_query_header(struct dns_msg_t *msg, uint16_t *src_id);
 
-static inline int llmnr_unpack_query_header(struct dns_msg_t *msg,
-					    uint16_t *src_id)
+static inline int llmnr_unpack_query_header(struct dns_msg_t *msg, uint16_t *src_id)
 {
 	return mdns_unpack_query_header(msg, src_id);
 }
@@ -458,8 +455,7 @@ static inline int llmnr_unpack_query_header(struct dns_msg_t *msg,
  * @retval -EINVAL if QTYPE is not "A" (IPv4) or "AAAA" (IPv6) or if QCLASS
  *         is not "IN".
  */
-int dns_unpack_query(struct dns_msg_t *dns_msg, struct net_buf *buf,
-		     enum dns_rr_type *qtype,
+int dns_unpack_query(struct dns_msg_t *dns_msg, struct net_buf *buf, enum dns_rr_type *qtype,
 		     enum dns_class *qclass);
 
 #endif

--- a/subsys/net/lib/dns/dns_sd.c
+++ b/subsys/net/lib/dns/dns_sd.c
@@ -31,29 +31,19 @@ const uint16_t dns_sd_port_zero;
 
 static size_t service_proto_size(const struct dns_sd_rec *inst);
 static bool label_is_valid(const char *label, size_t label_size);
-static int add_a_record(const struct dns_sd_rec *inst, uint32_t ttl,
-			uint16_t host_offset, uint32_t addr,
-			uint8_t *buf,
-			uint16_t buf_offset, uint16_t buf_size);
-static int add_ptr_record(const struct dns_sd_rec *inst, uint32_t ttl,
-			  uint8_t *buf, uint16_t buf_offset,
-			  uint16_t buf_size,
-			  uint16_t *service_offset,
-			  uint16_t *instance_offset,
-			  uint16_t *domain_offset);
-static int add_txt_record(const struct dns_sd_rec *inst, uint32_t ttl,
-			  uint16_t instance_offset, uint8_t *buf,
-			  uint16_t buf_offset, uint16_t buf_size);
-static int add_aaaa_record(const struct dns_sd_rec *inst, uint32_t ttl,
-			   uint16_t host_offset, const uint8_t addr[16],
-			   uint8_t *buf, uint16_t buf_offset,
+static int add_a_record(const struct dns_sd_rec *inst, uint32_t ttl, uint16_t host_offset,
+			uint32_t addr, uint8_t *buf, uint16_t buf_offset, uint16_t buf_size);
+static int add_ptr_record(const struct dns_sd_rec *inst, uint32_t ttl, uint8_t *buf,
+			  uint16_t buf_offset, uint16_t buf_size, uint16_t *service_offset,
+			  uint16_t *instance_offset, uint16_t *domain_offset);
+static int add_txt_record(const struct dns_sd_rec *inst, uint32_t ttl, uint16_t instance_offset,
+			  uint8_t *buf, uint16_t buf_offset, uint16_t buf_size);
+static int add_aaaa_record(const struct dns_sd_rec *inst, uint32_t ttl, uint16_t host_offset,
+			   const uint8_t addr[16], uint8_t *buf, uint16_t buf_offset,
 			   uint16_t buf_size);
-static int add_srv_record(const struct dns_sd_rec *inst, uint32_t ttl,
-			  uint16_t instance_offset,
-			  uint16_t domain_offset,
-			  uint8_t *buf, uint16_t buf_offset,
-			  uint16_t buf_size,
-			  uint16_t *host_offset);
+static int add_srv_record(const struct dns_sd_rec *inst, uint32_t ttl, uint16_t instance_offset,
+			  uint16_t domain_offset, uint8_t *buf, uint16_t buf_offset,
+			  uint16_t buf_size, uint16_t *host_offset);
 static bool rec_is_valid(const struct dns_sd_rec *inst);
 
 #endif /* CONFIG_NET_TEST */
@@ -80,12 +70,8 @@ static bool rec_is_valid(const struct dns_sd_rec *inst);
  */
 size_t service_proto_size(const struct dns_sd_rec *ref)
 {
-	return 0
-	       + DNS_LABEL_LEN_SIZE + strlen(ref->service)
-	       + DNS_LABEL_LEN_SIZE + strlen(ref->proto)
-	       + DNS_LABEL_LEN_SIZE + strlen(ref->domain)
-	       + DNS_LABEL_LEN_SIZE
-	;
+	return 0 + DNS_LABEL_LEN_SIZE + strlen(ref->service) + DNS_LABEL_LEN_SIZE +
+	       strlen(ref->proto) + DNS_LABEL_LEN_SIZE + strlen(ref->domain) + DNS_LABEL_LEN_SIZE;
 }
 
 /**
@@ -112,12 +98,9 @@ bool label_is_valid(const char *label, size_t label_size)
 		label_size = strlen(label);
 	}
 
-	if (label_size < DNS_LABEL_MIN_SIZE ||
-	    label_size > DNS_LABEL_MAX_SIZE) {
-		NET_DBG("label invalid size (%zu, min: %u, max: %u)",
-			 label_size,
-			 DNS_LABEL_MIN_SIZE,
-			 DNS_LABEL_MAX_SIZE);
+	if (label_size < DNS_LABEL_MIN_SIZE || label_size > DNS_LABEL_MAX_SIZE) {
+		NET_DBG("label invalid size (%zu, min: %u, max: %u)", label_size,
+			DNS_LABEL_MIN_SIZE, DNS_LABEL_MAX_SIZE);
 		return false;
 	}
 
@@ -155,26 +138,22 @@ static bool instance_is_valid(const char *instance)
 
 	instance_size = strlen(instance);
 	if (instance_size < DNS_SD_INSTANCE_MIN_SIZE) {
-		NET_DBG("instance '%s' is too small (%zu, min: %u)",
-			instance, instance_size,
+		NET_DBG("instance '%s' is too small (%zu, min: %u)", instance, instance_size,
 			DNS_SD_INSTANCE_MIN_SIZE);
 		return false;
 	}
 
 	if (instance_size > DNS_SD_INSTANCE_MAX_SIZE) {
-		NET_DBG("instance '%s' is too big (%zu, max: %u)",
-			instance, instance_size,
+		NET_DBG("instance '%s' is too big (%zu, max: %u)", instance, instance_size,
 			DNS_SD_INSTANCE_MAX_SIZE);
 		return false;
 	}
 
 	for (i = 0; i < instance_size; ++i) {
 		/* RFC 6763 Section 4.1.1 */
-		if (instance[i] <= 0x1f ||
-		    instance[i] == 0x7f) {
-			NET_DBG(
-				"instance '%s' contains illegal byte 0x%02x",
-				instance, instance[i]);
+		if (instance[i] <= 0x1f || instance[i] == 0x7f) {
+			NET_DBG("instance '%s' contains illegal byte 0x%02x", instance,
+				instance[i]);
 			return false;
 		}
 	}
@@ -193,26 +172,24 @@ static bool service_is_valid(const char *service)
 
 	service_size = strlen(service);
 	if (service_size < DNS_SD_SERVICE_MIN_SIZE) {
-		NET_DBG("service '%s' is too small (%zu, min: %u)",
-			service, service_size, DNS_SD_SERVICE_MIN_SIZE);
+		NET_DBG("service '%s' is too small (%zu, min: %u)", service, service_size,
+			DNS_SD_SERVICE_MIN_SIZE);
 		return false;
 	}
 
 	if (service_size > DNS_SD_SERVICE_MAX_SIZE) {
-		NET_DBG("service '%s' is too big (%zu, max: %u)",
-			service, service_size, DNS_SD_SERVICE_MAX_SIZE);
+		NET_DBG("service '%s' is too big (%zu, max: %u)", service, service_size,
+			DNS_SD_SERVICE_MAX_SIZE);
 		return false;
 	}
 
 	if (service[0] != DNS_SD_SERVICE_PREFIX) {
-		NET_DBG("service '%s' invalid (no leading underscore)",
-			service);
+		NET_DBG("service '%s' invalid (no leading underscore)", service);
 		return false;
 	}
 
 	if (!label_is_valid(&service[1], service_size - 1)) {
-		NET_DBG("service '%s' contains invalid characters",
-			service);
+		NET_DBG("service '%s' contains invalid characters", service);
 		return false;
 	}
 
@@ -230,16 +207,15 @@ static bool proto_is_valid(const char *proto)
 
 	proto_size = strlen(proto);
 	if (proto_size != DNS_SD_PROTO_SIZE) {
-		NET_DBG("proto '%s' wrong size (%zu, exp: %u)",
-			proto, proto_size, DNS_SD_PROTO_SIZE);
+		NET_DBG("proto '%s' wrong size (%zu, exp: %u)", proto, proto_size,
+			DNS_SD_PROTO_SIZE);
 		return false;
 	}
 
 	if (!(strncasecmp("_tcp", proto, DNS_SD_PROTO_SIZE) == 0 ||
 	      strncasecmp("_udp", proto, DNS_SD_PROTO_SIZE) == 0)) {
 		/* RFC 1034 Section 3.1 */
-		NET_DBG("proto '%s' is invalid (not _tcp or _udp)",
-			proto);
+		NET_DBG("proto '%s' is invalid (not _tcp or _udp)", proto);
 		return false;
 	}
 
@@ -257,20 +233,19 @@ static bool domain_is_valid(const char *domain)
 
 	domain_size = strlen(domain);
 	if (domain_size < DNS_SD_DOMAIN_MIN_SIZE) {
-		NET_DBG("domain '%s' is too small (%zu, min: %u)",
-			domain, domain_size, DNS_SD_DOMAIN_MIN_SIZE);
+		NET_DBG("domain '%s' is too small (%zu, min: %u)", domain, domain_size,
+			DNS_SD_DOMAIN_MIN_SIZE);
 		return false;
 	}
 
 	if (domain_size > DNS_SD_DOMAIN_MAX_SIZE) {
-		NET_DBG("domain '%s' is too big (%zu, max: %u)",
-			domain, domain_size, DNS_SD_DOMAIN_MAX_SIZE);
+		NET_DBG("domain '%s' is too big (%zu, max: %u)", domain, domain_size,
+			DNS_SD_DOMAIN_MAX_SIZE);
 		return false;
 	}
 
 	if (!label_is_valid(domain, domain_size)) {
-		NET_DBG("domain '%s' contains invalid characters",
-			domain);
+		NET_DBG("domain '%s' contains invalid characters", domain);
 		return false;
 	}
 
@@ -286,20 +261,13 @@ static bool domain_is_valid(const char *domain)
  */
 bool rec_is_valid(const struct dns_sd_rec *inst)
 {
-	return true
-	       && inst != NULL
-	       && instance_is_valid(inst->instance)
-	       && service_is_valid(inst->service)
-	       && proto_is_valid(inst->proto)
-	       && domain_is_valid(inst->domain)
-	       && inst->text != NULL
-	       && inst->port != NULL
-	;
+	return true && inst != NULL && instance_is_valid(inst->instance) &&
+	       service_is_valid(inst->service) && proto_is_valid(inst->proto) &&
+	       domain_is_valid(inst->domain) && inst->text != NULL && inst->port != NULL;
 }
 
-int add_a_record(const struct dns_sd_rec *inst, uint32_t ttl,
-		 uint16_t host_offset, uint32_t addr, uint8_t *buf,
-		 uint16_t buf_offset, uint16_t buf_size)
+int add_a_record(const struct dns_sd_rec *inst, uint32_t ttl, uint16_t host_offset, uint32_t addr,
+		 uint8_t *buf, uint16_t buf_offset, uint16_t buf_size)
 {
 	uint16_t total_size;
 	struct dns_rr *rr;
@@ -308,8 +276,7 @@ int add_a_record(const struct dns_sd_rec *inst, uint32_t ttl,
 	uint16_t offset = buf_offset;
 
 	if ((DNS_SD_PTR_MASK & host_offset) != 0) {
-		NET_DBG("offset %u too big for message compression",
-			host_offset);
+		NET_DBG("offset %u too big for message compression", host_offset);
 		return -E2BIG;
 	}
 
@@ -319,8 +286,8 @@ int add_a_record(const struct dns_sd_rec *inst, uint32_t ttl,
 		2 + sizeof(*rr) + sizeof(*rdata);
 
 	if (offset > buf_size || total_size >= buf_size - offset) {
-		NET_DBG("Buffer too small. required: %u available: %d",
-			total_size, (int)buf_size - (int)offset);
+		NET_DBG("Buffer too small. required: %u available: %d", total_size,
+			(int)buf_size - (int)offset);
 		return -ENOSPC;
 	}
 
@@ -347,9 +314,8 @@ int add_a_record(const struct dns_sd_rec *inst, uint32_t ttl,
 	return offset - buf_offset;
 }
 
-int add_ptr_record(const struct dns_sd_rec *inst, uint32_t ttl,
-		   uint8_t *buf, uint16_t buf_offset, uint16_t buf_size,
-		   uint16_t *service_offset, uint16_t *instance_offset,
+int add_ptr_record(const struct dns_sd_rec *inst, uint32_t ttl, uint8_t *buf, uint16_t buf_offset,
+		   uint16_t buf_size, uint16_t *service_offset, uint16_t *instance_offset,
 		   uint16_t *domain_offset)
 {
 	uint8_t i;
@@ -396,27 +362,24 @@ int add_ptr_record(const struct dns_sd_rec *inst, uint32_t ttl,
 		+ 1 + strlen(inst->instance) + 2;
 
 	if (offset > buf_size || name_size >= buf_size - offset) {
-		NET_DBG("Buffer too small. required: %u available: %d",
-			name_size, (int)buf_size - (int)offset);
+		NET_DBG("Buffer too small. required: %u available: %d", name_size,
+			(int)buf_size - (int)offset);
 		return -ENOSPC;
 	}
 
 	svc_offs = offset;
 	if ((svc_offs & DNS_SD_PTR_MASK) != 0) {
-		NET_DBG("offset %u too big for message compression",
-			svc_offs);
+		NET_DBG("offset %u too big for message compression", svc_offs);
 		return -E2BIG;
 	}
 
 	inst_offs = offset + sp_size + sizeof(*rr);
 	if ((inst_offs & DNS_SD_PTR_MASK) != 0) {
-		NET_DBG("offset %u too big for message compression",
-			inst_offs);
+		NET_DBG("offset %u too big for message compression", inst_offs);
 		return -E2BIG;
 	}
 
-	dom_offs = offset + sp_size - 1 -
-		   strlen(inst->domain) - 1;
+	dom_offs = offset + sp_size - 1 - strlen(inst->domain) - 1;
 
 	/* Finally, write output with confidence that doing so is safe */
 
@@ -442,10 +405,7 @@ int add_ptr_record(const struct dns_sd_rec *inst, uint32_t ttl,
 	rr->type = htons(DNS_RR_TYPE_PTR);
 	rr->class_ = htons(DNS_CLASS_IN);
 	rr->ttl = htonl(ttl);
-	rr->rdlength = htons(
-		DNS_LABEL_LEN_SIZE +
-		strlen(inst->instance)
-		+ DNS_POINTER_SIZE);
+	rr->rdlength = htons(DNS_LABEL_LEN_SIZE + strlen(inst->instance) + DNS_POINTER_SIZE);
 	offset += sizeof(*rr);
 
 	__ASSERT_NO_MSG(inst_offs == offset);
@@ -466,9 +426,8 @@ int add_ptr_record(const struct dns_sd_rec *inst, uint32_t ttl,
 	return offset - buf_offset;
 }
 
-int add_txt_record(const struct dns_sd_rec *inst, uint32_t ttl,
-		   uint16_t instance_offset, uint8_t *buf,
-		   uint16_t buf_offset, uint16_t buf_size)
+int add_txt_record(const struct dns_sd_rec *inst, uint32_t ttl, uint16_t instance_offset,
+		   uint8_t *buf, uint16_t buf_offset, uint16_t buf_size)
 {
 	uint16_t total_size;
 	struct dns_rr *rr;
@@ -476,8 +435,7 @@ int add_txt_record(const struct dns_sd_rec *inst, uint32_t ttl,
 	uint16_t offset = buf_offset;
 
 	if ((DNS_SD_PTR_MASK & instance_offset) != 0) {
-		NET_DBG("offset %u too big for message compression",
-			instance_offset);
+		NET_DBG("offset %u too big for message compression", instance_offset);
 		return -E2BIG;
 	}
 
@@ -487,8 +445,8 @@ int add_txt_record(const struct dns_sd_rec *inst, uint32_t ttl,
 		DNS_POINTER_SIZE + sizeof(*rr) + dns_sd_txt_size(inst);
 
 	if (offset > buf_size || total_size >= buf_size - offset) {
-		NET_DBG("Buffer too small. required: %u available: %d",
-			total_size, (int)buf_size - (int)offset);
+		NET_DBG("Buffer too small. required: %u available: %d", total_size,
+			(int)buf_size - (int)offset);
 		return -ENOSPC;
 	}
 
@@ -514,9 +472,8 @@ int add_txt_record(const struct dns_sd_rec *inst, uint32_t ttl,
 	return offset - buf_offset;
 }
 
-int add_aaaa_record(const struct dns_sd_rec *inst, uint32_t ttl,
-		    uint16_t host_offset, const uint8_t addr[16],
-		    uint8_t *buf, uint16_t buf_offset, uint16_t buf_size)
+int add_aaaa_record(const struct dns_sd_rec *inst, uint32_t ttl, uint16_t host_offset,
+		    const uint8_t addr[16], uint8_t *buf, uint16_t buf_offset, uint16_t buf_size)
 {
 	uint16_t total_size;
 	struct dns_rr *rr;
@@ -525,8 +482,7 @@ int add_aaaa_record(const struct dns_sd_rec *inst, uint32_t ttl,
 	uint16_t offset = buf_offset;
 
 	if ((DNS_SD_PTR_MASK & host_offset) != 0) {
-		NET_DBG("offset %u too big for message compression",
-			host_offset);
+		NET_DBG("offset %u too big for message compression", host_offset);
 		return -E2BIG;
 	}
 
@@ -536,8 +492,8 @@ int add_aaaa_record(const struct dns_sd_rec *inst, uint32_t ttl,
 		DNS_POINTER_SIZE + sizeof(*rr) + sizeof(*rdata);
 
 	if (offset > buf_size || total_size >= buf_size - offset) {
-		NET_DBG("Buffer too small. required: %u available: %d",
-			total_size, (int)buf_size - (int)offset);
+		NET_DBG("Buffer too small. required: %u available: %d", total_size,
+			(int)buf_size - (int)offset);
 		return -ENOSPC;
 	}
 
@@ -564,9 +520,8 @@ int add_aaaa_record(const struct dns_sd_rec *inst, uint32_t ttl,
 	return offset - buf_offset;
 }
 
-int add_srv_record(const struct dns_sd_rec *inst, uint32_t ttl,
-		   uint16_t instance_offset, uint16_t domain_offset,
-		   uint8_t *buf, uint16_t buf_offset, uint16_t buf_size,
+int add_srv_record(const struct dns_sd_rec *inst, uint32_t ttl, uint16_t instance_offset,
+		   uint16_t domain_offset, uint8_t *buf, uint16_t buf_offset, uint16_t buf_size,
 		   uint16_t *host_offset)
 {
 	uint16_t total_size;
@@ -577,31 +532,29 @@ int add_srv_record(const struct dns_sd_rec *inst, uint32_t ttl,
 	uint16_t offset = buf_offset;
 
 	if ((DNS_SD_PTR_MASK & instance_offset) != 0) {
-		NET_DBG("offset %u too big for message compression",
-			instance_offset);
+		NET_DBG("offset %u too big for message compression", instance_offset);
 		return -E2BIG;
 	}
 
 	if ((DNS_SD_PTR_MASK & domain_offset) != 0) {
-		NET_DBG("offset %u too big for message compression",
-			domain_offset);
+		NET_DBG("offset %u too big for message compression", domain_offset);
 		return -E2BIG;
 	}
 
 	/* First, calculate that there is enough space in the buffer */
 	total_size =
 		/* pointer to .<Instance>.<Service>.<Protocol>.local. */
-		DNS_POINTER_SIZE + sizeof(*rr)
-		+ sizeof(*rdata)
+		DNS_POINTER_SIZE + sizeof(*rr) +
+		sizeof(*rdata)
 		/* .<Instance> */
-		+ DNS_LABEL_LEN_SIZE
-		+ strlen(inst->instance)
+		+ DNS_LABEL_LEN_SIZE +
+		strlen(inst->instance)
 		/* pointer to .local. */
 		+ DNS_POINTER_SIZE;
 
 	if (offset > buf_size || total_size >= buf_size - offset) {
-		NET_DBG("Buffer too small. required: %u available: %d",
-			total_size, (int)buf_size - (int)offset);
+		NET_DBG("Buffer too small. required: %u available: %d", total_size,
+			(int)buf_size - (int)offset);
 		return -ENOSPC;
 	}
 
@@ -617,8 +570,7 @@ int add_srv_record(const struct dns_sd_rec *inst, uint32_t ttl,
 	rr->class_ = htons(DNS_CLASS_IN | DNS_CLASS_FLUSH);
 	rr->ttl = htonl(ttl);
 	/* .<Instance>.local. */
-	rr->rdlength = htons(sizeof(*rdata) + DNS_LABEL_LEN_SIZE
-			     + strlen(inst->instance) +
+	rr->rdlength = htons(sizeof(*rdata) + DNS_LABEL_LEN_SIZE + strlen(inst->instance) +
 			     DNS_POINTER_SIZE);
 	offset += sizeof(*rr);
 
@@ -646,8 +598,7 @@ int add_srv_record(const struct dns_sd_rec *inst, uint32_t ttl,
 }
 
 #ifndef CONFIG_NET_TEST
-static bool port_in_use_sockaddr(uint16_t proto, uint16_t port,
-	const struct sockaddr *addr)
+static bool port_in_use_sockaddr(uint16_t proto, uint16_t port, const struct sockaddr *addr)
 {
 	const struct sockaddr_in any = {
 		.sin_family = AF_INET,
@@ -657,18 +608,15 @@ static bool port_in_use_sockaddr(uint16_t proto, uint16_t port,
 		.sin6_family = AF_INET6,
 		.sin6_addr = in6addr_any,
 	};
-	const struct sockaddr *anyp =
-		(addr->sa_family == AF_INET)
-		? (const struct sockaddr *) &any
-		: (const struct sockaddr *) &any6;
+	const struct sockaddr *anyp = (addr->sa_family == AF_INET) ? (const struct sockaddr *)&any
+								   : (const struct sockaddr *)&any6;
 
-	return
-		net_context_port_in_use(proto, port, addr)
-		|| net_context_port_in_use(proto, port, anyp);
+	return net_context_port_in_use(proto, port, addr) ||
+	       net_context_port_in_use(proto, port, anyp);
 }
 
 static bool port_in_use(uint16_t proto, uint16_t port, const struct in_addr *addr4,
-	const struct in6_addr *addr6)
+			const struct in6_addr *addr6)
 {
 	bool r;
 	struct sockaddr sa;
@@ -695,9 +643,9 @@ static bool port_in_use(uint16_t proto, uint16_t port, const struct in_addr *add
 
 	return false;
 }
-#else /* CONFIG_NET_TEST */
+#else  /* CONFIG_NET_TEST */
 static inline bool port_in_use(uint16_t proto, uint16_t port, const struct in_addr *addr4,
-	const struct in6_addr *addr6)
+			       const struct in6_addr *addr6)
 {
 	ARG_UNUSED(port);
 	ARG_UNUSED(addr4);
@@ -705,7 +653,6 @@ static inline bool port_in_use(uint16_t proto, uint16_t port, const struct in_ad
 	return true;
 }
 #endif /* CONFIG_NET_TEST */
-
 
 int dns_sd_handle_ptr_query(const struct dns_sd_rec *inst, const struct in_addr *addr4,
 			    const struct in6_addr *addr6, uint8_t *buf, uint16_t buf_size)
@@ -741,9 +688,8 @@ int dns_sd_handle_ptr_query(const struct dns_sd_rec *inst, const struct in_addr 
 	}
 
 	if (*(inst->port) == 0) {
-		NET_DBG("Ephemeral port %u for %s.%s.%s.%s not initialized",
-			ntohs(*(inst->port)), inst->instance, inst->service, inst->proto,
-			inst->domain);
+		NET_DBG("Ephemeral port %u for %s.%s.%s.%s not initialized", ntohs(*(inst->port)),
+			inst->instance, inst->service, inst->proto, inst->domain);
 		return -EHOSTDOWN;
 	}
 
@@ -820,11 +766,10 @@ int dns_sd_handle_ptr_query(const struct dns_sd_rec *inst, const struct in_addr 
 	return offset;
 }
 
-int dns_sd_handle_service_type_enum(const struct dns_sd_rec *inst,
-				    const struct in_addr *addr4, const struct in6_addr *addr6,
-				    uint8_t *buf, uint16_t buf_size)
+int dns_sd_handle_service_type_enum(const struct dns_sd_rec *inst, const struct in_addr *addr4,
+				    const struct in6_addr *addr6, uint8_t *buf, uint16_t buf_size)
 {
-	static const char query[] = { "\x09_services\x07_dns-sd\x04_udp\x05local" };
+	static const char query[] = {"\x09_services\x07_dns-sd\x04_udp\x05local"};
 	/* offset of '.local' in the above */
 	uint16_t domain_offset = DNS_SD_PTR_MASK | 35;
 	uint16_t proto;
@@ -863,12 +808,11 @@ int dns_sd_handle_service_type_enum(const struct dns_sd_rec *inst,
 	service_size = strlen(inst->service);
 	name_size =
 		/* uncompressed. e.g. "._foo._tcp.local." */
-		sizeof(query)
-		+ sizeof(*rr)
+		sizeof(query) +
+		sizeof(*rr)
 		/* compressed e.g. ._googlecast._tcp" followed by (DNS_SD_PTR_MASK | 0x0abc) */
-		+ DNS_LABEL_LEN_SIZE + service_size
-		+ DNS_LABEL_LEN_SIZE + DNS_SD_PROTO_SIZE
-		+ DNS_POINTER_SIZE;
+		+ DNS_LABEL_LEN_SIZE + service_size + DNS_LABEL_LEN_SIZE + DNS_SD_PROTO_SIZE +
+		DNS_POINTER_SIZE;
 
 	if (offset > buf_size || name_size >= buf_size - offset) {
 		NET_DBG("Buffer too small. required: %u available: %d", name_size,
@@ -884,10 +828,8 @@ int dns_sd_handle_service_type_enum(const struct dns_sd_rec *inst,
 	rr->type = htons(DNS_RR_TYPE_PTR);
 	rr->class_ = htons(DNS_CLASS_IN);
 	rr->ttl = htonl(DNS_SD_PTR_TTL);
-	rr->rdlength = htons(0
-		+ DNS_LABEL_LEN_SIZE + service_size
-		+ DNS_LABEL_LEN_SIZE + DNS_SD_PROTO_SIZE
-		+ DNS_POINTER_SIZE);
+	rr->rdlength = htons(0 + DNS_LABEL_LEN_SIZE + service_size + DNS_LABEL_LEN_SIZE +
+			     DNS_SD_PROTO_SIZE + DNS_POINTER_SIZE);
 	offset += sizeof(*rr);
 
 	buf[offset++] = service_size;
@@ -910,8 +852,7 @@ int dns_sd_handle_service_type_enum(const struct dns_sd_rec *inst,
 /* TODO: dns_sd_handle_srv_query() */
 /* TODO: dns_sd_handle_txt_query() */
 
-bool dns_sd_rec_match(const struct dns_sd_rec *record,
-		      const struct dns_sd_rec *filter)
+bool dns_sd_rec_match(const struct dns_sd_rec *record, const struct dns_sd_rec *filter)
 {
 	size_t i;
 	const char *rec_label;
@@ -942,10 +883,8 @@ bool dns_sd_rec_match(const struct dns_sd_rec *record,
 
 	/* Deref only after it is deemed safe to do so */
 	const char *const pairs[] = {
-		record->instance, filter->instance,
-		record->service, filter->service,
-		record->proto, filter->proto,
-		record->domain, filter->domain,
+		record->instance, filter->instance, record->service, filter->service,
+		record->proto,    filter->proto,    record->domain,  filter->domain,
 	};
 
 	BUILD_ASSERT(ARRAY_SIZE(pairs) == 2 * ARRAY_SIZE(checkers));
@@ -958,13 +897,11 @@ bool dns_sd_rec_match(const struct dns_sd_rec *record,
 		/* check for the "wildcard" pointer */
 		if (filt_label != NULL) {
 			if (!checkers[i](rec_label)) {
-				LOG_WRN("invalid %s label: '%s'",
-					names[i], rec_label);
+				LOG_WRN("invalid %s label: '%s'", names[i], rec_label);
 				return false;
 			}
 
-			if (strncasecmp(rec_label, filt_label,
-					DNS_LABEL_MAX_SIZE) != 0) {
+			if (strncasecmp(rec_label, filt_label, DNS_LABEL_MAX_SIZE) != 0) {
 				return false;
 			}
 		}
@@ -1065,8 +1002,7 @@ int dns_sd_query_extract(const uint8_t *query, size_t query_size, struct dns_sd_
 	}
 
 	if (qlabels > N) {
-		NET_DBG("too few buffers to extract query: qlabels: %zu, N: %zu",
-			qlabels, N);
+		NET_DBG("too few buffers to extract query: qlabels: %zu, N: %zu", qlabels, N);
 		return -ENOBUFS;
 	}
 
@@ -1147,7 +1083,7 @@ int dns_sd_extract_service_proto_domain(const uint8_t *query, size_t query_size,
 	size_t n = ARRAY_SIZE(label);
 
 	BUILD_ASSERT(ARRAY_SIZE(label) == ARRAY_SIZE(size),
-		"label and size arrays are different size");
+		     "label and size arrays are different size");
 
 	/*
 	 * work around for bug in compliance scripts which say that the array

--- a/subsys/net/lib/dns/dns_sd.h
+++ b/subsys/net/lib/dns/dns_sd.h
@@ -18,10 +18,10 @@
 #include "dns_pack.h"
 
 /* TODO: Move these into Kconfig */
-#define DNS_SD_PTR_TTL 4500
-#define DNS_SD_TXT_TTL 4500
-#define DNS_SD_SRV_TTL 120
-#define DNS_SD_A_TTL 120
+#define DNS_SD_PTR_TTL  4500
+#define DNS_SD_TXT_TTL  4500
+#define DNS_SD_SRV_TTL  120
+#define DNS_SD_A_TTL    120
 #define DNS_SD_AAAA_TTL 120
 
 #define DNS_SD_PTR_MASK (NS_CMPRSFLGS << 8)
@@ -30,8 +30,7 @@
 extern "C" {
 #endif
 
-#define DNS_SD_FOREACH(it) \
-	STRUCT_SECTION_FOREACH(dns_sd_rec, it)
+#define DNS_SD_FOREACH(it) STRUCT_SECTION_FOREACH(dns_sd_rec, it)
 
 /**
  * @brief Extract labels from a DNS-SD PTR query
@@ -87,11 +86,11 @@ int dns_sd_query_extract(const uint8_t *query, size_t query_size, struct dns_sd_
  * @return on success, a positive number representing length of the query
  * @return on failure, a negative errno value
  */
-__deprecated
-int dns_sd_extract_service_proto_domain(const uint8_t *query,
-	size_t query_size, struct dns_sd_rec *record, char *service,
-	size_t service_size, char *proto, size_t proto_size,
-	char *domain, size_t domain_size);
+__deprecated int dns_sd_extract_service_proto_domain(const uint8_t *query, size_t query_size,
+						     struct dns_sd_rec *record, char *service,
+						     size_t service_size, char *proto,
+						     size_t proto_size, char *domain,
+						     size_t domain_size);
 
 /**
  * @brief See if the DNS SD @p filter matches the @p record
@@ -137,8 +136,7 @@ int dns_sd_extract_service_proto_domain(const uint8_t *query,
  * @return false if @p record is not a match for @p filter
  * @return false if either @p record or @p filter are invalid
  */
-bool dns_sd_rec_match(const struct dns_sd_rec *record,
-	const struct dns_sd_rec *filter);
+bool dns_sd_rec_match(const struct dns_sd_rec *record, const struct dns_sd_rec *filter);
 
 /**
  * @brief Handle a DNS PTR Query with DNS Service Discovery
@@ -161,9 +159,8 @@ bool dns_sd_rec_match(const struct dns_sd_rec *record,
  * @return on success, number of bytes written to @p buf
  * @return on failure, a negative errno value
  */
-int dns_sd_handle_ptr_query(const struct dns_sd_rec *inst,
-	const struct in_addr *addr4, const struct in6_addr *addr6,
-	uint8_t *buf, uint16_t buf_size);
+int dns_sd_handle_ptr_query(const struct dns_sd_rec *inst, const struct in_addr *addr4,
+			    const struct in6_addr *addr6, uint8_t *buf, uint16_t buf_size);
 
 /**
  * @brief Handle a Service Type Enumeration with DNS Service Discovery
@@ -179,9 +176,8 @@ int dns_sd_handle_ptr_query(const struct dns_sd_rec *inst,
  * @return on success, number of bytes written to @p buf
  * @return on failure, a negative errno value
  */
-int dns_sd_handle_service_type_enum(const struct dns_sd_rec *service,
-	const struct in_addr *addr4, const struct in6_addr *addr6,
-	uint8_t *buf, uint16_t buf_size);
+int dns_sd_handle_service_type_enum(const struct dns_sd_rec *service, const struct in_addr *addr4,
+				    const struct in6_addr *addr6, uint8_t *buf, uint16_t buf_size);
 
 #ifdef __cplusplus
 };

--- a/subsys/net/lib/dns/llmnr_responder.c
+++ b/subsys/net/lib/dns/llmnr_responder.c
@@ -49,13 +49,11 @@ static struct net_mgmt_event_callback mgmt_cb;
 #define BUF_ALLOC_TIMEOUT K_MSEC(100)
 
 /* This value is recommended by RFC 1035 */
-#define DNS_RESOLVER_MAX_BUF_SIZE	512
-#define DNS_RESOLVER_MIN_BUF		2
-#define DNS_RESOLVER_BUF_CTR	(DNS_RESOLVER_MIN_BUF + \
-				 CONFIG_LLMNR_RESOLVER_ADDITIONAL_BUF_CTR)
+#define DNS_RESOLVER_MAX_BUF_SIZE 512
+#define DNS_RESOLVER_MIN_BUF      2
+#define DNS_RESOLVER_BUF_CTR      (DNS_RESOLVER_MIN_BUF + CONFIG_LLMNR_RESOLVER_ADDITIONAL_BUF_CTR)
 
-NET_BUF_POOL_DEFINE(llmnr_dns_msg_pool, DNS_RESOLVER_BUF_CTR,
-		    DNS_RESOLVER_MAX_BUF_SIZE, 0, NULL);
+NET_BUF_POOL_DEFINE(llmnr_dns_msg_pool, DNS_RESOLVER_BUF_CTR, DNS_RESOLVER_MAX_BUF_SIZE, 0, NULL);
 
 #if defined(CONFIG_NET_IPV6)
 static void create_ipv6_addr(struct sockaddr_in6 *addr)
@@ -64,12 +62,10 @@ static void create_ipv6_addr(struct sockaddr_in6 *addr)
 	addr->sin6_port = htons(LLMNR_LISTEN_PORT);
 
 	/* Well known IPv6 ff02::1:3 address */
-	net_ipv6_addr_create(&addr->sin6_addr,
-			     0xff02, 0, 0, 0, 0, 0, 0x01, 0x03);
+	net_ipv6_addr_create(&addr->sin6_addr, 0xff02, 0, 0, 0, 0, 0, 0x01, 0x03);
 }
 
-static void create_ipv6_dst_addr(struct net_pkt *pkt,
-				 struct sockaddr_in6 *addr)
+static void create_ipv6_dst_addr(struct net_pkt *pkt, struct sockaddr_in6 *addr)
 {
 	struct net_udp_hdr *udp_hdr, hdr;
 
@@ -95,8 +91,7 @@ static void create_ipv4_addr(struct sockaddr_in *addr)
 	addr->sin_addr.s_addr = htonl(0xE00000FC);
 }
 
-static void create_ipv4_dst_addr(struct net_pkt *pkt,
-				 struct sockaddr_in *addr)
+static void create_ipv4_dst_addr(struct net_pkt *pkt, struct sockaddr_in *addr)
 {
 	struct net_udp_hdr *udp_hdr, hdr;
 
@@ -113,16 +108,15 @@ static void create_ipv4_dst_addr(struct net_pkt *pkt,
 }
 #endif
 
-static void llmnr_iface_event_handler(struct net_mgmt_event_callback *cb,
-				      uint32_t mgmt_event, struct net_if *iface)
+static void llmnr_iface_event_handler(struct net_mgmt_event_callback *cb, uint32_t mgmt_event,
+				      struct net_if *iface)
 {
 	if (mgmt_event == NET_EVENT_IF_UP) {
 #if defined(CONFIG_NET_IPV4)
 		int ret = net_ipv4_igmp_join(iface, &local_addr4.sin_addr, NULL);
 
 		if (ret < 0) {
-			NET_DBG("Cannot add IPv4 multicast address to iface %p",
-				iface);
+			NET_DBG("Cannot add IPv4 multicast address to iface %p", iface);
 		}
 #endif /* defined(CONFIG_NET_IPV4) */
 	}
@@ -142,9 +136,7 @@ static struct net_context *get_ctx(sa_family_t family)
 	return ctx;
 }
 
-static int bind_ctx(struct net_context *ctx,
-		    struct sockaddr *local_addr,
-		    socklen_t addrlen)
+static int bind_ctx(struct net_context *ctx, struct sockaddr *local_addr, socklen_t addrlen)
 {
 	int ret;
 
@@ -155,8 +147,7 @@ static int bind_ctx(struct net_context *ctx,
 	ret = net_context_bind(ctx, local_addr, addrlen);
 	if (ret < 0) {
 		NET_DBG("Cannot bind to LLMNR %s port (%d)",
-			local_addr->sa_family == AF_INET ?
-			"IPv4" : "IPv6", ret);
+			local_addr->sa_family == AF_INET ? "IPv4" : "IPv6", ret);
 		return ret;
 	}
 
@@ -170,12 +161,12 @@ static void setup_dns_hdr(uint8_t *buf, uint16_t answers, uint16_t dns_id)
 
 	/* See RFC 1035, ch 4.1.1 and RFC 4795 ch 2.1.1 for header details */
 
-	flags = BIT(15);  /* This is response */
+	flags = BIT(15); /* This is response */
 
 	UNALIGNED_PUT(htons(dns_id), (uint16_t *)(buf));
 	offset = DNS_HEADER_ID_LEN;
 
-	UNALIGNED_PUT(htons(flags), (uint16_t *)(buf+offset));
+	UNALIGNED_PUT(htons(flags), (uint16_t *)(buf + offset));
 	offset += DNS_HEADER_FLAGS_LEN;
 
 	UNALIGNED_PUT(htons(1), (uint16_t *)(buf + offset));
@@ -211,14 +202,13 @@ static void add_question(struct net_buf *query, enum dns_rr_type qtype)
 	}
 
 	offset = DNS_MSG_HEADER_SIZE + query->len + 1;
-	UNALIGNED_PUT(htons(qtype), (uint16_t *)(query->data+offset));
+	UNALIGNED_PUT(htons(qtype), (uint16_t *)(query->data + offset));
 
 	offset += DNS_QTYPE_LEN;
-	UNALIGNED_PUT(htons(DNS_CLASS_IN), (uint16_t *)(query->data+offset));
+	UNALIGNED_PUT(htons(DNS_CLASS_IN), (uint16_t *)(query->data + offset));
 }
 
-static int add_answer(struct net_buf *query, uint32_t ttl,
-		       uint16_t addr_len, const uint8_t *addr)
+static int add_answer(struct net_buf *query, uint32_t ttl, uint16_t addr_len, const uint8_t *addr)
 {
 	const uint16_t q_len = query->len + 1 + DNS_QTYPE_LEN + DNS_QCLASS_LEN;
 	uint16_t offset = DNS_MSG_HEADER_SIZE + q_len;
@@ -237,19 +227,15 @@ static int add_answer(struct net_buf *query, uint32_t ttl,
 	return offset + addr_len;
 }
 
-static int create_answer(struct net_context *ctx,
-			 enum dns_rr_type qtype,
-			 struct net_buf *query,
-			 uint16_t dns_id,
-			 uint16_t addr_len, const uint8_t *addr)
+static int create_answer(struct net_context *ctx, enum dns_rr_type qtype, struct net_buf *query,
+			 uint16_t dns_id, uint16_t addr_len, const uint8_t *addr)
 {
 	/* Prepare the response into the query buffer: move the name
 	 * query buffer has to get enough free space: dns_hdr + query + answer
 	 */
-	if ((query->size - query->len) < (DNS_MSG_HEADER_SIZE +
-					  (DNS_QTYPE_LEN + DNS_QCLASS_LEN) * 2 +
-					  DNS_TTL_LEN + DNS_RDLENGTH_LEN +
-					  addr_len + query->len)) {
+	if ((query->size - query->len) <
+	    (DNS_MSG_HEADER_SIZE + (DNS_QTYPE_LEN + DNS_QCLASS_LEN) * 2 + DNS_TTL_LEN +
+	     DNS_RDLENGTH_LEN + addr_len + query->len)) {
 		return -ENOBUFS;
 	}
 
@@ -293,13 +279,9 @@ static const uint8_t *get_ipv6_src(struct net_if *iface, struct in6_addr *dst)
 #endif
 
 #if defined(CONFIG_NET_IPV4)
-static int create_ipv4_answer(struct net_context *ctx,
-			      struct net_pkt *pkt,
-			      union net_ip_header *ip_hdr,
-			      enum dns_rr_type qtype,
-			      struct net_buf *query,
-			      uint16_t dns_id,
-			      struct sockaddr *dst,
+static int create_ipv4_answer(struct net_context *ctx, struct net_pkt *pkt,
+			      union net_ip_header *ip_hdr, enum dns_rr_type qtype,
+			      struct net_buf *query, uint16_t dns_id, struct sockaddr *dst,
 			      socklen_t *dst_len)
 {
 	const uint8_t *addr;
@@ -310,8 +292,7 @@ static int create_ipv4_answer(struct net_context *ctx,
 
 	if (qtype == DNS_RR_TYPE_A) {
 		/* Select proper address according to destination */
-		addr = get_ipv4_src(net_pkt_iface(pkt),
-				    &net_sin(dst)->sin_addr);
+		addr = get_ipv4_src(net_pkt_iface(pkt), &net_sin(dst)->sin_addr);
 		if (!addr) {
 			return -ENOENT;
 		}
@@ -320,8 +301,7 @@ static int create_ipv4_answer(struct net_context *ctx,
 
 	} else if (qtype == DNS_RR_TYPE_AAAA) {
 #if defined(CONFIG_NET_IPV6)
-		addr = get_ipv6_src(net_pkt_iface(pkt),
-				    (struct in6_addr *)ip_hdr->ipv6->src);
+		addr = get_ipv6_src(net_pkt_iface(pkt), (struct in6_addr *)ip_hdr->ipv6->src);
 		if (!addr) {
 			return -ENOENT;
 		}
@@ -345,13 +325,9 @@ static int create_ipv4_answer(struct net_context *ctx,
 }
 #endif /* CONFIG_NET_IPV4 */
 
-static int create_ipv6_answer(struct net_context *ctx,
-			      struct net_pkt *pkt,
-			      union net_ip_header *ip_hdr,
-			      enum dns_rr_type qtype,
-			      struct net_buf *query,
-			      uint16_t dns_id,
-			      struct sockaddr *dst,
+static int create_ipv6_answer(struct net_context *ctx, struct net_pkt *pkt,
+			      union net_ip_header *ip_hdr, enum dns_rr_type qtype,
+			      struct net_buf *query, uint16_t dns_id, struct sockaddr *dst,
 			      socklen_t *dst_len)
 {
 #if defined(CONFIG_NET_IPV6)
@@ -362,8 +338,7 @@ static int create_ipv6_answer(struct net_context *ctx,
 	*dst_len = sizeof(struct sockaddr_in6);
 
 	if (qtype == DNS_RR_TYPE_AAAA) {
-		addr = get_ipv6_src(net_pkt_iface(pkt),
-				    (struct in6_addr *)ip_hdr->ipv6->src);
+		addr = get_ipv6_src(net_pkt_iface(pkt), (struct in6_addr *)ip_hdr->ipv6->src);
 		if (!addr) {
 			return -ENOENT;
 		}
@@ -371,8 +346,7 @@ static int create_ipv6_answer(struct net_context *ctx,
 		addr_len = sizeof(struct in6_addr);
 	} else if (qtype == DNS_RR_TYPE_A) {
 #if defined(CONFIG_NET_IPV4)
-		addr = get_ipv4_src(net_pkt_iface(pkt),
-				    (struct in_addr *)ip_hdr->ipv4->src);
+		addr = get_ipv4_src(net_pkt_iface(pkt), (struct in_addr *)ip_hdr->ipv4->src);
 		if (!addr) {
 			return -ENOENT;
 		}
@@ -395,25 +369,20 @@ static int create_ipv6_answer(struct net_context *ctx,
 	return 0;
 }
 
-static int send_response(struct net_context *ctx, struct net_pkt *pkt,
-			 union net_ip_header *ip_hdr, struct net_buf *reply,
-			 enum dns_rr_type qtype, uint16_t dns_id)
+static int send_response(struct net_context *ctx, struct net_pkt *pkt, union net_ip_header *ip_hdr,
+			 struct net_buf *reply, enum dns_rr_type qtype, uint16_t dns_id)
 {
 	struct sockaddr dst;
 	socklen_t dst_len;
 	int ret;
 
-	if (IS_ENABLED(CONFIG_NET_IPV4) &&
-	    net_pkt_family(pkt) == AF_INET) {
-		ret = create_ipv4_answer(ctx, pkt, ip_hdr, qtype, reply,
-					 dns_id, &dst, &dst_len);
+	if (IS_ENABLED(CONFIG_NET_IPV4) && net_pkt_family(pkt) == AF_INET) {
+		ret = create_ipv4_answer(ctx, pkt, ip_hdr, qtype, reply, dns_id, &dst, &dst_len);
 		if (ret < 0) {
 			return ret;
 		}
-	} else if (IS_ENABLED(CONFIG_NET_IPV6) &&
-		   net_pkt_family(pkt) == AF_INET6) {
-		ret = create_ipv6_answer(ctx, pkt, ip_hdr, qtype, reply,
-					 dns_id, &dst, &dst_len);
+	} else if (IS_ENABLED(CONFIG_NET_IPV6) && net_pkt_family(pkt) == AF_INET6) {
+		ret = create_ipv6_answer(ctx, pkt, ip_hdr, qtype, reply, dns_id, &dst, &dst_len);
 		if (ret < 0) {
 			return ret;
 		}
@@ -422,24 +391,21 @@ static int send_response(struct net_context *ctx, struct net_pkt *pkt,
 		return -EPFNOSUPPORT;
 	}
 
-	ret = net_context_sendto(ctx, reply->data, reply->len, &dst,
-				 dst_len, NULL, K_NO_WAIT, NULL);
+	ret = net_context_sendto(ctx, reply->data, reply->len, &dst, dst_len, NULL, K_NO_WAIT,
+				 NULL);
 	if (ret < 0) {
 		NET_DBG("Cannot send LLMNR reply to %s (%d)",
-			net_pkt_family(pkt) == AF_INET ?
-			net_sprint_ipv4_addr(&net_sin(&dst)->sin_addr) :
-			net_sprint_ipv6_addr(&net_sin6(&dst)->sin6_addr),
+			net_pkt_family(pkt) == AF_INET
+				? net_sprint_ipv4_addr(&net_sin(&dst)->sin_addr)
+				: net_sprint_ipv6_addr(&net_sin6(&dst)->sin6_addr),
 			ret);
 	}
 
 	return ret;
 }
 
-static int dns_read(struct net_context *ctx,
-		    struct net_pkt *pkt,
-		    union net_ip_header *ip_hdr,
-		    struct net_buf *dns_data,
-		    struct dns_addrinfo *info)
+static int dns_read(struct net_context *ctx, struct net_pkt *pkt, union net_ip_header *ip_hdr,
+		    struct net_buf *dns_data, struct dns_addrinfo *info)
 {
 	/* Helper struct to track the dns msg received from the server */
 	const char *hostname = net_hostname_get();
@@ -480,11 +446,9 @@ static int dns_read(struct net_context *ctx,
 
 	queries = ret;
 
-	NET_DBG("Received %d %s from %s (id 0x%04x)", queries,
-		queries > 1 ? "queries" : "query",
-		net_pkt_family(pkt) == AF_INET ?
-		net_sprint_ipv4_addr(&ip_hdr->ipv4->src) :
-		net_sprint_ipv6_addr(&ip_hdr->ipv6->src),
+	NET_DBG("Received %d %s from %s (id 0x%04x)", queries, queries > 1 ? "queries" : "query",
+		net_pkt_family(pkt) == AF_INET ? net_sprint_ipv4_addr(&ip_hdr->ipv4->src)
+					       : net_sprint_ipv6_addr(&ip_hdr->ipv6->src),
 		dns_id);
 
 	do {
@@ -500,16 +464,13 @@ static int dns_read(struct net_context *ctx,
 		}
 
 		NET_DBG("[%d] query %s/%s label %s (%d bytes)", queries,
-			qtype == DNS_RR_TYPE_A ? "A" : "AAAA", "IN",
-			result->data, ret);
+			qtype == DNS_RR_TYPE_A ? "A" : "AAAA", "IN", result->data, ret);
 
 		/* If the query matches to our hostname, then send reply */
 		if (!strncasecmp(hostname, result->data + 1, hostname_len) &&
 		    (result->len - 1) >= hostname_len) {
-			NET_DBG("LLMNR query to our hostname %s",
-				hostname);
-			ret = send_response(ctx, pkt, ip_hdr, result, qtype,
-					    dns_id);
+			NET_DBG("LLMNR query to our hostname %s", hostname);
+			ret = send_response(ctx, pkt, ip_hdr, result, qtype, dns_id);
 			if (ret < 0) {
 				NET_DBG("Cannot send response (%d)", ret);
 			}
@@ -526,16 +487,12 @@ quit:
 	return ret;
 }
 
-static void recv_cb(struct net_context *net_ctx,
-		    struct net_pkt *pkt,
-		    union net_ip_header *ip_hdr,
-		    union net_proto_header *proto_hdr,
-		    int status,
-		    void *user_data)
+static void recv_cb(struct net_context *net_ctx, struct net_pkt *pkt, union net_ip_header *ip_hdr,
+		    union net_proto_header *proto_hdr, int status, void *user_data)
 {
 	struct net_context *ctx = user_data;
 	struct net_buf *dns_data = NULL;
-	struct dns_addrinfo info = { 0 };
+	struct dns_addrinfo info = {0};
 	int ret;
 
 	ARG_UNUSED(net_ctx);
@@ -573,8 +530,8 @@ static void iface_ipv6_cb(struct net_if *iface, void *user_data)
 
 	ret = net_ipv6_mld_join(iface, addr);
 	if (ret < 0) {
-		NET_DBG("Cannot join %s IPv6 multicast group (%d)",
-			net_sprint_ipv6_addr(addr), ret);
+		NET_DBG("Cannot join %s IPv6 multicast group (%d)", net_sprint_ipv6_addr(addr),
+			ret);
 	}
 }
 
@@ -594,8 +551,7 @@ static void iface_ipv4_cb(struct net_if *iface, void *user_data)
 
 	ret = net_ipv4_igmp_join(iface, addr, NULL);
 	if (ret < 0) {
-		NET_DBG("Cannot add IPv4 multicast address to iface %p",
-			iface);
+		NET_DBG("Cannot add IPv4 multicast address to iface %p", iface);
 	}
 }
 
@@ -619,8 +575,7 @@ static int init_listener(void)
 
 		ipv6 = get_ctx(AF_INET6);
 
-		ret = bind_ctx(ipv6, (struct sockaddr *)&local_addr,
-			       sizeof(local_addr));
+		ret = bind_ctx(ipv6, (struct sockaddr *)&local_addr, sizeof(local_addr));
 		if (ret < 0) {
 			net_context_put(ipv6);
 			goto ipv6_out;
@@ -638,26 +593,25 @@ ipv6_out:
 #endif /* CONFIG_NET_IPV6 */
 
 #if defined(CONFIG_NET_IPV4)
-	{
-		setup_ipv4_addr(&local_addr4);
+{
+	setup_ipv4_addr(&local_addr4);
 
-		ipv4 = get_ctx(AF_INET);
+	ipv4 = get_ctx(AF_INET);
 
-		ret = bind_ctx(ipv4, (struct sockaddr *)&local_addr4,
-			       sizeof(local_addr4));
-		if (ret < 0) {
-			net_context_put(ipv4);
-			goto ipv4_out;
-		}
-
-		ret = net_context_recv(ipv4, recv_cb, K_NO_WAIT, ipv4);
-		if (ret < 0) {
-			NET_WARN("Cannot receive IPv4 LLMNR data (%d)", ret);
-			net_context_put(ipv4);
-		} else {
-			ok++;
-		}
+	ret = bind_ctx(ipv4, (struct sockaddr *)&local_addr4, sizeof(local_addr4));
+	if (ret < 0) {
+		net_context_put(ipv4);
+		goto ipv4_out;
 	}
+
+	ret = net_context_recv(ipv4, recv_cb, K_NO_WAIT, ipv4);
+	if (ret < 0) {
+		NET_WARN("Cannot receive IPv4 LLMNR data (%d)", ret);
+		net_context_put(ipv4);
+	} else {
+		ok++;
+	}
+}
 ipv4_out:
 #endif /* CONFIG_NET_IPV4 */
 
@@ -671,8 +625,7 @@ ipv4_out:
 static int llmnr_responder_init(void)
 {
 
-	net_mgmt_init_event_callback(&mgmt_cb, llmnr_iface_event_handler,
-				     NET_EVENT_IF_UP);
+	net_mgmt_init_event_callback(&mgmt_cb, llmnr_iface_event_handler, NET_EVENT_IF_UP);
 
 	net_mgmt_add_event_callback(&mgmt_cb);
 


### PR DESCRIPTION
- Format using clang-format with zephyr config
- I was working on this subsys and did not want to pollute the PRs with formatting changes
- Fix `.clang-format` to not indent goto labels. Gives CI error.