### PR TITLE
soc/riscv/opentitan: Kconfig.defconfig.series:  Set NUM_IRQS to 256

### DIFF
--- a/soc/riscv/opentitan/Kconfig.defconfig
+++ b/soc/riscv/opentitan/Kconfig.defconfig
@@ -25,6 +25,6 @@ config 2ND_LVL_INTR_00_OFFSET
 	default 11
 
 config NUM_IRQS
-	default 217
+	default 256
 
 endif # SOC_OPENTITAN


### PR DESCRIPTION
The OpenTitan PLIC has support for up to 255 interrupt vectors, so set it to that. Previously was set to number of IRQs used.