### PR TITLE
Some Xtensa cores do not support NMI

### DIFF
--- a/arch/xtensa/core/xtensa-asm2-util.S
+++ b/arch/xtensa/core/xtensa-asm2-util.S
@@ -298,27 +298,40 @@ _handle_excint:
 
 DEF_EXCINT 1, _handle_excint, xtensa_excint1_c
 
-#if XCHAL_NMILEVEL >= 2
+/* In code below we are using XCHAL_NMILEVEL and XCHAL_NUM_INTLEVELS
+ * (whichever is higher), since not all Xtensa configurations support
+ * NMI. In such case we will use XCHAL_NUM_INTLEVELS.
+ */
+#if XCHAL_HAVE_NMI
+#define MAX_INTR_LEVEL XCHAL_NMILEVEL
+#elif XCHAL_HAVE_INTERRUPTS
+#define MAX_INTR_LEVEL XCHAL_NUM_INTLEVELS
+#else
+#error Xtensa core with no interrupt support is used
+#define MAX_INTR_LEVEL 0
+#endif
+
+#if MAX_INTR_LEVEL >= 2
 DEF_EXCINT 2, _handle_excint, xtensa_int2_c
 #endif
 
-#if XCHAL_NMILEVEL >= 3
+#if MAX_INTR_LEVEL >= 3
 DEF_EXCINT 3, _handle_excint, xtensa_int3_c
 #endif
 
-#if XCHAL_NMILEVEL >= 4
+#if MAX_INTR_LEVEL >= 4
 DEF_EXCINT 4, _handle_excint, xtensa_int4_c
 #endif
 
-#if XCHAL_NMILEVEL >= 5
+#if MAX_INTR_LEVEL >= 5
 DEF_EXCINT 5, _handle_excint, xtensa_int5_c
 #endif
 
-#if XCHAL_NMILEVEL >= 6
+#if MAX_INTR_LEVEL >= 6
 DEF_EXCINT 6, _handle_excint, xtensa_int6_c
 #endif
 
-#if XCHAL_NMILEVEL >= 7
+#if MAX_INTR_LEVEL >= 7
 DEF_EXCINT 7, _handle_excint, xtensa_int7_c
 #endif
 

--- a/arch/xtensa/include/xtensa-asm2-s.h
+++ b/arch/xtensa/include/xtensa-asm2-s.h
@@ -306,7 +306,7 @@ _do_call_\@:
 	 * execution) while we muck with the windows and decrement the nested
 	 * count.  The restore will unmask them correctly.
 	 */
-	rsil a0, XCHAL_NMILEVEL
+	rsil a0, XCHAL_NUM_INTLEVELS
 
 	/* Decrement nest count */
 	rsr.\SR a3


### PR DESCRIPTION
Some Xtensa cores do not support NMI, so XCHAL_HAVE_NMI=0 and XCHAL_NMILEVEL won't be defined at all causing `arch/xtensa/include/xtensa-asm2-s.h` to throw compilation error.

Fixes: #67855