### PR TITLE
tests: latency_measure: Remove TICK_SYNCH()

### DIFF
--- a/tests/benchmarks/latency_measure/src/int_to_thread.c
+++ b/tests/benchmarks/latency_measure/src/int_to_thread.c
@@ -168,7 +168,6 @@ int int_to_thread(uint32_t num_iterations)
 	uint64_t sum;
 
 	timing_start();
-	TICK_SYNCH();
 
 	int_to_interrupted_thread(num_iterations, &sum);
 


### PR DESCRIPTION
It has been observed that on some simulator platforms the TICK_SYNCH at the start of the ISR tests was acting as a bottle neck and leading the test to take an absurdly long time to execute. Removing this TICK_SYNCH() (which is a call to k_sleep(1 tick)) greatly speeds up the execution of this test on those platforms.

The ISR tests began with a call to TICK_SYNCH() which aligned the execution to the next tick boundary. The original aim of this was to prevent a rogue timer ISR from coming and interfering with the measurements. This used to be necessary as once upon a time that test only did a single iteration. However, it has since been updated to perform this measurement 10000 times. Consequently, should a rogue ISR be included in the measurement, it will be averaged out.

For example, if a rogue ISR of say 10 usec were to be included in a single measurement, its impact would be averaged down to 1 nsec, and that seems well within any expected experimental error.