### PR TITLE
Bluetooth: Host: bt_gatt_cb.att_mtu_updated only called when MTU exchange completes

### DIFF
--- a/doc/releases/migration-guide-3.6.rst
+++ b/doc/releases/migration-guide-3.6.rst
@@ -289,6 +289,9 @@ Bluetooth
 * The :c:func:`bt_l2cap_chan_send` API now requires the application to reserve
   enough bytes for the L2CAP headers. Call ``net_buf_reserve(buf,
   BT_L2CAP_SDU_CHAN_SEND_RESERVE);`` at buffer allocation time to do so.
+* The handler `att_mtu_updated` registered over the :c:func:`bt_gatt_cb_register`
+  API is no longer triggered upon connection establishment. It is now only
+  called when the MTU exchange has taken place.
 
 * Mesh
 

--- a/samples/bluetooth/mtu_update/peripheral/src/peripheral_mtu_update.c
+++ b/samples/bluetooth/mtu_update/peripheral/src/peripheral_mtu_update.c
@@ -39,9 +39,9 @@ BT_GATT_SERVICE_DEFINE(mtu_test, BT_GATT_PRIMARY_SERVICE(&mtu_test_service),
 					      BT_GATT_PERM_NONE, NULL, NULL, NULL),
 		       BT_GATT_CCC(ccc_cfg_changed, BT_GATT_PERM_READ | BT_GATT_PERM_WRITE));
 
-void mtu_updated(struct bt_conn *conn, uint16_t tx, uint16_t rx)
+static void mtu_updated(struct bt_conn *conn, uint16_t tx, uint16_t rx)
 {
-	printk("Updated MTU: TX: %d RX: %d bytes\n", tx, rx);
+	printk("Updated MTU: TX: %u RX: %u bytes\n", tx, rx);
 }
 
 static struct bt_gatt_cb gatt_callbacks = {.att_mtu_updated = mtu_updated};

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -3087,7 +3087,10 @@ static void bt_att_connected(struct bt_l2cap_chan *chan)
 
 	atomic_set_bit(att_chan->flags, ATT_CONNECTED);
 
-	att_chan_mtu_updated(att_chan);
+	/** On EATT L2CAP channels the rx/tx MTU is exchanged as part of the ATT connection */
+	if (bt_att_is_enhanced(att_chan)) {
+		att_chan_mtu_updated(att_chan);
+	}
 
 	k_work_init_delayable(&att_chan->timeout_work, att_timeout);
 


### PR DESCRIPTION
This PR attempts to address #64172, by issuing the following changes:
1. `bt_gatt_cb.att_mtu_updated` is only called when the MTU exchange is completed (only once per connection).
2. Modified `tests/bsim/bluetooth/host/att/mtu_update` to directly verify MTU exchange takes place both on Central and Peripheral.
3. Updated Migration Guide document to reflect the behavior change of `att_mu_updated` as it was previously also triggered upon connection establishment (before MTU exchange).

NOTE: `att_mtu_updated` is not triggered if an MTU exchange results in an `ATT_ERROR_RSP` (e.g: Not supported). There's a comment on the issue whether that should also result in calling `att_mtu_updated`.


**Status on PR Actionable Items:**
- [ ] Modify triggering of `att_mtu_updated` callback.
    - [ ] For (U)ATT Bearers
        - [x]  Do not trigger on ATT connection.
        - [x] Trigger after successful MTU Exchange.
        - [ ] Trigger after a Failed MTU Exchange.
    - [x] For EATT Bearers
        - [x] May trigger on ATT connection, with updated MTU. 
        - [x] May trigger on Channel Reconfiguration.
- [ ] Capture test-cases to lock-in MTU update behavior.
    - [ ] For (U)ATT Bearers
        - [x] On Successfull MTU Exchange.
        - [ ] On Failed MTU exchange.
    - [ ] For EATT Bearers
        - [ ] On MTU-update from ATT connection.
        - [x] On MTU-update from ATT channel reconfiguration.