### PR TITLE
Some Xtensa cores do not support NMI

### DIFF
--- a/arch/xtensa/core/userspace.S
+++ b/arch/xtensa/core/userspace.S
@@ -38,7 +38,13 @@ xtensa_do_syscall:
 	rsr.epc1 a2
 	s32i a2, a0, ___xtensa_irq_bsa_t_pc_OFFSET
 
+#if XCHAL_HAVE_NMI
 	movi a2, PS_WOE|PS_INTLEVEL(XCHAL_NMILEVEL)
+#elif XCHAL_HAVE_INTERRUPTS
+	movi a2, PS_WOE|PS_INTLEVEL(XCHAL_NUM_INTLEVELS)
+#else
+#error Xtensa core with no interrupt support is used
+#endif
 	rsr.ps a3
 	or a3, a3, a2
 	movi a2, ~(PS_EXCM | PS_RING_MASK)

--- a/arch/xtensa/core/vector_handlers.c
+++ b/arch/xtensa/core/vector_handlers.c
@@ -173,27 +173,36 @@ __unused void *xtensa_int##l##_c(void *interrupted_stack)	\
 	return return_to(interrupted_stack);		\
 }
 
-#if XCHAL_NMILEVEL >= 2
+#if XCHAL_HAVE_NMI
+#define MAX_INTR_LEVEL XCHAL_NMILEVEL
+#elif XCHAL_HAVE_INTERRUPTS
+#define MAX_INTR_LEVEL XCHAL_NUM_INTLEVELS
+#else
+#error Xtensa core with no interrupt support is used
+#define MAX_INTR_LEVEL 0
+#endif
+
+#if MAX_INTR_LEVEL >= 2
 DEF_INT_C_HANDLER(2)
 #endif
 
-#if XCHAL_NMILEVEL >= 3
+#if MAX_INTR_LEVEL >= 3
 DEF_INT_C_HANDLER(3)
 #endif
 
-#if XCHAL_NMILEVEL >= 4
+#if MAX_INTR_LEVEL >= 4
 DEF_INT_C_HANDLER(4)
 #endif
 
-#if XCHAL_NMILEVEL >= 5
+#if MAX_INTR_LEVEL >= 5
 DEF_INT_C_HANDLER(5)
 #endif
 
-#if XCHAL_NMILEVEL >= 6
+#if MAX_INTR_LEVEL >= 6
 DEF_INT_C_HANDLER(6)
 #endif
 
-#if XCHAL_NMILEVEL >= 7
+#if MAX_INTR_LEVEL >= 7
 DEF_INT_C_HANDLER(7)
 #endif
 

--- a/arch/xtensa/core/xtensa_asm2_util.S
+++ b/arch/xtensa/core/xtensa_asm2_util.S
@@ -312,37 +312,50 @@ _handle_excint:
 
 DEF_EXCINT 1, _handle_excint, xtensa_excint1_c
 
-#if XCHAL_NMILEVEL >= 2
+/* In code below we are using XCHAL_NMILEVEL and XCHAL_NUM_INTLEVELS
+ * (whichever is higher), since not all Xtensa configurations support
+ * NMI. In such case we will use XCHAL_NUM_INTLEVELS.
+ */
+#if XCHAL_HAVE_NMI
+#define MAX_INTR_LEVEL XCHAL_NMILEVEL
+#elif XCHAL_HAVE_INTERRUPTS
+#define MAX_INTR_LEVEL XCHAL_NUM_INTLEVELS
+#else
+#error Xtensa core with no interrupt support is used
+#define MAX_INTR_LEVEL 0
+#endif
+
+#if MAX_INTR_LEVEL >= 2
 #if !(defined(CONFIG_GDBSTUB) && (XCHAL_DEBUGLEVEL == 2))
 DEF_EXCINT 2, _handle_excint, xtensa_int2_c
 #endif
 #endif
 
-#if XCHAL_NMILEVEL >= 3
+#if MAX_INTR_LEVEL >= 3
 #if !(defined(CONFIG_GDBSTUB) && (XCHAL_DEBUGLEVEL == 3))
 DEF_EXCINT 3, _handle_excint, xtensa_int3_c
 #endif
 #endif
 
-#if XCHAL_NMILEVEL >= 4
+#if MAX_INTR_LEVEL >= 4
 #if !(defined(CONFIG_GDBSTUB) && (XCHAL_DEBUGLEVEL == 4))
 DEF_EXCINT 4, _handle_excint, xtensa_int4_c
 #endif
 #endif
 
-#if XCHAL_NMILEVEL >= 5
+#if MAX_INTR_LEVEL >= 5
 #if !(defined(CONFIG_GDBSTUB) && (XCHAL_DEBUGLEVEL == 5))
 DEF_EXCINT 5, _handle_excint, xtensa_int5_c
 #endif
 #endif
 
-#if XCHAL_NMILEVEL >= 6
+#if MAX_INTR_LEVEL >= 6
 #if !(defined(CONFIG_GDBSTUB) && (XCHAL_DEBUGLEVEL == 6))
 DEF_EXCINT 6, _handle_excint, xtensa_int6_c
 #endif
 #endif
 
-#if XCHAL_NMILEVEL >= 7
+#if MAX_INTR_LEVEL >= 7
 #if !(defined(CONFIG_GDBSTUB) && (XCHAL_DEBUGLEVEL == 7))
 DEF_EXCINT 7, _handle_excint, xtensa_int7_c
 #endif

--- a/arch/xtensa/include/xtensa_asm2_s.h
+++ b/arch/xtensa/include/xtensa_asm2_s.h
@@ -490,7 +490,7 @@ _do_call_\@:
 	 * execution) while we muck with the windows and decrement the nested
 	 * count.  The restore will unmask them correctly.
 	 */
-	rsil a0, XCHAL_NMILEVEL
+	rsil a0, XCHAL_NUM_INTLEVELS
 
 	/* Decrement nest count */
 	rsr.ZSR_CPU a3


### PR DESCRIPTION
Some Xtensa cores do not support NMI, so XCHAL_HAVE_NMI=0 and XCHAL_NMILEVEL won't be defined at all causing arch/xtensa/include/xtensa-asm2-s.h` to throw compilation error.

Fixes: #67855