### PR TITLE
ci: compliance: undef CONFIG_ACE_VERSION_1_5

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -612,6 +612,7 @@ flagged.
     # Many of these are symbols used as examples. Note that the list is sorted
     # alphabetically, and skips the CONFIG_ prefix.
     UNDEF_KCONFIG_WHITELIST = {
+        "ACE_VERSION_1_5", # Optional module
         "ALSO_MISSING",
         "APP_LINK_WITH_",
         "APP_LOG_LEVEL", # Application log level is not detected correctly as


### PR DESCRIPTION
This is used by an optional module, undef so that the script can be run with the default modules and succeed.