### PR TITLE
boards: qemu_cortex_m0: minor cleanups

### DIFF
--- a/boards/arm/bbc_microbit/Kconfig.defconfig
+++ b/boards/arm/bbc_microbit/Kconfig.defconfig
@@ -11,9 +11,6 @@ config BOARD
 config BT_CTLR
 	default BT
 
-config LOG_BUFFER_SIZE
-	default 128 if LOG
-
 if FXOS8700
 
 choice FXOS8700_MODE

--- a/boards/arm/qemu_cortex_m0/Kconfig.defconfig
+++ b/boards/arm/qemu_cortex_m0/Kconfig.defconfig
@@ -17,7 +17,4 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config SYS_CLOCK_TICKS_PER_SEC
 	default 100
 
-config LOG_BUFFER_SIZE
-	default 128 if LOG
-
 endif # BOARD_QEMU_CORTEX_M0

--- a/drivers/flash/soc_flash_nrf.c
+++ b/drivers/flash/soc_flash_nrf.c
@@ -59,7 +59,11 @@ static const struct flash_parameters flash_nrf_parameters = {
 #else
 	.write_block_size = 4,
 #endif
+#ifdef CONFIG_QEMU_TARGET
+	.erase_value = 0x00,
+#else
 	.erase_value = 0xff,
+#endif
 };
 
 #if defined(CONFIG_MULTITHREADING)


### PR DESCRIPTION
Don't set arbitrary low values for `LOG_BUFFER_SIZE` in boards.
Correct the `.erase_value` parameter for nRF SoC flash when running in emulation.