### PR TITLE
drivers: sensor: adxl375 accelerometer driver support

### DIFF
--- a/drivers/sensor/adi/CMakeLists.txt
+++ b/drivers/sensor/adi/CMakeLists.txt
@@ -9,4 +9,5 @@ add_subdirectory_ifdef(CONFIG_ADXL345 adxl345)
 add_subdirectory_ifdef(CONFIG_ADXL362 adxl362)
 add_subdirectory_ifdef(CONFIG_ADXL367 adxl367)
 add_subdirectory_ifdef(CONFIG_ADXL372 adxl372)
+add_subdirectory_ifdef(CONFIG_ADXL375 adxl375)
 # zephyr-keep-sorted-stop

--- a/drivers/sensor/adi/Kconfig
+++ b/drivers/sensor/adi/Kconfig
@@ -9,4 +9,5 @@ source "drivers/sensor/adi/adxl345/Kconfig"
 source "drivers/sensor/adi/adxl362/Kconfig"
 source "drivers/sensor/adi/adxl367/Kconfig"
 source "drivers/sensor/adi/adxl372/Kconfig"
+source "drivers/sensor/adi/adxl375/Kconfig"
 # zephyr-keep-sorted-stop

--- a/drivers/sensor/adi/adxl375/CMakeLists.txt
+++ b/drivers/sensor/adi/adxl375/CMakeLists.txt
@@ -1,0 +1,10 @@
+#
+#  Copyright (c) 2024 Aaron Chan
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+zephyr_library()
+
+zephyr_library_sources(adxl375.c)
+zephyr_library_sources(adxl375_spi.c)
+zephyr_library_sources(adxl375_i2c.c)

--- a/drivers/sensor/adi/adxl375/Kconfig
+++ b/drivers/sensor/adi/adxl375/Kconfig
@@ -1,0 +1,13 @@
+# Low power, 3-Axis, +/-200g Digital Accelerometer
+
+# Copyright (c) 2023 Aaron Chan
+# SPDX-License-Identifier: Apache-2.0
+
+config ADXL375
+	bool "ADXL375 Three Axis High-g I2C/SPI accelerometer"
+	default y
+	depends on DT_HAS_ADI_ADXL375_ENABLED
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ADI_ADXL375),i2c)
+	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ADI_ADXL375),spi)
+	help
+	  Enable driver for ADXL375 Three-Axis Digital Accelerometers.

--- a/drivers/sensor/adi/adxl375/adxl375.c
+++ b/drivers/sensor/adi/adxl375/adxl375.c
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2023 Aaron Chan
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT adi_adxl375
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/init.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/kernel.h>
+#include "zephyr/sys/byteorder.h"
+#include <zephyr/sys/__assert.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "adxl375.h"
+
+LOG_MODULE_REGISTER(ADXL375, CONFIG_SENSOR_LOG_LEVEL);
+
+static int adxl375_check_id(const struct device *dev)
+{
+	struct adxl375_data *data = dev->data;
+	uint8_t device_id = 0;
+
+	int ret = data->hw_tf->read_reg(dev, ADXL375_DEVID, &device_id);
+
+	if (ret != 0) {
+		return ret;
+	}
+
+	if (ADXL375_DEVID_VAL != device_id) {
+		return -ENODEV;
+	}
+
+	return 0;
+}
+
+static int adxl375_set_odr_and_lp(const struct device *dev, uint32_t data_rate,
+				  const bool low_power)
+{
+	struct adxl375_data *data = dev->data;
+
+	if (low_power) {
+		data_rate |= 0x8;
+	}
+
+	return data->hw_tf->write_reg(dev, ADXL375_BW_RATE, data_rate);
+}
+
+static int adxl375_set_op_mode(const struct device *dev, enum adxl375_op_mode op_mode)
+{
+	struct adxl375_data *data = dev->data;
+
+	return data->hw_tf->write_reg(dev, ADXL375_POWER_CTL, op_mode);
+}
+
+static int adxl375_set_data_format(const struct device *dev, uint8_t val)
+{
+	struct adxl375_data *data = dev->data;
+
+	return data->hw_tf->write_reg(dev, ADXL375_DATA_FORMAT, val);
+}
+
+static int adxl375_init(const struct device *dev)
+{
+	int ret;
+	const struct adxl375_dev_config *cfg = dev->config;
+
+	ret = cfg->bus_init(dev);
+	if (ret < 0) {
+		LOG_ERR("Failed to initialize sensor bus.");
+		return ret;
+	}
+
+	ret = adxl375_check_id(dev);
+	if (ret < 0) {
+		LOG_ERR("Failed to get valid device ID.");
+		return ret;
+	}
+
+	ret = adxl375_set_odr_and_lp(dev, cfg->odr, cfg->lp);
+	if (ret < 0) {
+		LOG_ERR("Failed to set ODR and LP mode");
+		return ret;
+	}
+
+	ret = adxl375_set_data_format(dev, ADXL375_DATA_FORMAT_DEFAULT_BITS);
+	if (ret < 0) {
+		LOG_ERR("Failed to initialize data format");
+		return ret;
+	}
+
+	ret = adxl375_set_op_mode(dev, ADXL375_MEASUREMENT);
+	if (ret < 0) {
+		LOG_ERR("Failed to put in standby mode");
+	}
+
+	return 0;
+}
+
+static int adxl375_sample_fetch(const struct device *dev, enum sensor_channel chan)
+{
+	struct adxl375_data *data = dev->data;
+	uint8_t buff[6] = {0};
+
+	int ret = data->hw_tf->read_reg_multiple(dev, ADXL375_DATAX0, buff, 6);
+
+	data->sample.x = sys_get_le16(&buff[0]);
+	data->sample.y = sys_get_le16(&buff[2]);
+	data->sample.z = sys_get_le16(&buff[4]);
+
+	return ret;
+}
+
+static void adxl375_accel_convert(struct sensor_value *result, int16_t sample_val)
+{
+	int64_t value = (int64_t)sample_val * SENSOR_G * ADXL375_MG2G_MULTIPLIER;
+
+	result->val1 = value / 1000000;
+	result->val2 = value % 1000000;
+}
+
+static int adxl375_channel_get(const struct device *dev, enum sensor_channel chan,
+			       struct sensor_value *val)
+{
+	struct adxl375_data *data = dev->data;
+
+	switch (chan) {
+	case SENSOR_CHAN_ACCEL_X:
+		adxl375_accel_convert(val, data->sample.x);
+		break;
+	case SENSOR_CHAN_ACCEL_Y:
+		adxl375_accel_convert(val, data->sample.y);
+		break;
+	case SENSOR_CHAN_ACCEL_Z:
+		adxl375_accel_convert(val, data->sample.z);
+		break;
+	case SENSOR_CHAN_ACCEL_XYZ:
+		adxl375_accel_convert(val++, data->sample.x);
+		adxl375_accel_convert(val++, data->sample.y);
+		adxl375_accel_convert(val, data->sample.z);
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+static const struct sensor_driver_api adxl375_api_funcs = {.channel_get = adxl375_channel_get,
+							   .sample_fetch = adxl375_sample_fetch};
+
+#if DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 0
+#warning "ADXL375 driver enabled without any devices"
+#endif
+
+#define ADXL375_DEVICE_INIT(inst)                                                                  \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, adxl375_init, NULL, &adxl375_data_##inst,               \
+				     &adxl375_config_##inst, POST_KERNEL,                          \
+				     CONFIG_SENSOR_INIT_PRIORITY, &adxl375_api_funcs);
+
+#define ADXL375_CONFIG(inst)                                                                       \
+	.odr = DT_INST_ENUM_IDX(inst, odr), .lp = DT_INST_PROP(inst, lp), .op_mode = ADXL375_STANDBY
+
+/*
+ * Instantiation macros used when a device is on a SPI bus.
+ */
+#define ADXL375_CONFIG_SPI(inst)                                                                   \
+	{.bus_init = adxl375_spi_init,                                                             \
+	 .spi = SPI_DT_SPEC_INST_GET(inst, SPI_WORD_SET(8) | SPI_TRANSFER_MSB, 0),                 \
+	 ADXL375_CONFIG(inst)}
+
+#define ADXL375_DEFINE_SPI(inst)                                                                   \
+	static struct adxl375_data adxl375_data_##inst;                                            \
+	static const struct adxl375_dev_config adxl375_config_##inst = ADXL375_CONFIG_SPI(inst);   \
+	ADXL375_DEVICE_INIT(inst)
+
+/*
+ * Instantiation macros used when a device is on an I2C bus.
+ */
+
+#define ADXL375_CONFIG_I2C(inst)                                                                   \
+	{.bus_init = adxl375_i2c_init, .i2c = I2C_DT_SPEC_INST_GET(inst), ADXL375_CONFIG(inst)}
+
+#define ADXL375_DEFINE_I2C(inst)                                                                   \
+	static struct adxl375_data adxl375_data_##inst;                                            \
+	static const struct adxl375_dev_config adxl375_config_##inst = ADXL375_CONFIG_I2C(inst);   \
+	ADXL375_DEVICE_INIT(inst)
+/*
+ * Main instantiation macro. Use of COND_CODE_1() selects the right
+ * bus-specific macro at preprocessor time.
+ */
+
+#define ADXL375_DEFINE(inst)                                                                       \
+	COND_CODE_1(DT_INST_ON_BUS(inst, spi), (ADXL375_DEFINE_SPI(inst)),                         \
+		    (ADXL375_DEFINE_I2C(inst)))
+
+DT_INST_FOREACH_STATUS_OKAY(ADXL375_DEFINE)

--- a/drivers/sensor/adi/adxl375/adxl375.h
+++ b/drivers/sensor/adi/adxl375/adxl375.h
@@ -1,0 +1,328 @@
+/*
+ * Copyright (c) 2023 Aaron Chan
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_SENSOR_ADXL375_ADXL375_H_
+#define ZEPHYR_DRIVERS_SENSOR_ADXL375_ADXL375_H_
+
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/types.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/util.h>
+
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
+#include <zephyr/drivers/spi.h>
+#endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(spi) */
+
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
+#include <zephyr/drivers/i2c.h>
+#endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c) */
+
+/*
+ * ADXL375 registers definition
+ */
+#define ADXL375_DEVID            0x00u /* Analog Devices accelerometer ID */
+#define ADXL375_THRESH_SHOCK     0x1Du /* Shock Threshold */
+#define ADXL375_OFFSET_X         0x1E  /* X-axis Offset */
+#define ADXL375_OFFSET_Y         0x1F  /* Y-axis Offset */
+#define ADXL375_OFFSET_Z         0x20  /* Z-axis Offset */
+#define ADXL375_DUR_SHOCK        0x21  /* Shock Duration */
+#define ADXL375_LATENT_SHOCK     0x22  /* Shock Latency */
+#define ADXL375_WINDOW_SHOCK     0x23  /* Shock Window */
+#define ADXL375_THRESH_ACT       0x24  /* Activity Threshold */
+#define ADXL375_THRESH_INACT     0x25  /* Inctivity Threshold */
+#define ADXL375_TIME_INACT       0x26  /* Inactivity Time */
+#define ADXL375_ACT_INACT_CTL    0x27  /* Axis enable control for activity/inactivity detection */
+#define ADXL375_SHOCK_AXES       0x2A  /* Axis control for single shock/double shock */
+#define ADXL375_ACT_SHOCK_STATUS 0x2B  /* Source of single shock/double shock */
+#define ADXL375_BW_RATE          0x2C  /* Data rate and power mode control */
+#define ADXL375_POWER_CTL        0x2D  /* Power saving features control */
+#define ADXL375_INT_ENABLE       0x2E  /* Interrupt enable control */
+#define ADXL375_INT_MAP          0x2F  /* Interrupt mapping control */
+#define ADXL375_INT_SOURCE       0x30  /* Interrupt source */
+#define ADXL375_DATA_FORMAT      0x31  /* Data format control */
+#define ADXL375_DATAX0           0x32  /* X-Axis Data 0 (LSB) */
+#define ADXL375_DATAX1           0x33  /* X-Axis Data 1 (MSB) */
+#define ADXL375_DATAY0           0x34  /* Y-Axis Data 0 (LSB) */
+#define ADXL375_DATAY1           0x35  /* Y-Axis Data 1 (MSB) */
+#define ADXL375_DATAZ0           0x36  /* Z-Axis Data 0 (LSB) */
+#define ADXL375_DATAZ1           0x37  /* Z-Axis Data 1 (MSB) */
+#define ADXL375_FIFO_CTL         0x38  /* FIFO control */
+#define ADXL375_FIFO_STATUS      0x39  /* FIFO status */
+
+#define ADXL375_DEVID_VAL 0xE5u /* Analog Devices accelerometer ID */
+
+#define ADXL375_READ          0x01u
+#define ADXL375_REG_READ(x)   (((x & 0xFF) << 1) | ADXL375_READ)
+#define ADXL375_REG_WRITE(x)  ((x & 0xFF) << 1)
+#define ADXL375_TO_I2C_REG(x) ((x) >> 1)
+
+/* ADXL375_ACT_INACT_CTL */
+#define ADXL375_POWER_CTL_ACT_ACDC_MSK   BIT(7)
+#define ADXL375_POWER_CTL_ACT_X_EN_MSK   BIT(6)
+#define ADXL375_POWER_CTL_ACT_Y_EN_MSK   BIT(5)
+#define ADXL375_POWER_CTL_ACT_Z_EN_MSK   BIT(4)
+#define ADXL375_POWER_CTL_INACT_ACDC_MSK BIT(3)
+#define ADXL375_POWER_CTL_INACT_X_EN_MSK BIT(2)
+#define ADXL375_POWER_CTL_INACT_Y_EN_MSK BIT(1)
+#define ADXL375_POWER_CTL_INACT_Z_EN_MSK BIT(0)
+
+#define ADXL375_POWER_CTL_ACT_ACDC_MODE(x)   (((x) & 0x1) << 7)
+#define ADXL375_POWER_CTL_ACT_X_EN_MODE(x)   (((x) & 0x1) << 6)
+#define ADXL375_POWER_CTL_ACT_Y_EN_MODE(x)   (((x) & 0x1) << 5)
+#define ADXL375_POWER_CTL_ACT_Z_EN_MODE(x)   (((x) & 0x1) << 4)
+#define ADXL375_POWER_CTL_INACT_ACDC_MODE(x) (((x) & 0x1) << 3)
+#define ADXL375_POWER_CTL_INACT_X_EN_MODE(x) (((x) & 0x1) << 2)
+#define ADXL375_POWER_CTL_INACT_Y_EN_MODE(x) (((x) & 0x1) << 1)
+#define ADXL375_POWER_CTL_INACT_Z_EN_MODE(x) (((x) & 0x1) << 0)
+
+/* ADXL375_SHOCK_AXES */
+#define ADXL375_SHOCK_CTL_SUPPRESS_MSK   BIT(3)
+#define ADXL375_SHOCK_CTL_SHOCK_X_EN_MSK BIT(2)
+#define ADXL375_SHOCK_CTL_SHOCK_Y_EN_MSK BIT(1)
+#define ADXL375_SHOCK_CTL_SHOCK_Z_EN_MSK BIT(0)
+
+#define ADXL375_SHOCK_CTL_SUPPRESS_MODE(x)   (((x) & 0x1) << 3)
+#define ADXL375_SHOCK_CTL_SHOCK_X_EN_MODE(x) (((x) & 0x1) << 2)
+#define ADXL375_SHOCK_CTL_SHOCK_Y_EN_MODE(x) (((x) & 0x1) << 1)
+#define ADXL375_SHOCK_CTL_SHOCK_Z_EN_MODE(x) (((x) & 0x1) << 0)
+
+/* ADXL375_ACT_SHOCK_STATUS */
+#define ADXL375_ACT_SHOCK_STATUS_ACT_X_SRC(x)   (((x) >> 6) & 0x1)
+#define ADXL375_ACT_SHOCK_STATUS_ACT_Y_SRC(x)   (((x) >> 5) & 0x1)
+#define ADXL375_ACT_SHOCK_STATUS_ACT_Z_SRC(x)   (((x) >> 4) & 0x1)
+#define ADXL375_ACT_SHOCK_STATUS_ASLEEP(x)      (((x) >> 3) & 0x1)
+#define ADXL375_ACT_SHOCK_STATUS_SHOCK_X_SRC(x) (((x) >> 2) & 0x1)
+#define ADXL375_ACT_SHOCK_STATUS_SHOCK_Y_SRC(x) (((x) >> 1) & 0x1)
+#define ADXL375_ACT_SHOCK_STATUS_SHOCK_Z_SRC(x) (((x) >> 0) & 0x1)
+
+/* ADXL375_BW_RATE */
+#define ADXL375_BW_RATE_LOW_POWER_MSK BIT(4)
+#define ADXL375_BW_RATE_RATE_MSK      GENMASK(3, 0)
+
+#define ADXL375_BW_RATE_LOW_POWER_MODE (((x) & 0x1) << 4)
+#define ADXL375_BW_RATE_RATE_MODE      (((x) & 0x15) << 4)
+
+/* ADXL375_POWER_CTL */
+#define ADXL375_POWER_CTL_LINK_MSK       BIT(5)
+#define ADXL375_POWER_CTL_AUTO_SLEEP_MSK BIT(4)
+#define ADXL375_POWER_CTL_MEASURE_MSK    BIT(3)
+#define ADXL375_POWER_CTL_SLEEP_MSK      BIT(2)
+#define ADXL375_POWER_CTL_WAKEUP_MSK     GENMASK(1, 0)
+
+#define ADXL375_POWER_CTL_LINK_MODE(x)       (((x) & 0x1) << 5)
+#define ADXL375_POWER_CTL_AUTO_SLEEP_MODE(x) (((x) & 0x1) << 4)
+#define ADXL375_POWER_CTL_MEASURE_MODE(x)    (((x) & 0x1) << 3)
+#define ADXL375_POWER_CTL_SLEEP_MODE(x)      (((x) & 0x1) << 2)
+#define ADXL375_POWER_CTL_WAKEUP_MODE(x)     (((x) & 0x3) << 0)
+
+/* ADXL375_MEASURE */
+#define ADXL375_MEASURE_AUTOSLEEP_MSK     BIT(6)
+#define ADXL375_MEASURE_AUTOSLEEP_MODE(x) (((x) & 0x1) << 6)
+#define ADXL375_MEASURE_LINKLOOP_MSK      GENMASK(5, 4)
+#define ADXL375_MEASURE_LINKLOOP_MODE(x)  (((x) & 0x3) << 4)
+#define ADXL375_MEASURE_LOW_NOISE_MSK     BIT(3)
+#define ADXL375_MEASURE_LOW_NOISE_MODE(x) (((x) & 0x1) << 3)
+#define ADXL375_MEASURE_BANDWIDTH_MSK     GENMASK(2, 0)
+#define ADXL375_MEASURE_BANDWIDTH_MODE(x) (((x) & 0x7) << 0)
+
+/* ADXL375_INT_ENABLE */
+#define ADXL375_INT_ENABLE_DATA_READY_MSK   BIT(7)
+#define ADXL375_INT_ENABLE_SINGLE_SHOCK_MSK BIT(6)
+#define ADXL375_INT_ENABLE_DOUBLE_SHOCK_MSK BIT(5)
+#define ADXL375_INT_ENABLE_ACTIVITY_MSK     BIT(4)
+#define ADXL375_INT_ENABLE_INACTIVITY_MSK   BIT(3)
+#define ADXL375_INT_ENABLE_WATERMARK_MSK    BIT(1)
+#define ADXL375_INT_ENABLE_OVERRUN_MSK      BIT(0)
+
+#define ADXL375_INT_ENABLE_DATA_READY_MODE(x)   (((x) & 0x1) << 7)
+#define ADXL375_INT_ENABLE_SINGLE_SHOCK_MODE(x) (((x) & 0x1) << 6)
+#define ADXL375_INT_ENABLE_DOUBLE_SHOCK_MODE(x) (((x) & 0x1) << 5)
+#define ADXL375_INT_ENABLE_ACTIVITY_MODE(x)     (((x) & 0x1) << 4)
+#define ADXL375_INT_ENABLE_INACTIVITY_MODE(x)   (((x) & 0x1) << 3)
+#define ADXL375_INT_ENABLE_WATERMARK_MODE(x)    (((x) & 0x1) << 1)
+#define ADXL375_INT_ENABLE_OVERRUN_MODE(x)      (((x) & 0x1) << 0)
+
+/* ADXL375_INT_MAP */
+#define ADXL375_INT_MAP_DATA_READY_MSK   BIT(7)
+#define ADXL375_INT_MAP_SINGLE_SHOCK_MSK BIT(6)
+#define ADXL375_INT_MAP_DOUBLE_SHOCK_MSK BIT(5)
+#define ADXL375_INT_MAP_ACTIVITY_MSK     BIT(4)
+#define ADXL375_INT_MAP_INACTIVITY_MSK   BIT(3)
+#define ADXL375_INT_MAP_WATERMARK_MSK    BIT(1)
+#define ADXL375_INT_MAP_OVERRUN_MSK      BIT(0)
+
+#define ADXL375_INT_MAP_DATA_READY_MODE(x)   (((x) & 0x1) << 7)
+#define ADXL375_INT_MAP_SINGLE_SHOCK_MODE(x) (((x) & 0x1) << 6)
+#define ADXL375_INT_MAP_DOUBLE_SHOCK_MODE(x) (((x) & 0x1) << 5)
+#define ADXL375_INT_MAP_ACTIVITY_MODE(x)     (((x) & 0x1) << 4)
+#define ADXL375_INT_MAP_INACTIVITY_MODE(x)   (((x) & 0x1) << 3)
+#define ADXL375_INT_MAP_WATERMARK_MODE(x)    (((x) & 0x1) << 1)
+#define ADXL375_INT_MAP_OVERRUN_MODE(x)      (((x) & 0x1) << 0)
+
+/* ADXL375_INT_SOURCE */
+#define ADXL375_INT_DATA_READY_SRC(x)   (((x) >> 7) & 0x1)
+#define ADXL375_INT_SINGLE_SHOCK_SRC(x) (((x) >> 6) & 0x1)
+#define ADXL375_INT_DOUBLE_SHOCK_SRC(x) (((x) >> 5) & 0x1)
+#define ADXL375_INT_ACTIVITY_SRC(x)     (((x) >> 4) & 0x1)
+#define ADXL375_INT_INACTIVITY_SRC(x)   (((x) >> 3) & 0x1)
+#define ADXL375_INT_WATERMARK_SRC(x)    (((x) >> 1) & 0x1)
+#define ADXL375_INT_OVERRUN_SRC(x)      (((x) >> 0) & 0x1)
+
+/* ADX375_DATA_FORMAT */
+#define ADXL375_FORMAT_SELF_TEST_MSK  BIT(7)
+#define ADXL375_FORMAT_SPI_MSK        BIT(6)
+#define ADXL375_FORMAT_INT_INVERT_MSK BIT(5)
+#define ADXL375_FORMAT_JUSTIFY_MSK    BIT(2)
+
+#define ADXL375_FORMAT_SELF_TEST_MODE(x)  (((x) & 0x1) << 7)
+#define ADXL375_FORMAT_SPI_MODE(x)        (((x) & 0x1) << 6)
+#define ADXL375_FORMAT_INT_INVERT_MODE(x) (((x) & 0x1) << 5)
+#define ADXL375_FORMAT_JUSTIFY_MODE(x)    (((x) & 0x1) << 2)
+
+/* ADXL375_FIFO_CTL */
+#define ADXL375_FIFO_CTL_FIFO_MODE_MSK GENMASK(7, 5)
+#define ADXL375_FIFO_CTL_TRIGGER_MSK   BIT(5)
+#define ADXL375_FIFO_CTL_SAMPLES_MSK   GENMASK(4, 0)
+
+#define ADXL375_FIFO_CTL_FIFO_MODE_MODE(x) (((x) & 0x7) << 5)
+#define ADXL375_FIFO_CTL_TRIGGER_MODE(x)   (((x) & 0x1) << 5)
+#define ADXL375_FIFO_CTL_SAMPLES_MODE(x)   ((x) & 0x1F)
+
+/* ADXL375_FIFO_STATUS */
+#define ADXL375_FIFO_STATUS_FIFO_TRIG(x) (((x) >> 7) & 0x1)
+#define ADXL375_FIFO_STATUS_ENTRIES(x)   ((x) & 0x7F)
+
+/* ADXL375 scale factors specified in page 3, table 1 of datasheet */
+#define ADXL375_MG2G_MULTIPLIER 0.049
+
+/* Set bits 3, 1 and 0 since register defaults to 0. Datasheet pages 20-24 */
+#define ADXL375_DATA_FORMAT_DEFAULT_BITS 0x0B
+
+enum adxl375_axis {
+	ADXL375_X_AXIS,
+	ADXL375_Y_AXIS,
+	ADXL375_Z_AXIS
+};
+
+enum adxl375_op_mode {
+	ADXL375_STANDBY = 0x04,
+	ADXL375_MEASUREMENT = 0x08,
+	ADXL375_AUTOSLEEP = 0x24
+};
+
+enum adxl375_bandwidth {
+	ADXL375_BW_0_05HZ,
+	ADXL375_BW_0_10HZ,
+	ADXL375_BW_0_20HZ,
+	ADXL375_BW_0_39HZ,
+	ADXL375_BW_0_78HZ,
+	ADXL375_BW_1_56HZ,
+	ADXL375_BW_3_13HZ,
+	ADXL375_BW_6_25HZ,
+	ADXL375_BW_12_5HZ,
+	ADXL375_BW_25HZ,
+	ADXL375_BW_50HZ,
+	ADXL375_BW_100HZ,
+	ADXL375_BW_200HZ,
+	ADXL375_BW_400HZ,
+	ADXL375_BW_800HZ,
+	ADXL375_BW_1600HZ
+};
+
+enum adxl375_odr {
+	ADXL375_ODR_0_10HZ = 0,
+	ADXL375_ODR_0_20HZ,
+	ADXL375_ODR_0_39HZ,
+	ADXL375_ODR_0_78HZ,
+	ADXL375_ODR_1_56HZ,
+	ADXL375_ODR_3_13HZ,
+	ADXL375_ODR_6_25HZ,
+	ADXL375_ODR_12_5HZ,
+	ADXL375_ODR_25HZ,
+	ADXL375_ODR_50HZ,
+	ADXL375_ODR_100HZ,
+	ADXL375_ODR_200HZ,
+	ADXL375_ODR_400HZ,
+	ADXL375_ODR_800HZ,
+	ADXL375_ODR_1600HZ,
+	ADXL375_ODR_3200HZ
+};
+
+enum adxl375_fifo_format {
+	ADXL375_XYZ_FIFO,
+	ADXL375_X_FIFO,
+	ADXL375_Y_FIFO,
+	ADXL375_XY_FIFO,
+	ADXL375_Z_FIFO,
+	ADXL375_XZ_FIFO,
+	ADXL375_YZ_FIFO,
+	ADXL375_XYZ_PEAK_FIFO,
+};
+
+enum adxl375_fifo_mode {
+	ADXL375_FIFO_BYPASS,
+	ADXL375_FIFO_STREAM,
+	ADXL375_FIFO_TRIGGER
+};
+
+struct adxl375_fifo_config {
+	enum adxl375_fifo_mode fifo_mode;
+	enum adxl375_fifo_format fifo_format;
+	uint16_t fifo_samples;
+};
+
+struct adxl375_activity_threshold {
+	uint16_t thresh;
+	bool referenced;
+	bool enable;
+};
+
+struct adxl375_xyz_accel_data {
+	int16_t x;
+	int16_t y;
+	int16_t z;
+};
+
+struct adxl375_transfer_function {
+	int (*read_reg_multiple)(const struct device *dev, uint8_t reg_addr, uint8_t *value,
+				 uint16_t len);
+	int (*write_reg)(const struct device *dev, uint8_t reg_addr, uint8_t value);
+	int (*read_reg)(const struct device *dev, uint8_t reg_addr, uint8_t *value);
+	int (*write_reg_mask)(const struct device *dev, uint8_t reg_addr, uint32_t mask,
+			      uint8_t value);
+};
+
+struct adxl375_data {
+	struct adxl375_xyz_accel_data sample;
+	const struct adxl375_transfer_function *hw_tf;
+	struct adxl375_fifo_config fifo_config;
+};
+
+struct adxl375_dev_config {
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
+	struct i2c_dt_spec i2c;
+#endif
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
+	struct spi_dt_spec spi;
+#endif
+	int (*bus_init)(const struct device *dev);
+
+	enum adxl375_odr odr;
+
+	/* Device Settings */
+	bool autosleep;
+
+	bool lp;
+
+	enum adxl375_op_mode op_mode;
+};
+
+int adxl375_spi_init(const struct device *dev);
+int adxl375_i2c_init(const struct device *dev);
+
+#endif /* ZEPHYR_DRIVERS_SENSOR_ADXL375_ADXL375_H_ */

--- a/drivers/sensor/adi/adxl375/adxl375_i2c.c
+++ b/drivers/sensor/adi/adxl375/adxl375_i2c.c
@@ -1,0 +1,82 @@
+/* adxl375_i2c.c - I2C routines for ADXL375 driver
+ */
+
+/*
+ * Copyright (c) 2022 Analog Devices
+ * Copyright (c) 2024 Aaron Chan
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "zephyr/drivers/i2c.h"
+#define DT_DRV_COMPAT adi_adxl375
+
+#include <string.h>
+#include <zephyr/logging/log.h>
+
+#include "adxl375.h"
+
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
+
+LOG_MODULE_DECLARE(ADXL375, CONFIG_SENSOR_LOG_LEVEL);
+
+static int adxl375_i2c_reg_read(const struct device *dev, uint8_t reg_addr, uint8_t *reg_data)
+{
+	const struct adxl375_dev_config *config = dev->config;
+
+	return i2c_burst_read_dt(&config->i2c, reg_addr, reg_data, 1);
+}
+
+static int adxl375_i2c_reg_read_multiple(const struct device *dev, uint8_t reg_addr,
+					 uint8_t *reg_data, uint16_t count)
+{
+	const struct adxl375_dev_config *config = dev->config;
+
+	return i2c_burst_read_dt(&config->i2c, reg_addr, reg_data, count);
+}
+
+static int adxl375_i2c_reg_write(const struct device *dev, uint8_t reg_addr, uint8_t reg_data)
+{
+	const struct adxl375_dev_config *config = dev->config;
+
+	return i2c_reg_write_byte_dt(&config->i2c, reg_addr, reg_data);
+}
+
+int adxl375_i2c_reg_write_mask(const struct device *dev, uint8_t reg_addr, uint32_t mask,
+			       uint8_t data)
+{
+	int ret;
+	uint8_t tmp;
+
+	ret = adxl375_i2c_reg_read(dev, reg_addr, &tmp);
+	if (ret) {
+		return ret;
+	}
+
+	tmp &= ~mask;
+	tmp |= data;
+
+	return adxl375_i2c_reg_write(dev, reg_addr, tmp);
+}
+
+static const struct adxl375_transfer_function adxl375_i2c_transfer_fn = {
+	.read_reg_multiple = adxl375_i2c_reg_read_multiple,
+	.write_reg = adxl375_i2c_reg_write,
+	.read_reg = adxl375_i2c_reg_read,
+	.write_reg_mask = adxl375_i2c_reg_write_mask,
+};
+
+int adxl375_i2c_init(const struct device *dev)
+{
+	struct adxl375_data *data = dev->data;
+	const struct adxl375_dev_config *config = dev->config;
+
+	data->hw_tf = &adxl375_i2c_transfer_fn;
+
+	if (!i2c_is_ready_dt(&config->i2c)) {
+		return -ENODEV;
+	}
+
+	return 0;
+}
+#endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c) */

--- a/drivers/sensor/adi/adxl375/adxl375_spi.c
+++ b/drivers/sensor/adi/adxl375/adxl375_spi.c
@@ -1,0 +1,99 @@
+/* adxl375_spi.c - SPI routines for ADXL375 driver
+ */
+
+/*
+ * Copyright (c) 2022 Analog Devices
+ * Copyright (c) 2024 Aaron Chan
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT adi_adxl375
+
+#include <string.h>
+#include <zephyr/logging/log.h>
+
+#include "adxl375.h"
+
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
+
+LOG_MODULE_DECLARE(adxl375, CONFIG_SENSOR_LOG_LEVEL);
+
+static int adxl375_bus_access(const struct device *dev, uint8_t reg, void *data, size_t length)
+{
+	const struct adxl375_dev_config *config = dev->config;
+
+	const struct spi_buf buf[2] = {{.buf = &reg, .len = 1}, {.buf = data, .len = length}};
+
+	struct spi_buf_set tx = {
+		.buffers = buf,
+	};
+
+	if (reg & ADXL375_READ) {
+		const struct spi_buf_set rx = {.buffers = buf, .count = 2};
+
+		tx.count = 1;
+
+		return spi_transceive_dt(&config->spi, &tx, &rx);
+	}
+
+	tx.count = 2;
+
+	return spi_write_dt(&config->spi, &tx);
+}
+
+static int adxl375_spi_reg_read(const struct device *dev, uint8_t reg_addr, uint8_t *reg_data)
+{
+	return adxl375_bus_access(dev, ADXL375_REG_READ(reg_addr), reg_data, 1);
+}
+
+static int adxl375_spi_reg_read_multiple(const struct device *dev, uint8_t reg_addr,
+					 uint8_t *reg_data, uint16_t count)
+{
+	return adxl375_bus_access(dev, ADXL375_REG_READ(reg_addr), reg_data, count);
+}
+
+static int adxl375_spi_reg_write(const struct device *dev, uint8_t reg_addr, uint8_t reg_data)
+{
+	return adxl375_bus_access(dev, ADXL375_REG_WRITE(reg_addr), &reg_data, 1);
+}
+
+int adxl375_spi_reg_write_mask(const struct device *dev, uint8_t reg_addr, uint32_t mask,
+			       uint8_t data)
+{
+	int ret;
+	uint8_t tmp;
+
+	ret = adxl375_spi_reg_read(dev, reg_addr, &tmp);
+	if (ret) {
+		return ret;
+	}
+
+	tmp &= ~mask;
+	tmp |= data;
+
+	return adxl375_spi_reg_write(dev, reg_addr, tmp);
+}
+
+static const struct adxl375_transfer_function adxl375_spi_transfer_fn = {
+	.read_reg_multiple = adxl375_spi_reg_read_multiple,
+	.write_reg = adxl375_spi_reg_write,
+	.read_reg = adxl375_spi_reg_read,
+	.write_reg_mask = adxl375_spi_reg_write_mask,
+};
+
+int adxl375_spi_init(const struct device *dev)
+{
+	struct adxl375_data *data = dev->data;
+	const struct adxl375_dev_config *config = dev->config;
+
+	data->hw_tf = &adxl375_spi_transfer_fn;
+
+	if (!spi_is_ready_dt(&config->spi)) {
+		return -ENODEV;
+	}
+
+	return 0;
+}
+
+#endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(spi) */

--- a/dts/bindings/sensor/adi,adxl375-common.yaml
+++ b/dts/bindings/sensor/adi,adxl375-common.yaml
@@ -1,0 +1,33 @@
+# Copyright (c) 2023 Aaron Chan
+# SPDX-License-Identifier: Apache-2.0
+
+include: sensor-device.yaml
+
+properties:
+  odr:
+    type: string
+    default: "100"
+    description: |
+          Accelerometer sampling frequency (ODR) in Hz. Default is power on reset value.
+    enum:
+      - "0.10"
+      - "0.20"
+      - "0.39"
+      - "0.78"
+      - "1.56"
+      - "3.13"
+      - "6.25"
+      - "12.5"
+      - "25"
+      - "50"
+      - "100"
+      - "200"
+      - "400"
+      - "800"
+      - "1600"
+      - "3200"
+
+  lp:
+    type: boolean
+    description: |
+          Low power mode. Default is false.

--- a/dts/bindings/sensor/adi,adxl375-i2c.yaml
+++ b/dts/bindings/sensor/adi,adxl375-i2c.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2023 Aaron Chan
+# SPDX-License-Identifier: Apache-2.0
+
+description: ADXL375 3-axis accelerometer using the I2C bus
+
+compatible: "adi,adxl375"
+
+include: ["i2c-device.yaml", "adi,adxl375-common.yaml"]

--- a/dts/bindings/sensor/adi,adxl375-spi.yaml
+++ b/dts/bindings/sensor/adi,adxl375-spi.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2024 Aaron Chan
+# SPDX-License-Identifier: Apache-2.0
+
+description: ADXL375 3-axis accelerometer using the SPI bus
+
+compatible: "adi,adxl375"
+
+include: ["spi-device.yaml", "adi,adxl375-common.yaml"]

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -1049,3 +1049,9 @@ test_i2c_ina226: ina226@8d {
 	current-lsb-microamps = <5000>;
 	rshunt-micro-ohms = <500>;
 };
+
+test_i2c_adxl375: adxl375@8e {
+	compatible = "adi,adxl375";
+	reg = <0x8e>;
+	stauts = "okay";
+};

--- a/tests/drivers/build_all/sensor/spi.dtsi
+++ b/tests/drivers/build_all/sensor/spi.dtsi
@@ -383,3 +383,10 @@ test_spi_tle9104: tle9104@2e {
 		#sensor-cells = <0>;
 	};
 };
+
+test_spi_adxl375: adxl375@2f {
+	compatible = "adi,adxl375";
+	reg = <0x2f>;
+	spi-max-frequency = <0>;
+	status = "okay";
+};


### PR DESCRIPTION
Basic support for an ADXL375 accelerometer driver similar to other ADXL37X models over I2C and SPI tested on an Adafruit ADXL375 breakout board. Support for configuring output data rate and low power mode, as well as retrieving acceleration values.

Signed-off-by: Aaron Chan [aarchan108@gmail.com](mailto:aarchan108@gmail.com)