### PR TITLE
boards: arm: ucans32k1sic: enable watchdog support

### DIFF
--- a/boards/arm/ucans32k1sic/doc/index.rst
+++ b/boards/arm/ucans32k1sic/doc/index.rst
@@ -51,6 +51,7 @@ LPI2C         on-chip     i2c
 LPSPI         on-chip     spi
 FTM           on-chip     pwm
 FlexCAN       on-chip     can
+Watchdog      on-chip     watchdog
 ============  ==========  ================================
 
 The default configuration can be found in the Kconfig file

--- a/boards/arm/ucans32k1sic/ucans32k1sic.yaml
+++ b/boards/arm/ucans32k1sic/ucans32k1sic.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 NXP
+# Copyright 2023-2024 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 identifier: ucans32k1sic
@@ -19,3 +19,4 @@ supported:
   - spi
   - pwm
   - can
+  - watchdog

--- a/dts/arm/nxp/nxp_s32k1xx.dtsi
+++ b/dts/arm/nxp/nxp_s32k1xx.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 NXP
+ * Copyright 2023-2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -9,6 +9,10 @@
 #include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
+	aliases {
+		watchdog0 = &wdog;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -122,6 +126,15 @@
 			compatible = "nxp,kinetis-pinmux";
 			reg = <0x4004d000 0x1000>;
 			clocks = <&clock NXP_S32_PORTE_CLK>;
+		};
+
+		wdog: watchdog@40052000 {
+			compatible = "nxp,kinetis-wdog32";
+			reg = <0x40052000 0x1000>;
+			interrupts = <22 0>;
+			clocks = <&clock NXP_S32_LPO_128K_CLK>;
+			clk-source = <1>;
+			clk-divider = <256>;
 		};
 
 		clock: clock-controller@40064000 {

--- a/soc/arm/nxp_s32/s32k1/Kconfig.series
+++ b/soc/arm/nxp_s32/s32k1/Kconfig.series
@@ -1,6 +1,6 @@
 # NXP S32K1XX MCU series
 
-# Copyright 2023 NXP
+# Copyright 2023-2024 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 config SOC_SERIES_S32K1XX
@@ -18,5 +18,6 @@ config SOC_SERIES_S32K1XX
 	select HAS_MCUX_LPSPI
 	select HAS_MCUX_FTM
 	select HAS_MCUX_FLEXCAN
+	select HAS_MCUX_WDOG32
 	help
 	  Enable support for NXP S32K1XX MCU series.

--- a/soc/arm/nxp_s32/s32k1/soc.c
+++ b/soc/arm/nxp_s32/s32k1/soc.c
@@ -20,8 +20,6 @@
 #endif
 
 #if defined(CONFIG_WDOG_INIT)
-#define WDOG_UPDATE_KEY    0xD928C520U
-
 void z_arm_watchdog_init(void)
 {
 	/*

--- a/west.yml
+++ b/west.yml
@@ -193,7 +193,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: d6d43cab73f1a0fc73ec26084dab3f54c6324d2e
+      revision: 3d4be32141dd8605515d95f8d1a2340974190cff
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Enable watchdog support for `ucans32k1sic` board.

```
west twister -p ucans32k1sic --device-testing --device-serial=/dev/ttyUSB_ucans32k1sic \
  -T samples/drivers/watchdog   -T tests/drivers/watchdog/
INFO    - Using Ninja..
INFO    - Zephyr version: zephyr-v3.5.0-4524-gafda6e38b343
INFO    - Using 'zephyr' toolchain.
...
INFO    - Total complete:   18/  18  100%  skipped:   16, failed:    0, error:    0
INFO    - 18 test scenarios (18 test instances) selected, 16 configurations skipped (16 by static filter, 0 at runtime).
INFO    - 2 of 18 test configurations passed (100.00%), 0 failed, 0 errored, 16 skipped with 0 warnings in 39.21 seconds
INFO    - In total 2 test cases were executed, 17 skipped on 1 out of total 673 platforms (0.15%)
INFO    - 2 test configurations executed on platforms, 0 test configurations were only built.
```