### PR TITLE
SCA: Add Parasoft C++test support

### DIFF
--- a/cmake/sca/codechecker/sca.cmake
+++ b/cmake/sca/codechecker/sca.cmake
@@ -3,7 +3,7 @@
 # Copyright (c) 2023, Basalte bv
 
 find_program(CODECHECKER_EXE CodeChecker REQUIRED)
-message(STATUS "Found CodeChecker: ${CODECHECKER_EXE}")
+message(STATUS "Found SCA: CodeChecker (${CODECHECKER_EXE})")
 
 # CodeChecker uses the compile_commands.json as input
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/cmake/sca/cpptest/sca.cmake
+++ b/cmake/sca/cpptest/sca.cmake
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (c) 2024, Space Cubics, LLC.
+
+find_program(CPPTESTSCAN cpptestscan REQUIRED)
+message(STATUS "Found SCA: Parasoft C/C++test (${CPPTESTSCAN})")
+
+set(output_dir ${CMAKE_BINARY_DIR}/sca/cpptest)
+file(MAKE_DIRECTORY ${output_dir})
+
+set(output_file ${output_dir}/cpptestscan.bdf)
+set(output_arg --cpptestscanOutputFile=${output_file})
+
+set(CMAKE_C_COMPILER_LAUNCHER ${CPPTESTSCAN} ${output_arg} CACHE INTERNAL "")
+set(CMAKE_CXX_COMPILER_LAUNCHER ${CPPTESTSCAN} ${output_arg} CACHE INTERNAL "")

--- a/cmake/sca/sparse/sca.cmake
+++ b/cmake/sca/sparse/sca.cmake
@@ -3,7 +3,7 @@
 # Copyright (c) 2022, Nordic Semiconductor ASA
 
 find_program(SPARSE_COMPILER cgcc REQUIRED)
-message(STATUS "Found sparse: ${SPARSE_COMPILER}")
+message(STATUS "Found SCA: sparse (${SPARSE_COMPILER})")
 
 # Create sparse.cmake which will be called as compiler launcher.
 # sparse.cmake will ensure that REAL_CC is set correctly in environment before

--- a/doc/develop/sca/cpptest.rst
+++ b/doc/develop/sca/cpptest.rst
@@ -1,0 +1,40 @@
+.. _cpptest:
+
+Parasoft C/C++test support
+##########################
+
+Parasoft `C/C++test <https://www.parasoft.com/products/parasoft-c-ctest/>`__ is a software testing
+and static analysis tool for C and C++. It is a commercial software and you must acquire a
+commercial license to use it.
+
+Documentation of C/C++test can be found at https://docs.parasoft.com/.  Please refer to the
+documentation for how to use it.
+
+Generating Build Data Files
+***************************
+
+To use C/C++test, ``cpptestscan`` must be found in your :envvar:`PATH` environment variable.  And
+:ref:`west build <west-building>` should be called with a ``-DZEPHYR_SCA_VARIANT=cpptest``
+parameter, e.g.
+
+.. code-block:: shell
+
+    west build -b qemu_cortex_m3 zephyr/samples/hello_world -- -DZEPHYR_SCA_VARIANT=cpptest
+
+
+A ``.bdf`` file will be generated as :file:`build/sca/cpptest/cpptestscan.bdf`.
+
+Generating a report file
+************************
+
+Please refer to Parasoft C/C++test documentation for more details.
+
+To import and generate a report file, something like the following should work.
+
+.. code-block:: shell
+
+    cpptestcli -data out -localsettings local.conf -bdf build/sca/cpptest/cpptestscan.bdf -config "builtin://Recommended Rules" -report out/report
+
+
+You might need to set ``bdf.import.c.compiler.exec``, ``bdf.import.cpp.compiler.exec``, and
+``bdf.import.linker.exec`` to the toolchain :ref:`west build <west-building>` used.

--- a/doc/develop/sca/index.rst
+++ b/doc/develop/sca/index.rst
@@ -64,3 +64,4 @@ The following is a list of SCA tools natively supported by Zephyr build system.
    codechecker
    sparse
    gcc
+   cpptest


### PR DESCRIPTION
This PR adds Parasoft C++test as one of the [Static Code Analysis (SCA)](https://docs.zephyrproject.org/latest/develop/sca/index.html) tools.

This fixes #67816.