### PR TITLE
teensy: add west flash teensy_loader_cli integration

### DIFF
--- a/boards/common/teensy.board.cmake
+++ b/boards/common/teensy.board.cmake
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+
+board_set_flasher_ifnset(teensy)
+board_finalize_runner_args(teensy)

--- a/boards/pjrc/teensy4/board.cmake
+++ b/boards/pjrc/teensy4/board.cmake
@@ -1,0 +1,11 @@
+#SPDX-License-Identifier: Apache-2.0
+
+board_set_flasher_ifnset(teensy)
+
+if(CONFIG_BOARD_TEENSY40)
+board_runner_args(teensy "--mcu=TEENSY40")
+else()
+board_runner_args(teensy "--mcu=TEENSY41")
+endif()
+
+include(${ZEPHYR_BASE}/boards/common/teensy.board.cmake)

--- a/scripts/west_commands/runners/__init__.py
+++ b/scripts/west_commands/runners/__init__.py
@@ -53,6 +53,7 @@ _names = [
     'spi_burn',
     'stm32cubeprogrammer',
     'stm32flash',
+    'teensy',
     'trace32',
     'uf2',
     'xtensa',

--- a/scripts/west_commands/runners/teensy.py
+++ b/scripts/west_commands/runners/teensy.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2024 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+
+'''Runner for teensy .'''
+
+import os
+import subprocess
+
+from runners.core import ZephyrBinaryRunner
+
+class TeensyBinaryRunner(ZephyrBinaryRunner):
+    '''Runner front-end for teensy.'''
+
+    def __init__(self, cfg, mcu, teensy_loader):
+        super().__init__(cfg)
+
+        self.mcu_args = ['--mcu', mcu]
+        self.teensy_loader = teensy_loader
+        self.hex_name = cfg.hex_file
+
+    @classmethod
+    def name(cls):
+        return 'teensy'
+
+    @classmethod
+    def do_add_parser(cls, parser):
+        parser.add_argument('--mcu', required=True,
+                            help='Teensy mcu target')
+        parser.add_argument('--teensy', default='teensy_loader_cli',
+                            help='path to teensy cli tool, default is teensy_loader_cli')
+
+    @classmethod
+    def do_create(cls, cfg, args):
+        ret = TeensyBinaryRunner(
+            cfg, args.mcu,
+            teensy_loader=args.teensy)
+        return ret
+
+    def do_run(self, command):
+        self.require(self.teensy_loader)
+        if command == 'flash':
+            self.flash()
+
+    def flash(self):
+        if self.hex_name is not None and os.path.isfile(self.hex_name):
+            fname = self.hex_name
+        else:
+            raise ValueError(
+                'Cannot flash; no hex ({}) file found. '.format(self.hex_name))
+
+        cmd = ([self.teensy_loader] +
+               self.mcu_args +
+               [fname])
+
+        self.logger.info('Flashing file: {}'.format(fname))
+
+        try:
+            self.check_output(cmd)
+            self.logger.info('Success')
+        except subprocess.CalledProcessError as grepexc:
+            self.logger.error("Failure %i" % grepexc.returncode)

--- a/scripts/west_commands/tests/test_imports.py
+++ b/scripts/west_commands/tests/test_imports.py
@@ -44,6 +44,7 @@ def test_runner_imports():
                     'stm32cubeprogrammer',
                     'stm32flash',
                     'trace32',
+                    'teensy',
                     'uf2',
                     'xtensa'))
     assert runner_names == expected


### PR DESCRIPTION
Allows Teensy 4.0 and 4.1 board to be flashed using the `west flash` command.