### PR TITLE
lib/libc: Update picolibc to 1.8.6

### DIFF
--- a/tests/lib/c_lib/strerror/src/main.c
+++ b/tests/lib/c_lib/strerror/src/main.c
@@ -55,46 +55,4 @@ ZTEST(libc_strerror, test_strerror)
 	}
 }
 
-ZTEST(libc_strerror, test_strerror_r)
-{
-	const char *expected;
-	char actual[] = {'1', 'n', 'v', 'a', '1', '1', 'd', ' ',  'a',
-			 '2', 'g', 'u', 'm', '3', 'n', '7', 0x00, 0x42};
-	static const size_t n = sizeof(actual);
-
-	if (IS_ENABLED(CONFIG_NEWLIB_LIBC) || IS_ENABLED(CONFIG_ARCMWDT_LIBC)) {
-		/* FIXME: Please see Issue #46846 */
-		ztest_test_skip();
-	}
-
-	errno = 4242;
-	if (IS_ENABLED(CONFIG_MINIMAL_LIBC_DISABLE_STRING_ERROR_TABLE)) {
-		expected = "";
-		zassert_equal(0, strerror_r(EINVAL, actual, n), "");
-		zassert_equal(0, strncmp(expected, actual, n),
-			      "mismatch: exp: %s act: %s", expected, actual);
-	} else {
-		expected = "Invalid argument";
-		zassert_equal(0, strerror_r(EINVAL, actual, n), "%d",
-			      strerror_r(EINVAL, actual, n));
-		zassert_equal(0, strncmp(expected, actual, n),
-			      "mismatch: exp: %s act: %s", expected, actual);
-		/* only the necessary buffer area is written */
-		zassert_equal(0x42, (uint8_t)actual[n - 1],
-			      "exp: %02x act: %02x", 0x42,
-			      (uint8_t)actual[n - 1]);
-
-		zassert_equal(ERANGE, strerror_r(EINVAL, actual, 0), "");
-	}
-
-	/* do not change errno on success */
-	zassert_equal(4242, errno, "");
-
-	errno = 0;
-	zassert_equal(EINVAL, strerror_r(-42, actual, n), "");
-	zassert_equal(EINVAL, strerror_r(4242, actual, n), "");
-	/* do not change errno on failure */
-	zassert_equal(0, errno, "");
-}
-
 ZTEST_SUITE(libc_strerror, NULL, NULL, NULL, NULL, NULL);

--- a/west.yml
+++ b/west.yml
@@ -310,7 +310,7 @@ manifest:
         - debug
     - name: picolibc
       path: modules/lib/picolibc
-      revision: 1a5c603b9f8e228f9459bdafedad15ea28efc700
+      revision: 764ef4e401a8f4c6a86ab723533841f072885a5b
     - name: segger
       revision: 9d0191285956cef43daf411edc2f1a7788346def
       path: modules/debug/segger


### PR DESCRIPTION
The associated sdk-ng PR is https://github.com/zephyrproject-rtos/sdk-ng/pull/728