### PR TITLE
tests: lib: devicetree: api: fix reg addr mismatch for test-mtd@ffeeddcc

### DIFF
--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -669,7 +669,7 @@
 		};
 
 		test-mtd@ffeeddcc {
-			reg = < 0x0 0x1000 >;
+			reg = < 0xffeeddcc 0x1000 >;
 			#address-cells = < 1 >;
 			#size-cells = < 1 >;
 


### PR DESCRIPTION
Fix unit address and first address in 'reg' (0x0) don't match for /test/test-mtd@ffeeddcc.