### PR TITLE
net: change `net_time_t` defined type.

### DIFF
--- a/include/zephyr/net/net_time.h
+++ b/include/zephyr/net/net_time.h
@@ -30,14 +30,7 @@ extern "C" {
 
 /**
  * @brief Any occurrence of net_time_t specifies a concept of nanosecond
- * resolution scalar time span, future (positive) or past (negative) relative
- * time or absolute timestamp referred to some local network uptime reference
- * clock that does not wrap during uptime and is - in a certain, well-defined
- * sense - common to all local network interfaces, sometimes even to remote
- * interfaces on the same network.
- *
- * This type is EXPERIMENTAL. Usage is currently restricted to representation of
- * time within the network subsystem.
+ * resolution scalar time span.
  *
  * @details Timed network protocols (PTP, TDMA, ...) usually require several
  * local or remote interfaces to share a common notion of elapsed time within
@@ -50,66 +43,19 @@ extern "C" {
  * signal. Be aware that while syntonized clocks share the same frequency and
  * phase, they do not usually share the same epoch (zero-point).
  *
- * This also explains why network time, if represented as a cycle value of some
- * specific hardware counter, will never be "precise" but only can be "good
- * enough" with respect to the tolerances (resolution, drift, jitter) required
- * by a given network protocol. All counter peripherals involved in a timed
- * network protocol must comply with these tolerances.
- *
- * Please use specific cycle/tick counter values rather than net_time_t whenever
- * possible especially when referring to the kernel system clock or values of
- * any single counter peripheral.
- *
- * net_time_t cannot represent general clocks referred to an arbitrary epoch as
- * it only covers roughly +/- ~290 years. It also cannot be used to represent
- * time according to a more complex timescale (e.g. including leap seconds, time
- * adjustments, complex calendars or time zones). In these cases you may use
- * @ref timespec (C11, POSIX.1-2001), @ref timeval (POSIX.1-2001) or broken down
- * time as in @ref tm (C90). The advantage of net_time_t over these structured
- * time representations is lower memory footprint, faster and simpler scalar
- * arithmetics and easier conversion from/to low-level hardware counter values.
- * Also net_time_t can be used in the network stack as well as in applications
- * while POSIX concepts cannot. Converting net_time_t from/to structured time
- * representations is possible in a limited way but - except for @ref timespec -
- * requires concepts that must be implemented by higher-level APIs. Utility
- * functions converting from/to @ref timespec will be provided as part of the
- * net_time_t API as and when needed.
- *
- * If you want to represent more coarse grained scalar time in network
- * applications, use @ref time_t (C99, POSIX.1-2001) which is specified to
- * represent seconds or @ref suseconds_t (POSIX.1-2001) for microsecond
- * resolution. Kernel @ref k_ticks_t and cycles (both specific to Zephyr) have
- * an unspecified resolution but are useful to represent kernel timer values and
- * implement high resolution spinning.
- *
- * If you need even finer grained time resolution, you may want to look at
- * (g)PTP concepts, see @ref net_ptp_extended_time.
- *
- * The reason why we don't use int64_t directly to represent scalar nanosecond
- * resolution times in the network stack is that it has been shown in the past
- * that fields using generic type will often not be used correctly (e.g. with
- * the wrong resolution or to represent underspecified concepts of time with
- * unclear syntonization semantics).
- *
- * Any API that exposes or consumes net_time_t values SHALL ensure that it
- * maintains the specified contract including all protocol specific tolerances
- * and therefore clients can rely on common semantics of this type. This makes
- * times coming from different hardware peripherals and even from different
- * network nodes comparable within well-defined limits and therefore net_time_t
- * is the ideal intermediate building block for timed network protocols.
  */
-typedef int64_t net_time_t;
+typedef uint64_t net_time_t;
 
-/** The largest positive time value that can be represented by net_time_t */
-#define NET_TIME_MAX INT64_MAX
+/** The largest time value that can be represented by net_time_t */
+#define NET_TIME_MAX UINT64_MAX
 
-/** The smallest negative time value that can be represented by net_time_t */
-#define NET_TIME_MIN INT64_MIN
+/** The smallest time value that can be represented by net_time_t */
+#define NET_TIME_MIN 0
 
-/** The largest positive number of seconds that can be safely represented by net_time_t */
+/** The largest number of seconds that can be safely represented by net_time_t */
 #define NET_TIME_SEC_MAX (NET_TIME_MAX / NSEC_PER_SEC)
 
-/** The smallest negative number of seconds that can be safely represented by net_time_t */
+/** The smallest number of seconds that can be safely represented by net_time_t */
 #define NET_TIME_SEC_MIN (NET_TIME_MIN / NSEC_PER_SEC)
 
 #ifdef __cplusplus

--- a/include/zephyr/net/ptp_time.h
+++ b/include/zephyr/net/ptp_time.h
@@ -200,7 +200,7 @@ static inline net_time_t net_ptp_time_to_ns(struct net_ptp_time *ts)
 		return NET_TIME_MAX;
 	}
 
-	return ((int64_t)ts->second * NSEC_PER_SEC) + ts->nanosecond;
+	return ((net_time_t)ts->second * NSEC_PER_SEC) + ts->nanosecond;
 }
 
 /**
@@ -214,8 +214,6 @@ static inline net_time_t net_ptp_time_to_ns(struct net_ptp_time *ts)
 static inline struct net_ptp_time ns_to_net_ptp_time(net_time_t nsec)
 {
 	struct net_ptp_time ts;
-
-	__ASSERT_NO_MSG(nsec >= 0);
 
 	ts.second = nsec / NSEC_PER_SEC;
 	ts.nanosecond = nsec % NSEC_PER_SEC;

--- a/modules/openthread/platform/radio.c
+++ b/modules/openthread/platform/radio.c
@@ -313,7 +313,6 @@ static net_time_t convert_32bit_us_wrapped_to_64bit_ns(uint32_t target_time_us_w
 		}
 	}
 
-	__ASSERT_NO_MSG(result <= INT64_MAX / NSEC_PER_USEC);
 	return (net_time_t)result * NSEC_PER_USEC;
 }
 #endif /* CONFIG_NET_PKT_TXTIME || CONFIG_OPENTHREAD_CSL_RECEIVER */

--- a/tests/subsys/openthread/radio_test.c
+++ b/tests/subsys/openthread/radio_test.c
@@ -46,7 +46,7 @@ FAKE_VALUE_FUNC(int, set_channel_mock, const struct device *, uint16_t);
 FAKE_VALUE_FUNC(int, filter_mock, const struct device *, bool, enum ieee802154_filter_type,
 		const struct ieee802154_filter *);
 FAKE_VALUE_FUNC(int, set_txpower_mock, const struct device *, int16_t);
-FAKE_VALUE_FUNC(int64_t, get_time_mock, const struct device *);
+FAKE_VALUE_FUNC(net_time_t, get_time_mock, const struct device *);
 FAKE_VALUE_FUNC(int, tx_mock, const struct device *, enum ieee802154_tx_mode, struct net_pkt *,
 		struct net_buf *);
 FAKE_VALUE_FUNC(int, start_mock, const struct device *);


### PR DESCRIPTION
Commit changes `net_time_t` to `uint64_t` and adjust related defines. The reason for this change is that in whole Zephyr time is fedined as unsigned integers.