### PR TITLE
fs: possibility to mount filesystems earlier

### DIFF
--- a/subsys/fs/Kconfig
+++ b/subsys/fs/Kconfig
@@ -43,6 +43,14 @@ config FILE_SYSTEM_MAX_FILE_NAME
 	  supported by a file system may result in memory access
 	  violations.
 
+config FILE_SYSTEM_INIT_PRIORITY
+	int "File system initialization priority"
+	default 99
+	help
+	  Specify the initialization priority for file systems. In case
+	  automount is enabled, the initialization should be done after
+	  the underlying storage device is initialized.
+
 config FILE_SYSTEM_SHELL
 	bool "File system shell"
 	depends on SHELL

--- a/subsys/fs/fat_fs.c
+++ b/subsys/fs/fat_fs.c
@@ -527,4 +527,4 @@ static int fatfs_init(void)
 	return fs_register(FS_FATFS, &fatfs_fs);
 }
 
-SYS_INIT(fatfs_init, POST_KERNEL, 99);
+SYS_INIT(fatfs_init, POST_KERNEL, CONFIG_FILE_SYSTEM_INIT_PRIORITY);

--- a/subsys/fs/fs.c
+++ b/subsys/fs/fs.c
@@ -22,10 +22,10 @@
 LOG_MODULE_REGISTER(fs);
 
 /* list of mounted file systems */
-static sys_dlist_t fs_mnt_list;
+static sys_dlist_t fs_mnt_list = SYS_DLIST_STATIC_INIT(&fs_mnt_list);
 
 /* lock to protect mount list operations */
-static struct k_mutex mutex;
+static K_MUTEX_DEFINE(mutex);
 
 /* Maps an identifier used in mount points to the file system
  * implementation.
@@ -875,12 +875,3 @@ int fs_unregister(int type, const struct fs_file_system_t *fs)
 	LOG_DBG("fs unregister %d: %d", type, rc);
 	return rc;
 }
-
-static int fs_init(void)
-{
-	k_mutex_init(&mutex);
-	sys_dlist_init(&fs_mnt_list);
-	return 0;
-}
-
-SYS_INIT(fs_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/subsys/fs/littlefs_fs.c
+++ b/subsys/fs/littlefs_fs.c
@@ -1098,4 +1098,4 @@ static int littlefs_init(void)
 	return rc;
 }
 
-SYS_INIT(littlefs_init, POST_KERNEL, 99);
+SYS_INIT(littlefs_init, POST_KERNEL, CONFIG_FILE_SYSTEM_INIT_PRIORITY);


### PR DESCRIPTION
https://github.com/zephyrproject-rtos/zephyr/pull/29907 changed the file system initialization to happen with POST_KERNEL/99 priority quite time ago.

Sometimes that is too late. For instance, a driver might want to access some data from the file system. So change the file system initialization to be configurable.