### PR TITLE
drivers: gnss: quectel_lcx6g: fix compilation error when CONFIG_PM_DEVICE=y

### DIFF
--- a/drivers/gnss/gnss_quectel_lcx6g.c
+++ b/drivers/gnss/gnss_quectel_lcx6g.c
@@ -211,7 +211,7 @@ static int quectel_lcx6g_suspend(const struct device *dev)
 	struct quectel_lcx6g_data *data = dev->data;
 	int ret;
 
-	ret = modem_chat_run_script_run(&data->chat, &suspend_script);
+	ret = modem_chat_run_script(&data->chat, &suspend_script);
 	if (ret < 0) {
 		modem_pipe_close(data->uart_pipe);
 	}


### PR DESCRIPTION
Fixes a compilation error in quectel_lcx6g driver when `CONFIG_PM_DEVICE=y`.
Corrects the function call in `quectel_lcx6g_suspend` from `modem_chat_run_script_run` to `modem_chat_run_script`.