### PR TITLE
stm32g0: add fdcan2 in dts file

### DIFF
--- a/boards/arm/nucleo_g0b1re/doc/index.rst
+++ b/boards/arm/nucleo_g0b1re/doc/index.rst
@@ -108,7 +108,7 @@ The Zephyr nucleo_g0b1re board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | die-temp  | on-chip    | die temperature sensor              |
 +-----------+------------+-------------------------------------+
-| FDCAN1    | on-chip    | CAN controller                      |
+| FDCAN     | on-chip    | CAN controller                      |
 +-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported in this Zephyr port.
@@ -140,6 +140,7 @@ Default Zephyr Peripheral Mapping:
 - ADC1 IN1  : PA1
 - DAC1_OUT1 : PA4
 - FDCAN1 RX/TX: PA11/PA12
+- FDCAN2 RX/TX: PB0/PB1
 
 For more details please refer to `STM32 Nucleo-64 board User Manual`_.
 

--- a/boards/arm/nucleo_g0b1re/nucleo_g0b1re.dts
+++ b/boards/arm/nucleo_g0b1re/nucleo_g0b1re.dts
@@ -187,6 +187,16 @@ zephyr_udc0: &usb {
 	status = "okay";
 };
 
+&fdcan2 {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00001000>,
+		 <&rcc STM32_SRC_PLL_Q FDCAN_SEL(1)>;
+	pinctrl-0 = <&fdcan2_rx_pb0 &fdcan2_tx_pb1>;
+	pinctrl-names = "default";
+	bus-speed = <125000>;
+	bus-speed-data = <1000000>;
+	status = "okay";
+};
+
 &flash0 {
 	partitions {
 		compatible = "fixed-partitions";

--- a/boards/arm/nucleo_g0b1re/nucleo_g0b1re.yaml
+++ b/boards/arm/nucleo_g0b1re/nucleo_g0b1re.yaml
@@ -14,6 +14,7 @@ supported:
   - arduino_i2c
   - arduino_spi
   - arduino_serial
+  - can
   - uart
   - gpio
   - i2c

--- a/dts/arm/st/g0/stm32g0b1.dtsi
+++ b/dts/arm/st/g0/stm32g0b1.dtsi
@@ -43,6 +43,19 @@
 			status = "disabled";
 		};
 
+		fdcan2: can@40006800 {
+			compatible = "st,stm32-fdcan";
+			reg = <0x40006800 0x400>, <0x4000b750 0x350>;
+			reg-names = "m_can", "message_ram";
+			interrupts = <21 0>, <22 0>;
+			interrupt-names = "int0", "int1";
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00001000>;
+			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
+			sample-point = <875>;
+			sample-point-data = <875>;
+			status = "disabled";
+		};
+
 		usart5: serial@40005000 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40005000 0x400>;

--- a/soc/arm/st_stm32/stm32g0/Kconfig.defconfig.stm32g0b1xx
+++ b/soc/arm/st_stm32/stm32g0/Kconfig.defconfig.stm32g0b1xx
@@ -11,4 +11,11 @@ config SOC
 config NUM_IRQS
 	default 31
 
+if CAN_STM32_FDCAN
+
+config SHARED_INTERRUPTS
+	default y if $(dt_nodelabel_enabled,fdcan1) && $(dt_nodelabel_enabled,fdcan2)
+
+endif # CAN_STM32_FDCAN
+
 endif # SOC_STM32G0B1XX


### PR DESCRIPTION
Hello,

Following my recent [opened discussion](https://github.com/zephyrproject-rtos/zephyr/discussions/67444), I have tried to deal with the dual can controller of the stm32g0.

Right now, it is not supported, however, it seems very small changes are needed to make it work.

STM32G0 shares the same interrupt line for both its CAN controllers and about a year ago, the shared interrupt line had been added (see [shared interrupt PR](https://github.com/zephyrproject-rtos/zephyr/pull/61422))

Another interesting information is about the driver itself, the can_stm32_fdcan.c implements a macro to generate fdcan instances based on all enabled fdcan controller nodes in dts that are with a status okay (see [macro](https://github.com/zephyrproject-rtos/zephyr/blob/04de43b1a119665532b6b2a0c6bbcbefd47eb7d6/drivers/can/can_stm32_fdcan.c#L689)).

So on my side, i've just added the fdcan2 for the stm32g0 in the stm32g0b1.dtsi and also on the nucleo_g0b1re board with appropriate pinout. 

To test my setup, I have used the nucleo_g0b1re board with 2 external transceivers on a breadboard to set up a communication between fdcan1 and fdcan2. I used a PEAK CAN probe to check frames are well physically transferred from one to another.
I have tested only fdcan1, then only fdcan2, then both, it seems to work great !

Right now, there is no sample program from zephyr ready to go with this configuration so I had to update the counter example for my needs and I'm definitely not sure it is absolutely needed.

Important note on this modification. In the nucleo_g0b1re dts file, I have added the fdcan2 node with the correct pinout. However, fdcan2 is disabled by default whereas fdcan1 is enabled. 

If you enable fdcan1 and fdcan2, you will get this error:

```
[151/155] Generating isr_tables.c
FAILED: zephyr/isr_tables.c .../build/zephyr/isr_tables.c 
[...]
gen_isr_tables.py: error: multiple registrations at table_index 22 for irq 22 (0x16)
Existing handler 0x8009c8b, new handler 0x8009c8b
Has IRQ_CONNECT or IRQ_DIRECT_CONNECT accidentally been invoked on the same irq multiple times?
```

You must add the `CONFIG_SHARED_INTERRUPT=y` flag to make it work. This could be confusing for anyone who is not familiar with the fact that stm32g0 fdcan controller is concerned about shared interrupt. 

I am not sure if the zephyr community wants to live with it, improve the comment above when the error is raised, add a specific paragraph in the nucleo_g0b1re doc page. Any feedback will be very appreciated.

Regards,
Adrien M.