### PR TITLE
net: lwm2m: Fix segfault on failed bootstrap

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -645,7 +645,7 @@ cleanup:
  */
 static void hint_socket_state(struct lwm2m_ctx *ctx, struct lwm2m_message *ongoing_tx)
 {
-	if (!ctx->set_socket_state) {
+	if (!ctx || !ctx->set_socket_state) {
 		return;
 	}
 


### PR DESCRIPTION
If bootstrap fails, RD client will call lwm2m_engine_stop() which will close the context.
The socket loop, however still contains a call to
hint_socket_state(context, NULL) which has a null pointer now.

Fix the segfault by allowing nullpointer on hint_socket_state().