### PR TITLE
scripts: zephyr_module: Add URL, PURL and version to SPDX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1621,9 +1621,8 @@ if(CONFIG_BUILD_OUTPUT_BIN AND CONFIG_BUILD_OUTPUT_UF2)
   set(BYPRODUCT_KERNEL_UF2_NAME "${PROJECT_BINARY_DIR}/${KERNEL_UF2_NAME}" CACHE FILEPATH "Kernel uf2 file" FORCE)
 endif()
 
+set(KERNEL_META_PATH  ${PROJECT_BINARY_DIR}/${KERNEL_META_NAME} CACHE INTERNAL "")
 if(CONFIG_BUILD_OUTPUT_META)
-  set(KERNEL_META_PATH  ${PROJECT_BINARY_DIR}/${KERNEL_META_NAME} CACHE INTERNAL "")
-
   list(APPEND
     post_build_commands
     COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/zephyr_module.py
@@ -1637,6 +1636,9 @@ if(CONFIG_BUILD_OUTPUT_META)
     post_build_byproducts
     ${KERNEL_META_PATH}
   )
+else(CONFIG_BUILD_OUTPUT_META)
+  # Prevent spdx to use invalid data
+  file(REMOVE ${KERNEL_META_PATH})
 endif()
 
 # Cleanup intermediate files

--- a/scripts/west_commands/zspdx/datatypes.py
+++ b/scripts/west_commands/zspdx/datatypes.py
@@ -68,6 +68,18 @@ class PackageConfig:
         # SPDX ID, including "SPDXRef-"
         self.spdxID = ""
 
+        # package URL
+        self.url = ""
+
+        # package version
+        self.version = ""
+
+        # package revision
+        self.revision = ""
+
+        # package external references
+        self.externalReferences = []
+
         # the Package's declared license
         self.declaredLicense = "NOASSERTION"
 

--- a/scripts/west_commands/zspdx/writer.py
+++ b/scripts/west_commands/zspdx/writer.py
@@ -8,6 +8,15 @@ from west import log
 
 from zspdx.util import getHashes
 
+import re
+
+CPE23TYPE_REGEX = (
+    r'^cpe:2\.3:[aho\*\-](:(((\?*|\*?)([a-zA-Z0-9\-\._]|(\\[\\\*\?!"#$$%&\'\(\)\+,\/:;<=>@\[\]\^'
+    r"`\{\|}~]))+(\?*|\*?))|[\*\-])){5}(:(([a-zA-Z]{2,3}(-([a-zA-Z]{2}|[0-9]{3}))?)|[\*\-]))(:(((\?*"
+    r'|\*?)([a-zA-Z0-9\-\._]|(\\[\\\*\?!"#$$%&\'\(\)\+,\/:;<=>@\[\]\^`\{\|}~]))+(\?*|\*?))|[\*\-])){4}$'
+)
+PURL_REGEX = r"^pkg:.+(\/.+)?\/.+(@.+)?(\?.+)?(#.+)?$"
+
 # Output tag-value SPDX 2.2 content for the given Relationship object.
 # Arguments:
 #   1) f: file handle for SPDX document
@@ -51,12 +60,29 @@ def writePackageSPDX(f, pkg):
 
 PackageName: {pkg.cfg.name}
 SPDXID: {pkg.cfg.spdxID}
-PackageDownloadLocation: NOASSERTION
 PackageLicenseConcluded: {pkg.concludedLicense}
 """)
     f.write(f"""PackageLicenseDeclared: {pkg.cfg.declaredLicense}
 PackageCopyrightText: {pkg.cfg.copyrightText}
 """)
+
+    if len(pkg.cfg.url) > 0:
+        f.write(f"PackageDownloadLocation: {pkg.cfg.url}\n")
+    else:
+        f.write("PackageDownloadLocation: NOASSERTION\n")
+
+    if len(pkg.cfg.version) > 0:
+        f.write(f"PackageVersion: {pkg.cfg.version}\n")
+    elif len(pkg.cfg.revision) > 0:
+        f.write(f"PackageVersion: {pkg.cfg.revision}\n")
+
+    for ref in pkg.cfg.externalReferences:
+        if re.fullmatch(CPE23TYPE_REGEX, ref):
+            f.write(f"ExternalRef: SECURITY cpe23Type {ref}\n")
+        elif re.fullmatch(PURL_REGEX, ref):
+            f.write(f"ExternalRef: PACKAGE_MANAGER purl {ref}\n")
+        else:
+            log.wrn(f"Unknown external reference ({ref})")
 
     # flag whether files analyzed / any files present
     if len(pkg.files) > 0:


### PR DESCRIPTION
Improve the SPDX with the current values:
 - URL: extracted from `git remote`. If more than one remote, URL is not set.
 - Version: extracted from `git rev-parse` (commit id).
 - PURL: generated from URL and Version.

For zephyr, the tag is extracted, if present, and replace the commit id for the version field.
Since official modules does not have tags, tags are not yet extracted for modules.

This PR follows this [issue](https://github.com/zephyrproject-rtos/zephyr/issues/53479) and PR #66182 and #66495.