### PR TITLE
Bluetooth: Mesh: Send generic provisioning PDUs with randomized delay 

### DIFF
--- a/subsys/bluetooth/mesh/adv.c
+++ b/subsys/bluetooth/mesh/adv.c
@@ -76,7 +76,7 @@ void bt_mesh_adv_send_start(uint16_t duration, int err, struct bt_mesh_adv_ctx *
 	}
 }
 
-static void bt_mesh_adv_send_end(int err, struct bt_mesh_adv_ctx const *ctx)
+void bt_mesh_adv_send_end(int err, struct bt_mesh_adv_ctx const *ctx)
 {
 	if (ctx->started && ctx->cb && ctx->cb->end) {
 		ctx->cb->end(err, ctx->cb_data);
@@ -136,7 +136,6 @@ void bt_mesh_adv_unref(struct bt_mesh_adv *adv)
 	}
 
 	struct k_mem_slab *slab = &local_adv_pool;
-	struct bt_mesh_adv_ctx ctx = adv->ctx;
 
 #if defined(CONFIG_BT_MESH_RELAY)
 	if (adv->ctx.tag == BT_MESH_ADV_TAG_RELAY) {
@@ -151,7 +150,6 @@ void bt_mesh_adv_unref(struct bt_mesh_adv *adv)
 #endif
 
 	k_mem_slab_free(slab, (void *)adv);
-	bt_mesh_adv_send_end(0, &ctx);
 }
 
 struct bt_mesh_adv *bt_mesh_adv_create(enum bt_mesh_adv_type type,

--- a/subsys/bluetooth/mesh/adv.h
+++ b/subsys/bluetooth/mesh/adv.h
@@ -76,6 +76,7 @@ struct bt_mesh_adv *bt_mesh_adv_create(enum bt_mesh_adv_type type,
 
 void bt_mesh_adv_send(struct bt_mesh_adv *adv, const struct bt_mesh_send_cb *cb,
 		      void *cb_data);
+void bt_mesh_adv_send_end(int err, struct bt_mesh_adv_ctx const *ctx);
 
 struct bt_mesh_adv *bt_mesh_adv_get(k_timeout_t timeout);
 

--- a/subsys/bluetooth/mesh/adv.h
+++ b/subsys/bluetooth/mesh/adv.h
@@ -101,7 +101,7 @@ void bt_mesh_adv_local_ready(void);
 
 void bt_mesh_adv_relay_ready(void);
 
-void bt_mesh_adv_terminate(struct bt_mesh_adv *adv);
+int bt_mesh_adv_terminate(struct bt_mesh_adv *adv);
 
 void bt_mesh_adv_friend_ready(void);
 

--- a/subsys/bluetooth/mesh/adv_ext.c
+++ b/subsys/bluetooth/mesh/adv_ext.c
@@ -259,7 +259,12 @@ static void send_pending_adv(struct k_work *work)
 		atomic_clear_bit(ext_adv->flags, ADV_FLAG_PROXY_START);
 
 		if (ext_adv->adv) {
+			struct bt_mesh_adv_ctx ctx = ext_adv->adv->ctx;
+
+			ext_adv->adv->ctx.started = 0;
 			bt_mesh_adv_unref(ext_adv->adv);
+			bt_mesh_adv_send_end(0, &ctx);
+
 			ext_adv->adv = NULL;
 		}
 

--- a/subsys/bluetooth/mesh/adv_ext.c
+++ b/subsys/bluetooth/mesh/adv_ext.c
@@ -370,7 +370,7 @@ void bt_mesh_adv_friend_ready(void)
 	}
 }
 
-void bt_mesh_adv_terminate(struct bt_mesh_adv *adv)
+int bt_mesh_adv_terminate(struct bt_mesh_adv *adv)
 {
 	int err;
 
@@ -382,13 +382,13 @@ void bt_mesh_adv_terminate(struct bt_mesh_adv *adv)
 		}
 
 		if (!atomic_test_bit(ext_adv->flags, ADV_FLAG_ACTIVE)) {
-			return;
+			return 0;
 		}
 
 		err = bt_le_ext_adv_stop(ext_adv->instance);
 		if (err) {
 			LOG_ERR("Failed to stop adv %d", err);
-			return;
+			return err;
 		}
 
 		/* Do not call `cb:end`, since this user action */
@@ -398,8 +398,10 @@ void bt_mesh_adv_terminate(struct bt_mesh_adv *adv)
 
 		k_work_submit(&ext_adv->work);
 
-		return;
+		return 0;
 	}
+
+	return -EINVAL;
 }
 
 void bt_mesh_adv_init(void)

--- a/subsys/bluetooth/mesh/adv_legacy.c
+++ b/subsys/bluetooth/mesh/adv_legacy.c
@@ -214,9 +214,11 @@ void bt_mesh_adv_gatt_update(void)
 	bt_mesh_adv_get_cancel();
 }
 
-void bt_mesh_adv_terminate(struct bt_mesh_adv *adv)
+int bt_mesh_adv_terminate(struct bt_mesh_adv *adv)
 {
 	ARG_UNUSED(adv);
+
+	return 0;
 }
 
 void bt_mesh_adv_init(void)

--- a/subsys/bluetooth/mesh/adv_legacy.c
+++ b/subsys/bluetooth/mesh/adv_legacy.c
@@ -182,7 +182,11 @@ static void adv_thread(void *p1, void *p2, void *p3)
 			adv_send(adv);
 		}
 
+		struct bt_mesh_adv_ctx ctx = adv->ctx;
+
+		adv->ctx.started = 0;
 		bt_mesh_adv_unref(adv);
+		bt_mesh_adv_send_end(0, &ctx);
 
 		/* Give other threads a chance to run */
 		k_yield();


### PR DESCRIPTION
This implements the following statement from the section 5.3.3:
> Each Generic Provisioning PDU shall be sent after a random delay between
20 and 50 milliseconds.

MESH/NODE/PROV PTS tests pass.