### PR TITLE
LE Audio shell better LTV prints

### DIFF
--- a/doc/connectivity/bluetooth/api/shell/bap.rst
+++ b/doc/connectivity/bluetooth/api/shell/bap.rst
@@ -164,54 +164,52 @@ Example Broadcast Sink
 **********************
 
 Scan for and establish a broadcast sink stream.
-The command :code:`bap create_broadcast_sink 0xEF6716` will either use existing periodic advertising
-sync (if exist) or start scanning and sync to the periodic advertising before syncing to the BIG.
+The command :code:`bap create_broadcast_sink` will either use existing periodic advertising
+sync (if exist) or start scanning and sync to the periodic advertising with the provided broadcast
+ID before syncing to the BIG.
 
 .. code-block:: console
 
    uart:~$ bap init
-   uart:~$ bap broadcast_scan on
-   Found broadcaster with ID 0xEF6716 and addr 3D:A5:F9:35:0B:19 (random) and sid 0x00
    uart:~$ bap create_broadcast_sink 0xEF6716
+   No PA sync available, starting scanning for broadcast_id
+   Found broadcaster with ID 0xEF6716 and addr 03:47:95:75:C0:08 (random) and sid 0x00
    Attempting to PA sync to the broadcaster
    PA synced to broadcast with broadcast ID 0xEF6716
    Attempting to sync to the BIG
-   Received BASE from sink 0x20031fac:
+   Received BASE from sink 0x20019080:
    Presentation delay: 40000
-   Subgroup count: 2
-   Subgroup[0]:
-   codec cfg id 0x06 cid 0x0000 vid 0x0000
-   data_count 4
-   data #0: type 0x01 len 1
-   00000000: 03                                               |.                |
-   data #1: type 0x02 len 1
-   00000000: 01                                               |.                |
-   data #2: type 0x03 len 4
-   00000000: 01 00 00 00                                      |....             |
-   data #3: type 0x04 len 2
-   00000000: 28 00                                            |(.               |
-   meta_count 4
-   meta #0: type 0x02 len 2
-   00000000: 01 00                                            |..               |
-      BIS[0] index 0x01
-   Subgroup[1]:
-   codec cfg id 0x06 cid 0x0000 vid 0x0000
-   data_count 4
-   data #0: type 0x01 len 1
-   00000000: 03                                               |.                |
-   data #1: type 0x02 len 1
-   00000000: 01                                               |.                |
-   data #2: type 0x03 len 4
-   00000000: 01 00 00 00                                      |....             |
-   data #3: type 0x04 len 2
-   00000000: 28 00                                            |(.               |
-   meta_count 4
-   meta #0: type 0x02 len 2
-   00000000: 01 00                                            |..               |
-      BIS[1] index 0x01
-   [0]: 0x01
-   [1]: 0x01
-   Possible indexes: 0x01 0x01
+   Subgroup count: 1
+   Subgroup 0x20024182:
+      Codec Format: 0x06
+      Company ID  : 0x0000
+      Vendor ID   : 0x0000
+      codec cfg id 0x06 cid 0x0000 vid 0x0000 count 16
+         Codec specific configuration:
+         Sampling frequency: 16000 Hz (3)
+         Frame duration: 10000 us (1)
+         Channel allocation:
+                  Front left (0x00000001)
+                  Front right (0x00000002)
+         Octets per codec frame: 40
+         Codec specific metadata:
+         Streaming audio contexts:
+            Unspecified (0x0001)
+         BIS index: 0x01
+            codec cfg id 0x06 cid 0x0000 vid 0x0000 count 6
+            Codec specific configuration:
+               Channel allocation:
+                  Front left (0x00000001)
+            Codec specific metadata:
+               None
+         BIS index: 0x02
+            codec cfg id 0x06 cid 0x0000 vid 0x0000 count 6
+            Codec specific configuration:
+               Channel allocation:
+                  Front right (0x00000002)
+            Codec specific metadata:
+               None
+   Possible indexes: 0x01 0x02
    Sink 0x20019110 is ready to sync without encryption
    uart:~$ bap sync_broadcast 0x01
 
@@ -280,20 +278,35 @@ characteristics representing remote endpoints.
    Exchange successful
    uart:~$ bap discover [type: sink, source]
    uart:~$ bap discover sink
-   cap 0x8175940 type 0x01
-   codec 0x06 cid 0x0000 vid 0x0000 count 4
-   data #0: type 0x01 len 1
-   00000000: 3f                                             |?                |
-   data #1: type 0x02 len 1
-   00000000: 03                                             |.                |
-   data #2: type 0x03 len 1
-   00000000: 03                                             |.                |
-   data #3: type 0x04 len 4
-   00000000: 1e 00 f0 00                                    |....             |
-   meta #0: type 0x01 len 2
-   00000000: 06 00                                          |..               |
-   meta #1: type 0x02 len 2
-   00000000: ff 03                                          |..               |
+   conn 0x2000b168: codec_cap 0x2001f8ec dir 0x02
+   codec cap id 0x06 cid 0x0000 vid 0x0000
+      Codec specific capabilities:
+         Supported sampling frequencies:
+            8000 Hz (0x0001)
+            11025 Hz (0x0002)
+            16000 Hz (0x0004)
+            22050 Hz (0x0008)
+            24000 Hz (0x0010)
+            32000 Hz (0x0020)
+            44100 Hz (0x0040)
+            48000 Hz (0x0080)
+            88200 Hz (0x0100)
+            96000 Hz (0x0200)
+            176400 Hz (0x0400)
+            192000 Hz (0x0800)
+            384000 Hz (0x1000)
+         Supported frame durations:
+            10 ms (0x02)
+         Supported channel counts:
+            1 channel (0x01)
+         Supported octets per codec frame counts:
+            Min: 40
+            Max: 120
+         Supported max codec frames per SDU: 1
+      Codec capabilities metadata:
+         Preferred audio contexts:
+            Converstation (0x0002)
+            Media (0x0004)
    ep 0x81754e0
    ep 0x81755d4
    Discover complete: err 0
@@ -329,29 +342,34 @@ any stream previously configured.
                   [vendor <meta>]]
    uart:~$ bap preset sink
    16_2_1
-   codec 0x06 cid 0x0000 vid 0x0000 count 4
-   data #0: type 0x01 len 1
-   data #1: type 0x02 len 1
-   data #2: type 0x03 len 4
-   00000000: 01 00 00                                         |...              |
-   data #3: type 0x04 len 2
-   00000000: 28                                               |(                |
-   meta #0: type 0x02 len 2
-   00000000: 06                                               |.                |
+   codec cfg id 0x06 cid 0x0000 vid 0x0000 count 16
+      Codec specific configuration:
+         Sampling frequency: 16000 Hz (3)
+         Frame duration: 10000 us (1)
+         Channel allocation:
+                     Front left (0x00000001)
+                     Front right (0x00000002)
+         Octets per codec frame: 40
+      Codec specific metadata:
+         Streaming audio contexts:
+            Game (0x0008)
    QoS: interval 10000 framing 0x00 phy 0x02 sdu 40 rtn 2 latency 10 pd 40000
 
    uart:~$ bap preset sink 32_2_1
    32_2_1
-   codec 0x06 cid 0x0000 vid 0x0000 count 4
-   data #0: type 0x01 len 1
-   data #1: type 0x02 len 1
-   data #2: type 0x03 len 4
-   00000000: 01 00 00                                         |...              |
-   data #3: type 0x04 len 2
-   00000000: 50                                               |P                |
-   meta #0: type 0x02 len 2
-   00000000: 06                                               |.                |
-   QoS: interval 10000 framing 0x00 phy 0x02 sdu 80 rtn 2 latency 10 pd 40000
+   codec cfg id 0x06 cid 0x0000 vid 0x0000 count 16
+      Codec specific configuration:
+         Sampling frequency: 32000 Hz (6)
+         Frame duration: 10000 us (1)
+         Channel allocation:
+                     Front left (0x00000001)
+                     Front right (0x00000002)
+         Octets per codec frame: 80
+      Codec specific metadata:
+         Streaming audio contexts:
+            Game (0x0008)
+      QoS: interval 10000 framing 0x00 phy 0x02 sdu 80 rtn 2 latency 10 pd 40000
+
 
 Configure preset
 ****************
@@ -427,19 +445,9 @@ or in case it is omitted the default preset is used.
 
    uart:~$ bap config <direction: sink, source> <index> [loc <loc_bits>] [preset <preset_name>]
    uart:~$ bap config sink 0
-   ASE Codec Config: conn 0x8173800 ep 0x81754e0 cap 0x816a360
-   codec 0x06 cid 0x0000 vid 0x0000 count 3
-   data #0: type 0x01 len 1
-   00000000: 02                                             |.                |
-   data #1: type 0x02 len 1
-   00000000: 01                                             |.                |
-   data #2: type 0x04 len 2
-   00000000: 28 00                                          |(.               |
-   meta #0: type 0x02 len 2
-   00000000: 02 00                                          |..               |
-   ASE Codec Config stream 0x8179e60
-   Default ase: 1
+   Setting location to 0x00000000
    ASE config: preset 16_2_1
+   stream 0x2000df70 config operation rsp_code 0 reason 0
 
 Configure Stream QoS
 ********************

--- a/subsys/bluetooth/audio/shell/audio.h
+++ b/subsys/bluetooth/audio/shell/audio.h
@@ -197,15 +197,172 @@ static void print_ltv_array(const struct shell *sh, const char *str, const uint8
 	bt_audio_data_parse(ltv_data, ltv_data_len, print_ltv_elem, &ltv_info);
 }
 
+static inline char *codec_cap_freq_bit_to_str(enum bt_audio_codec_cap_freq freq)
+{
+	switch (freq) {
+	case BT_AUDIO_CODEC_CAP_FREQ_8KHZ:
+		return "8000 Hz";
+	case BT_AUDIO_CODEC_CAP_FREQ_11KHZ:
+		return "11025 Hz";
+	case BT_AUDIO_CODEC_CAP_FREQ_16KHZ:
+		return "16000 Hz";
+	case BT_AUDIO_CODEC_CAP_FREQ_22KHZ:
+		return "22050 Hz";
+	case BT_AUDIO_CODEC_CAP_FREQ_24KHZ:
+		return "24000 Hz";
+	case BT_AUDIO_CODEC_CAP_FREQ_32KHZ:
+		return "32000 Hz";
+	case BT_AUDIO_CODEC_CAP_FREQ_44KHZ:
+		return "44100 Hz";
+	case BT_AUDIO_CODEC_CAP_FREQ_48KHZ:
+		return "48000 Hz";
+	case BT_AUDIO_CODEC_CAP_FREQ_88KHZ:
+		return "88200 Hz";
+	case BT_AUDIO_CODEC_CAP_FREQ_96KHZ:
+		return "96000 Hz";
+	case BT_AUDIO_CODEC_CAP_FREQ_176KHZ:
+		return "176400 Hz";
+	case BT_AUDIO_CODEC_CAP_FREQ_192KHZ:
+		return "192000 Hz";
+	case BT_AUDIO_CODEC_CAP_FREQ_384KHZ:
+		return "384000 Hz";
+	default:
+		return "Unknown supported frequency";
+	}
+}
+
+static inline void print_codec_cap_freq(const struct shell *sh, enum bt_audio_codec_cap_freq freq)
+{
+	shell_print(sh, "\tSupported sampling frequencies:");
+	/* There can be up to 16 bits set in the field */
+	for (size_t i = 0; i < 16; i++) {
+		const uint16_t bit_val = BIT(i);
+
+		if (freq & bit_val) {
+			shell_print(sh, "\t\t%s (0x%04X)", codec_cap_freq_bit_to_str(bit_val),
+				    bit_val);
+		}
+	}
+}
+
+static inline char *codec_cap_frame_dur_bit_to_str(enum bt_audio_codec_cap_frame_dur frame_dur)
+{
+	switch (frame_dur) {
+	case BT_AUDIO_CODEC_CAP_DURATION_7_5:
+		return "7.5 ms";
+	case BT_AUDIO_CODEC_CAP_DURATION_10:
+		return "10 ms";
+	case BT_AUDIO_CODEC_CAP_DURATION_PREFER_7_5:
+		return "7.5 ms preferred";
+	case BT_AUDIO_CODEC_CAP_DURATION_PREFER_10:
+		return "10 ms preferred";
+	default:
+		return "Unknown frame duration";
+	}
+}
+
+static inline void print_codec_cap_frame_dur(const struct shell *sh,
+					     enum bt_audio_codec_cap_frame_dur frame_dur)
+{
+	shell_print(sh, "\tSupported frame durations:");
+	/* There can be up to 8 bits set in the field */
+	for (size_t i = 0; i < 8; i++) {
+		const uint8_t bit_val = BIT(i);
+
+		if (frame_dur & bit_val) {
+			shell_print(sh, "\t\t%s (0x%02X)", codec_cap_frame_dur_bit_to_str(bit_val),
+				    bit_val);
+		}
+	}
+}
+
+static inline char *codec_cap_chan_count_bit_to_str(enum bt_audio_codec_cap_chan_count chan_count)
+{
+	switch (chan_count) {
+	case BT_AUDIO_CODEC_CAP_CHAN_COUNT_1:
+		return "1 channel";
+	case BT_AUDIO_CODEC_CAP_CHAN_COUNT_2:
+		return "2 channels";
+	case BT_AUDIO_CODEC_CAP_CHAN_COUNT_3:
+		return "3 channels";
+	case BT_AUDIO_CODEC_CAP_CHAN_COUNT_4:
+		return "4 channels";
+	case BT_AUDIO_CODEC_CAP_CHAN_COUNT_5:
+		return "5 channels";
+	case BT_AUDIO_CODEC_CAP_CHAN_COUNT_6:
+		return "6 channels";
+	case BT_AUDIO_CODEC_CAP_CHAN_COUNT_7:
+		return "7 channels";
+	case BT_AUDIO_CODEC_CAP_CHAN_COUNT_8:
+		return "8 channels";
+	default:
+		return "Unknown channel count";
+	}
+}
+
+static inline void print_codec_cap_chan_count(const struct shell *sh,
+					      enum bt_audio_codec_cap_chan_count chan_count)
+{
+	shell_print(sh, "\tSupported channel counts:");
+	/* There can be up to 8 bits set in the field */
+	for (size_t i = 0; i < 8; i++) {
+		const uint8_t bit_val = BIT(i);
+
+		if (chan_count & bit_val) {
+			shell_print(sh, "\t\t%s (0x%02X)", codec_cap_chan_count_bit_to_str(bit_val),
+				    bit_val);
+		}
+	}
+}
+
+static inline void print_codec_cap_octets_per_codec_frame(
+	const struct shell *sh, const struct bt_audio_codec_octets_per_codec_frame *codec_frame)
+{
+	shell_print(sh, "\tSupported octets per codec frame counts:\n\t\tMin: %u\n\t\tMax: %u",
+		    codec_frame->min, codec_frame->max);
+}
+
+static inline void print_codec_cap_max_codec_frames_per_sdu(const struct shell *sh,
+							    uint8_t codec_frames_per_sdu)
+{
+	shell_print(sh, "\tSupported max codec frames per SDU: %u", codec_frames_per_sdu);
+}
+
 static inline void print_codec_cap(const struct shell *sh,
 				   const struct bt_audio_codec_cap *codec_cap)
 {
-	shell_print(sh, "codec cap id 0x%02x cid 0x%04x vid 0x%04x count %u", codec_cap->id,
-		    codec_cap->cid, codec_cap->vid, codec_cap->data_len);
+	shell_print(sh, "codec cap id 0x%02x cid 0x%04x vid 0x%04x", codec_cap->id, codec_cap->cid,
+		    codec_cap->vid);
 
 #if CONFIG_BT_AUDIO_CODEC_CAP_MAX_DATA_SIZE > 0
 	if (codec_cap->id == BT_HCI_CODING_FORMAT_LC3) {
-		print_ltv_array(sh, "data", codec_cap->data, codec_cap->data_len);
+		struct bt_audio_codec_octets_per_codec_frame codec_frame;
+		int ret;
+
+		ret = bt_audio_codec_cap_get_freq(codec_cap);
+		if (ret >= 0) {
+			print_codec_cap_freq(sh, (enum bt_audio_codec_cap_freq)ret);
+		}
+
+		ret = bt_audio_codec_cap_get_frame_dur(codec_cap);
+		if (ret >= 0) {
+			print_codec_cap_frame_dur(sh, (enum bt_audio_codec_cap_frame_dur)ret);
+		}
+
+		ret = bt_audio_codec_cap_get_supported_audio_chan_counts(codec_cap);
+		if (ret >= 0) {
+			print_codec_cap_chan_count(sh, (enum bt_audio_codec_cap_chan_count)ret);
+		}
+
+		ret = bt_audio_codec_cap_get_octets_per_frame(codec_cap, &codec_frame);
+		if (ret >= 0) {
+			print_codec_cap_octets_per_codec_frame(sh, &codec_frame);
+		}
+
+		ret = bt_audio_codec_cap_get_max_codec_frames_per_sdu(codec_cap);
+		if (ret >= 0) {
+			print_codec_cap_max_codec_frames_per_sdu(sh, (uint8_t)ret);
+		}
 	} else { /* If not LC3, we cannot assume it's LTV */
 		shell_hexdump(sh, codec_cap->data, codec_cap->data_len);
 	}

--- a/subsys/bluetooth/audio/shell/audio.h
+++ b/subsys/bluetooth/audio/shell/audio.h
@@ -197,6 +197,202 @@ static void print_ltv_array(const struct shell *sh, const char *str, const uint8
 	bt_audio_data_parse(ltv_data, ltv_data_len, print_ltv_elem, &ltv_info);
 }
 
+static inline char *context_bit_to_str(enum bt_audio_context context)
+{
+	switch (context) {
+	case BT_AUDIO_CONTEXT_TYPE_PROHIBITED:
+		return "Prohibited";
+	case BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED:
+		return "Unspecified";
+	case BT_AUDIO_CONTEXT_TYPE_CONVERSATIONAL:
+		return "Converstation";
+	case BT_AUDIO_CONTEXT_TYPE_MEDIA:
+		return "Media";
+	case BT_AUDIO_CONTEXT_TYPE_GAME:
+		return "Game";
+	case BT_AUDIO_CONTEXT_TYPE_INSTRUCTIONAL:
+		return "Instructional";
+	case BT_AUDIO_CONTEXT_TYPE_VOICE_ASSISTANTS:
+		return "Voice assistant";
+	case BT_AUDIO_CONTEXT_TYPE_LIVE:
+		return "Live";
+	case BT_AUDIO_CONTEXT_TYPE_SOUND_EFFECTS:
+		return "Sound effects";
+	case BT_AUDIO_CONTEXT_TYPE_NOTIFICATIONS:
+		return "Notifications";
+	case BT_AUDIO_CONTEXT_TYPE_RINGTONE:
+		return "Ringtone";
+	case BT_AUDIO_CONTEXT_TYPE_ALERTS:
+		return "Alerts";
+	case BT_AUDIO_CONTEXT_TYPE_EMERGENCY_ALARM:
+		return "Emergency alarm";
+	default:
+		return "Unknown context";
+	}
+}
+
+static inline void print_codec_meta_pref_context(const struct shell *sh,
+						 enum bt_audio_context context)
+{
+	shell_print(sh, "\tPreferred audio contexts:");
+
+	/* There can be up to 16 bits set in the field */
+	for (size_t i = 0U; i < 16; i++) {
+		const uint16_t bit_val = BIT(i);
+
+		if (context & bit_val) {
+			shell_print(sh, "\t\t%s (0x%04X)", context_bit_to_str(bit_val), bit_val);
+		}
+	}
+}
+
+static inline void print_codec_meta_stream_context(const struct shell *sh,
+						   enum bt_audio_context context)
+{
+	shell_print(sh, "\tStreaming audio contexts:");
+
+	/* There can be up to 16 bits set in the field */
+	for (size_t i = 0U; i < 16; i++) {
+		const uint16_t bit_val = BIT(i);
+
+		if (context & bit_val) {
+			shell_print(sh, "\t\t%s (0x%04X)", context_bit_to_str(bit_val), bit_val);
+		}
+	}
+}
+
+static inline void print_codec_meta_program_info(const struct shell *sh,
+						 const uint8_t *program_info,
+						 uint8_t program_info_len)
+{
+	shell_fprintf(sh, SHELL_NORMAL, "\tProgram info:\n\t\t");
+
+	for (uint8_t i = 0U; i < program_info_len; i++) {
+		shell_fprintf(sh, SHELL_NORMAL, "%c", (char)program_info[i]);
+	}
+
+	shell_fprintf(sh, SHELL_NORMAL, "\n");
+}
+
+static inline void print_codec_meta_language(const struct shell *sh, uint32_t stream_lang)
+{
+	uint8_t lang_array[3];
+
+	sys_put_be24(stream_lang, lang_array);
+
+	shell_print(sh, "\tLanguage: %c%c%c", (char)lang_array[0], (char)lang_array[1],
+		    (char)lang_array[2]);
+}
+
+static inline void print_codec_meta_ccid_list(const struct shell *sh, const uint8_t *ccid_list,
+					      uint8_t ccid_list_len)
+{
+	shell_print(sh, "\tCCID list:\n");
+
+	/* There can be up to 16 bits set in the field */
+	for (uint8_t i = 0U; i < ccid_list_len; i++) {
+
+		shell_print(sh, "\t\t0x%02X ", ccid_list[i]);
+	}
+}
+
+static inline char *parental_rating_to_str(enum bt_audio_parental_rating parental_rating)
+{
+	switch (parental_rating) {
+	case BT_AUDIO_PARENTAL_RATING_NO_RATING:
+		return "No rating";
+	case BT_AUDIO_PARENTAL_RATING_AGE_ANY:
+		return "Any";
+	case BT_AUDIO_PARENTAL_RATING_AGE_5_OR_ABOVE:
+		return "Age 5 or above";
+	case BT_AUDIO_PARENTAL_RATING_AGE_6_OR_ABOVE:
+		return "Age 6 or above";
+	case BT_AUDIO_PARENTAL_RATING_AGE_7_OR_ABOVE:
+		return "Age 7 or above";
+	case BT_AUDIO_PARENTAL_RATING_AGE_8_OR_ABOVE:
+		return "Age 8 or above";
+	case BT_AUDIO_PARENTAL_RATING_AGE_9_OR_ABOVE:
+		return "Age 9 or above";
+	case BT_AUDIO_PARENTAL_RATING_AGE_10_OR_ABOVE:
+		return "Age 10 or above";
+	case BT_AUDIO_PARENTAL_RATING_AGE_11_OR_ABOVE:
+		return "Age 11 or above";
+	case BT_AUDIO_PARENTAL_RATING_AGE_12_OR_ABOVE:
+		return "Age 12 or above";
+	case BT_AUDIO_PARENTAL_RATING_AGE_13_OR_ABOVE:
+		return "Age 13 or above";
+	case BT_AUDIO_PARENTAL_RATING_AGE_14_OR_ABOVE:
+		return "Age 14 or above";
+	case BT_AUDIO_PARENTAL_RATING_AGE_15_OR_ABOVE:
+		return "Age 15 or above";
+	case BT_AUDIO_PARENTAL_RATING_AGE_16_OR_ABOVE:
+		return "Age 16 or above";
+	case BT_AUDIO_PARENTAL_RATING_AGE_17_OR_ABOVE:
+		return "Age 17 or above";
+	case BT_AUDIO_PARENTAL_RATING_AGE_18_OR_ABOVE:
+		return "Age 18 or above";
+	default:
+		return "Unknown rating";
+	}
+}
+
+static inline void print_codec_meta_parental_rating(const struct shell *sh,
+						    enum bt_audio_parental_rating parental_rating)
+{
+	shell_print(sh, "\tRating: %s (0x%02X)", parental_rating_to_str(parental_rating),
+		    (uint8_t)parental_rating);
+}
+
+static inline void print_codec_meta_program_info_uri(const struct shell *sh,
+						     const uint8_t *program_info_uri,
+						     uint8_t program_info_uri_len)
+{
+	shell_fprintf(sh, SHELL_NORMAL, "\tProgram info URI:\n\t\t");
+
+	for (uint8_t i = 0U; i < program_info_uri_len; i++) {
+		shell_fprintf(sh, SHELL_NORMAL, "%c", (char)program_info_uri[i]);
+	}
+
+	shell_fprintf(sh, SHELL_NORMAL, "\n");
+}
+
+static inline void print_codec_meta_audio_active_state(const struct shell *sh,
+						       enum bt_audio_active_state state)
+{
+	shell_print(sh, "\tAudio active state: %s (0x%02X)",
+		    state == BT_AUDIO_ACTIVE_STATE_ENABLED ? "enabled" : "disabled",
+		    (uint8_t)state);
+}
+
+static inline void print_codec_meta_bcast_audio_immediate_rend_flag(const struct shell *sh)
+{
+	shell_print(sh, "\tBroadcast audio immediate rendering flag set");
+}
+
+static inline void print_codec_meta_extended(const struct shell *sh, const uint8_t *extended_meta,
+					     size_t extended_meta_len)
+{
+	shell_fprintf(sh, SHELL_NORMAL, "\tExtended metadata:\n\t\t");
+
+	for (uint8_t i = 0U; i < extended_meta_len; i++) {
+		shell_fprintf(sh, SHELL_NORMAL, "%c", (char)extended_meta[i]);
+	}
+
+	shell_fprintf(sh, SHELL_NORMAL, "\n");
+}
+
+static inline void print_codec_meta_vendor(const struct shell *sh, const uint8_t *vendor_meta,
+					   size_t vender_meta_len)
+{
+	shell_fprintf(sh, SHELL_NORMAL, "\tVender metadata:\n\t\t");
+
+	for (uint8_t i = 0U; i < vender_meta_len; i++) {
+		shell_fprintf(sh, SHELL_NORMAL, "%c", (char)vendor_meta[i]);
+	}
+
+	shell_fprintf(sh, SHELL_NORMAL, "\n");
+}
+
 static inline char *codec_cap_freq_bit_to_str(enum bt_audio_codec_cap_freq freq)
 {
 	switch (freq) {
@@ -335,7 +531,10 @@ static inline void print_codec_cap(const struct shell *sh,
 		    codec_cap->vid);
 
 #if CONFIG_BT_AUDIO_CODEC_CAP_MAX_DATA_SIZE > 0
-	if (codec_cap->id == BT_HCI_CODING_FORMAT_LC3) {
+	shell_print(sh, "Codec specific capabilities:");
+	if (codec_cap->data_len == 0U) {
+		shell_print(sh, "\tNone");
+	} else if (codec_cap->id == BT_HCI_CODING_FORMAT_LC3) {
 		struct bt_audio_codec_octets_per_codec_frame codec_frame;
 		int ret;
 
@@ -369,7 +568,63 @@ static inline void print_codec_cap(const struct shell *sh,
 #endif /* CONFIG_BT_AUDIO_CODEC_CAP_MAX_DATA_SIZE > 0 */
 
 #if CONFIG_BT_AUDIO_CODEC_CAP_MAX_METADATA_SIZE > 0
-	print_ltv_array(sh, "meta", codec_cap->meta, codec_cap->meta_len);
+	shell_print(sh, "Codec specific metadata:");
+	if (codec_cap->meta_len == 0U) {
+		shell_print(sh, "\tNone");
+	} else {
+		const uint8_t *data;
+		int ret;
+
+		ret = bt_audio_codec_cap_meta_get_pref_context(codec_cap);
+		if (ret >= 0) {
+			print_codec_meta_pref_context(sh, (enum bt_audio_context)ret);
+		}
+
+		ret = bt_audio_codec_cap_meta_get_stream_context(codec_cap);
+		if (ret >= 0) {
+			print_codec_meta_stream_context(sh, (enum bt_audio_context)ret);
+		}
+
+		ret = bt_audio_codec_cap_meta_get_program_info(codec_cap, &data);
+		if (ret >= 0) {
+			print_codec_meta_program_info(sh, data, (uint8_t)ret);
+		}
+
+		ret = bt_audio_codec_cap_meta_get_stream_lang(codec_cap);
+		if (ret >= 0) {
+			print_codec_meta_language(sh, (uint32_t)ret);
+		}
+
+		ret = bt_audio_codec_cap_meta_get_ccid_list(codec_cap, &data);
+		if (ret >= 0) {
+			print_codec_meta_ccid_list(sh, data, (uint8_t)ret);
+		}
+
+		ret = bt_audio_codec_cap_meta_get_parental_rating(codec_cap);
+		if (ret >= 0) {
+			print_codec_meta_parental_rating(sh, (enum bt_audio_parental_rating)ret);
+		}
+
+		ret = bt_audio_codec_cap_meta_get_audio_active_state(codec_cap);
+		if (ret >= 0) {
+			print_codec_meta_audio_active_state(sh, (enum bt_audio_active_state)ret);
+		}
+
+		ret = bt_audio_codec_cap_meta_get_bcast_audio_immediate_rend_flag(codec_cap);
+		if (ret >= 0) {
+			print_codec_meta_bcast_audio_immediate_rend_flag(sh);
+		}
+
+		ret = bt_audio_codec_cap_meta_get_extended(codec_cap, &data);
+		if (ret >= 0) {
+			print_codec_meta_extended(sh, data, (uint8_t)ret);
+		}
+
+		ret = bt_audio_codec_cap_meta_get_vendor(codec_cap, &data);
+		if (ret >= 0) {
+			print_codec_meta_vendor(sh, data, (uint8_t)ret);
+		}
+	}
 #endif /* CONFIG_BT_AUDIO_CODEC_CAP_MAX_METADATA_SIZE > 0 */
 }
 
@@ -486,7 +741,10 @@ static inline void print_codec_cfg(const struct shell *sh,
 		    codec_cfg->cid, codec_cfg->vid, codec_cfg->data_len);
 
 #if CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0
-	if (codec_cfg->id == BT_HCI_CODING_FORMAT_LC3) {
+	shell_print(sh, "Codec specific configuration:");
+	if (codec_cfg->data_len == 0U) {
+		shell_print(sh, "\tNone");
+	} else if (codec_cfg->id == BT_HCI_CODING_FORMAT_LC3) {
 		enum bt_audio_location chan_allocation;
 		int ret;
 
@@ -520,7 +778,63 @@ static inline void print_codec_cfg(const struct shell *sh,
 #endif /* CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0 */
 
 #if CONFIG_BT_AUDIO_CODEC_CFG_MAX_METADATA_SIZE > 0
-	print_ltv_array(sh, "meta", codec_cfg->meta, codec_cfg->meta_len);
+	shell_print(sh, "Codec specific metadata:");
+	if (codec_cfg->meta_len == 0U) {
+		shell_print(sh, "\tNone");
+	} else {
+		const uint8_t *data;
+		int ret;
+
+		ret = bt_audio_codec_cfg_meta_get_pref_context(codec_cfg);
+		if (ret >= 0) {
+			print_codec_meta_pref_context(sh, (enum bt_audio_context)ret);
+		}
+
+		ret = bt_audio_codec_cfg_meta_get_stream_context(codec_cfg);
+		if (ret >= 0) {
+			print_codec_meta_stream_context(sh, (enum bt_audio_context)ret);
+		}
+
+		ret = bt_audio_codec_cfg_meta_get_program_info(codec_cfg, &data);
+		if (ret >= 0) {
+			print_codec_meta_program_info(sh, data, (uint8_t)ret);
+		}
+
+		ret = bt_audio_codec_cfg_meta_get_stream_lang(codec_cfg);
+		if (ret >= 0) {
+			print_codec_meta_language(sh, (uint32_t)ret);
+		}
+
+		ret = bt_audio_codec_cfg_meta_get_ccid_list(codec_cfg, &data);
+		if (ret >= 0) {
+			print_codec_meta_ccid_list(sh, data, (uint8_t)ret);
+		}
+
+		ret = bt_audio_codec_cfg_meta_get_parental_rating(codec_cfg);
+		if (ret >= 0) {
+			print_codec_meta_parental_rating(sh, (enum bt_audio_parental_rating)ret);
+		}
+
+		ret = bt_audio_codec_cfg_meta_get_audio_active_state(codec_cfg);
+		if (ret >= 0) {
+			print_codec_meta_audio_active_state(sh, (enum bt_audio_active_state)ret);
+		}
+
+		ret = bt_audio_codec_cfg_meta_get_bcast_audio_immediate_rend_flag(codec_cfg);
+		if (ret >= 0) {
+			print_codec_meta_bcast_audio_immediate_rend_flag(sh);
+		}
+
+		ret = bt_audio_codec_cfg_meta_get_extended(codec_cfg, &data);
+		if (ret >= 0) {
+			print_codec_meta_extended(sh, data, (uint8_t)ret);
+		}
+
+		ret = bt_audio_codec_cfg_meta_get_vendor(codec_cfg, &data);
+		if (ret >= 0) {
+			print_codec_meta_vendor(sh, data, (uint8_t)ret);
+		}
+	}
 #endif /* CONFIG_BT_AUDIO_CODEC_CFG_MAX_METADATA_SIZE > 0 */
 }
 
@@ -546,7 +860,15 @@ static inline bool print_base_subgroup_bis_cb(const struct bt_bap_base_subgroup_
 	shell_print(ctx_shell, "\t\tBIS index: 0x%02X", bis->index);
 	/* Print CC data */
 	if (codec_id->id == BT_HCI_CODING_FORMAT_LC3) {
-		print_ltv_array(ctx_shell, "\t\tdata", bis->data, bis->data_len);
+		struct bt_audio_codec_cfg codec_cfg;
+		int err;
+
+		err = bt_bap_base_subgroup_bis_codec_to_codec_cfg(bis, &codec_cfg);
+		if (err == 0) {
+			print_codec_cfg(ctx_shell, &codec_cfg);
+		} else {
+			print_ltv_array(ctx_shell, "\t\tdata", bis->data, bis->data_len);
+		}
 	} else { /* If not LC3, we cannot assume it's LTV */
 		shell_hexdump(ctx_shell, bis->data, bis->data_len);
 	}
@@ -558,6 +880,7 @@ static inline bool print_base_subgroup_cb(const struct bt_bap_base_subgroup *sub
 					  void *user_data)
 {
 	struct bt_bap_base_codec_id codec_id;
+	struct bt_audio_codec_cfg codec_cfg;
 	uint8_t *data;
 	int ret;
 
@@ -577,23 +900,28 @@ static inline bool print_base_subgroup_cb(const struct bt_bap_base_subgroup *sub
 		return false;
 	}
 
-	/* Print CC data */
-	if (codec_id.id == BT_HCI_CODING_FORMAT_LC3) {
-		print_ltv_array(ctx_shell, "\tdata", data, (uint8_t)ret);
-	} else { /* If not LC3, we cannot assume it's LTV */
-		shell_hexdump(ctx_shell, data, (uint8_t)ret);
-	}
+	ret = bt_bap_base_subgroup_codec_to_codec_cfg(subgroup, &codec_cfg);
+	if (ret == 0) {
+		print_codec_cfg(ctx_shell, &codec_cfg);
+	} else {
+		/* Print CC data */
+		if (codec_id.id == BT_HCI_CODING_FORMAT_LC3) {
+			print_ltv_array(ctx_shell, "\tdata", data, (uint8_t)ret);
+		} else { /* If not LC3, we cannot assume it's LTV */
+			shell_hexdump(ctx_shell, data, (uint8_t)ret);
+		}
 
-	ret = bt_bap_base_get_subgroup_codec_meta(subgroup, &data);
-	if (ret < 0) {
-		return false;
-	}
+		ret = bt_bap_base_get_subgroup_codec_meta(subgroup, &data);
+		if (ret < 0) {
+			return false;
+		}
 
-	/* Print metadata */
-	if (codec_id.id == BT_HCI_CODING_FORMAT_LC3) {
-		print_ltv_array(ctx_shell, "\tdata", data, (uint8_t)ret);
-	} else { /* If not LC3, we cannot assume it's LTV */
-		shell_hexdump(ctx_shell, data, (uint8_t)ret);
+		/* Print metadata */
+		if (codec_id.id == BT_HCI_CODING_FORMAT_LC3) {
+			print_ltv_array(ctx_shell, "\tdata", data, (uint8_t)ret);
+		} else { /* If not LC3, we cannot assume it's LTV */
+			shell_hexdump(ctx_shell, data, (uint8_t)ret);
+		}
 	}
 
 	ret = bt_bap_base_subgroup_foreach_bis(subgroup, print_base_subgroup_bis_cb, &codec_id);

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -495,7 +495,7 @@ static int lc3_config(struct bt_conn *conn, const struct bt_bap_ep *ep, enum bt_
 {
 	shell_print(ctx_shell, "ASE Codec Config: conn %p ep %p dir %u", conn, ep, dir);
 
-	print_codec_cfg(ctx_shell, codec_cfg);
+	print_codec_cfg(ctx_shell, 0, codec_cfg);
 
 	*stream = stream_alloc();
 	if (*stream == NULL) {
@@ -521,7 +521,7 @@ static int lc3_reconfig(struct bt_bap_stream *stream, enum bt_audio_dir dir,
 {
 	shell_print(ctx_shell, "ASE Codec Reconfig: stream %p", stream);
 
-	print_codec_cfg(ctx_shell, codec_cfg);
+	print_codec_cfg(ctx_shell, 0, codec_cfg);
 
 	if (default_stream == NULL) {
 		set_unicast_stream(stream);
@@ -768,7 +768,7 @@ static void print_remote_codec_cap(const struct bt_conn *conn,
 	shell_print(ctx_shell, "conn %p: codec_cap %p dir 0x%02x", conn, codec_cap,
 		    dir);
 
-	print_codec_cap(ctx_shell, codec_cap);
+	print_codec_cap(ctx_shell, 0, codec_cap);
 }
 
 #if CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT > 0
@@ -2128,8 +2128,8 @@ static int cmd_preset(const struct shell *sh, size_t argc, char *argv[])
 
 	shell_print(sh, "%s", named_preset->name);
 
-	print_codec_cfg(sh, &named_preset->preset.codec_cfg);
-	print_qos(sh, &named_preset->preset.qos);
+	print_codec_cfg(ctx_shell, 0, &named_preset->preset.codec_cfg);
+	print_qos(ctx_shell, &named_preset->preset.qos);
 
 	return 0;
 }


### PR DESCRIPTION
Improves how the LTV values in codec capabilities and codec configurations are printed, so that it is more human readable. 

fixes https://github.com/zephyrproject-rtos/zephyr/issues/53199