### PR TITLE
drivers/espi: Add FLASH_HAS_DRIVER support

### DIFF
--- a/drivers/espi/Kconfig.xec
+++ b/drivers/espi/Kconfig.xec
@@ -191,3 +191,16 @@ config ESPI_PERIPHERAL_KBC_OBE_CBK
 	  Enable KBC OBE callback from OBE ISR
 
 endif #ESPI_XEC_V2 && ESPI_PERIPHERAL_8042_KBC
+
+if ESPI_FLASH_CHANNEL
+
+config ESPI_FLASH_STORAGE
+	bool "ESPI Flash channel storage"
+	default y
+	select FLASH
+	select FLASH_HAS_DRIVER_ENABLED
+	select FLASH_HAS_PAGE_LAYOUT
+	help
+	  Enable shared flash on ESPI to be used as storage
+
+endif #ESPI_FLASH_STORAGE

--- a/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.series
+++ b/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.series
@@ -16,6 +16,15 @@ config NUM_IRQS
 
 source "soc/arm/microchip_mec/mec172x/Kconfig.defconfig.mec172x*"
 
+config FLASH_SIZE
+	default $(dt_node_reg_size_int,/flash@c0000,0)
+
+config FLASH_BASE_ADDRESS
+	default $(dt_node_reg_addr_hex,/flash@c0000)
+
+config ROM_START_OFFSET
+	default 0 if BOOTLOADER_MCUBOOT
+
 if RTOS_TIMER
 
 config SOC_HAS_TIMING_FUNCTIONS


### PR DESCRIPTION
Shared flash channel over ESPI can be used as a flash device for private storage.  The ESPI flash channel support doesn't fit directly into the normal flash driver support in order to use flash as a storage device. This code adds this support, starting with the MEC172x.