### PR TITLE
ci: run assigner bot on collab branches

### DIFF
--- a/.github/workflows/assigner.yml
+++ b/.github/workflows/assigner.yml
@@ -9,6 +9,7 @@ on:
     - ready_for_review
     branches:
     - main
+    - collab-*
     - v*-branch
   issues:
     types:


### PR DESCRIPTION
Get more reviewers added to make sure we have all relevant reviewers
looking at changes targeting collab branches.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
