### PR TITLE
samples: portability: link to posix api samples

### DIFF
--- a/samples/posix/posix.rst
+++ b/samples/posix/posix.rst
@@ -1,7 +1,7 @@
 .. _posix-samples:
 
-POSIX Subsystem Samples
-#######################
+POSIX API Samples
+#################
 
 .. toctree::
    :maxdepth: 1

--- a/samples/subsys/portability/portability.rst
+++ b/samples/subsys/portability/portability.rst
@@ -8,3 +8,5 @@ Portability Samples
    :glob:
 
    **/*
+
+See also :ref:`POSIX API Samples <posix-samples>`.


### PR DESCRIPTION
* link to POSIX API Samples from Portability Samples
* change Subsystem to API since lib/posix is more of a library than a subsystem