### PR TITLE
intel_adsp: ace: do not use external kconfigs in code

### DIFF
--- a/drivers/power_domain/power_domain_intel_adsp.c
+++ b/drivers/power_domain/power_domain_intel_adsp.c
@@ -9,9 +9,9 @@
 #include <zephyr/pm/device_runtime.h>
 #include <adsp_shim.h>
 
-#if CONFIG_ACE_VERSION_1_5
+#if CONFIG_SOC_INTEL_ACE15_MTPM
 #include <adsp_power.h>
-#endif /* CONFIG_ACE_VERSION_1_5 */
+#endif /* CONFIG_SOC_INTEL_ACE15_MTPM */
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(power_domain_intel_adsp, LOG_LEVEL_INF);
@@ -35,7 +35,7 @@ static int pd_intel_adsp_set_power_enable(struct pg_bits *bits, bool power_enabl
 			return -EIO;
 		}
 	} else {
-#if CONFIG_ACE_VERSION_1_5
+#if CONFIG_SOC_INTEL_ACE15_MTPM
 		extern uint32_t g_key_read_holder;
 
 		if (bits->SPA_bit == INTEL_ADSP_HST_DOMAIN_BIT) {

--- a/soc/xtensa/intel_adsp/ace/multiprocessing.c
+++ b/soc/xtensa/intel_adsp/ace/multiprocessing.c
@@ -27,10 +27,10 @@
 
 #define ACE_INTC_IRQ DT_IRQN(DT_NODELABEL(ace_intc))
 
-#if CONFIG_ACE_VERSION_1_5
+#if CONFIG_SOC_INTEL_ACE15_MTPM
 /* .bss is uncached, we further check it below */
 uint32_t g_key_read_holder;
-#endif /* CONFIG_ACE_VERSION_1_5 */
+#endif /* CONFIG_SOC_INTEL_ACE15_MTPM */
 
 static void ipc_isr(void *arg)
 {
@@ -88,11 +88,11 @@ void soc_mp_init(void)
 
 	/* Set the core 0 active */
 	soc_cpus_active[0] = true;
-#if CONFIG_ACE_VERSION_1_5
+#if CONFIG_SOC_INTEL_ACE15_MTPM
 	__ASSERT(!arch_xtensa_is_ptr_cached(&g_key_read_holder),
 		 "g_key_read_holder must be uncached");
 	g_key_read_holder = INTEL_ADSP_ACE15_MAGIC_KEY;
-#endif /* CONFIG_ACE_VERSION_1_5 */
+#endif /* CONFIG_SOC_INTEL_ACE15_MTPM */
 }
 
 static int host_runtime_get(void)


### PR DESCRIPTION
use SOC_INTEL_ACE15_MTPM instead of CONFIG_ACE_VERSION_1_5.

CONFIG_ACE_VERSION_1_5 leaked from SOF.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
