### PR TITLE
drivers: clock_control: ra: sub-clock oscillator select fix

### DIFF
--- a/drivers/clock_control/clock_control_renesas_ra.c
+++ b/drivers/clock_control/clock_control_renesas_ra.c
@@ -18,7 +18,7 @@
 #elif DT_SAME_NODE(DT_INST_PROP(0, clock_source), DT_PATH(clocks, mosc))
 #define SYSCLK_SRC mosc
 #elif DT_SAME_NODE(DT_INST_PROP(0, clock_source), DT_PATH(clocks, sosc))
-#define SYSCLK_SRC soco
+#define SYSCLK_SRC sosc
 #elif DT_SAME_NODE(DT_INST_PROP(0, clock_source), DT_PATH(clocks, hoco))
 #define SYSCLK_SRC hoco
 #elif DT_SAME_NODE(DT_INST_PROP(0, clock_source), DT_PATH(clocks, moco))


### PR DESCRIPTION
Due to a typo it is not possible to select the sub-clock oscillator (SOSC) as a clock source for an RA Microcontroller. This patch resolves the issue.