### PR TITLE
net: sockets: tls: Add error log when cert parse fails

### DIFF
--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -974,6 +974,7 @@ static int tls_add_ca_certificate(struct tls_context *tls,
 	}
 
 	if (err != 0) {
+		NET_ERR("Failed to parse CA certificate, err: -0x%x", -err);
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Add an error log if there's a failure when attempting to load certificates during socket connect.

Signed-off-by: Noah Pendleton <noah.pendleton@gmail.com>