### PR TITLE
drivers: power-domain: Add option for initialization priority

### DIFF
--- a/drivers/power_domain/Kconfig
+++ b/drivers/power_domain/Kconfig
@@ -44,6 +44,16 @@ config POWER_DOMAIN_INTEL_ADSP
 	help
 	  Include Intel ADSP power domain control mechanisms
 
+if POWER_DOMAIN_INTEL_ADSP
+
+config POWER_DOMAIN_INTEL_ADSP_INIT_PRIORITY
+	int "Intel ADSP power domain init priority"
+	default KERNEL_INIT_PRIORITY_DEFAULT
+	help
+	  Intel ADSP power domain initialization priority.
+
+endif #POWER_DOMAIN_INTEL_ADSP
+
 config POWER_DOMAIN_GPIO_MONITOR
 	bool "GPIO monitor for sensing power on rail"
 	default y

--- a/drivers/power_domain/Kconfig
+++ b/drivers/power_domain/Kconfig
@@ -26,6 +26,16 @@ config POWER_DOMAIN_GPIO
 	depends on TIMEOUT_64BIT
 	select DEVICE_DEPS
 
+if POWER_DOMAIN_GPIO
+
+config POWER_DOMAIN_GPIO_INIT_PRIORITY
+	int "GPIO power domain init priority"
+	default POWER_DOMAIN_INIT_PRIORITY
+	help
+	  GPIO power domain initialization priority.
+
+endif #POWER_DOMAIN_GPIO_MONITOR
+
 config POWER_DOMAIN_INTEL_ADSP
 	bool "Use Intel ADSP power gating mechanisms"
 	default y

--- a/drivers/power_domain/Kconfig
+++ b/drivers/power_domain/Kconfig
@@ -41,4 +41,14 @@ config POWER_DOMAIN_GPIO_MONITOR
 	depends on GPIO
 	select DEVICE_DEPS
 
+if POWER_DOMAIN_GPIO_MONITOR
+
+config POWER_DOMAIN_GPIO_MONITOR_INIT_PRIORITY
+	int "GPIO monitor power domain init priority"
+	default POWER_DOMAIN_INIT_PRIORITY
+	help
+	  GPIO monitor power domain initialization priority.
+
+endif #POWER_DOMAIN_GPIO_MONITOR
+
 endif

--- a/drivers/power_domain/power_domain_gpio.c
+++ b/drivers/power_domain/power_domain_gpio.c
@@ -135,7 +135,7 @@ static int pd_gpio_init(const struct device *dev)
 	PM_DEVICE_DT_INST_DEFINE(id, pd_gpio_pm_action);			\
 	DEVICE_DT_INST_DEFINE(id, pd_gpio_init, PM_DEVICE_DT_INST_GET(id),	\
 			      &pd_gpio_##id##_data, &pd_gpio_##id##_cfg,	\
-			      POST_KERNEL, CONFIG_POWER_DOMAIN_INIT_PRIORITY,	\
+			      POST_KERNEL, CONFIG_POWER_DOMAIN_GPIO_INIT_PRIORITY,	\
 			      NULL);
 
 DT_INST_FOREACH_STATUS_OKAY(POWER_DOMAIN_DEVICE)

--- a/drivers/power_domain/power_domain_gpio_monitor.c
+++ b/drivers/power_domain/power_domain_gpio_monitor.c
@@ -145,6 +145,6 @@ unconfigure_pin:
 	DEVICE_DT_INST_DEFINE(inst, pd_gpio_monitor_init,					\
 				PM_DEVICE_DT_INST_GET(inst), &pd_gpio_monitor_data_##inst,	\
 				&pd_gpio_monitor_config_##inst, POST_KERNEL,			\
-				CONFIG_POWER_DOMAIN_INIT_PRIORITY, NULL);
+				CONFIG_POWER_DOMAIN_GPIO_MONITOR_INIT_PRIORITY, NULL);
 
 DT_INST_FOREACH_STATUS_OKAY(POWER_DOMAIN_DEVICE)

--- a/drivers/power_domain/power_domain_intel_adsp.c
+++ b/drivers/power_domain/power_domain_intel_adsp.c
@@ -99,6 +99,6 @@ static int pd_intel_adsp_init(const struct device *dev)
 	PM_DEVICE_DT_INST_DEFINE(id, pd_intel_adsp_pm_action);				\
 	DEVICE_DT_INST_DEFINE(id, pd_intel_adsp_init, PM_DEVICE_DT_INST_GET(id),	\
 			      &pd_pg_reg##id, NULL, POST_KERNEL,			\
-			      CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
+			      CONFIG_POWER_DOMAIN_INTEL_ADSP_INIT_PRIORITY, NULL);
 
 DT_INST_FOREACH_STATUS_OKAY(POWER_DOMAIN_DEVICE)


### PR DESCRIPTION
Add a build option to change specific power domains initialization priority.