### PR TITLE
bindesc: Add include zephyr/sys/util_macro.h

### DIFF
--- a/include/zephyr/bindesc.h
+++ b/include/zephyr/bindesc.h
@@ -7,6 +7,8 @@
 #ifndef ZEPHYR_INCLUDE_ZEPHYR_BINDESC_H_
 #define ZEPHYR_INCLUDE_ZEPHYR_BINDESC_H_
 
+#include <zephyr/sys/util_macro.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */


### PR DESCRIPTION
Including `zephyr/bindesc.h` without `zephyr/sys/util_macro.h` already present will cause a compile error. As it's a reasonable expectation that this should work, this patch adds the missing include.