### PR TITLE
drivers: pinctrl: renesas: fix ipsr generation for Spider boards

### DIFF
--- a/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-rcar-common.h
+++ b/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-rcar-common.h
@@ -17,8 +17,10 @@
  * @param func the 4 bits encoded alternate function.
  *
  * Function code    [ 0 : 3 ]
- * Function shift   [ 4 : 9 ]
- * IPSR bank        [ 10 : 13 ]
+ * Function shift   [ 4 : 8 ]
+ * Empty            [ 9 ]
+ * IPSR bank        [ 10 : 14 ]
+ * Register index   [ 15 : 17 ] (S4 only)
  */
 #define IPSR(bank, shift, func) (((bank) << 10U) | ((shift) << 4U) | (func))
 
@@ -45,7 +47,7 @@
  * Each base address has 4 IPSR banks.
  */
 #define IPnSR(bank, reg, shift, func) \
-	IPSR(((reg) << 4U) | (bank), shift, func)
+	IPSR(((reg) << 5U) | (bank), shift, func)
 
 #define IP0SR0(shift, func) IPnSR(0, 0, shift, func)
 #define IP1SR0(shift, func) IPnSR(1, 0, shift, func)

--- a/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-rcar-common.h
+++ b/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-rcar-common.h
@@ -73,6 +73,14 @@
 #define IP1SR5(shift, func) IPnSR(1, 5, shift, func)
 #define IP2SR5(shift, func) IPnSR(2, 5, shift, func)
 #define IP3SR5(shift, func) IPnSR(3, 5, shift, func)
+#define IP0SR6(shift, func) IPnSR(0, 6, shift, func)
+#define IP1SR6(shift, func) IPnSR(1, 6, shift, func)
+#define IP2SR6(shift, func) IPnSR(2, 6, shift, func)
+#define IP3SR6(shift, func) IPnSR(3, 6, shift, func)
+#define IP0SR7(shift, func) IPnSR(0, 7, shift, func)
+#define IP1SR7(shift, func) IPnSR(1, 7, shift, func)
+#define IP2SR7(shift, func) IPnSR(2, 7, shift, func)
+#define IP3SR7(shift, func) IPnSR(3, 7, shift, func)
 
 #define PIN_VOLTAGE_NONE 0
 #define PIN_VOLTAGE_1P8V 1


### PR DESCRIPTION
Avoid unexpected memory access in cases where the IPSR has an odd register index. In the scenario where an odd register index is present in IPSR, the LSB of the register index is utilized as MSB of the bank number. Observe how we pack reg/bank:
    'IPSR(((reg) << 4U) | (bank), shift, func)' (macro IPnSR)
and how it is read from the device tree source:
    '(RCAR_IPSR(node_id) >> 10U) & 0x1FU' (macro RCAR_PIN_FUNC).

 Finally, this bank is used to obtain the required IPSR offset:
    'PFC_RCAR_IPSR + rcar_func->bank * sizeof(uint32_t)'
in the 'pfc_rcar_set_ipsr' function. For example, if we have the 1 as a reg index and the 3-rd bank, the resulting offset would be 19, which is beyond the IPSR range.

Align the IPSR comment with the definition of the 'rcar_pin_func' structure.

Add missed definitions of IP[0-3]SR[67] macros.

Note: we can omit the usage of the register index entirely since this information is obtained from the pin number inside the 'pfc_rcar_get_reg_index' function.