### PR TITLE
subsys: net: zperf: fix the calculation ratio between mbps, kbps and bps

### DIFF
--- a/doc/releases/migration-guide-3.6.rst
+++ b/doc/releases/migration-guide-3.6.rst
@@ -435,6 +435,9 @@ Networking
   cannot be accessed from usermode thread. This means that the API calls will need to made
   from supervisor mode thread.
 
+* The zperf ratio between mbps and kbps, kbps and bps is changed to 1000, instead of 1024,
+  to align with iperf ratios.
+
 zcbor
 =====
 

--- a/subsys/net/lib/zperf/zperf_shell.c
+++ b/subsys/net/lib/zperf/zperf_shell.c
@@ -76,9 +76,9 @@ static struct in_addr shell_ipv4;
 
 const uint32_t TIME_US[] = { 60 * 1000 * 1000, 1000 * 1000, 1000, 0 };
 const char *TIME_US_UNIT[] = { "m", "s", "ms", "us" };
-const uint32_t KBPS[] = { 1024, 0 };
+const uint32_t KBPS[] = { 1000, 0 };
 const char *KBPS_UNIT[] = { "Mbps", "Kbps" };
-const uint32_t K[] = { 1024 * 1024, 1024, 0 };
+const uint32_t K[] = { 1000 * 1000, 1000, 0 };
 const char *K_UNIT[] = { "M", "K", "" };
 
 static void print_number(const struct shell *sh, uint32_t value,
@@ -308,7 +308,7 @@ static void udp_session_cb(enum zperf_status status,
 			rate_in_kbps = (uint32_t)
 				(((uint64_t)result->total_len * 8ULL *
 				  (uint64_t)USEC_PER_SEC) /
-				 ((uint64_t)result->time_in_us * 1024ULL));
+				 ((uint64_t)result->time_in_us * 1000ULL));
 		} else {
 			rate_in_kbps = 0U;
 		}
@@ -408,7 +408,7 @@ static void shell_udp_upload_print_stats(const struct shell *sh,
 			rate_in_kbps = (uint32_t)
 				(((uint64_t)results->total_len *
 				  (uint64_t)8 * (uint64_t)USEC_PER_SEC) /
-				 ((uint64_t)results->time_in_us * 1024U));
+				 ((uint64_t)results->time_in_us * 1000U));
 		} else {
 			rate_in_kbps = 0U;
 		}
@@ -418,7 +418,7 @@ static void shell_udp_upload_print_stats(const struct shell *sh,
 				(((uint64_t)results->nb_packets_sent *
 				  (uint64_t)results->packet_size * (uint64_t)8 *
 				  (uint64_t)USEC_PER_SEC) /
-				 ((uint64_t)results->client_time_in_us * 1024U));
+				 ((uint64_t)results->client_time_in_us * 1000U));
 		} else {
 			client_rate_in_kbps = 0U;
 		}
@@ -474,7 +474,7 @@ static void shell_tcp_upload_print_stats(const struct shell *sh,
 				(((uint64_t)results->nb_packets_sent *
 				  (uint64_t)results->packet_size * (uint64_t)8 *
 				  (uint64_t)USEC_PER_SEC) /
-				 ((uint64_t)results->client_time_in_us * 1024U));
+				 ((uint64_t)results->client_time_in_us * 1000U));
 		} else {
 			client_rate_in_kbps = 0U;
 		}
@@ -884,7 +884,7 @@ static int shell_cmd_upload(const struct shell *sh, size_t argc,
 
 	if (argc > 5) {
 		param.rate_kbps =
-			(parse_number(argv[start + 5], K, K_UNIT) + 1023) / 1024;
+			(parse_number(argv[start + 5], K, K_UNIT) + 999) / 1000;
 	} else {
 		param.rate_kbps = 10U;
 	}
@@ -1035,7 +1035,7 @@ static int shell_cmd_upload2(const struct shell *sh, size_t argc,
 
 	if (argc > 4) {
 		param.rate_kbps =
-			(parse_number(argv[start + 4], K, K_UNIT) + 1023) / 1024;
+			(parse_number(argv[start + 4], K, K_UNIT) + 999) / 1000;
 	} else {
 		param.rate_kbps = 10U;
 	}
@@ -1108,7 +1108,7 @@ static void tcp_session_cb(enum zperf_status status,
 			rate_in_kbps = (uint32_t)
 				(((uint64_t)result->total_len * 8ULL *
 				  (uint64_t)USEC_PER_SEC) /
-				 ((uint64_t)result->time_in_us * 1024ULL));
+				 ((uint64_t)result->time_in_us * 1000ULL));
 		} else {
 			rate_in_kbps = 0U;
 		}


### PR DESCRIPTION
The ratio between mbps and kbps, kbps and bps should be 1000, instead of 1024, as common sense. The wrong ratio will decrease the Zperf throughput result.