### PR TITLE
Bluetooth: Mesh: Introduce random delay in adv layer

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -2113,6 +2113,23 @@ __syscall void *k_queue_peek_tail(struct k_queue *queue);
 	STRUCT_SECTION_ITERABLE(k_queue, name) = \
 		Z_QUEUE_INITIALIZER(name)
 
+/**
+ * @brief Provide the primitive to iterate on a queue
+ * Note: the loop is unsafe and thus curr should not be removed
+ *
+ * User _MUST_ add the loop statement curly braces enclosing its own code:
+ *
+ *     K_QUEUE_FOR_EACH_CONTAINER(l, n) {
+ *         <user code>
+ *     }
+ *
+ * @param _queue Address of the queue.
+ * @param __cn   A pointer to peek each entry of the list
+ * @param __n    The field name of sys_node_t within the container struct
+ */
+#define K_QUEUE_FOR_EACH_CONTAINER(_queue, __cn, __n) \
+	SYS_SFLIST_FOR_EACH_CONTAINER(&((_queue)->data_q), __cn, __n)
+
 /** @} */
 
 #ifdef CONFIG_USERSPACE

--- a/subsys/bluetooth/mesh/adv.h
+++ b/subsys/bluetooth/mesh/adv.h
@@ -49,10 +49,12 @@ struct bt_mesh_adv_ctx {
 		  tag:4;
 
 	uint8_t      xmit;
+
+	uint16_t delay_ms;
 };
 
 struct bt_mesh_adv {
-	sys_snode_t node;
+	sys_sfnode_t node;
 
 	struct bt_mesh_adv_ctx ctx;
 
@@ -75,7 +77,9 @@ struct bt_mesh_adv *bt_mesh_adv_create(enum bt_mesh_adv_type type,
 				       uint8_t xmit, k_timeout_t timeout);
 
 void bt_mesh_adv_send(struct bt_mesh_adv *adv, const struct bt_mesh_send_cb *cb,
-		      void *cb_data);
+		      void *cb_data, uint16_t delay_ms);
+
+uint16_t bt_mesh_adv_random_delay(uint16_t down, uint16_t up);
 
 struct bt_mesh_adv *bt_mesh_adv_get(k_timeout_t timeout);
 

--- a/subsys/bluetooth/mesh/beacon.c
+++ b/subsys/bluetooth/mesh/beacon.c
@@ -279,7 +279,7 @@ static bool net_beacon_send(struct bt_mesh_subnet *sub, struct bt_mesh_beacon *b
 
 	err = beacon_create(sub, &adv->b);
 	if (!err) {
-		bt_mesh_adv_send(adv, &send_cb, beacon);
+		bt_mesh_adv_send(adv, &send_cb, beacon, 0);
 	}
 
 	bt_mesh_adv_unref(adv);
@@ -355,7 +355,7 @@ static int unprovisioned_beacon_send(void)
 	net_buf_simple_add_be16(&adv->b, oob_info);
 	net_buf_simple_add_mem(&adv->b, uri_hash, 4);
 
-	bt_mesh_adv_send(adv, NULL, NULL);
+	bt_mesh_adv_send(adv, NULL, NULL, 0);
 	bt_mesh_adv_unref(adv);
 
 	if (prov->uri) {
@@ -373,7 +373,7 @@ static int unprovisioned_beacon_send(void)
 			LOG_WRN("Too long URI to fit advertising data");
 		} else {
 			net_buf_simple_add_mem(&adv->b, prov->uri, len);
-			bt_mesh_adv_send(adv, NULL, NULL);
+			bt_mesh_adv_send(adv, NULL, NULL, 0);
 		}
 
 		bt_mesh_adv_unref(adv);

--- a/subsys/bluetooth/mesh/friend.c
+++ b/subsys/bluetooth/mesh/friend.c
@@ -1291,7 +1291,7 @@ send_last:
 
 	frnd->pending_req = 0U;
 	frnd->pending_buf = 1U;
-	bt_mesh_adv_send(adv, &buf_sent_cb, frnd);
+	bt_mesh_adv_send(adv, &buf_sent_cb, frnd, 0);
 	bt_mesh_adv_unref(adv);
 }
 

--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -581,7 +581,7 @@ int bt_mesh_net_send(struct bt_mesh_net_tx *tx, struct bt_mesh_adv *adv,
 		(void)bt_mesh_proxy_cli_relay(adv);
 	}
 
-	bt_mesh_adv_send(adv, cb, cb_data);
+	bt_mesh_adv_send(adv, cb, cb_data, 0);
 
 done:
 	bt_mesh_adv_unref(adv);
@@ -749,7 +749,7 @@ static void bt_mesh_net_relay(struct net_buf_simple *sbuf,
 	}
 
 	if (relay_to_adv(rx->net_if) || rx->friend_cred) {
-		bt_mesh_adv_send(adv, NULL, NULL);
+		bt_mesh_adv_send(adv, NULL, NULL, 0);
 	}
 
 done:

--- a/tests/bsim/bluetooth/mesh/src/mesh_test.c
+++ b/tests/bsim/bluetooth/mesh/src/mesh_test.c
@@ -552,7 +552,7 @@ void bt_mesh_test_send_over_adv(void *data, size_t len)
 	struct bt_mesh_adv *adv = bt_mesh_adv_create(BT_MESH_ADV_DATA, BT_MESH_ADV_TAG_LOCAL,
 						     BT_MESH_TRANSMIT(0, 20), K_NO_WAIT);
 	net_buf_simple_add_mem(&adv->b, data, len);
-	bt_mesh_adv_send(adv, NULL, NULL);
+	bt_mesh_adv_send(adv, NULL, NULL, 0);
 }
 
 int bt_mesh_test_wait_for_packet(bt_le_scan_cb_t scan_cb, struct k_sem *observer_sem, uint16_t wait)

--- a/tests/bsim/bluetooth/mesh/src/test_advertiser.c
+++ b/tests/bsim/bluetooth/mesh/src/test_advertiser.c
@@ -284,7 +284,7 @@ static void send_adv_buf(struct bt_mesh_adv *adv, uint8_t curr, uint8_t prev)
 	(void)net_buf_simple_add_u8(&adv->b, curr);
 	(void)net_buf_simple_add_u8(&adv->b, prev);
 
-	bt_mesh_adv_send(adv, &send_cb, adv);
+	bt_mesh_adv_send(adv, &send_cb, adv, 0);
 	bt_mesh_adv_unref(adv);
 }
 
@@ -331,7 +331,7 @@ static void test_tx_cb_single(void)
 	net_buf_simple_add_mem(&adv->b, txt_msg, sizeof(txt_msg));
 	seq_checker = 0;
 	tx_timestamp = k_uptime_get();
-	bt_mesh_adv_send(adv, &send_cb, (void *)cb_msg);
+	bt_mesh_adv_send(adv, &send_cb, (void *)cb_msg, 0);
 	bt_mesh_adv_unref(adv);
 
 	err = k_sem_take(&observer_sem, K_SECONDS(1));
@@ -369,7 +369,7 @@ static void test_tx_cb_multi(void)
 	send_cb.end = realloc_end_cb;
 	net_buf_simple_add_mem(&(adv[0]->b), txt_msg, sizeof(txt_msg));
 
-	bt_mesh_adv_send(adv[0], &send_cb, adv[0]);
+	bt_mesh_adv_send(adv[0], &send_cb, adv[0], 0);
 	bt_mesh_adv_unref(adv[0]);
 
 	err = k_sem_take(&observer_sem, K_SECONDS(1));
@@ -382,7 +382,7 @@ static void test_tx_cb_multi(void)
 
 	for (int i = 0; i < CONFIG_BT_MESH_ADV_BUF_COUNT; i++) {
 		net_buf_simple_add_le32(&(adv[i]->b), i);
-		bt_mesh_adv_send(adv[i], &send_cb, (void *)(intptr_t)i);
+		bt_mesh_adv_send(adv[i], &send_cb, (void *)(intptr_t)i, 0);
 		bt_mesh_adv_unref(adv[i]);
 	}
 
@@ -429,7 +429,7 @@ static void test_tx_proxy_mixin(void)
 	struct bt_mesh_adv *adv = bt_mesh_adv_create(BT_MESH_ADV_DATA, BT_MESH_ADV_TAG_LOCAL,
 			BT_MESH_TRANSMIT(5, 20), K_NO_WAIT);
 	net_buf_simple_add_mem(&adv->b, txt_msg, sizeof(txt_msg));
-	bt_mesh_adv_send(adv, NULL, NULL);
+	bt_mesh_adv_send(adv, NULL, NULL, 0);
 	k_sleep(K_MSEC(150));
 
 	/* Let the tester to measure an interval between advertisements again. */


### PR DESCRIPTION
Introduce random delay.

Since random delay is involved everywhere in the Mesh Protocol(Such as access message, PB-ADV, DFW, etc..), it is best to put this part of the logic in a common part(`adv.c` here) instead of duplicating the design work.