### PR TITLE
gen_isr_tables: print index number at the end of each entry as comment

### DIFF
--- a/scripts/build/gen_isr_tables.py
+++ b/scripts/build/gen_isr_tables.py
@@ -250,7 +250,7 @@ def write_source_file(fp, vt, swt, intlist, syms, shared):
             fp.write("\t/* Level 3 interrupts start here (offset: {}) */\n".
                      format(level3_offset))
 
-        fp.write("\t{{(const void *){0}, (ISR){1}}},\n".format(param, func_as_string))
+        fp.write("\t{{(const void *){0}, (ISR){1}}}, /* {2} */\n".format(param, func_as_string, i))
     fp.write("};\n")
 
 def get_symbols(obj):


### PR DESCRIPTION
Make it easier to debug by printing the index number at the end, this is especially helpful when there's a lot of interrupts.

before:
```c
/* build/zephyr/isr_tables.c */
...
struct _isr_table_entry __sw_isr_table _sw_isr_table[1035] = {
	{(const void *)0x0, (ISR)((uintptr_t)&z_irq_spurious)},
	{(const void *)0x0, (ISR)((uintptr_t)&z_irq_spurious)},
	{(const void *)0x0, (ISR)((uintptr_t)&z_irq_spurious)},
	{(const void *)0x0, (ISR)((uintptr_t)&z_irq_spurious)},
	{(const void *)0x0, (ISR)((uintptr_t)&z_irq_spurious)},
	{(const void *)0x0, (ISR)((uintptr_t)&z_irq_spurious)},
	{(const void *)0x0, (ISR)((uintptr_t)&z_irq_spurious)},
	...
```

after:
```c
/* build/zephyr/isr_tables.c */
...
struct _isr_table_entry __sw_isr_table _sw_isr_table[1035] = {
	{(const void *)0x0, (ISR)((uintptr_t)&z_irq_spurious)}, /* 0 */
	{(const void *)0x0, (ISR)((uintptr_t)&z_irq_spurious)}, /* 1 */
	{(const void *)0x0, (ISR)((uintptr_t)&z_irq_spurious)}, /* 2 */
	{(const void *)0x0, (ISR)((uintptr_t)&z_irq_spurious)}, /* 3 */
	{(const void *)0x0, (ISR)((uintptr_t)&z_irq_spurious)}, /* 4 */
	{(const void *)0x0, (ISR)((uintptr_t)&z_irq_spurious)}, /* 5 */
	{(const void *)0x0, (ISR)((uintptr_t)&z_irq_spurious)}, /* 6 */
	...
```