### PR TITLE
devicetree: use `DT_CAT*` wherever possible

### DIFF
--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -1208,7 +1208,7 @@
  * @return the property's value as a sequence of tokens, with no quotes
  */
 #define DT_STRING_UNQUOTED_BY_IDX(node_id, prop, idx) \
-	DT_CAT4(node_id, _P_, prop##_IDX_##idx, _STRING_UNQUOTED)
+	DT_CAT6(node_id, _P_, prop, _IDX_, idx, _STRING_UNQUOTED)
 
 /*
  * phandle properties
@@ -1383,7 +1383,7 @@
  * @return the cell's value or @p default_value
  */
 #define DT_PHA_BY_IDX_OR(node_id, pha, idx, cell, default_value) \
-	DT_PROP_OR(node_id, pha##_IDX_##idx##_VAL_##cell, default_value)
+	DT_PROP_OR(node_id, DT_CAT5(pha, _IDX_, idx, _VAL_, cell), default_value)
 
 /**
  * @brief Equivalent to DT_PHA_BY_IDX(node_id, pha, 0, cell)
@@ -1476,7 +1476,7 @@
  * @return the cell's value or @p default_value
  */
 #define DT_PHA_BY_NAME_OR(node_id, pha, name, cell, default_value) \
-	DT_PROP_OR(node_id, pha##_NAME_##name##_VAL_##cell, default_value)
+	DT_PROP_OR(node_id, DT_CAT5(pha, _NAME_, name, _VAL_, cell), default_value)
 
 /**
  * @brief Get a phandle's node identifier from a phandle array by @p name

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -356,7 +356,7 @@
  * @param node_id node identifier
  * @return a node identifier for the node's parent
  */
-#define DT_PARENT(node_id) UTIL_CAT(node_id, _PARENT)
+#define DT_PARENT(node_id) DT_CAT(node_id, _PARENT)
 
 /**
  * @brief Get a node identifier for a grandparent node
@@ -3109,7 +3109,7 @@
  */
 #define DT_FOREACH_STATUS_OKAY(compat, fn)				\
 	COND_CODE_1(DT_HAS_COMPAT_STATUS_OKAY(compat),			\
-		    (UTIL_CAT(DT_FOREACH_OKAY_, compat)(fn)),	\
+		    (DT_CAT(DT_FOREACH_OKAY_, compat)(fn)),	\
 		    ())
 
 /**
@@ -3158,7 +3158,7 @@
  */
 #define DT_FOREACH_STATUS_OKAY_VARGS(compat, fn, ...)			\
 	COND_CODE_1(DT_HAS_COMPAT_STATUS_OKAY(compat),			\
-		    (UTIL_CAT(DT_FOREACH_OKAY_VARGS_,			\
+		    (DT_CAT(DT_FOREACH_OKAY_VARGS_,			\
 			      compat)(fn, __VA_ARGS__)),		\
 		    ())
 
@@ -4121,7 +4121,7 @@
  *         0 otherwise
  */
 #define DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(compat, bus) \
-	IS_ENABLED(UTIL_CAT(DT_CAT(DT_COMPAT_, compat), _BUS_##bus))
+	IS_ENABLED(DT_CAT4(DT_COMPAT_, compat, _BUS_, bus))
 
 /**
  * @brief Test if any `DT_DRV_COMPAT` node is on a bus of a given type


### PR DESCRIPTION
Use `DT_CAT*` macros to paste simple things together instead of `UTIL_CAT` wherever possible. This should reduce the amount of error messages from the compiler when something goes wrong.