### PR TITLE
sys: util: Accept empty FOR_EACH

### DIFF
--- a/include/zephyr/sys/util_loops.h
+++ b/include/zephyr/sys/util_loops.h
@@ -408,7 +408,7 @@
 		Z_FOR_LOOP_3, \
 		Z_FOR_LOOP_2, \
 		Z_FOR_LOOP_1, \
-		Z_FOR_LOOP_0)(x, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__)
+		Z_FOR_LOOP_0)(x, sep, fixed_arg0, fixed_arg1, __VA_ARGS__)
 
 #define Z_GET_ARG_1(_0, ...) _0
 

--- a/tests/unit/util/main.c
+++ b/tests/unit/util/main.c
@@ -236,6 +236,7 @@ ZTEST(util, test_IN_RANGE) {
 
 ZTEST(util, test_FOR_EACH) {
 	#define FOR_EACH_MACRO_TEST(arg) *buf++ = arg
+	#define FOR_EACH_MACRO_TEST2(arg) arg
 
 	uint8_t array[3] = {0};
 	uint8_t *buf = array;
@@ -245,6 +246,14 @@ ZTEST(util, test_FOR_EACH) {
 	zassert_equal(array[0], 1, "Unexpected value %d", array[0]);
 	zassert_equal(array[1], 2, "Unexpected value %d", array[1]);
 	zassert_equal(array[2], 3, "Unexpected value %d", array[2]);
+
+	uint8_t test0[] = { 0, FOR_EACH(FOR_EACH_MACRO_TEST2, (,))};
+
+	BUILD_ASSERT(sizeof(test0) == 1, "Unexpected length due to FOR_EACH fail");
+
+	uint8_t test1[] = { 0, FOR_EACH(FOR_EACH_MACRO_TEST2, (,), 1)};
+
+	BUILD_ASSERT(sizeof(test1) == 2, "Unexpected length due to FOR_EACH fail");
 }
 
 ZTEST(util, test_FOR_EACH_NONEMPTY_TERM) {


### PR DESCRIPTION
The `##` part of `##__VA_ARGS__` in the `Z_FOR_EACH_ENGINE` macro technically
breaks the invocation of empty `FOR_EACH` sequences, as the empty
__VA_ARGS__ gets squashed with in the invocation of `Z_FOR_LOOP_1()` in
`Z_FOR_LOOP_2()`, which makes the macro only pass 4 arguments to
`Z_FOR_LOOP_1`.

This breaks IntelliSense in Microsoft's C/C++ extension for VS Code,
which is strict about the amount of arguments you can pass to a variadic
macro.

Fixes #62460.