### PR TITLE
drivers: ieee802154: fix ACK header IE related bugs

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -899,35 +899,38 @@ static int nrf5_configure(const struct device *dev,
 		uint8_t ext_addr_le[EXTENDED_ADDRESS_SIZE];
 		uint8_t short_addr_le[SHORT_ADDRESS_SIZE];
 		uint8_t element_id;
+		bool valid_vendor_specific_ie = false;
 
 		if (config->ack_ie.short_addr == IEEE802154_BROADCAST_ADDRESS ||
 		    config->ack_ie.ext_addr == NULL) {
 			return -ENOTSUP;
 		}
 
-		element_id = ieee802154_header_ie_get_element_id(config->ack_ie.header_ie);
-
-		if (element_id != IEEE802154_HEADER_IE_ELEMENT_ID_CSL_IE &&
-		    (!IS_ENABLED(CONFIG_NET_L2_OPENTHREAD) ||
-		     element_id != IEEE802154_HEADER_IE_ELEMENT_ID_VENDOR_SPECIFIC_IE)) {
-			return -ENOTSUP;
-		}
-
-#if defined(CONFIG_NET_L2_OPENTHREAD)
-		uint8_t vendor_oui_le[IEEE802154_OPENTHREAD_VENDOR_OUI_LEN] =
-			IEEE802154_OPENTHREAD_THREAD_IE_VENDOR_OUI;
-
-		if (element_id == IEEE802154_HEADER_IE_ELEMENT_ID_VENDOR_SPECIFIC_IE &&
-		    memcmp(config->ack_ie.header_ie->content.vendor_specific.vendor_oui,
-			   vendor_oui_le, sizeof(vendor_oui_le))) {
-			return -ENOTSUP;
-		}
-#endif
-
 		sys_put_le16(config->ack_ie.short_addr, short_addr_le);
 		sys_memcpy_swap(ext_addr_le, config->ack_ie.ext_addr, EXTENDED_ADDRESS_SIZE);
 
-		if (config->ack_ie.header_ie && config->ack_ie.header_ie->length > 0) {
+		if (config->ack_ie.header_ie == NULL || config->ack_ie.header_ie->length == 0) {
+			nrf_802154_ack_data_clear(short_addr_le, false, NRF_802154_ACK_DATA_IE);
+			nrf_802154_ack_data_clear(ext_addr_le, true, NRF_802154_ACK_DATA_IE);
+		} else {
+			element_id = ieee802154_header_ie_get_element_id(config->ack_ie.header_ie);
+
+#if defined(CONFIG_NET_L2_OPENTHREAD)
+			uint8_t vendor_oui_le[IEEE802154_OPENTHREAD_VENDOR_OUI_LEN] =
+				IEEE802154_OPENTHREAD_THREAD_IE_VENDOR_OUI;
+
+			if (element_id == IEEE802154_HEADER_IE_ELEMENT_ID_VENDOR_SPECIFIC_IE &&
+			    memcmp(config->ack_ie.header_ie->content.vendor_specific.vendor_oui,
+				   vendor_oui_le, sizeof(vendor_oui_le)) == 0) {
+				valid_vendor_specific_ie = true;
+			}
+#endif
+
+			if (element_id != IEEE802154_HEADER_IE_ELEMENT_ID_CSL_IE &&
+			    !valid_vendor_specific_ie) {
+				return -ENOTSUP;
+			}
+
 			nrf_802154_ack_data_set(short_addr_le, false, config->ack_ie.header_ie,
 						config->ack_ie.header_ie->length +
 							IEEE802154_HEADER_IE_HEADER_LENGTH,
@@ -936,9 +939,6 @@ static int nrf5_configure(const struct device *dev,
 						config->ack_ie.header_ie->length +
 							IEEE802154_HEADER_IE_HEADER_LENGTH,
 						NRF_802154_ACK_DATA_IE);
-		} else {
-			nrf_802154_ack_data_clear(short_addr_le, false, NRF_802154_ACK_DATA_IE);
-			nrf_802154_ack_data_clear(ext_addr_le, true, NRF_802154_ACK_DATA_IE);
 		}
 	} break;
 

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -901,6 +901,12 @@ static int nrf5_configure(const struct device *dev,
 		uint8_t element_id;
 		bool valid_vendor_specific_ie = false;
 
+		if (config->ack_ie.purge_ie) {
+			nrf_802154_ack_data_remove_all(false, NRF_802154_ACK_DATA_IE);
+			nrf_802154_ack_data_remove_all(true, NRF_802154_ACK_DATA_IE);
+			break;
+		}
+
 		if (config->ack_ie.short_addr == IEEE802154_BROADCAST_ADDRESS ||
 		    config->ack_ie.ext_addr == NULL) {
 			return -ENOTSUP;

--- a/include/zephyr/net/ieee802154_radio.h
+++ b/include/zephyr/net/ieee802154_radio.h
@@ -1241,6 +1241,15 @@ struct ieee802154_config {
 			 * in CPU byte order
 			 */
 			uint16_t short_addr;
+
+			/**
+			 * Flag for purging enh ACK header IEs.
+			 * When flag is set to true, driver should remove all existing
+			 * header IEs, and all other entries in config should be ignored.
+			 * This means that purging current header IEs and
+			 * configuring a new one in the same call is not allowed.
+			 */
+			bool purge_ie;
 		} ack_ie;
 	};
 };

--- a/modules/openthread/platform/radio.c
+++ b/modules/openthread/platform/radio.c
@@ -1257,10 +1257,7 @@ void otPlatRadioSetMacFrameCounterIfLarger(otInstance *aInstance, uint32_t aMacF
 otError otPlatRadioEnableCsl(otInstance *aInstance, uint32_t aCslPeriod, otShortAddress aShortAddr,
 			     const otExtAddress *aExtAddr)
 {
-	struct ieee802154_config config = {
-		.ack_ie.short_addr = aShortAddr,
-		.ack_ie.ext_addr = aExtAddr->m8,
-	};
+	struct ieee802154_config config = { 0 };
 	int result;
 
 	ARG_UNUSED(aInstance);
@@ -1273,6 +1270,8 @@ otError otPlatRadioEnableCsl(otInstance *aInstance, uint32_t aCslPeriod, otShort
 	if (result) {
 		return OT_ERROR_FAILED;
 	}
+	config.ack_ie.short_addr = aShortAddr;
+	config.ack_ie.ext_addr = aExtAddr != NULL ? aExtAddr->m8 : NULL;
 
 	/* Configure the CSL IE. */
 	if (aCslPeriod > 0) {

--- a/modules/openthread/platform/radio.c
+++ b/modules/openthread/platform/radio.c
@@ -1296,6 +1296,22 @@ otError otPlatRadioEnableCsl(otInstance *aInstance, uint32_t aCslPeriod, otShort
 	return result ? OT_ERROR_FAILED : OT_ERROR_NONE;
 }
 
+otError otPlatRadioResetCsl(otInstance *aInstance)
+{
+	struct ieee802154_config config = { 0 };
+	int result;
+
+	result = radio_api->configure(radio_dev, IEEE802154_CONFIG_CSL_PERIOD, &config);
+	if (result) {
+		return OT_ERROR_FAILED;
+	}
+
+	config.ack_ie.purge_ie = true;
+	result = radio_api->configure(radio_dev, IEEE802154_CONFIG_ENH_ACK_HEADER_IE, &config);
+
+	return result ? OT_ERROR_FAILED : OT_ERROR_NONE;
+}
+
 void otPlatRadioUpdateCslSampleTime(otInstance *aInstance, uint32_t aCslSampleTime)
 {
 	ARG_UNUSED(aInstance);

--- a/west.yml
+++ b/west.yml
@@ -301,7 +301,7 @@ manifest:
       revision: da78aea63159771956fe0c9263f2e6985b66e9d5
       path: modules/lib/open-amp
     - name: openthread
-      revision: 00076aff3ae571db7c90509ec9dc293457098c35
+      revision: 7761b81d23b10b3d5ee21b8504c67535cde10896
       path: modules/lib/openthread
     - name: percepio
       path: modules/debug/percepio


### PR DESCRIPTION
fix bugs in current implementation of ieee802154 driver:
- after refactoring `set_vendor_ie_header_lm`, case when `link_metrics_data_len == 0` has been ignored. Fixed by refactoring the code again.
- Resetting RCP stack by openthread has been handled incorrectly (`-ENOTSUP` returned). Fixed by implementing `otPlatRadioResetCsl` in upstream OpenThread and adding `clear_ie` flag.
- refactoring of enh ACK header IE resulted with returning `-ENOTSUP` when `ack_ie.header_ie == NULL` (set when csl period set to 0 in `otPlatRadioEnableCsl`), because
`ieee802154_header_ie_get_element_id` accessed `NULL` pointer.
- `struct ieee802154_config config` is a struct containing an union. Members of `config` were accessed incorrectly in `otPlatRadioEnableCsl`. Fixed by initializing `config` with `0` and accessing one member at a time.