### PR TITLE
Modem chat implement transmit idle

### DIFF
--- a/drivers/gnss/gnss_nmea_generic.c
+++ b/drivers/gnss/gnss_nmea_generic.c
@@ -127,7 +127,6 @@ static int gnss_nmea_generic_init_chat(const struct device *dev)
 		.argv_size = ARRAY_SIZE(data->chat_argv),
 		.unsol_matches = unsol_matches,
 		.unsol_matches_size = ARRAY_SIZE(unsol_matches),
-		.process_timeout = K_MSEC(2),
 	};
 
 	return modem_chat_init(&data->chat, &chat_config);

--- a/drivers/gnss/gnss_quectel_lcx6g.c
+++ b/drivers/gnss/gnss_quectel_lcx6g.c
@@ -686,7 +686,6 @@ static int quectel_lcx6g_init_chat(const struct device *dev)
 		.argv_size = ARRAY_SIZE(data->chat_argv),
 		.unsol_matches = unsol_matches,
 		.unsol_matches_size = ARRAY_SIZE(unsol_matches),
-		.process_timeout = K_MSEC(2),
 	};
 
 	return modem_chat_init(&data->chat, &chat_config);

--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -1520,7 +1520,6 @@ static int modem_cellular_init(const struct device *dev)
 			.argv_size = ARRAY_SIZE(data->chat_argv),
 			.unsol_matches = unsol_matches,
 			.unsol_matches_size = ARRAY_SIZE(unsol_matches),
-			.process_timeout = K_MSEC(2),
 		};
 
 		modem_chat_init(&data->chat, &chat_config);

--- a/include/zephyr/modem/chat.h
+++ b/include/zephyr/modem/chat.h
@@ -240,8 +240,8 @@ struct modem_chat {
 	struct k_sem script_stopped_sem;
 
 	/* Script sending */
-	uint16_t script_send_request_pos;
-	uint16_t script_send_delimiter_pos;
+	enum modem_chat_script_send_state script_send_state;
+	uint16_t script_send_pos;
 	struct k_work script_send_work;
 	struct k_work_delayable script_send_timeout_work;
 

--- a/include/zephyr/modem/chat.h
+++ b/include/zephyr/modem/chat.h
@@ -242,7 +242,7 @@ struct modem_chat {
 	/* Script sending */
 	uint16_t script_send_request_pos;
 	uint16_t script_send_delimiter_pos;
-	struct k_work_delayable script_send_work;
+	struct k_work script_send_work;
 	struct k_work_delayable script_send_timeout_work;
 
 	/* Match parsing */
@@ -252,8 +252,7 @@ struct modem_chat {
 	uint16_t parse_match_type;
 
 	/* Process received data */
-	struct k_work_delayable process_work;
-	k_timeout_t process_timeout;
+	struct k_work receive_work;
 };
 
 /**
@@ -282,8 +281,6 @@ struct modem_chat_config {
 	const struct modem_chat_match *unsol_matches;
 	/** Elements in array of unsolicited matches */
 	uint16_t unsol_matches_size;
-	/** Delay from receive ready event to pipe receive occurs */
-	k_timeout_t process_timeout;
 };
 
 /**

--- a/tests/subsys/modem/modem_chat/src/main.c
+++ b/tests/subsys/modem/modem_chat/src/main.c
@@ -254,7 +254,6 @@ static void *test_modem_chat_setup(void)
 		.argv_size = ARRAY_SIZE(cmd_argv),
 		.unsol_matches = unsol_matches,
 		.unsol_matches_size = ARRAY_SIZE(unsol_matches),
-		.process_timeout = K_MSEC(2),
 	};
 
 	zassert(modem_chat_init(&cmd, &cmd_config) == 0, "Failed to init modem CMD");


### PR DESCRIPTION
Update the modem chat module to use the transmit idle event. This addition removes the need for the `process_timeout` parameter passed to the modem_chat module in the init function, so this PR removes all in-tree setting of this property.
