### PR TITLE
include: usb: include usb_ch9.h

### DIFF
--- a/include/zephyr/usb/class/usb_hid.h
+++ b/include/zephyr/usb/class/usb_hid.h
@@ -14,6 +14,7 @@
 #define ZEPHYR_INCLUDE_USB_HID_CLASS_DEVICE_H_
 
 #include <zephyr/usb/class/hid.h>
+#include <zephyr/usb/usb_ch9.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
In usb_hid.h `struct usb_setup_packet` is used. This is defined in usb_ch9.h but not included in usb_hid.h which leads to build errors when you include the usb header files in the wrong order. This commit fixes this behaviour.