### PR TITLE
posix: Implement mq_notify()

### DIFF
--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -359,7 +359,7 @@ _POSIX_MESSAGE_PASSING
 
     mq_close(),yes
     mq_getattr(),yes
-    mq_notify(),
+    mq_notify(),yes
     mq_open(),yes
     mq_receive(),yes
     mq_send(),yes

--- a/include/zephyr/posix/mqueue.h
+++ b/include/zephyr/posix/mqueue.h
@@ -10,6 +10,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/posix/time.h>
 #include <zephyr/posix/fcntl.h>
+#include <zephyr/posix/signal.h>
 #include <zephyr/posix/sys/stat.h>
 #include "posix_types.h"
 
@@ -40,6 +41,7 @@ int mq_timedreceive(mqd_t mqdes, char *msg_ptr, size_t msg_len,
 			unsigned int *msg_prio, const struct timespec *abstime);
 int mq_timedsend(mqd_t mqdes, const char *msg_ptr, size_t msg_len,
 		 unsigned int msg_prio, const struct timespec *abstime);
+int mq_notify(mqd_t mqdes, const struct sigevent *notification);
 
 #ifdef __cplusplus
 }

--- a/tests/posix/headers/src/mqueue_h.c
+++ b/tests/posix/headers/src/mqueue_h.c
@@ -29,7 +29,7 @@ ZTEST(posix_headers, test_mqueue_h)
 	if (IS_ENABLED(CONFIG_POSIX_API)) {
 		zassert_not_null(mq_close);
 		zassert_not_null(mq_getattr);
-		/* zassert_not_null(mq_notify); */ /* not implemented */
+		zassert_not_null(mq_notify);
 		zassert_not_null(mq_open);
 		zassert_not_null(mq_receive);
 		zassert_not_null(mq_send);


### PR DESCRIPTION
The function was the last missing piece of the `_POSIX_MESSAGE_PASSING`
option group. Due to lack of signal subsystem in the Zephyr RTOS
the `sigev_notify` member of the `sigevent` structure that describes
the notification cannot be set to `SIGEV_SIGNAL` - this notification
type is not implemented, the function will return -1 and set `errno`
to `ENOSYS`.

`mq_notify` documentation:
https://pubs.opengroup.org/onlinepubs/9699919799/functions/mq_notify.html

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/66958