### PR TITLE
drivers: flash: stm32 flash base address from the DTS node

### DIFF
--- a/drivers/flash/flash_stm32.c
+++ b/drivers/flash/flash_stm32.c
@@ -157,7 +157,7 @@ static void flash_stm32_flush_caches(const struct device *dev,
 		regs->ACR |= FLASH_ACR_DCEN;
 	}
 #elif defined(CONFIG_SOC_SERIES_STM32F7X)
-	SCB_InvalidateDCache_by_Addr((uint32_t *)(CONFIG_FLASH_BASE_ADDRESS
+	SCB_InvalidateDCache_by_Addr((uint32_t *)(FLASH_STM32_BASE_ADDRESS
 						  + offset), len);
 #endif
 }
@@ -178,7 +178,7 @@ static int flash_stm32_read(const struct device *dev, off_t offset,
 
 	LOG_DBG("Read offset: %ld, len: %zu", (long int) offset, len);
 
-	memcpy(data, (uint8_t *) CONFIG_FLASH_BASE_ADDRESS + offset, len);
+	memcpy(data, (uint8_t *) FLASH_STM32_BASE_ADDRESS + offset, len);
 
 	return 0;
 }
@@ -562,7 +562,8 @@ static int stm32_flash_init(const struct device *dev)
 
 	flash_stm32_sem_init(dev);
 
-	LOG_DBG("Flash initialized. BS: %zu",
+	LOG_DBG("Flash @0x%x initialized. BS: %zu",
+		FLASH_STM32_BASE_ADDRESS,
 		flash_stm32_parameters.write_block_size);
 
 	/* Check Flash configuration */

--- a/drivers/flash/flash_stm32.h
+++ b/drivers/flash/flash_stm32.h
@@ -17,6 +17,9 @@
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #endif
 
+/* Get the base address of the flash from the DTS node */
+#define FLASH_STM32_BASE_ADDRESS DT_REG_ADDR(DT_INST(0, st_stm32_nv_flash))
+
 struct flash_stm32_priv {
 	FLASH_TypeDef *regs;
 #if DT_NODE_HAS_PROP(DT_INST(0, st_stm32_flash_controller), clocks) || \

--- a/drivers/flash/flash_stm32f1x.c
+++ b/drivers/flash/flash_stm32f1x.c
@@ -62,7 +62,7 @@ static void erase_page_begin(FLASH_TypeDef *regs, unsigned int page)
 {
 	/* Set the PER bit and select the page you wish to erase */
 	regs->CR |= FLASH_CR_PER;
-	regs->AR = CONFIG_FLASH_BASE_ADDRESS + page * FLASH_PAGE_SIZE;
+	regs->AR = FLASH_STM32_BASE_ADDRESS + page * FLASH_PAGE_SIZE;
 
 	barrier_dsync_fence_full();
 
@@ -99,7 +99,7 @@ static void write_disable(FLASH_TypeDef *regs)
 static void erase_page_begin(FLASH_TypeDef *regs, unsigned int page)
 {
 	volatile flash_prg_t *page_base = (flash_prg_t *)(
-		CONFIG_FLASH_BASE_ADDRESS + page * FLASH_PAGE_SIZE);
+		FLASH_STM32_BASE_ADDRESS + page * FLASH_PAGE_SIZE);
 	/* Enable programming in erase mode. An erase is triggered by
 	 * writing 0 to the first word of a page.
 	 */
@@ -123,7 +123,7 @@ static int write_value(const struct device *dev, off_t offset,
 		       flash_prg_t val)
 {
 	volatile flash_prg_t *flash = (flash_prg_t *)(
-		offset + CONFIG_FLASH_BASE_ADDRESS);
+		offset + FLASH_STM32_BASE_ADDRESS);
 	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);
 	int rc;
 

--- a/drivers/flash/flash_stm32f2x.c
+++ b/drivers/flash/flash_stm32f2x.c
@@ -76,7 +76,7 @@ static int write_byte(const struct device *dev, off_t offset, uint8_t val)
 	/* flush the register write */
 	tmp = regs->CR;
 
-	*((uint8_t *) offset + CONFIG_FLASH_BASE_ADDRESS) = val;
+	*((uint8_t *) offset + FLASH_STM32_BASE_ADDRESS) = val;
 
 	/* Wait until the BSY bit is cleared */
 	rc = flash_stm32_wait_flash_idle(dev);

--- a/drivers/flash/flash_stm32f4x.c
+++ b/drivers/flash/flash_stm32f4x.c
@@ -117,7 +117,7 @@ static int write_value(const struct device *dev, off_t offset, flash_prg_t val)
 	/* flush the register write */
 	tmp = regs->CR;
 
-	*((flash_prg_t *)(offset + CONFIG_FLASH_BASE_ADDRESS)) = val;
+	*((flash_prg_t *)(offset + FLASH_STM32_BASE_ADDRESS)) = val;
 
 	rc = flash_stm32_wait_flash_idle(dev);
 	regs->CR &= (~FLASH_CR_PG);

--- a/drivers/flash/flash_stm32f7x.c
+++ b/drivers/flash/flash_stm32f7x.c
@@ -60,7 +60,7 @@ static int write_byte(const struct device *dev, off_t offset, uint8_t val)
 	barrier_dsync_fence_full();
 
 	/* write the data */
-	*((uint8_t *) offset + CONFIG_FLASH_BASE_ADDRESS) = val;
+	*((uint8_t *) offset + FLASH_STM32_BASE_ADDRESS) = val;
 	/* flush the register write */
 	barrier_dsync_fence_full();
 

--- a/drivers/flash/flash_stm32g0x.c
+++ b/drivers/flash/flash_stm32g0x.c
@@ -56,7 +56,7 @@ static inline void flush_cache(FLASH_TypeDef *regs)
 
 static int write_dword(const struct device *dev, off_t offset, uint64_t val)
 {
-	volatile uint32_t *flash = (uint32_t *)(offset + CONFIG_FLASH_BASE_ADDRESS);
+	volatile uint32_t *flash = (uint32_t *)(offset + FLASH_STM32_BASE_ADDRESS);
 	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);
 	uint32_t tmp;
 	int rc;

--- a/drivers/flash/flash_stm32g4x.c
+++ b/drivers/flash/flash_stm32g4x.c
@@ -75,7 +75,7 @@ static inline void flush_cache(FLASH_TypeDef *regs)
 
 static int write_dword(const struct device *dev, off_t offset, uint64_t val)
 {
-	volatile uint32_t *flash = (uint32_t *)(offset + CONFIG_FLASH_BASE_ADDRESS);
+	volatile uint32_t *flash = (uint32_t *)(offset + FLASH_STM32_BASE_ADDRESS);
 	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);
 #if defined(FLASH_STM32_DBANK)
 	bool dcache_enabled = false;

--- a/drivers/flash/flash_stm32h7x.c
+++ b/drivers/flash/flash_stm32h7x.c
@@ -307,7 +307,7 @@ static int write_ndwords(const struct device *dev,
 			 uint8_t n)
 {
 	volatile uint64_t *flash = (uint64_t *)(offset
-						+ CONFIG_FLASH_BASE_ADDRESS);
+						+ FLASH_STM32_BASE_ADDRESS);
 	int rc;
 	int i;
 	struct flash_stm32_sector_t sector = get_sector(dev, offset);
@@ -451,7 +451,7 @@ static void flash_stm32h7_flush_caches(const struct device *dev,
 		return; /* Cache not enabled */
 	}
 
-	SCB_InvalidateDCache_by_Addr((uint32_t *)(CONFIG_FLASH_BASE_ADDRESS
+	SCB_InvalidateDCache_by_Addr((uint32_t *)(FLASH_STM32_BASE_ADDRESS
 						  + offset), len);
 }
 #endif /* CONFIG_CPU_CORTEX_M7 */
@@ -574,7 +574,7 @@ static int flash_stm32h7_read(const struct device *dev, off_t offset,
 	barrier_dsync_fence_full();
 	barrier_isync_fence_full();
 
-	memcpy(data, (uint8_t *) CONFIG_FLASH_BASE_ADDRESS + offset, len);
+	memcpy(data, (uint8_t *) FLASH_STM32_BASE_ADDRESS + offset, len);
 
 	__set_FAULTMASK(0);
 	SCB->CCR &= ~SCB_CCR_BFHFNMIGN_Msk;

--- a/drivers/flash/flash_stm32l4x.c
+++ b/drivers/flash/flash_stm32l4x.c
@@ -69,7 +69,7 @@ static unsigned int get_page(off_t offset)
 
 static int write_dword(const struct device *dev, off_t offset, uint64_t val)
 {
-	volatile uint32_t *flash = (uint32_t *)(offset + CONFIG_FLASH_BASE_ADDRESS);
+	volatile uint32_t *flash = (uint32_t *)(offset + FLASH_STM32_BASE_ADDRESS);
 	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);
 #ifdef CONTROL_DCACHE
 	bool dcache_enabled = false;

--- a/drivers/flash/flash_stm32l5x.c
+++ b/drivers/flash/flash_stm32l5x.c
@@ -161,7 +161,7 @@ static int write_nwords(const struct device *dev, off_t offset, const uint32_t *
 {
 	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);
 	volatile uint32_t *flash = (uint32_t *)(offset
-						+ CONFIG_FLASH_BASE_ADDRESS);
+						+ FLASH_STM32_BASE_ADDRESS);
 	bool full_zero = true;
 	uint32_t tmp;
 	int rc;

--- a/drivers/flash/flash_stm32wba_fm.c
+++ b/drivers/flash/flash_stm32wba_fm.c
@@ -93,7 +93,7 @@ static int flash_stm32_read(const struct device *dev, off_t offset,
 
 	flash_stm32_sem_take(dev);
 
-	memcpy(data, (uint8_t *) CONFIG_FLASH_BASE_ADDRESS + offset, len);
+	memcpy(data, (uint8_t *) FLASH_STM32_BASE_ADDRESS + offset, len);
 
 	flash_stm32_sem_give(dev);
 
@@ -153,7 +153,7 @@ static int flash_stm32_write(const struct device *dev, off_t offset,
 	LOG_DBG("Write offset: %p, len: %zu", (void *)offset, len);
 
 	rc = FM_Write((uint32_t *)data,
-		      (uint32_t *)(CONFIG_FLASH_BASE_ADDRESS + offset),
+		      (uint32_t *)(FLASH_STM32_BASE_ADDRESS + offset),
 		      (int32_t)len/4, &cb_ptr);
 	if (rc == 0) {
 		k_sem_take(&flash_busy, K_FOREVER);

--- a/drivers/flash/flash_stm32wbax.c
+++ b/drivers/flash/flash_stm32wbax.c
@@ -109,7 +109,7 @@ static int write_qword(const struct device *dev, off_t offset, const uint32_t *b
 {
 	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);
 	volatile uint32_t *flash = (uint32_t *)(offset
-						+ CONFIG_FLASH_BASE_ADDRESS);
+						+ FLASH_STM32_BASE_ADDRESS);
 	uint32_t tmp;
 	int rc;
 

--- a/drivers/flash/flash_stm32wbx.c
+++ b/drivers/flash/flash_stm32wbx.c
@@ -60,7 +60,7 @@ static inline void flush_cache(FLASH_TypeDef *regs)
 
 static int write_dword(const struct device *dev, off_t offset, uint64_t val)
 {
-	volatile uint32_t *flash = (uint32_t *)(offset + CONFIG_FLASH_BASE_ADDRESS);
+	volatile uint32_t *flash = (uint32_t *)(offset + FLASH_STM32_BASE_ADDRESS);
 	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);
 	uint32_t tmp;
 	int ret, rc;

--- a/tests/drivers/flash/common/testcase.yaml
+++ b/tests/drivers/flash/common/testcase.yaml
@@ -48,6 +48,7 @@ tests:
       - stm32f3_disco
       - nucleo_f429zi
       - stm32f746g_disco
+      - nucleo_f767zi
       - nucleo_g0b1re
       - nucleo_g474re
       - nucleo_h743zi


### PR DESCRIPTION
For the flash driver, the base address is the MCU internal flash address (usually 0x8000000). This PR gets  that address from the device tree node "st,stm32-nv-flash"
instead of relying on the CONFIG_FLASH_BASE_ADDRESS which might differ when building for another flash memory.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/67986