### PR TITLE
Bluetooth: Controller: Fix ISO Sync Receiver sequential BIS PDU drop

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
@@ -804,6 +804,9 @@ isr_rx_find_subevent:
 						   ((lll->bn * lll->irc) +
 						    lll->ptc)) + 1U;
 
+					/* BIS index */
+					bis_idx = lll->bis_curr - 1U;
+
 					/* Find the missing (bn_curr)th Rx PDU
 					 * of bis_curr
 					 */


### PR DESCRIPTION
Fix ISO Synchronized Receiver sequential packing BIS PDU being dropped in the first repetation just after previous BIS subevents where skipped.