### PR TITLE
arm: aarch32: cortex_a_r: Add MMU_ALIGN define to Linker script

### DIFF
--- a/include/zephyr/arch/arm/cortex_a_r/scripts/linker.ld
+++ b/include/zephyr/arch/arm/cortex_a_r/scripts/linker.ld
@@ -81,6 +81,8 @@ _region_min_align = 4;
 
 #define BSS_ALIGN ALIGN(_region_min_align)
 
+#define MMU_ALIGN    . = ALIGN(_region_min_align)
+
 MEMORY
 {
     FLASH    (rx) : ORIGIN = ROM_ADDR, LENGTH = ROM_SIZE


### PR DESCRIPTION
Zephyr compilation fails when I'm trying to build test application for CORTEX_A9 with:
> CONFIG_NOCACHE_MEMORY=y

the following linker error appears:

> ld.bfd: cannot find MMU_ALIGN: No such file or directory

The problem appears because cortex_a_r lacks of MMU_ALIGN definition. This define was added to the target linker script when CONFIG_NOCACHE_MEMORY is enabled which adds .nocache section where this define is used.

Steps to reproduce:
1) Apply patch with test code from the following link:https://pastebin.com/dKSA20fz
2) Build dma scatter_gather test with the following command:
> west build -b qemu_cortex_a9 -p always tests/drivers/dma/scatter_gather

Linking fails without provided fix. 