### PR TITLE
llext: additional CMake harmonizations

### DIFF
--- a/cmake/compiler/gcc/target_xtensa.cmake
+++ b/cmake/compiler/gcc/target_xtensa.cmake
@@ -17,5 +17,4 @@ set(LLEXT_APPEND_FLAGS
   -fPIC
   -nostdlib
   -nodefaultlibs
-  -shared
 )

--- a/cmake/modules/FindTargetTools.cmake
+++ b/cmake/modules/FindTargetTools.cmake
@@ -31,7 +31,8 @@ endif()
 set(CMAKE_C_COMPILER_FORCED   1)
 set(CMAKE_CXX_COMPILER_FORCED 1)
 
-# No official documentation exists for the "Generic" value, except their wiki.
+# https://cmake.org/cmake/help/latest/variable/CMAKE_SYSTEM_NAME.html:
+#   The name of the operating system for which CMake is to build.
 #
 # https://gitlab.kitware.com/cmake/community/wikis/doc/cmake/CrossCompiling:
 #   CMAKE_SYSTEM_NAME : this one is mandatory, it is the name of the target
@@ -40,7 +41,10 @@ set(CMAKE_CXX_COMPILER_FORCED 1)
 #   variable is used for constructing the file names of the platform files
 #   like Linux.cmake or Windows-gcc.cmake. If your target is an embedded
 #   system without OS set CMAKE_SYSTEM_NAME to "Generic".
-set(CMAKE_SYSTEM_NAME Generic)
+#
+# This will force CMake to load cmake/modules/Platform/Zephyr.cmake,
+# allowing Zephyr-specific embedded system features to be enabled.
+set(CMAKE_SYSTEM_NAME Zephyr)
 
 # https://cmake.org/cmake/help/latest/variable/CMAKE_SYSTEM_PROCESSOR.html:
 #   The name of the CPU CMake is building for.
@@ -74,7 +78,7 @@ else()
   set(CMAKE_CXX_BYTE_ORDER LITTLE_ENDIAN)
 endif()
 
-# We are not building dynamically loadable libraries
+# Do not build dynamically loadable libraries by default
 set(BUILD_SHARED_LIBS OFF)
 
 # Custom targets for compiler and linker flags.

--- a/cmake/modules/Platform/Zephyr.cmake
+++ b/cmake/modules/Platform/Zephyr.cmake
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (c) 2024, Arduino SA
+
+# Perform the same initialization as the Generic platform, then enable
+# dynamic library support if CONFIG_LLEXT is enabled.
+
+include(Platform/Generic)
+
+# Enable dynamic library support when CONFIG_LLEXT is enabled.
+if(CONFIG_LLEXT)
+  set_property(GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS true)
+endif()

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -35,6 +35,8 @@ include(CheckCXXCompilerFlag)
 # 5.1. zephyr_linker*
 # 6 Function helper macros
 # 7 Linkable loadable extensions (llext)
+# 7.1 llext_* configuration functions
+# 7.2 add_llext_* build control functions
 
 ########################################################
 # 1. Zephyr-aware extensions
@@ -5099,6 +5101,38 @@ endmacro()
 # loadable extensions (llexts).
 #
 
+# 7.1 Configuration functions
+#
+# The following functions simplify access to the compilation/link stage
+# properties of an llext using the same API of the target_* functions.
+#
+
+function(llext_compile_definitions target_name)
+  target_compile_definitions(${target_name}_llext_lib PRIVATE ${ARGN})
+endfunction()
+
+function(llext_compile_features target_name)
+  target_compile_features(${target_name}_llext_lib PRIVATE ${ARGN})
+endfunction()
+
+function(llext_compile_options target_name)
+  target_compile_options(${target_name}_llext_lib PRIVATE ${ARGN})
+endfunction()
+
+function(llext_include_directories target_name)
+  target_include_directories(${target_name}_llext_lib PRIVATE ${ARGN})
+endfunction()
+
+function(llext_link_options target_name)
+  target_link_options(${target_name}_llext_lib PRIVATE ${ARGN})
+endfunction()
+
+# 7.2 Build control functions
+#
+# The following functions add targets and subcommands to the build system
+# to compile and link an llext.
+#
+
 # Usage:
 #   add_llext_target(<target_name>
 #                    OUTPUT  <output_file>
@@ -5114,9 +5148,6 @@ endmacro()
 # in the Zephyr build, but with some important modifications. The list of
 # flags to remove and flags to append is controlled respectively by the
 # LLEXT_REMOVE_FLAGS and LLEXT_APPEND_FLAGS global variables.
-
-# The C_FLAGS argument can be used to pass additional compiler flags to the
-# compilation of this particular llext.
 #
 # The following custom properties of <target_name> are defined and can be
 # retrieved using the get_target_property() function:
@@ -5130,14 +5161,13 @@ endmacro()
 #   add_llext_target(hello_world
 #     OUTPUT  ${PROJECT_BINARY_DIR}/hello_world.llext
 #     SOURCES ${PROJECT_SOURCE_DIR}/src/llext/hello_world.c
-#     C_FLAGS -Werror
 #   )
 # will compile the source file src/llext/hello_world.c to a file
-# ${PROJECT_BINARY_DIR}/hello_world.llext, adding -Werror to the compilation.
+# named "${PROJECT_BINARY_DIR}/hello_world.llext".
 #
 function(add_llext_target target_name)
   set(single_args OUTPUT)
-  set(multi_args SOURCES;C_FLAGS)
+  set(multi_args SOURCES)
   cmake_parse_arguments(PARSE_ARGV 1 LLEXT "${options}" "${single_args}" "${multi_args}")
 
   # Check that the llext subsystem is enabled for this build
@@ -5201,7 +5231,6 @@ function(add_llext_target target_name)
   target_compile_options(${llext_lib_target} PRIVATE
     ${zephyr_filtered_flags}
     ${LLEXT_APPEND_FLAGS}
-    ${LLEXT_C_FLAGS}
   )
   target_include_directories(${llext_lib_target} PRIVATE
     $<TARGET_PROPERTY:zephyr_interface,INTERFACE_INCLUDE_DIRECTORIES>

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -5099,6 +5099,12 @@ endmacro()
 # loadable extensions (llexts).
 #
 
+# Usage:
+#   add_llext_target(<target_name>
+#                    OUTPUT  <output_file>
+#                    SOURCES <source_file>
+#   )
+#
 # Add a custom target that compiles a single source file to a .llext file.
 #
 # Output and source files must be specified using the OUTPUT and SOURCES
@@ -5111,6 +5117,14 @@ endmacro()
 
 # The C_FLAGS argument can be used to pass additional compiler flags to the
 # compilation of this particular llext.
+#
+# The following custom properties of <target_name> are defined and can be
+# retrieved using the get_target_property() function:
+#
+# - lib_target  Target name for the source compilation and/or link step.
+# - lib_output  The binary file resulting from compilation and/or
+#               linking steps.
+# - pkg_output  The final .llext file.
 #
 # Example usage:
 #   add_llext_target(hello_world
@@ -5131,10 +5145,8 @@ function(add_llext_target target_name)
     message(FATAL_ERROR "add_llext_target: CONFIG_LLEXT must be enabled")
   endif()
 
-  # Output file must be provided
-  if(NOT LLEXT_OUTPUT)
-    message(FATAL_ERROR "add_llext_target: OUTPUT argument must be provided")
-  endif()
+  # Source and output files must be provided
+  zephyr_check_arguments_required_all("add_llext_target" LLEXT OUTPUT SOURCES)
 
   # Source list length must currently be 1
   list(LENGTH LLEXT_SOURCES source_count)
@@ -5142,15 +5154,8 @@ function(add_llext_target target_name)
     message(FATAL_ERROR "add_llext_target: only one source file is supported")
   endif()
 
-  set(output_file ${LLEXT_OUTPUT})
+  set(llext_pkg_output ${LLEXT_OUTPUT})
   set(source_file ${LLEXT_SOURCES})
-  get_filename_component(output_name ${output_file} NAME)
-
-  # Add user-visible target and dependency
-  add_custom_target(${target_name}
-    COMMENT "Compiling ${output_name}"
-    DEPENDS ${output_file}
-  )
 
   # Convert the LLEXT_REMOVE_FLAGS list to a regular expression, and use it to
   # filter out these flags from the Zephyr target settings
@@ -5166,62 +5171,86 @@ function(add_llext_target target_name)
       "$<FILTER:${zephyr_flags},EXCLUDE,${llext_remove_flags_regexp}>"
   )
 
-  # Compile the source file to an object file using current Zephyr settings
-  # but a different set of flags
-  add_library(${target_name}_lib OBJECT ${source_file})
-  target_compile_definitions(${target_name}_lib PRIVATE
+  # Compile the source file using current Zephyr settings but a different
+  # set of flags.
+  # This is currently arch-specific since the ARM loader for .llext files
+  # expects object file format, while the Xtensa one uses shared libraries.
+  set(llext_lib_target ${target_name}_llext_lib)
+  if(CONFIG_ARM)
+
+    # Create an object library to compile the source file
+    add_library(${llext_lib_target} OBJECT ${source_file})
+    set(llext_lib_output $<TARGET_OBJECTS:${llext_lib_target}>)
+
+  elseif(CONFIG_XTENSA)
+
+    # Create a shared library
+    add_library(${llext_lib_target} SHARED ${source_file})
+    set(llext_lib_output $<TARGET_FILE:${llext_lib_target}>)
+
+    # Add the llext flags to the linking step as well
+    target_link_options(${llext_lib_target} PRIVATE
+      ${LLEXT_APPEND_FLAGS}
+    )
+
+  endif()
+
+  target_compile_definitions(${llext_lib_target} PRIVATE
     $<TARGET_PROPERTY:zephyr_interface,INTERFACE_COMPILE_DEFINITIONS>
   )
-  target_compile_options(${target_name}_lib PRIVATE
+  target_compile_options(${llext_lib_target} PRIVATE
     ${zephyr_filtered_flags}
     ${LLEXT_APPEND_FLAGS}
     ${LLEXT_C_FLAGS}
   )
-  target_include_directories(${target_name}_lib PRIVATE
+  target_include_directories(${llext_lib_target} PRIVATE
     $<TARGET_PROPERTY:zephyr_interface,INTERFACE_INCLUDE_DIRECTORIES>
   )
-  target_include_directories(${target_name}_lib SYSTEM PUBLIC
+  target_include_directories(${llext_lib_target} SYSTEM PUBLIC
     $<TARGET_PROPERTY:zephyr_interface,INTERFACE_SYSTEM_INCLUDE_DIRECTORIES>
   )
-  add_dependencies(${target_name}_lib
+  add_dependencies(${llext_lib_target}
     zephyr_interface
     zephyr_generated_headers
   )
 
-  # Arch-specific conversion of the object file to an llext
+  # Arch-specific packaging of the built binary file into an .llext file
   if(CONFIG_ARM)
 
-    # No conversion required, simply copy the object file
+    # No packaging required, simply copy the object file
     add_custom_command(
-      OUTPUT ${output_file}
-      COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_OBJECTS:${target_name}_lib> ${output_file}
-      DEPENDS ${target_name}_lib $<TARGET_OBJECTS:${target_name}_lib>
+      OUTPUT ${llext_pkg_output}
+      COMMAND ${CMAKE_COMMAND} -E copy ${llext_lib_output} ${llext_pkg_output}
+      DEPENDS ${llext_lib_target} ${llext_lib_output}
     )
 
   elseif(CONFIG_XTENSA)
 
-    # Generate an intermediate file name
-    get_filename_component(output_dir ${output_file} DIRECTORY)
-    get_filename_component(output_name_we ${output_file} NAME_WE)
-    set(pre_output_file ${output_dir}/${output_name_we}.pre.llext)
-
-    # Need to convert the object file to a shared library, then strip some sections
+    # Need to strip the shared library of some sections
     add_custom_command(
-      OUTPUT ${output_file}
-      BYPRODUCTS ${pre_output_file}
-      COMMAND ${CMAKE_C_COMPILER} ${LLEXT_APPEND_FLAGS}
-              -o ${pre_output_file}
-              $<TARGET_OBJECTS:${target_name}_lib>
+      OUTPUT ${llext_pkg_output}
       COMMAND $<TARGET_PROPERTY:bintools,strip_command>
               $<TARGET_PROPERTY:bintools,strip_flag>
               $<TARGET_PROPERTY:bintools,strip_flag_remove_section>.xt.*
-              $<TARGET_PROPERTY:bintools,strip_flag_infile>${pre_output_file}
-              $<TARGET_PROPERTY:bintools,strip_flag_outfile>${output_file}
+              $<TARGET_PROPERTY:bintools,strip_flag_infile>${llext_lib_output}
+              $<TARGET_PROPERTY:bintools,strip_flag_outfile>${llext_pkg_output}
               $<TARGET_PROPERTY:bintools,strip_flag_final>
-      DEPENDS ${target_name}_lib $<TARGET_OBJECTS:${target_name}_lib>
+      DEPENDS ${llext_lib_target} ${llext_lib_output}
     )
 
   else()
     message(FATAL_ERROR "add_llext_target: unsupported architecture")
   endif()
+
+  # Add user-visible target and dependency, and fill in properties
+  get_filename_component(output_name ${llext_pkg_output} NAME)
+  add_custom_target(${target_name}
+    COMMENT "Generating ${output_name}"
+    DEPENDS ${llext_pkg_output}
+  )
+  set_target_properties(${target_name} PROPERTIES
+    lib_target ${llext_lib_target}
+    lib_output ${llext_lib_output}
+    pkg_output ${llext_pkg_output}
+  )
 endfunction()

--- a/tests/subsys/llext/simple/CMakeLists.txt
+++ b/tests/subsys/llext/simple/CMakeLists.txt
@@ -27,4 +27,14 @@ foreach(ext_name hello_world logging relative_jump object)
   )
   generate_inc_file_for_target(app ${ext_bin} ${ext_inc})
 endforeach()
+
+# Add a dummy custom processing command to test add_llext_command
+get_target_property(proc_in_file hello_world_ext lib_output)
+get_target_property(proc_out_file hello_world_ext pkg_input)
+add_llext_command(
+  TARGET hello_world_ext
+  POST_BUILD
+  COMMAND echo "dummy patching ${proc_in_file} to create ${proc_out_file}"
+  COMMAND ${CMAKE_COMMAND} -E copy ${proc_in_file} ${proc_out_file}
+)
 endif()


### PR DESCRIPTION
This PR reworks `add_llext_target` to more cleanly mimic existing CMake machinery, and support adding custom commands to the extension building stages (as turned out to be useful in [this SOF PR](https://github.com/thesofproject/sof/pull/8180)).

The `C_FLAGS` argument to `add_llext_target` has been removed. Flags, defines, paths and similar configuration options can now be set using functions that mimic CMake's `target_`* API.

Custom build steps can be requested via the new `add_llext_command` function, that shares the API with `add_custom_command`:
```CMake
add_llext_command(
   TARGET llext_target
   PRE_BUILD | POST_BUILD | POST_PKG
   COMMAND ...
)
```

Intermediate file or target names are exported via properties on the main target and can be accessed via the `get_target_property()` function:
    - `lib_target`: Target name for the compilation and/or link step.
    - `lib_output`: Name of the binary file resulting from compilation and/or linking steps.
    - `pkg_input`: Name of the binary file to be used as input to the packaging stage.
    - `pkg_output`: Name of the final llext file.
    
The phase options have natural meanings:
* `PRE_BUILD` runs after compilation, but before any linking step takes place (as CMake); might use `lib_target` to get additional variables.
* `POST_BUILD`runs after all code-related compile/link stages have been executed (as CMake), but before packaging; this is expected to create `pkg_input` by processing the contents of `lib_output`.
* `POST_PKG` is a new stage after the packaging in .llext is complete; might access the contents of the file `pkg_output`.