### PR TITLE
drivers: i2c: rv32m1: Fix build error

### DIFF
--- a/drivers/i2c/i2c_rv32m1_lpi2c.c
+++ b/drivers/i2c/i2c_rv32m1_lpi2c.c
@@ -15,6 +15,7 @@
 #include <zephyr/irq.h>
 #include <fsl_lpi2c.h>
 #include <zephyr/logging/log.h>
+#include <soc.h>
 #include <zephyr/drivers/pinctrl.h>
 
 LOG_MODULE_REGISTER(rv32m1_lpi2c);


### PR DESCRIPTION
This fixes following build error when rv32m1_vega_zero_riscy board gets compiled:

    implicit declaration of function 'INST_DT_CLOCK_IP_NAME'

Fixes #68012