### PR TITLE
sd: omit zero-initialization for local variable and add config SD_CMD_RETRIES

### DIFF
--- a/subsys/sd/Kconfig
+++ b/subsys/sd/Kconfig
@@ -80,6 +80,12 @@ config SD_BUFFER_SIZE
 	  Size in bytes of internal buffer SD card uses for unaligned reads and
 	  internal data reads during initialization
 
+config SD_CMD_RETRIES
+	int "Number of times to retry sending command to card"
+	default 0
+	help
+	  Number of times to retry sending command to SD card in case of failure
+
 config SD_DATA_RETRIES
 	int "Number of times to retry sending data to card"
 	default 3

--- a/subsys/sd/sd.c
+++ b/subsys/sd/sd.c
@@ -21,7 +21,7 @@ LOG_MODULE_REGISTER(sd, CONFIG_SD_LOG_LEVEL);
 /* Idle all cards on bus. Can be used to clear errors on cards */
 static inline int sd_idle(struct sd_card *card)
 {
-	struct sdhc_command cmd = {0};
+	struct sdhc_command cmd;
 
 	/* Reset card with CMD0 */
 	cmd.opcode = SD_GO_IDLE_STATE;
@@ -35,7 +35,7 @@ static inline int sd_idle(struct sd_card *card)
 /* Sends CMD8 during SD initialization */
 static int sd_send_interface_condition(struct sd_card *card)
 {
-	struct sdhc_command cmd = {0};
+	struct sdhc_command cmd;
 	int ret;
 	uint32_t resp;
 
@@ -72,7 +72,7 @@ static int sd_send_interface_condition(struct sd_card *card)
 /* Sends CMD59 to enable CRC checking for SD card in SPI mode */
 static int sd_enable_crc(struct sd_card *card)
 {
-	struct sdhc_command cmd = {0};
+	struct sdhc_command cmd;
 
 	/* CMD59 for CRC mode is only valid for SPI hosts */
 	__ASSERT_NO_MSG(card->host_props.is_spi);

--- a/subsys/sd/sd.c
+++ b/subsys/sd/sd.c
@@ -27,6 +27,7 @@ static inline int sd_idle(struct sd_card *card)
 	cmd.opcode = SD_GO_IDLE_STATE;
 	cmd.arg = 0x0;
 	cmd.response_type = (SD_RSP_TYPE_NONE | SD_SPI_RSP_TYPE_R1);
+	cmd.retries = CONFIG_SD_CMD_RETRIES;
 	cmd.timeout_ms = CONFIG_SD_CMD_TIMEOUT;
 	return sdhc_request(card->sdhc, &cmd, NULL);
 }
@@ -41,6 +42,7 @@ static int sd_send_interface_condition(struct sd_card *card)
 	cmd.opcode = SD_SEND_IF_COND;
 	cmd.arg = SD_IF_COND_VHS_3V3 | SD_IF_COND_CHECK;
 	cmd.response_type = (SD_RSP_TYPE_R7 | SD_SPI_RSP_TYPE_R7);
+	cmd.retries = CONFIG_SD_CMD_RETRIES;
 	cmd.timeout_ms = CONFIG_SD_CMD_TIMEOUT;
 	ret = sdhc_request(card->sdhc, &cmd, NULL);
 	if (ret) {
@@ -77,6 +79,7 @@ static int sd_enable_crc(struct sd_card *card)
 	cmd.opcode = SD_SPI_CRC_ON_OFF;
 	cmd.arg = 0x1; /* Enable CRC */
 	cmd.response_type = SD_SPI_RSP_TYPE_R1;
+	cmd.retries = CONFIG_SD_CMD_RETRIES;
 	cmd.timeout_ms = CONFIG_SD_CMD_TIMEOUT;
 	return sdhc_request(card->sdhc, &cmd, NULL);
 }

--- a/subsys/sd/sd_ops.c
+++ b/subsys/sd/sd_ops.c
@@ -27,6 +27,7 @@ int sdmmc_read_status(struct sd_card *card)
 		cmd.arg = (card->relative_addr << 16U);
 	}
 	cmd.response_type = (SD_RSP_TYPE_R1 | SD_SPI_RSP_TYPE_R2);
+	cmd.retries = CONFIG_SD_CMD_RETRIES;
 	cmd.timeout_ms = CONFIG_SD_CMD_TIMEOUT;
 
 	ret = sdhc_request(card->sdhc, &cmd, NULL);
@@ -204,6 +205,7 @@ static int sdmmc_spi_read_cxd(struct sd_card *card, uint32_t opcode, uint32_t *c
 	cmd.opcode = opcode;
 	cmd.arg = 0;
 	cmd.response_type = SD_SPI_RSP_TYPE_R1;
+	cmd.retries = CONFIG_SD_CMD_RETRIES;
 	cmd.timeout_ms = CONFIG_SD_CMD_TIMEOUT;
 
 	/* CID/CSD is 16 bytes */
@@ -232,6 +234,7 @@ static int sdmmc_read_cxd(struct sd_card *card, uint32_t opcode, uint32_t rca, u
 	cmd.opcode = opcode;
 	cmd.arg = (rca << 16);
 	cmd.response_type = SD_RSP_TYPE_R2;
+	cmd.retries = CONFIG_SD_CMD_RETRIES;
 	cmd.timeout_ms = CONFIG_SD_CMD_TIMEOUT;
 
 	ret = sdhc_request(card->sdhc, &cmd, NULL);
@@ -325,6 +328,7 @@ int sdmmc_switch_voltage(struct sd_card *card)
 	cmd.opcode = SD_VOL_SWITCH;
 	cmd.arg = 0U;
 	cmd.response_type = SD_RSP_TYPE_R1;
+	cmd.retries = CONFIG_SD_CMD_RETRIES;
 	cmd.timeout_ms = CONFIG_SD_CMD_TIMEOUT;
 	ret = sdhc_request(card->sdhc, &cmd, NULL);
 	if (ret) {
@@ -403,6 +407,7 @@ int sdmmc_request_rca(struct sd_card *card)
 	cmd.opcode = SD_SEND_RELATIVE_ADDR;
 	cmd.arg = 0;
 	cmd.response_type = SD_RSP_TYPE_R6;
+	cmd.retries = CONFIG_SD_CMD_RETRIES;
 	cmd.timeout_ms = CONFIG_SD_CMD_TIMEOUT;
 	/* Issue CMD3 until card responds with nonzero RCA */
 	do {
@@ -429,6 +434,7 @@ int sdmmc_select_card(struct sd_card *card)
 	cmd.opcode = SD_SELECT_CARD;
 	cmd.arg = ((card->relative_addr) << 16U);
 	cmd.response_type = SD_RSP_TYPE_R1;
+	cmd.retries = CONFIG_SD_CMD_RETRIES;
 	cmd.timeout_ms = CONFIG_SD_CMD_TIMEOUT;
 
 	ret = sdhc_request(card->sdhc, &cmd, NULL);
@@ -453,6 +459,7 @@ int card_app_command(struct sd_card *card, int relative_card_address)
 	cmd.opcode = SD_APP_CMD;
 	cmd.arg = relative_card_address << 16U;
 	cmd.response_type = (SD_RSP_TYPE_R1 | SD_SPI_RSP_TYPE_R1);
+	cmd.retries = CONFIG_SD_CMD_RETRIES;
 	cmd.timeout_ms = CONFIG_SD_CMD_TIMEOUT;
 	ret = sdhc_request(card->sdhc, &cmd, NULL);
 	if (ret) {
@@ -498,8 +505,8 @@ static int card_read(struct sd_card *card, uint8_t *rbuf, uint32_t start_block, 
 		cmd.arg = start_block;
 	}
 	cmd.response_type = (SD_RSP_TYPE_R1 | SD_SPI_RSP_TYPE_R1);
-	cmd.timeout_ms = CONFIG_SD_CMD_TIMEOUT;
 	cmd.retries = CONFIG_SD_DATA_RETRIES;
+	cmd.timeout_ms = CONFIG_SD_CMD_TIMEOUT;
 
 	data.block_addr = start_block;
 	data.block_size = card->block_size;
@@ -610,6 +617,7 @@ static int card_query_written(struct sd_card *card, uint32_t *num_written)
 	cmd.opcode = SD_APP_SEND_NUM_WRITTEN_BLK;
 	cmd.arg = 0;
 	cmd.response_type = (SD_RSP_TYPE_R1 | SD_SPI_RSP_TYPE_R1);
+	cmd.retries = CONFIG_SD_CMD_RETRIES;
 	cmd.timeout_ms = CONFIG_SD_CMD_TIMEOUT;
 
 	data.block_size = 4U;
@@ -653,8 +661,8 @@ static int card_write(struct sd_card *card, const uint8_t *wbuf, uint32_t start_
 		cmd.arg = start_block;
 	}
 	cmd.response_type = (SD_RSP_TYPE_R1 | SD_SPI_RSP_TYPE_R1);
-	cmd.timeout_ms = CONFIG_SD_CMD_TIMEOUT;
 	cmd.retries = CONFIG_SD_DATA_RETRIES;
+	cmd.timeout_ms = CONFIG_SD_CMD_TIMEOUT;
 
 	data.block_addr = start_block;
 	data.block_size = card->block_size;

--- a/subsys/sd/sd_ops.c
+++ b/subsys/sd/sd_ops.c
@@ -253,7 +253,7 @@ static int sdmmc_read_cxd(struct sd_card *card, uint32_t opcode, uint32_t rca, u
 int sdmmc_read_csd(struct sd_card *card)
 {
 	int ret;
-	uint32_t csd[4] = {0};
+	uint32_t csd[4];
 	/* Keep CSD on stack for reduced RAM usage */
 	struct sd_csd card_csd = {0};
 
@@ -276,7 +276,7 @@ int sdmmc_read_csd(struct sd_card *card)
 /* Reads card identification register, and decodes it */
 int card_read_cid(struct sd_card *card)
 {
-	uint32_t cid[4] = {0};
+	uint32_t cid[4];
 	int ret;
 #if defined(CONFIG_SDMMC_STACK) || defined(CONFIG_SDIO_STACK)
 	/* Keep CID on stack for reduced RAM usage */

--- a/subsys/sd/sd_ops.c
+++ b/subsys/sd/sd_ops.c
@@ -19,10 +19,11 @@ LOG_MODULE_DECLARE(sd, CONFIG_SD_LOG_LEVEL);
 /* Read card status. Return 0 if card is inactive */
 int sdmmc_read_status(struct sd_card *card)
 {
-	struct sdhc_command cmd = {0};
+	struct sdhc_command cmd;
 	int ret;
 
 	cmd.opcode = SD_SEND_STATUS;
+	cmd.arg = 0;
 	if (!card->host_props.is_spi) {
 		cmd.arg = (card->relative_addr << 16U);
 	}
@@ -196,8 +197,8 @@ static inline void sdmmc_decode_cid(struct sd_cid *cid, uint32_t *raw_cid)
 /* Reads card id/csd register (in SPI mode) */
 static int sdmmc_spi_read_cxd(struct sd_card *card, uint32_t opcode, uint32_t *cxd)
 {
-	struct sdhc_command cmd = {0};
-	struct sdhc_data data = {0};
+	struct sdhc_command cmd;
+	struct sdhc_data data;
 	int ret, i;
 	/* Use internal card buffer for data transfer */
 	uint32_t *cxd_be = (uint32_t *)card->card_buffer;
@@ -209,6 +210,7 @@ static int sdmmc_spi_read_cxd(struct sd_card *card, uint32_t opcode, uint32_t *c
 	cmd.timeout_ms = CONFIG_SD_CMD_TIMEOUT;
 
 	/* CID/CSD is 16 bytes */
+	data.block_addr = 0;        /* Unused set to 0 */
 	data.block_size = 16;
 	data.blocks = 1U;
 	data.data = cxd_be;
@@ -228,7 +230,7 @@ static int sdmmc_spi_read_cxd(struct sd_card *card, uint32_t opcode, uint32_t *c
 /* Reads card id/csd register (native SD mode */
 static int sdmmc_read_cxd(struct sd_card *card, uint32_t opcode, uint32_t rca, uint32_t *cxd)
 {
-	struct sdhc_command cmd = {0};
+	struct sdhc_command cmd;
 	int ret;
 
 	cmd.opcode = opcode;
@@ -316,7 +318,7 @@ int card_read_cid(struct sd_card *card)
 int sdmmc_switch_voltage(struct sd_card *card)
 {
 	int ret, sd_clock;
-	struct sdhc_command cmd = {0};
+	struct sdhc_command cmd;
 
 	/* Check to make sure card supports 1.8V */
 	if (!(card->flags & SD_1800MV_FLAG)) {
@@ -401,7 +403,7 @@ int sdmmc_switch_voltage(struct sd_card *card)
  */
 int sdmmc_request_rca(struct sd_card *card)
 {
-	struct sdhc_command cmd = {0};
+	struct sdhc_command cmd;
 	int ret;
 
 	cmd.opcode = SD_SEND_RELATIVE_ADDR;
@@ -428,7 +430,7 @@ int sdmmc_request_rca(struct sd_card *card)
  */
 int sdmmc_select_card(struct sd_card *card)
 {
-	struct sdhc_command cmd = {0};
+	struct sdhc_command cmd;
 	int ret;
 
 	cmd.opcode = SD_SELECT_CARD;
@@ -453,7 +455,7 @@ int sdmmc_select_card(struct sd_card *card)
 /* Helper to send SD app command */
 int card_app_command(struct sd_card *card, int relative_card_address)
 {
-	struct sdhc_command cmd = {0};
+	struct sdhc_command cmd;
 	int ret;
 
 	cmd.opcode = SD_APP_CMD;
@@ -482,8 +484,8 @@ int card_app_command(struct sd_card *card, int relative_card_address)
 static int card_read(struct sd_card *card, uint8_t *rbuf, uint32_t start_block, uint32_t num_blocks)
 {
 	int ret;
-	struct sdhc_command cmd = {0};
-	struct sdhc_data data = {0};
+	struct sdhc_command cmd;
+	struct sdhc_data data;
 
 	/*
 	 * Note: The SD specification allows for CMD23 to be sent before a
@@ -604,8 +606,8 @@ int card_read_blocks(struct sd_card *card, uint8_t *rbuf, uint32_t start_block, 
 static int card_query_written(struct sd_card *card, uint32_t *num_written)
 {
 	int ret;
-	struct sdhc_command cmd = {0};
-	struct sdhc_data data = {0};
+	struct sdhc_command cmd;
+	struct sdhc_data data;
 	uint32_t *blocks = (uint32_t *)card->card_buffer;
 
 	ret = card_app_command(card, card->relative_addr);
@@ -620,6 +622,7 @@ static int card_query_written(struct sd_card *card, uint32_t *num_written)
 	cmd.retries = CONFIG_SD_CMD_RETRIES;
 	cmd.timeout_ms = CONFIG_SD_CMD_TIMEOUT;
 
+	data.block_addr = 0;        /* Unused set to 0 */
 	data.block_size = 4U;
 	data.blocks = 1U;
 	data.data = blocks;
@@ -646,8 +649,8 @@ static int card_write(struct sd_card *card, const uint8_t *wbuf, uint32_t start_
 {
 	int ret;
 	uint32_t blocks;
-	struct sdhc_command cmd = {0};
-	struct sdhc_data data = {0};
+	struct sdhc_command cmd;
+	struct sdhc_data data;
 
 	/*
 	 * See the note in card_read() above. We will not issue CMD23

--- a/subsys/sd/sd_ops.c
+++ b/subsys/sd/sd_ops.c
@@ -313,7 +313,7 @@ int card_read_cid(struct sd_card *card)
 
 /*
  * Implements signal voltage switch procedure described in section 3.6.1 of
- * SD specification.
+ * SD host controller specification.
  */
 int sdmmc_switch_voltage(struct sd_card *card)
 {

--- a/subsys/sd/sd_ops.h
+++ b/subsys/sd/sd_ops.h
@@ -10,7 +10,7 @@
 
 /*
  * Switches voltage of SD card to 1.8V, as described by
- * "Signal volatage switch procedure" in section 3.6.1 of SD specification.
+ * "Signal voltage switch procedure" in section 3.6.1 of SD specification.
  */
 int sdmmc_switch_voltage(struct sd_card *card);
 

--- a/subsys/sd/sd_ops.h
+++ b/subsys/sd/sd_ops.h
@@ -10,7 +10,7 @@
 
 /*
  * Switches voltage of SD card to 1.8V, as described by
- * "Signal voltage switch procedure" in section 3.6.1 of SD specification.
+ * "Signal voltage switch procedure" in section 3.6.1 of SD host controller specification.
  */
 int sdmmc_switch_voltage(struct sd_card *card);
 


### PR DESCRIPTION
This series of commits is an effort to remove zero-initialization, specifically targeting the `sdhc_command` and `sdhc_data` structures.
Suggestions and insights from maintainers are always welcome and appreciated. 🚀 