### PR TITLE
soc: intel_adsp/ace: fix assert for uncached pointer

### DIFF
--- a/soc/xtensa/intel_adsp/ace/multiprocessing.c
+++ b/soc/xtensa/intel_adsp/ace/multiprocessing.c
@@ -89,8 +89,14 @@ void soc_mp_init(void)
 	/* Set the core 0 active */
 	soc_cpus_active[0] = true;
 #if CONFIG_SOC_INTEL_ACE15_MTPM
+#if defined(CONFIG_SMP) && (CONFIG_MP_MAX_NUM_CPUS > 1)
+	/*
+	 * Only when more than 1 CPUs is enabled, then this is in uncached area.
+	 * Otherwise, this is in cached area and will fail this test.
+	 */
 	__ASSERT(!arch_xtensa_is_ptr_cached(&g_key_read_holder),
 		 "g_key_read_holder must be uncached");
+#endif /* defined(CONFIG_SMP) && (CONFIG_MP_MAX_NUM_CPUS > 1) */
 	g_key_read_holder = INTEL_ADSP_ACE15_MAGIC_KEY;
 #endif /* CONFIG_SOC_INTEL_ACE15_MTPM */
 }


### PR DESCRIPTION
Only when CONFIG_MP_MAX_NUM_CPUS > 1, then .bss is put in uncached region. Otherwise, .bss is in cached region. So the assertion that g_key_read_holder must be in uncached region must take into account how many CPUs are enabled on build.