### PR TITLE
MAINTAINERS: add a separate area for blackmagicprobe runner

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -300,6 +300,15 @@ Binary Descriptors:
   tests:
     - bindesc
 
+Black Magic Probe Runner:
+  status: maintained
+  maintainers:
+    - fabiobaltieri
+  files:
+    - boards/common/blackmagicprobe.board.cmake
+    - scripts/west_commands/runners/blackmagicprobe.py
+    - scripts/west_commands/tests/test_blackmagicprobe.py
+
 Bluetooth:
   status: maintained
   maintainers:


### PR DESCRIPTION
Add an area for Black Magic Probe and myself as maintainer. It's just a runner file and does not get much traffic, but I have the hardware to test this and use it regularly so I may as well get PRs for this from the bot.