### PR TITLE
scripts: improve yaml schema and board.yml validation for revisions

### DIFF
--- a/scripts/list_boards.py
+++ b/scripts/list_boards.py
@@ -197,6 +197,15 @@ def find_v2_boards(args):
                         # Not the board we're looking for, ignore.
                         continue
 
+                board_revision = board.get('revision')
+                if board_revision is not None and board_revision.get('format') != 'custom':
+                    if board_revision.get('default') is None:
+                        sys.exit(f'ERROR: Malformed "board" section in file: {board_yml.as_posix()}\n'
+                                 "Cannot find required key 'default'. Path: '/board/revision.'")
+                    if board_revision.get('revisions') is None:
+                        sys.exit(f'ERROR: Malformed "board" section in file: {board_yml.as_posix()}\n'
+                                 "Cannot find required key 'revisions'. Path: '/board/revision.'")
+
                 mutual_exclusive = {'socs', 'variants'}
                 if len(mutual_exclusive - board.keys()) < 1:
                     sys.exit(f'ERROR: Malformed "board" section in file: {board_yml.as_posix()}\n'

--- a/scripts/schemas/board-schema.yml
+++ b/scripts/schemas/board-schema.yml
@@ -44,13 +44,13 @@ schema;board-schema:
           enum:
             ["major.minor.patch", "letter", "number", "custom"]
         default:
-          required: true
+          required: false # This field is required when 'format' != 'custom'
           type: str
         exact:
           required: false
           type: bool
         revisions:
-          required: true
+          required: false # This field is required when 'format' != 'custom'
           type: seq
           sequence:
             - type: map


### PR DESCRIPTION
Make 'default' and 'revisions' fields optional for custom revisions. When using custom revision format, then board author must create a revision.cmake file for revision handling, in which case revisions don't need to be specified in the board.yml file.

Therefore make 'default' and 'revisions' fields optional in the schema and implement custom yaml validation which can validate that 'default' and 'revisions' are specified for all other revision formats.