### PR TITLE
multi_heap: keep number of heaps as an unsigned value

### DIFF
--- a/include/zephyr/sys/multi_heap.h
+++ b/include/zephyr/sys/multi_heap.h
@@ -58,7 +58,7 @@ struct sys_multi_heap_rec {
 };
 
 struct sys_multi_heap {
-	int nheaps;
+	unsigned int nheaps;
 	sys_multi_heap_fn_t choice;
 	struct sys_multi_heap_rec heaps[MAX_MULTI_HEAPS];
 };


### PR DESCRIPTION
Although very unlikely for this value to ever be negative in practice,
this would make Coverity happy.

Fixes #67969
