### PR TITLE
drivers: nxp_enet: Fix build error with PTP on

### DIFF
--- a/drivers/ptp_clock/ptp_clock_nxp_enet.c
+++ b/drivers/ptp_clock/ptp_clock_nxp_enet.c
@@ -153,7 +153,7 @@ static int ptp_clock_nxp_enet_rate_adjust(const struct device *dev,
 
 void nxp_enet_ptp_clock_callback(const struct device *dev,
 			enum nxp_enet_callback_reason event,
-			void *data)
+			void *cb_data)
 {
 	const struct ptp_clock_nxp_enet_config *config = dev->config;
 	struct ptp_clock_nxp_enet_data *data = dev->data;
@@ -181,9 +181,9 @@ void nxp_enet_ptp_clock_callback(const struct device *dev,
 				      &ptp_config);
 	}
 
-	if (data != NULL) {
+	if (cb_data != NULL) {
 		/* Share the mutex with mac driver */
-		*(struct k_mutex *)data = &data->ptp_mutex;
+		*(uintptr_t *)cb_data = (uintptr_t)&data->ptp_mutex;
 	}
 }
 

--- a/samples/net/gptp/sample.yaml
+++ b/samples/net/gptp/sample.yaml
@@ -21,3 +21,10 @@ tests:
     depends_on: netif
     integration_platforms:
       - frdm_k64f
+  sample.net.gpt.nxp_enet_experimental:
+    extra_args: EXTRA_DTC_OVERLAY_FILE="nxp,enet-experimental.overlay"
+    platform_allow:
+      - mimxrt1050_evk
+      - mimxrt1060_evk
+      - mimxrt1064_evk
+      - mimxrt1024_evk


### PR DESCRIPTION
Fix build errors in nxp enet driver during case where PTP is on, and add coverage of this code to CI 

Fixes #67929

