### PR TITLE
drivers: display: ili9xxx: support display_read

### DIFF
--- a/boards/shields/adafruit_2_8_tft_touch_v2/dts/adafruit_2_8_tft_touch_v2.dtsi
+++ b/boards/shields/adafruit_2_8_tft_touch_v2/dts/adafruit_2_8_tft_touch_v2.dtsi
@@ -19,7 +19,7 @@
 		invert-y;
 	};
 
-	adafruit_2_8_tft_touch_v2_mipi_dbi {
+	adafruit_2_8_tft_touch_v2_mipi_dbi: adafruit_2_8_tft_touch_v2_mipi_dbi {
 		compatible = "zephyr,mipi-dbi-spi";
 		spi-dev = <&arduino_spi>;
 		dc-gpios = <&arduino_header 15 GPIO_ACTIVE_HIGH>;	/* D9 */

--- a/drivers/display/Kconfig.ili9xxx
+++ b/drivers/display/Kconfig.ili9xxx
@@ -10,6 +10,15 @@ config ILI9XXX
 	help
 	  Hidden configuration entry for all ILI9XXX drivers.
 
+config ILI9XXX_READ
+	bool "Allow display_read API with ILI9XXX"
+	help
+	  Support display_read API with ILI9XXX controllers. This API is opt-in,
+	  because it adds code overhead and is not very performant due to
+	  the requirement to bitshift data read from the ILI9XXX. Note the
+	  API only supports RGB565 mode.
+
+
 config ILI9340
 	bool "ILI9340 display driver"
 	default y

--- a/drivers/display/display_ili9xxx.h
+++ b/drivers/display/display_ili9xxx.h
@@ -22,8 +22,11 @@
 #define ILI9XXX_CASET 0x2a
 #define ILI9XXX_PASET 0x2b
 #define ILI9XXX_RAMWR 0x2c
+#define ILI9XXX_RGBSET 0x2d
+#define ILI9XXX_RAMRD 0x2e
 #define ILI9XXX_MADCTL 0x36
 #define ILI9XXX_PIXSET 0x3A
+#define ILI9XXX_RAMRD_CONT 0x3e
 
 /* MADCTL register fields. */
 #define ILI9XXX_MADCTL_MY BIT(7U)

--- a/tests/drivers/display/display_read_write/adafruit_2_8_tft_touch_rgb565.overlay
+++ b/tests/drivers/display/display_read_write/adafruit_2_8_tft_touch_rgb565.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/display/ili9xxx.h>
+
+&adafruit_2_8_tft_touch_v2_ili9340 {
+	pixel-format = <ILI9XXX_PIXEL_FORMAT_RGB565>;
+};
+
+&adafruit_2_8_tft_touch_v2_mipi_dbi {
+	/delete-property/ write-only;
+};

--- a/tests/drivers/display/display_read_write/testcase.yaml
+++ b/tests/drivers/display/display_read_write/testcase.yaml
@@ -50,3 +50,15 @@ tests:
     extra_configs:
       - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_BGR_565=y
       - CONFIG_SDL_DISPLAY_USE_HARDWARE_ACCELERATOR=n
+  drivers.display.read_write.ili9340:
+    tags:
+      - shield
+    extra_args:
+      - SHIELD=adafruit_2_8_tft_touch_v2
+      - EXTRA_DTC_OVERLAY_FILE=adafruit_2_8_tft_touch_rgb565.overlay
+    extra_configs:
+      - CONFIG_ILI9XXX_READ=y
+    # Use platform_allow, because we cannot filter the test based on the
+    # presence of the arduino_spi DT nodelabel
+    platform_allow:
+      - mimxrt685_evk/mimxrt685s/cm33


### PR DESCRIPTION
Add support for ILI9xxx display reads. This feature is opt-in, as the bit shifting required results in a very slow performance. It is primarily useful for testing, and was implemented to verify the mipi command read support present in #64587, and therefore contains the commits from that PR. This will be kept as a draft until that RFC merges.