### PR TITLE
tests: kernel: timer: timer_api: disable CONFIG_PM for it8xxx2_evb

### DIFF
--- a/tests/kernel/timer/timer_api/testcase.yaml
+++ b/tests/kernel/timer/timer_api/testcase.yaml
@@ -6,6 +6,8 @@ tests:
       - userspace
   kernel.timer.tickless:
     extra_args: CONF_FILE="prj_tickless.conf"
+    extra_configs:
+      - platform:it8xxx2_evb:CONFIG_PM=n
     arch_exclude:
       - nios2
       - posix


### PR DESCRIPTION
The it8xxx2 chip needs more time to resume from low-power mode and it results in the failure of the kernel.timer.tickless test. This commit disables CONFIG_PM for the it8xxx2_evb platform to address this issue.