### PR TITLE
 posix: implement pthread_rwlockattr_setpshared() #66965

### DIFF
--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -403,7 +403,7 @@ _POSIX_READER_WRITER_LOCKS
     pthread_rwlockattr_destroy(),yes
     pthread_rwlockattr_getpshared(),
     pthread_rwlockattr_init(),yes
-    pthread_rwlockattr_setpshared(),
+    pthread_rwlockattr_setpshared(),yes
 
 .. _posix_option_thread_attr_stackaddr:
 

--- a/include/zephyr/posix/pthread.h
+++ b/include/zephyr/posix/pthread.h
@@ -403,7 +403,7 @@ static inline int pthread_rwlockattr_init(pthread_rwlockattr_t *attr)
 	ARG_UNUSED(attr);
 	return 0;
 }
-
+int pthread_rwlockattr_setpshared(pthread_rwlockattr_t *attr, int pshared);
 int pthread_attr_getguardsize(const pthread_attr_t *ZRESTRICT attr, size_t *ZRESTRICT guardsize);
 int pthread_attr_getstacksize(const pthread_attr_t *attr, size_t *stacksize);
 int pthread_attr_setguardsize(pthread_attr_t *attr, size_t guardsize);

--- a/lib/posix/rwlock.c
+++ b/lib/posix/rwlock.c
@@ -34,6 +34,11 @@ int pthread_rwlock_init(pthread_rwlock_t *rwlock,
 	return 0;
 }
 
+int pthread_rwlockattr_setpshared(pthread_rwlockattr_t *attr, int pshared);
+{
+	(*rwlock)->status = pshared;
+}
+
 /**
  * @brief Destroy read-write lock object.
  *

--- a/tests/posix/headers/src/pthread_h.c
+++ b/tests/posix/headers/src/pthread_h.c
@@ -145,7 +145,7 @@ ZTEST(posix_headers, test_pthread_h)
 		zassert_not_null(pthread_rwlockattr_destroy);
 		/* zassert_not_null(pthread_rwlockattr_getpshared); */ /* not implemented */
 		zassert_not_null(pthread_rwlockattr_init);
-		/* zassert_not_null(pthread_rwlockattr_setpshared); */ /* not implemented */
+		zassert_not_null(pthread_rwlockattr_setpshared);
 		zassert_not_null(pthread_self);
 		zassert_not_null(pthread_setcancelstate);
 		zassert_not_null(pthread_setcanceltype);


### PR DESCRIPTION
implimented pthread_rwlockattr_setpshared()
is required as part of _POSIX_READER_WRITER_LOCKS Option Group.

Signed-off-by: Zack leung <z.liang111@gmail.com>