### PR TITLE
ITE: pinctrl: Distinguish between func3-gcr and func3-ext setings

### DIFF
--- a/drivers/pinctrl/pinctrl_ite_it8xxx2.c
+++ b/drivers/pinctrl/pinctrl_ite_it8xxx2.c
@@ -162,6 +162,9 @@ static int pinctrl_gpio_it8xxx2_configure_pins(const pinctrl_soc_pin_t *pins)
 	/*
 	 * Handle alternate function.
 	 */
+	if (reg_func3_gcr != NULL) {
+		*reg_func3_gcr &= ~gpio->func3_en_mask[pin];
+	}
 	/* Ensure that func3-ext setting is in default state. */
 	if (reg_func3_ext != NULL) {
 		*reg_func3_ext &= ~gpio->func3_ext_mask[pin];
@@ -179,8 +182,9 @@ static int pinctrl_gpio_it8xxx2_configure_pins(const pinctrl_soc_pin_t *pins)
 		 * Func3: In addition to the alternate setting above,
 		 *        Func3 also need to set the general control.
 		 */
-		*reg_func3_gcr |= gpio->func3_en_mask[pin];
-
+		if (reg_func3_gcr != NULL) {
+			*reg_func3_gcr |= gpio->func3_en_mask[pin];
+		}
 		/* Func3-external: Some pins require external setting. */
 		if (reg_func3_ext != NULL) {
 			*reg_func3_ext |= gpio->func3_ext_mask[pin];

--- a/dts/riscv/ite/it82xx2.dtsi
+++ b/dts/riscv/ite/it82xx2.dtsi
@@ -521,14 +521,14 @@
 		pinctrle: pinctrl@f01680 {
 			compatible = "ite,it8xxx2-pinctrl-func";
 			reg = <0x00f01680 8>;   /* GPCR */
-			func3-gcr =     <0xf02032 0xf03e16 0xf03e16 NO_FUNC
-					 NO_FUNC  0xf03e10 NO_FUNC  0xf02032>;
-			func3-en-mask = <0x01     0x20     0x20     0
-					 0        0x08     0        0x01    >;
-			func3-ext =     <NO_FUNC 0xf02032  0xf02032 NO_FUNC
-					 NO_FUNC NO_FUNC   NO_FUNC  NO_FUNC>;
-			func3-ext-mask = <0      0x02      0x02     0
-					  0      0         0        0       >;
+			func3-gcr =     <NO_FUNC  0xf03e16 0xf03e16 NO_FUNC
+					 NO_FUNC  0xf03e10 NO_FUNC  NO_FUNC >;
+			func3-en-mask = <0        0x20     0x20     0
+					 0        0x08     0        0       >;
+			func3-ext =     <0xf02032 0xf02032 0xf02032 NO_FUNC
+					 NO_FUNC  NO_FUNC  NO_FUNC  0xf02032>;
+			func3-ext-mask = <0x01    0x02     0x02     0
+					  0       0        0        0x01    >;
 			func4-gcr =     <0xf03e13 NO_FUNC  NO_FUNC  NO_FUNC
 					 NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC >;
 			func4-en-mask = <0x01     0        0        0


### PR DESCRIPTION

This PR separates the GCTRL settings from func3-gcr to func3-ext.