### PR TITLE
ci: compliance: exclude optional modules during compliance check

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -44,7 +44,7 @@ jobs:
         # debug
         git log  --pretty=oneline | head -n 10
         west init -l . || true
-        west config manifest.group-filter -- +ci,+optional
+        west config manifest.group-filter -- +ci,-optional
         west update -o=--depth=1 -n 2>&1 1> west.update.log || west update -o=--depth=1 -n 2>&1 1> west.update2.log
 
     - name: Run Compliance Tests


### PR DESCRIPTION
We should not have any dependencies on optional modules, for example on
Kconfigs from optional modules. Compliance has to pass without any
optional modules enabled.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
