### PR TITLE
it82xx2/usb: disable 15K-ohm default pull-down if device isn't enabled

### DIFF
--- a/drivers/usb/device/usb_dc_it82xx2.c
+++ b/drivers/usb/device/usb_dc_it82xx2.c
@@ -62,9 +62,6 @@ enum it82xx2_transaction_types {
 /* The bit definitions of the register Host/Device Control: 0XE0 */
 #define RESET_CORE			BIT(1)
 
-/* Bit definitions of the register Port0/Port1 MISC Control: 0XE4/0xE8 */
-#define PULL_DOWN_EN			BIT(4)
-
 /* ENDPOINT[3..0]_STATUS_REG */
 #define DC_STALL_SENT			BIT(5)
 

--- a/soc/riscv/ite_ec/common/chip_chipregs.h
+++ b/soc/riscv/ite_ec/common/chip_chipregs.h
@@ -708,6 +708,13 @@ struct it82xx2_usb_ep_fifo_regs {
 
 };
 
+/* USB Control registers */
+#define USB_IT82XX2_REGS_BASE \
+	((struct usb_it82xx2_regs *)DT_REG_ADDR(DT_NODELABEL(usb0)))
+
+/* Bit definitions of the register Port0/Port1 MISC Control: 0XE4/0xE8 */
+#define PULL_DOWN_EN	BIT(4)
+
 struct usb_it82xx2_regs {
 	/* 0x00:  Host TX Contrl Register */
 	volatile uint8_t host_tx_ctrl;

--- a/soc/riscv/ite_ec/it8xxx2/soc.c
+++ b/soc/riscv/ite_ec/it8xxx2/soc.c
@@ -288,6 +288,13 @@ static int ite_it8xxx2_init(void)
 	struct gpio_it8xxx2_regs *const gpio_regs = GPIO_IT8XXX2_REG_BASE;
 	struct gctrl_it8xxx2_regs *const gctrl_regs = GCTRL_IT8XXX2_REGS_BASE;
 
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(usb0), disabled)
+	struct usb_it82xx2_regs *const usb_regs = USB_IT82XX2_REGS_BASE;
+
+	usb_regs->port0_misc_control &= ~PULL_DOWN_EN;
+	usb_regs->port1_misc_control &= ~PULL_DOWN_EN;
+#endif
+
 	/*
 	 * bit7: wake up CPU if it is in low power mode and
 	 * an interrupt is pending.


### PR DESCRIPTION
There is default 15K-ohm pull-down for USB controller. To disable the default pull-down to avoid signal contention in GPIO mode.