### PR TITLE
cmake: Adjust LMA for user-specified sections

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1524,11 +1524,14 @@ endif()
 
 if(CONFIG_BUILD_OUTPUT_ADJUST_LMA)
   math(EXPR adjustment "${CONFIG_BUILD_OUTPUT_ADJUST_LMA}" OUTPUT_FORMAT DECIMAL)
+  set(args_adjustment ${CONFIG_BUILD_OUTPUT_ADJUST_LMA_SECTIONS})
+  list(TRANSFORM args_adjustment PREPEND $<TARGET_PROPERTY:bintools,elfconvert_flag_lma_adjust>)
+  list(TRANSFORM args_adjustment APPEND +${adjustment})
   list(APPEND
     post_build_commands
     COMMAND $<TARGET_PROPERTY:bintools,elfconvert_command>
             $<TARGET_PROPERTY:bintools,elfconvert_flag_final>
-            $<TARGET_PROPERTY:bintools,elfconvert_flag_lma_adjust>${adjustment}
+            ${args_adjustment}
             $<TARGET_PROPERTY:bintools,elfconvert_flag_infile>${KERNEL_ELF_NAME}
             $<TARGET_PROPERTY:bintools,elfconvert_flag_outfile>${KERNEL_ELF_NAME}
     )

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -704,6 +704,23 @@ config BUILD_OUTPUT_ADJUST_LMA
 	    default "$(dt_chosen_reg_addr_hex,$(DT_CHOSEN_IMAGE_M4))-\
 	             $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))"
 
+config BUILD_OUTPUT_ADJUST_LMA_SECTIONS
+	def_string "*"
+	depends on BUILD_OUTPUT_ADJUST_LMA!=""
+	help
+	  This determines the output sections to which the above LMA adjustment
+	  will be applied.
+	  The value can be the name of a section in the final ELF, like "text".
+	  It can also be a pattern with wildcards, such as "*bss", which could
+	  match more than one section name. Multiple such patterns can be given
+	  as a ";"-separated list. It's possible to supply a 'negative' pattern
+	  starting with "!", to exclude sections matched by a preceding pattern.
+
+	  By default, all sections will have their LMA adjusted. The following
+	  example excludes one section produced by the code relocation feature:
+	  config BUILD_OUTPUT_ADJUST_LMA_SECTIONS
+	    default "*;!.extflash_text_reloc"
+
 config BUILD_OUTPUT_INFO_HEADER
 	bool "Create a image information header"
 	help

--- a/cmake/bintools/gnu/target_bintools.cmake
+++ b/cmake/bintools/gnu/target_bintools.cmake
@@ -41,7 +41,7 @@ set_property(TARGET bintools PROPERTY elfconvert_flag_section_remove "--remove-s
 set_property(TARGET bintools PROPERTY elfconvert_flag_section_only "--only-section=")
 set_property(TARGET bintools PROPERTY elfconvert_flag_section_rename "--rename-section;")
 
-set_property(TARGET bintools PROPERTY elfconvert_flag_lma_adjust "--change-section-lma;*+")
+set_property(TARGET bintools PROPERTY elfconvert_flag_lma_adjust "--change-section-lma;")
 
 # Note, placing a ';' at the end results in the following param  to be a list,
 # and hence space separated.


### PR DESCRIPTION
Fixes #64149

Add support for a new Kconfig symbol: BUILD_OUTPUT_ADJUST_LMA_SECTIONS. This is supplemental to the existing BUILD_OUTPUT_ADJUST_LMA setting, which normally adjusts all output sections' LMA by the provided offset. Defining the new symbol will narrow down the set of applicable sections to a user-specified CMake list of name patterns.

Example usage:
```
DT_CHOSEN_Z_FLASH = zephyr,flash
DT_CHOSEN_Z_SRAM = zephyr,sram
config BUILD_OUTPUT_ADJUST_LMA
        default "$(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH)) - \
                 $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_SRAM))"

config BUILD_OUTPUT_ADJUST_LMA_SECTIONS
        default "*;!bss;!noinit"
```
Supported values for BUILD_OUTPUT_ADJUST_LMA_SECTIONS are aligned with objcopy, since this feature has only been supported with GNU binutils thus far.