### PR TITLE
arm: mpu: clear mpu regions before initialization

### DIFF
--- a/arch/arm/core/mpu/arm_mpu.c
+++ b/arch/arm/core/mpu/arm_mpu.c
@@ -459,6 +459,11 @@ int z_arm_mpu_init(void)
 		return -EINVAL;
 	}
 
+	/* Clear all regions before enabling MPU */
+	for (int i = static_regions_num; i < get_num_regions(); i++) {
+		mpu_clear_region(i);
+	}
+
 	arm_core_mpu_enable();
 
 	/* Program additional fixed flash region for null-pointer

--- a/arch/arm/core/mpu/arm_mpu_v7_internal.h
+++ b/arch/arm/core/mpu/arm_mpu_v7_internal.h
@@ -269,4 +269,9 @@ static int mpu_configure_dynamic_mpu_regions(const struct z_arm_mpu_partition
 	return mpu_reg_index;
 }
 
+static inline void mpu_clear_region(uint32_t rnr)
+{
+	ARM_MPU_ClrRegion(rnr);
+}
+
 #endif	/* ZEPHYR_ARCH_ARM_CORE_AARCH32_MPU_ARM_MPU_V7_INTERNAL_H_ */


### PR DESCRIPTION
Disabling the MPU doesn't clear regions configuration. There is a risk in multi-image environment that there are some old region setting e.g. stack guard. This may cause a memory fault, because of different images layout e.g. RO/RW.

Just clear and disable all regions configuration before the new initialization.