### PR TITLE
boards: remove `LOG_BUFFER_SIZE` low defaults

### DIFF
--- a/boards/arm/bbc_microbit/Kconfig.defconfig
+++ b/boards/arm/bbc_microbit/Kconfig.defconfig
@@ -11,9 +11,6 @@ config BOARD
 config BT_CTLR
 	default BT
 
-config LOG_BUFFER_SIZE
-	default 128 if LOG
-
 if FXOS8700
 
 choice FXOS8700_MODE

--- a/boards/arm/qemu_cortex_m0/Kconfig.defconfig
+++ b/boards/arm/qemu_cortex_m0/Kconfig.defconfig
@@ -17,7 +17,4 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config SYS_CLOCK_TICKS_PER_SEC
 	default 100
 
-config LOG_BUFFER_SIZE
-	default 128 if LOG
-
 endif # BOARD_QEMU_CORTEX_M0


### PR DESCRIPTION
Setting an extremely low value by default on two boards doesn't seem like the right thing to do.
The defaults were added with the v1 logging subsystem in https://github.com/zephyrproject-rtos/zephyr/pull/8023.
This can cause these platforms to fail tests because the log output is lost.