### PR TITLE
ztest: export ztest_test_* symbols to llexts

### DIFF
--- a/lib/os/printk.c
+++ b/lib/os/printk.c
@@ -154,6 +154,7 @@ void vprintk(const char *fmt, va_list ap)
 #endif
 	}
 }
+EXPORT_SYMBOL(vprintk);
 
 void z_impl_k_str_out(char *c, size_t n)
 {

--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -13,6 +13,8 @@
 #include <zephyr/logging/log_ctrl.h>
 #include <zephyr/sys/reboot.h>
 
+#include <zephyr/llext/symbol.h>
+
 #ifdef KERNEL
 static struct k_thread ztest_thread;
 #endif
@@ -324,6 +326,7 @@ void ztest_test_fail(void)
 		longjmp(stack_fail, 1);
 	}
 }
+EXPORT_SYMBOL(ztest_test_fail);
 
 void ztest_test_pass(void)
 {
@@ -334,6 +337,7 @@ void ztest_test_pass(void)
 	      get_friendly_phase_name(cur_phase));
 	longjmp(stack_fail, 1);
 }
+EXPORT_SYMBOL(ztest_test_pass);
 
 void ztest_test_skip(void)
 {
@@ -348,6 +352,7 @@ void ztest_test_skip(void)
 		longjmp(stack_fail, 1);
 	}
 }
+EXPORT_SYMBOL(ztest_test_skip);
 
 void ztest_test_expect_fail(void)
 {
@@ -471,6 +476,7 @@ void ztest_test_fail(void)
 		break;
 	}
 }
+EXPORT_SYMBOL(ztest_test_fail);
 
 void ztest_test_pass(void)
 {
@@ -488,6 +494,7 @@ void ztest_test_pass(void)
 		}
 	}
 }
+EXPORT_SYMBOL(ztest_test_pass);
 
 void ztest_test_skip(void)
 {
@@ -507,6 +514,7 @@ void ztest_test_skip(void)
 		break;
 	}
 }
+EXPORT_SYMBOL(ztest_test_skip);
 
 void ztest_test_expect_fail(void)
 {

--- a/subsys/testsuite/ztest/src/ztest_defaults.c
+++ b/subsys/testsuite/ztest/src/ztest_defaults.c
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/ztest.h>
+#include <zephyr/llext/symbol.h>
 
 /**
  * @brief Try to shorten a filename by removing the current directory
@@ -21,6 +22,7 @@ const char *ztest_relative_filename(const char *file)
 {
 	return file;
 }
+EXPORT_SYMBOL(ztest_relative_filename);
 
 /**
  * Default entry point for running registered unit tests.


### PR DESCRIPTION
Export the minimal set of `ztest_test_*` symbols to llexts so that the `zassert_*` macros can be used by the extension code to affect test execution. Calling these also requires `vprintk()` to be exported.

This is a prerequisite to enlarging the llext test suite with a "linker workout" test that checks all possible types of relocations and data types. 