### PR TITLE
doc: Clean up list of Fedora dependencies

### DIFF
--- a/doc/develop/getting_started/installation_linux.rst
+++ b/doc/develop/getting_started/installation_linux.rst
@@ -86,9 +86,8 @@ need one.
       .. code-block:: console
 
          sudo dnf group install "Development Tools" "C Development Tools and Libraries"
-         sudo dnf install git cmake ninja-build gperf ccache dfu-util dtc wget \
-           python3-pip python3-tkinter xz file glibc-devel.i686 libstdc++-devel.i686 python38 \
-           SDL2-devel
+         sudo dnf install cmake ninja-build gperf dfu-util dtc wget which \
+           python3-pip python3-tkinter xz file python3-devel SDL2-devel
 
    .. group-tab:: Clear Linux
 


### PR DESCRIPTION
Fixed several issues with the install instructions for Fedora:

- removed packages that are already pulled by "Development Tools" and "C Development Tools and Libraries" groups
- added missing "which" package needed for SDK installation script
- added python3-devel package (needed for some of the Python requirements) and install python3 instead of a fixed python38

Tested on a vanilla Fedora 39 Docker image.