### PR TITLE
drivers: can: add `can_get_mode()` and `can_get_transceiver()` system calls

### DIFF
--- a/doc/hardware/peripherals/can/shell.rst
+++ b/doc/hardware/peripherals/can/shell.rst
@@ -62,7 +62,8 @@ Inspection
 
 The properties of a given CAN controller can be inspected using the ``can show`` subcommand as shown
 below. The properties include the core CAN clock rate, the maximum supported bitrate, the number of
-RX filters supported, capabilities, current state, error counters, timing limits, and more:
+RX filters supported, capabilities, current mode, current state, error counters, timing limits, and
+more:
 
 .. code-block:: console
 
@@ -72,6 +73,7 @@ RX filters supported, capabilities, current state, error counters, timing limits
    max std filters: 15
    max ext filters: 15
    capabilities:    normal loopback listen-only fd
+   mode:            normal
    state:           stopped
    rx errors:       0
    tx errors:       0

--- a/doc/hardware/peripherals/can/shell.rst
+++ b/doc/hardware/peripherals/can/shell.rst
@@ -79,6 +79,7 @@ more:
    tx errors:       0
    timing:          sjw 1..128, prop_seg 0..0, phase_seg1 2..256, phase_seg2 2..128, prescaler 1..512
    timing data:     sjw 1..16, prop_seg 0..0, phase_seg1 1..32, phase_seg2 1..16, prescaler 1..32
+   transceiver:     passive/none
    statistics:
      bit errors:    0
        bit0 errors: 0

--- a/doc/releases/release-notes-3.6.rst
+++ b/doc/releases/release-notes-3.6.rst
@@ -154,6 +154,12 @@ Drivers and Sensors
 
 * CAN
 
+  * Added system call :c:func:`can_get_mode()` for getting the current operation mode of a CAN
+    controller.
+
+  * Add system call :c:func:`can_get_transceiver()` for getting the CAN transceiver associated with
+    a CAN controller.
+
 * Clock control
 
   * Renesas R-Car clock control driver now supports Gen4 SoCs

--- a/drivers/can/can_handlers.c
+++ b/drivers/can/can_handlers.c
@@ -146,6 +146,14 @@ static inline int z_vrfy_can_get_capabilities(const struct device *dev, can_mode
 }
 #include <syscalls/can_get_capabilities_mrsh.c>
 
+static inline const struct device *z_vrfy_can_get_transceiver(const struct device *dev)
+{
+	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_CAN));
+
+	return z_impl_can_get_transceiver(dev);
+}
+#include <syscalls/can_get_transceiver_mrsh.c>
+
 static inline int z_vrfy_can_start(const struct device *dev)
 {
 	K_OOPS(K_SYSCALL_DRIVER_CAN(dev, start));

--- a/drivers/can/can_handlers.c
+++ b/drivers/can/can_handlers.c
@@ -170,6 +170,14 @@ static inline int z_vrfy_can_set_mode(const struct device *dev, can_mode_t mode)
 }
 #include <syscalls/can_set_mode_mrsh.c>
 
+static inline can_mode_t z_vrfy_can_get_mode(const struct device *dev)
+{
+	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_CAN));
+
+	return z_impl_can_get_mode(dev);
+}
+#include <syscalls/can_get_mode_mrsh.c>
+
 static inline int z_vrfy_can_set_bitrate(const struct device *dev, uint32_t bitrate)
 {
 	K_OOPS(K_SYSCALL_DRIVER_CAN(dev, set_timing));

--- a/drivers/can/can_shell.c
+++ b/drivers/can/can_shell.c
@@ -202,7 +202,7 @@ static const char *can_shell_state_to_string(enum can_state state)
 	}
 }
 
-static void can_shell_print_capabilities(const struct shell *sh, can_mode_t cap)
+static void can_shell_print_extended_modes(const struct shell *sh, can_mode_t cap)
 {
 	int bit;
 	int i;
@@ -331,7 +331,11 @@ static int cmd_can_show(const struct shell *sh, size_t argc, char **argv)
 	shell_print(sh, "max ext filters: %d", max_ext_filters);
 
 	shell_fprintf(sh, SHELL_NORMAL, "capabilities:    normal ");
-	can_shell_print_capabilities(sh, cap);
+	can_shell_print_extended_modes(sh, cap);
+	shell_fprintf(sh, SHELL_NORMAL, "\n");
+
+	shell_fprintf(sh, SHELL_NORMAL, "mode:            normal ");
+	can_shell_print_extended_modes(sh, can_get_mode(dev));
 	shell_fprintf(sh, SHELL_NORMAL, "\n");
 
 	shell_print(sh, "state:           %s", can_shell_state_to_string(state));

--- a/drivers/can/can_shell.c
+++ b/drivers/can/can_shell.c
@@ -273,6 +273,7 @@ static int cmd_can_stop(const struct shell *sh, size_t argc, char **argv)
 static int cmd_can_show(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *dev = device_get_binding(argv[1]);
+	const struct device *phy;
 	const struct can_timing *timing_min;
 	const struct can_timing *timing_max;
 	struct can_bus_err_cnt err_cnt;
@@ -365,6 +366,9 @@ static int cmd_can_show(const struct shell *sh, size_t argc, char **argv)
 			    timing_min->phase_seg2, timing_max->phase_seg2,
 			    timing_min->prescaler, timing_max->prescaler);
 	}
+
+	phy = can_get_transceiver(dev);
+	shell_print(sh, "transceiver:     %s", phy != NULL ? phy->name : "passive/none");
 
 #ifdef CONFIG_CAN_STATS
 	shell_print(sh, "statistics:");

--- a/drivers/can/can_stm32_bxcan.c
+++ b/drivers/can/can_stm32_bxcan.c
@@ -532,6 +532,8 @@ static int can_stm32_set_mode(const struct device *dev, can_mode_t mode)
 		can->MCR &= ~CAN_MCR_NART;
 	}
 
+	data->common.mode = mode;
+
 	k_mutex_unlock(&data->inst_mutex);
 
 	return 0;

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -1131,6 +1131,22 @@ static inline int z_impl_can_set_mode(const struct device *dev, can_mode_t mode)
 }
 
 /**
+ * @brief Get the operation mode of the CAN controller
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ *
+ * @return Current operation mode.
+ */
+__syscall can_mode_t can_get_mode(const struct device *dev);
+
+static inline can_mode_t z_impl_can_get_mode(const struct device *dev)
+{
+	const struct can_driver_data *common = (const struct can_driver_data *)dev->data;
+
+	return common->mode;
+}
+
+/**
  * @brief Set the bitrate of the CAN controller
  *
  * CAN in Automation (CiA) 301 v4.2.0 recommends a sample point location of

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -1062,6 +1062,24 @@ static inline int z_impl_can_get_capabilities(const struct device *dev, can_mode
 }
 
 /**
+ * @brief Get the CAN transceiver associated with the CAN controller
+ *
+ * Get a pointer to the device structure for the CAN transceiver associated with the CAN controller.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @return Pointer to the device structure for the associated CAN transceiver driver instance, or
+ *         NULL if no transceiver is associated.
+ */
+__syscall const struct device *can_get_transceiver(const struct device *dev);
+
+static const struct device *z_impl_can_get_transceiver(const struct device *dev)
+{
+	const struct can_driver_config *common = (const struct can_driver_config *)dev->config;
+
+	return common->phy;
+}
+
+/**
  * @brief Start the CAN controller
  *
  * Bring the CAN controller out of `CAN_STATE_STOPPED`. This will reset the RX/TX error counters,

--- a/tests/drivers/can/api/CMakeLists.txt
+++ b/tests/drivers/can/api/CMakeLists.txt
@@ -6,6 +6,7 @@ project(integration)
 
 target_sources(app PRIVATE src/common.c)
 target_sources(app PRIVATE src/classic.c)
+target_sources(app PRIVATE src/transceiver.c)
 target_sources(app PRIVATE src/utilities.c)
 target_sources_ifdef(CONFIG_CAN_FD_MODE app PRIVATE src/canfd.c)
 target_sources_ifdef(CONFIG_CAN_STATS app PRIVATE src/stats.c)

--- a/tests/drivers/can/api/src/canfd.c
+++ b/tests/drivers/can/api/src/canfd.c
@@ -286,6 +286,7 @@ static void check_filters_preserved_between_modes(can_mode_t first, can_mode_t s
 
 	err = can_set_mode(can_dev, first | CAN_MODE_LOOPBACK);
 	zassert_equal(err, 0, "failed to set first loopback mode (err %d)", err);
+	zassert_equal(first | CAN_MODE_LOOPBACK, can_get_mode(can_dev));
 
 	err = can_start(can_dev);
 	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);
@@ -318,6 +319,7 @@ static void check_filters_preserved_between_modes(can_mode_t first, can_mode_t s
 
 	err = can_set_mode(can_dev, second | CAN_MODE_LOOPBACK);
 	zassert_equal(err, 0, "failed to set second loopback mode (err %d)", err);
+	zassert_equal(second | CAN_MODE_LOOPBACK, can_get_mode(can_dev));
 
 	err = can_start(can_dev);
 	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);
@@ -346,6 +348,7 @@ static void check_filters_preserved_between_modes(can_mode_t first, can_mode_t s
 
 	err = can_set_mode(can_dev, CAN_MODE_FD | CAN_MODE_LOOPBACK);
 	zassert_equal(err, 0, "failed to set loopback-mode (err %d)", err);
+	zassert_equal(CAN_MODE_FD | CAN_MODE_LOOPBACK, can_get_mode(can_dev));
 
 	err = can_start(can_dev);
 	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);
@@ -433,6 +436,7 @@ void *canfd_setup(void)
 
 	err = can_set_mode(can_dev, CAN_MODE_LOOPBACK | CAN_MODE_FD);
 	zassert_equal(err, 0, "failed to set CAN FD loopback mode (err %d)", err);
+	zassert_equal(CAN_MODE_LOOPBACK | CAN_MODE_FD, can_get_mode(can_dev));
 
 	err = can_start(can_dev);
 	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);

--- a/tests/drivers/can/api/src/classic.c
+++ b/tests/drivers/can/api/src/classic.c
@@ -915,9 +915,11 @@ ZTEST_USER(can_classic, test_filters_preserved_through_mode_change)
 
 	err = can_set_mode(can_dev, CAN_MODE_NORMAL);
 	zassert_equal(err, 0, "failed to set normal mode (err %d)", err);
+	zassert_equal(CAN_MODE_NORMAL, can_get_mode(can_dev));
 
 	err = can_set_mode(can_dev, CAN_MODE_LOOPBACK);
 	zassert_equal(err, 0, "failed to set loopback-mode (err %d)", err);
+	zassert_equal(CAN_MODE_LOOPBACK, can_get_mode(can_dev));
 
 	err = can_start(can_dev);
 	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);
@@ -1121,6 +1123,7 @@ void *can_classic_setup(void)
 
 	err = can_set_mode(can_dev, CAN_MODE_LOOPBACK);
 	zassert_equal(err, 0, "failed to set loopback mode (err %d)", err);
+	zassert_equal(CAN_MODE_LOOPBACK, can_get_mode(can_dev));
 
 	err = can_start(can_dev);
 	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);

--- a/tests/drivers/can/api/src/common.c
+++ b/tests/drivers/can/api/src/common.c
@@ -15,6 +15,8 @@
  * @brief Global variables.
  */
 ZTEST_DMEM const struct device *const can_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
+ZTEST_DMEM const struct device *const can_phy =
+	DEVICE_DT_GET_OR_NULL(DT_PHANDLE(DT_CHOSEN(zephyr_canbus), phys));
 struct k_sem rx_callback_sem;
 struct k_sem tx_callback_sem;
 

--- a/tests/drivers/can/api/src/common.h
+++ b/tests/drivers/can/api/src/common.h
@@ -52,6 +52,7 @@
  * @brief Common variables.
  */
 extern ZTEST_DMEM const struct device *const can_dev;
+extern ZTEST_DMEM const struct device *const can_phy;
 extern struct k_sem rx_callback_sem;
 extern struct k_sem tx_callback_sem;
 extern struct k_msgq can_msgq;

--- a/tests/drivers/can/api/src/transceiver.c
+++ b/tests/drivers/can/api/src/transceiver.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2024 Vestas Wind Systems A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/can.h>
+#include <zephyr/ztest.h>
+
+#include "common.h"
+
+/**
+ * @addtogroup t_can_driver
+ * @{
+ * @defgroup t_can_transceiver test_can_transceiver
+ * @}
+ */
+
+/**
+ * @brief Test getting CAN transceiver device pointer.
+ */
+ZTEST_USER(can_transceiver, test_get_transceiver)
+{
+	const struct device *phy = can_get_transceiver(can_dev);
+
+	zassert_equal(phy, can_phy, "wrong CAN transceiver device pointer returned");
+}
+
+static bool can_transceiver_predicate(const void *state)
+{
+	ARG_UNUSED(state);
+
+	if (!device_is_ready(can_dev)) {
+		TC_PRINT("CAN device not ready");
+		return false;
+	}
+
+	if (!device_is_ready(can_phy)) {
+		TC_PRINT("CAN transceiver device not ready");
+		return false;
+	}
+
+	return true;
+}
+
+void *can_transceiver_setup(void)
+{
+	k_object_access_grant(can_dev, k_current_get());
+	k_object_access_grant(can_phy, k_current_get());
+
+	zassert_true(device_is_ready(can_dev), "CAN device not ready");
+	zassert_true(device_is_ready(can_phy), "CAN transceiver device not ready");
+
+	return NULL;
+}
+
+ZTEST_SUITE(can_transceiver, can_transceiver_predicate, can_transceiver_setup, NULL, NULL, NULL);


### PR DESCRIPTION
- Add system call `can_get_mode()` for getting the current operation mode of a CAN controller.
- Add system call `can_get_transceiver()` for getting the CAN transceiver associated with a CAN controller.
- Add relevant tests for these two new system calls.
- Use these new system calls in the CAN shell module.
