### PR TITLE
cache: stm32: add new cache API to display and i2s

### DIFF
--- a/drivers/display/Kconfig.stm32_ltdc
+++ b/drivers/display/Kconfig.stm32_ltdc
@@ -8,6 +8,7 @@ menuconfig STM32_LTDC
 	default y
 	depends on DT_HAS_ST_STM32_LTDC_ENABLED
 	select USE_STM32_HAL_LTDC
+	select CACHE_MANAGEMENT if CPU_HAS_DCACHE
 	help
 	  Enable driver for STM32 LCT-TFT display controller periheral.
 

--- a/drivers/i2s/Kconfig.stm32
+++ b/drivers/i2s/Kconfig.stm32
@@ -7,6 +7,7 @@ menuconfig I2S_STM32
 	bool "STM32 MCU I2S controller driver"
 	default y
 	depends on DT_HAS_ST_STM32_I2S_ENABLED
+	select CACHE_MANAGEMENT if CPU_HAS_DCACHE
 	select DMA
 	help
 	  Enable I2S support on the STM32 family of processors.


### PR DESCRIPTION
Use sys_cache API to handle cache flush/invalidate.

Resolves https://github.com/zephyrproject-rtos/zephyr/issues/67302