### PR TITLE
drivers: can: propagate CAN controller operation mode to CAN transceiver

### DIFF
--- a/doc/releases/migration-guide-3.6.rst
+++ b/doc/releases/migration-guide-3.6.rst
@@ -184,6 +184,11 @@ Device Drivers and Device Tree
   common accessor function. Out-of-tree CAN controller drivers need to be updated to no longer
   supply this callback.
 
+* The CAN transceiver API function :c:func:`can_transceiver_enable` now takes a :c:type:`can_mode_t`
+  argument for propagating the CAN controller operational mode to the CAN transceiver. Out-of-tree
+  CAN controller and CAN transceiver drivers need to be updated to match this new API function
+  signature.
+
 * The ``CAN_FILTER_FDF`` flag for filtering classic CAN/CAN FD frames was removed since no known CAN
   controllers implement support for this. Applications can still filter on classic CAN/CAN FD frames
   in their receive callback functions as needed.

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -276,7 +276,7 @@ int can_mcan_start(const struct device *dev)
 	}
 
 	if (config->common.phy != NULL) {
-		err = can_transceiver_enable(config->common.phy);
+		err = can_transceiver_enable(config->common.phy, data->common.mode);
 		if (err != 0) {
 			LOG_ERR("failed to enable CAN transceiver (err %d)", err);
 			return err;

--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -435,7 +435,7 @@ static int mcp2515_start(const struct device *dev)
 	}
 
 	if (dev_cfg->common.phy != NULL) {
-		ret = can_transceiver_enable(dev_cfg->common.phy);
+		ret = can_transceiver_enable(dev_cfg->common.phy, dev_data->common.mode);
 		if (ret != 0) {
 			LOG_ERR("Failed to enable CAN transceiver [%d]", ret);
 			return ret;

--- a/drivers/can/can_mcp251xfd.c
+++ b/drivers/can/can_mcp251xfd.c
@@ -1164,7 +1164,7 @@ static int mcp251xfd_start(const struct device *dev)
 	mcp251xfd_reset_tx_fifos(dev, -ENETDOWN);
 
 	if (dev_cfg->common.phy != NULL) {
-		ret = can_transceiver_enable(dev_cfg->common.phy);
+		ret = can_transceiver_enable(dev_cfg->common.phy, dev_data->common.mode);
 		if (ret < 0) {
 			LOG_ERR("Failed to enable CAN transceiver [%d]", ret);
 			return ret;

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -275,7 +275,7 @@ static int mcux_flexcan_start(const struct device *dev)
 	}
 
 	if (config->common.phy != NULL) {
-		err = can_transceiver_enable(config->common.phy);
+		err = can_transceiver_enable(config->common.phy, data->common.mode);
 		if (err != 0) {
 			LOG_ERR("failed to enable CAN transceiver (err %d)", err);
 			return err;

--- a/drivers/can/can_nxp_s32_canxl.c
+++ b/drivers/can/can_nxp_s32_canxl.c
@@ -218,7 +218,7 @@ static int can_nxp_s32_start(const struct device *dev)
 	}
 
 	if (config->common.phy != NULL) {
-		err = can_transceiver_enable(config->common.phy);
+		err = can_transceiver_enable(config->common.phy, data->common.mode);
 		if (err != 0) {
 			LOG_ERR("failed to enable CAN transceiver (err %d)", err);
 			return err;

--- a/drivers/can/can_rcar.c
+++ b/drivers/can/can_rcar.c
@@ -584,7 +584,7 @@ static int can_rcar_start(const struct device *dev)
 	}
 
 	if (config->common.phy != NULL) {
-		ret = can_transceiver_enable(config->common.phy);
+		ret = can_transceiver_enable(config->common.phy, data->common.mode);
 		if (ret != 0) {
 			LOG_ERR("failed to enable CAN transceiver (err %d)", ret);
 			return ret;

--- a/drivers/can/can_sja1000.c
+++ b/drivers/can/can_sja1000.c
@@ -155,7 +155,7 @@ int can_sja1000_start(const struct device *dev)
 	}
 
 	if (config->common.phy != NULL) {
-		err = can_transceiver_enable(config->common.phy);
+		err = can_transceiver_enable(config->common.phy, data->common.mode);
 		if (err != 0) {
 			LOG_ERR("failed to enable CAN transceiver (err %d)", err);
 			return err;

--- a/drivers/can/can_stm32_bxcan.c
+++ b/drivers/can/can_stm32_bxcan.c
@@ -419,7 +419,7 @@ static int can_stm32_start(const struct device *dev)
 	}
 
 	if (cfg->common.phy != NULL) {
-		ret = can_transceiver_enable(cfg->common.phy);
+		ret = can_transceiver_enable(cfg->common.phy, data->common.mode);
 		if (ret != 0) {
 			LOG_ERR("failed to enable CAN transceiver (err %d)", ret);
 			goto unlock;

--- a/drivers/can/transceiver/can_transceiver_gpio.c
+++ b/drivers/can/transceiver/can_transceiver_gpio.c
@@ -58,8 +58,10 @@ static int can_transceiver_gpio_set_state(const struct device *dev, bool enabled
 	return 0;
 }
 
-static int can_transceiver_gpio_enable(const struct device *dev)
+static int can_transceiver_gpio_enable(const struct device *dev, can_mode_t mode)
 {
+	ARG_UNUSED(mode);
+
 	return can_transceiver_gpio_set_state(dev, true);
 }
 

--- a/include/zephyr/drivers/can/transceiver.h
+++ b/include/zephyr/drivers/can/transceiver.h
@@ -7,6 +7,7 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CAN_TRANSCEIVER_H_
 #define ZEPHYR_INCLUDE_DRIVERS_CAN_TRANSCEIVER_H_
 
+#include <zephyr/drivers/can.h>
 #include <zephyr/device.h>
 
 #ifdef __cplusplus
@@ -30,7 +31,7 @@ extern "C" {
  * @brief Callback API upon enabling CAN transceiver
  * See @a can_transceiver_enable() for argument description
  */
-typedef int (*can_transceiver_enable_t)(const struct device *dev);
+typedef int (*can_transceiver_enable_t)(const struct device *dev, can_mode_t mode);
 
 /**
  * @brief Callback API upon disabling CAN transceiver
@@ -56,15 +57,16 @@ __subsystem struct can_transceiver_driver_api {
  * @see can_start()
  *
  * @param dev Pointer to the device structure for the driver instance.
+ * @param mode Operation mode.
  * @retval 0 If successful.
  * @retval -EIO General input/output error, failed to enable device.
  */
-static inline int can_transceiver_enable(const struct device *dev)
+static inline int can_transceiver_enable(const struct device *dev, can_mode_t mode)
 {
 	const struct can_transceiver_driver_api *api =
 		(const struct can_transceiver_driver_api *)dev->api;
 
-	return api->enable(dev);
+	return api->enable(dev, mode);
 }
 
 /**


### PR DESCRIPTION
Propagate the current CAN controller operation mode to the CAN transceiver when enabling it.
    
Some more advanced CAN transceivers, especially those supporting Partial Networking (CAN PN), require knowledge of the intended CAN operation mode (e.g. normal mode vs. listen-only mode).
    
This commit simply prepares the CAN transceiver API for supporting such CAN transceivers, although no in-tree drivers require this information yet.
