### PR TITLE
tests: smp_suspend: Add configurable delay

### DIFF
--- a/tests/kernel/smp_suspend/Kconfig
+++ b/tests/kernel/smp_suspend/Kconfig
@@ -1,0 +1,10 @@
+# Copyright (c) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+mainmenu "SMP suspend test"
+
+source "Kconfig.zephyr"
+
+config SMP_TEST_RELAX
+	int "A delay to compensate for spinlock bias induced by arch_spin_relax"
+	default 16


### PR DESCRIPTION
Adds a configurable delay to the test threads. It exists to keep thread0 from hogging the scheduler's spin lock and giving threads on another core a better chance to obtain that lock and not starve.