### PR TITLE
tests/bsim host/privacy/peripheral: Minor fixes to allow equality check

### DIFF
--- a/tests/bsim/bluetooth/host/privacy/peripheral/test_scripts/run_test.sh
+++ b/tests/bsim/bluetooth/host/privacy/peripheral/test_scripts/run_test.sh
@@ -9,19 +9,19 @@ source "${bash_source_dir}/_env.sh"
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 verbosity_level=2
-simulation_id="$(basename "$(realpath "$bash_source_dir/..")")"
+simulation_id="host_privacy_peripheral"
 EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 
 Execute "$central_exe" \
     -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central -RealEncryption=1 \
-    -flash="${simulation_id}.central.log.bin"
+    -flash="${simulation_id}.central.log.bin" -flash_erase
 
 
 Execute "$peripheral_exe" \
     -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral -RealEncryption=1 \
-    -flash="${simulation_id}.peripheral.log.bin"
+    -flash="${simulation_id}.peripheral.log.bin" -flash_erase
 
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
@@ -30,16 +30,16 @@ Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
 wait_for_background_jobs
 
 Execute "$central_exe" \
-    -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central -RealEncryption=1 \
+    -v=${verbosity_level} -s=${simulation_id}.2 -d=0 -testid=central -RealEncryption=1 \
     -flash="${simulation_id}.central.log.bin" -flash_rm
 
 
 Execute "$peripheral_exe" \
-    -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral -RealEncryption=1 \
+    -v=${verbosity_level} -s=${simulation_id}.2 -d=1 -testid=peripheral -RealEncryption=1 \
     -flash="${simulation_id}.peripheral.log.bin" -flash_rm
 
 
-Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
+Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id}.2 \
     -D=2 -sim_length=70e6 $@
 
 wait_for_background_jobs


### PR DESCRIPTION
Minor fixes in this test script to:
* Start with an empty flash even if there was a left over flash file on disk
* Not overwrite the simulation activity from the first part of the test in the second part of the test, to allow looking into the traffic and to allow rerunning the test in check mode, to ensure there is no radio activity changes when another change is done.
* Set the simulation id to something more unique (it was just "peripheral" before which is too easy to be repeated in another test)