### PR TITLE
Remove SOC_FLASH_0_ID and SPI_FLASH_0_ID from flash_map.h

### DIFF
--- a/include/zephyr/storage/flash_map.h
+++ b/include/zephyr/storage/flash_map.h
@@ -45,11 +45,6 @@
 extern "C" {
 #endif
 
-/** Provided for compatibility with MCUboot */
-#define SOC_FLASH_0_ID 0
-/** Provided for compatibility with MCUboot */
-#define SPI_FLASH_0_ID 1
-
 /**
  * @brief Flash partition
  *


### PR DESCRIPTION
storage/flash_map: Remove definition of SOC_FLASH_0_ID

The commit removes definitions of SOC_FLASH_0_ID and SPI_FLASH_0_ID.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>