### PR TITLE
posix: add a top-level menu

### DIFF
--- a/lib/posix/Kconfig
+++ b/lib/posix/Kconfig
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+menu "POSIX API Support"
+
 config POSIX_MAX_FDS
 	int "Maximum number of open file descriptors"
 	default 16 if WIFI_NM_WPA_SUPPLICANT
@@ -58,3 +60,5 @@ source "lib/posix/Kconfig.timer"
 source "lib/posix/Kconfig.uname"
 
 rsource "shell/Kconfig"
+
+endmenu # "POSIX API Support"


### PR DESCRIPTION
Add a top-level menu to prevent POSIX API options from cluttering the menuconfig view under
"Additional libraries".

Fixes #68079