### PR TITLE
samples: thrift: update doc to include optional modules

### DIFF
--- a/samples/modules/thrift/hello/README.rst
+++ b/samples/modules/thrift/hello/README.rst
@@ -48,6 +48,14 @@ layers in thrift can be combined to build an application with desired features.
 Requirements
 ************
 
+- Optional Modules
+
+.. code-block:: console
+   :caption: Download optional modules with west
+
+   west config manifest.group-filter -- +optional
+   west update
+
 - QEMU Networking (described in :ref:`networking_with_qemu`)
 - Thrift dependencies installed for your host OS e.g. in Ubuntu
 


### PR DESCRIPTION
Update the Thrift sample to include instructions on fetching optional modules. Without this, user builds will fail.

