### PR TITLE
doc: release-notes: document `spi_nor` sleep changes

### DIFF
--- a/doc/releases/release-notes-3.6.rst
+++ b/doc/releases/release-notes-3.6.rst
@@ -176,6 +176,10 @@ Drivers and Sensors
 
 * Flash
 
+  * ``spi_nor`` driver now sleeps between polls in ``spi_nor_wait_until_ready``. If this is not
+    desired (For example due to ROM constraints in a bootloader),
+    :kconfig:option:`CONFIG_SPI_NOR_SLEEP_WHILE_WAITING_UNTIL_READY` can be disabled.
+
 * GPIO
 
   * Renesas R-Car GPIO driver now supports Gen4 SoCs


### PR DESCRIPTION
Document the changes to sleeping in `spi_nor_wait_until_ready`.
As requested in #67975.