### PR TITLE
west.yml: Update hal_silabs to pull request #55 | Update to GSDK 4.4.0

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -219,7 +219,7 @@ manifest:
       groups:
         - hal
     - name: hal_silabs
-      revision: 2ea874714edf5ce76b7b5fd19e7fa83507e83cc2
+      revision: 20024164aa2a79c186aedc721cf51d667eecb35a
       path: modules/hal/silabs
       groups:
         - hal


### PR DESCRIPTION
Update the EFR32BG22, BG27 and MG24 device files inside gecko/Device/SiliconLabs/ from gecko_sdk to align the codebase of hal_silabs with gecko_sdk 4.4.0.

This pull request is required to align the codebase of zephyr_rtos/hal_silabs (https://github.com/zephyrproject-rtos/hal_silabs) with gecko_sdk v4.4.0 (https://github.com/SiliconLabs/gecko_sdk)

PR in hal_silabs : https://github.com/zephyrproject-rtos/hal_silabs/pull/55