### PR TITLE
drivers: adc: stm32: do not disable adc after measurement

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -1078,8 +1078,6 @@ static void adc_context_on_complete(struct adc_context *ctx, int status)
 
 	ARG_UNUSED(status);
 
-	adc_stm32_disable(adc);
-
 	/* Reset acquisition time used for the sequence */
 	data->acq_time_index[0] = -1;
 	data->acq_time_index[1] = -1;
@@ -1087,6 +1085,8 @@ static void adc_context_on_complete(struct adc_context *ctx, int status)
 #if defined(CONFIG_SOC_SERIES_STM32H7X) || defined(CONFIG_SOC_SERIES_STM32U5X)
 	/* Reset channel preselection register */
 	LL_ADC_SetChannelPreselection(adc, 0);
+#else
+	ARG_UNUSED(adc);
 #endif /* CONFIG_SOC_SERIES_STM32H7X || CONFIG_SOC_SERIES_STM32U5X */
 }
 


### PR DESCRIPTION
Do not disable the ADC after the end of the measurement to avoid systematic enabling which is time-consuming in case the configuration is unchanged.