### PR TITLE
Bluetooth: BAP: client: Add support for source ASEs disconnects

### DIFF
--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -1047,6 +1047,8 @@ static void unicast_client_ep_set_status(struct bt_bap_ep *ep, struct net_buf_si
 			case BT_BAP_EP_STATE_CODEC_CONFIGURED:
 			/* or 0x02 (QoS Configured) */
 			case BT_BAP_EP_STATE_QOS_CONFIGURED:
+			/* or 0x04 (Streaming) if there is a disconnect */
+			case BT_BAP_EP_STATE_STREAMING:
 			/* or 0x05 (Disabling) */
 			case BT_BAP_EP_STATE_DISABLING:
 				break;


### PR DESCRIPTION
When the CIS of a source ASE disconnects, the server shall put it into the QoS Configured state, which is not really part of the state machine for source ASEs, but more like a hidden bonus state change.

The state machine handler in the unicast client has been updated to support this state change.