### PR TITLE
Bluetooth: Audio: improve BASS state logging to be more readable.

### DIFF
--- a/subsys/bluetooth/audio/bap_internal.h
+++ b/subsys/bluetooth/audio/bap_internal.h
@@ -89,3 +89,37 @@ union bt_bap_bass_cp {
 	struct bt_bap_bass_cp_broadcase_code broadcast_code;
 	struct bt_bap_bass_cp_rem_src rem_src;
 };
+
+static inline const char *bt_bap_pa_state_str(uint8_t state)
+{
+	switch (state) {
+	case BT_BAP_PA_STATE_NOT_SYNCED:
+		return "Not synchronized to PA";
+	case BT_BAP_PA_STATE_INFO_REQ:
+		return "SyncInfo Request";
+	case BT_BAP_PA_STATE_SYNCED:
+		return "Synchronized to PA";
+	case BT_BAP_PA_STATE_FAILED:
+		return "Failed to synchronize to PA";
+	case BT_BAP_PA_STATE_NO_PAST:
+		return "No PAST";
+	default:
+		return "unknown state";
+	}
+}
+
+static inline const char *bt_bap_big_enc_state_str(uint8_t state)
+{
+	switch (state) {
+	case BT_BAP_BIG_ENC_STATE_NO_ENC:
+		return "Not encrypted";
+	case BT_BAP_BIG_ENC_STATE_BCODE_REQ:
+		return "Broadcast_Code required";
+	case BT_BAP_BIG_ENC_STATE_DEC:
+		return "Decrypting";
+	case BT_BAP_BIG_ENC_STATE_BAD_CODE:
+		return "Bad_Code (incorrect encryption key)";
+	default:
+		return "unknown state";
+	}
+}

--- a/subsys/bluetooth/audio/shell/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/shell/bap_scan_delegator.c
@@ -16,6 +16,7 @@
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/audio/bap.h>
+#include <audio/bap_internal.h>
 #include "shell/bt.h"
 
 #define SYNC_RETRY_COUNT          6 /* similar to retries for connections */
@@ -551,7 +552,7 @@ static int cmd_bap_scan_delegator_add_src(const struct shell *sh, size_t argc,
 	}
 
 	if (enc_state > BT_BAP_BIG_ENC_STATE_BAD_CODE) {
-		shell_error(sh, "Invalid enc_state %lu", enc_state);
+		shell_error(sh, "Invalid enc_state %s", bt_bap_big_enc_state_str(enc_state));
 
 		return -EINVAL;
 	}
@@ -661,7 +662,7 @@ static int cmd_bap_scan_delegator_mod_src(const struct shell *sh, size_t argc,
 	}
 
 	if (enc_state > BT_BAP_BIG_ENC_STATE_BAD_CODE) {
-		shell_error(sh, "Invalid enc_state %lu", enc_state);
+		shell_error(sh, "Invalid enc_state %s", bt_bap_big_enc_state_str(enc_state));
 
 		return -EINVAL;
 	}
@@ -779,7 +780,7 @@ static int cmd_bap_scan_delegator_bis_synced(const struct shell *sh, size_t argc
 	}
 
 	if (pa_sync_state > BT_BAP_PA_STATE_NO_PAST) {
-		shell_error(sh, "Invalid pa_sync_state %ld", pa_sync_state);
+		shell_error(sh, "Invalid pa_sync_state %s", bt_bap_pa_state_str(pa_sync_state));
 
 		return -ENOEXEC;
 	}


### PR DESCRIPTION
When debugging it is hard to remember each state value (e.g. 0, 1, 2, 3) means. Therefore, make functions to improve logging for humans.

Fixes #59679