### PR TITLE
input: keymap: use the non `_OR_NULL` DEVICE_DT_GET variant

### DIFF
--- a/subsys/input/input_keymap.c
+++ b/subsys/input/input_keymap.c
@@ -102,7 +102,7 @@ static int keymap_init(const struct device *dev)
 	{											\
 		keymap_cb(DEVICE_DT_INST_GET(inst), evt);					\
 	}											\
-	INPUT_CALLBACK_DEFINE(DEVICE_DT_GET_OR_NULL(DT_INST_PARENT(inst)), keymap_cb_##inst);	\
+	INPUT_CALLBACK_DEFINE(DEVICE_DT_GET(DT_INST_PARENT(inst)), keymap_cb_##inst);		\
 												\
 	DT_INST_FOREACH_PROP_ELEM(inst, keymap, KEYMAP_ENTRY_VALIDATE)				\
 												\


### PR DESCRIPTION
This driver really needs a device associated with it for the syncronization bit to make sense, and since the argument is DT_PARENT it will get it all the time, so no changes in practice, but this should have been using the normal macro anyway.