### PR TITLE
Bluetooth: ATT: don't callback if bearer is invalid

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -595,6 +595,13 @@ static void att_on_sent_cb(struct bt_att_tx_meta_data *meta)
 
 	LOG_DBG("opcode 0x%x", meta->opcode);
 
+	if (!meta->att_chan ||
+	    !meta->att_chan->att ||
+	    !meta->att_chan->att->conn) {
+		LOG_DBG("Bearer not connected, dropping ATT cb");
+		return;
+	}
+
 	if (meta->err) {
 		LOG_ERR("Got err %d, not calling ATT cb", meta->err);
 		return;


### PR DESCRIPTION
If an att buf is destroyed during bearer teardown, we want to avoid using invalid references.

Double-check that the current bearer, the ATT object and the ACL conn objects it is attached to are not NULL before proceeding.

Shouldn't change behavior, just avoids a segfault.