### PR TITLE
kconfig: remove Kconfig BOARD_RPI_PICO_W safe guard.

### DIFF
--- a/boards/v2/raspberry_pi/rpi_pico/Kconfig.defconfig
+++ b/boards/v2/raspberry_pi/rpi_pico/Kconfig.defconfig
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Yonatan Schachter
 # SPDX-License-Identifier: Apache-2.0
 
-if BOARD_RPI_PICO || BOARD_RPI_PICO_W
+if BOARD_RPI_PICO
 
 config RP2_FLASH_W25Q080
 	default y
@@ -16,4 +16,4 @@ endif # I2C_DW
 config USB_SELF_POWERED
 	default n
 
-endif # BOARD_RPI_PICO || BOARD_RPI_PICO_W
+endif # BOARD_RPI_PICO


### PR DESCRIPTION
Boards are defining two Kconfigs, `BOARD_<board_name>` and `BOARD_<board_name>_<identifier>`.

For the raspberry pi pico, this is then BOARD_RPI_PICO and BOARD_RPI_PICO_RP2040 / BOARD_RPI_PICO_RP2040_W.

Thus there is no BOARD_RPI_PICO_W.
As all occurences with BOARD_RPI_PICO_W, is done as: BOARD_RPI_PICO || BOARD_RPI_PICO_W, then simply remove BOARD_RPI_PICO_W.