### PR TITLE
net: icmp: Don't report error on ICMP messages w/o handler

### DIFF
--- a/subsys/net/ip/icmpv4.c
+++ b/subsys/net/ip/icmpv4.c
@@ -639,7 +639,7 @@ enum net_verdict net_icmpv4_input(struct net_pkt *pkt,
 	net_stats_update_icmp_recv(net_pkt_iface(pkt));
 
 	ret = net_icmp_call_ipv4_handlers(pkt, ip_hdr, icmp_hdr);
-	if (ret < 0) {
+	if (ret < 0 && ret != -ENOENT) {
 		NET_ERR("ICMPv4 handling failure (%d)", ret);
 	}
 

--- a/subsys/net/ip/icmpv6.c
+++ b/subsys/net/ip/icmpv6.c
@@ -364,7 +364,7 @@ enum net_verdict net_icmpv6_input(struct net_pkt *pkt,
 	net_stats_update_icmp_recv(net_pkt_iface(pkt));
 
 	ret = net_icmp_call_ipv6_handlers(pkt, ip_hdr, icmp_hdr);
-	if (ret < 0) {
+	if (ret < 0 && ret != -ENOENT) {
 		NET_ERR("ICMPv6 handling failure (%d)", ret);
 	}
 


### PR DESCRIPTION
ICMPv4/6 modules print error when ICMP message handling fails, which includes no message handler registered. This is a bit problematic, as there are many ICMP messages that Zephyr does not process, and every time such a message is received, an error log is printed (which wasn't the case before ICMP rework).

Restore the old behavior (no log on unrecognized ICMP message) by explicitly filtering out ENOENT error code from printing error. That way, log will only be printed if an error occured within the actual message handler.