### PR TITLE
Revert "init: add missing initialization of dev pointer in SYS_INIT (alternative to PR68125)

### DIFF
--- a/include/zephyr/init.h
+++ b/include/zephyr/init.h
@@ -202,10 +202,10 @@ struct init_entry {
  *
  * @see SYS_INIT()
  */
-#define SYS_INIT_NAMED(name, init_fn_, level, prio)                                       \
-	static const Z_DECL_ALIGN(struct init_entry)                                      \
-		Z_INIT_ENTRY_SECTION(level, prio, 0) __used __noasan                      \
-		Z_INIT_ENTRY_NAME(name) = {.init_fn = {.sys = (init_fn_)}, .dev = NULL}
+#define SYS_INIT_NAMED(name, init_fn_, level, prio)                            \
+	static const Z_DECL_ALIGN(struct init_entry)                           \
+		Z_INIT_ENTRY_SECTION(level, prio, 0) __used __noasan           \
+		Z_INIT_ENTRY_NAME(name) = {.init_fn = {.sys = (init_fn_)}}
 
 /** @} */
 


### PR DESCRIPTION
…acro"

This reverts commit 2438dbb613731f1abb90be9e1b4c7bd529d46574.

This commit breaks compilation on the Cadence XCC toolchain we use for Intel Tiger Lake products (this is the oldest platform we support in Zephyr upstream for the audio DSP).

Error:
/work/zephyr/lib/os/p4wq.c:216: error: unknown field ‘dev’ specified in initializer /work/zephyr/lib/os/p4wq.c:216: warning: missing braces around initializer /work/zephyr/lib/os/p4wq.c:216: warning: (near initialization for ‘__init_static_init.<anonymous>’)

This is XCC RG-2017.8-linux (xt-xcc version 12.0.8)