### PR TITLE
init: adjust the SYS_INIT dev field init to play nice with older comp (alternative to PR68118)

### DIFF
--- a/include/zephyr/init.h
+++ b/include/zephyr/init.h
@@ -205,7 +205,7 @@ struct init_entry {
 #define SYS_INIT_NAMED(name, init_fn_, level, prio)                                       \
 	static const Z_DECL_ALIGN(struct init_entry)                                      \
 		Z_INIT_ENTRY_SECTION(level, prio, 0) __used __noasan                      \
-		Z_INIT_ENTRY_NAME(name) = {.init_fn = {.sys = (init_fn_)}, .dev = NULL}
+		Z_INIT_ENTRY_NAME(name) = {{ (init_fn_) }, { NULL } }
 
 /** @} */
 


### PR DESCRIPTION
…ilers

Fix a build error with certain older Cadence XCC toolchains. These are used e.g. for Intel Tiger Lake products for the audio DSP (thhe oldest platform supported in Zephyr upstream for the audio DSP).

Error:
/work/zephyr/lib/os/p4wq.c:216: error: unknown field ‘dev’ specified in initializer /work/zephyr/lib/os/p4wq.c:216: warning: missing braces around initializer /work/zephyr/lib/os/p4wq.c:216: warning: (near initialization for ‘__init_static_init.<anonymous>’)

Compiler version XCC RG-2017.8-linux (xt-xcc version 12.0.8)

Fixes: 2438dbb613731f ("init: add missing initialization of dev pointer in SYS_INIT macro")