### PR TITLE
drivers: display: uc81xx: fix 16-bit 'tres'

### DIFF
--- a/drivers/display/uc81xx.c
+++ b/drivers/display/uc81xx.c
@@ -677,7 +677,7 @@ static inline int uc81xx_set_ptl_8(const struct device *dev, uint16_t x, uint16_
 static int uc81xx_set_tres_16(const struct device *dev)
 {
 	const struct uc81xx_config *config = dev->config;
-	const struct uc81xx_tres8 tres = {
+	const struct uc81xx_tres16 tres = {
 		.hres = sys_cpu_to_be16(config->width),
 		.vres = sys_cpu_to_be16(config->height),
 	};


### PR DESCRIPTION
Use `struct uc81xx_tres16` for 16-bit 'tres' setup, instead of `struct uc81xx_tres8`. This fixes a
regression when support for 'uc8175' was added and `struct uc81xx_tres` was replaced with `struct
uc81xx_tres16`.

Fixes: 7c46b0b8984e ("drivers: display: uc81xx: add support for uc8175")