### PR TITLE
doc: releases: fix typo

### DIFF
--- a/doc/releases/migration-guide-3.5.rst
+++ b/doc/releases/migration-guide-3.5.rst
@@ -73,7 +73,7 @@ C Library
   * Picolibc has four different printf/scanf variants supported in Zephyr,
     'double', 'long long', 'integer', and 'minimal. 'double' offers a
     complete printf implementation with exact floating point in decimal and
-    hexidecimal formats, full integer support including long long, C99
+    hexadecimal formats, full integer support including long long, C99
     integer size specifiers (j, z, t) and POSIX positional arguments. 'long
     long' mode removes float support, 'integer' removes long long support
     while 'minimal' mode also removes support for format modifiers and

--- a/doc/releases/release-notes-2.2.rst
+++ b/doc/releases/release-notes-2.2.rst
@@ -197,7 +197,7 @@ Kernel
 * Propagate a distinct error code if a workqueue item is submitted that
   has already been completed
 * Disable preemption when handing fatal errors
-* Fix an issue with the sytsem call stack frame if the system call is
+* Fix an issue with the system call stack frame if the system call is
   preempted and then later tries to Z_OOPS()
 * add k_thread_stack_space_get() system call for analyzing thread stack
   space. Older methods which had problems in some cases or on some
@@ -636,7 +636,7 @@ Bluetooth
     address resolution support
   * Added dynamic TX power control, including a set of vendor-specific commands
     to read and write the TX power
-  * Added a Kconfig option, BT_CTLR_PARAM_CHECK, to enable addtional parameter
+  * Added a Kconfig option, BT_CTLR_PARAM_CHECK, to enable additional parameter
     checking
   * Added basic support for SMI (Stable Modulation Index)
   * Ticker: Implemented dynamic rescheduling

--- a/doc/releases/release-notes-2.4.rst
+++ b/doc/releases/release-notes-2.4.rst
@@ -73,7 +73,7 @@ API Changes
 
 * ``<drivers/dma.h>`` has seen its callback normalized. It had its signature
   changed to add a struct device pointer as first parameter. Such callback
-  signature has been generalized throuh the addition of dma_callback_t.
+  signature has been generalized through the addition of dma_callback_t.
   'callback_arg' argument has been renamed to 'user_data. All user code have
   been modified accordingly.
 
@@ -98,7 +98,7 @@ API Changes
 * All device instances got a const qualifier. So this applies to all APIs
   manipulating ``struct device *`` (ADC, GPIO, I2C, ...). In order to avoid
   const qualifier loss on ISRs, all ISRs now take a ``const *void`` as a
-  paremeter as well.
+  parameter as well.
 
 * The ``_gatt_`` and ``_GATT_`` infixes have been removed for the HRS, DIS
   and BAS APIs and the Kconfig options.
@@ -400,7 +400,7 @@ Drivers and Sensors
 
 * DMA
 
-  * STM32: Number of changes including k_malloc removal, driver piority init
+  * STM32: Number of changes including k_malloc removal, driver priority init
     increase, get_status API addition and various cleanups.
   * Added MCUX EDMA driver for i.MX RT and Kinetis K6x SoCs.
   * Added MCUX LPC driver for LPC and i.MX RT6xx SoCs.
@@ -634,7 +634,7 @@ Networking
 * Added support for IPv6 multicast packet routing.
 * Added support to SOCK_DGRAM type sockets for AF_PACKET family.
 * Added support for using TLS sockets when using socket offloading.
-* Added additonal checks in IPv6 to ensure that multicasts are only passed to the
+* Added additional checks in IPv6 to ensure that multicasts are only passed to the
   upper layer if the originating interface actually joined the destination
   multicast group.
 * Allow user to specify TCP port number in HTTP request.

--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -453,7 +453,7 @@ Drivers and Sensors
 
 * I2C
 
-  * Added driver support for lmx6x, it8xxx2, and npcx7 plaforms.
+  * Added driver support for lmx6x, it8xxx2, and npcx7 platforms.
   * Added Atmel SAM4L TWIM driver.
   * Added I2C slave support in the microchip i2c driver.
   * Reversed 2.4 decision to downgrade I2C eeprom slave driver to a
@@ -900,7 +900,7 @@ MCUBoot
   * Renamed single-image mode to single-slot mode,
     see ``CONFIG_SINGLE_APPLICATION_SLOT``.
   * Added patch for turning off cache for Cortex M7 before chain-loading.
-  * Fixed boostrapping in swap-move mode.
+  * Fixed bootstrapping in swap-move mode.
   * Fixed issue causing that interrupted swap-move operation might brick device
     if the primary image was padded.
   * Fixed issue causing that HW stack protection catches the chain-loaded

--- a/doc/releases/release-notes-2.6.rst
+++ b/doc/releases/release-notes-2.6.rst
@@ -259,7 +259,7 @@ Bluetooth
   * Added the ability to send HCI monitor traces over RTT.
   * Refactored the Bluetooth buffer configuration for simplicity. See the
     commit message of 6483e12a8ac4f495b28279a6b84014f633b0d374 for more info.
-    Note however that the aformentioned commit message has two typos;
+    Note however that the aforementioned commit message has two typos;
 
     * ``BT_CTLR_TX_BUFFER`` should be ``BT_CTLR_TX_BUFFERS``
     * ``BT_CTLR_TX_BUFFERS_SIZE`` should be ``BT_CTLR_TX_BUFFER_SIZE``
@@ -611,7 +611,7 @@ Drivers and Sensors
 * Sensor
 
   * Added support for STM32 internal (CPU) temperature sensor.
-  * Refactored mulitple ST sensor drivers to use gpio_dt_spec macros and common
+  * Refactored multiple ST sensor drivers to use gpio_dt_spec macros and common
     stmemc routines, support multiple instances, and configure ODR/range
     properties in device tree.
   * Added SBS 1.1 compliant fuel gauge driver.
@@ -1038,7 +1038,7 @@ Tests and Samples
      filter: dt_enabled_alias_with_parent_compat("led0", "gpio-leds")
 
 * Add a feature which handles pytest script in twister and provide an example.
-* Provide test excution time per ztest testcase.
+* Provide test execution time per ztest testcase.
 * Added and refined some testcases, most of them are negative testcases, to
   improve the test code coverage:
 

--- a/doc/releases/release-notes-2.7.rst
+++ b/doc/releases/release-notes-2.7.rst
@@ -730,7 +730,7 @@ USB
 
 * Added new header file where all defines and structures from Chapter 9
   (USB Device Framework) should be included.
-* Revised configuraiton of USB device support.
+* Revised configuration of USB device support.
   Removed Kconfig option ``CONFIG_USB`` and introduced Kconfig option
   ``CONFIG_USB_DEVICE_DRIVER`` to enable USB device controller drivers,
   which is selected when option ``CONFIG_USB_DEVICE_STACK`` is enabled.

--- a/doc/releases/release-notes-3.0.rst
+++ b/doc/releases/release-notes-3.0.rst
@@ -380,7 +380,7 @@ Bluetooth
   * Updated the supported Bluetooth HCI version to 5.3
   * Added support for Periodic Advertiser List
   * Added support for Periodic Advertising Synchronization Receive Enable
-  * Added support for filter access list filtering for exended scanning
+  * Added support for filter access list filtering for extended scanning
   * Added support for Advertising Extensions dynamic TX power control
   * Added handling of direct address type in extended adv reports
   * Implemented auxiliary PDU device address matching
@@ -660,7 +660,7 @@ Networking
   * Added support for multiple LwM2M Firmware Update object instances.
   * Improved error handling in LwM2M content writers.
   * Added unit tests for LwM2M content writers.
-  * Implmented LwM2M Security, Server, Connection Monitor objects in version 1.1.
+  * Implemented LwM2M Security, Server, Connection Monitor objects in version 1.1.
   * Multiple minor bugfixes in the LwM2M stack.
   * Added support for the following objects:
 
@@ -678,7 +678,7 @@ Networking
     unaliged access warnings from gcc.
   * Added automatic loopback addresses registration to loopback interface.
   * Fixed source address selection for ARP.
-  * Allow to implment a custom IEEE802154 L2 on top of existing drivers.
+  * Allow to implement a custom IEEE802154 L2 on top of existing drivers.
   * Introduced a network packet filtering framework.
 
 * MQTT:

--- a/doc/releases/release-notes-3.1.rst
+++ b/doc/releases/release-notes-3.1.rst
@@ -620,7 +620,7 @@ Networking
   * Added a
     :kconfig:option:`CONFIG_NET_ETHERNET_FORWARD_UNRECOGNISED_ETHERTYPE`
     option, which allows to forward frames with unrecognised EtherType to the
-    netowrk stack.
+    network stack.
 
 * HTTP:
 
@@ -1721,7 +1721,7 @@ Addressed issues
 * :github:`43344` - intel_adsp_cavs25: samples/subsys/logging/syst is failing with a timeout when the sample is enabled to run on intel_adsp_cavs25
 * :github:`43333` - RFC: Bring zcbor as CBOR decoder/encoder in replacement for TinyCBOR
 * :github:`43326` - Unstable SD Card performance on Teensy 4.1
-* :github:`43319` - Hardware reset cause api sets reset pin bit everytime the api is called
+* :github:`43319` - Hardware reset cause api sets reset pin bit every time the api is called
 * :github:`43316` - stm32wl55 cannot enable PLL source as MSI
 * :github:`43314` - LE Audio: BAP ``sent`` callback missing
 * :github:`43310` - disco_l475_iot1: BLE not working

--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -165,7 +165,7 @@ Deprecated in this release
 
 * Flash Map API macros :c:macro:`FLASH_MAP_`, which have been using DTS node label
   property to reference partitions, have been deprecated and replaced with
-  :c:macro:`FIXED_PARTITION_` whch use DTS node label instead.
+  :c:macro:`FIXED_PARTITION_` which use DTS node label instead.
   Replacement list:
 
   .. table::
@@ -270,7 +270,7 @@ Architectures
   * Reduced callee-saved registers for RV32E.
   * Introduced Zicsr, Zifencei and BitManip as separate extensions.
   * Introduced :kconfig:option:`CONFIG_RISCV_ALWAYS_SWITCH_THROUGH_ECALL` for
-    plaforms that require every ``mret`` to be balanced by ``ecall``.
+    platforms that require every ``mret`` to be balanced by ``ecall``.
   * IRQ vector table is now used for vectored mode.
   * Disabled :kconfig:option:`CONFIG_IRQ_VECTOR_TABLE_JUMP_BY_CODE` for CLIC.
   * ``STRINGIFY`` macro is now used for CSR helpers.
@@ -511,7 +511,7 @@ Drivers and Sensors
   * The STM32 CAN-FD CAN driver clock configuration has been moved from Kconfig to :ref:`devicetree
     <dt-guide>`. See the :dtcompatible:`st,stm32-fdcan` devicetree binding for more information.
   * The filter handling of STM32 bxCAN driver has been simplified and made more reliable.
-  * The STM32 bxCAN driver now supports dual intances.
+  * The STM32 bxCAN driver now supports dual instances.
   * The CAN loopback driver now supports CAN-FD.
   * The CAN shell module has been rewritten to properly support the additions and changes to the CAN
     controller API.
@@ -543,7 +543,7 @@ Drivers and Sensors
 
 * DFU
 
-  * Fixed fetch of the flash write block size from incorect device by
+  * Fixed fetch of the flash write block size from incorrect device by
     ``flash_img``.
   * Fixed possible build failure in the image manager for mcuboot on
     redefinitions of :c:macro:`BOOT_MAX_ALIGN` and :c:macro:`BOOT_MAGIC_SZ`.
@@ -757,7 +757,7 @@ Drivers and Sensors
     for various drivers.
   * Various fixes on ``lpuart``.
   * Added a workaround on bytes dropping on ``nrfx_uarte``.
-  * Fixed compilation error on ``uart_pl011`` when interrupt is diabled.
+  * Fixed compilation error on ``uart_pl011`` when interrupt is disabled.
   * Added power management support on ``stm32``.
   * ``xlnx_ps`` has moved to using ``DEVICE_MMIO`` API.
   * ``gd32`` now supports using reset API to reset hardware and clock
@@ -1398,7 +1398,7 @@ Libraries / Subsystems
     response is now only used for mcumgr errors, shell command
     execution result codes are instead returned in the ``ret``
     variable instead, see :ref:`mcumgr_smp_group_9` for updated
-    information. Legacy bahaviour can be restored by enabling
+    information. Legacy behaviour can be restored by enabling
     :kconfig:option:`CONFIG_MCUMGR_CMD_SHELL_MGMT_LEGACY_RC_RETURN_CODE`.
   * MCUMGR img_mgmt erase command now accepts an optional slot number
     to select which image will be erased, using the ``slot`` input

--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -742,7 +742,7 @@ Drivers and Sensors
 
   * STM32 OSPI: Now supports DMA transfer on STM32U5.
 
-  * STM32: Flash driver was revisited to simplify re-use of driver for new series, taking
+  * STM32: Flash driver was revisited to simplify reuse of driver for new series, taking
     advantage of device tree compatibles.
 
 * FPGA

--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -776,7 +776,7 @@ Drivers and Sensors
     channel(s) to link a software channel configuration to.
   * MCUX LPADC driver ``voltage-ref`` and ``power-level`` devicetree properties
     were shifted to match the hardware as described in reference manual instead
-    of matching the NXP SDK enum identifers.
+    of matching the NXP SDK enum identifiers.
   * Added support for STM32C0 and STM32H5.
   * Added DMA support for STM32H7.
   * STM32: Resolutions are now listed in the device tree for each ADC instance

--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -260,7 +260,7 @@ Bluetooth
   * Fixed BIS payload sliding window overrun check
   * Fixed CIS Central FT calculation
   * Fixed CIS Central error handling
-  * Fixed CIS assymmetric PHY usage
+  * Fixed CIS asymmetric PHY usage
   * Fixed CIS encryption when DF support enabled
   * Fixed ISO-AL for quality tests and time stamps
   * Fixed PHY value in HCI LE CIS Established Event
@@ -840,7 +840,7 @@ Networking
     When :kconfig:option:`CONFIG_LWM2M_COAP_BLOCK_TRANSFER` is enabled, any content that is larger
     than :kconfig:option:`CONFIG_LWM2M_COAP_MAX_MSG_SIZE` is split into a block-wise transfer.
   * Block-wise transfers don't require tokens to match anymore as this was not in line
-    with CoAP specification (CoAP doesn't require tokens re-use).
+    with CoAP specification (CoAP doesn't require tokens reuse).
   * Various fixes to bootstrap. Now client ensures that Bootstrap-Finish command is sent,
     before closing the DTLS pipe. Also allows Bootstrap server to close the DTLS pipe.
     Added timeout when waiting for bootstrap commands.
@@ -2115,7 +2115,7 @@ Libraries / Subsystems
   * Added support of mounting littlefs on the block device from the shell/fs.
   * Added alignment parameter to FS_LITTLEFS_DECLARE_CUSTOM_CONFIG macro, it can speed up read/write
     operation for SDMMC devices in case when we align buffers on CONFIG_SDHC_BUFFER_ALIGNMENT,
-    because we can avoid extra copy of data from card bffer to read/prog buffer.
+    because we can avoid extra copy of data from card buffer to read/prog buffer.
 
 * Random
 

--- a/doc/releases/release-notes-3.6.rst
+++ b/doc/releases/release-notes-3.6.rst
@@ -74,7 +74,7 @@ Boards & SoC Support
 * Made these changes in other SoC series:
 
   * Nordic SoCs now imply :kconfig:option:`CONFIG_XIP` instead of selecting it, this allows for
-    creating RAM-based applicatins by disabling it.
+    creating RAM-based applications by disabling it.
 
 * Added support for these ARC boards:
 


### PR DESCRIPTION
Utilize a code spell-checking tool to scan for and correct spelling errors in all files within the doc/releases directory.

The typo in the '**Issue Related Items**' section will be left unchanged.