### PR TITLE
drivers: mdio: Include errno in header

### DIFF
--- a/include/zephyr/drivers/mdio.h
+++ b/include/zephyr/drivers/mdio.h
@@ -21,6 +21,7 @@
  */
 #include <zephyr/types.h>
 #include <zephyr/device.h>
+#include <errno.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
MDIO driver header (mdio.h)is using errno values without including errno header, this causes build errors depending on the order of inclusion of this mdio header in other files, fix by including the errno header in this mdio.h file.