### PR TITLE
timer: nrf_rtc: don't disable RTC in secure firmware

### DIFF
--- a/drivers/timer/Kconfig.nrf_rtc
+++ b/drivers/timer/Kconfig.nrf_rtc
@@ -8,7 +8,8 @@ config NRF_RTC_TIMER
 	depends on CLOCK_CONTROL
 	depends on SOC_COMPATIBLE_NRF
 	select TICKLESS_CAPABLE
-	select SYSTEM_TIMER_HAS_DISABLE_SUPPORT
+	# Secure firmware hands off access to RTC peripheral
+	select SYSTEM_TIMER_HAS_DISABLE_SUPPORT if !ARM_SECURE_FIRMWARE
 	depends on !$(dt_nodelabel_enabled,rtc1)
 	help
 	  This module implements a kernel device driver for the nRF Real Time


### PR DESCRIPTION
Don't attempt to disable the RTC in `sys_clock_disable` when rebooting from secure firmware, as peripheral control has already been handed to the nonsecure domain.