### PR TITLE
dfu: img_util: option to use standard partitions

### DIFF
--- a/subsys/dfu/Kconfig
+++ b/subsys/dfu/Kconfig
@@ -80,6 +80,14 @@ config IMG_ENABLE_IMAGE_CHECK
 	  Another use is to ensure that firmware upgrade routines from internet
 	  server to flash slot are performing properly.
 
+config IMG_IGNORE_NONSECURE_PARTITION
+	bool "Don't try and use _ns partitions for writing new images"
+	depends on MCUBOOT_IMG_MANAGER
+	help
+	  Applications built with TRUSTED_EXECUTION_NONSECURE may still
+	  want to use the standard mcuboot partitions. Enabling this option
+	  means that slot1_ns_partition is not automatically selected.
+
 module = IMG_MANAGER
 module-str = image manager
 source "subsys/logging/Kconfig.template.log_config"

--- a/subsys/dfu/img_util/flash_img.c
+++ b/subsys/dfu/img_util/flash_img.c
@@ -19,7 +19,8 @@
 #endif
 
 #include <zephyr/devicetree.h>
-#ifdef CONFIG_TRUSTED_EXECUTION_NONSECURE
+#if defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) && \
+	!defined(CONFIG_IMG_IGNORE_NONSECURE_PARTITION)
 	#define UPLOAD_FLASH_AREA_LABEL slot1_ns_partition
 #else
 #if FIXED_PARTITION_EXISTS(slot1_partition)


### PR DESCRIPTION
Add an option to use standard partitions for image upload when also built with `CONFIG_TRUSTED_EXECUTION_NONSECURE`.

This is intended for partitions setups like the following:
```
&flash0 {
	partitions {
		boot_partition: partition@0 {
			reg = <0x000000000 0x00010000>;
		};
		slot0_partition: partition@10000 {
			reg = <0x00010000 0x00010000>;
		};
		slot0_ns_partition: partition@20000 {
			reg = <0x00020000 0x00050000>;
		};
		slot1_partition: partition@70000 {
			reg = <0x00070000 0x00060000>;
		};
	};
};
```
While the application running the DFU process is in `slot0_ns_partition`, it wants to write the complete image for `slot1_partition`.
AFAIK there is no capability to split `slot1` into secure and non-secure and upload a new merged image with mcumgr.
