### PR TITLE
arch: Kconfig: add BOARD symbol prompt

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -999,6 +999,15 @@ config SOC_FAMILY
 	  This option holds the directory name used by the build system to locate
 	  the correct linker and header files.
 
+config BOARD
+	string "Name of the board"
+	help
+	  This option holds the name of the board and is used to locate the files
+	  related to the board in the source tree (under boards/).
+	  The Board is the first location where we search for a linker.ld file,
+	  if not found we look for the linker file in
+	  soc/<arch>/<family>/<series>
+
 config TOOLCHAIN_HAS_BUILTIN_FFS
 	bool
 	default y if !(64BIT && RISCV)


### PR DESCRIPTION
Add a prompt to the BOARD symbol so that board version files can override the value to contain the revision.

Not sure how valid the help text is under the V2 board model.