### PR TITLE
drivers: power_domain: add missing dependency

### DIFF
--- a/drivers/power_domain/Kconfig
+++ b/drivers/power_domain/Kconfig
@@ -23,6 +23,7 @@ config POWER_DOMAIN_GPIO
 	default y
 	depends on DT_HAS_POWER_DOMAIN_GPIO_ENABLED
 	depends on GPIO
+	depends on PM_DEVICE || !PM_DEVICE_POWER_DOMAIN
 	depends on TIMEOUT_64BIT
 	select DEVICE_DEPS
 


### PR DESCRIPTION
The GPIO power domain driver needs device power management enabled to compile if `PM_DEVICE_POWER_DOMAIN` is enabled.