### PR TITLE
net: dns: option to disable auto context init

### DIFF
--- a/include/zephyr/net/dns_resolve.h
+++ b/include/zephyr/net/dns_resolve.h
@@ -464,12 +464,12 @@ static inline int dns_cancel_addr_info(uint16_t dns_id)
 /**
  * @brief Initialize DNS subsystem.
  */
-#if defined(CONFIG_DNS_RESOLVER)
+#if defined(CONFIG_DNS_RESOLVER_AUTO_INIT)
 void dns_init_resolver(void);
 
 #else
 #define dns_init_resolver(...)
-#endif /* CONFIG_DNS_RESOLVER */
+#endif /* CONFIG_DNS_RESOLVER_AUTO_INIT */
 
 /** @endcond */
 

--- a/include/zephyr/net/dns_resolve.h
+++ b/include/zephyr/net/dns_resolve.h
@@ -278,6 +278,15 @@ int dns_resolve_init(struct dns_resolve_context *ctx,
 		     const struct sockaddr *dns_servers_sa[]);
 
 /**
+ * @brief Init DNS resolving context with default Kconfig options.
+ *
+ * @param ctx DNS context.
+ *
+ * @return 0 if ok, <0 if error.
+ */
+int dns_resolve_init_default(struct dns_resolve_context *ctx);
+
+/**
  * @brief Close DNS resolving context.
  *
  * @details This releases DNS resolving context and marks the context unusable.

--- a/subsys/net/lib/dns/Kconfig
+++ b/subsys/net/lib/dns/Kconfig
@@ -10,6 +10,13 @@ config DNS_RESOLVER
 
 if DNS_RESOLVER
 
+config DNS_RESOLVER_AUTO_INIT
+	bool "Automatically initialize the default DNS context"
+	default y
+	help
+	  Automatically initialize the default DNS context so dns_resolve_init
+	  does not need to be manually called.
+
 config MDNS_RESOLVER
 	bool "MDNS support"
 	help

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -1486,12 +1486,12 @@ struct dns_resolve_context *dns_resolve_get_default(void)
 	return &dns_default_ctx;
 }
 
-void dns_init_resolver(void)
+int dns_resolve_init_default(struct dns_resolve_context *ctx)
 {
+	int ret = 0;
 #if defined(CONFIG_DNS_SERVER_IP_ADDRESSES)
 	static const char *dns_servers[SERVER_COUNT + 1];
 	int count = DNS_SERVER_COUNT;
-	int ret;
 
 	if (count > 5) {
 		count = 5;
@@ -1558,7 +1558,7 @@ void dns_init_resolver(void)
 
 	dns_servers[SERVER_COUNT] = NULL;
 
-	ret = dns_resolve_init(dns_resolve_get_default(), dns_servers, NULL);
+	ret = dns_resolve_init(ctx, dns_servers, NULL);
 	if (ret < 0) {
 		NET_WARN("Cannot initialize DNS resolver (%d)", ret);
 	}
@@ -1568,4 +1568,10 @@ void dns_init_resolver(void)
 	 */
 	(void)dns_resolve_init(dns_resolve_get_default(), NULL, NULL);
 #endif
+	return ret;
+}
+
+void dns_init_resolver(void)
+{
+	dns_resolve_init_default(dns_resolve_get_default());
 }

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -1571,7 +1571,9 @@ int dns_resolve_init_default(struct dns_resolve_context *ctx)
 	return ret;
 }
 
+#ifdef CONFIG_DNS_RESOLVER_AUTO_INIT
 void dns_init_resolver(void)
 {
 	dns_resolve_init_default(dns_resolve_get_default());
 }
+#endif /* CONFIG_DNS_RESOLVER_AUTO_INIT */


### PR DESCRIPTION
Adds an option to disable the automatic initialization of the default
dns_context. This lets applications use the default context, while also
managing the `init` and `close` functions.

Adds a function that can be used to initialize a dns context to the
default Kconfig values.
