### PR TITLE
drivers: systick: Allow external clock source for Cortex-M SysTick

### DIFF
--- a/dts/bindings/timer/arm,armv6m-systick.yaml
+++ b/dts/bindings/timer/arm,armv6m-systick.yaml
@@ -5,8 +5,4 @@ description: ARMv6-M System Tick
 
 compatible: "arm,armv6m-systick"
 
-include: base.yaml
-
-properties:
-  reg:
-    required: true
+include: "arm,cortex-m-systick.yaml"

--- a/dts/bindings/timer/arm,armv7m-systick.yaml
+++ b/dts/bindings/timer/arm,armv7m-systick.yaml
@@ -5,8 +5,4 @@ description: ARMv7-M System Tick
 
 compatible: "arm,armv7m-systick"
 
-include: base.yaml
-
-properties:
-  reg:
-    required: true
+include: "arm,cortex-m-systick.yaml"

--- a/dts/bindings/timer/arm,armv8.1m-systick.yaml
+++ b/dts/bindings/timer/arm,armv8.1m-systick.yaml
@@ -5,8 +5,4 @@ description: ARMv8.1-M System Tick
 
 compatible: "arm,armv8.1m-systick"
 
-include: base.yaml
-
-properties:
-  reg:
-    required: true
+include: "arm,cortex-m-systick.yaml"

--- a/dts/bindings/timer/arm,armv8m-systick.yaml
+++ b/dts/bindings/timer/arm,armv8m-systick.yaml
@@ -5,8 +5,4 @@ description: ARMv8-M System Tick
 
 compatible: "arm,armv8m-systick"
 
-include: base.yaml
-
-properties:
-  reg:
-    required: true
+include: "arm,cortex-m-systick.yaml"

--- a/dts/bindings/timer/arm,cortex-m-systick.yaml
+++ b/dts/bindings/timer/arm,cortex-m-systick.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2024 Enphase Energy
+# SPDX-License-Identifier: Apache-2.0
+
+description: ARM Cortex-M System Tick
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true
+
+  external-reference-clock:
+    type: boolean
+    description: |
+      The default clock source for the Cortex-M systick is the processor
+      clock. Enabling this option switches to an implementation defined
+      external reference clock (if available). If unsure, leave disabled.
+
+      See section "SysTick Control and Status Register" of the
+      Armv6-M/Armv7-M/Armv8-M Architecture Reference Manuals for details.


### PR DESCRIPTION
I'm currently working on an out-of-tree SoC where we want to run the Cortex-M systick from a clock source other than the processor clock. This change makes that configurable (if it is supported by the SoC).

Section "B3.3.3 SysTick Control and Status Register, SYST_CSR" of the Armv7-M Architecture Reference Manual:
![image](https://github.com/zephyrproject-rtos/zephyr/assets/124088381/59038729-dcea-42bc-a4f3-366a41964a8c)