### PR TITLE
dfu: mcuboot: function to query header of current image

### DIFF
--- a/include/zephyr/dfu/mcuboot.h
+++ b/include/zephyr/dfu/mcuboot.h
@@ -160,6 +160,18 @@ int boot_read_bank_header(uint8_t area_id,
 			  size_t header_size);
 
 /**
+ * @brief Read the MCUboot header for the currently running image
+ *
+ * @param header On success, the returned header information is available
+ *               in this structure.
+ * @param header_size Size of the header structure passed by the caller.
+ *                    If this is not large enough to contain all of the
+ *                    necessary information, an error is returned.
+ * @return Zero on success, a negative value on error.
+ */
+int boot_read_img_header(struct mcuboot_img_header *header, size_t header_size);
+
+/**
  * @brief Check if the currently running image is confirmed as OK.
  *
  * MCUboot can perform "test" upgrades. When these occur, a new

--- a/subsys/dfu/boot/mcuboot.c
+++ b/subsys/dfu/boot/mcuboot.c
@@ -144,6 +144,11 @@ int boot_read_bank_header(uint8_t area_id,
 	return 0;
 }
 
+int boot_read_img_header(struct mcuboot_img_header *header, size_t header_size)
+{
+	return boot_read_bank_header(FLASH_AREA_IMAGE_PRIMARY, header, header_size);
+}
+
 int mcuboot_swap_type_multi(int image_index)
 {
 	return boot_swap_type_multi(image_index);


### PR DESCRIPTION
Adds the ability to query the MCUboot header of the currently running image without the `img_mgmt` subsystem being enabled, and without having to specify the flash area ID of the current image.

Retrieving the flash area ID of the current image would require duplicating the logic in `subsys/dfu/boot/mcuboot_priv.h` (Where `FLASH_AREA_IMAGE_PRIMARY` is defined).