### PR TITLE
drivers: watchdog: andes atcwdt200 remove #include <soc.h>

### DIFF
--- a/drivers/watchdog/wdt_andes_atcwdt200.c
+++ b/drivers/watchdog/wdt_andes_atcwdt200.c
@@ -7,7 +7,6 @@
 #define DT_DRV_COMPAT andestech_atcwdt200
 
 #include <zephyr/kernel.h>
-#include <soc.h>
 #include <zephyr/drivers/watchdog.h>
 
 #define LOG_LEVEL CONFIG_WDT_LOG_LEVEL


### PR DESCRIPTION
This PR is to resolve 'fatal error: soc.h: No such file or directory' in twister-build (1) of watchdog driver.
soc\riscv\andes_v5\ae350\soc.h was empty and deleted last week in #67673, so to revise wdt_andes_atcwdt200.c to remove "#include <soc.h>".