### PR TITLE
net: net_pkt: add peer sockaddr member in net_pkt struct 

### DIFF
--- a/include/zephyr/net/net_pkt.h
+++ b/include/zephyr/net/net_pkt.h
@@ -290,6 +290,13 @@ struct net_pkt {
 	 */
 	uint8_t priority;
 
+#if defined(CONFIG_NET_OFFLOAD)
+	/* Remote address of the recived packet. This is only used by
+	 * network interfaces with an offloaded TCP/IP stack.
+	 */
+	struct sockaddr remote;
+#endif /* CONFIG_NET_OFFLOAD */
+
 	/* @endcond */
 };
 


### PR DESCRIPTION
Add recvfrom() in net_offload api for UDP sockets and make use of it in esp_at driver. bind() is also changed in esp_at to make it possible to bind UDP sockets and poll it for data. This also necessitated changes in esp_at AP mode to keep WIFI non dormant when AP mode is used. recvfrom() and bind() works for STA or AP mode.