### PR TITLE
net: wifi: Make sure scan band string is null terminated

### DIFF
--- a/subsys/net/l2/wifi/wifi_utils.c
+++ b/subsys/net/l2/wifi/wifi_utils.c
@@ -241,7 +241,8 @@ int wifi_utils_parse_scan_bands(char *scan_bands_str, uint8_t *band_map)
 		return -EINVAL;
 	}
 
-	strncpy(parse_str, scan_bands_str, sizeof(parse_str));
+	strncpy(parse_str, scan_bands_str, sizeof(parse_str) - 1);
+	parse_str[sizeof(parse_str) - 1] = '\0';
 
 	band_str = strtok_r(parse_str, ",", &ctx);
 


### PR DESCRIPTION
Make sure that scan band string is properly terminated when parsing user supplied string.

Fixes: #67944
Coverity-CID: 342930