### PR TITLE
Bluetooth: Controller: Fix RXFIFO_DEFINE to reduce FLASH usage

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_internal.h
@@ -134,8 +134,9 @@ void ull_drift_ticks_get(struct node_rx_event_done *done,
 	mem_init(mem_pool_##_name.pool, mem_##_name.size, \
 		 mem_##_name.count, &mem_pool_##_name.free); \
 	\
-	mem_init(mem_link_##_name.pool, sizeof(memq_link_t), mem_##_name.count + \
-		 mem_##_name.extra_links, &mem_link_##_name.free)
+	mem_init(mem_link_##_name.pool, sizeof(memq_link_t), \
+		 (mem_##_name.count + mem_##_name.extra_links), \
+		 &mem_link_##_name.free)
 
 /**
  * @brief   Allocate FIFO elements with backing

--- a/subsys/bluetooth/controller/ll_sw/ull_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_iso.c
@@ -1543,7 +1543,7 @@ void *ll_iso_rx_get(void)
 			(void)memq_dequeue(memq_ll_iso_rx.tail,
 						&memq_ll_iso_rx.head, NULL);
 			mem_release(link, &mem_link_iso_rx.free);
-			mem_release(rx, &mem_iso_rx.free);
+			mem_release(rx, &mem_pool_iso_rx.free);
 			RXFIFO_ALLOC(iso_rx, 1);
 
 			link = memq_peek(memq_ll_iso_rx.head, memq_ll_iso_rx.tail, (void **)&rx);
@@ -1589,7 +1589,7 @@ void ll_iso_rx_mem_release(void **node_rx)
 
 		switch (rx_free->type) {
 		case NODE_RX_TYPE_ISO_PDU:
-			mem_release(rx_free, &mem_iso_rx.free);
+			mem_release(rx_free, &mem_pool_iso_rx.free);
 			break;
 		default:
 			/* Ignore other types as node may have been initialized due to


### PR DESCRIPTION
Fix RXFIFO_DEFINE to reduce FLASH usage by moving the pool outside the struct that is static initialized.