### PR TITLE
twister: pytest: fix pytest hw testing windows

### DIFF
--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/device_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/device_adapter.py
@@ -66,10 +66,18 @@ class DeviceAdapter(abc.ABC):
 
         if not self.command:
             self.generate_command()
-        self._flash_and_run()
+
+        if self.device_config.type != 'hardware':
+            self._flash_and_run()
+
         self._device_run.set()
         self._start_reader_thread()
         self.connect()
+
+        if self.device_config.type == 'hardware':
+            # On hardware, flash after connecting to COM port, otherwise some messages
+            # from target can be lost.
+            self._flash_and_run()
 
     def close(self) -> None:
         """Disconnect, close device and close reader thread."""

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
@@ -6,7 +6,8 @@ from __future__ import annotations
 
 import logging
 import os
-import pty
+if os.name != 'nt':
+    import pty
 import re
 import subprocess
 import time
@@ -150,7 +151,13 @@ class HardwareAdapter(DeviceAdapter):
         """Open a pty pair, run process and return tty name"""
         if not self.device_config.serial_pty:
             return None
-        master, slave = pty.openpty()
+
+        try:
+            master, slave = pty.openpty()
+        except NameError as exc:
+            logger.exception('PTY module is not available.')
+            raise exc
+
         try:
             self._serial_pty_proc = subprocess.Popen(
                 re.split(',| ', self.device_config.serial_pty),


### PR DESCRIPTION
Import of pty module causes exception when pytest harness is used for device testing on Windows. Fix it by importing pty module on non-windows hosts only. Add logger message for case pty is used by mistake on Windows.

When pytest harness test is run on hardware, messages sent from target right after application start-up are lost, because connection to COM port is not established yet. It can cause unexpected behavior of a test. Fix it by flashing and running application after connecting to COM port when testing on hardware.