### PR TITLE
Add test cases in Display & LVGL samples for boards with a supported display

### DIFF
--- a/samples/drivers/display/sample.yaml
+++ b/samples/drivers/display/sample.yaml
@@ -146,3 +146,11 @@ tests:
       - CONFIG_IDLE_STACK_SIZE=400
     harness_config:
       fixture: fixture_display
+  sample.display.builtin:
+    # This test case is intended to insure that this sample builds & runs
+    # correctly for all boards that have a supported built-in display.
+    filter: dt_chosen_enabled("zephyr,display")
+    harness: console
+    harness_config:
+      fixture: fixture_display
+    tags: display

--- a/samples/modules/lvgl/demos/sample.yaml
+++ b/samples/modules/lvgl/demos/sample.yaml
@@ -6,7 +6,11 @@ common:
     - lvgl
   harness: none
   filter: dt_chosen_enabled("zephyr,display")
-  tags: samples lvgl display gui
+  tags:
+    - samples
+    - display
+    - lvgl
+    - gui
 tests:
   sample.modules.lvgl.demo_music:
     extra_configs:
@@ -17,3 +21,19 @@ tests:
   sample.modules.lvgl.demo_stress:
     extra_configs:
       - CONFIG_LV_Z_DEMO_STRESS=y
+  sample.modules.lvgl.demos.st_b_lcd40_dsi1_mb1166:
+    platform_allow: stm32h747i_disco_m7
+    extra_args: SHIELD=st_b_lcd40_dsi1_mb1166
+    harness: console
+    harness_config:
+      fixture: fixture_display
+    extra_configs:
+      - CONFIG_LV_Z_DEMO_BENCHMARK=y
+    modules:
+      - lvgl
+    tags:
+      - samples
+      - display
+      - shield
+      - lvgl
+      - gui

--- a/samples/subsys/display/lvgl/sample.yaml
+++ b/samples/subsys/display/lvgl/sample.yaml
@@ -40,3 +40,17 @@ tests:
       - mimxrt595_evk_cm33
     integration_platforms:
       - mimxrt1170_evk_cm7
+  sample.subsys.display.lvgl.st_b_lcd40_dsi1_mb1166:
+    platform_allow: stm32h747i_disco_m7
+    extra_args: SHIELD=st_b_lcd40_dsi1_mb1166
+    harness: console
+    harness_config:
+      fixture: fixture_display
+    modules:
+      - lvgl
+    tags:
+      - samples
+      - display
+      - shield
+      - lvgl
+      - gui


### PR DESCRIPTION
This PR adds test cases in Display & LVGL samples for STM32 boards that come with a display (built-in or as a shield) that is
supported in Zephyr.
This patch will make it easier to catch display & LVGL regressions on STM32 boards in CI.