### PR TITLE
scripts: board_v1_to_v2: Fix CONFIG_SOC_SERIES_ exclusion

### DIFF
--- a/scripts/utils/board_v1_to_v2.py
+++ b/scripts/utils/board_v1_to_v2.py
@@ -104,7 +104,7 @@ def board_v1_to_v2(board_root, board, new_board, group, vendor, soc, variants):
             m = re.match(r"^CONFIG_(SOC_[A-Z0-9_]+).*$", line)
             if m:
                 dropped_line = True
-                if re.match(r"(?!SERIES_).*$", str(m)):
+                if not re.match(r"^CONFIG_SOC_SERIES_.*$", line):
                     board_soc_settings.append(m.group(1))
                 continue
 


### PR DESCRIPTION
Testing r"(?!SERIES_).*$" was not correct as we need to consider lines not starting by SERIES.
Fix this and make the condition globally more simple.