### PR TITLE
twister: pytest: Fix failing tests of mcumgr fixture.

### DIFF
--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/helpers/mcumgr.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/helpers/mcumgr.py
@@ -56,7 +56,7 @@ class MCUmgr:
 
     def image_upload(self, image: Path | str, slot: int | None = None, timeout: int = 30):
         command = f'-t {timeout} image upload {image}'
-        if slot:
+        if slot is not None:
             command += f' -e -n {slot}'
         self.run_command(command)
         logger.info('Image successfully uploaded')
@@ -98,7 +98,7 @@ class MCUmgr:
         raise MCUmgrException('No not active image found')
 
     def get_hash_to_confirm(self):
-        image_list = self.mcumgr.get_image_list()
+        image_list = self.get_image_list()
         for image in image_list:
             if 'confirmed' not in image.flags:
                 return image.hash

--- a/scripts/pylib/pytest-twister-harness/tests/fixtures/mcumgr_fixture_test.py
+++ b/scripts/pylib/pytest-twister-harness/tests/fixtures/mcumgr_fixture_test.py
@@ -27,6 +27,9 @@ def test_if_mcumgr_fixture_generate_proper_command(
     mcumgr.image_upload('/path/to/image', timeout=100)
     patched_run_command.assert_called_with('-t 100 image upload /path/to/image')
 
+    mcumgr.image_upload('/path/to/image', slot=2, timeout=100)
+    patched_run_command.assert_called_with('-t 100 image upload /path/to/image -e -n 2')
+
     mcumgr.image_test(hash='ABCD')
     patched_run_command.assert_called_with('image test ABCD')
 
@@ -55,12 +58,12 @@ def test_if_mcumgr_fixture_parse_image_list(mcumgr: MCUmgr) -> None:
         image=0 slot=0
             version: 0.0.0
             bootable: true
-            flags:
+            flags: active confirmed
             hash: 0000
         image=0 slot=1
             version: 1.1.1
             bootable: true
-            flags: pending
+            flags:
             hash: 1111
         Split status: N/A (0)
     """)
@@ -69,12 +72,12 @@ def test_if_mcumgr_fixture_parse_image_list(mcumgr: MCUmgr) -> None:
     assert image_list[0].image == 0
     assert image_list[0].slot == 0
     assert image_list[0].version == '0.0.0'
-    assert image_list[0].flags == ''
+    assert image_list[0].flags == 'active confirmed'
     assert image_list[0].hash == '0000'
     assert image_list[1].image == 0
     assert image_list[1].slot == 1
     assert image_list[1].version == '1.1.1'
-    assert image_list[1].flags == 'pending'
+    assert image_list[1].flags == ''
     assert image_list[1].hash == '1111'
 
     # take second hash to test
@@ -83,4 +86,4 @@ def test_if_mcumgr_fixture_parse_image_list(mcumgr: MCUmgr) -> None:
 
     # take first hash to confirm
     mcumgr.image_confirm()
-    mcumgr.run_command.assert_called_with('image confirm 0000')
+    mcumgr.run_command.assert_called_with('image confirm 1111')


### PR DESCRIPTION
Updated tests of mcumgr fixture in pytest-twister-harness plugin.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/68172