### PR TITLE
doc: posix: Add missing entries in POSIX supported API doc

### DIFF
--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -486,8 +486,8 @@ _POSIX_TIMEOUTS
    :header: API, Supported
    :widths: 50,10
 
-    mq_timedreceive(),
-    mq_timedsend(),
+    mq_timedreceive(),yes
+    mq_timedsend(),yes
     pthread_mutex_timedlock(),yes
     pthread_rwlock_timedrdlock(),yes
     pthread_rwlock_timedwrlock(),yes


### PR DESCRIPTION
`mq_timedsend()` and `mq_timedreceive()` are implemented but the information is missing in the documentation.

Fixes #66970
Fixes #66971