### PR TITLE
drivers: serial: add missed binding for xen dom0 consoleio driver

### DIFF
--- a/drivers/serial/Kconfig.xen
+++ b/drivers/serial/Kconfig.xen
@@ -18,7 +18,7 @@ config UART_XEN_HVC
 config UART_XEN_HVC_CONSOLEIO
 	bool "Xen hypervisor consoleio UART driver"
 	select SERIAL_HAS_DRIVER
-	depends on XEN_DOM0 || XEN_DOM0LESS
+	depends on DT_HAS_XEN_HVC_CONSOLEIO_ENABLED && (XEN_DOM0 || XEN_DOM0LESS)
 	default y
 	help
 	  Enable Xen hypervisor console driver. Used for Zephyr as

--- a/drivers/serial/uart_hvc_xen_consoleio.c
+++ b/drivers/serial/uart_hvc_xen_consoleio.c
@@ -17,6 +17,8 @@
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 
+#define DT_DRV_COMPAT xen_hvc_consoleio
+
 static int xen_consoleio_poll_in(const struct device *dev,
 			unsigned char *c)
 {
@@ -44,12 +46,12 @@ static const struct uart_driver_api xen_consoleio_hvc_api = {
 	.poll_out = xen_consoleio_poll_out,
 };
 
-int xen_consoleio_init(const struct device *dev)
+static int xen_consoleio_init(const struct device *dev)
 {
 	/* Nothing to do, but still needed for device API */
 	return 0;
 }
 
-DEVICE_DT_DEFINE(DT_NODELABEL(xen_consoleio_hvc), xen_consoleio_init, NULL, NULL,
+DEVICE_DT_INST_DEFINE(0, xen_consoleio_init, NULL, NULL,
 		NULL, PRE_KERNEL_1, CONFIG_XEN_HVC_INIT_PRIORITY,
 		&xen_consoleio_hvc_api);

--- a/dts/bindings/serial/xen,hvc-consoleio.yaml
+++ b/dts/bindings/serial/xen,hvc-consoleio.yaml
@@ -1,0 +1,5 @@
+description: Xen Dom0/Dom0less Platform HVC ConsoleIO
+
+compatible: "xen,hvc-consoleio"
+
+include: uart-controller.yaml

--- a/snippets/xen_dom0/xen_dom0.overlay
+++ b/snippets/xen_dom0/xen_dom0.overlay
@@ -19,7 +19,7 @@
 	};
 
 	xen_consoleio_hvc: hvc {
-		compatible = "xen,uart_hvc";
+		compatible = "xen,hvc-consoleio";
 		status = "okay";
 	};
 };


### PR DESCRIPTION
Add missed binding and appropriate changes for Xen Dom0/Dom0less UART driver.