### PR TITLE
ci: update Github actions versions

### DIFF
--- a/.github/workflows/assigner.yml
+++ b/.github/workflows/assigner.yml
@@ -27,7 +27,7 @@ jobs:
         pip3 install -U PyGithub>=1.55 west
 
     - name: Check out source code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Run assignment script
       env:

--- a/.github/workflows/backport_issue_check.yml
+++ b/.github/workflows/backport_issue_check.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Check out source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/bsim-tests.yaml
+++ b/.github/workflows/bsim-tests.yaml
@@ -62,7 +62,7 @@ jobs:
           git remote set-url origin ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -191,7 +191,7 @@ jobs:
 
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bsim-test-results
           path: |
@@ -207,7 +207,7 @@ jobs:
 
       - name: Upload Event Details
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: event
           path: |

--- a/.github/workflows/bug_snapshot.yaml
+++ b/.github/workflows/bug_snapshot.yaml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install Python dependencies
       run: |

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -41,7 +41,7 @@ jobs:
           git remote set-url origin ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
@@ -126,7 +126,7 @@ jobs:
 
       - name: Upload Unit Test Results
         if: always() && steps.twister.outputs.report_needed != 0
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Unit Test Results (Subset ${{ matrix.platform }})
           path: twister-out/twister.xml
@@ -138,7 +138,7 @@ jobs:
     if: (success() || failure() ) && needs.clang-build.outputs.report_needed != 0
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
       - name: Merge Test Results
@@ -149,7 +149,7 @@ jobs:
 
       - name: Upload Unit Test Results in HTML
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: HTML Unit Test Results
           if-no-files-found: ignore

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -41,7 +41,7 @@ jobs:
           git remote set-url origin ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}
 
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -104,7 +104,7 @@ jobs:
 
       - name: Upload Coverage Results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Coverage Data (Subset ${{ matrix.platform }})
           path: coverage/reports/${{ matrix.platform }}.json
@@ -118,11 +118,11 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Download Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: coverage/reports
 
@@ -166,7 +166,7 @@ jobs:
 
       - name: Upload Merged Coverage Results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Merged Coverage Data
           path: |

--- a/.github/workflows/coding_guidelines.yml
+++ b/.github/workflows/coding_guidelines.yml
@@ -8,13 +8,13 @@ jobs:
     name: Run coding guidelines checks on patch series (PR)
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
 
     - name: cache-pip
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('.github/workflows/coding_guidelines.yml') }}

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -12,13 +12,13 @@ jobs:
         echo "$HOME/.local/bin" >> $GITHUB_PATH
 
     - name: Checkout the code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
 
     - name: cache-pip
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('.github/workflows/compliance.yml') }}
@@ -61,7 +61,7 @@ jobs:
         -c origin/${BASE_REF}..
 
     - name: upload-results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       continue-on-error: true
       with:
         name: compliance.xml

--- a/.github/workflows/daily_test_version.yml
+++ b/.github/workflows/daily_test_version.yml
@@ -28,7 +28,7 @@ jobs:
         pip3 install gitpython
 
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 

--- a/.github/workflows/devicetree_checks.yml
+++ b/.github/workflows/devicetree_checks.yml
@@ -35,14 +35,14 @@ jobs:
           python-version: 3.6
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: cache-pip-linux
       if: startsWith(runner.os, 'Linux')
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.python-version }}
@@ -50,7 +50,7 @@ jobs:
           ${{ runner.os }}-pip-${{ matrix.python-version }}
     - name: cache-pip-mac
       if: startsWith(runner.os, 'macOS')
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/Library/Caches/pip
         # Trailing '-' was just to get a different cache name
@@ -59,7 +59,7 @@ jobs:
           ${{ runner.os }}-pip-${{ matrix.python-version }}-
     - name: cache-pip-win
       if: startsWith(runner.os, 'Windows')
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~\AppData\Local\pip\Cache
         key: ${{ runner.os }}-pip-${{ matrix.python-version }}

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
@@ -70,7 +70,7 @@ jobs:
         echo "${PWD}/doxygen-${DOXYGEN_VERSION}/bin" >> $GITHUB_PATH
 
     - name: cache-pip
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: pip-${{ hashFiles('doc/requirements.txt') }}
@@ -116,13 +116,13 @@ jobs:
         tar cfJ api-coverage.tar.xz coverage-report
 
     - name: upload-build
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: html-output
         path: html-output.tar.xz
 
     - name: upload-api-coverage
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: api-coverage
         path: api-coverage.tar.xz
@@ -142,7 +142,7 @@ jobs:
         echo "API Coverage Report will be available shortly at: ${API_COVERAGE_URL}" >> $GITHUB_STEP_SUMMARY
 
     - name: upload-pr-number
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: github.event_name == 'pull_request'
       with:
         name: pr_num
@@ -166,7 +166,7 @@ jobs:
         git config --global --add safe.directory ${GITHUB_WORKSPACE}
 
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: install-pkgs
       run: |
@@ -174,7 +174,7 @@ jobs:
         apt-get install -y python3-pip python3-venv ninja-build doxygen graphviz librsvg2-bin
 
     - name: cache-pip
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: pip-${{ hashFiles('doc/requirements.txt') }}
@@ -210,7 +210,7 @@ jobs:
 
     - name: upload-build
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: pdf-output
         if-no-files-found: ignore

--- a/.github/workflows/errno.yml
+++ b/.github/workflows/errno.yml
@@ -22,7 +22,7 @@ jobs:
           git config --global --add safe.directory ${GITHUB_WORKSPACE}
 
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Environment Setup
         run: |

--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -51,7 +51,7 @@ jobs:
           sudo pip3 install -U setuptools wheel pip gitpython
 
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0

--- a/.github/workflows/footprint.yml
+++ b/.github/workflows/footprint.yml
@@ -31,7 +31,7 @@ jobs:
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0

--- a/.github/workflows/greet_first_time_contributor.yml
+++ b/.github/workflows/greet_first_time_contributor.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.repository == 'zephyrproject-rtos/zephyr'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: zephyrproject-rtos/action-first-interaction@v1.1.1-zephyr-5
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issue_count.yml
+++ b/.github/workflows/issue_count.yml
@@ -35,7 +35,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: upload-stats
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       continue-on-error: true
       with:
         name: ${{ env.OUTPUT_FILE_NAME }}

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -8,7 +8,7 @@ jobs:
     name: Scan code for licenses
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Scan the code
@@ -17,7 +17,7 @@ jobs:
       with:
         directory-to-scan: 'scan/'
     - name: Artifact Upload
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: scancode
         path: ./artifacts

--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -8,7 +8,7 @@ jobs:
     name: Manifest
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: zephyrproject/zephyr
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/pylib_tests.yml
+++ b/.github/workflows/pylib_tests.yml
@@ -29,14 +29,14 @@ jobs:
         os: [ubuntu-22.04]
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: cache-pip-linux
       if: startsWith(runner.os, 'Linux')
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.python-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
   release:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -26,7 +26,7 @@ jobs:
           args: spdx -o zephyr-${{ steps.get_version.outputs.VERSION }}.spdx
 
       - name: upload-results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: zephyr-${{ steps.get_version.outputs.VERSION }}.spdx

--- a/.github/workflows/scripts_tests.yml
+++ b/.github/workflows/scripts_tests.yml
@@ -29,7 +29,7 @@ jobs:
         os: [ubuntu-20.04]
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
@@ -52,7 +52,7 @@ jobs:
 
       - name: cache-pip-linux
         if: startsWith(runner.os, 'Linux')
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}

--- a/.github/workflows/stats_merged_prs.yml
+++ b/.github/workflows/stats_merged_prs.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: PR event
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Checkout
         if: github.event_name == 'pull_request_target'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
@@ -156,7 +156,7 @@ jobs:
           git remote set-url origin ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
@@ -271,7 +271,7 @@ jobs:
 
       - name: Upload Unit Test Results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Unit Test Results (Subset ${{ matrix.subset }})
           if-no-files-found: ignore
@@ -293,7 +293,7 @@ jobs:
 
       - if: matrix.subset == 1 && github.event_name == 'push'
         name: Upload the list of Python packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Frozen PIP package set
           path: |
@@ -313,13 +313,13 @@ jobs:
       # Needed for opensearch and upload script
       - if: github.event_name == 'push' || github.event_name == 'schedule'
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
 
@@ -345,7 +345,7 @@ jobs:
 
       - name: Upload Unit Test Results in HTML
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: HTML Unit Test Results
           if-no-files-found: ignore

--- a/.github/workflows/twister_tests.yml
+++ b/.github/workflows/twister_tests.yml
@@ -33,14 +33,14 @@ jobs:
         os: [ubuntu-22.04]
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: cache-pip-linux
       if: startsWith(runner.os, 'Linux')
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.python-version }}

--- a/.github/workflows/twister_tests_blackbox.yml
+++ b/.github/workflows/twister_tests_blackbox.yml
@@ -34,7 +34,7 @@ jobs:
         git config --global --add safe.directory ${GITHUB_WORKSPACE}
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Environment Setup
       run: |

--- a/.github/workflows/west_cmds.yml
+++ b/.github/workflows/west_cmds.yml
@@ -36,14 +36,14 @@ jobs:
           python-version: 3.6
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: cache-pip-linux
       if: startsWith(runner.os, 'Linux')
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.python-version }}
@@ -51,7 +51,7 @@ jobs:
           ${{ runner.os }}-pip-${{ matrix.python-version }}
     - name: cache-pip-mac
       if: startsWith(runner.os, 'macOS')
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/Library/Caches/pip
         # Trailing '-' was just to get a different cache name
@@ -60,7 +60,7 @@ jobs:
           ${{ runner.os }}-pip-${{ matrix.python-version }}-
     - name: cache-pip-win
       if: startsWith(runner.os, 'Windows')
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~\AppData\Local\pip\Cache
         key: ${{ runner.os }}-pip-${{ matrix.python-version }}


### PR DESCRIPTION
Update Github actions to their latest versions to fix the following warnings on runs:
```
Node.js 16 actions are deprecated. Please update the following actions
to use Node.js 20: actions/checkout@v3, actions/cache@v3,
actions/upload-artifact@v3. For more information see:
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

`actions/checkout` and `actions/cache` are straight Node version upgrades, `actions/upload-artifact` and `actions/download-artifact` have breaking changes, but don't appear to affect our usage. https://github.com/actions/upload-artifact