### PR TITLE
Bluetooth: Controller: Fix missing ull_chan_reset call

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -63,6 +63,7 @@
 #include "isoal.h"
 #include "ll_feat_internal.h"
 #include "ull_internal.h"
+#include "ull_chan_internal.h"
 #include "ull_iso_internal.h"
 #include "ull_adv_internal.h"
 #include "ull_scan_internal.h"
@@ -2284,6 +2285,18 @@ static inline int init_reset(void)
 	/* Allocate rx free buffers */
 	mem_link_rx.quota_pdu = RX_CNT;
 	rx_replenish_all();
+
+#if (defined(CONFIG_BT_BROADCASTER) && defined(CONFIG_BT_CTLR_ADV_EXT)) || \
+	defined(CONFIG_BT_CTLR_ADV_PERIODIC) || \
+	defined(CONFIG_BT_CTLR_SYNC_PERIODIC) || \
+	defined(CONFIG_BT_CONN)
+	/* Initialize channel map */
+	ull_chan_reset();
+#endif /* (CONFIG_BT_BROADCASTER && CONFIG_BT_CTLR_ADV_EXT) ||
+	* CONFIG_BT_CTLR_ADV_PERIODIC ||
+	* CONFIG_BT_CTLR_SYNC_PERIODIC ||
+	* CONFIG_BT_CONN
+	*/
 
 	return 0;
 }

--- a/subsys/bluetooth/controller/ll_sw/ull_chan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_chan.c
@@ -34,13 +34,12 @@
 #include "ull_adv_internal.h"
 #include "ull_central_internal.h"
 
-/* Initial channel map indicating Used and Unused data channels.
- * The HCI LE Set Host Channel Classification command allows the Host to
+/* The HCI LE Set Host Channel Classification command allows the Host to
  * specify a channel classification for the data, secondary advertising,
  * periodic, and isochronous physical channels based on its local information.
  */
-static uint8_t map[5] = {0xFF, 0xFF, 0xFF, 0xFF, 0x1F};
-static uint8_t count = 37U;
+static uint8_t map[5];
+static uint8_t count;
 
 static void chan_map_set(uint8_t const *const chan_map);
 
@@ -70,17 +69,15 @@ uint8_t ll_chm_update(uint8_t const *const chm)
 	return 0;
 }
 
-int ull_chan_reset(void)
+void ull_chan_reset(void)
 {
-	/* initialise connection channel map */
+	/* Initial channel map indicating Used and Unused data channels. */
 	map[0] = 0xFF;
 	map[1] = 0xFF;
 	map[2] = 0xFF;
 	map[3] = 0xFF;
 	map[4] = 0x1F;
 	count = 37U;
-
-	return 0;
 }
 
 uint8_t ull_chan_map_get(uint8_t *const chan_map)

--- a/subsys/bluetooth/controller/ll_sw/ull_chan_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_chan_internal.h
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-int ull_chan_reset(void);
+void ull_chan_reset(void);
 uint8_t ull_chan_map_get(uint8_t *const chan_map);
 void ull_chan_map_set(uint8_t const *const chan_map);


### PR DESCRIPTION
Fix missing call to ull_chan_reset(), this fixes
uninitialized channel map being used after LL reset.