### PR TITLE
wifi: shell: refactor wifi_shell.c

### DIFF
--- a/subsys/net/l2/wifi/CMakeLists.txt
+++ b/subsys/net/l2/wifi/CMakeLists.txt
@@ -2,6 +2,9 @@
 
 zephyr_library()
 zephyr_library_include_directories(${ZEPHYR_BASE}/subsys/net/ip)
+zephyr_library_include_directories_ifdef(
+  CONFIG_NET_L2_WIFI_SHELL ${ZEPHYR_BASE}/subsys/net/lib/shell
+  )
 zephyr_library_compile_definitions_ifdef(
   CONFIG_NEWLIB_LIBC __LINUX_ERRNO_EXTENSIONS__
   )

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -52,6 +52,7 @@ LOG_MODULE_REGISTER(net_wifi_shell, LOG_LEVEL_INF);
 
 static struct {
 	const struct shell *sh;
+	uint32_t scan_result;
 
 	union {
 		struct {
@@ -63,8 +64,6 @@ static struct {
 		uint8_t all;
 	};
 } context;
-
-static uint32_t scan_result;
 
 static struct net_mgmt_event_callback wifi_shell_mgmt_cb;
 static struct wifi_reg_chan_info chan_info[MAX_REG_CHAN_NUM];
@@ -117,9 +116,9 @@ static void handle_wifi_scan_result(struct net_mgmt_event_callback *cb)
 		(const struct wifi_scan_result *)cb->info;
 	uint8_t mac_string_buf[sizeof("xx:xx:xx:xx:xx:xx")];
 
-	scan_result++;
+	context.scan_result++;
 
-	if (scan_result == 1U) {
+	if (context.scan_result == 1U) {
 		print(context.sh, SHELL_NORMAL,
 		      "\n%-4s | %-32s %-5s | %-13s | %-4s | %-15s | %-17s | %-8s\n",
 		      "Num", "SSID", "(len)", "Chan (Band)", "RSSI", "Security", "BSSID", "MFP");
@@ -127,7 +126,7 @@ static void handle_wifi_scan_result(struct net_mgmt_event_callback *cb)
 
 	print(context.sh, SHELL_NORMAL,
 	      "%-4d | %-32s %-5u | %-4u (%-6s) | %-4d | %-15s | %-17s | %-8s\n",
-	      scan_result, entry->ssid, entry->ssid_length, entry->channel,
+	      context.scan_result, entry->ssid, entry->ssid_length, entry->channel,
 	      wifi_band_txt(entry->band),
 	      entry->rssi,
 	      wifi_security_txt(entry->security),
@@ -186,9 +185,9 @@ static void handle_wifi_raw_scan_result(struct net_mgmt_event_callback *cb)
 	uint8_t mac_string_buf[sizeof("xx:xx:xx:xx:xx:xx")];
 	const struct shell *sh = context.sh;
 
-	scan_result++;
+	context.scan_result++;
 
-	if (scan_result == 1U) {
+	if (context.scan_result == 1U) {
 		print(sh, SHELL_NORMAL,
 		      "\n%-4s | %-13s | %-4s |  %-15s | %-15s | %-32s\n",
 		      "Num", "Channel (Band)", "RSSI", "BSSID", "Frame length", "Frame Body");
@@ -199,7 +198,7 @@ static void handle_wifi_raw_scan_result(struct net_mgmt_event_callback *cb)
 	band = wifi_freq_to_band(raw->frequency);
 
 	print(sh, SHELL_NORMAL, "%-4d | %-4u (%-6s) | %-4d | %s |      %-4d        ",
-	      scan_result,
+	      context.scan_result,
 	      channel,
 	      wifi_band_txt(band),
 	      rssi,
@@ -227,7 +226,7 @@ static void handle_wifi_scan_done(struct net_mgmt_event_callback *cb)
 		print(sh, SHELL_NORMAL, "Scan request done\n");
 	}
 
-	scan_result = 0U;
+	context.scan_result = 0U;
 }
 
 static void handle_wifi_connect_result(struct net_mgmt_event_callback *cb)
@@ -2052,7 +2051,7 @@ static int wifi_shell_init(void)
 
 	context.sh = NULL;
 	context.all = 0U;
-	scan_result = 0U;
+	context.scan_result = 0U;
 
 	net_mgmt_init_event_callback(&wifi_shell_mgmt_cb,
 				     wifi_mgmt_event_handler,

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -184,11 +184,12 @@ static void handle_wifi_raw_scan_result(struct net_mgmt_event_callback *cb)
 	int rssi;
 	int i = 0;
 	uint8_t mac_string_buf[sizeof("xx:xx:xx:xx:xx:xx")];
+	const struct shell *sh = context.sh;
 
 	scan_result++;
 
 	if (scan_result == 1U) {
-		print(context.sh, SHELL_NORMAL,
+		print(sh, SHELL_NORMAL,
 		      "\n%-4s | %-13s | %-4s |  %-15s | %-15s | %-32s\n",
 		      "Num", "Channel (Band)", "RSSI", "BSSID", "Frame length", "Frame Body");
 	}
@@ -197,7 +198,7 @@ static void handle_wifi_raw_scan_result(struct net_mgmt_event_callback *cb)
 	channel = wifi_freq_to_channel(raw->frequency);
 	band = wifi_freq_to_band(raw->frequency);
 
-	print(context.sh, SHELL_NORMAL, "%-4d | %-4u (%-6s) | %-4d | %s |      %-4d        ",
+	print(sh, SHELL_NORMAL, "%-4d | %-4u (%-6s) | %-4d | %s |      %-4d        ",
 	      scan_result,
 	      channel,
 	      wifi_band_txt(band),
@@ -206,10 +207,10 @@ static void handle_wifi_raw_scan_result(struct net_mgmt_event_callback *cb)
 				     sizeof(mac_string_buf)), raw->frame_length);
 
 	for (i = 0; i < 32; i++) {
-		print(context.sh, SHELL_NORMAL, "%02X ", *(raw->data + i));
+		print(sh, SHELL_NORMAL, "%02X ", *(raw->data + i));
 	}
 
-	print(context.sh, SHELL_NORMAL, "\n");
+	print(sh, SHELL_NORMAL, "\n");
 }
 #endif /* CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS */
 
@@ -217,12 +218,13 @@ static void handle_wifi_scan_done(struct net_mgmt_event_callback *cb)
 {
 	const struct wifi_status *status =
 		(const struct wifi_status *)cb->info;
+	const struct shell *sh = context.sh;
 
 	if (status->status) {
-		print(context.sh, SHELL_WARNING,
+		print(sh, SHELL_WARNING,
 		      "Scan request failed (%d)\n", status->status);
 	} else {
-		print(context.sh, SHELL_NORMAL, "Scan request done\n");
+		print(sh, SHELL_NORMAL, "Scan request done\n");
 	}
 
 	scan_result = 0U;
@@ -266,47 +268,50 @@ static void print_twt_params(uint8_t dialog_token, uint8_t flow_id,
 			     bool trigger, uint32_t twt_wake_interval,
 			     uint64_t twt_interval)
 {
-	print(context.sh, SHELL_NORMAL, "TWT Dialog token: %d\n",
+	const struct shell *sh = context.sh;
+
+	print(sh, SHELL_NORMAL, "TWT Dialog token: %d\n",
 	      dialog_token);
-	print(context.sh, SHELL_NORMAL, "TWT flow ID: %d\n",
+	print(sh, SHELL_NORMAL, "TWT flow ID: %d\n",
 	      flow_id);
-	print(context.sh, SHELL_NORMAL, "TWT negotiation type: %s\n",
+	print(sh, SHELL_NORMAL, "TWT negotiation type: %s\n",
 	      wifi_twt_negotiation_type_txt(negotiation_type));
-	print(context.sh, SHELL_NORMAL, "TWT responder: %s\n",
+	print(sh, SHELL_NORMAL, "TWT responder: %s\n",
 	       responder ? "true" : "false");
-	print(context.sh, SHELL_NORMAL, "TWT implicit: %s\n",
+	print(sh, SHELL_NORMAL, "TWT implicit: %s\n",
 	      implicit ? "true" : "false");
-	print(context.sh, SHELL_NORMAL, "TWT announce: %s\n",
+	print(sh, SHELL_NORMAL, "TWT announce: %s\n",
 	      announce ? "true" : "false");
-	print(context.sh, SHELL_NORMAL, "TWT trigger: %s\n",
+	print(sh, SHELL_NORMAL, "TWT trigger: %s\n",
 	      trigger ? "true" : "false");
-	print(context.sh, SHELL_NORMAL, "TWT wake interval: %d us\n",
+	print(sh, SHELL_NORMAL, "TWT wake interval: %d us\n",
 	      twt_wake_interval);
-	print(context.sh, SHELL_NORMAL, "TWT interval: %lld us\n",
+	print(sh, SHELL_NORMAL, "TWT interval: %lld us\n",
 	      twt_interval);
-	print(context.sh, SHELL_NORMAL, "========================\n");
+	print(sh, SHELL_NORMAL, "========================\n");
 }
 
 static void handle_wifi_twt_event(struct net_mgmt_event_callback *cb)
 {
 	const struct wifi_twt_params *resp =
 		(const struct wifi_twt_params *)cb->info;
+	const struct shell *sh = context.sh;
 
 	if (resp->operation == WIFI_TWT_TEARDOWN) {
 		if (resp->teardown_status == WIFI_TWT_TEARDOWN_SUCCESS) {
-			print(context.sh, SHELL_NORMAL, "TWT teardown succeeded for flow ID %d\n",
+			print(sh, SHELL_NORMAL, "TWT teardown succeeded for flow ID %d\n",
 			      resp->flow_id);
 		} else {
-			print(context.sh, SHELL_NORMAL, "TWT teardown failed for flow ID %d\n",
+			print(sh, SHELL_NORMAL, "TWT teardown failed for flow ID %d\n",
 			      resp->flow_id);
 		}
 		return;
 	}
 
 	if (resp->resp_status == WIFI_TWT_RESP_RECEIVED) {
-		print(context.sh, SHELL_NORMAL, "TWT response: %s\n",
+		print(sh, SHELL_NORMAL, "TWT response: %s\n",
 		      wifi_twt_setup_cmd_txt(resp->setup_cmd));
-		print(context.sh, SHELL_NORMAL, "== TWT negotiated parameters ==\n");
+		print(sh, SHELL_NORMAL, "== TWT negotiated parameters ==\n");
 		print_twt_params(resp->dialog_token,
 				 resp->flow_id,
 				 resp->negotiation_type,
@@ -317,7 +322,7 @@ static void handle_wifi_twt_event(struct net_mgmt_event_callback *cb)
 				 resp->setup.twt_wake_interval,
 				 resp->setup.twt_interval);
 	} else {
-		print(context.sh, SHELL_NORMAL, "TWT response timed out\n");
+		print(sh, SHELL_NORMAL, "TWT response timed out\n");
 	}
 }
 
@@ -325,12 +330,13 @@ static void handle_wifi_ap_enable_result(struct net_mgmt_event_callback *cb)
 {
 	const struct wifi_status *status =
 		(const struct wifi_status *)cb->info;
+	const struct shell *sh = context.sh;
 
 	if (status->status) {
-		print(context.sh, SHELL_WARNING,
+		print(sh, SHELL_WARNING,
 		      "AP enable request failed (%d)\n", status->status);
 	} else {
-		print(context.sh, SHELL_NORMAL, "AP enabled\n");
+		print(sh, SHELL_NORMAL, "AP enabled\n");
 	}
 }
 
@@ -338,12 +344,13 @@ static void handle_wifi_ap_disable_result(struct net_mgmt_event_callback *cb)
 {
 	const struct wifi_status *status =
 		(const struct wifi_status *)cb->info;
+	const struct shell *sh = context.sh;
 
 	if (status->status) {
-		print(context.sh, SHELL_WARNING,
+		print(sh, SHELL_WARNING,
 		      "AP disable request failed (%d)\n", status->status);
 	} else {
-		print(context.sh, SHELL_NORMAL, "AP disabled\n");
+		print(sh, SHELL_NORMAL, "AP disabled\n");
 	}
 
 	k_mutex_lock(&wifi_ap_sta_list_lock, K_FOREVER);
@@ -355,10 +362,11 @@ static void handle_wifi_ap_sta_connected(struct net_mgmt_event_callback *cb)
 {
 	const struct wifi_ap_sta_info *sta_info =
 		(const struct wifi_ap_sta_info *)cb->info;
+	const struct shell *sh = context.sh;
 	uint8_t mac_string_buf[sizeof("xx:xx:xx:xx:xx:xx")];
 	int i;
 
-	print(context.sh, SHELL_NORMAL, "Station connected: %s\n",
+	print(sh, SHELL_NORMAL, "Station connected: %s\n",
 	      net_sprint_ll_addr_buf(sta_info->mac, WIFI_MAC_ADDR_LEN,
 				     mac_string_buf, sizeof(mac_string_buf)));
 
@@ -371,7 +379,7 @@ static void handle_wifi_ap_sta_connected(struct net_mgmt_event_callback *cb)
 		}
 	}
 	if (i == CONFIG_WIFI_SHELL_MAX_AP_STA) {
-		print(context.sh, SHELL_WARNING, "No space to store station info: "
+		print(sh, SHELL_WARNING, "No space to store station info: "
 			"Increase CONFIG_WIFI_SHELL_MAX_AP_STA\n");
 	}
 	k_mutex_unlock(&wifi_ap_sta_list_lock);
@@ -381,9 +389,10 @@ static void handle_wifi_ap_sta_disconnected(struct net_mgmt_event_callback *cb)
 {
 	const struct wifi_ap_sta_info *sta_info =
 		(const struct wifi_ap_sta_info *)cb->info;
+	const struct shell *sh = context.sh;
 	uint8_t mac_string_buf[sizeof("xx:xx:xx:xx:xx:xx")];
 
-	print(context.sh, SHELL_NORMAL, "Station disconnected: %s\n",
+	print(sh, SHELL_NORMAL, "Station disconnected: %s\n",
 	      net_sprint_ll_addr_buf(sta_info->mac, WIFI_MAC_ADDR_LEN,
 				     mac_string_buf, sizeof(mac_string_buf)));
 
@@ -449,6 +458,7 @@ static int __wifi_args_to_params(size_t argc, char *argv[],
 {
 	char *endptr;
 	int idx = 1;
+	const struct shell *sh = context.sh;
 
 	/* Defaults */
 	params->band = WIFI_FREQ_BAND_UNKNOWN;
@@ -459,7 +469,7 @@ static int __wifi_args_to_params(size_t argc, char *argv[],
 	params->ssid = argv[0];
 	params->ssid_length = strlen(params->ssid);
 	if (params->ssid_length > WIFI_SSID_MAX_LEN) {
-		print(context.sh, SHELL_WARNING,
+		print(sh, SHELL_WARNING,
 		      "SSID too long (max %d characters)\n",
 		      WIFI_SSID_MAX_LEN);
 		return -EINVAL;
@@ -477,7 +487,7 @@ static int __wifi_args_to_params(size_t argc, char *argv[],
 		size_t offset = 0;
 
 		if (*endptr != '\0') {
-			print(context.sh, SHELL_ERROR,
+			print(sh, SHELL_ERROR,
 			      "Failed to parse channel: %s: endp: %s, err: %s\n",
 			      argv[idx],
 			      endptr,
@@ -520,7 +530,7 @@ static int __wifi_args_to_params(size_t argc, char *argv[],
 						  band ? "," : "",
 						  wifi_band_txt(all_bands[band]));
 				if (offset >= sizeof(bands_str)) {
-					print(context.sh, SHELL_ERROR,
+					print(sh, SHELL_ERROR,
 					      "Failed to parse channel: %s: "
 					      "band string too long\n",
 					      argv[idx]);
@@ -535,7 +545,7 @@ static int __wifi_args_to_params(size_t argc, char *argv[],
 			}
 
 			if (!found) {
-				print(context.sh, SHELL_ERROR,
+				print(sh, SHELL_ERROR,
 				      "Invalid channel: %ld, checked bands: %s\n",
 				       channel,
 				       bands_str);
@@ -571,7 +581,7 @@ static int __wifi_args_to_params(size_t argc, char *argv[],
 
 				if (security == WIFI_SECURITY_TYPE_NONE ||
 				    security == WIFI_SECURITY_TYPE_WPA_PSK) {
-					print(context.sh, SHELL_ERROR,
+					print(sh, SHELL_ERROR,
 					      "MFP not supported for security type %s\n",
 					      wifi_security_txt(security));
 					return -EINVAL;
@@ -589,7 +599,7 @@ static int __wifi_args_to_params(size_t argc, char *argv[],
 		     params->psk_length > WIFI_PSK_MAX_LEN) ||
 		    (params->security == WIFI_SECURITY_TYPE_SAE &&
 		     params->psk_length > WIFI_SAE_PSWD_MAX_LEN)) {
-			print(context.sh, SHELL_ERROR,
+			print(sh, SHELL_ERROR,
 			      "Invalid PSK length (%d) for security type %s\n",
 			      params->psk_length,
 			      wifi_security_txt(params->security));
@@ -969,7 +979,7 @@ static int cmd_wifi_ps(const struct shell *sh, size_t argc, char *argv[])
 					config.twt_flows[i].trigger,
 					config.twt_flows[i].twt_wake_interval,
 					config.twt_flows[i].twt_interval);
-				shell_fprintf(context.sh, SHELL_NORMAL,
+				shell_fprintf(sh, SHELL_NORMAL,
 					      "TWT Wake ahead duration : %d us\n",
 					      config.twt_flows[i].twt_wake_ahead_duration);
 			}


### PR DESCRIPTION
- introduces a local variable `sh` to store `context.sh` for use with the `shell_fprintf` function. By doing so, we avoid the repeated dereferencing of `context.sh`, thereby reducing the code footprint.

- Moved `scan_result` from a standalone variable into the `context` struct to enhance code optimization.

- Replaced direct `shell_fprintf` calls with `PR`, `PR_ERROR`, `PR_INFO` and `PR_WARNING` macros.


