### PR TITLE
west.yml: update hal_atmel to include qdec SAME70b fix

### DIFF
--- a/boards/arm/sam_e70_xplained/sam_e70_xplained-pinctrl.dtsi
+++ b/boards/arm/sam_e70_xplained/sam_e70_xplained-pinctrl.dtsi
@@ -83,6 +83,27 @@
 		};
 	};
 
+	tc1_qdec_default: tc1_qdec_default {
+		group1 {
+			pinmux = <PC23B_TC1_TIOA3>,
+				 <PC24B_TC1_TIOB3>;
+		};
+	};
+
+	tc2_qdec_default: tc2_qdec_default {
+		group1 {
+			pinmux = <PC5B_TC2_TIOA6>,
+				 <PC6B_TC2_TIOB6>;
+		};
+	};
+
+	tc3_qdec_default: tc3_qdec_default {
+		group1 {
+			pinmux = <PE0B_TC3_TIOA9>,
+				 <PE1B_TC3_TIOB9>;
+		};
+	};
+
 	twihs0_default: twihs0_default {
 		group1 {
 			pinmux = <PA4A_TWI0_TWCK>,

--- a/boards/arm/sam_e70_xplained/sam_e70_xplained.dts
+++ b/boards/arm/sam_e70_xplained/sam_e70_xplained.dts
@@ -23,3 +23,27 @@
 	pinctrl-0 = <&tc0_qdec_default>;
 	pinctrl-names = "default";
 };
+
+&tc1 {
+	status = "disabled";
+	compatible = "atmel,sam-tc-qdec";
+
+	pinctrl-0 = <&tc1_qdec_default>;
+	pinctrl-names = "default";
+};
+
+&tc2 {
+	status = "disabled";
+	compatible = "atmel,sam-tc-qdec";
+
+	pinctrl-0 = <&tc2_qdec_default>;
+	pinctrl-names = "default";
+};
+
+&tc3 {
+	status = "disabled";
+	compatible = "atmel,sam-tc-qdec";
+
+	pinctrl-0 = <&tc3_qdec_default>;
+	pinctrl-names = "default";
+};

--- a/west.yml
+++ b/west.yml
@@ -147,7 +147,7 @@ manifest:
       groups:
         - hal
     - name: hal_atmel
-      revision: b0cc87f2a494d8b3c383292d1d6c7d10323932bd
+      revision: aad79bf530b69b72712d18873df4120ad052d921
       path: modules/hal/atmel
       groups:
         - hal


### PR DESCRIPTION
This update fixes the qdec in SAME70b, which could not be compiled prior to this fix, due to missing TC_CMR definitions. Moreover it fixes #65432.