### PR TITLE
soc: arm: xilinx_zynqmp: Add "Execute Never" MPU flag to non-code RAM

### DIFF
--- a/soc/arm/xilinx_zynqmp/arm_mpu_regions.c
+++ b/soc/arm/xilinx_zynqmp/arm_mpu_regions.c
@@ -22,11 +22,12 @@
 				| MPU_RASR_B_Msk) \
 	}
 
-#define MPUTYPE_PRIV_WBWACACHE \
+#define MPUTYPE_PRIV_WBWACACHE_XN \
 	{ \
 		.rasr = (P_RW_U_NA_Msk \
 				| (5 << MPU_RASR_TEX_Pos) \
-				| MPU_RASR_B_Msk) \
+				| MPU_RASR_B_Msk \
+				| MPU_RASR_XN_Msk) \
 	}
 
 #define MPUTYPE_PRIV_DEVICE \
@@ -45,7 +46,7 @@ static const struct arm_mpu_region mpu_regions[] = {
 	MPU_REGION_ENTRY("SRAM_PRIV",
 			0x00000000,
 			REGION_2G,
-			MPUTYPE_PRIV_WBWACACHE),
+			MPUTYPE_PRIV_WBWACACHE_XN),
 
 	MPU_REGION_ENTRY("SRAM",
 			0x00000000,

--- a/tests/kernel/mem_protect/protection/src/main.c
+++ b/tests/kernel/mem_protect/protection/src/main.c
@@ -34,8 +34,7 @@ void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
 	ztest_test_pass();
 }
 
-#ifdef CONFIG_CPU_CORTEX_M
-#include <cmsis_core.h>
+#ifdef CONFIG_COMPILER_ISA_THUMB2
 /* Must clear LSB of function address to access as data. */
 #define FUNC_TO_PTR(x) (void *)((uintptr_t)(x) & ~0x1)
 /* Must set LSB of function address to call in Thumb mode. */


### PR DESCRIPTION
Fix kernel memory protection tests that were generating a false negative on Cortex-R due to incorrect handling of thumb instructions.

Add MPU XN (Execute Never) flag to non-code RAM for qemu_cortex_r5.

---

Previously the `test_exec_heap`/`test_exec_stack` tests were passing with:
```
E: ***** UNDEFINED INSTRUCTION ABORT *****
```
After fixing handling thumb instructions those tests fail:
```
Execute from data did not fault
Execute from heap did not fault
```
After adding the MPU XN flag the tests pass with:
```
E: ***** PREFETCH ABORT *****
```