### PR TITLE
doc: Update Zephyr SDK install instructions to use code-blocks

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -137,8 +137,11 @@ set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${GEN_DEVICETREE_
 #-------------------------------------------------------------------------------
 # html
 
+set(CODE_BLOCKS_SUB_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/_scripts/code_block_subs.py)
+
 add_doc_target(
   html
+  COMMAND ${PYTHON_EXECUTABLE} ${CODE_BLOCKS_SUB_SCRIPT}
   COMMAND ${CMAKE_COMMAND} -E env ${SPHINX_ENV}
   ${SPHINXBUILD}
     -b html
@@ -150,6 +153,7 @@ add_doc_target(
     ${SPHINXOPTS_EXTRA}
     ${DOCS_SRC_DIR}
     ${DOCS_HTML_DIR}
+  COMMAND ${PYTHON_EXECUTABLE} ${CODE_BLOCKS_SUB_SCRIPT} --post
   USES_TERMINAL
   COMMENT "Running Sphinx HTML build..."
 )

--- a/doc/_scripts/code_block_subs.py
+++ b/doc/_scripts/code_block_subs.py
@@ -1,0 +1,61 @@
+"""
+Copyright (c) 2024 Zephyr Project members and individual contributors
+SPDX-License-Identifier: Apache-2.0
+
+This document contains functions to substitute variables in code-block
+directives using python.
+
+Currently it substitutes SDK version related literals in the Developing 
+with Zephyr section.
+"""
+import sys
+import os
+from pathlib import Path
+import argparse
+
+ZEPHYR_BASE = Path(__file__).resolve().parents[2]
+ZEPHYR_DOC_BASE = ZEPHYR_BASE / "doc" / "develop"
+
+# parse SDK version from 'SDK_VERSION' file
+with open(ZEPHYR_BASE / "SDK_VERSION") as f:
+    sdk_version = f.read().strip()
+
+sdk_url_base = "https://github.com/zephyrproject-rtos/sdk-ng/releases/"
+sdk_url_prefix = f"{sdk_url_base}/download/v{sdk_version}/zephyr-sdk-{sdk_version}"
+sdk_url_shasum = f"{sdk_url_base}/download/v{sdk_version}/sha256.sum"
+
+subs_list = [("|sdk-url-linux|", f"`{sdk_url_prefix}_linux-x86_64.tar.xz`"),
+             ("|sdk-url-macos|", f"`{sdk_url_prefix}_macos-x86_64.tar.xz`"),
+             ("|sdk-url-windows|", f"`{sdk_url_prefix}_windows-x86_64.7z`"),
+             ("|sdk-url-shasum|", f"`{sdk_url_shasum}`"),
+             ("|sdk-version-literal|", f"``{sdk_version}``"),
+             ("|sdk-version|", f"{sdk_version}"),
+]
+
+def find_and_replace_all(root, post):
+    orig = 0 if post else 1
+    for dname, _, files in os.walk(root, topdown=True, followlinks=False):
+        for file in files:
+            if file.endswith('.rst'):
+                fpath = os.path.join(dname, file)
+                with open(fpath, 'r+') as f:
+                    contents = f.read()
+                    for sub in subs_list:
+                        if sub[1-orig] in contents:
+                            contents = contents.replace(sub[1-orig], sub[orig])
+                            f.seek(0)
+                            f.write(contents)
+                            f.truncate()
+                    
+
+def main():
+    # Parse sys.argv to determine if pre or post
+    parser = argparse.ArgumentParser(allow_abbrev=False)
+    parser.add_argument('--post', required=False, action='store_true')
+    post_substitute = parser.parse_args().post
+    find_and_replace_all(ZEPHYR_DOC_BASE, post_substitute)
+
+
+if __name__ == '__main__':
+    main()
+    sys.exit(0)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -135,22 +135,9 @@ nitpick_ignore = [
     ("c:identifier", "va_list"),
 ]
 
-SDK_URL_BASE="https://github.com/zephyrproject-rtos/sdk-ng/releases/download"
-
 rst_epilog = f"""
 .. include:: /substitutions.txt
-
-.. |sdk-version-literal| replace:: ``{sdk_version}``
-.. |sdk-version-trim| unicode:: {sdk_version}
-   :trim:
-.. |sdk-version-ltrim| unicode:: {sdk_version}
-   :ltrim:
 .. _Zephyr SDK bundle: https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v{sdk_version}
-.. |sdk-url-linux| replace:: `{SDK_URL_BASE}/v{sdk_version}/zephyr-sdk-{sdk_version}_linux-x86_64.tar.xz`
-.. |sdk-url-linux-sha| replace:: `{SDK_URL_BASE}/v{sdk_version}/sha256.sum`
-.. |sdk-url-macos| replace:: `{SDK_URL_BASE}/v{sdk_version}/zephyr-sdk-{sdk_version}_macos-x86_64.tar.xz`
-.. |sdk-url-macos-sha| replace:: `{SDK_URL_BASE}/v{sdk_version}/sha256.sum`
-.. |sdk-url-windows| replace:: `{SDK_URL_BASE}/v{sdk_version}/zephyr-sdk-{sdk_version}_windows-x86_64.7z`
 """
 
 # -- Options for HTML output ----------------------------------------------

--- a/doc/develop/getting_started/installation_linux.rst
+++ b/doc/develop/getting_started/installation_linux.rst
@@ -226,35 +226,12 @@ The Zephyr SDK supports the following target architectures:
 
 Follow these steps to install the Zephyr SDK:
 
-#. Download and verify the `Zephyr SDK bundle`_:
+.. include:: ../toolchains/zephyr_sdk.rst
+   :start-after: _ubuntu_zephyr_sdk_start
+   :end-before: _ubuntu_zephyr_sdk_end
 
-   .. parsed-literal::
-
-      wget |sdk-url-linux|
-      wget -O - |sdk-url-linux-sha| | shasum --check --ignore-missing
-
-   You can change |sdk-version-literal| to another version if needed; the
-   `Zephyr SDK Releases`_ page contains all available SDK releases.
-
-   If your host architecture is 64-bit ARM (for example, Raspberry Pi), replace
-   ``x86_64`` with ``aarch64`` in order to download the 64-bit ARM Linux SDK.
-
-#. Extract the Zephyr SDK bundle archive:
-
-   .. parsed-literal::
-
-      cd <sdk download directory>
-      tar xvf zephyr-sdk- |sdk-version-trim| _linux-x86_64.tar.xz
-
-#. Run the Zephyr SDK bundle setup script:
-
-   .. parsed-literal::
-
-      cd zephyr-sdk- |sdk-version-ltrim|
-      ./setup.sh
-
-   If this fails, make sure Zephyr's dependencies were installed as described
-   in `Install Requirements and Dependencies`_.
+If this fails, make sure Zephyr's dependencies were installed as described
+in `Install Requirements and Dependencies`_.
 
 If you want to uninstall the SDK, remove the directory where you installed it.
 If you relocate the SDK directory, you need to re-run the setup script.

--- a/doc/develop/toolchains/zephyr_sdk.rst
+++ b/doc/develop/toolchains/zephyr_sdk.rst
@@ -85,24 +85,24 @@ Zephyr SDK installation
 
    .. group-tab:: Ubuntu
 
-      .. _ubuntu_zephyr_sdk:
+      .. _ubuntu_zephyr_sdk_start
 
       #. Download and verify the `Zephyr SDK bundle`_:
 
-         .. parsed-literal::
+         .. code-block:: bash
 
             cd ~
             wget |sdk-url-linux|
-            wget -O - |sdk-url-linux-sha| | shasum --check --ignore-missing
+            wget -O - |sdk-url-shasum| | shasum --check --ignore-missing
 
          If your host architecture is 64-bit ARM (for example, Raspberry Pi), replace ``x86_64``
          with ``aarch64`` in order to download the 64-bit ARM Linux SDK.
 
       #. Extract the Zephyr SDK bundle archive:
 
-         .. parsed-literal::
+         .. code-block:: bash
 
-            tar xvf zephyr-sdk- |sdk-version-trim| _linux-x86_64.tar.xz
+            tar xvf zephyr-sdk-|sdk-version|_linux-x86_64.tar.xz
 
          .. note::
             It is recommended to extract the Zephyr SDK bundle at one of the following locations:
@@ -120,9 +120,9 @@ Zephyr SDK installation
 
       #. Run the Zephyr SDK bundle setup script:
 
-         .. parsed-literal::
+         .. code-block:: bash
 
-            cd zephyr-sdk- |sdk-version-ltrim|
+            cd zephyr-sdk-|sdk-version|
             ./setup.sh
 
          .. note::
@@ -134,10 +134,12 @@ Zephyr SDK installation
       #. Install `udev <https://en.wikipedia.org/wiki/Udev>`_ rules, which
          allow you to flash most Zephyr boards as a regular user:
 
-         .. parsed-literal::
+         .. code-block:: bash
 
-            sudo cp ~/zephyr-sdk- |sdk-version-trim| /sysroots/x86_64-pokysdk-linux/usr/share/openocd/contrib/60-openocd.rules /etc/udev/rules.d
+            sudo cp ~/zephyr-sdk-|sdk-version|/sysroots/x86_64-pokysdk-linux/usr/share/openocd/contrib/60-openocd.rules /etc/udev/rules.d
             sudo udevadm control --reload
+
+      .. _ubuntu_zephyr_sdk_end
 
    .. group-tab:: macOS
 
@@ -145,20 +147,20 @@ Zephyr SDK installation
 
       #. Download and verify the `Zephyr SDK bundle`_:
 
-         .. parsed-literal::
+         .. code-block:: bash
 
             cd ~
             curl -L -O |sdk-url-macos|
-            curl -L |sdk-url-macos-sha| | shasum --check --ignore-missing
+            curl -L |sdk-url-shasum| | shasum --check --ignore-missing
 
          If your host architecture is 64-bit ARM (Apple Silicon, also known as M1), replace
          ``x86_64`` with ``aarch64`` in order to download the 64-bit ARM macOS SDK.
 
       #. Extract the Zephyr SDK bundle archive:
 
-         .. parsed-literal::
+         .. code-block:: bash
 
-            tar xvf zephyr-sdk- |sdk-version-trim| _macos-x86_64.tar.xz
+            tar xvf zephyr-sdk-|sdk-version|_macos-x86_64.tar.xz
 
          .. note::
             It is recommended to extract the Zephyr SDK bundle at one of the following locations:
@@ -176,9 +178,9 @@ Zephyr SDK installation
 
       #. Run the Zephyr SDK bundle setup script:
 
-         .. parsed-literal::
+         .. code-block:: bash
 
-            cd zephyr-sdk- |sdk-version-ltrim|
+            cd zephyr-sdk-|sdk-version|
             ./setup.sh
 
          .. note::
@@ -195,16 +197,16 @@ Zephyr SDK installation
 
       #. Download the `Zephyr SDK bundle`_:
 
-         .. parsed-literal::
+         .. code-block:: bat
 
             cd %HOMEPATH%
             wget |sdk-url-windows|
 
       #. Extract the Zephyr SDK bundle archive:
 
-         .. parsed-literal::
+         .. code-block:: bat
 
-            7z x zephyr-sdk- |sdk-version-trim| _windows-x86_64.7z
+            7z x zephyr-sdk-|sdk-version-trim|_windows-x86_64.7z
 
          .. note::
             It is recommended to extract the Zephyr SDK bundle at one of the following locations:
@@ -218,7 +220,7 @@ Zephyr SDK installation
 
       #. Run the Zephyr SDK bundle setup script:
 
-         .. parsed-literal::
+         .. code-block:: bat
 
             cd zephyr-sdk- |sdk-version-ltrim|
             setup.cmd


### PR DESCRIPTION
I was going through the getting started documentation and noticed that some commands for installing the Zephyr SDK were not being shown correctly. 

I created this commit to fix that.
I tested this by generating the HTML documentation locally.

