### PR TITLE
boards: arm: ucans32k1sic: add support for RTC

### DIFF
--- a/boards/arm/ucans32k1sic/doc/index.rst
+++ b/boards/arm/ucans32k1sic/doc/index.rst
@@ -52,6 +52,7 @@ LPSPI         on-chip     spi
 FTM           on-chip     pwm
 FlexCAN       on-chip     can
 Watchdog      on-chip     watchdog
+RTC           on-chip     counter
 ============  ==========  ================================
 
 The default configuration can be found in the Kconfig file

--- a/boards/arm/ucans32k1sic/ucans32k1sic.yaml
+++ b/boards/arm/ucans32k1sic/ucans32k1sic.yaml
@@ -20,3 +20,4 @@ supported:
   - pwm
   - can
   - watchdog
+  - counter

--- a/drivers/counter/counter_mcux_rtc.c
+++ b/drivers/counter/counter_mcux_rtc.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018 blik GmbH
- * Copyright (c) 2018, NXP
+ * Copyright (c) 2018,2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -236,9 +236,11 @@ static int mcux_rtc_init(const struct device *dev)
 	RTC_GetDefaultConfig(&rtc_config);
 	RTC_Init(config->base, &rtc_config);
 
+#if !(defined(FSL_FEATURE_RTC_HAS_NO_CR_OSCE) && FSL_FEATURE_RTC_HAS_NO_CR_OSCE)
 	/* Enable 32kHz oscillator and wait for 1ms to settle */
-	config->base->CR |= 0x100;
+	RTC_SetClockSource(config->base);
 	k_busy_wait(USEC_PER_MSEC);
+#endif /* !FSL_FEATURE_RTC_HAS_NO_CR_OSCE */
 
 	config->irq_config_func(dev);
 

--- a/dts/arm/nxp/nxp_s32k1xx.dtsi
+++ b/dts/arm/nxp/nxp_s32k1xx.dtsi
@@ -317,5 +317,14 @@
 			prescaler = <1>;
 			status = "disabled";
 		};
+
+		rtc: rtc@4003d000 {
+			compatible = "nxp,kinetis-rtc";
+			reg = <0x4003d000 0x1000>;
+			interrupts = <46 0>, <47 0>;
+			interrupt-names = "alarm", "seconds";
+			clock-frequency = <32768>;
+			prescaler = <32768>;
+		};
 	};
 };

--- a/soc/arm/nxp_s32/s32k1/Kconfig.series
+++ b/soc/arm/nxp_s32/s32k1/Kconfig.series
@@ -19,5 +19,6 @@ config SOC_SERIES_S32K1XX
 	select HAS_MCUX_FTM
 	select HAS_MCUX_FLEXCAN
 	select HAS_MCUX_WDOG32
+	select HAS_MCUX_RTC
 	help
 	  Enable support for NXP S32K1XX MCU series.


### PR DESCRIPTION
Add support for Real Time Clock (RTC) counter driver on `ucans32k1sic` board.