### PR TITLE
dts: bindings: series of fix typo in multiple directories

### DIFF
--- a/dts/bindings/adc/espressif,esp32-adc.yaml
+++ b/dts/bindings/adc/espressif,esp32-adc.yaml
@@ -14,7 +14,7 @@ description: |
 
   Zephyr API is using gain unit to characterize ADC input.
   To achieve compatibility we choose to select those gain,
-  which coresponds to the ESP32 ADC attenuation feature.
+  which corresponds to the ESP32 ADC attenuation feature.
 
     ESP32,attenuation ~ zephyr,gain
     -----------------   -----------

--- a/dts/bindings/adc/infineon,cat1-adc.yaml
+++ b/dts/bindings/adc/infineon,cat1-adc.yaml
@@ -6,7 +6,7 @@
 description: |
   Infineon Cat1 ADC
   Each ADC group Cat1 is assigned to a Zephyr device. Refer to the Infineon PSoC6 reference
-  manual (Section Port I/O functions) for the group/chanel mapping to a specific port-pin on
+  manual (Section Port I/O functions) for the group/channel mapping to a specific port-pin on
   the board.  For example on the cy8cproto_062_4343w P10.0 is mapped to adc0,channel0 and
   P10.1 is mapped to adc0,channel1.
 

--- a/dts/bindings/adc/infineon,xmc4xxx-adc.yaml
+++ b/dts/bindings/adc/infineon,xmc4xxx-adc.yaml
@@ -4,7 +4,7 @@
 description: |
   Infineon XMC4XXX ADC
   Each ADC group XMC4XXX is assigned to a Zephyr device. Refer to Infineon XMC4XXX reference manual
-  (Section Port I/O functions) for the group/chanel mapping to a specific port-pin on the board.
+  (Section Port I/O functions) for the group/channel mapping to a specific port-pin on the board.
   For example on the xmc45_relax_kit P14.0 is mapped to adc0,channel0 and P14.1 is mapped to
   adc0,channel1.
 

--- a/dts/bindings/arm/atmel,samd2x-pm.yaml
+++ b/dts/bindings/arm/atmel,samd2x-pm.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-description: Atmel SAMD2x Power Manger (PM)
+description: Atmel SAMD2x Power Manager (PM)
 
 compatible: "atmel,samd2x-pm"
 

--- a/dts/bindings/bluetooth/ambiq,bt-hci-spi.yaml
+++ b/dts/bindings/bluetooth/ambiq,bt-hci-spi.yaml
@@ -27,6 +27,6 @@ properties:
     type: phandle-array
     description: |
       This clkreq gpio is used to send the XO32MHz clock request to host from
-      from controller. The host needs to enable XO32MHz when receiving low to
-      high edge interrupt and disable XO32MHz when receiving high to low edge
-      interrupt.
+      controller. The host needs to enable XO32MHz when receiving low to high
+      edge interrupts and disable XO32MHz when receiving high to low edge
+      interrupts.

--- a/dts/bindings/bluetooth/ambiq,bt-hci-spi.yaml
+++ b/dts/bindings/bluetooth/ambiq,bt-hci-spi.yaml
@@ -27,6 +27,6 @@ properties:
     type: phandle-array
     description: |
       This clkreq gpio is used to send the XO32MHz clock request to host from
-      from controller. The host needs to enable XO32MHz when receiveing low to
-      high edge interrupt and disable XO32MHz when receiveing high to low edge
+      from controller. The host needs to enable XO32MHz when receiving low to
+      high edge interrupt and disable XO32MHz when receiving high to low edge
       interrupt.

--- a/dts/bindings/bluetooth/infineon,cyw43xxx-bt-hci.yaml
+++ b/dts/bindings/bluetooth/infineon,cyw43xxx-bt-hci.yaml
@@ -66,10 +66,10 @@ properties:
     type: int
     description: |
       HCI UART boudrate for feature operation. If not defined
-      bus/current-speed wil be used as default.
+      bus/current-speed will be used as default.
 
   fw-download-speed:
     type: int
     description: |
-      HCI UART boudrate for FW dowload operation. If not defined
-      bus/current-speed wil be used as default.
+      HCI UART boudrate for FW download operation. If not defined
+      bus/current-speed will be used as default.

--- a/dts/bindings/can/microchip,mcp251xfd.yaml
+++ b/dts/bindings/can/microchip,mcp251xfd.yaml
@@ -47,7 +47,7 @@ properties:
   pll-enable:
     type: boolean
     description: |
-      Enables controller PLL, which multiples input clock frequency x10.
+      Enables controller PLL, which multiplies input clock frequency by 10.
       This parameter also implicitly sets whether the clock is from the PLL
       output or directly from the oscillator.
       If this option is enabled the clock source is the PLL, otherwise its

--- a/dts/bindings/can/microchip,mcp251xfd.yaml
+++ b/dts/bindings/can/microchip,mcp251xfd.yaml
@@ -48,7 +48,7 @@ properties:
     type: boolean
     description: |
       Enables controller PLL, which multiples input clock frequency x10.
-      This parameter also implicity sets whether the clock is from the PLL
+      This parameter also implicitly sets whether the clock is from the PLL
       output or directly from the oscillator.
       If this option is enabled the clock source is the PLL, otherwise its
       the oscillator.

--- a/dts/bindings/clock/microchip,xec-pcr.yaml
+++ b/dts/bindings/clock/microchip,xec-pcr.yaml
@@ -59,7 +59,7 @@ properties:
     type: int
     required: true
     description: |
-      Mininum number of consecutive 32KHz pulses that pass all monitor tests
+      Minimum number of consecutive 32KHz pulses that pass all monitor tests
 
   xtal-enable-delay-ms:
     type: int

--- a/dts/bindings/clock/pwm-clock.yaml
+++ b/dts/bindings/clock/pwm-clock.yaml
@@ -22,7 +22,7 @@ description: |
   property.
 
   The PWM node may need to be properly configured to generate
-  the target period (i.e. using prescaler options). See the documention
+  the target period (i.e. using prescaler options). See the documentation
   for the target PWM driver.
 
 compatible: "pwm-clock"

--- a/dts/bindings/clock/raspberrypi,pico-rosc.yaml
+++ b/dts/bindings/clock/raspberrypi,pico-rosc.yaml
@@ -34,5 +34,5 @@ properties:
   phase:
     type: int
     description: |
-      The phase-shift vlaue.
+      The phase-shift value.
       The valid range is 0 to 3

--- a/dts/bindings/clock/renesas,ra-clock-generation-circuit.yaml
+++ b/dts/bindings/clock/renesas,ra-clock-generation-circuit.yaml
@@ -37,7 +37,7 @@ properties:
 
   clock-source:
     type: phandle
-    description: System clock sorce
+    description: System clock source
 
   "#clock-cells":
     const: 1

--- a/dts/bindings/clock/st,stm32-rcc.yaml
+++ b/dts/bindings/clock/st,stm32-rcc.yaml
@@ -51,7 +51,7 @@ description: |
            ...
   }
   In this example, I2C1 device is assigned HSI as domain clock source.
-  Domain clock is independent from the bus/gatted clock and allows access to the device's
+  Domain clock is independent from the bus/gated clock and allows access to the device's
   register while the gated clock is off. As it doesn't feed the peripheral's controller, it
   allows peripheral operation, but can't be used for peripheral configuration.
   It is peripheral driver's responsibility to query and use clock source information in

--- a/dts/bindings/clock/st,stm32-rcc.yaml
+++ b/dts/bindings/clock/st,stm32-rcc.yaml
@@ -54,7 +54,7 @@ description: |
   Domain clock is independent from the bus/gatted clock and allows access to the device's
   register while the gated clock is off. As it doesn't feed the peripheral's controller, it
   allows peripheral operation, but can't be used for peripheral configuration.
-  It is peripheral driver's responsibility to querry and use clock source information in
+  It is peripheral driver's responsibility to query and use clock source information in
   accordance with clock_control API specifications.
 
   Since the peripheral subsystem rate is dictated by the clock used for peripheral

--- a/dts/bindings/clock/st,stm32f1-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32f1-pll-clock.yaml
@@ -35,11 +35,11 @@ properties:
   xtpre:
     type: boolean
     description: |
-        Otpional HSE divider for PLL entry
+        Optional HSE divider for PLL entry
 
   usbpre:
     type: boolean
     description: |
-        Otpional PLL output divisor to generate a 48MHz USB clock.
+        Optional PLL output divisor to generate a 48MHz USB clock.
         When set, PLL clock is not divided.
         Otherwise, PLL output clock is divided by 1.5.

--- a/dts/bindings/clock/st,stm32f105-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32f105-pll-clock.yaml
@@ -55,6 +55,6 @@ properties:
   otgfspre:
     type: boolean
     description: |
-        Otpional PLL output divisor to generate a 48MHz USB clock.
+        Optional PLL output divisor to generate a 48MHz USB clock.
         When set, PLL output clock is not divided.
         Otherwise, PLL output clock is divided by 1.5.

--- a/dts/bindings/clock/st,stm32f3-rcc.yaml
+++ b/dts/bindings/clock/st,stm32f3-rcc.yaml
@@ -52,4 +52,4 @@ properties:
         ADC 3 and 4 prescaler
         - 0: Disables the clock so the ADC can use AHB clock (synchronous mode)
         - Other values n: The ADC can use the PLL clock divided by n
-        Check RefMan for availabilty.
+        Check RefMan for availability.

--- a/dts/bindings/clock/st,stm32wba-rcc.yaml
+++ b/dts/bindings/clock/st,stm32wba-rcc.yaml
@@ -49,7 +49,7 @@ description: |
            ...
   }
   In this example I2C1 device is assigned HSI as clock source.
-  It is device driver's responsibility to querry and use clock source information in
+  It is device driver's responsibility to query and use clock source information in
   accordance with clock_control API specifications.
 
 compatible: "st,stm32wba-rcc"

--- a/dts/bindings/clock/st,stm32wl-hse-clock.yaml
+++ b/dts/bindings/clock/st,stm32wl-hse-clock.yaml
@@ -12,7 +12,7 @@ properties:
     type: boolean
     description: |
       When set, TCXO is selected as external source clock for HSE.
-      Otherwise, external cyrstal is selected as HSE source clock.
+      Otherwise, external crystal is selected as HSE source clock.
 
   hse-div2:
     type: boolean

--- a/dts/bindings/dac/atmel,sam-dac.yaml
+++ b/dts/bindings/dac/atmel,sam-dac.yaml
@@ -20,7 +20,7 @@ properties:
     type: int
     default: 15
     description: |
-      Peripheral Clock to DAC Clock Ratio. Prescaler value is calcuated as
+      Peripheral Clock to DAC Clock Ratio. Prescaler value is calculated as
       PRESCAL = (MCK / DACClock) - 2. Should be in range from 0 to 15. The
       value will be written to DACC_MR.PRESCALER bit-field. The property is
       applicable only to SAME70, SAMV71 series devices.

--- a/dts/bindings/display/ilitek,ili9342c.yaml
+++ b/dts/bindings/display/ilitek,ili9342c.yaml
@@ -16,7 +16,7 @@ properties:
     default: [0x01]
     description:
       select the desired Gamma curve for the current display.
-      A maximum of 4 fixed gamma curves canbe selected.
+      A maximum of 4 fixed gamma curves can be selected.
 
   ifmode:
     type: uint8-array

--- a/dts/bindings/display/nxp,imx-elcdif.yaml
+++ b/dts/bindings/display/nxp,imx-elcdif.yaml
@@ -34,5 +34,5 @@ properties:
   nxp,pxp:
     type: phandle
     description:
-      NXP PXP device phandle. The LCDIF can utilize the PXP for acclerated
+      NXP PXP device phandle. The LCDIF can utilize the PXP for accelerated
       display rotation via the DMA API, when present and enabled.

--- a/dts/bindings/dma/andestech,atcdmac300.yaml
+++ b/dts/bindings/dma/andestech,atcdmac300.yaml
@@ -29,7 +29,7 @@ description: |
   Andes DMA controller
   channel: a phandle to the DMA controller plus the following four integer cells:
     1. channel: the dma channel
-    2. slot: DMA peripherial request ID
+    2. slot: DMA peripheral request ID
     3. channel-config: A 32bit mask specifying the DMA channel configuration
     which is device dependent:
         -bit 0-1 : Direction  (see dma.h)

--- a/dts/bindings/dma/st,stm32-dma-v1.yaml
+++ b/dts/bindings/dma/st,stm32-dma-v1.yaml
@@ -13,7 +13,7 @@ description: |
     2. slot: DMA periph request ID, which is written in the DMAREQ_ID of the DMAMUX_CxCR
     this value is 0 for Memory-to-memory transfers
     or a value between <1> .. <dma-generators> (not supported yet)
-    or a value beweeen <dma-generators>+1  ..  <dma-generators>+<dma-requests>
+    or a value between <dma-generators>+1  ..  <dma-generators>+<dma-requests>
     3. channel-config: A 32bit mask specifying the DMA channel configuration
     which is device dependent:
         -bit 6-7 : Direction  (see dma.h)

--- a/dts/bindings/dma/st,stm32-dma-v2.yaml
+++ b/dts/bindings/dma/st,stm32-dma-v2.yaml
@@ -16,7 +16,7 @@ description: |
     2. slot: DMA periph request ID, which is written in the DMAREQ_ID of the DMAMUX_CxCR
     this value is 0 for Memory-to-memory transfers
     or a value between <1> .. <dma-generators> (not supported yet)
-    or a value beweeen <dma-generators>+1  ..  <dma-generators>+<dma-requests>
+    or a value between <dma-generators>+1  ..  <dma-generators>+<dma-requests>
     3. channel-config: A 32bit mask specifying the DMA channel configuration
     A name custom DMA flags for channel configuration is used
     which is device dependent see stm32_dma.h:

--- a/dts/bindings/dma/st,stm32-dma-v2.yaml
+++ b/dts/bindings/dma/st,stm32-dma-v2.yaml
@@ -19,7 +19,7 @@ description: |
     or a value between <dma-generators>+1  ..  <dma-generators>+<dma-requests>
     3. channel-config: A 32bit mask specifying the DMA channel configuration
     A name custom DMA flags for channel configuration is used
-    which is device dependent see stm32_dma.h:
+    which is device dependent. See stm32_dma.h:
       -bit 5 : DMA  cyclic mode config
                 0x0: STM32_DMA_MODE_NORMAL
                 0x1: STM32_DMA_MODE_CYCLIC

--- a/dts/bindings/dma/st,stm32-dmamux.yaml
+++ b/dts/bindings/dma/st,stm32-dmamux.yaml
@@ -41,7 +41,7 @@ description: |
                0x1: medium
                0x2: high
                0x3: very high
-   exemple for stm32wb55x
+   example for stm32wb55x
      dmamux1: dmamux@40020800 {
          compatible = "st,stm32-dmamux";
          ...

--- a/dts/bindings/ethernet/xlnx,gem.yaml
+++ b/dts/bindings/ethernet/xlnx,gem.yaml
@@ -303,7 +303,7 @@ properties:
   multicast-hash:
     type: boolean
     description: |
-      Optional feature flag - Enable multicast hash. When set, mutlicast
+      Optional feature flag - Enable multicast hash. When set, multicast
       frames will be accepted when the 6 bit hash function of the desti-
       nation address points to a bit that is set in the hash register.
 

--- a/dts/bindings/gpio/richtek,rt1718s.yaml
+++ b/dts/bindings/gpio/richtek,rt1718s.yaml
@@ -5,7 +5,7 @@ description: |
     Richtek RT1718S TCPC chip
 
     The Richtek RT1718S chip is TCPC, but also has 3 pins, which can be used as
-    a usual GPIO. This node collects common proprties for RT1718S chip e.g. I2C
+    a usual GPIO. This node collects common properties for RT1718S chip e.g. I2C
     address. Feature-specific(GPIO, TCPC) properties should be placed in a child
     node e.g. a number of GPIOs.
 

--- a/dts/bindings/i2c/atmel,sam-i2c-twim.yaml
+++ b/dts/bindings/i2c/atmel,sam-i2c-twim.yaml
@@ -14,7 +14,7 @@ description: |
 
   When using speeds above standard mode, user may need adjust clock and data
   lines slew and strength parameters.  In general, slew 0 and minimal strength
-  is enough for short buses and light loads.  As reference, the below
+  is enough for short buses and light loads.  As a reference, the below
   is the lowest power configuration:
 
     std-clk-slew-lim = <0>;

--- a/dts/bindings/i2c/atmel,sam-i2c-twim.yaml
+++ b/dts/bindings/i2c/atmel,sam-i2c-twim.yaml
@@ -14,7 +14,7 @@ description: |
 
   When using speeds above standard mode, user may need adjust clock and data
   lines slew and strength parameters.  In general, slew 0 and minimal strength
-  is enougth for short buses and light loads.  As reference, the below
+  is enough for short buses and light loads.  As reference, the below
   is the lowest power configuration:
 
     std-clk-slew-lim = <0>;

--- a/dts/bindings/interrupt-controller/cypress,psoc6-intmux.yaml
+++ b/dts/bindings/interrupt-controller/cypress,psoc6-intmux.yaml
@@ -57,12 +57,12 @@ description: |
   intmux[20 mod 8] |= 0x02 << (20 mod 4);
 
   These results in Cortex-M0+ NVIC line 20 handling PSoC-6 interrupt source 2.
-  The interrupt can be enabled/disable at NVIC at line 20 as usual.
+  The interrupt can be enabled/disabled at NVIC at line 20 as usual.
 
   Notes:
   1) Multiple definitions will generate multiple interrupts
-  2) The interrupt sources are shared between Cortex-M0+/M4. These means, can
-     trigger action in parallel in both processors.
+  2) The interrupt sources are shared between Cortex-M0+/M4. This means, they
+     can trigger actions in parallel on both processors.
   3) User can change priority at Cortex-M0+ NVIC by changing interrupt channels
      at interrupt-parent properties.
   4) Only the peripherals used by Cortex-M0+ should be configured.

--- a/dts/bindings/interrupt-controller/cypress,psoc6-intmux.yaml
+++ b/dts/bindings/interrupt-controller/cypress,psoc6-intmux.yaml
@@ -28,7 +28,7 @@ description: |
   ...
   intmux[7] = {ch31, ch30, ch29, ch28}
 
-  In pratical terms, the Cortex-M0+ requires user to define all NVIC interrupt
+  In practical terms, the Cortex-M0+ requires user to define all NVIC interrupt
   sources and the proper NVIC interrupt order. With that, the system configures
   the Cortex-M0+ Interrupt Multiplexer and interrupts can be processed.
   More information about it at PSoC-6 Architecture Technical Reference Manual,
@@ -60,7 +60,7 @@ description: |
   The interrupt can be enabled/disable at NVIC at line 20 as usual.
 
   Notes:
-  1) Multiple definitions will generate multiple interrutps
+  1) Multiple definitions will generate multiple interrupts
   2) The interrupt sources are shared between Cortex-M0+/M4. These means, can
      trigger action in parallel in both processors.
   3) User can change priority at Cortex-M0+ NVIC by changing interrupt channels

--- a/dts/bindings/interrupt-controller/nuvoton,npcx-miwu.yaml
+++ b/dts/bindings/interrupt-controller/nuvoton,npcx-miwu.yaml
@@ -16,7 +16,7 @@ properties:
   "#miwu-cells":
     type: int
     required: true
-    description: Number of items to present a MIWU input souce specifier
+    description: Number of items to present a MIWU input source specifier
 
 miwu-cells:
   - group

--- a/dts/bindings/net/wireless/gpio-radio-coex.yaml
+++ b/dts/bindings/net/wireless/gpio-radio-coex.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-    Generic representation of Coexistance pin interface for radios. This
+    Generic representation of Coexistence pin interface for radios. This
     interface is usually available on Wifi/Bluetooth/LTE modules to
     interact with each other when sharing same antenna. This prevents
     any collisions between transmissions from different modules. The grant

--- a/dts/bindings/net/wireless/gpio-radio-coex.yaml
+++ b/dts/bindings/net/wireless/gpio-radio-coex.yaml
@@ -4,7 +4,7 @@
 description: |
     Generic representation of Coexistence pin interface for radios. This
     interface is usually available on Wifi/Bluetooth/LTE modules to
-    interact with each other when sharing same antenna. This prevents
+    interact with each other when sharing the same antenna. This prevents
     any collisions between transmissions from different modules. The grant
     signal should signal that the external transceiver/module is not
     transmitting. Therefore you are free to perform any TX operations as

--- a/dts/bindings/pinctrl/ite,it8xxx2-pinctrl.yaml
+++ b/dts/bindings/pinctrl/ite,it8xxx2-pinctrl.yaml
@@ -46,7 +46,7 @@ description: |
 
     The 'uart1_rx_pb0_default' child node encodes the pin configurations
     for a particular state of a device; in this case, the default
-    (that is, active) sate.
+    (that is, active) state.
 
     To link pin configurations with a device, use a pinctrl-N property for some
     number N, like this example you could place in your board's DTS file:
@@ -65,7 +65,7 @@ include: base.yaml
 
 child-binding:
   description: |
-      This binding gives a base representation of the ITE IT8XXX2 pins configration.
+      This binding gives a base representation of the ITE IT8XXX2 pins configuration.
 
   include:
     - name: pincfg-node.yaml

--- a/dts/bindings/pinctrl/renesas,rcar-pfc.yaml
+++ b/dts/bindings/pinctrl/renesas,rcar-pfc.yaml
@@ -40,7 +40,7 @@ description: |
 
     The 'can0_data_a_tx_default' child node encodes the pin configurations
     for a particular state of a device; in this case, the default
-    (that is, active) sate. You would specify the low-power configuration for
+    (that is, active) state. You would specify the low-power configuration for
     the same device in a separate child node.
 
     A pin configuration can also specify pin properties such as the

--- a/dts/bindings/pinctrl/st,stm32-pinctrl.yaml
+++ b/dts/bindings/pinctrl/st,stm32-pinctrl.yaml
@@ -34,7 +34,7 @@ properties:
 
 child-binding:
   description: |
-      This binding gives a base representation of the STM32 pins configration
+      This binding gives a base representation of the STM32 pins configuration
 
   include:
     - name: pincfg-node.yaml
@@ -76,7 +76,7 @@ child-binding:
         This macro is available here:
           -include/zephyr/dt-bindings/pinctrl/stm32-pinctrl-common.h
         Some examples of macro usage:
-           GPIO A9 set as alernate function 2
+           GPIO A9 set as alternate function 2
         ... {
                  pinmux = <STM32_PINMUX('A', 9, AF2)>;
         };

--- a/dts/bindings/pinctrl/st,stm32f1-pinctrl.yaml
+++ b/dts/bindings/pinctrl/st,stm32f1-pinctrl.yaml
@@ -41,7 +41,7 @@ properties:
 child-binding:
   description: |
       This binding gives a base representation of the STM32F1 pins
-      configration
+      configuration
 
   include:
     - name: pincfg-node.yaml
@@ -85,11 +85,11 @@ child-binding:
         This macro is available here:
           -include/zephyr/dt-bindings/pinctrl/stm32f1-pinctrl.h
         Some examples of macro usage:
-           GPIO A9 set as alernate with no remap
+           GPIO A9 set as alternate with no remap
         ... {
                  pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_NO)>;
         };
-           GPIO A9 set as alernate with full remap
+           GPIO A9 set as alternate with full remap
         ... {
                  pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, REMAP_FULL)>;
         };

--- a/dts/bindings/pinctrl/telink,b91-pinctrl.yaml
+++ b/dts/bindings/pinctrl/telink,b91-pinctrl.yaml
@@ -39,7 +39,7 @@ description: |
 
     The 'uart0_tx_pb2_default' child node encodes the pin configurations
     for a particular state of a device; in this case, the default
-    (that is, active) sate. You would specify the low-power configuration for
+    (that is, active) state. You would specify the low-power configuration for
     the same device in a separate child node.
 
     A pin configuration can also specify pin properties such as the
@@ -83,7 +83,7 @@ properties:
 
 child-binding:
   description: |
-      This binding gives a base representation of the Telink B91 pins configration.
+      This binding gives a base representation of the Telink B91 pins configuration.
 
   include:
   - name: pincfg-node.yaml

--- a/dts/bindings/power-domain/power-domain-gpio-monitor.yaml
+++ b/dts/bindings/power-domain/power-domain-gpio-monitor.yaml
@@ -6,7 +6,7 @@ description: |
 
   This power domain monitors the state of a GPIO pin to detect whether a power
   rail is on/off. Therefore, performing resume/suspend on power domain won't
-  change physical state of power rails and those action won't be triggerd on
+  change physical state of power rails and those action won't be triggered on
   child nodes. Additionally, due to the asynchronous nature of monitoring a
   pending transaction won't be interrupted by power state change.
 

--- a/dts/bindings/power-domain/power-domain-gpio-monitor.yaml
+++ b/dts/bindings/power-domain/power-domain-gpio-monitor.yaml
@@ -6,8 +6,8 @@ description: |
 
   This power domain monitors the state of a GPIO pin to detect whether a power
   rail is on/off. Therefore, performing resume/suspend on power domain won't
-  change physical state of power rails and those action won't be triggered on
-  child nodes. Additionally, due to the asynchronous nature of monitoring a
+  change physical state of power rails and that action won't be triggered on
+  child nodes. Additionally, due to the asynchronous nature of monitoring, a
   pending transaction won't be interrupted by power state change.
 
 compatible: "power-domain-gpio-monitor"

--- a/dts/bindings/pwm/nxp,s32-emios-pwm.yaml
+++ b/dts/bindings/pwm/nxp,s32-emios-pwm.yaml
@@ -179,7 +179,7 @@ child-binding:
       default: 0
       enum: [0, 2, 4, 8, 16]
       description: |
-        Select the minimim input pulse width, in filter clock cycles that can pass
+        Select the minimum input pulse width, in filter clock cycles that can pass
         through the input filter. The filter latency - the difference in time between
         the input and the response is three clock edges. Default 0 means the filter
         is bypassed. The clock source for programmable input filter is eMIOS clock.

--- a/dts/bindings/qspi/nxp,s32-qspi.yaml
+++ b/dts/bindings/qspi/nxp,s32-qspi.yaml
@@ -70,7 +70,7 @@ properties:
     type: int
     default: 0
     description: |
-      Column Address Space bit width. For example, if the coulmn address is
+      Column Address Space bit width. For example, if the column address is
       [2:0] of QSPI_SFAR/AHB address, then the column address space bit width
       must be 3. If there is no column address separation in any serial flash
       device connected to this controller, this value must be programmed to 0.

--- a/dts/bindings/retained_mem/zephyr,retained-ram.yaml
+++ b/dts/bindings/retained_mem/zephyr,retained-ram.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-description: Unitialised RAM-based retained memory area.
+description: Uninitialised RAM-based retained memory area.
 
 compatible: "zephyr,retained-ram"
 

--- a/dts/bindings/rng/st,stm32-rng.yaml
+++ b/dts/bindings/rng/st,stm32-rng.yaml
@@ -19,7 +19,7 @@ properties:
                    <&rcc STM32_SRC_MSI CLK48_SEL(3)> /* RNG clock domain set to MSI */
          A correctly configured domain clock is required to allow the integrated low
          sampling clock detection mechanism to behave properly.
-         In provided example, MSI should be configured to provide 48Mhz clock.
+         In the provided example, MSI should be configured to provide 48Mhz clock.
 
   nist-config:
     type: int

--- a/dts/bindings/rng/st,stm32-rng.yaml
+++ b/dts/bindings/rng/st,stm32-rng.yaml
@@ -18,7 +18,7 @@ properties:
          the clock domain used, for instance:
                    <&rcc STM32_SRC_MSI CLK48_SEL(3)> /* RNG clock domain set to MSI */
          A correctly configured domain clock is required to allow the integrated low
-         sampling clock detection mecanism to behave properly.
+         sampling clock detection mechanism to behave properly.
          In provided example, MSI should be configured to provide 48Mhz clock.
 
   nist-config:

--- a/dts/bindings/sensor/ams,tsl2540.yaml
+++ b/dts/bindings/sensor/ams,tsl2540.yaml
@@ -20,7 +20,7 @@ properties:
     default: 100000
     description: |
       Visible light attenuation.
-      Integer value for a represenation with 5 decimal points.
+      Integer value for a representation with 5 decimal points.
       This default value (1.00000) is chosen for free open space (no glass).
       Example: 1.2 would be 120000
 
@@ -29,6 +29,6 @@ properties:
     default: 100000
     description: |
       Infa-red light attenuation.
-      Integer value for a represenation with 5 decimal points.
+      Integer value for a representation with 5 decimal points.
       This default value (1.00000) is chosen for free open space (no glass).
       Example: 1.2 would be 120000

--- a/dts/bindings/sensor/maxim,max31875.yaml
+++ b/dts/bindings/sensor/maxim,max31875.yaml
@@ -17,7 +17,7 @@ properties:
   conversions-per-second:
     description: |
       Number of temperature readings performed by the MAX31875 per second.
-      0.25 converions per second is the power-on reset configuration.
+      0.25 conversions per second is the power-on reset configuration.
     type: string
     default: "0.25"
     # Note: the driver relies on the ordering of this enum,

--- a/dts/bindings/sensor/nuvoton,adc-cmp.yaml
+++ b/dts/bindings/sensor/nuvoton,adc-cmp.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 description: |
-    This will perform signal comparision with threshold established.
+    This will perform signal comparison with threshold established.
 
 compatible: "nuvoton,adc-cmp"
 

--- a/dts/bindings/sensor/nxp,kinetis-temperature.yaml
+++ b/dts/bindings/sensor/nxp,kinetis-temperature.yaml
@@ -25,7 +25,7 @@ properties:
     type: int
     required: true
     description: |
-        Temperature sensor voltage at 25 degrees Celcius in microvolts
+        Temperature sensor voltage at 25 degrees Celsius in microvolts
 
   sensor-slope-cold:
     type: int

--- a/dts/bindings/sensor/st,lis2mdl-common.yaml
+++ b/dts/bindings/sensor/st,lis2mdl-common.yaml
@@ -16,7 +16,7 @@ properties:
     type: boolean
     description: |
       Set to config the sensor in single measurement mode. Leave
-      unset to configure the sensor in continious measurement mode.
+      unset to configure the sensor in continuous measurement mode.
 
   cancel-offset:
     type: boolean

--- a/dts/bindings/sensor/st,lsm6dsv16x-common.yaml
+++ b/dts/bindings/sensor/st,lsm6dsv16x-common.yaml
@@ -135,7 +135,7 @@ properties:
     description: |
       Specify the default gyro output data rate expressed in samples per second (Hz).
       The values are taken in accordance to lsm6dsv16x_data_rate_t enumerative in hal/st
-      module. Please note that this values will not change the operating mode, which will remain
+      module. Please note that these values will not change the operating mode, which will remain
       High Performance (device default). Moreover, the values here which will be selected in the
       DT are the only way to specify the odr accuracy even at runtime with
       SENSOR_ATTR_SAMPLING_FREQUENCY.

--- a/dts/bindings/sensor/st,lsm6dsv16x-common.yaml
+++ b/dts/bindings/sensor/st,lsm6dsv16x-common.yaml
@@ -137,7 +137,7 @@ properties:
       The values are taken in accordance to lsm6dsv16x_data_rate_t enumerative in hal/st
       module. Please note that this values will not change the operating mode, which will remain
       High Performance (device default). Moreover, the values here which will be selected in the
-      DT are the only way to specifiy the odr accuracy even at runtime with
+      DT are the only way to specify the odr accuracy even at runtime with
       SENSOR_ATTR_SAMPLING_FREQUENCY.
       Default is power-up configuration.
 

--- a/dts/bindings/sensor/ti,fdc2x1x.yaml
+++ b/dts/bindings/sensor/ti,fdc2x1x.yaml
@@ -44,7 +44,7 @@ properties:
     description: |
       Reference frequency of the used clock source in KHz.
       The internal clock oscillates at around 43360 KHz (43.36 MHz)
-      at 20 degrees Celcius.
+      at 20 degrees Celsius.
       Recommended external clock source frequency is 40000 KHz (40 MHz).
 
   rr-sequence:

--- a/dts/bindings/sensor/ti,tmag5170.yaml
+++ b/dts/bindings/sensor/ti,tmag5170.yaml
@@ -183,7 +183,7 @@ properties:
     type: int
     default: 1
     description: |
-      The time in miliseconds the sensor will be in sleep during conversions.
+      The time in milliseconds the sensor will be in sleep during conversions.
       For this property to take effect sensor must be in `duty-cycled` mode.
       Note that to calculate total time between conversions, the conversion time
       itself must be taken into account. The conversion time is dependent

--- a/dts/bindings/serial/infineon,xmc4xxx-uart.yaml
+++ b/dts/bindings/serial/infineon,xmc4xxx-uart.yaml
@@ -100,7 +100,7 @@ properties:
          dma1 can connect to lines [8, 11].
       2. For a given interrupt, calculate the service request (SR) number. Note the following
          simple mapping: in USIC0 interrupt 84->SR0, interrupt 85->SR1, ... etc.
-         In USIC1, intterupt 90->SR0, 91->SR1, etc.
+         In USIC1, interrupt 90->SR0, 91->SR1, etc.
       3. Select request_source from Table "DMA Request Source Selection" in XMC4XXX reference
          manual.
 

--- a/dts/bindings/serial/st,stm32-uart-base.yaml
+++ b/dts/bindings/serial/st,stm32-uart-base.yaml
@@ -90,7 +90,7 @@ properties:
   fifo-enable:
     type: boolean
     description: |
-      Enables transmit and receive FIFO using default FIFO configuration (typically thresholds
+      Enables transmit and receive FIFO using default FIFO configuration (typically threshold is
       set to 1/8).
       In TX, FIFO allows to work in burst mode, easing scheduling of loaded applications. It also
       allows more reliable communication with UART devices sensitive to variation of inter-frames

--- a/dts/bindings/serial/st,stm32-uart-base.yaml
+++ b/dts/bindings/serial/st,stm32-uart-base.yaml
@@ -90,9 +90,9 @@ properties:
   fifo-enable:
     type: boolean
     description: |
-      Enables transmit and receive FIFO using default FIFO confugration (typically threasholds
+      Enables transmit and receive FIFO using default FIFO configuration (typically thresholds
       set to 1/8).
       In TX, FIFO allows to work in burst mode, easing scheduling of loaded applications. It also
       allows more reliable communication with UART devices sensitive to variation of inter-frames
       delays.
-      In RX, FIFO reduces overrun occurences.
+      In RX, FIFO reduces overrun occurrences.

--- a/dts/bindings/spi/infineon,xmc4xxx-spi.yaml
+++ b/dts/bindings/spi/infineon,xmc4xxx-spi.yaml
@@ -55,7 +55,7 @@ properties:
          dma1 can connect to lines [8, 11].
       2. For a given interrupt, calculate the service request (SR) number. Note the following
          simple mapping: in USIC0 interrupt 84->SR0, interrupt 85->SR1, ... etc.
-         In USIC1, intterupt 90->SR0, 91->SR1, etc.
+         In USIC1, interrupt 90->SR0, 91->SR1, etc.
       3. Select request_source from Table "DMA Request Source Selection" in XMC4XXX reference
          manual.
 

--- a/dts/bindings/spi/microchip,xec-qmspi-ldma.yaml
+++ b/dts/bindings/spi/microchip,xec-qmspi-ldma.yaml
@@ -55,14 +55,14 @@ properties:
     type: int
     description: |
       Delay in QMSPI main clocks from CS# assertion to first clock edge.
-      If not present use hardware default value. Refer to chip documention
+      If not present use hardware default value. Refer to chip documentation
       for QMSPI input clock frequency.
 
   dckcsoff:
     type: int
     description: |
       Delay in QMSPI main clocks from last clock edge to CS# de-assertion.
-      If not present use hardware default value. Refer to chip documention
+      If not present use hardware default value. Refer to chip documentation
       for QMSPI input clock frequency.
 
   dldh:
@@ -76,7 +76,7 @@ properties:
     type: int
     description: |
       Delay in QMSPI main clocks from CS# de-assertion to CS# assertion.
-      If not present use hardware default value. Refer to chip documention
+      If not present use hardware default value. Refer to chip documentation
       for QMSPI input clock frequency.
 
   cs1-freq:

--- a/dts/bindings/timer/nuclei,systimer.yaml
+++ b/dts/bindings/timer/nuclei,systimer.yaml
@@ -44,5 +44,5 @@ properties:
       Setting clk-divider to 2 specifies the system timer uses the clock
       that CPU clock frequency divided by (2^2=)4, or 27MHz.
 
-      Devision ratio constants can be found in the
+      Division ratio constants can be found in the
       dt-bindings/timer/nuclei-systimer.h header file.

--- a/dts/bindings/timer/nxp,imx-gpt.yaml
+++ b/dts/bindings/timer/nxp,imx-gpt.yaml
@@ -17,4 +17,4 @@ properties:
   gptfreq:
     type: int
     required: true
-    description: gpt frequences
+    description: gpt frequencies

--- a/dts/bindings/usb-c/usb-c-connector.yaml
+++ b/dts/bindings/usb-c/usb-c-connector.yaml
@@ -115,7 +115,7 @@ properties:
     type: array
     description: |
       An array of source Power Data Objects (PDOs).
-      Use tht following macros to define the PDOs, defined in
+      Use the following macros to define the PDOs, defined in
       dt-bindings/usb-c/pd.h.
         * PDO_FIXED
         * PDO_BATT
@@ -127,7 +127,7 @@ properties:
     type: array
     description: |
       An array of sink Power Data Objects (PDOs).
-      Use tht following macros to define the PDOs, defined in
+      Use the following macros to define the PDOs, defined in
       dt-bindings/usb-c/pd.h.
         * PDO_FIXED
         * PDO_BATT
@@ -139,7 +139,7 @@ properties:
     type: array
     description: |
       An array of sink Vendor Defined Objects (VDOs).
-      Use tht following macros to define the VDOs, defined in
+      Use the following macros to define the VDOs, defined in
       dt-bindings/usb-c/pd.h.
         * VDO_IDH
         * VDO_CERT
@@ -155,7 +155,7 @@ properties:
     type: array
     description: |
       An array of sink Vendor Defined Objects (VDOs).
-      Use tht following macros to define the VDOs, defined in
+      Use the following macros to define the VDOs, defined in
       dt-bindings/usb-c/pd.h.
         * VDO_IDH
         * VDO_CERT

--- a/dts/bindings/usb/uac2/zephyr,uac2.yaml
+++ b/dts/bindings/usb/uac2/zephyr,uac2.yaml
@@ -13,7 +13,7 @@ compatible: "zephyr,uac2"
 # The only reason for putting Audio Streaming interfaces at the end is because
 # Audio Control entities derive their unique ID from child index (+ 1). For most
 # cases the order shouldn't really matter, but if there happen to be maximum
-# possible number of entities (255) then the Audio Streaming would inadvertedly
+# possible number of entities (255) then the Audio Streaming would inadvertently
 # "consume" one of the available IDs.
 
 properties:

--- a/dts/bindings/usb/usb-audio-hs.yaml
+++ b/dts/bindings/usb/usb-audio-hs.yaml
@@ -23,7 +23,7 @@ properties:
     type: string
     description: |
       Type of endpoint synchronization for IN devices.
-      Default value is Sychronous.
+      Default value is Synchronous.
       Adaptive is not supported.
     enum:
       - "No Synchronization"

--- a/dts/bindings/usb/usb-audio-mic.yaml
+++ b/dts/bindings/usb/usb-audio-mic.yaml
@@ -23,7 +23,7 @@ properties:
     type: string
     description: |
       Type of endpoint synchronization for IN devices.
-      Default value is Sychronous.
+      Default value is Synchronous.
       Adaptive is not supported.
     enum:
       - "No Synchronization"

--- a/dts/bindings/watchdog/intel,adsp-watchdog.yaml
+++ b/dts/bindings/watchdog/intel,adsp-watchdog.yaml
@@ -16,7 +16,7 @@ properties:
     type: int
     description: |
       Clock frequency used by counter in Hz. You can specify a frequency here or specify a clock
-      using the clocks propertie.
+      using the clocks properties.
 
   reset-pulse-length:
     type: int

--- a/dts/bindings/watchdog/intel,adsp-watchdog.yaml
+++ b/dts/bindings/watchdog/intel,adsp-watchdog.yaml
@@ -16,7 +16,7 @@ properties:
     type: int
     description: |
       Clock frequency used by counter in Hz. You can specify a frequency here or specify a clock
-      using the clocks properties.
+      using the property "clocks".
 
   reset-pulse-length:
     type: int

--- a/dts/bindings/watchdog/lowrisc,opentitan-aontimer.yaml
+++ b/dts/bindings/watchdog/lowrisc,opentitan-aontimer.yaml
@@ -22,5 +22,5 @@ properties:
   wdog-lock:
     type: boolean
     description: |
-      When set, lock watchdog configration after setup until the next
+      When set, lock watchdog configuration after setup until the next
       reset.

--- a/dts/bindings/watchdog/snps,designware-watchdog.yaml
+++ b/dts/bindings/watchdog/snps,designware-watchdog.yaml
@@ -16,7 +16,7 @@ properties:
     type: int
     description: |
       Clock frequency used by counter in Hz. You can specify a frequency here or specify a clock
-      using the clocks propertie.
+      using the clocks properties.
 
   reset-pulse-length:
     type: int


### PR DESCRIPTION
I've made typo corrections in various dts/bindings directories:

- `dts/bindings/(adc|arm)/*`
- `dts/bindings/(bluetooth|can|dac|display)/*`
- `dts/bindings/clock/*`
- `dts/bindings/dma/*`
- `dts/bindings/(ethernet|gpio|i2c|interrupt-controlle)/*`
- `dts/bindings/(net|power-domain|pwm|qspi)/*`
- `dts/bindings/pinctrl/*`
- `dts/bindings/(retained_mem|rng|serial|spi)/*`
- `dts/bindings/sensor/*`
- `dts/bindings/(timer|usb-c|usb|watchdog)/*`

Aiming to improve Zephyr project's documentation quality. 🚀