### PR TITLE
posix: timer: build timer.c using the correct kconfig option

### DIFF
--- a/lib/posix/CMakeLists.txt
+++ b/lib/posix/CMakeLists.txt
@@ -43,7 +43,6 @@ zephyr_library_sources_ifdef(CONFIG_POSIX_API perror.c)
 zephyr_library_sources_ifdef(CONFIG_POSIX_CLOCK clock.c)
 zephyr_library_sources_ifdef(CONFIG_POSIX_CLOCK nanosleep.c)
 zephyr_library_sources_ifdef(CONFIG_POSIX_CLOCK sleep.c)
-zephyr_library_sources_ifdef(CONFIG_POSIX_CLOCK timer.c)
 zephyr_library_sources_ifdef(CONFIG_POSIX_FS fs.c)
 zephyr_library_sources_ifdef(CONFIG_POSIX_MQUEUE mqueue.c)
 zephyr_library_sources_ifdef(CONFIG_POSIX_SIGNAL signal.c ${STRSIGNAL_TABLE_H})
@@ -58,6 +57,7 @@ zephyr_library_sources_ifdef(CONFIG_PTHREAD_RWLOCK rwlock.c)
 zephyr_library_sources_ifdef(CONFIG_POSIX_PRIORITY_SCHEDULING sched.c)
 zephyr_library_sources_ifdef(CONFIG_PTHREAD_IPC semaphore.c)
 zephyr_library_sources_ifdef(CONFIG_PTHREAD_SPINLOCK spinlock.c)
+zephyr_library_sources_ifdef(CONFIG_TIMER timer.c)
 
 zephyr_library_include_directories(
   ${ZEPHYR_BASE}/kernel/include

--- a/lib/posix/Kconfig.clock
+++ b/lib/posix/Kconfig.clock
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config POSIX_CLOCK
-	bool "POSIX clock, timer, and sleep APIs"
+	bool "POSIX clock and sleep APIs"
 	default y if POSIX_API
+	imply TIMER
 	depends on !NATIVE_LIBC
 	help
-	  This enables POSIX clock\_\*(), timer\_\*(), and \*sleep()
-	  functions.
+	  This enables POSIX clock\_\*() and \*sleep() functions.


### PR DESCRIPTION
Previously timer.c was only built with `CONFIG_POSIX_CLOCK=y` even though it has had its own Kconfig symbol (`CONFIG_TIMER`) for a very long time.

Make `POSIX_CLOCK` imply `TIMER` rather than control whether it is built, and adjust Kconfig / CMake as necessary.

Fixes #68195