### PR TITLE
Bluetooth: Controller: Fix MFIFO_DEFINE to reduce FLASH usage

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -938,17 +938,18 @@ ll_rx_get_again:
 	link = memq_peek(memq_ll_rx.head, memq_ll_rx.tail, (void **)&rx);
 	if (link) {
 #if defined(CONFIG_BT_CONN) || defined(CONFIG_BT_CTLR_ADV_ISO)
-		cmplt = tx_cmplt_get(handle, &mfifo_tx_ack.f, rx->ack_last);
+		cmplt = tx_cmplt_get(handle, &mfifo_fifo_tx_ack.f,
+				     rx->ack_last);
 		if (!cmplt) {
 			uint8_t f, cmplt_prev, cmplt_curr;
 			uint16_t h;
 
 			cmplt_curr = 0U;
-			f = mfifo_tx_ack.f;
+			f = mfifo_fifo_tx_ack.f;
 			do {
 				cmplt_prev = cmplt_curr;
 				cmplt_curr = tx_cmplt_get(&h, &f,
-							  mfifo_tx_ack.l);
+							  mfifo_fifo_tx_ack.l);
 			} while ((cmplt_prev != 0U) ||
 				 (cmplt_prev != cmplt_curr));
 #endif /* CONFIG_BT_CONN || CONFIG_BT_CTLR_ADV_ISO */
@@ -1015,7 +1016,8 @@ ll_rx_get_again:
 #if defined(CONFIG_BT_CONN) || defined(CONFIG_BT_CTLR_ADV_ISO)
 		}
 	} else {
-		cmplt = tx_cmplt_get(handle, &mfifo_tx_ack.f, mfifo_tx_ack.l);
+		cmplt = tx_cmplt_get(handle, &mfifo_fifo_tx_ack.f,
+				     mfifo_fifo_tx_ack.l);
 #endif /* CONFIG_BT_CONN || CONFIG_BT_CTLR_ADV_ISO */
 	}
 
@@ -1713,7 +1715,7 @@ void ll_rx_put(memq_link_t *link, void *rx)
 	/* Serialize Tx ack with Rx enqueue by storing reference to
 	 * last element index in Tx ack FIFO.
 	 */
-	rx_hdr->ack_last = mfifo_tx_ack.l;
+	rx_hdr->ack_last = mfifo_fifo_tx_ack.l;
 #endif /* CONFIG_BT_CONN || CONFIG_BT_CTLR_ADV_ISO */
 
 	/* Enqueue the Rx object */
@@ -2547,8 +2549,8 @@ static uint8_t tx_cmplt_get(uint16_t *handle, uint8_t *first, uint8_t last)
 	uint8_t next;
 
 	next = *first;
-	tx = mfifo_dequeue_iter_get(mfifo_tx_ack.m, mfifo_tx_ack.s,
-				    mfifo_tx_ack.n, mfifo_tx_ack.f, last,
+	tx = mfifo_dequeue_iter_get(mfifo_fifo_tx_ack.m, mfifo_tx_ack.s,
+				    mfifo_tx_ack.n, mfifo_fifo_tx_ack.f, last,
 				    &next);
 	if (!tx) {
 		return 0;
@@ -2663,8 +2665,8 @@ next_ack:
 #endif /* CONFIG_BT_CTLR_ADV_ISO || CONFIG_BT_CTLR_CONN_ISO */
 
 		*first = next;
-		tx = mfifo_dequeue_iter_get(mfifo_tx_ack.m, mfifo_tx_ack.s,
-					    mfifo_tx_ack.n, mfifo_tx_ack.f,
+		tx = mfifo_dequeue_iter_get(mfifo_fifo_tx_ack.m, mfifo_tx_ack.s,
+					    mfifo_tx_ack.n, mfifo_fifo_tx_ack.f,
 					    last, &next);
 	} while (tx && tx->handle == *handle);
 

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1384,7 +1384,7 @@ void ull_conn_link_tx_release(void *link)
 
 uint8_t ull_conn_ack_last_idx_get(void)
 {
-	return mfifo_conn_ack.l;
+	return mfifo_fifo_conn_ack.l;
 }
 
 memq_link_t *ull_conn_ack_peek(uint8_t *ack_last, uint16_t *handle,
@@ -1397,7 +1397,7 @@ memq_link_t *ull_conn_ack_peek(uint8_t *ack_last, uint16_t *handle,
 		return NULL;
 	}
 
-	*ack_last = mfifo_conn_ack.l;
+	*ack_last = mfifo_fifo_conn_ack.l;
 
 	*handle = lll_tx->handle;
 	*tx = lll_tx->node;
@@ -1410,8 +1410,8 @@ memq_link_t *ull_conn_ack_by_last_peek(uint8_t last, uint16_t *handle,
 {
 	struct lll_tx *lll_tx;
 
-	lll_tx = mfifo_dequeue_get(mfifo_conn_ack.m, mfifo_conn_ack.s,
-				   mfifo_conn_ack.f, last);
+	lll_tx = mfifo_dequeue_get(mfifo_fifo_conn_ack.m, mfifo_conn_ack.s,
+				   mfifo_fifo_conn_ack.f, last);
 	if (!lll_tx) {
 		return NULL;
 	}

--- a/subsys/bluetooth/controller/ll_sw/ull_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_internal.h
@@ -144,10 +144,10 @@ void ull_drift_ticks_get(struct node_rx_event_done *done,
  *          enqueuing pointers to memory elements with associated memq links.
  */
 #define RXFIFO_ALLOC(_name, _count) \
-	ull_rxfifo_alloc(mfifo_##_name.s, mfifo_##_name.n, mfifo_##_name.f, \
-			 &mfifo_##_name.l, mfifo_##_name.m, \
-			 &mem_pool_##_name.free, &mem_link_##_name.free, \
-			 _count)
+	ull_rxfifo_alloc(mfifo_##_name.s, mfifo_##_name.n, \
+			 mfifo_fifo_##_name.f, &mfifo_fifo_##_name.l, \
+			 mfifo_fifo_##_name.m, &mem_pool_##_name.free, \
+			 &mem_link_##_name.free, _count)
 
 /**
  * @brief Initialize and allocate MFIFO and pools
@@ -161,8 +161,9 @@ void ull_drift_ticks_get(struct node_rx_event_done *done,
  * @details Enqueues an RX node back into the FIFO.
  */
 #define RXFIFO_RELEASE(_name, _link, _rx) \
-	ull_rxfifo_release(mfifo_##_name.s, mfifo_##_name.n, mfifo_##_name.f, \
-			   &mfifo_##_name.l, mfifo_##_name.m, _link, \
+	ull_rxfifo_release(mfifo_##_name.s, mfifo_##_name.n, \
+			   mfifo_fifo_##_name.f, &mfifo_fifo_##_name.l, \
+			   mfifo_fifo_##_name.m, _link, \
 			   (struct node_rx_hdr *)_rx)
 
 void ull_rxfifo_alloc(uint8_t s, uint8_t n, uint8_t f, uint8_t *l, uint8_t *m,


### PR DESCRIPTION
Fix MFIFO_DEFINE to reduce FLASH usage by moving the pool outside the struct that is static initialized.
