### PR TITLE
posix: sched: Implement sched_setparam() and sched_setscheduler()

### DIFF
--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -380,8 +380,8 @@ _POSIX_PRIORITY_SCHEDULING
     sched_getparam(),
     sched_getscheduler(),
     sched_rr_get_interval(),
-    sched_setparam(),
-    sched_setscheduler(),
+    sched_setparam(),yes
+    sched_setscheduler(),yes
     sched_yield(),yes
 
 .. _posix_option_reader_writer_locks:

--- a/include/zephyr/posix/sched.h
+++ b/include/zephyr/posix/sched.h
@@ -51,6 +51,9 @@ int sched_get_priority_max(int policy);
 int sched_getparam(pid_t pid, struct sched_param *param);
 int sched_getscheduler(pid_t pid);
 
+int sched_setparam(pid_t pid, const struct sched_param *param);
+int sched_setscheduler(pid_t pid, int policy, const struct sched_param *param);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/posix/sched.c
+++ b/lib/posix/sched.c
@@ -70,3 +70,34 @@ int sched_getscheduler(pid_t pid)
 
 	return -1;
 }
+
+/**
+ * @brief Set scheduling parameters
+ *
+ * See IEEE 1003.1
+ */
+int sched_setparam(pid_t pid, const struct sched_param *param)
+{
+	ARG_UNUSED(pid);
+	ARG_UNUSED(param);
+
+	errno = ENOSYS;
+
+	return -1;
+}
+
+/**
+ * @brief Set scheduling policy
+ *
+ * See IEEE 1003.1
+ */
+int sched_setscheduler(pid_t pid, int policy, const struct sched_param *param)
+{
+	ARG_UNUSED(pid);
+	ARG_UNUSED(policy);
+	ARG_UNUSED(param);
+
+	errno = ENOSYS;
+
+	return -1;
+}

--- a/tests/posix/common/src/pthread.c
+++ b/tests/posix/common/src/pthread.c
@@ -405,6 +405,28 @@ ZTEST(pthread, test_sched_getscheduler)
 
 	zassert_true((rc == -1 && err == ENOSYS));
 }
+ZTEST(pthread, test_sched_setparam)
+{
+	struct sched_param param = {
+		.sched_priority = 2,
+	};
+	int rc = sched_setparam(0, &param);
+	int err = errno;
+
+	zassert_true((rc == -1 && err == ENOSYS));
+}
+
+ZTEST(pthread, test_sched_setscheduler)
+{
+	struct sched_param param = {
+		.sched_priority = 2,
+	};
+	int policy = 0;
+	int rc = sched_setscheduler(0, policy, &param);
+	int err = errno;
+
+	zassert_true((rc == -1 && err == ENOSYS));
+}
 
 ZTEST(pthread, test_pthread_equal)
 {

--- a/tests/posix/headers/src/sched_h.c
+++ b/tests/posix/headers/src/sched_h.c
@@ -35,8 +35,8 @@ ZTEST(posix_headers, test_sched_h)
 
 		/* zassert_not_null(sched_rr_get_interval); */ /* not implemented */
 
-		/* zassert_not_null(sched_setparam); */ /* not implemented */
-		/* zassert_not_null(sched_setscheduler); */ /* not implemented */
+		zassert_not_null(sched_setparam);
+		zassert_not_null(sched_setscheduler);
 
 		zassert_not_null(sched_yield);
 	}


### PR DESCRIPTION
Implement sched_setparam() and sched_setscheduler() POSIX APIs
as a part of PSE53 _POSIX_PRIORITY_SCHEDULING option group.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/66963
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/66962