### PR TITLE
west.yml: Update hal_silabs to pull request #56 | Update to GSDK 4.4.0

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -219,7 +219,7 @@ manifest:
       groups:
         - hal
     - name: hal_silabs
-      revision: 20024164aa2a79c186aedc721cf51d667eecb35a
+      revision: b11b29167f3f9a0fd0c34a8eeeb36b0c1d218917
       path: modules/hal/silabs
       groups:
         - hal


### PR DESCRIPTION
Update the copyright line in files to latest version as per gecko_sdk 4.4.0. Correction in location of se_manager in gecko/README

This is the final pull request in a series of PRs required to align the codebase of zephyr_rtos/hal_silabs (https://github.com/zephyrproject-rtos/hal_silabs) with gecko_sdk v4.4.0 (https://github.com/SiliconLabs/gecko_sdk)

PR in hal_silabs : https://github.com/zephyrproject-rtos/hal_silabs/pull/56