### PR TITLE
net: if: Do not join multicast address if IPv6 is not enabled

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -2995,10 +2995,12 @@ static void iface_ipv6_start(struct net_if *iface)
 	if (IS_ENABLED(CONFIG_NET_IPV6_DAD)) {
 		net_if_start_dad(iface);
 	} else {
-		struct net_if_ipv6 *ipv6 __unused = iface->config.ip.ipv6;
+		struct net_if_ipv6 *ipv6 = iface->config.ip.ipv6;
 
-		join_mcast_nodes(iface,
-				 &ipv6->mcast[0].address.in6_addr);
+		if (ipv6 != NULL) {
+			join_mcast_nodes(iface,
+					 &ipv6->mcast[0].address.in6_addr);
+		}
 	}
 
 	net_if_start_rs(iface);


### PR DESCRIPTION
If IPv6 is not enabled for the interface, then do not try to join the IPv6 solicited multicast address.