### PR TITLE
net: shell: Clarify the name of the virtual interface

### DIFF
--- a/subsys/net/lib/shell/iface.c
+++ b/subsys/net/lib/shell/iface.c
@@ -218,7 +218,7 @@ static void iface_cb(struct net_if *iface, void *user_data)
 			name = "<unknown>";
 		}
 
-		PR("Name      : %s\n", name);
+		PR("Virtual name : %s\n", name);
 
 		orig_iface = net_virtual_get_iface(iface);
 		if (orig_iface == NULL) {


### PR DESCRIPTION
The net-shell printed virtual interface name so that it got the impression it was the network interface name which is not correct. Now the name is printed as "Virtual name" which is unambiguous.