### PR TITLE
scripts: native_simulator: common: Fix typo in comment

### DIFF
--- a/scripts/native_simulator/common/src/include/nsi_host_trampolines.h
+++ b/scripts/native_simulator/common/src/include/nsi_host_trampolines.h
@@ -11,7 +11,7 @@
  * to the embedded side, for example due to non-basic types being used in
  * function calls, as that would break the include path isolation
  *
- * Naming convention: nsi_hots_<fun>() where <func> is the name of the equivalent
+ * Naming convention: nsi_host_<fun>() where <func> is the name of the equivalent
  * C library call we call thru.
  */
 


### PR DESCRIPTION
Fix a typo in comment describing the naming convention for nsi_host.