### PR TITLE
net: dhcpv4_server: Improve address pool range validation

### DIFF
--- a/subsys/net/lib/dhcpv4/dhcpv4_server.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4_server.c
@@ -1224,6 +1224,13 @@ int net_dhcpv4_server_start(struct net_if *iface, struct in_addr *base_addr)
 		return -EINVAL;
 	}
 
+	if ((htonl(server_addr->s_addr) >= htonl(base_addr->s_addr)) &&
+	    (htonl(server_addr->s_addr) <
+	     htonl(base_addr->s_addr) + CONFIG_NET_DHCPV4_SERVER_ADDR_COUNT)) {
+		LOG_ERR("Address pool overlaps with server address.");
+		return -EINVAL;
+	}
+
 	netmask = net_if_ipv4_get_netmask(iface);
 	if (net_ipv4_is_addr_unspecified(&netmask)) {
 		LOG_ERR("Failed to obtain subnet mask.");

--- a/tests/net/dhcpv4/server/src/main.c
+++ b/tests/net/dhcpv4/server/src/main.c
@@ -840,6 +840,25 @@ ZTEST(dhcpv4_server_tests, test_inform)
 	verify_lease_count(0, 0, 0);
 }
 
+/* Verify that the DHCP server can start and validate input properly. */
+ZTEST(dhcpv4_server_tests_no_init, test_initialization)
+{
+	struct in_addr base_addr_wrong_subnet = { { { 192, 0, 3, 10 } } };
+	struct in_addr base_addr_overlap = { { { 192, 0, 2, 1 } } };
+	int ret;
+
+	ret = net_dhcpv4_server_start(test_ctx.iface, &base_addr_wrong_subnet);
+	zassert_equal(ret, -EINVAL, "Started server for wrong subnet");
+
+	ret = net_dhcpv4_server_start(test_ctx.iface, &base_addr_overlap);
+	zassert_equal(ret, -EINVAL, "Started server for overlapping address");
+
+	ret = net_dhcpv4_server_start(test_ctx.iface, &test_base_addr);
+	zassert_ok(ret, "Failed to start server for valid address range");
+
+	net_dhcpv4_server_stop(test_ctx.iface);
+}
+
 static void dhcpv4_server_tests_before(void *fixture)
 {
 	ARG_UNUSED(fixture);
@@ -865,3 +884,5 @@ static void dhcpv4_server_tests_after(void *fixture)
 
 ZTEST_SUITE(dhcpv4_server_tests, NULL, NULL, dhcpv4_server_tests_before,
 	    dhcpv4_server_tests_after, NULL);
+
+ZTEST_SUITE(dhcpv4_server_tests_no_init, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Minor improvement for the server's address pool range validation.

Not only check if the address pool belongs to the same subnet as the server, but also that it does not overlap with the server address - otherwise the server might end up assigning its own address.