### PR TITLE
doc: mqtt: Fix incorrect usage of poll()

### DIFF
--- a/doc/connectivity/networking/api/mqtt.rst
+++ b/doc/connectivity/networking/api/mqtt.rst
@@ -109,7 +109,7 @@ application through the callback function.
 
    fds[0].fd = client_ctx.transport.tcp.sock;
    fds[0].events = ZSOCK_POLLIN;
-   poll(fds, 1, K_MSEC(5000));
+   poll(fds, 1, 5000);
 
    mqtt_input(&client_ctx);
 


### PR DESCRIPTION
The MQTT docs used K_MSEC() to provide the timeout parameter to poll(). Doing this causes a compilation error as poll() expects it's third parameter to be of type int, not k_timeout_t.