### PR TITLE
manifest: update hal_nxp

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -193,7 +193,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: e6b0d96d865da1bdda357073570a13ae95e08d9c
+      revision: ae438701d6029f4f989fe036abe4b91be51e6258
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Update hal_nxp revision to contain the fix for build error when trying to use dma_nxp_edma.c DMA driver.