### PR TITLE
drivers: gpio: fix build of BD8LB600FS on intel_adl_crb

### DIFF
--- a/drivers/gpio/gpio_bd8lb600fs.c
+++ b/drivers/gpio/gpio_bd8lb600fs.c
@@ -76,7 +76,7 @@ static int write_state(const struct device *dev, uint32_t state)
 			}
 		}
 
-		LOG_DBG("%s: configuration for instance %i: %04X (position %i)",
+		LOG_DBG("%s: configuration for instance %zu: %04X (position %i)",
 			dev->name,
 			j,
 			state_converted,


### PR DESCRIPTION
Fix the build of the gpio driver BD8LB600FS on the board intel_adl_crb.

Fixes #68219.