### PR TITLE
net: ipv6: nbr: Add IPv6 reachability confirmation API

### DIFF
--- a/subsys/net/ip/Kconfig.tcp
+++ b/subsys/net/ip/Kconfig.tcp
@@ -244,4 +244,13 @@ config NET_TCP_REJECT_CONN_WITH_RST
 	  If enabled, TCP stack will reject connection attempts on unbound ports
 	  with TCP RST packet.
 
+config NET_TCP_IPV6_ND_REACHABILITY_HINT
+	bool "Provide a reachability hint for IPv6 Neighbor Discovery"
+	depends on NET_TCP
+	depends on NET_IPV6_ND
+	help
+	  If enabled, TCP stack will inform the IPv6 Neighbor Discovery process
+	  about the active link to a specific neighbor by signaling recent
+	  "forward progress" event as described in RFC 4861.
+
 endif # NET_TCP

--- a/subsys/net/ip/ipv6.h
+++ b/subsys/net/ip/ipv6.h
@@ -386,6 +386,29 @@ static inline void net_ipv6_nbr_foreach(net_nbr_cb_t cb, void *user_data)
 #endif /* CONFIG_NET_IPV6_NBR_CACHE */
 
 /**
+ * @brief Provide a reachability hint for IPv6 Neighbor Discovery.
+ *
+ * This function is intended for upper-layer protocols to inform the IPv6
+ * Neighbor Discovery process about the active link to a specific neighbor.
+ * By signaling recent "forward progress" event, such as the reception of
+ * an ACK, this function can help reducing unnecessary ND traffic as per the
+ * guidelines in RFC 4861 (section 7.3).
+ *
+ * @param iface A pointer to the network interface.
+ * @param ipv6_addr Pointer to the IPv6 address of the neighbor node.
+ */
+#if defined(CONFIG_NET_IPV6_ND) && defined(CONFIG_NET_NATIVE_IPV6)
+void net_ipv6_nbr_reachability_hint(struct net_if *iface, const struct in6_addr *ipv6_addr);
+#else
+static inline void net_ipv6_nbr_reachability_hint(struct net_if *iface,
+						  const struct in6_addr *ipv6_addr)
+{
+	ARG_UNUSED(iface);
+	ARG_UNUSED(ipv6_addr);
+}
+#endif
+
+/**
  * @brief Set the neighbor reachable timer.
  *
  * @param iface A valid pointer on a network interface

--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -1536,6 +1536,27 @@ void net_ipv6_nbr_set_reachable_timer(struct net_if *iface,
 
 	ipv6_nd_restart_reachable_timer(nbr, time);
 }
+
+void net_ipv6_nbr_reachability_hint(struct net_if *iface,
+				    const struct in6_addr *ipv6_addr)
+{
+	struct net_nbr *nbr = NULL;
+
+	nbr = nbr_lookup(&net_neighbor.table, iface, ipv6_addr);
+
+	NET_DBG("nbr %p got rechability hint", nbr);
+
+	if (nbr && net_ipv6_nbr_data(nbr)->state != NET_IPV6_NBR_STATE_INCOMPLETE &&
+	    net_ipv6_nbr_data(nbr)->state != NET_IPV6_NBR_STATE_STATIC) {
+		ipv6_nbr_set_state(nbr, NET_IPV6_NBR_STATE_REACHABLE);
+
+		/* We might have active timer from PROBE */
+		net_ipv6_nbr_data(nbr)->reachable = 0;
+		net_ipv6_nbr_data(nbr)->reachable_timeout = 0;
+
+		net_ipv6_nbr_set_reachable_timer(iface, nbr);
+	}
+}
 #endif /* CONFIG_NET_IPV6_ND */
 
 #if defined(CONFIG_NET_IPV6_NBR_CACHE)


### PR DESCRIPTION
This commit introduces a new IPv6 API for positive reachability confirmation, as specified in `RFC 4861, Section 7.3.1`. This feature aims to enhance the effectiveness of the Neighbor Discovery mechanism, by enabling upper-layer protocols to signal that the connection makes a *"forward progress"*.

The implementation within TCP serves as a reference, and the feature is kept disabled by default to minimize impact on the existing network stack. Compliance with `RFC 4861, Appendix E.1`, was ensured by focusing on reliable handshake and acknowledgment of new data transmissions.

Though initially integrated with TCP, the API is designed for broader applicability. For example, it might be used by some UDP-based protocols that can indicate two-way communication progress.

*Background*: This functionality may help to reduce the power consumption of battery-powered devices that communicate very rarely with their peers using transport protocol capable of providing reachability confirmation. Without the optimization, the node is required to send Neighbor Solicitation (probe), 5 seconds after the data transaction happened with a node in the `STALE` state.

Below screenshot from Wireshark pcap, with ND reachability hints enabled (tested between Linux and `native_sim`)

![Screenshot from 2024-01-29 12-41-35](https://github.com/zephyrproject-rtos/zephyr/assets/5144764/b88baf06-2eb4-413f-9237-76550214f1c6)

 - **Packets 1-6**: ICMPv6 Echo Request with first Niegbor Discovery (`NS->NA`) procedures in both ways.
 - **Packets 7-8**: UDP echo message sent after `REACHABLE_TIME` expires (peer becomes `STALE`).
 - **Packets 9-12**: ICMPv6 Neighbor Discovery messages (reachability probe) in both ways (5s - `PROBE_TIME` after packets 7-8). There is no ND optimization for generic UDP messages thus the behavior stays the same.
 - **Packets 13-20**: TCP handshake and data transfer, sent after `REACHABLE_TIME` expires.
 - **Packets 21-22**: ICMPv6 Neighbor Discovery messages (reachability probe) in one way only. The `NS->NA` transaction is not triggered from the Zephyr-based device benefiting optimization implemented in this PR.
 
I also tested it against `netcat` and ND optimization is also effective for `PSH, ACK` messages when TCP connection is constantly opened.
 
 Side note: I believe that `ipv6_nbr.c` implementation is not particularly thread-safe, I will create a separate issue about this.