### PR TITLE
Enable mailbox in selected ARM boards

### DIFF
--- a/boards/arm/arduino_giga_r1/arduino_giga_r1.dtsi
+++ b/boards/arm/arduino_giga_r1/arduino_giga_r1.dtsi
@@ -38,3 +38,7 @@
 	d2ppre2 = <2>;
 	d3ppre = <2>;
 };
+
+&mailbox {
+	status = "okay";
+};

--- a/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q.dtsi
+++ b/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q.dtsi
@@ -39,3 +39,7 @@
 	d2ppre2 = <2>;
 	d3ppre = <2>;
 };
+
+&mailbox {
+	status = "okay";
+};

--- a/boards/arm/stm32h747i_disco/stm32h747i_disco.dtsi
+++ b/boards/arm/stm32h747i_disco/stm32h747i_disco.dtsi
@@ -118,3 +118,7 @@
 		     &spi5_miso_pj11 &spi5_mosi_pj10>;
 	pinctrl-names = "default";
 };
+
+&mailbox {
+	status = "okay";
+};


### PR DESCRIPTION
The mailbox peripheral is actively accessed by stm32_hsem functions, so mark the device as enabled in DTS.