### PR TITLE
Define _POSIX_C_SOURCE in a few files which use strnlen()

### DIFF
--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -6,6 +6,9 @@
 
 #define DT_DRV_COMPAT espressif_esp32_wifi
 
+#undef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(esp32_wifi, CONFIG_WIFI_LOG_LEVEL);
 

--- a/drivers/wifi/eswifi/eswifi_core.c
+++ b/drivers/wifi/eswifi/eswifi_core.c
@@ -10,6 +10,9 @@
 #define DT_DRV_COMPAT inventek_eswifi
 #endif
 
+#undef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+
 #include "eswifi_log.h"
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 

--- a/subsys/ipc/ipc_service/backends/ipc_icbmsg.c
+++ b/subsys/ipc/ipc_service/backends/ipc_icbmsg.c
@@ -75,6 +75,9 @@
  * data messages, it calls bound endpoint and it is ready to send data.
  */
 
+#undef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+
 #include <string.h>
 
 #include <zephyr/logging/log.h>

--- a/subsys/llext/shell.c
+++ b/subsys/llext/shell.c
@@ -5,6 +5,9 @@
  *
  */
 
+#undef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+
 #include <zephyr/sys/slist.h>
 #include <zephyr/kernel.h>
 #include <zephyr/shell/shell.h>


### PR DESCRIPTION
Define _POSIX_C_SOURCE in a few files which use strnlen()

As newlib does not expose by default strnlen(), we need to set this macro, otherwise we will get an
"implicit declaration" warning when building for newlib or other C libraries which do not expose it.

These cases were missed from #67052 as they were not triggered by CI as we do not build by default with newlibc.
