### PR TITLE
Bluetooth: Audio: Moved seq_num check

### DIFF
--- a/subsys/bluetooth/audio/bap_stream.c
+++ b/subsys/bluetooth/audio/bap_stream.c
@@ -245,6 +245,7 @@ static bool bt_bap_stream_can_send(const struct bt_bap_stream *stream)
 int bt_bap_stream_send(struct bt_bap_stream *stream, struct net_buf *buf,
 			 uint16_t seq_num, uint32_t ts)
 {
+	int ret;
 	struct bt_bap_ep *ep;
 
 	if (stream == NULL || stream->ep == NULL) {
@@ -265,6 +266,12 @@ int bt_bap_stream_send(struct bt_bap_stream *stream, struct net_buf *buf,
 		return -EBADMSG;
 	}
 
+	ret = bt_iso_chan_send(bt_bap_stream_iso_chan_get(stream),
+			       buf, seq_num, ts);
+	if (ret) {
+		return ret;
+	}
+
 #if defined(CONFIG_BT_BAP_DEBUG_STREAM_SEQ_NUM)
 	if (stream->_prev_seq_num != 0U && seq_num != 0U &&
 	    (stream->_prev_seq_num + 1U) != seq_num) {
@@ -277,8 +284,7 @@ int bt_bap_stream_send(struct bt_bap_stream *stream, struct net_buf *buf,
 
 	/* TODO: Add checks for broadcast sink */
 
-	return bt_iso_chan_send(bt_bap_stream_iso_chan_get(stream),
-				buf, seq_num, ts);
+	return ret;
 }
 
 int bt_bap_stream_get_tx_sync(struct bt_bap_stream *stream, struct bt_iso_tx_info *info)


### PR DESCRIPTION
Moved seq_num check to after bt_iso_chan_send.
This prevents WRN prints if ISO send fails.