### PR TITLE
boards: RAK4631: enable DCDC

### DIFF
--- a/boards/rak/rak4631/Kconfig
+++ b/boards/rak/rak4631/Kconfig
@@ -1,0 +1,18 @@
+# RAKWIRELESS RAK4631 Board configuration
+
+# Copyright (c) 2024 Kelly Helmut Lord
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_RAK4631
+
+config BOARD_ENABLE_DCDC
+	bool "DCDC mode"
+	select SOC_DCDC_NRF52X
+	default y
+
+config BOARD_ENABLE_DCDC_HV
+	bool "High Voltage DCDC converter"
+	select SOC_DCDC_NRF52X_HV
+	default y
+
+endif # BOARD_RAK4631


### PR DESCRIPTION
Enables the DCDC converters by default for the RAK4631