### PR TITLE
ipc_rpmsg_static_vrings: use names for WQ threads

### DIFF
--- a/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.c
+++ b/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.c
@@ -325,13 +325,14 @@ static int mbox_init(const struct device *instance)
 {
 	const struct backend_config_t *conf = instance->config;
 	struct backend_data_t *data = instance->data;
+	struct k_work_queue_config wq_cfg = {.name = instance->name};
 	int prio, err;
 
 	prio = (conf->wq_prio_type == PRIO_COOP) ? K_PRIO_COOP(conf->wq_prio) :
 						   K_PRIO_PREEMPT(conf->wq_prio);
 
 	k_work_queue_init(&data->mbox_wq);
-	k_work_queue_start(&data->mbox_wq, mbox_stack[conf->id], WQ_STACK_SIZE, prio, NULL);
+	k_work_queue_start(&data->mbox_wq, mbox_stack[conf->id], WQ_STACK_SIZE, prio, &wq_cfg);
 
 	if (IS_ENABLED(CONFIG_THREAD_NAME)) {
 		char name[THREAD_MAX_NAME_LEN];


### PR DESCRIPTION
This patch adds names to the threads created by `mbox_init` via `k_work_queue_start`. The name of the thread is the same as the name in the device instance.

The main reason for this (at lest for me) has to do with how `mcumgr` reports [thread information](https://docs.zephyrproject.org/latest/services/device_mgmt/smp_groups/smp_group_0.html#task-statistics-command). Specifically, data about threads is sent in a CBOR encoded map where the map keys are the thread names (at least in the default configuration). If there's more than one IPC channel defined (one example of this being `samples/subsys/logging/multidomain`), both threads would be created with an empty name and `mcumgr` will only return the data associated with the thread created by the last call to `mbox_init`.