### PR TITLE
samples: modules: nanopb: Showcase configuring options

### DIFF
--- a/doc/services/index.rst
+++ b/doc/services/index.rst
@@ -29,6 +29,7 @@ OS Services
    portability/index.rst
    poweroff.rst
    shell/index.rst
+   serialization/index.rst
    settings/index.rst
    smf/index.rst
    storage/index.rst

--- a/doc/services/serialization/index.rst
+++ b/doc/services/serialization/index.rst
@@ -1,0 +1,12 @@
+.. _seialization_reference:
+
+Serialization
+#############
+
+Zephyr has support for several data serialization subsystems. These can be used to encode/decode
+structured data with a known format on-the-wire.
+
+.. toctree::
+   :maxdepth: 1
+
+   nanopb.rst

--- a/doc/services/serialization/nanopb.rst
+++ b/doc/services/serialization/nanopb.rst
@@ -1,0 +1,70 @@
+.. _nanopb_reference:
+
+Nanopb
+######
+
+`Nanopb <https://jpa.kapsi.fi/nanopb/>`_ is a C implementation of Google's
+`Protocol Buffers <https://protobuf.dev/>`_.
+
+Requirements
+************
+
+Nanopb uses the protocol buffer compiler to generate source and header files,
+make sure the ``protoc`` executable is installed and available.
+
+.. tabs::
+
+   .. group-tab:: Ubuntu
+
+      Use ``apt`` to install dependency:
+
+         .. code-block:: shell
+
+            sudo apt install protobuf-compiler
+
+   .. group-tab:: macOS
+
+      Use ``brew`` to install dependency:
+
+         .. code-block:: shell
+
+            brew install protobuf
+
+   .. group-tab:: Windows
+
+      Use ``choco`` to install dependency:
+
+         .. code-block:: shell
+
+            choco install protoc
+
+
+Additionally, Nanopb is an optional module and needs to be added explicitly to the workspace:
+
+.. code-block:: shell
+
+   west config manifest.project-filter -- +nanopb
+   west update
+
+Configuration
+*************
+
+Make sure to include ``nanopb`` within your ``CMakeLists.txt`` file as follows:
+
+.. code-block:: cmake
+
+   list(APPEND CMAKE_MODULE_PATH ${ZEPHYR_BASE}/modules/nanopb)
+   include(nanopb)
+
+Adding ``proto`` files can be done with the ``zephyr_nanopb_sources()`` CMake function which
+ensures the generated header and source files are created before building the specified target.
+
+Nanopb has `generator options <https://jpa.kapsi.fi/nanopb/docs/reference.html#generator-options>`_
+that can be used to configure messages or fields. This allows to set fixed sizes or skip fields
+entirely.
+
+The internal CMake generator has an extension to configure ``*.options.in`` files automatically
+with CMake variables.
+
+See :zephyr_file:`samples/modules/nanopb/src/simple.options.in` and
+:zephyr_file:`samples/modules/nanopb/CMakeLists.txt` for usage example.

--- a/samples/modules/nanopb/CMakeLists.txt
+++ b/samples/modules/nanopb/CMakeLists.txt
@@ -8,6 +8,11 @@ project(nanopb_sample)
 list(APPEND CMAKE_MODULE_PATH ${ZEPHYR_BASE}/modules/nanopb)
 include(nanopb)
 
+if(CONFIG_SAMPLE_UNLUCKY_NUMBER)
+  set(unlucky_number_type "FT_DEFAULT")
+else()
+  set(unlucky_number_type "FT_IGNORE")
+endif()
 zephyr_nanopb_sources(app src/simple.proto)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/modules/nanopb/Kconfig
+++ b/samples/modules/nanopb/Kconfig
@@ -1,0 +1,14 @@
+# Private config options for nanopb app
+
+# Copyright (c) 2024 Basalte bv
+# SPDX-License-Identifier: Apache-2.0
+
+mainmenu "Nanopb protobuf sample application"
+
+config SAMPLE_BUFFER_SIZE
+	int "Simple message buffer size"
+	default 8
+	help
+	  Configure the simple message buffer field's size.
+
+source "Kconfig.zephyr"

--- a/samples/modules/nanopb/Kconfig
+++ b/samples/modules/nanopb/Kconfig
@@ -11,4 +11,9 @@ config SAMPLE_BUFFER_SIZE
 	help
 	  Configure the simple message buffer field's size.
 
+config SAMPLE_UNLUCKY_NUMBER
+	bool "Unlucky number field"
+	help
+	  Enable the unlucky number field.
+
 source "Kconfig.zephyr"

--- a/samples/modules/nanopb/README.rst
+++ b/samples/modules/nanopb/README.rst
@@ -6,50 +6,29 @@ Nanopb sample
 Overview
 ********
 
-A simple protocol buffer sample using Nanopb for serializing structured data
+A simple protocol buffer sample using :ref:`nanopb_reference` for serializing structured data
 to platform independent raw buffers or streams.
 
+The structured data to encode/decode is presented as follows:
 
-Requirements
-************
+.. code-block:: proto
 
-Nanopb uses the protocol buffer compiler to generate source and header files,
-make sure the ``protoc`` executable is installed and available.
+   syntax = "proto3";
 
-.. tabs::
+   message SimpleMessage {
+       int32 lucky_number = 1;
+       bytes buffer = 2;
+       int32 unlucky_number = 3;
+   }
 
-   .. group-tab:: Ubuntu
+Configuration
+*************
 
-      Use ``apt`` to install dependency:
+This sample uses two configuration options to modify the behavior.
 
-         .. code-block:: shell
-
-            sudo apt install protobuf-compiler
-
-   .. group-tab:: macOS
-
-      Use ``brew`` to install dependency:
-
-         .. code-block:: shell
-
-            brew install protobuf
-
-   .. group-tab:: Windows
-
-      Use ``choco`` to install dependency:
-
-         .. code-block:: shell
-
-            choco install protoc
-
-
-Additionally Nanopb is an optional module and needs to be added explicitly to the workspace:
-
-.. code-block:: shell
-
-   west config manifest.project-filter -- +nanopb
-   west update
-
+* :kconfig:option:`CONFIG_SAMPLE_BUFFER_SIZE` sets the ``buffer`` field's size
+* :kconfig:option:`CONFIG_SAMPLE_UNLUCKY_NUMBER` either enables or disables the ``unlucky_number``
+  field.
 
 Building and Running
 ********************

--- a/samples/modules/nanopb/src/main.c
+++ b/samples/modules/nanopb/src/main.c
@@ -33,6 +33,9 @@ bool encode_message(uint8_t *buffer, size_t buffer_size, size_t *message_length)
 	for (int i = 0; i < 8; ++i) {
 		message.buffer[i] = (uint8_t)(i * 2);
 	}
+#ifdef CONFIG_SAMPLE_UNLUCKY_NUMBER
+	message.unlucky_number = 42;
+#endif
 
 	/* Now we are ready to encode the message! */
 	status = pb_encode(&stream, SimpleMessage_fields, &message);
@@ -67,6 +70,9 @@ bool decode_message(uint8_t *buffer, size_t message_length)
 			printk("%s%d", ((i == 0) ? "" : ", "), (int) message.buffer[i]);
 		}
 		printk("\n");
+#ifdef CONFIG_SAMPLE_UNLUCKY_NUMBER
+		printk("Your unlucky number was %d!\n", (int)message.unlucky_number);
+#endif
 	} else {
 		printk("Decoding failed: %s\n", PB_GET_ERROR(&stream));
 	}

--- a/samples/modules/nanopb/src/simple.options
+++ b/samples/modules/nanopb/src/simple.options
@@ -1,1 +1,0 @@
-SimpleMessage.buffer max_size:8 fixed_length:true

--- a/samples/modules/nanopb/src/simple.options.in
+++ b/samples/modules/nanopb/src/simple.options.in
@@ -1,1 +1,2 @@
 SimpleMessage.buffer max_size:@CONFIG_SAMPLE_BUFFER_SIZE@ fixed_length:true
+SimpleMessage.unlucky_number type:@unlucky_number_type@

--- a/samples/modules/nanopb/src/simple.options.in
+++ b/samples/modules/nanopb/src/simple.options.in
@@ -1,0 +1,1 @@
+SimpleMessage.buffer max_size:@CONFIG_SAMPLE_BUFFER_SIZE@ fixed_length:true

--- a/samples/modules/nanopb/src/simple.proto
+++ b/samples/modules/nanopb/src/simple.proto
@@ -6,4 +6,5 @@ syntax = "proto3";
 message SimpleMessage {
     int32 lucky_number = 1;
     bytes buffer = 2;
+    int32 unlucky_number = 3;
 }

--- a/submanifests/optional.yaml
+++ b/submanifests/optional.yaml
@@ -22,7 +22,7 @@ manifest:
       groups:
         - optional
     - name: nanopb
-      revision: 42fa8b211e946b90b9d968523fce7b1cfe27617e
+      revision: 65cbefb4695bc7af1cb733ced99618afb3586b20
       path: modules/lib/nanopb
       remote: upstream
       groups:


### PR DESCRIPTION
The latest version of nanopb allows for using kconfig symbols in files with an `options.in` extension.

See https://github.com/nanopb/nanopb/pull/936 