### PR TITLE
Improve STM32H7B3I DK configuration to run LVGL

### DIFF
--- a/boards/st/stm32h7b3i_dk/CMakeLists.txt
+++ b/boards/st/stm32h7b3i_dk/CMakeLists.txt
@@ -1,0 +1,9 @@
+#
+# Copyright (c) Charles Dias <charlesdias.cd@outlook.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Add custom linker section to relocate framebuffers to PSRAM
+zephyr_linker_sources_ifdef(CONFIG_LV_Z_VBD_CUSTOM_SECTION
+  SECTIONS dc_ram.ld)

--- a/boards/st/stm32h7b3i_dk/Kconfig.defconfig
+++ b/boards/st/stm32h7b3i_dk/Kconfig.defconfig
@@ -1,6 +1,7 @@
 # STM32H7B3I DISCOVERY KIT board configuration
 
 # Copyright (c) 2022 Byte-Lab d.o.o. <dev@byte-lab.com>
+# Copyright (c) 2024 Charles Dias <charlesdias.cd@outlook.com>
 # SPDX-License-Identifier: Apache-2.0
 
 if BOARD_STM32H7B3I_DK
@@ -15,5 +16,39 @@ config INPUT_FT5336_INTERRUPT
 # display buffer to external SDRAM connected to FMC
 config MEMC
 	default y if DISPLAY
+
+if LVGL
+
+config CACHE_MANAGEMENT
+	default y
+
+config LV_USE_GPU_STM32_DMA2D
+	default y
+
+config LV_GPU_DMA2D_CMSIS_INCLUDE
+	default "stm32h7xx.h"
+
+config STM32_LTDC_FB_NUM
+	default 2
+
+config LV_Z_VDB_SIZE
+	default 100
+
+config LV_Z_DOUBLE_VDB
+	default y
+
+config LV_Z_FULL_REFRESH
+	default y
+
+config LV_Z_VBD_CUSTOM_SECTION
+	default y
+
+config LV_Z_FLUSH_THREAD
+	default y
+
+config LV_Z_BITS_PER_PIXEL
+	default 16 if STM32_LTDC_RGB565
+
+endif # LVGL
 
 endif # BOARD_STM32H7B3I_DK

--- a/boards/st/stm32h7b3i_dk/dc_ram.ld
+++ b/boards/st/stm32h7b3i_dk/dc_ram.ld
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Charles Dias <charlesdias.cd@outlook.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(sdram2), okay)
+GROUP_START(SDRAM2)
+
+	SECTION_PROLOGUE(_STM32_SDRAM2_SECTION_NAME, (NOLOAD),)
+	{
+		*(.lvgl_buf)
+	} GROUP_LINK_IN(SDRAM2)
+
+GROUP_END(SDRAM2)
+#endif

--- a/boards/st/stm32h7b3i_dk/doc/index.rst
+++ b/boards/st/stm32h7b3i_dk/doc/index.rst
@@ -1,6 +1,6 @@
 .. _stm32h7b3i_dk_board:
 
-ST STM32H7B3I Discovery Kit
+ST STM32H7B3I Discovery kit
 ###########################
 
 Overview
@@ -21,16 +21,77 @@ camera, SDRAM, Octo-SPI Flash memory and RGB interface LCD with capacitive touch
 panel). ARDUINO® Uno V3 connectors provide easy connection to extension shields or
 daughterboards for specific applications.
 
-STLINK-V3E is integrated into the board, as an embedded in-circuit debugger and
-programmer for the STM32 MCU and the USB Virtual COM port bridge. The STM32H7B3I-DK
-board comes with the STM32CubeH7 MCU Package, which provides an STM32 comprehensive
-software HAL library as well as various software examples.
+Important board features include:
+
+- STM32H7B3LIH6Q microcontroller featuring 2 Mbytes of Flash memory and 1.4 Mbyte of RAM in BGA225 package
+- 4.3" (480x272 pixels) TFT color LCD module including a capacitive touch panel with RGB interface
+- Wi-Fi |reg| module compliant with 802.11 b/g/n
+- USB OTG HS
+- Audio codec
+- 512-Mbit Octo-SPI NOR Flash memory
+- 128-Mbit SDRAM
+- 2 user LEDs
+- User and Reset push-buttons
+- Fanout daughterboard
+- 1x FDCAN
+- Board connectors:
+   - Camera (8 bit)
+   - USB with Micro-AB
+   - Stereo headset jack including analog microphone input
+   - Audio jack for external speakers
+   - microSD |trade| card
+   - TAG-Connect 10-pin footprint
+   - Arm |reg| Cortex |reg| 10-pin 1.27mm-pitch debug connector over STDC14 footprint
+   - ARDUINO |reg| Uno V3 expansion connector
+   - STMod+ expansion connector
+   - Audio daughterboard expansion connector
+   - External I2C expansion connector
+- Flexible power-supply options:
+   - ST-LINK USB VBUS, USB OTG HS connector, or external sources
+- On-board STLINK-V3E debugger/programmer with USB re-enumeration capability
 
 .. image:: img/stm32h7b3i_dk.jpg
      :align: center
      :alt: STM32H7B3I-DK
 
 More information about the board can be found at the `STM32H7B3I-DK website`_.
+
+Hardware
+********
+
+The STM32H7B3I Discovery kit provides the following hardware components:
+
+- STM32H7B3LIH6Q in BGA225 package
+- ARM |reg| 32-bit Cortex |reg| -M7 CPU with FPU
+- 280 MHz max CPU frequency
+- VDD from 1.62 V to 3.6 V
+- 2 MB Flash
+- ~1.4 Mbytes SRAM
+- 32-bit timers(2)
+- 16-bit timers(15)
+- SPI(6)
+- I2C(4)
+- I2S (4)
+- USART(5)
+- UART(5)
+- USB OTG Full Speed and High Speed(1)
+- CAN FD(2)
+- 2xSAI (serial audio interface)
+- SPDIFRX interface(1)
+- HDMI-CEC(1)
+- Octo-SPI memory interfaces with on-the-fly decryption(2)
+- 8- to 14-bit camera interface (1)
+- 8-/16-bit parallel synchronous data input/output slave interface (PSSI)
+- GPIO (up to 168) with external interrupt capability
+- 16-bit ADC(2) with 24 channels / 3.6 MSPS
+- 1x12-bit single-channel DAC + 1x12-bit dual-channel DAC
+- True Random Number Generator (RNG)
+- 5 DMA controllers
+- LCD-TFT Controller with XGA resolution
+- Chrom-ART graphical hardware Accelerator (DMA2D)
+- Hardware JPEG Codec
+- Chrom-GRC™ (GFXMMU)
+
 More information about STM32H7B3 can be found here:
 
 - `STM32H7A3/7B3 on www.st.com`_
@@ -56,6 +117,12 @@ The current Zephyr stm32h7b3i_dk board configuration supports the following hard
 +-----------+------------+-------------------------------------+
 | I2C       | on-chip    | i2c                                 |
 +-----------+------------+-------------------------------------+
+| SDMMC     | on-chip    | disk access                         |
++-----------+------------+-------------------------------------+
+| SPI       | on-chip    | spi                                 |
++-----------+------------+-------------------------------------+
+| OSPI NOR  | on-chip    | off-chip flash                      |
++-----------+------------+-------------------------------------+
 | FLASH     | on-chip    | flash memory                        |
 +-----------+------------+-------------------------------------+
 | FMC       | on-chip    | memc (SDRAM)                        |
@@ -74,10 +141,16 @@ The default configuration can be found in the defconfig file:
 Pin Mapping
 ===========
 
-For more details please refer to `STM32H7B3I-DK website`_.
+STM32H7B3I Discovery kit has 11 GPIO controllers. These controllers are responsible for pin muxing,
+input/output, pull-up, etc.
+
+For more details please refer to `STM32H7B3I-DK board User Manual`_.
 
 Default Zephyr Peripheral Mapping:
 ----------------------------------
+
+The STM32H7B3I Discovery kit features an Arduino Uno V3 connector. Board is
+configured as follows
 
 - UART_1 TX/RX : PA9/PA10 (ST-Link Virtual Port Com)
 - UART_4 TX/RX : PH13/PH14 (Arduino Serial)
@@ -101,7 +174,7 @@ Default Zephyr Peripheral Mapping:
 
     - R0-R7 : PI15/PJ0/PJ1/PJ2/PJ3/PJ4/PJ5/PJ6
     - G0-G7 : PJ7/PJ8/PJ9/PJ10/PJ11/PK0/PK1/PK2
-    - B0-B7 : PJ12/PK13/PJ14/PJ15/PK3/PK4/PK5/PK6
+    - B0-B7 : PJ12/PJ13/PJ14/PJ15/PK3/PK4/PK5/PK6
     - DE/CLK/HSYNC/VSYNC : PK7/PI14/PI12/PI13
 
 
@@ -115,26 +188,51 @@ by the PLL clock at 280MHz. PLL clock is fed by a 24MHz high speed external cloc
 Serial Port
 ===========
 
-The STM32H7B3I Discovery kit has up to 8 UARTs.
-The Zephyr console output is assigned to UART1 which connected to the onboard
-ST-LINK/V3.0. Virtual COM port interface. Default communication settings are
-115200 8N1.
+The STM32H7B3I Discovery kit has up to 10 UARTs. The Zephyr console output is assigned
+to UART1 which is connected to the onboard STLINK-V3E. Virtual COM port interface
+default communication settings are 115200 8N1.
 
 
 Programming and Debugging
 *************************
 
-See :ref:`build_an_application` for more information about application builds.
-
+Applications for the ``stm32h7b3i_dk`` board configuration can be built and
+flashed in the usual way (see :ref:`build_an_application` and
+:ref:`application_run` for more details).
 
 Flashing
 ========
 
-Flashing operation will depend on the target to be flashed and the SoC
-option bytes configuration.
-It is advised to use `STM32CubeProgrammer`_ to check and update option bytes
-configuration and flash the ``stm32h7b3i_dk`` target.
+STM32H7B3I Discovery kit includes an STLINK-V3E embedded debug tool interface.
+This interface is supported by the openocd version included in the Zephyr SDK.
 
+Flashing may depend on the SoC option bytes configuration, which can be checked and
+updated using `STM32CubeProgrammer`_.
+
+Flashing an application to STM32H7B3I
+-------------------------------------
+
+First, connect the STM32H7B3I Discovery kit to your host computer using
+the USB port to prepare it for flashing. Then build and flash your application.
+
+Here is an example for the :ref:`hello_world` application.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: stm32h7b3i_dk
+   :goals: build flash
+
+Run a serial host program to connect with your board:
+
+.. code-block:: console
+
+   $ minicom -D /dev/ttyACM0
+
+You should see the following message on the console:
+
+.. code-block:: console
+
+   Hello World! arm
 
 Debugging
 =========
@@ -150,6 +248,9 @@ You can debug an application in the usual way.  Here is an example for the
 
 .. _STM32H7B3I-DK website:
    https://www.st.com/en/evaluation-tools/stm32h7b3i-dk.html
+
+.. _STM32H7B3I-DK board User Manual:
+   https://www.st.com/resource/en/user_manual/um2569-discovery-kit-with-stm32h7b3li-mcu-stmicroelectronics.pdf
 
 .. _STM32H7A3/7B3 on www.st.com:
    https://www.st.com/en/microcontrollers-microprocessors/stm32h7a3-7b3.html

--- a/boards/st/stm32h7b3i_dk/stm32h7b3i_dk.dts
+++ b/boards/st/stm32h7b3i_dk/stm32h7b3i_dk.dts
@@ -55,7 +55,8 @@
 		device_type = "memory";
 		reg = <0xd0000000 DT_SIZE_M(16)>;
 		zephyr,memory-region = "SDRAM2";
-		zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_RAM) )>;
+		/* Frame buffer memory cache will cause screen flickering. */
+		zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE) )>;
 	};
 
 	transceiver0: can-phy0 {


### PR DESCRIPTION
Using the default configuration, the FPS range is 12 to 17, while CPU usage often reaches maximum capacity. 

https://github.com/zephyrproject-rtos/zephyr/assets/27859307/d2a8b386-4094-4f9a-8b44-506bf1f28412

After updating the defconfig, it was possible to keep the 33 FSP with less CPU usage.

- enable ICache,  DCache, and cache management.
- enable Chrom-ART.
- enable double frame buffer and full refresh.
- set bits per pixel to 16 if the RGB565 is used.

https://github.com/zephyrproject-rtos/zephyr/assets/27859307/9b7564e2-36a0-4227-9a99-39e48c82daa0
