### PR TITLE
usb: device_next: implementation of USB device support notification

### DIFF
--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -16,6 +16,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/usb/usb_ch9.h>
+#include <zephyr/usb/usbd_msg.h>
 #include <zephyr/net/buf.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/slist.h>
@@ -167,6 +168,8 @@ struct usbd_contex {
 	struct k_mutex mutex;
 	/** Pointer to UDC device */
 	const struct device *dev;
+	/** Notification message recipient callback */
+	usbd_msg_cb_t msg_cb;
 	/** Middle layer runtime data */
 	struct usbd_ch9_data ch9_data;
 	/** slist to manage descriptors like string, bos */
@@ -499,6 +502,17 @@ int usbd_register_class(struct usbd_contex *uds_ctx,
 int usbd_unregister_class(struct usbd_contex *uds_ctx,
 			  const char *name,
 			  uint8_t cfg);
+
+/**
+ * @brief Register USB notification message callback
+ *
+ * @param[in] uds_ctx Pointer to USB device support context
+ * @param[in] cb      Pointer to message callback function
+ *
+ * @return 0 on success, other values on fail.
+ */
+int usbd_msg_register_cb(struct usbd_contex *const uds_ctx,
+			 const usbd_msg_cb_t cb);
 
 /**
  * @brief Initialize USB device

--- a/include/zephyr/usb/usbd_msg.h
+++ b/include/zephyr/usb/usbd_msg.h
@@ -44,6 +44,10 @@ enum usbd_msg_type {
 	USBD_MSG_UDC_ERROR,
 	/** Unrecoverable device stack error message  */
 	USBD_MSG_STACK_ERROR,
+	/** CDC ACM Line Coding update */
+	USBD_MSG_CDC_ACM_LINE_CODING,
+	/** CDC ACM Line State update */
+	USBD_MSG_CDC_ACM_CONTROL_LINE_STATE,
 	/** Maximum number of message types */
 	USBD_MSG_MAX_NUMBER,
 };
@@ -57,6 +61,8 @@ static const char *const usbd_msg_type_list[] = {
 	"Bus reset",
 	"Controller error",
 	"Stack error",
+	"CDC ACM line coding",
+	"CDC ACM control line state",
 };
 
 BUILD_ASSERT(ARRAY_SIZE(usbd_msg_type_list) == USBD_MSG_MAX_NUMBER,

--- a/include/zephyr/usb/usbd_msg.h
+++ b/include/zephyr/usb/usbd_msg.h
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief USB support message types and structure
+ */
+
+#ifndef ZEPHYR_INCLUDE_USBD_MSG_H_
+#define ZEPHYR_INCLUDE_USBD_MSG_H_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @defgroup usbd_msg_api USB device core API
+ * @ingroup usb
+ * @{
+ */
+
+/**
+ * @brief USB device support message types
+ *
+ * The first set of message types map to event types from the UDC driver API.
+ */
+enum usbd_msg_type {
+	/** VBUS ready message (optional) */
+	USBD_MSG_VBUS_READY,
+	/** VBUS removed message (optional) */
+	USBD_MSG_VBUS_REMOVED,
+	/** Device resume message */
+	USBD_MSG_RESUME,
+	/** Device suspended message */
+	USBD_MSG_SUSPEND,
+	/** Bus reset detected */
+	USBD_MSG_RESET,
+	/** Non-correctable UDC error message  */
+	USBD_MSG_UDC_ERROR,
+	/** Unrecoverable device stack error message  */
+	USBD_MSG_STACK_ERROR,
+	/** Maximum number of message types */
+	USBD_MSG_MAX_NUMBER,
+};
+
+
+static const char *const usbd_msg_type_list[] = {
+	"VBUS ready",
+	"VBUS removed",
+	"Device resumed",
+	"Device suspended",
+	"Bus reset",
+	"Controller error",
+	"Stack error",
+};
+
+BUILD_ASSERT(ARRAY_SIZE(usbd_msg_type_list) == USBD_MSG_MAX_NUMBER,
+	     "Number of entries in usbd_msg_type_list is not equal to USBD_MSG_MAX_NUMBER");
+
+/**
+ * @brief USB device message
+ */
+struct usbd_msg {
+	/** Message type */
+	enum usbd_msg_type type;
+	/** Message status, value or data */
+	union {
+		int status;
+		const struct device *dev;
+	};
+};
+
+/**
+ * @brief Callback type definition for USB device message delivery
+ *
+ * The implementation uses the system workqueue, and a callback provided and
+ * registered by the application. The application callback is called in the
+ * context of the system workqueue. Notification messages are stored in a queue
+ * and delivered to the callback in sequence.
+ *
+ * @param[in] msg Pointer to USB device message
+ */
+typedef void (*usbd_msg_cb_t)(const struct usbd_msg *const msg);
+
+/**
+ * @brief Returns the message type as a constant string
+ *
+ * @param[in] type USBD message type
+ *
+ * @return Message type as a constant string
+ */
+static inline const char *usbd_msg_type_string(const enum usbd_msg_type type)
+{
+	if (type >= 0 && type < USBD_MSG_MAX_NUMBER) {
+		return usbd_msg_type_list[type];
+	}
+
+	return "?";
+}
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_USBD_MSG_H_ */

--- a/samples/subsys/usb/cdc_acm/src/main.c
+++ b/samples/subsys/usb/cdc_acm/src/main.c
@@ -26,6 +26,8 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(cdc_acm_echo, LOG_LEVEL_INF);
 
+const struct device *const uart_dev = DEVICE_DT_GET_ONE(zephyr_cdc_acm_uart);
+
 #define RING_BUF_SIZE 1024
 uint8_t ring_buffer[RING_BUF_SIZE];
 
@@ -33,14 +35,46 @@ struct ring_buf ringbuf;
 
 static bool rx_throttled;
 
+static inline void print_baudrate(const struct device *dev)
+{
+	uint32_t baudrate;
+	int ret;
+
+	ret = uart_line_ctrl_get(dev, UART_LINE_CTRL_BAUD_RATE, &baudrate);
+	if (ret) {
+		LOG_WRN("Failed to get baudrate, ret code %d", ret);
+	} else {
+		LOG_INF("Baudrate %u", baudrate);
+	}
+}
+
 #if defined(CONFIG_USB_DEVICE_STACK_NEXT)
 static struct usbd_contex *sample_usbd;
+K_SEM_DEFINE(dtr_sem, 0, 1);
+
+static void sample_msg_cb(const struct usbd_msg *msg)
+{
+	LOG_INF("USBD message: %s", usbd_msg_type_string(msg->type));
+
+	if (msg->type == USBD_MSG_CDC_ACM_CONTROL_LINE_STATE) {
+		uint32_t dtr = 0U;
+
+		uart_line_ctrl_get(msg->dev, UART_LINE_CTRL_DTR, &dtr);
+		if (dtr) {
+			k_sem_give(&dtr_sem);
+		}
+	}
+
+	if (msg->type == USBD_MSG_CDC_ACM_LINE_CODING) {
+		print_baudrate(msg->dev);
+	}
+}
 
 static int enable_usb_device_next(void)
 {
 	int err;
 
-	sample_usbd = sample_usbd_init_device(NULL);
+	sample_usbd = sample_usbd_init_device(sample_msg_cb);
 	if (sample_usbd == NULL) {
 		LOG_ERR("Failed to initialize USB device");
 		return -ENODEV;
@@ -121,12 +155,9 @@ static void interrupt_handler(const struct device *dev, void *user_data)
 
 int main(void)
 {
-	const struct device *dev;
-	uint32_t baudrate, dtr = 0U;
 	int ret;
 
-	dev = DEVICE_DT_GET_ONE(zephyr_cdc_acm_uart);
-	if (!device_is_ready(dev)) {
+	if (!device_is_ready(uart_dev)) {
 		LOG_ERR("CDC ACM device not ready");
 		return 0;
 	}
@@ -146,8 +177,13 @@ int main(void)
 
 	LOG_INF("Wait for DTR");
 
+#if defined(CONFIG_USB_DEVICE_STACK_NEXT)
+	k_sem_take(&dtr_sem, K_FOREVER);
+#else
 	while (true) {
-		uart_line_ctrl_get(dev, UART_LINE_CTRL_DTR, &dtr);
+		uint32_t dtr = 0U;
+
+		uart_line_ctrl_get(uart_dev, UART_LINE_CTRL_DTR, &dtr);
 		if (dtr) {
 			break;
 		} else {
@@ -155,16 +191,17 @@ int main(void)
 			k_sleep(K_MSEC(100));
 		}
 	}
+#endif
 
 	LOG_INF("DTR set");
 
 	/* They are optional, we use them to test the interrupt endpoint */
-	ret = uart_line_ctrl_set(dev, UART_LINE_CTRL_DCD, 1);
+	ret = uart_line_ctrl_set(uart_dev, UART_LINE_CTRL_DCD, 1);
 	if (ret) {
 		LOG_WRN("Failed to set DCD, ret code %d", ret);
 	}
 
-	ret = uart_line_ctrl_set(dev, UART_LINE_CTRL_DSR, 1);
+	ret = uart_line_ctrl_set(uart_dev, UART_LINE_CTRL_DSR, 1);
 	if (ret) {
 		LOG_WRN("Failed to set DSR, ret code %d", ret);
 	}
@@ -172,16 +209,13 @@ int main(void)
 	/* Wait 100ms for the host to do all settings */
 	k_msleep(100);
 
-	ret = uart_line_ctrl_get(dev, UART_LINE_CTRL_BAUD_RATE, &baudrate);
-	if (ret) {
-		LOG_WRN("Failed to get baudrate, ret code %d", ret);
-	} else {
-		LOG_INF("Baudrate detected: %d", baudrate);
-	}
-
-	uart_irq_callback_set(dev, interrupt_handler);
+#ifndef CONFIG_USB_DEVICE_STACK_NEXT
+	print_baudrate(uart_dev);
+#endif
+	uart_irq_callback_set(uart_dev, interrupt_handler);
 
 	/* Enable rx interrupts */
-	uart_irq_rx_enable(dev);
+	uart_irq_rx_enable(uart_dev);
+
 	return 0;
 }

--- a/samples/subsys/usb/cdc_acm/src/main.c
+++ b/samples/subsys/usb/cdc_acm/src/main.c
@@ -40,7 +40,7 @@ static int enable_usb_device_next(void)
 {
 	int err;
 
-	sample_usbd = sample_usbd_init_device();
+	sample_usbd = sample_usbd_init_device(NULL);
 	if (sample_usbd == NULL) {
 		LOG_ERR("Failed to initialize USB device");
 		return -ENODEV;

--- a/samples/subsys/usb/common/sample_usbd.h
+++ b/samples/subsys/usb/common/sample_usbd.h
@@ -27,6 +27,6 @@
  * It returns the configured and initialized USB device context on success,
  * otherwise it returns NULL.
  */
-struct usbd_contex *sample_usbd_init_device(void);
+struct usbd_contex *sample_usbd_init_device(usbd_msg_cb_t msg_cb);
 
 #endif /* ZEPHYR_SAMPLES_SUBSYS_USB_COMMON_SAMPLE_USBD_H */

--- a/samples/subsys/usb/common/sample_usbd_init.c
+++ b/samples/subsys/usb/common/sample_usbd_init.c
@@ -33,7 +33,7 @@ USBD_CONFIGURATION_DEFINE(sample_config,
 			  attributes,
 			  CONFIG_SAMPLE_USBD_MAX_POWER);
 
-struct usbd_contex *sample_usbd_init_device(void)
+struct usbd_contex *sample_usbd_init_device(usbd_msg_cb_t msg_cb)
 {
 	int err;
 
@@ -91,6 +91,14 @@ struct usbd_contex *sample_usbd_init_device(void)
 					    USB_BCC_MISCELLANEOUS, 0x02, 0x01);
 	} else {
 		usbd_device_set_code_triple(&sample_usbd, 0, 0, 0);
+	}
+
+	if (msg_cb != NULL) {
+		err = usbd_msg_register_cb(&sample_usbd, msg_cb);
+		if (err) {
+			LOG_ERR("Failed to register message callback");
+			return NULL;
+		}
 	}
 
 	err = usbd_init(&sample_usbd);

--- a/samples/subsys/usb/console/src/main.c
+++ b/samples/subsys/usb/console/src/main.c
@@ -22,7 +22,7 @@ static int enable_usb_device_next(void)
 {
 	int err;
 
-	sample_usbd = sample_usbd_init_device();
+	sample_usbd = sample_usbd_init_device(NULL);
 	if (sample_usbd == NULL) {
 		return -ENODEV;
 	}

--- a/samples/subsys/usb/mass/src/main.c
+++ b/samples/subsys/usb/mass/src/main.c
@@ -54,7 +54,7 @@ static int enable_usb_device_next(void)
 {
 	int err;
 
-	sample_usbd = sample_usbd_init_device();
+	sample_usbd = sample_usbd_init_device(NULL);
 	if (sample_usbd == NULL) {
 		LOG_ERR("Failed to initialize USB device");
 		return -ENODEV;

--- a/samples/subsys/usb/uac2_explicit_feedback/src/main.c
+++ b/samples/subsys/usb/uac2_explicit_feedback/src/main.c
@@ -285,7 +285,7 @@ int main(void)
 
 	usbd_uac2_set_ops(dev, &usb_audio_ops, &main_ctx);
 
-	sample_usbd = sample_usbd_init_device();
+	sample_usbd = sample_usbd_init_device(NULL);
 	if (sample_usbd == NULL) {
 		return -ENODEV;
 	}

--- a/subsys/usb/device_next/CMakeLists.txt
+++ b/subsys/usb/device_next/CMakeLists.txt
@@ -14,6 +14,7 @@ zephyr_library_sources(
 	usbd_class.c
 	usbd_interface.c
 	usbd_endpoint.c
+	usbd_msg.c
 )
 
 zephyr_library_sources_ifdef(

--- a/subsys/usb/device_next/Kconfig
+++ b/subsys/usb/device_next/Kconfig
@@ -40,6 +40,13 @@ config USBD_MAX_UDC_MSG
 	help
 	  Maximum number of USB device controller events that can be queued.
 
+config USBD_MSG_SLAB_COUNT
+	int "Maximum number of USB device notification messages"
+	range 4 64
+	default 8
+	help
+	  Maximum number of USB device notification messages that can be queued.
+
 rsource "class/Kconfig"
 
 endif # USB_DEVICE_STACK_NEXT

--- a/subsys/usb/device_next/class/usbd_cdc_acm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_acm.c
@@ -18,6 +18,8 @@
 
 #include <zephyr/drivers/usb/udc.h>
 
+#include "usbd_msg.h"
+
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(usbd_cdc_acm, CONFIG_USBD_CDC_ACM_LOG_LEVEL);
 
@@ -359,6 +361,7 @@ static int usbd_cdc_acm_ctd(struct usbd_class_node *const c_nd,
 			    const struct usb_setup_packet *const setup,
 			    const struct net_buf *const buf)
 {
+	struct usbd_contex *uds_ctx = c_nd->data->uds_ctx;
 	const struct device *dev = c_nd->data->priv;
 	struct cdc_acm_uart_data *data = dev->data;
 	size_t len;
@@ -373,11 +376,13 @@ static int usbd_cdc_acm_ctd(struct usbd_class_node *const c_nd,
 
 		memcpy(&data->line_coding, buf->data, len);
 		cdc_acm_update_uart_cfg(data);
+		usbd_msg_pub_device(uds_ctx, USBD_MSG_CDC_ACM_LINE_CODING, dev);
 		return 0;
 
 	case SET_CONTROL_LINE_STATE:
 		data->line_state = setup->wValue;
 		cdc_acm_update_linestate(data);
+		usbd_msg_pub_device(uds_ctx, USBD_MSG_CDC_ACM_CONTROL_LINE_STATE, dev);
 		return 0;
 
 	default:

--- a/subsys/usb/device_next/usbd_msg.c
+++ b/subsys/usb/device_next/usbd_msg.c
@@ -94,3 +94,16 @@ void usbd_msg_pub_simple(struct usbd_contex *const ctx,
 		usbd_msg_pub(ctx, msg);
 	}
 }
+
+void usbd_msg_pub_device(struct usbd_contex *const ctx,
+			 const enum usbd_msg_type type, const struct device *const dev)
+{
+	const struct usbd_msg msg = {
+		.type = type,
+		.dev = dev,
+	};
+
+	if (ctx->msg_cb != NULL) {
+		usbd_msg_pub(ctx, msg);
+	}
+}

--- a/subsys/usb/device_next/usbd_msg.c
+++ b/subsys/usb/device_next/usbd_msg.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <zephyr/kernel.h>
+#include <zephyr/init.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/usb/usbd.h>
+
+#include "usbd_device.h"
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(usbd_msg, CONFIG_USBD_LOG_LEVEL);
+
+static void msg_work_handler(struct k_work *work);
+static K_WORK_DEFINE(msg_work, msg_work_handler);
+K_FIFO_DEFINE(msg_queue);
+
+struct usbd_msg_pkt {
+	sys_snode_t node;
+	struct usbd_contex *ctx;
+	struct usbd_msg msg;
+};
+
+K_MEM_SLAB_DEFINE_STATIC(usbd_msg_slab, sizeof(struct usbd_msg_pkt),
+			 CONFIG_USBD_MSG_SLAB_COUNT, sizeof(void *));
+
+static inline void usbd_msg_pub(struct usbd_contex *const ctx,
+				const struct usbd_msg msg)
+{
+	struct usbd_msg_pkt *m_pkt;
+
+	if (k_mem_slab_alloc(&usbd_msg_slab, (void **)&m_pkt, K_NO_WAIT)) {
+		LOG_DBG("Failed to allocate message memory");
+		return;
+	}
+
+	m_pkt->ctx = ctx;
+	m_pkt->msg = msg;
+
+	k_fifo_put(&msg_queue, m_pkt);
+	if (k_work_submit(&msg_work) < 0) {
+		__ASSERT(false, "Failed to submit work");
+	}
+}
+
+static void msg_work_handler(struct k_work *work)
+{
+	struct usbd_msg_pkt *m_pkt;
+
+	m_pkt = k_fifo_get(&msg_queue, K_NO_WAIT);
+	if (m_pkt != NULL) {
+		m_pkt->ctx->msg_cb(&m_pkt->msg);
+		k_mem_slab_free(&usbd_msg_slab, (void *)m_pkt);
+	}
+
+	if (!k_fifo_is_empty(&msg_queue)) {
+		(void)k_work_submit(work);
+	}
+}
+
+int usbd_msg_register_cb(struct usbd_contex *const uds_ctx,
+			 const usbd_msg_cb_t cb)
+{
+	int ret = 0;
+
+	usbd_device_lock(uds_ctx);
+
+	if (uds_ctx->msg_cb != NULL) {
+		ret = -EALREADY;
+		goto register_cb_exit;
+	}
+
+	uds_ctx->msg_cb = cb;
+
+register_cb_exit:
+	usbd_device_unlock(uds_ctx);
+
+	return ret;
+}
+
+void usbd_msg_pub_simple(struct usbd_contex *const ctx,
+			 const enum usbd_msg_type type, const int status)
+{
+	const struct usbd_msg msg = {
+		.type = type,
+		.status = status,
+	};
+
+	if (ctx->msg_cb != NULL) {
+		usbd_msg_pub(ctx, msg);
+	}
+}

--- a/subsys/usb/device_next/usbd_msg.h
+++ b/subsys/usb/device_next/usbd_msg.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_USBD_MSG_H
+#define ZEPHYR_INCLUDE_USBD_MSG_H
+
+#include <zephyr/usb/usbd.h>
+
+/**
+ * @brief Publish simple USB device message
+ *
+ * @param[in] uds_ctx Pointer to a device context
+ * @param[in] type    Message type
+ * @param[in] status  Status or error code
+ */
+void usbd_msg_pub_simple(struct usbd_contex *const ctx,
+			 const enum usbd_msg_type type, const int status);
+
+#endif /* ZEPHYR_INCLUDE_USBD_MSG_H */

--- a/subsys/usb/device_next/usbd_msg.h
+++ b/subsys/usb/device_next/usbd_msg.h
@@ -19,4 +19,14 @@
 void usbd_msg_pub_simple(struct usbd_contex *const ctx,
 			 const enum usbd_msg_type type, const int status);
 
+/**
+ * @brief Publish USB device message with pointer to a device payload
+ *
+ * @param[in] uds_ctx Pointer to a device context
+ * @param[in] type    Message type
+ * @param[in] dev     Pointer to a device structure
+ */
+void usbd_msg_pub_device(struct usbd_contex *const ctx,
+			 const enum usbd_msg_type type, const struct device *const dev);
+
 #endif /* ZEPHYR_INCLUDE_USBD_MSG_H */


### PR DESCRIPTION
usb: device_next: implementation of USB device support notification

The implementation uses the system workqueue and a callback provided
and registered by the application. The application callback is called in
the context of the workqueue. Notification messages are stored in a
queue and delivered to the callback in sequence. The callback may return
error code -EBUSY or -EAGAIN, in which case the implementation retries
to deliver the message again.

We cannot call application callback directly from the USB device stack
thread because the behavior of arbitrary code provided by the
application is unpredictable, and we do not want it to be executed in
the same context where all events from the device controller are
handled.

Nor can we use the ZBUS subsystem directly. ZBUS offloads responsibility
for defined behavior to the observers and application, and does not
provide any way for the publisher to enforce defined behavior and
execution context.
ZBUS listener would be called from the USB thread context and is not
acceptable. ZBUS subscriber does not provide delivery guarantee and
cached message can be overwritten. ZBUS message subscriber has
cumbersome global configuration and buffers that are too complicated to
handle from USB configuration, and even if we would use it, defined
behavior is not possible because of how listener and subscriber are
handled.

Resolves: #51034
Resolves: #50759