### PR TITLE
xtensa: misc fixes

### DIFF
--- a/arch/xtensa/core/CMakeLists.txt
+++ b/arch/xtensa/core/CMakeLists.txt
@@ -61,6 +61,7 @@ set(ZSR_H ${CMAKE_BINARY_DIR}/zephyr/include/generated/zsr.h)
 add_custom_command(OUTPUT ${ZSR_H} DEPENDS ${CORE_ISA_DM}
   COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/gen_zsr.py
                                $<$<BOOL:${CONFIG_XTENSA_MMU}>:--mmu>
+                               $<$<BOOL:${CONFIG_KERNEL_COHERENCE}>:--coherence>
                                ${CORE_ISA_DM} ${ZSR_H})
 add_custom_target(zsr_h DEPENDS ${ZSR_H})
 add_dependencies(zephyr_interface zsr_h)

--- a/arch/xtensa/core/fatal.c
+++ b/arch/xtensa/core/fatal.c
@@ -132,8 +132,6 @@ FUNC_NORETURN void z_system_halt(unsigned int reason)
 
 FUNC_NORETURN void arch_syscall_oops(void *ssf)
 {
-	ARG_UNUSED(ssf);
-
 	xtensa_arch_kernel_oops(K_ERR_KERNEL_OOPS, ssf);
 
 	CODE_UNREACHABLE;

--- a/arch/xtensa/core/gen_zsr.py
+++ b/arch/xtensa/core/gen_zsr.py
@@ -14,6 +14,8 @@ import re
 def parse_args():
     parser = argparse.ArgumentParser(allow_abbrev=False)
 
+    parser.add_argument("--coherence", action="store_true",
+                        help="Enable scratch registers for CONFIG_KERNEL_COHERENCE")
     parser.add_argument("--mmu", action="store_true",
                         help="Enable scratch registers for MMU usage")
     parser.add_argument("coreisa",
@@ -25,9 +27,11 @@ def parse_args():
 
 args = parse_args()
 
-NEEDED = ["A0SAVE", "CPU", "FLUSH"]
+NEEDED = ["A0SAVE", "CPU"]
 if args.mmu:
     NEEDED += ["MMU_0", "MMU_1", "DBLEXC"]
+if args.coherence:
+    NEEDED += ["FLUSH"]
 
 coreisa = args.coreisa
 outfile = args.outfile

--- a/arch/xtensa/core/userspace.S
+++ b/arch/xtensa/core/userspace.S
@@ -265,8 +265,6 @@ xtensa_userspace_enter:
 	/* stash user stack */
 	l32i a0, a1, 4
 
-	addi a1, a1, 28
-
 	/* Go back to user stack */
 	mov a1, a0
 

--- a/arch/xtensa/core/vector_handlers.c
+++ b/arch/xtensa/core/vector_handlers.c
@@ -89,6 +89,10 @@ void xtensa_dump_stack(const z_arch_esf_t *stack)
 #endif
 
 	LOG_ERR(" ** SAR %p", (void *)bsa->sar);
+
+#if XCHAL_HAVE_THREADPTR
+	LOG_ERR(" **  THREADPTR %p", (void *)bsa->threadptr);
+#endif
 }
 
 static inline unsigned int get_bits(int offset, int num_bits, unsigned int val)
@@ -121,10 +125,6 @@ static void print_fatal_exception(void *print_stack, int cause,
 	if (is_dblexc) {
 		LOG_ERR(" **  DEPC %p", (void *)depc);
 	}
-
-#ifdef CONFIG_USERSPACE
-	LOG_ERR(" **  THREADPTR %p", (void *)bsa->threadptr);
-#endif /* CONFIG_USERSPACE */
 
 	LOG_ERR(" **  PS %p", (void *)bsa->ps);
 	LOG_ERR(" **    (INTLEVEL:%d EXCM: %d UM:%d RING:%d WOE:%d OWB:%d CALLINC:%d)",


### PR DESCRIPTION
* xtensa: remove unneeded addi in xtensa_userspace_enter
* xtensa: remove ARG_UNUSED from arch_syscall_oops
* xtensa: only need ZSR_FLUSH if CONFIG_KERNEL_COHERENCE
* xtensa: print THREADPTR when dumping stack