### PR TITLE
fb: cfb: Supporting multiple display

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -1343,6 +1343,13 @@ CFB
   * Use :kconfig:option:`CONFIG_CACHE_HAS_MIRRORED_MEMORY_REGIONS` instead of
     :kconfig:option:`CONFIG_CACHE_DOUBLEMAP` as the former is more descriptive of the feature.
 
+CFB
+===
+
+* :c:func:`cfb_get_font_size` and :c:func:`cfb_get_numof_fonts` take a
+  :c:struct:`driver` pointer as a first argument, but not used it.
+  Removed this argument.
+
 Flash
 =====
 

--- a/include/zephyr/display/cfb.h
+++ b/include/zephyr/display/cfb.h
@@ -60,6 +60,110 @@ struct cfb_position {
 };
 
 /**
+ * A parameter structure for ::cfb_display_init.
+ */
+struct cfb_display_init_param {
+	/** Display device */
+	const struct device *dev;
+
+	/** Pointer to a buffer */
+	uint8_t *transfer_buf;
+
+	/** Size of the transfer_buf */
+	uint32_t transfer_buf_size;
+};
+
+/**
+ * A representation of framebuffer.
+ *
+ * This struct is a private definition.
+ * Do not have direct access to members of this structure.
+ */
+struct cfb_framebuffer {
+	/**
+	 * @private
+	 * Pointer to a buffer in RAM
+	 */
+	uint8_t *buf;
+
+	/**
+	 * @private
+	 * Size of the buf
+	 */
+	uint32_t size;
+
+	/**
+	 * @private
+	 * Display pixel format
+	 */
+	enum display_pixel_format pixel_format;
+
+	/**
+	 * @private
+	 * Display screen info
+	 */
+	enum display_screen_info screen_info;
+
+	/**
+	 * @private
+	 * Framebuffer width in pixels.
+	 */
+	uint16_t width;
+
+	/**
+	 * @private
+	 * Framebuffer height in pixels.
+	 */
+	uint16_t height;
+
+	/**
+	 * @private
+	 * Number of pixels per tile, typically 8
+	 */
+	uint8_t ppt;
+
+};
+
+/**
+ * A representation of display.
+ *
+ * This struct is a private definition.
+ * Do not have direct access to members of this structure.
+ */
+struct cfb_display {
+	/**
+	 * @private
+	 * Framebuffer
+	 */
+	struct cfb_framebuffer fb;
+
+	/**
+	 * @private
+	 * Pointer to device
+	 */
+	const struct device *dev;
+
+	/**
+	 * @private
+	 * Current font index
+	 */
+	uint8_t font_idx;
+
+	/**
+	 * @private
+	 * Current font kerning
+	 */
+	int8_t kerning;
+
+	/**
+	 * @private
+	 * Inverted
+	 */
+	bool inverted;
+};
+
+
+/**
  * @brief Macro for creating a font entry.
  *
  * @param _name   Name of the font entry.
@@ -83,61 +187,61 @@ struct cfb_position {
 /**
  * @brief Print a string into the framebuffer.
  *
- * @param dev Pointer to device structure for driver instance
+ * @param fb Pointer to framebuffer to rendering
  * @param str String to print
  * @param x Position in X direction of the beginning of the string
  * @param y Position in Y direction of the beginning of the string
  *
  * @return 0 on success, negative value otherwise
  */
-int cfb_print(const struct device *dev, const char *const str, int16_t x, int16_t y);
+int cfb_print(struct cfb_framebuffer *fb, const char *const str, int16_t x, int16_t y);
 
 /**
  * @brief Print a string into the framebuffer.
  * For compare to cfb_print, cfb_draw_text accept non tile-aligned coords
  * and not line wrapping.
  *
- * @param dev Pointer to device structure for driver instance
+ * @param fb Pointer to framebuffer to rendering
  * @param str String to print
  * @param x Position in X direction of the beginning of the string
  * @param y Position in Y direction of the beginning of the string
  *
  * @return 0 on success, negative value otherwise
  */
-int cfb_draw_text(const struct device *dev, const char *const str, int16_t x, int16_t y);
+int cfb_draw_text(struct cfb_framebuffer *fb, const char *const str, int16_t x, int16_t y);
 
 /**
  * @brief Draw a point.
  *
- * @param dev Pointer to device structure for driver instance
+ * @param fb Pointer to framebuffer to rendering
  * @param pos position of the point
  *
  * @return 0 on success, negative value otherwise
  */
-int cfb_draw_point(const struct device *dev, const struct cfb_position *pos);
+int cfb_draw_point(struct cfb_framebuffer *fb, const struct cfb_position *pos);
 
 /**
  * @brief Draw a line.
  *
- * @param dev Pointer to device structure for driver instance
+ * @param fb Pointer to framebuffer to rendering
  * @param start start position of the line
  * @param end end position of the line
  *
  * @return 0 on success, negative value otherwise
  */
-int cfb_draw_line(const struct device *dev, const struct cfb_position *start,
+int cfb_draw_line(struct cfb_framebuffer *fb, const struct cfb_position *start,
 		  const struct cfb_position *end);
 
 /**
  * @brief Draw a rectangle.
  *
- * @param dev Pointer to device structure for driver instance
+ * @param fb Pointer to framebuffer to rendering
  * @param start Top-Left position of the rectangle
  * @param end Bottom-Right position of the rectangle
  *
  * @return 0 on success, negative value otherwise
  */
-int cfb_draw_rect(const struct device *dev, const struct cfb_position *start,
+int cfb_draw_rect(struct cfb_framebuffer *fb, const struct cfb_position *start,
 		  const struct cfb_position *end);
 
 /**
@@ -149,31 +253,31 @@ int cfb_draw_rect(const struct device *dev, const struct cfb_position *start,
  *
  * @return 0 on success, negative value otherwise
  */
-int cfb_draw_circle(const struct device *dev, const struct cfb_position *start, uint16_t radius);
+int cfb_draw_circle(struct cfb_framebuffer *fb, const struct cfb_position *start, uint16_t radius);
 
 /**
  * @brief Clear framebuffer.
  *
- * @param dev Pointer to device structure for driver instance
+ * @param fb Pointer to framebuffer to rendering
  * @param clear_display Clear the display as well
  *
  * @return 0 on success, negative value otherwise
  */
-int cfb_framebuffer_clear(const struct device *dev, bool clear_display);
+int cfb_framebuffer_clear(struct cfb_framebuffer *fb, bool clear_display);
 
 /**
  * @brief Invert Pixels.
  *
- * @param dev Pointer to device structure for driver instance
+ * @param fb Pointer to framebuffer to rendering
  *
  * @return 0 on success, negative value otherwise
  */
-int cfb_framebuffer_invert(const struct device *dev);
+int cfb_framebuffer_invert(struct cfb_framebuffer *fb);
 
 /**
  * @brief Invert Pixels in selected area.
  *
- * @param dev Pointer to device structure for driver instance
+ * @param fb Pointer to framebuffer to rendering
  * @param x Position in X direction of the beginning of area
  * @param y Position in Y direction of the beginning of area
  * @param width Width of area in pixels
@@ -181,87 +285,111 @@ int cfb_framebuffer_invert(const struct device *dev);
  *
  * @return 0 on success, negative value otherwise
  */
-int cfb_invert_area(const struct device *dev, int16_t x, int16_t y,
-		    uint16_t width, uint16_t height);
+int cfb_invert_area(struct cfb_framebuffer *fb, int16_t x, int16_t y, uint16_t width,
+		    uint16_t height);
 
 /**
  * @brief Finalize framebuffer and write it to display RAM,
  * invert or reorder pixels if necessary.
  *
- * @param dev Pointer to device structure for driver instance
+ * @param fb Pointer to framebuffer to rendering
  *
  * @return 0 on success, negative value otherwise
  */
-int cfb_framebuffer_finalize(const struct device *dev);
+int cfb_framebuffer_finalize(struct cfb_framebuffer *fb);
 
 /**
  * @brief Get display parameter.
  *
- * @param dev Pointer to device structure for driver instance
+ * @param disp Pointer to display instance
  * @param cfb_display_param One of the display parameters
  *
  * @return Display parameter value
  */
-int cfb_get_display_parameter(const struct device *dev,
-			      enum cfb_display_param);
+int cfb_get_display_parameter(const struct cfb_display *disp, enum cfb_display_param);
 
 /**
  * @brief Set font.
  *
- * @param dev Pointer to device structure for driver instance
+ * @param fb Pointer to framebuffer instance
  * @param idx Font index
  *
  * @return 0 on success, negative value otherwise
  */
-int cfb_framebuffer_set_font(const struct device *dev, uint8_t idx);
+int cfb_framebuffer_set_font(struct cfb_framebuffer *fb, uint8_t idx);
 
 /**
  * @brief Set font kerning (spacing between individual letters).
  *
- * @param dev Pointer to device structure for driver instance
+ * @param fb Pointer to framebuffer instance
  * @param kerning Font kerning
  *
  * @return 0 on success, negative value otherwise
  */
-int cfb_set_kerning(const struct device *dev, int8_t kerning);
+int cfb_set_kerning(struct cfb_framebuffer *fb, int8_t kerning);
 
 /**
  * @brief Get font size.
  *
- * @param dev Pointer to device structure for driver instance
+ * Get width and height of font that is specified by idx.
+ *
  * @param idx Font index
  * @param width Pointers to the variable where the font width will be stored.
  * @param height Pointers to the variable where the font height will be stored.
  *
- * @return 0 on success, negative value otherwise
+ * @retval 0 on success
+ * @retval -EINVAL If you specify idx for a font that does not exist
  */
-int cfb_get_font_size(const struct device *dev, uint8_t idx, uint8_t *width,
-		      uint8_t *height);
+int cfb_get_font_size(struct cfb_framebuffer *fb, uint8_t idx, uint8_t *width, uint8_t *height);
 
 /**
  * @brief Get number of fonts.
  *
- * @param dev Pointer to device structure for driver instance
- *
  * @return number of fonts
  */
-int cfb_get_numof_fonts(const struct device *dev);
+int cfb_get_numof_fonts(struct cfb_framebuffer *fb);
 
 /**
- * @brief Initialize Character Framebuffer.
+ * @brief Initialize display
  *
- * @param dev Pointer to device structure for driver instance
+ * @param disp A display instance to initialize.
+ * @param param Pointer to display initialize parameter.
  *
- * @return 0 on success, negative value otherwise
+ * @return 0 on succeeded
  */
-int cfb_framebuffer_init(const struct device *dev);
+int cfb_display_init(struct cfb_display *disp, const struct cfb_display_init_param *param);
 
 /**
- * @brief Deinitialize Character Framebuffer.
+ * Allocate a full-screen buffer and initialize a display instance.
  *
- * @param dev Pointer to device structure for driver instance
+ * @param dev A display device which is used to displaying.
+ *
+ * @retval NULL If memory allocation fails.
+ * @retval Non-NULL on succeeded
  */
-void cfb_framebuffer_deinit(const struct device *dev);
+struct cfb_display *cfb_display_alloc(const struct device *dev);
+
+/**
+ * Deinitialize display instance.
+ *
+ * @param disp A display instance to deinitialize.
+ */
+void cfb_display_deinit(struct cfb_display *disp);
+
+/**
+ * Release an allocated display instance.
+ *
+ * @param disp A display instance that was allocated by ::cfb_display_alloc.
+ */
+void cfb_display_free(struct cfb_display *disp);
+
+/**
+ * Get a framebuffer subordinate to the given display.
+ *
+ * @param disp A display instance to retrieve framebuffer.
+ * @return A framebuffer is subordinate to the given display.
+ */
+struct cfb_framebuffer *cfb_display_get_framebuffer(struct cfb_display *disp);
 
 #ifdef __cplusplus
 }

--- a/samples/boards/phytec/reel_board/mesh_badge/src/reel_board.c
+++ b/samples/boards/phytec/reel_board/mesh_badge/src/reel_board.c
@@ -55,6 +55,7 @@ struct font_info {
 #define STAT_COUNT 128
 
 static const struct device *const epd_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
+static struct cfb_display *epd_disp;
 static bool pressed;
 static uint8_t screen_id = SCREEN_MAIN;
 static struct k_work_delayable epd_work;
@@ -74,11 +75,12 @@ struct k_work_delayable led_timer;
 static size_t print_line(enum font_size font_size, int row, const char *text,
 			 size_t len, bool center)
 {
+	struct cfb_framebuffer *fb = cfb_display_get_framebuffer(epd_disp);
 	uint8_t font_height, font_width;
 	uint8_t line[fonts[FONT_SMALL].columns + 1];
 	int pad;
 
-	cfb_framebuffer_set_font(epd_dev, font_size);
+	cfb_framebuffer_set_font(fb, font_size);
 
 	len = MIN(len, fonts[font_size].columns);
 	memcpy(line, text, len);
@@ -90,9 +92,9 @@ static size_t print_line(enum font_size font_size, int row, const char *text,
 		pad = 0;
 	}
 
-	cfb_get_font_size(epd_dev, font_size, &font_width, &font_height);
+	cfb_get_font_size(fb, font_size, &font_width, &font_height);
 
-	if (cfb_print(epd_dev, line, font_width * pad, font_height * row)) {
+	if (cfb_print(fb, line, font_width * pad, font_height * row)) {
 		printk("Failed to print a string\n");
 	}
 
@@ -134,9 +136,10 @@ void board_blink_leds(void)
 
 void board_show_text(const char *text, bool center, k_timeout_t duration)
 {
+	struct cfb_framebuffer *fb = cfb_display_get_framebuffer(epd_disp);
 	int i;
 
-	cfb_framebuffer_clear(epd_dev, false);
+	cfb_framebuffer_clear(fb, false);
 
 	for (i = 0; i < 3; i++) {
 		size_t len;
@@ -156,7 +159,7 @@ void board_show_text(const char *text, bool center, k_timeout_t duration)
 		}
 	}
 
-	cfb_framebuffer_finalize(epd_dev);
+	cfb_framebuffer_finalize(fb);
 
 	if (!K_TIMEOUT_EQ(duration, K_FOREVER)) {
 		k_work_reschedule(&epd_work, duration);
@@ -267,12 +270,13 @@ void board_add_heartbeat(uint16_t addr, uint8_t hops)
 
 static void show_statistics(void)
 {
+	struct cfb_framebuffer *fb = cfb_display_get_framebuffer(epd_disp);
 	int top[4] = { -1, -1, -1, -1 };
 	int len, i, line = 0;
 	struct stat *stat;
 	char str[32];
 
-	cfb_framebuffer_clear(epd_dev, false);
+	cfb_framebuffer_clear(fb, false);
 
 	len = snprintk(str, sizeof(str),
 		       "Own Address: 0x%04x", mesh_get_addr());
@@ -335,16 +339,17 @@ static void show_statistics(void)
 		}
 	}
 
-	cfb_framebuffer_finalize(epd_dev);
+	cfb_framebuffer_finalize(fb);
 }
 
 static void show_sensors_data(k_timeout_t interval)
 {
+	struct cfb_framebuffer *fb = cfb_display_get_framebuffer(epd_disp);
 	struct sensor_value val[3];
 	uint8_t line = 0U;
 	uint16_t len = 0U;
 
-	cfb_framebuffer_clear(epd_dev, false);
+	cfb_framebuffer_clear(fb, false);
 
 	/* hdc1010 */
 	if (get_hdc1010_val(val)) {
@@ -386,7 +391,7 @@ static void show_sensors_data(k_timeout_t interval)
 	len = snprintf(str_buf, sizeof(str_buf), "Proximity:%d\n", val[1].val1);
 	print_line(FONT_SMALL, line++, str_buf, len, false);
 
-	cfb_framebuffer_finalize(epd_dev);
+	cfb_framebuffer_finalize(fb);
 
 	k_work_reschedule(&epd_work, interval);
 
@@ -584,17 +589,22 @@ void board_refresh_display(void)
 
 int board_init(void)
 {
+	struct cfb_framebuffer *fb;
+
 	if (!device_is_ready(epd_dev)) {
 		printk("%s: device not ready.\n", epd_dev->name);
 		return -ENODEV;
 	}
 
-	if (cfb_framebuffer_init(epd_dev)) {
+	epd_disp = cfb_display_alloc(epd_dev);
+	if (!epd_disp) {
 		printk("Framebuffer initialization failed\n");
 		return -EIO;
 	}
 
-	cfb_framebuffer_clear(epd_dev, true);
+	fb = cfb_display_get_framebuffer(epd_disp);
+
+	cfb_framebuffer_clear(fb, true);
 
 	if (configure_button()) {
 		printk("Failed to configure button\n");

--- a/samples/subsys/display/cfb/src/main.c
+++ b/samples/subsys/display/cfb/src/main.c
@@ -35,12 +35,12 @@ int main(void)
 
 	printf("Initialized %s\n", dev->name);
 
-	if (cfb_framebuffer_init(dev)) {
+	if (cfb_framebuffer_init(fb)) {
 		printf("Framebuffer initialization failed!\n");
 		return 0;
 	}
 
-	ret = cfb_framebuffer_clear(dev, true);
+	ret = cfb_framebuffer_clear(fb, true);
 	if (ret < 0) {
 		printf("cfb_framebuffer_clear(%s, true) failed: %d\n", dev->name, ret);
 		return 0;
@@ -52,16 +52,16 @@ int main(void)
 		return 0;
 	}
 
-	x_res = cfb_get_display_parameter(dev, CFB_DISPLAY_WIDTH);
-	y_res = cfb_get_display_parameter(dev, CFB_DISPLAY_HEIGHT);
-	rows = cfb_get_display_parameter(dev, CFB_DISPLAY_ROWS);
-	ppt = cfb_get_display_parameter(dev, CFB_DISPLAY_PPT);
+	x_res = cfb_get_display_parameter(fb, CFB_DISPLAY_WIDTH);
+	y_res = cfb_get_display_parameter(fb, CFB_DISPLAY_HEIGHT);
+	rows = cfb_get_display_parameter(fb, CFB_DISPLAY_ROWS);
+	ppt = cfb_get_display_parameter(fb, CFB_DISPLAY_PPT);
 
 	for (int idx = 0; idx < 42; idx++) {
-		if (cfb_get_font_size(dev, idx, &font_width, &font_height)) {
+		if (cfb_get_font_size(fb, idx, &font_width, &font_height)) {
 			break;
 		}
-		ret = cfb_framebuffer_set_font(dev, idx);
+		ret = cfb_framebuffer_set_font(fb, idx);
 		if (ret < 0) {
 			printf("cfb_framebuffer_set_font(%s, %d) failed: %d\n", dev->name, idx,
 			       ret);
@@ -76,15 +76,15 @@ int main(void)
 	       y_res,
 	       ppt,
 	       rows,
-	       cfb_get_display_parameter(dev, CFB_DISPLAY_COLS));
+	       cfb_get_display_parameter(fb, CFB_DISPLAY_COLS));
 
-	ret = cfb_framebuffer_invert(dev);
+	ret = cfb_framebuffer_invert(fb);
 	if (ret < 0) {
 		printf("cfb_framebuffer_invert(%s) failed: %d\n", dev->name, ret);
 		return 0;
 	}
 
-	ret = cfb_set_kerning(dev, 3);
+	ret = cfb_set_kerning(fb, 3);
 	if (ret < 0) {
 		printf("cfb_set_kerning(%s, 3) failed: %d\n", dev->name, ret);
 		return 0;
@@ -96,19 +96,19 @@ int main(void)
 			k_sleep(K_MSEC(20));
 #endif
 
-			ret = cfb_framebuffer_clear(dev, false);
+			ret = cfb_framebuffer_clear(fb, false);
 			if (ret < 0) {
 				printf("Failed to clear the framebuffer: %d\n", ret);
 				continue;
 			}
 
-			ret = cfb_print(dev, "0123456789mMgj!\"\xc2\xA7$%&/()=", i, i);
+			ret = cfb_print(fb, "0123456789mMgj!\"\xc2\xA7$%&/()=", i, i);
 			if (ret < 0) {
 				printf("Failed to print a string: %d\n", ret);
 				continue;
 			}
 
-			ret = cfb_framebuffer_finalize(dev);
+			ret = cfb_framebuffer_finalize(fb);
 			if (ret < 0) {
 				printf("Finalize failed: %d\n", ret);
 				continue;

--- a/samples/subsys/display/cfb/src/main.c
+++ b/samples/subsys/display/cfb/src/main.c
@@ -12,13 +12,15 @@
 int main(void)
 {
 	const struct device *dev;
+	struct cfb_display *disp;
+	struct cfb_framebuffer *fb;
 	uint16_t x_res;
 	uint16_t y_res;
 	uint16_t rows;
 	uint8_t ppt;
 	uint8_t font_width;
 	uint8_t font_height;
-	int ret;
+	int ret = 0;
 
 	dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
 	if (!device_is_ready(dev)) {
@@ -35,16 +37,19 @@ int main(void)
 
 	printf("Initialized %s\n", dev->name);
 
-	if (cfb_framebuffer_init(fb)) {
-		printf("Framebuffer initialization failed!\n");
+	disp = cfb_display_alloc(dev);
+	if (!disp) {
+		printf("Framebuffer allocation failed!\n");
 		return 0;
 	}
 
-	ret = cfb_framebuffer_clear(fb, true);
+	fb = cfb_display_get_framebuffer(disp);
 	if (ret < 0) {
 		printf("cfb_framebuffer_clear(%s, true) failed: %d\n", dev->name, ret);
 		return 0;
 	}
+
+	cfb_framebuffer_clear(fb, true);
 
 	ret = display_blanking_off(dev);
 	if (ret < 0 && ret != -ENOSYS) {
@@ -52,10 +57,10 @@ int main(void)
 		return 0;
 	}
 
-	x_res = cfb_get_display_parameter(fb, CFB_DISPLAY_WIDTH);
-	y_res = cfb_get_display_parameter(fb, CFB_DISPLAY_HEIGHT);
-	rows = cfb_get_display_parameter(fb, CFB_DISPLAY_ROWS);
-	ppt = cfb_get_display_parameter(fb, CFB_DISPLAY_PPT);
+	x_res = cfb_get_display_parameter(disp, CFB_DISPLAY_WIDTH);
+	y_res = cfb_get_display_parameter(disp, CFB_DISPLAY_HEIGHT);
+	rows = cfb_get_display_parameter(disp, CFB_DISPLAY_ROWS);
+	ppt = cfb_get_display_parameter(disp, CFB_DISPLAY_PPT);
 
 	for (int idx = 0; idx < 42; idx++) {
 		if (cfb_get_font_size(fb, idx, &font_width, &font_height)) {
@@ -76,7 +81,7 @@ int main(void)
 	       y_res,
 	       ppt,
 	       rows,
-	       cfb_get_display_parameter(fb, CFB_DISPLAY_COLS));
+	       cfb_get_display_parameter(disp, CFB_DISPLAY_COLS));
 
 	ret = cfb_framebuffer_invert(fb);
 	if (ret < 0) {

--- a/samples/subsys/display/cfb_custom_font/src/main.c
+++ b/samples/subsys/display/cfb_custom_font/src/main.c
@@ -13,21 +13,23 @@
 
 int main(void)
 {
-	const struct device *const display = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
+	const struct device *const dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
+	struct cfb_display *disp;
+	struct cfb_framebuffer *fb;
 	int err;
 
-	if (!device_is_ready(display)) {
+	if (!device_is_ready(dev)) {
 		printk("Display device not ready\n");
 	}
 
-	if (display_set_pixel_format(display, PIXEL_FORMAT_MONO10) != 0) {
-		if (display_set_pixel_format(display, PIXEL_FORMAT_MONO01) != 0) {
+	if (display_set_pixel_format(dev, PIXEL_FORMAT_MONO10) != 0) {
+		if (display_set_pixel_format(dev, PIXEL_FORMAT_MONO01) != 0) {
 			printk("Failed to set required pixel format");
 			return 0;
 		}
 	}
 
-	err = display_blanking_off(display);
+	err = display_blanking_off(dev);
 	if (err == -ENOSYS) {
 		printk("Display blanking off not available");
 	} else if (err) {
@@ -35,22 +37,25 @@ int main(void)
 		return 0;
 	}
 
-	err = cfb_framebuffer_init(display);
-	if (err) {
-		printk("Could not initialize framebuffer (err %d)\n", err);
+	disp = cfb_display_alloc(dev);
+	if (!disp) {
+		printk("Could not allocate framebuffer\n");
+		return 0;
 	}
 
-	err = cfb_framebuffer_clear(display, true);
+	fb = cfb_display_get_framebuffer(disp);
+
+	err = cfb_framebuffer_clear(fb, true);
 	if (err) {
 		printk("Could not clear framebuffer (err %d)\n", err);
 	}
 
-	err = cfb_print(display, "123456", 0, 0);
+	err = cfb_print(fb, "123456", 0, 0);
 	if (err) {
 		printk("Could not display custom font (err %d)\n", err);
 	}
 
-	err = cfb_framebuffer_finalize(display);
+	err = cfb_framebuffer_finalize(fb);
 	if (err) {
 		printk("Could not finalize framebuffer (err %d)\n", err);
 	}

--- a/subsys/fb/cfb.c
+++ b/subsys/fb/cfb.c
@@ -27,45 +27,7 @@ static inline uint8_t byte_reverse(uint8_t b)
 	return b;
 }
 
-struct char_framebuffer {
-	/** Pointer to a buffer in RAM */
-	uint8_t *buf;
-
-	/** Size of the framebuffer */
-	uint32_t size;
-
-	/** Pointer to the font entry array */
-	const struct cfb_font *fonts;
-
-	/** Display pixel format */
-	enum display_pixel_format pixel_format;
-
-	/** Display screen info */
-	enum display_screen_info screen_info;
-
-	/** Resolution of a framebuffer in pixels in X direction */
-	uint16_t x_res;
-
-	/** Resolution of a framebuffer in pixels in Y direction */
-	uint16_t y_res;
-
-	/** Number of pixels per tile, typically 8 */
-	uint8_t ppt;
-
-	/** Number of available fonts */
-	uint8_t numof_fonts;
-
-	/** Current font index */
-	uint8_t font_idx;
-
-	/** Font kerning */
-	int8_t kerning;
-
-	/** Inverted */
-	bool inverted;
-};
-
-static struct char_framebuffer char_fb;
+//static struct cfb_framebuffer char_fb;
 
 static inline const uint8_t *get_glyph_ptr(const struct cfb_font *fptr, uint8_t c)
 {
@@ -169,11 +131,22 @@ static inline uint8_t get_glyph_byte(const uint8_t *glyph_ptr, const struct cfb_
 	return 0;
 }
 
+static inline const struct cfb_font *font_get(uint32_t idx)
+{
+	static const struct cfb_font *fonts = TYPE_SECTION_START(cfb_font);
+
+	if (idx < cfb_get_numof_fonts(NULL)) {
+		return fonts + idx;
+	}
+
+	return NULL;
+}
+
 /*
  * Draw the monochrome character in the monochrome tiled framebuffer,
  * a byte is interpreted as 8 pixels ordered vertically among each other.
  */
-static uint8_t draw_char_vtmono_vpacked(const struct char_framebuffer *fb,
+static uint8_t draw_char_vtmono_vpacked(const struct cfb_framebuffer *fb,
 					const struct cfb_font *fptr, uint8_t c, uint16_t x,
 					uint16_t y, bool draw_bg)
 {
@@ -192,14 +165,14 @@ static uint8_t draw_char_vtmono_vpacked(const struct char_framebuffer *fb,
 			 */
 
 			const int16_t fb_y = y + g_y;
-			const size_t fb_index = (fb_y / 8U) * fb->x_res + fb_x;
-			const size_t offset = ((y % 8) + 8) % 8;
+			const size_t fb_index = (fb_y / 8U) * fb->width + fb_x;
+			const size_t offset = (y >= 0) ? y % 8 : (8 + (y % 8));
 			const uint8_t bottom_lines = ((offset + fptr->height) % 8);
 			uint8_t bg_mask;
 			uint8_t byte;
 			uint8_t next_byte;
 
-			if (fb_x < 0 || fb->x_res <= fb_x || fb_y < 0 || fb->y_res <= fb_y) {
+			if (fb_x < 0 || fb->width <= fb_x || fb_y < 0 || fb->height <= fb_y) {
 				g_y++;
 				continue;
 			}
@@ -282,7 +255,7 @@ static uint8_t draw_char_vtmono_vpacked(const struct char_framebuffer *fb,
 	return fptr->width;
 }
 
-static uint8_t draw_char_vtmono_hpacked(const struct char_framebuffer *fb,
+static uint8_t draw_char_vtmono_hpacked(const struct cfb_framebuffer *fb,
 					const struct cfb_font *fptr, uint8_t c, uint16_t x,
 					uint16_t y, bool draw_bg)
 {
@@ -293,12 +266,12 @@ static uint8_t draw_char_vtmono_hpacked(const struct char_framebuffer *fb,
 	for (size_t g_y = 0; g_y < fptr->height; g_y++) {
 		const int16_t fb_y = y + g_y;
 
-		if (fb_y < 0 || fb->y_res <= fb_y) {
+		if (fb_y < 0 || fb->height <= fb_y) {
 			continue;
 		}
 
 		const uint8_t bg_mask = disp_is_msbfirst ? BIT(7U - (fb_y % 8U)) : BIT(fb_y % 8U);
-		const size_t fb_row_base = (fb_y / 8U) * fb->x_res;
+		const size_t fb_row_base = (fb_y / 8U) * fb->width;
 
 		for (size_t g_x = 0; g_x < fptr->width; g_x += 8U) {
 			const uint8_t gbyte = get_glyph_byte(glyph_ptr, fptr, g_x, g_y, true);
@@ -309,7 +282,7 @@ static uint8_t draw_char_vtmono_hpacked(const struct char_framebuffer *fb,
 			for (size_t g_bit = 0; g_bit < pixels_in_byte; g_bit++) {
 				const int16_t fb_x = x + g_x + g_bit;
 
-				if (fb_x < 0 || fb->x_res <= fb_x) {
+				if (fb_x < 0 || fb->width <= fb_x) {
 					continue;
 				}
 
@@ -329,10 +302,11 @@ static uint8_t draw_char_vtmono_hpacked(const struct char_framebuffer *fb,
 	return fptr->width;
 }
 
-static inline uint8_t draw_char_vtmono(const struct char_framebuffer *fb, uint8_t c, uint16_t x,
+static inline uint8_t draw_char_vtmono(const struct cfb_framebuffer *fb, uint8_t c, uint16_t x,
 				       uint16_t y, bool draw_bg)
 {
-	const struct cfb_font *fptr = &(fb->fonts[fb->font_idx]);
+	const struct cfb_display *disp = CONTAINER_OF(fb, struct cfb_display, fb);
+	const struct cfb_font *fptr = font_get(disp->font_idx);
 
 	if (fptr->caps & CFB_FONT_MONO_HPACKED) {
 		return draw_char_vtmono_hpacked(fb, fptr, c, x, y, draw_bg);
@@ -345,10 +319,11 @@ static inline uint8_t draw_char_vtmono(const struct char_framebuffer *fb, uint8_
  * Draw the monochrome character in the monochrome tiled framebuffer,
  * a byte is interpreted as 8 pixels ordered horizontally among each other.
  */
-static uint8_t draw_char_htmono(const struct char_framebuffer *fb, uint8_t c, uint16_t x,
+static uint8_t draw_char_htmono(const struct cfb_framebuffer *fb, uint8_t c, uint16_t x,
 				uint16_t y, bool draw_bg)
 {
-	const struct cfb_font *fptr = &(fb->fonts[fb->font_idx]);
+	const struct cfb_display *disp = CONTAINER_OF(fb, struct cfb_display, fb);
+	const struct cfb_font *fptr = font_get(disp->font_idx);
 	const uint8_t *glyph_ptr = get_glyph_ptr(fptr, c);
 	const bool font_is_msbfirst = (fptr->caps & CFB_FONT_MSB_FIRST) != 0;
 	const bool display_is_msbfirst = (fb->screen_info & SCREEN_INFO_MONO_MSB_FIRST) != 0;
@@ -358,12 +333,12 @@ static uint8_t draw_char_htmono(const struct char_framebuffer *fb, uint8_t c, ui
 
 		for (size_t g_x = 0; g_x < fptr->width; g_x++) {
 			const int16_t fb_x = x + g_x;
-			const size_t fb_pixel_index = fb_y * fb->x_res + fb_x;
+			const size_t fb_pixel_index = fb_y * fb->width + fb_x;
 			const size_t fb_byte_index = fb_pixel_index / 8;
 			uint8_t byte;
 			uint8_t pixel_value;
 
-			if (fb_x < 0 || fb->x_res <= fb_x || fb_y < 0 || fb->y_res <= fb_y) {
+			if (fb_x < 0 || fb->width <= fb_x || fb_y < 0 || fb->height <= fb_y) {
 				continue;
 			}
 
@@ -390,25 +365,25 @@ static uint8_t draw_char_htmono(const struct char_framebuffer *fb, uint8_t c, ui
 	return fptr->width;
 }
 
-static inline void draw_point(struct char_framebuffer *fb, int16_t x, int16_t y)
+static inline void draw_point(struct cfb_framebuffer *fb, int16_t x, int16_t y)
 {
 	const bool need_reverse = ((fb->screen_info & SCREEN_INFO_MONO_MSB_FIRST) != 0);
 	size_t index;
 	uint8_t m;
 
 	if ((fb->screen_info & SCREEN_INFO_MONO_VTILED) != 0) {
-		index = (x + (y / 8) * fb->x_res);
+		index = (x + (y / 8) * fb->width);
 		m = BIT(y % 8);
 	} else {
-		index = ((x / 8) + y * (fb->x_res / 8));
+		index = ((x / 8) + y * (fb->width / 8));
 		m = BIT(x % 8);
 	}
 
-	if (x < 0 || x >= fb->x_res) {
+	if (x < 0 || x >= fb->width) {
 		return;
 	}
 
-	if (y < 0 || y >= fb->y_res) {
+	if (y < 0 || y >= fb->height) {
 		return;
 	}
 
@@ -419,7 +394,7 @@ static inline void draw_point(struct char_framebuffer *fb, int16_t x, int16_t y)
 	fb->buf[index] |= m;
 }
 
-static void draw_line(struct char_framebuffer *fb, int16_t x0, int16_t y0, int16_t x1, int16_t y1)
+static void draw_line(struct cfb_framebuffer *fb, int16_t x0, int16_t y0, int16_t x1, int16_t y1)
 {
 	int16_t sx = (x0 < x1) ? 1 : -1;
 	int16_t sy = (y0 < y1) ? 1 : -1;
@@ -449,58 +424,52 @@ static void draw_line(struct char_framebuffer *fb, int16_t x0, int16_t y0, int16
 	}
 }
 
-static int draw_text(const struct device *dev, const char *const str, int16_t x, int16_t y,
+static int draw_text(struct cfb_framebuffer *fb, const char *const str, int16_t x, int16_t y,
 		     bool wrap)
 {
-	const struct char_framebuffer *fb = &char_fb;
+	const struct cfb_display *disp = CONTAINER_OF(fb, struct cfb_display, fb);
 	const struct cfb_font *fptr;
 	size_t len;
 
-	if (!fb->fonts || !fb->buf) {
+	if (!fb->buf) {
 		return -ENODEV;
 	}
 
-	fptr = &(fb->fonts[fb->font_idx]);
+	fptr = font_get(disp->font_idx);
 	len = strlen(str);
 
 	for (size_t i = 0; i < len; i++) {
-		if ((x + fptr->width > fb->x_res) && wrap) {
+		if ((x + fptr->width > fb->width) && wrap) {
 			x = 0U;
 			y += fptr->height;
 		}
 		if (fb->screen_info & SCREEN_INFO_MONO_VTILED) {
-			x += fb->kerning + draw_char_vtmono(fb, str[i], x, y, wrap);
+			x += disp->kerning + draw_char_vtmono(fb, str[i], x, y, wrap);
 		} else {
-			x += fb->kerning + draw_char_htmono(fb, str[i], x, y, wrap);
+			x += disp->kerning + draw_char_htmono(fb, str[i], x, y, wrap);
 		}
 	}
 	return 0;
 }
 
-int cfb_draw_point(const struct device *dev, const struct cfb_position *pos)
+int cfb_draw_point(struct cfb_framebuffer *fb, const struct cfb_position *pos)
 {
-	struct char_framebuffer *fb = &char_fb;
-
 	draw_point(fb, pos->x, pos->y);
 
 	return 0;
 }
 
-int cfb_draw_line(const struct device *dev, const struct cfb_position *start,
+int cfb_draw_line(struct cfb_framebuffer *fb, const struct cfb_position *start,
 		  const struct cfb_position *end)
 {
-	struct char_framebuffer *fb = &char_fb;
-
 	draw_line(fb, start->x, start->y, end->x, end->y);
 
 	return 0;
 }
 
-int cfb_draw_rect(const struct device *dev, const struct cfb_position *start,
+int cfb_draw_rect(struct cfb_framebuffer *fb, const struct cfb_position *start,
 		  const struct cfb_position *end)
 {
-	struct char_framebuffer *fb = &char_fb;
-
 	draw_line(fb, start->x, start->y, end->x, start->y);
 	draw_line(fb, end->x, start->y, end->x, end->y);
 	draw_line(fb, end->x, end->y, start->x, end->y);
@@ -509,9 +478,8 @@ int cfb_draw_rect(const struct device *dev, const struct cfb_position *start,
 	return 0;
 }
 
-int cfb_draw_circle(const struct device *dev, const struct cfb_position *center, uint16_t radius)
+int cfb_draw_circle(struct cfb_framebuffer *fb, const struct cfb_position *center, uint16_t radius)
 {
-	struct char_framebuffer *fb = &char_fb;
 	uint16_t x = 0;
 	int16_t y = -radius;
 	int16_t p = -radius;
@@ -539,27 +507,26 @@ int cfb_draw_circle(const struct device *dev, const struct cfb_position *center,
 	return 0;
 }
 
-int cfb_draw_text(const struct device *dev, const char *const str, int16_t x, int16_t y)
+int cfb_draw_text(struct cfb_framebuffer *fb, const char *const str, int16_t x, int16_t y)
 {
-	return draw_text(dev, str, x, y, false);
+	return draw_text(fb, str, x, y, false);
 }
 
-int cfb_print(const struct device *dev, const char *const str, int16_t x, int16_t y)
+int cfb_print(struct cfb_framebuffer *fb, const char *const str, int16_t x, int16_t y)
 {
-	return draw_text(dev, str, x, y, true);
+	return draw_text(fb, str, x, y, true);
 }
 
-int cfb_invert_area(const struct device *dev, int16_t x, int16_t y,
-		    uint16_t width, uint16_t height)
+int cfb_invert_area(struct cfb_framebuffer *fb, int16_t x, int16_t y, uint16_t width,
+		    uint16_t height)
 {
-	const struct char_framebuffer *fb = &char_fb;
 	const bool need_reverse = ((fb->screen_info & SCREEN_INFO_MONO_MSB_FIRST) != 0);
 
-	if ((x + width) < 0 || x >= fb->x_res) {
+	if ((x + width) < 0 || x >= fb->width) {
 		return 0;
 	}
 
-	if ((y + height) < 0 || y >= fb->y_res) {
+	if ((y + height) < 0 || y >= fb->height) {
 		return 0;
 	}
 
@@ -573,12 +540,12 @@ int cfb_invert_area(const struct device *dev, int16_t x, int16_t y,
 		y = 0;
 	}
 
-	if (width > (fb->x_res - x)) {
-		width = fb->x_res - x;
+	if (width > (fb->width - x)) {
+		width = fb->width - x;
 	}
 
-	if (height > (fb->y_res - y)) {
-		height = fb->y_res - y;
+	if (height > (fb->height - y)) {
+		height = fb->height - y;
 	}
 
 
@@ -590,7 +557,7 @@ int cfb_invert_area(const struct device *dev, int16_t x, int16_t y,
 				 * by separating per 8-line boundaries.
 				 */
 
-				const size_t index = ((j / 8) * fb->x_res) + i;
+				const size_t index = ((j / 8) * fb->width) + i;
 				const uint8_t remains = y + height - j;
 
 				/*
@@ -634,7 +601,7 @@ int cfb_invert_area(const struct device *dev, int16_t x, int16_t y,
 			}
 		}
 	} else {
-		const size_t bytes_per_row = fb->x_res / 8U;
+		const size_t bytes_per_row = fb->width / 8U;
 
 		for (uint16_t j = y; j < (y + height); j++) {
 			const uint16_t start_byte = x / 8U;
@@ -666,19 +633,17 @@ int cfb_invert_area(const struct device *dev, int16_t x, int16_t y,
 	return 0;
 }
 
-static int cfb_invert(const struct char_framebuffer *fb)
+static int buffer_invert(struct cfb_framebuffer *fb)
 {
-	for (size_t i = 0; i < fb->x_res * fb->y_res / 8U; i++) {
+	for (size_t i = 0; i < fb->width * fb->height / 8U; i++) {
 		fb->buf[i] = ~fb->buf[i];
 	}
 
 	return 0;
 }
 
-int cfb_framebuffer_clear(const struct device *dev, bool clear_display)
+int cfb_framebuffer_clear(struct cfb_framebuffer *fb, bool clear_display)
 {
-	const struct char_framebuffer *fb = &char_fb;
-
 	if (!fb->buf) {
 		return -ENODEV;
 	}
@@ -686,95 +651,99 @@ int cfb_framebuffer_clear(const struct device *dev, bool clear_display)
 	memset(fb->buf, 0, fb->size);
 
 	if (clear_display) {
-		cfb_framebuffer_finalize(dev);
+		cfb_framebuffer_finalize(fb);
 	}
 
 	return 0;
 }
 
-int cfb_framebuffer_invert(const struct device *dev)
+int cfb_framebuffer_invert(struct cfb_framebuffer *fb)
 {
-	struct char_framebuffer *fb = &char_fb;
+	struct cfb_display *disp;
 
-	fb->inverted = !fb->inverted;
+	if (!fb) {
+		return -ENODEV;
+	}
+
+	disp = CONTAINER_OF(fb, struct cfb_display, fb);
+	disp->inverted = !disp->inverted;
 
 	return 0;
 }
 
-int cfb_framebuffer_finalize(const struct device *dev)
+int cfb_framebuffer_finalize(struct cfb_framebuffer *fb)
 {
-	const struct display_driver_api *api = dev->api;
-	const struct char_framebuffer *fb = &char_fb;
+	struct display_buffer_descriptor desc;
+	struct cfb_display *disp;
 	int err;
 
-	__ASSERT_NO_MSG(DEVICE_API_IS(display, dev));
+	//__ASSERT_NO_MSG(DEVICE_API_IS(display, dev));
 
 	if (!fb->buf) {
 		return -ENODEV;
 	}
 
-	struct display_buffer_descriptor desc = {
-		.buf_size = fb->size,
-		.width = fb->x_res,
-		.height = fb->y_res,
-		.pitch = fb->x_res,
-	};
+	disp = CONTAINER_OF(fb, struct cfb_display, fb);
 
-	if ((fb->pixel_format == PIXEL_FORMAT_MONO10) != fb->inverted) {
-		cfb_invert(fb);
-		err = api->write(dev, 0, 0, &desc, fb->buf);
-		cfb_invert(fb);
+	desc.buf_size = fb->size;
+	desc.width = fb->width;
+	desc.height = fb->height;
+	desc.pitch = fb->width;
+
+	if (!(fb->pixel_format & PIXEL_FORMAT_MONO10) != !(disp->inverted)) {
+		buffer_invert(fb);
+		err = display_write(disp->dev, 0, 0, &desc, fb->buf);
+		buffer_invert(fb);
 		return err;
 	}
 
-	return api->write(dev, 0, 0, &desc, fb->buf);
+	return display_write(disp->dev, 0, 0, &desc, fb->buf);
 }
 
-int cfb_get_display_parameter(const struct device *dev,
-			       enum cfb_display_param param)
+int cfb_get_display_parameter(const struct cfb_display *disp, enum cfb_display_param param)
 {
-	const struct char_framebuffer *fb = &char_fb;
+	struct display_capabilities cfg;
+
+	display_get_capabilities(disp->dev, &cfg);
 
 	switch (param) {
 	case CFB_DISPLAY_HEIGHT:
-		return fb->y_res;
+		return cfg.y_resolution;
 	case CFB_DISPLAY_WIDTH:
-		return fb->x_res;
+		return cfg.x_resolution;
 	case CFB_DISPLAY_PPT:
-		return fb->ppt;
+		return disp->fb.ppt;
 	case CFB_DISPLAY_ROWS:
-		if (fb->screen_info & SCREEN_INFO_MONO_VTILED) {
-			return fb->y_res / fb->ppt;
+		if (disp->fb.screen_info & SCREEN_INFO_MONO_VTILED) {
+			return cfg.y_resolution / disp->fb.ppt;
 		}
-		return fb->y_res;
+		return cfg.y_resolution;
 	case CFB_DISPLAY_COLS:
-		if (fb->screen_info & SCREEN_INFO_MONO_VTILED) {
-			return fb->x_res;
+		if (disp->fb.screen_info & SCREEN_INFO_MONO_VTILED) {
+			return cfg.x_resolution;
 		}
-		return fb->x_res / fb->ppt;
+		return cfg.x_resolution / disp->fb.ppt;
 	}
 	return 0;
 }
 
-int cfb_framebuffer_set_font(const struct device *dev, uint8_t idx)
+int cfb_framebuffer_set_font(struct cfb_framebuffer *fb, uint8_t idx)
 {
-	struct char_framebuffer *fb = &char_fb;
+	struct cfb_display *disp = CONTAINER_OF(fb, struct cfb_display, fb);
 
-	if (idx >= fb->numof_fonts) {
+	if (idx >= cfb_get_numof_fonts(NULL)) {
 		return -EINVAL;
 	}
 
-	fb->font_idx = idx;
+	disp->font_idx = idx;
 
 	return 0;
 }
 
-int cfb_get_font_size(const struct device *dev, uint8_t idx, uint8_t *width,
+int cfb_get_font_size(struct cfb_framebuffer *fb, uint8_t idx, uint8_t *width,
 		      uint8_t *height)
 {
-	const struct char_framebuffer *fb = &char_fb;
-
-	if (idx >= fb->numof_fonts) {
+	if (idx >= cfb_get_numof_fonts(NULL)) {
 		return -EINVAL;
 	}
 
@@ -789,63 +758,99 @@ int cfb_get_font_size(const struct device *dev, uint8_t idx, uint8_t *width,
 	return 0;
 }
 
-int cfb_set_kerning(const struct device *dev, int8_t kerning)
+int cfb_set_kerning(struct cfb_framebuffer *fb, int8_t kerning)
 {
-	char_fb.kerning = kerning;
+	struct cfb_display *disp = CONTAINER_OF(fb, struct cfb_display, fb);
+
+	disp->kerning = kerning;
 
 	return 0;
 }
 
-int cfb_get_numof_fonts(const struct device *dev)
+int cfb_get_numof_fonts(struct cfb_framebuffer *fb)
 {
-	const struct char_framebuffer *fb = &char_fb;
+	static int numof_fonts;
 
-	return fb->numof_fonts;
+	if (numof_fonts == 0) {
+		STRUCT_SECTION_COUNT(cfb_font, &numof_fonts);
+	}
+
+	return numof_fonts;
 }
 
-int cfb_framebuffer_init(const struct device *dev)
+int cfb_display_init(struct cfb_display *disp, const struct cfb_display_init_param *param)
 {
-	const struct display_driver_api *api = dev->api;
-	struct char_framebuffer *fb = &char_fb;
 	struct display_capabilities cfg;
 
-	__ASSERT_NO_MSG(DEVICE_API_IS(display, dev));
+	//__ASSERT_NO_MSG(DEVICE_API_IS(display, dev));
 
-	api->get_capabilities(dev, &cfg);
+	display_get_capabilities(param->dev, &cfg);
 
-	STRUCT_SECTION_COUNT(cfb_font, &fb->numof_fonts);
+	disp->dev = param->dev;
+	disp->fb.ppt = 8U;
+	disp->fb.pixel_format = cfg.current_pixel_format;
+	disp->fb.screen_info = cfg.screen_info;
+	disp->fb.buf = NULL;
+	disp->kerning = 0;
+	disp->inverted = false;
+	disp->fb.width = cfg.x_resolution;
+	disp->fb.height = cfg.y_resolution;
 
-	LOG_DBG("number of fonts %d", fb->numof_fonts);
+	disp->font_idx = 0U;
 
-	fb->x_res = cfg.x_resolution;
-	fb->y_res = cfg.y_resolution;
-	fb->ppt = 8U;
-	fb->pixel_format = cfg.current_pixel_format;
-	fb->screen_info = cfg.screen_info;
-	fb->kerning = 0;
-	fb->inverted = false;
+	disp->fb.size = param->transfer_buf_size;
+	disp->fb.buf = param->transfer_buf;
 
-	fb->fonts = TYPE_SECTION_START(cfb_font);
-	fb->font_idx = 0U;
-
-	fb->size = fb->x_res * fb->y_res / fb->ppt;
-	fb->buf = k_malloc(fb->size);
-	if (!fb->buf) {
-		return -ENOMEM;
-	}
-
-	memset(fb->buf, 0, fb->size);
+	memset(disp->fb.buf, 0, disp->fb.size);
 
 	return 0;
 }
 
-void cfb_framebuffer_deinit(const struct device *dev)
+void cfb_display_deinit(struct cfb_display *disp)
 {
-	struct char_framebuffer *fb = &char_fb;
+	memset(disp, 0, sizeof(struct cfb_display));
+}
 
-	if (fb->buf) {
-		k_free(fb->buf);
-		fb->buf = NULL;
+struct cfb_display *cfb_display_alloc(const struct device *dev)
+{
+	struct display_capabilities cfg;
+	struct cfb_display *disp;
+	struct cfb_display_init_param param;
+	size_t buf_size;
+	int err;
+
+	display_get_capabilities(dev, &cfg);
+
+	param.dev = dev;
+	param.transfer_buf_size = cfg.x_resolution * cfg.y_resolution / 8U;
+
+	buf_size = ROUND_UP(sizeof(struct cfb_display), sizeof(void *)) +
+		   ROUND_UP(param.transfer_buf_size, sizeof(void *));
+
+	disp = k_malloc(buf_size);
+	if (!disp) {
+		return NULL;
 	}
 
+	param.transfer_buf = (uint8_t *)disp + ROUND_UP(sizeof(struct cfb_display), sizeof(void *));
+
+	err = cfb_display_init(disp, &param);
+	if (err) {
+		k_free(disp);
+		return NULL;
+	}
+
+	return disp;
 }
+
+void cfb_display_free(struct cfb_display *disp)
+{
+	k_free(disp);
+}
+
+struct cfb_framebuffer *cfb_display_get_framebuffer(struct cfb_display *disp)
+{
+	return &disp->fb;
+}
+
+

--- a/subsys/fb/cfb_shell.c
+++ b/subsys/fb/cfb_shell.c
@@ -26,6 +26,7 @@
 
 static const struct device *const dev =
 	DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
+static struct cfb_display *disp;
 static const char * const param_name[] = {
 	"height", "width", "ppt", "rows", "cols"};
 
@@ -36,13 +37,18 @@ static int cmd_clear(const struct shell *sh, size_t argc, char *argv[])
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	err = cfb_framebuffer_clear(dev, true);
+	if (!disp) {
+		shell_error(sh, HELP_INIT);
+		return -ENODEV;
+	}
+
+	err = cfb_framebuffer_clear(&disp->fb, true);
 	if (err) {
 		shell_error(sh, "Framebuffer clear error=%d", err);
 		return err;
 	}
 
-	err = cfb_framebuffer_finalize(dev);
+	err = cfb_framebuffer_finalize(&disp->fb);
 	if (err) {
 		shell_error(sh, "Framebuffer finalize error=%d", err);
 		return err;
@@ -58,22 +64,27 @@ static int cmd_cfb_print(const struct shell *sh, int col, int row, char *str)
 	int err;
 	uint8_t ppt;
 
-	ppt = cfb_get_display_parameter(dev, CFB_DISPLAY_PPT);
+	if (!disp) {
+		shell_error(sh, HELP_INIT);
+		return -ENODEV;
+	}
 
-	err = cfb_framebuffer_clear(dev, false);
+	ppt = cfb_get_display_parameter(disp, CFB_DISPLAY_PPT);
+
+	err = cfb_framebuffer_clear(&disp->fb, false);
 	if (err) {
 		shell_error(sh, "Framebuffer clear failed error=%d", err);
 		return err;
 	}
 
-	err = cfb_print(dev, str, col, row * ppt);
+	err = cfb_print(&disp->fb, str, col, row * ppt);
 	if (err) {
 		shell_error(sh, "Failed to print the string %s error=%d",
 		      str, err);
 		return err;
 	}
 
-	err = cfb_framebuffer_finalize(dev);
+	err = cfb_framebuffer_finalize(&disp->fb);
 	if (err) {
 		shell_error(sh,
 			    "Failed to finalize the Framebuffer error=%d", err);
@@ -88,14 +99,19 @@ static int cmd_print(const struct shell *sh, size_t argc, char *argv[])
 	int err;
 	int col, row;
 
+	if (!disp) {
+		shell_error(sh, HELP_INIT);
+		return -ENODEV;
+	}
+
 	col = strtol(argv[1], NULL, 10);
-	if (col > cfb_get_display_parameter(dev, CFB_DISPLAY_COLS)) {
+	if (col > cfb_get_display_parameter(disp, CFB_DISPLAY_COLS)) {
 		shell_error(sh, "Invalid col=%d position", col);
 		return -EINVAL;
 	}
 
 	row = strtol(argv[2], NULL, 10);
-	if (row > cfb_get_display_parameter(dev, CFB_DISPLAY_ROWS)) {
+	if (row > cfb_get_display_parameter(disp, CFB_DISPLAY_ROWS)) {
 		shell_error(sh, "Invalid row=%d position", row);
 		return -EINVAL;
 	}
@@ -114,15 +130,20 @@ static int cmd_draw_text(const struct shell *sh, size_t argc, char *argv[])
 	int err;
 	int x, y;
 
+	if (!disp) {
+		shell_error(sh, HELP_INIT);
+		return -ENODEV;
+	}
+
 	x = strtol(argv[1], NULL, 10);
 	y = strtol(argv[2], NULL, 10);
-	err = cfb_draw_text(dev, argv[3], x, y);
+	err = cfb_draw_text(&disp->fb, argv[3], x, y);
 	if (err) {
 		shell_error(sh, "Failed text drawing to Framebuffer error=%d", err);
 		return err;
 	}
 
-	err = cfb_framebuffer_finalize(dev);
+	err = cfb_framebuffer_finalize(&disp->fb);
 
 	return err;
 }
@@ -132,16 +153,21 @@ static int cmd_draw_point(const struct shell *sh, size_t argc, char *argv[])
 	int err;
 	struct cfb_position pos;
 
+	if (!disp) {
+		shell_error(sh, HELP_INIT);
+		return -ENODEV;
+	}
+
 	pos.x = strtol(argv[1], NULL, 10);
 	pos.y = strtol(argv[2], NULL, 10);
 
-	err = cfb_draw_point(dev, &pos);
+	err = cfb_draw_point(&disp->fb, &pos);
 	if (err) {
 		shell_error(sh, "Failed point drawing to Framebuffer error=%d", err);
 		return err;
 	}
 
-	err = cfb_framebuffer_finalize(dev);
+	err = cfb_framebuffer_finalize(&disp->fb);
 
 	return err;
 }
@@ -151,18 +177,23 @@ static int cmd_draw_line(const struct shell *sh, size_t argc, char *argv[])
 	int err;
 	struct cfb_position start, end;
 
+	if (!disp) {
+		shell_error(sh, HELP_INIT);
+		return -ENODEV;
+	}
+
 	start.x = strtol(argv[1], NULL, 10);
 	start.y = strtol(argv[2], NULL, 10);
 	end.x = strtol(argv[3], NULL, 10);
 	end.y = strtol(argv[4], NULL, 10);
 
-	err = cfb_draw_line(dev, &start, &end);
+	err = cfb_draw_line(&disp->fb, &start, &end);
 	if (err) {
 		shell_error(sh, "Failed text drawing to Framebuffer error=%d", err);
 		return err;
 	}
 
-	err = cfb_framebuffer_finalize(dev);
+	err = cfb_framebuffer_finalize(&disp->fb);
 
 	return err;
 }
@@ -172,18 +203,23 @@ static int cmd_draw_rect(const struct shell *sh, size_t argc, char *argv[])
 	int err;
 	struct cfb_position start, end;
 
+	if (!disp) {
+		shell_error(sh, HELP_INIT);
+		return -ENODEV;
+	}
+
 	start.x = strtol(argv[1], NULL, 10);
 	start.y = strtol(argv[2], NULL, 10);
 	end.x = strtol(argv[3], NULL, 10);
 	end.y = strtol(argv[4], NULL, 10);
 
-	err = cfb_draw_rect(dev, &start, &end);
+	err = cfb_draw_rect(&disp->fb, &start, &end);
 	if (err) {
 		shell_error(sh, "Failed rectanble drawing to Framebuffer error=%d", err);
 		return err;
 	}
 
-	err = cfb_framebuffer_finalize(dev);
+	err = cfb_framebuffer_finalize(&disp->fb);
 
 	return err;
 }
@@ -198,13 +234,13 @@ static int cmd_draw_circle(const struct shell *sh, size_t argc, char *argv[])
 	center.y = strtol(argv[2], NULL, 10);
 	radius = strtol(argv[3], NULL, 10);
 
-	err = cfb_draw_circle(dev, &center, radius);
+	err = cfb_draw_circle(&disp->fb, &center, radius);
 	if (err) {
 		shell_error(sh, "Failed circle drawing to Framebuffer error=%d", err);
 		return err;
 	}
 
-	err = cfb_framebuffer_finalize(dev);
+	err = cfb_framebuffer_finalize(&disp->fb);
 
 	return err;
 }
@@ -215,19 +251,24 @@ static int cmd_scroll_vert(const struct shell *sh, size_t argc, char *argv[])
 	int col, row;
 	int boundary;
 
+	if (!disp) {
+		shell_error(sh, HELP_INIT);
+		return -ENODEV;
+	}
+
 	col = strtol(argv[1], NULL, 10);
-	if (col > cfb_get_display_parameter(dev, CFB_DISPLAY_COLS)) {
+	if (col > cfb_get_display_parameter(disp, CFB_DISPLAY_COLS)) {
 		shell_error(sh, "Invalid col=%d position", col);
 		return -EINVAL;
 	}
 
 	row = strtol(argv[2], NULL, 10);
-	if (row > cfb_get_display_parameter(dev, CFB_DISPLAY_ROWS)) {
+	if (row > cfb_get_display_parameter(disp, CFB_DISPLAY_ROWS)) {
 		shell_error(sh, "Invalid row=%d position", row);
 		return -EINVAL;
 	}
 
-	boundary = cfb_get_display_parameter(dev, CFB_DISPLAY_ROWS) - row;
+	boundary = cfb_get_display_parameter(disp, CFB_DISPLAY_ROWS) - row;
 
 	for (int i = 0; i < boundary; i++) {
 		err = cmd_cfb_print(sh, col, row, argv[3]);
@@ -251,20 +292,25 @@ static int cmd_scroll_horz(const struct shell *sh, size_t argc, char *argv[])
 	int col, row;
 	int boundary;
 
+	if (!disp) {
+		shell_error(sh, HELP_INIT);
+		return -ENODEV;
+	}
+
 	col = strtol(argv[1], NULL, 10);
-	if (col > cfb_get_display_parameter(dev, CFB_DISPLAY_COLS)) {
+	if (col > cfb_get_display_parameter(disp, CFB_DISPLAY_COLS)) {
 		shell_error(sh, "Invalid col=%d position", col);
 		return -EINVAL;
 	}
 
 	row = strtol(argv[2], NULL, 10);
-	if (row > cfb_get_display_parameter(dev, CFB_DISPLAY_ROWS)) {
+	if (row > cfb_get_display_parameter(disp, CFB_DISPLAY_ROWS)) {
 		shell_error(sh, "Invalid row=%d position", row);
 		return -EINVAL;
 	}
 
 	col++;
-	boundary = cfb_get_display_parameter(dev, CFB_DISPLAY_COLS) - col;
+	boundary = cfb_get_display_parameter(disp, CFB_DISPLAY_COLS) - col;
 
 	for (int i = 0; i < boundary; i++) {
 		err = cmd_cfb_print(sh, col, row, argv[3]);
@@ -289,15 +335,20 @@ static int cmd_set_font(const struct shell *sh, size_t argc, char *argv[])
 	uint8_t height;
 	uint8_t width;
 
+	if (!disp) {
+		shell_error(sh, HELP_INIT);
+		return -ENODEV;
+	}
+
 	idx = strtol(argv[1], NULL, 10);
 
-	err = cfb_get_font_size(dev, idx, &width, &height);
+	err = cfb_get_font_size(&disp->fb, idx, &width, &height);
 	if (err) {
 		shell_error(sh, "Invalid font idx=%d err=%d\n", idx, err);
 		return err;
 	}
 
-	err = cfb_framebuffer_set_font(dev, idx);
+	err = cfb_framebuffer_set_font(&disp->fb, idx);
 	if (err) {
 		shell_error(sh, "Failed setting font idx=%d err=%d", idx,
 			    err);
@@ -315,13 +366,19 @@ static int cmd_set_kerning(const struct shell *sh, size_t argc, char *argv[])
 	int err = 0;
 	long kerning;
 
+	if (!disp) {
+		shell_error(sh, HELP_INIT);
+		return -ENODEV;
+	}
+
+	errno = 0;
 	kerning = shell_strtol(argv[1], 10, &err);
 	if (err) {
 		shell_error(sh, HELP_INIT);
 		return -EINVAL;
 	}
 
-	err = cfb_set_kerning(dev, kerning);
+	err = cfb_set_kerning(&disp->fb, kerning);
 	if (err) {
 		shell_error(sh, "Failed to set kerning err=%d", err);
 		return err;
@@ -334,8 +391,13 @@ static int cmd_invert(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err;
 
+	if (!disp) {
+		shell_error(sh, HELP_INIT);
+		return -ENODEV;
+	}
+
 	if (argc == 1) {
-		err = cfb_framebuffer_invert(dev);
+		err = cfb_framebuffer_invert(&disp->fb);
 		if (err) {
 			shell_error(sh, "Error inverting Framebuffer");
 			return err;
@@ -348,7 +410,7 @@ static int cmd_invert(const struct shell *sh, size_t argc, char *argv[])
 		w = strtol(argv[3], NULL, 10);
 		h = strtol(argv[4], NULL, 10);
 
-		err = cfb_invert_area(dev, x, y, w, h);
+		err = cfb_invert_area(&disp->fb, x, y, w, h);
 		if (err) {
 			shell_error(sh, "Error invert area");
 			return err;
@@ -358,7 +420,7 @@ static int cmd_invert(const struct shell *sh, size_t argc, char *argv[])
 		return 0;
 	}
 
-	cfb_framebuffer_finalize(dev);
+	cfb_framebuffer_finalize(&disp->fb);
 
 	shell_print(sh, "Framebuffer Inverted");
 
@@ -374,8 +436,13 @@ static int cmd_get_fonts(const struct shell *sh, size_t argc, char *argv[])
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	for (int idx = 0; idx < cfb_get_numof_fonts(dev); idx++) {
-		if (cfb_get_font_size(dev, idx, &font_width, &font_height)) {
+	if (!disp) {
+		shell_error(sh, HELP_INIT);
+		return -ENODEV;
+	}
+
+	for (int idx = 0; idx < cfb_get_numof_fonts(&disp->fb); idx++) {
+		if (cfb_get_font_size(&disp->fb, idx, &font_width, &font_height)) {
 			break;
 		}
 		shell_print(sh, "idx=%d height=%d width=%d", idx,
@@ -392,6 +459,11 @@ static int cmd_get_device(const struct shell *sh, size_t argc, char *argv[])
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
+	if (!disp) {
+		shell_error(sh, HELP_INIT);
+		return -ENODEV;
+	}
+
 	shell_print(sh, "Framebuffer Device: %s", dev->name);
 
 	return err;
@@ -403,9 +475,14 @@ static int cmd_get_param_all(const struct shell *sh, size_t argc,
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
+	if (!disp) {
+		shell_error(sh, HELP_INIT);
+		return -ENODEV;
+	}
+
 	for (unsigned int i = 0; i <= CFB_DISPLAY_COLS; i++) {
 		shell_print(sh, "param: %s=%d", param_name[i],
-				cfb_get_display_parameter(dev, i));
+				cfb_get_display_parameter(disp, i));
 
 	}
 
@@ -418,8 +495,13 @@ static int cmd_get_param_height(const struct shell *sh, size_t argc,
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
+	if (!disp) {
+		shell_error(sh, HELP_INIT);
+		return -ENODEV;
+	}
+
 	shell_print(sh, "param: %s=%d", param_name[CFB_DISPLAY_HEIGHT],
-		    cfb_get_display_parameter(dev, CFB_DISPLAY_HEIGHT));
+		    cfb_get_display_parameter(disp, CFB_DISPLAY_HEIGHT));
 
 	return 0;
 }
@@ -430,8 +512,13 @@ static int cmd_get_param_width(const struct shell *sh, size_t argc,
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
+	if (!disp) {
+		shell_error(sh, HELP_INIT);
+		return -ENODEV;
+	}
+
 	shell_print(sh, "param: %s=%d", param_name[CFB_DISPLAY_WIDTH],
-		    cfb_get_display_parameter(dev, CFB_DISPLAY_WIDTH));
+		    cfb_get_display_parameter(disp, CFB_DISPLAY_WIDTH));
 
 	return 0;
 }
@@ -442,8 +529,13 @@ static int cmd_get_param_ppt(const struct shell *sh, size_t argc,
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
+	if (!disp) {
+		shell_error(sh, HELP_INIT);
+		return -ENODEV;
+	}
+
 	shell_print(sh, "param: %s=%d", param_name[CFB_DISPLAY_PPT],
-		    cfb_get_display_parameter(dev, CFB_DISPLAY_PPT));
+		    cfb_get_display_parameter(disp, CFB_DISPLAY_PPT));
 
 	return 0;
 }
@@ -454,8 +546,13 @@ static int cmd_get_param_rows(const struct shell *sh, size_t argc,
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
+	if (!disp) {
+		shell_error(sh, HELP_INIT);
+		return -ENODEV;
+	}
+
 	shell_print(sh, "param: %s=%d", param_name[CFB_DISPLAY_ROWS],
-		    cfb_get_display_parameter(dev, CFB_DISPLAY_ROWS));
+		    cfb_get_display_parameter(disp, CFB_DISPLAY_ROWS));
 
 	return 0;
 }
@@ -466,8 +563,13 @@ static int cmd_get_param_cols(const struct shell *sh, size_t argc,
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
+	if (!disp) {
+		shell_error(sh, HELP_INIT);
+		return -ENODEV;
+	}
+
 	shell_print(sh, "param: %s=%d", param_name[CFB_DISPLAY_COLS],
-		    cfb_get_display_parameter(dev, CFB_DISPLAY_COLS));
+		    cfb_get_display_parameter(disp, CFB_DISPLAY_COLS));
 
 	return 0;
 }
@@ -496,10 +598,14 @@ static int cmd_init(const struct shell *sh, size_t argc, char *argv[])
 		return err;
 	}
 
-	err = cfb_framebuffer_init(dev);
-	if (err) {
+	if (disp) {
+		cfb_display_free(disp);
+	}
+
+	disp = cfb_display_alloc(dev);
+	if (!disp) {
 		shell_error(sh, "Framebuffer initialization failed!");
-		return err;
+		return -ENOMEM;
 	}
 
 	shell_print(sh, "Framebuffer initialized: %s", dev->name);

--- a/tests/subsys/display/cfb/basic/src/clear.c
+++ b/tests/subsys/display/cfb/basic/src/clear.c
@@ -36,17 +36,17 @@ static void cfb_test_before(void *text_fixture)
 
 	zassert_ok(display_blanking_off(dev));
 
-	zassert_ok(cfb_framebuffer_init(dev));
+	zassert_ok(cfb_framebuffer_init(fb));
 }
 
 static void cfb_test_after(void *test_fixture)
 {
-	cfb_framebuffer_deinit(dev);
+	cfb_framebuffer_deinit(fb);
 }
 
 ZTEST(clear, test_clear_false)
 {
-	zassert_ok(cfb_framebuffer_clear(dev, false));
+	zassert_ok(cfb_framebuffer_clear(fb, false));
 
 	/* checking memory not updated */
 	zassert_false(verify_color_inside_rect(0, 0, 320, 240, 0x0));
@@ -54,7 +54,7 @@ ZTEST(clear, test_clear_false)
 
 ZTEST(clear, test_clear_true)
 {
-	zassert_ok(cfb_framebuffer_clear(dev, true));
+	zassert_ok(cfb_framebuffer_clear(fb, true));
 
 	zassert_true(verify_color_inside_rect(0, 0, 320, 240, 0x0));
 }

--- a/tests/subsys/display/cfb/basic/src/clear.c
+++ b/tests/subsys/display/cfb/basic/src/clear.c
@@ -15,9 +15,9 @@
 
 LOG_MODULE_REGISTER(clear, CONFIG_DISPLAY_LOG_LEVEL);
 
-static const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
-static const uint32_t display_width = DT_PROP(DT_CHOSEN(zephyr_display), width);
-static const uint32_t display_height = DT_PROP(DT_CHOSEN(zephyr_display), height);
+
+static struct cfb_display *disp;
+static struct cfb_framebuffer *fb;
 
 /**
  * Fill the buffer with 0xAA before running tests.
@@ -28,20 +28,19 @@ static void cfb_test_before(void *text_fixture)
 		.height = display_height,
 		.pitch = display_width,
 		.width = display_width,
-		.buf_size = display_height * display_width / 8,
+		.buf_size = display_buf_size(dev),
 	};
+
+	disp = display_init();
+	fb = cfb_display_get_framebuffer(disp);
 
 	memset(read_buffer, 0xAA, sizeof(read_buffer));
 	zassert_ok(display_write(dev, 0, 0, &desc, read_buffer));
-
-	zassert_ok(display_blanking_off(dev));
-
-	zassert_ok(cfb_framebuffer_init(fb));
 }
 
 static void cfb_test_after(void *test_fixture)
 {
-	cfb_framebuffer_deinit(fb);
+	display_deinit(disp);
 }
 
 ZTEST(clear, test_clear_false)

--- a/tests/subsys/display/cfb/basic/src/draw_circle.c
+++ b/tests/subsys/display/cfb/basic/src/draw_circle.c
@@ -15,33 +15,21 @@
 
 LOG_MODULE_REGISTER(draw_circle, CONFIG_DISPLAY_LOG_LEVEL);
 
-static const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
-static const uint32_t display_width = DT_PROP(DT_CHOSEN(zephyr_display), width);
-static const uint32_t display_height = DT_PROP(DT_CHOSEN(zephyr_display), height);
+static struct cfb_display *disp;
+static struct cfb_framebuffer *fb;
 
 /**
  * Fill the buffer with 0 before running tests.
  */
 static void cfb_test_before(void *text_fixture)
 {
-	struct display_buffer_descriptor desc = {
-		.height = display_height,
-		.pitch = display_width,
-		.width = display_width,
-		.buf_size = display_height * display_width / 8,
-	};
-
-	memset(read_buffer, 0, sizeof(read_buffer));
-	zassert_ok(display_write(dev, 0, 0, &desc, read_buffer));
-
-	zassert_ok(display_blanking_off(dev));
-
-	zassert_ok(cfb_framebuffer_init(fb));
+	disp = display_init();
+	fb = cfb_display_get_framebuffer(disp);
 }
 
 static void cfb_test_after(void *test_fixture)
 {
-	cfb_framebuffer_deinit(fb);
+	display_deinit(disp);
 }
 
 /*

--- a/tests/subsys/display/cfb/basic/src/draw_circle.c
+++ b/tests/subsys/display/cfb/basic/src/draw_circle.c
@@ -36,12 +36,12 @@ static void cfb_test_before(void *text_fixture)
 
 	zassert_ok(display_blanking_off(dev));
 
-	zassert_ok(cfb_framebuffer_init(dev));
+	zassert_ok(cfb_framebuffer_init(fb));
 }
 
 static void cfb_test_after(void *test_fixture)
 {
-	cfb_framebuffer_deinit(dev);
+	cfb_framebuffer_deinit(fb);
 }
 
 /*
@@ -53,8 +53,8 @@ ZTEST(draw_circle, test_draw_circle_10_at_10_10)
 	const uint16_t rect_side_len = 21;
 	const struct cfb_position center = {10, 10};
 
-	zassert_ok(cfb_draw_circle(dev, &center, radius), "");
-	zassert_ok(cfb_framebuffer_finalize(dev), "");
+	zassert_ok(cfb_draw_circle(fb, &center, radius), "");
+	zassert_ok(cfb_framebuffer_finalize(fb), "");
 
 	zassert_true(verify_image(0, 0, circle10, rect_side_len, rect_side_len), "");
 }
@@ -65,8 +65,8 @@ ZTEST(draw_circle, test_draw_circle_10_at_11_11)
 	const uint16_t rect_side_len = 21;
 	const struct cfb_position center = {11, 11};
 
-	zassert_ok(cfb_draw_circle(dev, &center, radius), "");
-	zassert_ok(cfb_framebuffer_finalize(dev), "");
+	zassert_ok(cfb_draw_circle(fb, &center, radius), "");
+	zassert_ok(cfb_framebuffer_finalize(fb), "");
 
 	zassert_true(verify_image(1, 1, circle10, rect_side_len, rect_side_len), "");
 }
@@ -78,8 +78,8 @@ ZTEST(draw_circle, test_draw_circle_10_at_19_25)
 	const uint16_t rect_side_len = 21;
 	const struct cfb_position center = {19, 25};
 
-	zassert_ok(cfb_draw_circle(dev, &center, radius), "");
-	zassert_ok(cfb_framebuffer_finalize(dev), "");
+	zassert_ok(cfb_draw_circle(fb, &center, radius), "");
+	zassert_ok(cfb_framebuffer_finalize(fb), "");
 
 	zassert_true(verify_image(9, 15, circle10, rect_side_len, rect_side_len), "");
 }
@@ -90,8 +90,8 @@ ZTEST(draw_circle, test_draw_circle_10_at_20_26)
 	const uint16_t rect_side_len = 21;
 	const struct cfb_position center = {20, 26};
 
-	zassert_ok(cfb_draw_circle(dev, &center, radius), "");
-	zassert_ok(cfb_framebuffer_finalize(dev), "");
+	zassert_ok(cfb_draw_circle(fb, &center, radius), "");
+	zassert_ok(cfb_framebuffer_finalize(fb), "");
 
 	zassert_true(verify_image(10, 16, circle10, rect_side_len, rect_side_len), "");
 }
@@ -102,8 +102,8 @@ ZTEST(draw_circle, test_draw_circle_10_at_21_27)
 	const uint16_t rect_side_len = 21;
 	const struct cfb_position center = {21, 27};
 
-	zassert_ok(cfb_draw_circle(dev, &center, radius), "");
-	zassert_ok(cfb_framebuffer_finalize(dev), "");
+	zassert_ok(cfb_draw_circle(fb, &center, radius), "");
+	zassert_ok(cfb_framebuffer_finalize(fb), "");
 
 	zassert_true(verify_image(11, 17, circle10, rect_side_len, rect_side_len), "");
 }
@@ -116,8 +116,8 @@ ZTEST(draw_circle, test_draw_circle_10_outside_top_left)
 	const uint16_t radius = 10;
 	const struct cfb_position center = {-4, -4};
 
-	zassert_ok(cfb_draw_circle(dev, &center, radius), "");
-	zassert_ok(cfb_framebuffer_finalize(dev), "");
+	zassert_ok(cfb_draw_circle(fb, &center, radius), "");
+	zassert_ok(cfb_framebuffer_finalize(fb), "");
 
 	zassert_true(verify_image_and_bg(0, 0, circle10_outside_top_left, 6, 6, 0), "");
 }
@@ -129,8 +129,8 @@ ZTEST(draw_circle, test_draw_circle_10_outside_top_right)
 	const struct cfb_position center = {display_width - 5 + radius,
 					    -(rect_side_len - 8) + radius};
 
-	zassert_ok(cfb_draw_circle(dev, &center, radius), "");
-	zassert_ok(cfb_framebuffer_finalize(dev), "");
+	zassert_ok(cfb_draw_circle(fb, &center, radius), "");
+	zassert_ok(cfb_framebuffer_finalize(fb), "");
 
 	zassert_true(verify_image(display_width - 5, 0, circle10_outside_top_right, 5, 8), "");
 }
@@ -140,8 +140,8 @@ ZTEST(draw_circle, test_draw_circle_10_outside_bottom_right)
 	const uint16_t radius = 10;
 	const struct cfb_position center = {display_width + 3, display_height + 3};
 
-	zassert_ok(cfb_draw_circle(dev, &center, radius), "");
-	zassert_ok(cfb_framebuffer_finalize(dev), "");
+	zassert_ok(cfb_draw_circle(fb, &center, radius), "");
+	zassert_ok(cfb_framebuffer_finalize(fb), "");
 
 	zassert_true(verify_image_and_bg(display_width - 6, display_height - 6,
 					 circle10_outside_bottom_right, 6, 6, 0),
@@ -155,8 +155,8 @@ ZTEST(draw_circle, test_draw_circle_10_outside_bottom_left)
 	const struct cfb_position center = {-(rect_side_len - 3) + radius,
 					    display_height - 14 + radius};
 
-	zassert_ok(cfb_draw_circle(dev, &center, radius), "");
-	zassert_ok(cfb_framebuffer_finalize(dev), "");
+	zassert_ok(cfb_draw_circle(fb, &center, radius), "");
+	zassert_ok(cfb_framebuffer_finalize(fb), "");
 
 	zassert_true(verify_image(0, display_height - 14, circle10_outside_bottom_left, 3, 14), "");
 }
@@ -166,8 +166,8 @@ ZTEST(draw_circle, test_draw_circle_10_outside_top_left_no_visible_pixels)
 	const uint16_t radius = 10;
 	const struct cfb_position center = {-12, -12};
 
-	zassert_ok(cfb_draw_circle(dev, &center, radius), "");
-	zassert_ok(cfb_framebuffer_finalize(dev), "");
+	zassert_ok(cfb_draw_circle(fb, &center, radius), "");
+	zassert_ok(cfb_framebuffer_finalize(fb), "");
 
 	zassert_true(verify_color_inside_rect(0, 0, display_width, display_height, 0), "");
 }

--- a/tests/subsys/display/cfb/basic/src/draw_line.c
+++ b/tests/subsys/display/cfb/basic/src/draw_line.c
@@ -36,12 +36,12 @@ static void cfb_test_before(void *text_fixture)
 
 	zassert_ok(display_blanking_off(dev));
 
-	zassert_ok(cfb_framebuffer_init(dev));
+	zassert_ok(cfb_framebuffer_init(fb));
 }
 
 static void cfb_test_after(void *test_fixture)
 {
-	cfb_framebuffer_deinit(dev);
+	cfb_framebuffer_deinit(fb);
 }
 
 ZTEST(draw_line, test_draw_line_top_end)
@@ -49,8 +49,8 @@ ZTEST(draw_line, test_draw_line_top_end)
 	struct cfb_position start = {0, 0};
 	struct cfb_position end = {display_width, 0};
 
-	zassert_ok(cfb_draw_line(dev, &start, &end));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_line(fb, &start, &end));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_color_inside_rect(0, 0, display_width, 1, 0xFFFFFF));
 }
@@ -60,8 +60,8 @@ ZTEST(draw_line, test_draw_line_left_end)
 	struct cfb_position start = {0, 0};
 	struct cfb_position end = {0, display_height};
 
-	zassert_ok(cfb_draw_line(dev, &start, &end));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_line(fb, &start, &end));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_color_inside_rect(0, 0, 1, display_height, 0xFFFFFF));
 }
@@ -71,8 +71,8 @@ ZTEST(draw_line, test_draw_right_end)
 	struct cfb_position start = {display_width - 1, 0};
 	struct cfb_position end = {display_width - 1, display_height};
 
-	zassert_ok(cfb_draw_line(dev, &start, &end));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_line(fb, &start, &end));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_color_inside_rect(display_width - 1, 0, 1, display_height, 0xFFFFFF));
 }
@@ -82,8 +82,8 @@ ZTEST(draw_line, test_draw_line_bottom_end)
 	struct cfb_position start = {0, 239};
 	struct cfb_position end = {display_width, 239};
 
-	zassert_ok(cfb_draw_line(dev, &start, &end));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_line(fb, &start, &end));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_color_inside_rect(0, display_height - 1, display_width, 1, 0xFFFFFF));
 }
@@ -93,11 +93,11 @@ ZTEST(draw_line, test_render_twice_on_same_tile)
 	struct cfb_position start = {0, 0};
 	struct cfb_position end = {display_width, 0};
 
-	zassert_ok(cfb_draw_line(dev, &start, &end));
+	zassert_ok(cfb_draw_line(fb, &start, &end));
 	start.y = 7;
 	end.y = 7;
-	zassert_ok(cfb_draw_line(dev, &start, &end));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_line(fb, &start, &end));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_color_inside_rect(0, 0, display_width, 1, 0xFFFFFF));
 	zassert_true(verify_color_inside_rect(0, 1, display_width, 6, 0x0));
@@ -110,8 +110,8 @@ ZTEST(draw_line, test_crossing_diagonally_end_to_end)
 	struct cfb_position start = {0, 0};
 	struct cfb_position end = {320, 240};
 
-	zassert_ok(cfb_draw_line(dev, &start, &end));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_line(fb, &start, &end));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	for (size_t i = 0; i < 10; i++) {
 		zassert_true(verify_image(32 * i, 24 * i, diagonal3224, 32, 24));
@@ -123,8 +123,8 @@ ZTEST(draw_line, test_crossing_diagonally_from_outside_area)
 	struct cfb_position start = {-32, -48};
 	struct cfb_position end = {384, 264};
 
-	zassert_ok(cfb_draw_line(dev, &start, &end));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_line(fb, &start, &end));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	for (size_t i = 0; i < 9; i++) {
 		zassert_true(verify_image(32 + 32 * i, 24 * i, diagonal3224, 32, 24));

--- a/tests/subsys/display/cfb/basic/src/draw_line.c
+++ b/tests/subsys/display/cfb/basic/src/draw_line.c
@@ -15,33 +15,21 @@
 
 LOG_MODULE_REGISTER(draw_line, CONFIG_DISPLAY_LOG_LEVEL);
 
-static const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
-static const uint32_t display_width = DT_PROP(DT_CHOSEN(zephyr_display), width);
-static const uint32_t display_height = DT_PROP(DT_CHOSEN(zephyr_display), height);
+static struct cfb_display *disp;
+static struct cfb_framebuffer *fb;
 
 /**
  * Fill the buffer with 0 before running tests.
  */
 static void cfb_test_before(void *text_fixture)
 {
-	struct display_buffer_descriptor desc = {
-		.height = display_height,
-		.pitch = display_width,
-		.width = display_width,
-		.buf_size = display_height * display_width / 8,
-	};
-
-	memset(read_buffer, 0, sizeof(read_buffer));
-	zassert_ok(display_write(dev, 0, 0, &desc, read_buffer));
-
-	zassert_ok(display_blanking_off(dev));
-
-	zassert_ok(cfb_framebuffer_init(fb));
+	disp = display_init();
+	fb = cfb_display_get_framebuffer(disp);
 }
 
 static void cfb_test_after(void *test_fixture)
 {
-	cfb_framebuffer_deinit(fb);
+	display_deinit(disp);
 }
 
 ZTEST(draw_line, test_draw_line_top_end)

--- a/tests/subsys/display/cfb/basic/src/draw_point.c
+++ b/tests/subsys/display/cfb/basic/src/draw_point.c
@@ -15,33 +15,21 @@
 
 LOG_MODULE_REGISTER(draw_point, CONFIG_DISPLAY_LOG_LEVEL);
 
-static const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
-static const uint32_t display_width = DT_PROP(DT_CHOSEN(zephyr_display), width);
-static const uint32_t display_height = DT_PROP(DT_CHOSEN(zephyr_display), height);
+static struct cfb_display *disp;
+static struct cfb_framebuffer *fb;
 
 /**
  * Fill the buffer with 0 before running tests.
  */
 static void cfb_test_before(void *text_fixture)
 {
-	struct display_buffer_descriptor desc = {
-		.height = display_height,
-		.pitch = display_width,
-		.width = display_width,
-		.buf_size = display_height * display_width / 8,
-	};
-
-	memset(read_buffer, 0, sizeof(read_buffer));
-	zassert_ok(display_write(dev, 0, 0, &desc, read_buffer));
-
-	zassert_ok(display_blanking_off(dev));
-
-	zassert_ok(cfb_framebuffer_init(fb));
+	disp = display_init();
+	fb = cfb_display_get_framebuffer(disp);
 }
 
 static void cfb_test_after(void *test_fixture)
 {
-	cfb_framebuffer_deinit(fb);
+	display_deinit(disp);
 }
 
 /*

--- a/tests/subsys/display/cfb/basic/src/draw_point.c
+++ b/tests/subsys/display/cfb/basic/src/draw_point.c
@@ -36,12 +36,12 @@ static void cfb_test_before(void *text_fixture)
 
 	zassert_ok(display_blanking_off(dev));
 
-	zassert_ok(cfb_framebuffer_init(dev));
+	zassert_ok(cfb_framebuffer_init(fb));
 }
 
 static void cfb_test_after(void *test_fixture)
 {
-	cfb_framebuffer_deinit(dev);
+	cfb_framebuffer_deinit(fb);
 }
 
 /*
@@ -51,8 +51,8 @@ ZTEST(draw_point, test_draw_point_at_0_0)
 {
 	struct cfb_position pos = {0, 0};
 
-	zassert_ok(cfb_draw_point(dev, &pos));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_point(fb, &pos));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_pixel_and_bg(0, 0, 1, 0));
 }
@@ -61,8 +61,8 @@ ZTEST(draw_point, test_draw_point_at_1_1)
 {
 	struct cfb_position pos = {1, 1};
 
-	zassert_ok(cfb_draw_point(dev, &pos));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_point(fb, &pos));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_pixel_and_bg(1, 1, 1, 0));
 }
@@ -74,8 +74,8 @@ ZTEST(draw_point, test_draw_pont_at_9_15)
 {
 	struct cfb_position pos = {9, 15};
 
-	zassert_ok(cfb_draw_point(dev, &pos));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_point(fb, &pos));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_pixel_and_bg(9, 15, 1, 0));
 }
@@ -84,8 +84,8 @@ ZTEST(draw_point, test_draw_point_at_10_16)
 {
 	struct cfb_position pos = {10, 16};
 
-	zassert_ok(cfb_draw_point(dev, &pos));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_point(fb, &pos));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_pixel_and_bg(10, 16, 1, 0));
 }
@@ -94,8 +94,8 @@ ZTEST(draw_point, test_draw_point_at_11_17)
 {
 	struct cfb_position pos = {11, 17};
 
-	zassert_ok(cfb_draw_point(dev, &pos));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_point(fb, &pos));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_pixel_and_bg(11, 17, 1, 0));
 }
@@ -105,15 +105,15 @@ ZTEST(draw_point, test_draw_point_twice_on_same_tile)
 	struct cfb_position pos = {10, 0};
 
 	pos.y = 7;
-	zassert_ok(cfb_draw_point(dev, &pos));
+	zassert_ok(cfb_draw_point(fb, &pos));
 
 	pos.y = 8;
-	zassert_ok(cfb_draw_point(dev, &pos));
+	zassert_ok(cfb_draw_point(fb, &pos));
 
 	pos.y = 9;
-	zassert_ok(cfb_draw_point(dev, &pos));
+	zassert_ok(cfb_draw_point(fb, &pos));
 
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_color_inside_rect(10, 7, 1, 3, 0xFFFFFF));
 	zassert_true(verify_color_outside_rect(10, 7, 1, 3, 0x0));
@@ -123,8 +123,8 @@ ZTEST(draw_point, test_draw_point_outside_top_left)
 {
 	struct cfb_position pos = {0, -1};
 
-	zassert_ok(cfb_draw_point(dev, &pos));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_point(fb, &pos));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_color_inside_rect(0, 0, display_width, display_height, 0));
 }
@@ -133,8 +133,8 @@ ZTEST(draw_point, test_draw_point_outside_top_right)
 {
 	struct cfb_position pos = {display_width, 0};
 
-	zassert_ok(cfb_draw_point(dev, &pos));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_point(fb, &pos));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_color_inside_rect(0, 0, display_width, display_height, 0));
 }
@@ -143,8 +143,8 @@ ZTEST(draw_point, test_draw_point_outside_bottom_right)
 {
 	struct cfb_position pos = {0, display_height};
 
-	zassert_ok(cfb_draw_point(dev, &pos));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_point(fb, &pos));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_color_inside_rect(0, 0, display_width, display_height, 0));
 }
@@ -153,8 +153,8 @@ ZTEST(draw_point, test_draw_point_outside_bottom_left)
 {
 	struct cfb_position pos = {-1, display_height};
 
-	zassert_ok(cfb_draw_point(dev, &pos));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_point(fb, &pos));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_color_inside_rect(0, 0, display_width, display_height, 0));
 }

--- a/tests/subsys/display/cfb/basic/src/draw_rect.c
+++ b/tests/subsys/display/cfb/basic/src/draw_rect.c
@@ -15,33 +15,21 @@
 
 LOG_MODULE_REGISTER(draw_rect, CONFIG_DISPLAY_LOG_LEVEL);
 
-static const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
-static const uint32_t display_width = DT_PROP(DT_CHOSEN(zephyr_display), width);
-static const uint32_t display_height = DT_PROP(DT_CHOSEN(zephyr_display), height);
+static struct cfb_display *disp;
+static struct cfb_framebuffer *fb;
 
 /**
  * Fill the buffer with 0 before running tests.
  */
 static void cfb_test_before(void *text_fixture)
 {
-	struct display_buffer_descriptor desc = {
-		.height = display_height,
-		.pitch = display_width,
-		.width = display_width,
-		.buf_size = display_height * display_width / 8,
-	};
-
-	memset(read_buffer, 0, sizeof(read_buffer));
-	zassert_ok(display_write(dev, 0, 0, &desc, read_buffer));
-
-	zassert_ok(display_blanking_off(dev));
-
-	zassert_ok(cfb_framebuffer_init(fb));
+	disp = display_init();
+	fb = cfb_display_get_framebuffer(disp);
 }
 
 static void cfb_test_after(void *test_fixture)
 {
-	cfb_framebuffer_deinit(fb);
+	display_deinit(disp);
 }
 
 /*

--- a/tests/subsys/display/cfb/basic/src/draw_rect.c
+++ b/tests/subsys/display/cfb/basic/src/draw_rect.c
@@ -36,12 +36,12 @@ static void cfb_test_before(void *text_fixture)
 
 	zassert_ok(display_blanking_off(dev));
 
-	zassert_ok(cfb_framebuffer_init(dev));
+	zassert_ok(cfb_framebuffer_init(fb));
 }
 
 static void cfb_test_after(void *test_fixture)
 {
-	cfb_framebuffer_deinit(dev);
+	cfb_framebuffer_deinit(fb);
 }
 
 /*
@@ -52,8 +52,8 @@ ZTEST(draw_rect, test_draw_rect_1123_at_0_0)
 	struct cfb_position start = {0, 0};
 	struct cfb_position end = {start.x + 10, start.y + 22};
 
-	zassert_ok(cfb_draw_rect(dev, &start, &end), "");
-	zassert_ok(cfb_framebuffer_finalize(dev), "");
+	zassert_ok(cfb_draw_rect(fb, &start, &end), "");
+	zassert_ok(cfb_framebuffer_finalize(fb), "");
 
 	zassert_true(verify_image_and_bg(0, 0, rectspace1123, 11, 23, 0), "");
 }
@@ -63,8 +63,8 @@ ZTEST(draw_rect, test_draw_rect_1123_at_1_1)
 	struct cfb_position start = {1, 1};
 	struct cfb_position end = {start.x + 10, start.y + 22};
 
-	zassert_ok(cfb_draw_rect(dev, &start, &end), "");
-	zassert_ok(cfb_framebuffer_finalize(dev), "");
+	zassert_ok(cfb_draw_rect(fb, &start, &end), "");
+	zassert_ok(cfb_framebuffer_finalize(fb), "");
 
 	zassert_true(verify_image_and_bg(1, 1, rectspace1123, 11, 23, 0), "");
 }
@@ -75,8 +75,8 @@ ZTEST(draw_rect, test_draw_rect_1123_at_9_15)
 	struct cfb_position start = {9, 15};
 	struct cfb_position end = {start.x + 10, start.y + 22};
 
-	zassert_ok(cfb_draw_rect(dev, &start, &end), "");
-	zassert_ok(cfb_framebuffer_finalize(dev), "");
+	zassert_ok(cfb_draw_rect(fb, &start, &end), "");
+	zassert_ok(cfb_framebuffer_finalize(fb), "");
 
 	zassert_true(verify_image_and_bg(9, 15, rectspace1123, 11, 23, 0), "");
 }
@@ -86,8 +86,8 @@ ZTEST(draw_rect, test_draw_rect_1123_at_10_16)
 	struct cfb_position start = {10, 16};
 	struct cfb_position end = {start.x + 10, start.y + 22};
 
-	zassert_ok(cfb_draw_rect(dev, &start, &end), "");
-	zassert_ok(cfb_framebuffer_finalize(dev), "");
+	zassert_ok(cfb_draw_rect(fb, &start, &end), "");
+	zassert_ok(cfb_framebuffer_finalize(fb), "");
 
 	zassert_true(verify_image_and_bg(10, 16, rectspace1123, 11, 23, 0), "");
 }
@@ -97,8 +97,8 @@ ZTEST(draw_rect, test_draw_rect_1123_at_11_17)
 	struct cfb_position start = {11, 17};
 	struct cfb_position end = {start.x + 10, start.y + 22};
 
-	zassert_ok(cfb_draw_rect(dev, &start, &end), "");
-	zassert_ok(cfb_framebuffer_finalize(dev), "");
+	zassert_ok(cfb_draw_rect(fb, &start, &end), "");
+	zassert_ok(cfb_framebuffer_finalize(fb), "");
 
 	zassert_true(verify_image_and_bg(11, 17, rectspace1123, 11, 23, 0), "");
 }
@@ -111,8 +111,8 @@ ZTEST(draw_rect, test_draw_rect_1123_outside_top_left)
 	struct cfb_position start = {-(11 - 3), -(23 - 4)};
 	struct cfb_position end = {start.x + 10, start.y + 22};
 
-	zassert_ok(cfb_draw_rect(dev, &start, &end), "");
-	zassert_ok(cfb_framebuffer_finalize(dev), "");
+	zassert_ok(cfb_draw_rect(fb, &start, &end), "");
+	zassert_ok(cfb_framebuffer_finalize(fb), "");
 
 	zassert_true(verify_image_and_bg(0, 0, outside_top_left, 3, 4, 0), "");
 }
@@ -122,8 +122,8 @@ ZTEST(draw_rect, test_draw_rect_1123_outside_top_right)
 	struct cfb_position start = {display_width - 5, -(23 - 8)};
 	struct cfb_position end = {start.x + 10, start.y + 22};
 
-	zassert_ok(cfb_draw_rect(dev, &start, &end), "");
-	zassert_ok(cfb_framebuffer_finalize(dev), "");
+	zassert_ok(cfb_draw_rect(fb, &start, &end), "");
+	zassert_ok(cfb_framebuffer_finalize(fb), "");
 
 	zassert_true(verify_image(display_width - 5, 0, outside_top_right, 5, 8), "");
 }
@@ -133,8 +133,8 @@ ZTEST(draw_rect, test_draw_rect_1123_outside_bottom_right)
 	struct cfb_position start = {display_width - 3, display_height - 5};
 	struct cfb_position end = {start.x + 10, start.y + 22};
 
-	zassert_ok(cfb_draw_rect(dev, &start, &end), "");
-	zassert_ok(cfb_framebuffer_finalize(dev), "");
+	zassert_ok(cfb_draw_rect(fb, &start, &end), "");
+	zassert_ok(cfb_framebuffer_finalize(fb), "");
 
 	zassert_true(
 		verify_image(display_width - 3, display_height - 5, outside_bottom_right, 3, 5),
@@ -146,8 +146,8 @@ ZTEST(draw_rect, test_draw_rect_1123_outside_bottom_left)
 	struct cfb_position start = {-(11 - 3), display_height - 14};
 	struct cfb_position end = {start.x + 10, start.y + 22};
 
-	zassert_ok(cfb_draw_rect(dev, &start, &end), "");
-	zassert_ok(cfb_framebuffer_finalize(dev), "");
+	zassert_ok(cfb_draw_rect(fb, &start, &end), "");
+	zassert_ok(cfb_framebuffer_finalize(fb), "");
 
 	zassert_true(verify_image(0, display_height - 14, outside_bottom_left, 3, 14), "");
 }

--- a/tests/subsys/display/cfb/basic/src/invert.c
+++ b/tests/subsys/display/cfb/basic/src/invert.c
@@ -15,33 +15,21 @@
 
 LOG_MODULE_REGISTER(invert, CONFIG_DISPLAY_LOG_LEVEL);
 
-static const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
-static const uint32_t display_width = DT_PROP(DT_CHOSEN(zephyr_display), width);
-static const uint32_t display_height = DT_PROP(DT_CHOSEN(zephyr_display), height);
+static struct cfb_display *disp;
+static struct cfb_framebuffer *fb;
 
 /**
  * Fill the buffer with 0 before running tests.
  */
 static void cfb_test_before(void *text_fixture)
 {
-	struct display_buffer_descriptor desc = {
-		.height = display_height,
-		.pitch = display_width,
-		.width = display_width,
-		.buf_size = display_height * display_width / 8,
-	};
-
-	memset(read_buffer, 0, sizeof(read_buffer));
-	zassert_ok(display_write(dev, 0, 0, &desc, read_buffer));
-
-	zassert_ok(display_blanking_off(dev));
-
-	zassert_ok(cfb_framebuffer_init(fb));
+	disp = display_init();
+	fb = cfb_display_get_framebuffer(disp);
 }
 
 static void cfb_test_after(void *test_fixture)
 {
-	cfb_framebuffer_deinit(fb);
+	display_deinit(disp);
 }
 
 ZTEST(invert, test_invert)

--- a/tests/subsys/display/cfb/basic/src/invert.c
+++ b/tests/subsys/display/cfb/basic/src/invert.c
@@ -36,31 +36,31 @@ static void cfb_test_before(void *text_fixture)
 
 	zassert_ok(display_blanking_off(dev));
 
-	zassert_ok(cfb_framebuffer_init(dev));
+	zassert_ok(cfb_framebuffer_init(fb));
 }
 
 static void cfb_test_after(void *test_fixture)
 {
-	cfb_framebuffer_deinit(dev);
+	cfb_framebuffer_deinit(fb);
 }
 
 ZTEST(invert, test_invert)
 {
-	zassert_ok(cfb_framebuffer_invert(dev));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_framebuffer_invert(fb));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_color_inside_rect(0, 0, 320, 240, 0xFFFFFF));
 }
 
 ZTEST(invert, test_invert_contents)
 {
-	zassert_ok(cfb_invert_area(dev, 10, 10, 10, 10));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_invert_area(fb, 10, 10, 10, 10));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 	zassert_true(verify_color_outside_rect(10, 10, 10, 10, 0));
 	zassert_true(verify_color_inside_rect(10, 10, 10, 10, 0xFFFFFF));
 
-	zassert_ok(cfb_framebuffer_invert(dev));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_framebuffer_invert(fb));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_color_outside_rect(10, 10, 10, 10, 0xFFFFFF));
 }

--- a/tests/subsys/display/cfb/basic/src/invert_area.c
+++ b/tests/subsys/display/cfb/basic/src/invert_area.c
@@ -15,33 +15,21 @@
 
 LOG_MODULE_REGISTER(invert_area, CONFIG_DISPLAY_LOG_LEVEL);
 
-static const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
-static const uint32_t display_width = DT_PROP(DT_CHOSEN(zephyr_display), width);
-static const uint32_t display_height = DT_PROP(DT_CHOSEN(zephyr_display), height);
+static struct cfb_display *disp;
+static struct cfb_framebuffer *fb;
 
 /**
  * Fill the buffer with 0 before running tests.
  */
 static void cfb_test_before(void *text_fixture)
 {
-	struct display_buffer_descriptor desc = {
-		.height = display_height,
-		.pitch = display_width,
-		.width = display_width,
-		.buf_size = display_height * display_width / 8,
-	};
-
-	memset(read_buffer, 0, sizeof(read_buffer));
-	zassert_ok(display_write(dev, 0, 0, &desc, read_buffer));
-
-	zassert_ok(display_blanking_off(dev));
-
-	zassert_ok(cfb_framebuffer_init(fb));
+	disp = display_init();
+	fb = cfb_display_get_framebuffer(disp);
 }
 
 static void cfb_test_after(void *test_fixture)
 {
-	cfb_framebuffer_deinit(fb);
+	display_deinit(disp);
 }
 
 ZTEST(invert_area, test_invert_area_whole_screen)

--- a/tests/subsys/display/cfb/basic/src/invert_area.c
+++ b/tests/subsys/display/cfb/basic/src/invert_area.c
@@ -36,27 +36,27 @@ static void cfb_test_before(void *text_fixture)
 
 	zassert_ok(display_blanking_off(dev));
 
-	zassert_ok(cfb_framebuffer_init(dev));
+	zassert_ok(cfb_framebuffer_init(fb));
 }
 
 static void cfb_test_after(void *test_fixture)
 {
-	cfb_framebuffer_deinit(dev);
+	cfb_framebuffer_deinit(fb);
 }
 
 ZTEST(invert_area, test_invert_area_whole_screen)
 {
-	zassert_ok(cfb_invert_area(dev, 0, 0, 320, 240));
-	zassert_ok(cfb_framebuffer_finalize(dev), "cfb_framebuffer_finalize failed");
+	zassert_ok(cfb_invert_area(fb, 0, 0, 320, 240));
+	zassert_ok(cfb_framebuffer_finalize(fb), "cfb_framebuffer_finalize failed");
 
 	zassert_true(verify_color_inside_rect(0, 0, 320, 240, 0xFFFFFF));
 }
 
 ZTEST(invert_area, test_invert_area_overlapped_2times)
 {
-	zassert_ok(cfb_invert_area(dev, 33, 37, 79, 77));
-	zassert_ok(cfb_invert_area(dev, 100, 37, 53, 77));
-	zassert_ok(cfb_framebuffer_finalize(dev), "cfb_framebuffer_finalize failed");
+	zassert_ok(cfb_invert_area(fb, 33, 37, 79, 77));
+	zassert_ok(cfb_invert_area(fb, 100, 37, 53, 77));
+	zassert_ok(cfb_framebuffer_finalize(fb), "cfb_framebuffer_finalize failed");
 
 	zassert_true(verify_color_inside_rect(33, 37, 67, 77, 0xFFFFFF));
 	zassert_true(verify_color_inside_rect(100, 37, 12, 77, 0x0));
@@ -66,8 +66,8 @@ ZTEST(invert_area, test_invert_area_overlapped_2times)
 
 ZTEST(invert_area, test_invert_area_overlap_top_left)
 {
-	zassert_ok(cfb_invert_area(dev, -10, -10, 20, 20));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_invert_area(fb, -10, -10, 20, 20));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_color_inside_rect(0, 0, 10, 10, 0xFFFFFF));
 	zassert_true(verify_color_outside_rect(0, 0, 10, 10, 0x0));
@@ -75,8 +75,8 @@ ZTEST(invert_area, test_invert_area_overlap_top_left)
 
 ZTEST(invert_area, test_invert_area_overlap_top_right)
 {
-	zassert_ok(cfb_invert_area(dev, display_width - 10, -10, 20, 20));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_invert_area(fb, display_width - 10, -10, 20, 20));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_color_inside_rect(display_width - 10, 0, 10, 10, 0xFFFFFF));
 	zassert_true(verify_color_outside_rect(display_width - 10, 0, 10, 10, 0x0));
@@ -84,8 +84,8 @@ ZTEST(invert_area, test_invert_area_overlap_top_right)
 
 ZTEST(invert_area, test_invert_area_overlap_bottom_left)
 {
-	zassert_ok(cfb_invert_area(dev, -10, display_height - 10, 20, 20));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_invert_area(fb, -10, display_height - 10, 20, 20));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_color_inside_rect(0, display_height - 10, 10, 10, 0xFFFFFF));
 	zassert_true(verify_color_outside_rect(0, display_height - 10, 10, 10, 0x0));
@@ -93,8 +93,8 @@ ZTEST(invert_area, test_invert_area_overlap_bottom_left)
 
 ZTEST(invert_area, test_invert_area_overlap_bottom_right)
 {
-	zassert_ok(cfb_invert_area(dev, display_width - 10, display_height - 10, 20, 20));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_invert_area(fb, display_width - 10, display_height - 10, 20, 20));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_color_inside_rect(display_width - 10, display_height - 10, 10, 10,
 					      0xFFFFFF));
@@ -104,40 +104,40 @@ ZTEST(invert_area, test_invert_area_overlap_bottom_right)
 
 ZTEST(invert_area, test_invert_area_outside_top_left)
 {
-	zassert_ok(cfb_invert_area(dev, -10, -10, 10, 10));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_invert_area(fb, -10, -10, 10, 10));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_color_inside_rect(0, 0, display_width, display_height, 0x0));
 }
 
 ZTEST(invert_area, test_invert_area_outside_left_only)
 {
-	zassert_ok(cfb_invert_area(dev, -11, 0, 10, 10));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_invert_area(fb, -11, 0, 10, 10));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_color_inside_rect(0, 0, display_width, display_height, 0x0));
 }
 
 ZTEST(invert_area, test_invert_area_outside_top_only)
 {
-	zassert_ok(cfb_invert_area(dev, 0, -11, 10, 10));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_invert_area(fb, 0, -11, 10, 10));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_color_inside_rect(0, 0, display_width, display_height, 0x0));
 }
 
 ZTEST(invert_area, test_invert_area_outside_bottom_right)
 {
-	zassert_ok(cfb_invert_area(dev, display_width, display_height, 20, 20));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_invert_area(fb, display_width, display_height, 20, 20));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_color_inside_rect(0, 0, display_width, display_height, 0x0));
 }
 
 ZTEST(invert_area, test_invert_area_outside_bottom_only)
 {
-	zassert_ok(cfb_invert_area(dev, 0, display_height, 10, 10));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_invert_area(fb, 0, display_height, 10, 10));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_color_inside_rect(0, 0, display_width, display_height, 0x0));
 }

--- a/tests/subsys/display/cfb/common/utils.h
+++ b/tests/subsys/display/cfb/common/utils.h
@@ -10,9 +10,18 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <zephyr/devicetree.h>
+#include <zephyr/device.h>
 
+extern const struct device *dev;
+extern const uint32_t display_width;
+extern const uint32_t display_height;
 extern uint8_t read_buffer[DT_PROP(DT_CHOSEN(zephyr_display), width) *
 			   DT_PROP(DT_CHOSEN(zephyr_display), height) * 4];
+
+struct cfb_display *display_init(void);
+void display_deinit(struct cfb_display *disp);
+
+uint32_t display_buf_size(const struct device *dev);
 
 uint32_t display_pixel(int x, int y);
 uint32_t image_pixel(const uint32_t *img, size_t width, int x, int y);

--- a/tests/subsys/display/cfb/fonts/src/draw_text_dot0101.c
+++ b/tests/subsys/display/cfb/fonts/src/draw_text_dot0101.c
@@ -39,15 +39,15 @@ static void cfb_test_before(void *text_fixture)
 
 	zassert_ok(display_blanking_off(dev));
 
-	zassert_ok(cfb_framebuffer_init(dev));
+	zassert_ok(cfb_framebuffer_init(fb));
 
-	for (int idx = 0; idx < cfb_get_numof_fonts(dev); idx++) {
-		if (cfb_get_font_size(dev, idx, &font_width, &font_height)) {
+	for (int idx = 0; idx < cfb_get_numof_fonts(fb); idx++) {
+		if (cfb_get_font_size(fb, idx, &font_width, &font_height)) {
 			break;
 		}
 
 		if (font_width == 1 && font_height == 1) {
-			cfb_framebuffer_set_font(dev, idx);
+			cfb_framebuffer_set_font(fb, idx);
 			font_found = true;
 			break;
 		}
@@ -58,7 +58,7 @@ static void cfb_test_before(void *text_fixture)
 
 static void cfb_test_after(void *test_fixture)
 {
-	cfb_framebuffer_deinit(dev);
+	cfb_framebuffer_deinit(fb);
 }
 
 /*
@@ -66,16 +66,16 @@ static void cfb_test_after(void *test_fixture)
  */
 ZTEST(draw_text_dot0101, test_draw_text_at_0_0)
 {
-	zassert_ok(cfb_draw_text(dev, "1", 0, 0));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_text(fb, "1", 0, 0));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_pixel_and_bg(0, 0, 1, 0));
 }
 
 ZTEST(draw_text_dot0101, test_draw_text_at_1_1)
 {
-	zassert_ok(cfb_draw_text(dev, "1", 1, 1));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_text(fb, "1", 1, 1));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_pixel_and_bg(1, 1, 1, 0));
 }
@@ -85,24 +85,24 @@ ZTEST(draw_text_dot0101, test_draw_text_at_1_1)
  */
 ZTEST(draw_text_dot0101, test_draw_text_at_9_15)
 {
-	zassert_ok(cfb_draw_text(dev, "1", 9, 15));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_text(fb, "1", 9, 15));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_pixel_and_bg(9, 15, 1, 0));
 }
 
 ZTEST(draw_text_dot0101, test_draw_text_at_10_16)
 {
-	zassert_ok(cfb_draw_text(dev, "1", 10, 16));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_text(fb, "1", 10, 16));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_pixel_and_bg(10, 16, 1, 0));
 }
 
 ZTEST(draw_text_dot0101, test_draw_text_at_11_17)
 {
-	zassert_ok(cfb_draw_text(dev, "1", 11, 17));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_text(fb, "1", 11, 17));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_pixel_and_bg(11, 17, 1, 0));
 }
@@ -112,63 +112,63 @@ ZTEST(draw_text_dot0101, test_draw_text_at_11_17)
  */
 ZTEST(draw_text_dot0101, test_draw_text_at_0_0_kerning_3)
 {
-	cfb_set_kerning(dev, 3);
-	zassert_ok(cfb_draw_text(dev, "11", 0, 0));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 3);
+	zassert_ok(cfb_draw_text(fb, "11", 0, 0));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(0, 0, kerning_3_2dot0101, 5, 1, 0));
 }
 
 ZTEST(draw_text_dot0101, test_draw_text_at_1_1_kerning_3)
 {
-	cfb_set_kerning(dev, 3);
-	zassert_ok(cfb_draw_text(dev, "11", 1, 1));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 3);
+	zassert_ok(cfb_draw_text(fb, "11", 1, 1));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(1, 1, kerning_3_2dot0101, 5, 1, 0));
 }
 
 ZTEST(draw_text_dot0101, test_draw_text_at_9_15_kerning_3)
 {
-	cfb_set_kerning(dev, 3);
-	zassert_ok(cfb_draw_text(dev, "11", 9, 15));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 3);
+	zassert_ok(cfb_draw_text(fb, "11", 9, 15));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(9, 15, kerning_3_2dot0101, 5, 1, 0));
 }
 
 ZTEST(draw_text_dot0101, test_draw_text_at_10_16_kerning_3)
 {
-	cfb_set_kerning(dev, 3);
-	zassert_ok(cfb_draw_text(dev, "11", 10, 16));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 3);
+	zassert_ok(cfb_draw_text(fb, "11", 10, 16));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(10, 16, kerning_3_2dot0101, 5, 1, 0));
 }
 
 ZTEST(draw_text_dot0101, test_draw_text_at_11_17_kerning_3)
 {
-	cfb_set_kerning(dev, 3);
-	zassert_ok(cfb_draw_text(dev, "11", 11, 17));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 3);
+	zassert_ok(cfb_draw_text(fb, "11", 11, 17));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(11, 17, kerning_3_2dot0101, 5, 1, 0));
 }
 
 ZTEST(draw_text_dot0101, test_draw_text_at_right_border_17_kerning_3)
 {
-	cfb_set_kerning(dev, 3);
-	zassert_ok(cfb_draw_text(dev, "11", display_width - 5, 17));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 3);
+	zassert_ok(cfb_draw_text(fb, "11", display_width - 5, 17));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(display_width - 5, 17, kerning_3_2dot0101, 5, 1, 0));
 }
 
 ZTEST(draw_text_dot0101, test_draw_text_kerning_3_over_border)
 {
-	cfb_set_kerning(dev, 3);
-	zassert_ok(cfb_draw_text(dev, "11", display_width - 4, 17));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 3);
+	zassert_ok(cfb_draw_text(fb, "11", display_width - 4, 17));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_pixel(display_width - 4, 17, 0xFFFFFF));
 	zassert_true(verify_pixel(display_width - 3, 17, 0x0));
@@ -179,32 +179,32 @@ ZTEST(draw_text_dot0101, test_draw_text_kerning_3_over_border)
 
 ZTEST(draw_text_dot0101, test_draw_text_outside_top_left)
 {
-	zassert_ok(cfb_draw_text(dev, "1", 0, -1));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_text(fb, "1", 0, -1));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_color_inside_rect(0, 0, display_width, display_height, 0));
 }
 
 ZTEST(draw_text_dot0101, test_draw_text_outside_top_right)
 {
-	zassert_ok(cfb_draw_text(dev, "1", display_width, 0));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_text(fb, "1", display_width, 0));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_color_inside_rect(0, 0, display_width, display_height, 0));
 }
 
 ZTEST(draw_text_dot0101, test_draw_text_outside_bottom_right)
 {
-	zassert_ok(cfb_draw_text(dev, "1", 0, display_height));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_text(fb, "1", 0, display_height));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_color_inside_rect(0, 0, display_width, display_height, 0));
 }
 
 ZTEST(draw_text_dot0101, test_draw_text_outside_bottom_left)
 {
-	zassert_ok(cfb_draw_text(dev, "1", display_width, -1));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_text(fb, "1", display_width, -1));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_color_inside_rect(0, 0, display_width, display_height, 0));
 }

--- a/tests/subsys/display/cfb/fonts/src/draw_text_dot0101.c
+++ b/tests/subsys/display/cfb/fonts/src/draw_text_dot0101.c
@@ -15,31 +15,20 @@
 
 LOG_MODULE_REGISTER(draw_text_dot0101, CONFIG_DISPLAY_LOG_LEVEL);
 
-static const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
-static const uint32_t display_width = DT_PROP(DT_CHOSEN(zephyr_display), width);
-static const uint32_t display_height = DT_PROP(DT_CHOSEN(zephyr_display), height);
+static struct cfb_display *disp;
+static struct cfb_framebuffer *fb;
 
 /**
  * Fill the buffer with 0 before running tests.
  */
 static void cfb_test_before(void *text_fixture)
 {
-	struct display_buffer_descriptor desc = {
-		.height = display_height,
-		.pitch = display_width,
-		.width = display_width,
-		.buf_size = display_height * display_width / 8,
-	};
 	uint8_t font_width;
 	uint8_t font_height;
 	bool font_found = false;
 
-	memset(read_buffer, 0, sizeof(read_buffer));
-	zassert_ok(display_write(dev, 0, 0, &desc, read_buffer));
-
-	zassert_ok(display_blanking_off(dev));
-
-	zassert_ok(cfb_framebuffer_init(fb));
+	disp = display_init();
+	fb = cfb_display_get_framebuffer(disp);
 
 	for (int idx = 0; idx < cfb_get_numof_fonts(fb); idx++) {
 		if (cfb_get_font_size(fb, idx, &font_width, &font_height)) {
@@ -58,7 +47,7 @@ static void cfb_test_before(void *text_fixture)
 
 static void cfb_test_after(void *test_fixture)
 {
-	cfb_framebuffer_deinit(fb);
+	display_deinit(disp);
 }
 
 /*

--- a/tests/subsys/display/cfb/fonts/src/draw_text_rectspace1016.c
+++ b/tests/subsys/display/cfb/fonts/src/draw_text_rectspace1016.c
@@ -39,15 +39,15 @@ static void cfb_test_before(void *text_fixture)
 
 	zassert_ok(display_blanking_off(dev));
 
-	zassert_ok(cfb_framebuffer_init(dev));
+	zassert_ok(cfb_framebuffer_init(fb));
 
-	for (int idx = 0; idx < cfb_get_numof_fonts(dev); idx++) {
-		if (cfb_get_font_size(dev, idx, &font_width, &font_height)) {
+	for (int idx = 0; idx < cfb_get_numof_fonts(fb); idx++) {
+		if (cfb_get_font_size(fb, idx, &font_width, &font_height)) {
 			break;
 		}
 
 		if (font_width == 10 && font_height == 16) {
-			cfb_framebuffer_set_font(dev, idx);
+			cfb_framebuffer_set_font(fb, idx);
 			font_found = true;
 			break;
 		}
@@ -58,7 +58,7 @@ static void cfb_test_before(void *text_fixture)
 
 static void cfb_test_after(void *test_fixture)
 {
-	cfb_framebuffer_deinit(dev);
+	cfb_framebuffer_deinit(fb);
 }
 
 /*
@@ -66,16 +66,16 @@ static void cfb_test_after(void *test_fixture)
  */
 ZTEST(draw_text_rectspace1016, test_draw_text_at_0_0)
 {
-	zassert_ok(cfb_draw_text(dev, " ", 0, 0));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_text(fb, " ", 0, 0));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(0, 0, rectspace1016, 10, 16, 0));
 }
 
 ZTEST(draw_text_rectspace1016, test_draw_text_at_1_1)
 {
-	zassert_ok(cfb_draw_text(dev, " ", 1, 1));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_text(fb, " ", 1, 1));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(1, 1, rectspace1016, 10, 16, 0));
 }
@@ -85,40 +85,40 @@ ZTEST(draw_text_rectspace1016, test_draw_text_at_1_1)
  */
 ZTEST(draw_text_rectspace1016, test_draw_text_at_9_15)
 {
-	zassert_ok(cfb_draw_text(dev, " ", 9, 15));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_text(fb, " ", 9, 15));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(9, 15, rectspace1016, 10, 16, 0));
 }
 
 ZTEST(draw_text_rectspace1016, test_draw_text_at_10_16)
 {
-	zassert_ok(cfb_draw_text(dev, " ", 10, 16));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_text(fb, " ", 10, 16));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(10, 16, rectspace1016, 10, 16, 0));
 }
 
 ZTEST(draw_text_rectspace1016, test_draw_text_at_11_17)
 {
-	zassert_ok(cfb_draw_text(dev, " ", 11, 17));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_text(fb, " ", 11, 17));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(11, 17, rectspace1016, 10, 16, 0));
 }
 
 ZTEST(draw_text_rectspace1016, test_draw_text_missing_glyph_at_0_0)
 {
-	zassert_ok(cfb_draw_text(dev, "~", 0, 0));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_text(fb, "~", 0, 0));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(0, 0, tofu1016, 10, 16, 0));
 }
 
 ZTEST(draw_text_rectspace1016, test_draw_text_missing_glyph_at_9_15)
 {
-	zassert_ok(cfb_draw_text(dev, "~", 9, 15));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_text(fb, "~", 9, 15));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(9, 15, tofu1016, 10, 16, 0));
 }
@@ -128,81 +128,81 @@ ZTEST(draw_text_rectspace1016, test_draw_text_missing_glyph_at_9_15)
  */
 ZTEST(draw_text_rectspace1016, test_draw_text_at_0_0_kerning_3)
 {
-	cfb_set_kerning(dev, 3);
-	zassert_ok(cfb_draw_text(dev, "  ", 0, 0));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 3);
+	zassert_ok(cfb_draw_text(fb, "  ", 0, 0));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(0, 0, kerning_3_2rectspace1016, 23, 16, 0));
 }
 
 ZTEST(draw_text_rectspace1016, test_draw_text_at_1_1_kerning_3)
 {
-	cfb_set_kerning(dev, 3);
-	zassert_ok(cfb_draw_text(dev, "  ", 1, 1));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 3);
+	zassert_ok(cfb_draw_text(fb, "  ", 1, 1));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(1, 1, kerning_3_2rectspace1016, 23, 16, 0));
 }
 
 ZTEST(draw_text_rectspace1016, test_draw_text_at_9_15_kerning_3)
 {
-	cfb_set_kerning(dev, 3);
-	zassert_ok(cfb_draw_text(dev, "  ", 9, 15));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 3);
+	zassert_ok(cfb_draw_text(fb, "  ", 9, 15));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(9, 15, kerning_3_2rectspace1016, 23, 16, 0));
 }
 
 ZTEST(draw_text_rectspace1016, test_draw_text_at_10_16_kerning_3)
 {
-	cfb_set_kerning(dev, 3);
-	zassert_ok(cfb_draw_text(dev, "  ", 10, 16));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 3);
+	zassert_ok(cfb_draw_text(fb, "  ", 10, 16));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(10, 16, kerning_3_2rectspace1016, 23, 16, 0));
 }
 
 ZTEST(draw_text_rectspace1016, test_draw_text_at_11_17_kerning_3)
 {
-	cfb_set_kerning(dev, 3);
-	zassert_ok(cfb_draw_text(dev, "  ", 11, 17));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 3);
+	zassert_ok(cfb_draw_text(fb, "  ", 11, 17));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(11, 17, kerning_3_2rectspace1016, 23, 16, 0));
 }
 
 ZTEST(draw_text_rectspace1016, test_draw_text_missing_glyph_at_0_0_kerning_3)
 {
-	cfb_set_kerning(dev, 3);
-	zassert_ok(cfb_draw_text(dev, "~~", 0, 0));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 3);
+	zassert_ok(cfb_draw_text(fb, "~~", 0, 0));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(0, 0, kerning_3_2tofu1016, 23, 16, 0));
 }
 
 ZTEST(draw_text_rectspace1016, test_draw_text_missing_glyph_kerning_3_over_right_border)
 {
-	cfb_set_kerning(dev, 3);
-	zassert_ok(cfb_draw_text(dev, "~~", display_width - 22, 17));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 3);
+	zassert_ok(cfb_draw_text(fb, "~~", display_width - 22, 17));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image(display_width - 22, 17, kerning_3_rightclip_1_2tofu1016, 22, 16));
 }
 
 ZTEST(draw_text_rectspace1016, test_draw_text_kerning_3_within_right_border)
 {
-	cfb_set_kerning(dev, 3);
-	zassert_ok(cfb_draw_text(dev, "  ", display_width - 23, 17));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 3);
+	zassert_ok(cfb_draw_text(fb, "  ", display_width - 23, 17));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image(display_width - 23, 17, kerning_3_2rectspace1016, 23, 16));
 }
 
 ZTEST(draw_text_rectspace1016, test_draw_text_kerning_3_over_right_border)
 {
-	cfb_set_kerning(dev, 3);
-	zassert_ok(cfb_draw_text(dev, "  ", display_width - 22, 17));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 3);
+	zassert_ok(cfb_draw_text(fb, "  ", display_width - 22, 17));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(
 		verify_image(display_width - 22, 17, kerning_3_rightclip_1_2rectspace1016, 22, 16));
@@ -210,40 +210,40 @@ ZTEST(draw_text_rectspace1016, test_draw_text_kerning_3_over_right_border)
 
 ZTEST(draw_text_rectspace1016, test_draw_text_outside_top_left)
 {
-	zassert_ok(cfb_draw_text(dev, " ", -(10 - 3), -(16 - 4)));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_text(fb, " ", -(10 - 3), -(16 - 4)));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(0, 0, outside_top_left, 3, 4, 0));
 }
 
 ZTEST(draw_text_rectspace1016, test_draw_text_missing_glyph_outside_top_left)
 {
-	zassert_ok(cfb_draw_text(dev, "~", -(10 - 3), -(16 - 4)));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_text(fb, "~", -(10 - 3), -(16 - 4)));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(0, 0, outside_top_left_tofu1016, 3, 4, 0));
 }
 
 ZTEST(draw_text_rectspace1016, test_draw_text_outside_top_right)
 {
-	zassert_ok(cfb_draw_text(dev, " ", display_width - 5, -(16 - 8)));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_text(fb, " ", display_width - 5, -(16 - 8)));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image(display_width - 5, 0, outside_top_right, 5, 8));
 }
 
 ZTEST(draw_text_rectspace1016, test_draw_text_missing_glyph_outside_top_right)
 {
-	zassert_ok(cfb_draw_text(dev, "~", display_width - 5, -(16 - 8)));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_text(fb, "~", display_width - 5, -(16 - 8)));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image(display_width - 5, 0, outside_top_right_tofu1016, 5, 8));
 }
 
 ZTEST(draw_text_rectspace1016, test_draw_text_outside_bottom_right)
 {
-	zassert_ok(cfb_draw_text(dev, " ", display_width - 3, display_height - 5));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_text(fb, " ", display_width - 3, display_height - 5));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(
 		verify_image(display_width - 3, display_height - 5, outside_bottom_right, 3, 5));
@@ -251,8 +251,8 @@ ZTEST(draw_text_rectspace1016, test_draw_text_outside_bottom_right)
 
 ZTEST(draw_text_rectspace1016, test_draw_text_missing_glyph_outside_bottom_right)
 {
-	zassert_ok(cfb_draw_text(dev, "~", display_width - 3, display_height - 5));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_text(fb, "~", display_width - 3, display_height - 5));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image(display_width - 3, display_height - 5,
 				  outside_bottom_right_tofu1016, 3, 5));
@@ -260,16 +260,16 @@ ZTEST(draw_text_rectspace1016, test_draw_text_missing_glyph_outside_bottom_right
 
 ZTEST(draw_text_rectspace1016, test_draw_text_outside_bottom_left)
 {
-	zassert_ok(cfb_draw_text(dev, " ", -(10 - 3), display_height - 14));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_text(fb, " ", -(10 - 3), display_height - 14));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image(0, display_height - 14, outside_bottom_left, 3, 14));
 }
 
 ZTEST(draw_text_rectspace1016, test_draw_text_missing_glyph_outside_bottom_left)
 {
-	zassert_ok(cfb_draw_text(dev, "~", -(10 - 3), display_height - 14));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_text(fb, "~", -(10 - 3), display_height - 14));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image(0, display_height - 14, outside_bottom_left_tofu1016, 3, 14));
 }

--- a/tests/subsys/display/cfb/fonts/src/draw_text_rectspace1016.c
+++ b/tests/subsys/display/cfb/fonts/src/draw_text_rectspace1016.c
@@ -15,31 +15,20 @@
 
 LOG_MODULE_REGISTER(draw_text_rectspace1016, CONFIG_DISPLAY_LOG_LEVEL);
 
-static const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
-static const uint32_t display_width = DT_PROP(DT_CHOSEN(zephyr_display), width);
-static const uint32_t display_height = DT_PROP(DT_CHOSEN(zephyr_display), height);
+static struct cfb_display *disp;
+static struct cfb_framebuffer *fb;
 
 /**
  * Fill the buffer with 0 before running tests.
  */
 static void cfb_test_before(void *text_fixture)
 {
-	struct display_buffer_descriptor desc = {
-		.height = display_height,
-		.pitch = display_width,
-		.width = display_width,
-		.buf_size = display_height * display_width / 8,
-	};
 	uint8_t font_width;
 	uint8_t font_height;
 	bool font_found = false;
 
-	memset(read_buffer, 0, sizeof(read_buffer));
-	zassert_ok(display_write(dev, 0, 0, &desc, read_buffer));
-
-	zassert_ok(display_blanking_off(dev));
-
-	zassert_ok(cfb_framebuffer_init(fb));
+	disp = display_init();
+	fb = cfb_display_get_framebuffer(disp);
 
 	for (int idx = 0; idx < cfb_get_numof_fonts(fb); idx++) {
 		if (cfb_get_font_size(fb, idx, &font_width, &font_height)) {
@@ -58,7 +47,7 @@ static void cfb_test_before(void *text_fixture)
 
 static void cfb_test_after(void *test_fixture)
 {
-	cfb_framebuffer_deinit(fb);
+	display_deinit(disp);
 }
 
 /*

--- a/tests/subsys/display/cfb/fonts/src/draw_text_rectspace1123.c
+++ b/tests/subsys/display/cfb/fonts/src/draw_text_rectspace1123.c
@@ -15,31 +15,20 @@
 
 LOG_MODULE_REGISTER(draw_text_rectspace1123, CONFIG_DISPLAY_LOG_LEVEL);
 
-static const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
-static const uint32_t display_width = DT_PROP(DT_CHOSEN(zephyr_display), width);
-static const uint32_t display_height = DT_PROP(DT_CHOSEN(zephyr_display), height);
+static struct cfb_display *disp;
+static struct cfb_framebuffer *fb;
 
 /**
  * Fill the buffer with 0 before running tests.
  */
 static void cfb_test_before(void *text_fixture)
 {
-	struct display_buffer_descriptor desc = {
-		.height = display_height,
-		.pitch = display_width,
-		.width = display_width,
-		.buf_size = display_height * display_width / 8,
-	};
 	uint8_t font_width;
 	uint8_t font_height;
 	bool font_found = false;
 
-	memset(read_buffer, 0, sizeof(read_buffer));
-	zassert_ok(display_write(dev, 0, 0, &desc, read_buffer));
-
-	zassert_ok(display_blanking_off(dev));
-
-	zassert_ok(cfb_framebuffer_init(fb));
+	disp = display_init();
+	fb = cfb_display_get_framebuffer(disp);
 
 	for (int idx = 0; idx < cfb_get_numof_fonts(fb); idx++) {
 		if (cfb_get_font_size(fb, idx, &font_width, &font_height)) {
@@ -58,7 +47,7 @@ static void cfb_test_before(void *text_fixture)
 
 static void cfb_test_after(void *test_fixture)
 {
-	cfb_framebuffer_deinit(fb);
+	display_deinit(disp);
 }
 
 /*

--- a/tests/subsys/display/cfb/fonts/src/draw_text_rectspace1123.c
+++ b/tests/subsys/display/cfb/fonts/src/draw_text_rectspace1123.c
@@ -39,15 +39,15 @@ static void cfb_test_before(void *text_fixture)
 
 	zassert_ok(display_blanking_off(dev));
 
-	zassert_ok(cfb_framebuffer_init(dev));
+	zassert_ok(cfb_framebuffer_init(fb));
 
-	for (int idx = 0; idx < cfb_get_numof_fonts(dev); idx++) {
-		if (cfb_get_font_size(dev, idx, &font_width, &font_height)) {
+	for (int idx = 0; idx < cfb_get_numof_fonts(fb); idx++) {
+		if (cfb_get_font_size(fb, idx, &font_width, &font_height)) {
 			break;
 		}
 
 		if (font_width == 11 && font_height == 23) {
-			cfb_framebuffer_set_font(dev, idx);
+			cfb_framebuffer_set_font(fb, idx);
 			font_found = true;
 			break;
 		}
@@ -58,7 +58,7 @@ static void cfb_test_before(void *text_fixture)
 
 static void cfb_test_after(void *test_fixture)
 {
-	cfb_framebuffer_deinit(dev);
+	cfb_framebuffer_deinit(fb);
 }
 
 /*
@@ -66,16 +66,16 @@ static void cfb_test_after(void *test_fixture)
  */
 ZTEST(draw_text_rectspace1123, test_draw_text_at_0_0)
 {
-	zassert_ok(cfb_draw_text(dev, " ", 0, 0));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_text(fb, " ", 0, 0));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(0, 0, rectspace1123, 11, 23, 0));
 }
 
 ZTEST(draw_text_rectspace1123, test_draw_text_at_1_1)
 {
-	zassert_ok(cfb_draw_text(dev, " ", 1, 1));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_text(fb, " ", 1, 1));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(1, 1, rectspace1123, 11, 23, 0));
 }
@@ -85,24 +85,24 @@ ZTEST(draw_text_rectspace1123, test_draw_text_at_1_1)
  */
 ZTEST(draw_text_rectspace1123, test_draw_text_at_9_15)
 {
-	zassert_ok(cfb_draw_text(dev, " ", 9, 15));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_text(fb, " ", 9, 15));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(9, 15, rectspace1123, 11, 23, 0));
 }
 
 ZTEST(draw_text_rectspace1123, test_draw_text_at_10_16)
 {
-	zassert_ok(cfb_draw_text(dev, " ", 10, 16));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_text(fb, " ", 10, 16));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(10, 16, rectspace1123, 11, 23, 0));
 }
 
 ZTEST(draw_text_rectspace1123, test_draw_text_at_11_17)
 {
-	zassert_ok(cfb_draw_text(dev, " ", 11, 17));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_text(fb, " ", 11, 17));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(11, 17, rectspace1123, 11, 23, 0));
 }
@@ -112,63 +112,63 @@ ZTEST(draw_text_rectspace1123, test_draw_text_at_11_17)
  */
 ZTEST(draw_text_rectspace1123, test_draw_text_at_0_0_kerning_1)
 {
-	cfb_set_kerning(dev, 1);
-	zassert_ok(cfb_draw_text(dev, "  ", 0, 0));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 1);
+	zassert_ok(cfb_draw_text(fb, "  ", 0, 0));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(0, 0, kerning_1_2rectspace1123, 23, 23, 0));
 }
 
 ZTEST(draw_text_rectspace1123, test_draw_text_at_1_1_kerning_1)
 {
-	cfb_set_kerning(dev, 1);
-	zassert_ok(cfb_draw_text(dev, "  ", 1, 1));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 1);
+	zassert_ok(cfb_draw_text(fb, "  ", 1, 1));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(1, 1, kerning_1_2rectspace1123, 23, 23, 0));
 }
 
 ZTEST(draw_text_rectspace1123, test_draw_text_at_9_15_kerning_1)
 {
-	cfb_set_kerning(dev, 1);
-	zassert_ok(cfb_draw_text(dev, "  ", 9, 15));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 1);
+	zassert_ok(cfb_draw_text(fb, "  ", 9, 15));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(9, 15, kerning_1_2rectspace1123, 23, 23, 0));
 }
 
 ZTEST(draw_text_rectspace1123, test_draw_text_at_10_16_kerning_1)
 {
-	cfb_set_kerning(dev, 1);
-	zassert_ok(cfb_draw_text(dev, "  ", 10, 16));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 1);
+	zassert_ok(cfb_draw_text(fb, "  ", 10, 16));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(10, 16, kerning_1_2rectspace1123, 23, 23, 0));
 }
 
 ZTEST(draw_text_rectspace1123, test_draw_text_at_11_17_kerning_1)
 {
-	cfb_set_kerning(dev, 1);
-	zassert_ok(cfb_draw_text(dev, "  ", 11, 17));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 1);
+	zassert_ok(cfb_draw_text(fb, "  ", 11, 17));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(11, 17, kerning_1_2rectspace1123, 23, 23, 0));
 }
 
 ZTEST(draw_text_rectspace1123, test_draw_text_at_right_border_17_kerning_1)
 {
-	cfb_set_kerning(dev, 1);
-	zassert_ok(cfb_draw_text(dev, "  ", display_width - 23, 17));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 1);
+	zassert_ok(cfb_draw_text(fb, "  ", display_width - 23, 17));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image(display_width - 23, 17, kerning_1_2rectspace1123, 23, 23));
 }
 
 ZTEST(draw_text_rectspace1123, test_draw_text_at_right_border_plus1_kerning_1)
 {
-	cfb_set_kerning(dev, 1);
-	zassert_ok(cfb_draw_text(dev, "  ", display_width - 22, 17));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 1);
+	zassert_ok(cfb_draw_text(fb, "  ", display_width - 22, 17));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(
 		verify_image(display_width - 22, 17, kerning_1_rightclip_1_2rectspace1123, 22, 23));
@@ -176,24 +176,24 @@ ZTEST(draw_text_rectspace1123, test_draw_text_at_right_border_plus1_kerning_1)
 
 ZTEST(draw_text_rectspace1123, test_draw_text_outside_top_left)
 {
-	zassert_ok(cfb_draw_text(dev, " ", -(11 - 3), -(23 - 4)));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_text(fb, " ", -(11 - 3), -(23 - 4)));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(0, 0, outside_top_left, 3, 4, 0));
 }
 
 ZTEST(draw_text_rectspace1123, test_draw_text_outside_top_right)
 {
-	zassert_ok(cfb_draw_text(dev, " ", display_width - 5, -(23 - 8)));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_text(fb, " ", display_width - 5, -(23 - 8)));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image(display_width - 5, 0, outside_top_right, 5, 8));
 }
 
 ZTEST(draw_text_rectspace1123, test_draw_text_outside_bottom_right)
 {
-	zassert_ok(cfb_draw_text(dev, " ", display_width - 3, display_height - 5));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_text(fb, " ", display_width - 3, display_height - 5));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(
 		verify_image(display_width - 3, display_height - 5, outside_bottom_right, 3, 5));
@@ -201,8 +201,8 @@ ZTEST(draw_text_rectspace1123, test_draw_text_outside_bottom_right)
 
 ZTEST(draw_text_rectspace1123, test_draw_text_outside_bottom_left)
 {
-	zassert_ok(cfb_draw_text(dev, " ", -(11 - 3), display_height - 14));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_draw_text(fb, " ", -(11 - 3), display_height - 14));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image(0, display_height - 14, outside_bottom_left, 3, 14));
 }

--- a/tests/subsys/display/cfb/fonts/src/print_dot0101.c
+++ b/tests/subsys/display/cfb/fonts/src/print_dot0101.c
@@ -39,15 +39,15 @@ static void cfb_test_before(void *text_fixture)
 
 	zassert_ok(display_blanking_off(dev));
 
-	zassert_ok(cfb_framebuffer_init(dev));
+	zassert_ok(cfb_framebuffer_init(fb));
 
-	for (int idx = 0; idx < cfb_get_numof_fonts(dev); idx++) {
-		if (cfb_get_font_size(dev, idx, &font_width, &font_height)) {
+	for (int idx = 0; idx < cfb_get_numof_fonts(fb); idx++) {
+		if (cfb_get_font_size(fb, idx, &font_width, &font_height)) {
 			break;
 		}
 
 		if (font_width == 1 && font_height == 1) {
-			cfb_framebuffer_set_font(dev, idx);
+			cfb_framebuffer_set_font(fb, idx);
 			font_found = true;
 			break;
 		}
@@ -58,7 +58,7 @@ static void cfb_test_before(void *text_fixture)
 
 static void cfb_test_after(void *test_fixture)
 {
-	cfb_framebuffer_deinit(dev);
+	cfb_framebuffer_deinit(fb);
 }
 
 /*
@@ -66,16 +66,16 @@ static void cfb_test_after(void *test_fixture)
  */
 ZTEST(print_dot0101, test_print_at_0_0)
 {
-	zassert_ok(cfb_print(dev, "1", 0, 0));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_print(fb, "1", 0, 0));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_pixel_and_bg(0, 0, 1, 0));
 }
 
 ZTEST(print_dot0101, test_print_at_1_1)
 {
-	zassert_ok(cfb_print(dev, "1", 1, 1));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_print(fb, "1", 1, 1));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_pixel_and_bg(1, 1, 1, 0));
 }
@@ -85,24 +85,24 @@ ZTEST(print_dot0101, test_print_at_1_1)
  */
 ZTEST(print_dot0101, test_print_at_9_15)
 {
-	zassert_ok(cfb_print(dev, "1", 9, 15));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_print(fb, "1", 9, 15));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_pixel_and_bg(9, 15, 1, 0));
 }
 
 ZTEST(print_dot0101, test_print_at_10_16)
 {
-	zassert_ok(cfb_print(dev, "1", 10, 16));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_print(fb, "1", 10, 16));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_pixel_and_bg(10, 16, 1, 0));
 }
 
 ZTEST(print_dot0101, test_print_at_11_17)
 {
-	zassert_ok(cfb_print(dev, "1", 11, 17));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_print(fb, "1", 11, 17));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_pixel_and_bg(11, 17, 1, 0));
 }
@@ -112,63 +112,63 @@ ZTEST(print_dot0101, test_print_at_11_17)
  */
 ZTEST(print_dot0101, test_print_at_0_0_kerning_3)
 {
-	cfb_set_kerning(dev, 3);
-	zassert_ok(cfb_print(dev, "11", 0, 0));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 3);
+	zassert_ok(cfb_print(fb, "11", 0, 0));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(0, 0, kerning_3_2dot0101, 5, 1, 0));
 }
 
 ZTEST(print_dot0101, test_print_at_1_1_kerning_3)
 {
-	cfb_set_kerning(dev, 3);
-	zassert_ok(cfb_print(dev, "11", 1, 1));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 3);
+	zassert_ok(cfb_print(fb, "11", 1, 1));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(1, 1, kerning_3_2dot0101, 5, 1, 0));
 }
 
 ZTEST(print_dot0101, test_print_at_9_15_kerning_3)
 {
-	cfb_set_kerning(dev, 3);
-	zassert_ok(cfb_print(dev, "11", 9, 15));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 3);
+	zassert_ok(cfb_print(fb, "11", 9, 15));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(9, 15, kerning_3_2dot0101, 5, 1, 0));
 }
 
 ZTEST(print_dot0101, test_print_at_10_16_kerning_3)
 {
-	cfb_set_kerning(dev, 3);
-	zassert_ok(cfb_print(dev, "11", 10, 16));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 3);
+	zassert_ok(cfb_print(fb, "11", 10, 16));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(10, 16, kerning_3_2dot0101, 5, 1, 0));
 }
 
 ZTEST(print_dot0101, test_print_at_11_17_kerning_3)
 {
-	cfb_set_kerning(dev, 3);
-	zassert_ok(cfb_print(dev, "11", 11, 17));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 3);
+	zassert_ok(cfb_print(fb, "11", 11, 17));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(11, 17, kerning_3_2dot0101, 5, 1, 0));
 }
 
 ZTEST(print_dot0101, test_print_kerning_3_within_right_border)
 {
-	cfb_set_kerning(dev, 3);
-	zassert_ok(cfb_print(dev, "11", display_width - 5, 17));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 3);
+	zassert_ok(cfb_print(fb, "11", display_width - 5, 17));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(display_width - 5, 17, kerning_3_2dot0101, 5, 1, 0));
 }
 
 ZTEST(print_dot0101, test_print_kerning_3_over_right_border_wrap)
 {
-	cfb_set_kerning(dev, 3);
-	zassert_ok(cfb_print(dev, "11", display_width - 4, 17));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 3);
+	zassert_ok(cfb_print(fb, "11", display_width - 4, 17));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_pixel(display_width - 4, 17, 0xFFFFFF));
 	zassert_true(verify_pixel(display_width - 3, 17, 0x0));
@@ -179,32 +179,32 @@ ZTEST(print_dot0101, test_print_kerning_3_over_right_border_wrap)
 
 ZTEST(print_dot0101, test_print_outside_top_left)
 {
-	zassert_ok(cfb_print(dev, "1", 0, -1));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_print(fb, "1", 0, -1));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_color_inside_rect(0, 0, display_width, display_height, 0));
 }
 
 ZTEST(print_dot0101, test_print_outside_top_right)
 {
-	zassert_ok(cfb_print(dev, "1", display_width, 0));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_print(fb, "1", display_width, 0));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_pixel_and_bg(0, 1, 1, 0), "");
 }
 
 ZTEST(print_dot0101, test_print_outside_bottom_right)
 {
-	zassert_ok(cfb_print(dev, "1", 0, display_height));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_print(fb, "1", 0, display_height));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_color_inside_rect(0, 0, display_width, display_height, 0));
 }
 
 ZTEST(print_dot0101, test_print_outside_bottom_left)
 {
-	zassert_ok(cfb_print(dev, "1", display_width, -1));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_print(fb, "1", display_width, -1));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_pixel_and_bg(0, 0, 1, 0), "");
 }

--- a/tests/subsys/display/cfb/fonts/src/print_dot0101.c
+++ b/tests/subsys/display/cfb/fonts/src/print_dot0101.c
@@ -15,31 +15,20 @@
 
 LOG_MODULE_REGISTER(print_dot0101, CONFIG_DISPLAY_LOG_LEVEL);
 
-static const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
-static const uint32_t display_width = DT_PROP(DT_CHOSEN(zephyr_display), width);
-static const uint32_t display_height = DT_PROP(DT_CHOSEN(zephyr_display), height);
+static struct cfb_display *disp;
+static struct cfb_framebuffer *fb;
 
 /**
  * Fill the buffer with 0 before running tests.
  */
 static void cfb_test_before(void *text_fixture)
 {
-	struct display_buffer_descriptor desc = {
-		.height = display_height,
-		.pitch = display_width,
-		.width = display_width,
-		.buf_size = display_height * display_width / 8,
-	};
 	uint8_t font_width;
 	uint8_t font_height;
 	bool font_found = false;
 
-	memset(read_buffer, 0, sizeof(read_buffer));
-	zassert_ok(display_write(dev, 0, 0, &desc, read_buffer));
-
-	zassert_ok(display_blanking_off(dev));
-
-	zassert_ok(cfb_framebuffer_init(fb));
+	disp = display_init();
+	fb = cfb_display_get_framebuffer(disp);
 
 	for (int idx = 0; idx < cfb_get_numof_fonts(fb); idx++) {
 		if (cfb_get_font_size(fb, idx, &font_width, &font_height)) {
@@ -58,7 +47,7 @@ static void cfb_test_before(void *text_fixture)
 
 static void cfb_test_after(void *test_fixture)
 {
-	cfb_framebuffer_deinit(fb);
+	display_deinit(disp);
 }
 
 /*

--- a/tests/subsys/display/cfb/fonts/src/print_rectspace1016.c
+++ b/tests/subsys/display/cfb/fonts/src/print_rectspace1016.c
@@ -39,15 +39,15 @@ static void cfb_test_before(void *text_fixture)
 
 	zassert_ok(display_blanking_off(dev));
 
-	zassert_ok(cfb_framebuffer_init(dev));
+	zassert_ok(cfb_framebuffer_init(fb));
 
-	for (int idx = 0; idx < cfb_get_numof_fonts(dev); idx++) {
-		if (cfb_get_font_size(dev, idx, &font_width, &font_height)) {
+	for (int idx = 0; idx < cfb_get_numof_fonts(fb); idx++) {
+		if (cfb_get_font_size(fb, idx, &font_width, &font_height)) {
 			break;
 		}
 
 		if (font_width == 10 && font_height == 16) {
-			cfb_framebuffer_set_font(dev, idx);
+			cfb_framebuffer_set_font(fb, idx);
 			font_found = true;
 			break;
 		}
@@ -58,7 +58,7 @@ static void cfb_test_before(void *text_fixture)
 
 static void cfb_test_after(void *test_fixture)
 {
-	cfb_framebuffer_deinit(dev);
+	cfb_framebuffer_deinit(fb);
 }
 
 static void verify_rectspace1016_bottom_half_at_origin(void)
@@ -75,16 +75,16 @@ static void verify_rectspace1016_bottom_half_at_origin(void)
  */
 ZTEST(print_rectspace1016, test_print_at_0_0)
 {
-	zassert_ok(cfb_print(dev, " ", 0, 0));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_print(fb, " ", 0, 0));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(0, 0, rectspace1016, 10, 16, 0));
 }
 
 ZTEST(print_rectspace1016, test_print_at_1_1)
 {
-	zassert_ok(cfb_print(dev, " ", 1, 1));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_print(fb, " ", 1, 1));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(1, 1, rectspace1016, 10, 16, 0));
 }
@@ -94,40 +94,40 @@ ZTEST(print_rectspace1016, test_print_at_1_1)
  */
 ZTEST(print_rectspace1016, test_print_at_9_15)
 {
-	zassert_ok(cfb_print(dev, " ", 9, 15));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_print(fb, " ", 9, 15));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(9, 15, rectspace1016, 10, 16, 0));
 }
 
 ZTEST(print_rectspace1016, test_print_at_10_16)
 {
-	zassert_ok(cfb_print(dev, " ", 10, 16));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_print(fb, " ", 10, 16));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(10, 16, rectspace1016, 10, 16, 0));
 }
 
 ZTEST(print_rectspace1016, test_print_at_11_17)
 {
-	zassert_ok(cfb_print(dev, " ", 11, 17));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_print(fb, " ", 11, 17));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(11, 17, rectspace1016, 10, 16, 0));
 }
 
 ZTEST(print_rectspace1016, test_print_missing_glyph_at_0_0)
 {
-	zassert_ok(cfb_print(dev, "~", 0, 0));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_print(fb, "~", 0, 0));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(0, 0, tofu1016, 10, 16, 0));
 }
 
 ZTEST(print_rectspace1016, test_print_missing_glyph_at_9_15)
 {
-	zassert_ok(cfb_print(dev, "~", 9, 15));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_print(fb, "~", 9, 15));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(9, 15, tofu1016, 10, 16, 0));
 }
@@ -137,72 +137,72 @@ ZTEST(print_rectspace1016, test_print_missing_glyph_at_9_15)
  */
 ZTEST(print_rectspace1016, test_print_at_0_0_kerning_3)
 {
-	cfb_set_kerning(dev, 3);
-	zassert_ok(cfb_print(dev, "  ", 0, 0));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 3);
+	zassert_ok(cfb_print(fb, "  ", 0, 0));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(0, 0, kerning_3_2rectspace1016, 23, 16, 0));
 }
 
 ZTEST(print_rectspace1016, test_print_at_1_1_kerning_3)
 {
-	cfb_set_kerning(dev, 3);
-	zassert_ok(cfb_print(dev, "  ", 1, 1));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 3);
+	zassert_ok(cfb_print(fb, "  ", 1, 1));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(1, 1, kerning_3_2rectspace1016, 23, 16, 0));
 }
 
 ZTEST(print_rectspace1016, test_print_at_9_15_kerning_3)
 {
-	cfb_set_kerning(dev, 3);
-	zassert_ok(cfb_print(dev, "  ", 9, 15));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 3);
+	zassert_ok(cfb_print(fb, "  ", 9, 15));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(9, 15, kerning_3_2rectspace1016, 23, 16, 0));
 }
 
 ZTEST(print_rectspace1016, test_print_at_10_16_kerning_3)
 {
-	cfb_set_kerning(dev, 3);
-	zassert_ok(cfb_print(dev, "  ", 10, 16));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 3);
+	zassert_ok(cfb_print(fb, "  ", 10, 16));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(10, 16, kerning_3_2rectspace1016, 23, 16, 0));
 }
 
 ZTEST(print_rectspace1016, test_print_at_11_17_kerning_3)
 {
-	cfb_set_kerning(dev, 3);
-	zassert_ok(cfb_print(dev, "  ", 11, 17));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 3);
+	zassert_ok(cfb_print(fb, "  ", 11, 17));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(11, 17, kerning_3_2rectspace1016, 23, 16, 0));
 }
 
 ZTEST(print_rectspace1016, test_print_missing_glyph_at_0_0_kerning_3)
 {
-	cfb_set_kerning(dev, 3);
-	zassert_ok(cfb_print(dev, "~~", 0, 0));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 3);
+	zassert_ok(cfb_print(fb, "~~", 0, 0));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(0, 0, kerning_3_2tofu1016, 23, 16, 0));
 }
 
 ZTEST(print_rectspace1016, test_print_kerning_3_within_right_border)
 {
-	cfb_set_kerning(dev, 3);
-	zassert_ok(cfb_print(dev, "  ", display_width - 23, 17));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 3);
+	zassert_ok(cfb_print(fb, "  ", display_width - 23, 17));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image(display_width - 23, 17, kerning_3_2rectspace1016, 23, 16));
 }
 
 ZTEST(print_rectspace1016, test_print_kerning_3_text_wrap)
 {
-	cfb_set_kerning(dev, 3);
-	zassert_ok(cfb_print(dev, "  ", display_width - 22, 17));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 3);
+	zassert_ok(cfb_print(fb, "  ", display_width - 22, 17));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image(display_width - 22, 17, rectspace1016, 10, 16));
 	zassert_true(verify_image(0, 33, rectspace1016, 10, 16));
@@ -210,9 +210,9 @@ ZTEST(print_rectspace1016, test_print_kerning_3_text_wrap)
 
 ZTEST(print_rectspace1016, test_print_missing_glyph_kerning_3_text_wrap)
 {
-	cfb_set_kerning(dev, 3);
-	zassert_ok(cfb_print(dev, "~~", display_width - 22, 17));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 3);
+	zassert_ok(cfb_print(fb, "~~", display_width - 22, 17));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image(display_width - 22, 17, tofu1016, 10, 16));
 	zassert_true(verify_image(0, 33, tofu1016, 10, 16));
@@ -220,81 +220,81 @@ ZTEST(print_rectspace1016, test_print_missing_glyph_kerning_3_text_wrap)
 
 ZTEST(print_rectspace1016, test_print_outside_top_left)
 {
-	zassert_ok(cfb_print(dev, " ", -(10 - 3), -(16 - 4)));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_print(fb, " ", -(10 - 3), -(16 - 4)));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(0, 0, outside_top_left, 3, 4, 0));
 }
 
 ZTEST(print_rectspace1016, test_print_outside_top_tile_aligned)
 {
-	zassert_ok(cfb_print(dev, " ", 0, -8));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_print(fb, " ", 0, -8));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	verify_rectspace1016_bottom_half_at_origin();
 }
 
 ZTEST(print_rectspace1016, test_print_missing_glyph_outside_top_left)
 {
-	zassert_ok(cfb_print(dev, "~", -(10 - 3), -(16 - 4)));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_print(fb, "~", -(10 - 3), -(16 - 4)));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(0, 0, outside_top_left_tofu1016, 3, 4, 0));
 }
 
 ZTEST(print_rectspace1016, test_print_outside_top_right)
 {
-	zassert_ok(cfb_print(dev, " ", display_width - 5, -8));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_print(fb, " ", display_width - 5, -8));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(0, 8, rectspace1016, 10, 16, 0));
 }
 
 ZTEST(print_rectspace1016, test_print_missing_glyph_outside_top_right)
 {
-	zassert_ok(cfb_print(dev, "~", display_width - 5, -8));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_print(fb, "~", display_width - 5, -8));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(0, 8, tofu1016, 10, 16, 0));
 }
 
 ZTEST(print_rectspace1016, test_print_outside_bottom_right)
 {
-	zassert_ok(cfb_print(dev, " ", display_width - 3, display_height - 5));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_print(fb, " ", display_width - 3, display_height - 5));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_color_inside_rect(0, 0, display_width, display_height, 0));
 }
 
 ZTEST(print_rectspace1016, test_print_missing_glyph_outside_bottom_right)
 {
-	zassert_ok(cfb_print(dev, "~", display_width - 3, display_height - 5));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_print(fb, "~", display_width - 3, display_height - 5));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_color_inside_rect(0, 0, display_width, display_height, 0));
 }
 
 ZTEST(print_rectspace1016, test_print_outside_bottom_left)
 {
-	zassert_ok(cfb_print(dev, " ", -(10 - 3), display_height - 14));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_print(fb, " ", -(10 - 3), display_height - 14));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image(0, display_height - 14, outside_bottom_left, 3, 14));
 }
 
 ZTEST(print_rectspace1016, test_print_missing_glyph_outside_bottom_left)
 {
-	zassert_ok(cfb_print(dev, "~", -(10 - 3), display_height - 14));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_print(fb, "~", -(10 - 3), display_height - 14));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image(0, display_height - 14, outside_bottom_left_tofu1016, 3, 14));
 }
 
 ZTEST(print_rectspace1016, test_print_wrap_to_3_lines)
 {
-	cfb_set_kerning(dev, 3);
-	zassert_ok(cfb_print(dev, "                                                 ", 160, 17));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 3);
+	zassert_ok(cfb_print(fb, "                                                 ", 160, 17));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image(160, 17, kerning_3_12rectspace1016, 153, 16));
 	zassert_true(verify_image(0, 33, kerning_3_12rectspace1016, 153, 16));

--- a/tests/subsys/display/cfb/fonts/src/print_rectspace1016.c
+++ b/tests/subsys/display/cfb/fonts/src/print_rectspace1016.c
@@ -15,31 +15,20 @@
 
 LOG_MODULE_REGISTER(print_rectspace1016, CONFIG_DISPLAY_LOG_LEVEL);
 
-static const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
-static const uint32_t display_width = DT_PROP(DT_CHOSEN(zephyr_display), width);
-static const uint32_t display_height = DT_PROP(DT_CHOSEN(zephyr_display), height);
+static struct cfb_display *disp;
+static struct cfb_framebuffer *fb;
 
 /**
  * Fill the buffer with 0 before running tests.
  */
 static void cfb_test_before(void *text_fixture)
 {
-	struct display_buffer_descriptor desc = {
-		.height = display_height,
-		.pitch = display_width,
-		.width = display_width,
-		.buf_size = display_height * display_width / 8,
-	};
 	uint8_t font_width;
 	uint8_t font_height;
 	bool font_found = false;
 
-	memset(read_buffer, 0, sizeof(read_buffer));
-	zassert_ok(display_write(dev, 0, 0, &desc, read_buffer));
-
-	zassert_ok(display_blanking_off(dev));
-
-	zassert_ok(cfb_framebuffer_init(fb));
+	disp = display_init();
+	fb = cfb_display_get_framebuffer(disp);
 
 	for (int idx = 0; idx < cfb_get_numof_fonts(fb); idx++) {
 		if (cfb_get_font_size(fb, idx, &font_width, &font_height)) {
@@ -58,7 +47,7 @@ static void cfb_test_before(void *text_fixture)
 
 static void cfb_test_after(void *test_fixture)
 {
-	cfb_framebuffer_deinit(fb);
+	display_deinit(disp);
 }
 
 static void verify_rectspace1016_bottom_half_at_origin(void)

--- a/tests/subsys/display/cfb/fonts/src/print_rectspace1123.c
+++ b/tests/subsys/display/cfb/fonts/src/print_rectspace1123.c
@@ -15,31 +15,20 @@
 
 LOG_MODULE_REGISTER(print_rectspace1123, CONFIG_DISPLAY_LOG_LEVEL);
 
-static const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
-static const uint32_t display_width = DT_PROP(DT_CHOSEN(zephyr_display), width);
-static const uint32_t display_height = DT_PROP(DT_CHOSEN(zephyr_display), height);
+static struct cfb_display *disp;
+static struct cfb_framebuffer *fb;
 
 /**
  * Fill the buffer with 0 before running tests.
  */
 static void cfb_test_before(void *text_fixture)
 {
-	struct display_buffer_descriptor desc = {
-		.height = display_height,
-		.pitch = display_width,
-		.width = display_width,
-		.buf_size = display_height * display_width / 8,
-	};
 	uint8_t font_width;
 	uint8_t font_height;
 	bool font_found = false;
 
-	memset(read_buffer, 0, sizeof(read_buffer));
-	zassert_ok(display_write(dev, 0, 0, &desc, read_buffer));
-
-	zassert_ok(display_blanking_off(dev));
-
-	zassert_ok(cfb_framebuffer_init(fb));
+	disp = display_init();
+	fb = cfb_display_get_framebuffer(disp);
 
 	for (int idx = 0; idx < cfb_get_numof_fonts(fb); idx++) {
 		if (cfb_get_font_size(fb, idx, &font_width, &font_height)) {
@@ -58,7 +47,7 @@ static void cfb_test_before(void *text_fixture)
 
 static void cfb_test_after(void *test_fixture)
 {
-	cfb_framebuffer_deinit(fb);
+	display_deinit(disp);
 }
 
 /*

--- a/tests/subsys/display/cfb/fonts/src/print_rectspace1123.c
+++ b/tests/subsys/display/cfb/fonts/src/print_rectspace1123.c
@@ -39,15 +39,15 @@ static void cfb_test_before(void *text_fixture)
 
 	zassert_ok(display_blanking_off(dev));
 
-	zassert_ok(cfb_framebuffer_init(dev));
+	zassert_ok(cfb_framebuffer_init(fb));
 
-	for (int idx = 0; idx < cfb_get_numof_fonts(dev); idx++) {
-		if (cfb_get_font_size(dev, idx, &font_width, &font_height)) {
+	for (int idx = 0; idx < cfb_get_numof_fonts(fb); idx++) {
+		if (cfb_get_font_size(fb, idx, &font_width, &font_height)) {
 			break;
 		}
 
 		if (font_width == 11 && font_height == 23) {
-			cfb_framebuffer_set_font(dev, idx);
+			cfb_framebuffer_set_font(fb, idx);
 			font_found = true;
 			break;
 		}
@@ -58,7 +58,7 @@ static void cfb_test_before(void *text_fixture)
 
 static void cfb_test_after(void *test_fixture)
 {
-	cfb_framebuffer_deinit(dev);
+	cfb_framebuffer_deinit(fb);
 }
 
 /*
@@ -66,16 +66,16 @@ static void cfb_test_after(void *test_fixture)
  */
 ZTEST(print_rectspace1123, test_print_at_0_0)
 {
-	zassert_ok(cfb_print(dev, " ", 0, 0));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_print(fb, " ", 0, 0));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(0, 0, rectspace1123, 11, 23, 0));
 }
 
 ZTEST(print_rectspace1123, test_print_at_1_1)
 {
-	zassert_ok(cfb_print(dev, " ", 1, 1));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_print(fb, " ", 1, 1));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(1, 1, rectspace1123, 11, 23, 0));
 }
@@ -85,24 +85,24 @@ ZTEST(print_rectspace1123, test_print_at_1_1)
  */
 ZTEST(print_rectspace1123, test_print_at_9_15)
 {
-	zassert_ok(cfb_print(dev, " ", 9, 15));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_print(fb, " ", 9, 15));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(9, 15, rectspace1123, 11, 23, 0));
 }
 
 ZTEST(print_rectspace1123, test_print_at_10_16)
 {
-	zassert_ok(cfb_print(dev, " ", 10, 16));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_print(fb, " ", 10, 16));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(10, 16, rectspace1123, 11, 23, 0));
 }
 
 ZTEST(print_rectspace1123, test_print_at_11_17)
 {
-	zassert_ok(cfb_print(dev, " ", 11, 17));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_print(fb, " ", 11, 17));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(11, 17, rectspace1123, 11, 23, 0));
 }
@@ -112,63 +112,63 @@ ZTEST(print_rectspace1123, test_print_at_11_17)
  */
 ZTEST(print_rectspace1123, test_print_at_0_0_kerning_1)
 {
-	cfb_set_kerning(dev, 1);
-	zassert_ok(cfb_print(dev, "  ", 0, 0));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 1);
+	zassert_ok(cfb_print(fb, "  ", 0, 0));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(0, 0, kerning_1_2rectspace1123, 23, 23, 0));
 }
 
 ZTEST(print_rectspace1123, test_print_at_1_1_kerning_1)
 {
-	cfb_set_kerning(dev, 1);
-	zassert_ok(cfb_print(dev, "  ", 1, 1));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 1);
+	zassert_ok(cfb_print(fb, "  ", 1, 1));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(1, 1, kerning_1_2rectspace1123, 23, 23, 0));
 }
 
 ZTEST(print_rectspace1123, test_print_at_9_15_kerning_1)
 {
-	cfb_set_kerning(dev, 1);
-	zassert_ok(cfb_print(dev, "  ", 9, 15));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 1);
+	zassert_ok(cfb_print(fb, "  ", 9, 15));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(9, 15, kerning_1_2rectspace1123, 23, 23, 0));
 }
 
 ZTEST(print_rectspace1123, test_print_at_10_16_kerning_1)
 {
-	cfb_set_kerning(dev, 1);
-	zassert_ok(cfb_print(dev, "  ", 10, 16));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 1);
+	zassert_ok(cfb_print(fb, "  ", 10, 16));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(10, 16, kerning_1_2rectspace1123, 23, 23, 0));
 }
 
 ZTEST(print_rectspace1123, test_print_at_11_17_kerning_1)
 {
-	cfb_set_kerning(dev, 1);
-	zassert_ok(cfb_print(dev, "  ", 11, 17));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 1);
+	zassert_ok(cfb_print(fb, "  ", 11, 17));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(11, 17, kerning_1_2rectspace1123, 23, 23, 0));
 }
 
 ZTEST(print_rectspace1123, test_print_at_right_border_17_kerning_1)
 {
-	cfb_set_kerning(dev, 1);
-	zassert_ok(cfb_print(dev, "  ", display_width - 23, 17));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 1);
+	zassert_ok(cfb_print(fb, "  ", display_width - 23, 17));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image(display_width - 23, 17, kerning_1_2rectspace1123, 23, 23));
 }
 
 ZTEST(print_rectspace1123, test_print_at_right_border_plus1_kerning_1)
 {
-	cfb_set_kerning(dev, 1);
-	zassert_ok(cfb_print(dev, "  ", display_width - 22, 17));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	cfb_set_kerning(fb, 1);
+	zassert_ok(cfb_print(fb, "  ", display_width - 22, 17));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image(display_width - 22, 17, rectspace1123, 11, 23));
 	zassert_true(verify_image(0, 40, rectspace1123, 11, 23));
@@ -176,32 +176,32 @@ ZTEST(print_rectspace1123, test_print_at_right_border_plus1_kerning_1)
 
 ZTEST(print_rectspace1123, test_print_outside_top_left)
 {
-	zassert_ok(cfb_print(dev, " ", -(11 - 3), -(23 - 4)));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_print(fb, " ", -(11 - 3), -(23 - 4)));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(0, 0, outside_top_left, 3, 4, 0));
 }
 
 ZTEST(print_rectspace1123, test_print_outside_top_right)
 {
-	zassert_ok(cfb_print(dev, " ", display_width - 5, -(23 - 8)));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_print(fb, " ", display_width - 5, -(23 - 8)));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image_and_bg(0, 8, rectspace1123, 11, 23, 0));
 }
 
 ZTEST(print_rectspace1123, test_print_outside_bottom_right)
 {
-	zassert_ok(cfb_print(dev, " ", display_width - 3, display_height - 5));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_print(fb, " ", display_width - 3, display_height - 5));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_color_inside_rect(0, 0, display_width, display_height, 0));
 }
 
 ZTEST(print_rectspace1123, test_print_outside_bottom_left)
 {
-	zassert_ok(cfb_print(dev, " ", -(11 - 3), display_height - 14));
-	zassert_ok(cfb_framebuffer_finalize(dev));
+	zassert_ok(cfb_print(fb, " ", -(11 - 3), display_height - 14));
+	zassert_ok(cfb_framebuffer_finalize(fb));
 
 	zassert_true(verify_image(0, display_height - 14, outside_bottom_left, 3, 14));
 }


### PR DESCRIPTION
This PR adds support for multi-display. This change affects APIs widely.
I also make some API improvements.
(Removal of font size restrictions, Function argument signedness changes, Remove needless arguments from font APIs)

- Introducing `struct cfb_display`
- Changed the argument `struct device *` to `struct cfb_framebuffer *`
- Rename APIs starting with `cfb_framebuffer_*`

Introduces struct cfb_display as a data structure to represent the display.
As a result, it is now possible to create multiple pieces of data managed
using a single static variable in previous implementations,
making it possible to handle multiple displays.
The old `struct cfb_framebuffer` remains but is now part of the
`struct cfb_display` data structure.
You can get cfb_framebuffer from cfb_display using the added API
`cfb_display_get_framebuffer`.

All places where a `struct device *` argument was passed to specify the
target will be replaced with a `struct cfb_framebuffer *`.
In line with this, API names starting with `cfb_framebuffer_*`,
which were redundant and inconsistent names, will remove
`_framebuffer` and change to `cfb_*` .

Related API and implementation improvement have also been committed.

* Remove unused arguments

`cfb_get_font_size`
`cfb_get_numof_fonts`

* Change coordinate specification to signed integer

`cfb_invert_area`
`cfb_print`
`cfb_draw_point` (cfb_position)
`cfb_draw_line`
`cfb_draw_rect`

* Removed the restriction that the vertical size of the font must be a multiple of 8.

---------------------

This PR is part of a series of CFB enhancements (second of four https://github.com/zephyrproject-rtos/zephyr/issues/72177). 
I would appreciate it if you could check the #67881  part first.

