### PR TITLE
libc: common: declare strnlen() and strtok_r() in string.h

### DIFF
--- a/lib/libc/common/include/string.h
+++ b/lib/libc/common/include/string.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024, Meta
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_LIB_LIBC_COMMON_INCLUDE_STRING_H_
+#define ZEPHYR_LIB_LIBC_COMMON_INCLUDE_STRING_H_
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if _POSIX_C_SOURCE >= 200809L || defined(_ZEPHYR_SOURCE)
+size_t strnlen(const char *s, size_t maxlen);
+#endif
+
+#if _POSIX_C_SOURCE >= 200112L || defined(_ZEPHYR_SOURCE)
+char *strtok_r(char *str, const char *sep, char **state);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#include_next <string.h>
+
+#endif /* ZEPHYR_LIB_LIBC_COMMON_INCLUDE_STRING_H_ */

--- a/lib/libc/newlib/CMakeLists.txt
+++ b/lib/libc/newlib/CMakeLists.txt
@@ -37,6 +37,11 @@ zephyr_compile_definitions(_ANSI_SOURCE)
 # used by the network stack
 zephyr_compile_definitions(__LINUX_ERRNO_EXTENSIONS__)
 
+# define _ZEPHYR_SOURCE so we can get POSIX extensions to ISO C declared in
+# lib/libc/common/include/string.h, to satisfy Rule A.4 of Zephyr's Coding
+# Guidelines.
+zephyr_compile_definitions(_ZEPHYR_SOURCE)
+
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
   # We are using
   # - ${CMAKE_C_LINKER_WRAPPER_FLAG}${CMAKE_LINK_LIBRARY_FLAG}c

--- a/tests/lib/c_lib/common/src/main.c
+++ b/tests/lib/c_lib/common/src/main.c
@@ -15,7 +15,7 @@
  * it guarantee that ALL functionality provided is working correctly.
  */
 
-#if defined(CONFIG_NEWLIB_LIBC) || defined(CONFIG_NATIVE_LIBC)
+#if defined(CONFIG_NATIVE_LIBC)
 #undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
 #endif


### PR DESCRIPTION
Rules [A.4](https://docs.zephyrproject.org/latest/contribute/coding_guidelines/index.html#rule-a-4-c-standard-library-usage-restrictions-in-zephyr-kernel) and [A.5](https://docs.zephyrproject.org/latest/contribute/coding_guidelines/index.html#rule-a-5-c-standard-library-usage-restrictions-in-zephyr-codebase) of the coding guidelines allow the POSIX `strnlen()` and `strtok_r()` functions to be used anywhere within Zephyr, including in the kernel.

These are not part of ISO C and typically require `_POSIX_C_SOURCE` to be declared. However, in Zephyr, POSIX and the interfaces it provides, are optional. `_POSIX_C_SOURCE` should not be used to compile the kernel and core components of the system, which is also specified by Rules A.4 and A.5 of the coding guidelines.

Declare `strnlen()` and `strtok_r()` with `_POSIX_C_SOURCE` or with `_ZEPHYR_SOURCE` so that they can be provided in a way that does not conflict with coding guidelines.