### PR TITLE
drivers: i2c: andes: Remove the inclusion of soc.h

### DIFF
--- a/drivers/i2c/i2c_andes_atciic100.h
+++ b/drivers/i2c/i2c_andes_atciic100.h
@@ -10,7 +10,6 @@
 #include <errno.h>
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
-#include <soc.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/sys_io.h>


### PR DESCRIPTION
The purpose of the PR is to address the build error in the eeprom driver's testcase using board adp_xc7k_ae350.

Remove the inclusion of empty file "soc.h" which is deleted in  [PR #67673](https://github.com/zephyrproject-rtos/zephyr/pull/67673/commits/e35e4b6fde675705e8f3eb7056b1760a746daaa8)