### PR TITLE
soc: riscv: andes_v5: fix missing header in PMA driver and the MPU padding issue in linker.ld

### DIFF
--- a/soc/andestech/ae350/linker.ld
+++ b/soc/andestech/ae350/linker.ld
@@ -400,10 +400,6 @@ GROUP_END(DTCM)
     /* Sections generated from 'zephyr,memory-region' nodes */
     LINKER_DT_SECTIONS()
 
-/* Because ROMABLE_REGION != RAMABLE_REGION in XIP-system, it is valid
- * to set __rom_region_end symbol at the end of linker script and
- * doesn't mistakenly contain the RAMABLE_REGION in it.
- */
 #ifdef CONFIG_XIP
 /* Must be last in romable region */
 SECTION_PROLOGUE(.last_section,,)
@@ -415,17 +411,27 @@ SECTION_PROLOGUE(.last_section,,)
 #endif
 } GROUP_LINK_IN(ROMABLE_REGION)
 
+/* Because ROMABLE_REGION != RAMABLE_REGION in XIP-system, it is valid
+ * to set __rom_region_end symbol at the end of linker script and
+ * doesn't mistakenly contain the RAMABLE_REGION in it.
+ */
 #ifndef CONFIG_RISCV_PMP
-/* To provide the image size as a const expression,
- * calculate this value here. */
 __rom_region_end = LOADADDR(.last_section) + SIZEOF(.last_section);
 #else
+/* Padding __rom_region_end to matches the requirement of the MPU region.
+ * __rom_region_size is used to configure the MPU region, but the actual rom
+ * region data usage is ends at .last_section.
+ */
 SECTION_PROLOGUE(rom_mpu_padding,(NOLOAD),)
 {
 	MPU_ALIGN(__rom_region_size);
 } GROUP_LINK_IN(ROMABLE_REGION)
 __rom_region_end = LOADADDR(rom_mpu_padding) + SIZEOF(rom_mpu_padding);
 #endif /* !CONFIG_RISCV_PMP */
+
+/* To provide the rom region size as a const expression,
+ * calculate this value here.
+ */
 __rom_region_size = __rom_region_end - __rom_region_start;
 #endif
 

--- a/soc/andestech/ae350/linker.ld
+++ b/soc/andestech/ae350/linker.ld
@@ -423,8 +423,8 @@ __rom_region_end = LOADADDR(.last_section) + SIZEOF(.last_section);
 SECTION_PROLOGUE(rom_mpu_padding,(NOLOAD),)
 {
 	MPU_ALIGN(__rom_region_size);
-	__rom_region_end = .;
 } GROUP_LINK_IN(ROMABLE_REGION)
+__rom_region_end = LOADADDR(rom_mpu_padding) + SIZEOF(rom_mpu_padding);
 #endif /* !CONFIG_RISCV_PMP */
 __rom_region_size = __rom_region_end - __rom_region_start;
 #endif

--- a/soc/andestech/ae350/pma.c
+++ b/soc/andestech/ae350/pma.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "soc_v5.h"
+
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/arch/cpu.h>


### PR DESCRIPTION
This PR fix two issues in the andes_v5 SoC

1. PMA driver lacks the `#include "soc_v5.h"` for CSR definition.
2. In the linker.ld, the location counter is not correct for padding the MPU region because it had been assigned to `RAM_BASE`. Fixed this issue by utilizing LMA.