### PR TITLE
cmake: modules: generated_file_directories: fix paths

### DIFF
--- a/cmake/modules/generated_file_directories.cmake
+++ b/cmake/modules/generated_file_directories.cmake
@@ -19,6 +19,6 @@ include_guard(GLOBAL)
 # Optional environment variables:
 # None
 
-set(BINARY_DIR_INCLUDE ${PROJECT_BINARY_DIR}/include/generated)
-set(BINARY_DIR_INCLUDE_GENERATED ${PROJECT_BINARY_DIR}/include/generated)
+set(BINARY_DIR_INCLUDE ${PROJECT_BINARY_DIR}/include)
+set(BINARY_DIR_INCLUDE_GENERATED ${BINARY_DIR_INCLUDE}/generated)
 file(MAKE_DIRECTORY ${BINARY_DIR_INCLUDE_GENERATED})


### PR DESCRIPTION
The paths that got assigned to these variable don't quite match the description, likely a typo, fix that.