### PR TITLE
.github: workflows: Add test trigger for pytest harness

### DIFF
--- a/.github/workflows/twister_tests.yml
+++ b/.github/workflows/twister_tests.yml
@@ -9,7 +9,7 @@ on:
     - main
     - v*-branch
     paths:
-    - 'scripts/pylib/twister/**'
+    - 'scripts/pylib/**'
     - 'scripts/twister'
     - 'scripts/tests/twister/**'
     - '.github/workflows/twister_tests.yml'
@@ -18,7 +18,7 @@ on:
     - main
     - v*-branch
     paths:
-    - 'scripts/pylib/twister/**'
+    - 'scripts/pylib/**'
     - 'scripts/twister'
     - 'scripts/tests/twister/**'
     - '.github/workflows/twister_tests.yml'


### PR DESCRIPTION
Pytest twister harness tests have been added to the `twister_tests.yml` workflow some time ago.

However, the `$ZEPHYR_BASE/scripts/pylib/pytest-twister-harness/**` has not been monitored by the automatic GitHub Action triggers of that workflow.

This change adds monitoring for the relevant files.

Note that this mistake has already caused problems in our CI, namely #68172