### PR TITLE
STM32  nor flash controller gets address and size

### DIFF
--- a/boards/arm/arduino_giga_r1/arduino_giga_r1_m7.dts
+++ b/boards/arm/arduino_giga_r1/arduino_giga_r1_m7.dts
@@ -171,11 +171,10 @@
 	pinctrl-names = "default";
 	status = "okay";
 
-	n25q128a1: qspi-nor-flash@0 {
+	n25q128a1: qspi-nor-flash@90000000 {
 		compatible = "st,stm32-qspi-nor";
-		reg = <0>;
+		reg = <0x90000000 DT_SIZE_M(16)>; /* 128 Mbits */
 		qspi-max-frequency = <72000000>;
-		size = <DT_SIZE_M(16*8)>;
 		status = "okay";
 
 		partitions {

--- a/boards/arm/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
+++ b/boards/arm/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
@@ -131,11 +131,10 @@ stm32_lp_tick_source: &lptim1 {
 
 	status = "okay";
 
-	mx25lm51245: ospi-nor-flash@0 {
+	mx25lm51245: ospi-nor-flash@70000000 {
 		compatible = "st,stm32-ospi-nor";
-		reg = <0>;
+		reg = <0x70000000 DT_SIZE_M(64)>; /* 512 Mbits */
 		ospi-max-frequency = <DT_FREQ_M(50)>;
-		size = <DT_SIZE_M(512)>; /* 64 MBytes */
 		spi-bus-width = <OSPI_OPI_MODE>;
 		data-rate = <OSPI_DTR_TRANSFER>;
 		four-byte-opcodes;

--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -321,12 +321,10 @@ zephyr_udc0: &usbotg_fs {
 
 	status = "okay";
 
-	mx25r6435f: qspi-nor-flash@0 {
+	mx25r6435f: qspi-nor-flash@90000000 {
 		compatible = "st,stm32-qspi-nor";
-		reg = <0>;
+		reg = <0x90000000 DT_SIZE_M(8)>; /* 64 Mbits */
 		qspi-max-frequency = <50000000>;
-		/* 64 Megabits = 8 Megabytes */
-		size = <0x4000000>;
 		status = "okay";
 
 		partitions {

--- a/boards/arm/pandora_stm32l475/pandora_stm32l475.dts
+++ b/boards/arm/pandora_stm32l475/pandora_stm32l475.dts
@@ -79,11 +79,10 @@
 	pinctrl-names = "default";
 
 	status = "okay";
-	w25q128jv: qspi-nor-flash@0 {
+	w25q128jv: qspi-nor-flash@90000000 {
 			compatible = "st,stm32-qspi-nor";
-			reg = <0>;
+			reg = <0x90000000 DT_SIZE_M(16)>; /* 128 Mbits */
 			qspi-max-frequency = <80000000>;
-			size = <0x8000000>;
 			jedec-id = [ef 40 18];
 			spi-bus-width = <4>;
 			status = "okay";

--- a/boards/arm/stm32f412g_disco/stm32f412g_disco.dts
+++ b/boards/arm/stm32f412g_disco/stm32f412g_disco.dts
@@ -147,11 +147,10 @@
 	pinctrl-names = "default";
 	status = "okay";
 
-	n25q128a1: qspi-nor-flash@0 {
+	n25q128a1: qspi-nor-flash@90000000 {
 		compatible = "st,stm32-qspi-nor";
-		reg = <0>;
+		reg = <0x90000000 DT_SIZE_M(16)>; /* 128 Mbits */
 		qspi-max-frequency = <72000000>;
-		size = <DT_SIZE_M(16*8)>;
 		status = "okay";
 	};
 };

--- a/boards/arm/stm32f723e_disco/stm32f723e_disco.dts
+++ b/boards/arm/stm32f723e_disco/stm32f723e_disco.dts
@@ -124,11 +124,10 @@
 	flash-id = <1>;
 	status = "okay";
 
-	mx25r512: qspi-nor-flash@0 {
+	mx25r512: qspi-nor-flash@90000000 {
 		compatible = "st,stm32-qspi-nor";
-		reg = <0>;
+		reg = <0x90000000 DT_SIZE_M(64)>; /* 512 Mbits */
 		qspi-max-frequency = <8000000>;
-		size = <DT_SIZE_M(512)>; /* 64 MBytes */
 		status = "okay";
 		spi-bus-width = <4>;
 		writeoc = "PP_1_4_4";

--- a/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
+++ b/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
@@ -187,11 +187,10 @@ zephyr_udc0: &usbotg_fs {
 	pinctrl-names = "default";
 	status = "okay";
 
-	n25q128a1: qspi-nor-flash@0 {
+	n25q128a1: qspi-nor-flash@90000000 {
 		compatible = "st,stm32-qspi-nor";
-		reg = <0>;
+		reg = <0x90000000 DT_SIZE_M(16)>; /* 128 Mbits */
 		qspi-max-frequency = <72000000>;
-		size = <DT_SIZE_M(16*8)>;
 		status = "okay";
 
 		partitions {

--- a/boards/arm/stm32f7508_dk/stm32f7508_dk.dts
+++ b/boards/arm/stm32f7508_dk/stm32f7508_dk.dts
@@ -183,11 +183,10 @@ zephyr_udc0: &usbotg_fs {
 	pinctrl-names = "default";
 	status = "okay";
 
-	n25q128a1: qspi-nor-flash@0 {
+	n25q128a1: qspi-nor-flash@90000000 {
 		compatible = "st,stm32-qspi-nor";
-		reg = <0>;
+		reg = <0x90000000 DT_SIZE_M(16)>; /* 128 Mbits */
 		qspi-max-frequency = <72000000>;
-		size = <DT_SIZE_M(16*8)>;
 		status = "okay";
 
 		partitions {

--- a/boards/arm/stm32f769i_disco/stm32f769i_disco.dts
+++ b/boards/arm/stm32f769i_disco/stm32f769i_disco.dts
@@ -172,11 +172,10 @@ arduino_serial: &usart6 {};
 	pinctrl-names = "default";
 	status = "okay";
 
-	mx25l51245g: qspi-nor-flash@0 {
+	mx25l51245g: qspi-nor-flash@90000000 {
 		compatible = "st,stm32-qspi-nor";
-		reg = <0>;
+		reg = <0x90000000 DT_SIZE_M(64)>; /* 512 Mbits */
 		qspi-max-frequency = <72000000>;
-		size = <DT_SIZE_M(64*8)>;
 		status = "okay";
 
 		partitions {
@@ -186,7 +185,7 @@ arduino_serial: &usart6 {};
 
 			slot1_partition: partition@0 {
 				label = "image-1";
-				reg = <0x00000000 DT_SIZE_K(1664)>;
+				reg = <0x00000000 DT_SIZE_K(16)>;
 				};
 
 			storage_partition: partition@1a0000 {

--- a/boards/arm/stm32h747i_disco/stm32h747i_disco_m7.dts
+++ b/boards/arm/stm32h747i_disco/stm32h747i_disco_m7.dts
@@ -232,11 +232,10 @@ zephyr_udc0: &usbotg_hs {
 	pinctrl-names = "default";
 	status = "okay";
 
-	mt25ql512ab1: qspi-nor-flash-1@0 {
+	mt25ql512ab1: qspi-nor-flash-1@90000000 {
 		compatible = "st,stm32-qspi-nor";
-		reg = <0>;
+		reg = <0x90000000 DT_SIZE_M(64)>; /* 512 Mbits */
 		qspi-max-frequency = <72000000>;
-		size = <DT_SIZE_M(512)>; /* 64 MBytes */
 		spi-bus-width = <4>;
 		status = "okay";
 
@@ -251,11 +250,10 @@ zephyr_udc0: &usbotg_hs {
 		};
 	};
 
-	mt25ql512ab2: qspi-nor-flash-2@0 {
+	mt25ql512ab2: qspi-nor-flash-2@90000000 {
 		compatible = "st,stm32-qspi-nor";
-		reg = <0>;
+		reg = <0x90000000 DT_SIZE_M(64)>; /* 512 Mbits */
 		qspi-max-frequency = <72000000>;
-		size = <DT_SIZE_M(512)>; /* 64 MBytes */
 		status = "okay";
 	};
 };

--- a/boards/arm/stm32h750b_dk/stm32h750b_dk.dts
+++ b/boards/arm/stm32h750b_dk/stm32h750b_dk.dts
@@ -102,11 +102,10 @@
 	flash-id = <1>;
 	status = "okay";
 
-	mt25ql512ab1: qspi-nor-flash-1@0 {
+	mt25ql512ab1: qspi-nor-flash-1@90000000 {
 		compatible = "st,stm32-qspi-nor";
-		reg = <0>;
+		reg = <0x90000000 DT_SIZE_M(64)>; /* 512 Mbits */
 		qspi-max-frequency = <72000000>;
-		size = <DT_SIZE_M(512)>; /* 64 MBytes */
 		spi-bus-width = <4>;
 		status = "okay";
 
@@ -121,9 +120,9 @@
 		};
 	};
 
-	mt25ql512ab2: qspi-nor-flash-2@1 {
+	mt25ql512ab2: qspi-nor-flash-2@90000000 {
 		compatible = "st,stm32-qspi-nor";
-		reg = <1>;
+		reg = <0x90000000 DT_SIZE_M(64)>; /* 512 Mbits */
 		qspi-max-frequency = <72000000>;
 		size = <DT_SIZE_M(512)>; /* 64 MBytes */
 		status = "okay";

--- a/boards/arm/stm32l496g_disco/stm32l496g_disco.dts
+++ b/boards/arm/stm32l496g_disco/stm32l496g_disco.dts
@@ -201,11 +201,10 @@ zephyr_udc0: &usbotg_fs {
 	flash-id = <1>;
 	status = "okay";
 
-	mx25r6435: qspi-nor-flash@0 {
+	mx25r6435: qspi-nor-flash@90000000 {
 		compatible = "st,stm32-qspi-nor";
-		reg = <0>;
+		reg = <0x90000000 DT_SIZE_M(8)>; /* 64 Mbits */
 		qspi-max-frequency = <8000000>;
-		size = <DT_SIZE_M(64)>; /* 8 MBytes */
 		status = "okay";
 		spi-bus-width = <4>;
 		writeoc = "PP_1_4_4";

--- a/boards/arm/stm32l562e_dk/stm32l562e_dk_common.dtsi
+++ b/boards/arm/stm32l562e_dk/stm32l562e_dk_common.dtsi
@@ -135,11 +135,10 @@ stm32_lp_tick_source: &lptim1 {
 
 	status = "okay";
 
-	mx25lm51245: ospi-nor-flash@0 {
+	mx25lm51245: ospi-nor-flash@90000000 {
 		compatible = "st,stm32-ospi-nor";
-		reg = <0>;
+		reg = <0x90000000 DT_SIZE_M(64)>; /* 512 Mbits */
 		ospi-max-frequency = <DT_FREQ_M(50)>;
-		size = <DT_SIZE_M(512)>; /* 64 MBytes */
 		spi-bus-width = <OSPI_OPI_MODE>;
 		data-rate = <OSPI_DTR_TRANSFER>;
 		four-byte-opcodes;

--- a/doc/releases/migration-guide-3.6.rst
+++ b/doc/releases/migration-guide-3.6.rst
@@ -166,6 +166,18 @@ Device Drivers and Device Tree
             status = "okay";
     };
 
+
+* The :dtcompatible:`st,stm32-ospi-nor` and :dtcompatible:`st,stm32-qspi-nor` give the nor flash
+  base address and size (in Bytes) with the **reg** property as follows.
+  The <size> property is not used anymore.
+
+  .. code-block:: devicetree
+
+    mx25lm51245: ospi-nor-flash@70000000 {
+            compatible = "st,stm32-ospi-nor";
+            reg = <0x70000000 DT_SIZE_M(64)>; /* 512 Mbits*/
+    };
+
 * The native Linux SocketCAN driver, which can now be used in both :ref:`native_posix<native_posix>`
   and :ref:`native_sim<native_sim>` with or without an embedded C-library, has been renamed to
   reflect this:

--- a/drivers/flash/flash_stm32_ospi.c
+++ b/drivers/flash/flash_stm32_ospi.c
@@ -36,6 +36,9 @@ LOG_MODULE_REGISTER(flash_stm32_ospi, CONFIG_FLASH_LOG_LEVEL);
 		    (_CONCAT(HAL_OSPIM_, DT_STRING_TOKEN(STM32_OSPI_NODE, prop))),	\
 		    ((default_value)))
 
+/* Get the base address of the flash from the DTS node */
+#define STM32_OSPI_BASE_ADDRESS DT_INST_REG_ADDR(0)
+
 #define STM32_OSPI_RESET_GPIO DT_INST_NODE_HAS_PROP(0, reset_gpios)
 
 #define STM32_OSPI_DLYB_BYPASSED DT_PROP(STM32_OSPI_NODE, dlyb_bypass)
@@ -2235,6 +2238,10 @@ static int flash_stm32_ospi_init(const struct device *dev)
 	}
 #endif /* CONFIG_FLASH_PAGE_LAYOUT */
 
+	LOG_INF("NOR octo-flash at 0x%lx (0x%x bytes)",
+		(long)(STM32_OSPI_BASE_ADDRESS),
+		dev_cfg->flash_size);
+
 	return 0;
 }
 
@@ -2300,7 +2307,7 @@ static const struct flash_stm32_ospi_config flash_stm32_ospi_cfg = {
 		       .enr = DT_CLOCKS_CELL_BY_NAME(STM32_OSPI_NODE, ospi_mgr, bits)},
 #endif
 	.irq_config = flash_stm32_ospi_irq_config_func,
-	.flash_size = DT_INST_PROP(0, size) / 8U,
+	.flash_size = DT_INST_REG_ADDR_BY_IDX(0, 1),
 	.max_frequency = DT_INST_PROP(0, ospi_max_frequency),
 	.data_mode = DT_INST_PROP(0, spi_bus_width), /* SPI or OPI */
 	.data_rate = DT_INST_PROP(0, data_rate), /* DTR or STR */

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -29,6 +29,9 @@
 #define STM32_QSPI_USE_QUAD_IO 0
 #endif
 
+/* Get the base address of the flash from the DTS node */
+#define STM32_QSPI_BASE_ADDRESS DT_INST_REG_ADDR(0)
+
 #define STM32_QSPI_RESET_GPIO DT_INST_NODE_HAS_PROP(0, reset_gpios)
 #define STM32_QSPI_RESET_CMD DT_INST_NODE_HAS_PROP(0, reset_cmd)
 
@@ -1364,6 +1367,10 @@ static int flash_stm32_qspi_init(const struct device *dev)
 	}
 #endif /* CONFIG_FLASH_PAGE_LAYOUT */
 
+	LOG_INF("NOR quad-flash at 0x%lx (0x%x bytes)",
+		(long)(STM32_QSPI_BASE_ADDRESS),
+		dev_cfg->flash_size);
+
 	return 0;
 }
 
@@ -1420,7 +1427,7 @@ static const struct flash_stm32_qspi_config flash_stm32_qspi_cfg = {
 		.bus = DT_CLOCKS_CELL(STM32_QSPI_NODE, bus)
 	},
 	.irq_config = flash_stm32_qspi_irq_config_func,
-	.flash_size = DT_INST_PROP(0, size) / 8U,
+	.flash_size = DT_INST_REG_ADDR_BY_IDX(0, 1),
 	.max_frequency = DT_INST_PROP(0, qspi_max_frequency),
 	.pcfg = PINCTRL_DT_DEV_CONFIG_GET(STM32_QSPI_NODE),
 #if STM32_QSPI_RESET_GPIO

--- a/dts/bindings/flash_controller/st,stm32-ospi-nor.yaml
+++ b/dts/bindings/flash_controller/st,stm32-ospi-nor.yaml
@@ -6,13 +6,12 @@ description: |
 
     Representation of a serial flash on a octospi bus:
 
-        mx25lm51245: ospi-nor-flash@0 {
+        mx25lm51245: ospi-nor-flash@70000000 {
                 compatible = "st,stm32-ospi-nor";
-                reg = <0>;
+                reg = <0x70000000 DT_SIZE_M(64)>; /* 512 Mbits */
                 data-mode = <OSPI_OPI_MODE>; /* access on 8 data lines */
                 data-rate = <OSPI_DTR_TRANSFER>; /* access in DTR */
                 ospi-max-frequency = <DT_FREQ_M(50)>;
-                size = <DT_SIZE_M(64*8)>; /* 512 Mbit */
                 status = "okay";
         };
 
@@ -25,13 +24,11 @@ on-bus: ospi
 properties:
   reg:
     required: true
+    description: Flash Memory base address and size in bytes
   ospi-max-frequency:
     type: int
     required: true
     description: Maximum clock frequency of device's OSPI interface in Hz
-  size:
-    required: true
-    description: Flash Memory size in bits
   reset-gpios:
     type: phandle-array
     description: RESETn pin

--- a/dts/bindings/flash_controller/st,stm32-qspi-nor.yaml
+++ b/dts/bindings/flash_controller/st,stm32-qspi-nor.yaml
@@ -6,11 +6,10 @@ description: |
 
     Representation of a serial flash on a quadspi bus:
 
-        mx25r6435f: qspi-nor-flash@0 {
+        mx25r6435f: qspi-nor-flash@90000000 {
                 compatible = "st,stm32-qspi-nor";
-                reg = <0>;
+                reg = <0x90000000 DT_SIZE_M(8)>; /* 64 Mbits */
                 qspi-max-frequency = <80000000>;
-                size = <0x4000000>;
                 reset-gpios = <&gpiod 3 GPIO_ACTIVE_LOW>;
                 reset-gpios-duration = <1>;
                 spi-bus-width = <4>;
@@ -26,13 +25,11 @@ on-bus: qspi
 properties:
   reg:
     required: true
+    description: Flash Memory base address and size in bytes
   qspi-max-frequency:
     type: int
     required: true
     description: Maximum clock frequency of device's QSPI interface in Hz
-  size:
-    required: true
-    description: Flash Memory size in bits
   reset-gpios:
     type: phandle-array
     description: RESETn pin

--- a/samples/subsys/fs/littlefs/boards/nucleo_h743zi.overlay
+++ b/samples/subsys/fs/littlefs/boards/nucleo_h743zi.overlay
@@ -23,11 +23,10 @@
 	flash-id = <2>;
 	status = "okay";
 
-	mx25l25645g: qspi-nor-flash@0 {
+	mx25l25645g: qspi-nor-flash@90000000 {
 		compatible = "st,stm32-qspi-nor";
-		reg = <0>;
+		reg = <0x90000000 DT_SIZE_M(32)>; /* 256 Mbits */
 		qspi-max-frequency = <50000000>;
-		size = <DT_SIZE_M(32*8)>;
 		reset-gpios = <&gpiod 3 GPIO_ACTIVE_LOW>;
 		reset-gpios-duration = <1>;
 		spi-bus-width = <4>;


### PR DESCRIPTION
the stm32  qspi and ospi flash drivers can retrieve the NOR flash address and size directly from the device tree 
of their `compatible = "st,stm32-qspi-nor";`  or `compatible = "st,stm32-ospi-nor";`
This is done with the <reg> property of the qspi-nor-flash or ospi-nor-flash node as follows:

```
 mx25lm51245: ospi-nor-flash@70000000 {
                 compatible = "st,stm32-ospi-nor";
                reg = <0x70000000 DT_SIZE_M(64)>; /* 512 Mbits */
```

That will make the nor-flash controller driver using the address and size property and will prepare the flash controller for the memory mapped mode (XIP).
That will avoid confusion around the <size> expressed in bits or in byte : here is the reg second param a size in Bytes.