### PR TITLE
bluetooth: gatt: remove operation infix from authorization callback API

### DIFF
--- a/include/zephyr/bluetooth/gatt.h
+++ b/include/zephyr/bluetooth/gatt.h
@@ -248,8 +248,8 @@ struct bt_gatt_authorization_cb {
 	 *  @retval true  Authorize the operation and allow it to execute.
 	 *  @retval false Reject the operation and prevent it from executing.
 	 */
-	bool (*read_operation_authorize)(struct bt_conn *conn,
-					 const struct bt_gatt_attr *attr);
+	bool (*read_authorize)(struct bt_conn *conn,
+			       const struct bt_gatt_attr *attr);
 
 	/** @brief Authorize the GATT write operation.
 	 *
@@ -262,8 +262,8 @@ struct bt_gatt_authorization_cb {
 	 *  @retval true  Authorize the operation and allow it to execute.
 	 *  @retval false Reject the operation and prevent it from executing.
 	 */
-	bool (*write_operation_authorize)(struct bt_conn *conn,
-					  const struct bt_gatt_attr *attr);
+	bool (*write_authorize)(struct bt_conn *conn,
+				const struct bt_gatt_attr *attr);
 };
 
 /** Characteristic Properties Bit field values */

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -1278,11 +1278,11 @@ static bool attr_read_authorize(struct bt_conn *conn,
 		return true;
 	}
 
-	if (!authorization_cb || !authorization_cb->read_operation_authorize) {
+	if (!authorization_cb || !authorization_cb->read_authorize) {
 		return true;
 	}
 
-	return authorization_cb->read_operation_authorize(conn, attr);
+	return authorization_cb->read_authorize(conn, attr);
 }
 
 static bool attr_read_type_cb(struct net_buf *frag, ssize_t read,
@@ -1956,11 +1956,11 @@ static bool attr_write_authorize(struct bt_conn *conn,
 		return true;
 	}
 
-	if (!authorization_cb || !authorization_cb->write_operation_authorize) {
+	if (!authorization_cb || !authorization_cb->write_authorize) {
 		return true;
 	}
 
-	return authorization_cb->write_operation_authorize(conn, attr);
+	return authorization_cb->write_authorize(conn, attr);
 }
 
 static uint8_t write_cb(const struct bt_gatt_attr *attr, uint16_t handle,

--- a/tests/bsim/bluetooth/host/gatt/authorization/src/gatt_server_test.c
+++ b/tests/bsim/bluetooth/host/gatt/authorization/src/gatt_server_test.c
@@ -287,8 +287,7 @@ BT_GATT_SERVICE_DEFINE(test_svc,
 			       NULL, write_cp_chrc, NULL),
 );
 
-static bool gatt_read_operation_authorize(struct bt_conn *conn,
-					  const struct bt_gatt_attr *attr)
+static bool gatt_read_authorize(struct bt_conn *conn, const struct bt_gatt_attr *attr)
 {
 	if (bt_uuid_cmp(attr->uuid, TEST_UNAUTHORIZED_CHRC_UUID) == 0) {
 		unauthorized_chrc_ctx.auth_read_cnt++;
@@ -301,8 +300,7 @@ static bool gatt_read_operation_authorize(struct bt_conn *conn,
 	}
 }
 
-static bool gatt_write_operation_authorize(struct bt_conn *conn,
-					   const struct bt_gatt_attr *attr)
+static bool gatt_write_authorize(struct bt_conn *conn, const struct bt_gatt_attr *attr)
 {
 	if (bt_uuid_cmp(attr->uuid, TEST_UNAUTHORIZED_CHRC_UUID) == 0) {
 		unauthorized_chrc_ctx.auth_write_cnt++;
@@ -316,8 +314,8 @@ static bool gatt_write_operation_authorize(struct bt_conn *conn,
 }
 
 static const struct bt_gatt_authorization_cb gatt_authorization_callbacks = {
-	.read_operation_authorize = gatt_read_operation_authorize,
-	.write_operation_authorize = gatt_write_operation_authorize,
+	.read_authorize = gatt_read_authorize,
+	.write_authorize = gatt_write_authorize,
 };
 
 static void test_main(void)


### PR DESCRIPTION
Related to: https://github.com/zephyrproject-rtos/zephyr/pull/67615

This PR attempts to address the following suggestion:

https://github.com/zephyrproject-rtos/zephyr/pull/67615#discussion_r1459250604