### PR TITLE
usb: host: use uint16_t for Language ID

### DIFF
--- a/subsys/usb/host/usbh_ch9.c
+++ b/subsys/usb/host/usbh_ch9.c
@@ -85,7 +85,7 @@ buf_alloc_err:
 
 int usbh_req_desc(struct usb_device *const udev,
 		  const uint8_t type, const uint8_t index,
-		  const uint8_t id,
+		  const uint16_t id,
 		  const uint16_t len,
 		  struct net_buf *const buf)
 {

--- a/subsys/usb/host/usbh_ch9.h
+++ b/subsys/usb/host/usbh_ch9.h
@@ -22,7 +22,7 @@ int usbh_req_setup(struct usb_device *const udev,
 
 int usbh_req_desc(struct usb_device *const udev,
 		  const uint8_t type, const uint8_t index,
-		  const uint8_t id,
+		  const uint16_t id,
 		  const uint16_t len,
 		  struct net_buf *const data);
 


### PR DESCRIPTION
usbh_req_desc() truncates the descriptor id. This problem is most visible with string descriptor requests, as only then can wIndex be greater than 0xFF. In particular, this affects commonly used language IDs such as English (United States), which is 0x0409.

Picked from stale #65254 and fixed the commit message.
@akaiserUS FYI

Fixes #65252