### PR TITLE
drivers: sensor: lsm6dl fixing -Wdouble-promotion warning

### DIFF
--- a/drivers/sensor/lsm6dsl/lsm6dsl.c
+++ b/drivers/sensor/lsm6dsl/lsm6dsl.c
@@ -211,7 +211,7 @@ static int lsm6dsl_accel_range_set(const struct device *dev, int32_t range)
 		return -EIO;
 	}
 
-	data->accel_sensitivity = (float)(lsm6dsl_accel_fs_sens[fs]
+	data->accel_sensitivity = (double)(lsm6dsl_accel_fs_sens[fs]
 						    * SENSI_GRAIN_XL);
 	return 0;
 }
@@ -274,7 +274,7 @@ static int lsm6dsl_gyro_range_set(const struct device *dev, int32_t range)
 		return -EIO;
 	}
 
-	data->gyro_sensitivity = (float)(lsm6dsl_gyro_fs_sens[fs]
+	data->gyro_sensitivity = (double)(lsm6dsl_gyro_fs_sens[fs]
 						    * SENSI_GRAIN_G);
 	return 0;
 }

--- a/drivers/sensor/lsm6dsl/lsm6dsl.h
+++ b/drivers/sensor/lsm6dsl/lsm6dsl.h
@@ -647,11 +647,11 @@ struct lsm6dsl_data {
 	int accel_sample_x;
 	int accel_sample_y;
 	int accel_sample_z;
-	float accel_sensitivity;
+	double accel_sensitivity;
 	int gyro_sample_x;
 	int gyro_sample_y;
 	int gyro_sample_z;
-	float gyro_sensitivity;
+	double gyro_sensitivity;
 #if defined(CONFIG_LSM6DSL_ENABLE_TEMP)
 	int temp_sample;
 #endif
@@ -659,7 +659,7 @@ struct lsm6dsl_data {
 	int magn_sample_x;
 	int magn_sample_y;
 	int magn_sample_z;
-	float magn_sensitivity;
+	double magn_sensitivity;
 #endif
 #if defined(CONFIG_LSM6DSL_EXT0_LPS22HB)
 	int sample_press;


### PR DESCRIPTION
Fixing this "revealed" bug which got introduced when a PR added the -Wdouble-promotion flag to GCC builds
Based on the recent PR https://github.com/zephyrproject-rtos/zephyr/pull/68237

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/68284
