### PR TITLE
Bluetooth: Audio: MCC optional procedures actually optional

### DIFF
--- a/include/zephyr/bluetooth/audio/mcc.h
+++ b/include/zephyr/bluetooth/audio/mcc.h
@@ -54,7 +54,6 @@ typedef void (*bt_mcc_discover_mcs_cb)(struct bt_conn *conn, int err);
  */
 typedef void (*bt_mcc_read_player_name_cb)(struct bt_conn *conn, int err, const char *name);
 
-#ifdef CONFIG_BT_OTS_CLIENT
 /**
  * @brief Callback function for bt_mcc_read_icon_obj_id()
  *
@@ -64,8 +63,7 @@ typedef void (*bt_mcc_read_player_name_cb)(struct bt_conn *conn, int err, const 
  * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param icon_id       The ID of the Icon Object. This is a UINT48 in a uint64_t
  */
-typedef void (*bt_mcc_read_icon_obj_id_cb)(struct bt_conn *conn, int err, uint64_t id);
-#endif /* CONFIG_BT_OTS_CLIENT */
+typedef void (*bt_mcc_read_icon_obj_id_cb)(struct bt_conn *conn, int err, uint64_t icon_id);
 
 /**
  * @brief Callback function for bt_mcc_read_icon_url()
@@ -169,7 +167,6 @@ typedef void (*bt_mcc_set_playback_speed_cb)(struct bt_conn *conn, int err, int8
  */
 typedef void (*bt_mcc_read_seeking_speed_cb)(struct bt_conn *conn, int err, int8_t speed);
 
-#ifdef CONFIG_BT_OTS_CLIENT
 /**
  * @brief Callback function for bt_mcc_read_segments_obj_id()
  *
@@ -254,11 +251,9 @@ typedef void (*bt_mcc_read_current_group_obj_id_cb)(struct bt_conn *conn, int er
  *
  * @param conn          The connection that was used to initialise the media control client
  * @param err           Error value. 0 on success, GATT error or errno on fail
- * @param id            The Object ID (UINT48) set (or attempted to set)
+ * @param obj_id        The Object ID (UINT48) set (or attempted to set)
  */
 typedef void (*bt_mcc_set_current_group_obj_id_cb)(struct bt_conn *conn, int err, uint64_t obj_id);
-
-#endif /* CONFIG_BT_OTS_CLIENT */
 
 /**
  * @brief Callback function for bt_mcc_read_playing_order()
@@ -343,7 +338,6 @@ typedef void (*bt_mcc_cmd_ntf_cb)(struct bt_conn *conn, int err, const struct mp
 typedef void (*bt_mcc_read_opcodes_supported_cb)(struct bt_conn *conn, int err,
 						 uint32_t opcodes);
 
-#ifdef CONFIG_BT_OTS_CLIENT
 /**
  * @brief Callback function for bt_mcc_send_search()
  *
@@ -367,7 +361,7 @@ typedef void (*bt_mcc_send_search_cb)(struct bt_conn *conn, int err,
  *
  * @param conn          The connection that was used to initialise the media control client
  * @param err           Error value. 0 on success, GATT error or errno on fail
- * @param ntf           The search notification
+ * @param result_code   The search notification
  */
 typedef void (*bt_mcc_search_ntf_cb)(struct bt_conn *conn, int err,
 				     uint8_t result_code);
@@ -387,7 +381,6 @@ typedef void (*bt_mcc_search_ntf_cb)(struct bt_conn *conn, int err,
  */
 typedef void (*bt_mcc_read_search_results_obj_id_cb)(struct bt_conn *conn,
 						     int err, uint64_t id);
-#endif /* CONFIG_BT_OTS_CLIENT */
 
 /**
  * @brief Callback function for bt_mcc_read_content_control_id()
@@ -400,7 +393,7 @@ typedef void (*bt_mcc_read_search_results_obj_id_cb)(struct bt_conn *conn,
  */
 typedef void (*bt_mcc_read_content_control_id_cb)(struct bt_conn *conn,
 						  int err, uint8_t ccid);
-#ifdef CONFIG_BT_OTS_CLIENT
+
 /**** Callback functions for the included Object Transfer service *************/
 
 /**
@@ -507,8 +500,6 @@ typedef void (*bt_mcc_otc_read_parent_group_object_cb)(struct bt_conn *conn, int
 typedef void (*bt_mcc_otc_read_current_group_object_cb)(struct bt_conn *conn, int err,
 							struct net_buf_simple *buf);
 
-#endif /* CONFIG_BT_OTS_CLIENT */
-
 
 /**
  * @brief Media control client callbacks
@@ -519,15 +510,31 @@ struct bt_mcc_cb {
 #ifdef CONFIG_BT_OTS_CLIENT
 	bt_mcc_read_icon_obj_id_cb               read_icon_obj_id;
 #endif /* CONFIG_BT_OTS_CLIENT */
+#if defined(CONFIG_BT_MCC_READ_MEDIA_PLAYER_ICON_URL)
 	bt_mcc_read_icon_url_cb                  read_icon_url;
+#endif /* defined(CONFIG_BT_MCC_READ_MEDIA_PLAYER_ICON_URL) */
 	bt_mcc_track_changed_ntf_cb              track_changed_ntf;
+#if defined(CONFIG_BT_MCC_READ_TRACK_TITLE)
 	bt_mcc_read_track_title_cb               read_track_title;
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_TITLE) */
+#if defined(CONFIG_BT_MCC_READ_TRACK_DURATION)
 	bt_mcc_read_track_duration_cb            read_track_duration;
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_DURATION) */
+#if defined(CONFIG_BT_MCC_READ_TRACK_POSITION)
 	bt_mcc_read_track_position_cb            read_track_position;
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_POSITION) */
+#if defined(CONFIG_BT_MCC_SET_TRACK_POSITION)
 	bt_mcc_set_track_position_cb             set_track_position;
+#endif /* defined(CONFIG_BT_MCC_SET_TRACK_POSITION) */
+#if defined(CONFIG_BT_MCC_READ_PLAYBACK_SPEED)
 	bt_mcc_read_playback_speed_cb            read_playback_speed;
+#endif /* defined (CONFIG_BT_MCC_READ_PLAYBACK_SPEED) */
+#if defined(CONFIG_BT_MCC_SET_PLAYBACK_SPEED)
 	bt_mcc_set_playback_speed_cb             set_playback_speed;
+#endif /* defined (CONFIG_BT_MCC_SET_PLAYBACK_SPEED) */
+#if defined(CONFIG_BT_MCC_READ_SEEKING_SPEED)
 	bt_mcc_read_seeking_speed_cb             read_seeking_speed;
+#endif /* defined (CONFIG_BT_MCC_READ_SEEKING_SPEED) */
 #ifdef CONFIG_BT_OTS_CLIENT
 	bt_mcc_read_segments_obj_id_cb           read_segments_obj_id;
 	bt_mcc_read_current_track_obj_id_cb      read_current_track_obj_id;
@@ -538,19 +545,33 @@ struct bt_mcc_cb {
 	bt_mcc_set_current_group_obj_id_cb       set_current_group_obj_id;
 	bt_mcc_read_parent_group_obj_id_cb       read_parent_group_obj_id;
 #endif /* CONFIG_BT_OTS_CLIENT */
+#if defined(CONFIG_BT_MCC_READ_PLAYING_ORDER)
 	bt_mcc_read_playing_order_cb	         read_playing_order;
+#endif /* defined(CONFIG_BT_MCC_READ_PLAYING_ORDER) */
+#if defined(CONFIG_BT_MCC_SET_PLAYING_ORDER)
 	bt_mcc_set_playing_order_cb              set_playing_order;
+#endif /* defined(CONFIG_BT_MCC_SET_PLAYING_ORDER) */
+#if defined(CONFIG_BT_MCC_READ_PLAYING_ORDER_SUPPORTED)
 	bt_mcc_read_playing_orders_supported_cb  read_playing_orders_supported;
+#endif /* defined(CONFIG_BT_MCC_READ_PLAYING_ORDER_SUPPORTED) */
+#if defined(CONFIG_BT_MCC_READ_MEDIA_STATE)
 	bt_mcc_read_media_state_cb               read_media_state;
+#endif /* defined(CONFIG_BT_MCC_READ_MEDIA_STATE) */
+#if defined(CONFIG_BT_MCC_SET_MEDIA_CONTROL_POINT)
 	bt_mcc_send_cmd_cb                       send_cmd;
+#endif /* defined(CONFIG_BT_MCC_SET_MEDIA_CONTROL_POINT) */
 	bt_mcc_cmd_ntf_cb                        cmd_ntf;
+#if defined(CONFIG_BT_MCC_READ_MEDIA_CONTROL_POINT_OPCODES_SUPPORTED)
 	bt_mcc_read_opcodes_supported_cb         read_opcodes_supported;
+#endif /* defined(CONFIG_BT_MCC_READ_MEDIA_CONTROL_POINT_OPCODES_SUPPORTED) */
 #ifdef CONFIG_BT_OTS_CLIENT
 	bt_mcc_send_search_cb                    send_search;
 	bt_mcc_search_ntf_cb                     search_ntf;
 	bt_mcc_read_search_results_obj_id_cb     read_search_results_obj_id;
 #endif /* CONFIG_BT_OTS_CLIENT */
+#if defined(CONFIG_BT_MCC_READ_CONTENT_CONTROL_ID)
 	bt_mcc_read_content_control_id_cb        read_content_control_id;
+#endif /* defined(CONFIG_BT_MCC_READ_CONTENT_CONTROL_ID) */
 #ifdef CONFIG_BT_OTS_CLIENT
 	bt_mcc_otc_obj_selected_cb               otc_obj_selected;
 	bt_mcc_otc_obj_metadata_cb               otc_obj_metadata;
@@ -600,7 +621,6 @@ int bt_mcc_discover_mcs(struct bt_conn *conn, bool subscribe);
  */
 int bt_mcc_read_player_name(struct bt_conn *conn);
 
-#ifdef CONFIG_BT_OTS_CLIENT
 /**
  * @brief Read Icon Object ID
  *
@@ -609,7 +629,6 @@ int bt_mcc_read_player_name(struct bt_conn *conn);
  * @return 0 if success, errno on failure.
  */
 int bt_mcc_read_icon_obj_id(struct bt_conn *conn);
-#endif /* CONFIG_BT_OTS_CLIENT */
 
 /**
  * @brief Read Icon Object URL
@@ -685,7 +704,6 @@ int bt_mcc_set_playback_speed(struct bt_conn *conn, int8_t speed);
  */
 int bt_mcc_read_seeking_speed(struct bt_conn *conn);
 
-#ifdef CONFIG_BT_OTS_CLIENT
 /**
  * @brief Read Track Segments Object ID
  *
@@ -720,7 +738,6 @@ int bt_mcc_set_current_track_obj_id(struct bt_conn *conn, uint64_t id);
  * @brief Read Next Track Object ID
  *
  * @param conn  Connection to the peer device
- * @param id    Object Transfer Service ID (UINT48) of the track to set as the current track
  *
  * @return 0 if success, errno on failure.
  */
@@ -767,7 +784,6 @@ int bt_mcc_set_current_group_obj_id(struct bt_conn *conn, uint64_t id);
  * @return 0 if success, errno on failure.
  */
 int bt_mcc_read_parent_group_obj_id(struct bt_conn *conn);
-#endif /* CONFIG_BT_OTS_CLIENT */
 
 /**
  * @brief Read Playing Order
@@ -827,7 +843,6 @@ int bt_mcc_send_cmd(struct bt_conn *conn, const struct mpl_cmd *cmd);
  */
 int bt_mcc_read_opcodes_supported(struct bt_conn *conn);
 
-#ifdef CONFIG_BT_OTS_CLIENT
 /**
  * @brief Send a Search command
  *
@@ -848,7 +863,6 @@ int bt_mcc_send_search(struct bt_conn *conn, const struct mpl_search *search);
  * @return 0 if success, errno on failure.
  */
 int bt_mcc_read_search_results_obj_id(struct bt_conn *conn);
-#endif /* CONFIG_BT_OTS_CLIENT */
 
 /**
  * @brief Read Content Control ID
@@ -859,7 +873,6 @@ int bt_mcc_read_search_results_obj_id(struct bt_conn *conn);
  */
 int bt_mcc_read_content_control_id(struct bt_conn *conn);
 
-#ifdef CONFIG_BT_OTS_CLIENT
 /**
  * @brief Read the current object metadata
  *
@@ -923,10 +936,15 @@ int bt_mcc_otc_read_current_group_object(struct bt_conn *conn);
  */
 int bt_mcc_otc_read_parent_group_object(struct bt_conn *conn);
 
-#if defined(CONFIG_BT_MCC_SHELL)
+/**
+ * @brief Look up MCC OTC instance
+ *
+ * @param conn  The connection to the MCC server.
+ *
+ * @return Pointer to a MCC OTC instance if found else NULL.
+ *
+ */
 struct bt_ots_client *bt_mcc_otc_inst(struct bt_conn *conn);
-#endif /* defined(CONFIG_BT_MCC_SHELL) */
-#endif /* CONFIG_BT_OTS_CLIENT */
 
 #ifdef __cplusplus
 }

--- a/subsys/bluetooth/audio/Kconfig.mcs
+++ b/subsys/bluetooth/audio/Kconfig.mcs
@@ -121,4 +121,106 @@ config BT_MCC_SHELL
 	help
 	  This option enables shell support for the Media Control Client.
 
+config BT_MCC_MINIMAL
+	bool "Minimal Media Control Client without optional procedures"
+	help
+	  This option disables all optional procedures in the Media Control Client.
+
+config BT_MCC_READ_MEDIA_PLAYER_ICON_URL
+	bool "Support reading Media Player Icon URL"
+	default !BT_MCC_MINIMAL
+	help
+	  This option enables support for Read Media Information procedure
+	  optionally read the Media Player Icon URL.
+
+config BT_MCC_READ_TRACK_TITLE
+	bool "Support reading Track Title"
+	default !BT_MCC_MINIMAL
+	help
+	  This option enables support for reading Track Title.
+
+config BT_MCC_READ_TRACK_TITLE_ENABLE_SUBSCRIPTION
+	bool "Support to enable or disable the subscription of Track Title"
+	default !BT_MCC_MINIMAL
+	help
+	  This option enables support for the subscription of Track Title.
+
+config BT_MCC_READ_TRACK_DURATION
+	bool "Support reading Track Duration"
+	default !BT_MCC_MINIMAL
+	help
+	  This option enables support for reading Track Duration.
+
+config BT_MCC_READ_TRACK_POSITION
+	bool "Support reading Track Position"
+	default !BT_MCC_MINIMAL
+	help
+	  This option enables support for reading Track Position.
+
+config BT_MCC_SET_TRACK_POSITION
+	bool "Support setting Track Position"
+	default !BT_MCC_MINIMAL
+	help
+	  This option enables support for setting Track Position.
+
+config BT_MCC_READ_PLAYBACK_SPEED
+	bool "Support reading Playback Speed"
+	default !BT_MCC_MINIMAL
+	help
+	  This option enables support for reading Playback Speed.
+
+config BT_MCC_SET_PLAYBACK_SPEED
+	bool "Support setting Playback Speed"
+	default !BT_MCC_MINIMAL
+	help
+	  This option enables support for setting Playback Speed.
+
+config BT_MCC_READ_SEEKING_SPEED
+	bool "Support reading Seeking Speed"
+	default !BT_MCC_MINIMAL
+	help
+	  This option enables support for reading Seeking Speed.
+
+config BT_MCC_READ_PLAYING_ORDER
+	bool "Support reading Playing Order"
+	default !BT_MCC_MINIMAL
+	help
+	  This option enables support for reading Playing Order.
+
+config BT_MCC_SET_PLAYING_ORDER
+	bool "Support setting Playing Order"
+	default !BT_MCC_MINIMAL
+	help
+	  This option enables support for setting Playing Order.
+
+config BT_MCC_READ_PLAYING_ORDER_SUPPORTED
+	bool "Support reading Playing Order Supported"
+	default !BT_MCC_MINIMAL
+	help
+	  This option enables support for reading Playing Order Supported.
+
+config BT_MCC_READ_MEDIA_STATE
+	bool "Support reading Media State"
+	default !BT_MCC_MINIMAL
+	help
+	  This option enables support for reading Media State.
+
+config BT_MCC_SET_MEDIA_CONTROL_POINT
+	bool "Support setting Media Control Point"
+	default !BT_MCC_MINIMAL
+	help
+	  This option enables support for setting Media Control Point.
+
+config BT_MCC_READ_MEDIA_CONTROL_POINT_OPCODES_SUPPORTED
+	bool "Support reading Media Control Point Opcodes Supported"
+	default !BT_MCC_MINIMAL
+	help
+	  This option enables support for reading Media Control Point Opcodes Supported.
+
+config BT_MCC_READ_CONTENT_CONTROL_ID
+	bool "Support reading Content Control ID"
+	default !BT_MCC_MINIMAL
+	help
+	  This option enables support for reading Content Control ID.
+
 endif # BT_MCC

--- a/subsys/bluetooth/audio/mcc.c
+++ b/subsys/bluetooth/audio/mcc.c
@@ -156,6 +156,7 @@ static uint8_t mcc_read_icon_obj_id_cb(struct bt_conn *conn, uint8_t err,
 }
 #endif /* CONFIG_BT_MCC_OTS */
 
+#if defined(CONFIG_BT_MCC_READ_MEDIA_PLAYER_ICON_URL)
 static uint8_t mcc_read_icon_url_cb(struct bt_conn *conn, uint8_t err,
 				    struct bt_gatt_read_params *params,
 				    const void *data, uint16_t length)
@@ -185,7 +186,9 @@ static uint8_t mcc_read_icon_url_cb(struct bt_conn *conn, uint8_t err,
 
 	return BT_GATT_ITER_STOP;
 }
+#endif /* defined(CONFIG_BT_MCC_READ_MEDIA_PLAYER_ICON_URL) */
 
+#if defined(CONFIG_BT_MCC_READ_TRACK_TITLE)
 static void mcc_track_title_cb(struct bt_conn *conn, uint8_t err, const void *data, uint16_t length)
 {
 	int cb_err = err;
@@ -222,7 +225,9 @@ static uint8_t mcc_read_track_title_cb(struct bt_conn *conn, uint8_t err,
 
 	return BT_GATT_ITER_STOP;
 }
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_TITLE)*/
 
+#if defined(CONFIG_BT_MCC_READ_TRACK_DURATION)
 static void mcc_track_duration_cb(struct bt_conn *conn, uint8_t err, const void *data,
 				  uint16_t length)
 {
@@ -256,7 +261,9 @@ static uint8_t mcc_read_track_duration_cb(struct bt_conn *conn, uint8_t err,
 
 	return BT_GATT_ITER_STOP;
 }
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_DURATION) */
 
+#if defined(CONFIG_BT_MCC_READ_TRACK_POSITION)
 static void mcc_track_position_cb(struct bt_conn *conn, uint8_t err, const void *data,
 				  uint16_t length)
 {
@@ -290,7 +297,9 @@ static uint8_t mcc_read_track_position_cb(struct bt_conn *conn, uint8_t err,
 
 	return BT_GATT_ITER_STOP;
 }
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_POSITION) */
 
+#if defined(CONFIG_BT_MCC_SET_TRACK_POSITION)
 static void mcs_write_track_position_cb(struct bt_conn *conn, uint8_t err,
 					struct bt_gatt_write_params *params)
 {
@@ -314,7 +323,9 @@ static void mcs_write_track_position_cb(struct bt_conn *conn, uint8_t err,
 		mcc_cb->set_track_position(conn, cb_err, pos);
 	}
 }
+#endif /* defined(CONFIG_BT_MCC_SET_TRACK_POSITION) */
 
+#if defined(CONFIG_BT_MCC_READ_PLAYBACK_SPEED)
 static void mcc_playback_speed_cb(struct bt_conn *conn, uint8_t err, const void *data,
 				  uint16_t length)
 {
@@ -348,7 +359,9 @@ static uint8_t mcc_read_playback_speed_cb(struct bt_conn *conn, uint8_t err,
 
 	return BT_GATT_ITER_STOP;
 }
+#endif /* defined (CONFIG_BT_MCC_READ_PLAYBACK_SPEED) */
 
+#if defined(CONFIG_BT_MCC_SET_PLAYBACK_SPEED)
 static void mcs_write_playback_speed_cb(struct bt_conn *conn, uint8_t err,
 					struct bt_gatt_write_params *params)
 {
@@ -371,7 +384,9 @@ static void mcs_write_playback_speed_cb(struct bt_conn *conn, uint8_t err,
 		mcc_cb->set_playback_speed(conn, cb_err, speed);
 	}
 }
+#endif /* defined (CONFIG_BT_MCC_SET_PLAYBACK_SPEED) */
 
+#if defined(CONFIG_BT_MCC_READ_SEEKING_SPEED)
 static void mcc_seeking_speed_cb(struct bt_conn *conn, uint8_t err, const void *data,
 				 uint16_t length)
 {
@@ -405,6 +420,7 @@ static uint8_t mcc_read_seeking_speed_cb(struct bt_conn *conn, uint8_t err,
 
 	return BT_GATT_ITER_STOP;
 }
+#endif /* defined (CONFIG_BT_MCC_READ_SEEKING_SPEED) */
 
 #ifdef CONFIG_BT_MCC_OTS
 static uint8_t mcc_read_segments_obj_id_cb(struct bt_conn *conn, uint8_t err,
@@ -679,6 +695,7 @@ static void mcs_write_current_group_obj_id_cb(struct bt_conn *conn, uint8_t err,
 }
 #endif /* CONFIG_BT_MCC_OTS */
 
+#if defined(CONFIG_BT_MCC_READ_PLAYING_ORDER)
 static void mcc_playing_order_cb(struct bt_conn *conn, uint8_t err, const void *data,
 				 uint16_t length)
 {
@@ -712,7 +729,9 @@ static uint8_t mcc_read_playing_order_cb(struct bt_conn *conn, uint8_t err,
 
 	return BT_GATT_ITER_STOP;
 }
+#endif /* defined(CONFIG_BT_MCC_READ_PLAYING_ORDER) */
 
+#if defined(CONFIG_BT_MCC_SET_PLAYING_ORDER)
 static void mcs_write_playing_order_cb(struct bt_conn *conn, uint8_t err,
 				       struct bt_gatt_write_params *params)
 {
@@ -735,7 +754,9 @@ static void mcs_write_playing_order_cb(struct bt_conn *conn, uint8_t err,
 		mcc_cb->set_playing_order(conn, cb_err, order);
 	}
 }
+#endif /* defined(CONFIG_BT_MCC_SET_PLAYING_ORDER) */
 
+#if defined(CONFIG_BT_MCC_READ_PLAYING_ORDER_SUPPORTED)
 static uint8_t mcc_read_playing_orders_supported_cb(struct bt_conn *conn, uint8_t err,
 						    struct bt_gatt_read_params *params,
 						    const void *data, uint16_t length)
@@ -762,7 +783,9 @@ static uint8_t mcc_read_playing_orders_supported_cb(struct bt_conn *conn, uint8_
 
 	return BT_GATT_ITER_STOP;
 }
+#endif /* defined(CONFIG_BT_MCC_READ_PLAYING_ORDER_SUPPORTED) */
 
+#if defined(CONFIG_BT_MCC_READ_MEDIA_STATE)
 static void mcc_media_state_cb(struct bt_conn *conn, uint8_t err, const void *data, uint16_t length)
 {
 	int cb_err = err;
@@ -795,7 +818,9 @@ static uint8_t mcc_read_media_state_cb(struct bt_conn *conn, uint8_t err,
 
 	return BT_GATT_ITER_STOP;
 }
+#endif /* defined(CONFIG_BT_MCC_READ_MEDIA_STATE) */
 
+#if defined(CONFIG_BT_MCC_SET_MEDIA_CONTROL_POINT)
 static void mcs_write_cp_cb(struct bt_conn *conn, uint8_t err,
 			    struct bt_gatt_write_params *params)
 {
@@ -829,7 +854,9 @@ static void mcs_write_cp_cb(struct bt_conn *conn, uint8_t err,
 		mcc_cb->send_cmd(conn, cb_err, &cmd);
 	}
 }
+#endif /* defined(CONFIG_BT_MCC_SET_MEDIA_CONTROL_POINT) */
 
+#if defined(CONFIG_BT_MCC_READ_MEDIA_CONTROL_POINT_OPCODES_SUPPORTED)
 static void mcc_opcodes_supported_cb(struct bt_conn *conn, uint8_t err, const void *data,
 				     uint16_t length)
 {
@@ -864,6 +891,7 @@ static uint8_t mcc_read_opcodes_supported_cb(struct bt_conn *conn, uint8_t err,
 
 	return BT_GATT_ITER_STOP;
 }
+#endif /* defined(CONFIG_BT_MCC_READ_MEDIA_CONTROL_POINT_OPCODES_SUPPORTED) */
 
 #ifdef CONFIG_BT_MCC_OTS
 static void mcs_write_scp_cb(struct bt_conn *conn, uint8_t err,
@@ -935,6 +963,7 @@ static uint8_t mcc_read_search_results_obj_id_cb(struct bt_conn *conn, uint8_t e
 }
 #endif /* CONFIG_BT_MCC_OTS */
 
+#if defined(CONFIG_BT_MCC_READ_CONTENT_CONTROL_ID)
 static uint8_t mcc_read_content_control_id_cb(struct bt_conn *conn, uint8_t err,
 					      struct bt_gatt_read_params *params,
 					      const void *data, uint16_t length)
@@ -962,6 +991,7 @@ static uint8_t mcc_read_content_control_id_cb(struct bt_conn *conn, uint8_t err,
 
 	return BT_GATT_ITER_STOP;
 }
+#endif /* defined(CONFIG_BT_MCC_READ_CONTENT_CONTROL_ID) */
 
 static uint8_t mcs_notify_handler(struct bt_conn *conn,
 				  struct bt_gatt_subscribe_params *params,
@@ -1007,25 +1037,35 @@ static uint8_t mcs_notify_handler(struct bt_conn *conn,
 			mcc_cb->track_changed_ntf(conn, cb_err);
 		}
 
+#if defined(CONFIG_BT_MCC_READ_TRACK_TITLE_ENABLE_SUBSCRIPTION)
 	} else if (handle == mcs_inst->track_title_handle) {
 		LOG_DBG("Track Title notification");
 		mcc_track_title_cb(conn, 0, data, length);
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_TITLE_ENABLE_SUBSCRIPTION) */
 
+#if defined(CONFIG_BT_MCC_READ_TRACK_DURATION)
 	} else if (handle == mcs_inst->track_duration_handle) {
 		LOG_DBG("Track Duration notification");
 		mcc_track_duration_cb(conn, 0, data, length);
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_DURATION) */
 
+#if defined(CONFIG_BT_MCC_READ_TRACK_POSITION)
 	} else if (handle == mcs_inst->track_position_handle) {
 		LOG_DBG("Track Position notification");
 		mcc_track_position_cb(conn, 0, data, length);
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_POSITION) */
 
+#if defined(CONFIG_BT_MCC_READ_PLAYBACK_SPEED)
 	} else if (handle == mcs_inst->playback_speed_handle) {
 		LOG_DBG("Playback Speed notification");
 		mcc_playback_speed_cb(conn, 0, data, length);
+#endif /* defined (CONFIG_BT_MCC_READ_PLAYBACK_SPEED) */
 
+#if defined(CONFIG_BT_MCC_READ_SEEKING_SPEED)
 	} else if (handle == mcs_inst->seeking_speed_handle) {
 		LOG_DBG("Seeking Speed notification");
 		mcc_seeking_speed_cb(conn, 0, data, length);
+#endif /* defined (CONFIG_BT_MCC_READ_SEEKING_SPEED) */
 
 #ifdef CONFIG_BT_MCC_OTS
 	} else if (handle == mcs_inst->current_track_obj_id_handle) {
@@ -1045,13 +1085,17 @@ static uint8_t mcs_notify_handler(struct bt_conn *conn,
 		mcc_current_group_obj_id_cb(conn, 0, data, length);
 #endif /* CONFIG_BT_MCC_OTS */
 
+#if defined(CONFIG_BT_MCC_READ_PLAYING_ORDER)
 	} else if (handle == mcs_inst->playing_order_handle) {
 		LOG_DBG("Playing Order notification");
 		mcc_playing_order_cb(conn, 0, data, length);
+#endif /* defined(CONFIG_BT_MCC_READ_PLAYING_ORDER) */
 
+#if defined(CONFIG_BT_MCC_READ_MEDIA_STATE)
 	} else if (handle == mcs_inst->media_state_handle) {
 		LOG_DBG("Media State notification");
 		mcc_media_state_cb(conn, 0, data, length);
+#endif /* defined(CONFIG_BT_MCC_READ_MEDIA_STATE) */
 
 	} else if (handle == mcs_inst->cp_handle) {
 		/* The control point is is a special case - only */
@@ -1075,9 +1119,11 @@ static uint8_t mcs_notify_handler(struct bt_conn *conn,
 			mcc_cb->cmd_ntf(conn, cb_err, &ntf);
 		}
 
+#if defined(CONFIG_BT_MCC_READ_MEDIA_CONTROL_POINT_OPCODES_SUPPORTED)
 	} else if (handle == mcs_inst->opcodes_supported_handle) {
 		LOG_DBG("Opcodes Supported notification");
 		mcc_opcodes_supported_cb(conn, 0, data, length);
+#endif /* defined(CONFIG_BT_MCC_READ_MEDIA_CONTROL_POINT_OPCODES_SUPPORTED) */
 
 #ifdef CONFIG_BT_MCC_OTS
 	} else if (handle == mcs_inst->scp_handle) {
@@ -1122,21 +1168,37 @@ static void reset_mcs_inst(struct mcs_instance_t *mcs_inst, struct bt_conn *conn
 	 */
 	(void)bt_gatt_unsubscribe(conn, &mcs_inst->player_name_sub_params);
 	(void)bt_gatt_unsubscribe(conn, &mcs_inst->track_changed_sub_params);
+#if defined(CONFIG_BT_MCC_READ_TRACK_TITLE_ENABLE_SUBSCRIPTION)
 	(void)bt_gatt_unsubscribe(conn, &mcs_inst->track_title_sub_params);
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_TITLE_ENABLE_SUBSCRIPTION) */
+#if defined(CONFIG_BT_MCC_READ_TRACK_DURATION)
 	(void)bt_gatt_unsubscribe(conn, &mcs_inst->track_duration_sub_params);
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_DURATION) */
+#if defined(CONFIG_BT_MCC_READ_TRACK_POSITION)
 	(void)bt_gatt_unsubscribe(conn, &mcs_inst->track_position_sub_params);
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_POSITION) */
+#if defined(CONFIG_BT_MCC_READ_PLAYBACK_SPEED)
 	(void)bt_gatt_unsubscribe(conn, &mcs_inst->playback_speed_sub_params);
+#endif /* defined (CONFIG_BT_MCC_READ_PLAYBACK_SPEED) */
+#if defined(CONFIG_BT_MCC_READ_SEEKING_SPEED)
 	(void)bt_gatt_unsubscribe(conn, &mcs_inst->seeking_speed_sub_params);
+#endif /* defined (CONFIG_BT_MCC_READ_SEEKING_SPEED) */
 #ifdef CONFIG_BT_MCC_OTS
 	(void)bt_gatt_unsubscribe(conn, &mcs_inst->current_track_obj_sub_params);
 	(void)bt_gatt_unsubscribe(conn, &mcs_inst->next_track_obj_sub_params);
 	(void)bt_gatt_unsubscribe(conn, &mcs_inst->parent_group_obj_sub_params);
 	(void)bt_gatt_unsubscribe(conn, &mcs_inst->current_group_obj_sub_params);
 #endif /* CONFIG_BT_MCC_OTS */
+#if defined(CONFIG_BT_MCC_READ_PLAYING_ORDER)
 	(void)bt_gatt_unsubscribe(conn, &mcs_inst->playing_order_sub_params);
+#endif /* defined(CONFIG_BT_MCC_READ_PLAYING_ORDER) */
+#if defined(CONFIG_BT_MCC_READ_MEDIA_STATE)
 	(void)bt_gatt_unsubscribe(conn, &mcs_inst->media_state_sub_params);
+#endif /* defined(CONFIG_BT_MCC_READ_MEDIA_STATE) */
 	(void)bt_gatt_unsubscribe(conn, &mcs_inst->cp_sub_params);
+#if defined(CONFIG_BT_MCC_READ_MEDIA_CONTROL_POINT_OPCODES_SUPPORTED)
 	(void)bt_gatt_unsubscribe(conn, &mcs_inst->opcodes_supported_sub_params);
+#endif /* defined(CONFIG_BT_MCC_READ_MEDIA_CONTROL_POINT_OPCODES_SUPPORTED) */
 #ifdef CONFIG_BT_MCC_OTS
 	(void)bt_gatt_unsubscribe(conn, &mcs_inst->scp_sub_params);
 	(void)bt_gatt_unsubscribe(conn, &mcs_inst->search_results_obj_sub_params);
@@ -1428,31 +1490,41 @@ static bool subscribe_next_mcs_char(struct mcs_instance_t *mcs_inst,
 		   mcs_inst->track_changed_sub_params.disc_params == NULL) {
 		sub_params = &mcs_inst->track_changed_sub_params;
 		handle = mcs_inst->track_changed_handle;
+#if defined(CONFIG_BT_MCC_READ_TRACK_TITLE_ENABLE_SUBSCRIPTION)
 	} else if (mcs_inst->track_title_handle &&
 		   mcs_inst->track_title_sub_params.value &&
 		   mcs_inst->track_title_sub_params.disc_params == NULL) {
 		sub_params = &mcs_inst->track_title_sub_params;
 		handle = mcs_inst->track_title_handle;
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_TITLE_ENABLE_SUBSCRIPTION) */
+#if defined(CONFIG_BT_MCC_READ_TRACK_DURATION)
 	} else if (mcs_inst->track_duration_handle &&
 		   mcs_inst->track_duration_sub_params.value &&
 		   mcs_inst->track_duration_sub_params.disc_params == NULL) {
 		sub_params = &mcs_inst->track_duration_sub_params;
 		handle = mcs_inst->track_duration_handle;
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_DURATION) */
+#if defined(CONFIG_BT_MCC_READ_TRACK_POSITION)
 	} else if (mcs_inst->track_position_handle &&
 		   mcs_inst->track_position_sub_params.value &&
 		   mcs_inst->track_position_sub_params.disc_params == NULL) {
 		sub_params = &mcs_inst->track_position_sub_params;
 		handle = mcs_inst->track_position_handle;
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_POSITION) */
+#if defined(CONFIG_BT_MCC_READ_PLAYBACK_SPEED)
 	} else if (mcs_inst->playback_speed_handle &&
 		   mcs_inst->playback_speed_sub_params.value &&
 		   mcs_inst->playback_speed_sub_params.disc_params == NULL) {
 		sub_params = &mcs_inst->playback_speed_sub_params;
 		handle = mcs_inst->playback_speed_handle;
+#endif /* defined (CONFIG_BT_MCC_READ_PLAYBACK_SPEED) */
+#if defined(CONFIG_BT_MCC_READ_SEEKING_SPEED)
 	} else if (mcs_inst->seeking_speed_handle &&
 		   mcs_inst->seeking_speed_sub_params.value &&
 		   mcs_inst->seeking_speed_sub_params.disc_params == NULL) {
 		sub_params = &mcs_inst->seeking_speed_sub_params;
 		handle = mcs_inst->seeking_speed_handle;
+#endif /* defined (CONFIG_BT_MCC_READ_SEEKING_SPEED) */
 #ifdef CONFIG_BT_MCC_OTS
 	} else if (mcs_inst->current_track_obj_id_handle &&
 		   mcs_inst->current_track_obj_sub_params.value &&
@@ -1475,26 +1547,32 @@ static bool subscribe_next_mcs_char(struct mcs_instance_t *mcs_inst,
 		sub_params = &mcs_inst->current_group_obj_sub_params;
 		handle = mcs_inst->current_group_obj_id_handle;
 #endif /* CONFIG_BT_MCC_OTS */
+#if defined(CONFIG_BT_MCC_READ_PLAYING_ORDER)
 	} else if (mcs_inst->playing_order_handle &&
 		   mcs_inst->playing_order_sub_params.value &&
 		   mcs_inst->playing_order_sub_params.disc_params == NULL) {
 		sub_params = &mcs_inst->playing_order_sub_params;
 		handle = mcs_inst->playing_order_handle;
+#endif /* defined(CONFIG_BT_MCC_READ_PLAYING_ORDER) */
+#if defined(CONFIG_BT_MCC_READ_MEDIA_STATE)
 	} else if (mcs_inst->media_state_handle &&
 		  mcs_inst->media_state_sub_params.value &&
 		  mcs_inst->media_state_sub_params.disc_params == NULL) {
 		sub_params = &mcs_inst->media_state_sub_params;
 		handle = mcs_inst->media_state_handle;
+#endif /* defined(CONFIG_BT_MCC_READ_MEDIA_STATE) */
 	} else if (mcs_inst->cp_handle &&
 		   mcs_inst->cp_sub_params.value &&
 		   mcs_inst->cp_sub_params.disc_params == NULL) {
 		sub_params = &mcs_inst->cp_sub_params;
 		handle = mcs_inst->cp_handle;
+#if defined(CONFIG_BT_MCC_READ_MEDIA_CONTROL_POINT_OPCODES_SUPPORTED)
 	} else if (mcs_inst->opcodes_supported_handle &&
 		   mcs_inst->opcodes_supported_sub_params.value &&
 		   mcs_inst->opcodes_supported_sub_params.disc_params == NULL) {
 		sub_params = &mcs_inst->opcodes_supported_sub_params;
 		handle = mcs_inst->opcodes_supported_handle;
+#endif /* defined(CONFIG_BT_MCC_READ_MEDIA_CONTROL_POINT_OPCODES_SUPPORTED) */
 #ifdef CONFIG_BT_MCC_OTS
 	} else if (mcs_inst->scp_handle &&
 		   mcs_inst->scp_sub_params.value &&
@@ -1567,9 +1645,11 @@ static uint8_t discover_mcs_char_func(struct bt_conn *conn,
 			LOG_DBG("Icon Object, UUID: %s", bt_uuid_str(chrc->uuid));
 			mcs_inst->icon_obj_id_handle = chrc->value_handle;
 #endif /* CONFIG_BT_MCC_OTS */
+#if defined(CONFIG_BT_MCC_READ_MEDIA_PLAYER_ICON_URL)
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_ICON_URL)) {
 			LOG_DBG("Icon URL, UUID: %s", bt_uuid_str(chrc->uuid));
 			mcs_inst->icon_url_handle = chrc->value_handle;
+#endif /* defined(CONFIG_BT_MCC_READ_MEDIA_PLAYER_ICON_URL) */
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_TRACK_CHANGED)) {
 			LOG_DBG("Track Changed, UUID: %s", bt_uuid_str(chrc->uuid));
 			mcs_inst->track_changed_handle = chrc->value_handle;
@@ -1577,13 +1657,18 @@ static uint8_t discover_mcs_char_func(struct bt_conn *conn,
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
 				mcs_inst->track_changed_sub_params.value = BT_GATT_CCC_NOTIFY;
 			}
+#if defined(CONFIG_BT_MCC_READ_TRACK_TITLE)
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_TRACK_TITLE)) {
 			LOG_DBG("Track Title, UUID: %s", bt_uuid_str(chrc->uuid));
 			mcs_inst->track_title_handle = chrc->value_handle;
+#if defined(BT_MCC_READ_TRACK_TITLE_ENABLE_SUBSCRIPTION)
 			mcs_inst->track_title_sub_params.disc_params = NULL;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
 				mcs_inst->track_title_sub_params.value = BT_GATT_CCC_NOTIFY;
 			}
+#endif /* defined(BT_MCC_READ_TRACK_TITLE_ENABLE_SUBSCRIPTION) */
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_TITLE) */
+#if defined(CONFIG_BT_MCC_READ_TRACK_DURATION)
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_TRACK_DURATION)) {
 			LOG_DBG("Track Duration, UUID: %s", bt_uuid_str(chrc->uuid));
 			mcs_inst->track_duration_handle = chrc->value_handle;
@@ -1591,20 +1676,32 @@ static uint8_t discover_mcs_char_func(struct bt_conn *conn,
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
 				mcs_inst->track_duration_sub_params.value = BT_GATT_CCC_NOTIFY;
 			}
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_DURATION) */
+#if defined(CONFIG_BT_MCC_READ_TRACK_POSITION) || defined(CONFIG_BT_MCC_SET_TRACK_POSITION)
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_TRACK_POSITION)) {
 			LOG_DBG("Track Position, UUID: %s", bt_uuid_str(chrc->uuid));
 			mcs_inst->track_position_handle = chrc->value_handle;
+#if defined(CONFIG_BT_MCC_READ_TRACK_POSITION)
 			mcs_inst->track_position_sub_params.disc_params = NULL;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
 				mcs_inst->track_position_sub_params.value = BT_GATT_CCC_NOTIFY;
 			}
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_POSITION) */
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_POSITION) || defined(CONFIG_BT_MCC_SET_TRACK_POSITION) */
+#if defined(CONFIG_BT_MCC_READ_PLAYBACK_SPEED) || defined(CONFIG_BT_MCC_SET_PLAYBACK_SPEED)
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_PLAYBACK_SPEED)) {
 			LOG_DBG("Playback Speed, UUID: %s", bt_uuid_str(chrc->uuid));
 			mcs_inst->playback_speed_handle = chrc->value_handle;
+#if defined(CONFIG_BT_MCC_READ_PLAYBACK_SPEED)
 			mcs_inst->playback_speed_sub_params.disc_params = NULL;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
 				mcs_inst->playback_speed_sub_params.value = BT_GATT_CCC_NOTIFY;
 			}
+#endif /* defined (CONFIG_BT_MCC_READ_PLAYBACK_SPEED) */
+#endif /* defined (CONFIG_BT_MCC_READ_PLAYBACK_SPEED) ||
+	* defined (CONFIG_BT_MCC_SET_PLAYBACK_SPEED)
+	*/
+#if defined(CONFIG_BT_MCC_READ_SEEKING_SPEED)
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_SEEKING_SPEED)) {
 			LOG_DBG("Seeking Speed, UUID: %s", bt_uuid_str(chrc->uuid));
 			mcs_inst->seeking_speed_handle = chrc->value_handle;
@@ -1612,6 +1709,7 @@ static uint8_t discover_mcs_char_func(struct bt_conn *conn,
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
 				mcs_inst->seeking_speed_sub_params.value = BT_GATT_CCC_NOTIFY;
 			}
+#endif /* defined (CONFIG_BT_MCC_READ_SEEKING_SPEED) */
 #ifdef CONFIG_BT_MCC_OTS
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_TRACK_SEGMENTS_OBJ_ID)) {
 			LOG_DBG("Track Segments Object, UUID: %s", bt_uuid_str(chrc->uuid));
@@ -1648,16 +1746,23 @@ static uint8_t discover_mcs_char_func(struct bt_conn *conn,
 					BT_GATT_CCC_NOTIFY;
 			}
 #endif /* CONFIG_BT_MCC_OTS */
+#if defined(CONFIG_BT_MCC_READ_PLAYING_ORDER) || defined(CONFIG_BT_MCC_SET_PLAYING_ORDER)
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_PLAYING_ORDER)) {
 			LOG_DBG("Playing Order, UUID: %s", bt_uuid_str(chrc->uuid));
 			mcs_inst->playing_order_handle = chrc->value_handle;
+#if defined(CONFIG_BT_MCC_READ_PLAYING_ORDER)
 			mcs_inst->playing_order_sub_params.disc_params = NULL;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
 				mcs_inst->playing_order_sub_params.value = BT_GATT_CCC_NOTIFY;
 			}
+#endif /* defined(CONFIG_BT_MCC_READ_PLAYING_ORDER) */
+#endif /* defined(CONFIG_BT_MCC_READ_PLAYING_ORDER) || defined(CONFIG_BT_MCC_SET_PLAYING_ORDER) */
+#if defined(CONFIG_BT_MCC_READ_PLAYING_ORDER_SUPPORTED)
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_PLAYING_ORDERS)) {
 			LOG_DBG("Playing Orders supported, UUID: %s", bt_uuid_str(chrc->uuid));
 			mcs_inst->playing_orders_supported_handle = chrc->value_handle;
+#endif /* defined(CONFIG_BT_MCC_READ_PLAYING_ORDER_SUPPORTED) */
+#if defined(CONFIG_BT_MCC_READ_MEDIA_STATE)
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_MEDIA_STATE)) {
 			LOG_DBG("Media State, UUID: %s", bt_uuid_str(chrc->uuid));
 			mcs_inst->media_state_handle = chrc->value_handle;
@@ -1665,6 +1770,7 @@ static uint8_t discover_mcs_char_func(struct bt_conn *conn,
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
 				mcs_inst->media_state_sub_params.value = BT_GATT_CCC_NOTIFY;
 			}
+#endif /* defined(CONFIG_BT_MCC_READ_MEDIA_STATE) */
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_MEDIA_CONTROL_POINT)) {
 			LOG_DBG("Media Control Point, UUID: %s", bt_uuid_str(chrc->uuid));
 			mcs_inst->cp_handle = chrc->value_handle;
@@ -1672,6 +1778,7 @@ static uint8_t discover_mcs_char_func(struct bt_conn *conn,
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
 				mcs_inst->cp_sub_params.value = BT_GATT_CCC_NOTIFY;
 			}
+#if defined(CONFIG_BT_MCC_READ_MEDIA_CONTROL_POINT_OPCODES_SUPPORTED)
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_MEDIA_CONTROL_OPCODES)) {
 			LOG_DBG("Media control opcodes supported, UUID: %s",
 			       bt_uuid_str(chrc->uuid));
@@ -1681,6 +1788,7 @@ static uint8_t discover_mcs_char_func(struct bt_conn *conn,
 				mcs_inst->opcodes_supported_sub_params.value =
 					BT_GATT_CCC_NOTIFY;
 			}
+#endif /* defined(CONFIG_BT_MCC_READ_MEDIA_CONTROL_POINT_OPCODES_SUPPORTED) */
 #ifdef CONFIG_BT_MCC_OTS
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_SEARCH_CONTROL_POINT)) {
 			LOG_DBG("Search control point, UUID: %s", bt_uuid_str(chrc->uuid));
@@ -1698,9 +1806,11 @@ static uint8_t discover_mcs_char_func(struct bt_conn *conn,
 					BT_GATT_CCC_NOTIFY;
 			}
 #endif /* CONFIG_BT_MCC_OTS */
+#if defined(CONFIG_BT_MCC_READ_CONTENT_CONTROL_ID)
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_CCID)) {
 			LOG_DBG("Content Control ID, UUID: %s", bt_uuid_str(chrc->uuid));
 			mcs_inst->content_control_id_handle = chrc->value_handle;
+#endif /* defined(CONFIG_BT_MCC_READ_CONTENT_CONTROL_ID) */
 		}
 
 
@@ -1937,6 +2047,7 @@ int bt_mcc_read_icon_obj_id(struct bt_conn *conn)
 }
 #endif /* CONFIG_BT_MCC_OTS */
 
+#if defined(CONFIG_BT_MCC_READ_MEDIA_PLAYER_ICON_URL)
 int bt_mcc_read_icon_url(struct bt_conn *conn)
 {
 	struct mcs_instance_t *mcs_inst;
@@ -1974,7 +2085,9 @@ int bt_mcc_read_icon_url(struct bt_conn *conn)
 	}
 	return err;
 }
+#endif /* defined(CONFIG_BT_MCC_READ_MEDIA_PLAYER_ICON_URL) */
 
+#if defined(CONFIG_BT_MCC_READ_TRACK_TITLE)
 int bt_mcc_read_track_title(struct bt_conn *conn)
 {
 	struct mcs_instance_t *mcs_inst;
@@ -2012,7 +2125,9 @@ int bt_mcc_read_track_title(struct bt_conn *conn)
 	}
 	return err;
 }
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_TITLE) */
 
+#if defined(CONFIG_BT_MCC_READ_TRACK_DURATION)
 int bt_mcc_read_track_duration(struct bt_conn *conn)
 {
 	struct mcs_instance_t *mcs_inst;
@@ -2050,7 +2165,9 @@ int bt_mcc_read_track_duration(struct bt_conn *conn)
 	}
 	return err;
 }
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_DURATION) */
 
+#if defined(CONFIG_BT_MCC_READ_TRACK_POSITION)
 int bt_mcc_read_track_position(struct bt_conn *conn)
 {
 	struct mcs_instance_t *mcs_inst;
@@ -2088,7 +2205,9 @@ int bt_mcc_read_track_position(struct bt_conn *conn)
 	}
 	return err;
 }
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_POSITION) */
 
+#if defined(CONFIG_BT_MCC_SET_TRACK_POSITION)
 int bt_mcc_set_track_position(struct bt_conn *conn, int32_t pos)
 {
 	struct mcs_instance_t *mcs_inst;
@@ -2131,7 +2250,9 @@ int bt_mcc_set_track_position(struct bt_conn *conn, int32_t pos)
 	}
 	return err;
 }
+#endif /* defined(CONFIG_BT_MCC_SET_TRACK_POSITION) */
 
+#if defined(CONFIG_BT_MCC_READ_PLAYBACK_SPEED)
 int bt_mcc_read_playback_speed(struct bt_conn *conn)
 {
 	struct mcs_instance_t *mcs_inst;
@@ -2169,7 +2290,9 @@ int bt_mcc_read_playback_speed(struct bt_conn *conn)
 	}
 	return err;
 }
+#endif /* defined (CONFIG_BT_MCC_READ_PLAYBACK_SPEED) */
 
+#if defined(CONFIG_BT_MCC_SET_PLAYBACK_SPEED)
 int bt_mcc_set_playback_speed(struct bt_conn *conn, int8_t speed)
 {
 	struct mcs_instance_t *mcs_inst;
@@ -2212,7 +2335,9 @@ int bt_mcc_set_playback_speed(struct bt_conn *conn, int8_t speed)
 	}
 	return err;
 }
+#endif /* defined (CONFIG_BT_MCC_SET_PLAYBACK_SPEED) */
 
+#if defined(CONFIG_BT_MCC_READ_SEEKING_SPEED)
 int bt_mcc_read_seeking_speed(struct bt_conn *conn)
 {
 	struct mcs_instance_t *mcs_inst;
@@ -2250,6 +2375,7 @@ int bt_mcc_read_seeking_speed(struct bt_conn *conn)
 	}
 	return err;
 }
+#endif /* defined (CONFIG_BT_MCC_READ_SEEKING_SPEED) */
 
 #ifdef CONFIG_BT_MCC_OTS
 int bt_mcc_read_segments_obj_id(struct bt_conn *conn)
@@ -2584,6 +2710,7 @@ int bt_mcc_set_current_group_obj_id(struct bt_conn *conn, uint64_t obj_id)
 }
 #endif /* CONFIG_BT_MCC_OTS */
 
+#if defined(CONFIG_BT_MCC_READ_PLAYING_ORDER)
 int bt_mcc_read_playing_order(struct bt_conn *conn)
 {
 	struct mcs_instance_t *mcs_inst;
@@ -2621,7 +2748,9 @@ int bt_mcc_read_playing_order(struct bt_conn *conn)
 	}
 	return err;
 }
+#endif /* defined(CONFIG_BT_MCC_READ_PLAYING_ORDER) */
 
+#if defined(CONFIG_BT_MCC_SET_PLAYING_ORDER)
 int bt_mcc_set_playing_order(struct bt_conn *conn, uint8_t order)
 {
 	struct mcs_instance_t *mcs_inst;
@@ -2672,7 +2801,9 @@ int bt_mcc_set_playing_order(struct bt_conn *conn, uint8_t order)
 	}
 	return err;
 }
+#endif /* defined(CONFIG_BT_MCC_SET_PLAYING_ORDER) */
 
+#if defined(CONFIG_BT_MCC_READ_PLAYING_ORDER_SUPPORTED)
 int bt_mcc_read_playing_orders_supported(struct bt_conn *conn)
 {
 	struct mcs_instance_t *mcs_inst;
@@ -2710,7 +2841,9 @@ int bt_mcc_read_playing_orders_supported(struct bt_conn *conn)
 	}
 	return err;
 }
+#endif /* defined(CONFIG_BT_MCC_READ_PLAYING_ORDER_SUPPORTED) */
 
+#if defined(CONFIG_BT_MCC_READ_MEDIA_STATE)
 int bt_mcc_read_media_state(struct bt_conn *conn)
 {
 	struct mcs_instance_t *mcs_inst;
@@ -2748,7 +2881,9 @@ int bt_mcc_read_media_state(struct bt_conn *conn)
 	}
 	return err;
 }
+#endif /* defined(CONFIG_BT_MCC_READ_MEDIA_STATE) */
 
+#if defined(CONFIG_BT_MCC_SET_MEDIA_CONTROL_POINT)
 int bt_mcc_send_cmd(struct bt_conn *conn, const struct mpl_cmd *cmd)
 {
 	struct mcs_instance_t *mcs_inst;
@@ -2810,7 +2945,9 @@ int bt_mcc_send_cmd(struct bt_conn *conn, const struct mpl_cmd *cmd)
 	}
 	return err;
 }
+#endif /* defined(CONFIG_BT_MCC_SET_MEDIA_CONTROL_POINT) */
 
+#if defined(CONFIG_BT_MCC_READ_MEDIA_CONTROL_POINT_OPCODES_SUPPORTED)
 int bt_mcc_read_opcodes_supported(struct bt_conn *conn)
 {
 	struct mcs_instance_t *mcs_inst;
@@ -2848,6 +2985,7 @@ int bt_mcc_read_opcodes_supported(struct bt_conn *conn)
 	}
 	return err;
 }
+#endif /* defined(CONFIG_BT_MCC_READ_MEDIA_CONTROL_POINT_OPCODES_SUPPORTED) */
 
 #ifdef CONFIG_BT_MCC_OTS
 int bt_mcc_send_search(struct bt_conn *conn, const struct mpl_search *search)
@@ -2944,6 +3082,7 @@ int bt_mcc_read_search_results_obj_id(struct bt_conn *conn)
 }
 #endif /* CONFIG_BT_MCC_OTS */
 
+#if defined(CONFIG_BT_MCC_READ_CONTENT_CONTROL_ID)
 int bt_mcc_read_content_control_id(struct bt_conn *conn)
 {
 	struct mcs_instance_t *mcs_inst;
@@ -2981,6 +3120,7 @@ int bt_mcc_read_content_control_id(struct bt_conn *conn)
 	}
 	return err;
 }
+#endif /* defined(CONFIG_BT_MCC_READ_CONTENT_CONTROL_ID) */
 
 #ifdef CONFIG_BT_MCC_OTS
 

--- a/subsys/bluetooth/audio/mcc_internal.h
+++ b/subsys/bluetooth/audio/mcc_internal.h
@@ -25,13 +25,26 @@ struct mcs_instance_t {
 #ifdef CONFIG_BT_MCC_OTS
 	uint16_t icon_obj_id_handle;
 #endif /* CONFIG_BT_MCC_OTS */
+#if defined(CONFIG_BT_MCC_READ_MEDIA_PLAYER_ICON_URL)
 	uint16_t icon_url_handle;
+#endif /* defined(CONFIG_BT_MCC_READ_MEDIA_PLAYER_ICON_URL) */
 	uint16_t track_changed_handle;
+#if defined(CONFIG_BT_MCC_READ_TRACK_TITLE)
 	uint16_t track_title_handle;
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_TITLE) */
+#if defined(CONFIG_BT_MCC_READ_TRACK_DURATION)
 	uint16_t track_duration_handle;
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_DURATION) */
+#if defined(CONFIG_BT_MCC_READ_TRACK_POSITION) || defined(CONFIG_BT_MCC_SET_TRACK_POSITION)
 	uint16_t track_position_handle;
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_POSITION) || defined(CONFIG_BT_MCC_SET_TRACK_POSITION) */
+#if defined(CONFIG_BT_MCC_READ_PLAYBACK_SPEED) || defined(CONFIG_BT_MCC_SET_PLAYBACK_SPEED)
 	uint16_t playback_speed_handle;
+#endif /* defined (CONFIG_BT_MCC_READ_PLAYBACK_SPEED) || */
+       /* defined (CONFIG_BT_MCC_SET_PLAYBACK_SPEED) */
+#if defined(CONFIG_BT_MCC_READ_SEEKING_SPEED)
 	uint16_t seeking_speed_handle;
+#endif /* defined (CONFIG_BT_MCC_READ_SEEKING_SPEED) */
 #ifdef CONFIG_BT_MCC_OTS
 	uint16_t segments_obj_id_handle;
 	uint16_t current_track_obj_id_handle;
@@ -39,16 +52,26 @@ struct mcs_instance_t {
 	uint16_t current_group_obj_id_handle;
 	uint16_t parent_group_obj_id_handle;
 #endif /* CONFIG_BT_MCC_OTS */
+#if defined(CONFIG_BT_MCC_READ_PLAYING_ORDER) || defined(CONFIG_BT_MCC_SET_PLAYING_ORDER)
 	uint16_t playing_order_handle;
+#endif /* defined(CONFIG_BT_MCC_READ_PLAYING_ORDER) || defined(CONFIG_BT_MCC_SET_PLAYING_ORDER) */
+#if defined(CONFIG_BT_MCC_READ_PLAYING_ORDER_SUPPORTED)
 	uint16_t playing_orders_supported_handle;
+#endif /* defined(CONFIG_BT_MCC_READ_PLAYING_ORDER_SUPPORTED) */
+#if defined(CONFIG_BT_MCC_READ_MEDIA_STATE)
 	uint16_t media_state_handle;
+#endif /* defined(CONFIG_BT_MCC_READ_MEDIA_STATE) */
 	uint16_t cp_handle;
+#if defined(CONFIG_BT_MCC_READ_MEDIA_CONTROL_POINT_OPCODES_SUPPORTED)
 	uint16_t opcodes_supported_handle;
+#endif /* defined(CONFIG_BT_MCC_READ_MEDIA_CONTROL_POINT_OPCODES_SUPPORTED) */
 #ifdef CONFIG_BT_MCC_OTS
 	uint16_t scp_handle;
 	uint16_t search_results_obj_id_handle;
 #endif /* CONFIG_BT_MCC_OTS */
+#if defined(CONFIG_BT_MCC_READ_CONTENT_CONTROL_ID)
 	uint16_t content_control_id_handle;
+#endif /* defined(CONFIG_BT_MCC_READ_CONTENT_CONTROL_ID) */
 
 
 	/* The write buffer is used for
@@ -84,21 +107,37 @@ struct mcs_instance_t {
 
 	struct bt_gatt_subscribe_params player_name_sub_params;
 	struct bt_gatt_subscribe_params track_changed_sub_params;
+#if defined(CONFIG_BT_MCC_READ_TRACK_TITLE_ENABLE_SUBSCRIPTION)
 	struct bt_gatt_subscribe_params track_title_sub_params;
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_TITLE_ENABLE_SUBSCRIPTION) */
+#if defined(CONFIG_BT_MCC_READ_TRACK_DURATION)
 	struct bt_gatt_subscribe_params track_duration_sub_params;
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_DURATION) */
+#if defined(CONFIG_BT_MCC_READ_TRACK_POSITION)
 	struct bt_gatt_subscribe_params track_position_sub_params;
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_POSITION)*/
+#if defined(CONFIG_BT_MCC_READ_PLAYBACK_SPEED)
 	struct bt_gatt_subscribe_params playback_speed_sub_params;
+#endif /* defined (CONFIG_BT_MCC_READ_PLAYBACK_SPEED) */
+#if defined(CONFIG_BT_MCC_READ_SEEKING_SPEED)
 	struct bt_gatt_subscribe_params seeking_speed_sub_params;
+#endif /* defined (CONFIG_BT_MCC_READ_SEEKING_SPEED) */
 #ifdef CONFIG_BT_MCC_OTS
 	struct bt_gatt_subscribe_params current_track_obj_sub_params;
 	struct bt_gatt_subscribe_params next_track_obj_sub_params;
 	struct bt_gatt_subscribe_params parent_group_obj_sub_params;
 	struct bt_gatt_subscribe_params current_group_obj_sub_params;
 #endif /* CONFIG_BT_MCC_OTS */
+#if defined(CONFIG_BT_MCC_READ_PLAYING_ORDER)
 	struct bt_gatt_subscribe_params playing_order_sub_params;
+#endif /* defined(CONFIG_BT_MCC_READ_PLAYING_ORDER) */
+#if defined(CONFIG_BT_MCC_READ_MEDIA_STATE)
 	struct bt_gatt_subscribe_params media_state_sub_params;
+#endif /* defined(CONFIG_BT_MCC_READ_MEDIA_STATE) */
 	struct bt_gatt_subscribe_params cp_sub_params;
+#if defined(CONFIG_BT_MCC_READ_MEDIA_CONTROL_POINT_OPCODES_SUPPORTED)
 	struct bt_gatt_subscribe_params opcodes_supported_sub_params;
+#endif /* defined(CONFIG_BT_MCC_READ_MEDIA_CONTROL_POINT_OPCODES_SUPPORTED) */
 #ifdef CONFIG_BT_MCC_OTS
 	struct bt_gatt_subscribe_params scp_sub_params;
 	struct bt_gatt_subscribe_params search_results_obj_sub_params;

--- a/subsys/bluetooth/audio/media_proxy.c
+++ b/subsys/bluetooth/audio/media_proxy.c
@@ -278,6 +278,7 @@ static void mcc_read_icon_obj_id_cb(struct bt_conn *conn, int err, uint64_t id)
 }
 #endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL_OBJECTS */
 
+#if defined(CONFIG_BT_MCC_READ_MEDIA_PLAYER_ICON_URL)
 static void mcc_read_icon_url_cb(struct bt_conn *conn, int err, const char *url)
 {
 	if (err) {
@@ -290,6 +291,7 @@ static void mcc_read_icon_url_cb(struct bt_conn *conn, int err, const char *url)
 		LOG_DBG("No callback");
 	}
 }
+#endif /* defined(CONFIG_BT_MCC_READ_MEDIA_PLAYER_ICON_URL) */
 
 static void mcc_track_changed_ntf_cb(struct bt_conn *conn, int err)
 {
@@ -305,6 +307,7 @@ static void mcc_track_changed_ntf_cb(struct bt_conn *conn, int err)
 	}
 }
 
+#if defined(CONFIG_BT_MCC_READ_TRACK_TITLE)
 static void mcc_read_track_title_cb(struct bt_conn *conn, int err, const char *title)
 {
 	if (err) {
@@ -317,7 +320,9 @@ static void mcc_read_track_title_cb(struct bt_conn *conn, int err, const char *t
 		LOG_DBG("No callback");
 	}
 }
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_TITLE) */
 
+#if defined(CONFIG_BT_MCC_READ_TRACK_DURATION)
 static void mcc_read_track_duration_cb(struct bt_conn *conn, int err, int32_t dur)
 {
 	if (err) {
@@ -330,7 +335,9 @@ static void mcc_read_track_duration_cb(struct bt_conn *conn, int err, int32_t du
 		LOG_DBG("No callback");
 	}
 }
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_DURATION) */
 
+#if defined(CONFIG_BT_MCC_READ_TRACK_POSITION)
 static void mcc_read_track_position_cb(struct bt_conn *conn, int err, int32_t pos)
 {
 	if (err) {
@@ -343,7 +350,9 @@ static void mcc_read_track_position_cb(struct bt_conn *conn, int err, int32_t po
 		LOG_DBG("No callback");
 	}
 }
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_POSITION) */
 
+#if defined(CONFIG_BT_MCC_SET_TRACK_POSITION)
 static void mcc_set_track_position_cb(struct bt_conn *conn, int err, int32_t pos)
 {
 	if (err) {
@@ -356,7 +365,9 @@ static void mcc_set_track_position_cb(struct bt_conn *conn, int err, int32_t pos
 		LOG_DBG("No callback");
 	}
 }
+#endif /* defined(CONFIG_BT_MCC_SET_TRACK_POSITION) */
 
+#if defined(CONFIG_BT_MCC_READ_PLAYBACK_SPEED)
 static void mcc_read_playback_speed_cb(struct bt_conn *conn, int err, int8_t speed)
 {
 	if (err) {
@@ -369,7 +380,9 @@ static void mcc_read_playback_speed_cb(struct bt_conn *conn, int err, int8_t spe
 		LOG_DBG("No callback");
 	}
 }
+#endif /* defined (CONFIG_BT_MCC_READ_PLAYBACK_SPEED) */
 
+#if defined(CONFIG_BT_MCC_SET_PLAYBACK_SPEED)
 static void mcc_set_playback_speed_cb(struct bt_conn *conn, int err, int8_t speed)
 {
 	if (err) {
@@ -382,7 +395,9 @@ static void mcc_set_playback_speed_cb(struct bt_conn *conn, int err, int8_t spee
 		LOG_DBG("No callback");
 	}
 }
+#endif /* defined (CONFIG_BT_MCC_SET_PLAYBACK_SPEED) */
 
+#if defined(CONFIG_BT_MCC_READ_SEEKING_SPEED)
 static void mcc_read_seeking_speed_cb(struct bt_conn *conn, int err, int8_t speed)
 {
 	if (err) {
@@ -395,6 +410,7 @@ static void mcc_read_seeking_speed_cb(struct bt_conn *conn, int err, int8_t spee
 		LOG_DBG("No callback");
 	}
 }
+#endif /* defined (CONFIG_BT_MCC_READ_SEEKING_SPEED) */
 
 #ifdef CONFIG_MCTL_REMOTE_PLAYER_CONTROL_OBJECTS
 static void mcc_read_segments_obj_id_cb(struct bt_conn *conn, int err, uint64_t id)
@@ -470,6 +486,7 @@ static void mcc_read_current_group_obj_id_cb(struct bt_conn *conn, int err, uint
 
 #endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL_OBJECTS */
 
+#if defined(CONFIG_BT_MCC_READ_PLAYING_ORDER)
 static void mcc_read_playing_order_cb(struct bt_conn *conn, int err, uint8_t order)
 {
 	if (err) {
@@ -482,7 +499,9 @@ static void mcc_read_playing_order_cb(struct bt_conn *conn, int err, uint8_t ord
 		LOG_DBG("No callback");
 	}
 }
+#endif /* defined(CONFIG_BT_MCC_READ_PLAYING_ORDER) */
 
+#if defined(CONFIG_BT_MCC_SET_PLAYING_ORDER)
 static void mcc_set_playing_order_cb(struct bt_conn *conn, int err, uint8_t order)
 {
 	if (err) {
@@ -495,7 +514,9 @@ static void mcc_set_playing_order_cb(struct bt_conn *conn, int err, uint8_t orde
 		LOG_DBG("No callback");
 	}
 }
+#endif /* defined(CONFIG_BT_MCC_SET_PLAYING_ORDER) */
 
+#if defined(CONFIG_BT_MCC_READ_PLAYING_ORDER_SUPPORTED)
 static void mcc_read_playing_orders_supported_cb(struct bt_conn *conn, int err, uint16_t orders)
 {
 	if (err) {
@@ -508,7 +529,9 @@ static void mcc_read_playing_orders_supported_cb(struct bt_conn *conn, int err, 
 		LOG_DBG("No callback");
 	}
 }
+#endif /* defined(CONFIG_BT_MCC_READ_PLAYING_ORDER_SUPPORTED) */
 
+#if defined(CONFIG_BT_MCC_READ_MEDIA_STATE)
 static void mcc_read_media_state_cb(struct bt_conn *conn, int err, uint8_t state)
 {
 	if (err) {
@@ -521,7 +544,9 @@ static void mcc_read_media_state_cb(struct bt_conn *conn, int err, uint8_t state
 		LOG_DBG("No callback");
 	}
 }
+#endif /* defined(CONFIG_BT_MCC_READ_MEDIA_STATE) */
 
+#if defined(CONFIG_BT_MCC_SET_MEDIA_CONTROL_POINT)
 static void mcc_send_cmd_cb(struct bt_conn *conn, int err, const struct mpl_cmd *cmd)
 {
 	if (err) {
@@ -535,6 +560,7 @@ static void mcc_send_cmd_cb(struct bt_conn *conn, int err, const struct mpl_cmd 
 		LOG_DBG("No callback");
 	}
 }
+#endif /* defined(CONFIG_BT_MCC_SET_MEDIA_CONTROL_POINT) */
 
 static void mcc_cmd_ntf_cb(struct bt_conn *conn, int err,
 			   const struct mpl_cmd_ntf *ntf)
@@ -551,6 +577,7 @@ static void mcc_cmd_ntf_cb(struct bt_conn *conn, int err,
 	}
 }
 
+#if defined(CONFIG_BT_MCC_READ_MEDIA_CONTROL_POINT_OPCODES_SUPPORTED)
 static void mcc_read_opcodes_supported_cb(struct bt_conn *conn, int err, uint32_t opcodes)
 {
 	if (err) {
@@ -563,6 +590,7 @@ static void mcc_read_opcodes_supported_cb(struct bt_conn *conn, int err, uint32_
 		LOG_DBG("No callback");
 	}
 }
+#endif /* defined(CONFIG_BT_MCC_READ_MEDIA_CONTROL_POINT_OPCODES_SUPPORTED) */
 
 #ifdef CONFIG_MCTL_REMOTE_PLAYER_CONTROL_OBJECTS
 static void mcc_send_search_cb(struct bt_conn *conn, int err, const struct mpl_search *search)
@@ -605,6 +633,7 @@ static void mcc_read_search_results_obj_id_cb(struct bt_conn *conn, int err, uin
 }
 #endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL_OBJECTS */
 
+#if defined(CONFIG_BT_MCC_READ_CONTENT_CONTROL_ID)
 static void mcc_read_content_control_id_cb(struct bt_conn *conn, int err, uint8_t ccid)
 {
 	if (err) {
@@ -617,6 +646,7 @@ static void mcc_read_content_control_id_cb(struct bt_conn *conn, int err, uint8_
 		LOG_DBG("No callback");
 	}
 }
+#endif /* defined(CONFIG_BT_MCC_READ_CONTENT_CONTROL_ID) */
 
 #endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL */
 
@@ -672,15 +702,31 @@ int media_proxy_ctrl_discover_player(struct bt_conn *conn)
 #ifdef CONFIG_MCTL_REMOTE_PLAYER_CONTROL_OBJECTS
 	mprx.mcc_cbs.read_icon_obj_id              = mcc_read_icon_obj_id_cb;
 #endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL_OBJECTS */
+#if defined(CONFIG_BT_MCC_READ_MEDIA_PLAYER_ICON_URL)
 	mprx.mcc_cbs.read_icon_url                 = mcc_read_icon_url_cb;
+#endif /* defined(CONFIG_BT_MCC_READ_MEDIA_PLAYER_ICON_URL) */
 	mprx.mcc_cbs.track_changed_ntf             = mcc_track_changed_ntf_cb;
+#if defined(CONFIG_BT_MCC_READ_TRACK_TITLE)
 	mprx.mcc_cbs.read_track_title              = mcc_read_track_title_cb;
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_TITLE) */
+#if defined(CONFIG_BT_MCC_READ_TRACK_DURATION)
 	mprx.mcc_cbs.read_track_duration           = mcc_read_track_duration_cb;
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_DURATION) */
+#if defined(CONFIG_BT_MCC_READ_TRACK_POSITION)
 	mprx.mcc_cbs.read_track_position           = mcc_read_track_position_cb;
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_POSITION) */
+#if defined(CONFIG_BT_MCC_SET_TRACK_POSITION)
 	mprx.mcc_cbs.set_track_position            = mcc_set_track_position_cb;
+#endif /* defined(CONFIG_BT_MCC_SET_TRACK_POSITION) */
+#if defined(CONFIG_BT_MCC_READ_PLAYBACK_SPEED)
 	mprx.mcc_cbs.read_playback_speed           = mcc_read_playback_speed_cb;
+#endif /* defined (CONFIG_BT_MCC_READ_PLAYBACK_SPEED) */
+#if defined(CONFIG_BT_MCC_SET_PLAYBACK_SPEED)
 	mprx.mcc_cbs.set_playback_speed            = mcc_set_playback_speed_cb;
+#endif /* defined (CONFIG_BT_MCC_SET_PLAYBACK_SPEED) */
+#if defined(CONFIG_BT_MCC_READ_SEEKING_SPEED)
 	mprx.mcc_cbs.read_seeking_speed            = mcc_read_seeking_speed_cb;
+#endif /* defined (CONFIG_BT_MCC_READ_SEEKING_SPEED) */
 #ifdef CONFIG_MCTL_REMOTE_PLAYER_CONTROL_OBJECTS
 	mprx.mcc_cbs.read_segments_obj_id          = mcc_read_segments_obj_id_cb;
 	mprx.mcc_cbs.read_current_track_obj_id     = mcc_read_current_track_obj_id_cb;
@@ -688,19 +734,33 @@ int media_proxy_ctrl_discover_player(struct bt_conn *conn)
 	mprx.mcc_cbs.read_parent_group_obj_id      = mcc_read_parent_group_obj_id_cb;
 	mprx.mcc_cbs.read_current_group_obj_id     = mcc_read_current_group_obj_id_cb;
 #endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL_OBJECTS */
+#if defined(CONFIG_BT_MCC_READ_PLAYING_ORDER)
 	mprx.mcc_cbs.read_playing_order	      = mcc_read_playing_order_cb;
+#endif /* defined(CONFIG_BT_MCC_READ_PLAYING_ORDER) */
+#if defined(CONFIG_BT_MCC_SET_PLAYING_ORDER)
 	mprx.mcc_cbs.set_playing_order             = mcc_set_playing_order_cb;
+#endif /* defined(CONFIG_BT_MCC_SET_PLAYING_ORDER) */
+#if defined(CONFIG_BT_MCC_READ_PLAYING_ORDER_SUPPORTED)
 	mprx.mcc_cbs.read_playing_orders_supported = mcc_read_playing_orders_supported_cb;
+#endif /* defined(CONFIG_BT_MCC_READ_PLAYING_ORDER_SUPPORTED) */
+#if defined(CONFIG_BT_MCC_READ_MEDIA_STATE)
 	mprx.mcc_cbs.read_media_state              = mcc_read_media_state_cb;
+#endif /* defined(CONFIG_BT_MCC_READ_MEDIA_STATE) */
+#if defined(CONFIG_BT_MCC_SET_MEDIA_CONTROL_POINT)
 	mprx.mcc_cbs.send_cmd                      = mcc_send_cmd_cb;
+#endif /* defined(CONFIG_BT_MCC_SET_MEDIA_CONTROL_POINT) */
 	mprx.mcc_cbs.cmd_ntf                       = mcc_cmd_ntf_cb;
+#if defined(CONFIG_BT_MCC_READ_MEDIA_CONTROL_POINT_OPCODES_SUPPORTED)
 	mprx.mcc_cbs.read_opcodes_supported        = mcc_read_opcodes_supported_cb;
+#endif /* defined(CONFIG_BT_MCC_READ_MEDIA_CONTROL_POINT_OPCODES_SUPPORTED) */
 #ifdef CONFIG_MCTL_REMOTE_PLAYER_CONTROL_OBJECTS
 	mprx.mcc_cbs.send_search                   = mcc_send_search_cb;
 	mprx.mcc_cbs.search_ntf                    = mcc_search_ntf_cb;
 	mprx.mcc_cbs.read_search_results_obj_id    = mcc_read_search_results_obj_id_cb;
 #endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL_OBJECTS */
+#if defined(CONFIG_BT_MCC_READ_CONTENT_CONTROL_ID)
 	mprx.mcc_cbs.read_content_control_id       = mcc_read_content_control_id_cb;
+#endif /* defined(CONFIG_BT_MCC_READ_CONTENT_CONTROL_ID) */
 
 	err = bt_mcc_init(&mprx.mcc_cbs);
 	if (err) {
@@ -825,11 +885,11 @@ int media_proxy_ctrl_get_icon_url(struct media_player *player)
 	}
 #endif /* CONFIG_MCTL_LOCAL_PLAYER_LOCAL_CONTROL */
 
-#if defined(CONFIG_MCTL_REMOTE_PLAYER_CONTROL)
+#if defined(CONFIG_MCTL_REMOTE_PLAYER_CONTROL) && defined(CONFIG_BT_MCC_READ_MEDIA_PLAYER_ICON_URL)
 	if (mprx.remote_player.registered && player == &mprx.remote_player) {
 		return bt_mcc_read_icon_url(mprx.remote_player.conn);
 	}
-#endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL */
+#endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL && CONFIG_BT_MCC_READ_MEDIA_PLAYER_ICON_URL */
 
 	return -EINVAL;
 }
@@ -860,11 +920,11 @@ int media_proxy_ctrl_get_track_title(struct media_player *player)
 	}
 #endif /* CONFIG_MCTL_LOCAL_PLAYER_LOCAL_CONTROL */
 
-#if defined(CONFIG_MCTL_REMOTE_PLAYER_CONTROL)
+#if defined(CONFIG_MCTL_REMOTE_PLAYER_CONTROL) && defined(CONFIG_BT_MCC_READ_TRACK_TITLE)
 	if (mprx.remote_player.registered && player == &mprx.remote_player) {
 		return bt_mcc_read_track_title(mprx.remote_player.conn);
 	}
-#endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL */
+#endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL && CONFIG_BT_MCC_READ_TRACK_TITLE */
 
 	return -EINVAL;
 }
@@ -896,11 +956,11 @@ int media_proxy_ctrl_get_track_duration(struct media_player *player)
 	}
 #endif /* CONFIG_MCTL_LOCAL_PLAYER_LOCAL_CONTROL */
 
-#if defined(CONFIG_MCTL_REMOTE_PLAYER_CONTROL)
+#if defined(CONFIG_MCTL_REMOTE_PLAYER_CONTROL) && defined(CONFIG_BT_MCC_READ_TRACK_DURATION)
 	if (mprx.remote_player.registered && player == &mprx.remote_player) {
 		return bt_mcc_read_track_duration(mprx.remote_player.conn);
 	}
-#endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL */
+#endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL && CONFIG_BT_MCC_READ_TRACK_DURATION */
 
 	return -EINVAL;
 }
@@ -932,11 +992,11 @@ int media_proxy_ctrl_get_track_position(struct media_player *player)
 	}
 #endif /* CONFIG_MCTL_LOCAL_PLAYER_LOCAL_CONTROL */
 
-#if defined(CONFIG_MCTL_REMOTE_PLAYER_CONTROL)
+#if defined(CONFIG_MCTL_REMOTE_PLAYER_CONTROL) && defined(CONFIG_BT_MCC_READ_TRACK_POSITION)
 	if (mprx.remote_player.registered && player == &mprx.remote_player) {
 		return bt_mcc_read_track_position(mprx.remote_player.conn);
 	}
-#endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL */
+#endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL && CONFIG_BT_MCC_READ_TRACK_POSITION */
 
 	return -EINVAL;
 }
@@ -967,11 +1027,11 @@ int media_proxy_ctrl_set_track_position(struct media_player *player, int32_t pos
 	}
 #endif /* CONFIG_MCTL_LOCAL_PLAYER_LOCAL_CONTROL */
 
-#if defined(CONFIG_MCTL_REMOTE_PLAYER_CONTROL)
+#if defined(CONFIG_MCTL_REMOTE_PLAYER_CONTROL) && CONFIG_BT_MCC_SET_TRACK_POSITION
 	if (mprx.remote_player.registered && player == &mprx.remote_player) {
 		return bt_mcc_set_track_position(mprx.remote_player.conn, position);
 	}
-#endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL */
+#endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL && CONFIG_BT_MCC_SET_TRACK_POSITION */
 
 	return -EINVAL;
 }
@@ -1002,11 +1062,11 @@ int media_proxy_ctrl_get_playback_speed(struct media_player *player)
 	}
 #endif /* CONFIG_MCTL_LOCAL_PLAYER_LOCAL_CONTROL */
 
-#if defined(CONFIG_MCTL_REMOTE_PLAYER_CONTROL)
+#if defined(CONFIG_MCTL_REMOTE_PLAYER_CONTROL) && defined(CONFIG_BT_MCC_READ_PLAYBACK_SPEED)
 	if (mprx.remote_player.registered && player == &mprx.remote_player) {
 		return bt_mcc_read_playback_speed(mprx.remote_player.conn);
 	}
-#endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL */
+#endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL && CONFIG_BT_MCC_READ_PLAYBACK_SPEED */
 
 	return -EINVAL;
 }
@@ -1037,11 +1097,11 @@ int media_proxy_ctrl_set_playback_speed(struct media_player *player, int8_t spee
 	}
 #endif /* CONFIG_MCTL_LOCAL_PLAYER_LOCAL_CONTROL */
 
-#if defined(CONFIG_MCTL_REMOTE_PLAYER_CONTROL)
+#if defined(CONFIG_MCTL_REMOTE_PLAYER_CONTROL) && defined(CONFIG_BT_MCC_SET_PLAYBACK_SPEED)
 	if (mprx.remote_player.registered && player == &mprx.remote_player) {
 		return bt_mcc_set_playback_speed(mprx.remote_player.conn, speed);
 	}
-#endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL */
+#endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL && CONFIG_BT_MCC_SET_PLAYBACK_SPEED */
 
 	return -EINVAL;
 }
@@ -1072,11 +1132,11 @@ int media_proxy_ctrl_get_seeking_speed(struct media_player *player)
 	}
 #endif /* CONFIG_MCTL_LOCAL_PLAYER_LOCAL_CONTROL */
 
-#if defined(CONFIG_MCTL_REMOTE_PLAYER_CONTROL)
+#if defined(CONFIG_MCTL_REMOTE_PLAYER_CONTROL) && defined(CONFIG_BT_MCC_READ_SEEKING_SPEED)
 	if (mprx.remote_player.registered && player == &mprx.remote_player) {
 		return bt_mcc_read_seeking_speed(mprx.remote_player.conn);
 	}
-#endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL */
+#endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL && CONFIG_BT_MCC_READ_SEEKING_SPEED */
 
 	return -EINVAL;
 }
@@ -1409,12 +1469,12 @@ int media_proxy_ctrl_get_playing_order(struct media_player *player)
 	}
 #endif /* CONFIG_MCTL_LOCAL_PLAYER_LOCAL_CONTROL */
 
-#if defined(CONFIG_MCTL_REMOTE_PLAYER_CONTROL)
+#if defined(CONFIG_MCTL_REMOTE_PLAYER_CONTROL) && defined(CONFIG_BT_MCC_READ_PLAYING_ORDER)
 	if (mprx.remote_player.registered && player == &mprx.remote_player) {
 		LOG_DBG("Remote player");
 		return bt_mcc_read_playing_order(mprx.remote_player.conn);
 	}
-#endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL */
+#endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL && CONFIG_BT_MCC_READ_PLAYING_ORDER */
 
 	return -EINVAL;
 }
@@ -1445,11 +1505,11 @@ int media_proxy_ctrl_set_playing_order(struct media_player *player, uint8_t orde
 	}
 #endif /* CONFIG_MCTL_LOCAL_PLAYER_LOCAL_CONTROL */
 
-#if defined(CONFIG_MCTL_REMOTE_PLAYER_CONTROL)
+#if defined(CONFIG_MCTL_REMOTE_PLAYER_CONTROL) && defined(CONFIG_BT_MCC_SET_PLAYING_ORDER)
 	if (mprx.remote_player.registered && player == &mprx.remote_player) {
 		return bt_mcc_set_playing_order(mprx.remote_player.conn, order);
 	}
-#endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL */
+#endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL && CONFIG_BT_MCC_SET_PLAYING_ORDER */
 
 	return -EINVAL;
 }
@@ -1481,11 +1541,12 @@ int media_proxy_ctrl_get_playing_orders_supported(struct media_player *player)
 	}
 #endif /* CONFIG_MCTL_LOCAL_PLAYER_LOCAL_CONTROL */
 
-#if defined(CONFIG_MCTL_REMOTE_PLAYER_CONTROL)
+#if defined(CONFIG_MCTL_REMOTE_PLAYER_CONTROL) && \
+	defined(CONFIG_BT_MCC_READ_PLAYING_ORDER_SUPPORTED)
 	if (mprx.remote_player.registered && player == &mprx.remote_player) {
 		return bt_mcc_read_playing_orders_supported(mprx.remote_player.conn);
 	}
-#endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL */
+#endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL && CONFIG_BT_MCC_READ_PLAYING_ORDER_SUPPORTED */
 
 	return -EINVAL;
 }
@@ -1516,11 +1577,11 @@ int media_proxy_ctrl_get_media_state(struct media_player *player)
 	}
 #endif /* CONFIG_MCTL_LOCAL_PLAYER_LOCAL_CONTROL */
 
-#if defined(CONFIG_MCTL_REMOTE_PLAYER_CONTROL)
+#if defined(CONFIG_MCTL_REMOTE_PLAYER_CONTROL) && defined(CONFIG_BT_MCC_READ_MEDIA_STATE)
 	if (mprx.remote_player.registered && player == &mprx.remote_player) {
 		return bt_mcc_read_media_state(mprx.remote_player.conn);
 	}
-#endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL */
+#endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL && CONFIG_BT_MCC_READ_MEDIA_STATE */
 
 	return -EINVAL;
 }
@@ -1551,11 +1612,11 @@ int media_proxy_ctrl_send_command(struct media_player *player, const struct mpl_
 	}
 #endif /* CONFIG_MCTL_LOCAL_PLAYER_LOCAL_CONTROL */
 
-#if defined(CONFIG_MCTL_REMOTE_PLAYER_CONTROL)
+#if defined(CONFIG_MCTL_REMOTE_PLAYER_CONTROL) && defined(CONFIG_BT_MCC_SET_MEDIA_CONTROL_POINT)
 	if (mprx.remote_player.registered && player == &mprx.remote_player) {
 		return bt_mcc_send_cmd(mprx.remote_player.conn, cmd);
 	}
-#endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL */
+#endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL && CONFIG_BT_MCC_SET_MEDIA_CONTROL_POINT */
 
 	return -EINVAL;
 }
@@ -1587,11 +1648,14 @@ int media_proxy_ctrl_get_commands_supported(struct media_player *player)
 	}
 #endif /* CONFIG_MCTL_LOCAL_PLAYER_LOCAL_CONTROL */
 
-#if defined(CONFIG_MCTL_REMOTE_PLAYER_CONTROL)
+#if defined(CONFIG_MCTL_REMOTE_PLAYER_CONTROL) && \
+	defined(CONFIG_BT_MCC_READ_MEDIA_CONTROL_POINT_OPCODES_SUPPORTED)
 	if (mprx.remote_player.registered && player == &mprx.remote_player) {
 		return bt_mcc_read_opcodes_supported(mprx.remote_player.conn);
 	}
-#endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL */
+#endif	/* CONFIG_MCTL_REMOTE_PLAYER_CONTROL &&
+	 * CONFIG_BT_MCC_READ_MEDIA_CONTROL_POINT_OPCODES_SUPPORTED
+	 */
 
 	return -EINVAL;
 }
@@ -1693,11 +1757,11 @@ uint8_t media_proxy_ctrl_get_content_ctrl_id(struct media_player *player)
 	}
 #endif /* CONFIG_MCTL_LOCAL_PLAYER_LOCAL_CONTROL */
 
-#if defined(CONFIG_MCTL_REMOTE_PLAYER_CONTROL)
+#if defined(CONFIG_MCTL_REMOTE_PLAYER_CONTROL) && defined(CONFIG_BT_MCC_READ_CONTENT_CONTROL_ID)
 	if (mprx.remote_player.registered && player == &mprx.remote_player) {
 		return bt_mcc_read_content_control_id(mprx.remote_player.conn);
 	}
-#endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL */
+#endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL && CONFIG_BT_MCC_READ_CONTENT_CONTROL_ID */
 
 	return -EINVAL;
 }

--- a/subsys/bluetooth/audio/shell/mcc.c
+++ b/subsys/bluetooth/audio/shell/mcc.c
@@ -78,6 +78,7 @@ static void mcc_read_icon_obj_id_cb(struct bt_conn *conn, int err, uint64_t id)
 }
 #endif /* CONFIG_BT_MCC_OTS */
 
+#if defined(CONFIG_BT_MCC_READ_MEDIA_PLAYER_ICON_URL)
 static void mcc_read_icon_url_cb(struct bt_conn *conn, int err, const char *url)
 {
 	if (err) {
@@ -87,7 +88,9 @@ static void mcc_read_icon_url_cb(struct bt_conn *conn, int err, const char *url)
 
 	shell_print(ctx_shell, "Icon URL: 0x%s", url);
 }
+#endif /* defined(CONFIG_BT_MCC_READ_MEDIA_PLAYER_ICON_URL) */
 
+#if defined(CONFIG_BT_MCC_READ_TRACK_TITLE)
 static void mcc_read_track_title_cb(struct bt_conn *conn, int err, const char *title)
 {
 	if (err) {
@@ -97,6 +100,7 @@ static void mcc_read_track_title_cb(struct bt_conn *conn, int err, const char *t
 
 	shell_print(ctx_shell, "Track title: %s", title);
 }
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_TITLE) */
 
 static void mcc_track_changed_ntf_cb(struct bt_conn *conn, int err)
 {
@@ -108,6 +112,7 @@ static void mcc_track_changed_ntf_cb(struct bt_conn *conn, int err)
 	shell_print(ctx_shell, "Track changed");
 }
 
+#if defined(CONFIG_BT_MCC_READ_TRACK_DURATION)
 static void mcc_read_track_duration_cb(struct bt_conn *conn, int err, int32_t dur)
 {
 	if (err) {
@@ -117,7 +122,9 @@ static void mcc_read_track_duration_cb(struct bt_conn *conn, int err, int32_t du
 
 	shell_print(ctx_shell, "Track duration: %d", dur);
 }
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_DURATION) */
 
+#if defined(CONFIG_BT_MCC_READ_TRACK_POSITION)
 static void mcc_read_track_position_cb(struct bt_conn *conn, int err, int32_t pos)
 {
 	if (err) {
@@ -127,7 +134,9 @@ static void mcc_read_track_position_cb(struct bt_conn *conn, int err, int32_t po
 
 	shell_print(ctx_shell, "Track Position: %d", pos);
 }
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_POSITION) */
 
+#if defined(CONFIG_BT_MCC_SET_TRACK_POSITION)
 static void mcc_set_track_position_cb(struct bt_conn *conn, int err, int32_t pos)
 {
 	if (err) {
@@ -137,7 +146,9 @@ static void mcc_set_track_position_cb(struct bt_conn *conn, int err, int32_t pos
 
 	shell_print(ctx_shell, "Track Position: %d", pos);
 }
+#endif /* defined(CONFIG_BT_MCC_SET_TRACK_POSITION) */
 
+#if defined(CONFIG_BT_MCC_READ_PLAYBACK_SPEED)
 static void mcc_read_playback_speed_cb(struct bt_conn *conn, int err,
 				       int8_t speed)
 {
@@ -148,7 +159,9 @@ static void mcc_read_playback_speed_cb(struct bt_conn *conn, int err,
 
 	shell_print(ctx_shell, "Playback speed: %d", speed);
 }
+#endif /* defined (CONFIG_BT_MCC_READ_PLAYBACK_SPEED) */
 
+#if defined(CONFIG_BT_MCC_SET_PLAYBACK_SPEED)
 static void mcc_set_playback_speed_cb(struct bt_conn *conn, int err, int8_t speed)
 {
 	if (err) {
@@ -158,7 +171,9 @@ static void mcc_set_playback_speed_cb(struct bt_conn *conn, int err, int8_t spee
 
 	shell_print(ctx_shell, "Playback speed: %d", speed);
 }
+#endif /* defined (CONFIG_BT_MCC_SET_PLAYBACK_SPEED) */
 
+#if defined(CONFIG_BT_MCC_READ_SEEKING_SPEED)
 static void mcc_read_seeking_speed_cb(struct bt_conn *conn, int err,
 				      int8_t speed)
 {
@@ -169,6 +184,7 @@ static void mcc_read_seeking_speed_cb(struct bt_conn *conn, int err,
 
 	shell_print(ctx_shell, "Seeking speed: %d", speed);
 }
+#endif /* defined (CONFIG_BT_MCC_READ_SEEKING_SPEED) */
 
 
 #ifdef CONFIG_BT_MCC_OTS
@@ -311,6 +327,7 @@ static void mcc_set_current_group_obj_id_cb(struct bt_conn *conn, int err,
 #endif /* CONFIG_BT_MCC_OTS */
 
 
+#if defined(CONFIG_BT_MCC_READ_PLAYING_ORDER)
 static void mcc_read_playing_order_cb(struct bt_conn *conn, int err, uint8_t order)
 {
 	if (err) {
@@ -320,7 +337,9 @@ static void mcc_read_playing_order_cb(struct bt_conn *conn, int err, uint8_t ord
 
 	shell_print(ctx_shell, "Playing order: %d", order);
 }
+#endif /* defined(CONFIG_BT_MCC_READ_PLAYING_ORDER) */
 
+#if defined(CONFIG_BT_MCC_SET_PLAYING_ORDER)
 static void mcc_set_playing_order_cb(struct bt_conn *conn, int err, uint8_t order)
 {
 	if (err) {
@@ -330,7 +349,9 @@ static void mcc_set_playing_order_cb(struct bt_conn *conn, int err, uint8_t orde
 
 	shell_print(ctx_shell, "Playing order: %d", order);
 }
+#endif /* defined(CONFIG_BT_MCC_SET_PLAYING_ORDER) */
 
+#if defined(CONFIG_BT_MCC_READ_PLAYING_ORDER_SUPPORTED)
 static void mcc_read_playing_orders_supported_cb(struct bt_conn *conn, int err,
 						 uint16_t orders)
 {
@@ -342,7 +363,9 @@ static void mcc_read_playing_orders_supported_cb(struct bt_conn *conn, int err,
 
 	shell_print(ctx_shell, "Playing orders supported: %d", orders);
 }
+#endif /* defined(CONFIG_BT_MCC_READ_PLAYING_ORDER_SUPPORTED) */
 
+#if defined(CONFIG_BT_MCC_READ_MEDIA_STATE)
 static void mcc_read_media_state_cb(struct bt_conn *conn, int err, uint8_t state)
 {
 	if (err) {
@@ -352,7 +375,9 @@ static void mcc_read_media_state_cb(struct bt_conn *conn, int err, uint8_t state
 
 	shell_print(ctx_shell, "Media State: %d", state);
 }
+#endif /* defined(CONFIG_BT_MCC_READ_MEDIA_STATE) */
 
+#if defined(CONFIG_BT_MCC_SET_MEDIA_CONTROL_POINT)
 static void mcc_send_cmd_cb(struct bt_conn *conn, int err, const struct mpl_cmd *cmd)
 {
 	if (err) {
@@ -364,6 +389,7 @@ static void mcc_send_cmd_cb(struct bt_conn *conn, int err, const struct mpl_cmd 
 
 	shell_print(ctx_shell, "Command opcode: %d, param: %d", cmd->opcode, cmd->param);
 }
+#endif /* defined(CONFIG_BT_MCC_SET_MEDIA_CONTROL_POINT) */
 
 static void mcc_cmd_ntf_cb(struct bt_conn *conn, int err,
 			   const struct mpl_cmd_ntf *ntf)
@@ -379,6 +405,7 @@ static void mcc_cmd_ntf_cb(struct bt_conn *conn, int err,
 		    ntf->requested_opcode, ntf->result_code);
 }
 
+#if defined(CONFIG_BT_MCC_READ_MEDIA_CONTROL_POINT_OPCODES_SUPPORTED)
 static void mcc_read_opcodes_supported_cb(struct bt_conn *conn, int err,
 					    uint32_t opcodes)
 {
@@ -390,6 +417,7 @@ static void mcc_read_opcodes_supported_cb(struct bt_conn *conn, int err,
 
 	shell_print(ctx_shell, "Opcodes supported: %d", opcodes);
 }
+#endif /* defined(CONFIG_BT_MCC_READ_MEDIA_CONTROL_POINT_OPCODES_SUPPORTED) */
 
 #ifdef CONFIG_BT_MCC_OTS
 static void mcc_send_search_cb(struct bt_conn *conn, int err,
@@ -439,6 +467,7 @@ static void mcc_read_search_results_obj_id_cb(struct bt_conn *conn, int err,
 }
 #endif /* CONFIG_BT_MCC_OTS */
 
+#if defined(CONFIG_BT_MCC_READ_CONTENT_CONTROL_ID)
 static void mcc_read_content_control_id_cb(struct bt_conn *conn, int err, uint8_t ccid)
 {
 	if (err) {
@@ -448,6 +477,7 @@ static void mcc_read_content_control_id_cb(struct bt_conn *conn, int err, uint8_
 
 	shell_print(ctx_shell, "Content Control ID: %d", ccid);
 }
+#endif /* defined(CONFIG_BT_MCC_READ_CONTENT_CONTROL_ID) */
 
 #ifdef CONFIG_BT_MCC_OTS
 /**** Callback functions for the included Object Transfer service *************/
@@ -569,15 +599,31 @@ static int cmd_mcc_init(const struct shell *sh, size_t argc, char **argv)
 #ifdef CONFIG_BT_MCC_OTS
 	cb.read_icon_obj_id              = mcc_read_icon_obj_id_cb;
 #endif /* CONFIG_BT_MCC_OTS */
+#if defined(CONFIG_BT_MCC_READ_MEDIA_PLAYER_ICON_URL)
 	cb.read_icon_url                 = mcc_read_icon_url_cb;
+#endif /* defined(CONFIG_BT_MCC_READ_MEDIA_PLAYER_ICON_URL) */
 	cb.track_changed_ntf             = mcc_track_changed_ntf_cb;
+#if defined(CONFIG_BT_MCC_READ_TRACK_TITLE)
 	cb.read_track_title              = mcc_read_track_title_cb;
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_TITLE) */
+#if defined(CONFIG_BT_MCC_READ_TRACK_DURATION)
 	cb.read_track_duration           = mcc_read_track_duration_cb;
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_DURATION) */
+#if defined(CONFIG_BT_MCC_READ_TRACK_POSITION)
 	cb.read_track_position           = mcc_read_track_position_cb;
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_POSITION) */
+#if defined(CONFIG_BT_MCC_SET_TRACK_POSITION)
 	cb.set_track_position            = mcc_set_track_position_cb;
+#endif /* defined(CONFIG_BT_MCC_SET_TRACK_POSITION) */
+#if defined(CONFIG_BT_MCC_READ_PLAYBACK_SPEED)
 	cb.read_playback_speed           = mcc_read_playback_speed_cb;
+#endif /* defined (CONFIG_BT_MCC_READ_PLAYBACK_SPEED) */
+#if defined(CONFIG_BT_MCC_SET_PLAYBACK_SPEED)
 	cb.set_playback_speed            = mcc_set_playback_speed_cb;
+#endif /* defined (CONFIG_BT_MCC_SET_PLAYBACK_SPEED) */
+#if defined(CONFIG_BT_MCC_READ_SEEKING_SPEED)
 	cb.read_seeking_speed            = mcc_read_seeking_speed_cb;
+#endif /* defined (CONFIG_BT_MCC_READ_SEEKING_SPEED) */
 #ifdef CONFIG_BT_MCC_OTS
 	cb.read_segments_obj_id          = mcc_read_segments_obj_id_cb;
 	cb.read_current_track_obj_id     = mcc_read_current_track_obj_id_cb;
@@ -588,19 +634,33 @@ static int cmd_mcc_init(const struct shell *sh, size_t argc, char **argv)
 	cb.read_current_group_obj_id     = mcc_read_current_group_obj_id_cb;
 	cb.set_current_group_obj_id      = mcc_set_current_group_obj_id_cb;
 #endif /* CONFIG_BT_MCC_OTS */
+#if defined(CONFIG_BT_MCC_READ_PLAYING_ORDER)
 	cb.read_playing_order            = mcc_read_playing_order_cb;
+#endif /* defined(CONFIG_BT_MCC_READ_PLAYING_ORDER) */
+#if defined(CONFIG_BT_MCC_SET_PLAYING_ORDER)
 	cb.set_playing_order             = mcc_set_playing_order_cb;
+#endif /* defined(CONFIG_BT_MCC_SET_PLAYING_ORDER) */
+#if defined(CONFIG_BT_MCC_READ_PLAYING_ORDER_SUPPORTED)
 	cb.read_playing_orders_supported = mcc_read_playing_orders_supported_cb;
+#endif /* defined(CONFIG_BT_MCC_READ_PLAYING_ORDER_SUPPORTED) */
+#if defined(CONFIG_BT_MCC_READ_MEDIA_STATE)
 	cb.read_media_state              = mcc_read_media_state_cb;
+#endif /* defined(CONFIG_BT_MCC_READ_MEDIA_STATE) */
+#if defined(CONFIG_BT_MCC_SET_MEDIA_CONTROL_POINT)
 	cb.send_cmd                      = mcc_send_cmd_cb;
+#endif /* defined(CONFIG_BT_MCC_SET_MEDIA_CONTROL_POINT) */
 	cb.cmd_ntf                       = mcc_cmd_ntf_cb;
+#if defined(CONFIG_BT_MCC_READ_MEDIA_CONTROL_POINT_OPCODES_SUPPORTED)
 	cb.read_opcodes_supported        = mcc_read_opcodes_supported_cb;
+#endif /* defined(CONFIG_BT_MCC_READ_MEDIA_CONTROL_POINT_OPCODES_SUPPORTED) */
 #ifdef CONFIG_BT_MCC_OTS
 	cb.send_search                   = mcc_send_search_cb;
 	cb.search_ntf                    = mcc_search_ntf_cb;
 	cb.read_search_results_obj_id    = mcc_read_search_results_obj_id_cb;
 #endif /* CONFIG_BT_MCC_OTS */
+#if defined(CONFIG_BT_MCC_READ_CONTENT_CONTROL_ID)
 	cb.read_content_control_id       = mcc_read_content_control_id_cb;
+#endif /* defined(CONFIG_BT_MCC_READ_CONTENT_CONTROL_ID) */
 #ifdef CONFIG_BT_MCC_OTS
 	cb.otc_obj_selected              = mcc_otc_obj_selected_cb;
 	cb.otc_obj_metadata              = mcc_otc_obj_metadata_cb;
@@ -670,6 +730,7 @@ static int cmd_mcc_read_icon_obj_id(const struct shell *sh, size_t argc,
 }
 #endif /* CONFIG_BT_MCC_OTS */
 
+#if defined(CONFIG_BT_MCC_READ_MEDIA_PLAYER_ICON_URL)
 static int cmd_mcc_read_icon_url(const struct shell *sh, size_t argc,
 				 char *argv[])
 {
@@ -681,7 +742,9 @@ static int cmd_mcc_read_icon_url(const struct shell *sh, size_t argc,
 	}
 	return result;
 }
+#endif /* defined(CONFIG_BT_MCC_READ_MEDIA_PLAYER_ICON_URL) */
 
+#if defined(CONFIG_BT_MCC_READ_TRACK_TITLE)
 static int cmd_mcc_read_track_title(const struct shell *sh, size_t argc,
 				    char *argv[])
 {
@@ -693,7 +756,9 @@ static int cmd_mcc_read_track_title(const struct shell *sh, size_t argc,
 	}
 	return result;
 }
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_TITLE) */
 
+#if defined(CONFIG_BT_MCC_READ_TRACK_DURATION)
 static int cmd_mcc_read_track_duration(const struct shell *sh, size_t argc,
 				       char *argv[])
 {
@@ -705,7 +770,9 @@ static int cmd_mcc_read_track_duration(const struct shell *sh, size_t argc,
 	}
 	return result;
 }
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_DURATION) */
 
+#if defined(CONFIG_BT_MCC_READ_TRACK_POSITION)
 static int cmd_mcc_read_track_position(const struct shell *sh, size_t argc,
 				       char *argv[])
 {
@@ -717,7 +784,9 @@ static int cmd_mcc_read_track_position(const struct shell *sh, size_t argc,
 	}
 	return result;
 }
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_POSITION) */
 
+#if defined(CONFIG_BT_MCC_SET_TRACK_POSITION)
 static int cmd_mcc_set_track_position(const struct shell *sh, size_t argc,
 				      char *argv[])
 {
@@ -743,8 +812,10 @@ static int cmd_mcc_set_track_position(const struct shell *sh, size_t argc,
 	}
 	return result;
 }
+#endif /* defined(CONFIG_BT_MCC_SET_TRACK_POSITION) */
 
 
+#if defined(CONFIG_BT_MCC_READ_PLAYBACK_SPEED)
 static int cmd_mcc_read_playback_speed(const struct shell *sh, size_t argc,
 				       char *argv[])
 {
@@ -756,8 +827,10 @@ static int cmd_mcc_read_playback_speed(const struct shell *sh, size_t argc,
 	}
 	return result;
 }
+#endif /* defined (CONFIG_BT_MCC_READ_PLAYBACK_SPEED) */
 
 
+#if defined(CONFIG_BT_MCC_SET_PLAYBACK_SPEED)
 static int cmd_mcc_set_playback_speed(const struct shell *sh, size_t argc,
 				      char *argv[])
 {
@@ -783,7 +856,9 @@ static int cmd_mcc_set_playback_speed(const struct shell *sh, size_t argc,
 	}
 	return result;
 }
+#endif /* defined (CONFIG_BT_MCC_SET_PLAYBACK_SPEED) */
 
+#if defined(CONFIG_BT_MCC_READ_SEEKING_SPEED)
 static int cmd_mcc_read_seeking_speed(const struct shell *sh, size_t argc,
 				      char *argv[])
 {
@@ -795,6 +870,7 @@ static int cmd_mcc_read_seeking_speed(const struct shell *sh, size_t argc,
 	}
 	return result;
 }
+#endif /* defined (CONFIG_BT_MCC_READ_SEEKING_SPEED) */
 
 
 #ifdef CONFIG_BT_MCC_OTS
@@ -938,6 +1014,7 @@ static int cmd_mcc_set_current_group_obj_id(const struct shell *sh, size_t argc,
 }
 #endif /* CONFIG_BT_MCC_OTS */
 
+#if defined(CONFIG_BT_MCC_READ_PLAYING_ORDER)
 static int cmd_mcc_read_playing_order(const struct shell *sh, size_t argc,
 				      char *argv[])
 {
@@ -949,7 +1026,9 @@ static int cmd_mcc_read_playing_order(const struct shell *sh, size_t argc,
 	}
 	return result;
 }
+#endif /* defined(CONFIG_BT_MCC_READ_PLAYING_ORDER) */
 
+#if defined(CONFIG_BT_MCC_SET_PLAYING_ORDER)
 static int cmd_mcc_set_playing_order(const struct shell *sh, size_t argc,
 				     char *argv[])
 {
@@ -975,7 +1054,9 @@ static int cmd_mcc_set_playing_order(const struct shell *sh, size_t argc,
 	}
 	return result;
 }
+#endif /* defined(CONFIG_BT_MCC_SET_PLAYING_ORDER) */
 
+#if defined(CONFIG_BT_MCC_READ_PLAYING_ORDER_SUPPORTED)
 static int cmd_mcc_read_playing_orders_supported(const struct shell *sh,
 						 size_t argc, char *argv[])
 {
@@ -987,7 +1068,9 @@ static int cmd_mcc_read_playing_orders_supported(const struct shell *sh,
 	}
 	return result;
 }
+#endif /* defined(CONFIG_BT_MCC_READ_PLAYING_ORDER_SUPPORTED) */
 
+#if defined(CONFIG_BT_MCC_READ_MEDIA_STATE)
 static int cmd_mcc_read_media_state(const struct shell *sh, size_t argc,
 				    char *argv[])
 {
@@ -999,7 +1082,9 @@ static int cmd_mcc_read_media_state(const struct shell *sh, size_t argc,
 	}
 	return result;
 }
+#endif /* defined(CONFIG_BT_MCC_READ_MEDIA_STATE) */
 
+#if defined(CONFIG_BT_MCC_SET_MEDIA_CONTROL_POINT)
 static int cmd_mcc_play(const struct shell *sh, size_t argc, char *argv[])
 {
 	const struct mpl_cmd cmd = {
@@ -1430,7 +1515,9 @@ static int cmd_mcc_goto_group(const struct shell *sh, size_t argc, char *argv[])
 
 	return err;
 }
+#endif /* defined(CONFIG_BT_MCC_SET_MEDIA_CONTROL_POINT) */
 
+#if defined(CONFIG_BT_MCC_READ_MEDIA_CONTROL_POINT_OPCODES_SUPPORTED)
 static int cmd_mcc_read_opcodes_supported(const struct shell *sh, size_t argc,
 					  char *argv[])
 {
@@ -1442,6 +1529,7 @@ static int cmd_mcc_read_opcodes_supported(const struct shell *sh, size_t argc,
 	}
 	return result;
 }
+#endif /* defined(CONFIG_BT_MCC_READ_MEDIA_CONTROL_POINT_OPCODES_SUPPORTED) */
 
 #ifdef CONFIG_BT_MCC_OTS
 static int cmd_mcc_send_search_raw(const struct shell *sh, size_t argc,
@@ -1632,6 +1720,7 @@ static int cmd_mcc_read_search_results_obj_id(const struct shell *sh,
 }
 #endif /* CONFIG_BT_MCC_OTS */
 
+#if defined(CONFIG_BT_MCC_READ_CONTENT_CONTROL_ID)
 static int cmd_mcc_read_content_control_id(const struct shell *sh, size_t argc,
 					   char *argv[])
 {
@@ -1643,6 +1732,7 @@ static int cmd_mcc_read_content_control_id(const struct shell *sh, size_t argc,
 	}
 	return result;
 }
+#endif /* defined(CONFIG_BT_MCC_READ_CONTENT_CONTROL_ID) */
 
 
 #ifdef CONFIG_BT_MCC_OTS
@@ -1867,22 +1957,38 @@ SHELL_STATIC_SUBCMD_SET_CREATE(mcc_cmds,
 	SHELL_CMD_ARG(read_icon_obj_id, NULL, "Read Icon Object ID",
 		      cmd_mcc_read_icon_obj_id, 1, 0),
 #endif /* CONFIG_BT_MCC_OTS */
+#if defined(CONFIG_BT_MCC_READ_MEDIA_PLAYER_ICON_URL)
 	SHELL_CMD_ARG(read_icon_url, NULL, "Read Icon URL",
 		      cmd_mcc_read_icon_url, 1, 0),
+#endif /* defined(CONFIG_BT_MCC_READ_MEDIA_PLAYER_ICON_URL) */
+#if defined(CONFIG_BT_MCC_READ_TRACK_TITLE)
 	SHELL_CMD_ARG(read_track_title, NULL, "Read Track Title",
 		      cmd_mcc_read_track_title, 1, 0),
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_TITLE) */
+#if defined(CONFIG_BT_MCC_READ_TRACK_DURATION)
 	SHELL_CMD_ARG(read_track_duration, NULL, "Read Track Duration",
 		      cmd_mcc_read_track_duration, 1, 0),
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_DURATION) */
+#if defined(CONFIG_BT_MCC_READ_TRACK_POSITION)
 	SHELL_CMD_ARG(read_track_position, NULL, "Read Track Position",
 		      cmd_mcc_read_track_position, 1, 0),
+#endif /* defined(CONFIG_BT_MCC_READ_TRACK_POSITION) */
+#if defined(CONFIG_BT_MCC_SET_TRACK_POSITION)
 	SHELL_CMD_ARG(set_track_position, NULL, "Set Track position <position>",
 		      cmd_mcc_set_track_position, 2, 0),
+#endif /* defined(CONFIG_BT_MCC_SET_TRACK_POSITION) */
+#if defined(CONFIG_BT_MCC_READ_PLAYBACK_SPEED)
 	SHELL_CMD_ARG(read_playback_speed, NULL, "Read Playback Speed",
 		      cmd_mcc_read_playback_speed, 1, 0),
+#endif /* defined (CONFIG_BT_MCC_READ_PLAYBACK_SPEED */
+#if defined(CONFIG_BT_MCC_SET_PLAYBACK_SPEED)
 	SHELL_CMD_ARG(set_playback_speed, NULL, "Set Playback Speed <speed>",
 		      cmd_mcc_set_playback_speed, 2, 0),
+#endif /* defined (CONFIG_BT_MCC_SET_PLAYBACK_SPEED) */
+#if defined(CONFIG_BT_MCC_READ_SEEKING_SPEED)
 	SHELL_CMD_ARG(read_seeking_speed, NULL, "Read Seeking Speed",
 		      cmd_mcc_read_seeking_speed, 1, 0),
+#endif /* defined (CONFIG_BT_MCC_READ_SEEKING_SPEED) */
 #ifdef CONFIG_BT_MCC_OTS
 	SHELL_CMD_ARG(read_track_segments_obj_id, NULL,
 		      "Read Track Segments Object ID",
@@ -1909,15 +2015,24 @@ SHELL_STATIC_SUBCMD_SET_CREATE(mcc_cmds,
 		      "Set Current Group Object ID <id: 48 bits or less>",
 		      cmd_mcc_set_current_group_obj_id, 2, 0),
 #endif /* CONFIG_BT_MCC_OTS */
+#if defined(CONFIG_BT_MCC_READ_PLAYING_ORDER)
 	SHELL_CMD_ARG(read_playing_order, NULL, "Read Playing Order",
 		      cmd_mcc_read_playing_order, 1, 0),
+#endif /* defined(CONFIG_BT_MCC_READ_PLAYING_ORDER) */
+#if defined(CONFIG_BT_MCC_SET_PLAYING_ORDER)
 	SHELL_CMD_ARG(set_playing_order, NULL, "Set Playing Order <order>",
 		      cmd_mcc_set_playing_order, 2, 0),
+#endif /* defined(CONFIG_BT_MCC_SET_PLAYING_ORDER) */
+#if defined(CONFIG_BT_MCC_READ_PLAYING_ORDER_SUPPORTED)
 	SHELL_CMD_ARG(read_playing_orders_supported, NULL,
 		     "Read Playing Orders Supported",
 		      cmd_mcc_read_playing_orders_supported, 1, 0),
+#endif /* defined(CONFIG_BT_MCC_READ_PLAYING_ORDER_SUPPORTED) */
+#if defined(CONFIG_BT_MCC_READ_MEDIA_STATE)
 	SHELL_CMD_ARG(read_media_state, NULL, "Read Media State",
 		      cmd_mcc_read_media_state, 1, 0),
+#endif /* defined(CONFIG_BT_MCC_READ_MEDIA_STATE) */
+#if defined(CONFIG_BT_MCC_SET_MEDIA_CONTROL_POINT)
 	SHELL_CMD_ARG(play, NULL, "Send the play command", cmd_mcc_play, 1, 0),
 	SHELL_CMD_ARG(pause, NULL, "Send the pause command",
 		      cmd_mcc_pause, 1, 0),
@@ -1962,8 +2077,11 @@ SHELL_STATIC_SUBCMD_SET_CREATE(mcc_cmds,
 	SHELL_CMD_ARG(goto_group, NULL,
 		      "Send the goto group command <int32_t: group>",
 		      cmd_mcc_goto_group, 2, 0),
+#endif /* defined(CONFIG_BT_MCC_SET_MEDIA_CONTROL_POINT) */
+#if defined(CONFIG_BT_MCC_READ_MEDIA_CONTROL_POINT_OPCODES_SUPPORTED)
 	SHELL_CMD_ARG(read_opcodes_supported, NULL, "Send the Read Opcodes Supported",
 		      cmd_mcc_read_opcodes_supported, 1, 0),
+#endif /* defined(CONFIG_BT_MCC_READ_MEDIA_CONTROL_POINT_OPCODES_SUPPORTED) */
 #ifdef CONFIG_BT_MCC_OTS
 	SHELL_CMD_ARG(send_search_raw, NULL, "Send search <search control item sequence>",
 		      cmd_mcc_send_search_raw, 2, 0),
@@ -1982,8 +2100,10 @@ SHELL_STATIC_SUBCMD_SET_CREATE(mcc_cmds,
 		      "Read Search Results Object ID",
 		      cmd_mcc_read_search_results_obj_id, 1, 0),
 #endif /* CONFIG_BT_MCC_OTS */
+#if defined(CONFIG_BT_MCC_READ_CONTENT_CONTROL_ID)
 	SHELL_CMD_ARG(read_content_control_id, NULL, "Read Content Control ID",
 		      cmd_mcc_read_content_control_id, 1, 0),
+#endif /* defined(CONFIG_BT_MCC_READ_CONTENT_CONTROL_ID) */
 #ifdef CONFIG_BT_MCC_OTS
 	SHELL_CMD_ARG(ots_read_features, NULL, "Read OTC Features",
 		      cmd_mcc_otc_read_features, 1, 0),

--- a/tests/bluetooth/shell/testcase.yaml
+++ b/tests/bluetooth/shell/testcase.yaml
@@ -181,6 +181,12 @@ tests:
     extra_configs:
       - CONFIG_BT_MCC_OTS=n
     tags: bluetooth
+  bluetooth.shell.audio.mcc_minimal:
+    extra_args: CONF_FILE="audio.conf"
+    build_only: true
+    extra_configs:
+      - CONFIG_BT_MCC_MINIMAL=y
+    tags: bluetooth
   bluetooth.shell.audio.no_otsc:
     extra_args: CONF_FILE="audio.conf"
     build_only: true


### PR DESCRIPTION
This change makes the optional procedures in the Media Control Client optional and configurable through Kconfig.