### PR TITLE
doc: Add information to enable tflite-micro in hello world example

### DIFF
--- a/samples/modules/tflite-micro/hello_world/README.rst
+++ b/samples/modules/tflite-micro/hello_world/README.rst
@@ -28,6 +28,17 @@ reference kernels and one with CMSIS-NN optimized kernels.
 .. _the TensorFlow Hello World sample for Zephyr:
    https://github.com/tensorflow/tflite-micro/tree/main/tensorflow/lite/micro/examples/hello_world
 
+Prerequisites
+**************
+
+Tensorflow Lite for Microcontrollers library is an optional Zephyr module and needs to be enabled
+using the following command:
+
+.. code-block:: bash
+
+   west config manifest.group-filter -- +optional
+   west update
+
 Building and Running
 ********************
 


### PR DESCRIPTION
Information about how to enable Tensorflow Lite for Microcontrollers was missing (so it was not simple to find out how to build this example right after the Getting Started tutorial). A section of prerequisites has been added, which includes the necessary commands to include tflite-micro library. Related to issue #40827. 