### PR TITLE
Bluetooth: host: att: Unsupport user-provided handles

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -1150,25 +1150,6 @@ BT_GATT_SERVICE_DEFINE(_1_gatt_svc,
 );
 
 #if defined(CONFIG_BT_GATT_DYNAMIC_DB)
-static uint8_t found_attr(const struct bt_gatt_attr *attr, uint16_t handle,
-			  void *user_data)
-{
-	const struct bt_gatt_attr **found = user_data;
-
-	*found = attr;
-
-	return BT_GATT_ITER_STOP;
-}
-
-static const struct bt_gatt_attr *find_attr(uint16_t handle)
-{
-	const struct bt_gatt_attr *attr = NULL;
-
-	bt_gatt_foreach_attr(handle, handle, found_attr, &attr);
-
-	return attr;
-}
-
 static void gatt_insert(struct bt_gatt_service *svc, uint16_t last_handle)
 {
 	struct bt_gatt_service *tmp, *prev = NULL;


### PR DESCRIPTION
`bt_gatt_service_register` would previously honor ATT handles provided from the app. Only if a handle is the zero handle, would the host allocate a handle.

`bt_gatt_service_unregister` would leave the host-allocated handle values in `bt_gatt_service.attrs[i].handle`, the same location where `bt_gatt_service_register` finds the provided handles.

This resulted in unexpected behavior https://github.com/zephyrproject-rtos/zephyr/issues/67377 where register/unregister of services A and B like (+A -A +B +A) will fail.

Additionally, there was insufficient logic to protect the data-structure invariants of the host. The app could provide handles that are not in increasing order, or handles that overlap with another service.

`bt_gatt_service_register` will now always allocate. It will also log a diagnostic error if the provided handle is not null, to RFU the non-nullvalues.

`bt_gatt_service_unregister` now resets the handle to zero.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/67377