### PR TITLE
MAINTAINERS: fix incorrect files-exclude entry for NXP Drivers

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3255,7 +3255,7 @@ NXP Drivers:
     - dts/bindings/*/nxp*
   files-exclude:
     - drivers/*/*s32*
-    - drivers/misc/*/*s32*/
+    - drivers/misc/*/*s32*
     - include/zephyr/dt-bindings/*/*s32*
     - include/zephyr/drivers/*/*s32*
     - dts/bindings/*/*s32*


### PR DESCRIPTION
Typo in a files-exclude entry is causing get_maintainer.py script to error out under certain conditions