### PR TITLE
drivers: dma: intel-adsp-hda: change stop ordering

### DIFF
--- a/drivers/dma/dma_intel_adsp_hda.c
+++ b/drivers/dma/dma_intel_adsp_hda.c
@@ -324,15 +324,17 @@ int intel_adsp_hda_dma_stop(const struct device *dev, uint32_t channel)
 		return 0;
 	}
 
-	intel_adsp_hda_disable(cfg->base, cfg->regblock_size, channel);
-
 	/* host dma needs some cycles to completely stop */
 	if (cfg->direction == HOST_TO_MEMORY || cfg->direction == MEMORY_TO_HOST) {
 		if (!WAIT_FOR(!(*DGCS(cfg->base, cfg->regblock_size, channel) & DGCS_GBUSY), 1000,
 				  k_busy_wait(1))) {
+			printk("DEBUG: %s: Channel%u stuck busy after disable (DGCS: %#x)\n",
+				__func__, channel, *DGCS(cfg->base, cfg->regblock_size, channel));
 			return -EBUSY;
 		}
 	}
+
+	intel_adsp_hda_disable(cfg->base, cfg->regblock_size, channel);
 
 	return pm_device_runtime_put(dev);
 }


### PR DESCRIPTION
Clearing the GEN/FIFORDY bits with intel_adsp_hda_disable() disconnects the DMA from DSP memory. This can block pending transfers to DSP memory to complete, so change the order so that the check of GBUSY is done first, and intel_adsp_hda_disable() is only called in the end if the DMA is idle.

This also addresses the case where DMA remains busy and stop cannot be completed and -EBUSY is returned. Without this patch, further calls to intel_adsp_hda_dma_stop() fail with no action as the GEN/FIFORDY is already cleared and the runtime-PM ref is lost forever.

Suggested-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>