### PR TITLE
llext: Fixes for testcase.yaml

### DIFF
--- a/tests/subsys/llext/hello_world/testcase.yaml
+++ b/tests/subsys/llext/hello_world/testcase.yaml
@@ -16,9 +16,22 @@ tests:
     extra_configs:
       - arch:arm:CONFIG_ARM_MPU=n
       - CONFIG_LLEXT_STORAGE_WRITABLE=y
-  llext.simple.modules_enabled:
+  llext.simple.modules_enabled_writable:
     platform_key:
       - simulation
+      - arch
+    platform_exclude:
+      - qemu_cortex_a9 # MMU
+    extra_configs:
+      - arch:arm:CONFIG_ARM_MPU=n
+      - CONFIG_MODULES=y
+      - CONFIG_LLEXT_STORAGE_WRITABLE=y
+      - CONFIG_LLEXT_TEST_HELLO=m
+  llext.simple.modules_enabled_readonly:
+    arch_exclude: xtensa # for now
+    platform_key:
+      - simulation
+      - arch
     platform_exclude:
       - qemu_cortex_a9 # MMU
     extra_configs:


### PR DESCRIPTION
The platform key using arch + simulation better provides coverage of unique architectures. Adds a testcase for writable module builds and loading which was uncovered previously and would've led to a failure on xtensa as xtensa currently requires writable storage.