### PR TITLE
log: net: Add TCP support to syslog transmitter

### DIFF
--- a/subsys/logging/backends/Kconfig.net
+++ b/subsys/logging/backends/Kconfig.net
@@ -14,6 +14,70 @@ config LOG_BACKEND_NET
 
 if LOG_BACKEND_NET
 
+config LOG_BACKEND_NET_RFC5424_STRUCTURED_DATA
+	bool "Print structured data according to RFC 5424"
+	help
+	  Print additional structured data as described in
+	  RFC 5424 chapter 6.3. Note that this might increase the
+	  length of the syslog message a lot.
+
+config LOG_BACKEND_NET_RFC5424_SDATA_TZKNOWN
+	bool "RFC 5424 chapter 7.1.1 tzKnown field"
+	depends on LOG_BACKEND_NET_RFC5424_STRUCTURED_DATA
+	help
+	  The tzKnown parameter indicates whether the originator knows its time zone.
+	  See RFC 5424 chapter 7.1 for details.
+
+config LOG_BACKEND_NET_RFC5424_SDATA_ISSYNCED
+	bool "RFC 5424 chapter 7.1.2 isSynced field"
+	depends on LOG_BACKEND_NET_RFC5424_STRUCTURED_DATA
+	help
+	  The isSynced parameter indicates whether the originator is
+	  synchronized to a reliable external time source, e.g., via NTP.
+	  See RFC 5424 chapter 7.1 for details.
+
+config LOG_BACKEND_NET_RFC5424_SDATA_SOFTWARE
+	bool "RFC 5424 chapter 7.2.3 software description field"
+	depends on LOG_BACKEND_NET_RFC5424_STRUCTURED_DATA
+	help
+	  Software description parameter uniquely identifies the software that
+	  generated the message.
+	  See RFC 5424 chapter 7.2 for details.
+
+config LOG_BACKEND_NET_RFC5424_SDATA_SOFTWARE_VALUE
+	string "RFC 5424 chapter 7.2.3 software field value"
+	default "zephyr"
+	depends on LOG_BACKEND_NET_RFC5424_SDATA_SOFTWARE
+	help
+	  User defined value for the software field.
+	  See RFC 5424 chapter 7.2.3 for details.
+
+config LOG_BACKEND_NET_RFC5424_SDATA_SOFTWARE_VERSION
+	bool "RFC 5424 chapter 7.2.4 software version field"
+	depends on LOG_BACKEND_NET_RFC5424_STRUCTURED_DATA
+	help
+	  Software version parameter uniquely identifies the software that
+	  generated the message.
+	  See RFC 5424 chapter 7.2.4 for details.
+
+config LOG_BACKEND_NET_RFC5424_SDATA_SEQID
+	bool "RFC 5424 chapter 7.3.1 sequence id field"
+	depends on LOG_BACKEND_NET_RFC5424_STRUCTURED_DATA
+	help
+	  Sequence id parameter tracks the sequence in which the
+	  originator submits messages to the syslog transport for sending.
+	  See RFC 5424 chapter 7.3.1 for details.
+
+config LOG_BACKEND_NET_RFC5424_SDATA_UPTIME
+	bool "RFC 5424 chapter 7.3.2 system uptime field"
+	depends on LOG_BACKEND_NET_RFC5424_STRUCTURED_DATA
+	help
+	  The system uptime parameter tracks the "time (in hundredths of a
+	  second) since the network management portion of the system was last
+	  re-initialized." For Zephyr this is currently interpreted as the
+	  system uptime.
+	  See RFC 5424 chapter 7.3.2 for details.
+
 config LOG_BACKEND_NET_SERVER
 	string "Syslog server IP address"
 	help

--- a/subsys/logging/backends/Kconfig.net
+++ b/subsys/logging/backends/Kconfig.net
@@ -5,12 +5,12 @@
 # rsyslog message to be malformed.
 config LOG_BACKEND_NET
 	bool "Networking backend"
-	depends on NETWORKING && NET_UDP && !LOG_MODE_IMMEDIATE
+	depends on NETWORKING && (NET_UDP || NET_TCP) && !LOG_MODE_IMMEDIATE
 	select LOG_OUTPUT
 	help
 	  Send syslog messages to network server.
-	  See RFC 5424 (syslog protocol) and RFC 5426 (syslog over UDP)
-	  specifications for details.
+	  See RFC 5424 (syslog protocol) and RFC 5426 (syslog over UDP) and
+	  RFC 6587 (syslog over TCP) specifications for details.
 
 if LOG_BACKEND_NET
 
@@ -25,6 +25,12 @@ config LOG_BACKEND_NET_SERVER
 	  [2001:db8::1]:514
 	  [2001:db8::2]
 	  2001:db::42
+	  If you want to use TCP, add "tcp://" in front of the address
+	  like this
+	  tcp://192.0.2.1:514
+	  tcp://192.0.2.42
+	  tcp://[2001:db8::1]:514
+	  UDP is used by default if the URI is missing.
 
 config LOG_BACKEND_NET_MAX_BUF_SIZE
 	int "Max syslog message size"

--- a/subsys/logging/backends/log_backend_net.c
+++ b/subsys/logging/backends/log_backend_net.c
@@ -199,7 +199,9 @@ err:
 static void process(const struct log_backend *const backend,
 		    union log_msg_generic *msg)
 {
-	uint32_t flags = LOG_OUTPUT_FLAG_FORMAT_SYSLOG | LOG_OUTPUT_FLAG_TIMESTAMP;
+	uint32_t flags = LOG_OUTPUT_FLAG_FORMAT_SYSLOG |
+			 LOG_OUTPUT_FLAG_TIMESTAMP |
+			 LOG_OUTPUT_FLAG_THREAD;
 
 	if (panic_mode) {
 		return;

--- a/subsys/logging/backends/log_backend_net.c
+++ b/subsys/logging/backends/log_backend_net.c
@@ -7,6 +7,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(log_backend_net, CONFIG_LOG_DEFAULT_LEVEL);
 
+#include <zephyr/sys/util_macro.h>
 #include <zephyr/logging/log_backend.h>
 #include <zephyr/logging/log_core.h>
 #include <zephyr/logging/log_output.h>
@@ -16,11 +17,7 @@ LOG_MODULE_REGISTER(log_backend_net, CONFIG_LOG_DEFAULT_LEVEL);
 /* Set this to 1 if you want to see what is being sent to server */
 #define DEBUG_PRINTING 0
 
-#if DEBUG_PRINTING
-#define DBG(fmt, ...) printk(fmt, ##__VA_ARGS__)
-#else
-#define DBG(fmt, ...)
-#endif
+#define DBG(fmt, ...) IF_ENABLED(DEBUG_PRINTING, (printk(fmt, ##__VA_ARGS__)))
 
 #if defined(CONFIG_NET_IPV6) || CONFIG_NET_HOSTNAME_ENABLE
 #define MAX_HOSTNAME_LEN NET_IPV6_ADDR_LEN
@@ -38,6 +35,7 @@ static uint32_t log_format_current = CONFIG_LOG_BACKEND_NET_OUTPUT_DEFAULT;
 
 static struct log_backend_net_ctx {
 	int sock;
+	bool is_tcp;
 } ctx = {
 	.sock = -1,
 };
@@ -48,12 +46,37 @@ static int line_out(uint8_t *data, size_t length, void *output_ctx)
 {
 	struct log_backend_net_ctx *ctx = (struct log_backend_net_ctx *)output_ctx;
 	int ret = -ENOMEM;
+	struct msghdr msg = { 0 };
+	struct iovec io_vector[2];
+	int pos = 0;
 
 	if (ctx == NULL) {
 		return length;
 	}
 
-	ret = zsock_send(ctx->sock, data, length, ZSOCK_MSG_DONTWAIT);
+#if defined(CONFIG_NET_TCP)
+	char len[sizeof("123456789")];
+
+	if (ctx->is_tcp) {
+		(void)snprintk(len, sizeof(len), "%zu ", length);
+		io_vector[pos].iov_base = (void *)len;
+		io_vector[pos].iov_len = strlen(len);
+		pos++;
+	}
+#else
+	if (ctx->is_tcp) {
+		return -ENOTSUP;
+	}
+#endif
+
+	io_vector[pos].iov_base = (void *)data;
+	io_vector[pos].iov_len = length;
+	pos++;
+
+	msg.msg_iov = io_vector;
+	msg.msg_iovlen = pos;
+
+	ret = zsock_sendmsg(ctx->sock, &msg, ctx->is_tcp ? 0 : ZSOCK_MSG_DONTWAIT);
 	if (ret < 0) {
 		goto fail;
 	}
@@ -71,7 +94,7 @@ static int do_net_init(struct log_backend_net_ctx *ctx)
 	struct sockaddr_in6 local_addr6 = {0};
 	struct sockaddr_in local_addr4 = {0};
 	socklen_t server_addr_len;
-	int ret;
+	int ret, proto = IPPROTO_UDP, type = SOCK_DGRAM;
 
 	if (IS_ENABLED(CONFIG_NET_IPV4) && server_addr.sa_family == AF_INET) {
 		local_addr = (struct sockaddr *)&local_addr4;
@@ -92,7 +115,12 @@ static int do_net_init(struct log_backend_net_ctx *ctx)
 
 	local_addr->sa_family = server_addr.sa_family;
 
-	ret = zsock_socket(server_addr.sa_family, SOCK_DGRAM, IPPROTO_UDP);
+	if (ctx->is_tcp) {
+		proto = IPPROTO_TCP;
+		type = SOCK_STREAM;
+	}
+
+	ret = zsock_socket(server_addr.sa_family, type, proto);
 	if (ret < 0) {
 		ret = -errno;
 		DBG("Cannot get socket (%d)\n", ret);
@@ -246,8 +274,15 @@ static void init_net(struct log_backend const *const backend)
 	ARG_UNUSED(backend);
 
 	if (strlen(CONFIG_LOG_BACKEND_NET_SERVER) != 0) {
-		bool ret = log_backend_net_set_addr(CONFIG_LOG_BACKEND_NET_SERVER);
+		const char *server = CONFIG_LOG_BACKEND_NET_SERVER;
+		bool ret;
 
+		if (memcmp(server, "tcp://", sizeof("tcp://") - 1) == 0) {
+			server += sizeof("tcp://") - 1;
+			ctx.is_tcp = true;
+		}
+
+		ret = log_backend_net_set_addr(server);
 		if (!ret) {
 			return;
 		}

--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -255,7 +255,7 @@ static int timestamp_print(const struct log_output *output,
 			length = log_custom_timestamp_print(output, timestamp, print_formatted);
 		} else if (IS_ENABLED(CONFIG_LOG_BACKEND_NET) &&
 			   flags & LOG_OUTPUT_FLAG_FORMAT_SYSLOG) {
-#if defined(CONFIG_NEWLIB_LIBC)
+#if defined(CONFIG_REQUIRES_FULL_LIBC)
 			char time_str[sizeof("1970-01-01T00:00:00")];
 			struct tm *tm;
 			time_t time;


### PR DESCRIPTION
Allow user to configure the syslog net backend to use TCP
instead of UDP. The syslog server address for TCP needs to
have "tcp://" URI in front of the address, for example the
tcp://192.0.2.2 server address would use TCP as a transport.
If there is no URI, then UDP would be used by default.
    
See the relevant RFC at https://www.rfc-editor.org/rfc/rfc6587
for details.
    
Fixes #66728
