### PR TITLE
twister: fix predicate handling 

### DIFF
--- a/tests/drivers/can/api/src/canfd.c
+++ b/tests/drivers/can/api/src/canfd.c
@@ -227,7 +227,7 @@ static void send_receive(const struct can_filter *filter1,
 /**
  * @brief Test getting the CAN controller capabilities.
  */
-ZTEST(canfd, test_get_capabilities)
+ZTEST(canfd, test_canfd_get_capabilities)
 {
 	can_mode_t cap;
 	int err;

--- a/tests/drivers/can/api/src/classic.c
+++ b/tests/drivers/can/api/src/classic.c
@@ -443,7 +443,7 @@ ZTEST_USER(can_classic, test_get_core_clock)
 /**
  * @brief Test getting the CAN controller capabilities.
  */
-ZTEST_USER(can_classic, test_get_capabilities)
+ZTEST_USER(can_classic, test_classic_get_capabilities)
 {
 	can_mode_t cap;
 	int err;


### PR DESCRIPTION
- tests: CAN: change duplicate test name: get_capabilities
- twister: deal with predicates and skipped tests
