### PR TITLE
i2c_mcux_flexcomm: add transaction timeout option

### DIFF
--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -93,6 +93,7 @@ source "drivers/i2c/Kconfig.mchp_mss"
 source "drivers/i2c/Kconfig.sedi"
 source "drivers/i2c/Kconfig.ambiq"
 source "drivers/i2c/Kconfig.numaker"
+source "drivers/i2c/Kconfig.mcux"
 
 config I2C_INIT_PRIORITY
 	int "Init priority"

--- a/drivers/i2c/Kconfig.mcux
+++ b/drivers/i2c/Kconfig.mcux
@@ -1,0 +1,14 @@
+# I2C configuration options
+
+# Copyright (c) 2024, NXP
+# SPDX-License-Identifier: Apache-2.0
+
+config I2C_NXP_TRANSFER_TIMEOUT
+	int "Transfer timeout [ms]"
+	default 0
+	help
+	  Timeout in milliseconds used for each I2C transfer.
+	  0 means that the driver should use the K_FOREVER value,
+	  i.e. it should wait as long as necessary.
+	  In conjunction with this, FSL_FEATURE_I2C_TIMEOUT_RECOVERY
+	  must be enabled to allow the driver to fully recover.

--- a/drivers/i2c/i2c_mcux_flexcomm.c
+++ b/drivers/i2c/i2c_mcux_flexcomm.c
@@ -19,6 +19,10 @@ LOG_MODULE_REGISTER(mcux_flexcomm);
 
 #include "i2c-priv.h"
 
+#define I2C_TRANSFER_TIMEOUT_MSEC                                                                  \
+	COND_CODE_0(CONFIG_I2C_NXP_TRANSFER_TIMEOUT, (K_FOREVER),                                  \
+		    (K_MSEC(CONFIG_I2C_NXP_TRANSFER_TIMEOUT)))
+
 struct mcux_flexcomm_config {
 	I2C_Type *base;
 	const struct device *clock_dev;
@@ -168,7 +172,7 @@ static int mcux_flexcomm_transfer(const struct device *dev,
 		}
 
 		/* Wait for the transfer to complete */
-		k_sem_take(&data->device_sync_sem, K_FOREVER);
+		k_sem_take(&data->device_sync_sem, I2C_TRANSFER_TIMEOUT_MSEC);
 
 		/* Return an error if the transfer didn't complete
 		 * successfully. e.g., nak, timeout, lost arbitration


### PR DESCRIPTION
With the device_sync_sem semaphore, there is the possibility of the code not returning to give it back (mcux_flexcomm_master_transfer_callback is never called), causing it to get stuck in k_sem_take(&data->device_sync_sem, K_FOREVER) in subsequent calls.

The i2c driver recovers by other means (enabling FSL_FEATURE_I2C_TIMEOUT_RECOVERY) but the callback might not return.

Adding a timeout option allows for this occurrence to be avoided.