### PR TITLE
posix: implement sched_rr_get_interval()

### DIFF
--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -379,7 +379,7 @@ _POSIX_PRIORITY_SCHEDULING
     sched_get_priority_min(),yes
     sched_getparam(),
     sched_getscheduler(),
-    sched_rr_get_interval(),
+    sched_rr_get_interval(),yes
     sched_setparam(),yes
     sched_setscheduler(),yes
     sched_yield(),yes

--- a/include/zephyr/posix/sched.h
+++ b/include/zephyr/posix/sched.h
@@ -10,6 +10,8 @@
 
 #include "posix_types.h"
 
+#include <time.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -53,6 +55,7 @@ int sched_getscheduler(pid_t pid);
 
 int sched_setparam(pid_t pid, const struct sched_param *param);
 int sched_setscheduler(pid_t pid, int policy, const struct sched_param *param);
+int sched_rr_get_interval(pid_t pid, struct timespec *interval);
 
 #ifdef __cplusplus
 }

--- a/lib/posix/options/sched.c
+++ b/lib/posix/options/sched.c
@@ -101,3 +101,13 @@ int sched_setscheduler(pid_t pid, int policy, const struct sched_param *param)
 
 	return -1;
 }
+
+int sched_rr_get_interval(pid_t pid, struct timespec *interval)
+{
+	ARG_UNUSED(pid);
+	ARG_UNUSED(interval);
+
+	errno = ENOSYS;
+
+	return -1;
+}

--- a/tests/posix/common/src/pthread.c
+++ b/tests/posix/common/src/pthread.c
@@ -428,6 +428,18 @@ ZTEST(pthread, test_sched_setscheduler)
 	zassert_true((rc == -1 && err == ENOSYS));
 }
 
+ZTEST(pthread, test_sched_rr_get_interval)
+{
+	struct timespec interval = {
+		.tv_sec = 0,
+		.tv_nsec = 0,
+	};
+	int rc = sched_rr_get_interval(0, &interval);
+	int err = errno;
+
+	zassert_true((rc == -1 && err == ENOSYS));
+}
+
 ZTEST(pthread, test_pthread_equal)
 {
 	zassert_true(pthread_equal(pthread_self(), pthread_self()));

--- a/tests/posix/headers/src/sched_h.c
+++ b/tests/posix/headers/src/sched_h.c
@@ -33,7 +33,7 @@ ZTEST(posix_headers, test_sched_h)
 		zassert_not_null(sched_getparam);
 		zassert_not_null(sched_getscheduler);
 
-		/* zassert_not_null(sched_rr_get_interval); */ /* not implemented */
+		zassert_not_null(sched_rr_get_interval);
 
 		zassert_not_null(sched_setparam);
 		zassert_not_null(sched_setscheduler);


### PR DESCRIPTION
This is part of the See https://github.com/zephyrproject-rtos/zephyr/issues/51211 (RFC https://github.com/zephyrproject-rtos/zephyr/issues/51211).

sched_rr_get_interval() is required as part of _POSIX_PRIORITY_SCHEDULING Option Group.

For more information, please refer to https://pubs.opengroup.org/onlinepubs/9699919799/functions/sched_rr_get_interval.html

Function is actually placeholders and just return `ENOSYS`
since Zephyr does not yet support processes or process scheduling.

Fixes #66961