### PR TITLE
sensing: sensing.h: fix doxygen warnings

### DIFF
--- a/include/zephyr/sensing/sensing.h
+++ b/include/zephyr/sensing/sensing.h
@@ -38,16 +38,20 @@ extern "C" {
  */
 struct sensing_sensor_version {
 	union {
-		uint32_t value;
+		uint32_t value; /**< The version represented as a 32-bit value. */
 		struct {
-			uint8_t major;
-			uint8_t minor;
-			uint8_t hotfix;
-			uint8_t build;
+			uint8_t major;  /**< The major version number. */
+			uint8_t minor;  /**< The minor version number. */
+			uint8_t hotfix; /**< The hotfix version number. */
+			uint8_t build;  /**< The build version number. */
 		};
 	};
 };
 
+/**
+ * @brief Macro to create a sensor version value.
+ *
+ */
 #define SENSING_SENSOR_VERSION(_major, _minor, _hotfix, _build)         \
 				(FIELD_PREP(GENMASK(31, 24), _major) |  \
 				 FIELD_PREP(GENMASK(23, 16), _minor) |  \
@@ -83,8 +87,8 @@ struct sensing_sensor_version {
  *
  */
 enum sensing_sensor_state {
-	SENSING_SENSOR_STATE_READY = 0,
-	SENSING_SENSOR_STATE_OFFLINE = 1,
+	SENSING_SENSOR_STATE_READY = 0,   /**< The sensor is ready. */
+	SENSING_SENSOR_STATE_OFFLINE = 1, /**< The sensor is offline. */
 };
 
 /**
@@ -92,12 +96,15 @@ enum sensing_sensor_state {
  *
  */
 enum sensing_sensor_attribute {
+	/** The interval attribute of a sensor configuration. */
 	SENSING_SENSOR_ATTRIBUTE_INTERVAL = 0,
+	/** The sensitivity attribute of a sensor configuration. */
 	SENSING_SENSOR_ATTRIBUTE_SENSITIVITY = 1,
+	/** The latency attribute of a sensor configuration. */
 	SENSING_SENSOR_ATTRIBUTE_LATENCY = 2,
+	/** The maximum number of attributes that a sensor configuration can have. */
 	SENSING_SENSOR_ATTRIBUTE_MAX,
 };
-
 
 /**
  * @brief Define Sensing subsystem sensor handle
@@ -105,14 +112,11 @@ enum sensing_sensor_attribute {
  */
 typedef void *sensing_sensor_handle_t;
 
-
 /**
  * @brief Sensor data event receive callback.
  *
  * @param handle The sensor instance handle.
- *
  * @param buf The data buffer with sensor data.
- *
  * @param context User provided context pointer.
  */
 typedef void (*sensing_data_event_t)(
@@ -151,41 +155,52 @@ struct sensing_sensor_info {
  *
  */
 struct sensing_callback_list {
-	sensing_data_event_t on_data_event;
-	void *context;
+	sensing_data_event_t on_data_event; /**< Callback function for a sensor data event. */
+	void *context;                      /**< Associated context with on_data_event */
 };
+
 /**
  * @struct sensing_sensor_config
  * @brief Sensing subsystem sensor configure, including interval, sensitivity, latency
  *
  */
 struct sensing_sensor_config {
-	enum sensing_sensor_attribute attri;
+	enum sensing_sensor_attribute attri; /**< Attribute of the sensor configuration. */
 
 	/** \ref SENSING_SENSITIVITY_INDEX_ALL */
-	int8_t data_field;
+	int8_t data_field; /**< Data field of the sensor configuration. */
 
 	union {
+		/** Interval between two sensor samples in microseconds (us). */
 		uint32_t interval;
+
+		/**
+		 * Sensitivity threshold for reporting new data. A new sensor sample is reported
+		 * only if the difference between it and the previous sample exceeds this
+		 * sensitivity value.
+		 */
 		uint32_t sensitivity;
+
+		/**
+		 * Maximum duration for batching sensor samples before reporting in
+		 * microseconds (us). This defines how long sensor samples can be
+		 * accumulated before they must be reported.
+		 */
 		uint64_t latency;
 	};
 };
 
-
- /**
-  * @brief Get all supported sensor instances' information.
-  *
-  * This API just returns read only information of sensor instances, pointer info will
-  * directly point to internal buffer, no need for caller to allocate buffer,
-  * no side effect to sensor instances.
-  *
-  * @param num_sensors Get number of sensor instances.
-  *
-  * @param info For receiving sensor instances' information array pointer.
-  *
-  * @return 0 on success or negative error value on failure.
-  */
+/**
+ * @brief Get all supported sensor instances' information.
+ *
+ * This API just returns read only information of sensor instances, pointer info will
+ * directly point to internal buffer, no need for caller to allocate buffer,
+ * no side effect to sensor instances.
+ *
+ * @param num_sensors Get number of sensor instances.
+ * @param info For receiving sensor instances' information array pointer.
+ * @return 0 on success or negative error value on failure.
+ */
 int sensing_get_sensors(int *num_sensors, const struct sensing_sensor_info **info);
 
 /**
@@ -197,12 +212,9 @@ int sensing_get_sensors(int *num_sensors, const struct sensing_sensor_info **inf
  * meanwhile, also register sensing callback list
  *
  * @param info The sensor info got from \ref sensing_get_sensors
- *
  * @param cb_list callback list to be registered to sensing, must have a static
  *                lifetime.
- *
  * @param handle The opened instance handle, if failed will be set to NULL.
- *
  * @return 0 on success or negative error value on failure.
  */
 int sensing_open_sensor(
@@ -219,12 +231,9 @@ int sensing_open_sensor(
  * meanwhile, also register sensing callback list.
  *
  * @param dev pointer device get from device tree.
- *
  * @param cb_list callback list to be registered to sensing, must have a static
  *                lifetime.
- *
  * @param handle The opened instance handle, if failed will be set to NULL.
- *
  * @return 0 on success or negative error value on failure.
  */
 int sensing_open_sensor_by_dt(
@@ -235,7 +244,6 @@ int sensing_open_sensor_by_dt(
  * @brief Close sensor instance.
  *
  * @param handle The sensor instance handle need to close.
- *
  * @return 0 on success or negative error value on failure.
  */
 int sensing_close_sensor(
@@ -245,11 +253,8 @@ int sensing_close_sensor(
  * @brief Set current config items to Sensing subsystem.
  *
  * @param handle The sensor instance handle.
- *
  * @param configs The configs to be set according to config attribute.
- *
  * @param count count of configs.
- *
  * @return 0 on success or negative error value on failure, not support etc.
  */
 int sensing_set_config(
@@ -260,11 +265,8 @@ int sensing_set_config(
  * @brief Get current config items from Sensing subsystem.
  *
  * @param handle The sensor instance handle.
- *
  * @param configs The configs to be get according to config attribute.
- *
  * @param count count of configs.
- *
  * @return 0 on success or negative error value on failure, not support etc.
  */
 int sensing_get_config(
@@ -275,7 +277,6 @@ int sensing_get_config(
  * @brief Get sensor information from sensor instance handle.
  *
  * @param handle The sensor instance handle.
- *
  * @return a const pointer to \ref sensing_sensor_info on success or NULL on failure.
  */
 const struct sensing_sensor_info *sensing_get_sensor_info(
@@ -288,6 +289,5 @@ const struct sensing_sensor_info *sensing_get_sensor_info(
 /**
  * @}
  */
-
 
 #endif /*ZEPHYR_INCLUDE_SENSING_H_*/

--- a/include/zephyr/sensing/sensing_datatypes.h
+++ b/include/zephyr/sensing/sensing_datatypes.h
@@ -45,9 +45,9 @@
  * system/chre/chre_api/include/chre_api/chre/sensor_types.h
  */
 struct sensing_sensor_value_header {
-	/** base timestamp of this data readings, unit is micro seconds */
+	/** Base timestamp of this data readings, unit is micro seconds */
 	uint64_t base_timestamp;
-	/** count of this data readings */
+	/** Count of this data readings */
 	uint16_t reading_count;
 };
 
@@ -65,19 +65,28 @@ struct sensing_sensor_value_header {
  * q31 version
  */
 struct sensing_sensor_value_3d_q31 {
+	/** Header of the sensor value data structure. */
 	struct sensing_sensor_value_header header;
-	int8_t shift;
+	int8_t shift; /**< The shift value for the q31_t v[3] reading. */
 	struct {
+		/** Timestamp delta of the reading. Unit is micro seconds. */
 		uint32_t timestamp_delta;
 		union {
+			/**
+			 * 3D vector of the reading represented as an array.
+			 * For SENSING_SENSOR_TYPE_MOTION_ACCELEROMETER_3D and
+			 * SENSING_SENSOR_TYPE_MOTION_UNCALIB_ACCELEROMETER_3D,
+			 * the unit is Gs (gravitational force).
+			 * For SENSING_SENSOR_TYPE_MOTION_GYROMETER_3D, the unit is degrees.
+			 */
 			q31_t v[3];
 			struct {
-				q31_t x;
-				q31_t y;
-				q31_t z;
+				q31_t x; /**< X value of the 3D vector. */
+				q31_t y; /**< Y value of the 3D vector. */
+				q31_t z; /**< Z value of the 3D vector. */
 			};
 		};
-	} readings[1];
+	} readings[1]; /**< Array of readings. */
 };
 
 /**
@@ -86,11 +95,17 @@ struct sensing_sensor_value_3d_q31 {
  * uint32_t version
  */
 struct sensing_sensor_value_uint32 {
+	/** Header of the sensor value data structure. */
 	struct sensing_sensor_value_header header;
 	struct {
+		/** Timestamp delta of the reading. Unit is micro seconds. */
 		uint32_t timestamp_delta;
+		/**
+		 * Value of the reading.
+		 * For SENSING_SENSOR_TYPE_LIGHT_AMBIENTLIGHT, the unit is luxs.
+		 */
 		uint32_t v;
-	} readings[1];
+	} readings[1];      /**< Array of readings. */
 };
 
 /**
@@ -99,14 +114,19 @@ struct sensing_sensor_value_uint32 {
  * q31 version
  */
 struct sensing_sensor_value_q31 {
+	/** Header of the sensor value data structure. */
 	struct sensing_sensor_value_header header;
-	int8_t shift;
+	int8_t shift; /**< The shift value for the q31_t v reading. */
 	struct {
+		/** Timestamp delta of the reading. Unit is micro seconds. */
 		uint32_t timestamp_delta;
+		/**
+		 * Value of the reading.
+		 * For SENSING_SENSOR_TYPE_MOTION_HINGE_ANGLE, the unit is degrees.
+		 */
 		q31_t v;
-	} readings[1];
+	} readings[1];   /**< Array of readings. */
 };
-
 
 /**
  * @}

--- a/include/zephyr/sensing/sensing_sensor.h
+++ b/include/zephyr/sensing/sensing_sensor.h
@@ -57,30 +57,40 @@ struct sensing_sensor_register_info {
 	struct sensing_sensor_version version;
 };
 
+/** @cond INTERNAL_HIDDEN */
+
+/**
+ * @brief Enumeration for sensing subsystem event.
+ *
+ * This enumeration defines the various events used by the sensing subsystem.
+ */
 enum {
-	EVENT_CONFIG_READY,
+	EVENT_CONFIG_READY, /**< Configuration is ready. */
 };
 
+/**
+ * @brief Enumeration for sensor flag bit.
+ *
+ * This enumeration defines the bit for sensor flag.
+ */
 enum {
-	SENSOR_LATER_CFG_BIT,
+	SENSOR_LATER_CFG_BIT, /**< Indicates if there is a configuration request pending. */
 };
 
 /**
  * @brief Connection between a source and sink of sensor data
  */
 struct sensing_connection {
-	sys_snode_t snode;
-	struct sensing_sensor *source;
-	struct sensing_sensor *sink;
-	/* interval and sensitivity set from client(sink) to reporter(source) */
-	uint32_t interval;
+	sys_snode_t snode;             /**< Node in the singly-linked list of connections. */
+	struct sensing_sensor *source; /**< Source sensor of the connection. */
+	struct sensing_sensor *sink;   /**< Sink sensor of the connection. */
+	uint32_t interval;             /**< Report interval in micro seconds. */
+	/** Sensitivity of the connection. */
 	int sensitivity[CONFIG_SENSING_MAX_SENSITIVITY_COUNT];
-	/* copy sensor data to connection data buf from reporter */
-	void *data;
-	/* client(sink) next consume time */
+	void *data;                 /**< Pointer to sensor sample data of the connection. */
+	/** Next consume time of the connection. Unit is micro seconds. */
 	uint64_t next_consume_time;
-	/* post data to application */
-	struct sensing_callback_list *callback_list;
+	struct sensing_callback_list *callback_list; /**< Callback list of the connection. */
 };
 
 /**
@@ -93,57 +103,126 @@ struct sensing_connection {
  * build report relationship model base on them, etc.
  */
 struct sensing_sensor {
-	const struct device *dev;
-	const struct sensing_sensor_info *info;
+	const struct device *dev;               /**< Device of the sensor instance. */
+	const struct sensing_sensor_info *info; /**< Info of the sensor instance. */
+	/** Register info of the sensor instance. */
 	const struct sensing_sensor_register_info *register_info;
-	const uint16_t reporter_num;
-	sys_slist_t client_list;
-	uint32_t interval;
-	uint8_t sensitivity_count;
+	const uint16_t reporter_num; /**< Reporter number of the sensor instance. */
+	sys_slist_t client_list;     /**< List of the sensor clients. */
+	uint32_t interval;           /**< Report interval of the sensor sample in micro seconds. */
+	uint8_t sensitivity_count;   /**< Sensitivity count of the sensor instance. */
+	/** Sensitivity array of the sensor instance. */
 	int sensitivity[CONFIG_SENSING_MAX_SENSITIVITY_COUNT];
-	enum sensing_sensor_state state;
-	/* runtime info */
-	struct rtio_iodev *iodev;
-	struct k_timer timer;
-	struct rtio_sqe *stream_sqe;
-	atomic_t flag;
-	struct sensing_connection *conns;
+	enum sensing_sensor_state state;  /**< State of the sensor instance. */
+	struct rtio_iodev *iodev;         /**< Pointer to RTIO device of the sensor instance. */
+	struct k_timer timer;             /**< Timer for non streaming mode */
+	struct rtio_sqe *stream_sqe;      /**< Sqe for streaming mode. */
+	atomic_t flag;                    /**< Sensor flag of the sensor instance. */
+	struct sensing_connection *conns; /**< Pointer to sensor connections. */
 };
 
+/**
+ * @brief Macro to generate a name for a sensor info structure.
+ *
+ * This macro generates a name for a sensor info structure based on a node and an index.
+ *
+ * @param node The devicetree node identifier.
+ * @param idx Logical index into the sensor-types array.
+ */
 #define SENSING_SENSOR_INFO_NAME(node, idx)					\
 	_CONCAT(_CONCAT(__sensing_sensor_info_, idx), DEVICE_DT_NAME_GET(node))
 
+/**
+ * @brief Macro to define a sensor info structure.
+ *
+ * This macro defines a sensor info structure based on a node and an index.
+ * The structure includes the type, name, friendly name, vendor, model, and minimal interval of the
+ * sensor.
+ *
+ * @param node The devicetree node identifier.
+ * @param idx Logical index into the sensor-types array.
+ */
 #define SENSING_SENSOR_INFO_DEFINE(node, idx)				\
 	const static STRUCT_SECTION_ITERABLE(sensing_sensor_info,	\
 			SENSING_SENSOR_INFO_NAME(node, idx)) = {	\
-		.type = DT_PROP_BY_IDX(node, sensor_types, idx),		\
+		.type = DT_PROP_BY_IDX(node, sensor_types, idx),	\
 		.name = DT_NODE_FULL_NAME(node),			\
 		.friendly_name = DT_PROP(node, friendly_name),		\
 		.vendor = DT_NODE_VENDOR_OR(node, NULL),		\
 		.model = DT_NODE_MODEL_OR(node, NULL),			\
-		.minimal_interval = DT_PROP(node, minimal_interval),\
+		.minimal_interval = DT_PROP(node, minimal_interval),	\
 	};
 
+/**
+ * @brief Macro to generate a name for a connections array.
+ *
+ * This macro generates a name for a connections array based on a node.
+ *
+ * @param node The devicetree node identifier.
+ */
 #define SENSING_CONNECTIONS_NAME(node)					\
 	_CONCAT(__sensing_connections_, DEVICE_DT_NAME_GET(node))
 
+/**
+ * @brief Macro to generate a name for a sensor source.
+ *
+ * This macro generates a name for a sensor source based on an index and a node.
+ *
+ * @param idx Logical index into the reporters array.
+ * @param node The devicetree node identifier.
+ */
 #define SENSING_SENSOR_SOURCE_NAME(idx, node)				\
 	SENSING_SENSOR_NAME(DT_PHANDLE_BY_IDX(node, reporters, idx),	\
 		DT_PROP_BY_IDX(node, reporters_index, idx))
 
+/**
+ * @brief Macro to declare an external sensor source.
+ *
+ * This macro declares an external sensor source based on an index and a node.
+ *
+ * @param idx Logical index into the reporters array.
+ * @param node The devicetree node identifier.
+ */
 #define SENSING_SENSOR_SOURCE_EXTERN(idx, node)				\
-extern struct sensing_sensor SENSING_SENSOR_SOURCE_NAME(idx, node);	\
+extern struct sensing_sensor SENSING_SENSOR_SOURCE_NAME(idx, node);
 
+/**
+ * @brief Macro to initialize a connection.
+ *
+ * This macro initializes a connection with a source name and a callback list pointer.
+ *
+ * @param source_name The name of struct sensing_sensor for source sensor.
+ * @param cb_list_ptr Pointer to sensing callback list.
+ */
 #define SENSING_CONNECTION_INITIALIZER(source_name, cb_list_ptr)	\
 {									\
 	.callback_list = cb_list_ptr,					\
 	.source = &source_name,						\
 }
 
+/**
+ * @brief Macro to define a connection.
+ *
+ * This macro defines a connection based on an index, a node, and a callback list pointer.
+ *
+ * @param idx Logical index into the reporters array.
+ * @param node The devicetree node identifier.
+ * @param cb_list_ptr Pointer to sensing callback list.
+ */
 #define SENSING_CONNECTION_DEFINE(idx, node, cb_list_ptr)		\
 	SENSING_CONNECTION_INITIALIZER(SENSING_SENSOR_SOURCE_NAME(idx, node), \
 				       cb_list_ptr)
 
+/**
+ * @brief Macro to define an array of connections.
+ *
+ * This macro defines an array of connections based on a node, a number, and a callback list
+ * pointer.
+ *
+ * @param node The devicetree node identifier.
+ * @param num The number of the connections.
+ * @param cb_list_ptr Pointer to sensing callback list.
+ */
 #define SENSING_CONNECTIONS_DEFINE(node, num, cb_list_ptr)		\
 	LISTIFY(num, SENSING_SENSOR_SOURCE_EXTERN,			\
 				(), node)				\
@@ -153,20 +232,56 @@ extern struct sensing_sensor SENSING_SENSOR_SOURCE_NAME(idx, node);	\
 				(,), node, cb_list_ptr)			\
 	};
 
+/**
+ * @brief Structure for sensor submit configuration.
+ *
+ * This structure represents a sensor submit configuration. It includes the channel, info index, and
+ * streaming flag.
+ */
 struct sensing_submit_config {
-	enum sensor_channel chan;
-	const int info_index;
-	const bool is_streaming;
+	enum sensor_channel chan; /**< Channel of the sensor to submit. */
+	const int info_index;     /**< Logical index into the sensor-types array. */
+	const bool is_streaming;  /**< Working in streaming mode or not. */
 };
 
+/**
+ * @brief External declaration for the sensing I/O device API.
+ *
+ * This external declaration represents the sensing I/O device API.
+ */
 extern const struct rtio_iodev_api __sensing_iodev_api;
 
+/**
+ * @brief Macro to generate a name for a submit configuration.
+ *
+ * This macro generates a name for a submit configuration based on a node and an index.
+ *
+ * @param node The devicetree node identifier.
+ * @param idx Logical index into the sensor-types array.
+ */
 #define SENSING_SUBMIT_CFG_NAME(node, idx)						\
 	_CONCAT(_CONCAT(__sensing_submit_cfg_, idx), DEVICE_DT_NAME_GET(node))
 
+/**
+ * @brief Macro to generate a name for a sensor I/O device.
+ *
+ * This macro generates a name for a sensor I/O device based on a node and an index.
+ *
+ * @param node The devicetree node identifier.
+ * @param idx Logical index into the sensor-types array.
+ */
 #define SENSING_SENSOR_IODEV_NAME(node, idx)						\
 	_CONCAT(_CONCAT(__sensing_iodev_, idx), DEVICE_DT_NAME_GET(node))
 
+/**
+ * @brief Macro to define a sensor I/O device.
+ *
+ * This macro defines a sensor I/O device based on a node and an index.
+ * The device includes a submit configuration with a streaming flag and an info index.
+ *
+ * @param node The devicetree node identifier.
+ * @param idx Logical index into the sensor-types array.
+ */
 #define SENSING_SENSOR_IODEV_DEFINE(node, idx)						\
 	static struct sensing_submit_config SENSING_SUBMIT_CFG_NAME(node, idx) = {	\
 		.is_streaming = DT_PROP(node, stream_mode),				\
@@ -176,9 +291,30 @@ extern const struct rtio_iodev_api __sensing_iodev_api;
 			  &__sensing_iodev_api,						\
 			  &SENSING_SUBMIT_CFG_NAME(node, idx));
 
+/**
+ * @brief Macro to generate a name for a sensor.
+ *
+ * This macro generates a name for a sensor based on a node and an index.
+ *
+ * @param node The devicetree node identifier.
+ * @param idx Logical index into the sensor-types array.
+ */
 #define SENSING_SENSOR_NAME(node, idx)					\
 	_CONCAT(_CONCAT(__sensing_sensor_, idx), DEVICE_DT_NAME_GET(node))
 
+/**
+ * @brief Macro to define a sensor.
+ *
+ * This macro defines a sensor based on a node, a property, an index, a register info pointer, and a
+ * callback list pointer. The sensor includes a device, info, register info, reporter number,
+ * connections, and an I/O device.
+ *
+ * @param node The devicetree node identifier.
+ * @param prop property name.
+ * @param idx Logical index into the sensor-types array.
+ * @param reg_ptr Pointer to the device's sensing_sensor_register_info.
+ * @param cb_list_ptr Pointer to sensing callback list.
+ */
 #define SENSING_SENSOR_DEFINE(node, prop, idx, reg_ptr, cb_list_ptr)	\
 	SENSING_SENSOR_INFO_DEFINE(node, idx)				\
 	SENSING_SENSOR_IODEV_DEFINE(node, idx)				\
@@ -192,9 +328,22 @@ extern const struct rtio_iodev_api __sensing_iodev_api;
 		.iodev = &SENSING_SENSOR_IODEV_NAME(node, idx),		\
 	};
 
+/**
+ * @brief Macro to define sensors.
+ *
+ * This macro defines sensors based on a node, a register info pointer, and a callback list pointer.
+ * It uses the DT_FOREACH_PROP_ELEM_VARGS macro to define each sensor.
+ *
+ * @param node The devicetree node identifier.
+ * @param reg_ptr Pointer to the device's sensing_sensor_register_info.
+ * @param cb_list_ptr Pointer to sensing callback list.
+ */
 #define SENSING_SENSORS_DEFINE(node, reg_ptr, cb_list_ptr)		\
 	DT_FOREACH_PROP_ELEM_VARGS(node, sensor_types,			\
 			SENSING_SENSOR_DEFINE, reg_ptr, cb_list_ptr)
+
+/** @endcond */
+
 /**
  * @brief Like SENSOR_DEVICE_DT_DEFINE() with sensing specifics.
  *
@@ -203,26 +352,17 @@ extern const struct rtio_iodev_api __sensing_iodev_api;
  * sensors.
  *
  * @param node The devicetree node identifier.
- *
  * @param reg_ptr Pointer to the device's sensing_sensor_register_info.
- *
- * @param cb_list_ptr Pointer to devices callback list.
- *
+ * @param cb_list_ptr Pointer to sensing callback list.
  * @param init_fn Name of the init function of the driver.
- *
  * @param pm_device PM device resources reference (NULL if device does not use
  * PM).
- *
  * @param data_ptr Pointer to the device's private data.
- *
  * @param cfg_ptr The address to the structure containing the configuration
  * information for this instance of the driver.
- *
  * @param level The initialization level. See SYS_INIT() for details.
- *
  * @param prio Priority within the selected initialization level. See
  * SYS_INIT() for details.
- *
  * @param api_ptr Provides an initial pointer to the API function struct used
  * by the driver. Can be NULL.
  */
@@ -244,7 +384,6 @@ extern const struct rtio_iodev_api __sensing_iodev_api;
  *
  * @param inst instance number. This is replaced by
  * <tt>DT_DRV_COMPAT(inst)</tt> in the call to SENSING_SENSORS_DT_DEFINE().
- *
  * @param ... other parameters as expected by SENSING_SENSORS_DT_DEFINE().
  */
 #define SENSING_SENSORS_DT_INST_DEFINE(inst, ...)	\
@@ -254,16 +393,12 @@ extern const struct rtio_iodev_api __sensing_iodev_api;
  * @brief Get reporter handles	of a given sensor instance by sensor type.
  *
  * @param dev The sensor instance device structure.
- *
  * @param type The given type, \ref SENSING_SENSOR_TYPE_ALL to get reporters
  * with all types.
- *
  * @param max_handles The max count of the \p reporter_handles array input. Can
  * get real count number via \ref sensing_sensor_get_reporters_count
- *
  * @param reporter_handles Input handles array for receiving found reporter
  * sensor instances
- *
  * @return number of reporters found, 0 returned if not found.
  */
 int sensing_sensor_get_reporters(
@@ -274,9 +409,7 @@ int sensing_sensor_get_reporters(
  * @brief Get reporters count of a given sensor instance by sensor type.
  *
  * @param dev The sensor instance device structure.
- *
  * @param type The sensor type for checking, \ref SENSING_SENSOR_TYPE_ALL
- *
  * @return Count of reporters by \p type, 0 returned if no reporters by \p type.
  */
 int sensing_sensor_get_reporters_count(
@@ -286,9 +419,7 @@ int sensing_sensor_get_reporters_count(
  * @brief Get this sensor's state
  *
  * @param dev The sensor instance device structure.
- *
  * @param state Returned sensor state value
- *
  * @return 0 on success or negative error value on failure.
  */
 int sensing_sensor_get_state(

--- a/include/zephyr/sensing/sensing_sensor_types.h
+++ b/include/zephyr/sensing/sensing_sensor_types.h
@@ -27,8 +27,11 @@
 /**
  * sensor category motion
  */
+/* Sensor type for 3D accelerometers. */
 #define SENSING_SENSOR_TYPE_MOTION_ACCELEROMETER_3D		0x73
+/* Sensor type for 3D gyrometers. */
 #define SENSING_SENSOR_TYPE_MOTION_GYROMETER_3D			0x76
+/* Sensor type for motion detectors. */
 #define SENSING_SENSOR_TYPE_MOTION_MOTION_DETECTOR		0x77
 
 
@@ -37,10 +40,16 @@
  */
 #define SENSING_SENSOR_TYPE_OTHER_CUSTOM			0xE1
 
+/* Sensor type for uncalibrated 3D accelerometers. */
 #define SENSING_SENSOR_TYPE_MOTION_UNCALIB_ACCELEROMETER_3D	0x240
-
+/* Sensor type for hinge angle sensors. */
 #define SENSING_SENSOR_TYPE_MOTION_HINGE_ANGLE			0x20B
 
+/**
+ * @brief Sensor type for all sensors.
+ *
+ * This macro defines the sensor type for all sensors.
+ */
 #define SENSING_SENSOR_TYPE_ALL					0xFFFF
 
 /**


### PR DESCRIPTION
Add missing parameter information in `sensing_data_event_t`.