### PR TITLE
drivers: serial: Fix async to interrupt driven adaptation layer

### DIFF
--- a/drivers/serial/uart_async_to_irq.c
+++ b/drivers/serial/uart_async_to_irq.c
@@ -105,12 +105,15 @@ static void on_rx_buf_req(const struct device *dev,
 static void on_rx_dis(const struct device *dev, struct uart_async_to_irq_data *data)
 {
 	if (data->flags & A2I_RX_ENABLE) {
-		data->rx.pending_buf_req = 0;
+		int err;
 
-		int err = try_rx_enable(dev, data);
+		err = try_rx_enable(dev, data);
+		if (err == 0) {
+			data->rx.pending_buf_req = 0;
+		}
 
 		LOG_INST_DBG(get_config(dev)->log, "Reenabling RX from RX_DISABLED (err:%d)", err);
-		__ASSERT_NO_MSG(err >= 0);
+		__ASSERT((err >= 0) || (err == -EBUSY), "err: %d", err);
 		return;
 	}
 


### PR DESCRIPTION
Whenever UART_RX_DISABLED event is received module attempts to re-enable receiver since in interrupt driven API receiver is always on. However, it is possible that there is no free buffers and in that case attempt to enable the receiver will fail with -EBUSY. That scenario shall be accepted since the receiver will be re-enabled when at least one buffer will be freed.

Given that, -EBUSY return shall be accepted (no assert) and number of pending RX buffer requests shall be reset only on successful enabling.