### PR TITLE
boards: xtensa: qemu_xtensa: Convert to v2

### DIFF
--- a/boards/v2/qemu/qemu_xtensa/Kconfig.qemu_xtensa
+++ b/boards/v2/qemu/qemu_xtensa/Kconfig.qemu_xtensa
@@ -4,6 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_QEMU_XTENSA
-	select QEMU_TARGET
-	select ARCH_SUPPORTS_COREDUMP
-	select XTENSA_MMU if BOARD_QEMU_XTENSA_DC233C_MMU
+	select SOC_XTENSA_DC233C


### PR DESCRIPTION
Converts the board to hwmv2.

This commit is a followup to commit
86d612086ee15b6715522ea453f0aabf78fad140