### PR TITLE
net:gptp: Fix double converted byte order of BMCA info steps_removed …

### DIFF
--- a/subsys/net/l2/ethernet/gptp/gptp_mi.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_mi.c
@@ -1701,7 +1701,7 @@ static int compute_best_vector(void)
 		}
 
 		global_ds->gm_priority.steps_removed =
-			htons(ntohs(best_vector->steps_removed) + 1);
+			ntohs(best_vector->steps_removed) + 1;
 
 		if (&global_ds->gm_priority.src_port_id !=
 		    &best_vector->src_port_id) {


### PR DESCRIPTION
…in gptp_mi.c within the gptp module

Fixes #68320