### PR TITLE
ci: update to osource for soc/Kconfig.defconfig files

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -419,7 +419,7 @@ class KconfigCheck(ComplianceTest):
 
         with open(kconfig_defconfig_file, 'w') as fp:
             for soc in v2_systems.get_socs():
-                fp.write('source "' + os.path.join(soc.folder, 'Kconfig.defconfig') + '"\n')
+                fp.write('osource "' + os.path.join(soc.folder, 'Kconfig.defconfig') + '"\n')
 
         with open(kconfig_soc_file, 'w') as fp:
             for soc in v2_systems.get_socs():


### PR DESCRIPTION
This commit aligns check_compliance to use osource for SoC Kconfig.defconfig, as that is also the rule for the Kconfig tree in Zephyr itself.