### PR TITLE
Bluetooth: BAP: Update log for unicast iso recv without endpoint

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -853,7 +853,8 @@ static void ascs_iso_recv(struct bt_iso_chan *chan,
 		 * host as HCI ISO data packets, which we should just ignore
 		 */
 		if ((info->flags & BT_ISO_FLAGS_VALID) != 0) {
-			LOG_ERR("iso %p not bound with ep", chan);
+			LOG_DBG("Valid ISO packet of len %zu received for iso %p not bound with ep",
+				net_buf_frags_len(buf), chan);
 		}
 
 		return;

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -231,7 +231,8 @@ static void unicast_client_ep_iso_recv(struct bt_iso_chan *chan,
 		 * host as HCI ISO data packets, which we should just ignore
 		 */
 		if ((info->flags & BT_ISO_FLAGS_VALID) != 0) {
-			LOG_ERR("iso %p not bound with ep", chan);
+			LOG_DBG("Valid ISO packet of len %zu received for iso %p not bound with ep",
+				net_buf_frags_len(buf), chan);
 		}
 
 		return;


### PR DESCRIPTION
Since we always set up the ISO data path for endpoints in both directions (due to limitations in the ISO API), we can actually receive valid (empty) SDUs on a CIS in a direction that has not been configured.

This is not the ideal solution, but prevents unncessary LOG_ERR. The ideal solution is to modify the ISO API to provide the flexibility that BAP needs w.r.t. ISO data paths, but that is a larger change for later.