### PR TITLE
soc: arm: nordic_nrf: Clean up and unify a bit cmake code

### DIFF
--- a/soc/arm/nordic_nrf/CMakeLists.txt
+++ b/soc/arm/nordic_nrf/CMakeLists.txt
@@ -1,9 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
+zephyr_library()
+
 add_subdirectory(${SOC_SERIES})
 add_subdirectory(common)
 
-zephyr_sources(
+zephyr_library_sources(
   validate_base_addresses.c
   validate_enabled_instances.c
   )

--- a/soc/arm/nordic_nrf/common/CMakeLists.txt
+++ b/soc/arm/nordic_nrf/common/CMakeLists.txt
@@ -3,10 +3,13 @@
 
 zephyr_library_sources_ifdef(CONFIG_SOC_FAMILY_NRF soc_nrf_common.S)
 zephyr_library_sources_ifdef(CONFIG_POWEROFF poweroff.c)
+
 zephyr_include_directories(.)
 
+set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/linker.ld CACHE INTERNAL "")
+
 if (CONFIG_TFM_PARTITION_PLATFORM)
-  zephyr_sources(soc_secure.c)
+  zephyr_library_sources(soc_secure.c)
   zephyr_library_include_directories(
     $<TARGET_PROPERTY:tfm,TFM_BINARY_DIR>/api_ns/interface/include
   )

--- a/soc/arm/nordic_nrf/nrf51/CMakeLists.txt
+++ b/soc/arm/nordic_nrf/nrf51/CMakeLists.txt
@@ -1,14 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
-zephyr_library_sources(
-  soc.c
-  )
-
-zephyr_library_include_directories(
-  ${ZEPHYR_BASE}/kernel/include
-  ${ZEPHYR_BASE}/arch/arm/include
-  )
-
-set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/linker.ld CACHE INTERNAL "")
+zephyr_library_sources(soc.c)

--- a/soc/arm/nordic_nrf/nrf52/CMakeLists.txt
+++ b/soc/arm/nordic_nrf/nrf52/CMakeLists.txt
@@ -1,15 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
-zephyr_library_sources(
-  soc.c
-  )
-
-zephyr_library_include_directories(
-  ${ZEPHYR_BASE}/kernel/include
-  ${ZEPHYR_BASE}/arch/arm/include
-  )
+zephyr_library_sources(soc.c)
 
 if(CONFIG_SOC_NRF52832_ALLOW_SPIM_DESPITE_PAN_58 AND CONFIG_SPI_NRFX_SPIM)
   message(WARNING "Both SOC_NRF52832_ALLOW_SPIM_DESPITE_PAN_58 and an NRF SPIM driver are enabled, therefore PAN 58 will apply if RXD.MAXCNT == 1 and TXD.MAXCNT <= 1")
@@ -22,5 +13,3 @@ if(CONFIG_SOC_NRF52832)
     endif()
   endif()
 endif()
-
-set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/linker.ld CACHE INTERNAL "")

--- a/soc/arm/nordic_nrf/nrf53/CMakeLists.txt
+++ b/soc/arm/nordic_nrf/nrf53/CMakeLists.txt
@@ -1,12 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_sources(
-  soc.c
-  )
+zephyr_library_sources(soc.c)
 
-zephyr_library_sources_ifdef(CONFIG_NRF53_SYNC_RTC
-  sync_rtc.c
-  )
+zephyr_library_sources_ifdef(CONFIG_NRF53_SYNC_RTC sync_rtc.c)
 
 if (CONFIG_SOC_NRF53_ANOMALY_160_WORKAROUND_NEEDED AND
     NOT CONFIG_SYS_CLOCK_EXISTS)
@@ -19,5 +15,3 @@ if (CONFIG_SOC_NRF53_ANOMALY_160_WORKAROUND_NEEDED AND
     At your own risk, you can suppress this warning by setting
     CONFIG_SOC_NRF53_ANOMALY_160_WORKAROUND_NEEDED=n.")
 endif()
-
-set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/linker.ld CACHE INTERNAL "")

--- a/soc/arm/nordic_nrf/nrf54l/CMakeLists.txt
+++ b/soc/arm/nordic_nrf/nrf54l/CMakeLists.txt
@@ -1,11 +1,9 @@
 # Copyright (c) 2024 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_sources(
+zephyr_library_sources(
   soc.c
   ../validate_rram_partitions.c)
-
-set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/linker.ld CACHE INTERNAL "")
 
 if (CONFIG_ELV_GRTC_LFXO_ALLOWED)
   message(WARNING "WARNING! ELV mode feature is EXPERIMENTAL and may brick your device!")

--- a/soc/arm/nordic_nrf/nrf91/CMakeLists.txt
+++ b/soc/arm/nordic_nrf/nrf91/CMakeLists.txt
@@ -1,7 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_sources(
-  soc.c
-  )
-
-set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/linker.ld CACHE INTERNAL "")
+zephyr_library_sources(soc.c)


### PR DESCRIPTION
Consistently use `zephyr_library*` cmake functions for all nRF Series and set the Cortex-M linker script in a common place for all of them. Remove no longer needed include directories.