### PR TITLE
ci: codecov: stick with gcovr 6.0 for now

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -89,7 +89,7 @@ jobs:
           export ZEPHYR_BASE=${PWD}
           export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
           mkdir -p coverage/reports
-          pip3 install gcovr
+          pip3 install gcovr==6.0
           ./scripts/twister -i --force-color -N -v --filter runnable -p ${{ matrix.platform }} --coverage -T tests --coverage-tool gcovr -xCONFIG_TEST_EXTRA_STACK_SIZE=4096 -e nano
 
       - name: ccache stats post


### PR DESCRIPTION
gcovr 7.0 has some incompatible format, stick with 6.0 for now until we
have a compatible solution with gcovr 7.0 output.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
