### PR TITLE
tests: dma: fix DT node label, avoid conflicts

### DIFF
--- a/drivers/dma/dma_andes_atcdmac300.c
+++ b/drivers/dma/dma_andes_atcdmac300.c
@@ -11,7 +11,6 @@
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 #include <zephyr/drivers/dma.h>
-#include <soc.h>
 
 #define DT_DRV_COMPAT andestech_atcdmac300
 

--- a/tests/drivers/dma/chan_blen_transfer/boards/adafruit_itsybitsy_m4_express.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/adafruit_itsybitsy_m4_express.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dmac { };
+tst_dma0: &dmac { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/adafruit_trinket_m0.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/adafruit_trinket_m0.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dmac { };
+tst_dma0: &dmac { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/adp_xc7k_ae350.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/adp_xc7k_ae350.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma0 {
+tst_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/chan_blen_transfer/boards/arduino_mkrzero.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/arduino_mkrzero.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dmac { };
+tst_dma0: &dmac { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/arduino_nano_33_iot.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/arduino_nano_33_iot.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dmac { };
+tst_dma0: &dmac { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/arduino_zero.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/arduino_zero.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dmac { };
+tst_dma0: &dmac { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/atsamc21n_xpro.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/atsamc21n_xpro.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dmac { };
+tst_dma0: &dmac { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/atsamd21_xpro.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/atsamd21_xpro.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dmac { };
+tst_dma0: &dmac { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/atsaml21_xpro.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/atsaml21_xpro.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dmac { };
+tst_dma0: &dmac { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/atsamr34_xpro.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/atsamr34_xpro.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dmac { };
+tst_dma0: &dmac { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/b_u585i_iot02a.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/b_u585i_iot02a.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &gpdma1 {
+tst_dma0: &gpdma1 {
 	status = "okay";
 };

--- a/tests/drivers/dma/chan_blen_transfer/boards/da1469x_dk_pro.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/da1469x_dk_pro.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
- test_dma0: &dma {
+ tst_dma0: &dma {
 	status = "okay";
 };

--- a/tests/drivers/dma/chan_blen_transfer/boards/disco_l475_iot1.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/disco_l475_iot1.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma1 { };
+tst_dma0: &dma1 { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/esp32c3_devkitm.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/esp32c3_devkitm.overlay
@@ -8,4 +8,4 @@
 	status = "okay";
 };
 
-test_dma0: &dma { };
+tst_dma0: &dma { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/esp32c3_luatos_core.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/esp32c3_luatos_core.overlay
@@ -8,4 +8,4 @@
 	status = "okay";
 };
 
-test_dma0: &dma { };
+tst_dma0: &dma { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/esp32c3_luatos_core_usb.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/esp32c3_luatos_core_usb.overlay
@@ -8,4 +8,4 @@
 	status = "okay";
 };
 
-test_dma0: &dma { };
+tst_dma0: &dma { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/esp32s3_devkitm.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/esp32s3_devkitm.overlay
@@ -8,4 +8,4 @@
 	status = "okay";
 };
 
-test_dma0: &dma { };
+tst_dma0: &dma { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/esp32s3_luatos_core.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/esp32s3_luatos_core.overlay
@@ -8,4 +8,4 @@
 	status = "okay";
 };
 
-test_dma0: &dma { };
+tst_dma0: &dma { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/esp32s3_luatos_core_usb.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/esp32s3_luatos_core_usb.overlay
@@ -8,4 +8,4 @@
 	status = "okay";
 };
 
-test_dma0: &dma { };
+tst_dma0: &dma { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/frdm_k64f.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/frdm_k64f.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &edma0 { };
+tst_dma0: &edma0 { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/intel_adsp_cavs25.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/intel_adsp_cavs25.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &lpgpdma0 { };
+tst_dma0: &lpgpdma0 { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/intel_adsp_cavs25_tgph.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/intel_adsp_cavs25_tgph.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &lpgpdma0 { };
+tst_dma0: &lpgpdma0 { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/lpcxpresso55s36.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/lpcxpresso55s36.overlay
@@ -1,1 +1,1 @@
-test_dma0: &dma0 { };
+tst_dma0: &dma0 { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/lpcxpresso55s69_ns.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/lpcxpresso55s69_ns.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma0 { };
+tst_dma0: &dma0 { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/mec172xevb_assy6906.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/mec172xevb_assy6906.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma: &dmac {
+tst_dma: &dmac {
 	status = "okay";
 };

--- a/tests/drivers/dma/chan_blen_transfer/boards/mimxrt1024_evk.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/mimxrt1024_evk.overlay
@@ -11,4 +11,4 @@
 	zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE) )>;
 };
 
-test_dma0: &edma0 { };
+tst_dma0: &edma0 { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/mimxrt1050_evk.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/mimxrt1050_evk.overlay
@@ -11,4 +11,4 @@
 	zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE) )>;
 };
 
-test_dma0: &edma0 { };
+tst_dma0: &edma0 { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/mimxrt1060_evk.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/mimxrt1060_evk.overlay
@@ -11,4 +11,4 @@
 	zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE) )>;
 };
 
-test_dma0: &edma0 { };
+tst_dma0: &edma0 { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/mimxrt1060_evkb.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/mimxrt1060_evkb.overlay
@@ -11,4 +11,4 @@
 	zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE) )>;
 };
 
-test_dma0: &edma0 { };
+tst_dma0: &edma0 { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/mimxrt1064_evk.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/mimxrt1064_evk.overlay
@@ -11,4 +11,4 @@
 	zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE) )>;
 };
 
-test_dma0: &edma0 { };
+tst_dma0: &edma0 { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/mimxrt1160_evk_cm4.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/mimxrt1160_evk_cm4.overlay
@@ -11,4 +11,4 @@
 	zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE) )>;
 };
 
-test_dma0: &edma_lpsr0 { };
+tst_dma0: &edma_lpsr0 { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/mimxrt1160_evk_cm7.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/mimxrt1160_evk_cm7.overlay
@@ -11,4 +11,4 @@
 	zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE) )>;
 };
 
-test_dma0: &edma0 { };
+tst_dma0: &edma0 { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/mimxrt1170_evk_cm4.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/mimxrt1170_evk_cm4.overlay
@@ -11,4 +11,4 @@
 	zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE) )>;
 };
 
-test_dma0: &edma_lpsr0 { };
+tst_dma0: &edma_lpsr0 { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/mimxrt1170_evk_cm7.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/mimxrt1170_evk_cm7.overlay
@@ -11,4 +11,4 @@
 	zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE) )>;
 };
 
-test_dma0: &edma0 { };
+tst_dma0: &edma0 { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/mimxrt1170_evkb_cm4.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/mimxrt1170_evkb_cm4.overlay
@@ -11,4 +11,4 @@
 	zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE) )>;
 };
 
-test_dma0: &edma_lpsr0 { };
+tst_dma0: &edma_lpsr0 { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/mimxrt595_evk_cm33.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/mimxrt595_evk_cm33.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma0 { };
+tst_dma0: &dma0 { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/mimxrt685_evk_cm33.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/mimxrt685_evk_cm33.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma0 { };
+tst_dma0: &dma0 { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/mm_feather.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/mm_feather.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &edma0 { };
+tst_dma0: &edma0 { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/mr_canhubk3.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/mr_canhubk3.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &edma0 { };
+tst_dma0: &edma0 { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/native_posix.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/native_posix.overlay
@@ -9,4 +9,4 @@
 	status = "okay";
 };
 
-test_dma0: &dma { };
+tst_dma0: &dma { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/native_posix_64.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/native_posix_64.overlay
@@ -9,4 +9,4 @@
 	status = "okay";
 };
 
-test_dma0: &dma { };
+tst_dma0: &dma { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_c031c6.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_c031c6.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma1 {
+tst_dma0: &dma1 {
 	status = "okay";
 };

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_f070rb.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_f070rb.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma1 {
+tst_dma0: &dma1 {
 	status = "okay";
 };

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_f091rc.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_f091rc.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma1 { };
+tst_dma0: &dma1 { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_f103rb.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_f103rb.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma1 { };
+tst_dma0: &dma1 { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_f207zg.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_f207zg.overlay
@@ -8,6 +8,6 @@
 	status = "okay";
 };
 
-test_dma0: &dma2 {
+tst_dma0: &dma2 {
 	status = "okay";
 };

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_f429zi.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_f429zi.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma2 { };
+tst_dma0: &dma2 { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_f746zg.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_f746zg.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma2 { };
+tst_dma0: &dma2 { };
 
 /* The test driver expects the SRAM0 region to be non-cachable */
 &sram0 {

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_f767zi.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_f767zi.overlay
@@ -8,7 +8,7 @@
 	status = "okay";
 };
 
-test_dma0: &dma2 {
+tst_dma0: &dma2 {
 	status = "okay";
 };
 

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_g071rb.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_g071rb.overlay
@@ -8,6 +8,6 @@
 	status = "okay";
 };
 
-test_dma0: &dmamux1 {
+tst_dma0: &dmamux1 {
 	status = "okay";
 };

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_g0b1re.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_g0b1re.overlay
@@ -12,6 +12,6 @@
 	status = "okay";
 };
 
-test_dma0: &dmamux1 {
+tst_dma0: &dmamux1 {
 	status = "okay";
 };

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_g474re.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_g474re.overlay
@@ -12,6 +12,6 @@
 	status = "okay";
 };
 
-test_dma0: &dmamux1 {
+tst_dma0: &dmamux1 {
 	status = "okay";
 };

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_h743zi.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_h743zi.overlay
@@ -12,7 +12,7 @@
 	status = "okay";
 };
 
-test_dma0: &dmamux1 {
+tst_dma0: &dmamux1 {
 	status = "okay";
 };
 
@@ -27,6 +27,6 @@ test_dma0: &dmamux1 {
 	status = "okay";
 };
 
-test_dma1: &dmamux2 {
+tst_dma1: &dmamux2 {
 	status = "okay";
 };

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_l053r8.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_l053r8.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma1 {
+tst_dma0: &dma1 {
 	status = "okay";
 };

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_l152re.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_l152re.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma1 { };
+tst_dma0: &dma1 { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_l476rg.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_l476rg.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma1 {
+tst_dma0: &dma1 {
 	status = "okay";
 };
 

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_l496zg.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_l496zg.overlay
@@ -8,6 +8,6 @@
 	status = "okay";
 };
 
-test_dma0: &dma2 {
+tst_dma0: &dma2 {
 	status = "okay";
 };

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_l552ze_q.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_l552ze_q.overlay
@@ -12,6 +12,6 @@
 	status = "okay";
 };
 
-test_dma0: &dmamux1 {
+tst_dma0: &dmamux1 {
 	status = "okay";
 };

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_u575zi_q.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_u575zi_q.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &gpdma1 {
+tst_dma0: &gpdma1 {
 	status = "okay";
 };

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_wb55rg.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_wb55rg.overlay
@@ -12,6 +12,6 @@
 	status = "okay";
 };
 
-test_dma0: &dmamux1 {
+tst_dma0: &dmamux1 {
 	status = "okay";
 };

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_wl55jc.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_wl55jc.overlay
@@ -12,6 +12,6 @@
 	status = "okay";
 };
 
-test_dma0: &dmamux1 {
+tst_dma0: &dmamux1 {
 	status = "okay";
 };

--- a/tests/drivers/dma/chan_blen_transfer/boards/seeeduino_xiao.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/seeeduino_xiao.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dmac { };
+tst_dma0: &dmac { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/stm32f3_disco.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/stm32f3_disco.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma1 { };
+tst_dma0: &dma1 { };

--- a/tests/drivers/dma/chan_blen_transfer/boards/stm32g0316_disco.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/stm32g0316_disco.overlay
@@ -8,6 +8,6 @@
 	status = "okay";
 };
 
-test_dma0: &dmamux1 {
+tst_dma0: &dmamux1 {
 	status = "okay";
 };

--- a/tests/drivers/dma/chan_blen_transfer/boards/stm32h573i_dk.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/stm32h573i_dk.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &gpdma1 {
+tst_dma0: &gpdma1 {
 	status = "okay";
 };

--- a/tests/drivers/dma/chan_blen_transfer/boards/stm32l562e_dk.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/stm32l562e_dk.overlay
@@ -12,6 +12,6 @@
 	status = "okay";
 };
 
-test_dma0: &dmamux1 {
+tst_dma0: &dmamux1 {
 	status = "okay";
 };

--- a/tests/drivers/dma/chan_blen_transfer/boards/stm32mp157c_dk2.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/stm32mp157c_dk2.overlay
@@ -10,6 +10,6 @@
 	status = "okay";
 };
 
-test_dma0: &dmamux {
+tst_dma0: &dmamux {
 	status = "okay";
 };

--- a/tests/drivers/dma/chan_blen_transfer/boards/twr_ke18f.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/twr_ke18f.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &edma { };
+tst_dma0: &edma { };

--- a/tests/drivers/dma/chan_blen_transfer/src/test_dma.c
+++ b/tests/drivers/dma/chan_blen_transfer/src/test_dma.c
@@ -91,7 +91,7 @@ static int test_task(const struct device *dma, uint32_t chan_id, uint32_t blen)
 	return TC_PASS;
 }
 
-#define DMA_NAME(i, _) test_dma##i
+#define DMA_NAME(i, _) tst_dma##i
 #define DMA_LIST       LISTIFY(CONFIG_DMA_LOOP_TRANSFER_NUMBER_OF_DMAS, DMA_NAME, (,))
 
 #if CONFIG_DMA_TRANSFER_BURST16

--- a/tests/drivers/dma/chan_blen_transfer/testcase.yaml
+++ b/tests/drivers/dma/chan_blen_transfer/testcase.yaml
@@ -8,13 +8,13 @@ tests:
     integration_platforms:
       - native_posix
       - native_posix_64
-    filter: dt_nodelabel_enabled("test_dma0")
+    filter: dt_nodelabel_enabled("tst_dma0")
   drivers.dma.chan_blen_transfer.low_footprint:
     tags:
       - dma
     min_ram: 12
     depends_on:
       - dma
-    filter: dt_nodelabel_enabled("test_dma0")
+    filter: dt_nodelabel_enabled("tst_dma0")
     platform_allow:
       - nucleo_c031c6


### PR DESCRIPTION
Simple rename of node label from test_dma to tst_dma to avoid conflicts
and confusion about the test_ prefix when parsing test results in
twister.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
