### PR TITLE
Bluetooth: Controller: Fix handling of CTEInfo in le_ext_adv_report()

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -7002,6 +7002,11 @@ static void le_ext_adv_report(struct pdu_data *pdu_data,
 			ptr += BDADDR_SIZE;
 		}
 
+		if (h->cte_info) {
+			/* CTEInfo is RFU */
+			ptr += 1;
+		}
+
 		if (h->adi) {
 			adi_curr = (void *)ptr;
 


### PR DESCRIPTION
Handling of CTEInfo being present was missing; Fixes test failure of LL/DDI/SCN/BV-89-C