### PR TITLE
tests: posis/fs: close only valid descriptor

### DIFF
--- a/tests/posix/fs/src/test_fs_open_flags.c
+++ b/tests/posix/fs/src/test_fs_open_flags.c
@@ -22,7 +22,9 @@ static int test_file_open_flags(void)
 	fd = open(THE_FILE, 0);
 	if (fd >= 0 || errno != ENOENT) {
 		TC_PRINT("Expected fail; fd = %d, errno = %d\n", fd, errno);
-		close(fd);
+		if (fd >= 0) {
+			close(fd);
+		}
 		return TC_FAIL;
 	}
 
@@ -30,14 +32,18 @@ static int test_file_open_flags(void)
 	fd = open(THE_FILE, O_RDONLY);
 	if (fd >= 0 || errno != ENOENT) {
 		TC_PRINT("Expected fail; fd = %d, errno = %d\n", fd, errno);
-		close(fd);
+		if (fd >= 0) {
+			close(fd);
+		}
 		return TC_FAIL;
 	}
 	TC_PRINT("Open on non-existent file, flags = O_WRONLY\n");
 	fd = open(THE_FILE, O_WRONLY);
 	if (fd >= 0 || errno != ENOENT) {
 		TC_PRINT("Expected fail; fd = %d, errno = %d\n", fd, errno);
-		close(fd);
+		if (fd >= 0) {
+			close(fd);
+		}
 		return TC_FAIL;
 	}
 
@@ -45,7 +51,9 @@ static int test_file_open_flags(void)
 	fd = open(THE_FILE, O_RDWR);
 	if (fd >= 0 || errno != ENOENT) {
 		TC_PRINT("Expected fail; fd = %d, errno = %d\n", fd, errno);
-		close(fd);
+		if (fd >= 0) {
+			close(fd);
+		}
 		return TC_FAIL;
 	}
 	/* end 1 */


### PR DESCRIPTION
Only call close() if open() has not returned a negative value.

Fixes CID 211585