### PR TITLE
samples: modules: lvgl: add keypad and encoder demo

### DIFF
--- a/samples/modules/lvgl/demos/CMakeLists.txt
+++ b/samples/modules/lvgl/demos/CMakeLists.txt
@@ -88,3 +88,7 @@ target_sources_ifdef(CONFIG_LV_USE_DEMO_WIDGETS app PRIVATE
     ${LVGL_DIR}/demos/widgets/assets/img_lvgl_logo.c
     ${LVGL_DIR}/demos/widgets/lv_demo_widgets.c
 )
+
+target_sources_ifdef(CONFIG_LV_USE_DEMO_KEYPAD_AND_ENCODER app PRIVATE
+    ${LVGL_DIR}/demos/keypad_encoder/lv_demo_keypad_encoder.c
+)

--- a/samples/modules/lvgl/demos/Kconfig
+++ b/samples/modules/lvgl/demos/Kconfig
@@ -31,6 +31,12 @@ config LV_Z_DEMO_WIDGETS
 	help
 	  Build stress testing demo application.
 
+config LV_Z_DEMO_KEYPAD_AND_ENCODER
+	bool "LVGL keypad and encoder demo"
+	select LV_USE_DEMO_KEYPAD_AND_ENCODER
+	help
+	  Build keypad and encoder demo application.
+
 endchoice
 
 source "Kconfig.zephyr"

--- a/samples/modules/lvgl/demos/README.rst
+++ b/samples/modules/lvgl/demos/README.rst
@@ -17,6 +17,8 @@ A sample showcasing upstream LVGL demos.
       A stress test for LVGL. It contains a lot of object creation, deletion, animations, styles usage, and so on. It can be used if there is any memory corruption during heavy usage or any memory leaks.
 * Widgets
       Shows how the widgets look like out of the box using the built-in material theme.
+* Keypad and encoder
+      Sample for keypad and encoder inputs
 
 Requirements
 ************
@@ -57,5 +59,13 @@ These demos can be built as follows:
    :host-os: unix
    :board: native_sim
    :gen-args: -DCONFIG_LV_Z_DEMO_WIDGETS=y
+   :goals: run
+   :compact:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/modules/lvgl/demos
+   :host-os: unix
+   :board: native_sim
+   :gen-args: -DCONFIG_LV_Z_DEMO_KEYPAD_AND_ENCODER=y
    :goals: run
    :compact:

--- a/samples/modules/lvgl/demos/sample.yaml
+++ b/samples/modules/lvgl/demos/sample.yaml
@@ -21,6 +21,9 @@ tests:
   sample.modules.lvgl.demo_stress:
     extra_configs:
       - CONFIG_LV_Z_DEMO_STRESS=y
+  sample.modules.lvgl.demo_keypad_encoder:
+    extra_configs:
+      - CONFIG_LV_Z_DEMO_KEYPAD_AND_ENCODER=y
   sample.modules.lvgl.demos.st_b_lcd40_dsi1_mb1166:
     platform_allow: stm32h747i_disco_m7
     extra_args: SHIELD=st_b_lcd40_dsi1_mb1166

--- a/samples/modules/lvgl/demos/src/main.c
+++ b/samples/modules/lvgl/demos/src/main.c
@@ -31,6 +31,8 @@ int main(void)
 	lv_demo_stress();
 #elif defined(CONFIG_LV_USE_DEMO_WIDGETS)
 	lv_demo_widgets();
+#elif defined(CONFIG_LV_USE_DEMO_KEYPAD_AND_ENCODER)
+	lv_demo_keypad_encoder();
 #else
 #error Enable one of the demos CONFIG_LV_USE_DEMO_MUSIC, CONFIG_LV_USE_DEMO_BENCHMARK ,\
 	CONFIG_LV_USE_DEMO_STRESS, or CONFIG_LV_USE_DEMO_WIDGETS


### PR DESCRIPTION
Adds the LVGL keypad and encoder demo to sample build.