### PR TITLE
drivers: can: fake: use delegate for reporting core clock rate

### DIFF
--- a/drivers/can/can_fake.c
+++ b/drivers/can/can_fake.c
@@ -54,6 +54,17 @@ DEFINE_FAKE_VOID_FUNC(fake_can_set_state_change_callback, const struct device *,
 
 DEFINE_FAKE_VALUE_FUNC(int, fake_can_get_max_filters, const struct device *, bool);
 
+DEFINE_FAKE_VALUE_FUNC(int, fake_can_get_core_clock, const struct device *, uint32_t *);
+
+static int fake_can_get_core_clock_delegate(const struct device *dev, uint32_t *rate)
+{
+	ARG_UNUSED(dev);
+
+	*rate = 16000000;
+
+	return 0;
+}
+
 #ifdef CONFIG_ZTEST
 static void fake_can_reset_rule_before(const struct ztest_unit_test *test, void *fixture)
 {
@@ -73,19 +84,14 @@ static void fake_can_reset_rule_before(const struct ztest_unit_test *test, void 
 	RESET_FAKE(fake_can_recover);
 	RESET_FAKE(fake_can_set_state_change_callback);
 	RESET_FAKE(fake_can_get_max_filters);
+	RESET_FAKE(fake_can_get_core_clock);
+
+	/* Re-install default delegate for reporting the core clock */
+	fake_can_get_core_clock_fake.custom_fake = fake_can_get_core_clock_delegate;
 }
 
 ZTEST_RULE(fake_can_reset_rule, fake_can_reset_rule_before, NULL);
 #endif /* CONFIG_ZTEST */
-
-static int fake_can_get_core_clock(const struct device *dev, uint32_t *rate)
-{
-	ARG_UNUSED(dev);
-
-	*rate = 16000000;
-
-	return 0;
-}
 
 static const struct can_driver_api fake_can_driver_api = {
 	.start = fake_can_start,

--- a/include/zephyr/drivers/can/can_fake.h
+++ b/include/zephyr/drivers/can/can_fake.h
@@ -45,6 +45,8 @@ DECLARE_FAKE_VOID_FUNC(fake_can_set_state_change_callback, const struct device *
 
 DECLARE_FAKE_VALUE_FUNC(int, fake_can_get_max_filters, const struct device *, bool);
 
+DECLARE_FAKE_VALUE_FUNC(int, fake_can_get_core_clock, const struct device *, uint32_t *);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/drivers/can/shell/src/main.c
+++ b/tests/drivers/can/shell/src/main.c
@@ -120,6 +120,8 @@ ZTEST(can_shell, test_can_show)
 	zassert_equal(fake_can_get_capabilities_fake.call_count, 1,
 		      "get_capabilities function not called");
 	zassert_equal(fake_can_get_state_fake.call_count, 1, "get_state function not called");
+	zassert_equal(fake_can_get_core_clock_fake.call_count, 1,
+		      "get_core_clock function not called");
 }
 
 ZTEST(can_shell, test_can_bitrate_missing_value)


### PR DESCRIPTION
- Use a delegate for reporting the core clock rate of the fake CAN driver. This allows overriding the delegate at run-time and inspecting its call count.
- Verify the call count of `can_get_core_clock()` after executing "can show" shell subcommand.