### PR TITLE
doc: posix: mark sched_getscheduler and getparam  as supported

### DIFF
--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -377,8 +377,8 @@ _POSIX_PRIORITY_SCHEDULING
 
     sched_get_priority_max(),yes
     sched_get_priority_min(),yes
-    sched_getparam(),
-    sched_getscheduler(),
+    sched_getparam(),yes
+    sched_getscheduler(),yes
     sched_rr_get_interval(),yes
     sched_setparam(),yes
     sched_setscheduler(),yes


### PR DESCRIPTION
`sched_getscheduler()` and `sched_getparam()` are missing in the documentation.
Has been discuss here https://github.com/zephyrproject-rtos/zephyr/pull/67711
and here https://github.com/zephyrproject-rtos/zephyr/pull/68200