### PR TITLE
adsp: power: make needlessly global assembly functions static

### DIFF
--- a/soc/intel/intel_adsp/ace/power.c
+++ b/soc/intel/intel_adsp/ace/power.c
@@ -179,7 +179,7 @@ void power_gate_entry(uint32_t core_id)
 	z_xt_ints_off(0xffffffff);
 }
 
-void power_gate_exit(void)
+static void __used power_gate_exit(void)
 {
 	cpu_early_init();
 	sys_cache_data_flush_and_invd_all();

--- a/soc/intel/intel_adsp/cavs/power.c
+++ b/soc/intel/intel_adsp/cavs/power.c
@@ -99,7 +99,7 @@ static ALWAYS_INLINE void _restore_core_context(void)
 	__asm__ volatile("rsync");
 }
 
-void power_gate_exit(void)
+static void __used power_gate_exit(void)
 {
 	cpu_early_init();
 	sys_cache_data_flush_and_invd_all();

--- a/soc/intel/intel_adsp/common/multiprocessing.c
+++ b/soc/intel/intel_adsp/common/multiprocessing.c
@@ -96,7 +96,7 @@ __asm__(".section .text.z_soc_mp_asm_entry, \"x\" \n\t"
 #undef NOP32
 #undef NOP4
 
-__imr void z_mp_entry(void)
+static __imr void __used z_mp_entry(void)
 {
 	cpu_early_init();
 	/* Set up the CPU pointer. */


### PR DESCRIPTION
C functions called from assembly aren't recognised by the compiler as being called, so if they're `static` the compiler complains. Make them `used` explicitly