### PR TITLE
drivers: i2s_nrfx: add support for divider setup on NRF54L15

### DIFF
--- a/drivers/i2s/i2s_nrfx.c
+++ b/drivers/i2s/i2s_nrfx.c
@@ -100,7 +100,7 @@ static void find_suitable_clock(const struct i2s_nrfx_drv_cfg *drv_cfg,
 			continue;
 		}
 
-		if (IS_ENABLED(CONFIG_SOC_SERIES_NRF53X)) {
+		if (IS_ENABLED(CONFIG_SOC_SERIES_NRF53X) || IS_ENABLED(CONFIG_SOC_SERIES_NRF54LX)) {
 			uint32_t requested_mck =
 				i2s_cfg->frame_clk_freq * ratios[r].ratio_val;
 			/* As specified in the nRF5340 PS:


### PR DESCRIPTION
Add support for NRF54L15 divider setting which is same as on NRF5340