### PR TITLE
twister:pytest: Fix shell fixture - add clearing buffer after reading prompt 

### DIFF
--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/fixtures.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/fixtures.py
@@ -6,6 +6,7 @@ import logging
 from typing import Generator, Type
 
 import pytest
+import time
 
 from twister_harness.device.device_adapter import DeviceAdapter
 from twister_harness.device.factory import DeviceFactory
@@ -58,7 +59,13 @@ def shell(dut: DeviceAdapter) -> Shell:
     """Return ready to use shell interface"""
     shell = Shell(dut, timeout=20.0)
     logger.info('Wait for prompt')
-    assert shell.wait_for_prompt()
+    if not shell.wait_for_prompt():
+        pytest.fail('Prompt not found')
+    if dut.device_config.type == 'hardware':
+        # after booting up the device, there might appear additional logs
+        # after first prompt, so we need to wait and clear the buffer
+        time.sleep(0.5)
+        dut.clear_buffer()
     return shell
 
 

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/helpers/shell.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/helpers/shell.py
@@ -45,8 +45,6 @@ class Shell:
                 continue
             if self.prompt in line:
                 logger.debug('Got prompt')
-                time.sleep(0.05)
-                self._device.clear_buffer()
                 return True
         return False
 


### PR DESCRIPTION
After merging that commit:
https://github.com/zephyrproject-rtos/zephyr/pull/68166/commits/76cf6ec870037710213db7eb4eb171444a279894
tests from https://github.com/zephyrproject-rtos/zephyr/tree/main/tests/boot/with_mcumgr
started failing.
When we are connected to the device before flashing is finished, then more additional logs might appear (especially when sysbuild is configured, then more apps can be loaded).

As a solution I proposed to wait 0.5s and clear the internal buffer. It is done only for the hardware and only when using `shell` fixture in test. 