### PR TITLE
drivers/sensor: lps2xdf: Fix uninitialized variables

### DIFF
--- a/drivers/sensor/lps2xdf/lps22df.c
+++ b/drivers/sensor/lps2xdf/lps22df.c
@@ -207,6 +207,7 @@ int st_lps22df_init(const struct device *dev)
 		lps22df_bus_mode_t bus_mode;
 
 		/* Select bus interface */
+		lps22df_bus_mode_get(ctx, &bus_mode);
 		bus_mode.filter = LPS22DF_AUTO;
 		bus_mode.interface = LPS22DF_SEL_BY_HW;
 		lps22df_bus_mode_set(ctx, &bus_mode);

--- a/drivers/sensor/lps2xdf/lps28dfw.c
+++ b/drivers/sensor/lps2xdf/lps28dfw.c
@@ -214,6 +214,7 @@ int st_lps28dfw_init(const struct device *dev)
 		lps28dfw_bus_mode_t bus_mode;
 
 		/* Select bus interface */
+		lps28dfw_bus_mode_get(ctx, &bus_mode);
 		bus_mode.filter = LPS28DFW_AUTO;
 		bus_mode.interface = LPS28DFW_SEL_BY_HW;
 		lps28dfw_bus_mode_set(ctx, &bus_mode);

--- a/drivers/sensor/lps2xdf/lps2xdf_trigger.c
+++ b/drivers/sensor/lps2xdf/lps2xdf_trigger.c
@@ -168,6 +168,9 @@ int lps2xdf_init_interrupt(const struct device *dev, enum sensor_variant variant
 #if DT_HAS_COMPAT_STATUS_OKAY(st_lps22df)
 		lps22df_int_mode_t mode;
 
+		if (lps22df_interrupt_mode_get(ctx, &mode) < 0) {
+			return -EIO;
+		}
 		mode.drdy_latched = ~cfg->drdy_pulsed;
 		if (lps22df_interrupt_mode_set(ctx, &mode) < 0) {
 			return -EIO;
@@ -177,6 +180,9 @@ int lps2xdf_init_interrupt(const struct device *dev, enum sensor_variant variant
 #if DT_HAS_COMPAT_STATUS_OKAY(st_lps28dfw)
 		lps28dfw_int_mode_t mode;
 
+		if (lps28dfw_interrupt_mode_get(ctx, &mode) < 0) {
+			return -EIO;
+		}
 		mode.drdy_latched = ~cfg->drdy_pulsed;
 		if (lps28dfw_interrupt_mode_set(ctx, &mode) < 0) {
 			return -EIO;


### PR DESCRIPTION
Fix some uninitialized variables calling the proper get() routine prior the equivalent set() operation.

Fixes #66791
Fixes #66778 
Fixes #66772
Coverity-CID: 338119, 338144, 338157.