### PR TITLE
drivers: modem/simcom: Unused variable

### DIFF
--- a/drivers/modem/simcom-sim7080.c
+++ b/drivers/modem/simcom-sim7080.c
@@ -750,7 +750,7 @@ static int offload_getaddrinfo(const char *node, const char *service,
 static void offload_freeaddrinfo(struct zsock_addrinfo *res)
 {
 	/* No need to free static memory. */
-	res = NULL;
+	ARG_UNUSED(res);
 }
 
 /*


### PR DESCRIPTION
Make coverity happy and mark a variable as unused.

Fixes CID-248325