### PR TITLE
stm32 board runner can flash external NOR with STM32CubeProgrammer

### DIFF
--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -236,6 +236,10 @@ class RunnerCaps:
     - reset: whether the runner supports a --reset option, which
       resets the device after a flash operation is complete.
 
+    - extload: whether the runner supports a --extload option, which
+      must be given one time and is passed on to the underlying tool
+      that the runner wraps.
+
     - tool_opt: whether the runner supports a --tool-opt (-O) option, which
       can be given multiple times and is passed on to the underlying tool
       that the runner wraps.
@@ -250,6 +254,7 @@ class RunnerCaps:
     flash_addr: bool = False
     erase: bool = False
     reset: bool = False
+    extload: bool = False
     tool_opt: bool = False
     file: bool = False
 
@@ -531,6 +536,10 @@ class ZephyrBinaryRunner(abc.ABC):
                                   "Default action depends on each specific runner."
                                   if caps.reset else argparse.SUPPRESS))
 
+        parser.add_argument('--extload', dest='extload',
+                            help=(cls.extload_help() if caps.extload
+                                  else argparse.SUPPRESS))
+
         parser.add_argument('-O', '--tool-opt', dest='tool_opt',
                             default=[], action='append',
                             help=(cls.tool_opt_help() if caps.tool_opt
@@ -561,6 +570,8 @@ class ZephyrBinaryRunner(abc.ABC):
             _missing_cap(cls, '--erase')
         if args.reset and not caps.reset:
             _missing_cap(cls, '--reset')
+        if args.extload and not caps.extload:
+            _missing_cap(cls, '--extload')
         if args.tool_opt and not caps.tool_opt:
             _missing_cap(cls, '--tool-opt')
         if args.file and not caps.file:
@@ -648,6 +659,15 @@ class ZephyrBinaryRunner(abc.ABC):
                   which debugger, device, node or instance to
                   target when multiple ones are available or
                   connected.'''
+
+    @classmethod
+    def extload_help(cls) -> str:
+        ''' Get the ArgParse help text for the --extload option.'''
+        return '''External loader to be used by stm32cubeprogrammer
+                  to program the targeted external memory.
+                  The runner requires the external loader (*.stldr) filename.
+                  This external loader (*.stldr) must be located within
+                  STM32CubeProgrammer/bin/ExternalLoader directory.'''
 
     @classmethod
     def tool_opt_help(cls) -> str:

--- a/scripts/west_commands/runners/stm32cubeprogrammer.py
+++ b/scripts/west_commands/runners/stm32cubeprogrammer.py
@@ -37,6 +37,7 @@ class STM32CubeProgrammerBinaryRunner(ZephyrBinaryRunner):
         cli: Optional[Path],
         use_elf: bool,
         erase: bool,
+        extload: Optional[str],
         tool_opt: List[str],
     ) -> None:
         super().__init__(cfg)
@@ -50,6 +51,12 @@ class STM32CubeProgrammerBinaryRunner(ZephyrBinaryRunner):
         )
         self._use_elf = use_elf
         self._erase = erase
+
+        if extload:
+            p = STM32CubeProgrammerBinaryRunner._get_stm32cubeprogrammer_path().parent.resolve() / 'ExternalLoader'
+            self._extload = ['-el', str(p / extload)]
+        else:
+            self._extload = []
 
         self._tool_opt: List[str] = list()
         for opts in [shlex.split(opt) for opt in tool_opt]:
@@ -112,7 +119,7 @@ class STM32CubeProgrammerBinaryRunner(ZephyrBinaryRunner):
 
     @classmethod
     def capabilities(cls):
-        return RunnerCaps(commands={"flash"}, erase=True, tool_opt=True)
+        return RunnerCaps(commands={"flash"}, erase=True, extload=True, tool_opt=True)
 
     @classmethod
     def do_add_parser(cls, parser):
@@ -152,6 +159,10 @@ class STM32CubeProgrammerBinaryRunner(ZephyrBinaryRunner):
         )
 
     @classmethod
+    def extload_help(cls) -> str:
+        return "External Loader for STM32_Programmer_CLI"
+
+    @classmethod
     def tool_opt_help(cls) -> str:
         return "Additional options for STM32_Programmer_CLI"
 
@@ -168,6 +179,7 @@ class STM32CubeProgrammerBinaryRunner(ZephyrBinaryRunner):
             cli=args.cli,
             use_elf=args.use_elf,
             erase=args.erase,
+            extload=args.extload,
             tool_opt=args.tool_opt,
         )
 
@@ -192,6 +204,9 @@ class STM32CubeProgrammerBinaryRunner(ZephyrBinaryRunner):
 
         cmd += ["--connect", connect_opts]
         cmd += self._tool_opt
+        if self._extload:
+            # external loader to come after the tool option in STM32CubeProgrammer
+            cmd += self._extload
 
         # erase first if requested
         if self._erase:

--- a/scripts/west_commands/runners/stm32cubeprogrammer.py
+++ b/scripts/west_commands/runners/stm32cubeprogrammer.py
@@ -200,7 +200,7 @@ class STM32CubeProgrammerBinaryRunner(ZephyrBinaryRunner):
         # flash image and run application
         dl_file = self.cfg.elf_file if self._use_elf else self.cfg.hex_file
         if dl_file is None:
-            raise RuntimeError(f'cannot flash; no download file was specified')
+            raise RuntimeError('cannot flash; no download file was specified')
         elif not os.path.isfile(dl_file):
             raise RuntimeError(f'download file {dl_file} does not exist')
         self.check_call(cmd + ["--download", dl_file, "--start"])

--- a/scripts/west_commands/tests/test_stm32cubeprogrammer.py
+++ b/scripts/west_commands/tests/test_stm32cubeprogrammer.py
@@ -68,6 +68,7 @@ TEST_CASES = (
         "cli": CLI_PATH,
         "use_elf": False,
         "erase": False,
+        "extload": None,
         "tool_opt": [],
         "system": "",
         "cli_path": str(CLI_PATH),
@@ -90,6 +91,7 @@ TEST_CASES = (
         "cli": CLI_PATH,
         "use_elf": False,
         "erase": False,
+        "extload": None,
         "tool_opt": [],
         "system": "",
         "cli_path": str(CLI_PATH),
@@ -112,6 +114,7 @@ TEST_CASES = (
         "cli": CLI_PATH,
         "use_elf": False,
         "erase": False,
+        "extload": None,
         "tool_opt": [],
         "system": "",
         "cli_path": str(CLI_PATH),
@@ -134,6 +137,7 @@ TEST_CASES = (
         "cli": CLI_PATH,
         "use_elf": False,
         "erase": False,
+        "extload": None,
         "tool_opt": [],
         "system": "",
         "cli_path": str(CLI_PATH),
@@ -156,6 +160,7 @@ TEST_CASES = (
         "cli": CLI_PATH,
         "use_elf": False,
         "erase": False,
+        "extload": None,
         "tool_opt": [],
         "system": "",
         "cli_path": str(CLI_PATH),
@@ -178,6 +183,7 @@ TEST_CASES = (
         "cli": CLI_PATH,
         "use_elf": False,
         "erase": False,
+        "extload": None,
         "tool_opt": [],
         "system": "",
         "cli_path": str(CLI_PATH),
@@ -200,6 +206,7 @@ TEST_CASES = (
         "cli": CLI_PATH,
         "use_elf": True,
         "erase": False,
+        "extload": None,
         "tool_opt": [],
         "system": "",
         "cli_path": str(CLI_PATH),
@@ -222,6 +229,7 @@ TEST_CASES = (
         "cli": CLI_PATH,
         "use_elf": False,
         "erase": True,
+        "extload": None,
         "tool_opt": [],
         "system": "",
         "cli_path": str(CLI_PATH),
@@ -245,6 +253,7 @@ TEST_CASES = (
         "cli": CLI_PATH,
         "use_elf": False,
         "erase": False,
+        "extload": None,
         "tool_opt": ["--skipErase"],
         "system": "",
         "cli_path": str(CLI_PATH),
@@ -268,6 +277,7 @@ TEST_CASES = (
         "cli": None,
         "use_elf": False,
         "erase": False,
+        "extload": None,
         "tool_opt": [],
         "system": "Linux",
         "cli_path": str(LINUX_CLI_PATH),
@@ -290,6 +300,7 @@ TEST_CASES = (
         "cli": None,
         "use_elf": False,
         "erase": False,
+        "extload": None,
         "tool_opt": [],
         "system": "Darwin",
         "cli_path": str(MACOS_CLI_PATH),
@@ -312,6 +323,7 @@ TEST_CASES = (
         "cli": None,
         "use_elf": False,
         "erase": False,
+        "extload": None,
         "tool_opt": [],
         "system": "Windows",
         "cli_path": str(WINDOWS_CLI_PATH),
@@ -355,6 +367,7 @@ def test_stm32cubeprogrammer_init(
         cli=tc["cli"],
         use_elf=tc["use_elf"],
         erase=tc["erase"],
+        extload=tc["extload"],
         tool_opt=tc["tool_opt"],
     )
 
@@ -393,6 +406,8 @@ def test_stm32cubeprogrammer_create(
         args.extend(["--use-elf"])
     if tc["erase"]:
         args.append("--erase")
+    if tc["extload"]:
+        args.extend(["--extload", tc["extload"]])
     if tc["tool_opt"]:
         args.extend(["--tool-opt", " " + tc["tool_opt"][0]])
 


### PR DESCRIPTION
Add an option to the STM32CubeProgrammer board runner to include the external loader corresponding to the target board.
The west flash command is updated to support the option and flash external octo-NOR with an external loader.
This is mainly use for stm32 disco kit target boards where the external NOR flash is in MemoryMapped mode, for XiP.
The external flash memory is mapped to 0x70000000. for stm32u585 disco kit
The external flash memory is mapped to 0x90000000. for stm32h7b3 disco kit

The board runner STM32CubeProgrammer is updated to get : 
- the hexa file to flash `board_runner_args(stm32cubeprogrammer "--hex-file=${ZEPHYR_BASE}/build/zephyr/zephyr.hex")`
- the address of the external flash to write `board_runner_args(stm32cubeprogrammer "--tool-opt=0x70000000")`
- the external loader to use for flashing it `board_runner_args(stm32cubeprogrammer "--extload=MX25LM51245G_STM32U585I-IOT02A.stldr")`

