### PR TITLE
drivers: display: fix ili9xxx write size

### DIFF
--- a/drivers/display/display_ili9xxx.c
+++ b/drivers/display/display_ili9xxx.c
@@ -111,12 +111,11 @@ static int ili9xxx_write(const struct device *dev, const uint16_t x,
 	} else {
 		write_h = desc->height;
 		mipi_desc.height = desc->height;
-		mipi_desc.buf_size = desc->buf_size;
+		mipi_desc.buf_size = desc->width * data->bytes_per_pixel * write_h;
 		nbr_of_writes = 1U;
 	}
 
 	mipi_desc.width = desc->width;
-	mipi_desc.height = desc->height;
 	/* Per MIPI API, pitch must always match width */
 	mipi_desc.pitch = desc->width;
 

--- a/drivers/display/display_ili9xxx.c
+++ b/drivers/display/display_ili9xxx.c
@@ -48,7 +48,9 @@ static void ili9xxx_hw_reset(const struct device *dev)
 {
 	const struct ili9xxx_config *config = dev->config;
 
-	mipi_dbi_reset(config->mipi_dev, ILI9XXX_RESET_PULSE_TIME);
+	if (mipi_dbi_reset(config->mipi_dev, ILI9XXX_RESET_PULSE_TIME) < 0) {
+		return;
+	};
 	k_sleep(K_MSEC(ILI9XXX_RESET_WAIT_TIME));
 }
 

--- a/include/zephyr/drivers/mipi_dbi.h
+++ b/include/zephyr/drivers/mipi_dbi.h
@@ -208,7 +208,8 @@ static inline int mipi_dbi_command_read(const struct device *dev,
  * @param config MIPI DBI configuration
  * @param framebuf: framebuffer to write to display
  * @param desc: descriptor of framebuffer to write. Note that the pitch must
- *   be equal to width.
+ *   be equal to width. "buf_size" field determines how many bytes will be
+ *   written.
  * @param pixfmt: pixel format of framebuffer data
  * @retval 0 buffer write succeeded.
  * @retval -EIO I/O error


### PR DESCRIPTION
This PR resolves an issue I noticed when performing additional testing of #64587, which does not break the display driver but can result in longer write times for the ILI9xxx display when using display buffer descriptors with a `buf_size` not equal to the requested write area. The MIPI DBI driver bases the amount of data to write on the `buf_size` field of the display buffer descriptor, so if this is not equal to the `desc->height * desc->width * diplay_bytes_per_pixel` more data will be written then strictly necessary.