### PR TITLE
boards: x86: more stack space for qemu_x86_tiny@768

### DIFF
--- a/boards/x86/qemu_x86/qemu_x86_tiny_768.conf
+++ b/boards/x86/qemu_x86/qemu_x86_tiny_768.conf
@@ -3,3 +3,7 @@
 
 # Enable coverage regardless since this config for coverage only.
 CONFIG_COVERAGE=y
+
+# Need more stack space due to coverage being enabled.
+CONFIG_MAIN_STACK_SIZE=4096
+CONFIG_IDLE_STACK_SIZE=1024


### PR DESCRIPTION
qemu_x86_tiny@768 has coverage enabled by default. Because of this, it requires more stack space for running tests. The increases needed are verified via twister.

Fixes #68272