### PR TITLE
libc/newlib: Wrap <string.h> to define strnlen and strtok_r when needed

### DIFF
--- a/lib/libc/newlib/include/string.h
+++ b/lib/libc/newlib/include/string.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2024 Keith Packard <keithp@keithp.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_LIB_LIBC_NEWLIB_INCLUDE_STRING_H_
+#define ZEPHYR_LIB_LIBC_NEWLIB_INCLUDE_STRING_H_
+
+/* This should work on GCC and clang.
+ *
+ * If we need to support a toolchain without #include_next the CMake
+ * infrastructure should be used to identify it and provide an
+ * alternative solution.
+ */
+#include_next <string.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Define these two Zephyr APIs when _POSIX_C_SOURCE is not set to expose
+ * them from newlib
+ */
+#if !__MISC_VISIBLE && !__POSIX_VISIBLE
+char *strtok_r(char *__restrict, const char *__restrict, char **__restrict);
+#endif
+#if __POSIX_VISIBLE < 200809L
+size_t strnlen(const char *, size_t);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_LIB_LIBC_NEWLIB_INCLUDE_STRING_H_ */

--- a/tests/lib/c_lib/common/src/main.c
+++ b/tests/lib/c_lib/common/src/main.c
@@ -15,7 +15,7 @@
  * it guarantee that ALL functionality provided is working correctly.
  */
 
-#if defined(CONFIG_NEWLIB_LIBC) || defined(CONFIG_NATIVE_LIBC)
+#if defined(CONFIG_NATIVE_LIBC)
 #undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
 #endif


### PR DESCRIPTION
Newlib doesn't have Zephyr support, so we need to define these functions when the application doesn't ask for the right level of POSIX support.

This is a replacement for #67040