### PR TITLE
net: tcp: Rate-limiting of neighbor reachability hints

### DIFF
--- a/subsys/net/ip/tcp_private.h
+++ b/subsys/net/ip/tcp_private.h
@@ -297,6 +297,9 @@ struct tcp { /* TCP connection */
 	};
 	union tcp_endpoint src;
 	union tcp_endpoint dst;
+#if defined(CONFIG_NET_TCP_IPV6_ND_REACHABILITY_HINT)
+	int64_t last_nd_hint_time;
+#endif
 	size_t send_data_total;
 	size_t send_retries;
 	int unacked_len;


### PR DESCRIPTION
This commit implements an arbitrary chosen 5-second rate-limiting interval for neighbor reachability hints in the TCP module to prevent the potentially costly process of frequent neighbor searches in the table, enhancing system performance.

Related to: #68226 