### PR TITLE
MAINTAINERS: Remove aaronemassey add GRobertZieba

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1000,8 +1000,9 @@ Release Notes:
 "Drivers: Charger":
   status: maintained
   maintainers:
-    - aaronemassey
     - rriveramcrus
+  collaborators:
+    - GRobertZieba
   files:
     - drivers/charger/
     - dts/bindings/charger/


### PR DESCRIPTION
Aaron Massey (aaronemassey - Google) doesn't have the cycles to remain a maintainer on the charger subsystem. Robert Zieba (GRobertZieba - Google) has been participating as a collaborator for the charger subsystem.

Remove aaronemassey as a maintainer of the charger subsystem and add GRobertZieba as a collaborator.

Signed-off-by Aaron Massey <aaronmassey@google.com>