### PR TITLE
Hwmv2 porting followup 1

### DIFF
--- a/boards/v2/qemu/qemu_kvm_arm64/Kconfig
+++ b/boards/v2/qemu/qemu_kvm_arm64/Kconfig
@@ -2,4 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_QEMU_KVM_ARM64
-	select SOC_QEMU_VIRT_ARM64
+	select ARM64
+	select QEMU_TARGET

--- a/soc/v2/rockchip/rk3399/Kconfig
+++ b/soc/v2/rockchip/rk3399/Kconfig
@@ -8,3 +8,6 @@ config SOC_RK3399
 	select ARM64
 	select CPU_CORTEX_A53
 	select ARM_ARCH_TIMER if SYS_CLOCK_EXISTS
+
+config SOC_PART_NUMBER
+	default "RK3399" if SOC_SERIES_RK3399

--- a/soc/v2/rockchip/rk3399/Kconfig.soc
+++ b/soc/v2/rockchip/rk3399/Kconfig.soc
@@ -17,6 +17,3 @@ config SOC
 
 config SOC_SERIES
 	default "rk3399" if SOC_SERIES_RK3399
-
-config SOC_PART_NUMBER
-	default "RK3399" if SOC_SERIES_RK3399

--- a/soc/v2/rockchip/rk3568/Kconfig
+++ b/soc/v2/rockchip/rk3568/Kconfig
@@ -7,3 +7,6 @@ config SOC_SERIES_RK3568
 	select CPU_CORTEX_A55
 	select ARM_ARCH_TIMER
 	select GIC_V3
+
+config SOC_PART_NUMBER
+	default "RK3568" if SOC_SERIES_RK3568

--- a/soc/v2/rockchip/rk3568/Kconfig.soc
+++ b/soc/v2/rockchip/rk3568/Kconfig.soc
@@ -15,6 +15,3 @@ config SOC
 
 config SOC_SERIES
 	default "rk3568" if SOC_RK3568
-
-config SOC_PART_NUMBER
-	default "RK3568" if SOC_SERIES_RK3568

--- a/soc/v2/ti/k3/am6x/Kconfig
+++ b/soc/v2/ti/k3/am6x/Kconfig
@@ -17,3 +17,7 @@ config SOC_SERIES_AM6X_M4
 	select EXTERNAL_ADDRESS_TRANSLATION
 	select MM_DRV
 	select MM_TI_RAT
+
+config SOC_PART_NUMBER
+	default "AM6234" if SOC_AM6234_A53
+	default "AM6234" if SOC_AM6234_M4

--- a/soc/v2/ti/k3/am6x/Kconfig.soc
+++ b/soc/v2/ti/k3/am6x/Kconfig.soc
@@ -27,7 +27,3 @@ config SOC_AM6234_M4
 
 config SOC_SERIES
 	default "am6x" if SOC_SERIES_AM6X
-
-config SOC_PART_NUMBER
-	default "AM6234" if SOC_AM6234_A53
-	default "AM6234" if SOC_AM6234_M4


### PR DESCRIPTION
A series of follow-up commits with adjustments not noticed during review.
- soc: ti_k3
- soc: rk3568
- soc: rk3399
- board: qemu_kvm_arm64
