### PR TITLE
kernel: smp: CPU start may result in null pointer access

### DIFF
--- a/kernel/smp.c
+++ b/kernel/smp.c
@@ -119,6 +119,13 @@ static inline void smp_init_top(void *arg)
 	 */
 	wait_for_start_signal(&cpu_start_flag);
 
+	if ((csc == NULL) || csc->invoke_sched) {
+		/* Initialize the dummy thread struct so that
+		 * the scheduler can schedule actual threads to run.
+		 */
+		z_dummy_thread_init(&dummy_thread);
+	}
+
 #ifdef CONFIG_SYS_CLOCK_EXISTS
 	if ((csc == NULL) || csc->reinit_timer) {
 		smp_timer_init();
@@ -134,11 +141,6 @@ static inline void smp_init_top(void *arg)
 		/* Don't invoke scheduler. */
 		return;
 	}
-
-	/* Initialize the dummy thread struct so that
-	 * the scheduler can schedule actual threads to run.
-	 */
-	z_dummy_thread_init(&dummy_thread);
 
 	/* Let scheduler decide what thread to run next. */
 	z_swap_unlocked();


### PR DESCRIPTION
It is observed that starting up CPU may result in other CPUs crashing due to de-referencing NULL pointers. Note that this happened on the up_squared board, but there was no way to attach debugger to verify. It started working again after moving z_dummy_thread_init() before smp_timer_init(), which was the old behavior before commit
eefaeee061c869cfa33be9693ff186ca60f76ff9 where the issue first appeared. So mimic the old behavior to workaround the issue.

Fixes #68115