### PR TITLE
ci: codecov: stick with gcovr 6.0 for now.

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -160,7 +160,7 @@ jobs:
       - name: Merge coverage files
         run: |
           cd ./coverage/reports
-          pip3 install gcovr
+          pip3 install gcovr==6.0
           gcovr ${{ steps.get-coverage-files.outputs.mergefiles }}  --merge-mode-functions=separate --json merged.json
           gcovr ${{ steps.get-coverage-files.outputs.mergefiles }} --merge-mode-functions=separate --cobertura merged.xml
 


### PR DESCRIPTION
Related to https://github.com/zephyrproject-rtos/zephyr/pull/68344 
There is still a problem with gcovr while merging coverage data.
https://github.com/zephyrproject-rtos/zephyr/actions/runs/7737197294/job/21097414132#step:6:3