### PR TITLE
doc: fix index typo in sdl bindings

### DIFF
--- a/dts/bindings/gpio/zephyr,gpio-emul-sdl.yaml
+++ b/dts/bindings/gpio/zephyr,gpio-emul-sdl.yaml
@@ -28,7 +28,7 @@ description: |
     key1: key1 {
       gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
     };
-    key1: key2 {
+    key2: key2 {
       gpios = <&gpio0 1 GPIO_ACTIVE_HIGH>;
     };
     key3: key3 {


### PR DESCRIPTION
Label "key1" is used twice in the exemple, renaming to "key2".