### PR TITLE
drivers: sensor: tmp108: fix coverity integer handling issue

### DIFF
--- a/drivers/sensor/tmp108/tmp108.c
+++ b/drivers/sensor/tmp108/tmp108.c
@@ -165,6 +165,7 @@ static int tmp108_attr_get(const struct device *dev,
 			   struct sensor_value *val)
 {
 	int result;
+	uint16_t tmp_val;
 
 	if (chan != SENSOR_CHAN_AMBIENT_TEMP && chan != SENSOR_CHAN_ALL) {
 		return -ENOTSUP;
@@ -174,7 +175,9 @@ static int tmp108_attr_get(const struct device *dev,
 	case SENSOR_ATTR_CONFIGURATION:
 		result =  tmp108_reg_read(dev,
 					  TI_TMP108_REG_CONF,
-					  (uint16_t *) &(val->val1));
+					  &tmp_val);
+		val->val1 = tmp_val;
+		val->val2 = 0;
 		break;
 	default:
 		return -ENOTSUP;


### PR DESCRIPTION
Fix coverity integer handling issue (CWE-188).
Modifying a variable through a pointer of an incompatible type (other than unsigned char) can lead to unpredictable results.

Fix: #67965
Coverity-CID: 248434