### PR TITLE
logging: Add option to not generate dictionary database always

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1875,27 +1875,30 @@ list(APPEND
   )
 
 if(CONFIG_LOG_DICTIONARY_DB)
-  set(log_dict_db_output --json=${PROJECT_BINARY_DIR}/log_dictionary.json)
+  set(LOG_DICT_DB_NAME ${PROJECT_BINARY_DIR}/log_dictionary.json)
+  set(LOG_DICT_DB_NAME_ARG --json)
 elseif(CONFIG_LOG_MIPI_SYST_USE_CATALOG)
-  set(log_dict_db_output --syst=${PROJECT_BINARY_DIR}/mipi_syst_collateral.xml)
+  set(LOG_DICT_DB_NAME ${PROJECT_BINARY_DIR}/mipi_syst_collateral.xml)
+  set(LOG_DICT_DB_NAME_ARG --syst)
 endif()
 
-if(log_dict_db_output)
-  list(APPEND
-    post_build_commands
+if(LOG_DICT_DB_NAME_ARG)
+  if (NOT CONFIG_LOG_DICTIONARY_DB_TARGET)
+    set(LOG_DICT_DB_ALL_TARGET ALL)
+  endif()
+  add_custom_command(
+    OUTPUT ${LOG_DICT_DB_NAME}
     COMMAND
-    ${PYTHON_EXECUTABLE}
-    ${ZEPHYR_BASE}/scripts/logging/dictionary/database_gen.py
-    ${KERNEL_ELF_NAME}
-    ${log_dict_db_output}
-    --build-header ${PROJECT_BINARY_DIR}/include/generated/version.h
-    )
-  list(APPEND
-    post_build_byproducts
-    ${LOG_DICT_DB_NAME}
-    )
-
-  unset(log_dict_db_output)
+      ${PYTHON_EXECUTABLE}
+      ${ZEPHYR_BASE}/scripts/logging/dictionary/database_gen.py
+      ${KERNEL_ELF_NAME}
+      ${LOG_DICT_DB_NAME_ARG}=${LOG_DICT_DB_NAME}
+      --build-header ${PROJECT_BINARY_DIR}/include/generated/version.h
+    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+    COMMENT "Generating logging dictionary database: ${LOG_DICT_DB_NAME}"
+    DEPENDS ${logical_target_for_zephyr_elf}
+  )
+  add_custom_target(log_dict_db_gen ${LOG_DICT_DB_ALL_TARGET} DEPENDS ${LOG_DICT_DB_NAME})
 endif()
 
 # Add post_build_commands to post-process the final .elf file produced by

--- a/subsys/logging/Kconfig.misc
+++ b/subsys/logging/Kconfig.misc
@@ -99,6 +99,15 @@ config LOG_MEM_UTILIZATION
 config LOG_DICTIONARY_DB
 	bool
 
+config LOG_DICTIONARY_DB_TARGET
+	bool "Only generated log dictionary database from target"
+	depends on LOG_DICTIONARY_DB
+	help
+	  Enable this option to make generating the log dictionary database
+	  only done by its own build target.
+	  This removes the target from the ALL make target and the target
+	  'log_dict_db_gen' has to be called in addition.
+
 config LOG_MSG_APPEND_RO_STRING_LOC
 	bool
 	help


### PR DESCRIPTION
Add option to not generate the logging dictionary database when the zephyr finale image is created. Instead this database can be created by its own build target.
This reduces the build time during debugging as the database file is not required as part of the debugging.

Fix build byproducts not listing the output file.
Add comment so users know which command is executing as this command can take a long time.