### PR TITLE
kernel: provide Platform abstract interface for device drivers which are designed to works seamlessly on PCI bus, ACPI and DTS 

### DIFF
--- a/arch/x86/core/early_serial.c
+++ b/arch/x86/core/early_serial.c
@@ -9,12 +9,18 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/drivers/pcie/pcie.h>
 #include <soc.h>
+#ifdef CONFIG_ACPI
+#include <zephyr/acpi/acpi.h>
+#endif
 
+#define UART_IS_ACPIDEV \
+	DT_NODE_HAS_PROP(DT_CHOSEN(zephyr_console), acpi_hw_id)
 
 #if DT_PROP_OR(DT_CHOSEN(zephyr_console), io_mapped, 0) != 0
 #define UART_IS_IOPORT_ACCESS 1
 #endif
 
+#if !defined(UART_IS_ACPIDEV)
 #if defined(UART_IS_IOPORT_ACCESS)
 /* Legacy I/O Port Access to a NS16550 UART */
 #define IN(reg)       sys_in8(reg + DT_REG_ADDR(DT_CHOSEN(zephyr_console)))
@@ -119,3 +125,15 @@ void z_x86_early_serial_init(void)
 		       suppressed_chars);
 	}
 }
+#else
+/* TODO: ACPI need kheap and hence we cannot support early console currently. */
+int arch_printk_char_out(int c)
+{
+	return 0;
+}
+
+void z_x86_early_serial_init(void)
+{
+
+}
+#endif

--- a/boards/qemu/x86/qemu_x86_lakemont.dts
+++ b/boards/qemu/x86/qemu_x86_lakemont.dts
@@ -46,6 +46,7 @@
 			interrupt-parent = <&intc>;
 			current-speed = <115200>;
 			reg-shift = <2>;
+			io-mapped;
 			status = "okay";
 		};
 

--- a/drivers/serial/Kconfig.ns16550
+++ b/drivers/serial/Kconfig.ns16550
@@ -6,6 +6,7 @@ menuconfig UART_NS16550
 	depends on DT_HAS_NS16550_ENABLED
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
+	select BUS_DEV
 	help
 	  This option enables the NS16550 serial driver.
 	  This driver can be used for the serial hardware

--- a/dts/bindings/bus/bus.yaml
+++ b/dts/bindings/bus/bus.yaml
@@ -1,0 +1,8 @@
+# Common fields for platforms interface
+
+include: [acpi.yaml, pcie-device.yaml]
+
+properties:
+  io-mapped:
+    type: boolean
+    description: specify registers are IO mapped or memory mapped

--- a/dts/bindings/rtc/motorola,mc146818.yaml
+++ b/dts/bindings/rtc/motorola,mc146818.yaml
@@ -6,7 +6,7 @@ description: Motorola MC146818 compatible Real Timer Clock
 
 compatible: "motorola,mc146818"
 
-include: [rtc-device.yaml, acpi.yaml]
+include: [rtc-device.yaml, bus.yaml]
 
 properties:
   clock-frequency:
@@ -17,3 +17,6 @@ properties:
       - 1048576
       - 32768
     description: Frequency of the input-clock in Hertz (Hz)
+
+  io-mapped:
+    required: true

--- a/dts/bindings/serial/ns16550.yaml
+++ b/dts/bindings/serial/ns16550.yaml
@@ -2,7 +2,8 @@ description: ns16550 UART
 
 compatible: "ns16550"
 
-include: [uart-controller.yaml, pcie-device.yaml, pinctrl-device.yaml, reset-device.yaml]
+include: [uart-controller.yaml, bus.yaml,
+          pinctrl-device.yaml, reset-device.yaml]
 
 properties:
   reg-shift:

--- a/dts/bindings/serial/ns16550.yaml
+++ b/dts/bindings/serial/ns16550.yaml
@@ -17,7 +17,3 @@ properties:
   dlf:
     type: int
     description: divisor latch fraction (DLF, if supported)
-
-  io-mapped:
-    type: boolean
-    description: specify registers are IO mapped or memory mapped

--- a/dts/x86/intel/alder_lake.dtsi
+++ b/dts/x86/intel/alder_lake.dtsi
@@ -470,13 +470,13 @@
 			status = "okay";
 		};
 
-		rtc: counter: rtc@70 {
+		rtc: counter: rtc0 {
 			compatible = "motorola,mc146818";
-			reg = <0x70 0x0D 0x71 0x0D>;
+			acpi-hid = "PNP0B00";
 			interrupts = <8 IRQ_TYPE_LOWEST_EDGE_RISING 3>;
 			interrupt-parent = <&intc>;
 			alarms-count = <1>;
-
+			io-mapped;
 			status = "okay";
 		};
 

--- a/dts/x86/intel/apollo_lake.dtsi
+++ b/dts/x86/intel/apollo_lake.dtsi
@@ -395,7 +395,7 @@
 			interrupts = <8 IRQ_TYPE_LOWEST_EDGE_RISING 3>;
 			interrupt-parent = <&intc>;
 			alarms-count = <1>;
-
+			io-mapped;
 			status = "okay";
 		};
 	};

--- a/dts/x86/intel/atom.dtsi
+++ b/dts/x86/intel/atom.dtsi
@@ -56,6 +56,7 @@
 			interrupts = <4 IRQ_TYPE_LOWEST_EDGE_RISING 3>;
 			interrupt-parent = <&intc>;
 			reg-shift = <0>;
+			io-mapped;
 			status = "disabled";
 		};
 
@@ -67,6 +68,7 @@
 			interrupts = <3 IRQ_TYPE_LOWEST_EDGE_RISING 3>;
 			interrupt-parent = <&intc>;
 			reg-shift = <0>;
+			io-mapped;
 			status = "disabled";
 		};
 

--- a/dts/x86/intel/atom.dtsi
+++ b/dts/x86/intel/atom.dtsi
@@ -87,7 +87,7 @@
 			interrupts = <8 IRQ_TYPE_LOWEST_EDGE_RISING 3>;
 			interrupt-parent = <&intc>;
 			alarms-count = <1>;
-
+			io-mapped;
 			status = "okay";
 		};
 

--- a/dts/x86/intel/elkhart_lake.dtsi
+++ b/dts/x86/intel/elkhart_lake.dtsi
@@ -712,7 +712,7 @@
 			interrupts = <8 IRQ_TYPE_LOWEST_EDGE_RISING 3>;
 			interrupt-parent = <&intc>;
 			alarms-count = <1>;
-
+			io-mapped;
 			status = "okay";
 		};
 

--- a/dts/x86/intel/raptor_lake_p.dtsi
+++ b/dts/x86/intel/raptor_lake_p.dtsi
@@ -435,13 +435,13 @@
 			status = "okay";
 		};
 
-		rtc: counter: rtc@70 {
+		rtc: counter: rtc {
 			compatible = "motorola,mc146818";
-			reg = <0x70 0x0D 0x71 0x0D>;
+			acpi-hid = "PNP0B00";
 			interrupts = <8 IRQ_TYPE_LOWEST_EDGE_RISING 3>;
 			interrupt-parent = <&intc>;
 			alarms-count = <1>;
-
+			io-mapped;
 			status = "okay";
 		};
 

--- a/dts/x86/intel/raptor_lake_s.dtsi
+++ b/dts/x86/intel/raptor_lake_s.dtsi
@@ -544,13 +544,13 @@
 			status = "okay";
 		};
 
-		rtc: counter: rtc@70 {
+		rtc: counter: rtc {
 			compatible = "motorola,mc146818";
-			reg = <0x70 0x0D 0x71 0x0D>;
+			acpi-hid = "PNP0B00";
 			interrupts = <8 IRQ_TYPE_LOWEST_EDGE_RISING 3>;
 			interrupt-parent = <&intc>;
 			alarms-count = <1>;
-
+			io-mapped;
 			status = "okay";
 		};
 

--- a/dts/x86/intel/raptor_lake_s.dtsi
+++ b/dts/x86/intel/raptor_lake_s.dtsi
@@ -8,6 +8,7 @@
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/pcie/pcie.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/acpi/acpi.h>
 
 / {
 	cpus {
@@ -42,6 +43,18 @@
 		interrupt-controller;
 		#interrupt-cells = <3>;
 		#address-cells = <1>;
+	};
+
+	uart_ec_0: uart_ec_0 {
+		compatible = "ns16550";
+		acpi-hid = "PNP0501";
+		acpi-uid = "2";
+		clock-frequency = <1843200>;
+		interrupt-parent = <&intc>;
+		interrupts = <ACPI_IRQ_DETECT ACPI_IRQ_FLAG_DETECT 3>;
+		reg-shift = <0>;
+		io-mapped;
+		status = "okay";
 	};
 
 	pcie0: pcie0 {
@@ -336,18 +349,6 @@
 			compatible = "intel,vt-d";
 			reg = <0xfed91000 0x1000>;
 
-			status = "okay";
-		};
-
-		uart_ec_0: uart@3f8 {
-			compatible = "ns16550";
-			reg = <0x000003f8 0x100>;
-			io-mapped;
-			clock-frequency = <1843200>;
-			interrupts = <4 IRQ_TYPE_LOWEST_EDGE_RISING 3>;
-			interrupt-parent = <&intc>;
-			reg-shift = <0>;
-			io-mapped;
 			status = "okay";
 		};
 

--- a/include/zephyr/bus.h
+++ b/include/zephyr/bus.h
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2024 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_BUS_H_
+#define ZEPHYR_INCLUDE_BUS_H_
+
+#include <zephyr/devicetree.h>
+#include <zephyr/init.h>
+#include <zephyr/device.h>
+#include <zephyr/irq.h>
+#include <zephyr/linker/sections.h>
+#include <zephyr/sys/device_mmio.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
+#if defined(CONFIG_BUS_DEV)
+#include <zephyr/sys/slist.h>
+#endif /* CONFIG_BUS_DEV */
+
+typedef void (*platform_isr_t)(const struct device *dev);
+
+#if defined(CONFIG_PCIE)
+#include <zephyr/bus/pcie_internal.h>
+#endif
+
+#if defined(CONFIG_ACPI)
+#include <zephyr/bus/acpi_internal.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define Z_BUS_DEV_INIT_NAME(dev_id) _CONCAT(dev_init_, dev_id)
+
+/**
+ * @def BUS_DEV_MMIO_ROM
+ *
+ * @brief Declare storage for MMIO data within a device's config struct
+ *
+ * @see DEVICE_MMIO_ROM()
+ */
+#define BUS_DEV_MMIO_ROM DEVICE_MMIO_ROM
+
+#if !DT_ANY_INST_ON_BUS_STATUS_OKAY(pcie)
+#define BUS_DEV_MMIO_RAM DEVICE_MMIO_RAM
+#endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(pcie) */
+
+#ifndef BUS_DEV_RAM_INIT
+#define BUS_DEV_RAM_INIT(node_id)
+#endif
+
+#define BUS_DEV_MMIO_RAM_PTR(dev) DEVICE_MMIO_RAM_PTR(dev)
+#define BUS_DEV_MMIO_GET(dev)     DEVICE_MMIO_GET(dev)
+
+#define Z_IS_IO_MAPPED(n) COND_CODE_1(DT_NODE_HAS_PROP(n, io_mapped), (1), (0))
+
+#ifdef CONFIG_MMU
+#define Z_BUS_DEV_MMIO_MAP(dev, phy_add, size)                                                    \
+	device_map(BUS_DEV_MMIO_RAM_PTR(dev), phy_add, size, K_MEM_CACHE_NONE);
+#else
+#define Z_BUS_DEV_MMIO_MAP(dev, phy_add, size) *BUS_DEV_MMIO_RAM_PTR(dev) = (uintptr_t)phy_add
+#endif
+
+#define Z_IRQ_FLAGS_GET(n)  COND_CODE_1(DT_IRQ_HAS_CELL(n, sense), (DT_IRQ(n, sense)), (0))
+
+#if !defined(BUS_DEV_DISABLE_INTR)
+#define IRQ_CONFIG(n)                                                                            \
+	IRQ_CONNECT(DT_IRQN(n), DT_IRQ(n, priority), __platform_isr_##n, DEVICE_DT_GET(n),         \
+		    Z_IRQ_FLAGS_GET(n));
+#define Z_IRQ_CONFIG(n) COND_CODE_1(DT_IRQ_HAS_IDX(n, 0), (IRQ_CONFIG(n)), ())
+
+#define Z_IRQ_ENABLE(n) COND_CODE_1(DT_IRQ_HAS_IDX(n, 0), (irq_enable(DT_IRQN(n))), ())
+
+#define Z_BUS_DEV_ISR_INIT(n, isr)                                                                \
+	static inline void __platform_isr_##n(const struct device *dev)                            \
+	{                                                                                          \
+		platform_isr_t isr_fn = (platform_isr_t)isr;                                       \
+		if (isr_fn) {                                                                      \
+			isr_fn(dev);                                                               \
+		}                                                                                  \
+	}                                                                                          \
+	static inline void __config_irq_##n(const struct device *dev)                              \
+	{                                                                                          \
+		Z_IRQ_CONFIG(n);                                                                   \
+	}                                                                                          \
+	static inline void __enable_irq_##n(const struct device *dev)                              \
+	{                                                                                          \
+		Z_IRQ_ENABLE(n);                                                                   \
+	}
+
+#define Z_DEVICE_DT_INIT(n, init, isr)                                                             \
+	static inline int __common_dev_init##n(const struct device *dev)                           \
+	{                                                                                          \
+		platform_isr_t isr_fn = (platform_isr_t)isr;                                       \
+		int status;                                                                        \
+                                                                                                   \
+		if (isr_fn) {                                                                      \
+			__config_irq_##n(dev);                                                     \
+		}                                                                                  \
+		status = init(dev);                                                                \
+		if (status) {                                                                      \
+			return status;                                                             \
+		}                                                                                  \
+		if (isr_fn) {                                                                      \
+			__enable_irq_##n(dev);                                                     \
+		}                                                                                  \
+		return 0;                                                                          \
+	}
+#else
+#define Z_BUS_DEV_ISR_INIT(n, isr)
+#define Z_DEVICE_DT_INIT(n, init, isr)                                                             \
+	static inline int __common_dev_init##n(const struct device *dev)                           \
+	{                                                                                          \
+		return init(dev);                                                                  \
+	}
+#endif
+/**
+ * @brief Platform DTS based init function (Internal use only).
+ *
+ */
+#ifdef DEVICE_MMIO_IS_IN_RAM
+#define BUS_DEV_ROM_INIT(node_id)
+
+#define Z_BUS_DEV_DTS_INIT(n, init, isr)                                                      \
+	Z_BUS_DEV_ISR_INIT(n, isr);                                                               \
+	Z_DEVICE_DT_INIT(n, init, isr);                                                            \
+	static int Z_BUS_DEV_INIT_NAME(n)(const struct device *dev)                           \
+	{                                                                                          \
+		uintptr_t *reg = BUS_DEV_MMIO_RAM_PTR(dev);                                       \
+                                                                                                   \
+		if (!Z_IS_IO_MAPPED(n)) {                                                          \
+			Z_BUS_DEV_MMIO_MAP(dev, DT_REG_ADDR(n), DT_REG_SIZE(n));                  \
+		} else {                                                                           \
+			*reg = DT_REG_ADDR(n);                                                     \
+		}                                                                                  \
+		return __common_dev_init##n(dev);                                                  \
+	}
+#else
+/**
+ * @def BUS_DEV_ROM_INIT
+ *
+ * @brief Initialize a DEVICE_MMIO_ROM member
+ *
+ * @param node_id DTS node identifier
+ *
+ * @see DEVICE_MMIO_ROM_INIT()
+ */
+#define BUS_DEV_ROM_INIT(node_id) DEVICE_MMIO_ROM_INIT(node_id),
+
+#define Z_BUS_DEV_DTS_INIT(n, init, isr)                                                      \
+	Z_BUS_DEV_ISR_INIT(n, isr);                                                               \
+	Z_DEVICE_DT_INIT(n, init, isr);                                                            \
+	static int Z_BUS_DEV_INIT_NAME(n)(const struct device *dev)                           \
+	{                                                                                          \
+		return __common_dev_init##n(dev);                                                  \
+	}
+#endif
+
+#define BUS_DEV_ACPI_INIT(n, init, isr)                                                         \
+	COND_CODE_1(DT_NODE_HAS_PROP(n, acpi_hid), (Z_BUS_DEV_ACPI_INIT(n, init, isr)), \
+		(Z_BUS_DEV_DTS_INIT(n, init, isr)))
+
+#define Z_BUS_DEV_INIT(n, init, isr)                                                          \
+	COND_CODE_1(DT_ON_BUS(n, pcie), (Z_BUS_DEV_PCI_INIT(n, init, isr)),\
+		(BUS_DEV_ACPI_INIT(n, init, isr)))
+
+/**
+ * @brief Create a device object from a devicetree node identifier and set it up
+ * for boot time initialization. This macro is similar to DEVICE_DT_DEFINE but also provide
+ * platform abstract interface for device drivers which are designed to work on multiple bus
+ * topologies such as PCI, ACPI or just DTS base. Driver developers can use these macro instead
+ * of DEVICE_DT_DEFINE in case they need to design drivers which works seamlessly on PCI bus,
+ * ACPI and DTS base. Please note that MSI and multi vector interrupt support are still not
+ * available. In case platform need different way of register ISR or no interrupt support then
+ * they must define BUS_DEV_DISABLE_INTR before include platform.h header. Please refer
+ * DEVICE_DT_DEFINE documentation for details of all the parameters.
+ *
+ * @param node_id The devicetree node identifier.
+ * @param init_fn Pointer to the device's initialization function, which will be
+ * run by the kernel during system initialization. Can be `NULL`.
+ * @param isr Pointer to the device's ISR function (optional).
+ */
+#define BUS_DEV_DT_DEFINE(node_id, init_fn, isr, ...)                                         \
+	Z_BUS_DEV_INIT(node_id, init_fn, isr);                                                \
+	DEVICE_DT_DEFINE(node_id, Z_BUS_DEV_INIT_NAME(node_id), __VA_ARGS__)
+
+#define BUS_DEV_DT_INST_DEFINE(inst, init_fn, isr, ...)                                       \
+	BUS_DEV_DT_DEFINE(DT_DRV_INST(inst), init_fn, isr, __VA_ARGS__)
+#endif /* ZEPHYR_INCLUDE_BUS_H_ */

--- a/include/zephyr/bus/acpi_internal.h
+++ b/include/zephyr/bus/acpi_internal.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2024 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_ACPI_INTF_H_
+#define ZEPHYR_INCLUDE_ACPI_INTF_H_
+
+#include <zephyr/dt-bindings/acpi/acpi.h>
+#include <zephyr/acpi/acpi.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Platform ACPI init function (Internal use only).
+ *
+ */
+int platform_acpi_init(const struct device *dev, platform_isr_t isr, int irq, int priority,
+		       uint32_t flags, char *hid, char *uid);
+
+/**
+ * @brief ACPI specific init function (Internal use only).
+ *
+ */
+#define Z_BUS_DEV_ACPI_INIT(n, init, isr)                                                     \
+	static int __acpi_init_##n(const struct device *dev)                                       \
+	{                                                                                          \
+		return platform_acpi_init(dev, isr, DT_IRQN(n), DT_IRQ(n, priority),               \
+					  Z_IRQ_FLAGS_GET(n), ACPI_DT_HID(n), ACPI_DT_UID(n));     \
+	}                                                                                          \
+												   \
+	static int Z_BUS_DEV_INIT_NAME(n)(const struct device *dev)				   \
+	{                                                                                          \
+		int status;                                                                        \
+												   \
+		status = __acpi_init_##n(dev);                                                     \
+		if (!status) {                                                                     \
+			status = init(dev);                                                        \
+		}						                                   \
+		return status;                                                                     \
+	}
+
+#endif /* ZEPHYR_INCLUDE_ACPI_INTF_H_ */

--- a/include/zephyr/bus/pcie_internal.h
+++ b/include/zephyr/bus/pcie_internal.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2024 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_PCI_INTF_H_
+#define ZEPHYR_INCLUDE_PCI_INTF_H_
+
+#include <zephyr/drivers/pcie/pcie.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief PCI config structure (Internal use only).
+ */
+struct pci_conf {
+	struct pcie_dev *pcie;
+	bool bus_master;
+	unsigned int irq_num;
+	unsigned int irq_prio;
+	unsigned int irq_flag;
+};
+
+/**
+ * @brief Platform PCI init function (Internal use only).
+ *
+ */
+int platform_pci_init(const struct device *dev, struct pci_conf *cfg, platform_isr_t isr);
+
+/**
+ * @def BUS_DEV_MMIO_ROM
+ *
+ * @brief Declare storage for MMIO data within a device's config struct
+ *
+ * @see DEVICE_MMIO_ROM()
+ */
+#define BUS_DEV_MMIO_ROM DEVICE_MMIO_ROM
+
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(pcie)
+#define Z_BUS_DEV_PCI_DECLARE(n) COND_CODE_1(DT_INST_ON_BUS(n, pcie),\
+	(DEVICE_PCIE_INST_DECLARE(n);), ())
+
+DT_INST_FOREACH_STATUS_OKAY(Z_BUS_DEV_PCI_DECLARE)
+
+/**
+ * @def BUS_DEV_MMIO_RAM
+ *
+ * Declare storage for MMIO information within a device's dev_data struct.
+ *
+ * @see DEVICE_MMIO_RAM()
+ */
+#define BUS_DEV_MMIO_RAM                                                                      \
+	DEVICE_MMIO_RAM;                                                               \
+	struct pcie_dev *pcie
+#endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(pcie) */
+
+ /**
+  * @def BUS_DEV_RAM_INIT
+  *
+@@ -70,11 +66,11 @@ DT_INST_FOREACH_STATUS_OKAY(Z_BUS_DEV_PCI_DECLARE)
+  *
+  * @see DEVICE_MMIO_RAM()
+  */
+
+#define BUS_DEV_RAM_INIT(node_id) COND_CODE_1(DT_ON_BUS(node_id, pcie),\
+	(DEVICE_PCIE_INIT(node_id, pcie),), ())
+
+#define BUS_DEV_PCI_CTX_GET(n) &Z_DEVICE_PCIE_NAME(n)
+
+/**
+ * @brief PCIe specific init function (Internal use only).
+ *
+ */
+#define Z_BUS_DEV_PCI_INIT(n, init, isr)                                                      \
+	static int __pci_init_##n(const struct device *dev)                                        \
+	{                                                                                          \
+		struct pci_conf pci_cfg = {                                                        \
+			.pcie = BUS_DEV_PCI_CTX_GET(n),                                           \
+			.bus_master = DT_PROP_OR(n, bus_master, 1),                                \
+			.irq_num = DT_IRQN(n),                                                     \
+			.irq_prio = DT_IRQ(n, priority),                                           \
+			.irq_flag = Z_IRQ_FLAGS_GET(n),                                            \
+		};                                                                                 \
+		platform_isr_t isr_fn = (platform_isr_t)isr;                                       \
+												   \
+		return platform_pci_init(dev, &pci_cfg, isr_fn);                                   \
+	}                                                                                          \
+												   \
+	static int Z_BUS_DEV_INIT_NAME(n)(const struct device *dev)                           \
+	{                                                                                          \
+		int status;                                                                        \
+												   \
+		status = __pci_init_##n(dev);                                                      \
+		if (!status) {                                                                     \
+			status = init(dev);                                                        \
+		}                                                                                  \
+		return status;                                                                     \
+	}
+
+#endif /* ZEPHYR_INCLUDE_PCI_INTF_H_ */

--- a/include/zephyr/dt-bindings/acpi/acpi.h
+++ b/include/zephyr/dt-bindings/acpi/acpi.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_ACPI_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_ACPI_H_
+
+#define ACPI_IRQ_DETECT 0xFFFFFFFU
+#define ACPI_IRQ_FLAG_DETECT 0xFFFFFFFU
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_ACPI_H_ */

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -189,6 +189,8 @@ target_sources_ifdef(
   userspace.c
   )
 
+target_sources_ifdef(CONFIG_BUS_DEV kernel PRIVATE bus.c)
+
 if(${CONFIG_DYNAMIC_THREAD})
   target_sources(kernel PRIVATE dynamic.c)
 else()

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -1005,5 +1005,13 @@ config THREAD_LOCAL_STORAGE
 
 endmenu
 
+config BUS_DEV
+	bool "Bus device support"
+	help
+	  Provide abstract interface for device drivers which are designed to work on
+	  multiple bus topologies such as PCI, ACPI or just DTS base. Driver developers can use
+	  the new BUS_DEV_INST_DEFINE macro instead of DEVICE_INST_DEFINE in case
+	  they have to design drivers which need to works seamlessly on PCI bus, ACPI and DTS base.
+
 rsource "Kconfig.device"
 rsource "Kconfig.vm"

--- a/kernel/bus.c
+++ b/kernel/bus.c
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2023 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/bus.h>
+
+#if defined(CONFIG_ACPI)
+int platform_acpi_init(const struct device *dev, platform_isr_t isr, int irq, int priority,
+		       uint32_t flags, char *hid, char *uid)
+{
+	int ret;
+	struct acpi_dev *acpi_chld;
+	uint16_t irqs[CONFIG_ACPI_IRQ_VECTOR_MAX];
+	struct acpi_reg_base reg_bases[CONFIG_ACPI_MMIO_ENTRIES_MAX];
+	struct acpi_irq_resource irq_res;
+	struct acpi_mmio_resource mmio_res;
+	mm_reg_t *reg_base = DEVICE_MMIO_RAM_PTR(dev);
+
+	acpi_chld = acpi_device_get(hid, uid);
+	if (!acpi_chld) {
+		return -ENODEV;
+	}
+
+	mmio_res.mmio_max = ARRAY_SIZE(reg_bases);
+	mmio_res.reg_base = reg_bases;
+	ret = acpi_device_mmio_get(acpi_chld, &mmio_res);
+	if (ret) {
+		return ret;
+	}
+
+	if (ACPI_RESOURCE_TYPE_GET(&mmio_res) == ACPI_RES_TYPE_IO) {
+		*reg_base = (mm_reg_t)ACPI_IO_GET(&mmio_res);
+	} else if (ACPI_RESOURCE_TYPE_GET(&mmio_res) == ACPI_RES_TYPE_MEM) {
+#if defined(CONFIG_MMU)
+		device_map(reg_base, ACPI_MMIO_GET(&mmio_res), ACPI_RESOURCE_SIZE_GET(&mmio_res),
+			   K_MEM_CACHE_NONE);
+#else
+		*reg_base = ACPI_MMIO_GET(&mmio_res);
+#endif
+	} else {
+		return -ENODEV;
+	}
+
+	if (isr) {
+		irq_res.irq_vector_max = ARRAY_SIZE(irqs);
+		irq_res.irqs = irqs;
+		if (irq != ACPI_IRQ_DETECT) {
+			irq_connect_dynamic(irq, priority,
+					(void (*)(const void *))isr, dev, flags);
+			irq_enable(irq);
+		} else if (!acpi_device_irq_get(acpi_chld, &irq_res)) {
+			irq_connect_dynamic(irq_res.irqs[0], priority,
+					(void (*)(const void *))isr, dev,
+					    irq_res.flags);
+			irq_enable(irq_res.irqs[0]);
+		} else {
+			return -ENODEV;
+		}
+	}
+
+	return 0;
+}
+#endif
+
+#if defined(CONFIG_PCIE)
+/* TODO: add support for Multi MSI interrupt. */
+static int child_dev_config_irq(const struct device *dev, struct pci_conf *cfg, platform_isr_t isr)
+{
+	int irq;
+
+	/* If found valid ISR for the device. */
+	if (cfg->irq_num == PCIE_IRQ_DETECT) {
+		irq = pcie_alloc_irq(cfg->pcie->bdf);
+		if (irq == PCIE_CONF_INTR_IRQ_NONE) {
+			return -EINVAL;
+		}
+	} else {
+		irq = cfg->irq_num;
+		pcie_conf_write(cfg->pcie->bdf, PCIE_CONF_INTR, irq);
+	}
+
+	pcie_connect_dynamic_irq(cfg->pcie->bdf, irq, cfg->irq_prio, (void (*)(const void *))isr,
+				 dev, cfg->irq_flag);
+
+	pcie_irq_enable(cfg->pcie->bdf, irq);
+
+	return 0;
+}
+
+int platform_pci_init(const struct device *dev, struct pci_conf *cfg, platform_isr_t isr)
+{
+	int status = 0;
+	struct pcie_bar mbar;
+
+	if (!(cfg->pcie)) {
+		return -EINVAL;
+	}
+
+	if (!pcie_probe_mbar(cfg->pcie->bdf, 0, &mbar)) {
+		return -EINVAL;
+	}
+
+	/* TODO check IO mapped or not. */
+	pcie_set_cmd(cfg->pcie->bdf, PCIE_CONF_CMDSTAT_MEM, true);
+
+#if defined(CONFIG_MMU)
+	/* TODO check IO mapped or not. */
+	device_map(DEVICE_MMIO_RAM_PTR(dev), mbar.phys_addr, mbar.size, K_MEM_CACHE_NONE);
+#else
+	dev->mmio->mem = mbar.phys_addr;
+#endif
+
+	if (cfg->bus_master) {
+		pcie_set_cmd(cfg->pcie->bdf, PCIE_CONF_CMDSTAT_MASTER, true);
+	}
+
+	if (isr) {
+		status = child_dev_config_irq(dev, cfg, isr);
+	}
+
+	return status;
+}
+#endif


### PR DESCRIPTION
Provide Platform abstract interface for device drivers which are designed to work on multiple bus topologies such as PCI, ACPI or just DTS base. Driver developers can use the new PLATFORM_DT_DEV_INST_DEFINE macro instead of DEVICE_DT_INST_DEFINE in case they have to design drivers which need to works seamlessly on PCI bus, ACPI and DTS base.  Currently  there is no support for multi MSI and multi vectors. Following are some of the key features/highlight:

- Abstract underlying bus/parent complexity and providing a generic interface to driver developers. Using the new interface, driver developers need not want to bother about underlying bus interface and associated complexity. 
- Based on their parent node type, the interface will automatically enumerate resource such as MMIO and IRQ resources and configure them which will be completely transparent to device drivers
- The interface will take care of memory map of MMIO address in case platform support MMU
- The new PLATFORM_DT_DEV_INST_DEFINE  interface take ISR as one of the argument and will take care the ISR registration based on underlying bus/parent node  type(PCI/ACPI or just DTS). 
- The new interface add very little overhead (almost NIL) 