### PR TITLE
net: buf: resolve issues with fixed size network buffer pool

### DIFF
--- a/doc/releases/migration-guide-3.6.rst
+++ b/doc/releases/migration-guide-3.6.rst
@@ -503,6 +503,11 @@ Networking
 * The zperf ratio between mbps and kbps, kbps and bps is changed to 1000, instead of 1024,
   to align with iperf ratios.
 
+* For network buffer pools maximum allocation size was added to a common structure
+  ``struct net_buf_data_alloc`` as a new field ``max_alloc_size``. Similar member ``data_size`` of
+  ``struct net_buf_pool_fixed`` that was specific only for buffer pools with a fixed size was
+  removed.
+
 zcbor
 =====
 

--- a/include/zephyr/net/buf.h
+++ b/include/zephyr/net/buf.h
@@ -965,6 +965,7 @@ struct net_buf_data_cb {
 struct net_buf_data_alloc {
 	const struct net_buf_data_cb *cb;
 	void *alloc_data;
+	size_t max_alloc_size;
 };
 
 /**
@@ -1078,7 +1079,6 @@ extern const struct net_buf_data_alloc net_buf_heap_alloc;
 					 _destroy)
 
 struct net_buf_pool_fixed {
-	size_t data_size;
 	uint8_t *data_pool;
 };
 
@@ -1118,12 +1118,12 @@ extern const struct net_buf_data_cb net_buf_fixed_cb;
 	_NET_BUF_ARRAY_DEFINE(_name, _count, _ud_size);                        \
 	static uint8_t __noinit net_buf_data_##_name[_count][_data_size] __net_buf_align; \
 	static const struct net_buf_pool_fixed net_buf_fixed_##_name = {       \
-		.data_size = _data_size,                                       \
 		.data_pool = (uint8_t *)net_buf_data_##_name,                  \
 	};                                                                     \
 	static const struct net_buf_data_alloc net_buf_fixed_alloc_##_name = { \
 		.cb = &net_buf_fixed_cb,                                       \
 		.alloc_data = (void *)&net_buf_fixed_##_name,                  \
+		.max_alloc_size = _data_size,                                  \
 	};                                                                     \
 	static STRUCT_SECTION_ITERABLE(net_buf_pool, _name) =                  \
 		NET_BUF_POOL_INITIALIZER(_name, &net_buf_fixed_alloc_##_name,  \
@@ -1164,6 +1164,7 @@ extern const struct net_buf_data_cb net_buf_var_cb;
 	static const struct net_buf_data_alloc net_buf_data_alloc_##_name = {  \
 		.cb = &net_buf_var_cb,                                         \
 		.alloc_data = &net_buf_mem_pool_##_name,                       \
+		.max_alloc_size = 0,                                           \
 	};                                                                     \
 	static STRUCT_SECTION_ITERABLE(net_buf_pool, _name) =                  \
 		NET_BUF_POOL_INITIALIZER(_name, &net_buf_data_alloc_##_name,   \

--- a/tests/net/net_pkt/src/main.c
+++ b/tests/net/net_pkt/src/main.c
@@ -956,7 +956,7 @@ ZTEST(net_pkt_test_suite, test_net_pkt_headroom)
 	net_pkt_unref(pkt);
 }
 
-NET_BUF_POOL_FIXED_DEFINE(test_net_pkt_headroom_copy_pool, 2, 4, 4, NULL);
+NET_BUF_POOL_VAR_DEFINE(test_net_pkt_headroom_copy_pool, 2, 128, 4, NULL);
 
 ZTEST(net_pkt_test_suite, test_net_pkt_headroom_copy)
 {


### PR DESCRIPTION
This PR fixes issue discussed in https://github.com/zephyrproject-rtos/zephyr/issues/66870 (fix proposed by @jhedberg) with new test case. 
Additionally, it resolves an additional issue where fixed buffer would set it's size to requested length instead of the actual size (with additional check in existing unit test) .
 
Fixes #66870