### PR TITLE
Support multiple IPv4 netmasks per interface

### DIFF
--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -2168,7 +2168,9 @@ static bool on_cmd_atcmdinfo_ipaddr(struct net_buf **buf, uint16_t len)
 				LOG_ERR("Cannot set iface IPv4 addr");
 			}
 
-			net_if_ipv4_set_netmask(iface_ctx.iface, &iface_ctx.subnet);
+			net_if_ipv4_set_netmask_by_addr(iface_ctx.iface,
+							&new_ipv4_addr,
+							&iface_ctx.subnet);
 			net_if_ipv4_set_gw(iface_ctx.iface, &iface_ctx.gateway);
 #endif
 			/* store the new IP addr */

--- a/drivers/net/loopback.c
+++ b/drivers/net/loopback.c
@@ -50,7 +50,7 @@ static void loopback_init(struct net_if *iface)
 			LOG_ERR("Failed to register IPv4 loopback address");
 		}
 
-		net_if_ipv4_set_netmask(iface, &netmask);
+		net_if_ipv4_set_netmask_by_addr(iface, &ipv4_loopback, &netmask);
 	}
 
 	if (IS_ENABLED(CONFIG_NET_IPV6)) {

--- a/drivers/wifi/esp_at/esp.c
+++ b/drivers/wifi/esp_at/esp.c
@@ -514,13 +514,13 @@ static void esp_ip_addr_work(struct k_work *work)
 
 #if defined(CONFIG_NET_NATIVE_IPV4)
 	/* update interface addresses */
-	net_if_ipv4_set_gw(dev->net_iface, &dev->gw);
-	net_if_ipv4_set_netmask(dev->net_iface, &dev->nm);
 #if defined(CONFIG_WIFI_ESP_AT_IP_STATIC)
 	net_if_ipv4_addr_add(dev->net_iface, &dev->ip, NET_ADDR_MANUAL, 0);
 #else
 	net_if_ipv4_addr_add(dev->net_iface, &dev->ip, NET_ADDR_DHCP, 0);
 #endif
+	net_if_ipv4_set_gw(dev->net_iface, &dev->gw);
+	net_if_ipv4_set_netmask_by_addr(dev->net_iface, &dev->ip, &dev->nm);
 #endif
 
 	if (IS_ENABLED(CONFIG_WIFI_ESP_AT_DNS_USE)) {

--- a/drivers/wifi/eswifi/eswifi_core.c
+++ b/drivers/wifi/eswifi/eswifi_core.c
@@ -677,8 +677,8 @@ static int eswifi_mgmt_ap_enable(const struct device *dev,
 
 	/* Set IP Address */
 	for (i = 0; ipv4 && i < NET_IF_MAX_IPV4_ADDR; i++) {
-		if (ipv4->unicast[i].is_used) {
-			unicast = &ipv4->unicast[i];
+		if (ipv4->unicast[i].ipv4.is_used) {
+			unicast = &ipv4->unicast[i].ipv4;
 			break;
 		}
 	}

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -368,18 +368,27 @@ struct net_if_dhcpv6 {
 #endif
 /** @endcond */
 
+/**
+ * @brief Network Interface unicast IPv4 address and netmask
+ *
+ * Stores the unicast IPv4 address and related netmask.
+ */
+struct net_if_addr_ipv4 {
+	/** IPv4 address */
+	struct net_if_addr ipv4;
+	/** Netmask */
+	struct in_addr netmask;
+};
+
 struct net_if_ipv4 {
 	/** Unicast IP addresses */
-	struct net_if_addr unicast[NET_IF_MAX_IPV4_ADDR];
+	struct net_if_addr_ipv4 unicast[NET_IF_MAX_IPV4_ADDR];
 
 	/** Multicast IP addresses */
 	struct net_if_mcast_addr mcast[NET_IF_MAX_IPV4_MADDR];
 
 	/** Gateway */
 	struct in_addr gw;
-
-	/** Netmask */
-	struct in_addr netmask;
 
 	/** IPv4 time-to-live */
 	uint8_t ttl;
@@ -2280,6 +2289,18 @@ struct in_addr *net_if_ipv4_get_global_addr(struct net_if *iface,
 					    enum net_addr_state addr_state);
 
 /**
+ * @brief Get IPv4 netmask related to an address of an interface.
+ *
+ * @param iface Interface to use.
+ * @param addr IPv4 address to check.
+ *
+ * @return The netmask set on the interface related to the give address,
+ *         unspecified address if not found.
+ */
+struct in_addr net_if_ipv4_get_netmask_by_addr(struct net_if *iface,
+					       const struct in_addr *addr);
+
+/**
  * @brief Get IPv4 netmask of an interface.
  *
  * @param iface Interface to use.
@@ -2307,6 +2328,32 @@ void net_if_ipv4_set_netmask(struct net_if *iface,
  */
 __syscall bool net_if_ipv4_set_netmask_by_index(int index,
 						const struct in_addr *netmask);
+
+/**
+ * @brief Set IPv4 netmask for an interface index for a given address.
+ *
+ * @param index Network interface index
+ * @param addr IPv4 address related to this netmask
+ * @param netmask IPv4 netmask
+ *
+ * @return True if netmask was added, false otherwise.
+ */
+__syscall bool net_if_ipv4_set_netmask_by_addr_by_index(int index,
+							const struct in_addr *addr,
+							const struct in_addr *netmask);
+
+/**
+ * @brief Set IPv4 netmask for an interface index for a given address.
+ *
+ * @param iface Network interface
+ * @param addr IPv4 address related to this netmask
+ * @param netmask IPv4 netmask
+ *
+ * @return True if netmask was added, false otherwise.
+ */
+bool net_if_ipv4_set_netmask_by_addr(struct net_if *iface,
+				     const struct in_addr *addr,
+				     const struct in_addr *netmask);
 
 /**
  * @brief Set IPv4 gateway for an interface.

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -2303,31 +2303,37 @@ struct in_addr net_if_ipv4_get_netmask_by_addr(struct net_if *iface,
 /**
  * @brief Get IPv4 netmask of an interface.
  *
+ * @deprecated Use net_if_ipv4_get_netmask_by_addr() instead.
+ *
  * @param iface Interface to use.
  *
  * @return The netmask set on the interface, unspecified address if not found.
  */
-struct in_addr net_if_ipv4_get_netmask(struct net_if *iface);
+__deprecated struct in_addr net_if_ipv4_get_netmask(struct net_if *iface);
 
 /**
  * @brief Set IPv4 netmask for an interface.
  *
+ * @deprecated Use net_if_ipv4_set_netmask_by_addr() instead.
+ *
  * @param iface Interface to use.
  * @param netmask IPv4 netmask
  */
-void net_if_ipv4_set_netmask(struct net_if *iface,
-			     const struct in_addr *netmask);
+__deprecated void net_if_ipv4_set_netmask(struct net_if *iface,
+					  const struct in_addr *netmask);
 
 /**
  * @brief Set IPv4 netmask for an interface index.
+ *
+ * @deprecated Use net_if_ipv4_set_netmask_by_addr() instead.
  *
  * @param index Network interface index
  * @param netmask IPv4 netmask
  *
  * @return True if netmask was added, false otherwise.
  */
-__syscall bool net_if_ipv4_set_netmask_by_index(int index,
-						const struct in_addr *netmask);
+__deprecated __syscall bool net_if_ipv4_set_netmask_by_index(int index,
+							     const struct in_addr *netmask);
 
 /**
  * @brief Set IPv4 netmask for an interface index for a given address.

--- a/samples/boards/nxp_s32/netc/src/main.c
+++ b/samples/boards/nxp_s32/netc/src/main.c
@@ -54,12 +54,14 @@ static int setup_iface(struct net_if *iface, const char *ipv6_addr,
 		LOG_INF("IPv4 address: %s", ipv4_addr);
 
 		if (netmask && netmask[0]) {
-			if (net_addr_pton(AF_INET, netmask, &addr4)) {
+			struct in_addr nm;
+
+			if (net_addr_pton(AF_INET, netmask, &nm)) {
 				LOG_ERR("Invalid netmask: %s", netmask);
 				return -EINVAL;
 			}
 
-			net_if_ipv4_set_netmask(iface, &addr4);
+			net_if_ipv4_set_netmask_by_addr(iface, &addr4, &nm);
 		}
 	}
 

--- a/samples/net/dhcpv4_client/src/main.c
+++ b/samples/net/dhcpv4_client/src/main.c
@@ -50,18 +50,18 @@ static void handler(struct net_mgmt_event_callback *cb,
 	for (i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
 		char buf[NET_IPV4_ADDR_LEN];
 
-		if (iface->config.ip.ipv4->unicast[i].addr_type !=
+		if (iface->config.ip.ipv4->unicast[i].ipv4.addr_type !=
 							NET_ADDR_DHCP) {
 			continue;
 		}
 
 		LOG_INF("   Address[%d]: %s", net_if_get_by_iface(iface),
 			net_addr_ntop(AF_INET,
-			    &iface->config.ip.ipv4->unicast[i].address.in_addr,
+			    &iface->config.ip.ipv4->unicast[i].ipv4.address.in_addr,
 						  buf, sizeof(buf)));
 		LOG_INF("    Subnet[%d]: %s", net_if_get_by_iface(iface),
 			net_addr_ntop(AF_INET,
-				       &iface->config.ip.ipv4->netmask,
+				       &iface->config.ip.ipv4->unicast[i].netmask,
 				       buf, sizeof(buf)));
 		LOG_INF("    Router[%d]: %s", net_if_get_by_iface(iface),
 			net_addr_ntop(AF_INET,

--- a/samples/net/dns_resolve/src/main.c
+++ b/samples/net/dns_resolve/src/main.c
@@ -168,6 +168,7 @@ static void print_dhcpv4_addr(struct net_if *iface, struct net_if_addr *if_addr,
 {
 	bool *found = (bool *)user_data;
 	char hr_addr[NET_IPV4_ADDR_LEN];
+	struct in_addr netmask;
 
 	if (*found) {
 		return;
@@ -181,10 +182,11 @@ static void print_dhcpv4_addr(struct net_if *iface, struct net_if_addr *if_addr,
 		net_addr_ntop(AF_INET, &if_addr->address.in_addr,
 			      hr_addr, NET_IPV4_ADDR_LEN));
 	LOG_INF("Lease time: %u seconds", iface->config.dhcpv4.lease_time);
+
+	netmask = net_if_ipv4_get_netmask_by_addr(iface,
+						  &if_addr->address.in_addr);
 	LOG_INF("Subnet: %s",
-		net_addr_ntop(AF_INET,
-			      &iface->config.ip.ipv4->netmask,
-			      hr_addr, NET_IPV4_ADDR_LEN));
+		net_addr_ntop(AF_INET, &netmask, hr_addr, NET_IPV4_ADDR_LEN));
 	LOG_INF("Router: %s",
 		net_addr_ntop(AF_INET,
 			      &iface->config.ip.ipv4->gw,

--- a/samples/net/ipv4_autoconf/src/main.c
+++ b/samples/net/ipv4_autoconf/src/main.c
@@ -41,13 +41,17 @@ static void handler(struct net_mgmt_event_callback *cb,
 	for (i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
 		char buf[NET_IPV4_ADDR_LEN];
 
-		if (cfg->ip.ipv4->unicast[i].addr_type != NET_ADDR_AUTOCONF) {
+		if (cfg->ip.ipv4->unicast[i].ipv4.addr_type != NET_ADDR_AUTOCONF) {
 			continue;
 		}
 
 		LOG_INF("Your address: %s",
 			net_addr_ntop(AF_INET,
-				    &cfg->ip.ipv4->unicast[i].address.in_addr,
+				    &cfg->ip.ipv4->unicast[i].ipv4.address.in_addr,
+				    buf, sizeof(buf)));
+		LOG_INF("Your netmask: %s",
+			net_addr_ntop(AF_INET,
+				    &cfg->ip.ipv4->unicast[i].netmask,
 				    buf, sizeof(buf)));
 	}
 }

--- a/samples/net/mdns_responder/src/vlan.c
+++ b/samples/net/mdns_responder/src/vlan.c
@@ -86,12 +86,14 @@ static int setup_iface(struct net_if *iface, const char *ipv6_addr,
 		}
 
 		if (netmask && netmask[0]) {
-			if (net_addr_pton(AF_INET, netmask, &addr4)) {
+			struct in_addr nm;
+
+			if (net_addr_pton(AF_INET, netmask, &nm)) {
 				LOG_ERR("Invalid netmask: %s", ipv4_addr);
 				return -EINVAL;
 			}
 
-			net_if_ipv4_set_netmask(iface, &addr4);
+			net_if_ipv4_set_netmask_by_addr(iface, &addr4, &nm);
 		}
 	}
 

--- a/samples/net/sockets/echo_server/src/vlan.c
+++ b/samples/net/sockets/echo_server/src/vlan.c
@@ -86,12 +86,14 @@ static int setup_iface(struct net_if *iface, const char *ipv6_addr,
 		}
 
 		if (netmask && netmask[0]) {
-			if (net_addr_pton(AF_INET, netmask, &addr4)) {
+			struct in_addr nm;
+
+			if (net_addr_pton(AF_INET, netmask, &nm)) {
 				LOG_ERR("Invalid netmask: %s", ipv4_addr);
 				return -EINVAL;
 			}
 
-			net_if_ipv4_set_netmask(iface, &addr4);
+			net_if_ipv4_set_netmask_by_addr(iface, &addr4, &nm);
 		}
 	}
 

--- a/samples/net/virtual/src/main.c
+++ b/samples/net/virtual/src/main.c
@@ -302,12 +302,14 @@ try_ipv4:
 		}
 
 		if (netmask) {
-			if (net_addr_pton(AF_INET, netmask, &addr4)) {
+			struct in_addr nm;
+
+			if (net_addr_pton(AF_INET, netmask, &nm)) {
 				LOG_ERR("Invalid netmask: %s", netmask);
 				return -EINVAL;
 			}
 
-			net_if_ipv4_set_netmask(iface, &addr4);
+			net_if_ipv4_set_netmask_by_addr(iface, &addr4, &nm);
 		}
 
 		if (!peer4addr || *peer4addr == '\0') {

--- a/samples/subsys/mgmt/hawkbit/src/dhcp.c
+++ b/samples/subsys/mgmt/hawkbit/src/dhcp.c
@@ -22,24 +22,15 @@ static void handler(struct net_mgmt_event_callback *cb,
 		    uint32_t mgmt_event,
 		    struct net_if *iface)
 {
-	int i;
 	bool notified = false;
 
-	if (mgmt_event != NET_EVENT_IPV4_ADDR_ADD) {
+	if (mgmt_event != NET_EVENT_IPV4_DHCP_BOUND) {
 		return;
 	}
 
-	for (i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
-		if (iface->config.ip.ipv4->unicast[i].ipv4.addr_type !=
-		    NET_ADDR_DHCP) {
-			continue;
-		}
-
-		if (!notified) {
-			k_sem_give(&got_address);
-			notified = true;
-		}
-		break;
+	if (!notified) {
+		k_sem_give(&got_address);
+		notified = true;
 	}
 }
 
@@ -51,7 +42,7 @@ void app_dhcpv4_startup(void)
 	struct net_if *iface;
 
 	net_mgmt_init_event_callback(&mgmt_cb, handler,
-				     NET_EVENT_IPV4_ADDR_ADD);
+				     NET_EVENT_IPV4_DHCP_BOUND);
 	net_mgmt_add_event_callback(&mgmt_cb);
 
 	iface = net_if_get_default();

--- a/samples/subsys/mgmt/hawkbit/src/dhcp.c
+++ b/samples/subsys/mgmt/hawkbit/src/dhcp.c
@@ -30,7 +30,7 @@ static void handler(struct net_mgmt_event_callback *cb,
 	}
 
 	for (i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
-		if (iface->config.ip.ipv4->unicast[i].addr_type !=
+		if (iface->config.ip.ipv4->unicast[i].ipv4.addr_type !=
 		    NET_ADDR_DHCP) {
 			continue;
 		}

--- a/subsys/net/ip/ipv4_autoconf.c
+++ b/subsys/net/ip/ipv4_autoconf.c
@@ -182,7 +182,9 @@ static inline void ipv4_autoconf_addr_set(struct net_if_ipv4_autoconf *ipv4auto)
 		return;
 	}
 
-	net_if_ipv4_set_netmask(ipv4auto->iface, &netmask);
+	net_if_ipv4_set_netmask_by_addr(ipv4auto->iface,
+					&ipv4auto->requested_ip,
+					&netmask);
 
 	ipv4auto->state = NET_IPV4_AUTOCONF_ASSIGNED;
 }

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -3751,8 +3751,8 @@ out:
  * in this case and set the first one found. Please use
  * net_if_ipv4_set_netmask_by_addr() instead.
  */
-void net_if_ipv4_set_netmask(struct net_if *iface,
-			     const struct in_addr *netmask)
+static void net_if_ipv4_set_netmask_deprecated(struct net_if *iface,
+					       const struct in_addr *netmask)
 {
 	struct net_if_ipv4 *ipv4;
 
@@ -3781,6 +3781,12 @@ out:
 	net_if_unlock(iface);
 }
 
+void net_if_ipv4_set_netmask(struct net_if *iface,
+			     const struct in_addr *netmask)
+{
+	net_if_ipv4_set_netmask_deprecated(iface, netmask);
+}
+
 bool z_impl_net_if_ipv4_set_netmask_by_index(int index,
 					     const struct in_addr *netmask)
 {
@@ -3791,7 +3797,7 @@ bool z_impl_net_if_ipv4_set_netmask_by_index(int index,
 		return false;
 	}
 
-	net_if_ipv4_set_netmask(iface, netmask);
+	net_if_ipv4_set_netmask_deprecated(iface, netmask);
 
 	return true;
 }

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -3280,16 +3280,17 @@ bool net_if_ipv4_addr_mask_cmp(struct net_if *iface,
 		goto out;
 	}
 
-	subnet = UNALIGNED_GET(&addr->s_addr) & ipv4->netmask.s_addr;
-
 	for (i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
-		if (!ipv4->unicast[i].is_used ||
-		    ipv4->unicast[i].address.family != AF_INET) {
+		if (!ipv4->unicast[i].ipv4.is_used ||
+		    ipv4->unicast[i].ipv4.address.family != AF_INET) {
 			continue;
 		}
 
-		if ((ipv4->unicast[i].address.in_addr.s_addr &
-		     ipv4->netmask.s_addr) == subnet) {
+		subnet = UNALIGNED_GET(&addr->s_addr) &
+			 ipv4->unicast[i].netmask.s_addr;
+
+		if ((ipv4->unicast[i].ipv4.address.in_addr.s_addr &
+		     ipv4->unicast[i].netmask.s_addr) == subnet) {
 			ret = true;
 			goto out;
 		}
@@ -3306,6 +3307,7 @@ static bool ipv4_is_broadcast_address(struct net_if *iface,
 {
 	struct net_if_ipv4 *ipv4;
 	bool ret = false;
+	struct in_addr bcast;
 
 	net_if_lock(iface);
 
@@ -3315,15 +3317,19 @@ static bool ipv4_is_broadcast_address(struct net_if *iface,
 		goto out;
 	}
 
-	if (!net_if_ipv4_addr_mask_cmp(iface, addr)) {
-		ret = false;
-		goto out;
-	}
+	for (int i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
+		if (!ipv4->unicast[i].ipv4.is_used ||
+		    ipv4->unicast[i].ipv4.address.family != AF_INET) {
+			continue;
+		}
 
-	if ((UNALIGNED_GET(&addr->s_addr) & ~ipv4->netmask.s_addr) ==
-	    ~ipv4->netmask.s_addr) {
-		ret = true;
-		goto out;
+		bcast.s_addr = ipv4->unicast[i].ipv4.address.in_addr.s_addr |
+			       ~ipv4->unicast[i].netmask.s_addr;
+
+		if (bcast.s_addr == addr->s_addr) {
+			ret = true;
+			goto out;
+		}
 	}
 
 out:
@@ -3408,14 +3414,14 @@ static struct in_addr *net_if_ipv4_get_best_match(struct net_if *iface,
 	}
 
 	for (i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
-		if (!is_proper_ipv4_address(&ipv4->unicast[i])) {
+		if (!is_proper_ipv4_address(&ipv4->unicast[i].ipv4)) {
 			continue;
 		}
 
-		len = get_diff_ipv4(dst, &ipv4->unicast[i].address.in_addr);
+		len = get_diff_ipv4(dst, &ipv4->unicast[i].ipv4.address.in_addr);
 		if (len >= *best_so_far) {
 			*best_so_far = len;
-			src = &ipv4->unicast[i].address.in_addr;
+			src = &ipv4->unicast[i].ipv4.address.in_addr;
 		}
 	}
 
@@ -3444,14 +3450,14 @@ static struct in_addr *if_ipv4_get_addr(struct net_if *iface,
 	}
 
 	for (i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
-		if (!ipv4->unicast[i].is_used ||
+		if (!ipv4->unicast[i].ipv4.is_used ||
 		    (addr_state != NET_ADDR_ANY_STATE &&
-		     ipv4->unicast[i].addr_state != addr_state) ||
-		    ipv4->unicast[i].address.family != AF_INET) {
+		     ipv4->unicast[i].ipv4.addr_state != addr_state) ||
+		    ipv4->unicast[i].ipv4.address.family != AF_INET) {
 			continue;
 		}
 
-		if (net_ipv4_is_ll_addr(&ipv4->unicast[i].address.in_addr)) {
+		if (net_ipv4_is_ll_addr(&ipv4->unicast[i].ipv4.address.in_addr)) {
 			if (!ll) {
 				continue;
 			}
@@ -3461,7 +3467,7 @@ static struct in_addr *if_ipv4_get_addr(struct net_if *iface,
 			}
 		}
 
-		addr = &ipv4->unicast[i].address.in_addr;
+		addr = &ipv4->unicast[i].ipv4.address.in_addr;
 		goto out;
 	}
 
@@ -3570,19 +3576,19 @@ struct net_if_addr *net_if_ipv4_addr_lookup(const struct in_addr *addr,
 		}
 
 		for (i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
-			if (!ipv4->unicast[i].is_used ||
-			    ipv4->unicast[i].address.family != AF_INET) {
+			if (!ipv4->unicast[i].ipv4.is_used ||
+			    ipv4->unicast[i].ipv4.address.family != AF_INET) {
 				continue;
 			}
 
 			if (UNALIGNED_GET(&addr->s4_addr32[0]) ==
-			    ipv4->unicast[i].address.in_addr.s_addr) {
+			    ipv4->unicast[i].ipv4.address.in_addr.s_addr) {
 
 				if (ret) {
 					*ret = iface;
 				}
 
-				ifaddr = &ipv4->unicast[i];
+				ifaddr = &ipv4->unicast[i].ipv4;
 				net_if_unlock(iface);
 				goto out;
 			}
@@ -3621,9 +3627,12 @@ static inline int z_vrfy_net_if_ipv4_addr_lookup_by_index(
 #include <syscalls/net_if_ipv4_addr_lookup_by_index_mrsh.c>
 #endif
 
-struct in_addr net_if_ipv4_get_netmask(struct net_if *iface)
+struct in_addr net_if_ipv4_get_netmask_by_addr(struct net_if *iface,
+					       const struct in_addr *addr)
 {
 	struct in_addr netmask = { 0 };
+	struct net_if_ipv4 *ipv4;
+	uint32_t subnet;
 
 	net_if_lock(iface);
 
@@ -3631,31 +3640,143 @@ struct in_addr net_if_ipv4_get_netmask(struct net_if *iface)
 		goto out;
 	}
 
-	if (!iface->config.ip.ipv4) {
+	ipv4 = iface->config.ip.ipv4;
+	if (ipv4 == NULL) {
 		goto out;
 	}
 
-	netmask = iface->config.ip.ipv4->netmask;
+	for (int i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
+		if (!ipv4->unicast[i].ipv4.is_used ||
+		    ipv4->unicast[i].ipv4.address.family != AF_INET) {
+			continue;
+		}
+
+		subnet = UNALIGNED_GET(&addr->s_addr) &
+			 ipv4->unicast[i].netmask.s_addr;
+
+		if ((ipv4->unicast[i].ipv4.address.in_addr.s_addr &
+		     ipv4->unicast[i].netmask.s_addr) == subnet) {
+			netmask = ipv4->unicast[i].netmask;
+			goto out;
+		}
+	}
+
 out:
 	net_if_unlock(iface);
 
 	return netmask;
 }
 
-void net_if_ipv4_set_netmask(struct net_if *iface,
-			     const struct in_addr *netmask)
+bool net_if_ipv4_set_netmask_by_addr(struct net_if *iface,
+				     const struct in_addr *addr,
+				     const struct in_addr *netmask)
 {
+	struct net_if_ipv4 *ipv4;
+	uint32_t subnet;
+	bool ret = false;
+
 	net_if_lock(iface);
 
 	if (net_if_config_ipv4_get(iface, NULL) < 0) {
 		goto out;
 	}
 
-	if (!iface->config.ip.ipv4) {
+	ipv4 = iface->config.ip.ipv4;
+	if (ipv4 == NULL) {
 		goto out;
 	}
 
-	net_ipaddr_copy(&iface->config.ip.ipv4->netmask, netmask);
+	for (int i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
+		if (!ipv4->unicast[i].ipv4.is_used ||
+		    ipv4->unicast[i].ipv4.address.family != AF_INET) {
+			continue;
+		}
+
+		subnet = UNALIGNED_GET(&addr->s_addr) &
+			 ipv4->unicast[i].netmask.s_addr;
+
+		if ((ipv4->unicast[i].ipv4.address.in_addr.s_addr &
+		     ipv4->unicast[i].netmask.s_addr) == subnet) {
+			ipv4->unicast[i].netmask = *netmask;
+			ret = true;
+			goto out;
+		}
+	}
+
+out:
+	net_if_unlock(iface);
+
+	return ret;
+}
+
+/* Using this function is problematic as if we have multiple
+ * addresses configured, which one to return. Use heuristic
+ * in this case and return the first one found. Please use
+ * net_if_ipv4_get_netmask_by_addr() instead.
+ */
+struct in_addr net_if_ipv4_get_netmask(struct net_if *iface)
+{
+	struct in_addr netmask = { 0 };
+	struct net_if_ipv4 *ipv4;
+
+	net_if_lock(iface);
+
+	if (net_if_config_ipv4_get(iface, NULL) < 0) {
+		goto out;
+	}
+
+	ipv4 = iface->config.ip.ipv4;
+	if (ipv4 == NULL) {
+		goto out;
+	}
+
+	for (int i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
+		if (!ipv4->unicast[i].ipv4.is_used ||
+		    ipv4->unicast[i].ipv4.address.family != AF_INET) {
+			continue;
+		}
+
+		netmask = iface->config.ip.ipv4->unicast[i].netmask;
+		break;
+	}
+
+out:
+	net_if_unlock(iface);
+
+	return netmask;
+}
+
+/* Using this function is problematic as if we have multiple
+ * addresses configured, which one to set. Use heuristic
+ * in this case and set the first one found. Please use
+ * net_if_ipv4_set_netmask_by_addr() instead.
+ */
+void net_if_ipv4_set_netmask(struct net_if *iface,
+			     const struct in_addr *netmask)
+{
+	struct net_if_ipv4 *ipv4;
+
+	net_if_lock(iface);
+
+	if (net_if_config_ipv4_get(iface, NULL) < 0) {
+		goto out;
+	}
+
+	ipv4 = iface->config.ip.ipv4;
+	if (ipv4 == NULL) {
+		goto out;
+	}
+
+	for (int i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
+		if (!ipv4->unicast[i].ipv4.is_used ||
+		    ipv4->unicast[i].ipv4.address.family != AF_INET) {
+			continue;
+		}
+
+		net_ipaddr_copy(&ipv4->unicast[i].netmask, netmask);
+		break;
+	}
+
 out:
 	net_if_unlock(iface);
 }
@@ -3671,6 +3792,22 @@ bool z_impl_net_if_ipv4_set_netmask_by_index(int index,
 	}
 
 	net_if_ipv4_set_netmask(iface, netmask);
+
+	return true;
+}
+
+bool z_impl_net_if_ipv4_set_netmask_by_addr_by_index(int index,
+						     const struct in_addr *addr,
+						     const struct in_addr *netmask)
+{
+	struct net_if *iface;
+
+	iface = net_if_get_by_index(index);
+	if (!iface) {
+		return false;
+	}
+
+	net_if_ipv4_set_netmask_by_addr(iface, addr, netmask);
 
 	return true;
 }
@@ -3694,6 +3831,30 @@ bool z_vrfy_net_if_ipv4_set_netmask_by_index(int index,
 }
 
 #include <syscalls/net_if_ipv4_set_netmask_by_index_mrsh.c>
+
+bool z_vrfy_net_if_ipv4_set_netmask_by_addr_by_index(int index,
+						     const struct in_addr *addr,
+						     const struct in_addr *netmask)
+{
+	struct in_addr ipv4_addr, netmask_addr;
+	struct net_if *iface;
+
+	iface = z_vrfy_net_if_get_by_index(index);
+	if (!iface) {
+		return false;
+	}
+
+	K_OOPS(k_usermode_from_copy(&ipv4_addr, (void *)addr,
+				    sizeof(ipv4_addr)));
+	K_OOPS(k_usermode_from_copy(&netmask_addr, (void *)netmask,
+				    sizeof(netmask_addr)));
+
+	return z_impl_net_if_ipv4_set_netmask_by_addr_by_index(index,
+							       &ipv4_addr,
+							       &netmask_addr);
+}
+
+#include <syscalls/net_if_ipv4_set_netmask_by_addr_by_index_mrsh.c>
 #endif /* CONFIG_USERSPACE */
 
 void net_if_ipv4_set_gw(struct net_if *iface, const struct in_addr *gw)
@@ -3755,13 +3916,13 @@ static struct net_if_addr *ipv4_addr_find(struct net_if *iface,
 	int i;
 
 	for (i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
-		if (!ipv4->unicast[i].is_used) {
+		if (!ipv4->unicast[i].ipv4.is_used) {
 			continue;
 		}
 
 		if (net_ipv4_addr_cmp(addr,
-				      &ipv4->unicast[i].address.in_addr)) {
-			return &ipv4->unicast[i];
+				      &ipv4->unicast[i].ipv4.address.in_addr)) {
+			return &ipv4->unicast[i].ipv4;
 		}
 	}
 
@@ -3790,7 +3951,7 @@ struct net_if_addr *net_if_ipv4_addr_add(struct net_if *iface,
 	}
 
 	for (i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
-		struct net_if_addr *cur = &ipv4->unicast[i];
+		struct net_if_addr *cur = &ipv4->unicast[i].ipv4;
 
 		if (addr_type == NET_ADDR_DHCP
 		    && cur->addr_type == NET_ADDR_OVERRIDABLE) {
@@ -3798,7 +3959,7 @@ struct net_if_addr *net_if_ipv4_addr_add(struct net_if *iface,
 			break;
 		}
 
-		if (!ipv4->unicast[i].is_used) {
+		if (!ipv4->unicast[i].ipv4.is_used) {
 			ifaddr = cur;
 			break;
 		}
@@ -3854,23 +4015,23 @@ bool net_if_ipv4_addr_rm(struct net_if *iface, const struct in_addr *addr)
 	}
 
 	for (i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
-		if (!ipv4->unicast[i].is_used) {
+		if (!ipv4->unicast[i].ipv4.is_used) {
 			continue;
 		}
 
-		if (!net_ipv4_addr_cmp(&ipv4->unicast[i].address.in_addr,
+		if (!net_ipv4_addr_cmp(&ipv4->unicast[i].ipv4.address.in_addr,
 				       addr)) {
 			continue;
 		}
 
-		ipv4->unicast[i].is_used = false;
+		ipv4->unicast[i].ipv4.is_used = false;
 
 		NET_DBG("[%d] interface %p address %s removed",
 			i, iface, net_sprint_ipv4_addr(addr));
 
 		net_mgmt_event_notify_with_info(
 			NET_EVENT_IPV4_ADDR_DEL, iface,
-			&ipv4->unicast[i].address.in_addr,
+			&ipv4->unicast[i].ipv4.address.in_addr,
 			sizeof(struct in_addr));
 
 		ret = true;
@@ -3975,7 +4136,7 @@ void net_if_ipv4_addr_foreach(struct net_if *iface, net_if_ip_addr_cb_t cb,
 	}
 
 	for (int i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
-		struct net_if_addr *if_addr = &ipv4->unicast[i];
+		struct net_if_addr *if_addr = &ipv4->unicast[i].ipv4;
 
 		if (!if_addr->is_used) {
 			continue;

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -1274,7 +1274,7 @@ void net_if_start_dad(struct net_if *iface)
 	struct net_if_addr *ifaddr;
 	struct net_if_ipv6 *ipv6;
 	struct in6_addr addr = { };
-	int ret, i;
+	int ret;
 
 	net_if_lock(iface);
 
@@ -1304,7 +1304,7 @@ void net_if_start_dad(struct net_if *iface)
 	/* Start DAD for all the addresses that were added earlier when
 	 * the interface was down.
 	 */
-	for (i = 0; i < NET_IF_MAX_IPV6_ADDR; i++) {
+	ARRAY_FOR_EACH(ipv6->unicast, i) {
 		if (!ipv6->unicast[i].is_used ||
 		    ipv6->unicast[i].address.family != AF_INET6 ||
 		    &ipv6->unicast[i] == ifaddr ||
@@ -1500,7 +1500,6 @@ struct net_if_addr *net_if_ipv6_addr_lookup(const struct in6_addr *addr,
 
 	STRUCT_SECTION_FOREACH(net_if, iface) {
 		struct net_if_ipv6 *ipv6;
-		int i;
 
 		net_if_lock(iface);
 
@@ -1510,7 +1509,7 @@ struct net_if_addr *net_if_ipv6_addr_lookup(const struct in6_addr *addr,
 			continue;
 		}
 
-		for (i = 0; i < NET_IF_MAX_IPV6_ADDR; i++) {
+		ARRAY_FOR_EACH(ipv6->unicast, i) {
 			if (!ipv6->unicast[i].is_used ||
 			    ipv6->unicast[i].address.family != AF_INET6) {
 				continue;
@@ -1543,7 +1542,6 @@ struct net_if_addr *net_if_ipv6_addr_lookup_by_iface(struct net_if *iface,
 {
 	struct net_if_addr *ifaddr = NULL;
 	struct net_if_ipv6 *ipv6;
-	int i;
 
 	net_if_lock(iface);
 
@@ -1552,7 +1550,7 @@ struct net_if_addr *net_if_ipv6_addr_lookup_by_iface(struct net_if *iface,
 		goto out;
 	}
 
-	for (i = 0; i < NET_IF_MAX_IPV6_ADDR; i++) {
+	ARRAY_FOR_EACH(ipv6->unicast, i) {
 		if (!ipv6->unicast[i].is_used ||
 		    ipv6->unicast[i].address.family != AF_INET6) {
 			continue;
@@ -1687,9 +1685,8 @@ static struct net_if_addr *ipv6_addr_find(struct net_if *iface,
 					  struct in6_addr *addr)
 {
 	struct net_if_ipv6 *ipv6 = iface->config.ip.ipv6;
-	int i;
 
-	for (i = 0; i < NET_IF_MAX_IPV6_ADDR; i++) {
+	ARRAY_FOR_EACH(ipv6->unicast, i) {
 		if (!ipv6->unicast[i].is_used) {
 			continue;
 		}
@@ -1736,7 +1733,6 @@ struct net_if_addr *net_if_ipv6_addr_add(struct net_if *iface,
 {
 	struct net_if_addr *ifaddr = NULL;
 	struct net_if_ipv6 *ipv6;
-	int i;
 
 	net_if_lock(iface);
 
@@ -1749,7 +1745,7 @@ struct net_if_addr *net_if_ipv6_addr_add(struct net_if *iface,
 		goto out;
 	}
 
-	for (i = 0; i < NET_IF_MAX_IPV6_ADDR; i++) {
+	ARRAY_FOR_EACH(ipv6->unicast, i) {
 		if (ipv6->unicast[i].is_used) {
 			continue;
 		}
@@ -1757,7 +1753,7 @@ struct net_if_addr *net_if_ipv6_addr_add(struct net_if *iface,
 		net_if_addr_init(&ipv6->unicast[i], addr, addr_type,
 				 vlifetime);
 
-		NET_DBG("[%d] interface %p address %s type %s added", i,
+		NET_DBG("[%zu] interface %p address %s type %s added", i,
 			iface, net_sprint_ipv6_addr(addr),
 			net_addr_type2str(addr_type));
 
@@ -1819,7 +1815,7 @@ bool net_if_ipv6_addr_rm(struct net_if *iface, const struct in6_addr *addr)
 
 	net_ipv6_addr_create_solicited_node(addr, &maddr);
 
-	for (int i = 0; i < NET_IF_MAX_IPV6_ADDR; i++) {
+	ARRAY_FOR_EACH(ipv6->unicast, i) {
 		struct in6_addr unicast_maddr;
 
 		if (!ipv6->unicast[i].is_used) {
@@ -1992,7 +1988,7 @@ void net_if_ipv6_addr_foreach(struct net_if *iface, net_if_ip_addr_cb_t cb,
 		goto out;
 	}
 
-	for (int i = 0; i < NET_IF_MAX_IPV6_ADDR; i++) {
+	ARRAY_FOR_EACH(ipv6->unicast, i) {
 		struct net_if_addr *if_addr = &ipv6->unicast[i];
 
 		if (!if_addr->is_used) {
@@ -2011,7 +2007,6 @@ struct net_if_mcast_addr *net_if_ipv6_maddr_add(struct net_if *iface,
 {
 	struct net_if_mcast_addr *ifmaddr = NULL;
 	struct net_if_ipv6 *ipv6;
-	int i;
 
 	net_if_lock(iface);
 
@@ -2031,7 +2026,7 @@ struct net_if_mcast_addr *net_if_ipv6_maddr_add(struct net_if *iface,
 		goto out;
 	}
 
-	for (i = 0; i < NET_IF_MAX_IPV6_MADDR; i++) {
+	ARRAY_FOR_EACH(ipv6->mcast, i) {
 		if (ipv6->mcast[i].is_used) {
 			continue;
 		}
@@ -2040,7 +2035,7 @@ struct net_if_mcast_addr *net_if_ipv6_maddr_add(struct net_if *iface,
 		ipv6->mcast[i].address.family = AF_INET6;
 		memcpy(&ipv6->mcast[i].address.in6_addr, addr, 16);
 
-		NET_DBG("[%d] interface %p address %s added", i, iface,
+		NET_DBG("[%zu] interface %p address %s added", i, iface,
 			net_sprint_ipv6_addr(addr));
 
 		net_mgmt_event_notify_with_info(
@@ -2062,7 +2057,6 @@ bool net_if_ipv6_maddr_rm(struct net_if *iface, const struct in6_addr *addr)
 {
 	bool ret = false;
 	struct net_if_ipv6 *ipv6;
-	int i;
 
 	net_if_lock(iface);
 
@@ -2071,7 +2065,7 @@ bool net_if_ipv6_maddr_rm(struct net_if *iface, const struct in6_addr *addr)
 		goto out;
 	}
 
-	for (i = 0; i < NET_IF_MAX_IPV6_MADDR; i++) {
+	ARRAY_FOR_EACH(ipv6->mcast, i) {
 		if (!ipv6->mcast[i].is_used) {
 			continue;
 		}
@@ -2083,7 +2077,7 @@ bool net_if_ipv6_maddr_rm(struct net_if *iface, const struct in6_addr *addr)
 
 		ipv6->mcast[i].is_used = false;
 
-		NET_DBG("[%d] interface %p address %s removed",
+		NET_DBG("[%zu] interface %p address %s removed",
 			i, iface, net_sprint_ipv6_addr(addr));
 
 		net_mgmt_event_notify_with_info(
@@ -2108,7 +2102,6 @@ struct net_if_mcast_addr *net_if_ipv6_maddr_lookup(const struct in6_addr *maddr,
 
 	STRUCT_SECTION_FOREACH(net_if, iface) {
 		struct net_if_ipv6 *ipv6;
-		int i;
 
 		if (ret && *ret && iface != *ret) {
 			continue;
@@ -2122,7 +2115,7 @@ struct net_if_mcast_addr *net_if_ipv6_maddr_lookup(const struct in6_addr *maddr,
 			continue;
 		}
 
-		for (i = 0; i < NET_IF_MAX_IPV6_MADDR; i++) {
+		ARRAY_FOR_EACH(ipv6->mcast, i) {
 			if (!ipv6->mcast[i].is_used ||
 			    ipv6->mcast[i].address.family != AF_INET6) {
 				continue;
@@ -2174,9 +2167,7 @@ static void remove_prefix_addresses(struct net_if *iface,
 				    struct in6_addr *addr,
 				    uint8_t len)
 {
-	int i;
-
-	for (i = 0; i < NET_IF_MAX_IPV6_ADDR; i++) {
+	ARRAY_FOR_EACH(ipv6->unicast, i) {
 		if (!ipv6->unicast[i].is_used ||
 		    ipv6->unicast[i].address.family != AF_INET6 ||
 		    ipv6->unicast[i].addr_type != NET_ADDR_AUTOCONF) {
@@ -2317,13 +2308,12 @@ static struct net_if_ipv6_prefix *ipv6_prefix_find(struct net_if *iface,
 						   uint8_t prefix_len)
 {
 	struct net_if_ipv6 *ipv6 = iface->config.ip.ipv6;
-	int i;
 
 	if (!ipv6) {
 		return NULL;
 	}
 
-	for (i = 0; i < NET_IF_MAX_IPV6_PREFIX; i++) {
+	ARRAY_FOR_EACH(ipv6->prefix, i) {
 		if (!ipv6->prefix[i].is_used) {
 			continue;
 		}
@@ -2361,7 +2351,6 @@ struct net_if_ipv6_prefix *net_if_ipv6_prefix_add(struct net_if *iface,
 {
 	struct net_if_ipv6_prefix *ifprefix = NULL;
 	struct net_if_ipv6 *ipv6;
-	int i;
 
 	net_if_lock(iface);
 
@@ -2378,7 +2367,7 @@ struct net_if_ipv6_prefix *net_if_ipv6_prefix_add(struct net_if *iface,
 		goto out;
 	}
 
-	for (i = 0; i < NET_IF_MAX_IPV6_PREFIX; i++) {
+	ARRAY_FOR_EACH(ipv6->prefix, i) {
 		if (ipv6->prefix[i].is_used) {
 			continue;
 		}
@@ -2386,7 +2375,7 @@ struct net_if_ipv6_prefix *net_if_ipv6_prefix_add(struct net_if *iface,
 		net_if_ipv6_prefix_init(iface, &ipv6->prefix[i], prefix,
 					len, lifetime);
 
-		NET_DBG("[%d] interface %p prefix %s/%d added", i, iface,
+		NET_DBG("[%zu] interface %p prefix %s/%d added", i, iface,
 			net_sprint_ipv6_addr(prefix), len);
 
 		if (IS_ENABLED(CONFIG_NET_MGMT_EVENT_INFO)) {
@@ -2418,7 +2407,6 @@ bool net_if_ipv6_prefix_rm(struct net_if *iface, struct in6_addr *addr,
 {
 	bool ret = false;
 	struct net_if_ipv6 *ipv6;
-	int i;
 
 	net_if_lock(iface);
 
@@ -2427,7 +2415,7 @@ bool net_if_ipv6_prefix_rm(struct net_if *iface, struct in6_addr *addr,
 		goto out;
 	}
 
-	for (i = 0; i < NET_IF_MAX_IPV6_PREFIX; i++) {
+	ARRAY_FOR_EACH(ipv6->prefix, i) {
 		if (!ipv6->prefix[i].is_used) {
 			continue;
 		}
@@ -2475,7 +2463,6 @@ struct net_if_ipv6_prefix *net_if_ipv6_prefix_get(struct net_if *iface,
 {
 	struct net_if_ipv6_prefix *prefix = NULL;
 	struct net_if_ipv6 *ipv6;
-	int i;
 
 	if (!iface) {
 		iface = net_if_get_default();
@@ -2488,7 +2475,7 @@ struct net_if_ipv6_prefix *net_if_ipv6_prefix_get(struct net_if *iface,
 		goto out;
 	}
 
-	for (i = 0; i < NET_IF_MAX_IPV6_PREFIX; i++) {
+	ARRAY_FOR_EACH(ipv6->prefix, i) {
 		if (!ipv6->prefix[i].is_used) {
 			continue;
 		}
@@ -2514,7 +2501,6 @@ struct net_if_ipv6_prefix *net_if_ipv6_prefix_lookup(struct net_if *iface,
 {
 	struct net_if_ipv6_prefix *prefix = NULL;
 	struct net_if_ipv6 *ipv6;
-	int i;
 
 	net_if_lock(iface);
 
@@ -2523,7 +2509,7 @@ struct net_if_ipv6_prefix *net_if_ipv6_prefix_lookup(struct net_if *iface,
 		goto out;
 	}
 
-	for (i = 0; i < NET_IF_MAX_IPV6_PREFIX; i++) {
+	ARRAY_FOR_EACH(ipv6->prefix, i) {
 		if (!ipv6->prefix[i].is_used) {
 			continue;
 		}
@@ -2547,7 +2533,6 @@ bool net_if_ipv6_addr_onlink(struct net_if **iface, struct in6_addr *addr)
 
 	STRUCT_SECTION_FOREACH(net_if, tmp) {
 		struct net_if_ipv6 *ipv6;
-		int i;
 
 		if (iface && *iface && *iface != tmp) {
 			continue;
@@ -2561,7 +2546,7 @@ bool net_if_ipv6_addr_onlink(struct net_if **iface, struct in6_addr *addr)
 			continue;
 		}
 
-		for (i = 0; i < NET_IF_MAX_IPV6_PREFIX; i++) {
+		ARRAY_FOR_EACH(ipv6->prefix, i) {
 			if (ipv6->prefix[i].is_used &&
 			    net_ipv6_is_prefix(ipv6->prefix[i].prefix.s6_addr,
 					       addr->s6_addr,
@@ -2729,7 +2714,6 @@ struct in6_addr *net_if_ipv6_get_ll(struct net_if *iface,
 {
 	struct in6_addr *addr = NULL;
 	struct net_if_ipv6 *ipv6;
-	int i;
 
 	net_if_lock(iface);
 
@@ -2738,7 +2722,7 @@ struct in6_addr *net_if_ipv6_get_ll(struct net_if *iface,
 		goto out;
 	}
 
-	for (i = 0; i < NET_IF_MAX_IPV6_ADDR; i++) {
+	ARRAY_FOR_EACH(ipv6->unicast, i) {
 		if (!ipv6->unicast[i].is_used ||
 		    (addr_state != NET_ADDR_ANY_STATE &&
 		     ipv6->unicast[i].addr_state != addr_state) ||
@@ -2787,13 +2771,12 @@ static inline struct in6_addr *check_global_addr(struct net_if *iface,
 						 enum net_addr_state state)
 {
 	struct net_if_ipv6 *ipv6 = iface->config.ip.ipv6;
-	int i;
 
 	if (!ipv6) {
 		return NULL;
 	}
 
-	for (i = 0; i < NET_IF_MAX_IPV6_ADDR; i++) {
+	ARRAY_FOR_EACH(ipv6->unicast, i) {
 		if (!ipv6->unicast[i].is_used ||
 		    (ipv6->unicast[i].addr_state != state) ||
 		    ipv6->unicast[i].address.family != AF_INET6) {
@@ -2861,7 +2844,6 @@ static struct in6_addr *net_if_ipv6_get_best_match(struct net_if *iface,
 	struct net_if_ipv6 *ipv6;
 	struct in6_addr *src = NULL;
 	uint8_t len;
-	int i;
 
 	net_if_lock(iface);
 
@@ -2870,7 +2852,7 @@ static struct in6_addr *net_if_ipv6_get_best_match(struct net_if *iface,
 		goto out;
 	}
 
-	for (i = 0; i < NET_IF_MAX_IPV6_ADDR; i++) {
+	ARRAY_FOR_EACH(ipv6->unicast, i) {
 		if (!is_proper_ipv6_address(&ipv6->unicast[i])) {
 			continue;
 		}
@@ -3008,8 +2990,6 @@ static void iface_ipv6_start(struct net_if *iface)
 
 static void iface_ipv6_init(int if_count)
 {
-	int i;
-
 	iface_ipv6_dad_init();
 	iface_ipv6_nd_init();
 
@@ -3025,7 +3005,7 @@ static void iface_ipv6_init(int if_count)
 			 "value.");
 	}
 
-	for (i = 0; i < ARRAY_SIZE(ipv6_addresses); i++) {
+	ARRAY_FOR_EACH(ipv6_addresses, i) {
 		ipv6_addresses[i].ipv6.hop_limit = CONFIG_NET_INITIAL_HOP_LIMIT;
 		ipv6_addresses[i].ipv6.mcast_hop_limit = CONFIG_NET_INITIAL_MCAST_HOP_LIMIT;
 		ipv6_addresses[i].ipv6.base_reachable_time = REACHABLE_TIME;
@@ -3074,7 +3054,6 @@ struct in6_addr *net_if_ipv6_get_global_addr(enum net_addr_state state,
 int net_if_config_ipv4_get(struct net_if *iface, struct net_if_ipv4 **ipv4)
 {
 	int ret = 0;
-	int i;
 
 	net_if_lock(iface);
 
@@ -3093,7 +3072,7 @@ int net_if_config_ipv4_get(struct net_if *iface, struct net_if_ipv4 **ipv4)
 
 	k_mutex_lock(&lock, K_FOREVER);
 
-	for (i = 0; i < ARRAY_SIZE(ipv4_addresses); i++) {
+	ARRAY_FOR_EACH(ipv4_addresses, i) {
 		if (ipv4_addresses[i].iface) {
 			continue;
 		}
@@ -3121,7 +3100,6 @@ out:
 int net_if_config_ipv4_put(struct net_if *iface)
 {
 	int ret = 0;
-	int i;
 
 	net_if_lock(iface);
 
@@ -3137,7 +3115,7 @@ int net_if_config_ipv4_put(struct net_if *iface)
 
 	k_mutex_lock(&lock, K_FOREVER);
 
-	for (i = 0; i < ARRAY_SIZE(ipv4_addresses); i++) {
+	ARRAY_FOR_EACH(ipv4_addresses, i) {
 		if (ipv4_addresses[i].iface != iface) {
 			continue;
 		}
@@ -3271,7 +3249,6 @@ bool net_if_ipv4_addr_mask_cmp(struct net_if *iface,
 	bool ret = false;
 	struct net_if_ipv4 *ipv4;
 	uint32_t subnet;
-	int i;
 
 	net_if_lock(iface);
 
@@ -3280,7 +3257,7 @@ bool net_if_ipv4_addr_mask_cmp(struct net_if *iface,
 		goto out;
 	}
 
-	for (i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
+	ARRAY_FOR_EACH(ipv4->unicast, i) {
 		if (!ipv4->unicast[i].ipv4.is_used ||
 		    ipv4->unicast[i].ipv4.address.family != AF_INET) {
 			continue;
@@ -3317,7 +3294,7 @@ static bool ipv4_is_broadcast_address(struct net_if *iface,
 		goto out;
 	}
 
-	for (int i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
+	ARRAY_FOR_EACH(ipv4->unicast, i) {
 		if (!ipv4->unicast[i].ipv4.is_used ||
 		    ipv4->unicast[i].ipv4.address.family != AF_INET) {
 			continue;
@@ -3404,7 +3381,6 @@ static struct in_addr *net_if_ipv4_get_best_match(struct net_if *iface,
 	struct net_if_ipv4 *ipv4;
 	struct in_addr *src = NULL;
 	uint8_t len;
-	int i;
 
 	net_if_lock(iface);
 
@@ -3413,7 +3389,7 @@ static struct in_addr *net_if_ipv4_get_best_match(struct net_if *iface,
 		goto out;
 	}
 
-	for (i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
+	ARRAY_FOR_EACH(ipv4->unicast, i) {
 		if (!is_proper_ipv4_address(&ipv4->unicast[i].ipv4)) {
 			continue;
 		}
@@ -3436,7 +3412,6 @@ static struct in_addr *if_ipv4_get_addr(struct net_if *iface,
 {
 	struct in_addr *addr = NULL;
 	struct net_if_ipv4 *ipv4;
-	int i;
 
 	if (!iface) {
 		return NULL;
@@ -3449,7 +3424,7 @@ static struct in_addr *if_ipv4_get_addr(struct net_if *iface,
 		goto out;
 	}
 
-	for (i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
+	ARRAY_FOR_EACH(ipv4->unicast, i) {
 		if (!ipv4->unicast[i].ipv4.is_used ||
 		    (addr_state != NET_ADDR_ANY_STATE &&
 		     ipv4->unicast[i].ipv4.addr_state != addr_state) ||
@@ -3565,7 +3540,6 @@ struct net_if_addr *net_if_ipv4_addr_lookup(const struct in_addr *addr,
 
 	STRUCT_SECTION_FOREACH(net_if, iface) {
 		struct net_if_ipv4 *ipv4;
-		int i;
 
 		net_if_lock(iface);
 
@@ -3575,7 +3549,7 @@ struct net_if_addr *net_if_ipv4_addr_lookup(const struct in_addr *addr,
 			continue;
 		}
 
-		for (i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
+		ARRAY_FOR_EACH(ipv4->unicast, i) {
 			if (!ipv4->unicast[i].ipv4.is_used ||
 			    ipv4->unicast[i].ipv4.address.family != AF_INET) {
 				continue;
@@ -3645,7 +3619,7 @@ struct in_addr net_if_ipv4_get_netmask_by_addr(struct net_if *iface,
 		goto out;
 	}
 
-	for (int i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
+	ARRAY_FOR_EACH(ipv4->unicast, i) {
 		if (!ipv4->unicast[i].ipv4.is_used ||
 		    ipv4->unicast[i].ipv4.address.family != AF_INET) {
 			continue;
@@ -3686,7 +3660,7 @@ bool net_if_ipv4_set_netmask_by_addr(struct net_if *iface,
 		goto out;
 	}
 
-	for (int i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
+	ARRAY_FOR_EACH(ipv4->unicast, i) {
 		if (!ipv4->unicast[i].ipv4.is_used ||
 		    ipv4->unicast[i].ipv4.address.family != AF_INET) {
 			continue;
@@ -3730,7 +3704,7 @@ struct in_addr net_if_ipv4_get_netmask(struct net_if *iface)
 		goto out;
 	}
 
-	for (int i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
+	ARRAY_FOR_EACH(ipv4->unicast, i) {
 		if (!ipv4->unicast[i].ipv4.is_used ||
 		    ipv4->unicast[i].ipv4.address.family != AF_INET) {
 			continue;
@@ -3767,7 +3741,7 @@ static void net_if_ipv4_set_netmask_deprecated(struct net_if *iface,
 		goto out;
 	}
 
-	for (int i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
+	ARRAY_FOR_EACH(ipv4->unicast, i) {
 		if (!ipv4->unicast[i].ipv4.is_used ||
 		    ipv4->unicast[i].ipv4.address.family != AF_INET) {
 			continue;
@@ -3919,9 +3893,8 @@ static struct net_if_addr *ipv4_addr_find(struct net_if *iface,
 					  struct in_addr *addr)
 {
 	struct net_if_ipv4 *ipv4 = iface->config.ip.ipv4;
-	int i;
 
-	for (i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
+	ARRAY_FOR_EACH(ipv4->unicast, i) {
 		if (!ipv4->unicast[i].ipv4.is_used) {
 			continue;
 		}
@@ -3942,7 +3915,7 @@ struct net_if_addr *net_if_ipv4_addr_add(struct net_if *iface,
 {
 	struct net_if_addr *ifaddr = NULL;
 	struct net_if_ipv4 *ipv4;
-	int i;
+	int idx;
 
 	net_if_lock(iface);
 
@@ -3956,17 +3929,19 @@ struct net_if_addr *net_if_ipv4_addr_add(struct net_if *iface,
 		goto out;
 	}
 
-	for (i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
+	ARRAY_FOR_EACH(ipv4->unicast, i) {
 		struct net_if_addr *cur = &ipv4->unicast[i].ipv4;
 
 		if (addr_type == NET_ADDR_DHCP
 		    && cur->addr_type == NET_ADDR_OVERRIDABLE) {
 			ifaddr = cur;
+			idx = i;
 			break;
 		}
 
 		if (!ipv4->unicast[i].ipv4.is_used) {
 			ifaddr = cur;
+			idx = i;
 			break;
 		}
 	}
@@ -3991,8 +3966,8 @@ struct net_if_addr *net_if_ipv4_addr_add(struct net_if *iface,
 		 */
 		ifaddr->addr_state = NET_ADDR_PREFERRED;
 
-		NET_DBG("[%d] interface %p address %s type %s added", i, iface,
-			net_sprint_ipv4_addr(addr),
+		NET_DBG("[%d] interface %p address %s type %s added",
+			idx, iface, net_sprint_ipv4_addr(addr),
 			net_addr_type2str(addr_type));
 
 		net_mgmt_event_notify_with_info(NET_EVENT_IPV4_ADDR_ADD, iface,
@@ -4011,7 +3986,6 @@ bool net_if_ipv4_addr_rm(struct net_if *iface, const struct in_addr *addr)
 {
 	struct net_if_ipv4 *ipv4;
 	bool ret = false;
-	int i;
 
 	net_if_lock(iface);
 
@@ -4020,7 +3994,7 @@ bool net_if_ipv4_addr_rm(struct net_if *iface, const struct in_addr *addr)
 		goto out;
 	}
 
-	for (i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
+	ARRAY_FOR_EACH(ipv4->unicast, i) {
 		if (!ipv4->unicast[i].ipv4.is_used) {
 			continue;
 		}
@@ -4032,7 +4006,7 @@ bool net_if_ipv4_addr_rm(struct net_if *iface, const struct in_addr *addr)
 
 		ipv4->unicast[i].ipv4.is_used = false;
 
-		NET_DBG("[%d] interface %p address %s removed",
+		NET_DBG("[%zu] interface %p address %s removed",
 			i, iface, net_sprint_ipv4_addr(addr));
 
 		net_mgmt_event_notify_with_info(
@@ -4141,7 +4115,7 @@ void net_if_ipv4_addr_foreach(struct net_if *iface, net_if_ip_addr_cb_t cb,
 		goto out;
 	}
 
-	for (int i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
+	ARRAY_FOR_EACH(ipv4->unicast, i) {
 		struct net_if_addr *if_addr = &ipv4->unicast[i].ipv4;
 
 		if (!if_addr->is_used) {
@@ -4160,13 +4134,12 @@ static struct net_if_mcast_addr *ipv4_maddr_find(struct net_if *iface,
 						 const struct in_addr *addr)
 {
 	struct net_if_ipv4 *ipv4 = iface->config.ip.ipv4;
-	int i;
 
 	if (!ipv4) {
 		return NULL;
 	}
 
-	for (i = 0; i < NET_IF_MAX_IPV4_MADDR; i++) {
+	ARRAY_FOR_EACH(ipv4->mcast, i) {
 		if ((is_used && !ipv4->mcast[i].is_used) ||
 		    (!is_used && ipv4->mcast[i].is_used)) {
 			continue;
@@ -4319,13 +4292,12 @@ static void iface_ipv4_init(int if_count)
 static void leave_ipv4_mcast_all(struct net_if *iface)
 {
 	struct net_if_ipv4 *ipv4 = iface->config.ip.ipv4;
-	int i;
 
 	if (!ipv4) {
 		return;
 	}
 
-	for (i = 0; i < NET_IF_MAX_IPV4_MADDR; i++) {
+	ARRAY_FOR_EACH(ipv4->mcast, i) {
 		if (!ipv4->mcast[i].is_used ||
 		    !ipv4->mcast[i].is_joined) {
 			continue;

--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -227,13 +227,13 @@ static inline struct in_addr *if_get_addr(struct net_if *iface,
 	}
 
 	for (i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
-		if (ipv4->unicast[i].is_used &&
-		    ipv4->unicast[i].address.family == AF_INET &&
-		    ipv4->unicast[i].addr_state == NET_ADDR_PREFERRED &&
+		if (ipv4->unicast[i].ipv4.is_used &&
+		    ipv4->unicast[i].ipv4.address.family == AF_INET &&
+		    ipv4->unicast[i].ipv4.addr_state == NET_ADDR_PREFERRED &&
 		    (!addr ||
 		     net_ipv4_addr_cmp(addr,
-				       &ipv4->unicast[i].address.in_addr))) {
-			return &ipv4->unicast[i].address.in_addr;
+				       &ipv4->unicast[i].ipv4.address.in_addr))) {
+			return &ipv4->unicast[i].ipv4.address.in_addr;
 		}
 	}
 

--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -220,13 +220,12 @@ static inline struct in_addr *if_get_addr(struct net_if *iface,
 					  struct in_addr *addr)
 {
 	struct net_if_ipv4 *ipv4 = iface->config.ip.ipv4;
-	int i;
 
 	if (!ipv4) {
 		return NULL;
 	}
 
-	for (i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
+	ARRAY_FOR_EACH(ipv4->unicast, i) {
 		if (ipv4->unicast[i].ipv4.is_used &&
 		    ipv4->unicast[i].ipv4.address.family == AF_INET &&
 		    ipv4->unicast[i].ipv4.addr_state == NET_ADDR_PREFERRED &&

--- a/subsys/net/lib/capture/capture.c
+++ b/subsys/net/lib/capture/capture.c
@@ -230,7 +230,9 @@ static int setup_iface(struct net_if *iface, const char *ipaddr,
 		/* Set the netmask so that we do not get IPv4 traffic routed
 		 * into this interface.
 		 */
-		net_if_ipv4_set_netmask(iface, &netmask);
+		net_if_ipv4_set_netmask_by_addr(iface,
+						&net_sin(addr)->sin_addr,
+						&netmask);
 
 		*addr_len = sizeof(struct sockaddr_in);
 	} else {

--- a/subsys/net/lib/config/init.c
+++ b/subsys/net/lib/config/init.c
@@ -70,7 +70,7 @@ static void ipv4_addr_add_handler(struct net_mgmt_event_callback *cb,
 
 	for (i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
 		struct net_if_addr *if_addr =
-					&iface->config.ip.ipv4->unicast[i];
+					&iface->config.ip.ipv4->unicast[i].ipv4;
 
 		if (if_addr->addr_type != NET_ADDR_DHCP || !if_addr->is_used) {
 			continue;
@@ -85,7 +85,7 @@ static void ipv4_addr_add_handler(struct net_mgmt_event_callback *cb,
 			 iface->config.dhcpv4.lease_time);
 		NET_INFO("Subnet: %s",
 			 net_addr_ntop(AF_INET,
-				       &iface->config.ip.ipv4->netmask,
+				       &iface->config.ip.ipv4->unicast[i].netmask,
 				       hr_addr, sizeof(hr_addr)));
 		NET_INFO("Router: %s",
 			 net_addr_ntop(AF_INET,
@@ -141,7 +141,7 @@ static void setup_ipv4(struct net_if *iface)
 #if CONFIG_NET_CONFIG_LOG_LEVEL >= LOG_LEVEL_INF
 	char hr_addr[NET_IPV4_ADDR_LEN];
 #endif
-	struct in_addr addr;
+	struct in_addr addr, netmask;
 
 	if (sizeof(CONFIG_NET_CONFIG_MY_IPV4_ADDR) == 1) {
 		/* Empty address, skip setting ANY address in this case */
@@ -177,11 +177,11 @@ static void setup_ipv4(struct net_if *iface)
 	if (sizeof(CONFIG_NET_CONFIG_MY_IPV4_NETMASK) > 1) {
 		/* If not empty */
 		if (net_addr_pton(AF_INET, CONFIG_NET_CONFIG_MY_IPV4_NETMASK,
-				  &addr)) {
+				  &netmask)) {
 			NET_ERR("Invalid netmask: %s",
 				CONFIG_NET_CONFIG_MY_IPV4_NETMASK);
 		} else {
-			net_if_ipv4_set_netmask(iface, &addr);
+			net_if_ipv4_set_netmask_by_addr(iface, &addr, &netmask);
 		}
 	}
 

--- a/subsys/net/lib/config/init.c
+++ b/subsys/net/lib/config/init.c
@@ -62,13 +62,12 @@ static void ipv4_addr_add_handler(struct net_mgmt_event_callback *cb,
 #if CONFIG_NET_CONFIG_LOG_LEVEL >= LOG_LEVEL_INF
 	char hr_addr[NET_IPV4_ADDR_LEN];
 #endif
-	int i;
 
 	if (mgmt_event != NET_EVENT_IPV4_ADDR_ADD) {
 		return;
 	}
 
-	for (i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
+	ARRAY_FOR_EACH(iface->config.ip.ipv4->unicast, i) {
 		struct net_if_addr *if_addr =
 					&iface->config.ip.ipv4->unicast[i].ipv4;
 

--- a/subsys/net/lib/dhcpv4/dhcpv4.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4.c
@@ -738,7 +738,9 @@ static bool dhcpv4_parse_options(struct net_pkt *pkt,
 				return false;
 			}
 
-			net_if_ipv4_set_netmask(iface, &netmask);
+			net_if_ipv4_set_netmask_by_addr(iface,
+							&iface->config.dhcpv4.requested_ip,
+							&netmask);
 			NET_DBG("options_subnet_mask %s",
 				net_sprint_ipv4_addr(&netmask));
 			break;

--- a/subsys/net/lib/dhcpv4/dhcpv4_server.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4_server.c
@@ -1436,7 +1436,7 @@ int net_dhcpv4_server_start(struct net_if *iface, struct in_addr *base_addr)
 		return -EINVAL;
 	}
 
-	netmask = net_if_ipv4_get_netmask(iface);
+	netmask = net_if_ipv4_get_netmask_by_addr(iface, server_addr);
 	if (net_ipv4_is_addr_unspecified(&netmask)) {
 		LOG_ERR("Failed to obtain subnet mask.");
 		return -EINVAL;

--- a/subsys/net/lib/shell/iface.c
+++ b/subsys/net/lib/shell/iface.c
@@ -437,14 +437,16 @@ skip_ipv6:
 
 	PR("IPv4 unicast addresses (max %d):\n", NET_IF_MAX_IPV4_ADDR);
 	for (i = 0; ipv4 && i < NET_IF_MAX_IPV4_ADDR; i++) {
-		unicast = &ipv4->unicast[i];
+		unicast = &ipv4->unicast[i].ipv4;
 
 		if (!unicast->is_used) {
 			continue;
 		}
 
-		PR("\t%s %s %s%s\n",
+		PR("\t%s/%s %s %s%s\n",
 		   net_sprint_ipv4_addr(&unicast->address.in_addr),
+		   net_sprint_ipv4_addr(&ipv4->unicast[i].netmask),
+
 		   addrtype2str(unicast->addr_type),
 		   addrstate2str(unicast->addr_state),
 		   unicast->is_infinite ? " infinite" : "");
@@ -480,8 +482,6 @@ skip_ipv4:
 	if (ipv4) {
 		PR("IPv4 gateway : %s\n",
 		   net_sprint_ipv4_addr(&ipv4->gw));
-		PR("IPv4 netmask : %s\n",
-		   net_sprint_ipv4_addr(&ipv4->netmask));
 	}
 #endif /* CONFIG_NET_IPV4 */
 

--- a/subsys/net/lib/shell/iface.c
+++ b/subsys/net/lib/shell/iface.c
@@ -54,9 +54,8 @@ static void print_supported_ethernet_capabilities(
 	const struct shell *sh, struct net_if *iface)
 {
 	enum ethernet_hw_caps caps = net_eth_get_hw_capabilities(iface);
-	int i;
 
-	for (i = 0; i < ARRAY_SIZE(eth_hw_caps); i++) {
+	ARRAY_FOR_EACH(eth_hw_caps, i) {
 		if (caps & eth_hw_caps[i].capability) {
 			PR("\t%s\n", eth_hw_caps[i].description);
 		}
@@ -150,7 +149,7 @@ static void iface_cb(struct net_if *iface, void *user_data)
 #endif
 	const char *extra;
 #if defined(CONFIG_NET_IP)
-	int i, count;
+	int count;
 #endif
 
 	if (data->user_data && data->user_data != iface) {
@@ -257,7 +256,7 @@ static void iface_cb(struct net_if *iface, void *user_data)
 		if (!ret && params.priority_queues_num) {
 			count = params.priority_queues_num;
 			PR("Priority queues:\n");
-			for (i = 0; i < count; ++i) {
+			for (int i = 0; i < count; ++i) {
 				params.qav_param.queue_id = i;
 				params.qav_param.type =
 					ETHERNET_QAV_PARAM_TYPE_STATUS;
@@ -290,7 +289,7 @@ static void iface_cb(struct net_if *iface, void *user_data)
 		eth_ctx = net_if_l2_data(iface);
 
 		if (eth_ctx->vlan_enabled) {
-			for (i = 0; i < CONFIG_NET_VLAN_COUNT; i++) {
+			for (int i = 0; i < CONFIG_NET_VLAN_COUNT; i++) {
 				if (eth_ctx->vlan[i].iface != iface ||
 				    eth_ctx->vlan[i].tag ==
 							NET_VLAN_TAG_UNSPEC) {
@@ -316,17 +315,16 @@ static void iface_cb(struct net_if *iface, void *user_data)
 
 #if defined(CONFIG_NET_IPV6)
 	count = 0;
+	ipv6 = iface->config.ip.ipv6;
 
-	if (!net_if_flag_is_set(iface, NET_IF_IPV6)) {
+	if (!net_if_flag_is_set(iface, NET_IF_IPV6) || ipv6 == NULL) {
 		PR("%s not %s for this interface.\n", "IPv6", "enabled");
 		ipv6 = NULL;
 		goto skip_ipv6;
 	}
 
-	ipv6 = iface->config.ip.ipv6;
-
 	PR("IPv6 unicast addresses (max %d):\n", NET_IF_MAX_IPV6_ADDR);
-	for (i = 0; ipv6 && i < NET_IF_MAX_IPV6_ADDR; i++) {
+	ARRAY_FOR_EACH(ipv6->unicast, i) {
 		unicast = &ipv6->unicast[i];
 
 		if (!unicast->is_used) {
@@ -349,7 +347,7 @@ static void iface_cb(struct net_if *iface, void *user_data)
 	count = 0;
 
 	PR("IPv6 multicast addresses (max %d):\n", NET_IF_MAX_IPV6_MADDR);
-	for (i = 0; ipv6 && i < NET_IF_MAX_IPV6_MADDR; i++) {
+	ARRAY_FOR_EACH(ipv6->mcast, i) {
 		mcast = &ipv6->mcast[i];
 
 		if (!mcast->is_used) {
@@ -368,7 +366,7 @@ static void iface_cb(struct net_if *iface, void *user_data)
 	count = 0;
 
 	PR("IPv6 prefixes (max %d):\n", NET_IF_MAX_IPV6_PREFIX);
-	for (i = 0; ipv6 && i < NET_IF_MAX_IPV6_PREFIX; i++) {
+	ARRAY_FOR_EACH(ipv6->prefix, i) {
 		prefix = &ipv6->prefix[i];
 
 		if (!prefix->is_used) {
@@ -426,17 +424,16 @@ skip_ipv6:
 	}
 
 	count = 0;
+	ipv4 = iface->config.ip.ipv4;
 
-	if (!net_if_flag_is_set(iface, NET_IF_IPV4)) {
+	if (!net_if_flag_is_set(iface, NET_IF_IPV4) || ipv4 == NULL) {
 		PR("%s not %s for this interface.\n", "IPv4", "enabled");
 		ipv4 = NULL;
 		goto skip_ipv4;
 	}
 
-	ipv4 = iface->config.ip.ipv4;
-
 	PR("IPv4 unicast addresses (max %d):\n", NET_IF_MAX_IPV4_ADDR);
-	for (i = 0; ipv4 && i < NET_IF_MAX_IPV4_ADDR; i++) {
+	ARRAY_FOR_EACH(ipv4->unicast, i) {
 		unicast = &ipv4->unicast[i].ipv4;
 
 		if (!unicast->is_used) {
@@ -461,7 +458,7 @@ skip_ipv6:
 	count = 0;
 
 	PR("IPv4 multicast addresses (max %d):\n", NET_IF_MAX_IPV4_MADDR);
-	for (i = 0; ipv4 && i < NET_IF_MAX_IPV4_MADDR; i++) {
+	ARRAY_FOR_EACH(ipv4->mcast, i) {
 		mcast = &ipv4->mcast[i];
 
 		if (!mcast->is_used) {

--- a/subsys/net/lib/shell/ipv4.c
+++ b/subsys/net/lib/shell/ipv4.c
@@ -36,18 +36,18 @@ static void ip_address_lifetime_cb(struct net_if *iface, void *user_data)
 	PR("Type      \tState    \tLifetime (sec)\tAddress\n");
 
 	for (i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
-		if (!ipv4->unicast[i].is_used ||
-		    ipv4->unicast[i].address.family != AF_INET) {
+		if (!ipv4->unicast[i].ipv4.is_used ||
+		    ipv4->unicast[i].ipv4.address.family != AF_INET) {
 			continue;
 		}
 
 		PR("%s  \t%s    \t%12s/%12s\n",
-		       addrtype2str(ipv4->unicast[i].addr_type),
-		       addrstate2str(ipv4->unicast[i].addr_state),
+		       addrtype2str(ipv4->unicast[i].ipv4.addr_type),
+		       addrstate2str(ipv4->unicast[i].ipv4.addr_state),
 		       net_sprint_ipv4_addr(
-			       &ipv4->unicast[i].address.in_addr),
+			       &ipv4->unicast[i].ipv4.address.in_addr),
 		       net_sprint_ipv4_addr(
-			       &ipv4->netmask));
+			       &ipv4->unicast[i].netmask));
 	}
 }
 #endif /* CONFIG_NET_NATIVE_IPV4 */
@@ -126,6 +126,7 @@ static int cmd_net_ip_add(const struct shell *sh, size_t argc, char *argv[])
 		}
 	} else {
 		struct net_if_addr *ifaddr;
+		struct in_addr netmask;
 
 		if (argc < 4) {
 			PR_ERROR("Netmask is missing.\n");
@@ -139,12 +140,12 @@ static int cmd_net_ip_add(const struct shell *sh, size_t argc, char *argv[])
 			return -ENOMEM;
 		}
 
-		if (net_addr_pton(AF_INET, argv[3], &addr)) {
+		if (net_addr_pton(AF_INET, argv[3], &netmask)) {
 			PR_ERROR("Invalid netmask: %s", argv[3]);
 			return -EINVAL;
 		}
 
-		net_if_ipv4_set_netmask(iface, &addr);
+		net_if_ipv4_set_netmask_by_addr(iface, &addr, &netmask);
 	}
 
 #else /* CONFIG_NET_NATIVE_IPV4 */

--- a/subsys/net/lib/shell/ipv4.c
+++ b/subsys/net/lib/shell/ipv4.c
@@ -20,7 +20,6 @@ static void ip_address_lifetime_cb(struct net_if *iface, void *user_data)
 	const struct shell *sh = data->sh;
 	struct net_if_ipv4 *ipv4 = iface->config.ip.ipv4;
 	const char *extra;
-	int i;
 
 	ARG_UNUSED(user_data);
 
@@ -35,7 +34,7 @@ static void ip_address_lifetime_cb(struct net_if *iface, void *user_data)
 
 	PR("Type      \tState    \tLifetime (sec)\tAddress\n");
 
-	for (i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
+	ARRAY_FOR_EACH(ipv4->unicast, i) {
 		if (!ipv4->unicast[i].ipv4.is_used ||
 		    ipv4->unicast[i].ipv4.address.family != AF_INET) {
 			continue;

--- a/subsys/net/lib/shell/ipv6.c
+++ b/subsys/net/lib/shell/ipv6.c
@@ -62,7 +62,6 @@ static void address_lifetime_cb(struct net_if *iface, void *user_data)
 	const struct shell *sh = data->sh;
 	struct net_if_ipv6 *ipv6 = iface->config.ip.ipv6;
 	const char *extra;
-	int i;
 
 	ARG_UNUSED(user_data);
 
@@ -77,7 +76,7 @@ static void address_lifetime_cb(struct net_if *iface, void *user_data)
 
 	PR("Type      \tState    \tLifetime (sec)\tAddress\n");
 
-	for (i = 0; i < NET_IF_MAX_IPV6_ADDR; i++) {
+	ARRAY_FOR_EACH(ipv6->unicast, i) {
 		struct net_if_ipv6_prefix *prefix;
 		char remaining_str[sizeof("01234567890")];
 		uint64_t remaining;

--- a/subsys/net/lib/shell/tcp.c
+++ b/subsys/net/lib/shell/tcp.c
@@ -51,7 +51,7 @@ static void get_my_ipv4_addr(struct net_if *iface,
 #if defined(CONFIG_NET_NATIVE_IPV4)
 	/* Just take the first IPv4 address of an interface. */
 	memcpy(&net_sin(myaddr)->sin_addr,
-	       &iface->config.ip.ipv4->unicast[0].address.in_addr,
+	       &iface->config.ip.ipv4->unicast[0].ipv4.address.in_addr,
 	       sizeof(struct in_addr));
 
 	net_sin(myaddr)->sin_port = 0U; /* let the IP stack to select */

--- a/tests/net/arp/src/main.c
+++ b/tests/net/arp/src/main.c
@@ -154,13 +154,13 @@ static inline struct in_addr *if_get_addr(struct net_if *iface)
 	int i;
 
 	for (i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
-		if (iface->config.ip.ipv4->unicast[i].is_used &&
-		    iface->config.ip.ipv4->unicast[i].address.family ==
+		if (iface->config.ip.ipv4->unicast[i].ipv4.is_used &&
+		    iface->config.ip.ipv4->unicast[i].ipv4.address.family ==
 								AF_INET &&
-		    iface->config.ip.ipv4->unicast[i].addr_state ==
+		    iface->config.ip.ipv4->unicast[i].ipv4.addr_state ==
 							NET_ADDR_PREFERRED) {
 			return
-			    &iface->config.ip.ipv4->unicast[i].address.in_addr;
+			    &iface->config.ip.ipv4->unicast[i].ipv4.address.in_addr;
 		}
 	}
 
@@ -347,7 +347,6 @@ ZTEST(arp_fn_tests, test_arp)
 	iface = net_if_lookup_by_dev(DEVICE_GET(net_arp_test));
 
 	net_if_ipv4_set_gw(iface, &gw);
-	net_if_ipv4_set_netmask(iface, &netmask);
 
 	/* Unicast test */
 	ifaddr = net_if_ipv4_addr_add(iface,
@@ -356,6 +355,8 @@ ZTEST(arp_fn_tests, test_arp)
 				      0);
 	zassert_not_null(ifaddr, "Cannot add address");
 	ifaddr->addr_state = NET_ADDR_PREFERRED;
+
+	net_if_ipv4_set_netmask_by_addr(iface, &src, &netmask);
 
 	len = strlen(app_data);
 

--- a/tests/net/checksum_offload/src/main.c
+++ b/tests/net/checksum_offload/src/main.c
@@ -578,7 +578,7 @@ static void test_address_setup(void)
 				      NET_ADDR_MANUAL, 0);
 	zassert_not_null(ifaddr, "Cannot add IPv4 address");
 
-	net_if_ipv4_set_netmask(iface1, &netmask);
+	net_if_ipv4_set_netmask_by_addr(iface1, &in4addr_my, &netmask);
 
 	ifaddr = net_if_ipv6_addr_add(iface2, &my_addr2,
 				      NET_ADDR_MANUAL, 0);
@@ -594,7 +594,7 @@ static void test_address_setup(void)
 				      NET_ADDR_MANUAL, 0);
 	zassert_not_null(ifaddr, "Cannot add IPv4 address");
 
-	net_if_ipv4_set_netmask(iface2, &netmask);
+	net_if_ipv4_set_netmask_by_addr(iface2, &in4addr_my2, &netmask);
 
 	net_if_up(iface1);
 	net_if_up(iface2);

--- a/tests/net/dhcpv4/server/src/main.c
+++ b/tests/net/dhcpv4/server/src/main.c
@@ -67,7 +67,7 @@ static void server_iface_init(struct net_if *iface)
 	test_ctx.iface = iface;
 
 	(void)net_if_ipv4_addr_add(iface, &server_addr, NET_ADDR_MANUAL, 0);
-	(void)net_if_ipv4_set_netmask(iface, &netmask);
+	(void)net_if_ipv4_set_netmask_by_addr(iface, &server_addr, &netmask);
 }
 
 static void send_icmp_echo_reply(struct net_pkt *pkt,

--- a/tests/net/iface/src/main.c
+++ b/tests/net/iface/src/main.c
@@ -41,7 +41,7 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 /* Interface 1 addresses */
 static struct in6_addr my_addr1 = { { { 0x20, 0x01, 0x0d, 0xb8, 1, 0, 0, 0,
 					0, 0, 0, 0, 0, 0, 0, 0x1 } } };
-static struct in_addr my_ipv4_addr1 = { { { 192, 0, 2, 1 } } };
+static ZTEST_BMEM struct in_addr my_ipv4_addr1 = { { { 192, 0, 2, 1 } } };
 
 /* Interface 2 addresses */
 static struct in6_addr my_addr2 = { { { 0x20, 0x01, 0x0d, 0xb8, 2, 0, 0, 0,
@@ -1068,7 +1068,7 @@ static void netmask_addr_add(void *p1, void *p2, void *p3)
 	struct in_addr my_netmask = { { { 255, 255, 255, 0 } } };
 	bool ret;
 
-	ret = net_if_ipv4_set_netmask_by_index(1, &my_netmask);
+	ret = net_if_ipv4_set_netmask_by_addr_by_index(1, &my_ipv4_addr1, &my_netmask);
 	zassert_true(ret, "Cannot add IPv4 netmask");
 }
 

--- a/tests/net/ip-addr/src/main.c
+++ b/tests/net/ip-addr/src/main.c
@@ -404,11 +404,15 @@ ZTEST(ip_addr_fn, test_ipv4_addresses)
 	zassert_true(net_ipv4_is_my_addr(&addr4),
 		     "My IPv4 address check failed");
 
+	net_if_ipv4_set_netmask_by_addr(default_iface, &addr4, &netmask);
+
 	ifaddr1 = net_if_ipv4_addr_add(default_iface,
 				       &lladdr4,
 				       NET_ADDR_MANUAL,
 				       0);
 	zassert_not_null(ifaddr1, "IPv4 interface address add failed");
+
+	net_if_ipv4_set_netmask_by_addr(default_iface, &lladdr4, &netmask2);
 
 	zassert_true(net_ipv4_is_my_addr(&lladdr4),
 		     "My IPv4 address check failed");
@@ -471,10 +475,9 @@ ZTEST(ip_addr_fn, test_ipv4_addresses)
 	iface = default_iface;
 
 	net_if_ipv4_set_gw(iface, &gw);
-	net_if_ipv4_set_netmask(iface, &netmask);
 
 	zassert_false(net_ipv4_addr_mask_cmp(iface, &fail_addr),
-		"IPv4 wrong match failed");
+		      "IPv4 wrong match failed");
 
 	zassert_true(net_ipv4_addr_mask_cmp(iface, &match_addr),
 		     "IPv4 match failed");
@@ -541,10 +544,10 @@ ZTEST(ip_addr_fn, test_ipv4_addresses)
 	ret = net_ipv4_is_addr_bcast(iface, &bcast_addr5);
 	zassert_true(ret, "IPv4 address 5 is not broadcast address");
 
-	net_if_ipv4_set_netmask(iface, &netmask2);
-
 	ret = net_ipv4_is_addr_bcast(iface, &bcast_addr2);
 	zassert_false(ret, "IPv4 address 2 is broadcast address");
+
+	net_if_ipv4_set_netmask_by_addr(iface, &addr4, &netmask2);
 
 	ret = net_ipv4_is_addr_bcast(iface, &bcast_addr3);
 	zassert_true(ret, "IPv4 address 3 is not broadcast address");

--- a/tests/net/shell/src/main.c
+++ b/tests/net/shell/src/main.c
@@ -112,13 +112,13 @@ static inline struct in_addr *if_get_addr(struct net_if *iface)
 	int i;
 
 	for (i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
-		if (iface->config.ip.ipv4->unicast[i].is_used &&
-		    iface->config.ip.ipv4->unicast[i].address.family ==
+		if (iface->config.ip.ipv4->unicast[i].ipv4.is_used &&
+		    iface->config.ip.ipv4->unicast[i].ipv4.address.family ==
 								AF_INET &&
-		    iface->config.ip.ipv4->unicast[i].addr_state ==
+		    iface->config.ip.ipv4->unicast[i].ipv4.addr_state ==
 							NET_ADDR_PREFERRED) {
 			return
-			    &iface->config.ip.ipv4->unicast[i].address.in_addr;
+			    &iface->config.ip.ipv4->unicast[i].ipv4.address.in_addr;
 		}
 	}
 

--- a/tests/net/udp/src/main.c
+++ b/tests/net/udp/src/main.c
@@ -114,13 +114,13 @@ static inline struct in_addr *if_get_addr(struct net_if *iface)
 	int i;
 
 	for (i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
-		if (iface->config.ip.ipv4->unicast[i].is_used &&
-		    iface->config.ip.ipv4->unicast[i].address.family ==
+		if (iface->config.ip.ipv4->unicast[i].ipv4.is_used &&
+		    iface->config.ip.ipv4->unicast[i].ipv4.address.family ==
 								AF_INET &&
-		    iface->config.ip.ipv4->unicast[i].addr_state ==
+		    iface->config.ip.ipv4->unicast[i].ipv4.addr_state ==
 							NET_ADDR_PREFERRED) {
 			return
-			    &iface->config.ip.ipv4->unicast[i].address.in_addr;
+			    &iface->config.ip.ipv4->unicast[i].ipv4.address.in_addr;
 		}
 	}
 


### PR DESCRIPTION
The netmask should be tied to the IPv4 address instead of being global for the network interface.

If there is only one IPv4 address specified to the network interface, nothing changes from user point of view. But if there are more than one IPv4 address / network interface, the netmask must be specified to each address separately.

This means that the `net_if_ipv4_get_netmask()` and `net_if_ipv4_set_netmask()` functions should not be used as they will only work reliably if there is only one IPv4 address in the network interface.

Instead new `net_if_ipv4_get_netmask_by_addr()` and `net_if_ipv4_set_netmask_by_addr()` should be used instead as they make sure that the netmask is tied to correct IPv4 address in the network interface.

No need to try to rush and try to get this to 3.6, existing functionality works for most of the use cases.