### PR TITLE
Bluetooth: Host: Set user data size for hfp tx pool

### DIFF
--- a/subsys/bluetooth/host/hfp_hf.c
+++ b/subsys/bluetooth/host/hfp_hf.c
@@ -35,7 +35,8 @@ LOG_MODULE_REGISTER(bt_hfp_hf);
 struct bt_hfp_hf_cb *bt_hf;
 
 NET_BUF_POOL_FIXED_DEFINE(hf_pool, CONFIG_BT_MAX_CONN + 1,
-			  BT_RFCOMM_BUF_SIZE(BT_HF_CLIENT_MAX_PDU), 0, NULL);
+			  BT_RFCOMM_BUF_SIZE(BT_HF_CLIENT_MAX_PDU),
+			  CONFIG_BT_CONN_TX_USER_DATA_SIZE, NULL);
 
 static struct bt_hfp_hf bt_hfp_hf_pool[CONFIG_BT_MAX_CONN];
 


### PR DESCRIPTION
The user data size of hfp tx pool is zero.

There is not enough space to put tx_mate.

Use CONFIG_BT_CONN_TX_USER_DATA_SIZE to set data size of hfp tx pool.