### PR TITLE
Bluetooth: BAP: Broadcast sink: Fix bis_sync issue in update_recv_state_base

### DIFF
--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -494,6 +494,14 @@ static void update_recv_state_base(const struct bt_bap_broadcast_sink *sink,
 	mod_src_param.src_id = recv_state->src_id;
 	mod_src_param.encrypt_state = recv_state->encrypt_state;
 	mod_src_param.broadcast_id = recv_state->broadcast_id;
+	mod_src_param.num_subgroups = sink->subgroup_count;
+	for (uint8_t i = 0U; i < sink->subgroup_count; i++) {
+		struct bt_bap_scan_delegator_subgroup *subgroup_param = &mod_src_param.subgroups[i];
+		const struct bt_bap_broadcast_sink_subgroup *sink_subgroup = &sink->subgroups[i];
+
+		/* Set the bis_sync value to the indexes available per subgroup */
+		subgroup_param->bis_sync = sink_subgroup->bis_indexes & sink->indexes_bitfield;
+	}
 
 	err = bt_bap_scan_delegator_mod_src(&mod_src_param);
 	if (err != 0) {


### PR DESCRIPTION

In the update_recv_state_base function, we should update the BASE with any new metadata that we have received (as that may change while streaming). However, this function did not properly keep the existing bis_sync values for the subgroups, causing the bis_sync for all subgroups to be 0.