### PR TITLE
Bluetooth: BAP: Stop broadcast sink from removing receive state

### DIFF
--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -926,17 +926,6 @@ static void broadcast_sink_cleanup_streams(struct bt_bap_broadcast_sink *sink)
 
 static void broadcast_sink_cleanup(struct bt_bap_broadcast_sink *sink)
 {
-	if (atomic_test_bit(sink->flags,
-			    BT_BAP_BROADCAST_SINK_FLAG_SRC_ID_VALID)) {
-		int err;
-
-		err = bt_bap_scan_delegator_rem_src(sink->bass_src_id);
-		if (err != 0) {
-			/* This is likely due to the receive state been removed */
-			LOG_DBG("Could not remove Receive State for sink %p: %d", sink, err);
-		}
-	}
-
 	if (sink->stream_count > 0U) {
 		broadcast_sink_cleanup_streams(sink);
 	}


### PR DESCRIPTION
The receive state may be added by the broadcast sink if not added by the application, but even in that case when the broadcast sink is deleted, we should not remove the receive state, as the receive state may still container information about the PA sync that has a lifetime not coupled with the broadcast sink.