### PR TITLE
Bluetooth: BAP: Do not send PA term request on local remove

### DIFF
--- a/subsys/bluetooth/audio/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/bap_scan_delegator.c
@@ -913,8 +913,9 @@ static int scan_delegator_rem_src(struct bt_conn *conn,
 
 	state = &internal_state->state;
 
-	if (state->pa_sync_state == BT_BAP_PA_STATE_INFO_REQ ||
-	    state->pa_sync_state == BT_BAP_PA_STATE_SYNCED) {
+	/* If conn == NULL then it's a local operation and we do not need to ask the application */
+	if (conn != NULL && (state->pa_sync_state == BT_BAP_PA_STATE_INFO_REQ ||
+			     state->pa_sync_state == BT_BAP_PA_STATE_SYNCED)) {
 		int err;
 
 		/* Terminate PA sync */

--- a/tests/bsim/bluetooth/audio/src/bap_scan_delegator_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_scan_delegator_test.c
@@ -616,6 +616,13 @@ static void remove_all_sources(void)
 
 			printk("[%zu]: Source removed with id %u\n",
 			       i, state->src_id);
+
+			printk("Terminating PA sync\n");
+			err = pa_sync_term(state);
+			if (err) {
+				FAIL("[%zu]: PA sync term failed (err %d)\n", err);
+				return;
+			}
 		}
 	}
 }


### PR DESCRIPTION
If the receive state is locally removed, then we should not request permission from the application, as that is implicit when removing the source locally.