### PR TITLE
github: hello_world_multiplatform: run on macOS ARM

### DIFF
--- a/.github/workflows/hello_world_multiplatform.yaml
+++ b/.github/workflows/hello_world_multiplatform.yaml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-12, windows-2022]
+        os: [ubuntu-22.04, macos-12, macos-14, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout


### PR DESCRIPTION
What do you folks think? Just randomly spotted this from https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories.

Worth a try? Worst case we revert it I guess...

---

Seems like GitHub introduced a macOS on ARM runner, add it to the multiplatform test, with this we are running all the SDKs minus the Linux ARM64 one.