### PR TITLE
tests: bsim: Bluetooth: CSIP: Increase EXECUTE_TIMEOUT to 30

### DIFF
--- a/tests/bsim/bluetooth/audio/test_scripts/csip.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2020-2023 Nordic Semiconductor ASA
+# Copyright (c) 2020-2024 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -10,7 +10,7 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=20
+EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/csip_encrypted_sirk.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip_encrypted_sirk.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2023 Nordic Semiconductor ASA
+# Copyright (c) 2023-2024 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -9,7 +9,7 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=20
+EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/csip_forced_release.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip_forced_release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2023 Nordic Semiconductor ASA
+# Copyright (c) 2023-2024 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -9,7 +9,7 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=20
+EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/csip_no_lock.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip_no_lock.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2023 Nordic Semiconductor ASA
+# Copyright (c) 2023-2024 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -9,7 +9,7 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=20
+EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/csip_no_rank.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip_no_rank.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2023 Nordic Semiconductor ASA
+# Copyright (c) 2023-2024 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -9,7 +9,7 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=20
+EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/csip_no_size.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip_no_size.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2023 Nordic Semiconductor ASA
+# Copyright (c) 2023-2024 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -9,7 +9,7 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=20
+EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/csip_notify.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip_notify.sh
@@ -8,7 +8,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 SIMULATION_ID="csip_notify"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=200
+EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 


### PR DESCRIPTION
Some of the CSIP tests take a while to run given the number of devices, and some of them started to fail in CI because of a timeout, so we increase the EXECUTE_TIMEOUT a bit.