### PR TITLE
adi_sdp_k1: Enable usb cdc support

### DIFF
--- a/boards/adi/sdp_k1/adi_sdp_k1.dts
+++ b/boards/adi/sdp_k1/adi_sdp_k1.dts
@@ -41,6 +41,12 @@
 		};
 	};
 
+	otghs_ulpi_phy: otghs_ulpis_phy {
+		compatible = "usb-ulpi-phy";
+		reset-gpios = <&gpiod 7 (GPIO_ACTIVE_LOW)>;
+		#phy-cells = <0>;
+	};
+
 	aliases {
 		led0 = &status_led;
 	};
@@ -76,5 +82,27 @@
 	pinctrl-0 = <&uart5_tx_pc12 &uart5_rx_pd2>;
 	pinctrl-names = "default";
 	current-speed = <115200>;
+	status = "okay";
+};
+
+zephyr_udc0: &usbotg_hs {
+	pinctrl-0 = <&usb_otg_hs_ulpi_ck_pa5
+		     &usb_otg_hs_ulpi_d0_pa3
+		     &usb_otg_hs_ulpi_d1_pb0
+		     &usb_otg_hs_ulpi_d2_pb1
+		     &usb_otg_hs_ulpi_d3_pb10
+		     &usb_otg_hs_ulpi_d4_pb11
+		     &usb_otg_hs_ulpi_d5_pb12
+		     &usb_otg_hs_ulpi_d6_pb13
+		     &usb_otg_hs_ulpi_d7_pb5
+		     &usb_otg_hs_ulpi_stp_pc0
+		     &usb_otg_hs_ulpi_dir_pc2
+		     &usb_otg_hs_ulpi_nxt_pc3>;
+	pinctrl-names = "default";
+	maximum-speed = "high-speed";
+	/* Enable OTGHSULPIEN rather than OTGHSEN */
+	clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x60000000>,
+		 <&rcc STM32_SRC_PLL_Q NO_SEL>;
+	phys = <&otghs_ulpi_phy>;
 	status = "okay";
 };

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -276,14 +276,16 @@ static int usb_dc_stm32_clock_enable(void)
 	 */
 	LL_AHB1_GRP1_DisableClockSleep(LL_AHB1_GRP1_PERIPH_USB1OTGHSULPI);
 #endif
-#else
+#else /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32_usbphyc) */
+#if !USB_OTG_HS_ULPI_PHY
 	/* Disable ULPI interface (for external high-speed PHY) clock in low
 	 * power mode. It is disabled by default in run power mode, no need to
 	 * disable it.
 	 */
 	LL_AHB1_GRP1_DisableClockLowPower(LL_AHB1_GRP1_PERIPH_OTGHSULPI);
-#endif
-#endif
+#endif /* USB_OTG_HS_ULPI_PHY */
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32_usbphyc) */
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32_otghs) */
 
 	return 0;
 }

--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -988,14 +988,16 @@ static int priv_clock_enable(void)
 	 */
 	LL_AHB1_GRP1_DisableClockSleep(LL_AHB1_GRP1_PERIPH_USB2OTGHSULPI);
 #endif
-#else
+#else /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32_usbphyc) */
+#if !USB_OTG_HS_ULPI_PHY
 	/* Disable ULPI interface (for external high-speed PHY) clock in low
 	 * power mode. It is disabled by default in run power mode, no need to
 	 * disable it.
 	 */
 	LL_AHB1_GRP1_DisableClockLowPower(LL_AHB1_GRP1_PERIPH_OTGHSULPI);
-#endif
-#endif
+#endif /* USB_OTG_HS_ULPI_PHY */
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32_usbphyc) */
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32_otghs) */
 
 	return 0;
 }


### PR DESCRIPTION
This PR adds support for usb cdc on the adi sdp k1.

the PR includes:
- patch to fix to avoid disabling ULPI clk in case of external ULPI phy.
- DT changes to enable ulpi phy and usb udc on sdp_k1.

Validated using a sdp_k1 revE using the  samples/subsys/usb/cdc_acm application: the board enumerates correctly on a linux pc, and opening the ttyACMx
device we are able to see the characters that are echoed back.