### PR TITLE
kernel/thread: Detect in-kernel "reserved" stack overflow

### DIFF
--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -530,6 +530,15 @@ static char *setup_thread_stack(struct k_thread *new_thread,
 		stack_obj_size = Z_KERNEL_STACK_SIZE_ADJUST(stack_size);
 		stack_buf_start = Z_KERNEL_STACK_BUFFER(stack);
 		stack_buf_size = stack_obj_size - K_KERNEL_STACK_RESERVED;
+
+		/* Zephyr treats stack overflow as an app bug.  But
+		 * this particular overflow can be seen by static
+		 * analysis so needs to be handled somehow.
+		 */
+		if (K_KERNEL_STACK_RESERVED > stack_obj_size) {
+			k_panic();
+		}
+
 	}
 
 	/* Initial stack pointer at the high end of the stack object, may


### PR DESCRIPTION
Traditionally, k_thread_create() has required that the application size the stack correctly.  Zephyr doesn't detect or return errors and treats stack overflow as an application bug (though obviously some architectures have runtime features to trap on overflows).

At this one spot though, it's possible for the kernel to adjust the stack for K_THREAD_STACK_RESERVED in such a way that the arch layer's own stack initialization overflows.  That failure can be seen by static analysis, so we can't just sweep it under the rug as an application failure.

Unfortunately there aren't any good options for handling it here (no way to return failure, can't be a build assert as the size is a runtime argument).  A panic will have to do.

Fixes: #67106
Fixes: #65584