### PR TITLE
twister: add calling pre/post scripts from testcase

### DIFF
--- a/scripts/pylib/twister/twisterlib/config_parser.py
+++ b/scripts/pylib/twister/twisterlib/config_parser.py
@@ -78,7 +78,8 @@ class TwisterConfigParser:
                        "harness": {"type": "str", "default": "test"},
                        "harness_config": {"type": "map", "default": {}},
                        "seed": {"type": "int", "default": 0},
-                       "sysbuild": {"type": "bool", "default": False}
+                       "sysbuild": {"type": "bool", "default": False},
+                       "extra_script": {"type": "map", "default": []}
                        }
 
     def __init__(self, filename, schema):

--- a/scripts/schemas/twister/testsuite-schema.yaml
+++ b/scripts/schemas/twister/testsuite-schema.yaml
@@ -207,6 +207,21 @@ schema;scenario-schema:
     "sysbuild":
       type: bool
       required: false
+    "extra_script":
+      type: map
+      required: false
+      mapping:
+        "platforms":
+          type: seq
+          required: false
+          sequence:
+            - type: str
+        "script_type":
+          type: seq
+          required: false
+          sequence:
+            - type: str
+              enum: ["pre_script", "post_flash_script", "post_script"]
 
 type: map
 mapping:


### PR DESCRIPTION
During the testing process, certain tests may necessitate additional actions specific to the board type.
While Twister currently offers pre/post scripts through the hardware map, parameters, or runner parameters, these solutions apply universally to all executions. This proposal aims to enhance flexibility by enabling the execution of pre/post scripts on a per-testcase basis. According to this i would like to propose to enable running pre/post scripts per testcase. Extend functionality is made by adding "extra_script" argument in testcase.yaml file, where we define which script we would execute
( ["pre_script", "post_flash_script", "post_script"] ) and on which board.
 Example:
```
   extra_script:
      platforms:
       - frdm_k64f 
      script_type:
       - pre_script 
       - post_flash_script 
       - post_script 
```
 This approach require extending the board file structure by a "support" folder containing predefined scripts for use. In the testcase.yaml file, specify the "extra_script" argument, indicating the desired script and its associated board. During execution, Twister will incorporate the specified pre/post script used already implemented solutions.