### PR TITLE
[DNM] why you should care about _POSIX_C_SOURCE

### DIFF
--- a/include/zephyr/posix/arpa/inet.h
+++ b/include/zephyr/posix/arpa/inet.h
@@ -17,8 +17,7 @@
 extern "C" {
 #endif
 
-#ifndef CONFIG_NET_SOCKETS_POSIX_NAMES
-
+#if _POSIX_C_SOURCE >= 200112L
 static inline char *inet_ntop(sa_family_t family, const void *src, char *dst,
 			      size_t size)
 {
@@ -29,8 +28,7 @@ static inline int inet_pton(sa_family_t family, const char *src, void *dst)
 {
 	return zsock_inet_pton(family, src, dst);
 }
-
-#endif /* CONFIG_NET_SOCKETS_POSIX_NAMES */
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/posix/dirent.h
+++ b/include/zephyr/posix/dirent.h
@@ -9,12 +9,13 @@
 #include <limits.h>
 #include "posix_types.h"
 
-#ifdef CONFIG_POSIX_FS
 #include <zephyr/fs/fs.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#if _XOPEN_SOURCE >= 700 || _POSIX_C_SOURCE >= 200809L
 
 typedef void DIR;
 
@@ -28,10 +29,10 @@ DIR *opendir(const char *dirname);
 int closedir(DIR *dirp);
 struct dirent *readdir(DIR *dirp);
 
+#endif
+
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* CONFIG_POSIX_FS */
 
 #endif	/* ZEPHYR_INCLUDE_POSIX_DIRENT_H_ */

--- a/include/zephyr/posix/fcntl.h
+++ b/include/zephyr/posix/fcntl.h
@@ -31,8 +31,12 @@
 extern "C" {
 #endif
 
+#if _POSIX_C_SOURCE >= 200112L
+
 int open(const char *name, int flags, ...);
 int fcntl(int fildes, int cmd, ...);
+
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/posix/fnmatch.h
+++ b/include/zephyr/posix/fnmatch.h
@@ -50,7 +50,11 @@
 extern "C" {
 #endif
 
+#if _POSIX_C_SOURCE >= 2
+
 int fnmatch(const char *, const char *, int);
+
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/posix/mqueue.h
+++ b/include/zephyr/posix/mqueue.h
@@ -18,6 +18,8 @@
 extern "C" {
 #endif
 
+#if _POSIX_C_SOURCE >= 200112L
+
 typedef void *mqd_t;
 
 struct mq_attr {
@@ -42,6 +44,8 @@ int mq_timedreceive(mqd_t mqdes, char *msg_ptr, size_t msg_len,
 int mq_timedsend(mqd_t mqdes, const char *msg_ptr, size_t msg_len,
 		 unsigned int msg_prio, const struct timespec *abstime);
 int mq_notify(mqd_t mqdes, const struct sigevent *notification);
+
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/posix/netdb.h
+++ b/include/zephyr/posix/netdb.h
@@ -29,7 +29,7 @@
 extern "C" {
 #endif
 
-#ifndef CONFIG_NET_SOCKETS_POSIX_NAMES
+#if _POSIX_C_SOURCE >= 1 || _XOPEN_SOURCE || _POSIX_SOURCE
 
 #define addrinfo zsock_addrinfo
 
@@ -58,7 +58,7 @@ static inline int getnameinfo(const struct sockaddr *addr, socklen_t addrlen,
 				 serv, servlen, flags);
 }
 
-#endif /* CONFIG_NET_SOCKETS_POSIX_NAMES */
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/posix/poll.h
+++ b/include/zephyr/posix/poll.h
@@ -12,7 +12,7 @@
 extern "C" {
 #endif
 
-#ifndef CONFIG_NET_SOCKETS_POSIX_NAMES
+#if _POSIX_C_SOURCE >= 200112L
 
 #define pollfd zsock_pollfd
 

--- a/include/zephyr/posix/pthread.h
+++ b/include/zephyr/posix/pthread.h
@@ -19,6 +19,8 @@
 extern "C" {
 #endif
 
+#if _POSIX_C_SOURCE >= 200112L
+
 /*
  * Pthread detach/joinable
  * Undefine possibly predefined values by external toolchain headers
@@ -511,8 +513,6 @@ int pthread_setname_np(pthread_t thread, const char *name);
  * @retval Negative value if kernel function error
  */
 int pthread_getname_np(pthread_t thread, char *name, size_t len);
-
-#ifdef CONFIG_PTHREAD_IPC
 
 /**
  * @brief Destroy a pthread_spinlock_t.

--- a/include/zephyr/posix/sched.h
+++ b/include/zephyr/posix/sched.h
@@ -14,6 +14,8 @@
 extern "C" {
 #endif
 
+#if _POSIX_C_SOURCE >= 200112L
+
 /*
  * Other mandatory scheduling policy. Must be numerically distinct. May
  * execute identically to SCHED_RR or SCHED_FIFO. For Zephyr this is a
@@ -53,6 +55,8 @@ int sched_getscheduler(pid_t pid);
 
 int sched_setparam(pid_t pid, const struct sched_param *param);
 int sched_setscheduler(pid_t pid, int policy, const struct sched_param *param);
+
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/posix/semaphore.h
+++ b/include/zephyr/posix/semaphore.h
@@ -13,6 +13,8 @@
 extern "C" {
 #endif
 
+#if _POSIX_C_SOURCE >= 200112L
+
 #define SEM_FAILED ((sem_t *) 0)
 
 int sem_destroy(sem_t *semaphore);
@@ -25,6 +27,8 @@ int sem_wait(sem_t *semaphore);
 sem_t *sem_open(const char *name, int oflags, ...);
 int sem_unlink(const char *name);
 int sem_close(sem_t *sem);
+
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/posix/signal.h
+++ b/include/zephyr/posix/signal.h
@@ -92,17 +92,22 @@ struct sigevent {
 	int sigev_signo;
 };
 
-#ifdef CONFIG_POSIX_SIGNAL
+#if _POSIX_C_SOURCE >= 200809L
 char *strsignal(int signum);
+#endif
+
+#if _POSIX_C_SOURCE >= 1 || _XOPEN_SOURCE || _POSIX_SOURCE
 int sigemptyset(sigset_t *set);
 int sigfillset(sigset_t *set);
 int sigaddset(sigset_t *set, int signo);
 int sigdelset(sigset_t *set, int signo);
 int sigismember(const sigset_t *set, int signo);
 int sigprocmask(int how, const sigset_t *ZRESTRICT set, sigset_t *ZRESTRICT oset);
+#endif
 
+#if _POSIX_C_SOURCE >= 199506L || _XOPEN_SOURCE >= 500
 int pthread_sigmask(int how, const sigset_t *ZRESTRICT set, sigset_t *ZRESTRICT oset);
-#endif /* CONFIG_POSIX_SIGNAL */
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/posix/stropts.h
+++ b/include/zephyr/posix/stropts.h
@@ -5,6 +5,9 @@
  */
 #ifndef ZEPHYR_INCLUDE_POSIX_STROPTS_H_
 #define ZEPHYR_INCLUDE_POSIX_STROPTS_H_
+
+#if _POSIX_C_SOURCE >= 200112L
+
 #define RS_HIPRI BIT(0)
 
 #ifdef __cplusplus
@@ -21,6 +24,8 @@ int putmsg(int fildes, const struct strbuf *ctlptr, const struct strbuf *dataptr
 
 #ifdef __cplusplus
 }
+#endif
+
 #endif
 
 #endif /* ZEPHYR_INCLUDE_POSIX_STROPTS_H_ */

--- a/include/zephyr/posix/sys/select.h
+++ b/include/zephyr/posix/sys/select.h
@@ -13,7 +13,7 @@
 extern "C" {
 #endif
 
-#ifndef CONFIG_NET_SOCKETS_POSIX_NAMES
+#if _POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600
 
 #define fd_set zsock_fd_set
 #define FD_SETSIZE ZSOCK_FD_SETSIZE
@@ -32,7 +32,7 @@ static inline int select(int nfds, fd_set *readfds,
 			    (struct zsock_timeval *)timeout);
 }
 
-#endif /* CONFIG_NET_SOCKETS_POSIX_NAMES */
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/posix/sys/socket.h
+++ b/include/zephyr/posix/sys/socket.h
@@ -18,7 +18,7 @@ struct linger {
 	int  l_linger;
 };
 
-#ifndef CONFIG_NET_SOCKETS_POSIX_NAMES
+#if _POSIX_C_SOURCE >= 200112L
 
 static inline int socket(int family, int type, int proto)
 {
@@ -118,7 +118,7 @@ static inline int getsockname(int sock, struct sockaddr *addr,
 	return zsock_getsockname(sock, addr, addrlen);
 }
 
-#endif /* CONFIG_NET_SOCKETS_POSIX_NAMES */
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/posix/sys/stat.h
+++ b/include/zephyr/posix/sys/stat.h
@@ -39,6 +39,8 @@ extern "C" {
 #include <sys/types.h>
 #include <sys/_timespec.h>
 
+#if _BSD_SOURCE || _XOPEN_SOURCE >= 500 || _XOPEN_SOURCE && _XOPEN_SOURCE_EXTENDED || _POSIX_C_SOURCE >= 200112L
+
 #ifndef _DEV_T_DECLARED
 typedef int dev_t;
 #define _DEV_T_DECLARED
@@ -270,6 +272,9 @@ int _fstat64(int __fd, struct stat64 *__sbuf);
 #endif
 
 #endif /* !_STAT_H_ */
+
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/posix/sys/time.h
+++ b/include/zephyr/posix/sys/time.h
@@ -29,7 +29,11 @@ struct timeval {
 extern "C" {
 #endif
 
+#if _POSIX_C_SOURCE >= 200112L
+
 int gettimeofday(struct timeval *tv, void *tz);
+
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/posix/sys/utsname.h
+++ b/include/zephyr/posix/sys/utsname.h
@@ -10,6 +10,8 @@
 extern "C" {
 #endif
 
+#if _POSIX_C_SOURCE >= 200112L
+
 struct utsname {
 	char sysname[sizeof("Zephyr")];
 	char nodename[CONFIG_POSIX_UNAME_NODENAME_LEN + 1];
@@ -19,6 +21,8 @@ struct utsname {
 };
 
 int uname(struct utsname *name);
+
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/posix/time.h
+++ b/include/zephyr/posix/time.h
@@ -86,9 +86,12 @@ static inline int32_t _ts_to_ms(const struct timespec *to)
 	return (to->tv_sec * MSEC_PER_SEC) + (to->tv_nsec / NSEC_PER_MSEC);
 }
 
+#if _POSIX_C_SOURCE >= 200112L
 int clock_gettime(clockid_t clock_id, struct timespec *ts);
 int clock_settime(clockid_t clock_id, const struct timespec *ts);
-int clock_getcpuclockid(pid_t pid, clockid_t *clock_id);
+#endif
+
+#if _POSIX_C_SOURCE >= 199309L
 /* Timer APIs */
 int timer_create(clockid_t clockId, struct sigevent *evp, timer_t *timerid);
 int timer_delete(timer_t timerid);
@@ -96,9 +99,17 @@ int timer_gettime(timer_t timerid, struct itimerspec *its);
 int timer_settime(timer_t timerid, int flags, const struct itimerspec *value,
 		  struct itimerspec *ovalue);
 int timer_getoverrun(timer_t timerid);
+#endif
+
+#if _POSIX_C_SOURCE >= 199309L
 int nanosleep(const struct timespec *rqtp, struct timespec *rmtp);
+#endif
+
+#if _XOPEN_SOURCE >= 600 || _POSIX_C_SOURCE >= 200112L
 int clock_nanosleep(clockid_t clock_id, int flags,
 		    const struct timespec *rqtp, struct timespec *rmtp);
+int clock_getcpuclockid(pid_t pid, clockid_t *clock_id);
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/posix/unistd.h
+++ b/include/zephyr/posix/unistd.h
@@ -8,19 +8,13 @@
 
 #include "posix_types.h"
 #include <zephyr/posix/sys/stat.h>
-#ifdef CONFIG_NETWORKING
 /* For zsock_gethostname() */
 #include <zephyr/net/socket.h>
 #include <zephyr/net/hostname.h>
-#endif
 
-#ifdef CONFIG_POSIX_API
 #include <zephyr/fs/fs.h>
-#endif
 
-#ifdef CONFIG_POSIX_SYSCONF
 #include <zephyr/posix/signal.h>
-#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -224,7 +218,7 @@ extern "C" {
 #define POSIX_REC_XFER_ALIGN	 (4)
 #define SYMLINK_MAX		 _POSIX_SYMLINK_MAX
 
-#ifdef CONFIG_POSIX_API
+#if _POSIX_C_SOURCE >= 200112L
 /* File related operations */
 int close(int file);
 ssize_t write(int file, const void *buffer, size_t count);
@@ -234,29 +228,39 @@ off_t lseek(int file, off_t offset, int whence);
 /* File System related operations */
 int rename(const char *old, const char *newp);
 int unlink(const char *path);
-int stat(const char *path, struct stat *buf);
 int mkdir(const char *path, mode_t mode);
+#endif
+
+#if _BSD_SOURCE || _XOPEN_SOURCE >= 500 || _XOPEN_SOURCE && _XOPEN_SOURCE_EXTENDED || _POSIX_C_SOURCE >= 200112L
+int stat(const char *path, struct stat *buf);
+#endif
 
 FUNC_NORETURN void _exit(int status);
 
-#ifdef CONFIG_NETWORKING
+#if _BSD_SOURCE || _XOPEN_SOURCE >= 500 || _POSIX_C_SOURCE >= 200112L
 static inline int gethostname(char *buf, size_t len)
 {
 	return zsock_gethostname(buf, len);
 }
-#endif /* CONFIG_NETWORKING */
+#endif
 
-#endif /* CONFIG_POSIX_API */
-
-#ifdef CONFIG_GETOPT
+#if _POSIX_C_SOURCE >= 2 || _XOPEN_SOURCE
 int getopt(int argc, char *const argv[], const char *optstring);
 extern char *optarg;
 extern int opterr, optind, optopt;
 #endif
 
+#if _POSIX_C_SOURCE >= 200112L
 pid_t getpid(void);
+#endif
+
+#if _POSIX_C_SOURCE >= 200112L
 unsigned sleep(unsigned int seconds);
+#endif
+
+#if _BSD_SOURCE || (_XOPEN_SOURCE >= 500 || _XOPEN_SOURCE && _XOPEN_SOURCE_EXTENDED) && !(_POSIX_C_SOURCE >= 200809L || _XOPEN_SOURCE >= 700)
 int usleep(useconds_t useconds);
+#endif
 
 #ifdef CONFIG_POSIX_SYSCONF
 #define __z_posix_sysconf_SC_ADVISORY_INFO		  _POSIX_ADVISORY_INFO
@@ -385,7 +389,9 @@ int usleep(useconds_t useconds);
 #define __z_posix_sysconf_SC_TTY_NAME_MAX		  TTY_NAME_MAX
 #define __z_posix_sysconf_SC_TZNAME_MAX			  TZNAME_MAX
 
+#if _POSIX_C_SOURCE >= 200112L
 #define sysconf(x) (long)CONCAT(__z_posix_sysconf, x)
+#endif
 
 #endif /* CONFIG_POSIX_SYSCONF */
 

--- a/lib/libc/minimal/include/string.h
+++ b/lib/libc/minimal/include/string.h
@@ -18,16 +18,22 @@ extern "C" {
 
 extern char  *strcpy(char *ZRESTRICT d, const char *ZRESTRICT s);
 extern char  *strerror(int errnum);
+#if _POSIX_C_SOURCE >= 200112L
 extern int   strerror_r(int errnum, char *strerrbuf, size_t buflen);
+#endif
 extern char  *strncpy(char *ZRESTRICT d, const char *ZRESTRICT s,
 		      size_t n);
 extern char  *strchr(const char *s, int c);
 extern char  *strrchr(const char *s, int c);
 extern size_t strlen(const char *s);
+#if _POSIX_C_SOURCE >= 200809L
 extern size_t strnlen(const char *s, size_t maxlen);
+#endif
 extern int    strcmp(const char *s1, const char *s2);
 extern int    strncmp(const char *s1, const char *s2, size_t n);
+#if _POSIX_C_SOURCE >= 200112L
 extern char  *strtok_r(char *str, const char *sep, char **state);
+#endif
 extern char *strcat(char *ZRESTRICT dest,
 		    const char *ZRESTRICT src);
 extern char  *strncat(char *ZRESTRICT dest, const char *ZRESTRICT src,

--- a/lib/libc/minimal/include/time.h
+++ b/lib/libc/minimal/include/time.h
@@ -49,8 +49,10 @@ typedef _SUSECONDS_T_ suseconds_t;
  * require access to time zone information.
  */
 struct tm *gmtime(const time_t *timep);
+#if _POSIX_C_SOURCE >= 1 || _XOPEN_SOURCE || _BSD_SOURCE || _SVID_SOURCE || _POSIX_SOURCE
 struct tm *gmtime_r(const time_t *ZRESTRICT timep,
 		    struct tm *ZRESTRICT result);
+#endif
 
 time_t time(time_t *tloc);
 


### PR DESCRIPTION
DO NOT MERGE
DO NOT REVIEW (this is for demonstration purposes only)

This is a proof-of-concept PR that demonstrates the scale of breakage we will be looking at by not addressing the issue of managing _POSIX_C_SOURCE in an intelligent and scalable way.

```shell
twister --build-only -p qemu_x86 -T tests/posix/ \
  -T samples/posix -T samples/net -T tests/lib/c_lib -T tests/net/
...
- Total complete:  403/ 403  100%  skipped: 146, failed: 0, error:  103
INFO    - 404 test scenarios (403 test instances) selected, 146 configurations skipped (139 by static filter, 7 at runtime).
INFO    - 154 of 403 test configurations passed (59.92%), 0 failed, 103 errored, 146 skipped with 0 warnings in 265.66 seconds
INFO    - 0 test configurations executed on platforms, 257 test configurations were only built.
```
<img width="1011" alt="Screenshot 2024-02-01 at 1 51 18 PM" src="https://github.com/zephyrproject-rtos/zephyr/assets/983494/33c98486-8aab-4a37-829a-4cd3ab41c1c3">

