### PR TITLE
drivers: spi: stm32: improve performance with FIFO usage

### DIFF
--- a/drivers/spi/Kconfig.stm32
+++ b/drivers/spi/Kconfig.stm32
@@ -13,6 +13,13 @@ menuconfig SPI_STM32
 
 if SPI_STM32
 
+config SPI_STM32_FIFO
+	bool "STM32 MCU SPI FIFO Support"
+	help
+	  Enable use of FIFO when transmitting and receiving.
+
+	  This comes with RAM, ROM and runtime overhead.
+
 config SPI_STM32_INTERRUPT
 	bool "STM32 MCU SPI Interrupt Support"
 	help

--- a/drivers/spi/Kconfig.stm32
+++ b/drivers/spi/Kconfig.stm32
@@ -15,6 +15,7 @@ if SPI_STM32
 
 config SPI_STM32_FIFO
 	bool "STM32 MCU SPI FIFO Support"
+	default y if DT_HAS_ST_STM32_SPI_FIFO_ENABLED
 	help
 	  Enable use of FIFO when transmitting and receiving.
 

--- a/drivers/spi/spi_ll_stm32.h
+++ b/drivers/spi/spi_ll_stm32.h
@@ -34,6 +34,9 @@ struct spi_stm32_config {
 #endif
 	size_t pclk_len;
 	const struct stm32_pclken *pclken;
+#if CONFIG_SPI_STM32_FIFO
+	uint8_t fifo_size;
+#endif
 };
 
 #ifdef CONFIG_SPI_STM32_DMA
@@ -61,6 +64,10 @@ struct stream {
 
 struct spi_stm32_data {
 	struct spi_context ctx;
+#if CONFIG_SPI_STM32_FIFO
+	size_t tx_fifo_room;
+	size_t transfer_len;
+#endif /* CONFIG_SPI_STM32_FIFO */
 #ifdef CONFIG_SPI_STM32_DMA
 	struct k_sem status_sem;
 	volatile uint32_t status_flags;

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -201,6 +201,7 @@
 			reg = <0x40013000 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00001000>;
 			interrupts = <25 3>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/f0/stm32f030X8.dtsi
+++ b/dts/arm/st/f0/stm32f030X8.dtsi
@@ -46,6 +46,7 @@
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00004000>;
 			interrupts = <26 3>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/f0/stm32f042.dtsi
+++ b/dts/arm/st/f0/stm32f042.dtsi
@@ -35,6 +35,7 @@
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00004000>;
 			interrupts = <26 3>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/f0/stm32f051.dtsi
+++ b/dts/arm/st/f0/stm32f051.dtsi
@@ -38,6 +38,7 @@
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00004000>;
 			interrupts = <26 3>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/f0/stm32f070Xb.dtsi
+++ b/dts/arm/st/f0/stm32f070Xb.dtsi
@@ -62,6 +62,7 @@
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00004000>;
 			interrupts = <26 3>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -239,6 +239,7 @@
 			reg = <0x40013000 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00001000>;
 			interrupts = <35 5>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/f3/stm32f302.dtsi
+++ b/dts/arm/st/f3/stm32f302.dtsi
@@ -55,6 +55,7 @@
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00004000>;
 			interrupts = <36 5>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 
@@ -65,6 +66,7 @@
 			reg = <0X40003c00 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00008000>;
 			interrupts = <51 5>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/f3/stm32f303.dtsi
+++ b/dts/arm/st/f3/stm32f303.dtsi
@@ -39,6 +39,7 @@
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00004000>;
 			interrupts = <36 5>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 
@@ -49,6 +50,7 @@
 			reg = <0x40003c00 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00008000>;
 			interrupts = <51 5>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/f3/stm32f373.dtsi
+++ b/dts/arm/st/f3/stm32f373.dtsi
@@ -52,6 +52,7 @@
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00004000>;
 			interrupts = <36 5>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 
@@ -62,6 +63,7 @@
 			reg = <0x40003c00 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00008000>;
 			interrupts = <51 5>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -353,6 +353,7 @@
 			reg = <0x40013000 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00001000>;
 			interrupts = <35 5>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 
@@ -363,6 +364,7 @@
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00004000>;
 			interrupts = <36 5>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 
@@ -373,6 +375,7 @@
 			reg = <0x40003c00 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00008000>;
 			interrupts = <51 5>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 
@@ -383,6 +386,7 @@
 			reg = <0x40013400 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00002000>;
 			interrupts = <84 5>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 
@@ -393,6 +397,7 @@
 			reg = <0x40015000 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00100000>;
 			interrupts = <85 5>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/f7/stm32f745.dtsi
+++ b/dts/arm/st/f7/stm32f745.dtsi
@@ -63,6 +63,7 @@
 			reg = <0x40015400 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00200000>;
 			interrupts = <86 5>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/f7/stm32f765.dtsi
+++ b/dts/arm/st/f7/stm32f765.dtsi
@@ -65,6 +65,7 @@
 			reg = <0x40015400 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00200000>;
 			interrupts = <86 5>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -376,6 +376,7 @@
 			reg = <0x40013000 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00001000>;
 			interrupts = <25 0>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 
@@ -386,6 +387,7 @@
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00004000>;
 			interrupts = <26 0>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/g0/stm32g0b0.dtsi
+++ b/dts/arm/st/g0/stm32g0b0.dtsi
@@ -74,6 +74,7 @@
 			reg = <0x40003c00 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00008000>;
 			interrupts = <26 3>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/g0/stm32g0b1.dtsi
+++ b/dts/arm/st/g0/stm32g0b1.dtsi
@@ -119,6 +119,7 @@
 			reg = <0x40003c00 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00008000>;
 			interrupts = <26 3>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -359,6 +359,7 @@
 			reg = <0x40013000 0x400>;
 			interrupts = <35 5>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00001000>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 
@@ -369,6 +370,7 @@
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00004000>;
 			interrupts = <36 5>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 
@@ -379,6 +381,7 @@
 			reg = <0x40003c00 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00008000>;
 			interrupts = <51 5>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/g4/stm32g473.dtsi
+++ b/dts/arm/st/g4/stm32g473.dtsi
@@ -64,6 +64,7 @@
 			reg = <0x40013c00 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00008000>;
 			interrupts = <84 5>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -410,6 +410,7 @@
 			reg = <0x40013000 0x400>;
 			interrupts = <55 5>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00001000>;
+			fifo-size = <16>;
 			status = "disabled";
 		};
 
@@ -420,6 +421,7 @@
 			reg = <0x40003800 0x400>;
 			interrupts = <56 5>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00004000>;
+			fifo-size = <16>;
 			status = "disabled";
 		};
 
@@ -430,6 +432,7 @@
 			reg = <0x40003c00 0x400>;
 			interrupts = <57 5>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00008000>;
+			fifo-size = <16>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -139,6 +139,7 @@
 			reg = <0x40014c00 0x400>;
 			interrupts = <82 5>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00080000>;
+			fifo-size = <8>;
 			status = "disabled";
 		};
 
@@ -149,6 +150,7 @@
 			reg = <0x44002000 0x400>;
 			interrupts = <83 5>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB3 0x00000020>;
+			fifo-size = <8>;
 			status = "disabled";
 		};
 
@@ -159,6 +161,7 @@
 			reg = <0x40015000 0x400>;
 			interrupts = <84 5>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00100000>;
+			fifo-size = <8>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -411,6 +411,7 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00001000>,
 				<&rcc STM32_SRC_PLL1_Q SPI123_SEL(0)>;
 			interrupts = <35 0>;
+			fifo-size = <16>;
 			status = "disabled";
 		};
 
@@ -422,6 +423,7 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00004000>,
 				<&rcc STM32_SRC_PLL1_Q SPI123_SEL(0)>;
 			interrupts = <36 0>;
+			fifo-size = <16>;
 			status = "disabled";
 		};
 
@@ -433,6 +435,7 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00008000>,
 				<&rcc STM32_SRC_PLL1_Q SPI123_SEL(0)>;
 			interrupts = <51 0>;
+			fifo-size = <16>;
 			status = "disabled";
 		};
 
@@ -443,6 +446,7 @@
 			reg = <0x40013400 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00002000>;
 			interrupts = <84 0>;
+			fifo-size = <8>;
 			status = "disabled";
 		};
 
@@ -453,6 +457,7 @@
 			reg = <0x40015000 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00100000>;
 			interrupts = <85 0>;
+			fifo-size = <8>;
 			status = "disabled";
 		};
 
@@ -463,6 +468,7 @@
 			reg = <0x58001400 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB4 0x00000020>;
 			interrupts = <86 0>;
+			fifo-size = <8>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -271,6 +271,7 @@
 			reg = <0x40013000 0x400>;
 			interrupts = <35 5>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00001000>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/l4/stm32l412.dtsi
+++ b/dts/arm/st/l4/stm32l412.dtsi
@@ -57,6 +57,7 @@
 			reg = <0x40003800 0x400>;
 			interrupts = <36 5>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00004000>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/l4/stm32l431.dtsi
+++ b/dts/arm/st/l4/stm32l431.dtsi
@@ -63,6 +63,7 @@
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00004000>;
 			interrupts = <36 5>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 
@@ -73,6 +74,7 @@
 			reg = <0x40003c00 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00008000>;
 			interrupts = <51 5>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/l4/stm32l432.dtsi
+++ b/dts/arm/st/l4/stm32l432.dtsi
@@ -31,6 +31,7 @@
 			reg = <0x40003c00 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00008000>;
 			interrupts = <51 5>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/l4/stm32l433.dtsi
+++ b/dts/arm/st/l4/stm32l433.dtsi
@@ -47,6 +47,7 @@
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00004000>;
 			interrupts = <36 5>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/l4/stm32l451.dtsi
+++ b/dts/arm/st/l4/stm32l451.dtsi
@@ -73,6 +73,7 @@
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00004000>;
 			interrupts = <36 5>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 
@@ -83,6 +84,7 @@
 			reg = <0x40003c00 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00008000>;
 			interrupts = <51 5>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/l4/stm32l471.dtsi
+++ b/dts/arm/st/l4/stm32l471.dtsi
@@ -91,6 +91,7 @@
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00004000>;
 			interrupts = <36 5>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 
@@ -101,6 +102,7 @@
 			reg = <0x40003c00 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00008000>;
 			interrupts = <51 5>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/l4/stm32l4p5.dtsi
+++ b/dts/arm/st/l4/stm32l4p5.dtsi
@@ -144,6 +144,7 @@
 			reg = <0x40003800 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00004000>;
 			interrupts = <36 5>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 
@@ -154,6 +155,7 @@
 			reg = <0x40003c00 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00008000>;
 			interrupts = <51 5>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -390,6 +390,7 @@
 			reg = <0x40013000 0x400>;
 			interrupts = <59 5>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00001000>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 
@@ -418,6 +419,7 @@
 			reg = <0x40003800 0x400>;
 			interrupts = <60 5>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00004000>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 
@@ -428,6 +430,7 @@
 			reg = <0x40003c00 0x400>;
 			interrupts = <99 5>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00008000>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/mp1/stm32mp157.dtsi
+++ b/dts/arm/st/mp1/stm32mp157.dtsi
@@ -218,6 +218,7 @@
 			#size-cells = <0>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x100>;
 			interrupts = <35 5>;
+			fifo-size = <16>;
 			status = "disabled";
 		};
 
@@ -228,6 +229,7 @@
 			#size-cells = <0>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x800>;
 			interrupts = <36 5>;
+			fifo-size = <16>;
 			status = "disabled";
 		};
 
@@ -238,6 +240,7 @@
 			#size-cells = <0>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x1000>;
 			interrupts = <51 5>;
+			fifo-size = <16>;
 			status = "disabled";
 		};
 
@@ -248,6 +251,7 @@
 			#size-cells = <0>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x200>;
 			interrupts = <84 5>;
+			fifo-size = <8>;
 			status = "disabled";
 		};
 
@@ -258,6 +262,7 @@
 			#size-cells = <0>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x400>;
 			interrupts = <85 5>;
+			fifo-size = <8>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -354,6 +354,7 @@
 			reg = <0x40013000 0x400>;
 			interrupts = <59 5>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00001000>;
+			fifo-size = <16>;
 			status = "disabled";
 		};
 
@@ -364,6 +365,7 @@
 			reg = <0x40003800 0x400>;
 			interrupts = <60 5>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00004000>;
+			fifo-size = <16>;
 			status = "disabled";
 		};
 
@@ -374,6 +376,7 @@
 			reg = <0x46002000 0x400>;
 			interrupts = <99 5>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB3 0x00000020>;
+			fifo-size = <8>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -301,6 +301,7 @@
 			reg = <0x40013000 0x400>;
 			interrupts = <34 5>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00001000>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 
@@ -311,6 +312,7 @@
 			reg = <0x40003800 0x400>;
 			interrupts = <35 5>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00004000>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -262,6 +262,7 @@
 			reg = <0x40013000 0x400>;
 			interrupts = <45 5>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00001000>;
+			fifo-size = <16>;
 			status = "disabled";
 		};
 
@@ -272,6 +273,7 @@
 			reg = <0x46002000 0x400>;
 			interrupts = <63 5>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB7 0x00000020>;
+			fifo-size = <8>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -306,6 +306,7 @@
 			reg = <0x40013000 0x400>;
 			interrupts = <34 5>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00001000>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 
@@ -316,6 +317,7 @@
 			reg = <0x40003800 0x400>;
 			interrupts = <35 5>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00004000>;
+			fifo-size = <4>;
 			status = "disabled";
 		};
 

--- a/dts/bindings/spi/st,stm32-spi-fifo.yaml
+++ b/dts/bindings/spi/st,stm32-spi-fifo.yaml
@@ -6,3 +6,8 @@ description: STM32 SPI controller with embedded Rx and Tx FIFOs
 compatible: "st,stm32-spi-fifo"
 
 include: st,stm32-spi-common.yaml
+
+properties:
+  fifo-size:
+    type: int
+    description: RX/TX FIFO size in bytes

--- a/dts/bindings/spi/st,stm32h7-spi.yaml
+++ b/dts/bindings/spi/st,stm32h7-spi.yaml
@@ -27,3 +27,7 @@ properties:
     description: |
       (Master SS Idleness) minimum clock inserted between
       start and first data transaction.
+
+  fifo-size:
+    type: int
+    description: RX/TX FIFO size in bytes

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_g071rb.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_g071rb.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2024 Marcin Niestroj
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&spi1 {
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <500000>;
+	};
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <16000000>;
+	};
+};

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_h563zi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_h563zi.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2024 Marcin Niestroj
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&spi1 {
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <937500>;
+	};
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <24000000>;
+	};
+};

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_l073rz.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_l073rz.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2024 Marcin Niestroj
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&spi1 {
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <500000>;
+	};
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <4000000>;
+	};
+};

--- a/tests/drivers/spi/spi_loopback/boards/stm32f0_disco.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/stm32f0_disco.overlay
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2024 Marcin Niestroj
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&spi1 {
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <500000>;
+	};
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <16000000>;
+	};
+
+	pinctrl-0 = <&spi1_nss_pa4 &spi1_sck_pa5
+		     &spi1_miso_pa6 &spi1_mosi_pa7>;
+	pinctrl-names = "default";
+	status = "okay";
+};


### PR DESCRIPTION
Make use of SPI peripheral internal FIFO. Each STM32 family has different
FIFO sizes and some families have per SPI instance FIFO size. Allow to
configure that over devicetree with new `fifo-size` property.

Performance benefits are shown on below testing platforms and Kconfig
options (numbers provided are the duration of nCS pulse being low, in
microseconds):

 * nucleo_l476rg with SPI at 16MHz (CONFIG_SPI_STM32_INTERRUPT=n)

```
   | Transfer direction             |  TX   |  RX   |  TX  |  RX  |
   | Transferred bytes              |  32   |  32   |   4  |   4  |
   |--------------------------------+-------+-------+------+------|
   | CONFIG_SPI_STM32_FIFO=n        |  56.9 |  64.1 |  9.4 | 10.7 |
   | CONFIG_SPI_STM32_FIFO=y        |  36.1 |  37.1 |  9.0 |  9.3 |
```

 * nucleo_l476rg with SPI at 16MHz (CONFIG_SPI_STM32_INTERRUPT=y)

```
   | Transfer direction             |  TX   |  RX   |  TX  |  RX  |
   | Transferred bytes              |  32   |  32   |   4  |   4  |
   |--------------------------------+-------+-------+------+------|
   | CONFIG_SPI_STM32_FIFO=n        | 108.3 | 116.5 | 17.2 | 18.4 |
   | CONFIG_SPI_STM32_FIFO=y        |  39.1 |  39.9 | 12.3 | 12.6 |
```

 * nucleo_h563zi with SPI at 24MHz (CONFIG_SPI_STM32_INTERRUPT=n)

```
   | Transfer direction             |  TX   |  RX   |  TX  |  RX  |
   | Transferred bytes              |  32   |  32   |   4  |   4  |
   |--------------------------------+-------+-------+------+------|
   | CONFIG_SPI_STM32_FIFO=n        |  32.9 |  34.8 |  4.6 |  4.9 |
   | CONFIG_SPI_STM32_FIFO=y        |  18.4 |  18.9 |  3.2 |  4.0 |
```

 * nucleo_h563zi with SPI at 24MHz (CONFIG_SPI_STM32_INTERRUPT=y)

```
   | Transfer direction             |  TX   |  RX   |  TX  |  RX  |
   | Transferred bytes              |  32   |  32   |   4  |   4  |
   |--------------------------------+-------+-------+------+------|
   | CONFIG_SPI_STM32_FIFO=n        |  46.4 |  50.3 |  6.8 |  7.3 |
   | CONFIG_SPI_STM32_FIFO=y        |  19.3 |  20.6 |  3.8 |  5.5 |
```

Tested `tests/drivers/spi/spi_loopback/` with FIFO enabled on following
platforms:
 * `nucleo_g071rb`
 * `nucleo_h563zi`
 * `nucleo_h723zg`
 * `nucleo_l073rz`
 * `nucleo_l476rg`
 * `nucleo_wl55jc`
 * `stm32f0_disco`
 * `stm32f3_disco`