### PR TITLE
MAINTAINERS: Add pin-zephyr to Bluetooth Audio

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -443,6 +443,7 @@ Bluetooth Audio:
     - fredrikdanebjer
     - kruithofa
     - larsgk
+    - pin-zephyr
   files:
     - subsys/bluetooth/audio/
     - include/zephyr/bluetooth/audio/


### PR DESCRIPTION
Ping is collaborating on Bluetooth Audio

Ping has contributed the following PRs

#68286 
#68100
#68092
#63743

and is attending the weekly LE Audio Zephyr meetings