### PR TITLE
boards: arm: fk7b0m1_vbt6: add support to external NOR Flash

### DIFF
--- a/boards/fanke/fk7b0m1_vbt6/doc/index.rst
+++ b/boards/fanke/fk7b0m1_vbt6/doc/index.rst
@@ -57,13 +57,15 @@ More information about STM32H7B0VB can be found here:
 Supported Features
 ==================
 
-The Zephyr nucleo_h723zg board configuration supports the following hardware
+The Zephyr fk7b0m1_vbt6 board configuration supports the following hardware
 features:
 
 +-------------+------------+-------------------------------------+
 | Interface   | Controller | Driver/Component                    |
 +=============+============+=====================================+
 | NVIC        | on-chip    | nested vector interrupt controller  |
++-------------+------------+-------------------------------------+
+| FLASH       | on-chip    | flash memory                        |
 +-------------+------------+-------------------------------------+
 | UART        | on-chip    | serial port                         |
 +-------------+------------+-------------------------------------+
@@ -75,19 +77,20 @@ features:
 +-------------+------------+-------------------------------------+
 | Backup SRAM | on-chip    | Backup SRAM                         |
 +-------------+------------+-------------------------------------+
+| SPI         | on-chip    | spi bus                             |
++-------------+------------+-------------------------------------+
+| OCTOSPI     | on-chip    | octospi                             |
++-------------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on this Zephyr port.
 
 The default configuration per core can be found in
 :zephyr_file:`boards/fanke/fk7b0m1_vbt6/fk7b0m1_vbt6_defconfig`
 
-Connections and IOs
-===================
+Pin Mapping
+===========
 
-Available pins:
----------------
-
-Nucleo FK7B0M1-VBT6 board has 6 GPIO controllers. These controllers are responsible for pin muxing,
+FK7B0M1-VBT6 board has 5 GPIO controllers. These controllers are responsible for pin muxing,
 input/output, pull-up, etc.
 
 .. figure:: img/fk7b0m1_vbt6_pins.webp
@@ -97,29 +100,17 @@ input/output, pull-up, etc.
 
      FK7B0M1-VBT6 (Credit: FANKE Technology Co., Ltd)
 
-LED
----
+Default Zephyr Peripheral Mapping:
+----------------------------------
 
-- User LED (blue) = PC1
+The FK7B0M1-VBT6 board is configured as follows
 
-Push buttons
--------------------------
-
-- BOOT = SW1 = BOOT0
-- RESET = SW2 = NRST
-- User button = SW3 = PC13
-
-UART
------
-
-- TX device = USART1 PA9
-- RX device = USART1 PA10
-
-USB
----
-
-- USB D- = PA11
-- USB D+ = PA12
+- UART_1 TX/RX : PA9/PA10 (available on the header pins)
+- User LED (blue) : PC1
+- User PB : PC13
+- SPI1 NCS/CLK/MISO/MOSI : PA15/PB3/PB4/PB5 (NOR Flash)
+- QuadSPI NCS/CLK/IO0/IO1/IO2/IO3 : PB6/PB2/PD11/PD12/PE2/PD13 (NOR Flash)
+- USB DM/DP : PA11/PA12
 
 System Clock
 ============
@@ -136,13 +127,19 @@ The Zephyr console output is assigned to UART1. The default communication settin
 Programming and Debugging
 *************************
 
+Applications for the ``fk7b0m1_vbt6`` board configuration can be built and flashed in the usual
+way (see :ref:`build_an_application` and :ref:`application_run` for more details).
+
+Flashing
+========
+
 The FK7B0M1-VBT6 board does not include an on-board debugger. As a result, it requires
 an external debugger, such as ST-Link, for programming and debugging purposes.
 
 The board provides header pins for the Serial Wire Debug (SWD) interface.
 
-Flashing
-========
+Flashing an application to FK7B0M1-VBT6
+---------------------------------------
 
 To begin, connect the ST-Link Debug Programmer to the FK7B0M1-VBT6 board using the SWD
 interface. Next, connect the ST-Link to your host computer via a USB port.

--- a/boards/fanke/fk7b0m1_vbt6/fk7b0m1_vbt6.dts
+++ b/boards/fanke/fk7b0m1_vbt6/fk7b0m1_vbt6.dts
@@ -41,6 +41,7 @@
 	aliases {
 		led0 = &user_led;
 		sw0 = &user_button;
+		spi-flash0 = &w25q64jvssiq_spi;
 	};
 };
 
@@ -73,6 +74,60 @@
 	d2ppre1 = <2>;
 	d2ppre2 = <2>;
 	d3ppre = <2>;
+};
+
+&octospi1 {
+	pinctrl-0 = <&octospim_p1_clk_pb2 &octospim_p1_ncs_pb6
+		     &octospim_p1_io0_pd11 &octospim_p1_io1_pd12
+		     &octospim_p1_io2_pe2 &octospim_p1_io3_pd13>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	/* Winbond external flash */
+	w25q64jvssiq_qspi: qspi-nor-flash@0 {
+		compatible = "st,stm32-ospi-nor";
+		reg = <0 DT_SIZE_M(8)>; /* 64 Mbits */
+		ospi-max-frequency = <DT_FREQ_M(133)>;
+		spi-bus-width = <OSPI_QUAD_MODE>;
+		data-rate = <OSPI_STR_TRANSFER>;
+		writeoc = "PP_1_1_4";
+		status = "okay";
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			slot0_partition: partition@0 {
+				reg = <0x00000000 DT_SIZE_M(8)>; /* 64 Mbits */
+			};
+		};
+	};
+};
+
+&spi6 {
+	pinctrl-0 = <&spi6_sck_pb3 &spi6_miso_pb4 &spi6_mosi_pb5>;
+	cs-gpios = <&gpioa 15 GPIO_ACTIVE_LOW>;
+	pinctrl-names = "default";
+	status = "okay";
+	w25q64jvssiq_spi: spi-nor-flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(40)>;
+		size = <DT_SIZE_M(64)>; /* 64 Mbits */
+		status = "okay";
+		jedec-id = [ef 40 17];
+		has-dpd;
+		t-enter-dpd = <3500>;
+		t-exit-dpd = <3500>;
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			storage_partition: partition@0 {
+				label = "storage";
+				reg = <0x00000000 DT_SIZE_M(8)>; /* 64 Mbits */
+			};
+		};
+	};
 };
 
 &usart1 {


### PR DESCRIPTION
Updates the DTS file by adding support for Quad SPI and SPI NOR Flash.

This update has been validated via **samples/drivers/spi_flash** and **samples/drivers/flash_shell/**.

```
*** Booting Zephyr OS build zephyr-v3.5.0-4931-ga37bd8e7ba34 ***

spi-nor-flash@0 SPI flash testing
==========================

Perform test on single sector
Test 1: Flash erase
Flash erase succeeded!

Test 2: Flash write
Attempting to write 4 bytes
Data read matches data written. Good!!

Perform test on multiple consequtive sectors
Test 1: Flash erase
Flash erase succeeded!

Test 2: Flash write
Attempting to write 4 bytes at offset 0xff000
Data read matches data written. Good!!
Attempting to write 4 bytes at offset 0x100000
Data read matches data written. Good!!
```

```
Flash shell sample[00:00:00.100,000] <inf> flash_stm32_ospi: OSPI flash config is SPI|DUAL|QUAD / STR
[00:00:00.100,000] <inf> flash_stm32_ospi: Read SFDP from octoFlash
[00:00:00.100,000] <inf> flash_stm32_ospi: Read SFDP from octoFlash
*** Booting Zephyr OS build zephyr-v3.5.0-4932-gb3541b2e175e ***
uart:~$ flash page_info qspi-nor-flash@0 0
Page for address 0x0:
start offset: 0x0
size: 4096
index: 0
uart:~$ flash erase qspi-nor-flash@0 0x1000
Erase success.
[00:00:57.477,000] <inf> flash_stm32_ospi: Sector/Block Erase
[00:00:57.477,000] <inf> flash_stm32_ospi: Sector/Block Erase addr 0x1000, asize 0x2000 amode0
uart:~$ flash write qspi-nor-flash@0 0x1000 0x12345678 0x9abcdef0
Write OK.
Verified.
uart:~$ flash read qspi-nor-flash@0 0x1000 0x10
00001000: 78 56 34 12 f0 de bc 9a  ff ff ff ff ff ff ff ff |xV4..... ........|

uart:~$ flash page_info spi-nor-flash@0 0
Page for address 0x0:
start offset: 0x0
size: 65536
index: 0
uart:~$ flash erase spi-nor-flash@0 0x1000
Erase success.
uart:~$ flash write spi-nor-flash@0 0x1000 0x12345678 0x9abcdef0
Write OK.
Verified.
uart:~$ flash read spi-nor-flash@0 0x1000 0x10
00001000: 78 56 34 12 f0 de bc 9a  ff ff ff ff ff ff ff ff |xV4..... ........|

uart:~$ 
```


