### PR TITLE
lib: cbprintf: do not blindly skip tags

### DIFF
--- a/lib/os/cbprintf_complete.c
+++ b/lib/os/cbprintf_complete.c
@@ -1378,14 +1378,6 @@ int z_cbvprintf_impl(cbprintf_cb out, void *ctx, const char *fp,
 			continue;
 		}
 
-		if (IS_ENABLED(CONFIG_CBPRINTF_PACKAGE_SUPPORT_TAGGED_ARGUMENTS)
-		    && tagged_ap) {
-			/* Skip over the argument tag as it is not being
-			 * used here.
-			 */
-			(void)va_arg(ap, int);
-		}
-
 		/* Force union into RAM with conversion state to
 		 * mitigate LLVM code generation bug.
 		 */
@@ -1407,6 +1399,16 @@ int z_cbvprintf_impl(cbprintf_cb out, void *ctx, const char *fp,
 		char sign = 0;
 
 		fp = extract_conversion(conv, sp);
+
+		if (conv->specifier_cat != SPECIFIER_INVALID) {
+			if (IS_ENABLED(CONFIG_CBPRINTF_PACKAGE_SUPPORT_TAGGED_ARGUMENTS)
+			    && tagged_ap) {
+				/* Skip over the argument tag as it is not being
+				 * used here.
+				 */
+				(void)va_arg(ap, int);
+			}
+		}
 
 		/* If dynamic width is specified, process it,
 		 * otherwise set width if present.


### PR DESCRIPTION
When CONFIG_LOG_USE_TAGGED_ARGUMENTS is enabled, and CONFIG_CBPRINTF_COMPLETE is also enabled, we should not be blindly skipping tags when processing the tagged package for output.  The issue is that if there is a "%%" in the format string, the specifier is considered invalid but the code blindly skips ahead in the argument list as if it is a valid specifier (think "%s"), which resulting in the next valid specifier using incorrect argument in the list. So fix it by skipping ahead if and only if the specifier is not invalid.

Fixes #68271