### PR TITLE
linker: esp32s2: esp32c3: esp32s3: DROM section alignment

### DIFF
--- a/soc/riscv/espressif_esp32/esp32c3/default.ld
+++ b/soc/riscv/espressif_esp32/esp32c3/default.ld
@@ -10,6 +10,8 @@
  * Linker script for the esp32c3 platform.
  */
 
+#define Z_VM_KERNEL 1
+
 #include <zephyr/devicetree.h>
 #include <zephyr/linker/sections.h>
 #include <zephyr/linker/linker-defs.h>
@@ -276,7 +278,7 @@ SECTIONS
     * dram0_0_seg reflect the same address space on different buses.
     */
     . = ORIGIN(dram0_0_seg) + _iram_end - _iram_start;
-  } GROUP_LINK_IN(RAMABLE_REGION)
+  } > RAMABLE_REGION
 
  /* Shared RAM */
   SECTION_DATA_PROLOGUE(_BSS_SECTION_NAME,(NOLOAD),)
@@ -299,7 +301,7 @@ SECTIONS
     *(COMMON)
     . = ALIGN (8);
     __bss_end = ABSOLUTE(.);
-  } GROUP_LINK_IN(RAMABLE_REGION)
+  } > RAMABLE_REGION
 
   SECTION_DATA_PROLOGUE(_NOINIT_SECTION_NAME, (NOLOAD),)
   {
@@ -307,7 +309,7 @@ SECTIONS
     *(.noinit)
     *(.noinit.*)
     . = ALIGN(4);
-  } GROUP_LINK_IN(RAMABLE_REGION)
+  } > RAMABLE_REGION
 
   .dram0.data :
   {
@@ -372,7 +374,7 @@ SECTIONS
   {
     /* C3 memprot requires 512 B alignment for split lines */
     . = ALIGN (16);
-  } GROUP_LINK_IN(IRAM_REGION)
+  } > IRAM_REGION
 
   .iram0.data :
   {
@@ -389,7 +391,7 @@ SECTIONS
 
     . = ALIGN(16);
     _iram_end = ABSOLUTE(.);
-  } GROUP_LINK_IN(IRAM_REGION)
+  }  > IRAM_REGION
 
   _image_irom_start = LOADADDR(.flash.text);
   _image_irom_size = LOADADDR(.flash.text) + SIZEOF(.flash.text) - _image_irom_start;
@@ -399,7 +401,7 @@ SECTIONS
   {
     . = SIZEOF(_RODATA_SECTION_NAME);
     . = ALIGN(0x10000) + 0x20;
-  } GROUP_LINK_IN(FLASH_CODE_REGION)
+  }  > FLASH_CODE_REGION
 
   .flash.text : ALIGN(IROM_SEG_ALIGN)
   {
@@ -454,7 +456,7 @@ SECTIONS
   .rtc.dummy (NOLOAD):
   {
     . = SIZEOF(.rtc.text);
-  } GROUP_LINK_IN(rtc_iram_seg)
+  } > rtc_iram_seg
 
   .rtc.data :
   {
@@ -471,7 +473,7 @@ SECTIONS
     *rtc_wake_stub*.o(.bss .bss.*)
     *rtc_wake_stub*.o(COMMON)
     _rtc_bss_end = ABSOLUTE(.);
-  } GROUP_LINK_IN(rtc_iram_seg)
+  }  > rtc_iram_seg
 
   /**
    * This section located in RTC SLOW Memory area.

--- a/soc/xtensa/espressif_esp32/esp32s2/default.ld
+++ b/soc/xtensa/espressif_esp32/esp32s2/default.ld
@@ -10,6 +10,8 @@
  * Linker script for the esp32s2 platform.
  */
 
+#define Z_VM_KERNEL 1
+
 #include <zephyr/devicetree.h>
 #include <zephyr/linker/sections.h>
 #include <zephyr/linker/linker-defs.h>
@@ -133,7 +135,7 @@ SECTIONS
    * Adding .rodata as first section helps to reduce size of generated binary by
    * few kBs.
    */
-  SECTION_PROLOGUE(_RODATA_SECTION_NAME,,ALIGN(4))
+  SECTION_PROLOGUE(_RODATA_SECTION_NAME,,)
   {
     _rodata_reserved_start = ABSOLUTE(.);
     __rodata_region_start = ABSOLUTE(.);
@@ -191,7 +193,7 @@ SECTIONS
 
   /* Create an explicit section at the end of all the data that shall be mapped into drom.
    * This is used to calculate the size of the _image_drom_size variable */
-  SECTION_PROLOGUE(_RODATA_SECTION_END,,ALIGN(0x10))
+  SECTION_PROLOGUE(_RODATA_SECTION_END,,)
   {
     _rodata_reserved_end = ABSOLUTE(.);
     . = ALIGN(4);
@@ -301,7 +303,7 @@ SECTIONS
     */
     . = ALIGN (8);
     . = ORIGIN(dram0_0_seg) + _iram_end - _iram_start;
-  } GROUP_LINK_IN(RAMABLE_REGION)
+  } > RAMABLE_REGION
 
   /* Shared RAM */
   SECTION_DATA_PROLOGUE(_BSS_SECTION_NAME,(NOLOAD),)
@@ -326,7 +328,7 @@ SECTIONS
     *(COMMON)
     . = ALIGN (8);
     __bss_end = ABSOLUTE(.);
-  } GROUP_LINK_IN(RAMABLE_REGION)
+  } > RAMABLE_REGION
 
 #if defined(CONFIG_ESP_SPIRAM)
   .ext_ram.bss (NOLOAD):
@@ -358,7 +360,7 @@ SECTIONS
     *(.noinit)
     *(.noinit.*)
     . = ALIGN(8);
-  } GROUP_LINK_IN(RAMABLE_REGION)
+  } > RAMABLE_REGION
 
   .dram0.data :
   {
@@ -420,7 +422,7 @@ SECTIONS
   {
     . = ALIGN(4);
     _iram_end = ABSOLUTE(.);
-  } GROUP_LINK_IN(IRAM_REGION)
+  } > IRAM_REGION
 
   _image_irom_start = LOADADDR(.flash.text);
   _image_irom_size = LOADADDR(.flash.text) + SIZEOF(.flash.text) - _image_irom_start;
@@ -430,7 +432,7 @@ SECTIONS
   {
     . = ALIGN(4);
     . = SIZEOF(_RODATA_SECTION_NAME);
-  } GROUP_LINK_IN(FLASH_CODE_REGION)
+  } > FLASH_CODE_REGION
 
   .flash.text : ALIGN(IROM_SEG_ALIGN)
   {
@@ -492,7 +494,7 @@ SECTIONS
     *rtc_wake_stub*.o(.bss .bss.*)
     *rtc_wake_stub*.o(COMMON)
     _rtc_bss_end = ABSOLUTE(.);
-  } GROUP_LINK_IN(rtc_slow_seg)
+  } > rtc_slow_seg
 
   /* This section located in RTC SLOW Memory area.
      It holds data marked with RTC_SLOW_ATTR attribute.

--- a/soc/xtensa/espressif_esp32/esp32s3/default.ld
+++ b/soc/xtensa/espressif_esp32/esp32s3/default.ld
@@ -10,6 +10,8 @@
  * Linker script for the ESP32S3 platform.
  */
 
+#define Z_VM_KERNEL 1
+
 #include <zephyr/devicetree.h>
 #include <zephyr/linker/sections.h>
 #include <zephyr/linker/linker-defs.h>
@@ -165,7 +167,7 @@ SECTIONS
    * Adding .rodata as first section helps to reduce size of generated binary by
    * few kBs.
    */
-  SECTION_PROLOGUE(_RODATA_SECTION_NAME,,ALIGN(0x10))
+  SECTION_PROLOGUE(_RODATA_SECTION_NAME,,)
   {
     _rodata_reserved_start = ABSOLUTE(.);
     _rodata_start = ABSOLUTE(.);
@@ -228,7 +230,7 @@ SECTIONS
 
   /* Create an explicit section at the end of all the data that shall be mapped into drom.
    * This is used to calculate the size of the _image_drom_size variable */
-  SECTION_PROLOGUE(_RODATA_SECTION_END,,ALIGN(0x10))
+  SECTION_PROLOGUE(_RODATA_SECTION_END,,)
   {
     _rodata_reserved_end = ABSOLUTE(.);
     . = ALIGN(16);
@@ -359,7 +361,7 @@ SECTIONS
      * prefetch and 256B alignment for PMS split lines */
     . = ALIGN(16);
     _iram_text_end = ABSOLUTE(.);
-  } GROUP_LINK_IN(IRAM_REGION)
+  } > IRAM_REGION
 
   .iram0.data :
   {
@@ -376,7 +378,7 @@ SECTIONS
 
     . = ALIGN(16);
     _iram_end = ABSOLUTE(.);
-  } GROUP_LINK_IN(IRAM_REGION)
+  } > IRAM_REGION
 
 
   /* This section is required to skip .iram0.text area because iram0_0_seg and
@@ -386,7 +388,7 @@ SECTIONS
   {
     . = ALIGN (8);
     . = ORIGIN(dram0_0_seg) + MAX(_iram_end, SRAM_DIRAM_I_START) - SRAM_DIRAM_I_START;
-  } GROUP_LINK_IN(RAMABLE_REGION)
+  } > RAMABLE_REGION
 
   /* Shared RAM */
   SECTION_DATA_PROLOGUE(_BSS_SECTION_NAME,(NOLOAD),)
@@ -411,7 +413,7 @@ SECTIONS
     *(COMMON)
     . = ALIGN (8);
     __bss_end = ABSOLUTE(.);
-  } GROUP_LINK_IN(RAMABLE_REGION)
+  } > RAMABLE_REGION
 
   ASSERT(((__bss_end - ORIGIN(dram0_0_seg)) <= LENGTH(dram0_0_seg)), "DRAM segment data does not fit.")
 
@@ -421,7 +423,7 @@ SECTIONS
     *(.noinit)
     *(.noinit.*)
     . = ALIGN(8) ;
-  } GROUP_LINK_IN(RAMABLE_REGION)
+  } > RAMABLE_REGION
 
   .dram0.data :
   {
@@ -490,7 +492,7 @@ SECTIONS
   {
     . = SIZEOF(_RODATA_SECTION_NAME);
     . = ALIGN(IROM_SEG_ALIGN) + 0x20;
-  } GROUP_LINK_IN(FLASH_CODE_REGION)
+  } > FLASH_CODE_REGION
 
   .flash.text : ALIGN(IROM_SEG_ALIGN)
   {


### PR DESCRIPTION
The alignment of rodata was not assured and could by corrupted by the inclusion of some libraries. Added Z_VM_KERNEL to linker script to force included scripts to use ALIGN_WITH_INPUT attribute on sections they create.

The background and testing done to confirm is in issue #68028.