### PR TITLE
posix: implement pthread_attr_getscope() and pthread_attr_setscope()

### DIFF
--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -440,10 +440,10 @@ _POSIX_THREAD_PRIORITY_SCHEDULING
 
     pthread_attr_getinheritsched(),
     pthread_attr_getschedpolicy(),yes
-    pthread_attr_getscope(),
+    pthread_attr_getscope(),yes
     pthread_attr_setinheritsched(),
     pthread_attr_setschedpolicy(),yes
-    pthread_attr_setscope(),
+    pthread_attr_setscope(),yes
     pthread_getschedparam(),yes
     pthread_setschedparam(),yes
     pthread_setschedprio(),yes

--- a/include/zephyr/posix/pthread.h
+++ b/include/zephyr/posix/pthread.h
@@ -39,6 +39,12 @@ extern "C" {
 #define PTHREAD_CANCEL_DEFERRED     0
 #define PTHREAD_CANCEL_ASYNCHRONOUS 1
 
+/* Pthread scope */
+#undef PTHREAD_SCOPE_PROCESS
+#define PTHREAD_SCOPE_PROCESS    1
+#undef PTHREAD_SCOPE_SYSTEM
+#define PTHREAD_SCOPE_SYSTEM     0
+
 /* Passed to pthread_once */
 #define PTHREAD_ONCE_INIT {0}
 
@@ -429,6 +435,8 @@ int pthread_attr_getstack(const pthread_attr_t *attr,
 			  void **stackaddr, size_t *stacksize);
 int pthread_attr_setstack(pthread_attr_t *attr, void *stackaddr,
 			  size_t stacksize);
+int pthread_attr_getscope(const pthread_attr_t *attr, int *contentionscope);
+int pthread_attr_setscope(pthread_attr_t *attr, int contentionscope);
 #ifdef CONFIG_PTHREAD_IPC
 int pthread_once(pthread_once_t *once, void (*initFunc)(void));
 #endif

--- a/lib/posix/options/posix_internal.h
+++ b/lib/posix/options/posix_internal.h
@@ -29,6 +29,7 @@ struct posix_thread_attr {
 	uint16_t guardsize : CONFIG_POSIX_PTHREAD_ATTR_GUARDSIZE_BITS;
 	int8_t priority;
 	uint8_t schedpolicy: 2;
+	bool contentionscope: 1;
 	union {
 		bool caller_destroys: 1;
 		bool initialized: 1;

--- a/tests/posix/common/src/pthread_attr.c
+++ b/tests/posix/common/src/pthread_attr.c
@@ -439,6 +439,48 @@ ZTEST(pthread_attr, test_pthread_attr_setstacksize)
 	}
 }
 
+ZTEST(pthread_attr, test_pthread_attr_getscope)
+{
+	int contentionscope = BIOS_FOOD;
+
+	/* degenerate cases */
+	{
+		if (false) {
+			/* undefined behaviour */
+			zassert_equal(pthread_attr_getscope(NULL, NULL), EINVAL);
+			zassert_equal(pthread_attr_getscope(NULL, &contentionscope), EINVAL);
+			zassert_equal(pthread_attr_getscope(&uninit_attr, &contentionscope),
+				      EINVAL);
+		}
+		zassert_equal(pthread_attr_getscope(&attr, NULL), EINVAL);
+	}
+
+	zassert_ok(pthread_attr_getscope(&attr, &contentionscope));
+	zassert_equal(contentionscope, PTHREAD_SCOPE_SYSTEM);
+}
+
+ZTEST(pthread_attr, test_pthread_attr_setscope)
+{
+	int contentionscope = BIOS_FOOD;
+
+	/* degenerate cases */
+	{
+		if (false) {
+			/* undefined behaviour */
+			zassert_equal(pthread_attr_setscope(NULL, PTHREAD_SCOPE_SYSTEM), EINVAL);
+			zassert_equal(pthread_attr_setscope(NULL, contentionscope), EINVAL);
+			zassert_equal(pthread_attr_setscope((pthread_attr_t *)&uninit_attr,
+				      contentionscope), EINVAL);
+		}
+		zassert_equal(pthread_attr_setscope(&attr, 3), EINVAL);
+	}
+
+	zassert_equal(pthread_attr_setscope(&attr, PTHREAD_SCOPE_PROCESS), ENOTSUP);
+	zassert_ok(pthread_attr_setscope(&attr, PTHREAD_SCOPE_SYSTEM));
+	zassert_ok(pthread_attr_getscope(&attr, &contentionscope));
+	zassert_equal(contentionscope, PTHREAD_SCOPE_SYSTEM);
+}
+
 ZTEST(pthread_attr, test_pthread_attr_large_stacksize)
 {
 	size_t actual_size;

--- a/tests/posix/headers/src/pthread_h.c
+++ b/tests/posix/headers/src/pthread_h.c
@@ -53,8 +53,8 @@ ZTEST(posix_headers, test_pthread_h)
 	zassert_not_equal(-1, PTHREAD_PROCESS_SHARED);
 	zassert_not_equal(-1, PTHREAD_PROCESS_PRIVATE);
 
-	/* zassert_not_equal(-1, PTHREAD_SCOPE_PROCESS); */ /* not implemented */
-	/* zassert_not_equal(-1, PTHREAD_SCOPE_SYSTEM); */ /* not implemented */
+	zassert_not_equal(-1, PTHREAD_SCOPE_PROCESS);
+	zassert_not_equal(-1, PTHREAD_SCOPE_SYSTEM);
 
 	pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
 	pthread_mutex_t mu = PTHREAD_MUTEX_INITIALIZER;
@@ -68,7 +68,7 @@ ZTEST(posix_headers, test_pthread_h)
 		/* zassert_not_null(pthread_attr_getinheritsched); */ /* not implemented */
 		zassert_not_null(pthread_attr_getschedparam);
 		zassert_not_null(pthread_attr_getschedpolicy);
-		/* zassert_not_null(pthread_attr_getscope); */ /* not implemented */
+		zassert_not_null(pthread_attr_getscope);
 		zassert_not_null(pthread_attr_getstack);
 		zassert_not_null(pthread_attr_getstacksize);
 		zassert_not_null(pthread_attr_init);
@@ -77,7 +77,7 @@ ZTEST(posix_headers, test_pthread_h)
 		/* zassert_not_null(pthread_attr_setinheritsched); */ /* not implemented */
 		zassert_not_null(pthread_attr_setschedparam);
 		zassert_not_null(pthread_attr_setschedpolicy);
-		/* zassert_not_null(pthread_attr_setscope); */ /* not implemented */
+		zassert_not_null(pthread_attr_setscope);
 		zassert_not_null(pthread_attr_setstack);
 		zassert_not_null(pthread_attr_setstacksize);
 		zassert_not_null(pthread_barrier_destroy);


### PR DESCRIPTION
This is part of the See https://github.com/zephyrproject-rtos/zephyr/issues/51211 (RFC https://github.com/zephyrproject-rtos/zephyr/issues/51211).

`pthread_attr_getscope()` and `pthread_attr_setscope()` are required as part of _POSIX_THREAD_PRIORITY_SCHEDULING Option Group.

For more information, please refer to https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_attr_getscope.html

Fixes #66969
Fixes #66967