### PR TITLE
Develop/ram console option known addr buf

### DIFF
--- a/drivers/console/Kconfig
+++ b/drivers/console/Kconfig
@@ -109,8 +109,10 @@ config RAM_CONSOLE_BUFFER_SIZE
 	default 1024
 	depends on RAM_CONSOLE
 	help
-	  Size of the RAM console buffer. Messages will wrap around if the
-	  length is exceeded.
+	  Total size of the RAM console buffer, to ensure it's always
+	  NULL-terminated leave one byte unused, the actual length is
+	  one byte less. Messages will wrap around if the actual length
+	  is exceeded.
 
 config RTT_CONSOLE
 	bool "Use RTT console"

--- a/drivers/console/Kconfig
+++ b/drivers/console/Kconfig
@@ -96,16 +96,30 @@ config JAILHOUSE_DEBUG_CONSOLE
 	  Useful in board bring-up if there aren't any working serial
 	  drivers.
 
+# Workaround for not being able to have commas in macro arguments
+DT_CHOSEN_Z_RAM_CONSOLE := zephyr,ram-console
+
 config RAM_CONSOLE
 	bool "Use RAM console"
 	select CONSOLE_HAS_DRIVER
+	select RAM_CONSOLE_BUFFER_SECTION if $(dt_chosen_enabled,$(DT_CHOSEN_Z_RAM_CONSOLE))
 	help
 	  Emit console messages to a RAM buffer "ram_console" which can
 	  be examined at runtime with a debugger. Useful in board bring-up
 	  if there aren't any working serial drivers.
 
+config RAM_CONSOLE_BUFFER_SECTION
+	bool "Use dedicated section as RAM console buffer"
+	depends on RAM_CONSOLE && $(dt_chosen_enabled,$(DT_CHOSEN_Z_RAM_CONSOLE))
+	select KERNEL_DIRECT_MAP if MMU
+	help
+	  Use a dedicated section as the RAM console buffer, whose address is
+	  known before build so that the console output messages can be easily
+	  examined by a debugger or software tool from a parallel-running OS.
+
 config RAM_CONSOLE_BUFFER_SIZE
 	int "Ram Console buffer size"
+	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_RAM_CONSOLE)) if RAM_CONSOLE_BUFFER_SECTION
 	default 1024
 	depends on RAM_CONSOLE
 	help

--- a/drivers/console/ram_console.c
+++ b/drivers/console/ram_console.c
@@ -2,6 +2,7 @@
 
 /*
  * Copyright (c) 2015 Intel Corporation
+ * Copyright 2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -11,11 +12,26 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/device.h>
 #include <zephyr/init.h>
+#include <zephyr/linker/devicetree_regions.h>
+
+#ifdef CONFIG_RAM_CONSOLE_BUFFER_SECTION
+#if !DT_HAS_CHOSEN(zephyr_ram_console)
+#error "Lack of chosen property zephyr,ram_console!"
+#elif (CONFIG_RAM_CONSOLE_BUFFER_SIZE > DT_REG_SIZE(DT_CHOSEN(zephyr_ram_console)))
+#error "Custom RAM console buffer exceeds the section size!"
+#endif
+
+#define RAM_CONSOLE_BUF_ATTR	\
+	__attribute__((__section__(LINKER_DT_NODE_REGION_NAME(DT_CHOSEN(zephyr_ram_console)))))
+#else
+#define RAM_CONSOLE_BUF_ATTR
+#endif
 
 extern void __printk_hook_install(int (*fn)(int));
 extern void __stdout_hook_install(int (*fn)(int));
 
-char ram_console[CONFIG_RAM_CONSOLE_BUFFER_SIZE];
+char ram_console_buf[CONFIG_RAM_CONSOLE_BUFFER_SIZE] RAM_CONSOLE_BUF_ATTR;
+char *ram_console;
 static int pos;
 
 static int ram_console_out(int character)
@@ -28,6 +44,15 @@ static int ram_console_out(int character)
 
 static int ram_console_init(void)
 {
+#ifdef CONFIG_RAM_CONSOLE_BUFFER_SECTION
+	mm_reg_t ram_console_va;
+
+	device_map((mm_reg_t *)&ram_console_va, DT_REG_ADDR(DT_CHOSEN(zephyr_ram_console)),
+		   CONFIG_RAM_CONSOLE_BUFFER_SIZE, K_MEM_CACHE_NONE | K_MEM_DIRECT_MAP);
+	ram_console = (char *)ram_console_va,
+#else
+	ram_console = ram_console_buf,
+#endif
 	__printk_hook_install(ram_console_out);
 	__stdout_hook_install(ram_console_out);
 

--- a/drivers/console/ram_console.c
+++ b/drivers/console/ram_console.c
@@ -15,14 +15,14 @@
 extern void __printk_hook_install(int (*fn)(int));
 extern void __stdout_hook_install(int (*fn)(int));
 
-/* Extra byte to ensure we're always NULL-terminated */
-char ram_console[CONFIG_RAM_CONSOLE_BUFFER_SIZE + 1];
+char ram_console[CONFIG_RAM_CONSOLE_BUFFER_SIZE];
 static int pos;
 
 static int ram_console_out(int character)
 {
 	ram_console[pos] = (char)character;
-	pos = (pos + 1) % CONFIG_RAM_CONSOLE_BUFFER_SIZE;
+	/* Leave one byte to ensure we're always NULL-terminated */
+	pos = (pos + 1) % (CONFIG_RAM_CONSOLE_BUFFER_SIZE - 1);
 	return character;
 }
 

--- a/include/zephyr/arch/arm64/scripts/linker.ld
+++ b/include/zephyr/arch/arm64/scripts/linker.ld
@@ -14,6 +14,7 @@
 #include <zephyr/linker/sections.h>
 #include <zephyr/devicetree.h>
 
+#include <zephyr/linker/devicetree_regions.h>
 #include <zephyr/linker/linker-defs.h>
 #include <zephyr/linker/linker-tool.h>
 
@@ -66,6 +67,7 @@ MEMORY
 {
     FLASH     (rx) : ORIGIN = ROM_ADDR, LENGTH = ROM_SIZE
     RAM       (wx) : ORIGIN = RAM_ADDR, LENGTH = RAM_SIZE
+    LINKER_DT_REGIONS()
     /* Used by and documented in include/linker/intlist.ld */
     IDT_LIST  (wx) : ORIGIN = 0xFFFF8000, LENGTH = 32K
 }
@@ -329,6 +331,8 @@ SECTIONS
 
     /DISCARD/ : { *(.note.GNU-stack) }
 
+    /* Sections generated from 'zephyr,memory-region' nodes */
+    LINKER_DT_SECTIONS()
 
     /* Must be last in romable region */
     SECTION_PROLOGUE(.last_section,,)

--- a/lib/open-amp/resource_table.c
+++ b/lib/open-amp/resource_table.c
@@ -66,7 +66,7 @@ static struct fw_resource_table __resource resource_table = {
 #if defined(CONFIG_RAM_CONSOLE)
 	.cm_trace = {
 		RSC_TRACE,
-		(uint32_t)ram_console, CONFIG_RAM_CONSOLE_BUFFER_SIZE + 1, 0,
+		(uint32_t)ram_console, CONFIG_RAM_CONSOLE_BUFFER_SIZE, 0,
 		"Zephyr_log",
 	},
 #endif

--- a/snippets/ram-console/README.rst
+++ b/snippets/ram-console/README.rst
@@ -1,0 +1,37 @@
+.. _snippet-ram-console:
+
+RAM Console Snippet (ram-console)
+#################################
+
+.. code-block:: console
+
+   west build -S ram-console [...]
+
+Overview
+********
+
+This snippet redirects console output to a RAM buffer. The RAM console
+buffer is a global array located in RAM region by default, whose address
+is unknown before building. The RAM console driver also supports using
+a dedicated section for the RAM console buffer with prefined address.
+
+How to enable RAM console buffer section
+****************************************
+
+Add board dts overlay to this snippet to add property ``zephyr,ram-console``
+in the chosen node and memory-region node with compatible string
+:dtcompatible:`zephyr,memory-region` as the following:
+
+.. code-block:: DTS
+
+    / {
+        chosen {
+            zephyr,ram-console = &snippet_ram_console;
+        };
+
+       snippet_ram_console: memory@93d00000 {
+            compatible = "zephyr,memory-region";
+            reg = <0x93d00000 DT_SIZE_K(4)>;
+            zephyr,memory-region = "RAM_CONSOLE";
+       };
+    };

--- a/snippets/ram-console/boards/imx8mm_evk_mimx8mm6_a53.overlay
+++ b/snippets/ram-console/boards/imx8mm_evk_mimx8mm6_a53.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,ram-console = &snippet_ram_console;
+	};
+
+	snippet_ram_console: memory@93d00000 {
+		compatible = "zephyr,memory-region";
+		reg = <0x93d00000 DT_SIZE_K(4)>;
+		zephyr,memory-region = "RAM_CONSOLE";
+	};
+};

--- a/snippets/ram-console/boards/imx8mn_evk_mimx8mn6_a53.overlay
+++ b/snippets/ram-console/boards/imx8mn_evk_mimx8mn6_a53.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,ram-console = &snippet_ram_console;
+	};
+
+	snippet_ram_console: memory@93d00000 {
+		compatible = "zephyr,memory-region";
+		reg = <0x93d00000 DT_SIZE_K(4)>;
+		zephyr,memory-region = "RAM_CONSOLE";
+	};
+};

--- a/snippets/ram-console/boards/imx8mp_evk_mimx8ml8_a53.overlay
+++ b/snippets/ram-console/boards/imx8mp_evk_mimx8ml8_a53.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,ram-console = &snippet_ram_console;
+	};
+
+	snippet_ram_console: memory@c0100000 {
+		compatible = "zephyr,memory-region";
+		reg = <0xc0100000 DT_SIZE_K(4)>;
+		zephyr,memory-region = "RAM_CONSOLE";
+	};
+};

--- a/snippets/ram-console/boards/imx93_evk_mimx9352_a55.overlay
+++ b/snippets/ram-console/boards/imx93_evk_mimx9352_a55.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,ram-console = &snippet_ram_console;
+	};
+
+	snippet_ram_console: memory@d0100000 {
+		compatible = "zephyr,memory-region";
+		reg = <0xd0100000 DT_SIZE_K(4)>;
+		zephyr,memory-region = "RAM_CONSOLE";
+	};
+};

--- a/snippets/ram-console/ram-console.conf
+++ b/snippets/ram-console/ram-console.conf
@@ -1,0 +1,9 @@
+#
+# Copyright 2024 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Disable UART Console
+CONFIG_UART_CONSOLE=n
+# Enable RAM Console
+CONFIG_RAM_CONSOLE=y

--- a/snippets/ram-console/snippet.yml
+++ b/snippets/ram-console/snippet.yml
@@ -1,0 +1,32 @@
+#
+# Copyright 2024 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+name: ram-console
+append:
+  EXTRA_CONF_FILE: ram-console.conf
+
+boards:
+  imx8mm_evk/mimx8mm6/a53:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: boards/imx8mm_evk_mimx8mm6_a53.overlay
+  imx8mm_evk/mimx8mm6/a53/smp:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: boards/imx8mm_evk_mimx8mm6_a53.overlay
+  imx8mn_evk/mimx8mn6/a53:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: boards/imx8mn_evk_mimx8mn6_a53.overlay
+  imx8mn_evk/mimx8mn6/a53/smp:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: boards/imx8mn_evk_mimx8mn6_a53.overlay
+  imx8mp_evk/mimx8ml8/a53:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: boards/imx8mp_evk_mimx8ml8_a53.overlay
+  imx8mp_evk/mimx8ml8/a53/smp:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: boards/imx8mp_evk_mimx8ml8_a53.overlay
+  imx93_evk/mimx9352/a55:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: boards/imx93_evk_mimx9352_a55.overlay

--- a/soc/nxp/imx/imx9/a55/linker.ld
+++ b/soc/nxp/imx/imx9/a55/linker.ld
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 NXP
+ * Copyright 2023-2024 NXP
  * Copyright (c) 2013-2014 Wind River Systems, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -14,6 +14,7 @@
 #include <zephyr/linker/sections.h>
 #include <zephyr/devicetree.h>
 
+#include <zephyr/linker/devicetree_regions.h>
 #include <zephyr/linker/linker-defs.h>
 #include <zephyr/linker/linker-tool.h>
 
@@ -60,6 +61,7 @@ MEMORY
 {
     FLASH     (rx) : ORIGIN = ROM_ADDR, LENGTH = ROM_SIZE
     RAM       (wx) : ORIGIN = RAM_ADDR, LENGTH = RAM_SIZE
+    LINKER_DT_REGIONS()
     /* Used by and documented in include/linker/intlist.ld */
     IDT_LIST  (wx) : ORIGIN = 0xFFFFF7FF, LENGTH = 2K
 }
@@ -336,6 +338,8 @@ SECTIONS
 
     /DISCARD/ : { *(.note.GNU-stack) }
 
+    /* Sections generated from 'zephyr,memory-region' nodes */
+    LINKER_DT_SECTIONS()
 
     /* Must be last in romable region */
     SECTION_PROLOGUE(.last_section,,)

--- a/tests/drivers/syscon/linker_arm64_reserved.ld
+++ b/tests/drivers/syscon/linker_arm64_reserved.ld
@@ -5,19 +5,8 @@
 
 #include <zephyr/linker/sections.h>
 #include <zephyr/devicetree.h>
-#include <zephyr/linker/devicetree_regions.h>
 
 #include <zephyr/linker/linker-defs.h>
 #include <zephyr/linker/linker-tool.h>
-
-MEMORY
-{
-	LINKER_DT_REGIONS()
-}
-
-SECTIONS
-{
-	LINKER_DT_SECTIONS()
-}
 
 #include <zephyr/arch/arm64/scripts/linker.ld>

--- a/tests/lib/shared_multi_heap/linker_arm64_shared_pool.ld
+++ b/tests/lib/shared_multi_heap/linker_arm64_shared_pool.ld
@@ -6,19 +6,8 @@
 
 #include <zephyr/linker/sections.h>
 #include <zephyr/devicetree.h>
-#include <zephyr/linker/devicetree_regions.h>
 
 #include <zephyr/linker/linker-defs.h>
 #include <zephyr/linker/linker-tool.h>
-
-MEMORY
-{
-	LINKER_DT_REGIONS()
-}
-
-SECTIONS
-{
-	LINKER_DT_SECTIONS()
-}
 
 #include <zephyr/arch/arm64/scripts/linker.ld>


### PR DESCRIPTION
This PR added an option for RAM console driver to locate the console buffer to a predefined memory region, so that the RAM console can be used easily, and also added an example on imx8mmevk.