### PR TITLE
Bluetooth: Controller: Fix PA sync-ed ACL supervision timeout

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -328,7 +328,7 @@ static int create_prepare_cb(struct lll_prepare_param *p)
 #else
 	} else {
 #endif /* CONFIG_BT_CTLR_DF_SCAN_CTE_RX */
-		if (IS_ENABLED(CONFIG_BT_CTLR_DF_SUPPORT)) {
+		if (IS_ENABLED(CONFIG_BT_CTLR_DF)) {
 			/* Disable CTE reception and sampling in Radio */
 			radio_df_cte_inline_set_enabled(false);
 		}


### PR DESCRIPTION
Fix Periodic Advertising Synchronization leading to Peripheral ACL connection supervision timeout, due to direction finding related radio hardware registers being updated in the implementation that is not built for direction finding feature support.

Fixes #68353.