### PR TITLE
posix: implement isastream()

### DIFF
--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -572,7 +572,7 @@ _XOPEN_STREAMS
     getmsg(),  yes (will fail with ``ENOSYS``:ref:`†<posix_undefined_behaviour>`)
     getpmsg(),  yes (will fail with ``ENOSYS``:ref:`†<posix_undefined_behaviour>`)
     ioctl(),yes
-    isastream(),
+    isastream(),yes (will fail with ``ENOSYS``:ref:`†<posix_undefined_behaviour>`)
     putmsg(), yes (will fail with ``ENOSYS``:ref:`†<posix_undefined_behaviour>`)
     putpmsg(),
 

--- a/include/zephyr/posix/stropts.h
+++ b/include/zephyr/posix/stropts.h
@@ -22,6 +22,7 @@ int fdetach(const char *path);
 int fattach(int fildes, const char *path);
 int getmsg(int fildes, struct strbuf *ctlptr, struct strbuf *dataptr, int *flagsp);
 int getpmsg(int fildes, struct strbuf *ctlptr, struct strbuf *dataptr, int *bandp, int *flagsp);
+int isastream(int fildes);
 
 #ifdef __cplusplus
 }

--- a/lib/posix/options/stropts.c
+++ b/lib/posix/options/stropts.c
@@ -58,3 +58,11 @@ int getpmsg(int fildes, struct strbuf *ctlptr, struct strbuf *dataptr, int *band
 	errno = ENOSYS;
 	return -1;
 }
+
+int isastream(int fildes)
+{
+	ARG_UNUSED(fildes);
+
+	errno = ENOSYS;
+	return -1;
+}

--- a/tests/posix/common/src/stropts.c
+++ b/tests/posix/common/src/stropts.c
@@ -59,4 +59,13 @@ ZTEST(stropts, test_getpmsg)
 	zassert_equal(errno, ENOSYS, "Expected errno ENOSYS, got %d", errno);
 }
 
+ZTEST(stropts, test_isastream)
+{
+	int fd = -1;
+	int ret = isastream(fd);
+
+	zassert_equal(ret, -1, "Expected return value -1, got %d", ret);
+	zassert_equal(errno, ENOSYS, "Expected errno ENOSYS, got %d", errno);
+}
+
 ZTEST_SUITE(stropts, NULL, NULL, NULL, NULL, NULL);

--- a/tests/posix/headers/src/stropts_h.c
+++ b/tests/posix/headers/src/stropts_h.c
@@ -23,6 +23,7 @@ ZTEST(posix_headers, test_stropts_h)
 	zassert_not_null((void *)fattach, "fattach is null");
 	zassert_not_null((void *)getmsg, "getmsg is null");
 	zassert_not_null((void *)getpmsg, "getpmsg is null");
+	zassert_not_null((void *)isastream, "isastream is null");
 
 	zassert_true(sizeof(((struct strbuf *)0)->maxlen) > 0, "maxlen size is 0");
 	zassert_true(sizeof(((struct strbuf *)0)->len) > 0, "len size is 0");


### PR DESCRIPTION
This is part of the See https://github.com/zephyrproject-rtos/zephyr/issues/51211 (RFC https://github.com/zephyrproject-rtos/zephyr/issues/51211).

isastream() is required as part of _XOPEN_STREAMS Option Group.

For more information, please refer to https://pubs.opengroup.org/onlinepubs/9699919799/functions/isastream.html

Fixes #66977