### PR TITLE
Bluetooth: Host: Set `conn->err` in prio

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -838,6 +838,8 @@ static void hci_disconn_complete_prio(struct net_buf *buf)
 		return;
 	}
 
+	conn->err = evt->reason;
+
 	bt_conn_set_state(conn, BT_CONN_DISCONNECT_COMPLETE);
 	bt_conn_unref(conn);
 }
@@ -859,8 +861,6 @@ static void hci_disconn_complete(struct net_buf *buf)
 		LOG_ERR("Unable to look up conn with handle %u", handle);
 		return;
 	}
-
-	conn->err = evt->reason;
 
 	bt_conn_set_state(conn, BT_CONN_DISCONNECTED);
 


### PR DESCRIPTION
The goal is to not access `buf` in the non-prio `hci_disconn_complete` so that the buffer does not need to be retained.

This commit moves the copy of `conn->err` to the prio handler.