### PR TITLE
posix: implement fattach() and fdetach()

### DIFF
--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -503,8 +503,8 @@ _XOPEN_STREAMS
    :header: API, Supported
    :widths: 50,10
 
-    fattach(),
-    fdetach(),
+    fattach(),yes (will fail with ``ENOSYS``:ref:`†<posix_undefined_behaviour>`)
+    fdetach(),yes (will fail with ``ENOSYS``:ref:`†<posix_undefined_behaviour>`)
     getmsg(),
     getpmsg(),
     ioctl(),yes

--- a/include/zephyr/posix/stropts.h
+++ b/include/zephyr/posix/stropts.h
@@ -18,6 +18,8 @@ struct strbuf {
 };
 
 int putmsg(int fildes, const struct strbuf *ctlptr, const struct strbuf *dataptr, int flags);
+int fdetach(const char *path);
+int fattach(int fildes, const char *path);
 
 #ifdef __cplusplus
 }

--- a/lib/posix/options/stropts.c
+++ b/lib/posix/options/stropts.c
@@ -18,3 +18,20 @@ int putmsg(int fildes, const struct strbuf *ctlptr, const struct strbuf *dataptr
 	errno = ENOSYS;
 	return -1;
 }
+
+int fdetach(const char *path)
+{
+	ARG_UNUSED(path);
+
+	errno = ENOSYS;
+	return -1;
+}
+
+int fattach(int fildes, const char *path)
+{
+	ARG_UNUSED(fildes);
+	ARG_UNUSED(path);
+
+	errno = ENOSYS;
+	return -1;
+}

--- a/tests/posix/common/src/stropts.c
+++ b/tests/posix/common/src/stropts.c
@@ -18,4 +18,23 @@ ZTEST(stropts, test_putmsg)
 	zassert_equal(errno, ENOSYS, "Expected errno ENOSYS, got %d", errno);
 }
 
+ZTEST(stropts, test_fdetach)
+{
+	char *path = NULL;
+	int ret = fdetach(path);
+
+	zassert_equal(ret, -1, "Expected return value -1, got %d", ret);
+	zassert_equal(errno, ENOSYS, "Expected errno ENOSYS, got %d", errno);
+}
+
+ZTEST(stropts, test_fattach)
+{
+	char *path = NULL;
+	int fd = -1;
+	int ret = fattach(fd, path);
+
+	zassert_equal(ret, -1, "Expected return value -1, got %d", ret);
+	zassert_equal(errno, ENOSYS, "Expected errno ENOSYS, got %d", errno);
+}
+
 ZTEST_SUITE(stropts, NULL, NULL, NULL, NULL, NULL);

--- a/tests/posix/headers/src/stropts_h.c
+++ b/tests/posix/headers/src/stropts_h.c
@@ -19,6 +19,8 @@ ZTEST(posix_headers, test_stropts_h)
 {
 	#ifdef CONFIG_POSIX_API
 	zassert_not_null((void *)putmsg, "putmsg is null");
+	zassert_not_null((void *)fdetach, "fdetach is null");
+	zassert_not_null((void *)fattach, "fattach is null");
 
 	zassert_true(sizeof(((struct strbuf *)0)->maxlen) > 0, "maxlen size is 0");
 	zassert_true(sizeof(((struct strbuf *)0)->len) > 0, "len size is 0");


### PR DESCRIPTION
This is part of the See https://github.com/zephyrproject-rtos/zephyr/issues/51211 (RFC https://github.com/zephyrproject-rtos/zephyr/issues/51211).

`fattach()` and `fdetach()` are required as part of _XOPEN_STREAMS Option Group.

For more information, please refer to https://pubs.opengroup.org/onlinepubs/9699919799/functions/fattach.html

Fixes #66973
Fixes #66974