### PR TITLE
hwmv2: Adjust bsim/ite paths

### DIFF
--- a/boards/boards_legacy/posix/nrf_bsim/nrf52_bsim.dts
+++ b/boards/boards_legacy/posix/nrf_bsim/nrf52_bsim.dts
@@ -10,7 +10,7 @@
 #include <mem.h>
 #include <arm/nordic/nrf52833.dtsi>
 /* We resuse the pinctrl definitions directly from the real board : */
-#include <../boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833-pinctrl.dtsi>
+#include <../boards/boards_legacy/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833-pinctrl.dtsi>
 
 / {
 	model = "nrf52 bsim";

--- a/boards/boards_legacy/posix/nrf_bsim/nrf5340bsim_nrf5340_cpuapp.dts
+++ b/boards/boards_legacy/posix/nrf_bsim/nrf5340bsim_nrf5340_cpuapp.dts
@@ -115,4 +115,4 @@
 /* We re-use the IPC shared buffer definition from the real HW. But note the start address of the
  * buffer won't be used.
  */
-#include <../boards/arm/nrf5340dk_nrf5340/nrf5340_shared_sram_planning_conf.dtsi>
+#include <../boards/board_legacy/arm/nrf5340dk_nrf5340/nrf5340_shared_sram_planning_conf.dtsi>

--- a/boards/boards_legacy/posix/nrf_bsim/nrf5340bsim_nrf5340_cpunet.dts
+++ b/boards/boards_legacy/posix/nrf_bsim/nrf5340bsim_nrf5340_cpunet.dts
@@ -77,4 +77,4 @@
 /* We re-use the IPC shared buffer definition from the real HW. But note the start address of the
  * buffer won't be used.
  */
-#include <../boards/arm/nrf5340dk_nrf5340/nrf5340_shared_sram_planning_conf.dtsi>
+#include <../boards/boards_legacy/arm/nrf5340dk_nrf5340/nrf5340_shared_sram_planning_conf.dtsi>

--- a/boards/boards_legacy/posix/nrf_bsim/soc/pinctrl_soc.h
+++ b/boards/boards_legacy/posix/nrf_bsim/soc/pinctrl_soc.h
@@ -8,6 +8,6 @@
 #define BOARDS_POSIX_NRF_BSIM_SOC_PINCTRL_SOC_H
 
 /* We reuse the real SOC's header: */
-#include "../soc/arm/nordic_nrf/common/pinctrl_soc.h"
+#include "../soc/soc_legacy/arm/nordic_nrf/common/pinctrl_soc.h"
 
 #endif /* BOARDS_POSIX_NRF_BSIM_SOC_PINCTRL_SOC_H */

--- a/boards/boards_legacy/posix/nrf_bsim/soc/soc_nrf_common.h
+++ b/boards/boards_legacy/posix/nrf_bsim/soc/soc_nrf_common.h
@@ -8,6 +8,6 @@
 #define BOARDS_POSIX_NRF_BSIM_SOC_SOC_NRF_COMMON_H
 
 /* We reuse the real SOC's header: */
-#include "../soc/arm/nordic_nrf/common/soc_nrf_common.h"
+#include "../soc/soc_legacy/arm/nordic_nrf/common/soc_nrf_common.h"
 
 #endif /* BOARDS_POSIX_NRF_BSIM_SOC_SOC_NRF_COMMON_H */

--- a/tests/drivers/gpio/gpio_ite_it8xxx2_v2/CMakeLists.txt
+++ b/tests/drivers/gpio/gpio_ite_it8xxx2_v2/CMakeLists.txt
@@ -13,8 +13,8 @@ target_include_directories(app PRIVATE
 
 zephyr_include_directories(
   include
-  ${ZEPHYR_BASE}/soc/riscv/ite_ec/common
-  ${ZEPHYR_BASE}/soc/riscv/ite_ec/it8xxx2
+  ${ZEPHYR_BASE}/soc/soc_legacy/riscv/ite_ec/common
+  ${ZEPHYR_BASE}/soc/soc_legacy/riscv/ite_ec/it8xxx2
 )
 
 target_sources(app

--- a/tests/drivers/gpio/gpio_ite_it8xxx2_v2/include/chip_chipregs.h
+++ b/tests/drivers/gpio/gpio_ite_it8xxx2_v2/include/chip_chipregs.h
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <../soc/riscv/ite_ec/common/chip_chipregs.h>
+#include <../soc/soc_legacy/riscv/ite_ec/common/chip_chipregs.h>
 
 /*
  * Macros for emulated hardware registers access.


### PR DESCRIPTION
Adjusts paths until socs/boards can be ported. RISCV cannot currently be ported and nordic socs are awaiting stm32f4 socs to be ported for a board that has 2 CPUs.

    boards: posix: bsim: Update paths
    
    Updates paths to account for legacy in them to prevent build
    failures

    tests: drivers: gpio: gpio_ite_it8xxx2_v2: Temp fix
    
    Resolves a test failure by changing the paths as riscv boards
    cannot currently be ported
