### PR TITLE
ipc: Drain pending work items before deregistering endpoint

### DIFF
--- a/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.c
+++ b/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.c
@@ -456,6 +456,7 @@ static int deregister_ept(const struct device *instance, void *token)
 {
 	struct backend_data_t *data = instance->data;
 	struct ipc_rpmsg_ept *rpmsg_ept;
+	static struct k_work_sync sync;
 
 	/* Instance is not ready */
 	if (atomic_get(&data->state) != STATE_INITED) {
@@ -468,6 +469,13 @@ static int deregister_ept(const struct device *instance, void *token)
 	if (!rpmsg_ept) {
 		return -ENOENT;
 	}
+
+	/* Drain pending work items before tearing down channel.
+	 *
+	 * Note: `k_work_flush` Faults on Cortex-M33 with "illegal use of EPSR"
+	 * if `sync` is not declared static.
+	 */
+	k_work_flush(&data->mbox_work, &sync);
 
 	rpmsg_destroy_ept(&rpmsg_ept->ep);
 


### PR DESCRIPTION
The work item will attempt to dereference pointers that have been nulled by the backend.

To avoid that, wait until all items currently on the queue have been processed.

The symptom is a busfault on ARM, and is "fixed" by adding a `k_msleep(1)` right before `ipc_service_deregister_endpoint()`. This will in effect do the same thing as this patch, and allow the scheduler to run the work item on the ipc workqueue.