### PR TITLE
tests: drivers: spi: allow to configure thread stack size

### DIFF
--- a/tests/drivers/spi/spi_loopback/src/spi.c
+++ b/tests/drivers/spi/spi_loopback/src/spi.c
@@ -55,7 +55,7 @@ static struct spi_dt_spec spi_slow = SPI_DT_SPEC_GET(SPI_SLOW_DEV, SPI_OP(FRAME_
 
 /* to run this test, connect MOSI pin to the MISO of the SPI */
 
-#define STACK_SIZE 512
+#define STACK_SIZE (512 + CONFIG_TEST_EXTRA_STACK_SIZE)
 #define BUF_SIZE 18
 #define BUF2_SIZE 36
 

--- a/tests/drivers/spi/spi_loopback/src/spi.c
+++ b/tests/drivers/spi/spi_loopback/src/spi.c
@@ -542,7 +542,7 @@ static void spi_async_call_cb(void *p1,
 	LOG_DBG("Polling...");
 
 	while (1) {
-		ret = k_poll(evt, 1, K_MSEC(200));
+		ret = k_poll(evt, 1, K_MSEC(2000));
 		zassert_false(ret, "one or more events are not ready");
 
 		result = evt->signal->result;

--- a/tests/drivers/spi/spi_loopback/src/spi_rtio.c
+++ b/tests/drivers/spi/spi_loopback/src/spi_rtio.c
@@ -37,7 +37,7 @@ RTIO_DEFINE(r, 8, 8);
 
 /* to run this test, connect MOSI pin to the MISO of the SPI */
 
-#define STACK_SIZE 512
+#define STACK_SIZE (512 + CONFIG_TEST_EXTRA_STACK_SIZE)
 #define BUF_SIZE 17
 #define BUF2_SIZE 36
 


### PR DESCRIPTION
Used to perform coverage analysis when testing on HW. Gathering coverage data require more stack,
so its needs to configurable.
There is used CONFIG_TEST_EXTRA_STACK_SIZE for that. (with value depending on used HW).