### PR TITLE
posix: implement pthread_attr_getinheritsched() and pthread_attr_setinheritsched()

### DIFF
--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -502,10 +502,10 @@ _POSIX_THREAD_PRIORITY_SCHEDULING
    :header: API, Supported
    :widths: 50,10
 
-    pthread_attr_getinheritsched(),
+    pthread_attr_getinheritsched(),yes
     pthread_attr_getschedpolicy(),yes
     pthread_attr_getscope(),yes
-    pthread_attr_setinheritsched(),
+    pthread_attr_setinheritsched(),yes
     pthread_attr_setschedpolicy(),yes
     pthread_attr_setscope(),yes
     pthread_getschedparam(),yes

--- a/include/zephyr/posix/pthread.h
+++ b/include/zephyr/posix/pthread.h
@@ -45,6 +45,12 @@ extern "C" {
 #undef PTHREAD_SCOPE_SYSTEM
 #define PTHREAD_SCOPE_SYSTEM     0
 
+/* Pthread inherit scheduler */
+#undef PTHREAD_INHERIT_SCHED
+#define PTHREAD_INHERIT_SCHED  0
+#undef PTHREAD_EXPLICIT_SCHED
+#define PTHREAD_EXPLICIT_SCHED 1
+
 /* Passed to pthread_once */
 #define PTHREAD_ONCE_INIT {0}
 
@@ -423,6 +429,8 @@ int pthread_attr_setstack(pthread_attr_t *attr, void *stackaddr,
 			  size_t stacksize);
 int pthread_attr_getscope(const pthread_attr_t *attr, int *contentionscope);
 int pthread_attr_setscope(pthread_attr_t *attr, int contentionscope);
+int pthread_attr_getinheritsched(const pthread_attr_t *attr, int *inheritsched);
+int pthread_attr_setinheritsched(pthread_attr_t *attr, int inheritsched);
 #ifdef CONFIG_PTHREAD_IPC
 int pthread_once(pthread_once_t *once, void (*initFunc)(void));
 #endif

--- a/lib/posix/options/posix_internal.h
+++ b/lib/posix/options/posix_internal.h
@@ -30,6 +30,7 @@ struct posix_thread_attr {
 	int8_t priority;
 	uint8_t schedpolicy: 2;
 	bool contentionscope: 1;
+	bool inheritsched: 1;
 	union {
 		bool caller_destroys: 1;
 		bool initialized: 1;

--- a/tests/posix/headers/src/pthread_h.c
+++ b/tests/posix/headers/src/pthread_h.c
@@ -34,8 +34,8 @@ ZTEST(posix_headers, test_pthread_h)
 	zassert_not_equal(-1, PTHREAD_CREATE_DETACHED);
 	zassert_not_equal(-1, PTHREAD_CREATE_JOINABLE);
 
-	/* zassert_not_equal(-1, PTHREAD_EXPLICIT_SCHED); */ /* not implemented */
-	/* zassert_not_equal(-1, PTHREAD_INHERIT_SCHED); */ /* not implemented */
+	zassert_not_equal(-1, PTHREAD_EXPLICIT_SCHED);
+	zassert_not_equal(-1, PTHREAD_INHERIT_SCHED);
 
 	zassert_not_equal(-1, PTHREAD_MUTEX_DEFAULT);
 	zassert_not_equal(-1, PTHREAD_MUTEX_ERRORCHECK);
@@ -65,7 +65,7 @@ ZTEST(posix_headers, test_pthread_h)
 		zassert_not_null(pthread_attr_destroy);
 		zassert_not_null(pthread_attr_getdetachstate);
 		zassert_not_null(pthread_attr_getguardsize);
-		/* zassert_not_null(pthread_attr_getinheritsched); */ /* not implemented */
+		zassert_not_null(pthread_attr_getinheritsched);
 		zassert_not_null(pthread_attr_getschedparam);
 		zassert_not_null(pthread_attr_getschedpolicy);
 		zassert_not_null(pthread_attr_getscope);
@@ -74,7 +74,7 @@ ZTEST(posix_headers, test_pthread_h)
 		zassert_not_null(pthread_attr_init);
 		zassert_not_null(pthread_attr_setdetachstate);
 		zassert_not_null(pthread_attr_setguardsize);
-		/* zassert_not_null(pthread_attr_setinheritsched); */ /* not implemented */
+		zassert_not_null(pthread_attr_setinheritsched);
 		zassert_not_null(pthread_attr_setschedparam);
 		zassert_not_null(pthread_attr_setschedpolicy);
 		zassert_not_null(pthread_attr_setscope);


### PR DESCRIPTION
This is part of the See https://github.com/zephyrproject-rtos/zephyr/issues/51211 (RFC https://github.com/zephyrproject-rtos/zephyr/issues/51211).

`pthread_attr_setinheritsched()` and `pthread_attr_getinheritsched()` are required as part of _POSIX_THREAD_PRIORITY_SCHEDULING Option Group.

For more information, please refer to https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_attr_setinheritsched.html

Fixes  #66968
Fixes #66966