### PR TITLE
lib: acpi: fix for build error when acpi not enabled

### DIFF
--- a/include/zephyr/acpi/acpi.h
+++ b/include/zephyr/acpi/acpi.h
@@ -62,11 +62,8 @@ struct acpi_mcfg {
 
 struct acpi_irq_resource {
 	uint32_t flags;
-	union {
-		uint16_t irq;
-		uint16_t irqs[CONFIG_ACPI_IRQ_VECTOR_MAX];
-	};
 	uint8_t irq_vector_max;
+	uint16_t *irqs;
 };
 
 struct acpi_reg_base {
@@ -79,8 +76,8 @@ struct acpi_reg_base {
 };
 
 struct acpi_mmio_resource {
-	struct acpi_reg_base reg_base[CONFIG_ACPI_MMIO_ENTRIES_MAX];
 	uint8_t mmio_max;
+	struct acpi_reg_base *reg_base;
 };
 
 /**

--- a/lib/acpi/acpi.c
+++ b/lib/acpi/acpi.c
@@ -457,11 +457,10 @@ int acpi_device_irq_get(struct acpi_dev *child_dev, struct acpi_irq_resource *ir
 			return -ENODEV;
 		}
 
-		if (res->Data.ExtendedIrq.InterruptCount > CONFIG_ACPI_IRQ_VECTOR_MAX) {
+		if (res->Data.ExtendedIrq.InterruptCount > irq_res->irq_vector_max) {
 			return -ENOMEM;
 		}
 
-		memset(irq_res, 0, sizeof(struct acpi_irq_resource));
 		irq_res->irq_vector_max = res->Data.ExtendedIrq.InterruptCount;
 		for (int i = 0; i < irq_res->irq_vector_max; i++) {
 			irq_res->irqs[i] = (uint16_t)res->Data.ExtendedIrq.Interrupts[i];
@@ -470,7 +469,7 @@ int acpi_device_irq_get(struct acpi_dev *child_dev, struct acpi_irq_resource *ir
 		irq_res->flags = arch_acpi_encode_irq_flags(res->Data.ExtendedIrq.Polarity,
 							    res->Data.ExtendedIrq.Triggering);
 	} else {
-		if (res->Data.Irq.InterruptCount > CONFIG_ACPI_IRQ_VECTOR_MAX) {
+		if (res->Data.Irq.InterruptCount > irq_res->irq_vector_max) {
 			return -ENOMEM;
 		}
 
@@ -531,7 +530,7 @@ int acpi_device_mmio_get(struct acpi_dev *child_dev, struct acpi_mmio_resource *
 		}
 
 		res = ACPI_NEXT_RESOURCE(res);
-		if (mmio_cnt >= CONFIG_ACPI_MMIO_ENTRIES_MAX &&
+		if (mmio_cnt >= mmio_res->mmio_max &&
 			 res->Type != ACPI_RESOURCE_TYPE_END_TAG) {
 			return -ENOMEM;
 		}

--- a/lib/acpi/acpi_shell.c
+++ b/lib/acpi/acpi_shell.c
@@ -279,6 +279,8 @@ static int get_acpi_dev_resource(const struct shell *sh, size_t argc, char **arg
 	struct acpi_dev *dev;
 	struct acpi_irq_resource irq_res;
 	struct acpi_mmio_resource mmio_res;
+	uint16_t irqs[CONFIG_ACPI_IRQ_VECTOR_MAX];
+	struct acpi_reg_base reg_base[CONFIG_ACPI_MMIO_ENTRIES_MAX];
 
 	if (argc < 3) {
 		return -EINVAL;
@@ -293,6 +295,8 @@ static int get_acpi_dev_resource(const struct shell *sh, size_t argc, char **arg
 	if (dev->path) {
 		shell_print(sh, "Device Path: %s", dev->path);
 
+		mmio_res.mmio_max = ARRAY_SIZE(reg_base);
+		mmio_res.reg_base = reg_base;
 		if (!acpi_device_mmio_get(dev, &mmio_res)) {
 
 			shell_print(sh, "Device MMIO resources");
@@ -304,6 +308,8 @@ static int get_acpi_dev_resource(const struct shell *sh, size_t argc, char **arg
 			}
 		}
 
+		irq_res.irq_vector_max = ARRAY_SIZE(irqs);
+		irq_res.irqs = irqs;
 		if (!acpi_device_irq_get(dev, &irq_res)) {
 
 			shell_print(sh, "Device IRQ resources");

--- a/tests/lib/acpi/integration/src/main.c
+++ b/tests/lib/acpi/integration/src/main.c
@@ -49,6 +49,8 @@ ZTEST(acpi, test_resource_enum)
 	struct acpi_dev *dev;
 	struct acpi_irq_resource irq_res;
 	struct acpi_mmio_resource mmio_res;
+	uint16_t irqs[CONFIG_ACPI_IRQ_VECTOR_MAX];
+	struct acpi_reg_base reg_base[CONFIG_ACPI_MMIO_ENTRIES_MAX];
 	int ret;
 
 	Z_TEST_SKIP_IFNDEF(APCI_TEST_DEV);
@@ -57,10 +59,14 @@ ZTEST(acpi, test_resource_enum)
 
 	zassert_not_null(dev, "Failed to get acpi device with given HID");
 
+	mmio_res.mmio_max = ARRAY_SIZE(reg_base);
+	mmio_res.reg_base = reg_base;
 	ret = acpi_device_mmio_get(dev, &mmio_res);
 
 	zassert_ok(ret, "Failed to get MMIO resources");
 
+	irq_res.irq_vector_max = ARRAY_SIZE(irqs);
+	irq_res.irqs = irqs;
 	ret = acpi_device_irq_get(dev, &irq_res);
 
 	zassert_ok(ret, "Failed to get IRQ resources");


### PR DESCRIPTION
Fix for acpi.h header file generates invalid C-code when CONFIG_ACPI=n

Fixes #68467