### PR TITLE
toolchain: do not use posix C code for asm language in gcc.h

### DIFF
--- a/include/zephyr/toolchain/gcc.h
+++ b/include/zephyr/toolchain/gcc.h
@@ -103,7 +103,7 @@
 #define FUNC_ALIAS(real_func, new_alias, return_type) \
 	return_type new_alias() ALIAS_OF(real_func)
 
-#if defined(CONFIG_ARCH_POSIX)
+#if defined(CONFIG_ARCH_POSIX) && !defined(_ASMLANGUAGE)
 #include <zephyr/arch/posix/posix_trace.h>
 
 /*let's not segfault if this were to happen for some reason*/


### PR DESCRIPTION
I have asm file to built-in some data into the final image as following:

```asm
#include <zephyr/toolchain.h>

.section .data.aos_root_ca,"a"
GDATA(__aos_root_ca_start)
GDATA(__aos_root_ca_end)
.align 8
__aos_root_ca_start:
.incbin  CONFIG_MY_DATA_FILE
__aos_root_ca_end:
```

This file is not compiled for `native_posix` boards due to the following error:

```bash
zephyr/arch/posix/posix_trace.h: Assembler messages:
zephyr/arch/posix/posix_trace.h:13: Error: no such instruction: `void posix_print_error_and_exit(const char *format,...)'
zephyr/arch/posix/posix_trace.h:14: Error: no such instruction: `void posix_print_warning(const char *format,...)'
zephyr/arch/posix/posix_trace.h:15: Error: no such instruction: `void posix_print_trace(const char *format,...)'
zephyr/arch/posix/posix_trace.h:28: Error: junk `(int output)' after expression
zephyr/arch/posix/posix_trace.h:28: Error: operand size mismatch for `int'
```

Including `<zephyr/arch/posix/posix_trace.h>` in `<toolchain/gcc.h>` causes the issues. The proposal fix is to remove the posix header for `asm` language conditionally.
