### PR TITLE
manifest: update cmsis-dsp

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -121,7 +121,7 @@ manifest:
       groups:
         - hal
     - name: cmsis-dsp
-      revision: ff7b5fd1ea5f094665c090c343ec44e74dc0b193
+      revision: 6489e771e9c405f1763b52d64a3f17a1ec488ace
       path: modules/lib/cmsis-dsp
     - name: cmsis-nn
       revision: 0c8669d81381ccf3b1a01d699f3b68b50134a99f


### PR DESCRIPTION
Update cmsis-dsp revision to contain the fixes for:
- Buffer overflow in certain implementation of arm_conv_q31, q15 and q7
- Name conflicts with Zephyr macros SQ and ROUND_UP

cc @carlescufi 