### PR TITLE
Fix: (no paths) != sum(<no paths>)

### DIFF
--- a/scripts/footprint/size_report
+++ b/scripts/footprint/size_report
@@ -664,6 +664,7 @@ def generate_any_tree(symbol_dict, total_size, path_prefix):
     # Need to account for code and data where there are not emitted
     # symbols associated with them.
     node_hidden_syms = TreeNode('(hidden)', "(hidden)", parent=root)
+    node_no_paths._size = sum_node_children_size(node_no_paths)
     node_hidden_syms._size = root._size - sum_node_children_size(root)
 
     return root


### PR DESCRIPTION
In some cases it was observed that item were being added to the node_no_paths and these only had a path of ':' hence no node was ever added.

This resulted in the size of (no paths) to not be equal to the sum of it's children.

I am not sure if this size should be a child named of no paths or if  this should be part of the node_hidden_syms. I assumed it should be part of node_hidden_syms