### PR TITLE
newlibc-hooks with userspace: Bug fix for assertion during printf

### DIFF
--- a/lib/libc/newlib/libc-hooks.c
+++ b/lib/libc/newlib/libc-hooks.c
@@ -369,6 +369,9 @@ void __retarget_lock_init(_LOCK_T *lock)
 	__ASSERT(*lock != NULL, "non-recursive lock allocation failed");
 
 	k_sem_init((struct k_sem *)*lock, 1, 1);
+#ifdef CONFIG_USERSPACE
+	k_object_access_all_grant(*lock);
+#endif /* CONFIG_USERSPACE */
 }
 
 /* Create a new dynamic recursive lock */
@@ -385,6 +388,9 @@ void __retarget_lock_init_recursive(_LOCK_T *lock)
 	__ASSERT(*lock != NULL, "recursive lock allocation failed");
 
 	k_mutex_init((struct k_mutex *)*lock);
+#ifdef CONFIG_USERSPACE
+	k_object_access_all_grant(*lock);
+#endif /* CONFIG_USERSPACE */
 }
 
 /* Close dynamic non-recursive lock */


### PR DESCRIPTION
Fixes: zephyrproject-rtos#67504

The following error is produced  when using the following configuration
```
CONFIG_USERSPACE=y
CONFIG_NEWLIB_LIBC=y
CONFIG_NEWLIB_LIBC_NANO=n
CONFIG_DYNAMIC_OBJECTS=y
CONFIG_HEAP_MEM_POOL_SIZE=256
CONFIG_THREAD_LOCAL_STORAGE=y
CONFIG_MAIN_STACK_SIZE=2048
```

```
os: thread 0x301a2950 (-1) does not have permission on k_mutex 0x301aaca4 
os: permission bitmap 01 00 |..
os: syscall z_vrfy_k_mutex_lock failed check: access denied
os: r0/a1: 0x00000000 r1/a2: 0x00000000 r2/a3: 0x00000000
os: r3/a4: 0x00000000 r12/ip: 0x00000000 r14/lr: 0x00000000
os: xpsr: 0x00000000
os: s[ 0]: 0x00000000 s[ 1]: 0x00000000 s[ 2]: 0x00000000 s[ 3]: 0x00000000
os: s[ 4]: 0x00000000 s[ 5]: 0x00000000 s[ 6]: 0x00000000 s[ 7]: 0x00000000
os: s[ 8]: 0x00000000 s[ 9]: 0x00000000 s[10]: 0x00000000 s[11]: 0x00000000
os: s[12]: 0x00000000 s[13]: 0x00000000 s[14]: 0x00000000 s[15]: 0x00000000
os: fpscr: 0x00000000
os: Faulting instruction address (r15/pc): 0xee7fdb7d
os: >>> ZEPHYR FATAL ERROR 3: Kernel oops on CPU 0
os: Current thread: 0x301a2950
```

This bug caused by a global mutex used by _vfprintf_r()
which is initialized in __sinit() and located in z_malloc_partition.
This mutex not being granted access to be used my multiple user threads despite 
each user thread being granted read and write permission to the z_malloc_partition.
They must also be granted access to use the object.

Here is a sample main.c to reproduce the bug
```

extern struct k_mem_partition z_libc_partition;
extern struct k_mem_partition z_malloc_partition;

static k_tid_t tids[TEST_THDS];
static struct k_thread tcbs[TEST_THDS];
static struct k_mem_domain domains[TEST_THDS];
static K_THREAD_STACK_ARRAY_DEFINE(thd_stacks, TEST_THDS, 2048);

static int forbidden_global_data = 2;

void thread_worker(void* a, void* b, void* c) {
    (void)b;
    (void)c;
    printf("thd %d started\n", (int)(intptr_t)a);
    k_sleep(K_MSEC(1000));
    forbidden_global_data++; /* This should cause an MPU Fault */
}

int main(void) {
    forbidden_global_data = 1;
    struct k_mem_partition* share_parts[2] = {
        &z_libc_partition,
        &z_malloc_partition,
    };

    for (int i = 0l; i < TEST_THDS; i++) {
        tids[i] = k_thread_create(&tcbs[i], 
                                thd_stacks[i], 
                                K_THREAD_STACK_SIZEOF(thd_stacks[i]), 
                                thread_worker, 
                                (void*)(intptr_t)i, 
                                NULL, 
                                NULL, 
                                5, 
                                K_USER, K_FOREVER);
        k_mem_domain_init(&domains[i], 2, share_parts);
        k_mem_domain_add_thread(&domains[i], tids[i]);
        k_thread_start(tids[i]);
   }

    for (int i = 0; i < TEST_THDS; i++) {
        k_thread_join(tids[i], K_FOREVER);
    }

   return 0;
}
```