### PR TITLE
dts: arm: nxp: nxp_rt1010: provide flexspi clock source

### DIFF
--- a/dts/arm/nxp/nxp_rt1010.dtsi
+++ b/dts/arm/nxp/nxp_rt1010.dtsi
@@ -112,6 +112,7 @@
 			ahb-bufferable;
 			ahb-cacheable;
 			status = "disabled";
+			clocks = <&ccm IMX_CCM_FLEXSPI_CLK 0x0 0x0>;
 		};
 
 		/* Remove SEMC, it does'nt exist on RT1010 */


### PR DESCRIPTION
Add FlexSPI clock source to RT1010 devicetree definition for FlexSPI node, to match FlexSPI clock source defined on standard FlexSPI dt node that is removed in the RT1010 devicetree.

Fixes #68488