### PR TITLE
west: percepio: update module

### DIFF
--- a/modules/percepio/CMakeLists.txt
+++ b/modules/percepio/CMakeLists.txt
@@ -102,14 +102,14 @@ if(CONFIG_PERCEPIO_DFM)
 
   set(DFM_DIR ${ZEPHYR_CURRENT_MODULE_DIR}/DFM)
 
-  zephyr_library_sources_ifdef(
-    CONFIG_PERCEPIO_DFM
+  zephyr_library_sources(
     ${DFM_DIR}/dfm.c
     ${DFM_DIR}/dfmAlert.c
     ${DFM_DIR}/dfmCloud.c
     ${DFM_DIR}/dfmEntry.c
     ${DFM_DIR}/dfmSession.c
     ${DFM_DIR}/dfmStorage.c
+    ${DFM_DIR}/dfmRetainedMemory.c
     ${DFM_DIR}/kernelports/Zephyr/dfmKernelPort.c
     )
 
@@ -133,6 +133,16 @@ if(CONFIG_PERCEPIO_DFM)
     )
   endif()
 
+  if(CONFIG_PERCEPIO_DFM_CFG_STORAGEPORT_FILESYSTEM)
+    zephyr_library_sources(
+      ${DFM_DIR}/kernelports/Zephyr/storageports/Filesystem/dfmStoragePort.c
+    )
+
+    zephyr_include_directories(
+      ${DFM_DIR}/kernelports/Zephyr/storageports/Filesystem/include/
+    )
+  endif()
+
   if(CONFIG_PERCEPIO_DFM_CFG_CLOUDPORT_NONE)
     zephyr_library_sources(
       ${DFM_DIR}/cloudports/Dummy/dfmCloudPort.c
@@ -151,6 +161,12 @@ if(CONFIG_PERCEPIO_DFM)
     zephyr_include_directories(
       ${DFM_DIR}/kernelports/Zephyr/cloudports/Serial/config/
       ${DFM_DIR}/kernelports/Zephyr/cloudports/Serial/include/
+    )
+  endif()
+
+  if(CONFIG_PERCEPIO_DFM_CFG_RETAINED_MEMORY)
+    zephyr_library_sources(
+      ${DFM_DIR}/kernelports/Zephyr/dfmRetainedMemoryPort.c
     )
   endif()
 

--- a/west.yml
+++ b/west.yml
@@ -305,7 +305,7 @@ manifest:
       path: modules/lib/openthread
     - name: percepio
       path: modules/debug/percepio
-      revision: 0fbc5b72aeab8a6434523a3a7bc8111c17f0bc73
+      revision: 7f6fb3f12ea1493a2f8ab6a876fb255a39db47c8
       groups:
         - debug
     - name: picolibc


### PR DESCRIPTION
Update the percepio module to use TraceRecorder v4.8.2 and DevAlert (DFM) v2.1.0.

Signed-off-by: Erik Tamlin <erik.tamlin@percepio.com>