### PR TITLE
dts: arm: microchip: mec172xnsz: Remove pinctrl from device tree in MEC172x SoC 

### DIFF
--- a/dts/arm/microchip/mec1501hsz.dtsi
+++ b/dts/arm/microchip/mec1501hsz.dtsi
@@ -74,9 +74,6 @@
 			clk32kmon-valid-min = <4>;
 			xtal-enable-delay-ms = <300>;
 			pll-lock-timeout-ms = <30>;
-			/* pin configured only if the sources is set to PIN */
-			pinctrl-0 = <&clk_32khz_in_gpio165>;
-			pinctrl-names = "default";
 			#clock-cells = <3>;
 		};
 		ecia: ecia@4000e000 {

--- a/dts/arm/microchip/mec172x_common.dtsi
+++ b/dts/arm/microchip/mec172x_common.dtsi
@@ -22,9 +22,6 @@ pcr: pcr@40080100 {
 	clk32kmon-valid-min = <4>;
 	xtal-enable-delay-ms = <300>;
 	pll-lock-timeout-ms = <30>;
-	/* pin configured only if one of the sources is set to PIN */
-	pinctrl-0 = <&clk_32khz_in_gpio165>;
-	pinctrl-names = "default";
 	#clock-cells = <3>;
 };
 ecia: ecia@4000e000 {

--- a/dts/bindings/clock/microchip,xec-pcr.yaml
+++ b/dts/bindings/clock/microchip,xec-pcr.yaml
@@ -87,12 +87,6 @@ properties:
       for PLL and Periheral devices then disable the internal 32KHz
       oscillator to save power.
 
-  pinctrl-0:
-    required: true
-
-  pinctrl-names:
-    required: true
-
   "#clock-cells":
     const: 3
 


### PR DESCRIPTION
Make pinctrl optional for PCR block since it is not always required, e.g. using internal oscillator.

Remove pinctrl from device tree in MEC172x SoC since the default is internal oscillator to free the unused pin.
