### PR TITLE
intel_adsp/ace: power: Lock interruption when power gate fails

### DIFF
--- a/soc/intel/intel_adsp/ace/power.c
+++ b/soc/intel/intel_adsp/ace/power.c
@@ -176,6 +176,13 @@ void power_gate_entry(uint32_t core_id)
 	soc_cpus_active[core_id] = false;
 	sys_cache_data_flush_range(soc_cpus_active, sizeof(soc_cpus_active));
 	k_cpu_idle();
+
+	/* It is unlikely we get in here, but when this happens
+	 * we need to lock interruptions again.
+	 *
+	 * @note Zephyr looks PS.INTLEVEL to check if interruptions are locked.
+	 */
+	(void)arch_irq_lock();
 	z_xt_ints_off(0xffffffff);
 }
 


### PR DESCRIPTION
In case the core is not power gated, waiti will restore intlevel. In this case we lock interruption after it.