### PR TITLE
doc: posix: mark putmsg as supported

### DIFF
--- a/doc/services/portability/posix/conformance/index.rst
+++ b/doc/services/portability/posix/conformance/index.rst
@@ -109,7 +109,7 @@ POSIX System Interfaces
     _XOPEN_CRYPT, -1,
     _XOPEN_REALTIME, -1,
     _XOPEN_REALTIME_THREADS, -1,
-    :ref:`_XOPEN_STREAMS<posix_option_xopen_streams>`, -1, :kconfig:option:`CONFIG_NET_SOCKETS`
+    :ref:`_XOPEN_STREAMS<posix_option_xopen_streams>`, -1, :ref:`†<posix_undefined_behaviour>`
     _XOPEN_UNIX, -1,
 
 POSIX Shell and Utilities

--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -379,9 +379,9 @@ _POSIX_PRIORITY_SCHEDULING
     sched_get_priority_min(),yes
     sched_getparam(),yes
     sched_getscheduler(),yes
-    sched_rr_get_interval(),yes
-    sched_setparam(),yes
-    sched_setscheduler(),yes
+    sched_rr_get_interval(),yes (will fail with ``ENOSYS``:ref:`†<posix_undefined_behaviour>`)
+    sched_setparam(),yes (will fail with ``ENOSYS``:ref:`†<posix_undefined_behaviour>`)
+    sched_setscheduler(),yes (will fail with ``ENOSYS``:ref:`†<posix_undefined_behaviour>`)
     sched_yield(),yes
 
 .. _posix_option_reader_writer_locks:

--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -509,7 +509,7 @@ _XOPEN_STREAMS
     getpmsg(),
     ioctl(),yes
     isastream(),
-    putmsg(),
+    putmsg(), yes (will fail with ``ENOSYS``:ref:`†<posix_undefined_behaviour>`)
     putpmsg(),
 
 


### PR DESCRIPTION
`putmsg()` is missing in the documentation.
Has been discuss here https://github.com/zephyrproject-rtos/zephyr/pull/67711