### PR TITLE
modbus: refactor modbus_server.c

### DIFF
--- a/subsys/modbus/modbus_core.c
+++ b/subsys/modbus/modbus_core.c
@@ -16,7 +16,7 @@ LOG_MODULE_REGISTER(modbus, CONFIG_MODBUS_LOG_LEVEL);
 #define DT_DRV_COMPAT zephyr_modbus_serial
 
 #define MB_RTU_DEFINE_GPIO_CFG(inst, prop)				\
-	static struct gpio_dt_spec prop##_cfg_##inst = {		\
+	static const struct gpio_dt_spec prop##_cfg_##inst = {		\
 		.port = DEVICE_DT_GET(DT_INST_PHANDLE(inst, prop)),	\
 		.pin = DT_INST_GPIO_PIN(inst, prop),			\
 		.dt_flags = DT_INST_GPIO_FLAGS(inst,  prop),		\

--- a/subsys/modbus/modbus_internal.h
+++ b/subsys/modbus/modbus_internal.h
@@ -76,9 +76,9 @@ struct modbus_serial_config {
 	/* Pointer to current position in buffer */
 	uint8_t *uart_buf_ptr;
 	/* Pointer to driver enable (DE) pin config */
-	struct gpio_dt_spec *de;
+	const struct gpio_dt_spec *de;
 	/* Pointer to receiver enable (nRE) pin config */
-	struct gpio_dt_spec *re;
+	const struct gpio_dt_spec *re;
 	/* RTU timer to detect frame end point */
 	struct k_timer rtu_timer;
 	/* Number of bytes received or to send */

--- a/subsys/modbus/modbus_server.c
+++ b/subsys/modbus/modbus_server.c
@@ -148,8 +148,6 @@ static bool mbs_fc01_coil_read(struct modbus_context *ctx)
 	presp = &ctx->tx_adu.data[1];
 	memset(presp, 0, num_bytes);
 
-	/* Reset the pointer to the start of the response payload */
-	presp = &ctx->tx_adu.data[1];
 	/* Start with bit 0 in response byte data mask. */
 	bit_mask = BIT(0);
 	/* Initialize loop counter. */
@@ -246,11 +244,9 @@ static bool mbs_fc02_di_read(struct modbus_context *ctx)
 	/* Clear bytes in response */
 	presp = &ctx->tx_adu.data[1];
 	for (di_cntr = 0; di_cntr < num_bytes; di_cntr++) {
-		*presp++ = 0x00;
+		presp[di_cntr] = 0x00;
 	}
 
-	/* Reset the pointer to the start of the response payload */
-	presp = &ctx->tx_adu.data[1];
 	/* Start with bit 0 in response byte data mask. */
 	bit_mask = BIT(0);
 	/* Initialize loop counter. */

--- a/subsys/modbus/modbus_server.c
+++ b/subsys/modbus/modbus_server.c
@@ -111,11 +111,11 @@ static bool mbs_fc01_coil_read(struct modbus_context *ctx)
 	uint8_t *presp;
 	bool coil_state;
 	int err;
-	uint16_t coil_addr;
-	uint16_t coil_qty;
-	uint16_t num_bytes;
-	uint8_t bit_mask;
-	uint16_t coil_cntr;
+	uint_fast16_t coil_addr;
+	uint_fast16_t coil_qty;
+	uint_fast16_t num_bytes;
+	uint_fast8_t bit_mask;
+	uint_fast16_t coil_cntr;
 
 	if (ctx->rx_adu.length != request_len) {
 		LOG_ERR("Wrong request length");
@@ -140,7 +140,7 @@ static bool mbs_fc01_coil_read(struct modbus_context *ctx)
 	/* Calculate byte count for response. */
 	num_bytes = ((coil_qty - 1) / 8) + 1;
 	/* Number of data bytes + byte count. */
-	ctx->tx_adu.length = num_bytes + 1;
+	ctx->tx_adu.length = (uint16_t)(num_bytes + 1);
 	/* Set number of data bytes in response message. */
 	ctx->tx_adu.data[0] = (uint8_t)num_bytes;
 
@@ -208,11 +208,11 @@ static bool mbs_fc02_di_read(struct modbus_context *ctx)
 	uint8_t *presp;
 	bool di_state;
 	int err;
-	uint16_t di_addr;
-	uint16_t di_qty;
-	uint16_t num_bytes;
-	uint8_t bit_mask;
-	uint16_t di_cntr;
+	uint_fast16_t di_addr;
+	uint_fast16_t di_qty;
+	uint_fast16_t num_bytes;
+	uint_fast8_t bit_mask;
+	uint_fast16_t di_cntr;
 
 	if (ctx->rx_adu.length != request_len) {
 		LOG_ERR("Wrong request length");
@@ -237,7 +237,7 @@ static bool mbs_fc02_di_read(struct modbus_context *ctx)
 	/* Get number of bytes needed for response. */
 	num_bytes = ((di_qty - 1) / 8) + 1;
 	/* Number of data bytes + byte count. */
-	ctx->tx_adu.length = num_bytes + 1;
+	ctx->tx_adu.length = (uint16_t)(num_bytes + 1);
 	/* Set number of data bytes in response message. */
 	ctx->tx_adu.data[0] = (uint8_t)num_bytes;
 
@@ -306,9 +306,9 @@ static bool mbs_fc03_hreg_read(struct modbus_context *ctx)
 	const uint8_t request_len = 4;
 	uint8_t *presp;
 	uint16_t err;
-	uint16_t reg_addr;
-	uint16_t reg_qty;
-	uint16_t num_bytes;
+	uint_fast16_t reg_addr;
+	uint_fast16_t reg_qty;
+	uint_fast16_t num_bytes;
 
 	if (ctx->rx_adu.length != request_len) {
 		LOG_ERR("Wrong request length");
@@ -333,7 +333,7 @@ static bool mbs_fc03_hreg_read(struct modbus_context *ctx)
 		}
 
 		/* Get number of bytes needed for response. */
-		num_bytes = (uint8_t)(reg_qty * sizeof(uint16_t));
+		num_bytes = (reg_qty * sizeof(uint16_t));
 	} else {
 		/* Read floating-point register */
 		if (ctx->mbs_user_cb->holding_reg_rd_fp == NULL) {
@@ -348,11 +348,11 @@ static bool mbs_fc03_hreg_read(struct modbus_context *ctx)
 		}
 
 		/* Get number of bytes needed for response. */
-		num_bytes = (uint8_t)(reg_qty * sizeof(float));
+		num_bytes = (reg_qty * sizeof(float));
 	}
 
 	/* Number of data bytes + byte count. */
-	ctx->tx_adu.length = num_bytes + 1;
+	ctx->tx_adu.length = (uint16_t)(num_bytes + 1);
 	/* Set number of data bytes in response message. */
 	ctx->tx_adu.data[0] = (uint8_t)num_bytes;
 
@@ -416,9 +416,9 @@ static bool mbs_fc04_inreg_read(struct modbus_context *ctx)
 	const uint8_t request_len = 4;
 	uint8_t *presp;
 	int err;
-	uint16_t reg_addr;
-	uint16_t reg_qty;
-	uint16_t num_bytes;
+	uint_fast16_t reg_addr;
+	uint_fast16_t reg_qty;
+	uint_fast16_t num_bytes;
 
 	if (ctx->rx_adu.length != request_len) {
 		LOG_ERR("Wrong request length");
@@ -443,7 +443,7 @@ static bool mbs_fc04_inreg_read(struct modbus_context *ctx)
 		}
 
 		/* Get number of bytes needed for response. */
-		num_bytes = (uint8_t)(reg_qty * sizeof(uint16_t));
+		num_bytes = (reg_qty * sizeof(uint16_t));
 	} else {
 		/* Read floating-point register */
 		if (ctx->mbs_user_cb->input_reg_rd_fp == NULL) {
@@ -458,11 +458,11 @@ static bool mbs_fc04_inreg_read(struct modbus_context *ctx)
 		}
 
 		/* Get number of bytes needed for response. */
-		num_bytes = (uint8_t)(reg_qty * sizeof(float));
+		num_bytes = (reg_qty * sizeof(float));
 	}
 
 	/* Number of data bytes + byte count. */
-	ctx->tx_adu.length = num_bytes + 1;
+	ctx->tx_adu.length = (uint16_t)(num_bytes + 1);
 	/* Set number of data bytes in response message. */
 	ctx->tx_adu.data[0] = (uint8_t)num_bytes;
 
@@ -724,11 +724,11 @@ static bool mbs_fc15_coils_write(struct modbus_context *ctx)
 	const uint8_t response_len = 4;
 	uint8_t temp = 0;
 	int err;
-	uint16_t coil_addr;
-	uint16_t coil_qty;
-	uint16_t num_bytes;
-	uint16_t coil_cntr;
-	uint8_t data_ix;
+	uint_fast16_t coil_addr;
+	uint_fast16_t coil_qty;
+	uint_fast16_t num_bytes;
+	uint_fast16_t coil_cntr;
+	uint_fast8_t data_ix;
 	bool coil_state;
 
 	if (ctx->rx_adu.length < request_len) {
@@ -754,7 +754,7 @@ static bool mbs_fc15_coils_write(struct modbus_context *ctx)
 
 	/* Be sure byte count is valid for quantity of coils. */
 	if (((((coil_qty - 1) / 8) + 1) !=  num_bytes) ||
-	    (ctx->rx_adu.length  != (num_bytes + 5))) {
+	    (ctx->rx_adu.length != (num_bytes + 5))) {
 		LOG_ERR("Mismatch in the number of coils");
 		mbs_exception_rsp(ctx, MODBUS_EXC_ILLEGAL_DATA_VAL);
 		return true;
@@ -826,10 +826,10 @@ static bool mbs_fc16_hregs_write(struct modbus_context *ctx)
 	const uint8_t response_len = 4;
 	uint8_t *prx_data;
 	int err;
-	uint16_t reg_addr;
-	uint16_t reg_qty;
-	uint16_t num_bytes;
-	uint8_t reg_size;
+	uint_fast16_t reg_addr;
+	uint_fast16_t reg_qty;
+	uint_fast16_t num_bytes;
+	uint_fast8_t reg_size;
 
 	if (ctx->rx_adu.length < request_len) {
 		LOG_ERR("Wrong request length %u", ctx->rx_adu.length);
@@ -879,7 +879,7 @@ static bool mbs_fc16_hregs_write(struct modbus_context *ctx)
 		return true;
 	}
 
-	if ((num_bytes / reg_qty) != (uint16_t)reg_size) {
+	if ((num_bytes / reg_qty) != (uint_fast16_t)reg_size) {
 		LOG_ERR("Mismatch in the number of registers");
 		mbs_exception_rsp(ctx, MODBUS_EXC_ILLEGAL_DATA_VAL);
 		return true;


### PR DESCRIPTION
- Apply `struct gpio_dt_spec` of de/re pin as `static const` in `modbus_core.c`.

- Remove redundant 'presp' pointer reset in `modbus_server.c`.

- Use `uint_fast16_t`, `uint_fast8_t` for CPU register optimization in `modbus_server.c`.



