### PR TITLE
posix: cmake: allow empty library

### DIFF
--- a/lib/posix/options/CMakeLists.txt
+++ b/lib/posix/options/CMakeLists.txt
@@ -61,3 +61,5 @@ zephyr_library_include_directories(
   ${ZEPHYR_BASE}/kernel/include
   ${ARCH_DIR}/${ARCH}/include
 )
+
+zephyr_library_property(ALLOW_EMPTY TRUE)


### PR DESCRIPTION
This change mitigates the following cmake warning

No SOURCES given to Zephyr library: lib__posix__options

without needing to have a separate interface library (as we do not need private headers exposed).