### PR TITLE
posix: implement getmsg() and getpmsg()

### DIFF
--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -505,8 +505,8 @@ _XOPEN_STREAMS
 
     fattach(),yes (will fail with ``ENOSYS``:ref:`†<posix_undefined_behaviour>`)
     fdetach(),yes (will fail with ``ENOSYS``:ref:`†<posix_undefined_behaviour>`)
-    getmsg(),
-    getpmsg(),
+    getmsg(),  yes (will fail with ``ENOSYS``:ref:`†<posix_undefined_behaviour>`)
+    getpmsg(),  yes (will fail with ``ENOSYS``:ref:`†<posix_undefined_behaviour>`)
     ioctl(),yes
     isastream(),
     putmsg(),

--- a/include/zephyr/posix/stropts.h
+++ b/include/zephyr/posix/stropts.h
@@ -20,6 +20,8 @@ struct strbuf {
 int putmsg(int fildes, const struct strbuf *ctlptr, const struct strbuf *dataptr, int flags);
 int fdetach(const char *path);
 int fattach(int fildes, const char *path);
+int getmsg(int fildes, struct strbuf *ctlptr, struct strbuf *dataptr, int *flagsp);
+int getpmsg(int fildes, struct strbuf *ctlptr, struct strbuf *dataptr, int *bandp, int *flagsp);
 
 #ifdef __cplusplus
 }

--- a/lib/posix/options/stropts.c
+++ b/lib/posix/options/stropts.c
@@ -31,6 +31,29 @@ int fattach(int fildes, const char *path)
 {
 	ARG_UNUSED(fildes);
 	ARG_UNUSED(path);
+	errno = ENOSYS;
+
+	return -1;
+}
+
+int getmsg(int fildes, struct strbuf *ctlptr, struct strbuf *dataptr, int *flagsp)
+{
+	ARG_UNUSED(fildes);
+	ARG_UNUSED(ctlptr);
+	ARG_UNUSED(dataptr);
+	ARG_UNUSED(flagsp);
+
+	errno = ENOSYS;
+	return -1;
+}
+
+int getpmsg(int fildes, struct strbuf *ctlptr, struct strbuf *dataptr, int *bandp, int *flagsp)
+{
+	ARG_UNUSED(fildes);
+	ARG_UNUSED(ctlptr);
+	ARG_UNUSED(dataptr);
+	ARG_UNUSED(bandp);
+	ARG_UNUSED(flagsp);
 
 	errno = ENOSYS;
 	return -1;

--- a/tests/posix/common/src/stropts.c
+++ b/tests/posix/common/src/stropts.c
@@ -37,4 +37,26 @@ ZTEST(stropts, test_fattach)
 	zassert_equal(errno, ENOSYS, "Expected errno ENOSYS, got %d", errno);
 }
 
+ZTEST(stropts, test_getmsg)
+{
+	struct strbuf *ctrl = NULL;
+	struct strbuf *data = NULL;
+	int fd = -1;
+	int ret = getmsg(fd, ctrl, data, 0);
+
+	zassert_equal(ret, -1, "Expected return value -1, got %d", ret);
+	zassert_equal(errno, ENOSYS, "Expected errno ENOSYS, got %d", errno);
+}
+
+ZTEST(stropts, test_getpmsg)
+{
+	struct strbuf *ctrl = NULL;
+	struct strbuf *data = NULL;
+	int fd = -1;
+	int ret = getpmsg(fd, ctrl, data, 0, 0);
+
+	zassert_equal(ret, -1, "Expected return value -1, got %d", ret);
+	zassert_equal(errno, ENOSYS, "Expected errno ENOSYS, got %d", errno);
+}
+
 ZTEST_SUITE(stropts, NULL, NULL, NULL, NULL, NULL);

--- a/tests/posix/headers/src/stropts_h.c
+++ b/tests/posix/headers/src/stropts_h.c
@@ -21,6 +21,8 @@ ZTEST(posix_headers, test_stropts_h)
 	zassert_not_null((void *)putmsg, "putmsg is null");
 	zassert_not_null((void *)fdetach, "fdetach is null");
 	zassert_not_null((void *)fattach, "fattach is null");
+	zassert_not_null((void *)getmsg, "getmsg is null");
+	zassert_not_null((void *)getpmsg, "getpmsg is null");
 
 	zassert_true(sizeof(((struct strbuf *)0)->maxlen) > 0, "maxlen size is 0");
 	zassert_true(sizeof(((struct strbuf *)0)->len) > 0, "len size is 0");


### PR DESCRIPTION
This is part of the See https://github.com/zephyrproject-rtos/zephyr/issues/51211 (RFC https://github.com/zephyrproject-rtos/zephyr/issues/51211).

`getmsg()` and `getpmsg()` are required as part of _XOPEN_STREAMS Option Group.

For more information, please refer to https://pubs.opengroup.org/onlinepubs/9699919799/functions/getmsg.html

Fixes #66975
Fixes #66976

I add precision on the documentation that the function is a placeholder and will fail with ENOSYS.