### PR TITLE
drivers: gpio: add acpi resource enumeration support for Intel GPIO driver

### DIFF
--- a/dts/bindings/gpio/intel,gpio.yaml
+++ b/dts/bindings/gpio/intel,gpio.yaml
@@ -5,26 +5,24 @@ description: Intel GPIO node
 
 compatible: "intel,gpio"
 
-include: [gpio-controller.yaml, base.yaml]
+include: [acpi.yaml, gpio-controller.yaml, base.yaml]
 
 properties:
   reg:
-    required: true
+    description: reg properties not required if acpi enumerated
 
   group-index:
     type: int
     description: Group number for this GPIO entry
 
   interrupts:
-    required: true
+    description: interrupts properties not required if acpi enumerated
 
   ngpios:
-    required: true
     description: Number of pins for this GPIO entry
 
   pin-offset:
     type: int
-    required: true
     description: Pin offset of this GPIO entry
 
   "#gpio-cells":

--- a/dts/x86/intel/alder_lake.dtsi
+++ b/dts/x86/intel/alder_lake.dtsi
@@ -9,6 +9,7 @@
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/pcie/pcie.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
+#include "gpio_common.dtsi"
 
 / {
 	cpus {
@@ -43,6 +44,92 @@
 		interrupt-controller;
 		#interrupt-cells = <3>;
 		#address-cells = <1>;
+	};
+
+	acpi {
+		gpio_a: gpio_a {
+			acpi-hid = "INTC1057";
+			acpi-uid = "2";
+			group-index = <0x02>;
+			status = "okay";
+		};
+
+		gpio_b: gpio_b {
+			acpi-hid = "INTC1057";
+			acpi-uid = "0";
+			group-index = <0x0>;
+			status = "okay";
+		};
+
+		gpio_c: gpio_c {
+			acpi-hid = "INTC1057";
+			acpi-uid = "0";
+			group-index = <0x0B>;
+			status = "okay";
+		};
+
+		gpio_d: gpio_d {
+			acpi-hid = "INTC1057";
+			acpi-uid = "0";
+			group-index = <0x8>;
+			status = "okay";
+		};
+
+		gpio_e: gpio_e {
+			acpi-hid = "INTC1057";
+			acpi-uid = "0";
+			group-index = <0xE>;
+			status = "okay";
+		};
+
+		gpio_f: gpio_f {
+			acpi-hid = "INTC1057";
+			acpi-uid = "0";
+			group-index = <0xC>;
+			status = "okay";
+		};
+
+		gpio_h: gpio_h {
+			acpi-hid = "INTC1057";
+			acpi-uid = "0";
+			group-index = <0x7>;
+			status = "okay";
+		};
+
+		gpio_i: gpio_i {
+			acpi-hid = "INTC1057";
+			acpi-uid = "0";
+			group-index = <0x9>;
+			status = "okay";
+		};
+
+		gpio_s: gpio_s {
+			acpi-hid = "INTC1057";
+			acpi-uid = "0";
+			group-index = <0x6>;
+			status = "okay";
+		};
+
+		gpio_r: gpio_r {
+			acpi-hid = "INTC1057";
+			acpi-uid = "0";
+			group-index = <0x3>;
+			status = "okay";
+		};
+
+		gpio_t: gpio_t {
+			acpi-hid = "INTC1057";
+			acpi-uid = "0";
+			group-index = <0x1>;
+			status = "okay";
+		};
+
+		gpio_v: gpio_v {
+			acpi-hid = "INTC1057";
+			acpi-uid = "0";
+			group-index = <0xA>;
+			status = "okay";
+		};
 	};
 
 	pcie0: pcie0 {
@@ -207,7 +294,7 @@
 			pw,cs-mode = <0>;
 			pw,cs-output = <0>;
 			pw,fifo-depth = <64>;
-			cs-gpios = <&gpio_4_e 10 GPIO_ACTIVE_LOW>;
+			cs-gpios = <&gpio_e 10 GPIO_ACTIVE_LOW>;
 			clock-frequency = <100000000>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
@@ -223,7 +310,7 @@
 			pw,cs-mode = <0>;
 			pw,cs-output = <0>;
 			pw,fifo-depth = <64>;
-			cs-gpios = <&gpio_4_f 16 GPIO_ACTIVE_LOW>;
+			cs-gpios = <&gpio_f 16 GPIO_ACTIVE_LOW>;
 			clock-frequency = <100000000>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
@@ -239,7 +326,7 @@
 			pw,cs-mode = <0>;
 			pw,cs-output = <0>;
 			pw,fifo-depth = <64>;
-			cs-gpios = <&gpio_1_d 9 GPIO_ACTIVE_LOW>;
+			cs-gpios = <&gpio_d 9 GPIO_ACTIVE_LOW>;
 			clock-frequency = <100000000>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
@@ -289,167 +376,6 @@
 			interrupts = <4 IRQ_TYPE_LOWEST_EDGE_RISING 3>;
 			interrupt-parent = <&intc>;
 			reg-shift = <0>;
-			status = "okay";
-		};
-
-		gpio_0_b: gpio@fd6e0700 {
-			compatible = "intel,gpio";
-			reg = <0xfd6e0700 0x1000>;
-			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
-			interrupt-parent = <&intc>;
-
-			group-index = <0x0>;
-			gpio-controller;
-			#gpio-cells = <2>;
-
-			ngpios = <24>;
-			pin-offset = <0>;
-
-			status = "okay";
-		};
-
-		gpio_0_a: gpio@fd6e09a0 {
-			compatible = "intel,gpio";
-			reg = <0xfd6e09a0 0x1000>;
-			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
-			interrupt-parent = <&intc>;
-
-			group-index = <0x2>;
-			gpio-controller;
-			#gpio-cells = <2>;
-
-			ngpios = <24>;
-			pin-offset = <41>;
-
-			status = "okay";
-		};
-
-		gpio_1_s: gpio@fd6d0700 {
-			compatible = "intel,gpio";
-			reg = <0xfd6d0700 0x1000>;
-			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
-			interrupt-parent = <&intc>;
-
-			group-index = <0x0>;
-			gpio-controller;
-			#gpio-cells = <2>;
-
-			ngpios = <8>;
-			pin-offset = <0>;
-
-			status = "okay";
-		};
-
-		gpio_1_i: gpio@fd6d0780 {
-			compatible = "intel,gpio";
-			reg = <0xfd6d0780 0x1000>;
-			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
-			interrupt-parent = <&intc>;
-
-			group-index = <0x1>;
-			gpio-controller;
-			#gpio-cells = <2>;
-
-			ngpios = <19>;
-			pin-offset = <8>;
-
-			status = "okay";
-		};
-
-
-		gpio_1_h: gpio@fd6d08c0 {
-			compatible = "intel,gpio";
-			reg = <0xfd6d08c0 0x1000>;
-			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
-			interrupt-parent = <&intc>;
-
-			group-index = <0x2>;
-			gpio-controller;
-			#gpio-cells = <2>;
-
-			ngpios = <24>;
-			pin-offset = <25>;
-
-			status = "okay";
-		};
-
-		gpio_1_d: gpio@fd6d0a40 {
-			compatible = "intel,gpio";
-			reg = <0xfd6d0a40 0x1000>;
-			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
-			interrupt-parent = <&intc>;
-
-			group-index = <0x3>;
-			gpio-controller;
-			#gpio-cells = <2>;
-
-			ngpios = <20>;
-			pin-offset = <49>;
-
-			status = "okay";
-		};
-
-		gpio_4_c: gpio@fd6a0700 {
-			compatible = "intel,gpio";
-			reg = <0xfd6a0700 0x1000>;
-			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
-			interrupt-parent = <&intc>;
-
-			group-index = <0x0>;
-			gpio-controller;
-			#gpio-cells = <2>;
-
-			ngpios = <8>;
-			pin-offset = <0>;
-
-			status = "okay";
-		};
-
-		gpio_4_f: gpio@fd6a0880 {
-			compatible = "intel,gpio";
-			reg = <0xfd6a0880 0x1000>;
-			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
-			interrupt-parent = <&intc>;
-
-			group-index = <0x1>;
-			gpio-controller;
-			#gpio-cells = <2>;
-
-			ngpios = <24>;
-			pin-offset = <24>;
-
-			status = "okay";
-		};
-
-		gpio_4_e: gpio@fd6a0a70 {
-			compatible = "intel,gpio";
-			reg = <0xfd6a0a70 0x1000>;
-			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
-			interrupt-parent = <&intc>;
-
-			group-index = <0x3>;
-			gpio-controller;
-			#gpio-cells = <2>;
-
-			ngpios = <24>;
-			pin-offset = <57>;
-
-			status = "okay";
-		};
-
-		gpio_5_r: gpio@fd690700 {
-			compatible = "intel,gpio";
-			reg = <0xfd690700 0x1000>;
-			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
-			interrupt-parent = <&intc>;
-
-			group-index = <0x0>;
-			gpio-controller;
-			#gpio-cells = <2>;
-
-			ngpios = <8>;
-			pin-offset = <0>;
-
 			status = "okay";
 		};
 

--- a/dts/x86/intel/gpio_common.dtsi
+++ b/dts/x86/intel/gpio_common.dtsi
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "skeleton.dtsi"
+#include <zephyr/dt-bindings/interrupt-controller/intel-ioapic.h>
+#include <zephyr/dt-bindings/acpi/acpi.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
+/ {
+	acpi {
+		gpio_a: gpio_a {
+			compatible = "intel,gpio";
+			interrupt-parent = <&intc>;
+			interrupts = <ACPI_IRQ_DETECT ACPI_IRQ_FLAG_DETECT 3>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			status = "disabled";
+		};
+
+		gpio_b: gpio_b {
+			compatible = "intel,gpio";
+			interrupt-parent = <&intc>;
+			interrupts = <ACPI_IRQ_DETECT ACPI_IRQ_FLAG_DETECT 3>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			status = "disabled";
+		};
+
+		gpio_c: gpio_c {
+			compatible = "intel,gpio";
+			interrupt-parent = <&intc>;
+			interrupts = <ACPI_IRQ_DETECT ACPI_IRQ_FLAG_DETECT 3>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			status = "disabled";
+		};
+
+		gpio_d: gpio_d {
+			compatible = "intel,gpio";
+			interrupt-parent = <&intc>;
+			interrupts = <ACPI_IRQ_DETECT ACPI_IRQ_FLAG_DETECT 3>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			status = "disabled";
+		};
+
+		gpio_e: gpio_e {
+			compatible = "intel,gpio";
+			interrupt-parent = <&intc>;
+			interrupts = <ACPI_IRQ_DETECT ACPI_IRQ_FLAG_DETECT 3>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			status = "disabled";
+		};
+
+		gpio_f: gpio_f {
+			compatible = "intel,gpio";
+			interrupt-parent = <&intc>;
+			interrupts = <ACPI_IRQ_DETECT ACPI_IRQ_FLAG_DETECT 3>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			status = "disabled";
+		};
+
+		gpio_g: gpio_g {
+			compatible = "intel,gpio";
+			interrupt-parent = <&intc>;
+			interrupts = <ACPI_IRQ_DETECT ACPI_IRQ_FLAG_DETECT 3>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			status = "disabled";
+		};
+
+		gpio_h: gpio_h {
+			compatible = "intel,gpio";
+			interrupt-parent = <&intc>;
+			interrupts = <ACPI_IRQ_DETECT ACPI_IRQ_FLAG_DETECT 3>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			status = "disabled";
+		};
+
+		gpio_i: gpio_i {
+			compatible = "intel,gpio";
+			interrupt-parent = <&intc>;
+			interrupts = <ACPI_IRQ_DETECT ACPI_IRQ_FLAG_DETECT 3>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			status = "disabled";
+		};
+
+		gpio_j: gpio_j {
+			compatible = "intel,gpio";
+			interrupt-parent = <&intc>;
+			interrupts = <ACPI_IRQ_DETECT ACPI_IRQ_FLAG_DETECT 3>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			status = "disabled";
+		};
+
+		gpio_k: gpio_k {
+			compatible = "intel,gpio";
+			interrupt-parent = <&intc>;
+			interrupts = <ACPI_IRQ_DETECT ACPI_IRQ_FLAG_DETECT 3>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			status = "disabled";
+		};
+
+		gpio_s: gpio_s {
+			compatible = "intel,gpio";
+			interrupt-parent = <&intc>;
+			interrupts = <ACPI_IRQ_DETECT ACPI_IRQ_FLAG_DETECT 3>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			status = "disabled";
+		};
+
+		gpio_r: gpio_r {
+			compatible = "intel,gpio";
+			interrupt-parent = <&intc>;
+			interrupts = <ACPI_IRQ_DETECT ACPI_IRQ_FLAG_DETECT 3>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			status = "disabled";
+		};
+
+		gpio_t: gpio_t {
+			compatible = "intel,gpio";
+			interrupt-parent = <&intc>;
+			interrupts = <ACPI_IRQ_DETECT ACPI_IRQ_FLAG_DETECT 3>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			status = "disabled";
+		};
+
+		gpio_u: gpio_u {
+			compatible = "intel,gpio";
+			interrupt-parent = <&intc>;
+			interrupts = <ACPI_IRQ_DETECT ACPI_IRQ_FLAG_DETECT 3>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			status = "disabled";
+		};
+
+		vgpio: vgpio {
+			compatible = "intel,gpio";
+			interrupt-parent = <&intc>;
+			interrupts = <ACPI_IRQ_DETECT ACPI_IRQ_FLAG_DETECT 3>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			status = "disabled";
+		};
+	};
+};

--- a/include/zephyr/drivers/gpio/gpio_intel.h
+++ b/include/zephyr/drivers/gpio/gpio_intel.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2023 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+struct gpio_acpi_res {
+	uint8_t num_pins;
+	uint32_t pad_base;
+	uint32_t host_owner_reg;
+	uint32_t pad_owner_reg;
+	uint32_t intr_stat_reg;
+	uint16_t base_num;
+	uintptr_t reg_base;
+};

--- a/include/zephyr/dt-bindings/acpi/acpi.h
+++ b/include/zephyr/dt-bindings/acpi/acpi.h
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define ACPI_IRQ_DETECT 0xFFFFFFFU
+#define ACPI_IRQ_FLAG_DETECT 0xFFFFFFFU

--- a/soc/intel/alder_lake/CMakeLists.txt
+++ b/soc/intel/alder_lake/CMakeLists.txt
@@ -8,5 +8,6 @@ zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 zephyr_cc_option(-march=goldmont)
 
 zephyr_library_sources(cpu.c)
+zephyr_library_sources(../common/soc_gpio.c)
 
 set(SOC_LINKER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld CACHE INTERNAL "")

--- a/soc/intel/alder_lake/soc.h
+++ b/soc/intel/alder_lake/soc.h
@@ -23,6 +23,10 @@
 #include <zephyr/random/random.h>
 #endif
 
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(acpi_hid)
+#include "../common/soc_gpio.h"
+#endif
+
 #ifdef CONFIG_GPIO_INTEL
 #include "soc_gpio.h"
 #endif

--- a/soc/intel/common/soc_gpio.c
+++ b/soc/intel/common/soc_gpio.c
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2023 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <errno.h>
+#include <zephyr/acpi/acpi.h>
+#include "soc.h"
+#include "soc_gpio.h"
+
+#define GET_GPIO_BASE_NUM ("\\_SB.GINF")
+
+static int gpio_info_acpi_get(uint32_t bank_idx, uint32_t field_idx, uint32_t *ret_val)
+{
+	int status;
+	ACPI_OBJECT args[2];
+	ACPI_OBJECT_LIST arg_list;
+	ACPI_OBJECT gpio_obj;
+
+	arg_list.Count = ARRAY_SIZE(args);
+	arg_list.Pointer = args;
+
+	args[0].Type = ACPI_TYPE_INTEGER;
+	args[0].Integer.Value = bank_idx;
+
+	args[1].Type = ACPI_TYPE_INTEGER;
+	args[1].Integer.Value = field_idx;
+
+	status = acpi_invoke_method(GET_GPIO_BASE_NUM, &arg_list, &gpio_obj);
+	if (status) {
+		return status;
+	}
+
+	if (gpio_obj.Type == ACPI_TYPE_INTEGER) {
+		*ret_val = gpio_obj.Integer.Value;
+	}
+
+	return status;
+}
+
+int soc_acpi_gpio_resource_get(int bank_idx, char *hid, char *uid, struct gpio_acpi_res *res)
+{
+	int ret;
+	struct acpi_dev *acpi_child;
+	struct acpi_irq_resource irq_res;
+	struct acpi_mmio_resource mmio_res;
+	uint32_t field_val[7];
+	uint16_t irqs[CONFIG_ACPI_IRQ_VECTOR_MAX];
+	struct acpi_reg_base reg_base[CONFIG_ACPI_MMIO_ENTRIES_MAX];
+
+	acpi_child = acpi_device_get(hid, uid);
+	if (!acpi_child) {
+		printk("acpi_device_get failed\n");
+		return -EIO;
+	}
+
+	mmio_res.mmio_max = ARRAY_SIZE(reg_base);
+	mmio_res.reg_base = reg_base;
+	ret = acpi_device_mmio_get(acpi_child, &mmio_res);
+	if (ret) {
+		printk("acpi_device_mmio_get failed\n");
+		return ret;
+	}
+
+	irq_res.irq_vector_max = ARRAY_SIZE(irqs);
+	irq_res.irqs = irqs;
+	ret = acpi_device_irq_get(acpi_child, &irq_res);
+	if (ret) {
+		printk("acpi_device_irq_get failed\n");
+		return ret;
+	}
+
+	res->irq = irq_res.irqs[0];
+	res->irq_flags = irq_res.flags;
+
+	if (ACPI_RESOURCE_TYPE_GET(&mmio_res) == ACPI_RES_TYPE_MEM) {
+		for (int i = 0; i < ARRAY_SIZE(field_val); i++) {
+			ret = gpio_info_acpi_get(bank_idx, i, &field_val[i]);
+			if (ret) {
+				printk("gpio_info_acpi_get failed\n");
+				return ret;
+			}
+		}
+
+		res->reg_base = ACPI_MMIO_GET(&mmio_res) & (~0x0FFFFFF);
+		res->reg_base += field_val[0];
+		res->len = ACPI_RESOURCE_SIZE_GET(&mmio_res);
+		res->num_pins = field_val[1];
+		res->pad_base = field_val[2];
+		res->host_owner_reg = field_val[3];
+		res->pad_owner_reg = field_val[4];
+		res->intr_stat_reg = field_val[5] - 0x40;
+		res->base_num = field_val[6];
+	} else {
+		printk("ACPI_RES_TYPE_MEM failed\n");
+		return -ENODEV;
+	}
+
+	return 0;
+}

--- a/soc/intel/common/soc_gpio.h
+++ b/soc/intel/common/soc_gpio.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+struct gpio_acpi_res {
+	uintptr_t reg_base;
+	uint32_t len;
+	uint32_t pad_base;
+	uint8_t num_pins;
+	uint32_t host_owner_reg;
+	uint32_t pad_owner_reg;
+	uint32_t intr_stat_reg;
+	uint16_t base_num;
+	uint16_t irq;
+	uint32_t irq_flags;
+};
+
+/**
+ * @brief Retrieve current resource settings of a gpio device from acpi.
+ *
+ * @param bank_idx band index of the gpio group (eg: gpp_a, gpp_b etc.)
+ * @param hid the hardware id of the acpi device
+ * @param uid the unique id of the acpi device
+ * @param res the pointer to resource struct on which data return
+ * @return return 0 on success or error code
+ */
+int soc_acpi_gpio_resource_get(int bank_idx, char *hid, char *uid, struct gpio_acpi_res *res);

--- a/soc/intel/raptor_lake/CMakeLists.txt
+++ b/soc/intel/raptor_lake/CMakeLists.txt
@@ -3,5 +3,6 @@
 zephyr_include_directories(.)
 
 zephyr_cc_option(-march=goldmont)
+zephyr_library_sources(../common/soc_gpio.c)
 
 set(SOC_LINKER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld CACHE INTERNAL "")

--- a/soc/intel/raptor_lake/soc.h
+++ b/soc/intel/raptor_lake/soc.h
@@ -21,6 +21,10 @@
 #include <zephyr/random/random.h>
 #endif
 
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(acpi_hid)
+#include "../common/soc_gpio.h"
+#endif
+
 #ifdef CONFIG_GPIO_INTEL
 #include "soc_gpio.h"
 #endif

--- a/tests/drivers/gpio/gpio_basic_api/boards/intel_adl_crb.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/intel_adl_crb.overlay
@@ -16,7 +16,7 @@
 	resources {
 		compatible = "test-gpio-basic-api";
 
-		out-gpios = <&gpio_0_b 14 0>;
-		in-gpios  = <&gpio_0_b 15 0>;
+		out-gpios = <&gpio_b 14 0>;
+		in-gpios  = <&gpio_b 15 0>;
 	};
 };


### PR DESCRIPTION
Add acpi resource enumeration support such as retrieve MMIO and IRQ via ACPI instead of DTS for Intel GPIO driver