### PR TITLE
drivers: espi: npcx: update for espi reset level

### DIFF
--- a/drivers/espi/espi_npcx.c
+++ b/drivers/espi/espi_npcx.c
@@ -38,7 +38,7 @@ struct espi_npcx_config {
 struct espi_npcx_data {
 	sys_slist_t callbacks;
 	uint8_t plt_rst_asserted;
-	uint8_t espi_rst_asserted;
+	uint8_t espi_rst_level;
 	uint8_t sx_state;
 #if defined(CONFIG_ESPI_OOB_CHANNEL)
 	struct k_sem oob_rx_lock;
@@ -611,11 +611,11 @@ static void espi_vw_espi_rst_isr(const struct device *dev, struct npcx_wui *wui)
 	struct espi_npcx_data *const data = dev->data;
 	struct espi_event evt = { ESPI_BUS_RESET, 0, 0 };
 
-	data->espi_rst_asserted = !IS_BIT_SET(inst->ESPISTS,
-						NPCX_ESPISTS_ESPIRST_LVL);
-	LOG_DBG("eSPI RST asserted is %d!", data->espi_rst_asserted);
+	data->espi_rst_level = IS_BIT_SET(inst->ESPISTS,
+					  NPCX_ESPISTS_ESPIRST_LVL);
+	LOG_DBG("eSPI RST level is %d!", data->espi_rst_level);
 
-	evt.evt_data = data->espi_rst_asserted;
+	evt.evt_data = data->espi_rst_level;
 	espi_send_callbacks(&data->callbacks, dev, evt);
 }
 

--- a/drivers/espi/host_subs_npcx.c
+++ b/drivers/espi/host_subs_npcx.c
@@ -147,7 +147,7 @@ struct host_sub_npcx_config {
 struct host_sub_npcx_data {
 	sys_slist_t *callbacks; /* pointer on the espi callback list */
 	uint8_t plt_rst_asserted; /* current PLT_RST# status */
-	uint8_t espi_rst_asserted; /* current ESPI_RST# status */
+	uint8_t espi_rst_level; /* current ESPI_RST# status */
 	const struct device *host_bus_dev; /* device for eSPI/LPC bus */
 #ifdef CONFIG_ESPI_NPCX_PERIPHERAL_DEBUG_PORT_80_MULTI_BYTE
 	struct ring_buf port80_ring_buf;


### PR DESCRIPTION
This CL updates the event data returned by eSPI reset ISR.  
The event data is indicated the state of eSPIRST.  
The 0 means eSPI bus in reset, and 1 means eSPI bus out-of-reset.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/68557