### PR TITLE
Hotfix driver display gc9x01x

### DIFF
--- a/drivers/display/display_gc9x01x.c
+++ b/drivers/display/display_gc9x01x.c
@@ -8,7 +8,7 @@
 
 #include "display_gc9x01x.h"
 
-#include <zephyr/dt-bindings/display/gc9x01x.h>
+#include <zephyr/dt-bindings/display/panel.h>
 #include <zephyr/drivers/display.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/spi.h>

--- a/dts/bindings/display/galaxycore,gc9x01x.yaml
+++ b/dts/bindings/display/galaxycore,gc9x01x.yaml
@@ -21,10 +21,8 @@ description: |
       cmd-data-gpios = <&gpio0 4 GPIO_ACTIVE_HIGH>;
       reset-gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
       pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
-
       width = <240>;
       height = <240>;
-      pixel-format = <GC9X01X_PIXEL_FORMAT_RGB565>;
     };
   };
 


### PR DESCRIPTION
The purpose of this Pull Request is to fix GC9X01X driver:
- documentation with a duplicated entry
- an include not properly done and not checked during the integration of this driver few weeks ago

@fabiobaltieri here it is the most important fix from my board PR for 3.6.0-rc1 :)