### PR TITLE
drivers: input: cst816s: add alternative chip id

### DIFF
--- a/drivers/input/input_cst816s.c
+++ b/drivers/input/input_cst816s.c
@@ -14,7 +14,8 @@
 
 LOG_MODULE_REGISTER(cst816s, CONFIG_INPUT_LOG_LEVEL);
 
-#define CST816S_CHIP_ID 0xB4
+#define CST816S_CHIP_ID1 0xB4
+#define CST816S_CHIP_ID2 0xB5
 
 #define CST816S_REG_DATA                0x00
 #define CST816S_REG_GESTURE_ID          0x01
@@ -202,7 +203,7 @@ static int cst816s_chip_init(const struct device *dev)
 		return ret;
 	}
 
-	if (chip_id != CST816S_CHIP_ID) {
+	if ((chip_id != CST816S_CHIP_ID1) && (chip_id != CST816S_CHIP_ID2)) {
 		LOG_ERR("CST816S wrong chip id: returned 0x%x", chip_id);
 		return -ENODEV;
 	}


### PR DESCRIPTION
The CST816S chip ID have an alternative value. It seems that this field represents in fact a version number of controller. Fix by adding the new chip ID.

This is required for the integration of the board at https://github.com/zephyrproject-rtos/zephyr/pull/67311