### PR TITLE
tests: bsim: bluetooth: mesh: Advertiser suspend test

### DIFF
--- a/subsys/bluetooth/mesh/adv.c
+++ b/subsys/bluetooth/mesh/adv.c
@@ -257,6 +257,10 @@ void bt_mesh_adv_send(struct bt_mesh_adv *adv, const struct bt_mesh_send_cb *cb,
 	LOG_DBG("type 0x%02x len %u: %s", adv->ctx.type, adv->b.len,
 		bt_hex(adv->b.data, adv->b.len));
 
+	if (atomic_test_bit(bt_mesh.flags, BT_MESH_SUSPENDED)) {
+		LOG_WRN("Sending advertisement while suspended");
+	}
+
 	adv->ctx.cb = cb;
 	adv->ctx.cb_data = cb_data;
 	adv->ctx.busy = 1U;

--- a/tests/bsim/bluetooth/mesh/CMakeLists.txt
+++ b/tests/bsim/bluetooth/mesh/CMakeLists.txt
@@ -52,6 +52,7 @@ elseif(CONFIG_BT_CTLR_LOW_LAT)
   src/test_friendship.c
   src/test_transport.c
   src/test_suspend.c
+  src/test_advertiser.c
  )
 
 else()

--- a/tests/bsim/bluetooth/mesh/src/main.c
+++ b/tests/bsim/bluetooth/mesh/src/main.c
@@ -26,6 +26,7 @@ extern struct bst_test_list *test_beacon_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_transport_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_friendship_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_suspend_install(struct bst_test_list *test);
+extern struct bst_test_list *test_adv_install(struct bst_test_list *test);
 #else
 extern struct bst_test_list *test_transport_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_friendship_install(struct bst_test_list *tests);
@@ -63,6 +64,7 @@ bst_test_install_t test_installers[] = {
 	test_transport_install,
 	test_friendship_install,
 	test_suspend_install,
+	test_adv_install,
 #else
 	test_transport_install,
 	test_friendship_install,

--- a/tests/bsim/bluetooth/mesh/src/mesh_test.c
+++ b/tests/bsim/bluetooth/mesh/src/mesh_test.c
@@ -575,7 +575,7 @@ int bt_mesh_test_wait_for_packet(bt_le_scan_cb_t scan_cb, struct k_sem *observer
 	err = k_sem_take(observer_sem, K_SECONDS(wait));
 	if (err == -EAGAIN) {
 		LOG_WRN("Taking sem timed out (err %d)", err);
-		returned_value = -EAGAIN;
+		returned_value = -ETIMEDOUT;
 	} else if (err) {
 		LOG_ERR("Taking sem failed (err %d)", err);
 		return err;

--- a/tests/bsim/bluetooth/mesh/src/test_suspend.c
+++ b/tests/bsim/bluetooth/mesh/src/test_suspend.c
@@ -429,7 +429,7 @@ static void test_tester_gatt(void)
 	ASSERT_EQUAL(dut_status, DUT_SUSPENDED);
 	k_sleep(K_MSEC(500));
 	err = bt_mesh_test_wait_for_packet(gatt_scan_cb, &publish_sem, 10);
-	ASSERT_FALSE(err && err != -EAGAIN);
+	ASSERT_FALSE(err && err != -ETIMEDOUT);
 
 	/* Wait for DUT to resume Mesh and notify Tester, then scan for gatt proxy beacons */
 	ASSERT_OK(bt_mesh_test_wait_for_packet(suspend_state_change_cb, &publish_sem, 20));

--- a/tests/bsim/bluetooth/mesh/tests_scripts/advertiser/disable.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/advertiser/disable.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Copyright 2024 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
+
+# The test checks that both advertisers, the legacy and the extended, behave identically.
+# In particular:
+# - `bt_mesh_send_cb.end` callback with error code `0` is called for the advertisement that the
+#   advertiser already pushed to the ble host (called `bt_mesh_send_cb.start`),
+# - `bt_mesh_send_cb.start` callback with error `-ENODEV` is called for every advertisement that
+#   was pushed to the mesh advertiser using `bt_mesh_adv_send` function,
+# - `bt_mesh_adv_create` returns NULL when attempting to create a new advertisement while the stack
+#   is suspended.
+#
+# Tx device procedure:
+# 1. Tx device creates `CONFIG_BT_MESH_ADV_BUF_COUNT` advertisements, setting the first byte of the
+# PDU to 0xAA and the second byte of the PDU to the advertisement order number
+# 2. Tx devices pushes all created advs to the pool by calling `bt_mesh_adv_send` function
+# 3. When the `bt_mesh_send_cb.start` callback is called for the first adv, the tx device submits
+#    a work item which suspends the advertiser by calling `bt_mesh_adv_disable`.
+# 4. Tx device checks that for the first adv the `bt_mesh_send_cb.end` callback is called with the
+#    error code `0`.
+# 5. Tx device checks that for the consecutive advs the `bt_mesh_send_cb.start` is called with error
+#    `-ENODEV`.
+# 6. Tx device checks that no more advs can be created using `bt_mesh_adv_create` function.
+# 7. Tx device resumes the advertiser and repeats steps 1 and 2.
+# 8. Tx device expects that all advs are sent.
+#
+# Rx device procedure:
+# 1. Rx devices listens all the time while tx device sends advs and ensure that no new advs were
+#    sent after the advertiser was suspended.
+
+RunTest mesh_adv_disable adv_tx_disable adv_rx_disable
+
+# Low latency overlay uses legacy advertiser
+overlay=overlay_low_lat_conf
+RunTest mesh_adv_disable adv_tx_disable adv_rx_disable


### PR DESCRIPTION
Add a test that checks that both advertisers, the legacy and the
extended behaves identically when the stack is suspended, in particular:
- `bt_mesh_send_cb.end` callback is called with error code `0` for the
  advertisement that the advertiser already pushed to the ble host
  (called `bt_mesh_send_cb.start`),
- `bt_mesh_send_cb.start` callback with error `-ENODEV` is called for
  every advertisement that was pushed to the mesh advertiser using
  `bt_mesh_adv_send` function before the stack was suspended,
- `bt_mesh_adv_create` returns NULL when attempting to create a new
  advertisement while the stack is suspended.

The `bt_mesh_adv_disable` is called from the work because calling it
from the `bt_mesh_send_cb.start` callback will cause a deadlock.