### PR TITLE
display: stm32: add ltdc compatible to ignore-priority-check list

### DIFF
--- a/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
+++ b/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
@@ -235,7 +235,7 @@
 		     &ltdc_hsync_pc6 &ltdc_vsync_pa4>;
 	pinctrl-names = "default";
 	ext-sdram = <&sdram2>;
-	display-controller = <&ili9341>;
+	panel-controller = <&ili9341>;
 	status = "okay";
 
 	width = <240>;

--- a/drivers/display/display_stm32_ltdc.c
+++ b/drivers/display/display_stm32_ltdc.c
@@ -75,7 +75,7 @@ struct display_stm32_ltdc_config {
 	struct stm32_pclken pclken;
 	const struct pinctrl_dev_config *pctrl;
 	void (*irq_config_func)(const struct device *dev);
-	const struct device *display_controller;
+	const struct device *panel_controller;
 };
 
 static void stm32_ltdc_global_isr(const struct device *dev)
@@ -250,7 +250,7 @@ static int stm32_ltdc_read(const struct device *dev, const uint16_t x,
 static int stm32_ltdc_display_blanking_off(const struct device *dev)
 {
 	const struct display_stm32_ltdc_config *config = dev->config;
-	const struct device *display_dev = config->display_controller;
+	const struct device *display_dev = config->panel_controller;
 
 	if (display_dev == NULL) {
 		return 0;
@@ -267,13 +267,13 @@ static int stm32_ltdc_display_blanking_off(const struct device *dev)
 static int stm32_ltdc_display_blanking_on(const struct device *dev)
 {
 	const struct display_stm32_ltdc_config *config = dev->config;
-	const struct device *display_dev = config->display_controller;
+	const struct device *display_dev = config->panel_controller;
 
 	if (display_dev == NULL) {
 		return 0;
 	}
 
-	if (!device_is_ready(config->display_controller)) {
+	if (!device_is_ready(config->panel_controller)) {
 		LOG_ERR("Display device %s not ready", display_dev->name);
 		return -ENODEV;
 	}
@@ -607,8 +607,8 @@ static const struct display_driver_api stm32_ltdc_display_api = {
 		},										\
 		.pctrl = STM32_LTDC_DEVICE_PINCTRL_GET(inst),					\
 		.irq_config_func = stm32_ltdc_irq_config_func_##inst,				\
-		.display_controller = DEVICE_DT_GET_OR_NULL(					\
-			DT_INST_PHANDLE(inst, display_controller)),				\
+		.panel_controller = DEVICE_DT_GET_OR_NULL(					\
+			DT_INST_PHANDLE(inst, panel_controller)),				\
 	};											\
 	DEVICE_DT_INST_DEFINE(inst,								\
 			&stm32_ltdc_init,							\

--- a/dts/bindings/display/st,stm32-ltdc.yaml
+++ b/dts/bindings/display/st,stm32-ltdc.yaml
@@ -66,8 +66,8 @@ properties:
     type: int
     description: Last pixel in y direction on layer 0. Defaults to height.
 
-  display-controller:
+  panel-controller:
     type: phandle
     description: |
-      Phandle of the display's controller. When provided, it's used to forward some of the
+      Phandle of the panel's controller. When provided, it's used to forward some of the
       configuration calls (e.g. blanking on/off) sent to LTDC device.

--- a/scripts/build/check_init_priorities.py
+++ b/scripts/build/check_init_priorities.py
@@ -51,6 +51,7 @@ _IGNORE_COMPATIBLES = frozenset([
         # device controller, the logical connection is established after USB
         # device support is enabled.
         "zephyr,cdc-acm-uart",
+        "st,stm32-ltdc",
         ])
 
 class Priority:


### PR DESCRIPTION
Fixes issue #68527.
Also addresses https://github.com/zephyrproject-rtos/zephyr/pull/68105#discussion_r1476504953.