### PR TITLE
arch: arm, arm64: Disable swi_tables.ld file when not required

### DIFF
--- a/arch/arm/core/swi_tables.ld
+++ b/arch/arm/core/swi_tables.ld
@@ -4,5 +4,5 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #if LINKER_ZEPHYR_FINAL && defined(CONFIG_ISR_TABLES_LOCAL_DECLARATION)
-INCLUDE zephyr/isr_tables_swi.ld
+INCLUDE isr_tables_swi.ld
 #endif

--- a/arch/arm/core/swi_tables.ld
+++ b/arch/arm/core/swi_tables.ld
@@ -3,6 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#if LINKER_ZEPHYR_FINAL
+#if LINKER_ZEPHYR_FINAL && defined(CONFIG_ISR_TABLES_LOCAL_DECLARATION)
 INCLUDE zephyr/isr_tables_swi.ld
 #endif

--- a/arch/arm/core/vector_table.ld
+++ b/arch/arm/core/vector_table.ld
@@ -51,7 +51,7 @@ _vector_start = .;
 KEEP(*(.exc_vector_table))
 KEEP(*(".exc_vector_table.*"))
 
-#if LINKER_ZEPHYR_FINAL && CONFIG_ISR_TABLES_LOCAL_DECLARATION
+#if LINKER_ZEPHYR_FINAL && defined(CONFIG_ISR_TABLES_LOCAL_DECLARATION)
 INCLUDE zephyr/isr_tables_vt.ld
 #else
 KEEP(*(.vectors))

--- a/arch/arm/core/vector_table.ld
+++ b/arch/arm/core/vector_table.ld
@@ -52,7 +52,7 @@ KEEP(*(.exc_vector_table))
 KEEP(*(".exc_vector_table.*"))
 
 #if LINKER_ZEPHYR_FINAL && defined(CONFIG_ISR_TABLES_LOCAL_DECLARATION)
-INCLUDE zephyr/isr_tables_vt.ld
+INCLUDE isr_tables_vt.ld
 #else
 KEEP(*(.vectors))
 #endif

--- a/arch/arm64/core/swi_tables.ld
+++ b/arch/arm64/core/swi_tables.ld
@@ -4,5 +4,5 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #if LINKER_ZEPHYR_FINAL && defined(CONFIG_ISR_TABLES_LOCAL_DECLARATION)
-INCLUDE zephyr/isr_tables_swi.ld
+INCLUDE isr_tables_swi.ld
 #endif

--- a/arch/arm64/core/swi_tables.ld
+++ b/arch/arm64/core/swi_tables.ld
@@ -3,6 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#if LINKER_ZEPHYR_FINAL
+#if LINKER_ZEPHYR_FINAL && defined(CONFIG_ISR_TABLES_LOCAL_DECLARATION)
 INCLUDE zephyr/isr_tables_swi.ld
 #endif

--- a/include/zephyr/arch/arm64/scripts/linker.ld
+++ b/include/zephyr/arch/arm64/scripts/linker.ld
@@ -112,7 +112,7 @@ SECTIONS
         KEEP(*(".exc_vector_table.*"))
 
 #if LINKER_ZEPHYR_FINAL && defined(CONFIG_ISR_TABLES_LOCAL_DECLARATION)
-        INCLUDE zephyr/isr_tables_vt.ld
+        INCLUDE isr_tables_vt.ld
 #else
         KEEP(*(.vectors))
 #endif

--- a/include/zephyr/arch/arm64/scripts/linker.ld
+++ b/include/zephyr/arch/arm64/scripts/linker.ld
@@ -111,7 +111,7 @@ SECTIONS
         KEEP(*(.exc_vector_table))
         KEEP(*(".exc_vector_table.*"))
 
-#if LINKER_ZEPHYR_FINAL && CONFIG_ISR_TABLES_LOCAL_DECLARATION
+#if LINKER_ZEPHYR_FINAL && defined(CONFIG_ISR_TABLES_LOCAL_DECLARATION)
         INCLUDE zephyr/isr_tables_vt.ld
 #else
         KEEP(*(.vectors))


### PR DESCRIPTION
This commit removes the need of swi_tables.ld file if the ISR table generator is not configured to use it.

Fixes #68508