### PR TITLE
drivers: rpi_pico_pwm: Fix compilation warnings

### DIFF
--- a/drivers/pwm/pwm_rpi_pico.c
+++ b/drivers/pwm/pwm_rpi_pico.c
@@ -44,7 +44,7 @@ static float pwm_rpi_get_clkdiv(const struct device *dev, int slice)
 
 	/* the divider is a fixed point 8.4 convert to float for use in pico-sdk */
 	return (float)cfg->slice_configs[slice].integral +
-		(float)cfg->slice_configs[slice].frac / 16.0;
+		(float)cfg->slice_configs[slice].frac / 16.0f;
 }
 
 static inline uint32_t pwm_rpi_channel_to_slice(uint32_t channel)


### PR DESCRIPTION
return value of pwm_rpi_get_clkdiv contains implicit conversions from 'float' to 'double', triggered by floating-point operations involving mixed data types.