### PR TITLE
boards: arm: stm32 disco kit has ospi nor flash node

### DIFF
--- a/boards/arm/adi_eval_adin1110ebz/adi_eval_adin1110ebz.dts
+++ b/boards/arm/adi_eval_adin1110ebz/adi_eval_adin1110ebz.dts
@@ -261,11 +261,10 @@ zephyr_udc0: &usbotg_fs {
 
 	status = "okay";
 
-	mx25r6435f: ospi-nor-flash@0 {
+	mx25r6435f: ospi-nor-flash@90000000 {
 		compatible = "st,stm32-ospi-nor";
-		reg = <0>;
+		reg = <0x90000000 DT_SIZE_M(8)>; /* 64 Megabits */
 		ospi-max-frequency = <DT_FREQ_M(26)>; /* for Voltage Range 2 */
-		size = <DT_SIZE_M(64)>; /* 64 Megabits */
 		spi-bus-width = <OSPI_QUAD_MODE>;
 		data-rate = <OSPI_STR_TRANSFER>;
 		writeoc="PP_1_4_4";

--- a/boards/arm/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
+++ b/boards/arm/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
@@ -251,11 +251,10 @@ zephyr_udc0: &usbotg_fs {
 
 	status = "okay";
 
-	mx25r6435f: ospi-nor-flash@0 {
+	mx25r6435f: ospi-nor-flash@90000000 {
 		compatible = "st,stm32-ospi-nor";
-		reg = <0>;
+		reg = <0x90000000 DT_SIZE_M(8)>; /* 64 Megabits */
 		ospi-max-frequency = <DT_FREQ_M(26)>; /* for Voltage Range 2 */
-		size = <DT_SIZE_M(64)>; /* 64 Megabits */
 		spi-bus-width = <OSPI_QUAD_MODE>;
 		data-rate = <OSPI_STR_TRANSFER>;
 		writeoc="PP_1_4_4";

--- a/boards/arm/stm32h573i_dk/stm32h573i_dk.dts
+++ b/boards/arm/stm32h573i_dk/stm32h573i_dk.dts
@@ -239,11 +239,10 @@
 
 	status = "okay";
 
-	mx25lm51245: ospi-nor-flash@0 {
+	mx25lm51245: ospi-nor-flash@90000000 {
 		compatible = "st,stm32-ospi-nor";
-		reg = <0>;
+		reg = <0x90000000 DT_SIZE_M(64)>; /* 512 Mbits */
 		ospi-max-frequency = <DT_FREQ_M(50)>;
-		size = <DT_SIZE_M(512)>; /* 64 MBytes */
 		spi-bus-width = <OSPI_OPI_MODE>;
 		data-rate = <OSPI_DTR_TRANSFER>;
 		four-byte-opcodes;

--- a/boards/arm/stm32h735g_disco/stm32h735g_disco.dts
+++ b/boards/arm/stm32h735g_disco/stm32h735g_disco.dts
@@ -165,11 +165,10 @@
 
 	status = "okay";
 
-	mx25lm51245: ospi-nor-flash@0 {
+	mx25lm51245: ospi-nor-flash@90000000 {
 		compatible = "st,stm32-ospi-nor";
-		reg = <0>;
+		reg = <0x90000000 DT_SIZE_M(64)>; /* 512 Mbits */
 		ospi-max-frequency = <DT_FREQ_M(50)>;
-		size = <DT_SIZE_M(512)>; /* 64 MBytes */
 		spi-bus-width = <OSPI_OPI_MODE>;
 		data-rate = <OSPI_DTR_TRANSFER>;
 		status = "okay";

--- a/boards/arm/stm32h750b_dk/stm32h750b_dk.dts
+++ b/boards/arm/stm32h750b_dk/stm32h750b_dk.dts
@@ -124,7 +124,6 @@
 		compatible = "st,stm32-qspi-nor";
 		reg = <0x90000000 DT_SIZE_M(64)>; /* 512 Mbits */
 		qspi-max-frequency = <72000000>;
-		size = <DT_SIZE_M(512)>; /* 64 MBytes */
 		status = "okay";
 	};
 };

--- a/boards/arm/stm32h7b3i_dk/stm32h7b3i_dk.dts
+++ b/boards/arm/stm32h7b3i_dk/stm32h7b3i_dk.dts
@@ -253,11 +253,10 @@
 
 	status = "okay";
 
-	mx25lm51245: ospi-nor-flash@0 {
+	mx25lm51245: ospi-nor-flash@90000000 {
 		compatible = "st,stm32-ospi-nor";
-		reg = <0>;
+		reg = <0x90000000 DT_SIZE_M(64)>; /* 512 Mbits */
 		ospi-max-frequency = <DT_FREQ_M(50)>;
-		size = <DT_SIZE_M(512)>; /* 512 Megabits */
 		spi-bus-width = <OSPI_OPI_MODE>;
 		data-rate = <OSPI_DTR_TRANSFER>;
 		status = "okay";

--- a/boards/arm/stm32l4r9i_disco/stm32l4r9i_disco.dts
+++ b/boards/arm/stm32l4r9i_disco/stm32l4r9i_disco.dts
@@ -224,12 +224,11 @@ zephyr_udc0: &usbotg_fs {
 			&octospim_p2_dqs_pg15>;
 	pinctrl-names = "default";
 
-	mx25lm51245: ospi-nor-flash@0 {
+	mx25lm51245: ospi-nor-flash@90000000 {
 		status = "okay";
 		compatible = "st,stm32-ospi-nor";
-		reg = <0>;
+		reg = <0x90000000 DT_SIZE_M(64)>; /* 512 Mbits */
 		ospi-max-frequency = <DT_FREQ_M(25)>;
-		size = <DT_SIZE_M(512)>; /* 512 Mbits = 64 MBytes */
 		spi-bus-width = <OSPI_OPI_MODE>;
 		data-rate = <OSPI_STR_TRANSFER>;
 		four-byte-opcodes;


### PR DESCRIPTION
Define the reg and size property for the stm32 disco kits which have an octospi instance
Completing the list of boards modified by the https://github.com/zephyrproject-rtos/zephyr/pull/68274
Refer to the dts/bindings/flash_controller/st,stm32-ospi-nor.yaml. 



Fixes https://github.com/zephyrproject-rtos/zephyr/issues/68479