### PR TITLE
Bluetooth: Mesh: Reset solicitation settings before calling reset cb

### DIFF
--- a/subsys/bluetooth/mesh/main.c
+++ b/subsys/bluetooth/mesh/main.c
@@ -401,16 +401,16 @@ void bt_mesh_reset(void)
 
 	bt_mesh_comp_unprovision();
 
+	if (IS_ENABLED(CONFIG_BT_MESH_PROXY_SOLICITATION)) {
+		bt_mesh_sol_reset();
+	}
+
 	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
 		bt_mesh_settings_store_pending();
 	}
 
 	if (IS_ENABLED(CONFIG_BT_MESH_PROV)) {
 		bt_mesh_prov_reset();
-	}
-
-	if (IS_ENABLED(CONFIG_BT_MESH_PROXY_SOLICITATION)) {
-		bt_mesh_sol_reset();
 	}
 }
 


### PR DESCRIPTION
Trigger erasing solicitation settings before calling `bt_mesh_settings_store_pending` and `bt_mesh_prov.reset` callback. The `bt_mesh_settings_store_pending` flushes every settings that is pending to be erased. The `bt_mesh_prov.reset` callback must be called as the last step because a user is free to do anything from this callback including rebooting or reprovisioning the device.