### PR TITLE
samples: usb: set UAC2 explicit feedback sample harness to TBD

### DIFF
--- a/samples/subsys/usb/uac2_explicit_feedback/sample.yaml
+++ b/samples/subsys/usb/uac2_explicit_feedback/sample.yaml
@@ -2,5 +2,9 @@ sample:
   name: USB Audio 2 asynchronous explicit feedback sample
 tests:
   sample.subsys.usb.uac2_explicit_feedback:
+    depends_on:
+      - usb_device
+      - i2s
     tags: usb i2s
     platform_allow: nrf5340dk_nrf5340_cpuapp
+    harness: TBD


### PR DESCRIPTION
UAC2 explicit feedback sample currently fails twister device testing with timeout. It is not really clear what twister expects to see on the serial output when running the sample. Because there is no meaningful way of testing USB <-> I2S communication, mark the sample with TBD harness to silence the timeout.