### PR TITLE
samples/sensor: lsm6dsl: fix -Wdouble-promotion warning

### DIFF
--- a/samples/sensor/lsm6dsl/src/main.c
+++ b/samples/sensor/lsm6dsl/src/main.c
@@ -10,11 +10,6 @@
 #include <stdio.h>
 #include <zephyr/sys/util.h>
 
-static inline float out_ev(struct sensor_value *val)
-{
-	return (val->val1 + (float)val->val2 / 1000000);
-}
-
 static int print_samples;
 static int lsm6dsl_trig_cnt;
 
@@ -147,31 +142,31 @@ int main(void)
 
 		/* lsm6dsl accel */
 		sprintf(out_str, "accel x:%f ms/2 y:%f ms/2 z:%f ms/2",
-							  out_ev(&accel_x_out),
-							  out_ev(&accel_y_out),
-							  out_ev(&accel_z_out));
+							  sensor_value_to_double(&accel_x_out),
+							  sensor_value_to_double(&accel_y_out),
+							  sensor_value_to_double(&accel_z_out));
 		printk("%s\n", out_str);
 
 		/* lsm6dsl gyro */
 		sprintf(out_str, "gyro x:%f dps y:%f dps z:%f dps",
-							   out_ev(&gyro_x_out),
-							   out_ev(&gyro_y_out),
-							   out_ev(&gyro_z_out));
+							   sensor_value_to_double(&gyro_x_out),
+							   sensor_value_to_double(&gyro_y_out),
+							   sensor_value_to_double(&gyro_z_out));
 		printk("%s\n", out_str);
 
 #if defined(CONFIG_LSM6DSL_EXT0_LIS2MDL)
 		/* lsm6dsl external magn */
 		sprintf(out_str, "magn x:%f gauss y:%f gauss z:%f gauss",
-							   out_ev(&magn_x_out),
-							   out_ev(&magn_y_out),
-							   out_ev(&magn_z_out));
+							   sensor_value_to_double(&magn_x_out),
+							   sensor_value_to_double(&magn_y_out),
+							   sensor_value_to_double(&magn_z_out));
 		printk("%s\n", out_str);
 #endif
 
 #if defined(CONFIG_LSM6DSL_EXT0_LPS22HB)
 		/* lsm6dsl external press/temp */
 		sprintf(out_str, "press: %f kPa - temp: %f deg",
-			out_ev(&press_out), out_ev(&temp_out));
+			sensor_value_to_double(&press_out), sensor_value_to_double(&temp_out));
 		printk("%s\n", out_str);
 #endif
 


### PR DESCRIPTION
Fix -Wdouble-promotion warning just using sensor_value_to_double() routine.

Fixes #68284

If ok to everybody it may replace #68285, as this PR do not touch the lsm6dsl driver at all.