### PR TITLE
Bluetooth: BAP: Broadcast source enabling state transition fix

### DIFF
--- a/subsys/bluetooth/audio/bap_broadcast_source.c
+++ b/subsys/bluetooth/audio/bap_broadcast_source.c
@@ -86,7 +86,7 @@ static void broadcast_source_set_ep_state(struct bt_bap_ep *ep, uint8_t state)
 		}
 		break;
 	case BT_BAP_EP_STATE_ENABLING:
-		if (state != BT_BAP_EP_STATE_STREAMING) {
+		if (state != BT_BAP_EP_STATE_STREAMING && state != BT_BAP_EP_STATE_QOS_CONFIGURED) {
 			LOG_DBG("Invalid broadcast sync endpoint state transition");
 			return;
 		}


### PR DESCRIPTION
Since we may go from enabling to qos-configured state if the call to bt_iso_big_create fails, that is a valid transition. If bt_iso_big_create currently fails, then the source ends in a state where it cannot be recovered.