### PR TITLE
lorawan: add emulator and clock_sync unit tests

### DIFF
--- a/include/zephyr/lorawan/emul.h
+++ b/include/zephyr/lorawan/emul.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2024 A Labs GmbH
+ * Copyright (c) 2024 tado GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_LORAWAN_EMUL_H_
+#define ZEPHYR_INCLUDE_LORAWAN_EMUL_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <zephyr/lorawan/lorawan.h>
+
+/**
+ * @brief Defines the emulator uplink callback handler function signature.
+ *
+ * @param port LoRaWAN port
+ * @param len Payload data length
+ * @param data Pointer to the payload data
+ */
+typedef void (*lorawan_uplink_cb_t)(uint8_t port, uint8_t len, const uint8_t *data);
+
+/**
+ * @brief Emulate LoRaWAN downlink message
+ *
+ * @param port Port message was sent on
+ * @param data_pending Network server has more downlink packets pending
+ * @param rssi Received signal strength in dBm
+ * @param snr Signal to Noise ratio in dBm
+ * @param len Length of data received, will be 0 for ACKs
+ * @param data Data received, will be NULL for ACKs
+ */
+void lorawan_emul_send_downlink(uint8_t port, bool data_pending, int16_t rssi, int8_t snr,
+				uint8_t len, const uint8_t *data);
+
+/**
+ * @brief Register callback for emulated uplink messages
+ *
+ * @param cb Pointer to the uplink callback handler function
+ */
+void lorawan_emul_register_uplink_callback(lorawan_uplink_cb_t cb);
+
+#endif /* ZEPHYR_INCLUDE_LORAWAN_EMUL_H_ */

--- a/subsys/lorawan/CMakeLists.txt
+++ b/subsys/lorawan/CMakeLists.txt
@@ -20,8 +20,15 @@ zephyr_compile_definitions_ifdef(CONFIG_LORAMAC_REGION_IN865 REGION_IN865)
 zephyr_compile_definitions_ifdef(CONFIG_LORAMAC_REGION_US915 REGION_US915)
 zephyr_compile_definitions_ifdef(CONFIG_LORAMAC_REGION_RU864 REGION_RU864)
 
-zephyr_library_sources_ifdef(CONFIG_LORAWAN lorawan.c)
-zephyr_library_sources_ifdef(CONFIG_LORAWAN lw_priv.c)
+if(CONFIG_LORAWAN)
+	if(CONFIG_LORAWAN_EMUL)
+		zephyr_library_sources(lorawan_emul.c)
+	else()
+		zephyr_library_sources(lorawan.c)
+	endif()
+
+	zephyr_library_sources(lw_priv.c)
+endif()
 
 add_subdirectory(services)
 add_subdirectory(nvm)

--- a/subsys/lorawan/Kconfig
+++ b/subsys/lorawan/Kconfig
@@ -20,6 +20,16 @@ module = LORAWAN
 module-str = lorawan
 source "subsys/logging/Kconfig.template.log_config"
 
+config LORAWAN_EMUL
+	bool "LoRaWAN Emulator"
+	help
+	  The emulator can be used for unit testing of LoRaWAN services.
+	  It provides interfaces to send arbitrary messages to the LoRaWAN
+	  stack and receive the response through callbacks without using
+	  actual LoRa hardware.
+
+	  See include/zephyr/lorawan/emul.h for the emulator API.
+
 config LORAWAN_SYSTEM_MAX_RX_ERROR
 	int "LoRaWAN System Max Rx Error"
 	default 20

--- a/subsys/lorawan/lorawan_emul.c
+++ b/subsys/lorawan/lorawan_emul.c
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2024 A Labs GmbH
+ * Copyright (c) 2024 tado GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/lorawan/emul.h>
+#include <zephyr/lorawan/lorawan.h>
+
+#include <errno.h>
+
+#include <LoRaMac.h>
+#include <Region.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/init.h>
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(lorawan_emul, CONFIG_LORAWAN_LOG_LEVEL);
+
+static bool lorawan_adr_enable;
+
+static sys_slist_t dl_callbacks;
+
+static DeviceClass_t current_class;
+
+static lorawan_battery_level_cb_t battery_level_cb;
+static lorawan_dr_changed_cb_t dr_changed_cb;
+static lorawan_uplink_cb_t uplink_cb;
+
+/* implementation required by the soft-se (software secure element) */
+void BoardGetUniqueId(uint8_t *id)
+{
+	/* Do not change the default value */
+}
+
+void lorawan_emul_send_downlink(uint8_t port, bool data_pending, int16_t rssi, int8_t snr,
+				uint8_t len, const uint8_t *data)
+{
+	struct lorawan_downlink_cb *cb;
+
+	/* Iterate over all registered downlink callbacks */
+	SYS_SLIST_FOR_EACH_CONTAINER(&dl_callbacks, cb, node) {
+		if ((cb->port == LW_RECV_PORT_ANY) || (cb->port == port)) {
+			cb->cb(port, data_pending, rssi, snr, len, data);
+		}
+	}
+}
+
+int lorawan_join(const struct lorawan_join_config *join_cfg)
+{
+	return 0;
+}
+
+int lorawan_set_class(enum lorawan_class dev_class)
+{
+	switch (dev_class) {
+	case LORAWAN_CLASS_A:
+		current_class = CLASS_A;
+		break;
+	case LORAWAN_CLASS_B:
+		LOG_ERR("Class B not supported yet!");
+		return -ENOTSUP;
+	case LORAWAN_CLASS_C:
+		current_class = CLASS_C;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+int lorawan_set_datarate(enum lorawan_datarate dr)
+{
+	ARG_UNUSED(dr);
+
+	/* Bail out if using ADR */
+	if (lorawan_adr_enable) {
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+void lorawan_get_payload_sizes(uint8_t *max_next_payload_size, uint8_t *max_payload_size)
+{
+	LoRaMacTxInfo_t tx_info;
+
+	/* QueryTxPossible cannot fail */
+	(void)LoRaMacQueryTxPossible(0, &tx_info);
+
+	*max_next_payload_size = tx_info.MaxPossibleApplicationDataSize;
+	*max_payload_size = tx_info.CurrentPossiblePayloadSize;
+}
+
+enum lorawan_datarate lorawan_get_min_datarate(void)
+{
+	return LORAWAN_DR_0;
+}
+
+void lorawan_enable_adr(bool enable)
+{
+	lorawan_adr_enable = enable;
+}
+
+int lorawan_set_conf_msg_tries(uint8_t tries)
+{
+	return 0;
+}
+
+int lorawan_send(uint8_t port, uint8_t *data, uint8_t len, enum lorawan_message_type type)
+{
+	if (data == NULL) {
+		return -EINVAL;
+	}
+
+	if (uplink_cb != NULL) {
+		uplink_cb(port, len, data);
+	}
+
+	return 0;
+}
+
+void lorawan_register_battery_level_callback(lorawan_battery_level_cb_t cb)
+{
+	battery_level_cb = cb;
+}
+
+void lorawan_register_downlink_callback(struct lorawan_downlink_cb *cb)
+{
+	sys_slist_append(&dl_callbacks, &cb->node);
+}
+
+void lorawan_register_dr_changed_callback(lorawan_dr_changed_cb_t cb)
+{
+	dr_changed_cb = cb;
+}
+
+int lorawan_start(void)
+{
+	return 0;
+}
+
+static int lorawan_init(void)
+{
+	sys_slist_init(&dl_callbacks);
+
+	return 0;
+}
+
+void lorawan_emul_register_uplink_callback(lorawan_uplink_cb_t cb)
+{
+	uplink_cb = cb;
+}
+
+SYS_INIT(lorawan_init, POST_KERNEL, 0);

--- a/subsys/lorawan/services/clock_sync.c
+++ b/subsys/lorawan/services/clock_sync.c
@@ -85,6 +85,12 @@ static int clock_sync_serialize_device_time(uint8_t *buf, size_t size)
 	return sizeof(uint32_t);
 }
 
+static inline k_timeout_t clock_sync_calc_periodicity(void)
+{
+	/* add +-30s jitter to nominal periodicity as required by the spec */
+	return K_SECONDS(ctx.periodicity - 30 + sys_rand32_get() % 61);
+}
+
 static void clock_sync_package_callback(uint8_t port, bool data_pending, int16_t rssi, int8_t snr,
 					uint8_t len, const uint8_t *rx_buf)
 {
@@ -145,6 +151,9 @@ static void clock_sync_package_callback(uint8_t port, bool data_pending, int16_t
 			tx_pos += clock_sync_serialize_device_time(tx_buf + tx_pos,
 								   sizeof(tx_buf) - tx_pos);
 
+			lorawan_services_reschedule_work(&ctx.resync_work,
+							 clock_sync_calc_periodicity());
+
 			LOG_DBG("DeviceAppTimePeriodicityReq period: %u", period);
 			break;
 		}
@@ -196,18 +205,14 @@ static int clock_sync_app_time_req(void)
 
 static void clock_sync_resync_handler(struct k_work *work)
 {
-	uint32_t periodicity;
-
 	clock_sync_app_time_req();
 
 	if (ctx.nb_transmissions > 0) {
 		ctx.nb_transmissions--;
 		lorawan_services_reschedule_work(&ctx.resync_work, K_SECONDS(CLOCK_RESYNC_DELAY));
 	} else {
-		/* Add +-30s jitter to actual periodicity as required */
-		periodicity = ctx.periodicity - 30 + sys_rand32_get() % 61;
-
-		lorawan_services_reschedule_work(&ctx.resync_work, K_SECONDS(periodicity));
+		lorawan_services_reschedule_work(&ctx.resync_work,
+						 clock_sync_calc_periodicity());
 	}
 }
 

--- a/tests/subsys/lorawan/clock_sync/CMakeLists.txt
+++ b/tests/subsys/lorawan/clock_sync/CMakeLists.txt
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(lorawan_clock_sync_test)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/subsys/lorawan/clock_sync/boards/native_sim.conf
+++ b/tests/subsys/lorawan/clock_sync/boards/native_sim.conf
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Turn off log messages for failed communication with non-existing LoRa PHY
+CONFIG_LORA_LOG_LEVEL_OFF=y

--- a/tests/subsys/lorawan/clock_sync/boards/native_sim.overlay
+++ b/tests/subsys/lorawan/clock_sync/boards/native_sim.overlay
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2024 A Labs GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This overlay defines a fake LoRa PHY node which is required to build the driver.
+ */
+
+#include <zephyr/dt-bindings/lora/sx126x.h>
+
+/ {
+        chosen {
+                zephyr,code-partition = &slot0_partition;
+        };
+
+	aliases {
+		lora0 = &lora;
+	};
+
+	test {
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		test_spi: spi@33334444 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			compatible = "vnd,spi";
+			reg = <0x33334444 0x1000>;
+			status = "okay";
+			clock-frequency = <2000000>;
+
+			cs-gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+
+			lora: lora@0 {
+				compatible = "semtech,sx1262";
+				status = "okay";
+				reg = <0>;
+				reset-gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+				busy-gpios = <&gpio0 3 GPIO_ACTIVE_HIGH>;
+				tx-enable-gpios = <&gpio0 4 GPIO_ACTIVE_LOW>;
+				rx-enable-gpios = <&gpio0 5 GPIO_ACTIVE_LOW>;
+				dio1-gpios = <&gpio0 5 GPIO_ACTIVE_HIGH>;
+				dio2-tx-enable;
+				dio3-tcxo-voltage = <SX126X_DIO3_TCXO_3V3>;
+				tcxo-power-startup-delay-ms = <5>;
+				spi-max-frequency = <1000000>;
+			};
+		};
+	};
+};

--- a/tests/subsys/lorawan/clock_sync/prj.conf
+++ b/tests/subsys/lorawan/clock_sync/prj.conf
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ZTEST=y
+
+# General Zephyr settings
+CONFIG_MAIN_STACK_SIZE=2048
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
+CONFIG_THREAD_NAME=y
+CONFIG_LOG=y
+
+# LoRa PHY and required peripherals
+CONFIG_LORA=y
+CONFIG_SPI=y
+CONFIG_GPIO=y
+
+# Random number generator required for several LoRaWAN services
+CONFIG_ENTROPY_GENERATOR=y
+
+# LoRaWAN application layer
+CONFIG_LORAWAN=y
+CONFIG_LORAWAN_EMUL=y
+CONFIG_LORAMAC_REGION_EU868=y
+
+# LoRaWAN services required for this test
+CONFIG_LORAWAN_SERVICES=y
+CONFIG_LORAWAN_APP_CLOCK_SYNC=y
+# use shortest possible periodicity for testing
+CONFIG_LORAWAN_APP_CLOCK_SYNC_PERIODICITY=128

--- a/tests/subsys/lorawan/clock_sync/src/main.c
+++ b/tests/subsys/lorawan/clock_sync/src/main.c
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2024 A Labs GmbH
+ * Copyright (c) 2024 tado GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
+#include <zephyr/lorawan/emul.h>
+#include <zephyr/lorawan/lorawan.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/ztest.h>
+
+#define CMD_PACKAGE_VERSION             (0x00)
+#define CMD_APP_TIME                    (0x01)
+#define CMD_DEVICE_APP_TIME_PERIODICITY (0x02)
+#define CMD_FORCE_DEVICE_RESYNC         (0x03)
+
+#define CLOCK_SYNC_PORT (202)
+#define CLOCK_SYNC_ID
+
+struct lorawan_msg {
+	/* large enough buffer to fit maximum clock sync message length */
+	uint8_t data[6];
+	uint8_t len;
+};
+
+K_MSGQ_DEFINE(uplink_msgq, sizeof(struct lorawan_msg), 10, 4);
+
+void uplink_handler(uint8_t port, uint8_t len, const uint8_t *data)
+{
+	struct lorawan_msg msg;
+	int ret;
+
+	zassert_equal(port, CLOCK_SYNC_PORT);
+
+	zassert_true(len <= sizeof(msg.data));
+	memcpy(msg.data, data, len);
+	msg.len = len;
+
+	ret = k_msgq_put(&uplink_msgq, &msg, K_NO_WAIT);
+	zassert_equal(ret, 0);
+}
+
+ZTEST(clock_sync, test_package_version)
+{
+	struct lorawan_msg ans;
+	uint8_t req_data[] = {CMD_PACKAGE_VERSION};
+	int ret;
+
+	k_msgq_purge(&uplink_msgq);
+
+	lorawan_emul_send_downlink(CLOCK_SYNC_PORT, false, 0, 0, sizeof(req_data), req_data);
+
+	ret = k_msgq_get(&uplink_msgq, &ans, K_MSEC(100));
+	zassert_equal(ret, 0, "receiving PackageVersionAns timed out");
+	zassert_equal(ans.len, 3);
+	zassert_equal(ans.data[0], CMD_PACKAGE_VERSION);
+	zassert_equal(ans.data[1], 1); /* PackageIdentifier */
+	zassert_equal(ans.data[2], 2); /* PackageVersion */
+}
+
+ZTEST(clock_sync, test_app_time)
+{
+	uint8_t ans_data[6] = {CMD_APP_TIME};
+	struct lorawan_msg req;
+	uint32_t device_time;
+	uint32_t gps_time;
+	uint8_t token_req;
+	int ret;
+
+	k_msgq_purge(&uplink_msgq);
+
+	/* wait for more than the default (=minimum) periodicity of 128s + 30s jitter */
+	ret = k_msgq_get(&uplink_msgq, &req, K_SECONDS(128 + 30 + 1));
+	zassert_equal(ret, 0, "receiving AppTimeReq timed out");
+	zassert_equal(req.len, 6);
+	zassert_equal(req.data[0], CMD_APP_TIME);
+
+	device_time = sys_get_le32(req.data + 1);
+	token_req = req.data[5] & 0xF;
+	zassert_within((int)device_time, (int)(k_uptime_get() / 1000), 1);
+
+	/* apply a time correction of 1000 seconds */
+	sys_put_le32(1000, ans_data + 1);
+	ans_data[5] = token_req;
+
+	lorawan_emul_send_downlink(CLOCK_SYNC_PORT, false, 0, 0, sizeof(ans_data), ans_data);
+
+	lorawan_clock_sync_get(&gps_time);
+	zassert_within(gps_time, (k_uptime_get() / 1000) + 1000, 1);
+}
+
+ZTEST(clock_sync, test_device_app_time_periodicity)
+{
+	const uint8_t period = 1; /* actual periodicity in seconds: 128 * 2^period */
+	uint8_t req_data[] = {
+		CMD_DEVICE_APP_TIME_PERIODICITY,
+		period & 0xF,
+	};
+	struct lorawan_msg app_time_req;
+	struct lorawan_msg ans;
+	uint32_t device_time;
+	uint32_t gps_time;
+	int ret;
+
+	k_msgq_purge(&uplink_msgq);
+
+	lorawan_emul_send_downlink(CLOCK_SYNC_PORT, false, 0, 0, sizeof(req_data), req_data);
+
+	ret = k_msgq_get(&uplink_msgq, &ans, K_MSEC(100));
+	zassert_equal(ret, 0, "receiving DeviceAppTimePeriodicityAns timed out");
+	zassert_equal(ans.len, 6);
+	zassert_equal(ans.data[0], CMD_DEVICE_APP_TIME_PERIODICITY);
+	zassert_equal(ans.data[1], 0);
+
+	device_time = sys_get_le32(ans.data + 2);
+	lorawan_clock_sync_get(&gps_time);
+	zassert_within(device_time, gps_time, 1);
+
+	/* wait for more than the old periodicity of 128s + 30s jitter */
+	ret = k_msgq_get(&uplink_msgq, &app_time_req, K_SECONDS(128 + 30 + 1));
+	zassert_equal(ret, -EAGAIN, "received AppTimeReq too early");
+
+	/* wait for another 128s to cover the new periodicity of 256s + 30s jitter */
+	ret = k_msgq_get(&uplink_msgq, &app_time_req, K_SECONDS(128));
+	zassert_equal(ret, 0, "receiving AppTimeReq timed out");
+	zassert_equal(app_time_req.len, 6);
+	zassert_equal(app_time_req.data[0], CMD_APP_TIME);
+
+	/* reset to minimum periodicity */
+	req_data[1] = 0;
+	lorawan_emul_send_downlink(CLOCK_SYNC_PORT, false, 0, 0, sizeof(req_data), req_data);
+	ret = k_msgq_get(&uplink_msgq, &ans, K_MSEC(100));
+	zassert_equal(ret, 0, "receiving DeviceAppTimePeriodicityAns timed out");
+	zassert_equal(ans.len, 6);
+	zassert_equal(ans.data[0], CMD_DEVICE_APP_TIME_PERIODICITY);
+}
+
+ZTEST(clock_sync, test_force_device_resync)
+{
+	const uint8_t nb_transmissions = 2;
+	uint8_t resync_req_data[] = {
+		CMD_FORCE_DEVICE_RESYNC,
+		nb_transmissions,
+	};
+	struct lorawan_msg app_time_req;
+	int ret;
+
+	k_msgq_purge(&uplink_msgq);
+
+	lorawan_emul_send_downlink(CLOCK_SYNC_PORT, false, 0, 0, sizeof(resync_req_data),
+				   resync_req_data);
+
+	for (int i = 0; i < nb_transmissions; i++) {
+		/* wait for more than CLOCK_RESYNC_DELAY of 10 secs */
+		ret = k_msgq_get(&uplink_msgq, &app_time_req, K_SECONDS(11));
+		zassert_equal(ret, 0, "receiving AppTimeReq #%d timed out", i + 1);
+		zassert_equal(app_time_req.len, 6);
+		zassert_equal(app_time_req.data[0], CMD_APP_TIME);
+	}
+}
+
+static void *clock_sync_setup(void)
+{
+	const struct device *lora_dev = DEVICE_DT_GET(DT_ALIAS(lora0));
+	struct lorawan_join_config join_cfg = {0};
+	int ret;
+
+	zassert_true(device_is_ready(lora_dev), "LoRa device not ready");
+
+	ret = lorawan_start();
+	zassert_equal(ret, 0, "lorawan_start failed: %d", ret);
+
+	ret = lorawan_join(&join_cfg);
+	zassert_equal(ret, 0, "lorawan_join failed: %d", ret);
+
+	lorawan_emul_register_uplink_callback(uplink_handler);
+
+	ret = lorawan_clock_sync_run();
+	zassert_equal(ret, 0, "clock_sync_run failed: %d", ret);
+
+	/* wait for first messages to be processed in the background */
+	k_sleep(K_SECONDS(1));
+
+	return NULL;
+}
+
+ZTEST_SUITE(clock_sync, NULL, clock_sync_setup, NULL, NULL, NULL);

--- a/tests/subsys/lorawan/clock_sync/testcase.yaml
+++ b/tests/subsys/lorawan/clock_sync/testcase.yaml
@@ -1,0 +1,14 @@
+common:
+  tags:
+    - lorawan
+tests:
+  lorawan.clock_sync.sim:
+    integration_platforms:
+      - native_sim
+    platform_allow:
+      - native_sim
+  lorawan.clock_sync.phy:
+    depends_on: lora
+    filter: CONFIG_ENTROPY_HAS_DRIVER
+    integration_platforms:
+      - nucleo_wl55jc

--- a/west.yml
+++ b/west.yml
@@ -271,7 +271,7 @@ manifest:
         - fs
       revision: 408c16a909dd6cf128874a76f21c793798c9e423
     - name: loramac-node
-      revision: 842413c5fb98707eb5f26e619e8e792453877897
+      revision: 1bf2120cffcedae174ae35d695a28a46caefcb23
       path: modules/lib/loramac-node
     - name: lvgl
       revision: 2b76c641749725ac90c6ac7959ca7718804cf356


### PR DESCRIPTION
This PR proposes to add a LoRaWAN emulation layer that allows to test LoRaWAN services in CI.

It provides interfaces to send arbitrary messages to the LoRaWAN stack and receive the response through callbacks without using actual LoRa hardware.

As a first user of the emulator, unit tests for the `clock_sync` service are added.

While writing the tests, two minor bugs in the application were discovered, which are fixed as part of the PR.