### PR TITLE
Bluetooth: CAP: Fix uninitialized values in broadcast start

### DIFF
--- a/subsys/bluetooth/audio/cap_initiator.c
+++ b/subsys/bluetooth/audio/cap_initiator.c
@@ -192,7 +192,7 @@ int bt_cap_initiator_broadcast_audio_create(
 		bap_subgroup_params[CONFIG_BT_BAP_BROADCAST_SRC_SUBGROUP_COUNT];
 	struct bt_bap_broadcast_source_stream_param
 		bap_stream_params[CONFIG_BT_BAP_BROADCAST_SRC_STREAM_COUNT];
-	struct bt_bap_broadcast_source_param bap_create_param;
+	struct bt_bap_broadcast_source_param bap_create_param = {0};
 
 	CHECKIF(param == NULL) {
 		LOG_DBG("param is NULL");


### PR DESCRIPTION
When CONFIG_BT_ISO_TEST_PARAMS is enabled then the bt_bap_broadcast_source_param in
bt_cap_initiator_broadcast_audio_create had uninitialized values.

A general and future proof solution for this is to simply initialize the entire struct to 0.