### PR TITLE
scripts: tests: Blackbox test expansion - config 

### DIFF
--- a/scripts/tests/twister_blackbox/test_config.py
+++ b/scripts/tests/twister_blackbox/test_config.py
@@ -56,3 +56,38 @@ class TestConfig:
         assert str(sys_exit.value) == '0'
 
         assert len(filtered_j) == 3
+
+    @pytest.mark.parametrize(
+        'level, expected_tests',
+        [
+            ('smoke', 5),
+            ('acceptance', 6),
+        ],
+        ids=['smoke', 'acceptance']
+    )
+    @mock.patch.object(TestPlan, 'TESTSUITE_FILENAME', testsuite_filename_mock)
+    def test_level(self, out_path, level, expected_tests):
+        test_platforms = ['qemu_x86', 'frdm_k64f']
+        path = os.path.join(TEST_DATA, 'tests', 'dummy')
+        config_path = os.path.join(TEST_DATA, 'test_config.yaml')
+        args = ['-i','--outdir', out_path, '-T', path, '--level', level, '-y',
+                '--test-config', config_path] + \
+               [val for pair in zip(
+                   ['-p'] * len(test_platforms), test_platforms
+               ) for val in pair]
+
+        with mock.patch.object(sys, 'argv', [sys.argv[0]] + args), \
+                pytest.raises(SystemExit) as sys_exit:
+            self.loader.exec_module(self.twister_module)
+
+        with open(os.path.join(out_path, 'testplan.json')) as f:
+            j = json.load(f)
+        filtered_j = [
+            (ts['platform'], ts['name'], tc['identifier']) \
+                for ts in j['testsuites'] \
+                for tc in ts['testcases'] if 'reason' not in tc
+        ]
+
+        assert str(sys_exit.value) == '0'
+
+        assert expected_tests == len(filtered_j)

--- a/scripts/tests/twister_blackbox/test_config.py
+++ b/scripts/tests/twister_blackbox/test_config.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Blackbox tests for twister's command line functions related to test configuration files.
+"""
+
+import importlib
+import mock
+import os
+import pytest
+import sys
+import json
+
+from conftest import ZEPHYR_BASE, TEST_DATA, testsuite_filename_mock
+from twisterlib.testplan import TestPlan
+
+
+class TestConfig:
+    @classmethod
+    def setup_class(cls):
+        apath = os.path.join(ZEPHYR_BASE, 'scripts', 'twister')
+        cls.loader = importlib.machinery.SourceFileLoader('__main__', apath)
+        cls.spec = importlib.util.spec_from_loader(cls.loader.name, cls.loader)
+        cls.twister_module = importlib.util.module_from_spec(cls.spec)
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    @mock.patch.object(TestPlan, 'TESTSUITE_FILENAME', testsuite_filename_mock)
+    def test_alt_config_root(self, out_path):
+        test_platforms = ['qemu_x86', 'frdm_k64f']
+        path = os.path.join(TEST_DATA, 'tests', 'dummy')
+        alt_config_root = os.path.join(TEST_DATA, 'alt-test-configs', 'dummy')
+        args = ['-i', '--outdir', out_path, '-T', path, '-y'] + \
+               ['--alt-config-root', alt_config_root] + \
+               ['--tag', 'alternate-config-root'] + \
+               [val for pair in zip(
+                   ['-p'] * len(test_platforms), test_platforms
+               ) for val in pair]
+
+        with mock.patch.object(sys, 'argv', [sys.argv[0]] + args), \
+                pytest.raises(SystemExit) as sys_exit:
+            self.loader.exec_module(self.twister_module)
+
+        with open(os.path.join(out_path, 'testplan.json')) as f:
+            j = json.load(f)
+        filtered_j = [
+           (ts['platform'], ts['name'], tc['identifier']) \
+               for ts in j['testsuites'] \
+               for tc in ts['testcases'] if 'reason' not in tc
+        ]
+
+        assert str(sys_exit.value) == '0'
+
+        assert len(filtered_j) == 3

--- a/scripts/tests/twister_blackbox/test_data/alt-test-configs/dummy/agnostic/group2/test_data.yaml
+++ b/scripts/tests/twister_blackbox/test_data/alt-test-configs/dummy/agnostic/group2/test_data.yaml
@@ -1,0 +1,12 @@
+tests:
+  dummy.agnostic.group2.alt:
+    platform_allow:
+      - native_sim
+      - qemu_x86
+      - qemu_x86_64
+    integration_platforms:
+      - native_sim
+    slow: true
+    tags:
+      - agnostic
+      - alternate-config-root

--- a/scripts/tests/twister_blackbox/test_testplan.py
+++ b/scripts/tests/twister_blackbox/test_testplan.py
@@ -20,10 +20,6 @@ from twisterlib.error import TwisterRuntimeError
 
 class TestTestPlan:
     TESTDATA_1 = [
-        ('smoke', 5),
-        ('acceptance', 6),
-    ]
-    TESTDATA_2 = [
         ('dummy.agnostic.group2.assert1', SystemExit, 3),
         (
             os.path.join('scripts', 'tests', 'twister_blackbox', 'test_data', 'tests',
@@ -33,11 +29,11 @@ class TestTestPlan:
             None
         ),
     ]
-    TESTDATA_3 = [
+    TESTDATA_2 = [
         ('buildable', 6),
         ('runnable', 5),
     ]
-    TESTDATA_4 = [
+    TESTDATA_3 = [
         (True, 1),
         (False, 6),
     ]
@@ -54,40 +50,8 @@ class TestTestPlan:
         pass
 
     @pytest.mark.parametrize(
-        'level, expected_tests',
-        TESTDATA_1,
-        ids=['smoke', 'acceptance']
-    )
-    @mock.patch.object(TestPlan, 'TESTSUITE_FILENAME', testsuite_filename_mock)
-    def test_level(self, out_path, level, expected_tests):
-        test_platforms = ['qemu_x86', 'frdm_k64f']
-        path = os.path.join(TEST_DATA, 'tests', 'dummy')
-        config_path = os.path.join(TEST_DATA, 'test_config.yaml')
-        args = ['-i','--outdir', out_path, '-T', path, '--level', level, '-y',
-                '--test-config', config_path] + \
-               [val for pair in zip(
-                   ['-p'] * len(test_platforms), test_platforms
-               ) for val in pair]
-
-        with mock.patch.object(sys, 'argv', [sys.argv[0]] + args), \
-                pytest.raises(SystemExit) as sys_exit:
-            self.loader.exec_module(self.twister_module)
-
-        with open(os.path.join(out_path, 'testplan.json')) as f:
-            j = json.load(f)
-        filtered_j = [
-            (ts['platform'], ts['name'], tc['identifier']) \
-                for ts in j['testsuites'] \
-                for tc in ts['testcases'] if 'reason' not in tc
-        ]
-
-        assert str(sys_exit.value) == '0'
-
-        assert expected_tests == len(filtered_j)
-
-    @pytest.mark.parametrize(
         'test, expected_exception, expected_subtest_count',
-        TESTDATA_2,
+        TESTDATA_1,
         ids=['valid', 'invalid']
     )
     @mock.patch.object(TestPlan, 'TESTSUITE_FILENAME', testsuite_filename_mock)
@@ -120,7 +84,7 @@ class TestTestPlan:
 
     @pytest.mark.parametrize(
         'filter, expected_count',
-        TESTDATA_3,
+        TESTDATA_2,
         ids=['buildable', 'runnable']
     )
     @mock.patch.object(TestPlan, 'TESTSUITE_FILENAME', testsuite_filename_mock)
@@ -150,7 +114,7 @@ class TestTestPlan:
 
     @pytest.mark.parametrize(
         'integration, expected_count',
-        TESTDATA_4,
+        TESTDATA_3,
         ids=['integration', 'no integration']
     )
     @mock.patch.object(TestPlan, 'TESTSUITE_FILENAME', testsuite_filename_mock)


### PR DESCRIPTION
Adds tests related to the Twister config files:
* `--alt-config-root`

Moves the previously-existing `--level` and `--test-config` tests to the config section file.