### PR TITLE
Bluetooth: Mesh: Fix solicitation PDU transmission dependency on proxy feature

### DIFF
--- a/subsys/bluetooth/mesh/adv_ext.c
+++ b/subsys/bluetooth/mesh/adv_ext.c
@@ -292,13 +292,13 @@ static void send_pending_adv(struct k_work *work)
 		}
 	}
 
-	if (!IS_ENABLED(CONFIG_BT_MESH_GATT_SERVER) ||
-	    !(ext_adv->tags & BT_MESH_ADV_TAG_BIT_PROXY)) {
+	if (IS_ENABLED(CONFIG_BT_MESH_PROXY_SOLICITATION) &&
+	    !bt_mesh_sol_send()) {
 		return;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_MESH_PROXY_SOLICITATION) &&
-	    !bt_mesh_sol_send()) {
+	if (!IS_ENABLED(CONFIG_BT_MESH_GATT_SERVER) ||
+	    !(ext_adv->tags & BT_MESH_ADV_TAG_BIT_PROXY)) {
 		return;
 	}
 


### PR DESCRIPTION
If `CONFIG_BT_MESH_GATT_SERVER` is disabled or the advertising set doesn't support proxy adv, the solicitation PDU will not be sent. However, solicitation PDU transmission doesn't depend on the proxy feature of the device it sends. Therefore, solicatation PDU should be sent regradless of `CONFIG_BT_MESH_GATT_SERVER` option and advertiser tag.

Fixes #68726