### PR TITLE
drivers: mipi_dbi: mipi_dbi_spi: change reset pin polarity

### DIFF
--- a/boards/arm/bl5340_dvk/bl5340_dvk_cpuapp_common.dtsi
+++ b/boards/arm/bl5340_dvk/bl5340_dvk_cpuapp_common.dtsi
@@ -110,7 +110,7 @@
 
 	mipi_dbi {
 		compatible = "zephyr,mipi-dbi-spi";
-		reset-gpios = <&gpio0 6 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&gpio0 6 GPIO_ACTIVE_LOW>;
 		dc-gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
 		spi-dev = <&spi2>;
 		write-only;

--- a/boards/arm/wio_terminal/wio_terminal.dts
+++ b/boards/arm/wio_terminal/wio_terminal.dts
@@ -128,7 +128,7 @@
 	mipi_dbi {
 		compatible = "zephyr,mipi-dbi-spi";
 		dc-gpios = <&portc 6 GPIO_ACTIVE_HIGH>;
-		reset-gpios = <&portc 7 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&portc 7 GPIO_ACTIVE_LOW>;
 		#address-cells = <1>;
 		#size-cells = <0>;
 		spi-dev = <&sercom7>;

--- a/boards/shields/buydisplay_2_8_tft_touch_arduino/buydisplay_2_8_tft_touch_arduino.overlay
+++ b/boards/shields/buydisplay_2_8_tft_touch_arduino/buydisplay_2_8_tft_touch_arduino.overlay
@@ -22,7 +22,7 @@
 	buydisplay_2_8_tft_touch_arduino_mipi_dbi {
 		compatible = "zephyr,mipi-dbi-spi";
 		dc-gpios = <&arduino_header 13 GPIO_ACTIVE_HIGH>; /* D7 */
-		reset-gpios = <&arduino_header 16 GPIO_ACTIVE_HIGH>; /* D10 */
+		reset-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>; /* D10 */
 		spi-dev = <&arduino_spi>;
 		write-only;
 		#address-cells = <1>;

--- a/boards/shields/buydisplay_3_5_tft_touch_arduino/buydisplay_3_5_tft_touch_arduino.overlay
+++ b/boards/shields/buydisplay_3_5_tft_touch_arduino/buydisplay_3_5_tft_touch_arduino.overlay
@@ -22,7 +22,7 @@
 	buydisplay_3_5_tft_touch_arduino_mipi_dbi {
 		compatible = "zephyr,mipi-dbi-spi";
 		dc-gpios = <&arduino_header 13 GPIO_ACTIVE_HIGH>; /* D7 */
-		reset-gpios = <&arduino_header 16 GPIO_ACTIVE_HIGH>; /* D10 */
+		reset-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>; /* D10 */
 		spi-dev = <&arduino_spi>;
 		write-only;
 		#address-cells = <1>;

--- a/boards/xtensa/esp_wrover_kit/esp_wrover_kit.dts
+++ b/boards/xtensa/esp_wrover_kit/esp_wrover_kit.dts
@@ -74,7 +74,7 @@
 	mipi_dbi {
 		compatible = "zephyr,mipi-dbi-spi";
 		dc-gpios = <&gpio0 21 GPIO_ACTIVE_HIGH>;
-		reset-gpios = <&gpio0 18 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
 		spi-dev = <&spi3>;
 		write-only;
 		#address-cells = <1>;

--- a/boards/xtensa/m5stack_core2/m5stack_core2.dts
+++ b/boards/xtensa/m5stack_core2/m5stack_core2.dts
@@ -52,7 +52,7 @@
 	mipi_dbi {
 		compatible = "zephyr,mipi-dbi-spi";
 		dc-gpios = <&gpio0 15 GPIO_ACTIVE_HIGH>;
-		reset-gpios = <&axp192_gpio 4 (GPIO_OPEN_DRAIN | GPIO_ACTIVE_HIGH)>;
+		reset-gpios = <&axp192_gpio 4 (GPIO_OPEN_DRAIN | GPIO_ACTIVE_LOW)>;
 		spi-dev = <&spi3>;
 		write-only;
 		#address-cells = <1>;

--- a/doc/releases/migration-guide-3.6.rst
+++ b/doc/releases/migration-guide-3.6.rst
@@ -246,7 +246,9 @@ Device Drivers and Device Tree
 
 * ILI9XXX based displays now use the MIPI DBI driver class. These displays
   must now be declared within a MIPI DBI driver wrapper device, which will
-  manage interfacing with the display. For an example, see below:
+  manage interfacing with the display. Note that the `cmd-data-gpios` pin has
+  changed polarity with this update, to align better with the new
+  `dc-gpios` name. For an example, see below:
 
   .. code-block:: devicetree
 
@@ -269,7 +271,7 @@ Device Drivers and Device Tree
     mipi_dbi {
         compatible = "zephyr,mipi-dbi-spi";
         reset-gpios = <&gpio0 6 GPIO_ACTIVE_LOW>;
-        dc-gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+        dc-gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
         spi-dev = <&spi2>;
         #address-cells = <1>;
         #size-cells = <0>;

--- a/drivers/mipi_dbi/mipi_dbi_spi.c
+++ b/drivers/mipi_dbi/mipi_dbi_spi.c
@@ -251,12 +251,12 @@ static int mipi_dbi_spi_reset(const struct device *dev, uint32_t delay)
 		return -ENOTSUP;
 	}
 
-	ret = gpio_pin_set_dt(&config->reset, 0);
+	ret = gpio_pin_set_dt(&config->reset, 1);
 	if (ret < 0) {
 		return ret;
 	}
 	k_msleep(delay);
-	return gpio_pin_set_dt(&config->reset, 1);
+	return gpio_pin_set_dt(&config->reset, 0);
 }
 
 static int mipi_dbi_spi_init(const struct device *dev)

--- a/dts/bindings/mipi-dbi/zephyr,mipi-dbi-spi.yaml
+++ b/dts/bindings/mipi-dbi/zephyr,mipi-dbi-spi.yaml
@@ -25,8 +25,7 @@ properties:
   reset-gpios:
     type: phandle-array
     description: |
-      Reset GPIO pin. Used to reset the display during initialization.
-      Active low pin.
+      Reset GPIO pin. Set high to reset the display
 
   write-only:
     type: boolean


### PR DESCRIPTION
Change reset pin polarity for MIPI DBI SPI controller, so that the board
devicetree is responsible for setting the GPIO to active low, and the
driver always sets the pin to a logic 1 to reset the display.

Fixes #68562