### PR TITLE
mimxrt1010_evk: Fix i2c pinctrl dts

### DIFF
--- a/boards/arm/mimxrt1010_evk/mimxrt1010_evk-pinctrl.dtsi
+++ b/boards/arm/mimxrt1010_evk/mimxrt1010_evk-pinctrl.dtsi
@@ -22,18 +22,12 @@
 
 	pinmux_lpi2c1: pinmux_lpi2c1 {
 		group0 {
-			pinmux = <&iomuxc_gpio_01_lpi2c1_sda>;
+			pinmux = <&iomuxc_gpio_01_lpi2c1_sda>, <&iomuxc_gpio_02_lpi2c1_scl>;
 			drive-strength = "r0-4";
 			drive-open-drain;
 			slew-rate = "slow";
 			nxp,speed = "100-mhz";
 			input-enable;
-		};
-		group1 {
-			pinmux = <&iomuxc_gpio_02_lpi2c1_scl>;
-			drive-strength = "r0-4";
-			slew-rate = "slow";
-			nxp,speed = "100-mhz";
 		};
 	};
 


### PR DESCRIPTION
i2c pads were incorrectly configured and failed to work when testing against an external fram part. Correct the i2c pinctrl settings for arduino i2c to match other boards in the mimxrt lineup.