### PR TITLE
drivers: espi: Clear virtual wire interrupt before calling handler

### DIFF
--- a/drivers/espi/espi_mchp_xec.c
+++ b/drivers/espi/espi_mchp_xec.c
@@ -1365,6 +1365,7 @@ static void espi_xec_vw_isr(const struct device *dev)
 	uint32_t girq_result;
 
 	girq_result = MCHP_GIRQ_RESULT(config->vw_girq_ids[0]);
+	MCHP_GIRQ_SRC(config->vw_girq_ids[0]) = girq_result;
 
 	for (int i = 0; i < m2s_vwires_isr_cnt; i++) {
 		struct espi_isr entry = m2s_vwires_isr[i];
@@ -1375,8 +1376,6 @@ static void espi_xec_vw_isr(const struct device *dev)
 			}
 		}
 	}
-
-	REG32(MCHP_GIRQ_SRC_ADDR(config->vw_girq_ids[0])) = girq_result;
 }
 
 #if DT_INST_PROP_HAS_IDX(0, vw_girqs, 1)


### PR DESCRIPTION
Clearing virtual wire interrupt after calling handler may cause next interrupt miss if the same virtual wire changes due to action in handler. As the interrupt source is read from register, it can be cleared before calling handler to avoid next interrupt miss due to action/delay in the callback handler.