### PR TITLE
scripts/utils/board_v1_to_v2.py: update glob to find path to board

### DIFF
--- a/scripts/utils/board_v1_to_v2.py
+++ b/scripts/utils/board_v1_to_v2.py
@@ -43,7 +43,7 @@ ZEPHYR_BASE = Path(__file__).parents[2]
 
 def board_v1_to_v2(board_root, board, new_board, group, vendor, soc, variants):
     try:
-        board_path = next(board_root.glob(f"boards/*/{board}"))
+        board_path = next(board_root.glob(f"boards/boards_legacy/*/{board}"))
     except StopIteration:
         sys.exit(f"Board not found: {board}")
 


### PR DESCRIPTION
board_v1_to_v2(), as it seems, was not updated for the move of the boards, not yet updated for v2, to boards/boards_legacy.

The expression given to glob() needs to changed from:

board_path = next(board_root.glob(f"boards/*/{board}"))

to

board_path = next(board_root.glob(f"boards/boards_legacy/*/{board}"))