### PR TITLE
linker: esp32s2: esp32c3: esp32s3: DROM/DRAM section corruption

### DIFF
--- a/soc/riscv/espressif_esp32/esp32c3/default.ld
+++ b/soc/riscv/espressif_esp32/esp32c3/default.ld
@@ -53,6 +53,8 @@
  * Executing directly from LMA is not possible. */
 #undef GROUP_ROM_LINK_IN
 #define GROUP_ROM_LINK_IN(vregion, lregion) > RODATA_REGION AT > lregion
+#undef SECTION_PROLOGUE
+#define SECTION_PROLOGUE SECTION_DATA_PROLOGUE
 
 /* Global symbols required for espressif hal build */
 MEMORY

--- a/soc/xtensa/espressif_esp32/esp32s2/default.ld
+++ b/soc/xtensa/espressif_esp32/esp32s2/default.ld
@@ -57,6 +57,8 @@
  * Executing directly from LMA is not possible. */
 #undef GROUP_ROM_LINK_IN
 #define GROUP_ROM_LINK_IN(vregion, lregion) > RODATA_REGION AT > lregion
+#undef SECTION_PROLOGUE
+#define SECTION_PROLOGUE SECTION_DATA_PROLOGUE
 
 MEMORY
 {
@@ -133,7 +135,7 @@ SECTIONS
    * Adding .rodata as first section helps to reduce size of generated binary by
    * few kBs.
    */
-  SECTION_PROLOGUE(_RODATA_SECTION_NAME,,ALIGN(4))
+  SECTION_PROLOGUE(_RODATA_SECTION_NAME,,)
   {
     _rodata_reserved_start = ABSOLUTE(.);
     __rodata_region_start = ABSOLUTE(.);
@@ -191,7 +193,7 @@ SECTIONS
 
   /* Create an explicit section at the end of all the data that shall be mapped into drom.
    * This is used to calculate the size of the _image_drom_size variable */
-  SECTION_PROLOGUE(_RODATA_SECTION_END,,ALIGN(0x10))
+  SECTION_PROLOGUE(_RODATA_SECTION_END,,)
   {
     _rodata_reserved_end = ABSOLUTE(.);
     . = ALIGN(4);

--- a/soc/xtensa/espressif_esp32/esp32s3/default.ld
+++ b/soc/xtensa/espressif_esp32/esp32s3/default.ld
@@ -71,6 +71,8 @@
  * Executing directly from LMA is not possible. */
 #undef GROUP_ROM_LINK_IN
 #define GROUP_ROM_LINK_IN(vregion, lregion) > RODATA_REGION AT > lregion
+#undef SECTION_PROLOGUE
+#define SECTION_PROLOGUE SECTION_DATA_PROLOGUE
 
 MEMORY
 {
@@ -165,7 +167,7 @@ SECTIONS
    * Adding .rodata as first section helps to reduce size of generated binary by
    * few kBs.
    */
-  SECTION_PROLOGUE(_RODATA_SECTION_NAME,,ALIGN(0x10))
+  SECTION_PROLOGUE(_RODATA_SECTION_NAME,,)
   {
     _rodata_reserved_start = ABSOLUTE(.);
     _rodata_start = ABSOLUTE(.);
@@ -228,7 +230,7 @@ SECTIONS
 
   /* Create an explicit section at the end of all the data that shall be mapped into drom.
    * This is used to calculate the size of the _image_drom_size variable */
-  SECTION_PROLOGUE(_RODATA_SECTION_END,,ALIGN(0x10))
+  SECTION_PROLOGUE(_RODATA_SECTION_END,,)
   {
     _rodata_reserved_end = ABSOLUTE(.);
     . = ALIGN(16);


### PR DESCRIPTION
Updated from closed PR #68447.

So just a  heads up @marekmatej @sylvioalves including the default.ld from [the 5.1 fork](https://github.com/marekmatej/zephyr/blob/feature/simple_boot_hal_v5.1/soc/riscv/espressif_esp32/esp32c3/default.ld) results in the same behavior as I am seeing, and is fixed by the same approach as here.

My minimal test case is;

```console
west build --sysbuild -p always -b esp32c3_devkitm samples/subsys/zbus/hello_world/ -- -DCONFIG_BOOTLOADER_MCUBOOT=y -DCONFIG_COMPILER_SAVE_TEMPS=y -DCONFIG_DEBUG_OPTIMIZATIONS=y
```
I see the same with `esp32s3_devkitm`. The good news is I couldn't leave this alone ... as it was really bugging me. So I have spent another day on this and come up with what I see as the most non-invasive solution. I have tested that it works on c3 in the test case and in our application which show the same behavior.

The linked issue (#68028) has an s2 application with the same issue, and there are others that relate to segfaults with the inclusion of mcuboot. Maybe these guys can help out with testing.

I have to leave it to you to verify/rationalise this more generally but as of now I can't spend anymore time on it, and for our application to deploy I am comfortable to move on with this (until 5.1, where someone will have had to fix this as well).

## Not working

Note that readelf shows that the _static_thread_data_area on, and the log_const sections don't appear in the load segments that they are supposed to belong in, namely DROM and DRAM. This means that they don't end up in the binary as loadable for mcuboot as this only surfaces with it. The IDF bootloader seems to work.

```console
(.venv) you@yours:~/zephyrproject/zephyr$ readelf -l build/hello_world/zephyr/zephyr.elf 

Elf file type is EXEC (Executable file)
Entry point 0x403824e0
There are 13 program headers, starting at offset 52

Program Headers:
  Type           Offset   VirtAddr   PhysAddr   FileSiz MemSiz  Flg Align
  RISCV_ATTRIBUT 0x0db0a0 0x00000000 0x00000000 0x00044 0x00000 R   0x1
  LOAD           0x0001d4 0x00000000 0x00000000 0x00020 0x00020 R   0x1
  LOAD           0x0001f4 0x00000020 0x00000020 0x00020 0x00020 RW  0x4
  LOAD           0x000214 0x3c000040 0x00000040 0x01094 0x01094 R   0x4
  LOAD           0x0012a8 0x3c0010d8 0x000010d4 0x000a8 0x000a8 RW  0x8
  LOAD           0x001400 0x40380000 0x0000117c 0x02da4 0x02da4 R E 0x100
  LOAD           0x0041a4 0x3fc85a40 0x00003f20 0x00372 0x00372 RW  0x4
  LOAD           0x004518 0x3fc85db4 0x00004292 0x00038 0x00038 R   0x4
  LOAD           0x010000 0x42020000 0x00010000 0x044a0 0x044a0 R E 0x10000
  LOAD           0x000000 0x3fc80000 0x3fc80000 0x00000 0x05a40 RW  0x10
  LOAD           0x000000 0x40382da4 0x40382da4 0x00000 0x0000c RW  0x1
  LOAD           0x000000 0x42000000 0x42000000 0x00000 0x10020 RW  0x10000
  TLS            0x001350 0x3c001180 0x0000117c 0x00000 0x00004 R   0x4

 Section to Segment mapping:
  Segment Sections...
   00     .riscv.attributes 
   01     .mcuboot_header 
   02     .metadata 
   03     rodata initlevel device_area 
   04     _static_thread_data_area zbus_channel_area zbus_observer_area zbus_channel_observation_area 
   05     .iram0.text 
   06     .dram0.data sw_isr_table device_states k_heap_area k_msgq_area zbus_channel_observation_mask_area 
   07     log_const_area 
   08     .flash.text 
   09     .dram0.dummy bss noinit 
   10     .iram0.text_end 
   11     .flash_text_dummy 
   12     tbss 
```

```console
ESP-ROM:esp32c3-api1-20210207
Build:Feb  7 2021
rst:0x1 (POWERON),boot:0xd (SPI_FAST_FLASH_BOOT)
SPIWP:0xee
mode:DIO, clock div:2
load:0x3fcd8000,len:0x1018
load:0x403cad98,len:0x3d8c
load:0x403d0000,len:0x1a20
entry 0x403cc724
[esp32c3] [INF] MCUboot 2nd stage bootloader
[esp32c3] [INF] compiled at Feb  6 2024 13:32:20
[esp32c3] [INF] Chip revision: 3
[esp32c3] [INF] SPI Flash speed: 40MHz, mode: DIO, size: 4MB
[esp32c3] [INF] Image index: 0, Swap type: none
[esp32c3] [INF] Loading image 0 - slot 0 from flash, area id: 1
[esp32c3] [INF] Application start=403824E0h
[esp32c3] [INF] DRAM segment: paddr=00003F20h, vaddr=3FC85A40h, size=003AAh (   938) load
[esp32c3] [INF] IRAM segment: paddr=0000117Ch, vaddr=40380000h, size=02DA4h ( 11684) load
[esp32c3] [INF] DROM segment: paddr=00010040h, vaddr=3C000040h, size=0113Ch (  4412) map
[esp32c3] [INF] IROM segment: paddr=00020000h, vaddr=42020000h, size=044A0h ( 17568) map
E: 
E:  mcause: 7, Store/AMO access fault
E:   mtval: 3c001108
E:      a0: 00000004    t0: b7cea83c
E:      a1: 0000000a    t1: ec652ef3
E:      a2: 3fc85e3c    t2: 5e11b3c9
E:      a3: 3c001108    t3: b8712ce4
E:      a4: 3c001170    t4: f7d06428
E:      a5: 3c001160    t5: 9058e709
E:      a6: dfd3393b    t6: 9440849a
E:      a7: 48877149
E:      ra: 403809e0
E:    mepc: 42022d28
E: mstatus: 00001880
E: 
E: >>> ZEPHYR FATAL ERROR 0: CPU exception on CPU 0
E: Current thread: 0x3fc82f28 (unknown)
E: Halting system

(.venv) you@yours:~/zephyrproject/zephyr$ addr2line -e build/hello_world/zephyr/zephyr.elf 3c001108
/home/you/zephyrproject/zephyr/samples/subsys/zbus/hello_world/src/main.c:35
(.venv) you@yours:~/zephyrproject/zephyr$ addr2line -e build/hello_world/zephyr/zephyr.elf 42022d28
/home/you/zephyrproject/zephyr/subsys/zbus/zbus.c:67
```

## Working

**NOTE:** That the DROM and DRAM segments now contain all the sections they should.

```console
(.venv) you@yours:~/zephyrproject/zephyr$ readelf -l build/hello_world/zephyr/zephyr.elf 

Elf file type is EXEC (Executable file)
Entry point 0x403824e0
There are 11 program headers, starting at offset 52

Program Headers:
  Type           Offset   VirtAddr   PhysAddr   FileSiz MemSiz  Flg Align
  RISCV_ATTRIBUT 0x0db0a0 0x00000000 0x00000000 0x00044 0x00000 R   0x1
  LOAD           0x000194 0x00000000 0x00000000 0x00020 0x00020 R   0x1
  LOAD           0x0001b4 0x00000020 0x00000020 0x00020 0x00020 RW  0x4
  LOAD           0x0001d8 0x3c000040 0x00000040 0x01140 0x01140 RW  0x8
  LOAD           0x001400 0x40380000 0x00001180 0x02da4 0x02da4 R E 0x100
  LOAD           0x0041a4 0x3fc85a40 0x00003f24 0x003ac 0x003ac RW  0x4
  LOAD           0x010000 0x42020000 0x00010000 0x044a0 0x044a0 R E 0x10000
  LOAD           0x000000 0x3fc80000 0x3fc80000 0x00000 0x05a40 RW  0x10
  LOAD           0x000000 0x40382da4 0x40382da4 0x00000 0x0000c RW  0x1
  LOAD           0x000000 0x42000000 0x42000000 0x00000 0x10020 RW  0x10000
  TLS            0x001318 0x3c001180 0x00001180 0x00000 0x00004 R   0x4

 Section to Segment mapping:
  Segment Sections...
   00     .riscv.attributes 
   01     .mcuboot_header 
   02     .metadata 
   03     rodata initlevel device_area _static_thread_data_area zbus_channel_area zbus_observer_area zbus_channel_observation_area 
   04     .iram0.text 
   05     .dram0.data sw_isr_table device_states k_heap_area k_msgq_area zbus_channel_observation_mask_area log_const_area 
   06     .flash.text 
   07     .dram0.dummy bss noinit 
   08     .iram0.text_end 
   09     .flash_text_dummy 
   10     tbss 
```

```console
ESP-ROM:esp32c3-api1-20210207
Build:Feb  7 2021
rst:0x1 (POWERON),boot:0xd (SPI_FAST_FLASH_BOOT)
SPIWP:0xee
mode:DIO, clock div:2
load:0x3fcd8000,len:0x1018
load:0x403cad98,len:0x3d8c
load:0x403d0000,len:0x1a20
entry 0x403cc724
[esp32c3] [INF] MCUboot 2nd stage bootloader
[esp32c3] [INF] compiled at Feb  6 2024 13:00:07
[esp32c3] [INF] Chip revision: 3
[esp32c3] [INF] SPI Flash speed: 40MHz, mode: DIO, size: 4MB
[esp32c3] [INF] Image index: 0, Swap type: none
[esp32c3] [INF] Loading image 0 - slot 0 from flash, area id: 1
[esp32c3] [INF] Application start=403824E0h
[esp32c3] [INF] DRAM segment: paddr=00003F24h, vaddr=3FC85A40h, size=003ACh (   940) load
[esp32c3] [INF] IRAM segment: paddr=00001180h, vaddr=40380000h, size=02DA4h ( 11684) load
[esp32c3] [INF] DROM segment: paddr=00010040h, vaddr=3C000040h, size=01140h (  4416) map
[esp32c3] [INF] IROM segment: paddr=00020000h, vaddr=42020000h, size=044A0h ( 17568) map
I: Sensor sample started raw reading, version 0.1-2!
I: Channel list:
I: 0 - Channel acc_data_chan:
I:       Message size: 12
I:       Observers:
I:       - foo_lis
I:       - bar_sub
I: 1 - Channel simple_chan:
I:       Message size: 4
I:       Observers:
I: 2 - Channel version_chan:
I:       Message size: 4
I:       Observers:
I: Observers list:
I: 0 - Subscriber bar_sub
I: 1 - Listener foo_lis
I: From listener -> Acc x=1, y=1, z=1
I: From subscriber -> Acc x=1, y=1, z=1
I: From listener -> Acc x=2, y=2, z=2
I: From subscriber -> Acc x=2, y=2, z=2
I: Pub a valid value to a channel with validator successfully.
I: Pub an invalid value to a channel with validator successfully.
```
