### PR TITLE
version.h.in: Do not use @template@

### DIFF
--- a/version.h.in
+++ b/version.h.in
@@ -1,8 +1,8 @@
 #ifndef _@VERSION_TYPE@_VERSION_H_
 #define _@VERSION_TYPE@_VERSION_H_
 
-/* @templates@ values come from cmake/version.cmake
- * BUILD_VERSION related @template@ values will be 'git describe',
+/* The template values come from cmake/version.cmake
+ * BUILD_VERSION related template values will be 'git describe',
  * alternatively user defined BUILD_VERSION.
  */
 


### PR DESCRIPTION
@template@s will be replaced by empty strings and the comment in generated files will be broken.  Replace them with just simple words.