### PR TITLE
drivers: w1: fix return check in bit_read and bus_reset for w1-gpio

### DIFF
--- a/drivers/w1/w1_zephyr_gpio.c
+++ b/drivers/w1/w1_zephyr_gpio.c
@@ -156,10 +156,11 @@ static int w1_gpio_reset_bus(const struct device *dev)
 	}
 
 	W1_GPIO_WAIT_US(timing->i);
-	ret = gpio_pin_get_dt(spec) ^ 0x01;
+	ret = gpio_pin_get_dt(spec);
 	if (ret < 0) {
 		goto out;
 	}
+	ret ^= 0x01;
 
 	W1_GPIO_WAIT_US(timing->j);
 out:
@@ -190,10 +191,11 @@ static int w1_gpio_read_bit(const struct device *dev)
 	}
 
 	W1_GPIO_WAIT_US(timing->e);
-	ret = gpio_pin_get_dt(spec) & 0x01;
+	ret = gpio_pin_get_dt(spec);
 	if (ret < 0) {
 		goto out;
 	}
+	ret &= 0x01;
 
 	W1_GPIO_WAIT_US(timing->f);
 out:


### PR DESCRIPTION
The driver masked the return value of a pin read operation before checking the error.
Thus not detecting a potential error and leading to logically dead code, which was detected by coverity in CID 340853. Anther instance XORs 1 before returning, resulting in an unexpected return value

Fixes #67945