### PR TITLE
dts: arm: stm32h7 MPU attribute for the external Memory

### DIFF
--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -45,10 +45,10 @@
 		};
 	};
 
-	quadspi_memory: memory@90000000 {
-		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0x90000000 DT_SIZE_M(256)>;
-		zephyr,memory-region = "QSPI";
+	ext_memory: memory@90000000 {
+		compatible = "zephyr,memory-region";
+		reg = <0x90000000 DT_SIZE_M(256)>; /* max addressable area */
+		zephyr,memory-region = "EXTMEM";
 		zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_EXTMEM) )>;
 	};
 

--- a/dts/arm/st/h7/stm32h7a3.dtsi
+++ b/dts/arm/st/h7/stm32h7a3.dtsi
@@ -152,6 +152,13 @@
 		zephyr,memory-region = "ITCM";
 	};
 
+	ext_memory2: memory@70000000 {
+		compatible = "zephyr,memory-region";
+		reg = <0x70000000 DT_SIZE_M(256)>; /* max addressable area */
+		zephyr,memory-region = "EXTMEM2";
+		zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_EXTMEM) )>;
+	};
+
 	otghs_fs_phy: otghs_fs_phy {
 		compatible = "usb-nop-xceiv";
 		#phy-cells = <0>;


### PR DESCRIPTION
Define the MPU attribute to be ATTR_MPU_IO for the qspi region, starting at 0x90000000 of the stm32h7 serie. That will allow XiP on the external NOR flash octo-quad spi.

This change will prepare the XiP on external NOR flash with stm32h7 boards