### PR TITLE
logging: Add option to select/imply immediate mode

### DIFF
--- a/subsys/logging/Kconfig.mode
+++ b/subsys/logging/Kconfig.mode
@@ -5,6 +5,7 @@ choice LOG_MODE
 	prompt "Mode"
 	depends on !LOG_FRONTEND_ONLY
 	default LOG_MODE_MINIMAL if LOG_DEFAULT_MINIMAL
+	default LOG_MODE_IMMEDIATE if LOG_DEFAULT_IMMEDIATE
 	default LOG_MODE_DEFERRED
 
 config LOG_MODE_DEFERRED
@@ -69,6 +70,13 @@ config LOG_CUSTOM_HEADER
 
 config LOG_DEFAULT_MINIMAL
 	bool
+	help
+	  Can be used to select or imply minimal mode by other Kconfig option.
+
+config LOG_DEFAULT_IMMEDIATE
+	bool
+	help
+	  Can be used to select or imply immediate mode by other Kconfig option.
 
 config LOG_MULTIDOMAIN
 	bool "Multi-domain logger"


### PR DESCRIPTION
It's not possible to use choice entries for imply/select. Added LOG_DEFAULT_IMMEDIATE option which can be used with select/imply to set immadiate mode. Same approach was taken as for minimal mode where LOG_DEFAULT_MINIMAL can be used.

Added help entry for LOG_DEFAULT_MINIMAL.

Fixes #67378.