### PR TITLE
net: l2: wifi: Fix Print of SSID in WIFI scan result

### DIFF
--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -107,6 +107,7 @@ static void handle_wifi_scan_result(struct net_mgmt_event_callback *cb)
 		(const struct wifi_scan_result *)cb->info;
 	uint8_t mac_string_buf[sizeof("xx:xx:xx:xx:xx:xx")];
 	const struct shell *sh = context.sh;
+	uint8_t ssid_print[WIFI_SSID_MAX_LEN + 1];
 
 	context.scan_result++;
 
@@ -115,8 +116,11 @@ static void handle_wifi_scan_result(struct net_mgmt_event_callback *cb)
 		   "Num", "SSID", "(len)", "Chan (Band)", "RSSI", "Security", "BSSID", "MFP");
 	}
 
+	strncpy(ssid_print, entry->ssid, sizeof(ssid_print) - 1);
+	ssid_print[sizeof(ssid_print) - 1] = '\0';
+
 	PR("%-4d | %-32s %-5u | %-4u (%-6s) | %-4d | %-15s | %-17s | %-8s\n",
-	   context.scan_result, entry->ssid, entry->ssid_length, entry->channel,
+	   context.scan_result, ssid_print, entry->ssid_length, entry->channel,
 	   wifi_band_txt(entry->band),
 	   entry->rssi,
 	   wifi_security_txt(entry->security),


### PR DESCRIPTION
WIFI scan result shows junk character in SSID because of the length of ssid is maximum(32 character) which leads to buffer overflow. It required one character for null terminator ‘\0’.