### PR TITLE
ssd1306: add color inversion at run-time

### DIFF
--- a/drivers/display/ssd1306.c
+++ b/drivers/display/ssd1306.c
@@ -60,8 +60,6 @@ struct ssd1306_config {
 };
 
 struct ssd1306_data {
-	uint8_t contrast;
-	uint8_t scan_mode;
 	enum display_pixel_format pf;
 };
 
@@ -357,12 +355,12 @@ static void ssd1306_get_capabilities(const struct device *dev,
 	const struct ssd1306_config *config = dev->config;
 	struct ssd1306_data *data = dev->data;
 
-	memset(caps, 0, sizeof(struct display_capabilities));
 	caps->x_resolution = config->width;
 	caps->y_resolution = config->height;
 	caps->supported_pixel_formats = PIXEL_FORMAT_MONO10 | PIXEL_FORMAT_MONO01;
 	caps->current_pixel_format = data->pf;
 	caps->screen_info = SCREEN_INFO_MONO_VTILED;
+	caps->current_orientation = DISPLAY_ORIENTATION_NORMAL;
 }
 
 static int ssd1306_set_orientation(const struct device *dev,
@@ -461,8 +459,6 @@ static int ssd1306_init_device(const struct device *dev)
 static int ssd1306_init(const struct device *dev)
 {
 	const struct ssd1306_config *config = dev->config;
-
-	LOG_DBG("");
 
 	k_sleep(K_TIMEOUT_ABS_MS(config->ready_time_ms));
 

--- a/drivers/display/ssd1306.c
+++ b/drivers/display/ssd1306.c
@@ -62,6 +62,7 @@ struct ssd1306_config {
 struct ssd1306_data {
 	uint8_t contrast;
 	uint8_t scan_mode;
+	enum display_pixel_format pf;
 };
 
 #if (DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(solomon_ssd1306fb, i2c) || \
@@ -354,11 +355,13 @@ static void ssd1306_get_capabilities(const struct device *dev,
 				     struct display_capabilities *caps)
 {
 	const struct ssd1306_config *config = dev->config;
+	struct ssd1306_data *data = dev->data;
+
 	memset(caps, 0, sizeof(struct display_capabilities));
 	caps->x_resolution = config->width;
 	caps->y_resolution = config->height;
-	caps->supported_pixel_formats = PIXEL_FORMAT_MONO10;
-	caps->current_pixel_format = PIXEL_FORMAT_MONO10;
+	caps->supported_pixel_formats = PIXEL_FORMAT_MONO10 | PIXEL_FORMAT_MONO01;
+	caps->current_pixel_format = data->pf;
 	caps->screen_info = SCREEN_INFO_MONO_VTILED;
 }
 
@@ -373,22 +376,45 @@ static int ssd1306_set_orientation(const struct device *dev,
 static int ssd1306_set_pixel_format(const struct device *dev,
 				    const enum display_pixel_format pf)
 {
-	if (pf == PIXEL_FORMAT_MONO10) {
+	struct ssd1306_data *data = dev->data;
+	uint8_t cmd;
+	int ret;
+
+	if (pf == data->pf) {
 		return 0;
 	}
-	LOG_ERR("Unsupported");
-	return -ENOTSUP;
+
+	if (pf == PIXEL_FORMAT_MONO10) {
+		cmd = SSD1306_SET_REVERSE_DISPLAY;
+	} else if (pf == PIXEL_FORMAT_MONO01) {
+		cmd = SSD1306_SET_NORMAL_DISPLAY;
+	} else {
+		LOG_WRN("Unsupported pixel format");
+		return -ENOTSUP;
+	}
+
+	ret = ssd1306_write_bus(dev, &cmd, 1, true);
+	if (ret) {
+		return ret;
+	}
+
+	data->pf = pf;
+
+	return 0;
 }
 
 static int ssd1306_init_device(const struct device *dev)
 {
 	const struct ssd1306_config *config = dev->config;
+	struct ssd1306_data *data = dev->data;
 
 	uint8_t cmd_buf[] = {
 		SSD1306_SET_ENTIRE_DISPLAY_OFF,
 		(config->color_inversion ? SSD1306_SET_REVERSE_DISPLAY
 					 : SSD1306_SET_NORMAL_DISPLAY),
 	};
+
+	data->pf = config->color_inversion ? PIXEL_FORMAT_MONO10 : PIXEL_FORMAT_MONO01;
 
 	/* Reset if pin connected */
 	if (config->reset.port) {

--- a/drivers/display/ssd1306_regs.h
+++ b/drivers/display/ssd1306_regs.h
@@ -28,7 +28,9 @@
 #define SSD1306_SET_ENTIRE_DISPLAY_OFF		0xa4
 #define SSD1306_SET_ENTIRE_DISPLAY_ON		0xa5
 
+/* RAM data of 1 indicates an "ON" pixel */
 #define SSD1306_SET_NORMAL_DISPLAY		0xa6
+/* RAM data of 0 indicates an "ON" pixel */
 #define SSD1306_SET_REVERSE_DISPLAY		0xa7
 
 #define SSD1306_DISPLAY_OFF			0xae


### PR DESCRIPTION
This PR implements the color inversion at run-time via the `display_set_pixel_format` function for the ssd1306 display.

I also extended `display_get_capabilities`, s.t. it returns the current pixel format.

~~Since it is now possible to do this at run-time, I removed the compile-time configuration `color_inversion`. But I will happily revert this commit (the last one), if wished.~~ Nvm, I dropped the last commit again. I came to the conclusion, that it still makes sense to have the compile-time option, which could then be adjusted later on during run-time.