### PR TITLE
Bluetooth: ISO: Introduce bt_iso_chan_send_ts

### DIFF
--- a/doc/releases/migration-guide-3.6.rst
+++ b/doc/releases/migration-guide-3.6.rst
@@ -433,6 +433,9 @@ Bluetooth
 * The :c:func:`bt_l2cap_chan_send` API now requires the application to reserve
   enough bytes for the L2CAP headers. Call ``net_buf_reserve(buf,
   BT_L2CAP_SDU_CHAN_SEND_RESERVE);`` at buffer allocation time to do so.
+* `BT_ISO_TIMESTAMP_NONE` has been removed and the `ts` parameter of :c:func:`bt_iso_chan_send` has
+  as well. :c:func:`bt_iso_chan_send` now always sends without timestamp. To send with a timestamp,
+  :c:func:`bt_iso_chan_send_ts` can be used.
 
 * Mesh
 
@@ -477,6 +480,13 @@ Bluetooth
     E.g. ``bt_audio_codec_config_freq`` is now ``bt_audio_codec_cfg_freq``,
     ``bt_audio_codec_capability_type`` is now ``bt_audio_codec_cap_type``,
     ``bt_audio_codec_config_type`` is now ``bt_audio_codec_cfg_type``, etc. (:github:`67024`)
+  * The `ts` parameter of :c:func:`bt_bap_stream_send` has been removed.
+    :c:func:`bt_bap_stream_send` now always sends without timestamp.
+    To send with a timestamp, :c:func:`bt_bap_stream_send_ts` can be used.
+  * The `ts` parameter of :c:func:`bt_cap_stream_send` has been removed.
+    :c:func:`bt_cap_stream_send` now always sends without timestamp.
+    To send with a timestamp, :c:func:`bt_cap_stream_send_ts` can be used.
+
 
 LoRaWAN
 =======

--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -770,7 +770,23 @@ int bt_bap_stream_stop(struct bt_bap_stream *stream);
 int bt_bap_stream_release(struct bt_bap_stream *stream);
 
 /**
- * @brief Send data to Audio stream
+ * @brief Send data to Audio stream without timestamp
+ *
+ * Send data from buffer to the stream.
+ *
+ * @note Support for sending must be supported, determined by @kconfig{CONFIG_BT_AUDIO_TX}.
+ *
+ * @param stream   Stream object.
+ * @param buf      Buffer containing data to be sent.
+ * @param seq_num  Packet Sequence number. This value shall be incremented for each call to this
+ *                 function and at least once per SDU interval for a specific channel.
+ *
+ * @return Bytes sent in case of success or negative value in case of error.
+ */
+int bt_bap_stream_send(struct bt_bap_stream *stream, struct net_buf *buf, uint16_t seq_num);
+
+/**
+ * @brief Send data to Audio stream with timestamp
  *
  * Send data from buffer to the stream.
  *
@@ -781,14 +797,12 @@ int bt_bap_stream_release(struct bt_bap_stream *stream);
  * @param seq_num  Packet Sequence number. This value shall be incremented for each call to this
  *                 function and at least once per SDU interval for a specific channel.
  * @param ts       Timestamp of the SDU in microseconds (us). This value can be used to transmit
- *                 multiple SDUs in the same SDU interval in a CIG or BIG. Can be omitted by using
- *                 @ref BT_ISO_TIMESTAMP_NONE which will simply enqueue the ISO SDU in a FIFO
- *                 manner.
+ *                 multiple SDUs in the same SDU interval in a CIG or BIG.
  *
  * @return Bytes sent in case of success or negative value in case of error.
  */
-int bt_bap_stream_send(struct bt_bap_stream *stream, struct net_buf *buf, uint16_t seq_num,
-		       uint32_t ts);
+int bt_bap_stream_send_ts(struct bt_bap_stream *stream, struct net_buf *buf, uint16_t seq_num,
+			  uint32_t ts);
 
 /**
  * @brief Get ISO transmission timing info for a Basic Audio Profile stream

--- a/include/zephyr/bluetooth/audio/cap.h
+++ b/include/zephyr/bluetooth/audio/cap.h
@@ -158,7 +158,24 @@ struct bt_cap_stream {
 void bt_cap_stream_ops_register(struct bt_cap_stream *stream, struct bt_bap_stream_ops *ops);
 
 /**
- * @brief Send data to Common Audio Profile stream
+ * @brief Send data to Common Audio Profile stream without timestamp
+ *
+ * See bt_bap_stream_send() for more information
+ *
+ * @note Support for sending must be supported, determined by @kconfig{CONFIG_BT_AUDIO_TX}.
+ *
+ * @param stream   Stream object.
+ * @param buf      Buffer containing data to be sent.
+ * @param seq_num  Packet Sequence number. This value shall be incremented for each call to this
+ *                 function and at least once per SDU interval for a specific channel.
+ *
+ * @retval -EINVAL if stream object is NULL
+ * @retval Any return value from bt_bap_stream_send()
+ */
+int bt_cap_stream_send(struct bt_cap_stream *stream, struct net_buf *buf, uint16_t seq_num);
+
+/**
+ * @brief Send data to Common Audio Profile stream with timestamp
  *
  * See bt_bap_stream_send() for more information
  *
@@ -169,15 +186,13 @@ void bt_cap_stream_ops_register(struct bt_cap_stream *stream, struct bt_bap_stre
  * @param seq_num  Packet Sequence number. This value shall be incremented for each call to this
  *                 function and at least once per SDU interval for a specific channel.
  * @param ts       Timestamp of the SDU in microseconds (us). This value can be used to transmit
- *                 multiple SDUs in the same SDU interval in a CIG or BIG. Can be omitted by using
- *                 @ref BT_ISO_TIMESTAMP_NONE which will simply enqueue the ISO SDU in a FIFO
- *                 manner.
+ *                 multiple SDUs in the same SDU interval in a CIG or BIG.
  *
  * @retval -EINVAL if stream object is NULL
  * @retval Any return value from bt_bap_stream_send()
  */
-int bt_cap_stream_send(struct bt_cap_stream *stream, struct net_buf *buf, uint16_t seq_num,
-		       uint32_t ts);
+int bt_cap_stream_send_ts(struct bt_cap_stream *stream, struct net_buf *buf, uint16_t seq_num,
+			  uint32_t ts);
 
 /**
  * @brief Get ISO transmission timing info for a Common Audio Profile stream

--- a/include/zephyr/bluetooth/iso.h
+++ b/include/zephyr/bluetooth/iso.h
@@ -118,14 +118,6 @@ extern "C" {
 /** Maximum pre-transmission offset */
 #define BT_ISO_PTO_MAX              0x0FU
 
-
-/** Omit time stamp when sending to controller
- *
- * Using this value will enqueue the ISO SDU in a FIFO manner, instead of
- * transmitting it at a specified timestamp.
- */
-#define BT_ISO_TIMESTAMP_NONE 0U
-
 /** @brief Life-span states of ISO channel. Used only by internal APIs
  *  dealing with setting channel to proper state depending on operational
  *  context.
@@ -843,7 +835,27 @@ int bt_iso_chan_connect(const struct bt_iso_connect_param *param, size_t count);
  */
 int bt_iso_chan_disconnect(struct bt_iso_chan *chan);
 
-/** @brief Send data to ISO channel
+/** @brief Send data to ISO channel without timestamp
+ *
+ *  Send data from buffer to the channel. If credits are not available, buf will
+ *  be queued and sent as and when credits are received from peer.
+ *  Regarding to first input parameter, to get details see reference description
+ *  to bt_iso_chan_connect() API above.
+ *
+ *  @note Buffer ownership is transferred to the stack in case of success, in
+ *  case of an error the caller retains the ownership of the buffer.
+ *
+ *  @param chan     Channel object.
+ *  @param buf      Buffer containing data to be sent.
+ *  @param seq_num  Packet Sequence number. This value shall be incremented for
+ *                  each call to this function and at least once per SDU
+ *                  interval for a specific channel.
+ *
+ *  @return Bytes sent in case of success or negative value in case of error.
+ */
+int bt_iso_chan_send(struct bt_iso_chan *chan, struct net_buf *buf, uint16_t seq_num);
+
+/** @brief Send data to ISO channel with timestamp
  *
  *  Send data from buffer to the channel. If credits are not available, buf will
  *  be queued and sent as and when credits are received from peer.
@@ -860,14 +872,12 @@ int bt_iso_chan_disconnect(struct bt_iso_chan *chan);
  *                  interval for a specific channel.
  *  @param ts       Timestamp of the SDU in microseconds (us).
  *                  This value can be used to transmit multiple
- *                  SDUs in the same SDU interval in a CIG or BIG. Can be
- *                  omitted by using @ref BT_ISO_TIMESTAMP_NONE which will
- *                  simply enqueue the ISO SDU in a FIFO manner.
+ *                  SDUs in the same SDU interval in a CIG or BIG.
  *
  *  @return Bytes sent in case of success or negative value in case of error.
  */
-int bt_iso_chan_send(struct bt_iso_chan *chan, struct net_buf *buf,
-		     uint16_t seq_num, uint32_t ts);
+int bt_iso_chan_send_ts(struct bt_iso_chan *chan, struct net_buf *buf, uint16_t seq_num,
+			uint32_t ts);
 
 /** @brief ISO Unicast TX Info Structure */
 struct bt_iso_unicast_tx_info {

--- a/samples/bluetooth/broadcast_audio_source/src/main.c
+++ b/samples/bluetooth/broadcast_audio_source/src/main.c
@@ -198,7 +198,7 @@ static void send_data(struct broadcast_source_stream *source_stream)
 	net_buf_add_mem(buf, send_pcm_data, preset_active.qos.sdu);
 #endif /* defined(CONFIG_LIBLC3) */
 
-	ret = bt_bap_stream_send(stream, buf, source_stream->seq_num++, BT_ISO_TIMESTAMP_NONE);
+	ret = bt_bap_stream_send(stream, buf, source_stream->seq_num++);
 	if (ret < 0) {
 		/* This will end broadcasting on this stream. */
 		printk("Unable to broadcast data on %p: %d\n", stream, ret);

--- a/samples/bluetooth/central_iso/src/main.c
+++ b/samples/bluetooth/central_iso/src/main.c
@@ -64,7 +64,7 @@ static void iso_timer_timeout(struct k_work *work)
 
 	net_buf_add_mem(buf, buf_data, len_to_send);
 
-	ret = bt_iso_chan_send(&iso_chan, buf, seq_num++, BT_ISO_TIMESTAMP_NONE);
+	ret = bt_iso_chan_send(&iso_chan, buf, seq_num++);
 
 	if (ret < 0) {
 		printk("Failed to send ISO data (%d)\n", ret);

--- a/samples/bluetooth/hap_ha/src/bap_unicast_sr.c
+++ b/samples/bluetooth/hap_ha/src/bap_unicast_sr.c
@@ -159,9 +159,7 @@ static void audio_timer_timeout(struct k_work *work)
 
 		net_buf_add_mem(buf, buf_data, len_to_send);
 
-		ret = bt_bap_stream_send(stream, buf,
-					   get_and_incr_seq_num(stream),
-					   BT_ISO_TIMESTAMP_NONE);
+		ret = bt_bap_stream_send(stream, buf, get_and_incr_seq_num(stream));
 		if (ret < 0) {
 			printk("Failed to send audio data on streams[%zu] (%p): (%d)\n",
 			       i, stream, ret);

--- a/samples/bluetooth/iso_broadcast/src/main.c
+++ b/samples/bluetooth/iso_broadcast/src/main.c
@@ -171,8 +171,7 @@ int main(void)
 			net_buf_reserve(buf, BT_ISO_CHAN_SEND_RESERVE);
 			sys_put_le32(iso_send_count, iso_data);
 			net_buf_add_mem(buf, iso_data, sizeof(iso_data));
-			ret = bt_iso_chan_send(&bis_iso_chan[chan], buf,
-					       seq_num, BT_ISO_TIMESTAMP_NONE);
+			ret = bt_iso_chan_send(&bis_iso_chan[chan], buf, seq_num);
 			if (ret < 0) {
 				printk("Unable to broadcast data on channel %u"
 				       " : %d", chan, ret);

--- a/samples/bluetooth/iso_broadcast_benchmark/src/broadcaster.c
+++ b/samples/bluetooth/iso_broadcast_benchmark/src/broadcaster.c
@@ -593,8 +593,7 @@ static void iso_timer_timeout(struct k_work *work)
 
 		net_buf_reserve(buf, BT_ISO_CHAN_SEND_RESERVE);
 		net_buf_add_mem(buf, iso_data, iso_tx_qos.sdu);
-		ret = bt_iso_chan_send(&bis_iso_chans[i], buf, seq_num,
-				       BT_ISO_TIMESTAMP_NONE);
+		ret = bt_iso_chan_send(&bis_iso_chans[i], buf, seq_num);
 		if (ret < 0) {
 			LOG_ERR("Unable to broadcast data: %d", ret);
 			net_buf_unref(buf);

--- a/samples/bluetooth/iso_connected_benchmark/src/main.c
+++ b/samples/bluetooth/iso_connected_benchmark/src/main.c
@@ -207,8 +207,7 @@ static void iso_send(struct bt_iso_chan *chan)
 	net_buf_reserve(buf, BT_ISO_CHAN_SEND_RESERVE);
 	net_buf_add_mem(buf, iso_data, iso_tx_qos.sdu);
 
-	ret = bt_iso_chan_send(chan, buf, chan_work->seq_num++,
-			       BT_ISO_TIMESTAMP_NONE);
+	ret = bt_iso_chan_send(chan, buf, chan_work->seq_num++);
 	if (ret < 0) {
 		LOG_ERR("Unable to send data: %d", ret);
 		net_buf_unref(buf);

--- a/samples/bluetooth/public_broadcast_source/src/main.c
+++ b/samples/bluetooth/public_broadcast_source/src/main.c
@@ -104,7 +104,7 @@ static void broadcast_sent_cb(struct bt_bap_stream *stream)
 
 	net_buf_reserve(buf, BT_ISO_CHAN_SEND_RESERVE);
 	net_buf_add_mem(buf, mock_data, broadcast_preset_48_2_1.qos.sdu);
-	ret = bt_bap_stream_send(stream, buf, seq_num++, BT_ISO_TIMESTAMP_NONE);
+	ret = bt_bap_stream_send(stream, buf, seq_num++);
 	if (ret < 0) {
 		/* This will end broadcasting on this stream. */
 		net_buf_unref(buf);

--- a/samples/bluetooth/tmap_bms/src/cap_initiator.c
+++ b/samples/bluetooth/tmap_bms/src/cap_initiator.c
@@ -93,7 +93,7 @@ static void broadcast_sent_cb(struct bt_bap_stream *stream)
 
 	net_buf_reserve(buf, BT_ISO_CHAN_SEND_RESERVE);
 	net_buf_add_mem(buf, mock_data, broadcast_preset_48_2_1.qos.sdu);
-	ret = bt_bap_stream_send(stream, buf, seq_num++, BT_ISO_TIMESTAMP_NONE);
+	ret = bt_bap_stream_send(stream, buf, seq_num++);
 	if (ret < 0) {
 		/* This will end broadcasting on this stream. */
 		net_buf_unref(buf);

--- a/samples/bluetooth/tmap_central/src/cap_initiator.c
+++ b/samples/bluetooth/tmap_central/src/cap_initiator.c
@@ -387,7 +387,7 @@ static void audio_timer_timeout(struct k_work *work)
 	net_buf_add_mem(buf, buf_data, len_to_send);
 	buf_to_send = buf;
 
-	ret = bt_bap_stream_send(stream, buf_to_send, 0, BT_ISO_TIMESTAMP_NONE);
+	ret = bt_bap_stream_send(stream, buf_to_send, 0);
 	if (ret < 0) {
 		printk("Failed to send audio data on streams: (%d)\n", ret);
 		net_buf_unref(buf_to_send);

--- a/samples/bluetooth/unicast_audio_client/src/main.c
+++ b/samples/bluetooth/unicast_audio_client/src/main.c
@@ -206,9 +206,7 @@ static void lc3_audio_timer_timeout(struct k_work *work)
 				buf_to_send = net_buf_clone(buf, K_FOREVER);
 			}
 
-			ret = bt_bap_stream_send(stream, buf_to_send,
-						   get_and_incr_seq_num(stream),
-						   BT_ISO_TIMESTAMP_NONE);
+			ret = bt_bap_stream_send(stream, buf_to_send, get_and_incr_seq_num(stream));
 			if (ret < 0) {
 				printk("  Failed to send LC3 audio data on streams[%zu] (%d)\n",
 				       i, ret);
@@ -337,9 +335,7 @@ static void audio_timer_timeout(struct k_work *work)
 			buf_to_send = net_buf_clone(buf, K_FOREVER);
 		}
 
-		ret = bt_bap_stream_send(stream, buf_to_send,
-					   get_and_incr_seq_num(stream),
-					   BT_ISO_TIMESTAMP_NONE);
+		ret = bt_bap_stream_send(stream, buf_to_send, get_and_incr_seq_num(stream));
 		if (ret < 0) {
 			printk("Failed to send audio data on streams[%zu]: (%d)\n",
 			       i, ret);

--- a/samples/bluetooth/unicast_audio_server/src/main.c
+++ b/samples/bluetooth/unicast_audio_server/src/main.c
@@ -218,9 +218,7 @@ static void audio_timer_timeout(struct k_work *work)
 
 		net_buf_add_mem(buf, buf_data, ++source_streams[i].len_to_send);
 
-		ret = bt_bap_stream_send(stream, buf,
-					   get_and_incr_seq_num(stream),
-					   BT_ISO_TIMESTAMP_NONE);
+		ret = bt_bap_stream_send(stream, buf, get_and_incr_seq_num(stream));
 		if (ret < 0) {
 			printk("Failed to send audio data on streams[%zu] (%p): (%d)\n",
 			       i, stream, ret);

--- a/subsys/bluetooth/audio/cap_stream.c
+++ b/subsys/bluetooth/audio/cap_stream.c
@@ -247,8 +247,7 @@ void bt_cap_stream_ops_register(struct bt_cap_stream *stream,
 }
 
 #if defined(CONFIG_BT_AUDIO_TX)
-int bt_cap_stream_send(struct bt_cap_stream *stream, struct net_buf *buf, uint16_t seq_num,
-		       uint32_t ts)
+int bt_cap_stream_send(struct bt_cap_stream *stream, struct net_buf *buf, uint16_t seq_num)
 {
 	CHECKIF(stream == NULL) {
 		LOG_DBG("stream is NULL");
@@ -256,7 +255,19 @@ int bt_cap_stream_send(struct bt_cap_stream *stream, struct net_buf *buf, uint16
 		return -EINVAL;
 	}
 
-	return bt_bap_stream_send(&stream->bap_stream, buf, seq_num, ts);
+	return bt_bap_stream_send(&stream->bap_stream, buf, seq_num);
+}
+
+int bt_cap_stream_send_ts(struct bt_cap_stream *stream, struct net_buf *buf, uint16_t seq_num,
+			  uint32_t ts)
+{
+	CHECKIF(stream == NULL) {
+		LOG_DBG("stream is NULL");
+
+		return -EINVAL;
+	}
+
+	return bt_bap_stream_send_ts(&stream->bap_stream, buf, seq_num, ts);
 }
 
 int bt_cap_stream_get_tx_sync(struct bt_cap_stream *stream, struct bt_iso_tx_info *info)

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -351,7 +351,7 @@ static void lc3_audio_send_data(struct k_work *work)
 		}
 	}
 
-	err = bt_bap_stream_send(bap_stream, buf, sh_stream->seq_num, BT_ISO_TIMESTAMP_NONE);
+	err = bt_bap_stream_send(bap_stream, buf, sh_stream->seq_num);
 	if (err < 0) {
 		shell_error(ctx_shell, "Failed to send LC3 audio data (%d)", err);
 		net_buf_unref(buf);
@@ -2546,8 +2546,7 @@ static int cmd_send(const struct shell *sh, size_t argc, char *argv[])
 
 	net_buf_add_mem(buf, data, len);
 
-	ret = bt_bap_stream_send(default_stream, buf, get_next_seq_num(default_stream),
-				 BT_ISO_TIMESTAMP_NONE);
+	ret = bt_bap_stream_send(default_stream, buf, get_next_seq_num(default_stream));
 	if (ret < 0) {
 		shell_print(sh, "Unable to send: %d", -ret);
 		net_buf_unref(buf);

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -730,8 +730,7 @@ void bt_iso_recv(struct bt_conn *iso, struct net_buf *buf, uint8_t flags)
 #endif /* CONFIG_BT_ISO_UNICAST) || defined(CONFIG_BT_ISO_SYNC_RECEIVER */
 
 #if defined(CONFIG_BT_ISO_UNICAST) || defined(CONFIG_BT_ISO_BROADCASTER)
-static uint16_t iso_chan_max_data_len(const struct bt_iso_chan *chan,
-				      uint32_t ts)
+static uint16_t iso_chan_max_data_len(const struct bt_iso_chan *chan)
 {
 	size_t max_controller_data_len;
 	uint16_t max_data_len;
@@ -751,11 +750,11 @@ static uint16_t iso_chan_max_data_len(const struct bt_iso_chan *chan,
 	return max_data_len;
 }
 
-int bt_iso_chan_send(struct bt_iso_chan *chan, struct net_buf *buf,
-		     uint16_t seq_num, uint32_t ts)
+static int validate_send(const struct bt_iso_chan *chan, const struct net_buf *buf,
+			 uint8_t hdr_size)
 {
+	const struct bt_conn *iso_conn;
 	uint16_t max_data_len;
-	struct bt_conn *iso_conn;
 
 	CHECKIF(!chan || !buf) {
 		LOG_DBG("Invalid parameters: chan %p buf %p", chan, buf);
@@ -775,46 +774,67 @@ int bt_iso_chan_send(struct bt_iso_chan *chan, struct net_buf *buf,
 		return -EINVAL;
 	}
 
-	if (ts == BT_ISO_TIMESTAMP_NONE &&
-	    buf->size < BT_HCI_ISO_DATA_HDR_SIZE) {
+	if (buf->size < hdr_size) {
 		LOG_DBG("Cannot send ISO packet with buffer size %u", buf->size);
-
-		return -EMSGSIZE;
-	} else if (buf->size < BT_HCI_ISO_TS_DATA_HDR_SIZE) {
-		LOG_DBG("Cannot send ISO packet with timestamp with buffer size %u", buf->size);
 
 		return -EMSGSIZE;
 	}
 
-	max_data_len = iso_chan_max_data_len(chan, ts);
+	max_data_len = iso_chan_max_data_len(chan);
 	if (buf->len > max_data_len) {
 		LOG_DBG("Cannot send %u octets, maximum %u", buf->len, max_data_len);
 		return -EMSGSIZE;
 	}
 
-	if (ts == BT_ISO_TIMESTAMP_NONE) {
-		struct bt_hci_iso_data_hdr *hdr;
+	return 0;
+}
 
-		hdr = net_buf_push(buf, sizeof(*hdr));
-		hdr->sn = sys_cpu_to_le16(seq_num);
-		hdr->slen = sys_cpu_to_le16(bt_iso_pkt_len_pack(net_buf_frags_len(buf)
-								- sizeof(*hdr),
-								BT_ISO_DATA_VALID));
-	} else {
-		struct bt_hci_iso_ts_data_hdr *hdr;
+int bt_iso_chan_send(struct bt_iso_chan *chan, struct net_buf *buf, uint16_t seq_num)
+{
+	struct bt_hci_iso_data_hdr *hdr;
+	struct bt_conn *iso_conn;
+	int err;
 
-		hdr = net_buf_push(buf, sizeof(*hdr));
-		hdr->ts = ts;
-		hdr->data.sn = sys_cpu_to_le16(seq_num);
-		hdr->data.slen = sys_cpu_to_le16(bt_iso_pkt_len_pack(net_buf_frags_len(buf)
-								     - sizeof(*hdr),
-								     BT_ISO_DATA_VALID));
+	err = validate_send(chan, buf, BT_HCI_ISO_DATA_HDR_SIZE);
+	if (err != 0) {
+		return err;
 	}
 
-	return bt_conn_send_iso_cb(iso_conn,
-				   buf,
-				   bt_iso_send_cb,
-				   ts != BT_ISO_TIMESTAMP_NONE);
+	BT_ISO_DATA_DBG("chan %p len %zu", chan, net_buf_frags_len(buf));
+
+	hdr = net_buf_push(buf, sizeof(*hdr));
+	hdr->sn = sys_cpu_to_le16(seq_num);
+	hdr->slen = sys_cpu_to_le16(
+		bt_iso_pkt_len_pack(net_buf_frags_len(buf) - sizeof(*hdr), BT_ISO_DATA_VALID));
+
+	iso_conn = chan->iso;
+
+	return bt_conn_send_iso_cb(iso_conn, buf, bt_iso_send_cb, false);
+}
+
+int bt_iso_chan_send_ts(struct bt_iso_chan *chan, struct net_buf *buf, uint16_t seq_num,
+			uint32_t ts)
+{
+	struct bt_hci_iso_ts_data_hdr *hdr;
+	struct bt_conn *iso_conn;
+	int err;
+
+	err = validate_send(chan, buf, BT_HCI_ISO_TS_DATA_HDR_SIZE);
+	if (err != 0) {
+		return err;
+	}
+
+	BT_ISO_DATA_DBG("chan %p len %zu", chan, net_buf_frags_len(buf));
+
+	hdr = net_buf_push(buf, sizeof(*hdr));
+	hdr->ts = ts;
+	hdr->data.sn = sys_cpu_to_le16(seq_num);
+	hdr->data.slen = sys_cpu_to_le16(
+		bt_iso_pkt_len_pack(net_buf_frags_len(buf) - sizeof(*hdr), BT_ISO_DATA_VALID));
+
+	iso_conn = chan->iso;
+
+	return bt_conn_send_iso_cb(iso_conn, buf, bt_iso_send_cb, true);
 }
 
 #if defined(CONFIG_BT_ISO_CENTRAL) || defined(CONFIG_BT_ISO_BROADCASTER)

--- a/subsys/bluetooth/shell/iso.c
+++ b/subsys/bluetooth/shell/iso.c
@@ -582,8 +582,7 @@ static int cmd_send(const struct shell *sh, size_t argc, char *argv[])
 
 		net_buf_add_mem(buf, buf_data, len);
 		shell_info(sh, "send: %d bytes of data with PSN %u", len, cis_sn_last);
-		ret = bt_iso_chan_send(&iso_chan, buf, cis_sn_last,
-				       BT_ISO_TIMESTAMP_NONE);
+		ret = bt_iso_chan_send(&iso_chan, buf, cis_sn_last);
 		if (ret < 0) {
 			shell_print(sh, "Unable to send: %d", -ret);
 			net_buf_unref(buf);
@@ -699,7 +698,7 @@ static int cmd_broadcast(const struct shell *sh, size_t argc, char *argv[])
 
 		net_buf_add_mem(buf, buf_data, len);
 		shell_info(sh, "send: %d bytes of data with PSN %u", len, bis_sn_last);
-		ret = bt_iso_chan_send(&bis_iso_chan, buf, bis_sn_last, BT_ISO_TIMESTAMP_NONE);
+		ret = bt_iso_chan_send(&bis_iso_chan, buf, bis_sn_last);
 		if (ret < 0) {
 			shell_print(sh, "Unable to broadcast: %d", -ret);
 			net_buf_unref(buf);

--- a/tests/bluetooth/audio/bap_broadcast_source/src/main.c
+++ b/tests/bluetooth/audio/bap_broadcast_source/src/main.c
@@ -228,7 +228,7 @@ ZTEST_F(bap_broadcast_source_test_suite, test_broadcast_source_create_start_send
 			struct bt_bap_stream *bap_stream = create_param->params[i].params[j].stream;
 
 			/* Since BAP doesn't care about the `buf` we can just provide NULL */
-			err = bt_bap_stream_send(bap_stream, NULL, 0, BT_ISO_TIMESTAMP_NONE);
+			err = bt_bap_stream_send(bap_stream, NULL, 0);
 			zassert_equal(0, err,
 				      "Unable to send on broadcast stream[%zu][%zu]: err %d", i, j,
 				      err);

--- a/tests/bluetooth/audio/mocks/src/iso.c
+++ b/tests/bluetooth/audio/mocks/src/iso.c
@@ -18,7 +18,17 @@ static struct bt_iso_server *iso_server;
 DEFINE_FAKE_VALUE_FUNC(int, bt_iso_chan_get_tx_sync, const struct bt_iso_chan *,
 		       struct bt_iso_tx_info *);
 
-int bt_iso_chan_send(struct bt_iso_chan *chan, struct net_buf *buf, uint16_t seq_num, uint32_t ts)
+int bt_iso_chan_send(struct bt_iso_chan *chan, struct net_buf *buf, uint16_t seq_num)
+{
+	if (chan->ops != NULL && chan->ops->sent != NULL) {
+		chan->ops->sent(chan);
+	}
+
+	return 0;
+}
+
+int bt_iso_chan_send_ts(struct bt_iso_chan *chan, struct net_buf *buf, uint16_t seq_num,
+			uint32_t ts)
 {
 	if (chan->ops != NULL && chan->ops->sent != NULL) {
 		chan->ops->sent(chan);

--- a/tests/bluetooth/tester/src/btp_bap_audio_stream.c
+++ b/tests/bluetooth/tester/src/btp_bap_audio_stream.c
@@ -98,7 +98,7 @@ static void audio_send_timeout(struct k_work *work)
 			LOG_DBG("Sending data to stream %p len %d seq %d", bap_stream, size,
 				stream->last_req_seq_num);
 
-			err = bt_bap_stream_send(bap_stream, buf, 0, BT_ISO_TIMESTAMP_NONE);
+			err = bt_bap_stream_send(bap_stream, buf, 0);
 			if (err != 0) {
 				LOG_ERR("Failed to send audio data to stream %p, err %d",
 					bap_stream, err);

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_source_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_source_test.c
@@ -72,7 +72,7 @@ static void stream_sent_cb(struct bt_bap_stream *stream)
 
 	net_buf_reserve(buf, BT_ISO_CHAN_SEND_RESERVE);
 	net_buf_add_mem(buf, mock_iso_data, test_stream->tx_sdu_size);
-	ret = bt_bap_stream_send(stream, buf, test_stream->seq_num++, BT_ISO_TIMESTAMP_NONE);
+	ret = bt_bap_stream_send(stream, buf, test_stream->seq_num++);
 	if (ret < 0) {
 		/* This will end broadcasting on this stream. */
 		net_buf_unref(buf);

--- a/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
@@ -190,7 +190,7 @@ static void stream_sent_cb(struct bt_bap_stream *stream)
 
 	net_buf_reserve(buf, BT_ISO_CHAN_SEND_RESERVE);
 	net_buf_add_mem(buf, mock_iso_data, test_stream->tx_sdu_size);
-	ret = bt_bap_stream_send(stream, buf, test_stream->seq_num++, BT_ISO_TIMESTAMP_NONE);
+	ret = bt_bap_stream_send(stream, buf, test_stream->seq_num++);
 	if (ret < 0) {
 		/* This will end broadcasting on this stream. */
 		net_buf_unref(buf);

--- a/tests/bsim/bluetooth/audio/src/bap_unicast_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_unicast_server_test.c
@@ -304,7 +304,7 @@ static void stream_sent_cb(struct bt_bap_stream *stream)
 
 	net_buf_reserve(buf, BT_ISO_CHAN_SEND_RESERVE);
 	net_buf_add_mem(buf, mock_iso_data, test_stream->tx_sdu_size);
-	ret = bt_bap_stream_send(stream, buf, test_stream->seq_num++, BT_ISO_TIMESTAMP_NONE);
+	ret = bt_bap_stream_send(stream, buf, test_stream->seq_num++);
 	if (ret < 0) {
 		/* This will end broadcasting on this stream. */
 		net_buf_unref(buf);

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_broadcast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_broadcast_test.c
@@ -140,7 +140,7 @@ static void broadcast_sent_cb(struct bt_bap_stream *bap_stream)
 
 	net_buf_reserve(buf, BT_ISO_CHAN_SEND_RESERVE);
 	net_buf_add_mem(buf, mock_iso_data, test_stream->tx_sdu_size);
-	ret = bt_cap_stream_send(cap_stream, buf, test_stream->seq_num++, BT_ISO_TIMESTAMP_NONE);
+	ret = bt_cap_stream_send(cap_stream, buf, test_stream->seq_num++);
 	if (ret < 0) {
 		/* This will end broadcasting on this stream. */
 		net_buf_unref(buf);

--- a/tests/bsim/bluetooth/audio/src/gmap_ugg_test.c
+++ b/tests/bsim/bluetooth/audio/src/gmap_ugg_test.c
@@ -188,7 +188,7 @@ static void stream_sent_cb(struct bt_bap_stream *bap_stream)
 
 	net_buf_reserve(buf, BT_ISO_CHAN_SEND_RESERVE);
 	net_buf_add_mem(buf, mock_iso_data, test_stream->tx_sdu_size);
-	ret = bt_cap_stream_send(cap_stream, buf, test_stream->seq_num++, BT_ISO_TIMESTAMP_NONE);
+	ret = bt_cap_stream_send(cap_stream, buf, test_stream->seq_num++);
 	if (ret < 0) {
 		/* This will end broadcasting on this stream. */
 		net_buf_unref(buf);

--- a/tests/bsim/bluetooth/audio/src/pbp_public_broadcast_source_test.c
+++ b/tests/bsim/bluetooth/audio/src/pbp_public_broadcast_source_test.c
@@ -101,7 +101,7 @@ static void sent_cb(struct bt_bap_stream *stream)
 
 	net_buf_reserve(buf, BT_ISO_CHAN_SEND_RESERVE);
 	net_buf_add_mem(buf, mock_data, broadcast_preset_48_2_1.qos.sdu);
-	ret = bt_bap_stream_send(stream, buf, seq_num++, BT_ISO_TIMESTAMP_NONE);
+	ret = bt_bap_stream_send(stream, buf, seq_num++);
 	if (ret < 0) {
 		/* This will end broadcasting on this stream. */
 		net_buf_unref(buf);

--- a/tests/bsim/bluetooth/host/iso/cis/src/cis_central.c
+++ b/tests/bsim/bluetooth/host/iso/cis/src/cis_central.c
@@ -53,7 +53,7 @@ static void send_data_cb(struct k_work *work)
 
 	net_buf_add_mem(buf, buf_data, len_to_send);
 
-	ret = bt_iso_chan_send(default_chan, buf, seq_num++, BT_ISO_TIMESTAMP_NONE);
+	ret = bt_iso_chan_send(default_chan, buf, seq_num++);
 	if (ret < 0) {
 		printk("Failed to send ISO data (%d)\n", ret);
 		net_buf_unref(buf);

--- a/tests/bsim/bluetooth/ll/bis/src/main.c
+++ b/tests/bsim/bluetooth/ll/bis/src/main.c
@@ -184,8 +184,7 @@ static void iso_send(struct k_work *work)
 	net_buf_add_mem(buf, iso_data, iso_data_len);
 
 	bs_trace_info_time(4, "ISO send: seq_num %u\n", seq_num);
-	ret = bt_iso_chan_send(&bis_iso_chan, buf, seq_num++,
-			       BT_ISO_TIMESTAMP_NONE);
+	ret = bt_iso_chan_send(&bis_iso_chan, buf, seq_num++);
 	if (ret < 0) {
 		FAIL("Unable to broadcast data on channel (%d)\n", ret);
 		net_buf_unref(buf);

--- a/tests/bsim/bluetooth/ll/cis/src/main.c
+++ b/tests/bsim/bluetooth/ll/cis/src/main.c
@@ -553,8 +553,7 @@ static void test_cis_central(void)
 				}
 
 				printk("ISO send: seq_num %u, chan %d\n", seq_num, chan);
-				ret = bt_iso_chan_send(&iso_chan[chan], buf,
-						       seq_num, BT_ISO_TIMESTAMP_NONE);
+				ret = bt_iso_chan_send(&iso_chan[chan], buf, seq_num);
 				if (ret < 0) {
 					FAIL("Unable to send data on channel %d : %d\n", chan, ret);
 					net_buf_unref(buf);
@@ -781,8 +780,7 @@ static void test_cis_peripheral(void)
 				}
 
 				printk("ISO send: seq_num %u, chan %d\n", seq_num, chan);
-				ret = bt_iso_chan_send(&iso_chan_p[chan], buf, seq_num,
-						       BT_ISO_TIMESTAMP_NONE);
+				ret = bt_iso_chan_send(&iso_chan_p[chan], buf, seq_num);
 				if (ret < 0) {
 					FAIL("Unable to send data on channel %d : %d\n", chan, ret);
 					net_buf_unref(buf);


### PR DESCRIPTION
The bt_iso_chan_send function could take an optional timestamp by using 0 as an indicator. The issue with this approach was that a timestamp value of 0 is valid, and could cause potential issue with syncing streams in a group.

To fully support transmitting with and without timestamp, bt_iso_chan_send_ts has been introduced, which is the only function of the two (bt_iso_chan_send being the other) that supports timestamps.

A new function, rather than adding a boolean to the existing, was chosen as it simplifies the individual functions as well as making it more explicit what the function does.

Since the bt_iso_chan_send function is used by LE audio, both the BAP and CAP send functions have similarly been updated. Likewise, all tests and samples have been updated to use the updated function(s), and BT_ISO_TIMESTAMP_NONE has been removed.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/68293