### PR TITLE
dts: bindings: dma: raspberrypi: Fix irq0-channels definition

### DIFF
--- a/dts/bindings/dma/raspberrypi,pico-dma.yaml
+++ b/dts/bindings/dma/raspberrypi,pico-dma.yaml
@@ -30,7 +30,7 @@ properties:
 
   irq0-channels:
     type: uint8-array
-    default: [0, 2, 4, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30]
+    default: [0, 2, 4, 6, 8, 10]
     description: Channels list that uses the irq0
 
   "#dma-cells":

--- a/dts/bindings/dma/raspberrypi,pico-dma.yaml
+++ b/dts/bindings/dma/raspberrypi,pico-dma.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  Raspberry Pi Pico GPIO
+  Raspberry Pi Pico DMA
 
   channel: Select channel for data transmitting
 


### PR DESCRIPTION
`irq0-channels` defines even-numbered channels as the default value.
Since 6 was dropped from this definition, it is added.
Also, since the maximum number of channels is 12,
remove the ones that are exceeded.

And also, a `GPIO` word is in the description section.
Correcting it to `DMA`.

Fix #65778

Thank you for pointing. > @renestraub
