### PR TITLE
drivers: dma: dma_dw_common: Disable channel even if draining times out

### DIFF
--- a/drivers/dma/dma_dw_common.c
+++ b/drivers/dma/dma_dw_common.c
@@ -595,8 +595,13 @@ int dw_dma_stop(const struct device *dev, uint32_t channel)
 	bool fifo_empty = WAIT_FOR(dw_read(dev_cfg->base, DW_CFG_LOW(channel)) & DW_CFGL_FIFO_EMPTY,
 				DW_DMA_TIMEOUT, k_busy_wait(DW_DMA_TIMEOUT/10));
 	if (!fifo_empty) {
-		LOG_ERR("%s: dma %d channel drain time out", __func__, channel);
-		return -ETIMEDOUT;
+		LOG_WRN("%s: dma %d channel drain time out", __func__, channel);
+
+		/* Continue even if draining timed out to make sure that the channel is going to be
+		 * disabled.
+		 * The same channel might be requested for other purpose (or for same) next time
+		 * which will fail if the channel has been left enabled.
+		 */
 	}
 #endif
 


### PR DESCRIPTION
If the channel suspend with draining fails on stop because of reasons outside of the scope of the DMA driver (the peripheral is powered off before trying to drain for example) we must continue and disable the channel.

The channel can be released by the client despite of it remained enabled. A new DMA channel request can pick the channel (as it is released) but re-configuration is going to be skipped and the use of the channel is going to fail. Then we will see the same drain timeout on channel stop again since the channel retained the configuration which resulted the first timeout.

The drain timeout was made fatal by an earlier commit which fixed the WAIT_FOR return value handling.

At the same time improve the warning and error prints for drain and disable timeout by including the DMA device name.

Fixes: 6226f9e6e44f ("dma: dw: fix the return value check")