### PR TITLE
drivers: serial: nrfx_uarte2: Fixes in the new nordic shim

### DIFF
--- a/tests/drivers/uart/uart_async_api/testcase.yaml
+++ b/tests/drivers/uart/uart_async_api/testcase.yaml
@@ -34,7 +34,6 @@ tests:
     depends_on: gpio
     extra_configs:
       - CONFIG_UART_NRFX_UARTE_LEGACY_SHIM=n
-    tags: bsim_skip_CI
   drivers.uart.async_api.nrf_uart:
     filter: CONFIG_SERIAL_SUPPORT_ASYNC
     harness: ztest

--- a/tests/drivers/uart/uart_mix_fifo_poll/testcase.yaml
+++ b/tests/drivers/uart/uart_mix_fifo_poll/testcase.yaml
@@ -20,7 +20,6 @@ tests:
       - CONFIG_UART_ASYNC_API=n
       - CONFIG_UART_0_ENHANCED_POLL_OUT=n
       - CONFIG_UART_NRFX_UARTE_LEGACY_SHIM=n
-    tags: bsim_skip_CI
 
   drivers.uart.uart_mix_poll_fifo:
     extra_configs:
@@ -28,7 +27,6 @@ tests:
       - CONFIG_UART_0_INTERRUPT_DRIVEN=y
       - CONFIG_UART_0_ENHANCED_POLL_OUT=n
       - CONFIG_UART_NRFX_UARTE_LEGACY_SHIM=n
-    tags: bsim_skip_CI
 
   drivers.uart.uart_mix_poll_async_api:
     extra_configs:
@@ -37,7 +35,6 @@ tests:
       - CONFIG_UART_0_ASYNC=y
       - CONFIG_UART_0_ENHANCED_POLL_OUT=n
       - CONFIG_UART_NRFX_UARTE_LEGACY_SHIM=n
-    tags: bsim_skip_CI
 
   drivers.uart.uart_mix_poll_async_api_const:
     extra_args: TEST_CONST_BUFFER=1


### PR DESCRIPTION
Set of fixes for new UART shim. After those fixes tests with new shim can be re-enabled on CI for nordic bsim targets.

Fixes #67890.