### PR TITLE
drivers: serial: emul: Make fifo_read() respect size

### DIFF
--- a/drivers/serial/uart_emul.c
+++ b/drivers/serial/uart_emul.c
@@ -172,6 +172,7 @@ static int uart_emul_fifo_read(const struct device *dev, uint8_t *rx_data, int s
 
 	K_SPINLOCK(&data->rx_lock) {
 		bytes_to_read = MIN(config->latch_buffer_size, ring_buf_size_get(data->rx_rb));
+		bytes_to_read = MIN(bytes_to_read, size);
 		ring_buf_get(data->rx_rb, rx_data, bytes_to_read);
 	}
 


### PR DESCRIPTION
uart_emul_fifo_read() didn't regard the size arg, hence if the RX ring buffer contained more data than the size of the input rx_data buffer size, this could result in buffer overflow. This becomes more obvious when configuring device tree property latch-buffer-size > 1.