### PR TITLE
scripts: tests: Blackbox test expansion - printouts

### DIFF
--- a/scripts/tests/twister_blackbox/conftest.py
+++ b/scripts/tests/twister_blackbox/conftest.py
@@ -22,6 +22,7 @@ sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts"))
 
 
 testsuite_filename_mock = mock.PropertyMock(return_value='test_data.yaml')
+sample_filename_mock = mock.PropertyMock(return_value='test_sample.yaml')
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "noclearlog: disable the clear_log autouse fixture")

--- a/scripts/tests/twister_blackbox/test_data/samples/hello_world/CMakeLists.txt
+++ b/scripts/tests/twister_blackbox/test_data/samples/hello_world/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(hello_world)
+
+target_sources(app PRIVATE src/main.c)

--- a/scripts/tests/twister_blackbox/test_data/samples/hello_world/prj.conf
+++ b/scripts/tests/twister_blackbox/test_data/samples/hello_world/prj.conf
@@ -1,0 +1,1 @@
+# nothing here

--- a/scripts/tests/twister_blackbox/test_data/samples/hello_world/src/main.c
+++ b/scripts/tests/twister_blackbox/test_data/samples/hello_world/src/main.c
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2012-2014 Wind River Systems, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+
+int main(void)
+{
+	printf("Hello World! %s\n", CONFIG_BOARD);
+	return 0;
+}

--- a/scripts/tests/twister_blackbox/test_data/samples/hello_world/test_sample.yaml
+++ b/scripts/tests/twister_blackbox/test_data/samples/hello_world/test_sample.yaml
@@ -1,0 +1,16 @@
+sample:
+  description: Hello World sample, the simplest Zephyr
+    application
+  name: hello world
+common:
+  tags: introduction
+  integration_platforms:
+    - native_sim
+  harness: console
+  harness_config:
+    type: one_line
+    regex:
+      - "Hello World! (.*)"
+tests:
+  sample.basic.helloworld:
+    tags: introduction


### PR DESCRIPTION
Adds tests related to the flags creating alternate printouts instead of running Twister tests:
* `-z`, `--size`

Note the `hello_world` sample has been copied to the `test_data` folder, so as to be independent of any Zephyr changes; thus its copyright information is unchanged.