### PR TITLE
storeage/stream_flash: Cache write_block_size to ctx on init

### DIFF
--- a/include/zephyr/storage/stream_flash.h
+++ b/include/zephyr/storage/stream_flash.h
@@ -65,6 +65,8 @@ struct stream_flash_ctx {
 #ifdef CONFIG_STREAM_FLASH_ERASE
 	off_t last_erased_page_start_offset; /* Last erased offset */
 #endif
+	uint8_t erase_value;
+	uint8_t write_block_size;	/* Offset/size device write alignment */
 };
 
 /**


### PR DESCRIPTION
The commit caches write_block_size and erase_value to stream flash context, at init, to avoid calling Flash API multiple times to get these values at various stages of code exectuion, at run-time.