### PR TITLE
manifest: Update nrf hw models to latest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -295,7 +295,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: d17c9d749c817d2522468fa3c0eee3705feb8951
+      revision: 52d0b4b7b7431d8da6222cc3b17a8afdcb099baf
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
       revision: da78aea63159771956fe0c9263f2e6985b66e9d5


### PR DESCRIPTION
@Thalley reported some CI instability around the BT HCI UART tests.
With enough load and reps it was possible to reproduce what seemed like the same issue.
This PR updates the nRF HW models to include 2 patches that avoid this.
It also includes other minor patches that got into main of the HW models since the latest update.

------

Update the HW models module to 52d0b4b7b7431d8da6222cc3b17a8afdcb099baf

Including the following:
* 52d0b4b UART: FIFO backend: Do not error out if other side disconnects Rx
* 3582b68 UART: FIFO backend: Avoid possible race
* 414f160 AAR: Fix UBSAN warnings
* 24f5d3d PPI: Fix UBSAN warning

---------

Fixes: #68664