### PR TITLE
twister: Add support for GTEST_SKIP()

### DIFF
--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -511,6 +511,7 @@ class Gtest(Harness):
     ANSI_ESCAPE = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
     TEST_START_PATTERN = r".*\[ RUN      \] (?P<suite_name>.*)\.(?P<test_name>.*)$"
     TEST_PASS_PATTERN = r".*\[       OK \] (?P<suite_name>.*)\.(?P<test_name>.*)$"
+    TEST_SKIP_PATTERN = r".*\[ DISABLED \] (?P<suite_name>.*)\.(?P<test_name>.*)$"
     TEST_FAIL_PATTERN = r".*\[  FAILED  \] (?P<suite_name>.*)\.(?P<test_name>.*)$"
     FINISHED_PATTERN = r".*\[==========\] Done running all tests\.$"
 
@@ -592,6 +593,9 @@ class Gtest(Harness):
         test_pass_match = re.search(self.TEST_PASS_PATTERN, line)
         if test_pass_match:
             return "passed", "{}.{}.{}".format(self.id, test_pass_match.group("suite_name"), test_pass_match.group("test_name"))
+        test_skip_match = re.search(self.TEST_SKIP_PATTERN, line)
+        if test_skip_match:
+            return "skipped", "{}.{}.{}".format(self.id, test_skip_match.group("suite_name"), test_skip_match.group("test_name"))
         test_fail_match = re.search(self.TEST_FAIL_PATTERN, line)
         if test_fail_match:
             return "failed", "{}.{}.{}".format(self.id, test_fail_match.group("suite_name"), test_fail_match.group("test_name"))

--- a/scripts/tests/twister/test_harness.py
+++ b/scripts/tests/twister/test_harness.py
@@ -28,6 +28,7 @@ from twisterlib.harness import HarnessImporter
 
 GTEST_START_STATE = " RUN      "
 GTEST_PASS_STATE = "       OK "
+GTEST_SKIP_STATE = " DISABLED "
 GTEST_FAIL_STATE = "  FAILED  "
 SAMPLE_GTEST_START = (
     "[00:00:00.000,000] [0m<inf> label:  [==========] Running all tests.[0m"
@@ -524,6 +525,26 @@ def test_gtest_failed(gtest):
     assert gtest.instance.get_case_by_name("id.suite_name.test_name").status == "failed"
 
 
+def test_gtest_skipped(gtest):
+    process_logs(
+        gtest,
+        [
+            SAMPLE_GTEST_START,
+            SAMPLE_GTEST_FMT.format(
+                state=GTEST_START_STATE, suite="suite_name", test="test_name"
+            ),
+            SAMPLE_GTEST_FMT.format(
+                state=GTEST_SKIP_STATE, suite="suite_name", test="test_name"
+            ),
+        ],
+    )
+    assert gtest.state is None
+    assert len(gtest.detected_suite_names) == 1
+    assert gtest.detected_suite_names[0] == "suite_name"
+    assert gtest.instance.get_case_by_name("id.suite_name.test_name") is not None
+    assert gtest.instance.get_case_by_name("id.suite_name.test_name").status == "skipped"
+
+
 def test_gtest_all_pass(gtest):
     process_logs(
         gtest,
@@ -543,6 +564,35 @@ def test_gtest_all_pass(gtest):
     assert gtest.detected_suite_names[0] == "suite_name"
     assert gtest.instance.get_case_by_name("id.suite_name.test_name") is not None
     assert gtest.instance.get_case_by_name("id.suite_name.test_name").status == "passed"
+
+
+def test_gtest_one_skipped(gtest):
+    process_logs(
+        gtest,
+        [
+            SAMPLE_GTEST_START,
+            SAMPLE_GTEST_FMT.format(
+                state=GTEST_START_STATE, suite="suite_name", test="test_name"
+            ),
+            SAMPLE_GTEST_FMT.format(
+                state=GTEST_PASS_STATE, suite="suite_name", test="test_name"
+            ),
+            SAMPLE_GTEST_FMT.format(
+                state=GTEST_START_STATE, suite="suite_name", test="test_name1"
+            ),
+            SAMPLE_GTEST_FMT.format(
+                state=GTEST_SKIP_STATE, suite="suite_name", test="test_name1"
+            ),
+            SAMPLE_GTEST_END,
+        ],
+    )
+    assert gtest.state == "passed"
+    assert len(gtest.detected_suite_names) == 1
+    assert gtest.detected_suite_names[0] == "suite_name"
+    assert gtest.instance.get_case_by_name("id.suite_name.test_name") is not None
+    assert gtest.instance.get_case_by_name("id.suite_name.test_name").status == "passed"
+    assert gtest.instance.get_case_by_name("id.suite_name.test_name1") is not None
+    assert gtest.instance.get_case_by_name("id.suite_name.test_name1").status == "skipped"
 
 
 def test_gtest_one_fail(gtest):


### PR DESCRIPTION
Calling GTEST_SKIP will print the test as DISABLED, add support and unit tests for this.

Fixes #68993