### PR TITLE
Bluetooth: Host: Send status for terminated directed adv

### DIFF
--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -2185,11 +2185,10 @@ void bt_hci_le_adv_set_terminated(struct net_buf *buf)
 
 	if (evt->status && IS_ENABLED(CONFIG_BT_PERIPHERAL) &&
 	    atomic_test_bit(adv->flags, BT_ADV_CONNECTABLE)) {
-		/* Only set status for legacy advertising API.
-		 * This will call connected callback for high duty cycle
+		/* This will call connected callback for high duty cycle
 		 * directed advertiser timeout.
 		 */
-		le_adv_stop_free_conn(adv, adv == bt_dev.adv ? evt->status : 0);
+		le_adv_stop_free_conn(adv, evt->status);
 	}
 
 	if (IS_ENABLED(CONFIG_BT_CONN) && !evt->status) {


### PR DESCRIPTION
- Fix bug where status was only sent for legacy adv
- Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/68681