### PR TITLE
Bluetooth samples: Add USE_SPECIFIC_BROADCAST_CHANNEL Kconfig

### DIFF
--- a/samples/bluetooth/broadcast_audio_sink/Kconfig
+++ b/samples/bluetooth/broadcast_audio_sink/Kconfig
@@ -55,11 +55,18 @@ config USE_USB_AUDIO_OUTPUT
 	  phone or PC as a USB-in device (such as a USB microphone).
 	  USB audio only supports a single audio channel.
 
+config USE_SPECIFIC_BROADCAST_CHANNEL
+	bool "Use specific Broadcast Channel Audio Location"
+	default y
+	depends on USE_USB_AUDIO_OUTPUT
+	help
+	  Enables the use of a specific Channel Audio Location (see config TARGET_BROADCAST_CHANNEL).
+
 config TARGET_BROADCAST_CHANNEL
 	int "Broadcast Channel Audio Location to sync to"
 	range 0 2
 	default 1
-	depends on USE_USB_AUDIO_OUTPUT
+	depends on USE_SPECIFIC_BROADCAST_CHANNEL
 	help
 	  Channel Audio Location to sync to. These corresponds to the bt_audio_location,
 	  supporting mono, left and right channels

--- a/samples/bluetooth/broadcast_audio_sink/src/main.c
+++ b/samples/bluetooth/broadcast_audio_sink/src/main.c
@@ -364,7 +364,6 @@ static void stream_started_cb(struct bt_bap_stream *stream)
 	sink_stream->valid_cnt = 0U;
 	sink_stream->error_cnt = 0U;
 
-
 #if defined(CONFIG_LIBLC3)
 	int err;
 
@@ -458,6 +457,15 @@ static bool find_valid_bis_cb(const struct bt_bap_base_subgroup_bis *bis,
 	err = bt_audio_codec_cfg_get_chan_allocation(&codec_cfg, &chan_allocation);
 	if (err != 0) {
 		printk("Could not find channel allocation (err=%d)\n", err);
+		if (err == -ENODATA && strlen(CONFIG_TARGET_BROADCAST_NAME) > 0U) {
+			/* Accept no channel allocation data available
+			 * if TARGET_BROADCAST_NAME defined. Use current index.
+			 */
+			*bis_index = bis->index;
+
+			return false;
+		}
+
 		return true;
 	}
 


### PR DESCRIPTION
Added USE_SPECIFIC_BROADCAST_CHANNEL which enable/disables the use of a specific channel audio location for the broadcast audio sink sample. If USE_SPECIFIC_BROADCAST_CHANNEL is set to no then first valid channel is chosen. In this case broadcast channel with no audio location is also supported.