### PR TITLE
boards: nrf54h20pdk_nrf54h20_cpuppr: use `riscv32` instead of `riscv`

### DIFF
--- a/boards/riscv/nrf54h20pdk_nrf54h20/nrf54h20pdk_nrf54h20_cpuppr.yaml
+++ b/boards/riscv/nrf54h20pdk_nrf54h20/nrf54h20pdk_nrf54h20_cpuppr.yaml
@@ -4,7 +4,7 @@
 identifier: nrf54h20pdk_nrf54h20_cpuppr
 name: nRF54H20-PDK-nRF54H20-PPR
 type: mcu
-arch: riscv
+arch: riscv32
 toolchain:
   - zephyr
 ram: 28


### PR DESCRIPTION
The yaml uses `arch: riscv` while other boards specify either `arch: riscv32` or `arch: riscv64`.
Unify this by changing the value to `riscv32`.