### PR TITLE
net: sockets: tls: Timeout DTLS with poll

### DIFF
--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -3028,11 +3028,16 @@ static int ztls_socket_data_check(struct tls_context *ctx)
 		/* MbedTLS API documentation requires session to
 		 * be reset in other error cases
 		 */
-		ret = tls_mbedtls_reset(ctx);
-		if (ret != 0) {
+		if (tls_mbedtls_reset(ctx) != 0) {
 			return -ENOMEM;
 		}
 
+#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
+		if (ret == MBEDTLS_ERR_SSL_TIMEOUT && ctx->type == SOCK_DGRAM) {
+			/* DTLS timeout interpreted as closing of connection. */
+			return -ENOTCONN;
+		}
+#endif
 		return -ECONNABORTED;
 	}
 
@@ -3052,15 +3057,26 @@ static int ztls_poll_update_pollin(int fd, struct tls_context *ctx,
 		}
 	}
 
-	if (!(pfd->revents & ZSOCK_POLLIN)) {
-		/* No new data on a socket. */
-		goto next;
-	}
+	if (ctx->type == SOCK_STREAM) {
+		if (!(pfd->revents & ZSOCK_POLLIN)) {
+			/* No new data on a socket. */
+			goto next;
+		}
 
-	if (ctx->is_listening) {
-		goto next;
+		if (ctx->is_listening) {
+			goto next;
+		}
 	}
-
+#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
+	else {
+		/* Perform data check without incoming data for completed DTLS connections.
+		 * This allows the connections to timeout with CONFIG_NET_SOCKETS_DTLS_TIMEOUT.
+		 */
+		if (!is_handshake_complete(ctx) && !(pfd->revents & ZSOCK_POLLIN)) {
+			goto next;
+		}
+	}
+#endif
 	ret = ztls_socket_data_check(ctx);
 	if (ret == -ENOTCONN || (pfd->revents & ZSOCK_POLLHUP)) {
 		/* Datagram does not return 0 on consecutive recv, but an error


### PR DESCRIPTION
Changed poll to perform incoming data check with connected DTLS connections. This allows the CONFIG_NET_SOCKETS_DTLS_TIMEOUT to timeout the connections to server socket if there is no incoming data.

Previously, if the remote client closed the DTLS connection without close notify, the timeout of the ongoing connection only happened when next connection was taken to the server socket. Depending on the timeouts, this could prevent the next connection from succeeding.