### PR TITLE
arch: riscv: always set CONFIG_ARCH to 'riscv'

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -6,8 +6,7 @@ menu "RISCV Options"
 
 config ARCH
 	string
-	default "riscv64" if 64BIT
-	default "riscv32"
+	default "riscv"
 
 config FLOAT_HARD
 	bool "Hard-float calling convention"

--- a/boards/riscv/adp_xc7k_ae350/adp_xc7k_ae350.yaml
+++ b/boards/riscv/adp_xc7k_ae350/adp_xc7k_ae350.yaml
@@ -1,7 +1,7 @@
 identifier: adp_xc7k_ae350
 name: Andes ADP-XC7K AE350
 type: mcu
-arch: riscv32
+arch: riscv
 toolchain:
   - zephyr
   - cross-compile

--- a/boards/riscv/beaglev_fire/beaglev_fire.yaml
+++ b/boards/riscv/beaglev_fire/beaglev_fire.yaml
@@ -1,7 +1,7 @@
 identifier: beaglev_fire
 name: Beagleboard BeagleV-Fire
 type: mcu
-arch: riscv64
+arch: riscv
 toolchain:
   - zephyr
 ram: 3840

--- a/boards/riscv/esp32c3_devkitm/esp32c3_devkitm.yaml
+++ b/boards/riscv/esp32c3_devkitm/esp32c3_devkitm.yaml
@@ -1,7 +1,7 @@
 identifier: esp32c3_devkitm
 name: ESP32-C3
 type: mcu
-arch: riscv32
+arch: riscv
 toolchain:
   - zephyr
 supported:

--- a/boards/riscv/esp32c3_luatos_core/esp32c3_luatos_core.yaml
+++ b/boards/riscv/esp32c3_luatos_core/esp32c3_luatos_core.yaml
@@ -1,7 +1,7 @@
 identifier: esp32c3_luatos_core
 name: ESP32C3 LuatOS Core
 type: mcu
-arch: riscv32
+arch: riscv
 toolchain:
   - zephyr
 supported:

--- a/boards/riscv/esp32c3_luatos_core/esp32c3_luatos_core_usb.yaml
+++ b/boards/riscv/esp32c3_luatos_core/esp32c3_luatos_core_usb.yaml
@@ -1,7 +1,7 @@
 identifier: esp32c3_luatos_core_usb
 name: ESP32C3 LuatOS Core USB
 type: mcu
-arch: riscv32
+arch: riscv
 toolchain:
   - zephyr
 supported:

--- a/boards/riscv/gd32vf103c_starter/gd32vf103c_starter.yaml
+++ b/boards/riscv/gd32vf103c_starter/gd32vf103c_starter.yaml
@@ -4,7 +4,7 @@
 identifier: gd32vf103c_starter
 name: GigaDevice GD32VF103C-STARTER
 type: mcu
-arch: riscv32
+arch: riscv
 ram: 32
 flash: 128
 toolchain:

--- a/boards/riscv/gd32vf103v_eval/gd32vf103v_eval.yaml
+++ b/boards/riscv/gd32vf103v_eval/gd32vf103v_eval.yaml
@@ -4,7 +4,7 @@
 identifier: gd32vf103v_eval
 name: GigaDevice GD32VF103V-EVAL
 type: mcu
-arch: riscv32
+arch: riscv
 ram: 32
 flash: 128
 toolchain:

--- a/boards/riscv/hifive1/hifive1.yaml
+++ b/boards/riscv/hifive1/hifive1.yaml
@@ -1,7 +1,7 @@
 identifier: hifive1
 name: SiFive HiFive1
 type: mcu
-arch: riscv32
+arch: riscv
 toolchain:
   - zephyr
 ram: 16

--- a/boards/riscv/hifive1_revb/hifive1_revb.yaml
+++ b/boards/riscv/hifive1_revb/hifive1_revb.yaml
@@ -1,7 +1,7 @@
 identifier: hifive1_revb
 name: SiFive HiFive1 Rev B
 type: mcu
-arch: riscv32
+arch: riscv
 toolchain:
   - zephyr
 ram: 16

--- a/boards/riscv/hifive_unleashed/hifive_unleashed.yaml
+++ b/boards/riscv/hifive_unleashed/hifive_unleashed.yaml
@@ -1,7 +1,7 @@
 identifier: hifive_unleashed
 name: SiFive HiFive Unleashed
 type: mcu
-arch: riscv64
+arch: riscv
 toolchain:
   - zephyr
 ram: 3840

--- a/boards/riscv/hifive_unmatched/hifive_unmatched.yaml
+++ b/boards/riscv/hifive_unmatched/hifive_unmatched.yaml
@@ -1,7 +1,7 @@
 identifier: hifive_unmatched
 name: SiFive HiFive Unmatched
 type: mcu
-arch: riscv64
+arch: riscv
 toolchain:
   - zephyr
 ram: 3840

--- a/boards/riscv/icev_wireless/icev_wireless.yaml
+++ b/boards/riscv/icev_wireless/icev_wireless.yaml
@@ -1,7 +1,7 @@
 identifier: icev_wireless
 name: ICE-V Wireless
 type: mcu
-arch: riscv32
+arch: riscv
 toolchain:
   - zephyr
 testing:

--- a/boards/riscv/it82xx2_evb/it82xx2_evb.yaml
+++ b/boards/riscv/it82xx2_evb/it82xx2_evb.yaml
@@ -1,7 +1,7 @@
 identifier: it82xx2_evb
 name: ITE IT82XX2 EVB
 type: mcu
-arch: riscv32
+arch: riscv
 toolchain:
   - zephyr
 ram: 256

--- a/boards/riscv/it8xxx2_evb/it8xxx2_evb.yaml
+++ b/boards/riscv/it8xxx2_evb/it8xxx2_evb.yaml
@@ -1,7 +1,7 @@
 identifier: it8xxx2_evb
 name: ITE IT8XXX2 EVB
 type: mcu
-arch: riscv32
+arch: riscv
 toolchain:
   - zephyr
 ram: 60

--- a/boards/riscv/litex_vexriscv/litex_vexriscv.yaml
+++ b/boards/riscv/litex_vexriscv/litex_vexriscv.yaml
@@ -7,7 +7,7 @@
 identifier: litex_vexriscv
 name: LiteX SoC with VexRiscV softcore CPU
 type: mcu
-arch: riscv32
+arch: riscv
 toolchain:
   - zephyr
 ram: 262144

--- a/boards/riscv/longan_nano/longan_nano.yaml
+++ b/boards/riscv/longan_nano/longan_nano.yaml
@@ -1,7 +1,7 @@
 identifier: longan_nano
 name: Sipeed Longan Nano
 type: mcu
-arch: riscv32
+arch: riscv
 toolchain:
   - zephyr
   - xtools

--- a/boards/riscv/longan_nano/longan_nano_lite.yaml
+++ b/boards/riscv/longan_nano/longan_nano_lite.yaml
@@ -1,7 +1,7 @@
 identifier: longan_nano_lite
 name: Sipeed Longan Nano Lite
 type: mcu
-arch: riscv32
+arch: riscv
 toolchain:
   - zephyr
   - xtools

--- a/boards/riscv/m2gl025_miv/m2gl025_miv.yaml
+++ b/boards/riscv/m2gl025_miv/m2gl025_miv.yaml
@@ -1,7 +1,7 @@
 identifier: m2gl025_miv
 name: Microchip M2GL025 with MiV target
 type: mcu
-arch: riscv32
+arch: riscv
 toolchain:
   - zephyr
 ram: 64

--- a/boards/riscv/mpfs_icicle/mpfs_icicle.yaml
+++ b/boards/riscv/mpfs_icicle/mpfs_icicle.yaml
@@ -1,7 +1,7 @@
 identifier: mpfs_icicle
 name: Microchip PolarFire ICICLE kit
 type: mcu
-arch: riscv64
+arch: riscv
 toolchain:
   - zephyr
 ram: 3840

--- a/boards/riscv/neorv32/neorv32.yaml
+++ b/boards/riscv/neorv32/neorv32.yaml
@@ -1,7 +1,7 @@
 identifier: neorv32
 name: NEORV32 Processor (SoC)
 type: mcu
-arch: riscv32
+arch: riscv
 toolchain:
   - cross-compile
   - zephyr

--- a/boards/riscv/niosv_g/niosv_g.yaml
+++ b/boards/riscv/niosv_g/niosv_g.yaml
@@ -1,7 +1,7 @@
 identifier: niosv_g
 name: INTEL FPGA Nios V/g general purpose processor
 type: mcu
-arch: riscv32
+arch: riscv
 toolchain:
   - zephyr
 ram: 256

--- a/boards/riscv/niosv_m/niosv_m.yaml
+++ b/boards/riscv/niosv_m/niosv_m.yaml
@@ -1,7 +1,7 @@
 identifier: niosv_m
 name: INTEL FPGA niosv_m
 type: mcu
-arch: riscv32
+arch: riscv
 toolchain:
   - zephyr
 ram: 256

--- a/boards/riscv/nrf54h20pdk_nrf54h20/nrf54h20pdk_nrf54h20_cpuppr.yaml
+++ b/boards/riscv/nrf54h20pdk_nrf54h20/nrf54h20pdk_nrf54h20_cpuppr.yaml
@@ -4,7 +4,7 @@
 identifier: nrf54h20pdk_nrf54h20_cpuppr
 name: nRF54H20-PDK-nRF54H20-PPR
 type: mcu
-arch: riscv32
+arch: riscv
 toolchain:
   - zephyr
 ram: 28

--- a/boards/riscv/opentitan_earlgrey/opentitan_earlgrey.yaml
+++ b/boards/riscv/opentitan_earlgrey/opentitan_earlgrey.yaml
@@ -1,7 +1,7 @@
 identifier: opentitan_earlgrey
 name: OpenTitan Earl Grey
 type: mcu
-arch: riscv32
+arch: riscv
 toolchain:
   - zephyr
 ram: 128

--- a/boards/riscv/qemu_riscv32/qemu_riscv32.yaml
+++ b/boards/riscv/qemu_riscv32/qemu_riscv32.yaml
@@ -2,7 +2,7 @@ identifier: qemu_riscv32
 name: QEMU Emulation for RISC-V 32-bit
 type: qemu
 simulation: qemu
-arch: riscv32
+arch: riscv
 toolchain:
   - zephyr
   - xtools

--- a/boards/riscv/qemu_riscv32/qemu_riscv32_smp.yaml
+++ b/boards/riscv/qemu_riscv32/qemu_riscv32_smp.yaml
@@ -2,7 +2,7 @@ identifier: qemu_riscv32_smp
 name: QEMU Emulation for RISC-V 32-bit SMP
 type: qemu
 simulation: qemu
-arch: riscv32
+arch: riscv
 toolchain:
   - zephyr
   - xtools

--- a/boards/riscv/qemu_riscv32/qemu_riscv32_xip.yaml
+++ b/boards/riscv/qemu_riscv32/qemu_riscv32_xip.yaml
@@ -2,7 +2,7 @@ identifier: qemu_riscv32_xip
 name: QEMU Emulation for RISC-V 32-bit in XIP mode
 type: qemu
 simulation: qemu
-arch: riscv32
+arch: riscv
 ram: 16
 toolchain:
   - zephyr

--- a/boards/riscv/qemu_riscv32e/qemu_riscv32e.yaml
+++ b/boards/riscv/qemu_riscv32e/qemu_riscv32e.yaml
@@ -2,7 +2,7 @@ identifier: qemu_riscv32e
 name: QEMU Emulation for RISC-V (RV32E) 32-bit
 type: qemu
 simulation: qemu
-arch: riscv32
+arch: riscv
 toolchain:
   - zephyr
   - xtools

--- a/boards/riscv/qemu_riscv64/qemu_riscv64.yaml
+++ b/boards/riscv/qemu_riscv64/qemu_riscv64.yaml
@@ -2,7 +2,7 @@ identifier: qemu_riscv64
 name: QEMU Emulation for RISC-V 64-bit
 type: qemu
 simulation: qemu
-arch: riscv64
+arch: riscv
 toolchain:
   - zephyr
 supported:

--- a/boards/riscv/qemu_riscv64/qemu_riscv64_smp.yaml
+++ b/boards/riscv/qemu_riscv64/qemu_riscv64_smp.yaml
@@ -2,7 +2,7 @@ identifier: qemu_riscv64_smp
 name: QEMU Emulation for RISC-V 64-bit SMP
 type: qemu
 simulation: qemu
-arch: riscv64
+arch: riscv
 toolchain:
   - zephyr
 supported:

--- a/boards/riscv/riscv32_virtual/riscv32_virtual.yaml
+++ b/boards/riscv/riscv32_virtual/riscv32_virtual.yaml
@@ -1,7 +1,7 @@
 identifier: riscv32_virtual
 name: Renode RISC-V 32-bit Virtual Board
 type: mcu
-arch: riscv32
+arch: riscv
 toolchain:
   - zephyr
 ram: 4096

--- a/boards/riscv/rv32m1_vega/rv32m1_vega_ri5cy.yaml
+++ b/boards/riscv/rv32m1_vega/rv32m1_vega_ri5cy.yaml
@@ -1,7 +1,7 @@
 identifier: rv32m1_vega_ri5cy
 name: RV32M1-VEGA (RI5CY)
 type: mcu
-arch: riscv32
+arch: riscv
 toolchain:
   - cross-compile
   - zephyr

--- a/boards/riscv/rv32m1_vega/rv32m1_vega_zero_riscy.yaml
+++ b/boards/riscv/rv32m1_vega/rv32m1_vega_zero_riscy.yaml
@@ -1,7 +1,7 @@
 identifier: rv32m1_vega_zero_riscy
 name: RV32M1-VEGA (ZERO-RISCY)
 type: mcu
-arch: riscv32
+arch: riscv
 toolchain:
   - cross-compile
   - zephyr

--- a/boards/riscv/sparkfun_red_v_things_plus/sparkfun_red_v_things_plus.yaml
+++ b/boards/riscv/sparkfun_red_v_things_plus/sparkfun_red_v_things_plus.yaml
@@ -1,7 +1,7 @@
 identifier: sparkfun_red_v_things_plus
 name: SparkFun RED-V Things Plus
 type: mcu
-arch: riscv32
+arch: riscv
 toolchain:
   - zephyr
 ram: 16

--- a/boards/riscv/stamp_c3/stamp_c3.yaml
+++ b/boards/riscv/stamp_c3/stamp_c3.yaml
@@ -1,7 +1,7 @@
 identifier: stamp_c3
 name: M5Stack STAMP-C3
 type: mcu
-arch: riscv32
+arch: riscv
 toolchain:
   - zephyr
 supported:

--- a/boards/riscv/titanium_ti60_f225/titanium_ti60_f225.yaml
+++ b/boards/riscv/titanium_ti60_f225/titanium_ti60_f225.yaml
@@ -1,7 +1,7 @@
 identifier: titanium_ti60_f225
 name: titanium_ti60_f225 FPGA development kit with Efinix Sapphire riscv SoC
 type: mcu
-arch: riscv32
+arch: riscv
 toolchain:
   - zephyr
 ram: 196608

--- a/boards/riscv/tlsr9518adk80d/tlsr9518adk80d.yaml
+++ b/boards/riscv/tlsr9518adk80d/tlsr9518adk80d.yaml
@@ -1,7 +1,7 @@
 identifier: tlsr9518adk80d
 name: Telink TLSR9518ADK80D
 type: mcu
-arch: riscv32
+arch: riscv
 toolchain:
   - cross-compile
   - zephyr

--- a/boards/riscv/xiao_esp32c3/xiao_esp32c3.yaml
+++ b/boards/riscv/xiao_esp32c3/xiao_esp32c3.yaml
@@ -1,7 +1,7 @@
 identifier: xiao_esp32c3
 name: XIAO ESP32C3
 type: mcu
-arch: riscv32
+arch: riscv
 toolchain:
   - zephyr
 supported:

--- a/samples/userspace/syscall_perf/sample.yaml
+++ b/samples/userspace/syscall_perf/sample.yaml
@@ -11,8 +11,6 @@ common:
 tests:
   sample.syscall_performances:
     filter: CONFIG_ARCH_HAS_USERSPACE
-    arch_allow:
-      - riscv32
-      - riscv64
+    arch_allow: riscv
     integration_platforms:
       - hifive1_revb

--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -193,6 +193,7 @@ class Filters:
             if p:
                 if p.group(1) != 'common':
                     if p.group(1) == 'riscv':
+                        archs.add('riscv')
                         archs.add('riscv32')
                         archs.add('riscv64')
                     else:

--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -182,8 +182,6 @@ class Filters:
 
     def find_archs(self):
         # we match both arch/<arch>/* and include/zephyr/arch/<arch> and skip common.
-        # Some architectures like riscv require special handling, i.e. riscv
-        # directory covers 2 architectures known to twister: riscv32 and riscv64.
         archs = set()
 
         for f in self.modified_files:
@@ -192,12 +190,7 @@ class Filters:
                 p = re.match(r"^include\/zephyr\/arch\/([^/]+)\/", f)
             if p:
                 if p.group(1) != 'common':
-                    if p.group(1) == 'riscv':
-                        archs.add('riscv')
-                        archs.add('riscv32')
-                        archs.add('riscv64')
-                    else:
-                        archs.add(p.group(1))
+                    archs.add(p.group(1))
                     # Modified file is treated as resolved, since a matching scope was found
                     self.resolved_files.append(f)
 

--- a/scripts/pylib/twister/twisterlib/platform.py
+++ b/scripts/pylib/twister/twisterlib/platform.py
@@ -88,8 +88,6 @@ class Platform:
           "arm64": ["zephyr", "cross-compile"],
           "mips": ["zephyr", "xtools"],
           "nios2": ["zephyr", "xtools"],
-          "riscv32": ["zephyr", "cross-compile", "xtools"],
-          "riscv64": ["zephyr"],
           "riscv": ["zephyr", "cross-compile"],
           "posix": ["host", "llvm"],
           "sparc": ["zephyr", "xtools"],

--- a/scripts/pylib/twister/twisterlib/platform.py
+++ b/scripts/pylib/twister/twisterlib/platform.py
@@ -90,6 +90,7 @@ class Platform:
           "nios2": ["zephyr", "xtools"],
           "riscv32": ["zephyr", "cross-compile", "xtools"],
           "riscv64": ["zephyr"],
+          "riscv": ["zephyr", "cross-compile"],
           "posix": ["host", "llvm"],
           "sparc": ["zephyr", "xtools"],
           "x86": ["zephyr", "xtools", "llvm"],

--- a/scripts/tests/twister/test_platform.py
+++ b/scripts/tests/twister/test_platform.py
@@ -49,7 +49,7 @@ arch: arch0
     (
 """\
 identifier: dummy full
-arch: riscv32
+arch: riscv
 twister: true
 ram: 1024
 testing:
@@ -81,7 +81,7 @@ env:
 """,
         {
             'name': 'dummy full',
-            'arch': 'riscv32',
+            'arch': 'riscv',
             'twister': True,
             'ram': 1024,
             'timeout_multiplier': 2.0,
@@ -96,11 +96,11 @@ env:
             'type': 'unit',
             'simulation': 'nsim',
             'simulation_exec': 'nsimdrv',
-            'supported_toolchains': ['zephyr', 'llvm', 'cross-compile', 'xtools'],
+            'supported_toolchains': ['zephyr', 'llvm', 'cross-compile'],
             'env': ['dummynonexistentvar'],
             'env_satisfied': False
         },
-        '<dummy full on riscv32>'
+        '<dummy full on riscv>'
     ),
 ]
 

--- a/tests/arch/common/ramfunc/testcase.yaml
+++ b/tests/arch/common/ramfunc/testcase.yaml
@@ -6,7 +6,6 @@ tests:
       - userspace
     arch_allow:
       - arm
-      - riscv32
-      - riscv64
+      - riscv
     extra_configs:
       - CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=0

--- a/tests/arch/common/semihost/testcase.yaml
+++ b/tests/arch/common/semihost/testcase.yaml
@@ -3,7 +3,6 @@ tests:
     arch_allow:
       - arm
       - arm64
-      - riscv32
-      - riscv64
+      - riscv
     platform_type:
       - qemu

--- a/tests/arch/riscv/fpu_sharing/testcase.yaml
+++ b/tests/arch/riscv/fpu_sharing/testcase.yaml
@@ -1,6 +1,4 @@
 tests:
   arch.riscv.fpu_sharing:
-    arch_allow:
-      - riscv32
-      - riscv64
+    arch_allow: riscv
     filter: CONFIG_CPU_HAS_FPU

--- a/tests/drivers/console/hello_world/testcase.yaml
+++ b/tests/drivers/console/hello_world/testcase.yaml
@@ -23,8 +23,7 @@ tests:
     arch_allow:
       - arm
       - arm64
-      - riscv32
-      - riscv64
+      - riscv
     platform_type:
       - qemu
     extra_args: CONF_FILE=prj_semihost.conf

--- a/tests/kernel/fpu_sharing/generic/testcase.yaml
+++ b/tests/kernel/fpu_sharing/generic/testcase.yaml
@@ -30,8 +30,8 @@ tests:
     timeout: 600
   kernel.fpu_sharing.generic.riscv32:
     extra_args: PI_NUM_ITERATIONS=500
-    filter: CONFIG_CPU_HAS_FPU
-    arch_allow: riscv32
+    filter: CONFIG_CPU_HAS_FPU and not CONFIG_64BIT
+    arch_allow: riscv
     tags:
       - fpu
       - kernel
@@ -41,8 +41,8 @@ tests:
     extra_args: PI_NUM_ITERATIONS=500
     extra_configs:
       - CONFIG_MAIN_STACK_SIZE=2048
-    filter: CONFIG_CPU_HAS_FPU
-    arch_allow: riscv64
+    filter: CONFIG_CPU_HAS_FPU and CONFIG_64BIT
+    arch_allow: riscv
     tags:
       - fpu
       - kernel

--- a/tests/kernel/gen_isr_table/testcase.yaml
+++ b/tests/kernel/gen_isr_table/testcase.yaml
@@ -68,9 +68,7 @@ tests:
       - CONFIG_ARC_FIRQ_STACK=y
       - CONFIG_TEST_HW_STACK_PROTECTION=n
   arch.interrupt.gen_isr_table.riscv_direct:
-    arch_allow:
-      - riscv32
-      - riscv64
+    arch_allow: riscv
     platform_exclude:
       - m2gl025_miv
       - adp_xc7k_ae350
@@ -79,9 +77,7 @@ tests:
       - CONFIG_GEN_IRQ_VECTOR_TABLE=y
   arch.interrupt.gen_isr_table.riscv_no_direct:
     platform_exclude: m2gl025_miv
-    arch_allow:
-      - riscv32
-      - riscv64
+    arch_allow: riscv
     filter: CONFIG_RISCV_PRIVILEGED
     extra_configs:
       - CONFIG_GEN_IRQ_VECTOR_TABLE=n


### PR DESCRIPTION
Note that the _dual_ `ARCH` in RISC-V is causing issues in HWMv2, hence this cleanup. Also, it didn't make much sense, since we already have `CONFIG_64BIT`.