### PR TITLE
twister: pytest: update device id when testing with pytest harness

### DIFF
--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -366,6 +366,8 @@ class Pytest(Harness):
         hardware = handler.get_hardware()
         if not hardware:
             raise PytestHarnessException('Hardware is not available')
+        # update the instance with the device id to have it in the summary report
+        self.instance.dut = hardware.id
 
         self.reserved_serial = hardware.serial_pty or hardware.serial
         if hardware.serial_pty:

--- a/scripts/tests/twister/test_harness.py
+++ b/scripts/tests/twister/test_harness.py
@@ -302,6 +302,7 @@ def test_pytest__generate_parameters_for_hardware(pty_value, hardware_value):
     hardware.post_script = 'post_script'
 
     pytest_test = Pytest()
+    pytest_test.configure(instance)
 
     #Act
     if hardware_value == 0:


### PR DESCRIPTION
Updated the instance with the device id to have it in the summary report also when using pytest harness.
It was missed for pytest. To test it run:
```
./scripts/twister -T samples/subsys/testsuite/pytest/shell --hardware-map ~/tmp/hardware_map.yml --device-testing -v 
...
INFO    - 1/1 nrf5340dk_nrf5340_cpuapp  samples/subsys/testsuite/pytest/shell/sample.pytest.shell PASSED (device: 000960185465, 14.277s)
```