### PR TITLE
tests: stop relying on filters to determine non-secure execution

### DIFF
--- a/boards/actinius/icarus/actinius_icarus_nrf9160_ns_1_4_0.yaml
+++ b/boards/actinius/icarus/actinius_icarus_nrf9160_ns_1_4_0.yaml
@@ -9,6 +9,7 @@ toolchain:
 ram: 128
 flash: 192
 supported:
+  - tfm-ns
   - gpio
   - i2c
   - pwm

--- a/boards/actinius/icarus/actinius_icarus_nrf9160_ns_1_4_0.yaml
+++ b/boards/actinius/icarus/actinius_icarus_nrf9160_ns_1_4_0.yaml
@@ -22,3 +22,7 @@ supported:
   - arduino_i2c
   - arduino_spi
 vendor: actinius
+testing:
+  ignore_tags:
+    - kernel
+    - userspace

--- a/boards/actinius/icarus_bee/actinius_icarus_bee_nrf9160_ns.yaml
+++ b/boards/actinius/icarus_bee/actinius_icarus_bee_nrf9160_ns.yaml
@@ -9,6 +9,7 @@ toolchain:
 ram: 128
 flash: 192
 supported:
+  - tfm-ns
   - gpio
   - i2c
   - pwm

--- a/boards/actinius/icarus_bee/actinius_icarus_bee_nrf9160_ns.yaml
+++ b/boards/actinius/icarus_bee/actinius_icarus_bee_nrf9160_ns.yaml
@@ -17,3 +17,7 @@ supported:
   - watchdog
   - counter
 vendor: actinius
+testing:
+  ignore_tags:
+    - kernel
+    - userspace

--- a/boards/actinius/icarus_som/actinius_icarus_som_nrf9160_ns.yaml
+++ b/boards/actinius/icarus_som/actinius_icarus_som_nrf9160_ns.yaml
@@ -9,6 +9,7 @@ toolchain:
 ram: 128
 flash: 192
 supported:
+  - tfm-ns
   - gpio
   - i2c
   - pwm

--- a/boards/actinius/icarus_som/actinius_icarus_som_nrf9160_ns.yaml
+++ b/boards/actinius/icarus_som/actinius_icarus_som_nrf9160_ns.yaml
@@ -16,3 +16,7 @@ supported:
   - watchdog
   - counter
 vendor: actinius
+testing:
+  ignore_tags:
+    - kernel
+    - userspace

--- a/boards/actinius/icarus_som_dk/actinius_icarus_som_dk_nrf9160_ns.yaml
+++ b/boards/actinius/icarus_som_dk/actinius_icarus_som_dk_nrf9160_ns.yaml
@@ -9,6 +9,7 @@ toolchain:
 ram: 128
 flash: 192
 supported:
+  - tfm-ns
   - gpio
   - i2c
   - pwm

--- a/boards/actinius/icarus_som_dk/actinius_icarus_som_dk_nrf9160_ns.yaml
+++ b/boards/actinius/icarus_som_dk/actinius_icarus_som_dk_nrf9160_ns.yaml
@@ -21,3 +21,7 @@ supported:
   - arduino_serial
   - arduino_spi
 vendor: actinius
+testing:
+  ignore_tags:
+    - kernel
+    - userspace

--- a/boards/arm/fvp_base_revc_2xaemv8a/fvp_base_revc_2xaemv8a_fvp_base_revc_2xaemv8a_smp_ns.yaml
+++ b/boards/arm/fvp_base_revc_2xaemv8a/fvp_base_revc_2xaemv8a_fvp_base_revc_2xaemv8a_smp_ns.yaml
@@ -8,6 +8,8 @@ type: sim
 toolchain:
   - zephyr
   - cross-compile
+supported:
+  - tfm-ns
 ram: 2048
 flash: 64
 vendor: arm

--- a/boards/arm/fvp_base_revc_2xaemv8a/fvp_base_revc_2xaemv8a_fvp_base_revc_2xaemv8a_smp_ns.yaml
+++ b/boards/arm/fvp_base_revc_2xaemv8a/fvp_base_revc_2xaemv8a_fvp_base_revc_2xaemv8a_smp_ns.yaml
@@ -13,3 +13,7 @@ supported:
 ram: 2048
 flash: 64
 vendor: arm
+testing:
+  ignore_tags:
+    - kernel
+    - userspace

--- a/boards/arm/mps2/mps2_an521_cpu0_ns.yaml
+++ b/boards/arm/mps2/mps2_an521_cpu0_ns.yaml
@@ -9,6 +9,8 @@ toolchain:
   - gnuarmemb
   - zephyr
   - xtools
+supported:
+  - tfm-ns
 testing:
   default: true
   only_tags:

--- a/boards/arm/mps3/mps3_an547_ns.yaml
+++ b/boards/arm/mps3/mps3_an547_ns.yaml
@@ -15,6 +15,8 @@ toolchain:
   - gnuarmemb
   - zephyr
   - xtools
+supported:
+  - tfm-ns
 testing:
   default: true
   only_tags:

--- a/boards/arm/v2m_musca_b1/v2m_musca_b1_musca_b1_ns.yaml
+++ b/boards/arm/v2m_musca_b1/v2m_musca_b1_musca_b1_ns.yaml
@@ -11,3 +11,7 @@ supported:
 ram: 64
 flash: 1663
 vendor: arm
+testing:
+  ignore_tags:
+    - kernel
+    - userspace

--- a/boards/arm/v2m_musca_b1/v2m_musca_b1_musca_b1_ns.yaml
+++ b/boards/arm/v2m_musca_b1/v2m_musca_b1_musca_b1_ns.yaml
@@ -6,6 +6,8 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
+supported:
+  - tfm-ns
 ram: 64
 flash: 1663
 vendor: arm

--- a/boards/arm/v2m_musca_s1/v2m_musca_s1_musca_s1_ns.yaml
+++ b/boards/arm/v2m_musca_s1/v2m_musca_s1_musca_s1_ns.yaml
@@ -6,6 +6,8 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
+supported:
+  - tfm-ns
 ram: 256
 flash: 511
 vendor: arm

--- a/boards/arm/v2m_musca_s1/v2m_musca_s1_musca_s1_ns.yaml
+++ b/boards/arm/v2m_musca_s1/v2m_musca_s1_musca_s1_ns.yaml
@@ -11,3 +11,7 @@ supported:
 ram: 256
 flash: 511
 vendor: arm
+testing:
+  ignore_tags:
+    - kernel
+    - userspace

--- a/boards/circuit_dojo/feather/circuitdojo_feather_nrf9160_ns.yaml
+++ b/boards/circuit_dojo/feather/circuitdojo_feather_nrf9160_ns.yaml
@@ -9,6 +9,7 @@ toolchain:
 ram: 128
 flash: 192
 supported:
+  - tfm-ns
   - i2c
   - pwm
   - watchdog

--- a/boards/circuit_dojo/feather/circuitdojo_feather_nrf9160_ns.yaml
+++ b/boards/circuit_dojo/feather/circuitdojo_feather_nrf9160_ns.yaml
@@ -13,3 +13,7 @@ supported:
   - i2c
   - pwm
   - watchdog
+testing:
+  ignore_tags:
+    - kernel
+    - userspace

--- a/boards/innblue/innblue21/innblue21_nrf9160_ns.yaml
+++ b/boards/innblue/innblue21/innblue21_nrf9160_ns.yaml
@@ -9,6 +9,7 @@ toolchain:
 ram: 128
 flash: 192
 supported:
+  - tfm-ns
   - i2c
   - pwm
   - watchdog

--- a/boards/innblue/innblue21/innblue21_nrf9160_ns.yaml
+++ b/boards/innblue/innblue21/innblue21_nrf9160_ns.yaml
@@ -13,3 +13,7 @@ supported:
   - i2c
   - pwm
   - watchdog
+testing:
+  ignore_tags:
+    - kernel
+    - userspace

--- a/boards/innblue/innblue22/innblue22_nrf9160_ns.yaml
+++ b/boards/innblue/innblue22/innblue22_nrf9160_ns.yaml
@@ -9,6 +9,7 @@ toolchain:
 ram: 128
 flash: 192
 supported:
+  - tfm-ns
   - i2c
   - pwm
   - watchdog

--- a/boards/innblue/innblue22/innblue22_nrf9160_ns.yaml
+++ b/boards/innblue/innblue22/innblue22_nrf9160_ns.yaml
@@ -13,3 +13,7 @@ supported:
   - i2c
   - pwm
   - watchdog
+testing:
+  ignore_tags:
+    - kernel
+    - userspace

--- a/boards/lairdconnect/bl5340_dvk/bl5340_dvk_nrf5340_cpuapp_ns.yaml
+++ b/boards/lairdconnect/bl5340_dvk/bl5340_dvk_nrf5340_cpuapp_ns.yaml
@@ -9,6 +9,7 @@ toolchain:
 ram: 192
 flash: 192
 supported:
+  - tfm-ns
   - counter
   - gpio
   - i2c

--- a/boards/lairdconnect/bl5340_dvk/bl5340_dvk_nrf5340_cpuapp_ns.yaml
+++ b/boards/lairdconnect/bl5340_dvk/bl5340_dvk_nrf5340_cpuapp_ns.yaml
@@ -20,3 +20,7 @@ supported:
   - usb_device
   - watchdog
 vendor: lairdconnect
+testing:
+  ignore_tags:
+    - kernel
+    - userspace

--- a/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_nrf5340_cpuapp_ns.yaml
+++ b/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_nrf5340_cpuapp_ns.yaml
@@ -18,3 +18,7 @@ supported:
   - usb_cdc
   - usb_device
 vendor: nordic
+testing:
+  ignore_tags:
+    - kernel
+    - userspace

--- a/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_nrf5340_cpuapp_ns.yaml
+++ b/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_nrf5340_cpuapp_ns.yaml
@@ -9,6 +9,7 @@ toolchain:
 ram: 192
 flash: 192
 supported:
+  - tfm-ns
   - i2c
   - i2s
   - spi

--- a/boards/nordic/nrf5340dk/nrf5340dk_nrf5340_cpuapp_ns.yaml
+++ b/boards/nordic/nrf5340dk/nrf5340dk_nrf5340_cpuapp_ns.yaml
@@ -9,6 +9,7 @@ toolchain:
 ram: 192
 flash: 192
 supported:
+  - tfm-ns
   - i2c
   - pwm
   - watchdog

--- a/boards/nordic/nrf5340dk/nrf5340dk_nrf5340_cpuapp_ns.yaml
+++ b/boards/nordic/nrf5340dk/nrf5340dk_nrf5340_cpuapp_ns.yaml
@@ -19,3 +19,7 @@ supported:
   - gpio
   - spi
 vendor: nordic
+testing:
+  ignore_tags:
+    - kernel
+    - userspace

--- a/boards/nordic/nrf9131ek/nrf9131ek_nrf9131_ns.yaml
+++ b/boards/nordic/nrf9131ek/nrf9131ek_nrf9131_ns.yaml
@@ -9,6 +9,7 @@ toolchain:
 ram: 128
 flash: 212
 supported:
+  - tfm-ns
   - i2c
   - pwm
   - watchdog

--- a/boards/nordic/nrf9131ek/nrf9131ek_nrf9131_ns.yaml
+++ b/boards/nordic/nrf9131ek/nrf9131ek_nrf9131_ns.yaml
@@ -14,3 +14,7 @@ supported:
   - pwm
   - watchdog
   - netif:modem
+testing:
+  ignore_tags:
+    - kernel
+    - userspace

--- a/boards/nordic/nrf9151dk/nrf9151dk_nrf9151_ns.yaml
+++ b/boards/nordic/nrf9151dk/nrf9151dk_nrf9151_ns.yaml
@@ -19,3 +19,7 @@ supported:
   - watchdog
   - netif:modem
 vendor: nordic
+testing:
+  ignore_tags:
+    - kernel
+    - userspace

--- a/boards/nordic/nrf9151dk/nrf9151dk_nrf9151_ns.yaml
+++ b/boards/nordic/nrf9151dk/nrf9151dk_nrf9151_ns.yaml
@@ -9,6 +9,7 @@ toolchain:
 ram: 128
 flash: 192
 supported:
+  - tfm-ns
   - arduino_gpio
   - arduino_i2c
   - arduino_serial

--- a/boards/nordic/nrf9160dk/nrf9160dk_nrf9160_ns_0_14_0.yaml
+++ b/boards/nordic/nrf9160dk/nrf9160dk_nrf9160_ns_0_14_0.yaml
@@ -9,6 +9,7 @@ toolchain:
 ram: 128
 flash: 192
 supported:
+  - tfm-ns
   - arduino_gpio
   - arduino_i2c
   - arduino_serial

--- a/boards/nordic/nrf9160dk/nrf9160dk_nrf9160_ns_0_14_0.yaml
+++ b/boards/nordic/nrf9160dk/nrf9160dk_nrf9160_ns_0_14_0.yaml
@@ -20,3 +20,7 @@ supported:
   - netif:modem
   - gpio
 vendor: nordic
+testing:
+  ignore_tags:
+    - kernel
+    - userspace

--- a/boards/nordic/nrf9161dk/nrf9161dk_nrf9161_ns_0_9_0.yaml
+++ b/boards/nordic/nrf9161dk/nrf9161dk_nrf9161_ns_0_9_0.yaml
@@ -19,3 +19,7 @@ supported:
   - watchdog
   - netif:modem
 vendor: nordic
+testing:
+  ignore_tags:
+    - kernel
+    - userspace

--- a/boards/nordic/nrf9161dk/nrf9161dk_nrf9161_ns_0_9_0.yaml
+++ b/boards/nordic/nrf9161dk/nrf9161dk_nrf9161_ns_0_9_0.yaml
@@ -9,6 +9,7 @@ toolchain:
 ram: 128
 flash: 192
 supported:
+  - tfm-ns
   - arduino_gpio
   - arduino_i2c
   - arduino_serial

--- a/boards/nordic/thingy53/thingy53_nrf5340_cpuapp_ns.yaml
+++ b/boards/nordic/thingy53/thingy53_nrf5340_cpuapp_ns.yaml
@@ -18,3 +18,7 @@ supported:
   - usb_device
   - netif:openthread
 vendor: nordic
+testing:
+  ignore_tags:
+    - kernel
+    - userspace

--- a/boards/nordic/thingy53/thingy53_nrf5340_cpuapp_ns.yaml
+++ b/boards/nordic/thingy53/thingy53_nrf5340_cpuapp_ns.yaml
@@ -9,6 +9,7 @@ toolchain:
 ram: 192
 flash: 192
 supported:
+  - tfm-ns
   - gpio
   - i2c
   - pwm

--- a/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0_ns.yaml
+++ b/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0_ns.yaml
@@ -24,3 +24,7 @@ supported:
   - spi
   - watchdog
 vendor: nxp
+testing:
+  ignore_tags:
+    - kernel
+    - userspace

--- a/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0_ns.yaml
+++ b/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0_ns.yaml
@@ -15,6 +15,7 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
+  - tfm-ns
   - adc
   - arduino_spi
   - counter

--- a/boards/raytac/mdbt53_db_40/raytac_mdbt53_db_40_nrf5340_cpuapp_ns.yaml
+++ b/boards/raytac/mdbt53_db_40/raytac_mdbt53_db_40_nrf5340_cpuapp_ns.yaml
@@ -9,6 +9,7 @@ toolchain:
 ram: 192
 flash: 192
 supported:
+  - tfm-ns
   - counter
   - i2c
   - pwm

--- a/boards/raytac/mdbt53_db_40/raytac_mdbt53_db_40_nrf5340_cpuapp_ns.yaml
+++ b/boards/raytac/mdbt53_db_40/raytac_mdbt53_db_40_nrf5340_cpuapp_ns.yaml
@@ -20,3 +20,7 @@ supported:
   - usb_device
   - netif:openthread
   - gpio
+testing:
+  ignore_tags:
+    - kernel
+    - userspace

--- a/boards/raytac/mdbt53v_db_40/raytac_mdbt53v_db_40_nrf5340_cpuapp_ns.yaml
+++ b/boards/raytac/mdbt53v_db_40/raytac_mdbt53v_db_40_nrf5340_cpuapp_ns.yaml
@@ -9,6 +9,7 @@ toolchain:
 ram: 192
 flash: 192
 supported:
+  - tfm-ns
   - i2c
   - pwm
   - watchdog

--- a/boards/raytac/mdbt53v_db_40/raytac_mdbt53v_db_40_nrf5340_cpuapp_ns.yaml
+++ b/boards/raytac/mdbt53v_db_40/raytac_mdbt53v_db_40_nrf5340_cpuapp_ns.yaml
@@ -15,3 +15,7 @@ supported:
   - watchdog
   - netif:openthread
   - gpio
+testing:
+  ignore_tags:
+    - kernel
+    - userspace

--- a/boards/sparkfun/thing_plus/sparkfun_thing_plus_nrf9160_ns.yaml
+++ b/boards/sparkfun/thing_plus/sparkfun_thing_plus_nrf9160_ns.yaml
@@ -9,6 +9,7 @@ toolchain:
 ram: 128
 flash: 192
 supported:
+  - tfm-ns
   - i2c
   - pwm
   - watchdog

--- a/boards/sparkfun/thing_plus/sparkfun_thing_plus_nrf9160_ns.yaml
+++ b/boards/sparkfun/thing_plus/sparkfun_thing_plus_nrf9160_ns.yaml
@@ -14,3 +14,7 @@ supported:
   - pwm
   - watchdog
 vendor: sparkfun
+testing:
+  ignore_tags:
+    - kernel
+    - userspace

--- a/boards/st/b_u585i_iot02a/b_u585i_iot02a_stm32u585xx_ns.yaml
+++ b/boards/st/b_u585i_iot02a/b_u585i_iot02a_stm32u585xx_ns.yaml
@@ -11,3 +11,7 @@ supported:
 ram: 786
 flash: 512
 vendor: st
+testing:
+  ignore_tags:
+    - kernel
+    - userspace

--- a/boards/st/b_u585i_iot02a/b_u585i_iot02a_stm32u585xx_ns.yaml
+++ b/boards/st/b_u585i_iot02a/b_u585i_iot02a_stm32u585xx_ns.yaml
@@ -6,6 +6,8 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
+supported:
+  - tfm-ns
 ram: 786
 flash: 512
 vendor: st

--- a/boards/st/nucleo_l552ze_q/nucleo_l552ze_q_stm32l552xx_ns.yaml
+++ b/boards/st/nucleo_l552ze_q/nucleo_l552ze_q_stm32l552xx_ns.yaml
@@ -6,6 +6,7 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
+  - tfm-ns
   - gpio
   - dac
 ram: 192

--- a/boards/st/nucleo_l552ze_q/nucleo_l552ze_q_stm32l552xx_ns.yaml
+++ b/boards/st/nucleo_l552ze_q/nucleo_l552ze_q_stm32l552xx_ns.yaml
@@ -12,3 +12,7 @@ supported:
 ram: 192
 flash: 328
 vendor: st
+testing:
+  ignore_tags:
+    - kernel
+    - userspace

--- a/boards/st/stm32l562e_dk/stm32l562e_dk_stm32l562xx_ns.yaml
+++ b/boards/st/stm32l562e_dk/stm32l562e_dk_stm32l562xx_ns.yaml
@@ -20,3 +20,7 @@ supported:
 ram: 192
 flash: 512
 vendor: st
+testing:
+  ignore_tags:
+    - kernel
+    - userspace

--- a/boards/st/stm32l562e_dk/stm32l562e_dk_stm32l562xx_ns.yaml
+++ b/boards/st/stm32l562e_dk/stm32l562e_dk_stm32l562xx_ns.yaml
@@ -6,6 +6,7 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
+  - tfm-ns
   - counter
   - gpio
   - i2c

--- a/tests/arch/arm/arm_thread_swap_tz/testcase.yaml
+++ b/tests/arch/arm/arm_thread_swap_tz/testcase.yaml
@@ -1,5 +1,6 @@
 common:
-  filter: (CONFIG_TFM_BOARD != "") and CONFIG_ARM_NONSECURE_FIRMWARE
+  depends_on:
+    - tfm-ns
   tags:
     - arm
     - fpu

--- a/tests/crypto/rand32/testcase.yaml
+++ b/tests/crypto/rand32/testcase.yaml
@@ -25,8 +25,9 @@ tests:
     integration_platforms:
       - native_sim
   drivers.rand32.random_psa_crypto:
-    filter: CONFIG_BUILD_WITH_TFM
     arch_exclude: posix
+    depends_on:
+      - tfm-ns
     extra_args:
       - DTC_OVERLAY_FILE=./entropy_psa_crypto.overlay
       - CONF_FILE=prj_hw_random_psa_crypto.conf

--- a/tests/drivers/flash/common/testcase.yaml
+++ b/tests/drivers/flash/common/testcase.yaml
@@ -37,8 +37,10 @@ tests:
       - mimxrt1060_evk
   drivers.flash.common.tfm_ns:
     build_only: true
-    filter: (CONFIG_FLASH_HAS_DRIVER_ENABLED and CONFIG_TRUSTED_EXECUTION_NONSECURE
-      and dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions"))
+    filter: CONFIG_FLASH_HAS_DRIVER_ENABLED and
+             dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")
+    depends_on:
+      - tfm-ns
     integration_platforms:
       - nrf9161dk/nrf9161/ns
   drivers.flash.common.stm32:

--- a/tests/net/lib/tls_credentials/testcase.yaml
+++ b/tests/net/lib/tls_credentials/testcase.yaml
@@ -5,10 +5,11 @@ tests:
       - tls
     depends_on: netif
   net.tls_credentials.trusted_tfm:
-    filter: CONFIG_BUILD_WITH_TFM
     extra_args: OVERLAY_CONFIG=./prj_trusted_tfm.conf
     tags:
       - net
       - tls
       - trusted
-    depends_on: netif
+    depends_on:
+      - netif
+      - tfm-ns


### PR DESCRIPTION
Instead of relying on filters, use the supported keyword and
execute/build tests faster.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
