### PR TITLE
tests: dma: rename DT node label for tested device

### DIFF
--- a/tests/drivers/dma/loop_transfer/boards/adafruit_itsybitsy_m4_express.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/adafruit_itsybitsy_m4_express.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dmac { };
+tst_dma0: &dmac { };

--- a/tests/drivers/dma/loop_transfer/boards/adafruit_trinket_m0.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/adafruit_trinket_m0.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dmac { };
+tst_dma0: &dmac { };

--- a/tests/drivers/dma/loop_transfer/boards/adp_xc7k_ae350.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/adp_xc7k_ae350.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma0 {
+tst_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/loop_transfer/boards/arduino_mkrzero.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/arduino_mkrzero.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dmac { };
+tst_dma0: &dmac { };

--- a/tests/drivers/dma/loop_transfer/boards/arduino_nano_33_iot.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/arduino_nano_33_iot.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dmac { };
+tst_dma0: &dmac { };

--- a/tests/drivers/dma/loop_transfer/boards/arduino_zero.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/arduino_zero.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dmac { };
+tst_dma0: &dmac { };

--- a/tests/drivers/dma/loop_transfer/boards/atsamc21n_xpro.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/atsamc21n_xpro.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dmac { };
+tst_dma0: &dmac { };

--- a/tests/drivers/dma/loop_transfer/boards/atsamd21_xpro.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/atsamd21_xpro.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dmac { };
+tst_dma0: &dmac { };

--- a/tests/drivers/dma/loop_transfer/boards/atsaml21_xpro.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/atsaml21_xpro.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dmac { };
+tst_dma0: &dmac { };

--- a/tests/drivers/dma/loop_transfer/boards/atsamr34_xpro.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/atsamr34_xpro.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dmac { };
+tst_dma0: &dmac { };

--- a/tests/drivers/dma/loop_transfer/boards/b_u585i_iot02a.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/b_u585i_iot02a.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &gpdma1 {
+tst_dma0: &gpdma1 {
 	status = "okay";
 };

--- a/tests/drivers/dma/loop_transfer/boards/disco_l475_iot1.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/disco_l475_iot1.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma1 { };
+tst_dma0: &dma1 { };

--- a/tests/drivers/dma/loop_transfer/boards/esp32c3_devkitm.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/esp32c3_devkitm.overlay
@@ -8,4 +8,4 @@
 	status = "okay";
 };
 
-test_dma0: &dma { };
+tst_dma0: &dma { };

--- a/tests/drivers/dma/loop_transfer/boards/esp32c3_luatos_core.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/esp32c3_luatos_core.overlay
@@ -8,4 +8,4 @@
 	status = "okay";
 };
 
-test_dma0: &dma { };
+tst_dma0: &dma { };

--- a/tests/drivers/dma/loop_transfer/boards/esp32c3_luatos_core_usb.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/esp32c3_luatos_core_usb.overlay
@@ -8,4 +8,4 @@
 	status = "okay";
 };
 
-test_dma0: &dma { };
+tst_dma0: &dma { };

--- a/tests/drivers/dma/loop_transfer/boards/esp32s3_devkitm.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/esp32s3_devkitm.overlay
@@ -8,4 +8,4 @@
 	status = "okay";
 };
 
-test_dma0: &dma { };
+tst_dma0: &dma { };

--- a/tests/drivers/dma/loop_transfer/boards/esp32s3_luatos_core.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/esp32s3_luatos_core.overlay
@@ -8,4 +8,4 @@
 	status = "okay";
 };
 
-test_dma0: &dma { };
+tst_dma0: &dma { };

--- a/tests/drivers/dma/loop_transfer/boards/esp32s3_luatos_core_usb.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/esp32s3_luatos_core_usb.overlay
@@ -8,4 +8,4 @@
 	status = "okay";
 };
 
-test_dma0: &dma { };
+tst_dma0: &dma { };

--- a/tests/drivers/dma/loop_transfer/boards/frdm_k64f.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/frdm_k64f.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &edma0 { };
+tst_dma0: &edma0 { };

--- a/tests/drivers/dma/loop_transfer/boards/gd32e103v_eval.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/gd32e103v_eval.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma0 {
+tst_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/loop_transfer/boards/gd32e507v_start.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/gd32e507v_start.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma0 {
+tst_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/loop_transfer/boards/gd32e507z_eval.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/gd32e507z_eval.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma0 {
+tst_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/loop_transfer/boards/gd32f350r_eval.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/gd32f350r_eval.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma {
+tst_dma0: &dma {
 	status = "okay";
 };

--- a/tests/drivers/dma/loop_transfer/boards/gd32f403z_eval.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/gd32f403z_eval.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma0 {
+tst_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/loop_transfer/boards/gd32f407v_start.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/gd32f407v_start.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma1 {
+tst_dma0: &dma1 {
 	status = "okay";
 };

--- a/tests/drivers/dma/loop_transfer/boards/gd32f450i_eval.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/gd32f450i_eval.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma1 {
+tst_dma0: &dma1 {
 	status = "okay";
 };

--- a/tests/drivers/dma/loop_transfer/boards/gd32f450v_start.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/gd32f450v_start.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma1 {
+tst_dma0: &dma1 {
 	status = "okay";
 };

--- a/tests/drivers/dma/loop_transfer/boards/gd32f450z_eval.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/gd32f450z_eval.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma1 {
+tst_dma0: &dma1 {
 	status = "okay";
 };

--- a/tests/drivers/dma/loop_transfer/boards/gd32f470i_eval.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/gd32f470i_eval.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma1 {
+tst_dma0: &dma1 {
 	status = "okay";
 };

--- a/tests/drivers/dma/loop_transfer/boards/gd32vf103c_starter.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/gd32vf103c_starter.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma0 {
+tst_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/loop_transfer/boards/gd32vf103v_eval.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/gd32vf103v_eval.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma0 {
+tst_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/loop_transfer/boards/intel_adsp_ace15_mtpm.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/intel_adsp_ace15_mtpm.overlay
@@ -5,4 +5,4 @@
  * Author: Tomasz Leman <tomasz.m.leman@intel.com>
  */
 
-test_dma0: &lpgpdma0 { };
+tst_dma0: &lpgpdma0 { };

--- a/tests/drivers/dma/loop_transfer/boards/intel_adsp_cavs25.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/intel_adsp_cavs25.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &lpgpdma0 { };
+tst_dma0: &lpgpdma0 { };

--- a/tests/drivers/dma/loop_transfer/boards/intel_adsp_cavs25_tgph.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/intel_adsp_cavs25_tgph.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &lpgpdma0 { };
+tst_dma0: &lpgpdma0 { };

--- a/tests/drivers/dma/loop_transfer/boards/longan_nano.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/longan_nano.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma0 {
+tst_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/loop_transfer/boards/longan_nano_lite.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/longan_nano_lite.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma0 {
+tst_dma0: &dma0 {
 	status = "okay";
 };

--- a/tests/drivers/dma/loop_transfer/boards/lpcxpresso55s36.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/lpcxpresso55s36.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma0 { };
+tst_dma0: &dma0 { };

--- a/tests/drivers/dma/loop_transfer/boards/lpcxpresso55s69_cpu0.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/lpcxpresso55s69_cpu0.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma0 { };
+tst_dma0: &dma0 { };

--- a/tests/drivers/dma/loop_transfer/boards/lpcxpresso55s69_ns.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/lpcxpresso55s69_ns.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma0 { };
+tst_dma0: &dma0 { };

--- a/tests/drivers/dma/loop_transfer/boards/mec172xevb_assy6906.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/mec172xevb_assy6906.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma: &dmac {
+tst_dma: &dmac {
 	status = "okay";
 };

--- a/tests/drivers/dma/loop_transfer/boards/mimxrt1024_evk.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/mimxrt1024_evk.overlay
@@ -11,4 +11,4 @@
 	zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE) )>;
 };
 
-test_dma0: &edma0 { };
+tst_dma0: &edma0 { };

--- a/tests/drivers/dma/loop_transfer/boards/mimxrt1050_evk.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/mimxrt1050_evk.overlay
@@ -11,4 +11,4 @@
 	zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE) )>;
 };
 
-test_dma0: &edma0 { };
+tst_dma0: &edma0 { };

--- a/tests/drivers/dma/loop_transfer/boards/mimxrt1060_evk.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/mimxrt1060_evk.overlay
@@ -11,4 +11,4 @@
 	zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE) )>;
 };
 
-test_dma0: &edma0 { };
+tst_dma0: &edma0 { };

--- a/tests/drivers/dma/loop_transfer/boards/mimxrt1060_evkb.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/mimxrt1060_evkb.overlay
@@ -11,4 +11,4 @@
 	zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE) )>;
 };
 
-test_dma0: &edma0 { };
+tst_dma0: &edma0 { };

--- a/tests/drivers/dma/loop_transfer/boards/mimxrt1064_evk.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/mimxrt1064_evk.overlay
@@ -11,4 +11,4 @@
 	zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE) )>;
 };
 
-test_dma0: &edma0 { };
+tst_dma0: &edma0 { };

--- a/tests/drivers/dma/loop_transfer/boards/mimxrt1160_evk_cm4.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/mimxrt1160_evk_cm4.overlay
@@ -11,4 +11,4 @@
 	zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE) )>;
 };
 
-test_dma0: &edma_lpsr0 { };
+tst_dma0: &edma_lpsr0 { };

--- a/tests/drivers/dma/loop_transfer/boards/mimxrt1160_evk_cm7.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/mimxrt1160_evk_cm7.overlay
@@ -11,4 +11,4 @@
 	zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE) )>;
 };
 
-test_dma0: &edma0 { };
+tst_dma0: &edma0 { };

--- a/tests/drivers/dma/loop_transfer/boards/mimxrt1170_evk_cm4.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/mimxrt1170_evk_cm4.overlay
@@ -11,4 +11,4 @@
 	zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE) )>;
 };
 
-test_dma0: &edma_lpsr0 { };
+tst_dma0: &edma_lpsr0 { };

--- a/tests/drivers/dma/loop_transfer/boards/mimxrt1170_evk_cm7.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/mimxrt1170_evk_cm7.overlay
@@ -11,4 +11,4 @@
 	zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE) )>;
 };
 
-test_dma0: &edma0 { };
+tst_dma0: &edma0 { };

--- a/tests/drivers/dma/loop_transfer/boards/mimxrt1170_evkb_cm4.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/mimxrt1170_evkb_cm4.overlay
@@ -11,4 +11,4 @@
 	zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE) )>;
 };
 
-test_dma0: &edma_lpsr0 { };
+tst_dma0: &edma_lpsr0 { };

--- a/tests/drivers/dma/loop_transfer/boards/mimxrt1170_evkb_cm7.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/mimxrt1170_evkb_cm7.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &edma0 { };
+tst_dma0: &edma0 { };

--- a/tests/drivers/dma/loop_transfer/boards/mimxrt595_evk_cm33.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/mimxrt595_evk_cm33.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma0 { };
+tst_dma0: &dma0 { };

--- a/tests/drivers/dma/loop_transfer/boards/mimxrt685_evk_cm33.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/mimxrt685_evk_cm33.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma0 { };
+tst_dma0: &dma0 { };

--- a/tests/drivers/dma/loop_transfer/boards/mm_feather.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/mm_feather.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &edma0 { };
+tst_dma0: &edma0 { };

--- a/tests/drivers/dma/loop_transfer/boards/mr_canhubk3.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/mr_canhubk3.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &edma0 { };
+tst_dma0: &edma0 { };

--- a/tests/drivers/dma/loop_transfer/boards/native_posix.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/native_posix.overlay
@@ -9,4 +9,4 @@
 	status = "okay";
 };
 
-test_dma0: &dma { };
+tst_dma0: &dma { };

--- a/tests/drivers/dma/loop_transfer/boards/native_posix_64.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/native_posix_64.overlay
@@ -9,4 +9,4 @@
 	status = "okay";
 };
 
-test_dma0: &dma { };
+tst_dma0: &dma { };

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_f070rb.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_f070rb.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma1 {
+tst_dma0: &dma1 {
 	status = "okay";
 };

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_f091rc.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_f091rc.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma1 { };
+tst_dma0: &dma1 { };

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_f103rb.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_f103rb.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma1 { };
+tst_dma0: &dma1 { };

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_f207zg.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_f207zg.overlay
@@ -8,6 +8,6 @@
 	status = "okay";
 };
 
-test_dma0: &dma2 {
+tst_dma0: &dma2 {
 	status = "okay";
 };

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_f429zi.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_f429zi.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma2 { };
+tst_dma0: &dma2 { };

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_f746zg.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_f746zg.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma2 { };
+tst_dma0: &dma2 { };
 
 /* The test driver expects the SRAM0 region to be non-cachable */
 &sram0 {

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_f767zi.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_f767zi.overlay
@@ -8,7 +8,7 @@
 	status = "okay";
 };
 
-test_dma0: &dma2 {
+tst_dma0: &dma2 {
 	status = "okay";
 };
 

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_g071rb.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_g071rb.overlay
@@ -8,6 +8,6 @@
 	status = "okay";
 };
 
-test_dma0: &dmamux1 {
+tst_dma0: &dmamux1 {
 	status = "okay";
 };

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_g0b1re.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_g0b1re.overlay
@@ -8,6 +8,6 @@
 	status = "okay";
 };
 
-test_dma0: &dmamux1 {
+tst_dma0: &dmamux1 {
 	status = "okay";
 };

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_g474re.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_g474re.overlay
@@ -8,6 +8,6 @@
 	status = "okay";
 };
 
-test_dma0: &dmamux1 {
+tst_dma0: &dmamux1 {
 	status = "okay";
 };

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_h743zi.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_h743zi.overlay
@@ -10,7 +10,7 @@
 	status = "okay";
 };
 
-test_dma0: &dmamux1 {
+tst_dma0: &dmamux1 {
 	status = "okay";
 };
 
@@ -25,6 +25,6 @@ test_dma0: &dmamux1 {
 	status = "okay";
 };
 
-test_dma1: &dmamux2 {
+tst_dma1: &dmamux2 {
 	status = "okay";
 };

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_l053r8.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_l053r8.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma1 {
+tst_dma0: &dma1 {
 	status = "okay";
 };

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_l152re.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_l152re.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma1 { };
+tst_dma0: &dma1 { };

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_l476rg.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_l476rg.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma1 {
+tst_dma0: &dma1 {
 	status = "okay";
 };
 

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_l496zg.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_l496zg.overlay
@@ -8,6 +8,6 @@
 	status = "okay";
 };
 
-test_dma0: &dma2 {
+tst_dma0: &dma2 {
 	status = "okay";
 };

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_l552ze_q.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_l552ze_q.overlay
@@ -12,6 +12,6 @@
 	status = "okay";
 };
 
-test_dma0: &dmamux1 {
+tst_dma0: &dmamux1 {
 	status = "okay";
 };

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_u575zi_q.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_u575zi_q.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &gpdma1 {
+tst_dma0: &gpdma1 {
 	status = "okay";
 };

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_wb55rg.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_wb55rg.overlay
@@ -12,6 +12,6 @@
 	status = "okay";
 };
 
-test_dma0: &dmamux1 {
+tst_dma0: &dmamux1 {
 	status = "okay";
 };

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_wl55jc.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_wl55jc.overlay
@@ -12,6 +12,6 @@
 	status = "okay";
 };
 
-test_dma0: &dmamux1 {
+tst_dma0: &dmamux1 {
 	status = "okay";
 };

--- a/tests/drivers/dma/loop_transfer/boards/rpi_pico.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/rpi_pico.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma: &dma {
+tst_dma0: &dma {
 	status = "okay";
 };

--- a/tests/drivers/dma/loop_transfer/boards/seeeduino_xiao.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/seeeduino_xiao.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dmac { };
+tst_dma0: &dmac { };

--- a/tests/drivers/dma/loop_transfer/boards/stm32f3_disco.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/stm32f3_disco.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &dma1 { };
+tst_dma0: &dma1 { };

--- a/tests/drivers/dma/loop_transfer/boards/stm32g0316_disco.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/stm32g0316_disco.overlay
@@ -8,6 +8,6 @@
 	status = "okay";
 };
 
-test_dma0: &dmamux1 {
+tst_dma0: &dmamux1 {
 	status = "okay";
 };

--- a/tests/drivers/dma/loop_transfer/boards/stm32h573i_dk.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/stm32h573i_dk.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &gpdma2 {
+tst_dma0: &gpdma2 {
 	status = "okay";
 };

--- a/tests/drivers/dma/loop_transfer/boards/stm32l562e_dk.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/stm32l562e_dk.overlay
@@ -12,6 +12,6 @@
 	status = "okay";
 };
 
-test_dma0: &dmamux1 {
+tst_dma0: &dmamux1 {
 	status = "okay";
 };

--- a/tests/drivers/dma/loop_transfer/boards/stm32mp157c_dk2.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/stm32mp157c_dk2.overlay
@@ -16,6 +16,6 @@
 	status = "okay";
 };
 
-test_dma0: &dmamux {
+tst_dma0: &dmamux {
 	status = "okay";
 };

--- a/tests/drivers/dma/loop_transfer/boards/twr_ke18f.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/twr_ke18f.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-test_dma0: &edma { };
+tst_dma0: &edma { };

--- a/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
+++ b/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
@@ -472,7 +472,7 @@ static int test_loop_repeated_start_stop(const struct device *dma)
 	return TC_PASS;
 }
 
-#define DMA_NAME(i, _)	test_dma ## i
+#define DMA_NAME(i, _)	tst_dma ## i
 #define DMA_LIST	LISTIFY(CONFIG_DMA_LOOP_TRANSFER_NUMBER_OF_DMAS, DMA_NAME, (,))
 
 #define TEST_LOOP(dma_name)                                                                        \

--- a/tests/drivers/dma/loop_transfer/testcase.yaml
+++ b/tests/drivers/dma/loop_transfer/testcase.yaml
@@ -7,4 +7,4 @@ tests:
     integration_platforms:
       - native_posix
       - native_posix_64
-    filter: dt_nodelabel_enabled("test_dma0")
+    filter: dt_nodelabel_enabled("tst_dma0")


### PR DESCRIPTION
Use tst_dma0 to avoid conflict with how twister and ztest deal with
testcase names.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
