### PR TITLE
boards: arm: rpi_pico: Add default serial for connector definition

### DIFF
--- a/boards/raspberrypi/rpi_pico/rpi_pico-common.dtsi
+++ b/boards/raspberrypi/rpi_pico/rpi_pico-common.dtsi
@@ -157,3 +157,4 @@ zephyr_udc0: &usbd {
 pico_spi: &spi0 {};
 pico_i2c0: &i2c0 {};
 pico_i2c1: &i2c1 {};
+pico_serial: &uart0 {};


### PR DESCRIPTION
Add `pico_serial` which is alias of `uart0` as a definition related to pico_header.
The uart0(GP0 and GP1)  is shown as default serial port in pinout diaglam.