### PR TITLE
cmake: improved board handling for revisions

### DIFF
--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -226,7 +226,8 @@ class Filters:
             roots.append(repository_path)
 
         # Look for boards in monitored repositories
-        lb_args = argparse.Namespace(**{ 'arch_roots': roots, 'board_roots': roots, 'board': None})
+        lb_args = argparse.Namespace(**{'arch_roots': roots, 'board_roots': roots, 'board': None,
+                                        'board_dir': None})
         known_boards = list_boards.find_boards(lb_args)
         for b in boards:
             name_re = re.compile(b)

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -405,7 +405,7 @@ class TestPlan:
         # but in Zephyr build system, the board root is without the `boards` in folder path.
         board_roots = [Path(os.path.dirname(root)) for root in self.env.board_roots]
         lb_args = Namespace(arch_roots=[Path(ZEPHYR_BASE)], soc_roots=[Path(ZEPHYR_BASE)],
-                            board_roots=board_roots, board=None)
+                            board_roots=board_roots, board=None, board_dir=None)
         v1_boards = list_boards.find_boards(lb_args)
         v2_boards = list_boards.find_v2_boards(lb_args)
         for b in v1_boards:


### PR DESCRIPTION
This commit improves board handling for boards in HWMv2. On a CMake rerun, then BOARD_DIR is passed to `list_boards.py` which is extended to take such parameter.

This allows to run `list_boards.py` whenever CMake reruns without the penalty of searching for all board.yml files, as only the board.yml of the current BOARD_DIR is processed.

This allows `list_boards.py` to be invoked and from there obtain list of valid revisions and board identifiers for further board validation.

This removes the need for caching additional CMake variables related to the board identifier and revision and thereby remove the risk of settings becoming out of sync as only the board provided by user is needed.

This work further ensure that use-cases described in #50536 is still supported.