### PR TITLE
cmake: improve arch error message for invalid arch selection

### DIFF
--- a/cmake/modules/arch_v2.cmake
+++ b/cmake/modules/arch_v2.cmake
@@ -31,8 +31,15 @@ if(HWMv2)
   # (read: multi-core and multi-arch SoC).
   set(ARCH ${CONFIG_ARCH})
   string(TOUPPER "${ARCH}" arch_upper)
-  cmake_path(GET ARCH_V2_${arch_upper}_DIR PARENT_PATH ARCH_DIR)
 
+  if(NOT ARCH)
+    message(FATAL_ERROR "ARCH not defined. Check that BOARD=${BOARD}, is selecting "
+            "an appropriate SoC in Kconfig, SoC=${CONFIG_SOC}, and that the SoC "
+            "is selecting the correct architecture."
+    )
+  endif()
+
+  cmake_path(GET ARCH_V2_${arch_upper}_DIR PARENT_PATH ARCH_DIR)
   if(NOT ARCH_DIR)
     message(FATAL_ERROR "Could not find ARCH=${ARCH} for BOARD=${BOARD}, \
 please check your installation. ARCH roots searched: \n\


### PR DESCRIPTION
Legacy hw model picked the arch based on folder names. The new hw model allows for greater flexibility and instead uses the architecture defined by `CONFIG_ARCH` in Kconfig.

Therefore check that ARCH is defined and fail with a better error message if ARCH is not defined. The error message includes the board and SoC selected to make it easier to trace such errors.