### PR TITLE
drivers: Fix signs in max31865 temperature calculation

### DIFF
--- a/drivers/sensor/max31865/max31865.c
+++ b/drivers/sensor/max31865/max31865.c
@@ -99,8 +99,8 @@ static double calculate_temperature(double resistance, double resistance_0)
 	}
 	resistance /= resistance_0;
 	resistance *= 100.0;
-	temperature = A[0] + A[1] * resistance + A[2] * pow(resistance, 2) +
-		      A[3] * pow(resistance, 3) + A[4] * pow(resistance, 4) +
+	temperature = A[0] + A[1] * resistance + A[2] * pow(resistance, 2) -
+		      A[3] * pow(resistance, 3) - A[4] * pow(resistance, 4) +
 		      A[5] * pow(resistance, 5);
 	return temperature;
 }


### PR DESCRIPTION
The reference document says that the formula for negative temperatures has two minus signs missing.

fixes #68710