### PR TITLE
dts: bindings: can: remove deprecated properties for initial timing

### DIFF
--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -45,6 +45,19 @@ Bluetooth HCI
 Controller Area Network (CAN)
 =============================
 
+* Removed the following deprecated CAN controller devicetree properties. Out-of-tree boards using
+  these properties need to switch to using the ``bus-speed``, ``sample-point``, ``bus-speed-data``,
+  and ``sample-point-data`` devicetree properties for specifying the initial CAN bitrate:
+
+  * ``sjw``
+  * ``prop-seg``
+  * ``phase-seg1``
+  * ``phase-seg1``
+  * ``sjw-data``
+  * ``prop-seg-data``
+  * ``phase-seg1-data``
+  * ``phase-seg1-data``
+
 Display
 =======
 

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -1457,46 +1457,25 @@ int can_mcan_init(const struct device *dev)
 		return err;
 	}
 
-	if (config->common.sample_point) {
-		err = can_calc_timing(dev, &timing, config->common.bus_speed,
-				      config->common.sample_point);
-		if (err == -EINVAL) {
-			LOG_ERR("Can't find timing for given param");
-			return -EIO;
-		}
-		LOG_DBG("Presc: %d, TS1: %d, TS2: %d", timing.prescaler, timing.phase_seg1,
-			timing.phase_seg2);
-		LOG_DBG("Sample-point err : %d", err);
-	} else if (config->prop_ts1) {
-		timing.sjw = config->sjw;
-		timing.prop_seg = 0U;
-		timing.phase_seg1 = config->prop_ts1;
-		timing.phase_seg2 = config->ts2;
-		err = can_calc_prescaler(dev, &timing, config->common.bus_speed);
-		if (err != 0) {
-			LOG_WRN("Bitrate error: %d", err);
-		}
+	err = can_calc_timing(dev, &timing, config->common.bus_speed,
+			      config->common.sample_point);
+	if (err == -EINVAL) {
+		LOG_ERR("Can't find timing for given param");
+		return -EIO;
 	}
-#ifdef CONFIG_CAN_FD_MODE
-	if (config->common.sample_point_data) {
-		err = can_calc_timing_data(dev, &timing_data, config->common.bus_speed_data,
-					   config->common.sample_point_data);
-		if (err == -EINVAL) {
-			LOG_ERR("Can't find timing for given dataphase param");
-			return -EIO;
-		}
 
-		LOG_DBG("Sample-point err data phase: %d", err);
-	} else if (config->prop_ts1_data) {
-		timing_data.sjw = config->sjw_data;
-		timing_data.prop_seg = 0U;
-		timing_data.phase_seg1 = config->prop_ts1_data;
-		timing_data.phase_seg2 = config->ts2_data;
-		err = can_calc_prescaler(dev, &timing_data, config->common.bus_speed_data);
-		if (err != 0) {
-			LOG_WRN("Dataphase bitrate error: %d", err);
-		}
+	LOG_DBG("Presc: %d, TS1: %d, TS2: %d", timing.prescaler, timing.phase_seg1,
+		timing.phase_seg2);
+	LOG_DBG("Sample-point err : %d", err);
+#ifdef CONFIG_CAN_FD_MODE
+	err = can_calc_timing_data(dev, &timing_data, config->common.bus_speed_data,
+				   config->common.sample_point_data);
+	if (err == -EINVAL) {
+		LOG_ERR("Can't find timing for given dataphase param");
+		return -EIO;
 	}
+
+	LOG_DBG("Sample-point err data phase: %d", err);
 #endif /* CONFIG_CAN_FD_MODE */
 
 	err = can_set_timing(dev, &timing);

--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -17,23 +17,6 @@ LOG_MODULE_REGISTER(can_mcp2515, CONFIG_CAN_LOG_LEVEL);
 
 #include "can_mcp2515.h"
 
-#define SP_IS_SET(inst) DT_INST_NODE_HAS_PROP(inst, sample_point) ||
-
-/* Macro to exclude the sample point algorithm from compilation if not used
- * Without the macro, the algorithm would always waste ROM
- */
-#define USE_SP_ALGO (DT_INST_FOREACH_STATUS_OKAY(SP_IS_SET) 0)
-
-#define SP_AND_TIMING_NOT_SET(inst) \
-	(!DT_INST_NODE_HAS_PROP(inst, sample_point) && \
-	!(DT_INST_NODE_HAS_PROP(inst, prop_seg) && \
-	DT_INST_NODE_HAS_PROP(inst, phase_seg1) && \
-	DT_INST_NODE_HAS_PROP(inst, phase_seg2))) ||
-
-#if DT_INST_FOREACH_STATUS_OKAY(SP_AND_TIMING_NOT_SET) 0
-#error You must either set a sampling-point or timings (phase-seg* and prop-seg)
-#endif
-
 /* Timeout for changing mode */
 #define MCP2515_MODE_CHANGE_TIMEOUT_USEC 1000
 #define MCP2515_MODE_CHANGE_RETRIES      100
@@ -1009,26 +992,16 @@ static int mcp2515_init(const struct device *dev)
 	(void)memset(dev_data->filter, 0, sizeof(dev_data->filter));
 	dev_data->old_state = CAN_STATE_ERROR_ACTIVE;
 
-	if (dev_cfg->common.sample_point && USE_SP_ALGO) {
-		ret = can_calc_timing(dev, &timing, dev_cfg->common.bus_speed,
-				      dev_cfg->common.sample_point);
-		if (ret == -EINVAL) {
-			LOG_ERR("Can't find timing for given param");
-			return -EIO;
-		}
-		LOG_DBG("Presc: %d, BS1: %d, BS2: %d",
-			timing.prescaler, timing.phase_seg1, timing.phase_seg2);
-		LOG_DBG("Sample-point err : %d", ret);
-	} else {
-		timing.sjw = dev_cfg->tq_sjw;
-		timing.prop_seg = dev_cfg->tq_prop;
-		timing.phase_seg1 = dev_cfg->tq_bs1;
-		timing.phase_seg2 = dev_cfg->tq_bs2;
-		ret = can_calc_prescaler(dev, &timing, dev_cfg->common.bus_speed);
-		if (ret) {
-			LOG_WRN("Bitrate error: %d", ret);
-		}
+	ret = can_calc_timing(dev, &timing, dev_cfg->common.bus_speed,
+			      dev_cfg->common.sample_point);
+	if (ret == -EINVAL) {
+		LOG_ERR("Can't find timing for given param");
+		return -EIO;
 	}
+
+	LOG_DBG("Presc: %d, BS1: %d, BS2: %d",
+		timing.prescaler, timing.phase_seg1, timing.phase_seg2);
+	LOG_DBG("Sample-point err : %d", ret);
 
 	k_usleep(MCP2515_OSC_STARTUP_US);
 
@@ -1058,14 +1031,10 @@ static int mcp2515_init(const struct device *dev)
 		.int_gpio = GPIO_DT_SPEC_INST_GET(inst, int_gpios),                                \
 		.int_thread_stack_size = CONFIG_CAN_MCP2515_INT_THREAD_STACK_SIZE,                 \
 		.int_thread_priority = CONFIG_CAN_MCP2515_INT_THREAD_PRIO,                         \
-		.tq_sjw = DT_INST_PROP(inst, sjw),                                                 \
-		.tq_prop = DT_INST_PROP_OR(inst, prop_seg, 0),                                     \
-		.tq_bs1 = DT_INST_PROP_OR(inst, phase_seg1, 0),                                    \
-		.tq_bs2 = DT_INST_PROP_OR(inst, phase_seg2, 0),                                    \
 		.osc_freq = DT_INST_PROP(inst, osc_freq),                                          \
 	};                                                                                         \
                                                                                                    \
-	CAN_DEVICE_DT_INST_DEFINE(inst, mcp2515_init, NULL, &mcp2515_data_##inst,                 \
+	CAN_DEVICE_DT_INST_DEFINE(inst, mcp2515_init, NULL, &mcp2515_data_##inst,                  \
 				  &mcp2515_config_##inst, POST_KERNEL, CONFIG_CAN_INIT_PRIORITY,   \
 				  &can_api_funcs);
 

--- a/drivers/can/can_mcp2515.h
+++ b/drivers/can/can_mcp2515.h
@@ -59,10 +59,6 @@ struct mcp2515_config {
 	int int_thread_priority;
 
 	/* CAN timing */
-	uint8_t tq_sjw;
-	uint8_t tq_prop;
-	uint8_t tq_bs1;
-	uint8_t tq_bs2;
 	uint32_t osc_freq;
 };
 

--- a/drivers/can/can_mcp251xfd.h
+++ b/drivers/can/can_mcp251xfd.h
@@ -511,13 +511,6 @@ struct mcp251xfd_data {
 
 };
 
-struct mcp251xfd_timing_params {
-	uint8_t sjw;
-	uint8_t prop_seg;
-	uint8_t phase_seg1;
-	uint8_t phase_seg2;
-};
-
 struct mcp251xfd_config {
 	const struct can_driver_config common;
 
@@ -533,12 +526,6 @@ struct mcp251xfd_config {
 	uint8_t clko_div;
 
 	uint16_t timestamp_prescaler;
-
-	/* CAN Timing */
-	struct mcp251xfd_timing_params timing_params;
-#if defined(CONFIG_CAN_FD_MODE)
-	struct mcp251xfd_timing_params timing_params_data;
-#endif
 
 	const struct device *clk_dev;
 	uint8_t clk_id;

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -24,23 +24,6 @@
 
 LOG_MODULE_REGISTER(can_mcux_flexcan, CONFIG_CAN_LOG_LEVEL);
 
-#define SP_IS_SET(inst) DT_INST_NODE_HAS_PROP(inst, sample_point) ||
-
-/* Macro to exclude the sample point algorithm from compilation if not used
- * Without the macro, the algorithm would always waste ROM
- */
-#define USE_SP_ALGO (DT_INST_FOREACH_STATUS_OKAY(SP_IS_SET) 0)
-
-#define SP_AND_TIMING_NOT_SET(inst) \
-	(!DT_INST_NODE_HAS_PROP(inst, sample_point) && \
-	!(DT_INST_NODE_HAS_PROP(inst, prop_seg) && \
-	DT_INST_NODE_HAS_PROP(inst, phase_seg1) && \
-	DT_INST_NODE_HAS_PROP(inst, phase_seg2))) ||
-
-#if DT_INST_FOREACH_STATUS_OKAY(SP_AND_TIMING_NOT_SET) 0
-#error You must either set a sampling-point or timings (phase-seg* and prop-seg)
-#endif
-
 #if ((defined(FSL_FEATURE_FLEXCAN_HAS_ERRATA_5641) && FSL_FEATURE_FLEXCAN_HAS_ERRATA_5641) || \
 	(defined(FSL_FEATURE_FLEXCAN_HAS_ERRATA_5829) && FSL_FEATURE_FLEXCAN_HAS_ERRATA_5829))
 /* the first valid MB should be occupied by ERRATA 5461 or 5829. */
@@ -90,16 +73,8 @@ struct mcux_flexcan_config {
 	const struct device *clock_dev;
 	clock_control_subsys_t clock_subsys;
 	int clk_source;
-	uint32_t sjw;
-	uint32_t prop_seg;
-	uint32_t phase_seg1;
-	uint32_t phase_seg2;
 #ifdef CONFIG_CAN_MCUX_FLEXCAN_FD
 	bool flexcan_fd;
-	uint32_t sjw_data;
-	uint32_t prop_seg_data;
-	uint32_t phase_seg1_data;
-	uint32_t phase_seg2_data;
 #endif /* CONFIG_CAN_MCUX_FLEXCAN_FD */
 	void (*irq_config_func)(const struct device *dev);
 	void (*irq_enable_func)(void);
@@ -1146,28 +1121,16 @@ static int mcux_flexcan_init(const struct device *dev)
 	k_sem_init(&data->tx_allocs_sem, MCUX_FLEXCAN_MAX_TX,
 		   MCUX_FLEXCAN_MAX_TX);
 
-	data->timing.sjw = config->sjw;
-	if (config->common.sample_point && USE_SP_ALGO) {
-		err = can_calc_timing(dev, &data->timing, config->common.bus_speed,
-				      config->common.sample_point);
-		if (err == -EINVAL) {
-			LOG_ERR("Can't find timing for given param");
-			return -EIO;
-		}
-		LOG_DBG("Presc: %d, Seg1S1: %d, Seg2: %d",
-			data->timing.prescaler, data->timing.phase_seg1,
-			data->timing.phase_seg2);
-		LOG_DBG("Sample-point err : %d", err);
-	} else {
-		data->timing.sjw = config->sjw;
-		data->timing.prop_seg = config->prop_seg;
-		data->timing.phase_seg1 = config->phase_seg1;
-		data->timing.phase_seg2 = config->phase_seg2;
-		err = can_calc_prescaler(dev, &data->timing, config->common.bus_speed);
-		if (err) {
-			LOG_WRN("Bitrate error: %d", err);
-		}
+	err = can_calc_timing(dev, &data->timing, config->common.bus_speed,
+			      config->common.sample_point);
+	if (err == -EINVAL) {
+		LOG_ERR("Can't find timing for given param");
+		return -EIO;
 	}
+	LOG_DBG("Presc: %d, Seg1S1: %d, Seg2: %d",
+		 data->timing.prescaler, data->timing.phase_seg1,
+		 data->timing.phase_seg2);
+	LOG_DBG("Sample-point err : %d", err);
 
 	/* Validate initial timing parameters */
 	err = can_set_timing(dev, &data->timing);
@@ -1178,39 +1141,25 @@ static int mcux_flexcan_init(const struct device *dev)
 
 #ifdef CONFIG_CAN_MCUX_FLEXCAN_FD
 	if (config->flexcan_fd) {
-		data->timing_data.sjw = config->sjw_data;
-		if (config->common.sample_point_data && USE_SP_ALGO) {
-			err = can_calc_timing_data(dev, &data->timing_data,
-						   config->common.bus_speed_data,
-						   config->common.sample_point_data);
-			if (err == -EINVAL) {
-				LOG_ERR("Can't find timing for given param");
-				return -EIO;
-			}
-			LOG_DBG("Presc: %d, Seg1S1: %d, Seg2: %d",
-				data->timing_data.prescaler, data->timing_data.phase_seg1,
-				data->timing_data.phase_seg2);
-			LOG_DBG("Sample-point err : %d", err);
-		} else {
-			data->timing_data.sjw = config->sjw_data;
-			data->timing_data.prop_seg = config->prop_seg_data;
-			data->timing_data.phase_seg1 = config->phase_seg1_data;
-			data->timing_data.phase_seg2 = config->phase_seg2_data;
-			err = can_calc_prescaler(dev, &data->timing_data,
-						 config->common.bus_speed_data);
-			if (err) {
-				LOG_WRN("Bitrate error: %d", err);
-			}
+		err = can_calc_timing_data(dev, &data->timing_data,
+					   config->common.bus_speed_data,
+					   config->common.sample_point_data);
+		if (err == -EINVAL) {
+			LOG_ERR("Can't find timing for given param");
+			return -EIO;
+		}
+		LOG_DBG("Presc: %d, Seg1S1: %d, Seg2: %d",
+			data->timing_data.prescaler, data->timing_data.phase_seg1,
+			data->timing_data.phase_seg2);
+		LOG_DBG("Sample-point err : %d", err);
+
+		/* Validate initial data phase timing parameters */
+		err = can_set_timing_data(dev, &data->timing_data);
+		if (err != 0) {
+			LOG_ERR("failed to set data phase timing (err %d)", err);
+			return -ENODEV;
 		}
 	}
-
-	/* Validate initial data phase timing parameters */
-	err = can_set_timing_data(dev, &data->timing_data);
-	if (err != 0) {
-		LOG_ERR("failed to set data phase timing (err %d)", err);
-		return -ENODEV;
-	}
-
 #endif /* CONFIG_CAN_MCUX_FLEXCAN_FD */
 
 	err = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
@@ -1436,16 +1385,8 @@ static const struct can_driver_api mcux_flexcan_fd_driver_api = {
 		.clock_subsys = (clock_control_subsys_t)		\
 			DT_INST_CLOCKS_CELL(id, name),			\
 		.clk_source = DT_INST_PROP(id, clk_source),		\
-		.sjw = DT_INST_PROP(id, sjw),				\
-		.prop_seg = DT_INST_PROP_OR(id, prop_seg, 0),		\
-		.phase_seg1 = DT_INST_PROP_OR(id, phase_seg1, 0),	\
-		.phase_seg2 = DT_INST_PROP_OR(id, phase_seg2, 0),	\
 		IF_ENABLED(CONFIG_CAN_MCUX_FLEXCAN_FD, (		\
 			.flexcan_fd = DT_NODE_HAS_COMPAT(DT_DRV_INST(id), FLEXCAN_FD_DRV_COMPAT), \
-			.sjw_data = DT_INST_PROP_OR(id, sjw_data, 0),			\
-			.prop_seg_data = DT_INST_PROP_OR(id, prop_seg_data, 0),		\
-			.phase_seg1_data = DT_INST_PROP_OR(id, phase_seg1_data, 0),	\
-			.phase_seg2_data = DT_INST_PROP_OR(id, phase_seg2_data, 0),	\
 		))							\
 		.irq_config_func = mcux_flexcan_irq_config_##id,	\
 		.irq_enable_func = mcux_flexcan_irq_enable_##id,	\

--- a/drivers/can/can_sja1000.c
+++ b/drivers/can/can_sja1000.c
@@ -770,26 +770,14 @@ int can_sja1000_init(const struct device *dev)
 	can_sja1000_write_reg(dev, CAN_SJA1000_AMR2, 0xFF);
 	can_sja1000_write_reg(dev, CAN_SJA1000_AMR3, 0xFF);
 
-	if (config->common.sample_point != 0) {
-		err = can_calc_timing(dev, &timing, config->common.bus_speed,
-				      config->common.sample_point);
-		if (err == -EINVAL) {
-			LOG_ERR("bitrate/sample point cannot be met (err %d)", err);
-			return err;
-		}
-
-		LOG_DBG("initial sample point error: %d", err);
-	} else {
-		timing.sjw = config->sjw;
-		timing.prop_seg = 0;
-		timing.phase_seg1 = config->phase_seg1;
-		timing.phase_seg2 = config->phase_seg2;
-
-		err = can_calc_prescaler(dev, &timing, config->common.bus_speed);
-		if (err != 0) {
-			LOG_WRN("initial bitrate error: %d", err);
-		}
+	err = can_calc_timing(dev, &timing, config->common.bus_speed,
+			      config->common.sample_point);
+	if (err == -EINVAL) {
+		LOG_ERR("bitrate/sample point cannot be met (err %d)", err);
+		return err;
 	}
+
+	LOG_DBG("initial sample point error: %d", err);
 
 	/* Configure timing */
 	err = can_set_timing(dev, &timing);

--- a/dts/bindings/can/can-controller.yaml
+++ b/dts/bindings/can/can-controller.yaml
@@ -10,43 +10,9 @@ properties:
       Initial bitrate in bit/s.
   sample-point:
     type: int
+    required: true
     description: |
       Initial sample point in per mille (e.g. 875 equals 87.5%).
-
-      This property is required unless the timing is specified using time quanta based properties
-      (`sjw`, `prop-seg`, `phase-seg1`, and `phase-seg2`).
-
-      If this property is present, the time quanta based timing properties are ignored.
-  sjw:
-    type: int
-    deprecated: true
-    default: 1
-    description: |
-      Initial time quanta of resynchronization jump width (ISO 11898-1).
-
-      Deprecated in favor of automatic calculation of a suitable default SJW based on existing
-      timing parameters. Default of 1 matches the default value previously used for all in-tree CAN
-      controller devicetree instances.
-
-      Applications can still manually set the SJW using the CAN timing APIs.
-  prop-seg:
-    type: int
-    deprecated: true
-    description: |
-      Initial time quanta of propagation segment (ISO 11898-1). Deprecated in favor of setting
-      advanced timing parameters from the application.
-  phase-seg1:
-    type: int
-    deprecated: true
-    description: |
-      Initial time quanta of phase buffer 1 segment (ISO 11898-1). Deprecated in favor of setting
-      advanced timing parameters from the application.
-  phase-seg2:
-    type: int
-    deprecated: true
-    description: |
-      Initial time quanta of phase buffer 2 segment (ISO 11898-1). Deprecated in favor of setting
-      advanced timing parameters from the application.
   phys:
     type: phandle
     description: |

--- a/dts/bindings/can/can-fd-controller.yaml
+++ b/dts/bindings/can/can-fd-controller.yaml
@@ -10,43 +10,9 @@ properties:
       Initial data phase bitrate in bit/s.
   sample-point-data:
     type: int
+    required: true
     description: |
       Initial data phase sample point in per mille (e.g. 875 equals 87.5%).
-
-      This property is required unless the timing is specified using time quanta based properties
-      (`sjw-data`, `prop-seg-data`, `phase-seg1-data`, and `phase-seg2-data`).
-
-      If this property is present, the time quanta based timing properties are ignored.
-  sjw-data:
-    type: int
-    deprecated: true
-    default: 1
-    description: |
-      Initial time quanta of resynchronization jump width for the data phase (ISO11898-1:2015).
-
-      Deprecated in favor of automatic calculation of a suitable default SJW based on existing
-      timing parameters. Default of 1 matches the default value previously used for all in-tree CAN
-      controller devicetree instances.
-
-      Applications can still manually set the SJW using the CAN timing APIs.
-  prop-seg-data:
-    type: int
-    deprecated: true
-    description: |
-      Initial time quanta of propagation segment for the data phase (ISO11898-1:2015). Deprecated in
-      favor of setting advanced timing parameters from the application.
-  phase-seg1-data:
-    type: int
-    deprecated: true
-    description: |
-      Initial time quanta of phase buffer 1 segment for the data phase (ISO11898-1:2015). Deprecated
-      in favor of setting advanced timing parameters from the application.
-  phase-seg2-data:
-    type: int
-    deprecated: true
-    description: |
-      Initial time quanta of phase buffer 2 segment for the data phase (ISO11898-1:2015). Deprecated
-      in favor of setting advanced timing parameters from the application.
   tx-delay-comp-offset:
     type: int
     default: 0

--- a/include/zephyr/drivers/can/can_mcan.h
+++ b/include/zephyr/drivers/can/can_mcan.h
@@ -1237,13 +1237,7 @@ struct can_mcan_config {
 	uint16_t mram_elements[CAN_MCAN_MRAM_CFG_NUM_CELLS];
 	uint16_t mram_offsets[CAN_MCAN_MRAM_CFG_NUM_CELLS];
 	size_t mram_size;
-	uint16_t sjw;
-	uint16_t prop_ts1;
-	uint16_t ts2;
 #ifdef CONFIG_CAN_FD_MODE
-	uint8_t sjw_data;
-	uint8_t prop_ts1_data;
-	uint8_t ts2_data;
 	uint8_t tx_delay_comp_offset;
 #endif
 	const void *custom;
@@ -1306,13 +1300,6 @@ struct can_mcan_config {
 		.mram_elements = CAN_MCAN_DT_MRAM_ELEMENTS_GET(node_id),                           \
 		.mram_offsets = CAN_MCAN_DT_MRAM_OFFSETS_GET(node_id),                             \
 		.mram_size = CAN_MCAN_DT_MRAM_ELEMENTS_SIZE(node_id),                              \
-		.sjw = DT_PROP(node_id, sjw),                                                      \
-		.prop_ts1 = DT_PROP_OR(node_id, prop_seg, 0) + DT_PROP_OR(node_id, phase_seg1, 0), \
-		.ts2 = DT_PROP_OR(node_id, phase_seg2, 0),                                         \
-		.sjw_data = DT_PROP(node_id, sjw_data),                                            \
-		.prop_ts1_data = DT_PROP_OR(node_id, prop_seg_data, 0) +                           \
-				 DT_PROP_OR(node_id, phase_seg1_data, 0),                          \
-		.ts2_data = DT_PROP_OR(node_id, phase_seg2_data, 0),                               \
 		.tx_delay_comp_offset = DT_PROP(node_id, tx_delay_comp_offset),                    \
 		.custom = _custom,                                                                 \
 	}
@@ -1325,9 +1312,6 @@ struct can_mcan_config {
 		.mram_elements = CAN_MCAN_DT_MRAM_ELEMENTS_GET(node_id),                           \
 		.mram_offsets = CAN_MCAN_DT_MRAM_OFFSETS_GET(node_id),                             \
 		.mram_size = CAN_MCAN_DT_MRAM_ELEMENTS_SIZE(node_id),                              \
-		.sjw = DT_PROP(node_id, sjw),                                                      \
-		.prop_ts1 = DT_PROP_OR(node_id, prop_seg, 0) + DT_PROP_OR(node_id, phase_seg1, 0), \
-		.ts2 = DT_PROP_OR(node_id, phase_seg2, 0),                                         \
 		.custom = _custom,                                                                 \
 	}
 #endif /* !CONFIG_CAN_FD_MODE */

--- a/include/zephyr/drivers/can/can_sja1000.h
+++ b/include/zephyr/drivers/can/can_sja1000.h
@@ -105,9 +105,6 @@ struct can_sja1000_config {
 	const struct can_driver_config common;
 	can_sja1000_read_reg_t read_reg;
 	can_sja1000_write_reg_t write_reg;
-	uint32_t sjw;
-	uint32_t phase_seg1;
-	uint32_t phase_seg2;
 	uint8_t ocr;
 	uint8_t cdr;
 	const void *custom;
@@ -128,9 +125,6 @@ struct can_sja1000_config {
 		.common = CAN_DT_DRIVER_CONFIG_GET(node_id, 1000000),                              \
 		.read_reg = _read_reg,                                                             \
 		.write_reg = _write_reg,                                                           \
-		.sjw = DT_PROP(node_id, sjw),                                                      \
-		.phase_seg1 = DT_PROP_OR(node_id, phase_seg1, 0),                                  \
-		.phase_seg2 = DT_PROP_OR(node_id, phase_seg2, 0),                                  \
 		.ocr = _ocr,                                                                       \
 		.cdr = _cdr,                                                                       \
 		.custom = _custom,                                                                 \


### PR DESCRIPTION
Remove the deprecated properties for setting the initial timing parameters of a CAN controller.