### PR TITLE
drivers: modem: ublox-sara-r4: freeaddrinfo mark unused param

### DIFF
--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -2035,7 +2035,7 @@ static int offload_getaddrinfo(const char *node, const char *service,
 static void offload_freeaddrinfo(struct zsock_addrinfo *res)
 {
 	/* using static result from offload_getaddrinfo() -- no need to free */
-	res = NULL;
+	ARG_UNUSED(res);
 }
 
 static const struct socket_dns_offload offload_dns_ops = {


### PR DESCRIPTION
The res param in offload_freeaddrinfo is not used. Mark it as unused, to avoid static analysis complaining about Parse warning (PW.PARAM_SET_BUT_NOT_USED)
Fixes CID 316235

Closes #58581