### PR TITLE
drivers: led: lp50xx: brightness: don't check uint8_t >= 0

### DIFF
--- a/drivers/led/lp50xx.c
+++ b/drivers/led/lp50xx.c
@@ -23,7 +23,6 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(lp50xx, CONFIG_LED_LOG_LEVEL);
 
-#define LP50XX_MIN_BRIGHTNESS		0U
 #define LP50XX_MAX_BRIGHTNESS		100U
 
 /*
@@ -127,13 +126,9 @@ static int lp50xx_set_brightness(const struct device *dev,
 		return -ENODEV;
 	}
 
-	if (!IN_RANGE(value, LP50XX_MIN_BRIGHTNESS, LP50XX_MAX_BRIGHTNESS)) {
-		LOG_ERR("%s: brightness value out of bounds: "
-			"val=%d, min=%d, max=%d",
-			dev->name,
-			value,
-			LP50XX_MIN_BRIGHTNESS,
-			LP50XX_MAX_BRIGHTNESS);
+	if (value > LP50XX_MAX_BRIGHTNESS) {
+		LOG_ERR("%s: brightness value out of bounds: val=%d, max=%d",
+			dev->name, value, LP50XX_MAX_BRIGHTNESS);
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
No need to check if an uint8_t is greater or equal 0 in lp50xx_set_brightness.
Fixes CID 322654

Closes #65381