### PR TITLE
stm32: flash: ospi: Fix for erase on devices larger than 16MB

### DIFF
--- a/drivers/flash/flash_stm32_ospi.c
+++ b/drivers/flash/flash_stm32_ospi.c
@@ -1052,7 +1052,7 @@ static int flash_stm32_ospi_erase(const struct device *dev, off_t addr,
 			}
 		} else {
 			/* Sector or Block erase depending on the size */
-			LOG_INF("Sector/Block Erase");
+			LOG_DBG("Sector/Block Erase");
 
 			cmd_erase.AddressMode =
 				(dev_cfg->data_mode == OSPI_OPI_MODE)
@@ -1098,7 +1098,7 @@ static int flash_stm32_ospi_erase(const struct device *dev, off_t addr,
 					bet = NULL;
 				}
 			}
-			LOG_INF("Sector/Block Erase addr 0x%x, asize 0x%x amode 0x%x  instr 0x%x",
+			LOG_DBG("Sector/Block Erase addr 0x%x, asize 0x%x amode 0x%x  instr 0x%x",
 				cmd_erase.Address, cmd_erase.AddressSize,
 				cmd_erase.AddressMode, cmd_erase.Instruction);
 


### PR DESCRIPTION
https://github.com/zephyrproject-rtos/zephyr/pull/66229 broke flash erase for flash sizes larger than 16 Mbytes

Issue is that now the correct entry from the erase_types is selected - but the opcodes in this table is wrong. The correct opcodes in 4 byte address mode shall be read by the JEDEC 4-byte Address Instruction Parameter table.

Issue can be reproduced by running a program  with file system placed above the 16 MByte boundary
