### PR TITLE
Kconfig LTO: Prevent with native simulator based targets

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -430,7 +430,7 @@ endchoice
 
 config LTO
 	bool "Link Time Optimization [EXPERIMENTAL]"
-	depends on !(GEN_ISR_TABLES || GEN_IRQ_VECTOR_TABLE) || ISR_TABLES_LOCAL_DECLARATION
+	depends on (!(GEN_ISR_TABLES || GEN_IRQ_VECTOR_TABLE) || ISR_TABLES_LOCAL_DECLARATION) && !NATIVE_LIBRARY
 	select EXPERIMENTAL
 	help
 	  This option enables Link Time Optimization.


### PR DESCRIPTION
LTO cannot be really used with the native simulator based targets today.

When doing a partial link as we do for these targets the linker will complain if we are mixing LTO and non LTO built code, and fall back to only produce non-LTO output.
(And the link warning will cause twister to fail if LTO is enabled in a sample/test)

Today not all inputs to this partial link are built with LTO enabled (offsets.c and the app library are not).

Even if they were, the native targets are mostly a test and debugging facility, so optimizations like these are not beneficial in general.

Let's just prevent selecting LTO for these targets.

Fixes #68737