### PR TITLE
[collab-hwm] ci: ignore maintainer file checks in collab-hwm branch

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -57,7 +57,8 @@ jobs:
         # debug
         ls -la
         git log  --pretty=oneline | head -n 10
-        ./scripts/ci/check_compliance.py --annotate -e KconfigBasic \
+        # ignore maintainer check for now, needs to be fixed before merge into main
+        ./scripts/ci/check_compliance.py --annotate -e KconfigBasic -e ModulesMaintainers -e MaintainersFormat \
         -c origin/${BASE_REF}..
 
     - name: upload-results


### PR DESCRIPTION
Maintainer file checks to be ignored until we have the final structure.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
