### PR TITLE
ipc: rpmsg: Add support for IPM drivers without data transfer

### DIFF
--- a/drivers/ipm/ipm_esp32.c
+++ b/drivers/ipm/ipm_esp32.c
@@ -95,7 +95,7 @@ static int esp32_ipm_send(const struct device *dev, int wait, uint32_t id,
 {
 	struct esp32_ipm_data *dev_data = (struct esp32_ipm_data *)dev->data;
 
-	if (data == NULL) {
+	if (size > 0 && data == NULL) {
 		LOG_ERR("Invalid data source");
 		return -EINVAL;
 	}


### PR DESCRIPTION
The RPMsg service backend relies on an IPM driver to notify the other CPU of new messages; However, it currently requires the IPM to support data transfer, since it sends over four dummy bytes. However, some IPM drivers, like the STM32 HSEM IPM driver, do not support any data transfer at all. Most IPM drivers do support sending empty messages, resulting in a "doorbell" interrupt on the other side. To increase compatibility, send only an empty message without any dummy bytes.

One current IPM implementation that does not support empty transfers is the ESP32 IPM driver; However, this is an arbitrary limitation, since it causes an interrupt at the other processor to signal the data. To get rid of this limitation, the guard clause is appended to only catch if the size of the data transfer is given to be greater than zero.

This pull request allows for support of the RPMsg service on the STM32H747i_DISCO board that I am working on; I have tested the RPMsg sample with success.

This change should preserve compatibility with the ESP32S3 DEVKIT M board. However, I am unable to test this on actual hardware.