### PR TITLE
Bluetooth: TMAP: Move role definitions from shell/tmap.c to tmap.h

### DIFF
--- a/include/zephyr/bluetooth/audio/tmap.h
+++ b/include/zephyr/bluetooth/audio/tmap.h
@@ -12,6 +12,37 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/sys/util.h>
 
+/** Call Gateway (CG) supported */
+#define BT_TMAP_CG_SUPPORTED                                                                       \
+	(IS_ENABLED(CONFIG_BT_CAP_INITIATOR) && IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) &&        \
+	 IS_ENABLED(CONFIG_BT_TBS) && IS_ENABLED(CONFIG_BT_VCP_VOL_CTLR))
+
+/** Call Terminal (CT) supported */
+#define BT_TMAP_CT_SUPPORTED                                                                       \
+	(IS_ENABLED(CONFIG_BT_CAP_ACCEPTOR) && IS_ENABLED(CONFIG_BT_BAP_UNICAST_SERVER) &&         \
+	 IS_ENABLED(CONFIG_BT_TBS_CLIENT) &&                                                       \
+	 (IS_ENABLED(CONFIG_BT_ASCS_ASE_SNK) &&                                                    \
+	  IS_ENABLED(CONFIG_BT_VCP_VOL_REND) == IS_ENABLED(CONFIG_BT_ASCS_ASE_SNK)))
+
+/** Unicast Media Sender (UMS) supported */
+#define BT_TMAP_UMS_SUPPORTED                                                                      \
+	(IS_ENABLED(CONFIG_BT_CAP_INITIATOR) &&                                                    \
+	 IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK) && IS_ENABLED(CONFIG_BT_VCP_VOL_CTLR) && \
+	 IS_ENABLED(CONFIG_BT_MCS))
+
+/** Unicast Media Receiver (UMR) supported */
+#define BT_TMAP_UMR_SUPPORTED                                                                      \
+	(IS_ENABLED(CONFIG_BT_CAP_ACCEPTOR) && IS_ENABLED(CONFIG_BT_ASCS_ASE_SNK) &&               \
+	 IS_ENABLED(CONFIG_BT_VCP_VOL_REND))
+
+/** Broadcast Media Sender (BMS) supported */
+#define BT_TMAP_BMS_SUPPORTED                                                                      \
+	(IS_ENABLED(CONFIG_BT_CAP_INITIATOR) && IS_ENABLED(CONFIG_BT_BAP_BROADCAST_SOURCE))
+
+/** Broadcast Media Receiver (BMR) supported */
+#define BT_TMAP_BMR_SUPPORTED                                                                      \
+	(IS_ENABLED(CONFIG_BT_CAP_ACCEPTOR) && IS_ENABLED(CONFIG_BT_BAP_BROADCAST_SINK))
+
 /** @brief TMAP Role characteristic */
 enum bt_tmap_role {
 	BT_TMAP_ROLE_CG = BIT(0),

--- a/subsys/bluetooth/audio/shell/tmap.c
+++ b/subsys/bluetooth/audio/shell/tmap.c
@@ -16,39 +16,14 @@
 
 #include "shell/bt.h"
 
-#define TMAP_CG_SUPPORTED                                                                          \
-	(IS_ENABLED(CONFIG_BT_CAP_INITIATOR) && IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) &&        \
-	 IS_ENABLED(CONFIG_BT_TBS) && IS_ENABLED(CONFIG_BT_VCP_VOL_CTLR))
-
-#define TMAP_CT_SUPPORTED                                                                          \
-	(IS_ENABLED(CONFIG_BT_CAP_ACCEPTOR) && IS_ENABLED(CONFIG_BT_BAP_UNICAST_SERVER) &&         \
-	 IS_ENABLED(CONFIG_BT_TBS_CLIENT) &&                                                       \
-	 (IS_ENABLED(CONFIG_BT_ASCS_ASE_SNK) &&                                                    \
-	  IS_ENABLED(CONFIG_BT_VCP_VOL_REND) == IS_ENABLED(CONFIG_BT_ASCS_ASE_SNK)))
-
-#define TMAP_UMS_SUPPORTED                                                                         \
-	(IS_ENABLED(CONFIG_BT_CAP_INITIATOR) &&                                                    \
-	 IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK) && IS_ENABLED(CONFIG_BT_VCP_VOL_CTLR) && \
-	 IS_ENABLED(CONFIG_BT_MCS))
-
-#define TMAP_UMR_SUPPORTED                                                                         \
-	(IS_ENABLED(CONFIG_BT_CAP_ACCEPTOR) && IS_ENABLED(CONFIG_BT_ASCS_ASE_SNK) &&               \
-	 IS_ENABLED(CONFIG_BT_VCP_VOL_REND))
-
-#define TMAP_BMS_SUPPORTED                                                                         \
-	(IS_ENABLED(CONFIG_BT_CAP_INITIATOR) && IS_ENABLED(CONFIG_BT_BAP_BROADCAST_SOURCE))
-
-#define TMAP_BMR_SUPPORTED                                                                         \
-	(IS_ENABLED(CONFIG_BT_CAP_ACCEPTOR) && IS_ENABLED(CONFIG_BT_BAP_BROADCAST_SINK))
-
 static int cmd_tmap_init(const struct shell *sh, size_t argc, char **argv)
 {
-	const enum bt_tmap_role role = (TMAP_CG_SUPPORTED ? BT_TMAP_ROLE_CG : 0U) |
-				       (TMAP_CT_SUPPORTED ? BT_TMAP_ROLE_CT : 0U) |
-				       (TMAP_UMS_SUPPORTED ? BT_TMAP_ROLE_UMS : 0U) |
-				       (TMAP_UMR_SUPPORTED ? BT_TMAP_ROLE_UMR : 0U) |
-				       (TMAP_BMS_SUPPORTED ? BT_TMAP_ROLE_BMS : 0U) |
-				       (TMAP_BMR_SUPPORTED ? BT_TMAP_ROLE_BMR : 0U);
+	const enum bt_tmap_role role = (BT_TMAP_CG_SUPPORTED ? BT_TMAP_ROLE_CG : 0U) |
+				       (BT_TMAP_CT_SUPPORTED ? BT_TMAP_ROLE_CT : 0U) |
+				       (BT_TMAP_UMS_SUPPORTED ? BT_TMAP_ROLE_UMS : 0U) |
+				       (BT_TMAP_UMR_SUPPORTED ? BT_TMAP_ROLE_UMR : 0U) |
+				       (BT_TMAP_BMS_SUPPORTED ? BT_TMAP_ROLE_BMS : 0U) |
+				       (BT_TMAP_BMR_SUPPORTED ? BT_TMAP_ROLE_BMR : 0U);
 	int err;
 
 	shell_info(sh, "Registering TMAS with role: %u", role);


### PR DESCRIPTION
These role definition are also used in bttester, so it could be globally available.