### PR TITLE
Bluetooth: BAP: Reset _prev_seq_num on ISO connection

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -968,6 +968,11 @@ static void ascs_ep_iso_connected(struct bt_bap_ep *ep)
 
 	LOG_DBG("stream %p ep %p dir %s", stream, ep, bt_audio_dir_str(ep->dir));
 
+#if defined(CONFIG_BT_BAP_DEBUG_STREAM_SEQ_NUM)
+	/* reset sequence number */
+	stream->_prev_seq_num = 0U;
+#endif /* CONFIG_BT_BAP_DEBUG_STREAM_SEQ_NUM */
+
 	stream_ops = stream->ops;
 	if (stream_ops != NULL && stream_ops->connected != NULL) {
 		stream_ops->connected(stream);

--- a/subsys/bluetooth/audio/bap_broadcast_source.c
+++ b/subsys/bluetooth/audio/bap_broadcast_source.c
@@ -168,6 +168,11 @@ static void broadcast_source_iso_connected(struct bt_iso_chan *chan)
 
 	LOG_DBG("stream %p ep %p", stream, ep);
 
+#if defined(CONFIG_BT_BAP_DEBUG_STREAM_SEQ_NUM)
+	/* reset sequence number */
+	stream->_prev_seq_num = 0U;
+#endif /* CONFIG_BT_BAP_DEBUG_STREAM_SEQ_NUM */
+
 	ops = stream->ops;
 	if (ops != NULL && ops->connected != NULL) {
 		ops->connected(stream);

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -315,6 +315,11 @@ static void unicast_client_ep_iso_connected(struct bt_bap_ep *ep)
 	LOG_DBG("stream %p ep %p dir %s receiver_ready %u",
 		stream, ep, bt_audio_dir_str(ep->dir), ep->receiver_ready);
 
+#if defined(CONFIG_BT_BAP_DEBUG_STREAM_SEQ_NUM)
+	/* reset sequence number */
+	stream->_prev_seq_num = 0U;
+#endif /* CONFIG_BT_BAP_DEBUG_STREAM_SEQ_NUM */
+
 	stream_ops = stream->ops;
 	if (stream_ops != NULL && stream_ops->connected != NULL) {
 		stream_ops->connected(stream);


### PR DESCRIPTION
Once an ISO channel has connected, the sequence number always starts at 0. This reset was missing in the implementation, and the _prev_seq_num from a previous connection may have been kept.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/68744