### PR TITLE
Bluetooth: Mesh: Fix messages reordering in DFD and RPR servers

### DIFF
--- a/doc/connectivity/bluetooth/api/mesh/access.rst
+++ b/doc/connectivity/bluetooth/api/mesh/access.rst
@@ -246,6 +246,14 @@ message, it will send messages with delay close to expiration to free memory.
 When the mesh stack is suspended or reset, messages not yet sent are removed and
 the :c:member:`bt_mesh_send_cb.start` callback is raised with an error code.
 
+.. note::
+   When a model sends several messages in a row, it may happen that the messages are not sent in
+   the order they were passed to the access layer. This is because some messages can be delayed
+   for a longer time than the others.
+
+   Disable the randomization by setting the :c:member:`bt_mesh_msg_ctx.rnd_delay` to ``false``,
+   when a set of messages originated by the same model needs to be sent in a certain order.
+
 Delayable publications
 ======================
 

--- a/subsys/bluetooth/mesh/dfd_srv.c
+++ b/subsys/bluetooth/mesh/dfd_srv.c
@@ -1148,6 +1148,14 @@ enum bt_mesh_dfd_status bt_mesh_dfd_srv_cancel(struct bt_mesh_dfd_srv *srv,
 		return BT_MESH_DFD_ERR_INTERNAL;
 	}
 
+	if (prev_phase == BT_MESH_DFD_PHASE_APPLYING_UPDATE && ctx) {
+		/* Disable randomization for the Firmware Distribution State message to avoid
+		 * reordering when Firmware Distribution Server sends 2 messages in a row when
+		 * cancelling the update (see section 6.2.3.10 of MshDFUv1.0).
+		 */
+		ctx->rnd_delay = false;
+	}
+
 	if (ctx != NULL) {
 		status_rsp(srv, ctx, BT_MESH_DFD_SUCCESS);
 	}

--- a/subsys/bluetooth/mesh/rpr_srv.c
+++ b/subsys/bluetooth/mesh/rpr_srv.c
@@ -968,6 +968,12 @@ static int handle_link_close(const struct bt_mesh_model *mod, struct bt_mesh_msg
 	 * which will be used in the link report when the link is fully closed.
 	 */
 
+	/* Disable randomization for the Remote Provisioning Link Status message to avoid reordering
+	 * of it with the Remote Provisioning Link Report message that shall be sent in a sequence
+	 * when closing an active link (see section 4.4.5.5.3.3 of MshPRTv1.1).
+	 */
+	ctx->rnd_delay = false;
+
 	link_status_send(ctx, BT_MESH_RPR_SUCCESS);
 	link_close(BT_MESH_RPR_ERR_LINK_CLOSED_BY_CLIENT, reason);
 


### PR DESCRIPTION
When a model sends several messages in a row and the randomization feature is enabled, it may happen that the messages are sent not in the order they were passed to the access layer. This is because some messages can be delayed for a longer time than the others. This causes 2 PTS tests to fail: DFU/SR/FD/BV-43-C and MESH/SR/RPR/PDU/BV-03-C.

DFU test fails because the server sequentially sends 2 Firmware Distribution Status messages as a response on Firmware Distribution Cancel message as required by the specification. Because of the randomization both messages gets reordered, PTS receives the second message first and fails because the phase doesn't match its expectation.

RPR test fails because the server sequentially sends 2 messages when closes an active link: Link Status and Link Report messages. Because Link Report message is not a response message, it is always sent first while the status message is delayed by the randomization feature.

This PR fixes DFU/SR/FD/BV-43-C and MESH/SR/RPR/PDU/BV-03-C tests.

Fixes #68750
Fixes #68751