### PR TITLE
drivers: ethernet: w5500: Add link status detection

### DIFF
--- a/drivers/ethernet/eth_w5500.c
+++ b/drivers/ethernet/eth_w5500.c
@@ -164,12 +164,12 @@ static int w5500_command(const struct device *dev, uint8_t cmd)
 		w5500_spi_read(dev, W5500_S0_CR, &reg, 1);
 		if (!reg) {
 			break;
-			}
+		}
 		if (sys_timepoint_expired(end)) {
 			return -EIO;
-			}
-		k_busy_wait(W5500_PHY_ACCESS_DELAY);
 		}
+		k_busy_wait(W5500_PHY_ACCESS_DELAY);
+	}
 	return 0;
 }
 
@@ -275,6 +275,30 @@ static void w5500_rx(const struct device *dev)
 	w5500_command(dev, S0_CR_RECV);
 }
 
+static void w5500_update_link_status(const struct device *dev)
+{
+	uint8_t phycfgr;
+	struct w5500_runtime *ctx = dev->data;
+
+	if (w5500_spi_read(dev, W5500_PHYCFGR, &phycfgr, 1) < 0) {
+		return;
+	}
+
+	if (phycfgr & 0x01) {
+		if (ctx->link_up != true) {
+			LOG_INF("%s: Link up", dev->name);
+			ctx->link_up = true;
+			net_eth_carrier_on(ctx->iface);
+		}
+	} else {
+		if (ctx->link_up != false) {
+			LOG_INF("%s: Link down", dev->name);
+			ctx->link_up = false;
+			net_eth_carrier_off(ctx->iface);
+		}
+	}
+}
+
 static void w5500_thread(void *p1, void *p2, void *p3)
 {
 	ARG_UNUSED(p2);
@@ -282,32 +306,43 @@ static void w5500_thread(void *p1, void *p2, void *p3)
 
 	const struct device *dev = p1;
 	uint8_t ir;
+	int res;
 	struct w5500_runtime *ctx = dev->data;
 	const struct w5500_config *config = dev->config;
 
 	while (true) {
-		k_sem_take(&ctx->int_sem, K_FOREVER);
+		res = k_sem_take(&ctx->int_sem, K_MSEC(CONFIG_PHY_MONITOR_PERIOD));
 
-		while (gpio_pin_get_dt(&(config->interrupt))) {
-			/* Read interrupt */
-			w5500_spi_read(dev, W5500_S0_IR, &ir, 1);
+		if (res == 0) {
+			/* semaphore taken, update link status and receive packets */
+			if (ctx->link_up != true) {
+				w5500_update_link_status(dev);
+			}
 
-			if (ir) {
-				/* Clear interrupt */
-				w5500_spi_write(dev, W5500_S0_IR, &ir, 1);
+			while (gpio_pin_get_dt(&(config->interrupt))) {
+				/* Read interrupt */
+				w5500_spi_read(dev, W5500_S0_IR, &ir, 1);
 
-				LOG_DBG("IR received");
+				if (ir) {
+					/* Clear interrupt */
+					w5500_spi_write(dev, W5500_S0_IR, &ir, 1);
 
-				if (ir & S0_IR_SENDOK) {
-					k_sem_give(&ctx->tx_sem);
-					LOG_DBG("TX Done");
-				}
+					LOG_DBG("IR received");
 
-				if (ir & S0_IR_RECV) {
-					w5500_rx(dev);
-					LOG_DBG("RX Done");
+					if (ir & S0_IR_SENDOK) {
+						k_sem_give(&ctx->tx_sem);
+						LOG_DBG("TX Done");
+					}
+
+					if (ir & S0_IR_RECV) {
+						w5500_rx(dev);
+						LOG_DBG("RX Done");
+					}
 				}
 			}
+		} else if (res == -EAGAIN) {
+			/* semaphore timeout period expired, check link status */
+			w5500_update_link_status(dev);
 		}
 	}
 }
@@ -326,6 +361,9 @@ static void w5500_iface_init(struct net_if *iface)
 	}
 
 	ethernet_init(iface);
+
+	/* Do not start the interface until PHY link is up */
+	net_if_carrier_off(iface);
 }
 
 static enum ethernet_hw_caps w5500_get_capabilities(const struct device *dev)
@@ -504,6 +542,8 @@ static int w5500_init(const struct device *dev)
 	uint8_t rtr[2];
 	const struct w5500_config *config = dev->config;
 	struct w5500_runtime *ctx = dev->data;
+
+	ctx->link_up = false;
 
 	if (!spi_is_ready_dt(&config->spi)) {
 		LOG_ERR("SPI master port %s not ready", config->spi.bus->name);

--- a/drivers/ethernet/eth_w5500_priv.h
+++ b/drivers/ethernet/eth_w5500_priv.h
@@ -25,6 +25,7 @@
 #define W5500_SHAR		0x0009 /* Source MAC address */
 #define W5500_IR		0x0015 /* Interrupt Register */
 #define W5500_COMMON_REGS_LEN	0x0040
+#define W5500_PHYCFGR		0x002E /* PHY Configuration register */
 
 #define W5500_Sn_MR		0x0000 /* Sn Mode Register */
 #define W5500_Sn_CR		0x0001 /* Sn Command Register */
@@ -97,6 +98,7 @@ struct w5500_runtime {
 	struct gpio_callback gpio_cb;
 	struct k_sem tx_sem;
 	struct k_sem int_sem;
+	bool link_up;
 	void (*generate_mac)(uint8_t *mac);
 	uint8_t buf[NET_ETH_MAX_FRAME_SIZE];
 };


### PR DESCRIPTION
This PR introduces link status detection functionality to the W5500 Ethernet driver within the Zephyr OS. This feature enhances the driver's capability to monitor and respond to changes in Ethernet link status (cable insertion/removal), providing a more robust and reliable network connection for devices utilizing the W5500 chip.

- Implemented link status detection using the W5500's built-in register functions.
- Added periodic link status polling to the Ethernet driver, configurable via Kconfig.
- Speeds up DHCPv4 configuration (from 9 seconds at best, to ~2 seconds after power-up).
- Should be completely backward compatible.

## Test

The test was performed on WeAct BlackPill STM32F411CE + WIZnet W5500

```log
*** Booting Zephyr OS build v3.6.0-rc1-8-gf6ecad20a1e7 ***
[00:00:00.006,000] <inf> eth_w5500: W5500 Initialized
[00:00:00.007,000] <inf> sample: Started
[00:00:00.030,000] <inf> eth_w5500: w5500@0 MAC set to 01:02:03:04:05:06
[00:00:00.030,000] <inf> sample: DHCPv4 start on w5500@0
[00:00:02.007,000] <inf> eth_w5500: w5500@0: Link up
[00:00:02.018,000] <inf> net_dhcpv4: Received: 10.42.0.211
<unplug cable>
[00:00:12.552,000] <inf> eth_w5500: w5500@0: Link down
<plug in cable>
[00:00:17.053,000] <inf> eth_w5500: w5500@0: Link up
```