### PR TITLE
Bluetooth: HCI: Add full opcode to hci_types.h

### DIFF
--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -344,16 +344,16 @@ struct bt_hci_cmd_hdr {
 /* Obtain OCF from OpCode */
 #define BT_OCF(opcode)                          ((opcode) & BIT_MASK(10))
 
-#define BT_HCI_OP_INQUIRY                       BT_OP(BT_OGF_LINK_CTRL, 0x0001)
+#define BT_HCI_OP_INQUIRY                       BT_OP(BT_OGF_LINK_CTRL, 0x0001) /* 0x0401 */
 struct bt_hci_op_inquiry {
 	uint8_t lap[3];
 	uint8_t length;
 	uint8_t num_rsp;
 } __packed;
 
-#define BT_HCI_OP_INQUIRY_CANCEL                BT_OP(BT_OGF_LINK_CTRL, 0x0002)
+#define BT_HCI_OP_INQUIRY_CANCEL                BT_OP(BT_OGF_LINK_CTRL, 0x0002) /* 0x0402 */
 
-#define BT_HCI_OP_CONNECT                       BT_OP(BT_OGF_LINK_CTRL, 0x0005)
+#define BT_HCI_OP_CONNECT                       BT_OP(BT_OGF_LINK_CTRL, 0x0005) /* 0x0405 */
 struct bt_hci_cp_connect {
 	bt_addr_t bdaddr;
 	uint16_t  packet_type;
@@ -363,13 +363,13 @@ struct bt_hci_cp_connect {
 	uint8_t   allow_role_switch;
 } __packed;
 
-#define BT_HCI_OP_DISCONNECT                    BT_OP(BT_OGF_LINK_CTRL, 0x0006)
+#define BT_HCI_OP_DISCONNECT                    BT_OP(BT_OGF_LINK_CTRL, 0x0006) /* 0x0406 */
 struct bt_hci_cp_disconnect {
 	uint16_t handle;
 	uint8_t  reason;
 } __packed;
 
-#define BT_HCI_OP_CONNECT_CANCEL                BT_OP(BT_OGF_LINK_CTRL, 0x0008)
+#define BT_HCI_OP_CONNECT_CANCEL                BT_OP(BT_OGF_LINK_CTRL, 0x0008) /* 0x0408 */
 struct bt_hci_cp_connect_cancel {
 	bt_addr_t bdaddr;
 } __packed;
@@ -378,13 +378,13 @@ struct bt_hci_rp_connect_cancel {
 	bt_addr_t bdaddr;
 } __packed;
 
-#define BT_HCI_OP_ACCEPT_CONN_REQ               BT_OP(BT_OGF_LINK_CTRL, 0x0009)
+#define BT_HCI_OP_ACCEPT_CONN_REQ               BT_OP(BT_OGF_LINK_CTRL, 0x0009) /* 0x0409 */
 struct bt_hci_cp_accept_conn_req {
 	bt_addr_t bdaddr;
 	uint8_t   role;
 } __packed;
 
-#define BT_HCI_OP_SETUP_SYNC_CONN               BT_OP(BT_OGF_LINK_CTRL, 0x0028)
+#define BT_HCI_OP_SETUP_SYNC_CONN               BT_OP(BT_OGF_LINK_CTRL, 0x0028) /* 0x0428 */
 struct bt_hci_cp_setup_sync_conn {
 	uint16_t  handle;
 	uint32_t  tx_bandwidth;
@@ -395,7 +395,7 @@ struct bt_hci_cp_setup_sync_conn {
 	uint16_t  pkt_type;
 } __packed;
 
-#define BT_HCI_OP_ACCEPT_SYNC_CONN_REQ          BT_OP(BT_OGF_LINK_CTRL, 0x0029)
+#define BT_HCI_OP_ACCEPT_SYNC_CONN_REQ          BT_OP(BT_OGF_LINK_CTRL, 0x0029) /* 0x0429 */
 struct bt_hci_cp_accept_sync_conn_req {
 	bt_addr_t bdaddr;
 	uint32_t  tx_bandwidth;
@@ -406,24 +406,24 @@ struct bt_hci_cp_accept_sync_conn_req {
 	uint16_t  pkt_type;
 } __packed;
 
-#define BT_HCI_OP_REJECT_CONN_REQ               BT_OP(BT_OGF_LINK_CTRL, 0x000a)
+#define BT_HCI_OP_REJECT_CONN_REQ               BT_OP(BT_OGF_LINK_CTRL, 0x000a) /* 0x040a */
 struct bt_hci_cp_reject_conn_req {
 	bt_addr_t bdaddr;
 	uint8_t   reason;
 } __packed;
 
-#define BT_HCI_OP_LINK_KEY_REPLY                BT_OP(BT_OGF_LINK_CTRL, 0x000b)
+#define BT_HCI_OP_LINK_KEY_REPLY                BT_OP(BT_OGF_LINK_CTRL, 0x000b) /* 0x040b */
 struct bt_hci_cp_link_key_reply {
 	bt_addr_t bdaddr;
 	uint8_t   link_key[16];
 } __packed;
 
-#define BT_HCI_OP_LINK_KEY_NEG_REPLY            BT_OP(BT_OGF_LINK_CTRL, 0x000c)
+#define BT_HCI_OP_LINK_KEY_NEG_REPLY            BT_OP(BT_OGF_LINK_CTRL, 0x000c) /* 0x040c */
 struct bt_hci_cp_link_key_neg_reply {
 	bt_addr_t bdaddr;
 } __packed;
 
-#define BT_HCI_OP_PIN_CODE_REPLY                BT_OP(BT_OGF_LINK_CTRL, 0x000d)
+#define BT_HCI_OP_PIN_CODE_REPLY                BT_OP(BT_OGF_LINK_CTRL, 0x000d) /* 0x040d */
 struct bt_hci_cp_pin_code_reply {
 	bt_addr_t bdaddr;
 	uint8_t   pin_len;
@@ -434,7 +434,7 @@ struct bt_hci_rp_pin_code_reply {
 	bt_addr_t bdaddr;
 } __packed;
 
-#define BT_HCI_OP_PIN_CODE_NEG_REPLY            BT_OP(BT_OGF_LINK_CTRL, 0x000e)
+#define BT_HCI_OP_PIN_CODE_NEG_REPLY            BT_OP(BT_OGF_LINK_CTRL, 0x000e) /* 0x040e */
 struct bt_hci_cp_pin_code_neg_reply {
 	bt_addr_t bdaddr;
 } __packed;
@@ -443,18 +443,18 @@ struct bt_hci_rp_pin_code_neg_reply {
 	bt_addr_t bdaddr;
 } __packed;
 
-#define BT_HCI_OP_AUTH_REQUESTED                BT_OP(BT_OGF_LINK_CTRL, 0x0011)
+#define BT_HCI_OP_AUTH_REQUESTED                BT_OP(BT_OGF_LINK_CTRL, 0x0011) /* 0x0411 */
 struct bt_hci_cp_auth_requested {
 	uint16_t handle;
 } __packed;
 
-#define BT_HCI_OP_SET_CONN_ENCRYPT              BT_OP(BT_OGF_LINK_CTRL, 0x0013)
+#define BT_HCI_OP_SET_CONN_ENCRYPT              BT_OP(BT_OGF_LINK_CTRL, 0x0013) /* 0x0413 */
 struct bt_hci_cp_set_conn_encrypt {
 	uint16_t handle;
 	uint8_t  encrypt;
 } __packed;
 
-#define BT_HCI_OP_REMOTE_NAME_REQUEST           BT_OP(BT_OGF_LINK_CTRL, 0x0019)
+#define BT_HCI_OP_REMOTE_NAME_REQUEST           BT_OP(BT_OGF_LINK_CTRL, 0x0019) /* 0x0419 */
 struct bt_hci_cp_remote_name_request {
 	bt_addr_t bdaddr;
 	uint8_t   pscan_rep_mode;
@@ -462,7 +462,7 @@ struct bt_hci_cp_remote_name_request {
 	uint16_t  clock_offset;
 } __packed;
 
-#define BT_HCI_OP_REMOTE_NAME_CANCEL            BT_OP(BT_OGF_LINK_CTRL, 0x001a)
+#define BT_HCI_OP_REMOTE_NAME_CANCEL            BT_OP(BT_OGF_LINK_CTRL, 0x001a) /* 0x041a */
 struct bt_hci_cp_remote_name_cancel {
 	bt_addr_t bdaddr;
 } __packed;
@@ -471,23 +471,23 @@ struct bt_hci_rp_remote_name_cancel {
 	bt_addr_t bdaddr;
 } __packed;
 
-#define BT_HCI_OP_READ_REMOTE_FEATURES          BT_OP(BT_OGF_LINK_CTRL, 0x001b)
+#define BT_HCI_OP_READ_REMOTE_FEATURES          BT_OP(BT_OGF_LINK_CTRL, 0x001b) /* 0x041b */
 struct bt_hci_cp_read_remote_features {
 	uint16_t handle;
 } __packed;
 
-#define BT_HCI_OP_READ_REMOTE_EXT_FEATURES      BT_OP(BT_OGF_LINK_CTRL, 0x001c)
+#define BT_HCI_OP_READ_REMOTE_EXT_FEATURES      BT_OP(BT_OGF_LINK_CTRL, 0x001c) /* 0x041c */
 struct bt_hci_cp_read_remote_ext_features {
 	uint16_t handle;
 	uint8_t  page;
 } __packed;
 
-#define BT_HCI_OP_READ_REMOTE_VERSION_INFO      BT_OP(BT_OGF_LINK_CTRL, 0x001d)
+#define BT_HCI_OP_READ_REMOTE_VERSION_INFO      BT_OP(BT_OGF_LINK_CTRL, 0x001d) /* 0x041d */
 struct bt_hci_cp_read_remote_version_info {
 	uint16_t handle;
 } __packed;
 
-#define BT_HCI_OP_IO_CAPABILITY_REPLY           BT_OP(BT_OGF_LINK_CTRL, 0x002b)
+#define BT_HCI_OP_IO_CAPABILITY_REPLY           BT_OP(BT_OGF_LINK_CTRL, 0x002b) /* 0x042b */
 struct bt_hci_cp_io_capability_reply {
 	bt_addr_t bdaddr;
 	uint8_t   capability;
@@ -495,8 +495,8 @@ struct bt_hci_cp_io_capability_reply {
 	uint8_t   authentication;
 } __packed;
 
-#define BT_HCI_OP_USER_CONFIRM_REPLY            BT_OP(BT_OGF_LINK_CTRL, 0x002c)
-#define BT_HCI_OP_USER_CONFIRM_NEG_REPLY        BT_OP(BT_OGF_LINK_CTRL, 0x002d)
+#define BT_HCI_OP_USER_CONFIRM_REPLY            BT_OP(BT_OGF_LINK_CTRL, 0x002c) /* 0x042c */
+#define BT_HCI_OP_USER_CONFIRM_NEG_REPLY        BT_OP(BT_OGF_LINK_CTRL, 0x002d) /* 0x042d */
 struct bt_hci_cp_user_confirm_reply {
 	bt_addr_t bdaddr;
 } __packed;
@@ -505,42 +505,42 @@ struct bt_hci_rp_user_confirm_reply {
 	bt_addr_t bdaddr;
 } __packed;
 
-#define BT_HCI_OP_USER_PASSKEY_REPLY            BT_OP(BT_OGF_LINK_CTRL, 0x002e)
+#define BT_HCI_OP_USER_PASSKEY_REPLY            BT_OP(BT_OGF_LINK_CTRL, 0x002e) /* 0x042e */
 struct bt_hci_cp_user_passkey_reply {
 	bt_addr_t bdaddr;
 	uint32_t  passkey;
 } __packed;
 
-#define BT_HCI_OP_USER_PASSKEY_NEG_REPLY        BT_OP(BT_OGF_LINK_CTRL, 0x002f)
+#define BT_HCI_OP_USER_PASSKEY_NEG_REPLY        BT_OP(BT_OGF_LINK_CTRL, 0x002f) /* 0x042f */
 struct bt_hci_cp_user_passkey_neg_reply {
 	bt_addr_t bdaddr;
 } __packed;
 
-#define BT_HCI_OP_IO_CAPABILITY_NEG_REPLY       BT_OP(BT_OGF_LINK_CTRL, 0x0034)
+#define BT_HCI_OP_IO_CAPABILITY_NEG_REPLY       BT_OP(BT_OGF_LINK_CTRL, 0x0034) /* 0x0434 */
 struct bt_hci_cp_io_capability_neg_reply {
 	bt_addr_t bdaddr;
 	uint8_t   reason;
 } __packed;
 
-#define BT_HCI_OP_SET_EVENT_MASK                BT_OP(BT_OGF_BASEBAND, 0x0001)
+#define BT_HCI_OP_SET_EVENT_MASK                BT_OP(BT_OGF_BASEBAND, 0x0001) /* 0x0c01 */
 struct bt_hci_cp_set_event_mask {
 	uint8_t  events[8];
 } __packed;
 
-#define BT_HCI_OP_RESET                         BT_OP(BT_OGF_BASEBAND, 0x0003)
+#define BT_HCI_OP_RESET                         BT_OP(BT_OGF_BASEBAND, 0x0003) /* 0x0c03 */
 
-#define BT_HCI_OP_WRITE_LOCAL_NAME              BT_OP(BT_OGF_BASEBAND, 0x0013)
+#define BT_HCI_OP_WRITE_LOCAL_NAME              BT_OP(BT_OGF_BASEBAND, 0x0013) /* 0x0c13 */
 struct bt_hci_write_local_name {
 	uint8_t local_name[248];
 } __packed;
 
-#define BT_HCI_OP_READ_CONN_ACCEPT_TIMEOUT      BT_OP(BT_OGF_BASEBAND, 0x0015)
+#define BT_HCI_OP_READ_CONN_ACCEPT_TIMEOUT      BT_OP(BT_OGF_BASEBAND, 0x0015) /* 0x0c15 */
 struct bt_hci_rp_read_conn_accept_timeout {
 	uint8_t  status;
 	uint16_t conn_accept_timeout;
 } __packed;
 
-#define BT_HCI_OP_WRITE_CONN_ACCEPT_TIMEOUT     BT_OP(BT_OGF_BASEBAND, 0x0016)
+#define BT_HCI_OP_WRITE_CONN_ACCEPT_TIMEOUT     BT_OP(BT_OGF_BASEBAND, 0x0016) /* 0x0c16 */
 struct bt_hci_cp_write_conn_accept_timeout {
 	uint16_t conn_accept_timeout;
 } __packed;
@@ -549,21 +549,21 @@ struct bt_hci_rp_write_conn_accept_timeout {
 	uint8_t  status;
 } __packed;
 
-#define BT_HCI_OP_WRITE_PAGE_TIMEOUT            BT_OP(BT_OGF_BASEBAND, 0x0018)
+#define BT_HCI_OP_WRITE_PAGE_TIMEOUT            BT_OP(BT_OGF_BASEBAND, 0x0018) /* 0x0c18 */
 
-#define BT_HCI_OP_WRITE_SCAN_ENABLE             BT_OP(BT_OGF_BASEBAND, 0x001a)
+#define BT_HCI_OP_WRITE_SCAN_ENABLE             BT_OP(BT_OGF_BASEBAND, 0x001a) /* 0x0c1a */
 #define BT_BREDR_SCAN_DISABLED                  0x00
 #define BT_BREDR_SCAN_INQUIRY                   0x01
 #define BT_BREDR_SCAN_PAGE                      0x02
 
-#define BT_HCI_OP_WRITE_CLASS_OF_DEVICE         BT_OP(BT_OGF_BASEBAND, 0x0024)
+#define BT_HCI_OP_WRITE_CLASS_OF_DEVICE         BT_OP(BT_OGF_BASEBAND, 0x0024) /* 0x0c24 */
 struct bt_hci_cp_write_class_of_device {
 	uint8_t  class_of_device[3];
 } __packed;
 
 #define BT_TX_POWER_LEVEL_CURRENT               0x00
 #define BT_TX_POWER_LEVEL_MAX                   0x01
-#define BT_HCI_OP_READ_TX_POWER_LEVEL           BT_OP(BT_OGF_BASEBAND, 0x002d)
+#define BT_HCI_OP_READ_TX_POWER_LEVEL           BT_OP(BT_OGF_BASEBAND, 0x002d) /* 0x0c2d */
 struct bt_hci_cp_read_tx_power_level {
 	uint16_t handle;
 	uint8_t  type;
@@ -579,7 +579,7 @@ struct bt_hci_rp_read_tx_power_level {
 #define BT_HCI_LE_TX_POWER_PHY_2M               0x02
 #define BT_HCI_LE_TX_POWER_PHY_CODED_S8         0x03
 #define BT_HCI_LE_TX_POWER_PHY_CODED_S2         0x04
-#define BT_HCI_OP_LE_ENH_READ_TX_POWER_LEVEL    BT_OP(BT_OGF_LE, 0x0076)
+#define BT_HCI_OP_LE_ENH_READ_TX_POWER_LEVEL    BT_OP(BT_OGF_LE, 0x0076) /* 0x2076 */
 struct bt_hci_cp_le_read_tx_power_level {
 	uint16_t handle;
 	uint8_t  phy;
@@ -593,11 +593,11 @@ struct bt_hci_rp_le_read_tx_power_level {
 	int8_t   max_tx_power_level;
 } __packed;
 
-#define BT_HCI_OP_LE_READ_REMOTE_TX_POWER_LEVEL	BT_OP(BT_OGF_LE, 0x0077)
+#define BT_HCI_OP_LE_READ_REMOTE_TX_POWER_LEVEL	BT_OP(BT_OGF_LE, 0x0077) /* 0x2077 */
 
 #define BT_HCI_LE_TX_POWER_REPORT_DISABLE       0x00
 #define BT_HCI_LE_TX_POWER_REPORT_ENABLE        0x01
-#define BT_HCI_OP_LE_SET_TX_POWER_REPORT_ENABLE BT_OP(BT_OGF_LE, 0x007A)
+#define BT_HCI_OP_LE_SET_TX_POWER_REPORT_ENABLE BT_OP(BT_OGF_LE, 0x007A) /* 0x207A */
 struct bt_hci_cp_le_set_tx_power_report_enable {
 	uint16_t handle;
 	uint8_t  local_enable;
@@ -606,12 +606,12 @@ struct bt_hci_cp_le_set_tx_power_report_enable {
 
 #define BT_HCI_CTL_TO_HOST_FLOW_DISABLE         0x00
 #define BT_HCI_CTL_TO_HOST_FLOW_ENABLE          0x01
-#define BT_HCI_OP_SET_CTL_TO_HOST_FLOW          BT_OP(BT_OGF_BASEBAND, 0x0031)
+#define BT_HCI_OP_SET_CTL_TO_HOST_FLOW          BT_OP(BT_OGF_BASEBAND, 0x0031) /* 0x0c31 */
 struct bt_hci_cp_set_ctl_to_host_flow {
 	uint8_t  flow_enable;
 } __packed;
 
-#define BT_HCI_OP_HOST_BUFFER_SIZE              BT_OP(BT_OGF_BASEBAND, 0x0033)
+#define BT_HCI_OP_HOST_BUFFER_SIZE              BT_OP(BT_OGF_BASEBAND, 0x0033) /* 0x0c33 */
 struct bt_hci_cp_host_buffer_size {
 	uint16_t acl_mtu;
 	uint8_t  sco_mtu;
@@ -624,39 +624,39 @@ struct bt_hci_handle_count {
 	uint16_t count;
 } __packed;
 
-#define BT_HCI_OP_HOST_NUM_COMPLETED_PACKETS    BT_OP(BT_OGF_BASEBAND, 0x0035)
+#define BT_HCI_OP_HOST_NUM_COMPLETED_PACKETS    BT_OP(BT_OGF_BASEBAND, 0x0035) /* 0x0c35 */
 struct bt_hci_cp_host_num_completed_packets {
 	uint8_t  num_handles;
 	struct bt_hci_handle_count h[0];
 } __packed;
 
-#define BT_HCI_OP_WRITE_INQUIRY_MODE            BT_OP(BT_OGF_BASEBAND, 0x0045)
+#define BT_HCI_OP_WRITE_INQUIRY_MODE            BT_OP(BT_OGF_BASEBAND, 0x0045) /* 0x0c45 */
 struct bt_hci_cp_write_inquiry_mode {
 	uint8_t  mode;
 } __packed;
 
-#define BT_HCI_OP_WRITE_SSP_MODE                BT_OP(BT_OGF_BASEBAND, 0x0056)
+#define BT_HCI_OP_WRITE_SSP_MODE                BT_OP(BT_OGF_BASEBAND, 0x0056) /* 0x0c56 */
 struct bt_hci_cp_write_ssp_mode {
 	uint8_t mode;
 } __packed;
 
-#define BT_HCI_OP_SET_EVENT_MASK_PAGE_2         BT_OP(BT_OGF_BASEBAND, 0x0063)
+#define BT_HCI_OP_SET_EVENT_MASK_PAGE_2         BT_OP(BT_OGF_BASEBAND, 0x0063) /* 0x0c63 */
 struct bt_hci_cp_set_event_mask_page_2 {
 	uint8_t  events_page_2[8];
 } __packed;
 
-#define BT_HCI_OP_LE_WRITE_LE_HOST_SUPP         BT_OP(BT_OGF_BASEBAND, 0x006d)
+#define BT_HCI_OP_LE_WRITE_LE_HOST_SUPP         BT_OP(BT_OGF_BASEBAND, 0x006d) /* 0x0c6d */
 struct bt_hci_cp_write_le_host_supp {
 	uint8_t  le;
 	uint8_t  simul;
 } __packed;
 
-#define BT_HCI_OP_WRITE_SC_HOST_SUPP            BT_OP(BT_OGF_BASEBAND, 0x007a)
+#define BT_HCI_OP_WRITE_SC_HOST_SUPP            BT_OP(BT_OGF_BASEBAND, 0x007a) /* 0x0c7a */
 struct bt_hci_cp_write_sc_host_supp {
 	uint8_t  sc_support;
 } __packed;
 
-#define BT_HCI_OP_READ_AUTH_PAYLOAD_TIMEOUT     BT_OP(BT_OGF_BASEBAND, 0x007b)
+#define BT_HCI_OP_READ_AUTH_PAYLOAD_TIMEOUT     BT_OP(BT_OGF_BASEBAND, 0x007b) /* 0x0c7b */
 struct bt_hci_cp_read_auth_payload_timeout {
 	uint16_t handle;
 } __packed;
@@ -667,7 +667,7 @@ struct bt_hci_rp_read_auth_payload_timeout {
 	uint16_t auth_payload_timeout;
 } __packed;
 
-#define BT_HCI_OP_WRITE_AUTH_PAYLOAD_TIMEOUT    BT_OP(BT_OGF_BASEBAND, 0x007c)
+#define BT_HCI_OP_WRITE_AUTH_PAYLOAD_TIMEOUT    BT_OP(BT_OGF_BASEBAND, 0x007c) /* 0x0c7c */
 struct bt_hci_cp_write_auth_payload_timeout {
 	uint16_t handle;
 	uint16_t auth_payload_timeout;
@@ -678,7 +678,7 @@ struct bt_hci_rp_write_auth_payload_timeout {
 	uint16_t handle;
 } __packed;
 
-#define BT_HCI_OP_CONFIGURE_DATA_PATH           BT_OP(BT_OGF_BASEBAND, 0x0083)
+#define BT_HCI_OP_CONFIGURE_DATA_PATH           BT_OP(BT_OGF_BASEBAND, 0x0083) /* 0x0c83 */
 struct bt_hci_cp_configure_data_path {
 	uint8_t  data_path_dir;
 	uint8_t  data_path_id;
@@ -706,7 +706,7 @@ struct bt_hci_rp_configure_data_path {
 #define BT_HCI_VERSION_5_3                      12
 #define BT_HCI_VERSION_5_4                      13
 
-#define BT_HCI_OP_READ_LOCAL_VERSION_INFO       BT_OP(BT_OGF_INFO, 0x0001)
+#define BT_HCI_OP_READ_LOCAL_VERSION_INFO       BT_OP(BT_OGF_INFO, 0x0001) /* 0x1001 */
 struct bt_hci_rp_read_local_version_info {
 	uint8_t  status;
 	uint8_t  hci_version;
@@ -716,13 +716,13 @@ struct bt_hci_rp_read_local_version_info {
 	uint16_t lmp_subversion;
 } __packed;
 
-#define BT_HCI_OP_READ_SUPPORTED_COMMANDS       BT_OP(BT_OGF_INFO, 0x0002)
+#define BT_HCI_OP_READ_SUPPORTED_COMMANDS       BT_OP(BT_OGF_INFO, 0x0002) /* 0x1002 */
 struct bt_hci_rp_read_supported_commands {
 	uint8_t  status;
 	uint8_t  commands[64];
 } __packed;
 
-#define BT_HCI_OP_READ_LOCAL_EXT_FEATURES       BT_OP(BT_OGF_INFO, 0x0004)
+#define BT_HCI_OP_READ_LOCAL_EXT_FEATURES       BT_OP(BT_OGF_INFO, 0x0004) /* 0x1004 */
 struct bt_hci_cp_read_local_ext_features {
 	uint8_t page;
 };
@@ -733,13 +733,13 @@ struct bt_hci_rp_read_local_ext_features {
 	uint8_t  ext_features[8];
 } __packed;
 
-#define BT_HCI_OP_READ_LOCAL_FEATURES           BT_OP(BT_OGF_INFO, 0x0003)
+#define BT_HCI_OP_READ_LOCAL_FEATURES           BT_OP(BT_OGF_INFO, 0x0003) /* 0x1003 */
 struct bt_hci_rp_read_local_features {
 	uint8_t  status;
 	uint8_t  features[8];
 } __packed;
 
-#define BT_HCI_OP_READ_BUFFER_SIZE              BT_OP(BT_OGF_INFO, 0x0005)
+#define BT_HCI_OP_READ_BUFFER_SIZE              BT_OP(BT_OGF_INFO, 0x0005) /* 0x1005 */
 struct bt_hci_rp_read_buffer_size {
 	uint8_t  status;
 	uint16_t acl_max_len;
@@ -748,7 +748,7 @@ struct bt_hci_rp_read_buffer_size {
 	uint16_t sco_max_num;
 } __packed;
 
-#define BT_HCI_OP_READ_BD_ADDR                  BT_OP(BT_OGF_INFO, 0x0009)
+#define BT_HCI_OP_READ_BD_ADDR                  BT_OP(BT_OGF_INFO, 0x0009) /* 0x1009 */
 struct bt_hci_rp_read_bd_addr {
 	uint8_t   status;
 	bt_addr_t bdaddr;
@@ -787,7 +787,7 @@ struct bt_hci_rp_read_bd_addr {
 #define BT_HCI_CODING_FORMAT_VS          0xFF
 
 
-#define BT_HCI_OP_READ_CODECS                   BT_OP(BT_OGF_INFO, 0x000b)
+#define BT_HCI_OP_READ_CODECS                   BT_OP(BT_OGF_INFO, 0x000b) /* 0x100b */
 struct bt_hci_std_codec_info {
 	uint8_t codec_id;
 } __packed;
@@ -809,7 +809,7 @@ struct bt_hci_rp_read_codecs {
 	uint8_t codecs[0];
 } __packed;
 
-#define BT_HCI_OP_READ_CODECS_V2                BT_OP(BT_OGF_INFO, 0x000d)
+#define BT_HCI_OP_READ_CODECS_V2                BT_OP(BT_OGF_INFO, 0x000d) /* 0x100d */
 struct bt_hci_std_codec_info_v2 {
 	uint8_t codec_id;
 	uint8_t transports; /* bitmap */
@@ -839,7 +839,7 @@ struct bt_hci_cp_codec_id {
 	uint16_t vs_codec_id;
 } __packed;
 
-#define BT_HCI_OP_READ_CODEC_CAPABILITIES       BT_OP(BT_OGF_INFO, 0x000e)
+#define BT_HCI_OP_READ_CODEC_CAPABILITIES       BT_OP(BT_OGF_INFO, 0x000e) /* 0x100e */
 struct bt_hci_cp_read_codec_capabilities {
 	struct bt_hci_cp_codec_id codec_id;
 	uint8_t transport;
@@ -856,7 +856,7 @@ struct bt_hci_rp_read_codec_capabilities {
 	uint8_t capabilities[0];
 } __packed;
 
-#define BT_HCI_OP_READ_CTLR_DELAY               BT_OP(BT_OGF_INFO, 0x000f)
+#define BT_HCI_OP_READ_CTLR_DELAY               BT_OP(BT_OGF_INFO, 0x000f) /* 0x100f */
 struct bt_hci_cp_read_ctlr_delay {
 	struct bt_hci_cp_codec_id codec_id;
 	uint8_t transport;
@@ -870,7 +870,7 @@ struct bt_hci_rp_read_ctlr_delay {
 	uint8_t max_ctlr_delay[3];
 } __packed;
 
-#define BT_HCI_OP_READ_RSSI                     BT_OP(BT_OGF_STATUS, 0x0005)
+#define BT_HCI_OP_READ_RSSI                     BT_OP(BT_OGF_STATUS, 0x0005) /* 0x1405 */
 struct bt_hci_cp_read_rssi {
 	uint16_t handle;
 } __packed;
@@ -883,7 +883,7 @@ struct bt_hci_rp_read_rssi {
 #define BT_HCI_ENCRYPTION_KEY_SIZE_MIN          7
 #define BT_HCI_ENCRYPTION_KEY_SIZE_MAX          16
 
-#define BT_HCI_OP_READ_ENCRYPTION_KEY_SIZE      BT_OP(BT_OGF_STATUS, 0x0008)
+#define BT_HCI_OP_READ_ENCRYPTION_KEY_SIZE      BT_OP(BT_OGF_STATUS, 0x0008) /* 0x1408 */
 struct bt_hci_cp_read_encryption_key_size {
 	uint16_t handle;
 } __packed;
@@ -895,25 +895,25 @@ struct bt_hci_rp_read_encryption_key_size {
 
 /* BLE */
 
-#define BT_HCI_OP_LE_SET_EVENT_MASK             BT_OP(BT_OGF_LE, 0x0001)
+#define BT_HCI_OP_LE_SET_EVENT_MASK             BT_OP(BT_OGF_LE, 0x0001) /* 0x2001 */
 struct bt_hci_cp_le_set_event_mask {
 	uint8_t events[8];
 } __packed;
 
-#define BT_HCI_OP_LE_READ_BUFFER_SIZE           BT_OP(BT_OGF_LE, 0x0002)
+#define BT_HCI_OP_LE_READ_BUFFER_SIZE           BT_OP(BT_OGF_LE, 0x0002) /* 0x2002 */
 struct bt_hci_rp_le_read_buffer_size {
 	uint8_t  status;
 	uint16_t le_max_len;
 	uint8_t  le_max_num;
 } __packed;
 
-#define BT_HCI_OP_LE_READ_LOCAL_FEATURES        BT_OP(BT_OGF_LE, 0x0003)
+#define BT_HCI_OP_LE_READ_LOCAL_FEATURES        BT_OP(BT_OGF_LE, 0x0003) /* 0x2003 */
 struct bt_hci_rp_le_read_local_features {
 	uint8_t  status;
 	uint8_t  features[8];
 } __packed;
 
-#define BT_HCI_OP_LE_SET_RANDOM_ADDRESS         BT_OP(BT_OGF_LE, 0x0005)
+#define BT_HCI_OP_LE_SET_RANDOM_ADDRESS         BT_OP(BT_OGF_LE, 0x0005) /* 0x2005 */
 struct bt_hci_cp_le_set_random_address {
 	bt_addr_t bdaddr;
 } __packed;
@@ -939,7 +939,7 @@ struct bt_hci_cp_le_set_random_address {
 #define BT_LE_ADV_FP_FILTER_CONN_IND            0x02
 #define BT_LE_ADV_FP_FILTER_BOTH                0x03
 
-#define BT_HCI_OP_LE_SET_ADV_PARAM              BT_OP(BT_OGF_LE, 0x0006)
+#define BT_HCI_OP_LE_SET_ADV_PARAM              BT_OP(BT_OGF_LE, 0x0006) /* 0x2006 */
 struct bt_hci_cp_le_set_adv_param {
 	uint16_t     min_interval;
 	uint16_t     max_interval;
@@ -950,19 +950,19 @@ struct bt_hci_cp_le_set_adv_param {
 	uint8_t      filter_policy;
 } __packed;
 
-#define BT_HCI_OP_LE_READ_ADV_CHAN_TX_POWER     BT_OP(BT_OGF_LE, 0x0007)
+#define BT_HCI_OP_LE_READ_ADV_CHAN_TX_POWER     BT_OP(BT_OGF_LE, 0x0007) /* 0x2007 */
 struct bt_hci_rp_le_read_chan_tx_power {
 	uint8_t status;
 	int8_t  tx_power_level;
 } __packed;
 
-#define BT_HCI_OP_LE_SET_ADV_DATA               BT_OP(BT_OGF_LE, 0x0008)
+#define BT_HCI_OP_LE_SET_ADV_DATA               BT_OP(BT_OGF_LE, 0x0008) /* 0x2008 */
 struct bt_hci_cp_le_set_adv_data {
 	uint8_t  len;
 	uint8_t  data[31];
 } __packed;
 
-#define BT_HCI_OP_LE_SET_SCAN_RSP_DATA          BT_OP(BT_OGF_LE, 0x0009)
+#define BT_HCI_OP_LE_SET_SCAN_RSP_DATA          BT_OP(BT_OGF_LE, 0x0009) /* 0x2009 */
 struct bt_hci_cp_le_set_scan_rsp_data {
 	uint8_t  len;
 	uint8_t  data[31];
@@ -971,13 +971,13 @@ struct bt_hci_cp_le_set_scan_rsp_data {
 #define BT_HCI_LE_ADV_DISABLE                   0x00
 #define BT_HCI_LE_ADV_ENABLE                    0x01
 
-#define BT_HCI_OP_LE_SET_ADV_ENABLE             BT_OP(BT_OGF_LE, 0x000a)
+#define BT_HCI_OP_LE_SET_ADV_ENABLE             BT_OP(BT_OGF_LE, 0x000a) /* 0x200a */
 struct bt_hci_cp_le_set_adv_enable {
 	uint8_t  enable;
 } __packed;
 
 /* Scan types */
-#define BT_HCI_OP_LE_SET_SCAN_PARAM             BT_OP(BT_OGF_LE, 0x000b)
+#define BT_HCI_OP_LE_SET_SCAN_PARAM             BT_OP(BT_OGF_LE, 0x000b) /* 0x200b */
 #define BT_HCI_LE_SCAN_PASSIVE                  0x00
 #define BT_HCI_LE_SCAN_ACTIVE                   0x01
 
@@ -994,7 +994,7 @@ struct bt_hci_cp_le_set_scan_param {
 	uint8_t  filter_policy;
 } __packed;
 
-#define BT_HCI_OP_LE_SET_SCAN_ENABLE            BT_OP(BT_OGF_LE, 0x000c)
+#define BT_HCI_OP_LE_SET_SCAN_ENABLE            BT_OP(BT_OGF_LE, 0x000c) /* 0x200c */
 
 #define BT_HCI_LE_SCAN_DISABLE                  0x00
 #define BT_HCI_LE_SCAN_ENABLE                   0x01
@@ -1007,7 +1007,7 @@ struct bt_hci_cp_le_set_scan_enable {
 	uint8_t  filter_dup;
 } __packed;
 
-#define BT_HCI_OP_LE_CREATE_CONN                BT_OP(BT_OGF_LE, 0x000d)
+#define BT_HCI_OP_LE_CREATE_CONN                BT_OP(BT_OGF_LE, 0x000d) /* 0x200d */
 
 #define BT_HCI_LE_CREATE_CONN_FP_NO_FILTER      0x00
 #define BT_HCI_LE_CREATE_CONN_FP_FILTER         0x01
@@ -1026,27 +1026,27 @@ struct bt_hci_cp_le_create_conn {
 	uint16_t     max_ce_len;
 } __packed;
 
-#define BT_HCI_OP_LE_CREATE_CONN_CANCEL         BT_OP(BT_OGF_LE, 0x000e)
+#define BT_HCI_OP_LE_CREATE_CONN_CANCEL         BT_OP(BT_OGF_LE, 0x000e) /* 0x200e */
 
-#define BT_HCI_OP_LE_READ_FAL_SIZE               BT_OP(BT_OGF_LE, 0x000f)
+#define BT_HCI_OP_LE_READ_FAL_SIZE               BT_OP(BT_OGF_LE, 0x000f) /* 0x200f */
 struct bt_hci_rp_le_read_fal_size {
 	uint8_t  status;
 	uint8_t  fal_size;
 } __packed;
 
-#define BT_HCI_OP_LE_CLEAR_FAL                   BT_OP(BT_OGF_LE, 0x0010)
+#define BT_HCI_OP_LE_CLEAR_FAL                   BT_OP(BT_OGF_LE, 0x0010) /* 0x2010 */
 
-#define BT_HCI_OP_LE_ADD_DEV_TO_FAL              BT_OP(BT_OGF_LE, 0x0011)
+#define BT_HCI_OP_LE_ADD_DEV_TO_FAL              BT_OP(BT_OGF_LE, 0x0011) /* 0x2011 */
 struct bt_hci_cp_le_add_dev_to_fal {
 	bt_addr_le_t  addr;
 } __packed;
 
-#define BT_HCI_OP_LE_REM_DEV_FROM_FAL            BT_OP(BT_OGF_LE, 0x0012)
+#define BT_HCI_OP_LE_REM_DEV_FROM_FAL            BT_OP(BT_OGF_LE, 0x0012) /* 0x2012 */
 struct bt_hci_cp_le_rem_dev_from_fal {
 	bt_addr_le_t  addr;
 } __packed;
 
-#define BT_HCI_OP_LE_CONN_UPDATE                BT_OP(BT_OGF_LE, 0x0013)
+#define BT_HCI_OP_LE_CONN_UPDATE                BT_OP(BT_OGF_LE, 0x0013) /* 0x2013 */
 struct hci_cp_le_conn_update {
 	uint16_t handle;
 	uint16_t conn_interval_min;
@@ -1057,12 +1057,12 @@ struct hci_cp_le_conn_update {
 	uint16_t max_ce_len;
 } __packed;
 
-#define BT_HCI_OP_LE_SET_HOST_CHAN_CLASSIF      BT_OP(BT_OGF_LE, 0x0014)
+#define BT_HCI_OP_LE_SET_HOST_CHAN_CLASSIF      BT_OP(BT_OGF_LE, 0x0014) /* 0x2014 */
 struct bt_hci_cp_le_set_host_chan_classif {
 	uint8_t  ch_map[5];
 } __packed;
 
-#define BT_HCI_OP_LE_READ_CHAN_MAP              BT_OP(BT_OGF_LE, 0x0015)
+#define BT_HCI_OP_LE_READ_CHAN_MAP              BT_OP(BT_OGF_LE, 0x0015) /* 0x2015 */
 struct bt_hci_cp_le_read_chan_map {
 	uint16_t handle;
 } __packed;
@@ -1072,12 +1072,12 @@ struct bt_hci_rp_le_read_chan_map {
 	uint8_t  ch_map[5];
 } __packed;
 
-#define BT_HCI_OP_LE_READ_REMOTE_FEATURES       BT_OP(BT_OGF_LE, 0x0016)
+#define BT_HCI_OP_LE_READ_REMOTE_FEATURES       BT_OP(BT_OGF_LE, 0x0016) /* 0x2016 */
 struct bt_hci_cp_le_read_remote_features {
 	uint16_t  handle;
 } __packed;
 
-#define BT_HCI_OP_LE_ENCRYPT                    BT_OP(BT_OGF_LE, 0x0017)
+#define BT_HCI_OP_LE_ENCRYPT                    BT_OP(BT_OGF_LE, 0x0017) /* 0x2017 */
 struct bt_hci_cp_le_encrypt {
 	uint8_t  key[16];
 	uint8_t  plaintext[16];
@@ -1087,13 +1087,13 @@ struct bt_hci_rp_le_encrypt {
 	uint8_t  enc_data[16];
 } __packed;
 
-#define BT_HCI_OP_LE_RAND                       BT_OP(BT_OGF_LE, 0x0018)
+#define BT_HCI_OP_LE_RAND                       BT_OP(BT_OGF_LE, 0x0018) /* 0x2018 */
 struct bt_hci_rp_le_rand {
 	uint8_t  status;
 	uint8_t  rand[8];
 } __packed;
 
-#define BT_HCI_OP_LE_START_ENCRYPTION           BT_OP(BT_OGF_LE, 0x0019)
+#define BT_HCI_OP_LE_START_ENCRYPTION           BT_OP(BT_OGF_LE, 0x0019) /* 0x2019 */
 struct bt_hci_cp_le_start_encryption {
 	uint16_t handle;
 	uint64_t rand;
@@ -1101,7 +1101,7 @@ struct bt_hci_cp_le_start_encryption {
 	uint8_t  ltk[16];
 } __packed;
 
-#define BT_HCI_OP_LE_LTK_REQ_REPLY              BT_OP(BT_OGF_LE, 0x001a)
+#define BT_HCI_OP_LE_LTK_REQ_REPLY              BT_OP(BT_OGF_LE, 0x001a) /* 0x201a */
 struct bt_hci_cp_le_ltk_req_reply {
 	uint16_t handle;
 	uint8_t  ltk[16];
@@ -1111,7 +1111,7 @@ struct bt_hci_rp_le_ltk_req_reply {
 	uint16_t handle;
 } __packed;
 
-#define BT_HCI_OP_LE_LTK_REQ_NEG_REPLY          BT_OP(BT_OGF_LE, 0x001b)
+#define BT_HCI_OP_LE_LTK_REQ_NEG_REPLY          BT_OP(BT_OGF_LE, 0x001b) /* 0x201b */
 struct bt_hci_cp_le_ltk_req_neg_reply {
 	uint16_t handle;
 } __packed;
@@ -1120,13 +1120,13 @@ struct bt_hci_rp_le_ltk_req_neg_reply {
 	uint16_t handle;
 } __packed;
 
-#define BT_HCI_OP_LE_READ_SUPP_STATES           BT_OP(BT_OGF_LE, 0x001c)
+#define BT_HCI_OP_LE_READ_SUPP_STATES           BT_OP(BT_OGF_LE, 0x001c) /* 0x201c */
 struct bt_hci_rp_le_read_supp_states {
 	uint8_t  status;
 	uint8_t  le_states[8];
 } __packed;
 
-#define BT_HCI_OP_LE_RX_TEST                    BT_OP(BT_OGF_LE, 0x001d)
+#define BT_HCI_OP_LE_RX_TEST                    BT_OP(BT_OGF_LE, 0x001d) /* 0x201d */
 struct bt_hci_cp_le_rx_test {
 	uint8_t  rx_ch;
 } __packed;
@@ -1140,20 +1140,20 @@ struct bt_hci_cp_le_rx_test {
 #define BT_HCI_TEST_PKT_PAYLOAD_00001111        0x06
 #define BT_HCI_TEST_PKT_PAYLOAD_01010101        0x07
 
-#define BT_HCI_OP_LE_TX_TEST                    BT_OP(BT_OGF_LE, 0x001e)
+#define BT_HCI_OP_LE_TX_TEST                    BT_OP(BT_OGF_LE, 0x001e) /* 0x201e */
 struct bt_hci_cp_le_tx_test {
 	uint8_t  tx_ch;
 	uint8_t  test_data_len;
 	uint8_t  pkt_payload;
 } __packed;
 
-#define BT_HCI_OP_LE_TEST_END                   BT_OP(BT_OGF_LE, 0x001f)
+#define BT_HCI_OP_LE_TEST_END                   BT_OP(BT_OGF_LE, 0x001f) /* 0x201f */
 struct bt_hci_rp_le_test_end {
 	uint8_t  status;
 	uint16_t rx_pkt_count;
 } __packed;
 
-#define BT_HCI_OP_LE_CONN_PARAM_REQ_REPLY       BT_OP(BT_OGF_LE, 0x0020)
+#define BT_HCI_OP_LE_CONN_PARAM_REQ_REPLY       BT_OP(BT_OGF_LE, 0x0020) /* 0x2020 */
 struct bt_hci_cp_le_conn_param_req_reply {
 	uint16_t handle;
 	uint16_t interval_min;
@@ -1168,7 +1168,7 @@ struct bt_hci_rp_le_conn_param_req_reply {
 	uint16_t handle;
 } __packed;
 
-#define BT_HCI_OP_LE_CONN_PARAM_REQ_NEG_REPLY   BT_OP(BT_OGF_LE, 0x0021)
+#define BT_HCI_OP_LE_CONN_PARAM_REQ_NEG_REPLY   BT_OP(BT_OGF_LE, 0x0021) /* 0x2021 */
 struct bt_hci_cp_le_conn_param_req_neg_reply {
 	uint16_t handle;
 	uint8_t  reason;
@@ -1178,7 +1178,7 @@ struct bt_hci_rp_le_conn_param_req_neg_reply {
 	uint16_t handle;
 } __packed;
 
-#define BT_HCI_OP_LE_SET_DATA_LEN               BT_OP(BT_OGF_LE, 0x0022)
+#define BT_HCI_OP_LE_SET_DATA_LEN               BT_OP(BT_OGF_LE, 0x0022) /* 0x2022 */
 struct bt_hci_cp_le_set_data_len {
 	uint16_t handle;
 	uint16_t tx_octets;
@@ -1189,28 +1189,28 @@ struct bt_hci_rp_le_set_data_len {
 	uint16_t handle;
 } __packed;
 
-#define BT_HCI_OP_LE_READ_DEFAULT_DATA_LEN      BT_OP(BT_OGF_LE, 0x0023)
+#define BT_HCI_OP_LE_READ_DEFAULT_DATA_LEN      BT_OP(BT_OGF_LE, 0x0023) /* 0x2023 */
 struct bt_hci_rp_le_read_default_data_len {
 	uint8_t  status;
 	uint16_t max_tx_octets;
 	uint16_t max_tx_time;
 } __packed;
 
-#define BT_HCI_OP_LE_WRITE_DEFAULT_DATA_LEN     BT_OP(BT_OGF_LE, 0x0024)
+#define BT_HCI_OP_LE_WRITE_DEFAULT_DATA_LEN     BT_OP(BT_OGF_LE, 0x0024) /* 0x2024 */
 struct bt_hci_cp_le_write_default_data_len {
 	uint16_t max_tx_octets;
 	uint16_t max_tx_time;
 } __packed;
 
-#define BT_HCI_OP_LE_P256_PUBLIC_KEY            BT_OP(BT_OGF_LE, 0x0025)
+#define BT_HCI_OP_LE_P256_PUBLIC_KEY            BT_OP(BT_OGF_LE, 0x0025) /* 0x2025 */
 
-#define BT_HCI_OP_LE_GENERATE_DHKEY             BT_OP(BT_OGF_LE, 0x0026)
+#define BT_HCI_OP_LE_GENERATE_DHKEY             BT_OP(BT_OGF_LE, 0x0026) /* 0x2026 */
 struct bt_hci_cp_le_generate_dhkey {
 	uint8_t key[64];
 } __packed;
 
 
-#define BT_HCI_OP_LE_GENERATE_DHKEY_V2          BT_OP(BT_OGF_LE, 0x005e)
+#define BT_HCI_OP_LE_GENERATE_DHKEY_V2          BT_OP(BT_OGF_LE, 0x005e) /* 0x205e */
 
 #define BT_HCI_LE_KEY_TYPE_GENERATED            0x00
 #define BT_HCI_LE_KEY_TYPE_DEBUG                0x01
@@ -1221,27 +1221,27 @@ struct bt_hci_cp_le_generate_dhkey_v2 {
 } __packed;
 
 
-#define BT_HCI_OP_LE_ADD_DEV_TO_RL              BT_OP(BT_OGF_LE, 0x0027)
+#define BT_HCI_OP_LE_ADD_DEV_TO_RL              BT_OP(BT_OGF_LE, 0x0027) /* 0x2027 */
 struct bt_hci_cp_le_add_dev_to_rl {
 	bt_addr_le_t  peer_id_addr;
 	uint8_t       peer_irk[16];
 	uint8_t       local_irk[16];
 } __packed;
 
-#define BT_HCI_OP_LE_REM_DEV_FROM_RL            BT_OP(BT_OGF_LE, 0x0028)
+#define BT_HCI_OP_LE_REM_DEV_FROM_RL            BT_OP(BT_OGF_LE, 0x0028) /* 0x2028 */
 struct bt_hci_cp_le_rem_dev_from_rl {
 	bt_addr_le_t  peer_id_addr;
 } __packed;
 
-#define BT_HCI_OP_LE_CLEAR_RL                   BT_OP(BT_OGF_LE, 0x0029)
+#define BT_HCI_OP_LE_CLEAR_RL                   BT_OP(BT_OGF_LE, 0x0029) /* 0x2029 */
 
-#define BT_HCI_OP_LE_READ_RL_SIZE               BT_OP(BT_OGF_LE, 0x002a)
+#define BT_HCI_OP_LE_READ_RL_SIZE               BT_OP(BT_OGF_LE, 0x002a) /* 0x202a */
 struct bt_hci_rp_le_read_rl_size {
 	uint8_t  status;
 	uint8_t  rl_size;
 } __packed;
 
-#define BT_HCI_OP_LE_READ_PEER_RPA              BT_OP(BT_OGF_LE, 0x002b)
+#define BT_HCI_OP_LE_READ_PEER_RPA              BT_OP(BT_OGF_LE, 0x002b) /* 0x202b */
 struct bt_hci_cp_le_read_peer_rpa {
 	bt_addr_le_t  peer_id_addr;
 } __packed;
@@ -1250,7 +1250,7 @@ struct bt_hci_rp_le_read_peer_rpa {
 	bt_addr_t  peer_rpa;
 } __packed;
 
-#define BT_HCI_OP_LE_READ_LOCAL_RPA             BT_OP(BT_OGF_LE, 0x002c)
+#define BT_HCI_OP_LE_READ_LOCAL_RPA             BT_OP(BT_OGF_LE, 0x002c) /* 0x202c */
 struct bt_hci_cp_le_read_local_rpa {
 	bt_addr_le_t  peer_id_addr;
 } __packed;
@@ -1262,17 +1262,17 @@ struct bt_hci_rp_le_read_local_rpa {
 #define BT_HCI_ADDR_RES_DISABLE                 0x00
 #define BT_HCI_ADDR_RES_ENABLE                  0x01
 
-#define BT_HCI_OP_LE_SET_ADDR_RES_ENABLE        BT_OP(BT_OGF_LE, 0x002d)
+#define BT_HCI_OP_LE_SET_ADDR_RES_ENABLE        BT_OP(BT_OGF_LE, 0x002d) /* 0x202d */
 struct bt_hci_cp_le_set_addr_res_enable {
 	uint8_t  enable;
 } __packed;
 
-#define BT_HCI_OP_LE_SET_RPA_TIMEOUT            BT_OP(BT_OGF_LE, 0x002e)
+#define BT_HCI_OP_LE_SET_RPA_TIMEOUT            BT_OP(BT_OGF_LE, 0x002e) /* 0x202e */
 struct bt_hci_cp_le_set_rpa_timeout {
 	uint16_t rpa_timeout;
 } __packed;
 
-#define BT_HCI_OP_LE_READ_MAX_DATA_LEN          BT_OP(BT_OGF_LE, 0x002f)
+#define BT_HCI_OP_LE_READ_MAX_DATA_LEN          BT_OP(BT_OGF_LE, 0x002f) /* 0x202f */
 struct bt_hci_rp_le_read_max_data_len {
 	uint8_t  status;
 	uint16_t max_tx_octets;
@@ -1285,7 +1285,7 @@ struct bt_hci_rp_le_read_max_data_len {
 #define BT_HCI_LE_PHY_2M                        0x02
 #define BT_HCI_LE_PHY_CODED                     0x03
 
-#define BT_HCI_OP_LE_READ_PHY                   BT_OP(BT_OGF_LE, 0x0030)
+#define BT_HCI_OP_LE_READ_PHY                   BT_OP(BT_OGF_LE, 0x0030) /* 0x2030 */
 struct bt_hci_cp_le_read_phy {
 	uint16_t handle;
 } __packed;
@@ -1303,7 +1303,7 @@ struct bt_hci_rp_le_read_phy {
 #define BT_HCI_LE_PHY_PREFER_2M                 BIT(1)
 #define BT_HCI_LE_PHY_PREFER_CODED              BIT(2)
 
-#define BT_HCI_OP_LE_SET_DEFAULT_PHY            BT_OP(BT_OGF_LE, 0x0031)
+#define BT_HCI_OP_LE_SET_DEFAULT_PHY            BT_OP(BT_OGF_LE, 0x0031) /* 0x2031 */
 struct bt_hci_cp_le_set_default_phy {
 	uint8_t all_phys;
 	uint8_t tx_phys;
@@ -1314,7 +1314,7 @@ struct bt_hci_cp_le_set_default_phy {
 #define BT_HCI_LE_PHY_CODED_S2                  0x01
 #define BT_HCI_LE_PHY_CODED_S8                  0x02
 
-#define BT_HCI_OP_LE_SET_PHY                    BT_OP(BT_OGF_LE, 0x0032)
+#define BT_HCI_OP_LE_SET_PHY                    BT_OP(BT_OGF_LE, 0x0032) /* 0x2032 */
 struct bt_hci_cp_le_set_phy {
 	uint16_t  handle;
 	uint8_t   all_phys;
@@ -1330,7 +1330,7 @@ struct bt_hci_cp_le_set_phy {
 #define BT_HCI_LE_RX_PHY_2M                     0x02
 #define BT_HCI_LE_RX_PHY_CODED                  0x03
 
-#define BT_HCI_OP_LE_ENH_RX_TEST                BT_OP(BT_OGF_LE, 0x0033)
+#define BT_HCI_OP_LE_ENH_RX_TEST                BT_OP(BT_OGF_LE, 0x0033) /* 0x2033 */
 struct bt_hci_cp_le_enh_rx_test {
 	uint8_t  rx_ch;
 	uint8_t  phy;
@@ -1342,7 +1342,7 @@ struct bt_hci_cp_le_enh_rx_test {
 #define BT_HCI_LE_TX_PHY_CODED_S8               0x03
 #define BT_HCI_LE_TX_PHY_CODED_S2               0x04
 
-#define BT_HCI_OP_LE_ENH_TX_TEST                BT_OP(BT_OGF_LE, 0x0034)
+#define BT_HCI_OP_LE_ENH_TX_TEST                BT_OP(BT_OGF_LE, 0x0034) /* 0x2034 */
 struct bt_hci_cp_le_enh_tx_test {
 	uint8_t  tx_ch;
 	uint8_t  test_data_len;
@@ -1350,7 +1350,7 @@ struct bt_hci_cp_le_enh_tx_test {
 	uint8_t  phy;
 } __packed;
 
-#define BT_HCI_OP_LE_SET_ADV_SET_RANDOM_ADDR    BT_OP(BT_OGF_LE, 0x0035)
+#define BT_HCI_OP_LE_SET_ADV_SET_RANDOM_ADDR    BT_OP(BT_OGF_LE, 0x0035) /* 0x2035 */
 struct bt_hci_cp_le_set_adv_set_random_addr {
 	uint8_t   handle;
 	bt_addr_t bdaddr;
@@ -1376,7 +1376,7 @@ struct bt_hci_cp_le_set_adv_set_random_addr {
 
 #define BT_HCI_LE_EXT_ADV_SID_INVALID  0xFF
 
-#define BT_HCI_OP_LE_SET_EXT_ADV_PARAM          BT_OP(BT_OGF_LE, 0x0036)
+#define BT_HCI_OP_LE_SET_EXT_ADV_PARAM          BT_OP(BT_OGF_LE, 0x0036) /* 0x2036 */
 struct bt_hci_cp_le_set_ext_adv_param {
 	uint8_t      handle;
 	uint16_t     props;
@@ -1409,7 +1409,7 @@ struct bt_hci_rp_le_set_ext_adv_param {
 
 #define BT_HCI_LE_EXT_ADV_FRAG_MAX_LEN          251
 
-#define BT_HCI_OP_LE_SET_EXT_ADV_DATA           BT_OP(BT_OGF_LE, 0x0037)
+#define BT_HCI_OP_LE_SET_EXT_ADV_DATA           BT_OP(BT_OGF_LE, 0x0037) /* 0x2037 */
 struct bt_hci_cp_le_set_ext_adv_data {
 	uint8_t  handle;
 	uint8_t  op;
@@ -1418,7 +1418,7 @@ struct bt_hci_cp_le_set_ext_adv_data {
 	uint8_t  data[0];
 } __packed;
 
-#define BT_HCI_OP_LE_SET_EXT_SCAN_RSP_DATA      BT_OP(BT_OGF_LE, 0x0038)
+#define BT_HCI_OP_LE_SET_EXT_SCAN_RSP_DATA      BT_OP(BT_OGF_LE, 0x0038) /* 0x2038 */
 struct bt_hci_cp_le_set_ext_scan_rsp_data {
 	uint8_t  handle;
 	uint8_t  op;
@@ -1427,7 +1427,7 @@ struct bt_hci_cp_le_set_ext_scan_rsp_data {
 	uint8_t  data[0];
 } __packed;
 
-#define BT_HCI_OP_LE_SET_EXT_ADV_ENABLE         BT_OP(BT_OGF_LE, 0x0039)
+#define BT_HCI_OP_LE_SET_EXT_ADV_ENABLE         BT_OP(BT_OGF_LE, 0x0039) /* 0x2039 */
 struct bt_hci_ext_adv_set {
 	uint8_t  handle;
 	uint16_t duration;
@@ -1440,29 +1440,29 @@ struct bt_hci_cp_le_set_ext_adv_enable {
 	struct bt_hci_ext_adv_set s[0];
 } __packed;
 
-#define BT_HCI_OP_LE_READ_MAX_ADV_DATA_LEN      BT_OP(BT_OGF_LE, 0x003a)
+#define BT_HCI_OP_LE_READ_MAX_ADV_DATA_LEN      BT_OP(BT_OGF_LE, 0x003a) /* 0x203a */
 struct bt_hci_rp_le_read_max_adv_data_len {
 	uint8_t  status;
 	uint16_t max_adv_data_len;
 } __packed;
 
-#define BT_HCI_OP_LE_READ_NUM_ADV_SETS          BT_OP(BT_OGF_LE, 0x003b)
+#define BT_HCI_OP_LE_READ_NUM_ADV_SETS          BT_OP(BT_OGF_LE, 0x003b) /* 0x203b */
 struct bt_hci_rp_le_read_num_adv_sets {
 	uint8_t  status;
 	uint8_t  num_sets;
 } __packed;
 
-#define BT_HCI_OP_LE_REMOVE_ADV_SET             BT_OP(BT_OGF_LE, 0x003c)
+#define BT_HCI_OP_LE_REMOVE_ADV_SET             BT_OP(BT_OGF_LE, 0x003c) /* 0x203c */
 struct bt_hci_cp_le_remove_adv_set {
 	uint8_t  handle;
 } __packed;
 
-#define BT_HCI_OP_CLEAR_ADV_SETS                BT_OP(BT_OGF_LE, 0x003d)
+#define BT_HCI_OP_CLEAR_ADV_SETS                BT_OP(BT_OGF_LE, 0x003d) /* 0x203d */
 
 #define BT_HCI_LE_PER_ADV_INTERVAL_MIN          0x0006
 #define BT_HCI_LE_PER_ADV_INTERVAL_MAX          0xFFFF
 
-#define BT_HCI_OP_LE_SET_PER_ADV_PARAM          BT_OP(BT_OGF_LE, 0x003e)
+#define BT_HCI_OP_LE_SET_PER_ADV_PARAM          BT_OP(BT_OGF_LE, 0x003e) /* 0x203e */
 struct bt_hci_cp_le_set_per_adv_param {
 	uint8_t  handle;
 	uint16_t min_interval;
@@ -1477,7 +1477,7 @@ struct bt_hci_cp_le_set_per_adv_param {
 
 #define BT_HCI_LE_PER_ADV_FRAG_MAX_LEN          252
 
-#define BT_HCI_OP_LE_SET_PER_ADV_DATA           BT_OP(BT_OGF_LE, 0x003f)
+#define BT_HCI_OP_LE_SET_PER_ADV_DATA           BT_OP(BT_OGF_LE, 0x003f) /* 0x203f */
 struct bt_hci_cp_le_set_per_adv_data {
 	uint8_t  handle;
 	uint8_t  op;
@@ -1488,13 +1488,13 @@ struct bt_hci_cp_le_set_per_adv_data {
 #define BT_HCI_LE_SET_PER_ADV_ENABLE_ENABLE     BIT(0)
 #define BT_HCI_LE_SET_PER_ADV_ENABLE_ADI        BIT(1)
 
-#define BT_HCI_OP_LE_SET_PER_ADV_ENABLE         BT_OP(BT_OGF_LE, 0x0040)
+#define BT_HCI_OP_LE_SET_PER_ADV_ENABLE         BT_OP(BT_OGF_LE, 0x0040) /* 0x2040 */
 struct bt_hci_cp_le_set_per_adv_enable {
 	uint8_t  enable;
 	uint8_t  handle;
 } __packed;
 
-#define BT_HCI_OP_LE_SET_EXT_SCAN_PARAM         BT_OP(BT_OGF_LE, 0x0041)
+#define BT_HCI_OP_LE_SET_EXT_SCAN_PARAM         BT_OP(BT_OGF_LE, 0x0041) /* 0x2041 */
 struct bt_hci_ext_scan_phy {
 	uint8_t  type;
 	uint16_t interval;
@@ -1515,7 +1515,7 @@ struct bt_hci_cp_le_set_ext_scan_param {
 /* Extends BT_HCI_LE_SCAN_FILTER_DUP */
 #define BT_HCI_LE_EXT_SCAN_FILTER_DUP_ENABLE_RESET  0x02
 
-#define BT_HCI_OP_LE_SET_EXT_SCAN_ENABLE        BT_OP(BT_OGF_LE, 0x0042)
+#define BT_HCI_OP_LE_SET_EXT_SCAN_ENABLE        BT_OP(BT_OGF_LE, 0x0042) /* 0x2042 */
 struct bt_hci_cp_le_set_ext_scan_enable {
 	uint8_t  enable;
 	uint8_t  filter_dup;
@@ -1523,8 +1523,8 @@ struct bt_hci_cp_le_set_ext_scan_enable {
 	uint16_t period;
 } __packed;
 
-#define BT_HCI_OP_LE_EXT_CREATE_CONN            BT_OP(BT_OGF_LE, 0x0043)
-#define BT_HCI_OP_LE_EXT_CREATE_CONN_V2         BT_OP(BT_OGF_LE, 0x0085)
+#define BT_HCI_OP_LE_EXT_CREATE_CONN            BT_OP(BT_OGF_LE, 0x0043) /* 0x2043 */
+#define BT_HCI_OP_LE_EXT_CREATE_CONN_V2         BT_OP(BT_OGF_LE, 0x0085) /* 0x2085 */
 struct bt_hci_ext_conn_phy {
 	uint16_t scan_interval;
 	uint16_t scan_window;
@@ -1554,7 +1554,7 @@ struct bt_hci_cp_le_ext_create_conn_v2 {
 	struct bt_hci_ext_conn_phy p[0];
 } __packed;
 
-#define BT_HCI_OP_LE_SET_PER_ADV_SUBEVENT_DATA  BT_OP(BT_OGF_LE, 0x0082)
+#define BT_HCI_OP_LE_SET_PER_ADV_SUBEVENT_DATA  BT_OP(BT_OGF_LE, 0x0082) /* 0x2082 */
 struct bt_hci_cp_le_set_pawr_subevent_data_element {
 	uint8_t subevent;
 	uint8_t response_slot_start;
@@ -1570,7 +1570,7 @@ struct bt_hci_cp_le_set_pawr_subevent_data {
 } __packed;
 
 
-#define BT_HCI_OP_LE_SET_PER_ADV_RESPONSE_DATA  BT_OP(BT_OGF_LE, 0x0083)
+#define BT_HCI_OP_LE_SET_PER_ADV_RESPONSE_DATA  BT_OP(BT_OGF_LE, 0x0083) /* 0x2083 */
 struct bt_hci_cp_le_set_pawr_response_data {
 	uint16_t sync_handle;
 	uint16_t request_event;
@@ -1581,7 +1581,7 @@ struct bt_hci_cp_le_set_pawr_response_data {
 	uint8_t response_data[0];
 } __packed;
 
-#define BT_HCI_OP_LE_SET_PER_ADV_SYNC_SUBEVENT  BT_OP(BT_OGF_LE, 0x0084)
+#define BT_HCI_OP_LE_SET_PER_ADV_SYNC_SUBEVENT  BT_OP(BT_OGF_LE, 0x0084) /* 0x2084 */
 struct bt_hci_cp_le_set_pawr_sync_subevent {
 	uint16_t sync_handle;
 	uint16_t periodic_adv_properties;
@@ -1590,7 +1590,7 @@ struct bt_hci_cp_le_set_pawr_sync_subevent {
 } __packed;
 
 
-#define BT_HCI_OP_LE_SET_PER_ADV_PARAM_V2       BT_OP(BT_OGF_LE, 0x0086)
+#define BT_HCI_OP_LE_SET_PER_ADV_PARAM_V2       BT_OP(BT_OGF_LE, 0x0086) /* 0x2086 */
 struct bt_hci_cp_le_set_per_adv_param_v2 {
 	uint8_t  handle;
 	uint16_t min_interval;
@@ -1619,7 +1619,7 @@ struct bt_hci_cp_le_set_per_adv_param_v2 {
 #define BT_HCI_LE_PER_ADV_CREATE_SYNC_CTE_TYPE_INVALID_VALUE \
 	(~BIT_MASK(BT_HCI_LE_PER_ADV_CREATE_SYNC_CTE_TYPE_ALLOWED_BITS))
 
-#define BT_HCI_OP_LE_PER_ADV_CREATE_SYNC        BT_OP(BT_OGF_LE, 0x0044)
+#define BT_HCI_OP_LE_PER_ADV_CREATE_SYNC        BT_OP(BT_OGF_LE, 0x0044) /* 0x2044 */
 struct bt_hci_cp_le_per_adv_create_sync {
 	uint8_t options;
 	uint8_t      sid;
@@ -1629,48 +1629,48 @@ struct bt_hci_cp_le_per_adv_create_sync {
 	uint8_t      cte_type;
 } __packed;
 
-#define BT_HCI_OP_LE_PER_ADV_CREATE_SYNC_CANCEL BT_OP(BT_OGF_LE, 0x0045)
+#define BT_HCI_OP_LE_PER_ADV_CREATE_SYNC_CANCEL BT_OP(BT_OGF_LE, 0x0045) /* 0x2045 */
 
-#define BT_HCI_OP_LE_PER_ADV_TERMINATE_SYNC     BT_OP(BT_OGF_LE, 0x0046)
+#define BT_HCI_OP_LE_PER_ADV_TERMINATE_SYNC     BT_OP(BT_OGF_LE, 0x0046) /* 0x2046 */
 struct bt_hci_cp_le_per_adv_terminate_sync {
 	uint16_t handle;
 } __packed;
 
-#define BT_HCI_OP_LE_ADD_DEV_TO_PER_ADV_LIST    BT_OP(BT_OGF_LE, 0x0047)
+#define BT_HCI_OP_LE_ADD_DEV_TO_PER_ADV_LIST    BT_OP(BT_OGF_LE, 0x0047) /* 0x2047 */
 struct bt_hci_cp_le_add_dev_to_per_adv_list {
 	bt_addr_le_t addr;
 	uint8_t      sid;
 } __packed;
 
-#define BT_HCI_OP_LE_REM_DEV_FROM_PER_ADV_LIST  BT_OP(BT_OGF_LE, 0x0048)
+#define BT_HCI_OP_LE_REM_DEV_FROM_PER_ADV_LIST  BT_OP(BT_OGF_LE, 0x0048) /* 0x2048 */
 struct bt_hci_cp_le_rem_dev_from_per_adv_list {
 	bt_addr_le_t addr;
 	uint8_t      sid;
 } __packed;
 
-#define BT_HCI_OP_LE_CLEAR_PER_ADV_LIST         BT_OP(BT_OGF_LE, 0x0049)
+#define BT_HCI_OP_LE_CLEAR_PER_ADV_LIST         BT_OP(BT_OGF_LE, 0x0049) /* 0x2049 */
 
-#define BT_HCI_OP_LE_READ_PER_ADV_LIST_SIZE     BT_OP(BT_OGF_LE, 0x004a)
+#define BT_HCI_OP_LE_READ_PER_ADV_LIST_SIZE     BT_OP(BT_OGF_LE, 0x004a) /* 0x204a */
 struct bt_hci_rp_le_read_per_adv_list_size {
 	uint8_t  status;
 	uint8_t  list_size;
 } __packed;
 
-#define BT_HCI_OP_LE_READ_TX_POWER              BT_OP(BT_OGF_LE, 0x004b)
+#define BT_HCI_OP_LE_READ_TX_POWER              BT_OP(BT_OGF_LE, 0x004b) /* 0x204b */
 struct bt_hci_rp_le_read_tx_power {
 	uint8_t status;
 	int8_t  min_tx_power;
 	int8_t  max_tx_power;
 } __packed;
 
-#define BT_HCI_OP_LE_READ_RF_PATH_COMP          BT_OP(BT_OGF_LE, 0x004c)
+#define BT_HCI_OP_LE_READ_RF_PATH_COMP          BT_OP(BT_OGF_LE, 0x004c) /* 0x204c */
 struct bt_hci_rp_le_read_rf_path_comp {
 	uint8_t status;
 	int16_t tx_path_comp;
 	int16_t rx_path_comp;
 } __packed;
 
-#define BT_HCI_OP_LE_WRITE_RF_PATH_COMP         BT_OP(BT_OGF_LE, 0x004d)
+#define BT_HCI_OP_LE_WRITE_RF_PATH_COMP         BT_OP(BT_OGF_LE, 0x004d) /* 0x204d */
 struct bt_hci_cp_le_write_rf_path_comp {
 	int16_t  tx_path_comp;
 	int16_t  rx_path_comp;
@@ -1679,7 +1679,7 @@ struct bt_hci_cp_le_write_rf_path_comp {
 #define BT_HCI_LE_PRIVACY_MODE_NETWORK          0x00
 #define BT_HCI_LE_PRIVACY_MODE_DEVICE           0x01
 
-#define BT_HCI_OP_LE_SET_PRIVACY_MODE           BT_OP(BT_OGF_LE, 0x004e)
+#define BT_HCI_OP_LE_SET_PRIVACY_MODE           BT_OP(BT_OGF_LE, 0x004e) /* 0x204e */
 struct bt_hci_cp_le_set_privacy_mode {
 	bt_addr_le_t id_addr;
 	uint8_t         mode;
@@ -1690,7 +1690,7 @@ struct bt_hci_cp_le_set_privacy_mode {
 #define BT_HCI_LE_TEST_SLOT_DURATION_ANY        0x00
 #define BT_HCI_LE_TEST_SWITCH_PATTERN_LEN_ANY   0x00
 
-#define BT_HCI_OP_LE_RX_TEST_V3                 BT_OP(BT_OGF_LE, 0x004f)
+#define BT_HCI_OP_LE_RX_TEST_V3                 BT_OP(BT_OGF_LE, 0x004f) /* 0x204f */
 struct bt_hci_cp_le_rx_test_v3 {
 	uint8_t  rx_ch;
 	uint8_t  phy;
@@ -1702,7 +1702,7 @@ struct bt_hci_cp_le_rx_test_v3 {
 	uint8_t  ant_ids[0];
 } __packed;
 
-#define BT_HCI_OP_LE_TX_TEST_V3                 BT_OP(BT_OGF_LE, 0x0050)
+#define BT_HCI_OP_LE_TX_TEST_V3                 BT_OP(BT_OGF_LE, 0x0050) /* 0x2050 */
 
 struct bt_hci_cp_le_tx_test_v3 {
 	uint8_t  tx_ch;
@@ -1727,7 +1727,7 @@ struct bt_hci_cp_le_tx_test_v3 {
 #define BT_HCI_LE_CTE_COUNT_MIN                0x1
 #define BT_HCI_LE_CTE_COUNT_MAX                0x10
 
-#define BT_HCI_OP_LE_SET_CL_CTE_TX_PARAMS      BT_OP(BT_OGF_LE, 0x0051)
+#define BT_HCI_OP_LE_SET_CL_CTE_TX_PARAMS      BT_OP(BT_OGF_LE, 0x0051) /* 0x2051 */
 struct bt_hci_cp_le_set_cl_cte_tx_params {
 	uint8_t handle;
 	uint8_t cte_len;
@@ -1737,7 +1737,7 @@ struct bt_hci_cp_le_set_cl_cte_tx_params {
 	uint8_t ant_ids[0];
 } __packed;
 
-#define BT_HCI_OP_LE_SET_CL_CTE_TX_ENABLE      BT_OP(BT_OGF_LE, 0x0052)
+#define BT_HCI_OP_LE_SET_CL_CTE_TX_ENABLE      BT_OP(BT_OGF_LE, 0x0052) /* 0x2052 */
 struct bt_hci_cp_le_set_cl_cte_tx_enable {
 	uint8_t handle;
 	uint8_t cte_enable;
@@ -1750,7 +1750,7 @@ struct bt_hci_cp_le_set_cl_cte_tx_enable {
 #define BT_HCI_LE_SAMPLE_CTE_COUNT_MIN         0x1
 #define BT_HCI_LE_SAMPLE_CTE_COUNT_MAX         0x10
 
-#define BT_HCI_OP_LE_SET_CL_CTE_SAMPLING_ENABLE BT_OP(BT_OGF_LE, 0x0053)
+#define BT_HCI_OP_LE_SET_CL_CTE_SAMPLING_ENABLE BT_OP(BT_OGF_LE, 0x0053) /* 0x2053 */
 struct bt_hci_cp_le_set_cl_cte_sampling_enable {
 	uint16_t sync_handle;
 	uint8_t  sampling_enable;
@@ -1765,7 +1765,7 @@ struct bt_hci_rp_le_set_cl_cte_sampling_enable {
 	uint16_t sync_handle;
 } __packed;
 
-#define BT_HCI_OP_LE_SET_CONN_CTE_RX_PARAMS BT_OP(BT_OGF_LE, 0x0054)
+#define BT_HCI_OP_LE_SET_CONN_CTE_RX_PARAMS BT_OP(BT_OGF_LE, 0x0054) /* 0x2054 */
 struct bt_hci_cp_le_set_conn_cte_rx_params {
 	uint16_t handle;
 	uint8_t  sampling_enable;
@@ -1786,7 +1786,7 @@ struct bt_hci_rp_le_set_conn_cte_rx_params {
 #define BT_HCI_LE_SWITCH_PATTERN_LEN_MIN        0x2
 #define BT_HCI_LE_SWITCH_PATTERN_LEN_MAX        0x4B
 
-#define BT_HCI_OP_LE_SET_CONN_CTE_TX_PARAMS     BT_OP(BT_OGF_LE, 0x0055)
+#define BT_HCI_OP_LE_SET_CONN_CTE_TX_PARAMS     BT_OP(BT_OGF_LE, 0x0055) /* 0x2055 */
 struct bt_hci_cp_le_set_conn_cte_tx_params {
 	uint16_t handle;
 	uint8_t  cte_types;
@@ -1804,7 +1804,7 @@ struct bt_hci_rp_le_set_conn_cte_tx_params {
 #define BT_HCI_REQUEST_CTE_INTERVAL_MIN        0x1
 #define BT_HCI_REQUEST_CTE_INTERVAL_MAX        0xFFFF
 
-#define BT_HCI_OP_LE_CONN_CTE_REQ_ENABLE       BT_OP(BT_OGF_LE, 0x0056)
+#define BT_HCI_OP_LE_CONN_CTE_REQ_ENABLE       BT_OP(BT_OGF_LE, 0x0056) /* 0x2056 */
 struct bt_hci_cp_le_conn_cte_req_enable {
 	uint16_t handle;
 	uint8_t  enable;
@@ -1818,7 +1818,7 @@ struct bt_hci_rp_le_conn_cte_req_enable {
 	uint16_t handle;
 } __packed;
 
-#define BT_HCI_OP_LE_CONN_CTE_RSP_ENABLE       BT_OP(BT_OGF_LE, 0x0057)
+#define BT_HCI_OP_LE_CONN_CTE_RSP_ENABLE       BT_OP(BT_OGF_LE, 0x0057) /* 0x2057 */
 struct bt_hci_cp_le_conn_cte_rsp_enable {
 	uint16_t handle;
 	uint8_t  enable;
@@ -1842,7 +1842,7 @@ struct bt_hci_rp_le_conn_cte_rsp_enable {
 #define BT_HCI_LE_MAX_CTE_LEN_MIN               0x2
 #define BT_HCI_LE_MAX_CTE_LEN_MAX               0x14
 
-#define BT_HCI_OP_LE_READ_ANT_INFO              BT_OP(BT_OGF_LE, 0x0058)
+#define BT_HCI_OP_LE_READ_ANT_INFO              BT_OP(BT_OGF_LE, 0x0058) /* 0x2058 */
 struct bt_hci_rp_le_read_ant_info {
 	uint8_t status;
 	uint8_t switch_sample_rates;
@@ -1854,13 +1854,13 @@ struct bt_hci_rp_le_read_ant_info {
 #define BT_HCI_LE_SET_PER_ADV_RECV_ENABLE_ENABLE           BIT(0)
 #define BT_HCI_LE_SET_PER_ADV_RECV_ENABLE_FILTER_DUPLICATE BIT(1)
 
-#define BT_HCI_OP_LE_SET_PER_ADV_RECV_ENABLE     BT_OP(BT_OGF_LE, 0x0059)
+#define BT_HCI_OP_LE_SET_PER_ADV_RECV_ENABLE     BT_OP(BT_OGF_LE, 0x0059) /* 0x2059 */
 struct bt_hci_cp_le_set_per_adv_recv_enable {
 	uint16_t handle;
 	uint8_t  enable;
 } __packed;
 
-#define BT_HCI_OP_LE_PER_ADV_SYNC_TRANSFER      BT_OP(BT_OGF_LE, 0x005a)
+#define BT_HCI_OP_LE_PER_ADV_SYNC_TRANSFER      BT_OP(BT_OGF_LE, 0x005a) /* 0x205a */
 struct bt_hci_cp_le_per_adv_sync_transfer {
 	uint16_t conn_handle;
 	uint16_t service_data;
@@ -1872,7 +1872,7 @@ struct bt_hci_rp_le_per_adv_sync_transfer {
 	uint16_t conn_handle;
 } __packed;
 
-#define BT_HCI_OP_LE_PER_ADV_SET_INFO_TRANSFER  BT_OP(BT_OGF_LE, 0x005b)
+#define BT_HCI_OP_LE_PER_ADV_SET_INFO_TRANSFER  BT_OP(BT_OGF_LE, 0x005b) /* 0x205b */
 struct bt_hci_cp_le_per_adv_set_info_transfer {
 	uint16_t conn_handle;
 	uint16_t service_data;
@@ -1895,7 +1895,7 @@ struct bt_hci_rp_le_per_adv_set_info_transfer {
 #define BT_HCI_LE_PAST_CTE_TYPE_NO_CTE           BIT(3)
 #define BT_HCI_LE_PAST_CTE_TYPE_ONLY_CTE         BIT(4)
 
-#define BT_HCI_OP_LE_PAST_PARAM                 BT_OP(BT_OGF_LE, 0x005c)
+#define BT_HCI_OP_LE_PAST_PARAM                 BT_OP(BT_OGF_LE, 0x005c) /* 0x205c */
 struct bt_hci_cp_le_past_param {
 	uint16_t conn_handle;
 	uint8_t  mode;
@@ -1909,7 +1909,7 @@ struct bt_hci_rp_le_past_param {
 	uint16_t conn_handle;
 } __packed;
 
-#define BT_HCI_OP_LE_DEFAULT_PAST_PARAM         BT_OP(BT_OGF_LE, 0x005d)
+#define BT_HCI_OP_LE_DEFAULT_PAST_PARAM         BT_OP(BT_OGF_LE, 0x005d) /* 0x205d */
 struct bt_hci_cp_le_default_past_param {
 	uint8_t  mode;
 	uint16_t skip;
@@ -1921,7 +1921,7 @@ struct bt_hci_rp_le_default_past_param {
 	uint8_t  status;
 } __packed;
 
-#define BT_HCI_OP_LE_READ_BUFFER_SIZE_V2        BT_OP(BT_OGF_LE, 0x0060)
+#define BT_HCI_OP_LE_READ_BUFFER_SIZE_V2        BT_OP(BT_OGF_LE, 0x0060) /* 0x2060 */
 struct bt_hci_rp_le_read_buffer_size_v2 {
 	uint8_t  status;
 	uint16_t acl_max_len;
@@ -1930,7 +1930,7 @@ struct bt_hci_rp_le_read_buffer_size_v2 {
 	uint8_t  iso_max_num;
 } __packed;
 
-#define BT_HCI_OP_LE_READ_ISO_TX_SYNC           BT_OP(BT_OGF_LE, 0x0061)
+#define BT_HCI_OP_LE_READ_ISO_TX_SYNC           BT_OP(BT_OGF_LE, 0x0061) /* 0x2061 */
 struct bt_hci_cp_le_read_iso_tx_sync {
 	uint16_t handle;
 } __packed;
@@ -1958,7 +1958,7 @@ struct bt_hci_rp_le_read_iso_tx_sync {
 #define BT_HCI_ISO_INTERVAL_MIN                 0x0004
 #define BT_HCI_ISO_INTERVAL_MAX                 0x0C80
 
-#define BT_HCI_OP_LE_SET_CIG_PARAMS             BT_OP(BT_OGF_LE, 0x0062)
+#define BT_HCI_OP_LE_SET_CIG_PARAMS             BT_OP(BT_OGF_LE, 0x0062) /* 0x2062 */
 struct bt_hci_cis_params {
 	uint8_t  cis_id;
 	uint16_t c_sdu;
@@ -1989,7 +1989,7 @@ struct bt_hci_rp_le_set_cig_params {
 	uint16_t handle[0];
 } __packed;
 
-#define BT_HCI_OP_LE_SET_CIG_PARAMS_TEST        BT_OP(BT_OGF_LE, 0x0063)
+#define BT_HCI_OP_LE_SET_CIG_PARAMS_TEST        BT_OP(BT_OGF_LE, 0x0063) /* 0x2063 */
 struct bt_hci_cis_params_test {
 	uint8_t  cis_id;
 	uint8_t  nse;
@@ -2024,7 +2024,7 @@ struct bt_hci_rp_le_set_cig_params_test {
 	uint16_t handle[0];
 } __packed;
 
-#define BT_HCI_OP_LE_CREATE_CIS                 BT_OP(BT_OGF_LE, 0x0064)
+#define BT_HCI_OP_LE_CREATE_CIS                 BT_OP(BT_OGF_LE, 0x0064) /* 0x2064 */
 struct bt_hci_cis {
 	uint16_t  cis_handle;
 	uint16_t  acl_handle;
@@ -2035,7 +2035,7 @@ struct bt_hci_cp_le_create_cis {
 	struct bt_hci_cis cis[0];
 } __packed;
 
-#define BT_HCI_OP_LE_REMOVE_CIG                 BT_OP(BT_OGF_LE, 0x0065)
+#define BT_HCI_OP_LE_REMOVE_CIG                 BT_OP(BT_OGF_LE, 0x0065) /* 0x2065 */
 struct bt_hci_cp_le_remove_cig {
 	uint8_t  cig_id;
 } __packed;
@@ -2045,12 +2045,12 @@ struct bt_hci_rp_le_remove_cig {
 	uint8_t  cig_id;
 } __packed;
 
-#define BT_HCI_OP_LE_ACCEPT_CIS                 BT_OP(BT_OGF_LE, 0x0066)
+#define BT_HCI_OP_LE_ACCEPT_CIS                 BT_OP(BT_OGF_LE, 0x0066) /* 0x2066 */
 struct bt_hci_cp_le_accept_cis {
 	uint16_t handle;
 } __packed;
 
-#define BT_HCI_OP_LE_REJECT_CIS                 BT_OP(BT_OGF_LE, 0x0067)
+#define BT_HCI_OP_LE_REJECT_CIS                 BT_OP(BT_OGF_LE, 0x0067) /* 0x2067 */
 struct bt_hci_cp_le_reject_cis {
 	uint16_t handle;
 	uint8_t  reason;
@@ -2061,7 +2061,7 @@ struct bt_hci_rp_le_reject_cis {
 	uint16_t handle;
 } __packed;
 
-#define BT_HCI_OP_LE_CREATE_BIG                 BT_OP(BT_OGF_LE, 0x0068)
+#define BT_HCI_OP_LE_CREATE_BIG                 BT_OP(BT_OGF_LE, 0x0068) /* 0x2068 */
 struct bt_hci_cp_le_create_big {
 	uint8_t  big_handle;
 	uint8_t  adv_handle;
@@ -2077,7 +2077,7 @@ struct bt_hci_cp_le_create_big {
 	uint8_t  bcode[16];
 } __packed;
 
-#define BT_HCI_OP_LE_CREATE_BIG_TEST            BT_OP(BT_OGF_LE, 0x0069)
+#define BT_HCI_OP_LE_CREATE_BIG_TEST            BT_OP(BT_OGF_LE, 0x0069) /* 0x2069 */
 struct bt_hci_cp_le_create_big_test {
 	uint8_t  big_handle;
 	uint8_t  adv_handle;
@@ -2097,13 +2097,13 @@ struct bt_hci_cp_le_create_big_test {
 	uint8_t  bcode[16];
 } __packed;
 
-#define BT_HCI_OP_LE_TERMINATE_BIG              BT_OP(BT_OGF_LE, 0x006a)
+#define BT_HCI_OP_LE_TERMINATE_BIG              BT_OP(BT_OGF_LE, 0x006a) /* 0x206a */
 struct bt_hci_cp_le_terminate_big {
 	uint8_t  big_handle;
 	uint8_t  reason;
 } __packed;
 
-#define BT_HCI_OP_LE_BIG_CREATE_SYNC            BT_OP(BT_OGF_LE, 0x006b)
+#define BT_HCI_OP_LE_BIG_CREATE_SYNC            BT_OP(BT_OGF_LE, 0x006b) /* 0x206b */
 struct bt_hci_cp_le_big_create_sync {
 	uint8_t  big_handle;
 	uint16_t sync_handle;
@@ -2115,7 +2115,7 @@ struct bt_hci_cp_le_big_create_sync {
 	uint8_t  bis[0];
 } __packed;
 
-#define BT_HCI_OP_LE_BIG_TERMINATE_SYNC         BT_OP(BT_OGF_LE, 0x006c)
+#define BT_HCI_OP_LE_BIG_TERMINATE_SYNC         BT_OP(BT_OGF_LE, 0x006c) /* 0x206c */
 struct bt_hci_cp_le_big_terminate_sync {
 	uint8_t  big_handle;
 } __packed;
@@ -2125,12 +2125,12 @@ struct bt_hci_rp_le_big_terminate_sync {
 	uint8_t  big_handle;
 } __packed;
 
-#define BT_HCI_OP_LE_REQ_PEER_SC                BT_OP(BT_OGF_LE, 0x006d)
+#define BT_HCI_OP_LE_REQ_PEER_SC                BT_OP(BT_OGF_LE, 0x006d) /* 0x206d */
 struct bt_hci_cp_le_req_peer_sca {
 	uint16_t handle;
 } __packed;
 
-#define BT_HCI_OP_LE_SETUP_ISO_PATH             BT_OP(BT_OGF_LE, 0x006e)
+#define BT_HCI_OP_LE_SETUP_ISO_PATH             BT_OP(BT_OGF_LE, 0x006e) /* 0x206e */
 struct bt_hci_cp_le_setup_iso_path {
 	uint16_t handle;
 	uint8_t  path_dir;
@@ -2146,7 +2146,7 @@ struct bt_hci_rp_le_setup_iso_path {
 	uint16_t handle;
 } __packed;
 
-#define BT_HCI_OP_LE_REMOVE_ISO_PATH            BT_OP(BT_OGF_LE, 0x006f)
+#define BT_HCI_OP_LE_REMOVE_ISO_PATH            BT_OP(BT_OGF_LE, 0x006f) /* 0x206f */
 struct bt_hci_cp_le_remove_iso_path {
 	uint16_t handle;
 	uint8_t  path_dir;
@@ -2161,7 +2161,7 @@ struct bt_hci_rp_le_remove_iso_path {
 #define BT_HCI_ISO_TEST_VARIABLE_SIZE_SDU 1
 #define BT_HCI_ISO_TEST_MAX_SIZE_SDU      2
 
-#define BT_HCI_OP_LE_ISO_TRANSMIT_TEST          BT_OP(BT_OGF_LE, 0x0070)
+#define BT_HCI_OP_LE_ISO_TRANSMIT_TEST          BT_OP(BT_OGF_LE, 0x0070) /* 0x2070 */
 struct bt_hci_cp_le_iso_transmit_test {
 	uint16_t handle;
 	uint8_t  payload_type;
@@ -2172,7 +2172,7 @@ struct bt_hci_rp_le_iso_transmit_test {
 	uint16_t handle;
 } __packed;
 
-#define BT_HCI_OP_LE_ISO_RECEIVE_TEST           BT_OP(BT_OGF_LE, 0x0071)
+#define BT_HCI_OP_LE_ISO_RECEIVE_TEST           BT_OP(BT_OGF_LE, 0x0071) /* 0x2071 */
 struct bt_hci_cp_le_iso_receive_test {
 	uint16_t handle;
 	uint8_t  payload_type;
@@ -2183,7 +2183,7 @@ struct bt_hci_rp_le_iso_receive_test {
 	uint16_t handle;
 } __packed;
 
-#define BT_HCI_OP_LE_ISO_READ_TEST_COUNTERS     BT_OP(BT_OGF_LE, 0x0072)
+#define BT_HCI_OP_LE_ISO_READ_TEST_COUNTERS     BT_OP(BT_OGF_LE, 0x0072) /* 0x2072 */
 struct bt_hci_cp_le_read_test_counters {
 	uint16_t handle;
 } __packed;
@@ -2196,7 +2196,7 @@ struct bt_hci_rp_le_read_test_counters {
 	uint32_t failed_cnt;
 } __packed;
 
-#define BT_HCI_OP_LE_ISO_TEST_END               BT_OP(BT_OGF_LE, 0x0073)
+#define BT_HCI_OP_LE_ISO_TEST_END               BT_OP(BT_OGF_LE, 0x0073) /* 0x2073 */
 struct bt_hci_cp_le_iso_test_end {
 	uint16_t handle;
 } __packed;
@@ -2209,7 +2209,7 @@ struct bt_hci_rp_le_iso_test_end {
 	uint32_t failed_cnt;
 } __packed;
 
-#define BT_HCI_OP_LE_SET_HOST_FEATURE           BT_OP(BT_OGF_LE, 0x0074)
+#define BT_HCI_OP_LE_SET_HOST_FEATURE           BT_OP(BT_OGF_LE, 0x0074) /* 0x2074 */
 struct bt_hci_cp_le_set_host_feature {
 	uint8_t  bit_number;
 	uint8_t  bit_value;
@@ -2219,7 +2219,7 @@ struct bt_hci_rp_le_set_host_feature {
 	uint8_t  status;
 } __packed;
 
-#define BT_HCI_OP_LE_READ_ISO_LINK_QUALITY      BT_OP(BT_OGF_LE, 0x0075)
+#define BT_HCI_OP_LE_READ_ISO_LINK_QUALITY      BT_OP(BT_OGF_LE, 0x0075) /* 0x2075 */
 struct bt_hci_cp_le_read_iso_link_quality {
 	uint16_t handle;
 } __packed;
@@ -2236,7 +2236,7 @@ struct bt_hci_rp_le_read_iso_link_quality {
 	uint32_t duplicate_packets;
 } __packed;
 
-#define BT_HCI_OP_LE_TX_TEST_V4                 BT_OP(BT_OGF_LE, 0x007B)
+#define BT_HCI_OP_LE_TX_TEST_V4                 BT_OP(BT_OGF_LE, 0x007B) /* 0x207B */
 
 struct bt_hci_cp_le_tx_test_v4 {
 	uint8_t  tx_ch;


### PR DESCRIPTION
Mental arithmetic shouldn't be required to analyze logs.

With this, a user can just "grep" the Bluetooth tree for the opcode reported in an HCI error.