### PR TITLE
samples: ipc: rpmsg_service: Add support for stm32h747i_disco

### DIFF
--- a/samples/subsys/ipc/rpmsg_service/boards/stm32h747i_disco_m7.overlay
+++ b/samples/subsys/ipc/rpmsg_service/boards/stm32h747i_disco_m7.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2023 Celina Sophie Kalus <hello@celinakalus.de>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,ipc_shm = &sram4;
+		zephyr,ipc = &mailbox;
+	};
+};
+
+&mailbox {
+	status = "okay";
+};

--- a/samples/subsys/ipc/rpmsg_service/remote/boards/stm32h747i_disco_m4.overlay
+++ b/samples/subsys/ipc/rpmsg_service/remote/boards/stm32h747i_disco_m4.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2023 Celina Sophie Kalus <hello@celinakalus.de>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,ipc_shm = &sram4;
+		zephyr,ipc = &mailbox;
+	};
+};
+
+&mailbox {
+	status = "okay";
+};


### PR DESCRIPTION
With the changes made in pull request #68741, RPMsg service is supported on stm32h747i_disco using the STM32 HSEM IPM driver. For the sample to work, add device tree overlays to enable the mailbox and set the shared memory appropriately.