### PR TITLE
dts: bindings: nxp,edma: force dma-cells number to 2

### DIFF
--- a/dts/bindings/dma/nxp,edma.yaml
+++ b/dts/bindings/dma/nxp,edma.yaml
@@ -39,3 +39,13 @@ properties:
       configurations available, the user will have to specify which
       configuration to use through this property. If missing, the
       configuration found at index 0 will be used.
+  "#dma-cells":
+    const: 2
+
+# IMPORTANT: if your EDMA version doesn't support channel MUX-ing please
+# leave the MUX cell as 0. This is not mandatory for the driver as the
+# MUX value will be ignored in this case but all entities using EDMA should
+# be consistent in this regard.
+dma-cells:
+  - channel
+  - mux


### PR DESCRIPTION
To allow EDMA configuration with the help of the DT_INST_DMAS_* and DT_DMAS_* macros, all that a consumer node needs to know is which channel to configure and what MUX value needs to be used. As such, this commit allows doing this by forcing the dma-cells property to 2, each cell representing one of the aforementioned properties.