### PR TITLE
drivers: dai: sai: use "dmas" property for handshake encoding

### DIFF
--- a/drivers/dai/nxp/sai/sai.c
+++ b/drivers/dai/nxp/sai/sai.c
@@ -865,13 +865,13 @@ BUILD_ASSERT(SAI_TX_SYNC_MODE(inst) != SAI_RX_SYNC_MODE(inst) ||		\
 static const struct dai_properties sai_tx_props_##inst = {			\
 	.fifo_address = SAI_TX_FIFO_BASE(inst),					\
 	.fifo_depth = SAI_FIFO_DEPTH(inst) * CONFIG_SAI_FIFO_WORD_SIZE,		\
-	.dma_hs_id = SAI_TX_DMA_MUX(inst),					\
+	.dma_hs_id = SAI_TX_RX_DMA_HANDSHAKE(inst, tx),				\
 };										\
 										\
 static const struct dai_properties sai_rx_props_##inst = {			\
 	.fifo_address = SAI_RX_FIFO_BASE(inst),					\
 	.fifo_depth = SAI_FIFO_DEPTH(inst) * CONFIG_SAI_FIFO_WORD_SIZE,		\
-	.dma_hs_id = SAI_RX_DMA_MUX(inst),					\
+	.dma_hs_id = SAI_TX_RX_DMA_HANDSHAKE(inst, rx),				\
 };										\
 										\
 void irq_config_##inst(void)							\

--- a/drivers/dai/nxp/sai/sai.h
+++ b/drivers/dai/nxp/sai/sai.h
@@ -137,6 +137,15 @@ LOG_MODULE_REGISTER(nxp_dai_sai);
 #define SAI_RX_SYNC_MODE(inst)\
 	DT_INST_PROP_OR(inst, rx_sync_mode, kSAI_ModeAsync)
 
+/* used to retrieve the handshake value for given direction. The handshake
+ * is computed as follows:
+ *	handshake = CHANNEL_ID | (MUX_VALUE << 8)
+ * The channel ID and MUX value are each encoded in 8 bits.
+ */
+#define SAI_TX_RX_DMA_HANDSHAKE(inst, dir)\
+	((DT_INST_DMAS_CELL_BY_NAME(inst, dir, channel) & GENMASK(7, 0)) |\
+	 ((DT_INST_DMAS_CELL_BY_NAME(inst, dir, mux) << 8) & GENMASK(15, 8)))
+
 /* utility macros */
 
 /* invert a clock's polarity. This works because a clock's polarity is expressed


### PR DESCRIPTION
Since a DMA cell now allows specifying a channel and a MUX value there's no need to fetch these values from the HAL. This, in turn, allows for more flexibility and reduces the coding effort for new platforms that want to use the SAI driver.