### PR TITLE
net: ipv6: Improve Neighbor Discovery thread safety

### DIFF
--- a/subsys/net/ip/ipv6.h
+++ b/subsys/net/ip/ipv6.h
@@ -271,6 +271,21 @@ static inline enum net_verdict net_ipv6_prepare_for_send(struct net_pkt *pkt)
 #endif
 
 /**
+ * @brief Lock IPv6 Neighbor table mutex
+ *
+ * Neighbor table mutex is used by IPv6 Neighbor cache and IPv6 Routing module.
+ * Mutex shall be held whenever accessing or manipulating neighbor or routing
+ * table entries (for example when obtaining a pointer to the neighbor table
+ * entry). Neighbor and Routing API functions will lock the mutex when called.
+ */
+void net_ipv6_nbr_lock(void);
+
+/**
+ * @brief Unlock IPv6 Neighbor table mutex
+ */
+void net_ipv6_nbr_unlock(void);
+
+/**
  * @brief Look for a neighbor from it's address on an iface
  *
  * @param iface A valid pointer on a network interface

--- a/subsys/net/ip/route.c
+++ b/subsys/net/ip/route.c
@@ -44,8 +44,6 @@ static sys_slist_t active_route_lifetime_timers;
 /* Timer that manages expired route entries. */
 static struct k_work_delayable route_lifetime_timer;
 
-static K_MUTEX_DEFINE(lock);
-
 static void net_route_nexthop_remove(struct net_nbr *nbr)
 {
 	NET_DBG("Nexthop %p removed", nbr);
@@ -135,11 +133,12 @@ static inline struct net_route_entry *net_route_data(struct net_nbr *nbr)
 
 struct net_nbr *net_route_get_nbr(struct net_route_entry *route)
 {
+	struct net_nbr *ret = NULL;
 	int i;
 
 	NET_ASSERT(route);
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_ipv6_nbr_lock();
 
 	for (i = 0; i < CONFIG_NET_MAX_ROUTES; i++) {
 		struct net_nbr *nbr = get_nbr(i);
@@ -150,24 +149,23 @@ struct net_nbr *net_route_get_nbr(struct net_route_entry *route)
 
 		if (nbr->data == (uint8_t *)route) {
 			if (!nbr->ref) {
-				k_mutex_unlock(&lock);
-				return NULL;
+				break;
 			}
 
-			k_mutex_unlock(&lock);
-			return nbr;
+			ret = nbr;
+			break;
 		}
 	}
 
-	k_mutex_unlock(&lock);
-	return NULL;
+	net_ipv6_nbr_unlock();
+	return ret;
 }
 
 void net_routes_print(void)
 {
 	int i;
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_ipv6_nbr_lock();
 
 	for (i = 0; i < CONFIG_NET_MAX_ROUTES; i++) {
 		struct net_nbr *nbr = get_nbr(i);
@@ -188,7 +186,7 @@ void net_routes_print(void)
 				net_nbr_get_lladdr(nbr->idx)->len));
 	}
 
-	k_mutex_unlock(&lock);
+	net_ipv6_nbr_unlock();
 }
 
 static inline void nbr_free(struct net_nbr *nbr)
@@ -255,7 +253,6 @@ static int nbr_nexthop_put(struct net_nbr *nbr)
 	return 0;
 }
 
-
 #define net_route_info(str, route, dst)					\
 	do {								\
 	if (CONFIG_NET_ROUTE_LOG_LEVEL >= LOG_LEVEL_DBG) {		\
@@ -283,7 +280,7 @@ struct net_route_entry *net_route_lookup(struct net_if *iface,
 	uint8_t longest_match = 0U;
 	int i;
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_ipv6_nbr_lock();
 
 	for (i = 0; i < CONFIG_NET_MAX_ROUTES && longest_match < 128; i++) {
 		struct net_nbr *nbr = get_nbr(i);
@@ -313,7 +310,7 @@ struct net_route_entry *net_route_lookup(struct net_if *iface,
 		update_route_access(found);
 	}
 
-	k_mutex_unlock(&lock);
+	net_ipv6_nbr_unlock();
 	return found;
 }
 
@@ -354,7 +351,7 @@ struct net_route_entry *net_route_add(struct net_if *iface,
 		return NULL;
 	}
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_ipv6_nbr_lock();
 
 	nbr_nexthop = net_ipv6_nbr_lookup(iface, nexthop);
 	if (!nbr_nexthop) {
@@ -479,7 +476,7 @@ struct net_route_entry *net_route_add(struct net_if *iface,
 #endif
 
 exit:
-	k_mutex_unlock(&lock);
+	net_ipv6_nbr_unlock();
 	return route;
 }
 
@@ -502,7 +499,7 @@ static void route_lifetime_timeout(struct k_work *work)
 
 	ARG_UNUSED(work);
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_ipv6_nbr_lock();
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&active_route_lifetime_timers,
 					  current, next, lifetime.node) {
@@ -524,7 +521,7 @@ static void route_lifetime_timeout(struct k_work *work)
 		k_work_reschedule(&route_lifetime_timer, K_MSEC(next_update));
 	}
 
-	k_mutex_unlock(&lock);
+	net_ipv6_nbr_unlock();
 }
 
 void net_route_update_lifetime(struct net_route_entry *route, uint32_t lifetime)
@@ -537,7 +534,7 @@ void net_route_update_lifetime(struct net_route_entry *route, uint32_t lifetime)
 		return;
 	}
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_ipv6_nbr_lock();
 
 	if (lifetime == NET_IPV6_ND_INFINITE_LIFETIME) {
 		route->is_infinite = true;
@@ -556,7 +553,7 @@ void net_route_update_lifetime(struct net_route_entry *route, uint32_t lifetime)
 		k_work_reschedule(&route_lifetime_timer, K_NO_WAIT);
 	}
 
-	k_mutex_unlock(&lock);
+	net_ipv6_nbr_unlock();
 }
 
 int net_route_del(struct net_route_entry *route)
@@ -571,7 +568,7 @@ int net_route_del(struct net_route_entry *route)
 		return -EINVAL;
 	}
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_ipv6_nbr_lock();
 
 #if defined(CONFIG_NET_MGMT_EVENT_INFO)
 	net_ipaddr_copy(&info.addr, &route->addr);
@@ -599,7 +596,7 @@ int net_route_del(struct net_route_entry *route)
 
 	nbr = net_route_get_nbr(route);
 	if (!nbr) {
-		k_mutex_unlock(&lock);
+		net_ipv6_nbr_unlock();
 		return -ENOENT;
 	}
 
@@ -616,7 +613,7 @@ int net_route_del(struct net_route_entry *route)
 
 	nbr_free(nbr);
 
-	k_mutex_unlock(&lock);
+	net_ipv6_nbr_unlock();
 	return 0;
 }
 
@@ -630,7 +627,7 @@ int net_route_del_by_nexthop(struct net_if *iface, struct in6_addr *nexthop)
 	NET_ASSERT(iface);
 	NET_ASSERT(nexthop);
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_ipv6_nbr_lock();
 
 	nbr_nexthop = net_ipv6_nbr_lookup(iface, nexthop);
 
@@ -657,7 +654,7 @@ int net_route_del_by_nexthop(struct net_if *iface, struct in6_addr *nexthop)
 		}
 	}
 
-	k_mutex_unlock(&lock);
+	net_ipv6_nbr_unlock();
 
 	if (count) {
 		return count;
@@ -680,11 +677,11 @@ int net_route_del_by_nexthop_data(struct net_if *iface,
 	NET_ASSERT(iface);
 	NET_ASSERT(nexthop);
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_ipv6_nbr_lock();
 
 	nbr_nexthop = net_ipv6_nbr_lookup(iface, nexthop);
 	if (!nbr_nexthop) {
-		k_mutex_unlock(&lock);
+		net_ipv6_nbr_unlock();
 		return -EINVAL;
 	}
 
@@ -723,7 +720,7 @@ int net_route_del_by_nexthop_data(struct net_if *iface,
 		}
 	}
 
-	k_mutex_unlock(&lock);
+	net_ipv6_nbr_unlock();
 
 	if (count) {
 		return count;
@@ -741,7 +738,7 @@ struct in6_addr *net_route_get_nexthop(struct net_route_entry *route)
 		return NULL;
 	}
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_ipv6_nbr_lock();
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&route->nexthop, nexthop_route, node) {
 		struct in6_addr *addr;
@@ -751,14 +748,14 @@ struct in6_addr *net_route_get_nexthop(struct net_route_entry *route)
 			addr = &ipv6_nbr_data->addr;
 			NET_ASSERT(addr);
 
-			k_mutex_unlock(&lock);
+			net_ipv6_nbr_unlock();
 			return addr;
 		} else {
 			NET_ERR("could not get neighbor data from next hop");
 		}
 	}
 
-	k_mutex_unlock(&lock);
+	net_ipv6_nbr_unlock();
 	return NULL;
 }
 
@@ -766,7 +763,7 @@ int net_route_foreach(net_route_cb_t cb, void *user_data)
 {
 	int i, ret = 0;
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_ipv6_nbr_lock();
 
 	for (i = 0; i < CONFIG_NET_MAX_ROUTES; i++) {
 		struct net_route_entry *route;
@@ -791,7 +788,7 @@ int net_route_foreach(net_route_cb_t cb, void *user_data)
 		ret++;
 	}
 
-	k_mutex_unlock(&lock);
+	net_ipv6_nbr_unlock();
 	return ret;
 }
 
@@ -876,13 +873,13 @@ struct net_route_entry_mcast *net_route_mcast_add(struct net_if *iface,
 {
 	int i;
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_ipv6_nbr_lock();
 
 	if ((!net_if_flag_is_set(iface, NET_IF_FORWARD_MULTICASTS)) ||
 			(!net_ipv6_is_addr_mcast(group)) ||
 			(net_ipv6_is_addr_mcast_iface(group)) ||
 			(net_ipv6_is_addr_mcast_link(group))) {
-		k_mutex_unlock(&lock);
+		net_ipv6_nbr_unlock();
 		return NULL;
 	}
 
@@ -896,12 +893,12 @@ struct net_route_entry_mcast *net_route_mcast_add(struct net_if *iface,
 			route->iface = iface;
 			route->is_used = true;
 
-			k_mutex_unlock(&lock);
+			net_ipv6_nbr_unlock();
 			return route;
 		}
 	}
 
-	k_mutex_unlock(&lock);
+	net_ipv6_nbr_unlock();
 	return NULL;
 }
 
@@ -952,7 +949,7 @@ bool net_route_get_info(struct net_if *iface,
 	struct net_if_router *router;
 	bool ret = false;
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_ipv6_nbr_lock();
 
 	/* Search in neighbor table first, if not search in routing table. */
 	if (net_ipv6_nbr_lookup(iface, dst)) {
@@ -989,7 +986,7 @@ bool net_route_get_info(struct net_if *iface,
 	}
 
 exit:
-	k_mutex_unlock(&lock);
+	net_ipv6_nbr_unlock();
 	return ret;
 }
 
@@ -999,7 +996,7 @@ int net_route_packet(struct net_pkt *pkt, struct in6_addr *nexthop)
 	struct net_nbr *nbr;
 	int err;
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_ipv6_nbr_lock();
 
 	nbr = net_ipv6_nbr_lookup(NULL, nexthop);
 	if (!nbr) {
@@ -1066,11 +1063,11 @@ int net_route_packet(struct net_pkt *pkt, struct in6_addr *nexthop)
 
 	net_pkt_set_iface(pkt, nbr->iface);
 
-	k_mutex_unlock(&lock);
+	net_ipv6_nbr_unlock();
 	return net_send_data(pkt);
 
 error:
-	k_mutex_unlock(&lock);
+	net_ipv6_nbr_unlock();
 	return err;
 }
 


### PR DESCRIPTION
Currently, the only thread-safe part of the IPv6 Neighbor processing implementation are stale_counter related operation.

Fix this, by extending the mutex protection over all of the module, so that message handlers, timers and API functions do not interfere with each other.

As IPv6 Neighbor cache is tightly coupled with the Routing module, use the same mutex to protect both, neighbor and routing tables, to prevent deadlocks.

Also, replace the semaphore used with a mutex, as it seems more fit for this particular job.

Fixes #68229