### PR TITLE
doc: drivers: mipi-dbi: detail write-only and duplex options

### DIFF
--- a/dts/bindings/mipi-dbi/mipi-dbi-spi-device.yaml
+++ b/dts/bindings/mipi-dbi/mipi-dbi-spi-device.yaml
@@ -12,6 +12,8 @@ properties:
     description: |
       SPI Duplex mode, full or half. By default it's always full duplex thus 0
       as this is, by far, the most common mode.
+      Selecting half duplex allows to use SPI MOSI as a bidirectional line,
+      typically used when only one data line is connected.
       Use the macros not the actual enum value, here is the concordance
       list (see dt-bindings/spi/spi.h)
         0    SPI_FULL_DUPLEX

--- a/dts/bindings/mipi-dbi/zephyr,mipi-dbi-spi.yaml
+++ b/dts/bindings/mipi-dbi/zephyr,mipi-dbi-spi.yaml
@@ -31,5 +31,8 @@ properties:
   write-only:
     type: boolean
     description: |
-      Controller is not readable, IE only DOUT pin is connected on the SPI
-      interface.
+      Only writes to display controller, do not perform reads.
+      If all controllers are write-only, read functions will be
+      optimized out for size.
+      It can also be used as an alternative to half duplex when
+      only one data line is connected.


### PR DESCRIPTION
Add clarifications to mipi-dbi bindings to avoid the confusion between two options, write-only and duplex.