### PR TITLE
doc: release-notes/migration-guide/3.6: I3C, PCIe, UART, Userspace and Xtensa

### DIFF
--- a/doc/releases/migration-guide-3.6.rst
+++ b/doc/releases/migration-guide-3.6.rst
@@ -634,6 +634,25 @@ Xtensa
 * :kconfig:option:`CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC` no longer has a default in
   the architecture layer. Instead, SoCs or boards will need to define it.
 
+* Scratch registers ``ZSR_ALLOCA`` has been renamed to ``ZSR_A0SAVE``.
+
+* Renamed files with hyhphens to underscores:
+
+  * ``xtensa-asm2-context.h`` to ``xtensa_asm2_context.h``
+
+  * ``xtensa-asm2-s.h`` to ``xtensa_asm2_s.h``
+
+* ``xtensa_asm2.h`` has been removed. Use ``xtensa_asm2_context.h`` instead for
+  stack frame structs.
+
+* Renamed functions out of ``z_`` namespace into ``xtensa_`` namespace.
+
+  * ``z_xtensa_irq_enable`` to :c:func:`xtensa_irq_enable`
+
+  * ``z_xtensa_irq_disable`` to :c:func:`xtensa_irq_disable`
+
+  * ``z_xtensa_irq_is_enabled`` to :c:func:`xtensa_irq_is_enabled`
+
 Recommended Changes
 *******************
 

--- a/doc/releases/migration-guide-3.6.rst
+++ b/doc/releases/migration-guide-3.6.rst
@@ -591,6 +591,43 @@ Other Subsystems
   zbus options are renamed. Instead, the new :kconfig:option:`ZBUS_MSG_SUBSCRIBER_BUF_ALLOC_DYNAMIC`
   and :kconfig:option:`ZBUS_MSG_SUBSCRIBER_BUF_ALLOC_STATIC` options should be used.
 
+Userspace
+=========
+
+* A number of userspace related functions have been moved out of the ``z_`` namespace
+  and into the kernel namespace.
+
+  * ``Z_OOPS`` to :c:macro:`K_OOPS`
+  * ``Z_SYSCALL_MEMORY`` to :c:macro:`K_SYSCALL_MEMORY`
+  * ``Z_SYSCALL_MEMORY_READ`` to :c:macro:`K_SYSCALL_MEMORY_READ`
+  * ``Z_SYSCALL_MEMORY_WRITE`` to :c:macro:`K_SYSCALL_MEMORY_WRITE`
+  * ``Z_SYSCALL_DRIVER_OP`` to :c:macro:`K_SYSCALL_DRIVER_OP`
+  * ``Z_SYSCALL_SPECIFIC_DRIVER`` to :c:macro:`K_SYSCALL_SPECIFIC_DRIVER`
+  * ``Z_SYSCALL_OBJ`` to :c:macro:`K_SYSCALL_OBJ`
+  * ``Z_SYSCALL_OBJ_INIT`` to :c:macro:`K_SYSCALL_OBJ_INIT`
+  * ``Z_SYSCALL_OBJ_NEVER_INIT`` to :c:macro:`K_SYSCALL_OBJ_NEVER_INIT`
+  * ``z_user_from_copy`` to :c:func:`k_usermode_from_copy`
+  * ``z_user_to_copy`` to :c:func:`k_usermode_to_copy`
+  * ``z_user_string_copy`` to :c:func:`k_usermode_string_copy`
+  * ``z_user_string_alloc_copy`` to :c:func:`k_usermode_string_alloc_copy`
+  * ``z_user_alloc_from_copy```` to :c:func:`k_usermode_alloc_from_copy`
+  * ``z_user_string_nlen`` to :c:func:`k_usermode_string_nlen`
+  * ``z_dump_object_error`` to :c:func:`k_object_dump_error`
+  * ``z_object_validate`` to :c:func:`k_object_validate`
+  * ``z_object_find`` to :c:func:`k_object_find`
+  * ``z_object_wordlist_foreach`` to :c:func:`k_object_wordlist_foreach`
+  * ``z_thread_perms_inherit`` to :c:func:`k_thread_perms_inherit`
+  * ``z_thread_perms_set`` to :c:func:`k_thread_perms_set`
+  * ``z_thread_perms_clear`` to :c:func:`k_thread_perms_clear`
+  * ``z_thread_perms_all_clear`` to :c:func:`k_thread_perms_all_clear`
+  * ``z_object_uninit`` to :c:func:`k_object_uninit`
+  * ``z_object_recycle`` to :c:func:`k_object_recycle`
+  * ``z_obj_validation_check`` to :c:func:`k_object_validation_check`
+  * ``Z_SYSCALL_VERIFY_MSG`` to :c:macro:`K_SYSCALL_VERIFY_MSG`
+  * ``z_object`` to :c:struct:`k_object`
+  * ``z_object_init`` to :c:func:`k_object_init`
+  * ``z_dynamic_object_aligned_create`` to :c:func:`k_object_create_dynamic_aligned`
+
 Xtensa
 ======
 

--- a/doc/releases/release-notes-3.6.rst
+++ b/doc/releases/release-notes-3.6.rst
@@ -39,6 +39,8 @@ Architectures
 
   * Removed the unused Kconfig option ``CONFIG_XTENSA_NO_IPC``.
 
+  * Added userspace support via MMU.
+
 * x86
 
 * POSIX

--- a/doc/releases/release-notes-3.6.rst
+++ b/doc/releases/release-notes-3.6.rst
@@ -266,6 +266,34 @@ Drivers and Sensors
   * The Legacy Virtual Register defines have been renamed from ``I3C_DCR_I2C_*``
     to ``I3C_LVR_I2C_*``.
 
+  * Added the ability to specify a start address when searching for a free I3C
+    address to be reserved. This requires a new function argument to
+    :c:func:`i3c_addr_slots_next_free_find`.
+
+  * Added a field named ``num_xfer`` in :c:struct:`i3c_msg` and
+    :c:struct:`i3c_ccc_taget_payload` as an output to indicate the actual
+    number of bytes transferred.
+
+  * Cadence I3C driver (:file:`drivers/i3c/i3c_cdns.c`):
+
+    * Added support to handle controller abort where target does not emit
+      end of data for register read but continues sending data.
+
+    * Updated the timeout calculation to be coupled with CPU speed instead of
+      a fixed number of retries.
+
+  * NXP MCUX I3C driver (:file:`drivers/i3c/i3c_mcux.c`):
+
+    * Fixed ``mcux_i3c_config_get()`` of not returning the configuration to caller.
+
+    * Sped up the FIFO read routine to support higher transfer rate.
+
+    * Removed the infinite wait for MCTRLDONE in auto IBI.
+
+    * Added ``disable-open-drain-high-pp`` property to
+      :dtcompatible:`nxp,mcux-i3c`, which allows alternative high time for
+      open-drain clock.
+
 * IEEE 802.15.4
 
   * Removed :kconfig:option:`CONFIG_IEEE802154_SELECTIVE_TXPOWER` Kconfig option.

--- a/doc/releases/release-notes-3.6.rst
+++ b/doc/releases/release-notes-3.6.rst
@@ -318,6 +318,10 @@ Drivers and Sensors
 
 * PCIE
 
+  * Fixed MMIO size calculation by disabling IO/memory decoding beforehand.
+
+  * Modified to use PNP ID for PRT retrieval.
+
 * ACPI
 
 * Pin control

--- a/doc/releases/release-notes-3.6.rst
+++ b/doc/releases/release-notes-3.6.rst
@@ -351,7 +351,30 @@ Drivers and Sensors
 
 * Serial
 
-  * Renamed ``CONFIG_UART_RA`` to :kconfig:option:`CONFIG_UART_RENESAS_RA`
+  * Added drivers to support UART on Renesas RA and RZ/T2M.
+
+  * Added support for higher baud rate for ITE IT8xxx2.
+
+  * Added driver to support Intel Lightweight UART.
+
+  * Added UART asynchronous RX helper.
+
+  * Added support for async API on NS16550 driver.
+
+  * Updated ``uart_esp32`` to use serial port configuration from devicetree.
+
+  * Added an adaptation API to provide interrupt driven API for drivers
+    which have only implemented async API.
+
+  * Emulated UART driver (:file:`drivers/serial/uart_emul.c`):
+
+    * Added emulated interrupt based TX.
+
+    * Added emulated error for testing.
+
+    * Modified to use local work queue for data transfer.
+
+    * Modified FIFO size and its handling to be more aligned with real hardware.
 
 * SPI
 


### PR DESCRIPTION
* doc: release-notes/migration-guide/3.6: add bits on Xtensa
* docs: migration-guide-3.6: notes about userspace funcs renaming
* doc: release-notes/3.6: add some bits about UART
* doc: release-notes/3.6: add some bits about PCIe
* doc: release-notes/3.6: add some bits about I3C