### PR TITLE
build: gen_isr_tables.py: fix bad IRQ index computation for L3 interrupts

### DIFF
--- a/scripts/build/gen_isr_tables.py
+++ b/scripts/build/gen_isr_tables.py
@@ -200,7 +200,7 @@ class gen_isr_config:
         irq1 = irq & self.int_lvl_masks[0]
         # Figure out third level interrupt position
         if irq3:
-            list_index = self.get_irq_index(irq2, 3)
+            list_index = self.get_irq_index(irq2 - 1, 3)
             irq3_pos = self.get_irq_baseoffset(3) + self.__max_irq_per * list_index + irq3 - 1
             self.__log.debug('IRQ_level = 3')
             self.__log.debug('IRQ_Indx = ' + str(irq3))


### PR DESCRIPTION
According to the Zephyr documentation, the multi-level interrupts are encoded as follows:
	`L1_ID | ((L2_ID + 1) << L2_BITS) | ((L3_ID + 1) << (L3_BITS + L2_BITS))`
This means that when L3 interrupts are enabled, the gen_isr_table.py script will receive the value of L2_ID + 1. Currently, the script takes this value and directly compares it with the offsets set via `CONFIG_3RD_LVL_INTR_xx_OFFSET`. This is wrong because the values from said configurations are the same as L2_ID and because of that the script will generate an error. To fix this, use the value of L2_ID instead of L2_ID + 1.

To test this out simply enable L2 and L3 interrupts and statically connect an L3 interrupt. The build should break.