### PR TITLE
Fix example in sparkfun,serlcd.yaml

### DIFF
--- a/dts/bindings/auxdisplay/sparkfun,serlcd.yaml
+++ b/dts/bindings/auxdisplay/sparkfun,serlcd.yaml
@@ -11,8 +11,8 @@ description: |
         reg = <0x72>;
         columns = <16>;
         rows = <2>;
-        command-delay = <10>;
-        special-command-delay = <50>;
+        command-delay-ms = <10>;
+        special-command-delay-ms = <50>;
       };
     };
 


### PR DESCRIPTION
fix documentation to include `-ms`