### PR TITLE
devicetree.h: switch to DT_IRQ_INTC_BY_IDX for L2 and L3 INTID encodings

### DIFF
--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -2549,12 +2549,13 @@
 #define DT_IRQN_L1_INTERNAL(node_id, idx) DT_IRQ_BY_IDX(node_id, idx, irq)
 /* DT helper macro to encode a node's IRQN to level 2 according to the multi-level scheme */
 #define DT_IRQN_L2_INTERNAL(node_id, idx)                                                          \
-	(IRQ_TO_L2(DT_IRQN_L1_INTERNAL(node_id, idx)) | DT_IRQ(DT_IRQ_INTC(node_id), irq))
+	(IRQ_TO_L2(DT_IRQN_L1_INTERNAL(node_id, idx)) |                                            \
+	 DT_IRQ(DT_IRQ_INTC_BY_IDX(node_id, idx), irq))
 /* DT helper macro to encode a node's IRQN to level 3 according to the multi-level scheme */
 #define DT_IRQN_L3_INTERNAL(node_id, idx)                                                          \
 	(IRQ_TO_L3(DT_IRQN_L1_INTERNAL(node_id, idx)) |                                            \
-	 IRQ_TO_L2(DT_IRQ(DT_IRQ_INTC(node_id), irq)) |                                            \
-	 DT_IRQ(DT_IRQ_INTC(DT_IRQ_INTC(node_id)), irq))
+	 IRQ_TO_L2(DT_IRQ(DT_IRQ_INTC_BY_IDX(node_id, idx), irq)) |                                \
+	 DT_IRQ(DT_IRQ_INTC(DT_IRQ_INTC_BY_IDX(node_id, idx)), irq))
 /* DT helper macro for the macros above */
 #define DT_IRQN_LVL_INTERNAL(node_id, idx, level) DT_CAT3(DT_IRQN_L, level, _INTERNAL)(node_id, idx)
 

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -440,6 +440,19 @@
 			interrupt-parent = <&test_cpu_intc>;
 		};
 
+		/* same as `test_intc` but extends a different L1 interrupt.
+		 * Required for testing if interrupts are encoded properly for
+		 * nodes consuming interrupts from different aggregators.
+		 */
+		test_intc2: interrupt-controller@bbbbdccc {
+			compatible = "vnd,intc";
+			reg = <0xbbbbdccc 0x1000>;
+			interrupt-controller;
+			#interrupt-cells = <2>;
+			interrupts = <12 0>;
+			interrupt-parent = <&test_cpu_intc>;
+		};
+
 		/* there should only be one of these */
 		test_irq: interrupt-holder {
 			compatible = "vnd,interrupt-holder";
@@ -454,8 +467,9 @@
 			compatible = "vnd,interrupt-holder-extended";
 			status = "okay";
 			interrupts-extended = <&test_intc 70 7>,
-					      <&test_gpio_4 30 3>;
-			interrupt-names = "int1", "int2";
+					      <&test_gpio_4 30 3>,
+					      <&test_intc2 42 7>;
+			interrupt-names = "int1", "int2", "int3";
 		};
 
 		test_fixed_clk: test-fixed-clock {

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -750,6 +750,20 @@ ZTEST(devicetree_api, test_irq)
 	zassert_true(DT_INST_IRQ_HAS_NAME(0, stat), "");
 	zassert_true(DT_INST_IRQ_HAS_NAME(0, done), "");
 	zassert_false(DT_INST_IRQ_HAS_NAME(0, alpha), "");
+
+#ifdef CONFIG_MULTI_LEVEL_INTERRUPTS
+	/* the following asserts check if interrupt IDs are encoded
+	 * properly when dealing with a node that consumes interrupts
+	 * from L2 aggregators extending different L1 interrupts.
+	 */
+	zassert_equal(DT_IRQN_BY_IDX(TEST_IRQ_EXT, 0),
+		      ((70 + 1) << CONFIG_1ST_LEVEL_INTERRUPT_BITS) | 11, "");
+	zassert_equal(DT_IRQN_BY_IDX(TEST_IRQ_EXT, 2),
+		      ((42 + 1) << CONFIG_1ST_LEVEL_INTERRUPT_BITS) | 12, "");
+#else
+	zassert_equal(DT_IRQN_BY_IDX(TEST_IRQ_EXT, 0), 70, "");
+	zassert_equal(DT_IRQN_BY_IDX(TEST_IRQ_EXT, 2), 42, "");
+#endif /* CONFIG_MULTI_LEVEL_INTERRUPTS */
 }
 
 ZTEST(devicetree_api, test_irq_level)


### PR DESCRIPTION
Using `DT_IRQ_INTC()` to fetch the interrupt controller associated with a node works well for nodes which consume interrupts from a single aggregator. However, when specifying multiple (and different) interrupt aggregators via the `interrupts-extended` property, the L2 and L3 interrupts will no longer be encoded properly. This is because `DT_IRQ_INTC(node_id)` uses `DT_IRQ_INTC_BY_IDX(node_id, 0)` so all the interrupts will use the first aggregator as their parent. To fix this, switch from using `DT_IRQ_INTC()` to `DT_IRQ_INTC_BY_IDX()`.

This can be tested using configurations such as the following:

```
intc1: interrupt-controller@cafebabe {
    /* some more properties here */
    interrupt-controller;
    #interrupt-cells = <1>;
};

intc2: interrupt-controller@deadbeef {
     /* some more properties here */
    interrupt-controller;
    interrupts-extended = <&intc1 14>;
};

intc3: interruptc-controller@babebeef {
     /* some more properties here */
    interrupt-controller;
    interrupts-extended = <&intc1 15>;
};

consumer_node: ip@cafecafe {
    /* some more properties here */
    interrupts-extended = <&intc2 16>, <&intc3 15>;
};

```

Without this patch the interrupts from `consumer_node` will be encoded as follows: `14 | ((16 + 1) << 8)` and `14 | ((15 + 1) << 8)`

Fixes #69820