### PR TITLE
boards: mimxrt1040_evk: Fix typo in CMakeLists.txt

### DIFF
--- a/boards/arm/mimxrt1040_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1040_evk/CMakeLists.txt
@@ -21,7 +21,7 @@ if(CONFIG_NXP_IMX_RT_BOOT_HEADER)
     zephyr_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)
     zephyr_compile_definitions(BOARD_FLASH_SIZE=CONFIG_FLASH_SIZE*1024)
     zephyr_library_sources(${RT1040_BOARD_DIR}/xip/evkmimxrt1040_flexspi_nor_config.c)
-    zephyr_library_include_directories(${RT1024_BOARD_DIR}/xip)
+    zephyr_library_include_directories(${RT1040_BOARD_DIR}/xip)
   endif()
   if(CONFIG_DEVICE_CONFIGURATION_DATA)
     # Include device configuration data block for RT1040 EVK from NXP's HAL.


### PR DESCRIPTION
Fix typo of board dir variable in CMakeLists.txt

Fixes #68786