### PR TITLE
net: ipv6: Allow user to configure the IPv6 MTU size

### DIFF
--- a/include/zephyr/net/net_ip.h
+++ b/include/zephyr/net/net_ip.h
@@ -410,7 +410,11 @@ enum net_ip_mtu {
 	/** IPv6 MTU length. We must be able to receive this size IPv6 packet
 	 * without fragmentation.
 	 */
+#if defined(CONFIG_NET_NATIVE_IPV6)
+	NET_IPV6_MTU = CONFIG_NET_IPV6_MTU,
+#else
 	NET_IPV6_MTU = 1280,
+#endif
 
 	/** IPv4 MTU length. We must be able to receive this size IPv4 packet
 	 * without fragmentation.

--- a/subsys/net/ip/Kconfig.ipv6
+++ b/subsys/net/ip/Kconfig.ipv6
@@ -39,6 +39,14 @@ config NET_IF_IPV6_PREFIX_COUNT
 
 if NET_NATIVE_IPV6
 
+config NET_IPV6_MTU
+	int "Initial IPv6 MTU value"
+	default 1280
+	range 1280 1500
+	help
+	  The value should normally be 1280 which is the minimum IPv6 packet
+	  size that implementations need to support without fragmentation.
+
 config NET_INITIAL_HOP_LIMIT
 	int "Initial IPv6 hop limit value for unicast packets"
 	default 64


### PR DESCRIPTION
This makes it possible to set the minimum IPv6 packet size that can be sent without fragmentation. The default value is 1280 bytes. This commit allows user to set the IPv6 MTU value within reasonable limits [1280, 1500].

Fixes #61587