### PR TITLE
drivers: counter: maxim_ds3231: Fix coverity issues

### DIFF
--- a/drivers/counter/maxim_ds3231.c
+++ b/drivers/counter/maxim_ds3231.c
@@ -92,8 +92,6 @@ struct ds3231_data {
 	struct maxim_ds3231_syncpoint syncpoint;
 	struct maxim_ds3231_syncpoint new_sp;
 
-	time_t rtc_registers;
-	time_t rtc_base;
 	uint32_t syncclock_base;
 
 	/* Pointer to the structure used to notify when a synchronize
@@ -432,8 +430,7 @@ static uint32_t decode_rtc(struct ds3231_data *data)
 		tm.tm_year += 100;
 	}
 
-	data->rtc_registers = timeutil_timegm(&tm);
-	return data->rtc_registers;
+	return timeutil_timegm(&tm);
 }
 
 static int update_registers(const struct device *dev)
@@ -451,7 +448,6 @@ static int update_registers(const struct device *dev)
 	if (rc < 0) {
 		return rc;
 	}
-	data->rtc_base = decode_rtc(data);
 
 	return 0;
 }


### PR DESCRIPTION
maxim_ds3231 driver stores the current time in a 64-bit time_t variable before casting it to an unsigned 32-bit integer, resulting in CWE-197 numeric truncation violations. Since counter API cannot return 64-bit values, work around these violations by explicitly performing the truncations.

Fixes #59546
Fixes #59545
Fixes #59543
Fixes #59542
Fixes #59537