### PR TITLE
drivers: dma: dma_nxp_edma: allow channel re-configuration

### DIFF
--- a/drivers/dma/dma_nxp_edma.h
+++ b/drivers/dma/dma_nxp_edma.h
@@ -241,7 +241,8 @@ static inline int channel_change_state(struct edma_channel *chan,
 		}
 		break;
 	case CHAN_STATE_CONFIGURED:
-		if (next != CHAN_STATE_STARTED) {
+		if (next != CHAN_STATE_STARTED &&
+		    next != CHAN_STATE_CONFIGURED) {
 			return -EPERM;
 		}
 		break;


### PR DESCRIPTION
Currently, the state transition function doesn't allow the re-configuration of an already configured channel (i.e: CHAN_CONFIGURED -> CHAN_CONFIGURED transition). This causes problems when using `pulseaudio` and `SOF` because the same channel ends up being configured multiple times in the beginning due to how pulse seems to work. Logically speaking, re-configuring an already configured channel is not wrong so this commit solves the issue by allowing the CHAN_CONFIGURED -> CHAN_CONFIGURED transition.