### PR TITLE
thrift: null-terminate certificates in samples and tests

### DIFF
--- a/samples/modules/thrift/hello/client/src/main.cpp
+++ b/samples/modules/thrift/hello/client/src/main.cpp
@@ -78,14 +78,17 @@ int main(int argc, char **argv)
 #ifdef __ZEPHYR__
 		static const char qemu_cert_pem[] = {
 #include "qemu_cert.pem.inc"
+			'\0'
 		};
 
 		static const char qemu_key_pem[] = {
 #include "qemu_key.pem.inc"
+			'\0'
 		};
 
 		static const char native_cert_pem[] = {
 #include "native_cert.pem.inc"
+			'\0'
 		};
 
 		socketFactory->loadCertificateFromBuffer(qemu_cert_pem);

--- a/samples/modules/thrift/hello/server/src/main.cpp
+++ b/samples/modules/thrift/hello/server/src/main.cpp
@@ -80,14 +80,17 @@ int main(int argc, char **argv)
 #ifdef __ZEPHYR__
 		static const char qemu_cert_pem[] = {
 #include "qemu_cert.pem.inc"
+			'\0'
 		};
 
 		static const char qemu_key_pem[] = {
 #include "qemu_key.pem.inc"
+			'\0'
 		};
 
 		static const char native_cert_pem[] = {
 #include "native_cert.pem.inc"
+			'\0'
 		};
 
 		socketFactory->loadCertificateFromBuffer(qemu_cert_pem);

--- a/tests/modules/thrift/ThriftTest/src/main.cpp
+++ b/tests/modules/thrift/ThriftTest/src/main.cpp
@@ -29,9 +29,11 @@ ctx context;
 static K_THREAD_STACK_DEFINE(ThriftTest_server_stack, CONFIG_THRIFTTEST_SERVER_STACK_SIZE);
 static const char cert_pem[] = {
 #include "qemu_cert.pem.inc"
+	'\0'
 };
 static const char key_pem[] = {
 #include "qemu_key.pem.inc"
+	'\0'
 };
 
 static void *server_func(void *arg)


### PR DESCRIPTION
The thrift methods `loadCertificateFromBuffer()`, `loadPrivateKeyFromBuffer()`, and `loadTrustedCertificatesFromBuffer()` expect a null-terminated string.

Append `'\0'` to each array used to hold a certificate in thrift samples and tests.

Fixes #68755