### PR TITLE
wifi: shell: added NULL check to net_mgmt callback

### DIFF
--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -404,6 +404,10 @@ static void handle_wifi_ap_sta_disconnected(struct net_mgmt_event_callback *cb)
 static void wifi_mgmt_event_handler(struct net_mgmt_event_callback *cb,
 				    uint32_t mgmt_event, struct net_if *iface)
 {
+	if (context.sh == NULL) {
+		return;
+	}
+
 	switch (mgmt_event) {
 	case NET_EVENT_WIFI_SCAN_RESULT:
 		handle_wifi_scan_result(cb);


### PR DESCRIPTION
By default variable context.sh is set to NULL. If any net_mgmt event will be called when the variable has default value, there will be a system exception.

This will happen if any shell command is not called before the first wifi event. 
Fixing following crash
```
[00:00:16.320,000] <err> os: ***** BUS FAULT *****
[00:00:16.320,000] <err> os:   Precise data bus error
[00:00:16.320,000] <err> os:   BFAR Address: 0x8
[00:00:16.320,000] <err> os: r0/a1:  0x00000000  r1/a2:  0x00000008  r2/a3:  0x081004d8
[00:00:16.320,000] <err> os: r3/a4:  0x2003006c r12/ip:  0x0807d46d r14/lr:  0x0809bc7b
[00:00:16.320,000] <err> os:  xpsr:  0x61000000
[00:00:16.320,000] <err> os: s[ 0]:  0x00000006  s[ 1]:  0x00000010  s[ 2]:  0x00000010  s[ 3]:  0x080b054d
[00:00:16.320,000] <err> os: s[ 4]:  0x2000a2b8  s[ 5]:  0x00000010  s[ 6]:  0x2000ab80  s[ 7]:  0x080afd77
[00:00:16.320,000] <err> os: s[ 8]:  0x00000000  s[ 9]:  0x08050207  s[10]:  0x2000aca0  s[11]:  0x20030078
[00:00:16.320,000] <err> os: s[12]:  0x00000000  s[13]:  0x00002710  s[14]:  0x2000aca0  s[15]:  0x20030078
[00:00:16.320,000] <err> os: fpscr:  0x000000e5
[00:00:16.320,000] <err> os: Faulting instruction address (r15/pc): 0x0809bbe4
[00:00:16.320,000] <err> os: >>> ZEPHYR FATAL ERROR 25: Unknown error on CPU 0
[00:00:16.320,000] <err> os: Current thread: 0x2000ebe8 (net_mgmt)
[00:00:16.379,000] <err> tu_assert: Reboting system
```