### PR TITLE
[hwm2] ci: update check_compliance to not create duplicate lines in Kconfig

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -431,17 +431,18 @@ class KconfigCheck(ComplianceTest):
         root_args = argparse.Namespace(**{'soc_roots': [Path(ZEPHYR_BASE)]})
         v2_systems = list_hardware.find_v2_systems(root_args)
 
+        soc_folders = {soc.folder for soc in v2_systems.get_socs()}
         with open(kconfig_defconfig_file, 'w') as fp:
-            for soc in v2_systems.get_socs():
-                fp.write('osource "' + os.path.join(soc.folder, 'Kconfig.defconfig') + '"\n')
+            for folder in soc_folders:
+                fp.write('osource "' + os.path.join(folder, 'Kconfig.defconfig') + '"\n')
 
         with open(kconfig_soc_file, 'w') as fp:
-            for soc in v2_systems.get_socs():
-                fp.write('source "' + os.path.join(soc.folder, 'Kconfig.soc') + '"\n\n')
+            for folder in soc_folders:
+                fp.write('source "' + os.path.join(folder, 'Kconfig.soc') + '"\n')
 
         with open(kconfig_file, 'w') as fp:
-            for soc in v2_systems.get_socs():
-                fp.write('source "' + os.path.join(soc.folder, 'Kconfig') + '"\n')
+            for folder in soc_folders:
+                fp.write('source "' + os.path.join(folder, 'Kconfig') + '"\n')
 
         kconfig_file = os.path.join(kconfig_dir, 'arch', 'Kconfig')
 


### PR DESCRIPTION
check_compliance generates Kconfig files for sourcing board and soc Kconfig tree in order to run compliance.

Each board and soc generated a source entry, however several socs are using same soc dir and thus multiple identical source lines where created.

Use a set() to ensure unique lines before generating Kconfig files. This ensures that each Kconfig file is only sourced once. This improves both compliance as fewer lines needs to be written, as well as improves Kconfiglib as fewer Kconfig files must be sourced, as redundant sourcing is not avoided.