### PR TITLE
net: shell: ensure the shell `sh` is valid before call shell_printf

### DIFF
--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -404,10 +404,6 @@ static void handle_wifi_ap_sta_disconnected(struct net_mgmt_event_callback *cb)
 static void wifi_mgmt_event_handler(struct net_mgmt_event_callback *cb,
 				    uint32_t mgmt_event, struct net_if *iface)
 {
-	if (context.sh == NULL) {
-		return;
-	}
-
 	switch (mgmt_event) {
 	case NET_EVENT_WIFI_SCAN_RESULT:
 		handle_wifi_scan_result(cb);

--- a/subsys/net/lib/shell/net_shell_private.h
+++ b/subsys/net/lib/shell/net_shell_private.h
@@ -8,20 +8,50 @@
 #include <zephyr/shell/shell.h>
 #include <zephyr/net/net_ip.h>
 
-#define PR(fmt, ...)						\
-	shell_fprintf(sh, SHELL_NORMAL, fmt, ##__VA_ARGS__)
+#define PR(fmt, ...)                                                            \
+	do {                                                                    \
+		if (sh) {                                                       \
+			shell_fprintf(sh, SHELL_NORMAL, fmt, ##__VA_ARGS__);    \
+		} else {                                                        \
+			printk(fmt, ##__VA_ARGS__);                             \
+		}                                                               \
+	} while (false)
 
-#define PR_SHELL(sh, fmt, ...)				\
-	shell_fprintf(sh, SHELL_NORMAL, fmt, ##__VA_ARGS__)
+#define PR_SHELL(sh, fmt, ...)                                                  \
+	do {                                                                    \
+		if (sh) {                                                       \
+			shell_fprintf(sh, SHELL_NORMAL, fmt, ##__VA_ARGS__);    \
+		} else {                                                        \
+			printk(fmt, ##__VA_ARGS__);                             \
+		}                                                               \
+	} while (false)
 
-#define PR_ERROR(fmt, ...)					\
-	shell_fprintf(sh, SHELL_ERROR, fmt, ##__VA_ARGS__)
+#define PR_ERROR(fmt, ...)                                                      \
+	do {                                                                    \
+		if (sh) {                                                       \
+			shell_fprintf(sh, SHELL_ERROR, fmt, ##__VA_ARGS__);     \
+		} else {                                                        \
+			printk(fmt, ##__VA_ARGS__);                             \
+		}                                                               \
+	} while (false)
 
-#define PR_INFO(fmt, ...)					\
-	shell_fprintf(sh, SHELL_INFO, fmt, ##__VA_ARGS__)
+#define PR_INFO(fmt, ...)                                                       \
+	do {                                                                    \
+		if (sh) {                                                       \
+			shell_fprintf(sh, SHELL_INFO, fmt, ##__VA_ARGS__);      \
+		} else {                                                        \
+			printk(fmt, ##__VA_ARGS__);                             \
+		}                                                               \
+	} while (false)
 
-#define PR_WARNING(fmt, ...)					\
-	shell_fprintf(sh, SHELL_WARNING, fmt, ##__VA_ARGS__)
+#define PR_WARNING(fmt, ...)                                                    \
+	do {                                                                    \
+		if (sh) {                                                       \
+			shell_fprintf(sh, SHELL_WARNING, fmt, ##__VA_ARGS__);   \
+		} else {                                                        \
+			printk(fmt, ##__VA_ARGS__);                             \
+		}                                                               \
+	} while (false)
 
 #include "net_private.h"
 #include "../ip/ipv6.h"


### PR DESCRIPTION
- It is possible that the `sh` was not set before use. This change adds a NULL check for `sh` in the following macros: PR, PR_SHELL, PR_ERROR, PR_INFO, and PR_WARNING.
Fixes #68793.

- Since PR, PR_SHELL, PR_ERROR, PR_INFO, and PR_WARNING already have
an embedded `sh` NULL check, we can remove the change from PR #68809.
