### PR TITLE
drivers: gpio: pcal64xxa: give semaphore in case of error

### DIFF
--- a/drivers/gpio/gpio_pcal64xxa.c
+++ b/drivers/gpio/gpio_pcal64xxa.c
@@ -204,6 +204,7 @@ static int pcal64xxa_process_input(const struct device *dev, gpio_port_value_t *
 
 	if (rc != 0) {
 		LOG_ERR("failed to read inputs from device %s", dev->name);
+		k_sem_give(&drv_data->lock);
 		return rc;
 	}
 


### PR DESCRIPTION
In function pcal64xxa_process_input, lock was not released in case of error when calling inputs_read.
This was causing an infinite wait in the following calls of functions using I2C bus.