### PR TITLE
hwmv2: boards: up_squared_pro_700: Add missed intel_adl changes

### DIFF
--- a/boards/up/up_squared_pro_7000/Kconfig.defconfig
+++ b/boards/up/up_squared_pro_7000/Kconfig.defconfig
@@ -32,14 +32,23 @@ config HEAP_MEM_POOL_ADD_SIZE_ACPI
 	default 64000000
 config MAIN_STACK_SIZE
 	default 320000
-config ACPI_PRT_BUS_NAME
-	default "_SB.PC00"
 
 if SHELL
 config SHELL_STACK_SIZE
 	default 320000
 endif # SHELL
 endif # ACPI
+
+if DMA
+config DMA_64BIT
+  default y
+config DMA_DW_HW_LLI
+  default n
+config DMA_DW_CHANNEL_COUNT
+  default 2
+endif
+config UART_NS16550_INTEL_LPSS_DMA
+  default y
 
 config HAS_COVERAGE_SUPPORT
 	default y


### PR DESCRIPTION
Align `boards/up/up_squared_pro_7000` with changes at `boards/x86/intel_adl` done by #62694 and #67452 at the 'main' branch while the `up_squared_pro_700` board was in migration to HWMv2 at `collab-hwm` branch.