### PR TITLE
soc: xtensa: imx8: move SYS_CLOCK_HW_CYCLES_PER_SEC to each SoC defconfig

### DIFF
--- a/soc/xtensa/nxp_adsp/imx8/Kconfig.defconfig.imx8qm
+++ b/soc/xtensa/nxp_adsp/imx8/Kconfig.defconfig.imx8qm
@@ -6,4 +6,7 @@ if SOC_MIMX8QM_ADSP
 config SOC
 	default "mimx8qm6"
 
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default 666000000 if XTENSA_TIMER
+
 endif # SOC_MIMX8QM_ADSP

--- a/soc/xtensa/nxp_adsp/imx8/Kconfig.defconfig.imx8qxp
+++ b/soc/xtensa/nxp_adsp/imx8/Kconfig.defconfig.imx8qxp
@@ -6,4 +6,7 @@ if SOC_MIMX8QXP_ADSP
 config SOC
 	default "mimx8qx6"
 
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default 640000000 if XTENSA_TIMER
+
 endif # SOC_MIMX8QXP_ADSP

--- a/soc/xtensa/nxp_adsp/imx8/Kconfig.defconfig.series
+++ b/soc/xtensa/nxp_adsp/imx8/Kconfig.defconfig.series
@@ -11,9 +11,6 @@ config SOC_TOOLCHAIN_NAME
 	string
 	default "nxp_imx_adsp"
 
-config SYS_CLOCK_HW_CYCLES_PER_SEC
-	default 666000000 if XTENSA_TIMER
-
 config SYS_CLOCK_TICKS_PER_SEC
 	default 50000
 


### PR DESCRIPTION
i.MX8QM and i.MX8QXP have different values for
CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC so move the configuration to each of the SoC's `Kconfig.defconfig` file.