### PR TITLE
drivers: display: drop a bunch of redundant placeholder API functions

### DIFF
--- a/drivers/display/display_dummy.c
+++ b/drivers/display/display_dummy.c
@@ -57,19 +57,6 @@ static int dummy_display_write(const struct device *dev, const uint16_t x,
 	return 0;
 }
 
-static int dummy_display_read(const struct device *dev, const uint16_t x,
-			      const uint16_t y,
-			      const struct display_buffer_descriptor *desc,
-			      void *buf)
-{
-	return -ENOTSUP;
-}
-
-static void *dummy_display_get_framebuffer(const struct device *dev)
-{
-	return NULL;
-}
-
 static int dummy_display_blanking_off(const struct device *dev)
 {
 	return 0;
@@ -123,8 +110,6 @@ static const struct display_driver_api dummy_display_api = {
 	.blanking_on = dummy_display_blanking_on,
 	.blanking_off = dummy_display_blanking_off,
 	.write = dummy_display_write,
-	.read = dummy_display_read,
-	.get_framebuffer = dummy_display_get_framebuffer,
 	.set_brightness = dummy_display_set_brightness,
 	.set_contrast = dummy_display_set_contrast,
 	.get_capabilities = dummy_display_get_capabilities,

--- a/drivers/display/display_ili9xxx.c
+++ b/drivers/display/display_ili9xxx.c
@@ -142,20 +142,6 @@ static int ili9xxx_write(const struct device *dev, const uint16_t x,
 	return 0;
 }
 
-static int ili9xxx_read(const struct device *dev, const uint16_t x,
-			const uint16_t y,
-			const struct display_buffer_descriptor *desc, void *buf)
-{
-	LOG_ERR("Reading not supported");
-	return -ENOTSUP;
-}
-
-static void *ili9xxx_get_framebuffer(const struct device *dev)
-{
-	LOG_ERR("Direct framebuffer access not supported");
-	return NULL;
-}
-
 static int ili9xxx_display_blanking_off(const struct device *dev)
 {
 	LOG_DBG("Turning display blanking off");
@@ -166,20 +152,6 @@ static int ili9xxx_display_blanking_on(const struct device *dev)
 {
 	LOG_DBG("Turning display blanking on");
 	return ili9xxx_transmit(dev, ILI9XXX_DISPOFF, NULL, 0);
-}
-
-static int ili9xxx_set_brightness(const struct device *dev,
-				  const uint8_t brightness)
-{
-	LOG_ERR("Set brightness not implemented");
-	return -ENOTSUP;
-}
-
-static int ili9xxx_set_contrast(const struct device *dev,
-				const uint8_t contrast)
-{
-	LOG_ERR("Set contrast not supported");
-	return -ENOTSUP;
 }
 
 static int
@@ -372,10 +344,6 @@ static const struct display_driver_api ili9xxx_api = {
 	.blanking_on = ili9xxx_display_blanking_on,
 	.blanking_off = ili9xxx_display_blanking_off,
 	.write = ili9xxx_write,
-	.read = ili9xxx_read,
-	.get_framebuffer = ili9xxx_get_framebuffer,
-	.set_brightness = ili9xxx_set_brightness,
-	.set_contrast = ili9xxx_set_contrast,
 	.get_capabilities = ili9xxx_get_capabilities,
 	.set_pixel_format = ili9xxx_set_pixel_format,
 	.set_orientation = ili9xxx_set_orientation,

--- a/drivers/display/ls0xx.c
+++ b/drivers/display/ls0xx.c
@@ -203,34 +203,6 @@ static int ls0xx_write(const struct device *dev, const uint16_t x,
 	return ls0xx_update_display(dev, y + 1, desc->height, buf);
 }
 
-static int ls0xx_read(const struct device *dev, const uint16_t x,
-		      const uint16_t y,
-		      const struct display_buffer_descriptor *desc,
-		      void *buf)
-{
-	LOG_ERR("not supported");
-	return -ENOTSUP;
-}
-
-static void *ls0xx_get_framebuffer(const struct device *dev)
-{
-	LOG_ERR("not supported");
-	return NULL;
-}
-
-static int ls0xx_set_brightness(const struct device *dev,
-				const uint8_t brightness)
-{
-	LOG_WRN("not supported");
-	return -ENOTSUP;
-}
-
-static int ls0xx_set_contrast(const struct device *dev, uint8_t contrast)
-{
-	LOG_WRN("not supported");
-	return -ENOTSUP;
-}
-
 static void ls0xx_get_capabilities(const struct device *dev,
 				   struct display_capabilities *caps)
 {
@@ -240,13 +212,6 @@ static void ls0xx_get_capabilities(const struct device *dev,
 	caps->supported_pixel_formats = PIXEL_FORMAT_MONO01;
 	caps->current_pixel_format = PIXEL_FORMAT_MONO01;
 	caps->screen_info = SCREEN_INFO_X_ALIGNMENT_WIDTH;
-}
-
-static int ls0xx_set_orientation(const struct device *dev,
-				 const enum display_orientation orientation)
-{
-	LOG_ERR("Unsupported");
-	return -ENOTSUP;
 }
 
 static int ls0xx_set_pixel_format(const struct device *dev,
@@ -317,13 +282,8 @@ static struct display_driver_api ls0xx_driver_api = {
 	.blanking_on = ls0xx_blanking_on,
 	.blanking_off = ls0xx_blanking_off,
 	.write = ls0xx_write,
-	.read = ls0xx_read,
-	.get_framebuffer = ls0xx_get_framebuffer,
-	.set_brightness = ls0xx_set_brightness,
-	.set_contrast = ls0xx_set_contrast,
 	.get_capabilities = ls0xx_get_capabilities,
 	.set_pixel_format = ls0xx_set_pixel_format,
-	.set_orientation = ls0xx_set_orientation,
 };
 
 DEVICE_DT_INST_DEFINE(0, ls0xx_init, NULL, NULL, &ls0xx_config, POST_KERNEL,

--- a/drivers/display/ssd1306.c
+++ b/drivers/display/ssd1306.c
@@ -318,28 +318,6 @@ static int ssd1306_write(const struct device *dev, const uint16_t x, const uint1
 	return ssd1306_write_default(dev, x, y, desc, buf, buf_len);
 }
 
-static int ssd1306_read(const struct device *dev, const uint16_t x,
-			const uint16_t y,
-			const struct display_buffer_descriptor *desc,
-			void *buf)
-{
-	LOG_ERR("Unsupported");
-	return -ENOTSUP;
-}
-
-static void *ssd1306_get_framebuffer(const struct device *dev)
-{
-	LOG_ERR("Unsupported");
-	return NULL;
-}
-
-static int ssd1306_set_brightness(const struct device *dev,
-				  const uint8_t brightness)
-{
-	LOG_WRN("Unsupported");
-	return -ENOTSUP;
-}
-
 static int ssd1306_set_contrast(const struct device *dev, const uint8_t contrast)
 {
 	uint8_t cmd_buf[] = {
@@ -360,14 +338,6 @@ static void ssd1306_get_capabilities(const struct device *dev,
 	caps->supported_pixel_formats = PIXEL_FORMAT_MONO10;
 	caps->current_pixel_format = PIXEL_FORMAT_MONO10;
 	caps->screen_info = SCREEN_INFO_MONO_VTILED;
-}
-
-static int ssd1306_set_orientation(const struct device *dev,
-				   const enum display_orientation
-				   orientation)
-{
-	LOG_ERR("Unsupported");
-	return -ENOTSUP;
 }
 
 static int ssd1306_set_pixel_format(const struct device *dev,
@@ -467,13 +437,9 @@ static struct display_driver_api ssd1306_driver_api = {
 	.blanking_on = ssd1306_suspend,
 	.blanking_off = ssd1306_resume,
 	.write = ssd1306_write,
-	.read = ssd1306_read,
-	.get_framebuffer = ssd1306_get_framebuffer,
-	.set_brightness = ssd1306_set_brightness,
 	.set_contrast = ssd1306_set_contrast,
 	.get_capabilities = ssd1306_get_capabilities,
 	.set_pixel_format = ssd1306_set_pixel_format,
-	.set_orientation = ssd1306_set_orientation,
 };
 
 #define SSD1306_CONFIG_SPI(node_id)                                                                \

--- a/drivers/display/ssd16xx.c
+++ b/drivers/display/ssd16xx.c
@@ -581,25 +581,6 @@ static int ssd16xx_read(const struct device *dev,
 	return ssd16xx_read_ram(dev, SSD16XX_RAM_BLACK, x, y, desc, buf);
 }
 
-static void *ssd16xx_get_framebuffer(const struct device *dev)
-{
-	LOG_ERR("not supported");
-	return NULL;
-}
-
-static int ssd16xx_set_brightness(const struct device *dev,
-				  const uint8_t brightness)
-{
-	LOG_WRN("not supported");
-	return -ENOTSUP;
-}
-
-static int ssd16xx_set_contrast(const struct device *dev, uint8_t contrast)
-{
-	LOG_WRN("not supported");
-	return -ENOTSUP;
-}
-
 static void ssd16xx_get_capabilities(const struct device *dev,
 				     struct display_capabilities *caps)
 {
@@ -614,14 +595,6 @@ static void ssd16xx_get_capabilities(const struct device *dev,
 	caps->screen_info = SCREEN_INFO_MONO_VTILED |
 			    SCREEN_INFO_MONO_MSB_FIRST |
 			    SCREEN_INFO_EPD;
-}
-
-static int ssd16xx_set_orientation(const struct device *dev,
-				   const enum display_orientation
-				   orientation)
-{
-	LOG_ERR("Unsupported");
-	return -ENOTSUP;
 }
 
 static int ssd16xx_set_pixel_format(const struct device *dev,
@@ -979,12 +952,8 @@ static struct display_driver_api ssd16xx_driver_api = {
 	.blanking_off = ssd16xx_blanking_off,
 	.write = ssd16xx_write,
 	.read = ssd16xx_read,
-	.get_framebuffer = ssd16xx_get_framebuffer,
-	.set_brightness = ssd16xx_set_brightness,
-	.set_contrast = ssd16xx_set_contrast,
 	.get_capabilities = ssd16xx_get_capabilities,
 	.set_pixel_format = ssd16xx_set_pixel_format,
-	.set_orientation = ssd16xx_set_orientation,
 };
 
 #if DT_HAS_COMPAT_STATUS_OKAY(solomon_ssd1608)

--- a/drivers/display/uc81xx.c
+++ b/drivers/display/uc81xx.c
@@ -491,32 +491,6 @@ static int uc81xx_write(const struct device *dev, const uint16_t x, const uint16
 	return 0;
 }
 
-static int uc81xx_read(const struct device *dev, const uint16_t x, const uint16_t y,
-		       const struct display_buffer_descriptor *desc, void *buf)
-{
-	LOG_ERR("not supported");
-	return -ENOTSUP;
-}
-
-static void *uc81xx_get_framebuffer(const struct device *dev)
-{
-	LOG_ERR("not supported");
-	return NULL;
-}
-
-static int uc81xx_set_brightness(const struct device *dev,
-				 const uint8_t brightness)
-{
-	LOG_WRN("not supported");
-	return -ENOTSUP;
-}
-
-static int uc81xx_set_contrast(const struct device *dev, uint8_t contrast)
-{
-	LOG_WRN("not supported");
-	return -ENOTSUP;
-}
-
 static void uc81xx_get_capabilities(const struct device *dev,
 				    struct display_capabilities *caps)
 {
@@ -528,14 +502,6 @@ static void uc81xx_get_capabilities(const struct device *dev,
 	caps->supported_pixel_formats = PIXEL_FORMAT_MONO10;
 	caps->current_pixel_format = PIXEL_FORMAT_MONO10;
 	caps->screen_info = SCREEN_INFO_MONO_MSB_FIRST | SCREEN_INFO_EPD;
-}
-
-static int uc81xx_set_orientation(const struct device *dev,
-				  const enum display_orientation
-				  orientation)
-{
-	LOG_ERR("Unsupported");
-	return -ENOTSUP;
 }
 
 static int uc81xx_set_pixel_format(const struct device *dev,
@@ -792,13 +758,8 @@ static struct display_driver_api uc81xx_driver_api = {
 	.blanking_on = uc81xx_blanking_on,
 	.blanking_off = uc81xx_blanking_off,
 	.write = uc81xx_write,
-	.read = uc81xx_read,
-	.get_framebuffer = uc81xx_get_framebuffer,
-	.set_brightness = uc81xx_set_brightness,
-	.set_contrast = uc81xx_set_contrast,
 	.get_capabilities = uc81xx_get_capabilities,
 	.set_pixel_format = uc81xx_set_pixel_format,
-	.set_orientation = uc81xx_set_orientation,
 };
 
 #define UC81XX_MAKE_ARRAY_OPT(n, p)					\


### PR DESCRIPTION
Drop a bunch of display functions that only return "not supported", the display API already handles these by checking for NULL API function pointer.