### PR TITLE
manifest: Update trusted-firmware-m to address LPC55S69 failure

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -322,7 +322,7 @@ manifest:
       groups:
         - crypto
     - name: trusted-firmware-m
-      revision: 58d0b5367f0fada9dbaddad1e08e302aeb044863
+      revision: 0b898c9b72171b0a260c0bb64a92ea4713f9e931
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
A bug was introduced with the TF-M 2.0 update. Patches have been submitted to the TF-M upstream and were also applied to the Zephyr fork.

Details on the patches applied:

Platform: nxp: Add initialization flag to the CMSIS USART driver. Avoid possible USART_Deinit() stuck found in Zephyr TFM MCUBoot. From Upstream TFM:SHA: I1f6c19c3e7e5556423ddf3aec7555ff44ed7e562

Crypto: Add FPU flags for p256m
Fixes build error in #67751
From Upstream TFM:SHA: I4ed6f6ac7c1f52fb5ced18f0006dd3eb7a6a7359

Fixes #67751