### PR TITLE
sys: util: add a sign_extend function

### DIFF
--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -24,6 +24,7 @@
 
 #ifndef _ASMLANGUAGE
 
+#include <zephyr/sys/__assert.h>
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -561,6 +562,36 @@ static inline uint8_t bin2bcd(uint8_t bin)
  *             any), or 0 if an error occurred.
  */
 uint8_t u8_to_dec(char *buf, uint8_t buflen, uint8_t value);
+
+/**
+ * @brief Sign extend an 8, 16 or 32 bit value using the index bit as sign bit.
+ *
+ * @param value The value to sign expand.
+ * @param index 0 based bit index to sign bit (0 to 31)
+ */
+static inline int32_t sign_extend(uint32_t value, uint8_t index)
+{
+	__ASSERT_NO_MSG(index <= 31);
+
+	uint8_t shift = 31 - index;
+
+	return (int32_t)(value << shift) >> shift;
+}
+
+/**
+ * @brief Sign extend a 64 bit value using the index bit as sign bit.
+ *
+ * @param value The value to sign expand.
+ * @param index 0 based bit index to sign bit (0 to 63)
+ */
+static inline int64_t sign_extend_64(uint64_t value, uint8_t index)
+{
+	__ASSERT_NO_MSG(index <= 63);
+
+	uint8_t shift = 63 - index;
+
+	return (int64_t)(value << shift) >> shift;
+}
 
 /**
  * @brief Properly truncate a NULL-terminated UTF-8 string

--- a/tests/unit/util/main.c
+++ b/tests/unit/util/main.c
@@ -64,6 +64,47 @@ ZTEST(util, test_u8_to_dec) {
 		      "Length of converted value using 0 byte buffer isn't 0");
 }
 
+ZTEST(util, test_sign_extend) {
+	uint8_t u8;
+	uint16_t u16;
+	uint32_t u32;
+
+	u8 = 0x0f;
+	zassert_equal(sign_extend(u8, 3), -1);
+	zassert_equal(sign_extend(u8, 4), 0xf);
+
+	u16 = 0xfff;
+	zassert_equal(sign_extend(u16, 11), -1);
+	zassert_equal(sign_extend(u16, 12), 0xfff);
+
+	u32 = 0xfffffff;
+	zassert_equal(sign_extend(u32, 27), -1);
+	zassert_equal(sign_extend(u32, 28), 0xfffffff);
+}
+
+ZTEST(util, test_sign_extend_64) {
+	uint8_t u8;
+	uint16_t u16;
+	uint32_t u32;
+	uint64_t u64;
+
+	u8 = 0x0f;
+	zassert_equal(sign_extend_64(u8, 3), -1);
+	zassert_equal(sign_extend_64(u8, 4), 0xf);
+
+	u16 = 0xfff;
+	zassert_equal(sign_extend_64(u16, 11), -1);
+	zassert_equal(sign_extend_64(u16, 12), 0xfff);
+
+	u32 = 0xfffffff;
+	zassert_equal(sign_extend_64(u32, 27), -1);
+	zassert_equal(sign_extend_64(u32, 28), 0xfffffff);
+
+	u64 = 0xfffffffffffffff;
+	zassert_equal(sign_extend_64(u64, 59), -1);
+	zassert_equal(sign_extend_64(u64, 60), 0xfffffffffffffff);
+}
+
 ZTEST(util, test_COND_CODE_1) {
 	#define TEST_DEFINE_1 1
 	#define TEST_DEFINE_0 0


### PR DESCRIPTION
Pretty much the same as https://elixir.bootlin.com/linux/latest/source/include/linux/bitops.h#L186, figured I would not use the `32` suffix since it works fine for smaller types as well but let me know what you think.

---

Add a sign_extend function, same as the Linux sign_extend32 one. This is useful for sign extending values smaller than 32 bits.