### PR TITLE
doc: release: 3.6: Adding additional ARM boards.

### DIFF
--- a/doc/releases/release-notes-3.6.rst
+++ b/doc/releases/release-notes-3.6.rst
@@ -86,6 +86,10 @@ Boards & SoC Support
 
   * Added support for Renesas R-Car Spider board CR52: ``rcar_spider_cr52``
 
+  * Added support for Adafruit QTPy RP2040 board: ``adafruit_qt_py_rp2040``
+
+  * Added support for Wiznet W5500 Evaluation Pico board: ``w5500_evb_pico``
+
 * Added support for these ARM64 boards:
 
 * Added support for these RISC-V boards:


### PR DESCRIPTION
This adds the Adafruit QTPy RP2040 and the Wiznet W5500 Evaluation Pico boards to the 3.6 release notes.