### PR TITLE
tests: mem_protect/obj_validation: fix check for heap size

### DIFF
--- a/tests/kernel/mem_protect/obj_validation/src/main.c
+++ b/tests/kernel/mem_protect/obj_validation/src/main.c
@@ -135,7 +135,7 @@ ZTEST(object_validation, test_kobj_assign_perms_on_alloc_obj)
 	struct k_thread *thread = _current;
 
 	uintptr_t start_addr, end_addr;
-	size_t size_heap = CONFIG_HEAP_MEM_POOL_SIZE;
+	size_t size_heap = K_HEAP_MEM_POOL_SIZE;
 
 	/* dynamically allocate kernel object semaphore */
 	test_dyn_sem = k_object_alloc(K_OBJ_SEM);


### PR DESCRIPTION
Commit 3fbf12487c6c01c488210bc56b0f342f07098df9 introduced a way to add to CONFIG_HEAP_MEM_POOL_SIZE if, for example, subsystems need more heap space. However, the size check in obj_validation was still using the old kconfig, and was failing when extra space was specified. So update the size check to use the updated size.