### PR TITLE
posix: pthread: ensure pthread_exit() has noreturn attribute

### DIFF
--- a/include/zephyr/posix/pthread.h
+++ b/include/zephyr/posix/pthread.h
@@ -432,7 +432,7 @@ int pthread_attr_setstack(pthread_attr_t *attr, void *stackaddr,
 #ifdef CONFIG_PTHREAD_IPC
 int pthread_once(pthread_once_t *once, void (*initFunc)(void));
 #endif
-void pthread_exit(void *retval);
+FUNC_NORETURN void pthread_exit(void *retval);
 int pthread_join(pthread_t thread, void **status);
 int pthread_cancel(pthread_t pthread);
 int pthread_detach(pthread_t thread);


### PR DESCRIPTION
The function pthread_exit() does not return. It should be declared with the noreturn attribute.