### PR TITLE
hwmv2: boards: Add bl654_dvk pa variant

### DIFF
--- a/boards/lairdconnect/bl654_dvk/Kconfig.defconfig
+++ b/boards/lairdconnect/bl654_dvk/Kconfig.defconfig
@@ -16,3 +16,12 @@ config I2C
 endif # DAC
 
 endif # BOARD_BL654_DVK
+
+if BOARD_BL654_DVK_NRF52840_PA
+
+# Limit max power for FCC compliance with power amplifier
+choice BT_CTLR_TX_PWR
+	default BT_CTLR_TX_PWR_MINUS_4
+endchoice
+
+endif # BOARD_BL654_DVK_NRF52840_PA

--- a/boards/lairdconnect/bl654_dvk/bl654_dvk_nrf52840_pa.dts
+++ b/boards/lairdconnect/bl654_dvk/bl654_dvk_nrf52840_pa.dts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2019 Laird Connectivity
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "bl654_dvk.dts"
+
+/ {
+	/* Information from Nordic SDK-Based Application Development and SKY66112 datasheet */
+	sky66112_fem: fem {
+		compatible = "generic-fem-two-ctrl-pins";
+		ctx-gpios = <&gpio1 2 GPIO_ACTIVE_HIGH>;
+		crx-gpios = <&gpio1 4 GPIO_ACTIVE_HIGH>;
+		ctx-settle-time-us = <23>;
+		crx-settle-time-us = <5>;
+		tx-gain-db = <22>;
+		rx-gain-db = <11>;
+	};
+};
+
+&radio {
+	fem = <&sky66112_fem>;
+};

--- a/boards/lairdconnect/bl654_dvk/bl654_dvk_nrf52840_pa.yaml
+++ b/boards/lairdconnect/bl654_dvk/bl654_dvk_nrf52840_pa.yaml
@@ -1,0 +1,15 @@
+identifier: bl654_dvk/nrf52840/pa
+name: BL654_DVK_NRF52840_PA
+type: mcu
+arch: arm
+toolchain:
+  - zephyr
+  - gnuarmemb
+  - xtools
+supported:
+  - adc
+  - usb_device
+  - ble
+  - pwm
+  - watchdog
+vendor: lairdconnect

--- a/boards/lairdconnect/bl654_dvk/bl654_dvk_nrf52840_pa_defconfig
+++ b/boards/lairdconnect/bl654_dvk/bl654_dvk_nrf52840_pa_defconfig
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+
+
+# Enable MPU
+CONFIG_ARM_MPU=y
+
+# Enable RTT
+CONFIG_USE_SEGGER_RTT=y
+
+# enable GPIO
+CONFIG_GPIO=y
+
+# enable uart driver
+CONFIG_SERIAL=y
+
+# enable console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+CONFIG_RTT_CONSOLE=y
+
+# 32kHz clock source
+CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC=y
+CONFIG_CLOCK_CONTROL_NRF_K32SRC_500PPM=y

--- a/boards/lairdconnect/bl654_dvk/board.yml
+++ b/boards/lairdconnect/bl654_dvk/board.yml
@@ -3,3 +3,5 @@ board:
   vendor: lairdconnect
   socs:
   - name: nrf52840
+    variants:
+    - name: pa

--- a/boards/lairdconnect/bl654_dvk/doc/bl654_dvk.rst
+++ b/boards/lairdconnect/bl654_dvk/doc/bl654_dvk.rst
@@ -9,6 +9,11 @@ Overview
 The BL654 Development Kit hardware provides
 support for the Laird Connectivity BL654 module powered by a Nordic Semiconductor nRF52840 ARM Cortex-M4F CPU.
 
+It is also pin compatible with the BL654PA which adds a power amplifier. The "pa" variant provides
+this compatibility. Use board ``bl654_dvk/nrf52840/pa`` to build for that target.
+Bluetooth LE regulatory certifications obtained by Ezurio are not applicable to BL654PA variant.
+It should not be used in commercial applications prior to re-certification being performed - please review with the Ezurio team at www.ezurio.com/contact
+
 This development kit has the following features:
 
 * :abbr:`ADC (Analog to Digital Converter)`


### PR DESCRIPTION
Add defconfig, dts, yaml for bl654_dvk_bl654pa. They are largely the same as bl654_dvk
Add Kconfig support for bl654_dvk_bl654pa.
Add samples/bluetooth/hci_uart support for this config at 1 MHz with power amplifier
Add docs