### PR TITLE
Move STM32 MCO configuration from Kconfig to dts

### DIFF
--- a/drivers/clock_control/CMakeLists.txt
+++ b/drivers/clock_control/CMakeLists.txt
@@ -34,6 +34,7 @@ zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_RPI_PICO            clock_cont
 
 if(CONFIG_CLOCK_CONTROL_STM32_CUBE)
   zephyr_library_sources_ifdef(CONFIG_CLOCK_STM32_MUX clock_stm32_mux.c)
+  zephyr_library_sources_ifdef(CONFIG_CLOCK_STM32_MCO clock_stm32_mco.c)
 if(CONFIG_SOC_SERIES_STM32MP1X)
   zephyr_library_sources(clock_stm32_ll_mp1.c)
 elseif(CONFIG_SOC_SERIES_STM32H7X)

--- a/drivers/clock_control/Kconfig.stm32
+++ b/drivers/clock_control/Kconfig.stm32
@@ -46,6 +46,13 @@ config CLOCK_STM32_MUX
 	  for a specific domain. For instance per_ck clock on STM32H7 or
 	  CLK48 clock
 
+config CLOCK_STM32_MCO
+	bool "STM32 clock MCO driver"
+	default y
+	depends on DT_HAS_ST_STM32_MCO_CLOCK_ENABLED
+	help
+	  Enable driver for STM32 clock MCO clock output.
+
 # Micro-controller Clock output configuration options
 
 choice

--- a/drivers/clock_control/clock_stm32_mco.c
+++ b/drivers/clock_control/clock_stm32_mco.c
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2024 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT st_stm32_mco_clock
+
+#include <zephyr/arch/common/sys_bitops.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/clock_control/stm32_clock_control.h>
+#include <zephyr/drivers/pinctrl.h>
+
+#include <stdint.h>
+
+struct clock_control_stm32_mco_config {
+	uint32_t base;
+	const struct stm32_pclken *pclken;
+	size_t pclk_len;
+	const struct pinctrl_dev_config *pcfg;
+};
+
+static int clock_control_stm32_mco_init(const struct device *dev)
+{
+	const struct clock_control_stm32_mco_config *config = dev->config;
+
+	for (int i = 0; i < config->pclk_len; i++) {
+		sys_clear_bits(config->base + STM32_CLOCK_REG_GET(config->pclken->enr),
+			       STM32_CLOCK_MASK_GET(config->pclken[i].enr)
+				       << STM32_CLOCK_SHIFT_GET(config->pclken[i].enr));
+		sys_set_bits(config->base + STM32_CLOCK_REG_GET(config->pclken->enr),
+			     STM32_CLOCK_VAL_GET(config->pclken[i].enr)
+				     << STM32_CLOCK_SHIFT_GET(config->pclken[i].enr));
+	}
+
+	return 0;
+}
+
+#define STM32_MCO_INIT(inst)								\
+	PINCTRL_DT_INST_DEFINE(inst);							\
+											\
+	static const struct stm32_pclken pclken_##inst[] = STM32_DT_INST_CLOCKS(inst);	\
+											\
+	static struct clock_control_stm32_mco_config clk_cfg_##inst = {			\
+		.base = DT_REG_ADDR(DT_INST_CLOCKS_CTLR(inst)),				\
+		.pclken = pclken_##inst,						\
+		.pclk_len = DT_INST_NUM_CLOCKS(inst),					\
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),				\
+	};										\
+											\
+	DEVICE_DT_INST_DEFINE(inst, &clock_control_stm32_mco_init,			\
+			NULL, NULL, &clk_cfg_##inst,					\
+			PRE_KERNEL_1, CONFIG_CLOCK_CONTROL_INIT_PRIORITY,		\
+			NULL);
+
+DT_INST_FOREACH_STATUS_OKAY(STM32_MCO_INIT)
+
+#define GET_DEV(node_id) DEVICE_DT_GET(node_id),
+
+static int stm32_mco_pinctrl_init(void)
+{
+	const struct device *dev_list[] = {DT_FOREACH_STATUS_OKAY(st_stm32_mco_clock, GET_DEV)};
+	int list_len = ARRAY_SIZE(dev_list);
+
+	for (int i = 0; i < list_len; i++) {
+		const struct clock_control_stm32_mco_config *config = dev_list[i]->config;
+		int res = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
+		if (res < 0) {
+			return res;
+		}
+	}
+
+	return 0;
+}
+
+/* Need to be initialised after GPIO driver */
+SYS_INIT(stm32_mco_pinctrl_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);

--- a/dts/arm/st/c0/stm32c0.dtsi
+++ b/dts/arm/st/c0/stm32c0.dtsi
@@ -64,6 +64,16 @@
 			clock-frequency = <DT_FREQ_K(32)>;
 			status = "disabled";
 		};
+
+		clk_mco: clk-mco {
+			compatible = "st,stm32-mco-clock";
+			status = "disabled";
+		};
+
+		clk_mco2: clk-mco2 {
+			compatible = "st,stm32-mco-clock";
+			status = "disabled";
+		};
 	};
 
 	soc {

--- a/dts/bindings/clock/st,stm32-mco-clock.yaml
+++ b/dts/bindings/clock/st,stm32-mco-clock.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+description: STM32 MCO Clock
+
+compatible: "st,stm32-mco-clock"
+
+include: [pinctrl-device.yaml, base.yaml]
+
+properties:
+
+  pinctrl-0:
+    required: true
+
+  pinctrl-names:
+    required: true

--- a/include/zephyr/dt-bindings/clock/stm32c0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32c0_clock.h
@@ -57,6 +57,9 @@
 	 (((mask) & STM32_CLOCK_MASK_MASK) << STM32_CLOCK_MASK_SHIFT) |		\
 	 (((val) & STM32_CLOCK_VAL_MASK) << STM32_CLOCK_VAL_SHIFT))
 
+/** @brief RCC_CFGRR register offset */
+#define CFGR_REG		0x08
+
 /** @brief RCC_CCIPR register offset */
 #define CCIPR_REG		0x54
 
@@ -64,6 +67,11 @@
 #define CSR1_REG		0x5C
 
 /** @brief Device domain clocks selection helpers */
+/** CFGR devices */
+#define MCO_SEL(val)		STM32_CLOCK(val, 3, 24, CFGR_REG)
+#define MCO_DIV(val)		STM32_CLOCK(val, 3, 28, CFGR_REG)
+#define MCO2_SEL(val)		STM32_CLOCK(val, 3, 16, CFGR_REG)
+#define MCO2_DIV(val)		STM32_CLOCK(val, 3, 20, CFGR_REG)
 /** CCIPR devices */
 #define USART1_SEL(val)		STM32_CLOCK(val, 3, 0, CCIPR_REG)
 #define I2C1_SEL(val)		STM32_CLOCK(val, 3, 12, CCIPR_REG)

--- a/west.yml
+++ b/west.yml
@@ -229,7 +229,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 60c9634f61c697e1c310ec648d33529712806069
+      revision: pull/195/head
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
This PR is intended to resolve the STM32 MCO clock issue discussed here [#31912](https://github.com/zephyrproject-rtos/zephyr/issues/31912#issue-800175840), [#58443](https://github.com/zephyrproject-rtos/zephyr/discussions/58443#discussion-5248213).

A couple of things come to mind while working on this so I decided to make this a draft before continuing:
- Do we want to have pinctrl applied during boot, maybe a Kconfig to switch the SYS_INIT part on/off?
- As @GeorgeCGV points out [here](https://github.com/zephyrproject-rtos/zephyr/issues/31912#issuecomment-1334061384), the reference manual states that the MCO configuration should happen prior clock configurations, so the init priority should maybe be one less that of the rcc driver? But this should cause a compile time error if the rcc node is referenced from the mco node with lower priority?
- Also pointed out by @GeorgeCGV [here](https://github.com/zephyrproject-rtos/zephyr/issues/31912#issuecomment-1324138616) is the question about power management.
- Also not sure about the mco nodes inside the clocks node?