### PR TITLE
net: dhcpv4_server: Improve declined addresses management

### DIFF
--- a/subsys/net/lib/dhcpv4/Kconfig
+++ b/subsys/net/lib/dhcpv4/Kconfig
@@ -79,6 +79,7 @@ config NET_DHCPV4_SERVER_ADDR_COUNT
 
 config NET_DHCPV4_SERVER_ADDR_LEASE_TIME
 	int "Lease time for IPv4 addresses assigned by the server (seconds)"
+	range 0 4294967295
 	default 86400
 	help
 	  Lease time in seconds for IPv4 addresses assigned by the server.
@@ -87,6 +88,7 @@ config NET_DHCPV4_SERVER_ADDR_LEASE_TIME
 
 config NET_DHCPV4_SERVER_ADDR_DECLINE_TIME
 	int "The time IPv4 addresses remains blocked after conflict detection (seconds)"
+	range 0 4294967295
 	default 86400
 	help
 	  In case IPv4 address becomes blocked (either because of receiving
@@ -98,6 +100,7 @@ config NET_DHCPV4_SERVER_ADDR_DECLINE_TIME
 
 config NET_DHCPV4_SERVER_ICMP_PROBE_TIMEOUT
 	int "Timeout for ICMP probes sent by the server (miliseconds)"
+	range 0 60000
 	default 1000
 	help
 	  DHCPv4 server will probe the offered IP address (send ICMP echo

--- a/subsys/net/lib/dhcpv4/Kconfig
+++ b/subsys/net/lib/dhcpv4/Kconfig
@@ -85,6 +85,17 @@ config NET_DHCPV4_SERVER_ADDR_LEASE_TIME
 	  The lease time determines when the IPv4 address lease expires if the
 	  client does not renew it.
 
+config NET_DHCPV4_SERVER_ADDR_DECLINE_TIME
+	int "The time IPv4 addresses remains blocked after conflict detection (seconds)"
+	default 86400
+	help
+	  In case IPv4 address becomes blocked (either because of receiving
+	  Decline message or due to ICMP probe detecting conflict), the address
+	  can no longer be assigned. This timeout specifies how long the address
+	  remains in the Declined state.
+	  Note, that the server may try to reuse the oldest declined address in
+	  case it runs out of free addresses to assign.
+
 config NET_DHCPV4_SERVER_ICMP_PROBE_TIMEOUT
 	int "Timeout for ICMP probes sent by the server (miliseconds)"
 	default 1000

--- a/tests/net/dhcpv4/server/prj.conf
+++ b/tests/net/dhcpv4/server/prj.conf
@@ -11,8 +11,9 @@ CONFIG_NET_IPV4=y
 CONFIG_NET_IPV6=n
 CONFIG_NET_UDP=y
 CONFIG_NET_DHCPV4_SERVER=y
-# Reduce probe timeout to speed up tests
+# Reduce probe/decline timeout to speed up tests
 CONFIG_NET_DHCPV4_SERVER_ICMP_PROBE_TIMEOUT=10
+CONFIG_NET_DHCPV4_SERVER_ADDR_DECLINE_TIME=1
 
 # We need to set POSIX_API and use picolibc for eventfd to work
 CONFIG_POSIX_API=y


### PR DESCRIPTION
In case conflict is detected (either due to receiving Decline message or
due to ICMP probe getting reply), the conflicting address becomes
blocked for further use.

Although the RFC is not specific about how long should the address be
blocked, it make sense to implement some fallback mechanisms to reuse
blocked addresses in the server, otherwise, after longer period of
operation, it may run out of usable address.

This commit adds a timeout for declined addresses, so that by default
the address is marked back as "free" after 24 hrs (default lease time).
It also implements a mechanism, which allows to re-use the oldest
declined entry in case the server runs out of fresh addresses to assign.