### PR TITLE
modbus: Respect CONFIG_UART_USE_RUNTIME_CONFIGURE flag

### DIFF
--- a/subsys/modbus/Kconfig
+++ b/subsys/modbus/Kconfig
@@ -44,7 +44,7 @@ config MODBUS_SERIAL
 	default y
 	depends on SERIAL && SERIAL_HAS_DRIVER
 	depends on DT_HAS_ZEPHYR_MODBUS_SERIAL_ENABLED
-	select UART_USE_RUNTIME_CONFIGURE
+	imply UART_USE_RUNTIME_CONFIGURE
 	help
 	  Enable Modbus over serial line support.
 


### PR DESCRIPTION
Only perform runtime UART configuration if it is enabled.

This allows using serial modbus on a native ptty.