### PR TITLE
doc: releases: release-notes: 3.6: no relevant EEPROM changes

### DIFF
--- a/doc/releases/release-notes-3.6.rst
+++ b/doc/releases/release-notes-3.6.rst
@@ -236,8 +236,6 @@ Drivers and Sensors
 
 * DMA
 
-* EEPROM
-
 * Entropy
 
   * The "native_posix" entropy driver now accepts a new command line option ``seed-random``.


### PR DESCRIPTION
Remove the EEPROM subsection from the v3.6.0 release notes.