### PR TITLE
boards native_posix: Detect attempt to configure not existing int

### DIFF
--- a/boards/posix/native_posix/irq_handler.c
+++ b/boards/posix/native_posix/irq_handler.c
@@ -228,6 +228,11 @@ int posix_get_current_irq(void)
 void posix_isr_declare(unsigned int irq_p, int flags, void isr_p(const void *),
 		       const void *isr_param_p)
 {
+	if (irq_p >= N_IRQS) {
+		posix_print_error_and_exit("Attempted to configure not existent interrupt %u\n",
+					   irq_p);
+		return;
+	}
 	irq_vector_table[irq_p].irq   = irq_p;
 	irq_vector_table[irq_p].func  = isr_p;
 	irq_vector_table[irq_p].param = isr_param_p;


### PR DESCRIPTION
Prevent overrunning the irq vector table.
This is not happening today in tree, but coverity thinks it may. Checking for it to prevent it is not a bad idea anyhow, so let's do it.

Fixes #68637