### PR TITLE
drivers: entropy: neorv32: add missing soc.h include

### DIFF
--- a/drivers/entropy/entropy_neorv32_trng.c
+++ b/drivers/entropy/entropy_neorv32_trng.c
@@ -9,10 +9,12 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/syscon.h>
 #include <zephyr/drivers/entropy.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/sys/sys_io.h>
 
-#include <zephyr/logging/log.h>
+#include <soc.h>
+
 LOG_MODULE_REGISTER(neorv32_trng, CONFIG_ENTROPY_LOG_LEVEL);
 
 /* TRNG CTRL register bits */


### PR DESCRIPTION
Add missing soc.h include for NEORV32_SYSINFO_FEATURES.

This is causing compilation failures in https://github.com/zephyrproject-rtos/zephyr/runs/21448859418