### PR TITLE
settings: NVS: add entry into cache after writing

### DIFF
--- a/subsys/settings/src/settings_nvs.c
+++ b/subsys/settings/src/settings_nvs.c
@@ -216,10 +216,13 @@ static int settings_nvs_save(struct settings_store *cs, const char *name,
 	delete = ((value == NULL) || (val_len == 0));
 
 #if CONFIG_SETTINGS_NVS_NAME_CACHE
+	bool name_in_cache = false;
+
 	name_id = settings_nvs_cache_match(cf, name, rdname, sizeof(rdname));
 	if (name_id != NVS_NAMECNT_ID) {
 		write_name_id = name_id;
 		write_name = false;
+		name_in_cache = true;
 		goto found;
 	}
 #endif
@@ -251,9 +254,6 @@ static int settings_nvs_save(struct settings_store *cs, const char *name,
 		}
 
 		if (!delete) {
-#if CONFIG_SETTINGS_NVS_NAME_CACHE
-			settings_nvs_cache_add(cf, name, name_id);
-#endif
 			write_name_id = name_id;
 			write_name = false;
 		}
@@ -321,6 +321,12 @@ found:
 			return rc;
 		}
 	}
+
+#if CONFIG_SETTINGS_NVS_NAME_CACHE
+	if (!name_in_cache) {
+		settings_nvs_cache_add(cf, name, write_name_id);
+	}
+#endif
 
 	return 0;
 }


### PR DESCRIPTION
Settings NVS adds entry into Settings NVS cache after writing it into flash. Previously, the entry was added into cache only on the second writing attempt that caused very huge timing despite cache was enabled since it was still empty.

Scenario: store ble mesh replay protection list with 255 entries by button pressing(in real life by timer):
![proof1](https://github.com/zephyrproject-rtos/zephyr/assets/47027043/4992bcfa-52e7-42e6-9e53-e8647d458d5f)
Right picture with this improvement. The second attempt is encircled in red.
Branch with testing app: https://github.com/alxelax/zephyr/tree/settings_with_large_rpl
Referenced sample: bluetooth/mesh. Referenced device: nrf52840dk_nrf52840
You can see the second attempt takes to write RPL about 30 seconds because cache is empty.
If build cache during the first writing attempt, then it takes about 1.7 seconds (improvement).