### PR TITLE
dts: xtensa: nxp_imx8: add SAI1 node

### DIFF
--- a/dts/xtensa/nxp/nxp_imx8.dtsi
+++ b/dts/xtensa/nxp/nxp_imx8.dtsi
@@ -124,6 +124,17 @@
 		status = "disabled";
 	};
 
+	sai1: dai@59050000 {
+		compatible = "nxp,dai-sai";
+		reg = <0x59050000 DT_SIZE_K(64)>;
+		interrupt-parent = <&master5>;
+		interrupts = <28>;
+		dai-index = <1>;
+		dmas = <&edma0 15 0>, <&edma0 14 0>;
+		dma-names = "tx", "rx";
+		status = "disabled";
+	};
+
 	/* LSIO MU2, used to interact with the SCFW */
 	scu_mu: mailbox@5d1d0000 {
 		reg = <0x5d1d0000 DT_SIZE_K(64)>;


### PR DESCRIPTION
This depends on the following PRs (except for NXP HAL PR):

- [x] https://github.com/zephyrproject-rtos/zephyr/pull/68865
- [x] https://github.com/zephyrproject-rtos/zephyr/pull/68761
- [x] https://github.com/zephyrproject-rtos/zephyr/pull/69344