### PR TITLE
drivers: nrf_qspi_nor: Add option for 2bit IO

### DIFF
--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -617,7 +617,8 @@ static int configure_chip(const struct device *dev)
 		bool qe_value = (prot_if->writeoc == NRF_QSPI_WRITEOC_PP4IO) ||
 				(prot_if->writeoc == NRF_QSPI_WRITEOC_PP4O)  ||
 				(prot_if->readoc == NRF_QSPI_READOC_READ4IO) ||
-				(prot_if->readoc == NRF_QSPI_READOC_READ4O);
+				(prot_if->readoc == NRF_QSPI_READOC_READ4O)  ||
+				(prot_if->readoc == NRF_QSPI_READOC_READ2IO);
 		uint8_t sr_num = 0;
 		uint8_t qe_mask = 0;
 


### PR DESCRIPTION
Add missing NRF_QSPI_READOC_READ2IO option handling to enable 2bit IO