### PR TITLE
fix: lvgl: modules: keypad input log module

### DIFF
--- a/modules/lvgl/input/lvgl_keypad_input.c
+++ b/modules/lvgl/input/lvgl_keypad_input.c
@@ -12,7 +12,7 @@
 
 #include <zephyr/logging/log.h>
 
-LOG_MODULE_DECLARE(lvgl);
+LOG_MODULE_DECLARE(lvgl, CONFIG_LV_Z_LOG_LEVEL);
 
 struct lvgl_keypad_input_config {
 	struct lvgl_common_input_config common_config; /* Needs to be first member */


### PR DESCRIPTION
Compilation error "undefined reference to log_const_lvgl" happened in lvgl_keypad_input.c when trying to get logs with lvgl keypad module. Fixed by adding log level parameter in log module macro.