### PR TITLE
input: kbd_matrix: skip column with empty mask

### DIFF
--- a/drivers/input/input_kbd_matrix.c
+++ b/drivers/input/input_kbd_matrix.c
@@ -88,6 +88,11 @@ static bool input_kbd_matrix_scan(const struct device *dev)
 	kbd_row_t key_event = 0U;
 
 	for (int col = 0; col < cfg->col_size; col++) {
+		if (cfg->actual_key_mask != NULL &&
+		    cfg->actual_key_mask[col] == 0) {
+			continue;
+		}
+
 		input_kbd_matrix_drive_column(dev, col);
 
 		/* Allow the matrix to stabilize before reading it */


### PR DESCRIPTION
The active key mask can be used for supporting multiple keyboard layouts with a single firmware. A possible use case is to support keyboard with or without a numpad, in which case an entire set of columns may be missing. Add a check to detect this condition and skip scanning that column entirely if no keys are defined in it.