### PR TITLE
doc: release: 3.6: Add management subsys changes

### DIFF
--- a/doc/releases/release-notes-3.6.rst
+++ b/doc/releases/release-notes-3.6.rst
@@ -427,6 +427,14 @@ Libraries / Subsystems
   * Fixed an issue whereby messages that were too large to be sent over the UDP transport would
     wrongly return :c:enum:`MGMT_ERR_EINVAL` instead of :c:enum:`MGMT_ERR_EMSGSIZE`.
 
+  * Fixed an issue where confirming an image in Direct XIP mode would always confirm the image in
+    the primary slot even when executing from the secondary slot, now the currently active image is
+    always confirmed.
+
+  * Added support for retrieving registered command groups, to support registering and deregistering
+    default command groups at runtime, allowing an application to support multiple implementations
+    for the same command group.
+
 * File systems
 
 * Modem modules


### PR DESCRIPTION
Add to management subsystem section of release notes:
- Fix image confirm for Direct XIP
- Support for finding registered command groups