### PR TITLE
Delay relocation of data/bss init after MEMC init is completed

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -864,6 +864,17 @@ config CODE_DATA_RELOCATION
 	  the target regions should be specified in CMakeLists.txt using
 	  zephyr_code_relocate().
 
+config DELAY_DATA_RELOCATION
+	bool "Support delayed data relocation/bss init"
+	depends on ARCH_HAS_CODE_DATA_RELOCATION
+	depends on CODE_DATA_RELOCATION
+	help
+	  Enable support for delaying data relocation and bss zero initialization. Enable this option when
+	  relocation must be delayed after the device driver initialization is finished.
+	  Delayed relocation will only be applied to memory regions (compatible zephyr,memory-region)
+	  which have delay-relocation property set. The delayed routines will be run
+	  after PRE_KERNEL_1 initialization has completed.
+
 menu "DSP Options"
 
 config DSP_SHARING

--- a/dts/bindings/base/zephyr,memory-region.yaml
+++ b/dts/bindings/base/zephyr,memory-region.yaml
@@ -16,3 +16,9 @@ properties:
       memory region in the final executable. The region address and size
       is taken from the <reg> property, while the name is the value of
       this property.
+
+  delay-relocation:
+    type: boolean
+    description: |
+      Delay .data relocation and .bss zero initialization until PRE_KERNEL_1
+      initialization levels have completed.

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -198,7 +198,7 @@ void z_bss_zero(void)
 
 #ifdef CONFIG_LINKER_USE_BOOT_SECTION
 /**
- * @brief Clear BSS within the bot region
+ * @brief Clear BSS within the boot region
  *
  * This routine clears the BSS within the boot region.
  * This is separate from z_bss_zero() as boot region may
@@ -574,6 +574,15 @@ FUNC_NORETURN void z_cstart(void)
 
 	/* perform basic hardware initialization */
 	z_sys_init_run_level(INIT_LEVEL_PRE_KERNEL_1);
+
+#ifdef CONFIG_DELAY_DATA_RELOCATION
+	extern void bss_zeroing_relocation_delayed(void);
+	extern void data_copy_xip_relocation_delayed(void);
+
+	bss_zeroing_relocation_delayed();
+	data_copy_xip_relocation_delayed();
+#endif	/* CONFIG_DELAY_DATA_RELOCATION */
+
 	z_sys_init_run_level(INIT_LEVEL_PRE_KERNEL_2);
 
 #ifdef CONFIG_STACK_CANARIES


### PR DESCRIPTION
Currently, when relocating to external SRAM regions via MEMC drivers, the relocation/zero initialization is done before the MEMC drivers are initialized.

See issue https://github.com/zephyrproject-rtos/zephyr/issues/68884

This patch delays initialization after PRE_KERNEL_1 level.
The initialization is only delayed on devicetree memory  regions with delay-relocation property set.

Note, MEMC drivers (i.e. Atmel SAM SMC) use POST_KERNEL level, so their initialization levels would have to be updated. 
