### PR TITLE
drivers: ecia: microchip: Prevent lost eSPI interrupts

### DIFF
--- a/drivers/interrupt_controller/intc_mchp_ecia_xec.c
+++ b/drivers/interrupt_controller/intc_mchp_ecia_xec.c
@@ -476,6 +476,10 @@ static void xec_girq_isr(const struct device *dev_girq)
 	for (int i = 0; result && i < 32; i++) {
 		uint8_t bitpos = 31 - (__builtin_clz(result) & 0x1f);
 
+		/* clear GIRQ latched status */
+		girq->SRC = BIT(bitpos);
+		result &= ~BIT(bitpos);
+
 		/* is it an implemented source? */
 		if (cfg->sources[bitpos] & BIT(7)) {
 			/* yes, get the index by removing bit[7] flag */
@@ -489,10 +493,6 @@ static void xec_girq_isr(const struct device *dev_girq)
 		} else { /* paranoia, we should not get here... */
 			girq->EN_CLR = BIT(bitpos);
 		}
-
-		/* clear GIRQ latched status */
-		girq->SRC = BIT(bitpos);
-		result &= ~BIT(bitpos);
 	}
 }
 #endif


### PR DESCRIPTION
Clearing virtual wire interrupt after calling callback may cause interrupt miss if the same virtual wire changes due to action in handler.

e.g. HOST_RST_WRN pulse within 50 us