### PR TITLE
soc: xtensa: intel_adsp: restore bootctl with per-core state

### DIFF
--- a/soc/xtensa/intel_adsp/ace/power.c
+++ b/soc/xtensa/intel_adsp/ace/power.c
@@ -354,7 +354,7 @@ void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 	if (state == PM_STATE_SOFT_OFF) {
 		/* restore clock gating state */
 		DSPCS.bootctl[cpu].bctl |=
-			(core_desc[0].bctl & DSPBR_BCTL_WAITIPCG);
+			(core_desc[cpu].bctl & DSPBR_BCTL_WAITIPCG);
 
 #ifdef CONFIG_ADSP_IMR_CONTEXT_SAVE
 		if (cpu == 0) {


### PR DESCRIPTION
When exiting PM_STATE_SOFT_OFF, the primary core state is always used to restore bootctl register and the clock and power gating settings.

This can lead to problems if non-primary core is powered up and down many times before primary core 0 is powered down the first time. The saved state in core_desc[0].bctl will be null, and as a result- power gating and clock gating is not disabled correctly for non-primary cores.

Link: https://github.com/thesofproject/sof/issues/8642