### PR TITLE
modem: hl7800: fix parsing APN username

### DIFF
--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -2719,6 +2719,9 @@ static bool on_cmd_atcmdinfo_pdp_authentication_cfg(struct net_buf **buf,
 					MDM_HL7800_APN_USERNAME_MAX_STRLEN)) {
 					iface_ctx.mdm_apn.username[i++] = *p++;
 				}
+			} else {
+				LOG_WRN("Issue parsing APN username");
+				goto done;
 			}
 			LOG_INF("APN Username: %s",
 				iface_ctx.mdm_apn.username);
@@ -2737,6 +2740,7 @@ static bool on_cmd_atcmdinfo_pdp_authentication_cfg(struct net_buf **buf,
 				iface_ctx.mdm_apn.password);
 		}
 	}
+done:
 	net_buf_remove(buf, line_length);
 	net_buf_skipcrlf(buf);
 


### PR DESCRIPTION
Ensure a null reference cannot happen if there is an issue parsing the APN username.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/58567