### PR TITLE
drivers: sensor: ltrf216a: fix overflow in conversion of raw sensor value

### DIFF
--- a/drivers/sensor/ltrf216a/ltrf216a.c
+++ b/drivers/sensor/ltrf216a/ltrf216a.c
@@ -127,7 +127,7 @@ static int ltrf216a_channel_get(const struct device *dev, enum sensor_channel ch
 	 * 0.45 -> 45 / 100, multiplied by 1000000 for millilux
 	 * gain 3 (default), integration time 100ms=1
 	 */
-	uint64_t microlux = (greendata * 45000 * LTRF216A_WIN_FAC * 10) / (3 * 1);
+	uint64_t microlux = ((uint64_t)greendata * 45000 * LTRF216A_WIN_FAC * 10) / (3 * 1);
 
 	val->val1 = microlux / 1000000;
 	val->val2 = microlux % 1000000;


### PR DESCRIPTION
The conversion of the raw sensor value overflows because only a 32 bit multiplication is executed.
Fix the issue by promoting the raw sensor value to uint64_t before executing the multiplication.

Analysis:
The current implementation overflows for all raw values grater than 9544(14-bit).
But according to the datasheet the sensor has a maximum resolution of 20-bit. So Multiplying that value with 450.000 would need at least 39 bit arithmetic to avoid an overflow, hence do it using 64-bit arithmetic.

Fixes CID 330657
Closes #65329
