### PR TITLE
boards: lpcxpresso55s69: Fix misnomer

### DIFF
--- a/boards/nxp/lpcxpresso55s69/CMakeLists.txt
+++ b/boards/nxp/lpcxpresso55s69/CMakeLists.txt
@@ -6,4 +6,4 @@
 #
 
 zephyr_library()
-zephyr_library_sources(pinmux.c)
+zephyr_library_sources(board.c)

--- a/boards/nxp/lpcxpresso55s69/board.c
+++ b/boards/nxp/lpcxpresso55s69/board.c
@@ -6,10 +6,9 @@
 #include <zephyr/init.h>
 #include <zephyr/devicetree.h>
 #include <fsl_common.h>
-#include <fsl_iocon.h>
 #include <soc.h>
 
-static int lpcxpresso_55s69_pinmux_init(void)
+static int lpcxpresso_55s69_board_init(void)
 {
 
 #if (DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(flexcomm6), nxp_lpc_i2s, okay)) && \
@@ -52,4 +51,4 @@ static int lpcxpresso_55s69_pinmux_init(void)
 	return 0;
 }
 
-SYS_INIT(lpcxpresso_55s69_pinmux_init,  PRE_KERNEL_1, 0);
+SYS_INIT(lpcxpresso_55s69_board_init,  PRE_KERNEL_1, 0);


### PR DESCRIPTION
pinmux.c is inaptly named since it has nothing to do with pinmux. Also, remove inclusion of iocon.h since this file does not use it, as this file has nothing to do with pinmux.

Fixes #59185