### PR TITLE
drivers: wifi: esp_at: fix ssid_len calculation for AP query.

### DIFF
--- a/drivers/wifi/esp_at/esp.c
+++ b/drivers/wifi/esp_at/esp.c
@@ -7,6 +7,9 @@
 
 #define DT_DRV_COMPAT espressif_esp_at
 
+#undef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(wifi_esp_at, CONFIG_WIFI_LOG_LEVEL);
 
@@ -16,6 +19,7 @@ LOG_MODULE_REGISTER(wifi_esp_at, CONFIG_WIFI_LOG_LEVEL);
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/uart.h>
@@ -319,7 +323,7 @@ MODEM_CMD_DEFINE(on_cmd_cwjap)
 	}
 
 	strncpy(status->ssid, ssid, sizeof(status->ssid));
-	status->ssid_len = strlen(status->ssid);
+	status->ssid_len = strnlen(status->ssid, sizeof(status->ssid));
 
 	err = net_bytes_from_str(status->bssid, sizeof(status->bssid), bssid);
 	if (err) {


### PR DESCRIPTION
The driver seems to be designed to use the very last byte of the ssid buffer(scan, connect), so null terminating the ssid string of the status query might have unintended consequences.
However we should not use strlen to determine the ssid_len, to avoid depending on the following buffer(bssid) to be zeroed.
Related to CID 316354

Please let me know if you agree, then we should mark #58587 as false positive and close that issue as won't fix.