### PR TITLE
doc: fix include path of log_ctrl.h

### DIFF
--- a/doc/services/logging/index.rst
+++ b/doc/services/logging/index.rst
@@ -318,7 +318,7 @@ The following snippet shows how logging can be processed in simple forever loop.
 
 .. code-block:: c
 
-   #include <zephyr/log_ctrl.h>
+   #include <zephyr/logging/log_ctrl.h>
 
    int main(void)
    {


### PR DESCRIPTION
fix zephyr/log_ctrl.h -> zephyr/logging/log_ctrl.h

Fixes #68902

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
