### PR TITLE
drivers: i2c_mchp: Replace slave by target

### DIFF
--- a/drivers/i2c/i2c_mchp_xec.c
+++ b/drivers/i2c/i2c_mchp_xec.c
@@ -768,7 +768,7 @@ clear_iag:
 }
 
 #ifdef CONFIG_I2C_TARGET
-static int i2c_xec_slave_register(const struct device *dev,
+static int i2c_xec_target_register(const struct device *dev,
 				  struct i2c_target_config *config)
 {
 	const struct i2c_xec_config *cfg = dev->config;
@@ -811,7 +811,7 @@ static int i2c_xec_slave_register(const struct device *dev,
 	return 0;
 }
 
-static int i2c_xec_slave_unregister(const struct device *dev,
+static int i2c_xec_target_unregister(const struct device *dev,
 				    struct i2c_target_config *config)
 {
 	const struct i2c_xec_config *cfg = dev->config;
@@ -833,8 +833,8 @@ static const struct i2c_driver_api i2c_xec_driver_api = {
 	.configure = i2c_xec_configure,
 	.transfer = i2c_xec_transfer,
 #ifdef CONFIG_I2C_TARGET
-	.slave_register = i2c_xec_slave_register,
-	.slave_unregister = i2c_xec_slave_unregister,
+	.target_register = i2c_xec_target_register,
+	.target_unregister = i2c_xec_target_unregister,
 #endif
 };
 


### PR DESCRIPTION
Replace slave_register with target_register and slave_unregister with target_unregister.