### PR TITLE
soc: riscv: nrf54h: fix VPR core dependencies

### DIFF
--- a/soc/riscv/nordic_nrf/common/vpr/Kconfig
+++ b/soc/riscv/nordic_nrf/common/vpr/Kconfig
@@ -5,7 +5,7 @@ config RISCV_CORE_NORDIC_VPR
 	bool "RISC-V Nordic VPR core"
 	default y
 	depends on DT_HAS_NORDIC_VPR_ENABLED
-	depends on RISCV
+	select RISCV
 	select ATOMIC_OPERATIONS_C
 	select RISCV_ISA_RV32E
 	select RISCV_ISA_EXT_M

--- a/soc/riscv/nordic_nrf/nrf54h/Kconfig.soc
+++ b/soc/riscv/nordic_nrf/nrf54h/Kconfig.soc
@@ -12,7 +12,7 @@ choice
 
 config SOC_NRF54H20_ENGA_CPUPPR
 	bool "nRF54H20 ENGA CPUPPR"
-	select RISCV
+	depends on RISCV_CORE_NORDIC_VPR
 
 endchoice
 


### PR DESCRIPTION
The actual RISC-V core needs to select RISCV, and specific SoC CPU depend on it.