### PR TITLE
net: trickle: Print the abs value using %u

### DIFF
--- a/subsys/net/lib/trickle/trickle.c
+++ b/subsys/net/lib/trickle/trickle.c
@@ -172,7 +172,7 @@ int net_trickle_create(struct net_trickle *trickle,
 
 	NET_ASSERT(trickle->Imax_abs);
 
-	NET_DBG("Imin %d Imax %u k %u Imax_abs %d",
+	NET_DBG("Imin %d Imax %u k %u Imax_abs %u",
 		trickle->Imin, trickle->Imax, trickle->k,
 		trickle->Imax_abs);
 


### PR DESCRIPTION
The Imax_abs value should be printed using %u instead of %d as it can be large and should be printed as positive value.