### PR TITLE
Set name for acquisition thread of MCP320x

### DIFF
--- a/drivers/adc/adc_mcp320x.c
+++ b/drivers/adc/adc_mcp320x.c
@@ -283,12 +283,14 @@ static int mcp320x_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	k_thread_create(&data->thread, data->stack,
+	k_tid_t tid = k_thread_create(&data->thread, data->stack,
 			K_KERNEL_STACK_SIZEOF(data->stack),
 			mcp320x_acquisition_thread,
 			data, NULL, NULL,
 			CONFIG_ADC_MCP320X_ACQUISITION_THREAD_PRIO,
 			0, K_NO_WAIT);
+
+	k_thread_name_set(tid, dev->name);
 
 	adc_context_unlock_unconditionally(&data->ctx);
 


### PR DESCRIPTION
Set the name of the acquisition thread for the ADC MCP320x.