### PR TITLE
boards: nucleo_f722ze: Add code-partition chosen

### DIFF
--- a/boards/arm/nucleo_f722ze/nucleo_f722ze.dts
+++ b/boards/arm/nucleo_f722ze/nucleo_f722ze.dts
@@ -21,6 +21,7 @@
 		zephyr,flash = &flash0;
 		zephyr,dtcm = &dtcm;
 		zephyr,canbus = &can1;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds {


### PR DESCRIPTION
If slots partitions are defined, related chosen should be configured.

Fixes build issue in samples/subsys/usb/dfu