### PR TITLE
hwmv2: Enhance board aliases & deprecation for HWMv2

### DIFF
--- a/cmake/modules/boards.cmake
+++ b/cmake/modules/boards.cmake
@@ -139,13 +139,13 @@ set(list_boards_commands
 
 if(NOT BOARD_DIR)
   if(BOARD_ALIAS)
-    execute_process(${list_boards_commands} --board=${BOARD_ALIAS} --format={name}\;{dir}\;{hwm}
+    execute_process(${list_boards_commands} --board=${BOARD_ALIAS} --cmakeformat={DIR}
                     OUTPUT_VARIABLE ret_board
                     ERROR_VARIABLE err_board
                     RESULT_VARIABLE ret_val
     )
-    list(GET ret_board 1 BOARD_HIDDEN_DIR)
-    string(STRIP "${BOARD_HIDDEN_DIR}" BOARD_HIDDEN_DIR)
+    string(STRIP "${ret_board}" ret_board)
+    cmake_parse_arguments(BOARD_HIDDEN "" "DIR" "" ${ret_board})
     set(BOARD_HIDDEN_DIR ${BOARD_HIDDEN_DIR} CACHE PATH "Path to a folder." FORCE)
 
     if(BOARD_HIDDEN_DIR)

--- a/cmake/modules/boards.cmake
+++ b/cmake/modules/boards.cmake
@@ -92,11 +92,30 @@ if(DEFINED ZEPHYR_BOARD_ALIASES)
     set(BOARD_IDENTIFIER ${BOARD_ALIAS_IDENTIFIER}${BOARD_IDENTIFIER})
   endif()
 endif()
+
 include(${ZEPHYR_BASE}/boards/deprecated.cmake)
 if(${BOARD}_DEPRECATED)
   set(BOARD_DEPRECATED ${BOARD} CACHE STRING "Deprecated board name, provided by user")
-  set(BOARD ${${BOARD}_DEPRECATED})
+  parse_board_components(${BOARD}_DEPRECATED BOARD BOARD_DEPRECATED_REVISION BOARD_DEPRECATED_IDENTIFIER)
   message(WARNING "Deprecated BOARD=${BOARD_DEPRECATED} name specified, board automatically changed to: ${BOARD}.")
+  if(DEFINED BOARD_DEPRECATED_REVISION)
+    if(DEFINED BOARD_REVISION)
+      message(FATAL_ERROR
+        "Invalid board revision: ${BOARD_REVISION}\n"
+        "Deprecated board '${BOARD_DEPRECATED}' is now implemented as a revision of another board "
+        "(${BOARD}@${BOARD_DEPRECATED_REVISION}), so the specified revision does not apply. "
+        "Please consult the documentation for '${BOARD}' to see how to build for the new board."
+      )
+    endif()
+    set(BOARD_REVISION ${BOARD_DEPRECATED_REVISION})
+  endif()
+  if(DEFINED BOARD_IDENTIFIER)
+    message(FATAL_ERROR
+      "Deprecated boards cannot have board identifiers: ${BOARD_DEPRECATED}${BOARD_IDENTIFIER}.\n"
+      "Please consult the documentation for '${BOARD}' to see how to build for the new board."
+    )
+  endif()
+  set(BOARD_IDENTIFIER ${BOARD_DEPRECATED_IDENTIFIER})
 endif()
 
 zephyr_boilerplate_watch(BOARD)


### PR DESCRIPTION
To address concerns about lengthy board identifiers in HWMv2, the proposal is to apply the existing BOARD_ALIAS feature, like so:
```
set(<alias>_BOARD_ALIAS <board>/<soc>)
```
It should then be possible to build with either:
```
-DBOARD=<alias>            # expands to <board>/<soc>
-DBOARD=<alias>/<variant>  # expands to <board>/<soc>/<variant>
```
However, this wouldn't work out of the box. A board alias can only be expanded to a board name, without revision or identifier, because the alias substitution happens after having parsed BOARD as user input - namely, into BOARD (name), BOARD_REVISION, and BOARD_IDENTIFIER.

Furthermore, this means that in the legacy model, it was possible to build with `-DBOARD=<alias>@<revision>`, and it would resolve to the actual board name + revision.

To support both the old and new use cases, we can parse the alias just like BOARD itself, then concatenate their identifiers as shown above. Adding a revision works as before, but now it is also possible for the alias to set its own revision. In this example:
```
set(<alias>_BOARD_ALIAS <board>@<rev-A>/<soc>/<variant>)
```
`<rev-A>` is treated as the default revision, and it can be overridden:
```
-DBOARD=<alias>          # expands to <board>@<rev-A>/<soc>/<variant>
-DBOARD=<alias>@<rev-B>  # expands to <board>@<rev-B>/<soc>/<variant>
```