### PR TITLE
boards: stm32h573i_dk: Enable debug support with pyocd

### DIFF
--- a/boards/arm/stm32h573i_dk/board.cmake
+++ b/boards/arm/stm32h573i_dk/board.cmake
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(stm32cubeprogrammer "--erase" "--port=swd" "--reset-mode=hw")
+board_runner_args(pyocd "--target=stm32h573iikx")
 
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 # FIXME: openocd runner not yet available.

--- a/boards/arm/stm32h573i_dk/doc/index.rst
+++ b/boards/arm/stm32h573i_dk/doc/index.rst
@@ -293,8 +293,16 @@ You should see the following message on the console:
 Debugging
 =========
 
-You can debug an application in the usual way.  Here is an example for the
-:ref:`hello_world` application.
+Waiting for openocd support, debugging could be performed with pyocd which
+requires to enable "pack" support with the following pyocd command:
+
+.. code-block:: console
+
+   $ pyocd pack --update
+   $ pyocd pack --install stm32h5
+
+Once installed, you can debug an application in the usual way. Here is an
+example for the :ref:`hello_world` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world


### PR DESCRIPTION
Support of stm32h5 targets with pyocd is required to allow debugging. Provide runner configuration and update board documentation.