### PR TITLE
dts: stm32h7.dtsi: Add missing timer definitions

### DIFF
--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -135,6 +135,50 @@
 				status = "disabled";
 			};
 		};
+
+		timers23: timers@0x4000e000 {
+			compatible = "st,stm32-timers";
+			reg = <0x4000e000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x01000000>;
+			resets = <&rctl STM32_RESET(APB1H, 24U)>;
+			interrupts = <161 0>;
+			interrupt-names = "global";
+			st,prescaler = <0>;
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+		};
+
+		timers24: timers@4000e400 {
+			compatible = "st,stm32-timers";
+			reg = <0x4000e400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x02000000>;
+			resets = <&rctl STM32_RESET(APB1H, 25U)>;
+			interrupts = <162 0>;
+			interrupt-names = "global";
+			st,prescaler = <0>;
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+		};
 	};
 
 	/* D1 domain, AXI SRAM (128KB with shared ITCM 192KB as `TCM_AXI_SHARED` is `000`) */


### PR DESCRIPTION
TIM23/TIM24 are functionally equal to TIM2/TIM5, but regarding @erwango they are just not defined in ~~stm32h7.dtsi~~ stm32h723.dtsi. This PR adds their definitions.