### PR TITLE
logging: rename log2_generic to log_generic

### DIFF
--- a/include/zephyr/logging/log_core.h
+++ b/include/zephyr/logging/log_core.h
@@ -501,7 +501,7 @@ void z_log_printf_arg_checker(const char *fmt, ...)
 }
 
 /**
- * @brief Writes a generic log message to the logging v2.
+ * @brief Write a generic log message.
  *
  * @note This function is intended to be used when porting other log systems.
  *
@@ -509,7 +509,7 @@ void z_log_printf_arg_checker(const char *fmt, ...)
  * @param fmt            String to format.
  * @param ap             Pointer to arguments list.
  */
-static inline void log2_generic(uint8_t level, const char *fmt, va_list ap)
+static inline void log_generic(uint8_t level, const char *fmt, va_list ap)
 {
 	z_log_msg_runtime_vcreate(Z_LOG_LOCAL_DOMAIN_ID, NULL, level,
 				   NULL, 0, 0, fmt, ap);

--- a/samples/subsys/logging/logger/src/ext_log_system_adapter.c
+++ b/samples/subsys/logging/logger/src/ext_log_system_adapter.c
@@ -27,7 +27,7 @@ static void log_handler(enum ext_log_level level, const char *fmt, ...)
 	va_list ap;
 
 	va_start(ap, fmt);
-	log2_generic(log_level_lut[level], fmt, ap);
+	log_generic(log_level_lut[level], fmt, ap);
 	va_end(ap);
 }
 

--- a/tests/subsys/logging/log_core_additional/src/log_test.c
+++ b/tests/subsys/logging/log_core_additional/src/log_test.c
@@ -452,7 +452,7 @@ static void call_log_generic(const char *fmt, ...)
 	va_list ap;
 
 	va_start(ap, fmt);
-	log2_generic(LOG_LEVEL_INF, fmt, ap);
+	log_generic(LOG_LEVEL_INF, fmt, ap);
 	va_end(ap);
 }
 

--- a/tests/subsys/logging/log_core_additional/src/log_test_user.c
+++ b/tests/subsys/logging/log_core_additional/src/log_test_user.c
@@ -52,7 +52,7 @@ static void call_log_generic(uint32_t source_id, const char *fmt, ...)
 	va_list ap;
 
 	va_start(ap, fmt);
-	log2_generic(LOG_LEVEL_INF, fmt, ap);
+	log_generic(LOG_LEVEL_INF, fmt, ap);
 	va_end(ap);
 }
 


### PR DESCRIPTION
The `log2` prefix was deprecated and changed to `log` some time ago, but `log2_generic()` seems to have been inadvertently left with the old prefix.

Rename the function and instances in-tree.