### PR TITLE
boards: nrf54*: Add a note about current status

### DIFF
--- a/boards/arm/nrf54h20pdk_nrf54h20/doc/index.rst
+++ b/boards/arm/nrf54h20pdk_nrf54h20/doc/index.rst
@@ -6,6 +6,11 @@ nRF54H20 PDK
 Overview
 ********
 
+.. note::
+
+   All software for the nRF54H20 SoC is experimental and hardware availability
+   is restricted to the participants in the limited sampling program.
+
 The nRF54H20 PDK is a single-board preview development kit for evaluation
 and development on the Nordic nRF54H20 System-on-Chip (SoC).
 

--- a/boards/arm/nrf54l15pdk_nrf54l15/doc/index.rst
+++ b/boards/arm/nrf54l15pdk_nrf54l15/doc/index.rst
@@ -6,6 +6,11 @@ nRF54L15 PDK
 Overview
 ********
 
+.. note::
+
+   All software for the nRF54L15 SoC is experimental and hardware availability
+   is restricted to the participants in the limited sampling program.
+
 The nRF54L15 Preview Development Kit hardware provides
 support for the Nordic Semiconductor nRF54L15 Arm Cortex-M33 CPU and
 the following devices:


### PR DESCRIPTION
The nRF54* SoCs are in a very early stage of production and the software supporting them is to be considered experimental. Document this accordingly in the respective boards.