### PR TITLE
boards: arm: nrf52840_papyr/nrf52840_blip: add zephyr,code-partition chosen property

### DIFF
--- a/boards/arm/nrf52840_blip/nrf52840_blip.dts
+++ b/boards/arm/nrf52840_blip/nrf52840_blip.dts
@@ -17,6 +17,7 @@
 	compatible = "nordic,pca10056-dk";
 
 	chosen {
+		zephyr,code-partition = &slot0_partition;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-mcumgr = &uart0;

--- a/boards/arm/nrf52840_papyr/nrf52840_papyr.dts
+++ b/boards/arm/nrf52840_papyr/nrf52840_papyr.dts
@@ -14,6 +14,7 @@
 	compatible = "nordic,pca10056-dk";
 
 	chosen {
+		zephyr,code-partition = &slot0_partition;
 		zephyr,console = &uart0;
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,shell-uart = &uart0;


### PR DESCRIPTION
Add missing `zephyr,code-partition` chosen properties to the `nrf52840_papyr` and `nrf52840_blip` boards.

The missing properties are causing CI build failures in https://github.com/zephyrproject-rtos/zephyr/runs/21488672458