### PR TITLE
Bluetooth: Controller: Fix lll ISO stream get by group

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll_conn_iso.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_conn_iso.h
@@ -122,6 +122,9 @@ void lll_conn_iso_flush(uint16_t handle, struct lll_conn_iso_stream *lll);
 extern struct lll_conn_iso_stream *
 ull_conn_iso_lll_stream_get_by_group(struct lll_conn_iso_group *cig_lll,
 				     uint16_t *handle_iter);
+extern struct lll_conn_iso_stream *
+ull_conn_iso_lll_stream_sorted_get_by_group(struct lll_conn_iso_group *cig_lll,
+					    uint16_t *handle_iter);
 extern struct lll_conn_iso_group *
 ull_conn_iso_lll_group_get_by_stream(struct lll_conn_iso_stream *cis_lll);
 extern struct lll_conn_iso_stream *ull_conn_iso_lll_stream_get(uint16_t handle);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
@@ -168,7 +168,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 	/* Get the first CIS */
 	cis_handle_curr = UINT16_MAX;
 	do {
-		cis_lll = ull_conn_iso_lll_stream_get_by_group(cig_lll, &cis_handle_curr);
+		cis_lll = ull_conn_iso_lll_stream_sorted_get_by_group(cig_lll, &cis_handle_curr);
 	} while (cis_lll && !cis_lll->active);
 
 	LL_ASSERT(cis_lll);
@@ -373,7 +373,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 		} while (link);
 
 		do {
-			cis_lll = ull_conn_iso_lll_stream_get_by_group(cig_lll, &cis_handle);
+			cis_lll = ull_conn_iso_lll_stream_sorted_get_by_group(cig_lll, &cis_handle);
 		} while (cis_lll && !cis_lll->active);
 
 		if (!cis_lll) {
@@ -418,7 +418,8 @@ static void abort_cb(struct lll_prepare_param *prepare_param, void *param)
 
 		/* Adjust the SN, NESN and payload_count on abort for CISes  */
 		do {
-			next_cis_lll = ull_conn_iso_lll_stream_get_by_group(cig_lll,
+			next_cis_lll =
+				ull_conn_iso_lll_stream_sorted_get_by_group(cig_lll,
 									    &cis_handle_curr);
 			if (next_cis_lll && next_cis_lll->active) {
 				payload_count_rx_flush_or_txrx_inc(next_cis_lll);
@@ -765,7 +766,8 @@ static void isr_rx(void *param)
 		cig_lll = ull_conn_iso_lll_group_get_by_stream(cis_lll);
 		cis_handle = cis_handle_curr;
 		do {
-			next_cis_lll = ull_conn_iso_lll_stream_get_by_group(cig_lll, &cis_handle);
+			next_cis_lll =
+				ull_conn_iso_lll_stream_sorted_get_by_group(cig_lll, &cis_handle);
 		} while (next_cis_lll && !next_cis_lll->active);
 
 		if (!next_cis_lll) {
@@ -966,7 +968,7 @@ static void next_cis_prepare(void *param)
 	next_cis_lll = cis_lll;
 	cis_handle = cis_handle_curr;
 	do {
-		next_cis_lll = ull_conn_iso_lll_stream_get_by_group(cig_lll, &cis_handle);
+		next_cis_lll = ull_conn_iso_lll_stream_sorted_get_by_group(cig_lll, &cis_handle);
 	} while (next_cis_lll && !next_cis_lll->active);
 
 	if (!next_cis_lll) {

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
@@ -300,6 +300,86 @@ ull_conn_iso_lll_stream_get_by_group(struct lll_conn_iso_group *cig_lll,
 	return &cis->lll;
 }
 
+/*
+ * Helper function to iterate and return CIS LLL context sorted based on
+ * ascending order of the CIS offset from associated ACL and the CIG.
+ * This implementation be used by peripheral LLL to schedule subevents
+ * as CISes can be created in any order and ascending/descending order of
+ * CIS offsets used when creating CISes to peripheral.
+ *
+ * NOTE: This implementation assumes CISes created from same ACL. Support
+ *       for CISes created from different peer centrals is not supported yet.
+ */
+struct lll_conn_iso_stream *
+ull_conn_iso_lll_stream_sorted_get_by_group(struct lll_conn_iso_group *cig_lll,
+					    uint16_t *handle_iter)
+{
+	struct ll_conn_iso_stream *cis_next = NULL;
+	struct ll_conn_iso_group *cig;
+	uint32_t cis_offset_curr;
+	uint32_t cis_offset_next;
+	uint16_t handle;
+
+	cig = HDR_LLL2ULL(cig_lll);
+
+	if ((handle_iter == NULL) || ((*handle_iter) == UINT16_MAX)) {
+		/* First in the iteration, start with a minimum offset value and
+		 * find the first CIS offset of the active CIS.
+		 */
+		cis_offset_curr = 0U;
+	} else {
+		/* Subsequent iteration, get reference to current CIS and use
+		 * its CIS offset to find the next active CIS with offset
+		 * greater than the current CIS.
+		 */
+		struct ll_conn_iso_stream *cis_curr;
+
+		cis_curr = ll_conn_iso_stream_get(*handle_iter);
+		cis_offset_curr = cis_curr->offset;
+	}
+
+	cis_offset_next = UINT32_MAX;
+
+	/* Loop through all CIS contexts */
+	for (handle = LL_CIS_HANDLE_BASE; handle <= LL_CIS_HANDLE_LAST;
+	     handle++) {
+		struct ll_conn_iso_stream *cis;
+
+		/* Get CIS reference corresponding to loop handle */
+		cis = ll_conn_iso_stream_get(handle);
+
+		/* Match CIS contexts associated with the CIG */
+		if (cis->group == cig) {
+			if (cis->offset <= cis_offset_curr) {
+				/* Skip already returned CISes with offsets less
+				 * than the current CIS.
+				 */
+				continue;
+			}
+
+			/* Remember CIS with offset greater than current but
+			 * lower than previous that we remember as the next CIS
+			 * in ascending order.
+			 */
+			if (cis->offset < cis_offset_next) {
+				cis_next = cis;
+				cis_offset_next = cis_next->offset;
+
+				if (handle_iter) {
+					(*handle_iter) = handle;
+				}
+			}
+		}
+	}
+
+	if (cis_next) {
+		/* Found the next CIS with offset in ascending order. */
+		return &cis_next->lll;
+	}
+
+	return NULL;
+}
+
 struct lll_conn_iso_group *
 ull_conn_iso_lll_group_get_by_stream(struct lll_conn_iso_stream *cis_lll)
 {


### PR DESCRIPTION
Fix LLL ISO stream get by group to return stream context sorted by CIS offset in ascending order.