### PR TITLE
boards: x86/acrn: add devicetree PCIe controller node

### DIFF
--- a/boards/x86/acrn/acrn.dts
+++ b/boards/x86/acrn/acrn.dts
@@ -27,6 +27,14 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 	};
+
+	pcie0: pcie0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "pcie-controller";
+		acpi-hid = "PNP0A08";
+		ranges;
+	};
 };
 
 &uart0 {


### PR DESCRIPTION
Commit 940c66f82e8cd3fe1850d95b6ca57cbc4e365e12 added a bunch of ACPI PNP ID to x86 boards but skipped those for ACRN. And commit 34a2fbfba1ce3df187bd5177b472b304b1d257c8 changed the behavior of PCIe controller to looking for PNP ID, it results in compilation error due to build asserts. So add the PCIe controller node to the ACRN base DTS file.

Fixes #68956