### PR TITLE
drivers: eth_mcux: Fix PM_DEVICE build failure

### DIFF
--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -240,6 +240,7 @@ struct eth_context {
 	ROUND_UP(ENET_FRAME_MAX_FRAMELEN, ENET_BUFF_ALIGNMENT)
 #endif /* CONFIG_NET_VLAN */
 
+#ifdef CONFIG_SOC_FAMILY_KINETIS
 #if defined(CONFIG_NET_POWER_MANAGEMENT)
 static void eth_mcux_phy_enter_reset(struct eth_context *context);
 void eth_mcux_phy_stop(struct eth_context *context);
@@ -292,6 +293,7 @@ out:
 	return ret;
 }
 #endif /* CONFIG_NET_POWER_MANAGEMENT */
+#endif /* CONFIG_SOC_FAMILY_KINETIS */
 
 #if ETH_MCUX_FIXED_LINK
 static void eth_mcux_get_phy_params(phy_duplex_t *p_phy_duplex,
@@ -1491,6 +1493,7 @@ static void eth_mcux_err_isr(const struct device *dev)
 		    (ETH_MCUX_MAC_ADDR_LOCAL(n)),			\
 		    (ETH_MCUX_MAC_ADDR_GENERATE(n)))
 
+#ifdef CONFIG_SOC_FAMILY_KINETIS
 #define ETH_MCUX_POWER_INIT(n)						\
 	.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),		\
 
@@ -1498,6 +1501,15 @@ static void eth_mcux_err_isr(const struct device *dev)
 	COND_CODE_1(CONFIG_NET_POWER_MANAGEMENT,			\
 		    (ETH_MCUX_POWER_INIT(n)),				\
 		    (ETH_MCUX_NONE))
+#define ETH_MCUX_PM_DEVICE_INIT(n)					\
+	PM_DEVICE_DT_INST_DEFINE(n, eth_mcux_device_pm_action);
+#define ETH_MCUX_PM_DEVICE_GET(n) PM_DEVICE_DT_INST_GET(n)
+#else
+#define ETH_MCUX_POWER(n)
+#define ETH_MCUX_PM_DEVICE_INIT(n)
+#define ETH_MCUX_PM_DEVICE_GET(n) NULL
+#endif /* CONFIG_SOC_FAMILY_KINETIS */
+
 #define ETH_MCUX_GEN_MAC(n)                                             \
 	COND_CODE_0(ETH_MCUX_MAC_ADDR_TO_BOOL(n),                       \
 		    (ETH_MCUX_GENERATE_MAC(n)),                         \
@@ -1629,11 +1641,11 @@ static void eth_mcux_err_isr(const struct device *dev)
 		ETH_MCUX_PTP_FRAMEINFO(n)				\
 	};								\
 									\
-	PM_DEVICE_DT_INST_DEFINE(n, eth_mcux_device_pm_action);		\
+	ETH_MCUX_PM_DEVICE_INIT(n)					\
 									\
 	ETH_NET_DEVICE_DT_INST_DEFINE(n,				\
 			    eth_init,					\
-			    PM_DEVICE_DT_INST_GET(n),			\
+			    ETH_MCUX_PM_DEVICE_GET(n),			\
 			    &eth##n##_context,				\
 			    &eth##n##_buffer_config,			\
 			    CONFIG_ETH_INIT_PRIORITY,			\


### PR DESCRIPTION
Enabling device power management while building for RT series platform while using ethernet currently breaks the build, RT series has not been tested with this net PM code anyways, so disable it for now except for kinetis family on which it has been tested

Fixes #67630