### PR TITLE
drivers: bbram: stm32: add include to fix compilation error

### DIFF
--- a/drivers/bbram/bbram_stm32.c
+++ b/drivers/bbram/bbram_stm32.c
@@ -11,6 +11,7 @@
 #include <zephyr/drivers/bbram.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
+#include <stm32_ll_rtc.h>
 LOG_MODULE_REGISTER(bbram, CONFIG_BBRAM_LOG_LEVEL);
 
 #define STM32_BKP_REG_BYTES		 4


### PR DESCRIPTION
Driver BBRAM for STM32 had a compilation error: "unknown type name 'RTC_TypeDef'" due to missing include file.

Fixes #68958