### PR TITLE
Add: Support for pyocd runner for mr_canhubk3 board

### DIFF
--- a/boards/nxp/mr_canhubk3/board.cmake
+++ b/boards/nxp/mr_canhubk3/board.cmake
@@ -12,6 +12,8 @@ else()
 endif()
 
 board_runner_args(jlink "--device=S32K344" "--reset-after-load")
+board_runner_args(pyocd "--target=s32k344")
 
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/trace32.board.cmake)

--- a/boards/nxp/mr_canhubk3/doc/index.rst
+++ b/boards/nxp/mr_canhubk3/doc/index.rst
@@ -266,9 +266,10 @@ Programming and Debugging
 Applications for the ``mr_canhubk3`` board can be built in the usual way as
 documented in :ref:`build_an_application`.
 
-This board configuration supports `Lauterbach TRACE32`_ and `SEGGER J-Link`_
+This board configuration supports `Lauterbach TRACE32`_, `SEGGER J-Link`_ and `pyOCD`_
 West runners for flashing and debugging applications. Follow the steps described
-in :ref:`lauterbach-trace32-debug-host-tools` and :ref:`jlink-debug-host-tools`,
+in :ref:`lauterbach-trace32-debug-host-tools`, :ref:`jlink-debug-host-tools` and
+:ref:`pyocd-debug-host-tools`,
 to setup the flash and debug host tools for these runners, respectively. The
 default runner is J-Link.
 
@@ -276,7 +277,8 @@ Flashing
 ========
 
 Run the ``west flash`` command to flash the application using SEGGER J-Link.
-Alternatively, run ``west flash -r trace32`` to use Lauterbach TRACE32.
+Alternatively, run ``west flash -r trace32`` to use Lauterbach TRACE32, or
+``west flash -r pyocd``` to use pyOCD.
 
 The Lauterbach TRACE32 runner supports additional options that can be passed
 through command line:
@@ -309,8 +311,8 @@ Debugging
 =========
 
 Run the ``west debug`` command to start a GDB session using SEGGER J-Link.
-Alternatively, run ``west debug -r trace32`` to launch the Lauterbach TRACE32
-software debugging interface.
+Alternatively, run ``west debug -r trace32`` or ``west debug -r pyocd``
+to launch the Lauterbach TRACE32 or pyOCD software debugging interface respectively.
 
 References
 **********
@@ -337,3 +339,6 @@ References
 
 .. _SEGGER J-Link:
    https://wiki.segger.com/NXP_S32K3xx
+
+.. _pyOCD:
+   https://pyocd.io/


### PR DESCRIPTION
Modifying board.cmake file of mr_canhubk3 for pyocd support.