### PR TITLE
Bluetooth: CAP: Shell: Fix argument issue for unicast_stop

### DIFF
--- a/doc/connectivity/bluetooth/api/shell/cap.rst
+++ b/doc/connectivity/bluetooth/api/shell/cap.rst
@@ -60,7 +60,7 @@ the optionally included CSIS instance by calling (:code:`cap_initiator discover`
                       (default 1)] [conns (<cnt> | all) (default 1)]
      unicast_list    :Unicast list streams
      unicast_update  :Unicast Update <all | stream [stream [stream...]]>
-     unicast_stop    :Unicast stop all streams
+     unicast_stop    :Unicast stop streams <all | stream [stream [stream...]]>
      unicast_cancel  :Unicast cancel current procedure
 
 Before being able to perform any stream operation, the device must also perform the
@@ -120,24 +120,24 @@ To use multiple devices, simply connect to more and then use :code:`bt select` t
 the commands on.
 
 Once all devices have been connected and the respective discovery commands have been called, the
-:code:`cap_initiator unicast-start` command can be used to put one or more streams into the
+:code:`cap_initiator unicast_start` command can be used to put one or more streams into the
 streaming state.
 
 .. code-block:: console
 
-   uart:~$ cap_initiator unicast-start sinks 1 sources 0 conns all
+   uart:~$ cap_initiator unicast_start sinks 1 sources 0 conns all
    Setting up 1 sinks and 0 sources on each (2) conn
    Starting 1 streams
    Unicast start completed
 
-To stop all the streams that has been started, the :code:`cap_initiator unicast-stop` command can be
+To stop all the streams that has been started, the :code:`cap_initiator unicast_stop` command can be
 used.
 
 
 .. code-block:: console
 
-   uart:~$ cap_initiator unicast-stop
-   Unicast stopped for group 0x81e41c0 completed
+   uart:~$ cap_initiator unicast_stop all
+   Unicast stop completed
 
 CAP Commander
 *************

--- a/subsys/bluetooth/audio/shell/cap_initiator.c
+++ b/subsys/bluetooth/audio/shell/cap_initiator.c
@@ -66,7 +66,7 @@ static void unicast_stop_complete_cb(int err, struct bt_conn *conn)
 	} else if (err != 0) {
 		shell_error(ctx_shell, "Unicast stop failed for conn %p (%d)", conn, err);
 	} else {
-		shell_print(ctx_shell, "Unicast stopped completed");
+		shell_print(ctx_shell, "Unicast stop completed");
 
 		if (default_unicast_group != NULL) {
 			err = bt_bap_unicast_group_delete(default_unicast_group);
@@ -1224,8 +1224,9 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      0),
 	SHELL_CMD_ARG(unicast_update, NULL, "Unicast Update <all | stream [stream [stream...]]>",
 		      cmd_cap_initiator_unicast_update, 2, CAP_UNICAST_CLIENT_STREAM_COUNT),
-	SHELL_CMD_ARG(unicast_stop, NULL, "Unicast stop all streams",
-		      cmd_cap_initiator_unicast_stop, 1, 0),
+	SHELL_CMD_ARG(unicast_stop, NULL,
+		      "Unicast stop streams <all | stream [stream [stream...]]>",
+		      cmd_cap_initiator_unicast_stop, 2, CAP_UNICAST_CLIENT_STREAM_COUNT),
 	SHELL_CMD_ARG(unicast_cancel, NULL, "Unicast cancel current procedure",
 		      cmd_cap_initiator_unicast_cancel, 1, 0),
 #if UNICAST_SINK_SUPPORTED


### PR DESCRIPTION
The unicast_stop command takes either "all" or one or more stream pointers as argument, but the argument handler did not allow this.

The documentation for the command was also out of date.