### PR TITLE
drivers: dac: stm32: add dac value range check

### DIFF
--- a/drivers/dac/dac_stm32.c
+++ b/drivers/dac/dac_stm32.c
@@ -68,6 +68,11 @@ static int dac_stm32_write_value(const struct device *dev,
 		return -EINVAL;
 	}
 
+	if (value >= BIT(data->resolution)) {
+		LOG_ERR("Value %d is out of range", value);
+		return -EINVAL;
+	}
+
 	if (data->resolution == 8) {
 		LL_DAC_ConvertData8RightAligned(cfg->base,
 			table_channels[channel - STM32_FIRST_CHANNEL], value);


### PR DESCRIPTION
Compare value and DAC resolution in `dac_write_value` and return -ERANGE if the value is above supported resolution.