### PR TITLE
tests: bluetooth: Update ICS for Mesh v1.1, DFU v1.0 and MBT v1.0

### DIFF
--- a/tests/bluetooth/qualification/ICS_Zephyr_Bluetooth_Host.pts
+++ b/tests/bluetooth/qualification/ICS_Zephyr_Bluetooth_Host.pts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <project>
-  <qdid>225924</qdid>
+  <qdid>234540</qdid>
   <name>Zephyr_Bluetooth_Host</name>
   <pics>
     <profile>
@@ -2213,8 +2213,44 @@
     <profile>
       <name>MESH</name>
       <item>
+        <table>11</table>
+        <row>11</row>
+      </item>
+      <item>
+        <table>11</table>
+        <row>20</row>
+      </item>
+      <item>
+        <table>4</table>
+        <row>14</row>
+      </item>
+      <item>
+        <table>11</table>
+        <row>12</row>
+      </item>
+      <item>
+        <table>11</table>
+        <row>23</row>
+      </item>
+      <item>
+        <table>11</table>
+        <row>24</row>
+      </item>
+      <item>
+        <table>4</table>
+        <row>15</row>
+      </item>
+      <item>
         <table>12</table>
         <row>12</row>
+      </item>
+      <item>
+        <table>12</table>
+        <row>8</row>
+      </item>
+      <item>
+        <table>10</table>
+        <row>5</row>
       </item>
       <item>
         <table>18</table>
@@ -2225,28 +2261,80 @@
         <row>2</row>
       </item>
       <item>
+        <table>11</table>
+        <row>18</row>
+      </item>
+      <item>
+        <table>11</table>
+        <row>14</row>
+      </item>
+      <item>
+        <table>11</table>
+        <row>16</row>
+      </item>
+      <item>
         <table>4</table>
         <row>13</row>
+      </item>
+      <item>
+        <table>0</table>
+        <row>2</row>
+      </item>
+      <item>
+        <table>11</table>
+        <row>6</row>
+      </item>
+      <item>
+        <table>11</table>
+        <row>19</row>
       </item>
       <item>
         <table>2</table>
         <row>3</row>
       </item>
       <item>
-        <table>0a</table>
-        <row>3</row>
+        <table>18</table>
+        <row>13</row>
       </item>
       <item>
-        <table>0</table>
-        <row>1</row>
+        <table>11</table>
+        <row>15</row>
       </item>
       <item>
-        <table>0a</table>
-        <row>1</row>
+        <table>11</table>
+        <row>13</row>
       </item>
       <item>
-        <table>0a</table>
-        <row>2</row>
+        <table>12</table>
+        <row>7</row>
+      </item>
+      <item>
+        <table>11</table>
+        <row>17</row>
+      </item>
+      <item>
+        <table>4</table>
+        <row>16</row>
+      </item>
+      <item>
+        <table>11</table>
+        <row>5</row>
+      </item>
+      <item>
+        <table>11</table>
+        <row>22</row>
+      </item>
+      <item>
+        <table>11</table>
+        <row>21</row>
+      </item>
+      <item>
+        <table>12</table>
+        <row>11</row>
+      </item>
+      <item>
+        <table>4</table>
+        <row>17</row>
       </item>
       <item>
         <table>2</table>
@@ -9125,6 +9213,92 @@
       <item>
         <table>95</table>
         <row>6</row>
+      </item>
+    </profile>
+    <profile>
+      <name>MBT</name>
+      <item>
+        <table>10</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>3</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>20</table>
+        <row>2</row>
+      </item>
+      <item>
+        <table>20</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>3</table>
+        <row>2</row>
+      </item>
+      <item>
+        <table>0</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>10</table>
+        <row>2</row>
+      </item>
+    </profile>
+    <profile>
+      <name>DFU</name>
+      <item>
+        <table>3</table>
+        <row>3</row>
+      </item>
+      <item>
+        <table>3</table>
+        <row>2</row>
+      </item>
+      <item>
+        <table>22</table>
+        <row>3</row>
+      </item>
+      <item>
+        <table>10</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>11</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>30</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>0</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>11</table>
+        <row>2</row>
+      </item>
+      <item>
+        <table>3</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>20</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>22</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>21</table>
+        <row>2</row>
+      </item>
+      <item>
+        <table>21</table>
+        <row>1</row>
       </item>
     </profile>
   </pics>

--- a/tests/bluetooth/qualification/Project_Zephyr_Bluetooth_Host.bls
+++ b/tests/bluetooth/qualification/Project_Zephyr_Bluetooth_Host.bls
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <project>
-  <qdid>225924</qdid>
+  <qdid>234540</qdid>
   <project_name>Zephyr_Bluetooth_Host</project_name>
   <tcrl_version_id>83</tcrl_version_id>
   <integrated_qdids></integrated_qdids>
@@ -2216,8 +2216,44 @@
     <profile>
       <name>MESH</name>
       <item>
+        <table>11</table>
+        <row>11</row>
+      </item>
+      <item>
+        <table>11</table>
+        <row>20</row>
+      </item>
+      <item>
+        <table>4</table>
+        <row>14</row>
+      </item>
+      <item>
+        <table>11</table>
+        <row>12</row>
+      </item>
+      <item>
+        <table>11</table>
+        <row>23</row>
+      </item>
+      <item>
+        <table>11</table>
+        <row>24</row>
+      </item>
+      <item>
+        <table>4</table>
+        <row>15</row>
+      </item>
+      <item>
         <table>12</table>
         <row>12</row>
+      </item>
+      <item>
+        <table>12</table>
+        <row>8</row>
+      </item>
+      <item>
+        <table>10</table>
+        <row>5</row>
       </item>
       <item>
         <table>18</table>
@@ -2228,28 +2264,80 @@
         <row>2</row>
       </item>
       <item>
+        <table>11</table>
+        <row>18</row>
+      </item>
+      <item>
+        <table>11</table>
+        <row>14</row>
+      </item>
+      <item>
+        <table>11</table>
+        <row>16</row>
+      </item>
+      <item>
         <table>4</table>
         <row>13</row>
+      </item>
+      <item>
+        <table>0</table>
+        <row>2</row>
+      </item>
+      <item>
+        <table>11</table>
+        <row>6</row>
+      </item>
+      <item>
+        <table>11</table>
+        <row>19</row>
       </item>
       <item>
         <table>2</table>
         <row>3</row>
       </item>
       <item>
-        <table>0a</table>
-        <row>3</row>
+        <table>18</table>
+        <row>13</row>
       </item>
       <item>
-        <table>0</table>
-        <row>1</row>
+        <table>11</table>
+        <row>15</row>
       </item>
       <item>
-        <table>0a</table>
-        <row>1</row>
+        <table>11</table>
+        <row>13</row>
       </item>
       <item>
-        <table>0a</table>
-        <row>2</row>
+        <table>12</table>
+        <row>7</row>
+      </item>
+      <item>
+        <table>11</table>
+        <row>17</row>
+      </item>
+      <item>
+        <table>4</table>
+        <row>16</row>
+      </item>
+      <item>
+        <table>11</table>
+        <row>5</row>
+      </item>
+      <item>
+        <table>11</table>
+        <row>22</row>
+      </item>
+      <item>
+        <table>11</table>
+        <row>21</row>
+      </item>
+      <item>
+        <table>12</table>
+        <row>11</row>
+      </item>
+      <item>
+        <table>4</table>
+        <row>17</row>
       </item>
       <item>
         <table>2</table>
@@ -9128,6 +9216,92 @@
       <item>
         <table>95</table>
         <row>6</row>
+      </item>
+    </profile>
+    <profile>
+      <name>MBT</name>
+      <item>
+        <table>10</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>3</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>20</table>
+        <row>2</row>
+      </item>
+      <item>
+        <table>20</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>3</table>
+        <row>2</row>
+      </item>
+      <item>
+        <table>0</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>10</table>
+        <row>2</row>
+      </item>
+    </profile>
+    <profile>
+      <name>DFU</name>
+      <item>
+        <table>3</table>
+        <row>3</row>
+      </item>
+      <item>
+        <table>3</table>
+        <row>2</row>
+      </item>
+      <item>
+        <table>22</table>
+        <row>3</row>
+      </item>
+      <item>
+        <table>10</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>11</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>30</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>0</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>11</table>
+        <row>2</row>
+      </item>
+      <item>
+        <table>3</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>20</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>22</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>21</table>
+        <row>2</row>
+      </item>
+      <item>
+        <table>21</table>
+        <row>1</row>
       </item>
     </profile>
   </pics>


### PR DESCRIPTION
Mesh v1.1, DFU v1.0 and MBT v1.0 are supported by default in the stack. In this regard, this commit updates the ICS file and Launch Studio Project file to reflect supported features. Also, features that are neither supported nor fully implemented are dropped from the selection.

MESH

Mesh v1.0.1 is dropped and Mesh v1.1 is now selected.

Added features and models:
- Provisioning algorithm ECDH_P256 + HMAC_SHA256 + CCM_AES128.
- Node Provisioning Protocol Interface.
- Node address and composition refresh procedures.
- Private beacon server and client models.
- Remote provisioning server and client models.
- Composition data page 1 and 2.
- On-demand proxy server and client models.
- Solicitation PDU RPL configuration server model.
- Sending Proxy Solicitation.
- SAR configuration server and client models.
- Opcodes aggregator server and client models.
- Large composition data server and client models.
- Advertising with private network and node identity.

MBT

Mesh binary large object transfer model is added. Both client and
server models are supported.

DFU

Mesh device firmware update models are added.
- Firmware update server with pull/push mode BLOB transfer.
- Firmware distribution server with pull/push mode BLOB
transfer, store OOB firmware procedure and multiple image
support.
- Firmware update client with BLOB transfer.