### PR TITLE
doc: logging: remove references to logging v2

### DIFF
--- a/doc/services/logging/index.rst
+++ b/doc/services/logging/index.rst
@@ -660,7 +660,7 @@ not supported.  Occasionally, logging may inform backend about number of dropped
 messages with :c:func:`log_backend_dropped`. Message processing API is version
 specific.
 
-:c:func:`log_backend_msg2_process` is used for processing message. It is common for
+:c:func:`log_backend_msg_process` is used for processing message. It is common for
 standard and hexdump messages because log message hold string with arguments
 and data. It is also common for deferred and immediate logging.
 
@@ -670,7 +670,7 @@ Message formatting
 Logging provides set of function that can be used by the backend to format a
 message. Helper functions are available in :zephyr_file:`include/zephyr/logging/log_output.h`.
 
-Example message formatted using :c:func:`log_output_msg2_process`.
+Example message formatted using :c:func:`log_output_msg_process`.
 
 .. code-block:: console
 


### PR DESCRIPTION
Since the removal of logging v1, there's only one version, so remove the '2' from the function references for the docs to link to the correct functions properly.

https://docs.zephyrproject.org/latest/services/logging/index.html#logging-backends

[Preview](https://builds.zephyrproject.io/zephyr/pr/68976/docs/services/logging/index.html#logging-backends)