### PR TITLE
[HWMv2] kconfig: workaround to allow doc build [REVERT ME]

### DIFF
--- a/boards/Kconfig.v1
+++ b/boards/Kconfig.v1
@@ -5,6 +5,6 @@
 choice
 	prompt "Board Selection"
 
-source "$(BOARD_DIR)/Kconfig.board"
+osource "$(BOARD_DIR)/Kconfig.board"
 
 endchoice


### PR DESCRIPTION
Allow docs to build. This is a workaround.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
