### PR TITLE
soc: arm: stm32 with USB Type-C dead battery disabled if needed

### DIFF
--- a/soc/st/stm32/stm32g4x/soc.c
+++ b/soc/st/stm32/stm32g4x/soc.c
@@ -38,9 +38,13 @@ static int stm32g4_init(void)
 	LL_DBGMCU_EnableDBGSleepMode();
 
 #if defined(PWR_CR3_UCPD_DBDIS)
-	/* Disable USB Type-C dead battery pull-down behavior */
-	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
-	LL_PWR_DisableUCPDDeadBattery();
+	if (IS_ENABLED(CONFIG_DT_HAS_ST_STM32_UCPD_ENABLED) ||
+		!IS_ENABLED(CONFIG_USB_DEVICE_DRIVER)) {
+		/* Disable USB Type-C dead battery pull-down behavior */
+		LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
+		LL_PWR_DisableUCPDDeadBattery();
+	}
+
 #endif /* PWR_CR3_UCPD_DBDIS */
 	return 0;
 }

--- a/soc/st/stm32/stm32h5x/soc.c
+++ b/soc/st/stm32/stm32h5x/soc.c
@@ -40,10 +40,13 @@ static int stm32h5_init(void)
 	SystemCoreClock = 32000000;
 
 #if defined(PWR_UCPDR_UCPD_DBDIS)
-	/* Disable USB Type-C dead battery pull-down behavior */
-	LL_PWR_DisableUCPDDeadBattery();
-#endif /* PWR_UCPDR_UCPD_DBDIS */
+	if (IS_ENABLED(CONFIG_DT_HAS_ST_STM32_UCPD_ENABLED) ||
+		!IS_ENABLED(CONFIG_USB_DEVICE_DRIVER)) {
+		/* Disable USB Type-C dead battery pull-down behavior */
+		LL_PWR_DisableUCPDDeadBattery();
+	}
 
+#endif /* PWR_UCPDR_UCPD_DBDIS */
 	return 0;
 }
 

--- a/soc/st/stm32/stm32l5x/soc.c
+++ b/soc/st/stm32/stm32l5x/soc.c
@@ -44,8 +44,11 @@ static int stm32l5_init(void)
 	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
 	LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE0);
 
-	/* Disable USB Type-C dead battery pull-down behavior */
-	LL_PWR_DisableUCPDDeadBattery();
+	if (IS_ENABLED(CONFIG_DT_HAS_ST_STM32_UCPD_ENABLED) ||
+		!IS_ENABLED(CONFIG_USB_DEVICE_DRIVER)) {
+		/* Disable USB Type-C dead battery pull-down behavior */
+		LL_PWR_DisableUCPDDeadBattery();
+	}
 
 	return 0;
 }

--- a/soc/st/stm32/stm32u5x/soc.c
+++ b/soc/st/stm32/stm32u5x/soc.c
@@ -42,8 +42,11 @@ static int stm32u5_init(void)
 	/* Enable PWR */
 	LL_AHB3_GRP1_EnableClock(LL_AHB3_GRP1_PERIPH_PWR);
 
-	/* Disable USB Type-C dead battery pull-down behavior */
-	LL_PWR_DisableUCPDDeadBattery();
+	if (IS_ENABLED(CONFIG_DT_HAS_ST_STM32_UCPD_ENABLED) ||
+		!IS_ENABLED(CONFIG_USB_DEVICE_DRIVER)) {
+		/* Disable USB Type-C dead battery pull-down behavior */
+		LL_PWR_DisableUCPDDeadBattery();
+	}
 
 	/* Power Configuration */
 #if defined(CONFIG_POWER_SUPPLY_DIRECT_SMPS)


### PR DESCRIPTION
Check the driver configuration to disable
the USB Type-C dead battery, only if
- a USB PD system is in place (the UCPD node is enabled)
- or the user does not require USB PHY anyway

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/68577