### PR TITLE
soc: yaml: update boards vendor name

### DIFF
--- a/boards/riscv/esp32c3_luatos_core/esp32c3_luatos_core.yaml
+++ b/boards/riscv/esp32c3_luatos_core/esp32c3_luatos_core.yaml
@@ -19,4 +19,4 @@ testing:
   ignore_tags:
     - net
     - bluetooth
-vendor: espressif
+vendor: luatos

--- a/boards/riscv/icev_wireless/icev_wireless.yaml
+++ b/boards/riscv/icev_wireless/icev_wireless.yaml
@@ -8,4 +8,4 @@ testing:
   ignore_tags:
     - net
     - bluetooth
-vendor: espressif
+vendor: ice-v

--- a/boards/xtensa/esp32s2_franzininho/esp32s2_franzininho.yaml
+++ b/boards/xtensa/esp32s2_franzininho/esp32s2_franzininho.yaml
@@ -16,4 +16,4 @@ testing:
     - heap
     - net
     - bluetooth
-vendor: espressif
+vendor: franzininho

--- a/boards/xtensa/esp32s2_lolin_mini/esp32s2_lolin_mini.yaml
+++ b/boards/xtensa/esp32s2_lolin_mini/esp32s2_lolin_mini.yaml
@@ -12,3 +12,4 @@ testing:
   ignore_tags:
     - net
     - bluetooth
+vendor: wemos

--- a/boards/xtensa/esp32s3_luatos_core/esp32s3_luatos_core.yaml
+++ b/boards/xtensa/esp32s3_luatos_core/esp32s3_luatos_core.yaml
@@ -19,4 +19,4 @@ testing:
   ignore_tags:
     - net
     - bluetooth
-vendor: espressif
+vendor: luatos

--- a/boards/xtensa/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2.yaml
+++ b/boards/xtensa/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2.yaml
@@ -14,4 +14,4 @@ testing:
   ignore_tags:
     - net
     - bluetooth
-vendor: espressif
+vendor: heltec

--- a/boards/xtensa/heltec_wireless_stick_lite_v3/heltec_wireless_stick_lite_v3.yaml
+++ b/boards/xtensa/heltec_wireless_stick_lite_v3/heltec_wireless_stick_lite_v3.yaml
@@ -20,3 +20,4 @@ testing:
   ignore_tags:
     - net
     - bluetooth
+vendor: heltec

--- a/boards/xtensa/yd_esp32/yd_esp32.yaml
+++ b/boards/xtensa/yd_esp32/yd_esp32.yaml
@@ -21,4 +21,4 @@ testing:
   ignore_tags:
     - net
     - bluetooth
-vendor: espressif
+vendor: vcc-gnd


### PR DESCRIPTION
This adds proper board vendors in Espressif SoC's related boards. 
Some of the vendors are suggestions based on the website or github page.