### PR TITLE
MAINTAINERS: Remove szymon-czapracki as LE Audio collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -438,7 +438,6 @@ Bluetooth Audio:
     - Casper-Bonde-Bose
     - MariuszSkamra
     - sjanc
-    - szymon-czapracki
     - asbjornsabo
     - fredrikdanebjer
     - kruithofa


### PR DESCRIPTION
Szymon is not active in the LE Audio development.