### PR TITLE
mgmt: hawkbit: add support for custom attributes

### DIFF
--- a/include/zephyr/mgmt/hawkbit.h
+++ b/include/zephyr/mgmt/hawkbit.h
@@ -37,6 +37,20 @@ enum hawkbit_response {
 };
 
 /**
+ * @brief hawkBit attributes.
+ *
+ * @details These attributes are used to set the attributes
+ *
+ */
+enum hawkbit_attribute {
+	HAWKBIT_HWREVISION_ATTRIBUTE,
+	HAWKBIT_CUSTOM_ATTRIBUTE_0,
+	HAWKBIT_CUSTOM_ATTRIBUTE_1,
+	HAWKBIT_CUSTOM_ATTRIBUTE_2,
+	HAWKBIT_CUSTOM_ATTRIBUTE_3,
+};
+
+/**
  * @brief Init the flash partition
  *
  * @return 0 on success, negative on error.
@@ -62,6 +76,16 @@ void hawkbit_autohandler(void);
  * @return HAWKBIT_DOWNLOAD_ERROR fail while downloading the update package.
  */
 enum hawkbit_response hawkbit_probe(void);
+
+/**
+ * @brief Set a Hawkbit attribute.
+ *
+ * @param type Attribute type to set.
+ * @param attr Attribute to set.
+ * @return 0 on success.
+ * @return -EINVAL if attribute type is invalid.
+ */
+int hawkbit_set_attribute(enum hawkbit_attribute type, char *attr);
 
 /**
  * @}

--- a/subsys/mgmt/hawkbit/Kconfig
+++ b/subsys/mgmt/hawkbit/Kconfig
@@ -50,6 +50,106 @@ config HAWKBIT_PORT
 	help
 	  Configure the hawkbit port number.
 
+config HAWKBIT_HWREVISION_SIZE
+	int "Size for hardware revision attribute"
+	default 10
+	help
+		Configure the size of the hardware revision attribute.
+
+config HAWKBIT_CUSTOM_ATTRIBUTE_AMOUNT
+	int "Amount of custom attributes"
+	default 0
+	range 0 4
+	help
+		Configure the amount of custom attributes that will be used in the hawkbit server.
+
+config HAWKBIT_CUSTOM_ATTRIBUTE_0
+	bool "Emable first custom attribute"
+	default HAWKBIT_CUSTOM_ATTRIBUTE_AMOUNT >= 1
+	help
+		Enable the first custom attribute.
+
+if HAWKBIT_CUSTOM_ATTRIBUTE_0
+
+	config HAWKBIT_CUSTOM_ATTRIBUTE_0_NAME
+		string "Custom name for first custom attribute"
+		default "custom_0"
+		help
+			Configure the name of the first custom attribute.
+
+	config HAWKBIT_CUSTOM_ATTRIBUTE_0_SIZE
+		int "Size for first custom attribute"
+		default 10
+		help
+			Configure the size of the first custom attribute.
+endif
+
+config HAWKBIT_CUSTOM_ATTRIBUTE_1
+	bool "Emable second custom attribute"
+	default HAWKBIT_CUSTOM_ATTRIBUTE_AMOUNT >= 2
+	help
+		Enable the second custom attribute.
+
+if HAWKBIT_CUSTOM_ATTRIBUTE_1
+
+	config HAWKBIT_CUSTOM_ATTRIBUTE_1_NAME
+		string "Custom name for second custom attribute"
+		default "custom_1"
+		help
+			Configure the name of the second custom attribute.
+
+	config HAWKBIT_CUSTOM_ATTRIBUTE_1_SIZE
+		int "Size for second custom attribute"
+		default 10
+		help
+			Configure the size of the second custom attribute.
+
+endif
+
+config HAWKBIT_CUSTOM_ATTRIBUTE_2
+	bool "Emable third custom attribute"
+	default HAWKBIT_CUSTOM_ATTRIBUTE_AMOUNT >= 3
+	help
+		Enable the third custom attribute.
+
+if HAWKBIT_CUSTOM_ATTRIBUTE_2
+
+	config HAWKBIT_CUSTOM_ATTRIBUTE_2_NAME
+		string "Custom name for third custom attribute"
+		default "custom_2"
+		help
+			Configure the name of the third custom attribute.
+
+	config HAWKBIT_CUSTOM_ATTRIBUTE_2_SIZE
+		int "Size for third custom attribute"
+		default 10
+		help
+			Configure the size of the third custom attribute.
+
+endif
+
+config HAWKBIT_CUSTOM_ATTRIBUTE_3
+	bool "Emable fourth custom attribute"
+	default HAWKBIT_CUSTOM_ATTRIBUTE_AMOUNT >= 4
+	help
+		Enable the fourth custom attribute.
+
+if HAWKBIT_CUSTOM_ATTRIBUTE_3
+
+	config HAWKBIT_CUSTOM_ATTRIBUTE_3_NAME
+		string "Custom name for fourth custom attribute"
+		default "custom_3"
+		help
+			Configure the name of the fourth custom attribute.
+
+	config HAWKBIT_CUSTOM_ATTRIBUTE_3_SIZE
+		int "Size for fourth custom attribute"
+		default 10
+		help
+			Configure the size of the fourth custom attribute.
+
+endif
+
 choice HAWKBIT_DDI_SECURITY
 	prompt "Hawkbit DDI API authentication modes"
 	default HAWKBIT_DDI_NO_SECURITY

--- a/subsys/mgmt/hawkbit/hawkbit.c
+++ b/subsys/mgmt/hawkbit/hawkbit.c
@@ -67,6 +67,21 @@ static uint32_t poll_sleep = (300 * MSEC_PER_SEC);
 
 static struct nvs_fs fs;
 
+static char hawkbit_hwrevision[CONFIG_HAWKBIT_HWREVISION_SIZE + 1];
+
+#ifdef CONFIG_HAWKBIT_CUSTOM_ATTRIBUTE_0
+static char custom_attribute_0[CONFIG_HAWKBIT_CUSTOM_ATTRIBUTE_0_SIZE + 1];
+#endif
+#ifdef CONFIG_HAWKBIT_CUSTOM_ATTRIBUTE_1
+static char custom_attribute_1[CONFIG_HAWKBIT_CUSTOM_ATTRIBUTE_1_SIZE + 1];
+#endif
+#ifdef CONFIG_HAWKBIT_CUSTOM_ATTRIBUTE_2
+static char custom_attribute_2[CONFIG_HAWKBIT_CUSTOM_ATTRIBUTE_2_SIZE + 1];
+#endif
+#ifdef CONFIG_HAWKBIT_CUSTOM_ATTRIBUTE_3
+static char custom_attribute_3[CONFIG_HAWKBIT_CUSTOM_ATTRIBUTE_3_SIZE + 1];
+#endif
+
 struct hawkbit_download {
 	int download_status;
 	int download_progress;
@@ -137,6 +152,22 @@ static const struct json_obj_descr json_ctl_res_descr[] = {
 static const struct json_obj_descr json_cfg_data_descr[] = {
 	JSON_OBJ_DESCR_PRIM(struct hawkbit_cfg_data, VIN, JSON_TOK_STRING),
 	JSON_OBJ_DESCR_PRIM(struct hawkbit_cfg_data, hwRevision, JSON_TOK_STRING),
+#ifdef CONFIG_HAWKBIT_CUSTOM_ATTRIBUTE_0
+	JSON_OBJ_DESCR_PRIM_NAMED(struct hawkbit_cfg_data, CONFIG_HAWKBIT_CUSTOM_ATTRIBUTE_0_NAME,
+				  custom_attribute_0, JSON_TOK_STRING),
+#endif
+#ifdef CONFIG_HAWKBIT_CUSTOM_ATTRIBUTE_1
+	JSON_OBJ_DESCR_PRIM_NAMED(struct hawkbit_cfg_data, CONFIG_HAWKBIT_CUSTOM_ATTRIBUTE_1_NAME,
+				  custom_attribute_1, JSON_TOK_STRING),
+#endif
+#ifdef CONFIG_HAWKBIT_CUSTOM_ATTRIBUTE_2
+	JSON_OBJ_DESCR_PRIM_NAMED(struct hawkbit_cfg_data, CONFIG_HAWKBIT_CUSTOM_ATTRIBUTE_2_NAME,
+				  custom_attribute_2, JSON_TOK_STRING),
+#endif
+#ifdef CONFIG_HAWKBIT_CUSTOM_ATTRIBUTE_3
+	JSON_OBJ_DESCR_PRIM_NAMED(struct hawkbit_cfg_data, CONFIG_HAWKBIT_CUSTOM_ATTRIBUTE_3_NAME,
+				  custom_attribute_3, JSON_TOK_STRING),
+#endif
 };
 
 static const struct json_obj_descr json_cfg_descr[] = {
@@ -566,6 +597,51 @@ static void hawkbit_dump_deployment(struct hawkbit_dep_res *d)
 	LOG_DBG("md5sum =%s", l->md5sum_http.href);
 }
 
+
+
+int hawkbit_set_attribute(enum hawkbit_attribute type, char *attr)
+{
+	switch (type) {
+	case HAWKBIT_HWREVISION_ATTRIBUTE:
+		strncpy(hawkbit_hwrevision, attr, sizeof(hawkbit_hwrevision));
+		LOG_DBG("configured hawkbit hardware revision attribute: %s", hawkbit_hwrevision);
+		break;
+#ifdef CONFIG_HAWKBIT_CUSTOM_ATTRIBUTE_0
+	case HAWKBIT_CUSTOM_ATTRIBUTE_0:
+		strncpy(custom_attribute_0, attr, sizeof(custom_attribute_0));
+		LOG_DBG("configured hawkbit custom attribute %s: %s",
+			CONFIG_HAWKBIT_CUSTOM_ATTRIBUTE_0_NAME, custom_attribute_0);
+		break;
+#endif
+#ifdef CONFIG_HAWKBIT_CUSTOM_ATTRIBUTE_1
+	case HAWKBIT_CUSTOM_ATTRIBUTE_1:
+		strncpy(custom_attribute_1, attr, sizeof(custom_attribute_1));
+		LOG_DBG("configured hawkbit custom attribute %s: %s",
+			CONFIG_HAWKBIT_CUSTOM_ATTRIBUTE_1_NAME, custom_attribute_1);
+		break;
+#endif
+#ifdef CONFIG_HAWKBIT_CUSTOM_ATTRIBUTE_2
+	case HAWKBIT_CUSTOM_ATTRIBUTE_2:
+		strncpy(custom_attribute_2, attr, sizeof(custom_attribute_2));
+		LOG_DBG("configured hawkbit custom attribute %s: %s",
+			CONFIG_HAWKBIT_CUSTOM_ATTRIBUTE_2_NAME, custom_attribute_2);
+		break;
+#endif
+#ifdef CONFIG_HAWKBIT_CUSTOM_ATTRIBUTE_3
+	case HAWKBIT_CUSTOM_ATTRIBUTE_3:
+		strncpy(custom_attribute_3, attr, sizeof(custom_attribute_3));
+		LOG_DBG("configured hawkbit custom attribute %s: %s",
+			CONFIG_HAWKBIT_CUSTOM_ATTRIBUTE_3_NAME, custom_attribute_3);
+		break;
+#endif
+
+	default:
+		LOG_ERR("Invalid attribute type");
+		return -EINVAL;
+	}
+	return 0;
+}
+
 int hawkbit_init(void)
 {
 	bool image_ok;
@@ -843,7 +919,19 @@ static bool send_request(enum http_method method, enum hawkbit_http_request type
 		memset(&cfg, 0, sizeof(cfg));
 		cfg.mode = "merge";
 		cfg.data.VIN = device_id;
-		cfg.data.hwRevision = "3";
+		cfg.data.hwRevision = hawkbit_hwrevision;
+#ifdef CONFIG_HAWKBIT_CUSTOM_ATTRIBUTE_0
+		cfg.data.custom_attribute_0 = custom_attribute_0;
+#endif
+#ifdef CONFIG_HAWKBIT_CUSTOM_ATTRIBUTE_1
+		cfg.data.custom_attribute_1 = custom_attribute_1;
+#endif
+#ifdef CONFIG_HAWKBIT_CUSTOM_ATTRIBUTE_2
+		cfg.data.custom_attribute_2 = custom_attribute_2;
+#endif
+#ifdef CONFIG_HAWKBIT_CUSTOM_ATTRIBUTE_3
+		cfg.data.custom_attribute_3 = custom_attribute_3;
+#endif
 		cfg.id = "";
 		cfg.time = "";
 		cfg.status.execution = exec;

--- a/subsys/mgmt/hawkbit/hawkbit_priv.h
+++ b/subsys/mgmt/hawkbit/hawkbit_priv.h
@@ -82,6 +82,18 @@ struct hawkbit_ctl_res {
 struct hawkbit_cfg_data {
 	const char *VIN;
 	const char *hwRevision;
+#ifdef CONFIG_HAWKBIT_CUSTOM_ATTRIBUTE_0
+	const char *custom_attribute_0;
+#endif
+#ifdef CONFIG_HAWKBIT_CUSTOM_ATTRIBUTE_1
+	const char *custom_attribute_1;
+#endif
+#ifdef CONFIG_HAWKBIT_CUSTOM_ATTRIBUTE_2
+	const char *custom_attribute_2;
+#endif
+#ifdef CONFIG_HAWKBIT_CUSTOM_ATTRIBUTE_3
+	const char *custom_attribute_3;
+#endif
 };
 
 struct hawkbit_cfg {


### PR DESCRIPTION
Adds custom attributes, which are set during runtime, that are send to the hawkbit server.
Also adds the option to set the hardware revision during runtime, instant of always using 3.