### PR TITLE
adc: Fix precision error in adc_raw_to_millivolts()

### DIFF
--- a/include/zephyr/drivers/adc.h
+++ b/include/zephyr/drivers/adc.h
@@ -778,11 +778,12 @@ static inline int adc_raw_to_millivolts(int32_t ref_mv,
 					uint8_t resolution,
 					int32_t *valp)
 {
+	int32_t max_value = (1 << resolution) - 1;
 	int32_t adc_mv = *valp * ref_mv;
 	int ret = adc_gain_invert(gain, &adc_mv);
 
 	if (ret == 0) {
-		*valp = (adc_mv >> resolution);
+		*valp = adc_mv / max_value;
 	}
 
 	return ret;


### PR DESCRIPTION
The maximum value of an adc is one less than 1<<resolution. Therefore we must divide adc_mv with the max value rather than shift by resolution.

This is clearly seen when converting the maximum sample value:

For a 12-bit adc, the maximum sample value is 4095. With a ref_mv of 3300, adc_mv becomes 13513500. If we right-shift that 12 bits, effectively dividing by 4096, we get 3299 back instead of the correct value 3300.