### PR TITLE
doc: releases: ST BlueNRG and SPI properties changes

### DIFF
--- a/doc/releases/migration-guide-3.6.rst
+++ b/doc/releases/migration-guide-3.6.rst
@@ -358,6 +358,9 @@ Device Drivers and Device Tree
 
   (:github:`66427`)
 
+* The :dtcompatible:`st,hci-spi-v1` should be used instead of :dtcompatible:`zephyr,bt-hci-spi`
+  for the boards which are based on ST BlueNRG-MS.
+
 Power Management
 ================
 

--- a/doc/releases/release-notes-3.6.rst
+++ b/doc/releases/release-notes-3.6.rst
@@ -95,6 +95,12 @@ Bluetooth
 
   * Added deinit implementation for ESP32 controller.
 
+* HCI Driver
+
+  * Split ST HCI SPI Bluetooth driver from the Zephyr one to provide more features
+    based on ST SPI protocols V1 and V2. As a result, :dtcompatible:`st,hci-spi-v1` and
+    :dtcompatible:`st,hci-spi-v2` were introduced.
+
 Boards & SoC Support
 ********************
 

--- a/doc/releases/release-notes-3.6.rst
+++ b/doc/releases/release-notes-3.6.rst
@@ -898,6 +898,9 @@ API
 Bindings
 ========
 
+  * Introduced new SPI properties ``spi-cpol``, ``spi-cpha``, and ``spi-hold-cs`` to be used by
+    the macro :c:macro:`SPI_CONFIG_DT` in order to set SPI mode in a Devicetree file.
+
 Libraries / Subsystems
 **********************
 


### PR DESCRIPTION
Update release-notes and migration-guide version 3.6.0 with the changes
related to BlueNRG devices.

Update release-notes version 3.6.0 with the SPI properties changes.