### PR TITLE
shell: Add a configuration for not printing shell errors

### DIFF
--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -120,6 +120,18 @@ config SHELL_WILDCARD
 	help
 	  Enables using wildcards: * and ? in the shell.
 
+config SHELL_MSG_CMD_NOT_FOUND
+	bool "': command not found' message in the shell"
+	default y
+	help
+	  If enabled, the shell prints out this message.
+
+config SHELL_MSG_SPECIFY_SUBCOMMAND
+	bool "'Please specify a subcommand.' message in the shell"
+	default y
+	help
+	  If enabled, the shell prints out this message.
+
 config SHELL_ECHO_STATUS
 	bool "Echo on shell"
 	default y

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -528,8 +528,10 @@ static int exec_cmd(const struct shell *sh, size_t argc, const char **argv,
 			shell_internal_help_print(sh);
 			return SHELL_CMD_HELP_PRINTED;
 		} else {
-			z_shell_fprintf(sh, SHELL_ERROR,
-					SHELL_MSG_SPECIFY_SUBCOMMAND);
+			if (IS_ENABLED(CONFIG_SHELL_MSG_SPECIFY_SUBCOMMAND)) {
+				z_shell_fprintf(sh, SHELL_ERROR,
+						SHELL_MSG_SPECIFY_SUBCOMMAND);
+			}
 			return -ENOEXEC;
 		}
 	}
@@ -692,8 +694,10 @@ static int execute(const struct shell *sh)
 				return SHELL_CMD_HELP_PRINTED;
 			}
 
-			z_shell_fprintf(sh, SHELL_ERROR,
-					SHELL_MSG_SPECIFY_SUBCOMMAND);
+			if (IS_ENABLED(CONFIG_SHELL_MSG_SPECIFY_SUBCOMMAND)) {
+				z_shell_fprintf(sh, SHELL_ERROR,
+						SHELL_MSG_SPECIFY_SUBCOMMAND);
+			}
 			return -ENOEXEC;
 		}
 
@@ -736,7 +740,8 @@ static int execute(const struct shell *sh)
 					  &cmd_with_handler_lvl, &args_left);
 			parent = entry;
 		} else {
-			if (cmd_lvl == 0 &&
+			if (IS_ENABLED(CONFIG_SHELL_MSG_CMD_NOT_FOUND) &&
+				cmd_lvl == 0 &&
 				(!z_shell_in_select_mode(sh) ||
 				 sh->ctx->selected_cmd->handler == NULL)) {
 				z_shell_fprintf(sh, SHELL_ERROR,


### PR DESCRIPTION
The shell currently prints out `: command not found` and
`Please specify a subcommand.` when invalid commands are
sent.

This can cause issues in certain situations, such as if a U-Boot
console in interactive mode is on the other end of the shell's
UART, where the U-Boot console will stop booting the device
if it receives any characters, and it will print out strings that
the shell then sees as commands. This causes the shell to send
out the messages above, preventing the device running
U-Boot on the other end from booting up.

I added the configurations
`CONFIG_SHELL_MSG_SPECIFY_SUBCOMMAND` and
`CONFIG_SHELL_MSG_CMD_NOT_FOUND` to allow disabling
these messages.

Signed-off-by: Brian Moran <brian.moran@sabantoag.com>