### PR TITLE
doc: release notes: add 1-wire release notes for 3.6.0

### DIFF
--- a/doc/releases/release-notes-3.6.rst
+++ b/doc/releases/release-notes-3.6.rst
@@ -534,6 +534,11 @@ Drivers and Sensors
   * On compatible STM32 devices, isochronous endpoint are now functional thanks to the
     use of double buffering.
 
+* W1
+
+  * Added 1-Wire GPIO master driver. See the :dtcompatible:`zephyr,w1-gpio`
+    devicetree binding for more information.
+
 * Wi-Fi
 
   * Added Infineon airoc driver.


### PR DESCRIPTION
Add 1-Wire related release notes for Zephyr v3.6.0.