### PR TITLE
ITE: drivers/i2c target mode: Fix racing condition

### DIFF
--- a/drivers/i2c/i2c_ite_enhance.c
+++ b/drivers/i2c/i2c_ite_enhance.c
@@ -1016,6 +1016,11 @@ static void target_i2c_isr_dma(const struct device *dev,
 		target_cb->buf_write_received(data->target_cfg,
 			target_buffer->in_buffer, data->buffer_size);
 	}
+	/* Peripheral finish */
+	if (interrupt_status & IT8XXX2_I2C_P_CLR) {
+		/* Transfer done callback function */
+		target_cb->stop(data->target_cfg);
+	}
 	/* Controller to read data */
 	if (interrupt_status & IT8XXX2_I2C_IDR_CLR) {
 		uint32_t len;
@@ -1036,6 +1041,13 @@ static void target_i2c_isr_dma(const struct device *dev,
 		} else {
 			memcpy(target_buffer->out_buffer, rdata, len);
 		}
+	}
+
+	/* Write clear the peripheral status */
+	IT8XXX2_I2C_IRQ_ST(base) = interrupt_status;
+	if (interrupt_status & IT8XXX2_I2C_INT_ANY) {
+		/* Hardware reset */
+		IT8XXX2_I2C_CTR(base) |= IT8XXX2_I2C_HALT;
 	}
 }
 
@@ -1088,7 +1100,9 @@ static void target_i2c_isr(const struct device *dev)
 
 	/* Any error */
 	if (target_status & E_TARGET_ANY_ERROR) {
-		goto end;
+		/* Hardware reset */
+		IT8XXX2_I2C_CTR(base) |= IT8XXX2_I2C_HALT;
+		return;
 	}
 
 	/* Interrupt pending */
@@ -1103,26 +1117,26 @@ static void target_i2c_isr(const struct device *dev)
 				IT8XXX2_I2C_CTR(base) |= IT8XXX2_I2C_HALT;
 				data->target_nack = 1;
 			}
+			/* Peripheral finish */
+			if (interrupt_status & IT8XXX2_I2C_P_CLR) {
+				/* Transfer done callback function */
+				target_cb->stop(data->target_cfg);
+
+				if (data->target_nack) {
+					/* Set acknowledge */
+					IT8XXX2_I2C_CTR(base) |=
+						IT8XXX2_I2C_ACK;
+					data->target_nack = 0;
+				}
+			}
+			/* Write clear the peripheral status */
+			IT8XXX2_I2C_IRQ_ST(base) = interrupt_status;
+			/* Hardware reset */
+			IT8XXX2_I2C_CTR(base) |= IT8XXX2_I2C_HALT;
 		} else {
 			target_i2c_isr_dma(dev, interrupt_status);
 		}
-		/* Peripheral finish */
-		if (interrupt_status & IT8XXX2_I2C_P_CLR) {
-			/* Transfer done callback function */
-			target_cb->stop(data->target_cfg);
-
-			if (data->target_nack) {
-				/* Set acknowledge */
-				IT8XXX2_I2C_CTR(base) |= IT8XXX2_I2C_ACK;
-				data->target_nack = 0;
-			}
-		}
-		/* Write clear the peripheral status */
-		IT8XXX2_I2C_IRQ_ST(base) = interrupt_status;
 	}
-end:
-	/* Hardware reset */
-	IT8XXX2_I2C_CTR(base) |= IT8XXX2_I2C_HALT;
 }
 #endif
 

--- a/soc/riscv/ite_ec/common/chip_chipregs.h
+++ b/soc/riscv/ite_ec/common/chip_chipregs.h
@@ -1419,6 +1419,8 @@ enum chip_pll_mode {
 #define IT8XXX2_I2C_IDR_CLR           BIT(2)
 #define IT8XXX2_I2C_SLVDATAFLG        BIT(1)
 #define IT8XXX2_I2C_P_CLR             BIT(0)
+#define IT8XXX2_I2C_INT_ANY           (IT8XXX2_I2C_CNT_HOLD | IT8XXX2_I2C_IDW_CLR | \
+				       IT8XXX2_I2C_IDR_CLR | IT8XXX2_I2C_SLVDATAFLG)
 /* 0x13: Nack Status */
 #define IT8XXX2_I2C_NST_CNS           BIT(7)
 #define IT8XXX2_I2C_NST_ID_NACK       BIT(3)


### PR DESCRIPTION
The finish interrupt after the previous transaction is completed may occur in the next transaction. To do hardware reset at this time could potentially lead to the failure of the transaction. Therefore, removing the hardware reset upon completing the transaction helps to avoid a race condition.