### PR TITLE
modules: openthread: platform: logging: catch up on log2_generic rename

### DIFF
--- a/modules/openthread/platform/logging.c
+++ b/modules/openthread/platform/logging.c
@@ -52,7 +52,7 @@ void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat
 	}
 
 	va_start(param_list, aFormat);
-	log2_generic(level, aFormat, param_list);
+	log_generic(level, aFormat, param_list);
 	va_end(param_list);
 #else
 	ARG_UNUSED(aLogLevel);


### PR DESCRIPTION
The log2_generic() function was renamed to log_generic() in #68949.

Fixes: 2155a9e5f7771e05bd80b3505dd7804865ca1360