### PR TITLE
drivers: ieee802154: nrf: add channel caching

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.h
+++ b/drivers/ieee802154/ieee802154_nrf5.h
@@ -100,6 +100,9 @@ struct nrf5_802154_data {
 	/* The TX power in dBm. */
 	int8_t txpwr;
 
+	/* The radio channel. */
+	uint8_t channel;
+
 #if defined(CONFIG_NRF_802154_SER_HOST) && defined(CONFIG_IEEE802154_CSL_ENDPOINT)
 	/* The last configured value of CSL period in units of 10 symbols. */
 	uint32_t csl_period;


### PR DESCRIPTION
Add channel caching to prevent calling `nrf_802154_channel_set` with the same channel value as set previously.

This can be further optimized by utilizing metadata in radio transmit calls in the future.

Based on idea from https://github.com/zephyrproject-rtos/zephyr/commit/780b12854c11f10f6b3e4b21ae02eaa1b2965736