### PR TITLE
Bluetooth: BAP: Fix bad bcast assistant bis sync shift

### DIFF
--- a/subsys/bluetooth/audio/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/bap_broadcast_assistant.c
@@ -1006,8 +1006,12 @@ int bt_bap_broadcast_assistant_add_src(struct bt_conn *conn,
 
 		subgroup = net_buf_simple_add(&att_buf, subgroup_size);
 
-		/* The BIS Index bitfield to be sent must use BIT(0) for BIS Index 1 */
-		subgroup->bis_sync = param->subgroups[i].bis_sync >> 1;
+		if (param->subgroups[i].bis_sync != BT_BAP_BIS_SYNC_NO_PREF) {
+			/* The BIS Index bitfield to be sent must use BIT(0) for BIS Index 1 */
+			subgroup->bis_sync = param->subgroups[i].bis_sync >> 1;
+		} else {
+			subgroup->bis_sync = BT_BAP_BIS_SYNC_NO_PREF;
+		}
 
 		CHECKIF(param->pa_sync == 0 && subgroup->bis_sync != 0) {
 			LOG_DBG("Only syncing to BIS is not allowed");
@@ -1099,8 +1103,12 @@ int bt_bap_broadcast_assistant_mod_src(struct bt_conn *conn,
 		}
 		subgroup = net_buf_simple_add(&att_buf, subgroup_size);
 
-		/* The BIS Index bitfield to be sent must use BIT(0) for BIS Index 1 */
-		subgroup->bis_sync = param->subgroups[i].bis_sync >> 1;
+		if (param->subgroups[i].bis_sync != BT_BAP_BIS_SYNC_NO_PREF) {
+			/* The BIS Index bitfield to be sent must use BIT(0) for BIS Index 1 */
+			subgroup->bis_sync = param->subgroups[i].bis_sync >> 1;
+		} else {
+			subgroup->bis_sync = BT_BAP_BIS_SYNC_NO_PREF;
+		}
 
 		CHECKIF(param->pa_sync == 0 && subgroup->bis_sync != 0) {
 			LOG_DBG("Only syncing to BIS is not allowed");


### PR DESCRIPTION
The shift is currently necessary due to a mismatch of the specs and the API, but the shift should not be done when the value is BT_BAP_BIS_SYNC_NO_PREF as that is a special value.