### PR TITLE
doc: migration-guide-3.6: add note about async serial shell

### DIFF
--- a/doc/releases/migration-guide-3.6.rst
+++ b/doc/releases/migration-guide-3.6.rst
@@ -400,6 +400,11 @@ Shell
   macro accepts additional arguments (ring buffer TX & RX size arguments) for compatibility with
   previous Zephyr version, but they are ignored, and will be removed in future release.
 
+* :kconfig:option:`CONFIG_SHELL_BACKEND_SERIAL_API` now does not automatically default to
+  :kconfig:option:`CONFIG_SHELL_BACKEND_SERIAL_API_ASYNC` when
+  :kconfig:option:`CONFIG_UART_ASYNC_API` is enabled, :kconfig:option:`CONFIG_SHELL_ASYNC_API`
+  also has to be enabled in order to use the asynchronous serial shell (:github: `68475`).
+
 Bootloader
 ==========
 


### PR DESCRIPTION
Following PR #68475, CONFIG_SHELL_ASYNC_API needs to be enabled, in addition to CONFIG_UART_SYNC_API, to be able to use async serial shell.