### PR TITLE
scripts: ensure posix path is used with --cmakeformat

### DIFF
--- a/scripts/list_boards.py
+++ b/scripts/list_boards.py
@@ -298,7 +298,7 @@ def dump_v2_boards(args):
             notfound = lambda x: x or 'NOTFOUND'
             info = args.cmakeformat.format(
                 NAME='NAME;' + b.name,
-                DIR='DIR;' + str(b.dir),
+                DIR='DIR;' + str(b.dir.as_posix()),
                 VENDOR='VENDOR;' + notfound(b.vendor),
                 HWM='HWM;' + b.hwm,
                 REVISION_DEFAULT='REVISION_DEFAULT;' + notfound(b.revision_default),
@@ -323,7 +323,7 @@ def dump_boards(args):
             if args.cmakeformat is not None:
                 info = args.cmakeformat.format(
                     NAME='NAME;' + board.name,
-                    DIR='DIR;' + str(board.dir),
+                    DIR='DIR;' + str(board.dir.as_posix()),
                     HWM='HWM;' + board.hwm,
                     VENDOR='VENDOR;NOTFOUND',
                     REVISION_DEFAULT='REVISION_DEFAULT;NOTFOUND',

--- a/scripts/list_hardware.py
+++ b/scripts/list_hardware.py
@@ -217,7 +217,7 @@ def dump_v2_archs(args):
             info = args.cmakeformat.format(
                 TYPE='TYPE;' + arch['type'],
                 NAME='NAME;' + arch['name'],
-                DIR='DIR;' + str(arch['path']),
+                DIR='DIR;' + str(arch['path'].as_posix()),
                 HWM='HWM;' + arch['hwm'],
                 # Below is non exising for arch but is defined here to support
                 # common formatting string.
@@ -248,7 +248,7 @@ def dump_v2_system(args, type, system):
         info = args.cmakeformat.format(
            TYPE='TYPE;' + type,
            NAME='NAME;' + system.name,
-           DIR='DIR;' + system.folder,
+           DIR='DIR;' + Path(system.folder).as_posix(),
            HWM='HWM;' + 'v2'
         )
     else:


### PR DESCRIPTION
When printing with --cmakeformat format specifier then dir output should be printed as posix path, that is with forward slashes '/'.

This will make output compatible with CMake path style.