### PR TITLE
Bluetooth: BAP: BA: Add additional PAST log in past_available

### DIFF
--- a/subsys/bluetooth/audio/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/bap_broadcast_assistant.c
@@ -89,6 +89,10 @@ static bool past_available(const struct bt_conn *conn,
 			   const bt_addr_le_t *adv_addr,
 			   uint8_t sid)
 {
+	LOG_DBG("%p remote %s PAST, local %s PAST", (void *)conn,
+		BT_FEAT_LE_PAST_RECV(conn->le.features) ? "supports" : "does not support",
+		BT_FEAT_LE_PAST_SEND(bt_dev.le.features) ? "supports" : "does not support");
+
 	return BT_FEAT_LE_PAST_RECV(conn->le.features) &&
 	       BT_FEAT_LE_PAST_SEND(bt_dev.le.features) &&
 	       bt_le_per_adv_sync_lookup_addr(adv_addr, sid) != NULL;


### PR DESCRIPTION
Add additional logging in past_available to easily see the PAST support of the broadcast assistant and scan delegator devices.