### PR TITLE
soc: imx7: Change PWM enums to defines

### DIFF
--- a/soc/arm/nxp_imx/mcimx7_m4/soc.c
+++ b/soc/arm/nxp_imx/mcimx7_m4/soc.c
@@ -172,40 +172,40 @@ static void nxp_mcimx7_pwm_config(void)
 	/* We need to grasp board pwm exclusively */
 	RDC_SetPdapAccess(RDC, rdcPdapPwm1, RDC_DT_VAL(pwm1), false, false);
 	/* Select clock derived from OSC clock(24M) */
-	CCM_UpdateRoot(CCM, ccmRootPwm1, ccmRootmuxPwmOsc24m, 0, 0);
+	CCM_UpdateRoot(CCM, CCMROOTPWM1, CCMROOTMUXPWMOSC24M, 0, 0);
 	/* Enable pwm clock */
-	CCM_EnableRoot(CCM, ccmRootPwm1);
-	CCM_ControlGate(CCM, ccmCcgrGatePwm1, ccmClockNeededAll);
+	CCM_EnableRoot(CCM, CCMROOTPWM1);
+	CCM_ControlGate(CCM, CCMCCGRGATEPWM1, ccmClockNeededAll);
 #endif
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pwm2), okay)
 	/* We need to grasp board pwm exclusively */
 	RDC_SetPdapAccess(RDC, rdcPdapPwm2, RDC_DT_VAL(pwm2), false, false);
 	/* Select clock derived from OSC clock(24M) */
-	CCM_UpdateRoot(CCM, ccmRootPwm2, ccmRootmuxPwmOsc24m, 0, 0);
+	CCM_UpdateRoot(CCM, CCMROOTPWM2, CCMROOTMUXPWMOSC24M, 0, 0);
 	/* Enable pwm clock */
-	CCM_EnableRoot(CCM, ccmRootPwm2);
-	CCM_ControlGate(CCM, ccmCcgrGatePwm2, ccmClockNeededAll);
+	CCM_EnableRoot(CCM, CCMROOTPWM2);
+	CCM_ControlGate(CCM, CCMCCGRGATEPWM2, ccmClockNeededAll);
 #endif
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pwm3), okay)
 	/* We need to grasp board pwm exclusively */
 	RDC_SetPdapAccess(RDC, rdcPdapPwm3, RDC_DT_VAL(pwm3), false, false);
 	/* Select clock derived from OSC clock(24M) */
-	CCM_UpdateRoot(CCM, ccmRootPwm3, ccmRootmuxPwmOsc24m, 0, 0);
+	CCM_UpdateRoot(CCM, CCMROOTPWM3, CCMROOTMUXPWMOSC24M, 0, 0);
 	/* Enable pwm clock */
-	CCM_EnableRoot(CCM, ccmRootPwm3);
-	CCM_ControlGate(CCM, ccmCcgrGatePwm3, ccmClockNeededAll);
+	CCM_EnableRoot(CCM, CCMROOTPWM3);
+	CCM_ControlGate(CCM, CCMCCGRGATEPWM3, ccmClockNeededAll);
 #endif
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pwm4), okay)
 	/* We need to grasp board pwm exclusively */
 	RDC_SetPdapAccess(RDC, rdcPdapPwm4, RDC_DT_VAL(pwm4), false, false);
 	/* Select clock derived from OSC clock(24M) */
-	CCM_UpdateRoot(CCM, ccmRootPwm4, ccmRootmuxPwmOsc24m, 0, 0);
+	CCM_UpdateRoot(CCM, CCMROOTPWM4, CCMROOTMUXPWMOSC24M, 0, 0);
 	/* Enable pwm clock */
-	CCM_EnableRoot(CCM, ccmRootPwm4);
-	CCM_ControlGate(CCM, ccmCcgrGatePwm4, ccmClockNeededAll);
+	CCM_EnableRoot(CCM, CCMROOTPWM4);
+	CCM_ControlGate(CCM, CCMCCGRGATEPWM4, ccmClockNeededAll);
 #endif
 
 }

--- a/soc/arm/nxp_imx/mcimx7_m4/soc_clk_freq.c
+++ b/soc/arm/nxp_imx/mcimx7_m4/soc_clk_freq.c
@@ -17,30 +17,30 @@ uint32_t get_pwm_clock_freq(PWM_Type *base)
 
 	switch ((uint32_t)base) {
 	case PWM1_BASE:
-		root = CCM_GetRootMux(CCM, ccmRootPwm1);
-		CCM_GetRootDivider(CCM, ccmRootPwm1, &pre, &post);
+		root = CCM_GetRootMux(CCM, CCMROOTPWM1);
+		CCM_GetRootDivider(CCM, CCMROOTPWM1, &pre, &post);
 		break;
 	case PWM2_BASE:
-		root = CCM_GetRootMux(CCM, ccmRootPwm2);
-		CCM_GetRootDivider(CCM, ccmRootPwm2, &pre, &post);
+		root = CCM_GetRootMux(CCM, CCMROOTPWM2);
+		CCM_GetRootDivider(CCM, CCMROOTPWM2, &pre, &post);
 		break;
 	case PWM3_BASE:
-		root = CCM_GetRootMux(CCM, ccmRootPwm3);
-		CCM_GetRootDivider(CCM, ccmRootPwm3, &pre, &post);
+		root = CCM_GetRootMux(CCM, CCMROOTPWM3);
+		CCM_GetRootDivider(CCM, CCMROOTPWM3, &pre, &post);
 		break;
 	case PWM4_BASE:
-		root = CCM_GetRootMux(CCM, ccmRootPwm4);
-		CCM_GetRootDivider(CCM, ccmRootPwm4, &pre, &post);
+		root = CCM_GetRootMux(CCM, CCMROOTPWM4);
+		CCM_GetRootDivider(CCM, CCMROOTPWM4, &pre, &post);
 		break;
 	default:
 		return 0;
 	}
 
 	switch (root) {
-	case ccmRootmuxPwmOsc24m:
+	case CCMROOTMUXPWMOSC24M:
 		hz = 24000000U;
 		break;
-	case ccmRootmuxPwmSysPllDiv4:
+	case CCMROOTMUXPWMSYSPLLDIV4:
 		hz = CCM_ANALOG_GetSysPllFreq(CCM_ANALOG) >> 2;
 		break;
 	default:

--- a/soc/arm/nxp_imx/mcimx7_m4/soc_clk_freq.h
+++ b/soc/arm/nxp_imx/mcimx7_m4/soc_clk_freq.h
@@ -28,31 +28,22 @@ uint32_t get_pwm_clock_freq(PWM_Type *base);
 }
 #endif
 
-/*! @brief Root control names for root clock setting. */
-enum _ccm_root_control_extra {
-	ccmRootPwm1   = (uint32_t)(&CCM_TARGET_ROOT106),
-	ccmRootPwm2   = (uint32_t)(&CCM_TARGET_ROOT107),
-	ccmRootPwm3   = (uint32_t)(&CCM_TARGET_ROOT108),
-	ccmRootPwm4   = (uint32_t)(&CCM_TARGET_ROOT109),
-};
+#define CCMROOTPWM1 (uint32_t)(&CCM_TARGET_ROOT106)
+#define CCMROOTPWM2 (uint32_t)(&CCM_TARGET_ROOT107)
+#define CCMROOTPWM3 (uint32_t)(&CCM_TARGET_ROOT108)
+#define CCMROOTPWM4 (uint32_t)(&CCM_TARGET_ROOT109)
 
-/*! @brief Clock source enumeration for PWM peripheral. */
-enum _ccm_rootmux_pwm {
-	ccmRootmuxPwmOsc24m	  = 0U,
-	ccmRootmuxPwmEnetPllDiv10 = 1U,
-	ccmRootmuxPwmSysPllDiv4   = 2U,
-	ccmRootmuxPwmEnetPllDiv25 = 3U,
-	ccmRootmuxPwmAudioPll	  = 4U,
-	ccmRootmuxPwmExtClk2	  = 5U,
-	ccmRootmuxPwmRef1m	  = 6U,
-	ccmRootmuxPwmVideoPll	  = 7U,
-};
+#define CCMROOTMUXPWMOSC24M       0U
+#define CCMROOTMUXPWMENETPLLDIV10 1U
+#define CCMROOTMUXPWMSYSPLLDIV4   2U
+#define CCMROOTMUXPWMENETPLLDIV25 3U
+#define CCMROOTMUXPWMAUDIOPLL	  4U
+#define CCMROOTMUXPWMEXTCLK2	  5U
+#define CCMROOTMUXPWMREF1M	  6U
+#define CCMROOTMUXPWMVIDEOPLL	  7U
 
-/*! @brief CCM CCGR gate control. */
-enum _ccm_ccgr_gate_extra {
-	ccmCcgrGatePwm1      = (uint32_t)(&CCM_CCGR132),
-	ccmCcgrGatePwm2      = (uint32_t)(&CCM_CCGR133),
-	ccmCcgrGatePwm3      = (uint32_t)(&CCM_CCGR134),
-	ccmCcgrGatePwm4      = (uint32_t)(&CCM_CCGR135),
-};
+#define CCMCCGRGATEPWM1      (uint32_t)(&CCM_CCGR132)
+#define CCMCCGRGATEPWM2      (uint32_t)(&CCM_CCGR133)
+#define CCMCCGRGATEPWM3      (uint32_t)(&CCM_CCGR134)
+#define CCMCCGRGATEPWM4      (uint32_t)(&CCM_CCGR135)
 #endif /* __SOC_CLOCK_FREQ_H__ */


### PR DESCRIPTION
Change PWM enums to defines. There is no apparent reason for these to be enums, and it appears to break C++ support on this SOC.

Fixes #64784