### PR TITLE
hwmv2: soc: ite: add SOC_SERIES_ITE_IT8XXX2 guards around ITE options

### DIFF
--- a/soc/ite/ec/it8xxx2/Kconfig
+++ b/soc/ite/ec/it8xxx2/Kconfig
@@ -5,6 +5,8 @@ config SOC_SERIES_ITE_IT8XXX2
 	select CPU_HAS_FPU if "$(ZEPHYR_TOOLCHAIN_VARIANT)" != "zephyr" || RISCV_ISA_EXT_M
 	select HAS_PM
 
+if SOC_SERIES_ITE_IT8XXX2
+
 config SOC_IT8XXX2
 	select RISCV
 	select ATOMIC_OPERATIONS_BUILTIN
@@ -148,3 +150,5 @@ config ILM_MAX_SIZE
 	int "ILM Size in kB"
 	default 60 if SOC_IT81202_CX || SOC_IT81302_CX
 	default SRAM_SIZE
+
+endif # SOC_SERIES_ITE_IT8XXX2


### PR DESCRIPTION
Add a check for SOC_SERIES_ITE_IT8XXX2 around ITE options so that they only get set when building for ITE platforms.