### PR TITLE
soc: set linker script for ra4m1

### DIFF
--- a/soc/soc_legacy/arm/renesas_ra/ra4m1/CMakeLists.txt
+++ b/soc/soc_legacy/arm/renesas_ra/ra4m1/CMakeLists.txt
@@ -1,4 +1,4 @@
 # Copyright (c) 2023 TOKITA Hiroshi <tokita.hiroshi@fujitsu.com>
 # SPDX-License-Identifier: Apache-2.0
 
-set(SOC_LINKER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld CACHE INTERNAL "")
+set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/linker.ld CACHE INTERNAL "")


### PR DESCRIPTION
Follow-up: #66648

Commit 595b06aaa967820a0c02f9e81c02c7deb77cb016 accidentally removed linker.ld for the ra4m1 SoC.

As the linker.ld anyway included the common arm cortex_m linker script then fix this by setting a correct SOC_LINKER_SCRIPT value.