### PR TITLE
xcc/cmake: fix error message when TOOLCHAIN_VER is undefined

### DIFF
--- a/cmake/compiler/xcc/generic.cmake
+++ b/cmake/compiler/xcc/generic.cmake
@@ -6,12 +6,13 @@ find_program(CMAKE_C_COMPILER ${CROSS_COMPILE}${CC}   PATHS ${TOOLCHAIN_HOME} NO
 find_program(CMAKE_GCOV ${CROSS_COMPILE}gcov   PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
 
 if(CMAKE_C_COMPILER STREQUAL CMAKE_C_COMPILER-NOTFOUND)
-  message(FATAL_ERROR "Zephyr was unable to find the toolchain. Is the environment misconfigured?
+  message(FATAL_ERROR "Zephyr was unable to find ${CROSS_COMPILE}${CC}. Is the environment misconfigured?
 User-configuration:
 ZEPHYR_TOOLCHAIN_VARIANT: ${ZEPHYR_TOOLCHAIN_VARIANT}
 Internal variables:
 CROSS_COMPILE: ${CROSS_COMPILE}
 TOOLCHAIN_HOME: ${TOOLCHAIN_HOME}
+TOOLCHAIN_VER: ${TOOLCHAIN_VER}
 ")
 endif()
 


### PR DESCRIPTION
The exact set of environment variables required by xt-xcc and xt-clang is a bit of a dark magic and error-prone. TOOLCHAIN_VER is definitely one of them and the error message was puzzling when TOOLCHAIN_VER was undefined or not exported.

- Add TOOLCHAIN_VER to the list of variables in the error message

- Replace the vague "toolchain not found" in the error message with the more useful "XCC/install/tools//XtensaTools/bin/xt-xcc not found" where the double slash and comparison with the filesystem clearly point at where TOOLCHAIN_VER is missing.