### PR TITLE
cmake/compiler/gcc: use -flto/-fno-lto only for gcc >= 4.5.0

### DIFF
--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -21,8 +21,10 @@ endif()
 set_compiler_property(PROPERTY optimization_speed -O2)
 set_compiler_property(PROPERTY optimization_size  -Os)
 
-set_compiler_property(PROPERTY optimization_lto -flto)
-set_compiler_property(PROPERTY prohibit_lto -fno-lto)
+if(CMAKE_C_COMPILER_VERSION GREATER_EQUAL "4.5.0")
+  set_compiler_property(PROPERTY optimization_lto -flto)
+  set_compiler_property(PROPERTY prohibit_lto -fno-lto)
+endif()
 
 #######################################################
 # This section covers flags related to warning levels #


### PR DESCRIPTION
Fixes commit 26c8776c70ea ("buildsystem: Add an option to enable LTO")

Fixes the following error when compiling offsets.c

  xt-xcc ERROR parsing -fno-lto:  unknown flag

LTO options were introduced in gcc 4.5.0, compare:

https://gcc.gnu.org/onlinedocs/gcc-4.4.6/gcc/Option-Summary.html https://gcc.gnu.org/onlinedocs/gcc-4.5.0/gcc/Option-Summary.html