### PR TITLE
doc: build: sysbuild: Remove mention of child image

### DIFF
--- a/doc/build/sysbuild/index.rst
+++ b/doc/build/sysbuild/index.rst
@@ -65,7 +65,7 @@ The following are some key sysbuild features indicated in this figure:
 
 - Sysbuild itself is also configured using Kconfig. For example, you can
   instruct sysbuild to build the MCUboot bootloader, as well as to build and
-  link your main Zephyr application as an MCUboot child image, using sysbuild's
+  link your main Zephyr application as an MCUboot-bootable image, using sysbuild's
   Kconfig files.
 
 - Sysbuild integrates with west's :ref:`west-build-flash-debug` commands. It


### PR DESCRIPTION
Removes mention of child image to prevent confusion with other systems that have no relation to sysbuild