### PR TITLE
sched: finalize_cancel_locked can early return

### DIFF
--- a/kernel/work.c
+++ b/kernel/work.c
@@ -141,9 +141,9 @@ static void finalize_cancel_locked(struct k_work *work)
 		if (wc->work == work) {
 			sys_slist_remove(&pending_cancels, prev, &wc->node);
 			k_sem_give(&wc->sem);
-		} else {
-			prev = &wc->node;
+			break;
 		}
+		prev = &wc->node;
 	}
 }
 


### PR DESCRIPTION
The code `SYS_SLIST_FOR_EACH_CONTAINER_SAFE` just for remove work from `pending_cancels`. 
After removing work successfully, the function can return early. 
It is unnecessary to iterate continuously.