### PR TITLE
sensor: ms5837: fix compensate parameters for 30BA variant

### DIFF
--- a/drivers/sensor/meas/ms5837/ms5837.c
+++ b/drivers/sensor/meas/ms5837/ms5837.c
@@ -75,17 +75,17 @@ static void ms5837_compensate_30(const struct device *dev,
 
 	temp_sq = (int64_t)(data->temperature - 2000) * (data->temperature - 2000);
 	if (data->temperature < 2000) {
-		Ti = (3ll * dT * dT) / (1ll << 23);
-		OFFi = (3ll * temp_sq) / 1ll;
+		Ti = (3ll * dT * dT) / (1ll << 33);
+		OFFi = (3ll * temp_sq) / (1ll << 1);
 		SENSi = (5ll * temp_sq) / (1ll << 3);
 		if (data->temperature < -1500) {
 			temp_sq = (data->temperature + 1500) *
 				  (data->temperature + 1500);
 			OFFi += 7ll * temp_sq;
-			SENSi += 5ll * temp_sq;
+			SENSi += 4ll * temp_sq;
 		}
 	} else {
-		Ti = (1ll * dT * dT) / (1ll << 37);
+		Ti = (2ll * dT * dT) / (1ll << 37);
 		OFFi = temp_sq / (1ll << 4);
 		SENSi = 0;
 	}


### PR DESCRIPTION
The previous parameters seems wrong if we refer to: 
https://www.te.com/usa-en/product-CAT-BLPS0017.html

![compensation from data sheet](https://github.com/zephyrproject-rtos/zephyr/assets/50738558/c34e7ff4-768e-4d5b-b193-7b17017d4677)
