### PR TITLE
hwmv2: boards: fix few leftover ITE board references

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3543,7 +3543,7 @@ ITE Platforms:
     - brockus-zephyr
     - sjg20
   files:
-    - boards/riscv/it8*_evb/
+    - boards/ite/
     - drivers/*/*/*it8xxx2*.c
     - drivers/*/*it8xxx2*.c
     - drivers/*/*_ite_*

--- a/boards/ite/it82xx2_evb/doc/index.rst
+++ b/boards/ite/it82xx2_evb/doc/index.rst
@@ -96,7 +96,7 @@ currently supports the following hardware features:
 Other hardware features are not currently supported by Zephyr.
 
 The default configuration can be found in the
-:zephyr_file:`boards/riscv/it82xx2_evb/it82xx2_evb_defconfig` Kconfig file.
+:zephyr_file:`boards/ite/it82xx2_evb/it82xx2_evb_defconfig` Kconfig file.
 
 Programming and debugging on it82202
 ************************************

--- a/boards/ite/it8xxx2_evb/doc/index.rst
+++ b/boards/ite/it8xxx2_evb/doc/index.rst
@@ -72,7 +72,7 @@ currently supports the following hardware features:
 Other hardware features are not currently supported by Zephyr.
 
 The default configuration can be found in the
-:zephyr_file:`boards/riscv/it8xxx2_evb/it8xxx2_evb_defconfig` Kconfig file.
+:zephyr_file:`boards/ite/it8xxx2_evb/it8xxx2_evb_defconfig` Kconfig file.
 
 Hardware reworks
 ****************


### PR DESCRIPTION
Fix few leftover ITE references from the conversion to hwmv2.