### PR TITLE
hwmv2: boards: doc: fix a bunch of broken reference

### DIFF
--- a/boards/96boards/96b_carbon/doc/stm32f401xe.rst
+++ b/boards/96boards/96b_carbon/doc/stm32f401xe.rst
@@ -101,7 +101,7 @@ hardware features:
 More details about the board can be found at `96Boards website`_.
 
 The default configuration can be found in
-:zephyr_file:`boards/96boards/96b_carbon/96b_carbon_defconfig`
+:zephyr_file:`boards/96boards/96b_carbon/96b_carbon_stm32f401xe_defconfig`
 
 Connections and IOs
 ===================

--- a/boards/altera/altera_max10/doc/index.rst
+++ b/boards/altera/altera_max10/doc/index.rst
@@ -92,11 +92,11 @@ Reference CPU
 =============
 
 A reference CPU design of a Nios II/f core is included in the Zephyr tree
-in the :zephyr_file:`soc/nios2/nios2f-zephyr/cpu` directory.
+in the :zephyr_file:`soc/altera/zephyr_nios2f/cpu` directory.
 
 Flash this CPU using the ``nios2-configure-sof`` SDK tool with the FPGA
 configuration file
-:zephyr_file:`soc/nios2/nios2f-zephyr/cpu/ghrd_10m50da.sof`:
+:zephyr_file:`soc/altera/zephyr_nios2f/cpu/ghrd_10m50da.sof`:
 
 .. code-block:: console
 

--- a/boards/circuit_dojo/circuitdojo_feather/doc/index.rst
+++ b/boards/circuit_dojo/circuitdojo_feather/doc/index.rst
@@ -147,7 +147,7 @@ the board are working properly with Zephyr:
 
 You can build and flash the examples to make sure Zephyr is running correctly on
 your board. The button and LED definitions can be found in
-:zephyr_file:`boards/circuit_dojo/circuitdojo_feather_nrf9160/circuitdojo_feather_nrf9160_common.dtsi`.
+:zephyr_file:`boards/circuit_dojo/circuitdojo_feather/circuitdojo_feather_nrf9160_common.dtsi`.
 
 References
 **********

--- a/boards/google/google_twinkie_v2/doc/index.rst
+++ b/boards/google/google_twinkie_v2/doc/index.rst
@@ -32,7 +32,7 @@ The following features are supported:
 +-----------+------------+-------------------------------------+
 
 The default configuration can be found in the defconfig file:
-``boards/arm/google_twinkie_v2/google_twinkie_v2_defconfig``
+:zephyr_file:`boards/google/google_twinkie_v2/google_twinkie_v2_defconfig`
 
 Pin Mapping
 ===========

--- a/boards/holyiot/holyiot_yj16019/doc/index.rst
+++ b/boards/holyiot/holyiot_yj16019/doc/index.rst
@@ -136,7 +136,7 @@ the board are working properly with Zephyr:
 
 You can build and flash the examples to make sure Zephyr is running
 correctly on your board. The button and LED definitions can be found
-in :zephyr_file:`boards/holyiod/holyiot_yj16019/holyiot_yj16019.dts`.
+in :zephyr_file:`boards/holyiot/holyiot_yj16019/holyiot_yj16019.dts`.
 
 References
 **********

--- a/boards/nuvoton/npcx4m8f_evb/doc/index.rst
+++ b/boards/nuvoton/npcx4m8f_evb/doc/index.rst
@@ -62,7 +62,7 @@ The following features are supported:
 Other hardware features are not currently supported by Zephyr (at the moment)
 
 The default configuration can be found in the defconfig file:
-``boards/arm/npcx4m8f_evb/npcx4m8f_evb_defconfig``
+:zephyr_file:`boards/nuvoton/npcx4m8f_evb/npcx4m8f_evb_defconfig`
 
 
 Connections and IOs

--- a/boards/nuvoton/npcx7m6fb_evb/doc/index.rst
+++ b/boards/nuvoton/npcx7m6fb_evb/doc/index.rst
@@ -48,7 +48,7 @@ The following features are supported:
 Other hardware features are not currently supported by Zephyr (at the moment)
 
 The default configuration can be found in the defconfig file:
-``boards/arm/npcx7m6fb_evb/npcx7m6fb_evb_defconfig``
+:zephyr_file:`boards/nuvoton/npcx7m6fb_evb/npcx7m6fb_evb_defconfig`
 
 
 Connections and IOs

--- a/boards/nuvoton/npcx9m6f_evb/doc/index.rst
+++ b/boards/nuvoton/npcx9m6f_evb/doc/index.rst
@@ -62,7 +62,7 @@ The following features are supported:
 Other hardware features are not currently supported by Zephyr (at the moment)
 
 The default configuration can be found in the defconfig file:
-``boards/arm/npcx9m6f_evb/npcx9m6f_evb_defconfig``
+:zephyr_file:`boards/nuvoton/npcx9m6f_evb/npcx9m6f_evb_defconfig`
 
 
 Connections and IOs

--- a/boards/others/black_f407ve/doc/index.rst
+++ b/boards/others/black_f407ve/doc/index.rst
@@ -119,7 +119,7 @@ features:
 Other hardware features are not yet supported on Zephyr porting.
 
 The default configuration can be found in
-:zephyr_file:`boards/others/black_f407_generic/black_f407ve_defconfig`
+:zephyr_file:`boards/others/black_f407ve/black_f407ve_defconfig`
 
 
 Pin Mapping

--- a/boards/phytec/phyboard_lyra_am62x/doc/index.rst
+++ b/boards/phytec/phyboard_lyra_am62x/doc/index.rst
@@ -87,7 +87,7 @@ cores of the SoM. These cores will then load the zephyr binary on the M4 core
 using remoteproc.
 
 The default configuration can be found in
-:zephyr_file:`boards/phytec/phyboard_lyra_am63x/phyboard_lyra_am62x_am6234_m4_defconfig`
+:zephyr_file:`boards/phytec/phyboard_lyra_am62x/phyboard_lyra_am62x_am6234_m4_defconfig`
 
 Flashing
 ********

--- a/boards/raspberry_pi/rpi_4b/doc/index.rst
+++ b/boards/raspberry_pi/rpi_4b/doc/index.rst
@@ -35,7 +35,7 @@ hardware features:
 Other hardware features have not been enabled yet for this board.
 
 The default configuration can be found in
-:zephyr_file:`boards/raspberrypi/rpi_4b/rpi_4b_defconfig`
+:zephyr_file:`boards/raspberry_pi/rpi_4b/rpi_4b_defconfig`
 
 Programming and Debugging
 *************************

--- a/boards/seeed_studio/xiao_ble/doc/index.rst
+++ b/boards/seeed_studio/xiao_ble/doc/index.rst
@@ -182,7 +182,7 @@ properly with Zephyr:
 
 You can build and flash the examples to make sure Zephyr is running correctly on
 your board. The LED definitions can be found in
-:zephyr_file:`boards/xiao_ble/xiao_ble_common.dtsi`.
+:zephyr_file:`boards/seeed_studio/xiao_ble/xiao_ble_common.dtsi`.
 
 Testing shell over USB in the XIAO BLE (Sense)
 **********************************************

--- a/boards/sparkfun/sparkfun_thing_plus/doc/index.rst
+++ b/boards/sparkfun/sparkfun_thing_plus/doc/index.rst
@@ -139,7 +139,7 @@ the board are working properly with Zephyr:
 
 You can build and flash the examples to make sure Zephyr is running correctly on
 your board. The button and LED definitions can be found in
-:zephyr_file:`boards/sparkfun/sparkfun_thing_plus_nrf9160/sparkfun_thing_plus_nrf9160_common.dtsi`.
+:zephyr_file:`boards/sparkfun/sparkfun_thing_plus/sparkfun_thing_plus_nrf9160_common.dtsi`.
 
 References
 **********

--- a/boards/st/b_g474e_dpow1/doc/index.rst
+++ b/boards/st/b_g474e_dpow1/doc/index.rst
@@ -71,7 +71,7 @@ The Zephyr b_g474e_dpow1 board configuration supports the following hardware fea
 Other hardware features are not yet supported in this Zephyr port.
 
 The default configuration can be found in the defconfig file:
-``boards/arm/b_g474e_dpow1/b_g474e_dpow1_defconfig``
+:zephyr_file:`boards/st/b_g474e_dpow1/b_g474e_dpow1_defconfig`
 
 Connections and IOs
 ===================

--- a/boards/st/nucleo_g031k8/doc/index.rst
+++ b/boards/st/nucleo_g031k8/doc/index.rst
@@ -87,7 +87,7 @@ The Zephyr nucleo_g031k8 board configuration supports the following hardware fea
 Other hardware features are not yet supported in this Zephyr port.
 
 The default configuration can be found in the defconfig file:
-``boards/arm/nucleo_g031k8/nucleo_g031k8_defconfig``
+:zephyr_file:`boards/st/nucleo_g031k8/nucleo_g031k8_defconfig`
 
 Connections and IOs
 ===================

--- a/boards/st/nucleo_g070rb/doc/index.rst
+++ b/boards/st/nucleo_g070rb/doc/index.rst
@@ -112,7 +112,7 @@ The Zephyr nucleo_g070rb board configuration supports the following hardware fea
 Other hardware features are not yet supported in this Zephyr port.
 
 The default configuration can be found in the defconfig file:
-``boards/arm/nucleo_g070rb/nucleo_g070rb_defconfig``
+:zephyr_file:`boards/st/nucleo_g070rb/nucleo_g070rb_defconfig`
 
 Connections and IOs
 ===================

--- a/boards/st/nucleo_g071rb/doc/index.rst
+++ b/boards/st/nucleo_g071rb/doc/index.rst
@@ -116,7 +116,7 @@ The Zephyr nucleo_g071rb board configuration supports the following hardware fea
 Other hardware features are not yet supported in this Zephyr port.
 
 The default configuration can be found in the defconfig file:
-``boards/arm/nucleo_g071rb/nucleo_g071rb_defconfig``
+:zephyr_file:`boards/st/nucleo_g071rb/nucleo_g071rb_defconfig`
 
 Connections and IOs
 ===================

--- a/boards/st/nucleo_g0b1re/doc/index.rst
+++ b/boards/st/nucleo_g0b1re/doc/index.rst
@@ -114,7 +114,7 @@ The Zephyr nucleo_g0b1re board configuration supports the following hardware fea
 Other hardware features are not yet supported in this Zephyr port.
 
 The default configuration can be found in the defconfig file:
-``boards/arm/nucleo_g0b1re/nucleo_g0b1re_defconfig``
+:zephyr_file:`boards/st/nucleo_g0b1re/nucleo_g0b1re_defconfig`
 
 Connections and IOs
 ===================

--- a/boards/st/nucleo_g431rb/doc/index.rst
+++ b/boards/st/nucleo_g431rb/doc/index.rst
@@ -125,7 +125,7 @@ The Zephyr nucleo_g431rb board configuration supports the following hardware fea
 Other hardware features are not yet supported on this Zephyr port.
 
 The default configuration can be found in the defconfig file:
-``boards/arm/nucleo_g431rb/nucleo_g431rb_defconfig``
+:zephyr_file:`boards/st/nucleo_g431rb/nucleo_g431rb_defconfig`
 
 
 Connections and IOs

--- a/boards/st/nucleo_g474re/doc/index.rst
+++ b/boards/st/nucleo_g474re/doc/index.rst
@@ -133,7 +133,7 @@ The Zephyr nucleo_g474re board configuration supports the following hardware fea
 Other hardware features are not yet supported on this Zephyr port.
 
 The default configuration can be found in the defconfig file:
-``boards/arm/nucleo_g474re/nucleo_g474re_defconfig``
+:zephyr_file:`boards/st/nucleo_g474re/nucleo_g474re_defconfig`
 
 
 Connections and IOs

--- a/boards/st/stm32g0316_disco/doc/index.rst
+++ b/boards/st/stm32g0316_disco/doc/index.rst
@@ -59,7 +59,7 @@ The Zephyr stm32g0316_disco board configuration supports the following hardware 
 Other hardware features are not currently supported by the port.
 
 The default configuration can be found in the defconfig file:
-``boards/arm/stm32g0316_disco/stm32g0316_disco_defconfig``
+:zephyr_file:`boards/st/stm32g0316_disco/stm32g0316_disco_defconfig`
 
 Connections and IOs
 ===================

--- a/boards/st/stm32g071b_disco/doc/index.rst
+++ b/boards/st/stm32g071b_disco/doc/index.rst
@@ -80,7 +80,7 @@ The Zephyr stm32g071b_disco board configuration supports the following hardware 
 Other hardware features are not yet supported in this Zephyr port.
 
 The default configuration can be found in the defconfig file:
-``boards/arm/stm32g071b_disco/stm32g071b_disco_defconfig``
+:zephyr_file:`boards/st/stm32g071b_disco/stm32g071b_disco_defconfig`
 
 Connections and IOs
 ===================

--- a/boards/st/stm32g081b_eval/doc/index.rst
+++ b/boards/st/stm32g081b_eval/doc/index.rst
@@ -121,7 +121,7 @@ The Zephyr stm32g081b_eval board configuration supports the following hardware f
 Other hardware features are not yet supported in this Zephyr port.
 
 The default configuration can be found in the defconfig file:
-``boards/arm/stm32g081b_eval/stm32g081b_eval_defconfig``
+:zephyr_file:`boards/st/stm32g081b_eval/stm32g081b_eval_defconfig`
 
 Connections and IOs
 ===================

--- a/boards/st/stm32l562e_dk/doc/index.rst
+++ b/boards/st/stm32l562e_dk/doc/index.rst
@@ -199,12 +199,12 @@ The default configuration can be found in the defconfig and dts files:
 - Secure target:
 
   - :zephyr_file:`boards/st/stm32l562e_dk/stm32l562e_dk_defconfig`
-  - :zephyr_file:`boards/arm/stm32l562e_dk/stm32l562e_dk.dts`
+  - :zephyr_file:`boards/st/stm32l562e_dk/stm32l562e_dk.dts`
 
 - Non-Secure target:
 
-  - :zephyr_file:`boards/st/stm32l562e_dk/stm32l562e_dk_ns_defconfig`
-  - :zephyr_file:`boards/st/stm32l562e_dk/stm32l562e_dk_ns.dts`
+  - :zephyr_file:`boards/st/stm32l562e_dk/stm32l562e_dk_stm32l562xx_ns_defconfig`
+  - :zephyr_file:`boards/st/stm32l562e_dk/stm32l562e_dk_stm32l562xx_ns.dts`
 
 Zephyr board options
 ====================

--- a/boards/ti/cc3220sf_launchxl/doc/index.rst
+++ b/boards/ti/cc3220sf_launchxl/doc/index.rst
@@ -71,34 +71,6 @@ driver support.
 The accelerometer, temperature sensors, or other peripherals
 accessible through the BoosterPack, are not currently supported.
 
-Connections and IOs
-====================
-
-Peripherals on the CC3220SF LaunchXL are mapped to the following pins in
-the file :zephyr_file:`boards/ti/cc3220sf_launchxl/pinmux.c`.
-
-+------------+-------+-------+
-| Function   | PIN   | GPIO  |
-+============+=======+=======+
-| UART0_TX   | 55    | N/A   |
-+------------+-------+-------+
-| UART0_RX   | 57    | N/A   |
-+------------+-------+-------+
-| LED D7 (R) | 64    | 9     |
-+------------+-------+-------+
-| LED D6 (O) | 01    | 10    |
-+------------+-------+-------+
-| LED D5 (G) | 02    | 11    |
-+------------+-------+-------+
-| Switch SW2 | 15    | 22    |
-+------------+-------+-------+
-| Switch SW3 | 04    | 13    |
-+------------+-------+-------+
-
-The default configuration can be found in the Kconfig file at
-:zephyr_file:`boards/ti/cc3220sf_launchxl/cc3220sf_launchxl_defconfig`.
-
-
 Programming and Debugging
 *************************
 

--- a/boards/ti/cc3235sf_launchxl/doc/index.rst
+++ b/boards/ti/cc3235sf_launchxl/doc/index.rst
@@ -71,34 +71,6 @@ driver support.
 The accelerometer, temperature sensors, or other peripherals
 accessible through the BoosterPack, are not currently supported.
 
-Connections and IOs
-====================
-
-Peripherals on the CC3235SF LaunchXL are mapped to the following pins in
-the file :zephyr_file:`boards/ti/cc3235sf_launchxl/pinmux.c`.
-
-+------------+-------+-------+
-| Function   | PIN   | GPIO  |
-+============+=======+=======+
-| UART0_TX   | 55    | N/A   |
-+------------+-------+-------+
-| UART0_RX   | 57    | N/A   |
-+------------+-------+-------+
-| LED D7 (R) | 64    | 9     |
-+------------+-------+-------+
-| LED D6 (O) | 01    | 10    |
-+------------+-------+-------+
-| LED D5 (G) | 02    | 11    |
-+------------+-------+-------+
-| Switch SW2 | 15    | 22    |
-+------------+-------+-------+
-| Switch SW3 | 04    | 13    |
-+------------+-------+-------+
-
-The default configuration can be found in the Kconfig file at
-:zephyr_file:`boards/ti/cc3235sf_launchxl/cc3235sf_launchxl_defconfig`.
-
-
 Programming and Debugging
 *************************
 

--- a/boards/ublox/ubx_bmd345eval/doc/index.rst
+++ b/boards/ublox/ubx_bmd345eval/doc/index.rst
@@ -460,7 +460,7 @@ There are 2 samples that allow you to test that the buttons
 You can build and flash the examples to make sure Zephyr is running
 correctly on your board. The button and LED definitions can be found
 in
-:zephyr_file:`boards/ublox//ubx_bmd340eval/ubx_bmd345eval_nrf52840.dts`.
+:zephyr_file:`boards/ublox/ubx_bmd345eval/ubx_bmd345eval_nrf52840.dts`.
 
 Using UART1
 ***********

--- a/boards/ublox/ubx_evkninab3/doc/index.rst
+++ b/boards/ublox/ubx_evkninab3/doc/index.rst
@@ -261,7 +261,7 @@ There are 2 samples that allow you to test that the buttons
 
 You can build and flash the examples to make sure Zephyr is running correctly on
 your board. The button and LED definitions can be found in
-:zephyr_file:`boards/ublox/ubx_evkninab3/ubx_ninab3_nrf52840.dts`.
+:zephyr_file:`boards/ublox/ubx_evkninab3/ubx_evkninab3_nrf52840.dts`.
 
 Using UART1
 ***********

--- a/boards/weact/blackpill_f401cc/doc/index.rst
+++ b/boards/weact/blackpill_f401cc/doc/index.rst
@@ -72,7 +72,7 @@ hardware features:
 +------------+------------+-------------------------------------+
 
 The default configuration can be found in
-:zephyr_file:`boards/weact/blackpill_f401cc/blackpill_f401ce_defconfig`
+:zephyr_file:`boards/weact/blackpill_f401ce/blackpill_f401ce_defconfig`
 
 Pin Mapping
 ===========

--- a/boards/weact/blackpill_f411ce/doc/index.rst
+++ b/boards/weact/blackpill_f411ce/doc/index.rst
@@ -72,7 +72,7 @@ hardware features:
 +------------+------------+-------------------------------------+
 
 The default configuration can be found in
-:zephyr_file:`boards/weact/stm32_blackpill_v2/stm32_blackpill_v2_defconfig`
+:zephyr_file:`boards/weact/blackpill_f411ce/blackpill_f411ce_defconfig`
 
 Pin Mapping
 ===========

--- a/boards/weact/weact_stm32g431_core/doc/index.rst
+++ b/boards/weact/weact_stm32g431_core/doc/index.rst
@@ -52,7 +52,7 @@ features:
 
 The default configuration can be found in the defconfig file:
 
-        ``boards/arm/weact_stm32g431_core/weact_stm32g431_core_defconfig``
+:zephyr_file:`boards/weact/weact_stm32g431_core/weact_stm32g431_core_defconfig`
 
 Pin Mapping
 ===========

--- a/boards/xen/xenvm/doc/index.rst
+++ b/boards/xen/xenvm/doc/index.rst
@@ -34,8 +34,8 @@ The kernel currently does not support other hardware features on this platform.
 
 The default configuration for this board can be found in these files:
 
-- ``boards/arm64/xenvm/Kconfig.defconfig``
-- ``boards/arm64/xenvm/xenvm_defconfig``
+- :zephyr_file:`boards/xen/xenvm/Kconfig.defconfig`
+- :zephyr_file:`boards/xen/xenvm/xenvm_defconfig`
 
 Devices
 ========


### PR DESCRIPTION
Fix a bunch of broken reference to configuration and other files. Drop two TI ones that were stale, file were long gone.