### PR TITLE
boards: thingy52: deprecate board

### DIFF
--- a/boards/nordic/thingy52/doc/index.rst
+++ b/boards/nordic/thingy52/doc/index.rst
@@ -3,6 +3,11 @@
 Thingy:52
 #########
 
+.. warning::
+
+   Nordic Semiconductor no longer offers support for this board, so it is not
+   recommended for new prototypes.
+
 Overview
 ********
 


### PR DESCRIPTION
Nordic Semiconductor no longer offers support for this board, so warn users to avoid it for new prototypes.