### PR TITLE
Bluetooth: BAP: UC: Fix call to bt_gatt_get_mtu in notify

### DIFF
--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -1564,7 +1564,7 @@ static uint8_t unicast_client_ep_notify(struct bt_conn *conn,
 	struct net_buf_simple buf;
 	struct bt_bap_unicast_client_ep *client_ep;
 	const uint8_t att_ntf_header_size = 3; /* opcode (1) + handle (2) */
-	const uint16_t max_ntf_size = bt_gatt_get_mtu(conn) - att_ntf_header_size;
+	uint16_t max_ntf_size;
 	struct bt_bap_ep *ep;
 
 	client_ep = CONTAINER_OF(params, struct bt_bap_unicast_client_ep, subscribe);
@@ -1580,6 +1580,8 @@ static uint8_t unicast_client_ep_notify(struct bt_conn *conn,
 		params->value_handle = 0x0000;
 		return BT_GATT_ITER_STOP;
 	}
+
+	max_ntf_size = bt_gatt_get_mtu(conn) - att_ntf_header_size;
 
 	if (length == max_ntf_size) {
 		struct unicast_client *client = &uni_cli_insts[bt_conn_index(conn)];


### PR DESCRIPTION
In the unicast_client_ep_notify we would always call bt_gatt_get_mtu, regardless of whether data == NULL.

When there is a disconnection, the notify callbacks are called with data == NULL to indicate a unsubscription. In the case of the unicast client, this would also trigger calls to bt_gatt_get_mtu when there is a disconnect, which in turn would trigger a warning that ATT is not connected.

Postponing the call to bt_gatt_get_mtu fixes this.