### PR TITLE
boards: added arduino pins to nrf5340 audio DK network core

### DIFF
--- a/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_nrf5340_cpuapp_common.dtsi
+++ b/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_nrf5340_cpuapp_common.dtsi
@@ -25,35 +25,6 @@
 		};
 	};
 
-	arduino_header: connector {
-		compatible = "arduino-header-r3";
-		#gpio-cells = <2>;
-		gpio-map-mask = <0xffffffff 0xffffffc0>;
-		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio0 4 0>,	/* A0 */
-			   <1 0 &gpio0 5 0>,	/* A1 */
-			   <2 0 &gpio0 6 0>,	/* A2 */
-			   <3 0 &gpio0 7 0>,	/* A3 */
-			   <4 0 &gpio0 25 0>,	/* A4 */
-			   <5 0 &gpio0 26 0>,	/* A5 */
-			   <6 0 &gpio1 9 0>,	/* D0 */
-			   <7 0 &gpio1 8 0>,	/* D1 */
-			   <8 0 &gpio0 31 0>,	/* D2 */
-			   <9 0 &gpio1 0 0>,	/* D3 */
-			   <10 0 &gpio1 1 0>,	/* D4 */
-			   <11 0 &gpio1 14 0>,	/* D5 */
-			   <12 0 &gpio1 7 0>,	/* D6 */
-			   <13 0 &gpio1 11 0>,	/* D7 */
-			   <14 0 &gpio1 10 0>,	/* D8 */
-			   <15 0 &gpio1 13 0>,	/* D9 */
-			   <16 0 &gpio1 12 0>,	/* D10 */
-			   <17 0 &gpio0 9 0>,	/* D11 */
-			   <18 0 &gpio0 10 0>,	/* D12 */
-			   <19 0 &gpio0 8 0>,	/* D13 */
-			   <20 0 &gpio1 2 0>,	/* D14 */
-			   <21 0 &gpio1 3 0>;	/* D15 */
-	};
-
 	pmic {
 		compatible = "nordic,npm1100";
 		nordic,iset-gpios = <&gpio0 23 GPIO_ACTIVE_HIGH>;

--- a/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_nrf5340_cpunet-pinctrl.dtsi
+++ b/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_nrf5340_cpunet-pinctrl.dtsi
@@ -26,4 +26,21 @@
 		};
 	};
 
+	spi0_default: spi0_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 0, 8)>,
+				<NRF_PSEL(SPIM_MISO, 0, 10)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 9)>;
+		};
+	};
+
+	spi0_sleep: spi0_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 0, 8)>,
+				<NRF_PSEL(SPIM_MISO, 0, 10)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 9)>;
+			low-power-enable;
+		};
+	};
+
 };

--- a/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_nrf5340_cpunet.dts
+++ b/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_nrf5340_cpunet.dts
@@ -24,6 +24,17 @@
 		zephyr,code-partition = &slot0_partition;
 		watchdog0 = &wdt0;
 	};
+
+};
+
+arduino_spi: &spi0 {
+	compatible = "nordic,nrf-spim";
+	/* Cannot be used together with uart0. */
+	/* status = "okay"; */
+	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>; /* D10 */
+	pinctrl-0 = <&spi0_default>;
+	pinctrl-1 = <&spi0_sleep>;
+	pinctrl-names = "default", "sleep";
 };
 
 &gpiote {

--- a/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_nrf5340_shared.dtsi
+++ b/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_nrf5340_shared.dtsi
@@ -70,6 +70,35 @@
 		};
 	};
 
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpio0 4 0>,	/* A0 */
+			   <1 0 &gpio0 5 0>,	/* A1 */
+			   <2 0 &gpio0 6 0>,	/* A2 */
+			   <3 0 &gpio0 7 0>,	/* A3 */
+			   <4 0 &gpio0 25 0>,	/* A4 */
+			   <5 0 &gpio0 26 0>,	/* A5 */
+			   <6 0 &gpio1 9 0>,	/* D0 */
+			   <7 0 &gpio1 8 0>,	/* D1 */
+			   <8 0 &gpio0 31 0>,	/* D2 */
+			   <9 0 &gpio1 0 0>,	/* D3 */
+			   <10 0 &gpio1 1 0>,	/* D4 */
+			   <11 0 &gpio1 14 0>,	/* D5 */
+			   <12 0 &gpio1 7 0>,	/* D6 */
+			   <13 0 &gpio1 11 0>,	/* D7 */
+			   <14 0 &gpio1 10 0>,	/* D8 */
+			   <15 0 &gpio1 13 0>,	/* D9 */
+			   <16 0 &gpio1 12 0>,	/* D10 */
+			   <17 0 &gpio0 9 0>,	/* D11 */
+			   <18 0 &gpio0 10 0>,	/* D12 */
+			   <19 0 &gpio0 8 0>,	/* D13 */
+			   <20 0 &gpio1 2 0>,	/* D14 */
+			   <21 0 &gpio1 3 0>;	/* D15 */
+	};
+
 	aliases {
 		led0 = &rgb1_red;
 		led1 = &rgb1_green;


### PR DESCRIPTION
Added arduino pin definition for nRF5340 audio DK network core, so we can use nrf21540-ek easily with SDC.
Signed-off-by: Jui-Chou Chung <jui-chou.chung@nordicsemi.no>