### PR TITLE
hwmv2: Add definitions for the 64bit native_sim/posix boards as variants

### DIFF
--- a/boards/native/native_posix/Kconfig
+++ b/boards/native/native_posix/Kconfig
@@ -5,10 +5,10 @@ config BOARD_NATIVE_POSIX
 	imply NATIVE_POSIX_TIMER
 	select POSIX_ARCH_CONSOLE
 	select NATIVE_APPLICATION
+	select 64BIT if BOARD_NATIVE_POSIX_NATIVE_64
 	help
-	  Native POSIX - 32 bit version
-	  Will produce a console Linux process which can be executed natively
-	  as a 32-bit executable.
+	  Native POSIX
+	  Will produce a console Linux process which can be executed natively.
 	  It provides some minimal needed models:
 	  An interrupt controller, timer (system tick), and redirects kernel prints to
 	  stdout.

--- a/boards/native/native_posix/board.yml
+++ b/boards/native/native_posix/board.yml
@@ -3,6 +3,12 @@ boards:
   vendor: Zephyr
   socs:
   - name: native
+    variants:
+    - name: "64"
+
+# This board definition below, together with its respective
+# Kconfig.native_posix_64 exist for backwards compatibility with the hwmv1 board name
+# Once all its usage in tree is removed, or an alias has been introduced they can be removed.
 - name: native_posix_64
   vendor: Zephyr
   socs:

--- a/boards/native/native_sim/Kconfig
+++ b/boards/native/native_sim/Kconfig
@@ -6,11 +6,11 @@ config BOARD_NATIVE_SIM
 	select POSIX_ARCH_CONSOLE
 	select NATIVE_LIBRARY
 	select NATIVE_POSIX_TIMER
+	select 64BIT if BOARD_NATIVE_SIM_NATIVE_64
 	imply BOARD_NATIVE_POSIX if NATIVE_SIM_NATIVE_POSIX_COMPAT
 	help
 	  Native simulator (Single Core)
-	  Will produce a console Linux process which can be executed natively
-	  as a 32-bit executable.
+	  Will produce a console Linux process which can be executed natively.
 
 config BOARD_NATIVE_SIM_64
 	bool

--- a/boards/native/native_sim/board.yml
+++ b/boards/native/native_sim/board.yml
@@ -3,6 +3,12 @@ boards:
   vendor: Zephyr
   socs:
   - name: native
+    variants:
+    - name: "64"
+
+# This board definition below, together with its respective
+# Kconfig.native_sim_64 exist for backwards compatibility with the hwmv1 board name
+# Once all its usage in tree is removed, or an alias has been introduced they can be removed.
 - name: native_sim_64
   vendor: Zephyr
   socs:


### PR DESCRIPTION
For native_sim and native_posix add the 64 bit version definitions as board variants.

Follow up on https://github.com/zephyrproject-rtos/zephyr/pull/69034
After this PR users can build targeting native_sim//64 & native_posix//64 but tests are still using the old names.
