### PR TITLE
samples/modules/lvgl/demos: Increase heap for native 64 targets

### DIFF
--- a/samples/modules/lvgl/demos/boards/native_posix_64.conf
+++ b/samples/modules/lvgl/demos/boards/native_posix_64.conf
@@ -2,3 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 CONFIG_LV_COLOR_DEPTH_32=y
+CONFIG_LV_Z_MEM_POOL_SIZE=65536

--- a/samples/modules/lvgl/demos/boards/native_sim_64.conf
+++ b/samples/modules/lvgl/demos/boards/native_sim_64.conf
@@ -2,3 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 CONFIG_LV_COLOR_DEPTH_32=y
+CONFIG_LV_Z_MEM_POOL_SIZE=65536


### PR DESCRIPTION
For these targets, the widgets demo run out of heap and crashes. Let's just increase the heap size.

Fixes: #68398