### PR TITLE
doc: release-notes: add release notes for SDHC and Disk

### DIFF
--- a/doc/releases/release-notes-3.6.rst
+++ b/doc/releases/release-notes-3.6.rst
@@ -334,8 +334,6 @@ Drivers and Sensors
 
 * DAC
 
-* Disk
-
 * Display
 
   * Introduce frame buffer config to STM32 LTDC driver.

--- a/doc/releases/release-notes-3.6.rst
+++ b/doc/releases/release-notes-3.6.rst
@@ -520,6 +520,10 @@ Drivers and Sensors
 
 * SDHC
 
+  * Added SDHC driver for Cadence SDHC IP
+  * Added SDHC driver for Infineon CAT1 IP
+  * Added support for SDIO commands to iMX USDHC SDHC driver
+
 * Sensor
 
   * Fixed arithmetic overflow in the LTRF216A driver.
@@ -1061,6 +1065,10 @@ Libraries / Subsystems
 
   * Fixed issue whereby :kconfig:option:`CONFIG_RETENTION_BUFFER_SIZE` values over 256 would cause
     an infinite loop due to use of 8-bit variables.
+
+* SD
+
+  * Added support for SDIO devices
 
 * Storage
 


### PR DESCRIPTION
Add release notes for SDHC and disk drivers

**Note**: There were no changes to the disk driver layer since 3.5, so I simply removed the section from the docs. I could also add a placeholder note such as "no changes since prior release", if that is preferable