### PR TITLE
native_simulator: Get latest from upstream

### DIFF
--- a/scripts/native_simulator/common/src/include/nsi_host_trampolines.h
+++ b/scripts/native_simulator/common/src/include/nsi_host_trampolines.h
@@ -12,7 +12,7 @@
  * function calls, as that would break the include path isolation
  *
  * Naming convention: nsi_host_<fun>() where <func> is the name of the equivalent
- * C library call we call thru.
+ * C library function we call through
  */
 
 #ifndef NSI_COMMON_SRC_INCL_NSI_HOST_TRAMPOLINES_H

--- a/scripts/native_simulator/common/src/nsi_cpu_ctrl.c
+++ b/scripts/native_simulator/common/src/nsi_cpu_ctrl.c
@@ -15,7 +15,7 @@ static bool cpu_booted[NSI_N_CPUS];
 #define CPU_N_RANGE_CHECK(cpu_n) \
 	if (cpu_n >= NSI_N_CPUS) { \
 		nsi_print_error_and_exit("%s called with cpu_n(%i) >= NSI_N_CPUS (%i)\n", \
-					 cpu_n, NSI_N_CPUS); \
+					 __func__, cpu_n, NSI_N_CPUS); \
 	}
 
 void nsi_cpu_set_auto_start(int cpu_n, bool auto_start)
@@ -45,7 +45,7 @@ void nsi_cpu_boot(int cpu_n)
 	CPU_N_RANGE_CHECK(cpu_n);
 	if (cpu_booted[cpu_n]) {
 		nsi_print_warning("%s called with cpu_n(%i) which was already booted\n",
-				  cpu_n);
+				  __func__, cpu_n);
 	}
 	cpu_booted[cpu_n] = true;
 	nsif_cpun_boot(cpu_n);


### PR DESCRIPTION
Align with native_simulator's upstream main
f02906708cf1668fe54ef2c2f1e159ed947573aa

Which includes:
* f029067 CPU ctrl: Fix two malformed error/warning messages
* 114f78b Host trampolines: Fix typos in comment

Fixes: #69107
Fixes: #69106