### PR TITLE
drivers: adc: use K_KERNEL_STACK_SIZEOF()

### DIFF
--- a/drivers/adc/adc_ad5592.c
+++ b/drivers/adc/adc_ad5592.c
@@ -218,7 +218,7 @@ static int adc_ad5592_init(const struct device *dev)
 	adc_context_init(&data->ctx);
 
 	tid = k_thread_create(&data->thread, data->stack,
-			CONFIG_ADC_AD5592_ACQUISITION_THREAD_STACK_SIZE,
+			K_KERNEL_STACK_SIZEOF(data->stack),
 			(k_thread_entry_t)adc_ad5592_acquisition_thread, data, NULL, NULL,
 			CONFIG_ADC_AD5592_ACQUISITION_THREAD_PRIO, 0, K_NO_WAIT);
 

--- a/drivers/adc/adc_ads7052.c
+++ b/drivers/adc/adc_ads7052.c
@@ -275,7 +275,7 @@ static int adc_ads7052_init(const struct device *dev)
 	}
 
 	k_thread_create(&data->thread, data->stack,
-			CONFIG_ADC_ADS7052_ACQUISITION_THREAD_STACK_SIZE,
+			K_KERNEL_STACK_SIZEOF(data->stack),
 			ads7052_acquisition_thread, data, NULL, NULL,
 			CONFIG_ADC_ADS7052_ACQUISITION_THREAD_PRIO, 0, K_NO_WAIT);
 

--- a/drivers/adc/adc_lmp90xxx.c
+++ b/drivers/adc/adc_lmp90xxx.c
@@ -1017,7 +1017,7 @@ static int lmp90xxx_init(const struct device *dev)
 	}
 
 	tid = k_thread_create(&data->thread, data->stack,
-			      CONFIG_ADC_LMP90XXX_ACQUISITION_THREAD_STACK_SIZE,
+			      K_KERNEL_STACK_SIZEOF(data->stack),
 			      lmp90xxx_acquisition_thread,
 			      data, NULL, NULL,
 			      CONFIG_ADC_LMP90XXX_ACQUISITION_THREAD_PRIO,

--- a/drivers/adc/adc_max1125x.c
+++ b/drivers/adc/adc_max1125x.c
@@ -755,7 +755,7 @@ static int max1125x_init(const struct device *dev)
 	}
 
 	k_tid_t tid = k_thread_create(
-		&data->thread, data->stack, K_THREAD_STACK_SIZEOF(data->stack),
+		&data->thread, data->stack, K_KERNEL_STACK_SIZEOF(data->stack),
 		max1125x_acquisition_thread, (void *)dev, NULL, NULL,
 		CONFIG_ADC_MAX1125X_ACQUISITION_THREAD_PRIORITY, 0, K_NO_WAIT);
 	k_thread_name_set(tid, "adc_max1125x");

--- a/drivers/adc/adc_mcp320x.c
+++ b/drivers/adc/adc_mcp320x.c
@@ -284,7 +284,7 @@ static int mcp320x_init(const struct device *dev)
 	}
 
 	k_thread_create(&data->thread, data->stack,
-			CONFIG_ADC_MCP320X_ACQUISITION_THREAD_STACK_SIZE,
+			K_KERNEL_STACK_SIZEOF(data->stack),
 			mcp320x_acquisition_thread,
 			data, NULL, NULL,
 			CONFIG_ADC_MCP320X_ACQUISITION_THREAD_PRIO,


### PR DESCRIPTION
Use `K_KERNEL_STACK_SIZEOF()` for calculating thread stack size, as this takes `K_KERNEL_STACK_RESERVED` into account.
    
Fixes: #69129
Fixes: #69130
Fixes: #69131
Fixes: #69132
Fixes: #69133
