### PR TITLE
drivers: charger: bq25180: fix return value check

### DIFF
--- a/drivers/charger/charger_bq25180.c
+++ b/drivers/charger/charger_bq25180.c
@@ -263,7 +263,7 @@ static int bq25180_init(const struct device *dev)
 	}
 
 	if (cfg->initial_current_microamp > 0) {
-		bq25180_set_charge_current(dev, cfg->initial_current_microamp);
+		ret = bq25180_set_charge_current(dev, cfg->initial_current_microamp);
 		if (ret < 0) {
 			return ret;
 		}


### PR DESCRIPTION
Fix missing check of the return value of `bq25180_set_charge_current` function, resulting in logically dead code, as indicated by Coverity CID 347197.

Fixes #69117