### PR TITLE
Reordered net context connect operation #69145

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -1198,6 +1198,19 @@ int net_context_connect(struct net_context *context,
 		goto unlock;
 	}
 
+    if (IS_ENABLED(CONFIG_NET_OFFLOAD) &&
+        net_if_is_ip_offloaded(net_context_get_iface(context))) {
+        ret = net_offload_connect(
+                net_context_get_iface(context),
+                context,
+                addr,
+                addrlen,
+                cb,
+                timeout,
+                user_data);
+        goto unlock;
+    }
+
 	if (IS_ENABLED(CONFIG_NET_IPV6) &&
 	    net_context_get_family(context) == AF_INET6) {
 		struct sockaddr_in6 *addr6 = (struct sockaddr_in6 *)
@@ -1294,19 +1307,6 @@ int net_context_connect(struct net_context *context,
 		}
 	} else {
 		ret = -EINVAL; /* Not IPv4 or IPv6 */
-		goto unlock;
-	}
-
-	if (IS_ENABLED(CONFIG_NET_OFFLOAD) &&
-	    net_if_is_ip_offloaded(net_context_get_iface(context))) {
-		ret = net_offload_connect(
-			net_context_get_iface(context),
-			context,
-			addr,
-			addrlen,
-			cb,
-			timeout,
-			user_data);
 		goto unlock;
 	}
 

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -1198,18 +1198,18 @@ int net_context_connect(struct net_context *context,
 		goto unlock;
 	}
 
-    if (IS_ENABLED(CONFIG_NET_OFFLOAD) &&
-        net_if_is_ip_offloaded(net_context_get_iface(context))) {
-        ret = net_offload_connect(
-                net_context_get_iface(context),
-                context,
-                addr,
-                addrlen,
-                cb,
-                timeout,
-                user_data);
-        goto unlock;
-    }
+	if (IS_ENABLED(CONFIG_NET_OFFLOAD) &&
+	    net_if_is_ip_offloaded(net_context_get_iface(context))) {
+		ret = net_offload_connect(
+				net_context_get_iface(context),
+				context,
+				addr,
+				addrlen,
+				cb,
+				timeout,
+				user_data);
+		goto unlock;
+	}
 
 	if (IS_ENABLED(CONFIG_NET_IPV6) &&
 	    net_context_get_family(context) == AF_INET6) {


### PR DESCRIPTION
Moved socket offload connect ahead of non offload connect implementation to fix issue with multiple network interfaces
See #69145