### PR TITLE
arch: Fix bounds checking for dynamic shared interrupts

### DIFF
--- a/arch/common/shared_irq.c
+++ b/arch/common/shared_irq.c
@@ -50,7 +50,7 @@ void z_isr_install(unsigned int irq, void (*routine)(const void *),
 	table_idx = z_get_sw_isr_table_idx(irq);
 
 	/* check for out of bounds table index */
-	if (table_idx >= CONFIG_NUM_IRQS) {
+	if (table_idx >= IRQ_TABLE_SIZE) {
 		return;
 	}
 
@@ -170,7 +170,7 @@ int z_isr_uninstall(unsigned int irq,
 	table_idx = z_get_sw_isr_table_idx(irq);
 
 	/* check for out of bounds table index */
-	if (table_idx >= CONFIG_NUM_IRQS) {
+	if (table_idx >= IRQ_TABLE_SIZE) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Fixes z_isr_install() and z_isr_uninstall() routines to check the isr table index against the correct number of isr table entries. This prevents out-of-bounds isr table accesses when
CONFIG_GEN_IRQ_START_VECTOR is greater than zero, such as on the ARC architecture.

Fixes #69140 Coverity-CID: 347187
Fixes #69139 Coverity-CID: 347189
Fixes #69141 Coverity-CID: 347097
Fixes #69138 Coverity-CID: 347203
Fixes #69137 Coverity-CID: 347210

@LaurentiuM1234