### PR TITLE
doc: sensor: icm42605: this readme is for icm42605, not mpu6050

### DIFF
--- a/samples/sensor/icm42605/README.rst
+++ b/samples/sensor/icm42605/README.rst
@@ -1,6 +1,6 @@
 .. _icm42605:
 
-MPU6050: Invensense Motion Tracking Device
+ICM42605: Invensense Motion Tracking Device
 ##########################################
 
 Description


### PR DESCRIPTION
this readme is for icm42605, not mpu6050

Signed-off-by: Gerhardt Gao <gerhardt_gao@gmail.com>