### PR TITLE
sensors: lps22hb: Enhance driver with trigger

### DIFF
--- a/drivers/sensor/st/lps22hb/CMakeLists.txt
+++ b/drivers/sensor/st/lps22hb/CMakeLists.txt
@@ -3,5 +3,6 @@
 zephyr_library()
 
 zephyr_library_sources(lps22hb.c)
+zephyr_library_sources_ifdef(CONFIG_LPS22HB_TRIGGER    lps22hb_trigger.c)
 
 zephyr_library_include_directories(../stmemsc)

--- a/drivers/sensor/st/lps22hb/CMakeLists.txt
+++ b/drivers/sensor/st/lps22hb/CMakeLists.txt
@@ -3,3 +3,5 @@
 zephyr_library()
 
 zephyr_library_sources(lps22hb.c)
+
+zephyr_library_include_directories(../stmemsc)

--- a/drivers/sensor/st/lps22hb/Kconfig
+++ b/drivers/sensor/st/lps22hb/Kconfig
@@ -11,8 +11,7 @@ menuconfig LPS22HB
 	select HAS_STMEMSC
 	select USE_STDC_LPS22HB
 	help
-	  Enable driver for LPS22HB I2C-based pressure and temperature
-	  sensor.
+	  Enable driver for LPS22HB pressure and temperature sensor.
 
 if LPS22HB
 

--- a/drivers/sensor/st/lps22hb/Kconfig
+++ b/drivers/sensor/st/lps22hb/Kconfig
@@ -14,10 +14,44 @@ menuconfig LPS22HB
 	  Enable driver for LPS22HB I2C-based pressure and temperature
 	  sensor.
 
-config LPS22HB_SAMPLING_RATE
-	int "Output data rate"
-	default 25
-	depends on LPS22HB
+if LPS22HB
+
+choice LPS22HB_TRIGGER_MODE
+	prompt "Trigger mode"
+	default LPS22HB_TRIGGER_GLOBAL_THREAD
 	help
-	  Sensor output data rate expressed in samples per second.
-	  Data rates supported by the chip are 1, 10, 25, 50, 75.
+	  Specify the type of triggering to be used by the driver.
+
+config LPS22HB_TRIGGER_NONE
+	bool "No trigger"
+
+config LPS22HB_TRIGGER_GLOBAL_THREAD
+	bool "Use global thread"
+	depends on GPIO
+	select LPS22HB_TRIGGER
+
+config LPS22HB_TRIGGER_OWN_THREAD
+	bool "Use own thread"
+	depends on GPIO
+	select LPS22HB_TRIGGER
+
+endchoice # LPS22HB_TRIGGER_MODE
+
+config LPS22HB_TRIGGER
+	bool
+
+config LPS22HB_THREAD_PRIORITY
+	int "Thread priority"
+	depends on LPS22HB_TRIGGER_OWN_THREAD
+	default 10
+	help
+	  Priority of thread used by the driver to handle interrupts.
+
+config LPS22HB_THREAD_STACK_SIZE
+	int "Thread stack size"
+	depends on LPS22HB_TRIGGER_OWN_THREAD
+	default 1024
+	help
+	  Stack size of thread used by the driver to handle interrupts.
+
+endif # LPS22HB

--- a/drivers/sensor/st/lps22hb/Kconfig
+++ b/drivers/sensor/st/lps22hb/Kconfig
@@ -5,7 +5,11 @@ menuconfig LPS22HB
 	bool "LPS22HB pressure and temperature"
 	default y
 	depends on DT_HAS_ST_LPS22HB_PRESS_ENABLED
-	select I2C
+	depends on ZEPHYR_HAL_ST_MODULE
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ST_LPS22HB),i2c)
+	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_LPS22HB),spi)
+	select HAS_STMEMSC
+	select USE_STDC_LPS22HB
 	help
 	  Enable driver for LPS22HB I2C-based pressure and temperature
 	  sensor.

--- a/drivers/sensor/st/lps22hb/Kconfig
+++ b/drivers/sensor/st/lps22hb/Kconfig
@@ -15,6 +15,13 @@ menuconfig LPS22HB
 
 if LPS22HB
 
+config LPS22HB_SAMPLING_RATE
+	int "Output data rate"
+	default 25
+	help
+	  Sensor output data rate expressed in samples per second.
+	  Data rates supported by the chip are 1, 10, 25, 50, 75.
+
 choice LPS22HB_TRIGGER_MODE
 	prompt "Trigger mode"
 	default LPS22HB_TRIGGER_GLOBAL_THREAD

--- a/drivers/sensor/st/lps22hb/lps22hb.c
+++ b/drivers/sensor/st/lps22hb/lps22hb.c
@@ -136,6 +136,9 @@ static const struct sensor_driver_api lps22hb_driver_api = {
 	.attr_set = lps22hb_attr_set,
 	.sample_fetch = lps22hb_sample_fetch,
 	.channel_get = lps22hb_channel_get,
+#if CONFIG_LPS22HB_TRIGGER
+	.trigger_set = lps22hb_trigger_set,
+#endif
 };
 
 static int lps22hb_init_chip(const struct device *dev)
@@ -198,6 +201,13 @@ static int lps22hb_init(const struct device *dev)
 		LOG_ERR("Failed to initialize chip");
 		return -EIO;
 	}
+
+#ifdef CONFIG_LPS22HB_TRIGGER
+	if (lps22hb_init_interrupt(dev) < 0) {
+		LOG_ERR("Failed to initialize interrupt.");
+		return -EIO;
+	}
+#endif
 
 	return 0;
 }

--- a/drivers/sensor/st/lps22hb/lps22hb.c
+++ b/drivers/sensor/st/lps22hb/lps22hb.c
@@ -22,57 +22,57 @@ LOG_MODULE_REGISTER(LPS22HB, CONFIG_SENSOR_LOG_LEVEL);
 
 static inline int lps22hb_set_odr_raw(const struct device *dev, uint8_t odr)
 {
-	const struct lps22hb_config *config = dev->config;
+	const struct lps22hb_config *const cfg = dev->config;
+	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
 
-	return i2c_reg_update_byte_dt(&config->i2c, LPS22HB_REG_CTRL_REG1,
-				      LPS22HB_MASK_CTRL_REG1_ODR,
-				      odr << LPS22HB_SHIFT_CTRL_REG1_ODR);
+	return lps22hb_data_rate_set(ctx, odr);
 }
 
-static int lps22hb_sample_fetch(const struct device *dev,
-				enum sensor_channel chan)
+static int lps22hb_sample_fetch(const struct device *dev, enum sensor_channel chan)
 {
 	struct lps22hb_data *data = dev->data;
-	const struct lps22hb_config *config = dev->config;
-	uint8_t out[5];
+	const struct lps22hb_config *const cfg = dev->config;
+	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
+	uint32_t raw_press;
+	int16_t raw_temp;
 
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL);
 
-	if (i2c_burst_read_dt(&config->i2c, LPS22HB_REG_PRESS_OUT_XL,
-			      out, 5) < 0) {
-		LOG_DBG("Failed to read sample");
+	if (lps22hb_pressure_raw_get(ctx, &raw_press) < 0) {
+		LOG_ERR("Failed to read sample");
 		return -EIO;
 	}
 
-	data->sample_press = (int32_t)((uint32_t)(out[0]) |
-				     ((uint32_t)(out[1]) << 8) |
-				     ((uint32_t)(out[2]) << 16));
-	data->sample_temp = (int16_t)((uint16_t)(out[3]) |
-				    ((uint16_t)(out[4]) << 8));
+	if (lps22hb_temperature_raw_get(ctx, &raw_temp) < 0) {
+		LOG_ERR("Failed to read sample");
+		return -EIO;
+	}
+
+	data->sample_press = raw_press;
+	data->sample_temp = raw_temp;
 
 	return 0;
 }
 
-static inline void lps22hb_press_convert(struct sensor_value *val,
-					 int32_t raw_val)
+static inline void lps22hb_press_convert(struct sensor_value *val, int32_t raw_val)
 {
 	/* Pressure sensitivity is 4096 LSB/hPa */
+	/* raw value is shifted one byte by the stmemc driver*/
 	/* Convert raw_val to val in kPa */
+	raw_val = raw_val >> 8;
 	val->val1 = (raw_val >> 12) / 10;
-	val->val2 = (raw_val >> 12) % 10 * 100000 +
-		(((int32_t)((raw_val) & 0x0FFF) * 100000L) >> 12);
+	val->val2 =
+		(raw_val >> 12) % 10 * 100000 + (((int32_t)((raw_val) & 0x0FFF) * 100000L) >> 12);
 }
 
-static inline void lps22hb_temp_convert(struct sensor_value *val,
-					int16_t raw_val)
+static inline void lps22hb_temp_convert(struct sensor_value *val, int16_t raw_val)
 {
 	/* Temperature sensitivity is 100 LSB/deg C */
 	val->val1 = raw_val / 100;
 	val->val2 = ((int32_t)raw_val % 100) * 10000;
 }
 
-static int lps22hb_channel_get(const struct device *dev,
-			       enum sensor_channel chan,
+static int lps22hb_channel_get(const struct device *dev, enum sensor_channel chan,
 			       struct sensor_value *val)
 {
 	struct lps22hb_data *data = dev->data;
@@ -88,71 +88,178 @@ static int lps22hb_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api lps22hb_api_funcs = {
-	.sample_fetch = lps22hb_sample_fetch,
-	.channel_get = lps22hb_channel_get,
-};
+static const uint16_t lps22hb_map[] = {0, 1, 10, 25, 50, 75};
 
-static int lps22hb_init_chip(const struct device *dev)
+static int lps22hb_odr_set(const struct device *dev, uint16_t freq)
 {
-	const struct lps22hb_config *config = dev->config;
-	uint8_t chip_id;
+	int odr;
 
-	if (i2c_reg_read_byte_dt(&config->i2c, LPS22HB_REG_WHO_AM_I,
-				 &chip_id) < 0) {
-		LOG_DBG("Failed reading chip id");
-		goto err_poweroff;
+	for (odr = 0; odr < ARRAY_SIZE(lps22hb_map); odr++) {
+		if (freq == lps22hb_map[odr]) {
+			break;
+		}
 	}
 
-	if (chip_id != LPS22HB_VAL_WHO_AM_I) {
-		LOG_DBG("Invalid chip id 0x%x", chip_id);
-		goto err_poweroff;
+	if (odr == ARRAY_SIZE(lps22hb_map)) {
+		LOG_ERR("bad frequency");
+		return -EINVAL;
 	}
 
-	if (lps22hb_set_odr_raw(dev, LPS22HB_DEFAULT_SAMPLING_RATE) < 0) {
-		LOG_DBG("Failed to set sampling rate");
-		goto err_poweroff;
-	}
-
-	if (i2c_reg_update_byte_dt(&config->i2c, LPS22HB_REG_CTRL_REG1,
-				   LPS22HB_MASK_CTRL_REG1_BDU,
-				   (1 << LPS22HB_SHIFT_CTRL_REG1_BDU)) < 0) {
-		LOG_DBG("Failed to set BDU");
-		goto err_poweroff;
-	}
-
-	return 0;
-
-err_poweroff:
-	return -EIO;
-}
-
-static int lps22hb_init(const struct device *dev)
-{
-	const struct lps22hb_config * const config = dev->config;
-
-	if (!device_is_ready(config->i2c.bus)) {
-		LOG_ERR("I2C bus device not ready");
-		return -ENODEV;
-	}
-
-	if (lps22hb_init_chip(dev) < 0) {
-		LOG_DBG("Failed to initialize chip");
+	if (lps22hb_set_odr_raw(dev, odr) < 0) {
+		LOG_ERR("failed to set sampling rate");
 		return -EIO;
 	}
 
 	return 0;
 }
 
-#define LPS22HB_DEFINE(inst)									\
-	static struct lps22hb_data lps22hb_data_##inst;						\
-												\
-	static const struct lps22hb_config lps22hb_config_##inst = {				\
-		.i2c = I2C_DT_SPEC_INST_GET(inst),						\
-	};											\
-												\
-	SENSOR_DEVICE_DT_INST_DEFINE(inst, lps22hb_init, NULL,					\
-			      &lps22hb_data_##inst, &lps22hb_config_##inst, POST_KERNEL,	\
-			      CONFIG_SENSOR_INIT_PRIORITY, &lps22hb_api_funcs);			\
+static int lps22hb_attr_set(const struct device *dev, enum sensor_channel chan,
+			    enum sensor_attribute attr, const struct sensor_value *val)
+{
+	if (chan != SENSOR_CHAN_ALL) {
+		LOG_ERR("attr_set() not supported on this channel.");
+		return -ENOTSUP;
+	}
+
+	switch (attr) {
+	case SENSOR_ATTR_SAMPLING_FREQUENCY:
+		return lps22hb_odr_set(dev, val->val1);
+	default:
+		LOG_ERR("operation not supported.");
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+static const struct sensor_driver_api lps22hb_driver_api = {
+	.attr_set = lps22hb_attr_set,
+	.sample_fetch = lps22hb_sample_fetch,
+	.channel_get = lps22hb_channel_get,
+};
+
+static int lps22hb_init_chip(const struct device *dev)
+{
+	const struct lps22hb_config *const cfg = dev->config;
+	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
+	uint8_t chip_id;
+	int ret;
+
+	if (lps22hb_device_id_get(ctx, &chip_id) < 0) {
+		LOG_ERR("%s: Not able to read dev id", dev->name);
+		return -EIO;
+	}
+
+	if (chip_id != LPS22HB_ID) {
+		LOG_ERR("%s: Invalid chip ID 0x%02x", dev->name, chip_id);
+		return -EIO;
+	}
+
+	LOG_DBG("%s: chip id 0x%x", dev->name, chip_id);
+
+	if (lps22hb_reset_set(ctx, 1) < 0) {
+		LOG_ERR("%s: Not able to reset device", dev->name);
+		return -EIO;
+	}
+
+	/* configure sensor low-pass filter */
+	if (cfg->low_pass_enabled) {
+		ret = lps22hb_low_pass_filter_mode_set(ctx, cfg->filter_mode);
+		if (ret < 0) {
+			LOG_ERR("%s: Failed to set low-pass filter (mode=%d)", dev->name,
+				cfg->filter_mode);
+			return ret;
+		}
+		LOG_INF("%s: Low-pass filter enabled (mode=%d)", dev->name,
+			cfg->filter_mode);
+	} else {
+		LOG_INF("%s: Low-pass filter disabled", dev->name);
+	}
+
+	/* set sensor default odr */
+	LOG_DBG("%s: odr: %d", dev->name, cfg->odr);
+	ret = lps22hb_set_odr_raw(dev, cfg->odr);
+	if (ret < 0) {
+		LOG_ERR("%s: Failed to set odr %d", dev->name, cfg->odr);
+		return ret;
+	}
+
+	if (lps22hb_block_data_update_set(ctx, PROPERTY_ENABLE) < 0) {
+		LOG_ERR("%s: Failed to set BDU", dev->name);
+		return ret;
+	}
+
+	return 0;
+}
+
+static int lps22hb_init(const struct device *dev)
+{
+	if (lps22hb_init_chip(dev) < 0) {
+		LOG_ERR("Failed to initialize chip");
+		return -EIO;
+	}
+
+	return 0;
+}
+
+#if DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 0
+#warning "LPS22HB driver enabled without any devices"
+#endif
+
+#ifdef CONFIG_LPS22HB_TRIGGER
+#define LPS22HB_CFG_IRQ(inst) .gpio_int = GPIO_DT_SPEC_INST_GET(inst, drdy_gpios),
+#else
+#define LPS22HB_CFG_IRQ(inst)
+#endif /* CONFIG_LPS22HB_TRIGGER */
+
+#define LPS22HB_CONFIG_COMMON(inst)                                                                \
+	.odr = DT_INST_PROP(inst, odr), .low_pass_enabled = DT_INST_PROP(inst, lpf_en),            \
+	.filter_mode = DT_INST_PROP(inst, lpf_mode),                                               \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, drdy_gpios), (LPS22HB_CFG_IRQ(inst)), ())
+
+/*
+ * Instantiation macros used when a device is on a SPI bus.
+ */
+
+#define LPS22HB_SPI_OPERATION (SPI_WORD_SET(8) | SPI_OP_MODE_MASTER | SPI_MODE_CPOL | SPI_MODE_CPHA)
+
+#define LPS22HB_CONFIG_SPI(inst)                                                                   \
+	{                                                                                          \
+		STMEMSC_CTX_SPI(&lps22hb_config_##inst.stmemsc_cfg),                               \
+			.stmemsc_cfg =                                                             \
+				{                                                                  \
+					.spi = SPI_DT_SPEC_INST_GET(inst, LPS22HB_SPI_OPERATION,   \
+								    0),                            \
+				},                                                                 \
+			LPS22HB_CONFIG_COMMON(inst)                                                \
+	}
+
+/*
+ * Instantiation macros used when a device is on an I2C bus.
+ */
+
+#define LPS22HB_CONFIG_I2C(inst)                                                                   \
+	{                                                                                          \
+		STMEMSC_CTX_I2C(&lps22hb_config_##inst.stmemsc_cfg),                               \
+			.stmemsc_cfg =                                                             \
+				{                                                                  \
+					.i2c = I2C_DT_SPEC_INST_GET(inst),                         \
+				},                                                                 \
+			LPS22HB_CONFIG_COMMON(inst)                                                \
+	}
+
+/*
+ * Main instantiation macro. Use of COND_CODE_1() selects the right
+ * bus-specific macro at preprocessor time.
+ */
+
+#define LPS22HB_DEFINE(inst)                                                                       \
+	static struct lps22hb_data lps22hb_data_##inst;                                            \
+	static const struct lps22hb_config lps22hb_config_##inst =                                 \
+		COND_CODE_1(DT_INST_ON_BUS(inst, spi), (LPS22HB_CONFIG_SPI(inst)),                 \
+			    (LPS22HB_CONFIG_I2C(inst)));                                           \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, lps22hb_init, NULL, &lps22hb_data_##inst,               \
+				     &lps22hb_config_##inst, POST_KERNEL,                          \
+				     CONFIG_SENSOR_INIT_PRIORITY, &lps22hb_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(LPS22HB_DEFINE)

--- a/drivers/sensor/st/lps22hb/lps22hb.h
+++ b/drivers/sensor/st/lps22hb/lps22hb.h
@@ -12,154 +12,37 @@
 #define ZEPHYR_DRIVERS_SENSOR_LPS22HB_LPS22HB_H_
 
 #include <stdint.h>
-#include <zephyr/drivers/i2c.h>
 #include <zephyr/sys/util.h>
+#include <stmemsc.h>
+#include "lps22hb_reg.h"
 
-#define LPS22HB_REG_WHO_AM_I                    0x0F
-#define LPS22HB_VAL_WHO_AM_I                    0xB1
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
+#include <zephyr/drivers/spi.h>
+#endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(spi) */
 
-#define LPS22HB_REG_INTERRUPT_CFG               0x0B
-#define LPS22HB_MASK_INTERRUPT_CFG_AUTORIFP     BIT(7)
-#define LPS22HB_SHIFT_INTERRUPT_CFG_AUTORIFP    7
-#define LPS22HB_MASK_INTERRUPT_CFG_RESET_ARP    BIT(6)
-#define LPS22HB_SHIFT_INTERRUPT_CFG_RESET_ARP   6
-#define LPS22HB_MASK_INTERRUPT_CFG_AUTOZERO     BIT(5)
-#define LPS22HB_SHIFT_INTERRUPT_CFG_AUTOZERO    5
-#define LPS22HB_MASK_INTERRUPT_CFG_RESET_AZ     BIT(4)
-#define LPS22HB_SHIFT_INTERRUPT_CFG_RESET_AZ    4
-#define LPS22HB_MASK_INTERRUPT_CFG_DIFF_EN      BIT(3)
-#define LPS22HB_SHIFT_INTERRUPT_CFG_DIFF_EN     3
-#define LPS22HB_MASK_INTERRUPT_CFG_LIR          BIT(2)
-#define LPS22HB_SHIFT_INTERRUPT_CFG_LIR         2
-#define LPS22HB_MASK_INTERRUPT_CFG_PL_E         BIT(1)
-#define LPS22HB_SHIFT_INTERRUPT_CFG_PL_E        1
-#define LPS22HB_MASK_INTERRUPT_CFG_PH_E         BIT(0)
-#define LPS22HB_SHIFT_INTERRUPT_CFG_PH_E        0
-
-#define LPS22HB_REG_THS_P_L                     0x0C
-#define LPS22HB_REG_THS_P_H                     0x0D
-
-#define LPS22HB_REG_CTRL_REG1                   0x10
-#define LPS22HB_MASK_CTRL_REG1_ODR              (BIT(6) | BIT(5) | BIT(4))
-#define LPS22HB_SHIFT_CTRL_REG1_ODR             4
-#define LPS22HB_MASK_CTRL_REG1_EN_LPFP          BIT(3)
-#define LPS22HB_SHIFT_CTRL_REG1_EN_LPFP         3
-#define LPS22HB_MASK_CTRL_REG1_LPFP_CFG         BIT(2)
-#define LPS22HB_SHIFT_CTRL_REG1_LPFP_CFG        2
-#define LPS22HB_MASK_CTRL_REG1_BDU              BIT(1)
-#define LPS22HB_SHIFT_CTRL_REG1_BDU             1
-#define LPS22HB_MASK_CTRL_REG1_SIM              BIT(0)
-#define LPS22HB_SHIFT_CTRL_REG1_SIM             0
-
-#define LPS22HB_REG_CTRL_REG2                   0x11
-#define LPS22HB_MASK_CTRL_REG2_BOOT             BIT(7)
-#define LPS22HB_SHIFT_CTRL_REG2_BOOT            7
-#define LPS22HB_MASK_CTRL_REG2_FIFO_EN          BIT(6)
-#define LPS22HB_SHIFT_CTRL_REG2_FIFO_EN         6
-#define LPS22HB_MASK_CTRL_REG2_STOP_ON_FTH      BIT(5)
-#define LPS22HB_SHIFT_CTRL_REG2_STOP_ON_FTH     5
-#define LPS22HB_MASK_CTRL_REG2_IF_ADD_INC       BIT(4)
-#define LPS22HB_SHIFT_CTRL_REG2_IF_ADD_INC      4
-#define LPS22HB_MASK_CTRL_REG2_I2C_DIS          BIT(3)
-#define LPS22HB_SHIFT_CTRL_REG2_I2C_DIS         3
-#define LPS22HB_MASK_CTRL_REG2_SWRESET          BIT(2)
-#define LPS22HB_SHIFT_CTRL_REG2_SWRESET         2
-#define LPS22HB_MASK_CTRL_REG2_ONE_SHOT         BIT(0)
-#define LPS22HB_SHIFT_CTRL_REG2_ONE_SHOT        0
-
-#define LPS22HB_REG_CTRL_REG3                   0x12
-#define LPS22HB_MASK_CTRL_REG3_INT_H_L          BIT(7)
-#define LPS22HB_SHIFT_CTRL_REG3_INT_H_L         7
-#define LPS22HB_MASK_CTRL_REG3_PP_OD            BIT(6)
-#define LPS22HB_SHIFT_CTRL_REG3_PP_OD           6
-#define LPS22HB_MASK_CTRL_REG3_F_FSS5           BIT(5)
-#define LPS22HB_SHIFT_CTRL_REG3_F_FFS5          5
-#define LPS22HB_MASK_CTRL_REG3_F_FTH            BIT(4)
-#define LPS22HB_SHIFT_CTRL_REG3_F_FTH           4
-#define LPS22HB_MASK_CTRL_REG3_F_OVR            BIT(3)
-#define LPS22HB_SHIFT_CTRL_REG3_F_OVR           3
-#define LPS22HB_MASK_CTRL_REG3_DRDY             BIT(2)
-#define LPS22HB_SHIFT_CTRL_REG3_DRDY            2
-#define LPS22HB_MASK_CTRL_REG3_INT_S            (BIT(1) | BIT(0))
-#define LPS22HB_SHIFT_CTRL_REG_INT_S            0
-
-#define LPS22HB_REG_FIFO_CTRL                   0x14
-#define LPS22HB_MASK_FIFO_CTRL_F_MODE           (BIT(7) | BIT(6) | BIT(5))
-#define LPS22HB_SHIFT_FIFO_CTRL_F_MODE          5
-#define LPS22HB_MASK_FIFO_CTRL_WTM              (BIT(4) | BIT(3) | BIT(2) | \
-						 BIT(2) | BIT(1) | BIT(0))
-#define LPS22HB_SHIFT_FIFO_CTRL_WTM             0
-
-#define LPS22HB_REG_REF_P_XL                    0x15
-#define LPS22HB_REG_REF_P_L                     0x16
-#define LPS22HB_REG_REF_P_H                     0x17
-
-#define LPS22HB_REG_RPDS_L                      0x18
-#define LPS22HB_REG_RPDS_H                      0x19
-
-#define LPS22HB_REG_RES_CONF                    0x1A
-#define LPS22HB_MASK_RES_CONF_LC_EN             BIT(0)
-#define LPS22HB_SHIFT_RES_CONF_LC_EN            0
-
-#define LPS22HB_REG_INT_SOURCE                  0x25
-#define LPS22HB_MASK_INT_SOURCE_IA              BIT(2)
-#define LPS22HB_SHIFT_INT_SOURCE_IA             2
-#define LPS22HB_MASK_INT_SOURCE_PL              BIT(1)
-#define LPS22HB_SHIFT_INT_SOURCE_PL             1
-#define LPS22HB_MASK_INT_SOURCE_PH              BIT(0)
-#define LPS22HB_SHIFT_INT_SOURCE_PH             0
-
-#define LPS22HB_REG_FIFO_STATUS                 0x26
-#define LPS22HB_MASK_FIFO_STATUS_FTH_FIFO       BIT(7)
-#define LPS22HB_SHIFT_FIFO_STATUS_FTH_FIFO      7
-#define LPS22HB_MASK_FIFO_STATUS_OVR            BIT(6)
-#define LPS22HB_SHIFT_FIFO_STATUS_OVR           6
-#define LPS22HB_MASK_FIFO_STATUS_EMPTY_FIFO     BIT(5)
-#define LPS22HB_SHIFT_FIFO_STATUS_EMPTY_FIFO    5
-#define LPS22HB_MASK_FIFO_STATUS_FSS            (BIT(4) | BIT(3) | BIT(2) | \
-						 BIT(1) | BIT(0))
-#define LPS22HB_SHIFT_FIFO_STATUS_FSS           0
-
-#define LPS22HB_REG_STATUS                      0x27
-#define LPS22HB_MASK_STATUS_P_OR                BIT(5)
-#define LPS22HB_SHIFT_STATUS_P_OR               5
-#define LPS22HB_MASK_STATUS_T_OR                BIT(4)
-#define LPS22HB_SHIFT_STATUS_T_OR               4
-#define LPS22HB_MASK_STATUS_P_DA                BIT(1)
-#define LPS22HB_SHIFT_STATUS_P_DA               1
-#define LPS22HB_MASK_STATUS_T_DA                BIT(0)
-#define LPS22HB_SHIFT_STATUS_T_DA               0
-
-#define LPS22HB_REG_PRESS_OUT_XL                0x28
-#define LPS22HB_REG_PRESS_OUT_L                 0x29
-#define LPS22HB_REG_PRESS_OUT_H                 0x2A
-
-#define LPS22HB_REG_TEMP_OUT_L                  0x2B
-#define LPS22HB_REG_TEMP_OUT_H                  0x2C
-
-#define LPS22HB_REG_LPFP_RES                    0x33
-
-
-#if CONFIG_LPS22HB_SAMPLING_RATE == 1
-	#define LPS22HB_DEFAULT_SAMPLING_RATE      1
-#elif CONFIG_LPS22HB_SAMPLING_RATE == 10
-	#define LPS22HB_DEFAULT_SAMPLING_RATE      2
-#elif CONFIG_LPS22HB_SAMPLING_RATE == 25
-	#define LPS22HB_DEFAULT_SAMPLING_RATE      3
-#elif CONFIG_LPS22HB_SAMPLING_RATE == 50
-	#define LPS22HB_DEFAULT_SAMPLING_RATE      4
-#elif CONFIG_LPS22HB_SAMPLING_RATE == 75
-	#define LPS22HB_DEFAULT_SAMPLING_RATE      5
-#endif
-
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
+#include <zephyr/drivers/i2c.h>
+#endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c) */
 
 struct lps22hb_config {
-	struct i2c_dt_spec i2c;
+	stmdev_ctx_t ctx;
+	union {
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
+		const struct i2c_dt_spec i2c;
+#endif
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
+		const struct spi_dt_spec spi;
+#endif
+	} stmemsc_cfg;
+	uint8_t odr;
+	bool low_pass_enabled;
+	lps22hb_lpfp_t filter_mode;
 };
 
 struct lps22hb_data {
 	int32_t sample_press;
 	int16_t sample_temp;
 };
+
 
 #endif /* ZEPHYR_DRIVERS_SENSOR_LPS22HB_LPS22HB_H_ */

--- a/drivers/sensor/st/lps22hb/lps22hb.h
+++ b/drivers/sensor/st/lps22hb/lps22hb.h
@@ -37,12 +37,38 @@ struct lps22hb_config {
 	uint8_t odr;
 	bool low_pass_enabled;
 	lps22hb_lpfp_t filter_mode;
+#ifdef CONFIG_LPS22HB_TRIGGER
+	struct gpio_dt_spec gpio_int;
+#endif
 };
 
 struct lps22hb_data {
 	int32_t sample_press;
 	int16_t sample_temp;
+
+#ifdef CONFIG_LPS22HB_TRIGGER
+	struct gpio_callback gpio_cb;
+
+	const struct sensor_trigger *data_ready_trigger;
+	sensor_trigger_handler_t handler_drdy;
+	const struct device *dev;
+
+#if defined(CONFIG_LPS22HB_TRIGGER_OWN_THREAD)
+	K_KERNEL_STACK_MEMBER(thread_stack, CONFIG_LPS22HB_THREAD_STACK_SIZE);
+	struct k_thread thread;
+	struct k_sem intr_sem;
+#elif defined(CONFIG_LPS22HB_TRIGGER_GLOBAL_THREAD)
+	struct k_work work;
+#endif
+
+#endif /* CONFIG_LPS22HB_TRIGGER */
 };
 
+#ifdef CONFIG_LPS22HB_TRIGGER
+int lps22hb_trigger_set(const struct device *dev, const struct sensor_trigger *trig,
+			sensor_trigger_handler_t handler);
+
+int lps22hb_init_interrupt(const struct device *dev);
+#endif
 
 #endif /* ZEPHYR_DRIVERS_SENSOR_LPS22HB_LPS22HB_H_ */

--- a/drivers/sensor/st/lps22hb/lps22hb_trigger.c
+++ b/drivers/sensor/st/lps22hb/lps22hb_trigger.c
@@ -1,0 +1,201 @@
+/* ST Microelectronics LPS22HB pressure and temperature sensor
+ *
+ * Copyright (c) 2019 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Datasheet:
+ * https://www.st.com/resource/en/datasheet/lps22hb.pdf
+ */
+
+#define DT_DRV_COMPAT st_lps22hb_press
+
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/logging/log.h>
+
+#include "lps22hb.h"
+
+LOG_MODULE_DECLARE(LPS22HB, CONFIG_SENSOR_LOG_LEVEL);
+
+/**
+ * lps22hb_enable_int - enable selected int pin to generate interrupt
+ */
+static int lps22hb_enable_int(const struct device *dev, int enable)
+{
+	const struct lps22hb_config *const cfg = dev->config;
+	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
+
+	/* set interrupt */
+	int rc = lps22hb_int_generation_set(ctx, enable);
+	if (rc != 0) {
+		LOG_ERR("Failed to enable interrupt");
+		return -EIO;
+	}
+
+	LOG_INF("%s interrupts", enable ? "Enable" : "Disable");
+	return 0;
+}
+
+/**
+ * lps22hb_trigger_set - link external trigger to event data ready
+ */
+int lps22hb_trigger_set(const struct device *dev, const struct sensor_trigger *trig,
+			sensor_trigger_handler_t handler)
+{
+	struct lps22hb_data *lps22hb = dev->data;
+	const struct lps22hb_config *const cfg = dev->config;
+	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
+	uint32_t raw_press;
+
+	if (trig->chan == SENSOR_CHAN_ALL) {
+		lps22hb->handler_drdy = handler;
+		lps22hb->data_ready_trigger = trig;
+		if (handler) {
+			/* dummy read: re-trigger interrupt */
+			if (lps22hb_pressure_raw_get(ctx, &raw_press) < 0) {
+				LOG_ERR("Failed to read sample");
+				return -EIO;
+			}
+			return lps22hb_enable_int(dev, 1);
+		} else {
+			return lps22hb_enable_int(dev, 0);
+		}
+	}
+
+	return -ENOTSUP;
+}
+
+/**
+ * lps22hb_handle_interrupt - handle the drdy event
+ * read data and call handler if registered any
+ */
+static void lps22hb_handle_interrupt(const struct device *dev)
+{
+	int ret;
+	struct lps22hb_data *lps22hb = dev->data;
+	const struct lps22hb_config *cfg = dev->config;
+
+	if (lps22hb->handler_drdy != NULL) {
+		lps22hb->handler_drdy(dev, lps22hb->data_ready_trigger);
+	}
+
+	ret = gpio_pin_interrupt_configure_dt(&cfg->gpio_int, GPIO_INT_EDGE_TO_ACTIVE);
+	if (ret < 0) {
+		LOG_ERR("%s: Not able to configure pin_int", dev->name);
+	}
+}
+
+static void lps22hb_intr_callback(struct lps22hb_data *lps22hb)
+{
+#if defined(CONFIG_LPS22HB_TRIGGER_OWN_THREAD)
+	k_sem_give(&lps22hb->intr_sem);
+#elif defined(CONFIG_LPS22HB_TRIGGER_GLOBAL_THREAD)
+	k_work_submit(&lps22hb->work);
+#endif /* CONFIG_LPS22HB_TRIGGER_OWN_THREAD */
+}
+
+static void lps22hb_gpio_callback(const struct device *dev, struct gpio_callback *cb, uint32_t pins)
+{
+	struct lps22hb_data *lps22hb = CONTAINER_OF(cb, struct lps22hb_data, gpio_cb);
+
+	ARG_UNUSED(pins);
+	const struct lps22hb_config *cfg = lps22hb->dev->config;
+	int ret;
+
+	ret = gpio_pin_interrupt_configure_dt(&cfg->gpio_int, GPIO_INT_DISABLE);
+	if (ret < 0) {
+		LOG_ERR("%s: Not able to configure pin_int", dev->name);
+	}
+
+	lps22hb_intr_callback(lps22hb);
+}
+
+#ifdef CONFIG_LPS22HB_TRIGGER_OWN_THREAD
+static void lps22hb_thread(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	struct lps22hb_data *lps22hb = p1;
+
+	while (1) {
+		k_sem_take(&lps22hb->intr_sem, K_FOREVER);
+		lps22hb_handle_interrupt(lps22hb->dev);
+	}
+}
+#endif /* CONFIG_LPS22HB_TRIGGER_OWN_THREAD */
+
+#ifdef CONFIG_LPS22HB_TRIGGER_GLOBAL_THREAD
+static void lps22hb_work_cb(struct k_work *work)
+{
+	struct lps22hb_data *lps22hb = CONTAINER_OF(work, struct lps22hb_data, work);
+
+	lps22hb_handle_interrupt(lps22hb->dev);
+}
+#endif /* CONFIG_LPS22HB_TRIGGER_GLOBAL_THREAD */
+
+int lps22hb_init_interrupt(const struct device *dev)
+{
+	struct lps22hb_data *lps22hb = dev->data;
+	const struct lps22hb_config *cfg = dev->config;
+	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
+	int ret;
+
+	/* setup data ready gpio interrupt */
+	if (!gpio_is_ready_dt(&cfg->gpio_int)) {
+		if (cfg->gpio_int.port) {
+			LOG_ERR("%s: device %s is not ready", dev->name, cfg->gpio_int.port->name);
+			return -ENODEV;
+		}
+
+		LOG_DBG("%s: gpio_int not defined in DT", dev->name);
+		return 0;
+	}
+
+	lps22hb->dev = dev;
+
+#if defined(CONFIG_LPS22HB_TRIGGER_OWN_THREAD)
+	k_sem_init(&lps22hb->intr_sem, 0, K_SEM_MAX_LIMIT);
+
+	k_thread_create(&lps22hb->thread, lps22hb->thread_stack, CONFIG_LPS22HB_THREAD_STACK_SIZE,
+			lps22hb_thread, lps22hb, NULL, NULL,
+			K_PRIO_COOP(CONFIG_LPS22HB_THREAD_PRIORITY), 0, K_NO_WAIT);
+#elif defined(CONFIG_LPS22HB_TRIGGER_GLOBAL_THREAD)
+	lps22hb->work.handler = lps22hb_work_cb;
+#endif /* CONFIG_LPS22HB_TRIGGER_OWN_THREAD */
+
+	ret = gpio_pin_configure_dt(&cfg->gpio_int, GPIO_INPUT);
+	if (ret < 0) {
+		LOG_ERR("Could not configure gpio");
+		return ret;
+	}
+
+	LOG_INF("%s: int on %s.%02u", dev->name, cfg->gpio_int.port->name, cfg->gpio_int.pin);
+
+	gpio_init_callback(&lps22hb->gpio_cb, lps22hb_gpio_callback, BIT(cfg->gpio_int.pin));
+
+	ret = gpio_add_callback(cfg->gpio_int.port, &lps22hb->gpio_cb);
+	if (ret < 0) {
+		LOG_ERR("Could not set gpio callback");
+		return ret;
+	}
+
+	/* enable interrupt in pulse mode */
+	LOG_DBG("Configuring interrupts");
+	int rc = lps22hb_int_notification_mode_set(ctx, LPS22HB_INT_PULSED);
+	rc += lps22hb_stop_on_fifo_threshold_set(ctx, 0);
+	rc += lps22hb_fifo_mode_set(ctx, LPS22HB_BYPASS_MODE);
+	rc += lps22hb_drdy_on_int_set(ctx, 1);
+	rc += lps22hb_int_pin_mode_set(ctx, LPS22HB_DRDY_OR_FIFO_FLAGS);
+	rc += lps22hb_pin_mode_set(ctx, LPS22HB_OPEN_DRAIN);
+	rc += lps22hb_int_polarity_set(ctx, LPS22HB_ACTIVE_HIGH);
+	
+	if (rc != 0) {
+		LOG_ERR("Failed to configure interrupt");
+		return -EIO;
+	}
+
+	return gpio_pin_interrupt_configure_dt(&cfg->gpio_int, GPIO_INT_EDGE_TO_ACTIVE);
+}

--- a/dts/bindings/sensor/st,lps22hb-common.yaml
+++ b/dts/bindings/sensor/st,lps22hb-common.yaml
@@ -1,17 +1,12 @@
 # Copyright (c) 2021 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
-description: |
-  When setting the odr property in a .dts or .dtsi file you may include
-  lps22hb.h and use the macros defined there.
-
+description: |  
   Example:
-  #include <zephyr/dt-bindings/sensor/lps22hb.h>
 
   lps22hb: lps22hb@0 {
     ...
-
-    odr = <LPS22HB_DT_ODR_200HZ>;
+    odr = <75>;
   };
 
 include: sensor-device.yaml
@@ -33,18 +28,9 @@ properties:
     default: 0
     description: |
       Specify the default output data rate expressed in samples per second (Hz).
-      The default is the power-on reset value.
+      Data rates supported by the chip are 1, 10, 25, 50, 75.
 
-      - 0  # LPS22HB_DT_ODR_POWER_DOWN
-      - 1  # LPS22HB_DT_ODR_1HZ
-      - 2  # LPS22HB_DT_ODR_10HZ
-      - 3  # LPS22HB_DT_ODR_25HZ
-      - 4  # LPS22HB_DT_ODR_50HZ
-      - 5  # LPS22HB_DT_ODR_75HZ
-      - 6  # LPS22HB_DT_ODR_100HZ
-      - 7  # LPS22HB_DT_ODR_200HZ
-
-    enum: [0, 1, 2, 3, 4, 5, 6, 7]
+    enum: [0, 1, 10, 25, 50, 75]
 
   lpf_en:
     type: boolean

--- a/dts/bindings/sensor/st,lps22hb-common.yaml
+++ b/dts/bindings/sensor/st,lps22hb-common.yaml
@@ -1,0 +1,63 @@
+# Copyright (c) 2021 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  When setting the odr property in a .dts or .dtsi file you may include
+  lps22hb.h and use the macros defined there.
+
+  Example:
+  #include <zephyr/dt-bindings/sensor/lps22hb.h>
+
+  lps22hb: lps22hb@0 {
+    ...
+
+    odr = <LPS22HB_DT_ODR_200HZ>;
+  };
+
+include: sensor-device.yaml
+
+compatible: "st,lps22hb-press"
+
+properties:
+  drdy-gpios:
+    type: phandle-array
+    description: |
+      DRDY pin
+
+      This pin defaults to active high when produced by the sensor.
+      The property value should ensure the flags properly describe
+      the signal that is presented to the driver.
+
+  odr:
+    type: int
+    default: 0
+    description: |
+      Specify the default output data rate expressed in samples per second (Hz).
+      The default is the power-on reset value.
+
+      - 0  # LPS22HB_DT_ODR_POWER_DOWN
+      - 1  # LPS22HB_DT_ODR_1HZ
+      - 2  # LPS22HB_DT_ODR_10HZ
+      - 3  # LPS22HB_DT_ODR_25HZ
+      - 4  # LPS22HB_DT_ODR_50HZ
+      - 5  # LPS22HB_DT_ODR_75HZ
+      - 6  # LPS22HB_DT_ODR_100HZ
+      - 7  # LPS22HB_DT_ODR_200HZ
+
+    enum: [0, 1, 2, 3, 4, 5, 6, 7]
+
+  lpf_en:
+    type: boolean
+    description: |
+      Control the internal low-pass filter.
+
+  lpf_mode:
+    type: int
+    default: 2
+    description: |
+      Set the default filter bandwidth of the internal low-pass filter
+
+      - 0 # ODR/2
+      - 2 # ODR/9
+      - 3 # ODR/20
+    enum: [0, 2, 3]

--- a/dts/bindings/sensor/st,lps22hb-i2c.yaml
+++ b/dts/bindings/sensor/st,lps22hb-i2c.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2019 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    STMicroelectronics LPS22HB pressure and temperature sensor connected to I2C
+    bus
+
+include: ["i2c-device.yaml", "st,lps22hb-common.yaml"]

--- a/dts/bindings/sensor/st,lps22hb-press.yaml
+++ b/dts/bindings/sensor/st,lps22hb-press.yaml
@@ -1,8 +1,0 @@
-# Copyright (c) 2017, Linaro Limited
-# SPDX-License-Identifier: Apache-2.0
-
-description: STMicroelectronics LPS22HB pressure sensor
-
-compatible: "st,lps22hb-press"
-
-include: [sensor-device.yaml, i2c-device.yaml]

--- a/dts/bindings/sensor/st,lps22hb-spi.yaml
+++ b/dts/bindings/sensor/st,lps22hb-spi.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2019 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    STMicroelectronics LPS22HB pressure and temperature sensor connected to SPI
+    bus
+
+include: ["spi-device.yaml", "st,lps22hb-common.yaml"]

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -9,7 +9,6 @@
 #include <zephyr/dt-bindings/sensor/lsm6dsv16x.h>
 #include <zephyr/dt-bindings/sensor/lsm6dso.h>
 #include <zephyr/dt-bindings/sensor/lsm6dso16is.h>
-#include <zephyr/dt-bindings/sensor/lps22hb.h>
 #include <zephyr/dt-bindings/sensor/lps22hh.h>
 #include <zephyr/dt-bindings/sensor/lps2xdf.h>
 #include <zephyr/dt-bindings/sensor/lis2ds12.h>
@@ -346,7 +345,7 @@ test_i2c_lps22hb_press: lps22hb-press@31 {
 	compatible = "st,lps22hb-press";
 	reg = <0x31>;
 	drdy-gpios = <&test_gpio 0 0>;
-	odr = <5>;
+	odr = <75>;
 
 };
 

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -9,6 +9,7 @@
 #include <zephyr/dt-bindings/sensor/lsm6dsv16x.h>
 #include <zephyr/dt-bindings/sensor/lsm6dso.h>
 #include <zephyr/dt-bindings/sensor/lsm6dso16is.h>
+#include <zephyr/dt-bindings/sensor/lps22hb.h>
 #include <zephyr/dt-bindings/sensor/lps22hh.h>
 #include <zephyr/dt-bindings/sensor/lps2xdf.h>
 #include <zephyr/dt-bindings/sensor/lis2ds12.h>
@@ -344,6 +345,9 @@ test_i2c_lis3mdl_magn: lis3mdl-magn@30 {
 test_i2c_lps22hb_press: lps22hb-press@31 {
 	compatible = "st,lps22hb-press";
 	reg = <0x31>;
+	drdy-gpios = <&test_gpio 0 0>;
+	odr = <5>;
+
 };
 
 test_i2c_lps22hh: lps22hh@32 {


### PR DESCRIPTION
Using the `LPS22HH` driver as a basis, this PR replaces the very limited existing driver for the `HB` variant with a more sophisticated one that allows setting a trigger and gives a basis for further improvements.