### PR TITLE
posix: mqueue: do not return NULL after pthread_exit()

### DIFF
--- a/lib/posix/options/mqueue.c
+++ b/lib/posix/options/mqueue.c
@@ -411,7 +411,6 @@ static void *mq_notify_thread(void *arg)
 
 	remove_notification(mqueue);
 
-	pthread_exit(NULL);
 	return NULL;
 }
 


### PR DESCRIPTION
`pthread_exit()` does not return and therefore it does not make sense to `return NULL` after it in `mq_notify_thread()`.  That would also constitute dead code where there is no way to get coverage.

Rather than explicitly exiting the thread, simply return gracefully from the thread function, and allow the pthread to terminate in the usual way.