### PR TITLE
tests: posix: mqueue: increase sleep ms to reduce failures

### DIFF
--- a/tests/posix/common/src/mqueue.c
+++ b/tests/posix/common/src/mqueue.c
@@ -187,7 +187,7 @@ ZTEST(mqueue, test_mqueue_notify_thread)
 
 	zassert_ok(mq_send(mqd, send_data, MESSAGE_SIZE, 0), "Unable to send message");
 
-	usleep(USEC_PER_MSEC * 10U);
+	usleep(USEC_PER_MSEC * 100U);
 
 	zassert_true(notification_executed, "Notification not triggered.");
 


### PR DESCRIPTION
The `test_mqueue_notify_thread` testcase had a relatively high failure rate because sleeping only 10ms was in some cases not sufficiently long enough for the spawned thread to update `notification_executed`.

Sleep 100 ms instead of 10 ms to reduce the failure rate.

This should improve CI execution time by a small amount in that there should be fewer retries.