### PR TITLE
posix: mutexattr: improvements for pthread_mutexattr_t

### DIFF
--- a/include/zephyr/posix/posix_types.h
+++ b/include/zephyr/posix/posix_types.h
@@ -60,7 +60,8 @@ typedef struct k_sem sem_t;
 typedef uint32_t pthread_mutex_t;
 
 struct pthread_mutexattr {
-	int type;
+	unsigned char type: 2;
+	bool initialized: 1;
 };
 #if defined(CONFIG_MINIMAL_LIBC) || defined(CONFIG_PICOLIBC) || defined(CONFIG_ARMCLANG_STD_LIBC) \
 	|| defined(CONFIG_ARCMWDT_LIBC)

--- a/include/zephyr/posix/pthread.h
+++ b/include/zephyr/posix/pthread.h
@@ -253,12 +253,7 @@ int pthread_mutexattr_gettype(const pthread_mutexattr_t *attr, int *type);
  *
  * Note that pthread attribute structs are currently noops in Zephyr.
  */
-static inline int pthread_mutexattr_init(pthread_mutexattr_t *m)
-{
-	ARG_UNUSED(m);
-
-	return 0;
-}
+int pthread_mutexattr_init(pthread_mutexattr_t *attr);
 
 /**
  * @brief POSIX threading compatibility API
@@ -267,12 +262,7 @@ static inline int pthread_mutexattr_init(pthread_mutexattr_t *m)
  *
  * Note that pthread attribute structs are currently noops in Zephyr.
  */
-static inline int pthread_mutexattr_destroy(pthread_mutexattr_t *m)
-{
-	ARG_UNUSED(m);
-
-	return 0;
-}
+int pthread_mutexattr_destroy(pthread_mutexattr_t *attr);
 
 /**
  * @brief Declare a pthread barrier

--- a/tests/posix/common/src/mutex.c
+++ b/tests/posix/common/src/mutex.c
@@ -49,11 +49,12 @@ static void test_mutex_common(int type, void *(*entry)(void *arg))
 	pthread_t th;
 	int protocol;
 	int actual_type;
+	pthread_mutexattr_t mut_attr;
 	struct sched_param schedparam;
-	pthread_mutexattr_t mut_attr = {0};
 
 	schedparam.sched_priority = 2;
 
+	zassert_ok(pthread_mutexattr_init(&mut_attr));
 	zassert_ok(pthread_mutexattr_settype(&mut_attr, type), "setting mutex type is failed");
 	zassert_ok(pthread_mutex_init(&mutex, &mut_attr), "mutex initialization is failed");
 
@@ -61,6 +62,7 @@ static void test_mutex_common(int type, void *(*entry)(void *arg))
 		   "reading mutex type is failed");
 	zassert_ok(pthread_mutexattr_getprotocol(&mut_attr, &protocol),
 		   "reading mutex protocol is failed");
+	zassert_ok(pthread_mutexattr_destroy(&mut_attr));
 
 	zassert_ok(pthread_mutex_lock(&mutex));
 

--- a/tests/posix/common/src/mutex_attr.c
+++ b/tests/posix/common/src/mutex_attr.c
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2024, Meta
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <errno.h>
+#include <pthread.h>
+
+#include <zephyr/ztest.h>
+
+ZTEST(mutex_attr, test_pthread_mutexattr_init)
+{
+	pthread_mutexattr_t attr;
+
+	/* degenerate cases */
+	{
+		zassert_equal(EINVAL, pthread_mutexattr_init(NULL));
+	}
+
+	zassert_ok(pthread_mutexattr_init(&attr));
+	zassert_ok(pthread_mutexattr_destroy(&attr));
+}
+
+ZTEST(mutex_attr, test_pthread_mutexattr_destroy)
+{
+	pthread_mutexattr_t attr;
+
+	/* degenerate cases */
+	{
+		if (false) {
+			/* undefined behaviour */
+			zassert_equal(EINVAL, pthread_mutexattr_destroy(&attr));
+		}
+		zassert_equal(EINVAL, pthread_mutexattr_destroy(NULL));
+	}
+
+	zassert_ok(pthread_mutexattr_init(&attr));
+	zassert_ok(pthread_mutexattr_destroy(&attr));
+	if (false) {
+		/* undefined behaviour */
+		zassert_equal(EINVAL, pthread_mutexattr_destroy(&attr));
+	}
+}
+
+ZTEST(mutex_attr, test_pthread_mutexattr_gettype)
+{
+	int type;
+	pthread_mutexattr_t attr;
+
+	/* degenerate cases */
+	{
+		if (false) {
+			/* undefined behaviour */
+			zassert_equal(EINVAL, pthread_mutexattr_gettype(&attr, &type));
+		}
+		zassert_equal(EINVAL, pthread_mutexattr_gettype(NULL, NULL));
+		zassert_equal(EINVAL, pthread_mutexattr_gettype(NULL, &type));
+		zassert_equal(EINVAL, pthread_mutexattr_gettype(&attr, NULL));
+	}
+
+	zassert_ok(pthread_mutexattr_init(&attr));
+	zassert_ok(pthread_mutexattr_gettype(&attr, &type));
+	zassert_equal(type, PTHREAD_MUTEX_DEFAULT);
+	zassert_ok(pthread_mutexattr_destroy(&attr));
+}
+
+ZTEST(mutex_attr, test_pthread_mutexattr_settype)
+{
+	int type;
+	pthread_mutexattr_t attr;
+
+	/* degenerate cases */
+	{
+		if (false) {
+			/* undefined behaviour */
+			zassert_equal(EINVAL,
+				      pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_DEFAULT));
+		}
+		zassert_equal(EINVAL, pthread_mutexattr_settype(NULL, 42));
+		zassert_equal(EINVAL, pthread_mutexattr_settype(NULL, PTHREAD_MUTEX_NORMAL));
+		zassert_equal(EINVAL, pthread_mutexattr_settype(&attr, 42));
+	}
+
+	zassert_ok(pthread_mutexattr_init(&attr));
+
+	zassert_ok(pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_DEFAULT));
+	zassert_ok(pthread_mutexattr_gettype(&attr, &type));
+	zassert_equal(type, PTHREAD_MUTEX_DEFAULT);
+
+	zassert_ok(pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_NORMAL));
+	zassert_ok(pthread_mutexattr_gettype(&attr, &type));
+	zassert_equal(type, PTHREAD_MUTEX_NORMAL);
+
+	zassert_ok(pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE));
+	zassert_ok(pthread_mutexattr_gettype(&attr, &type));
+	zassert_equal(type, PTHREAD_MUTEX_RECURSIVE);
+
+	zassert_ok(pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ERRORCHECK));
+	zassert_ok(pthread_mutexattr_gettype(&attr, &type));
+	zassert_equal(type, PTHREAD_MUTEX_ERRORCHECK);
+
+	zassert_ok(pthread_mutexattr_destroy(&attr));
+}
+
+ZTEST_SUITE(mutex_attr, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
* tests: posix: mutex: initialize mutexattr properly
* reduce the size of `pthread_mutexattr_t` to one byte
* implement `pthread_mutexattr_init()` and `pthread_mutexattr_destroy()`
* make `pthread_mutexattr_gettype()` and `pthread_mutexattr_settype()` more robust
* add mutex_attr testsuite for `pthread_mutexattr_t`
