### PR TITLE
tests: posix: headers: uncomment tests for existing features

### DIFF
--- a/include/zephyr/posix/pthread.h
+++ b/include/zephyr/posix/pthread.h
@@ -171,6 +171,8 @@ int pthread_condattr_setclock(pthread_condattr_t *att, clockid_t clock_id);
  *  FIXME: Only PRIO_NONE is supported. Implement other protocols.
  */
 #define PTHREAD_PRIO_NONE           0
+#define PTHREAD_PRIO_INHERIT        1
+#define PTHREAD_PRIO_PROTECT        2
 
 /**
  * @brief POSIX threading compatibility API

--- a/tests/posix/headers/src/pthread_h.c
+++ b/tests/posix/headers/src/pthread_h.c
@@ -46,9 +46,9 @@ ZTEST(posix_headers, test_pthread_h)
 
 	pthread_once_t once = PTHREAD_ONCE_INIT;
 
-	/* zassert_not_equal(-1, PTHREAD_PRIO_INHERIT); */ /* not implemented */
+	zassert_not_equal(-1, PTHREAD_PRIO_INHERIT);
 	zassert_not_equal(-1, PTHREAD_PRIO_NONE);
-	/* zassert_not_equal(-1, PTHREAD_PRIO_PROTECT); */ /* not implemented */
+	zassert_not_equal(-1, PTHREAD_PRIO_PROTECT);
 
 	zassert_not_equal(-1, PTHREAD_PROCESS_SHARED);
 	zassert_not_equal(-1, PTHREAD_PROCESS_PRIVATE);
@@ -58,7 +58,7 @@ ZTEST(posix_headers, test_pthread_h)
 
 	pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
 	pthread_mutex_t mu = PTHREAD_MUTEX_INITIALIZER;
-	/* pthread_rwlock_t lock = PTHREAD_RWLOCK_INITIALIZER; */ /* not implemented */
+	pthread_rwlock_t lock = PTHREAD_RWLOCK_INITIALIZER;
 
 	if (IS_ENABLED(CONFIG_POSIX_API)) {
 		zassert_not_null(pthread_atfork);
@@ -128,7 +128,7 @@ ZTEST(posix_headers, test_pthread_h)
 		zassert_not_null(pthread_mutexattr_gettype);
 		zassert_not_null(pthread_mutexattr_init);
 		/* zassert_not_null(pthread_mutexattr_setprioceiling); */ /* not implemented */
-		/* zassert_not_null(pthread_mutexattr_setprotocol); */ /* not implemented */
+		zassert_not_null(pthread_mutexattr_setprotocol);
 		/* zassert_not_null(pthread_mutexattr_setpshared); */ /* not implemented */
 		/* zassert_not_null(pthread_mutexattr_setrobust); */ /* not implemented */
 		zassert_not_null(pthread_mutexattr_settype);


### PR DESCRIPTION
Several constants and functions exist in the pthread.h header that were not previously checked in the header testsuite.

Uncomment the checks to more accurately check what exists today.