### PR TITLE
hal_espressif: update to include bugfixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -152,7 +152,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: 67fa60bdffca7ba8ed199aecfaa26f485f24878b
+      revision: e705cc16c4b63b5b3cad5c395297a4c2b49651fd
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
Added longjmp patch.
Fixes build warning in phy driver
Fixes runtime missing rom function.
Fixes missing mcuboot assertion implementation (https://github.com/zephyrproject-rtos/hal_espressif/issues/239)

Fixes #69179
