### PR TITLE
ITE: drivers/gpio: Fix untrusted loop bound

### DIFF
--- a/drivers/gpio/gpio_ite_it8xxx2_v2.c
+++ b/drivers/gpio/gpio_ite_it8xxx2_v2.c
@@ -380,7 +380,7 @@ static void gpio_ite_isr(const void *arg)
 	uint8_t num_pins = gpio_config->num_pins;
 	uint8_t pin;
 
-	for (pin = 0; pin <= num_pins; pin++) {
+	for (pin = 0; pin < num_pins; pin++) {
 		if (irq == gpio_config->gpio_irq[pin]) {
 			volatile uint8_t *reg_base =
 				(uint8_t *)gpio_config->wuc_base[pin];


### PR DESCRIPTION
The pin in the loop start counting from 0, so the condition of the for loop should not be equal to num_pins.

Fixes #69118