### PR TITLE
samples: bluetooth: hci_uart: Fix wrongly converted board names

### DIFF
--- a/samples/bluetooth/hci_uart/sample.yaml
+++ b/samples/bluetooth/hci_uart/sample.yaml
@@ -12,7 +12,7 @@ tests:
   sample.bluetooth.hci_uart.nrf52833.df:
     harness: bluetooth
     platform_allow: nrf52833dk/nrf52833
-    extra_args: DTC_OVERLAY_FILE=./boards/nrf52833dk/nrf52833_dk.overlay
+    extra_args: DTC_OVERLAY_FILE=./boards/nrf52833dk_nrf52833_df.overlay
     extra_configs:
       - CONFIG_BT_CTLR_DF=y
     tags:
@@ -21,7 +21,7 @@ tests:
   sample.bluetooth.hci_uart.nrf5340_netcore.df:
     harness: bluetooth
     platform_allow: nrf5340dk/nrf5340/cpunet
-    extra_args: DTC_OVERLAY_FILE=./boards/nrf5340dk/nrf5340_cpunet_dk.overlay
+    extra_args: DTC_OVERLAY_FILE=./boards/nrf5340dk_nrf5340_cpunet_df.overlay
     extra_configs:
       - CONFIG_BT_CTLR_DF=y
     tags:
@@ -30,7 +30,7 @@ tests:
   sample.bluetooth.hci_uart.nrf52833.df.iq_report:
     harness: bluetooth
     platform_allow: nrf52833dk/nrf52833
-    extra_args: DTC_OVERLAY_FILE=./boards/nrf52833dk/nrf52833_dk.overlay
+    extra_args: DTC_OVERLAY_FILE=./boards/nrf52833dk_nrf52833_df.overlay
     extra_configs:
       - CONFIG_BT_CTLR_DF=y
       - CONFIG_BT_CTLR_DTM_HCI_DF_IQ_REPORT=y
@@ -40,7 +40,7 @@ tests:
   sample.bluetooth.hci_uart.nrf5340_netcore.df.iq_report:
     harness: bluetooth
     platform_allow: nrf5340dk/nrf5340/cpunet
-    extra_args: DTC_OVERLAY_FILE=./boards/nrf5340dk/nrf5340_cpunet_dk.overlay
+    extra_args: DTC_OVERLAY_FILE=./boards/nrf5340dk_nrf5340_cpunet_df.overlay
     extra_configs:
       - CONFIG_BT_CTLR_DF=y
       - CONFIG_BT_CTLR_DTM_HCI_DF_IQ_REPORT=y
@@ -54,7 +54,7 @@ tests:
       - nrf52833dk/nrf52833
     extra_args:
       - OVERLAY_CONFIG=overlay-all-bt_ll_sw_split.conf
-      - DTC_OVERLAY_FILE=./boards/nrf52833dk/nrf52833_dk.overlay
+      - DTC_OVERLAY_FILE=./boards/nrf52833dk_nrf52833_df.overlay
     tags:
       - uart
       - bluetooth


### PR DESCRIPTION
Fixes an issue whereby converted board names were wrong