### PR TITLE
tests/bsim: Reduce parallelism of build in CI to avoid hangs

### DIFF
--- a/tests/bsim/bluetooth/host/adv/compile.sh
+++ b/tests/bsim/bluetooth/host/adv/compile.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Copyright 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# Compile all the applications needed by the bsim tests in these subfolders
+
+#set -x #uncomment this line for debugging
+set -ue
+
+: "${BSIM_COMPONENTS_PATH:?BSIM_COMPONENTS_PATH must be defined}"
+: "${ZEPHYR_BASE:?ZEPHYR_BASE must be set to point to the zephyr root\
+ directory}"
+
+WORK_DIR="${WORK_DIR:-${ZEPHYR_BASE}/bsim_out}"
+
+BOARD_ROOT="${BOARD_ROOT:-${ZEPHYR_BASE}}"
+
+mkdir -p ${WORK_DIR}
+
+source ${ZEPHYR_BASE}/tests/bsim/compile.source
+
+app=tests/bsim/bluetooth/host/adv/resume compile
+app=tests/bsim/bluetooth/host/adv/resume conf_file=prj_2.conf compile
+app=tests/bsim/bluetooth/host/adv/chain compile
+app=tests/bsim/bluetooth/host/adv/extended conf_file=prj_advertiser.conf compile
+app=tests/bsim/bluetooth/host/adv/extended conf_file=prj_scanner.conf compile
+app=tests/bsim/bluetooth/host/adv/periodic compile
+app=tests/bsim/bluetooth/host/adv/periodic conf_file=prj_long_data.conf compile
+app=tests/bsim/bluetooth/host/adv/encrypted/css_sample_data compile
+app=tests/bsim/bluetooth/host/adv/encrypted/ead_sample compile
+
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/att/compile.sh
+++ b/tests/bsim/bluetooth/host/att/compile.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Copyright 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# Compile all the applications needed by the bsim tests in these subfolders
+
+#set -x #uncomment this line for debugging
+set -ue
+
+: "${BSIM_COMPONENTS_PATH:?BSIM_COMPONENTS_PATH must be defined}"
+: "${ZEPHYR_BASE:?ZEPHYR_BASE must be set to point to the zephyr root\
+ directory}"
+
+WORK_DIR="${WORK_DIR:-${ZEPHYR_BASE}/bsim_out}"
+
+BOARD_ROOT="${BOARD_ROOT:-${ZEPHYR_BASE}}"
+
+mkdir -p ${WORK_DIR}
+
+source ${ZEPHYR_BASE}/tests/bsim/compile.source
+
+app=tests/bsim/bluetooth/host/att/eatt conf_file=prj_lowres.conf compile
+app=tests/bsim/bluetooth/host/att/eatt conf_file=prj_collision.conf compile
+app=tests/bsim/bluetooth/host/att/eatt conf_file=prj_multiple_conn.conf compile
+app=tests/bsim/bluetooth/host/att/eatt conf_file=prj_autoconnect.conf compile
+app=tests/bsim/bluetooth/host/att/eatt_notif conf_file=prj.conf compile
+app=tests/bsim/bluetooth/host/att/mtu_update compile
+app=tests/bsim/bluetooth/host/att/read_fill_buf/client compile
+app=tests/bsim/bluetooth/host/att/read_fill_buf/server compile
+app=tests/bsim/bluetooth/host/att/retry_on_sec_err/client compile
+app=tests/bsim/bluetooth/host/att/retry_on_sec_err/server compile
+app=tests/bsim/bluetooth/host/att/sequential/dut compile
+app=tests/bsim/bluetooth/host/att/sequential/tester compile
+app=tests/bsim/bluetooth/host/att/pipeline/dut compile
+app=tests/bsim/bluetooth/host/att/pipeline/tester compile
+app=tests/bsim/bluetooth/host/att/long_read compile
+app=tests/bsim/bluetooth/host/att/open_close compile
+
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/compile.sh
+++ b/tests/bsim/bluetooth/host/compile.sh
@@ -19,58 +19,13 @@ mkdir -p ${WORK_DIR}
 
 source ${ZEPHYR_BASE}/tests/bsim/compile.source
 
-app=tests/bsim/bluetooth/host/adv/resume compile
-app=tests/bsim/bluetooth/host/adv/resume conf_file=prj_2.conf compile
-app=tests/bsim/bluetooth/host/adv/chain compile
-app=tests/bsim/bluetooth/host/adv/extended conf_file=prj_advertiser.conf compile
-app=tests/bsim/bluetooth/host/adv/extended conf_file=prj_scanner.conf compile
-app=tests/bsim/bluetooth/host/adv/periodic compile
-app=tests/bsim/bluetooth/host/adv/periodic conf_file=prj_long_data.conf compile
-app=tests/bsim/bluetooth/host/adv/encrypted/css_sample_data compile
-app=tests/bsim/bluetooth/host/adv/encrypted/ead_sample compile
-
-app=tests/bsim/bluetooth/host/att/eatt conf_file=prj_lowres.conf compile
-app=tests/bsim/bluetooth/host/att/eatt conf_file=prj_collision.conf compile
-app=tests/bsim/bluetooth/host/att/eatt conf_file=prj_multiple_conn.conf compile
-app=tests/bsim/bluetooth/host/att/eatt conf_file=prj_autoconnect.conf compile
-app=tests/bsim/bluetooth/host/att/eatt_notif conf_file=prj.conf compile
-app=tests/bsim/bluetooth/host/att/mtu_update compile
-app=tests/bsim/bluetooth/host/att/read_fill_buf/client compile
-app=tests/bsim/bluetooth/host/att/read_fill_buf/server compile
-app=tests/bsim/bluetooth/host/att/retry_on_sec_err/client compile
-app=tests/bsim/bluetooth/host/att/retry_on_sec_err/server compile
-app=tests/bsim/bluetooth/host/att/sequential/dut compile
-app=tests/bsim/bluetooth/host/att/sequential/tester compile
-app=tests/bsim/bluetooth/host/att/pipeline/dut compile
-app=tests/bsim/bluetooth/host/att/pipeline/tester compile
-app=tests/bsim/bluetooth/host/att/long_read compile
-app=tests/bsim/bluetooth/host/att/open_close compile
-
-app=tests/bsim/bluetooth/host/gatt/authorization compile
-app=tests/bsim/bluetooth/host/gatt/caching compile
-app=tests/bsim/bluetooth/host/gatt/general compile
-app=tests/bsim/bluetooth/host/gatt/notify compile
-app=tests/bsim/bluetooth/host/gatt/notify_multiple compile
-app=tests/bsim/bluetooth/host/gatt/settings compile
-app=tests/bsim/bluetooth/host/gatt/settings conf_file=prj_2.conf compile
-app=tests/bsim/bluetooth/host/gatt/ccc_store compile
-app=tests/bsim/bluetooth/host/gatt/ccc_store conf_file=prj_2.conf compile
-app=tests/bsim/bluetooth/host/gatt/sc_indicate compile
+${ZEPHYR_BASE}/tests/bsim/bluetooth/host/adv/compile.sh
+${ZEPHYR_BASE}/tests/bsim/bluetooth/host/att/compile.sh
+${ZEPHYR_BASE}/tests/bsim/bluetooth/host/gatt/compile.sh
+${ZEPHYR_BASE}/tests/bsim/bluetooth/host/l2cap/compile.sh
+${ZEPHYR_BASE}/tests/bsim/bluetooth/host/security/compile.sh
 
 app=tests/bsim/bluetooth/host/iso/cis compile
-
-app=tests/bsim/bluetooth/host/l2cap/general compile
-app=tests/bsim/bluetooth/host/l2cap/userdata compile
-app=tests/bsim/bluetooth/host/l2cap/stress compile
-app=tests/bsim/bluetooth/host/l2cap/split/dut compile
-app=tests/bsim/bluetooth/host/l2cap/split/tester compile
-app=tests/bsim/bluetooth/host/l2cap/credits compile
-app=tests/bsim/bluetooth/host/l2cap/credits conf_file=prj_ecred.conf compile
-app=tests/bsim/bluetooth/host/l2cap/credits_seg_recv compile
-app=tests/bsim/bluetooth/host/l2cap/credits_seg_recv conf_file=prj_ecred.conf compile
-app=tests/bsim/bluetooth/host/l2cap/frags compile
-app=tests/bsim/bluetooth/host/l2cap/send_on_connect compile
-app=tests/bsim/bluetooth/host/l2cap/send_on_connect conf_file=prj_ecred.conf compile
 
 app=tests/bsim/bluetooth/host/misc/disable compile
 app=tests/bsim/bluetooth/host/misc/disconnect/dut compile
@@ -84,15 +39,6 @@ app=tests/bsim/bluetooth/host/privacy/peripheral compile
 app=tests/bsim/bluetooth/host/privacy/peripheral conf_file=prj_rpa_sharing.conf compile
 app=tests/bsim/bluetooth/host/privacy/device compile
 app=tests/bsim/bluetooth/host/privacy/legacy compile
-
-app=tests/bsim/bluetooth/host/security/bond_overwrite_allowed compile
-app=tests/bsim/bluetooth/host/security/bond_overwrite_denied compile
-app=tests/bsim/bluetooth/host/security/bond_per_connection compile
-app=tests/bsim/bluetooth/host/security/ccc_update compile
-app=tests/bsim/bluetooth/host/security/ccc_update conf_file=prj_2.conf compile
-app=tests/bsim/bluetooth/host/security/id_addr_update/central compile
-app=tests/bsim/bluetooth/host/security/id_addr_update/peripheral compile
-app=tests/bsim/bluetooth/host/security/security_changed_callback compile
 
 app=tests/bsim/bluetooth/host/id/settings compile
 

--- a/tests/bsim/bluetooth/host/gatt/compile.sh
+++ b/tests/bsim/bluetooth/host/gatt/compile.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Copyright 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# Compile all the applications needed by the bsim tests in these subfolders
+
+#set -x #uncomment this line for debugging
+set -ue
+
+: "${BSIM_COMPONENTS_PATH:?BSIM_COMPONENTS_PATH must be defined}"
+: "${ZEPHYR_BASE:?ZEPHYR_BASE must be set to point to the zephyr root\
+ directory}"
+
+WORK_DIR="${WORK_DIR:-${ZEPHYR_BASE}/bsim_out}"
+
+BOARD_ROOT="${BOARD_ROOT:-${ZEPHYR_BASE}}"
+
+mkdir -p ${WORK_DIR}
+
+source ${ZEPHYR_BASE}/tests/bsim/compile.source
+
+app=tests/bsim/bluetooth/host/gatt/authorization compile
+app=tests/bsim/bluetooth/host/gatt/caching compile
+app=tests/bsim/bluetooth/host/gatt/general compile
+app=tests/bsim/bluetooth/host/gatt/notify compile
+app=tests/bsim/bluetooth/host/gatt/notify_multiple compile
+app=tests/bsim/bluetooth/host/gatt/settings compile
+app=tests/bsim/bluetooth/host/gatt/settings conf_file=prj_2.conf compile
+app=tests/bsim/bluetooth/host/gatt/ccc_store compile
+app=tests/bsim/bluetooth/host/gatt/ccc_store conf_file=prj_2.conf compile
+app=tests/bsim/bluetooth/host/gatt/sc_indicate compile
+
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/l2cap/compile.sh
+++ b/tests/bsim/bluetooth/host/l2cap/compile.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Copyright 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# Compile all the applications needed by the bsim tests in these subfolders
+
+#set -x #uncomment this line for debugging
+set -ue
+
+: "${BSIM_COMPONENTS_PATH:?BSIM_COMPONENTS_PATH must be defined}"
+: "${ZEPHYR_BASE:?ZEPHYR_BASE must be set to point to the zephyr root\
+ directory}"
+
+WORK_DIR="${WORK_DIR:-${ZEPHYR_BASE}/bsim_out}"
+
+BOARD_ROOT="${BOARD_ROOT:-${ZEPHYR_BASE}}"
+
+mkdir -p ${WORK_DIR}
+
+source ${ZEPHYR_BASE}/tests/bsim/compile.source
+
+app=tests/bsim/bluetooth/host/l2cap/general compile
+app=tests/bsim/bluetooth/host/l2cap/userdata compile
+app=tests/bsim/bluetooth/host/l2cap/stress compile
+app=tests/bsim/bluetooth/host/l2cap/split/dut compile
+app=tests/bsim/bluetooth/host/l2cap/split/tester compile
+app=tests/bsim/bluetooth/host/l2cap/credits compile
+app=tests/bsim/bluetooth/host/l2cap/credits conf_file=prj_ecred.conf compile
+app=tests/bsim/bluetooth/host/l2cap/credits_seg_recv compile
+app=tests/bsim/bluetooth/host/l2cap/credits_seg_recv conf_file=prj_ecred.conf compile
+app=tests/bsim/bluetooth/host/l2cap/frags compile
+app=tests/bsim/bluetooth/host/l2cap/send_on_connect compile
+app=tests/bsim/bluetooth/host/l2cap/send_on_connect conf_file=prj_ecred.conf compile
+
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/security/compile.sh
+++ b/tests/bsim/bluetooth/host/security/compile.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Copyright 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# Compile all the applications needed by the bsim tests in these subfolders
+
+#set -x #uncomment this line for debugging
+set -ue
+
+: "${BSIM_COMPONENTS_PATH:?BSIM_COMPONENTS_PATH must be defined}"
+: "${ZEPHYR_BASE:?ZEPHYR_BASE must be set to point to the zephyr root\
+ directory}"
+
+WORK_DIR="${WORK_DIR:-${ZEPHYR_BASE}/bsim_out}"
+
+BOARD_ROOT="${BOARD_ROOT:-${ZEPHYR_BASE}}"
+
+mkdir -p ${WORK_DIR}
+
+source ${ZEPHYR_BASE}/tests/bsim/compile.source
+
+app=tests/bsim/bluetooth/host/security/bond_overwrite_allowed compile
+app=tests/bsim/bluetooth/host/security/bond_overwrite_denied compile
+app=tests/bsim/bluetooth/host/security/bond_per_connection compile
+app=tests/bsim/bluetooth/host/security/ccc_update compile
+app=tests/bsim/bluetooth/host/security/ccc_update conf_file=prj_2.conf compile
+app=tests/bsim/bluetooth/host/security/id_addr_update/central compile
+app=tests/bsim/bluetooth/host/security/id_addr_update/peripheral compile
+app=tests/bsim/bluetooth/host/security/security_changed_callback compile
+
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/ll/cis/compile.sh
+++ b/tests/bsim/bluetooth/ll/cis/compile.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Copyright 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# Compile all the applications needed by the bsim tests in these subfolders
+
+#set -x #uncomment this line for debugging
+set -ue
+: "${BSIM_COMPONENTS_PATH:?BSIM_COMPONENTS_PATH must be defined}"
+: "${ZEPHYR_BASE:?ZEPHYR_BASE must be set to point to the zephyr root\
+ directory}"
+
+WORK_DIR="${WORK_DIR:-${ZEPHYR_BASE}/bsim_out}"
+
+BOARD_ROOT="${BOARD_ROOT:-${ZEPHYR_BASE}}"
+
+mkdir -p ${WORK_DIR}
+
+source ${ZEPHYR_BASE}/tests/bsim/compile.source
+
+app=tests/bsim/bluetooth/ll/cis conf_overlay=overlay.conf compile
+app=tests/bsim/bluetooth/ll/cis conf_overlay=overlay-acl_first.conf compile
+app=tests/bsim/bluetooth/ll/cis conf_overlay=overlay-legacy_adv.conf compile
+app=tests/bsim/bluetooth/ll/cis conf_overlay=overlay-legacy_adv_acl_first.conf compile
+app=tests/bsim/bluetooth/ll/cis conf_overlay=overlay-acl_group.conf compile
+app=tests/bsim/bluetooth/ll/cis conf_overlay=overlay-acl_group_acl_first.conf compile
+app=tests/bsim/bluetooth/ll/cis conf_overlay=overlay-peripheral_cis.conf compile
+app=tests/bsim/bluetooth/ll/cis conf_overlay=overlay-acl_first_ft_per_skip_2_se.conf compile
+app=tests/bsim/bluetooth/ll/cis conf_overlay=overlay-acl_first_ft_per_skip_4_se.conf compile
+app=tests/bsim/bluetooth/ll/cis conf_overlay=overlay-acl_first_ft_cen_skip_2_se.conf compile
+app=tests/bsim/bluetooth/ll/cis conf_overlay=overlay-acl_first_ft_cen_skip_4_se.conf compile
+
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/ll/compile.sh
+++ b/tests/bsim/bluetooth/ll/compile.sh
@@ -18,6 +18,8 @@ mkdir -p ${WORK_DIR}
 
 source ${ZEPHYR_BASE}/tests/bsim/compile.source
 
+${ZEPHYR_BASE}/tests/bsim/bluetooth/ll/cis/compile.sh
+
 app=tests/bsim/bluetooth/ll/advx compile
 app=tests/bsim/bluetooth/ll/advx \
   conf_overlay=overlay-ticker_expire_info.conf compile
@@ -31,18 +33,6 @@ app=tests/bsim/bluetooth/ll/bis compile
 app=tests/bsim/bluetooth/ll/bis \
   conf_overlay=overlay-ticker_expire_info.conf compile
 app=tests/bsim/bluetooth/ll/bis conf_file=prj_vs_dp.conf compile
-
-app=tests/bsim/bluetooth/ll/cis conf_overlay=overlay.conf compile
-app=tests/bsim/bluetooth/ll/cis conf_overlay=overlay-acl_first.conf compile
-app=tests/bsim/bluetooth/ll/cis conf_overlay=overlay-legacy_adv.conf compile
-app=tests/bsim/bluetooth/ll/cis conf_overlay=overlay-legacy_adv_acl_first.conf compile
-app=tests/bsim/bluetooth/ll/cis conf_overlay=overlay-acl_group.conf compile
-app=tests/bsim/bluetooth/ll/cis conf_overlay=overlay-acl_group_acl_first.conf compile
-app=tests/bsim/bluetooth/ll/cis conf_overlay=overlay-peripheral_cis.conf compile
-app=tests/bsim/bluetooth/ll/cis conf_overlay=overlay-acl_first_ft_per_skip_2_se.conf compile
-app=tests/bsim/bluetooth/ll/cis conf_overlay=overlay-acl_first_ft_per_skip_4_se.conf compile
-app=tests/bsim/bluetooth/ll/cis conf_overlay=overlay-acl_first_ft_cen_skip_2_se.conf compile
-app=tests/bsim/bluetooth/ll/cis conf_overlay=overlay-acl_first_ft_cen_skip_4_se.conf compile
 
 app=tests/bsim/bluetooth/ll/edtt/hci_test_app \
   conf_file=prj_dut_llcp.conf compile


### PR DESCRIPTION
There are quite many BT host and LL test images being built.
Today these are all built too much in parallel, causing a quite high load.

Let's split them in their separate sub-scripts, so we don't parallelize too many builds, and users have more granularity if they only want to build a subset.

----

As we are adding more tests images being built we see the CI runner tends to hang more often.
All jobs were initially parallelized in https://github.com/zephyrproject-rtos/zephyr/commit/1de363d9d5279e2c3d6021fecad41ffca96e09f1 