### PR TITLE
net: lib: coap: Add error check when waking server thread

### DIFF
--- a/subsys/net/lib/coap/coap_server.c
+++ b/subsys/net/lib/coap/coap_server.c
@@ -335,7 +335,9 @@ static int coap_server_poll_timeout(void)
 
 static void coap_server_update_services(void)
 {
-	zsock_send(control_socks[1], &(char){0}, 1, 0);
+	if (zsock_send(control_socks[1], &(char){0}, 1, 0) < 0) {
+		LOG_ERR("Failed to notify server thread (%d)", errno);
+	}
 }
 
 static inline bool coap_service_in_section(const struct coap_service *service)


### PR DESCRIPTION
There's not much to be done in case waking up the server thread with socketpair send() fails, but at least we can log an error on such event (to please coverity).

Fixes #69112