### PR TITLE
soc: nxp: imx: imx8m: Align resource table to 64bit for i.MX 8M

### DIFF
--- a/soc/nxp/imx/imx8m/m4_mini/linker.ld
+++ b/soc/nxp/imx/imx8m/m4_mini/linker.ld
@@ -9,7 +9,7 @@
 SECTIONS
      {
 #ifdef CONFIG_OPENAMP_RSC_TABLE
-        SECTION_PROLOGUE(.resource_table,, SUBALIGN(4))
+        SECTION_PROLOGUE(.resource_table,, SUBALIGN(8))
         {
             KEEP(*(.resource_table*))
         } GROUP_LINK_IN(ROMABLE_REGION)

--- a/soc/nxp/imx/imx8m/m7/linker.ld
+++ b/soc/nxp/imx/imx8m/m7/linker.ld
@@ -21,7 +21,7 @@ MEMORY
 SECTIONS
      {
 #ifdef CONFIG_OPENAMP_RSC_TABLE
-        SECTION_PROLOGUE(.resource_table,, SUBALIGN(4))
+        SECTION_PROLOGUE(.resource_table,, SUBALIGN(8))
         {
             KEEP(*(.resource_table*))
         } GROUP_LINK_IN(ROMABLE_REGION)


### PR DESCRIPTION
Running `samples/subsys/ipc/openamp_rsc_table` with some adjustments could result in linux kernel panics if this change isn't included.