### PR TITLE
doc: native_sim: Native logger backend is always enabled by default

### DIFF
--- a/boards/posix/native_sim/doc/index.rst
+++ b/boards/posix/native_sim/doc/index.rst
@@ -610,9 +610,7 @@ development by integrating more seamlessly with the host operating system:
   :kconfig:option:`CONFIG_LOG_MODE_IMMEDIATE`.
 
   This backend can be selected with :kconfig:option:`CONFIG_LOG_BACKEND_NATIVE_POSIX`
-  and is enabled by default unless the PTTY UART is compiled in.
-  In this later case, by default, the logger is set to output to the
-  `PTTY UART`_.
+  and is enabled by default.
 
 .. _nsim_back_trace:
 


### PR DESCRIPTION
Since bd9836be8c81f00337db226fef2e029b4d844821
the native logger is enabled always (even if a UART is present) as it was thought more convenient for users.
But the documentation was not updated to reflect this. Let's fix it.