### PR TITLE
include: mipi_dbi: fix initialization statement for SPI operation field

### DIFF
--- a/include/zephyr/drivers/mipi_dbi.h
+++ b/include/zephyr/drivers/mipi_dbi.h
@@ -92,7 +92,7 @@ extern "C" {
 	{								\
 		.frequency = DT_PROP(node_id, mipi_max_frequency),	\
 		.operation = (operation_) |				\
-			DT_PROP(node_id, duplex),			\
+			DT_PROP(node_id, duplex) |			\
 			COND_CODE_1(DT_PROP(node_id, mipi_cpol), SPI_MODE_CPOL, (0)) |	\
 			COND_CODE_1(DT_PROP(node_id, mipi_cpha), SPI_MODE_CPHA, (0)) |	\
 			COND_CODE_1(DT_PROP(node_id, mipi_hold_cs), SPI_HOLD_ON_CS, (0)),	\


### PR DESCRIPTION
SPI configuration "operation" field is a bitmask of several configuration settings for the SPI interface when using SPI controllers with the MIPI DBI API. The initialization statement for this configuration structure had a comma after the "duplex" property where a binary or should be present. correct this issue