### PR TITLE
docs/develop/test/bsim: Two trivial fixes

### DIFF
--- a/doc/develop/test/bsim.rst
+++ b/doc/develop/test/bsim.rst
@@ -22,7 +22,7 @@ In the BabbleSim documentation you can find more information on how to
 `get <https://babblesim.github.io/fetching.html>`_ and
 `build <https://babblesim.github.io/building.html>`_ the simulator.
 In the :ref:`nrf52_bsim<nrf52_bsim>` and :ref:`nrf5340bsim<nrf5340bsim>` boards documentation
-you can find more information about how to build Zephyr targeting thesee particular boards,
+you can find more information about how to build Zephyr targeting these particular boards,
 and a few examples.
 
 Types of tests
@@ -66,7 +66,7 @@ Test coverage and BabbleSim
 As the :ref:`nrf52_bsim<nrf52_bsim>` and :ref:`nrf5340bsim<nrf5340bsim>` boards are based on the
 POSIX architecture, you can easily collect test coverage information.
 
-You can use the script :code:`tests/bsim/generate_coverage_report.sh` to generate an html
+You can use the script :zephyr_file:`tests/bsim/generate_coverage_report.sh` to generate an html
 coverage report from tests.
 
 Check :ref:`the page on coverage generation <coverage_posix>` for more info.


### PR DESCRIPTION
Fix a typo and let a file be a link instead of just its name.