### PR TITLE
doc: release-notes-3.6: add release note about -Wdouble-promotion

### DIFF
--- a/doc/releases/release-notes-3.6.rst
+++ b/doc/releases/release-notes-3.6.rst
@@ -290,6 +290,9 @@ Build system and infrastructure
 
 * Deprecated ``CONF_FILE`` ``prj_<build>.conf`` build type.
 
+* Added `-Wdouble-promotion` as a default warning when compiling to warn developers with
+  single-precision floats easily being promoted to double-precision.
+
 Drivers and Sensors
 *******************
 


### PR DESCRIPTION
This adds a release note about -Wdouble-promotion now being a default warning flag.