### PR TITLE
ci: have skipped workflows work with protected branch ci checks

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -10,19 +10,6 @@ on:
     tags:
     - v*
   pull_request:
-    paths:
-    - 'doc/**'
-    - '**.rst'
-    - 'include/**'
-    - 'kernel/include/kernel_arch_interface.h'
-    - 'lib/libc/**'
-    - 'subsys/testsuite/ztest/include/**'
-    - 'tests/**'
-    - '**/Kconfig*'
-    - 'west.yml'
-    - '.github/workflows/doc-build.yml'
-    - 'scripts/dts/**'
-    - 'doc/requirements.txt'
 
 env:
   # NOTE: west docstrings will be extracted from the version listed here
@@ -33,9 +20,41 @@ env:
   DOXYGEN_VERSION: 1.9.6
 
 jobs:
+  doc-file-check:
+    name: Check for doc changes
+    runs-on: ubuntu-22.04
+    if: >
+      github.repository_owner == 'zephyrproject-rtos'
+    outputs:
+      file_check: ${{ steps.check-doc-files.outputs.any_changed }}
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
+    - name: Check if Documentation related files changed
+      uses: tj-actions/changed-files@v42
+      id: check-doc-files
+      with:
+        files: |
+          doc/**
+          **.rst
+          include/**
+          kernel/include/kernel_arch_interface.h
+          lib/libc/**
+          subsys/testsuite/ztest/include/**
+          tests/**
+          **/Kconfig*
+          west.yml
+          scripts/dts/**
+          doc/requirements.txt
+          .github/workflows/doc-build.yml
+
   doc-build-html:
     name: "Documentation Build (HTML)"
-    if: github.repository_owner == 'zephyrproject-rtos'
+    needs: [doc-file-check]
+    if: github.repository_owner == 'zephyrproject-rtos' && needs.doc-file-check.outputs.file_check == 'true'
     runs-on: zephyr-runner-linux-x64-4xlarge
     timeout-minutes: 45
     concurrency:
@@ -217,3 +236,14 @@ jobs:
         path: |
           doc/_build/latex/zephyr.pdf
           doc/_build/latex/zephyr.log
+
+  doc-build-status-check:
+    if: always()
+    name: "Documentation Build Status"
+    needs:
+    - doc-build-pdf
+    - doc-file-check
+    - doc-build-html
+    uses: ./.github/workflows/ready-to-merge.yml
+    with:
+      needs_context: ${{ toJson(needs) }}

--- a/.github/workflows/ready-to-merge.yml
+++ b/.github/workflows/ready-to-merge.yml
@@ -1,0 +1,28 @@
+name: ready to merge
+
+on:
+  workflow_call:
+    inputs:
+      needs_context:
+        type: string
+        required: true
+
+jobs:
+  all_jobs_passed:
+    name: all jobs passed
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Check status of all required jobs"
+        run: |-
+          NEEDS_CONTEXT='${{ inputs.needs_context }}'
+          JOB_IDS=$(echo "$NEEDS_CONTEXT" | jq -r 'keys[]')
+          for JOB_ID in $JOB_IDS; do
+            RESULT=$(echo "$NEEDS_CONTEXT" | jq -r ".[\"$JOB_ID\"].result")
+            echo "$JOB_ID job result: $RESULT"
+            if [[ $RESULT != "success" && $RESULT != "skipped" ]]; then
+              echo "***"
+              echo "Error: The $JOB_ID job did not pass."
+              exit 1
+            fi
+          done
+          echo "All jobs passed or were skipped."

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -358,3 +358,12 @@ jobs:
           check_name: Unit Test Results
           files: "**/twister.xml"
           comment_mode: off
+  twister-status-check:
+    if: always()
+    name: "Check Twister Status"
+    needs:
+      - twister-build-prep
+      - twister-build
+    uses: ./.github/workflows/ready-to-merge.yml
+    with:
+      needs_context: ${{ toJson(needs) }}


### PR DESCRIPTION
- ci: doc: always report status
- ci: twister status check

Related to this: https://docs.github.com/en/enterprise-cloud@latest/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks


![image](https://github.com/zephyrproject-rtos/zephyr/assets/180017/4b981400-2623-4017-b94a-39ade0250dca)
