### PR TITLE
Fix stream start issue in video sw generator

### DIFF
--- a/drivers/video/video_sw_generator.c
+++ b/drivers/video/video_sw_generator.c
@@ -55,7 +55,9 @@ static int video_sw_generator_stream_start(const struct device *dev)
 {
 	struct video_sw_generator_data *data = dev->data;
 
-	return k_work_schedule(&data->buf_work, K_MSEC(33));
+	k_work_schedule(&data->buf_work, K_MSEC(33));
+
+	return 0;
 }
 
 static int video_sw_generator_stream_stop(const struct device *dev)

--- a/drivers/video/video_sw_generator.c
+++ b/drivers/video/video_sw_generator.c
@@ -7,8 +7,8 @@
 
 #include <zephyr/drivers/video.h>
 
-#define VIDEO_PATTERN_COLOR_BAR	0
-#define VIDEO_PATTERN_FPS	30
+#define VIDEO_PATTERN_COLOR_BAR 0
+#define VIDEO_PATTERN_FPS       30
 
 struct video_sw_generator_data {
 	const struct device *dev;
@@ -23,8 +23,7 @@ struct video_sw_generator_data {
 	struct k_poll_signal *signal;
 };
 
-static int video_sw_generator_set_fmt(const struct device *dev,
-				      enum video_endpoint_id ep,
+static int video_sw_generator_set_fmt(const struct device *dev, enum video_endpoint_id ep,
 				      struct video_format *fmt)
 {
 	struct video_sw_generator_data *data = dev->data;
@@ -38,8 +37,7 @@ static int video_sw_generator_set_fmt(const struct device *dev,
 	return 0;
 }
 
-static int video_sw_generator_get_fmt(const struct device *dev,
-				      enum video_endpoint_id ep,
+static int video_sw_generator_get_fmt(const struct device *dev, enum video_endpoint_id ep,
 				      struct video_format *fmt)
 {
 	struct video_sw_generator_data *data = dev->data;
@@ -70,18 +68,16 @@ static int video_sw_generator_stream_stop(const struct device *dev)
 }
 
 /* Black, Blue, Red, Purple, Green, Aqua, Yellow, White */
-uint16_t rgb565_colorbar_value[] = { 0x0000, 0x001F, 0xF800, 0xF81F,
-				  0x07E0, 0x07FF, 0xFFE0, 0xFFFF };
+uint16_t rgb565_colorbar_value[] = {0x0000, 0x001F, 0xF800, 0xF81F, 0x07E0, 0x07FF, 0xFFE0, 0xFFFF};
 
-static void __fill_buffer_colorbar(struct video_sw_generator_data *data,
-				   struct video_buffer *vbuf)
+static void __fill_buffer_colorbar(struct video_sw_generator_data *data, struct video_buffer *vbuf)
 {
 	int bw = data->fmt.width / 8;
 	int h, w, i = 0;
 
 	for (h = 0; h < data->fmt.height; h++) {
 		for (w = 0; w < data->fmt.width; w++) {
-			int color_idx =  data->ctrl_vflip ? 7 - w / bw : w / bw;
+			int color_idx = data->ctrl_vflip ? 7 - w / bw : w / bw;
 			if (data->fmt.pixelformat == VIDEO_PIX_FMT_RGB565) {
 				uint16_t *pixel = (uint16_t *)&vbuf->buffer[i];
 				*pixel = rgb565_colorbar_value[color_idx];
@@ -124,8 +120,7 @@ static void __buffer_work(struct k_work *work)
 	k_yield();
 }
 
-static int video_sw_generator_enqueue(const struct device *dev,
-				      enum video_endpoint_id ep,
+static int video_sw_generator_enqueue(const struct device *dev, enum video_endpoint_id ep,
 				      struct video_buffer *vbuf)
 {
 	struct video_sw_generator_data *data = dev->data;
@@ -139,10 +134,8 @@ static int video_sw_generator_enqueue(const struct device *dev,
 	return 0;
 }
 
-static int video_sw_generator_dequeue(const struct device *dev,
-				      enum video_endpoint_id ep,
-				      struct video_buffer **vbuf,
-				      k_timeout_t timeout)
+static int video_sw_generator_dequeue(const struct device *dev, enum video_endpoint_id ep,
+				      struct video_buffer **vbuf, k_timeout_t timeout)
 {
 	struct video_sw_generator_data *data = dev->data;
 
@@ -158,8 +151,7 @@ static int video_sw_generator_dequeue(const struct device *dev,
 	return 0;
 }
 
-static int video_sw_generator_flush(const struct device *dev,
-				    enum video_endpoint_id ep,
+static int video_sw_generator_flush(const struct device *dev, enum video_endpoint_id ep,
 				    bool cancel)
 {
 	struct video_sw_generator_data *data = dev->data;
@@ -174,8 +166,7 @@ static int video_sw_generator_flush(const struct device *dev,
 		while ((vbuf = k_fifo_get(&data->fifo_in, K_NO_WAIT))) {
 			k_fifo_put(&data->fifo_out, vbuf);
 			if (IS_ENABLED(CONFIG_POLL) && data->signal) {
-				k_poll_signal_raise(data->signal,
-						    VIDEO_BUF_ABORTED);
+				k_poll_signal_raise(data->signal, VIDEO_BUF_ABORTED);
 			}
 		}
 	}
@@ -183,21 +174,18 @@ static int video_sw_generator_flush(const struct device *dev,
 	return 0;
 }
 
-static const struct video_format_cap fmts[] = {
-	{
-		.pixelformat = VIDEO_PIX_FMT_RGB565,
-		.width_min = 64,
-		.width_max = 1920,
-		.height_min = 64,
-		.height_max = 1080,
-		.width_step = 1,
-		.height_step = 1,
-	},
-	{ 0 }
-};
+static const struct video_format_cap fmts[] = {{
+						       .pixelformat = VIDEO_PIX_FMT_RGB565,
+						       .width_min = 64,
+						       .width_max = 1920,
+						       .height_min = 64,
+						       .height_max = 1080,
+						       .width_step = 1,
+						       .height_step = 1,
+					       },
+					       {0}};
 
-static int video_sw_generator_get_caps(const struct device *dev,
-				       enum video_endpoint_id ep,
+static int video_sw_generator_get_caps(const struct device *dev, enum video_endpoint_id ep,
 				       struct video_caps *caps)
 {
 	caps->format_caps = fmts;
@@ -207,8 +195,7 @@ static int video_sw_generator_get_caps(const struct device *dev,
 }
 
 #ifdef CONFIG_POLL
-static int video_sw_generator_set_signal(const struct device *dev,
-					 enum video_endpoint_id ep,
+static int video_sw_generator_set_signal(const struct device *dev, enum video_endpoint_id ep,
 					 struct k_poll_signal *signal)
 {
 	struct video_sw_generator_data *data = dev->data;
@@ -223,8 +210,7 @@ static int video_sw_generator_set_signal(const struct device *dev,
 }
 #endif
 
-static inline int video_sw_generator_set_ctrl(const struct device *dev,
-					      unsigned int cid,
+static inline int video_sw_generator_set_ctrl(const struct device *dev, unsigned int cid,
 					      void *value)
 {
 	struct video_sw_generator_data *data = dev->data;
@@ -258,7 +244,7 @@ static const struct video_driver_api video_sw_generator_driver_api = {
 static struct video_sw_generator_data video_sw_generator_data_0 = {
 	.fmt.width = 320,
 	.fmt.height = 160,
-	.fmt.pitch = 320*2,
+	.fmt.pitch = 320 * 2,
 	.fmt.pixelformat = VIDEO_PIX_FMT_RGB565,
 };
 
@@ -274,8 +260,6 @@ static int video_sw_generator_init(const struct device *dev)
 	return 0;
 }
 
-DEVICE_DEFINE(video_sw_generator, "VIDEO_SW_GENERATOR",
-		    &video_sw_generator_init, NULL,
-		    &video_sw_generator_data_0, NULL,
-		    POST_KERNEL, CONFIG_VIDEO_INIT_PRIORITY,
-		    &video_sw_generator_driver_api);
+DEVICE_DEFINE(video_sw_generator, "VIDEO_SW_GENERATOR", &video_sw_generator_init, NULL,
+	      &video_sw_generator_data_0, NULL, POST_KERNEL, CONFIG_VIDEO_INIT_PRIORITY,
+	      &video_sw_generator_driver_api);


### PR DESCRIPTION
The the video_sw_generator could not start streaming due to the wrong return value by stream_start callback. This tiny PR fixes it and also fixes the clang format.