### PR TITLE
samples: drivers: ipm: ipm_mcux: fix build command documentation

### DIFF
--- a/samples/drivers/ipm/ipm_mcux/README.rst
+++ b/samples/drivers/ipm/ipm_mcux/README.rst
@@ -28,6 +28,7 @@ Building the application for lpcxpresso54114_m4
    :zephyr-app: samples/drivers/ipm/ipm_mcux
    :board: lpcxpresso54114_m4
    :goals: debug
+   :west-args: --sysbuild
 
 
 Building the application for lpcxpresso55s69_cpu0
@@ -37,6 +38,7 @@ Building the application for lpcxpresso55s69_cpu0
    :zephyr-app: samples/drivers/ipm/ipm_mcux
    :board: lpcxpresso55s69_cpu0
    :goals: debug
+   :west-args: --sysbuild
 
 Running
 *******


### PR DESCRIPTION
Documentation for IPM MCUX sample did not provide correct command for building sample. To resolve this, add the "--sysbuild" argument to build command documentation