### PR TITLE
Add support for multi-color GPIO LEDs

### DIFF
--- a/drivers/led/led_gpio.c
+++ b/drivers/led/led_gpio.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Nordic Semiconductor ASA
+ * Copyright (c) 2024 Simon Guinot <simon.guinot@sequanux.org>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -19,24 +20,33 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(led_gpio, CONFIG_LED_LOG_LEVEL);
 
+struct led_gpio {
+	size_t num_gpios;
+	const struct gpio_dt_spec *gpio;
+};
+
 struct led_gpio_config {
 	size_t num_leds;
-	const struct gpio_dt_spec *led;
+	const struct led_gpio *led;
 };
 
 static int led_gpio_set_brightness(const struct device *dev, uint32_t led, uint8_t value)
 {
 
 	const struct led_gpio_config *config = dev->config;
-	const struct gpio_dt_spec *led_gpio;
+	const struct led_gpio *led_data;
 
 	if ((led >= config->num_leds) || (value > 100)) {
 		return -EINVAL;
 	}
 
-	led_gpio = &config->led[led];
+	led_data = &config->led[led];
 
-	return gpio_pin_set_dt(led_gpio, value > 0);
+	if (led_data->num_gpios != 1) {
+		return -ENOTSUP;
+	}
+
+	return gpio_pin_set_dt(&led_data->gpio[0], value > 0);
 }
 
 static int led_gpio_on(const struct device *dev, uint32_t led)
@@ -47,6 +57,30 @@ static int led_gpio_on(const struct device *dev, uint32_t led)
 static int led_gpio_off(const struct device *dev, uint32_t led)
 {
 	return led_gpio_set_brightness(dev, led, 0);
+}
+
+static int led_gpio_set_color(const struct device *dev, uint32_t led,
+			      uint8_t num_colors, const uint8_t *color)
+{
+	const struct led_gpio_config *config = dev->config;
+	const struct led_gpio *led_data;
+	int err = 0;
+
+	if (led >= config->num_leds) {
+		return -EINVAL;
+	}
+
+	led_data = &config->led[led];
+
+	if (led_data->num_gpios != num_colors) {
+		return -EINVAL;
+	}
+
+	for (size_t i = 0; (i < num_colors) && !err; i++) {
+		err = gpio_pin_set_dt(&led_data->gpio[i], color[i] > 0);
+	}
+
+	return err;
 }
 
 static int led_gpio_init(const struct device *dev)
@@ -60,17 +94,20 @@ static int led_gpio_init(const struct device *dev)
 	}
 
 	for (size_t i = 0; (i < config->num_leds) && !err; i++) {
-		const struct gpio_dt_spec *led = &config->led[i];
+		const struct led_gpio *led = &config->led[i];
 
-		if (device_is_ready(led->port)) {
-			err = gpio_pin_configure_dt(led, GPIO_OUTPUT_INACTIVE);
+		for (size_t j = 0; (j < led->num_gpios) && !err; j++) {
+			const struct gpio_dt_spec *gpio = &led->gpio[j];
 
-			if (err) {
-				LOG_ERR("Cannot configure GPIO (err %d)", err);
+			if (gpio_is_ready_dt(gpio)) {
+				err = gpio_pin_configure_dt(gpio, GPIO_OUTPUT_INACTIVE);
+				if (err) {
+					LOG_ERR("Cannot configure GPIO (err %d)", err);
+				}
+			} else {
+				LOG_ERR("%s: GPIO device not ready", dev->name);
+				err = -ENODEV;
 			}
-		} else {
-			LOG_ERR("%s: GPIO device not ready", dev->name);
-			err = -ENODEV;
 		}
 	}
 
@@ -81,22 +118,37 @@ static const struct led_driver_api led_gpio_api = {
 	.on		= led_gpio_on,
 	.off		= led_gpio_off,
 	.set_brightness	= led_gpio_set_brightness,
+	.set_color	= led_gpio_set_color,
 };
 
-#define LED_GPIO_DEVICE(i)					\
-								\
-static const struct gpio_dt_spec gpio_dt_spec_##i[] = {		\
-	DT_INST_FOREACH_CHILD_SEP_VARGS(i, GPIO_DT_SPEC_GET, (,), gpios) \
-};								\
-								\
-static const struct led_gpio_config led_gpio_config_##i = {	\
-	.num_leds	= ARRAY_SIZE(gpio_dt_spec_##i),	\
-	.led		= gpio_dt_spec_##i,			\
-};								\
-								\
-DEVICE_DT_INST_DEFINE(i, &led_gpio_init, NULL,			\
-		      NULL, &led_gpio_config_##i,		\
-		      POST_KERNEL, CONFIG_LED_INIT_PRIORITY,	\
+#define LED_GPIO_DT_SPEC(led_node_id)					\
+	static const struct gpio_dt_spec gpio_##led_node_id[] =	{	\
+		DT_FOREACH_PROP_ELEM_SEP(led_node_id, gpios,		\
+					 GPIO_DT_SPEC_GET_BY_IDX, (,))	\
+	};
+
+#define LED_GPIO(led_node_id)						\
+	{								\
+		.num_gpios	= DT_PROP_LEN(led_node_id, gpios),	\
+		.gpio		= gpio_##led_node_id,			\
+	},
+
+#define LED_GPIO_DEVICE(i)						\
+									\
+DT_INST_FOREACH_CHILD(i, LED_GPIO_DT_SPEC)				\
+									\
+static const struct led_gpio led_gpio_##i[] = {				\
+	DT_INST_FOREACH_CHILD(i, LED_GPIO)				\
+};									\
+									\
+static const struct led_gpio_config led_gpio_config_##i = {		\
+	.num_leds	= ARRAY_SIZE(led_gpio_##i),			\
+	.led		= led_gpio_##i,					\
+};									\
+									\
+DEVICE_DT_INST_DEFINE(i, &led_gpio_init, NULL,				\
+		      NULL, &led_gpio_config_##i,			\
+		      POST_KERNEL, CONFIG_LED_INIT_PRIORITY,		\
 		      &led_gpio_api);
 
 DT_INST_FOREACH_STATUS_OKAY(LED_GPIO_DEVICE)

--- a/dts/bindings/led/gpio-leds.yaml
+++ b/dts/bindings/led/gpio-leds.yaml
@@ -34,15 +34,11 @@ description: |
 
 compatible: "gpio-leds"
 
+include: led-controller.yaml
+
 child-binding:
   description: GPIO LED child node
   properties:
     gpios:
       type: phandle-array
       required: true
-    label:
-      type: string
-      description: |
-        Human readable string describing the LED. It can be used by an
-        application to identify this LED or to retrieve its number/index
-        (i.e. child node number) on the parent device.

--- a/dts/bindings/led/led-controller.yaml
+++ b/dts/bindings/led/led-controller.yaml
@@ -8,7 +8,10 @@ child-binding:
   properties:
     label:
       type: string
-      description: Human readable string describing the LED
+      description: |
+        Human readable string describing the LED. It can be used by an
+        application to identify this LED or to retrieve its number/index
+        (i.e. child node number) on the parent device.
     index:
       type: int
       description: |


### PR DESCRIPTION
Currently the led_gpio driver only supports RGB LEDs as three separate monochrome LEDs. Although an RGB LED is physically a single device, it must be defined in DT as three virtual LED devices.

Here is an example:

```
leds {
        compatible = "gpio-leds";

        led_0 {
                label = "Red LED";
                gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
        };
        led_1 {
                label = "Green LED";
                gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
        };
        led_2 {
                label = "Blue LED";
                gpios = <&gpio1 0 GPIO_ACTIVE_HIGH>;
        };
};
```

For users it means that `->set_brightness()` must be called three times (once for each virtual LED device) to configure an RGB LED.

This PR adds support for multi-color GPIO LEDs to the led_gpio driver and the following DT representation for an RGB GPIO LED is now supported:

```
leds {
        compatible = "gpio-leds";

        led_0 {
                label = "RGB LED";
                gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>,
                        <&gpio0 1 GPIO_ACTIVE_LOW>,
                        <&gpio1 0 GPIO_ACTIVE_HIGH>;
                color-mapping =
                        <LED_COLOR_ID_RED>,
                        <LED_COLOR_ID_GREEN>,
                        <LED_COLOR_ID_BLUE>;
        };
};
```

And `->set_color()` can now be used to set all colors at once. Note that the `color-mapping` DT property is not mandatory. This is shown in the example above because it can help users to retrieve the color from/to GPIO mapping.

Additionally, the led_gpio driver still supports RGB GPIO LEDs defined as three virtual monochrome LEDs in DT. There are no functional changes for DTS files using this representation.

And finally the new representation is not limited to RGB GPIO LEDs but can be used with any type of multi-color LEDs.

Implements https://github.com/zephyrproject-rtos/zephyr/issues/51858