### PR TITLE
net: sockets: Do not start service thread if too little resources

### DIFF
--- a/subsys/net/lib/sockets/sockets_service.c
+++ b/subsys/net/lib/sockets/sockets_service.c
@@ -195,11 +195,12 @@ static void socket_service_thread(void)
 	}
 
 	if ((count + 1) > ARRAY_SIZE(ctx.events)) {
-		NET_WARN("You have %d services to monitor but "
-			 "%zd poll entries configured.",
-			 count + 1, ARRAY_SIZE(ctx.events));
-		NET_WARN("Consider increasing value of %s to %d",
-			 "CONFIG_NET_SOCKETS_POLL_MAX", count + 1);
+		NET_ERR("You have %d services to monitor but "
+			"%zd poll entries configured.",
+			count + 1, ARRAY_SIZE(ctx.events));
+		NET_ERR("Please increase value of %s to at least %d",
+			"CONFIG_NET_SOCKETS_POLL_MAX", count + 1);
+		goto fail;
 	}
 
 	NET_DBG("Monitoring %d socket entries", count);


### PR DESCRIPTION
If the CONFIG_NET_SOCKETS_POLL_MAX is smaller than what is needed for the socket service API to work properly, then we should not start the service thread as the service API cannot work and might cause memory overwrite in ctx.events[] array.

Fixes #69233