### PR TITLE
sys: dlist: remove toolchain.h include

### DIFF
--- a/include/zephyr/sys/dlist.h
+++ b/include/zephyr/sys/dlist.h
@@ -27,7 +27,6 @@
 
 #include <stddef.h>
 #include <stdbool.h>
-#include <zephyr/toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
This header file is not used anywhere in the implementation, so drop it.