### PR TITLE
net: zperf: Select also sockets API in Kconfig

### DIFF
--- a/subsys/net/lib/zperf/Kconfig
+++ b/subsys/net/lib/zperf/Kconfig
@@ -6,6 +6,7 @@ menuconfig NET_ZPERF
 	bool "zperf shell utility"
 	select NET_CONTEXT_RCVTIMEO if NET_NATIVE_UDP
 	select NET_SOCKETS_SERVICE
+	select NET_SOCKETS
 	help
 	  This option enables zperf shell utility, which allows to generate
 	  network traffic and evaluate network bandwidth.


### PR DESCRIPTION
We select sockets service API in Kconfig but should select also sockets API so that user does not need to set the sockets API separately.