### PR TITLE
net: socket: Start socket service earlier

### DIFF
--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -117,7 +117,7 @@ config NET_SOCKETS_SERVICE_STACK_SIZE
 
 config NET_SOCKETS_SERVICE_INIT_PRIO
 	int "Startup priority for the network socket service"
-	default 95
+	default 90
 	depends on NET_SOCKETS_SERVICE
 
 config NET_SOCKETS_SOCKOPT_TLS


### PR DESCRIPTION
Make sure that socket service is started earlier than config library. This is enforced in config libs init.c but set the default value here too.
The reason for this is that the config library might need to start dhcpv4 server which needs socket service to work, so the ordering is important here.