### PR TITLE
Fix IPv4 TTL and IPv6 hoplimit setter/getter usage

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -3165,6 +3165,10 @@ uint8_t net_if_ipv4_get_ttl(struct net_if *iface)
 
 	net_if_lock(iface);
 
+	if (net_if_config_ipv4_get(iface, NULL) < 0) {
+		goto out;
+	}
+
 	if (!iface->config.ip.ipv4) {
 		goto out;
 	}
@@ -3186,6 +3190,10 @@ void net_if_ipv4_set_ttl(struct net_if *iface, uint8_t ttl)
 #if defined(CONFIG_NET_NATIVE_IPV4)
 	net_if_lock(iface);
 
+	if (net_if_config_ipv4_get(iface, NULL) < 0) {
+		goto out;
+	}
+
 	if (!iface->config.ip.ipv4) {
 		goto out;
 	}
@@ -3205,6 +3213,10 @@ uint8_t net_if_ipv4_get_mcast_ttl(struct net_if *iface)
 	int ret = 0;
 
 	net_if_lock(iface);
+
+	if (net_if_config_ipv4_get(iface, NULL) < 0) {
+		goto out;
+	}
 
 	if (!iface->config.ip.ipv4) {
 		goto out;
@@ -3226,6 +3238,10 @@ void net_if_ipv4_set_mcast_ttl(struct net_if *iface, uint8_t ttl)
 {
 #if defined(CONFIG_NET_NATIVE_IPV4)
 	net_if_lock(iface);
+
+	if (net_if_config_ipv4_get(iface, NULL) < 0) {
+		goto out;
+	}
 
 	if (!iface->config.ip.ipv4) {
 		goto out;

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -2649,6 +2649,10 @@ uint8_t net_if_ipv6_get_mcast_hop_limit(struct net_if *iface)
 
 	net_if_lock(iface);
 
+	if (net_if_config_ipv6_get(iface, NULL) < 0) {
+		goto out;
+	}
+
 	if (!iface->config.ip.ipv6) {
 		goto out;
 	}
@@ -2670,6 +2674,10 @@ void net_if_ipv6_set_mcast_hop_limit(struct net_if *iface, uint8_t hop_limit)
 #if defined(CONFIG_NET_NATIVE_IPV6)
 	net_if_lock(iface);
 
+	if (net_if_config_ipv6_get(iface, NULL) < 0) {
+		goto out;
+	}
+
 	if (!iface->config.ip.ipv6) {
 		goto out;
 	}
@@ -2689,6 +2697,10 @@ uint8_t net_if_ipv6_get_hop_limit(struct net_if *iface)
 	int ret = 0;
 
 	net_if_lock(iface);
+
+	if (net_if_config_ipv6_get(iface, NULL) < 0) {
+		goto out;
+	}
 
 	if (!iface->config.ip.ipv6) {
 		goto out;
@@ -2710,6 +2722,10 @@ void net_if_ipv6_set_hop_limit(struct net_if *iface, uint8_t hop_limit)
 {
 #if defined(CONFIG_NET_NATIVE_IPV6)
 	net_if_lock(iface);
+
+	if (net_if_config_ipv6_get(iface, NULL) < 0) {
+		goto out;
+	}
 
 	if (!iface->config.ip.ipv6) {
 		goto out;


### PR DESCRIPTION
Before accessing the IPv4 config (for TTL) or IPv6 config (for hoplimit), make sure that the network interface has enabled the IPv4 or IPv6.