### PR TITLE
drivers: ethernet: Disable drivers if tests are enabled

### DIFF
--- a/drivers/ethernet/Kconfig
+++ b/drivers/ethernet/Kconfig
@@ -7,6 +7,7 @@ menuconfig ETH_DRIVER
 	bool "Ethernet drivers"
 	default y
 	depends on NET_L2_ETHERNET
+	depends on !NET_TEST
 
 if ETH_DRIVER
 


### PR DESCRIPTION
The network tests at tests/net use simulated network interfaces and set CONFIG_NET_TEST to indicate that. If the config option is set, then we do not want any extra Ethernet driver to complicate the testing scenario so all external Ethernet network interfaces should be disabled.