### PR TITLE
Bluetooth: audio: BAP: check for NULL parameter

### DIFF
--- a/subsys/bluetooth/audio/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/bap_broadcast_assistant.c
@@ -337,6 +337,12 @@ static uint8_t notify_handler(struct bt_conn *conn,
 	struct bt_bap_scan_delegator_recv_state recv_state;
 	int16_t index;
 
+	if (conn == NULL) {
+		LOG_DBG("conn is NULL");
+
+		return BT_GATT_ITER_STOP;
+	}
+
 	if (data == NULL) {
 		LOG_DBG("[UNSUBSCRIBED] %u", handle);
 		params->value_handle = 0U;
@@ -360,11 +366,7 @@ static uint8_t notify_handler(struct bt_conn *conn,
 		/* Cancel any pending long reads containing now obsolete information */
 		(void)k_work_cancel_delayable(&broadcast_assistant.bap_read_work);
 
-		if (conn != NULL) {
-			max_ntf_size = bt_gatt_get_mtu(conn) - att_ntf_header_size;
-		} else {
-			max_ntf_size = MIN(BT_L2CAP_RX_MTU, BT_L2CAP_TX_MTU) - att_ntf_header_size;
-		}
+		max_ntf_size = bt_gatt_get_mtu(conn) - att_ntf_header_size;
 
 		if (length == max_ntf_size) {
 			/* TODO: if we are busy we should not overwrite the long_read_handle,


### PR DESCRIPTION
When entering the notify handler *conn may not be NULL. This PR adds a check for *conn being NULL, and always calculates the maximum notification size based on actual MTU size

This also fixes coverity issue 347167

fixes #69136