### PR TITLE
boards: stm32wb: Restore missing .defconfig file

### DIFF
--- a/boards/st/nucleo_wb55rg/Kconfig.defconfig
+++ b/boards/st/nucleo_wb55rg/Kconfig.defconfig
@@ -1,0 +1,13 @@
+# STM32WB55RG Nucleo board configuration
+
+# Copyright (c) 2019 Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_NUCLEO_WB55RG
+
+choice BT_HCI_BUS_TYPE
+	default BT_STM32_IPM
+	depends on BT
+endchoice
+
+endif

--- a/boards/st/stm32wb5mm_dk/Kconfig.defconfig
+++ b/boards/st/stm32wb5mm_dk/Kconfig.defconfig
@@ -1,0 +1,13 @@
+# STM32WB5MM-DK Discovery Development board configuration
+
+# Copyright (c) 2024 Javad Rahimipetroudi <javad.rahimipetroudi@mind.be>
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_STM32WB5MM_DK
+
+choice BT_HCI_BUS_TYPE
+	default BT_STM32_IPM
+	depends on BT
+endchoice
+
+endif

--- a/boards/st/stm32wb5mmg/Kconfig.defconfig
+++ b/boards/st/stm32wb5mmg/Kconfig.defconfig
@@ -1,0 +1,13 @@
+# STM32WB5MMG Bluetooth module board configuration
+
+# Copyright (c) 2024 Javad Rahimipetroudi <javad.rahimipetroudi@mind.be>
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_STM32WB5MMG
+
+choice BT_HCI_BUS_TYPE
+	default BT_STM32_IPM
+	depends on BT
+endchoice
+
+endif


### PR DESCRIPTION
Kconfig.defconfig file has been lost during migration. Put them back.