### PR TITLE
doc: release-notes-3.6: Add note on GRLIB SPIMCTRL driver

### DIFF
--- a/doc/releases/release-notes-3.6.rst
+++ b/doc/releases/release-notes-3.6.rst
@@ -679,6 +679,7 @@ Drivers and Sensors
   * On STM32H7 devices, ``fifo-enable`` property allows using SPI block FIFO. This
     feature is still experimental and requires maturation.
   * On STM32 devices impacted by BSY bit erratum, a workaround is implemented.
+  * Added driver for GRLIB SPIMCTRL
 
 * Timer
 


### PR DESCRIPTION
The GRLIB SPIMCTRL SPI device driver was added in commit e13d4a14df18a9e40b50cfbbde66dec38e6ac844.