### PR TITLE
boards: arm: fix gpio-led flags on adi_eval_adin1110ebz/adin2111ebz

### DIFF
--- a/boards/adi/eval_adin1110ebz/adi_eval_adin1110ebz.dts
+++ b/boards/adi/eval_adin1110ebz/adi_eval_adin1110ebz.dts
@@ -34,19 +34,19 @@
 	leds { /* Respecting pcb silkscreen naming */
 		compatible = "gpio-leds";
 		green_led: led_uC0 {
-			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;
 			label = "Status uC0";
 		};
 		red_led: led_uC1 {
-			gpios = <&gpioe 2 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpioe 2 GPIO_ACTIVE_LOW>;
 			label = "Status uC1 ";
 		};
 		yellow_led: led_uC2 {
-			gpios = <&gpioe 6 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpioe 6 GPIO_ACTIVE_LOW>;
 			label = "Status uC2";
 		};
 		blue_led: led_uC3 {
-			gpios = <&gpiog 15 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpiog 15 GPIO_ACTIVE_LOW>;
 			label = "Status uC3";
 		};
 	};

--- a/boards/adi/eval_adin2111ebz/adi_eval_adin2111ebz.dts
+++ b/boards/adi/eval_adin2111ebz/adi_eval_adin2111ebz.dts
@@ -24,23 +24,23 @@
 	leds {
 		compatible = "gpio-leds";
 		blue_led: uC_led1 {
-			gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpiob 6 GPIO_ACTIVE_LOW>;
 			label = "Debug led uC1";
 		};
 		net_red_led: led_NET1 {
-			gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpiob 10 GPIO_ACTIVE_LOW>;
 			label = "NET led 1";
 		};
 		net_green_led: led_NET2 {
-			gpios = <&gpiob 11 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpiob 11 GPIO_ACTIVE_LOW>;
 			label = "NET led 2";
 		};
 		mod_red_led: led_MOD1 {
-			gpios = <&gpioe 2 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpioe 2 GPIO_ACTIVE_LOW>;
 			label = "Mod led 1";
 		};
 		mod_green_led: led_MOD2 {
-			gpios = <&gpioe 6 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpioe 6 GPIO_ACTIVE_LOW>;
 			label = "Mod led 2";
 		};
 	};


### PR DESCRIPTION
This board's user LEDs are active-LOW, instead of active-HIGH

![image](https://github.com/zephyrproject-rtos/zephyr/assets/54812204/0d74d490-4bc1-46d0-a31d-75d64865a2be) ![image](https://github.com/zephyrproject-rtos/zephyr/assets/54812204/c627cc03-6fe5-4337-a5e9-8bcc99dbf5d2)
(adi_eval_adin1110ebz) (adi_eval_adin2111ebz)
