### PR TITLE
drivers: flash: at45: workaround for weird at45 devices

### DIFF
--- a/dts/bindings/mtd/atmel,at45.yaml
+++ b/dts/bindings/mtd/atmel,at45.yaml
@@ -45,11 +45,28 @@ properties:
     required: true
     description: Flash page size in bytes.
 
-  use-alternate-rw:
+  workaround-broken-read-01H:
     type: boolean
     description: |
-      Some AT45 flash chips do not support the regular read/write commands. If set,
-      the driver will perform read/write with an alternative set of commands.
+      You may encounter AT45 flash chips that are expected to support the 01H read opcode
+      [Continuous Array Read (Low Power Mode)] but it doesn't. If set, the driver will read with
+      0BH opcode [Continuous Array Read (High Frequency Mode)] instead.
+
+  workaround-broken-modify-58H:
+    type: boolean
+    description: |
+      You may encounter AT45 flash chips that are expected to support the 58H modify opcode
+      [Read-Modify-Write] but it doesn't. If set, the driver will modify by first doing
+      82H opcode [Main Memory Page Program Through Buffer 1] then 53H opcode
+      [Main Memory Page to Buffer 1 Transfer] instead.
+
+  workaround-broken-write-02H:
+    type: boolean
+    description: |
+      You may encounter AT45 flash chips that are expected to support the 02H write opcode
+      [Main Memory Byte/Page Program through Buffer 1 without Built-In Erase] but it doesn't.
+      If set, the driver will write by first doing 84H opcode [Buffer 1 write] then 88H opcode
+      [Buffer 1 to Main Memory Page Program without Built-In Erase] instead.
 
   no-chip-erase:
     type: boolean

--- a/dts/bindings/mtd/atmel,at45.yaml
+++ b/dts/bindings/mtd/atmel,at45.yaml
@@ -45,6 +45,12 @@ properties:
     required: true
     description: Flash page size in bytes.
 
+  use-alternate-rw:
+    type: boolean
+    description: |
+      Some AT45 flash chips do not support the regular read/write commands. If set,
+      the driver will perform read/write with an alternative set of commands.
+
   no-chip-erase:
     type: boolean
     description: |


### PR DESCRIPTION
I have some AT45DB321E flash lying around in my drawer (for years) that do not seem to work with the read, write & modify opcodes used in the existing driver.

This PR worksaround that by using a different opcode for `read`. The `write`/`modify` commands are convenience commands that combine 2 operations, this patch workaround that by performing those 2 operations manually.

## read

![image](https://github.com/zephyrproject-rtos/zephyr/assets/1563974/79ebed10-da7a-441f-ac8f-3fc688d68b90)

## write

![image](https://github.com/zephyrproject-rtos/zephyr/assets/1563974/b319dd1f-3a40-4d04-837f-08cc15e2dc1d)

![image](https://github.com/zephyrproject-rtos/zephyr/assets/1563974/47bd42e0-604a-4e40-879a-130bc9cf70e7)

## modify
![image](https://github.com/zephyrproject-rtos/zephyr/assets/1563974/60a68701-b7c0-428c-b3f5-b4bdd1f903e9)

![image](https://github.com/zephyrproject-rtos/zephyr/assets/1563974/a5a9640e-5bab-4b03-af43-af40e1f2edf5)
![image](https://github.com/zephyrproject-rtos/zephyr/assets/1563974/b1c6e380-1de5-464a-8f33-b81225fae032)



With this PR:
```
*** Booting Zephyr OS build v3.6.0-rc3 ***
DataFlash sample on nucleo_g0b1re
Using at45db321e@0, chip size: 4194304 bytes (page: 512)
Reading the first byte of the test region ... OK
Preparing test content starting with 0x20.
Writing the first half of the test region... OK
Writing the second half of the test region... OK
Reading the whole test region... OK
Checking the read content... OK
Putting the flash device into suspended state... OK
```

without:
```
*** Booting Zephyr OS build v3.6.0-rc3-1-ga8b60629a098 ***
DataFlash sample on nucleo_g0b1re
Using at45db321e@0, chip size: 4194304 bytes (page: 512)
Reading the first byte of the test region ... OK
Preparing test content starting with 0x01.
Writing the first half of the test region... OK
Writing the second half of the test region... OK
Reading the whole test region... OK
Checking the read content... 
ERROR at read_buf[0]: expected 0x01, got 0x00
```