### PR TITLE
bluetooth: series of fix typo in multiple directories

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -442,7 +442,7 @@ static void ase_exit_state_enabling(struct bt_ascs_ase *ase)
 
 	/*
 	 * When the EP direction is BT_AUDIO_DIR_SOURCE the state machine goes from
-	 * enabled to disabled where the disabled calback will be called,
+	 * enabled to disabled where the disabled callback will be called,
 	 * for BT_AUDIO_DIR_SINK we go from enabled to qos_configured,
 	 * and logically we have to do the disabled callback first
 	 */

--- a/subsys/bluetooth/audio/bap_iso.c
+++ b/subsys/bluetooth/audio/bap_iso.c
@@ -187,7 +187,7 @@ void bt_bap_iso_configure_data_path(struct bt_bap_ep *ep, struct bt_audio_codec_
 	}
 
 	/* Configure the data path to either use the controller for transcoding, or set the path to
-	 * be transparant to indicate that the transcoding happens somewhere else
+	 * be transparent to indicate that the transcoding happens somewhere else
 	 */
 	path->pid = codec_cfg->path_id;
 

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -1658,7 +1658,7 @@ static void pac_record_cb(struct bt_conn *conn, const struct bt_audio_codec_cap 
 		struct unicast_client *client = &uni_cli_insts[bt_conn_index(conn)];
 		const enum bt_audio_dir dir = client->dir;
 
-		/* TBD: Since the PAC records are optionally notifyable we may want to supply the
+		/* TBD: Since the PAC records are optionally notifiable we may want to supply the
 		 * index and total count of records in the callback, so that it easier for the
 		 * upper layers to determine when a new set of PAC records is being reported.
 		 */
@@ -2174,7 +2174,7 @@ static int bt_audio_cig_create(struct bt_bap_unicast_group *group,
 	cis_count = 0U;
 	for (size_t i = 0U; i < ARRAY_SIZE(group->cis); i++) {
 		if (group->cis[i] == NULL) {
-			/* A NULL CIS acts as a NULL terminater */
+			/* A NULL CIS acts as a NULL terminator */
 			break;
 		}
 
@@ -2208,7 +2208,7 @@ static int bt_audio_cig_reconfigure(struct bt_bap_unicast_group *group,
 	cis_count = 0U;
 	for (size_t i = 0U; i < ARRAY_SIZE(group->cis); i++) {
 		if (group->cis[i] == NULL) {
-			/* A NULL CIS acts as a NULL terminater */
+			/* A NULL CIS acts as a NULL terminator */
 			break;
 		}
 

--- a/subsys/bluetooth/audio/cap_initiator.c
+++ b/subsys/bluetooth/audio/cap_initiator.c
@@ -98,7 +98,7 @@ static bool data_func_cb(struct bt_data *data, void *user_data)
 			const uint8_t ccid = data->data[i];
 
 			if (bt_ccid_find_attr(ccid) == NULL) {
-				LOG_DBG("Unknown characterstic for CCID 0x%02X", ccid);
+				LOG_DBG("Unknown characteristic for CCID 0x%02X", ccid);
 				metadata_param->valid = false;
 
 				return false;

--- a/subsys/bluetooth/audio/media_proxy.c
+++ b/subsys/bluetooth/audio/media_proxy.c
@@ -241,7 +241,7 @@ static void mcc_discover_mcs_cb(struct bt_conn *conn, int err)
 		LOG_ERR("Discovery failed (%d)", err);
 	}
 
-	LOG_DBG("Disovered player");
+	LOG_DBG("Discovered player");
 
 	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->discover_player) {
 		mprx.ctrlr.cbs->discover_player(&mprx.remote_player, err);

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -1260,7 +1260,7 @@ static int cmd_config(const struct shell *sh, size_t argc, char *argv[])
 	uni_stream = shell_stream_from_bap_stream(bap_stream);
 	copy_unicast_stream_preset(uni_stream, named_preset);
 
-	/* If location has been modifed, we update the location in the codec configuration */
+	/* If location has been modified, we update the location in the codec configuration */
 	struct bt_audio_codec_cfg *codec_cfg = &uni_stream->codec_cfg;
 
 	for (size_t i = 0U; i < codec_cfg->data_len;) {

--- a/subsys/bluetooth/audio/shell/micp_mic_ctlr.c
+++ b/subsys/bluetooth/audio/shell/micp_mic_ctlr.c
@@ -116,7 +116,7 @@ static void micp_mic_ctlr_aics_set_manual_mode_cb(struct bt_aics *inst, int err)
 			    "Set manual mode failed (%d) for inst %p",
 			    err, inst);
 	} else {
-		shell_print(ctx_shell, "Manuel mode set for inst %p", inst);
+		shell_print(ctx_shell, "Manual mode set for inst %p", inst);
 	}
 }
 

--- a/subsys/bluetooth/audio/shell/vcp_vol_ctlr.c
+++ b/subsys/bluetooth/audio/shell/vcp_vol_ctlr.c
@@ -163,7 +163,7 @@ static void vcs_aics_set_manual_mode_cb(struct bt_aics *inst, int err)
 			    "Set manual mode failed (%d) for inst %p",
 			    err, inst);
 	} else {
-		shell_print(ctx_shell, "Manuel mode set for inst %p", inst);
+		shell_print(ctx_shell, "Manual mode set for inst %p", inst);
 	}
 }
 

--- a/subsys/bluetooth/audio/tbs_client.c
+++ b/subsys/bluetooth/audio/tbs_client.c
@@ -1554,14 +1554,14 @@ static uint8_t discover_func(struct bt_conn *conn,
 				err = bt_gatt_subscribe(conn, sub_params);
 				if (err != 0 && err != -EALREADY) {
 					LOG_DBG("Could not subscribe to "
-					       "characterstic at handle 0x%04X"
+					       "characteristic at handle 0x%04X"
 					       "(%d)",
 					       sub_params->value_handle, err);
 					tbs_client_discover_complete(conn, err);
 
 					return BT_GATT_ITER_STOP;
 				} else {
-					LOG_DBG("Subscribed to characterstic at "
+					LOG_DBG("Subscribed to characteristic at "
 					       "handle 0x%04X",
 					       sub_params->value_handle);
 				}

--- a/subsys/bluetooth/audio/tmap.c
+++ b/subsys/bluetooth/audio/tmap.c
@@ -63,7 +63,7 @@ uint8_t tmap_char_read(struct bt_conn *conn, uint8_t err,
 		return BT_GATT_ITER_STOP;
 	}
 
-	/* Extract the TMAP role of the peer and inform application fo the value found */
+	/* Extract the TMAP role of the peer and inform application of the value found */
 	peer_role = sys_get_le16(data);
 
 	if ((peer_role > 0U) && (peer_role <= TMAP_ALL_ROLES)) {

--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -198,7 +198,7 @@ config BT_HCI_VS_FATAL_ERROR
 	bool "Allow vendor specific HCI event Zephyr Fatal Error"
 	depends on BT_HCI_VS
 	help
-	  Enable emiting HCI Vendor-Specific events for system and Controller
+	  Enable emitting HCI Vendor-Specific events for system and Controller
 	  errors that are unrecoverable.
 
 config BT_HCI_VS_EXT_DETECT

--- a/subsys/bluetooth/controller/Kconfig.df
+++ b/subsys/bluetooth/controller/Kconfig.df
@@ -317,7 +317,7 @@ config BT_CTLR_DF_VS_CL_IQ_REPORT_16_BITS_IQ_SAMPLES
 	  Direction Finging connectionless IQ reports provide a set of IQ samples collected during
 	  sampling of CTE. Bluetooth 5.3 Core Specification defines IQ samples to be 8 bits signed
 	  integer, see Vol 4, Part E section 7.7.65.21. This option enables a vendor specific
-	  extenstion to HCI layer, so that connectionless IQ reports store samples in 16 bit signed
+	  extension to HCI layer, so that connectionless IQ reports store samples in 16 bit signed
 	  integer format.
 
 config BT_CTLR_DF_VS_CONN_IQ_REPORT_16_BITS_IQ_SAMPLES
@@ -327,7 +327,7 @@ config BT_CTLR_DF_VS_CONN_IQ_REPORT_16_BITS_IQ_SAMPLES
 	  Direction Finging connection IQ reports provide a set of IQ samples collected during
 	  sampling of CTE. Bluetooth 5.3 Core Specification defines IQ samples to be 8 bits signed
 	  integer, see Vol 4, Part E section 7.7.65.22. This option enables a vendor specific
-	  extenstion to HCI layer, so that connection IQ reports store samples in 16 bit signed
+	  extension to HCI layer, so that connection IQ reports store samples in 16 bit signed
 	  integer format.
 
 endif # BT_LL_SW_SPLIT

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -3130,7 +3130,7 @@ static void le_df_connection_iq_report(struct node_rx_pdu *node_rx, struct net_b
 #endif /* CONFIG_BT_CTLR_PHY */
 
 	/* TX LL thread has higher priority than RX thread. It may happen that host succefully
-	 * disables CTE sampling in the meantime. It should be verified here, to avoid reporing
+	 * disables CTE sampling in the meantime. It should be verified here, to avoid reporting
 	 * IQ samples after the functionality was disabled.
 	 */
 	if (ull_df_conn_cfg_is_not_enabled(&lll->df_rx_cfg)) {
@@ -5256,7 +5256,7 @@ static void vs_le_df_connection_iq_report(struct node_rx_pdu *node_rx, struct ne
 #endif /* CONFIG_BT_CTLR_PHY */
 
 	/* TX LL thread has higher priority than RX thread. It may happen that host succefully
-	 * disables CTE sampling in the meantime. It should be verified here, to avoid reporing
+	 * disables CTE sampling in the meantime. It should be verified here, to avoid reporting
 	 * IQ samples after the functionality was disabled.
 	 */
 	if (ull_df_conn_cfg_is_not_enabled(&lll->df_rx_cfg)) {
@@ -5767,7 +5767,7 @@ int hci_iso_handle(struct net_buf *buf, struct net_buf **evt)
 		sdu_frag_tx.iso_sdu_length = 0;
 	}
 
-	/* Packet boudary flags should be bitwise identical to the SDU state
+	/* Packet boundary flags should be bitwise identical to the SDU state
 	 * 0b00 BT_ISO_START
 	 * 0b01 BT_ISO_CONT
 	 * 0b10 BT_ISO_SINGLE
@@ -7353,7 +7353,7 @@ no_ext_hdr:
 	/* Clear the data status bits */
 	evt_type &= ~(BIT_MASK(2) << 5);
 
-	/* Allocate, append as buf fragement and construct the scan response
+	/* Allocate, append as buf fragment and construct the scan response
 	 * event.
 	 */
 	evt_buf = bt_buf_get_rx(BT_BUF_EVT, BUF_GET_TIMEOUT);

--- a/subsys/bluetooth/controller/ll_sw/isoal.c
+++ b/subsys/bluetooth/controller/ll_sw/isoal.c
@@ -923,7 +923,7 @@ static isoal_status_t isoal_rx_unframed_consume(struct isoal_sink *sink,
 	 *     Request for Clarification - Recombination actions when only
 	 *     padding unframed PDUs are received:
 	 *     The clarification was to be rejected, but the discussion in the
-	 *     comments from March 3rd 2023 were interpretted as "We are
+	 *     comments from March 3rd 2023 were interpreted as "We are
 	 *     expecting a PDU which ISOAL should convert into an SDU;
 	 *     instead we receive a padding PDU, which we cannot turn into a
 	 *     SDU, so the SDU wasn't received at all, and should be reported
@@ -1159,7 +1159,7 @@ static isoal_status_t isoal_rx_framed_consume(struct isoal_sink *sink,
 
 	if (pdu_padding && !pdu_err && !seq_err) {
 		/* Check and release missed SDUs on receiving padding PDUs */
-		ISOAL_LOG_DBGV("[%p] Recevied padding", sink);
+		ISOAL_LOG_DBGV("[%p] Received padding", sink);
 		err |= isoal_rx_framed_release_lost_sdus(sink, pdu_meta, false, timestamp);
 	}
 
@@ -1670,12 +1670,12 @@ static bool isoal_is_time_stamp_valid(const struct isoal_source *source_ctx,
 
 /**
  * Queue the PDU in production in the relevant LL transmit queue. If the
- * attmept to release the PDU fails, the buffer linked to the PDU will be released
+ * attempt to release the PDU fails, the buffer linked to the PDU will be released
  * and it will not be possible to retry the emit operation on the same PDU.
  * @param[in]  source_ctx        ISO-AL source reference for this CIS / BIS
  * @param[in]  produced_pdu      PDU in production
  * @param[in]  pdu_ll_id         LLID to be set indicating the type of fragment
- * @param[in]  sdu_fragments     Nummber of SDU HCI fragments consumed
+ * @param[in]  sdu_fragments     Number of SDU HCI fragments consumed
  * @param[in]  payload_number    CIS / BIS payload number
  * @param[in]  payload_size      Length of the data written to the PDU
  * @return     Error status of the operation
@@ -2032,7 +2032,7 @@ static isoal_status_t isoal_tx_unframed_produce(isoal_source_handle_t source_hdl
 
 		/* Get group reference point for this PDU based on the actual
 		 * event being set. This might introduce some errors as the
-		 * group refernce point for future events could drift. However
+		 * group reference point for future events could drift. However
 		 * as the time offset calculation requires an absolute value,
 		 * this seems to be the best candidate.
 		 */
@@ -2245,7 +2245,7 @@ static isoal_status_t isoal_insert_seg_header_timeoffset(struct isoal_source *so
 }
 
 /**
- * @breif  Updates the cmplt flag and length in the last segmentation header written
+ * @brief  Updates the cmplt flag and length in the last segmentation header written
  * @param  source     source handle
  * @param  cmplt      ew value for complete flag
  * param   add_length length to add
@@ -2325,7 +2325,7 @@ static uint16_t isoal_tx_framed_find_correct_tx_event(const struct isoal_source 
 
 	/* Get the drift updated group reference point for this event based on
 	 * the actual event being set. This might introduce some errors as the
-	 * group refernce point for future events could drift. However as the
+	 * group reference point for future events could drift. However as the
 	 * time offset calculation requires an absolute value, this seems to be
 	 * the best candidate.
 	 */
@@ -2376,7 +2376,7 @@ static uint16_t isoal_tx_framed_find_correct_tx_event(const struct isoal_source 
 
 			if (time_stamp_is_valid) {
 				/* Use provided time stamp for time offset
-				 * calcutation
+				 * calculation
 				 */
 				time_stamp_selected = tx_sdu->time_stamp;
 				ISOAL_LOG_DBGV("[%p] Selecting Time Stamp (%lu) from SDU",
@@ -2806,7 +2806,7 @@ static isoal_status_t isoal_tx_framed_event_prepare_handle(isoal_source_handle_t
  * @details Fragmentation will occur individually for every enabled source
  *
  * @param source_hdl[in] Handle of destination source
- * @param tx_sdu[in]     SDU along with packet boudary state
+ * @param tx_sdu[in]     SDU along with packet boundary state
  * @return Status
  */
 isoal_status_t isoal_tx_sdu_fragment(isoal_source_handle_t source_hdl,

--- a/subsys/bluetooth/controller/ll_sw/lll_sync.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_sync.h
@@ -70,7 +70,7 @@ struct lll_sync {
 	 * generation.
 	 */
 	struct node_rx_iq_report *node_cte_incomplete;
-	/* Member sotres information if there were insufficient IQ report rx nodes for all CTEs
+	/* Member stores information if there were insufficient IQ report rx nodes for all CTEs
 	 * in pending synchronization event.
 	 */
 	bool is_cte_incomplete;

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_df.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_df.h
@@ -33,9 +33,9 @@ void radio_df_cte_tx_aod_2us_set(uint8_t cte_len);
 void radio_df_cte_tx_aod_4us_set(uint8_t cte_len);
 /* Configure CTE transmission with for AoA. */
 void radio_df_cte_tx_aoa_set(uint8_t cte_len);
-/* Configure CTE reception with optionall AoA mode and 2us antenna switching. */
+/* Configure CTE reception with optional AoA mode and 2us antenna switching. */
 void radio_df_cte_rx_2us_switching(bool cte_info_in_s1, uint8_t phy);
-/* Configure CTE reception with optionall AoA mode and 4us antenna switching. */
+/* Configure CTE reception with optional AoA mode and 4us antenna switching. */
 void radio_df_cte_rx_4us_switching(bool cte_info_in_s1, uint8_t phy);
 
 /* Clears antenna switch pattern. */

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_dppi.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_dppi.h
@@ -638,9 +638,9 @@ static inline void hal_radio_group_task_disable_ppi_setup(void)
  * Radio peripheral. The EVENTS_CTEPRESENT event is wired to cancel EVENTS_COMPARE setup for
  * handling delayed EVENTS_PHYEND.
  *
- * Disable of the group of PPIs responsbile for handling of software based switch is done by
+ * Disable of the group of PPIs responsible for handling of software based switch is done by
  * timeout of regular EVENTS_PHYEND event. The EVENTS_PHYEND delay is short enough (16 us) that
- * the same EVENT COMPARE may be used to trigger disable task for the sotfware switch group.
+ * the same EVENT COMPARE may be used to trigger disable task for the software switch group.
  * In case the EVENTS_COMPARE for delayed EVENTS_PHYEND event timeouts, the group will be disabled
  * within the Radio TX rampup period.
  *

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi.h
@@ -399,7 +399,7 @@ static inline void hal_radio_b2b_txen_on_sw_switch(uint8_t compare_reg_index,
 {
 	/* NOTE: As independent PPI are used to trigger the Radio Tx task,
 	 *       double buffers implementation works for sw_switch using PPIs,
-	 *       simply reuse the hal_radio_txen_on_sw_switch() functon to set
+	 *       simply reuse the hal_radio_txen_on_sw_switch() function to set
 	 *	 the next PPIs task to be Radio Tx enable.
 	 */
 	hal_radio_txen_on_sw_switch(compare_reg_index, radio_enable_ppi);
@@ -425,7 +425,7 @@ static inline void hal_radio_b2b_rxen_on_sw_switch(uint8_t compare_reg_index,
 {
 	/* NOTE: As independent PPI are used to trigger the Radio Tx task,
 	 *       double buffers implementation works for sw_switch using PPIs,
-	 *       simply reuse the hal_radio_txen_on_sw_switch() functon to set
+	 *       simply reuse the hal_radio_txen_on_sw_switch() function to set
 	 *	 the next PPIs task to be Radio Tx enable.
 	 */
 	hal_radio_rxen_on_sw_switch(compare_reg_index, radio_enable_ppi);
@@ -565,7 +565,7 @@ static inline void hal_radio_group_task_disable_ppi_setup(void)
 #define SW_SWITCH_TIMER_PHYEND_DELAY_COMPENSATION_EVTS_COMP(index) \
 	(SW_SWITCH_TIMER_EVTS_COMP_PHYEND_DELAY_COMPENSATION_BASE + (index))
 /* Wire the SW SWITCH PHYEND delay compensation TIMER EVENTS_COMPARE[<cc_offset>] event to software
- * switch TIMER0->CLEAR taks task.
+ * switch TIMER0->CLEAR task.
  */
 #define HAL_SW_SWITCH_RADIO_ENABLE_PHYEND_DELAY_COMPENSATION_PPI(index) \
 	(HAL_SW_SWITCH_RADIO_ENABLE_PHYEND_DELAY_COMPENSATION_PPI_BASE + (index))
@@ -590,7 +590,7 @@ static inline void hal_radio_group_task_disable_ppi_setup(void)
  * Radio peripheral. The EVENTS_CTEPRESENT event is wired to cancel EVENTS_COMPARE setup for
  * handling delayed EVENTS_PHYEND.
  *
- * Disable of the group of PPIs responsbile for handling of software based switch is done by
+ * Disable of the group of PPIs responsible for handling of software based switch is done by
  * timeout of regular EVENTS_PHYEND event. The EVENTS_PHYEND delay is short enough (16 us) that
  * it can use the same PPI to trigger disable the group for timeout for both EVENTS_COMPAREs.
  * In case the EVENTS_COMPARE for delayed EVENTS_PHYEND event timesout, the group will be disabled

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi_resources.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi_resources.h
@@ -163,18 +163,18 @@
 
 #if defined(CONFIG_BT_CTLR_DF_PHYEND_OFFSET_COMPENSATION_ENABLE)
 /* Wire the SW SWITCH PHYEND delay compensation TIMER EVENTS_COMPARE[<cc_offset>] event to software
- * switch TIMER0->CLEAR taks task.
+ * switch TIMER0->CLEAR task.
  *
- * Note: Use the same nubmer of PPIs as for PHY CODED HAL_SW_SWITCH_RADIO_ENABLE_S2_PPI_BASE.
- *       The CTE is not allowe in PDUs sent over PHY CODED so this PPI may be re-used.
+ * Note: Use the same number of PPIs as for PHY CODED HAL_SW_SWITCH_RADIO_ENABLE_S2_PPI_BASE.
+ *       The CTE is not allowed in PDUs sent over PHY CODED so this PPI may be re-used.
  */
 #define HAL_SW_SWITCH_RADIO_ENABLE_PHYEND_DELAY_COMPENSATION_PPI_BASE 17
 
 /* Cancel the SW switch timer running considering PHYEND delay compensation timing:
  * wire the RADIO EVENTS_CTEPRESENT event to SW_SWITCH_TIMER TASKS_CAPTURE task.
  *
- * Note: Use the same nubmer of PPIs as for PHY CODED: HAL_SW_SWITCH_TIMER_S8_DISABLE_PPI.
- *       The CTE is not allowe in PDUs sent over PHY CODED so this PPI may be re-used.
+ * Note: Use the same number of PPIs as for PHY CODED: HAL_SW_SWITCH_TIMER_S8_DISABLE_PPI.
+ *       The CTE is not allowed in PDUs sent over PHY CODED so this PPI may be re-used.
  */
 #define HAL_SW_SWITCH_TIMER_PHYEND_DELAY_COMPENSATION_DISABLE_PPI 19
 #endif /* CONFIG_BT_CTLR_DF_PHYEND_OFFSET_COMPENSATION_ENABLE */

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_resources.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_resources.h
@@ -84,7 +84,7 @@
 #if defined(CONFIG_BT_CTLR_DF_PHYEND_OFFSET_COMPENSATION_ENABLE)
 /* Allocate 2 adjacent channels for PHYEND delay compensation. Use the same channels as for
  * PHY CODED S2. The CTEINLINE may not be enabled for PHY CODED so PHYEND event is generated
- * at the same instant as END event. Hence the channels are uesed interchangeably.
+ * at the same instant as END event. Hence the channels are used interchangeably.
  * That saves from use of another timer.
  */
 #define SW_SWITCH_TIMER_EVTS_COMP_PHYEND_DELAY_COMPENSATION_BASE 2
@@ -108,7 +108,7 @@
  */
 #define NRF_RADIO_SHORTS_TRX_END_DISABLE_Msk HAL_RADIO_SHORTS_TRX_PHYEND_DISABLE_Msk
 
-/* Delay of EVENTS_PHYEND event on receive PDU without CTE inclded when CTEINLINE is enabled */
+/* Delay of EVENTS_PHYEND event on receive PDU without CTE included when CTEINLINE is enabled */
 #define RADIO_EVENTS_PHYEND_DELAY_US 16
 
 /* Delay of CCM TASKS_CRYPT start in number of bits for Radio Bit counter */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -361,7 +361,7 @@ struct pdu_adv *lll_adv_pdu_alloc(struct lll_adv_pdu *pdu, uint8_t *idx)
 	void *p;
 
 	/* TODO: Make this unique mechanism to update last element in double
-	 *       buffer a re-usable utility function.
+	 *       buffer a reusable utility function.
 	 */
 	first = pdu->first;
 	last = pdu->last;
@@ -590,7 +590,7 @@ struct pdu_adv *lll_adv_pdu_and_extra_data_alloc(struct lll_adv_pdu *pdu,
 			/* There is no release of memory allocated by
 			 * adv_pdu_allocate because there is no memory leak.
 			 * If caller can recover from this error and subsequent
-			 * call to this function occures, no new memory will be
+			 * call to this function occurs, no new memory will be
 			 * allocated. adv_pdu_allocate will return already
 			 * allocated memory.
 			 */
@@ -648,7 +648,7 @@ struct pdu_adv *lll_adv_pdu_and_extra_data_latest_get(struct lll_adv_pdu *pdu,
 		if (ed && (!MFIFO_ENQUEUE_IDX_GET(extra_data_free,
 						  &ed_free_idx))) {
 			/* No pdu_free_idx clean up is required, sobsequent
-			 * calls to MFIFO_ENQUEUE_IDX_GET return ther same
+			 * calls to MFIFO_ENQUEUE_IDX_GET return the same
 			 * index to memory that is in limbo state.
 			 */
 			return NULL;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df.c
@@ -134,7 +134,7 @@ struct lll_df_sync_cfg *lll_df_sync_cfg_alloc(struct lll_df_sync *df_cfg,
 	uint8_t first, last;
 
 	/* TODO: Make this unique mechanism to update last element in double
-	 *       buffer a re-usable utility function.
+	 *       buffer a reusable utility function.
 	 */
 	first = df_cfg->first;
 	last = df_cfg->last;
@@ -294,7 +294,7 @@ int lll_df_iq_report_no_resources_prepare(struct lll_sync *sync_lll)
 			err = 0;
 		}
 
-		/* Do actual allocation and store the node for futher processing after a PDU
+		/* Do actual allocation and store the node for further processing after a PDU
 		 * reception,
 		 */
 		ull_df_iq_report_alloc();

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral.c
@@ -119,7 +119,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 
 	lll = p->param;
 
-	/* Check if stopped (on disconnection between prepare and pre-empt)
+	/* Check if stopped (on disconnection between prepare and preempt)
 	 */
 	if (unlikely(lll->handle == 0xFFFF)) {
 		radio_isr_set(lll_isr_early_abort, lll);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -170,7 +170,7 @@ bool lll_scan_adva_check(const struct lll_scan *lll, uint8_t addr_type,
 	}
 #endif /* CONFIG_BT_CTLR_PRIVACY */
 
-	/* NOTE: This function to be used only to check AdvA when intiating,
+	/* NOTE: This function to be used only to check AdvA when initiating,
 	 *       hence, otherwise we should not use the return value.
 	 *       This function is referenced in lll_scan_ext_tgta_check, but
 	 *       is not used when not being an initiator, hence return false

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -858,7 +858,7 @@ static int isr_rx(struct lll_sync *lll, uint8_t node_type, uint8_t crc_ok,
 				 * report with valid packet_status if there were free nodes for
 				 * that. Or report insufficient resources for IQ data report.
 				 *
-				 * Retunred value is not checked because it does not matter if there
+				 * Returned value is not checked because it does not matter if there
 				 * is a IQ report to be send towards ULL. There is always periodic
 				 * sync report to be send.
 				 */
@@ -1146,8 +1146,8 @@ isr_rx_aux_chain_done:
 #endif /* CONFIG_BT_CTLR_DF_SAMPLE_CTE_FOR_PDU_WITH_BAD_CRC */
 		} else {
 #if defined(CONFIG_BT_CTLR_DF_SCAN_CTE_RX)
-			/* Report insufficient resurces for IQ data report and relese additional
-			 * noder_rx_iq_data stored in lll_sync object, to vaoid buffers leakage.
+			/* Report insufficient resources for IQ data report and release additional
+			 * noder_rx_iq_data stored in lll_sync object, to avoid buffers leakage.
 			 */
 			iq_report_incomplete_create_put(lll);
 #endif /* CONFIG_BT_CTLR_DF_SCAN_CTE_RX */
@@ -1281,7 +1281,7 @@ static void iq_report_incomplete_create(struct lll_sync *lll, struct node_rx_iq_
 	 * may be invalid in case of insufficient resources.
 	 */
 	iq_report->rssi_ant_id = radio_df_pdu_antenna_switch_pattern_get();
-	/* Accodring to BT 5.3, Vol 4, Part E, section 7.7.65.21 below
+	/* According to BT 5.3, Vol 4, Part E, section 7.7.65.21 below
 	 * fields have invalid values in case of insufficient resources.
 	 */
 	iq_report->cte_info =

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
@@ -298,7 +298,7 @@ static int prepare_cb_common(struct lll_prepare_param *p)
 	radio_crc_configure(PDU_CRC_POLYNOMIAL, sys_get_le24(crc_init));
 	lll_chan_set(data_chan_use);
 
-	/* By design, there shall alway be one free node rx available for
+	/* By design, there shall always be one free node rx available for
 	 * setting up radio for new PDU reception.
 	 */
 	node_rx = ull_iso_pdu_rx_alloc_peek(1U);
@@ -934,7 +934,7 @@ isr_rx_next_subevent:
 			payload_count += (lll->bn_curr - 1U) +
 					 (lll->ptc_curr * lll->pto);
 
-			/* By design, there shall alway be one free node rx
+			/* By design, there shall always be one free node rx
 			 * available for setting up radio for new PDU reception.
 			 */
 			node_rx = ull_iso_pdu_rx_alloc_peek(1U);
@@ -959,7 +959,7 @@ isr_rx_next_subevent:
 		struct pdu_bis *pdu;
 
 		if (bis) {
-			/* By design, there shall alway be one free node rx
+			/* By design, there shall always be one free node rx
 			 * available for setting up radio for new PDU reception.
 			 */
 			node_rx = ull_iso_pdu_rx_alloc_peek(1U);

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -573,7 +573,7 @@ int ll_init(struct k_sem *sem_rx)
 	 * On init mayfly memq head and tail is assigned with a link instance
 	 * that is used during enqueue operation. New link provided by enqueue
 	 * is added as a tail and will be used in future enqueue. While dequeue,
-	 * the link that was used for storage of the job is relesed and stored
+	 * the link that was used for storage of the job is released and stored
 	 * in a job it was related to. The job may store initial link. If mayfly
 	 * is re-initialized but job objects were not re-initialized there is a
 	 * risk that enqueued job will point to the same link as it is in a memq
@@ -1849,7 +1849,7 @@ uint32_t ull_ticker_status_take(uint32_t ret, uint32_t volatile *ret_cb)
 {
 	if ((ret == TICKER_STATUS_BUSY) || (*ret_cb != TICKER_STATUS_BUSY)) {
 		/* Operation is either pending of completed via callback
-		 * prior to this function call. Take the sempaphore and wait,
+		 * prior to this function call. Take the semaphore and wait,
 		 * or take it to balance take/give counting.
 		 */
 		k_sem_take(&sem_ticker_api_cb, K_FOREVER);

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -344,7 +344,7 @@ uint8_t ll_adv_aux_ad_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 				 * the double buffer with the first PDU, and
 				 * returned the latest PDU as the new PDU, we
 				 * need to enqueue back the new PDU which is
-				 * infact the latest PDU.
+				 * in fact the latest PDU.
 				 */
 				if (pdu_prev == pdu) {
 					lll_adv_aux_data_enqueue(adv->lll.aux,
@@ -574,7 +574,7 @@ uint8_t ll_adv_aux_ad_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 				 * the double buffer with the first PDU, and
 				 * returned the latest PDU as the new PDU, we
 				 * need to enqueue back the new PDU which is
-				 * infact the latest PDU.
+				 * in fact the latest PDU.
 				 */
 				if (pdu_prev == pdu) {
 					lll_adv_aux_data_enqueue(adv->lll.aux,
@@ -594,7 +594,7 @@ uint8_t ll_adv_aux_ad_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 			 * the double buffer with the first PDU, and
 			 * returned the latest PDU as the new PDU, we
 			 * need to enqueue back the new PDU which is
-			 * infact the latest PDU.
+			 * in fact the latest PDU.
 			 */
 			if (pdu_prev == pdu) {
 				lll_adv_aux_data_enqueue(adv->lll.aux, sec_idx);
@@ -1055,7 +1055,7 @@ uint8_t ll_adv_aux_sr_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 				 * the double buffer with the first PDU, and
 				 * returned the latest PDU as the new PDU, we
 				 * need to enqueue back the new PDU which is
-				 * infact the latest PDU.
+				 * in fact the latest PDU.
 				 */
 				if (sr_pdu_prev == sr_pdu) {
 					lll_adv_scan_rsp_enqueue(lll, sr_idx);
@@ -1218,7 +1218,7 @@ uint8_t ll_adv_aux_sr_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 				 * the double buffer with the first PDU, and
 				 * returned the latest PDU as the new PDU, we
 				 * need to enqueue back the new PDU which is
-				 * infact the latest PDU.
+				 * in fact the latest PDU.
 				 */
 				if (sr_pdu_prev == sr_pdu) {
 					lll_adv_scan_rsp_enqueue(lll, sr_idx);
@@ -1239,7 +1239,7 @@ uint8_t ll_adv_aux_sr_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 			 * the double buffer with the first PDU, and
 			 * returned the latest PDU as the new PDU, we
 			 * need to enqueue back the new PDU which is
-			 * infact the latest PDU.
+			 * in fact the latest PDU.
 			 */
 			if (sr_pdu_prev == sr_pdu) {
 				lll_adv_aux_data_enqueue(adv->lll.aux, sr_idx);
@@ -2993,7 +2993,7 @@ static uint32_t aux_time_get(const struct ll_adv_aux_set *aux,
 
 	/* NOTE: 16-bit values are sufficient for minimum radio event time
 	 *       reservation, 32-bit are used here so that reservations for
-	 *       whole back-to-back chaining of PDUs can be accomodated where
+	 *       whole back-to-back chaining of PDUs can be accommodated where
 	 *       the required microseconds could overflow 16-bits, example,
 	 *       back-to-back chained Coded PHY PDUs.
 	 */
@@ -3050,7 +3050,7 @@ static uint32_t aux_time_min_get(const struct ll_adv_aux_set *aux)
 	/* Calculate the PDU Tx Time and hence the radio event length,
 	 * Always use maximum length for common extended header format so that
 	 * ACAD could be update when periodic advertising is active and the
-	 * time reservation need not be updated everytime avoiding overlapping
+	 * time reservation need not be updated every time avoiding overlapping
 	 * with other active states/roles.
 	 */
 	pdu_len = pdu->len - pdu->adv_ext_ind.ext_hdr_len -

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
@@ -168,7 +168,7 @@ uint8_t ull_adv_sync_pdu_cte_info_set(struct pdu_adv *pdu, const struct pdu_cte_
 /* notify adv_set that an aux instance has been created for it */
 void ull_adv_aux_created(struct ll_adv_set *adv);
 
-/* helper to get information whether ADI field is avaialbe in extended advertising PDU */
+/* helper to get information whether ADI field is available in extended advertising PDU */
 static inline bool ull_adv_sync_pdu_had_adi(const struct pdu_adv *pdu)
 {
 	return pdu->adv_ext_ind.ext_hdr.adi;

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
@@ -1152,7 +1152,7 @@ static uint8_t ptc_calc(const struct lll_adv_iso *lll, uint32_t event_spacing,
 		       (lll->sub_interval * lll->bn * lll->num_bis)) *
 		      lll->bn;
 
-		/* FIXME: Here we retrict to a maximum of BN Pre-Transmission
+		/* FIXME: Here we restrict to a maximum of BN Pre-Transmission
 		 * subevents per BIS
 		 */
 		ptc = MIN(ptc, lll->bn);

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -338,7 +338,7 @@ uint8_t ll_adv_sync_ad_data_set(uint8_t handle, uint8_t op, uint8_t len,
 		/* NOTE: latest PDU was not consumed by LLL and as
 		 * ull_adv_sync_pdu_alloc() has reverted back the double buffer
 		 * with the first PDU, and returned the latest PDU as the new
-		 * PDU, we need to enqueue back the new PDU which is infact
+		 * PDU, we need to enqueue back the new PDU which is in fact
 		 * the latest PDU.
 		 */
 		if (pdu_prev == pdu) {
@@ -1032,7 +1032,7 @@ uint8_t ull_adv_sync_pdu_alloc(struct ll_adv_set *adv,
 	if (extra_data_flag == ULL_ADV_PDU_EXTRA_DATA_ALLOC_ALWAYS ||
 	    (extra_data_flag == ULL_ADV_PDU_EXTRA_DATA_ALLOC_IF_EXIST && ed_prev)) {
 		/* If there was an extra data in past PDU data or it is required
-		 * by the hdr_add_fields then allocate memmory for it.
+		 * by the hdr_add_fields then allocate memory for it.
 		 */
 		pdu_new = lll_adv_sync_data_alloc(lll_sync, &ed_new,
 						  ter_idx);
@@ -2407,7 +2407,7 @@ static uint32_t sync_time_get(const struct ll_adv_sync_set *sync,
 	/* Calculate the PDU Tx Time and hence the radio event length,
 	 * Always use maximum length for common extended header format so that
 	 * ACAD could be update when periodic advertising is active and the
-	 * time reservation need not be updated everytime avoiding overlapping
+	 * time reservation need not be updated every time avoiding overlapping
 	 * with other active states/roles.
 	 */
 	len = pdu->len - pdu->adv_ext_ind.ext_hdr_len -

--- a/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
@@ -1155,7 +1155,7 @@ static void mfy_cis_offset_get(void *param)
 	}
 
 	/* Decrement event_count to compensate for offset_min_us greater than
-	 * CIG interval due to offset being atleast PDU_CIS_OFFSET_MIN_US.
+	 * CIG interval due to offset being at least PDU_CIS_OFFSET_MIN_US.
 	 */
 	if (offset_min_us > cig_interval_us) {
 		cis->lll.event_count--;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -99,7 +99,7 @@ static int empty_data_start_release(struct ll_conn *conn, struct node_tx *tx);
 
 #if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ)
 /* Connection context pointer used as CPR mutex to serialize connection
- * parameter requests procedures across simulataneous connections so that
+ * parameter requests procedures across simultaneous connections so that
  * offsets exchanged to the peer do not get changed.
  */
 struct ll_conn *conn_upd_curr;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_internal.h
@@ -42,7 +42,7 @@ void ull_pdu_data_init(struct pdu_data *pdu);
 
 #if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ)
 /* Connection context pointer used as CPR mutex to serialize connection
- * parameter requests procedures across simulataneous connections so that
+ * parameter requests procedures across simultaneous connections so that
  * offsets exchanged to the peer do not get changed.
  */
 extern struct ll_conn *conn_upd_curr;

--- a/subsys/bluetooth/controller/ll_sw/ull_df.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_df.c
@@ -401,7 +401,7 @@ uint8_t ll_df_set_cl_cte_tx_enable(uint8_t adv_handle, uint8_t cte_enable)
  * @return Status of command completion.
  *
  * @Note This function may put TX thread into wait state. This may lead to a
- *       situation that ll_sync_set instance is relased (RX thread has higher
+ *       situation that ll_sync_set instance is released (RX thread has higher
  *       priority than TX thread). ll_sync_set instance may not be accessed after
  *       call to ull_sync_slot_update.
  *       This is related with possible race condition with RX thread handling
@@ -764,7 +764,7 @@ static uint8_t cte_info_clear(struct ll_adv_set *adv, struct lll_df_adv_cfg *df_
 
 	if (err != BT_HCI_ERR_SUCCESS) {
 		/* TODO: return here leaves periodic advertising chain in an inconsistent state.
-		 * Add gracefull return or assert.
+		 * Add graceful return or assert.
 		 */
 		return err;
 	}
@@ -923,7 +923,7 @@ static void df_conn_cte_req_disable(void *param)
 /* @brief Function enables or disables CTE request control procedure for a connection.
  *
  * The procedure may be enabled in two modes:
- * - single-shot, it is autmatically disabled when the occurrence finishes.
+ * - single-shot, it is automatically disabled when the occurrence finishes.
  * - periodic, it is executed periodically until disabled, connection is lost or PHY is changed
  *   to the one that does not support CTE.
  *

--- a/subsys/bluetooth/controller/ll_sw/ull_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_internal.h
@@ -16,7 +16,7 @@
 #endif /* CONFIG_BT_CTLR_USER_CPR_INTERVAL_MIN */
 
 /**
- *  User deferance of CPR Anchor Point Move
+ *  User deference of CPR Anchor Point Move
  */
 #if !defined(CONFIG_BT_CTLR_USER_CPR_ANCHOR_POINT_MOVE)
 #define DEFER_APM_CHECK(x, y, z) (false)

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.c
@@ -1635,7 +1635,7 @@ static bool pdu_is_valid(struct pdu_data *pdu)
 		}
 	}
 
-	/* consider unsupported and unknows PDUs as valid */
+	/* consider unsupported and unknown PDUs as valid */
 	return true;
 }
 

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.h
@@ -156,7 +156,7 @@ uint8_t ull_cp_remote_cpr_pending(struct ll_conn *conn);
 bool ull_cp_remote_cpr_apm_awaiting_reply(struct ll_conn *conn);
 
 /**
- * @brief Repsond to anchor point move of remote connection
+ * @brief Respond to anchor point move of remote connection
  *        param reg.
  */
 void ull_cp_remote_cpr_apm_reply(struct ll_conn *conn, uint16_t *offsets);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
@@ -417,7 +417,7 @@ static void lp_comm_ntf(struct ll_conn *conn, struct proc_ctx *ctx)
 	}
 
 	if (!piggy_back) {
-		/* Enqueue notification towards LL, unless we re-use RX node,
+		/* Enqueue notification towards LL, unless we reuse RX node,
 		 * in which case it is handled on the ull_cp_rx return path
 		 */
 		ll_rx_put_sched(ntf->hdr.link, ntf);

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -726,7 +726,7 @@ void ull_sync_setup(struct ll_scan_set *scan, struct ll_scan_aux_set *aux,
 	interval = sys_le16_to_cpu(si->interval);
 	interval_us = interval * PERIODIC_INT_UNIT_US;
 
-	/* Convert fromm 10ms units to interval units */
+	/* Convert from 10ms units to interval units */
 	sync->timeout_reload = RADIO_SYNC_EVENTS((sync->timeout * 10U *
 						  USEC_PER_MSEC), interval_us);
 
@@ -1504,7 +1504,7 @@ static struct pdu_cte_info *pdu_cte_info_get(struct pdu_adv *pdu)
 		return NULL;
 	}
 
-	/* Make sure there are no fields that are not allowd for AUX_SYNC_IND and AUX_CHAIN_IND */
+	/* Make sure there are no fields that are not allowed for AUX_SYNC_IND and AUX_CHAIN_IND */
 	LL_ASSERT(!hdr->adv_addr);
 	LL_ASSERT(!hdr->tgt_addr);
 

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
@@ -582,7 +582,7 @@ void ull_sync_iso_setup(struct ll_sync_iso_set *sync_iso,
 		slot_us = (pdu_spacing * lll->nse * num_bis) + ctrl_spacing;
 
 	} else if (lll->bis_spacing >= (lll->sub_interval * lll->nse)) {
-		/* Time reservation omitting PTC subevents in sequetial
+		/* Time reservation omitting PTC subevents in sequential
 		 * packing.
 		 */
 		slot_us = pdu_spacing * ((lll->nse * num_bis) - lll->ptc);

--- a/subsys/bluetooth/crypto/bt_crypto.h
+++ b/subsys/bluetooth/crypto/bt_crypto.h
@@ -127,7 +127,7 @@ int bt_crypto_h6(const uint8_t w[16], const uint8_t key_id[4], uint8_t res[16]);
 int bt_crypto_h7(const uint8_t salt[16], const uint8_t w[16], uint8_t res[16]);
 
 /**
- * @brief Cryptograhic Toolbox function h8
+ * @brief Cryptographic Toolbox function h8
  *
  * Defined in Core Vol. 6, part E 1.1.1.
  *

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -299,7 +299,7 @@ config BT_CONN_PARAM_ANY
 	  Some controllers support additional connection parameter ranges
 	  beyond what is described in the specification. Enabling this option
 	  allows the application to set any value to all connection parameters.
-	  Tbe Host will perform no limits nor consistency checks on any of the
+	  The Host will perform no limits nor consistency checks on any of the
 	  connection parameters (conn interval min and max, latency and timeout).
 	  However, the Host will still use numerical comparisons between the
 	  min and max connection intervals in order to verify whether the
@@ -541,9 +541,9 @@ config BT_ID_UNPAIR_MATCHING_BONDS
 	  limitation" below.
 
 	  [RL limitation]:
-	  The Host implementors have considered it unlikely that applications
+	  The Host implementers have considered it unlikely that applications
 	  would ever want to have multiple bonds with the same peer. The
-	  implementors prioritize the simplicity of the implementation over this
+	  implementers prioritize the simplicity of the implementation over this
 	  capability.
 
 	  The Resolve List on a Controller is not able to accommodate multiple
@@ -911,7 +911,7 @@ config BT_DF_VS_CL_IQ_REPORT_16_BITS_IQ_SAMPLES
 	  Direction Finging connectionless IQ reports provide a set of IQ samples collected during
 	  sampling of CTE. Bluetooth 5.3 Core Specification defines IQ samples to be 8 bits signed
 	  integer, see Vol 4, Part E section 7.7.65.21. This option enables a vendor specific Host
-	  extenstion to handle connectionless IQ reports with samples that are in 16 bit signed
+	  extension to handle connectionless IQ reports with samples that are in 16 bit signed
 	  integer format.
 
 config BT_DF_VS_CONN_IQ_REPORT_16_BITS_IQ_SAMPLES
@@ -921,7 +921,7 @@ config BT_DF_VS_CONN_IQ_REPORT_16_BITS_IQ_SAMPLES
 	  Direction Finging connection IQ reports provide a set of IQ samples collected during
 	  sampling of CTE. Bluetooth 5.3 Core Specification defines IQ samples to be 8 bits signed
 	  integer, see Vol 4, Part E sections 7.7.65.22. This option enables a vendor specific Host
-	  extenstion to handle connection IQ report with samples that are in 16 bit signed integer
+	  extension to handle connection IQ report with samples that are in 16 bit signed integer
 	  format.
 
 endif # BT_DF

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -2270,7 +2270,7 @@ static uint8_t att_exec_write_rsp(struct bt_att_chan *chan, uint8_t flags)
 
 	/* The following code will iterate on all prepare writes in the
 	 * prep_queue, and reassemble those that share the same handle.
-	 * Once a handle has been ressembled, it is sent to the upper layers,
+	 * Once a handle has been reassembled, it is sent to the upper layers,
 	 * and the next handle is processed
 	 */
 	while (!sys_slist_is_empty(&chan->att->prep_queue)) {
@@ -3443,7 +3443,7 @@ static k_timeout_t credit_based_connection_delay(struct bt_conn *conn)
 		}
 
 		const uint8_t rand_delay = random & 0x7; /* Small random delay for IOP */
-		/* The maximum value of (latency + 1) * 2 multipled with the
+		/* The maximum value of (latency + 1) * 2 multiplied with the
 		 * maximum connection interval has a maximum value of
 		 * 4000000000 which can be stored in 32-bits, so this won't
 		 * result in an overflow

--- a/subsys/bluetooth/host/direction.c
+++ b/subsys/bluetooth/host/direction.c
@@ -1144,7 +1144,7 @@ static int bt_df_set_conn_cte_req_enable(struct bt_conn *conn, bool enable,
 	}
 
 	if (!atomic_test_bit(conn->flags, BT_CONN_CTE_RX_PARAMS_SET)) {
-		LOG_ERR("Can't start CTE requres procedure before CTE RX params setup");
+		LOG_ERR("Can't start CTE request procedure before CTE RX params setup");
 		return -EINVAL;
 	}
 

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -646,7 +646,7 @@ static bool cf_set_value(struct gatt_cf_cfg *cfg, const uint8_t *value, uint16_t
 		}
 	}
 
-	/* Set the bits for each octect */
+	/* Set the bits for each octet */
 	for (i = 0U; i < len && i < CF_NUM_BYTES; i++) {
 		if (i == (CF_NUM_BYTES - 1)) {
 			cfg->data[i] |= value[i] & BIT_MASK(CF_NUM_BITS % 8);
@@ -924,11 +924,11 @@ static void db_hash_gen(void)
 	}
 
 	/**
-	 * Core 5.1 does not state the endianess of the hash.
+	 * Core 5.1 does not state the endianness of the hash.
 	 * However Vol 3, Part F, 3.3.1 says that multi-octet Characteristic
 	 * Values shall be LE unless otherwise defined. PTS expects hash to be
-	 * in little endianess as well. bt_smp_aes_cmac calculates the hash in
-	 * big endianess so we have to swap.
+	 * in little endianness as well. bt_smp_aes_cmac calculates the hash in
+	 * big endianness so we have to swap.
 	 */
 	sys_mem_swap(db_hash.hash, sizeof(db_hash.hash));
 
@@ -3434,7 +3434,7 @@ static uint8_t disconnected_cb(const struct bt_gatt_attr *attr, uint16_t handle,
 			ccc->cfg_changed(attr, ccc->value);
 		}
 
-		LOG_DBG("ccc %p reseted", ccc);
+		LOG_DBG("ccc %p reset", ccc);
 	}
 
 	return BT_GATT_ITER_CONTINUE;

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -1610,7 +1610,7 @@ void bt_hci_le_enh_conn_complete_sync(struct bt_hci_evt_le_enh_conn_complete_v2 
 	update_conn(conn, &id_addr, (const struct bt_hci_evt_le_enh_conn_complete *)evt);
 
 #if defined(CONFIG_BT_USER_PHY_UPDATE)
-	/* The connection is always initated on the same phy as the PAwR advertiser */
+	/* The connection is always initiated on the same phy as the PAwR advertiser */
 	conn->le.phy.tx_phy = sync->phy;
 	conn->le.phy.rx_phy = sync->phy;
 #endif

--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -241,7 +241,7 @@ static void adv_rpa_expired(struct bt_le_ext_adv *adv, void *data)
 
 static void adv_rpa_invalidate(struct bt_le_ext_adv *adv, void *data)
 {
-	/* RPA of Advertisers limited by timeot or number of packets only expire
+	/* RPA of Advertisers limited by timeout or number of packets only expire
 	 * when they are stopped.
 	 */
 	if (!atomic_test_bit(adv->flags, BT_ADV_LIMITED) &&

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -2518,7 +2518,7 @@ int bt_iso_chan_connect(const struct bt_iso_connect_param *param, size_t count)
 	 */
 	err = iso_chan_connect_security(param, count);
 	if (err != 0) {
-		LOG_DBG("Failed to initate security for all CIS: %d", err);
+		LOG_DBG("Failed to initiate security for all CIS: %d", err);
 		return err;
 	}
 #endif /* CONFIG_BT_SMP */

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -1288,7 +1288,7 @@ static uint16_t le_err_to_result(int err)
 		return BT_L2CAP_LE_ERR_KEY_SIZE;
 	case -ENOTSUP:
 		/* This handle the cases where a fixed channel is registered but
-		 * for some reason (e.g. controller not suporting a feature)
+		 * for some reason (e.g. controller not supporting a feature)
 		 * cannot be used.
 		 */
 		return BT_L2CAP_LE_ERR_PSM_NOT_SUPP;

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -288,7 +288,7 @@ static const uint8_t *sc_public_key;
 static K_SEM_DEFINE(sc_local_pkey_ready, 0, 1);
 
 /* Pointer to internal data is used to mark that callbacks of given SMP channel are not initialized.
- * Value of NULL represents no authenticaiton capabilities and cannot be used for that purpose.
+ * Value of NULL represents no authentication capabilities and cannot be used for that purpose.
  */
 #define BT_SMP_AUTH_CB_UNINITIALIZED	((atomic_ptr_val_t)bt_smp_pool)
 
@@ -865,7 +865,7 @@ static void bt_smp_br_disconnected(struct bt_l2cap_chan *chan)
 
 static void smp_br_init(struct bt_smp_br *smp)
 {
-	/* Initialize SMP context exluding L2CAP channel context and anything
+	/* Initialize SMP context excluding L2CAP channel context and anything
 	 * else declared after.
 	 */
 	(void)memset(smp, 0, offsetof(struct bt_smp_br, chan));
@@ -2550,7 +2550,7 @@ static uint8_t smp_central_ident(struct bt_smp *smp, struct net_buf *buf)
 
 static int smp_init(struct bt_smp *smp)
 {
-	/* Initialize SMP context exluding L2CAP channel context and anything
+	/* Initialize SMP context excluding L2CAP channel context and anything
 	 * else declared after.
 	 */
 	(void)memset(smp, 0, offsetof(struct bt_smp, chan));

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -628,7 +628,7 @@ config BT_MESH_SAR_RX_SEG_INT_STEP
 	help
 	  This value defines the segments reception interval step used for
 	  delaying the transmission of an acknowledgment message after
-	  receiving a new segmnet. The interval is measured in milliseconds
+	  receiving a new segment. The interval is measured in milliseconds
 	  and calculated using the following formula:
 	  (CONFIG_BT_MESH_SAR_RX_SEG_INT_STEP + 1) * 10 ms
 
@@ -679,7 +679,7 @@ config BT_MESH_RPL_STORAGE_MODE_SETTINGS
 	bool "Persistent storage of RPL in Settings"
 	help
 	  Persistent storage of RPL in Settings. If BT_SETTINGS is not
-	  enabled this choise will provide a non-persistent implementation
+	  enabled this choice will provide a non-persistent implementation
 	  variant of the RPL list.
 
 endchoice

--- a/subsys/bluetooth/mesh/blob_cli.c
+++ b/subsys/bluetooth/mesh/blob_cli.c
@@ -764,9 +764,9 @@ static void block_get_tx(struct bt_mesh_blob_cli *cli, uint16_t dst)
  *
  * After sending all reported missing chunks to each target, the Client updates
  * @ref bt_mesh_blob_target_pull::block_report_timestamp value for every target individually in
- * chunk_tx_complete. The Client then proceedes to block_report_wait state and uses the earliest of
+ * chunk_tx_complete. The Client then proceeds to block_report_wait state and uses the earliest of
  * all block_report_timestamp and cli_timestamp to schedule the retry timer. When the retry
- * timer expires, the Client proceedes to the block_check_end state.
+ * timer expires, the Client proceeds to the block_check_end state.
  *
  * In Pull mode, target nodes send a Partial Block Report message to the Client to inform about
  * missing chunks. The Client doesn't control when these messages are sent by target nodes, and
@@ -916,7 +916,7 @@ static void chunk_tx_complete(struct bt_mesh_blob_cli *cli, uint16_t dst)
 	int64_t timestamp = k_uptime_get() + BLOCK_REPORT_TIME_MSEC;
 
 	if (!UNICAST_MODE(cli)) {
-		/* If using group adressing, reset timestamp for all targets after all chunks are
+		/* If using group addressing, reset timestamp for all targets after all chunks are
 		 * sent to the group address
 		 */
 		TARGETS_FOR_EACH(cli, target) {

--- a/subsys/bluetooth/mesh/op_agg_srv.c
+++ b/subsys/bluetooth/mesh/op_agg_srv.c
@@ -19,7 +19,7 @@ LOG_MODULE_REGISTER(bt_mesh_op_agg_srv);
 
 NET_BUF_SIMPLE_DEFINE_STATIC(sdu, BT_MESH_TX_SDU_MAX);
 
-/** Mesh Opcodes Aggragator Server Model Context */
+/** Mesh Opcodes Aggregator Server Model Context */
 static struct bt_mesh_op_agg_srv {
 	/** Composition data model entry pointer. */
 	const struct bt_mesh_model *model;

--- a/subsys/bluetooth/mesh/provisionee.c
+++ b/subsys/bluetooth/mesh/provisionee.c
@@ -195,7 +195,7 @@ static void prov_start(const uint8_t *data)
 		       bt_mesh_prov->static_val_len > auth_size ? auth_size
 								: bt_mesh_prov->static_val_len);
 
-		/* Padd with zeros if the Auth is shorter the required length*/
+		/* Pad with zeros if the Auth is shorter the required length */
 		if (bt_mesh_prov->static_val_len < auth_size) {
 			memset(bt_mesh_prov_link.auth + bt_mesh_prov->static_val_len, 0,
 			       auth_size - bt_mesh_prov->static_val_len);

--- a/subsys/bluetooth/mesh/provisioner.c
+++ b/subsys/bluetooth/mesh/provisioner.c
@@ -767,7 +767,7 @@ int bt_mesh_auth_method_set_static(const uint8_t *static_val, uint8_t size)
 	memcpy(bt_mesh_prov_link.auth, static_val,
 	       size > PROV_AUTH_MAX_LEN ? PROV_AUTH_MAX_LEN : size);
 
-	/* Padd with zeros if the Auth is shorter the required length*/
+	/* Pad with zeros if the Auth is shorter the required length */
 	if (size < PROV_AUTH_MAX_LEN) {
 		memset(bt_mesh_prov_link.auth + size, 0, PROV_AUTH_MAX_LEN - size);
 	}

--- a/subsys/bluetooth/mesh/sar_cfg_internal.h
+++ b/subsys/bluetooth/mesh/sar_cfg_internal.h
@@ -11,9 +11,9 @@
 #ifndef ZEPHYR_SUBSYS_BLUETOOTH_MESH_SAR_CFG_INTERNAL_H__
 #define ZEPHYR_SUBSYS_BLUETOOTH_MESH_SAR_CFG_INTERNAL_H__
 
-/** SAR Transmitter Configuraion state encoded length */
+/** SAR Transmitter state encoded length */
 #define BT_MESH_SAR_TX_LEN 4
-/** SAR Receiver Configuraion state encoded length */
+/** SAR Receiver state encoded length */
 #define BT_MESH_SAR_RX_LEN 3
 
 /** SAR Transmitter Configuration state initializer */

--- a/subsys/bluetooth/mesh/shell/cfg.c
+++ b/subsys/bluetooth/mesh/shell/cfg.c
@@ -1150,7 +1150,7 @@ static int cmd_mod_sub_del(const struct shell *sh, size_t argc, char *argv[])
 	if (status) {
 		shell_print(sh, "Model Subscription Delete failed with status 0x%02x", status);
 	} else {
-		shell_print(sh, "Model subscription deltion was successful");
+		shell_print(sh, "Model subscription deletion was successful");
 	}
 
 	return 0;
@@ -1387,7 +1387,7 @@ static int cmd_mod_sub_del_all(const struct shell *sh, size_t argc, char *argv[]
 	if (status) {
 		shell_print(sh, "Model Subscription Delete All failed with status 0x%02x", status);
 	} else {
-		shell_print(sh, "Model subscription deltion all was successful");
+		shell_print(sh, "Model subscription deletion all was successful");
 	}
 
 	return 0;

--- a/subsys/bluetooth/mesh/va.h
+++ b/subsys/bluetooth/mesh/va.h
@@ -42,7 +42,7 @@ uint8_t bt_mesh_va_del(const uint8_t *uuid);
  */
 const struct bt_mesh_va *bt_mesh_va_find(const uint8_t *uuid);
 
-/** @brief Check if there are more than one Label UUID which hash has the specificed virtual
+/** @brief Check if there are more than one Label UUID which hash has the specified virtual
  * address.
  *
  * @param addr Virtual address to check

--- a/subsys/bluetooth/services/ots/ots_dir_list.c
+++ b/subsys/bluetooth/services/ots/ots_dir_list.c
@@ -33,7 +33,7 @@ static size_t dir_list_object_record_size(const struct bt_gatt_ots_object *obj)
 	/* ID */
 	len += BT_OTS_OBJ_ID_SIZE;
 
-	/* Name length (single octect is used for the name length) */
+	/* Name length (single octet is used for the name length) */
 	len += sizeof(uint8_t);
 
 	/* Name */

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -2897,7 +2897,7 @@ static int cmd_read_local_tx_power(const struct shell *sh, size_t argc, char *ar
 		}
 		err = bt_conn_le_get_tx_power_level(default_conn, &tx_power_level);
 		if (err) {
-			shell_print(sh, "Commad returned error error %d", err);
+			shell_print(sh, "Command returned error error %d", err);
 			return err;
 		}
 		if (tx_power_level.current_level == unachievable_current_level) {


### PR DESCRIPTION
Typo corrections in various subsys/bluetooth directories:

- `subsys/bluetooth/audio/*`
- `subsys/bluetooth/controller/*`
- `subsys/bluetooth/host/*`
- `subsys/bluetooth/mesh/*`
- `subsys/bluetooth/(common|crypto|services|shell)/*`
