### PR TITLE
input: increase default stack size to 1024

### DIFF
--- a/subsys/input/Kconfig
+++ b/subsys/input/Kconfig
@@ -60,7 +60,7 @@ config INPUT_QUEUE_MAX_MSGS
 
 config INPUT_THREAD_STACK_SIZE
 	int "Input thread stack size"
-	default 512
+	default 1024
 	help
 	  Stack size for the thread processing the input events, must have
 	  enough space for executing the registered callbacks.

--- a/tests/subsys/input/api/testcase.yaml
+++ b/tests/subsys/input/api/testcase.yaml
@@ -9,7 +9,6 @@ tests:
   input.api.thread:
     extra_configs:
       - CONFIG_INPUT_MODE_THREAD=y
-      - CONFIG_INPUT_THREAD_STACK_SIZE=1024
   input.api.synchronous:
     extra_configs:
       - CONFIG_INPUT_MODE_SYNCHRONOUS=y


### PR DESCRIPTION
The default 512 bytes stack size is a bit tight for some architecture and leads to samples running out of stack. Let's default to 1024 and let the user tweak it down if necessary.