### PR TITLE
pm: use braces for .pm_base inside anonymous union initializer

### DIFF
--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -906,7 +906,7 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
 		.state = (state_),                                             \
 		.data = (data_),                                               \
 		IF_ENABLED(CONFIG_DEVICE_DEPS, (.deps = (deps_),)) /**/        \
-		IF_ENABLED(CONFIG_PM_DEVICE, (.pm_base = (pm_),)) /**/         \
+		IF_ENABLED(CONFIG_PM_DEVICE, ({ .pm_base = (pm_),)}) /**/         \
 	}
 
 /**


### PR DESCRIPTION
Fixes commit 25173f71cda6 ("pm: device_runtime: Extend with synchronous runtime PM")

Fixes compilation with gcc 4.2-based toolchain used by SOF for TGL generation products. As seen in the error message below, that gcc version requires braces for initialization of anonymous unions:

```
zephyr/soc/xtensa/intel_adsp/common/mem_window.c:62:
   error: unknown field ‘pm_base’ specified in initializer
   warning: missing braces around initializer
   warning: (near initialization for ‘__device_dts_ord_66.<anonymous>’)
```

This is a well-known and recurring issue, see past example(s) in #68118

As the Zephyr build is deterministic, I could easily verify that this commit makes zero .obj difference (when using the Zephyr SDK).