### PR TITLE
drivers: lora: reyax rylr module

### DIFF
--- a/boards/infineon/cy8ckit_062s4/cy8ckit_062s4.dts
+++ b/boards/infineon/cy8ckit_062s4/cy8ckit_062s4.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 David Ullmann
+ * Copyright (c) 2024 David Ullmann
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -29,6 +29,32 @@
 
 	};
 
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;		/* shared */
+		gpio-map = <0  0 &gpio_prt10   0 0>,	/* A0 */
+			   <1  0 &gpio_prt10   1 0>,	/* A1 */
+			   <2  0 &gpio_prt10   2 0>,	/* A2 */
+			   <3  0 &gpio_prt10   3 0>,	/* A3 */
+			   <4  0 &gpio_prt10   4 0>,	/* A4 */
+			   <5  0 &gpio_prt10   5 0>,	/* A5 */
+			   <6  0 &gpio_prt0   2 0>,	/* D0-RX-5 */
+			   <7  0 &gpio_prt0   3 0>,	/* D1-TX-5 */
+			   <8  0 &gpio_prt5   0 0>,	/* D2-RTS-5 */
+			   <9  0 &gpio_prt5   1 0>,	/* D3-CTS-5 */
+			   <10 0 &gpio_prt5   6 0>,	/* D4 */
+			   <11 0 &gpio_prt5   7 0>,	/* D5 */
+			   <12 0 &gpio_prt6   2 0>,	/* D6 */
+			   <13 0 &gpio_prt6   3 0>,	/* D7 */
+			   <14 0 &gpio_prt2   4 0>,	/* D8-RX-6 */
+			   <15 0 &gpio_prt2   6 0>,	/* D9-TX-6 */
+			   <16 0 &gpio_prt2   3 0>,	/* D10 */
+			   <17 0 &gpio_prt2   0 0>,	/* D11 */
+			   <18 0 &gpio_prt2   1 0>,	/* D12 */
+			   <19 0 &gpio_prt2   2 0>;	/* D13 */
+	};
 };
 
 &p3_1_scb2_uart_tx {
@@ -55,3 +81,9 @@ uart2: &scb2 {
 &gpio_prt2 {
 	status = "okay";
 };
+
+uart0: &scb0 {
+	compatible = "infineon,cat1-uart";
+};
+
+arduino_serial: &uart0 {};

--- a/boards/shields/reyax_lora/Kconfig.shield
+++ b/boards/shields/reyax_lora/Kconfig.shield
@@ -1,0 +1,5 @@
+# Copyright (c) 2024 David Ullmann
+# SPDX-License-Identifier: Apache-2.0
+
+config SHIELD_REYAX_LORA
+	def_bool $(shields_list_contains,reyax_lora)

--- a/boards/shields/reyax_lora/boards/cy8ckit_062s4.conf
+++ b/boards/shields/reyax_lora/boards/cy8ckit_062s4.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2024 David Ullmann
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_LORA=y
+CONFIG_LORA_RYLRXXX=y
+CONFIG_UART_INTERRUPT_DRIVEN=y

--- a/boards/shields/reyax_lora/boards/cy8ckit_062s4.overlay
+++ b/boards/shields/reyax_lora/boards/cy8ckit_062s4.overlay
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2024 David Ullmann
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+&p0_2_scb0_uart_rx {
+	input-enable;
+};
+
+&p0_3_scb0_uart_tx {
+	drive-push-pull;
+};
+
+&arduino_serial {
+	pinctrl-0 = <&p0_2_scb0_uart_rx &p0_3_scb0_uart_tx>;
+	pinctrl-names = "default";
+};
+
+&gpio_prt0 {
+	status = "okay";
+};
+
+&gpio_prt2 {
+	status = "okay";
+};

--- a/boards/shields/reyax_lora/doc/index.rst
+++ b/boards/shields/reyax_lora/doc/index.rst
@@ -1,0 +1,29 @@
+.. lora_reyax:
+
+Reyax LoRa RYLR896 and RYLR915 Modules
+######################################
+
+Overview
+********
+
+These modules expose a simple uart interface for the Semtech SX1276 chip,which implements the LoRa PHY.
+
+More information about the board can be found at the
+`Reyax RYLR page`_.
+
+Hardware Description
+********************
+The Module contains 4 pins
+
+- VDD: Power Supply
+- NRST: Active low reset
+- RXD: Serial data input
+- TXD: Serial data output
+- GND: Ground
+
+References
+**********
+
+.. target-notes::
+.. _Reyax RYLR page:
+    https://reyax.com/products/RYLR896

--- a/boards/shields/reyax_lora/reyax_lora.overlay
+++ b/boards/shields/reyax_lora/reyax_lora.overlay
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2024 David Ullmann
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
+/{
+	aliases {
+		lora0 = &rylr_lora_modem;
+	};
+};
+
+
+&arduino_serial {
+	current-speed = <115200>;
+	status = "okay";
+	rylr_lora_modem: rylr_lora_modem {
+			compatible = "reyax,rylrxxx";
+			status = "okay";
+			reset-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>;
+	};
+};

--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -339,6 +339,11 @@ Drivers and Sensors
   * The ``chain-length`` and ``color-mapping`` properties have been added to all LED strip
     bindings.
 
+
+* LoRa
+
+  * Added driver for Reyax LoRa module
+
 * MDIO
 
 * MFD

--- a/drivers/lora/CMakeLists.txt
+++ b/drivers/lora/CMakeLists.txt
@@ -20,3 +20,4 @@ endif()
 
 zephyr_library_sources_ifdef(CONFIG_LORA_SX126X sx126x_standalone.c)
 zephyr_library_sources_ifdef(CONFIG_LORA_STM32WL_SUBGHZ_RADIO sx126x_stm32wl.c)
+zephyr_library_sources_ifdef(CONFIG_LORA_RYLRXXX rylrxxx.c)

--- a/drivers/lora/Kconfig
+++ b/drivers/lora/Kconfig
@@ -33,4 +33,6 @@ config LORA_INIT_PRIORITY
 
 source "drivers/lora/Kconfig.sx12xx"
 
+source "drivers/lora/Kconfig.rylrxxx"
+
 endif # LORA

--- a/drivers/lora/Kconfig.rylrxxx
+++ b/drivers/lora/Kconfig.rylrxxx
@@ -1,0 +1,44 @@
+#
+# Copyright (c) 2024 David Ullmann
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+config LORA_RYLRXXX
+	bool "Reyax LYLR driver"
+	depends on DT_HAS_REYAX_RYLRXXX_ENABLED
+	select MODEM_MODULES
+	select MODEM_CHAT
+	select MODEM_PIPE
+	select MODEM_BACKEND_UART
+	select GPIO
+	help
+	  Enable the Reyax LYLR driver
+
+if LORA_RYLRXXX
+
+config LORA_RYLRXX_CMD_BUF_SIZE
+	int "cmd buffer size"
+	default 256
+	help
+	  Configure the cmd buffer size
+
+config RYLRXXX_UNSOLICITED_RX_MSGQ_SIZE
+	int "number of message to store in message queue"
+	default 1
+	help
+	  Configure the size of message queue
+
+config RYLRXXX_RADIO_CMD_RESPONSE_TIMEOUT_MS
+	int "timeout when waiting for response from radio serial interface after send cmd"
+	default 500
+	help
+	  Configure the number of milliseconds before timing out when waiting for acknowledgment from radio after sending cmd
+
+config RYLRXXX_MODEM_BUFFERS_SIZE
+	int "size of buffers for modem library"
+	default 512
+	help
+	  Configure the size of buffers for modem library
+
+endif # LORA_RYLRXXX

--- a/drivers/lora/rylrxxx.c
+++ b/drivers/lora/rylrxxx.c
@@ -1,0 +1,684 @@
+/*
+ * Copyright (C) 2024 David Ullmann
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#define DT_DRV_COMPAT reyax_rylrxxx
+
+#include <zephyr/logging/log.h>
+#include <zephyr/drivers/uart.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/lora.h>
+#include <zephyr/modem/pipe.h>
+#include <zephyr/modem/backend/uart.h>
+#include <zephyr/modem/chat.h>
+#include <zephyr/sys/atomic.h>
+#include <errno.h>
+
+LOG_MODULE_REGISTER(rylr, CONFIG_LORA_LOG_LEVEL);
+
+#define RYLR_CMD_BAND_FORMAT                "AT+BAND=%u\r\n"
+#define RYLR_CMD_BAND_PARM_CHARS            9U
+#define RYLR_CMD_BAND_FORMAT_NUM_WILDCARDS  1U
+#define RYLR_CMD_BAND_FORMAT_WILDCARD_CHARS (RYLR_CMD_BAND_FORMAT_NUM_WILDCARDS * 2)
+#define RYLR_CMD_BAND_FORMAT_LEN_WITHOUT_WILDCARDS                                                 \
+	(sizeof(RYLR_CMD_BAND_FORMAT) - RYLR_CMD_BAND_FORMAT_WILDCARD_CHARS - 1)
+#define RYLR_CMD_BAND_LENGTH (RYLR_CMD_BAND_FORMAT_LEN_WITHOUT_WILDCARDS + RYLR_CMD_BAND_PARM_CHARS)
+
+#define RYLR_CMD_SEND_FORMAT                "AT+SEND=0,%u,%s\r\n"
+#define RYLR_CMD_SEND_FORMAT_NUM_WILDCARDS  2U
+#define RYLR_CMD_SEND_FORMAT_WILDCARD_CHARS (RYLR_CMD_SEND_FORMAT_NUM_WILDCARDS * 2)
+#define RYLR_CMD_SEND_FORMAT_LEN_WITHOUT_WILDCARDS                                                 \
+	(sizeof(RYLR_CMD_SEND_FORMAT) - RYLR_CMD_SEND_FORMAT_WILDCARD_CHARS - 1)
+#define RYLR_PAYLOAD_LENGTH_FIELD_CHARS(payload_len)                                               \
+	(payload_len >= 100 ? 3 : (payload_len >= 10 ? 2 : 1))
+#define RYLR_CMD_SEND_LENGTH(payload_len)                                                          \
+	(RYLR_CMD_SEND_FORMAT_LEN_WITHOUT_WILDCARDS +                                              \
+	 RYLR_PAYLOAD_LENGTH_FIELD_CHARS(payload_len) + payload_len)
+
+#define RYLR_CMD_RF_SETTINGS_FORMAT                "AT+PARAMETER=%u,%u,%u,%u\r\n"
+#define RYLR_CMD_RF_SETTINGS_FORMAT_NUM_WILDCARDS  4U
+#define RYLR_CMD_RF_SETTINGS_FORMAT_WILDCARD_CHARS (RYLR_CMD_RF_SETTINGS_FORMAT_NUM_WILDCARDS * 2U)
+#define RYLR_CMD_RF_SETTINGS_FORMAT_LEN_WITHOUT_WILDCARDS                                          \
+	(sizeof(RYLR_CMD_RF_SETTINGS_FORMAT) - RYLR_CMD_RF_SETTINGS_FORMAT_WILDCARD_CHARS - 1)
+#define RYLR_CMD_RF_SETTINGS_FORMAT_PARAM_CHARS(spread_factor)                                     \
+	(RYLR_CMD_RF_SETTINGS_FORMAT_NUM_WILDCARDS - 1) + (spread_factor >= 10U ? 2U : 1U)
+#define RYLR_CMD_RF_SETTINGS_LEN(spread_factor)                                                    \
+	(RYLR_CMD_RF_SETTINGS_FORMAT_LEN_WITHOUT_WILDCARDS +                                       \
+	 RYLR_CMD_RF_SETTINGS_FORMAT_PARAM_CHARS(spread_factor))
+
+#define RYLR_CMD_POWER_FORMAT                "AT+CRFOP=%u\r\n"
+#define RYLR_CMD_POWER_FORMAT_NUM_WILDCARDS  1U
+#define RYLR_CMD_POWER_FORMAT_WILDCARD_CHARS (RYLR_CMD_POWER_FORMAT_NUM_WILDCARDS * 2U)
+#define RYLR_CMD_POWER_FORMAT_LEN_WITHOUT_WILDCARDS                                                \
+	(sizeof(RYLR_CMD_POWER_FORMAT) - RYLR_CMD_POWER_FORMAT_WILDCARD_CHARS - 1)
+#define RYLR_CMD_POWER_FORMAT_PARAM_CHARS(power) (power >= 10U ? 2U : 1U)
+#define RYLR_CMD_POWER_LEN(power)                                                                  \
+	(RYLR_CMD_POWER_FORMAT_LEN_WITHOUT_WILDCARDS + RYLR_CMD_POWER_FORMAT_PARAM_CHARS(power))
+
+#define RYLR_MAX_RESPONSE  256
+#define RYLR_MAX_MSG_BYTES 256
+
+#define RYLR_ALLOC_TIMEOUT K_SECONDS(1)
+
+#define RYLR_TX_PENDING_FLAG_POS (0U)
+#define RYLR_RX_PENDING_FLAG_POS (1U)
+
+#define RYLR_IS_TX_PENDING(flags) (flags & (0x01 << RYLR_TX_PENDING_FLAG_POS))
+#define RYLR_IS_RX_PENDING(flags) (flags & (0x01 << RYLR_RX_PENDING_FLAG_POS))
+
+#define RYLR_SET_TX_PENDING(flags) (flags |= (0x01 << RYLR_TX_PENDING_FLAG_POS))
+#define RYLR_SET_RX_PENDING(flags) (flags |= (0x01 << RYLR_RX_PENDING_FLAG_POS))
+
+#define RYLR_CLEAR_TX_PENDING(flags) (flags &= ~(0x01 << RYLR_TX_PENDING_FLAG_POS))
+#define RYLR_CLEAR_RX_PENDING(flags) (flags &= ~(0x01 << RYLR_RX_PENDING_FLAG_POS))
+
+#define RYLR_IS_ASYNC_OP_PENDING(flags) (RYLR_IS_RX_PENDING(flags) || RYLR_IS_TX_PENDING(flags))
+
+#define RYLR_MAX_RESPONSE_ARGS 6U
+
+#define RYLR_MIN_RESET_MSECS  (100U)
+#define RYLR_RESET_WAIT_MSECS (RYLR_MIN_RESET_MSECS + 10U)
+
+struct rylr_config {
+	const struct device *uart;
+	const struct gpio_dt_spec reset;
+};
+
+struct rylr_data {
+	uint8_t cmd_buffer[CONFIG_LORA_RYLRXX_CMD_BUF_SIZE];
+	size_t curr_cmd_len;
+	bool is_tx;
+	int handler_error;
+	struct k_msgq rx_msgq;
+	struct k_sem script_sem;
+	struct k_sem operation_sem;
+	uint8_t pending_async_flags;
+	struct k_poll_signal *async_tx_signal;
+	lora_recv_cb async_rx_cb;
+	const struct device *dev;
+	uint8_t msgq_buffer[CONFIG_RYLRXXX_UNSOLICITED_RX_MSGQ_SIZE];
+	struct modem_pipe *modem_pipe;
+	uint8_t uart_backend_rx_buff[CONFIG_RYLRXXX_MODEM_BUFFERS_SIZE];
+	uint8_t uart_backend_tx_buff[CONFIG_RYLRXXX_MODEM_BUFFERS_SIZE];
+	struct modem_pipe *uart_pipe;
+	struct modem_backend_uart uart_backend;
+	uint8_t chat_rx_buf[CONFIG_RYLRXXX_MODEM_BUFFERS_SIZE];
+	uint8_t chat_tx_buf[CONFIG_RYLRXXX_MODEM_BUFFERS_SIZE];
+	uint8_t *chat_argv[RYLR_MAX_RESPONSE_ARGS];
+	struct modem_chat chat;
+	struct modem_chat_script dynamic_script;
+	struct modem_chat_script_chat dynamic_chat;
+};
+
+struct rylr_recv_msg {
+	uint16_t addr;
+	uint8_t length;
+	uint8_t *data;
+	uint8_t rssi;
+	uint8_t snr;
+};
+
+static void on_ok(struct modem_chat *chat, char **argv, uint16_t argc, void *user_data)
+{
+	int err = 0;
+	struct rylr_data *driver_data = user_data;
+
+	driver_data->handler_error = err;
+}
+
+static void on_err(struct modem_chat *chat, char **argv, uint16_t argc, void *user_data)
+{
+	int radio_err = 0;
+	struct rylr_data *driver_data = user_data;
+
+	driver_data->handler_error = -EIO;
+
+	if (argc != 2) {
+		driver_data->handler_error = -EBADMSG;
+		LOG_ERR("malformed error message from radio");
+		return;
+	}
+
+	radio_err = atoi(argv[1]);
+	LOG_ERR("error from rylr: %d", radio_err);
+}
+
+static void on_rx(struct modem_chat *chat, char **argv, uint16_t argc, void *user_data)
+{
+	struct rylr_data *driver_data = user_data;
+	struct rylr_recv_msg msg;
+	int err = 0;
+
+	driver_data->handler_error = 0;
+
+	if (argc != 6) {
+		driver_data->handler_error = -EBADMSG;
+		return;
+	}
+
+	msg.addr = atoi(argv[1]);
+	msg.length = atoi(argv[2]);
+	msg.data = argv[3];
+	msg.rssi = atoi(argv[4]);
+	msg.snr = atoi(argv[5]);
+
+	if (RYLR_IS_RX_PENDING(driver_data->pending_async_flags)) {
+		driver_data->async_rx_cb(driver_data->dev, msg.data, msg.length, msg.rssi, msg.snr);
+	} else {
+		err = k_msgq_put(&driver_data->rx_msgq, &msg, K_NO_WAIT);
+		if (err != 0) {
+			LOG_ERR("error adding messgae to queue: %d", err);
+			driver_data->handler_error = err;
+		}
+	}
+}
+
+static void on_script_finished(struct modem_chat *chat, enum modem_chat_script_result result,
+			       void *user_data)
+{
+	struct rylr_data *driver_data = user_data;
+
+	if (RYLR_IS_TX_PENDING(driver_data->pending_async_flags)) {
+		RYLR_CLEAR_TX_PENDING(driver_data->pending_async_flags);
+		k_poll_signal_raise(driver_data->async_tx_signal, driver_data->handler_error);
+		k_sem_give(&driver_data->operation_sem);
+	}
+
+	k_sem_give(&driver_data->script_sem);
+}
+
+MODEM_CHAT_MATCH_DEFINE(ok_match, "+OK", "", on_ok);
+
+MODEM_CHAT_MATCHES_DEFINE(abort_matches, MODEM_CHAT_MATCH("+ERR=", "", on_err));
+
+MODEM_CHAT_MATCHES_DEFINE(unsol_matches, MODEM_CHAT_MATCH("+RCV=", ",", on_rx));
+
+MODEM_CHAT_SCRIPT_CMDS_DEFINE(ping_cmd, MODEM_CHAT_SCRIPT_CMD_RESP("AT\r\n", ok_match));
+
+MODEM_CHAT_SCRIPT_DEFINE(ping_script, ping_cmd, abort_matches, on_script_finished,
+			 CONFIG_RYLRXXX_RADIO_CMD_RESPONSE_TIMEOUT_MS);
+
+static void rylr_reset_dynamic_script(struct rylr_data *data)
+{
+	data->dynamic_chat.response_matches = &ok_match;
+	data->dynamic_chat.response_matches_size = 1;
+	data->dynamic_chat.timeout = 0;
+
+	data->dynamic_script.script_chats = &data->dynamic_chat;
+	data->dynamic_script.script_chats_size = 1;
+	data->dynamic_script.abort_matches = abort_matches;
+	data->dynamic_script.abort_matches_size = 1;
+	data->dynamic_script.callback = on_script_finished;
+	data->dynamic_script.timeout = CONFIG_RYLRXXX_RADIO_CMD_RESPONSE_TIMEOUT_MS;
+}
+
+static uint32_t rylr_get_bandwidth_index(enum lora_signal_bandwidth bw)
+{
+	switch (bw) {
+	case BW_125_KHZ:
+		return 7;
+	case BW_250_KHZ:
+		return 8;
+	case BW_500_KHZ:
+		return 9;
+	default:
+		return 7;
+	}
+}
+
+static int rylr_send_cmd_buffer(const struct device *dev)
+{
+	int err = 0;
+	struct rylr_data *data = dev->data;
+
+	rylr_reset_dynamic_script(data);
+
+	data->dynamic_chat.request = data->cmd_buffer;
+	data->dynamic_chat.request_size = data->curr_cmd_len;
+
+	err = modem_chat_run_script(&data->chat, &data->dynamic_script);
+	if (err != 0) {
+		LOG_ERR("could not send cmd: %s. err: %d", data->cmd_buffer, err);
+		return err;
+	}
+	err = k_sem_take(&data->script_sem, K_MSEC(CONFIG_RYLRXXX_RADIO_CMD_RESPONSE_TIMEOUT_MS));
+	if (err) {
+		LOG_ERR("error waiting for response: %d", err);
+		return err;
+	}
+	return data->handler_error;
+}
+
+static int rylr_set_rf_band(const struct device *dev, uint32_t frequency)
+{
+	struct rylr_data *data = dev->data;
+
+	if (sprintf(data->cmd_buffer, RYLR_CMD_BAND_FORMAT, frequency) != RYLR_CMD_BAND_LENGTH) {
+		LOG_ERR("could not create frequency string");
+		return -EINVAL;
+	}
+
+	data->curr_cmd_len = RYLR_CMD_BAND_LENGTH;
+	return rylr_send_cmd_buffer(dev);
+}
+
+static int rylr_set_rf_parameters(const struct device *dev, uint32_t datarate, uint32_t bandwidth,
+				  uint32_t coding_rate, uint32_t preamble_length)
+{
+	struct rylr_data *data = dev->data;
+	size_t cmd_len;
+
+	if (datarate < 7 || datarate > 12) {
+		LOG_ERR("datarate/spread factor must be between 7 and 12 inclusive");
+		return -EINVAL;
+	}
+
+	if (coding_rate < 1 || coding_rate > 4) {
+		LOG_ERR("coding rate must be between 1 and 4 inclusive");
+		return -EINVAL;
+	}
+
+	if (preamble_length < 4 || preamble_length > 7) {
+		LOG_ERR("preamble length must be between 4 and 7 inclusive");
+		return -EINVAL;
+	}
+
+	cmd_len = sprintf(data->cmd_buffer, RYLR_CMD_RF_SETTINGS_FORMAT, datarate,
+			  rylr_get_bandwidth_index(bandwidth), coding_rate, preamble_length);
+	if (cmd_len != RYLR_CMD_RF_SETTINGS_LEN(datarate)) {
+		LOG_ERR("could not create rf settings string");
+		return -EINVAL;
+	}
+
+	data->curr_cmd_len = cmd_len;
+	return rylr_send_cmd_buffer(dev);
+}
+
+static int rylr_set_power(const struct device *dev, uint32_t power)
+{
+	struct rylr_data *data = dev->data;
+	size_t cmd_len;
+
+	if (power > 15) {
+		LOG_ERR("power cannot be greater than 15");
+		return -EINVAL;
+	}
+
+	cmd_len = RYLR_CMD_POWER_LEN(power);
+	if (sprintf(data->cmd_buffer, RYLR_CMD_POWER_FORMAT, power) != cmd_len) {
+		LOG_ERR("could not create power string");
+		return -EINVAL;
+	}
+
+	data->curr_cmd_len = cmd_len;
+	return rylr_send_cmd_buffer(dev);
+}
+
+static int rylr_config(const struct device *dev, struct lora_modem_config *config)
+{
+	int err = 0;
+	struct rylr_data *data = dev->data;
+
+	err = k_sem_take(&data->operation_sem, K_NO_WAIT);
+	if (err != 0) {
+		LOG_ERR("error taking operation semaphore: %d", err);
+		return err;
+	}
+
+	if (RYLR_IS_ASYNC_OP_PENDING(data->pending_async_flags)) {
+		LOG_ERR("pending async opperation");
+		err = -EBUSY;
+		goto exit;
+	}
+
+	err = rylr_set_rf_band(dev, config->frequency);
+	if (err != 0) {
+		LOG_ERR("could not send frequency cmd: %d", err);
+		goto exit;
+	}
+
+	err = rylr_set_rf_parameters(dev, config->datarate, config->bandwidth, config->coding_rate,
+				     config->preamble_len);
+	if (err != 0) {
+		LOG_ERR("could not send rf params cmd: %d", err);
+		goto exit;
+	}
+
+	err = rylr_set_power(dev, config->tx_power);
+	if (err != 0) {
+		LOG_ERR("could not send power cmd: %d", err);
+		goto exit;
+	}
+
+	data->is_tx = config->tx;
+
+exit:
+	k_sem_give(&data->operation_sem);
+	return err;
+}
+
+int rylr_send(const struct device *dev, uint8_t *payload, uint32_t payload_len)
+{
+	int err = 0;
+	struct rylr_data *data = dev->data;
+	int cmd_len = RYLR_CMD_SEND_LENGTH(payload_len);
+
+	err = k_sem_take(&data->operation_sem, K_NO_WAIT);
+	if (err != 0) {
+		LOG_ERR("error taking operation semaphore: %d", err);
+		return err;
+	}
+
+	if (RYLR_IS_ASYNC_OP_PENDING(data->pending_async_flags)) {
+		LOG_ERR("pending async opperation");
+		err = -EBUSY;
+		goto exit;
+	}
+
+	if (!data->is_tx) {
+		LOG_ERR("radio not configured in tx mode");
+		err = -EOPNOTSUPP;
+		goto exit;
+	}
+
+	if (cmd_len > CONFIG_LORA_RYLRXX_CMD_BUF_SIZE) {
+		LOG_ERR("payload too long");
+		err = -EINVAL;
+		goto exit;
+	}
+
+	snprintf(data->cmd_buffer, cmd_len + 1, RYLR_CMD_SEND_FORMAT, payload_len, payload);
+	data->curr_cmd_len = cmd_len;
+	err = rylr_send_cmd_buffer(dev);
+	if (err != 0) {
+		LOG_ERR("error sending data: %d", err);
+		goto exit;
+	}
+
+exit:
+	k_sem_give(&data->operation_sem);
+	return err;
+}
+
+int rylr_send_async(const struct device *dev, uint8_t *payload, uint32_t payload_len,
+		    struct k_poll_signal *async)
+{
+	int err = 0;
+	struct rylr_data *data = dev->data;
+	int cmd_len;
+
+	err = k_sem_take(&data->operation_sem, K_NO_WAIT);
+	if (err != 0) {
+		LOG_ERR("error taking operation sem: %d", err);
+		return err;
+	}
+
+	if (RYLR_IS_ASYNC_OP_PENDING(data->pending_async_flags)) {
+		LOG_ERR("pending async opperation");
+		err = -EBUSY;
+		goto bail;
+	}
+
+	RYLR_SET_TX_PENDING(data->pending_async_flags);
+
+	if (!data->is_tx) {
+		LOG_ERR("radio not configured in tx mode");
+		err = -EOPNOTSUPP;
+		goto bail;
+	}
+
+	cmd_len = RYLR_CMD_SEND_LENGTH(payload_len);
+	if (cmd_len > CONFIG_LORA_RYLRXX_CMD_BUF_SIZE) {
+		LOG_ERR("payload too long");
+		err = -EINVAL;
+		goto bail;
+	}
+
+	if (async == NULL) {
+		LOG_ERR("async signal cannot be null");
+		err = -EINVAL;
+		goto bail;
+	}
+
+	data->async_tx_signal = async;
+	data->curr_cmd_len =
+		snprintf(data->cmd_buffer, cmd_len + 1, RYLR_CMD_SEND_FORMAT, payload_len, payload);
+	rylr_reset_dynamic_script(data);
+	data->dynamic_chat.request = data->cmd_buffer;
+	data->dynamic_chat.request_size = data->curr_cmd_len;
+
+	return modem_chat_run_script_async(&data->chat, &data->dynamic_script);
+bail:
+	RYLR_CLEAR_TX_PENDING(data->pending_async_flags);
+	k_sem_give(&data->operation_sem);
+	return err;
+}
+
+int rylr_recv(const struct device *dev, uint8_t *ret_msg, uint8_t size, k_timeout_t timeout,
+	      int16_t *rssi, int8_t *snr)
+{
+
+	int ret = 0;
+	struct rylr_data *data = dev->data;
+	struct rylr_recv_msg msg;
+
+	ret = k_sem_take(&data->operation_sem, K_NO_WAIT);
+	if (ret != 0) {
+		LOG_ERR("error taking operation semaphore: %d", ret);
+		return ret;
+	}
+
+	if (data->is_tx) {
+		LOG_ERR("radio is configured for tx");
+		ret = -EOPNOTSUPP;
+		goto exit;
+	}
+
+	if (RYLR_IS_ASYNC_OP_PENDING(data->pending_async_flags)) {
+		LOG_ERR("pending async opperation");
+		ret = -EBUSY;
+		goto exit;
+	}
+
+	ret = k_msgq_get(&data->rx_msgq, &msg, timeout);
+	if (ret != 0) {
+		LOG_ERR("error getting msg from queue: %d", ret);
+		goto exit;
+	}
+
+	ret = data->handler_error;
+	if (ret != 0) {
+		LOG_ERR("error in recv cb: %d", ret);
+		goto exit;
+	}
+
+	if (msg.length > size) {
+		LOG_ERR("buf len of %u too small for message len of %u", size, msg.length);
+		ret = -ENOBUFS;
+		goto exit;
+	}
+
+	*rssi = msg.rssi;
+	*snr = msg.snr;
+	memcpy(ret_msg, msg.data, msg.length);
+	ret = msg.length;
+
+exit:
+	k_sem_give(&data->operation_sem);
+	return ret;
+}
+
+int rylr_recv_async(const struct device *dev, lora_recv_cb cb)
+{
+	int err = 0;
+	struct rylr_data *data = dev->data;
+
+	err = k_sem_take(&data->operation_sem, K_NO_WAIT);
+	if (err != 0) {
+		LOG_ERR("error taking operation semaphore: %d", err);
+		return err;
+	}
+
+	/* This is not a user error but the documeted way to cancel async reception in lora api*/
+	if (cb == NULL) {
+		goto bail;
+	}
+
+	if (data->is_tx) {
+		LOG_ERR("radio is configured for tx");
+		err = -EOPNOTSUPP;
+		goto bail;
+	}
+
+	data->async_rx_cb = cb;
+	if (RYLR_IS_ASYNC_OP_PENDING(data->pending_async_flags)) {
+		LOG_ERR("pending async opperation");
+		err = -EBUSY;
+		goto bail;
+	}
+	RYLR_SET_RX_PENDING(data->pending_async_flags);
+
+	return err;
+bail:
+	RYLR_CLEAR_RX_PENDING(data->pending_async_flags);
+	k_sem_give(&data->operation_sem);
+	return err;
+}
+
+int rylr_test_cw(const struct device *dev, uint32_t frequency, int8_t tx_power, uint16_t duration)
+{
+	return -ENOSYS;
+}
+
+static int rylr_init(const struct device *dev)
+{
+	int err = 0;
+	struct rylr_data *data = dev->data;
+	const struct rylr_config *config = dev->config;
+
+	if (!gpio_is_ready_dt(&config->reset)) {
+		return -ENODEV;
+	}
+
+	if (!device_is_ready(config->uart)) {
+		return -ENODEV;
+	}
+
+	err = gpio_pin_configure_dt(&config->reset, config->reset.dt_flags);
+	if (err != 0) {
+		LOG_ERR("error configuring reset gpio: %d", err);
+		return err;
+	}
+
+	k_msgq_init(&data->rx_msgq, data->msgq_buffer, sizeof(struct rylr_recv_msg),
+		    ARRAY_SIZE(data->msgq_buffer));
+
+	err = k_sem_init(&data->script_sem, 0, 1);
+	if (err != 0) {
+		LOG_ERR("error initializing response semaphore. err=%d", err);
+	}
+
+	err = k_sem_init(&data->operation_sem, 1, 1);
+	if (err != 0) {
+		LOG_ERR("error initializing operation semaphore. err=%d", err);
+	}
+
+	const struct modem_backend_uart_config uart_backend_config = {
+		.uart = config->uart,
+		.receive_buf = data->uart_backend_rx_buff,
+		.receive_buf_size = ARRAY_SIZE(data->uart_backend_rx_buff),
+		.transmit_buf = data->uart_backend_tx_buff,
+		.transmit_buf_size = ARRAY_SIZE(data->uart_backend_tx_buff),
+	};
+
+	data->uart_pipe = modem_backend_uart_init(&data->uart_backend, &uart_backend_config);
+
+	const struct modem_chat_config chat_config = {
+		.user_data = data,
+		.receive_buf = data->chat_rx_buf,
+		.receive_buf_size = ARRAY_SIZE(data->chat_rx_buf),
+		.delimiter = "\r\n",
+		.delimiter_size = sizeof("\r\n") - 1,
+		.filter = NULL,
+		.filter_size = 0,
+		.argv = data->chat_argv,
+		.argv_size = ARRAY_SIZE(data->chat_argv),
+		.unsol_matches = unsol_matches,
+		.unsol_matches_size = ARRAY_SIZE(unsol_matches),
+	};
+
+	err = modem_chat_init(&data->chat, &chat_config);
+	if (err != 0) {
+		LOG_ERR("error initializing chat %d", err);
+		return err;
+	}
+
+	err = modem_chat_attach(&data->chat, data->uart_pipe);
+	if (err != 0) {
+		LOG_ERR("error attaching chat %d", err);
+		return err;
+	}
+
+	err = modem_pipe_open(data->uart_pipe);
+	if (err != 0) {
+		LOG_ERR("error opening uart pipe %d", err);
+		return err;
+	}
+
+	err = gpio_pin_set_dt(&config->reset, 1);
+	if (err != 0) {
+		LOG_ERR("error setting reset line: %d", err);
+		return err;
+	}
+
+	k_sleep(K_MSEC(RYLR_RESET_WAIT_MSECS));
+
+	err = gpio_pin_set_dt(&config->reset, 0);
+	if (err != 0) {
+		LOG_ERR("error unsetting reset line: %d", err);
+		return err;
+	}
+
+	k_sleep(K_MSEC(RYLR_RESET_WAIT_MSECS)); /* wait a bit more for module to boot up*/
+
+	err = modem_chat_run_script(&data->chat, &ping_script);
+	if (err != 0) {
+		LOG_ERR("error pinging radio: %d", err);
+		return err;
+	}
+
+	err = k_sem_take(&data->script_sem, K_MSEC(CONFIG_RYLRXXX_RADIO_CMD_RESPONSE_TIMEOUT_MS));
+	if (err != 0) {
+		LOG_ERR("error waiting for ping response from radio %d", err);
+		return err;
+	}
+
+	LOG_INF("successfully initialized rylr");
+	return err;
+}
+
+static const struct lora_driver_api rylr_lora_api = {
+	.config = rylr_config,
+	.send = rylr_send,
+	.send_async = rylr_send_async,
+	.recv = rylr_recv,
+	.recv_async = rylr_recv_async,
+	.test_cw = rylr_test_cw,
+};
+
+#define RYLR_DEVICE_INIT(n)                                                                        \
+	static struct rylr_data dev_data_##n;                                                      \
+	static const struct rylr_config dev_config_##n = {                                         \
+		.uart = DEVICE_DT_GET(DT_INST_BUS(n)),                                             \
+		.reset = GPIO_DT_SPEC_INST_GET(n, reset_gpios),                                    \
+	};                                                                                         \
+	DEVICE_DT_INST_DEFINE(n, &rylr_init, NULL, &dev_data_##n, &dev_config_##n, POST_KERNEL,    \
+			      CONFIG_LORA_INIT_PRIORITY, &rylr_lora_api);
+
+DT_INST_FOREACH_STATUS_OKAY(RYLR_DEVICE_INIT)

--- a/dts/bindings/lora/reyax,rylrxxx.yaml
+++ b/dts/bindings/lora/reyax,rylrxxx.yaml
@@ -1,0 +1,13 @@
+# Copyright (c) 2024 David Ullmann
+# SPDX-License-Identifier: Apache-2.0
+
+description: Reyax lora module with AT-command serial interface
+
+compatible: "reyax,rylrxxx"
+
+include: uart-device.yaml
+
+properties:
+  reset-gpios:
+    type: phandle-array
+    required: true

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -553,6 +553,7 @@ renode	Antmicro's open source simulation and virtual development framework
 rervision	Shenzhen Rervision Technology Co., Ltd.
 revotics	Revolution Robotics, Inc. (Revotics)
 rex	iMX6 Rex Project
+reyax	Reyax Technology Co., Ltd.
 richtek	Richtek Technology Corporation
 ricoh	Ricoh Co. Ltd.
 rikomagic	Rikomagic Tech Corp. Ltd

--- a/tests/drivers/build_all/lora/CMakeLists.txt
+++ b/tests/drivers/build_all/lora/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(build_all)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/drivers/build_all/lora/prj.conf
+++ b/tests/drivers/build_all/lora/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_TEST=y

--- a/tests/drivers/build_all/lora/src/main.c
+++ b/tests/drivers/build_all/lora/src/main.c
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2024 David Ullmann
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+int main(void)
+{
+	return 0;
+}

--- a/tests/drivers/build_all/lora/testcase.yaml
+++ b/tests/drivers/build_all/lora/testcase.yaml
@@ -1,0 +1,4 @@
+tests:
+  sample.driver.lora.rylr.send:
+    extra_args: SHIELD=reyax_lora
+    platform_allow: cy8ckit_062s4


### PR DESCRIPTION
writing a driver that implements the lora api for  [reyax lora rylr series modules](https://reyax.com/products/RYLR896) using the zephyr modem utilities.

Note: the bulk of this driver is implemented in `drivers/lora/rylrxxx.c` which must be opened manually (marked by "Large diffs are not rendered by default" warning) 

I tested with two modules: one connected to my board and the other connected to my PC via uart adapter. 

I built the `samples/hello_world` project
```
west build -b cy8ckit_062s4 --pristine -- -DSHIELD=reyax_lora -DCONFIG_LOG=y -DCONFIG_SHELL=y -DCONFIG_LORA_SHELL=y
west flash
```


in the zephyr shell, I sent:
```
uart:~$ lora config pre-len 7
uart:~$ lora config freq 865100000
uart:~$ lora send HELLO
```

on the serial console in my PC, I saw:
```
+RCV=1,5,HELLO,-41,36
```

then I ran this command in the zephyr terminal:
```
uart:~$ lora recv 
```
and I sent this command to the PC-connected module:
```
AT+SEND=0,3,sup
```
I saw this output in zephyr terminal:

```
00000000: 73 75 70                                         |sup              |
RSSI: 208 dBm, SNR:38 dBm
```





Signed-off-by: David Ullmann <davidl.ullmann@gmail.com>