### PR TITLE
net: if: Init must be called before setting the name

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -4998,6 +4998,8 @@ void net_if_init(void)
 
 	STRUCT_SECTION_FOREACH(net_if, iface) {
 
+		init_iface(iface);
+
 #if defined(CONFIG_NET_INTERFACE_NAME)
 		memset(net_if_get_config(iface)->name, 0,
 		       sizeof(iface->config.name));
@@ -5005,7 +5007,6 @@ void net_if_init(void)
 		set_default_name(iface);
 #endif
 
-		init_iface(iface);
 		if_count++;
 	}
 


### PR DESCRIPTION
As the interface init function might configure the system such a way that would affect the naming of the network interface, we need to call the init before setting the name. This is mostly needed by Wifi where the Wifi driver needs to mark its network interface as Wifi interface as by default the Wifi interface will look like Ethernet one.