### PR TITLE
dts: vendor-prefixes: Add Bang & Olufsen A/S

### DIFF
--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -90,6 +90,7 @@ baikal	BAIKAL ELECTRONICS, JSC
 bananapi	BIPAI KEJI LIMITED
 beacon	Compass Electronics Group, LLC
 beagle	BeagleBoard.org Foundation
+beo	Bang & Olufsen A/S
 bhf	Beckhoff Automation GmbH & Co. KG
 bitmain	Bitmain Technologies
 blues	Blues Wireless


### PR DESCRIPTION
Add Bang & Olufsen vendor prefix.