### PR TITLE
libc/newlib: define _LOCK_T

### DIFF
--- a/lib/libc/newlib/libc-hooks.c
+++ b/lib/libc/newlib/libc-hooks.c
@@ -304,6 +304,7 @@ void *_sbrk(intptr_t count)
 __weak FUNC_ALIAS(_sbrk, sbrk, void *);
 
 #ifdef CONFIG_MULTITHREADING
+#define _LOCK_T void *
 
 /* Make sure _RETARGETABLE_LOCKING is enabled in toolchain */
 BUILD_ASSERT(IS_ENABLED(_RETARGETABLE_LOCKING), "Retargetable locking must be enabled");


### PR DESCRIPTION
Add definition of _LOCK_T to satisfy compiler about types in __ASSERT statements, as it is done in picolibc.