### PR TITLE
STM32WBA: Do not enable Standby by default

### DIFF
--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -33,7 +33,8 @@
 			device_type = "cpu";
 			compatible = "arm,cortex-m33";
 			reg = <0>;
-			cpu-power-states = <&stop0 &stop1 &standby>;
+			/* Do not add &standby here since CONFIG_PM_S2RAM is disabled by default */
+			cpu-power-states = <&stop0 &stop1>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 

--- a/samples/boards/stm32/power_mgmt/suspend_to_ram/boards/nucleo_wba55cg.overlay
+++ b/samples/boards/stm32/power_mgmt/suspend_to_ram/boards/nucleo_wba55cg.overlay
@@ -7,6 +7,10 @@
 / {
 	/* Change min residency time to ease power consumption measurement */
 	cpus {
+		cpu0: cpu@0 {
+			cpu-power-states = <&stop0 &stop1 &standby>;
+		};
+
 		power-states {
 			stop0: state0 {
 				min-residency-us = <500000>;


### PR DESCRIPTION
STM32WBA had Standby low-power mode enabled by default. That can cause issues if Kconfig PM_S2RAM is disabled (which is the default state) since we could enter an unsupported low power mode.

This PR removes the Standby state from the default dtsi, and enables it only in the overlay of the sample dedicated to Suspend to RAM.