### PR TITLE
drivers: dac: esp32: fix clock control subsys argument

### DIFF
--- a/drivers/dac/dac_esp32.c
+++ b/drivers/dac/dac_esp32.c
@@ -66,7 +66,7 @@ static int dac_esp32_init(const struct device *dev)
 	}
 
 	if (clock_control_on(cfg->clock_dev,
-		(clock_control_subsys_t) &cfg->clock_subsys) != 0) {
+		(clock_control_subsys_t) cfg->clock_subsys) != 0) {
 		LOG_ERR("DAC clock setup failed (%d)", -EIO);
 		return -EIO;
 	}


### PR DESCRIPTION
Current cfg->clock_subsys is passed as address and is causing driver assertion.

Fixes #69198