### PR TITLE
mgmt: hawkbit: define attributes in the user application

### DIFF
--- a/include/zephyr/mgmt/hawkbit.h
+++ b/include/zephyr/mgmt/hawkbit.h
@@ -37,6 +37,33 @@ enum hawkbit_response {
 };
 
 /**
+ * @brief Callback to provide the custom data to the hawkBit server.
+ *
+ * @details This callback is used to provide the custom data to the hawkBit server.
+ * The custom data is used to provide the hawkBit server with the device specific
+ * data.
+ *
+ * @param device_id The device ID.
+ * @param buffer The buffer to store the json.
+ * @param buffer_size The size of the buffer.
+ */
+typedef int (*hawkbit_config_device_data_cb_handler_t)(const char *device_id, uint8_t *buffer,
+						  const size_t buffer_size);
+
+/**
+ * @brief Set the custom data callback.
+ *
+ * @details This function is used to set the custom data callback.
+ * The callback is used to provide the custom data to the hawkBit server.
+ *
+ * @param cb The callback function.
+ *
+ * @return 0 on success.
+ * @return -EINVAL if the callback is NULL.
+ */
+int hawkbit_set_custom_data_cb(hawkbit_config_device_data_cb_handler_t cb);
+
+/**
  * @brief Init the flash partition
  *
  * @return 0 on success, negative on error.

--- a/samples/subsys/mgmt/hawkbit/prj.conf
+++ b/samples/subsys/mgmt/hawkbit/prj.conf
@@ -58,3 +58,6 @@ CONFIG_LOG_BUFFER_SIZE=4096
 
 #Generate HEX output
 CONFIG_BUILD_OUTPUT_HEX=y
+
+#Use custom attributes for hawkBit
+CONFIG_HAWKBIT_CUSTOM_ATTRIBUTES=y

--- a/samples/subsys/mgmt/hawkbit/src/main.c
+++ b/samples/subsys/mgmt/hawkbit/src/main.c
@@ -10,6 +10,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/reboot.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/data/json.h>
 
 #include "dhcp.h"
 
@@ -19,6 +20,40 @@
 #endif
 
 LOG_MODULE_REGISTER(main);
+
+#ifdef CONFIG_HAWKBIT_CUSTOM_ATTRIBUTES
+struct hawkbit_cfg_data {
+	const char *VIN;
+	const char *customAttr;
+};
+
+struct hawkbit_cfg {
+	const char *mode;
+	struct hawkbit_cfg_data data;
+};
+
+static const struct json_obj_descr json_cfg_data_descr[] = {
+	JSON_OBJ_DESCR_PRIM(struct hawkbit_cfg_data, VIN, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM(struct hawkbit_cfg_data, customAttr, JSON_TOK_STRING),
+};
+
+static const struct json_obj_descr json_cfg_descr[] = {
+	JSON_OBJ_DESCR_PRIM(struct hawkbit_cfg, mode, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_OBJECT(struct hawkbit_cfg, data, json_cfg_data_descr),
+};
+
+int hawkbit_new_config_data_cb(const char *device_id, uint8_t *buffer, const size_t buffer_size)
+{
+	struct hawkbit_cfg cfg = {
+		.mode = "merge",
+		.data.VIN = device_id,
+		.data.customAttr = "Hello World!",
+	};
+
+	return json_obj_encode_buf(json_cfg_descr, ARRAY_SIZE(json_cfg_descr), &cfg, buffer,
+				   buffer_size);
+}
+#endif /* CONFIG_HAWKBIT_CUSTOM_ATTRIBUTES */
 
 int main(void)
 {
@@ -33,6 +68,12 @@ int main(void)
 	tls_credential_add(CA_CERTIFICATE_TAG, TLS_CREDENTIAL_CA_CERTIFICATE,
 			   ca_certificate, sizeof(ca_certificate));
 #endif
+#ifdef CONFIG_HAWKBIT_CUSTOM_ATTRIBUTES
+	ret = hawkbit_set_custom_data_cb(hawkbit_new_config_data_cb);
+	if (ret < 0) {
+		LOG_ERR("Failed to set custom data callback");
+	}
+#endif /* CONFIG_HAWKBIT_CUSTOM_ATTRIBUTES */
 
 	ret = hawkbit_init();
 

--- a/subsys/mgmt/hawkbit/Kconfig
+++ b/subsys/mgmt/hawkbit/Kconfig
@@ -79,6 +79,19 @@ config HAWKBIT_DDI_SECURITY_TOKEN
 	  Authentication security token for the configured hawkBit DDI
 	  authentication mode.
 
+config HAWKBIT_CUSTOM_ATTRIBUTES
+	bool "Custom device attributes"
+	help
+	  Use custom definition of device attributes.
+
+config HAWKBIT_STATUS_BUFFER_SIZE
+	int "hawkBit status buffer size"
+	default 200
+	help
+	  Set the size of the buffer, which is used to store the
+	  json strings, that are sent to the hawkBit server. It might
+	  be increased if the custom attributes are used extensively.
+
 module = HAWKBIT
 module-str = Log Level for hawkbit
 module-help = Enables logging for hawkBit code.


### PR DESCRIPTION
Attributes can now be defined in the user application by the use of a callback function. 
Resolves: #37640 

![image](https://github.com/zephyrproject-rtos/zephyr/assets/56227405/78eaf838-dc5e-4700-a62c-ccfc5fe5f3f8)