### PR TITLE
net: Add more specific dependencies for specialized samples

### DIFF
--- a/samples/net/dsa/sample.yaml
+++ b/samples/net/dsa/sample.yaml
@@ -10,4 +10,4 @@ tests:
   sample.net.dsa:
     build_only: true
     platform_allow: ip_k66f
-    depends_on: netif
+    depends_on: eth

--- a/samples/net/gptp/sample.yaml
+++ b/samples/net/gptp/sample.yaml
@@ -18,7 +18,7 @@ tests:
       - nucleo_f767zi
       - nucleo_h743zi
       - nucleo_h745zi_q/stm32h745xx/m7
-    depends_on: netif
+    depends_on: eth
     integration_platforms:
       - frdm_k64f
   sample.net.gpt.nxp_enet_experimental:

--- a/samples/net/lldp/sample.yaml
+++ b/samples/net/lldp/sample.yaml
@@ -15,4 +15,4 @@ tests:
       - native_sim_64
     integration_platforms:
       - native_sim
-    depends_on: netif
+    depends_on: eth

--- a/samples/net/openthread/coprocessor/sample.yaml
+++ b/samples/net/openthread/coprocessor/sample.yaml
@@ -3,7 +3,7 @@ common:
   tags:
     - net
     - openthread
-  depends_on: netif
+  depends_on: openthread
   min_flash: 140
 sample:
   description: Runs the OpenThread stack as NCP BR

--- a/samples/net/vlan/sample.yaml
+++ b/samples/net/vlan/sample.yaml
@@ -8,4 +8,4 @@ sample:
   name: VLAN sample app
 tests:
   sample.net.vlan:
-    depends_on: netif
+    depends_on: eth


### PR DESCRIPTION
Certain samples  are supposed to demonstrate technology-specific features, therefore their dependencies in sample.yml could be narrowed to verify build only on boards which support that specific technology (like Ethernet or OpenThread).

Resolves #51079