### PR TITLE
Beechwoods fixes

### DIFF
--- a/include/zephyr/net/buf.h
+++ b/include/zephyr/net/buf.h
@@ -865,7 +865,7 @@ struct net_buf_simple_state {
 static inline void net_buf_simple_save(struct net_buf_simple *buf,
 				       struct net_buf_simple_state *state)
 {
-	state->offset = net_buf_simple_headroom(buf);
+        state->offset = (uint16_t)net_buf_simple_headroom(buf);
 	state->len = buf->len;
 }
 

--- a/include/zephyr/net/hostname.h
+++ b/include/zephyr/net/hostname.h
@@ -74,6 +74,8 @@ int net_hostname_set_postfix(const uint8_t *hostname_postfix,
 static inline int net_hostname_set_postfix(const uint8_t *hostname_postfix,
 					   int postfix_len)
 {
+	(void) hostname_postfix;
+	(void) postfix_len;
 	return -EMSGSIZE;
 }
 #endif /* CONFIG_NET_HOSTNAME_UNIQUE */

--- a/include/zephyr/net/net_context.h
+++ b/include/zephyr/net/net_context.h
@@ -394,7 +394,7 @@ static inline void net_context_set_accepting(struct net_context *context,
 	if (accepting) {
 		context->flags |= NET_CONTEXT_ACCEPTING_SOCK;
 	} else {
-		context->flags &= ~NET_CONTEXT_ACCEPTING_SOCK;
+	  context->flags &= (uint16_t)~NET_CONTEXT_ACCEPTING_SOCK;
 	}
 }
 
@@ -426,7 +426,7 @@ static inline void net_context_set_closing(struct net_context *context,
 	if (closing) {
 		context->flags |= NET_CONTEXT_CLOSING_SOCK;
 	} else {
-		context->flags &= ~NET_CONTEXT_CLOSING_SOCK;
+	  context->flags &= (uint16_t)~NET_CONTEXT_CLOSING_SOCK;
 	}
 }
 
@@ -506,7 +506,7 @@ static inline void net_context_set_family(struct net_context *context,
 	if (family == AF_UNSPEC || family == AF_INET || family == AF_INET6 ||
 	    family == AF_PACKET || family == AF_CAN) {
 		/* Family is in BIT(4), BIT(5) and BIT(6) */
-		flag = family << 3;
+	  flag = (uint8_t)(family << 3);
 	}
 
 	context->flags |= flag;
@@ -548,7 +548,7 @@ static inline void net_context_set_type(struct net_context *context,
 
 	if (type == SOCK_DGRAM || type == SOCK_STREAM || type == SOCK_RAW) {
 		/* Type is in BIT(6) and BIT(7)*/
-		flag = type << 6;
+	  flag = (uint16_t)(type << 6);
 	}
 
 	context->flags |= flag;
@@ -666,7 +666,7 @@ static inline void net_context_set_iface(struct net_context *context,
 {
 	NET_ASSERT(iface);
 
-	context->iface = net_if_get_by_iface(iface);
+	context->iface = (uint8_t)net_if_get_by_iface(iface);
 }
 
 static inline uint8_t net_context_get_ipv4_ttl(struct net_context *context)
@@ -712,6 +712,7 @@ static inline void net_context_set_proxy_enabled(struct net_context *context,
 
 static inline bool net_context_is_proxy_enabled(struct net_context *context)
 {
+        ARG_UNUSED(context);
 	return false;
 }
 #endif
@@ -828,6 +829,10 @@ static inline int net_context_create_ipv6_new(struct net_context *context,
 					      const struct in6_addr *src,
 					      const struct in6_addr *dst)
 {
+        ARG_UNUSED(context);
+	ARG_UNUSED(pkt);
+	ARG_UNUSED(src);
+	ARG_UNUSED(dst);
 	return -1;
 }
 #endif /* CONFIG_NET_IPV6 */

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -1651,6 +1651,9 @@ static inline void net_if_ipv6_set_base_reachable_time(struct net_if *iface,
 	}
 
 	iface->config.ip.ipv6->base_reachable_time = reachable_time;
+#else
+	ARG_UNUSED(iface);
+	ARG_UNUSED(reachable_time);
 #endif
 }
 
@@ -1672,6 +1675,7 @@ static inline uint32_t net_if_ipv6_get_reachable_time(struct net_if *iface)
 
 	return iface->config.ip.ipv6->reachable_time;
 #else
+	ARG_UNUSED(iface);
 	return 0;
 #endif
 }
@@ -1699,6 +1703,8 @@ static inline void net_if_ipv6_set_reachable_time(struct net_if_ipv6 *ipv6)
 	}
 
 	ipv6->reachable_time = net_if_ipv6_calc_reachable_time(ipv6);
+#else
+	ARG_UNUSED(ipv6);
 #endif
 }
 
@@ -1719,6 +1725,9 @@ static inline void net_if_ipv6_set_retrans_timer(struct net_if *iface,
 	}
 
 	iface->config.ip.ipv6->retrans_timer = retrans_timer;
+#else
+	ARG_UNUSED(iface);
+	ARG_UNUSED(retrans_timer);
 #endif
 }
 
@@ -1740,6 +1749,7 @@ static inline uint32_t net_if_ipv6_get_retrans_timer(struct net_if *iface)
 
 	return iface->config.ip.ipv6->retrans_timer;
 #else
+	ARG_UNUSED(iface);
 	return 0;
 #endif
 }

--- a/include/zephyr/net/net_ip.h
+++ b/include/zephyr/net/net_ip.h
@@ -683,7 +683,7 @@ static inline bool net_ipv6_is_prefix(const uint8_t *addr1,
 	}
 
 	/* Create a mask that has remaining most significant bits set */
-	mask = ((0xff << (8 - remain)) ^ 0xff) << remain;
+	mask = (uint8_t)((0xff << (8 - remain)) ^ 0xff) << remain;
 
 	return (addr1[bytes] & mask) == (addr2[bytes] & mask);
 }

--- a/include/zephyr/posix/time.h
+++ b/include/zephyr/posix/time.h
@@ -79,7 +79,7 @@ extern "C" {
 
 static inline int32_t _ts_to_ms(const struct timespec *to)
 {
-	return (to->tv_sec * MSEC_PER_SEC) + (to->tv_nsec / NSEC_PER_MSEC);
+  return (int32_t)((to->tv_sec * MSEC_PER_SEC) + (to->tv_nsec / NSEC_PER_MSEC));
 }
 
 #if defined(CONFIG_ARCH_POSIX) && defined(CONFIG_EXTERNAL_LIBC)

--- a/include/zephyr/sys/byteorder.h
+++ b/include/zephyr/sys/byteorder.h
@@ -308,8 +308,8 @@
  */
 static inline void sys_put_be16(uint16_t val, uint8_t dst[2])
 {
-	dst[0] = val >> 8;
-	dst[1] = val;
+        dst[0] = (uint8_t)(val >> 8);
+	dst[1] = (uint8_t)val;
 }
 
 /**
@@ -323,8 +323,8 @@ static inline void sys_put_be16(uint16_t val, uint8_t dst[2])
  */
 static inline void sys_put_be24(uint32_t val, uint8_t dst[3])
 {
-	dst[0] = val >> 16;
-	sys_put_be16(val, &dst[1]);
+        dst[0] = (uint8_t)(val >> 16);
+	sys_put_be16((uint16_t)val, &dst[1]);
 }
 
 /**
@@ -338,8 +338,8 @@ static inline void sys_put_be24(uint32_t val, uint8_t dst[3])
  */
 static inline void sys_put_be32(uint32_t val, uint8_t dst[4])
 {
-	sys_put_be16(val >> 16, dst);
-	sys_put_be16(val, &dst[2]);
+        sys_put_be16((uint16_t)(val >> 16), dst);
+	sys_put_be16((uint16_t)val, &dst[2]);
 }
 
 /**
@@ -353,8 +353,8 @@ static inline void sys_put_be32(uint32_t val, uint8_t dst[4])
  */
 static inline void sys_put_be48(uint64_t val, uint8_t dst[6])
 {
-	sys_put_be16(val >> 32, dst);
-	sys_put_be32(val, &dst[2]);
+        sys_put_be16((uint16_t)(val >> 32), dst);
+	sys_put_be32((uint32_t)val, &dst[2]);
 }
 
 /**
@@ -368,8 +368,8 @@ static inline void sys_put_be48(uint64_t val, uint8_t dst[6])
  */
 static inline void sys_put_be64(uint64_t val, uint8_t dst[8])
 {
-	sys_put_be32(val >> 32, dst);
-	sys_put_be32(val, &dst[4]);
+        sys_put_be32((uint32_t)(val >> 32), dst);
+	sys_put_be32((uint32_t)val, &dst[4]);
 }
 
 /**
@@ -383,8 +383,8 @@ static inline void sys_put_be64(uint64_t val, uint8_t dst[8])
  */
 static inline void sys_put_le16(uint16_t val, uint8_t dst[2])
 {
-	dst[0] = val;
-	dst[1] = val >> 8;
+        dst[0] = (uint8_t)val;
+	dst[1] = (uint8_t)(val >> 8);
 }
 
 /**
@@ -398,8 +398,8 @@ static inline void sys_put_le16(uint16_t val, uint8_t dst[2])
  */
 static inline void sys_put_le24(uint32_t val, uint8_t dst[3])
 {
-	sys_put_le16(val, dst);
-	dst[2] = val >> 16;
+        sys_put_le16((uint16_t)val, dst);
+	dst[2] = (uint8_t)(val >> 16);
 }
 
 /**
@@ -413,8 +413,8 @@ static inline void sys_put_le24(uint32_t val, uint8_t dst[3])
  */
 static inline void sys_put_le32(uint32_t val, uint8_t dst[4])
 {
-	sys_put_le16(val, dst);
-	sys_put_le16(val >> 16, &dst[2]);
+        sys_put_le16((uint16_t)val, dst);
+	sys_put_le16((uint16_t)(val >> 16), &dst[2]);
 }
 
 /**
@@ -428,8 +428,8 @@ static inline void sys_put_le32(uint32_t val, uint8_t dst[4])
  */
 static inline void sys_put_le48(uint64_t val, uint8_t dst[6])
 {
-	sys_put_le32(val, dst);
-	sys_put_le16(val >> 32, &dst[4]);
+        sys_put_le32((uint32_t)val, dst);
+	sys_put_le16((uint16_t)(val >> 32), &dst[4]);
 }
 
 /**
@@ -443,8 +443,8 @@ static inline void sys_put_le48(uint64_t val, uint8_t dst[6])
  */
 static inline void sys_put_le64(uint64_t val, uint8_t dst[8])
 {
-	sys_put_le32(val, dst);
-	sys_put_le32(val >> 32, &dst[4]);
+        sys_put_le32((uint32_t)val, dst);
+	sys_put_le32((uint32_t)(val >> 32), &dst[4]);
 }
 
 /**

--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -500,7 +500,7 @@ size_t hex2bin(const char *hex, size_t hexlen, uint8_t *buf, size_t buflen);
  */
 static inline uint8_t bcd2bin(uint8_t bcd)
 {
-	return ((10 * (bcd >> 4)) + (bcd & 0x0F));
+  return (uint8_t)((uint8_t)((uint8_t)10 * (uint8_t)(bcd >> 4)) + (uint8_t)(bcd & 0x0F));
 }
 
 /**


### PR DESCRIPTION
Fixed the following compiler warnings/errors:
include/zephyr/net/buf.h - casts assignment to prevent warning 
include/zephyr/net/hostname.h - Just prevents a compiler warning due to unused arg. Should use "ARG_UNUSED(<arg>) rather than "(void) <arg>;"
include/zephyr/net/net_context.h - casts and ARG_UNUSED() to prevent compiler warnings.
include/zephyr/net/net_if.h - several ARG_UNUSED().
include/zephyr/net/net_ip.h - cast in an assignment (presumably to prevent warning).
include/zephyr/posix/time.h - cast to prevent warning
include/zephyr/sys/byteorder.h - lots of casts to prevent warnings
include/zephyr/sys/util.h - cast to prevent warnings