### PR TITLE
drivers: sensor: tmag5273: cast value to int64_t

### DIFF
--- a/drivers/sensor/tmag5273/tmag5273.c
+++ b/drivers/sensor/tmag5273/tmag5273.c
@@ -754,7 +754,7 @@ static inline void tmag5273_channel_b_field_convert(int64_t raw_value, const uin
 	/* calc remaining part (first mT digit + fractal part) and scale according to Zephyr.
 	 * Ensure that always positive.
 	 */
-	const int64_t raw_dec_part = b_field->val1 * (1 << 16);
+	const int64_t raw_dec_part = (int64_t)b_field->val1 * (1 << 16);
 
 	b_field->val2 = ((raw_value - raw_dec_part) * 1000000) / (1 << 16);
 }


### PR DESCRIPTION
Cast val1 from sensor_value before multiplication in order to avoid integer overflow, as indicated by Coverity CID 347136.

Fixes #69121 