### PR TITLE
scripts: ci: introduce soc name check in check_compliance

### DIFF
--- a/soc/synopsys/emsdp/Kconfig.soc
+++ b/soc/synopsys/emsdp/Kconfig.soc
@@ -50,7 +50,7 @@ config SOC_SERIES
 	default "emsdp" if SOC_ARC_EMSDP
 
 config SOC
-	default "emsdp_em4d" if SOC_EMSDP_EM4
+	default "emsdp_em4" if SOC_EMSDP_EM4
 	default "emsdp_em5d" if SOC_EMSDP_EM5D
 	default "emsdp_em6" if SOC_EMSDP_EM6
 	default "emsdp_em7d" if SOC_EMSDP_EM7D


### PR DESCRIPTION
soc.yml files define SoC names which are used in board.yml. All SoC names and directories are exported to the build system and can be referenced using the SoC name as identifier.

Kconfig defines a CONFIG_SOC setting with the same name which can be used in build system and is selected by the board.

Thus the CONFIG_SOC value can be used to lookup the details of the SoC.

This commit introduces a new compliance check which ensures the SoC name and the CONFIG_SOC name value are in sync.

--------

Failures in this PR is being addressed here:
- #69308
- #69322