### PR TITLE
doc: zbus: release notes and migration guide Zephyr 3.6

### DIFF
--- a/doc/releases/migration-guide-3.6.rst
+++ b/doc/releases/migration-guide-3.6.rst
@@ -587,10 +587,15 @@ Other Subsystems
   respective ``reset-gpios``. This has been fixed so those signals now have to
   be flagged as :c:macro:`GPIO_ACTIVE_LOW` in the devicetree. (:github:`64800`)
 
-* The :kconfig:option:`ZBUS_MSG_SUBSCRIBER_NET_BUF_DYNAMIC`
-  and :kconfig:option:`ZBUS_MSG_SUBSCRIBER_NET_BUF_STATIC`
-  zbus options are renamed. Instead, the new :kconfig:option:`ZBUS_MSG_SUBSCRIBER_BUF_ALLOC_DYNAMIC`
-  and :kconfig:option:`ZBUS_MSG_SUBSCRIBER_BUF_ALLOC_STATIC` options should be used.
+* The ``CONFIG_ZBUS_MSG_SUBSCRIBER_NET_BUF_DYNAMIC`` and
+  ``CONFIG_ZBUS_MSG_SUBSCRIBER_NET_BUF_STATIC`` zbus options are renamed. Instead, the new
+  :kconfig:option:`CONFIG_ZBUS_MSG_SUBSCRIBER_BUF_ALLOC_DYNAMIC` and
+  :kconfig:option:`CONFIG_ZBUS_MSG_SUBSCRIBER_BUF_ALLOC_STATIC` options should be used.
+  (:github:`65632`)
+
+* To enable the zbus HLP priority boost, the developer must call the
+  :c:func:`zbus_obs_attach_to_thread` inside the attaching thread. The observer will then assume the
+  attached thread priority which will be used by zbus to calculate HLP priority. (:github:`63183`)
 
 Userspace
 *********

--- a/doc/releases/release-notes-3.6.rst
+++ b/doc/releases/release-notes-3.6.rst
@@ -1229,10 +1229,25 @@ Libraries / Subsystems
 
 * ZBus
 
+  * Replace mutexes with semaphores to lock channels and implement the Highest Locker Protocol (HLP)
+    priority boost for the zbus operations. This feature avoids priority inversions and preemptions,
+    making the VDED delivery process faster and more consistent. (:github:`63183`)
+
+  * Fixed documentation for :c:func:`zbus_chan_add` and :c:func:`zbus_chan_rm` adding the timeout
+    argument. (:github:`65544`)
+
+  * Fixed warning when mixing C and C++ files using zbus. (:github:`65222`)
+
+  * :c:macro:`ZBUS_CHANNEL_DEFINE` macro is now compatible with C++. (:github:`65196`)
+
+  * Fixed parameter order of net buf pool fixed definition. (:github:`65039`)
+
+  * Complete refactoring of benchmark sample, adding message subscribers. (:github:`64524`)
+
   * Renamed ``CONFIG_ZBUS_MSG_SUBSCRIBER_NET_BUF_DYNAMIC`` and
-    ``CONFIG_ZBUS_MSG_SUBSCRIBER_NET_BUF_STATIC``
-    to :kconfig:option:`CONFIG_ZBUS_MSG_SUBSCRIBER_BUF_ALLOC_DYNAMIC` and
-    :kconfig:option:`CONFIG_ZBUS_MSG_SUBSCRIBER_BUF_ALLOC_STATIC`
+    ``CONFIG_ZBUS_MSG_SUBSCRIBER_NET_BUF_STATIC`` to
+    :kconfig:option:`CONFIG_ZBUS_MSG_SUBSCRIBER_BUF_ALLOC_DYNAMIC` and
+    :kconfig:option:`CONFIG_ZBUS_MSG_SUBSCRIBER_BUF_ALLOC_STATIC`. (:github:`65632`)
 
 HALs
 ****


### PR DESCRIPTION
Modify the release notes and migration guide for zbus. 