### PR TITLE
flash: stm32: configurable write block sizes

### DIFF
--- a/drivers/flash/flash_stm32f1x.c
+++ b/drivers/flash/flash_stm32f1x.c
@@ -25,6 +25,8 @@ typedef uint64_t flash_prg_t;
 typedef uint32_t flash_prg_t;
 #elif FLASH_STM32_WRITE_BLOCK_SIZE == 2
 typedef uint16_t flash_prg_t;
+#elif FLASH_STM32_WRITE_BLOCK_SIZE == 1
+typedef uint8_t flash_prg_t;
 #else
 #error Unknown write block size
 #endif

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -101,7 +101,8 @@
 			#size-cells = <1>;
 
 			flash0: flash@8000000 {
-				compatible = "st,stm32-nv-flash", "soc-nv-flash";
+				compatible = "st,stm32f4-nv-flash", "st,stm32-nv-flash",
+					     "soc-nv-flash";
 
 				write-block-size = <1>;
 				/* maximum erase time (ms) for a 128K sector */

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -115,7 +115,8 @@
 			#size-cells = <1>;
 
 			flash0: flash@8000000 {
-				compatible = "st,stm32-nv-flash", "soc-nv-flash";
+				compatible = "st,stm32l0-nv-flash", "st,stm32-nv-flash",
+					     "soc-nv-flash";
 
 				write-block-size = <4>;
 				/* maximum erase time(ms) for a 128B page */

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -91,7 +91,8 @@
 			#size-cells = <1>;
 
 			flash0: flash@8000000 {
-				compatible = "st,stm32-nv-flash", "soc-nv-flash";
+				compatible = "st,stm32f4-nv-flash", "st,stm32-nv-flash",
+					     "soc-nv-flash";
 
 				write-block-size = <4>;
 				/* maximum erase time(ms) for a 128B half-page

--- a/dts/bindings/mtd/st,stm32f4-nv-flash.yaml
+++ b/dts/bindings/mtd/st,stm32f4-nv-flash.yaml
@@ -1,0 +1,20 @@
+description: |
+  ST STM32F4 family flash memory.
+
+include: st,stm32-nv-flash.yaml
+
+compatible: st,stm32f4-nv-flash
+
+properties:
+  write-block-size:
+    required: true
+    type: int
+    enum:
+      - 1
+      - 2
+      - 4
+      - 8
+    default: 1
+    description: |
+      Number of bytes used in write operations. Default value is based on the
+      reset value of Flash Control Register (FLASH_CR).

--- a/dts/bindings/mtd/st,stm32l0-nv-flash.yaml
+++ b/dts/bindings/mtd/st,stm32l0-nv-flash.yaml
@@ -1,0 +1,17 @@
+description: |
+  ST STM32L0 family flash memory.
+
+include: st,stm32-nv-flash.yaml
+
+compatible: st,stm32l0-nv-flash
+
+properties:
+  write-block-size:
+    required: true
+    type: int
+    enum:
+      - 1
+      - 2
+      - 4
+    description: |
+      Number of bytes used in write operations.


### PR DESCRIPTION
Add new devicetree bindings for F4 and L1 series for configuration of block size used in flash write operations.

Allow byte-size write operations in `flash_stm32f1x.c`. This file is being shared between F0, F1, F3, L0 and L1 series. L0 and L1 series allows for single byte writes.

Fixes #68126