### PR TITLE
Hwmv2 various soc name sync

### DIFF
--- a/soc/arm/mps3/Kconfig.soc
+++ b/soc/arm/mps3/Kconfig.soc
@@ -15,4 +15,4 @@ config SOC_MPS3_AN547
 	select SOC_SERIES_MPS3
 
 config SOC
-	default "mps3_an547" if SOC_MPS3_AN547
+	default "an547" if SOC_MPS3_AN547

--- a/soc/broadcom/bcm_vk/viper/Kconfig.soc
+++ b/soc/broadcom/bcm_vk/viper/Kconfig.soc
@@ -23,5 +23,4 @@ config SOC_SERIES
 	default "viper" if SOC_SERIES_VIPER
 
 config SOC
-	default "bcm58402_m7" if SOC_BCM58402_M7
-	default "bcm58402_a72" if SOC_BCM58402_A72
+	default "bcm58402" if SOC_BCM58402_M7 || SOC_BCM58402_A72

--- a/soc/microchip/mec/mec1501x/Kconfig.soc
+++ b/soc/microchip/mec/mec1501x/Kconfig.soc
@@ -17,4 +17,4 @@ config SOC_MEC1501_HSZ
 	select SOC_SERIES_MEC1501X
 
 config SOC
-	default "mec1501hsz" if SOC_MEC1501_HSZ
+	default "mec1501_hsz" if SOC_MEC1501_HSZ

--- a/soc/microchip/mec/mec172x/Kconfig.soc
+++ b/soc/microchip/mec/mec172x/Kconfig.soc
@@ -21,5 +21,5 @@ config SOC_MEC172X_NLJ
 	select SOC_SERIES_MEC172X
 
 config SOC
-	default "mec172xnsz" if SOC_MEC172X_NSZ
-	default "mec172xnlj" if SOC_MEC172X_NLJ
+	default "mec172x_nsz" if SOC_MEC172X_NSZ
+	default "mec172x_nlj" if SOC_MEC172X_NLJ

--- a/soc/nxp/kinetis/soc.yml
+++ b/soc/nxp/kinetis/soc.yml
@@ -20,8 +20,8 @@ family:
     - name: mke18f16
   - name: k8x
     socs:
+    - name: mk80f25615
     - name: mk82f25615
-    - name: mk82f215
   - name: kl2x
     socs:
     - name: mkl25z4

--- a/soc/ti/k3/am6x/Kconfig.soc
+++ b/soc/ti/k3/am6x/Kconfig.soc
@@ -27,3 +27,6 @@ config SOC_AM6234_M4
 
 config SOC_SERIES
 	default "am6x" if SOC_SERIES_AM6X
+
+config SOC
+	default "am6234" if SOC_AM6234_M4 || SOC_AM6234_A53


### PR DESCRIPTION
Align SoC names in soc.yml files with Kconfig SOC settings.

The will allow to enable the CI check in: #69309