### PR TITLE
boards: nrf54l15pdk_nrf54l15 support west attach

### DIFF
--- a/boards/nordic/nrf54l15pdk/board.cmake
+++ b/boards/nordic/nrf54l15pdk/board.cmake
@@ -1,4 +1,8 @@
 # Copyright (c) 2024 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=cortex-m33" "--speed=4000")
+
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/nrfutil.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)


### PR DESCRIPTION
Add CMake code that fixes west attach on nrf54l15pdk_nrf54l15.

I don't know why this fixes west attach as this is cargo cult code.