### PR TITLE
hwmv2: Minor fixes

### DIFF
--- a/boards/nordic_nrf/nrf5340dk/Kconfig
+++ b/boards/nordic_nrf/nrf5340dk/Kconfig
@@ -38,7 +38,7 @@ config BOARD_ENABLE_CPUNET
 
 config DOMAIN_CPUNET_BOARD
 	string
-	default "nrf5340dk_nrf5340_cpunet"
+	default "nrf5340dk/nrf5340/cpunet"
 	depends on BOARD_ENABLE_CPUNET
 	help
 	  The board which will be used for CPUNET domain when creating a multi
@@ -50,7 +50,7 @@ endif #  BOARD_NRF5340DK_NRF5340_CPUAPP || BOARD_NRF5340DK_NRF5340_CPUAPP_NS
 
 config DOMAIN_CPUAPP_BOARD
 	string
-	default "nrf5340dk_nrf5340_cpuapp"
+	default "nrf5340dk/nrf5340/cpuapp"
 	depends on BOARD_NRF5340DK_NRF5340_CPUNET
 	help
 	  The board which will be used for CPUAPP domain when creating a multi

--- a/boards/nordic_nrf/nrf5340dk/doc/index.rst
+++ b/boards/nordic_nrf/nrf5340dk/doc/index.rst
@@ -17,8 +17,8 @@ The nRF5340 is a dual-core SoC based on the Arm® Cortex®-M33 architecture, wit
 * a secondary Arm Cortex-M33 core, with a reduced feature set, running at
   a fixed 64 MHz, referred to as the **network core**.
 
-The nrf5340dk_nrf5340_cpuapp build target provides support for the application
-core on the nRF5340 SoC. The nrf5340dk_nrf5340_cpunet build target provides
+The ``nrf5340dk/nrf5340/cpuapp`` build target provides support for the application
+core on the nRF5340 SoC. The ``nrf5340dk/nrf5340/cpunet`` build target provides
 support for the network core on the nRF5340 SoC.
 
 nRF5340 SoC provides support for the following devices:
@@ -62,7 +62,7 @@ is 32 MHz.
 Supported Features
 ==================
 
-The nrf5340dk_nrf5340_cpuapp board configuration supports the following
+The ``nrf5340dk/nrf5340/cpuapp`` board configuration supports the following
 hardware features:
 
 +-----------+------------+----------------------+
@@ -99,7 +99,7 @@ hardware features:
 | WDT       | on-chip    | watchdog             |
 +-----------+------------+----------------------+
 
-The nrf5340dk_nrf5340_cpunet board configuration supports the following
+The ``nrf5340dk/nrf5340/cpunet`` board configuration supports the following
 hardware features:
 
 +-----------+------------+----------------------+
@@ -169,7 +169,7 @@ Programming and Debugging
 *************************
 
 nRF5340 application core supports the Armv8-M Security Extension.
-Applications built for the nrf5340dk_nrf5340_cpuapp board by default
+Applications built for the ``nrf5340dk/nrf5340/cpuapp`` board by default
 boot in the Secure state.
 
 nRF5340 network core does not support the Armv8-M Security Extension.
@@ -198,7 +198,7 @@ The process to build the Secure firmware image using TF-M and the Non-Secure
 firmware image using Zephyr requires the following steps:
 
 1. Build the Non-Secure Zephyr application
-   for the application core using ``-DBOARD=nrf5340dk_nrf5340_cpuapp_ns``.
+   for the application core using ``-DBOARD=nrf5340dk/nrf5340/cpuapp/ns``.
    To invoke the building of TF-M the Zephyr build system requires the
    Kconfig option ``BUILD_WITH_TFM`` to be enabled, which is done by
    default when building Zephyr as a Non-Secure application.
@@ -216,7 +216,7 @@ firmware image using Zephyr requires the following steps:
    and sizes.
 
 2. Build the application firmware for the network core using
-   ``-DBOARD=nrf5340dk_nrf5340_cpunet``.
+   ``-DBOARD=nrf5340dk/nrf5340/cpunet``.
 
 
 Building the Secure firmware using Zephyr
@@ -226,14 +226,14 @@ The process to build the Secure and the Non-Secure firmware images
 using Zephyr requires the following steps:
 
 1. Build the Secure Zephyr application for the application core
-   using ``-DBOARD=nrf5340dk_nrf5340_cpuapp`` and
+   using ``-DBOARD=nrf5340dk/nrf5340/cpuapp`` and
    ``CONFIG_TRUSTED_EXECUTION_SECURE=y`` and ``CONFIG_BUILD_WITH_TFM=n``
    in the application project configuration file.
 2. Build the Non-Secure Zephyr application for the application core
-   using ``-DBOARD=nrf5340dk_nrf5340_cpuapp_ns``.
+   using ``-DBOARD=nrf5340dk/nrf5340/cpuapp/ns``.
 3. Merge the two binaries together.
 4. Build the application firmware for the network core using
-   ``-DBOARD=nrf5340dk_nrf5340_cpunet``.
+   ``-DBOARD=nrf5340dk/nrf5340/cpunet``.
 
 
 When building a Secure/Non-Secure application for the nRF5340 application core,
@@ -246,9 +246,9 @@ Building a Secure only application
 ==================================
 
 Build the Zephyr app in the usual way (see :ref:`build_an_application`
-and :ref:`application_run`), using ``-DBOARD=nrf5340dk_nrf5340_cpuapp`` for
+and :ref:`application_run`), using ``-DBOARD=nrf5340dk/nrf5340/cpuapp`` for
 the firmware running on the nRF5340 application core, and using
-``-DBOARD=nrf5340dk_nrf5340_cpunet`` for the firmware running
+``-DBOARD=nrf5340dk/nrf5340/cpunet`` for the firmware running
 on the nRF5340 network core.
 
 Flashing
@@ -294,7 +294,7 @@ Then build and flash the application in the usual way.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world
-   :board: nrf5340dk_nrf5340_cpuapp
+   :board: nrf5340dk/nrf5340/cpuapp
    :goals: build flash
 
 Debugging

--- a/boards/nordic_nrf/nrf9160dk/Kconfig.defconfig
+++ b/boards/nordic_nrf/nrf9160dk/Kconfig.defconfig
@@ -42,3 +42,13 @@ config I2C
 	default $(dt_compat_on_bus,$(DT_COMPAT_NXP_PCAL6408A),i2c)
 
 endif # BOARD_NRF9160DK_NRF9160 || BOARD_NRF9160DK_NRF9160_NS
+
+if BOARD_NRF9160DK_NRF52840
+
+config BT_CTLR
+	default BT
+
+config BT_WAIT_NOP
+	default BT && $(dt_nodelabel_enabled,reset_input)
+
+endif # BOARD_NRF9160DK_NRF52840

--- a/soc/cypress/Kconfig
+++ b/soc/cypress/Kconfig
@@ -2,4 +2,8 @@
 # Copyright (c) 2020, ATL Electronics
 # SPDX-License-Identifier: Apache-2.0
 
+if SOC_FAMILY_PSOC6 || SOC_FAMILY_INFINEON_CAT1
+
 rsource "*/Kconfig"
+
+endif # SOC_FAMILY_PSOC6 || SOC_FAMILY_INFINEON_CAT1

--- a/soc/xilinx/zynq7000/xc7zxxx/Kconfig
+++ b/soc/xilinx/zynq7000/xc7zxxx/Kconfig
@@ -6,7 +6,7 @@
 # https://www.xilinx.com/products/silicon-devices/soc/zynq-7000.html#productTable
 #
 
-config SOC_SERIES_XILINX_XC7ZXXX
+config SOC_SERIES_XC7ZXXX
 	select ARM
 	select CPU_CORTEX_A9
 	select ARM_ARCH_TIMER_ERRATUM_740657 if ARM_ARCH_TIMER

--- a/soc/xilinx/zynq7000/xc7zxxx/Kconfig.defconfig
+++ b/soc/xilinx/zynq7000/xc7zxxx/Kconfig.defconfig
@@ -3,10 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-if SOC_SERIES_XILINX_XC7ZXXX
+if SOC_SERIES_XC7ZXXX
 
 # Zephyr does not support SMP on aarch32 yet, so we default to 1 CPU core
 config MP_MAX_NUM_CPUS
 	default 1
 
-endif # SOC_SERIES_XILINX_XC7ZXXX
+endif # SOC_SERIES_XC7ZXXX

--- a/soc/xilinx/zynq7000/xc7zxxx/Kconfig.soc
+++ b/soc/xilinx/zynq7000/xc7zxxx/Kconfig.soc
@@ -6,7 +6,7 @@
 # https://www.xilinx.com/products/silicon-devices/soc/zynq-7000.html#productTable
 #
 
-config SOC_SERIES_XILINX_XC7ZXXX
+config SOC_SERIES_XC7ZXXX
 	bool
 	select SOC_FAMILY_XILINX_ZYNQ7000
 	help
@@ -15,14 +15,14 @@ config SOC_SERIES_XILINX_XC7ZXXX
 
 config SOC_XILINX_XC7Z010
 	bool
-	select SOC_SERIES_XILINX_XC7ZXXX
+	select SOC_SERIES_XC7ZXXX
 	help
 	  2 ARM Cortex-A9 cores up to 866 MHz, Artix-7 programmable logic,
 	  28k logic cells, 2.1Mb block RAM, 800 DSP slices, up to 100 I/O pins.
 
 config SOC_XILINX_XC7Z015
 	bool
-	select SOC_SERIES_XILINX_XC7ZXXX
+	select SOC_SERIES_XC7ZXXX
 	help
 	  2 ARM Cortex-A9 cores up to 866 MHz, Artix-7 programmable logic,
 	  74k logic cells, 3.3Mb block RAM, 160 DSP slices, up to 150 I/O pins,
@@ -30,14 +30,14 @@ config SOC_XILINX_XC7Z015
 
 config SOC_XILINX_XC7Z020
 	bool
-	select SOC_SERIES_XILINX_XC7ZXXX
+	select SOC_SERIES_XC7ZXXX
 	help
 	  2 ARM Cortex-A9 cores up to 866 MHz, Artix-7 programmable logic,
 	  85k logic cells, 4.9Mb block RAM, 220 DSP slices, up to 200 I/O pins.
 
 config SOC_XILINX_XC7Z030
 	bool
-	select SOC_SERIES_XILINX_XC7ZXXX
+	select SOC_SERIES_XC7ZXXX
 	help
 	  2 ARM Cortex-A9 cores up to 1 GHz, Kintex-7 programmable logic,
 	  125k logic cells, 9.3Mb block RAM, 400 DSP slices, up to 250 I/O pins,
@@ -45,7 +45,7 @@ config SOC_XILINX_XC7Z030
 
 config SOC_XILINX_XC7Z035
 	bool
-	select SOC_SERIES_XILINX_XC7ZXXX
+	select SOC_SERIES_XC7ZXXX
 	help
 	  2 ARM Cortex-A9 cores up to 1 GHz, Kintex-7 programmable logic,
 	  275k logic cells, 17.6Mb block RAM, 900 DSP slices, up to 362 I/O pins,
@@ -53,7 +53,7 @@ config SOC_XILINX_XC7Z035
 
 config SOC_XILINX_XC7Z045
 	bool
-	select SOC_SERIES_XILINX_XC7ZXXX
+	select SOC_SERIES_XC7ZXXX
 	help
 	  2 ARM Cortex-A9 cores up to 1 GHz, Kintex-7 programmable logic,
 	  350k logic cells, 19.1Mb block RAM, 900 DSP slices, up to 362 I/O pins,
@@ -61,14 +61,14 @@ config SOC_XILINX_XC7Z045
 
 config SOC_XILINX_XC7Z100
 	bool
-	select SOC_SERIES_XILINX_XC7ZXXX
+	select SOC_SERIES_XC7ZXXX
 	help
 	  2 ARM Cortex-A9 cores up to 1 GHz, Kintex-7 programmable logic,
 	  444k logic cells, 26.5Mb block RAM, 2020 DSP slices, up to 400 I/O pins,
 	  up to 16 transceivers.
 
 config SOC_SERIES
-	default "xc7zxxx" if SOC_SERIES_XILINX_XC7ZXXX
+	default "xc7zxxx" if SOC_SERIES_XC7ZXXX
 
 config SOC
 	default "xc7z010" if SOC_XILINX_XC7Z010

--- a/soc/xilinx/zynq7000/xc7zxxxs/Kconfig
+++ b/soc/xilinx/zynq7000/xc7zxxxs/Kconfig
@@ -6,7 +6,7 @@
 # https://www.xilinx.com/products/silicon-devices/soc/zynq-7000.html#productTable
 #
 
-config SOC_SERIES_XILINX_XC7ZXXXS
+config SOC_SERIES_XC7ZXXXS
 	select ARM
 	select CPU_CORTEX_A9
 	select ARM_ARCH_TIMER_ERRATUM_740657 if ARM_ARCH_TIMER

--- a/soc/xilinx/zynq7000/xc7zxxxs/Kconfig.defconfig
+++ b/soc/xilinx/zynq7000/xc7zxxxs/Kconfig.defconfig
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-if SOC_SERIES_XILINX_XC7ZXXXS
+if SOC_SERIES_XC7ZXXXS
 
 config MP_MAX_NUM_CPUS
 	default 1
 
-endif # SOC_SERIES_XILINX_XC7ZXXXS
+endif # SOC_SERIES_XC7ZXXXS

--- a/soc/xilinx/zynq7000/xc7zxxxs/Kconfig.soc
+++ b/soc/xilinx/zynq7000/xc7zxxxs/Kconfig.soc
@@ -6,7 +6,7 @@
 # https://www.xilinx.com/products/silicon-devices/soc/zynq-7000.html#productTable
 #
 
-config SOC_SERIES_XILINX_XC7ZXXXS
+config SOC_SERIES_XC7ZXXXS
 	bool
 	select SOC_FAMILY_XILINX_ZYNQ7000
 	help
@@ -15,14 +15,14 @@ config SOC_SERIES_XILINX_XC7ZXXXS
 
 config SOC_XILINX_XC7Z007S
 	bool
-	select SOC_SERIES_XILINX_XC7ZXXXS
+	select SOC_SERIES_XC7ZXXXS
 	help
 	  1 ARM Cortex-A9 core up to 766 MHz, Artix-7 programmable logic,
 	  23k logic cells, 1.8 Mb block RAM, 60 DSP slices, up to 100 I/O pins.
 
 config SOC_XILINX_XC7Z012S
 	bool
-	select SOC_SERIES_XILINX_XC7ZXXXS
+	select SOC_SERIES_XC7ZXXXS
 	help
 	  1 ARM Cortex-A9 core up to 766 MHz, Artix-7 programmable logic,
 	  55k logic cells, 2.5Mb block RAM, 120 DSP slices, up to 150 I/O pins,
@@ -30,13 +30,13 @@ config SOC_XILINX_XC7Z012S
 
 config SOC_XILINX_XC7Z014S
 	bool
-	select SOC_SERIES_XILINX_XC7ZXXXS
+	select SOC_SERIES_XC7ZXXXS
 	help
 	  1 ARM Cortex-A9 core up to 766 MHz, Artix-7 programmable logic,
 	  65k logic cells, 3.8Mb block RAM, 170 DSP slices, up to 200 I/O pins.
 
 config SOC_SERIES
-	default "xc7zxxxs" if SOC_SERIES_XILINX_XC7ZXXXS
+	default "xc7zxxxs" if SOC_SERIES_XC7ZXXXS
 
 config SOC
 	default "xc7z007s" if SOC_XILINX_XC7Z007S

--- a/tests/kernel/tickless/tickless_concept/testcase.yaml
+++ b/tests/kernel/tickless/tickless_concept/testcase.yaml
@@ -8,7 +8,6 @@ tests:
       - rv32m1_vega/openisa_rv32m1/zero_riscy
       - rv32m1_vega/openisa_rv32m1/ri5cy
       - nrf5340dk/nrf5340/cpunet
-      - nrf5340dk_nrf5340_cpunet
       - nucleo_l073rz
     tags:
       - kernel


### PR DESCRIPTION
Fixes missed updated board names with nrf5340, remove duplicate (wrong) board name, remove xilinx from soc series name