### PR TITLE
tests: subsys/fs/nvs: fix nvs-cache-gc test

### DIFF
--- a/tests/subsys/fs/nvs/src/main.c
+++ b/tests/subsys/fs/nvs/src/main.c
@@ -844,7 +844,8 @@ ZTEST_F(nvs, test_nvs_cache_gc)
 
 	/* Fill the first sector with writes of ID 1 */
 
-	while (fixture->fs.data_wra + sizeof(data) <= fixture->fs.ate_wra) {
+	while (fixture->fs.data_wra + sizeof(data) + sizeof(struct nvs_ate)
+	       <= fixture->fs.ate_wra) {
 		++data;
 		err = nvs_write(&fixture->fs, 1, &data, sizeof(data));
 		zassert_equal(err, sizeof(data), "nvs_write call failure: %d", err);


### PR DESCRIPTION
nvs-cache-gc test is running into infinite loop because of the wrong stop condition when filling a sector.
Fix this by keeping an empty ATE in the sector for delete operation as defined in the NVS filesystem write operations.