### PR TITLE
hwmv2: Add west build board completion support

### DIFF
--- a/scripts/list_boards.py
+++ b/scripts/list_boards.py
@@ -300,6 +300,11 @@ def board_v2_identifiers(board):
     return identifiers
 
 
+def board_v2_identifiers_csv(board):
+    # Return in csv (comma separated value) format
+    return ",".join(board_v2_identifiers(board))
+
+
 def dump_v2_boards(args):
     if args.board_dir:
         root_args = argparse.Namespace(**{'soc_roots': args.soc_roots})

--- a/scripts/west_commands/boards.py
+++ b/scripts/west_commands/boards.py
@@ -93,4 +93,4 @@ class Boards(WestCommand):
             if name_re is not None and not name_re.search(board.name):
                 continue
             log.inf(args.format.format(name=board.name, dir=board.dir, hwm=board.hwm,
-                                       identifiers=list_boards.board_v2_identifiers(board)))
+                                       identifiers=list_boards.board_v2_identifiers_csv(board)))

--- a/scripts/west_commands/completion/west-completion.bash
+++ b/scripts/west_commands/completion/west-completion.bash
@@ -392,7 +392,8 @@ __set_comp_west_projs()
 
 __set_comp_west_boards()
 {
-	__set_comp "$(__west_x boards --format={name} "$@")"
+	boards="$(__west_x boards --format={identifiers} "$@")\n$(__west_x boards --format={name} "$@")"
+	__set_comp ${boards//,/\ }
 }
 
 __comp_west_west()

--- a/scripts/west_commands/completion/west-completion.fish
+++ b/scripts/west_commands/completion/west-completion.fish
@@ -196,10 +196,20 @@ function __zephyr_west_complete_help
 end
 
 function __zephyr_west_complete_board
+    # HWMv1
     set -l boards (west 2>/dev/null boards --format="{name} {arch}")
     for board in $boards
         set -l b (string split " " $board)
         printf "%s\n" $b[1]\t"$b[2]"
+    end
+
+    # HWMv2
+    set -l boards (west 2>/dev/null boards --format="{identifiers}")
+    for board in $boards
+        set -l b (string split "," $board)
+        for variant in $b
+            printf "%s\n" $variant[1]
+        end
     end
 end
 

--- a/scripts/west_commands/completion/west-completion.zsh
+++ b/scripts/west_commands/completion/west-completion.zsh
@@ -102,7 +102,11 @@ _get_west_projs() {
 }
 
 _get_west_boards() {
-  _west_boards=($(__west_x boards --format={name}))
+  _west_boards="$(__west_x boards --format={identifiers})\n$(__west_x boards --format={name})"
+  _west_boards=${_west_boards//$'\n'/\ }
+  _west_boards=${_west_boards//,/\ }
+  _west_boards=(${(@s/ /)_west_boards})
+
   _describe 'boards' _west_boards
 }
 


### PR DESCRIPTION
- [x] bash
- [x] fish
- [x] zsh

Note: This is a bad user experience for hwmv2 because board listing has going from being basically instantaneous with hwmv1 to taking 5+ seconds on bash/zsh (this is with the whole zephyr tree residing in RAM) to 15+ seconds on fish with hwmv2