### PR TITLE
twister: normalize platform name when storing files/data

### DIFF
--- a/scripts/pylib/twister/twisterlib/platform.py
+++ b/scripts/pylib/twister/twisterlib/platform.py
@@ -52,6 +52,7 @@ class Platform:
         data = scp.data
 
         self.name = data['identifier']
+        self.normalized_name = self.name.replace("/", "_")
         self.twister = data.get("twister", True)
         # if no RAM size is specified by the board, take a default of 128K
         self.ram = data.get("ram", 128)

--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -545,13 +545,13 @@ class Reporting:
 
 
     def target_report(self, json_file, outdir, suffix):
-        platforms = {inst.platform.name for _, inst in self.instances.items()}
+        platforms = {inst.platform for _, inst in self.instances.items()}
         for platform in platforms:
             if suffix:
-                filename = os.path.join(outdir,"{}_{}.xml".format(platform, suffix))
-                json_platform_file = os.path.join(outdir,"{}_{}.json".format(platform, suffix))
+                filename = os.path.join(outdir,"{}_{}.xml".format(platform.normalized_name, suffix))
+                json_platform_file = os.path.join(outdir,"{}_{}.json".format(platform.normalized_name, suffix))
             else:
-                filename = os.path.join(outdir,"{}.xml".format(platform))
-                json_platform_file = os.path.join(outdir,"{}.json".format(platform))
-            self.xunit_report(json_file, filename, platform, full_report=True)
-            self.json_report(json_platform_file, version=self.env.version, platform=platform)
+                filename = os.path.join(outdir,"{}.xml".format(platform.normalized_name))
+                json_platform_file = os.path.join(outdir,"{}.json".format(platform.normalized_name))
+            self.xunit_report(json_file, filename, platform.name, full_report=True)
+            self.json_report(json_platform_file, version=self.env.version, platform=platform.name)

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -56,14 +56,13 @@ class TestInstance:
 
         self.name = os.path.join(platform.name, testsuite.name)
         self.dut = None
-        clean_platform_name = platform.name.replace("/", "_")
+
         if testsuite.detailed_test_id:
-            self.build_dir = os.path.join(outdir, clean_platform_name, testsuite.name)
+            self.build_dir = os.path.join(outdir, platform.normalized_name, testsuite.name)
         else:
             # if suite is not in zephyr, keep only the part after ".." in reconstructed dir structure
             source_dir_rel = testsuite.source_dir_rel.rsplit(os.pardir+os.path.sep, 1)[-1]
-            self.build_dir = os.path.join(outdir, clean_platform_name, source_dir_rel, testsuite.name)
-
+            self.build_dir = os.path.join(outdir, platform.normalized_name, source_dir_rel, testsuite.name)
         self.run_id = self._get_run_id()
         self.domains = None
 

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -459,6 +459,7 @@ class TestPlan:
                                         platform_revision = copy.deepcopy(platform)
                                         revision = revision.replace("_", ".")
                                         platform_revision.name = f"{platform.name}@{revision}"
+                                        platform_revision.normalized_name = platform_revision.name.replace("/", "_")
                                         platform_revision.default = False
                                         self.platforms.append(platform_revision)
 

--- a/scripts/tests/twister_blackbox/test_report.py
+++ b/scripts/tests/twister_blackbox/test_report.py
@@ -26,9 +26,9 @@ class TestReport:
     TESTDATA_1 = [
         (
             os.path.join(TEST_DATA, 'tests', 'dummy', 'agnostic'),
-            ['qemu_x86', 'qemu_x86_64'],
+            ['qemu_x86', 'mps2/an385'],
             [
-                'qemu_x86_64.xml', 'qemu_x86.xml',
+                'qemu_x86.xml', 'mps2_an385.xml',
                 'testplan.json', 'twister.json',
                 'twister.log', 'twister_report.xml',
                 'twister_suite_report.xml', 'twister.xml'
@@ -38,9 +38,9 @@ class TestReport:
     TESTDATA_2 = [
         (
             os.path.join(TEST_DATA, 'tests', 'dummy', 'agnostic'),
-            ['qemu_x86', 'qemu_x86_64'],
+            ['qemu_x86', 'mps2/an385'],
             [
-                'qemu_x86_64_TEST.xml', 'qemu_x86_TEST.xml',
+                'mps2_an385_TEST.xml', 'qemu_x86_TEST.xml',
                 'twister_TEST.json', 'twister_TEST_report.xml',
                 'twister_TEST_suite_report.xml', 'twister_TEST.xml'
             ]
@@ -49,7 +49,7 @@ class TestReport:
     TESTDATA_3 = [
         (
             os.path.join(TEST_DATA, 'tests', 'dummy', 'agnostic'),
-            ['qemu_x86', 'qemu_x86_64'],
+            ['qemu_x86', 'mps2/an385'],
             ['--report-name', 'abcd'],
             [
                 'abcd.json', 'abcd_report.xml',
@@ -58,20 +58,20 @@ class TestReport:
         ),
         (
             os.path.join(TEST_DATA, 'tests', 'dummy', 'agnostic'),
-            ['qemu_x86', 'qemu_x86_64'],
+            ['qemu_x86', 'mps2/an385'],
             ['--report-name', '1234', '--platform-reports'],
             [
-                'qemu_x86_64.xml', 'qemu_x86.xml',
+                'mps2_an385.xml', 'qemu_x86.xml',
                 '1234.json', '1234_report.xml',
                 '1234_suite_report.xml', '1234.xml'
             ]
         ),
         (
             os.path.join(TEST_DATA, 'tests', 'dummy', 'agnostic'),
-            ['qemu_x86', 'qemu_x86_64'],
+            ['qemu_x86', 'mps2/an385'],
             ['--report-name', 'Final', '--platform-reports', '--report-suffix=Test'],
             [
-                'qemu_x86_64_Test.xml', 'qemu_x86_Test.xml',
+                'mps2_an385_Test.xml', 'qemu_x86_Test.xml',
                 'Final_Test.json', 'Final_Test_report.xml',
                 'Final_Test_suite_report.xml', 'Final_Test.xml'
             ]
@@ -182,7 +182,7 @@ class TestReport:
                 pytest.fail(f"Unsupported file type: '{path}'")
 
         for f_platform in test_platforms:
-            platform_path = os.path.join(out_path, f_platform)
+            platform_path = os.path.join(out_path, f_platform.replace("/", "_"))
             assert os.path.exists(platform_path), f'file not found {f_platform}'
 
         assert str(sys_exit.value) == '0'


### PR DESCRIPTION
Convert slashes into underscores to allow saving of data related to
platforms on disk.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
