### PR TITLE
drivers: sensor: adxl367: fix trigger support

### DIFF
--- a/drivers/sensor/adxl367/adxl367_trigger.c
+++ b/drivers/sensor/adxl367/adxl367_trigger.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT adi_adxl367
+
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/sys/util.h>


### PR DESCRIPTION
The adxl367_trigger.c file was missing a DT_DRV_COMPAT definition, which resulted in the driver config structs being misaligned between the driver source files. This is fixed here.