### PR TITLE
drivers: dai: sai: use TDR/RDR for fifo base address computation

### DIFF
--- a/drivers/dai/nxp/sai/sai.h
+++ b/drivers/dai/nxp/sai/sai.h
@@ -101,13 +101,13 @@ LOG_MODULE_REGISTER(nxp_dai_sai);
 	DT_INST_PROP_OR(inst, rx_fifo_watermark,\
 			FSL_FEATURE_SAI_FIFO_COUNTn(UINT_TO_I2S(DT_INST_REG_ADDR(inst))) / 2)
 
-/* used to retrieve TFR0's address based on SAI's physical address */
+/* used to retrieve TDR0's address based on SAI's physical address */
 #define SAI_TX_FIFO_BASE(inst)\
-	FSL_FEATURE_SAI_TX_FIFO_BASEn(UINT_TO_I2S(DT_INST_REG_ADDR(inst)), 0)
+	POINTER_TO_UINT(&(UINT_TO_I2S(DT_INST_REG_ADDR(inst))->TDR[0]))
 
-/* used to retrieve RFR0's address based on SAI's physical address */
+/* used to retrieve RDR0's address based on SAI's physical address */
 #define SAI_RX_FIFO_BASE(inst)\
-	FSL_FEATURE_SAI_RX_FIFO_BASEn(UINT_TO_I2S(DT_INST_REG_ADDR(inst)), 0)
+	POINTER_TO_UINT(&(UINT_TO_I2S(DT_INST_REG_ADDR(inst))->RDR[0]))
 
 /* internal macro used to retrieve the default TX/RX FIFO's size (in FIFO words) */
 #define _SAI_FIFO_DEPTH(inst)\


### PR DESCRIPTION
Using the address of RDR/TDR for fifo base address computation has the same effect as using the FSL_FEATURE_SAI_{TX/RX}_FIFO_BASEn macro from NXP HAL. The only difference between the two is that the macro is not defined for all SoCs so whenever we introduce a new SoC that uses the SAI module we have to also introduce the macro for said SoC. Using TDR/RDR has the advantage that it doesn't require any additional changes to the NXP HAL.

Since we only support one data line per direction, it's fine to just use RDR[0] and TDR[0] for the address computation.