### PR TITLE
Bluetooth: BAP: Add bt_bap_base_subgroup_get_bis_indexes

### DIFF
--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -1506,6 +1506,18 @@ int bt_bap_base_subgroup_codec_to_codec_cfg(const struct bt_bap_base_subgroup *s
 int bt_bap_base_get_subgroup_bis_count(const struct bt_bap_base_subgroup *subgroup);
 
 /**
+ * @brief Get all BIS indexes of a subgroup
+ *
+ * @param[in]  subgroup    The subgroup pointer
+ * @param[out] bis_indexes 32-bit BIS index bitfield that will be populated
+ *
+ * @retval -EINVAL if arguments are invalid
+ * @retval 0 on success
+ */
+int bt_bap_base_subgroup_get_bis_indexes(const struct bt_bap_base_subgroup *subgroup,
+					 uint32_t *bis_indexes);
+
+/**
  * @brief Iterate on all BIS in the subgroup
  *
  * @param subgroup  The subgroup pointer

--- a/subsys/bluetooth/audio/bap_base.c
+++ b/subsys/bluetooth/audio/bap_base.c
@@ -545,6 +545,26 @@ static bool base_subgroup_cb(const struct bt_bap_base_subgroup *subgroup, void *
 	return true;
 }
 
+int bt_bap_base_subgroup_get_bis_indexes(const struct bt_bap_base_subgroup *subgroup,
+					 uint32_t *bis_indexes)
+{
+	CHECKIF(subgroup == NULL) {
+		LOG_DBG("subgroup is NULL");
+
+		return -EINVAL;
+	}
+
+	CHECKIF(bis_indexes == NULL) {
+		LOG_DBG("bis_indexes is NULL");
+
+		return -EINVAL;
+	}
+
+	*bis_indexes = 0U;
+
+	return bt_bap_base_subgroup_foreach_bis(subgroup, base_subgroup_bis_cb, bis_indexes);
+}
+
 int bt_bap_base_get_bis_indexes(const struct bt_bap_base *base, uint32_t *bis_indexes)
 {
 	CHECKIF(base == NULL) {

--- a/tests/bluetooth/audio/bap_base/src/main.c
+++ b/tests/bluetooth/audio/bap_base/src/main.c
@@ -613,6 +613,81 @@ ZTEST_F(bap_base_test_suite, test_base_get_subgroup_bis_count_inval_param_null_s
 }
 
 static bool
+test_bt_bap_base_subgroup_get_bis_indexes_cb(const struct bt_bap_base_subgroup *subgroup,
+					     void *user_data)
+{
+	uint32_t bis_indexes;
+	int ret;
+
+	ret = bt_bap_base_subgroup_get_bis_indexes(subgroup, &bis_indexes);
+	zassert_equal(ret, 0, "Unexpected return value: %d", ret);
+	zassert_not_equal(bis_indexes, 0 /* May be Bit 1 or 2 */,
+			  "Unexpected BIS index value: 0x%08X", bis_indexes);
+
+	return true;
+}
+
+ZTEST_F(bap_base_test_suite, test_bt_bap_base_subgroup_get_bis_indexes)
+{
+	const struct bt_bap_base *base = bt_bap_base_get_base_from_ad(&fixture->valid_base_ad);
+	uint32_t bis_indexes;
+	int ret;
+
+	zassert_not_null(base);
+
+	ret = bt_bap_base_foreach_subgroup(base, test_bt_bap_base_subgroup_get_bis_indexes_cb,
+					   NULL);
+	zassert_equal(ret, 0, "Unexpected return value: %d", ret);
+}
+
+static bool test_bt_bap_base_subgroup_get_bis_indexes_inval_param_null_subgroup_cb(
+	const struct bt_bap_base_subgroup *subgroup, void *user_data)
+{
+	uint32_t bis_indexes;
+	int ret;
+
+	ret = bt_bap_base_subgroup_get_bis_indexes(NULL, &bis_indexes);
+	zassert_equal(ret, -EINVAL, "Unexpected return value: %d", ret);
+
+	return true;
+}
+
+ZTEST_F(bap_base_test_suite, test_bt_bap_base_subgroup_get_bis_indexes_inval_param_null_subgroup)
+{
+	const struct bt_bap_base *base = bt_bap_base_get_base_from_ad(&fixture->valid_base_ad);
+	int ret;
+
+	zassert_not_null(base);
+
+	ret = bt_bap_base_foreach_subgroup(
+		base, test_bt_bap_base_subgroup_get_bis_indexes_inval_param_null_subgroup_cb, NULL);
+	zassert_equal(ret, 0, "Unexpected return value: %d", ret);
+}
+
+static bool test_bt_bap_base_subgroup_get_bis_indexes_inval_param_null_index_cb(
+	const struct bt_bap_base_subgroup *subgroup, void *user_data)
+{
+	int ret;
+
+	ret = bt_bap_base_subgroup_get_bis_indexes(subgroup, NULL);
+	zassert_equal(ret, -EINVAL, "Unexpected return value: %d", ret);
+
+	return true;
+}
+
+ZTEST_F(bap_base_test_suite, test_bt_bap_base_subgroup_get_bis_indexes_inval_param_null_index)
+{
+	const struct bt_bap_base *base = bt_bap_base_get_base_from_ad(&fixture->valid_base_ad);
+	int ret;
+
+	zassert_not_null(base);
+
+	ret = bt_bap_base_foreach_subgroup(
+		base, test_bt_bap_base_subgroup_get_bis_indexes_inval_param_null_index_cb, NULL);
+	zassert_equal(ret, 0, "Unexpected return value: %d", ret);
+}
+
+static bool
 test_base_subgroup_foreach_bis_subgroup_bis_cb(const struct bt_bap_base_subgroup_bis *bis,
 					       void *user_data)
 {


### PR DESCRIPTION
Add bt_bap_base_subgroup_get_bis_indexes that gets the BIS indexes of a subgroup. This work very similar to
bt_bap_base_get_bis_indexes, except that it works for subgroups rather than BASEs.