### PR TITLE
native_simulator: constify 'buffer' argument in nsi_host_write()

### DIFF
--- a/scripts/native_simulator/common/src/include/nsi_host_trampolines.h
+++ b/scripts/native_simulator/common/src/include/nsi_host_trampolines.h
@@ -36,7 +36,7 @@ long nsi_host_read(int fd, void *buffer, unsigned long size);
 void *nsi_host_realloc(void *ptr, unsigned long size);
 void nsi_host_srandom(unsigned int seed);
 char *nsi_host_strdup(const char *s);
-long nsi_host_write(int fd, void *buffer, unsigned long size);
+long nsi_host_write(int fd, const void *buffer, unsigned long size);
 
 #ifdef __cplusplus
 }

--- a/scripts/native_simulator/common/src/nsi_host_trampolines.c
+++ b/scripts/native_simulator/common/src/nsi_host_trampolines.c
@@ -71,7 +71,7 @@ char *nsi_host_strdup(const char *s)
 	return strdup(s);
 }
 
-long nsi_host_write(int fd, void *buffer, unsigned long size)
+long nsi_host_write(int fd, const void *buffer, unsigned long size)
 {
 	return write(fd, buffer, size);
 }


### PR DESCRIPTION
`buffer` argument is read only, so it can be `const`. This makes it
compatible with POSIX specification of `write(3)` syscall.