### PR TITLE
net: dhcpv4: little fixup in the option callbacks

### DIFF
--- a/subsys/net/lib/dhcpv4/dhcpv4.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4.c
@@ -45,7 +45,7 @@ static struct k_work_delayable timeout_work;
 static struct net_mgmt_event_callback mgmt4_cb;
 
 #if defined(CONFIG_NET_DHCPV4_OPTION_CALLBACKS)
-static sys_slist_t option_callbacks;
+static sys_slist_t option_callbacks = SYS_SLIST_STATIC_INIT(&option_callbacks);
 static int unique_types_in_callbacks;
 #endif
 
@@ -1479,11 +1479,6 @@ int net_dhcpv4_init(void)
 	net_mgmt_init_event_callback(&mgmt4_cb, dhcpv4_iface_event_handler,
 					 NET_EVENT_IF_DOWN | NET_EVENT_IF_UP);
 
-#if defined(CONFIG_NET_DHCPV4_OPTION_CALLBACKS)
-	k_mutex_lock(&lock, K_FOREVER);
-	sys_slist_init(&option_callbacks);
-	k_mutex_unlock(&lock);
-#endif
 	return 0;
 }
 

--- a/subsys/net/lib/dhcpv4/dhcpv4.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4.c
@@ -1363,7 +1363,7 @@ static void dhcpv4_start_internal(struct net_if *iface, bool first_start)
 
 int net_dhcpv4_add_option_callback(struct net_dhcpv4_option_callback *cb)
 {
-	if (!cb || !cb->handler) {
+	if (cb == NULL || cb->handler == NULL) {
 		return -EINVAL;
 	}
 
@@ -1378,7 +1378,7 @@ int net_dhcpv4_remove_option_callback(struct net_dhcpv4_option_callback *cb)
 {
 	int ret = 0;
 
-	if (!cb || !cb->handler) {
+	if (cb == NULL || cb->handler == NULL) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Check the value of net_dhcpv4_add_option_callback() and net_dhcpv4_remove_option_callback() explicitly, 
initialize sys_slist_t option_callbacks statically.