### PR TITLE
intel_ish: select lakemont CPU

### DIFF
--- a/soc/intel/intel_ish/Kconfig
+++ b/soc/intel/intel_ish/Kconfig
@@ -6,10 +6,10 @@
 
 config SOC_FAMILY_INTEL_ISH
 	select X86
+	select CPU_LAKEMONT
 	select X86_NO_SPECULATIVE_VULNERABILITIES
 	select IOAPIC
 	select LOAPIC
-	select CPU_HAS_FPU
 	select INTEL_HAL
 	select HAS_PM
 	select HAS_COVERAGE_SUPPORT


### PR DESCRIPTION
select CPU instead of listing features individually on the soc level.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
