### PR TITLE
snippets: Initial HWMv2 support

### DIFF
--- a/scripts/snippets.py
+++ b/scripts/snippets.py
@@ -159,11 +159,11 @@ zephyr_create_scope(snippets)
             board_re = board[1:-1]
             self.print(f'''\
 # Appends for board regular expression '{board_re}'
-if("${{BOARD}}" MATCHES "^{board_re}$")''')
+if("${{BOARD}}${{BOARD_IDENTIFIER}}" MATCHES "^{board_re}$")''')
         else:
             self.print(f'''\
 # Appends for board '{board}'
-if("${{BOARD}}" STREQUAL "{board}")''')
+if("${{BOARD}}${{BOARD_IDENTIFIER}}" STREQUAL "{board}")''')
         self.print_appends(appends, 1)
         self.print('endif()')
 

--- a/snippets/nordic-ppr/snippet.yml
+++ b/snippets/nordic-ppr/snippet.yml
@@ -3,6 +3,6 @@ append:
   EXTRA_DTC_OVERLAY_FILE: nordic-ppr.overlay
 
 boards:
-  nrf54h20pdk_nrf54h20_cpuapp:
+  nrf54h20pdk/nrf54h20/cpuapp:
     append:
       EXTRA_DTC_OVERLAY_FILE: boards/nrf54h20pdk_nrf54h20_cpuapp.overlay

--- a/snippets/xen_dom0/snippet.yml
+++ b/snippets/xen_dom0/snippet.yml
@@ -4,12 +4,12 @@ append:
   EXTRA_CONF_FILE: xen_dom0.conf
 
 boards:
-  qemu_cortex_a53:
+  qemu_cortex_a53/qemu_cortex_a53:
     append:
       EXTRA_DTC_OVERLAY_FILE: boards/qemu_cortex_a53.overlay
   rcar_h3ulcb/r8a77951/a57:
     append:
       EXTRA_DTC_OVERLAY_FILE: boards/rcar_h3ulcb_r8a77951_a57.overlay
-  rcar_salvator_xs:
+  rcar_salvator_xs/r8a77961:
     append:
       EXTRA_DTC_OVERLAY_FILE: boards/rcar_salvator_xs.overlay


### PR DESCRIPTION
Very simple adaptation to directly replace the use of HWMv1 board names with the new identifiers:
```yaml
boards:
  <name>/<identifier>:
    append: ...
```
All snippets in-tree are aligned with this format where needed.

Since the `boards` key supports regex, appends can also be applied to multiple targets grouped by board name, SoC, CPU cluster, or variant. Later, this can be followed up with native support for these items in the snippet schema.