### PR TITLE
board: arm: sparkfun_pro_micro_rp2040: Support JTAG

### DIFF
--- a/boards/raspberrypi/rpi_pico/support/openocd.cfg
+++ b/boards/raspberrypi/rpi_pico/support/openocd.cfg
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Checking and set 'adapter speed'.
-# Set adapter speed that assigned by argument if not be seted.
+# Set the adaptor speed, if unset, and given as an argument.
 proc set_adapter_speed_if_not_set { speed } {
 	puts "checking adapter speed..."
 	if { [catch {adapter speed} ret] } {

--- a/boards/sparkfun/pro_micro_rp2040/board.cmake
+++ b/boards/sparkfun/pro_micro_rp2040/board.cmake
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# This configuration allows selecting what debug adapter debugging to use
+# for the SparkFun Pro Micro RP2040 by a command-line argument.
+# It is mainly intended to support both the 'picoprobe' and 'raspberrypi-swd'
+# adapter described in "Getting started with Raspberry Pi Pico".
+# And any other SWD debug adapter might also be usable with this configuration.
+
+# Note that the Pro Micro RP2040 SWD pins are test points on the underside
+# of the board.
+
+# Set RPI_PICO_DEBUG_ADAPTER to select debug adapter by command-line arguments.
+# e.g.) west build -b rpi_pico -- -DRPI_PICO_DEBUG_ADAPTER=raspberrypi-swd
+# The value is treated as a part of an interface file name that
+# the debugger's configuration file.
+# The value must be the 'stem' part of the name of one of the files
+# in the openocd interface configuration file.
+# The setting is store to CMakeCache.txt.
+if ("${RPI_PICO_DEBUG_ADAPTER}" STREQUAL "")
+	set(RPI_PICO_DEBUG_ADAPTER "cmsis-dap")
+endif()
+
+board_runner_args(openocd --cmd-pre-init "source [find interface/${RPI_PICO_DEBUG_ADAPTER}.cfg]")
+board_runner_args(openocd --cmd-pre-init "transport select swd")
+board_runner_args(openocd --cmd-pre-init "source [find target/rp2040.cfg]")
+
+# The adapter speed is expected to be set by interface configuration.
+# But if not so, set 2000 to adapter speed.
+board_runner_args(openocd --cmd-pre-init "set_adapter_speed_if_not_set 2000")
+
+board_runner_args(jlink "--device=RP2040_M0_0")
+board_runner_args(uf2 "--board-id=RPI-RP2")
+board_runner_args(pyocd "--target=rp2040")
+
+include(${ZEPHYR_BASE}/boards/common/uf2.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/blackmagicprobe.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/sparkfun/pro_micro_rp2040/doc/index.rst
+++ b/boards/sparkfun/pro_micro_rp2040/doc/index.rst
@@ -115,12 +115,14 @@ Flashing
 Using UF2
 ---------
 
-Since it doesn't expose the SWD pins, you must flash the SparkFun Pro Micro
-RP2040 with a UF2 file. By default, building an app for this board will
-generate a `build/zephyr/zephyr.uf2` file. If the Pro Micro RP2040 is powered
-on with the `BOOTSEL` button pressed, it will appear on the host as a mass
-storage device. The UF2 file should be drag-and-dropped to the device, which
-will flash the Pro Micro RP2040.
+The Pro Micro board does make the SWD pins available on pads on the
+underside of the board. You can solder to these pins, and use a JTag
+debugger. You can also flash the SparkFun ProMicro RP2040 with a UF2 file.
+By default, building an app for this board will generate a
+`build/zephyr/zephyr.uf2` file. If the Pro Micro RP2040 is powered on with
+the `BOOTSEL` button pressed, it will appear on the host as a mass storage
+device. The UF2 file should be copied to the device, which will
+flash the Pro Micro RP2040.
 
 .. target-notes::
 

--- a/boards/sparkfun/pro_micro_rp2040/support/openocd.cfg
+++ b/boards/sparkfun/pro_micro_rp2040/support/openocd.cfg
@@ -1,0 +1,11 @@
+# Copyright (c) 2022 Tokita, Hiroshi <tokita.hiroshi@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+# Checking and set 'adapter speed'.
+# Set adapter speed that assigned by argument if not be seted.
+proc set_adapter_speed_if_not_set { speed } {
+	puts "checking adapter speed..."
+	if { [catch {adapter speed} ret] } {
+		adapter speed $speed
+	}
+}

--- a/boards/sparkfun/pro_micro_rp2040/support/openocd.cfg
+++ b/boards/sparkfun/pro_micro_rp2040/support/openocd.cfg
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Checking and set 'adapter speed'.
-# Set adapter speed that assigned by argument if not be seted.
+# Set the adaptor speed, if unset, and given as an argument.
 proc set_adapter_speed_if_not_set { speed } {
 	puts "checking adapter speed..."
 	if { [catch {adapter speed} ret] } {

--- a/boards/wiznet/w5500_evb_pico/support/openocd.cfg
+++ b/boards/wiznet/w5500_evb_pico/support/openocd.cfg
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Checking and set 'adapter speed'.
-# Set adapter speed that assigned by argument if not be seted.
+# Set the adaptor speed, if unset, and given as an argument.
 proc set_adapter_speed_if_not_set { speed } {
 	puts "checking adapter speed..."
 	if { [catch {adapter speed} ret] } {


### PR DESCRIPTION
Add JTag debugger support for this board.  Although there is not a debug header, the SWD pins are accessible and the adaptor is not that difficult to wire up.  This will allow for debugging beyond just flashing, that the UF2 programming setup allows for.