### PR TITLE
Add ws2812 support to SparkFun Pro Micro RP2040 Board

### DIFF
--- a/boards/sparkfun/pro_micro_rp2040/sparkfun_pro_micro_rp2040-pinctrl.dtsi
+++ b/boards/sparkfun/pro_micro_rp2040/sparkfun_pro_micro_rp2040-pinctrl.dtsi
@@ -49,4 +49,10 @@
 
 	clocks_default: clocks_default {
 	};
+
+	ws2812_pio0_default: ws2812_pio_default {
+		ws2812 {
+			pinmux = <PIO0_P25>;
+		};
+	};
 };

--- a/boards/sparkfun/pro_micro_rp2040/sparkfun_pro_micro_rp2040.dts
+++ b/boards/sparkfun/pro_micro_rp2040/sparkfun_pro_micro_rp2040.dts
@@ -10,6 +10,7 @@
 #include "sparkfun_pro_micro_rp2040-pinctrl.dtsi"
 #include "sparkfun_pro_micro_connector.dtsi"
 #include <freq.h>
+#include <zephyr/dt-bindings/led/led.h>
 
 / {
 	chosen {
@@ -22,6 +23,7 @@
 
 	aliases {
 		watchdog0 = &wdt0;
+		led-strip = &ws2812;
 	};
 };
 
@@ -96,6 +98,28 @@
 	pinctrl-names = "default";
 };
 
+&pio0 {
+	status = "okay";
+
+	pio-ws2812 {
+		compatible = "worldsemi,ws2812-rpi_pico-pio";
+		status = "okay";
+		pinctrl-0 = <&ws2812_pio0_default>;
+		pinctrl-names = "default";
+		bit-waveform = <3>, <3>, <4>;
+
+		ws2812: ws2812 {
+			status = "okay";
+			gpios = <&gpio0 25 GPIO_ACTIVE_HIGH>;
+			chain-length = <1>;
+			color-mapping = <LED_COLOR_ID_GREEN
+					 LED_COLOR_ID_RED
+					 LED_COLOR_ID_BLUE>;
+			reset-delay = <280>;
+			frequency = <800000>;
+		};
+	};
+};
 
 zephyr_udc0: &usbd {
 	status = "okay";


### PR DESCRIPTION
This board has a WS2812-style RGB LED. Support this by adding the necessary configuration to the devicetree and supporting the board in the ws2812 demo.

The jtag commit is from #69360, presuming that will merge first, this can be rebased.