### PR TITLE
tests: kernel: use TC_END_REPORT for faults

### DIFF
--- a/tests/kernel/fatal/exception/src/main.c
+++ b/tests/kernel/fatal/exception/src/main.c
@@ -56,20 +56,20 @@ void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
 
 	if (expected_reason == -1) {
 		printk("Was not expecting a crash\n");
-		printk("PROJECT EXECUTION FAILED\n");
+		TC_END_REPORT(TC_FAIL);
 		k_fatal_halt(reason);
 	}
 
 	if (k_current_get() != &alt_thread) {
 		printk("Wrong thread crashed\n");
-		printk("PROJECT EXECUTION FAILED\n");
+		TC_END_REPORT(TC_FAIL);
 		k_fatal_halt(reason);
 	}
 
 	if (reason != expected_reason) {
 		printk("Wrong crash type got %d expected %d\n", reason,
 		       expected_reason);
-		printk("PROJECT EXECUTION FAILED\n");
+		TC_END_REPORT(TC_FAIL);
 		k_fatal_halt(reason);
 	}
 

--- a/tests/kernel/mem_protect/demand_paging/src/main.c
+++ b/tests/kernel/mem_protect/demand_paging/src/main.c
@@ -73,7 +73,7 @@ void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
 		ztest_test_pass();
 	} else {
 		printk("Unexpected fault during test");
-		printk("PROJECT EXECUTION FAILED\n");
+		TC_END_REPORT(TC_FAIL);
 		k_fatal_halt(reason);
 	}
 }

--- a/tests/kernel/mem_protect/mem_map/src/main.c
+++ b/tests/kernel/mem_protect/mem_map/src/main.c
@@ -42,7 +42,7 @@ void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
 		ztest_test_pass();
 	} else {
 		printk("Unexpected fault during test\n");
-		printk("PROJECT EXECUTION FAILED\n");
+		TC_END_REPORT(TC_FAIL);
 		k_fatal_halt(reason);
 	}
 }

--- a/tests/kernel/mem_protect/mem_protect/src/common.c
+++ b/tests/kernel/mem_protect/mem_protect/src/common.c
@@ -16,7 +16,7 @@ void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
 		valid_fault = false; /* reset back to normal */
 	} else {
 		printk("fatal error was unexpected, aborting\n");
-		printk("PROJECT EXECUTION FAILED\n");
+		TC_END_REPORT(TC_FAIL);
 		k_fatal_halt(reason);
 	}
 }

--- a/tests/kernel/mem_protect/stackprot/src/main.c
+++ b/tests/kernel/mem_protect/stackprot/src/main.c
@@ -19,7 +19,7 @@ void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *esf)
 {
 	if (reason != K_ERR_STACK_CHK_FAIL) {
 		printk("wrong error type\n");
-		printk("PROJECT EXECUTION FAILED\n");
+		TC_END_REPORT(TC_FAIL);
 		k_fatal_halt(reason);
 	}
 }

--- a/tests/kernel/mem_protect/sys_sem/src/main.c
+++ b/tests/kernel/mem_protect/sys_sem/src/main.c
@@ -572,7 +572,7 @@ void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
 {
 	printk("Caught system error -- reason %d\n", reason);
 	printk("Unexpected fault during test\n");
-	printk("PROJECT EXECUTION FAILED\n");
+	TC_END_REPORT(TC_FAIL);
 	k_fatal_halt(reason);
 }
 

--- a/tests/kernel/mem_protect/syscalls/src/main.c
+++ b/tests/kernel/mem_protect/syscalls/src/main.c
@@ -40,7 +40,7 @@ void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
 {
 	printk("Caught system error -- reason %d\n", reason);
 	printk("Unexpected fault during test\n");
-	printk("PROJECT EXECUTION FAILED\n");
+	TC_END_REPORT(TC_FAIL);
 	k_fatal_halt(reason);
 }
 

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -82,12 +82,12 @@ void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
 		} else {
 			printk("Wrong fault reason, expecting %d\n",
 			       expected_reason);
-			printk("PROJECT EXECUTION FAILED\n");
+			TC_END_REPORT(TC_FAIL);
 			k_fatal_halt(reason);
 		}
 	} else {
 		printk("Unexpected fault during test\n");
-		printk("PROJECT EXECUTION FAILED\n");
+		TC_END_REPORT(TC_FAIL);
 		k_fatal_halt(reason);
 	}
 }

--- a/tests/kernel/pipe/pipe/src/test_pipe.c
+++ b/tests/kernel/pipe/pipe/src/test_pipe.c
@@ -681,7 +681,7 @@ void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
 		valid_fault = false; /* reset back to normal */
 		ztest_test_pass();
 	} else {
-		printk("PROJECT EXECUTION FAILED\n");
+		TC_END_REPORT(TC_FAIL);
 		k_fatal_halt(reason);
 	}
 }

--- a/tests/kernel/smp/src/main.c
+++ b/tests/kernel/smp/src/main.c
@@ -763,7 +763,7 @@ void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *esf)
 
 	if (reason != K_ERR_KERNEL_OOPS) {
 		printk("wrong error reason\n");
-		printk("PROJECT EXECUTION FAILED\n");
+		TC_END_REPORT(TC_FAIL);
 		k_fatal_halt(reason);
 	}
 

--- a/tests/kernel/threads/dynamic_thread/src/main.c
+++ b/tests/kernel/threads/dynamic_thread/src/main.c
@@ -20,12 +20,12 @@ void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *esf)
 {
 	if (reason != K_ERR_KERNEL_OOPS) {
 		printk("wrong error reason\n");
-		printk("PROJECT EXECUTION FAILED\n");
+		TC_END_REPORT(TC_FAIL);
 		k_fatal_halt(reason);
 	}
 	if (k_current_get() != dyn_thread) {
 		printk("wrong thread crashed\n");
-		printk("PROJECT EXECUTION FAILED\n");
+		TC_END_REPORT(TC_FAIL);
 		k_fatal_halt(reason);
 	}
 }


### PR DESCRIPTION
Use TC_END_REPORT() to report "PROJECT EXECUTION FAILED" instead of a call to printk() as this prints the failed message as well as the RunID.