### PR TITLE
pm: Fix a corner case when policy returns NULL

### DIFF
--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -183,6 +183,8 @@ bool pm_system_suspend(int32_t ticks)
 		info = pm_policy_next_state(id, ticks);
 		if (info != NULL) {
 			z_cpus_pm_state[id] = *info;
+		} else {
+			z_cpus_pm_state[id].state = PM_STATE_ACTIVE;
 		}
 	}
 	k_spin_unlock(&pm_forced_state_lock, key);


### PR DESCRIPTION
When the policy returns NULL pm_system_suspend was assuming that the current state in z_cpus_pm_state was ACTIVE, since that is the state set after the core wakes and return to this function. The problem is that in cases where the cpu does not preserve the context, and returns to this function, z_cpus_pm_state has the value of the last state used and the cpu use it again.

Fix it setting z_cpus_pm_state to ACTIVE every time the policy returns NULL.