### PR TITLE
modules: mcux: introduce CONFIG_MCUX_CORE_SUFFIX

### DIFF
--- a/modules/Kconfig.mcux
+++ b/modules/Kconfig.mcux
@@ -10,6 +10,12 @@ config HAS_MCUX
 
 if HAS_MCUX
 
+config MCUX_CORE_SUFFIX
+	string
+	help
+	  String describing the core identifer used by MCUX SDK when using
+	  dual core parts
+
 config HAS_MCUX_12B1MSPS_SAR
 	bool
 	help

--- a/west.yml
+++ b/west.yml
@@ -197,7 +197,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: pull/340/head
+      revision: pull/341/head
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
MCUX SDK depends on "core suffixes" in order to identify which core a build is targeting on a multicore part. Previously, this information was parsed from the CONFIG_SOC string, but with hardware model v2 this is no longer possible. Introduce the Kconfig MCUX_CORE_SUFFIX, which multicore SOCs can set to inform MCUX which core the build is targeting.