### PR TITLE
ztest: Remove superfluous comment

### DIFF
--- a/subsys/testsuite/ztest/include/zephyr/ztest_assert.h
+++ b/subsys/testsuite/ztest/include/zephyr/ztest_assert.h
@@ -622,7 +622,6 @@ static inline bool z_zexpect(bool cond, const char *default_msg, const char *fil
 
 /**
  * @brief Expect that @a a equals @a b, otherwise mark test as failed but continue its execution.
- * expectation fails, the test will be marked as "skipped".
  *
  * @param a Value to compare
  * @param b Value to compare


### PR DESCRIPTION
This is obviously a copy & paste error. It was introduced by 107cb86bb3f981ec89a02b279bacf313c822b564 (ztest: Add initial zexpect API for delayed failing).