### PR TITLE
Bluetooth: audio: BAP: allow for multiple callbacks

### DIFF
--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -2135,6 +2135,8 @@ struct bt_bap_broadcast_assistant_cb {
 	 * @param err     Error value. 0 on success, GATT error on fail.
 	 */
 	void (*rem_src)(struct bt_conn *conn, int err);
+
+	sys_snode_t _node;
 };
 
 /**
@@ -2178,8 +2180,26 @@ int bt_bap_broadcast_assistant_scan_stop(struct bt_conn *conn);
 
 /**
  * @brief Registers the callbacks used by Broadcast Audio Scan Service client.
+ *
+ * @param cb	The callback structure.
+ *
+ * @retval 0 on success
+ * @retval -EINVAL if @p cb is NULL
+ * @retval -EALREADY if @p cb was already registered
  */
-void bt_bap_broadcast_assistant_register_cb(struct bt_bap_broadcast_assistant_cb *cb);
+int bt_bap_broadcast_assistant_register_cb(struct bt_bap_broadcast_assistant_cb *cb);
+
+/**
+ * @brief Unregisters the callbacks used by the Broadcast Audio Scan Service client.
+ *
+ * @param cb   The callback structure.
+ *
+ * @retval 0 on success
+ * @retval -EINVAL if @p cb is NULL
+ * @retval -EALREADY if @p cb was not registered
+ */
+int bt_bap_broadcast_assistant_unregister_cb(struct bt_bap_broadcast_assistant_cb *cb);
+
 
 /** Parameters for adding a source to a Broadcast Audio Scan Service server */
 struct bt_bap_broadcast_assistant_add_src_param {

--- a/subsys/bluetooth/audio/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/bap_broadcast_assistant.c
@@ -430,6 +430,7 @@ static uint8_t notify_handler(struct bt_conn *conn,
 			return parse_and_send_recv_state(conn, handle, data, length, &recv_state);
 		}
 	} else {
+		broadcast_assistant.past_avail[index] = false;
 		bap_broadcast_assistant_recv_state_removed(conn, 0,
 							   broadcast_assistant.src_ids[index]);
 	}


### PR DESCRIPTION
The existing implementation allows for only one callback per procedure. This creates problems when for example adding CAP functionality. The callbacks are here implemented as an SLIST