### PR TITLE
drivers: can: add missing argument to LOG_ERR call

### DIFF
--- a/drivers/can/can_native_linux.c
+++ b/drivers/can/can_native_linux.c
@@ -240,7 +240,7 @@ static void can_native_linux_remove_rx_filter(const struct device *dev, int filt
 	struct can_native_linux_data *data = dev->data;
 
 	if (filter_id < 0 || filter_id >= ARRAY_SIZE(data->filters)) {
-		LOG_ERR("filter ID %d out of bounds");
+		LOG_ERR("filter ID %d out of bounds", filter_id);
 		return;
 	}
 


### PR DESCRIPTION
PR #64399 introduced checks for out-of-bounds filter IDs in CAN drivers, along with logging of said IDs; however, the call to LOG_ERR in the native POSIX/Linux driver is missing the 'filter_id' argument.

This commit adds the missing argument to ensure proper data is printed when the LOG_ERR call is performed.

Fixes: #69379