### PR TITLE
hwmv2: soc: atmel: Use new family prefix

### DIFF
--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -19,7 +19,7 @@
  * - no statistics collection
  */
 
-#if defined(CONFIG_SOC_FAMILY_SAM)
+#if defined(CONFIG_SOC_FAMILY_ATMEL_SAM)
 #define DT_DRV_COMPAT atmel_sam_gmac
 #else
 #define DT_DRV_COMPAT atmel_sam0_gmac
@@ -51,7 +51,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #include "eth.h"
 
-#ifdef CONFIG_SOC_FAMILY_SAM0
+#ifdef CONFIG_SOC_FAMILY_ATMEL_SAM0
 #include "eth_sam0_gmac.h"
 #endif
 
@@ -97,9 +97,9 @@ static inline void dcache_clean(uint32_t addr, uint32_t size)
 #define dcache_clean(addr, size)
 #endif
 
-#ifdef CONFIG_SOC_FAMILY_SAM0
+#ifdef CONFIG_SOC_FAMILY_ATMEL_SAM0
 #define MCK_FREQ_HZ	SOC_ATMEL_SAM0_MCK_FREQ_HZ
-#elif CONFIG_SOC_FAMILY_SAM
+#elif CONFIG_SOC_FAMILY_ATMEL_SAM
 #define MCK_FREQ_HZ	SOC_ATMEL_SAM_MCK_FREQ_HZ
 #else
 #error Unsupported SoC family
@@ -1796,7 +1796,7 @@ static int eth_initialize(const struct device *dev)
 
 	cfg->config_func();
 
-#ifdef CONFIG_SOC_FAMILY_SAM
+#ifdef CONFIG_SOC_FAMILY_ATMEL_SAM
 	/* Enable GMAC module's clock */
 	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
 			       (clock_control_subsys_t)&cfg->clock_cfg);
@@ -2235,7 +2235,7 @@ PINCTRL_DT_INST_DEFINE(0);
 static const struct eth_sam_dev_cfg eth0_config = {
 	.regs = (Gmac *)DT_INST_REG_ADDR(0),
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(0),
-#ifdef CONFIG_SOC_FAMILY_SAM
+#ifdef CONFIG_SOC_FAMILY_ATMEL_SAM
 	.clock_cfg = SAM_DT_INST_CLOCK_PMC_CFG(0),
 #endif
 	.config_func = eth0_irq_config,

--- a/drivers/ethernet/eth_sam_gmac_priv.h
+++ b/drivers/ethernet/eth_sam_gmac_priv.h
@@ -261,7 +261,7 @@ struct gmac_queue {
 /* Device constant configuration parameters */
 struct eth_sam_dev_cfg {
 	Gmac *regs;
-#ifdef CONFIG_SOC_FAMILY_SAM
+#ifdef CONFIG_SOC_FAMILY_ATMEL_SAM
 	const struct atmel_sam_pmc_config clock_cfg;
 #endif
 	const struct pinctrl_dev_config *pcfg;

--- a/drivers/hwinfo/Kconfig
+++ b/drivers/hwinfo/Kconfig
@@ -124,14 +124,14 @@ config HWINFO_RPI_PICO
 config HWINFO_SAM_RSTC
 	bool "Atmel SAM reset cause"
 	default y
-	depends on SOC_FAMILY_SAM && !SOC_SERIES_SAM4L
+	depends on SOC_FAMILY_ATMEL_SAM && !SOC_SERIES_SAM4L
 	help
 	  Enable Atmel SAM reset cause hwinfo driver.
 
 config HWINFO_SAM
 	bool "Atmel SAM device ID"
 	default y
-	depends on SOC_FAMILY_SAM && !SOC_SERIES_SAM4L
+	depends on SOC_FAMILY_ATMEL_SAM && !SOC_SERIES_SAM4L
 	help
 	  Enable Atmel SAM device ID hwinfo driver.
 
@@ -145,7 +145,7 @@ config HWINFO_SAM4L
 config HWINFO_SAM0
 	bool "Atmel SAM0 device ID"
 	default y
-	depends on SOC_FAMILY_SAM0
+	depends on SOC_FAMILY_ATMEL_SAM0
 	help
 	  Enable Atmel SAM0 hwinfo driver.
 

--- a/drivers/mdio/mdio_sam.c
+++ b/drivers/mdio/mdio_sam.c
@@ -21,7 +21,7 @@
 LOG_MODULE_REGISTER(mdio_sam, CONFIG_MDIO_LOG_LEVEL);
 
 /* GMAC */
-#ifdef CONFIG_SOC_FAMILY_SAM0
+#ifdef CONFIG_SOC_FAMILY_ATMEL_SAM0
 #define GMAC_MAN        MAN.reg
 #define GMAC_NSR        NSR.reg
 #define GMAC_NCR        NCR.reg
@@ -34,7 +34,7 @@ struct mdio_sam_dev_data {
 struct mdio_sam_dev_config {
 	Gmac * const regs;
 	const struct pinctrl_dev_config *pcfg;
-#ifdef CONFIG_SOC_FAMILY_SAM
+#ifdef CONFIG_SOC_FAMILY_ATMEL_SAM
 	const struct atmel_sam_pmc_config clock_cfg;
 #endif
 };
@@ -144,7 +144,7 @@ static int mdio_sam_initialize(const struct device *dev)
 
 	k_sem_init(&data->sem, 1, 1);
 
-#ifdef CONFIG_SOC_FAMILY_SAM
+#ifdef CONFIG_SOC_FAMILY_ATMEL_SAM
 	/* Enable GMAC module's clock */
 	(void) clock_control_on(SAM_DT_PMC_CONTROLLER, (clock_control_subsys_t) &cfg->clock_cfg);
 #else
@@ -168,7 +168,7 @@ static const struct mdio_driver_api mdio_sam_driver_api = {
 };
 
 #define MDIO_SAM_CLOCK(n)						\
-	COND_CODE_1(CONFIG_SOC_FAMILY_SAM,				\
+	COND_CODE_1(CONFIG_SOC_FAMILY_ATMEL_SAM,			\
 		(.clock_cfg = SAM_DT_INST_CLOCK_PMC_CFG(n),), ()	\
 	)
 

--- a/drivers/sensor/qdec_sam/Kconfig
+++ b/drivers/sensor/qdec_sam/Kconfig
@@ -8,6 +8,6 @@ config QDEC_SAM
 	bool "Atmel SAM QDEC driver"
 	default y
 	depends on DT_HAS_ATMEL_SAM_TC_QDEC_ENABLED
-	depends on SOC_FAMILY_SAM
+	depends on SOC_FAMILY_ATMEL_SAM
 	help
 	  Atmel SAM MCU family Quadrature Decoder (TC) driver.

--- a/include/zephyr/drivers/pinctrl/pinctrl_soc_sam_common.h
+++ b/include/zephyr/drivers/pinctrl/pinctrl_soc_sam_common.h
@@ -38,14 +38,14 @@ typedef uint32_t pinctrl_soc_pin_t;
  * @param prop Property name.
  * @param idx Property entry index.
  */
-#if defined(CONFIG_SOC_FAMILY_SAM)
+#if defined(CONFIG_SOC_FAMILY_ATMEL_SAM)
 #define Z_PINCTRL_STATE_PIN_INIT(node_id, prop, idx)				\
 	((DT_PROP_BY_IDX(node_id, prop, idx)   << SAM_PINCTRL_PINMUX_POS)	\
 	 | (DT_PROP(node_id, bias_pull_up)     << SAM_PINCTRL_PULLUP_POS)	\
 	 | (DT_PROP(node_id, bias_pull_down)   << SAM_PINCTRL_PULLDOWN_POS)	\
 	 | (DT_PROP(node_id, drive_open_drain) << SAM_PINCTRL_OPENDRAIN_POS)	\
 	),
-#else /* CONFIG_SOC_FAMILY_SAM0 */
+#else /* CONFIG_SOC_FAMILY_ATMEL_SAM0 */
 #define Z_PINCTRL_STATE_PIN_INIT(node_id, prop, idx)				  \
 	((DT_PROP_BY_IDX(node_id, prop, idx)     << SAM_PINCTRL_PINMUX_POS)	  \
 	 | (DT_PROP(node_id, bias_pull_up)       << SAM_PINCTRL_PULLUP_POS)	  \

--- a/modules/Kconfig.atmel
+++ b/modules/Kconfig.atmel
@@ -6,7 +6,7 @@
 config ASF
 	bool
 	select HAS_CMSIS_CORE
-	depends on SOC_FAMILY_SAM || SOC_FAMILY_SAM0
+	depends on SOC_FAMILY_ATMEL_SAM || SOC_FAMILY_ATMEL_SAM0
 
 config ATMEL_WINC1500
 	bool

--- a/samples/drivers/counter/alarm/src/main.c
+++ b/samples/drivers/counter/alarm/src/main.c
@@ -17,7 +17,7 @@ struct counter_alarm_cfg alarm_cfg;
 
 #if defined(CONFIG_BOARD_SAMD20_XPRO)
 #define TIMER DT_NODELABEL(tc4)
-#elif defined(CONFIG_SOC_FAMILY_SAM)
+#elif defined(CONFIG_SOC_FAMILY_ATMEL_SAM)
 #define TIMER DT_NODELABEL(tc0)
 #elif defined(CONFIG_COUNTER_MICROCHIP_MCP7940N)
 #define TIMER DT_NODELABEL(extrtc0)

--- a/soc/atmel/sam/Kconfig
+++ b/soc/atmel/sam/Kconfig
@@ -1,12 +1,12 @@
 # Copyright (c) 2024 Gerson Fernando Budke <nandojve@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-config SOC_FAMILY_SAM
+config SOC_FAMILY_ATMEL_SAM
 	select ASF
 	select HAS_SEGGER_RTT if ZEPHYR_SEGGER_MODULE
 
-if SOC_FAMILY_SAM
+if SOC_FAMILY_ATMEL_SAM
 
 rsource "*/Kconfig"
 
-endif # SOC_FAMILY_SAM
+endif # SOC_FAMILY_ATMEL_SAM

--- a/soc/atmel/sam/Kconfig.defconfig
+++ b/soc/atmel/sam/Kconfig.defconfig
@@ -4,7 +4,7 @@
 # Copyright (c) 2024 Gerson Fernando Budke <nandojve@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-if SOC_FAMILY_SAM
+if SOC_FAMILY_ATMEL_SAM
 
 rsource "*/Kconfig.defconfig"
 
@@ -23,4 +23,4 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config WATCHDOG
 	default y
 
-endif # SOC_FAMILY_SAM
+endif # SOC_FAMILY_ATMEL_SAM

--- a/soc/atmel/sam/Kconfig.soc
+++ b/soc/atmel/sam/Kconfig.soc
@@ -1,10 +1,10 @@
 # Copyright (c) 2024 Gerson Fernando Budke <nandojve@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-config SOC_FAMILY_SAM
+config SOC_FAMILY_ATMEL_SAM
 	bool
 
 config SOC_FAMILY
-	default "atmel_sam" if SOC_FAMILY_SAM
+	default "atmel_sam" if SOC_FAMILY_ATMEL_SAM
 
 rsource "*/Kconfig.soc"

--- a/soc/atmel/sam/common/Kconfig
+++ b/soc/atmel/sam/common/Kconfig
@@ -3,7 +3,7 @@
 # Copyright (c) 2024 Gerson Fernando Budke <nandojve@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-if SOC_FAMILY_SAM && !SOC_SERIES_SAM4L
+if SOC_FAMILY_ATMEL_SAM && !SOC_SERIES_SAM4L
 
 menu "Clocks"
 
@@ -93,4 +93,4 @@ config SOC_ATMEL_SAM_DISABLE_ERASE_PIN
 	  option will switch the pin to general IO mode giving control of the
 	  pin to the GPIO module.
 
-endif # SOC_FAMILY_SAM && !SOC_SERIES_SAM4L
+endif # SOC_FAMILY_ATMEL_SAM && !SOC_SERIES_SAM4L

--- a/soc/atmel/sam/sam3x/Kconfig.soc
+++ b/soc/atmel/sam/sam3x/Kconfig.soc
@@ -8,7 +8,7 @@
 
 config SOC_SERIES_SAM3X
 	bool
-	select SOC_FAMILY_SAM
+	select SOC_FAMILY_ATMEL_SAM
 	help
 	  Enable support for Atmel SAM3X MCU Series
 

--- a/soc/atmel/sam/sam4e/Kconfig.soc
+++ b/soc/atmel/sam/sam4e/Kconfig.soc
@@ -7,7 +7,7 @@
 
 config SOC_SERIES_SAM4E
 	bool
-	select SOC_FAMILY_SAM
+	select SOC_FAMILY_ATMEL_SAM
 	help
 	  Enable support for Atmel SAM4E MCU series
 

--- a/soc/atmel/sam/sam4l/Kconfig.soc
+++ b/soc/atmel/sam/sam4l/Kconfig.soc
@@ -3,7 +3,7 @@
 
 config SOC_SERIES_SAM4L
 	bool
-	select SOC_FAMILY_SAM
+	select SOC_FAMILY_ATMEL_SAM
 	help
 	  Enable support for Atmel SAM4L Cortex-M4 microcontrollers.
 	  Part No.: SAM4LS8C, SAM4LS8B, SAM4LS8A, SAM4LS4C, SAM4LS4B,

--- a/soc/atmel/sam/sam4s/Kconfig.soc
+++ b/soc/atmel/sam/sam4s/Kconfig.soc
@@ -7,7 +7,7 @@
 
 config SOC_SERIES_SAM4S
 	bool
-	select SOC_FAMILY_SAM
+	select SOC_FAMILY_ATMEL_SAM
 	help
 	  Enable support for Atmel SAM4S Cortex-M4 microcontrollers.
 	  Part No.: SAM4S16C, SAM4S16B, SAM4S8C, SAM4S8B,

--- a/soc/atmel/sam/same70/Kconfig.soc
+++ b/soc/atmel/sam/same70/Kconfig.soc
@@ -6,7 +6,7 @@
 
 config SOC_SERIES_SAME70
 	bool
-	select SOC_FAMILY_SAM
+	select SOC_FAMILY_ATMEL_SAM
 	help
 	  Enable support for Atmel SAM E70 ARM Cortex-M7 Microcontrollers.
 	  Part No.: SAME70J19, SAME70J20, SAME70J21, SAME70N19, SAME70N20,

--- a/soc/atmel/sam/samv71/Kconfig.soc
+++ b/soc/atmel/sam/samv71/Kconfig.soc
@@ -6,7 +6,7 @@
 
 config SOC_SERIES_SAMV71
 	bool
-	select SOC_FAMILY_SAM
+	select SOC_FAMILY_ATMEL_SAM
 	help
 	  Enable support for Atmel SAM V71 ARM Cortex-M7 Microcontrollers.
 	  Part No.: SAMV71J19, SAMV71J20, SAMV71J21, SAMV71N19, SAMV71N20,

--- a/soc/atmel/sam0/Kconfig
+++ b/soc/atmel/sam0/Kconfig
@@ -4,13 +4,13 @@
 # Copyright (c) 2024 Gerson Fernando Budke <nandojve@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-config SOC_FAMILY_SAM0
+config SOC_FAMILY_ATMEL_SAM0
 	select ASF
 	select HAS_SEGGER_RTT if ZEPHYR_SEGGER_MODULE
 
-if SOC_FAMILY_SAM0
+if SOC_FAMILY_ATMEL_SAM0
 
 rsource "common/Kconfig.sam*"
 rsource "*/Kconfig"
 
-endif # SOC_FAMILY_SAM0
+endif # SOC_FAMILY_ATMEL_SAM0

--- a/soc/atmel/sam0/Kconfig.defconfig
+++ b/soc/atmel/sam0/Kconfig.defconfig
@@ -4,7 +4,7 @@
 # Copyright (c) 2024 Gerson Fernando Budke <nandojve@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-if SOC_FAMILY_SAM0
+if SOC_FAMILY_ATMEL_SAM0
 
 rsource "*/Kconfig.defconfig"
 
@@ -27,4 +27,4 @@ config HEAP_MEM_POOL_ADD_SIZE_SOC
 
 endif # USB_DEVICE_DRIVER
 
-endif # SOC_FAMILY_SAM0
+endif # SOC_FAMILY_ATMEL_SAM0

--- a/soc/atmel/sam0/Kconfig.soc
+++ b/soc/atmel/sam0/Kconfig.soc
@@ -2,20 +2,20 @@
 # Copyright (c) 2022-2024 Gerson Fernando Budke <nandojve@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-config SOC_FAMILY_SAM0
+config SOC_FAMILY_ATMEL_SAM0
 	bool
 
 config SOC_FAMILY
-	default "atmel_sam0" if SOC_FAMILY_SAM0
+	default "atmel_sam0" if SOC_FAMILY_ATMEL_SAM0
 
 config SOC_SERIES_REVISION_N
 	bool
-	depends on SOC_FAMILY_SAM0
+	depends on SOC_FAMILY_ATMEL_SAM0
 
 config SOC_SERIES_REVISION
 	string
 	default "n" if SOC_SERIES_REVISION_N
 	default ""
-	depends on SOC_FAMILY_SAM0
+	depends on SOC_FAMILY_ATMEL_SAM0
 
 rsource "*/Kconfig.soc"

--- a/soc/atmel/sam0/samc20/Kconfig.soc
+++ b/soc/atmel/sam0/samc20/Kconfig.soc
@@ -6,7 +6,7 @@
 
 config SOC_SERIES_SAMC20
 	bool
-	select SOC_FAMILY_SAM0
+	select SOC_FAMILY_ATMEL_SAM0
 	help
 	  Enable support for Atmel SAMC20 Cortex-M0+ microcontrollers.
 

--- a/soc/atmel/sam0/samc21/Kconfig.soc
+++ b/soc/atmel/sam0/samc21/Kconfig.soc
@@ -6,7 +6,7 @@
 
 config SOC_SERIES_SAMC21
 	bool
-	select SOC_FAMILY_SAM0
+	select SOC_FAMILY_ATMEL_SAM0
 	help
 	  Enable support for Atmel SAMC21 Cortex-M0+ microcontrollers.
 

--- a/soc/atmel/sam0/samd20/Kconfig.soc
+++ b/soc/atmel/sam0/samd20/Kconfig.soc
@@ -6,7 +6,7 @@
 
 config SOC_SERIES_SAMD20
 	bool
-	select SOC_FAMILY_SAM0
+	select SOC_FAMILY_ATMEL_SAM0
 	help
 	  Enable support for Atmel SAMD20 Cortex-M0+ microcontrollers.
 

--- a/soc/atmel/sam0/samd21/Kconfig.soc
+++ b/soc/atmel/sam0/samd21/Kconfig.soc
@@ -6,7 +6,7 @@
 
 config SOC_SERIES_SAMD21
 	bool
-	select SOC_FAMILY_SAM0
+	select SOC_FAMILY_ATMEL_SAM0
 	help
 	  Enable support for Atmel SAMD21 Cortex-M0+ microcontrollers.
 

--- a/soc/atmel/sam0/samd51/Kconfig.soc
+++ b/soc/atmel/sam0/samd51/Kconfig.soc
@@ -6,7 +6,7 @@
 
 config SOC_SERIES_SAMD51
 	bool
-	select SOC_FAMILY_SAM0
+	select SOC_FAMILY_ATMEL_SAM0
 	help
 	  Enable support for Atmel SAMD51 Cortex-M4F microcontrollers.
 

--- a/soc/atmel/sam0/same51/Kconfig.soc
+++ b/soc/atmel/sam0/same51/Kconfig.soc
@@ -6,7 +6,7 @@
 
 config SOC_SERIES_SAME51
 	bool
-	select SOC_FAMILY_SAM0
+	select SOC_FAMILY_ATMEL_SAM0
 	help
 	  Enable support for Atmel SAME51 Cortex-M4F microcontrollers.
 

--- a/soc/atmel/sam0/same53/Kconfig.soc
+++ b/soc/atmel/sam0/same53/Kconfig.soc
@@ -6,7 +6,7 @@
 
 config SOC_SERIES_SAME53
 	bool
-	select SOC_FAMILY_SAM0
+	select SOC_FAMILY_ATMEL_SAM0
 	help
 	  Enable support for Atmel SAME53 Cortex-M4F microcontrollers.
 

--- a/soc/atmel/sam0/same54/Kconfig.soc
+++ b/soc/atmel/sam0/same54/Kconfig.soc
@@ -6,7 +6,7 @@
 
 config SOC_SERIES_SAME54
 	bool
-	select SOC_FAMILY_SAM0
+	select SOC_FAMILY_ATMEL_SAM0
 	help
 	  Enable support for Atmel SAME54 Cortex-M4F microcontrollers.
 

--- a/soc/atmel/sam0/saml21/Kconfig.soc
+++ b/soc/atmel/sam0/saml21/Kconfig.soc
@@ -6,7 +6,7 @@
 
 config SOC_SERIES_SAML21
 	bool
-	select SOC_FAMILY_SAM0
+	select SOC_FAMILY_ATMEL_SAM0
 	help
 	  Enable support for Atmel SAML21 Cortex-M0+ microcontrollers.
 

--- a/soc/atmel/sam0/samr21/Kconfig.soc
+++ b/soc/atmel/sam0/samr21/Kconfig.soc
@@ -6,7 +6,7 @@
 
 config SOC_SERIES_SAMR21
 	bool
-	select SOC_FAMILY_SAM0
+	select SOC_FAMILY_ATMEL_SAM0
 	help
 	  Enable support for Atmel SAMR21 Cortex-M0+ microcontrollers.
 

--- a/soc/atmel/sam0/samr34/Kconfig.soc
+++ b/soc/atmel/sam0/samr34/Kconfig.soc
@@ -6,7 +6,7 @@
 
 config SOC_SERIES_SAMR34
 	bool
-	select SOC_FAMILY_SAM0
+	select SOC_FAMILY_ATMEL_SAM0
 	help
 	  Enable support for Atmel SAMR34 Cortex-M0+ microcontrollers.
 

--- a/soc/atmel/sam0/samr35/Kconfig.soc
+++ b/soc/atmel/sam0/samr35/Kconfig.soc
@@ -6,7 +6,7 @@
 
 config SOC_SERIES_SAMR35
 	bool
-	select SOC_FAMILY_SAM0
+	select SOC_FAMILY_ATMEL_SAM0
 	help
 	  Enable support for Atmel SAMR35 Cortex-M0+ microcontrollers.
 

--- a/tests/drivers/uart/uart_async_api/testcase.yaml
+++ b/tests/drivers/uart/uart_async_api/testcase.yaml
@@ -63,7 +63,7 @@ tests:
     harness: ztest
     depends_on: dma
   drivers.uart.async_api.sam0:
-    filter: CONFIG_SERIAL_SUPPORT_ASYNC and CONFIG_SOC_FAMILY_SAM0
+    filter: CONFIG_SERIAL_SUPPORT_ASYNC and CONFIG_SOC_FAMILY_ATMEL_SAM0
     platform_allow:
       - samc21n_xpro
       - samd21_xpro

--- a/west.yml
+++ b/west.yml
@@ -151,7 +151,7 @@ manifest:
       groups:
         - hal
     - name: hal_atmel
-      revision: aad79bf530b69b72712d18873df4120ad052d921
+      revision: d6221e73d76a4a31d802e0657342fcbda77e21ae
       path: modules/hal/atmel
       groups:
         - hal


### PR DESCRIPTION
The newer HWMv2 impose a different semantic in the family names. This update from SOC_FAMILY_SAMx to SOC_FAMILY_ATMEL_SAMx to comply with.

Fixes #69046

NOTE: This should go after `collab-hwm` branch be merged.