### PR TITLE
disk/nvme: Update copyright headers

### DIFF
--- a/drivers/disk/nvme/nvme.h
+++ b/drivers/disk/nvme/nvme.h
@@ -1,7 +1,9 @@
 /*
  * Copyright (c) 2022 Intel Corporation
- *
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * Derived from FreeBSD original driver made by Jim Harris
+ * with contributions from Alexander Motin and Wojciech Macek
  */
 
 #ifndef ZEPHYR_DRIVERS_DISK_NVME_NHME_H_

--- a/drivers/disk/nvme/nvme_cmd.c
+++ b/drivers/disk/nvme/nvme_cmd.c
@@ -1,6 +1,9 @@
 /*
+ * Copyright (c) 2022 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) 2022 Intel Corp.
+ *
+ * Derived from FreeBSD original driver made by Jim Harris
+ * with contributions from Alexander Motin, Wojciech Macek, and Warner Losh
  */
 
 #include <zephyr/logging/log.h>

--- a/drivers/disk/nvme/nvme_cmd.h
+++ b/drivers/disk/nvme/nvme_cmd.h
@@ -1,6 +1,9 @@
 /*
+ * Copyright (c) 2022 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) 2022 Intel Corp.
+ *
+ * Derived from FreeBSD original driver made by Jim Harris
+ * with contributions from Alexander Motin and Wojciech Macek
  */
 
 #ifndef ZEPHYR_DRIVERS_DISK_NVME_NVME_COMMAND_H_

--- a/drivers/disk/nvme/nvme_controller.c
+++ b/drivers/disk/nvme/nvme_controller.c
@@ -1,7 +1,9 @@
 /*
  * Copyright (c) 2022 Intel Corporation
- *
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * Derived from FreeBSD original driver made by Jim Harris
+ * with contributions from Alexander Motin, Wojciech Macek, and Warner Losh
  */
 
 #define DT_DRV_COMPAT nvme_controller

--- a/drivers/disk/nvme/nvme_controller_cmd.c
+++ b/drivers/disk/nvme/nvme_controller_cmd.c
@@ -1,6 +1,8 @@
 /*
+ * Copyright (c) 2022 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) 2022 Intel Corp.
+ *
+ * Derived from FreeBSD original driver made by Jim Harris
  */
 
 #include <zephyr/logging/log.h>

--- a/drivers/disk/nvme/nvme_disk.c
+++ b/drivers/disk/nvme/nvme_disk.c
@@ -1,6 +1,6 @@
 /*
+ * Copyright (c) 2022 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) 2022 Intel Corp.
  */
 
 #include <zephyr/logging/log.h>

--- a/drivers/disk/nvme/nvme_namespace.c
+++ b/drivers/disk/nvme/nvme_namespace.c
@@ -1,6 +1,8 @@
 /*
+ * Copyright (c) 2022 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) 2022 Intel Corp.
+ *
+ * Derived from FreeBSD original driver made by Jim Harris
  */
 
 #include <zephyr/logging/log.h>

--- a/drivers/disk/nvme/nvme_namespace.h
+++ b/drivers/disk/nvme/nvme_namespace.h
@@ -1,7 +1,9 @@
 /*
  * Copyright (c) 2022 Intel Corporation
- *
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * Derived from FreeBSD original driver made by Jim Harris
+ * with contributions from Alexander Motin and Wojciech Macek
  */
 
 #ifndef ZEPHYR_DRIVERS_DISK_NVME_NVME_NAMESPACE_H_


### PR DESCRIPTION
(long over due)

Most of the code is a port of FreeBSD's NVMe's driver, made by Jim Harris (Intel).

Though all subsequent contributions that happened on this original driver were made on files copyrighted by Intel, and under BSD-2 clause, let's update the copyright header to point out Jim's original work and major contributors were relevant.