### PR TITLE
logging: support using real time as timestamp

### DIFF
--- a/subsys/logging/Kconfig.processing
+++ b/subsys/logging/Kconfig.processing
@@ -158,6 +158,13 @@ config LOG_TRACE_SHORT_TIMESTAMP
 config LOG_TIMESTAMP_64BIT
 	bool "Use 64 bit timestamp"
 
+config LOG_TIMESTAMP_USE_REALTIME
+	bool "Use real time clock for timestamp"
+	select LOG_TIMESTAMP_64BIT
+	depends on POSIX_CLOCK
+	help
+	  When enabled, real time clock is used for timestamping.
+
 config LOG_SPEED
 	bool "Prefer performance over size"
 	depends on LOG_MODE_DEFERRED


### PR DESCRIPTION
Adds a option to use real time from posix instant of the system uptime as the logging timestamp.