### PR TITLE
net: ethernet: Support HW MAC address filtering

### DIFF
--- a/drivers/ethernet/eth_nxp_s32_netc_priv.h
+++ b/drivers/ethernet/eth_nxp_s32_netc_priv.h
@@ -131,7 +131,7 @@ struct nxp_s32_eth_data {
 int nxp_s32_eth_initialize_common(const struct device *dev);
 int nxp_s32_eth_tx(const struct device *dev, struct net_pkt *pkt);
 enum ethernet_hw_caps nxp_s32_eth_get_capabilities(const struct device *dev);
-void nxp_s32_eth_mcast_cb(struct net_if *iface, const struct net_addr *addr, bool is_joined);
+void nxp_s32_eth_mcast_filter(const struct device *dev, const struct ethernet_filter *filter);
 int nxp_s32_eth_set_config(const struct device *dev, enum ethernet_config_type type,
 			   const struct ethernet_config *config);
 extern void Netc_Eth_Ip_MSIX_Rx(uint8_t si_idx);

--- a/drivers/ethernet/eth_nxp_s32_netc_psi.c
+++ b/drivers/ethernet/eth_nxp_s32_netc_psi.c
@@ -156,11 +156,6 @@ static void nxp_s32_eth_iface_init(struct net_if *iface)
 	struct nxp_s32_eth_data *ctx = dev->data;
 	const struct nxp_s32_eth_config *cfg = dev->config;
 	const struct nxp_s32_eth_msix *msix;
-#if defined(CONFIG_NET_IPV6)
-	static struct net_if_mcast_monitor mon;
-
-	net_if_mcast_mon_register(&mon, iface, nxp_s32_eth_mcast_cb);
-#endif /* CONFIG_NET_IPV6 */
 
 	/*
 	 * For VLAN, this value is only used to get the correct L2 driver.

--- a/drivers/ethernet/eth_nxp_s32_netc_vsi.c
+++ b/drivers/ethernet/eth_nxp_s32_netc_vsi.c
@@ -37,11 +37,6 @@ static void nxp_s32_eth_iface_init(struct net_if *iface)
 	struct nxp_s32_eth_data *ctx = dev->data;
 	const struct nxp_s32_eth_config *cfg = dev->config;
 	const struct nxp_s32_eth_msix *msix;
-#if defined(CONFIG_NET_IPV6)
-	static struct net_if_mcast_monitor mon;
-
-	net_if_mcast_mon_register(&mon, iface, nxp_s32_eth_mcast_cb);
-#endif /* CONFIG_NET_IPV6 */
 
 	/*
 	 * For VLAN, this value is only used to get the correct L2 driver.

--- a/drivers/ethernet/eth_stm32_hal_priv.h
+++ b/drivers/ethernet/eth_stm32_hal_priv.h
@@ -49,6 +49,9 @@ struct eth_stm32_hal_dev_data {
 		CONFIG_ETH_STM32_HAL_RX_THREAD_STACK_SIZE);
 	struct k_thread rx_thread;
 	bool link_up;
+#if defined(CONFIG_ETH_STM32_MULTICAST_FILTER)
+	uint8_t hash_index_cnt[64];
+#endif /* CONFIG_ETH_STM32_MULTICAST_FILTER */
 #if defined(CONFIG_PTP_CLOCK_STM32_HAL)
 	const struct device *ptp_clock;
 	float clk_ratio;

--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -1046,6 +1046,18 @@ int net_eth_promisc_mode(struct net_if *iface, bool enable);
 int net_eth_txinjection_mode(struct net_if *iface, bool enable);
 
 /**
+ * @brief Set or unset HW filtering for MAC address @p mac.
+ *
+ * @param iface Network interface
+ * @param mac Pointer to an ethernet MAC address
+ * @param type Filter type, either source or destination
+ * @param enable Set (true) or unset (false)
+ *
+ * @return 0 if filter set or unset was successful, <0 otherwise.
+ */
+int net_eth_mac_filter(struct net_if *iface, struct net_eth_addr *mac,
+		       enum ethernet_filter_type type, bool enable);
+/**
  * @brief Return PTP clock that is tied to this ethernet network interface.
  *
  * @param iface Network interface

--- a/include/zephyr/net/ethernet_mgmt.h
+++ b/include/zephyr/net/ethernet_mgmt.h
@@ -54,6 +54,7 @@ enum net_request_ethernet_cmd {
 	NET_REQUEST_ETHERNET_CMD_SET_T1S_PARAM,
 	NET_REQUEST_ETHERNET_CMD_SET_TXINJECTION_MODE,
 	NET_REQUEST_ETHERNET_CMD_GET_TXINJECTION_MODE,
+	NET_REQUEST_ETHERNET_CMD_SET_MAC_FILTER,
 };
 
 #define NET_REQUEST_ETHERNET_SET_AUTO_NEGOTIATION			\
@@ -146,6 +147,11 @@ NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_ETHERNET_SET_TXINJECTION_MODE);
 
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_ETHERNET_GET_TXINJECTION_MODE);
 
+#define NET_REQUEST_ETHERNET_SET_MAC_FILTER				\
+	(_NET_ETHERNET_BASE | NET_REQUEST_ETHERNET_CMD_SET_MAC_FILTER)
+
+NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_ETHERNET_SET_MAC_FILTER);
+
 struct net_eth_addr;
 struct ethernet_qav_param;
 struct ethernet_qbv_param;
@@ -172,6 +178,8 @@ struct ethernet_req_params {
 		struct ethernet_qbu_param qbu_param;
 		struct ethernet_txtime_param txtime_param;
 		struct ethernet_t1s_param t1s_param;
+
+		struct ethernet_filter filter;
 
 		int priority_queues_num;
 		int ports_num;

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -1495,7 +1495,7 @@ struct net_if_mcast_monitor {
  *
  * @param mon Monitor handle. This is a pointer to a monitor storage structure
  * which should be allocated by caller, but does not need to be initialized.
- * @param iface Network interface
+ * @param iface Network interface or NULL for all interfaces
  * @param cb Monitor callback
  */
 void net_if_mcast_mon_register(struct net_if_mcast_monitor *mon,

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -33,6 +33,11 @@ config NET_NATIVE
 # Hidden options for enabling native IPv6/IPv4. Using these options
 # avoids having "defined(CONFIG_NET_IPV6) && defined(CONFIG_NET_NATIVE)"
 # in the code as we can have "defined(CONFIG_NET_NATIVE_IPV6)" instead.
+config NET_NATIVE_IP
+	bool
+	depends on NET_NATIVE
+	default y if NET_IP
+
 config NET_NATIVE_IPV6
 	bool
 	depends on NET_NATIVE

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -994,7 +994,7 @@ void net_if_mcast_monitor(struct net_if *iface,
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&mcast_monitor_callbacks,
 					  mon, tmp, node) {
-		if (iface == mon->iface) {
+		if (iface == mon->iface || mon->iface == NULL) {
 			mon->cb(iface, addr, is_joined);
 		}
 	}

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -1215,6 +1215,32 @@ int net_eth_txinjection_mode(struct net_if *iface, bool enable)
 			&params, sizeof(struct ethernet_req_params));
 }
 
+int net_eth_mac_filter(struct net_if *iface, struct net_eth_addr *mac,
+		       enum ethernet_filter_type type, bool enable)
+{
+#ifdef CONFIG_NET_L2_ETHERNET_MGMT
+	struct ethernet_req_params params;
+
+	if (!(net_eth_get_hw_capabilities(iface) & ETHERNET_HW_FILTERING)) {
+		return -ENOTSUP;
+	}
+
+	memcpy(&params.filter.mac_address, mac, sizeof(struct net_eth_addr));
+	params.filter.type = type;
+	params.filter.set = enable;
+
+	return net_mgmt(NET_REQUEST_ETHERNET_SET_MAC_FILTER, iface, &params,
+			sizeof(struct ethernet_req_params));
+#else
+	ARG_UNUSED(iface);
+	ARG_UNUSED(mac);
+	ARG_UNUSED(type);
+	ARG_UNUSED(enable);
+
+	return -ENOTSUP;
+#endif
+}
+
 void ethernet_init(struct net_if *iface)
 {
 	struct ethernet_context *ctx = net_if_l2_data(iface);

--- a/subsys/net/l2/ethernet/ethernet_mgmt.c
+++ b/subsys/net/l2/ethernet/ethernet_mgmt.c
@@ -207,6 +207,13 @@ static int ethernet_set_config(uint32_t mgmt_request,
 
 		config.txinjection_mode = params->txinjection_mode;
 		type = ETHERNET_CONFIG_TYPE_TXINJECTION_MODE;
+	} else if (mgmt_request == NET_REQUEST_ETHERNET_SET_MAC_FILTER) {
+		if (!is_hw_caps_supported(dev, ETHERNET_HW_FILTERING)) {
+			return -ENOTSUP;
+		}
+
+		memcpy(&config.filter, &params->filter, sizeof(struct ethernet_filter));
+		type = ETHERNET_CONFIG_TYPE_FILTER;
 	} else {
 		return -EINVAL;
 	}
@@ -245,6 +252,9 @@ NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_ETHERNET_SET_T1S_PARAM,
 				  ethernet_set_config);
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_ETHERNET_SET_TXINJECTION_MODE,
+				  ethernet_set_config);
+
+NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_ETHERNET_SET_MAC_FILTER,
 				  ethernet_set_config);
 
 static int ethernet_get_config(uint32_t mgmt_request,


### PR DESCRIPTION
An existing ethernet configuration option can be utilized for MAC address filtering, this PR demonstrates this.