### PR TITLE
tests: dma: remove wrong license from overlay

### DIFF
--- a/tests/drivers/dma/loop_transfer/boards/intel_adsp_ace15_mtpm.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/intel_adsp_ace15_mtpm.overlay
@@ -1,8 +1,8 @@
-/* SPDX-License-Identifier: BSD-3-Clause */
 /*
  * Copyright (c) 2023 Intel Corporation
  *
  * Author: Tomasz Leman <tomasz.m.leman@intel.com>
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 tst_dma0: &lpgpdma0 { };


### PR DESCRIPTION
Wrongly licensed file, change to APL-2.0.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
