### PR TITLE
boards: arm: nrf54l15pdk: Added arduino_i2c

### DIFF
--- a/boards/nordic/nrf54l15pdk/nrf54l15pdk_nrf54l15-common.dtsi
+++ b/boards/nordic/nrf54l15pdk/nrf54l15pdk_nrf54l15-common.dtsi
@@ -98,3 +98,10 @@
 	pinctrl-1 = <&pwm20_sleep>;
 	pinctrl-names = "default", "sleep";
 };
+
+arduino_i2c: &i2c21 {
+	compatible = "nordic,nrf-twim";
+	pinctrl-0 = <&i2c21_default>;
+	pinctrl-1 = <&i2c21_sleep>;
+	pinctrl-names = "default", "sleep";
+};

--- a/boards/nordic/nrf54l15pdk/nrf54l15pdk_nrf54l15-pinctrl.dtsi
+++ b/boards/nordic/nrf54l15pdk/nrf54l15pdk_nrf54l15-pinctrl.dtsi
@@ -77,4 +77,19 @@
 			low-power-enable;
 		};
 	};
+
+	/omit-if-no-ref/ i2c21_default: i2c21_default {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 1, 11)>,
+				<NRF_PSEL(TWIM_SCL, 1, 12)>;
+		};
+	};
+
+	/omit-if-no-ref/ i2c21_sleep: i2c21_sleep {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 1, 11)>,
+				<NRF_PSEL(TWIM_SCL, 1, 12)>;
+			low-power-enable;
+		};
+	};
 };


### PR DESCRIPTION
Added arduino_i2c to nrf54l15pdk to support I2C shields.