### PR TITLE
Modules: LVGL: Add Support for Rounder Callback

### DIFF
--- a/boards/renesas/da1469x_dk_pro/Kconfig.defconfig
+++ b/boards/renesas/da1469x_dk_pro/Kconfig.defconfig
@@ -1,0 +1,12 @@
+# DA1469x series Development Kit Pro board configuration
+
+# Copyright (c) 2024 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_DA1469X_DK_PRO
+
+config LV_Z_AREA_X_ALIGNMENT_WIDTH
+	default 2
+	depends on LVGL
+
+endif # BOARD_DA1469X_DK_PRO

--- a/modules/lvgl/Kconfig
+++ b/modules/lvgl/Kconfig
@@ -52,6 +52,10 @@ config LV_Z_LOG_LEVEL
 	default 3 if LV_LOG_LEVEL_USER
 	default 4 if LV_LOG_LEVEL_TRACE
 
+config LV_Z_USE_ROUNDER_CB
+	bool
+	default y if LV_Z_AREA_X_ALIGNMENT_WIDTH != 1 || LV_Z_AREA_Y_ALIGNMENT_WIDTH != 1
+
 config APP_LINK_WITH_LVGL
 	bool "Link 'app' with LVGL"
 	default y
@@ -106,6 +110,22 @@ config LV_Z_FLUSH_THREAD_PRIO
 	  Cooperative priority of LVGL flush thread.
 
 endif # LV_Z_FLUSH_THREAD
+
+config LV_Z_AREA_X_ALIGNMENT_WIDTH
+	int "Frame X alignment size"
+	default 1
+	help
+	  Number of pixels, X axis should be rounded to. Should be used to override
+	  the current frame dimensions to meet display and/or LCD host
+	  controller requirements. The value must be power of 2.
+
+config LV_Z_AREA_Y_ALIGNMENT_WIDTH
+	int "Frame Y alignment size"
+	default 1
+	help
+	  Number of pixels, Y axis should be rounded to. Should be used to override
+	  the current frame dimensions to meet display and/or LCD host
+	  controller requirements. The value must be power of 2.
 
 rsource "Kconfig.memory"
 rsource "Kconfig.input"

--- a/modules/lvgl/include/lvgl_display.h
+++ b/modules/lvgl/include/lvgl_display.h
@@ -49,6 +49,10 @@ int set_lvgl_rendering_cb(lv_disp_drv_t *disp_drv);
 
 void lvgl_flush_display(struct lvgl_display_flush *request);
 
+#ifdef CONFIG_LV_Z_USE_ROUNDER_CB
+void lvgl_rounder_cb(lv_disp_drv_t *disp_drv, lv_area_t *area);
+#endif
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Add support for LVGL frame rounder callback function. Sometimes, either the underlying display controller and/or the LCD host controller might impose restrictions on frames resolution. For instance, the E1394AA65A display model should impose that either axis of a frame be multiple of 2 pixels or the Renesas LCD controller of the DA1469x SoC, should impose that the stride value, number of bytes between consecutive frame lines, be multiple of 4 bytes.