### PR TITLE
sched.c: the priority of deadline task should have the highest priority.

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -71,14 +71,6 @@ static inline bool is_thread_dummy(struct k_thread *thread)
 int32_t z_sched_prio_cmp(struct k_thread *thread_1,
 	struct k_thread *thread_2)
 {
-	/* `prio` is <32b, so the below cannot overflow. */
-	int32_t b1 = thread_1->base.prio;
-	int32_t b2 = thread_2->base.prio;
-
-	if (b1 != b2) {
-		return b2 - b1;
-	}
-
 #ifdef CONFIG_SCHED_DEADLINE
 	/* If we assume all deadlines live within the same "half" of
 	 * the 32 bit modulus space (this is a documented API rule),
@@ -99,6 +91,15 @@ int32_t z_sched_prio_cmp(struct k_thread *thread_1,
 		return (int32_t) (d2 - d1);
 	}
 #endif /* CONFIG_SCHED_DEADLINE */
+
+	/* `prio` is <32b, so the below cannot overflow. */
+	int32_t b1 = thread_1->base.prio;
+	int32_t b2 = thread_2->base.prio;
+
+	if (b1 != b2) {
+		return b2 - b1;
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
The thread have deadline means that the task is critical so it should run first to avoid timeout.
I think this is more straightforward for users.

For example, if there are two threads.
Thread A is a normal task and priority is 1.
Thread B is a deadline task, priority is 2.

Originally scheduler will select thread A to run first. After this modification, it will select thread B (deadline task) to run.