### PR TITLE
drivers: display: Add 3wire mode support in st7735 controller

### DIFF
--- a/drivers/display/display_st7735r.c
+++ b/drivers/display/display_st7735r.c
@@ -23,7 +23,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(display_st7735r, CONFIG_DISPLAY_LOG_LEVEL);
 
-#define ST7735R_RESET_TIME              K_MSEC(1)
+#define ST7735R_RESET_TIME      K_MSEC(1)
 #define ST7735R_EXIT_SLEEP_TIME K_MSEC(120)
 
 #define ST7735R_PIXEL_SIZE 2u
@@ -59,8 +59,7 @@ struct st7735r_data {
 	uint16_t y_offset;
 };
 
-static void st7735r_set_lcd_margins(const struct device *dev,
-				    uint16_t x_offset, uint16_t y_offset)
+static void st7735r_set_lcd_margins(const struct device *dev, uint16_t x_offset, uint16_t y_offset)
 {
 	struct st7735r_data *data = dev->data;
 
@@ -75,12 +74,12 @@ static void st7735r_set_cmd(const struct device *dev, int is_cmd)
 	gpio_pin_set_dt(&config->cmd_data, is_cmd);
 }
 
-static int st7735r_transmit_hold(const struct device *dev, uint8_t cmd,
-				 const uint8_t *tx_data, size_t tx_count)
+static int st7735r_transmit_hold(const struct device *dev, uint8_t cmd, const uint8_t *tx_data,
+				 size_t tx_count)
 {
 	const struct st7735r_config *config = dev->config;
-	struct spi_buf tx_buf = { .buf = &cmd, .len = 1 };
-	struct spi_buf_set tx_bufs = { .buffers = &tx_buf, .count = 1 };
+	struct spi_buf tx_buf = {.buf = &cmd, .len = 1};
+	struct spi_buf_set tx_bufs = {.buffers = &tx_buf, .count = 1};
 	int ret;
 
 	st7735r_set_cmd(dev, 1);
@@ -102,8 +101,8 @@ static int st7735r_transmit_hold(const struct device *dev, uint8_t cmd,
 	return 0;
 }
 
-static int st7735r_transmit(const struct device *dev, uint8_t cmd,
-			    const uint8_t *tx_data, size_t tx_count)
+static int st7735r_transmit(const struct device *dev, uint8_t cmd, const uint8_t *tx_data,
+			    size_t tx_count)
 {
 	const struct st7735r_config *config = dev->config;
 	int ret;
@@ -159,8 +158,7 @@ static int st7735r_blanking_off(const struct device *dev)
 	return st7735r_transmit(dev, ST7735R_CMD_DISP_ON, NULL, 0);
 }
 
-static int st7735r_set_mem_area(const struct device *dev,
-				const uint16_t x, const uint16_t y,
+static int st7735r_set_mem_area(const struct device *dev, const uint16_t x, const uint16_t y,
 				const uint16_t w, const uint16_t h)
 {
 	const struct st7735r_config *config = dev->config;
@@ -196,14 +194,11 @@ static int st7735r_set_mem_area(const struct device *dev,
 	return 0;
 }
 
-static int st7735r_write(const struct device *dev,
-			 const uint16_t x,
-			 const uint16_t y,
-			 const struct display_buffer_descriptor *desc,
-			 const void *buf)
+static int st7735r_write(const struct device *dev, const uint16_t x, const uint16_t y,
+			 const struct display_buffer_descriptor *desc, const void *buf)
 {
 	const struct st7735r_config *config = dev->config;
-	const uint8_t *write_data_start = (uint8_t *) buf;
+	const uint8_t *write_data_start = (uint8_t *)buf;
 	struct spi_buf tx_buf;
 	struct spi_buf_set tx_bufs;
 	uint16_t write_cnt;
@@ -212,11 +207,10 @@ static int st7735r_write(const struct device *dev,
 	int ret;
 
 	__ASSERT(desc->width <= desc->pitch, "Pitch is smaller than width");
-	__ASSERT((desc->pitch * ST7735R_PIXEL_SIZE * desc->height)
-		 <= desc->buf_size, "Input buffer too small");
+	__ASSERT((desc->pitch * ST7735R_PIXEL_SIZE * desc->height) <= desc->buf_size,
+		 "Input buffer too small");
 
-	LOG_DBG("Writing %dx%d (w,h) @ %dx%d (x,y)",
-		desc->width, desc->height, x, y);
+	LOG_DBG("Writing %dx%d (w,h) @ %dx%d (x,y)", desc->width, desc->height, x, y);
 	ret = st7735r_set_mem_area(dev, x, y, desc->width, desc->height);
 	if (ret < 0) {
 		goto out;
@@ -230,8 +224,7 @@ static int st7735r_write(const struct device *dev,
 		nbr_of_writes = 1U;
 	}
 
-	ret = st7735r_transmit_hold(dev, ST7735R_CMD_RAMWR,
-				    (void *) write_data_start,
+	ret = st7735r_transmit_hold(dev, ST7735R_CMD_RAMWR, (void *)write_data_start,
 				    desc->width * ST7735R_PIXEL_SIZE * write_h);
 	if (ret < 0) {
 		goto out;
@@ -291,13 +284,11 @@ static int st7735r_set_pixel_format(const struct device *dev,
 {
 	const struct st7735r_config *config = dev->config;
 
-	if ((pixel_format == PIXEL_FORMAT_RGB_565) &&
-	    (~config->madctl & ST7735R_MADCTL_BGR)) {
+	if ((pixel_format == PIXEL_FORMAT_RGB_565) && (~config->madctl & ST7735R_MADCTL_BGR)) {
 		return 0;
 	}
 
-	if ((pixel_format == PIXEL_FORMAT_BGR_565) &&
-	    (config->madctl & ST7735R_MADCTL_BGR)) {
+	if ((pixel_format == PIXEL_FORMAT_BGR_565) && (config->madctl & ST7735R_MADCTL_BGR)) {
 		return 0;
 	}
 
@@ -326,20 +317,17 @@ static int st7735r_lcd_init(const struct device *dev)
 
 	st7735r_set_lcd_margins(dev, data->x_offset, data->y_offset);
 
-	ret = st7735r_transmit(dev, ST7735R_CMD_FRMCTR1, config->frmctr1,
-			       sizeof(config->frmctr1));
+	ret = st7735r_transmit(dev, ST7735R_CMD_FRMCTR1, config->frmctr1, sizeof(config->frmctr1));
 	if (ret < 0) {
 		return ret;
 	}
 
-	ret = st7735r_transmit(dev, ST7735R_CMD_FRMCTR2, config->frmctr2,
-			       sizeof(config->frmctr2));
+	ret = st7735r_transmit(dev, ST7735R_CMD_FRMCTR2, config->frmctr2, sizeof(config->frmctr2));
 	if (ret < 0) {
 		return ret;
 	}
 
-	ret = st7735r_transmit(dev, ST7735R_CMD_FRMCTR3, config->frmctr3,
-			       sizeof(config->frmctr3));
+	ret = st7735r_transmit(dev, ST7735R_CMD_FRMCTR3, config->frmctr3, sizeof(config->frmctr3));
 	if (ret < 0) {
 		return ret;
 	}
@@ -349,32 +337,27 @@ static int st7735r_lcd_init(const struct device *dev)
 		return ret;
 	}
 
-	ret = st7735r_transmit(dev, ST7735R_CMD_PWCTR1, config->pwctr1,
-			       sizeof(config->pwctr1));
+	ret = st7735r_transmit(dev, ST7735R_CMD_PWCTR1, config->pwctr1, sizeof(config->pwctr1));
 	if (ret < 0) {
 		return ret;
 	}
 
-	ret = st7735r_transmit(dev, ST7735R_CMD_PWCTR2, config->pwctr2,
-			       sizeof(config->pwctr2));
+	ret = st7735r_transmit(dev, ST7735R_CMD_PWCTR2, config->pwctr2, sizeof(config->pwctr2));
 	if (ret < 0) {
 		return ret;
 	}
 
-	ret = st7735r_transmit(dev, ST7735R_CMD_PWCTR3, config->pwctr3,
-			       sizeof(config->pwctr3));
+	ret = st7735r_transmit(dev, ST7735R_CMD_PWCTR3, config->pwctr3, sizeof(config->pwctr3));
 	if (ret < 0) {
 		return ret;
 	}
 
-	ret = st7735r_transmit(dev, ST7735R_CMD_PWCTR4, config->pwctr4,
-			       sizeof(config->pwctr4));
+	ret = st7735r_transmit(dev, ST7735R_CMD_PWCTR4, config->pwctr4, sizeof(config->pwctr4));
 	if (ret < 0) {
 		return ret;
 	}
 
-	ret = st7735r_transmit(dev, ST7735R_CMD_PWCTR5, config->pwctr5,
-			       sizeof(config->pwctr5));
+	ret = st7735r_transmit(dev, ST7735R_CMD_PWCTR5, config->pwctr5, sizeof(config->pwctr5));
 	if (ret < 0) {
 		return ret;
 	}
@@ -403,14 +386,12 @@ static int st7735r_lcd_init(const struct device *dev)
 		return ret;
 	}
 
-	ret = st7735r_transmit(dev, ST7735R_CMD_CASET, config->caset,
-			       sizeof(config->caset));
+	ret = st7735r_transmit(dev, ST7735R_CMD_CASET, config->caset, sizeof(config->caset));
 	if (ret < 0) {
 		return ret;
 	}
 
-	ret = st7735r_transmit(dev, ST7735R_CMD_RASET, config->raset,
-			       sizeof(config->raset));
+	ret = st7735r_transmit(dev, ST7735R_CMD_RASET, config->raset, sizeof(config->raset));
 	if (ret < 0) {
 		return ret;
 	}
@@ -456,8 +437,7 @@ static int st7735r_init(const struct device *dev)
 			return -ENODEV;
 		}
 
-		ret = gpio_pin_configure_dt(&config->reset,
-					    GPIO_OUTPUT_INACTIVE);
+		ret = gpio_pin_configure_dt(&config->reset, GPIO_OUTPUT_INACTIVE);
 		if (ret) {
 			LOG_ERR("Couldn't configure reset pin");
 			return ret;
@@ -497,8 +477,7 @@ static int st7735r_init(const struct device *dev)
 }
 
 #ifdef CONFIG_PM_DEVICE
-static int st7735r_pm_action(const struct device *dev,
-			     enum pm_device_action action)
+static int st7735r_pm_action(const struct device *dev, enum pm_device_action action)
 {
 	int ret = 0;
 
@@ -527,46 +506,44 @@ static const struct display_driver_api st7735r_api = {
 	.set_orientation = st7735r_set_orientation,
 };
 
-
-#define ST7735R_INIT(inst)							\
-	const static struct st7735r_config st7735r_config_ ## inst = {		\
-		.bus = SPI_DT_SPEC_INST_GET(					\
-			inst, SPI_OP_MODE_MASTER | SPI_WORD_SET(8) |		\
-			SPI_HOLD_ON_CS | SPI_LOCK_ON, 0),			\
-		.cmd_data = GPIO_DT_SPEC_INST_GET(inst, cmd_data_gpios),	\
-		.reset = GPIO_DT_SPEC_INST_GET_OR(inst, reset_gpios, {}),	\
-		.width = DT_INST_PROP(inst, width),				\
-		.height = DT_INST_PROP(inst, height),				\
-		.madctl = DT_INST_PROP(inst, madctl),				\
-		.colmod = DT_INST_PROP(inst, colmod),				\
-		.caset = DT_INST_PROP(inst, caset),				\
-		.raset = DT_INST_PROP(inst, raset),				\
-		.vmctr1 = DT_INST_PROP(inst, vmctr1),				\
-		.invctr = DT_INST_PROP(inst, invctr),				\
-		.pwctr1 = DT_INST_PROP(inst, pwctr1),				\
-		.pwctr2 = DT_INST_PROP(inst, pwctr2),				\
-		.pwctr3 = DT_INST_PROP(inst, pwctr3),				\
-		.pwctr4 = DT_INST_PROP(inst, pwctr4),				\
-		.pwctr5 = DT_INST_PROP(inst, pwctr5),				\
-		.frmctr1 = DT_INST_PROP(inst, frmctr1),				\
-		.frmctr2 = DT_INST_PROP(inst, frmctr2),				\
-		.frmctr3 = DT_INST_PROP(inst, frmctr3),				\
-		.gamctrp1 = DT_INST_PROP(inst, gamctrp1),			\
-		.gamctrn1 = DT_INST_PROP(inst, gamctrn1),			\
-		.inversion_on = DT_INST_PROP(inst, inversion_on),		\
-		.rgb_is_inverted = DT_INST_PROP(inst, rgb_is_inverted),		\
-	};									\
-										\
-	static struct st7735r_data st7735r_data_ ## inst = {			\
-		.x_offset = DT_INST_PROP(inst, x_offset),			\
-		.y_offset = DT_INST_PROP(inst, y_offset),			\
-	};									\
-										\
-	PM_DEVICE_DT_INST_DEFINE(inst, st7735r_pm_action);			\
-										\
-	DEVICE_DT_INST_DEFINE(inst, st7735r_init, PM_DEVICE_DT_INST_GET(inst),	\
-			      &st7735r_data_ ## inst, &st7735r_config_ ## inst,	\
-			      POST_KERNEL, CONFIG_DISPLAY_INIT_PRIORITY,	\
-			      &st7735r_api);
+#define ST7735R_INIT(inst)                                                                         \
+	const static struct st7735r_config st7735r_config_##inst = {                               \
+		.bus = SPI_DT_SPEC_INST_GET(                                                       \
+			inst, SPI_OP_MODE_MASTER | SPI_WORD_SET(8) | SPI_HOLD_ON_CS | SPI_LOCK_ON, \
+			0),                                                                        \
+		.cmd_data = GPIO_DT_SPEC_INST_GET(inst, cmd_data_gpios),                           \
+		.reset = GPIO_DT_SPEC_INST_GET_OR(inst, reset_gpios, {}),                          \
+		.width = DT_INST_PROP(inst, width),                                                \
+		.height = DT_INST_PROP(inst, height),                                              \
+		.madctl = DT_INST_PROP(inst, madctl),                                              \
+		.colmod = DT_INST_PROP(inst, colmod),                                              \
+		.caset = DT_INST_PROP(inst, caset),                                                \
+		.raset = DT_INST_PROP(inst, raset),                                                \
+		.vmctr1 = DT_INST_PROP(inst, vmctr1),                                              \
+		.invctr = DT_INST_PROP(inst, invctr),                                              \
+		.pwctr1 = DT_INST_PROP(inst, pwctr1),                                              \
+		.pwctr2 = DT_INST_PROP(inst, pwctr2),                                              \
+		.pwctr3 = DT_INST_PROP(inst, pwctr3),                                              \
+		.pwctr4 = DT_INST_PROP(inst, pwctr4),                                              \
+		.pwctr5 = DT_INST_PROP(inst, pwctr5),                                              \
+		.frmctr1 = DT_INST_PROP(inst, frmctr1),                                            \
+		.frmctr2 = DT_INST_PROP(inst, frmctr2),                                            \
+		.frmctr3 = DT_INST_PROP(inst, frmctr3),                                            \
+		.gamctrp1 = DT_INST_PROP(inst, gamctrp1),                                          \
+		.gamctrn1 = DT_INST_PROP(inst, gamctrn1),                                          \
+		.inversion_on = DT_INST_PROP(inst, inversion_on),                                  \
+		.rgb_is_inverted = DT_INST_PROP(inst, rgb_is_inverted),                            \
+	};                                                                                         \
+                                                                                                   \
+	static struct st7735r_data st7735r_data_##inst = {                                         \
+		.x_offset = DT_INST_PROP(inst, x_offset),                                          \
+		.y_offset = DT_INST_PROP(inst, y_offset),                                          \
+	};                                                                                         \
+                                                                                                   \
+	PM_DEVICE_DT_INST_DEFINE(inst, st7735r_pm_action);                                         \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(inst, st7735r_init, PM_DEVICE_DT_INST_GET(inst),                     \
+			      &st7735r_data_##inst, &st7735r_config_##inst, POST_KERNEL,           \
+			      CONFIG_DISPLAY_INIT_PRIORITY, &st7735r_api);
 
 DT_INST_FOREACH_STATUS_OKAY(ST7735R_INIT)

--- a/drivers/display/display_st7735r.c
+++ b/drivers/display/display_st7735r.c
@@ -19,19 +19,19 @@
 #include <zephyr/pm/device.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/drivers/display.h>
+#include <zephyr/drivers/mipi_dbi.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(display_st7735r, CONFIG_DISPLAY_LOG_LEVEL);
 
-#define ST7735R_RESET_TIME      K_MSEC(1)
+#define ST7735R_RESET_TIME      1
 #define ST7735R_EXIT_SLEEP_TIME K_MSEC(120)
 
 #define ST7735R_PIXEL_SIZE 2u
 
 struct st7735r_config {
-	struct spi_dt_spec bus;
-	struct gpio_dt_spec cmd_data;
-	struct gpio_dt_spec reset;
+	const struct device *mipi_dev;
+	struct mipi_dbi_config dbi_config;
 	uint16_t height;
 	uint16_t width;
 	uint8_t madctl;
@@ -67,48 +67,26 @@ static void st7735r_set_lcd_margins(const struct device *dev, uint16_t x_offset,
 	data->y_offset = y_offset;
 }
 
-static void st7735r_set_cmd(const struct device *dev, int is_cmd)
-{
-	const struct st7735r_config *config = dev->config;
-
-	gpio_pin_set_dt(&config->cmd_data, is_cmd);
-}
-
 static int st7735r_transmit_hold(const struct device *dev, uint8_t cmd, const uint8_t *tx_data,
 				 size_t tx_count)
 {
 	const struct st7735r_config *config = dev->config;
-	struct spi_buf tx_buf = {.buf = &cmd, .len = 1};
-	struct spi_buf_set tx_bufs = {.buffers = &tx_buf, .count = 1};
 	int ret;
 
-	st7735r_set_cmd(dev, 1);
-	ret = spi_write_dt(&config->bus, &tx_bufs);
-	if (ret < 0) {
-		return ret;
-	}
+	ret = mipi_dbi_command_write(config->mipi_dev, &config->dbi_config, cmd, tx_data, tx_count);
 
-	if (tx_data != NULL) {
-		tx_buf.buf = (void *)tx_data;
-		tx_buf.len = tx_count;
-		st7735r_set_cmd(dev, 0);
-		ret = spi_write_dt(&config->bus, &tx_bufs);
-		if (ret < 0) {
-			return ret;
-		}
-	}
-
-	return 0;
+	return ret;
 }
 
 static int st7735r_transmit(const struct device *dev, uint8_t cmd, const uint8_t *tx_data,
 			    size_t tx_count)
 {
-	const struct st7735r_config *config = dev->config;
 	int ret;
 
 	ret = st7735r_transmit_hold(dev, cmd, tx_data, tx_count);
-	spi_release_dt(&config->bus);
+
+	/* TODO: How should this be handled with MIPI driver */
+	/* spi_release_dt(&config->bus); */
 	return ret;
 }
 
@@ -132,11 +110,8 @@ static int st7735r_reset_display(const struct device *dev)
 	int ret;
 
 	LOG_DBG("Resetting display");
-	if (config->reset.port != NULL) {
-		gpio_pin_set_dt(&config->reset, 1);
-		k_sleep(ST7735R_RESET_TIME);
-		gpio_pin_set_dt(&config->reset, 0);
-	} else {
+	ret = mipi_dbi_reset(config->mipi_dev, ST7735R_RESET_TIME);
+	if (ret == ENOTSUP) {
 		ret = st7735r_transmit(dev, ST7735R_CMD_SW_RESET, NULL, 0);
 		if (ret < 0) {
 			return ret;
@@ -199,12 +174,11 @@ static int st7735r_write(const struct device *dev, const uint16_t x, const uint1
 {
 	const struct st7735r_config *config = dev->config;
 	const uint8_t *write_data_start = (uint8_t *)buf;
-	struct spi_buf tx_buf;
-	struct spi_buf_set tx_bufs;
 	uint16_t write_cnt;
 	uint16_t nbr_of_writes;
 	uint16_t write_h;
 	int ret;
+	size_t tx_len;
 
 	__ASSERT(desc->width <= desc->pitch, "Pitch is smaller than width");
 	__ASSERT((desc->pitch * ST7735R_PIXEL_SIZE * desc->height) <= desc->buf_size,
@@ -224,20 +198,20 @@ static int st7735r_write(const struct device *dev, const uint16_t x, const uint1
 		nbr_of_writes = 1U;
 	}
 
-	ret = st7735r_transmit_hold(dev, ST7735R_CMD_RAMWR, (void *)write_data_start,
-				    desc->width * ST7735R_PIXEL_SIZE * write_h);
+	tx_len = desc->width * ST7735R_PIXEL_SIZE * write_h;
+	ret = st7735r_transmit_hold(dev, ST7735R_CMD_RAMWR, (void *)write_data_start, tx_len);
 	if (ret < 0) {
 		goto out;
 	}
 
-	tx_bufs.buffers = &tx_buf;
-	tx_bufs.count = 1;
-
 	write_data_start += (desc->pitch * ST7735R_PIXEL_SIZE);
 	for (write_cnt = 1U; write_cnt < nbr_of_writes; ++write_cnt) {
-		tx_buf.buf = (void *)write_data_start;
-		tx_buf.len = desc->width * ST7735R_PIXEL_SIZE * write_h;
-		ret = spi_write_dt(&config->bus, &tx_bufs);
+		struct display_buffer_descriptor mipi_desc;
+
+		mipi_desc.buf_size = tx_len;
+
+		ret = mipi_dbi_write_display(config->mipi_dev, &config->dbi_config,
+					     write_data_start, &mipi_desc, PIXEL_FORMAT_RGB_565);
 		if (ret < 0) {
 			goto out;
 		}
@@ -247,7 +221,8 @@ static int st7735r_write(const struct device *dev, const uint16_t x, const uint1
 
 	ret = 0;
 out:
-	spi_release_dt(&config->bus);
+	/* TODO: How should this be handled with MIPI driver */
+	/* spi_release_dt(&config->bus); */
 	return ret;
 }
 
@@ -426,33 +401,9 @@ static int st7735r_init(const struct device *dev)
 	const struct st7735r_config *config = dev->config;
 	int ret;
 
-	if (!spi_is_ready_dt(&config->bus)) {
-		LOG_ERR("SPI bus %s not ready", config->bus.bus->name);
+	if (!device_is_ready(config->mipi_dev)) {
+		LOG_ERR("MIPI DBI device is not ready");
 		return -ENODEV;
-	}
-
-	if (config->reset.port != NULL) {
-		if (!gpio_is_ready_dt(&config->reset)) {
-			LOG_ERR("Reset GPIO port for display not ready");
-			return -ENODEV;
-		}
-
-		ret = gpio_pin_configure_dt(&config->reset, GPIO_OUTPUT_INACTIVE);
-		if (ret) {
-			LOG_ERR("Couldn't configure reset pin");
-			return ret;
-		}
-	}
-
-	if (!gpio_is_ready_dt(&config->cmd_data)) {
-		LOG_ERR("cmd/DATA GPIO port not ready");
-		return -ENODEV;
-	}
-
-	ret = gpio_pin_configure_dt(&config->cmd_data, GPIO_OUTPUT);
-	if (ret) {
-		LOG_ERR("Couldn't configure cmd/DATA pin");
-		return ret;
 	}
 
 	ret = st7735r_reset_display(dev);
@@ -506,13 +457,23 @@ static const struct display_driver_api st7735r_api = {
 	.set_orientation = st7735r_set_orientation,
 };
 
+#define ST7735R_WORD_SIZE(inst) COND_CODE_1(IS_ENABLED(CONFIG_MIPI_DBI_SPI_3WIRE), (9), (8))
+
 #define ST7735R_INIT(inst)                                                                         \
 	const static struct st7735r_config st7735r_config_##inst = {                               \
-		.bus = SPI_DT_SPEC_INST_GET(                                                       \
-			inst, SPI_OP_MODE_MASTER | SPI_WORD_SET(8) | SPI_HOLD_ON_CS | SPI_LOCK_ON, \
-			0),                                                                        \
-		.cmd_data = GPIO_DT_SPEC_INST_GET(inst, cmd_data_gpios),                           \
-		.reset = GPIO_DT_SPEC_INST_GET_OR(inst, reset_gpios, {}),                          \
+		.mipi_dev = DEVICE_DT_GET(DT_PARENT(DT_DRV_INST(inst))),                           \
+		.dbi_config =                                                                      \
+			{                                                                          \
+				.mode = (IS_ENABLED(CONFIG_MIPI_DBI_SPI_3WIRE)                     \
+						 ? MIPI_DBI_MODE_SPI_3WIRE                         \
+						 : MIPI_DBI_MODE_SPI_4WIRE),                       \
+				.config = MIPI_DBI_SPI_CONFIG_DT(                                  \
+					DT_DRV_INST(inst),                                         \
+					SPI_OP_MODE_MASTER |                                       \
+						SPI_WORD_SET(ST7735R_WORD_SIZE(inst)) |            \
+						SPI_HOLD_ON_CS | SPI_LOCK_ON,                      \
+					0),                                                        \
+			},                                                                         \
 		.width = DT_INST_PROP(inst, width),                                                \
 		.height = DT_INST_PROP(inst, height),                                              \
 		.madctl = DT_INST_PROP(inst, madctl),                                              \

--- a/drivers/display/display_st7735r.h
+++ b/drivers/display/display_st7735r.h
@@ -8,69 +8,68 @@
 
 #include <zephyr/kernel.h>
 
-#define ST7735R_CMD_SW_RESET            0x01
-#define ST7735R_CMD_RDDID               0x04
-#define ST7735R_CMD_RDDST               0x09
-#define ST7735R_CMD_RDDPM               0x0A
-#define ST7735R_CMD_RDD_MADCTL          0x0B
-#define ST7735R_CMD_RDD_COLMOD          0x0C
-#define ST7735R_CMD_RDDIM               0x0D
-#define ST7735R_CMD_RDDSM               0x0E
+#define ST7735R_CMD_SW_RESET   0x01
+#define ST7735R_CMD_RDDID      0x04
+#define ST7735R_CMD_RDDST      0x09
+#define ST7735R_CMD_RDDPM      0x0A
+#define ST7735R_CMD_RDD_MADCTL 0x0B
+#define ST7735R_CMD_RDD_COLMOD 0x0C
+#define ST7735R_CMD_RDDIM      0x0D
+#define ST7735R_CMD_RDDSM      0x0E
 
-#define ST7735R_CMD_SLEEP_IN            0x10
-#define ST7735R_CMD_SLEEP_OUT           0x11
-#define ST7735R_CMD_PTLON               0x12
-#define ST7735R_CMD_NORON               0x13
+#define ST7735R_CMD_SLEEP_IN  0x10
+#define ST7735R_CMD_SLEEP_OUT 0x11
+#define ST7735R_CMD_PTLON     0x12
+#define ST7735R_CMD_NORON     0x13
 
-#define ST7735R_CMD_INV_OFF             0x20
-#define ST7735R_CMD_INV_ON              0x21
-#define ST7735R_CMD_GAMSET              0x26
-#define ST7735R_CMD_DISP_OFF            0x28
-#define ST7735R_CMD_DISP_ON             0x29
-#define ST7735R_CMD_CASET               0x2a
-#define ST7735R_CMD_RASET               0x2b
-#define ST7735R_CMD_RAMWR               0x2c
-#define ST7735R_CMD_RGBSET              0x2D
-#define ST7735R_CMD_RAMRD               0x2E
+#define ST7735R_CMD_INV_OFF  0x20
+#define ST7735R_CMD_INV_ON   0x21
+#define ST7735R_CMD_GAMSET   0x26
+#define ST7735R_CMD_DISP_OFF 0x28
+#define ST7735R_CMD_DISP_ON  0x29
+#define ST7735R_CMD_CASET    0x2a
+#define ST7735R_CMD_RASET    0x2b
+#define ST7735R_CMD_RAMWR    0x2c
+#define ST7735R_CMD_RGBSET   0x2D
+#define ST7735R_CMD_RAMRD    0x2E
 
-#define ST7735R_CMD_PTLAR               0x30
-#define ST7735R_CMD_TEOFF               0x34
-#define ST7735R_CMD_TEON                0x35
-#define ST7735R_CMD_MADCTL              0x36
-#define ST7735R_CMD_IDMOFF              0x38
-#define ST7735R_CMD_IDMON               0x39
-#define ST7735R_CMD_COLMOD              0x3a
+#define ST7735R_CMD_PTLAR  0x30
+#define ST7735R_CMD_TEOFF  0x34
+#define ST7735R_CMD_TEON   0x35
+#define ST7735R_CMD_MADCTL 0x36
+#define ST7735R_CMD_IDMOFF 0x38
+#define ST7735R_CMD_IDMON  0x39
+#define ST7735R_CMD_COLMOD 0x3a
 
-#define ST7735R_CMD_FRMCTR1             0xB1
-#define ST7735R_CMD_FRMCTR2             0xB2
-#define ST7735R_CMD_FRMCTR3             0xB3
-#define ST7735R_CMD_INVCTR              0xB4
+#define ST7735R_CMD_FRMCTR1 0xB1
+#define ST7735R_CMD_FRMCTR2 0xB2
+#define ST7735R_CMD_FRMCTR3 0xB3
+#define ST7735R_CMD_INVCTR  0xB4
 
-#define ST7735R_CMD_PWCTR1              0xC0
-#define ST7735R_CMD_PWCTR2              0xC1
-#define ST7735R_CMD_PWCTR3              0xC2
-#define ST7735R_CMD_PWCTR4              0xC3
-#define ST7735R_CMD_PWCTR5              0xC4
-#define ST7735R_CMD_VMCTR1              0xC5
-#define ST7735R_CMD_VMOFCTR             0xC7
+#define ST7735R_CMD_PWCTR1  0xC0
+#define ST7735R_CMD_PWCTR2  0xC1
+#define ST7735R_CMD_PWCTR3  0xC2
+#define ST7735R_CMD_PWCTR4  0xC3
+#define ST7735R_CMD_PWCTR5  0xC4
+#define ST7735R_CMD_VMCTR1  0xC5
+#define ST7735R_CMD_VMOFCTR 0xC7
 
-#define ST7735R_CMD_WRID2               0xD1
-#define ST7735R_CMD_WRID3               0xD2
-#define ST7735R_CMD_NVCTR1              0xD9
-#define ST7735R_CMD_NVCTR2              0xDE
-#define ST7735R_CMD_NVCTR3              0xDF
-#define ST7735R_CMD_RDID1               0xDA
-#define ST7735R_CMD_RDID2               0xDB
-#define ST7735R_CMD_RDID3               0xDC
-#define ST7735R_CMD_NVCTR2              0xDE
-#define ST7735R_CMD_NVCTR3              0xDF
+#define ST7735R_CMD_WRID2  0xD1
+#define ST7735R_CMD_WRID3  0xD2
+#define ST7735R_CMD_NVCTR1 0xD9
+#define ST7735R_CMD_NVCTR2 0xDE
+#define ST7735R_CMD_NVCTR3 0xDF
+#define ST7735R_CMD_RDID1  0xDA
+#define ST7735R_CMD_RDID2  0xDB
+#define ST7735R_CMD_RDID3  0xDC
+#define ST7735R_CMD_NVCTR2 0xDE
+#define ST7735R_CMD_NVCTR3 0xDF
 
-#define ST7735R_CMD_GAMCTRP1            0xE0
-#define ST7735R_CMD_GAMCTRN1            0xE1
+#define ST7735R_CMD_GAMCTRP1 0xE0
+#define ST7735R_CMD_GAMCTRN1 0xE1
 
 /* CMD_MADCTL bits */
-#define ST7735R_MADCTL_RBG                      0x00
-#define ST7735R_MADCTL_BGR                      0x08
+#define ST7735R_MADCTL_RBG 0x00
+#define ST7735R_MADCTL_BGR 0x08
 
-
-#endif  /* ST7735R_DISPLAY_DRIVER_H__ */
+#endif /* ST7735R_DISPLAY_DRIVER_H__ */

--- a/drivers/mipi_dbi/mipi_dbi_spi.c
+++ b/drivers/mipi_dbi/mipi_dbi_spi.c
@@ -71,7 +71,7 @@ static int mipi_dbi_spi_write_helper(const struct device *dev,
 		tmp_cfg.operation &= ~SPI_WORD_SIZE_MASK;
 		tmp_cfg.operation |= SPI_WORD_SET(9);
 		buffer.buf = &data->spi_byte;
-		buffer.len = 1;
+		buffer.len = 2;
 
 		/* Send command */
 		if (cmd_present) {

--- a/dts/bindings/display/sitronix,st7735r.yaml
+++ b/dts/bindings/display/sitronix,st7735r.yaml
@@ -5,26 +5,9 @@ description: ST7735R/ST7735S 160x128 (max) display controller
 
 compatible: "sitronix,st7735r"
 
-include: [spi-device.yaml, display-controller.yaml]
+include: [mipi-dbi-spi-device.yaml, display-controller.yaml]
 
 properties:
-  reset-gpios:
-    type: phandle-array
-    description: RESET pin.
-
-      The RESET pin of ST7735R is active low.
-      If connected directly the MCU pin should be configured
-      as active low.
-
-  cmd-data-gpios:
-    type: phandle-array
-    required: true
-    description: D/CX pin.
-
-      The D/CX pin of ST7735R is active low (transmission command byte).
-      If connected directly the MCU pin should be configured
-      as active low.
-
   x-offset:
     type: int
     required: true


### PR DESCRIPTION
st7735 display controller can driver display both over 3wire or 4wire mode.
Existing st7725r.c display controller only supports 4wire mode. This commit add 3wire mode support in the controller.

Both 3wire and 4wire mode tested with [MAX32672EVKIT ](https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/max32672evkit.html) which has [CFAF128128B1-0145T](https://www.crystalfontz.com/product/cfaf128128b10145t-128x128-graphic-tft-spi) display on board.

- 3-wire, 9-bit SPI mode. The D/C pin is not used. The 9th SPI bit selects the data or command register.
- 4-wire, 8-bit SPI mode. The D/C pin is used to select the data or command register.

![image](https://github.com/zephyrproject-rtos/zephyr/assets/46590392/0079372f-e439-4319-ad66-c3610425bdf5)


