### PR TITLE
dts: bindings: clock: increase d1cpre enum values

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -145,19 +145,6 @@
 /* end of clock feasability check */
 #endif /* CONFIG_CPU_CORTEX_M7 */
 
-
-#if defined(CONFIG_CPU_CORTEX_M7)
-#if STM32_D1CPRE > 1
-/*
- * D1CPRE prescaler allows to set a HCLK frequency lower than SYSCLK frequency.
- * Though, zephyr doesn't make a difference today between these two clocks.
- * So, changing this prescaler is not allowed until it is made possible to
- * use them independently in zephyr clock subsystem.
- */
-#error "D1CPRE presacler can't be higher than 1"
-#endif
-#endif /* CONFIG_CPU_CORTEX_M7 */
-
 #if defined(CONFIG_CPU_CORTEX_M7)
 /* Offset to access bus clock registers from M7 (or only) core */
 #define STM32H7_BUS_CLK_REG	DT_REG_ADDR(DT_NODELABEL(rcc))

--- a/dts/bindings/clock/st,stm32h7-rcc.yaml
+++ b/dts/bindings/clock/st,stm32h7-rcc.yaml
@@ -50,12 +50,17 @@ properties:
     required: true
     enum:
       - 1
+      - 2
+      - 4
+      - 8
+      - 16
+      - 64
+      - 128
+      - 256
+      - 512
     description: |
-        D1 Domain, CPU1 clock prescaler. Sets a HCLK frequency (feeding Cortex-M Systick)
-        lower than SYSCLK frequency (actual core frequency).
-        Zephyr doesn't make a difference today between these two clocks.
-        Changing this prescaler is not allowed until it is made possible to
-        use them independently in Zephyr clock subsystem.
+        D1 Domain, CPU1 clock prescaler. The frequency of the CPU clock
+        and the Systick clock are the same.
 
   hpre:
     type: int


### PR DESCRIPTION
I believe that the d1cpre limitation does not exist anymore.

Add new values to d1cpre enum (2, 4, 8, 16, 64, 128, 256, and 512) and remove the pre-compile check inside clock_stm32_ll_h7.c file.