### PR TITLE
Net mgmt socket fixes

### DIFF
--- a/subsys/net/lib/shell/sockets.c
+++ b/subsys/net/lib/shell/sockets.c
@@ -68,7 +68,8 @@ int walk_sockets(struct k_obj_core *obj_core, void *user_data)
 	PR("%25s  %-12s  %c%c%c\t%-5s%-13d   %-10" PRId64 "%-10" PRId64 "\n",
 	   thread_name, obj->reg->name,
 	   obj->socket_family == AF_INET6 ? '6' :
-	   (obj->socket_family ? '4' : ' '),
+	   (obj->socket_family == AF_INET ? '4' :
+	    (obj->socket_family == AF_NET_MGMT ? 'M' : ' ')),
 	   obj->socket_type == SOCK_DGRAM ? 'D' :
 	   (obj->socket_type == SOCK_STREAM ? 'S' :
 	    (obj->socket_type == SOCK_RAW ? 'R' : ' ')),

--- a/subsys/net/lib/sockets/sockets_net_mgmt.c
+++ b/subsys/net/lib/sockets/sockets_net_mgmt.c
@@ -313,7 +313,8 @@ static ssize_t net_mgmt_sock_write(void *obj, const void *buffer,
 static int net_mgmt_sock_ioctl(void *obj, unsigned int request,
 			       va_list args)
 {
-	return 0;
+	errno = EOPNOTSUPP;
+	return -1;
 }
 
 static int net_mgmt_sock_bind(void *obj, const struct sockaddr *addr,


### PR DESCRIPTION
Noticed two issues when experimenting with `AF_NET_MGMT` type socket:
* it cannot support `poll()` with current implementation so return `EOPNOTSUPP` to the caller
* `net sockets` printed the socket family wrong for management sockets

