### PR TITLE
sched: fix deadline init value and add a test case

### DIFF
--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -715,7 +715,7 @@ char *z_setup_new_thread(struct k_thread *new_thread,
 	}
 #endif
 #ifdef CONFIG_SCHED_DEADLINE
-	new_thread->base.prio_deadline = 0;
+	new_thread->base.prio_deadline = INT_MIN;
 #endif
 	new_thread->resource_pool = _current->resource_pool;
 


### PR DESCRIPTION
The init value of deadline scheduler algorithm should be INT_MAX.
If this value set to 0, it means normal task is going to run before deadline task.