### PR TITLE
llext: add STT_OBJECT relocation

### DIFF
--- a/subsys/llext/llext.c
+++ b/subsys/llext/llext.c
@@ -768,7 +768,8 @@ static int llext_link(struct llext_loader *ldr, struct llext *ext, bool do_local
 					return -ENODATA;
 				}
 			} else if (ELF_ST_TYPE(sym.st_info) == STT_SECTION ||
-				   ELF_ST_TYPE(sym.st_info) == STT_FUNC) {
+				   ELF_ST_TYPE(sym.st_info) == STT_FUNC ||
+				   ELF_ST_TYPE(sym.st_info) == STT_OBJECT) {
 				/* Link address is relative to the start of the section */
 				link_addr = (uintptr_t)ext->mem[ldr->sect_map[sym.st_shndx]]
 					+ sym.st_value;
@@ -776,6 +777,7 @@ static int llext_link(struct llext_loader *ldr, struct llext *ext, bool do_local
 				LOG_INF("found section symbol %s addr 0x%lx", name, link_addr);
 			} else {
 				/* Nothing to relocate here */
+				LOG_DBG("not relocated");
 				continue;
 			}
 

--- a/tests/subsys/llext/simple/CMakeLists.txt
+++ b/tests/subsys/llext/simple/CMakeLists.txt
@@ -16,7 +16,7 @@ target_include_directories(app PRIVATE
 )
 
 # generate extension targets foreach extension given by name
-foreach(ext_name hello_world logging relative_jump)
+foreach(ext_name hello_world logging relative_jump object)
   set(ext_src ${PROJECT_SOURCE_DIR}/src/${ext_name}_ext.c)
   set(ext_bin ${ZEPHYR_BINARY_DIR}/${ext_name}.llext)
   set(ext_inc ${ZEPHYR_BINARY_DIR}/include/generated/${ext_name}.inc)

--- a/tests/subsys/llext/simple/src/object_ext.c
+++ b/tests/subsys/llext/simple/src/object_ext.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2024 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * This code demonstrates object relocation support.
+ */
+
+#include <stdint.h>
+#include <zephyr/llext/symbol.h>
+#include <zephyr/kernel.h>
+
+/* Test non-static global object relocation */
+int number = 42;
+const char *string = "hello";
+
+void test_entry(void)
+{
+	printk("number: %d\n", number);
+	number = 0;
+	printk("number, updated: %d\n", number);
+	printk("string: %s\n", string);
+}
+LL_EXTENSION_SYMBOL(test_entry);

--- a/tests/subsys/llext/simple/src/test_llext_simple.c
+++ b/tests/subsys/llext/simple/src/test_llext_simple.c
@@ -152,6 +152,11 @@ static LLEXT_CONST uint8_t relative_jump_ext[] __aligned(4) = {
 };
 LLEXT_LOAD_UNLOAD(relative_jump, true)
 
+static LLEXT_CONST uint8_t object_ext[] __aligned(4) = {
+	#include "object.inc"
+};
+LLEXT_LOAD_UNLOAD(object, true)
+
 /*
  * Ensure that EXPORT_SYMBOL does indeed provide a symbol and a valid address
  * to it.


### PR DESCRIPTION
Adds STT_OBJECT relocation.

Fixes #67701.

You can test with the attached patch (it's a patch, just renamed) [0001-STT_OBJECT_test.patch.log](https://github.com/zephyrproject-rtos/zephyr/files/14397787/0001-STT_OBJECT_test.patch.log) and the `tests/subsys/llext/hello_world` test.