### PR TITLE
Compiler warnings fixes for unused variable and incorrect type

### DIFF
--- a/include/zephyr/net/buf.h
+++ b/include/zephyr/net/buf.h
@@ -869,7 +869,7 @@ struct net_buf_simple_state {
 static inline void net_buf_simple_save(struct net_buf_simple *buf,
 				       struct net_buf_simple_state *state)
 {
-	state->offset = net_buf_simple_headroom(buf);
+	state->offset = (uint16_t)net_buf_simple_headroom(buf);
 	state->len = buf->len;
 }
 

--- a/include/zephyr/net/hostname.h
+++ b/include/zephyr/net/hostname.h
@@ -103,6 +103,8 @@ int net_hostname_set_postfix(const uint8_t *hostname_postfix,
 static inline int net_hostname_set_postfix(const uint8_t *hostname_postfix,
 					   int postfix_len)
 {
+	ARG_UNUSED(hostname_postfix);
+	ARG_UNUSED(postfix_len);
 	return -EMSGSIZE;
 }
 #endif /* CONFIG_NET_HOSTNAME_UNIQUE */

--- a/include/zephyr/net/net_context.h
+++ b/include/zephyr/net/net_context.h
@@ -60,10 +60,10 @@ enum net_context_state {
 #define NET_CONTEXT_REMOTE_ADDR_SET  BIT(8)
 
 /** Is the socket accepting connections */
-#define NET_CONTEXT_ACCEPTING_SOCK  BIT(9)
+#define NET_CONTEXT_ACCEPTING_SOCK  (1<<9)
 
 /** Is the socket closing / closed */
-#define NET_CONTEXT_CLOSING_SOCK  BIT(10)
+#define NET_CONTEXT_CLOSING_SOCK  (1<<10)
 
 /* Context is bound to a specific interface */
 #define NET_CONTEXT_BOUND_TO_IFACE BIT(11)
@@ -547,7 +547,7 @@ static inline void net_context_set_family(struct net_context *context,
 	if (family == AF_UNSPEC || family == AF_INET || family == AF_INET6 ||
 	    family == AF_PACKET || family == AF_CAN) {
 		/* Family is in BIT(4), BIT(5) and BIT(6) */
-		flag = family << 3;
+		flag = (uint8_t)(family << 3);
 	}
 
 	context->flags |= flag;
@@ -589,7 +589,7 @@ static inline void net_context_set_type(struct net_context *context,
 
 	if (type == SOCK_DGRAM || type == SOCK_STREAM || type == SOCK_RAW) {
 		/* Type is in BIT(6) and BIT(7)*/
-		flag = type << 6;
+		flag = (uint16_t)(type << 6);
 	}
 
 	context->flags |= flag;
@@ -707,7 +707,7 @@ static inline void net_context_set_iface(struct net_context *context,
 {
 	NET_ASSERT(iface);
 
-	context->iface = net_if_get_by_iface(iface);
+	context->iface = (uint8_t)net_if_get_by_iface(iface);
 }
 
 /**
@@ -888,6 +888,7 @@ static inline bool net_context_is_proxy_enabled(struct net_context *context)
 #else
 static inline bool net_context_is_proxy_enabled(struct net_context *context)
 {
+	ARG_UNUSED(context);
 	return false;
 }
 #endif
@@ -1004,6 +1005,10 @@ static inline int net_context_create_ipv6_new(struct net_context *context,
 					      const struct in6_addr *src,
 					      const struct in6_addr *dst)
 {
+	ARG_UNUSED(context);
+	ARG_UNUSED(pkt);
+	ARG_UNUSED(src);
+	ARG_UNUSED(dst);
 	return -1;
 }
 #endif /* CONFIG_NET_IPV6 */

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -1788,6 +1788,9 @@ static inline void net_if_ipv6_set_base_reachable_time(struct net_if *iface,
 	}
 
 	iface->config.ip.ipv6->base_reachable_time = reachable_time;
+#else
+	ARG_UNUSED(iface);
+	ARG_UNUSED(reachable_time);
 #endif
 }
 
@@ -1809,6 +1812,7 @@ static inline uint32_t net_if_ipv6_get_reachable_time(struct net_if *iface)
 
 	return iface->config.ip.ipv6->reachable_time;
 #else
+	ARG_UNUSED(iface);
 	return 0;
 #endif
 }
@@ -1836,6 +1840,8 @@ static inline void net_if_ipv6_set_reachable_time(struct net_if_ipv6 *ipv6)
 	}
 
 	ipv6->reachable_time = net_if_ipv6_calc_reachable_time(ipv6);
+#else
+	ARG_UNUSED(ipv6);
 #endif
 }
 
@@ -1856,6 +1862,9 @@ static inline void net_if_ipv6_set_retrans_timer(struct net_if *iface,
 	}
 
 	iface->config.ip.ipv6->retrans_timer = retrans_timer;
+#else
+	ARG_UNUSED(iface);
+	ARG_UNUSED(retrans_timer);
 #endif
 }
 
@@ -1877,6 +1886,7 @@ static inline uint32_t net_if_ipv6_get_retrans_timer(struct net_if *iface)
 
 	return iface->config.ip.ipv6->retrans_timer;
 #else
+	ARG_UNUSED(iface);
 	return 0;
 #endif
 }

--- a/include/zephyr/net/net_ip.h
+++ b/include/zephyr/net/net_ip.h
@@ -687,7 +687,7 @@ static inline bool net_ipv6_is_prefix(const uint8_t *addr1,
 	}
 
 	/* Create a mask that has remaining most significant bits set */
-	mask = ((0xff << (8 - remain)) ^ 0xff) << remain;
+	mask = (uint8_t)((0xff << (8 - remain)) ^ 0xff) << remain;
 
 	return (addr1[bytes] & mask) == (addr2[bytes] & mask);
 }

--- a/include/zephyr/posix/time.h
+++ b/include/zephyr/posix/time.h
@@ -83,7 +83,7 @@ extern "C" {
 
 static inline int32_t _ts_to_ms(const struct timespec *to)
 {
-	return (to->tv_sec * MSEC_PER_SEC) + (to->tv_nsec / NSEC_PER_MSEC);
+	return (int32_t)((to->tv_sec * MSEC_PER_SEC) + (to->tv_nsec / NSEC_PER_MSEC));
 }
 
 int clock_gettime(clockid_t clock_id, struct timespec *ts);

--- a/include/zephyr/sys/byteorder.h
+++ b/include/zephyr/sys/byteorder.h
@@ -307,8 +307,8 @@
  */
 static inline void sys_put_be16(uint16_t val, uint8_t dst[2])
 {
-	dst[0] = val >> 8;
-	dst[1] = val;
+	dst[0] = (uint8_t)(val >> 8);
+	dst[1] = (uint8_t)val;
 }
 
 /**
@@ -322,8 +322,8 @@ static inline void sys_put_be16(uint16_t val, uint8_t dst[2])
  */
 static inline void sys_put_be24(uint32_t val, uint8_t dst[3])
 {
-	dst[0] = val >> 16;
-	sys_put_be16(val, &dst[1]);
+	dst[0] = (uint8_t)(val >> 16);
+	sys_put_be16((uint16_t)val, &dst[1]);
 }
 
 /**
@@ -337,8 +337,8 @@ static inline void sys_put_be24(uint32_t val, uint8_t dst[3])
  */
 static inline void sys_put_be32(uint32_t val, uint8_t dst[4])
 {
-	sys_put_be16(val >> 16, dst);
-	sys_put_be16(val, &dst[2]);
+	sys_put_be16((uint16_t)(val >> 16), dst);
+	sys_put_be16((uint16_t)val, &dst[2]);
 }
 
 /**
@@ -352,8 +352,8 @@ static inline void sys_put_be32(uint32_t val, uint8_t dst[4])
  */
 static inline void sys_put_be48(uint64_t val, uint8_t dst[6])
 {
-	sys_put_be16(val >> 32, dst);
-	sys_put_be32(val, &dst[2]);
+	sys_put_be16((uint16_t)(val >> 32), dst);
+	sys_put_be32((uint32_t)val, &dst[2]);
 }
 
 /**
@@ -367,8 +367,8 @@ static inline void sys_put_be48(uint64_t val, uint8_t dst[6])
  */
 static inline void sys_put_be64(uint64_t val, uint8_t dst[8])
 {
-	sys_put_be32(val >> 32, dst);
-	sys_put_be32(val, &dst[4]);
+	sys_put_be32((uint32_t)(val >> 32), dst);
+	sys_put_be32((uint32_t)val, &dst[4]);
 }
 
 /**
@@ -382,8 +382,8 @@ static inline void sys_put_be64(uint64_t val, uint8_t dst[8])
  */
 static inline void sys_put_le16(uint16_t val, uint8_t dst[2])
 {
-	dst[0] = val;
-	dst[1] = val >> 8;
+	dst[0] = (uint8_t)val;
+	dst[1] = (uint8_t)(val >> 8);
 }
 
 /**
@@ -397,8 +397,8 @@ static inline void sys_put_le16(uint16_t val, uint8_t dst[2])
  */
 static inline void sys_put_le24(uint32_t val, uint8_t dst[3])
 {
-	sys_put_le16(val, dst);
-	dst[2] = val >> 16;
+	sys_put_le16((uint16_t)val, dst);
+	dst[2] = (uint8_t)(val >> 16);
 }
 
 /**
@@ -412,8 +412,8 @@ static inline void sys_put_le24(uint32_t val, uint8_t dst[3])
  */
 static inline void sys_put_le32(uint32_t val, uint8_t dst[4])
 {
-	sys_put_le16(val, dst);
-	sys_put_le16(val >> 16, &dst[2]);
+	sys_put_le16((uint16_t)val, dst);
+	sys_put_le16((uint16_t)(val >> 16), &dst[2]);
 }
 
 /**
@@ -427,8 +427,8 @@ static inline void sys_put_le32(uint32_t val, uint8_t dst[4])
  */
 static inline void sys_put_le48(uint64_t val, uint8_t dst[6])
 {
-	sys_put_le32(val, dst);
-	sys_put_le16(val >> 32, &dst[4]);
+	sys_put_le32((uint32_t)val, dst);
+	sys_put_le16((uint16_t)(val >> 32), &dst[4]);
 }
 
 /**
@@ -442,8 +442,8 @@ static inline void sys_put_le48(uint64_t val, uint8_t dst[6])
  */
 static inline void sys_put_le64(uint64_t val, uint8_t dst[8])
 {
-	sys_put_le32(val, dst);
-	sys_put_le32(val >> 32, &dst[4]);
+	sys_put_le32((uint32_t)val, dst);
+	sys_put_le32((uint32_t)(val >> 32), &dst[4]);
 }
 
 /**

--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -538,7 +538,10 @@ size_t hex2bin(const char *hex, size_t hexlen, uint8_t *buf, size_t buflen);
  */
 static inline uint8_t bcd2bin(uint8_t bcd)
 {
-	return ((10 * (bcd >> 4)) + (bcd & 0x0F));
+	uint32_t t = bcd;
+
+	t = (10 * (t >> 4)) + (t & 0x0F);
+	return (uint8_t)t;
 }
 
 /**


### PR DESCRIPTION
Fixes for Compilation warnings/errors:
  include/zephyr/net/buf.h - casts assignment to prevent warning 
  include/zephyr/net/hostname.h - Just prevents a compiler warning due to unused arg. Should use "ARG_UNUSED(<arg>) rather than "(void) <arg>;"
  include/zephyr/net/net_context.h - casts and ARG_UNUSED() to prevent compiler warnings.
  include/zephyr/net/net_if.h - several ARG_UNUSED().
  include/zephyr/net/net_ip.h - cast in an assignment (presumably to prevent warning).
  include/zephyr/posix/time.h - cast to prevent warning
  include/zephyr/sys/byteorder.h - lots of casts to prevent warnings
  include/zephyr/sys/util.h - cast to prevent warnings


_edited by @ycsin: This PR is a re-incarnation of #69300_