### PR TITLE
drivers: spi: Fix SPI clock glitches at very high speed slew-rate

### DIFF
--- a/drivers/bluetooth/hci/hci_spi_st.c
+++ b/drivers/bluetooth/hci/hci_spi_st.c
@@ -97,7 +97,7 @@ static int bt_spi_send_aci_config(uint8_t offset, const uint8_t *value, size_t v
 #endif /* CONFIG_BT_BLUENRG_ACI */
 
 static const struct spi_dt_spec bus = SPI_DT_SPEC_INST_GET(
-	0, SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB | SPI_WORD_SET(8), 0);
+	0, SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB | SPI_WORD_SET(8) | SPI_LOCK_ON, 0);
 
 static struct spi_buf spi_tx_buf;
 static struct spi_buf spi_rx_buf;
@@ -176,16 +176,10 @@ static bool bt_spi_handle_vendor_evt(uint8_t *msg)
 /* as long as IRQ pin is high */
 #define READ_CONDITION IS_IRQ_HIGH
 
-static void assert_cs(void)
-{
-	gpio_pin_set_dt(&bus.config.cs.gpio, 0);
-	gpio_pin_set_dt(&bus.config.cs.gpio, 1);
-}
-
 static void release_cs(bool data_transaction)
 {
 	ARG_UNUSED(data_transaction);
-	gpio_pin_set_dt(&bus.config.cs.gpio, 0);
+	spi_release_dt(&bus);
 }
 
 static int bt_spi_get_header(uint8_t op, uint16_t *size)
@@ -215,7 +209,8 @@ static int bt_spi_get_header(uint8_t op, uint16_t *size)
 				return 0;
 			}
 		}
-		assert_cs();
+		/* Make sure CS is raised before a new attempt */
+		gpio_pin_set_dt(&bus.config.cs.gpio, 0);
 		ret = bt_spi_transceive(header_master, 5, header_slave, 5);
 		if (ret) {
 			/* SPI transaction failed */
@@ -234,16 +229,6 @@ static int bt_spi_get_header(uint8_t op, uint16_t *size)
 
 #define READ_CONDITION false
 
-static void assert_cs(uint16_t delay)
-{
-	gpio_pin_set_dt(&bus.config.cs.gpio, 0);
-	if (delay) {
-		k_sleep(K_USEC(delay));
-	}
-	gpio_pin_set_dt(&bus.config.cs.gpio, 1);
-	gpio_pin_interrupt_configure_dt(&irq_gpio, GPIO_INT_DISABLE);
-}
-
 static void release_cs(bool data_transaction)
 {
 	/* Consume possible event signals */
@@ -255,7 +240,7 @@ static void release_cs(bool data_transaction)
 		}
 	}
 	gpio_pin_interrupt_configure_dt(&irq_gpio, GPIO_INT_EDGE_TO_ACTIVE);
-	gpio_pin_set_dt(&bus.config.cs.gpio, 0);
+	spi_release_dt(&bus);
 }
 
 static int bt_spi_get_header(uint8_t op, uint16_t *size)
@@ -281,7 +266,15 @@ static int bt_spi_get_header(uint8_t op, uint16_t *size)
 		return -EINVAL;
 	}
 
-	assert_cs(cs_delay);
+	if (cs_delay) {
+		k_sleep(K_USEC(cs_delay));
+	}
+	/* Perform a zero byte SPI transaction to acquire the SPI lock and lower CS
+	 * while waiting for IRQ to be raised
+	 */
+	bt_spi_transceive(header_master, 0, header_slave, 0);
+	gpio_pin_interrupt_configure_dt(&irq_gpio, GPIO_INT_DISABLE);
+
 	/* Wait up to a maximum time of 100 ms */
 	if (!WAIT_FOR(IS_IRQ_HIGH, 100000, k_usleep(100))) {
 		LOG_ERR("IRQ pin did not raise");


### PR DESCRIPTION
Fix glitches on SPI clock line when the pin `slew-rate` is set to `very-high-speed`.

Under the following conditions:

- SPI master
- `spi-cpol` and `spi-hold-cs` properties are set.
- two consecutive SPI transactions are performed (i.e. two calls to SPI trasceive API) while keeping CS low

A glitch occurs on the SPI clock when the first transaction completes and in particular when the SPI is disabled.

This fix also applies to other values for slew-rate; however, at lower speeds the voltage drop is not significant to cause problem.

The figures below demonstrate the glitch captured by Saleae (digital analyzer) in both digital and analog modes before and after the fix.

![SCK_very-high-speed_fail](https://github.com/zephyrproject-rtos/zephyr/assets/135699308/2704a2bf-8116-4bec-9102-59119398df04)

![SCK_very-high-speed_pass](https://github.com/zephyrproject-rtos/zephyr/assets/135699308/76254421-905b-4377-a409-27d0a4986a3c)

