### PR TITLE
doc: net: Update NAT options for Internet connectivity

### DIFF
--- a/doc/connectivity/networking/qemu_setup.rst
+++ b/doc/connectivity/networking/qemu_setup.rst
@@ -160,14 +160,17 @@ For applications using the "Settings" facility (with the config option
 set the :kconfig:option:`CONFIG_NET_CONFIG_MY_IPV4_GW` option to the IP address
 of the gateway. For apps not using the "Settings" facility, set up the
 gateway by calling the :c:func:`net_if_ipv4_set_gw` at runtime.
+For example: ``CONFIG_NET_CONFIG_MY_IPV4_GW="192.0.2.2"``
 
 To access the internet from a custom application running in QEMU, NAT
-(masquerading) should be set up for QEMU's source address. Assuming 192.0.2.1 is
-used, the following command should be run as root:
+(masquerading) should be set up for QEMU's source address. Assuming ``192.0.2.1`` is
+used and the Zephyr network interface is ``zeth``, the following command should be run as root:
 
 .. code-block:: console
 
-   iptables -t nat -A POSTROUTING -j MASQUERADE -s 192.0.2.1
+   iptables -t nat -A POSTROUTING -j MASQUERADE -s 192.0.2.1/24
+   iptables -I FORWARD 1 -i zeth -j ACCEPT
+   iptables -I FORWARD 1 -o zeth -m state --state RELATED,ESTABLISHED -j ACCEPT
 
 Additionally, IPv4 forwarding should be enabled on the host, and you may need to
 check that other firewall (iptables) rules don't interfere with masquerading.
@@ -179,7 +182,7 @@ To enable IPv4 forwarding the following command should be run as root:
 
 Some applications may also require a DNS server. A number of Zephyr-provided
 samples assume by default that the DNS server is available on the host
-(IP 192.0.2.2), which, in modern Linux distributions, usually runs at least
+(IP ``192.0.2.2``), which, in modern Linux distributions, usually runs at least
 a DNS proxy. When running with QEMU, it may be required to restart the host's
 DNS, so it can serve requests on the newly created TAP interface. For example,
 on Debian-based systems:
@@ -189,7 +192,7 @@ on Debian-based systems:
    service dnsmasq restart
 
 An alternative to relying on the host's DNS server is to use one in the
-network. For example, 8.8.8.8 is a publicly available DNS server. You can
+network. For example, ``8.8.8.8`` is a publicly available DNS server. You can
 configure it using :kconfig:option:`CONFIG_DNS_SERVER1` option.
 
 


### PR DESCRIPTION
The host NAT options for QEMU/native_sim Internet connectivity needs updating.