### PR TITLE
drivers: charger: max20335: assure proper configuration

### DIFF
--- a/drivers/charger/Kconfig.max20335
+++ b/drivers/charger/Kconfig.max20335
@@ -5,6 +5,7 @@ config CHARGER_MAX20335
 	bool "MAX20335 battery charger driver"
 	default y
 	depends on DT_HAS_MAXIM_MAX20335_CHARGER_ENABLED
+	select GPIO
 	select I2C
 	select MFD
 	help

--- a/drivers/charger/charger_max20335.c
+++ b/drivers/charger/charger_max20335.c
@@ -52,17 +52,6 @@ struct charger_max20335_data {
 	enum charger_status charger_status;
 };
 
-enum {
-	MAX20335_CHARGER_OFF,
-	MAX20335_CHARGING_SUSPENDED_DUE_TO_TEMPERATURE,
-	MAX20335_PRE_CHARGE_IN_PROGRESS,
-	MAX20335_FAST_CHARGE_IN_PROGRESS_1,
-	MAX20335_FAST_CHARGE_IN_PROGRESS_2,
-	MAX20335_MAINTAIN_CHARGE_IN_PROGRESS,
-	MAX20335_MAIN_CHARGER_TIMER_DONE,
-	MAX20335_CHARGER_FAULT_CONDITION,
-};
-
 static const struct linear_range charger_uv_range =
 	LINEAR_RANGE_INIT(MAX20335_REG_CVC_VREG_MIN_UV,
 			  MAX20335_REG_CVC_VREG_STEP_UV,
@@ -71,6 +60,16 @@ static const struct linear_range charger_uv_range =
 
 static int max20335_get_charger_status(const struct device *dev, enum charger_status *status)
 {
+	enum {
+		MAX20335_CHARGER_OFF,
+		MAX20335_CHARGING_SUSPENDED_DUE_TO_TEMPERATURE,
+		MAX20335_PRE_CHARGE_IN_PROGRESS,
+		MAX20335_FAST_CHARGE_IN_PROGRESS_1,
+		MAX20335_FAST_CHARGE_IN_PROGRESS_2,
+		MAX20335_MAINTAIN_CHARGE_IN_PROGRESS,
+		MAX20335_MAIN_CHARGER_TIMER_DONE,
+		MAX20335_CHARGER_FAULT_CONDITION,
+	};
 	const struct charger_max20335_config *const config = dev->config;
 	uint8_t val;
 	int ret;

--- a/drivers/charger/charger_max20335.c
+++ b/drivers/charger/charger_max20335.c
@@ -188,7 +188,7 @@ static int max20335_get_constant_charge_current(const struct device *dev,
 }
 
 static int max20335_get_constant_charge_voltage(const struct device *dev,
-						uint32_t *current_uv)
+						uint32_t *voltage_uv)
 {
 	const struct charger_max20335_config *const config = dev->config;
 	uint8_t val;
@@ -201,7 +201,7 @@ static int max20335_get_constant_charge_voltage(const struct device *dev,
 
 	val = FIELD_GET(MAX20335_CHGCNTLA_BAT_REG_CFG_MASK, val);
 
-	return linear_range_get_value(&charger_uv_range, val, current_uv);
+	return linear_range_get_value(&charger_uv_range, val, voltage_uv);
 }
 
 static int max20335_set_enabled(const struct device *dev, bool enable)

--- a/drivers/charger/charger_max20335.c
+++ b/drivers/charger/charger_max20335.c
@@ -52,7 +52,7 @@ static const struct linear_range charger_uv_range =
 			  MAX20335_REG_CVC_VREG_MIN_IDX,
 			  MAX20335_REG_CVC_VREG_MAX_IDX);
 
-static int max20335_get_status(const struct device *dev, enum charger_status *status)
+static int max20335_get_charger_status(const struct device *dev, enum charger_status *status)
 {
 	const struct charger_max20335_config *const config = dev->config;
 	uint8_t val;
@@ -219,7 +219,7 @@ static int max20335_get_prop(const struct device *dev, charger_prop_t prop,
 {
 	switch (prop) {
 	case CHARGER_PROP_STATUS:
-		return max20335_get_status(dev, &val->status);
+		return max20335_get_charger_status(dev, &val->status);
 	case CHARGER_PROP_CONSTANT_CHARGE_CURRENT_UA:
 		return max20335_get_constant_charge_current(dev,
 							    &val->const_charge_current_ua);

--- a/dts/bindings/charger/maxim,max20335-charger.yaml
+++ b/dts/bindings/charger/maxim,max20335-charger.yaml
@@ -13,3 +13,8 @@ properties:
 
   constant-charge-voltage-max-microvolt:
     required: true
+
+  int-gpios:
+    type: phandle-array
+    required: true
+    description: Interrupt pin

--- a/tests/drivers/build_all/charger/app.overlay
+++ b/tests/drivers/build_all/charger/app.overlay
@@ -10,6 +10,14 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
+		test_gpio: gpio@deadbeef {
+			compatible = "vnd,gpio";
+			gpio-controller;
+			reg = <0xdeadbeef 0x1000>;
+			#gpio-cells = <0x2>;
+			status = "okay";
+		};
+
 		test_i2c: i2c@11112222 {
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/tests/drivers/build_all/charger/i2c.dtsi
+++ b/tests/drivers/build_all/charger/i2c.dtsi
@@ -26,6 +26,7 @@ max20335@1 {
 
 		constant-charge-current-max-microamp = <100000>;
 		constant-charge-voltage-max-microvolt = <4050000>;
+		int-gpios = <&test_gpio 0 0>;
 	};
 };
 


### PR DESCRIPTION
Charger hardware configuration registers are set to zero every time external voltage is applied.
Assure proper charger configuration by buffering properties set by application and applying them at external
voltage connection event notified via interrupt.

While on it do some minor fixes and improvements.