### PR TITLE
hwmv2: boards: sync up the vendor tags and vendor-list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,14 +68,17 @@ tags
 
 # from check_compliance.py
 BinaryFiles.txt
+BoardYml.txt
 Checkpatch.txt
 DevicetreeBindings.txt
+GitDiffCheck.txt
 Gitlint.txt
 Identity.txt
 ImageSize.txt
 Kconfig.txt
 KconfigBasic.txt
 KconfigBasicNoModules.txt
+KconfigHWMv2.txt
 KeepSorted.txt
 MaintainersFormat.txt
 ModulesMaintainers.txt

--- a/boards/96boards/96b_nitrogen/board.yml
+++ b/boards/96boards/96b_nitrogen/board.yml
@@ -1,5 +1,5 @@
 board:
   name: 96b_nitrogen
-  vendor: 96Boards
+  vendor: 96boards
   socs:
   - name: nrf52832

--- a/boards/aconno/acn52832/board.yml
+++ b/boards/aconno/acn52832/board.yml
@@ -1,5 +1,5 @@
 board:
   name: acn52832
-  vendor: Aconno
+  vendor: aconno
   socs:
   - name: nrf52832

--- a/boards/actinius/actinius_icarus/board.yml
+++ b/boards/actinius/actinius_icarus/board.yml
@@ -1,6 +1,6 @@
 board:
   name: actinius_icarus
-  vendor: Actinius
+  vendor: actinius
   socs:
   - name: nrf9160
     variants:

--- a/boards/actinius/actinius_icarus_bee/board.yml
+++ b/boards/actinius/actinius_icarus_bee/board.yml
@@ -1,6 +1,6 @@
 board:
   name: actinius_icarus_bee
-  vendor: Actinius
+  vendor: actinius
   socs:
   - name: nrf9160
     variants:

--- a/boards/actinius/actinius_icarus_som/board.yml
+++ b/boards/actinius/actinius_icarus_som/board.yml
@@ -1,6 +1,6 @@
 board:
   name: actinius_icarus_som
-  vendor: Actinius
+  vendor: actinius
   socs:
   - name: nrf9160
     variants:

--- a/boards/actinius/actinius_icarus_som_dk/board.yml
+++ b/boards/actinius/actinius_icarus_som_dk/board.yml
@@ -1,6 +1,6 @@
 board:
   name: actinius_icarus_som_dk
-  vendor: Actinius
+  vendor: actinius
   socs:
   - name: nrf9160
     variants:

--- a/boards/adafruit/adafruit_feather/board.yml
+++ b/boards/adafruit/adafruit_feather/board.yml
@@ -1,5 +1,5 @@
 board:
   name: adafruit_feather
-  vendor: Adafruit Industries LLC
+  vendor: adafruit
   socs:
   - name: nrf52840

--- a/boards/adafruit/adafruit_itsybitsy/board.yml
+++ b/boards/adafruit/adafruit_itsybitsy/board.yml
@@ -1,5 +1,5 @@
 board:
   name: adafruit_itsybitsy
-  vendor: Adafruit Industries LLC
+  vendor: adafruit
   socs:
   - name: nrf52840

--- a/boards/adafruit/adafruit_kb2040/board.yml
+++ b/boards/adafruit/adafruit_kb2040/board.yml
@@ -1,5 +1,5 @@
 board:
   name: adafruit_kb2040
-  vendor: Adafruit Industries LLC
+  vendor: adafruit
   socs:
   - name: rp2040

--- a/boards/adafruit/adafruit_qt_py_rp2040/board.yml
+++ b/boards/adafruit/adafruit_qt_py_rp2040/board.yml
@@ -1,5 +1,5 @@
 board:
   name: adafruit_qt_py_rp2040
-  vendor: Adafruit Industries LLC
+  vendor: adafruit
   socs:
   - name: rp2040

--- a/boards/adafruit/nrf52_adafruit_feather/board.yml
+++ b/boards/adafruit/nrf52_adafruit_feather/board.yml
@@ -1,5 +1,5 @@
 board:
   name: nrf52_adafruit_feather
-  vendor: Adafruit Industries LLC
+  vendor: adafruit
   socs:
   - name: nrf52832

--- a/boards/altera/altera_max10/board.yml
+++ b/boards/altera/altera_max10/board.yml
@@ -1,5 +1,5 @@
 board:
   name: altera_max10
-  vendor: Altera Corporation
+  vendor: altr
   socs:
   - name: zephyr_nios2f

--- a/boards/ambiq/apollo4p_blue_kxr_evb/board.yml
+++ b/boards/ambiq/apollo4p_blue_kxr_evb/board.yml
@@ -1,5 +1,5 @@
 board:
   name: apollo4p_blue_kxr_evb
-  vendor: Ambiq
+  vendor: ambiq
   socs:
   - name: apollo4p_blue

--- a/boards/ambiq/apollo4p_evb/board.yml
+++ b/boards/ambiq/apollo4p_evb/board.yml
@@ -1,5 +1,5 @@
 board:
   name: apollo4p_evb
-  vendor: Ambiq
+  vendor: ambiq
   socs:
   - name: apollo4p

--- a/boards/amd/kv260_r5/board.yml
+++ b/boards/amd/kv260_r5/board.yml
@@ -1,5 +1,5 @@
 board:
   name: kv260_r5
-  vendor: AMD
+  vendor: amd
   socs:
   - name: zynqmp_rpu

--- a/boards/andes/adp_xc7k_ae350/board.yml
+++ b/boards/andes/adp_xc7k_ae350/board.yml
@@ -1,5 +1,5 @@
 board:
   name: adp_xc7k
-  vendor: Andes Technology
+  vendor: andestech
   socs:
   - name: ae350

--- a/boards/arduino/arduino_nano_33_ble/board.yml
+++ b/boards/arduino/arduino_nano_33_ble/board.yml
@@ -1,6 +1,6 @@
 board:
   name: arduino_nano_33_ble
-  vendor: Arduino
+  vendor: arduino
   socs:
   - name: nrf52840
     variants:

--- a/boards/arduino/arduino_nicla_sense_me/board.yml
+++ b/boards/arduino/arduino_nicla_sense_me/board.yml
@@ -1,5 +1,5 @@
 board:
   name: arduino_nicla_sense_me
-  vendor: Arduino
+  vendor: arduino
   socs:
   - name: nrf52832

--- a/boards/arduino/arduino_uno_r4_minima/board.yml
+++ b/boards/arduino/arduino_uno_r4_minima/board.yml
@@ -1,5 +1,5 @@
 board:
   name: arduino_uno_r4_minima
-  vendor: Arduino
+  vendor: arduino
   socs:
   - name: r7fa4m1ab3cfm

--- a/boards/arm/fvp_base_revc_2xaemv8a/board.yml
+++ b/boards/arm/fvp_base_revc_2xaemv8a/board.yml
@@ -1,6 +1,6 @@
 board:
   name: fvp_base_revc_2xaemv8a
-  vendor: ARM
+  vendor: arm
   socs:
   - name: fvp_base_revc_2xaemv8a
     variants:

--- a/boards/arm/fvp_baser_aemv8r/board.yml
+++ b/boards/arm/fvp_baser_aemv8r/board.yml
@@ -1,6 +1,6 @@
 board:
   name: fvp_baser_aemv8r
-  vendor: ARM
+  vendor: arm
   socs:
   - name: fvp_aemv8r_aarch64
     variants:

--- a/boards/arm/mps2/board.yml
+++ b/boards/arm/mps2/board.yml
@@ -1,6 +1,6 @@
 board:
   name: mps2
-  vendor: ARM
+  vendor: arm
   socs:
   - name: an385
   - name: an521

--- a/boards/arm/v2m_beetle/board.yml
+++ b/boards/arm/v2m_beetle/board.yml
@@ -1,5 +1,5 @@
 board:
   name: v2m_beetle
-  vendor: ARM
+  vendor: arm
   socs:
   - name: beetle_r0

--- a/boards/arm/v2m_musca_b1/board.yml
+++ b/boards/arm/v2m_musca_b1/board.yml
@@ -1,6 +1,6 @@
 board:
   name: v2m_musca_b1
-  vendor: ARM
+  vendor: arm
   socs:
   - name: musca_b1
     variants:

--- a/boards/arm/v2m_musca_s1/board.yml
+++ b/boards/arm/v2m_musca_s1/board.yml
@@ -1,6 +1,6 @@
 board:
   name: v2m_musca_s1
-  vendor: ARM
+  vendor: arm
   socs:
   - name: musca_s1
     variants:

--- a/boards/arturo182/serpente/board.yml
+++ b/boards/arturo182/serpente/board.yml
@@ -1,5 +1,5 @@
 board:
   name: serpente
-  vendor: arturo182
+  vendor: solderparty
   socs:
     - name: samd21e18a

--- a/boards/aspeed/ast1030_evb/board.yml
+++ b/boards/aspeed/ast1030_evb/board.yml
@@ -1,5 +1,5 @@
 board:
   name: ast1030_evb
-  vendor: Aspeed Technology
+  vendor: aspeed
   socs:
   - name: ast1030

--- a/boards/atmark_techno/degu_evk/board.yml
+++ b/boards/atmark_techno/degu_evk/board.yml
@@ -1,5 +1,5 @@
 board:
   name: degu_evk
-  vendor: Atmark Techno
+  vendor: atmarktechno
   socs:
   - name: nrf52840

--- a/boards/bbc/bbc_microbit/board.yml
+++ b/boards/bbc/bbc_microbit/board.yml
@@ -1,5 +1,5 @@
 board:
   name: bbc_microbit
-  vendor: BBC
+  vendor: bbc
   socs:
   - name: nrf51822

--- a/boards/bbc/bbc_microbit_v2/board.yml
+++ b/boards/bbc/bbc_microbit_v2/board.yml
@@ -1,5 +1,5 @@
 board:
   name: bbc_microbit_v2
-  vendor: BBC
+  vendor: bbc
   socs:
   - name: nrf52833

--- a/boards/beagleboard/beagleconnect_freedom/board.yml
+++ b/boards/beagleboard/beagleconnect_freedom/board.yml
@@ -1,5 +1,5 @@
 board:
   name: beagleconnect_freedom
-  vendor: BeagleBoard
+  vendor: beagle
   socs:
   - name: cc1352p7

--- a/boards/beagleboard/beaglev_fire/board.yml
+++ b/boards/beagleboard/beaglev_fire/board.yml
@@ -1,5 +1,5 @@
 board:
   name: beaglev_fire
-  vendor: BeagleBoard
+  vendor: beagle
   socs:
   - name: polarfire

--- a/boards/blue_clover/blueclover_plt_demo_v2/board.yml
+++ b/boards/blue_clover/blueclover_plt_demo_v2/board.yml
@@ -1,5 +1,5 @@
 board:
   name: blueclover_plt_demo_v2
-  vendor: Blue Clover Devices
+  vendor: bcdevices
   socs:
   - name: nrf52832

--- a/boards/broadcom/bcm958401m2/board.yml
+++ b/boards/broadcom/bcm958401m2/board.yml
@@ -1,5 +1,5 @@
 board:
   name: bcm958401m2
-  vendor: Broadcom
+  vendor: brcm
   socs:
   - name: bcm58400

--- a/boards/broadcom/bcm958402m2/board.yml
+++ b/boards/broadcom/bcm958402m2/board.yml
@@ -1,5 +1,5 @@
 board:
   name: bcm958402m2
-  vendor: Broadcom
+  vendor: brcm
   socs:
   - name: bcm58402

--- a/boards/cadence/xt-sim/board.yml
+++ b/boards/cadence/xt-sim/board.yml
@@ -1,5 +1,5 @@
 board:
   name: xt-sim
-  vendor: Cadence Design Systems
+  vendor: cdns
   socs:
   - name: xtensa_sample_controller

--- a/boards/circuit_dojo/circuitdojo_feather/board.yml
+++ b/boards/circuit_dojo/circuitdojo_feather/board.yml
@@ -1,6 +1,6 @@
 board:
   name: circuitdojo_feather
-  vendor: Circuit Dojo
+  vendor: circuitdojo
   socs:
   - name: nrf9160
     variants:

--- a/boards/contextual_electronics/contextualelectronics_abc/board.yml
+++ b/boards/contextual_electronics/contextualelectronics_abc/board.yml
@@ -1,5 +1,5 @@
 board:
   name: contextualelectronics_abc
-  vendor: Contextual Electronics
+  vendor: contextualelectronics
   socs:
   - name: nrf52840

--- a/boards/cypress/cy8ckit_062_ble/board.yml
+++ b/boards/cypress/cy8ckit_062_ble/board.yml
@@ -1,6 +1,6 @@
 board:
   name: cy8ckit_062_ble
-  vendor: Cypress
+  vendor: cypress
   revision:
     format: "major.minor.patch"
     default: "0.0.0"

--- a/boards/cypress/cy8ckit_062_wifi_bt/board.yml
+++ b/boards/cypress/cy8ckit_062_wifi_bt/board.yml
@@ -1,5 +1,5 @@
 board:
   name: cy8ckit_062_wifi_bt
-  vendor: Cypress
+  vendor: cypress
   socs:
   - name: cy8c6247

--- a/boards/cypress/cy8ckit_062s4/board.yml
+++ b/boards/cypress/cy8ckit_062s4/board.yml
@@ -1,5 +1,5 @@
 board:
   name: cy8ckit_062s4
-  vendor: Cypress
+  vendor: cypress
   socs:
   - name: cy8c6244lqi_s4d92

--- a/boards/cypress/cy8cproto_062_4343w/board.yml
+++ b/boards/cypress/cy8cproto_062_4343w/board.yml
@@ -1,5 +1,5 @@
 board:
   name: cy8cproto_062_4343w
-  vendor: Cypress
+  vendor: cypress
   socs:
   - name: cy8c624abzi_s2d44

--- a/boards/cypress/cy8cproto_063_ble/board.yml
+++ b/boards/cypress/cy8cproto_063_ble/board.yml
@@ -1,5 +1,5 @@
 board:
   name: cy8cproto_063_ble
-  vendor: Cypress
+  vendor: cypress
   socs:
   - name: cyble_416045_02

--- a/boards/digilent/arty_a7/board.yml
+++ b/boards/digilent/arty_a7/board.yml
@@ -1,6 +1,6 @@
 board:
   name: arty_a7
-  vendor: Digilent
+  vendor: digilent
   socs:
   - name: designstart_fpga_cortex_m1
   - name: designstart_fpga_cortex_m3

--- a/boards/digilent/zybo/board.yml
+++ b/boards/digilent/zybo/board.yml
@@ -1,5 +1,5 @@
 board:
   name: zybo
-  vendor: Digilent
+  vendor: digilent
   socs:
   - name: xc7z010

--- a/boards/ebyte/ebyte_e73_tbb/board.yml
+++ b/boards/ebyte/ebyte_e73_tbb/board.yml
@@ -1,5 +1,5 @@
 board:
   name: ebyte_e73_tbb
-  vendor: Chengdu Ebyte Electronic Technology
+  vendor: ebyte
   socs:
   - name: nrf52832

--- a/boards/efinix/titanium_ti60_f225/board.yml
+++ b/boards/efinix/titanium_ti60_f225/board.yml
@@ -1,5 +1,5 @@
 board:
   name: titanium_ti60_f225
-  vendor: Efinix
+  vendor: efinix
   socs:
   - name: efinix_sapphire

--- a/boards/electronut_labs/nrf52840_blip/board.yml
+++ b/boards/electronut_labs/nrf52840_blip/board.yml
@@ -1,5 +1,5 @@
 board:
   name: nrf52840_blip
-  vendor: Electronut Labs
+  vendor: electronut
   socs:
   - name: nrf52840

--- a/boards/electronut_labs/nrf52840_papyr/board.yml
+++ b/boards/electronut_labs/nrf52840_papyr/board.yml
@@ -1,5 +1,5 @@
 board:
   name: nrf52840_papyr
-  vendor: Electronut Labs
+  vendor: electronut
   socs:
   - name: nrf52840

--- a/boards/enclustra/mercury_xu/board.yml
+++ b/boards/enclustra/mercury_xu/board.yml
@@ -1,5 +1,5 @@
 board:
   name: mercury_xu
-  vendor: Enclustra
+  vendor: enclustra
   socs:
   - name: zynqmp_rpu

--- a/boards/enjoy_digital/litex_vexriscv/board.yml
+++ b/boards/enjoy_digital/litex_vexriscv/board.yml
@@ -1,5 +1,5 @@
 board:
   name: litex_vexriscv
-  vendor: LiteX
+  vendor: litex
   socs:
   - name: litex_vexriscv

--- a/boards/firefly/roc_rk3568_pc/board.yml
+++ b/boards/firefly/roc_rk3568_pc/board.yml
@@ -1,6 +1,6 @@
 board:
   name: roc_rk3568_pc
-  vendor: Firefly
+  vendor: firefly
   socs:
   - name: rk3568
     variants:

--- a/boards/gaisler/generic_leon3/board.yml
+++ b/boards/gaisler/generic_leon3/board.yml
@@ -1,5 +1,5 @@
 board:
   name: generic_leon3
-  vendor: Gaisler
+  vendor: gaisler
   socs:
   - name: leon3

--- a/boards/gaisler/gr716a_mini/board.yml
+++ b/boards/gaisler/gr716a_mini/board.yml
@@ -1,5 +1,5 @@
 board:
   name: gr716a_mini
-  vendor: Gaisler
+  vendor: gaisler
   socs:
   - name: gr716a

--- a/boards/gd/gd32a503v_eval/board.yml
+++ b/boards/gd/gd32a503v_eval/board.yml
@@ -1,5 +1,5 @@
 board:
   name: gd32a503v_eval
-  vendor: GigaDevice Semiconductor
+  vendor: gd
   socs:
     - name: gd32a503

--- a/boards/gd/gd32e103v_eval/board.yml
+++ b/boards/gd/gd32e103v_eval/board.yml
@@ -1,5 +1,5 @@
 board:
   name: gd32e103v_eval
-  vendor: GigaDevice Semiconductor
+  vendor: gd
   socs:
     - name: gd32e103

--- a/boards/gd/gd32e507v_start/board.yml
+++ b/boards/gd/gd32e507v_start/board.yml
@@ -1,5 +1,5 @@
 board:
   name: gd32e507v_start
-  vendor: GigaDevice Semiconductor
+  vendor: gd
   socs:
     - name: gd32e507

--- a/boards/gd/gd32e507z_eval/board.yml
+++ b/boards/gd/gd32e507z_eval/board.yml
@@ -1,5 +1,5 @@
 board:
   name: gd32e507z_eval
-  vendor: GigaDevice Semiconductor
+  vendor: gd
   socs:
     - name: gd32e507

--- a/boards/gd/gd32f350r_eval/board.yml
+++ b/boards/gd/gd32f350r_eval/board.yml
@@ -1,5 +1,5 @@
 board:
   name: gd32f350r_eval
-  vendor: GigaDevice Semiconductor
+  vendor: gd
   socs:
     - name: gd32f350

--- a/boards/gd/gd32f403z_eval/board.yml
+++ b/boards/gd/gd32f403z_eval/board.yml
@@ -1,5 +1,5 @@
 board:
   name: gd32f403z_eval
-  vendor: GigaDevice Semiconductor
+  vendor: gd
   socs:
     - name: gd32f403

--- a/boards/gd/gd32f407v_start/board.yml
+++ b/boards/gd/gd32f407v_start/board.yml
@@ -1,5 +1,5 @@
 board:
   name: gd32f407v_start
-  vendor: GigaDevice Semiconductor
+  vendor: gd
   socs:
     - name: gd32f407

--- a/boards/gd/gd32f450i_eval/board.yml
+++ b/boards/gd/gd32f450i_eval/board.yml
@@ -1,5 +1,5 @@
 board:
   name: gd32f450i_eval
-  vendor: GigaDevice Semiconductor
+  vendor: gd
   socs:
     - name: gd32f450

--- a/boards/gd/gd32f450v_start/board.yml
+++ b/boards/gd/gd32f450v_start/board.yml
@@ -1,5 +1,5 @@
 board:
   name: gd32f450v_start
-  vendor: GigaDevice Semiconductor
+  vendor: gd
   socs:
     - name: gd32f450

--- a/boards/gd/gd32f450z_eval/board.yml
+++ b/boards/gd/gd32f450z_eval/board.yml
@@ -1,5 +1,5 @@
 board:
   name: gd32f450z_eval
-  vendor: GigaDevice Semiconductor
+  vendor: gd
   socs:
     - name: gd32f450

--- a/boards/gd/gd32f470i_eval/board.yml
+++ b/boards/gd/gd32f470i_eval/board.yml
@@ -1,5 +1,5 @@
 board:
   name: gd32f470i_eval
-  vendor: GigaDevice Semiconductor
+  vendor: gd
   socs:
     - name: gd32f470

--- a/boards/gd/gd32l233r_eval/board.yml
+++ b/boards/gd/gd32l233r_eval/board.yml
@@ -1,5 +1,5 @@
 board:
   name: gd32l233r_eval
-  vendor: GigaDevice Semiconductor
+  vendor: gd
   socs:
     - name: gd32l233

--- a/boards/gd/gd32vf103c_starter/board.yml
+++ b/boards/gd/gd32vf103c_starter/board.yml
@@ -1,5 +1,5 @@
 board:
   name: gd32vf103c_starter
-  vendor: GigaDevice Semiconductor
+  vendor: gd
   socs:
     - name: gd32vf103

--- a/boards/gd/gd32vf103v_eval/board.yml
+++ b/boards/gd/gd32vf103v_eval/board.yml
@@ -1,5 +1,5 @@
 board:
   name: gd32vf103v_eval
-  vendor: GigaDevice Semiconductor
+  vendor: gd
   socs:
     - name: gd32vf103

--- a/boards/holyiot/holyiot_yj16019/board.yml
+++ b/boards/holyiot/holyiot_yj16019/board.yml
@@ -1,5 +1,5 @@
 board:
   name: holyiot_yj16019
-  vendor: Shenzhen Holyiot Technology Co.
+  vendor: holyiot
   socs:
   - name: nrf52832

--- a/boards/infineon/xmc45_relax_kit/board.yml
+++ b/boards/infineon/xmc45_relax_kit/board.yml
@@ -1,5 +1,5 @@
 board:
   name: xmc45_relax_kit
-  vendor: Infineon
+  vendor: infineon
   socs:
   - name: xmc4500

--- a/boards/infineon/xmc47_relax_kit/board.yml
+++ b/boards/infineon/xmc47_relax_kit/board.yml
@@ -1,5 +1,5 @@
 board:
   name: xmc47_relax_kit
-  vendor: Infineon
+  vendor: infineon
   socs:
   - name: xmc4700

--- a/boards/ite/it82xx2_evb/board.yml
+++ b/boards/ite/it82xx2_evb/board.yml
@@ -1,5 +1,5 @@
 board:
   name: it82xx2_evb
-  vendor: ITE
+  vendor: ite
   socs:
     - name: it82202ax

--- a/boards/ite/it8xxx2_evb/board.yml
+++ b/boards/ite/it8xxx2_evb/board.yml
@@ -1,5 +1,5 @@
 board:
   name: it8xxx2_evb
-  vendor: ITE
+  vendor: ite
   socs:
     - name: it82202ax

--- a/boards/khadas/khadas_edgev/board.yml
+++ b/boards/khadas/khadas_edgev/board.yml
@@ -1,5 +1,5 @@
 board:
   name: khadas_edgev
-  vendor: Khadas
+  vendor: khadas
   socs:
   - name: rk3399

--- a/boards/laird_connect/bl5340_dvk/board.yml
+++ b/boards/laird_connect/bl5340_dvk/board.yml
@@ -1,6 +1,6 @@
 board:
   name: bl5340_dvk
-  vendor: Laird Connectivity
+  vendor: lairdconnect
   socs:
   - name: 'nrf5340'
     variants:

--- a/boards/laird_connect/bl652_dvk/board.yml
+++ b/boards/laird_connect/bl652_dvk/board.yml
@@ -1,5 +1,5 @@
 board:
   name: bl652_dvk
-  vendor: Laird Connectivity
+  vendor: lairdconnect
   socs:
   - name: nrf52832

--- a/boards/laird_connect/bl653_dvk/board.yml
+++ b/boards/laird_connect/bl653_dvk/board.yml
@@ -1,5 +1,5 @@
 board:
   name: bl653_dvk
-  vendor: Laird Connectivity
+  vendor: lairdconnect
   socs:
   - name: nrf52833

--- a/boards/laird_connect/bl654_dvk/board.yml
+++ b/boards/laird_connect/bl654_dvk/board.yml
@@ -1,5 +1,5 @@
 board:
   name: bl654_dvk
-  vendor: Laird Connectivity
+  vendor: lairdconnect
   socs:
   - name: nrf52840

--- a/boards/laird_connect/bl654_sensor_board/board.yml
+++ b/boards/laird_connect/bl654_sensor_board/board.yml
@@ -1,5 +1,5 @@
 board:
   name: bl654_sensor_board
-  vendor: Laird Connectivity
+  vendor: lairdconnect
   socs:
   - name: nrf52840

--- a/boards/laird_connect/bl654_usb/board.yml
+++ b/boards/laird_connect/bl654_usb/board.yml
@@ -1,5 +1,5 @@
 board:
   name: bl654_usb
-  vendor: Laird Connectivity
+  vendor: lairdconnect
   socs:
   - name: nrf52840

--- a/boards/laird_connect/bt510/board.yml
+++ b/boards/laird_connect/bt510/board.yml
@@ -1,5 +1,5 @@
 board:
   name: bt510
-  vendor: Laird Connectivity
+  vendor: lairdconnect
   socs:
   - name: nrf52840

--- a/boards/laird_connect/bt610/board.yml
+++ b/boards/laird_connect/bt610/board.yml
@@ -1,5 +1,5 @@
 board:
   name: bt610
-  vendor: Laird Connectivity
+  vendor: lairdconnect
   socs:
   - name: nrf52840

--- a/boards/laird_connect/mg100/board.yml
+++ b/boards/laird_connect/mg100/board.yml
@@ -1,5 +1,5 @@
 board:
   name: mg100
-  vendor: Laird Connectivity
+  vendor: lairdconnect
   socs:
   - name: nrf52840

--- a/boards/laird_connect/pinnacle_100_dvk/board.yml
+++ b/boards/laird_connect/pinnacle_100_dvk/board.yml
@@ -1,5 +1,5 @@
 board:
   name: pinnacle_100_dvk
-  vendor: Laird Connectivity
+  vendor: lairdconnect
   socs:
   - name: nrf52840

--- a/boards/laird_connect/rm1xx_dvk/board.yml
+++ b/boards/laird_connect/rm1xx_dvk/board.yml
@@ -1,5 +1,5 @@
 board:
   name: rm1xx_dvk
-  vendor: Laird Connectivity
+  vendor: lairdconnect
   socs:
   - name: nrf51822

--- a/boards/lowrisc/opentitan_earlgrey/board.yml
+++ b/boards/lowrisc/opentitan_earlgrey/board.yml
@@ -1,5 +1,5 @@
 board:
   name: opentitan_earlgrey
-  vendor: lowRISC
+  vendor: lowrisc
   socs:
   - name: opentitan

--- a/boards/maker_diary/nrf52832_mdk/board.yml
+++ b/boards/maker_diary/nrf52832_mdk/board.yml
@@ -1,5 +1,5 @@
 board:
   name: nrf52832_mdk
-  vendor: Maker Diary
+  vendor: makerdiary
   socs:
   - name: nrf52832

--- a/boards/maker_diary/nrf52840_mdk/board.yml
+++ b/boards/maker_diary/nrf52840_mdk/board.yml
@@ -1,5 +1,5 @@
 board:
   name: nrf52840_mdk
-  vendor: Maker Diary
+  vendor: makerdiary
   socs:
   - name: nrf52840

--- a/boards/maker_diary/nrf52840_mdk_usb_dongle/board.yml
+++ b/boards/maker_diary/nrf52840_mdk_usb_dongle/board.yml
@@ -1,5 +1,5 @@
 board:
   name: nrf52840_mdk_usb_dongle
-  vendor: Maker Diary
+  vendor: makerdiary
   socs:
   - name: nrf52840

--- a/boards/microchip/m2gl025_miv/board.yml
+++ b/boards/microchip/m2gl025_miv/board.yml
@@ -1,5 +1,5 @@
 board:
   name: m2gl025_miv
-  vendor: Microchip
+  vendor: microchip
   socs:
   - name: miv

--- a/boards/microchip/mec1501modular_assy6885/board.yml
+++ b/boards/microchip/mec1501modular_assy6885/board.yml
@@ -1,5 +1,5 @@
 board:
   name: mec1501modular_assy6885
-  vendor: Microchip
+  vendor: microchip
   socs:
     - name: mec1501_hsz

--- a/boards/microchip/mec15xxevb_assy6853/board.yml
+++ b/boards/microchip/mec15xxevb_assy6853/board.yml
@@ -1,5 +1,5 @@
 board:
   name: mec15xxevb_assy6853
-  vendor: Microchip
+  vendor: microchip
   socs:
     - name: mec1501_hsz

--- a/boards/microchip/mec172xevb_assy6906/board.yml
+++ b/boards/microchip/mec172xevb_assy6906/board.yml
@@ -1,5 +1,5 @@
 board:
   name: mec172xevb_assy6906
-  vendor: Microchip
+  vendor: microchip
   socs:
     - name: mec172x_nsz

--- a/boards/microchip/mec172xmodular_assy6930/board.yml
+++ b/boards/microchip/mec172xmodular_assy6930/board.yml
@@ -1,5 +1,5 @@
 board:
   name: mec172xmodular_assy6930
-  vendor: Microchip
+  vendor: microchip
   socs:
     - name: mec172x_nsz

--- a/boards/microchip/mpfs_icicle/board.yml
+++ b/boards/microchip/mpfs_icicle/board.yml
@@ -1,5 +1,5 @@
 board:
   name: mpfs_icicle
-  vendor: Microchip
+  vendor: microchip
   socs:
   - name: polarfire

--- a/boards/native/native_posix/board.yml
+++ b/boards/native/native_posix/board.yml
@@ -1,6 +1,6 @@
 boards:
 - name: native_posix
-  vendor: Zephyr
+  vendor: zephyr
   socs:
   - name: native
     variants:
@@ -10,6 +10,6 @@ boards:
 # Kconfig.native_posix_64 exist for backwards compatibility with the hwmv1 board name
 # Once all its usage in tree is removed, or an alias has been introduced they can be removed.
 - name: native_posix_64
-  vendor: Zephyr
+  vendor: zephyr
   socs:
   - name: native

--- a/boards/native/native_sim/board.yml
+++ b/boards/native/native_sim/board.yml
@@ -1,6 +1,6 @@
 boards:
 - name: native_sim
-  vendor: Zephyr
+  vendor: zephyr
   socs:
   - name: native
     variants:
@@ -10,6 +10,6 @@ boards:
 # Kconfig.native_sim_64 exist for backwards compatibility with the hwmv1 board name
 # Once all its usage in tree is removed, or an alias has been introduced they can be removed.
 - name: native_sim_64
-  vendor: Zephyr
+  vendor: zephyr
   socs:
   - name: native

--- a/boards/native/nrf_bsim/board.yml
+++ b/boards/native/nrf_bsim/board.yml
@@ -1,10 +1,10 @@
 boards:
 - name: nrf52_bsim
-  vendor: Zephyr
+  vendor: zephyr
   socs:
   - name: native
 - name: nrf5340bsim
-  vendor: Zephyr
+  vendor: zephyr
   socs:
   # Note this is referring to the real SOC yaml, but we only use its name and cpu-cluster definition
   # In practice this board uses the same native SOC (SOC_POSIX) as the nrf52_bsim
@@ -14,10 +14,10 @@ boards:
 # Kconfig.nrf5340bsim_nrf5340_cpu[app,net] exist for backwards compatibility with hwmv1 usage
 # Once all their usage in tree is removed, or aliases have been introduced they can be removed.
 - name: nrf5340bsim_nrf5340_cpuapp
-  vendor: Zephyr
+  vendor: zephyr
   socs:
   - name: native
 - name: nrf5340bsim_nrf5340_cpunet
-  vendor: Zephyr
+  vendor: zephyr
   socs:
   - name: native

--- a/boards/nordic_nrf/nrf21540dk/board.yml
+++ b/boards/nordic_nrf/nrf21540dk/board.yml
@@ -1,5 +1,5 @@
 board:
   name: nrf21540dk
-  vendor: Nordic Semiconductor
+  vendor: nordic
   socs:
   - name: nrf52840

--- a/boards/nordic_nrf/nrf51dk/board.yml
+++ b/boards/nordic_nrf/nrf51dk/board.yml
@@ -1,5 +1,5 @@
 board:
   name: nrf51dk
-  vendor: Nordic Semiconductor
+  vendor: nordic
   socs:
   - name: nrf51822

--- a/boards/nordic_nrf/nrf51dongle/board.yml
+++ b/boards/nordic_nrf/nrf51dongle/board.yml
@@ -1,5 +1,5 @@
 board:
   name: nrf51dongle
-  vendor: Nordic Semiconductor
+  vendor: nordic
   socs:
   - name: nrf51822

--- a/boards/nordic_nrf/nrf52833dk/board.yml
+++ b/boards/nordic_nrf/nrf52833dk/board.yml
@@ -1,6 +1,6 @@
 board:
   name: nrf52833dk
-  vendor: Nordic Semiconductor
+  vendor: nordic
   socs:
   - name: nrf52820
   - name: nrf52833

--- a/boards/nordic_nrf/nrf52840dk/board.yml
+++ b/boards/nordic_nrf/nrf52840dk/board.yml
@@ -1,6 +1,6 @@
 board:
   name: nrf52840dk
-  vendor: Nordic Semiconductor
+  vendor: nordic
   socs:
   # Physical nRF52840 SoC on PCA10056
   - name: nrf52840

--- a/boards/nordic_nrf/nrf52840dongle/board.yml
+++ b/boards/nordic_nrf/nrf52840dongle/board.yml
@@ -1,5 +1,5 @@
 board:
   name: nrf52840dongle
-  vendor: Nordic Semiconductor
+  vendor: nordic
   socs:
   - name: nrf52840

--- a/boards/nordic_nrf/nrf52dk/board.yml
+++ b/boards/nordic_nrf/nrf52dk/board.yml
@@ -1,6 +1,6 @@
 board:
   name: nrf52dk
-  vendor: Nordic Semiconductor
+  vendor: nordic
   socs:
   - name: nrf52805
   - name: nrf52810

--- a/boards/nordic_nrf/nrf5340_audio_dk/board.yml
+++ b/boards/nordic_nrf/nrf5340_audio_dk/board.yml
@@ -1,6 +1,6 @@
 board:
   name: nrf5340_audio_dk
-  vendor: Nordic Semiconductor
+  vendor: nordic
   socs:
   - name: 'nrf5340'
     variants:

--- a/boards/nordic_nrf/nrf5340dk/board.yml
+++ b/boards/nordic_nrf/nrf5340dk/board.yml
@@ -1,6 +1,6 @@
 board:
   name: nrf5340dk
-  vendor: Nordic Semiconductor
+  vendor: nordic
   socs:
   - name: 'nrf5340'
     variants:

--- a/boards/nordic_nrf/nrf54h20pdk/board.yml
+++ b/boards/nordic_nrf/nrf54h20pdk/board.yml
@@ -1,5 +1,5 @@
 board:
   name: nrf54h20pdk
-  vendor: Nordic Semiconductor
+  vendor: nordic
   socs:
   - name: nrf54h20

--- a/boards/nordic_nrf/nrf54l15pdk/board.yml
+++ b/boards/nordic_nrf/nrf54l15pdk/board.yml
@@ -1,5 +1,5 @@
 board:
   name: nrf54l15pdk
-  vendor: Nordic Semiconductor
+  vendor: nordic
   socs:
   - name: nrf54l15

--- a/boards/nordic_nrf/nrf9131ek/board.yml
+++ b/boards/nordic_nrf/nrf9131ek/board.yml
@@ -1,6 +1,6 @@
 board:
   name: nrf9131ek
-  vendor: Nordic Semiconductor
+  vendor: nordic
   socs:
   - name: nrf9131
     variants:

--- a/boards/nordic_nrf/nrf9151dk/board.yml
+++ b/boards/nordic_nrf/nrf9151dk/board.yml
@@ -1,6 +1,6 @@
 board:
   name: nrf9151dk
-  vendor: Nordic Semiconductor
+  vendor: nordic
   socs:
   - name: nrf9151
     variants:

--- a/boards/nordic_nrf/nrf9160dk/board.yml
+++ b/boards/nordic_nrf/nrf9160dk/board.yml
@@ -1,6 +1,6 @@
 board:
   name: nrf9160dk
-  vendor: Nordic Semiconductor
+  vendor: nordic
   socs:
   - name: nrf9160
     variants:

--- a/boards/nordic_nrf/nrf9161dk/board.yml
+++ b/boards/nordic_nrf/nrf9161dk/board.yml
@@ -1,6 +1,6 @@
 board:
   name: nrf9161dk
-  vendor: Nordic Semiconductor
+  vendor: nordic
   socs:
   - name: nrf9161
     variants:

--- a/boards/nordic_nrf/thingy52/board.yml
+++ b/boards/nordic_nrf/thingy52/board.yml
@@ -1,5 +1,5 @@
 board:
   name: thingy52
-  vendor: Nordic Semiconductor
+  vendor: nordic
   socs:
   - name: nrf52832

--- a/boards/nordic_nrf/thingy53/board.yml
+++ b/boards/nordic_nrf/thingy53/board.yml
@@ -1,6 +1,6 @@
 board:
   name: thingy53
-  vendor: Nordic Semiconductor
+  vendor: nordic
   socs:
   - name: 'nrf5340'
     variants:

--- a/boards/nuvoton/npcx4m8f_evb/board.yml
+++ b/boards/nuvoton/npcx4m8f_evb/board.yml
@@ -1,5 +1,5 @@
 board:
   name: npcx4m8f_evb
-  vendor: Nuvoton
+  vendor: nuvoton
   socs:
   - name: npcx4m8f

--- a/boards/nuvoton/npcx7m6fb_evb/board.yml
+++ b/boards/nuvoton/npcx7m6fb_evb/board.yml
@@ -1,5 +1,5 @@
 board:
   name: npcx7m6fb_evb
-  vendor: Nuvoton
+  vendor: nuvoton
   socs:
   - name: npcx7m6fb

--- a/boards/nuvoton/npcx9m6f_evb/board.yml
+++ b/boards/nuvoton/npcx9m6f_evb/board.yml
@@ -1,5 +1,5 @@
 board:
   name: npcx9m6f_evb
-  vendor: Nuvoton
+  vendor: nuvoton
   socs:
   - name: npcx9m6f

--- a/boards/nuvoton/numaker_pfm_m467/board.yml
+++ b/boards/nuvoton/numaker_pfm_m467/board.yml
@@ -1,5 +1,5 @@
 board:
   name: numaker_pfm_m467
-  vendor: Nuvoton
+  vendor: nuvoton
   socs:
   - name: m467

--- a/boards/nuvoton/numaker_pfm_m487/board.yml
+++ b/boards/nuvoton/numaker_pfm_m487/board.yml
@@ -1,5 +1,5 @@
 board:
   name: numaker_pfm_m487
-  vendor: Nuvoton
+  vendor: nuvoton
   socs:
   - name: m487

--- a/boards/openisa/rv32m1_vega/board.yml
+++ b/boards/openisa/rv32m1_vega/board.yml
@@ -1,5 +1,5 @@
 board:
   name: rv32m1_vega
-  vendor: OpenISA
+  vendor: openisa
   socs:
   - name: openisa_rv32m1

--- a/boards/panasonic/pan1770_evb/board.yml
+++ b/boards/panasonic/pan1770_evb/board.yml
@@ -1,5 +1,5 @@
 board:
   name: pan1770_evb
-  vendor: Panasonic Industrial Devices Europe GmbH
+  vendor: panasonic
   socs:
   - name: nrf52840

--- a/boards/panasonic/pan1780_evb/board.yml
+++ b/boards/panasonic/pan1780_evb/board.yml
@@ -1,5 +1,5 @@
 board:
   name: pan1780_evb
-  vendor: Panasonic Industrial Devices Europe GmbH
+  vendor: panasonic
   socs:
   - name: nrf52840

--- a/boards/panasonic/pan1781_evb/board.yml
+++ b/boards/panasonic/pan1781_evb/board.yml
@@ -1,5 +1,5 @@
 board:
   name: pan1781_evb
-  vendor: Panasonic Industrial Devices Europe GmbH
+  vendor: panasonic
   socs:
   - name: nrf52820

--- a/boards/panasonic/pan1782_evb/board.yml
+++ b/boards/panasonic/pan1782_evb/board.yml
@@ -1,5 +1,5 @@
 board:
   name: pan1782_evb
-  vendor: Panasonic Industrial Devices Europe GmbH
+  vendor: panasonic
   socs:
   - name: nrf52833

--- a/boards/panasonic/pan1783/board.yml
+++ b/boards/panasonic/pan1783/board.yml
@@ -1,13 +1,13 @@
 boards:
 - name: pan1783_evb
-  vendor: Panasonic Industrial Devices Europe GmbH
+  vendor: panasonic
   socs:
   - name: nrf5340
 - name: pan1783a_evb
-  vendor: Panasonic Industrial Devices Europe GmbH
+  vendor: panasonic
   socs:
   - name: nrf5340
 - name: pan1783a_pa_evb
-  vendor: Panasonic Industrial Devices Europe GmbH
+  vendor: panasonic
   socs:
   - name: nrf5340

--- a/boards/particle/nrf51_blenano/board.yml
+++ b/boards/particle/nrf51_blenano/board.yml
@@ -1,5 +1,5 @@
 board:
   name: nrf51_blenano
-  vendor: Particle Industries
+  vendor: particle
   socs:
   - name: nrf51822

--- a/boards/particle/nrf52_blenano2/board.yml
+++ b/boards/particle/nrf52_blenano2/board.yml
@@ -1,5 +1,5 @@
 board:
   name: nrf52_blenano2
-  vendor: Particle Industries
+  vendor: particle
   socs:
   - name: nrf52832

--- a/boards/particle/particle_argon/board.yml
+++ b/boards/particle/particle_argon/board.yml
@@ -1,5 +1,5 @@
 board:
   name: particle_argon
-  vendor: Particle Industries
+  vendor: particle
   socs:
   - name: nrf52840

--- a/boards/particle/particle_boron/board.yml
+++ b/boards/particle/particle_boron/board.yml
@@ -1,5 +1,5 @@
 board:
   name: particle_boron
-  vendor: Particle Industries
+  vendor: particle
   socs:
   - name: nrf52840

--- a/boards/particle/particle_xenon/board.yml
+++ b/boards/particle/particle_xenon/board.yml
@@ -1,5 +1,5 @@
 board:
   name: particle_xenon
-  vendor: Particle Industries
+  vendor: particle
   socs:
   - name: nrf52840

--- a/boards/phytec/phyboard_lyra_am62x/board.yml
+++ b/boards/phytec/phyboard_lyra_am62x/board.yml
@@ -1,5 +1,5 @@
 board:
   name: phyboard_lyra_am62x
-  vendor: Phytec
+  vendor: phytec
   socs:
   - name: am6234

--- a/boards/phytec/phycore_am62x/board.yml
+++ b/boards/phytec/phycore_am62x/board.yml
@@ -1,5 +1,5 @@
 board:
   name: phycore_am62x
-  vendor: Phytec
+  vendor: phytec
   socs:
   - name: am6234

--- a/boards/phytec/reel_board/board.yml
+++ b/boards/phytec/reel_board/board.yml
@@ -1,6 +1,6 @@
 board:
   name: reel_board
-  vendor: PHYTEC Messtechnik GmbH
+  vendor: phytec
   socs:
   - name: nrf52840
   revision:

--- a/boards/pine64/pinetime_devkit0/board.yml
+++ b/boards/pine64/pinetime_devkit0/board.yml
@@ -1,5 +1,5 @@
 board:
   name: pinetime_devkit0
-  vendor: PINE64
+  vendor: pine64
   socs:
   - name: nrf52832

--- a/boards/qemu/arc/board.yml
+++ b/boards/qemu/arc/board.yml
@@ -1,6 +1,6 @@
 board:
   name: qemu_arc
-  vendor: QEMU
+  vendor: qemu
   socs:
   - name: qemu_arc_em
   - name: qemu_arc_hs

--- a/boards/qemu/cortex_a9/board.yml
+++ b/boards/qemu/cortex_a9/board.yml
@@ -1,5 +1,5 @@
 board:
   name: qemu_cortex_a9
-  vendor: QEMU
+  vendor: qemu
   socs:
   - name: xc7z007s

--- a/boards/qemu/cortex_m3/board.yml
+++ b/boards/qemu/cortex_m3/board.yml
@@ -1,5 +1,5 @@
 board:
   name: qemu_cortex_m3
-  vendor: QEMU
+  vendor: qemu
   socs:
   - name: ti_lm3s6965

--- a/boards/qemu/cortex_r5/board.yml
+++ b/boards/qemu/cortex_r5/board.yml
@@ -1,5 +1,5 @@
 board:
   name: qemu_cortex_r5
-  vendor: QEMU
+  vendor: qemu
   socs:
   - name: zynqmp_rpu

--- a/boards/qemu/nios2/board.yml
+++ b/boards/qemu/nios2/board.yml
@@ -1,5 +1,5 @@
 board:
   name: qemu_nios2
-  vendor: Altera Corporation
+  vendor: altr
   socs:
   - name: qemu_nios2

--- a/boards/qemu/qemu_cortex_a53/board.yml
+++ b/boards/qemu/qemu_cortex_a53/board.yml
@@ -1,6 +1,6 @@
 board:
   name: qemu_cortex_a53
-  vendor: ARM
+  vendor: arm
   socs:
   - name: qemu_cortex_a53
     variants:

--- a/boards/qemu/qemu_cortex_m0/board.yml
+++ b/boards/qemu/qemu_cortex_m0/board.yml
@@ -1,5 +1,5 @@
 board:
   name: qemu_cortex_m0
-  vendor: Nordic Semiconductor
+  vendor: nordic
   socs:
   - name: nrf51822

--- a/boards/qemu/qemu_kvm_arm64/board.yml
+++ b/boards/qemu/qemu_kvm_arm64/board.yml
@@ -1,5 +1,5 @@
 board:
   name: qemu_kvm_arm64
-  vendor: ARM
+  vendor: arm
   socs:
   - name: qemu_virt_arm64

--- a/boards/qemu/qemu_leon3/board.yml
+++ b/boards/qemu/qemu_leon3/board.yml
@@ -1,5 +1,5 @@
 board:
   name: qemu_leon3
-  vendor: Gaisler
+  vendor: gaisler
   socs:
   - name: leon3

--- a/boards/qemu/qemu_malta/board.yml
+++ b/boards/qemu/qemu_malta/board.yml
@@ -1,6 +1,6 @@
 board:
   name: qemu_malta
-  vendor: QEMU
+  vendor: qemu
   socs:
   - name: qemu_malta
     variants:

--- a/boards/qemu/qemu_xtensa/board.yml
+++ b/boards/qemu/qemu_xtensa/board.yml
@@ -1,6 +1,6 @@
 board:
   name: qemu_xtensa
-  vendor: Cadence Design Systems
+  vendor: cdns
   socs:
   - name: dc233c
     variants:

--- a/boards/qorvo/decawave_dwm1001_dev/board.yml
+++ b/boards/qorvo/decawave_dwm1001_dev/board.yml
@@ -1,5 +1,5 @@
 board:
   name: decawave_dwm1001_dev
-  vendor: Qorvo
+  vendor: qorvo
   socs:
   - name: nrf52832

--- a/boards/quicklogic/qomu/board.yml
+++ b/boards/quicklogic/qomu/board.yml
@@ -1,5 +1,5 @@
 board:
   name: qomu
-  vendor: QuickLogic
+  vendor: quicklogic
   socs:
   - name: quicklogic_eos_s3

--- a/boards/quicklogic/quick_feather/board.yml
+++ b/boards/quicklogic/quick_feather/board.yml
@@ -1,5 +1,5 @@
 board:
   name: quick_feather
-  vendor: QuickLogic
+  vendor: quicklogic
   socs:
   - name: quicklogic_eos_s3

--- a/boards/rak/rak4631/board.yml
+++ b/boards/rak/rak4631/board.yml
@@ -1,5 +1,5 @@
 board:
   name: rak4631
-  vendor: RAKwireless
+  vendor: rakwireless
   socs:
   - name: nrf52840

--- a/boards/rak/rak5010/board.yml
+++ b/boards/rak/rak5010/board.yml
@@ -1,5 +1,5 @@
 board:
   name: rak5010
-  vendor: RAKwireless
+  vendor: rakwireless
   socs:
   - name: nrf52840

--- a/boards/raspberry_pi/rpi_4b/board.yml
+++ b/boards/raspberry_pi/rpi_4b/board.yml
@@ -1,5 +1,5 @@
 board:
   name: rpi_4b
-  vendor: Raspberry Pi
+  vendor: raspberrypi
   socs:
   - name: bcm2711

--- a/boards/raspberry_pi/rpi_pico/board.yml
+++ b/boards/raspberry_pi/rpi_pico/board.yml
@@ -1,6 +1,6 @@
 board:
   name: rpi_pico
-  vendor: Raspberry Pi
+  vendor: raspberrypi
   socs:
   - name: rp2040
     variants:

--- a/boards/raytac/raytac_mdbt50q_db_33/board.yml
+++ b/boards/raytac/raytac_mdbt50q_db_33/board.yml
@@ -1,5 +1,5 @@
 board:
   name: raytac_mdbt50q_db_33
-  vendor: Raytac Corporation
+  vendor: raytac
   socs:
   - name: nrf52833

--- a/boards/raytac/raytac_mdbt50q_db_40/board.yml
+++ b/boards/raytac/raytac_mdbt50q_db_40/board.yml
@@ -1,5 +1,5 @@
 board:
   name: raytac_mdbt50q_db_40
-  vendor: Raytac Corporation
+  vendor: raytac
   socs:
   - name: nrf52840

--- a/boards/raytac/raytac_mdbt53_db_40/board.yml
+++ b/boards/raytac/raytac_mdbt53_db_40/board.yml
@@ -1,6 +1,6 @@
 board:
   name: raytac_mdbt53_db_40
-  vendor: Raytac Corporation
+  vendor: raytac
   socs:
   - name: 'nrf5340'
     variants:

--- a/boards/raytac/raytac_mdbt53v_db_40/board.yml
+++ b/boards/raytac/raytac_mdbt53v_db_40/board.yml
@@ -1,6 +1,6 @@
 board:
   name: raytac_mdbt53v_db_40
-  vendor: Raytac Corporation
+  vendor: raytac
   socs:
   - name: 'nrf5340'
     variants:

--- a/boards/renesas/da14695_dk_usb/board.yml
+++ b/boards/renesas/da14695_dk_usb/board.yml
@@ -1,5 +1,5 @@
 board:
   name: da14695_dk_usb
-  vendor: Renesas
+  vendor: renesas
   socs:
   - name: da14695

--- a/boards/renesas/da1469x_dk_pro/board.yml
+++ b/boards/renesas/da1469x_dk_pro/board.yml
@@ -1,5 +1,5 @@
 board:
   name: da1469x_dk_pro
-  vendor: Renesas
+  vendor: renesas
   socs:
   - name: da14699

--- a/boards/renesas/rcar_h3ulcb/board.yml
+++ b/boards/renesas/rcar_h3ulcb/board.yml
@@ -1,5 +1,5 @@
 board:
   name: rcar_h3ulcb
-  vendor: Renesas
+  vendor: renesas
   socs:
   - name: r8a77951

--- a/boards/renesas/rcar_salvator_x/board.yml
+++ b/boards/renesas/rcar_salvator_x/board.yml
@@ -1,5 +1,5 @@
 board:
   name: rcar_salvator_x
-  vendor: Renesas
+  vendor: renesas
   socs:
   - name: r8a77951

--- a/boards/renesas/rcar_salvator_xs/board.yml
+++ b/boards/renesas/rcar_salvator_xs/board.yml
@@ -1,5 +1,5 @@
 board:
   name: rcar_salvator_xs
-  vendor: Renesas
+  vendor: renesas
   socs:
   - name: r8a77961

--- a/boards/renesas/rcar_spider_s4/board.yml
+++ b/boards/renesas/rcar_spider_s4/board.yml
@@ -1,5 +1,5 @@
 board:
   name: rcar_spider_s4
-  vendor: Renesas
+  vendor: renesas
   socs:
   - name: r8a779f0

--- a/boards/renesas/rzt2m_starterkit/board.yml
+++ b/boards/renesas/rzt2m_starterkit/board.yml
@@ -1,5 +1,5 @@
 board:
   name: rzt2m_starter_kit
-  vendor: Renesas
+  vendor: renesas
   socs:
   - name: renesas_rzt2m

--- a/boards/ruuvi/ruuvi_ruuvitag/board.yml
+++ b/boards/ruuvi/ruuvi_ruuvitag/board.yml
@@ -1,5 +1,5 @@
 board:
   name: ruuvi_ruuvitag
-  vendor: Ruuvi
+  vendor: ruuvi
   socs:
   - name: nrf52832

--- a/boards/seeed_studio/lora_e5_dev_board/board.yml
+++ b/boards/seeed_studio/lora_e5_dev_board/board.yml
@@ -1,5 +1,5 @@
 board:
   name: lora_e5_dev_board
-  vendor: seeed studio
+  vendor: seeed
   socs:
     - name: stm32wle5xx

--- a/boards/seeed_studio/lora_e5_mini/board.yml
+++ b/boards/seeed_studio/lora_e5_mini/board.yml
@@ -1,5 +1,5 @@
 board:
   name: lora_e5_mini
-  vendor: seeed studio
+  vendor: seeed
   socs:
     - name: stm32wle5xx

--- a/boards/seeed_studio/wio_terminal/board.yml
+++ b/boards/seeed_studio/wio_terminal/board.yml
@@ -1,5 +1,5 @@
 board:
   name: wio_terminal
-  vendor: Seeed Studio
+  vendor: seeed
   socs:
     - name: samd51p19a

--- a/boards/seeed_studio/xiao_ble/board.yml
+++ b/boards/seeed_studio/xiao_ble/board.yml
@@ -1,6 +1,6 @@
 board:
   name: xiao_ble
-  vendor: Seeed Studio
+  vendor: seeed
   socs:
   - name: nrf52840
     variants:

--- a/boards/sipeed/longan_nano/board.yml
+++ b/boards/sipeed/longan_nano/board.yml
@@ -1,6 +1,6 @@
 board:
   name: longan_nano
-  vendor: Sipeed
+  vendor: sipeed
   socs:
     - name: gd32vf103
       variants:

--- a/boards/space_cubics/scobc_module1/board.yml
+++ b/boards/space_cubics/scobc_module1/board.yml
@@ -1,5 +1,5 @@
 board:
   name: scobc_module1
-  vendor: Space Cubics
+  vendor: spacecubics
   socs:
   - name: designstart_fpga_cortex_m3

--- a/boards/sparkfun/nrf52_sparkfun/board.yml
+++ b/boards/sparkfun/nrf52_sparkfun/board.yml
@@ -1,5 +1,5 @@
 board:
   name: nrf52_sparkfun
-  vendor: SparkFun Electronics
+  vendor: sparkfun
   socs:
   - name: nrf52832

--- a/boards/sparkfun/sparkfun_pro_micro_rp2040/board.yml
+++ b/boards/sparkfun/sparkfun_pro_micro_rp2040/board.yml
@@ -1,5 +1,5 @@
 board:
   name: sparkfun_pro_micro_rp2040
-  vendor: SparkFun Electronics
+  vendor: sparkfun
   socs:
   - name: rp2040

--- a/boards/sparkfun/sparkfun_red_v_things_plus/board.yml
+++ b/boards/sparkfun/sparkfun_red_v_things_plus/board.yml
@@ -1,5 +1,5 @@
 board:
   name: sparkfun_red_v_things_plus
-  vendor: SparkFun Electronics
+  vendor: sparkfun
   socs:
     - name: fe310

--- a/boards/sparkfun/sparkfun_thing_plus/board.yml
+++ b/boards/sparkfun/sparkfun_thing_plus/board.yml
@@ -1,6 +1,6 @@
 board:
   name: sparkfun_thing_plus
-  vendor: SparkFun Electronics
+  vendor: sparkfun
   socs:
   - name: nrf9160
     variants:

--- a/boards/synopsys/em_starterkit/board.yml
+++ b/boards/synopsys/em_starterkit/board.yml
@@ -1,6 +1,6 @@
 board:
   name: em_starterkit
-  vendor: Synopsys
+  vendor: snps
   socs:
   - name: emsk_em7d
   - name: emsk_em9d

--- a/boards/synopsys/emsdp/board.yml
+++ b/boards/synopsys/emsdp/board.yml
@@ -1,6 +1,6 @@
 board:
   name: emsdp
-  vendor: Synopsys
+  vendor: snps
   socs:
   - name: emsdp_em4
   - name: emsdp_em5d

--- a/boards/synopsys/hsdk/board.yml
+++ b/boards/synopsys/hsdk/board.yml
@@ -1,6 +1,6 @@
 board:
   name: hsdk
-  vendor: Synopsys
+  vendor: snps
   socs:
   - name: arc_hsdk
     variants:

--- a/boards/synopsys/hsdk4xd/board.yml
+++ b/boards/synopsys/hsdk4xd/board.yml
@@ -1,5 +1,5 @@
 board:
   name: hsdk4xd
-  vendor: Synopsys
+  vendor: snps
   socs:
   - name: arc_hsdk4xd

--- a/boards/synopsys/iotdk/board.yml
+++ b/boards/synopsys/iotdk/board.yml
@@ -1,5 +1,5 @@
 board:
   name: iotdk
-  vendor: Synopsys
+  vendor: snps
   socs:
   - name: arc_iot

--- a/boards/synopsys/nsim/board.yml
+++ b/boards/synopsys/nsim/board.yml
@@ -1,6 +1,6 @@
 board:
   name: nsim
-  vendor: Synopsys
+  vendor: snps
   socs:
   - name: nsim_em
   - name: nsim_em7d_v22

--- a/boards/ti/cc1352p1_launchxl/board.yml
+++ b/boards/ti/cc1352p1_launchxl/board.yml
@@ -1,5 +1,5 @@
 board:
   name: cc1352p1_launchxl
-  vendor: Texas Instruments
+  vendor: ti
   socs:
   - name: cc1352p

--- a/boards/ti/cc1352r1_launchxl/board.yml
+++ b/boards/ti/cc1352r1_launchxl/board.yml
@@ -1,5 +1,5 @@
 board:
   name: cc1352r1_launchxl
-  vendor: Texas Instruments
+  vendor: ti
   socs:
   - name: cc1352r

--- a/boards/ti/cc1352r_sensortag/board.yml
+++ b/boards/ti/cc1352r_sensortag/board.yml
@@ -1,5 +1,5 @@
 board:
   name: cc1352r_sensortag
-  vendor: Texas Instruments
+  vendor: ti
   socs:
   - name: cc1352r

--- a/boards/ti/cc26x2r1_launchxl/board.yml
+++ b/boards/ti/cc26x2r1_launchxl/board.yml
@@ -1,5 +1,5 @@
 board:
   name: cc26x2r1_launchxl
-  vendor: Texas Instruments
+  vendor: ti
   socs:
   - name: cc2652r

--- a/boards/ti/cc3220sf_launchxl/board.yml
+++ b/boards/ti/cc3220sf_launchxl/board.yml
@@ -1,5 +1,5 @@
 board:
   name: cc3220sf_launchxl
-  vendor: Texas Instruments
+  vendor: ti
   socs:
   - name: cc3220sf

--- a/boards/ti/cc3235sf_launchxl/board.yml
+++ b/boards/ti/cc3235sf_launchxl/board.yml
@@ -1,5 +1,5 @@
 board:
   name: cc3235sf_launchxl
-  vendor: Texas Instruments
+  vendor: ti
   socs:
   - name: cc3235sf

--- a/boards/ti/msp_exp432p401r_launchxl/board.yml
+++ b/boards/ti/msp_exp432p401r_launchxl/board.yml
@@ -1,5 +1,5 @@
 board:
   name: msp_exp432p401r_launchxl
-  vendor: Texas Instruments
+  vendor: ti
   socs:
   - name: msp432p401r

--- a/boards/ti/sk_am62/board.yml
+++ b/boards/ti/sk_am62/board.yml
@@ -1,5 +1,5 @@
 board:
   name: sk_am62
-  vendor: Texas Instruments
+  vendor: ti
   socs:
   - name: am6234

--- a/boards/ublox/ubx_bmd300eval/board.yml
+++ b/boards/ublox/ubx_bmd300eval/board.yml
@@ -1,5 +1,5 @@
 board:
   name: ubx_bmd300eval
-  vendor: U-blox
+  vendor: u-blox
   socs:
   - name: nrf52832

--- a/boards/ublox/ubx_bmd330eval/board.yml
+++ b/boards/ublox/ubx_bmd330eval/board.yml
@@ -1,5 +1,5 @@
 board:
   name: ubx_bmd330eval
-  vendor: U-blox
+  vendor: u-blox
   socs:
   - name: nrf52810

--- a/boards/ublox/ubx_bmd340eval/board.yml
+++ b/boards/ublox/ubx_bmd340eval/board.yml
@@ -1,5 +1,5 @@
 board:
   name: ubx_bmd340eval
-  vendor: U-blox
+  vendor: u-blox
   socs:
   - name: nrf52840

--- a/boards/ublox/ubx_bmd345eval/board.yml
+++ b/boards/ublox/ubx_bmd345eval/board.yml
@@ -1,5 +1,5 @@
 board:
   name: ubx_bmd345eval
-  vendor: U-blox
+  vendor: u-blox
   socs:
   - name: nrf52840

--- a/boards/ublox/ubx_bmd360eval/board.yml
+++ b/boards/ublox/ubx_bmd360eval/board.yml
@@ -1,5 +1,5 @@
 board:
   name: ubx_bmd360eval
-  vendor: U-blox
+  vendor: u-blox
   socs:
   - name: nrf52811

--- a/boards/ublox/ubx_bmd380eval/board.yml
+++ b/boards/ublox/ubx_bmd380eval/board.yml
@@ -1,5 +1,5 @@
 board:
   name: ubx_bmd380eval
-  vendor: U-blox
+  vendor: u-blox
   socs:
   - name: nrf52840

--- a/boards/ublox/ubx_evkannab1/board.yml
+++ b/boards/ublox/ubx_evkannab1/board.yml
@@ -1,5 +1,5 @@
 board:
   name: ubx_evkannab1
-  vendor: U-blox
+  vendor: u-blox
   socs:
   - name: nrf52832

--- a/boards/ublox/ubx_evkninab1/board.yml
+++ b/boards/ublox/ubx_evkninab1/board.yml
@@ -1,5 +1,5 @@
 board:
   name: ubx_evkninab1
-  vendor: U-blox
+  vendor: u-blox
   socs:
   - name: nrf52832

--- a/boards/ublox/ubx_evkninab3/board.yml
+++ b/boards/ublox/ubx_evkninab3/board.yml
@@ -1,5 +1,5 @@
 board:
   name: ubx_evkninab3
-  vendor: U-blox
+  vendor: u-blox
   socs:
   - name: nrf52840

--- a/boards/ublox/ubx_evkninab4/board.yml
+++ b/boards/ublox/ubx_evkninab4/board.yml
@@ -1,5 +1,5 @@
 board:
   name: ubx_evkninab4
-  vendor: U-blox
+  vendor: u-blox
   socs:
   - name: nrf52833

--- a/boards/vng/nrf51_vbluno51/board.yml
+++ b/boards/vng/nrf51_vbluno51/board.yml
@@ -1,5 +1,5 @@
 board:
   name: nrf51_vbluno51
-  vendor: VNG Corporation
+  vendor: vngiotlab
   socs:
   - name: nrf51822

--- a/boards/vng/nrf52_vbluno52/board.yml
+++ b/boards/vng/nrf52_vbluno52/board.yml
@@ -1,5 +1,5 @@
 board:
   name: nrf52_vbluno52
-  vendor: VNG Corporation
+  vendor: vngiotlab
   socs:
   - name: nrf52832

--- a/boards/waveshare/nrf51_ble400/board.yml
+++ b/boards/waveshare/nrf51_ble400/board.yml
@@ -1,5 +1,5 @@
 board:
   name: nrf51_ble400
-  vendor: Waveshare
+  vendor: waveshare
   socs:
   - name: nrf51822

--- a/boards/wiznet/w5500_evb_pico/board.yml
+++ b/boards/wiznet/w5500_evb_pico/board.yml
@@ -1,5 +1,5 @@
 board:
   name: w5500_evb_pico
-  vendor: WIZnet
+  vendor: wiznet
   socs:
   - name: rp2040

--- a/boards/wurth_elektronik/we_ophelia1ev/board.yml
+++ b/boards/wurth_elektronik/we_ophelia1ev/board.yml
@@ -1,5 +1,5 @@
 board:
   name: we_ophelia1ev
-  vendor: Würth Elektronik
+  vendor: wurth
   socs:
   - name: nrf52805

--- a/boards/wurth_elektronik/we_proteus2ev/board.yml
+++ b/boards/wurth_elektronik/we_proteus2ev/board.yml
@@ -1,5 +1,5 @@
 board:
   name: we_proteus2ev
-  vendor: Würth Elektronik
+  vendor: wurth
   socs:
   - name: nrf52832

--- a/boards/wurth_elektronik/we_proteus3ev/board.yml
+++ b/boards/wurth_elektronik/we_proteus3ev/board.yml
@@ -1,5 +1,5 @@
 board:
   name: we_proteus3ev
-  vendor: Würth Elektronik
+  vendor: wurth
   socs:
   - name: nrf52840

--- a/boards/xen/xenvm/board.yml
+++ b/boards/xen/xenvm/board.yml
@@ -1,6 +1,6 @@
 board:
   name: xenvm
-  vendor: Xen
+  vendor: xen
   socs:
   - name: xenvm
     variants:

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -232,7 +232,7 @@ gd	GigaDevice Semiconductor
 ge	General Electric Company
 geekbuying	GeekBuying
 gef	GE Fanuc Intelligent Platforms Embedded Systems, Inc.
-GEFanuc	GE Fanuc Intelligent Platforms Embedded Systems, Inc.
+gefanuc	GE Fanuc Intelligent Platforms Embedded Systems, Inc.
 gemei	Gemei Digital Technology Co., Ltd.
 geniatech	Geniatech, Inc.
 giantec	Giantec Semiconductor, Inc.
@@ -453,7 +453,7 @@ openrisc	OpenRISC.io
 openthread	OpenThread.io
 option	Option NV
 oranth	Shenzhen Oranth Technology Co., Ltd.
-ORCL	Oracle Corporation
+orcl	Oracle Corporation
 orisetech	Orise Technology
 ortustech	Ortus Technology Co., Ltd.
 osddisplays	OSD Displays
@@ -598,7 +598,7 @@ stericsson	ST-Ericsson
 st-ericsson	ST-Ericsson
 summit	Summit microelectronics
 sunchip	Shenzhen Sunchip Technology Co., Ltd
-SUNW	Sun Microsystems, Inc
+sunw	Sun Microsystems, Inc
 supermicro	Super Micro Computer, Inc.
 silvaco	Silvaco, Inc.
 swir	Sierra Wireless

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -17,9 +17,9 @@ abracon	Abracon Corporation
 abt	ShenZhen Asia Better Technology Ltd.
 acer	Acer Inc.
 acme	Acme Systems srl
+actinius	Actinius B.V.
 actions	Actions Semiconductor Co., Ltd.
 active-semi	Active-Semi International Inc
-actinius	Actinius B.V.
 ad	Avionic Design GmbH
 adafruit	Adafruit Industries, LLC
 adapteva	Adapteva, Inc.
@@ -38,9 +38,9 @@ alphascale	AlphaScale Integrated Circuits Systems, Inc.
 alps	Alps Electric Co., Ltd.
 alt	Altus-Escon-Company BV
 altr	Altera Corp.
-ambiq	Ambiq Micro, Inc.
 amarula	Amarula Solutions
 amazon	Amazon.com, Inc.
+ambiq	Ambiq Micro, Inc.
 amcc	Applied Micro Circuits Corporation (APM, formally AMCC)
 amd	Advanced Micro Devices (AMD), Inc.
 amediatech	Shenzhen Amediatech Technology Co., Ltd
@@ -58,8 +58,8 @@ apm	Applied Micro Circuits Corporation (APM)
 apple	Apple Inc.
 aptina	Aptina Imaging
 arasan	Arasan Chip Systems
-archermind	ArcherMind Technology (Nanjing) Co., Ltd.
 arc	Synopsys, Inc. (formerly ARC International PLC)
+archermind	ArcherMind Technology (Nanjing) Co., Ltd.
 arctic	Arctic Sand
 arcx	arcx Inc. / Archronix Inc.
 arduino	Arduino
@@ -69,8 +69,8 @@ armadeus	ARMadeus Systems SARL
 arrow	Arrow Electronics
 artesyn	Artesyn Embedded Technologies Inc.
 asahi-kasei	Asahi Kasei Corp.
-asmedia	ASMedia Technology Inc.
 asc	All Sensors Corporation
+asmedia	ASMedia Technology Inc.
 aspeed	ASPEED Technology Inc.
 asus	AsusTek Computer Inc.
 atlas	Atlas Scientific LLC
@@ -97,11 +97,11 @@ blutek	BluTek Power
 boe	BOE Technology Group Co., Ltd.
 bosch	Bosch Sensortec GmbH
 boundary	Boundary Devices Inc.
-broadmobi	Shanghai Broadmobi Communication Technology Co.,Ltd.
 brcm	Broadcom Corporation
+broadmobi	Shanghai Broadmobi Communication Technology Co.,Ltd.
+bticino	Bticino International
 buffalo	Buffalo, Inc.
 bur	B&R Industrial Automation GmbH
-bticino	Bticino International
 calaosystems	CALAO Systems SAS
 calxeda	Calxeda
 canaan	Canaan, Inc.
@@ -259,13 +259,13 @@ hisilicon	Hisilicon Limited.
 hit	Hitachi Ltd.
 hitex	Hitex Development Tools
 holt	Holt Integrated Circuits, Inc.
+holtek	Holtek Semiconductor, Inc.
 honestar	Honestar Technologies Co., Ltd.
 honeywell	Honeywell
 hoperf	HOPERF Microelectronics Co. Ltd
 hoperun	Jiangsu HopeRun Software Co., Ltd.
 hp	Hewlett Packard
 hsg	HannStar Display Co.
-holtek	Holtek Semiconductor, Inc.
 hugsun	Shenzhen Hugsun Technology Co. Ltd.
 hwacom	HwaCom Systems Inc.
 hycon	Hycon Technology Corp.
@@ -285,8 +285,6 @@ incircuit	In-Circuit GmbH
 inet-tek	Shenzhen iNet Mobile Internet Technology Co., Ltd
 infineon	Infineon Technologies
 inforce	Inforce Computing
-inventek	Inventek Systems
-ivo	InfoVision Optoelectronics Kunshan Co. Ltd.
 ingenic	Ingenic Semiconductor
 innolux	Innolux Corporation
 inside-secure	INSIDE Secure
@@ -294,6 +292,7 @@ inspur	Inspur Corporation
 intel	Intel Corporation
 intercontrol	Inter Control Group
 invensense	InvenSense Inc.
+inventek	Inventek Systems
 inversepath	Inverse Path
 iom	Iomega Corporation
 isee	ISEE 2007 S.L.
@@ -302,12 +301,13 @@ isil	Intersil
 issi	Integrated Silicon Solutions Inc.
 ite	ITE Tech. Inc.
 itead	ITEAD Intelligent Systems Co.Ltd
+ivo	InfoVision Optoelectronics Kunshan Co. Ltd.
 iwave	iWave Systems Technologies Pvt. Ltd.
 jdi	Japan Display Inc.
 jedec	JEDEC Solid State Technology Association
 jesurun	Shenzhen Jesurun Electronics Business Dept.
-jianda	Jiandangjing Technology Co., Ltd.
 jhd	Shenzhen Jinghua Displays Electronics Co., Ltd.
+jianda	Jiandangjing Technology Co., Ltd.
 kam	Kamstrup A/S
 karo	Ka-Ro electronics GmbH
 keithkoep	Keith & Koep GmbH
@@ -420,9 +420,9 @@ netron-dy	Netron DY
 netronix	Netronix, Inc.
 netxeon	Shenzhen Netxeon Technology CO., LTD
 neweast	Guangdong Neweast Optoelectronics CO., LTD
+newhaven	Newhaven Display International
 nexbox	Nexbox
 nextthing	Next Thing Co.
-newhaven	Newhaven Display International
 ni	National Instruments
 nintendo	Nintendo
 nlt	NLT Technologies, Ltd.
@@ -430,8 +430,8 @@ nokia	Nokia
 nordic	Nordic Semiconductor
 noritake	Noritake Co., Inc. Electronics Division
 novtech	NovTech, Inc.
-nutsboard	NutsBoard
 nuclei	Nuclei System Technology
+nutsboard	NutsBoard
 nuvoton	Nuvoton Technology Corporation
 nvd	New Vision Display
 nvidia	NVIDIA
@@ -442,7 +442,6 @@ okaya	Okaya Electric America, Inc.
 oki	Oki Electric Industry Co., Ltd.
 olimex	OLIMEX Ltd.
 olpc	One Laptop Per Child
-ovti	OmniVision Technologies Co., Ltd.
 onion	Onion Corporation
 onnn	ON Semiconductor Corp.
 ontat	On Tat Industrial Company
@@ -460,12 +459,13 @@ osddisplays	OSD Displays
 ouya	Ouya Inc.
 overkiz	Overkiz SAS
 ovti	OmniVision Technologies
+ovti	OmniVision Technologies Co., Ltd.
 oxsemi	Oxford Semiconductor, Ltd.
 ozzmaker	OzzMaker
 panasonic	Panasonic Corporation
 parade	Parade Technologies Inc.
-particle	Particle.io
 parallax	Parallax Inc.
+particle	Particle.io
 pda	Precision Design Associates, Inc.
 pericom	Pericom Technology Inc.
 pervasive	Pervasive Displays, Inc.
@@ -498,8 +498,8 @@ qca	Qualcomm Atheros, Inc.
 qcom	Qualcomm Technologies, Inc
 qemu	QEMU, a generic and open source machine emulator and virtualizer
 qi	Qi Hardware
-qihua	Chengdu Kaixuan Information Technology Co., Ltd.
 qiaodian	QiaoDian XianShi Corporation
+qihua	Chengdu Kaixuan Information Technology Co., Ltd.
 qnap	QNAP Systems, Inc.
 qorvo	Qorvo, Inc.
 quectel	Quectel Wireless Solutions Co., Ltd.
@@ -515,21 +515,21 @@ realtek	Realtek Semiconductor Corp.
 remarkable	reMarkable AS
 renesas	Renesas Electronics Corporation
 renode	Antmicro's open source simulation and virtual development framework
-rex	iMX6 Rex Project
 rervision	Shenzhen Rervision Technology Co., Ltd.
 revotics	Revolution Robotics, Inc. (Revotics)
+rex	iMX6 Rex Project
 richtek	Richtek Technology Corporation
 ricoh	Ricoh Co. Ltd.
 rikomagic	Rikomagic Tech Corp. Ltd
-riscv	RISC-V Foundation
 riot	Embest RIoT
+riscv	RISC-V Foundation
 rockchip	Fuzhou Rockchip Electronics Co., Ltd
 rocktech	ROCKTECH DISPLAYS LIMITED
 rohm	ROHM Semiconductor Co., Ltd
 ronbo	Ronbo Electronics
 roofull	Shenzhen Roofull Technology Co, Ltd
-ruuvi	Ruuvi Innovations Ltd (Oy)
 roseapplepi	RoseapplePi.org
+ruuvi	Ruuvi Innovations Ltd (Oy)
 samsung	Samsung Semiconductor
 samtec	Samtec/Softing company
 sancloud	Sancloud Ltd
@@ -539,8 +539,8 @@ sbs	Smart Battery System
 sc	Space Cubics, LLC
 schindler	Schindler
 seagate	Seagate Technology PLC
-segger	SEGGER Microcontroller GmbH
 seeed	Seeed Technology Co., Ltd
+segger	SEGGER Microcontroller GmbH
 seirobotics	Shenzhen SEI Robotics Co., Ltd
 semtech	Semtech Corporation
 sensirion	Sensirion AG
@@ -554,6 +554,7 @@ shimafuji	Shimafuji Electric, Inc.
 shiratech	Shiratech Solutions
 si-en	Si-En Technology Ltd.
 si-linux	Silicon Linux Corporation
+siemens	Siemens AG
 sifive	SiFive, Inc.
 sigma	Sigma Designs, Inc.
 sii	Seiko Instruments, Inc.
@@ -564,7 +565,7 @@ silergy	Silergy Corp.
 silex-insight	Silex Insight
 siliconfile	Siliconfile Technologies lnc.
 siliconmitus	Silicon Mitus, Inc.
-siemens	Siemens AG
+silvaco	Silvaco, Inc.
 simcom	SIMCom Wireless Solutions Co., LTD
 simtek	Cypress Semiconductor Corporation (Simtek Corporation)
 sinlinx	Sinlinx Electronics Technology Co., LTD
@@ -578,7 +579,6 @@ skyworks	Skyworks Solutions, Inc.
 smartlabs	SmartLabs LLC
 smsc	Standard Microsystems Corporation
 snps	Synopsys, Inc.
-starfive	StarFive Technology Co. Ltd.
 sochip	Shenzhen SoChip Technology Co., Ltd.
 socionext	Socionext Inc.
 solidrun	SolidRun
@@ -591,16 +591,16 @@ sqn	Sequans Communications
 sst	Silicon Storage Technology, Inc.
 sstar	Xiamen Xingchen(SigmaStar) Technology Co., Ltd. (formerly part of MStar Semiconductor, Inc.)
 st	STMicroelectronics
+st-ericsson	ST-Ericsson
+starfive	StarFive Technology Co. Ltd.
 starry	Starry Electronic Technology (ShenZhen) Co., LTD
 startek	Startek
 ste	ST-Ericsson
 stericsson	ST-Ericsson
-st-ericsson	ST-Ericsson
 summit	Summit microelectronics
 sunchip	Shenzhen Sunchip Technology Co., Ltd
 sunw	Sun Microsystems, Inc
 supermicro	Super Micro Computer, Inc.
-silvaco	Silvaco, Inc.
 swir	Sierra Wireless
 syna	Synaptics Inc.
 synology	Synology, Inc.
@@ -613,10 +613,10 @@ tdk	TDK Corporation.
 tdo	Shangai Top Display Optoelectronics Co., Ltd
 technexion	TechNexion
 technologic	Technologic Systems
+techstar	Shenzhen Techstar Electronics Co., Ltd.
 telink	Telink Semiconductor
 telit	Telit Cinterion
 tempo	Tempo Semiconductor
-techstar	Shenzhen Techstar Electronics Co., Ltd.
 terasic	Terasic Inc.
 tfc	Three Five Corp
 thine	THine Electronics, Inc.
@@ -639,13 +639,12 @@ tq	TQ-Systems GmbH
 tronfy	Tronfy
 tronsmart	Tronsmart
 truly	Truly Semiconductors Limited
-visionox	Visionox
 tsd	Theobroma Systems Design und Consulting GmbH
 tyan	Tyan Computer Corporation
 u-blox	u-blox
 u-boot	U-Boot bootloader
-ucrobotics	uCRobotics
 ubnt	Ubiquiti Networks
+ucrobotics	uCRobotics
 udoo	Udoo
 ugoos	Ugoos Industrial Co., Ltd.
 ultrachip	UltraChip Inc.
@@ -664,6 +663,7 @@ videostrong	Videostrong Technology Co., Ltd.
 virtio	Virtual I/O Device Specification, developed by the OASIS consortium
 virtual	Used for virtual device without specific vendor.
 vishay	Vishay Intertechnology, Inc
+visionox	Visionox
 vitesse	Vitesse Semiconductor Corporation
 vivante	Vivante Corporation
 vnd	A stand-in for a real vendor which can be used in examples and tests
@@ -712,8 +712,8 @@ yna	YSH & ATIL
 yones-toptech	Yones Toptech Co., Ltd.
 ys	Shenzhen Yashi Changhua Intelligent Technology Co., Ltd.
 ysoft	Y Soft Corporation a.s.
-zealz	Zealz
 zarlink	Zarlink Semiconductor
+zealz	Zealz
 zeitec	ZEITEC Semiconductor Co., LTD.
 zephyr	Zephyr-specific binding
 zidoo	Shenzhen Zidoo Technology Co., Ltd.

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -11,6 +11,7 @@
 # <vendor-prefix><TAB><Full name of vendor>
 
 # zephyr-keep-sorted-start
+96boards	96Boards
 aaeon	AAEON Technology Inc.
 abb	ABB
 abilis	Abilis Systems
@@ -18,6 +19,7 @@ abracon	Abracon Corporation
 abt	ShenZhen Asia Better Technology Ltd.
 acer	Acer Inc.
 acme	Acme Systems srl
+aconno	aconno GmbH
 actinius	Actinius B.V.
 actions	Actions Semiconductor Co., Ltd.
 active-semi	Active-Semi International Inc
@@ -32,6 +34,7 @@ aeroflexgaisler	Aeroflex Gaisler AB
 aesop	AESOP Embedded Forum
 al	Annapurna Labs
 alcatel	Alcatel
+alientek	Alientek
 allegro	Allegro DVT
 allo	Allo.com
 allwinner	Allwinner Technology Co., Ltd.
@@ -75,6 +78,7 @@ asmedia	ASMedia Technology Inc.
 aspeed	ASPEED Technology Inc.
 asus	AsusTek Computer Inc.
 atlas	Atlas Scientific LLC
+atmarktechno	Atmark Techno, Inc.
 atmel	Atmel Corporation
 auo	AU Optronics Corporation
 auvidea	Auvidea GmbH
@@ -89,6 +93,8 @@ azoteq	Azoteq (Pty) Ltd
 azw	Shenzhen AZW Technology Co., Ltd.
 baikal	BAIKAL ELECTRONICS, JSC
 bananapi	BIPAI KEJI LIMITED
+bbc	BBC
+bcdevices	Blue Clover Devices
 beacon	Compass Electronics Group, LLC
 beagle	BeagleBoard.org Foundation
 bhf	Beckhoff Automation GmbH & Co. KG
@@ -125,6 +131,7 @@ chrp	Common Hardware Reference Platform
 chunghwa	Chunghwa Picture Tubes Ltd.
 chuwi	Chuwi Innovation Ltd.
 ciaa	Computadora Industrial Abierta Argentina
+circuitdojo	Circuit Dojo
 cirrus	Cirrus Logic, Inc.
 cisco	Cisco Systems, Inc.
 cloudengines	Cloud Engines, Inc.
@@ -132,6 +139,7 @@ cnm	Chips&Media, Inc.
 cnxt	Conexant Systems, Inc.
 colorfly	Colorful GRP, Shenzhen Xueyushi Technology Ltd.
 compulab	CompuLab Ltd.
+contextualelectronics	Contextual Electronics
 coreriver	CORERIVER Semiconductor Co.,Ltd.
 corpro	Chengdu Corpro Technology Co., Ltd.
 cortina	Cortina Systems, Inc.
@@ -174,12 +182,14 @@ ea	Embedded Artists AB
 ebang	Zhejiang Ebang Communication Co., Ltd
 ebs-systart	EBS-SYSTART GmbH
 ebv	EBV Elektronik
+ebyte	Chengdu Ebyte Electronic Technology
 eckelmann	Eckelmann AG
 edt	Emerging Display Technologies
 eeti	eGalax_eMPIA Technology Inc
 efinix	Efinix Inc
 einfochips	Einfochips
 elan	Elan Microelectronic Corp.
+electronut	Electronut Labs
 element14	Element14 (A Premier Farnell Company)
 elgin	Elgin S/A.
 elida	Shenzhen Elida Technology Co., Ltd.
@@ -189,6 +199,7 @@ emlid	Emlid, Ltd.
 emmicro	EM Microelectronic
 empire-electronix	Empire Electronix
 emtrion	emtrion GmbH
+enclustra	Enclustra
 endless	Endless Mobile, Inc.
 ene	ENE Technology, Inc.
 energymicro	Silicon Laboratories (formerly Energy Micro AS)
@@ -261,6 +272,7 @@ hit	Hitachi Ltd.
 hitex	Hitex Development Tools
 holt	Holt Integrated Circuits, Inc.
 holtek	Holtek Semiconductor, Inc.
+holyiot	Shenzhen Holyiot Technology Co., Ltd.
 honestar	Honestar Technologies Co., Ltd.
 honeywell	Honeywell
 hoperf	HOPERF Microelectronics Co. Ltd
@@ -287,6 +299,7 @@ inet-tek	Shenzhen iNet Mobile Internet Technology Co., Ltd
 infineon	Infineon Technologies
 inforce	Inforce Computing
 ingenic	Ingenic Semiconductor
+innblue	innblue UG
 innolux	Innolux Corporation
 inside-secure	INSIDE Secure
 inspur	Inspur Corporation
@@ -362,6 +375,8 @@ lwn	Liebherr-Werk Nenzing GmbH
 lxa	Linux Automation GmbH
 m5stack	M5Stack
 macnica	Macnica Americas
+madmachine	Shenzhen FeiKaiTe Technology Co., Ltd.
+makerdiary	Shenzhen Zaowubang Technology Co., Ltd.
 mantix	Mantix Display Technology Co.,Ltd.
 mapleboard	Mapleboard.org
 marvell	Marvell Technology Group Ltd.
@@ -410,6 +425,7 @@ mti	Imagination Technologies Ltd. (formerly MIPS Technologies Inc.)
 multi-inno	Multi-Inno Technology Co.,Ltd
 mundoreader	Mundo Reader S.L.
 murata	Murata Manufacturing Co., Ltd.
+mxchip	Shanghai MXCHIP Information Technology Co., Ltd.
 mxicy	Macronix International Co., Ltd.
 myir	MYIR Tech Limited
 national	National Semiconductor
@@ -476,6 +492,7 @@ picochip	Picochip Ltd
 pine64	Pine64
 pineriver	Shenzhen PineRiver Designs Co., Ltd.
 pixcir	PIXCIR MICROELECTRONICS Co., Ltd
+pjrc	PJRC
 plantower	Plantower Co., Ltd
 plathome	Plat'Home Co., Ltd.
 plda	PLDA
@@ -507,10 +524,12 @@ quectel	Quectel Wireless Solutions Co., Ltd.
 quicklogic	QuickLogic Corp.
 radxa	Radxa
 raidsonic	RaidSonic Technology GmbH
+rakwireless	RAKwireless Technology Limited
 ralink	Mediatek/Ralink Technology Corp.
 ramtron	Ramtron International
 raspberrypi	Raspberry Pi Foundation
 raydium	Raydium Semiconductor Corp.
+raytac	Raytac Corporation
 rda	Unisoc Communications, Inc.
 realtek	Realtek Semiconductor Corp.
 remarkable	reMarkable AS
@@ -528,6 +547,7 @@ rockchip	Fuzhou Rockchip Electronics Co., Ltd
 rocktech	ROCKTECH DISPLAYS LIMITED
 rohm	ROHM Semiconductor Co., Ltd
 ronbo	Ronbo Electronics
+ronoth	Ronoth
 roofull	Shenzhen Roofull Technology Co, Ltd
 roseapplepi	RoseapplePi.org
 ruuvi	Ruuvi Innovations Ltd (Oy)
@@ -540,6 +560,7 @@ sbs	Smart Battery System
 sc	Space Cubics, LLC
 schindler	Schindler
 seagate	Seagate Technology PLC
+seco	SECO S.p.A.
 seeed	Seeed Technology Co., Ltd
 segger	SEGGER Microcontroller GmbH
 seirobotics	Shenzhen SEI Robotics Co., Ltd
@@ -582,9 +603,11 @@ smsc	Standard Microsystems Corporation
 snps	Synopsys, Inc.
 sochip	Shenzhen SoChip Technology Co., Ltd.
 socionext	Socionext Inc.
+solderparty	Solder Party AB
 solidrun	SolidRun
 solomon	Solomon Systech Limited
 sony	Sony Corporation
+spacecubics	Space Cubics, LLC
 spansion	Spansion Inc.
 sparkfun	SparkFun Electronics
 sprd	Spreadtrum Communications Inc.
@@ -668,6 +691,7 @@ visionox	Visionox
 vitesse	Vitesse Semiconductor Corporation
 vivante	Vivante Corporation
 vnd	A stand-in for a real vendor which can be used in examples and tests
+vngiotlab	VNGIoTLab
 vocore	VoCore Studio
 voipac	Voipac Technologies s.r.o.
 vot	Vision Optical Technology Co., Ltd.
@@ -692,6 +716,7 @@ wnc	Wistron NeWeb Corporation
 wobo	Wobo
 wolfson	Cirrus Logic, Inc. (formerly Wolfson Microelectronics plc)
 worldsemi	Worldsemi Co., Limited
+wurth	Wurth Elektronik
 x-powers	X-Powers
 xen	Xen Hypervisor
 xes	Extreme Engineering Solutions (X-ES)

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -10,6 +10,7 @@
 #
 # <vendor-prefix><TAB><Full name of vendor>
 
+# zephyr-keep-sorted-start
 aaeon	AAEON Technology Inc.
 abb	ABB
 abilis	Abilis Systems
@@ -722,3 +723,4 @@ zinitix	Zinitix Co., Ltd
 zkmagic	Shenzhen Zkmagic Technology Co., Ltd.
 zte	ZTE Corp.
 zyxel	ZyXEL Communications Corp.
+# zephyr-keep-sorted-stop


### PR DESCRIPTION
Sync up the board.yml vendor prefixes with the vendor prefixes file, add a CI check to ensure they stay in sync.