### PR TITLE
drivers: flash: rram: remove build assert preventing build with default config

### DIFF
--- a/drivers/flash/soc_flash_nrf_rram.c
+++ b/drivers/flash/soc_flash_nrf_rram.c
@@ -47,8 +47,7 @@ static struct k_sem sem_lock;
 #define WRITE_LINE_SIZE       16 /* In bytes, one line is 128 bits. */
 #define WRITE_BUFFER_MAX_SIZE (WRITE_BUFFER_SIZE * WRITE_LINE_SIZE)
 BUILD_ASSERT((PAGE_SIZE % (WRITE_LINE_SIZE) == 0), "erase-block-size must be a multiple of 16");
-BUILD_ASSERT((WRITE_BLOCK_SIZE_FROM_DT % (WRITE_LINE_SIZE) == 0),
-	     "if NRF_RRAM_WRITE_BUFFER_SIZE > 0, then write-block-size must be a multiple of 16");
+
 #else
 #define WRITE_BUFFER_ENABLE   0
 #define WRITE_BUFFER_SIZE     0


### PR DESCRIPTION
By default [CONFIG_NRF_RRAM_WRITE_BUFFER_SIZE is 32](https://github.com/zephyrproject-rtos/zephyr/blob/main/drivers/flash/Kconfig.nrf_rram#L24) and rram [write-block-size is 1](https://github.com/zephyrproject-rtos/zephyr/blob/main/dts/arm/nordic/nrf54l_common.dtsi#L21) The build assert asserts the write-block-size is a multiple of 16 and is done if the WRITE_BUFFER_SIZE > 0 which is the case by default so the default config will not compile