### PR TITLE
net: sockets: tls: Return an error on send() after session is closed 

### DIFF
--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -2260,7 +2260,8 @@ static ssize_t send_tls(struct tls_context *ctx, const void *buf,
 	}
 
 	if (ctx->session_closed) {
-		return 0;
+		errno = ECONNABORTED;
+		return -1;
 	}
 
 	if (!is_block) {


### PR DESCRIPTION
It was an overlook to return 0 on TLS send() call, after detecting that TLS session has been closed by peer, such a behavior is only valid for recv(). Instead, an error should be returned.