### PR TITLE
crypto: Add support for ECB to the TinyCrypt shim

### DIFF
--- a/samples/drivers/crypto/sample.yaml
+++ b/samples/drivers/crypto/sample.yaml
@@ -17,9 +17,12 @@ tests:
       type: multi_line
       regex:
         - ".*: Cipher Sample"
-        - ".*: CBC Mode"
-        - ".*: CTR Mode"
-        - ".*: CCM Mode"
+        - ".*: CBC mode ENCRYPT - Match"
+        - ".*: CBC mode DECRYPT - Match"
+        - ".*: CTR mode ENCRYPT - Match"
+        - ".*: CTR mode DECRYPT - Match"
+        - ".*: CCM mode ENCRYPT - Match"
+        - ".*: CCM mode DECRYPT - Match"
         - ".*: GCM Mode"
   sample.drivers.crypto.mbedtls:
     min_flash: 34
@@ -31,10 +34,15 @@ tests:
       type: multi_line
       regex:
         - ".*: Cipher Sample"
-        - ".*: CBC Mode"
+        - ".*: ECB mode ENCRYPT - Match"
+        - ".*: ECB mode DECRYPT - Match"
+        - ".*: CBC mode ENCRYPT - Match"
+        - ".*: CBC mode DECRYPT - Match"
         - ".*: CTR Mode"
-        - ".*: CCM Mode"
-        - ".*: GCM Mode"
+        - ".*: CCM mode ENCRYPT - Match"
+        - ".*: CCM mode DECRYPT - Match"
+        - ".*: GCM mode ENCRYPT - Match"
+        - ".*: GCM mode DECRYPT - Match"
   sample.drivers.crypto.stm32:
     tags: crypto
     filter: dt_compat_enabled("st,stm32-aes") or dt_compat_enabled("st,stm32-cryp")

--- a/samples/drivers/crypto/sample.yaml
+++ b/samples/drivers/crypto/sample.yaml
@@ -17,6 +17,8 @@ tests:
       type: multi_line
       regex:
         - ".*: Cipher Sample"
+        - ".*: ECB mode ENCRYPT - Match"
+        - ".*: ECB mode DECRYPT - Match"
         - ".*: CBC mode ENCRYPT - Match"
         - ".*: CBC mode DECRYPT - Match"
         - ".*: CTR mode ENCRYPT - Match"


### PR DESCRIPTION
* Add support for ECB to the TinyCrypt shim
* Improve the test coverage slightly for both shims