### PR TITLE
boards: nrf54h20pdk_nrf54h20: add cpuapp/cpuppr shared memory

### DIFF
--- a/boards/arm/nrf54h20pdk_nrf54h20/nrf54h20pdk_nrf54h20-ipc_conf.dtsi
+++ b/boards/arm/nrf54h20pdk_nrf54h20/nrf54h20pdk_nrf54h20-ipc_conf.dtsi
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	ipc {
+		cpusec_cpuapp_ipc: ipc-1-2 {
+			compatible = "zephyr,ipc-icmsg";
+			status = "disabled";
+			mboxes = <&cpusec_bellboard 12>,
+				 <&cpuapp_bellboard 0>;
+		};
+
+		cpusec_cpurad_ipc: ipc-1-3 {
+			compatible = "zephyr,ipc-icmsg";
+			status = "disabled";
+			mboxes = <&cpusec_bellboard 18>,
+				 <&cpurad_bellboard 0>;
+		};
+
+		cpuapp_cpurad_ipc: ipc-2-3 {
+			status = "disabled";
+			mboxes = <&cpuapp_bellboard 18>,
+				 <&cpurad_bellboard 12>;
+		};
+
+		cpuapp_cpuppr_ipc: ipc-2-13 {
+			compatible = "zephyr,ipc-icmsg";
+			status = "disabled";
+			mboxes = <&cpuapp_bellboard 13>,
+				 <&cpuppr_vevif 12>;
+		};
+	};
+};

--- a/boards/arm/nrf54h20pdk_nrf54h20/nrf54h20pdk_nrf54h20-memory_map.dtsi
+++ b/boards/arm/nrf54h20pdk_nrf54h20/nrf54h20pdk_nrf54h20-memory_map.dtsi
@@ -6,6 +6,96 @@
 
 / {
 	reserved-memory {
+		cpuapp_ram0x_region: memory@2f000000 {
+			compatible = "nordic,owned-memory";
+			reg = <0x2f000000 DT_SIZE_K(260)>;
+			status = "disabled";
+			perm-read;
+			perm-write;
+			perm-secure;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x0 0x2f000000 0x41000>;
+
+			cpusec_cpuapp_ipc_shm: memory@0 {
+				reg = <0x0 DT_SIZE_K(2)>;
+			};
+
+			cpuapp_cpusec_ipc_shm: memory@800 {
+				reg = <0x800 DT_SIZE_K(2)>;
+			};
+
+			cpuapp_data: memory@1000 {
+				reg = <0x1000 DT_SIZE_K(256)>;
+			};
+		};
+
+		cpurad_ram0x_region: memory@2f041000 {
+			compatible = "nordic,owned-memory";
+			reg = <0x2f041000 DT_SIZE_K(4)>;
+			status = "disabled";
+			perm-read;
+			perm-write;
+			perm-secure;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x0 0x2f041000 0x1000>;
+
+			cpusec_cpurad_ipc_shm: memory@0 {
+				reg = <0x0 DT_SIZE_K(2)>;
+			};
+
+			cpurad_cpusec_ipc_shm: memory@800 {
+				reg = <0x800 DT_SIZE_K(2)>;
+			};
+		};
+
+		cpuapp_cpurad_ram0x_region: memory@2f0bf000 {
+			compatible = "nordic,owned-memory";
+			reg = <0x2f0bf000 DT_SIZE_K(4)>;
+			status = "disabled";
+			perm-read;
+			perm-write;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x0 0x2f0bf000 0x1000>;
+
+			cpuapp_cpurad_ipc_shm: memory@0 {
+				reg = <0x0 DT_SIZE_K(2)>;
+			};
+
+			cpurad_cpuapp_ipc_shm: memory@800 {
+				reg = <0x800 DT_SIZE_K(2)>;
+			};
+		};
+
+		shared_ram20_region: memory@2f88f000 {
+			compatible = "nordic,owned-memory";
+			reg = <0x2f88f000 DT_SIZE_K(4)>;
+			status = "disabled";
+			perm-read;
+			perm-write;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x0 0x2f88f000 0x1000>;
+
+			cpuapp_cpusys_ipc_shm: memory@ce0 {
+				reg = <0xce0 0x80>;
+			};
+
+			cpusys_cpuapp_ipc_shm: memory@d60 {
+				reg = <0xd60 0x80>;
+			};
+
+			cpurad_cpusys_ipc_shm: memory@e00 {
+				reg = <0xe00 0x80>;
+			};
+
+			cpusys_cpurad_ipc_shm: memory@e80 {
+				reg = <0xe80 0x80>;
+			};
+		};
+
 		cpuppr_ram3x_region: memory@2fc00000 {
 			compatible = "nordic,owned-memory";
 			reg = <0x2fc00000 DT_SIZE_K(28)>;
@@ -15,7 +105,7 @@
 			perm-execute;
 		};
 
-		ram3x_dma_region: memory@2fc07000 {
+		shared_ram3x_region: memory@2fc07000 {
 			compatible = "nordic,owned-memory";
 			reg = <0x2fc07000 DT_SIZE_K(4)>;
 			status = "disabled";
@@ -24,6 +114,14 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			ranges = <0x0 0x2fc07000 0x1000>;
+
+			cpuapp_cpuppr_ipc_shm: memory@0 {
+				reg = <0x0 0x340>;
+			};
+
+			cpuppr_cpuapp_ipc_shm: memory@340 {
+				reg = <0x340 0x340>;
+			};
 
 			cpuapp_dma_region: memory@680 {
 				compatible = "zephyr,memory-region";

--- a/boards/arm/nrf54h20pdk_nrf54h20/nrf54h20pdk_nrf54h20_cpuapp.dts
+++ b/boards/arm/nrf54h20pdk_nrf54h20/nrf54h20pdk_nrf54h20_cpuapp.dts
@@ -18,7 +18,7 @@
 		zephyr,console = &uart136;
 		zephyr,code-partition = &cpuapp_slot0_partition;
 		zephyr,flash = &mram1x;
-		zephyr,sram = &cpuapp_ram0;
+		zephyr,sram = &cpuapp_data;
 	};
 
 	aliases {
@@ -85,7 +85,7 @@
 	};
 };
 
-&ram3x_dma_region {
+&shared_ram3x_region {
 	status = "okay";
 };
 

--- a/boards/arm/nrf54h20pdk_nrf54h20/nrf54h20pdk_nrf54h20_cpuapp.dts
+++ b/boards/arm/nrf54h20pdk_nrf54h20/nrf54h20pdk_nrf54h20_cpuapp.dts
@@ -8,7 +8,10 @@
 
 #include <nordic/nrf54h20_enga_cpuapp.dtsi>
 #include "nrf54h20pdk_nrf54h20-memory_map.dtsi"
+#include "nrf54h20pdk_nrf54h20-ipc_conf.dtsi"
 #include "nrf54h20pdk_nrf54h20-pinctrl.dtsi"
+
+/delete-node/ &cpusec_cpurad_ipc;
 
 / {
 	compatible = "nordic,nrf54h20pdk_nrf54h20-cpuapp";
@@ -87,6 +90,30 @@
 
 &shared_ram3x_region {
 	status = "okay";
+};
+
+&cpuapp_bellboard {
+	/* irq0: 0: cpuapp-cpusec, 13: cpuapp-cpuppr, 18: cpuapp-cpurad */
+	nordic,interrupt-mapping = <0x00042001 0>;
+};
+
+&cpusec_cpuapp_ipc {
+	mbox-names = "tx", "rx";
+	tx-region = <&cpuapp_cpusec_ipc_shm>;
+	rx-region = <&cpusec_cpuapp_ipc_shm>;
+};
+
+&cpuapp_cpurad_ipc {
+	compatible = "zephyr,ipc-icmsg-me-initiator";
+	mbox-names = "rx", "tx";
+	tx-region = <&cpuapp_cpurad_ipc_shm>;
+	rx-region = <&cpurad_cpuapp_ipc_shm>;
+};
+
+&cpuapp_cpuppr_ipc {
+	mbox-names = "rx", "tx";
+	tx-region = <&cpuapp_cpuppr_ipc_shm>;
+	rx-region = <&cpuppr_cpuapp_ipc_shm>;
 };
 
 &cpuapp_dma_region {

--- a/boards/arm/nrf54h20pdk_nrf54h20/nrf54h20pdk_nrf54h20_cpurad.dts
+++ b/boards/arm/nrf54h20pdk_nrf54h20/nrf54h20pdk_nrf54h20_cpurad.dts
@@ -22,7 +22,7 @@
 	};
 };
 
-&ram3x_dma_region {
+&shared_ram3x_region {
 	status = "okay";
 };
 

--- a/boards/arm/nrf54h20pdk_nrf54h20/nrf54h20pdk_nrf54h20_cpurad.dts
+++ b/boards/arm/nrf54h20pdk_nrf54h20/nrf54h20pdk_nrf54h20_cpurad.dts
@@ -8,7 +8,11 @@
 
 #include <nordic/nrf54h20_enga_cpurad.dtsi>
 #include "nrf54h20pdk_nrf54h20-memory_map.dtsi"
+#include "nrf54h20pdk_nrf54h20-ipc_conf.dtsi"
 #include "nrf54h20pdk_nrf54h20-pinctrl.dtsi"
+
+/delete-node/ &cpuapp_cpuppr_ipc;
+/delete-node/ &cpusec_cpuapp_ipc;
 
 / {
 	compatible = "nordic,nrf54h20pdk_nrf54h20-cpurad";
@@ -24,6 +28,24 @@
 
 &shared_ram3x_region {
 	status = "okay";
+};
+
+&cpurad_bellboard {
+	/* irq0: 0: cpurad-cpusec, 12: cpurad-cpuapp */
+	nordic,interrupt-mapping = <0x00001001 0>;
+};
+
+&cpusec_cpurad_ipc {
+	mbox-names = "tx", "rx";
+	tx-region = <&cpurad_cpusec_ipc_shm>;
+	rx-region = <&cpusec_cpurad_ipc_shm>;
+};
+
+&cpuapp_cpurad_ipc {
+	compatible = "zephyr,ipc-icmsg-me-follower";
+	mbox-names = "tx", "rx";
+	tx-region = <&cpurad_cpuapp_ipc_shm>;
+	rx-region = <&cpuapp_cpurad_ipc_shm>;
 };
 
 &cpurad_dma_region {

--- a/boards/riscv/nrf54h20pdk_nrf54h20/nrf54h20pdk_nrf54h20_cpuppr.dts
+++ b/boards/riscv/nrf54h20pdk_nrf54h20/nrf54h20pdk_nrf54h20_cpuppr.dts
@@ -8,7 +8,12 @@
 
 #include <nordic/nrf54h20_enga_cpuppr.dtsi>
 #include "nrf54h20pdk_nrf54h20-memory_map.dtsi"
+#include "nrf54h20pdk_nrf54h20-ipc_conf.dtsi"
 #include "nrf54h20pdk_nrf54h20-pinctrl.dtsi"
+
+/delete-node/ &cpuapp_cpurad_ipc;
+/delete-node/ &cpusec_cpuapp_ipc;
+/delete-node/ &cpusec_cpurad_ipc;
 
 / {
 	compatible = "nordic,nrf54h20pdk_nrf54h20-cpuppr";
@@ -22,6 +27,12 @@
 		zephyr,flash = &mram1x;
 		zephyr,sram = &cpuppr_ram3x_region;
 	};
+};
+
+&cpuapp_cpuppr_ipc {
+	mbox-names = "tx", "rx";
+	tx-region = <&cpuppr_cpuapp_ipc_shm>;
+	rx-region = <&cpuapp_cpuppr_ipc_shm>;
 };
 
 &grtc {

--- a/dts/arm/nordic/nrf54h20_enga_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf54h20_enga_cpuapp.dtsi
@@ -9,6 +9,7 @@
 cpu: &cpuapp {};
 systick: &cpuapp_systick {};
 nvic: &cpuapp_nvic {};
+cpuppr_vevif: &cpuppr_vevif_remote {};
 
 /delete-node/ &cpuppr;
 /delete-node/ &cpurad;

--- a/dts/arm/nordic/nrf54h20_enga_cpurad.dtsi
+++ b/dts/arm/nordic/nrf54h20_enga_cpurad.dtsi
@@ -9,6 +9,7 @@
 cpu: &cpurad {};
 systick: &cpurad_systick {};
 nvic: &cpurad_nvic {};
+cpuppr_vevif: &cpuppr_vevif_remote {};
 
 /delete-node/ &cpuapp;
 /delete-node/ &cpuapp_peripherals;

--- a/dts/riscv/nordic/nrf54h20_enga_cpuppr.dtsi
+++ b/dts/riscv/nordic/nrf54h20_enga_cpuppr.dtsi
@@ -8,6 +8,7 @@
 
 cpu: &cpuppr {};
 clic: &cpuppr_clic {};
+cpuppr_vevif: &cpuppr_vevif_local {};
 
 /delete-node/ &cpuapp;
 /delete-node/ &cpuapp_peripherals;


### PR DESCRIPTION
Add shared memory for APP<->PPR, used for IPC.