### PR TITLE
scripts: ci: check_compliance: skip kconfig check in vulnerabilities.rst

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -582,9 +582,11 @@ https://docs.zephyrproject.org/latest/build/kconfig/tips.html#menuconfig-symbols
         # Warning: Needs to work with both --perl-regexp and the 're' module
         regex = r"\bCONFIG_[A-Z0-9_]+\b(?!\s*##|[$@{*])"
 
-        # Skip doc/releases, which often references removed symbols
+        # Skip doc/releases and doc/security/vulnerabilities.rst, which often
+        # reference removed symbols
         grep_stdout = git("grep", "--line-number", "-I", "--null",
                           "--perl-regexp", regex, "--", ":!/doc/releases",
+                          ":!/doc/security/vulnerabilities.rst",
                           cwd=Path(GIT_TOP))
 
         # splitlines() supports various line terminators


### PR DESCRIPTION
Skip `doc/security/vulnerabilities.rst` when checking for undefined Kconfig symbols as older vulnerabilities can contain references to removed Kconfig symbols.

This commit was split from https://github.com/zephyrproject-rtos/zephyr/pull/69460 where this was encountered by removal of a Kconfig symbol mentioned in `doc/security/vulnerabilities.rst`.