### PR TITLE
drivers: udc: eliminate C++ errors by casting void* to the target type

### DIFF
--- a/include/zephyr/drivers/usb/udc.h
+++ b/include/zephyr/drivers/usb/udc.h
@@ -311,7 +311,7 @@ struct udc_data {
  */
 static inline bool udc_is_initialized(const struct device *dev)
 {
-	struct udc_data *data = dev->data;
+	struct udc_data *data = (struct udc_data *)dev->data;
 
 	return atomic_test_bit(&data->status, UDC_STATUS_INITIALIZED);
 }
@@ -325,7 +325,7 @@ static inline bool udc_is_initialized(const struct device *dev)
  */
 static inline bool udc_is_enabled(const struct device *dev)
 {
-	struct udc_data *data = dev->data;
+	struct udc_data *data = (struct udc_data *)dev->data;
 
 	return atomic_test_bit(&data->status, UDC_STATUS_ENABLED);
 }
@@ -339,7 +339,7 @@ static inline bool udc_is_enabled(const struct device *dev)
  */
 static inline bool udc_is_suspended(const struct device *dev)
 {
-	struct udc_data *data = dev->data;
+	struct udc_data *data = (struct udc_data *)dev->data;
 
 	return atomic_test_bit(&data->status, UDC_STATUS_SUSPENDED);
 }
@@ -415,7 +415,7 @@ int udc_shutdown(const struct device *dev);
  */
 static inline struct udc_device_caps udc_caps(const struct device *dev)
 {
-	struct udc_data *data = dev->data;
+	struct udc_data *data = (struct udc_data *)dev->data;
 
 	return data->caps;
 }
@@ -445,7 +445,7 @@ enum udc_bus_speed udc_device_speed(const struct device *dev);
  */
 static inline int udc_set_address(const struct device *dev, const uint8_t addr)
 {
-	const struct udc_api *api = dev->api;
+	const struct udc_api *api = (const struct udc_api *)dev->api;
 	int ret;
 
 	if (!udc_is_enabled(dev)) {
@@ -477,7 +477,7 @@ static inline int udc_set_address(const struct device *dev, const uint8_t addr)
 static inline int udc_test_mode(const struct device *dev,
 				const uint8_t mode, const bool dryrun)
 {
-	const struct udc_api *api = dev->api;
+	const struct udc_api *api = (const struct udc_api *)dev->api;
 	int ret;
 
 	if (!udc_is_enabled(dev)) {
@@ -507,7 +507,7 @@ static inline int udc_test_mode(const struct device *dev,
  */
 static inline int udc_host_wakeup(const struct device *dev)
 {
-	const struct udc_api *api = dev->api;
+	const struct udc_api *api = (const struct udc_api *)dev->api;
 	int ret;
 
 	if (!udc_is_enabled(dev)) {
@@ -724,7 +724,7 @@ static inline struct udc_buf_info *udc_get_buf_info(const struct net_buf *const 
  */
 static inline const void *udc_get_event_ctx(const struct device *dev)
 {
-	struct udc_data *data = dev->data;
+	struct udc_data *data = (struct udc_data *)dev->data;
 
 	return data->event_ctx;
 }


### PR DESCRIPTION
When this header is included in a C++ source file, compilation fails due to invalid syntax. It can be converted to a warning with `-fpermissive`, but the long term solution is to just perform the missing casts as done here.