### PR TITLE
samples: driver: memc: Fix minor issues

### DIFF
--- a/samples/drivers/memc/README.rst
+++ b/samples/drivers/memc/README.rst
@@ -35,14 +35,20 @@ Sample Output
 
 .. code-block:: console
 
-*** Booting Zephyr OS build zephyr-v3.2.0-2686-gd52d828c2bdc ***
-Writing to memory region with base 0x38000000, size 0x800000
+  *** Booting Zephyr OS build zephyr-v3.2.0-2686-gd52d828c2bdc ***
+  Writing to memory region with base 0x38000000, size 0x800000
 
-First 1KB of Data in memory:
-\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=
-00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f
-10 11 12 13 14 15 16 17 18 19 1a 1b 1c 1d 1e 1f
-20 21 22 23 24 25 26 27 28 29 2a 2b 2c 2d 2e 2f
-....
+  Check (0/8191) passed!
+  Check (1/8191) passed!
+  ...
+  Check (8190/8191) passed!
+  Check (8191/8191) passed!
 
-Read data matches written data
+  First 1KB of Data in memory:
+  \=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=
+  00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f
+  10 11 12 13 14 15 16 17 18 19 1a 1b 1c 1d 1e 1f
+  20 21 22 23 24 25 26 27 28 29 2a 2b 2c 2d 2e 2f
+  ....
+
+  Read data matches written data

--- a/samples/drivers/memc/src/main.c
+++ b/samples/drivers/memc/src/main.c
@@ -54,7 +54,7 @@ int main(void)
 		memc_write_buffer[i] = (uint8_t)i;
 	}
 	printk("Writing to memory region with base %p, size 0x%0x\n\n",
-		MEMC_BASE, MEMC_SIZE);
+		memc, MEMC_SIZE);
 	/* Copy write buffer into memc region */
 	for (i = 0, j = 0; j < (MEMC_SIZE / BUF_SIZE); i += BUF_SIZE, j++) {
 		memcpy(memc + i, memc_write_buffer, BUF_SIZE);

--- a/samples/drivers/memc/src/main.c
+++ b/samples/drivers/memc/src/main.c
@@ -70,8 +70,11 @@ int main(void)
 		if (memcmp(memc_read_buffer, memc_write_buffer, BUF_SIZE)) {
 			printk("Error: read data differs in range [0x%x- 0x%x]\n",
 				i, i + (BUF_SIZE - 1));
+			dump_memory(memc_write_buffer, BUF_SIZE);
+			dump_memory(memc_read_buffer, BUF_SIZE);
 			return 0;
 		}
+		printk("Check (%i/%i) passed!\n", j, (MEMC_SIZE / BUF_SIZE) - 1);
 	}
 	/* Copy any remaining space bytewise */
 	for (; i < MEMC_SIZE; i++) {

--- a/samples/drivers/memc/src/main.c
+++ b/samples/drivers/memc/src/main.c
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
+#include <string.h>
 
 #if DT_HAS_COMPAT_STATUS_OKAY(nxp_imx_flexspi)
 /* Use memc API to get AHB base address for the device */


### PR DESCRIPTION
Fix the code-block inside the README and the missing include for memcpy. Make the sample more verbose and show if it's still running by printing something after each compare step.