### PR TITLE
net: zperf: Fix TOS option not working in zperf

### DIFF
--- a/subsys/net/lib/zperf/zperf_common.c
+++ b/subsys/net/lib/zperf/zperf_common.c
@@ -109,7 +109,7 @@ int zperf_get_ipv4_addr(char *host, struct in_addr *addr)
 	return 0;
 }
 
-int zperf_prepare_upload_sock(const struct sockaddr *peer_addr, int tos,
+int zperf_prepare_upload_sock(const struct sockaddr *peer_addr, uint8_t tos,
 			      int priority, int proto)
 {
 	socklen_t addrlen = peer_addr->sa_family == AF_INET6 ?

--- a/subsys/net/lib/zperf/zperf_internal.h
+++ b/subsys/net/lib/zperf/zperf_internal.h
@@ -95,7 +95,7 @@ struct sockaddr_in *zperf_get_sin(void);
 
 extern void connect_ap(char *ssid);
 
-int zperf_prepare_upload_sock(const struct sockaddr *peer_addr, int tos,
+int zperf_prepare_upload_sock(const struct sockaddr *peer_addr, uint8_t tos,
 			      int priority, int proto);
 
 uint32_t zperf_packet_duration(uint32_t packet_size, uint32_t rate_in_kbps);


### PR DESCRIPTION
Use zperf cmd with '-S' option, but return warning log and the WMM is not working. When call zsock_setsockopt() with 'IP_TOS', it will check the option length in set_context_dscp_ecn(), and the option length should be 1 byte in this case. Change the input parameter tos from 'int' to 'uint8_t' can fix this issue.