### PR TITLE
net: zperf: Fix wrong TP in long-duration traffic test

### DIFF
--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -81,6 +81,11 @@ Bluetooth Audio
 Networking
 **********
 
+* The zperf zperf_results struct is changed to support 64 bits transferred bytes (total_len)
+  and test duration (time_in_us and client_time_in_us), instead of 32 bits. This will make
+  the long-duration zperf test show with correct throughput result.
+  (:github:`69500`)
+
 Other Subsystems
 ****************
 

--- a/include/zephyr/net/zperf.h
+++ b/include/zephyr/net/zperf.h
@@ -51,10 +51,10 @@ struct zperf_results {
 	uint32_t nb_packets_rcvd;
 	uint32_t nb_packets_lost;
 	uint32_t nb_packets_outorder;
-	uint32_t total_len;
-	uint32_t time_in_us;
+	uint64_t total_len;
+	uint64_t time_in_us;
 	uint32_t jitter_in_us;
-	uint32_t client_time_in_us;
+	uint64_t client_time_in_us;
 	uint32_t packet_size;
 	uint32_t nb_packets_errors;
 };

--- a/subsys/net/lib/zperf/zperf_tcp_receiver.c
+++ b/subsys/net/lib/zperf/zperf_tcp_receiver.c
@@ -80,7 +80,7 @@ static void tcp_received(const struct sockaddr *addr, size_t datalen)
 			session->state = STATE_COMPLETED;
 
 			results.total_len = session->length;
-			results.time_in_us = k_ticks_to_us_ceil32(
+			results.time_in_us = k_ticks_to_us_ceil64(
 						time - session->start_time);
 
 			if (tcp_session_cb != NULL) {

--- a/subsys/net/lib/zperf/zperf_tcp_uploader.c
+++ b/subsys/net/lib/zperf/zperf_tcp_uploader.c
@@ -102,7 +102,7 @@ static int tcp_upload(int sock,
 	/* Add result coming from the client */
 	results->nb_packets_sent = nb_packets;
 	results->client_time_in_us =
-				k_ticks_to_us_ceil32(end_time - start_time);
+				k_ticks_to_us_ceil64(end_time - start_time);
 	results->packet_size = packet_size;
 	results->nb_packets_errors = nb_errors;
 

--- a/subsys/net/lib/zperf/zperf_udp_receiver.c
+++ b/subsys/net/lib/zperf/zperf_udp_receiver.c
@@ -145,9 +145,9 @@ static void udp_received(int sock, const struct sockaddr *addr, uint8_t *data,
 	case STATE_ONGOING:
 		if (id < 0) { /* Negative id means session end. */
 			struct zperf_results results = { 0 };
-			uint32_t duration;
+			uint64_t duration;
 
-			duration = k_ticks_to_us_ceil32(time -
+			duration = k_ticks_to_us_ceil64(time -
 							session->start_time);
 
 			/* Update state machine */

--- a/subsys/net/lib/zperf/zperf_udp_uploader.c
+++ b/subsys/net/lib/zperf/zperf_udp_uploader.c
@@ -38,7 +38,8 @@ static inline void zperf_upload_decode_stat(const uint8_t *data,
 	results->nb_packets_lost = ntohl(UNALIGNED_GET(&stat->error_cnt));
 	results->nb_packets_outorder =
 		ntohl(UNALIGNED_GET(&stat->outorder_cnt));
-	results->total_len = ntohl(UNALIGNED_GET(&stat->total_len2));
+	results->total_len = (((uint64_t)ntohl(UNALIGNED_GET(&stat->total_len1))) << 32) +
+		ntohl(UNALIGNED_GET(&stat->total_len2));
 	results->time_in_us = ntohl(UNALIGNED_GET(&stat->stop_usec)) +
 		ntohl(UNALIGNED_GET(&stat->stop_sec)) * USEC_PER_SEC;
 	results->jitter_in_us = ntohl(UNALIGNED_GET(&stat->jitter2)) +
@@ -256,7 +257,7 @@ static int udp_upload(int sock, int port,
 	/* Add result coming from the client */
 	results->nb_packets_sent = nb_packets;
 	results->client_time_in_us =
-				k_ticks_to_us_ceil32(end_time - start_time);
+				k_ticks_to_us_ceil64(end_time - start_time);
 	results->packet_size = packet_size;
 
 	return 0;


### PR DESCRIPTION
The zperf received or sent bytes length and duration are in 32bits, if running long-duration zperf test more than 20min, the value will overflow, and the test result is wrong. Change it to 64bits can fix this issue.