### PR TITLE
modem: chat: Add runtime API to modem chat matches

### DIFF
--- a/drivers/gnss/gnss_quectel_lcx6g.c
+++ b/drivers/gnss/gnss_quectel_lcx6g.c
@@ -59,13 +59,12 @@ struct quectel_lcx6g_data {
 	uint8_t chat_delimiter[2];
 	uint8_t *chat_argv[32];
 
-	/* Dynamic chat script */
-	uint8_t dynamic_match_buf[32];
-	uint8_t dynamic_separators_buf[2];
-	uint8_t dynamic_request_buf[32];
-	struct modem_chat_match dynamic_match;
-	struct modem_chat_script_chat dynamic_script_chat;
-	struct modem_chat_script dynamic_script;
+	/* Pair chat script */
+	uint8_t pair_request_buf[32];
+	uint8_t pair_match_buf[32];
+	struct modem_chat_match pair_match;
+	struct modem_chat_script_chat pair_script_chat;
+	struct modem_chat_script pair_script;
 
 	/* Allocation for responses from GNSS modem */
 	union {
@@ -141,23 +140,29 @@ static int quectel_lcx6g_configure_pps(const struct device *dev)
 		break;
 	}
 
-	ret = gnss_nmea0183_snprintk(data->dynamic_request_buf, sizeof(data->dynamic_request_buf),
+	ret = gnss_nmea0183_snprintk(data->pair_request_buf, sizeof(data->pair_request_buf),
 				     "PAIR752,%u,%u", pps_mode, config->pps_pulse_width);
 	if (ret < 0) {
 		return ret;
 	}
 
-	data->dynamic_script_chat.request_size = ret;
+	ret = modem_chat_script_chat_set_request(&data->pair_script_chat, data->pair_request_buf);
+	if (ret < 0) {
+		return ret;
+	}
 
-	ret = gnss_nmea0183_snprintk(data->dynamic_match_buf, sizeof(data->dynamic_match_buf),
+	ret = gnss_nmea0183_snprintk(data->pair_match_buf, sizeof(data->pair_match_buf),
 				     "PAIR001,752,0");
 	if (ret < 0) {
 		return ret;
 	}
 
-	data->dynamic_match.match_size = ret;
+	ret = modem_chat_match_set_match(&data->pair_match, data->pair_match_buf);
+	if (ret < 0) {
+		return ret;
+	}
 
-	return modem_chat_run_script(&data->chat, &data->dynamic_script);
+	return modem_chat_run_script(&data->chat, &data->pair_script);
 }
 
 static void quectel_lcx6g_lock(const struct device *dev)
@@ -312,23 +317,29 @@ static int quectel_lcx6g_set_fix_rate(const struct device *dev, uint32_t fix_int
 
 	quectel_lcx6g_lock(dev);
 
-	ret = gnss_nmea0183_snprintk(data->dynamic_request_buf, sizeof(data->dynamic_request_buf),
+	ret = gnss_nmea0183_snprintk(data->pair_request_buf, sizeof(data->pair_request_buf),
 				     "PAIR050,%u", fix_interval_ms);
 	if (ret < 0) {
 		goto unlock_return;
 	}
 
-	data->dynamic_script_chat.request_size = ret;
+	ret = modem_chat_script_chat_set_request(&data->pair_script_chat, data->pair_request_buf);
+	if (ret < 0) {
+		goto unlock_return;
+	}
 
-	ret = gnss_nmea0183_snprintk(data->dynamic_match_buf, sizeof(data->dynamic_match_buf),
+	ret = gnss_nmea0183_snprintk(data->pair_match_buf, sizeof(data->pair_match_buf),
 				     "PAIR001,050,0");
 	if (ret < 0) {
 		goto unlock_return;
 	}
 
-	data->dynamic_match.match_size = ret;
+	ret = modem_chat_match_set_match(&data->pair_match, data->pair_match_buf);
+	if (ret < 0) {
+		goto unlock_return;
+	}
 
-	ret = modem_chat_run_script(&data->chat, &data->dynamic_script);
+	ret = modem_chat_run_script(&data->chat, &data->pair_script);
 	if (ret < 0) {
 		goto unlock_return;
 	}
@@ -362,20 +373,26 @@ static int quectel_lcx6g_get_fix_rate(const struct device *dev, uint32_t *fix_in
 
 	quectel_lcx6g_lock(dev);
 
-	ret = gnss_nmea0183_snprintk(data->dynamic_request_buf, sizeof(data->dynamic_request_buf),
+	ret = gnss_nmea0183_snprintk(data->pair_request_buf, sizeof(data->pair_request_buf),
 				     "PAIR051");
 	if (ret < 0) {
 		goto unlock_return;
 	}
 
-	data->dynamic_script_chat.request_size = ret;
+	ret = modem_chat_script_chat_set_request(&data->pair_script_chat, data->pair_request_buf);
+	if (ret < 0) {
+		goto unlock_return;
+	}
 
-	strncpy(data->dynamic_match_buf, "$PAIR051,", sizeof(data->dynamic_match_buf));
-	data->dynamic_match.match_size = sizeof("$PAIR051,") - 1;
-	data->dynamic_match.callback = quectel_lcx6g_get_fix_rate_callback;
+	strncpy(data->pair_match_buf, "$PAIR051,", sizeof(data->pair_match_buf));
+	ret = modem_chat_match_set_match(&data->pair_match, data->pair_match_buf);
+	if (ret < 0) {
+		goto unlock_return;
+	}
 
-	ret = modem_chat_run_script(&data->chat, &data->dynamic_script);
-	data->dynamic_match.callback = NULL;
+	modem_chat_match_set_callback(&data->pair_match, quectel_lcx6g_get_fix_rate_callback);
+	ret = modem_chat_run_script(&data->chat, &data->pair_script);
+	modem_chat_match_set_callback(&data->pair_match, NULL);
 	if (ret < 0) {
 		goto unlock_return;
 	}
@@ -414,23 +431,29 @@ static int quectel_lcx6g_set_navigation_mode(const struct device *dev,
 
 	quectel_lcx6g_lock(dev);
 
-	ret = gnss_nmea0183_snprintk(data->dynamic_request_buf, sizeof(data->dynamic_request_buf),
+	ret = gnss_nmea0183_snprintk(data->pair_request_buf, sizeof(data->pair_request_buf),
 				     "PAIR080,%u", navigation_mode);
 	if (ret < 0) {
 		goto unlock_return;
 	}
 
-	data->dynamic_script_chat.request_size = ret;
+	ret = modem_chat_script_chat_set_request(&data->pair_script_chat, data->pair_request_buf);
+	if (ret < 0) {
+		goto unlock_return;
+	}
 
-	ret = gnss_nmea0183_snprintk(data->dynamic_match_buf, sizeof(data->dynamic_match_buf),
+	ret = gnss_nmea0183_snprintk(data->pair_match_buf, sizeof(data->pair_match_buf),
 				     "PAIR001,080,0");
 	if (ret < 0) {
 		goto unlock_return;
 	}
 
-	data->dynamic_match.match_size = ret;
+	ret = modem_chat_match_set_match(&data->pair_match, data->pair_match_buf);
+	if (ret < 0) {
+		goto unlock_return;
+	}
 
-	ret = modem_chat_run_script(&data->chat, &data->dynamic_script);
+	ret = modem_chat_run_script(&data->chat, &data->pair_script);
 	if (ret < 0) {
 		goto unlock_return;
 	}
@@ -440,8 +463,8 @@ unlock_return:
 	return ret;
 }
 
-static void quectel_lcx6g_get_navigation_mode_callback(struct modem_chat *chat, char **argv,
-						       uint16_t argc, void *user_data)
+static void quectel_lcx6g_get_nav_mode_callback(struct modem_chat *chat, char **argv,
+						uint16_t argc, void *user_data)
 {
 	struct quectel_lcx6g_data *data = user_data;
 	int32_t tmp;
@@ -481,20 +504,26 @@ static int quectel_lcx6g_get_navigation_mode(const struct device *dev,
 
 	quectel_lcx6g_lock(dev);
 
-	ret = gnss_nmea0183_snprintk(data->dynamic_request_buf, sizeof(data->dynamic_request_buf),
+	ret = gnss_nmea0183_snprintk(data->pair_request_buf, sizeof(data->pair_request_buf),
 				     "PAIR081");
 	if (ret < 0) {
 		goto unlock_return;
 	}
 
-	data->dynamic_script_chat.request_size = ret;
+	ret = modem_chat_script_chat_set_request(&data->pair_script_chat, data->pair_request_buf);
+	if (ret < 0) {
+		goto unlock_return;
+	}
 
-	strncpy(data->dynamic_match_buf, "$PAIR081,", sizeof(data->dynamic_match_buf));
-	data->dynamic_match.match_size = sizeof("$PAIR081,") - 1;
-	data->dynamic_match.callback = quectel_lcx6g_get_navigation_mode_callback;
+	strncpy(data->pair_match_buf, "$PAIR081,", sizeof(data->pair_match_buf));
+	ret = modem_chat_match_set_match(&data->pair_match, data->pair_match_buf);
+	if (ret < 0) {
+		goto unlock_return;
+	}
 
-	ret = modem_chat_run_script(&data->chat, &data->dynamic_script);
-	data->dynamic_match.callback = NULL;
+	modem_chat_match_set_callback(&data->pair_match, quectel_lcx6g_get_nav_mode_callback);
+	ret = modem_chat_run_script(&data->chat, &data->pair_script);
+	modem_chat_match_set_callback(&data->pair_match, NULL);
 	if (ret < 0) {
 		goto unlock_return;
 	}
@@ -521,7 +550,7 @@ static int quectel_lcx6g_set_enabled_systems(const struct device *dev, gnss_syst
 
 	quectel_lcx6g_lock(dev);
 
-	ret = gnss_nmea0183_snprintk(data->dynamic_request_buf, sizeof(data->dynamic_request_buf),
+	ret = gnss_nmea0183_snprintk(data->pair_request_buf, sizeof(data->pair_request_buf),
 				     "PAIR066,%u,%u,%u,%u,%u,0",
 				     (0 < (systems & GNSS_SYSTEM_GPS)),
 				     (0 < (systems & GNSS_SYSTEM_GLONASS)),
@@ -532,38 +561,50 @@ static int quectel_lcx6g_set_enabled_systems(const struct device *dev, gnss_syst
 		goto unlock_return;
 	}
 
-	data->dynamic_script_chat.request_size = ret;
+	ret = modem_chat_script_chat_set_request(&data->pair_script_chat, data->pair_request_buf);
+	if (ret < 0) {
+		goto unlock_return;
+	}
 
-	ret = gnss_nmea0183_snprintk(data->dynamic_match_buf, sizeof(data->dynamic_match_buf),
+	ret = gnss_nmea0183_snprintk(data->pair_match_buf, sizeof(data->pair_match_buf),
 				     "PAIR001,066,0");
 	if (ret < 0) {
 		goto unlock_return;
 	}
 
-	data->dynamic_match.match_size = ret;
-
-	ret = modem_chat_run_script(&data->chat, &data->dynamic_script);
+	ret = modem_chat_match_set_match(&data->pair_match, data->pair_match_buf);
 	if (ret < 0) {
 		goto unlock_return;
 	}
 
-	ret = gnss_nmea0183_snprintk(data->dynamic_request_buf, sizeof(data->dynamic_request_buf),
+	ret = modem_chat_run_script(&data->chat, &data->pair_script);
+	if (ret < 0) {
+		goto unlock_return;
+	}
+
+	ret = gnss_nmea0183_snprintk(data->pair_request_buf, sizeof(data->pair_request_buf),
 				     "PAIR410,%u", (0 < (systems & GNSS_SYSTEM_SBAS)));
 	if (ret < 0) {
 		goto unlock_return;
 	}
 
-	data->dynamic_script_chat.request_size = ret;
+	ret = modem_chat_script_chat_set_request(&data->pair_script_chat, data->pair_request_buf);
+	if (ret < 0) {
+		goto unlock_return;
+	}
 
-	ret = gnss_nmea0183_snprintk(data->dynamic_match_buf, sizeof(data->dynamic_match_buf),
+	ret = gnss_nmea0183_snprintk(data->pair_match_buf, sizeof(data->pair_match_buf),
 				     "PAIR001,410,0");
 	if (ret < 0) {
 		goto unlock_return;
 	}
 
-	data->dynamic_match.match_size = ret;
+	ret = modem_chat_match_set_match(&data->pair_match, data->pair_match_buf);
+	if (ret < 0) {
+		goto unlock_return;
+	}
 
-	ret = modem_chat_run_script(&data->chat, &data->dynamic_script);
+	ret = modem_chat_run_script(&data->chat, &data->pair_script);
 	if (ret < 0) {
 		goto unlock_return;
 	}
@@ -614,38 +655,50 @@ static int quectel_lcx6g_get_enabled_systems(const struct device *dev, gnss_syst
 
 	quectel_lcx6g_lock(dev);
 
-	ret = gnss_nmea0183_snprintk(data->dynamic_request_buf, sizeof(data->dynamic_request_buf),
+	ret = gnss_nmea0183_snprintk(data->pair_request_buf, sizeof(data->pair_request_buf),
 				     "PAIR067");
 	if (ret < 0) {
 		goto unlock_return;
 	}
 
-	data->dynamic_script_chat.request_size = ret;
-
-	strncpy(data->dynamic_match_buf, "$PAIR067,", sizeof(data->dynamic_match_buf));
-	data->dynamic_match.match_size = sizeof("$PAIR067,") - 1;
-	data->dynamic_match.callback = quectel_lcx6g_get_search_mode_callback;
-
-	ret = modem_chat_run_script(&data->chat, &data->dynamic_script);
-	data->dynamic_match.callback = NULL;
+	ret = modem_chat_script_chat_set_request(&data->pair_script_chat, data->pair_request_buf);
 	if (ret < 0) {
 		goto unlock_return;
 	}
 
-	ret = gnss_nmea0183_snprintk(data->dynamic_request_buf, sizeof(data->dynamic_request_buf),
+	strncpy(data->pair_match_buf, "$PAIR067,", sizeof(data->pair_match_buf));
+	ret = modem_chat_match_set_match(&data->pair_match, data->pair_match_buf);
+	if (ret < 0) {
+		goto unlock_return;
+	}
+
+	modem_chat_match_set_callback(&data->pair_match, quectel_lcx6g_get_search_mode_callback);
+	ret = modem_chat_run_script(&data->chat, &data->pair_script);
+	modem_chat_match_set_callback(&data->pair_match, NULL);
+	if (ret < 0) {
+		goto unlock_return;
+	}
+
+	ret = gnss_nmea0183_snprintk(data->pair_request_buf, sizeof(data->pair_request_buf),
 				     "PAIR411");
 	if (ret < 0) {
 		goto unlock_return;
 	}
 
-	data->dynamic_script_chat.request_size = ret;
+	ret = modem_chat_script_chat_set_request(&data->pair_script_chat, data->pair_request_buf);
+	if (ret < 0) {
+		goto unlock_return;
+	}
 
-	strncpy(data->dynamic_match_buf, "$PAIR411,", sizeof(data->dynamic_match_buf));
-	data->dynamic_match.match_size = sizeof("$PAIR411,") - 1;
-	data->dynamic_match.callback = quectel_lcx6g_get_sbas_status_callback;
+	strncpy(data->pair_match_buf, "$PAIR411,", sizeof(data->pair_match_buf));
+	ret = modem_chat_match_set_match(&data->pair_match, data->pair_match_buf);
+	if (ret < 0) {
+		goto unlock_return;
+	}
 
-	ret = modem_chat_run_script(&data->chat, &data->dynamic_script);
-	data->dynamic_match.callback = NULL;
+	modem_chat_match_set_callback(&data->pair_match, quectel_lcx6g_get_sbas_status_callback);
+	ret = modem_chat_run_script(&data->chat, &data->pair_script);
+	modem_chat_match_set_callback(&data->pair_match, NULL);
 	if (ret < 0) {
 		goto unlock_return;
 	}
@@ -726,28 +779,22 @@ static int quectel_lcx6g_init_chat(const struct device *dev)
 	return modem_chat_init(&data->chat, &chat_config);
 }
 
-static void quectel_lcx6g_init_dynamic_script(const struct device *dev)
+static void quectel_lcx6g_init_pair_script(const struct device *dev)
 {
 	struct quectel_lcx6g_data *data = dev->data;
 
-	data->dynamic_match.match = data->dynamic_match_buf;
-	data->dynamic_match.separators = data->dynamic_separators_buf;
-	data->dynamic_match.separators_size = sizeof(data->dynamic_separators_buf);
-	data->dynamic_match.wildcards = false;
-	data->dynamic_match.partial = false;
+	modem_chat_match_init(&data->pair_match);
+	modem_chat_match_set_separators(&data->pair_match, ",*");
 
-	data->dynamic_script_chat.request = data->dynamic_request_buf;
-	data->dynamic_script_chat.response_matches = &data->dynamic_match;
-	data->dynamic_script_chat.response_matches_size = 1;
-	data->dynamic_script_chat.timeout = 0;
+	modem_chat_script_chat_init(&data->pair_script_chat);
+	modem_chat_script_chat_set_response_matches(&data->pair_script_chat,
+						    &data->pair_match, 1);
 
-	data->dynamic_script.name = "pair";
-	data->dynamic_script.script_chats = &data->dynamic_script_chat;
-	data->dynamic_script.script_chats_size = 1;
-	data->dynamic_script.abort_matches = NULL;
-	data->dynamic_script.abort_matches_size = 0;
-	data->dynamic_script.callback = NULL;
-	data->dynamic_script.timeout = 10;
+	modem_chat_script_init(&data->pair_script);
+	modem_chat_script_set_name(&data->pair_script, "pair");
+	modem_chat_script_set_script_chats(&data->pair_script, &data->pair_script_chat, 1);
+	modem_chat_script_set_abort_matches(&data->pair_script, NULL, 0);
+	modem_chat_script_set_timeout(&data->pair_script, 10);
 }
 
 static int quectel_lcx6g_init(const struct device *dev)
@@ -769,7 +816,7 @@ static int quectel_lcx6g_init(const struct device *dev)
 		return ret;
 	}
 
-	quectel_lcx6g_init_dynamic_script(dev);
+	quectel_lcx6g_init_pair_script(dev);
 
 	quectel_lcx6g_pm_changed(dev);
 
@@ -798,7 +845,6 @@ static int quectel_lcx6g_init(const struct device *dev)
 											\
 	static struct quectel_lcx6g_data LCX6G_INST_NAME(inst, data) = {		\
 		.chat_delimiter = {'\r', '\n'},						\
-		.dynamic_separators_buf = {',', '*'},					\
 	};										\
 											\
 	PM_DEVICE_DT_INST_DEFINE(inst, quectel_lcx6g_pm_action);			\

--- a/include/zephyr/modem/chat.h
+++ b/include/zephyr/modem/chat.h
@@ -426,6 +426,45 @@ void modem_chat_match_set_partial(struct modem_chat_match *chat_match, bool part
  */
 void modem_chat_match_enable_wildcards(struct modem_chat_match *chat_match, bool enable);
 
+/**
+ * @brief Initialize modem chat script chat
+ * @param script_chat Modem chat script chat instance
+ */
+void modem_chat_script_chat_init(struct modem_chat_script_chat *script_chat);
+
+/**
+ * @brief Set request of modem chat script chat instance
+ * @param script_chat Modem chat script chat instance
+ * @param request Request to set
+ * @note The lifetime of request must match or exceed the lifetime of script_chat
+ * @warning Always call this API after request is modified
+ *
+ * @retval 0 if successful, negative errno code otherwise
+ */
+int modem_chat_script_chat_set_request(struct modem_chat_script_chat *script_chat,
+				       const char *request);
+
+/**
+ * @brief Set modem chat script chat matches
+ * @param script_chat Modem chat script chat instance
+ * @param response_matches Response match array to set
+ * @param response_matches_size Size of response match array
+ * @note The lifetime of response_matches must match or exceed the lifetime of script_chat
+ *
+ * @retval 0 if successful, negative errno code otherwise
+ */
+int modem_chat_script_chat_set_response_matches(struct modem_chat_script_chat *script_chat,
+						const struct modem_chat_match *response_matches,
+						uint16_t response_matches_size);
+
+/**
+ * @brief Set modem chat script chat timeout
+ * @param script_chat Modem chat script chat instance
+ * @param timeout_ms Timeout in milliseconds
+ */
+void modem_chat_script_chat_set_timeout(struct modem_chat_script_chat *script_chat,
+					uint16_t timeout_ms);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/modem/chat.h
+++ b/include/zephyr/modem/chat.h
@@ -45,9 +45,9 @@ struct modem_chat_match {
 	/** Size of separators array */
 	uint8_t separators_size;
 	/** Set if modem chat instance shall use wildcards when matching */
-	uint8_t wildcards : 1;
+	bool wildcards;
 	/** Set if script shall not continue to next step in case of match */
-	uint8_t partial : 1;
+	bool partial;
 	/** Type of modem chat instance */
 	modem_chat_match_callback callback;
 };
@@ -375,6 +375,56 @@ void modem_chat_script_abort(struct modem_chat *chat);
  * @param chat Chat instance
  */
 void modem_chat_release(struct modem_chat *chat);
+
+/**
+ * @brief Initialize modem chat match
+ * @param chat_match Modem chat match instance
+ */
+void modem_chat_match_init(struct modem_chat_match *chat_match);
+
+/**
+ * @brief Set match of modem chat match instance
+ * @param chat_match Modem chat match instance
+ * @param match Match to set
+ * @note The lifetime of match must match or exceed the lifetime of chat_match
+ * @warning Always call this API after match is modified
+ *
+ * @retval 0 if successful, negative errno code otherwise
+ */
+int modem_chat_match_set_match(struct modem_chat_match *chat_match, const char *match);
+
+/**
+ * @brief Set separators of modem chat match instance
+ * @param chat_match Modem chat match instance
+ * @param separators Separators to set
+ * @note The lifetime of separators must match or exceed the lifetime of chat_match
+ * @warning Always call this API after separators are modified
+ *
+ * @retval 0 if successful, negative errno code otherwise
+ */
+int modem_chat_match_set_separators(struct modem_chat_match *chat_match, const char *separators);
+
+/**
+ * @brief Set modem chat match callback
+ * @param chat_match Modem chat match instance
+ * @param callback Callback to set
+ */
+void modem_chat_match_set_callback(struct modem_chat_match *chat_match,
+				   modem_chat_match_callback callback);
+
+/**
+ * @brief Set modem chat match partial flag
+ * @param chat_match Modem chat match instance
+ * @param partial Partial flag to set
+ */
+void modem_chat_match_set_partial(struct modem_chat_match *chat_match, bool partial);
+
+/**
+ * @brief Set modem chat match wildcards flag
+ * @param chat_match Modem chat match instance
+ * @param enable Enable/disable Wildcards
+ */
+void modem_chat_match_enable_wildcards(struct modem_chat_match *chat_match, bool enable);
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/modem/chat.h
+++ b/include/zephyr/modem/chat.h
@@ -465,6 +465,61 @@ int modem_chat_script_chat_set_response_matches(struct modem_chat_script_chat *s
 void modem_chat_script_chat_set_timeout(struct modem_chat_script_chat *script_chat,
 					uint16_t timeout_ms);
 
+/**
+ * @brief Initialize modem chat script
+ * @param script Modem chat script instance
+ */
+void modem_chat_script_init(struct modem_chat_script *script);
+
+/**
+ * @brief Set modem chat script name
+ * @param script Modem chat script instance
+ * @param name Name to set
+ * @note The lifetime of name must match or exceed the lifetime of script
+ */
+void modem_chat_script_set_name(struct modem_chat_script *script, const char *name);
+
+/**
+ * @brief Set modem chat script chats
+ * @param script Modem chat script instance
+ * @param script_chats Chat script array to set
+ * @param script_chats_size Size of chat script array
+ * @note The lifetime of script_chats must match or exceed the lifetime of script
+ *
+ * @retval 0 if successful, negative errno code otherwise
+ */
+int modem_chat_script_set_script_chats(struct modem_chat_script *script,
+				       const struct modem_chat_script_chat *script_chats,
+				       uint16_t script_chats_size);
+
+/**
+ * @brief Set modem chat script abort matches
+ * @param script Modem chat script instance
+ * @param abort_matches Abort match array to set
+ * @param abort_matches_size Size of abort match array
+ * @note The lifetime of abort_matches must match or exceed the lifetime of script
+ *
+ * @retval 0 if successful, negative errno code otherwise
+ */
+int modem_chat_script_set_abort_matches(struct modem_chat_script *script,
+					const struct modem_chat_match *abort_matches,
+					uint16_t abort_matches_size);
+
+/**
+ * @brief Set modem chat script callback
+ * @param script Modem chat script instance
+ * @param callback Callback to set
+ */
+void modem_chat_script_set_callback(struct modem_chat_script *script,
+				    modem_chat_script_callback callback);
+
+/**
+ * @brief Set modem chat script timeout
+ * @param script Modem chat script instance
+ * @param timeout_s Timeout in seconds
+ */
+void modem_chat_script_set_timeout(struct modem_chat_script *script, uint32_t timeout_s);
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/modem/modem_chat.c
+++ b/subsys/modem/modem_chat.c
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#undef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(modem_chat, CONFIG_MODEM_MODULES_LOG_LEVEL);
 
@@ -928,4 +931,55 @@ void modem_chat_release(struct modem_chat *chat)
 	chat->matches_size[MODEM_CHAT_MATCHES_INDEX_ABORT] = 0;
 	chat->matches[MODEM_CHAT_MATCHES_INDEX_RESPONSE] = NULL;
 	chat->matches_size[MODEM_CHAT_MATCHES_INDEX_RESPONSE] = 0;
+}
+
+void modem_chat_match_init(struct modem_chat_match *chat_match)
+{
+	memset(chat_match, 0, sizeof(struct modem_chat_match));
+}
+
+int modem_chat_match_set_match(struct modem_chat_match *chat_match, const char *match)
+{
+	size_t size;
+
+	size = strnlen(match, UINT8_MAX + 1);
+
+	if (size == (UINT8_MAX + 1)) {
+		return -ENOMEM;
+	}
+
+	chat_match->match = match;
+	chat_match->match_size = (uint8_t)size;
+	return 0;
+}
+
+int modem_chat_match_set_separators(struct modem_chat_match *chat_match, const char *separators)
+{
+	size_t size;
+
+	size = strnlen(separators, UINT8_MAX + 1);
+
+	if (size == (UINT8_MAX + 1)) {
+		return -ENOMEM;
+	}
+
+	chat_match->separators = separators;
+	chat_match->separators_size = (uint8_t)size;
+	return 0;
+}
+
+void modem_chat_match_set_callback(struct modem_chat_match *match,
+				   modem_chat_match_callback callback)
+{
+	match->callback = callback;
+}
+
+void modem_chat_match_set_partial(struct modem_chat_match *match, bool partial)
+{
+	match->partial = partial;
+}
+
+void modem_chat_match_enable_wildcards(struct modem_chat_match *match, bool enable)
+{
+	match->wildcards = enable;
 }

--- a/subsys/modem/modem_chat.c
+++ b/subsys/modem/modem_chat.c
@@ -1029,3 +1029,51 @@ void modem_chat_script_chat_set_timeout(struct modem_chat_script_chat *script_ch
 {
 	script_chat->timeout = timeout;
 }
+
+void modem_chat_script_init(struct modem_chat_script *script)
+{
+	memset(script, 0, sizeof(struct modem_chat_script));
+	script->name = "";
+}
+
+void modem_chat_script_set_name(struct modem_chat_script *script, const char *name)
+{
+	script->name = name;
+}
+
+int modem_chat_script_set_script_chats(struct modem_chat_script *script,
+				       const struct modem_chat_script_chat *script_chats,
+				       uint16_t script_chats_size)
+{
+	if (!modem_chat_validate_array(script_chats, script_chats_size)) {
+		return -EINVAL;
+	}
+
+	script->script_chats = script_chats;
+	script->script_chats_size = script_chats_size;
+	return 0;
+}
+
+int modem_chat_script_set_abort_matches(struct modem_chat_script *script,
+					const struct modem_chat_match *abort_matches,
+					uint16_t abort_matches_size)
+{
+	if (!modem_chat_validate_array(abort_matches, abort_matches_size)) {
+		return -EINVAL;
+	}
+
+	script->abort_matches = abort_matches;
+	script->abort_matches_size = abort_matches_size;
+	return 0;
+}
+
+void modem_chat_script_set_callback(struct modem_chat_script *script,
+				    modem_chat_script_callback callback)
+{
+	script->callback = callback;
+}
+
+void modem_chat_script_set_timeout(struct modem_chat_script *script, uint32_t timeout_s)
+{
+	script->timeout = timeout_s;
+}

--- a/subsys/modem/modem_chat.c
+++ b/subsys/modem/modem_chat.c
@@ -764,6 +764,12 @@ static void modem_chat_pipe_callback(struct modem_pipe *pipe, enum modem_pipe_ev
 	}
 }
 
+static bool modem_chat_validate_array(const void *array, size_t size)
+{
+	return ((array == NULL) && (size == 0)) ||
+	       ((array != NULL) && (size > 0));
+}
+
 #if CONFIG_MODEM_STATS
 static uint32_t get_receive_buf_size(struct modem_chat *chat)
 {
@@ -982,4 +988,44 @@ void modem_chat_match_set_partial(struct modem_chat_match *match, bool partial)
 void modem_chat_match_enable_wildcards(struct modem_chat_match *match, bool enable)
 {
 	match->wildcards = enable;
+}
+
+void modem_chat_script_chat_init(struct modem_chat_script_chat *script_chat)
+{
+	memset(script_chat, 0, sizeof(struct modem_chat_script_chat));
+}
+
+int modem_chat_script_chat_set_request(struct modem_chat_script_chat *script_chat,
+				       const char *request)
+{
+	size_t size;
+
+	size = strnlen(request, UINT16_MAX + 1);
+
+	if (size == (UINT16_MAX + 1)) {
+		return -ENOMEM;
+	}
+
+	script_chat->request = request;
+	script_chat->request_size = (uint16_t)size;
+	return 0;
+}
+
+int modem_chat_script_chat_set_response_matches(struct modem_chat_script_chat *script_chat,
+						const struct modem_chat_match *response_matches,
+						uint16_t response_matches_size)
+{
+	if (!modem_chat_validate_array(response_matches, response_matches_size)) {
+		return -EINVAL;
+	}
+
+	script_chat->response_matches = response_matches;
+	script_chat->response_matches_size = response_matches_size;
+	return 0;
+}
+
+void modem_chat_script_chat_set_timeout(struct modem_chat_script_chat *script_chat,
+					uint16_t timeout)
+{
+	script_chat->timeout = timeout;
 }

--- a/tests/subsys/modem/modem_chat/src/main.c
+++ b/tests/subsys/modem/modem_chat/src/main.c
@@ -676,6 +676,34 @@ ZTEST(modem_chat, test_script_chat_timeout_cmd)
 		      "Script sent too many requests");
 }
 
+ZTEST(modem_chat, test_runtime_match)
+{
+	int ret;
+	struct modem_chat_match test_match;
+
+	modem_chat_match_init(&test_match);
+
+	ret = modem_chat_match_set_match(&test_match, "AT345");
+	zassert_ok(ret, "Failed to set match");
+	zassert_ok(strcmp(test_match.match, "AT345"), "Failed to set match");
+	zassert_equal(test_match.match_size, 5, "Failed to set size of match");
+
+	ret = modem_chat_match_set_separators(&test_match, ",*");
+	zassert_ok(ret, "Failed to set match");
+	zassert_ok(strcmp(test_match.separators, ",*"), "Failed to set separators");
+	zassert_equal(test_match.separators_size, 2, "Failed to set size of separators");
+
+	modem_chat_match_set_partial(&test_match, true);
+	zassert_equal(test_match.partial, true);
+	modem_chat_match_set_partial(&test_match, false);
+	zassert_equal(test_match.partial, false);
+
+	modem_chat_match_enable_wildcards(&test_match, true);
+	zassert_equal(test_match.wildcards, true);
+	modem_chat_match_enable_wildcards(&test_match, false);
+	zassert_equal(test_match.wildcards, false);
+}
+
 /*************************************************************************************************/
 /*                                         Test suite                                            */
 /*************************************************************************************************/

--- a/tests/subsys/modem/modem_chat/src/main.c
+++ b/tests/subsys/modem/modem_chat/src/main.c
@@ -704,6 +704,36 @@ ZTEST(modem_chat, test_runtime_match)
 	zassert_equal(test_match.wildcards, false);
 }
 
+ZTEST(modem_chat, test_runtime_script_chat)
+{
+	int ret;
+	struct modem_chat_script_chat test_script_chat;
+	struct modem_chat_match test_response_matches[2];
+
+	modem_chat_script_chat_init(&test_script_chat);
+
+	ret = modem_chat_script_chat_set_request(&test_script_chat, "AT345");
+	zassert_ok(ret, "Failed to set request");
+	zassert_ok(strcmp(test_script_chat.request, "AT345"), "Failed to set script_chat");
+	zassert_equal(test_script_chat.request_size, 5, "Failed to set size of script_chat");
+
+	ret = modem_chat_script_chat_set_response_matches(&test_script_chat,
+							  test_response_matches,
+							  ARRAY_SIZE(test_response_matches));
+	zassert_ok(ret, "Failed to set response matches");
+	zassert_equal(test_script_chat.response_matches, test_response_matches,
+		      "Failed to set response_matches");
+	zassert_equal(test_script_chat.response_matches_size, ARRAY_SIZE(test_response_matches),
+		      "Failed to set response_matches");
+
+	ret = modem_chat_script_chat_set_response_matches(&test_script_chat,
+							  test_response_matches, 0);
+	zassert_equal(ret, -EINVAL, "Should have failed to set response matches");
+
+	ret = modem_chat_script_chat_set_response_matches(&test_script_chat, NULL, 1);
+	zassert_equal(ret, -EINVAL, "Should have failed to set response matches");
+}
+
 /*************************************************************************************************/
 /*                                         Test suite                                            */
 /*************************************************************************************************/

--- a/tests/subsys/modem/modem_chat/src/main.c
+++ b/tests/subsys/modem/modem_chat/src/main.c
@@ -734,6 +734,45 @@ ZTEST(modem_chat, test_runtime_script_chat)
 	zassert_equal(ret, -EINVAL, "Should have failed to set response matches");
 }
 
+ZTEST(modem_chat, test_runtime_script)
+{
+	int ret;
+	struct modem_chat_script test_script;
+	struct modem_chat_script_chat test_script_chats[2];
+	struct modem_chat_match test_abort_matches[2];
+
+	modem_chat_script_init(&test_script);
+	zassert_equal(strlen(test_script.name), 0, "Failed to set default name");
+
+	ret = modem_chat_script_set_script_chats(&test_script, test_script_chats,
+						 ARRAY_SIZE(test_script_chats));
+	zassert_ok(ret, "Failed to set script chats");
+	zassert_equal(test_script.script_chats, test_script_chats,
+		      "Failed to set script_chats");
+	zassert_equal(test_script.script_chats_size, ARRAY_SIZE(test_script_chats),
+		      "Failed to set script_chats_size");
+
+	ret = modem_chat_script_set_script_chats(&test_script, test_script_chats, 0);
+	zassert_equal(ret, -EINVAL, "Should have failed to set script chats");
+
+	ret = modem_chat_script_set_script_chats(&test_script, NULL, 1);
+	zassert_equal(ret, -EINVAL, "Should have failed to set script chats");
+
+	ret = modem_chat_script_set_abort_matches(&test_script, test_abort_matches,
+						  ARRAY_SIZE(test_abort_matches));
+	zassert_ok(ret, "Failed to set abort matches");
+	zassert_equal(test_script.abort_matches, test_abort_matches,
+		      "Failed to set script_chats");
+	zassert_equal(test_script.abort_matches_size, ARRAY_SIZE(test_abort_matches),
+		      "Failed to set script_chats_size");
+
+	ret = modem_chat_script_set_abort_matches(&test_script, test_abort_matches, 0);
+	zassert_equal(ret, -EINVAL, "Should have failed to set abort matches");
+
+	ret = modem_chat_script_set_abort_matches(&test_script, NULL, 1);
+	zassert_equal(ret, -EINVAL, "Should have failed to set abort matches");
+}
+
 /*************************************************************************************************/
 /*                                         Test suite                                            */
 /*************************************************************************************************/


### PR DESCRIPTION
Adds dedicated API for manipulating `struct modem_chat_match` instances at runtime, to improve the currently working, but rather unsafe and wordy solution:
```
data->dynamic_match.match = data->dynamic_match_buf;
	data->dynamic_match.separators = data->dynamic_separators_buf;
	data->dynamic_match.separators_size = sizeof(data->dynamic_separators_buf);
	data->dynamic_match.wildcards = false;
	data->dynamic_match.partial = false;

	data->dynamic_script_chat.request = data->dynamic_request_buf;
	data->dynamic_script_chat.response_matches = &data->dynamic_match;
	data->dynamic_script_chat.response_matches_size = 1;
	data->dynamic_script_chat.timeout = 0;

	data->dynamic_script.name = "pair";
	data->dynamic_script.script_chats = &data->dynamic_script_chat;
	data->dynamic_script.script_chats_size = 1;
	data->dynamic_script.abort_matches = NULL;
	data->dynamic_script.abort_matches_size = 0;
	data->dynamic_script.callback = NULL;
	data->dynamic_script.timeout = 10;
```
turning it into:
```
	modem_chat_match_init(&data->pair_match);
	modem_chat_match_set_separators(&data->pair_match, ",*");

	modem_chat_script_chat_init(&data->pair_script_chat);
	modem_chat_script_chat_set_response_matches(&data->pair_script_chat, &data->pair_match, 1);

	modem_chat_script_init(&data->pair_script);
	modem_chat_script_set_name(&data->pair_script, "pair");
	modem_chat_script_set_script_chats(&data->pair_script, &data->pair_script_chat, 1);
	modem_chat_script_set_abort_matches(&data->pair_script, &data->pair_match, 1);
	modem_chat_script_set_timeout(&data->pair_script, 10);
```
This is way safer since the members are not directly interacted with, member values are validated when set. A notable safety improvement is updating the size of a modem_chat to match the string length, which was manually done before this PR like this:
```
	/* update buffer first */
	ret = gnss_nmea0183_snprintk(data->pair_request_buf, sizeof(data->pair_request_buf),
				     "PAIR752,%u,%u", pps_mode, config->pps_pulse_width);
	if (ret < 0) {
		return ret;
	}

	/* manually set request size to match strlen of buffer (not checking if length exceeds UINT16_MAX) */
	data->pair_script_chat.request_size = ret;
```
After this PR, the buffer is first updated, then set using the new runtime API
```
	/* update buffer first */
	ret = gnss_nmea0183_snprintk(data->pair_request_buf, sizeof(data->pair_request_buf),
				     "PAIR752,%u,%u", pps_mode, config->pps_pulse_width);
	if (ret < 0) {
		return ret;
	}

	/* set buffer using runtime API */
	ret = modem_chat_script_chat_set_request(&data->pair_script_chat, data->pair_request_buf);
	if (ret < 0) {
		return ret;
	}
```