### PR TITLE
stm32 watchdog testing on stm32c031 nucleo board

### DIFF
--- a/samples/drivers/watchdog/sample.yaml
+++ b/samples/drivers/watchdog/sample.yaml
@@ -27,6 +27,7 @@ tests:
     filter: dt_compat_enabled("st,stm32-window-watchdog")
     platform_allow:
       - b_u585i_iot02a
+      - nucleo_c031c6
       - nucleo_f091rc
       - nucleo_f103rb
       - nucleo_f207zg
@@ -53,6 +54,7 @@ tests:
     filter: dt_compat_enabled("st,stm32-watchdog")
     platform_allow:
       - b_u585i_iot02a
+      - nucleo_c031c6
       - nucleo_f091rc
       - nucleo_f103rb
       - nucleo_f207zg


### PR DESCRIPTION
Add the nucleo_c031c6 target to run the samples/drivers/watchdog for iwdg and wwdg on the stm32c0 serie.
and also tests/drivers/watchdog

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/69035
