### PR TITLE
bindings: net: nfct: Utilize EasyDMA property

### DIFF
--- a/dts/bindings/net/wireless/nordic,nrf-nfct.yaml
+++ b/dts/bindings/net/wireless/nordic,nrf-nfct.yaml
@@ -5,7 +5,7 @@ description: Nordic nRF family NFCT (Near Field Communication Tag)
 
 compatible: "nordic,nrf-nfct"
 
-include: base.yaml
+include: [base.yaml, memory-region.yaml]
 
 properties:
   reg:


### PR DESCRIPTION
This adds additional memory region property
to NFCT peripheral. This is not mandatory
property, it adds possibility to user to
specify memory region for DMA transfer.
If it is not set then data buffer is placed
in default RAM with other data.