### PR TITLE
drivers: adc: :adc_ad559x: add various fixes and improvements

### DIFF
--- a/drivers/adc/adc_ad559x.c
+++ b/drivers/adc/adc_ad559x.c
@@ -21,6 +21,7 @@ LOG_MODULE_REGISTER(adc_ad559x, CONFIG_ADC_LOG_LEVEL);
 #define AD559X_ADC_RD_POINTER      0x40
 
 #define AD559X_ADC_RESOLUTION 12U
+#define AD559X_ADC_VREF_MV 2500U
 
 struct adc_ad559x_config {
 	const struct device *mfd_dev;
@@ -257,6 +258,7 @@ static const struct adc_driver_api adc_ad559x_api = {
 #ifdef CONFIG_ADC_ASYNC
 	.read_async = adc_ad559x_read_async,
 #endif
+	.ref_internal = AD559X_ADC_VREF_MV,
 };
 
 #define ADC_AD559X_DEFINE(inst)                                                                    \

--- a/drivers/adc/adc_ad559x.c
+++ b/drivers/adc/adc_ad559x.c
@@ -242,9 +242,11 @@ static int adc_ad559x_init(const struct device *dev)
 			(k_thread_entry_t)adc_ad559x_acquisition_thread, data, NULL, NULL,
 			CONFIG_ADC_AD559X_ACQUISITION_THREAD_PRIO, 0, K_NO_WAIT);
 
-	ret = k_thread_name_set(tid, "adc_ad559x");
-	if (ret < 0) {
-		return ret;
+	if (IS_ENABLED(CONFIG_THREAD_NAME)) {
+		ret = k_thread_name_set(tid, "adc_ad559x");
+		if (ret < 0) {
+			return ret;
+		}
 	}
 
 	adc_context_unlock_unconditionally(&data->ctx);


### PR DESCRIPTION
Add the following fixes and improvements:

1. Add configuration of internal refference voltage value so raw ADC readings can be converted to mV utilizing dc_raw_to_millivolts() ADC API function.

2. Fix driver start with CONFIG_THREAD_NAME not enabled.

3. Improve ADC read function to make it robust.


