### PR TITLE
buildsystem: Enable LTO also for the application

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,7 +214,7 @@ endif()
 zephyr_compile_options(${OPTIMIZATION_FLAG})
 
 if(CONFIG_LTO)
-  add_compile_options($<TARGET_PROPERTY:compiler,optimization_lto>)
+  zephyr_compile_options($<TARGET_PROPERTY:compiler,optimization_lto>)
   add_link_options($<TARGET_PROPERTY:linker,lto_arguments>)
 endif()
 

--- a/lib/libc/newlib/CMakeLists.txt
+++ b/lib/libc/newlib/CMakeLists.txt
@@ -3,6 +3,9 @@
 zephyr_library()
 zephyr_library_sources(libc-hooks.c)
 
+# Do not allow LTO when compiling libc-hooks.c file
+set_source_files_properties(libc-hooks.c PROPERTIES COMPILE_OPTIONS $<TARGET_PROPERTY:compiler,prohibit_lto>)
+
 # Zephyr normally uses -ffreestanding, which with current GNU toolchains
 # means that the flag macros used by newlib 3.x <inttypes.h> to signal
 # support for PRI.64 macros are not present.  To make them available we

--- a/lib/libc/picolibc/CMakeLists.txt
+++ b/lib/libc/picolibc/CMakeLists.txt
@@ -3,6 +3,9 @@
 zephyr_library()
 zephyr_library_sources(libc-hooks.c)
 
+# Do not allow LTO when compiling libc-hooks.c file
+set_source_files_properties(libc-hooks.c PROPERTIES COMPILE_OPTIONS $<TARGET_PROPERTY:compiler,prohibit_lto>)
+
 # define __LINUX_ERRNO_EXTENSIONS__ so we get errno defines like -ESHUTDOWN
 # used by the network stack
 zephyr_compile_definitions(__LINUX_ERRNO_EXTENSIONS__)


### PR DESCRIPTION
It turns out that currently LTO is enabled only for the kernel. This commit updates it to enable it for the whole application and adds additional LTO exclusions required for the standard C libraries to build and link properly.