### PR TITLE
modules: hal_nordic: require nrf-regtool 5.1.0

### DIFF
--- a/modules/hal_nordic/CMakeLists.txt
+++ b/modules/hal_nordic/CMakeLists.txt
@@ -11,7 +11,7 @@ if(CONFIG_NRF_REGTOOL_GENERATE_UICR)
   list(APPEND nrf_regtool_components GENERATE:UICR)
 endif()
 if(DEFINED nrf_regtool_components)
-  find_package(nrf-regtool 5.0.1
+  find_package(nrf-regtool 5.1.0
     COMPONENTS ${nrf_regtool_components}
     PATHS ${CMAKE_CURRENT_LIST_DIR}/nrf-regtool
     NO_CMAKE_PATH


### PR DESCRIPTION
This new version is required to handle the upcoming IPC-related DT structure (i.e. BELLBOARD/VEVIF).