### PR TITLE
drivers: clock_control: Fix STM32H5 MCO2 support

### DIFF
--- a/drivers/clock_control/Kconfig.stm32
+++ b/drivers/clock_control/Kconfig.stm32
@@ -253,6 +253,7 @@ config CLOCK_STM32_MCO2_DIV
 	depends on !CLOCK_STM32_MCO2_SRC_NOCLOCK && (\
 	             SOC_SERIES_STM32F4X || \
 	             SOC_SERIES_STM32F7X || \
+	             SOC_SERIES_STM32H5X || \
 	             SOC_SERIES_STM32H7X \
 	           )
 	default 1


### PR DESCRIPTION
Add STM32H5 to the list of dependencies for CLOCK_STM32_MCO2_DIV.  Without the change, attempting to build using MCO2 would cause build errors.

Fixes #69483.