### PR TITLE
[RFC] drivers: crypto: Support working on net_pkt when using AES-CTR

### DIFF
--- a/drivers/crypto/crypto_tc_shim.c
+++ b/drivers/crypto/crypto_tc_shim.c
@@ -116,16 +116,24 @@ static int do_cbc_decrypt(struct cipher_ctx *ctx, struct cipher_pkt *op,
 }
 
 static int do_ctr_op(struct cipher_ctx *ctx, struct cipher_pkt *op,
-		     uint8_t *iv)
+		     uint8_t *ctr)
 {
 	struct tc_shim_drv_state *data =  ctx->drv_sessn_state;
-	uint8_t ctr[16] = {0};	/* CTR mode Counter =  iv:ctr */
-	int ivlen = ctx->keylen - (ctx->mode_params.ctr_info.ctr_len >> 3);
 
-	/* Tinycrypt takes the last 4 bytes of the counter parameter as the
-	 * true counter start. IV forms the first 12 bytes of the split counter.
-	 */
-	memcpy(ctr, iv, ivlen);
+	/* The counter needs to be initialized exactly once per session */
+	if (data->ctr_initialized == false) {
+		const uint_fast16_t ivlen = ctx->keylen - (ctx->mode_params.ctr_info.ctr_len >> 3);
+
+		/*
+		 * Tinycrypt takes the last 4 bytes of the counter parameter as the
+		 * true counter start. IV forms the first 12 bytes of the split counter.
+		 */
+		memcpy(ctr, ctx->mode_params.ctr_info.iv, ivlen);
+		memset(ctr + ivlen, 0, 16 - ivlen);
+		ctr[15] = ctx->mode_params.ctr_info.ctr_initial;
+
+		data->ctr_initialized = true;
+	}
 
 	if (tc_ctr_mode(op->out_buf, op->out_buf_max, op->in_buf,
 			op->in_len, ctr,
@@ -293,6 +301,10 @@ static int tc_session_setup(const struct device *dev, struct cipher_ctx *ctx,
 			ctx->ops.cbc_crypt_hndlr = do_cbc_decrypt;
 			break;
 		case CRYPTO_CIPHER_MODE_CTR:
+			if (ctx->mode_params.ctr_info.iv == NULL) {
+				LOG_ERR("Missing initialization vector");
+				return -EINVAL;
+			}
 			/* Maybe validate CTR length */
 			if (ctx->mode_params.ctr_info.ctr_len != 32U) {
 				LOG_ERR("Tinycrypt supports only 32 bit "
@@ -347,6 +359,7 @@ static int tc_session_free(const struct device *dev, struct cipher_ctx *sessn)
 	ARG_UNUSED(dev);
 	(void)memset(data, 0, sizeof(struct tc_shim_drv_state));
 	data->in_use = false;
+	data->ctr_initialized = false;
 
 	return 0;
 }

--- a/drivers/crypto/crypto_tc_shim.c
+++ b/drivers/crypto/crypto_tc_shim.c
@@ -21,6 +21,8 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(tinycrypt);
 
+#include <stdbool.h>
+
 #define CRYPTO_MAX_SESSION CONFIG_CRYPTO_TINYCRYPT_SHIM_MAX_SESSION
 
 static struct tc_shim_drv_state tc_driver_state[CRYPTO_MAX_SESSION];
@@ -221,8 +223,8 @@ static int get_unused_session(void)
 	int i;
 
 	for (i = 0; i < CRYPTO_MAX_SESSION; i++) {
-		if (tc_driver_state[i].in_use == 0) {
-			tc_driver_state[i].in_use = 1;
+		if (tc_driver_state[i].in_use == false) {
+			tc_driver_state[i].in_use = true;
 			break;
 		}
 	}
@@ -323,7 +325,7 @@ static int tc_session_setup(const struct device *dev, struct cipher_ctx *ctx,
 	if (tc_aes128_set_encrypt_key(&data->session_key, ctx->key.bit_stream)
 			 == TC_CRYPTO_FAIL) {
 		LOG_ERR("TC internal error in setting key");
-		tc_driver_state[idx].in_use = 0;
+		tc_driver_state[idx].in_use = false;
 
 		return -EIO;
 	}
@@ -344,7 +346,7 @@ static int tc_session_free(const struct device *dev, struct cipher_ctx *sessn)
 
 	ARG_UNUSED(dev);
 	(void)memset(data, 0, sizeof(struct tc_shim_drv_state));
-	data->in_use = 0;
+	data->in_use = false;
 
 	return 0;
 }
@@ -355,7 +357,7 @@ static int tc_shim_init(const struct device *dev)
 
 	ARG_UNUSED(dev);
 	for (i = 0; i < CRYPTO_MAX_SESSION; i++) {
-		tc_driver_state[i].in_use = 0;
+		tc_driver_state[i].in_use = false;
 	}
 
 	return 0;

--- a/drivers/crypto/crypto_tc_shim_priv.h
+++ b/drivers/crypto/crypto_tc_shim_priv.h
@@ -23,6 +23,14 @@
 
 struct tc_shim_drv_state {
 	bool in_use;
+
+	/**
+	 * True if counter argument got initialized using the initialization vector.
+	 *
+	 * Warning: Counters can not be preserved across crypto session!
+	 */
+	bool ctr_initialized;
+
 	struct tc_aes_key_sched_struct session_key;
 };
 

--- a/drivers/crypto/crypto_tc_shim_priv.h
+++ b/drivers/crypto/crypto_tc_shim_priv.h
@@ -17,10 +17,12 @@
 #ifndef ZEPHYR_DRIVERS_CRYPTO_CRYPTO_TC_SHIM_PRIV_H_
 #define ZEPHYR_DRIVERS_CRYPTO_CRYPTO_TC_SHIM_PRIV_H_
 
+#include <stdbool.h>
+
 #include <tinycrypt/aes.h>
 
 struct tc_shim_drv_state {
-	int in_use;
+	bool in_use;
 	struct tc_aes_key_sched_struct session_key;
 };
 

--- a/include/zephyr/crypto/cipher.h
+++ b/include/zephyr/crypto/cipher.h
@@ -94,6 +94,12 @@ struct ctr_params {
 	 * such that ivlen + ctr_len = keylen
 	 */
 	uint32_t ctr_len;
+
+	/** This field allows to start with a counter value of something else than 0. */
+	uint8_t ctr_initial;
+
+	/** Initialization vector, used to initialize counter */
+	const uint8_t *iv;
 };
 
 struct gcm_params {

--- a/include/zephyr/crypto/crypto.h
+++ b/include/zephyr/crypto/crypto.h
@@ -283,26 +283,20 @@ static inline int cipher_cbc_op(struct cipher_ctx *ctx,
  *
  * @param  ctx       Pointer to the crypto context of this op.
  * @param  pkt   Structure holding the input/output buffer pointers.
- * @param  iv        Initialization Vector (IV) for the operation. We use a
- *			 split counter formed by appending IV and ctr.
- *			 Consequently  ivlen = keylen - ctrlen. 'ctrlen' is
- *			 specified during session setup through the
- *			 'ctx.mode_params.ctr_params.ctr_len' parameter. IV
- *			 should not be reused across multiple operations
- *			 (within a session context) for security. The non-IV
- *			 part of the split counter is transparent to the caller
- *			 and is fully managed by the crypto provider.
+ * @param  ctr   Counter for the operation. Initialized based on the configured, this argument gets
+ *               initialized on the first run, and updated after every invocation. User needs to
+ *               provide the same buffer during the whole session
  *
  * @return 0 on success, negative errno code on fail.
  */
 static inline int cipher_ctr_op(struct cipher_ctx *ctx,
-				struct cipher_pkt *pkt, uint8_t *iv)
+				struct cipher_pkt *pkt, uint8_t *ctr)
 {
 	__ASSERT(ctx->ops.cipher_mode == CRYPTO_CIPHER_MODE_CTR, "CTR mode "
 		 "session invoking a different mode handler");
 
 	pkt->ctx = ctx;
-	return ctx->ops.ctr_crypt_hndlr(ctx, pkt, iv);
+	return ctx->ops.ctr_crypt_hndlr(ctx, pkt, ctr);
 }
 
 /**

--- a/samples/drivers/crypto/sample.yaml
+++ b/samples/drivers/crypto/sample.yaml
@@ -17,9 +17,12 @@ tests:
       type: multi_line
       regex:
         - ".*: Cipher Sample"
-        - ".*: CBC Mode"
-        - ".*: CTR Mode"
-        - ".*: CCM Mode"
+        - ".*: CBC mode ENCRYPT - Match"
+        - ".*: CBC mode DECRYPT - Match"
+        - ".*: CTR mode ENCRYPT - Match"
+        - ".*: CTR mode DECRYPT - Match"
+        - ".*: CCM mode ENCRYPT - Match"
+        - ".*: CCM mode DECRYPT - Match"
         - ".*: GCM Mode"
   sample.drivers.crypto.mbedtls:
     min_flash: 34
@@ -31,10 +34,15 @@ tests:
       type: multi_line
       regex:
         - ".*: Cipher Sample"
-        - ".*: CBC Mode"
+        - ".*: ECB mode ENCRYPT - Match"
+        - ".*: ECB mode DECRYPT - Match"
+        - ".*: CBC mode ENCRYPT - Match"
+        - ".*: CBC mode DECRYPT - Match"
         - ".*: CTR Mode"
-        - ".*: CCM Mode"
-        - ".*: GCM Mode"
+        - ".*: CCM mode ENCRYPT - Match"
+        - ".*: CCM mode DECRYPT - Match"
+        - ".*: GCM mode ENCRYPT - Match"
+        - ".*: GCM mode DECRYPT - Match"
   sample.drivers.crypto.stm32:
     tags: crypto
     filter: dt_compat_enabled("st,stm32-aes") or dt_compat_enabled("st,stm32-cryp")

--- a/samples/drivers/crypto/sample.yaml
+++ b/samples/drivers/crypto/sample.yaml
@@ -17,6 +17,8 @@ tests:
       type: multi_line
       regex:
         - ".*: Cipher Sample"
+        - ".*: ECB mode ENCRYPT - Match"
+        - ".*: ECB mode DECRYPT - Match"
         - ".*: CBC mode ENCRYPT - Match"
         - ".*: CBC mode DECRYPT - Match"
         - ".*: CTR mode ENCRYPT - Match"

--- a/samples/drivers/crypto/sample.yaml
+++ b/samples/drivers/crypto/sample.yaml
@@ -22,6 +22,7 @@ tests:
         - ".*: CBC mode ENCRYPT - Match"
         - ".*: CBC mode DECRYPT - Match"
         - ".*: CTR mode ENCRYPT - Match"
+        - ".*: CTR mode ENCRYPT - Multi block support working"
         - ".*: CTR mode DECRYPT - Match"
         - ".*: CCM mode ENCRYPT - Match"
         - ".*: CCM mode DECRYPT - Match"


### PR DESCRIPTION
Because the initialization vector got re-applied during every
invocation, the AES-CTR implementation was not able to handle
non-contiguous data fragments. Such fragments are very common when
dealing with net_pkts. The contained net_bufs require a separate call
to cipher_ctr_op each.

As the function signature ctr_op_t suggests, this implementation
changes the 3rd parameter to actually be the (current) counter value,
not the initialization vector.

The counter value gets updated by the CTR cipher_ctr_op() implementation
and needs to be provided by the user on successive invocations.

To reset the counter value, the session needs to be restarted
(cipher_free_session() followed by a call to cipher_begin_session()).

Please note:
 - This commit does not contain the required adaptations for the STM32
platform, as a) I do not own the needed hardware and b) I'd like to get some feedback first.
 - Basing on PRs #69523 and #69479.