### PR TITLE
cmake: Set memusage property for lld

### DIFF
--- a/cmake/linker/lld/linker_flags.cmake
+++ b/cmake/linker/lld/linker_flags.cmake
@@ -4,6 +4,8 @@
 # Since lld is a drop in replacement for ld, we can just use ld's flags
 include(${ZEPHYR_BASE}/cmake/linker/ld/${COMPILER}/linker_flags.cmake OPTIONAL)
 
+check_set_linker_property(TARGET linker PROPERTY memusage "${LINKERFLAGPREFIX},--print-memory-usage")
+
 set_property(TARGET linker PROPERTY no_position_independent "${LINKERFLAGPREFIX},--no-pie")
 
 set_property(TARGET linker PROPERTY partial_linking "-r")


### PR DESCRIPTION
lld gained support for the --print-memory-usage flag somewhat recently (May 2023). Associate this flag with the memusage property when building with lld, similar to what is done for GNU ld.