### PR TITLE
scripts: size_report: display object address in overview

### DIFF
--- a/doc/develop/optimizations/tools.rst
+++ b/doc/develop/optimizations/tools.rst
@@ -59,48 +59,48 @@ Use the ``ram_report`` target with your board, as in the following example.
 
 These commands will generate something similar to the output below::
 
-    Path                                                                       Size    %
+    Path                                                           Size    %      Address
     ========================================================================================
-    Root                                                                       4637 100.00%
-    ├── (hidden)                                                                  4   0.09%
-    ├── (no paths)                                                             2748  59.26%
-    │   ├── _cpus_active                                                          4   0.09%
-    │   ├── _kernel                                                              32   0.69%
-    │   ├── _sw_isr_table                                                       384   8.28%
-    │   ├── cli.1                                                                16   0.35%
-    │   ├── on.2                                                                  4   0.09%
-    │   ├── poll_out_lock.0                                                       4   0.09%
-    │   ├── z_idle_threads                                                      128   2.76%
-    │   ├── z_interrupt_stacks                                                 2048  44.17%
-    │   └── z_main_thread                                                       128   2.76%
-    ├── WORKSPACE                                                               184   3.97%
-    │   └── modules                                                             184   3.97%
-    │       └── hal                                                             184   3.97%
-    │           └── nordic                                                      184   3.97%
-    │               └── nrfx                                                    184   3.97%
-    │                   └── drivers                                             184   3.97%
-    │                       └── src                                             184   3.97%
-    │                           ├── nrfx_clock.c                                  8   0.17%
-    │                           │   └── m_clock_cb                                8   0.17%
-    │                           ├── nrfx_gpiote.c                               132   2.85%
-    │                           │   └── m_cb                                    132   2.85%
-    │                           ├── nrfx_ppi.c                                    4   0.09%
-    │                           │   └── m_channels_allocated                      4   0.09%
-    │                           └── nrfx_twim.c                                  40   0.86%
-    │                               └── m_cb                                     40   0.86%
-    └── ZEPHYR_BASE                                                            1701  36.68%
-        ├── arch                                                                  5   0.11%
-        │   └── arm                                                               5   0.11%
-        │       └── core                                                          5   0.11%
-        │           ├── mpu                                                       1   0.02%
-        │           │   └── arm_mpu.c                                             1   0.02%
-        │           │       └── static_regions_num                                1   0.02%
-        │           └── tls.c                                                     4   0.09%
-        │               └── z_arm_tls_ptr                                         4   0.09%
-        ├── drivers                                                             258   5.56%
-        │   ├── ...                                                             ...    ...%
+    Root                                                           4637 100.00%  -
+    ├── (hidden)                                                      4   0.09%  -
+    ├── (no paths)                                                 2748  59.26%  -
+    │   ├── _cpus_active                                              4   0.09%  0x20000314
+    │   ├── _kernel                                                  32   0.69%  0x20000318
+    │   ├── _sw_isr_table                                           384   8.28%  0x00006474
+    │   ├── cli.1                                                    16   0.35%  0x20000254
+    │   ├── on.2                                                      4   0.09%  0x20000264
+    │   ├── poll_out_lock.0                                           4   0.09%  0x200002d4
+    │   ├── z_idle_threads                                          128   2.76%  0x20000120
+    │   ├── z_interrupt_stacks                                     2048  44.17%  0x20000360
+    │   └── z_main_thread                                           128   2.76%  0x200001a0
+    ├── WORKSPACE                                                   184   3.97%  -
+    │   └── modules                                                 184   3.97%  -
+    │       └── hal                                                 184   3.97%  -
+    │           └── nordic                                          184   3.97%  -
+    │               └── nrfx                                        184   3.97%  -
+    │                   └── drivers                                 184   3.97%  -
+    │                       └── src                                 184   3.97%  -
+    │                           ├── nrfx_clock.c                      8   0.17%  -
+    │                           │   └── m_clock_cb                    8   0.17%  0x200002e4
+    │                           ├── nrfx_gpiote.c                   132   2.85%  -
+    │                           │   └── m_cb                        132   2.85%  0x20000060
+    │                           ├── nrfx_ppi.c                        4   0.09%  -
+    │                           │   └── m_channels_allocated          4   0.09%  0x200000e4
+    │                           └── nrfx_twim.c                      40   0.86%  -
+    │                               └── m_cb                         40   0.86%  0x200002ec
+    └── ZEPHYR_BASE                                                1701  36.68%  -
+        ├── arch                                                      5   0.11%  -
+        │   └── arm                                                   5   0.11%  -
+        │       └── core                                              5   0.11%  -
+        │           ├── mpu                                           1   0.02%  -
+        │           │   └── arm_mpu.c                                 1   0.02%  -
+        │           │       └── static_regions_num                    1   0.02%  0x20000348
+        │           └── tls.c                                         4   0.09%  -
+        │               └── z_arm_tls_ptr                             4   0.09%  0x20000240
+        ├── drivers                                                 258   5.56%  -
+        │   ├── ...                                                 ...    ...%
     ========================================================================================
-                                                                               4637
+                                                                   4637
 
 
 Build Target: rom_report
@@ -120,40 +120,40 @@ Use the ``rom_report`` target with your board, as in the following example.
 
 These commands will generate something similar to the output below::
 
-    Path                                                                       Size    %
+    Path                                                           Size    %      Address
     ========================================================================================
-    Root                                                                      21652 100.00%
-    ├── ...                                                                     ...    ...%
-    └── ZEPHYR_BASE                                                           13378  61.79%
-        ├── arch                                                               1718   7.93%
-        │   └── arm                                                            1718   7.93%
-        │       └── core                                                       1718   7.93%
-        │           ├── cortex_m                                               1020   4.71%
-        │           │   ├── fault.c                                             620   2.86%
-        │           │   │   ├── bus_fault.constprop.0                           108   0.50%
-        │           │   │   ├── mem_manage_fault.constprop.0                    120   0.55%
-        │           │   │   ├── usage_fault.constprop.0                          84   0.39%
-        │           │   │   ├── z_arm_fault                                     292   1.35%
-        │           │   │   └── z_arm_fault_init                                 16   0.07%
-        │           │   ├── ...                                                 ...    ...%
-        ├── boards                                                               32   0.15%
-        │   └── arm                                                              32   0.15%
-        │       └── reel_board                                                   32   0.15%
-        │           └── board.c                                                  32   0.15%
-        │               ├── __init_board_reel_board_init                          8   0.04%
-        │               └── board_reel_board_init                                24   0.11%
-        ├── build                                                               194   0.90%
-        │   └── zephyr                                                          194   0.90%
-        │       ├── isr_tables.c                                                192   0.89%
-        │       │   └── _irq_vector_table                                       192   0.89%
-        │       └── misc                                                          2   0.01%
-        │           └── generated                                                 2   0.01%
-        │               └── configs.c                                             2   0.01%
-        │                   └── _ConfigAbsSyms                                    2   0.01%
-        ├── drivers                                                            6162  28.46%
-        │   ├── ...                                                             ...    ...%
+    Root                                                          27828 100.00%  -
+    ├── ...                                                         ...    ...%
+    └── ZEPHYR_BASE                                               13558  48.72%  -
+        ├── arch                                                   1766   6.35%  -
+        │   └── arm                                                1766   6.35%  -
+        │       └── core                                           1766   6.35%  -
+        │           ├── cortex_m                                   1020   3.67%  -
+        │           │   ├── fault.c                                 620   2.23%  -
+        │           │   │   ├── bus_fault.constprop.0               108   0.39%  0x00000749
+        │           │   │   ├── mem_manage_fault.constprop.0        120   0.43%  0x000007b5
+        │           │   │   ├── usage_fault.constprop.0              84   0.30%  0x000006f5
+        │           │   │   ├── z_arm_fault                         292   1.05%  0x0000082d
+        │           │   │   └── z_arm_fault_init                     16   0.06%  0x00000951
+        │           │   ├── ...                                     ...    ...%
+        ├── boards                                                   32   0.11%  -
+        │   └── arm                                                  32   0.11%  -
+        │       └── reel_board                                       32   0.11%  -
+        │           └── board.c                                      32   0.11%  -
+        │               ├── __init_board_reel_board_init              8   0.03%  0x000063e4
+        │               └── board_reel_board_init                    24   0.09%  0x00000ed5
+        ├── build                                                   194   0.70%  -
+        │   └── zephyr                                              194   0.70%  -
+        │       ├── isr_tables.c                                    192   0.69%  -
+        │       │   └── _irq_vector_table                           192   0.69%  0x00000040
+        │       └── misc                                              2   0.01%  -
+        │           └── generated                                     2   0.01%  -
+        │               └── configs.c                                 2   0.01%  -
+        │                   └── _ConfigAbsSyms                        2   0.01%  0x00005945
+        ├── drivers                                                6282  22.57%  -
+        │   ├── ...                                                 ...    ...%
     ========================================================================================
-                                                                                    21652
+                                                                  21652
 
 Build Target: puncover
 ======================

--- a/scripts/footprint/size_report
+++ b/scripts/footprint/size_report
@@ -28,6 +28,7 @@ from anytree.exporter import DictExporter
 
 import elftools
 from elftools.elf.elffile import ELFFile
+from elftools.elf.relocation import RelocationSection
 from elftools.elf.sections import SymbolTableSection
 from elftools.dwarf.descriptions import describe_form_class
 from elftools.dwarf.descriptions import (
@@ -531,12 +532,13 @@ class TreeNode(NodeMixin):
     A symbol node.
     """
 
-    def __init__(self, name, identifier, size=0, parent=None, children=None):
+    def __init__(self, name, identifier, size=0, parent=None, children=None, address=0):
         super().__init__()
         self._name = name
         self._size = size
         self.parent = parent
         self._identifier = identifier
+        self.address = address
         if children:
             self.children = children
 
@@ -582,7 +584,7 @@ def generate_any_tree(symbol_dict, total_size, path_prefix):
 
     # A set of helper function for building a simple tree with a path-like
     # hierarchy.
-    def _insert_one_elem(root, path, size):
+    def _insert_one_elem(root, path, size, addr):
         cur = None
         node = None
         parent = root
@@ -600,7 +602,7 @@ def generate_any_tree(symbol_dict, total_size, path_prefix):
             else:
                 if node:
                     parent = node
-                node = TreeNode(name=str(part), identifier=cur, size=size, parent=parent)
+                node = TreeNode(name=str(part), identifier=cur, size=size, parent=parent, address=addr)
 
     # Mapping paths to tree nodes
     path_node_map = [
@@ -616,6 +618,7 @@ def generate_any_tree(symbol_dict, total_size, path_prefix):
     for name, sym in symbol_dict.items():
         for symbol in sym:
             size = get_symbol_size(symbol['symbol'])
+            addr = get_symbol_addr(symbol['symbol'])
             for file in symbol['mapped_files']:
                 path = Path(file, name)
                 if path.is_absolute():
@@ -633,7 +636,7 @@ def generate_any_tree(symbol_dict, total_size, path_prefix):
                 else:
                     dest_node = node_no_paths
 
-                _insert_one_elem(dest_node, path, size)
+                _insert_one_elem(dest_node, path, size, addr)
 
 
     if node_zephyr_base is not root:
@@ -680,25 +683,27 @@ def print_any_tree(root, total_size, depth):
     """
     Print the symbol tree.
     """
-    print('{:101s} {:7s} {:8s}'.format(
-        Fore.YELLOW + "Path", "Size", "%" + Fore.RESET))
-    print('=' * 110)
+    print('{:101s} {:7s} {:8s} {:10s}'.format(
+        Fore.YELLOW + "Path", "Size", "%", "Address" + Fore.RESET))
+    print('=' * 126)
     for row in RenderTree(root, childiter=node_sort, maxlevel=depth):
         f = len(row.pre) + len(row.node._name)
         s = str(row.node._size).rjust(100-f)
         percent = 100 * float(row.node._size) / float(total_size)
 
+        hex_addr = "-"
         cc = cr = ""
         if not row.node.children:
             if row.node._name != "(hidden)":
+                hex_addr = "0x{:08x}".format(row.node.address)
                 cc = Fore.CYAN
                 cr = Fore.RESET
         elif row.node._name.endswith(SRC_FILE_EXT):
             cc = Fore.GREEN
             cr = Fore.RESET
 
-        print(f"{row.pre}{cc}{row.node._name} {s} {cr}{Fore.BLUE}{percent:6.2f}%{Fore.RESET}")
-    print('=' * 110)
+        print(f"{row.pre}{cc}{row.node._name} {s} {cr}{Fore.BLUE}{percent:6.2f}%{Fore.RESET}  {hex_addr}")
+    print('=' * 126)
     print(f'{total_size:>101}')
 
 


### PR DESCRIPTION
Adds RAM address of static allocated objects to determine which RAM-bank is used