### PR TITLE
STM32 ADC with DMA fixes

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -221,12 +221,9 @@ static void adc_stm32_enable_dma_support(ADC_TypeDef *adc)
 
 #if defined(ADC_VER_V5_V90)
 	if (adc == ADC3) {
-		LL_ADC_REG_SetDMATransferMode(adc,
-			ADC3_CFGR_DMACONTREQ(LL_ADC_REG_DMA_TRANSFER_LIMITED));
-		LL_ADC_EnableDMAReq(adc);
+		LL_ADC_REG_SetDMATransferMode(adc, LL_ADC3_REG_DMA_TRANSFER_LIMITED);
 	} else {
-		LL_ADC_REG_SetDataTransferMode(adc,
-			ADC_CFGR_DMACONTREQ(LL_ADC_REG_DMA_TRANSFER_LIMITED));
+		LL_ADC_REG_SetDataTransferMode(adc, LL_ADC_REG_DMA_TRANSFER_LIMITED);
 	}
 #elif defined(ADC_VER_V5_X)
 	LL_ADC_REG_SetDataTransferMode(adc, LL_ADC_REG_DMA_TRANSFER_LIMITED);
@@ -238,7 +235,15 @@ static void adc_stm32_enable_dma_support(ADC_TypeDef *adc)
 
 #error "The STM32F1 ADC + DMA is not yet supported"
 
-#else /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32f1_adc) */
+#elif defined(CONFIG_SOC_SERIES_STM32U5X) /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32f1_adc) */
+
+	if (adc == ADC4) {
+		LL_ADC_REG_SetDMATransfer(adc, LL_ADC_REG_DMA_TRANSFER_LIMITED_ADC4);
+	} else {
+		LL_ADC_REG_SetDataTransferMode(adc, LL_ADC_REG_DMA_TRANSFER_LIMITED);
+	}
+
+#else /* defined(CONFIG_SOC_SERIES_STM32U5X) */
 
 	/* Default mechanism for other MCUs */
 	LL_ADC_REG_SetDMATransfer(adc, LL_ADC_REG_DMA_TRANSFER_LIMITED);

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -1550,7 +1550,7 @@ static const struct adc_driver_api api_stm32_driver_api = {
 #define ADC_DMA_CHANNEL_INIT(index, src_dev, dest_dev)					\
 	.dma = {									\
 		.dma_dev = DEVICE_DT_GET(DT_INST_DMAS_CTLR_BY_IDX(index, 0)),		\
-		.channel = STM32_DMA_SLOT_BY_IDX(index, 0, channel),			\
+		.channel = DT_INST_DMAS_CELL_BY_IDX(index, 0, channel),			\
 		.dma_cfg = {								\
 			.dma_slot = STM32_DMA_SLOT_BY_IDX(index, 0, slot),		\
 			.channel_direction = STM32_DMA_CONFIG_DIRECTION(		\
@@ -1675,6 +1675,8 @@ DT_INST_FOREACH_STATUS_OKAY(GENERATE_ISR)
 #define ADC_STM32_IRQ_FUNC(index)                                                                  \
 	.irq_cfg_func = COND_CODE_1(IS_EQ(index, FIRST_WITH_IRQN(index)),                          \
 				    (UTIL_CAT(ISR_FUNC(index), _init)), (NULL)),
+
+#define ADC_DMA_CHANNEL_INIT(index, src_dev, dest_dev)
 
 #endif /* CONFIG_ADC_STM32_DMA */
 

--- a/include/zephyr/drivers/dma/dma_stm32.h
+++ b/include/zephyr/drivers/dma/dma_stm32.h
@@ -33,7 +33,7 @@
 /* macro for dma slot (only for dma-v1 or dma-v2 types) */
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_dma_v2bis)
 #define STM32_DMA_SLOT(id, dir, slot) 0
-#define STM32_DMA_SLOT_BY_IDX(id, idx, slot)
+#define STM32_DMA_SLOT_BY_IDX(id, idx, slot) 0
 #else
 #define STM32_DMA_SLOT(id, dir, slot) DT_INST_DMAS_CELL_BY_NAME(id, dir, slot)
 #define STM32_DMA_SLOT_BY_IDX(id, idx, slot) DT_INST_DMAS_CELL_BY_IDX(id, idx, slot)


### PR DESCRIPTION
This PR fixes some problems that prevented the use of ADC with DMA for series with dma_v2bis DMA types.
Also prevents compilation failure in case a DMA is defined in an ADC dts node, but the macro STM32_ADC_DMA is disabled.