### PR TITLE
debug: coredump: do not call LOG_PROCESS before LOG_PANIC

### DIFF
--- a/subsys/debug/coredump/coredump_backend_logging.c
+++ b/subsys/debug/coredump/coredump_backend_logging.c
@@ -30,10 +30,6 @@ static void coredump_logging_backend_start(void)
 	/* Reset error */
 	error = 0;
 
-	while (LOG_PROCESS()) {
-		;
-	}
-
 	LOG_PANIC();
 	LOG_ERR(COREDUMP_PREFIX_STR COREDUMP_BEGIN_STR);
 }


### PR DESCRIPTION
COREDUMP logging backend should not process pending log messages before calling LOG_PANIC, doing so causes interrupt-using log backends (e.g. CONFIG_LOG_BACKEND_UART_ASYNC) to drop messages because they do not switch to blocking/polling mode in time.

Described behavior can be reproduced with a simple project looking as follows:
prj.conf
```
CONFIG_UART_ASYNC_API=y

CONFIG_LOG=y
CONFIG_LOG_BACKEND_UART=y
CONFIG_LOG_BACKEND_UART_ASYNC=y
CONFIG_LOG_MODE_DEFERRED=y

CONFIG_DEBUG_COREDUMP=y
CONFIG_DEBUG_COREDUMP_BACKEND_LOGGING=y

CONFIG_RESET_ON_FATAL_ERROR=n
```
main.c
```c
#include <zephyr/kernel.h>
#include <zephyr/logging/log.h>

int main(void)
{
    k_sleep(K_SECONDS(2));
    return 1 / 0;
}
```

With the current implementation of  `coredump_logging_backend_start` on fatal error some logs from the "os" module (a block starting with `<err> os: ***** USAGE FAULT *****`) will be silently dropped, whereas with my change both this block and everything related to COREDUMP itself are displayed.
Tested on nrf52dk_nrf52832