### PR TITLE
tests: kernel/cache: Do not invd the whole cache

### DIFF
--- a/tests/kernel/cache/src/test_cache_api.c
+++ b/tests/kernel/cache/src/test_cache_api.c
@@ -51,9 +51,6 @@ ZTEST(cache_api, test_data_cache_api)
 	ret = sys_cache_data_flush_all();
 	zassert_true((ret == 0) || (ret == -ENOTSUP));
 
-	ret = sys_cache_data_invd_all();
-	zassert_true((ret == 0) || (ret == -ENOTSUP));
-
 	ret = sys_cache_data_flush_and_invd_all();
 	zassert_true((ret == 0) || (ret == -ENOTSUP));
 


### PR DESCRIPTION
That is dangerous and a big no-no. Remove it.

Fixes: #69394