### PR TITLE
Bluetooth: BAP: Shell: Add USB out support for the BAP shell

### DIFF
--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -400,6 +400,9 @@ struct bt_bap_ep_info {
 	/** @brief True if the stream associated with the endpoint is able to send data */
 	bool can_send;
 
+	/** @brief True if the stream associated with the endpoint is able to receive data */
+	bool can_recv;
+
 	/** Pointer to paired endpoint if the endpoint is part of a bidirectional CIS,
 	 *  otherwise NULL
 	 */

--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -186,7 +186,7 @@ static struct bt_bap_broadcast_sink *broadcast_sink_lookup_iso_chan(
 {
 	for (size_t i = 0U; i < ARRAY_SIZE(broadcast_sinks); i++) {
 		for (uint8_t j = 0U; j < broadcast_sinks[i].stream_count; j++) {
-			if (broadcast_sinks[i].bis[j] == chan) {
+			if (broadcast_sinks[i].bis[j].chan == chan) {
 				return &broadcast_sinks[i];
 			}
 		}
@@ -251,6 +251,7 @@ static void broadcast_sink_iso_recv(struct bt_iso_chan *chan,
 	const struct bt_bap_stream_ops *ops;
 	struct bt_bap_stream *stream;
 	struct bt_bap_ep *ep = iso->rx.ep;
+	size_t buf_len;
 
 	if (ep == NULL) {
 		LOG_ERR("iso %p not bound with ep", chan);
@@ -265,8 +266,14 @@ static void broadcast_sink_iso_recv(struct bt_iso_chan *chan,
 
 	ops = stream->ops;
 
+	buf_len = net_buf_frags_len(buf);
 	if (IS_ENABLED(CONFIG_BT_BAP_DEBUG_STREAM_DATA)) {
-		LOG_DBG("stream %p ep %p len %zu", stream, stream->ep, net_buf_frags_len(buf));
+		LOG_DBG("stream %p ep %p len %zu", stream, stream->ep, buf_len);
+	}
+
+	if (buf_len > stream->qos->sdu) {
+		LOG_WRN("Received %u octets but stream %p was only configured for %u", buf_len,
+			stream, stream->qos->sdu);
 	}
 
 	if (ops != NULL && ops->recv != NULL) {
@@ -522,64 +529,145 @@ static bool codec_lookup_id(const struct bt_pacs_cap *cap, void *user_data)
 	return true;
 }
 
+struct store_base_info_data {
+	struct bt_bap_broadcast_sink_bis bis[CONFIG_BT_BAP_BROADCAST_SNK_STREAM_COUNT];
+	struct bt_bap_broadcast_sink_subgroup subgroups[CONFIG_BT_BAP_BROADCAST_SNK_SUBGROUP_COUNT];
+	struct bt_audio_codec_cfg *subgroup_codec_cfg;
+	uint32_t valid_indexes_bitfield;
+	uint8_t subgroup_count;
+	uint8_t bis_count;
+};
+
+static bool merge_bis_and_subgroup_data_cb(struct bt_data *data, void *user_data)
+{
+	struct bt_audio_codec_cfg *codec_cfg = user_data;
+	int err;
+
+	err = bt_audio_codec_cfg_set_val(codec_cfg, data->type, data->data, data->data_len);
+	if (err < 0) {
+		LOG_DBG("Failed to set type %u with len %u in codec_cfg: %d", data->type,
+			data->data_len, err);
+
+		return false;
+	}
+
+	return true;
+}
+
 static bool base_subgroup_bis_index_cb(const struct bt_bap_base_subgroup_bis *bis, void *user_data)
 {
-	uint32_t *bis_indexes = user_data;
+	struct bt_bap_broadcast_sink_subgroup *sink_subgroup;
+	struct store_base_info_data *data = user_data;
+	struct bt_bap_broadcast_sink_bis *sink_bis;
 
-	*bis_indexes |= BIT(bis->index);
+	if (data->bis_count == ARRAY_SIZE(data->bis)) {
+		/* We've parsed as many subgroups as we support */
+		LOG_DBG("Could only store %u BIS", data->bis_count);
+		return false;
+	}
+
+	sink_bis = &data->bis[data->bis_count];
+	sink_subgroup = &data->subgroups[data->subgroup_count];
+
+	sink_bis->index = bis->index;
+	sink_subgroup->bis_indexes |= BIT(bis->index);
+
+#if CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0
+	int err;
+
+	memcpy(&sink_bis->codec_cfg, data->subgroup_codec_cfg, sizeof(sink_bis->codec_cfg));
+
+	/* Merge subgroup codec configuration with the BIS configuration
+	 * As per the BAP spec, if a value exist at level 2 (subgroup) and 3 (BIS), then it is
+	 * the value at level 3 that shall be used
+	 */
+	if (sink_bis->codec_cfg.id == BT_HCI_CODING_FORMAT_LC3) {
+		memcpy(&sink_bis->codec_cfg, data->subgroup_codec_cfg, sizeof(sink_bis->codec_cfg));
+
+		err = bt_audio_data_parse(bis->data, bis->data_len, merge_bis_and_subgroup_data_cb,
+					  &sink_bis->codec_cfg);
+		if (err != 0) {
+			LOG_DBG("Could not merge BIS and subgroup config in codec_cfg: %d", err);
+
+			return false;
+		}
+	} else {
+		/* If it is not LC3, then we don't know how to merge the subgroup and BIS codecs,
+		 * so we just append them
+		 */
+		if (sink_bis->codec_cfg.data_len + bis->data_len >
+		    sizeof(sink_bis->codec_cfg.data)) {
+			LOG_DBG("Could not store BIS and subgroup config in codec_cfg (%u > %u)",
+				sink_bis->codec_cfg.data_len + bis->data_len,
+				sizeof(sink_bis->codec_cfg.data));
+
+			return false;
+		}
+
+		memcpy(&sink_bis->codec_cfg.data[sink_bis->codec_cfg.data_len], bis->data,
+		       bis->data_len);
+	}
+#endif /* CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0 */
+
+	data->bis_count++;
 
 	return true;
 }
 
 static bool base_subgroup_cb(const struct bt_bap_base_subgroup *subgroup, void *user_data)
 {
-	struct bt_bap_broadcast_sink *sink = user_data;
-	struct bt_bap_broadcast_sink_subgroup *sink_subgroup =
-		&sink->subgroups[sink->subgroup_count];
+	struct bt_bap_broadcast_sink_subgroup *sink_subgroup;
 	struct codec_cap_lookup_id_data lookup_data = {0};
+	struct store_base_info_data *data = user_data;
+	struct bt_audio_codec_cfg codec_cfg;
 	int ret;
 
-	if (sink->subgroup_count == ARRAY_SIZE(sink->subgroups)) {
+	if (data->subgroup_count == ARRAY_SIZE(data->subgroups)) {
 		/* We've parsed as many subgroups as we support */
-		LOG_DBG("Could only store %u subgroups", sink->subgroup_count);
+		LOG_DBG("Could only store %u subgroups", data->subgroup_count);
 		return false;
 	}
 
-	ret = bt_bap_base_subgroup_codec_to_codec_cfg(subgroup, &sink_subgroup->codec_cfg);
+	sink_subgroup = &data->subgroups[data->subgroup_count];
+
+	ret = bt_bap_base_subgroup_codec_to_codec_cfg(subgroup, &codec_cfg);
 	if (ret < 0) {
 		LOG_DBG("Could not store codec_cfg: %d", ret);
 		return false;
 	}
 
-	ret = bt_bap_base_subgroup_foreach_bis(subgroup, base_subgroup_bis_index_cb,
-					       &sink_subgroup->bis_indexes);
-	if (ret < 0) {
-		LOG_DBG("Could not parse BISes: %d", ret);
-		return false;
-	}
-
 	/* Lookup and assign path_id based on capabilities */
-	lookup_data.id = sink_subgroup->codec_cfg.id;
+	lookup_data.id = codec_cfg.id;
 
 	bt_pacs_cap_foreach(BT_AUDIO_DIR_SINK, codec_lookup_id, &lookup_data);
 	if (lookup_data.codec_cap == NULL) {
 		LOG_DBG("Codec with id %u is not supported by our capabilities", lookup_data.id);
 	} else {
-		/* Add BIS to bitfield of valid BIS indexes we support */
-		sink->valid_indexes_bitfield |= sink_subgroup->bis_indexes;
-	}
+		codec_cfg.path_id = lookup_data.codec_cap->path_id;
+		codec_cfg.ctlr_transcode = lookup_data.codec_cap->ctlr_transcode;
 
-	sink->subgroup_count++;
+		data->subgroup_codec_cfg = &codec_cfg;
+
+		ret = bt_bap_base_subgroup_foreach_bis(subgroup, base_subgroup_bis_index_cb, data);
+		if (ret < 0) {
+			LOG_DBG("Could not parse BISes: %d", ret);
+			return false;
+		}
+
+		/* Add BIS to bitfield of valid BIS indexes we support */
+		data->valid_indexes_bitfield |= sink_subgroup->bis_indexes;
+		data->subgroup_count++;
+	}
 
 	return true;
 }
 
 static int store_base_info(struct bt_bap_broadcast_sink *sink, const struct bt_bap_base *base)
 {
+	/* data is static due to its size, which easily can exceed the stack size */
+	static struct store_base_info_data data;
+	uint32_t pres_delay;
 	int ret;
-
-	sink->valid_indexes_bitfield = 0U;
-	sink->subgroup_count = 0U;
 
 	ret = bt_bap_base_get_pres_delay(base);
 	if (ret < 0) {
@@ -587,12 +675,23 @@ static int store_base_info(struct bt_bap_broadcast_sink *sink, const struct bt_b
 		return ret;
 	}
 
-	sink->codec_qos.pd = (uint32_t)ret;
+	pres_delay = (uint32_t)ret;
 
-	ret = bt_bap_base_foreach_subgroup(base, base_subgroup_cb, sink);
+	memset(&data, 0, sizeof(data));
+
+	ret = bt_bap_base_foreach_subgroup(base, base_subgroup_cb, &data);
 	if (ret != 0) {
 		LOG_DBG("Failed to parse all subgroups: %d", ret);
 		return ret;
+	}
+
+	/* Ensure that we have not synced while parsing the BASE */
+	if (sink->big == NULL) {
+		sink->codec_qos.pd = pres_delay;
+		memcpy(sink->bis, data.bis, sizeof(sink->bis));
+		memcpy(sink->subgroups, data.subgroups, sizeof(sink->subgroups));
+		sink->subgroup_count = data.subgroup_count;
+		sink->valid_indexes_bitfield = data.valid_indexes_bitfield;
 	}
 
 	return 0;
@@ -940,14 +1039,18 @@ static void broadcast_sink_cleanup(struct bt_bap_broadcast_sink *sink)
 
 	(void)memset(sink, 0, sizeof(*sink)); /* also clears flags */
 }
+
 static struct bt_audio_codec_cfg *codec_cfg_from_base_by_index(struct bt_bap_broadcast_sink *sink,
 							       uint8_t index)
 {
-	for (size_t i = 0U; i < sink->subgroup_count; i++) {
-		struct bt_bap_broadcast_sink_subgroup *subgroup = &sink->subgroups[i];
+	for (size_t i = 0U; i < ARRAY_SIZE(sink->bis); i++) {
+		struct bt_bap_broadcast_sink_bis *bis = &sink->bis[i];
 
-		if ((subgroup->bis_indexes & BIT(index)) != 0) {
-			return &subgroup->codec_cfg;
+		if (bis->index == index) {
+			return &bis->codec_cfg;
+		} else if (bis->index == 0) {
+			/* index 0 is invalid, so we can use that as a terminator in the array */
+			break;
 		}
 	}
 
@@ -1015,7 +1118,8 @@ int bt_bap_broadcast_sink_sync(struct bt_bap_broadcast_sink *sink, uint32_t inde
 			       struct bt_bap_stream *streams[], const uint8_t broadcast_code[16])
 {
 	struct bt_iso_big_sync_param param;
-	struct bt_audio_codec_cfg *codec_cfgs[CONFIG_BT_BAP_BROADCAST_SNK_SUBGROUP_COUNT] = {NULL};
+	struct bt_audio_codec_cfg *codec_cfgs[CONFIG_BT_BAP_BROADCAST_SNK_STREAM_COUNT] = {NULL};
+	struct bt_iso_chan *bis_channels[CONFIG_BT_BAP_BROADCAST_SNK_STREAM_COUNT];
 	uint8_t stream_count;
 	int err;
 
@@ -1110,12 +1214,14 @@ int bt_bap_broadcast_sink_sync(struct bt_bap_broadcast_sink *sink, uint32_t inde
 			return err;
 		}
 
-		sink->bis[i] = bt_bap_stream_iso_chan_get(stream);
+		sink->bis[i].chan = bt_bap_stream_iso_chan_get(stream);
 		sys_slist_append(&sink->streams, &stream->_node);
 		sink->stream_count++;
+
+		bis_channels[i] = sink->bis[i].chan;
 	}
 
-	param.bis_channels = sink->bis;
+	param.bis_channels = bis_channels;
 	param.num_bis = sink->stream_count;
 	param.bis_bitfield = indexes_bitfield;
 	param.mse = 0; /* Let controller decide */

--- a/subsys/bluetooth/audio/bap_endpoint.h
+++ b/subsys/bluetooth/audio/bap_endpoint.h
@@ -126,6 +126,11 @@ enum bt_bap_broadcast_sink_flag {
 
 struct bt_bap_broadcast_sink_subgroup {
 	uint32_t bis_indexes;
+};
+
+struct bt_bap_broadcast_sink_bis {
+	uint8_t index;
+	struct bt_iso_chan *chan;
 	struct bt_audio_codec_cfg codec_cfg;
 };
 
@@ -143,7 +148,7 @@ struct bt_bap_broadcast_sink {
 	struct bt_audio_codec_qos codec_qos;
 	struct bt_le_per_adv_sync *pa_sync;
 	struct bt_iso_big *big;
-	struct bt_iso_chan *bis[CONFIG_BT_BAP_BROADCAST_SNK_STREAM_COUNT];
+	struct bt_bap_broadcast_sink_bis bis[CONFIG_BT_BAP_BROADCAST_SNK_STREAM_COUNT];
 	struct bt_bap_broadcast_sink_subgroup subgroups[CONFIG_BT_BAP_BROADCAST_SNK_SUBGROUP_COUNT];
 	const struct bt_bap_scan_delegator_recv_state *recv_state;
 	/* The streams used to create the broadcast sink */

--- a/subsys/bluetooth/audio/bap_stream.c
+++ b/subsys/bluetooth/audio/bap_stream.c
@@ -112,25 +112,25 @@ int bt_bap_ep_get_info(const struct bt_bap_ep *ep, struct bt_bap_ep_info *info)
 	}
 
 	info->can_send = false;
+	info->can_recv = false;
 	if (IS_ENABLED(CONFIG_BT_AUDIO_TX) && ep->stream != NULL) {
 		if (IS_ENABLED(CONFIG_BT_BAP_BROADCAST_SOURCE) && bt_bap_ep_is_broadcast_src(ep)) {
 			info->can_send = true;
-		} else if (IS_ENABLED(CONFIG_BT_CONN) && ep->stream->conn != NULL) {
-			struct bt_conn_info conn_info;
-			uint8_t role;
-			int err;
-
-			err = bt_conn_get_info(ep->stream->conn, &conn_info);
-			if (err != 0) {
-				LOG_DBG("Could not get conn info: %d", err);
-
-				return err;
+		} else if (IS_ENABLED(CONFIG_BT_BAP_BROADCAST_SINK) &&
+			   bt_bap_ep_is_broadcast_snk(ep)) {
+			info->can_recv = true;
+		} else if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) &&
+			   bt_bap_ep_is_unicast_client(ep)) {
+			/* dir is not initialized before the connection is set */
+			if (ep->stream->conn != NULL) {
+				info->can_send = dir == BT_AUDIO_DIR_SINK;
+				info->can_recv = dir == BT_AUDIO_DIR_SOURCE;
 			}
-
-			role = conn_info.role;
-			if ((role == BT_CONN_ROLE_CENTRAL && dir == BT_AUDIO_DIR_SINK) ||
-			    (role == BT_CONN_ROLE_PERIPHERAL && dir == BT_AUDIO_DIR_SOURCE)) {
-				info->can_send = true;
+		} else if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_SERVER)) {
+			/* dir is not initialized before the connection is set */
+			if (ep->stream->conn != NULL) {
+				info->can_send = dir == BT_AUDIO_DIR_SOURCE;
+				info->can_recv = dir == BT_AUDIO_DIR_SINK;
 			}
 		}
 	}

--- a/subsys/bluetooth/audio/shell/CMakeLists.txt
+++ b/subsys/bluetooth/audio/shell/CMakeLists.txt
@@ -81,6 +81,9 @@ zephyr_library_sources_ifdef(
   CONFIG_BT_BAP_STREAM
   bap.c
   )
+if (CONFIG_BT_AUDIO_RX AND CONFIG_LIBLC3 AND CONFIG_USB_DEVICE_AUDIO)
+	zephyr_library_sources(bap_usb.c)
+endif()
 zephyr_library_sources_ifdef(
   CONFIG_BT_BAP_SCAN_DELEGATOR
   bap_scan_delegator.c

--- a/subsys/bluetooth/audio/shell/audio.h
+++ b/subsys/bluetooth/audio/shell/audio.h
@@ -22,6 +22,8 @@
 
 #include "shell/bt.h"
 
+#define MAX_CODEC_FRAMES_PER_SDU 5U
+
 extern struct bt_csip_set_member_svc_inst *svc_inst;
 
 ssize_t audio_ad_data_add(struct bt_data *data, const size_t data_size, const bool discoverable,
@@ -43,6 +45,13 @@ size_t pbp_ad_data_add(struct bt_data data[], size_t data_size);
 
 #if defined(CONFIG_LIBLC3)
 #include "lc3.h"
+
+#define USB_SAMPLE_RATE            48000U
+#define LC3_MAX_SAMPLE_RATE        48000U
+#define LC3_MAX_FRAME_DURATION_US  10000U
+#define LC3_MAX_NUM_SAMPLES_MONO   ((LC3_MAX_FRAME_DURATION_US * LC3_MAX_SAMPLE_RATE) /            \
+				    USEC_PER_SEC)
+#define LC3_MAX_NUM_SAMPLES_STEREO (LC3_MAX_NUM_SAMPLES_MONO * 2U)
 #endif /* CONFIG_LIBLC3 */
 
 #define LOCATION BT_AUDIO_LOCATION_FRONT_LEFT | BT_AUDIO_LOCATION_FRONT_RIGHT
@@ -61,6 +70,12 @@ struct named_lc3_preset {
 
 const struct named_lc3_preset *bap_get_named_preset(bool is_unicast, enum bt_audio_dir dir,
 						    const char *preset_arg);
+
+int bap_usb_init(void);
+int bap_usb_add_frame_to_usb(enum bt_audio_location lc3_chan_allocation, const int16_t *frame,
+			     size_t frame_size);
+void bap_usb_clear_frames_to_usb(void);
+void bap_usb_send_frames_to_usb(void);
 
 #if defined(CONFIG_BT_BAP_UNICAST)
 
@@ -167,6 +182,22 @@ int cap_ac_unicast(const struct shell *sh, size_t argc, char **argv,
 		   const struct bap_unicast_ac_param *param);
 #endif /* CONFIG_BT_BAP_UNICAST_CLIENT */
 #endif /* CONFIG_BT_BAP_UNICAST */
+
+static inline uint8_t get_chan_cnt(enum bt_audio_location chan_allocation)
+{
+	uint8_t cnt = 0U;
+
+	if (chan_allocation == BT_AUDIO_LOCATION_MONO_AUDIO) {
+		return 1;
+	}
+
+	while (chan_allocation != 0) {
+		cnt += chan_allocation & 1U;
+		chan_allocation >>= 1;
+	}
+
+	return cnt;
+}
 
 static inline void print_qos(const struct shell *sh, const struct bt_audio_codec_qos *qos)
 {

--- a/subsys/bluetooth/audio/shell/audio.h
+++ b/subsys/bluetooth/audio/shell/audio.h
@@ -41,6 +41,10 @@ size_t pbp_ad_data_add(struct bt_data data[], size_t data_size);
 #include <zephyr/bluetooth/audio/bap_lc3_preset.h>
 #include <zephyr/bluetooth/audio/cap.h>
 
+#if defined(CONFIG_LIBLC3)
+#include "lc3.h"
+#endif /* CONFIG_LIBLC3 */
+
 #define LOCATION BT_AUDIO_LOCATION_FRONT_LEFT | BT_AUDIO_LOCATION_FRONT_RIGHT
 #define CONTEXT                                                                                    \
 	(BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED | BT_AUDIO_CONTEXT_TYPE_CONVERSATIONAL |                \
@@ -79,12 +83,14 @@ struct shell_stream {
 	struct bt_cap_stream stream;
 	struct bt_audio_codec_cfg codec_cfg;
 	struct bt_audio_codec_qos qos;
+
 #if defined(CONFIG_LIBLC3)
 	uint32_t lc3_freq_hz;
 	uint32_t lc3_frame_duration_us;
 	uint16_t lc3_octets_per_frame;
 	uint8_t lc3_frames_per_sdu;
 #endif /* CONFIG_LIBLC3 */
+
 #if defined(CONFIG_BT_AUDIO_TX)
 	int64_t connected_at_ticks; /* The uptime tick measured when stream was connected */
 	uint16_t seq_num;
@@ -95,6 +101,7 @@ struct shell_stream {
 	size_t lc3_sdu_cnt;
 #endif /* CONFIG_LIBLC3 */
 #endif /* CONFIG_BT_AUDIO_TX */
+
 #if defined(CONFIG_BT_AUDIO_RX)
 	struct bt_iso_recv_info last_info;
 	size_t lost_pkts;
@@ -102,6 +109,12 @@ struct shell_stream {
 	size_t dup_psn;
 	size_t rx_cnt;
 	size_t dup_ts;
+#if defined(CONFIG_LIBLC3)
+	lc3_decoder_t lc3_decoder;
+	struct k_mutex lc3_decoder_mutex;
+	struct net_buf *in_buf;
+	size_t decoded_cnt;
+#endif /* CONFIG_LIBLC3 */
 #endif /* CONFIG_BT_AUDIO_RX */
 };
 

--- a/subsys/bluetooth/audio/shell/audio.h
+++ b/subsys/bluetooth/audio/shell/audio.h
@@ -88,7 +88,9 @@ struct shell_stream {
 	uint32_t lc3_freq_hz;
 	uint32_t lc3_frame_duration_us;
 	uint16_t lc3_octets_per_frame;
-	uint8_t lc3_frames_per_sdu;
+	uint8_t lc3_frame_blocks_per_sdu;
+	enum bt_audio_location lc3_chan_allocation;
+	uint8_t lc3_chan_cnt;
 #endif /* CONFIG_LIBLC3 */
 
 #if defined(CONFIG_BT_AUDIO_TX)

--- a/subsys/bluetooth/audio/shell/bap_usb.c
+++ b/subsys/bluetooth/audio/shell/bap_usb.c
@@ -1,0 +1,242 @@
+/**
+ * @file
+ * @brief Bluetooth Basic Audio Profile shell USB extension
+ *
+ * This files handles all the USB related functionality to audio in/out for the BAP shell
+ *
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdlib.h>
+
+#include <zephyr/bluetooth/audio/audio.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/shell/shell.h>
+#include <zephyr/sys/ring_buffer.h>
+#include <zephyr/usb/usb_device.h>
+#include <zephyr/usb/class/usb_audio.h>
+
+#include "shell/bt.h"
+#include "audio.h"
+
+LOG_MODULE_REGISTER(bap_usb, CONFIG_BT_BAP_STREAM_LOG_LEVEL);
+
+#define USB_ENQUEUE_COUNT     10U
+#define USB_FRAME_DURATION_US 1000U
+#define USB_MONO_SAMPLE_SIZE                                                                       \
+	((USB_FRAME_DURATION_US * USB_SAMPLE_RATE * sizeof(int16_t)) / USEC_PER_SEC)
+#define USB_STEREO_SAMPLE_SIZE (USB_MONO_SAMPLE_SIZE * 2U)
+#define USB_RING_BUF_SIZE      (5U * LC3_MAX_NUM_SAMPLES_STEREO) /* up to 5 stereo frames */
+
+static int16_t right_frames[MAX_CODEC_FRAMES_PER_SDU][LC3_MAX_NUM_SAMPLES_MONO];
+static int16_t left_frames[MAX_CODEC_FRAMES_PER_SDU][LC3_MAX_NUM_SAMPLES_MONO];
+static size_t right_frames_cnt;
+static size_t left_frames_cnt;
+static size_t mono_frames_cnt;
+
+RING_BUF_DECLARE(usb_out_ring_buf, USB_RING_BUF_SIZE);
+NET_BUF_POOL_DEFINE(usb_tx_buf_pool, USB_ENQUEUE_COUNT, USB_STEREO_SAMPLE_SIZE, 0, net_buf_destroy);
+
+/* USB consumer callback, called every 1ms, consumes data from ring-buffer */
+static void usb_data_request_cb(const struct device *dev)
+{
+	uint8_t usb_audio_data[USB_STEREO_SAMPLE_SIZE] = {0};
+	struct net_buf *pcm_buf;
+	uint32_t size;
+	int err;
+
+	pcm_buf = net_buf_alloc(&usb_tx_buf_pool, K_NO_WAIT);
+	if (pcm_buf == NULL) {
+		LOG_WRN("Could not allocate pcm_buf");
+		return;
+	}
+
+	/* This may fail without causing issues since usb_audio_data is 0-initialized */
+	size = ring_buf_get(&usb_out_ring_buf, usb_audio_data, sizeof(usb_audio_data));
+
+	net_buf_add_mem(pcm_buf, usb_audio_data, sizeof(usb_audio_data));
+
+	if (size != 0) {
+		static size_t cnt;
+
+		if (++cnt % 1000 == 0) { /* TODO replace with recv_stats_interval */
+			LOG_INF("[%zu]: Sending USB audio", cnt);
+		}
+	}
+
+	err = usb_audio_send(dev, pcm_buf, sizeof(usb_audio_data));
+	if (err != 0) {
+		LOG_ERR("Failed to send USB audio: %d", err);
+		net_buf_unref(pcm_buf);
+	}
+}
+
+static void usb_data_written_cb(const struct device *dev, struct net_buf *buf, size_t size)
+{
+	/* Unreference the buffer now that the USB is done with it */
+	net_buf_unref(buf);
+}
+
+int bap_usb_add_frame_to_usb(enum bt_audio_location chan_allocation, const int16_t *frame,
+			     size_t frame_size)
+{
+	const bool is_left = (chan_allocation & BT_AUDIO_LOCATION_FRONT_LEFT) != 0;
+	const bool is_right = (chan_allocation & BT_AUDIO_LOCATION_FRONT_RIGHT) != 0;
+	const bool is_mono = chan_allocation == BT_AUDIO_LOCATION_MONO_AUDIO;
+
+	if (frame_size > LC3_MAX_NUM_SAMPLES_MONO * sizeof(int16_t) || frame_size == 0U) {
+		LOG_DBG("Invalid frame of size %zu", frame_size);
+
+		return -EINVAL;
+	}
+
+	if (get_chan_cnt(chan_allocation) != 1) {
+		LOG_DBG("Invalid channel allocation %d", chan_allocation);
+
+		return -EINVAL;
+	}
+
+	if (((is_left || is_right) && mono_frames_cnt != 0) ||
+	    (is_mono && (left_frames_cnt != 0U || right_frames_cnt != 0U))) {
+		LOG_DBG("Cannot mix and match mono with left or right");
+
+		return -EINVAL;
+	}
+
+	if (is_left) {
+		if (left_frames_cnt >= ARRAY_SIZE(left_frames)) {
+			LOG_WRN("Could not add more left frames");
+
+			return -ENOMEM;
+		}
+
+		memcpy(left_frames[left_frames_cnt++], frame, frame_size);
+	} else if (is_right) {
+		if (right_frames_cnt >= ARRAY_SIZE(right_frames)) {
+			LOG_WRN("Could not add more right frames");
+
+			return -ENOMEM;
+		}
+
+		memcpy(right_frames[right_frames_cnt++], frame, frame_size);
+	} else if (is_mono) {
+		/* Use left as mono*/
+		if (mono_frames_cnt >= ARRAY_SIZE(left_frames)) {
+			LOG_WRN("Could not add more mono frames");
+
+			return -ENOMEM;
+		}
+
+		memcpy(left_frames[mono_frames_cnt++], frame, frame_size);
+	} else {
+		/* Unsupported channel */
+		LOG_DBG("Unsupported channel %d", chan_allocation);
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+void bap_usb_clear_frames_to_usb(void)
+{
+	right_frames_cnt = 0U;
+	left_frames_cnt = 0U;
+	mono_frames_cnt = 0U;
+	memset(left_frames, 0, sizeof(left_frames));
+	memset(right_frames, 0, sizeof(right_frames));
+}
+
+void bap_usb_send_frames_to_usb(void)
+{
+	const bool is_left_only = right_frames_cnt == 0U && mono_frames_cnt == 0U;
+	const bool is_right_only = left_frames_cnt == 0U && mono_frames_cnt == 0U;
+	const bool is_mono_only = left_frames_cnt == 0U && right_frames_cnt == 0U;
+
+	if (!is_left_only && !is_right_only && left_frames_cnt != right_frames_cnt) {
+		LOG_ERR("Mismatch between number of left (%zu) and right (%zu) frames, "
+			"discarding frames",
+			left_frames_cnt, right_frames_cnt);
+
+		bap_usb_clear_frames_to_usb();
+
+		return;
+	}
+
+	/* Send frames to USB - If we only have a single channel we mix it to stereo */
+	for (size_t i = 0U; i < MAX(mono_frames_cnt, MAX(left_frames_cnt, right_frames_cnt)); i++) {
+		const bool is_single_channel = is_left_only || is_right_only || is_mono_only;
+		static int16_t stereo_frame[LC3_MAX_NUM_SAMPLES_STEREO];
+		const int16_t *right_frame = right_frames[i];
+		const int16_t *left_frame = left_frames[i];
+		const int16_t *mono_frame = left_frames[i]; /* use left as mono */
+		uint32_t rb_size;
+
+		/* Not enough space to store data */
+		if (ring_buf_space_get(&usb_out_ring_buf) < sizeof(stereo_frame)) {
+			LOG_WRN("Could not send more than %zu frames to USB", i);
+
+			break;
+		}
+
+		/* Generate the stereo frame
+		 *
+		 * If we only have single channel then we mix that to stereo
+		 */
+		for (int j = 0; j < LC3_MAX_NUM_SAMPLES_MONO; j++) {
+			if (is_single_channel) {
+				int16_t sample = 0;
+
+				/* Mix to stereo as LRLRLRLR */
+				if (is_left_only) {
+					sample = left_frame[j];
+				} else if (is_right_only) {
+					sample = right_frame[j];
+				} else if (is_mono_only) {
+					sample = mono_frame[j];
+				}
+
+				stereo_frame[j * 2] = sample;
+				stereo_frame[j * 2 + 1] = sample;
+			} else {
+				stereo_frame[j * 2] = left_frame[j];
+				stereo_frame[j * 2 + 1] = right_frame[j];
+			}
+		}
+
+		rb_size = ring_buf_put(&usb_out_ring_buf, (uint8_t *)stereo_frame,
+				       sizeof(stereo_frame));
+		if (rb_size != sizeof(stereo_frame)) {
+			LOG_WRN("Failed to put frame on USB ring buf");
+
+			break;
+		}
+	}
+
+	bap_usb_clear_frames_to_usb();
+}
+
+int bap_usb_init(void)
+{
+	const struct device *hs_dev = DEVICE_DT_GET(DT_NODELABEL(hs_0));
+	static const struct usb_audio_ops usb_ops = {
+		.data_request_cb = usb_data_request_cb,
+		.data_written_cb = usb_data_written_cb,
+	};
+	int err;
+
+	if (!device_is_ready(hs_dev)) {
+		LOG_ERR("Cannot get USB Headset Device");
+		return -EIO;
+	}
+
+	usb_audio_register(hs_dev, &usb_ops);
+	err = usb_enable(NULL);
+	if (err != 0) {
+		LOG_ERR("Failed to enable USB");
+		return err;
+	}
+
+	return 0;
+}

--- a/tests/bluetooth/shell/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
+++ b/tests/bluetooth/shell/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
@@ -1,6 +1,12 @@
 # For LC3 the following configs are needed
 CONFIG_FPU=y
 CONFIG_LIBLC3=y
+CONFIG_RING_BUFFER=y
+CONFIG_USB_DEVICE_STACK=y
+CONFIG_USB_NRFX_EVT_QUEUE_SIZE=64
+CONFIG_USB_REQUEST_BUFFER_SIZE=256
+CONFIG_USB_DEVICE_AUDIO=y
+CONFIG_USB_DEVICE_PRODUCT="Zephyr Shell USB"
 # The LC3 codec uses a large amount of stack. This app runs the codec in the work-queue, hence
 # inctease stack size for that thread.
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096


### PR DESCRIPTION
Add USB out support for the BAP shell, so that decoded LC3 data can be sent to the host (e.g. a PC).

fixes https://github.com/zephyrproject-rtos/zephyr/issues/65640