### PR TITLE
Add sco connection management

### DIFF
--- a/include/zephyr/bluetooth/classic/hfp_hf.h
+++ b/include/zephyr/bluetooth/classic/hfp_hf.h
@@ -64,6 +64,24 @@ struct bt_hfp_hf_cb {
 	 *  @param conn Connection object.
 	 */
 	void (*disconnected)(struct bt_conn *conn);
+	/** HF SCO/eSCO connected Callback
+	 *
+	 *  If this callback is provided it will be called whenever the
+	 *  SCO/eSCO connection completes.
+	 *
+	 *  @param conn Connection object.
+	 *  @param sco_conn SCO/eSCO Connection object.
+	 */
+	void (*sco_connected)(struct bt_conn *conn, struct bt_conn *sco_conn);
+	/** HF SCO/eSCO disconnected Callback
+	 *
+	 *  If this callback is provided it will be called whenever the
+	 *  SCO/eSCO connection gets disconnected.
+	 *
+	 *  @param conn Connection object.
+	 *  @param reason BT_HCI_ERR_* reason for the disconnection.
+	 */
+	void (*sco_disconnected)(struct bt_conn *sco_conn, uint8_t reason);
 	/** HF indicator Callback
 	 *
 	 *  This callback provides service indicator value to the application

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -1774,19 +1774,6 @@ struct bt_br_conn_param {
 struct bt_conn *bt_conn_create_br(const bt_addr_t *peer,
 				  const struct bt_br_conn_param *param);
 
-/** @brief Initiate an SCO connection to a remote device.
- *
- *  Allows initiate new SCO link to remote peer using its address.
- *
- *  The caller gets a new reference to the connection object which must be
- *  released with bt_conn_unref() once done using the object.
- *
- *  @param peer  Remote address.
- *
- *  @return Valid connection object on success or NULL otherwise.
- */
-struct bt_conn *bt_conn_create_sco(const bt_addr_t *peer);
-
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/bluetooth/host/classic/CMakeLists.txt
+++ b/subsys/bluetooth/host/classic/CMakeLists.txt
@@ -14,6 +14,7 @@ zephyr_library_sources_ifdef(
   l2cap_br.c
   sdp.c
   ssp.c
+  sco.c
   )
 
 zephyr_library_sources_ifdef(

--- a/subsys/bluetooth/host/classic/hfp_internal.h
+++ b/subsys/bluetooth/host/classic/hfp_internal.h
@@ -48,6 +48,8 @@ struct bt_hfp_hf {
 	struct bt_rfcomm_dlc rfcomm_dlc;
 	/* ACL connection handle */
 	struct bt_conn *acl;
+	/* SCO Channel */
+	struct bt_sco_chan chan;
 	char hf_buffer[HF_MAX_BUF_LEN];
 	struct at_client at;
 	uint32_t hf_features;

--- a/subsys/bluetooth/host/classic/sco.c
+++ b/subsys/bluetooth/host/classic/sco.c
@@ -1,0 +1,528 @@
+/* sco.c - Bluetooth sco handling */
+
+/*
+ * Copyright (c) 2015-2016 Intel Corporation
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <errno.h>
+
+#include <zephyr/sys/atomic.h>
+#include <zephyr/sys/check.h>
+
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+
+#include "common/bt_str.h"
+
+#include "host/addr_internal.h"
+#include "host/hci_core.h"
+#include "br.h"
+#include "host/conn_internal.h"
+#include "sco_internal.h"
+
+#define LOG_LEVEL CONFIG_BT_CONN_LOG_LEVEL
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(bt_sco);
+
+struct bt_sco_server *sco_server;
+
+#define SCO_CHAN(_sco) ((_sco)->sco.chan);
+
+int bt_sco_server_register(struct bt_sco_server *server)
+{
+	CHECKIF(!server) {
+		LOG_DBG("Invalid parameter: server %p", server);
+		return -EINVAL;
+	}
+
+	if (sco_server) {
+		return -EADDRINUSE;
+	}
+
+	if (!server->accept) {
+		return -EINVAL;
+	}
+
+	if (server->sec_level > BT_SECURITY_L3) {
+		return -EINVAL;
+	}
+
+	LOG_DBG("%p", server);
+
+	sco_server = server;
+
+	return 0;
+}
+
+int bt_sco_server_unregister(struct bt_sco_server *server)
+{
+	CHECKIF(!server) {
+		LOG_DBG("Invalid parameter: server %p", server);
+		return -EINVAL;
+	}
+
+	if (sco_server != server) {
+		return -EINVAL;
+	}
+
+	sco_server = NULL;
+
+	return 0;
+}
+
+void bt_sco_connected(struct bt_conn *sco)
+{
+	struct bt_sco_chan *chan;
+
+	if (sco == NULL || sco->type != BT_CONN_TYPE_SCO) {
+		LOG_ERR("Invalid parameters: sco %p sco->type %u", sco, sco ? sco->type : 0);
+		return;
+	}
+
+	LOG_DBG("%p", sco);
+
+	chan = SCO_CHAN(sco);
+
+	if (chan == NULL) {
+		LOG_ERR("Could not lookup chan from connected SCO");
+		return;
+	}
+
+	bt_sco_chan_set_state(chan, BT_SCO_STATE_CONNECTED);
+
+	if (chan->ops && chan->ops->connected) {
+		chan->ops->connected(chan);
+	}
+}
+
+void bt_sco_disconnected(struct bt_conn *sco)
+{
+	struct bt_sco_chan *chan;
+
+	if (sco == NULL || sco->type != BT_CONN_TYPE_SCO) {
+		LOG_ERR("Invalid parameters: sco %p sco->type %u", sco, sco ? sco->type : 0);
+		return;
+	}
+	LOG_DBG("%p", sco);
+
+	chan = SCO_CHAN(sco);
+	if (chan == NULL) {
+		LOG_ERR("Could not lookup chan from connected SCO");
+		return;
+	}
+
+	bt_sco_chan_set_state(chan, BT_SCO_STATE_DISCONNECTED);
+
+	bt_sco_cleanup_acl(sco);
+
+	chan->sco = NULL;
+
+	if (chan->ops && chan->ops->disconnected) {
+		chan->ops->disconnected(chan, sco->err);
+	}
+}
+
+static uint8_t sco_server_check_security(struct bt_conn *conn)
+{
+	if (IS_ENABLED(CONFIG_BT_CONN_DISABLE_SECURITY)) {
+		return BT_HCI_ERR_SUCCESS;
+	}
+
+	if (conn->sec_level >= sco_server->sec_level) {
+		return BT_HCI_ERR_SUCCESS;
+	}
+
+	return BT_HCI_ERR_INSUFFICIENT_SECURITY;
+}
+
+#if defined(CONFIG_BT_CONN_LOG_LEVEL_DBG)
+const char *bt_sco_chan_state_str(uint8_t state)
+{
+	switch (state) {
+	case BT_SCO_STATE_DISCONNECTED:
+		return "disconnected";
+	case BT_SCO_STATE_CONNECTING:
+		return "connecting";
+	case BT_SCO_STATE_ENCRYPT_PENDING:
+		return "encryption pending";
+	case BT_SCO_STATE_CONNECTED:
+		return "connected";
+	case BT_SCO_STATE_DISCONNECTING:
+		return "disconnecting";
+	default:
+		return "unknown";
+	}
+}
+
+void bt_sco_chan_set_state_debug(struct bt_sco_chan *chan,
+				 enum bt_sco_state state,
+				 const char *func, int line)
+{
+	LOG_DBG("chan %p sco %p %s -> %s", chan, chan->sco, bt_sco_chan_state_str(chan->state),
+		bt_sco_chan_state_str(state));
+
+	/* check transitions validness */
+	switch (state) {
+	case BT_SCO_STATE_DISCONNECTED:
+		/* regardless of old state always allows this states */
+		break;
+	case BT_SCO_STATE_ENCRYPT_PENDING:
+		__fallthrough;
+	case BT_SCO_STATE_CONNECTING:
+		if (chan->state != BT_SCO_STATE_DISCONNECTED) {
+			LOG_WRN("%s()%d: invalid transition", func, line);
+		}
+		break;
+	case BT_SCO_STATE_CONNECTED:
+		if (chan->state != BT_SCO_STATE_CONNECTING) {
+			LOG_WRN("%s()%d: invalid transition", func, line);
+		}
+		break;
+	case BT_SCO_STATE_DISCONNECTING:
+		if (chan->state != BT_SCO_STATE_CONNECTING &&
+			chan->state != BT_SCO_STATE_CONNECTED) {
+			LOG_WRN("%s()%d: invalid transition", func, line);
+		}
+		break;
+	default:
+		LOG_ERR("%s()%d: unknown (%u) state was set", func, line, state);
+		return;
+	}
+
+	chan->state = state;
+}
+#else
+void bt_sco_chan_set_state(struct bt_sco_chan *chan, enum bt_sco_state state)
+{
+	chan->state = state;
+}
+#endif /* CONFIG_BT_CONN_LOG_LEVEL_DBG */
+
+
+static void bt_sco_chan_add(struct bt_conn *sco, struct bt_sco_chan *chan)
+{
+	/* Attach SCO channel to the connection */
+	chan->sco = sco;
+	sco->sco.chan = chan;
+
+	LOG_DBG("sco %p chan %p", sco, chan);
+}
+
+static int sco_accept(struct bt_conn *acl, struct bt_conn *sco)
+{
+	struct bt_sco_accept_info accept_info;
+	struct bt_sco_chan *chan;
+	int err;
+
+	CHECKIF(!sco || sco->type != BT_CONN_TYPE_SCO) {
+		LOG_ERR("Invalid parameters: sco %p sco->type %u", sco, sco ? sco->type : 0);
+		return -EINVAL;
+	}
+
+	LOG_DBG("%p", sco);
+
+	accept_info.acl = acl;
+	memcpy(accept_info.dev_class, sco->sco.dev_class, sizeof(accept_info.dev_class));
+	accept_info.link_type = sco->sco.link_type;
+
+	err = sco_server->accept(&accept_info, &chan);
+	if (err < 0) {
+		LOG_ERR("Server failed to accept: %d", err);
+		return err;
+	}
+
+	if (chan->ops == NULL) {
+		LOG_ERR("invalid parameter: chan %p chan->ops %p", chan, chan->ops);
+		return -EINVAL;
+	}
+
+	chan->required_sec_level = sco_server->sec_level;
+
+	bt_sco_chan_add(sco, chan);
+	bt_sco_chan_set_state(chan, BT_SCO_STATE_CONNECTING);
+
+	return 0;
+}
+
+static int accept_sco_conn(const bt_addr_t *bdaddr, struct bt_conn *sco_conn)
+{
+	struct bt_hci_cp_accept_sync_conn_req *cp;
+	struct net_buf *buf;
+	int err;
+
+	err = sco_accept(sco_conn->sco.acl, sco_conn);
+	if (err) {
+		return err;
+	}
+
+	buf = bt_hci_cmd_create(BT_HCI_OP_ACCEPT_SYNC_CONN_REQ, sizeof(*cp));
+	if (!buf) {
+		return -ENOBUFS;
+	}
+
+	cp = net_buf_add(buf, sizeof(*cp));
+	bt_addr_copy(&cp->bdaddr, bdaddr);
+	cp->pkt_type = sco_conn->sco.pkt_type;
+	cp->tx_bandwidth = 0x00001f40;
+	cp->rx_bandwidth = 0x00001f40;
+	cp->max_latency = 0x0007;
+	cp->retrans_effort = 0x01;
+	cp->content_format = BT_VOICE_CVSD_16BIT;
+
+	err = bt_hci_cmd_send_sync(BT_HCI_OP_ACCEPT_SYNC_CONN_REQ, buf, NULL);
+	if (err) {
+		return err;
+	}
+
+	return 0;
+}
+
+uint8_t bt_esco_conn_req(struct bt_hci_evt_conn_request *evt)
+{
+	struct bt_conn *sco_conn;
+	uint8_t sec_err;
+
+	if (sco_server == NULL) {
+		LOG_ERR("No SCO server registered");
+		return BT_HCI_ERR_UNSPECIFIED;
+	}
+
+	sco_conn = bt_conn_add_sco(&evt->bdaddr, evt->link_type);
+	if (!sco_conn) {
+		return BT_HCI_ERR_INSUFFICIENT_RESOURCES;
+	}
+
+	sec_err = sco_server_check_security(sco_conn->sco.acl);
+	if (BT_HCI_ERR_SUCCESS != sec_err) {
+		LOG_DBG("Insufficient security %u", sec_err);
+		bt_sco_cleanup(sco_conn);
+		return sec_err;
+	}
+
+	memcpy(sco_conn->sco.dev_class, evt->dev_class, sizeof(sco_conn->sco.dev_class));
+	sco_conn->sco.link_type = evt->link_type;
+
+	if (accept_sco_conn(&evt->bdaddr, sco_conn)) {
+		LOG_ERR("Error accepting connection from %s", bt_addr_str(&evt->bdaddr));
+		bt_sco_cleanup(sco_conn);
+		return BT_HCI_ERR_UNSPECIFIED;
+	}
+
+	sco_conn->role = BT_HCI_ROLE_PERIPHERAL;
+	bt_conn_set_state(sco_conn, BT_CONN_CONNECTING);
+	bt_conn_unref(sco_conn);
+
+	return BT_HCI_ERR_SUCCESS;
+}
+
+void bt_sco_cleanup_acl(struct bt_conn *sco)
+{
+	LOG_DBG("%p", sco);
+
+	if (sco->sco.acl) {
+		bt_conn_unref(sco->sco.acl);
+		sco->sco.acl = NULL;
+	}
+}
+
+static int sco_chan_connect_security(struct bt_conn *sco, struct bt_sco_chan *chan)
+{
+	struct bt_conn *acl;
+
+	acl = sco->sco.acl;
+
+	if (acl->sec_level < chan->required_sec_level) {
+		int err;
+
+		err = bt_conn_set_security(acl,	chan->required_sec_level);
+		if (err != 0) {
+			LOG_DBG("Failed to set security: %d", err);
+
+			/* Restore states */
+			bt_sco_cleanup_acl(sco);
+			bt_sco_chan_set_state(chan, BT_SCO_STATE_DISCONNECTED);
+
+			return err;
+		}
+		bt_sco_chan_set_state(chan, BT_SCO_STATE_ENCRYPT_PENDING);
+	}
+
+	return 0;
+}
+
+static int sco_setup_sync_conn(struct bt_conn *sco_conn)
+{
+	struct net_buf *buf;
+	struct bt_hci_cp_setup_sync_conn *cp;
+	int err;
+
+	buf = bt_hci_cmd_create(BT_HCI_OP_SETUP_SYNC_CONN, sizeof(*cp));
+	if (!buf) {
+		return -ENOBUFS;
+	}
+
+	cp = net_buf_add(buf, sizeof(*cp));
+
+	(void)memset(cp, 0, sizeof(*cp));
+
+	LOG_DBG("handle : %x", sco_conn->sco.acl->handle);
+
+	cp->handle = sco_conn->sco.acl->handle;
+	cp->pkt_type = sco_conn->sco.pkt_type;
+	cp->tx_bandwidth = 0x00001f40;
+	cp->rx_bandwidth = 0x00001f40;
+	cp->max_latency = 0x0007;
+	cp->retrans_effort = 0x01;
+	cp->content_format = BT_VOICE_CVSD_16BIT;
+
+	err = bt_hci_cmd_send_sync(BT_HCI_OP_SETUP_SYNC_CONN, buf, NULL);
+	if (err < 0) {
+		return err;
+	}
+	return 0;
+}
+
+struct bt_conn *bt_conn_create_sco(const bt_addr_t *peer, struct bt_sco_chan *chan)
+{
+	struct bt_conn *sco_conn;
+	int link_type;
+
+	sco_conn = bt_conn_lookup_addr_sco(peer);
+	if (sco_conn) {
+		switch (sco_conn->state) {
+		case BT_CONN_CONNECTING:
+		case BT_CONN_CONNECTED:
+			return sco_conn;
+		default:
+			bt_conn_unref(sco_conn);
+			return NULL;
+		}
+	}
+
+	if (BT_FEAT_LMP_ESCO_CAPABLE(bt_dev.features)) {
+		link_type = BT_HCI_ESCO;
+	} else {
+		link_type = BT_HCI_SCO;
+	}
+
+	sco_conn = bt_conn_add_sco(peer, link_type);
+	if (!sco_conn) {
+		return NULL;
+	}
+
+	sco_conn->sco.link_type = link_type;
+
+	bt_sco_chan_add(sco_conn, chan);
+	bt_conn_set_state(chan->sco, BT_CONN_CONNECTING);
+	bt_sco_chan_set_state(chan, BT_SCO_STATE_CONNECTING);
+
+	if (sco_chan_connect_security(sco_conn, chan) != 0)	{
+		bt_sco_cleanup(sco_conn);
+		return NULL;
+	}
+
+	if (chan->state == BT_SCO_STATE_ENCRYPT_PENDING) {
+		return sco_conn;
+	}
+
+	if (sco_setup_sync_conn(sco_conn) < 0) {
+		bt_conn_set_state(chan->sco, BT_CONN_DISCONNECTED);
+		bt_sco_chan_set_state(chan, BT_SCO_STATE_DISCONNECTED);
+		bt_sco_cleanup(sco_conn);
+		return NULL;
+	}
+
+	return sco_conn;
+}
+
+struct sco_conns_scanning_data {
+	struct bt_conn *acl;
+	struct bt_conn *sco[CONFIG_BT_MAX_SCO_CONN];
+};
+
+static void sco_conns_scanning_cb(struct bt_conn *sco, void *user_data)
+{
+	struct sco_conns_scanning_data *data;
+	struct bt_sco_chan *chan;
+	int i;
+
+	data = (struct sco_conns_scanning_data *)user_data;
+
+	if (sco->sco.acl != data->acl) {
+		return;
+	}
+
+	chan = SCO_CHAN(sco);
+	if (chan->state != BT_SCO_STATE_ENCRYPT_PENDING) {
+		return;
+	}
+
+	for (i = 0; i < CONFIG_BT_MAX_SCO_CONN; i++) {
+		if (data->sco[i] == NULL) {
+			data->sco[i] = sco;
+			break;
+		}
+	}
+	bt_sco_chan_set_state(chan, BT_SCO_STATE_DISCONNECTED);
+}
+
+void bt_sco_security_changed(struct bt_conn *acl, uint8_t hci_status)
+{
+	struct sco_conns_scanning_data data;
+	struct bt_sco_chan *chan;
+	int err;
+	int i;
+	uint8_t hci_err;
+
+	/* The peripheral does not accept any SCO requests if security is
+	 * insufficient, so we only need to handle central here.
+	 * BT_SCO_STATE_ENCRYPT_PENDING is only set by the central.
+	 */
+	if (!IS_ENABLED(CONFIG_BT_CENTRAL) ||
+		acl->role != BT_CONN_ROLE_CENTRAL) {
+		return;
+	}
+
+	(void)memset(&data, 0, sizeof(data));
+
+	bt_conn_foreach(BT_CONN_TYPE_SCO, sco_conns_scanning_cb, &data);
+
+	for (i = 0; i < CONFIG_BT_MAX_SCO_CONN; i++) {
+		struct bt_conn *sco;
+
+		sco = data.sco[i];
+		if (sco != NULL) {
+			chan = SCO_CHAN(sco);
+			hci_err = hci_status;
+
+			if (hci_status == BT_HCI_ERR_SUCCESS) {
+				err = sco_setup_sync_conn(sco);
+				if (err < 0) {
+					LOG_ERR("Failed to setup sync conn: %d", err);
+					bt_sco_cleanup(sco);
+					hci_err = BT_HCI_ERR_UNSPECIFIED;
+				} else {
+					/* Set connection states */
+					bt_sco_chan_set_state(chan, BT_SCO_STATE_CONNECTING);
+				}
+			}
+
+			if (hci_err != BT_HCI_ERR_SUCCESS) {
+				LOG_DBG("Failed to encrypt ACL %p for SCO %p: %u", acl,
+							sco, hci_status);
+
+				/* Notify upper-layer that the SCO connection
+				 * cannot be created due to the error.
+				 */
+				if (chan->ops->disconnected) {
+					chan->ops->disconnected(chan, hci_err);
+				}
+			}
+		}
+	}
+}

--- a/subsys/bluetooth/host/classic/sco_internal.h
+++ b/subsys/bluetooth/host/classic/sco_internal.h
@@ -53,16 +53,6 @@ struct bt_sco_chan {
 	struct bt_sco_chan_ops		*ops;
 
 	enum bt_sco_state		state;
-
-	/** @brief The required security level of the channel
-	 *
-	 * This value can be set as the central before calling bt_conn_create_sco().
-	 * The value is overwritten to @ref bt_iso_server::sec_level for the
-	 * peripheral once a channel has been accepted.
-	 *
-	 * Only available when @kconfig{CONFIG_BT_SMP} is enabled.
-	 */
-	bt_security_t			required_sec_level;
 };
 
 /** @brief Initiate an SCO connection to a remote device.
@@ -149,11 +139,7 @@ void bt_sco_connected(struct bt_conn *sco);
  */
 void bt_sco_disconnected(struct bt_conn *sco);
 
-/* Notify SCO connected channels of security changed */
-void bt_sco_security_changed(struct bt_conn *acl, uint8_t hci_status);
-
 uint8_t bt_esco_conn_req(struct bt_hci_evt_conn_request *evt);
-
 
 #if defined(CONFIG_BT_CONN_LOG_LEVEL_DBG)
 void bt_sco_chan_set_state_debug(struct bt_sco_chan *chan,

--- a/subsys/bluetooth/host/classic/sco_internal.h
+++ b/subsys/bluetooth/host/classic/sco_internal.h
@@ -1,0 +1,166 @@
+/** @file
+ *  @brief Internal APIs for Bluetooth SCO handling.
+ */
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** @brief Life-span states of SCO channel. Used only by internal APIs
+ *  dealing with setting channel to proper state depending on operational
+ *  context.
+ */
+enum bt_sco_state {
+	/** Channel disconnected */
+	BT_SCO_STATE_DISCONNECTED,
+	/** Channel is pending ACL encryption before connecting */
+	BT_SCO_STATE_ENCRYPT_PENDING,
+	/** Channel in connecting state */
+	BT_SCO_STATE_CONNECTING,
+	/** Channel ready for upper layer traffic on it */
+	BT_SCO_STATE_CONNECTED,
+	/** Channel in disconnecting state */
+	BT_SCO_STATE_DISCONNECTING,
+};
+
+struct bt_sco_chan;
+struct bt_sco_chan_ops {
+	/** @brief Channel connected callback
+	 *
+	 *  If this callback is provided it will be called whenever the
+	 *  connection completes.
+	 *
+	 *  @param chan The channel that has been connected
+	 */
+	void (*connected)(struct bt_sco_chan *chan);
+
+	/** @brief Channel disconnected callback
+	 *
+	 *  If this callback is provided it will be called whenever the
+	 *  channel is disconnected, including when a connection gets
+	 *  rejected or when setting security fails.
+	 *
+	 *  @param chan   The channel that has been Disconnected
+	 *  @param reason BT_HCI_ERR_* reason for the disconnection.
+	 */
+	void (*disconnected)(struct bt_sco_chan *chan, uint8_t reason);
+};
+
+struct bt_sco_chan {
+	struct bt_conn *sco;
+	/** Channel operations reference */
+	struct bt_sco_chan_ops		*ops;
+
+	enum bt_sco_state		state;
+
+	/** @brief The required security level of the channel
+	 *
+	 * This value can be set as the central before calling bt_conn_create_sco().
+	 * The value is overwritten to @ref bt_iso_server::sec_level for the
+	 * peripheral once a channel has been accepted.
+	 *
+	 * Only available when @kconfig{CONFIG_BT_SMP} is enabled.
+	 */
+	bt_security_t			required_sec_level;
+};
+
+/** @brief Initiate an SCO connection to a remote device.
+ *
+ *  Allows initiate new SCO link to remote peer using its address.
+ *
+ *  The caller gets a new reference to the connection object which must be
+ *  released with bt_conn_unref() once done using the object.
+ *
+ *  @param peer  Remote address.
+ *  @param chan  sco chan object.
+ *
+ *  @return Valid connection object on success or NULL otherwise.
+ */
+struct bt_conn *bt_conn_create_sco(const bt_addr_t *peer, struct bt_sco_chan *chan);
+
+/** @brief SCO Accept Info Structure */
+struct bt_sco_accept_info {
+	/** The ACL connection that is requesting authorization */
+	struct bt_conn *acl;
+
+	/** class code of peer device */
+	uint8_t   dev_class[3];
+
+	/** link type */
+	uint8_t   link_type;
+};
+
+/** @brief SCO Server structure. */
+struct bt_sco_server {
+	/** Required minimum security level.
+	 * Only available when @kconfig{CONFIG_BT_SMP} is enabled.
+	 */
+	bt_security_t		sec_level;
+	/** @brief Server accept callback
+	 *
+	 *  This callback is called whenever a new incoming connection requires
+	 *  authorization.
+	 *
+	 *  @param info The SCO accept information structure
+	 *  @param chan Pointer to receive the allocated channel
+	 *
+	 *  @return 0 in case of success or negative value in case of error.
+	 */
+	int (*accept)(const struct bt_sco_accept_info *info,
+			  struct bt_sco_chan **chan);
+};
+
+/** @brief Register SCO server.
+ *
+ *  Register SCO server, each new connection is authorized using the accept()
+ *  callback which in case of success shall allocate the channel structure
+ *  to be used by the new connection.
+ *
+ *  @param server Server structure.
+ *
+ *  @return 0 in case of success or negative value in case of error.
+ */
+int bt_sco_server_register(struct bt_sco_server *server);
+
+/** @brief Unregister SCO server.
+ *
+ *  Unregister previously registered SCO server.
+ *
+ *  @param server Server structure.
+ *
+ *  @return 0 in case of success or negative value in case of error.
+ */
+int bt_sco_server_unregister(struct bt_sco_server *server);
+
+/** @brief sco channel connected.
+ *
+ *  sco channel connected
+ *
+ *  @param sco SCO connection object.
+ */
+void bt_sco_connected(struct bt_conn *sco);
+
+/** @brief sco channel disconnected.
+ *
+ *  sco channel disconnected
+ *
+ *  @param sco SCO connection object.
+ */
+void bt_sco_disconnected(struct bt_conn *sco);
+
+/* Notify SCO connected channels of security changed */
+void bt_sco_security_changed(struct bt_conn *acl, uint8_t hci_status);
+
+uint8_t bt_esco_conn_req(struct bt_hci_evt_conn_request *evt);
+
+
+#if defined(CONFIG_BT_CONN_LOG_LEVEL_DBG)
+void bt_sco_chan_set_state_debug(struct bt_sco_chan *chan,
+				 enum bt_sco_state state,
+				 const char *func, int line);
+#define bt_sco_chan_set_state(_chan, _state) \
+	bt_sco_chan_set_state_debug(_chan, _state, __func__, __LINE__)
+#else
+void bt_sco_chan_set_state(struct bt_sco_chan *chan, enum bt_sco_state state);
+#endif /* CONFIG_BT_CONN_LOG_LEVEL_DBG */

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2317,10 +2317,6 @@ void bt_conn_security_changed(struct bt_conn *conn, uint8_t hci_err,
 		bt_iso_security_changed(conn, hci_err);
 	}
 
-	if (IS_ENABLED(CONFIG_BT_CLASSIC)) {
-		bt_sco_security_changed(conn, hci_err);
-	}
-
 	for (struct bt_conn_cb *cb = callback_list; cb; cb = cb->_next) {
 		if (cb->security_changed) {
 			cb->security_changed(conn, conn->sec_level, err);

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -42,6 +42,7 @@
 #include "att_internal.h"
 #include "iso_internal.h"
 #include "direction_internal.h"
+#include "classic/sco_internal.h"
 
 #define LOG_LEVEL CONFIG_BT_CONN_LOG_LEVEL
 #include <zephyr/logging/log.h>
@@ -1094,7 +1095,9 @@ void bt_conn_set_state(struct bt_conn *conn, bt_conn_state_t state)
 	switch (conn->state) {
 	case BT_CONN_CONNECTED:
 		if (conn->type == BT_CONN_TYPE_SCO) {
-			/* TODO: Notify sco connected */
+			if (IS_ENABLED(CONFIG_BT_CLASSIC)) {
+				bt_sco_connected(conn);
+			}
 			break;
 		}
 		k_fifo_init(&conn->tx_queue);
@@ -1128,7 +1131,9 @@ void bt_conn_set_state(struct bt_conn *conn, bt_conn_state_t state)
 	case BT_CONN_DISCONNECTED:
 #if defined(CONFIG_BT_CONN)
 		if (conn->type == BT_CONN_TYPE_SCO) {
-			/* TODO: Notify sco disconnected */
+			if (IS_ENABLED(CONFIG_BT_CLASSIC)) {
+				bt_sco_disconnected(conn);
+			}
 			bt_conn_unref(conn);
 			break;
 		}
@@ -1823,6 +1828,29 @@ static struct bt_conn *conn_lookup_iso(struct bt_conn *conn)
 }
 #endif /* CONFIG_BT_ISO */
 
+#if defined(CONFIG_BT_CLASSIC)
+static struct bt_conn *conn_lookup_sco(struct bt_conn *conn)
+{
+	int i;
+
+	for (i = 0; i < ARRAY_SIZE(sco_conns); i++) {
+		struct bt_conn *sco = bt_conn_ref(&sco_conns[i]);
+
+		if (sco == NULL) {
+			continue;
+		}
+
+		if (sco->sco.acl == conn) {
+			return sco;
+		}
+
+		bt_conn_unref(sco);
+	}
+
+	return NULL;
+}
+#endif /* CONFIG_BT_CLASSIC */
+
 static void deferred_work(struct k_work *work)
 {
 	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
@@ -1863,7 +1891,28 @@ static void deferred_work(struct k_work *work)
 			iso = conn_lookup_iso(conn);
 		}
 #endif
+#if defined(CONFIG_BT_CLASSIC)
+		struct bt_conn *sco;
 
+		/* Mark all SCO channels associated
+		 * with ACL conn as not connected, and
+		 * remove ACL reference
+		 */
+		sco = conn_lookup_sco(conn);
+		while (sco != NULL) {
+			struct bt_sco_chan *chan = sco->sco.chan;
+
+			if (chan != NULL) {
+				bt_sco_chan_set_state(chan,
+						      BT_SCO_STATE_DISCONNECTING);
+			}
+
+			bt_sco_cleanup_acl(sco);
+
+			bt_conn_unref(sco);
+			sco = conn_lookup_sco(conn);
+		}
+#endif /* CONFIG_BT_CLASSIC */
 		bt_l2cap_disconnected(conn);
 		notify_disconnected(conn);
 
@@ -1937,8 +1986,7 @@ static struct bt_conn *acl_conn_new(void)
 #if defined(CONFIG_BT_CLASSIC)
 void bt_sco_cleanup(struct bt_conn *sco_conn)
 {
-	bt_conn_unref(sco_conn->sco.acl);
-	sco_conn->sco.acl = NULL;
+	bt_sco_cleanup_acl(sco_conn);
 	bt_conn_unref(sco_conn);
 }
 
@@ -1996,67 +2044,6 @@ struct bt_conn *bt_conn_create_br(const bt_addr_t *peer,
 	conn->role = BT_CONN_ROLE_CENTRAL;
 
 	return conn;
-}
-
-struct bt_conn *bt_conn_create_sco(const bt_addr_t *peer)
-{
-	struct bt_hci_cp_setup_sync_conn *cp;
-	struct bt_conn *sco_conn;
-	struct net_buf *buf;
-	int link_type;
-
-	sco_conn = bt_conn_lookup_addr_sco(peer);
-	if (sco_conn) {
-		switch (sco_conn->state) {
-		case BT_CONN_CONNECTING:
-		case BT_CONN_CONNECTED:
-			return sco_conn;
-		default:
-			bt_conn_unref(sco_conn);
-			return NULL;
-		}
-	}
-
-	if (BT_FEAT_LMP_ESCO_CAPABLE(bt_dev.features)) {
-		link_type = BT_HCI_ESCO;
-	} else {
-		link_type = BT_HCI_SCO;
-	}
-
-	sco_conn = bt_conn_add_sco(peer, link_type);
-	if (!sco_conn) {
-		return NULL;
-	}
-
-	buf = bt_hci_cmd_create(BT_HCI_OP_SETUP_SYNC_CONN, sizeof(*cp));
-	if (!buf) {
-		bt_sco_cleanup(sco_conn);
-		return NULL;
-	}
-
-	cp = net_buf_add(buf, sizeof(*cp));
-
-	(void)memset(cp, 0, sizeof(*cp));
-
-	LOG_ERR("handle : %x", sco_conn->sco.acl->handle);
-
-	cp->handle = sco_conn->sco.acl->handle;
-	cp->pkt_type = sco_conn->sco.pkt_type;
-	cp->tx_bandwidth = 0x00001f40;
-	cp->rx_bandwidth = 0x00001f40;
-	cp->max_latency = 0x0007;
-	cp->retrans_effort = 0x01;
-	cp->content_format = BT_VOICE_CVSD_16BIT;
-
-	if (bt_hci_cmd_send_sync(BT_HCI_OP_SETUP_SYNC_CONN, buf,
-				 NULL) < 0) {
-		bt_sco_cleanup(sco_conn);
-		return NULL;
-	}
-
-	bt_conn_set_state(sco_conn, BT_CONN_CONNECTING);
-
-	return sco_conn;
 }
 
 struct bt_conn *bt_conn_lookup_addr_sco(const bt_addr_t *peer)
@@ -2328,6 +2315,10 @@ void bt_conn_security_changed(struct bt_conn *conn, uint8_t hci_err,
 	bt_l2cap_security_changed(conn, hci_err);
 	if (IS_ENABLED(CONFIG_BT_ISO_CENTRAL)) {
 		bt_iso_security_changed(conn, hci_err);
+	}
+
+	if (IS_ENABLED(CONFIG_BT_CLASSIC)) {
+		bt_sco_security_changed(conn, hci_err);
 	}
 
 	for (struct bt_conn_cb *cb = callback_list; cb; cb = cb->_next) {

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -104,7 +104,13 @@ struct bt_conn_br {
 struct bt_conn_sco {
 	/* Reference to ACL Connection */
 	struct bt_conn          *acl;
+
+	/* Reference to the struct bt_sco_chan */
+	struct bt_sco_chan      *chan;
+
 	uint16_t                pkt_type;
+	uint8_t                 dev_class[3];
+	uint8_t                 link_type;
 };
 #endif
 
@@ -292,6 +298,9 @@ struct bt_conn *bt_conn_add_br(const bt_addr_t *peer);
 
 /* Add a new SCO connection */
 struct bt_conn *bt_conn_add_sco(const bt_addr_t *peer, int link_type);
+
+/* Cleanup SCO ACL reference */
+void bt_sco_cleanup_acl(struct bt_conn *sco_conn);
 
 /* Cleanup SCO references */
 void bt_sco_cleanup(struct bt_conn *sco_conn);


### PR DESCRIPTION
Currently, SCO connections and disconnections are agnostic to upper-layer.

Add two functions, bt_sco_connected and bt_sco_disconnected, to notify the SCO connect changes.

For Central side, pass "struct bt_sco_chan" object when calling bt_conn_create_sco. it uses to manage the SCO channel for upper-
layer.

For Peripheral side, two functions bt_sco_server_register and bt_sco_server_unregister are added to monitor SCO connection request for upper-layer. The upper-layer could accept or reject SCO connect When the connection request received. If the connect is accepted, the "struct bt_sco_chan" object could be passed by "sco_server->accept".

Call bt_sco_server_register to register SCO server. Manage the SCO connection request. Get SCO connect/disconnect status via SCO channel ops.

Notify the uppper layer of the SCO connection status changes through bt_hfp_hf_cb::sco_connected and bt_hfp_hf_cb::sco_disconnected.