### PR TITLE
Reset data ready signal for ADS114s0x

### DIFF
--- a/drivers/adc/adc_ads114s0x.c
+++ b/drivers/adc/adc_ads114s0x.c
@@ -1006,6 +1006,7 @@ static int ads114s0x_adc_perform_read(const struct device *dev)
 	struct ads114s0x_data *data = dev->data;
 
 	k_sem_take(&data->acquire_signal, K_FOREVER);
+	k_sem_reset(&data->data_ready_signal);
 
 	result = ads114s0x_send_start_read(dev);
 	if (result != 0) {


### PR DESCRIPTION
Reset the data ready signal for a new read operation with a ADS114s0x.

This fixes an issue of receiving faulty samples when the timeout already occurred previously.