### PR TITLE
memory window: Increase memory window 2 size by one slot

### DIFF
--- a/soc/intel/intel_adsp/Kconfig
+++ b/soc/intel/intel_adsp/Kconfig
@@ -43,7 +43,7 @@ config MEMORY_WIN_1_SIZE
 
 config MEMORY_WIN_2_SIZE
 	int "Size of memory window 2"
-	default 8192
+	default 12288
 	help
 	  Size of memory window 2.
 


### PR DESCRIPTION
Hi, I'm a dev from SOF project. We need one more slot (4096 bytes ) for memory window 2 to have some space for telemetry implementation.

The thing is, increasing the size by one page like this also moves zephyr logs by one page, from what I've seen (it moves to a next slot/page, compared to the one before the change). I heard there are some scripts that need to be updated to point to new addresses in this case. I'll need some help here, as I don't know all of the consequences of this change.

