### PR TITLE
drivers: modem: gsm_ppp: add power & reset gpio

### DIFF
--- a/dts/bindings/modem/zephyr,gsm-ppp.yaml
+++ b/dts/bindings/modem/zephyr,gsm-ppp.yaml
@@ -6,3 +6,10 @@ description: GSM PPP modem
 compatible: "zephyr,gsm-ppp"
 
 include: uart-device.yaml
+
+properties:
+  mdm-power-gpios:
+    type: phandle-array
+
+  mdm-reset-gpios:
+    type: phandle-array


### PR DESCRIPTION
In its devicetree bindings yaml-file, the generic `zephyr,gsm-ppp` GSM modem device is missing the entries for `mdm-power-gpios` and `mdm-reset-gpios`. These are necessary to configure a power or a reset pin with this device.
The driver implementation is already using these properties in `drivers\modem\modem_cellular.c`, so there is no further implementation necessary.

https://github.com/zephyrproject-rtos/zephyr/blob/ff8c8923aefad2de2a8371f8579e5f2523d3536e/drivers/modem/modem_cellular.c#L2007-L2008
