### PR TITLE
Bluetooth: BAP: Apply missing guards for Kconfig values

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -655,7 +655,9 @@ enum bt_audio_dir {
 		.phy = _phy,                                                                       \
 		.sdu = _sdu,                                                                       \
 		.rtn = _rtn,                                                                       \
-		.latency = _latency,                                                               \
+		IF_ENABLED(UTIL_OR(IS_ENABLED(CONFIG_BT_BAP_BROADCAST_SOURCE),                     \
+				   IS_ENABLED(CONFIG_BT_BAP_UNICAST)),                             \
+			   (.latency = _latency,))                                                 \
 		.pd = _pd,                                                                         \
 	})
 

--- a/subsys/bluetooth/audio/Kconfig.bap
+++ b/subsys/bluetooth/audio/Kconfig.bap
@@ -170,8 +170,8 @@ config BT_BAP_BROADCAST_SINK
 	select EXPERIMENTAL
 	select BT_ISO_SYNC_RECEIVER
 	select BT_AUDIO_RX
+	select BT_PAC_SNK
 	depends on BT_PERIPHERAL
-	depends on BT_PAC_SNK
 	depends on BT_BAP_SCAN_DELEGATOR
 	help
 	  This option enables support for Bluetooth Broadcast Sink Audio using

--- a/subsys/bluetooth/audio/shell/audio.h
+++ b/subsys/bluetooth/audio/shell/audio.h
@@ -58,23 +58,6 @@ struct named_lc3_preset {
 const struct named_lc3_preset *bap_get_named_preset(bool is_unicast, enum bt_audio_dir dir,
 						    const char *preset_arg);
 
-#if defined(CONFIG_BT_BAP_UNICAST)
-
-#define UNICAST_SERVER_STREAM_COUNT                                                                \
-	COND_CODE_1(CONFIG_BT_ASCS, (CONFIG_BT_ASCS_ASE_SNK_COUNT + CONFIG_BT_ASCS_ASE_SRC_COUNT), \
-		    (0))
-#define UNICAST_CLIENT_STREAM_COUNT                                                                \
-	COND_CODE_1(CONFIG_BT_BAP_UNICAST_CLIENT,                                                  \
-		    (CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT +                                  \
-		     CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT),                                  \
-		    (0))
-
-#define BAP_UNICAST_AC_MAX_CONN   2U
-#define BAP_UNICAST_AC_MAX_SNK    (2U * BAP_UNICAST_AC_MAX_CONN)
-#define BAP_UNICAST_AC_MAX_SRC    (2U * BAP_UNICAST_AC_MAX_CONN)
-#define BAP_UNICAST_AC_MAX_PAIR   MAX(BAP_UNICAST_AC_MAX_SNK, BAP_UNICAST_AC_MAX_SRC)
-#define BAP_UNICAST_AC_MAX_STREAM (BAP_UNICAST_AC_MAX_SNK + BAP_UNICAST_AC_MAX_SRC)
-
 struct shell_stream {
 	struct bt_cap_stream stream;
 	struct bt_audio_codec_cfg codec_cfg;
@@ -123,6 +106,23 @@ struct broadcast_sink {
 	size_t stream_cnt;
 	bool syncable;
 };
+
+#define BAP_UNICAST_AC_MAX_CONN   2U
+#define BAP_UNICAST_AC_MAX_SNK    (2U * BAP_UNICAST_AC_MAX_CONN)
+#define BAP_UNICAST_AC_MAX_SRC    (2U * BAP_UNICAST_AC_MAX_CONN)
+#define BAP_UNICAST_AC_MAX_PAIR   MAX(BAP_UNICAST_AC_MAX_SNK, BAP_UNICAST_AC_MAX_SRC)
+#define BAP_UNICAST_AC_MAX_STREAM (BAP_UNICAST_AC_MAX_SNK + BAP_UNICAST_AC_MAX_SRC)
+
+#if defined(CONFIG_BT_BAP_UNICAST)
+
+#define UNICAST_SERVER_STREAM_COUNT                                                                \
+	COND_CODE_1(CONFIG_BT_ASCS, (CONFIG_BT_ASCS_ASE_SNK_COUNT + CONFIG_BT_ASCS_ASE_SRC_COUNT), \
+		    (0))
+#define UNICAST_CLIENT_STREAM_COUNT                                                                \
+	COND_CODE_1(CONFIG_BT_BAP_UNICAST_CLIENT,                                                  \
+		    (CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT +                                  \
+		     CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT),                                  \
+		    (0))
 
 extern struct shell_stream unicast_streams[CONFIG_BT_MAX_CONN * (UNICAST_SERVER_STREAM_COUNT +
 								 UNICAST_CLIENT_STREAM_COUNT)];

--- a/tests/bluetooth/shell/testcase.yaml
+++ b/tests/bluetooth/shell/testcase.yaml
@@ -204,6 +204,34 @@ tests:
     build_only: true
     extra_configs:
       - CONFIG_BT_PAC_SRC=n
+  bluetooth.audio_shell.only_unicast_client:
+    extra_args: CONF_FILE="audio.conf"
+    build_only: true
+    extra_configs:
+      - CONFIG_BT_BAP_UNICAST_SERVER=n
+      - CONFIG_BT_BAP_BROADCAST_SINK=n
+      - CONFIG_BT_BAP_BROADCAST_SOURCE=n
+  bluetooth.audio_shell.only_unicast_server:
+    extra_args: CONF_FILE="audio.conf"
+    build_only: true
+    extra_configs:
+      - CONFIG_BT_BAP_UNICAST_CLIENT=n
+      - CONFIG_BT_BAP_BROADCAST_SINK=n
+      - CONFIG_BT_BAP_BROADCAST_SOURCE=n
+  bluetooth.audio_shell.only_broadcast_source:
+    extra_args: CONF_FILE="audio.conf"
+    build_only: true
+    extra_configs:
+      - CONFIG_BT_BAP_UNICAST_SERVER=n
+      - CONFIG_BT_BAP_UNICAST_CLIENT=n
+      - CONFIG_BT_BAP_BROADCAST_SINK=n
+  bluetooth.audio_shell.only_broadcast_sink:
+    extra_args: CONF_FILE="audio.conf"
+    build_only: true
+    extra_configs:
+      - CONFIG_BT_BAP_UNICAST_SERVER=n
+      - CONFIG_BT_BAP_UNICAST_CLIENT=n
+      - CONFIG_BT_BAP_BROADCAST_SOURCE=n
   bluetooth.audio_shell.no_unicast_client:
     extra_args: CONF_FILE="audio.conf"
     build_only: true


### PR DESCRIPTION
Some pieces of code were missing proper guards for Kconfig values, which could cause compile issues