### PR TITLE
boards: intel: doc: hwmv2: Fix some renamed paths

### DIFF
--- a/boards/intel/socfpga/agilex5_socdk/doc/index.rst
+++ b/boards/intel/socfpga/agilex5_socdk/doc/index.rst
@@ -45,7 +45,7 @@ hardware features:
 NOTE: TODO, more details on dev kit will be updated as and when available.
 
 The default configuration can be found in the defconfig file:
-        `boards/intel/intel_socfpga/agilex5_socdk/intel_socfpga_agilex5_socdk_defconfig`
+        `boards/intel/socfpga/agilex5_socdk/intel_socfpga_agilex5_socdk_defconfig`
 
 Programming and Debugging
 *************************

--- a/boards/intel/socfpga_std/cyclonev_socdk/support/download_all.gdb
+++ b/boards/intel/socfpga_std/cyclonev_socdk/support/download_all.gdb
@@ -7,7 +7,7 @@ set confirm off
 set pagination off
 
 #Download and Run preloader
-source boards/intel/intel_socfpga_std/cyclonev_socdk/support/preloader_dl_cmd.txt
+source boards/intel/socfpga_std/cyclonev_socdk/support/preloader_dl_cmd.txt
 
 #Stop watchdog timer
 #permodrst Reg , reset watch dog timer

--- a/boards/intel/socfpga_std/cyclonev_socdk/support/preloader_dl_cmd.txt
+++ b/boards/intel/socfpga_std/cyclonev_socdk/support/preloader_dl_cmd.txt
@@ -3,7 +3,7 @@
 # Description:
 # Helper file to download the GSRD preloader to the board before the application
 
-restore boards/intel/intel_socfpga_std/cyclonev_socdk/support/u-boot-spl
-symbol-file -readnow boards/intel/intel_socfpga_std/cyclonev_socdk/support/u-boot-spl
+restore boards/intel/socfpga_std/cyclonev_socdk/support/u-boot-spl
+symbol-file -readnow boards/intel/socfpga_std/cyclonev_socdk/support/u-boot-spl
 thbreak spl_boot_device
 jump _start

--- a/soc/intel/intel_adsp/common/CMakeLists.txt
+++ b/soc/intel/intel_adsp/common/CMakeLists.txt
@@ -129,7 +129,7 @@ add_custom_target(zephyr.ri ALL
 
 # Parameters after the double dash -- are passed through to rimage.  For
 # other ways to override default rimage parameters check
-# boards/intel/intel_adsp_cavs25/doc/intel_adsp_generic.rst
+# boards/intel/adsp/doc/intel_adsp_generic.rst
 
 # Warning: because `west sign` can also be used interactively, using
 # ${WEST_SIGN_OPTS} like this has _higher_ precedence than `west config


### PR DESCRIPTION
Fix some paths affected by 'drop duplicate prefix' at folder names in boards change #69505


