### PR TITLE
scripts: ci: check_compliance: fix split on ":" for Windows

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -347,7 +347,7 @@ class KconfigCheck(ComplianceTest):
             lines = content.strip().split('\n')
             for line in lines:
                 if line.startswith('"DTS_ROOT":'):
-                    _, dts_root_path = line.split(":")
+                    _, dts_root_path = line.split(":", 1)
                     binding_paths.append(os.path.join(dts_root_path.strip('"'), "dts", "bindings"))
 
         cmd = [sys.executable, zephyr_drv_kconfig_path,


### PR DESCRIPTION
The method get_kconfig_dts() relies on str's split() to split lines into fields separated by ':'. The second field is an absolute path to a file.
On Windows, an absolute path includes a drive's letter followed by ':' which breaks the current code.
On Linux, although rare, a file or directory name may also include ':', which would also break the code.

The fix is to constraint the number of splits to 1. The code then becomes:

 _,b = line.split(":", 1)