### PR TITLE
shell: fix shell_stop command

### DIFF
--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1465,7 +1465,9 @@ int shell_stop(const struct shell *sh)
 
 	state_set(sh, SHELL_STATE_INITIALIZED);
 
-	z_shell_log_backend_disable(sh->log_backend);
+	if (IS_ENABLED(CONFIG_SHELL_LOG_BACKEND)) {
+		z_shell_log_backend_disable(sh->log_backend);
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Added missing condition to check if log backend is configured before calling the function: z_shell_log_backend_disable. Without this, in some configurations, a compilation error appeared due to calling a non-existent function.

Fixes #69555 [lukas-fwdev](https://github.com/lukas-fwdev)