### PR TITLE
Bluetooth: HFP: Fix session pointer invalid issue

### DIFF
--- a/subsys/bluetooth/host/hfp_internal.h
+++ b/subsys/bluetooth/host/hfp_internal.h
@@ -46,6 +46,8 @@
 
 struct bt_hfp_hf {
 	struct bt_rfcomm_dlc rfcomm_dlc;
+	/* ACL connection handle */
+	struct bt_conn *acl;
 	char hf_buffer[HF_MAX_BUF_LEN];
 	struct at_client at;
 	uint32_t hf_features;


### PR DESCRIPTION
The dlc->session is invalid in the callback hfp_hf_disconnected. The behavior of obtaining an ACL connection handle through an invalid pointer is unknown.

Add a field "struct bt_conn *acl" to "struct bt_hfp_hf". Save acl connect handle to "struct bt_hfp_hf::acl" in function bt_hfp_hf_accept.