### PR TITLE
fs: explicitly initialize fs_file_t and fs_dir_t

### DIFF
--- a/include/zephyr/fs/fs.h
+++ b/include/zephyr/fs/fs.h
@@ -231,7 +231,9 @@ struct fs_statvfs {
  */
 static inline void fs_file_t_init(struct fs_file_t *zfp)
 {
-	*zfp = (struct fs_file_t){ 0 };
+	zfp->filep = NULL;
+	zfp->mp = NULL;
+	zfp->flags = 0;
 }
 
 /**
@@ -245,7 +247,8 @@ static inline void fs_file_t_init(struct fs_file_t *zfp)
  */
 static inline void fs_dir_t_init(struct fs_dir_t *zdp)
 {
-	*zdp = (struct fs_dir_t){ 0 };
+	zdp->dirp = NULL;
+	zdp->mp = NULL;
 }
 
 /**


### PR DESCRIPTION
C++ compilers forbid usage of compound literals with -Wpedantic enabled.
They also forbid the usage of designated initializers for standards lower than c++20.
So switch to explicit initialization, that would not make compilers angry at us.