### PR TITLE
logging: Fix support for CONFIG_LOG_MSG_APPEND_RO_STRING_LOC

### DIFF
--- a/subsys/logging/log_msg.c
+++ b/subsys/logging/log_msg.c
@@ -93,11 +93,13 @@ static void z_log_msg_simple_create(const void *source, uint32_t level, uint32_t
 	/* Package length (in words) is increased by the header. */
 	size_t plen32 = len + CBPRINTF_DESC_SIZE32;
 	/* Package length in bytes. */
-	size_t plen8 = sizeof(uint32_t) * plen32;
+	size_t plen8 = sizeof(uint32_t) * plen32 +
+			(IS_ENABLED(CONFIG_LOG_MSG_APPEND_RO_STRING_LOC) ? 1 : 0);
 	struct log_msg *msg = z_log_msg_alloc(Z_LOG_MSG_ALIGNED_WLEN(plen8, 0));
 	union cbprintf_package_hdr package_hdr = {
 		.desc = {
-			.len = plen32
+			.len = plen32,
+			.ro_str_cnt = IS_ENABLED(CONFIG_LOG_MSG_APPEND_RO_STRING_LOC) ? 1 : 0
 		}
 	};
 
@@ -108,6 +110,10 @@ static void z_log_msg_simple_create(const void *source, uint32_t level, uint32_t
 		for (size_t i = 0; i < len; i++) {
 			*package++ = data[i];
 		}
+		if (IS_ENABLED(CONFIG_LOG_MSG_APPEND_RO_STRING_LOC)) {
+			/* fmt string located at index 1 */
+			*(uint8_t *)package = 1;
+		}
 	}
 
 	struct log_msg_desc desc = {
@@ -117,7 +123,6 @@ static void z_log_msg_simple_create(const void *source, uint32_t level, uint32_t
 	};
 
 	z_log_msg_finalize(msg, source, desc, NULL);
-
 }
 
 void z_impl_z_log_msg_simple_create_0(const void *source, uint32_t level, const char *fmt)
@@ -133,20 +138,30 @@ void z_impl_z_log_msg_simple_create_0(const void *source, uint32_t level, const 
 			uint32_t plen32 = CBPRINTF_DESC_SIZE32 + 1;
 			union cbprintf_package_hdr hdr = {
 				.desc = {
-					.len = plen32
+					.len = plen32,
+					.ro_str_cnt =
+					   IS_ENABLED(CONFIG_LOG_MSG_APPEND_RO_STRING_LOC) ? 1 : 0
 				}
 			};
-			uint32_t package[] = {
-				(uint32_t)(uintptr_t)hdr.raw,
-				(uint32_t)(uintptr_t)fmt,
-			};
+			uint8_t package[sizeof(uint32_t) * (CBPRINTF_DESC_SIZE32 + 1) +
+				(IS_ENABLED(CONFIG_LOG_MSG_APPEND_RO_STRING_LOC) ? 1 : 0)]
+				__aligned(sizeof(uint32_t));
+			uint32_t *p32 = (uint32_t *)package;
+
+			*p32++ = (uint32_t)(uintptr_t)hdr.raw;
+			*p32++ = (uint32_t)(uintptr_t)fmt;
+			if (IS_ENABLED(CONFIG_LOG_MSG_APPEND_RO_STRING_LOC)) {
+				/* fmt string located at index 1 */
+				*(uint8_t *)p32 = 1;
+			}
+
 			struct log_msg_desc desc = {
 				.level = level,
-				.package_len = plen32 * sizeof(uint32_t),
+				.package_len = sizeof(package),
 				.data_len = 0,
 			};
 
-			log_frontend_msg(source, desc, (uint8_t *)package, NULL);
+			log_frontend_msg(source, desc, package, NULL);
 		}
 	}
 
@@ -172,21 +187,31 @@ void z_impl_z_log_msg_simple_create_1(const void *source, uint32_t level,
 			uint32_t plen32 = CBPRINTF_DESC_SIZE32 + 2;
 			union cbprintf_package_hdr hdr = {
 				.desc = {
-					.len = plen32
+					.len = plen32,
+					.ro_str_cnt =
+					   IS_ENABLED(CONFIG_LOG_MSG_APPEND_RO_STRING_LOC) ? 1 : 0
 				}
 			};
-			uint32_t package[] = {
-				(uint32_t)(uintptr_t)hdr.raw,
-				(uint32_t)(uintptr_t)fmt,
-				arg
-			};
+			uint8_t package[sizeof(uint32_t) * (CBPRINTF_DESC_SIZE32 + 2) +
+				(IS_ENABLED(CONFIG_LOG_MSG_APPEND_RO_STRING_LOC) ? 1 : 0)]
+				__aligned(sizeof(uint32_t));
+			uint32_t *p32 = (uint32_t *)package;
+
+			*p32++ = (uint32_t)(uintptr_t)hdr.raw;
+			*p32++ = (uint32_t)(uintptr_t)fmt;
+			*p32++ = arg;
+			if (IS_ENABLED(CONFIG_LOG_MSG_APPEND_RO_STRING_LOC)) {
+				/* fmt string located at index 1 */
+				*(uint8_t *)p32 = 1;
+			}
+
 			struct log_msg_desc desc = {
 				.level = level,
-				.package_len = plen32 * sizeof(uint32_t),
+				.package_len = sizeof(package),
 				.data_len = 0,
 			};
 
-			log_frontend_msg(source, desc, (uint8_t *)package, NULL);
+			log_frontend_msg(source, desc, package, NULL);
 		}
 	}
 
@@ -212,22 +237,32 @@ void z_impl_z_log_msg_simple_create_2(const void *source, uint32_t level,
 			uint32_t plen32 = CBPRINTF_DESC_SIZE32 + 3;
 			union cbprintf_package_hdr hdr = {
 				.desc = {
-					.len = plen32
+					.len = plen32,
+					.ro_str_cnt =
+					   IS_ENABLED(CONFIG_LOG_MSG_APPEND_RO_STRING_LOC) ? 1 : 0
 				}
 			};
-			uint32_t package[] = {
-				[0](uint32_t)(uintptr_t)hdr.raw,
-				(uint32_t)(uintptr_t)fmt,
-				arg0,
-				arg1
-			};
+			uint8_t package[sizeof(uint32_t) * (CBPRINTF_DESC_SIZE32 + 3) +
+				(IS_ENABLED(CONFIG_LOG_MSG_APPEND_RO_STRING_LOC) ? 1 : 0)]
+				__aligned(sizeof(uint32_t));
+			uint32_t *p32 = (uint32_t *)package;
+
+			*p32++ = (uint32_t)(uintptr_t)hdr.raw;
+			*p32++ = (uint32_t)(uintptr_t)fmt;
+			*p32++ = arg0;
+			*p32++ = arg1;
+			if (IS_ENABLED(CONFIG_LOG_MSG_APPEND_RO_STRING_LOC)) {
+				/* fmt string located at index 1 */
+				*(uint8_t *)p32 = 1;
+			}
+
 			struct log_msg_desc desc = {
 				.level = level,
-				.package_len = plen32 * sizeof(uint32_t),
+				.package_len = sizeof(package),
 				.data_len = 0,
 			};
 
-			log_frontend_msg(source, desc, (uint8_t *)package, NULL);
+			log_frontend_msg(source, desc, package, NULL);
 		}
 	}
 
@@ -258,6 +293,8 @@ void z_impl_z_log_msg_static_create(const void *source,
 
 	if (inlen > 0) {
 		uint32_t flags = CBPRINTF_PACKAGE_CONVERT_RW_STR |
+				 (IS_ENABLED(CONFIG_LOG_MSG_APPEND_RO_STRING_LOC) ?
+				 CBPRINTF_PACKAGE_CONVERT_KEEP_RO_STR : 0) |
 				 (IS_ENABLED(CONFIG_LOG_FMT_SECTION_STRIP) ?
 				 0 : CBPRINTF_PACKAGE_CONVERT_PTR_CHECK);
 		uint16_t strl[4];

--- a/tests/subsys/logging/log_api/Kconfig
+++ b/tests/subsys/logging/log_api/Kconfig
@@ -5,4 +5,8 @@ module = SAMPLE_MODULE
 module-str = Test logging API
 source "subsys/logging/Kconfig.template.log_config"
 
+config TEST_LOG_MSG_APPEND_RO_STRING_LOC
+	bool "Append read-only string locations to the package"
+	select LOG_MSG_APPEND_RO_STRING_LOC
+
 source "Kconfig.zephyr"

--- a/tests/subsys/logging/log_api/src/main.c
+++ b/tests/subsys/logging/log_api/src/main.c
@@ -27,11 +27,14 @@ LOG_MODULE_REGISTER(test, CONFIG_SAMPLE_MODULE_LOG_LEVEL);
 #define LOG_SIMPLE_MSG_LEN \
 	ROUND_UP(sizeof(struct log_msg) + \
 		 sizeof(struct cbprintf_package_hdr_ext) + \
-		 sizeof(int), CBPRINTF_PACKAGE_ALIGNMENT)
+		 sizeof(int) + (IS_ENABLED(CONFIG_LOG_MSG_APPEND_RO_STRING_LOC) ? 1 : 0), \
+		 CBPRINTF_PACKAGE_ALIGNMENT)
 #else
 #define LOG_SIMPLE_MSG_LEN \
 	ROUND_UP(sizeof(struct log_msg) + \
-		 sizeof(struct cbprintf_package_hdr_ext), CBPRINTF_PACKAGE_ALIGNMENT)
+		 sizeof(struct cbprintf_package_hdr_ext) + \
+		 (IS_ENABLED(CONFIG_LOG_MSG_APPEND_RO_STRING_LOC) ? 1 : 0), \
+		 CBPRINTF_PACKAGE_ALIGNMENT)
 #endif
 
 #ifdef CONFIG_LOG_TIMESTAMP_64BIT
@@ -365,6 +368,9 @@ static size_t get_long_hexdump(void)
 		 * as argument => 1 tag.
 		 */
 		extra_hexdump_sz = sizeof(int);
+	}
+	if (IS_ENABLED(CONFIG_TEST_LOG_MSG_APPEND_RO_STRING_LOC)) {
+		extra_msg_sz += sizeof(uint8_t); /* Location of format string. */
 	}
 
 	return CONFIG_LOG_BUFFER_SIZE -

--- a/tests/subsys/logging/log_api/src/mock_backend.c
+++ b/tests/subsys/logging/log_api/src/mock_backend.c
@@ -167,8 +167,10 @@ static void process(const struct log_backend *const backend,
 
 	size_t len;
 	uint8_t *data;
+	struct cbprintf_package_desc *package_desc;
 
 	data = log_msg_get_data(&msg->log, &len);
+
 	zassert_equal(exp->data_len, len);
 	if (exp->data_len <= sizeof(exp->data)) {
 		zassert_equal(memcmp(data, exp->data, len), 0);
@@ -178,6 +180,15 @@ static void process(const struct log_backend *const backend,
 	struct test_str s = { .str = str };
 
 	data = log_msg_get_package(&msg->log, &len);
+	package_desc = (struct cbprintf_package_desc *)data;
+
+	if (IS_ENABLED(CONFIG_LOG_MSG_APPEND_RO_STRING_LOC)) {
+		/* If RO string locations are appended there is always at least 1: format string. */
+		zassert_true(package_desc->ro_str_cnt > 0);
+	} else {
+		zassert_equal(package_desc->ro_str_cnt, 0);
+	}
+
 	len = cbpprintf(out, &s, data);
 	if (len > 0) {
 		str[len] = '\0';

--- a/tests/subsys/logging/log_api/src/mock_frontend.c
+++ b/tests/subsys/logging/log_api/src/mock_frontend.c
@@ -88,6 +88,7 @@ void log_frontend_msg(const void *source,
 		      uint8_t *package, const void *data)
 {
 	struct mock_log_backend_msg *exp_msg = &mock.exp_msgs[mock.msg_proc_idx];
+	struct cbprintf_package_desc *package_desc = (struct cbprintf_package_desc *)package;
 
 	if (mock.do_check == false) {
 		return;
@@ -97,6 +98,13 @@ void log_frontend_msg(const void *source,
 
 	if (!exp_msg->check) {
 		return;
+	}
+
+	if (IS_ENABLED(CONFIG_LOG_MSG_APPEND_RO_STRING_LOC)) {
+		/* If RO string locations are appended there is always at least 1: format string. */
+		zassert_true(package_desc->ro_str_cnt > 0);
+	} else {
+		zassert_equal(package_desc->ro_str_cnt, 0);
 	}
 
 	zassert_equal(desc.level, exp_msg->level);

--- a/tests/subsys/logging/log_api/testcase.yaml
+++ b/tests/subsys/logging/log_api/testcase.yaml
@@ -32,6 +32,7 @@ tests:
     extra_configs:
       - CONFIG_LOG_MODE_DEFERRED=y
       - CONFIG_SAMPLE_MODULE_LOG_LEVEL_DBG=y
+      - CONFIG_TEST_LOG_MSG_APPEND_RO_STRING_LOC=y
 
   logging.deferred.api.printk:
     extra_configs:
@@ -105,6 +106,7 @@ tests:
     extra_configs:
       - CONFIG_LOG_FRONTEND=y
       - CONFIG_LOG_MODE_DEFERRED=y
+      - CONFIG_TEST_LOG_MSG_APPEND_RO_STRING_LOC=y
 
   logging.frontend.rt_filtering:
     extra_configs:


### PR DESCRIPTION
There is an Kconfig option which results in RO string locations
being appended to the cbprintf package of a log message. Option was
not correctly handled, especially optimized API which was recently
added did not support that. Restoring support.
