### PR TITLE
ec_host_cmd: shi_ite: add missing include

### DIFF
--- a/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_shi_ite.c
+++ b/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_shi_ite.c
@@ -8,6 +8,7 @@
 
 #include "ec_host_cmd_backend_shi.h"
 
+#include <chip_chipregs.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/dt-bindings/gpio/ite-it8xxx2-gpio.h>


### PR DESCRIPTION
Add a missing include with ITE registers definitions.