### PR TITLE
hwmv2: boards: intel: adsp: Fix runner after paths renamed

### DIFF
--- a/scripts/west_commands/runners/intel_adsp.py
+++ b/scripts/west_commands/runners/intel_adsp.py
@@ -78,7 +78,7 @@ class IntelAdspBinaryRunner(ZephyrBinaryRunner):
     def do_run(self, command, **kwargs):
         self.logger.info('Starting Intel ADSP runner')
 
-        if re.search("intel_adsp", self.platform):
+        if re.search("adsp", self.platform):
             self.require(self.cavstool)
             self.flash(**kwargs)
         else:


### PR DESCRIPTION
Fix intel_adsp runner unable to find boards for flash after 'drop duplicate prefix' folder renames #69505