### PR TITLE
net: telnet: Switch TELNET shell backend to use sockets 

### DIFF
--- a/include/zephyr/shell/shell_telnet.h
+++ b/include/zephyr/shell/shell_telnet.h
@@ -17,6 +17,7 @@ extern "C" {
 extern const struct shell_transport_api shell_telnet_transport_api;
 
 #define SHELL_TELNET_POLLFD_COUNT 3
+#define SHELL_TELNET_MAX_CMD_SIZE 3
 
 /** Line buffer structure. */
 struct shell_telnet_line_buf {
@@ -49,6 +50,8 @@ struct shell_telnet {
 
 	/** Mutex protecting the input buffer access. */
 	struct k_mutex rx_lock;
+	uint8_t cmd_buf[SHELL_TELNET_MAX_CMD_SIZE];
+	uint8_t cmd_len;
 
 	/** The delayed work is used to send non-lf terminated output that has
 	 *  been around for "too long". This will prove to be useful

--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -43,6 +43,7 @@ config NET_SOCKETS_POSIX_NAMES
 config NET_SOCKETS_POLL_MAX
 	int "Max number of supported poll() entries"
 	default 6 if WIFI_NM_WPA_SUPPLICANT
+	default 4 if SHELL_BACKEND_TELNET
 	default 3
 	help
 	  Maximum number of entries supported for poll() call.

--- a/subsys/net/lib/sockets/sockets_service.c
+++ b/subsys/net/lib/sockets/sockets_service.c
@@ -21,8 +21,7 @@ STRUCT_SECTION_START_EXTERN(net_socket_service_desc);
 STRUCT_SECTION_END_EXTERN(net_socket_service_desc);
 
 static struct service {
-	/* The +1 is for triggering events from register function */
-	struct zsock_pollfd events[1 + CONFIG_NET_SOCKETS_POLL_MAX];
+	struct zsock_pollfd events[CONFIG_NET_SOCKETS_POLL_MAX];
 	int count;
 } ctx;
 

--- a/subsys/shell/backends/Kconfig.backends
+++ b/subsys/shell/backends/Kconfig.backends
@@ -358,10 +358,21 @@ config SHELL_BACKEND_TELNET
 	bool "TELNET backend."
 	depends on NET_TCP
 	depends on NET_IPV4 || NET_IPV6
+	select NET_SOCKETS_SERVICE
+	select NET_SOCKETS
 	help
 	  Enable TELNET backend.
 
 if SHELL_BACKEND_TELNET
+
+config SHELL_TELNET_INIT_PRIORITY
+	int "Initialization priority"
+	default 95
+	range NET_SOCKETS_SERVICE_INIT_PRIO 99
+	help
+	  Initialization priority for telnet shell backend. This must be higher
+	  than socket service initialization priority, as socket service has to
+	  be initialized earlier.
 
 config SHELL_PROMPT_TELNET
 	string "Displayed prompt name"

--- a/subsys/shell/backends/shell_telnet.c
+++ b/subsys/shell/backends/shell_telnet.c
@@ -111,14 +111,14 @@ static void telnet_reply_dont_command(struct telnet_simple_command *cmd)
 		int ret = telnet_echo_set(sh_telnet->shell_context, false);
 
 		if (ret >= 0) {
-			cmd->op = NVT_CMD_WONT;
+			cmd->op = NVT_CMD_WILL_NOT;
 		} else {
 			cmd->op = NVT_CMD_WILL;
 		}
 		break;
 	}
 	default:
-		cmd->op = NVT_CMD_WONT;
+		cmd->op = NVT_CMD_WILL_NOT;
 		break;
 	}
 
@@ -139,12 +139,12 @@ static void telnet_reply_do_command(struct telnet_simple_command *cmd)
 		if (ret >= 0) {
 			cmd->op = NVT_CMD_WILL;
 		} else {
-			cmd->op = NVT_CMD_WONT;
+			cmd->op = NVT_CMD_WILL_NOT;
 		}
 		break;
 	}
 	default:
-		cmd->op = NVT_CMD_WONT;
+		cmd->op = NVT_CMD_WILL_NOT;
 		break;
 	}
 
@@ -172,7 +172,7 @@ static void telnet_reply_command(struct telnet_simple_command *cmd)
 	case NVT_CMD_DO:
 		telnet_reply_do_command(cmd);
 		break;
-	case NVT_CMD_DONT:
+	case NVT_CMD_DO_NOT:
 		telnet_reply_dont_command(cmd);
 		break;
 	default:
@@ -238,8 +238,8 @@ static void telnet_send_prematurely(struct k_work *work)
 
 static int telnet_command_length(uint8_t op)
 {
-	if (op == NVT_CMD_SB || op == NVT_CMD_WILL || op == NVT_CMD_WONT ||
-	    op == NVT_CMD_DO || op == NVT_CMD_DONT) {
+	if (op == NVT_CMD_SB || op == NVT_CMD_WILL || op == NVT_CMD_WILL_NOT ||
+	    op == NVT_CMD_DO || op == NVT_CMD_DO_NOT) {
 		return TELNET_WILL_DO_COMMAND_LEN;
 	}
 

--- a/subsys/shell/backends/shell_telnet_protocol.h
+++ b/subsys/shell/backends/shell_telnet_protocol.h
@@ -43,9 +43,9 @@
 #define NVT_CMD_GA			249
 #define NVT_CMD_SB			250
 #define NVT_CMD_WILL			251
-#define NVT_CMD_WONT			252
+#define NVT_CMD_WILL_NOT		252
 #define NVT_CMD_DO			253
-#define NVT_CMD_DONT			254
+#define NVT_CMD_DO_NOT			254
 #define NVT_CMD_IAC			255
 
 /* Telnet options */


### PR DESCRIPTION
Rework TELNET shell backend to use socket API for communication and socket service library for socket monitoring.
Improve TELNET command parsing to make it more robust against possible stream fragmentation.