### PR TITLE
boards: Raspberry Pi pico pwm led adjustment

### DIFF
--- a/boards/raspberrypi/rpi_pico/rpi_pico.dts
+++ b/boards/raspberrypi/rpi_pico/rpi_pico.dts
@@ -8,6 +8,10 @@
 
 #include "rpi_pico-common.dtsi"
 
+/* Only the rpi_pico/rp2040 has a pwm. */
+/* This define can be used to avoid sourcing board overlays when the PWM is not available */
+#define HAS_DT_PWM_LED 1
+
 / {
 	leds {
 		compatible = "gpio-leds";

--- a/samples/basic/blinky_pwm/boards/rpi_pico.overlay
+++ b/samples/basic/blinky_pwm/boards/rpi_pico.overlay
@@ -1,3 +1,7 @@
+/* The rpi_pico/rp2040/w doesn't have a pwm. */
+/* Use the HAS_DT_PWM defined by the based board to identify when this overlay is valid */
+#if HAS_DT_PWM_LED
+
 &{/pwm_leds} {
 	status = "okay";
 };
@@ -11,3 +15,5 @@
 	divider-frac-4 = <15>;
 	divider-int-4 = <255>;
 };
+
+#endif

--- a/samples/basic/blinky_pwm/boards/rpi_pico.overlay
+++ b/samples/basic/blinky_pwm/boards/rpi_pico.overlay
@@ -1,3 +1,7 @@
+&{/pwm_leds} {
+	status = "okay";
+};
+
 &pwm_led0 {
 	status = "okay";
 };

--- a/samples/basic/blinky_pwm/sample.yaml
+++ b/samples/basic/blinky_pwm/sample.yaml
@@ -8,4 +8,3 @@ tests:
       - pwm
     depends_on: pwm
     harness: led
-    platform_exclude: rpi_pico/rp2040/w


### PR DESCRIPTION
The Raspberry Pi pico defines PWM leds, but on the Raspberry Pi pico
w-variant the gpio to the led is routed to the WiFi/Bluetooth module,
thus the led is not available.

Introduce a HAS_DT_PWM_LED define which allows devicetree overlays for
the rpi_pico board to distinguish between board variants with a pwm
controlled led, and those without.