### PR TITLE
include: string.h Add zephyr conformant string.h header

### DIFF
--- a/include/zephyr/string.h
+++ b/include/zephyr/string.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 Bjarki Arge Andreasen
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_STRING_H_
+#define ZEPHYR_INCLUDE_STRING_H_
+
+#include <zephyr/types.h>
+
+void    *memchr(const void *, int, size_t);
+int      memcmp(const void *, const void *, size_t);
+void    *memcpy(void *restrict, const void *restrict, size_t);
+void    *memmove(void *, const void *, size_t);
+void    *memset(void *, int, size_t);
+char    *strcat(char *restrict, const char *restrict);
+char    *strchr(const char *, int);
+int      strcmp(const char *, const char *);
+char    *strcpy(char *restrict, const char *restrict);
+size_t   strcspn(const char *, const char *);
+char    *strerror(int);
+size_t   strlen(const char *);
+char    *strncat(char *restrict, const char *restrict, size_t);
+int      strncmp(const char *, const char *, size_t);
+char    *strncpy(char *restrict, const char *restrict, size_t);
+size_t   strnlen(const char *, size_t);
+char    *strrchr(const char *, int);
+size_t   strspn(const char *, const char *);
+char    *strstr(const char *, const char *);
+
+#endif /* ZEPHYR_INCLUDE_STRING_H_ */


### PR DESCRIPTION
Add <zephyr/string.h> which only exposes the standard functions we allow as defined by [Rule-a-4-c](https://docs.zephyrproject.org/latest/contribute/coding_guidelines/index.html#rule-a-4-c-standard-library-usage-restrictions-in-zephyr-kernel)

zephyr kernel code should `#include <zephyr/string.h>` if they need to use all of the standard functions we allow in zephyr.

This allows us to cherry-pick the functions from POSIX we allow in zephyr kernel code.

With this header, we could (and maybe should?) be even more strict, only defining the functions we allow within the kernel as stated in  which means, no #include <string.h>, we will declare strlen() etc. ourselves :)

This inspiration for this solution can be found here [linux/string.h](https://github.com/torvalds/linux/blob/master/include/linux/string.h)
