### PR TITLE
kernel: Remove unused routines from ksched.h

### DIFF
--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -43,7 +43,6 @@ void z_unpend_thread_no_timeout(struct k_thread *thread);
 struct k_thread *z_unpend1_no_timeout(_wait_q_t *wait_q);
 int z_pend_curr(struct k_spinlock *lock, k_spinlock_key_t key,
 	       _wait_q_t *wait_q, k_timeout_t timeout);
-int z_pend_curr_irqlock(uint32_t key, _wait_q_t *wait_q, k_timeout_t timeout);
 void z_pend_thread(struct k_thread *thread, _wait_q_t *wait_q,
 		   k_timeout_t timeout);
 void z_reschedule(struct k_spinlock *lock, k_spinlock_key_t key);

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -901,30 +901,6 @@ void z_thread_timeout(struct _timeout *timeout)
 }
 #endif
 
-int z_pend_curr_irqlock(uint32_t key, _wait_q_t *wait_q, k_timeout_t timeout)
-{
-	/* This is a legacy API for pre-switch architectures and isn't
-	 * correctly synchronized for multi-cpu use
-	 */
-	__ASSERT_NO_MSG(!IS_ENABLED(CONFIG_SMP));
-
-	pend_locked(_current, wait_q, timeout);
-
-#if defined(CONFIG_TIMESLICING) && defined(CONFIG_SWAP_NONATOMIC)
-	pending_current = _current;
-
-	int ret = z_swap_irqlock(key);
-	K_SPINLOCK(&_sched_spinlock) {
-		if (pending_current == _current) {
-			pending_current = NULL;
-		}
-	}
-	return ret;
-#else
-	return z_swap_irqlock(key);
-#endif
-}
-
 int z_pend_curr(struct k_spinlock *lock, k_spinlock_key_t key,
 	       _wait_q_t *wait_q, k_timeout_t timeout)
 {

--- a/tests/benchmarks/sched/src/main.c
+++ b/tests/benchmarks/sched/src/main.c
@@ -13,14 +13,14 @@
  * of specific low level scheduling primitives independent of overhead
  * from application or API abstractions.  It works very simply: a main
  * thread creates a "partner" thread at a higher priority, the partner
- * then sleeps using z_pend_curr_irqlock().  From this initial
+ * then sleeps using z_pend_curr().  From this initial
  * state:
  *
  * 1. The main thread calls z_unpend_first_thread()
  * 2. The main thread calls z_ready_thread()
  * 3. The main thread calls k_yield()
  *    (the kernel switches to the partner thread)
- * 4. The partner thread then runs and calls z_pend_curr_irqlock() again
+ * 4. The partner thread then runs and calls z_pend_curr() again
  *    (the kernel switches to the main thread)
  * 5. The main thread returns from k_yield()
  *
@@ -48,6 +48,8 @@ enum {
 };
 
 uint32_t stamps[NUM_STAMP_STATES];
+
+static struct k_spinlock lock;
 
 static inline int _stamp(int state)
 {
@@ -79,9 +81,9 @@ static void partner_fn(void *arg1, void *arg2, void *arg3)
 	printk("Running %p\n", k_current_get());
 
 	while (true) {
-		unsigned int key = irq_lock();
+		k_spinlock_key_t  key = k_spin_lock(&lock);
 
-		z_pend_curr_irqlock(key, &waitq, K_FOREVER);
+		z_pend_curr(&lock, key, &waitq, K_FOREVER);
 		stamp(PARTNER_AWAKE_PENDING);
 	}
 }


### PR DESCRIPTION
Performs some clean up on kernel/include/ksched.h to remove routines that are no longer used.