### PR TITLE
drivers: spi: Add support for half-duplex (3-wire) SPI

### DIFF
--- a/dts/bindings/spi/raspberrypi,pico-spi-pio.yaml
+++ b/dts/bindings/spi/raspberrypi,pico-spi-pio.yaml
@@ -24,5 +24,12 @@ properties:
     description: |
       Input pin for Master In Slave Out.
 
+  sio-gpios:
+    type: phandle-array
+    description: |
+      Single I/O gpio info
+
+      GPIO input/output pin for 3-wire mode.
+
   clocks:
     required: true


### PR DESCRIPTION
Add support for half-duplex (3-wire) SPI operation using the Raspberry Pi Pico PIO.  To allow control of the size of the driver, including half-duplex support is optional, under the control of Kconfig options.

The original PIO source code is also included as a reference.