### PR TITLE
input: pat912x: add a bunch of settings

### DIFF
--- a/dts/bindings/input/pixart,pat912x.yaml
+++ b/dts/bindings/input/pixart,pat912x.yaml
@@ -25,3 +25,35 @@ properties:
     description: |
       The input code for the Y axis to report for the device, typically any of
       INPUT_REL_*. No report produced for the device Y axis if unspecified.
+
+  res-x-cpi:
+    type: int
+    description: |
+      CPI resolution for the X axis, range 0 to 1275, rounded down to the
+      closest supported value in increments of 5.
+
+  res-y-cpi:
+    type: int
+    description: |
+      CPI resolution for the Y axis, range 0 to 1275, rounded down to the
+      closest supported value in increments of 5.
+
+  invert-x:
+    type: boolean
+    description: |
+      Invert X axis values.
+
+  invert-y:
+    type: boolean
+    description: |
+      Invert Y axis values.
+
+  sleep1-enable:
+    type: boolean
+    description: |
+      Enable sleep1 mode.
+
+  sleep2-enable:
+    type: boolean
+    description: |
+      Enable sleep2 mode, only valid if sleep1 is also enabled.

--- a/include/zephyr/input/input_pat912x.h
+++ b/include/zephyr/input/input_pat912x.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_INPUT_PAT912X_H_
+#define ZEPHYR_INCLUDE_INPUT_PAT912X_H_
+
+/**
+ * @brief Set resolution on a pat912x device
+ *
+ * @param dev pat912x device.
+ * @param res_x_cpi CPI resolution for the X axis, 0 to 1275, -1 to keep the
+ * current value.
+ * @param res_y_cpi CPI resolution for the Y axis, 0 to 1275, -1 to keep the
+ * current value.
+ */
+int pat912x_set_resolution(const struct device *dev,
+			   int16_t res_x_cpi, int16_t res_y_cpi);
+
+#endif /* ZEPHYR_INCLUDE_INPUT_PAT912X_H_ */

--- a/tests/drivers/build_all/input/app.overlay
+++ b/tests/drivers/build_all/input/app.overlay
@@ -204,6 +204,12 @@
 				motion-gpios = <&test_gpio 0 0>;
 				zephyr,axis-x = <0>;
 				zephyr,axis-y = <1>;
+				res-x-cpi = <0>;
+				res-y-cpi = <0>;
+				invert-x;
+				invert-y;
+				sleep1-enable;
+				sleep2-enable;
 			};
 		};
 


### PR DESCRIPTION
Second and last round for this interesting device, adds support for axis inversion, resolution settings at init and runtime and sleep mode.

Oddly enough, according to the datasheet some of these registers should be write protected and need another register to be unlocked, but my device does not seem to be bothered, not too sure why but I think it's fine to leave it as is for the moment and keep the code a bit simpler.

---

Add devicetree based settings for resolution, axis inversion and sleep mode enable. Keep the resolution setting in its own function so it can be called by the application again in runtime if needed.