### PR TITLE
 [Backport v2.7-branch] backport #65546: userspace: Additional checks in K_SYSCALL_MEMORY

### DIFF
--- a/include/sys/util.h
+++ b/include/sys/util.h
@@ -25,6 +25,7 @@
 
 #include <zephyr/types.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -60,6 +61,23 @@ extern "C" {
 
 /** @brief 0 if @p cond is true-ish; causes a compile error otherwise. */
 #define ZERO_OR_COMPILE_ERROR(cond) ((int) sizeof(char[1 - 2 * !(cond)]) - 1)
+
+/**
+ * @brief Determine if a buffer exceeds highest address
+ *
+ * This macro determines if a buffer identified by a starting address @a addr
+ * and length @a buflen spans a region of memory that goes beond the highest
+ * possible address (thereby resulting in a pointer overflow).
+ *
+ * @param addr Buffer starting address
+ * @param buflen Length of the buffer
+ *
+ * @return true if pointer overflow detected, false otherwise
+ */
+#define Z_DETECT_POINTER_OVERFLOW(addr, buflen)  \
+	(((buflen) != 0) &&                        \
+	((UINTPTR_MAX - (uintptr_t)(addr)) <= ((uintptr_t)((buflen) - 1))))
+
 
 #if defined(__cplusplus)
 

--- a/include/syscall_handler.h
+++ b/include/syscall_handler.h
@@ -330,6 +330,22 @@ extern int z_user_string_copy(char *dst, const char *src, size_t maxlen);
 #define Z_SYSCALL_VERIFY(expr) Z_SYSCALL_VERIFY_MSG(expr, #expr)
 
 /**
+ * @brief Macro to check if size is negative
+ *
+ * Z_SYSCALL_MEMORY can be called with signed/unsigned types
+ * and because of that if we check if size is greater or equal to
+ * zero, many static analyzers complain about no effect expression.
+ *
+ * @param ptr Memory area to examine
+ * @param size Size of the memory area
+ * @return true if size is valid, false otherwise
+ * @note This is an internal API. Do not use unless you are extending
+ *       functionality in the Zephyr tree.
+ */
+#define Z_SYSCALL_MEMORY_SIZE_CHECK(ptr, size) \
+	(((uintptr_t)ptr + size) >= (uintptr_t)ptr)
+
+/**
  * @brief Runtime check that a user thread has read and/or write permission to
  *        a memory area
  *
@@ -346,7 +362,8 @@ extern int z_user_string_copy(char *dst, const char *src, size_t maxlen);
  * @return 0 on success, nonzero on failure
  */
 #define Z_SYSCALL_MEMORY(ptr, size, write) \
-	Z_SYSCALL_VERIFY_MSG((size >= 0) && !Z_DETECT_POINTER_OVERFLOW(ptr, size) \
+	Z_SYSCALL_VERIFY_MSG(Z_SYSCALL_MEMORY_SIZE_CHECK(ptr, size) \
+			     && !Z_DETECT_POINTER_OVERFLOW(ptr, size) \
 			     && (arch_buffer_validate((void *)ptr, size, write) \
 			     == 0), \
 			     "Memory region %p (size %zu) %s access denied", \

--- a/include/syscall_handler.h
+++ b/include/syscall_handler.h
@@ -346,8 +346,9 @@ extern int z_user_string_copy(char *dst, const char *src, size_t maxlen);
  * @return 0 on success, nonzero on failure
  */
 #define Z_SYSCALL_MEMORY(ptr, size, write) \
-	Z_SYSCALL_VERIFY_MSG(arch_buffer_validate((void *)ptr, size, write) \
-			     == 0, \
+	Z_SYSCALL_VERIFY_MSG((size >= 0) && !Z_DETECT_POINTER_OVERFLOW(ptr, size) \
+			     && (arch_buffer_validate((void *)ptr, size, write) \
+			     == 0), \
 			     "Memory region %p (size %zu) %s access denied", \
 			     (void *)(ptr), (size_t)(size), \
 			     write ? "write" : "read")


### PR DESCRIPTION
Backport of #65546 for `v2.7-branch`.

Fixes #66775 