### PR TITLE
os: implement k_strnlen

### DIFF
--- a/include/zephyr/internal/syscall_handler.h
+++ b/include/zephyr/internal/syscall_handler.h
@@ -219,7 +219,7 @@ void k_object_recycle(const void *obj);
  *
  * Given a C string pointer and a maximum size, obtain the true
  * size of the string (not including the trailing NULL byte) just as
- * if calling strnlen() on it, with the same semantics of strnlen() with
+ * if calling k_strnlen() on it, with the same semantics of k_strnlen() with
  * respect to the return value and the maxlen parameter.
  *
  * Any memory protection faults triggered by the examination of the string

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -6099,6 +6099,26 @@ void k_sys_runtime_stats_enable(void);
  */
 void k_sys_runtime_stats_disable(void);
 
+/**
+ * @brief Compute the length of a string
+ *
+ * Compute the length of string @p s not including the terminating '\0'
+ * character. If the '\0' character is not present in the first @p maxlen
+ * characters of @p s, then return @p maxlen.
+ *
+ * @param s String to compute the length for.
+ * @param maxlen Maximum string length.
+ * @return the length of @p s
+ */
+size_t k_strnlen(const char *s, size_t maxlen);
+
+#ifdef CONFIG_DEFINE_STRNLEN_VIA_K_STRNLEN
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE < 200809L
+#undef strnlen
+#define strnlen(_s, _maxlen) k_strnlen(_s, _maxlen)
+#endif
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/sys/arch_interface.h
+++ b/include/zephyr/sys/arch_interface.h
@@ -843,7 +843,7 @@ FUNC_NORETURN void arch_syscall_oops(void *ssf);
  * @brief Safely take the length of a potentially bad string
  *
  * This must not fault, instead the @p err parameter must have -1 written to it.
- * This function otherwise should work exactly like libc strnlen(). On success
+ * This function otherwise should work exactly like libc k_strnlen(). On success
  * @p err should be set to 0.
  *
  * @param s String to measure

--- a/lib/libc/armstdc/include/string.h
+++ b/lib/libc/armstdc/include/string.h
@@ -16,7 +16,9 @@
 extern "C" {
 #endif
 
+#if _POSIX_C_SOURCE >= 200809L
 extern size_t strnlen(const char *s, size_t maxlen);
+#endif
 
 #ifdef __cplusplus
 }

--- a/lib/libc/common/source/string/strnlen.c
+++ b/lib/libc/common/source/string/strnlen.c
@@ -1,31 +1,15 @@
 /*
- * Copyright (c) 2014 Wind River Systems, Inc.
- * Copyright (c) 2021 Nordic Semiconductor ASA
+ * Copyright (c) 2024 Meta
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stddef.h>
 #include <string.h>
-#include <stdint.h>
-#include <sys/types.h>
 
-/**
- *
- * @brief Get fixed-size string length
- *
- *        This function is not available in ARM C Standard library.
- *
- * @return number of bytes in fixed-size string <s>
- */
+extern size_t k_strnlen(const char *s, size_t maxlen);
 
 size_t strnlen(const char *s, size_t maxlen)
 {
-	size_t n = 0;
-
-	while (*s != '\0' && n < maxlen) {
-		s++;
-		n++;
-	}
-
-	return n;
+	return k_strnlen(s, maxlen);
 }

--- a/lib/libc/minimal/include/string.h
+++ b/lib/libc/minimal/include/string.h
@@ -24,7 +24,9 @@ extern char  *strncpy(char *ZRESTRICT d, const char *ZRESTRICT s,
 extern char  *strchr(const char *s, int c);
 extern char  *strrchr(const char *s, int c);
 extern size_t strlen(const char *s);
+#if _POSIX_C_SOURCE >= 200809L
 extern size_t strnlen(const char *s, size_t maxlen);
+#endif
 extern int    strcmp(const char *s1, const char *s2);
 extern int    strncmp(const char *s1, const char *s2, size_t n);
 extern char  *strtok_r(char *str, const char *sep, char **state);

--- a/lib/libc/newlib/include/string.h
+++ b/lib/libc/newlib/include/string.h
@@ -20,14 +20,11 @@ extern "C" {
 #endif
 
 /*
- * Define these two Zephyr APIs when _POSIX_C_SOURCE is not set to expose
- * them from newlib
+ * Define this Zephyr API when _POSIX_C_SOURCE is not set to expose
+ * it from newlib
  */
 #if !__MISC_VISIBLE && !__POSIX_VISIBLE
 char *strtok_r(char *__restrict, const char *__restrict, char **__restrict);
-#endif
-#if __POSIX_VISIBLE < 200809L
-size_t strnlen(const char *, size_t);
 #endif
 
 #ifdef __cplusplus

--- a/lib/os/CMakeLists.txt
+++ b/lib/os/CMakeLists.txt
@@ -6,6 +6,7 @@ zephyr_syscall_header(
 
 zephyr_sources(
   cbprintf_packaged.c
+  k_strnlen.c
   printk.c
   sem.c
   thread_entry.c

--- a/lib/os/Kconfig
+++ b/lib/os/Kconfig
@@ -113,6 +113,13 @@ config POWEROFF
 	help
 	  Enable support for system power off.
 
+config DEFINE_STRNLEN_VIA_K_STRNLEN
+	bool "Define strnlen in terms of k_strnlen"
+	default y
+	help
+	  This option is here to assist in transitioning from strnlen() to
+	  k_strnlen().
+
 rsource "Kconfig.cbprintf"
 
 endmenu

--- a/lib/os/k_strnlen.c
+++ b/lib/os/k_strnlen.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2024, Meta
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define __STDC_WANT_LIB_EXT1__ 1
+
+#include <stddef.h>
+#include <string.h>
+
+#include <zephyr/kernel.h>
+
+size_t k_strnlen(const char *s, size_t maxlen)
+{
+#ifdef __STDC_LIB_EXT1__
+	return strnlen_s(s, maxlen);
+#else
+	size_t len = 0;
+
+	for (; len < maxlen && *s != '\0'; s++, len++) {
+	}
+
+	return len;
+#endif
+}

--- a/subsys/ipc/ipc_service/backends/ipc_icbmsg.c
+++ b/subsys/ipc/ipc_service/backends/ipc_icbmsg.c
@@ -572,7 +572,7 @@ static int find_ept_by_name(struct backend_data *dev_data, const char *name)
 	 * can be corrupted. Extra care must be taken to avoid out of
 	 * bounds reads.
 	 */
-	name_size = strnlen(name, buffer_end - name - 1) + 1;
+	name_size = k_strnlen(name, buffer_end - name - 1) + 1;
 
 	for (i = 0; i < NUM_EPT; i++) {
 		ept = &dev_data->ept[i];

--- a/subsys/llext/shell.c
+++ b/subsys/llext/shell.c
@@ -121,7 +121,7 @@ static uint8_t llext_buf[CONFIG_LLEXT_SHELL_MAX_SIZE];
 static int cmd_llext_load_hex(const struct shell *sh, size_t argc, char *argv[])
 {
 	char name[16];
-	size_t hex_len = strnlen(argv[2], CONFIG_LLEXT_SHELL_MAX_SIZE*2+1);
+	size_t hex_len = k_strnlen(argv[2], CONFIG_LLEXT_SHELL_MAX_SIZE*2+1);
 	size_t bin_len = hex_len/2;
 
 	if (bin_len > CONFIG_LLEXT_SHELL_MAX_SIZE) {

--- a/tests/benchmarks/footprints/src/libc.c
+++ b/tests/benchmarks/footprints/src/libc.c
@@ -20,7 +20,7 @@ void run_libc(void)
 	int len;
 
 	len = strlen(const_string);
-	len = strnlen(const_string, len);
+	len = k_strnlen(const_string, len);
 
 	memset(new_string, 0, sizeof(new_string));
 	if (memcmp(const_string, new_string, 0) != 0) {

--- a/tests/bluetooth/uuid/src/test_bt_uuid_to_str.c
+++ b/tests/bluetooth/uuid/src/test_bt_uuid_to_str.c
@@ -8,6 +8,7 @@
 #include <stdbool.h>
 #include <string.h>
 
+#include <zephyr/kernel.h>
 #include <zephyr/ztest.h>
 
 #include <zephyr/bluetooth/uuid.h>
@@ -16,7 +17,7 @@ ZTEST_SUITE(bt_uuid_to_str, NULL, NULL, NULL, NULL, NULL);
 
 static bool is_null_terminated(char *str, size_t size)
 {
-	return strnlen(str, size) < size;
+	return k_strnlen(str, size) < size;
 }
 
 static void result_is_null_terminated(const struct bt_uuid *uuid)

--- a/tests/kernel/common/CMakeLists.txt
+++ b/tests/kernel/common/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(app PRIVATE
 	src/bitarray.c
 	src/byteorder.c
 	src/clock.c
+	src/k_strnlen.c
 	src/main.c
 	src/timeout_order.c
 	src/multilib.c

--- a/tests/kernel/common/src/k_strnlen.c
+++ b/tests/kernel/common/src/k_strnlen.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2017 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+
+ZTEST(k_strnlen, test_k_strnlen)
+{
+#define BUFSIZE 10
+
+	char buffer[BUFSIZE];
+
+	(void)memset(buffer, '\0', BUFSIZE);
+	(void)memset(buffer, 'b', 5); /* 5 is BUFSIZE / 2 */
+
+	zassert_equal(k_strnlen(buffer, BUFSIZE / 3), BUFSIZE / 3, "k_strnlen failed");
+	zassert_equal(k_strnlen(buffer, BUFSIZE), BUFSIZE / 2, "k_strnlen failed");
+}
+
+ZTEST_SUITE(k_strnlen, NULL, NULL, NULL, NULL, NULL);

--- a/tests/lib/c_lib/common/src/main.c
+++ b/tests/lib/c_lib/common/src/main.c
@@ -204,7 +204,7 @@ ZTEST(libc_common, test_memset)
  *
  * @brief Test string length function
  *
- * @see strlen(), strnlen().
+ * @see strlen().
  *
  */
 ZTEST(libc_common, test_strlen)
@@ -212,9 +212,6 @@ ZTEST(libc_common, test_strlen)
 	(void)memset(buffer, '\0', BUFSIZE);
 	(void)memset(buffer, 'b', 5); /* 5 is BUFSIZE / 2 */
 	zassert_equal(strlen(buffer), 5, "strlen failed");
-
-	zassert_equal(strnlen(buffer, 3), 3, "strnlen failed");
-	zassert_equal(strnlen(buffer, BUFSIZE), 5, "strnlen failed");
 }
 
 /**


### PR DESCRIPTION
The function `k_strnlen()` is added to mitigate interface-level dependency cycles (layering violations) between the HAL, BSP, service, kernel, and POSIX layers.