### PR TITLE
spi_nor: remove unneeded enter_dpd() at end of spi_nor_configure()

### DIFF
--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -1344,11 +1344,6 @@ static int spi_nor_configure(const struct device *dev)
 	(void) mxicy_configure(dev, jedec_id);
 #endif /* DT_INST_NODE_HAS_PROP(0, mxicy_mx25r_power_mode) */
 
-	if (IS_ENABLED(CONFIG_SPI_NOR_IDLE_IN_DPD)
-	    && (enter_dpd(dev) != 0)) {
-		return -ENODEV;
-	}
-
 	return 0;
 }
 


### PR DESCRIPTION
This block of code was in the original commit that added CONFIG_SPI_NOR_IDLE_IN_DPD but later modifications added acquire_device() and release_device() calls
earlier in spi_nor_configure() and the release_device() function will have already done the enter_dpd().