### PR TITLE
Bluetooth: RFCOMM: Add data sent cb for RFCOMM

### DIFF
--- a/include/zephyr/bluetooth/classic/rfcomm.h
+++ b/include/zephyr/bluetooth/classic/rfcomm.h
@@ -62,6 +62,14 @@ struct bt_rfcomm_dlc_ops {
 	 *  @param buf Buffer containing incoming data.
 	 */
 	void (*recv)(struct bt_rfcomm_dlc *dlc, struct net_buf *buf);
+
+	/** DLC sent callback
+	 *
+	 *  @param dlc The dlc which has sent data.
+	 *  @param buf Buffer containing data has been sent.
+	 *  @param err Sent result.
+	 */
+	void (*sent)(struct bt_rfcomm_dlc *dlc, struct net_buf *buf, int err);
 };
 
 /** @brief Role of RFCOMM session and dlc. Used only by internal APIs

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -1061,6 +1061,15 @@ config BT_RFCOMM_L2CAP_MTU
 	help
 	  Maximum size of L2CAP PDU for RFCOMM frames.
 
+config BT_RFCOMM_TX_MAX
+	int "Maximum number of pending TX buffers for RFCOMM"
+	default BT_MAX_CONN
+	range BT_MAX_CONN 255
+	help
+	  Maximum number of pending TX buffers that have an associated
+	  sending buf. Normally this can be left to the default value, which
+	  is equal to the number of session in the stack-internal pool.
+
 config BT_HFP_HF
 	bool "Bluetooth Handsfree profile HF Role support [EXPERIMENTAL]"
 	depends on PRINTK

--- a/subsys/bluetooth/host/classic/hfp_hf.c
+++ b/subsys/bluetooth/host/classic/hfp_hf.c
@@ -94,6 +94,8 @@ int hfp_hf_send_cmd(struct bt_hfp_hf *hf, at_resp_cb_t resp,
 	net_buf_add(buf, ret);
 	net_buf_add_u8(buf, '\r');
 
+	LOG_DBG("HF %p, DLC %p sending buf %p", hf, &hf->rfcomm_dlc, buf);
+
 	ret = bt_rfcomm_dlc_send(&hf->rfcomm_dlc, buf);
 	if (ret < 0) {
 		LOG_ERR("Rfcomm send error :(%d)", ret);
@@ -640,6 +642,11 @@ static void hfp_hf_recv(struct bt_rfcomm_dlc *dlc, struct net_buf *buf)
 	}
 }
 
+static void hfp_hf_sent(struct bt_rfcomm_dlc *dlc, struct net_buf *buf, int err)
+{
+	LOG_DBG("DLC %p sent cb buf %p (err %d)", dlc, buf, err);
+}
+
 static int bt_hfp_hf_accept(struct bt_conn *conn, struct bt_rfcomm_dlc **dlc)
 {
 	int i;
@@ -647,6 +654,7 @@ static int bt_hfp_hf_accept(struct bt_conn *conn, struct bt_rfcomm_dlc **dlc)
 		.connected = hfp_hf_connected,
 		.disconnected = hfp_hf_disconnected,
 		.recv = hfp_hf_recv,
+		.sent = hfp_hf_sent,
 	};
 
 	LOG_DBG("conn %p", conn);


### PR DESCRIPTION
Currently, the upper layer cannot know whether the data is successfully sent through DLC.

Add a field "sent" for RFCOMM DLC ops. Notify upper-layer of the sending result through the field "sent".
