### PR TITLE
drivers: gpio: dw: Switch to `DT_INST_IRQN_BY_IDX`

### DIFF
--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -384,6 +384,7 @@ static inline int gpio_dw_manage_callback(const struct device *port,
 	return gpio_manage_callback(&context->callbacks, callback, set);
 }
 
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(interrupts)
 static void gpio_dw_isr(const struct device *port)
 {
 	struct gpio_dw_runtime *context = port->data;
@@ -396,6 +397,7 @@ static void gpio_dw_isr(const struct device *port)
 
 	gpio_fire_callbacks(&context->callbacks, port, int_status);
 }
+#endif /* DT_ANY_INST_HAS_PROP_STATUS_OKAY(interrupts) */
 
 static const struct gpio_driver_api api_funcs = {
 	.pin_configure = gpio_dw_config,

--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -437,10 +437,10 @@ static int gpio_dw_initialize(const struct device *port)
 	COND_CODE_1(DT_INST_IRQ_HAS_CELL(n, flags), (DT_INST_IRQ(n, flags)), (0))
 
 #define GPIO_CFG_IRQ(idx, n)									\
-		IRQ_CONNECT(DT_INST_IRQ_BY_IDX(n, idx, irq),					\
+		IRQ_CONNECT(DT_INST_IRQN_BY_IDX(n, idx),					\
 			    DT_INST_IRQ(n, priority), gpio_dw_isr,				\
 			    DEVICE_DT_INST_GET(n), INST_IRQ_FLAGS(n));				\
-		irq_enable(DT_INST_IRQ_BY_IDX(n, idx, irq));					\
+		irq_enable(DT_INST_IRQN_BY_IDX(n, idx));					\
 
 #define GPIO_DW_INIT(n)										\
 	static void gpio_config_##n##_irq(const struct device *port)				\

--- a/tests/drivers/build_all/gpio/app.overlay
+++ b/tests/drivers/build_all/gpio/app.overlay
@@ -23,6 +23,14 @@
 			status = "okay";
 		};
 
+		test_gpio_dw: gpio@c0ffee {
+			compatible = "snps,designware-gpio";
+			gpio-controller;
+			reg = <0xc0ffee 0x1000>;
+			#gpio-cells = <0x2>;
+			status = "okay";
+		};
+
 		test_i2c: i2c@11112222 {
 			#address-cells = <1>;
 			#size-cells = <0>;


### PR DESCRIPTION
As described in `doc/kernel/services/interrupts.rst`, multi-level interrupts are recorded in the ISR table using a value that is shifted (encoded) based on the level. The values passed to `IRQ_CONNECT` and `irq_enable`/`irq_disable` are also these encoded values, which are later used to extract the irq level and route these calls to the corresponding level of interrupt controller.

In previous versions, `gen_defines.py` implemented the corresponding encoding process, so the irq number we got through `DT_IRQ(node, irq)` was the encoded value. However, starting from #63289, this process has been moved to a C macro. As a result, we need to use `DT_IRQN(node)` to get the encoded value, instead of getting the as-seen irq cell value through `DT_IRQ(node, irq)`.

This PR updates `gpio-dw` to align with the mentioned changes. Thus, in SoCs where `gpio-dw` is connected to a secondary intc, the GPIO controller can be correctly connected to the ISR table via `IRQ_CONNECT`, and `irq_enable` can be routed to the correct intc instance.