### PR TITLE
doc: fix broken Sphinx by updating to Sphinx 5.0.2

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -253,8 +253,8 @@ graphviz_dot_args = [
 # -- Linkcheck options ----------------------------------------------------
 
 extlinks = {
-    "jira": ("https://jira.zephyrproject.org/browse/%s", ""),
-    "github": ("https://github.com/zephyrproject-rtos/zephyr/issues/%s", ""),
+    "jira": ("https://jira.zephyrproject.org/browse/%s", "JIRA %s"),
+    "github": ("https://github.com/zephyrproject-rtos/zephyr/issues/%s", "GitHub #%s"),
 }
 
 linkcheck_timeout = 30

--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -1,7 +1,7 @@
 # DOC: used to generate docs
 
 breathe>=4.30
-sphinx~=4.0
+sphinx~=5.0.2
 sphinx_rtd_theme~=1.0
 sphinx-tabs
 sphinxcontrib-svg2pdfconverter


### PR DESCRIPTION
Sphinx 4.x is way past EOL and due to it not pinning its dependencies, it's effectively broken.
See https://github.com/sphinx-doc/sphinx/issues/11890
The recommended fix, although not ideal in the context of an LTS branch, is to update to Sphinx 5.0.2, which should have minimal impact of how the rendered documentation looks.

Fixes #69656.