### PR TITLE
drivers: nxp_s32_canxl: use RTD API instead the current implementation for can_nxp_s32_abort_msg() API

### DIFF
--- a/drivers/can/can_nxp_s32_canxl.c
+++ b/drivers/can/can_nxp_s32_canxl.c
@@ -82,8 +82,6 @@ LOG_MODULE_REGISTER(nxp_s32_canxl, CONFIG_CAN_LOG_LEVEL);
 struct can_nxp_s32_config {
 	const struct can_driver_config common;
 	CANXL_SIC_Type *base_sic;
-	CANXL_GRP_CONTROL_Type *base_grp_ctrl;
-	CANXL_DSC_CONTROL_Type *base_dsc_ctrl;
 #ifdef CONFIG_CAN_NXP_S32_RX_FIFO
 	CANXL_RXFIFO_Type * base_rx_fifo;
 	CANXL_RXFIFO_CONTROL_Type *base_rx_fifo_ctrl;
@@ -230,35 +228,6 @@ static int can_nxp_s32_start(const struct device *dev)
 	return 0;
 }
 
-static int can_nxp_s32_abort_msg(const struct can_nxp_s32_config *config, int mb_idx)
-{
-	uint32_t time_start = 0;
-	int ret = 0;
-
-	Canexcel_Ip_EnterFreezeMode(config->instance);
-
-	CanXL_ClearMsgBuffIntCmd(config->base_grp_ctrl, mb_idx);
-	CanXL_ClearMsgDescIntStatusFlag(config->base_grp_ctrl, mb_idx);
-
-	time_start = k_uptime_get();
-	/* Set system lock Status */
-	(void)config->base_dsc_ctrl->DSCMBCTRLAR[mb_idx].SYSLOCK.DCSYSLOCK;
-	while (CanXL_GetDescControlStatus(config->base_dsc_ctrl, mb_idx)
-			== CANEXCEL_DESCNTSTATUS_LOCKED_HW) {
-		if (k_uptime_get() - time_start >= CAN_NXP_S32_TIMEOUT_MS) {
-			ret = CANEXCEL_STATUS_TIMEOUT;
-			break;
-		}
-	}
-
-	/* Inactive descriptor */
-	config->base_dsc_ctrl->DSCMBCTRLAR[mb_idx].ACT.DCACT = 0;
-
-	Canexcel_Ip_ExitFreezeMode(config->instance);
-
-	return ret;
-}
-
 static int can_nxp_s32_stop(const struct device *dev)
 {
 	const struct can_nxp_s32_config *config = dev->config;
@@ -280,7 +249,7 @@ static int can_nxp_s32_stop(const struct device *dev)
 		arg = data->tx_cbs[alloc].arg;
 
 		if (atomic_test_and_clear_bit(data->tx_allocs, alloc)) {
-			if (can_nxp_s32_abort_msg(config,
+			if (Canexcel_Ip_DeactivateMD(config->instance,
 					ALLOC_IDX_TO_TXMB_IDX(alloc))) {
 				LOG_ERR("Can't abort message !");
 			};
@@ -474,7 +443,7 @@ static void can_nxp_s32_remove_rx_filter(const struct device *dev, int filter_id
 
 		Canexcel_Ip_ExitFreezeMode(config->instance);
 #else
-		if (can_nxp_s32_abort_msg(config, mb_indx)) {
+		if (Canexcel_Ip_DeactivateMD(config->instance, mb_indx)) {
 			LOG_ERR("Can't abort message !");
 		};
 #endif
@@ -803,7 +772,7 @@ static void can_nxp_s32_err_callback(const struct device *dev,
 			arg = data->tx_cbs[alloc].arg;
 
 			if (atomic_test_and_clear_bit(data->tx_allocs, alloc)) {
-				if (can_nxp_s32_abort_msg(config,
+				if (Canexcel_Ip_DeactivateMD(config->instance,
 						ALLOC_IDX_TO_TXMB_IDX(alloc))) {
 					LOG_ERR("Can't abort message !");
 				};
@@ -1221,10 +1190,6 @@ static const struct can_driver_api can_nxp_s32_driver_api = {
 	static struct can_nxp_s32_config can_nxp_s32_config_##n = {			\
 		.common = CAN_DT_DRIVER_CONFIG_INST_GET(n, CAN_NXP_S32_MAX_BITRATE),	\
 		.base_sic = (CANXL_SIC_Type *)DT_INST_REG_ADDR_BY_NAME(n, sic),		\
-		.base_grp_ctrl = (CANXL_GRP_CONTROL_Type *)				\
-				DT_INST_REG_ADDR_BY_NAME(n, grp_ctrl),			\
-		.base_dsc_ctrl = (CANXL_DSC_CONTROL_Type *)				\
-				DT_INST_REG_ADDR_BY_NAME(n, dsc_ctrl),			\
 		IF_ENABLED(CONFIG_CAN_NXP_S32_RX_FIFO,					\
 			(.base_rx_fifo = (CANXL_RXFIFO_Type *)				\
 				DT_INST_REG_ADDR_BY_NAME(n, rx_fifo),			\

--- a/dts/arm/nxp/nxp_s32z27x_r52.dtsi
+++ b/dts/arm/nxp/nxp_s32z27x_r52.dtsi
@@ -694,11 +694,9 @@
 		can0: can@4741b000 {
 			compatible = "nxp,s32-canxl";
 			reg = <0x4741b000 0x1000>,
-				<0x47426000 0x1000>,
-				<0x47424000 0x1000>,
 				<0x47423000 0x1000>,
 				<0x47425000 0x1000>;
-			reg-names = "sic", "grp_ctrl", "dsc_ctrl", "rx_fifo", "rx_fifo_ctrl";
+			reg-names = "sic", "rx_fifo", "rx_fifo_ctrl";
 			status = "disabled";
 			interrupts = <GIC_SPI 224 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 					<GIC_SPI 225 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
@@ -709,11 +707,9 @@
 		can1: can@4751b000 {
 			compatible = "nxp,s32-canxl";
 			reg = <0x4751b000 0x1000>,
-				<0x47526000 0x1000>,
-				<0x47524000 0x1000>,
 				<0x47523000 0x1000>,
 				<0x47525000 0x1000>;
-			reg-names = "sic", "grp_ctrl", "dsc_ctrl", "rx_fifo", "rx_fifo_ctrl";
+			reg-names = "sic", "rx_fifo", "rx_fifo_ctrl";
 			status = "disabled";
 			interrupts = <GIC_SPI 226 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 					<GIC_SPI 227 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;


### PR DESCRIPTION
On HAL RTD version 1.0.0, there is available Canexcel_Ip_DeactivateMD() API that have similar capabilities as can_nxp_s32_abort_msg() API, can use to instead.
Remove the reg grp_ctrl and reg base_dsc_ctrl that unused after implementation.

```
python3 scripts/twister -p s32z270dc2_rtu0_r52 --device-testing --device-serial=/dev/s32z270dc2 -v --west-runner trace32 --west-flash="--config=./config.t32" -T tests/drivers/can -T tests/net/socket/can -T samples/drivers/can -T samples/net/socket/can

INFO    - Using Ninja..
INFO    - Zephyr version: 294118b55c4f
INFO    - Using 'zephyr' toolchain.
INFO    - Building initial testsuite list...

Device testing on:

| Platform            | ID   | Serial device   |
|---------------------|------|-----------------|
| s32z270dc2_rtu0_r52 |      | /dev/s32z270dc2 |

INFO    - JOBS: 4
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - 2/9 s32z270dc2_rtu0_r52       samples/drivers/can/babbling/sample.drivers.can.babbling PASSED (device 9.614s)
INFO    - 3/9 s32z270dc2_rtu0_r52       samples/drivers/can/counter/sample.drivers.can.counter PASSED (device 9.643s)
INFO    - 4/9 s32z270dc2_rtu0_r52       tests/net/socket/can/net.socket.can                PASSED (device 9.769s)
INFO    - 5/9 s32z270dc2_rtu0_r52       tests/drivers/can/shell/drivers.can.shell          PASSED (device 9.888s)
INFO    - 6/9 s32z270dc2_rtu0_r52       tests/drivers/can/timing/drivers.can.timing        PASSED (device 9.724s)
INFO    - 7/9 s32z270dc2_rtu0_r52       tests/drivers/can/api/drivers.can.api.nxp_s32_canxl.non_rx_fifo PASSED (device 9.662s)
INFO    - 8/9 s32z270dc2_rtu0_r52       tests/drivers/can/api/drivers.can.api.rtr          PASSED (device 9.384s)
INFO    - 9/9 s32z270dc2_rtu0_r52       tests/drivers/can/api/drivers.can.api              PASSED (device 9.997s)

INFO    - 9 test scenarios (9 test instances) selected, 1 configurations skipped (1 by static filter, 0 at runtime).
INFO    - 8 of 9 test configurations passed (100.00%), 0 failed, 0 errored, 1 skipped with 0 warnings in 193.59 seconds
INFO    - In total 174 test cases were executed, 71 skipped on 1 out of total 682 platforms (0.15%)
INFO    - 8 test configurations executed on platforms, 0 test configurations were only built.
```
