### PR TITLE
twister: add unit_testing soc and board

### DIFF
--- a/scripts/pylib/twister/boards/unit/unit_testing/board.yml
+++ b/scripts/pylib/twister/boards/unit/unit_testing/board.yml
@@ -1,0 +1,5 @@
+board:
+  name: unit_testing
+  vendor: zephyr
+  socs:
+  - name: unit_testing

--- a/scripts/pylib/twister/soc/unit/unit_testing/soc.yml
+++ b/scripts/pylib/twister/soc/unit/unit_testing/soc.yml
@@ -1,0 +1,2 @@
+socs:
+- name: unit_testing

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -404,7 +404,8 @@ class TestPlan:
         # Note, internally in twister a board root includes the `boards` folder
         # but in Zephyr build system, the board root is without the `boards` in folder path.
         board_roots = [Path(os.path.dirname(root)) for root in self.env.board_roots]
-        lb_args = Namespace(arch_roots=[Path(ZEPHYR_BASE)], soc_roots=[Path(ZEPHYR_BASE)],
+        lb_args = Namespace(arch_roots=[Path(ZEPHYR_BASE)], soc_roots=[Path(ZEPHYR_BASE),
+                            Path(ZEPHYR_BASE) / 'scripts' / 'pylib' / 'twister'],
                             board_roots=board_roots, board=None, board_dir=None)
         v1_boards = list_boards.find_boards(lb_args)
         v2_boards = list_boards.find_v2_boards(lb_args)


### PR DESCRIPTION
Create board.yml and soc.yml for the unit_testing board so that list_board.py can correctly find those boards for twister unit test test-cases.