### PR TITLE
lib/os/printk.c: use ARG_UNUSED() for char_out()

### DIFF
--- a/lib/os/printk.c
+++ b/lib/os/printk.c
@@ -107,7 +107,7 @@ static int buf_char_out(int c, void *ctx_p)
 
 static int char_out(int c, void *ctx_p)
 {
-	(void) ctx_p;
+	ARG_UNUSED(ctx_p);
 	return _char_out(c);
 }
 


### PR DESCRIPTION
ARG_UNUSED() could be used here. Any reason not to use it?

best regards,

Florian La Roche
