### PR TITLE
subsys/net/conn_mgr: set a thread name

### DIFF
--- a/subsys/net/conn_mgr/conn_mgr_monitor.c
+++ b/subsys/net/conn_mgr/conn_mgr_monitor.c
@@ -338,6 +338,7 @@ static int conn_mgr_mon_init(void)
 			CONFIG_NET_CONNECTION_MANAGER_MONITOR_STACK_SIZE,
 			conn_mgr_mon_thread_fn,
 			NULL, NULL, NULL, THREAD_PRIORITY, 0, K_NO_WAIT);
+	k_thread_name_set(&conn_mgr_mon_thread, "conn_mgr_monitor");
 
 	return 0;
 }


### PR DESCRIPTION
Having a thread name might make it easier to know what this thread is all about.
E.g. from the list of threads within the shell.

best regards,

Florian La Roche
