### PR TITLE
samples: fs: fat_fs: Add RAM disk sample for nrf52840dk

### DIFF
--- a/samples/subsys/fs/fs_sample/boards/nrf52840dk_nrf52840_ram_disk.conf
+++ b/samples/subsys/fs/fs_sample/boards/nrf52840dk_nrf52840_ram_disk.conf
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_DISK_DRIVERS=y
+CONFIG_DISK_DRIVER_RAM=y
+CONFIG_DISK_DRIVER_FLASH=n
+# There may be no files on internal SoC flash, so this Kconfig
+# options has ben enabled to create some if listing does not
+# find in the first place.
+CONFIG_FS_SAMPLE_CREATE_SOME_ENTRIES=y

--- a/samples/subsys/fs/fs_sample/boards/nrf52840dk_nrf52840_ram_disk.overlay
+++ b/samples/subsys/fs/fs_sample/boards/nrf52840dk_nrf52840_ram_disk.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	msc_disk0 {
+		status="okay";
+		compatible = "zephyr,ram-disk";
+		/* Sample, to make things easier, mounts all FAT
+		 * systems at "SD".
+		 */
+		disk-name = "SD";
+		/* Disk size is 64kB, 128 sectors of 512B, the minimal
+		 * required by FAT FS.
+		 */
+		sector-size = <512>;
+		sector-count = <128>;
+	};
+};

--- a/samples/subsys/fs/fs_sample/boards/nrf52840dk_nrf52840_ram_disk_region.overlay
+++ b/samples/subsys/fs/fs_sample/boards/nrf52840dk_nrf52840_ram_disk_region.overlay
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* The SRAM is defined for nrf52840 in DTS to take entire 256KiB
+ * of RAM there is. We need some for the Disk, so we need to
+ * remove the original definition and replace it with smaller one.
+ */
+/delete-node/ &sram0;
+
+/ {
+
+	soc {
+		/* This is defined based on dts and dtsi files for
+		 * nrf52840 SoC; because we are not able to just
+		 * change the size, what we have to do is to remove
+		 * the sram0 definition, which is a combined result
+		 * of all the sram0 referencing entries in included
+		 * dts files, and replace it with our own.
+		 * The first one is reduced in size original sram0:
+		 */
+		sram0: memory@20000000 {
+			compatible = "mmio-sram";
+			reg = <0x20000000 DT_SIZE_K(192)>;
+		};
+		/* The second one is 64kiB region taken out of SRAM,
+		 * labeled here ram_disk, label can be anything,
+		 * used later in disk definition.
+		 */
+		ram_disk: memory@20030000 {
+			compatible = "mmio-sram";
+			reg = <0x20030000 DT_SIZE_K(64)>;
+		};
+	};
+
+	msc_disk0 {
+		status="okay";
+		compatible = "zephyr,ram-disk";
+		/* Sample, to make things easier, mounts all FAT
+		 * systems at "SD".
+		 */
+		disk-name = "SD";
+		/* Disk size is 64kB, 128 sectors of 512B, the minimal
+		 * required by FAT FS.
+		 */
+		sector-size = <512>;
+		sector-count = <128>;
+		/* Here is the reference to the memory reserved for our
+		 * disk using a phandle; note that we reference the
+		 * region by label we have defined it above.
+		 */
+		ram-region = <&ram_disk>;
+	};
+};

--- a/samples/subsys/fs/fs_sample/sample.yaml
+++ b/samples/subsys/fs/fs_sample/sample.yaml
@@ -37,6 +37,12 @@ tests:
     extra_args:
       - OVERLAY_CONFIG=boards/nrf52840dk_nrf52840_ram_disk.conf
       - DTC_OVERLAY_FILE=boards/nrf52840dk_nrf52840_ram_disk.overlay
+  sample.filesystem.fat_fs.nrf52840dk_nrf52840_ram_disk_region:
+    build_only: true
+    platform_allow: nrf52840dk/nrf52840
+    extra_args:
+      - OVERLAY_CONFIG=boards/nrf52840dk_nrf52840_ram_disk.conf
+      - DTC_OVERLAY_FILE=boards/nrf52840dk_nrf52840_ram_disk_region.overlay
   sample.filesystem.fat_fs.nrf52840dk_nrf52840.qspi:
     build_only: true
     platform_allow: nrf52840dk/nrf52840

--- a/samples/subsys/fs/fs_sample/sample.yaml
+++ b/samples/subsys/fs/fs_sample/sample.yaml
@@ -31,6 +31,12 @@ tests:
   sample.filesystem.fat_fs.nrf52840dk_nrf52840:
     build_only: true
     platform_allow: nrf52840dk/nrf52840
+  sample.filesystem.fat_fs.nrf52840dk_nrf52840_ram_disk:
+    build_only: true
+    platform_allow: nrf52840dk/nrf52840
+    extra_args:
+      - OVERLAY_CONFIG=boards/nrf52840dk_nrf52840_ram_disk.conf
+      - DTC_OVERLAY_FILE=boards/nrf52840dk_nrf52840_ram_disk.overlay
   sample.filesystem.fat_fs.nrf52840dk_nrf52840.qspi:
     build_only: true
     platform_allow: nrf52840dk/nrf52840


### PR DESCRIPTION
Add configuration for nrf52840dk that allows to create RAM disk; this configuration does not reserve special region in RAM using DTS but uses automatic buffer allocation, by RAM Disk Drivers, according to RAM disk specification in DTS.