### PR TITLE
boards: st: stm32g0316: Use openocd as debug interface.

### DIFF
--- a/boards/st/stm32g0316_disco/board.cmake
+++ b/boards/st/stm32g0316_disco/board.cmake
@@ -3,6 +3,7 @@ board_runner_args(pyocd "--target=stm32g031j6mx")
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 board_runner_args(jlink "--device=STM32G031J6" "--speed=4000")
 
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)

--- a/boards/st/stm32g0316_disco/doc/index.rst
+++ b/boards/st/stm32g0316_disco/doc/index.rst
@@ -88,14 +88,8 @@ Flashing
 ========
 
 The STM32G0316-DISCO board includes an ST-LINK/V2-1 embedded debug tool
-interface. This interface is not yet supported by the openocd version included in
-the Zephyr SDK. Instead, support can be enabled on pyocd by adding "pack" support with
-the following pyocd command:
-
-.. code-block:: console
-
-   $ pyocd pack --update
-   $ pyocd pack --install stm32g031j6
+interface.
+This interface is supported by the openocd version included in the Zephyr SDK.
 
 Flashing an application to the STM32G0316-DISCO
 -----------------------------------------------

--- a/boards/st/stm32g0316_disco/support/openocd.cfg
+++ b/boards/st/stm32g0316_disco/support/openocd.cfg
@@ -1,0 +1,5 @@
+source [find interface/stlink.cfg]
+
+transport select hla_swd
+
+source [find target/stm32g0x.cfg]


### PR DESCRIPTION
Default pyocd configuration doesn't allow debugging on this board. Now that Zephyr openocd version support stm32g0 series, use it instead of pyocd.
This commit provides working openocd configuration for this board an update documentation.