### PR TITLE
scripts: utils: board_v1_to_v2: drop board_legacy prefix

### DIFF
--- a/scripts/utils/board_v1_to_v2.py
+++ b/scripts/utils/board_v1_to_v2.py
@@ -43,7 +43,7 @@ ZEPHYR_BASE = Path(__file__).parents[2]
 
 def board_v1_to_v2(board_root, board, new_board, group, vendor, soc, variants):
     try:
-        board_path = next(board_root.glob(f"boards/boards_legacy/*/{board}"))
+        board_path = next(board_root.glob(f"boards/*/{board}"))
     except StopIteration:
         sys.exit(f"Board not found: {board}")
 


### PR DESCRIPTION
So that script can be used for out of tree boards from now on. All in-tree boards have been already ported, so the prefix no longer makes sense.