### PR TITLE
Bluetooth: Mesh: make models metadata const

### DIFF
--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -116,6 +116,11 @@ Bluetooth
 Bluetooth Mesh
 ==============
 
+* The model metadata pointer declaration of :c:struct:`bt_mesh_model` has been changed
+  to add ``const`` qualifiers. The data pointer of :c:struct:`bt_mesh_models_metadata_entry`
+  got ``const`` qualifier too. The model's metadata structure and metadata raw value
+  can be declared as permanent constants in the non-volatile memory. (:github:`69679`)
+
 Bluetooth Audio
 ===============
 

--- a/include/zephyr/bluetooth/mesh/access.h
+++ b/include/zephyr/bluetooth/mesh/access.h
@@ -777,7 +777,7 @@ struct bt_mesh_models_metadata_entry {
 	const uint16_t id;
 
 	/* Pointer to raw data */
-	void *data;
+	const void * const data;
 };
 
 /**
@@ -924,7 +924,7 @@ struct bt_mesh_model {
 
 #if defined(CONFIG_BT_MESH_LARGE_COMP_DATA_SRV) || defined(__DOXYGEN__)
 	/* Pointer to the array of model metadata entries. */
-	struct bt_mesh_models_metadata_entry **metadata;
+	const struct bt_mesh_models_metadata_entry * const * const metadata;
 #endif
 };
 

--- a/include/zephyr/bluetooth/mesh/health_srv.h
+++ b/include/zephyr/bluetooth/mesh/health_srv.h
@@ -159,7 +159,7 @@ struct bt_mesh_health_srv {
 
 #ifdef CONFIG_BT_MESH_LARGE_COMP_DATA_SRV
 	/** Pointer to the array with Health Test Info Metadata */
-	struct bt_mesh_models_metadata_entry *metadata;
+	const struct bt_mesh_models_metadata_entry *metadata;
 #endif
 };
 

--- a/subsys/bluetooth/mesh/access.c
+++ b/subsys/bluetooth/mesh/access.c
@@ -174,7 +174,7 @@ static void data_buf_add_le16_offset(struct net_buf_simple *buf,
 	}
 }
 
-static void data_buf_add_mem_offset(struct net_buf_simple *buf, uint8_t *data, size_t len,
+static void data_buf_add_mem_offset(struct net_buf_simple *buf, const uint8_t *data, size_t len,
 				    size_t *offset)
 {
 	if (*offset >= len) {
@@ -694,13 +694,13 @@ static int bt_mesh_comp_data_get_page_2(struct net_buf_simple *buf, size_t offse
 		data_buf_add_u8_offset(buf, dev_comp2->record[i].version.z, &offset);
 		data_buf_add_u8_offset(buf, dev_comp2->record[i].elem_offset_cnt, &offset);
 		if (dev_comp2->record[i].elem_offset_cnt) {
-			data_buf_add_mem_offset(buf, (uint8_t *)dev_comp2->record[i].elem_offset,
+			data_buf_add_mem_offset(buf, dev_comp2->record[i].elem_offset,
 						dev_comp2->record[i].elem_offset_cnt, &offset);
 		}
 
 		data_buf_add_le16_offset(buf, dev_comp2->record[i].data_len, &offset);
 		if (dev_comp2->record[i].data_len) {
-			data_buf_add_mem_offset(buf, (uint8_t *)dev_comp2->record[i].data,
+			data_buf_add_mem_offset(buf, dev_comp2->record[i].data,
 						dev_comp2->record[i].data_len, &offset);
 		}
 	}

--- a/subsys/bluetooth/mesh/shell/shell.c
+++ b/subsys/bluetooth/mesh/shell/shell.c
@@ -145,12 +145,12 @@ static const struct bt_mesh_health_srv_cb health_srv_cb = {
 #endif /* CONFIG_BT_MESH_SHELL_HEALTH_SRV_INSTANCE */
 
 #ifdef CONFIG_BT_MESH_LARGE_COMP_DATA_SRV
-static uint8_t health_tests[] = {
+static const uint8_t health_tests[] = {
 	BT_MESH_HEALTH_TEST_INFO(COMPANY_ID_LF, 6, 0x01, 0x02, 0x03, 0x04, 0x34, 0x15),
 	BT_MESH_HEALTH_TEST_INFO(COMPANY_ID_NORDIC_SEMI, 3, 0x01, 0x02, 0x03),
 };
 
-static struct bt_mesh_models_metadata_entry health_srv_meta[] = {
+static const struct bt_mesh_models_metadata_entry health_srv_meta[] = {
 	BT_MESH_HEALTH_TEST_INFO_METADATA(health_tests),
 	BT_MESH_MODELS_METADATA_END,
 };

--- a/tests/bluetooth/tester/src/btp_mesh.c
+++ b/tests/bluetooth/tester/src/btp_mesh.c
@@ -691,9 +691,9 @@ static uint8_t health_tests[] = {
 	BT_MESH_HEALTH_TEST_INFO(COMPANY_ID_NORDIC_SEMI, 3, 0x01, 0x02, 0x03),
 };
 
-static uint8_t zero_metadata[100];
+static const uint8_t zero_metadata[100];
 
-static struct bt_mesh_models_metadata_entry health_srv_meta[] = {
+static const struct bt_mesh_models_metadata_entry health_srv_meta[] = {
 	BT_MESH_HEALTH_TEST_INFO_METADATA(health_tests),
 	{
 		.len = ARRAY_SIZE(zero_metadata),
@@ -703,13 +703,13 @@ static struct bt_mesh_models_metadata_entry health_srv_meta[] = {
 	BT_MESH_MODELS_METADATA_END,
 };
 
-static uint8_t health_tests_alt[] = {
+static const uint8_t health_tests_alt[] = {
 	BT_MESH_HEALTH_TEST_INFO(COMPANY_ID_LF, 6, 0x11, 0x22, 0x33, 0x44, 0x55,
 				 0x66),
 	BT_MESH_HEALTH_TEST_INFO(COMPANY_ID_NORDIC_SEMI, 3, 0x11, 0x22, 0x33),
 };
 
-static struct bt_mesh_models_metadata_entry health_srv_meta_alt[] = {
+static const struct bt_mesh_models_metadata_entry health_srv_meta_alt[] = {
 	BT_MESH_HEALTH_TEST_INFO_METADATA(health_tests_alt),
 	{
 		.len = ARRAY_SIZE(zero_metadata),

--- a/tests/bsim/bluetooth/mesh/src/test_lcd.c
+++ b/tests/bsim/bluetooth/mesh/src/test_lcd.c
@@ -86,7 +86,7 @@ static void test_args_parse(int argc, char *argv[])
 	bs_args_parse_all_cmd_line(argc, argv, args_struct);
 }
 
-static struct bt_mesh_models_metadata_entry *dummy_meta_entry[] = {};
+static const struct bt_mesh_models_metadata_entry *dummy_meta_entry[] = {};
 
 /* Empty elements to create large composition/meta data */
 #define DUMMY_ELEM(i, _) BT_MESH_ELEM((i) + 2,	\


### PR DESCRIPTION
Commit adds const qualifier to models metadata.
Specification claims: Composition Metadata Page 0
shall not change during a term of a node on the network.