### PR TITLE
pm: only define slots if CONFIG_PM is enabled

### DIFF
--- a/include/zephyr/pm/device.h
+++ b/include/zephyr/pm/device.h
@@ -274,6 +274,7 @@ BUILD_ASSERT(offsetof(struct pm_device_isr, base) == 0);
  */
 #define Z_PM_DEVICE_NAME(dev_id) _CONCAT(__pm_device_, dev_id)
 
+#ifdef CONFIG_PM
 /**
  * @brief Define device PM slot.
  *
@@ -288,6 +289,9 @@ BUILD_ASSERT(offsetof(struct pm_device_isr, base) == 0);
 #define Z_PM_DEVICE_DEFINE_SLOT(dev_id)					\
 	static STRUCT_SECTION_ITERABLE_ALTERNATE(pm_device_slots, device, \
 			_CONCAT(__pm_slot_, dev_id))
+#else
+#define Z_PM_DEVICE_DEFINE_SLOT(dev_id)
+#endif /* CONFIG_PM */
 
 #ifdef CONFIG_PM_DEVICE
 /**


### PR DESCRIPTION
The pm_device_slots section is only used by subsys/pm/pm.c. This file is only compiled if CONFIG_PM=y. pm_device_slots is unused otherwise.

Don't populate pm_device_slots when CONFIG_PM=n, CONFIG_PM_DEVICE=y to save a few bytes of ROM and RAM.