### PR TITLE
MAINTAINERS: Add pdgendt as networking collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2540,6 +2540,7 @@ Networking:
     - rlubos
     - jukkar
   collaborators:
+    - pdgendt
     - tbursztyka
     - ssharks
   files:


### PR DESCRIPTION
Adding Pieter De Gendt (pdgendt) as a collaborator to the networking subsystem.