### PR TITLE
x86: prefix x86 SSBD and IBRS related kconfigs with X86

### DIFF
--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -397,7 +397,7 @@ config X86_NO_SPECULATIVE_VULNERABILITIES
 	  or is a newer chip which is immune to the class of vulnerabilities
 	  which exploit speculative execution side channel attacks.
 
-config DISABLE_SSBD
+config X86_DISABLE_SSBD
 	bool "Disable Speculative Store Bypass"
 	depends on USERSPACE
 	default y if !X86_NO_SPECTRE_V4
@@ -417,7 +417,16 @@ config DISABLE_SSBD
 	  Even if enabled, will have no effect on CPUs that do not
 	  require this feature.
 
-config ENABLE_EXTENDED_IBRS
+config DISABLE_SSBD
+	bool "Disable Speculative Store Bypass [DEPRECATED]"
+	depends on USERSPACE
+	default y if !X86_NO_SPECTRE_V4
+	select X86_DISABLE_SSBD
+	select DEPRECATED
+	help
+	  Deprecated. Use CONFIG_X86_DISABLE_SSBD instead.
+
+config X86_ENABLE_EXTENDED_IBRS
 	bool "Extended IBRS"
 	depends on USERSPACE
 	default y if !X86_NO_SPECTRE_V2
@@ -425,6 +434,15 @@ config ENABLE_EXTENDED_IBRS
 	  This option will enable the Extended Indirect Branch Restricted
 	  Speculation 'always on' feature. This mitigates Indirect Branch
 	  Control vulnerabilities (aka Spectre V2).
+
+config ENABLE_EXTENDED_IBRS
+	bool "Extended IBRS [DEPRECATED]"
+	depends on USERSPACE
+	default y if !X86_NO_SPECTRE_V2
+	select X86_ENABLE_EXTENDED_IBRS
+	select DEPRECATED
+	help
+	  Deprecated. Use CONFIG_X86_ENABLE_EXTENDED_IBRS instead.
 
 config X86_BOUNDS_CHECK_BYPASS_MITIGATION
 	bool

--- a/arch/x86/core/spec_ctrl.c
+++ b/arch/x86/core/spec_ctrl.c
@@ -16,19 +16,19 @@
  * https://software.intel.com/security-software-guidance/api-app/sites/default/files/336996-Speculative-Execution-Side-Channel-Mitigations.pdf
  */
 
-#if defined(CONFIG_DISABLE_SSBD) || defined(CONFIG_ENABLE_EXTENDED_IBRS)
+#if defined(CONFIG_X86_DISABLE_SSBD) || defined(CONFIG_X86_ENABLE_EXTENDED_IBRS)
 static int spec_ctrl_init(void)
 {
 
 	uint32_t enable_bits = 0U;
 	uint32_t cpuid7 = z_x86_cpuid_extended_features();
 
-#ifdef CONFIG_DISABLE_SSBD
+#ifdef CONFIG_X86_DISABLE_SSBD
 	if ((cpuid7 & CPUID_SPEC_CTRL_SSBD) != 0U) {
 		enable_bits |= X86_SPEC_CTRL_MSR_SSBD;
 	}
 #endif
-#ifdef CONFIG_ENABLE_EXTENDED_IBRS
+#ifdef CONFIG_X86_ENABLE_EXTENDED_IBRS
 	if ((cpuid7 & CPUID_SPEC_CTRL_IBRS) != 0U) {
 		enable_bits |= X86_SPEC_CTRL_MSR_IBRS;
 	}
@@ -44,4 +44,4 @@ static int spec_ctrl_init(void)
 }
 
 SYS_INIT(spec_ctrl_init, PRE_KERNEL_1, 0);
-#endif /* CONFIG_DISABLE_SSBD || CONFIG_ENABLE_EXTENDED_IBRS */
+#endif /* CONFIG_X86_DISABLE_SSBD || CONFIG_X86_ENABLE_EXTENDED_IBRS */

--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -120,5 +120,11 @@ Userspace
 Architectures
 *************
 
+* x86
+
+  * Kconfigs ``CONFIG_DISABLE_SSBD`` and ``CONFIG_ENABLE_EXTENDED_IBRS``
+    are deprecated. Use :kconfig:option:`CONFIG_X86_DISABLE_SSBD` and
+    :kconfig:option:`CONFIG_X86_ENABLE_EXTENDED_IBRS` instead.
+
 Xtensa
 ======


### PR DESCRIPTION
There are two kconfigs that are security related and are x86 specific. Prefix them with X86 to put them under the x86 namespace.