### PR TITLE
boards: nucleo_g0{b1re,70rb,71rb}: add ST Morpho connector nexus node

### DIFF
--- a/boards/st/nucleo_g070rb/nucleo_g070rb.dts
+++ b/boards/st/nucleo_g070rb/nucleo_g070rb.dts
@@ -8,6 +8,7 @@
 #include <st/g0/stm32g070Xb.dtsi>
 #include <st/g0/stm32g070rbtx-pinctrl.dtsi>
 #include "arduino_r3_connector.dtsi"
+#include "st_morpho_connector.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {

--- a/boards/st/nucleo_g070rb/st_morpho_connector.dtsi
+++ b/boards/st/nucleo_g070rb/st_morpho_connector.dtsi
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2024 Marcin Niestroj
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/st-morpho-header.h>
+
+/ {
+	st_morpho_header: st-morpho-header {
+		compatible = "st-morpho-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <ST_MORPHO_PIN_MASK 0x0>;
+		gpio-map-pass-thru = <0x0 GPIO_DT_FLAGS_MASK>;
+		gpio-map = <ST_MORPHO_L_1 0 &gpioc 10 0>,
+			   <ST_MORPHO_L_2 0 &gpioc 11 0>,
+			   <ST_MORPHO_L_3 0 &gpioc 12 0>,
+			   <ST_MORPHO_L_4 0 &gpiod 2 0>,
+			   <ST_MORPHO_L_7 0 &gpioa 14 0>,
+			   <ST_MORPHO_L_9 0 &gpiod 0>,
+			   <ST_MORPHO_L_10 0 &gpiod 1>,
+			   <ST_MORPHO_L_11 0 &gpiod 3>,
+			   <ST_MORPHO_L_13 0 &gpioa 13 0>,
+			   <ST_MORPHO_L_15 0 &gpiod 4 0>,
+			   <ST_MORPHO_L_17 0 &gpioa 15 0>,
+			   <ST_MORPHO_L_21 0 &gpiob 7 0>,
+			   <ST_MORPHO_L_23 0 &gpioc 13 0>,
+			   <ST_MORPHO_L_25 0 &gpioc 14 0>, /* SB23=ON, R31=OFF */
+			   <ST_MORPHO_L_26 0 &gpiod 5 0>,
+			   <ST_MORPHO_L_27 0 &gpioc 15 0>, /* SB24=ON, R32=OFF */
+			   <ST_MORPHO_L_28 0 &gpioa 0 0>,
+			   <ST_MORPHO_L_29 0 &gpiof 0 0>,
+			   <ST_MORPHO_L_30 0 &gpioa 1 0>,
+			   <ST_MORPHO_L_31 0 &gpiof 1 0>,
+			   <ST_MORPHO_L_32 0 &gpioa 4 0>,
+			   <ST_MORPHO_L_34 0 &gpiob 1 0>,
+			   <ST_MORPHO_L_35 0 &gpioc 2 0>,
+			   <ST_MORPHO_L_36 0 &gpiob 11 0>, /* SB4=ON, SB2=OFF */
+			   <ST_MORPHO_L_37 0 &gpioc 3 0>,
+			   <ST_MORPHO_L_38 0 &gpiob 12 0>, /* SB3=ON, SB5=OFF */
+			   <ST_MORPHO_R_1 0 &gpioc 9 0>,
+			   <ST_MORPHO_R_2 0 &gpioc 8 0>,
+			   <ST_MORPHO_R_3 0 &gpiob 8 0>,
+			   <ST_MORPHO_R_4 0 &gpioc 6 0>,
+			   <ST_MORPHO_R_5 0 &gpiob 9 0>,
+			   <ST_MORPHO_R_6 0 &gpioa 3 0>,
+			   <ST_MORPHO_R_10 0 &gpiod 6 0>,
+			   <ST_MORPHO_R_11 0 &gpioa 5 0>,
+			   <ST_MORPHO_R_12 0 &gpioa 12 0>,
+			   <ST_MORPHO_R_13 0 &gpioa 6 0>,
+			   <ST_MORPHO_R_14 0 &gpioa 11 0>,
+			   <ST_MORPHO_R_15 0 &gpioa 7 0>,
+			   <ST_MORPHO_R_16 0 &gpioc 1 0>,
+			   <ST_MORPHO_R_17 0 &gpiob 0 0>,
+			   <ST_MORPHO_R_18 0 &gpioc 0 0>,
+			   <ST_MORPHO_R_19 0 &gpioc 7 0>,
+			   <ST_MORPHO_R_21 0 &gpioa 9 0>,
+			   <ST_MORPHO_R_22 0 &gpiob 2 0>,
+			   <ST_MORPHO_R_23 0 &gpioa 8 0>,
+			   <ST_MORPHO_R_24 0 &gpiob 6 0>,
+			   <ST_MORPHO_R_25 0 &gpiob 14 0>,
+			   <ST_MORPHO_R_26 0 &gpiob 15 0>,
+			   <ST_MORPHO_R_27 0 &gpiob 4 0>,
+			   <ST_MORPHO_R_28 0 &gpiob 10 0>,
+			   <ST_MORPHO_R_29 0 &gpiob 5 0>,
+			   <ST_MORPHO_R_30 0 &gpiob 13 0>,
+			   <ST_MORPHO_R_31 0 &gpiob 3 0>,
+			   <ST_MORPHO_R_33 0 &gpioa 10 0>,
+			   <ST_MORPHO_R_34 0 &gpioa 2 0>,
+			   <ST_MORPHO_R_35 0 &gpioc 4 0>,
+			   <ST_MORPHO_R_36 0 &gpiod 8 0>,
+			   <ST_MORPHO_R_37 0 &gpioc 5 0>,
+			   <ST_MORPHO_R_38 0 &gpiod 9 0>;
+	};
+};

--- a/boards/st/nucleo_g071rb/nucleo_g071rb.dts
+++ b/boards/st/nucleo_g071rb/nucleo_g071rb.dts
@@ -9,6 +9,7 @@
 #include <st/g0/stm32g071Xb.dtsi>
 #include <st/g0/stm32g071r(6-8-b)tx-pinctrl.dtsi>
 #include "arduino_r3_connector.dtsi"
+#include "st_morpho_connector.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {

--- a/boards/st/nucleo_g071rb/st_morpho_connector.dtsi
+++ b/boards/st/nucleo_g071rb/st_morpho_connector.dtsi
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2024 Marcin Niestroj
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/st-morpho-header.h>
+
+/ {
+	st_morpho_header: st-morpho-header {
+		compatible = "st-morpho-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <ST_MORPHO_PIN_MASK 0x0>;
+		gpio-map-pass-thru = <0x0 GPIO_DT_FLAGS_MASK>;
+		gpio-map = <ST_MORPHO_L_1 0 &gpioc 10 0>,
+			   <ST_MORPHO_L_2 0 &gpioc 11 0>,
+			   <ST_MORPHO_L_3 0 &gpioc 12 0>,
+			   <ST_MORPHO_L_4 0 &gpiod 2 0>,
+			   <ST_MORPHO_L_7 0 &gpioa 14 0>,
+			   <ST_MORPHO_L_9 0 &gpiod 0>,
+			   <ST_MORPHO_L_10 0 &gpiod 1>,
+			   <ST_MORPHO_L_11 0 &gpiod 3>,
+			   <ST_MORPHO_L_13 0 &gpioa 13 0>,
+			   <ST_MORPHO_L_15 0 &gpiod 4 0>,
+			   <ST_MORPHO_L_17 0 &gpioa 15 0>,
+			   <ST_MORPHO_L_21 0 &gpiob 7 0>,
+			   <ST_MORPHO_L_23 0 &gpioc 13 0>,
+			   <ST_MORPHO_L_25 0 &gpioc 14 0>, /* SB23=ON, R31=OFF */
+			   <ST_MORPHO_L_26 0 &gpiod 5 0>,
+			   <ST_MORPHO_L_27 0 &gpioc 15 0>, /* SB24=ON, R32=OFF */
+			   <ST_MORPHO_L_28 0 &gpioa 0 0>,
+			   <ST_MORPHO_L_29 0 &gpiof 0 0>,
+			   <ST_MORPHO_L_30 0 &gpioa 1 0>,
+			   <ST_MORPHO_L_31 0 &gpiof 1 0>,
+			   <ST_MORPHO_L_32 0 &gpioa 4 0>,
+			   <ST_MORPHO_L_34 0 &gpiob 1 0>,
+			   <ST_MORPHO_L_35 0 &gpioc 2 0>,
+			   <ST_MORPHO_L_36 0 &gpiob 11 0>, /* SB4=ON, SB2=OFF */
+			   <ST_MORPHO_L_37 0 &gpioc 3 0>,
+			   <ST_MORPHO_L_38 0 &gpiob 12 0>, /* SB3=ON, SB5=OFF */
+			   <ST_MORPHO_R_1 0 &gpioc 9 0>,
+			   <ST_MORPHO_R_2 0 &gpioc 8 0>,
+			   <ST_MORPHO_R_3 0 &gpiob 8 0>,
+			   <ST_MORPHO_R_4 0 &gpioc 6 0>,
+			   <ST_MORPHO_R_5 0 &gpiob 9 0>,
+			   <ST_MORPHO_R_6 0 &gpioa 3 0>,
+			   <ST_MORPHO_R_10 0 &gpiod 6 0>,
+			   <ST_MORPHO_R_11 0 &gpioa 5 0>,
+			   <ST_MORPHO_R_12 0 &gpioa 12 0>,
+			   <ST_MORPHO_R_13 0 &gpioa 6 0>,
+			   <ST_MORPHO_R_14 0 &gpioa 11 0>,
+			   <ST_MORPHO_R_15 0 &gpioa 7 0>,
+			   <ST_MORPHO_R_16 0 &gpioc 1 0>,
+			   <ST_MORPHO_R_17 0 &gpiob 0 0>,
+			   <ST_MORPHO_R_18 0 &gpioc 0 0>,
+			   <ST_MORPHO_R_19 0 &gpioc 7 0>,
+			   <ST_MORPHO_R_21 0 &gpioa 9 0>,
+			   <ST_MORPHO_R_22 0 &gpiob 2 0>,
+			   <ST_MORPHO_R_23 0 &gpioa 8 0>,
+			   <ST_MORPHO_R_24 0 &gpiob 6 0>,
+			   <ST_MORPHO_R_25 0 &gpiob 14 0>,
+			   <ST_MORPHO_R_26 0 &gpiob 15 0>,
+			   <ST_MORPHO_R_27 0 &gpiob 4 0>,
+			   <ST_MORPHO_R_28 0 &gpiob 10 0>,
+			   <ST_MORPHO_R_29 0 &gpiob 5 0>,
+			   <ST_MORPHO_R_30 0 &gpiob 13 0>,
+			   <ST_MORPHO_R_31 0 &gpiob 3 0>,
+			   <ST_MORPHO_R_33 0 &gpioa 10 0>,
+			   <ST_MORPHO_R_34 0 &gpioa 2 0>,
+			   <ST_MORPHO_R_35 0 &gpioc 4 0>,
+			   <ST_MORPHO_R_36 0 &gpiod 8 0>,
+			   <ST_MORPHO_R_37 0 &gpioc 5 0>,
+			   <ST_MORPHO_R_38 0 &gpiod 9 0>;
+	};
+};

--- a/boards/st/nucleo_g0b1re/nucleo_g0b1re.dts
+++ b/boards/st/nucleo_g0b1re/nucleo_g0b1re.dts
@@ -8,6 +8,7 @@
 #include <st/g0/stm32g0b1Xe.dtsi>
 #include <st/g0/stm32g0b1r(b-c-e)tx-pinctrl.dtsi>
 #include "arduino_r3_connector.dtsi"
+#include "st_morpho_connector.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {

--- a/boards/st/nucleo_g0b1re/st_morpho_connector.dtsi
+++ b/boards/st/nucleo_g0b1re/st_morpho_connector.dtsi
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2024 Marcin Niestroj
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/st-morpho-header.h>
+
+/ {
+	st_morpho_header: st-morpho-header {
+		compatible = "st-morpho-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <ST_MORPHO_PIN_MASK 0x0>;
+		gpio-map-pass-thru = <0x0 GPIO_DT_FLAGS_MASK>;
+		gpio-map = <ST_MORPHO_L_1 0 &gpioc 10 0>,
+			   <ST_MORPHO_L_2 0 &gpioc 11 0>,
+			   <ST_MORPHO_L_3 0 &gpioc 12 0>,
+			   <ST_MORPHO_L_4 0 &gpiod 2 0>,
+			   <ST_MORPHO_L_7 0 &gpioa 14 0>,
+			   <ST_MORPHO_L_9 0 &gpiod 0>,
+			   <ST_MORPHO_L_10 0 &gpiod 1>,
+			   <ST_MORPHO_L_11 0 &gpiod 3>,
+			   <ST_MORPHO_L_13 0 &gpioa 13 0>,
+			   <ST_MORPHO_L_15 0 &gpiod 4 0>,
+			   <ST_MORPHO_L_17 0 &gpioa 15 0>,
+			   <ST_MORPHO_L_21 0 &gpiob 7 0>,
+			   <ST_MORPHO_L_23 0 &gpioc 13 0>,
+			   <ST_MORPHO_L_25 0 &gpioc 14 0>, /* SB23=ON, R31=OFF */
+			   <ST_MORPHO_L_26 0 &gpiod 5 0>,
+			   <ST_MORPHO_L_27 0 &gpioc 15 0>, /* SB24=ON, R32=OFF */
+			   <ST_MORPHO_L_28 0 &gpioa 0 0>,
+			   <ST_MORPHO_L_29 0 &gpiof 0 0>,
+			   <ST_MORPHO_L_30 0 &gpioa 1 0>,
+			   <ST_MORPHO_L_31 0 &gpiof 1 0>,
+			   <ST_MORPHO_L_32 0 &gpioa 4 0>,
+			   <ST_MORPHO_L_34 0 &gpiob 1 0>,
+			   <ST_MORPHO_L_35 0 &gpioc 2 0>,
+			   <ST_MORPHO_L_36 0 &gpiob 11 0>, /* SB4=ON, SB2=OFF */
+			   <ST_MORPHO_L_37 0 &gpioc 3 0>,
+			   <ST_MORPHO_L_38 0 &gpiob 12 0>, /* SB3=ON, SB5=OFF */
+			   <ST_MORPHO_R_1 0 &gpioc 9 0>,
+			   <ST_MORPHO_R_2 0 &gpioc 8 0>,
+			   <ST_MORPHO_R_3 0 &gpiob 8 0>,
+			   <ST_MORPHO_R_4 0 &gpioc 6 0>,
+			   <ST_MORPHO_R_5 0 &gpiob 9 0>,
+			   <ST_MORPHO_R_6 0 &gpioa 3 0>,
+			   <ST_MORPHO_R_10 0 &gpiod 6 0>,
+			   <ST_MORPHO_R_11 0 &gpioa 5 0>,
+			   <ST_MORPHO_R_12 0 &gpioa 12 0>,
+			   <ST_MORPHO_R_13 0 &gpioa 6 0>,
+			   <ST_MORPHO_R_14 0 &gpioa 11 0>,
+			   <ST_MORPHO_R_15 0 &gpioa 7 0>,
+			   <ST_MORPHO_R_16 0 &gpioc 1 0>,
+			   <ST_MORPHO_R_17 0 &gpiob 0 0>,
+			   <ST_MORPHO_R_18 0 &gpioc 0 0>,
+			   <ST_MORPHO_R_19 0 &gpioc 7 0>,
+			   <ST_MORPHO_R_21 0 &gpioa 9 0>,
+			   <ST_MORPHO_R_22 0 &gpiob 2 0>,
+			   <ST_MORPHO_R_23 0 &gpioa 8 0>,
+			   <ST_MORPHO_R_24 0 &gpiob 6 0>,
+			   <ST_MORPHO_R_25 0 &gpiob 14 0>,
+			   <ST_MORPHO_R_26 0 &gpiob 15 0>,
+			   <ST_MORPHO_R_27 0 &gpiob 4 0>,
+			   <ST_MORPHO_R_28 0 &gpiob 10 0>,
+			   <ST_MORPHO_R_29 0 &gpiob 5 0>,
+			   <ST_MORPHO_R_30 0 &gpiob 13 0>,
+			   <ST_MORPHO_R_31 0 &gpiob 3 0>,
+			   <ST_MORPHO_R_33 0 &gpioa 10 0>,
+			   <ST_MORPHO_R_34 0 &gpioa 2 0>,
+			   <ST_MORPHO_R_35 0 &gpioc 4 0>,
+			   <ST_MORPHO_R_36 0 &gpiod 8 0>,
+			   <ST_MORPHO_R_37 0 &gpioc 5 0>,
+			   <ST_MORPHO_R_38 0 &gpiod 9 0>;
+	};
+};


### PR DESCRIPTION
Add ST Morpho connector nexus mode to following boards:
 - `nucleo_g0b1re`
 - `nucleo_g070rb`
 - `nucleo_g071rb`

They all share the same pin mapping, according to UM2324 (for STM32 Nucleo-64 MB1360 reference
boards).