### PR TITLE
drivers: can: deprecate can_calc_prescaler()

### DIFF
--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -68,6 +68,10 @@ Drivers and Sensors
 
 * CAN
 
+  * Deprecated the :c:func:`can_calc_prescaler` API function, as it allows for bitrate
+    errors. Bitrate errors between nodes on the same network leads to them drifting apart after the
+    start-of-frame (SOF) synchronization has taken place, leading to bus errors.
+
 * Clock control
 
 * Counter

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -1013,6 +1013,10 @@ __syscall int can_set_bitrate_data(const struct device *dev, uint32_t bitrate_da
  * The returned bitrate error is remainder of the division of the clock rate by
  * the bitrate times the timing segments.
  *
+ * @deprecated This function allows for bitrate errors, but bitrate errors between nodes on the same
+ *             network leads to them drifting apart after the start-of-frame (SOF) synchronization
+ *             has taken place.
+ *
  * @param dev     Pointer to the device structure for the driver instance.
  * @param timing  Result is written into the can_timing struct provided.
  * @param bitrate Target bitrate.
@@ -1020,8 +1024,8 @@ __syscall int can_set_bitrate_data(const struct device *dev, uint32_t bitrate_da
  * @retval 0 or positive bitrate error.
  * @retval Negative error code on error.
  */
-int can_calc_prescaler(const struct device *dev, struct can_timing *timing,
-		       uint32_t bitrate);
+__deprecated int can_calc_prescaler(const struct device *dev, struct can_timing *timing,
+				    uint32_t bitrate);
 
 /**
  * @brief Configure the bus timing of a CAN controller.


### PR DESCRIPTION
Deprecate the `can_calc_prescaler()` API function, as it allows for bitrate errors. Bitrate errors between nodes on the same network leads to them drifting apart after the start-of-frame (SOF) synchronization has taken place, leading to bus errors.

This function is unused in-tree after commit 0c13f3888d289de26909cfe2e70a27cccaf94993.