### PR TITLE
boards: shields: Add support for WIZ550io shield

### DIFF
--- a/boards/shields/wiznet_wiz550io/CMakeLists.txt
+++ b/boards/shields/wiznet_wiz550io/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Copyright (c) 2024 Grant Ramsay
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+
+zephyr_library_sources(wiznet_wiz550io.c)

--- a/boards/shields/wiznet_wiz550io/Kconfig.defconfig
+++ b/boards/shields/wiznet_wiz550io/Kconfig.defconfig
@@ -1,0 +1,13 @@
+# Copyright (c) 2024 Grant Ramsay
+# SPDX-License-Identifier: Apache-2.0
+
+if SHIELD_WIZNET_WIZ550IO
+
+if NETWORKING
+
+config NET_L2_ETHERNET
+	default y
+
+endif # NETWORKING
+
+endif # SHIELD_WIZNET_WIZ550IO

--- a/boards/shields/wiznet_wiz550io/Kconfig.shield
+++ b/boards/shields/wiznet_wiz550io/Kconfig.shield
@@ -1,0 +1,23 @@
+# Copyright (c) 2024 Grant Ramsay
+# SPDX-License-Identifier: Apache-2.0
+
+config SHIELD_WIZNET_WIZ550IO
+	def_bool $(shields_list_contains,wiznet_wiz550io)
+
+if SHIELD_WIZNET_WIZ550IO
+
+config WIZ550IO_PRE_W5500_INIT_PRIORITY
+	int "WIZ550io pre W5500 init priority"
+	default 79
+	help
+	  Must occur before W5500 init.
+	  The default is ETH_INIT_PRIORITY - 1.
+
+config WIZ550IO_POST_NET_IF_INIT_PRIORITY
+	int "WIZ550io post net interface init priority"
+	default 91
+	help
+	  Must occur after net interface init.
+	  The default is CONFIG_NET_INIT_PRIO + 1.
+
+endif # SHIELD_WIZNET_WIZ550IO

--- a/boards/shields/wiznet_wiz550io/doc/index.rst
+++ b/boards/shields/wiznet_wiz550io/doc/index.rst
@@ -1,0 +1,63 @@
+.. _wiznet_wiz550io:
+
+WIZnet WIZ550io
+###############
+
+Overview
+********
+
+WIZnet `WIZ550io`_ is a W5500 Ethernet breakout board with an extra PIC12F519
+MCU. The PIC12F519 MCU initialises the W5500 with a unique MAC address after
+a GPIO reset.
+
+`W5500`_  is 10/100 MBPS stand alone Ethernet controller with on-board MAC &
+PHY, 16 KiloBytes for FIFO buffer and SPI serial interface.
+
+Pins Assignment of the WIZ550io Shield
+======================================
+
++-----------------------+---------------------------------------------+
+| Shield Connector Pin  | Function                                    |
++=======================+=============================================+
+| RST#                  | Ethernet Controller's Reset                 |
++-----------------------+---------------------------------------------+
+| CS#                   | SPI's Chip Select                           |
++-----------------------+---------------------------------------------+
+| SCK                   | SPI's ClocK                                 |
++-----------------------+---------------------------------------------+
+| SDO                   | SPI's Slave Data Output  (MISO)             |
++-----------------------+---------------------------------------------+
+| SDI                   | SPI's Slave Data Input   (MISO)             |
++-----------------------+---------------------------------------------+
+| INT                   | Ethernet Controller's Interrupt Output      |
++-----------------------+---------------------------------------------+
+| RDY                   | WIZ550io Ready Output                       |
++-----------------------+---------------------------------------------+
+
+Requirements
+************
+
+This shield/breakout board can be used with any board with SPI interfaces in
+Arduino header or custom header (by adjusting the overlay).
+
+Usage
+*****
+
+Set ``--shield wiznet_wiz550io`` when you invoke ``west build``. For example:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/net/dhcpv4_client
+   :board: nrf52840dk/nrf52840
+   :shield: wiznet_wiz550io
+   :goals: build
+
+References
+**********
+
+.. target-notes::
+
+.. _WIZ550io:
+   https://wiznet.io/products/network-modules/wiz550io
+
+.. _W5500:
+   https://wiznet.io/products/iethernet-chips/w5500

--- a/boards/shields/wiznet_wiz550io/dts/bindings/wiznet,wiz550io.yaml
+++ b/boards/shields/wiznet_wiz550io/dts/bindings/wiznet,wiz550io.yaml
@@ -1,0 +1,36 @@
+# Copyright (c) 2024 Grant Ramsay
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  WIZnet WIZ550io - W5500 Ethernet controller.
+  WIZ550io contains a W5500 Ethernet controller with an extra PIC12F519 MCU.
+  The PIC12F519 MCU initialises the W5500 with a unique MAC address after a
+  GPIO reset. The unique MAC address is used if neither
+  "zephyr,random-mac-address" or "local-mac-address" properties are
+  configured in the corresponding W5500 device.
+
+compatible: "wiznet,wiz550io"
+
+include: base.yaml
+
+properties:
+  wiznet,w5500:
+    type: phandle
+    required: true
+    description: The corresponding W5500 device within the WIZ550io module
+  reset-gpios:
+    type: phandle-array
+    required: true
+    description: |
+      Reset pin (active low output).
+      The reset-gpios property must be assigned to WIZ550io rather than
+      the W5500 device. The hardware reset pin is required for WIZ550io,
+      as a software reset of W5500 will clear the MAC address assigned
+      by the PIC12F519.
+  ready-gpios:
+    type: phandle-array
+    description: |
+      Ready pin (active high input).
+      Optional GPIO pin that signals when the PIC12F519 has finished
+      configuring the W5500. Enabling this reduces the 150ms delay
+      after GPIO reset.

--- a/boards/shields/wiznet_wiz550io/wiznet_wiz550io.c
+++ b/boards/shields/wiznet_wiz550io/wiznet_wiz550io.c
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2024 Grant Ramsay
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Provides the initialsation sequence required for WIZ550io
+ * to configure the W5500 Ethernet controller with its
+ * embedded unique MAC address.
+ */
+
+#define DT_DRV_COMPAT wiznet_wiz550io
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/net/ethernet.h>
+
+LOG_MODULE_DECLARE(eth_w5500, CONFIG_ETHERNET_LOG_LEVEL);
+
+/* WIZ550io documentation recommends 150ms delay after HW reset
+ * for PIC12F519 MCU to configure the W5500.
+ */
+#define WIZ550IO_RESET_DELAY K_MSEC(150)
+
+/* W5500 registers */
+#define W5500_SHAR 0x0009 /* Source MAC address */
+
+#define W5500_SPI_BLOCK_SELECT(addr) (((addr) >> 16) & 0x1f)
+#define W5500_SPI_READ_CONTROL(addr) (W5500_SPI_BLOCK_SELECT(addr) << 3)
+
+struct wiz550io_data {
+	struct net_eth_addr mac_addr;
+};
+
+struct wiz550io_config {
+	const struct device *w5500_dev;
+	struct spi_dt_spec spi;
+	struct gpio_dt_spec reset;
+	struct gpio_dt_spec ready;
+	bool use_mac_addr;
+};
+
+static int wiz550io_spi_read_mac(const struct spi_dt_spec *spi, struct net_eth_addr *mac_addr)
+{
+	const uint32_t addr = W5500_SHAR;
+	int ret;
+
+	if (!spi_is_ready_dt(spi)) {
+		LOG_ERR("SPI %s not ready", spi->bus->name);
+		return -EINVAL;
+	}
+
+	uint8_t cmd[3] = {addr >> 8, addr, W5500_SPI_READ_CONTROL(addr)};
+	const struct spi_buf tx_buf = {
+		.buf = cmd,
+		.len = ARRAY_SIZE(cmd),
+	};
+	const struct spi_buf_set tx = {
+		.buffers = &tx_buf,
+		.count = 1,
+	};
+	/* skip the default dummy 0x010203 */
+	const struct spi_buf rx_buf[2] = {
+		{.buf = NULL, .len = 3},
+		{.buf = mac_addr->addr, .len = sizeof(mac_addr->addr)},
+	};
+	const struct spi_buf_set rx = {
+		.buffers = rx_buf,
+		.count = ARRAY_SIZE(rx_buf),
+	};
+
+	ret = spi_transceive_dt(spi, &tx, &rx);
+
+	return ret;
+}
+
+static int wiz550io_pre_w5500_init(struct wiz550io_data *data, const struct wiz550io_config *config)
+{
+	int ret;
+
+	if (!gpio_is_ready_dt(&config->reset)) {
+		LOG_ERR("GPIO port %s not ready", config->reset.port->name);
+		return -EINVAL;
+	}
+
+	if (gpio_pin_configure_dt(&config->reset, GPIO_OUTPUT)) {
+		LOG_ERR("Unable to configure GPIO pin %u", config->reset.pin);
+		return -EINVAL;
+	}
+
+	/* Hold reset pin low for 500us to perform a hardware reset */
+	gpio_pin_set_dt(&config->reset, 1);
+	k_usleep(500);
+	gpio_pin_set_dt(&config->reset, 0);
+
+	/* Wait for the device to be ready */
+	if (config->ready.port) {
+		if (!gpio_is_ready_dt(&config->ready)) {
+			LOG_ERR("GPIO port %s not ready", config->ready.port->name);
+			return -EINVAL;
+		}
+		if (gpio_pin_configure_dt(&config->ready, GPIO_INPUT)) {
+			LOG_ERR("Unable to configure GPIO pin %u", config->ready.pin);
+			return -EINVAL;
+		}
+
+		k_timepoint_t timeout = sys_timepoint_calc(WIZ550IO_RESET_DELAY);
+
+		while (!gpio_pin_get_dt(&config->ready)) {
+			if (sys_timepoint_expired(timeout)) {
+				LOG_ERR("WIZ550io not ready");
+				return -ETIMEDOUT;
+			}
+			k_msleep(1);
+		}
+	} else {
+		k_sleep(WIZ550IO_RESET_DELAY);
+	}
+
+	if (config->use_mac_addr) {
+		/* Read the WIZ550io unique MAC address set by the PIC12F519.
+		 * It needs to be read after a hardware reset and before software reset.
+		 */
+		ret = wiz550io_spi_read_mac(&config->spi, &data->mac_addr);
+		if (ret) {
+			LOG_ERR("WIZ550io unable to read MAC address");
+			return -EIO;
+		}
+	}
+
+	return 0;
+}
+
+static int wiz550io_post_net_if_init(struct wiz550io_data *data,
+				     const struct wiz550io_config *config)
+{
+	int ret = 0;
+
+	if (config->use_mac_addr) {
+		/* Assign the WIZ550io unique MAC address */
+		const struct device *w5500_dev = config->w5500_dev;
+		const struct ethernet_api *w5500_api = w5500_dev->api;
+		struct ethernet_config eth_config = {.mac_address = data->mac_addr};
+
+		ret = w5500_api->set_config(w5500_dev, ETHERNET_CONFIG_TYPE_MAC_ADDRESS,
+					    &eth_config);
+	}
+
+	return ret;
+}
+
+#define W5500_NODE(inst) DT_INST_PHANDLE(inst, wiznet_w5500)
+
+#define WIZ550IO_INIT(inst)                                                                        \
+	BUILD_ASSERT(!DT_NODE_HAS_PROP(W5500_NODE(inst), reset_gpios),                             \
+		     "The reset-gpios property must be assigned to WIZ550io "                      \
+		     "rather than the W5500 device");                                              \
+                                                                                                   \
+	static struct wiz550io_data wiz550io_data_##inst;                                          \
+                                                                                                   \
+	static const struct wiz550io_config wiz550io_config_##inst = {                             \
+		.w5500_dev = DEVICE_DT_GET(W5500_NODE(inst)),                                      \
+		.spi = SPI_DT_SPEC_GET(W5500_NODE(inst), SPI_WORD_SET(8), 0),                      \
+		.reset = GPIO_DT_SPEC_INST_GET(inst, reset_gpios),                                 \
+		.ready = GPIO_DT_SPEC_INST_GET_OR(inst, ready_gpios, {0}),                         \
+		.use_mac_addr = (!DT_PROP(W5500_NODE(inst), zephyr_random_mac_address) &&          \
+				 !DT_NODE_HAS_PROP(W5500_NODE(inst), local_mac_address)),          \
+	};                                                                                         \
+                                                                                                   \
+	static int wiz550io_pre_w5500_init_##inst(void)                                            \
+	{                                                                                          \
+		return wiz550io_pre_w5500_init(&wiz550io_data_##inst, &wiz550io_config_##inst);    \
+	}                                                                                          \
+	SYS_INIT(wiz550io_pre_w5500_init_##inst, POST_KERNEL,                                      \
+		 CONFIG_WIZ550IO_PRE_W5500_INIT_PRIORITY);                                         \
+                                                                                                   \
+	static int wiz550io_post_net_if_init_##inst(void)                                          \
+	{                                                                                          \
+		return wiz550io_post_net_if_init(&wiz550io_data_##inst, &wiz550io_config_##inst);  \
+	}                                                                                          \
+	SYS_INIT(wiz550io_post_net_if_init_##inst, POST_KERNEL,                                    \
+		 CONFIG_WIZ550IO_POST_NET_IF_INIT_PRIORITY);
+
+DT_INST_FOREACH_STATUS_OKAY(WIZ550IO_INIT)
+
+BUILD_ASSERT(CONFIG_WIZ550IO_PRE_W5500_INIT_PRIORITY < CONFIG_ETH_INIT_PRIORITY,
+	     "WIZ550io pre W5500 init must occur before W5500 init");
+BUILD_ASSERT(CONFIG_WIZ550IO_POST_NET_IF_INIT_PRIORITY > CONFIG_NET_INIT_PRIO,
+	     "WIZ550io post net interface init must occur after net interface init");

--- a/boards/shields/wiznet_wiz550io/wiznet_wiz550io.overlay
+++ b/boards/shields/wiznet_wiz550io/wiznet_wiz550io.overlay
@@ -1,0 +1,26 @@
+/* Copyright (c) 2024 Grant Ramsay
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&arduino_spi {
+	status = "okay";
+
+	eth_w5500: eth_w5500@0 {
+		compatible = "wiznet,w5500";
+		reg = <0x0>;
+		/* W5500 SCLK theoretical design speed is 80MHz.
+		 * The minimum guaranteed speed is 33.3MHz.
+		 */
+		spi-max-frequency = <DT_FREQ_M(33)>;
+		int-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>;    /* D9 */
+	};
+};
+
+/ {
+	wiz550io {
+		compatible = "wiznet,wiz550io";
+		wiznet,w5500 = <&eth_w5500>;
+		reset-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>;  /* D8 */
+		ready-gpios = <&arduino_header 13 GPIO_ACTIVE_HIGH>; /* D7 */
+	};
+};


### PR DESCRIPTION
WIZ550io is a W5500 breakout board with an extra PIC12F519 MCU.
The PIC12F519 MCU initialises the W5500 with a unique MAC address after a GPIO reset.
The PIC12F519 requires a 150ms delay after GPIO reset to configure the W5500.
There is an optional "ready" GPIO signal that can be used to reduce that delay.