### PR TITLE
drivers: ethernet: w5500: Minor tidy up

### DIFF
--- a/drivers/ethernet/eth_w5500_priv.h
+++ b/drivers/ethernet/eth_w5500_priv.h
@@ -83,8 +83,6 @@ struct w5500_config {
 	struct spi_dt_spec spi;
 	struct gpio_dt_spec interrupt;
 	struct gpio_dt_spec reset;
-	void (*config_func)(void);
-	uint8_t full_duplex;
 	int32_t timeout;
 };
 
@@ -99,7 +97,6 @@ struct w5500_runtime {
 	struct k_sem tx_sem;
 	struct k_sem int_sem;
 	bool link_up;
-	void (*generate_mac)(uint8_t *mac);
 	uint8_t buf[NET_ETH_MAX_FRAME_SIZE];
 };
 


### PR DESCRIPTION
* Rename `w5500_hw_reset` to `w5500_soft_reset`
* Set thread name to "eth_w5500"
* Simplify random MAC address code
Remove unnecessary function pointer and wrapper function
* Remove SPI read variable length array
The VLA causes unnecessary stack usage and its max size changes depending on `CONFIG_NET_BUF_DATA_SIZE`
* Remove unused variables `config_func` and `full_duplex`