### PR TITLE
dts: stm32h723.dtsi: fix timers23 address format warning

### DIFF
--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -136,7 +136,7 @@
 			};
 		};
 
-		timers23: timers@0x4000e000 {
+		timers23: timers@4000e000 {
 			compatible = "st,stm32-timers";
 			reg = <0x4000e000 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x01000000>;


### PR DESCRIPTION
Fixes `Warning (simple_bus_reg): /soc/timers@0x4000e000: simple-bus unit address format error, expected "4000e000"`.

