### PR TITLE
ci: doc-publish: Publish API coverage docs only when available

### DIFF
--- a/.github/workflows/doc-publish-pr.yml
+++ b/.github/workflows/doc-publish-pr.yml
@@ -46,7 +46,9 @@ jobs:
     - name: Uncompress HTML docs
       run: |
         tar xf html-output/html-output.tar.xz -C html-output
-        tar xf api-coverage/api-coverage.tar.xz -C api-coverage
+        if [ -f api-coverage/api-coverage.tar.xz ]; then
+          tar xf api-coverage/api-coverage.tar.xz -C api-coverage
+        fi
 
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v2
@@ -62,6 +64,8 @@ jobs:
         aws s3 sync --quiet html-output/html \
           s3://builds.zephyrproject.org/${{ github.event.repository.name }}/pr/${PR_NUM}/docs \
           --delete
-        aws s3 sync --quiet api-coverage/coverage-report/ \
-          s3://builds.zephyrproject.org/${{ github.event.repository.name }}/pr/${PR_NUM}/api-coverage \
-          --delete
+        if [ -d api-coverage/coverage-report ]; then
+          aws s3 sync --quiet api-coverage/coverage-report/ \
+            s3://builds.zephyrproject.org/${{ github.event.repository.name }}/pr/${PR_NUM}/api-coverage \
+            --delete
+        fi

--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -32,7 +32,9 @@ jobs:
     - name: Uncompress HTML docs
       run: |
         tar xf html-output/html-output.tar.xz -C html-output
-        tar xf api-coverage/api-coverage.tar.xz -C api-coverage
+        if [ -f api-coverage/api-coverage.tar.xz ]; then
+          tar xf api-coverage/api-coverage.tar.xz -C api-coverage
+        fi
 
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v2
@@ -53,5 +55,7 @@ jobs:
 
         aws s3 sync --quiet html-output/html s3://docs.zephyrproject.org/${VERSION} --delete
         aws s3 sync --quiet html-output/html/doxygen/html s3://docs.zephyrproject.org/apidoc/${VERSION} --delete
-        aws s3 sync --quiet api-coverage/coverage-report/ s3://docs.zephyrproject.org/api-coverage/${VERSION} --delete
+        if [ -d api-coverage/coverage-report ]; then
+          aws s3 sync --quiet api-coverage/coverage-report/ s3://docs.zephyrproject.org/api-coverage/${VERSION} --delete
+        fi
         aws s3 cp --quiet pdf-output/zephyr.pdf s3://docs.zephyrproject.org/${VERSION}/zephyr.pdf


### PR DESCRIPTION
The API coverage documentation support was (relatively) recently introduced in bad87f1684e7fe8be11a39290d688d9585549184 and is not available in older release branches.

Since doc-publish workflows always run in the default (main) branch context, it is necessary to make the API coverage documentation handling optional for the workflow runs that are triggered from older release branches.