### PR TITLE
sched: SCHED_MULTIQ support DLE algo

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -338,7 +338,6 @@ config SCHED_SCALABLE
 
 config SCHED_MULTIQ
 	bool "Traditional multi-queue ready queue"
-	depends on !SCHED_DEADLINE
 	help
 	  When selected, the scheduler ready queue will be implemented
 	  as the classic/textbook array of lists, one per priority
@@ -348,8 +347,7 @@ config SCHED_MULTIQ
 	  runs in O(1) time in almost all circumstances with very low
 	  constant factor.  But it requires a fairly large RAM budget
 	  to store those list heads, and the limited features make it
-	  incompatible with features like deadline scheduling that
-	  need to sort threads more finely, and SMP affinity which
+	  incompatible with features like SMP affinity which
 	  need to traverse the list of threads.  Typical applications
 	  with small numbers of runnable threads probably want the
 	  DUMB scheduler.

--- a/tests/kernel/sched/deadline/prj.conf
+++ b/tests/kernel/sched/deadline/prj.conf
@@ -3,7 +3,3 @@ CONFIG_MP_MAX_NUM_CPUS=1
 CONFIG_TEST_RANDOM_GENERATOR=y
 CONFIG_SCHED_DEADLINE=y
 CONFIG_BT=n
-
-# Deadline is not compatible with MULTIQ, so we have to pick something
-# specific instead of using the board-level default.
-CONFIG_SCHED_DUMB=y

--- a/tests/kernel/sched/deadline/testcase.yaml
+++ b/tests/kernel/sched/deadline/testcase.yaml
@@ -1,3 +1,4 @@
 tests:
   kernel.scheduler.deadline:
     tags: kernel
+    filter: CONFIG_SCHED_DUMB, CONFIG_SCHED_MULTIQ


### PR DESCRIPTION
In multi level queue, the priority already decide by thread's priority.
We only compare the deadline when adding thread to multi level queue.

The logic is similar with `z_priq_dumb_add`.
