### PR TITLE
tests: devicetree: check L2 interrupt encoding

### DIFF
--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -430,6 +430,19 @@
 			interrupt-parent = <&test_cpu_intc>;
 		};
 
+		/* same as `test_intc` but extends a different L1 interrupt.
+		 * Required for testing if interrupts are encoded properly for
+		 * nodes consumming interrupts from different aggregators.
+		 */
+		test_intc2: interrupt-controller@cafebabe {
+			compatible = "vnd,intc";
+			reg = <0xcafebabe 0x1000>;
+			interrupt-controller;
+			#interrupt-cells = <2>;
+			interrupts = <12 0>;
+			interrupt-parent = <&test_cpu_intc>;
+		};
+
 		/* there should only be one of these */
 		test_irq: interrupt-holder {
 			compatible = "vnd,interrupt-holder";
@@ -444,8 +457,9 @@
 			compatible = "vnd,interrupt-holder-extended";
 			status = "okay";
 			interrupts-extended = <&test_intc 70 7>,
-					      <&test_gpio_4 30 3>;
-			interrupt-names = "int1", "int2";
+					      <&test_gpio_4 30 3>,
+					      <&test_intc2 42 7>;
+			interrupt-names = "int1", "int2", "int3";
 		};
 
 		test_fixed_clk: test-fixed-clock {

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -3201,6 +3201,17 @@ ZTEST(devicetree_api, test_interrupt_controller)
 
 	/* DT_INST_IRQ_INTC */
 	zassert_true(DT_SAME_NODE(DT_INST_IRQ_INTC(0), TEST_INTC), "");
+
+#ifdef CONFIG_2ND_LEVEL_INTERRUPTS
+	/* the following asserts check if interrupt IDs are encoded
+	 * properly when dealing with a node that consumes interrupts
+	 * from L2 aggregators extending different L1 interrupts.
+	 */
+	zassert_true(DT_IRQN_BY_IDX(TEST_IRQ_EXT, 0) ==
+		     (((70 + 1) << CONFIG_1ST_LEVEL_INTERRUPT_BITS) | 11), "");
+	zassert_true(DT_IRQN_BY_IDX(TEST_IRQ_EXT, 2) ==
+		     (((42 + 1) << CONFIG_1ST_LEVEL_INTERRUPT_BITS) | 12), "");
+#endif /* CONFIG_2ND_LEVEL_INTERRUPTS */
 }
 
 ZTEST_SUITE(devicetree_api, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Add some assert statements meant to check if L2 interrupts are encoded right when dealing with nodes that consume interrupts from multiple aggregators. For this to work, also add another interrupt controller node which extends a different L1 interrupt from `test_intc`.

Note: the test will fail unless https://github.com/zephyrproject-rtos/zephyr/pull/68784 is merged first.