### PR TITLE
DAC0x0508 driver: fix for multiple DACs of the same type

### DIFF
--- a/drivers/dac/dac_dacx0508.c
+++ b/drivers/dac/dac_dacx0508.c
@@ -386,7 +386,7 @@ static const struct dac_driver_api dacx0508_driver_api = {
 			    &dac##t##_data_##n, \
 			    &dac##t##_config_##n, POST_KERNEL, \
 			    CONFIG_DAC_DACX0508_INIT_PRIORITY, \
-			    &dacx0508_driver_api)
+			    &dacx0508_driver_api);
 
 /*
  * DAC60508: 12-bit


### PR DESCRIPTION
Presently, this driver cannot handle multiple DACs of the same type without throwing a compile error due to a missing line ending. This PR fixes that issue by adding the missing line ending.

Signed-off-by: Kyle Kotowick <kotowick@invictonlabs.com>