### PR TITLE
tests: drivers/flash: fix suite identifier

### DIFF
--- a/tests/drivers/flash/common/testcase.yaml
+++ b/tests/drivers/flash/common/testcase.yaml
@@ -24,7 +24,7 @@ tests:
       fixture: external_flash_mx25l51245g
     integration_platforms:
       - nrf52840dk/nrf52840
-  drivers.flash.common.soc_flash/nrf:
+  drivers.flash.common.soc_flash_nrf:
     platform_allow: nrf52840dk/nrf52840
     extra_args: OVERLAY_CONFIG=boards/nrf52840_flash_soc.conf
     integration_platforms:


### PR DESCRIPTION
Fix name of scenario, we do not support / in scenario names.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
