### PR TITLE
drivers: can: sja1000: add tx_done callback for error cases

### DIFF
--- a/drivers/can/can_sja1000.c
+++ b/drivers/can/can_sja1000.c
@@ -679,8 +679,10 @@ static void can_sja1000_handle_error_warning_irq(const struct device *dev)
 		}
 	} else if ((sr & CAN_SJA1000_SR_ES) != 0) {
 		data->state = CAN_STATE_ERROR_WARNING;
+		can_sja1000_tx_done(dev, -ENETRESET);
 	} else {
 		data->state = CAN_STATE_ERROR_ACTIVE;
+		can_sja1000_tx_done(dev, -ENETDOWN);
 	}
 }
 


### PR DESCRIPTION
To avoid an infinite wait in can_send(), all error cases must call the transmit callback with an appropriate error code.