### PR TITLE
soc: add stm32f072x8 soc to stm32f0x series

### DIFF
--- a/soc/st/stm32/soc.yml
+++ b/soc/st/stm32/soc.yml
@@ -13,6 +13,7 @@ family:
     - name: stm32f042x6
     - name: stm32f051x8
     - name: stm32f070xb
+    - name: stm32f072x8
     - name: stm32f072xb
     - name: stm32f091xc
     - name: stm32f098xx

--- a/soc/st/stm32/stm32f0x/Kconfig.defconfig.stm32f072x8
+++ b/soc/st/stm32/stm32f0x/Kconfig.defconfig.stm32f072x8
@@ -1,0 +1,11 @@
+# ST Microelectronics STM32F072X8 MCU
+
+# Copyright (c) 2024, Jonas Otto
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_STM32F072X8
+
+config NUM_IRQS
+	default 32
+
+endif # SOC_STM32F072X8

--- a/soc/st/stm32/stm32f0x/Kconfig.defconfig.stm32f072xb
+++ b/soc/st/stm32/stm32f0x/Kconfig.defconfig.stm32f072xb
@@ -3,9 +3,9 @@
 # Copyright (c) 2017 BayLibre, SAS
 # SPDX-License-Identifier: Apache-2.0
 
-if SOC_STM32F072X8 || SOC_STM32F072XB
+if SOC_STM32F072XB
 
 config NUM_IRQS
 	default 32
 
-endif # SOC_STM32F072X8 || SOC_STM32F072XB
+endif # SOC_STM32F072XB


### PR DESCRIPTION
Adds the stm32f072x8 soc to the list of SOCs in the stm32f0x series.

Configuration for this SOC is already present as added in https://github.com/zephyrproject-rtos/zephyr/pull/62745, it was just missing from this list, preventing (OOT) boards from selecting it in `board.yml`.
