### PR TITLE
Bluetooth: Mesh: Add missing model extensions

### DIFF
--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -1044,12 +1044,14 @@ config BT_MESH_BLOB_IO_FLASH
 
 config BT_MESH_DFU_SRV
 	bool "Support for Firmware Update Server model"
+	depends on BT_MESH_MODEL_EXTENSIONS
 	depends on BT_MESH_BLOB_SRV
 	help
 	  Enable the Firmware Update Server model.
 
 config BT_MESH_DFU_CLI
 	bool "Support for Firmware Update Client model"
+	depends on BT_MESH_MODEL_EXTENSIONS
 	depends on BT_MESH_BLOB_CLI
 	help
 	  Enable the Firmware Update Client model.


### PR DESCRIPTION
DFD Server, DFU Server, and DFU Client models are extended models that extend other underlaying models. If BT_MESH_MODEL_EXTENSIONS is not enabled, extension hierarchy is not initialized and this results in issues in subscriptions and errors in representation of hierarchy in CDP1. Since extensions are spec defined, force selection of this option here to prevent users forgetting about it.