### PR TITLE
tests: devicetree: fix gpio intc `interrupt-cells` and add IRQN test

### DIFF
--- a/dts/bindings/test/vnd,gpio-intc-device.yaml
+++ b/dts/bindings/test/vnd,gpio-intc-device.yaml
@@ -25,5 +25,5 @@ gpio-cells:
   - flags
 
 interrupt-cells:
-  - pin
-  - flags
+  - irq
+  - priority

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -215,6 +215,8 @@
 			interrupt-controller;
 			#interrupt-cells = <0x2>;
 			status = "okay";
+			interrupts = <12 0>;
+			interrupt-parent = <&test_cpu_intc>;
 		};
 
 		test_i2c: i2c@11112222 {

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -3201,6 +3201,19 @@ ZTEST(devicetree_api, test_interrupt_controller)
 
 	/* DT_INST_IRQ_INTC */
 	zassert_true(DT_SAME_NODE(DT_INST_IRQ_INTC(0), TEST_INTC), "");
+
+#ifdef CONFIG_MULTI_LEVEL_INTERRUPTS
+	zassert_equal(DT_IRQN_BY_IDX(TEST_IRQ_EXT, 0),
+		      ((70 + 1) << CONFIG_1ST_LEVEL_INTERRUPT_BITS) | 11);
+	/*
+	 * Commented out for now, pending fix from PR #68784:
+	 * zassert_equal(DT_IRQN_BY_IDX(TEST_IRQ_EXT, 1),
+	 *        ((30 + 1) << CONFIG_1ST_LEVEL_INTERRUPT_BITS) | 12);
+	 */
+#else
+	zassert_equal(DT_IRQN_BY_IDX(TEST_IRQ_EXT, 0), 70);
+	zassert_equal(DT_IRQN_BY_IDX(TEST_IRQ_EXT, 1), 30);
+#endif
 }
 
 ZTEST_SUITE(devicetree_api, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
can probably be backported to 3.6?