### PR TITLE
tracing: sysview: Remove redundant depends on

### DIFF
--- a/subsys/tracing/sysview/Kconfig
+++ b/subsys/tracing/sysview/Kconfig
@@ -5,26 +5,21 @@ if SEGGER_SYSTEMVIEW
 
 config SEGGER_SYSTEMVIEW_BOOT_ENABLE
 	bool "Start logging SystemView events on system start"
-	depends on SEGGER_SYSTEMVIEW
 
 config SEGGER_SYSVIEW_RTT_BUFFER_SIZE
 	int "Buffer size for SystemView RTT"
-	depends on SEGGER_SYSTEMVIEW
 	default 4096
 
 config SEGGER_SYSVIEW_RTT_CHANNEL
 	int "RTT channel for SystemView"
-	depends on SEGGER_SYSTEMVIEW
 	default 0
 
 config SEGGER_SYSVIEW_APP_NAME
 	string "Application name to be displayed in SystemView"
-	depends on SEGGER_SYSTEMVIEW
 	default "ZephyrSysView"
 
 config SEGGER_SYSVIEW_POST_MORTEM_MODE
 	bool "Post-mortem mode for SystemView"
-	depends on SEGGER_SYSTEMVIEW
 
 choice SEGGER_SYSVIEW_SECTION
 	prompt "Choose SystemView data linker section"


### PR DESCRIPTION
Remove redundant depends on statements for SEGGER_SYSTEMVIEW. This is already inside an if SEGGER_SYSTEMVIEW so depends on are already added.