### PR TITLE
Bluetooth: Shell: Replace ctx_shell with logging

### DIFF
--- a/subsys/bluetooth/shell/bredr.c
+++ b/subsys/bluetooth/shell/bredr.c
@@ -27,9 +27,12 @@
 #include <zephyr/bluetooth/rfcomm.h>
 #include <zephyr/bluetooth/sdp.h>
 
+#include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
 
 #include "bt.h"
+
+LOG_MODULE_REGISTER(bredr_shell, LOG_LEVEL_DBG);
 
 #if defined(CONFIG_BT_CONN)
 /* Connection context for BR/EDR legacy pairing in sec mode 3 */
@@ -146,7 +149,7 @@ static void br_device_found(const bt_addr_t *addr, int8_t rssi,
 
 	bt_addr_to_str(addr, br_addr, sizeof(br_addr));
 
-	shell_print(ctx_shell, "[DEVICE]: %s, RSSI %i %s", br_addr, rssi, name);
+	LOG_DBG("[DEVICE]: %s, RSSI %i %s", br_addr, rssi, name);
 }
 
 static struct bt_br_discovery_result br_discovery_results[5];
@@ -156,7 +159,7 @@ static void br_discovery_complete(struct bt_br_discovery_result *results,
 {
 	size_t i;
 
-	shell_print(ctx_shell, "BR/EDR discovery complete");
+	LOG_DBG("BR/EDR discovery complete");
 
 	for (i = 0; i < count; i++) {
 		br_device_found(&results[i].addr, results[i].rssi,
@@ -207,25 +210,24 @@ static int cmd_discovery(const struct shell *sh, size_t argc, char *argv[])
 
 static int l2cap_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 {
-	shell_print(ctx_shell, "Incoming data channel %p len %u", chan,
-		    buf->len);
+	LOG_DBG("Incoming data channel %p len %u", chan, buf->len);
 
 	return 0;
 }
 
 static void l2cap_connected(struct bt_l2cap_chan *chan)
 {
-	shell_print(ctx_shell, "Channel %p connected", chan);
+	LOG_DBG("Channel %p connected", chan);
 }
 
 static void l2cap_disconnected(struct bt_l2cap_chan *chan)
 {
-	shell_print(ctx_shell, "Channel %p disconnected", chan);
+	LOG_DBG("Channel %p disconnected", chan);
 }
 
 static struct net_buf *l2cap_alloc_buf(struct bt_l2cap_chan *chan)
 {
-	shell_print(ctx_shell, "Channel %p requires buffer", chan);
+	LOG_DBG("Channel %p requires buffer", chan);
 
 	return net_buf_alloc(&data_pool, K_FOREVER);
 }
@@ -246,10 +248,10 @@ static struct bt_l2cap_br_chan l2cap_chan = {
 static int l2cap_accept(struct bt_conn *conn, struct bt_l2cap_server *server,
 			struct bt_l2cap_chan **chan)
 {
-	shell_print(ctx_shell, "Incoming BR/EDR conn %p", conn);
+	LOG_DBG("Incoming BR/EDR conn %p", (void *)conn);
 
 	if (l2cap_chan.chan.conn) {
-		shell_error(ctx_shell, "No channels available");
+		LOG_ERR("No channels available");
 		return -ENOMEM;
 	}
 
@@ -369,10 +371,8 @@ static uint8_t sdp_hfp_ag_user(struct bt_conn *conn,
 	conn_addr_str(conn, addr, sizeof(addr));
 
 	if (result) {
-		shell_print(ctx_shell, "SDP HFPAG data@%p (len %u) hint %u from"
-			    " remote %s", result->resp_buf,
-			    result->resp_buf->len, result->next_record_hint,
-			    addr);
+		LOG_DBG("SDP HFPAG data@%p (len %u) hint %u from remote %s", result->resp_buf,
+			result->resp_buf->len, result->next_record_hint, addr);
 
 		/*
 		 * Focus to get BT_SDP_ATTR_PROTO_DESC_LIST attribute item to
@@ -381,21 +381,19 @@ static uint8_t sdp_hfp_ag_user(struct bt_conn *conn,
 		res = bt_sdp_get_proto_param(result->resp_buf,
 					     BT_SDP_PROTO_RFCOMM, &param);
 		if (res < 0) {
-			shell_error(ctx_shell, "Error getting Server CN, "
-				    "err %d", res);
+			LOG_ERR("Error getting Server CN, err %d", res);
 			goto done;
 		}
-		shell_print(ctx_shell, "HFPAG Server CN param 0x%04x", param);
+		LOG_DBG("HFPAG Server CN param 0x%04x", param);
 
 		res = bt_sdp_get_profile_version(result->resp_buf,
 						 BT_SDP_HANDSFREE_SVCLASS,
 						 &version);
 		if (res < 0) {
-			shell_error(ctx_shell, "Error getting profile version, "
-				    "err %d", res);
+			LOG_ERR("Error getting profile version, err %d", res);
 			goto done;
 		}
-		shell_print(ctx_shell, "HFP version param 0x%04x", version);
+		LOG_DBG("HFP version param 0x%04x", version);
 
 		/*
 		 * Focus to get BT_SDP_ATTR_SUPPORTED_FEATURES attribute item to
@@ -403,15 +401,12 @@ static uint8_t sdp_hfp_ag_user(struct bt_conn *conn,
 		 */
 		res = bt_sdp_get_features(result->resp_buf, &features);
 		if (res < 0) {
-			shell_error(ctx_shell, "Error getting HFPAG Features, "
-				    "err %d", res);
+			LOG_ERR("Error getting HFPAG Features, err %d", res);
 			goto done;
 		}
-		shell_print(ctx_shell, "HFPAG Supported Features param 0x%04x",
-		      features);
+		LOG_DBG("HFPAG Supported Features param 0x%04x", features);
 	} else {
-		shell_print(ctx_shell, "No SDP HFPAG data from remote %s",
-			    addr);
+		LOG_DBG("No SDP HFPAG data from remote %s", addr);
 	}
 done:
 	return BT_SDP_DISCOVER_UUID_CONTINUE;
@@ -428,10 +423,8 @@ static uint8_t sdp_a2src_user(struct bt_conn *conn,
 	conn_addr_str(conn, addr, sizeof(addr));
 
 	if (result) {
-		shell_print(ctx_shell, "SDP A2SRC data@%p (len %u) hint %u from"
-			    " remote %s", result->resp_buf,
-			    result->resp_buf->len, result->next_record_hint,
-			    addr);
+		LOG_DBG("SDP A2SRC data@%p (len %u) hint %u from remote %s", result->resp_buf,
+			result->resp_buf->len, result->next_record_hint, addr);
 
 		/*
 		 * Focus to get BT_SDP_ATTR_PROTO_DESC_LIST attribute item to
@@ -440,13 +433,11 @@ static uint8_t sdp_a2src_user(struct bt_conn *conn,
 		res = bt_sdp_get_proto_param(result->resp_buf,
 					     BT_SDP_PROTO_L2CAP, &param);
 		if (res < 0) {
-			shell_error(ctx_shell, "A2SRC PSM Number not found, "
-				    "err %d", res);
+			LOG_ERR("A2SRC PSM Number not found, err %d", res);
 			goto done;
 		}
 
-		shell_print(ctx_shell, "A2SRC Server PSM Number param 0x%04x",
-			    param);
+		LOG_DBG("A2SRC Server PSM Number param 0x%04x", param);
 
 		/*
 		 * Focus to get BT_SDP_ATTR_PROFILE_DESC_LIST attribute item to
@@ -456,11 +447,10 @@ static uint8_t sdp_a2src_user(struct bt_conn *conn,
 						 BT_SDP_ADVANCED_AUDIO_SVCLASS,
 						 &version);
 		if (res < 0) {
-			shell_error(ctx_shell, "A2SRC version not found, "
-				    "err %d", res);
+			LOG_ERR("A2SRC version not found, err %d", res);
 			goto done;
 		}
-		shell_print(ctx_shell, "A2SRC version param 0x%04x", version);
+		LOG_DBG("A2SRC version param 0x%04x", version);
 
 		/*
 		 * Focus to get BT_SDP_ATTR_SUPPORTED_FEATURES attribute item to
@@ -468,15 +458,12 @@ static uint8_t sdp_a2src_user(struct bt_conn *conn,
 		 */
 		res = bt_sdp_get_features(result->resp_buf, &features);
 		if (res < 0) {
-			shell_error(ctx_shell, "A2SRC Features not found, "
-				    "err %d", res);
+			LOG_ERR("A2SRC Features not found, err %d", res);
 			goto done;
 		}
-		shell_print(ctx_shell, "A2SRC Supported Features param 0x%04x",
-		      features);
+		LOG_DBG("A2SRC Supported Features param 0x%04x", features);
 	} else {
-		shell_print(ctx_shell, "No SDP A2SRC data from remote %s",
-			    addr);
+		LOG_DBG("No SDP A2SRC data from remote %s", addr);
 	}
 done:
 	return BT_SDP_DISCOVER_UUID_CONTINUE;

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -33,12 +33,15 @@
 #include <zephyr/bluetooth/sdp.h>
 #include <zephyr/bluetooth/iso.h>
 
+#include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
 
 #include "bt.h"
 #include "ll.h"
 #include "hci.h"
 #include "../audio/shell/audio.h"
+
+LOG_MODULE_REGISTER(bt_shell, LOG_LEVEL_DBG);
 
 static bool no_settings_load;
 
@@ -122,8 +125,7 @@ static void print_le_addr(const char *desc, const bt_addr_le_t *addr)
 
 	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 
-	shell_print(ctx_shell, "%s address: %s (%s)", desc, addr_str,
-		    addr_desc);
+	LOG_DBG("%s address: %s (%s)", desc, addr_str, addr_desc);
 }
 #endif /* CONFIG_BT_CONN || (CONFIG_BT_BROADCASTER && CONFIG_BT_EXT_ADV) */
 
@@ -198,6 +200,7 @@ static struct bt_auto_connect {
 	bt_addr_le_t addr;
 	bool addr_set;
 	bool connect_name;
+	const struct shell *sh;
 } auto_connect;
 #endif
 
@@ -261,17 +264,28 @@ static bool data_cb(struct bt_data *data, void *user_data)
 	}
 }
 
-static void print_data_hex(const uint8_t *data, uint8_t len, enum shell_vt100_color color)
+/* Log a hex value as big-endian */
+static void print_data_hex_be(const uint8_t *data, uint8_t len, enum shell_vt100_color color)
 {
-	if (len == 0)
-		return;
+	static char data_str[UINT8_MAX + 1 /* null terminator */];
 
-	shell_fprintf(ctx_shell, color, "0x");
+	if (len == 0) {
+		return;
+	}
+
+	memset(data_str, 0, sizeof(data_str));
+
 	/* Reverse the byte order when printing as advertising data is LE
 	 * and the MSB should be first in the printed output.
 	 */
-	for (int16_t i = len - 1; i >= 0; i--) {
-		shell_fprintf(ctx_shell, color, "%02x", data[i]);
+	for (uint16_t i = len - 1, j = 3; i >= 0; i--, j++) {
+		hex2char(data[i], &data_str[j]);
+	}
+
+	if (color == SHELL_WARNING) {
+		LOG_WRN("\t\tExcess data: 0x%s", data_str);
+	} else {
+		LOG_DBG("\t\t0x%s", data_str);
 	}
 }
 
@@ -285,24 +299,18 @@ static void print_data_set(uint8_t set_value_len,
 	}
 
 	do {
-		if (idx > 0) {
-			shell_fprintf(ctx_shell, SHELL_INFO, ADV_DATA_DELIMITER);
-		}
-
-		print_data_hex(&scan_data[idx], set_value_len, SHELL_INFO);
+		print_data_hex_be(&scan_data[idx], set_value_len, SHELL_INFO);
 		idx += set_value_len;
 	} while (idx + set_value_len <= scan_data_len);
 
 	if (idx < scan_data_len) {
-		shell_fprintf(ctx_shell, SHELL_WARNING, " Excess data: ");
-		print_data_hex(&scan_data[idx], scan_data_len - idx, SHELL_WARNING);
+		print_data_hex_be(&scan_data[idx], scan_data_len - idx, SHELL_WARNING);
 	}
 }
 
 static bool data_verbose_cb(struct bt_data *data, void *user_data)
 {
-	shell_fprintf(ctx_shell, SHELL_INFO, "%*sType 0x%02x: ",
-		      strlen(scan_response_label), "", data->type);
+	LOG_DBG("\tType 0x%02x: ", data->type);
 
 	switch (data->type) {
 	case BT_DATA_UUID16_SOME:
@@ -315,17 +323,18 @@ static bool data_verbose_cb(struct bt_data *data, void *user_data)
 		 * the rest is unknown and printed as single bytes
 		 */
 		if (data->data_len < BT_UUID_SIZE_16) {
-			shell_fprintf(ctx_shell, SHELL_WARNING,
-				      "BT_DATA_SVC_DATA16 data length too short (%u)",
-				      data->data_len);
+			LOG_WRN("\t\tBT_DATA_SVC_DATA16 data length too short (%u)",
+				data->data_len);
 			break;
 		}
+
 		print_data_set(BT_UUID_SIZE_16, data->data, BT_UUID_SIZE_16);
 		if (data->data_len > BT_UUID_SIZE_16) {
-			shell_fprintf(ctx_shell, SHELL_INFO, ADV_DATA_DELIMITER);
-			print_data_set(1, data->data + BT_UUID_SIZE_16,
+			print_data_set(data->data_len - BT_UUID_SIZE_16,
+				       data->data + BT_UUID_SIZE_16,
 				       data->data_len - BT_UUID_SIZE_16);
 		}
+
 		break;
 	case BT_DATA_UUID32_SOME:
 	case BT_DATA_UUID32_ALL:
@@ -336,17 +345,19 @@ static bool data_verbose_cb(struct bt_data *data, void *user_data)
 		 * the rest is unknown and printed as single bytes
 		 */
 		if (data->data_len < BT_UUID_SIZE_32) {
-			shell_fprintf(ctx_shell, SHELL_WARNING,
-				      "BT_DATA_SVC_DATA32 data length too short (%u)",
-				      data->data_len);
+			LOG_WRN("\t\tBT_DATA_SVC_DATA32 data length too short (%u)",
+				data->data_len);
 			break;
 		}
+
 		print_data_set(BT_UUID_SIZE_32, data->data, BT_UUID_SIZE_32);
+
 		if (data->data_len > BT_UUID_SIZE_32) {
-			shell_fprintf(ctx_shell, SHELL_INFO, ADV_DATA_DELIMITER);
-			print_data_set(1, data->data + BT_UUID_SIZE_32,
+			print_data_set(data->data_len - BT_UUID_SIZE_32,
+				       data->data + BT_UUID_SIZE_32,
 				       data->data_len - BT_UUID_SIZE_32);
 		}
+
 		break;
 	case BT_DATA_UUID128_SOME:
 	case BT_DATA_UUID128_ALL:
@@ -358,22 +369,23 @@ static bool data_verbose_cb(struct bt_data *data, void *user_data)
 		 * the rest is unknown and printed as single bytes
 		 */
 		if (data->data_len < BT_UUID_SIZE_128) {
-			shell_fprintf(ctx_shell, SHELL_WARNING,
-				      "BT_DATA_SVC_DATA128 data length too short (%u)",
-				      data->data_len);
+			LOG_WRN("\t\tBT_DATA_SVC_DATA128 data length too short (%u)",
+				data->data_len);
 			break;
 		}
+
 		print_data_set(BT_UUID_SIZE_128, data->data, BT_UUID_SIZE_128);
 		if (data->data_len > BT_UUID_SIZE_128) {
-			shell_fprintf(ctx_shell, SHELL_INFO, ADV_DATA_DELIMITER);
-			print_data_set(1, data->data + BT_UUID_SIZE_128,
+			print_data_set(data->data_len - BT_UUID_SIZE_128,
+				       data->data + BT_UUID_SIZE_128,
 				       data->data_len - BT_UUID_SIZE_128);
 		}
+
 		break;
 	case BT_DATA_NAME_SHORTENED:
 	case BT_DATA_NAME_COMPLETE:
 	case BT_DATA_BROADCAST_NAME:
-		shell_fprintf(ctx_shell, SHELL_INFO, "%.*s", data->data_len, data->data);
+		LOG_HEXDUMP_DBG(data->data, data->data_len, "\t\tName:");
 		break;
 	case BT_DATA_PUB_TARGET_ADDR:
 	case BT_DATA_RAND_TARGET_ADDR:
@@ -384,10 +396,8 @@ static bool data_verbose_cb(struct bt_data *data, void *user_data)
 		print_data_set(3, data->data, data->data_len);
 		break;
 	default:
-		print_data_set(1, data->data, data->data_len);
+		print_data_set(data->data_len, data->data, data->data_len);
 	}
-
-	shell_fprintf(ctx_shell, SHELL_INFO, "\n");
 
 	return true;
 }
@@ -470,27 +480,21 @@ static void scan_recv(const struct bt_le_scan_recv_info *info, struct net_buf_si
 	bt_data_parse(buf, data_cb, name);
 	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
-	shell_print(ctx_shell, "%s%s, AD evt type %u, RSSI %i %s "
-		    "C:%u S:%u D:%d SR:%u E:%u Prim: %s, Secn: %s, "
-		    "Interval: 0x%04x (%u us), SID: 0x%x",
-		    scan_response_label,
-		    le_addr, info->adv_type, info->rssi, name,
-		    (info->adv_props & BT_GAP_ADV_PROP_CONNECTABLE) != 0,
-		    (info->adv_props & BT_GAP_ADV_PROP_SCANNABLE) != 0,
-		    (info->adv_props & BT_GAP_ADV_PROP_DIRECTED) != 0,
-		    (info->adv_props & BT_GAP_ADV_PROP_SCAN_RESPONSE) != 0,
-		    (info->adv_props & BT_GAP_ADV_PROP_EXT_ADV) != 0,
-		    phy2str(info->primary_phy), phy2str(info->secondary_phy),
-		    info->interval, BT_CONN_INTERVAL_TO_US(info->interval),
-		    info->sid);
+	LOG_DBG("%s%s, AD evt type %u, RSSI %i %s C:%u S:%u D:%d SR:%u E:%u Prim: %s, Secn: %s, "
+		"Interval: 0x%04x (%u us), SID: 0x%x",
+		scan_response_label, le_addr, info->adv_type, info->rssi, name,
+		(info->adv_props & BT_GAP_ADV_PROP_CONNECTABLE) != 0,
+		(info->adv_props & BT_GAP_ADV_PROP_SCANNABLE) != 0,
+		(info->adv_props & BT_GAP_ADV_PROP_DIRECTED) != 0,
+		(info->adv_props & BT_GAP_ADV_PROP_SCAN_RESPONSE) != 0,
+		(info->adv_props & BT_GAP_ADV_PROP_EXT_ADV) != 0, phy2str(info->primary_phy),
+		phy2str(info->secondary_phy), info->interval,
+		BT_CONN_INTERVAL_TO_US(info->interval), info->sid);
 
 	if (scan_verbose_output) {
-		shell_info(ctx_shell,
-			   "%*s[SCAN DATA START - %s]",
-			   strlen(scan_response_label), "",
-			   scan_response_type_txt(info->adv_type));
+		LOG_DBG("\t[SCAN DATA START - %s]", scan_response_type_txt(info->adv_type));
 		bt_data_parse(&buf_copy, data_verbose_cb, NULL);
-		shell_info(ctx_shell, "%*s[SCAN DATA END]", strlen(scan_response_label), "");
+		LOG_DBG("\t[SCAN DATA END]");
 	}
 
 #if defined(CONFIG_BT_CENTRAL)
@@ -507,13 +511,13 @@ static void scan_recv(const struct bt_le_scan_recv_info *info, struct net_buf_si
 			if (auto_connect.connect_name) {
 				auto_connect.connect_name = false;
 
-				cmd_scan_off(ctx_shell);
+				cmd_scan_off(auto_connect.sh);
 
 				/* "name" is what would be in argv[0] normally */
-				cmd_scan_filter_clear_name(ctx_shell, 1, (char *[]){"name"});
+				cmd_scan_filter_clear_name(auto_connect.sh, 1, (char *[]){"name"});
 
 				/* "connect" is what would be in argv[0] normally */
-				cmd_connect_le(ctx_shell, 1, (char *[]){"connect"});
+				cmd_connect_le(auto_connect.sh, 1, (char *[]){"connect"});
 			}
 		} else {
 			bt_conn_unref(conn);
@@ -524,13 +528,14 @@ static void scan_recv(const struct bt_le_scan_recv_info *info, struct net_buf_si
 
 static void scan_timeout(void)
 {
-	shell_print(ctx_shell, "Scan timeout");
+	LOG_DBG("Scan timeout");
 
 #if defined(CONFIG_BT_CENTRAL)
 	if (auto_connect.connect_name) {
 		auto_connect.connect_name = false;
 		/* "name" is what would be in argv[0] normally */
-		cmd_scan_filter_clear_name(ctx_shell, 1, (char *[]){ "name" });
+		cmd_scan_filter_clear_name(auto_connect.sh, 1, (char *[]){"name"});
+		auto_connect.sh = NULL;
 	}
 #endif /* CONFIG_BT_CENTRAL */
 }
@@ -541,8 +546,8 @@ static void scan_timeout(void)
 static void adv_sent(struct bt_le_ext_adv *adv,
 		     struct bt_le_ext_adv_sent_info *info)
 {
-	shell_print(ctx_shell, "Advertiser[%d] %p sent %d",
-		    bt_le_ext_adv_get_index(adv), adv, info->num_sent);
+	LOG_DBG("Advertiser[%d] %p sent %d", bt_le_ext_adv_get_index(adv), (void *)adv,
+		info->num_sent);
 }
 
 static void adv_scanned(struct bt_le_ext_adv *adv,
@@ -552,8 +557,7 @@ static void adv_scanned(struct bt_le_ext_adv *adv,
 
 	bt_addr_le_to_str(info->addr, str, sizeof(str));
 
-	shell_print(ctx_shell, "Advertiser[%d] %p scanned by %s",
-		    bt_le_ext_adv_get_index(adv), adv, str);
+	LOG_DBG("Advertiser[%d] %p scanned by %s", bt_le_ext_adv_get_index(adv), (void *)adv, str);
 }
 #endif /* CONFIG_BT_BROADCASTER */
 
@@ -565,8 +569,8 @@ static void adv_connected(struct bt_le_ext_adv *adv,
 
 	bt_addr_le_to_str(bt_conn_get_dst(info->conn), str, sizeof(str));
 
-	shell_print(ctx_shell, "Advertiser[%d] %p connected by %s",
-		    bt_le_ext_adv_get_index(adv), adv, str);
+	LOG_DBG("Advertiser[%d] %p connected by %s", bt_le_ext_adv_get_index(adv), (void *)adv,
+		str);
 }
 #endif /* CONFIG_BT_PERIPHERAL */
 
@@ -577,9 +581,8 @@ static bool adv_rpa_expired(struct bt_le_ext_adv *adv)
 
 	bool keep_rpa = atomic_test_bit(adv_set_opt[adv_index],
 					  SHELL_ADV_OPT_KEEP_RPA);
-	shell_print(ctx_shell, "Advertiser[%d] %p RPA %s",
-		    adv_index, adv,
-		    keep_rpa ? "not expired" : "expired");
+	LOG_DBG("Advertiser[%d] %p RPA %s", adv_index, (void *)adv,
+		keep_rpa ? "not expired" : "expired");
 
 	return keep_rpa;
 }
@@ -669,16 +672,15 @@ static void connected(struct bt_conn *conn, uint8_t err)
 	conn_addr_str(conn, addr, sizeof(addr));
 
 	if (err) {
-		shell_error(ctx_shell, "Failed to connect to %s (0x%02x)", addr,
-			     err);
+		LOG_ERR("Failed to connect to %s (0x%02x)", addr, err);
 		goto done;
 	}
 
-	shell_print(ctx_shell, "Connected: %s", addr);
+	LOG_DBG("Connected: %s", addr);
 
 	info_err = bt_conn_get_info(conn, &info);
 	if (info_err != 0) {
-		shell_error(ctx_shell, "Failed to connection information: %d", info_err);
+		LOG_ERR("Failed to connection information: %d", info_err);
 		goto done;
 	}
 
@@ -712,7 +714,7 @@ static void disconnected_set_new_default_conn_cb(struct bt_conn *conn, void *use
 	}
 
 	if (bt_conn_get_info(conn, &info) != 0) {
-		shell_error(ctx_shell, "Unable to get info: conn %p", conn);
+		LOG_ERR("Unable to get info: conn %p", (void *)conn);
 		return;
 	}
 
@@ -722,7 +724,7 @@ static void disconnected_set_new_default_conn_cb(struct bt_conn *conn, void *use
 		default_conn = bt_conn_ref(conn);
 
 		bt_addr_le_to_str(info.le.dst, addr_str, sizeof(addr_str));
-		shell_print(ctx_shell, "Selected conn is now: %s", addr_str);
+		LOG_DBG("Selected conn is now: %s", addr_str);
 	}
 }
 
@@ -731,7 +733,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	char addr[BT_ADDR_LE_STR_LEN];
 
 	conn_addr_str(conn, addr, sizeof(addr));
-	shell_print(ctx_shell, "Disconnected: %s (reason 0x%02x)", addr, reason);
+	LOG_DBG("Disconnected: %s (reason 0x%02x)", addr, reason);
 
 	if (default_conn == conn) {
 		bt_conn_unref(default_conn);
@@ -744,9 +746,8 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 
 static bool le_param_req(struct bt_conn *conn, struct bt_le_conn_param *param)
 {
-	shell_print(ctx_shell, "LE conn  param req: int (0x%04x, 0x%04x) lat %d"
-		    " to %d", param->interval_min, param->interval_max,
-		    param->latency, param->timeout);
+	LOG_DBG("LE conn  param req: int (0x%04x, 0x%04x) lat %d to %d", param->interval_min,
+		param->interval_max, param->latency, param->timeout);
 
 	return true;
 }
@@ -754,8 +755,7 @@ static bool le_param_req(struct bt_conn *conn, struct bt_le_conn_param *param)
 static void le_param_updated(struct bt_conn *conn, uint16_t interval,
 			     uint16_t latency, uint16_t timeout)
 {
-	shell_print(ctx_shell, "LE conn param updated: int 0x%04x lat %d "
-		     "to %d", interval, latency, timeout);
+	LOG_DBG("LE conn param updated: int 0x%04x lat %d to %d", interval, latency, timeout);
 }
 
 #if defined(CONFIG_BT_SMP)
@@ -768,8 +768,7 @@ static void identity_resolved(struct bt_conn *conn, const bt_addr_le_t *rpa,
 	bt_addr_le_to_str(identity, addr_identity, sizeof(addr_identity));
 	bt_addr_le_to_str(rpa, addr_rpa, sizeof(addr_rpa));
 
-	shell_print(ctx_shell, "Identity resolved %s -> %s", addr_rpa,
-	      addr_identity);
+	LOG_DBG("Identity resolved %s -> %s", addr_rpa, addr_identity);
 }
 #endif
 
@@ -808,12 +807,10 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
 	conn_addr_str(conn, addr, sizeof(addr));
 
 	if (!err) {
-		shell_print(ctx_shell, "Security changed: %s level %u", addr,
-			    level);
+		LOG_DBG("Security changed: %s level %u", addr, level);
 	} else {
-		shell_print(ctx_shell, "Security failed: %s level %u "
-			    "reason: %s (%d)",
-			    addr, level, security_err_str(err), err);
+		LOG_DBG("Security failed: %s level %u reason: %s (%d)", addr, level,
+			security_err_str(err), err);
 	}
 }
 #endif
@@ -841,11 +838,9 @@ static void remote_info_available(struct bt_conn *conn,
 	bt_conn_get_info(conn, &info);
 
 	if (IS_ENABLED(CONFIG_BT_REMOTE_VERSION)) {
-		shell_print(ctx_shell,
-			    "Remote LMP version %s (0x%02x) subversion 0x%04x "
-			    "manufacturer 0x%04x", ver_str(remote_info->version),
-			    remote_info->version, remote_info->subversion,
-			    remote_info->manufacturer);
+		LOG_DBG("Remote LMP version %s (0x%02x) subversion 0x%04x manufacturer 0x%04x",
+			ver_str(remote_info->version), remote_info->version,
+			remote_info->subversion, remote_info->manufacturer);
 	}
 
 	if (info.type == BT_CONN_TYPE_LE) {
@@ -856,7 +851,7 @@ static void remote_info_available(struct bt_conn *conn,
 				sizeof(features));
 		bin2hex(features, sizeof(features),
 			features_str, sizeof(features_str));
-		shell_print(ctx_shell, "LE Features: 0x%s ", features_str);
+		LOG_DBG("LE Features: 0x%s ", features_str);
 	}
 }
 #endif /* defined(CONFIG_BT_REMOTE_INFO) */
@@ -865,10 +860,8 @@ static void remote_info_available(struct bt_conn *conn,
 void le_data_len_updated(struct bt_conn *conn,
 			 struct bt_conn_le_data_len_info *info)
 {
-	shell_print(ctx_shell,
-		    "LE data len updated: TX (len: %d time: %d)"
-		    " RX (len: %d time: %d)", info->tx_max_len,
-		    info->tx_max_time, info->rx_max_len, info->rx_max_time);
+	LOG_DBG("LE data len updated: TX (len: %d time: %d) RX (len: %d time: %d)",
+		info->tx_max_len, info->tx_max_time, info->rx_max_len, info->rx_max_time);
 }
 #endif
 
@@ -876,8 +869,8 @@ void le_data_len_updated(struct bt_conn *conn,
 void le_phy_updated(struct bt_conn *conn,
 		    struct bt_conn_le_phy_info *info)
 {
-	shell_print(ctx_shell, "LE PHY updated: TX PHY %s, RX PHY %s",
-		    phy2str(info->tx_phy), phy2str(info->rx_phy));
+	LOG_DBG("LE PHY updated: TX PHY %s, RX PHY %s", phy2str(info->tx_phy),
+		phy2str(info->rx_phy));
 }
 #endif
 
@@ -885,11 +878,11 @@ void le_phy_updated(struct bt_conn *conn,
 void tx_power_report(struct bt_conn *conn,
 		    const struct bt_conn_le_tx_power_report *report)
 {
-	shell_print(ctx_shell, "Tx Power Report: Reason: %s, PHY: %s, Tx Power Level: %d",
-		    tx_power_report_reason2str(report->reason), tx_pwr_ctrl_phy2str(report->phy),
-		    report->tx_power_level);
-	shell_print(ctx_shell, "Tx Power Level Flag Info: %s, Delta: %d",
-		    tx_power_flag2str(report->tx_power_level_flag), report->delta);
+	LOG_DBG("Tx Power Report: Reason: %s, PHY: %s, Tx Power Level: %d",
+		tx_power_report_reason2str(report->reason), tx_pwr_ctrl_phy2str(report->phy),
+		report->tx_power_level);
+	LOG_DBG("Tx Power Level Flag Info: %s, Delta: %d",
+		tx_power_flag2str(report->tx_power_level_flag), report->delta);
 }
 #endif
 
@@ -961,12 +954,11 @@ static void per_adv_sync_sync_cb(struct bt_le_per_adv_sync *sync,
 		conn_addr_str(info->conn, past_peer, sizeof(past_peer));
 	}
 
-	shell_print(ctx_shell, "PER_ADV_SYNC[%u]: [DEVICE]: %s synced, "
-		    "Interval 0x%04x (%u us), PHY %s, SD 0x%04X, PAST peer %s",
-		    bt_le_per_adv_sync_get_index(sync), le_addr,
-		    info->interval, BT_CONN_INTERVAL_TO_US(info->interval),
-		    phy2str(info->phy), info->service_data,
-		    is_past_peer ? past_peer : "not present");
+	LOG_DBG("PER_ADV_SYNC[%u]: [DEVICE]: %s synced, Interval 0x%04x (%u us), PHY %s, SD "
+		"0x%04X, PAST peer %s",
+		bt_le_per_adv_sync_get_index(sync), le_addr, info->interval,
+		BT_CONN_INTERVAL_TO_US(info->interval), phy2str(info->phy), info->service_data,
+		is_past_peer ? past_peer : "not present");
 
 	if (info->conn) { /* if from PAST */
 		for (int i = 0; i < ARRAY_SIZE(per_adv_syncs); i++) {
@@ -992,8 +984,8 @@ static void per_adv_sync_terminated_cb(
 	}
 
 	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
-	shell_print(ctx_shell, "PER_ADV_SYNC[%u]: [DEVICE]: %s sync terminated",
-		    bt_le_per_adv_sync_get_index(sync), le_addr);
+	LOG_DBG("PER_ADV_SYNC[%u]: [DEVICE]: %s sync terminated",
+		bt_le_per_adv_sync_get_index(sync), le_addr);
 }
 
 static void per_adv_sync_recv_cb(
@@ -1004,10 +996,9 @@ static void per_adv_sync_recv_cb(
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
 	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
-	shell_print(ctx_shell, "PER_ADV_SYNC[%u]: [DEVICE]: %s, tx_power %i, "
-		    "RSSI %i, CTE %u, data length %u",
-		    bt_le_per_adv_sync_get_index(sync), le_addr, info->tx_power,
-		    info->rssi, info->cte_type, buf->len);
+	LOG_DBG("PER_ADV_SYNC[%u]: [DEVICE]: %s, tx_power %i, RSSI %i, CTE %u, data length %u",
+		bt_le_per_adv_sync_get_index(sync), le_addr, info->tx_power, info->rssi,
+		info->cte_type, buf->len);
 }
 
 static void per_adv_sync_biginfo_cb(struct bt_le_per_adv_sync *sync,
@@ -1016,16 +1007,15 @@ static void per_adv_sync_biginfo_cb(struct bt_le_per_adv_sync *sync,
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
 	bt_addr_le_to_str(biginfo->addr, le_addr, sizeof(le_addr));
-	shell_print(ctx_shell, "BIG_INFO PER_ADV_SYNC[%u]: [DEVICE]: %s, sid 0x%02x, num_bis %u, "
-		    "nse 0x%02x, interval 0x%04x (%u us), bn 0x%02x, pto 0x%02x, irc 0x%02x, "
-		    "max_pdu 0x%04x, sdu_interval 0x%04x, max_sdu 0x%04x, phy %s, framing 0x%02x, "
-		    "%sencrypted",
-		    bt_le_per_adv_sync_get_index(sync), le_addr, biginfo->sid, biginfo->num_bis,
-		    biginfo->sub_evt_count, biginfo->iso_interval,
-		    BT_CONN_INTERVAL_TO_US(biginfo->iso_interval), biginfo->burst_number,
-		    biginfo->offset, biginfo->rep_count, biginfo->max_pdu, biginfo->sdu_interval,
-		    biginfo->max_sdu, phy2str(biginfo->phy), biginfo->framing,
-		    biginfo->encryption ? "" : "not ");
+	LOG_DBG("BIG_INFO PER_ADV_SYNC[%u]: [DEVICE]: %s, sid 0x%02x, num_bis %u, nse 0x%02x, "
+		"interval 0x%04x (%u us), bn 0x%02x, pto 0x%02x, irc 0x%02x, max_pdu 0x%04x, "
+		"sdu_interval 0x%04x, max_sdu 0x%04x, phy %s, framing 0x%02x, %sencrypted",
+		bt_le_per_adv_sync_get_index(sync), le_addr, biginfo->sid, biginfo->num_bis,
+		biginfo->sub_evt_count, biginfo->iso_interval,
+		BT_CONN_INTERVAL_TO_US(biginfo->iso_interval), biginfo->burst_number,
+		biginfo->offset, biginfo->rep_count, biginfo->max_pdu, biginfo->sdu_interval,
+		biginfo->max_sdu, phy2str(biginfo->phy), biginfo->framing,
+		biginfo->encryption ? "" : "not ");
 }
 
 static struct bt_le_per_adv_sync_cb per_adv_sync_cb = {
@@ -1039,15 +1029,15 @@ static struct bt_le_per_adv_sync_cb per_adv_sync_cb = {
 static void bt_ready(int err)
 {
 	if (err) {
-		shell_error(ctx_shell, "Bluetooth init failed (err %d)", err);
+		LOG_ERR("Bluetooth init failed (err %d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Bluetooth initialized");
+	LOG_DBG("Bluetooth initialized");
 
 	if (IS_ENABLED(CONFIG_SETTINGS) && !no_settings_load) {
 		settings_load();
-		shell_print(ctx_shell, "Settings Loaded");
+		LOG_DBG("Settings Loaded");
 	}
 
 	if (IS_ENABLED(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)) {
@@ -1494,8 +1484,7 @@ static int cmd_scan_filter_set_name(const struct shell *sh, size_t argc,
 	const char *name_arg = argv[1];
 
 	if (strlen(name_arg) >= sizeof(scan_filter.name)) {
-		shell_error(ctx_shell, "Name is too long (max %zu): %s\n",
-			    sizeof(scan_filter.name), name_arg);
+		LOG_ERR("Name is too long (max %zu): %s\n", sizeof(scan_filter.name), name_arg);
 		return -ENOEXEC;
 	}
 
@@ -1513,8 +1502,7 @@ static int cmd_scan_filter_set_addr(const struct shell *sh, size_t argc,
 
 	/* Validate length including null terminator. */
 	if (strlen(addr_arg) > max_cpy_len) {
-		shell_error(ctx_shell, "Invalid address string: %s\n",
-			    addr_arg);
+		LOG_ERR("Invalid address string: %s\n", addr_arg);
 		return -ENOEXEC;
 	}
 
@@ -1524,9 +1512,7 @@ static int cmd_scan_filter_set_addr(const struct shell *sh, size_t argc,
 		uint8_t tmp;
 
 		if (c != ':' && char2hex(c, &tmp) < 0) {
-			shell_error(ctx_shell,
-					"Invalid address string: %s\n",
-					addr_arg);
+			LOG_ERR("Invalid address string: %s\n", addr_arg);
 			return -ENOEXEC;
 		}
 	}
@@ -1677,7 +1663,7 @@ static ssize_t ad_init(struct bt_data *data_array, const size_t data_array_size,
 		csis_ad_len = csis_ad_data_add(&data_array[ad_len],
 					       data_array_size - ad_len, discoverable);
 		if (csis_ad_len < 0) {
-			shell_error(ctx_shell, "Failed to add CSIS data (err %d)", csis_ad_len);
+			LOG_ERR("Failed to add CSIS data (err %d)", csis_ad_len);
 			return ad_len;
 		}
 
@@ -2171,7 +2157,7 @@ static int cmd_adv_delete(const struct shell *sh, size_t argc, char *argv[])
 
 	err = bt_le_ext_adv_delete(adv);
 	if (err) {
-		shell_error(ctx_shell, "Failed to delete advertiser set");
+		LOG_ERR("Failed to delete advertiser set");
 		return err;
 	}
 
@@ -2921,6 +2907,7 @@ static int cmd_connect_le_name(const struct shell *sh, size_t argc, char *argv[]
 
 	/* Set boolean to tell the scan callback to connect to this name */
 	auto_connect.connect_name = true;
+	auto_connect.sh = sh;
 
 	return 0;
 }
@@ -3059,14 +3046,12 @@ static int cmd_info(const struct shell *sh, size_t argc, char *argv[])
 
 	err = bt_conn_get_info(conn, &info);
 	if (err) {
-		shell_print(ctx_shell, "Failed to get info");
+		LOG_DBG("Failed to get info");
 		goto done;
 	}
 
-	shell_print(ctx_shell, "Type: %s, Role: %s, Id: %u",
-		    get_conn_type_str(info.type),
-		    get_conn_role_str(info.role),
-		    info.id);
+	LOG_DBG("Type: %s, Role: %s, Id: %u", get_conn_type_str(info.type),
+		get_conn_role_str(info.role), info.id);
 
 	if (info.type == BT_CONN_TYPE_LE) {
 		print_le_addr("Remote", info.le.dst);
@@ -3074,25 +3059,19 @@ static int cmd_info(const struct shell *sh, size_t argc, char *argv[])
 		print_le_addr("Remote on-air", info.le.remote);
 		print_le_addr("Local on-air", info.le.local);
 
-		shell_print(ctx_shell, "Interval: 0x%04x (%u us)",
-			    info.le.interval,
-			    BT_CONN_INTERVAL_TO_US(info.le.interval));
-		shell_print(ctx_shell, "Latency: 0x%04x",
-			    info.le.latency);
-		shell_print(ctx_shell, "Supervision timeout: 0x%04x (%d ms)",
-			    info.le.timeout, info.le.timeout * 10);
+		LOG_DBG("Interval: 0x%04x (%u us)", info.le.interval,
+			BT_CONN_INTERVAL_TO_US(info.le.interval));
+		LOG_DBG("Latency: 0x%04x", info.le.latency);
+		LOG_DBG("Supervision timeout: 0x%04x (%d ms)", info.le.timeout,
+			info.le.timeout * 10);
 #if defined(CONFIG_BT_USER_PHY_UPDATE)
-		shell_print(ctx_shell, "LE PHY: TX PHY %s, RX PHY %s",
-			    phy2str(info.le.phy->tx_phy),
-			    phy2str(info.le.phy->rx_phy));
+		LOG_DBG("LE PHY: TX PHY %s, RX PHY %s", phy2str(info.le.phy->tx_phy),
+			phy2str(info.le.phy->rx_phy));
 #endif
 #if defined(CONFIG_BT_USER_DATA_LEN_UPDATE)
-		shell_print(ctx_shell, "LE data len: TX (len: %d time: %d)"
-			    " RX (len: %d time: %d)",
-			    info.le.data_len->tx_max_len,
-			    info.le.data_len->tx_max_time,
-			    info.le.data_len->rx_max_len,
-			    info.le.data_len->rx_max_time);
+		LOG_DBG("LE data len: TX (len: %d time: %d) RX (len: %d time: %d)",
+			info.le.data_len->tx_max_len, info.le.data_len->tx_max_time,
+			info.le.data_len->rx_max_len, info.le.data_len->rx_max_time);
 #endif
 	}
 
@@ -3101,7 +3080,7 @@ static int cmd_info(const struct shell *sh, size_t argc, char *argv[])
 		char addr_str[BT_ADDR_STR_LEN];
 
 		bt_addr_to_str(info.br.dst, addr_str, sizeof(addr_str));
-		shell_print(ctx_shell, "Peer address %s", addr_str);
+		LOG_DBG("Peer address %s", addr_str);
 	}
 #endif /* defined(CONFIG_BT_BREDR) */
 
@@ -3439,7 +3418,7 @@ static void bond_info(const struct bt_bond_info *info, void *user_data)
 	int *bond_count = user_data;
 
 	bt_addr_le_to_str(&info->addr, addr, sizeof(addr));
-	shell_print(ctx_shell, "Remote Identity: %s", addr);
+	LOG_DBG("Remote Identity: %s", addr);
 	(*bond_count)++;
 }
 
@@ -3473,7 +3452,7 @@ static void connection_info(struct bt_conn *conn, void *user_data)
 	struct bt_conn_info info;
 
 	if (bt_conn_get_info(conn, &info) < 0) {
-		shell_error(ctx_shell, "Unable to get info: conn %p", conn);
+		LOG_ERR("Unable to get info: conn %p", (void *)conn);
 		return;
 	}
 
@@ -3481,19 +3460,19 @@ static void connection_info(struct bt_conn *conn, void *user_data)
 #if defined(CONFIG_BT_BREDR)
 	case BT_CONN_TYPE_BR:
 		bt_addr_to_str(info.br.dst, addr, sizeof(addr));
-		shell_print(ctx_shell, " #%u [BR][%s] %s", info.id, role_str(info.role), addr);
+		LOG_DBG(" #%u [BR][%s] %s", info.id, role_str(info.role), addr);
 		break;
 #endif
 	case BT_CONN_TYPE_LE:
 		bt_addr_le_to_str(info.le.dst, addr, sizeof(addr));
-		shell_print(ctx_shell, "%s#%u [LE][%s] %s: Interval %u latency %u timeout %u",
-			    conn == default_conn ? "*" : " ", info.id, role_str(info.role), addr,
-			    info.le.interval, info.le.latency, info.le.timeout);
+		LOG_DBG("%s#%u [LE][%s] %s: Interval %u latency %u timeout %u",
+			conn == default_conn ? "*" : " ", info.id, role_str(info.role), addr,
+			info.le.interval, info.le.latency, info.le.timeout);
 		break;
 #if defined(CONFIG_BT_ISO)
 	case BT_CONN_TYPE_ISO:
 		bt_addr_le_to_str(info.le.dst, addr, sizeof(addr));
-		shell_print(ctx_shell, " #%u [ISO][%s] %s", info.id, role_str(info.role), addr);
+		LOG_DBG(" #%u [ISO][%s] %s", info.id, role_str(info.role), addr);
 		break;
 #endif
 	default:
@@ -3523,7 +3502,7 @@ static void auth_passkey_display(struct bt_conn *conn, unsigned int passkey)
 
 	snprintk(passkey_str, 7, "%06u", passkey);
 
-	shell_print(ctx_shell, "Passkey for %s: %s", addr, passkey_str);
+	LOG_DBG("Passkey for %s: %s", addr, passkey_str);
 }
 
 #if defined(CONFIG_BT_PASSKEY_KEYPRESS)
@@ -3534,8 +3513,7 @@ static void auth_passkey_display_keypress(struct bt_conn *conn,
 
 	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
-	shell_print(ctx_shell, "Passkey keypress notification from %s: type %d",
-		    addr, type);
+	LOG_DBG("Passkey keypress notification from %s: type %d", addr, type);
 }
 #endif
 
@@ -3548,7 +3526,7 @@ static void auth_passkey_confirm(struct bt_conn *conn, unsigned int passkey)
 
 	snprintk(passkey_str, 7, "%06u", passkey);
 
-	shell_print(ctx_shell, "Confirm passkey for %s: %s", addr, passkey_str);
+	LOG_DBG("Confirm passkey for %s: %s", addr, passkey_str);
 }
 
 static void auth_passkey_entry(struct bt_conn *conn)
@@ -3557,7 +3535,7 @@ static void auth_passkey_entry(struct bt_conn *conn)
 
 	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
-	shell_print(ctx_shell, "Enter passkey for %s", addr);
+	LOG_DBG("Enter passkey for %s", addr);
 }
 
 static void auth_cancel(struct bt_conn *conn)
@@ -3566,7 +3544,7 @@ static void auth_cancel(struct bt_conn *conn)
 
 	conn_addr_str(conn, addr, sizeof(addr));
 
-	shell_print(ctx_shell, "Pairing cancelled: %s", addr);
+	LOG_DBG("Pairing cancelled: %s", addr);
 
 	/* clear connection reference for sec mode 3 pairing */
 	if (pairing_conn) {
@@ -3581,7 +3559,7 @@ static void auth_pairing_confirm(struct bt_conn *conn)
 
 	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
-	shell_print(ctx_shell, "Confirm pairing for %s", addr);
+	LOG_DBG("Confirm pairing for %s", addr);
 }
 
 #if !defined(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)
@@ -3627,9 +3605,7 @@ static void auth_pairing_oob_data_request(struct bt_conn *conn,
 		if (oobd_remote &&
 		    !bt_addr_le_eq(info.le.remote, &oob_remote.addr)) {
 			bt_addr_le_to_str(info.le.remote, addr, sizeof(addr));
-			shell_print(ctx_shell,
-				    "No OOB data available for remote %s",
-				    addr);
+			LOG_DBG("No OOB data available for remote %s", addr);
 			bt_conn_auth_cancel(conn);
 			return;
 		}
@@ -3637,9 +3613,7 @@ static void auth_pairing_oob_data_request(struct bt_conn *conn,
 		if (oobd_local &&
 		    !bt_addr_le_eq(info.le.local, &oob_local.addr)) {
 			bt_addr_le_to_str(info.le.local, addr, sizeof(addr));
-			shell_print(ctx_shell,
-				    "No OOB data available for local %s",
-				    addr);
+			LOG_DBG("No OOB data available for local %s", addr);
 			bt_conn_auth_cancel(conn);
 			return;
 		}
@@ -3647,14 +3621,14 @@ static void auth_pairing_oob_data_request(struct bt_conn *conn,
 		bt_le_oob_set_sc_data(conn, oobd_local, oobd_remote);
 
 		bt_addr_le_to_str(info.le.dst, addr, sizeof(addr));
-		shell_print(ctx_shell, "Set %s OOB SC data for %s, ",
-			    oob_config_str(oob_info->lesc.oob_config), addr);
+		LOG_DBG("Set %s OOB SC data for %s, ", oob_config_str(oob_info->lesc.oob_config),
+			addr);
 		return;
 	}
 #endif /* CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY */
 
 	bt_addr_le_to_str(info.le.dst, addr, sizeof(addr));
-	shell_print(ctx_shell, "Legacy OOB TK requested from remote %s", addr);
+	LOG_DBG("Legacy OOB TK requested from remote %s", addr);
 }
 
 static void auth_pairing_complete(struct bt_conn *conn, bool bonded)
@@ -3663,8 +3637,7 @@ static void auth_pairing_complete(struct bt_conn *conn, bool bonded)
 
 	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
-	shell_print(ctx_shell, "%s with %s", bonded ? "Bonded" : "Paired",
-		    addr);
+	LOG_DBG("%s with %s", bonded ? "Bonded" : "Paired", addr);
 }
 
 static void auth_pairing_failed(struct bt_conn *conn, enum bt_security_err err)
@@ -3673,8 +3646,7 @@ static void auth_pairing_failed(struct bt_conn *conn, enum bt_security_err err)
 
 	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
-	shell_print(ctx_shell, "Pairing failed with %s reason: %s (%d)", addr,
-		    security_err_str(err), err);
+	LOG_DBG("Pairing failed with %s reason: %s (%d)", addr, security_err_str(err), err);
 }
 
 #if defined(CONFIG_BT_BREDR)
@@ -3694,10 +3666,9 @@ static void auth_pincode_entry(struct bt_conn *conn, bool highsec)
 	bt_addr_to_str(info.br.dst, addr, sizeof(addr));
 
 	if (highsec) {
-		shell_print(ctx_shell, "Enter 16 digits wide PIN code for %s",
-			    addr);
+		LOG_DBG("Enter 16 digits wide PIN code for %s", addr);
 	} else {
-		shell_print(ctx_shell, "Enter PIN code for %s", addr);
+		LOG_DBG("Enter PIN code for %s", addr);
 	}
 
 	/*
@@ -3714,12 +3685,10 @@ static void auth_pincode_entry(struct bt_conn *conn, bool highsec)
 enum bt_security_err pairing_accept(
 	struct bt_conn *conn, const struct bt_conn_pairing_feat *const feat)
 {
-	shell_print(ctx_shell, "Remote pairing features: "
-			       "IO: 0x%02x, OOB: %d, AUTH: 0x%02x, Key: %d, "
-			       "Init Kdist: 0x%02x, Resp Kdist: 0x%02x",
-			       feat->io_capability, feat->oob_data_flag,
-			       feat->auth_req, feat->max_enc_key_size,
-			       feat->init_key_dist, feat->resp_key_dist);
+	LOG_DBG("Remote pairing features: IO: 0x%02x, OOB: %d, AUTH: 0x%02x, Key: %d, Init Kdist: "
+		"0x%02x, Resp Kdist: 0x%02x",
+		feat->io_capability, feat->oob_data_flag, feat->auth_req, feat->max_enc_key_size,
+		feat->init_key_dist, feat->resp_key_dist);
 
 	return BT_SECURITY_ERR_SUCCESS;
 }
@@ -3730,7 +3699,7 @@ void bond_deleted(uint8_t id, const bt_addr_le_t *peer)
 	char addr[BT_ADDR_LE_STR_LEN];
 
 	bt_addr_le_to_str(peer, addr, sizeof(addr));
-	shell_print(ctx_shell, "Bond deleted for %s, id %u", addr, id);
+	LOG_DBG("Bond deleted for %s, id %u", addr, id);
 }
 
 static struct bt_conn_auth_cb auth_cb_display = {

--- a/subsys/bluetooth/shell/gatt.c
+++ b/subsys/bluetooth/shell/gatt.c
@@ -24,9 +24,12 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/gatt.h>
 
+#include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
 
 #include "bt.h"
+
+LOG_MODULE_REGISTER(gatt_shell, LOG_LEVEL_DBG);
 
 #if defined(CONFIG_BT_GATT_CLIENT) || defined(CONFIG_BT_GATT_DYNAMIC_DB)
 extern uint8_t selected_id;
@@ -75,8 +78,8 @@ static void update_write_stats(uint16_t len)
 
 static void print_write_stats(void)
 {
-	shell_print(ctx_shell, "Write #%u: %u bytes (%u bps)",
-		    write_stats.count, write_stats.total, write_stats.rate);
+	LOG_DBG("Write #%u: %u bytes (%u bps)", write_stats.count, write_stats.total,
+		write_stats.rate);
 }
 #endif /* CONFIG_BT_GATT_CLIENT || CONFIG_BT_GATT_DYNAMIC_DB */
 
@@ -94,8 +97,7 @@ static struct bt_gatt_exchange_params exchange_params;
 static void exchange_func(struct bt_conn *conn, uint8_t err,
 			  struct bt_gatt_exchange_params *params)
 {
-	shell_print(ctx_shell, "Exchange %s", err == 0U ? "successful" :
-		    "failed");
+	LOG_DBG("Exchange %s", err == 0U ? "successful" : "failed");
 
 	/* Release global `exchange_params`. */
 	__ASSERT_NO_MSG(params == &exchange_params);
@@ -139,43 +141,43 @@ static int cmd_exchange_mtu(const struct shell *sh,
 static struct bt_gatt_discover_params discover_params;
 static struct bt_uuid_16 uuid = BT_UUID_INIT_16(0);
 
-static void print_chrc_props(const struct shell *sh, uint8_t properties)
+static void print_chrc_props(uint8_t properties)
 {
-	shell_print(sh, "Properties: ");
+	LOG_DBG("Properties: ");
 
 	if (properties & BT_GATT_CHRC_BROADCAST) {
-		shell_print(sh, "[bcast]");
+		LOG_DBG("[bcast]");
 	}
 
 	if (properties & BT_GATT_CHRC_READ) {
-		shell_print(sh, "[read]");
+		LOG_DBG("[read]");
 	}
 
 	if (properties & BT_GATT_CHRC_WRITE) {
-		shell_print(sh, "[write]");
+		LOG_DBG("[write]");
 	}
 
 	if (properties & BT_GATT_CHRC_WRITE_WITHOUT_RESP) {
-		shell_print(sh, "[write w/w rsp]");
+		LOG_DBG("[write w/w rsp]");
 	}
 
 	if (properties & BT_GATT_CHRC_NOTIFY) {
-		shell_print(sh, "[notify]");
+		LOG_DBG("[notify]");
 	}
 
 	if (properties & BT_GATT_CHRC_INDICATE) {
-		shell_print(sh, "[indicate]");
+		LOG_DBG("[indicate]");
 	}
 
 	if (properties & BT_GATT_CHRC_AUTH) {
-		shell_print(sh, "[auth]");
+		LOG_DBG("[auth]");
 	}
 
 	if (properties & BT_GATT_CHRC_EXT_PROP) {
-		shell_print(sh, "[ext prop]");
+		LOG_DBG("[ext prop]");
 	}
 
-	shell_print(sh, "");
+	LOG_DBG("");
 }
 
 static uint8_t discover_func(struct bt_conn *conn,
@@ -188,7 +190,7 @@ static uint8_t discover_func(struct bt_conn *conn,
 	char str[BT_UUID_STR_LEN];
 
 	if (!attr) {
-		shell_print(ctx_shell, "Discover complete");
+		LOG_DBG("Discover complete");
 		(void)memset(params, 0, sizeof(*params));
 		return BT_GATT_ITER_STOP;
 	}
@@ -198,29 +200,24 @@ static uint8_t discover_func(struct bt_conn *conn,
 	case BT_GATT_DISCOVER_PRIMARY:
 		gatt_service = attr->user_data;
 		bt_uuid_to_str(gatt_service->uuid, str, sizeof(str));
-		shell_print(ctx_shell, "Service %s found: start handle %x, "
-			    "end_handle %x", str, attr->handle,
-			    gatt_service->end_handle);
+		LOG_DBG("Service %s found: start handle %x, end_handle %x", str, attr->handle,
+			gatt_service->end_handle);
 		break;
 	case BT_GATT_DISCOVER_CHARACTERISTIC:
 		gatt_chrc = attr->user_data;
 		bt_uuid_to_str(gatt_chrc->uuid, str, sizeof(str));
-		shell_print(ctx_shell, "Characteristic %s found: handle %x",
-			    str, attr->handle);
-		print_chrc_props(ctx_shell, gatt_chrc->properties);
+		LOG_DBG("Characteristic %s found: handle %x", str, attr->handle);
+		print_chrc_props(gatt_chrc->properties);
 		break;
 	case BT_GATT_DISCOVER_INCLUDE:
 		gatt_include = attr->user_data;
 		bt_uuid_to_str(gatt_include->uuid, str, sizeof(str));
-		shell_print(ctx_shell, "Include %s found: handle %x, start %x, "
-			    "end %x", str, attr->handle,
-			    gatt_include->start_handle,
-			    gatt_include->end_handle);
+		LOG_DBG("Include %s found: handle %x, start %x, end %x", str, attr->handle,
+			gatt_include->start_handle, gatt_include->end_handle);
 		break;
 	default:
 		bt_uuid_to_str(attr->uuid, str, sizeof(str));
-		shell_print(ctx_shell, "Descriptor %s found: handle %x", str,
-			    attr->handle);
+		LOG_DBG("Descriptor %s found: handle %x", str, attr->handle);
 		break;
 	}
 
@@ -291,13 +288,13 @@ static uint8_t read_func(struct bt_conn *conn, uint8_t err,
 			 struct bt_gatt_read_params *params,
 			 const void *data, uint16_t length)
 {
-	shell_print(ctx_shell, "Read complete: err 0x%02x length %u", err, length);
+	LOG_DBG("Read complete: err 0x%02x length %u", err, length);
 
 	if (!data) {
 		(void)memset(params, 0, sizeof(*params));
 		return BT_GATT_ITER_STOP;
 	} else {
-		shell_hexdump(ctx_shell, data, length);
+		LOG_HEXDUMP_DBG(data, length, "");
 	}
 
 	return BT_GATT_ITER_CONTINUE;
@@ -429,7 +426,7 @@ static uint8_t gatt_write_buf[BT_ATT_MAX_ATTRIBUTE_LEN];
 static void write_func(struct bt_conn *conn, uint8_t err,
 		       struct bt_gatt_write_params *params)
 {
-	shell_print(ctx_shell, "Write complete: err 0x%02x", err);
+	LOG_DBG("Write complete: err 0x%02x", err);
 
 	(void)memset(&write_params, 0, sizeof(write_params));
 }
@@ -557,14 +554,13 @@ static uint8_t notify_func(struct bt_conn *conn,
 			const void *data, uint16_t length)
 {
 	if (!data) {
-		shell_print(ctx_shell, "Unsubscribed");
+		LOG_DBG("Unsubscribed");
 		params->value_handle = 0U;
 		return BT_GATT_ITER_STOP;
 	}
 
-	shell_print(ctx_shell, "Notification: value_handle %u, length %u",
-		    params->value_handle, length);
-	shell_hexdump(ctx_shell, data, length);
+	LOG_DBG("Notification: value_handle %u, length %u", params->value_handle, length);
+	LOG_HEXDUMP_DBG(data, length, "");
 
 	return BT_GATT_ITER_CONTINUE;
 }
@@ -793,7 +789,7 @@ static ssize_t write_vnd1(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			  uint8_t flags)
 {
 	if (echo_enabled) {
-		shell_print(ctx_shell, "Echo attr len %u", len);
+		LOG_DBG("Echo attr len %u", len);
 		bt_gatt_notify(conn, attr, buf, len);
 	}
 

--- a/subsys/bluetooth/shell/hci.c
+++ b/subsys/bluetooth/shell/hci.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/byteorder.h>
@@ -16,6 +17,8 @@
 #include <zephyr/bluetooth/conn.h>
 
 #include "../host/hci_core.h"
+
+LOG_MODULE_REGISTER(hci_shell, LOG_LEVEL_DBG);
 
 #if defined(CONFIG_BT_HCI_MESH_EXT)
 int cmd_mesh_adv(const struct shell *sh, size_t argc, char *argv[])

--- a/subsys/bluetooth/shell/ias.c
+++ b/subsys/bluetooth/shell/ias.c
@@ -13,26 +13,27 @@
 #include <zephyr/bluetooth/conn.h>
 
 #include <zephyr/types.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/services/ias.h>
 
-extern const struct shell *ctx_shell;
+LOG_MODULE_REGISTER(ias_shell, LOG_LEVEL_DBG);
 
 static void alert_stop(void)
 {
-	shell_print(ctx_shell, "Alert stopped\n");
+	LOG_DBG("Alert stopped\n");
 }
 
 static void alert_start(void)
 {
-	shell_print(ctx_shell, "Mild alert started\n");
+	LOG_DBG("Mild alert started\n");
 }
 
 static void alert_high_start(void)
 {
-	shell_print(ctx_shell, "High alert started\n");
+	LOG_DBG("High alert started\n");
 }
 
 BT_IAS_CB_DEFINE(ias_callbacks) = {

--- a/subsys/bluetooth/shell/ias_client.c
+++ b/subsys/bluetooth/shell/ias_client.c
@@ -9,6 +9,7 @@
 
 #include <stdint.h>
 #include <zephyr/types.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
 #include <stdlib.h>
 #include <zephyr/bluetooth/gatt.h>
@@ -17,14 +18,14 @@
 
 #include "bt.h"
 
-extern const struct shell *ctx_shell;
+LOG_MODULE_REGISTER(ias_client_shell, LOG_LEVEL_DBG);
 
 static void ias_discover_cb(struct bt_conn *conn, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "Failed to discover IAS err: %d\n", err);
+		LOG_ERR("Failed to discover IAS err: %d\n", err);
 	} else {
-		shell_print(ctx_shell, "IAS discover success\n");
+		LOG_DBG("IAS discover success\n");
 	}
 }
 
@@ -35,10 +36,6 @@ static struct bt_ias_client_cb ias_client_callbacks = {
 static int cmd_ias_client_init(const struct shell *sh, size_t argc, char **argv)
 {
 	int err;
-
-	if (!ctx_shell) {
-		ctx_shell = sh;
-	}
 
 	err = bt_ias_client_cb_register(&ias_client_callbacks);
 	if (err != 0) {

--- a/subsys/bluetooth/shell/iso.c
+++ b/subsys/bluetooth/shell/iso.c
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 #include <ctype.h>
 #include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
@@ -23,6 +24,8 @@
 #include <zephyr/bluetooth/iso.h>
 
 #include "bt.h"
+
+LOG_MODULE_REGISTER(iso_shell, LOG_LEVEL_DBG);
 
 #if defined(CONFIG_BT_ISO_TX)
 #define DEFAULT_IO_QOS                                                                             \
@@ -75,8 +78,8 @@ static void iso_recv(struct bt_iso_chan *chan, const struct bt_iso_recv_info *in
 		struct net_buf *buf)
 {
 	if (info->flags & BT_ISO_FLAGS_VALID) {
-		shell_print(ctx_shell, "Incoming data channel %p len %u, seq: %d, ts: %d",
-			    chan, buf->len, info->seq_num, info->ts);
+		LOG_DBG("Incoming data channel %p len %u, seq: %d, ts: %d", chan, buf->len,
+			info->seq_num, info->ts);
 	}
 }
 #endif /* CONFIG_BT_ISO_RX */
@@ -86,8 +89,7 @@ static void iso_connected(struct bt_iso_chan *chan)
 	struct bt_iso_info iso_info;
 	int err;
 
-	shell_print(ctx_shell, "ISO Channel %p connected", chan);
-
+	LOG_DBG("ISO Channel %p connected", chan);
 
 	err = bt_iso_chan_get_info(chan, &iso_info);
 	if (err != 0) {
@@ -108,8 +110,7 @@ static void iso_connected(struct bt_iso_chan *chan)
 
 static void iso_disconnected(struct bt_iso_chan *chan, uint8_t reason)
 {
-	shell_print(ctx_shell, "ISO Channel %p disconnected with reason 0x%02x",
-		    chan, reason);
+	LOG_DBG("ISO Channel %p disconnected with reason 0x%02x", chan, reason);
 }
 
 static struct bt_iso_chan_ops iso_ops = {
@@ -474,11 +475,11 @@ static int cmd_connect(const struct shell *sh, size_t argc, char *argv[])
 static int iso_accept(const struct bt_iso_accept_info *info,
 		      struct bt_iso_chan **chan)
 {
-	shell_print(ctx_shell, "Incoming request from %p with CIG ID 0x%02X and CIS ID 0x%02X",
-		    info->acl, info->cig_id, info->cis_id);
+	LOG_DBG("Incoming request from %p with CIG ID 0x%02X and CIS ID 0x%02X", (void *)info->acl,
+		info->cig_id, info->cis_id);
 
 	if (iso_chan.iso) {
-		shell_print(ctx_shell, "No channels available");
+		LOG_DBG("No channels available");
 		return -ENOMEM;
 	}
 

--- a/subsys/bluetooth/shell/l2cap.c
+++ b/subsys/bluetooth/shell/l2cap.c
@@ -27,9 +27,12 @@
 #include <zephyr/bluetooth/rfcomm.h>
 #include <zephyr/bluetooth/sdp.h>
 
+#include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
 
 #include "bt.h"
+
+LOG_MODULE_REGISTER(l2cap_shell, LOG_LEVEL_DBG);
 
 #define CREDITS			10
 #define DATA_MTU		(23 * CREDITS)
@@ -89,7 +92,7 @@ static void l2cap_recv_cb(struct k_work *work)
 	struct net_buf *buf;
 
 	while ((buf = net_buf_get(&l2cap_recv_fifo, K_NO_WAIT))) {
-		shell_print(ctx_shell, "Confirming reception");
+		LOG_DBG("Confirming reception");
 		bt_l2cap_chan_recv_complete(&c->ch.chan, buf);
 	}
 }
@@ -102,18 +105,16 @@ static int l2cap_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 		return l2cap_recv_metrics(chan, buf);
 	}
 
-	shell_print(ctx_shell, "Incoming data channel %p len %u", chan,
-		    buf->len);
+	LOG_DBG("Incoming data channel %p len %u", chan, buf->len);
 
 	if (buf->len) {
-		shell_hexdump(ctx_shell, buf->data, buf->len);
+		LOG_HEXDUMP_DBG(buf->data, buf->len, "");
 	}
 
 	if (l2cap_recv_delay_ms > 0) {
 		/* Submit work only if queue is empty */
 		if (k_fifo_is_empty(&l2cap_recv_fifo)) {
-			shell_print(ctx_shell, "Delaying response in %u ms...",
-				    l2cap_recv_delay_ms);
+			LOG_DBG("Delaying response in %u ms...", l2cap_recv_delay_ms);
 		}
 
 		net_buf_put(&l2cap_recv_fifo, buf);
@@ -127,12 +128,12 @@ static int l2cap_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 
 static void l2cap_sent(struct bt_l2cap_chan *chan)
 {
-	shell_print(ctx_shell, "Outgoing data channel %p transmitted", chan);
+	LOG_DBG("Outgoing data channel %p transmitted", chan);
 }
 
 static void l2cap_status(struct bt_l2cap_chan *chan, atomic_t *status)
 {
-	shell_print(ctx_shell, "Channel %p status %u", chan, (uint32_t)*status);
+	LOG_DBG("Channel %p status %u", chan, (uint32_t)*status);
 }
 
 static void l2cap_connected(struct bt_l2cap_chan *chan)
@@ -141,19 +142,19 @@ static void l2cap_connected(struct bt_l2cap_chan *chan)
 
 	k_work_init_delayable(&c->recv_work, l2cap_recv_cb);
 
-	shell_print(ctx_shell, "Channel %p connected", chan);
+	LOG_DBG("Channel %p connected", chan);
 }
 
 static void l2cap_disconnected(struct bt_l2cap_chan *chan)
 {
-	shell_print(ctx_shell, "Channel %p disconnected", chan);
+	LOG_DBG("Channel %p disconnected", chan);
 }
 
 static struct net_buf *l2cap_alloc_buf(struct bt_l2cap_chan *chan)
 {
 	/* print if metrics is disabled */
 	if (!metrics) {
-		shell_print(ctx_shell, "Channel %p requires buffer", chan);
+		LOG_DBG("Channel %p requires buffer", chan);
 	}
 
 	return net_buf_alloc(&data_rx_pool, K_FOREVER);
@@ -217,7 +218,7 @@ static int l2cap_accept(struct bt_conn *conn, struct bt_l2cap_server *server,
 {
 	int err;
 
-	shell_print(ctx_shell, "Incoming conn %p", conn);
+	LOG_DBG("Incoming conn %p", (void *)conn);
 
 	err = l2cap_accept_policy(conn);
 	if (err < 0) {
@@ -225,7 +226,7 @@ static int l2cap_accept(struct bt_conn *conn, struct bt_l2cap_server *server,
 	}
 
 	if (l2ch_chan.ch.chan.conn) {
-		shell_print(ctx_shell, "No channels available");
+		LOG_DBG("No channels available");
 		return -ENOMEM;
 	}
 

--- a/subsys/bluetooth/shell/ll.c
+++ b/subsys/bluetooth/shell/ll.c
@@ -17,12 +17,15 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
 
+#include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
 
 #include "../controller/util/memq.h"
 #include "../controller/include/ll.h"
 
 #include "bt.h"
+
+LOG_MODULE_REGISTER(ll_shell, LOG_LEVEL_DBG);
 
 int cmd_ll_addr_read(const struct shell *sh, size_t argc, char *argv[])
 {

--- a/subsys/bluetooth/shell/rfcomm.c
+++ b/subsys/bluetooth/shell/rfcomm.c
@@ -27,9 +27,12 @@
 #include <zephyr/bluetooth/rfcomm.h>
 #include <zephyr/bluetooth/sdp.h>
 
+#include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
 
 #include "bt.h"
+
+LOG_MODULE_REGISTER(rfcomm_shell, LOG_LEVEL_DBG);
 
 #define DATA_MTU 48
 
@@ -101,17 +104,17 @@ static struct bt_sdp_record spp_rec = BT_SDP_RECORD(spp_attrs);
 
 static void rfcomm_recv(struct bt_rfcomm_dlc *dlci, struct net_buf *buf)
 {
-	shell_print(ctx_shell, "Incoming data dlc %p len %u", dlci, buf->len);
+	LOG_DBG("Incoming data dlc %p len %u", dlci, buf->len);
 }
 
 static void rfcomm_connected(struct bt_rfcomm_dlc *dlci)
 {
-	shell_print(ctx_shell, "Dlc %p connected", dlci);
+	LOG_DBG("Dlc %p connected", dlci);
 }
 
 static void rfcomm_disconnected(struct bt_rfcomm_dlc *dlci)
 {
-	shell_print(ctx_shell, "Dlc %p disconnected", dlci);
+	LOG_DBG("Dlc %p disconnected", dlci);
 }
 
 static struct bt_rfcomm_dlc_ops rfcomm_ops = {
@@ -127,10 +130,10 @@ static struct bt_rfcomm_dlc rfcomm_dlc = {
 
 static int rfcomm_accept(struct bt_conn *conn, struct bt_rfcomm_dlc **dlc)
 {
-	shell_print(ctx_shell, "Incoming RFCOMM conn %p", conn);
+	LOG_DBG("Incoming RFCOMM conn %p", (void *)conn);
 
 	if (rfcomm_dlc.session) {
-		shell_error(ctx_shell, "No channels available");
+		LOG_ERR("No channels available");
 		return -ENOMEM;
 	}
 

--- a/subsys/bluetooth/shell/ticker.c
+++ b/subsys/bluetooth/shell/ticker.c
@@ -14,6 +14,7 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
 
+#include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
 
 #include "../controller/util/memq.h"
@@ -28,6 +29,8 @@
 #endif
 
 #include "bt.h"
+
+LOG_MODULE_REGISTER(ticker_shell, LOG_LEVEL_DBG);
 
 static void ticker_op_done(uint32_t err, void *context)
 {


### PR DESCRIPTION
Replace uses of ctx_shell with logging.
The ctx_shell is mostly (always?) used in callbacks, where spending time to print directly may affect the behavior of the stack, and should be avoided.

Logging has other advantages, such as following the order of operations when also logging things from the stack.