### PR TITLE
Bluetooth: ATT: lock scheduler when sending from user thread

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -3863,13 +3863,18 @@ int bt_att_req_send(struct bt_conn *conn, struct bt_att_req *req)
 	__ASSERT_NO_MSG(conn);
 	__ASSERT_NO_MSG(req);
 
+	k_sched_lock();
+
 	att = att_get(conn);
 	if (!att) {
+		k_sched_unlock();
 		return -ENOTCONN;
 	}
 
 	sys_slist_append(&att->reqs, &req->node);
 	att_req_send_process(att);
+
+	k_sched_unlock();
 
 	return 0;
 }


### PR DESCRIPTION
`att_req_send_process` is not thread safe.

In the case where the current context is pre-emptible (e.g. when a user sends something over GATT from the main thread):

The iterator in `att_req_send_process` can get interrupted mid-processing, breaking the logic and resulting in an assert/crash/data corruption.

This is a hotfix until we have a better solution or the host is refactored to avoid this problem.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/69737