### PR TITLE
Bluetooth: Audio: Shell: Replace ctx_shell with logging

### DIFF
--- a/subsys/bluetooth/audio/shell/CMakeLists.txt
+++ b/subsys/bluetooth/audio/shell/CMakeLists.txt
@@ -4,6 +4,10 @@ zephyr_library()
 zephyr_library_link_libraries(subsys__bluetooth)
 
 zephyr_library_sources_ifdef(
+  CONFIG_BT_AUDIO
+  audio.c
+  )
+zephyr_library_sources_ifdef(
   CONFIG_BT_VCP_VOL_REND
   vcp_vol_rend.c
   )

--- a/subsys/bluetooth/audio/shell/audio.c
+++ b/subsys/bluetooth/audio/shell/audio.c
@@ -1,0 +1,188 @@
+/** @file
+ *  @brief Bluetooth audio shell generic functions
+ *
+ */
+
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/printk.h>
+
+#include "shell/bt.h"
+#include "audio.h"
+
+LOG_MODULE_REGISTER(audio_shell, LOG_LEVEL_DBG);
+
+void print_qos(const struct bt_audio_codec_qos *qos)
+{
+#if defined(CONFIG_BT_BAP_BROADCAST_SOURCE) || defined(CONFIG_BT_BAP_UNICAST)
+	LOG_DBG("QoS: interval %u framing 0x%02x phy 0x%02x sdu %u rtn %u latency %u pd %u",
+		qos->interval, qos->framing, qos->phy, qos->sdu, qos->rtn, qos->latency, qos->pd);
+#else
+	LOG_DBG("QoS: interval %u framing 0x%02x phy 0x%02x sdu %u rtn %u pd %u", qos->interval,
+		qos->framing, qos->phy, qos->sdu, qos->rtn, qos->pd);
+#endif /* CONFIG_BT_BAP_BROADCAST_SOURCE || CONFIG_BT_BAP_UNICAST */
+}
+
+struct print_ltv_info {
+	const char *str;
+	size_t cnt;
+};
+
+static bool print_ltv_elem(struct bt_data *data, void *user_data)
+{
+	struct print_ltv_info *ltv_info = user_data;
+
+	LOG_DBG("%s #%zu: type 0x%02x value_len %u", ltv_info->str, ltv_info->cnt, data->type,
+		data->data_len);
+	LOG_HEXDUMP_DBG(data->data, data->data_len, "");
+
+	ltv_info->cnt++;
+
+	return true;
+}
+
+static void print_ltv_array(const char *str, const uint8_t *ltv_data, size_t ltv_data_len)
+{
+	struct print_ltv_info ltv_info = {
+		.str = str,
+		.cnt = 0U,
+	};
+
+	bt_audio_data_parse(ltv_data, ltv_data_len, print_ltv_elem, &ltv_info);
+}
+
+void print_codec_cap(const struct bt_audio_codec_cap *codec_cap)
+{
+	LOG_DBG("codec cap id 0x%02x cid 0x%04x vid 0x%04x count %u", codec_cap->id, codec_cap->cid,
+		codec_cap->vid, codec_cap->data_len);
+
+#if CONFIG_BT_AUDIO_CODEC_CAP_MAX_DATA_SIZE > 0
+	if (codec_cap->id == BT_HCI_CODING_FORMAT_LC3) {
+		print_ltv_array("data", codec_cap->data, codec_cap->data_len);
+	} else { /* If not LC3, we cannot assume it's LTV */
+		LOG_HEXDUMP_DBG(codec_cap->data, codec_cap->data_len, "data");
+	}
+#endif /* CONFIG_BT_AUDIO_CODEC_CAP_MAX_DATA_SIZE > 0 */
+
+#if CONFIG_BT_AUDIO_CODEC_CAP_MAX_METADATA_SIZE > 0
+	print_ltv_array("meta", codec_cap->meta, codec_cap->meta_len);
+#endif /* CONFIG_BT_AUDIO_CODEC_CAP_MAX_METADATA_SIZE > 0 */
+}
+
+void print_codec_cfg(const struct bt_audio_codec_cfg *codec_cfg)
+{
+	LOG_DBG("codec cfg id 0x%02x cid 0x%04x vid 0x%04x count %u", codec_cfg->id, codec_cfg->cid,
+		codec_cfg->vid, codec_cfg->data_len);
+
+#if CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0
+	if (codec_cfg->id == BT_HCI_CODING_FORMAT_LC3) {
+		print_ltv_array("data", codec_cfg->data, codec_cfg->data_len);
+	} else { /* If not LC3, we cannot assume it's LTV */
+		LOG_HEXDUMP_DBG(codec_cfg->data, codec_cfg->data_len, "data");
+	}
+#endif /* CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0 */
+
+#if CONFIG_BT_AUDIO_CODEC_CFG_MAX_METADATA_SIZE > 0
+	print_ltv_array("meta", codec_cfg->meta, codec_cfg->meta_len);
+#endif /* CONFIG_BT_AUDIO_CODEC_CFG_MAX_METADATA_SIZE > 0 */
+}
+
+bool print_base_subgroup_bis_cb(const struct bt_bap_base_subgroup_bis *bis, void *user_data)
+{
+	struct bt_bap_base_codec_id *codec_id = user_data;
+
+	LOG_DBG("\t\tBIS index: 0x%02X", bis->index);
+	/* Print CC data */
+	if (codec_id->id == BT_HCI_CODING_FORMAT_LC3) {
+		print_ltv_array("\t\tdata", bis->data, bis->data_len);
+	} else { /* If not LC3, we cannot assume it's LTV */
+		LOG_HEXDUMP_DBG(bis->data, bis->data_len, "data");
+	}
+
+	return true;
+}
+
+bool print_base_subgroup_cb(const struct bt_bap_base_subgroup *subgroup, void *user_data)
+{
+	struct bt_bap_base_codec_id codec_id;
+	uint8_t *data;
+	int ret;
+
+	LOG_DBG("Subgroup %p:", (void *)subgroup);
+
+	ret = bt_bap_base_get_subgroup_codec_id(subgroup, &codec_id);
+	if (ret < 0) {
+		return false;
+	}
+
+	LOG_DBG("\tCodec Format: 0x%02X", codec_id.id);
+	LOG_DBG("\tCompany ID  : 0x%04X", codec_id.cid);
+	LOG_DBG("\tVendor ID   : 0x%04X", codec_id.vid);
+
+	ret = bt_bap_base_get_subgroup_codec_data(subgroup, &data);
+	if (ret < 0) {
+		return false;
+	}
+
+	/* Print CC data */
+	if (codec_id.id == BT_HCI_CODING_FORMAT_LC3) {
+		print_ltv_array("\tdata", data, (uint8_t)ret);
+	} else { /* If not LC3, we cannot assume it's LTV */
+		LOG_HEXDUMP_DBG(data, (uint8_t)ret, "\tdata");
+	}
+
+	ret = bt_bap_base_get_subgroup_codec_meta(subgroup, &data);
+	if (ret < 0) {
+		return false;
+	}
+
+	/* Print metadata */
+	if (codec_id.id == BT_HCI_CODING_FORMAT_LC3) {
+		print_ltv_array("\tdata", data, (uint8_t)ret);
+	} else { /* If not LC3, we cannot assume it's LTV */
+		LOG_HEXDUMP_DBG(data, (uint8_t)ret, "\tdata");
+	}
+
+	ret = bt_bap_base_subgroup_foreach_bis(subgroup, print_base_subgroup_bis_cb, &codec_id);
+	if (ret < 0) {
+		return false;
+	}
+
+	return true;
+}
+
+void print_base(const struct bt_bap_base *base)
+{
+	int err;
+
+	LOG_DBG("Presentation delay: %d", bt_bap_base_get_pres_delay(base));
+	LOG_DBG("Subgroup count: %d", bt_bap_base_get_subgroup_count(base));
+
+	err = bt_bap_base_foreach_subgroup(base, print_base_subgroup_cb, NULL);
+	if (err < 0) {
+		LOG_DBG("Invalid BASE: %d", err);
+	}
+}
+
+void copy_unicast_stream_preset(struct shell_stream *stream,
+				const struct named_lc3_preset *named_preset)
+{
+	memcpy(&stream->qos, &named_preset->preset.qos, sizeof(stream->qos));
+	memcpy(&stream->codec_cfg, &named_preset->preset.codec_cfg, sizeof(stream->codec_cfg));
+}
+
+void copy_broadcast_source_preset(struct broadcast_source *source,
+				  const struct named_lc3_preset *named_preset)
+{
+	memcpy(&source->qos, &named_preset->preset.qos, sizeof(source->qos));
+	memcpy(&source->codec_cfg, &named_preset->preset.codec_cfg, sizeof(source->codec_cfg));
+}

--- a/subsys/bluetooth/audio/shell/audio.h
+++ b/subsys/bluetooth/audio/shell/audio.h
@@ -153,88 +153,6 @@ int cap_ac_unicast(const struct shell *sh, size_t argc, char **argv,
 #endif /* CONFIG_BT_BAP_UNICAST_CLIENT */
 #endif /* CONFIG_BT_BAP_UNICAST */
 
-static inline void print_qos(const struct shell *sh, const struct bt_audio_codec_qos *qos)
-{
-#if defined(CONFIG_BT_BAP_BROADCAST_SOURCE) || defined(CONFIG_BT_BAP_UNICAST)
-	shell_print(sh,
-		    "QoS: interval %u framing 0x%02x phy 0x%02x sdu %u rtn %u latency %u pd %u",
-		    qos->interval, qos->framing, qos->phy, qos->sdu, qos->rtn, qos->latency,
-		    qos->pd);
-#else
-	shell_print(sh, "QoS: interval %u framing 0x%02x phy 0x%02x sdu %u rtn %u pd %u",
-		    qos->interval, qos->framing, qos->phy, qos->sdu, qos->rtn, qos->pd);
-#endif /* CONFIG_BT_BAP_BROADCAST_SOURCE || CONFIG_BT_BAP_UNICAST */
-}
-
-struct print_ltv_info {
-	const struct shell *sh;
-	const char *str;
-	size_t cnt;
-};
-
-static bool print_ltv_elem(struct bt_data *data, void *user_data)
-{
-	struct print_ltv_info *ltv_info = user_data;
-
-	shell_print(ltv_info->sh, "%s #%zu: type 0x%02x value_len %u", ltv_info->str, ltv_info->cnt,
-		    data->type, data->data_len);
-	shell_hexdump(ltv_info->sh, data->data, data->data_len);
-
-	ltv_info->cnt++;
-
-	return true;
-}
-
-static void print_ltv_array(const struct shell *sh, const char *str, const uint8_t *ltv_data,
-			    size_t ltv_data_len)
-{
-	struct print_ltv_info ltv_info = {
-		.sh = sh,
-		.str = str,
-		.cnt = 0U,
-	};
-
-	bt_audio_data_parse(ltv_data, ltv_data_len, print_ltv_elem, &ltv_info);
-}
-
-static inline void print_codec_cap(const struct shell *sh,
-				   const struct bt_audio_codec_cap *codec_cap)
-{
-	shell_print(sh, "codec cap id 0x%02x cid 0x%04x vid 0x%04x count %u", codec_cap->id,
-		    codec_cap->cid, codec_cap->vid, codec_cap->data_len);
-
-#if CONFIG_BT_AUDIO_CODEC_CAP_MAX_DATA_SIZE > 0
-	if (codec_cap->id == BT_HCI_CODING_FORMAT_LC3) {
-		print_ltv_array(sh, "data", codec_cap->data, codec_cap->data_len);
-	} else { /* If not LC3, we cannot assume it's LTV */
-		shell_hexdump(sh, codec_cap->data, codec_cap->data_len);
-	}
-#endif /* CONFIG_BT_AUDIO_CODEC_CAP_MAX_DATA_SIZE > 0 */
-
-#if CONFIG_BT_AUDIO_CODEC_CAP_MAX_METADATA_SIZE > 0
-	print_ltv_array(sh, "meta", codec_cap->meta, codec_cap->meta_len);
-#endif /* CONFIG_BT_AUDIO_CODEC_CAP_MAX_METADATA_SIZE > 0 */
-}
-
-static inline void print_codec_cfg(const struct shell *sh,
-				   const struct bt_audio_codec_cfg *codec_cfg)
-{
-	shell_print(sh, "codec cfg id 0x%02x cid 0x%04x vid 0x%04x count %u", codec_cfg->id,
-		    codec_cfg->cid, codec_cfg->vid, codec_cfg->data_len);
-
-#if CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0
-	if (codec_cfg->id == BT_HCI_CODING_FORMAT_LC3) {
-		print_ltv_array(sh, "data", codec_cfg->data, codec_cfg->data_len);
-	} else { /* If not LC3, we cannot assume it's LTV */
-		shell_hexdump(sh, codec_cfg->data, codec_cfg->data_len);
-	}
-#endif /* CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0 */
-
-#if CONFIG_BT_AUDIO_CODEC_CFG_MAX_METADATA_SIZE > 0
-	print_ltv_array(sh, "meta", codec_cfg->meta, codec_cfg->meta_len);
-#endif /* CONFIG_BT_AUDIO_CODEC_CFG_MAX_METADATA_SIZE > 0 */
-}
-
 #if defined(CONFIG_BT_BAP_BROADCAST_SOURCE)
 struct bap_broadcast_ac_param {
 	char *name;
@@ -249,98 +167,16 @@ extern struct shell_stream broadcast_source_streams[CONFIG_BT_BAP_BROADCAST_SRC_
 extern struct broadcast_source default_source;
 #endif /* CONFIG_BT_BAP_BROADCAST_SOURCE */
 
-static inline bool print_base_subgroup_bis_cb(const struct bt_bap_base_subgroup_bis *bis,
-					      void *user_data)
-{
-	struct bt_bap_base_codec_id *codec_id = user_data;
+void print_qos(const struct bt_audio_codec_qos *qos);
+void print_codec_cap(const struct bt_audio_codec_cap *codec_cap);
+void print_codec_cfg(const struct bt_audio_codec_cfg *codec_cfg);
+void print_base(const struct bt_bap_base *base);
 
-	shell_print(ctx_shell, "\t\tBIS index: 0x%02X", bis->index);
-	/* Print CC data */
-	if (codec_id->id == BT_HCI_CODING_FORMAT_LC3) {
-		print_ltv_array(ctx_shell, "\t\tdata", bis->data, bis->data_len);
-	} else { /* If not LC3, we cannot assume it's LTV */
-		shell_hexdump(ctx_shell, bis->data, bis->data_len);
-	}
+void copy_unicast_stream_preset(struct shell_stream *stream,
+				const struct named_lc3_preset *named_preset);
 
-	return true;
-}
-
-static inline bool print_base_subgroup_cb(const struct bt_bap_base_subgroup *subgroup,
-					  void *user_data)
-{
-	struct bt_bap_base_codec_id codec_id;
-	uint8_t *data;
-	int ret;
-
-	shell_print(ctx_shell, "Subgroup %p:", subgroup);
-
-	ret = bt_bap_base_get_subgroup_codec_id(subgroup, &codec_id);
-	if (ret < 0) {
-		return false;
-	}
-
-	shell_print(ctx_shell, "\tCodec Format: 0x%02X", codec_id.id);
-	shell_print(ctx_shell, "\tCompany ID  : 0x%04X", codec_id.cid);
-	shell_print(ctx_shell, "\tVendor ID   : 0x%04X", codec_id.vid);
-
-	ret = bt_bap_base_get_subgroup_codec_data(subgroup, &data);
-	if (ret < 0) {
-		return false;
-	}
-
-	/* Print CC data */
-	if (codec_id.id == BT_HCI_CODING_FORMAT_LC3) {
-		print_ltv_array(ctx_shell, "\tdata", data, (uint8_t)ret);
-	} else { /* If not LC3, we cannot assume it's LTV */
-		shell_hexdump(ctx_shell, data, (uint8_t)ret);
-	}
-
-	ret = bt_bap_base_get_subgroup_codec_meta(subgroup, &data);
-	if (ret < 0) {
-		return false;
-	}
-
-	/* Print metadata */
-	if (codec_id.id == BT_HCI_CODING_FORMAT_LC3) {
-		print_ltv_array(ctx_shell, "\tdata", data, (uint8_t)ret);
-	} else { /* If not LC3, we cannot assume it's LTV */
-		shell_hexdump(ctx_shell, data, (uint8_t)ret);
-	}
-
-	ret = bt_bap_base_subgroup_foreach_bis(subgroup, print_base_subgroup_bis_cb, &codec_id);
-	if (ret < 0) {
-		return false;
-	}
-
-	return true;
-}
-
-static inline void print_base(const struct bt_bap_base *base)
-{
-	int err;
-
-	shell_print(ctx_shell, "Presentation delay: %d", bt_bap_base_get_pres_delay(base));
-	shell_print(ctx_shell, "Subgroup count: %d", bt_bap_base_get_subgroup_count(base));
-
-	err = bt_bap_base_foreach_subgroup(base, print_base_subgroup_cb, NULL);
-	if (err < 0) {
-		shell_info(ctx_shell, "Invalid BASE: %d", err);
-	}
-}
-
-static inline void copy_unicast_stream_preset(struct shell_stream *stream,
-					      const struct named_lc3_preset *named_preset)
-{
-	memcpy(&stream->qos, &named_preset->preset.qos, sizeof(stream->qos));
-	memcpy(&stream->codec_cfg, &named_preset->preset.codec_cfg, sizeof(stream->codec_cfg));
-}
-
-static inline void copy_broadcast_source_preset(struct broadcast_source *source,
-						const struct named_lc3_preset *named_preset)
-{
-	memcpy(&source->qos, &named_preset->preset.qos, sizeof(source->qos));
-	memcpy(&source->codec_cfg, &named_preset->preset.codec_cfg, sizeof(source->codec_cfg));
-}
+void copy_broadcast_source_preset(struct broadcast_source *source,
+				  const struct named_lc3_preset *named_preset);
 #endif /* CONFIG_BT_AUDIO */
 
 #endif /* __AUDIO_H */

--- a/subsys/bluetooth/audio/shell/cap_commander.c
+++ b/subsys/bluetooth/audio/shell/cap_commander.c
@@ -11,6 +11,7 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/audio/cap.h>
 #include <zephyr/bluetooth/audio/vocs.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/types.h>
@@ -18,46 +19,48 @@
 #include "shell/bt.h"
 #include "audio.h"
 
+LOG_MODULE_REGISTER(cap_commander_shell, LOG_LEVEL_DBG);
+
 static void cap_discover_cb(struct bt_conn *conn, int err,
 			    const struct bt_csip_set_coordinator_csis_inst *csis_inst)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "discover failed (%d)", err);
+		LOG_ERR("discover failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "discovery completed%s", csis_inst == NULL ? "" : " with CSIS");
+	LOG_DBG("discovery completed%s", csis_inst == NULL ? "" : " with CSIS");
 }
 
 #if defined(CONFIG_BT_VCP_VOL_CTLR)
 static void cap_volume_changed_cb(struct bt_conn *conn, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "Volume change failed (%d)", err);
+		LOG_ERR("Volume change failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Volume change completed");
+	LOG_DBG("Volume change completed");
 }
 
 static void cap_volume_mute_changed_cb(struct bt_conn *conn, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "Volume mute change failed (%d)", err);
+		LOG_ERR("Volume mute change failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Volume mute change completed");
+	LOG_DBG("Volume mute change completed");
 }
 #if defined(CONFIG_BT_VCP_VOL_CTLR_VOCS)
 static void cap_volume_offset_changed_cb(struct bt_conn *conn, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "Volume offset change failed (%d)", err);
+		LOG_ERR("Volume offset change failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Volume offset change completed");
+	LOG_DBG("Volume offset change completed");
 }
 #endif /* CONFIG_BT_VCP_VOL_CTLR_VOCS */
 #endif /* CONFIG_BT_VCP_VOL_CTLR */
@@ -81,10 +84,6 @@ static int cmd_cap_commander_discover(const struct shell *sh, size_t argc, char 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
-	}
-
-	if (ctx_shell == NULL) {
-		ctx_shell = sh;
 	}
 
 	if (!cbs_registered) {

--- a/subsys/bluetooth/audio/shell/csip_set_member.c
+++ b/subsys/bluetooth/audio/shell/csip_set_member.c
@@ -12,6 +12,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/types.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
 #include <stdlib.h>
 #include <zephyr/bluetooth/gatt.h>
@@ -19,7 +20,8 @@
 #include <zephyr/bluetooth/audio/csip.h>
 #include "shell/bt.h"
 
-extern const struct shell *ctx_shell;
+LOG_MODULE_REGISTER(csip_set_member_shell, LOG_LEVEL_DBG);
+
 struct bt_csip_set_member_svc_inst *svc_inst;
 static uint8_t sirk_read_rsp = BT_CSIP_READ_SIRK_REQ_RSP_ACCEPT;
 
@@ -28,15 +30,13 @@ static void locked_cb(struct bt_conn *conn,
 		      bool locked)
 {
 	if (conn == NULL) {
-		shell_error(ctx_shell, "Server %s the device",
-			    locked ? "locked" : "released");
+		LOG_ERR("Server %s the device", locked ? "locked" : "released");
 	} else {
 		char addr[BT_ADDR_LE_STR_LEN];
 
 		conn_addr_str(conn, addr, sizeof(addr));
 
-		shell_print(ctx_shell, "Client %s %s the device",
-			    addr, locked ? "locked" : "released");
+		LOG_DBG("Client %s %s the device", addr, locked ? "locked" : "released");
 	}
 }
 
@@ -50,8 +50,8 @@ static uint8_t sirk_read_req_cb(struct bt_conn *conn,
 
 	conn_addr_str(conn, addr, sizeof(addr));
 
-	shell_print(ctx_shell, "Client %s requested to read the sirk. "
-		    "Responding with %s", addr, rsp_strings[sirk_read_rsp]);
+	LOG_DBG("Client %s requested to read the sirk. Responding with %s", addr,
+		rsp_strings[sirk_read_rsp]);
 
 	return sirk_read_rsp;
 }
@@ -316,12 +316,12 @@ ssize_t csis_ad_data_add(struct bt_data *data_array, const size_t data_array_siz
 		 */
 		if (IS_ENABLED(CONFIG_BT_PRIVACY) &&
 		    !IS_ENABLED(CONFIG_BT_CSIP_SET_MEMBER_ENC_SIRK_SUPPORT)) {
-			shell_warn(ctx_shell, "RSI derived from unencrypted SIRK");
+			LOG_WRN("RSI derived from unencrypted SIRK");
 		}
 
 		err = bt_csip_set_member_generate_rsi(svc_inst, ad_rsi);
 		if (err != 0) {
-			shell_error(ctx_shell, "Failed to generate RSI (err %d)", err);
+			LOG_ERR("Failed to generate RSI (err %d)", err);
 			return err;
 		}
 

--- a/subsys/bluetooth/audio/shell/gmap.c
+++ b/subsys/bluetooth/audio/shell/gmap.c
@@ -14,12 +14,15 @@
 #include <zephyr/bluetooth/audio/gmap_lc3_preset.h>
 #include <zephyr/bluetooth/audio/gmap.h>
 #include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
 
 #include "shell/bt.h"
 #include "audio.h"
+
+LOG_MODULE_REGISTER(gmap_shell, LOG_LEVEL_DBG);
 
 #define UNICAST_SINK_SUPPORTED (CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT > 0)
 #define UNICAST_SRC_SUPPORTED  (CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT > 0)
@@ -55,15 +58,14 @@ static void gmap_discover_cb(struct bt_conn *conn, int err, enum bt_gmap_role ro
 			     struct bt_gmap_feat features)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "gmap discovery (err %d)", err);
+		LOG_ERR("gmap discovery (err %d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell,
-		    "gmap discovered for conn %p:\n\trole 0x%02x\n\tugg_feat 0x%02x\n\tugt_feat "
-		    "0x%02x\n\tbgs_feat 0x%02x\n\tbgr_feat 0x%02x",
-		    conn, role, features.ugg_feat, features.ugt_feat, features.bgs_feat,
-		    features.bgr_feat);
+	LOG_DBG("gmap discovered for conn %p:\n\trole 0x%02x\n\tugg_feat 0x%02x\n\tugt_feat "
+		"0x%02x\n\tbgs_feat 0x%02x\n\tbgr_feat 0x%02x",
+		(void *)conn, role, features.ugg_feat, features.ugt_feat, features.bgs_feat,
+		features.bgr_feat);
 }
 
 static const struct bt_gmap_cb gmap_cb = {
@@ -186,10 +188,6 @@ static int cmd_gmap_discover(const struct shell *sh, size_t argc, char **argv)
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
-	}
-
-	if (!ctx_shell) {
-		ctx_shell = sh;
 	}
 
 	err = bt_gmap_discover(default_conn);

--- a/subsys/bluetooth/audio/shell/has.c
+++ b/subsys/bluetooth/audio/shell/has.c
@@ -11,11 +11,14 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/audio/has.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
 #include <stdlib.h>
 #include <stdio.h>
 
 #include "shell/bt.h"
+
+LOG_MODULE_REGISTER(has_shell, LOG_LEVEL_DBG);
 
 static int preset_select(uint8_t index, bool sync)
 {
@@ -24,7 +27,7 @@ static int preset_select(uint8_t index, bool sync)
 
 static void preset_name_changed(uint8_t index, const char *name)
 {
-	shell_print(ctx_shell, "Preset name changed index %u name %s", index, name);
+	LOG_DBG("Preset name changed index %u name %s", index, name);
 }
 
 static const struct bt_has_preset_ops preset_ops = {

--- a/subsys/bluetooth/audio/shell/mcc.c
+++ b/subsys/bluetooth/audio/shell/mcc.c
@@ -11,6 +11,7 @@
 
 #include <stdlib.h>
 #include <zephyr/bluetooth/audio/mcc.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
@@ -23,7 +24,7 @@
 
 #include <zephyr/logging/log.h>
 
-LOG_MODULE_REGISTER(bt_mcc_shell, CONFIG_BT_MCC_LOG_LEVEL);
+LOG_MODULE_REGISTER(mcc_shell, LOG_LEVEL_DBG);
 
 static struct bt_mcc_cb cb;
 
@@ -44,21 +45,21 @@ static struct object_ids_t obj_ids;
 static void mcc_discover_mcs_cb(struct bt_conn *conn, int err)
 {
 	if (err) {
-		shell_error(ctx_shell, "Discovery failed (%d)", err);
+		LOG_ERR("Discovery failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Discovery complete");
+	LOG_DBG("Discovery complete");
 }
 
 static void mcc_read_player_name_cb(struct bt_conn *conn, int err, const char *name)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player Name read failed (%d)", err);
+		LOG_ERR("Player Name read failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player name: %s", name);
+	LOG_DBG("Player name: %s", name);
 }
 
 #ifdef CONFIG_BT_MCC_OTS
@@ -67,12 +68,12 @@ static void mcc_read_icon_obj_id_cb(struct bt_conn *conn, int err, uint64_t id)
 	char str[BT_OTS_OBJ_ID_STR_LEN];
 
 	if (err) {
-		shell_error(ctx_shell, "Icon Object ID read failed (%d)", err);
+		LOG_ERR("Icon Object ID read failed (%d)", err);
 		return;
 	}
 
 	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Icon object ID: %s", str);
+	LOG_DBG("Icon object ID: %s", str);
 
 	obj_ids.icon_obj_id = id;
 }
@@ -82,11 +83,11 @@ static void mcc_read_icon_obj_id_cb(struct bt_conn *conn, int err, uint64_t id)
 static void mcc_read_icon_url_cb(struct bt_conn *conn, int err, const char *url)
 {
 	if (err) {
-		shell_error(ctx_shell, "Icon URL read failed (%d)", err);
+		LOG_ERR("Icon URL read failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Icon URL: 0x%s", url);
+	LOG_DBG("Icon URL: 0x%s", url);
 }
 #endif /* defined(CONFIG_BT_MCC_READ_MEDIA_PLAYER_ICON_URL) */
 
@@ -94,33 +95,33 @@ static void mcc_read_icon_url_cb(struct bt_conn *conn, int err, const char *url)
 static void mcc_read_track_title_cb(struct bt_conn *conn, int err, const char *title)
 {
 	if (err) {
-		shell_error(ctx_shell, "Track title read failed (%d)", err);
+		LOG_ERR("Track title read failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Track title: %s", title);
+	LOG_DBG("Track title: %s", title);
 }
 #endif /* defined(CONFIG_BT_MCC_READ_TRACK_TITLE) */
 
 static void mcc_track_changed_ntf_cb(struct bt_conn *conn, int err)
 {
 	if (err) {
-		shell_error(ctx_shell, "Track changed notification failed (%d)", err);
+		LOG_ERR("Track changed notification failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Track changed");
+	LOG_DBG("Track changed");
 }
 
 #if defined(CONFIG_BT_MCC_READ_TRACK_DURATION)
 static void mcc_read_track_duration_cb(struct bt_conn *conn, int err, int32_t dur)
 {
 	if (err) {
-		shell_error(ctx_shell, "Track duration read failed (%d)", err);
+		LOG_ERR("Track duration read failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Track duration: %d", dur);
+	LOG_DBG("Track duration: %d", dur);
 }
 #endif /* defined(CONFIG_BT_MCC_READ_TRACK_DURATION) */
 
@@ -128,11 +129,11 @@ static void mcc_read_track_duration_cb(struct bt_conn *conn, int err, int32_t du
 static void mcc_read_track_position_cb(struct bt_conn *conn, int err, int32_t pos)
 {
 	if (err) {
-		shell_error(ctx_shell, "Track position read failed (%d)", err);
+		LOG_ERR("Track position read failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Track Position: %d", pos);
+	LOG_DBG("Track Position: %d", pos);
 }
 #endif /* defined(CONFIG_BT_MCC_READ_TRACK_POSITION) */
 
@@ -140,11 +141,11 @@ static void mcc_read_track_position_cb(struct bt_conn *conn, int err, int32_t po
 static void mcc_set_track_position_cb(struct bt_conn *conn, int err, int32_t pos)
 {
 	if (err) {
-		shell_error(ctx_shell, "Track Position set failed (%d)", err);
+		LOG_ERR("Track Position set failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Track Position: %d", pos);
+	LOG_DBG("Track Position: %d", pos);
 }
 #endif /* defined(CONFIG_BT_MCC_SET_TRACK_POSITION) */
 
@@ -153,11 +154,11 @@ static void mcc_read_playback_speed_cb(struct bt_conn *conn, int err,
 				       int8_t speed)
 {
 	if (err) {
-		shell_error(ctx_shell, "Playback speed read failed (%d)", err);
+		LOG_ERR("Playback speed read failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Playback speed: %d", speed);
+	LOG_DBG("Playback speed: %d", speed);
 }
 #endif /* defined (CONFIG_BT_MCC_READ_PLAYBACK_SPEED) */
 
@@ -165,11 +166,11 @@ static void mcc_read_playback_speed_cb(struct bt_conn *conn, int err,
 static void mcc_set_playback_speed_cb(struct bt_conn *conn, int err, int8_t speed)
 {
 	if (err) {
-		shell_error(ctx_shell, "Playback speed set failed (%d)", err);
+		LOG_ERR("Playback speed set failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Playback speed: %d", speed);
+	LOG_DBG("Playback speed: %d", speed);
 }
 #endif /* defined (CONFIG_BT_MCC_SET_PLAYBACK_SPEED) */
 
@@ -178,11 +179,11 @@ static void mcc_read_seeking_speed_cb(struct bt_conn *conn, int err,
 				      int8_t speed)
 {
 	if (err) {
-		shell_error(ctx_shell, "Seeking speed read failed (%d)", err);
+		LOG_ERR("Seeking speed read failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Seeking speed: %d", speed);
+	LOG_DBG("Seeking speed: %d", speed);
 }
 #endif /* defined (CONFIG_BT_MCC_READ_SEEKING_SPEED) */
 
@@ -194,13 +195,12 @@ static void mcc_read_segments_obj_id_cb(struct bt_conn *conn, int err,
 	char str[BT_OTS_OBJ_ID_STR_LEN];
 
 	if (err) {
-		shell_error(ctx_shell,
-			    "Track Segments Object ID read failed (%d)", err);
+		LOG_ERR("Track Segments Object ID read failed (%d)", err);
 		return;
 	}
 
 	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Track Segments Object ID: %s", str);
+	LOG_DBG("Track Segments Object ID: %s", str);
 
 	obj_ids.track_segments_obj_id = id;
 }
@@ -212,13 +212,12 @@ static void mcc_read_current_track_obj_id_cb(struct bt_conn *conn, int err,
 	char str[BT_OTS_OBJ_ID_STR_LEN];
 
 	if (err) {
-		shell_error(ctx_shell, "Current Track Object ID read failed (%d)",
-			    err);
+		LOG_ERR("Current Track Object ID read failed (%d)", err);
 		return;
 	}
 
 	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Current Track Object ID: %s", str);
+	LOG_DBG("Current Track Object ID: %s", str);
 
 	obj_ids.current_track_obj_id = id;
 }
@@ -230,12 +229,12 @@ static void mcc_set_current_track_obj_id_cb(struct bt_conn *conn, int err,
 	char str[BT_OTS_OBJ_ID_STR_LEN];
 
 	if (err) {
-		shell_error(ctx_shell, "Current Track Object ID set failed (%d)", err);
+		LOG_ERR("Current Track Object ID set failed (%d)", err);
 		return;
 	}
 
 	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Current Track Object ID written: %s", str);
+	LOG_DBG("Current Track Object ID written: %s", str);
 }
 
 
@@ -245,16 +244,15 @@ static void mcc_read_next_track_obj_id_cb(struct bt_conn *conn, int err,
 	char str[BT_OTS_OBJ_ID_STR_LEN];
 
 	if (err) {
-		shell_error(ctx_shell, "Next Track Object ID read failed (%d)",
-			    err);
+		LOG_ERR("Next Track Object ID read failed (%d)", err);
 		return;
 	}
 
 	if (id == MPL_NO_TRACK_ID) {
-		shell_print(ctx_shell, "Next Track Object ID is empty");
+		LOG_DBG("Next Track Object ID is empty");
 	} else {
 		(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-		shell_print(ctx_shell, "Next Track Object ID: %s", str);
+		LOG_DBG("Next Track Object ID: %s", str);
 	}
 
 	obj_ids.next_track_obj_id = id;
@@ -267,12 +265,12 @@ static void mcc_set_next_track_obj_id_cb(struct bt_conn *conn, int err,
 	char str[BT_OTS_OBJ_ID_STR_LEN];
 
 	if (err) {
-		shell_error(ctx_shell, "Next Track Object ID set failed (%d)", err);
+		LOG_ERR("Next Track Object ID set failed (%d)", err);
 		return;
 	}
 
 	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Next Track Object ID written: %s", str);
+	LOG_DBG("Next Track Object ID written: %s", str);
 }
 
 
@@ -282,13 +280,12 @@ static void mcc_read_parent_group_obj_id_cb(struct bt_conn *conn, int err,
 	char str[BT_OTS_OBJ_ID_STR_LEN];
 
 	if (err) {
-		shell_error(ctx_shell,
-			    "Parent Group Object ID read failed (%d)", err);
+		LOG_ERR("Parent Group Object ID read failed (%d)", err);
 		return;
 	}
 
 	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Parent Group Object ID: %s", str);
+	LOG_DBG("Parent Group Object ID: %s", str);
 
 	obj_ids.parent_group_obj_id = id;
 }
@@ -300,13 +297,12 @@ static void mcc_read_current_group_obj_id_cb(struct bt_conn *conn, int err,
 	char str[BT_OTS_OBJ_ID_STR_LEN];
 
 	if (err) {
-		shell_error(ctx_shell,
-			    "Current Group Object ID read failed (%d)", err);
+		LOG_ERR("Current Group Object ID read failed (%d)", err);
 		return;
 	}
 
 	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Current Group Object ID: %s", str);
+	LOG_DBG("Current Group Object ID: %s", str);
 
 	obj_ids.current_group_obj_id = id;
 }
@@ -317,12 +313,12 @@ static void mcc_set_current_group_obj_id_cb(struct bt_conn *conn, int err,
 	char str[BT_OTS_OBJ_ID_STR_LEN];
 
 	if (err) {
-		shell_error(ctx_shell, "Current Group Object ID set failed (%d)", err);
+		LOG_ERR("Current Group Object ID set failed (%d)", err);
 		return;
 	}
 
 	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Current Group Object ID written: %s", str);
+	LOG_DBG("Current Group Object ID written: %s", str);
 }
 #endif /* CONFIG_BT_MCC_OTS */
 
@@ -331,11 +327,11 @@ static void mcc_set_current_group_obj_id_cb(struct bt_conn *conn, int err,
 static void mcc_read_playing_order_cb(struct bt_conn *conn, int err, uint8_t order)
 {
 	if (err) {
-		shell_error(ctx_shell, "Playing order read failed (%d)", err);
+		LOG_ERR("Playing order read failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Playing order: %d", order);
+	LOG_DBG("Playing order: %d", order);
 }
 #endif /* defined(CONFIG_BT_MCC_READ_PLAYING_ORDER) */
 
@@ -343,11 +339,11 @@ static void mcc_read_playing_order_cb(struct bt_conn *conn, int err, uint8_t ord
 static void mcc_set_playing_order_cb(struct bt_conn *conn, int err, uint8_t order)
 {
 	if (err) {
-		shell_error(ctx_shell, "Playing order set failed (%d)", err);
+		LOG_ERR("Playing order set failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Playing order: %d", order);
+	LOG_DBG("Playing order: %d", order);
 }
 #endif /* defined(CONFIG_BT_MCC_SET_PLAYING_ORDER) */
 
@@ -356,12 +352,11 @@ static void mcc_read_playing_orders_supported_cb(struct bt_conn *conn, int err,
 						 uint16_t orders)
 {
 	if (err) {
-		shell_error(ctx_shell,
-			    "Playing orders supported read failed (%d)", err);
+		LOG_ERR("Playing orders supported read failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Playing orders supported: %d", orders);
+	LOG_DBG("Playing orders supported: %d", orders);
 }
 #endif /* defined(CONFIG_BT_MCC_READ_PLAYING_ORDER_SUPPORTED) */
 
@@ -369,11 +364,11 @@ static void mcc_read_playing_orders_supported_cb(struct bt_conn *conn, int err,
 static void mcc_read_media_state_cb(struct bt_conn *conn, int err, uint8_t state)
 {
 	if (err) {
-		shell_error(ctx_shell, "Media State read failed (%d)", err);
+		LOG_ERR("Media State read failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Media State: %d", state);
+	LOG_DBG("Media State: %d", state);
 }
 #endif /* defined(CONFIG_BT_MCC_READ_MEDIA_STATE) */
 
@@ -381,13 +376,12 @@ static void mcc_read_media_state_cb(struct bt_conn *conn, int err, uint8_t state
 static void mcc_send_cmd_cb(struct bt_conn *conn, int err, const struct mpl_cmd *cmd)
 {
 	if (err) {
-		shell_error(ctx_shell,
-			    "Command send failed (%d) - opcode: %d, param: %d",
-			    err, cmd->opcode, cmd->param);
+		LOG_ERR("Command send failed (%d) - opcode: %d, param: %d", err, cmd->opcode,
+			cmd->param);
 		return;
 	}
 
-	shell_print(ctx_shell, "Command opcode: %d, param: %d", cmd->opcode, cmd->param);
+	LOG_DBG("Command opcode: %d, param: %d", cmd->opcode, cmd->param);
 }
 #endif /* defined(CONFIG_BT_MCC_SET_MEDIA_CONTROL_POINT) */
 
@@ -395,14 +389,12 @@ static void mcc_cmd_ntf_cb(struct bt_conn *conn, int err,
 			   const struct mpl_cmd_ntf *ntf)
 {
 	if (err) {
-		shell_error(ctx_shell,
-			    "Command notification error (%d) - opcode: %d, result: %d",
-			    err, ntf->requested_opcode, ntf->result_code);
+		LOG_ERR("Command notification error (%d) - opcode: %d, result: %d", err,
+			ntf->requested_opcode, ntf->result_code);
 		return;
 	}
 
-	shell_print(ctx_shell, "Command opcode: %d, result: %d",
-		    ntf->requested_opcode, ntf->result_code);
+	LOG_DBG("Command opcode: %d, result: %d", ntf->requested_opcode, ntf->result_code);
 }
 
 #if defined(CONFIG_BT_MCC_READ_MEDIA_CONTROL_POINT_OPCODES_SUPPORTED)
@@ -410,12 +402,11 @@ static void mcc_read_opcodes_supported_cb(struct bt_conn *conn, int err,
 					    uint32_t opcodes)
 {
 	if (err) {
-		shell_error(ctx_shell, "Opcodes supported read failed (%d)",
-			    err);
+		LOG_ERR("Opcodes supported read failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Opcodes supported: %d", opcodes);
+	LOG_DBG("Opcodes supported: %d", opcodes);
 }
 #endif /* defined(CONFIG_BT_MCC_READ_MEDIA_CONTROL_POINT_OPCODES_SUPPORTED) */
 
@@ -424,25 +415,21 @@ static void mcc_send_search_cb(struct bt_conn *conn, int err,
 			       const struct mpl_search *search)
 {
 	if (err) {
-		shell_error(ctx_shell,
-			    "Search send failed (%d)", err);
+		LOG_ERR("Search send failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Search sent");
+	LOG_DBG("Search sent");
 }
 
 static void mcc_search_ntf_cb(struct bt_conn *conn, int err, uint8_t result_code)
 {
 	if (err) {
-		shell_error(ctx_shell,
-			    "Search notification error (%d), result code: %d",
-			    err, result_code);
+		LOG_ERR("Search notification error (%d), result code: %d", err, result_code);
 		return;
 	}
 
-	shell_print(ctx_shell, "Search notification result code: %d",
-		    result_code);
+	LOG_DBG("Search notification result code: %d", result_code);
 }
 
 static void mcc_read_search_results_obj_id_cb(struct bt_conn *conn, int err,
@@ -451,16 +438,15 @@ static void mcc_read_search_results_obj_id_cb(struct bt_conn *conn, int err,
 	char str[BT_OTS_OBJ_ID_STR_LEN];
 
 	if (err) {
-		shell_error(ctx_shell,
-			    "Search Results Object ID read failed (%d)", err);
+		LOG_ERR("Search Results Object ID read failed (%d)", err);
 		return;
 	}
 
 	if (id == 0) {
-		shell_print(ctx_shell, "Search Results Object ID: 0x000000000000");
+		LOG_DBG("Search Results Object ID: 0x000000000000");
 	} else {
 		(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-		shell_print(ctx_shell, "Search Results Object ID: %s", str);
+		LOG_DBG("Search Results Object ID: %s", str);
 	}
 
 	obj_ids.search_results_obj_id = id;
@@ -471,11 +457,11 @@ static void mcc_read_search_results_obj_id_cb(struct bt_conn *conn, int err,
 static void mcc_read_content_control_id_cb(struct bt_conn *conn, int err, uint8_t ccid)
 {
 	if (err) {
-		shell_error(ctx_shell, "Content Control ID read failed (%d)", err);
+		LOG_ERR("Content Control ID read failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Content Control ID: %d", ccid);
+	LOG_DBG("Content Control ID: %d", ccid);
 }
 #endif /* defined(CONFIG_BT_MCC_READ_CONTENT_CONTROL_ID) */
 
@@ -484,36 +470,33 @@ static void mcc_read_content_control_id_cb(struct bt_conn *conn, int err, uint8_
 static void mcc_otc_obj_selected_cb(struct bt_conn *conn, int err)
 {
 	if (err) {
-		shell_error(ctx_shell,
-			    "Error in selecting object (err %d)", err);
+		LOG_ERR("Error in selecting object (err %d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Selecting object succeeded");
+	LOG_DBG("Selecting object succeeded");
 }
 
 static void mcc_otc_obj_metadata_cb(struct bt_conn *conn, int err)
 {
 	if (err) {
-		shell_error(ctx_shell,
-			    "Error in reading object metadata (err %d)", err);
+		LOG_ERR("Error in reading object metadata (err %d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Reading object metadata succeeded\n");
+	LOG_DBG("Reading object metadata succeeded\n");
 }
 
 static void mcc_icon_object_read_cb(struct bt_conn *conn, int err,
 				    struct net_buf_simple *buf)
 {
 	if (err) {
-		shell_error(ctx_shell,
-			    "Icon Object read failed (%d)", err);
+		LOG_ERR("Icon Object read failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Icon content (%d octets)", buf->len);
-	shell_hexdump(ctx_shell, buf->data, buf->len);
+	LOG_DBG("Icon content (%d octets)", buf->len);
+	LOG_HEXDUMP_DBG(buf->data, buf->len, "");
 }
 
 /* TODO: May want to use a parsed type, instead of the raw buf, here */
@@ -521,65 +504,60 @@ static void mcc_track_segments_object_read_cb(struct bt_conn *conn, int err,
 					      struct net_buf_simple *buf)
 {
 	if (err) {
-		shell_error(ctx_shell,
-			    "Track Segments Object read failed (%d)", err);
+		LOG_ERR("Track Segments Object read failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Track Segments content (%d octets)", buf->len);
-	shell_hexdump(ctx_shell, buf->data, buf->len);
+	LOG_DBG("Track Segments content (%d octets)", buf->len);
+	LOG_HEXDUMP_DBG(buf->data, buf->len, "");
 }
 
 static void mcc_otc_read_current_track_object_cb(struct bt_conn *conn, int err,
 						 struct net_buf_simple *buf)
 {
 	if (err) {
-		shell_error(ctx_shell,
-			    "Current Track Object read failed (%d)", err);
+		LOG_ERR("Current Track Object read failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Current Track content (%d octets)", buf->len);
-	shell_hexdump(ctx_shell, buf->data, buf->len);
+	LOG_DBG("Current Track content (%d octets)", buf->len);
+	LOG_HEXDUMP_DBG(buf->data, buf->len, "");
 }
 
 static void mcc_otc_read_next_track_object_cb(struct bt_conn *conn, int err,
 						 struct net_buf_simple *buf)
 {
 	if (err) {
-		shell_error(ctx_shell,
-			    "Next Track Object read failed (%d)", err);
+		LOG_ERR("Next Track Object read failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Next Track content (%d octets)", buf->len);
-	shell_hexdump(ctx_shell, buf->data, buf->len);
+	LOG_DBG("Next Track content (%d octets)", buf->len);
+	LOG_HEXDUMP_DBG(buf->data, buf->len, "");
 }
 
 static void mcc_otc_read_parent_group_object_cb(struct bt_conn *conn, int err,
 						struct net_buf_simple *buf)
 {
 	if (err) {
-		shell_error(ctx_shell,
-			    "Parent Group Object read failed (%d)", err);
+		LOG_ERR("Parent Group Object read failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Parent Group content (%d octets)", buf->len);
-	shell_hexdump(ctx_shell, buf->data, buf->len);
+	LOG_DBG("Parent Group content (%d octets)", buf->len);
+	LOG_HEXDUMP_DBG(buf->data, buf->len, "");
 }
 
 static void mcc_otc_read_current_group_object_cb(struct bt_conn *conn, int err,
 						 struct net_buf_simple *buf)
 {
 	if (err) {
-		shell_error(ctx_shell,
-			    "Current Group Object read failed (%d)", err);
+		LOG_ERR("Current Group Object read failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Current Group content (%d octets)", buf->len);
-	shell_hexdump(ctx_shell, buf->data, buf->len);
+	LOG_DBG("Current Group content (%d octets)", buf->len);
+	LOG_HEXDUMP_DBG(buf->data, buf->len, "");
 }
 
 #endif /* CONFIG_BT_MCC_OTS */
@@ -588,10 +566,6 @@ static void mcc_otc_read_current_group_object_cb(struct bt_conn *conn, int err,
 static int cmd_mcc_init(const struct shell *sh, size_t argc, char **argv)
 {
 	int result;
-
-	if (!ctx_shell) {
-		ctx_shell = sh;
-	}
 
 	/* Set up the callbacks */
 	cb.discover_mcs                  = mcc_discover_mcs_cb;

--- a/subsys/bluetooth/audio/shell/media_controller.c
+++ b/subsys/bluetooth/audio/shell/media_controller.c
@@ -10,6 +10,7 @@
  */
 
 #include <stdlib.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
@@ -22,7 +23,7 @@
 
 #include <zephyr/logging/log.h>
 
-LOG_MODULE_REGISTER(bt_media_controller_shell, CONFIG_BT_MCS_LOG_LEVEL);
+LOG_MODULE_REGISTER(media_controller_shell, CONFIG_BT_MCS_LOG_LEVEL);
 
 static struct media_proxy_ctrl_cbs cbs;
 
@@ -38,12 +39,12 @@ static struct media_player *current_player;
 static void local_player_instance_cb(struct media_player *plr, int err)
 {
 	if (err) {
-		shell_error(ctx_shell, "Local player instance failed (%d)", err);
+		LOG_ERR("Local player instance failed (%d)", err);
 		return;
 	}
 
 	local_player = plr;
-	shell_print(ctx_shell, "Local player instance: %p", local_player);
+	LOG_DBG("Local player instance: %p", (void *)local_player);
 
 	if (!current_player) {
 		current_player = local_player;
@@ -54,12 +55,12 @@ static void local_player_instance_cb(struct media_player *plr, int err)
 static void discover_player_cb(struct media_player *plr, int err)
 {
 	if (err) {
-		shell_error(ctx_shell, "Discover player failed (%d)", err);
+		LOG_ERR("Discover player failed (%d)", err);
 		return;
 	}
 
 	remote_player = plr;
-	shell_print(ctx_shell, "Discovered player instance: %p", remote_player);
+	LOG_DBG("Discovered player instance: %p", (void *)remote_player);
 
 	/* Assuming that since discovery was called, the remote player is wanted */
 	current_player = remote_player;
@@ -69,11 +70,11 @@ static void discover_player_cb(struct media_player *plr, int err)
 static void player_name_cb(struct media_player *plr, int err, const char *name)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Player name failed (%d)", plr, err);
+		LOG_ERR("Player: %p, Player name failed (%d)", (void *)plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Player name: %s", plr, name);
+	LOG_DBG("Player: %p, Player name: %s", (void *)plr, name);
 }
 
 static void icon_id_cb(struct media_player *plr, int err, uint64_t id)
@@ -81,102 +82,102 @@ static void icon_id_cb(struct media_player *plr, int err, uint64_t id)
 	char str[BT_OTS_OBJ_ID_STR_LEN];
 
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Icon ID failed (%d)", plr, err);
+		LOG_ERR("Player: %p, Icon ID failed (%d)", (void *)plr, err);
 		return;
 	}
 
 	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Player: %p, Icon Object ID: %s", plr, str);
+	LOG_DBG("Player: %p, Icon Object ID: %s", (void *)plr, str);
 }
 
 static void icon_url_cb(struct media_player *plr, int err, const char *url)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Icon URL failed (%d)", plr, err);
+		LOG_ERR("Player: %p, Icon URL failed (%d)", (void *)plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Icon URL: %s", plr, url);
+	LOG_DBG("Player: %p, Icon URL: %s", (void *)plr, url);
 }
 
 static void track_changed_cb(struct media_player *plr, int err)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Track change failed (%d)", plr, err);
+		LOG_ERR("Player: %p, Track change failed (%d)", (void *)plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Track changed", plr);
+	LOG_DBG("Player: %p, Track changed", (void *)plr);
 }
 
 static void track_title_cb(struct media_player *plr, int err, const char *title)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Track title failed (%d)", plr, err);
+		LOG_ERR("Player: %p, Track title failed (%d)", (void *)plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Track title: %s", plr, title);
+	LOG_DBG("Player: %p, Track title: %s", (void *)plr, title);
 }
 
 static void track_duration_cb(struct media_player *plr, int err, int32_t duration)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Track duration failed (%d)", plr, err);
+		LOG_ERR("Player: %p, Track duration failed (%d)", (void *)plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Track duration: %d", plr, duration);
+	LOG_DBG("Player: %p, Track duration: %d", (void *)plr, duration);
 }
 
 static void track_position_recv_cb(struct media_player *plr, int err, int32_t position)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Track position receive failed (%d)", plr, err);
+		LOG_ERR("Player: %p, Track position receive failed (%d)", (void *)plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Track Position received: %d", plr, position);
+	LOG_DBG("Player: %p, Track Position received: %d", (void *)plr, position);
 }
 
 static void track_position_write_cb(struct media_player *plr, int err, int32_t position)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Track position write failed (%d)", plr, err);
+		LOG_ERR("Player: %p, Track position write failed (%d)", (void *)plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Track Position write: %d", plr, position);
+	LOG_DBG("Player: %p, Track Position write: %d", (void *)plr, position);
 }
 
 static void playback_speed_recv_cb(struct media_player *plr, int err, int8_t speed)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Playback speed receive failed (%d)", plr, err);
+		LOG_ERR("Player: %p, Playback speed receive failed (%d)", (void *)plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Playback speed received: %d", plr, speed);
+	LOG_DBG("Player: %p, Playback speed received: %d", (void *)plr, speed);
 }
 
 static void playback_speed_write_cb(struct media_player *plr, int err, int8_t speed)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Playback speed write failed (%d)", plr, err);
+		LOG_ERR("Player: %p, Playback speed write failed (%d)", (void *)plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Playback speed write: %d", plr, speed);
+	LOG_DBG("Player: %p, Playback speed write: %d", (void *)plr, speed);
 }
 
 static void seeking_speed_cb(struct media_player *plr, int err, int8_t speed)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Seeking speed failed (%d)", plr, err);
+		LOG_ERR("Player: %p, Seeking speed failed (%d)", (void *)plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Seeking speed: %d", plr, speed);
+	LOG_DBG("Player: %p, Seeking speed: %d", (void *)plr, speed);
 }
 
 #ifdef CONFIG_BT_OTS
@@ -185,12 +186,12 @@ static void track_segments_id_cb(struct media_player *plr, int err, uint64_t id)
 	char str[BT_OTS_OBJ_ID_STR_LEN];
 
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Track segments ID failed (%d)", plr, err);
+		LOG_ERR("Player: %p, Track segments ID failed (%d)", (void *)plr, err);
 		return;
 	}
 
 	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Player: %p, Track Segments Object ID: %s", plr, str);
+	LOG_DBG("Player: %p, Track Segments Object ID: %s", (void *)plr, str);
 }
 
 static void current_track_id_cb(struct media_player *plr, int err, uint64_t id)
@@ -198,12 +199,12 @@ static void current_track_id_cb(struct media_player *plr, int err, uint64_t id)
 	char str[BT_OTS_OBJ_ID_STR_LEN];
 
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Current track ID failed (%d)", plr, err);
+		LOG_ERR("Player: %p, Current track ID failed (%d)", (void *)plr, err);
 		return;
 	}
 
 	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Player: %p, Current Track Object ID: %s", plr, str);
+	LOG_DBG("Player: %p, Current Track Object ID: %s", (void *)plr, str);
 }
 
 static void next_track_id_cb(struct media_player *plr, int err, uint64_t id)
@@ -211,15 +212,15 @@ static void next_track_id_cb(struct media_player *plr, int err, uint64_t id)
 	char str[BT_OTS_OBJ_ID_STR_LEN];
 
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Next track ID failed (%d)", plr, err);
+		LOG_ERR("Player: %p, Next track ID failed (%d)", (void *)plr, err);
 		return;
 	}
 
 	if (id == MPL_NO_TRACK_ID) {
-		shell_print(ctx_shell, "Player: %p, Next Track Object ID is empty", plr);
+		LOG_DBG("Player: %p, Next Track Object ID is empty", (void *)plr);
 	} else {
 		(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-		shell_print(ctx_shell, "Player: %p, Next Track Object ID: %s", plr, str);
+		LOG_DBG("Player: %p, Next Track Object ID: %s", (void *)plr, str);
 	}
 }
 
@@ -228,12 +229,12 @@ static void current_group_id_cb(struct media_player *plr, int err, uint64_t id)
 	char str[BT_OTS_OBJ_ID_STR_LEN];
 
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Current group ID failed (%d)", plr, err);
+		LOG_ERR("Player: %p, Current group ID failed (%d)", (void *)plr, err);
 		return;
 	}
 
 	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Player: %p, Current Group Object ID: %s", plr, str);
+	LOG_DBG("Player: %p, Current Group Object ID: %s", (void *)plr, str);
 }
 
 static void parent_group_id_cb(struct media_player *plr, int err, uint64_t id)
@@ -241,87 +242,86 @@ static void parent_group_id_cb(struct media_player *plr, int err, uint64_t id)
 	char str[BT_OTS_OBJ_ID_STR_LEN];
 
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Parent group ID failed (%d)", plr, err);
+		LOG_ERR("Player: %p, Parent group ID failed (%d)", (void *)plr, err);
 		return;
 	}
 
 	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Player: %p, Parent Group Object ID: %s", plr, str);
+	LOG_DBG("Player: %p, Parent Group Object ID: %s", (void *)plr, str);
 }
 #endif /* CONFIG_BT_OTS */
 
 static void playing_order_recv_cb(struct media_player *plr, int err, uint8_t order)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Playing order receive_failed (%d)", plr, err);
+		LOG_ERR("Player: %p, Playing order receive_failed (%d)", (void *)plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Playing received: %u", plr, order);
+	LOG_DBG("Player: %p, Playing received: %u", (void *)plr, order);
 }
 
 static void playing_order_write_cb(struct media_player *plr, int err, uint8_t order)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Playing order write_failed (%d)", plr, err);
+		LOG_ERR("Player: %p, Playing order write_failed (%d)", (void *)plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Playing written: %u", plr, order);
+	LOG_DBG("Player: %p, Playing written: %u", (void *)plr, order);
 }
 
 static void playing_orders_supported_cb(struct media_player *plr, int err, uint16_t orders)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Playing orders supported failed (%d)",
-			    plr, err);
+		LOG_ERR("Player: %p, Playing orders supported failed (%d)", (void *)plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Playing orders supported: %u", plr, orders);
+	LOG_DBG("Player: %p, Playing orders supported: %u", (void *)plr, orders);
 	/* TODO: Parse bitmap and output list of playing orders */
 }
 
 static void media_state_cb(struct media_player *plr, int err, uint8_t state)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Media state failed (%d)", plr, err);
+		LOG_ERR("Player: %p, Media state failed (%d)", (void *)plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Media State: %u", plr, state);
+	LOG_DBG("Player: %p, Media State: %u", (void *)plr, state);
 	/* TODO: Parse state and output state name (e.g. "Playing") */
 }
 
 static void command_send_cb(struct media_player *plr, int err, const struct mpl_cmd *cmd)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Command send failed (%d)", plr, err);
+		LOG_ERR("Player: %p, Command send failed (%d)", (void *)plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Command opcode sent: %u", plr, cmd->opcode);
+	LOG_DBG("Player: %p, Command opcode sent: %u", (void *)plr, cmd->opcode);
 }
 
 static void command_recv_cb(struct media_player *plr, int err, const struct mpl_cmd_ntf *cmd_ntf)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Command failed (%d)", plr, err);
+		LOG_ERR("Player: %p, Command failed (%d)", (void *)plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Command opcode: %u, result: %u",
-		    plr, cmd_ntf->requested_opcode, cmd_ntf->result_code);
+	LOG_DBG("Player: %p, Command opcode: %u, result: %u", (void *)plr,
+		cmd_ntf->requested_opcode, cmd_ntf->result_code);
 }
 
 static void commands_supported_cb(struct media_player *plr, int err, uint32_t opcodes)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Commands supported failed (%d)", plr, err);
+		LOG_ERR("Player: %p, Commands supported failed (%d)", (void *)plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Command opcodes supported: %u", plr, opcodes);
+	LOG_DBG("Player: %p, Command opcodes supported: %u", (void *)plr, opcodes);
 	/* TODO: Parse bitmap and output list of opcodes */
 }
 
@@ -329,21 +329,21 @@ static void commands_supported_cb(struct media_player *plr, int err, uint32_t op
 static void search_send_cb(struct media_player *plr, int err, const struct mpl_search *search)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Search send failed (%d)", plr, err);
+		LOG_ERR("Player: %p, Search send failed (%d)", (void *)plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Search sent with len %u", plr, search->len);
+	LOG_DBG("Player: %p, Search sent with len %u", (void *)plr, search->len);
 }
 
 static void search_recv_cb(struct media_player *plr, int err, uint8_t result_code)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Search failed (%d)", plr, err);
+		LOG_ERR("Player: %p, Search failed (%d)", (void *)plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Search result code: %u", plr, result_code);
+	LOG_DBG("Player: %p, Search result code: %u", (void *)plr, result_code);
 }
 
 static void search_results_id_cb(struct media_player *plr, int err, uint64_t id)
@@ -351,40 +351,36 @@ static void search_results_id_cb(struct media_player *plr, int err, uint64_t id)
 	char str[BT_OTS_OBJ_ID_STR_LEN];
 
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Search results ID failed (%d)", plr, err);
+		LOG_ERR("Player: %p, Search results ID failed (%d)", (void *)plr, err);
 		return;
 	}
 
 	if (id == 0) {
-		shell_print(ctx_shell, "Player: %p, Search result not avilable", plr);
+		LOG_DBG("Player: %p, Search result not avilable", (void *)plr);
 	}
 
 	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Player: %p, Search Results Object ID: %s", plr, str);
+	LOG_DBG("Player: %p, Search Results Object ID: %s", (void *)plr, str);
 }
 #endif /* CONFIG_BT_OTS */
 
 static void content_ctrl_id_cb(struct media_player *plr, int err, uint8_t ccid)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Content control ID failed (%d)", plr, err);
+		LOG_ERR("Player: %p, Content control ID failed (%d)", (void *)plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Content Control ID: %u", plr, ccid);
+	LOG_DBG("Player: %p, Content Control ID: %u", (void *)plr, ccid);
 }
 
 static int cmd_media_init(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err;
 
-	if (!ctx_shell) {
-		ctx_shell = sh;
-	}
-
 	err = media_proxy_pl_init();  /* TODO: Fix direct call to player */
 	if (err) {
-		shell_error(ctx_shell, "Could not init mpl");
+		LOG_ERR("Could not init mpl");
 	}
 
 	/* Set up the callback structure */
@@ -426,7 +422,7 @@ static int cmd_media_init(const struct shell *sh, size_t argc, char *argv[])
 
 	err = media_proxy_ctrl_register(&cbs);
 	if (err) {
-		shell_error(ctx_shell, "Could not register media shell as controller");
+		LOG_ERR("Could not register media shell as controller");
 	}
 
 	return err;
@@ -437,46 +433,42 @@ static int cmd_media_set_player(const struct shell *sh, size_t argc, char *argv[
 	if (!strcmp(argv[1], "local")) {
 		if (local_player) {
 			current_player = local_player;
-			shell_print(ctx_shell, "Current player set to local player: %p",
-				    current_player);
+			LOG_DBG("Current player set to local player: %p", (void *)current_player);
 			return 0;
 		}
 
-		shell_print(ctx_shell, "No local player");
+		LOG_DBG("No local player");
 		return -EOPNOTSUPP;
 
 	} else if (!strcmp(argv[1], "remote")) {
 		if (remote_player) {
 			current_player = remote_player;
-			shell_print(ctx_shell, "Current player set to remote player: %p",
-				    current_player);
+			LOG_DBG("Current player set to remote player: %p", (void *)current_player);
 			return 0;
 		}
 
-		shell_print(ctx_shell, "No remote player");
+		LOG_DBG("No remote player");
 		return -EOPNOTSUPP;
 
 	} else {
-		shell_error(ctx_shell, "Input argument must be either \"local\" or \"remote\"");
+		LOG_ERR("Input argument must be either \"local\" or \"remote\"");
 		return -EINVAL;
 	}
 }
 
 static int cmd_media_show_players(const struct shell *sh, size_t argc, char *argv[])
 {
-	shell_print(ctx_shell, "Local player: %p", local_player);
-	shell_print(ctx_shell, "Remote player: %p", remote_player);
+	LOG_DBG("Local player: %p", (void *)local_player);
+	LOG_DBG("Remote player: %p", (void *)remote_player);
 
 	if (current_player == NULL) {
-		shell_print(ctx_shell, "Current player is not set");
+		LOG_DBG("Current player is not set");
 	} else if (current_player == local_player) {
-		shell_print(ctx_shell, "Current player is set to local player: %p",
-			    current_player);
+		LOG_DBG("Current player is set to local player: %p", (void *)current_player);
 	} else if (current_player == remote_player) {
-		shell_print(ctx_shell, "Current player is set to remote player: %p",
-			    current_player);
+		LOG_DBG("Current player is set to remote player: %p", (void *)current_player);
 	} else {
-		shell_print(ctx_shell, "Current player is not set to valid player");
+		LOG_DBG("Current player is not set to valid player");
 	}
 
 	return 0;
@@ -488,7 +480,7 @@ static int cmd_media_discover_player(const struct shell *sh, size_t argc, char *
 	int err = media_proxy_ctrl_discover_player(default_conn);
 
 	if (err) {
-		shell_error(ctx_shell, "Discover player failed (%d)", err);
+		LOG_ERR("Discover player failed (%d)", err);
 	}
 
 	return err;
@@ -500,7 +492,7 @@ static int cmd_media_read_player_name(const struct shell *sh, size_t argc, char 
 	int err = media_proxy_ctrl_get_player_name(current_player);
 
 	if (err) {
-		shell_error(ctx_shell, "Player name get failed (%d)", err);
+		LOG_ERR("Player name get failed (%d)", err);
 	}
 
 	return err;
@@ -512,7 +504,7 @@ static int cmd_media_read_icon_obj_id(const struct shell *sh, size_t argc, char 
 	int err = media_proxy_ctrl_get_icon_id(current_player);
 
 	if (err) {
-		shell_error(ctx_shell, "Icon ID get failed (%d)", err);
+		LOG_ERR("Icon ID get failed (%d)", err);
 	}
 
 	return err;
@@ -524,7 +516,7 @@ static int cmd_media_read_icon_url(const struct shell *sh, size_t argc, char *ar
 	int err = media_proxy_ctrl_get_icon_url(current_player);
 
 	if (err) {
-		shell_error(ctx_shell, "Icon URL get failed (%d)", err);
+		LOG_ERR("Icon URL get failed (%d)", err);
 	}
 
 	return err;
@@ -535,7 +527,7 @@ static int cmd_media_read_track_title(const struct shell *sh, size_t argc, char 
 	int err = media_proxy_ctrl_get_track_title(current_player);
 
 	if (err) {
-		shell_error(ctx_shell, "Track title get failed (%d)", err);
+		LOG_ERR("Track title get failed (%d)", err);
 	}
 
 	return err;
@@ -546,7 +538,7 @@ static int cmd_media_read_track_duration(const struct shell *sh, size_t argc, ch
 	int err = media_proxy_ctrl_get_track_duration(current_player);
 
 	if (err) {
-		shell_error(ctx_shell, "Track duration get failed (%d)", err);
+		LOG_ERR("Track duration get failed (%d)", err);
 	}
 
 	return err;
@@ -557,7 +549,7 @@ static int cmd_media_read_track_position(const struct shell *sh, size_t argc, ch
 	int err = media_proxy_ctrl_get_track_position(current_player);
 
 	if (err) {
-		shell_error(ctx_shell, "Track position get failed (%d)", err);
+		LOG_ERR("Track position get failed (%d)", err);
 	}
 
 	return err;
@@ -584,7 +576,7 @@ static int cmd_media_set_track_position(const struct shell *sh, size_t argc,
 
 	err = media_proxy_ctrl_set_track_position(current_player, position);
 	if (err) {
-		shell_error(ctx_shell, "Track position set failed (%d)", err);
+		LOG_ERR("Track position set failed (%d)", err);
 	}
 
 	return err;
@@ -595,7 +587,7 @@ static int cmd_media_read_playback_speed(const struct shell *sh, size_t argc, ch
 	int err = media_proxy_ctrl_get_playback_speed(current_player);
 
 	if (err) {
-		shell_error(ctx_shell, "Playback speed get get failed (%d)", err);
+		LOG_ERR("Playback speed get get failed (%d)", err);
 	}
 
 	return err;
@@ -622,7 +614,7 @@ static int cmd_media_set_playback_speed(const struct shell *sh, size_t argc, cha
 
 	err = media_proxy_ctrl_set_playback_speed(current_player, speed);
 	if (err) {
-		shell_error(ctx_shell, "Playback speed set failed (%d)", err);
+		LOG_ERR("Playback speed set failed (%d)", err);
 	}
 
 	return err;
@@ -633,7 +625,7 @@ static int cmd_media_read_seeking_speed(const struct shell *sh, size_t argc, cha
 	int err = media_proxy_ctrl_get_seeking_speed(current_player);
 
 	if (err) {
-		shell_error(ctx_shell, "Seeking speed get failed (%d)", err);
+		LOG_ERR("Seeking speed get failed (%d)", err);
 	}
 
 	return err;
@@ -645,7 +637,7 @@ static int cmd_media_read_track_segments_obj_id(const struct shell *sh, size_t a
 	int err = media_proxy_ctrl_get_track_segments_id(current_player);
 
 	if (err) {
-		shell_error(ctx_shell, "Track segments ID get failed (%d)", err);
+		LOG_ERR("Track segments ID get failed (%d)", err);
 	}
 
 	return err;
@@ -656,7 +648,7 @@ static int cmd_media_read_current_track_obj_id(const struct shell *sh, size_t ar
 	int err = media_proxy_ctrl_get_current_track_id(current_player);
 
 	if (err) {
-		shell_error(ctx_shell, "Current track ID get failed (%d)", err);
+		LOG_ERR("Current track ID get failed (%d)", err);
 	}
 
 	return err;
@@ -669,7 +661,7 @@ static int cmd_media_read_next_track_obj_id(const struct shell *sh, size_t argc,
 	int err = media_proxy_ctrl_get_next_track_id(current_player);
 
 	if (err) {
-		shell_error(ctx_shell, "Nect track ID get failed (%d)", err);
+		LOG_ERR("Nect track ID get failed (%d)", err);
 	}
 
 	return err;
@@ -680,8 +672,7 @@ static int cmd_media_read_current_group_obj_id(const struct shell *sh, size_t ar
 	int err = media_proxy_ctrl_get_current_group_id(current_player);
 
 	if (err) {
-		shell_error(ctx_shell, "Current group ID get failed (%d)", err);
-
+		LOG_ERR("Current group ID get failed (%d)", err);
 	}
 
 	return err;
@@ -692,7 +683,7 @@ static int cmd_media_read_parent_group_obj_id(const struct shell *sh, size_t arg
 	int err = media_proxy_ctrl_get_parent_group_id(current_player);
 
 	if (err) {
-		shell_error(ctx_shell, "Parent group ID get failed (%d)", err);
+		LOG_ERR("Parent group ID get failed (%d)", err);
 	}
 
 	return err;
@@ -704,7 +695,7 @@ static int cmd_media_read_playing_order(const struct shell *sh, size_t argc, cha
 	int err = media_proxy_ctrl_get_playing_order(current_player);
 
 	if (err) {
-		shell_error(ctx_shell, "Playing order get failed (%d)", err);
+		LOG_ERR("Playing order get failed (%d)", err);
 	}
 
 	return err;
@@ -730,7 +721,7 @@ static int cmd_media_set_playing_order(const struct shell *sh, size_t argc, char
 
 	err = media_proxy_ctrl_set_playing_order(current_player, order);
 	if (err) {
-		shell_error(ctx_shell, "Playing order set failed (%d)", err);
+		LOG_ERR("Playing order set failed (%d)", err);
 	}
 
 	return err;
@@ -742,7 +733,7 @@ static int cmd_media_read_playing_orders_supported(const struct shell *sh, size_
 	int err = media_proxy_ctrl_get_playing_orders_supported(current_player);
 
 	if (err) {
-		shell_error(ctx_shell, "Icon URL get failed (%d)", err);
+		LOG_ERR("Icon URL get failed (%d)", err);
 	}
 
 	return err;
@@ -753,7 +744,7 @@ static int cmd_media_read_media_state(const struct shell *sh, size_t argc, char 
 	int err = media_proxy_ctrl_get_media_state(current_player);
 
 	if (err) {
-		shell_error(ctx_shell, "Icon URL get failed (%d)", err);
+		LOG_ERR("Icon URL get failed (%d)", err);
 	}
 
 	return err;
@@ -1216,7 +1207,7 @@ static int cmd_media_read_commands_supported(const struct shell *sh, size_t argc
 	int err = media_proxy_ctrl_get_commands_supported(current_player);
 
 	if (err) {
-		shell_error(ctx_shell, "Commands supported read failed (%d)", err);
+		LOG_ERR("Commands supported read failed (%d)", err);
 	}
 
 	return err;
@@ -1245,7 +1236,7 @@ static int cmd_media_set_search(const struct shell *sh, size_t argc, char *argv[
 
 	err = media_proxy_ctrl_send_search(current_player, &search);
 	if (err) {
-		shell_error(ctx_shell, "Search send failed (%d)", err);
+		LOG_ERR("Search send failed (%d)", err);
 	}
 
 	return err;
@@ -1257,7 +1248,7 @@ static int cmd_media_read_search_results_obj_id(const struct shell *sh, size_t a
 	int err = media_proxy_ctrl_get_search_results_id(current_player);
 
 	if (err) {
-		shell_error(ctx_shell, "Search results ID get failed (%d)", err);
+		LOG_ERR("Search results ID get failed (%d)", err);
 	}
 
 	return err;
@@ -1270,7 +1261,7 @@ static int cmd_media_read_content_control_id(const struct shell *sh, size_t argc
 	int err = media_proxy_ctrl_get_content_ctrl_id(current_player);
 
 	if (err) {
-		shell_error(ctx_shell, "Content control ID get failed (%d)", err);
+		LOG_ERR("Content control ID get failed (%d)", err);
 	}
 
 	return err;
@@ -1278,7 +1269,7 @@ static int cmd_media_read_content_control_id(const struct shell *sh, size_t argc
 
 static int cmd_media(const struct shell *sh, size_t argc, char **argv)
 {
-	shell_error(ctx_shell, "%s unknown parameter: %s", argv[0], argv[1]);
+	LOG_ERR("%s unknown parameter: %s", argv[0], argv[1]);
 
 	return -ENOEXEC;
 }

--- a/subsys/bluetooth/audio/shell/micp_mic_ctlr.c
+++ b/subsys/bluetooth/audio/shell/micp_mic_ctlr.c
@@ -10,11 +10,14 @@
 #include <zephyr/types.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/audio/micp.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
 #include <stdlib.h>
 #include <stdio.h>
 
 #include "shell/bt.h"
+
+LOG_MODULE_REGISTER(micp_mic_ctlr_shell, LOG_LEVEL_DBG);
 
 static struct bt_micp_mic_ctlr *micp_mic_ctlr;
 #if defined(CONFIG_BT_MICP_MIC_CTLR_AICS)
@@ -25,15 +28,14 @@ static void micp_mic_ctlr_discover_cb(struct bt_micp_mic_ctlr *mic_ctlr,
 				      int err, uint8_t aics_count)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "Discovery failed (%d)", err);
+		LOG_ERR("Discovery failed (%d)", err);
 	} else {
-		shell_print(ctx_shell, "Discovery done with %u AICS",
-			    aics_count);
+		LOG_DBG("Discovery done with %u AICS", aics_count);
 
 #if defined(CONFIG_BT_MICP_MIC_CTLR_AICS)
 		if (bt_micp_mic_ctlr_included_get(mic_ctlr,
 						  &micp_included) != 0) {
-			shell_error(ctx_shell, "Could not get included services");
+			LOG_ERR("Could not get included services");
 		}
 #endif /* CONFIG_BT_MICP_MIC_CTLR_AICS */
 	}
@@ -43,9 +45,9 @@ static void micp_mic_ctlr_mute_written_cb(struct bt_micp_mic_ctlr *mic_ctlr,
 					  int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "Mute write failed (%d)", err);
+		LOG_ERR("Mute write failed (%d)", err);
 	} else {
-		shell_print(ctx_shell, "Mute write completed");
+		LOG_DBG("Mute write completed");
 	}
 }
 
@@ -53,9 +55,9 @@ static void micp_mic_ctlr_unmute_written_cb(struct bt_micp_mic_ctlr *mic_ctlr,
 					    int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "Unmute write failed (%d)", err);
+		LOG_ERR("Unmute write failed (%d)", err);
 	} else {
-		shell_print(ctx_shell, "Unmute write completed");
+		LOG_DBG("Unmute write completed");
 	}
 }
 
@@ -63,9 +65,9 @@ static void micp_mic_ctlr_mute_cb(struct bt_micp_mic_ctlr *mic_ctlr, int err,
 				  uint8_t mute)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "Mute get failed (%d)", err);
+		LOG_ERR("Mute get failed (%d)", err);
 	} else {
-		shell_print(ctx_shell, "Mute value %u", mute);
+		LOG_DBG("Mute value %u", mute);
 	}
 }
 
@@ -75,53 +77,45 @@ static struct bt_micp_included micp_included;
 static void micp_mic_ctlr_aics_set_gain_cb(struct bt_aics *inst, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "Set gain failed (%d) for inst %p",
-			    err, inst);
+		LOG_ERR("Set gain failed (%d) for inst %p", err, (void *)inst);
 	} else {
-		shell_print(ctx_shell, "Gain set for inst %p", inst);
+		LOG_DBG("Gain set for inst %p", (void *)inst);
 	}
 }
 
 static void micp_mic_ctlr_aics_unmute_cb(struct bt_aics *inst, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "Unmute failed (%d) for inst %p",
-			    err, inst);
+		LOG_ERR("Unmute failed (%d) for inst %p", err, (void *)inst);
 	} else {
-		shell_print(ctx_shell, "Unmuted inst %p", inst);
+		LOG_DBG("Unmuted inst %p", (void *)inst);
 	}
 }
 
 static void micp_mic_ctlr_aics_mute_cb(struct bt_aics *inst, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "Mute failed (%d) for inst %p",
-			    err, inst);
+		LOG_ERR("Mute failed (%d) for inst %p", err, (void *)inst);
 	} else {
-		shell_print(ctx_shell, "Muted inst %p", inst);
+		LOG_DBG("Muted inst %p", (void *)inst);
 	}
 }
 
 static void micp_mic_ctlr_aics_set_manual_mode_cb(struct bt_aics *inst, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell,
-			    "Set manual mode failed (%d) for inst %p",
-			    err, inst);
+		LOG_ERR("Set manual mode failed (%d) for inst %p", err, (void *)inst);
 	} else {
-		shell_print(ctx_shell, "Manuel mode set for inst %p", inst);
+		LOG_DBG("Manuel mode set for inst %p", (void *)inst);
 	}
 }
 
 static void micp_mic_ctlr_aics_automatic_mode_cb(struct bt_aics *inst, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell,
-			    "Set automatic mode failed (%d) for inst %p",
-			    err, inst);
+		LOG_ERR("Set automatic mode failed (%d) for inst %p", err, (void *)inst);
 	} else {
-		shell_print(ctx_shell, "Automatic mode set for inst %p",
-			    inst);
+		LOG_DBG("Automatic mode set for inst %p", (void *)inst);
 	}
 }
 
@@ -129,13 +123,11 @@ static void micp_mic_ctlr_aics_state_cb(struct bt_aics *inst, int err,
 					int8_t gain, uint8_t mute, uint8_t mode)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "AICS state get failed (%d) for "
-			    "inst %p", err, inst);
+		LOG_ERR("AICS state get failed (%d) for inst %p", err, (void *)inst);
 	} else {
-		shell_print(ctx_shell, "AICS inst %p state gain %d, mute %u, "
-			    "mode %u", inst, gain, mute, mode);
+		LOG_DBG("AICS inst %p state gain %d, mute %u, mode %u", (void *)inst, gain, mute,
+			mode);
 	}
-
 }
 
 static void micp_mic_ctlr_aics_gain_setting_cb(struct bt_aics *inst, int err,
@@ -143,51 +135,40 @@ static void micp_mic_ctlr_aics_gain_setting_cb(struct bt_aics *inst, int err,
 					       int8_t maximum)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "AICS gain settings get failed (%d) for "
-			    "inst %p", err, inst);
+		LOG_ERR("AICS gain settings get failed (%d) for inst %p", err, (void *)inst);
 	} else {
-		shell_print(ctx_shell, "AICS inst %p gain settings units %u, "
-			    "min %d, max %d", inst, units, minimum,
-			    maximum);
+		LOG_DBG("AICS inst %p gain settings units %u, min %d, max %d", (void *)inst, units,
+			minimum, maximum);
 	}
-
 }
 
 static void micp_mic_ctlr_aics_input_type_cb(struct bt_aics *inst, int err,
 					     uint8_t input_type)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "AICS input type get failed (%d) for "
-			    "inst %p", err, inst);
+		LOG_ERR("AICS input type get failed (%d) for inst %p", err, (void *)inst);
 	} else {
-		shell_print(ctx_shell, "AICS inst %p input type %u",
-			    inst, input_type);
+		LOG_DBG("AICS inst %p input type %u", (void *)inst, input_type);
 	}
-
 }
 
 static void micp_mic_ctlr_aics_status_cb(struct bt_aics *inst, int err,
 					 bool active)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "AICS status get failed (%d) for "
-			    "inst %p", err, inst);
+		LOG_ERR("AICS status get failed (%d) for inst %p", err, (void *)inst);
 	} else {
-		shell_print(ctx_shell, "AICS inst %p status %s",
-			    inst, active ? "active" : "inactive");
+		LOG_DBG("AICS inst %p status %s", (void *)inst, active ? "active" : "inactive");
 	}
-
 }
 
 static void micp_mic_ctlr_aics_description_cb(struct bt_aics *inst, int err,
 					      char *description)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "AICS description get failed (%d) for "
-			    "inst %p", err, inst);
+		LOG_ERR("AICS description get failed (%d) for inst %p", err, (void *)inst);
 	} else {
-		shell_print(ctx_shell, "AICS inst %p description %s",
-			    inst, description);
+		LOG_DBG("AICS inst %p description %s", (void *)inst, description);
 	}
 }
 #endif /* CONFIG_BT_MICP_MIC_CTLR_AICS */
@@ -219,10 +200,6 @@ static int cmd_micp_mic_ctlr_discover(const struct shell *sh, size_t argc,
 				    char **argv)
 {
 	int result;
-
-	if (ctx_shell == NULL) {
-		ctx_shell = sh;
-	}
 
 	result = bt_micp_mic_ctlr_cb_register(&micp_cbs);
 	if (result != 0) {

--- a/subsys/bluetooth/audio/shell/micp_mic_dev.c
+++ b/subsys/bluetooth/audio/shell/micp_mic_dev.c
@@ -10,15 +10,18 @@
 #include <zephyr/types.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/audio/micp.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
 #include <stdlib.h>
 #include <stdio.h>
 
 #include "shell/bt.h"
 
+LOG_MODULE_REGISTER(micp_mic_dev_shell, LOG_LEVEL_DBG);
+
 static void micp_mic_dev_mute_cb(uint8_t mute)
 {
-	shell_print(ctx_shell, "Mute value %u", mute);
+	LOG_DBG("Mute value %u", mute);
 }
 
 static struct bt_micp_mic_dev_cb micp_mic_dev_cbs = {
@@ -32,61 +35,52 @@ static void micp_mic_dev_aics_state_cb(struct bt_aics *inst, int err,
 				       int8_t gain, uint8_t mute, uint8_t mode)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "AICS state get failed (%d) for "
-			    "inst %p", err, inst);
+		LOG_ERR("AICS state get failed (%d) for inst %p", err, (void *)inst);
 	} else {
-		shell_print(ctx_shell, "AICS inst %p state gain %d, mute %u, "
-			    "mode %u", inst, gain, mute, mode);
+		LOG_DBG("AICS inst %p state gain %d, mute %u, mode %u", (void *)inst, gain, mute,
+			mode);
 	}
-
 }
+
 static void micp_mic_dev_aics_gain_setting_cb(struct bt_aics *inst, int err,
 					      uint8_t units, int8_t minimum,
 					      int8_t maximum)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "AICS gain settings get failed (%d) for "
-			    "inst %p", err, inst);
+		LOG_ERR("AICS gain settings get failed (%d) for inst %p", err, (void *)inst);
 	} else {
-		shell_print(ctx_shell, "AICS inst %p gain settings units %u, "
-			    "min %d, max %d", inst, units, minimum,
-			    maximum);
+		LOG_DBG("AICS inst %p gain settings units %u, min %d, max %d", (void *)inst, units,
+			minimum, maximum);
 	}
-
 }
+
 static void micp_mic_dev_aics_input_type_cb(struct bt_aics *inst, int err,
 					    uint8_t input_type)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "AICS input type get failed (%d) for "
-			    "inst %p", err, inst);
+		LOG_ERR("AICS input type get failed (%d) for inst %p", err, (void *)inst);
 	} else {
-		shell_print(ctx_shell, "AICS inst %p input type %u",
-			    inst, input_type);
+		LOG_DBG("AICS inst %p input type %u", (void *)inst, input_type);
 	}
-
 }
+
 static void micp_mic_dev_aics_status_cb(struct bt_aics *inst, int err,
 					bool active)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "AICS status get failed (%d) for "
-			    "inst %p", err, inst);
+		LOG_ERR("AICS status get failed (%d) for inst %p", err, (void *)inst);
 	} else {
-		shell_print(ctx_shell, "AICS inst %p status %s",
-			    inst, active ? "active" : "inactive");
+		LOG_DBG("AICS inst %p status %s", (void *)inst, active ? "active" : "inactive");
 	}
-
 }
+
 static void micp_mic_dev_aics_description_cb(struct bt_aics *inst, int err,
 					     char *description)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "AICS description get failed (%d) for "
-			    "inst %p", err, inst);
+		LOG_ERR("AICS description get failed (%d) for inst %p", err, (void *)inst);
 	} else {
-		shell_print(ctx_shell, "AICS inst %p description %s",
-			    inst, description);
+		LOG_DBG("AICS inst %p description %s", (void *)inst, description);
 	}
 }
 
@@ -104,10 +98,6 @@ static int cmd_micp_mic_dev_param(const struct shell *sh, size_t argc,
 {
 	int result;
 	struct bt_micp_mic_dev_register_param micp_param;
-
-	if (ctx_shell == NULL) {
-		ctx_shell = sh;
-	}
 
 	(void)memset(&micp_param, 0, sizeof(micp_param));
 

--- a/subsys/bluetooth/audio/shell/mpl.c
+++ b/subsys/bluetooth/audio/shell/mpl.c
@@ -10,6 +10,7 @@
  */
 
 #include <stdlib.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
@@ -21,7 +22,7 @@
 
 #include <zephyr/logging/log.h>
 
-LOG_MODULE_REGISTER(bt_mpl_shell, CONFIG_BT_MPL_LOG_LEVEL);
+LOG_MODULE_REGISTER(mpl_shell, CONFIG_BT_MPL_LOG_LEVEL);
 
 #if defined(CONFIG_BT_MPL)
 
@@ -73,10 +74,6 @@ int cmd_mpl_debug_dump_state(const struct shell *sh, size_t argc,
 
 int cmd_media_proxy_pl_init(const struct shell *sh, size_t argc, char *argv[])
 {
-	if (!ctx_shell) {
-		ctx_shell = sh;
-	}
-
 	int err = media_proxy_pl_init();
 
 	if (err) {

--- a/subsys/bluetooth/audio/shell/pbp.c
+++ b/subsys/bluetooth/audio/shell/pbp.c
@@ -9,11 +9,14 @@
  */
 
 #include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/bluetooth/audio/pbp.h>
 
 #include "shell/bt.h"
+
+LOG_MODULE_REGISTER(pbp_shell, LOG_LEVEL_DBG);
 
 #define PBS_DEMO                'P', 'B', 'P'
 
@@ -25,7 +28,6 @@ const uint8_t pba_metadata[] = {
 NET_BUF_SIMPLE_DEFINE_STATIC(pbp_ad_buf, BT_PBP_MIN_PBA_SIZE + ARRAY_SIZE(pba_metadata));
 
 enum bt_pbp_announcement_feature pbp_features;
-extern const struct shell *ctx_shell;
 
 static int cmd_pbp_set_features(const struct shell *sh, size_t argc, char **argv)
 {
@@ -54,9 +56,9 @@ size_t pbp_ad_data_add(struct bt_data data[], size_t data_size)
 				      &pbp_ad_buf);
 
 	if (err != 0) {
-		shell_info(ctx_shell, "Create Public Broadcast Announcement");
+		LOG_DBG("Create Public Broadcast Announcement");
 	} else {
-		shell_error(ctx_shell, "Failed to create Public Broadcast Announcement: %d", err);
+		LOG_ERR("Failed to create Public Broadcast Announcement: %d", err);
 	}
 
 	__ASSERT(data_size > 0, "No space for Public Broadcast Announcement");

--- a/subsys/bluetooth/audio/shell/tbs.c
+++ b/subsys/bluetooth/audio/shell/tbs.c
@@ -10,11 +10,14 @@
 
 #include <stdlib.h>
 #include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
 
 #include <zephyr/bluetooth/audio/tbs.h>
 
 #include "shell/bt.h"
+
+LOG_MODULE_REGISTER(tbs_shell, LOG_LEVEL_DBG);
 
 static struct bt_conn *tbs_authorized_conn;
 static bool cbs_registered;

--- a/subsys/bluetooth/audio/shell/tbs_client.c
+++ b/subsys/bluetooth/audio/shell/tbs_client.c
@@ -13,6 +13,7 @@
 #include <ctype.h>
 #include <zephyr/kernel.h>
 #include <zephyr/types.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/byteorder.h>
@@ -23,6 +24,8 @@
 #include <zephyr/bluetooth/audio/tbs.h>
 
 #include "shell/bt.h"
+
+LOG_MODULE_REGISTER(tbs_client_shell, LOG_LEVEL_DBG);
 
 static int cmd_tbs_client_discover(const struct shell *sh, size_t argc,
 				   char *argv[])

--- a/subsys/bluetooth/audio/shell/tmap.c
+++ b/subsys/bluetooth/audio/shell/tmap.c
@@ -11,10 +11,13 @@
 
 #include <zephyr/bluetooth/audio/tmap.h>
 #include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/sys/util.h>
 
 #include "shell/bt.h"
+
+LOG_MODULE_REGISTER(tmap_shell, LOG_LEVEL_DBG);
 
 static int cmd_tmap_init(const struct shell *sh, size_t argc, char **argv)
 {
@@ -41,11 +44,11 @@ static int cmd_tmap_init(const struct shell *sh, size_t argc, char **argv)
 static void tmap_discover_cb(enum bt_tmap_role role, struct bt_conn *conn, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "tmap discovery (err %d)", err);
+		LOG_ERR("tmap discovery (err %d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "tmap discovered for conn %p: role 0x%02x", conn, role);
+	LOG_DBG("tmap discovered for conn %p: role 0x%02x", (void *)conn, role);
 }
 
 static const struct bt_tmap_cb tmap_cb = {
@@ -60,10 +63,6 @@ static int cmd_tmap_discover(const struct shell *sh, size_t argc, char **argv)
 		shell_error(sh, "Not connected");
 
 		return -ENOEXEC;
-	}
-
-	if (!ctx_shell) {
-		ctx_shell = sh;
 	}
 
 	err = bt_tmap_discover(default_conn, &tmap_cb);

--- a/subsys/bluetooth/audio/shell/vcp_vol_ctlr.c
+++ b/subsys/bluetooth/audio/shell/vcp_vol_ctlr.c
@@ -10,10 +10,13 @@
 #include <zephyr/types.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/audio/vcp.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
 #include <stdlib.h>
 
 #include "shell/bt.h"
+
+LOG_MODULE_REGISTER(vcp_vol_ctlr_shell, LOG_LEVEL_DBG);
 
 static struct bt_vcp_vol_ctlr *vcp_vol_ctlr;
 static struct bt_vcp_included vcp_included;
@@ -22,13 +25,12 @@ static void vcs_discover_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err,
 			    uint8_t vocs_count, uint8_t aics_count)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "VCP discover failed (%d)", err);
+		LOG_ERR("VCP discover failed (%d)", err);
 	} else {
-		shell_print(ctx_shell, "VCP discover done with %u VOCS and %u AICS", vocs_count,
-			    aics_count);
+		LOG_DBG("VCP discover done with %u VOCS and %u AICS", vocs_count, aics_count);
 
 		if (bt_vcp_vol_ctlr_included_get(vol_ctlr, &vcp_included)) {
-			shell_error(ctx_shell, "Could not get VCP context");
+			LOG_ERR("Could not get VCP context");
 		}
 	}
 }
@@ -36,63 +38,63 @@ static void vcs_discover_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err,
 static void vcs_vol_down_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "VCP vol_down failed (%d)", err);
+		LOG_ERR("VCP vol_down failed (%d)", err);
 	} else {
-		shell_print(ctx_shell, "VCP vol_down done");
+		LOG_DBG("VCP vol_down done");
 	}
 }
 
 static void vcs_vol_up_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "VCP vol_up failed (%d)", err);
+		LOG_ERR("VCP vol_up failed (%d)", err);
 	} else {
-		shell_print(ctx_shell, "VCP vol_up done");
+		LOG_DBG("VCP vol_up done");
 	}
 }
 
 static void vcs_mute_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "VCP mute failed (%d)", err);
+		LOG_ERR("VCP mute failed (%d)", err);
 	} else {
-		shell_print(ctx_shell, "VCP mute done");
+		LOG_DBG("VCP mute done");
 	}
 }
 
 static void vcs_unmute_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "VCP unmute failed (%d)", err);
+		LOG_ERR("VCP unmute failed (%d)", err);
 	} else {
-		shell_print(ctx_shell, "VCP unmute done");
+		LOG_DBG("VCP unmute done");
 	}
 }
 
 static void vcs_vol_down_unmute_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "VCP vol_down_unmute failed (%d)", err);
+		LOG_ERR("VCP vol_down_unmute failed (%d)", err);
 	} else {
-		shell_print(ctx_shell, "VCP vol_down_unmute done");
+		LOG_DBG("VCP vol_down_unmute done");
 	}
 }
 
 static void vcs_vol_up_unmute_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "VCP vol_up_unmute failed (%d)", err);
+		LOG_ERR("VCP vol_up_unmute failed (%d)", err);
 	} else {
-		shell_print(ctx_shell, "VCP vol_up_unmute done");
+		LOG_DBG("VCP vol_up_unmute done");
 	}
 }
 
 static void vcs_vol_set_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "VCP vol_set failed (%d)", err);
+		LOG_ERR("VCP vol_set failed (%d)", err);
 	} else {
-		shell_print(ctx_shell, "VCP vol_set done");
+		LOG_DBG("VCP vol_set done");
 	}
 }
 
@@ -100,9 +102,9 @@ static void vcs_state_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err,
 			 uint8_t volume, uint8_t mute)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "VCP state get failed (%d)", err);
+		LOG_ERR("VCP state get failed (%d)", err);
 	} else {
-		shell_print(ctx_shell, "VCP volume %u, mute %u", volume, mute);
+		LOG_DBG("VCP volume %u, mute %u", volume, mute);
 	}
 }
 
@@ -110,9 +112,9 @@ static void vcs_flags_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err,
 			 uint8_t flags)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "VCP flags get failed (%d)", err);
+		LOG_ERR("VCP flags get failed (%d)", err);
 	} else {
-		shell_print(ctx_shell, "VCP flags 0x%02X", flags);
+		LOG_DBG("VCP flags 0x%02X", flags);
 	}
 }
 
@@ -120,53 +122,45 @@ static void vcs_flags_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err,
 static void vcs_aics_set_gain_cb(struct bt_aics *inst, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "Set gain failed (%d) for inst %p",
-			    err, inst);
+		LOG_ERR("Set gain failed (%d) for inst %p", err, (void *)inst);
 	} else {
-		shell_print(ctx_shell, "Gain set for inst %p", inst);
+		LOG_DBG("Gain set for inst %p", (void *)inst);
 	}
 }
 
 static void vcs_aics_unmute_cb(struct bt_aics *inst, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "Unmute failed (%d) for inst %p",
-			    err, inst);
+		LOG_ERR("Unmute failed (%d) for inst %p", err, (void *)inst);
 	} else {
-		shell_print(ctx_shell, "Unmuted inst %p", inst);
+		LOG_DBG("Unmuted inst %p", (void *)inst);
 	}
 }
 
 static void vcs_aics_mute_cb(struct bt_aics *inst, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "Mute failed (%d) for inst %p",
-			    err, inst);
+		LOG_ERR("Mute failed (%d) for inst %p", err, (void *)inst);
 	} else {
-		shell_print(ctx_shell, "Muted inst %p", inst);
+		LOG_DBG("Muted inst %p", (void *)inst);
 	}
 }
 
 static void vcs_aics_set_manual_mode_cb(struct bt_aics *inst, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell,
-			    "Set manual mode failed (%d) for inst %p",
-			    err, inst);
+		LOG_ERR("Set manual mode failed (%d) for inst %p", err, (void *)inst);
 	} else {
-		shell_print(ctx_shell, "Manuel mode set for inst %p", inst);
+		LOG_DBG("Manuel mode set for inst %p", (void *)inst);
 	}
 }
 
 static void vcs_aics_automatic_mode_cb(struct bt_aics *inst, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell,
-			    "Set automatic mode failed (%d) for inst %p",
-			    err, inst);
+		LOG_ERR("Set automatic mode failed (%d) for inst %p", err, (void *)inst);
 	} else {
-		shell_print(ctx_shell, "Automatic mode set for inst %p",
-			    inst);
+		LOG_DBG("Automatic mode set for inst %p", (void *)inst);
 	}
 }
 
@@ -174,12 +168,10 @@ static void vcs_aics_state_cb(struct bt_aics *inst, int err, int8_t gain,
 			      uint8_t mute, uint8_t mode)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "AICS state get failed (%d) for inst %p",
-			    err, inst);
+		LOG_ERR("AICS state get failed (%d) for inst %p", err, (void *)inst);
 	} else {
-		shell_print(ctx_shell,
-			    "AICS inst %p state gain %d, mute %u, mode %u",
-			    inst, gain, mute, mode);
+		LOG_DBG("AICS inst %p state gain %d, mute %u, mode %u", (void *)inst, gain, mute,
+			mode);
 	}
 }
 
@@ -188,13 +180,10 @@ static void vcs_aics_gain_setting_cb(struct bt_aics *inst, int err,
 				     int8_t maximum)
 {
 	if (err != 0) {
-		shell_error(ctx_shell,
-			    "AICS gain settings get failed (%d) for inst %p",
-			    err, inst);
+		LOG_ERR("AICS gain settings get failed (%d) for inst %p", err, (void *)inst);
 	} else {
-		shell_print(ctx_shell,
-			    "AICS inst %p gain settings units %u, min %d, max %d",
-			    inst, units, minimum, maximum);
+		LOG_DBG("AICS inst %p gain settings units %u, min %d, max %d", (void *)inst, units,
+			minimum, maximum);
 	}
 }
 
@@ -202,24 +191,18 @@ static void vcs_aics_input_type_cb(struct bt_aics *inst, int err,
 				   uint8_t input_type)
 {
 	if (err != 0) {
-		shell_error(ctx_shell,
-			    "AICS input type get failed (%d) for inst %p",
-			    err, inst);
+		LOG_ERR("AICS input type get failed (%d) for inst %p", err, (void *)inst);
 	} else {
-		shell_print(ctx_shell, "AICS inst %p input type %u",
-			    inst, input_type);
+		LOG_DBG("AICS inst %p input type %u", (void *)inst, input_type);
 	}
 }
 
 static void vcs_aics_status_cb(struct bt_aics *inst, int err, bool active)
 {
 	if (err != 0) {
-		shell_error(ctx_shell,
-			    "AICS status get failed (%d) for inst %p",
-			    err, inst);
+		LOG_ERR("AICS status get failed (%d) for inst %p", err, (void *)inst);
 	} else {
-		shell_print(ctx_shell, "AICS inst %p status %s",
-			    inst, active ? "active" : "inactive");
+		LOG_DBG("AICS inst %p status %s", (void *)inst, active ? "active" : "inactive");
 	}
 
 }
@@ -227,12 +210,9 @@ static void vcs_aics_description_cb(struct bt_aics *inst, int err,
 				    char *description)
 {
 	if (err != 0) {
-		shell_error(ctx_shell,
-			    "AICS description get failed (%d) for inst %p",
-			    err, inst);
+		LOG_ERR("AICS description get failed (%d) for inst %p", err, (void *)inst);
 	} else {
-		shell_print(ctx_shell, "AICS inst %p description %s",
-			    inst, description);
+		LOG_DBG("AICS inst %p description %s", (void *)inst, description);
 	}
 }
 #endif /* CONFIG_BT_VCP_VOL_CTLR_MAX_AICS_INST > 0 */
@@ -241,20 +221,18 @@ static void vcs_aics_description_cb(struct bt_aics *inst, int err,
 static void vcs_vocs_set_offset_cb(struct bt_vocs *inst, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "Set offset failed (%d) for inst %p",
-			    err, inst);
+		LOG_ERR("Set offset failed (%d) for inst %p", err, (void *)inst);
 	} else {
-		shell_print(ctx_shell, "Offset set for inst %p", inst);
+		LOG_DBG("Offset set for inst %p", (void *)inst);
 	}
 }
 
 static void vcs_vocs_state_cb(struct bt_vocs *inst, int err, int16_t offset)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "VOCS state get failed (%d) for inst %p",
-			    err, inst);
+		LOG_ERR("VOCS state get failed (%d) for inst %p", err, (void *)inst);
 	} else {
-		shell_print(ctx_shell, "VOCS inst %p offset %d", inst, offset);
+		LOG_DBG("VOCS inst %p offset %d", (void *)inst, offset);
 	}
 }
 
@@ -262,12 +240,9 @@ static void vcs_vocs_location_cb(struct bt_vocs *inst, int err,
 				 uint32_t location)
 {
 	if (err != 0) {
-		shell_error(ctx_shell,
-			    "VOCS location get failed (%d) for inst %p",
-			    err, inst);
+		LOG_ERR("VOCS location get failed (%d) for inst %p", err, (void *)inst);
 	} else {
-		shell_print(ctx_shell, "VOCS inst %p location %u",
-			    inst, location);
+		LOG_DBG("VOCS inst %p location %u", (void *)inst, location);
 	}
 }
 
@@ -275,12 +250,9 @@ static void vcs_vocs_description_cb(struct bt_vocs *inst, int err,
 				    char *description)
 {
 	if (err != 0) {
-		shell_error(ctx_shell,
-			    "VOCS description get failed (%d) for inst %p",
-			    err, inst);
+		LOG_ERR("VOCS description get failed (%d) for inst %p", err, (void *)inst);
 	} else {
-		shell_print(ctx_shell, "VOCS inst %p description %s",
-			    inst, description);
+		LOG_DBG("VOCS inst %p description %s", (void *)inst, description);
 	}
 }
 #endif /* CONFIG_BT_VCP_VOL_CTLR_MAX_VOCS_INST > 0 */
@@ -328,10 +300,6 @@ static int cmd_vcp_vol_ctlr_discover(const struct shell *sh, size_t argc,
 {
 	static bool cb_registered;
 	int result;
-
-	if (!ctx_shell) {
-		ctx_shell = sh;
-	}
 
 	if (!cb_registered) {
 		result = bt_vcp_vol_ctlr_cb_register(&vcp_cbs);

--- a/subsys/bluetooth/audio/shell/vcp_vol_rend.c
+++ b/subsys/bluetooth/audio/shell/vcp_vol_rend.c
@@ -10,6 +10,7 @@
 #include <zephyr/types.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/audio/vcp.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -17,23 +18,25 @@
 
 #include "shell/bt.h"
 
+LOG_MODULE_REGISTER(vcp_vol_rend_shell, LOG_LEVEL_DBG);
+
 static struct bt_vcp_included vcp_included;
 
 static void vcp_vol_rend_state_cb(int err, uint8_t volume, uint8_t mute)
 {
 	if (err) {
-		shell_error(ctx_shell, "VCP state get failed (%d)", err);
+		LOG_ERR("VCP state get failed (%d)", err);
 	} else {
-		shell_print(ctx_shell, "VCP volume %u, mute %u", volume, mute);
+		LOG_DBG("VCP volume %u, mute %u", volume, mute);
 	}
 }
 
 static void vcp_vol_rend_flags_cb(int err, uint8_t flags)
 {
 	if (err) {
-		shell_error(ctx_shell, "VCP flags get failed (%d)", err);
+		LOG_ERR("VCP flags get failed (%d)", err);
 	} else {
-		shell_print(ctx_shell, "VCP flags 0x%02X", flags);
+		LOG_DBG("VCP flags 0x%02X", flags);
 	}
 }
 
@@ -41,13 +44,10 @@ static void aics_state_cb(struct bt_aics *inst, int err, int8_t gain,
 			  uint8_t mute, uint8_t mode)
 {
 	if (err) {
-		shell_error(ctx_shell,
-			    "AICS state get failed (%d) for inst %p",
-			    err, inst);
+		LOG_ERR("AICS state get failed (%d) for inst %p", err, (void *)inst);
 	} else {
-		shell_print(ctx_shell,
-			    "AICS inst %p state gain %d, mute %u, mode %u",
-			    inst, gain, mute, mode);
+		LOG_DBG("AICS inst %p state gain %d, mute %u, mode %u", (void *)inst, gain, mute,
+			mode);
 	}
 }
 
@@ -55,13 +55,10 @@ static void aics_gain_setting_cb(struct bt_aics *inst, int err, uint8_t units,
 				 int8_t minimum, int8_t maximum)
 {
 	if (err) {
-		shell_error(ctx_shell,
-			    "AICS gain settings get failed (%d) for inst %p",
-			    err, inst);
+		LOG_ERR("AICS gain settings get failed (%d) for inst %p", err, (void *)inst);
 	} else {
-		shell_print(ctx_shell,
-			    "AICS inst %p gain settings units %u, min %d, max %d",
-			    inst, units, minimum, maximum);
+		LOG_DBG("AICS inst %p gain settings units %u, min %d, max %d", (void *)inst, units,
+			minimum, maximum);
 	}
 }
 
@@ -69,24 +66,18 @@ static void aics_input_type_cb(struct bt_aics *inst, int err,
 			       uint8_t input_type)
 {
 	if (err) {
-		shell_error(ctx_shell,
-			    "AICS input type get failed (%d) for inst %p",
-			    err, inst);
+		LOG_ERR("AICS input type get failed (%d) for inst %p", err, (void *)inst);
 	} else {
-		shell_print(ctx_shell, "AICS inst %p input type %u",
-			    inst, input_type);
+		LOG_DBG("AICS inst %p input type %u", (void *)inst, input_type);
 	}
 }
 
 static void aics_status_cb(struct bt_aics *inst, int err, bool active)
 {
 	if (err) {
-		shell_error(ctx_shell,
-			    "AICS status get failed (%d) for inst %p",
-			    err, inst);
+		LOG_ERR("AICS status get failed (%d) for inst %p", err, (void *)inst);
 	} else {
-		shell_print(ctx_shell, "AICS inst %p status %s",
-			    inst, active ? "active" : "inactive");
+		LOG_DBG("AICS inst %p status %s", (void *)inst, active ? "active" : "inactive");
 	}
 
 }
@@ -94,33 +85,26 @@ static void aics_description_cb(struct bt_aics *inst, int err,
 				char *description)
 {
 	if (err) {
-		shell_error(ctx_shell,
-			    "AICS description get failed (%d) for inst %p",
-			    err, inst);
+		LOG_ERR("AICS description get failed (%d) for inst %p", err, (void *)inst);
 	} else {
-		shell_print(ctx_shell, "AICS inst %p description %s",
-			    inst, description);
+		LOG_DBG("AICS inst %p description %s", (void *)inst, description);
 	}
 }
 static void vocs_state_cb(struct bt_vocs *inst, int err, int16_t offset)
 {
 	if (err) {
-		shell_error(ctx_shell, "VOCS state get failed (%d) for inst %p",
-			    err, inst);
+		LOG_ERR("VOCS state get failed (%d) for inst %p", err, (void *)inst);
 	} else {
-		shell_print(ctx_shell, "VOCS inst %p offset %d", inst, offset);
+		LOG_DBG("VOCS inst %p offset %d", (void *)inst, offset);
 	}
 }
 
 static void vocs_location_cb(struct bt_vocs *inst, int err, uint32_t location)
 {
 	if (err) {
-		shell_error(ctx_shell,
-			    "VOCS location get failed (%d) for inst %p",
-			    err, inst);
+		LOG_ERR("VOCS location get failed (%d) for inst %p", err, (void *)inst);
 	} else {
-		shell_print(ctx_shell, "VOCS inst %p location %u",
-			    inst, location);
+		LOG_DBG("VOCS inst %p location %u", (void *)inst, location);
 	}
 }
 
@@ -128,12 +112,9 @@ static void vocs_description_cb(struct bt_vocs *inst, int err,
 				char *description)
 {
 	if (err) {
-		shell_error(ctx_shell,
-			    "VOCS description get failed (%d) for inst %p",
-			    err, inst);
+		LOG_ERR("VOCS description get failed (%d) for inst %p", err, (void *)inst);
 	} else {
-		shell_print(ctx_shell, "VOCS inst %p description %s",
-			    inst, description);
+		LOG_DBG("VOCS inst %p description %s", (void *)inst, description);
 	}
 }
 
@@ -164,10 +145,6 @@ static int cmd_vcp_vol_rend_init(const struct shell *sh, size_t argc,
 	char input_desc[CONFIG_BT_VCP_VOL_REND_AICS_INSTANCE_COUNT][16];
 	char output_desc[CONFIG_BT_VCP_VOL_REND_VOCS_INSTANCE_COUNT][16];
 	static const char assignment_operator[] = "=";
-
-	if (!ctx_shell) {
-		ctx_shell = sh;
-	}
 
 	memset(&vcp_register_param, 0, sizeof(vcp_register_param));
 

--- a/subsys/bluetooth/shell/bredr.c
+++ b/subsys/bluetooth/shell/bredr.c
@@ -27,9 +27,12 @@
 #include <zephyr/bluetooth/rfcomm.h>
 #include <zephyr/bluetooth/sdp.h>
 
+#include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
 
 #include "bt.h"
+
+LOG_MODULE_REGISTER(bredr_shell, LOG_LEVEL_DBG);
 
 #if defined(CONFIG_BT_CONN)
 /* Connection context for BR/EDR legacy pairing in sec mode 3 */
@@ -146,7 +149,7 @@ static void br_device_found(const bt_addr_t *addr, int8_t rssi,
 
 	bt_addr_to_str(addr, br_addr, sizeof(br_addr));
 
-	shell_print(ctx_shell, "[DEVICE]: %s, RSSI %i %s", br_addr, rssi, name);
+	LOG_DBG("[DEVICE]: %s, RSSI %i %s", br_addr, rssi, name);
 }
 
 static struct bt_br_discovery_result br_discovery_results[5];
@@ -156,7 +159,7 @@ static void br_discovery_complete(struct bt_br_discovery_result *results,
 {
 	size_t i;
 
-	shell_print(ctx_shell, "BR/EDR discovery complete");
+	LOG_DBG("BR/EDR discovery complete");
 
 	for (i = 0; i < count; i++) {
 		br_device_found(&results[i].addr, results[i].rssi,
@@ -207,25 +210,24 @@ static int cmd_discovery(const struct shell *sh, size_t argc, char *argv[])
 
 static int l2cap_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 {
-	shell_print(ctx_shell, "Incoming data channel %p len %u", chan,
-		    buf->len);
+	LOG_DBG("Incoming data channel %p len %u", chan, buf->len);
 
 	return 0;
 }
 
 static void l2cap_connected(struct bt_l2cap_chan *chan)
 {
-	shell_print(ctx_shell, "Channel %p connected", chan);
+	LOG_DBG("Channel %p connected", chan);
 }
 
 static void l2cap_disconnected(struct bt_l2cap_chan *chan)
 {
-	shell_print(ctx_shell, "Channel %p disconnected", chan);
+	LOG_DBG("Channel %p disconnected", chan);
 }
 
 static struct net_buf *l2cap_alloc_buf(struct bt_l2cap_chan *chan)
 {
-	shell_print(ctx_shell, "Channel %p requires buffer", chan);
+	LOG_DBG("Channel %p requires buffer", chan);
 
 	return net_buf_alloc(&data_pool, K_FOREVER);
 }
@@ -246,10 +248,10 @@ static struct bt_l2cap_br_chan l2cap_chan = {
 static int l2cap_accept(struct bt_conn *conn, struct bt_l2cap_server *server,
 			struct bt_l2cap_chan **chan)
 {
-	shell_print(ctx_shell, "Incoming BR/EDR conn %p", conn);
+	LOG_DBG("Incoming BR/EDR conn %p", (void *)conn);
 
 	if (l2cap_chan.chan.conn) {
-		shell_error(ctx_shell, "No channels available");
+		LOG_ERR("No channels available");
 		return -ENOMEM;
 	}
 
@@ -369,10 +371,8 @@ static uint8_t sdp_hfp_ag_user(struct bt_conn *conn,
 	conn_addr_str(conn, addr, sizeof(addr));
 
 	if (result) {
-		shell_print(ctx_shell, "SDP HFPAG data@%p (len %u) hint %u from"
-			    " remote %s", result->resp_buf,
-			    result->resp_buf->len, result->next_record_hint,
-			    addr);
+		LOG_DBG("SDP HFPAG data@%p (len %u) hint %u from remote %s", result->resp_buf,
+			result->resp_buf->len, result->next_record_hint, addr);
 
 		/*
 		 * Focus to get BT_SDP_ATTR_PROTO_DESC_LIST attribute item to
@@ -381,21 +381,19 @@ static uint8_t sdp_hfp_ag_user(struct bt_conn *conn,
 		res = bt_sdp_get_proto_param(result->resp_buf,
 					     BT_SDP_PROTO_RFCOMM, &param);
 		if (res < 0) {
-			shell_error(ctx_shell, "Error getting Server CN, "
-				    "err %d", res);
+			LOG_ERR("Error getting Server CN, err %d", res);
 			goto done;
 		}
-		shell_print(ctx_shell, "HFPAG Server CN param 0x%04x", param);
+		LOG_DBG("HFPAG Server CN param 0x%04x", param);
 
 		res = bt_sdp_get_profile_version(result->resp_buf,
 						 BT_SDP_HANDSFREE_SVCLASS,
 						 &version);
 		if (res < 0) {
-			shell_error(ctx_shell, "Error getting profile version, "
-				    "err %d", res);
+			LOG_ERR("Error getting profile version, err %d", res);
 			goto done;
 		}
-		shell_print(ctx_shell, "HFP version param 0x%04x", version);
+		LOG_DBG("HFP version param 0x%04x", version);
 
 		/*
 		 * Focus to get BT_SDP_ATTR_SUPPORTED_FEATURES attribute item to
@@ -403,15 +401,12 @@ static uint8_t sdp_hfp_ag_user(struct bt_conn *conn,
 		 */
 		res = bt_sdp_get_features(result->resp_buf, &features);
 		if (res < 0) {
-			shell_error(ctx_shell, "Error getting HFPAG Features, "
-				    "err %d", res);
+			LOG_ERR("Error getting HFPAG Features, err %d", res);
 			goto done;
 		}
-		shell_print(ctx_shell, "HFPAG Supported Features param 0x%04x",
-		      features);
+		LOG_DBG("HFPAG Supported Features param 0x%04x", features);
 	} else {
-		shell_print(ctx_shell, "No SDP HFPAG data from remote %s",
-			    addr);
+		LOG_DBG("No SDP HFPAG data from remote %s", addr);
 	}
 done:
 	return BT_SDP_DISCOVER_UUID_CONTINUE;
@@ -428,10 +423,8 @@ static uint8_t sdp_a2src_user(struct bt_conn *conn,
 	conn_addr_str(conn, addr, sizeof(addr));
 
 	if (result) {
-		shell_print(ctx_shell, "SDP A2SRC data@%p (len %u) hint %u from"
-			    " remote %s", result->resp_buf,
-			    result->resp_buf->len, result->next_record_hint,
-			    addr);
+		LOG_DBG("SDP A2SRC data@%p (len %u) hint %u from remote %s", result->resp_buf,
+			result->resp_buf->len, result->next_record_hint, addr);
 
 		/*
 		 * Focus to get BT_SDP_ATTR_PROTO_DESC_LIST attribute item to
@@ -440,13 +433,11 @@ static uint8_t sdp_a2src_user(struct bt_conn *conn,
 		res = bt_sdp_get_proto_param(result->resp_buf,
 					     BT_SDP_PROTO_L2CAP, &param);
 		if (res < 0) {
-			shell_error(ctx_shell, "A2SRC PSM Number not found, "
-				    "err %d", res);
+			LOG_ERR("A2SRC PSM Number not found, err %d", res);
 			goto done;
 		}
 
-		shell_print(ctx_shell, "A2SRC Server PSM Number param 0x%04x",
-			    param);
+		LOG_DBG("A2SRC Server PSM Number param 0x%04x", param);
 
 		/*
 		 * Focus to get BT_SDP_ATTR_PROFILE_DESC_LIST attribute item to
@@ -456,11 +447,10 @@ static uint8_t sdp_a2src_user(struct bt_conn *conn,
 						 BT_SDP_ADVANCED_AUDIO_SVCLASS,
 						 &version);
 		if (res < 0) {
-			shell_error(ctx_shell, "A2SRC version not found, "
-				    "err %d", res);
+			LOG_ERR("A2SRC version not found, err %d", res);
 			goto done;
 		}
-		shell_print(ctx_shell, "A2SRC version param 0x%04x", version);
+		LOG_DBG("A2SRC version param 0x%04x", version);
 
 		/*
 		 * Focus to get BT_SDP_ATTR_SUPPORTED_FEATURES attribute item to
@@ -468,15 +458,12 @@ static uint8_t sdp_a2src_user(struct bt_conn *conn,
 		 */
 		res = bt_sdp_get_features(result->resp_buf, &features);
 		if (res < 0) {
-			shell_error(ctx_shell, "A2SRC Features not found, "
-				    "err %d", res);
+			LOG_ERR("A2SRC Features not found, err %d", res);
 			goto done;
 		}
-		shell_print(ctx_shell, "A2SRC Supported Features param 0x%04x",
-		      features);
+		LOG_DBG("A2SRC Supported Features param 0x%04x", features);
 	} else {
-		shell_print(ctx_shell, "No SDP A2SRC data from remote %s",
-			    addr);
+		LOG_DBG("No SDP A2SRC data from remote %s", addr);
 	}
 done:
 	return BT_SDP_DISCOVER_UUID_CONTINUE;

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -46,7 +46,6 @@ LOG_MODULE_REGISTER(bt_shell, LOG_LEVEL_DBG);
 static bool no_settings_load;
 
 uint8_t selected_id = BT_ID_DEFAULT;
-const struct shell *ctx_shell;
 
 #if defined(CONFIG_BT_CONN)
 struct bt_conn *default_conn;
@@ -1069,8 +1068,6 @@ static int cmd_init(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err;
 	bool sync = false;
-
-	ctx_shell = sh;
 
 	for (size_t argn = 1; argn < argc; argn++) {
 		const char *arg = argv[argn];

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -33,12 +33,15 @@
 #include <zephyr/bluetooth/sdp.h>
 #include <zephyr/bluetooth/iso.h>
 
+#include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
 
 #include "bt.h"
 #include "ll.h"
 #include "hci.h"
 #include "../audio/shell/audio.h"
+
+LOG_MODULE_REGISTER(bt_shell, LOG_LEVEL_DBG);
 
 static bool no_settings_load;
 
@@ -122,8 +125,7 @@ static void print_le_addr(const char *desc, const bt_addr_le_t *addr)
 
 	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 
-	shell_print(ctx_shell, "%s address: %s (%s)", desc, addr_str,
-		    addr_desc);
+	LOG_DBG("%s address: %s (%s)", desc, addr_str, addr_desc);
 }
 #endif /* CONFIG_BT_CONN || (CONFIG_BT_BROADCASTER && CONFIG_BT_EXT_ADV) */
 
@@ -198,6 +200,7 @@ static struct bt_auto_connect {
 	bt_addr_le_t addr;
 	bool addr_set;
 	bool connect_name;
+	const struct shell *sh;
 } auto_connect;
 #endif
 
@@ -261,17 +264,28 @@ static bool data_cb(struct bt_data *data, void *user_data)
 	}
 }
 
-static void print_data_hex(const uint8_t *data, uint8_t len, enum shell_vt100_color color)
+/* Log a hex value as big-endian */
+static void print_data_hex_be(const uint8_t *data, uint8_t len, enum shell_vt100_color color)
 {
-	if (len == 0)
-		return;
+	static char data_str[UINT8_MAX + 1 /* null terminator */];
 
-	shell_fprintf(ctx_shell, color, "0x");
+	if (len == 0) {
+		return;
+	}
+
+	memset(data_str, 0, sizeof(data_str));
+
 	/* Reverse the byte order when printing as advertising data is LE
 	 * and the MSB should be first in the printed output.
 	 */
-	for (int16_t i = len - 1; i >= 0; i--) {
-		shell_fprintf(ctx_shell, color, "%02x", data[i]);
+	for (uint16_t i = len - 1, j = 3; i >= 0; i--, j++) {
+		hex2char(data[i], &data_str[j]);
+	}
+
+	if (color == SHELL_WARNING) {
+		LOG_WRN("\t\tExcess data: 0x%s", data_str);
+	} else {
+		LOG_DBG("\t\t0x%s", data_str);
 	}
 }
 
@@ -285,24 +299,18 @@ static void print_data_set(uint8_t set_value_len,
 	}
 
 	do {
-		if (idx > 0) {
-			shell_fprintf(ctx_shell, SHELL_INFO, ADV_DATA_DELIMITER);
-		}
-
-		print_data_hex(&scan_data[idx], set_value_len, SHELL_INFO);
+		print_data_hex_be(&scan_data[idx], set_value_len, SHELL_INFO);
 		idx += set_value_len;
 	} while (idx + set_value_len <= scan_data_len);
 
 	if (idx < scan_data_len) {
-		shell_fprintf(ctx_shell, SHELL_WARNING, " Excess data: ");
-		print_data_hex(&scan_data[idx], scan_data_len - idx, SHELL_WARNING);
+		print_data_hex_be(&scan_data[idx], scan_data_len - idx, SHELL_WARNING);
 	}
 }
 
 static bool data_verbose_cb(struct bt_data *data, void *user_data)
 {
-	shell_fprintf(ctx_shell, SHELL_INFO, "%*sType 0x%02x: ",
-		      strlen(scan_response_label), "", data->type);
+	LOG_DBG("\tType 0x%02x: ", data->type);
 
 	switch (data->type) {
 	case BT_DATA_UUID16_SOME:
@@ -315,17 +323,18 @@ static bool data_verbose_cb(struct bt_data *data, void *user_data)
 		 * the rest is unknown and printed as single bytes
 		 */
 		if (data->data_len < BT_UUID_SIZE_16) {
-			shell_fprintf(ctx_shell, SHELL_WARNING,
-				      "BT_DATA_SVC_DATA16 data length too short (%u)",
-				      data->data_len);
+			LOG_WRN("\t\tBT_DATA_SVC_DATA16 data length too short (%u)",
+				data->data_len);
 			break;
 		}
+
 		print_data_set(BT_UUID_SIZE_16, data->data, BT_UUID_SIZE_16);
 		if (data->data_len > BT_UUID_SIZE_16) {
-			shell_fprintf(ctx_shell, SHELL_INFO, ADV_DATA_DELIMITER);
-			print_data_set(1, data->data + BT_UUID_SIZE_16,
+			print_data_set(data->data_len - BT_UUID_SIZE_16,
+				       data->data + BT_UUID_SIZE_16,
 				       data->data_len - BT_UUID_SIZE_16);
 		}
+
 		break;
 	case BT_DATA_UUID32_SOME:
 	case BT_DATA_UUID32_ALL:
@@ -336,17 +345,19 @@ static bool data_verbose_cb(struct bt_data *data, void *user_data)
 		 * the rest is unknown and printed as single bytes
 		 */
 		if (data->data_len < BT_UUID_SIZE_32) {
-			shell_fprintf(ctx_shell, SHELL_WARNING,
-				      "BT_DATA_SVC_DATA32 data length too short (%u)",
-				      data->data_len);
+			LOG_WRN("\t\tBT_DATA_SVC_DATA32 data length too short (%u)",
+				data->data_len);
 			break;
 		}
+
 		print_data_set(BT_UUID_SIZE_32, data->data, BT_UUID_SIZE_32);
+
 		if (data->data_len > BT_UUID_SIZE_32) {
-			shell_fprintf(ctx_shell, SHELL_INFO, ADV_DATA_DELIMITER);
-			print_data_set(1, data->data + BT_UUID_SIZE_32,
+			print_data_set(data->data_len - BT_UUID_SIZE_32,
+				       data->data + BT_UUID_SIZE_32,
 				       data->data_len - BT_UUID_SIZE_32);
 		}
+
 		break;
 	case BT_DATA_UUID128_SOME:
 	case BT_DATA_UUID128_ALL:
@@ -358,22 +369,23 @@ static bool data_verbose_cb(struct bt_data *data, void *user_data)
 		 * the rest is unknown and printed as single bytes
 		 */
 		if (data->data_len < BT_UUID_SIZE_128) {
-			shell_fprintf(ctx_shell, SHELL_WARNING,
-				      "BT_DATA_SVC_DATA128 data length too short (%u)",
-				      data->data_len);
+			LOG_WRN("\t\tBT_DATA_SVC_DATA128 data length too short (%u)",
+				data->data_len);
 			break;
 		}
+
 		print_data_set(BT_UUID_SIZE_128, data->data, BT_UUID_SIZE_128);
 		if (data->data_len > BT_UUID_SIZE_128) {
-			shell_fprintf(ctx_shell, SHELL_INFO, ADV_DATA_DELIMITER);
-			print_data_set(1, data->data + BT_UUID_SIZE_128,
+			print_data_set(data->data_len - BT_UUID_SIZE_128,
+				       data->data + BT_UUID_SIZE_128,
 				       data->data_len - BT_UUID_SIZE_128);
 		}
+
 		break;
 	case BT_DATA_NAME_SHORTENED:
 	case BT_DATA_NAME_COMPLETE:
 	case BT_DATA_BROADCAST_NAME:
-		shell_fprintf(ctx_shell, SHELL_INFO, "%.*s", data->data_len, data->data);
+		LOG_HEXDUMP_DBG(data->data, data->data_len, "\t\tName:");
 		break;
 	case BT_DATA_PUB_TARGET_ADDR:
 	case BT_DATA_RAND_TARGET_ADDR:
@@ -384,10 +396,8 @@ static bool data_verbose_cb(struct bt_data *data, void *user_data)
 		print_data_set(3, data->data, data->data_len);
 		break;
 	default:
-		print_data_set(1, data->data, data->data_len);
+		print_data_set(data->data_len, data->data, data->data_len);
 	}
-
-	shell_fprintf(ctx_shell, SHELL_INFO, "\n");
 
 	return true;
 }
@@ -470,27 +480,21 @@ static void scan_recv(const struct bt_le_scan_recv_info *info, struct net_buf_si
 	bt_data_parse(buf, data_cb, name);
 	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
-	shell_print(ctx_shell, "%s%s, AD evt type %u, RSSI %i %s "
-		    "C:%u S:%u D:%d SR:%u E:%u Prim: %s, Secn: %s, "
-		    "Interval: 0x%04x (%u us), SID: 0x%x",
-		    scan_response_label,
-		    le_addr, info->adv_type, info->rssi, name,
-		    (info->adv_props & BT_GAP_ADV_PROP_CONNECTABLE) != 0,
-		    (info->adv_props & BT_GAP_ADV_PROP_SCANNABLE) != 0,
-		    (info->adv_props & BT_GAP_ADV_PROP_DIRECTED) != 0,
-		    (info->adv_props & BT_GAP_ADV_PROP_SCAN_RESPONSE) != 0,
-		    (info->adv_props & BT_GAP_ADV_PROP_EXT_ADV) != 0,
-		    phy2str(info->primary_phy), phy2str(info->secondary_phy),
-		    info->interval, BT_CONN_INTERVAL_TO_US(info->interval),
-		    info->sid);
+	LOG_DBG("%s%s, AD evt type %u, RSSI %i %s C:%u S:%u D:%d SR:%u E:%u Prim: %s, Secn: %s, "
+		"Interval: 0x%04x (%u us), SID: 0x%x",
+		scan_response_label, le_addr, info->adv_type, info->rssi, name,
+		(info->adv_props & BT_GAP_ADV_PROP_CONNECTABLE) != 0,
+		(info->adv_props & BT_GAP_ADV_PROP_SCANNABLE) != 0,
+		(info->adv_props & BT_GAP_ADV_PROP_DIRECTED) != 0,
+		(info->adv_props & BT_GAP_ADV_PROP_SCAN_RESPONSE) != 0,
+		(info->adv_props & BT_GAP_ADV_PROP_EXT_ADV) != 0, phy2str(info->primary_phy),
+		phy2str(info->secondary_phy), info->interval,
+		BT_CONN_INTERVAL_TO_US(info->interval), info->sid);
 
 	if (scan_verbose_output) {
-		shell_info(ctx_shell,
-			   "%*s[SCAN DATA START - %s]",
-			   strlen(scan_response_label), "",
-			   scan_response_type_txt(info->adv_type));
+		LOG_DBG("\t[SCAN DATA START - %s]", scan_response_type_txt(info->adv_type));
 		bt_data_parse(&buf_copy, data_verbose_cb, NULL);
-		shell_info(ctx_shell, "%*s[SCAN DATA END]", strlen(scan_response_label), "");
+		LOG_DBG("\t[SCAN DATA END]");
 	}
 
 #if defined(CONFIG_BT_CENTRAL)
@@ -507,13 +511,13 @@ static void scan_recv(const struct bt_le_scan_recv_info *info, struct net_buf_si
 			if (auto_connect.connect_name) {
 				auto_connect.connect_name = false;
 
-				cmd_scan_off(ctx_shell);
+				cmd_scan_off(auto_connect.sh);
 
 				/* "name" is what would be in argv[0] normally */
-				cmd_scan_filter_clear_name(ctx_shell, 1, (char *[]){"name"});
+				cmd_scan_filter_clear_name(auto_connect.sh, 1, (char *[]){"name"});
 
 				/* "connect" is what would be in argv[0] normally */
-				cmd_connect_le(ctx_shell, 1, (char *[]){"connect"});
+				cmd_connect_le(auto_connect.sh, 1, (char *[]){"connect"});
 			}
 		} else {
 			bt_conn_unref(conn);
@@ -524,13 +528,14 @@ static void scan_recv(const struct bt_le_scan_recv_info *info, struct net_buf_si
 
 static void scan_timeout(void)
 {
-	shell_print(ctx_shell, "Scan timeout");
+	LOG_DBG("Scan timeout");
 
 #if defined(CONFIG_BT_CENTRAL)
 	if (auto_connect.connect_name) {
 		auto_connect.connect_name = false;
 		/* "name" is what would be in argv[0] normally */
-		cmd_scan_filter_clear_name(ctx_shell, 1, (char *[]){ "name" });
+		cmd_scan_filter_clear_name(auto_connect.sh, 1, (char *[]){"name"});
+		auto_connect.sh = NULL;
 	}
 #endif /* CONFIG_BT_CENTRAL */
 }
@@ -541,8 +546,8 @@ static void scan_timeout(void)
 static void adv_sent(struct bt_le_ext_adv *adv,
 		     struct bt_le_ext_adv_sent_info *info)
 {
-	shell_print(ctx_shell, "Advertiser[%d] %p sent %d",
-		    bt_le_ext_adv_get_index(adv), adv, info->num_sent);
+	LOG_DBG("Advertiser[%d] %p sent %d", bt_le_ext_adv_get_index(adv), (void *)adv,
+		info->num_sent);
 }
 
 static void adv_scanned(struct bt_le_ext_adv *adv,
@@ -552,8 +557,7 @@ static void adv_scanned(struct bt_le_ext_adv *adv,
 
 	bt_addr_le_to_str(info->addr, str, sizeof(str));
 
-	shell_print(ctx_shell, "Advertiser[%d] %p scanned by %s",
-		    bt_le_ext_adv_get_index(adv), adv, str);
+	LOG_DBG("Advertiser[%d] %p scanned by %s", bt_le_ext_adv_get_index(adv), (void *)adv, str);
 }
 #endif /* CONFIG_BT_BROADCASTER */
 
@@ -565,8 +569,8 @@ static void adv_connected(struct bt_le_ext_adv *adv,
 
 	bt_addr_le_to_str(bt_conn_get_dst(info->conn), str, sizeof(str));
 
-	shell_print(ctx_shell, "Advertiser[%d] %p connected by %s",
-		    bt_le_ext_adv_get_index(adv), adv, str);
+	LOG_DBG("Advertiser[%d] %p connected by %s", bt_le_ext_adv_get_index(adv), (void *)adv,
+		str);
 }
 #endif /* CONFIG_BT_PERIPHERAL */
 
@@ -577,9 +581,8 @@ static bool adv_rpa_expired(struct bt_le_ext_adv *adv)
 
 	bool keep_rpa = atomic_test_bit(adv_set_opt[adv_index],
 					  SHELL_ADV_OPT_KEEP_RPA);
-	shell_print(ctx_shell, "Advertiser[%d] %p RPA %s",
-		    adv_index, adv,
-		    keep_rpa ? "not expired" : "expired");
+	LOG_DBG("Advertiser[%d] %p RPA %s", adv_index, (void *)adv,
+		keep_rpa ? "not expired" : "expired");
 
 	return keep_rpa;
 }
@@ -669,16 +672,15 @@ static void connected(struct bt_conn *conn, uint8_t err)
 	conn_addr_str(conn, addr, sizeof(addr));
 
 	if (err) {
-		shell_error(ctx_shell, "Failed to connect to %s (0x%02x)", addr,
-			     err);
+		LOG_ERR("Failed to connect to %s (0x%02x)", addr, err);
 		goto done;
 	}
 
-	shell_print(ctx_shell, "Connected: %s", addr);
+	LOG_DBG("Connected: %s", addr);
 
 	info_err = bt_conn_get_info(conn, &info);
 	if (info_err != 0) {
-		shell_error(ctx_shell, "Failed to connection information: %d", info_err);
+		LOG_ERR("Failed to connection information: %d", info_err);
 		goto done;
 	}
 
@@ -712,7 +714,7 @@ static void disconnected_set_new_default_conn_cb(struct bt_conn *conn, void *use
 	}
 
 	if (bt_conn_get_info(conn, &info) != 0) {
-		shell_error(ctx_shell, "Unable to get info: conn %p", conn);
+		LOG_ERR("Unable to get info: conn %p", (void *)conn);
 		return;
 	}
 
@@ -722,7 +724,7 @@ static void disconnected_set_new_default_conn_cb(struct bt_conn *conn, void *use
 		default_conn = bt_conn_ref(conn);
 
 		bt_addr_le_to_str(info.le.dst, addr_str, sizeof(addr_str));
-		shell_print(ctx_shell, "Selected conn is now: %s", addr_str);
+		LOG_DBG("Selected conn is now: %s", addr_str);
 	}
 }
 
@@ -731,7 +733,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	char addr[BT_ADDR_LE_STR_LEN];
 
 	conn_addr_str(conn, addr, sizeof(addr));
-	shell_print(ctx_shell, "Disconnected: %s (reason 0x%02x)", addr, reason);
+	LOG_DBG("Disconnected: %s (reason 0x%02x)", addr, reason);
 
 	if (default_conn == conn) {
 		bt_conn_unref(default_conn);
@@ -744,9 +746,8 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 
 static bool le_param_req(struct bt_conn *conn, struct bt_le_conn_param *param)
 {
-	shell_print(ctx_shell, "LE conn  param req: int (0x%04x, 0x%04x) lat %d"
-		    " to %d", param->interval_min, param->interval_max,
-		    param->latency, param->timeout);
+	LOG_DBG("LE conn  param req: int (0x%04x, 0x%04x) lat %d to %d", param->interval_min,
+		param->interval_max, param->latency, param->timeout);
 
 	return true;
 }
@@ -754,8 +755,7 @@ static bool le_param_req(struct bt_conn *conn, struct bt_le_conn_param *param)
 static void le_param_updated(struct bt_conn *conn, uint16_t interval,
 			     uint16_t latency, uint16_t timeout)
 {
-	shell_print(ctx_shell, "LE conn param updated: int 0x%04x lat %d "
-		     "to %d", interval, latency, timeout);
+	LOG_DBG("LE conn param updated: int 0x%04x lat %d to %d", interval, latency, timeout);
 }
 
 #if defined(CONFIG_BT_SMP)
@@ -768,8 +768,7 @@ static void identity_resolved(struct bt_conn *conn, const bt_addr_le_t *rpa,
 	bt_addr_le_to_str(identity, addr_identity, sizeof(addr_identity));
 	bt_addr_le_to_str(rpa, addr_rpa, sizeof(addr_rpa));
 
-	shell_print(ctx_shell, "Identity resolved %s -> %s", addr_rpa,
-	      addr_identity);
+	LOG_DBG("Identity resolved %s -> %s", addr_rpa, addr_identity);
 }
 #endif
 
@@ -808,12 +807,10 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
 	conn_addr_str(conn, addr, sizeof(addr));
 
 	if (!err) {
-		shell_print(ctx_shell, "Security changed: %s level %u", addr,
-			    level);
+		LOG_DBG("Security changed: %s level %u", addr, level);
 	} else {
-		shell_print(ctx_shell, "Security failed: %s level %u "
-			    "reason: %s (%d)",
-			    addr, level, security_err_str(err), err);
+		LOG_DBG("Security failed: %s level %u reason: %s (%d)", addr, level,
+			security_err_str(err), err);
 	}
 }
 #endif
@@ -841,11 +838,9 @@ static void remote_info_available(struct bt_conn *conn,
 	bt_conn_get_info(conn, &info);
 
 	if (IS_ENABLED(CONFIG_BT_REMOTE_VERSION)) {
-		shell_print(ctx_shell,
-			    "Remote LMP version %s (0x%02x) subversion 0x%04x "
-			    "manufacturer 0x%04x", ver_str(remote_info->version),
-			    remote_info->version, remote_info->subversion,
-			    remote_info->manufacturer);
+		LOG_DBG("Remote LMP version %s (0x%02x) subversion 0x%04x manufacturer 0x%04x",
+			ver_str(remote_info->version), remote_info->version,
+			remote_info->subversion, remote_info->manufacturer);
 	}
 
 	if (info.type == BT_CONN_TYPE_LE) {
@@ -856,7 +851,7 @@ static void remote_info_available(struct bt_conn *conn,
 				sizeof(features));
 		bin2hex(features, sizeof(features),
 			features_str, sizeof(features_str));
-		shell_print(ctx_shell, "LE Features: 0x%s ", features_str);
+		LOG_DBG("LE Features: 0x%s ", features_str);
 	}
 }
 #endif /* defined(CONFIG_BT_REMOTE_INFO) */
@@ -865,10 +860,8 @@ static void remote_info_available(struct bt_conn *conn,
 void le_data_len_updated(struct bt_conn *conn,
 			 struct bt_conn_le_data_len_info *info)
 {
-	shell_print(ctx_shell,
-		    "LE data len updated: TX (len: %d time: %d)"
-		    " RX (len: %d time: %d)", info->tx_max_len,
-		    info->tx_max_time, info->rx_max_len, info->rx_max_time);
+	LOG_DBG("LE data len updated: TX (len: %d time: %d) RX (len: %d time: %d)",
+		info->tx_max_len, info->tx_max_time, info->rx_max_len, info->rx_max_time);
 }
 #endif
 
@@ -876,8 +869,8 @@ void le_data_len_updated(struct bt_conn *conn,
 void le_phy_updated(struct bt_conn *conn,
 		    struct bt_conn_le_phy_info *info)
 {
-	shell_print(ctx_shell, "LE PHY updated: TX PHY %s, RX PHY %s",
-		    phy2str(info->tx_phy), phy2str(info->rx_phy));
+	LOG_DBG("LE PHY updated: TX PHY %s, RX PHY %s", phy2str(info->tx_phy),
+		phy2str(info->rx_phy));
 }
 #endif
 
@@ -885,11 +878,11 @@ void le_phy_updated(struct bt_conn *conn,
 void tx_power_report(struct bt_conn *conn,
 		    const struct bt_conn_le_tx_power_report *report)
 {
-	shell_print(ctx_shell, "Tx Power Report: Reason: %s, PHY: %s, Tx Power Level: %d",
-		    tx_power_report_reason2str(report->reason), tx_pwr_ctrl_phy2str(report->phy),
-		    report->tx_power_level);
-	shell_print(ctx_shell, "Tx Power Level Flag Info: %s, Delta: %d",
-		    tx_power_flag2str(report->tx_power_level_flag), report->delta);
+	LOG_DBG("Tx Power Report: Reason: %s, PHY: %s, Tx Power Level: %d",
+		tx_power_report_reason2str(report->reason), tx_pwr_ctrl_phy2str(report->phy),
+		report->tx_power_level);
+	LOG_DBG("Tx Power Level Flag Info: %s, Delta: %d",
+		tx_power_flag2str(report->tx_power_level_flag), report->delta);
 }
 #endif
 
@@ -961,12 +954,11 @@ static void per_adv_sync_sync_cb(struct bt_le_per_adv_sync *sync,
 		conn_addr_str(info->conn, past_peer, sizeof(past_peer));
 	}
 
-	shell_print(ctx_shell, "PER_ADV_SYNC[%u]: [DEVICE]: %s synced, "
-		    "Interval 0x%04x (%u us), PHY %s, SD 0x%04X, PAST peer %s",
-		    bt_le_per_adv_sync_get_index(sync), le_addr,
-		    info->interval, BT_CONN_INTERVAL_TO_US(info->interval),
-		    phy2str(info->phy), info->service_data,
-		    is_past_peer ? past_peer : "not present");
+	LOG_DBG("PER_ADV_SYNC[%u]: [DEVICE]: %s synced, Interval 0x%04x (%u us), PHY %s, SD "
+		"0x%04X, PAST peer %s",
+		bt_le_per_adv_sync_get_index(sync), le_addr, info->interval,
+		BT_CONN_INTERVAL_TO_US(info->interval), phy2str(info->phy), info->service_data,
+		is_past_peer ? past_peer : "not present");
 
 	if (info->conn) { /* if from PAST */
 		for (int i = 0; i < ARRAY_SIZE(per_adv_syncs); i++) {
@@ -992,8 +984,8 @@ static void per_adv_sync_terminated_cb(
 	}
 
 	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
-	shell_print(ctx_shell, "PER_ADV_SYNC[%u]: [DEVICE]: %s sync terminated",
-		    bt_le_per_adv_sync_get_index(sync), le_addr);
+	LOG_DBG("PER_ADV_SYNC[%u]: [DEVICE]: %s sync terminated",
+		bt_le_per_adv_sync_get_index(sync), le_addr);
 }
 
 static void per_adv_sync_recv_cb(
@@ -1004,10 +996,9 @@ static void per_adv_sync_recv_cb(
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
 	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
-	shell_print(ctx_shell, "PER_ADV_SYNC[%u]: [DEVICE]: %s, tx_power %i, "
-		    "RSSI %i, CTE %u, data length %u",
-		    bt_le_per_adv_sync_get_index(sync), le_addr, info->tx_power,
-		    info->rssi, info->cte_type, buf->len);
+	LOG_DBG("PER_ADV_SYNC[%u]: [DEVICE]: %s, tx_power %i, RSSI %i, CTE %u, data length %u",
+		bt_le_per_adv_sync_get_index(sync), le_addr, info->tx_power, info->rssi,
+		info->cte_type, buf->len);
 }
 
 static void per_adv_sync_biginfo_cb(struct bt_le_per_adv_sync *sync,
@@ -1016,16 +1007,15 @@ static void per_adv_sync_biginfo_cb(struct bt_le_per_adv_sync *sync,
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
 	bt_addr_le_to_str(biginfo->addr, le_addr, sizeof(le_addr));
-	shell_print(ctx_shell, "BIG_INFO PER_ADV_SYNC[%u]: [DEVICE]: %s, sid 0x%02x, num_bis %u, "
-		    "nse 0x%02x, interval 0x%04x (%u us), bn 0x%02x, pto 0x%02x, irc 0x%02x, "
-		    "max_pdu 0x%04x, sdu_interval 0x%04x, max_sdu 0x%04x, phy %s, framing 0x%02x, "
-		    "%sencrypted",
-		    bt_le_per_adv_sync_get_index(sync), le_addr, biginfo->sid, biginfo->num_bis,
-		    biginfo->sub_evt_count, biginfo->iso_interval,
-		    BT_CONN_INTERVAL_TO_US(biginfo->iso_interval), biginfo->burst_number,
-		    biginfo->offset, biginfo->rep_count, biginfo->max_pdu, biginfo->sdu_interval,
-		    biginfo->max_sdu, phy2str(biginfo->phy), biginfo->framing,
-		    biginfo->encryption ? "" : "not ");
+	LOG_DBG("BIG_INFO PER_ADV_SYNC[%u]: [DEVICE]: %s, sid 0x%02x, num_bis %u, nse 0x%02x, "
+		"interval 0x%04x (%u us), bn 0x%02x, pto 0x%02x, irc 0x%02x, max_pdu 0x%04x, "
+		"sdu_interval 0x%04x, max_sdu 0x%04x, phy %s, framing 0x%02x, %sencrypted",
+		bt_le_per_adv_sync_get_index(sync), le_addr, biginfo->sid, biginfo->num_bis,
+		biginfo->sub_evt_count, biginfo->iso_interval,
+		BT_CONN_INTERVAL_TO_US(biginfo->iso_interval), biginfo->burst_number,
+		biginfo->offset, biginfo->rep_count, biginfo->max_pdu, biginfo->sdu_interval,
+		biginfo->max_sdu, phy2str(biginfo->phy), biginfo->framing,
+		biginfo->encryption ? "" : "not ");
 }
 
 static struct bt_le_per_adv_sync_cb per_adv_sync_cb = {
@@ -1039,15 +1029,15 @@ static struct bt_le_per_adv_sync_cb per_adv_sync_cb = {
 static void bt_ready(int err)
 {
 	if (err) {
-		shell_error(ctx_shell, "Bluetooth init failed (err %d)", err);
+		LOG_ERR("Bluetooth init failed (err %d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Bluetooth initialized");
+	LOG_DBG("Bluetooth initialized");
 
 	if (IS_ENABLED(CONFIG_SETTINGS) && !no_settings_load) {
 		settings_load();
-		shell_print(ctx_shell, "Settings Loaded");
+		LOG_DBG("Settings Loaded");
 	}
 
 	if (IS_ENABLED(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)) {
@@ -1494,8 +1484,7 @@ static int cmd_scan_filter_set_name(const struct shell *sh, size_t argc,
 	const char *name_arg = argv[1];
 
 	if (strlen(name_arg) >= sizeof(scan_filter.name)) {
-		shell_error(ctx_shell, "Name is too long (max %zu): %s\n",
-			    sizeof(scan_filter.name), name_arg);
+		LOG_ERR("Name is too long (max %zu): %s\n", sizeof(scan_filter.name), name_arg);
 		return -ENOEXEC;
 	}
 
@@ -1513,8 +1502,7 @@ static int cmd_scan_filter_set_addr(const struct shell *sh, size_t argc,
 
 	/* Validate length including null terminator. */
 	if (strlen(addr_arg) > max_cpy_len) {
-		shell_error(ctx_shell, "Invalid address string: %s\n",
-			    addr_arg);
+		LOG_ERR("Invalid address string: %s\n", addr_arg);
 		return -ENOEXEC;
 	}
 
@@ -1524,9 +1512,7 @@ static int cmd_scan_filter_set_addr(const struct shell *sh, size_t argc,
 		uint8_t tmp;
 
 		if (c != ':' && char2hex(c, &tmp) < 0) {
-			shell_error(ctx_shell,
-					"Invalid address string: %s\n",
-					addr_arg);
+			LOG_ERR("Invalid address string: %s\n", addr_arg);
 			return -ENOEXEC;
 		}
 	}
@@ -1677,7 +1663,7 @@ static ssize_t ad_init(struct bt_data *data_array, const size_t data_array_size,
 		csis_ad_len = csis_ad_data_add(&data_array[ad_len],
 					       data_array_size - ad_len, discoverable);
 		if (csis_ad_len < 0) {
-			shell_error(ctx_shell, "Failed to add CSIS data (err %d)", csis_ad_len);
+			LOG_ERR("Failed to add CSIS data (err %d)", csis_ad_len);
 			return ad_len;
 		}
 
@@ -2171,7 +2157,7 @@ static int cmd_adv_delete(const struct shell *sh, size_t argc, char *argv[])
 
 	err = bt_le_ext_adv_delete(adv);
 	if (err) {
-		shell_error(ctx_shell, "Failed to delete advertiser set");
+		LOG_ERR("Failed to delete advertiser set");
 		return err;
 	}
 
@@ -2921,6 +2907,7 @@ static int cmd_connect_le_name(const struct shell *sh, size_t argc, char *argv[]
 
 	/* Set boolean to tell the scan callback to connect to this name */
 	auto_connect.connect_name = true;
+	auto_connect.sh = sh;
 
 	return 0;
 }
@@ -3059,14 +3046,12 @@ static int cmd_info(const struct shell *sh, size_t argc, char *argv[])
 
 	err = bt_conn_get_info(conn, &info);
 	if (err) {
-		shell_print(ctx_shell, "Failed to get info");
+		LOG_DBG("Failed to get info");
 		goto done;
 	}
 
-	shell_print(ctx_shell, "Type: %s, Role: %s, Id: %u",
-		    get_conn_type_str(info.type),
-		    get_conn_role_str(info.role),
-		    info.id);
+	LOG_DBG("Type: %s, Role: %s, Id: %u", get_conn_type_str(info.type),
+		get_conn_role_str(info.role), info.id);
 
 	if (info.type == BT_CONN_TYPE_LE) {
 		print_le_addr("Remote", info.le.dst);
@@ -3074,25 +3059,19 @@ static int cmd_info(const struct shell *sh, size_t argc, char *argv[])
 		print_le_addr("Remote on-air", info.le.remote);
 		print_le_addr("Local on-air", info.le.local);
 
-		shell_print(ctx_shell, "Interval: 0x%04x (%u us)",
-			    info.le.interval,
-			    BT_CONN_INTERVAL_TO_US(info.le.interval));
-		shell_print(ctx_shell, "Latency: 0x%04x",
-			    info.le.latency);
-		shell_print(ctx_shell, "Supervision timeout: 0x%04x (%d ms)",
-			    info.le.timeout, info.le.timeout * 10);
+		LOG_DBG("Interval: 0x%04x (%u us)", info.le.interval,
+			BT_CONN_INTERVAL_TO_US(info.le.interval));
+		LOG_DBG("Latency: 0x%04x", info.le.latency);
+		LOG_DBG("Supervision timeout: 0x%04x (%d ms)", info.le.timeout,
+			info.le.timeout * 10);
 #if defined(CONFIG_BT_USER_PHY_UPDATE)
-		shell_print(ctx_shell, "LE PHY: TX PHY %s, RX PHY %s",
-			    phy2str(info.le.phy->tx_phy),
-			    phy2str(info.le.phy->rx_phy));
+		LOG_DBG("LE PHY: TX PHY %s, RX PHY %s", phy2str(info.le.phy->tx_phy),
+			phy2str(info.le.phy->rx_phy));
 #endif
 #if defined(CONFIG_BT_USER_DATA_LEN_UPDATE)
-		shell_print(ctx_shell, "LE data len: TX (len: %d time: %d)"
-			    " RX (len: %d time: %d)",
-			    info.le.data_len->tx_max_len,
-			    info.le.data_len->tx_max_time,
-			    info.le.data_len->rx_max_len,
-			    info.le.data_len->rx_max_time);
+		LOG_DBG("LE data len: TX (len: %d time: %d) RX (len: %d time: %d)",
+			info.le.data_len->tx_max_len, info.le.data_len->tx_max_time,
+			info.le.data_len->rx_max_len, info.le.data_len->rx_max_time);
 #endif
 	}
 
@@ -3101,7 +3080,7 @@ static int cmd_info(const struct shell *sh, size_t argc, char *argv[])
 		char addr_str[BT_ADDR_STR_LEN];
 
 		bt_addr_to_str(info.br.dst, addr_str, sizeof(addr_str));
-		shell_print(ctx_shell, "Peer address %s", addr_str);
+		LOG_DBG("Peer address %s", addr_str);
 	}
 #endif /* defined(CONFIG_BT_BREDR) */
 
@@ -3439,7 +3418,7 @@ static void bond_info(const struct bt_bond_info *info, void *user_data)
 	int *bond_count = user_data;
 
 	bt_addr_le_to_str(&info->addr, addr, sizeof(addr));
-	shell_print(ctx_shell, "Remote Identity: %s", addr);
+	LOG_DBG("Remote Identity: %s", addr);
 	(*bond_count)++;
 }
 
@@ -3473,7 +3452,7 @@ static void connection_info(struct bt_conn *conn, void *user_data)
 	struct bt_conn_info info;
 
 	if (bt_conn_get_info(conn, &info) < 0) {
-		shell_error(ctx_shell, "Unable to get info: conn %p", conn);
+		LOG_ERR("Unable to get info: conn %p", (void *)conn);
 		return;
 	}
 
@@ -3481,19 +3460,19 @@ static void connection_info(struct bt_conn *conn, void *user_data)
 #if defined(CONFIG_BT_BREDR)
 	case BT_CONN_TYPE_BR:
 		bt_addr_to_str(info.br.dst, addr, sizeof(addr));
-		shell_print(ctx_shell, " #%u [BR][%s] %s", info.id, role_str(info.role), addr);
+		LOG_DBG(" #%u [BR][%s] %s", info.id, role_str(info.role), addr);
 		break;
 #endif
 	case BT_CONN_TYPE_LE:
 		bt_addr_le_to_str(info.le.dst, addr, sizeof(addr));
-		shell_print(ctx_shell, "%s#%u [LE][%s] %s: Interval %u latency %u timeout %u",
-			    conn == default_conn ? "*" : " ", info.id, role_str(info.role), addr,
-			    info.le.interval, info.le.latency, info.le.timeout);
+		LOG_DBG("%s#%u [LE][%s] %s: Interval %u latency %u timeout %u",
+			conn == default_conn ? "*" : " ", info.id, role_str(info.role), addr,
+			info.le.interval, info.le.latency, info.le.timeout);
 		break;
 #if defined(CONFIG_BT_ISO)
 	case BT_CONN_TYPE_ISO:
 		bt_addr_le_to_str(info.le.dst, addr, sizeof(addr));
-		shell_print(ctx_shell, " #%u [ISO][%s] %s", info.id, role_str(info.role), addr);
+		LOG_DBG(" #%u [ISO][%s] %s", info.id, role_str(info.role), addr);
 		break;
 #endif
 	default:
@@ -3523,7 +3502,7 @@ static void auth_passkey_display(struct bt_conn *conn, unsigned int passkey)
 
 	snprintk(passkey_str, 7, "%06u", passkey);
 
-	shell_print(ctx_shell, "Passkey for %s: %s", addr, passkey_str);
+	LOG_DBG("Passkey for %s: %s", addr, passkey_str);
 }
 
 #if defined(CONFIG_BT_PASSKEY_KEYPRESS)
@@ -3534,8 +3513,7 @@ static void auth_passkey_display_keypress(struct bt_conn *conn,
 
 	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
-	shell_print(ctx_shell, "Passkey keypress notification from %s: type %d",
-		    addr, type);
+	LOG_DBG("Passkey keypress notification from %s: type %d", addr, type);
 }
 #endif
 
@@ -3548,7 +3526,7 @@ static void auth_passkey_confirm(struct bt_conn *conn, unsigned int passkey)
 
 	snprintk(passkey_str, 7, "%06u", passkey);
 
-	shell_print(ctx_shell, "Confirm passkey for %s: %s", addr, passkey_str);
+	LOG_DBG("Confirm passkey for %s: %s", addr, passkey_str);
 }
 
 static void auth_passkey_entry(struct bt_conn *conn)
@@ -3557,7 +3535,7 @@ static void auth_passkey_entry(struct bt_conn *conn)
 
 	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
-	shell_print(ctx_shell, "Enter passkey for %s", addr);
+	LOG_DBG("Enter passkey for %s", addr);
 }
 
 static void auth_cancel(struct bt_conn *conn)
@@ -3566,7 +3544,7 @@ static void auth_cancel(struct bt_conn *conn)
 
 	conn_addr_str(conn, addr, sizeof(addr));
 
-	shell_print(ctx_shell, "Pairing cancelled: %s", addr);
+	LOG_DBG("Pairing cancelled: %s", addr);
 
 	/* clear connection reference for sec mode 3 pairing */
 	if (pairing_conn) {
@@ -3581,7 +3559,7 @@ static void auth_pairing_confirm(struct bt_conn *conn)
 
 	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
-	shell_print(ctx_shell, "Confirm pairing for %s", addr);
+	LOG_DBG("Confirm pairing for %s", addr);
 }
 
 #if !defined(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)
@@ -3627,9 +3605,7 @@ static void auth_pairing_oob_data_request(struct bt_conn *conn,
 		if (oobd_remote &&
 		    !bt_addr_le_eq(info.le.remote, &oob_remote.addr)) {
 			bt_addr_le_to_str(info.le.remote, addr, sizeof(addr));
-			shell_print(ctx_shell,
-				    "No OOB data available for remote %s",
-				    addr);
+			LOG_DBG("No OOB data available for remote %s", addr);
 			bt_conn_auth_cancel(conn);
 			return;
 		}
@@ -3637,9 +3613,7 @@ static void auth_pairing_oob_data_request(struct bt_conn *conn,
 		if (oobd_local &&
 		    !bt_addr_le_eq(info.le.local, &oob_local.addr)) {
 			bt_addr_le_to_str(info.le.local, addr, sizeof(addr));
-			shell_print(ctx_shell,
-				    "No OOB data available for local %s",
-				    addr);
+			LOG_DBG("No OOB data available for local %s", addr);
 			bt_conn_auth_cancel(conn);
 			return;
 		}
@@ -3647,14 +3621,14 @@ static void auth_pairing_oob_data_request(struct bt_conn *conn,
 		bt_le_oob_set_sc_data(conn, oobd_local, oobd_remote);
 
 		bt_addr_le_to_str(info.le.dst, addr, sizeof(addr));
-		shell_print(ctx_shell, "Set %s OOB SC data for %s, ",
-			    oob_config_str(oob_info->lesc.oob_config), addr);
+		LOG_DBG("Set %s OOB SC data for %s, ", oob_config_str(oob_info->lesc.oob_config),
+			addr);
 		return;
 	}
 #endif /* CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY */
 
 	bt_addr_le_to_str(info.le.dst, addr, sizeof(addr));
-	shell_print(ctx_shell, "Legacy OOB TK requested from remote %s", addr);
+	LOG_DBG("Legacy OOB TK requested from remote %s", addr);
 }
 
 static void auth_pairing_complete(struct bt_conn *conn, bool bonded)
@@ -3663,8 +3637,7 @@ static void auth_pairing_complete(struct bt_conn *conn, bool bonded)
 
 	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
-	shell_print(ctx_shell, "%s with %s", bonded ? "Bonded" : "Paired",
-		    addr);
+	LOG_DBG("%s with %s", bonded ? "Bonded" : "Paired", addr);
 }
 
 static void auth_pairing_failed(struct bt_conn *conn, enum bt_security_err err)
@@ -3673,8 +3646,7 @@ static void auth_pairing_failed(struct bt_conn *conn, enum bt_security_err err)
 
 	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
-	shell_print(ctx_shell, "Pairing failed with %s reason: %s (%d)", addr,
-		    security_err_str(err), err);
+	LOG_DBG("Pairing failed with %s reason: %s (%d)", addr, security_err_str(err), err);
 }
 
 #if defined(CONFIG_BT_BREDR)
@@ -3694,10 +3666,9 @@ static void auth_pincode_entry(struct bt_conn *conn, bool highsec)
 	bt_addr_to_str(info.br.dst, addr, sizeof(addr));
 
 	if (highsec) {
-		shell_print(ctx_shell, "Enter 16 digits wide PIN code for %s",
-			    addr);
+		LOG_DBG("Enter 16 digits wide PIN code for %s", addr);
 	} else {
-		shell_print(ctx_shell, "Enter PIN code for %s", addr);
+		LOG_DBG("Enter PIN code for %s", addr);
 	}
 
 	/*
@@ -3714,12 +3685,10 @@ static void auth_pincode_entry(struct bt_conn *conn, bool highsec)
 enum bt_security_err pairing_accept(
 	struct bt_conn *conn, const struct bt_conn_pairing_feat *const feat)
 {
-	shell_print(ctx_shell, "Remote pairing features: "
-			       "IO: 0x%02x, OOB: %d, AUTH: 0x%02x, Key: %d, "
-			       "Init Kdist: 0x%02x, Resp Kdist: 0x%02x",
-			       feat->io_capability, feat->oob_data_flag,
-			       feat->auth_req, feat->max_enc_key_size,
-			       feat->init_key_dist, feat->resp_key_dist);
+	LOG_DBG("Remote pairing features: IO: 0x%02x, OOB: %d, AUTH: 0x%02x, Key: %d, Init Kdist: "
+		"0x%02x, Resp Kdist: 0x%02x",
+		feat->io_capability, feat->oob_data_flag, feat->auth_req, feat->max_enc_key_size,
+		feat->init_key_dist, feat->resp_key_dist);
 
 	return BT_SECURITY_ERR_SUCCESS;
 }
@@ -3730,7 +3699,7 @@ void bond_deleted(uint8_t id, const bt_addr_le_t *peer)
 	char addr[BT_ADDR_LE_STR_LEN];
 
 	bt_addr_le_to_str(peer, addr, sizeof(addr));
-	shell_print(ctx_shell, "Bond deleted for %s, id %u", addr, id);
+	LOG_DBG("Bond deleted for %s, id %u", addr, id);
 }
 
 static struct bt_conn_auth_cb auth_cb_display = {

--- a/subsys/bluetooth/shell/bt.h
+++ b/subsys/bluetooth/shell/bt.h
@@ -16,7 +16,6 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <sys/types.h>
 
-extern const struct shell *ctx_shell;
 extern struct bt_conn *default_conn;
 
 bool passes_scan_filter(const struct bt_le_scan_recv_info *info, const struct net_buf_simple *buf);

--- a/subsys/bluetooth/shell/gatt.c
+++ b/subsys/bluetooth/shell/gatt.c
@@ -24,9 +24,12 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/gatt.h>
 
+#include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
 
 #include "bt.h"
+
+LOG_MODULE_REGISTER(gatt_shell, LOG_LEVEL_DBG);
 
 #if defined(CONFIG_BT_GATT_CLIENT) || defined(CONFIG_BT_GATT_DYNAMIC_DB)
 extern uint8_t selected_id;
@@ -75,8 +78,8 @@ static void update_write_stats(uint16_t len)
 
 static void print_write_stats(void)
 {
-	shell_print(ctx_shell, "Write #%u: %u bytes (%u bps)",
-		    write_stats.count, write_stats.total, write_stats.rate);
+	LOG_DBG("Write #%u: %u bytes (%u bps)", write_stats.count, write_stats.total,
+		write_stats.rate);
 }
 #endif /* CONFIG_BT_GATT_CLIENT || CONFIG_BT_GATT_DYNAMIC_DB */
 
@@ -94,8 +97,7 @@ static struct bt_gatt_exchange_params exchange_params;
 static void exchange_func(struct bt_conn *conn, uint8_t err,
 			  struct bt_gatt_exchange_params *params)
 {
-	shell_print(ctx_shell, "Exchange %s", err == 0U ? "successful" :
-		    "failed");
+	LOG_DBG("Exchange %s", err == 0U ? "successful" : "failed");
 
 	/* Release global `exchange_params`. */
 	__ASSERT_NO_MSG(params == &exchange_params);
@@ -139,43 +141,43 @@ static int cmd_exchange_mtu(const struct shell *sh,
 static struct bt_gatt_discover_params discover_params;
 static struct bt_uuid_16 uuid = BT_UUID_INIT_16(0);
 
-static void print_chrc_props(const struct shell *sh, uint8_t properties)
+static void print_chrc_props(uint8_t properties)
 {
-	shell_print(sh, "Properties: ");
+	LOG_DBG("Properties: ");
 
 	if (properties & BT_GATT_CHRC_BROADCAST) {
-		shell_print(sh, "[bcast]");
+		LOG_DBG("[bcast]");
 	}
 
 	if (properties & BT_GATT_CHRC_READ) {
-		shell_print(sh, "[read]");
+		LOG_DBG("[read]");
 	}
 
 	if (properties & BT_GATT_CHRC_WRITE) {
-		shell_print(sh, "[write]");
+		LOG_DBG("[write]");
 	}
 
 	if (properties & BT_GATT_CHRC_WRITE_WITHOUT_RESP) {
-		shell_print(sh, "[write w/w rsp]");
+		LOG_DBG("[write w/w rsp]");
 	}
 
 	if (properties & BT_GATT_CHRC_NOTIFY) {
-		shell_print(sh, "[notify]");
+		LOG_DBG("[notify]");
 	}
 
 	if (properties & BT_GATT_CHRC_INDICATE) {
-		shell_print(sh, "[indicate]");
+		LOG_DBG("[indicate]");
 	}
 
 	if (properties & BT_GATT_CHRC_AUTH) {
-		shell_print(sh, "[auth]");
+		LOG_DBG("[auth]");
 	}
 
 	if (properties & BT_GATT_CHRC_EXT_PROP) {
-		shell_print(sh, "[ext prop]");
+		LOG_DBG("[ext prop]");
 	}
 
-	shell_print(sh, "");
+	LOG_DBG("");
 }
 
 static uint8_t discover_func(struct bt_conn *conn,
@@ -188,7 +190,7 @@ static uint8_t discover_func(struct bt_conn *conn,
 	char str[BT_UUID_STR_LEN];
 
 	if (!attr) {
-		shell_print(ctx_shell, "Discover complete");
+		LOG_DBG("Discover complete");
 		(void)memset(params, 0, sizeof(*params));
 		return BT_GATT_ITER_STOP;
 	}
@@ -198,29 +200,24 @@ static uint8_t discover_func(struct bt_conn *conn,
 	case BT_GATT_DISCOVER_PRIMARY:
 		gatt_service = attr->user_data;
 		bt_uuid_to_str(gatt_service->uuid, str, sizeof(str));
-		shell_print(ctx_shell, "Service %s found: start handle %x, "
-			    "end_handle %x", str, attr->handle,
-			    gatt_service->end_handle);
+		LOG_DBG("Service %s found: start handle %x, end_handle %x", str, attr->handle,
+			gatt_service->end_handle);
 		break;
 	case BT_GATT_DISCOVER_CHARACTERISTIC:
 		gatt_chrc = attr->user_data;
 		bt_uuid_to_str(gatt_chrc->uuid, str, sizeof(str));
-		shell_print(ctx_shell, "Characteristic %s found: handle %x",
-			    str, attr->handle);
-		print_chrc_props(ctx_shell, gatt_chrc->properties);
+		LOG_DBG("Characteristic %s found: handle %x", str, attr->handle);
+		print_chrc_props(gatt_chrc->properties);
 		break;
 	case BT_GATT_DISCOVER_INCLUDE:
 		gatt_include = attr->user_data;
 		bt_uuid_to_str(gatt_include->uuid, str, sizeof(str));
-		shell_print(ctx_shell, "Include %s found: handle %x, start %x, "
-			    "end %x", str, attr->handle,
-			    gatt_include->start_handle,
-			    gatt_include->end_handle);
+		LOG_DBG("Include %s found: handle %x, start %x, end %x", str, attr->handle,
+			gatt_include->start_handle, gatt_include->end_handle);
 		break;
 	default:
 		bt_uuid_to_str(attr->uuid, str, sizeof(str));
-		shell_print(ctx_shell, "Descriptor %s found: handle %x", str,
-			    attr->handle);
+		LOG_DBG("Descriptor %s found: handle %x", str, attr->handle);
 		break;
 	}
 
@@ -291,13 +288,13 @@ static uint8_t read_func(struct bt_conn *conn, uint8_t err,
 			 struct bt_gatt_read_params *params,
 			 const void *data, uint16_t length)
 {
-	shell_print(ctx_shell, "Read complete: err 0x%02x length %u", err, length);
+	LOG_DBG("Read complete: err 0x%02x length %u", err, length);
 
 	if (!data) {
 		(void)memset(params, 0, sizeof(*params));
 		return BT_GATT_ITER_STOP;
 	} else {
-		shell_hexdump(ctx_shell, data, length);
+		LOG_HEXDUMP_DBG(data, length, "");
 	}
 
 	return BT_GATT_ITER_CONTINUE;
@@ -429,7 +426,7 @@ static uint8_t gatt_write_buf[BT_ATT_MAX_ATTRIBUTE_LEN];
 static void write_func(struct bt_conn *conn, uint8_t err,
 		       struct bt_gatt_write_params *params)
 {
-	shell_print(ctx_shell, "Write complete: err 0x%02x", err);
+	LOG_DBG("Write complete: err 0x%02x", err);
 
 	(void)memset(&write_params, 0, sizeof(write_params));
 }
@@ -557,14 +554,13 @@ static uint8_t notify_func(struct bt_conn *conn,
 			const void *data, uint16_t length)
 {
 	if (!data) {
-		shell_print(ctx_shell, "Unsubscribed");
+		LOG_DBG("Unsubscribed");
 		params->value_handle = 0U;
 		return BT_GATT_ITER_STOP;
 	}
 
-	shell_print(ctx_shell, "Notification: value_handle %u, length %u",
-		    params->value_handle, length);
-	shell_hexdump(ctx_shell, data, length);
+	LOG_DBG("Notification: value_handle %u, length %u", params->value_handle, length);
+	LOG_HEXDUMP_DBG(data, length, "");
 
 	return BT_GATT_ITER_CONTINUE;
 }
@@ -793,7 +789,7 @@ static ssize_t write_vnd1(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			  uint8_t flags)
 {
 	if (echo_enabled) {
-		shell_print(ctx_shell, "Echo attr len %u", len);
+		LOG_DBG("Echo attr len %u", len);
 		bt_gatt_notify(conn, attr, buf, len);
 	}
 

--- a/subsys/bluetooth/shell/hci.c
+++ b/subsys/bluetooth/shell/hci.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/byteorder.h>
@@ -16,6 +17,8 @@
 #include <zephyr/bluetooth/conn.h>
 
 #include "../host/hci_core.h"
+
+LOG_MODULE_REGISTER(hci_shell, LOG_LEVEL_DBG);
 
 #if defined(CONFIG_BT_HCI_MESH_EXT)
 int cmd_mesh_adv(const struct shell *sh, size_t argc, char *argv[])

--- a/subsys/bluetooth/shell/ias.c
+++ b/subsys/bluetooth/shell/ias.c
@@ -13,26 +13,27 @@
 #include <zephyr/bluetooth/conn.h>
 
 #include <zephyr/types.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/services/ias.h>
 
-extern const struct shell *ctx_shell;
+LOG_MODULE_REGISTER(ias_shell, LOG_LEVEL_DBG);
 
 static void alert_stop(void)
 {
-	shell_print(ctx_shell, "Alert stopped\n");
+	LOG_DBG("Alert stopped\n");
 }
 
 static void alert_start(void)
 {
-	shell_print(ctx_shell, "Mild alert started\n");
+	LOG_DBG("Mild alert started\n");
 }
 
 static void alert_high_start(void)
 {
-	shell_print(ctx_shell, "High alert started\n");
+	LOG_DBG("High alert started\n");
 }
 
 BT_IAS_CB_DEFINE(ias_callbacks) = {

--- a/subsys/bluetooth/shell/ias_client.c
+++ b/subsys/bluetooth/shell/ias_client.c
@@ -9,6 +9,7 @@
 
 #include <stdint.h>
 #include <zephyr/types.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
 #include <stdlib.h>
 #include <zephyr/bluetooth/gatt.h>
@@ -17,14 +18,14 @@
 
 #include "bt.h"
 
-extern const struct shell *ctx_shell;
+LOG_MODULE_REGISTER(ias_client_shell, LOG_LEVEL_DBG);
 
 static void ias_discover_cb(struct bt_conn *conn, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "Failed to discover IAS err: %d\n", err);
+		LOG_ERR("Failed to discover IAS err: %d\n", err);
 	} else {
-		shell_print(ctx_shell, "IAS discover success\n");
+		LOG_DBG("IAS discover success\n");
 	}
 }
 
@@ -35,10 +36,6 @@ static struct bt_ias_client_cb ias_client_callbacks = {
 static int cmd_ias_client_init(const struct shell *sh, size_t argc, char **argv)
 {
 	int err;
-
-	if (!ctx_shell) {
-		ctx_shell = sh;
-	}
 
 	err = bt_ias_client_cb_register(&ias_client_callbacks);
 	if (err != 0) {

--- a/subsys/bluetooth/shell/iso.c
+++ b/subsys/bluetooth/shell/iso.c
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 #include <ctype.h>
 #include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
@@ -23,6 +24,8 @@
 #include <zephyr/bluetooth/iso.h>
 
 #include "bt.h"
+
+LOG_MODULE_REGISTER(iso_shell, LOG_LEVEL_DBG);
 
 #if defined(CONFIG_BT_ISO_TX)
 #define DEFAULT_IO_QOS                                                                             \
@@ -75,8 +78,8 @@ static void iso_recv(struct bt_iso_chan *chan, const struct bt_iso_recv_info *in
 		struct net_buf *buf)
 {
 	if (info->flags & BT_ISO_FLAGS_VALID) {
-		shell_print(ctx_shell, "Incoming data channel %p len %u, seq: %d, ts: %d",
-			    chan, buf->len, info->seq_num, info->ts);
+		LOG_DBG("Incoming data channel %p len %u, seq: %d, ts: %d", chan, buf->len,
+			info->seq_num, info->ts);
 	}
 }
 #endif /* CONFIG_BT_ISO_RX */
@@ -86,8 +89,7 @@ static void iso_connected(struct bt_iso_chan *chan)
 	struct bt_iso_info iso_info;
 	int err;
 
-	shell_print(ctx_shell, "ISO Channel %p connected", chan);
-
+	LOG_DBG("ISO Channel %p connected", chan);
 
 	err = bt_iso_chan_get_info(chan, &iso_info);
 	if (err != 0) {
@@ -108,8 +110,7 @@ static void iso_connected(struct bt_iso_chan *chan)
 
 static void iso_disconnected(struct bt_iso_chan *chan, uint8_t reason)
 {
-	shell_print(ctx_shell, "ISO Channel %p disconnected with reason 0x%02x",
-		    chan, reason);
+	LOG_DBG("ISO Channel %p disconnected with reason 0x%02x", chan, reason);
 }
 
 static struct bt_iso_chan_ops iso_ops = {
@@ -474,11 +475,11 @@ static int cmd_connect(const struct shell *sh, size_t argc, char *argv[])
 static int iso_accept(const struct bt_iso_accept_info *info,
 		      struct bt_iso_chan **chan)
 {
-	shell_print(ctx_shell, "Incoming request from %p with CIG ID 0x%02X and CIS ID 0x%02X",
-		    info->acl, info->cig_id, info->cis_id);
+	LOG_DBG("Incoming request from %p with CIG ID 0x%02X and CIS ID 0x%02X", (void *)info->acl,
+		info->cig_id, info->cis_id);
 
 	if (iso_chan.iso) {
-		shell_print(ctx_shell, "No channels available");
+		LOG_DBG("No channels available");
 		return -ENOMEM;
 	}
 

--- a/subsys/bluetooth/shell/l2cap.c
+++ b/subsys/bluetooth/shell/l2cap.c
@@ -27,9 +27,12 @@
 #include <zephyr/bluetooth/rfcomm.h>
 #include <zephyr/bluetooth/sdp.h>
 
+#include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
 
 #include "bt.h"
+
+LOG_MODULE_REGISTER(l2cap_shell, LOG_LEVEL_DBG);
 
 #define CREDITS			10
 #define DATA_MTU		(23 * CREDITS)
@@ -89,7 +92,7 @@ static void l2cap_recv_cb(struct k_work *work)
 	struct net_buf *buf;
 
 	while ((buf = net_buf_get(&l2cap_recv_fifo, K_NO_WAIT))) {
-		shell_print(ctx_shell, "Confirming reception");
+		LOG_DBG("Confirming reception");
 		bt_l2cap_chan_recv_complete(&c->ch.chan, buf);
 	}
 }
@@ -102,18 +105,16 @@ static int l2cap_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 		return l2cap_recv_metrics(chan, buf);
 	}
 
-	shell_print(ctx_shell, "Incoming data channel %p len %u", chan,
-		    buf->len);
+	LOG_DBG("Incoming data channel %p len %u", chan, buf->len);
 
 	if (buf->len) {
-		shell_hexdump(ctx_shell, buf->data, buf->len);
+		LOG_HEXDUMP_DBG(buf->data, buf->len, "");
 	}
 
 	if (l2cap_recv_delay_ms > 0) {
 		/* Submit work only if queue is empty */
 		if (k_fifo_is_empty(&l2cap_recv_fifo)) {
-			shell_print(ctx_shell, "Delaying response in %u ms...",
-				    l2cap_recv_delay_ms);
+			LOG_DBG("Delaying response in %u ms...", l2cap_recv_delay_ms);
 		}
 
 		net_buf_put(&l2cap_recv_fifo, buf);
@@ -127,12 +128,12 @@ static int l2cap_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 
 static void l2cap_sent(struct bt_l2cap_chan *chan)
 {
-	shell_print(ctx_shell, "Outgoing data channel %p transmitted", chan);
+	LOG_DBG("Outgoing data channel %p transmitted", chan);
 }
 
 static void l2cap_status(struct bt_l2cap_chan *chan, atomic_t *status)
 {
-	shell_print(ctx_shell, "Channel %p status %u", chan, (uint32_t)*status);
+	LOG_DBG("Channel %p status %u", chan, (uint32_t)*status);
 }
 
 static void l2cap_connected(struct bt_l2cap_chan *chan)
@@ -141,19 +142,19 @@ static void l2cap_connected(struct bt_l2cap_chan *chan)
 
 	k_work_init_delayable(&c->recv_work, l2cap_recv_cb);
 
-	shell_print(ctx_shell, "Channel %p connected", chan);
+	LOG_DBG("Channel %p connected", chan);
 }
 
 static void l2cap_disconnected(struct bt_l2cap_chan *chan)
 {
-	shell_print(ctx_shell, "Channel %p disconnected", chan);
+	LOG_DBG("Channel %p disconnected", chan);
 }
 
 static struct net_buf *l2cap_alloc_buf(struct bt_l2cap_chan *chan)
 {
 	/* print if metrics is disabled */
 	if (!metrics) {
-		shell_print(ctx_shell, "Channel %p requires buffer", chan);
+		LOG_DBG("Channel %p requires buffer", chan);
 	}
 
 	return net_buf_alloc(&data_rx_pool, K_FOREVER);
@@ -217,7 +218,7 @@ static int l2cap_accept(struct bt_conn *conn, struct bt_l2cap_server *server,
 {
 	int err;
 
-	shell_print(ctx_shell, "Incoming conn %p", conn);
+	LOG_DBG("Incoming conn %p", (void *)conn);
 
 	err = l2cap_accept_policy(conn);
 	if (err < 0) {
@@ -225,7 +226,7 @@ static int l2cap_accept(struct bt_conn *conn, struct bt_l2cap_server *server,
 	}
 
 	if (l2ch_chan.ch.chan.conn) {
-		shell_print(ctx_shell, "No channels available");
+		LOG_DBG("No channels available");
 		return -ENOMEM;
 	}
 

--- a/subsys/bluetooth/shell/ll.c
+++ b/subsys/bluetooth/shell/ll.c
@@ -17,12 +17,15 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
 
+#include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
 
 #include "../controller/util/memq.h"
 #include "../controller/include/ll.h"
 
 #include "bt.h"
+
+LOG_MODULE_REGISTER(ll_shell, LOG_LEVEL_DBG);
 
 int cmd_ll_addr_read(const struct shell *sh, size_t argc, char *argv[])
 {

--- a/subsys/bluetooth/shell/rfcomm.c
+++ b/subsys/bluetooth/shell/rfcomm.c
@@ -27,9 +27,12 @@
 #include <zephyr/bluetooth/rfcomm.h>
 #include <zephyr/bluetooth/sdp.h>
 
+#include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
 
 #include "bt.h"
+
+LOG_MODULE_REGISTER(rfcomm_shell, LOG_LEVEL_DBG);
 
 #define DATA_MTU 48
 
@@ -101,17 +104,17 @@ static struct bt_sdp_record spp_rec = BT_SDP_RECORD(spp_attrs);
 
 static void rfcomm_recv(struct bt_rfcomm_dlc *dlci, struct net_buf *buf)
 {
-	shell_print(ctx_shell, "Incoming data dlc %p len %u", dlci, buf->len);
+	LOG_DBG("Incoming data dlc %p len %u", dlci, buf->len);
 }
 
 static void rfcomm_connected(struct bt_rfcomm_dlc *dlci)
 {
-	shell_print(ctx_shell, "Dlc %p connected", dlci);
+	LOG_DBG("Dlc %p connected", dlci);
 }
 
 static void rfcomm_disconnected(struct bt_rfcomm_dlc *dlci)
 {
-	shell_print(ctx_shell, "Dlc %p disconnected", dlci);
+	LOG_DBG("Dlc %p disconnected", dlci);
 }
 
 static struct bt_rfcomm_dlc_ops rfcomm_ops = {
@@ -127,10 +130,10 @@ static struct bt_rfcomm_dlc rfcomm_dlc = {
 
 static int rfcomm_accept(struct bt_conn *conn, struct bt_rfcomm_dlc **dlc)
 {
-	shell_print(ctx_shell, "Incoming RFCOMM conn %p", conn);
+	LOG_DBG("Incoming RFCOMM conn %p", (void *)conn);
 
 	if (rfcomm_dlc.session) {
-		shell_error(ctx_shell, "No channels available");
+		LOG_ERR("No channels available");
 		return -ENOMEM;
 	}
 

--- a/subsys/bluetooth/shell/ticker.c
+++ b/subsys/bluetooth/shell/ticker.c
@@ -14,6 +14,7 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
 
+#include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
 
 #include "../controller/util/memq.h"
@@ -28,6 +29,8 @@
 #endif
 
 #include "bt.h"
+
+LOG_MODULE_REGISTER(ticker_shell, LOG_LEVEL_DBG);
 
 static void ticker_op_done(uint32_t err, void *context)
 {


### PR DESCRIPTION
Replace uses of ctx_shell with logging.
The ctx_shell is mostly (always?) used in callbacks,
where spending time to print directly may affect the behavior
of the stack, and should be avoided.

Logging has other advantages, such as following the order
of operations when also logging things from the stack.