### PR TITLE
boards: kconfig: Add BOARD_QUALIFIERS

### DIFF
--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -19,6 +19,17 @@ config BOARD_REVISION
 	  "plank@foo", this option will be "foo". If BOARD is "plank",
 	  this option will be the empty string.
 
+config BOARD_TARGET
+	string
+	default "$(BOARD)@$(BOARD_REVISION)$(BOARD_QUALIFIERS)" if "$(BOARD_REVISION)" != ""
+	default "$(BOARD)$(BOARD_QUALIFIERS)"
+	help
+	  Contains the board target (full string including name, revision, soc, cluster and
+	  variant) of the board being used.
+
+	  For example, if building for ``nrf5340dk/nrf5340/cpuapp`` then this will contain the
+	  value ``nrf5340dk/nrf5340/cpuapp``.
+
 config BOARD_DEPRECATED_RELEASE
 	string
 	help

--- a/boards/Kconfig.v2
+++ b/boards/Kconfig.v2
@@ -1,9 +1,10 @@
-# Copyright (c) 2022 Nordic Semiconductor ASA
+# Copyright (c) 2022-2024 Nordic Semiconductor ASA
 
 # SPDX-License-Identifier: Apache-2.0
 
 BOARD_STRING := $(normalize_upper,$(BOARD))
 BOARD_TARGET_STRING := $(normalize_upper,$(BOARD)$(BOARD_QUALIFIERS))
+BOARD_QUALIFIERS_NO_SEPARATOR := $(substring,$(BOARD_QUALIFIERS),1)
 
 config BOARD_$(BOARD_STRING)
 	def_bool y
@@ -14,5 +15,14 @@ config BOARD_$(BOARD_TARGET_STRING)
 	def_bool y
 	help
 	  Kconfig symbol identifying the board target.
+
+config BOARD_QUALIFIERS
+	string
+	default "$(BOARD_QUALIFIERS_NO_SEPARATOR)"
+	help
+	  Contains the qualifiers of the board being used without the name of the board itself.
+
+	  For example, if building for ``nrf5340dk/nrf5340/cpuapp`` then this will contain the
+	  value ``nrf5340/cpuapp``.
 
 osource "$(BOARD_DIR)/Kconfig.$(BOARD)"

--- a/samples/hello_world/src/main.c
+++ b/samples/hello_world/src/main.c
@@ -8,6 +8,7 @@
 
 int main(void)
 {
-	printf("Hello World! %s\n", CONFIG_BOARD);
+	printf("Hello World! %s\n", CONFIG_BOARD_TARGET);
+
 	return 0;
 }

--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -866,6 +866,16 @@ def shields_list_contains(kconf, _, shield):
     return "y" if shield in list.split(";") else "n"
 
 
+def substring(kconf, _, string, start, stop=None):
+    """
+    Extracts a portion of the string, removing characters from the front, back or both.
+    """
+    if stop is not None:
+        return string[int(start):int(stop)]
+    else:
+        return string[int(start):]
+
+
 # Keys in this dict are the function names as they appear
 # in Kconfig files. The values are tuples in this form:
 #
@@ -921,4 +931,5 @@ functions = {
         "dt_chosen_partition_addr_hex": (dt_chosen_partition_addr, 1, 3),
         "normalize_upper": (normalize_upper, 1, 1),
         "shields_list_contains": (shields_list_contains, 1, 1),
+        "substring": (substring, 2, 3),
 }


### PR DESCRIPTION
Adds the user-provided board qualifiers to Kconfig so it can be used by application code