### PR TITLE
snippets: nordic-ppr-ram: fix board identifier

### DIFF
--- a/snippets/nordic-ppr-ram/snippet.yml
+++ b/snippets/nordic-ppr-ram/snippet.yml
@@ -3,6 +3,6 @@ append:
   EXTRA_DTC_OVERLAY_FILE: nordic-ppr-ram.overlay
 
 boards:
-  nrf54h20pdk_nrf54h20_cpuapp:
+  nrf54h20pdk/nrf54h20/cpuapp:
     append:
       EXTRA_DTC_OVERLAY_FILE: boards/nrf54h20pdk_nrf54h20_cpuapp.overlay


### PR DESCRIPTION
Missed conversion to HWMv2.