### PR TITLE
tracing: segger-sysview: fix compilation error

### DIFF
--- a/subsys/tracing/sysview/tracing_sysview.h
+++ b/subsys/tracing/sysview/tracing_sysview.h
@@ -641,7 +641,7 @@ void sys_trace_k_thread_info(struct k_thread *thread);
 	SEGGER_SYSVIEW_RecordEndCallU32(TID_PM_DEVICE_RUNTIME_PUT,	       \
 					(uint32_t)ret)
 #define sys_port_trace_pm_device_runtime_put_async_enter(dev, delay)	       \
-	SEGGER_SYSVIEW_RecordU32(TID_PM_DEVICE_RUNTIME_PUT_ASYNC,	       \
+	SEGGER_SYSVIEW_RecordU32x2(TID_PM_DEVICE_RUNTIME_PUT_ASYNC,	       \
 			 (uint32_t)(uintptr_t)dev, (uint32_t)delay.ticks)
 #define sys_port_trace_pm_device_runtime_put_async_exit(dev, delay, ret)       \
 	SEGGER_SYSVIEW_RecordEndCallU32(TID_PM_DEVICE_RUNTIME_PUT_ASYNC,       \


### PR DESCRIPTION
Fixed the following compilation error:
```
In file included from /myproj/zephyr/include/zephyr/sys/util_macro.h:34,
                 from /myproj/zephyr/include/zephyr/irq_multilevel.h:15,
                 from /myproj/zephyr/include/zephyr/devicetree.h:20,
                 from /myproj/zephyr/include/zephyr/device.h:12,
                 from /myproj/zephyr/include/zephyr/pm/device.h:10,
                 from /myproj/zephyr/subsys/pm/device_runtime.c:8:
/myproj/zephyr/subsys/pm/device_runtime.c: In function 'pm_device_runtime_put_async':
/myproj/zephyr/subsys/tracing/sysview/./tracing_sysview.h:644:9: error: too many arguments to function 'SEGGER_SYSVIEW_RecordU32'
  644 |         SEGGER_SYSVIEW_RecordU32(TID_PM_DEVICE_RUNTIME_PUT_ASYNC,              \
```

In my setup, this exists when PM and Segger system view are enabled at the same time.