### PR TITLE
net: dns: Split long resolving to smaller pieces

### DIFF
--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -64,7 +64,27 @@ config NET_SOCKETS_DNS_TIMEOUT
 	help
 	  This variable specifies time in milliseconds after which DNS
 	  query is considered timeout. Minimum timeout is 1 second and
-	  maximum timeout is 5 min.
+	  maximum timeout is 5 min. If the value is higher than
+	  CONFIG_NET_SOCKETS_DNS_BACKOFF_INTERVAL, then we try multiple
+	  times with exponential backoff until the timeout is reached.
+
+config NET_SOCKETS_DNS_BACKOFF_INTERVAL
+	int "Backoff interval for the DNS timeout"
+	default 5000
+	range 1000 300000
+	depends on DNS_RESOLVER
+	help
+	  This variable is related to the DNS timeout. If the DNS timeout is
+	  smaller than this value, then this value is ignored. If the timeout
+	  is larger, then this variable specifies time in milliseconds after
+	  which DNS query is re-tried. If there is no reply, the backoff
+	  interval is doubled and query is retried.
+	  Example:
+	     The CONFIG_NET_SOCKETS_DNS_TIMEOUT is set to 17000 (17 secs).
+	     This value is 5000 (5 sec). If there is no reply from DNS server
+	     within 5 secs, a 2nd query is done with timeout set to 10 sec (5 * 2).
+	     If no reply is received, a 3rd query is done after 15 sec (5 + 5 * 2),
+	     and the timeout is set to 2 sec so that the total timeout is 17 seconds.
 
 config NET_SOCKET_MAX_SEND_WAIT
 	int "Max time in milliseconds waiting for a send command"

--- a/subsys/net/lib/sockets/getaddrinfo.c
+++ b/subsys/net/lib/sockets/getaddrinfo.c
@@ -103,19 +103,42 @@ static void dns_resolve_cb(enum dns_resolve_status status,
 	state->idx++;
 }
 
+static k_timeout_t recalc_timeout(k_timepoint_t end, k_timeout_t timeout)
+{
+	k_timepoint_t new_timepoint;
+
+	timeout.ticks <<= 1;
+
+	new_timepoint = sys_timepoint_calc(timeout);
+
+	if (sys_timepoint_cmp(end, new_timepoint) < 0) {
+		timeout = sys_timepoint_timeout(end);
+	}
+
+	return timeout;
+}
+
 static int exec_query(const char *host, int family,
 		      struct getaddrinfo_state *ai_state)
 {
 	enum dns_query_type qtype = DNS_QUERY_TYPE_A;
+	k_timepoint_t end = sys_timepoint_calc(K_MSEC(CONFIG_NET_SOCKETS_DNS_TIMEOUT));
+	k_timeout_t timeout = K_MSEC(MIN(CONFIG_NET_SOCKETS_DNS_TIMEOUT,
+					 CONFIG_NET_SOCKETS_DNS_BACKOFF_INTERVAL));
+	int timeout_ms;
 	int st, ret;
 
 	if (family == AF_INET6) {
 		qtype = DNS_QUERY_TYPE_AAAA;
 	}
 
+again:
+	timeout_ms = k_ticks_to_ms_floor32(timeout.ticks);
+
+	NET_DBG("Timeout %d", timeout_ms);
+
 	ret = dns_get_addr_info(host, qtype, &ai_state->dns_id,
-				dns_resolve_cb, ai_state,
-				CONFIG_NET_SOCKETS_DNS_TIMEOUT);
+				dns_resolve_cb, ai_state, timeout_ms);
 	if (ret == 0) {
 		/* If the DNS query for reason fails so that the
 		 * dns_resolve_cb() would not be called, then we want the
@@ -123,11 +146,23 @@ static int exec_query(const char *host, int family,
 		 * So make the sem timeout longer than the DNS timeout so that
 		 * we do not need to start to cancel any pending DNS queries.
 		 */
-		ret = k_sem_take(&ai_state->sem, K_MSEC(CONFIG_NET_SOCKETS_DNS_TIMEOUT + 100));
+		ret = k_sem_take(&ai_state->sem, K_MSEC(timeout_ms + 100));
 		if (ret == -EAGAIN) {
+			if (!sys_timepoint_expired(end)) {
+				timeout = recalc_timeout(end, timeout);
+				goto again;
+			}
+
 			(void)dns_cancel_addr_info(ai_state->dns_id);
 			st = DNS_EAI_AGAIN;
 		} else {
+			if (ai_state->status == DNS_EAI_CANCELED) {
+				if (!sys_timepoint_expired(end)) {
+					timeout = recalc_timeout(end, timeout);
+					goto again;
+				}
+			}
+
 			st = ai_state->status;
 		}
 	} else if (ret == -EPFNOSUPPORT) {

--- a/tests/net/socket/getaddrinfo/testcase.yaml
+++ b/tests/net/socket/getaddrinfo/testcase.yaml
@@ -1,11 +1,15 @@
 common:
   depends_on: netif
   filter: CONFIG_FULL_LIBC_SUPPORTED
+  tags:
+    - net
+    - socket
+    - getaddrinfo
+    - userspace
 tests:
   net.socket.get_addr_info:
     min_ram: 21
-    tags:
-      - net
-      - socket
-      - getaddrinfo
-      - userspace
+  net.socket.get_addr_info.timeout:
+    extra_configs:
+      - CONFIG_NET_SOCKETS_DNS_TIMEOUT=2000
+      - CONFIG_NET_SOCKETS_DNS_BACKOFF_INTERVAL=1000


### PR DESCRIPTION
If getaddrinfo() is called with a long DNS timeout, then split the timeout to smaller pieces with exponential backoff. Reason for this is that if a DNS query is lost, then we do not need to wait for a long time to find it out.

    
