### PR TITLE
x86: revert removing soc.h from atom soc

### DIFF
--- a/arch/x86/core/early_serial.c
+++ b/arch/x86/core/early_serial.c
@@ -8,6 +8,7 @@
 #include <zephyr/sys/device_mmio.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/drivers/pcie/pcie.h>
+#include <soc.h>
 
 
 #if DT_PROP_OR(DT_CHOSEN(zephyr_console), io_mapped, 0) != 0

--- a/drivers/counter/counter_cmos.c
+++ b/drivers/counter/counter_cmos.c
@@ -11,12 +11,11 @@
  * crossing clock domains (no pun intended). Use accordingly.
  */
 
-#include <zephyr/spinlock.h>
+#define DT_DRV_COMPAT motorola_mc146818
+
 #include <zephyr/drivers/counter.h>
 #include <zephyr/device.h>
-#include <limits.h>
-
-#define DT_DRV_COMPAT motorola_mc146818
+#include <soc.h>
 
 /* The "CMOS" device is accessed via an address latch and data port. */
 

--- a/drivers/disk/nvme/nvme_controller.c
+++ b/drivers/disk/nvme/nvme_controller.c
@@ -13,6 +13,7 @@ LOG_MODULE_REGISTER(nvme, CONFIG_NVME_LOG_LEVEL);
 
 #include <zephyr/kernel.h>
 
+#include <soc.h>
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 

--- a/drivers/timer/hpet.c
+++ b/drivers/timer/hpet.c
@@ -14,6 +14,8 @@
 
 #include <zephyr/dt-bindings/interrupt-controller/intel-ioapic.h>
 
+#include <soc.h>
+
 /**
  * @file
  * @brief HPET (High Precision Event Timers) driver

--- a/soc/intel/atom/soc.h
+++ b/soc/intel/atom/soc.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2010-2015, Wind River Systems, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Board configuration macros for the ia32 platform
+ *
+ * This header file is used to specify and describe board-level aspects for
+ * the 'ia32' platform.
+ */
+
+#ifndef __SOC_H_
+#define __SOC_H_
+
+#include <zephyr/sys/util.h>
+
+#ifndef _ASMLANGUAGE
+#include <zephyr/device.h>
+#include <zephyr/random/random.h>
+#endif
+
+/* PCI definitions */
+/* FIXME: The values below copied from generic ia32 soc, we need to get the
+ * correct numbers for Atom and the minnowboard
+ *
+ * This is added now to get basic enumeration of devices and verify that PCI
+ * driver is functional.
+ */
+#define PCI_BUS_NUMBERS 1
+
+#define PCI_CTRL_ADDR_REG 0xCF8
+#define PCI_CTRL_DATA_REG 0xCFC
+
+#define PCI_INTA 1
+#define PCI_INTB 2
+#define PCI_INTC 3
+#define PCI_INTD 4
+
+/**
+ *
+ * @brief Convert PCI interrupt PIN to IRQ
+ *
+ * @return IRQ number, -1 if the result is incorrect
+ *
+ */
+
+static inline int pci_pin2irq(int bus, int dev, int pin)
+{
+	ARG_UNUSED(bus);
+
+	if ((pin < PCI_INTA) || (pin > PCI_INTD)) {
+		return -1;
+	}
+	return 10 + (((pin + dev - 1) >> 1) & 1);
+}
+
+#endif /* __SOC_H_ */

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -18,6 +18,7 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/debug/stack.h>
 #include <zephyr/sys/__assert.h>
+#include <soc.h>
 
 #include <zephyr/settings/settings.h>
 


### PR DESCRIPTION
This was part of the mega hwmv2 commit. Looks like hpet drivers heavily
relies on soc.h. Reverting this for now while we look for a proper fix
and remove reliance on soc.h for drivers.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
