### PR TITLE
doc: migration-guide-3.7: Add IPv4 netmask information

### DIFF
--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -121,6 +121,13 @@ Networking
   the long-duration zperf test show with correct throughput result.
   (:github:`69500`)
 
+* Each IPv4 address assigned to a network interface has an IPv4 netmask
+  tied to it instead of being set for the whole interface.
+  If there is only one IPv4 address specified for a network interface,
+  nothing changes from the user point of view. But, if there is more than
+  one IPv4 address / network interface, the netmask must be specified
+  for each IPv4 address separately. (:github:`68419`)
+
 Other Subsystems
 ****************
 


### PR DESCRIPTION
The IPv4 netmask handling is changed and it might need adjustments from user if using more than one IPv4 address inside one specific network interface.