### PR TITLE
size_report: sort nodes by size, descending

### DIFF
--- a/scripts/footprint/size_report
+++ b/scripts/footprint/size_report
@@ -673,7 +673,7 @@ def node_sort(items):
     """
     Node sorting used with RenderTree.
     """
-    return sorted(items, key=lambda item: item._name)
+    return sorted(items, key=lambda item: -item._size)
 
 
 def print_any_tree(root, total_size, depth):


### PR DESCRIPTION
This makes the tool much more useful for its primary purpose, finding things that are large.