### PR TITLE
soc: nxp: Fix issues caught in CI from HWMv2 port

### DIFF
--- a/soc/nxp/imxrt/imxrt10xx/lpm_rt1064.c
+++ b/soc/nxp/imxrt/imxrt10xx/lpm_rt1064.c
@@ -214,6 +214,7 @@ void clock_full_power(void)
 #if DT_SAME_NODE(DT_NODELABEL(flexspi), DT_PARENT(DT_CHOSEN(flash)))
 	clock_set_div(kCLOCK_FlexspiDiv, flexspi_div);
 	clock_set_mux(kCLOCK_FlexspiMux, 3);
+#endif
 #if DT_SAME_NODE(DT_NODELABEL(flexspi2), DT_PARENT(DT_CHOSEN(flash)))
 	clock_set_div(kCLOCK_Flexspi2Div, flexspi_div);
 	clock_set_mux(kCLOCK_Flexspi2Mux, 1);
@@ -261,6 +262,7 @@ void clock_low_power(void)
 	clock_set_div(kCLOCK_FlexspiDiv, 0);
 	/* FLEXSPI1 mux to PLL3 PFD0 BYPASS */
 	clock_set_mux(kCLOCK_FlexspiMux, 3);
+#endif
 #if DT_SAME_NODE(DT_NODELABEL(flexspi2), DT_PARENT(DT_CHOSEN(flash)))
 	clock_set_div(kCLOCK_Flexspi2Div, 0);
 	/* FLEXSPI2 mux to PLL3 PFD0 BYPASS */

--- a/soc/nxp/imxrt/imxrt11xx/power.c
+++ b/soc/nxp/imxrt/imxrt11xx/power.c
@@ -9,7 +9,7 @@
 #include <fsl_dcdc.h>
 #include <fsl_gpc.h>
 #include <zephyr/dt-bindings/pm/imx_spc.h>
-#include "power_rt11xx.h"
+#include "power.h"
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);


### PR DESCRIPTION
During HWMv2 porting there was some build fails missed from typos in the RT1064 and RT11XX series, fix these.

Fixes #69734
Fixes #69735