### PR TITLE
x86, xtensa: use CONFIG_PRIVILEGED_STACK_SIZE for stack size

### DIFF
--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -471,6 +471,10 @@ config X86_EFI_CONSOLE
 	  Likewise be sure to disable any other console/printk
 	  drivers!
 
+config PRIVILEGED_STACK_SIZE
+	# Must be multiple of CONFIG_MMU_PAGE_SIZE
+	default 4096 if X86_MMU
+
 source "arch/x86/core/Kconfig.ia32"
 source "arch/x86/core/Kconfig.intel64"
 

--- a/arch/x86/core/userspace.c
+++ b/arch/x86/core/userspace.c
@@ -11,6 +11,9 @@
 #include <ksched.h>
 #include <x86_mmu.h>
 
+BUILD_ASSERT((CONFIG_PRIVILEGED_STACK_SIZE > 0) &&
+	     (CONFIG_PRIVILEGED_STACK_SIZE % CONFIG_MMU_PAGE_SIZE) == 0);
+
 #ifdef CONFIG_DEMAND_PAGING
 #include <zephyr/kernel/mm/demand_paging.h>
 #endif

--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -159,6 +159,10 @@ config XTENSA_MMU_DOUBLE_MAP
 		  This invalidates all TLBs referred by the incoming thread's
 		  memory domain when swapping page tables.
 
+config PRIVILEGED_STACK_SIZE
+	# Must be multiple of CONFIG_MMU_PAGE_SIZE
+	default 4096
+
 endif # XTENSA_MMU
 
 config XTENSA_SYSCALL_USE_HELPER

--- a/arch/xtensa/core/mmu.c
+++ b/arch/xtensa/core/mmu.c
@@ -9,6 +9,11 @@
 #include <xtensa_mmu_priv.h>
 #include <zephyr/cache.h>
 
+#ifdef CONFIG_USERSPACE
+BUILD_ASSERT((CONFIG_PRIVILEGED_STACK_SIZE > 0) &&
+	     (CONFIG_PRIVILEGED_STACK_SIZE % CONFIG_MMU_PAGE_SIZE) == 0);
+#endif
+
 #define ASID_INVALID 0
 
 struct tlb_regs {

--- a/include/zephyr/arch/x86/thread_stack.h
+++ b/include/zephyr/arch/x86/thread_stack.h
@@ -66,7 +66,7 @@ struct z_x86_thread_stack_header {
 	char guard_page[CONFIG_MMU_PAGE_SIZE];
 #endif
 #ifdef CONFIG_USERSPACE
-	char privilege_stack[CONFIG_MMU_PAGE_SIZE];
+	char privilege_stack[CONFIG_PRIVILEGED_STACK_SIZE];
 #endif /* CONFIG_USERSPACE */
 } __packed __aligned(Z_X86_STACK_BASE_ALIGN);
 

--- a/include/zephyr/arch/xtensa/thread_stack.h
+++ b/include/zephyr/arch/xtensa/thread_stack.h
@@ -47,7 +47,7 @@
 /* thread stack */
 #ifdef CONFIG_XTENSA_MMU
 struct xtensa_thread_stack_header {
-	char privilege_stack[CONFIG_MMU_PAGE_SIZE];
+	char privilege_stack[CONFIG_PRIVILEGED_STACK_SIZE];
 } __packed __aligned(XTENSA_STACK_BASE_ALIGN);
 
 #define ARCH_THREAD_STACK_RESERVED		\


### PR DESCRIPTION
Instead of using `CONFIG_MMU_PAGE_SIZE` for size of the privileged
stack, use the actual kconfig `CONFIG_PRIVILEGED_STACK_SIZE`.
This allows for changing the size of privileged stack, and
also aligns to the usage of `CONFIG_PRIVILEGED_STACK_SIZE`.