### PR TITLE
Restrict erase-value for flash simulator to 0x00 and 0xff for byte and fix flash simulator write

### DIFF
--- a/drivers/flash/Kconfig.simulator
+++ b/drivers/flash/Kconfig.simulator
@@ -26,7 +26,8 @@ config FLASH_SIMULATOR_DOUBLE_WRITES
 	bool "Allow program units to be programmed more than once"
 	help
 	 If selected, writing to a non-erased program unit will succeed, otherwise, it will return an error.
-	 Keep in mind that write operations can only pull bits to zero, regardless.
+	 Keep in mind that write operations can only change value of a bit from erase-value to the
+	 opposite.
 
 config FLASH_SIMULATOR_SIMULATE_TIMING
 	bool "Hardware timing simulation"

--- a/drivers/flash/flash_simulator.c
+++ b/drivers/flash/flash_simulator.c
@@ -268,7 +268,7 @@ static int flash_sim_write(const struct device *dev, const off_t offset,
 #if FLASH_SIMULATOR_ERASE_VALUE == 0xFF
 		*(MOCK_FLASH(offset + i)) &= *((uint8_t *)data + i);
 #else
-		*(MOCK_FLASH(offset + i)) = *((uint8_t *)data + i);
+		*(MOCK_FLASH(offset + i)) |= *((uint8_t *)data + i);
 #endif
 	}
 

--- a/dts/bindings/flash_controller/zephyr,sim-flash.yaml
+++ b/dts/bindings/flash_controller/zephyr,sim-flash.yaml
@@ -9,6 +9,7 @@ include: base.yaml
 properties:
   erase-value:
     type: int
+    enum: [0xff, 0x00]
     description: Value of erased flash cell
   memory-region:
     type: phandle


### PR DESCRIPTION
Two commits:
 1) restricts erase-value from flash simulator DTS binding to 0xff and 0x00
 2) fix write to 0x00 erase value device.
 3) Fix Kconfig FLASH_SIMULATOR_DOUBLE_WRITES option desciption