### PR TITLE
boards: nxp: set correct rimage target for ADSP

### DIFF
--- a/boards/nxp/imx8qm_mek/board.cmake
+++ b/boards/nxp/imx8qm_mek/board.cmake
@@ -8,5 +8,5 @@ if(CONFIG_SOC_MIMX8QM_ADSP)
   board_set_flasher_ifnset(misc-flasher)
   board_finalize_runner_args(misc-flasher)
 
-  board_set_rimage_target(imx)
+  board_set_rimage_target(imx8)
 endif()

--- a/boards/nxp/imx8qxp_mek/board.cmake
+++ b/boards/nxp/imx8qxp_mek/board.cmake
@@ -8,5 +8,5 @@ if(CONFIG_SOC_MIMX8QXP_ADSP)
   board_set_flasher_ifnset(misc-flasher)
   board_finalize_runner_args(misc-flasher)
 
-  board_set_rimage_target(imx)
+  board_set_rimage_target(imx8)
 endif()


### PR DESCRIPTION
Fix typo for rimage target name for imx8qm and imx8qxp boards.
For both, rimage name is imx8.