### PR TITLE
MAINTAINERS: Fix username typo on NXP MPU

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3346,7 +3346,7 @@ NXP Platforms (S32):
 NXP Platforms (MPU):
   status: maintained
   maintainers:
-    - dleach
+    - dleach02
   collaborators:
     - JiafeiPan
     - dbaluta


### PR DESCRIPTION
dleach -> dleach02

silly error in the rush of hwmv2