### PR TITLE
kconfig: shell: increase shell stack size for OpenThread

### DIFF
--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -40,9 +40,8 @@ endif
 
 config SHELL_STACK_SIZE
 	int "Shell thread stack size"
-	default 3168 if OPENTHREAD_SHELL && OPENTHREAD_JOINER
+	default 3168 if OPENTHREAD_SHELL
 	default 3072 if 64BIT
-	default 2616 if OPENTHREAD_SHELL
 	default 2048 if MULTITHREADING
 	default 0 if !MULTITHREADING
 	help


### PR DESCRIPTION
Shell stack size is too low for OpenThread without joiner functionality, causing overflow. This commit increases it.