### PR TITLE
tests: drivers: gpio: gpio_basic_api: boards: Enabled gpio_basic_api for intel_rpl_s_crb

### DIFF
--- a/boards/intel/rpl/intel_rpl_s_crb.yaml
+++ b/boards/intel/rpl/intel_rpl_s_crb.yaml
@@ -12,6 +12,7 @@ supported:
   - watchdog
   - rtc
   - pwm
+  - gpio
 testing:
   ignore_tags:
     - net

--- a/tests/drivers/gpio/gpio_basic_api/boards/intel_rpl_s_crb.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/intel_rpl_s_crb.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/ {
+	resources {
+		compatible = "test-gpio-basic-api";
+
+		out-gpios = <&gpio_0_i 16 0>;
+		in-gpios  = <&gpio_0_i 17 0>;
+	};
+};


### PR DESCRIPTION
Enable gpio_basic_api test for intel_rpl_s_crb platform.

Signed-off-by: Anisetti Avinash Krishna <anisetti.avinash.krishna@intel.com>