### PR TITLE
fs: allow fs_mkfs() for FATFS without auto-format on mounting

### DIFF
--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -190,6 +190,11 @@ Libraries / Subsystems
 
 * Storage
 
+  * FAT FS: It is now possible to expose file system formatting functionality for FAT without also
+    enabling automatic formatting on mount failure by setting the
+    :kconfig:option:`CONFIG_FS_FATFS_MKFS` Kconfig option. This option is enabled by default if
+    :kconfig:option:`CONFIG_FILE_SYSTEM_MKFS` is set.
+
 * POSIX API
 
 * LoRa/LoRaWAN

--- a/subsys/fs/Kconfig.fatfs
+++ b/subsys/fs/Kconfig.fatfs
@@ -25,7 +25,8 @@ config FS_FATFS_READ_ONLY
 	  ELM FAT module.
 
 config FS_FATFS_MKFS
-	bool
+	bool "mkfs support for FAT FS"
+	default y if FILE_SYSTEM_MKFS
 	help
 	  Adds code for creating disks with FAT file system.
 	  This option affects FF_USE_MKFS defined in ffconf.h, inside
@@ -48,7 +49,7 @@ config FS_FATFS_MOUNT_MKFS
 	  prior to connecting to a device, otherwise it will not be
 	  mountable.
 
-if FS_FATFS_MOUNT_MKFS
+if FS_FATFS_MKFS
 
 config FS_FATFS_MAX_ROOT_ENTRIES
 	int "Max number of entries in FAT FS root directory"
@@ -59,7 +60,7 @@ config FS_FATFS_MAX_ROOT_ENTRIES
 	  formatting new FAT system to a device.
 	  Note that this should be multiply of FS_FATFS_MAX_SS / 32.
 
-endif # FS_FATFS_MOUNT_MKFS
+endif # FS_FATFS_MKFS
 
 config FS_FATFS_EXFAT
 	bool "ExFAT support"

--- a/subsys/fs/fat_fs.c
+++ b/subsys/fs/fat_fs.c
@@ -469,7 +469,7 @@ static int fatfs_unmount(struct fs_mount_t *mountp)
 	return translate_error(res);
 }
 
-#if defined(CONFIG_FILE_SYSTEM_MKFS)
+#if defined(CONFIG_FILE_SYSTEM_MKFS) && defined(CONFIG_FS_FATFS_MKFS)
 
 static MKFS_PARM def_cfg = {
 	.fmt = FM_ANY | FM_SFD,	/* Any suitable FAT */
@@ -494,7 +494,7 @@ static int fatfs_mkfs(uintptr_t dev_id, void *cfg, int flags)
 	return translate_error(res);
 }
 
-#endif /* CONFIG_FILE_SYSTEM_MKFS */
+#endif /* CONFIG_FILE_SYSTEM_MKFS && FS_FATFS_MKFS */
 
 /* File system interface */
 static const struct fs_file_system_t fatfs_fs = {
@@ -516,7 +516,7 @@ static const struct fs_file_system_t fatfs_fs = {
 	.mkdir = fatfs_mkdir,
 	.stat = fatfs_stat,
 	.statvfs = fatfs_statvfs,
-#if defined(CONFIG_FILE_SYSTEM_MKFS)
+#if defined(CONFIG_FILE_SYSTEM_MKFS) && defined(CONFIG_FS_FATFS_MKFS)
 	.mkfs = fatfs_mkfs,
 #endif
 };


### PR DESCRIPTION
Users should be able to call `fs_mkfs()` manually even if `FS_FATFS_MOUNT_MKFS` is disabled.