### PR TITLE
twister: normalize platform name when packaging

### DIFF
--- a/scripts/pylib/twister/twisterlib/package.py
+++ b/scripts/pylib/twister/twisterlib/package.py
@@ -26,7 +26,9 @@ class Artifacts:
             jtp = json.load(json_test_plan)
             for t in jtp['testsuites']:
                 if t['status'] != "filtered":
-                    dirs.append(os.path.join(self.options.outdir, t['platform'], t['name']))
+                    p = t['platform']
+                    normalized  = p.replace("/", "_")
+                    dirs.append(os.path.join(self.options.outdir, normalized, t['name']))
 
         dirs.extend(
             [


### PR DESCRIPTION
When creating a package, normalize platform names.

Fixes #69793

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
