### PR TITLE
net: ip: Fix for improper offset return by `net_pkt_find_offset()`

### DIFF
--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -1817,7 +1817,7 @@ static int32_t net_pkt_find_offset(struct net_pkt *pkt, uint8_t *ptr)
 	buf = pkt->buffer;
 
 	while (buf) {
-		if (buf->data <= ptr && ptr <= (buf->data + buf->len)) {
+		if (buf->data <= ptr && ptr < (buf->data + buf->len)) {
 			ret = offset + (ptr - buf->data);
 			break;
 		}


### PR DESCRIPTION
The original packet's link-layer destination and source address can be stored in separately allocated memory. This allocated memory can be placed just after pkt data buffers.
In case when `net_pkt_find_offset()` uses condition: `if (buf->data <= ptr && ptr <= (buf->data + buf->len)) {` the offset is set outside the packet's buffer and the function returns incorrect offset instead of error code.
Finally the offset is used to set ll address in cloned packet, and this can have unexpected behavior (e.g. crash when cursor will be set to empty memory).

Fixes #69827