### PR TITLE
doc: drivers: gpio: detail scancodes from example

### DIFF
--- a/dts/bindings/gpio/zephyr,gpio-emul-sdl.yaml
+++ b/dts/bindings/gpio/zephyr,gpio-emul-sdl.yaml
@@ -8,10 +8,19 @@ description: |
   to be a child of a `zephyr,gpio-emul` compatible.
   Add a list of scancodes for the desired keys to be mapped.
 
+  This driver uses USB HID scancodes, they are different from linux key codes,
+  and thus do not match Zephyr code values as described in input-event-codes.h.
   Refer to https://www.usb.org/sites/default/files/documents/hut1_12v2.pdf
   section Keyboard/Keypad (p53) for a list of scancode values.
 
   The following example maps the first 3 numeric keys to GPIO pins:
+  - Scancode 30: "Keyboard 1 and !", mapped to gpio0 0
+  - Scancode 31: "Keyboard 2 and @", mapped to gpio0 1
+  - Scancode 32: "Keyboard 3 and \#", mapped to gpio0 2
+
+  The "typical position" column from HID table suggests to match them
+  with standard keycode values 2, 3 and 4, corresponding to
+  INPUT_KEY_1, INPUT_KEY_2 and INPUT_KEY_3 in input-event-codes.h.
 
   /* gpio0 has to be a zephyr,gpio-emul device */
   &gpio0 {


### PR DESCRIPTION
Add more explanation and details on how to use
USB HID scancodes in gpio-emul-sdl implementation.