### PR TITLE
Improve video sw generator

### DIFF
--- a/drivers/video/video_sw_generator.c
+++ b/drivers/video/video_sw_generator.c
@@ -72,6 +72,9 @@ static int video_sw_generator_stream_stop(const struct device *dev)
 /* Black, Blue, Red, Purple, Green, Aqua, Yellow, White */
 uint16_t rgb565_colorbar_value[] = {0x0000, 0x001F, 0xF800, 0xF81F, 0x07E0, 0x07FF, 0xFFE0, 0xFFFF};
 
+uint32_t xrgb32_colorbar_value[] = {0xFF000000, 0xFF0000FF, 0xFFFF0000, 0xFFFF00FF,
+				    0xFF00FF00, 0xFF00FFFF, 0xFFFFFF00, 0xFFFFFFFF};
+
 static void __fill_buffer_colorbar(struct video_sw_generator_data *data, struct video_buffer *vbuf)
 {
 	int bw = data->fmt.width / 8;
@@ -84,6 +87,10 @@ static void __fill_buffer_colorbar(struct video_sw_generator_data *data, struct 
 				uint16_t *pixel = (uint16_t *)&vbuf->buffer[i];
 				*pixel = rgb565_colorbar_value[color_idx];
 				i += 2;
+			} else if (data->fmt.pixelformat == VIDEO_PIX_FMT_XRGB32) {
+				uint32_t *pixel = (uint32_t *)&vbuf->buffer[i];
+				*pixel = xrgb32_colorbar_value[color_idx];
+				i += 4;
 			}
 		}
 	}
@@ -178,6 +185,14 @@ static int video_sw_generator_flush(const struct device *dev, enum video_endpoin
 
 static const struct video_format_cap fmts[] = {{
 						       .pixelformat = VIDEO_PIX_FMT_RGB565,
+						       .width_min = 64,
+						       .width_max = 1920,
+						       .height_min = 64,
+						       .height_max = 1080,
+						       .width_step = 1,
+						       .height_step = 1,
+					       }, {
+						       .pixelformat = VIDEO_PIX_FMT_XRGB32,
 						       .width_min = 64,
 						       .width_max = 1920,
 						       .height_min = 64,

--- a/drivers/video/video_sw_generator.c
+++ b/drivers/video/video_sw_generator.c
@@ -7,6 +7,10 @@
 
 #include <zephyr/drivers/video.h>
 
+#define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(video_sw_generator);
+
 #define VIDEO_PATTERN_COLOR_BAR 0
 #define VIDEO_PATTERN_FPS       30
 
@@ -23,13 +27,46 @@ struct video_sw_generator_data {
 	struct k_poll_signal *signal;
 };
 
+static const struct video_format_cap fmts[] = {{
+						       .pixelformat = VIDEO_PIX_FMT_RGB565,
+						       .width_min = 64,
+						       .width_max = 1920,
+						       .height_min = 64,
+						       .height_max = 1080,
+						       .width_step = 1,
+						       .height_step = 1,
+					       }, {
+						       .pixelformat = VIDEO_PIX_FMT_XRGB32,
+						       .width_min = 64,
+						       .width_max = 1920,
+						       .height_min = 64,
+						       .height_max = 1080,
+						       .width_step = 1,
+						       .height_step = 1,
+					       },
+					       {0}};
+
 static int video_sw_generator_set_fmt(const struct device *dev, enum video_endpoint_id ep,
 				      struct video_format *fmt)
 {
 	struct video_sw_generator_data *data = dev->data;
+	int i = 0;
 
 	if (ep != VIDEO_EP_OUT) {
 		return -EINVAL;
+	}
+
+	for (i = 0; i < ARRAY_SIZE(fmts); ++i) {
+		if (fmt->pixelformat == fmts[i].pixelformat && fmt->width >= fmts[i].width_min &&
+		    fmt->width <= fmts[i].width_max && fmt->height >= fmts[i].height_min &&
+		    fmt->height <= fmts[i].height_max) {
+			break;
+		}
+	}
+
+	if (i == ARRAY_SIZE(fmts)) {
+		LOG_ERR("Unsupported pixel format or resolution");
+		return -ENOTSUP;
 	}
 
 	data->fmt = *fmt;
@@ -182,25 +219,6 @@ static int video_sw_generator_flush(const struct device *dev, enum video_endpoin
 
 	return 0;
 }
-
-static const struct video_format_cap fmts[] = {{
-						       .pixelformat = VIDEO_PIX_FMT_RGB565,
-						       .width_min = 64,
-						       .width_max = 1920,
-						       .height_min = 64,
-						       .height_max = 1080,
-						       .width_step = 1,
-						       .height_step = 1,
-					       }, {
-						       .pixelformat = VIDEO_PIX_FMT_XRGB32,
-						       .width_min = 64,
-						       .width_max = 1920,
-						       .height_min = 64,
-						       .height_max = 1080,
-						       .width_step = 1,
-						       .height_step = 1,
-					       },
-					       {0}};
 
 static int video_sw_generator_get_caps(const struct device *dev, enum video_endpoint_id ep,
 				       struct video_caps *caps)

--- a/drivers/video/video_sw_generator.c
+++ b/drivers/video/video_sw_generator.c
@@ -55,7 +55,7 @@ static int video_sw_generator_stream_start(const struct device *dev)
 {
 	struct video_sw_generator_data *data = dev->data;
 
-	k_work_schedule(&data->buf_work, K_MSEC(33));
+	k_work_schedule(&data->buf_work, K_MSEC(1000 / VIDEO_PATTERN_FPS));
 
 	return 0;
 }

--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -611,6 +611,9 @@ void video_buffer_release(struct video_buffer *buf);
 /** RGB565 pixel format */
 #define VIDEO_PIX_FMT_RGB565 video_fourcc('R', 'G', 'B', 'P') /* 16  RGB-5-6-5 */
 
+/** XRGB32 pixel format */
+#define VIDEO_PIX_FMT_XRGB32 video_fourcc('B', 'X', '2', '4') /* 32  XRGB-8-8-8-8 */
+
 /**
  * @}
  */


### PR DESCRIPTION
This PR add support for XRGB32 format to the video sw generator as this is useful to test camera and display pipeline on i.MX RT11XX. It also contains some minor fixes.

The first commit (which adds XRGB fourcc) is part of [another PR](https://github.com/zephyrproject-rtos/zephyr/pull/69810) and could be dropped if that PR is merged first :

> [include: video: Add XRGB32 pixel format](https://github.com/zephyrproject-rtos/zephyr/commit/8465fec6f4ed53ef6b85d7501c1aaadde5afbae5)