### PR TITLE
Boards: Shell stack size for Silab's efr32xg24

### DIFF
--- a/boards/silabs/efr32xg24_dk2601b/Kconfig.defconfig
+++ b/boards/silabs/efr32xg24_dk2601b/Kconfig.defconfig
@@ -37,6 +37,13 @@ choice BT_HCI_BUS_TYPE
 	default BT_SILABS_HCI
 endchoice
 
+if SHELL
+
+config SHELL_STACK_SIZE
+	default 4096
+
+endif # SHELL
+
 endif # BT
 
 endif # BOARD_EFR32XG24_DK2601B


### PR DESCRIPTION
Set to 4096 to prevent stack overflow while running BT Shell