### PR TITLE
it8xxx2_evb: use correct SoC

### DIFF
--- a/boards/ite/it8xxx2_evb/Kconfig.it8xxx2_evb
+++ b/boards/ite/it8xxx2_evb/Kconfig.it8xxx2_evb
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_IT8XXX2_EVB
-	select SOC_IT82202_AX
+	select SOC_IT81302_BX

--- a/boards/ite/it8xxx2_evb/board.yml
+++ b/boards/ite/it8xxx2_evb/board.yml
@@ -2,4 +2,4 @@ board:
   name: it8xxx2_evb
   vendor: ite
   socs:
-    - name: it82202ax
+    - name: it81302bx


### PR DESCRIPTION
Use SOC_IT81302_BX as the SoC for this board.

Fixes #69809

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
