### PR TITLE
tests: latency benchmark: Add stack canaries

### DIFF
--- a/tests/benchmarks/latency_measure/README.rst
+++ b/tests/benchmarks/latency_measure/README.rst
@@ -26,18 +26,38 @@ including:
 * Time it takes to push and pop to/from a k_stack
 * Measure average time to alloc memory from heap then free that memory
 
-When userspace is enabled using the prj_user.conf configuration file, this benchmark will
-where possible, also test the above capabilities using various configurations involving user
-threads:
+When userspace is enabled, this benchmark will where possible, also test the
+above capabilities using various configurations involving user threads:
 
 * Kernel thread to kernel thread
 * Kernel thread to user thread
 * User thread to kernel thread
 * User thread to user thread
 
+The default configuration builds only for the kernel. However, additional
+configurations can be enabled via the use of EXTRA_CONF_FILE.
+
+For example, the following will build this project with userspace support:
+
+    EXTRA_CONF_FILE="prj.userspace.conf" west build -p -b <board> <path to project>
+
+The following table summarizes the purposes of the different extra
+configuration files that are available to be used with this benchmark.
+A tester may mix and match them allowing them different scenarios to
+be easily compared the default.
+
++-----------------------------+------------------------------------+
+| prj.canaries.conf           | Enable stack canaries              |
++-----------------------------+------------------------------------+
+| prj.objcore.conf            | Enable object cores and statistics |
++-----------------------------+------------------------------------+
+| prj.timeslicing.conf        | Enable timeslicing                 |
++-----------------------------+------------------------------------+
+| prj.userspace.conf          | Enable userspace support           |
++-----------------------------+------------------------------------+
+
 Sample output of the benchmark (without userspace enabled)::
 
-        *** Booting Zephyr OS build zephyr-v3.5.0-4267-g6ccdc31233a3 ***
         thread.yield.preemptive.ctx.k_to_k       - Context switch via k_yield                         :     329 cycles ,     2741 ns :
         thread.yield.cooperative.ctx.k_to_k      - Context switch via k_yield                         :     329 cycles ,     2741 ns :
         isr.resume.interrupted.thread.kernel     - Return from ISR to interrupted thread              :     363 cycles ,     3033 ns :
@@ -91,7 +111,6 @@ Sample output of the benchmark (without userspace enabled)::
 
 Sample output of the benchmark (with userspace enabled)::
 
-        *** Booting Zephyr OS build zephyr-v3.5.0-4268-g6af7a1230a08 ***
         thread.yield.preemptive.ctx.k_to_k       - Context switch via k_yield                         :     970 cycles ,     8083 ns :
         thread.yield.preemptive.ctx.u_to_u       - Context switch via k_yield                         :    1260 cycles ,    10506 ns :
         thread.yield.preemptive.ctx.k_to_u       - Context switch via k_yield                         :    1155 cycles ,     9632 ns :

--- a/tests/benchmarks/latency_measure/prj.canaries.conf
+++ b/tests/benchmarks/latency_measure/prj.canaries.conf
@@ -1,0 +1,5 @@
+# Extra configuration file to enable stack canary support
+# Use with EXTRA_CONF_FILE
+
+CONFIG_TEST_RANDOM_GENERATOR=y
+CONFIG_STACK_CANARIES=y

--- a/tests/benchmarks/latency_measure/prj.conf
+++ b/tests/benchmarks/latency_measure/prj.conf
@@ -1,3 +1,5 @@
+# Default base configuration file
+
 CONFIG_TEST=y
 
 # eliminate timer interrupts during the benchmark

--- a/tests/benchmarks/latency_measure/prj.objcore.conf
+++ b/tests/benchmarks/latency_measure/prj.objcore.conf
@@ -1,0 +1,5 @@
+# Extra configuration file to enable object core and statistics support
+# Use with EXTRA_CONF_FILE
+
+CONFIG_OBJ_CORE=y
+CONFIG_OBJ_CORE_STATS=y

--- a/tests/benchmarks/latency_measure/prj.timeslicing.conf
+++ b/tests/benchmarks/latency_measure/prj.timeslicing.conf
@@ -1,0 +1,4 @@
+# Extra configuration file to enable timeslicing support
+# Use with EXTRA_CONF_FILE
+
+CONFIG_TIMESLICING=y

--- a/tests/benchmarks/latency_measure/prj.userspace.conf
+++ b/tests/benchmarks/latency_measure/prj.userspace.conf
@@ -1,0 +1,4 @@
+# Extra configuration file to enable userspace support
+# Use with EXTRA_CONF_FILE
+
+CONFIG_USERSPACE=y

--- a/tests/benchmarks/latency_measure/testcase.yaml
+++ b/tests/benchmarks/latency_measure/testcase.yaml
@@ -20,28 +20,6 @@ tests:
       regex:
         - "PROJECT EXECUTION SUCCESSFUL"
 
-
-  benchmark.kernel.latency.objcore.stats:
-    # FIXME: no DWT and no RTC_TIMER for qemu_cortex_m0
-    platform_exclude:
-      - qemu_cortex_m0
-      - m2gl025_miv
-    filter: CONFIG_PRINTK and not CONFIG_SOC_FAMILY_STM32
-    harness: console
-    integration_platforms:
-      - qemu_x86
-      - qemu_arc/qemu_arc_em
-    extra_configs:
-      - CONFIG_OBJ_CORE=y
-      - CONFIG_OBJ_CORE_STATS=y
-    harness_config:
-      type: one_line
-      record:
-        regex: "(?P<metric>.*) - (?P<description>.*):(?P<cycles>.*) cycles ,(?P<nanoseconds>.*) ns"
-      regex:
-        - "PROJECT EXECUTION SUCCESSFUL"
-
-
   # Cortex-M has 24bit systick, so default 1 TICK per seconds
   # is achievable only if frequency is below 0x00FFFFFF (around 16MHz)
   # 20 Ticks per secondes allows a frequency up to 335544300Hz (335MHz)
@@ -69,65 +47,6 @@ tests:
     integration_platforms:
       - qemu_x86
       - qemu_cortex_a53
-    harness_config:
-      type: one_line
-      record:
-        regex: "(?P<metric>.*) - (?P<description>.*):(?P<cycles>.*) cycles ,(?P<nanoseconds>.*) ns"
-      regex:
-        - "PROJECT EXECUTION SUCCESSFUL"
-
-  # Obtain the benchmark results with object core statistics enabled for
-  # various user thread / kernel thread configurations on platforms that
-  # support user space
-  benchmark.kernel.latency.userspace.objcore.stats:
-    filter: CONFIG_ARCH_HAS_USERSPACE
-    timeout: 300
-    harness: console
-    integration_platforms:
-      - qemu_x86
-      - qemu_cortex_a53
-    extra_configs:
-      - CONFIG_USERSPACE=y
-      - CONFIG_OBJ_CORE=y
-      - CONFIG_OBJ_CORE_STATS=y
-    harness_config:
-      type: one_line
-      record:
-        regex: "(?P<metric>.*) - (?P<description>.*):(?P<cycles>.*) cycles ,(?P<nanoseconds>.*) ns"
-      regex:
-        - "PROJECT EXECUTION SUCCESSFUL"
-
-  # Obtain the various kernel benchmark results with time slicing enabled
-  benchmark.kernel.latency.timeslicing:
-    # FIXME: no DWT and no RTC_TIMER for qemu_cortex_m0
-    platform_exclude:
-      - qemu_cortex_m0
-      - m2gl025_miv
-    filter: CONFIG_PRINTK and not CONFIG_SOC_FAMILY_STM32
-    harness: console
-    integration_platforms:
-      - qemu_x86
-      - qemu_arc/qemu_arc_em
-    extra_configs:
-      - CONFIG_TIMESLICING=y
-    harness_config:
-      type: one_line
-      record:
-        regex: "(?P<metric>.*) - (?P<description>.*):(?P<cycles>.*) cycles ,(?P<nanoseconds>.*) ns"
-      regex:
-        - "PROJECT EXECUTION SUCCESSFUL"
-
-  # Obtain the various userspace benchmark results with timeslicing enabled
-  benchmark.kernel.latency.timeslicing.userspace:
-    filter: CONFIG_ARCH_HAS_USERSPACE
-    timeout: 300
-    harness: console
-    integration_platforms:
-      - qemu_x86
-      - qemu_cortex_a53
-    extra_configs:
-      - CONFIG_USERSPACE=y
-      - CONFIG_TIMESLICING=y
     harness_config:
       type: one_line
       record:


### PR DESCRIPTION
Updates the testcase.yaml to include cases for stack canaries. The output of these cases can later be compared to the output for the benchmark.kernel.latency and/or benchmark.kernel.latency.userspace to determine the impact of enabling stack canaries.