### PR TITLE
tests: mem_protect/userspace: exclude xenvm boards

### DIFF
--- a/tests/kernel/mem_protect/userspace/testcase.yaml
+++ b/tests/kernel/mem_protect/userspace/testcase.yaml
@@ -14,6 +14,11 @@ tests:
       - CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=0
     platform_exclude:
       - ucans32k1sic
+      # Commit cb19bd4fc2541931beb0e1f157127f7a50a082d4
+      # explicitly disabled CONFIG_USERSPACE so xenvm
+      # boards cannot run this test.
+      - xenvm
+      - xenvm/xenvm/gicv3
   kernel.memory_protection.userspace.gap_filling.arc:
     filter: CONFIG_ARCH_HAS_USERSPACE and CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS
     arch_allow: arc


### PR DESCRIPTION
This excludes xenvm and xenvm/xenvm/gicv3 platforms from userspace tests. The tests will run as long as the arch has CONFIG_ARCH_HAS_USERSPACE enabled. However, commit cb19bd4fc2541931beb0e1f157127f7a50a082d4 explicitly disabled CONFIG_USERSPACE for xenvm and xenvm/xenvm/gicv3 boards. This results in build errors as none of the userspace code is being built.