### PR TITLE
scripts/check_compliance: pass --no-ext-diff to git diff

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -202,7 +202,7 @@ class CheckPatch(ComplianceTest):
         if not os.path.exists(checkpatch):
             self.skip(f'{checkpatch} not found')
 
-        diff = subprocess.Popen(('git', 'diff', COMMIT_RANGE),
+        diff = subprocess.Popen(('git', 'diff', '--no-ext-diff', COMMIT_RANGE),
                                 stdout=subprocess.PIPE,
                                 cwd=GIT_TOP)
         try:


### PR DESCRIPTION
If $GIT_EXTERNAL_DIFF is set, this difftool is used instead of the default internal unified diff, which breaks the Checkpatch check.