### PR TITLE
net: lib: shell: iface: Fix when building ethernet without IP support

### DIFF
--- a/subsys/net/lib/shell/iface.c
+++ b/subsys/net/lib/shell/iface.c
@@ -148,7 +148,7 @@ static void iface_cb(struct net_if *iface, void *user_data)
 	int ret;
 #endif
 	const char *extra;
-#if defined(CONFIG_NET_IP)
+#if defined(CONFIG_NET_IP) || defined(CONFIG_NET_L2_ETHERNET_MGMT)
 	int count;
 #endif
 


### PR DESCRIPTION
The count stack variable is also used when CONFIG_NET_L2_ETHERNET_MGMT is enabled. Make sure it is available.