### PR TITLE
sys: Include sys/util.h header in sys/atomic.h

### DIFF
--- a/include/zephyr/sys/atomic.h
+++ b/include/zephyr/sys/atomic.h
@@ -15,7 +15,7 @@
 
 #include <zephyr/sys/atomic_types.h> /* IWYU pragma: export */
 #include <zephyr/types.h>
-#include <zephyr/sys/util_macro.h>
+#include <zephyr/sys/util.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Commit a1358aaedf0d10d5c105a7b0d79e48f16be6cacf introduced ROUND_UP macro use within sys/atomic.h header, but did not include the header (sys/util.h) which actually defines the macro. This commit fixes it.