### PR TITLE
tests: arch arm: runtime nmi testing with dcache for ARM V7

### DIFF
--- a/tests/arch/arm/arm_runtime_nmi/src/arm_runtime_nmi.c
+++ b/tests/arch/arm/arm_runtime_nmi/src/arm_runtime_nmi.c
@@ -12,6 +12,7 @@
 #include <zephyr/arch/arm/nmi.h>
 #include <zephyr/ztest.h>
 #include <zephyr/tc_util.h>
+#include <zephyr/cache.h>
 
 /* on v8m arch the nmi pend bit is renamed to pend nmi map it to old name */
 #ifndef SCB_ICSR_NMIPENDSET_Msk
@@ -67,7 +68,7 @@ ZTEST(arm_runtime_nmi_fn, test_arm_runtime_nmi)
 #ifdef ARM_CACHEL1_ARMV7_H
 	/* Flush Data Cache now if enabled */
 	if (IS_ENABLED(CONFIG_DCACHE)) {
-		SCB_CleanDCache();
+		sys_cache_data_flush_all();
 	}
 #endif /* ARM_CACHEL1_ARMV7_H */
 	zassert_true(nmi_triggered, "Isr not triggered!\n");


### PR DESCRIPTION

The testcase tests/arch/arm/arm_runtime_nmi/  fails  when running on stm32f7 or stm32h7 cortex ARM V7 devices

```
*** Booting Zephyr OS build v3.6.0-382-g3203bd660c6c ***
Running TESTSUITE arm_runtime_nmi_fn
===================================================================
START - test_arm_runtime_nmi
Trigger NMI in 2s: 0 s
Trigger NMI in 2s: 1 s
NMI triggered (test_handler_isr)!
ASSERTION FAIL [thread->base.pended_on] @ WEST_TOPDIR/zephyr/kernel/sched.c:792
E: r0/a1:  0x00000004  r1/a2:  0x00000318  r2/a3:  0x40004800
E: r3/a4:  0x08007127 r12/ip:  0x00000000 r14/lr:  0x08003249
E:  xpsr:  0x61000000
E: Faulting instruction address (r15/pc): 0x08005b40
E: >>> ZEPHYR FATAL ERROR 4: Kernel panic on CPU 60
E: Current thread: 0x20010160 (unknown)
E: Halting system
```



This PR is changing the [arm_runtime_nmi.c](https://github.com/zephyrproject-rtos/zephyr/blob/main/tests/arch/arm/arm_runtime_nmi/src/arm_runtime_nmi.c)
to flush the DCACHE according to the  cache mgnt API using the  **sys_cache_data_flush_all()** 

This PR follows what was done for  issue #66710 and PR #69556,
