### PR TITLE
adc: Use int64_t in voltage divider calculation to avoid overflow

### DIFF
--- a/include/zephyr/drivers/adc/voltage_divider.h
+++ b/include/zephyr/drivers/adc/voltage_divider.h
@@ -51,7 +51,7 @@ static inline int voltage_divider_scale_dt(const struct voltage_divider_dt_spec 
 	}
 
 	/* voltage scaled by voltage divider values using DT binding */
-	*v_to_v = *v_to_v * spec->full_ohms / spec->output_ohms;
+	*v_to_v = (int64_t)*v_to_v * spec->full_ohms / spec->output_ohms;
 
 	return 0;
 }


### PR DESCRIPTION
Since the resistance values are stored as milliohms, overflow otherwise occurs with any full_ohms value larger than 1.3 kΩ when using a 3300 mV vref:

2^32 / 3300 = 1301505
