### PR TITLE
drivers/disk: make name field in struct disk_info const

### DIFF
--- a/include/zephyr/drivers/disk.h
+++ b/include/zephyr/drivers/disk.h
@@ -70,7 +70,7 @@ struct disk_info {
 	/** Internally used list node */
 	sys_dnode_t node;
 	/** Disk name */
-	char *name;
+	const char *name;
 	/** Disk operations */
 	const struct disk_operations *ops;
 	/** Device associated to this disk */


### PR DESCRIPTION
This isn't modified anywhere, which is good, because it is typically initialized with a string literal, which would likely blow up if you tried.