### PR TITLE
drivers: Bluetooth: HCI: Reduce logging of No available ISO buffers

### DIFF
--- a/drivers/bluetooth/hci/ipc.c
+++ b/drivers/bluetooth/hci/ipc.c
@@ -159,6 +159,7 @@ static struct net_buf *bt_ipc_acl_recv(const uint8_t *data, size_t remaining)
 static struct net_buf *bt_ipc_iso_recv(const uint8_t *data, size_t remaining)
 {
 	struct bt_hci_iso_hdr hdr;
+	static size_t fail_cnt;
 	struct net_buf *buf;
 	size_t buf_tailroom;
 
@@ -174,8 +175,15 @@ static struct net_buf *bt_ipc_iso_recv(const uint8_t *data, size_t remaining)
 		remaining -= sizeof(hdr);
 
 		net_buf_add_mem(buf, &hdr, sizeof(hdr));
+
+		fail_cnt = 0U;
 	} else {
-		LOG_ERR("No available ISO buffers!");
+		if ((fail_cnt % 100U) == 0U) {
+			LOG_ERR("No available ISO buffers (%zu)!", fail_cnt);
+		}
+
+		fail_cnt++;
+
 		return NULL;
 	}
 


### PR DESCRIPTION
In the case that there are no more ISO buffers left, "No available ISO buffers" is logged. However, given the nature of ISO where we are (very) likely to get additional ISO very soon after (typically every 7.5 or 10ms for audio), this will get logged a lot, and the logging may in some cases actually prevent the application from handling and freeing existng buffers due to the immense logging, which may make this (minor) issue into a blocking issue.

This is fixed by reducing the logging to the first occurence, and then only every 100 afterwards, which has shown to reduce the risk of this effectively blocking the application.