### PR TITLE
hwmv2: scripts: handle Kconfig sources in a Windows compatible way

### DIFF
--- a/doc/_extensions/zephyr/kconfig/__init__.py
+++ b/doc/_extensions/zephyr/kconfig/__init__.py
@@ -97,18 +97,18 @@ def kconfig_load(app: Sphinx) -> Tuple[kconfiglib.Kconfig, Dict[str, str]]:
 
         with open(Path(td) / "soc" / "Kconfig.soc", "w") as f:
             for folder in soc_folders:
-                f.write('source "' + os.path.join(folder, 'Kconfig.soc') + '"\n')
+                f.write('source "' + (Path(folder) / 'Kconfig.soc').as_posix() + '"\n')
 
         with open(Path(td) / "soc" / "Kconfig", "w") as f:
             for folder in soc_folders:
-                f.write('osource "' + os.path.join(folder, 'Kconfig') + '"\n')
+                f.write('osource "' + (Path(folder) / 'Kconfig').as_posix() + '"\n')
 
         (Path(td) / 'arch').mkdir(exist_ok=True)
         root_args = argparse.Namespace(**{'arch_roots': [Path(ZEPHYR_BASE)], 'arch': None})
         v2_archs = list_hardware.find_v2_archs(root_args)
         kconfig = ""
         for arch in v2_archs['archs']:
-            kconfig += 'source "' + str(Path(arch['path']) / 'Kconfig') + '"\n'
+            kconfig += 'source "' + (Path(arch['path']) / 'Kconfig').as_posix() + '"\n'
         with open(Path(td) / "arch" / "Kconfig", "w") as f:
             f.write(kconfig)
 
@@ -126,7 +126,7 @@ def kconfig_load(app: Sphinx) -> Tuple[kconfiglib.Kconfig, Dict[str, str]]:
                     board_str = 'BOARD_' + re.sub(r"[^a-zA-Z0-9_]", "_", identifier).upper()
                     f.write('config  ' + board_str + '\n')
                     f.write('\t bool\n')
-                f.write('source "' + os.path.join(board.dir, 'Kconfig.') + board.name + '"\n\n')
+                f.write('source "' + (board.dir / ('Kconfig.' + board.name)).as_posix() + '"\n\n')
 
         # base environment
         os.environ["ZEPHYR_BASE"] = str(ZEPHYR_BASE)

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -441,7 +441,7 @@ class KconfigCheck(ComplianceTest):
 
         with open(kconfig_defconfig_file, 'w') as fp:
             for board in v2_boards:
-                fp.write('osource "' + os.path.join(board.dir, 'Kconfig.defconfig') + '"\n')
+                fp.write('osource "' + (Path(board.dir) / 'Kconfig.defconfig').as_posix() + '"\n')
 
         with open(kconfig_boards_file, 'w') as fp:
             for board in v2_boards:
@@ -452,12 +452,16 @@ class KconfigCheck(ComplianceTest):
                     board_str = 'BOARD_' + re.sub(r"[^a-zA-Z0-9_]", "_", identifier).upper()
                     fp.write('config  ' + board_str + '\n')
                     fp.write('\t bool\n')
-                fp.write('source "' + os.path.join(board.dir, 'Kconfig.') + board.name + '"\n\n')
+                fp.write(
+                    'source "' + (Path(board.dir) / ('Kconfig.' + board.name)).as_posix() + '"\n\n'
+                )
 
         with open(kconfig_file, 'w') as fp:
-            fp.write('osource "' + os.path.join(kconfig_dir, 'boards', 'Kconfig.syms.v1') + '"\n')
+            fp.write(
+                'osource "' + (Path(kconfig_dir) / 'boards' / 'Kconfig.syms.v1').as_posix() + '"\n'
+            )
             for board in v2_boards:
-                fp.write('osource "' + os.path.join(board.dir, 'Kconfig') + '"\n')
+                fp.write('osource "' + (Path(board.dir) / 'Kconfig').as_posix() + '"\n')
 
         kconfig_defconfig_file = os.path.join(kconfig_dir, 'soc', 'Kconfig.defconfig')
         kconfig_soc_file = os.path.join(kconfig_dir, 'soc', 'Kconfig.soc')
@@ -469,15 +473,15 @@ class KconfigCheck(ComplianceTest):
         soc_folders = {soc.folder for soc in v2_systems.get_socs()}
         with open(kconfig_defconfig_file, 'w') as fp:
             for folder in soc_folders:
-                fp.write('osource "' + os.path.join(folder, 'Kconfig.defconfig') + '"\n')
+                fp.write('osource "' + (Path(folder) / 'Kconfig.defconfig').as_posix() + '"\n')
 
         with open(kconfig_soc_file, 'w') as fp:
             for folder in soc_folders:
-                fp.write('source "' + os.path.join(folder, 'Kconfig.soc') + '"\n')
+                fp.write('source "' + (Path(folder) / 'Kconfig.soc').as_posix() + '"\n')
 
         with open(kconfig_file, 'w') as fp:
             for folder in soc_folders:
-                fp.write('source "' + os.path.join(folder, 'Kconfig') + '"\n')
+                fp.write('source "' + (Path(folder) / 'Kconfig').as_posix() + '"\n')
 
         kconfig_file = os.path.join(kconfig_dir, 'arch', 'Kconfig')
 
@@ -486,7 +490,7 @@ class KconfigCheck(ComplianceTest):
 
         with open(kconfig_file, 'w') as fp:
             for arch in v2_archs['archs']:
-                fp.write('source "' + os.path.join(arch['path'], 'Kconfig') + '"\n')
+                fp.write('source "' + (Path(arch['path']) / 'Kconfig').as_posix() + '"\n')
 
     def parse_kconfig(self, filename="Kconfig", hwm=None):
         """


### PR DESCRIPTION
Following hwmv2 integration, building documentation is broken on Windows, and so is the compliance_check script.

This PR fixes them by moving away from os.join.path and only relying on pathlib magic (concatenating paths and strings using "/"), and serializing all paths using POSIX path separators when generating source / osource entries.