### PR TITLE
drivers: eth: esp32: support setting mac address during runtime

### DIFF
--- a/drivers/ethernet/eth_esp32.c
+++ b/drivers/ethernet/eth_esp32.c
@@ -57,6 +57,29 @@ static enum ethernet_hw_caps eth_esp32_caps(const struct device *dev)
 	return ETHERNET_LINK_10BASE_T | ETHERNET_LINK_100BASE_T;
 }
 
+static int eth_esp32_set_config(const struct device *dev,
+				enum ethernet_config_type type,
+				const struct ethernet_config *config)
+{
+	struct eth_esp32_dev_data *const dev_data = dev->data;
+	int ret = -ENOTSUP;
+
+	switch (type) {
+	case ETHERNET_CONFIG_TYPE_MAC_ADDRESS:
+		memcpy(dev_data->mac_addr, config->mac_address.addr, 6);
+		emac_hal_set_address(&dev_data->hal, dev_data->mac_addr);
+		net_if_set_link_addr(dev_data->iface, dev_data->mac_addr,
+				     sizeof(dev_data->mac_addr),
+				     NET_LINK_ETHERNET);
+		ret = 0;
+		break;
+	default:
+		break;
+	}
+
+	return ret;
+}
+
 static int eth_esp32_send(const struct device *dev, struct net_pkt *pkt)
 {
 	struct eth_esp32_dev_data *dev_data = dev->data;
@@ -318,6 +341,7 @@ static void eth_esp32_iface_init(struct net_if *iface)
 static const struct ethernet_api eth_esp32_api = {
 	.iface_api.init		= eth_esp32_iface_init,
 	.get_capabilities	= eth_esp32_caps,
+	.set_config		= eth_esp32_set_config,
 	.send			= eth_esp32_send,
 };
 


### PR DESCRIPTION
Add support for setting the mac address of the esp32 during runtime.