### PR TITLE
drivers: adc: stm32: disable ADC before writing oversampling bits for g0

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -641,11 +641,14 @@ static const uint32_t table_oversampling_ratio[] = {
  */
 static void adc_stm32_oversampling_scope(ADC_TypeDef *adc, uint32_t ovs_scope)
 {
-#if defined(CONFIG_SOC_SERIES_STM32L0X) || \
+#if defined(CONFIG_SOC_SERIES_STM32G0X) || \
+	defined(CONFIG_SOC_SERIES_STM32L0X) || \
 	defined(CONFIG_SOC_SERIES_STM32WLX)
 	/*
-	 * setting OVS bits is conditioned to ADC state: ADC must be disabled
-	 * or enabled without conversion on going : disable it, it will stop
+	 * Setting OVS bits is conditioned to ADC state: ADC must be disabled
+	 * or enabled without conversion on going : disable it, it will stop.
+	 * For the G0 series, ADC must be disabled to prevent CKMODE bitfield
+	 * from getting reset, see errata ES0418 section 2.6.4.
 	 */
 	if (LL_ADC_GetOverSamplingScope(adc) == ovs_scope) {
 		return;


### PR DESCRIPTION
adc_read and adc_read_async functions both have a problem on the STM32g0 series where they try to write the ADC_CFRG2 register when setting the oversampling scope while the ADC is still active.
This results in the CKMODE bits being set to 0 due to not respecting the write conditions listed page 391 of the g0x1 ref manual, and as such the ADC uses an asynchronous clock regardless of previous settings.
As a fix for other series that use the same ip of ADCs was already implemented, i added the g0 series to the list.