### PR TITLE
doc: release_process drop the bit about the .99 tag

### DIFF
--- a/doc/project/release_process.rst
+++ b/doc/project/release_process.rst
@@ -172,13 +172,6 @@ The following syntax should be used for releases and tags in Git:
 
   - v[Major].[Minor].[Patch Level]-rc[RC Number]
   - v[Major].[Minor].[Patch Level]
-  - v[Major].[Minor].99 - A tag applied to main branch to signify that work on
-    v[Major].[Minor+1] has started. For example, v1.7.99 will be tagged at the
-    start of v1.8 process. The tag corresponds to
-    VERSION_MAJOR/VERSION_MINOR/PATCHLEVEL macros as defined for a
-    work-in-progress main branch version. Presence of this tag allows generation of
-    sensible output for "git describe" on main branch, as typically used for
-    automated builds and CI tools.
 
 
 .. figure:: release_flow.png


### PR DESCRIPTION
Drop the release process point about tagging the .99. The reasoning behind it makes sense (being able to distinguish between stable and upstream branches from a git describe) but:

- the last time this has been done was in 2021 and seemingly no one noticed this was missing.
- the current .99 tags seems like are dangling at some unclear point in the history, making them ineffective at what they were meant to do.

Let's drop this bit from the release process and keep not doing it.