### PR TITLE
soc: intel_adsp/ace: use CONFIG_XTENSA_MORE_SPIN_RELAX_NOPS

### DIFF
--- a/soc/intel/intel_adsp/ace/Kconfig.defconfig.series
+++ b/soc/intel/intel_adsp/ace/Kconfig.defconfig.series
@@ -60,6 +60,20 @@ config LOG_BACKEND_ADSP
 
 endif # LOG
 
+config XTENSA_MORE_SPIN_RELAX_NOPS
+	default y if SMP && MP_MAX_NUM_CPUS > 1
+
+if XTENSA_MORE_SPIN_RELAX_NOPS
+
+config XTENSA_NUM_SPIN_RELAX_NOPS
+	default 32 if MP_MAX_NUM_CPUS = 1
+	default 64 if MP_MAX_NUM_CPUS = 2
+	default 96 if MP_MAX_NUM_CPUS = 3
+	default 128 if MP_MAX_NUM_CPUS = 4
+	default 160 if MP_MAX_NUM_CPUS = 5
+
+endif # XTENSA_MORE_SPIN_RELAX_NOPS
+
 rsource "Kconfig.defconfig.ace*"
 
 endif # SOC_SERIES_INTEL_ADSP_ACE


### PR DESCRIPTION
This enables the use of CONFIG_XTENSA_MORE_SPIN_RELAX_NOPS to specify how many NOPs for arch_spin_relax(). This is to keep the atomic_cas() (via s32c1i) from saturating the internal bus with contant RCW ops. The numbers should be further tuned for specific application but these should provide a good start.