### PR TITLE
net: dhcpv4: Network interface netmask was set too early

### DIFF
--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -425,6 +425,9 @@ struct net_if_dhcpv4 {
 	/** Requested IP addr */
 	struct in_addr requested_ip;
 
+	/** Received netmask from the server */
+	struct in_addr netmask;
+
 	/**
 	 *  DHCPv4 client state in the process of network
 	 *  address allocation.

--- a/subsys/net/lib/dhcpv4/dhcpv4.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4.c
@@ -895,9 +895,8 @@ static bool dhcpv4_parse_options(struct net_pkt *pkt,
 				return false;
 			}
 
-			net_if_ipv4_set_netmask_by_addr(iface,
-							&iface->config.dhcpv4.requested_ip,
-							&netmask);
+			iface->config.dhcpv4.netmask = netmask;
+
 			NET_DBG("options_subnet_mask %s",
 				net_sprint_ipv4_addr(&netmask));
 			break;
@@ -1165,6 +1164,10 @@ static void dhcpv4_handle_msg_ack(struct net_if *iface)
 			NET_DBG("Failed to add IPv4 addr to iface %p", iface);
 			return;
 		}
+
+		net_if_ipv4_set_netmask_by_addr(iface,
+						&iface->config.dhcpv4.requested_ip,
+						&iface->config.dhcpv4.netmask);
 
 		dhcpv4_enter_bound(iface);
 		break;


### PR DESCRIPTION
When we receive the subnet mask option from the server, we cannot yet set the netmask to the network interface as the mask is tied to the IP address we received from the server. We need to delay the setting of netmask until we have added the requested IP address to the interface.