### PR TITLE
scripts: tests: --package-artifacts fix and blackbox tests for it

### DIFF
--- a/scripts/pylib/twister/twisterlib/package.py
+++ b/scripts/pylib/twister/twisterlib/package.py
@@ -15,7 +15,7 @@ class Artifacts:
     def make_tarfile(self, output_filename, source_dirs):
         root = os.path.basename(self.options.outdir)
         with tarfile.open(output_filename, "w:bz2") as tar:
-            tar.add("twister-out", recursive=False)
+            tar.add(self.options.outdir, recursive=False)
             for d in source_dirs:
                 f = os.path.relpath(d, self.options.outdir)
                 tar.add(d, arcname=os.path.join(root, f))

--- a/scripts/requirements-run-test.txt
+++ b/scripts/requirements-run-test.txt
@@ -14,3 +14,6 @@ cbor>=1.0.0
 
 # use for twister
 psutil
+
+# Artifacts package creation
+bz


### PR DESCRIPTION
Requirements added for `bz2`.
Blackbox test for `--package-artifacts` added.
`package.py` no longer includes `twister-out` no matter the specified `outdir`.