### PR TITLE
dts: bindings: can: make initial sample point properties optional

### DIFF
--- a/boards/infineon/xmc47_relax_kit/xmc47_relax_kit.dts
+++ b/boards/infineon/xmc47_relax_kit/xmc47_relax_kit.dts
@@ -208,7 +208,6 @@
 &can_node1 {
 	status = "okay";
 	bus-speed = <125000>;
-	sample-point = <875>;
 	input-src = "RXDC";
 	pinctrl-0 = <&can_tx_p1_12_node1 &can_rx_p1_13_node1>;
 	pinctrl-names = "default";

--- a/boards/native/native_sim/native_sim.dts
+++ b/boards/native/native_sim/native_sim.dts
@@ -190,7 +190,6 @@
 	can_loopback0: can_loopback0 {
 		status = "okay";
 		compatible = "zephyr,can-loopback";
-		sample-point = <875>;
 		bus-speed = <125000>;
 	};
 
@@ -201,7 +200,6 @@
 		 * name, e.g.: sudo ip link property add dev vcan0 altname zcan0
 		 */
 		host-interface = "zcan0";
-		sample-point = <875>;
 		bus-speed = <125000>;
 	};
 

--- a/boards/nxp/mr_canhubk3/mr_canhubk3.dts
+++ b/boards/nxp/mr_canhubk3/mr_canhubk3.dts
@@ -330,9 +330,7 @@
 	pinctrl-names = "default";
 	phys = <&can_phy0>;
 	bus-speed = <125000>;
-	sample-point = <875>;
 	bus-speed-data = <1000000>;
-	sample-point-data = <875>;
 	status = "okay";
 };
 
@@ -341,9 +339,7 @@
 	pinctrl-names = "default";
 	phys = <&can_phy1>;
 	bus-speed = <125000>;
-	sample-point = <875>;
 	bus-speed-data = <1000000>;
-	sample-point-data = <875>;
 };
 
 &flexcan2 {
@@ -351,9 +347,7 @@
 	pinctrl-names = "default";
 	phys = <&can_phy2>;
 	bus-speed = <125000>;
-	sample-point = <875>;
 	bus-speed-data = <1000000>;
-	sample-point-data = <875>;
 };
 
 &flexcan3 {
@@ -361,9 +355,7 @@
 	pinctrl-names = "default";
 	phys = <&can_phy3>;
 	bus-speed = <125000>;
-	sample-point = <875>;
 	bus-speed-data = <1000000>;
-	sample-point-data = <875>;
 };
 
 &flexcan4 {
@@ -371,9 +363,7 @@
 	pinctrl-names = "default";
 	phys = <&can_phy4>;
 	bus-speed = <125000>;
-	sample-point = <875>;
 	bus-speed-data = <1000000>;
-	sample-point-data = <875>;
 };
 
 &flexcan5 {
@@ -381,9 +371,7 @@
 	pinctrl-names = "default";
 	phys = <&can_phy5>;
 	bus-speed = <125000>;
-	sample-point = <875>;
 	bus-speed-data = <1000000>;
-	sample-point-data = <875>;
 };
 
 &lpi2c0 {

--- a/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270.dtsi
+++ b/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270.dtsi
@@ -35,9 +35,7 @@
 	pinctrl-0 = <&can0_default>;
 	pinctrl-names = "default";
 	bus-speed = <125000>;
-	sample-point = <875>;
 	bus-speed-data = <1000000>;
-	sample-point-data = <875>;
 	status = "okay";
 };
 
@@ -45,7 +43,5 @@
 	pinctrl-0 = <&can1_default>;
 	pinctrl-names = "default";
 	bus-speed = <125000>;
-	sample-point = <875>;
 	bus-speed-data = <1000000>;
-	sample-point-data = <875>;
 };

--- a/boards/nxp/ucans32k1sic/ucans32k1sic.dts
+++ b/boards/nxp/ucans32k1sic/ucans32k1sic.dts
@@ -175,9 +175,7 @@
 	pinctrl-names = "default";
 	phys = <&can_phy0>;
 	bus-speed = <125000>;
-	sample-point = <875>;
 	bus-speed-data = <1000000>;
-	sample-point-data = <875>;
 	status = "okay";
 };
 
@@ -186,8 +184,6 @@
 	pinctrl-names = "default";
 	phys = <&can_phy1>;
 	bus-speed = <125000>;
-	sample-point = <875>;
 	bus-speed-data = <1000000>;
-	sample-point-data = <875>;
 	status = "okay";
 };

--- a/boards/qemu/x86/qemu_x86.dts
+++ b/boards/qemu/x86/qemu_x86.dts
@@ -62,7 +62,6 @@
 			interrupts = <11 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 			bus-speed = <125000>;
-			sample-point = <875>;
 
 			can-transceiver {
 				max-bitrate = <1000000>;

--- a/boards/shields/mcp2515/adafruit_can_picowbell.overlay
+++ b/boards/shields/mcp2515/adafruit_can_picowbell.overlay
@@ -16,7 +16,6 @@
 		reg = <0x0>;
 		osc-freq = <16000000>;
 		bus-speed = <125000>;
-		sample-point = <875>;
 
 		can-transceiver {
 			max-bitrate = <1000000>;

--- a/boards/shields/mcp2515/dfrobot_can_bus_v2_0.overlay
+++ b/boards/shields/mcp2515/dfrobot_can_bus_v2_0.overlay
@@ -16,7 +16,6 @@
 		reg = <0x0>;
 		osc-freq = <16000000>;
 		bus-speed = <125000>;
-		sample-point = <875>;
 
 		can-transceiver {
 			min-bitrate = <60000>;

--- a/boards/shields/mcp2515/keyestudio_can_bus_ks0411.overlay
+++ b/boards/shields/mcp2515/keyestudio_can_bus_ks0411.overlay
@@ -16,7 +16,6 @@
 		reg = <0x0>;
 		osc-freq = <16000000>;
 		bus-speed = <125000>;
-		sample-point = <875>;
 
 		can-transceiver {
 			max-bitrate = <1000000>;

--- a/boards/shields/mikroe_mcp2518fd_click/mikroe_mcp2518fd_click.overlay
+++ b/boards/shields/mikroe_mcp2518fd_click/mikroe_mcp2518fd_click.overlay
@@ -11,9 +11,7 @@
 		osc-freq = <40000000>;
 
 		bus-speed = <125000>;
-		sample-point = <875>;
 		bus-speed-data = <1000000>;
-		sample-point-data = <875>;
 	};
 };
 

--- a/boards/shields/tcan4550evm/tcan4550evm.overlay
+++ b/boards/shields/tcan4550evm/tcan4550evm.overlay
@@ -28,8 +28,6 @@
 		reset-gpios = <&arduino_header 14 GPIO_ACTIVE_HIGH>; /* D8 */
 		int-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>; /* D9 */
 		bosch,mram-cfg = <0x0 15 15 7 7 0 10 10>;
-		sample-point = <875>;
-		sample-point-data = <875>;
 		bus-speed = <125000>;
 		bus-speed-data = <1000000>;
 		status = "okay";

--- a/boards/st/stm32h7b3i_dk/stm32h7b3i_dk.dts
+++ b/boards/st/stm32h7b3i_dk/stm32h7b3i_dk.dts
@@ -157,8 +157,6 @@
 	phys = <&transceiver0>;
 	bus-speed = <125000>;
 	bus-speed-data = <1000000>;
-	sample-point = <875>;
-	sample-point-data = <875>;
 	status = "okay";
 };
 

--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -87,6 +87,7 @@ Drivers and Sensors
     supported bitrate of a CAN controller/transceiver combination.
   * Updated the CAN timing functions to take the minimum supported bitrate into consideration when
     validating the bitrate.
+  * Made the ``sample-point`` and ``sample-point-data`` devicetree properties optional.
 
 * Clock control
 

--- a/dts/arm/atmel/samc21.dtsi
+++ b/dts/arm/atmel/samc21.dtsi
@@ -53,8 +53,6 @@
 			clock-names = "GCLK", "MCLK";
 			bosch,mram-cfg = <0x0 28 8 3 3 0 1 1>;
 			divider = <12>;
-			sample-point = <875>;
-			sample-point-data = <875>;
 			status = "disabled";
 		};
 
@@ -67,8 +65,6 @@
 			clock-names = "GCLK", "MCLK";
 			bosch,mram-cfg = <0x0 28 8 3 3 0 1 1>;
 			divider = <12>;
-			sample-point = <875>;
-			sample-point-data = <875>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/atmel/same5x.dtsi
+++ b/dts/arm/atmel/same5x.dtsi
@@ -36,8 +36,6 @@
 			clock-names = "GCLK", "MCLK";
 			bosch,mram-cfg = <0x0 128 64 64 64 64 32 32>;
 			divider = <12>;
-			sample-point = <875>;
-			sample-point-data = <875>;
 			status = "disabled";
 		};
 
@@ -50,8 +48,6 @@
 			clock-names = "GCLK", "MCLK";
 			bosch,mram-cfg = <0x0 128 64 64 64 64 32 32>;
 			divider = <12>;
-			sample-point = <875>;
-			sample-point-data = <875>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -425,8 +425,6 @@
 			clocks = <&pmc PMC_TYPE_PERIPHERAL 35>;
 			divider = <6>;
 			bosch,mram-cfg = <0x0 28 8 3 3 0 1 1>;
-			sample-point = <875>;
-			sample-point-data = <875>;
 			status = "disabled";
 		};
 
@@ -438,8 +436,6 @@
 			clocks = <&pmc PMC_TYPE_PERIPHERAL 37>;
 			divider = <6>;
 			bosch,mram-cfg = <0x0 28 8 3 3 0 1 1>;
-			sample-point = <875>;
-			sample-point-data = <875>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nuvoton/m46x.dtsi
+++ b/dts/arm/nuvoton/m46x.dtsi
@@ -443,8 +443,6 @@
 				  NUMAKER_CLK_CLKDIV5_CANFD0(1)>;
 			bosch,mram-cfg = <0x0 12 10 3 3 3 3 3>;
 			status = "disabled";
-			sample-point = <875>;
-			sample-point-data = <875>;
 		};
 
 		canfd1: canfd@40024000 {
@@ -459,8 +457,6 @@
 				  NUMAKER_CLK_CLKDIV5_CANFD1(1)>;
 			bosch,mram-cfg = <0x0 12 10 3 3 3 3 3>;
 			status = "disabled";
-			sample-point = <875>;
-			sample-point-data = <875>;
 		};
 
 		canfd2: canfd@40028000 {
@@ -475,8 +471,6 @@
 				  NUMAKER_CLK_CLKDIV5_CANFD2(1)>;
 			bosch,mram-cfg = <0x0 12 10 3 3 3 3 3>;
 			status = "disabled";
-			sample-point = <875>;
-			sample-point-data = <875>;
 		};
 
 		canfd3: canfd@4002c000 {
@@ -491,8 +485,6 @@
 				  NUMAKER_CLK_CLKDIV5_CANFD3(1)>;
 			bosch,mram-cfg = <0x0 12 10 3 3 3 3 3>;
 			status = "disabled";
-			sample-point = <875>;
-			sample-point-data = <875>;
 		};
 
 		emac: ethernet@40012000 {

--- a/dts/arm/nxp/nxp_k66.dtsi
+++ b/dts/arm/nxp/nxp_k66.dtsi
@@ -31,7 +31,6 @@
 			    "rx-warning", "wake-up";
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1030 4>;
 			clk-source = <1>;
-			sample-point = <875>;
 			status = "disabled";
 		  };
 	};

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -504,7 +504,6 @@
 			interrupt-names = "mb-0-15", "bus-off", "error", "tx-warning", "rx-warning", "wake-up";
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103C 4>;
 			clk-source = <1>;
-			sample-point = <875>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf.dtsi
@@ -405,7 +405,6 @@
 					  "mb-0-15";
 			clocks = <&scg KINETIS_SCG_BUS_CLK>;
 			clk-source = <1>;
-			sample-point = <875>;
 			status = "disabled";
 		};
 
@@ -417,7 +416,6 @@
 					  "mb-0-15";
 			clocks = <&scg KINETIS_SCG_BUS_CLK>;
 			clk-source = <1>;
-			sample-point = <875>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/nxp_lpc55S0x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S0x_common.dtsi
@@ -223,8 +223,6 @@
 		interrupt-names = "int0", "int1";
 		clocks = <&syscon MCUX_MCAN_CLK>;
 		bosch,mram-cfg = <0x0 15 15 8 8 0 15 15>;
-		sample-point = <875>;
-		sample-point-data = <875>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
@@ -218,8 +218,6 @@
 		interrupt-names = "int0", "int1";
 		clocks = <&syscon MCUX_MCAN_CLK>;
 		bosch,mram-cfg = <0x0 15 15 8 8 0 15 15>;
-		sample-point = <875>;
-		sample-point-data = <875>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
@@ -328,8 +328,6 @@
 		interrupt-names = "int0", "int1";
 		clocks = <&syscon MCUX_MCAN_CLK>;
 		bosch,mram-cfg = <0x0 15 15 8 8 0 15 15>;
-		sample-point = <875>;
-		sample-point-data = <875>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/nxp_rt10xx.dtsi
+++ b/dts/arm/nxp/nxp_rt10xx.dtsi
@@ -872,7 +872,6 @@
 			interrupt-names = "common";
 			clocks = <&ccm IMX_CCM_CAN_CLK 0x68 14>;
 			clk-source = <2>;
-			sample-point = <875>;
 			status = "disabled";
 		};
 
@@ -883,7 +882,6 @@
 			interrupt-names = "common";
 			clocks = <&ccm IMX_CCM_CAN_CLK 0x68 18>;
 			clk-source = <2>;
-			sample-point = <875>;
 			status = "disabled";
 		};
 
@@ -894,8 +892,6 @@
 			interrupt-names = "common";
 			clocks = <&ccm IMX_CCM_CAN_CLK 0x84 6>;
 			clk-source = <2>;
-			sample-point = <875>;
-			sample-point-data = <875>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -806,8 +806,6 @@
 			interrupt-names = "common", "error";
 			clocks = <&ccm IMX_CCM_CAN1_CLK 0x68 14>;
 			clk-source = <0>;
-			sample-point = <875>;
-			sample-point-data = <875>;
 			status = "disabled";
 		};
 
@@ -818,8 +816,6 @@
 			interrupt-names = "common", "error";
 			clocks = <&ccm IMX_CCM_CAN2_CLK 0x68 18>;
 			clk-source = <0>;
-			sample-point = <875>;
-			sample-point-data = <875>;
 			status = "disabled";
 		};
 
@@ -830,8 +826,6 @@
 			interrupt-names = "common", "error";
 			clocks = <&ccm IMX_CCM_CAN3_CLK 0x84 6>;
 			clk-source = <0>;
-			sample-point = <875>;
-			sample-point-data = <875>;
 			status = "disabled";
 		};
 

--- a/dts/arm/renesas/rcar/gen3/rcar_gen3_cr7.dtsi
+++ b/dts/arm/renesas/rcar/gen3/rcar_gen3_cr7.dtsi
@@ -94,7 +94,6 @@
 			interrupt-parent = <&gic>;
 			interrupts = <GIC_SPI 186 IRQ_TYPE_LEVEL
 					IRQ_DEFAULT_PRIORITY>;
-			sample-point = <875>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/f0/stm32f042.dtsi
+++ b/dts/arm/st/f0/stm32f042.dtsi
@@ -44,7 +44,6 @@
 			interrupts = <30 0>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 			status = "disabled";
-			sample-point = <875>;
 		};
 
 		timers15: timers@40014000 {

--- a/dts/arm/st/f0/stm32f072.dtsi
+++ b/dts/arm/st/f0/stm32f072.dtsi
@@ -16,7 +16,6 @@
 			interrupts = <30 0>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 			status = "disabled";
-			sample-point = <875>;
 		};
 
 		usb: usb@40005c00 {

--- a/dts/arm/st/f0/stm32f091.dtsi
+++ b/dts/arm/st/f0/stm32f091.dtsi
@@ -58,7 +58,6 @@
 			interrupts = <30 0>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 			status = "disabled";
-			sample-point = <875>;
 		};
 
 		dma2: dma@40020400 {

--- a/dts/arm/st/f1/stm32f103X8.dtsi
+++ b/dts/arm/st/f1/stm32f103X8.dtsi
@@ -54,7 +54,6 @@
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 			status = "disabled";
-			sample-point = <875>;
 		};
 	};
 

--- a/dts/arm/st/f1/stm32f105.dtsi
+++ b/dts/arm/st/f1/stm32f105.dtsi
@@ -40,7 +40,6 @@
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 			status = "disabled";
-			sample-point = <875>;
 		};
 
 		can2: can@40006800 {
@@ -51,7 +50,6 @@
 			/* also enabling clock for can1 (master instance) */
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x06000000>;
 			status = "disabled";
-			sample-point = <875>;
 		};
 
 		dac1: dac@40007400 {

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -420,7 +420,6 @@
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 			status = "disabled";
-			sample-point = <875>;
 		};
 
 		dma1: dma@40020000 {

--- a/dts/arm/st/f4/stm32f405.dtsi
+++ b/dts/arm/st/f4/stm32f405.dtsi
@@ -212,7 +212,6 @@
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 			status = "disabled";
-			sample-point = <875>;
 		};
 
 		can2: can@40006800 {
@@ -224,7 +223,6 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x06000000>;
 			master-can-reg = <0x40006400>;
 			status = "disabled";
-			sample-point = <875>;
 		};
 
 		rng: rng@50060800 {

--- a/dts/arm/st/f4/stm32f412.dtsi
+++ b/dts/arm/st/f4/stm32f412.dtsi
@@ -222,7 +222,6 @@
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 			status = "disabled";
-			sample-point = <875>;
 		};
 
 		can2: can@40006800 {
@@ -234,7 +233,6 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x06000000>;
 			master-can-reg = <0x40006400>;
 			status = "disabled";
-			sample-point = <875>;
 		};
 	};
 };

--- a/dts/arm/st/f4/stm32f413.dtsi
+++ b/dts/arm/st/f4/stm32f413.dtsi
@@ -79,7 +79,6 @@
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x08000000>;
 			status = "disabled";
-			sample-point = <875>;
 		};
 	};
 };

--- a/dts/arm/st/f4/stm32f446.dtsi
+++ b/dts/arm/st/f4/stm32f446.dtsi
@@ -65,7 +65,6 @@
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 			status = "disabled";
-			sample-point = <875>;
 		};
 
 		can2: can@40006800 {
@@ -77,7 +76,6 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x06000000>;
 			master-can-reg = <0x40006400>;
 			status = "disabled";
-			sample-point = <875>;
 		};
 
 		usbotg_fs: usb@50000000 {

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -403,7 +403,6 @@
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 			status = "disabled";
-			sample-point = <875>;
 		};
 
 		timers1: timers@40010000 {

--- a/dts/arm/st/f7/stm32f745.dtsi
+++ b/dts/arm/st/f7/stm32f745.dtsi
@@ -73,7 +73,6 @@
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x04000000>;
 			status = "disabled";
-			sample-point = <875>;
 		};
 
 		mac: ethernet@40028000 {

--- a/dts/arm/st/g0/stm32g0b1.dtsi
+++ b/dts/arm/st/g0/stm32g0b1.dtsi
@@ -38,8 +38,6 @@
 			interrupt-names = "int0", "int1";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00001000>;
 			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
-			sample-point = <875>;
-			sample-point-data = <875>;
 			status = "disabled";
 		};
 
@@ -51,8 +49,6 @@
 			interrupt-names = "int0", "int1";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00001000>;
 			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
-			sample-point = <875>;
-			sample-point-data = <875>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -390,8 +390,6 @@
 			interrupt-names = "int0", "int1";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
-			sample-point = <875>;
-			sample-point-data = <875>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/g4/stm32g473.dtsi
+++ b/dts/arm/st/g4/stm32g473.dtsi
@@ -103,8 +103,6 @@
 			interrupt-names = "int0", "int1";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 			bosch,mram-cfg = <0x6a0 28 8 3 3 0 3 3>;
-			sample-point = <875>;
-			sample-point-data = <875>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/g4/stm32g491.dtsi
+++ b/dts/arm/st/g4/stm32g491.dtsi
@@ -18,8 +18,6 @@
 			interrupt-names = "int0", "int1";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 			bosch,mram-cfg = <0x350 28 8 3 3 0 3 3>;
-			sample-point = <875>;
-			sample-point-data = <875>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -441,8 +441,6 @@
 			interrupt-names = "int0", "int1";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000200>;
 			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
-			sample-point = <875>;
-			sample-point-data = <875>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -330,8 +330,6 @@
 			/* common clock FDCAN 1 & 2 */
 			clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000200>;
 			bosch,mram-cfg = <0x350 28 8 3 3 0 3 3>;
-			sample-point = <875>;
-			sample-point-data = <875>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -516,8 +516,6 @@
 			interrupts = <19 0>, <21 0>, <63 0>;
 			interrupt-names = "int0", "int1", "calib";
 			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
-			sample-point = <875>;
-			sample-point-data = <875>;
 			status = "disabled";
 		};
 
@@ -529,8 +527,6 @@
 			interrupts = <20 0>, <22 0>, <63 0>;
 			interrupt-names = "int0", "int1", "calib";
 			bosch,mram-cfg = <0x350 28 8 3 3 0 3 3>;
-			sample-point = <875>;
-			sample-point-data = <875>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -123,8 +123,6 @@
 			interrupts = <159 0>, <160 0>, <63 0>;
 			interrupt-names = "int0", "int1", "calib";
 			bosch,mram-cfg = <0x6a0 28 8 3 3 0 3 3>;
-			sample-point = <875>;
-			sample-point-data = <875>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/l4/stm32l431.dtsi
+++ b/dts/arm/st/l4/stm32l431.dtsi
@@ -107,7 +107,6 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 			interrupts = <19 0>, <20 0>, <21 0>, <22 0>;
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
-			sample-point = <875>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/l4/stm32l432.dtsi
+++ b/dts/arm/st/l4/stm32l432.dtsi
@@ -57,7 +57,6 @@
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>; //RCC_APB1ENR1_CAN1EN
 			status = "disabled";
-			sample-point = <875>;
 		};
 
 		usb: usb@40006800 {

--- a/dts/arm/st/l4/stm32l451.dtsi
+++ b/dts/arm/st/l4/stm32l451.dtsi
@@ -141,7 +141,6 @@
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>; //RCC_APB1ENR1_CAN1EN
 			status = "disabled";
-			sample-point = <875>;
 		};
 
 		sdmmc1: sdmmc@40012800 {

--- a/dts/arm/st/l4/stm32l471.dtsi
+++ b/dts/arm/st/l4/stm32l471.dtsi
@@ -232,7 +232,6 @@
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>; //RCC_APB1ENR1_CAN1EN
 			status = "disabled";
-			sample-point = <875>;
 		};
 
 		sdmmc1: sdmmc@40012800 {

--- a/dts/arm/st/l4/stm32l496.dtsi
+++ b/dts/arm/st/l4/stm32l496.dtsi
@@ -56,7 +56,6 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x04000000>; //RCC_APB1ENR1_CAN2EN
 			master-can-reg = <0x40006400>;
 			status = "disabled";
-			sample-point = <875>;
 		};
 
 		aes: aes@50060000 {

--- a/dts/arm/st/l4/stm32l4p5.dtsi
+++ b/dts/arm/st/l4/stm32l4p5.dtsi
@@ -291,7 +291,6 @@
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>; //RCC_APB1ENR1_CAN1EN
 			status = "disabled";
-			sample-point = <875>;
 		};
 
 		aes: aes@50060000 {

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -801,8 +801,6 @@
 			interrupt-names = "int0", "int1";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000200>;
 			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
-			sample-point = <875>;
-			sample-point-data = <875>;
 			status = "disabled";
 		};
 

--- a/dts/bindings/can/can-controller.yaml
+++ b/dts/bindings/can/can-controller.yaml
@@ -10,9 +10,12 @@ properties:
       Initial bitrate in bit/s.
   sample-point:
     type: int
-    required: true
     description: |
       Initial sample point in per mille (e.g. 875 equals 87.5%).
+
+      If this is unset (or if it is set to 0), the initial sample point will default to 75.0% for
+      bitrates over 800 kbit/s, 80.0% for bitrates over 500 kbit/s, and 87.5% for all other
+      bitrates.
   phys:
     type: phandle
     description: |

--- a/dts/bindings/can/can-fd-controller.yaml
+++ b/dts/bindings/can/can-fd-controller.yaml
@@ -10,9 +10,12 @@ properties:
       Initial data phase bitrate in bit/s.
   sample-point-data:
     type: int
-    required: true
     description: |
       Initial data phase sample point in per mille (e.g. 875 equals 87.5%).
+
+      If this is unset (or if it is set to 0), the initial sample point will default to 75.0% for
+      bitrates over 800 kbit/s, 80.0% for bitrates over 500 kbit/s, and 87.5% for all other
+      bitrates.
   tx-delay-comp-offset:
     type: int
     default: 0

--- a/dts/bindings/can/microchip,mcp251xfd.yaml
+++ b/dts/bindings/can/microchip,mcp251xfd.yaml
@@ -20,9 +20,7 @@ description: |
           osc-freq = <40000000>;
 
           bus-speed = <125000>;
-          sample-point = <875>;
           bus-speed-data = <1000000>;
-          sample-point-data = <875>;
       };
   };
 

--- a/dts/bindings/can/nxp,flexcan-fd.yaml
+++ b/dts/bindings/can/nxp,flexcan-fd.yaml
@@ -15,8 +15,6 @@ description: |
       interrupt-names = "common";
       clocks = <&ccm IMX_CCM_CAN_CLK 0x84 6>;
       clk-source = <2>;
-      sample-point = <875>;
-      sample-point-data = <875>;
       bus-speed = <125000>;
       bus-speed-data = <1000000>;
       pinctrl-0 = <&pinmux_flexcan3>;

--- a/dts/bindings/can/nxp,flexcan.yaml
+++ b/dts/bindings/can/nxp,flexcan.yaml
@@ -13,7 +13,6 @@ description: |
       interrupt-names = "warning", "error", "wake-up", "mb-0-15";
       clocks = <&scg KINETIS_SCG_BUS_CLK>;
       clk-source = <1>;
-      sample-point = <875>;
       bus-speed = <125000>;
       pinctrl-0 = <&pinmux_flexcan0>;
       pinctrl-names = "default";

--- a/dts/bindings/can/ti,tcan4x5x.yaml
+++ b/dts/bindings/can/ti,tcan4x5x.yaml
@@ -16,8 +16,6 @@ description: |
         reset-gpios = <&gpio0 2 GPIO_ACTIVE_HIGH>;
         int-gpios = <&gpio0 3 GPIO_ACTIVE_LOW>;
         bosch,mram-cfg = <0x0 15 15 5 5 0 10 10>;
-        sample-point = <875>;
-        sample-point-data = <875>;
         bus-speed = <125000>;
         bus-speed-data = <1000000>;
         status = "okay";

--- a/dts/riscv/espressif/esp32c3/esp32c3_common.dtsi
+++ b/dts/riscv/espressif/esp32c3/esp32c3_common.dtsi
@@ -218,7 +218,6 @@
 			interrupts = <TWAI_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_TWAI_MODULE>;
-			sample-point = <875>;
 			status = "disabled";
 		};
 

--- a/dts/xtensa/espressif/esp32/esp32_common.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_common.dtsi
@@ -354,7 +354,6 @@
 			interrupts = <TWAI_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_TWAI_MODULE>;
-			sample-point = <875>;
 			status = "disabled";
 		};
 

--- a/dts/xtensa/espressif/esp32s2/esp32s2_common.dtsi
+++ b/dts/xtensa/espressif/esp32s2/esp32s2_common.dtsi
@@ -339,7 +339,6 @@
 			interrupts = <TWAI_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_TWAI_MODULE>;
-			sample-point = <875>;
 			status = "disabled";
 		};
 	};

--- a/dts/xtensa/espressif/esp32s3/esp32s3_common.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_common.dtsi
@@ -281,7 +281,6 @@
 			interrupts = <TWAI_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_TWAI_MODULE>;
-			sample-point = <875>;
 			status = "disabled";
 		};
 

--- a/tests/drivers/can/shell/app.overlay
+++ b/tests/drivers/can/shell/app.overlay
@@ -8,10 +8,7 @@
 	fake_can: fake_can {
 		compatible = "zephyr,fake-can";
 		status = "okay";
-		sample-point = <875>;
 		bus-speed = <125000>;
-		sample-point = <875>;
 		bus-speed-data = <1000000>;
-		sample-point-data = <750>;
 	};
 };

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -528,7 +528,6 @@
 		test_can0: can@55553333 {
 			compatible = "vnd,can-controller";
 			reg = < 0x55553333 0x1000 >;
-			sample-point = <875>;
 			bus-speed = <125000>;
 			status = "okay";
 			phys = <&test_transceiver0>;
@@ -537,7 +536,6 @@
 		test_can1: can@55554444 {
 			compatible = "vnd,can-controller";
 			reg = < 0x55554444 0x1000 >;
-			sample-point = <875>;
 			bus-speed = <125000>;
 			status = "okay";
 
@@ -550,7 +548,6 @@
 		test_can2: can@55555555 {
 			compatible = "vnd,can-controller";
 			reg = < 0x55555555 0x1000 >;
-			sample-point = <875>;
 			bus-speed = <125000>;
 			status = "okay";
 
@@ -562,7 +559,6 @@
 		test_can3: can@55557777 {
 			compatible = "vnd,can-controller";
 			reg = < 0x55556666 0x1000 >;
-			sample-point = <875>;
 			bus-speed = <125000>;
 			status = "okay";
 			phys = <&test_transceiver1>;


### PR DESCRIPTION
- Make the properties for setting the initial sample points for both the classic/arbitration phase and the data phase optional.
- Remove all optional, initial CAN sample point properties and rely on the CAN timing calculations to automatically pick the preferred sample point location based on the initial bitrate.
