### PR TITLE
arch: arm64: fix arch_secondary_cpu_init() function definition

### DIFF
--- a/arch/arm64/core/smp.c
+++ b/arch/arm64/core/smp.c
@@ -133,10 +133,10 @@ void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
 }
 
 /* the C entry of secondary cores */
-void arch_secondary_cpu_init(int cpu_num)
+FUNC_NORETURN void arch_secondary_cpu_init(void)
 {
-	cpu_num = arm64_cpu_boot_params.cpu_num;
-	arch_cpustart_t fn;
+	int cpu_num = arm64_cpu_boot_params.cpu_num;
+	FUNC_NORETURN arch_cpustart_t fn;
 	void *arg;
 
 	__ASSERT(arm64_cpu_boot_params.mpid == MPIDR_TO_CORE(GET_MPIDR()), "");


### PR DESCRIPTION
arch_secondary_cpu_init() in prep_c.c is marked as FUNC_NORETURN and it does not have any param. I adjusted the function implementation in smp.c to match this.


As additional info: With this change, I've been able to run qemu_cortex_a53_smp:samples/net/dhcpv4_client
with CONFIG_LTO. That's where this function mismatch did show up.

Thanks a lot for great work at zephyr,

Florian La Roche
