### PR TITLE
drivers: usb: device: fix Rx FIFO min size

### DIFF
--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -131,7 +131,7 @@ static const struct gpio_dt_spec ulpi_reset =
 #define TX_FIFO_NUM USB_NUM_BIDIR_ENDPOINTS
 
 /* We need a minimum size for RX FIFO */
-#define USB_FIFO_RX_MIN 160
+#define USB_FIFO_RX_MIN 120
 
 /* 4-byte words TX FIFO */
 #define TX_FIFO_WORDS ((USB_RAM_SIZE - USB_FIFO_RX_MIN - 64) / 4)


### PR DESCRIPTION
the FIFO Rx need to have a minimum memory to works
but a bug was introduced by
https://github.com/zephyrproject-rtos/zephyr/commit/1204aa25c82735b6359fbe79ec95a2186d612e30 ("drivers: usb: device: fix Rx FIFO min size")
The latest PR reveals that Rx FIFO min size was a little
too high so we set an intermediate level 120