### PR TITLE
tests: llext: Set min_ram requirement for readonly_mpu variant 

### DIFF
--- a/tests/subsys/llext/hello_world/testcase.yaml
+++ b/tests/subsys/llext/hello_world/testcase.yaml
@@ -13,6 +13,7 @@ tests:
       - arch:arm:CONFIG_ARM_MPU=n
       - CONFIG_LLEXT_STORAGE_WRITABLE=n
   llext.simple.readonly_mpu:
+    min_ram: 128
     arch_exclude: xtensa # for now
     filter: CONFIG_CPU_HAS_MPU
     extra_configs:


### PR DESCRIPTION
Disable test variant that does not fit in RAM from executing on nrf52dk_nrf52832.