### PR TITLE
scripts: remove board name from the identifier in list_boards.py

### DIFF
--- a/cmake/modules/boards.cmake
+++ b/cmake/modules/boards.cmake
@@ -284,12 +284,14 @@ elseif(HWMv2)
       string(REGEX REPLACE "^//" "/${LIST_BOARD_SOCS}/" BOARD_QUALIFIERS "${BOARD_QUALIFIERS}")
     endif()
 
-    if(NOT ("${BOARD}${BOARD_QUALIFIERS}" IN_LIST LIST_BOARD_QUALIFIERS))
-      string(REPLACE ";" "\n" LIST_BOARD_QUALIFIERS "${LIST_BOARD_QUALIFIERS}")
+    set(board_targets ${LIST_BOARD_QUALIFIERS})
+    list(TRANSFORM board_targets PREPEND "${BOARD}/")
+    if(NOT ("${BOARD}${BOARD_QUALIFIERS}" IN_LIST board_targets))
+      string(REPLACE ";" "\n" board_targets "${board_targets}")
       unset(CACHED_BOARD CACHE)
       message(FATAL_ERROR "Board qualifiers `${BOARD_QUALIFIERS}` for board \
             `${BOARD}` not found. Please specify a valid board target.\n"
-            "Valid board qualifiers for ${BOARD_NAME} are:\n${LIST_BOARD_QUALIFIERS}\n")
+            "Valid board targets for ${BOARD_NAME} are:\n${board_targets}\n")
     endif()
   endif()
 else()

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -449,7 +449,8 @@ class KconfigCheck(ComplianceTest):
                 fp.write('config  ' + board_str + '\n')
                 fp.write('\t bool\n')
                 for qualifier in list_boards.board_v2_qualifiers(board):
-                    board_str = 'BOARD_' + re.sub(r"[^a-zA-Z0-9_]", "_", qualifier).upper()
+                    board_str = ('BOARD_' + board.name + '_' +
+                                 re.sub(r"[^a-zA-Z0-9_]", "_", qualifier)).upper()
                     fp.write('config  ' + board_str + '\n')
                     fp.write('\t bool\n')
                 fp.write(

--- a/scripts/list_boards.py
+++ b/scripts/list_boards.py
@@ -275,10 +275,10 @@ def add_args_formatting(parser):
                         help='''CMake Format string to use to list each board''')
 
 
-def variant_v2_qualifiers(variant, qualifiers):
-    qualifiers_list = [qualifiers + '/' + variant.name]
+def variant_v2_qualifiers(variant, qualifiers = None):
+    qualifiers_list = [variant.name] if qualifiers is None else [qualifiers + '/' + variant.name]
     for v in variant.variants:
-        qualifiers_list.extend(variant_v2_qualifiers(v, qualifiers + '/' + variant.name))
+        qualifiers_list.extend(variant_v2_qualifiers(v, qualifiers_list[0]))
     return qualifiers_list
 
 
@@ -288,21 +288,17 @@ def board_v2_qualifiers(board):
     for s in board.socs:
         if s.cpuclusters:
             for c in s.cpuclusters:
-                id_str = board.name + '/' + s.name + '/' + c.name
+                id_str = s.name + '/' + c.name
                 qualifiers_list.append(id_str)
                 for v in c.variants:
                     qualifiers_list.extend(variant_v2_qualifiers(v, id_str))
         else:
-            id_str = board.name + '/' + s.name
-            qualifiers_list.append(id_str)
+            qualifiers_list.append(s.name)
             for v in s.variants:
-                qualifiers_list.extend(variant_v2_qualifiers(v, id_str))
-
-    if not board.socs:
-        qualifiers_list.append(board.name)
+                qualifiers_list.extend(variant_v2_qualifiers(v, s.name))
 
     for v in board.variants:
-        qualifiers_list.extend(variant_v2_qualifiers(v, board.name))
+        qualifiers_list.extend(variant_v2_qualifiers(v))
     return qualifiers_list
 
 

--- a/scripts/west_commands/completion/west-completion.bash
+++ b/scripts/west_commands/completion/west-completion.bash
@@ -392,8 +392,13 @@ __set_comp_west_projs()
 
 __set_comp_west_boards()
 {
-	boards="$(__west_x boards --format={identifiers} "$@")\n$(__west_x boards --format={name} "$@")"
-	__set_comp ${boards//,/\ }
+	boards=( $(__west_x boards --format='{name}|{qualifiers}' "$@") )
+	for i in ${!boards[@]}; do
+		name="${boards[$i]%%|*}"
+		transformed_board="${boards[$i]//|//}"
+		boards[$i]="${transformed_board//,/\ ${name}\/}"
+	done
+	__set_comp ${boards[@]}
 }
 
 __comp_west_west()

--- a/scripts/west_commands/completion/west-completion.fish
+++ b/scripts/west_commands/completion/west-completion.fish
@@ -196,19 +196,12 @@ function __zephyr_west_complete_help
 end
 
 function __zephyr_west_complete_board
-    # HWMv1
-    set -l boards (west 2>/dev/null boards --format="{name} {arch}")
+    set -l boards (west 2>/dev/null boards --format="{name}|{qualifiers}")
     for board in $boards
-        set -l b (string split " " $board)
-        printf "%s\n" $b[1]\t"$b[2]"
-    end
-
-    # HWMv2
-    set -l boards (west 2>/dev/null boards --format="{identifiers}")
-    for board in $boards
-        set -l b (string split "," $board)
-        for variant in $b
-            printf "%s\n" $variant[1]
+        set -l b (string split "|" $board)
+        set -l qualifiers (string split "," $b[2])
+        for i in $qualifiers
+            printf "%s\n" $b[1]/$i
         end
     end
 end
@@ -307,7 +300,7 @@ complete -c west -n "__zephyr_west_seen_subcommand_from boards" -l soc-root -xa 
 # build
 complete -c west -n "__zephyr_west_use_subcommand; and __zephyr_west_check_if_in_workspace" -ra build -d "compile a Zephyr application"
 complete -c west -n "__zephyr_west_seen_subcommand_from build" -ra "(__zephyr_west_complete_directories)"
-complete -c west -n "__zephyr_west_seen_subcommand_from build" -o b -l board -xa "(__zephyr_west_complete_board)" -d "board to build for"
+complete -c west -n "__zephyr_west_seen_subcommand_from build" -o b -l board -xa "(__zephyr_west_complete_board)"
 complete -c west -n "__zephyr_west_seen_subcommand_from build" -o d -l build-dir -xa "(__zephyr_west_complete_directories)" -d "build directory to create or use"
 complete -c west -n "__zephyr_west_seen_subcommand_from build" -o f -l force -d "ignore errors and continue"
 complete -c west -n "__zephyr_west_seen_subcommand_from build" -l sysbuild -d "create multi-domain build system"

--- a/scripts/west_commands/completion/west-completion.zsh
+++ b/scripts/west_commands/completion/west-completion.zsh
@@ -102,9 +102,12 @@ _get_west_projs() {
 }
 
 _get_west_boards() {
-  _west_boards="$(__west_x boards --format={identifiers})\n$(__west_x boards --format={name})"
-  _west_boards=${_west_boards//$'\n'/\ }
-  _west_boards=${_west_boards//,/\ }
+  _west_boards=( $(__west_x boards --format='{name}|{qualifiers}') )
+  for i in {1..${#_west_boards[@]}}; do
+    local name="${_west_boards[$i]%%|*}"
+    local transformed_board="${_west_boards[$i]//|//}"
+    _west_boards[$i]="${transformed_board//,/ ${name}/}"
+  done
   _west_boards=(${(@s/ /)_west_boards})
 
   _describe 'boards' _west_boards


### PR DESCRIPTION
Fixes: #69329

The board name was printed as part of printing board identifiers because those was being concatenated in the `board_v2_identifiers()` method.

Keep the identifiers speparated from the board name and let the caller concatenate the strings when required.