### PR TITLE
Bluetooth: add missing initilization of sync_info member

### DIFF
--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -1246,6 +1246,7 @@ static void bt_hci_le_past_received_common(struct net_buf *buf)
 	sync_info.addr = &per_adv_sync->addr;
 	sync_info.sid = per_adv_sync->sid;
 	sync_info.service_data = sys_le16_to_cpu(evt->service_data);
+	sync_info.recv_enabled = true;
 
 #if defined(CONFIG_BT_PER_ADV_SYNC_RSP)
 	sync_info.num_subevents =  per_adv_sync->num_subevents;


### PR DESCRIPTION
During manual testing with UBSAN enabled, it was found that bt_le_per_adv_sync_cb synced() callback in application sometimes gets unexpected different values in `sync_info.recv_enabled` field.
The UBSAN output contained the following warnings message: runtime error: load of value 65, which is not a valid value for type '_Bool'

It tunrned out that struct bt_le_per_adv_sync_synced_info sync_info structure inside bt_hci_le_past_received_common() contains uninitialized recv_enabled member. Set it to true by default to avoid possible issues.