### PR TITLE
MAINTAINERS: Add collaborator for OA TC6 and T1S driver (lan865x)

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1237,6 +1237,7 @@ Release Notes:
   status: odd fixes
   collaborators:
     - decsny
+    - lmajewski
   files:
     - drivers/ethernet/
     - include/zephyr/dt-bindings/ethernet/


### PR DESCRIPTION
I can help with maintaining this particular driver.