### PR TITLE
ADSP: don't use timer interrupts on secondary cores

### DIFF
--- a/drivers/timer/intel_adsp_timer.c
+++ b/drivers/timer/intel_adsp_timer.c
@@ -210,7 +210,6 @@ static void irq_init(void)
 
 void smp_timer_init(void)
 {
-	irq_init();
 }
 
 /* Runs on core 0 only */


### PR DESCRIPTION
When running SOF on Intel ADSP we choose to only serve the timer interrupt on the primary core.