### PR TITLE
drivers: input: Fix uninitialized closest_mv variable warning

### DIFF
--- a/drivers/input/input_adc_keys.c
+++ b/drivers/input/input_adc_keys.c
@@ -70,7 +70,7 @@ static inline int32_t adc_keys_read(const struct device *dev)
 static inline void adc_keys_process(const struct device *dev)
 {
 	const struct adc_keys_config *cfg = dev->config;
-	int32_t sample_mv, closest_mv;
+	int32_t sample_mv, closest_mv = 0;
 	uint32_t diff, closest_diff = UINT32_MAX;
 	const struct adc_keys_code_config *code_cfg;
 	struct adc_keys_key_state *key_state;


### PR DESCRIPTION
Building with GCC 9.4.0 gives the following warning/error:

`  error: closest_mv may be used uninitialized in this function`

This commit fixes it.