### PR TITLE
drivers: eeprom: add support for Microchip ATECC608

### DIFF
--- a/drivers/eeprom/CMakeLists.txt
+++ b/drivers/eeprom/CMakeLists.txt
@@ -19,3 +19,5 @@ zephyr_library_sources_ifdef(CONFIG_EEPROM_FAKE eeprom_fake.c)
 zephyr_library_sources_ifdef(CONFIG_EEPROM_AT2X_EMUL eeprom_at2x_emul.c)
 
 zephyr_library_sources_ifdef(CONFIG_EEPROM_MB85RCXX eeprom_mb85rcxx.c)
+
+zephyr_library_sources_ifdef(CONFIG_EEPROM_ATECCX08_OTP eeprom_ateccx08_otp.c)

--- a/drivers/eeprom/Kconfig
+++ b/drivers/eeprom/Kconfig
@@ -99,6 +99,7 @@ source "drivers/eeprom/Kconfig.eeprom_emu"
 source "drivers/eeprom/Kconfig.tmp116"
 source "drivers/eeprom/Kconfig.xec"
 source "drivers/eeprom/Kconfig.mb85rcxx"
+source "drivers/eeprom/Kconfig.ateccx08"
 
 config EEPROM_SIMULATOR
 	bool "Simulated EEPROM driver"

--- a/drivers/eeprom/Kconfig.ateccx08
+++ b/drivers/eeprom/Kconfig.ateccx08
@@ -1,0 +1,19 @@
+# Microchip ATECCx08 eeprom driver configuration
+
+# Copyright (c) 2024 Vogl Electronic GmbH
+# SPDX-License-Identifier: Apache-2.0
+
+config EEPROM_ATECCX08_OTP
+	bool "Microchip ATECCx08 otp eeprom driver"
+	default y
+	depends on DT_HAS_MICROCHIP_ATECCX08_OTP_ENABLED
+	depends on MFD_ATECCX08
+	help
+	  This option enables the Microchip ATECCx08 otp eeprom driver.
+
+config EEPROM_ATECCX08_OTP_INIT_PRIORITY
+	int "Microchip ATECCx08 otp eeprom driver initialization priority"
+	default MFD_ATECCX08_SUBDEVICE_INIT_PRIORITY
+	depends on EEPROM_ATECCX08_OTP
+	help
+	  Microchip ATECCx08 otp eeprom device initialization priority.

--- a/drivers/eeprom/eeprom_ateccx08_otp.c
+++ b/drivers/eeprom/eeprom_ateccx08_otp.c
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2024 Vogl Electronic GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Driver for Microchip ATECCX08 I2C EEPROMs.
+ */
+
+#define DT_DRV_COMPAT microchip_ateccx08_otp
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/mfd/ateccx08.h>
+#include <zephyr/drivers/eeprom.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(ateccx08_otp, CONFIG_EEPROM_LOG_LEVEL);
+
+struct eeprom_ateccx08_config {
+	const struct device *parent;
+	bool readonly;
+};
+
+static size_t eeprom_ateccx08_size(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	return atecc_get_zone_size(ATECC_ZONE_OTP, 0);
+}
+
+static int eeprom_ateccx08_write(const struct device *dev, off_t offset, const void *data,
+				 size_t len)
+{
+	const struct eeprom_ateccx08_config *cfg = dev->config;
+
+	if (cfg->readonly) {
+		LOG_ERR("attempt to write to read-only device");
+		return -EACCES;
+	}
+
+	return atecc_write_bytes(cfg->parent, ATECC_ZONE_OTP, 0, offset, data, len);
+}
+
+static int eeprom_ateccx08_read(const struct device *dev, off_t offset, void *data, size_t len)
+{
+	const struct eeprom_ateccx08_config *cfg = dev->config;
+
+	return atecc_read_bytes(cfg->parent, ATECC_ZONE_OTP, 0, offset, data, len);
+}
+
+static int eeprom_ateccx08_init(const struct device *dev)
+{
+	const struct eeprom_ateccx08_config *cfg = dev->config;
+
+	if (!device_is_ready(cfg->parent)) {
+		return -ENODEV;
+	}
+
+	return 0;
+}
+
+static const struct eeprom_driver_api eeprom_ateccx08_driver_api = {
+	.read = &eeprom_ateccx08_read,
+	.write = &eeprom_ateccx08_write,
+	.size = &eeprom_ateccx08_size,
+};
+
+BUILD_ASSERT(CONFIG_EEPROM_ATECCX08_OTP_INIT_PRIORITY >= CONFIG_MFD_ATECCX08_INIT_PRIORITY,
+	     "ATECCX08 EEPROM driver must be initialized after the mfd driver");
+
+#define DEFINE_ATECCX08_OTP(_num)                                                                  \
+	static const struct eeprom_ateccx08_config eeprom_ateccx08_config##_num = {                \
+		.parent = DEVICE_DT_GET(DT_INST_BUS(_num)),                                        \
+		.readonly = DT_INST_PROP(_num, read_only)};                                        \
+	DEVICE_DT_INST_DEFINE(_num, eeprom_ateccx08_init, NULL, NULL,                              \
+			      &eeprom_ateccx08_config##_num, POST_KERNEL,                          \
+			      CONFIG_EEPROM_ATECCX08_OTP_INIT_PRIORITY,                            \
+			      &eeprom_ateccx08_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(DEFINE_ATECCX08_OTP);

--- a/drivers/entropy/CMakeLists.txt
+++ b/drivers/entropy/CMakeLists.txt
@@ -4,6 +4,7 @@ zephyr_syscall_header(${ZEPHYR_BASE}/include/zephyr/drivers/entropy.h)
 
 zephyr_library()
 
+zephyr_library_sources_ifdef(CONFIG_ENTROPY_ATECCX08           entropy_ateccx08.c)
 zephyr_library_sources_ifdef(CONFIG_ENTROPY_TELINK_B91_TRNG    entropy_b91_trng.c)
 zephyr_library_sources_ifdef(CONFIG_ENTROPY_CC13XX_CC26XX_RNG  entropy_cc13xx_cc26xx.c)
 zephyr_library_sources_ifdef(CONFIG_ENTROPY_ESP32_RNG          entropy_esp32.c)

--- a/drivers/entropy/Kconfig
+++ b/drivers/entropy/Kconfig
@@ -20,6 +20,7 @@ config ENTROPY_INIT_PRIORITY
 	help
 	  Entropy driver device initialization priority.
 
+source "drivers/entropy/Kconfig.ateccx08"
 source "drivers/entropy/Kconfig.b91"
 source "drivers/entropy/Kconfig.cc13xx_cc26xx"
 source "drivers/entropy/Kconfig.mcux"

--- a/drivers/entropy/Kconfig.ateccx08
+++ b/drivers/entropy/Kconfig.ateccx08
@@ -1,0 +1,20 @@
+# Microchip ATECCx08 entropy generator driver configuration
+
+# Copyright (c) 2024 Vogl Electronic GmbH
+# SPDX-License-Identifier: Apache-2.0
+
+config ENTROPY_ATECCX08
+	bool "Microchip ATECCx08 RNG driver"
+	default y
+	depends on DT_HAS_MICROCHIP_ATECCX08_ENTROPY_ENABLED
+	depends on MFD_ATECCX08
+	select ENTROPY_HAS_DRIVER
+	help
+	  This option enables the Microchip ATECCx08 RNG driver.
+
+config ENTROPY_ATECCX08_INIT_PRIORITY
+	int "Microchip ATECCx08 RNG driver init priority"
+	default MFD_ATECCX08_SUBDEVICE_INIT_PRIORITY
+	depends on ENTROPY_ATECCX08
+	help
+	  Microchip ATECCx08 RNG driver device initialization priority.

--- a/drivers/entropy/entropy_ateccx08.c
+++ b/drivers/entropy/entropy_ateccx08.c
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2024 Vogl Electronic GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT microchip_ateccx08_entropy
+
+#include <errno.h>
+#include <string.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/entropy.h>
+#include <zephyr/drivers/mfd/ateccx08.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(entropy_ateccx08, CONFIG_ENTROPY_LOG_LEVEL);
+
+#define ATECCX08_RANDOM_SIZE 32
+
+struct entropy_ateccx08_config {
+	const struct device *parent;
+};
+
+struct entropy_ateccx08_data {
+	uint8_t random_buffer[ATECCX08_RANDOM_SIZE];
+	size_t buffer_remaining;
+	struct k_sem sem_lock;
+};
+
+static int entropy_ateccx08_get_entropy(const struct device *dev, uint8_t *buffer, uint16_t length)
+{
+	const struct entropy_ateccx08_config *config = dev->config;
+	struct entropy_ateccx08_data *dev_data = dev->data;
+
+	int ret = 0;
+
+	if (atecc_is_locked_config(config->parent) == false) {
+		LOG_ERR("Config not locked, no random data available.");
+		return -EPERM;
+	}
+
+	k_sem_take(&dev_data->sem_lock, K_FOREVER);
+
+	if (dev_data->buffer_remaining > 0) {
+		size_t to_copy = MIN(length, dev_data->buffer_remaining);
+		uint8_t *pos = dev_data->random_buffer + sizeof(dev_data->random_buffer) -
+			       dev_data->buffer_remaining;
+
+		memcpy(buffer, pos, to_copy);
+		buffer += to_copy;
+		length -= to_copy;
+		dev_data->buffer_remaining -= to_copy;
+	}
+
+	while (length > 0) {
+		size_t to_copy;
+
+		ret = atecc_random(config->parent, dev_data->random_buffer, true);
+		if (ret < 0) {
+			goto exit;
+		}
+
+		to_copy = MIN(length, sizeof(dev_data->random_buffer));
+
+		memcpy(buffer, dev_data->random_buffer, to_copy);
+		buffer += to_copy;
+		length -= to_copy;
+		dev_data->buffer_remaining = sizeof(dev_data->random_buffer) - to_copy;
+	}
+
+exit:
+	k_sem_give(&dev_data->sem_lock);
+	return ret;
+}
+
+static int entropy_ateccx08_init(const struct device *dev)
+{
+	const struct entropy_ateccx08_config *config = dev->config;
+	struct entropy_ateccx08_data *dev_data = dev->data;
+
+	if (!device_is_ready(config->parent)) {
+		return -ENODEV;
+	}
+
+	k_sem_init(&dev_data->sem_lock, 1, 1);
+
+	return 0;
+}
+
+static const struct entropy_driver_api entropy_ateccx08_api = {
+	.get_entropy = entropy_ateccx08_get_entropy};
+
+BUILD_ASSERT(CONFIG_ENTROPY_ATECCX08_INIT_PRIORITY >= CONFIG_MFD_ATECCX08_INIT_PRIORITY,
+	     "ATECCX08 entropy driver must be initialized after the mfd driver");
+
+#define DEFINE_ATECCX08_ENTROPY(_num)                                                              \
+	static const struct entropy_ateccx08_config entropy_ateccx08_config##_num = {              \
+		.parent = DEVICE_DT_GET(DT_INST_BUS(_num))};                                       \
+	static struct entropy_ateccx08_data entropy_ateccx08_data##_num;                           \
+	DEVICE_DT_INST_DEFINE(_num, entropy_ateccx08_init, NULL, &entropy_ateccx08_data##_num,     \
+			      &entropy_ateccx08_config##_num, POST_KERNEL,                         \
+			      CONFIG_ENTROPY_ATECCX08_INIT_PRIORITY, &entropy_ateccx08_api);
+
+DT_INST_FOREACH_STATUS_OKAY(DEFINE_ATECCX08_ENTROPY);

--- a/drivers/mfd/CMakeLists.txt
+++ b/drivers/mfd/CMakeLists.txt
@@ -16,3 +16,5 @@ zephyr_library_sources_ifdef(CONFIG_MFD_MAX31790 mfd_max31790.c)
 zephyr_library_sources_ifdef(CONFIG_NXP_LP_FLEXCOMM mfd_nxp_lp_flexcomm.c)
 zephyr_library_sources_ifdef(CONFIG_MFD_BD8LB600FS mfd_bd8lb600fs.c)
 zephyr_library_sources_ifdef(CONFIG_MFD_TLE9104 mfd_tle9104.c)
+
+add_subdirectory_ifdef(CONFIG_MFD_ATECCX08 ateccx08)

--- a/drivers/mfd/Kconfig
+++ b/drivers/mfd/Kconfig
@@ -30,4 +30,6 @@ source "drivers/mfd/Kconfig.npm6001"
 source "drivers/mfd/Kconfig.lpflexcomm"
 source "drivers/mfd/Kconfig.tle9104"
 
+source "drivers/mfd/ateccx08/Kconfig"
+
 endif # MFD

--- a/drivers/mfd/ateccx08/CMakeLists.txt
+++ b/drivers/mfd/ateccx08/CMakeLists.txt
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library_sources(mfd_ateccx08.c)
+zephyr_library_sources(atecc_basic.c)
+zephyr_library_sources(atecc_execution.c)
+zephyr_library_sources(atecc_random.c)
+zephyr_library_sources(atecc_read.c)
+zephyr_library_sources(atecc_write.c)
+zephyr_library_sources(atecc_info.c)
+zephyr_library_sources(atecc_lock.c)

--- a/drivers/mfd/ateccx08/Kconfig
+++ b/drivers/mfd/ateccx08/Kconfig
@@ -1,0 +1,43 @@
+# Microchip ATECCx08 MFD
+
+# Copyright (c) 2024 Vogl Electronic GmbH
+# SPDX-License-Identifier: Apache-2.0
+
+config MFD_ATECCX08
+	bool
+	help
+	  Enable support for Microchip ATECCx08 I2C CRYPTOs.
+
+config MFD_ATECC608
+	bool "Microchip ATECC608 I2C CRYPTO support"
+	default y
+	depends on DT_HAS_MICROCHIP_ATECC608_ENABLED
+	select I2C
+	select MFD_ATECCX08
+	help
+	  Enable support for Microchip ATECC608 I2C CRYPTOs.
+
+config MFD_ATECC508
+	bool "Microchip ATECC508 I2C CRYPTO support"
+	default y
+	depends on DT_HAS_MICROCHIP_ATECC508_ENABLED
+	select I2C
+	select MFD_ATECCX08
+	help
+	  Enable support for Microchip ATECC508 I2C CRYPTOs.
+
+if MFD_ATECCX08
+
+config MFD_ATECCX08_INIT_PRIORITY
+	int "Microchip ATECCx08 Initialization priority"
+	default 55
+	help
+	  This option enables the Microchip ATECCx08 eeprom driver OTP.
+
+config MFD_ATECCX08_SUBDEVICE_INIT_PRIORITY
+	int "Microchip ATECCx08 subdevice Initialization priority"
+	default 56
+	help
+	  This option enables the Microchip ATECCx08 eeprom driver OTP.
+
+endif

--- a/drivers/mfd/ateccx08/atecc_basic.c
+++ b/drivers/mfd/ateccx08/atecc_basic.c
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2024 Vogl Electronic GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "atecc_priv.h"
+LOG_MODULE_DECLARE(ateccx08);
+
+void atecc_crc(size_t length, const uint8_t *data, uint8_t *crc_le)
+{
+	size_t counter;
+	uint16_t crc_register = 0;
+	uint16_t polynom = 0x8005U;
+	uint8_t shift_register;
+	uint8_t data_bit, crc_bit;
+
+	for (counter = 0; counter < length; counter++) {
+		for (shift_register = 0x01; shift_register > 0x00; shift_register <<= 1) {
+			data_bit = ((data[counter] & shift_register) != 0) ? 1 : 0;
+			crc_bit = (uint8_t)(crc_register >> 15);
+			crc_register <<= 1;
+			if (data_bit != crc_bit) {
+				crc_register ^= polynom;
+			}
+		}
+	}
+	sys_put_le16(crc_register, crc_le);
+}
+
+static void atecc_calc_crc(struct ateccx08_packet *packet)
+{
+	const uint8_t length = packet->txsize - ATECC_CRC_SIZE;
+	uint8_t *crc = &packet->data[length - (ATECC_CMD_SIZE_MIN - ATECC_CRC_SIZE)];
+
+	packet->param2 = sys_cpu_to_le16(packet->param2);
+	atecc_crc(length, &(packet->txsize), crc);
+}
+
+int atecc_check_crc(const uint8_t *response)
+{
+	const uint8_t count = response[ATECC_COUNT_IDX] - ATECC_CRC_SIZE;
+	uint8_t crc[ATECC_CRC_SIZE];
+
+	atecc_crc(count, response, crc);
+
+	if (memcmp(crc, &response[count], ATECC_CRC_SIZE) == 0) {
+		return 0;
+	}
+	return -EBADMSG;
+}
+
+static int atecc_check_wake(const uint8_t *response)
+{
+	const uint8_t expected_response[4] = {0x04, 0x11, 0x33, 0x43};
+	const uint8_t selftest_fail_resp[4] = {0x04, 0x07, 0xC4, 0x40};
+
+	if (memcmp(response, expected_response, 4) == 0) {
+		return 0;
+	}
+	if (memcmp(response, selftest_fail_resp, 4) == 0) {
+		LOG_ERR("selftest failed");
+	}
+	return -EIO;
+}
+
+int atecc_wakeup(const struct device *dev)
+{
+	const struct ateccx08_config *cfg = dev->config;
+	struct ateccx08_data *dev_data = dev->data;
+	uint8_t second_byte = 0x01U;
+	uint16_t retries = cfg->retries;
+	uint32_t i2c_cfg_temp;
+	uint8_t wake[4];
+	int ret;
+
+	ret = i2c_get_config(cfg->i2c.bus, &i2c_cfg_temp);
+	if (ret < 0) {
+		i2c_cfg_temp = I2C_SPEED_SET(I2C_SPEED_STANDARD) | I2C_MODE_CONTROLLER;
+	}
+	if ((I2C_SPEED_GET(i2c_cfg_temp) != I2C_SPEED_STANDARD) || ret < 0) {
+		ret = i2c_configure(cfg->i2c.bus,
+				    I2C_SPEED_SET(I2C_SPEED_STANDARD) | I2C_MODE_CONTROLLER);
+		if (ret < 0) {
+			LOG_ERR("Failed to configure I2C: %d", ret);
+			return ret;
+		}
+	}
+
+	do {
+		(void)i2c_write(cfg->i2c.bus, (uint8_t *)&second_byte, sizeof(second_byte), 0x00);
+		k_busy_wait(cfg->wakedelay);
+
+		ret = i2c_read_dt(&cfg->i2c, wake, sizeof(wake));
+		if (ret < 0) {
+			continue;
+		}
+		ret = atecc_check_wake(wake);
+		if (ret < 0) {
+			continue;
+		} else {
+			dev_data->device_state = ATECC_DEVICE_STATE_ACTIVE;
+			break;
+		}
+	} while (retries-- > 0);
+
+	if (I2C_SPEED_GET(i2c_cfg_temp) != I2C_SPEED_STANDARD) {
+		(void)i2c_configure(cfg->i2c.bus, i2c_cfg_temp);
+	}
+
+	return ret;
+}
+
+int atecc_sleep(const struct device *dev)
+{
+	const struct ateccx08_config *cfg = dev->config;
+	struct ateccx08_data *dev_data = dev->data;
+	uint8_t command = ATECC_WA_SLEEP;
+	int ret;
+
+	ret = i2c_write_dt(&cfg->i2c, &command, 1);
+	if (ret < 0) {
+		LOG_ERR("%s: Failed to write to device: %d", __func__, ret);
+		dev_data->device_state = ATECC_DEVICE_STATE_UNKNOWN;
+		return ret;
+	}
+	dev_data->device_state = ATECC_DEVICE_STATE_SLEEP;
+	return ret;
+}
+
+int atecc_idle(const struct device *dev)
+{
+	const struct ateccx08_config *cfg = dev->config;
+	struct ateccx08_data *dev_data = dev->data;
+	uint8_t command = ATECC_WA_IDLE;
+	int ret;
+
+	ret = i2c_write_dt(&cfg->i2c, &command, 1);
+	if (ret < 0) {
+		LOG_ERR("%s: Failed to write to device: %d", __func__, ret);
+		dev_data->device_state = ATECC_DEVICE_STATE_UNKNOWN;
+		return ret;
+	}
+	dev_data->device_state = ATECC_DEVICE_STATE_IDLE;
+	return ret;
+}
+
+uint16_t atecc_get_addr(enum atecc_zone zone, uint8_t slot, uint8_t block, uint8_t offset)
+{
+	uint16_t addr = 0;
+
+	offset = offset & 0x07u;
+	switch (zone) {
+	case ATECC_ZONE_CONFIG:
+	case ATECC_ZONE_OTP:
+		addr = ((uint16_t)block) << 3;
+		addr |= offset;
+		break;
+
+	case ATECC_ZONE_DATA:
+		addr = ((uint16_t)slot) << 3;
+		addr |= offset;
+		addr |= ((uint16_t)block) << 8;
+		break;
+
+	default:
+		break;
+	}
+
+	return addr;
+}
+
+uint16_t atecc_get_zone_size(enum atecc_zone zone, uint8_t slot)
+{
+	switch (zone) {
+	case ATECC_ZONE_CONFIG:
+		return 128;
+	case ATECC_ZONE_OTP:
+		return 64;
+	case ATECC_ZONE_DATA:
+		__ASSERT(slot < 16U, "Invalid slot: %d", slot);
+		if (slot < 8U) {
+			return 36;
+		}
+		if (slot == 8U) {
+			return 416;
+		}
+		if (slot < 16U) {
+			return 72;
+		}
+		break;
+
+	default:
+		__ASSERT(false, "Invalid zone");
+		break;
+	}
+
+	return 0;
+}
+
+void atecc_command(enum ateccx08_opcode opcode, struct ateccx08_packet *packet)
+{
+	switch (opcode) {
+	case ATECC_INFO:
+	case ATECC_LOCK:
+	case ATECC_RANDOM:
+	case ATECC_READ:
+		packet->txsize = ATECC_CMD_SIZE_MIN;
+		break;
+
+	case ATECC_WRITE:
+		packet->txsize = ATECC_CMD_SIZE_MIN;
+
+		if ((packet->param1 & ATECC_ZONE_READWRITE_32) == ATECC_ZONE_READWRITE_32) {
+			packet->txsize += ATECC_BLOCK_SIZE;
+		} else {
+			packet->txsize += ATECC_WORD_SIZE;
+		}
+		break;
+
+	default:
+		__ASSERT(false, "Invalid opcode");
+		return;
+	}
+
+	packet->opcode = opcode;
+	atecc_calc_crc(packet);
+}

--- a/drivers/mfd/ateccx08/atecc_execution.c
+++ b/drivers/mfd/ateccx08/atecc_execution.c
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2024 Vogl Electronic GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "atecc_priv.h"
+LOG_MODULE_DECLARE(ateccx08);
+
+static int atecc_is_error(uint8_t *data)
+{
+	if (data[0] == 0x04U) {
+		if (data[1] == 0x00U) {
+			return 0;
+		}
+		LOG_ERR("ATECC error: %02x", data[1]);
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static int atecc_execute_receive(const struct device *dev, uint8_t *rxdata, size_t rxlength)
+{
+	const struct ateccx08_config *cfg = dev->config;
+	int ret = 0;
+	uint16_t read_length = 1;
+
+	ret = i2c_read_dt(&cfg->i2c, rxdata, read_length);
+	if (ret < 0) {
+		return ret;
+	}
+
+	read_length = rxdata[0];
+
+	if (read_length > rxlength) {
+		LOG_DBG("Buffer too small to read");
+		return -ENOBUFS;
+	}
+
+	if (read_length < 4u) {
+		LOG_DBG("Invalid response length");
+		return -EIO;
+	}
+
+	read_length -= 1u;
+
+	ret = i2c_read_dt(&cfg->i2c, &rxdata[1], read_length);
+	if (ret < 0) {
+		LOG_ERR("Failed to read from device: %d", ret);
+		return ret;
+	}
+
+	return ret;
+}
+
+int atecc_execute_command(const struct device *dev, struct ateccx08_packet *packet)
+{
+	const struct ateccx08_config *cfg = dev->config;
+	struct ateccx08_data *dev_data = dev->data;
+	uint32_t max_delay_count = ATECC_POLLING_MAX_TIME_MSEC / ATECC_POLLING_FREQUENCY_TIME_MSEC;
+	uint16_t retries = cfg->retries;
+	int ret;
+
+	packet->word_addr = ATECC_WA_CMD;
+
+	ret = k_mutex_lock(&dev_data->lock, K_FOREVER);
+	if (ret < 0) {
+		return ret;
+	}
+
+	do {
+		if (dev_data->device_state != ATECC_DEVICE_STATE_ACTIVE) {
+			(void)atecc_wakeup(dev);
+		}
+
+		ret = i2c_write_dt(&cfg->i2c, (uint8_t *)packet, (uint32_t)packet->txsize + 1u);
+		if (ret < 0) {
+			dev_data->device_state = ATECC_DEVICE_STATE_UNKNOWN;
+		} else {
+			dev_data->device_state = ATECC_DEVICE_STATE_ACTIVE;
+			break;
+		}
+	} while (retries-- > 0);
+
+	if (ret < 0) {
+		LOG_ERR("Failed to write to device: %d", ret);
+		goto execute_command_exit;
+	}
+
+	k_busy_wait(ATECC_POLLING_INIT_TIME_MSEC * USEC_PER_MSEC);
+
+	do {
+		(void)memset(packet->data, 0, sizeof(packet->data));
+		/* receive the response */
+		ret = atecc_execute_receive(dev, packet->data, sizeof(packet->data));
+		if (ret == 0) {
+			break;
+		}
+		LOG_DBG("try receive response again: %d", ret);
+		k_busy_wait(ATECC_POLLING_FREQUENCY_TIME_MSEC * USEC_PER_MSEC);
+	} while (max_delay_count-- > 0);
+
+	(void)atecc_idle(dev);
+
+execute_command_exit:
+	k_mutex_unlock(&dev_data->lock);
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = atecc_check_crc(packet->data);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return atecc_is_error(packet->data);
+}

--- a/drivers/mfd/ateccx08/atecc_info.c
+++ b/drivers/mfd/ateccx08/atecc_info.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024 Vogl Electronic GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "atecc_priv.h"
+LOG_MODULE_DECLARE(ateccx08);
+
+#define INFO_MODE_REVISION 0x00U
+
+static int atecc_info_base(const struct device *dev, uint8_t mode, uint16_t param2,
+			   uint8_t *out_data)
+{
+	__ASSERT(dev != NULL, "device is NULL");
+	__ASSERT(out_data != NULL, "out_data is NULL");
+
+	struct ateccx08_packet packet = {0};
+	int ret;
+
+	packet.param1 = mode;
+	packet.param2 = param2;
+
+	atecc_command(ATECC_INFO, &packet);
+
+	ret = atecc_execute_command_pm(dev, &packet);
+	if (ret < 0) {
+		LOG_ERR("%s: failed: %d", __func__, ret);
+		return ret;
+	}
+
+	memcpy(out_data, &packet.data[ATECC_RSP_DATA_IDX], 4);
+
+	return ret;
+}
+
+int atecc_info(const struct device *dev, uint8_t *revision)
+{
+	__ASSERT(revision != NULL, "revision is NULL");
+
+	return atecc_info_base(dev, INFO_MODE_REVISION, 0, revision);
+}

--- a/drivers/mfd/ateccx08/atecc_lock.c
+++ b/drivers/mfd/ateccx08/atecc_lock.c
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2024 Vogl Electronic GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "atecc_priv.h"
+LOG_MODULE_DECLARE(ateccx08);
+
+#define LOCK_ZONE_CONFIG 0x00U
+#define LOCK_ZONE_DATA   0x01U
+#define LOCK_ZONE_NO_CRC 0x80U
+#define ATECC_UNLOCKED   0x55U
+
+static int atecc_lock(const struct device *dev, uint8_t mode, uint16_t summary_crc)
+{
+	__ASSERT(dev != NULL, "device is NULL");
+
+	struct ateccx08_packet packet = {0};
+	int ret;
+
+	packet.param1 = mode;
+	packet.param2 = summary_crc;
+
+	atecc_command(ATECC_LOCK, &packet);
+
+	ret = atecc_execute_command_pm(dev, &packet);
+	if (ret < 0) {
+		LOG_ERR("%s: failed: %d", __func__, ret);
+		return ret;
+	}
+
+	atecc_update_lock(dev);
+
+	return 0;
+}
+
+int atecc_lock_zone(const struct device *dev, enum atecc_zone zone)
+{
+	switch (zone) {
+	case ATECC_ZONE_CONFIG:
+		return atecc_lock(dev, LOCK_ZONE_NO_CRC | LOCK_ZONE_CONFIG, 0);
+
+	case ATECC_ZONE_OTP:
+	case ATECC_ZONE_DATA:
+		return atecc_lock(dev, LOCK_ZONE_NO_CRC | LOCK_ZONE_DATA, 0);
+
+	default:
+		return -EINVAL;
+	}
+}
+
+int atecc_lock_zone_crc(const struct device *dev, enum atecc_zone zone, uint16_t summary_crc)
+{
+	switch (zone) {
+	case ATECC_ZONE_CONFIG:
+		return atecc_lock(dev, LOCK_ZONE_CONFIG, summary_crc);
+
+	case ATECC_ZONE_OTP:
+	case ATECC_ZONE_DATA:
+		return atecc_lock(dev, LOCK_ZONE_DATA, summary_crc);
+
+	default:
+		return -EINVAL;
+	}
+}
+
+void atecc_update_lock(const struct device *dev)
+{
+	__ASSERT(dev != NULL, "device is NULL");
+
+	struct ateccx08_data *dev_data = dev->data;
+	uint8_t data_lock[2];
+	int ret;
+
+	ret = atecc_read_bytes(dev, ATECC_ZONE_CONFIG, 0, 86, data_lock, sizeof(data_lock));
+	if (ret < 0) {
+		LOG_ERR("%s: failed: %d", __func__, ret);
+		return;
+	}
+
+	if (data_lock[0] == ATECC_UNLOCKED) {
+		dev_data->is_locked_data = false;
+	} else {
+		dev_data->is_locked_data = true;
+	}
+
+	if (data_lock[1] == ATECC_UNLOCKED) {
+		dev_data->is_locked_config = false;
+	} else {
+		dev_data->is_locked_config = true;
+	}
+}
+
+bool atecc_is_locked_config(const struct device *dev)
+{
+	__ASSERT(dev != NULL, "device is NULL");
+
+	struct ateccx08_data *data = dev->data;
+
+	return data->is_locked_config;
+}
+
+bool atecc_is_locked_data(const struct device *dev)
+{
+	__ASSERT(dev != NULL, "device is NULL");
+
+	struct ateccx08_data *data = dev->data;
+
+	return data->is_locked_data;
+}

--- a/drivers/mfd/ateccx08/atecc_priv.h
+++ b/drivers/mfd/ateccx08/atecc_priv.h
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2024 Vogl Electronic GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ATECC_PRIV_H_
+#define ATECC_PRIV_H_
+
+#include <zephyr/drivers/mfd/ateccx08.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/kernel.h>
+
+#define LOG_LEVEL CONFIG_EEPROM_LOG_LEVEL
+#include <zephyr/logging/log.h>
+
+enum ateccx08_opcode {
+	ATECC_AES = 0x51U,
+	ATECC_CHECKMAC = 0x28U,
+	ATECC_COUNTER = 0x24U,
+	ATECC_ECDH = 0x43U,
+	ATECC_GENDIG = 0x15U,
+	ATECC_GENKEY = 0x40U,
+	ATECC_INFO = 0x30U,
+	ATECC_KDF = 0x56U,
+	ATECC_LOCK = 0x17U,
+	ATECC_MAC = 0x08U,
+	ATECC_NONCE = 0x16U,
+	ATECC_RANDOM = 0x1BU,
+	ATECC_READ = 0x02U,
+	ATECC_SELFTEST = 0x77U,
+	ATECC_SIGN = 0x41U,
+	ATECC_SHA = 0x47U,
+	ATECC_UPDATE_EXTRA = 0x20U,
+	ATECC_VERIFY = 0x45U,
+	ATECC_WRITE = 0x12U,
+};
+
+#define ATECC_BLOCK_SIZE                  32U
+#define ATECC_CMD_SIZE_MIN                7U
+#define ATECC_COUNT_IDX                   0U
+#define ATECC_COUNT_SIZE                  1U
+#define ATECC_CRC_SIZE                    2U
+#define ATECC_MAX_PACKET_SIZE             41U
+#define ATECC_PACKET_OVERHEAD             (ATECC_COUNT_SIZE + ATECC_CRC_SIZE)
+#define ATECC_POLLING_INIT_TIME_MSEC      1U
+#define ATECC_POLLING_FREQUENCY_TIME_MSEC 2U
+#define ATECC_POLLING_MAX_TIME_MSEC       2500U
+#define ATECC_RSP_DATA_IDX                1U
+#define ATECC_WA_RESET                    0U
+#define ATECC_WA_SLEEP                    1U
+#define ATECC_WA_IDLE                     2U
+#define ATECC_WA_CMD                      3U
+#define ATECC_WORD_SIZE                   4U
+#define ATECC_ZONE_READWRITE_32           0x80U
+
+typedef enum {
+	ATECC_DEVICE_STATE_UNKNOWN = 0,
+	ATECC_DEVICE_STATE_SLEEP,
+	ATECC_DEVICE_STATE_IDLE,
+	ATECC_DEVICE_STATE_ACTIVE
+} ateccx08_device_state;
+
+struct ateccx08_packet {
+	uint8_t word_addr;
+	uint8_t txsize;
+	uint8_t opcode;
+	uint8_t param1;
+	uint16_t param2;
+	uint8_t data[ATECC_MAX_PACKET_SIZE - 6];
+} __packed;
+
+struct ateccx08_config {
+	struct i2c_dt_spec i2c;
+	uint16_t wakedelay;
+	uint16_t retries;
+};
+
+struct ateccx08_data {
+	bool is_locked_config;
+	bool is_locked_data;
+	ateccx08_device_state device_state;
+	struct k_mutex lock;
+};
+
+int atecc_check_crc(const uint8_t *response);
+
+void atecc_command(enum ateccx08_opcode opcode, struct ateccx08_packet *packet);
+
+int atecc_wakeup(const struct device *dev);
+
+int atecc_sleep(const struct device *dev);
+
+int atecc_idle(const struct device *dev);
+
+int atecc_execute_command(const struct device *dev, struct ateccx08_packet *packet);
+
+uint16_t atecc_get_zone_size(enum atecc_zone zone, uint8_t slot);
+
+uint16_t atecc_get_addr(enum atecc_zone zone, uint8_t slot, uint8_t block, uint8_t offset);
+
+void atecc_update_lock(const struct device *dev);
+
+static inline int atecc_execute_command_pm(const struct device *dev, struct ateccx08_packet *packet)
+{
+	int ret;
+
+	pm_device_busy_set(dev);
+	ret = atecc_execute_command(dev, packet);
+	pm_device_busy_clear(dev);
+
+	return ret;
+}
+
+#endif /* ATECC_PRIV_H_ */

--- a/drivers/mfd/ateccx08/atecc_random.c
+++ b/drivers/mfd/ateccx08/atecc_random.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2024 Vogl Electronic GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "atecc_priv.h"
+LOG_MODULE_DECLARE(ateccx08);
+
+#define RANDOM_SEED_UPDATE    0x00U
+#define RANDOM_NO_SEED_UPDATE 0x01U
+#define RANDOM_NUM_SIZE       32U
+#define RANDOM_RSP_SIZE       35U
+
+int atecc_random(const struct device *dev, uint8_t *rand_out, bool update_seed)
+{
+	__ASSERT(dev != NULL, "device is NULL");
+	__ASSERT(rand_out != NULL, "rand_out is NULL");
+
+	struct ateccx08_packet packet = {0};
+	int ret;
+
+	packet.param1 = (update_seed ? RANDOM_SEED_UPDATE : RANDOM_NO_SEED_UPDATE);
+
+	atecc_command(ATECC_RANDOM, &packet);
+
+	ret = atecc_execute_command_pm(dev, &packet);
+	if (ret < 0) {
+		LOG_ERR("%s: failed: %d", __func__, ret);
+		return ret;
+	}
+
+	if (packet.data[ATECC_COUNT_IDX] != RANDOM_RSP_SIZE) {
+		LOG_ERR("Wrong response size");
+		return -EBADMSG;
+	}
+
+	memcpy(rand_out, &packet.data[ATECC_RSP_DATA_IDX], RANDOM_NUM_SIZE);
+
+	return 0;
+}

--- a/drivers/mfd/ateccx08/atecc_read.c
+++ b/drivers/mfd/ateccx08/atecc_read.c
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2024 Vogl Electronic GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "atecc_priv.h"
+LOG_MODULE_DECLARE(ateccx08);
+
+static int atecc_read(const struct device *dev, enum atecc_zone zone, uint8_t slot, uint8_t block,
+		      uint8_t offset, uint8_t *data, uint8_t len)
+{
+	__ASSERT(len == 4U || len == 32U, "Invalid length");
+
+	struct ateccx08_packet packet = {0};
+	int ret;
+
+	packet.param1 = (len == ATECC_BLOCK_SIZE) ? (zone | ATECC_ZONE_READWRITE_32) : zone;
+	packet.param2 = atecc_get_addr(zone, slot, block, offset);
+
+	atecc_command(ATECC_READ, &packet);
+
+	ret = atecc_execute_command(dev, &packet);
+	if (ret < 0) {
+		LOG_ERR("%s: failed: %d", __func__, ret);
+		return ret;
+	}
+
+	memcpy(data, &packet.data[1], len);
+
+	return ret;
+}
+
+int atecc_read_bytes(const struct device *dev, enum atecc_zone zone, uint8_t slot, uint16_t offset,
+		     uint8_t *data, uint16_t len)
+{
+	__ASSERT(dev != NULL, "device is NULL");
+	__ASSERT(data != NULL, "data is NULL");
+
+	struct ateccx08_data *dev_data = dev->data;
+	uint8_t buffer_idx = 0;
+	uint8_t buffer[ATECC_BLOCK_SIZE] = {0};
+	uint8_t copy_length;
+	uint8_t current_block;
+	uint8_t current_offset = 0;
+	uint16_t data_idx = 0;
+	uint16_t read_offset = 0;
+	uint8_t read_size = ATECC_BLOCK_SIZE;
+	uint16_t zone_size;
+	int ret = 0;
+
+	switch (zone) {
+	case ATECC_ZONE_CONFIG:
+		break;
+	case ATECC_ZONE_DATA:
+	case ATECC_ZONE_OTP:
+		if (!dev_data->is_locked_data) {
+			LOG_ERR("Data zones unlocked");
+			return -EPERM;
+		}
+		break;
+
+	default:
+		LOG_ERR("Invalid zone");
+		return -EINVAL;
+	}
+
+	zone_size = atecc_get_zone_size(zone, slot);
+
+	if ((offset + len) > zone_size) {
+		LOG_WRN("attempt to read past zone boundary");
+		return -EINVAL;
+	}
+
+	current_block = offset / ATECC_BLOCK_SIZE;
+
+	if (len <= ATECC_WORD_SIZE &&
+	    ((offset / ATECC_WORD_SIZE) == ((offset + len - 1) / ATECC_WORD_SIZE))) {
+		read_size = ATECC_WORD_SIZE;
+		current_offset = (offset / ATECC_WORD_SIZE) % (ATECC_BLOCK_SIZE / ATECC_WORD_SIZE);
+	}
+
+	pm_device_busy_set(dev);
+
+	while (data_idx < len) {
+		if (read_size == ATECC_BLOCK_SIZE &&
+		    zone_size - (uint16_t)current_block * ATECC_BLOCK_SIZE < ATECC_BLOCK_SIZE) {
+			/* Switch to word reads */
+			read_size = ATECC_WORD_SIZE;
+			current_offset = ((data_idx + offset) / ATECC_WORD_SIZE) %
+					 (ATECC_BLOCK_SIZE / ATECC_WORD_SIZE);
+		}
+
+		ret = atecc_read(dev, zone, slot, current_block, current_offset, buffer, read_size);
+		if (ret < 0) {
+			LOG_ERR("Reading zone failed: %d", ret);
+			goto atecc_read_bytes_end;
+		}
+
+		read_offset = (uint16_t)current_block * ATECC_BLOCK_SIZE +
+			      (uint16_t)current_offset * ATECC_WORD_SIZE;
+
+		buffer_idx = (read_offset < offset) ? offset - read_offset : 0;
+
+		copy_length = MIN(read_size - buffer_idx, len - data_idx);
+
+		memcpy(&data[data_idx], &buffer[buffer_idx], copy_length);
+		data_idx += copy_length;
+		if (read_size == ATECC_BLOCK_SIZE) {
+			current_block++;
+		} else {
+			current_offset++;
+		}
+	}
+
+atecc_read_bytes_end:
+	pm_device_busy_clear(dev);
+	return ret;
+}
+
+int atecc_read_serial_number(const struct device *dev, uint8_t *serial_number)
+{
+	__ASSERT(dev != NULL, "device is NULL");
+	__ASSERT(serial_number != NULL, "serial_number is NULL");
+
+	int ret;
+	uint8_t buffer[ATECC_BLOCK_SIZE];
+
+	pm_device_busy_set(dev);
+	ret = atecc_read(dev, ATECC_ZONE_CONFIG, 0, 0, 0, buffer, ATECC_BLOCK_SIZE);
+	pm_device_busy_clear(dev);
+	if (ret < 0) {
+		LOG_ERR("Reading serial number failed: %d", ret);
+		return ret;
+	}
+
+	memcpy(&serial_number[0], &buffer[0], 4);
+	memcpy(&serial_number[4], &buffer[8], 5);
+
+	return ret;
+}

--- a/drivers/mfd/ateccx08/atecc_write.c
+++ b/drivers/mfd/ateccx08/atecc_write.c
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2024 Vogl Electronic GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "atecc_priv.h"
+LOG_MODULE_DECLARE(ateccx08);
+
+#define WRITE_SKIP_CONFIG_BLOCK 2U
+#define WRITE_SKIP_CONFIG_WORD  5U
+#define WRITE_SKIP_CONFIG_BYTES 16U
+
+static int atecc_write(const struct device *dev, enum atecc_zone zone, uint8_t slot, uint8_t block,
+		       uint8_t offset, const uint8_t *data, uint8_t len)
+{
+	__ASSERT(len == 4U || len == 32U, "Invalid length");
+
+	struct ateccx08_packet packet = {0};
+	int ret;
+
+	packet.param1 = (len == ATECC_BLOCK_SIZE) ? (zone | ATECC_ZONE_READWRITE_32) : zone;
+	packet.param2 = atecc_get_addr(zone, slot, block, offset);
+
+	memcpy(packet.data, data, len);
+
+	atecc_command(ATECC_WRITE, &packet);
+
+	ret = atecc_execute_command(dev, &packet);
+	if (ret < 0) {
+		LOG_ERR("%s: failed: %d", __func__, ret);
+	}
+
+	return ret;
+}
+
+int atecc_write_bytes(const struct device *dev, enum atecc_zone zone, uint8_t slot,
+		      uint16_t offset_bytes, const uint8_t *data, uint16_t len)
+{
+	__ASSERT(dev != NULL, "device is NULL");
+	__ASSERT(data != NULL, "data is NULL");
+
+	if (offset_bytes % ATECC_WORD_SIZE != 0 || len % ATECC_WORD_SIZE != 0) {
+		LOG_ERR("Invalid length/offset");
+		return -EINVAL;
+	}
+
+	struct ateccx08_data *dev_data = dev->data;
+	uint8_t current_block = offset_bytes / ATECC_BLOCK_SIZE;
+	uint8_t current_word = (offset_bytes % ATECC_BLOCK_SIZE) / ATECC_WORD_SIZE;
+	size_t data_idx = 0;
+	int ret = 0;
+
+	switch (zone) {
+	case ATECC_ZONE_CONFIG:
+		if (dev_data->is_locked_config) {
+			LOG_ERR("Config zone locked");
+			return -EPERM;
+		}
+		break;
+
+	case ATECC_ZONE_DATA:
+	case ATECC_ZONE_OTP:
+		if (!dev_data->is_locked_config) {
+			LOG_ERR("Config zone unlocked");
+			return -EPERM;
+		} else if (dev_data->is_locked_data) {
+			LOG_ERR("Data zones locked");
+			return -EPERM;
+		}
+		break;
+
+	default:
+		LOG_ERR("Invalid zone");
+		return -EINVAL;
+	}
+
+	if (offset_bytes + len > atecc_get_zone_size(zone, slot)) {
+		LOG_WRN("attempt to write past zone boundary");
+		return -EINVAL;
+	}
+
+	pm_device_busy_set(dev);
+	while (data_idx < len) {
+		if (current_word == 0 && len - data_idx >= ATECC_BLOCK_SIZE &&
+		    !(zone == ATECC_ZONE_CONFIG && current_block == WRITE_SKIP_CONFIG_BLOCK)) {
+			ret = atecc_write(dev, zone, slot, current_block, 0, &data[data_idx],
+					  ATECC_BLOCK_SIZE);
+			if (ret < 0) {
+				goto atecc_write_bytes_end;
+			}
+			data_idx += ATECC_BLOCK_SIZE;
+			current_block++;
+		} else {
+			/* Skip changing UserExtra, Selector, LockValue, and LockConfig */
+			if (!(zone == ATECC_ZONE_CONFIG &&
+			      current_block == WRITE_SKIP_CONFIG_BLOCK &&
+			      current_word == WRITE_SKIP_CONFIG_WORD)) {
+				ret = atecc_write(dev, zone, slot, current_block, current_word,
+						  &data[data_idx], ATECC_WORD_SIZE);
+				if (ret < 0) {
+					goto atecc_write_bytes_end;
+				}
+			}
+			data_idx += ATECC_WORD_SIZE;
+			current_word++;
+			if (current_word == ATECC_BLOCK_SIZE / ATECC_WORD_SIZE) {
+				current_block++;
+				current_word = 0;
+			}
+		}
+	}
+
+atecc_write_bytes_end:
+	pm_device_busy_clear(dev);
+	return ret;
+}
+
+int atecc_write_config(const struct device *dev, const uint8_t *config_data)
+{
+	if (config_data == NULL) {
+		LOG_ERR("NULL pointer received");
+		return -EINVAL;
+	}
+
+	int ret;
+	uint16_t config_size = atecc_get_zone_size(ATECC_ZONE_CONFIG, 0);
+
+	ret = atecc_write_bytes(dev, ATECC_ZONE_CONFIG, 0, WRITE_SKIP_CONFIG_BYTES,
+				&config_data[WRITE_SKIP_CONFIG_BYTES],
+				config_size - WRITE_SKIP_CONFIG_BYTES);
+	if (ret < 0) {
+		LOG_ERR("Write config failed: %d", ret);
+	}
+
+	return ret;
+}

--- a/drivers/mfd/ateccx08/mfd_ateccx08.c
+++ b/drivers/mfd/ateccx08/mfd_ateccx08.c
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2024 Vogl Electronic GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Driver for Microchip ATECCX08 I2C MFD.
+ */
+#include <zephyr/kernel.h>
+
+#include "atecc_priv.h"
+LOG_MODULE_REGISTER(ateccx08);
+
+static int mfd_ateccx08_init(const struct device *dev)
+{
+	const struct ateccx08_config *config = dev->config;
+	struct ateccx08_data *data = dev->data;
+
+	k_mutex_init(&data->lock);
+
+	if (!device_is_ready(config->i2c.bus)) {
+		LOG_ERR("parent bus device not ready");
+		return -EINVAL;
+	}
+
+	atecc_update_lock(dev);
+
+	LOG_DBG("Config lock status: %d", data->is_locked_config);
+	LOG_DBG("Data lock status: %d", data->is_locked_data);
+
+	return 0;
+}
+
+#ifdef CONFIG_PM_DEVICE
+static int eeprom_ateccx08_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
+		(void)atecc_wakeup(dev);
+		return atecc_sleep(dev);
+
+	case PM_DEVICE_ACTION_RESUME:
+		(void)atecc_wakeup(dev);
+		return atecc_idle(dev);
+
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+#endif
+
+#define INST_DT_ATECCX08(inst, t) DT_INST(inst, microchip_atecc##t)
+
+#define MFD_ATECCX08_DEVICE(n, t)                                                                  \
+	static const struct ateccx08_config atecc##t##_config_##n = {                              \
+		.i2c = I2C_DT_SPEC_GET(INST_DT_ATECCX08(n, t)),                                    \
+		.wakedelay = DT_PROP(INST_DT_ATECCX08(n, t), wake_delay),                          \
+		.retries = DT_PROP(INST_DT_ATECCX08(n, t), retries)};                              \
+                                                                                                   \
+	static struct ateccx08_data atecc##t##_data_##n;                                           \
+                                                                                                   \
+	PM_DEVICE_DT_DEFINE(INST_DT_ATECCX08(n, t), eeprom_ateccx08_pm_action);                    \
+                                                                                                   \
+	DEVICE_DT_DEFINE(INST_DT_ATECCX08(n, t), &mfd_ateccx08_init,                               \
+			 PM_DEVICE_DT_GET(INST_DT_ATECCX08(n, t)), &atecc##t##_data_##n,           \
+			 &atecc##t##_config_##n, POST_KERNEL, CONFIG_MFD_ATECCX08_INIT_PRIORITY,   \
+			 NULL)
+
+#define MFD_ATECC608_DEVICE(n) MFD_ATECCX08_DEVICE(n, 608)
+#define MFD_ATECC508_DEVICE(n) MFD_ATECCX08_DEVICE(n, 508)
+
+#define CALL_WITH_ARG(arg, expr) expr(arg);
+
+#define INST_DT_ATECCX08_FOREACH(t, inst_expr)                                                     \
+	LISTIFY(DT_NUM_INST_STATUS_OKAY(microchip_atecc##t), CALL_WITH_ARG, (), inst_expr)
+
+#ifdef CONFIG_MFD_ATECC608
+INST_DT_ATECCX08_FOREACH(608, MFD_ATECC608_DEVICE);
+#endif
+
+#ifdef CONFIG_MFD_ATECC508
+INST_DT_ATECCX08_FOREACH(508, MFD_ATECC508_DEVICE);
+#endif

--- a/dts/bindings/mfd/microchip,atecc508.yaml
+++ b/dts/bindings/mfd/microchip,atecc508.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2024 Vogl Electronic GmbH
+# SPDX-License-Identifier: Apache-2.0
+
+description: Microchip ATECC508 I2C
+
+compatible: "microchip,atecc508"
+
+include: microchip,ateccx08-base.yaml

--- a/dts/bindings/mfd/microchip,atecc608.yaml
+++ b/dts/bindings/mfd/microchip,atecc608.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2024 Vogl Electronic GmbH
+# SPDX-License-Identifier: Apache-2.0
+
+description: Microchip ATECC608 I2C
+
+compatible: "microchip,atecc608"
+
+include: microchip,ateccx08-base.yaml

--- a/dts/bindings/mfd/microchip,ateccx08-base.yaml
+++ b/dts/bindings/mfd/microchip,ateccx08-base.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) 2024 Vogl Electronic GmbH
+# SPDX-License-Identifier: Apache-2.0
+
+include: [i2c-device.yaml]
+
+bus: ateccx08
+
+properties:
+  wake-delay:
+    type: int
+    description: Delay in us to wait for the device to wake up. 1500us is the
+      minimum value according to the datasheet.
+    default: 1500
+  retries:
+    type: int
+    description: number of retries for operations

--- a/dts/bindings/mtd/microchip,ateccx08-otp.yaml
+++ b/dts/bindings/mtd/microchip,ateccx08-otp.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2024 Vogl Electronic GmbH
+# SPDX-License-Identifier: Apache-2.0
+
+description: Microchip ATECCx08 otp binding
+
+compatible: "microchip,ateccx08-otp"
+
+include: [eeprom-base.yaml, base.yaml]
+
+on-bus: ateccx08

--- a/dts/bindings/rng/microchip,ateccx08-entropy.yaml
+++ b/dts/bindings/rng/microchip,ateccx08-entropy.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2024 Vogl Electronic GmbH
+# SPDX-License-Identifier: Apache-2.0
+
+description: Microchip ATECCx08 entropy binding
+
+compatible: "microchip,ateccx08-entropy"
+
+include: base.yaml
+
+on-bus: ateccx08

--- a/include/zephyr/drivers/eeprom/ateccx08.h
+++ b/include/zephyr/drivers/eeprom/ateccx08.h
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2024 Vogl Electronic GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_EEPROM_ATECCX08_H_
+#define ZEPHYR_INCLUDE_DRIVERS_EEPROM_ATECCX08_H_
+
+#include <zephyr/drivers/eeprom.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum atecc_zone {
+	ATECC_ZONE_CONFIG = 0x00U,
+	ATECC_ZONE_OTP = 0x01U,
+	ATECC_ZONE_DATA = 0x02U,
+};
+
+/**
+ * @brief Set the zone for the EEPROM device.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param zone Zone to set: ATECC_ZONE_CONFIG, ATECC_ZONE_OTP, or
+ *             ATECC_ZONE_DATA.
+ *
+ * @retval 0 on success
+ * @retval -EINVAL if zone is invalid
+ */
+int eeprom_ateccx08_set_zone(const struct device *dev, enum atecc_zone zone);
+
+/**
+ * @brief Set the slot for the EEPROM device.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param slot Slot to set.
+ *
+ * @retval 0 on success
+ * @retval -EINVAL if slot is invalid
+ */
+int eeprom_ateccx08_set_slot(const struct device *dev, uint8_t slot);
+
+/**
+ * @brief Calculates CRC over the given raw data and returns the CRC in
+ *        little-endian byte order.
+ *
+ * @param length Size of data not including the CRC byte positions
+ * @param data Pointer to the data over which to compute the CRC
+ * @param crc_le Pointer to the place where the two-bytes of CRC will be
+ *               returned in little-endian byte order.
+ */
+void atecc_crc(size_t length, const uint8_t *data, uint8_t *crc_le);
+
+/**
+ * @brief Use the Info command to get the device revision (DevRev).
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param revision Device revision is returned here (4 bytes).
+ *
+ * @return 0 on success, negative errno code on failure.
+ */
+int atecc_info(const struct device *dev, uint8_t *revision);
+
+/**
+ * @brief Unconditionally (no CRC required) lock a zone.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param zone Zone to lock. Option are ATECC_ZONE_CONFIG or ATECC_ZONE_DATA.
+ *
+ * @return 0 on success, negative errno code on failure.
+ */
+int atecc_lock_zone(const struct device *dev, enum atecc_zone zone);
+
+/**
+ * @brief Lock a zone with summary CRC.
+ * For the config zone, the CRC is calculated over the entire config zone contents (128 bytes)
+ * For the data zone (slots and OTP), the CRC is calculated over the entire data zone (slots and
+ * OTP) Lock will fail if the provided CRC doesn't match the internally calculated one.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param zone Zone to lock. Option are ATECC_ZONE_CONFIG or ATECC_ZONE_DATA
+ * @param summary_crc Expected CRC over the zone.
+ *
+ * @return 0 on success, negative errno code on failure.
+ */
+int atecc_lock_zone_crc(const struct device *dev, enum atecc_zone zone, uint16_t summary_crc);
+
+/**
+ * @brief Check the lock status of the configuration zone.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ *
+ * @retval true if the configuration zone is locked
+ * @retval false if the configuration zone is not locked
+ */
+bool atecc_is_locked_config(const struct device *dev);
+
+/**
+ * @brief Check the lock status of the data zones.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ *
+ * @retval true if the data zones are locked
+ * @retval false if the data zones are not locked
+ */
+bool atecc_is_locked_data(const struct device *dev);
+
+/**
+ * @brief Executes Random command, which generates a 32 byte random number
+ *        from the device.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param rand_out 32 bytes of random data is returned here.
+ * @param update_seed If true, the seed will be updated.
+ *
+ * @return 0 on success, negative errno code on failure.
+ */
+int atecc_random(const struct device *dev, uint8_t *rand_out, bool update_seed);
+
+/**
+ * @brief Executes Read command, which reads the 9 byte serial number of the
+ *        device from the config zone.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param serial_number  9 byte serial number is returned here.
+ *
+ * @return 0 on success, negative errno code on failure.
+ */
+int atecc_read_serial_number(const struct device *dev, uint8_t *serial_number);
+
+/**
+ * @brief Used to read an arbitrary number of bytes from any zone configured
+ *        for clear reads.
+ *
+ * This function will issue the Read command as many times as is required to
+ * read the requested data.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param zone Zone to read data from. Option are ATECC_ZONE_CONFIG,
+ *             ATECC_ZONE_OTP, or ATECC_ZONE_DATA.
+ * @param slot Slot number to read from if zone is ATECC_ZONE_DATA.
+ *             Ignored for all other zones.
+ * @param offset Byte offset within the zone to read from.
+ * @param data Read data is returned here.
+ * @param len Number of bytes to read starting from the offset.
+ *
+ * @return 0 on success, negative errno code on failure.
+ */
+int atecc_read_bytes(const struct device *dev, enum atecc_zone zone, uint8_t slot, uint16_t offset,
+		     uint8_t *data, uint16_t len);
+
+/**
+ * @brief Executes the Write command, which writes data into the
+ * configuration, otp, or data zones with a given byte offset and
+ * length. Offset and length must be multiples of a word (4 bytes).
+ *
+ * Config zone must be unlocked for writes to that zone. If data zone is
+ * unlocked, only 32-byte writes are allowed to slots and OTP and the offset
+ * and length must be multiples of 32 or the write will fail.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param zone Zone to write data to: ATECC_ZONE_CONFIG,
+ *             ATECC_ZONE_OTP, or ATECC_ZONE_DATA.
+ * @param slot If zone is ATECC_ZONE_DATA, the slot number to
+ *             write to. Ignored for all other zones.
+ * @param offset_bytes Byte offset within the zone to write to. Must be
+ *                     a multiple of a word (4 bytes).
+ * @param data Data to be written.
+ * @param len Number of bytes to be written. Must be a multiple
+ *            of a word (4 bytes).
+ *
+ * @return 0 on success, negative errno code on failure.
+ */
+int atecc_write_bytes(const struct device *dev, enum atecc_zone zone, uint8_t slot,
+		      uint16_t offset_bytes, const uint8_t *data, uint16_t len);
+
+/**
+ * @brief Executes the Write command, which writes the configuration zone.
+ *
+ * First 16 bytes are skipped as they are not writable. LockValue and
+ * LockConfig are also skipped.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param config_data  Data to the config zone data. This should be 128 bytes.
+ *
+ * @return 0 on success, negative errno code on failure.
+ */
+int atecc_write_config(const struct device *dev, const uint8_t *config_data);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_EEPROM_ATECCX08_H_ */

--- a/include/zephyr/drivers/mfd/ateccx08.h
+++ b/include/zephyr/drivers/mfd/ateccx08.h
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2024 Vogl Electronic GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_MFD_ATECCX08_H_
+#define ZEPHYR_INCLUDE_DRIVERS_MFD_ATECCX08_H_
+
+#include <zephyr/types.h>
+#include <zephyr/device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum atecc_zone {
+	ATECC_ZONE_CONFIG = 0x00U,
+	ATECC_ZONE_OTP = 0x01U,
+	ATECC_ZONE_DATA = 0x02U,
+};
+
+/**
+ * @brief Set the zone for the EEPROM device.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param zone Zone to set: ATECC_ZONE_CONFIG, ATECC_ZONE_OTP, or
+ *             ATECC_ZONE_DATA.
+ *
+ * @retval 0 on success
+ * @retval -EINVAL if zone is invalid
+ */
+int eeprom_ateccx08_set_zone(const struct device *dev, enum atecc_zone zone);
+
+/**
+ * @brief Set the slot for the EEPROM device.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param slot Slot to set.
+ *
+ * @retval 0 on success
+ * @retval -EINVAL if slot is invalid
+ */
+int eeprom_ateccx08_set_slot(const struct device *dev, uint8_t slot);
+
+uint16_t atecc_get_zone_size(enum atecc_zone zone, uint8_t slot);
+
+/**
+ * @brief Calculates CRC over the given raw data and returns the CRC in
+ *        little-endian byte order.
+ *
+ * @param length Size of data not including the CRC byte positions
+ * @param data Pointer to the data over which to compute the CRC
+ * @param crc_le Pointer to the place where the two-bytes of CRC will be
+ *               returned in little-endian byte order.
+ */
+void atecc_crc(size_t length, const uint8_t *data, uint8_t *crc_le);
+
+/**
+ * @brief Use the Info command to get the device revision (DevRev).
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param revision Device revision is returned here (4 bytes).
+ *
+ * @return 0 on success, negative errno code on failure.
+ */
+int atecc_info(const struct device *dev, uint8_t *revision);
+
+/**
+ * @brief Unconditionally (no CRC required) lock a zone.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param zone Zone to lock. Option are ATECC_ZONE_CONFIG or ATECC_ZONE_DATA.
+ *
+ * @return 0 on success, negative errno code on failure.
+ */
+int atecc_lock_zone(const struct device *dev, enum atecc_zone zone);
+
+/**
+ * @brief Lock a zone with summary CRC.
+ * For the config zone, the CRC is calculated over the entire config zone contents (128 bytes)
+ * For the data zone (slots and OTP), the CRC is calculated over the entire data zone (slots and
+ * OTP) Lock will fail if the provided CRC doesn't match the internally calculated one.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param zone Zone to lock. Option are ATECC_ZONE_CONFIG or ATECC_ZONE_DATA
+ * @param summary_crc Expected CRC over the zone.
+ *
+ * @return 0 on success, negative errno code on failure.
+ */
+int atecc_lock_zone_crc(const struct device *dev, enum atecc_zone zone, uint16_t summary_crc);
+
+/**
+ * @brief Check the lock status of the configuration zone.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ *
+ * @retval true if the configuration zone is locked
+ * @retval false if the configuration zone is not locked
+ */
+bool atecc_is_locked_config(const struct device *dev);
+
+/**
+ * @brief Check the lock status of the data zones.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ *
+ * @retval true if the data zones are locked
+ * @retval false if the data zones are not locked
+ */
+bool atecc_is_locked_data(const struct device *dev);
+
+/**
+ * @brief Executes Random command, which generates a 32 byte random number
+ *        from the device.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param rand_out 32 bytes of random data is returned here.
+ * @param update_seed If true, the seed will be updated.
+ *
+ * @return 0 on success, negative errno code on failure.
+ */
+int atecc_random(const struct device *dev, uint8_t *rand_out, bool update_seed);
+
+/**
+ * @brief Executes Read command, which reads the 9 byte serial number of the
+ *        device from the config zone.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param serial_number  9 byte serial number is returned here.
+ *
+ * @return 0 on success, negative errno code on failure.
+ */
+int atecc_read_serial_number(const struct device *dev, uint8_t *serial_number);
+
+/**
+ * @brief Used to read an arbitrary number of bytes from any zone configured
+ *        for clear reads.
+ *
+ * This function will issue the Read command as many times as is required to
+ * read the requested data.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param zone Zone to read data from. Option are ATECC_ZONE_CONFIG,
+ *             ATECC_ZONE_OTP, or ATECC_ZONE_DATA.
+ * @param slot Slot number to read from if zone is ATECC_ZONE_DATA.
+ *             Ignored for all other zones.
+ * @param offset Byte offset within the zone to read from.
+ * @param data Read data is returned here.
+ * @param len Number of bytes to read starting from the offset.
+ *
+ * @return 0 on success, negative errno code on failure.
+ */
+int atecc_read_bytes(const struct device *dev, enum atecc_zone zone, uint8_t slot, uint16_t offset,
+		     uint8_t *data, uint16_t len);
+
+/**
+ * @brief Executes the Write command, which writes data into the
+ * configuration, otp, or data zones with a given byte offset and
+ * length. Offset and length must be multiples of a word (4 bytes).
+ *
+ * Config zone must be unlocked for writes to that zone. If data zone is
+ * unlocked, only 32-byte writes are allowed to slots and OTP and the offset
+ * and length must be multiples of 32 or the write will fail.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param zone Zone to write data to: ATECC_ZONE_CONFIG,
+ *             ATECC_ZONE_OTP, or ATECC_ZONE_DATA.
+ * @param slot If zone is ATECC_ZONE_DATA, the slot number to
+ *             write to. Ignored for all other zones.
+ * @param offset_bytes Byte offset within the zone to write to. Must be
+ *                     a multiple of a word (4 bytes).
+ * @param data Data to be written.
+ * @param len Number of bytes to be written. Must be a multiple
+ *            of a word (4 bytes).
+ *
+ * @return 0 on success, negative errno code on failure.
+ */
+int atecc_write_bytes(const struct device *dev, enum atecc_zone zone, uint8_t slot,
+		      uint16_t offset_bytes, const uint8_t *data, uint16_t len);
+
+/**
+ * @brief Executes the Write command, which writes the configuration zone.
+ *
+ * First 16 bytes are skipped as they are not writable. LockValue and
+ * LockConfig are also skipped.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param config_data  Data to the config zone data. This should be 128 bytes.
+ *
+ * @return 0 on success, negative errno code on failure.
+ */
+int atecc_write_config(const struct device *dev, const uint8_t *config_data);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_MFD_ATECCX08_H_ */


### PR DESCRIPTION
This adds support for the Microchip ATECC608 (and ATECC508) to be used as a eeprom. It also provides a driver to use it as a entropy source. 

The code is mainly adapted from the [Microchip cryptoauthlib](https://github.com/MicrochipTech/cryptoauthlib)

In the future it might also be extended to be used with the Crypto API.