### PR TITLE
arch: xtensa: add isync to interrupt vector

### DIFF
--- a/arch/xtensa/include/xtensa_asm2_s.h
+++ b/arch/xtensa/include/xtensa_asm2_s.h
@@ -604,6 +604,11 @@ _Level\LVL\()Vector:
 	s32i a2, a1, ___xtensa_irq_bsa_t_a2_OFFSET
 	s32i a3, a1, ___xtensa_irq_bsa_t_a3_OFFSET
 
+#ifdef CONFIG_ADSP_IDLE_CLOCK_GATING
+	/* Needed when waking from low-power waiti state */
+	isync
+#endif
+
 	/* Level "1" is the exception handler, which uses a different
 	 * calling convention.  No special register holds the
 	 * interrupted PS, instead we just assume that the CPU has


### PR DESCRIPTION
On Intel ADSP platforms, additional "isync" is needed in interrupt vector to synchronize icache when core is woken up from deeper sleep state by an interrupt. This is only needed if DSP clock gating is enabled.