### PR TITLE
boards: nordic: Add to GRTC missing child-owned-channels allocation

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
@@ -61,8 +61,6 @@
 &grtc {
 	status = "okay";
 	child-owned-channels = <8 9 10 11 12>;
-	interrupts = <109 NRF_DEFAULT_IRQ_PRIORITY>,
-		     <108 NRF_DEFAULT_IRQ_PRIORITY>;
 	nonsecure-channels = <8 9 10 11 12>;
 	owned-channels = <7 8 9 10 11 12 13 14>;
 };

--- a/dts/arm/nordic/nrf54h20_cpurad.dtsi
+++ b/dts/arm/nordic/nrf54h20_cpurad.dtsi
@@ -47,5 +47,6 @@ cpuppr_vevif: &cpuppr_vevif_remote {};
 };
 
 &grtc {
-	interrupts = <109 NRF_DEFAULT_IRQ_PRIORITY>;
+	interrupts = <109 NRF_DEFAULT_IRQ_PRIORITY>,
+		     <108 NRF_DEFAULT_IRQ_PRIORITY>;
 };

--- a/dts/arm/nordic/nrf54l15_cpuapp_peripherals.dtsi
+++ b/dts/arm/nordic/nrf54l15_cpuapp_peripherals.dtsi
@@ -330,7 +330,9 @@ grtc: grtc@e2000 {
 	reg = <0xe2000 0x1000>;
 	cc-num = <12>;
 	owned-channels = <0 1 2 3 4 5 6 7 8 9 10 11>;
-	interrupts = <228 NRF_DEFAULT_IRQ_PRIORITY>;
+	child-owned-channels = <7 8 9 10 11>;
+	interrupts = <228 NRF_DEFAULT_IRQ_PRIORITY>,
+		     <229 NRF_DEFAULT_IRQ_PRIORITY>;
 	status = "disabled";
 };
 


### PR DESCRIPTION
The child-owned-channels property of GRTC is used by nrfx_grtc driver to exclude channels for common pool of channels allowed for dynamic allocation. That is sort-of workaround for missing property that allowes to remove some channels from the pool.

There are also not aligned GRTC IRQs for nRF54H20 and nRF54L15. Only one of avaialbe IRQs was added to GRTC in DTS whereas there should be two. That allows to find second IRQ by other drivers that use GRTC peripehral.