### PR TITLE
West: Add `west simulate` and `west robot` commands

### DIFF
--- a/boards/common/renode.board.cmake
+++ b/boards/common/renode.board.cmake
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+board_set_sim_runner_ifnset(renode)
+
+board_runner_args(renode "--renode-command=$elf=@${PROJECT_BINARY_DIR}/${KERNEL_ELF_NAME}")
+board_runner_args(renode "--renode-command=include @${RENODE_SCRIPT}")
+
+board_finalize_runner_args(renode)

--- a/boards/common/renode_robot.board.cmake
+++ b/boards/common/renode_robot.board.cmake
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+
+board_set_robot_runner_ifnset(renode-robot)
+
+# `--variable` is a renode-test argument, for setting a variable that can be later used in a .robot file:
+# ELF:         used in common.robot to set the `elf` variable in the default .resc script defined in board.cmake
+# RESC:        path to the .resc script, defined in board.cmake
+# UART:        default UART used by Robot in tests, defined in board.cmake
+# KEYWORDS:    path to common.robot, which contains common Robot keywords
+# RESULTS_DIR: directory in which Robot artifacts will be generated after running a testsuite
+board_runner_args(renode-robot "--renode-robot-arg=--variable=ELF:@${PROJECT_BINARY_DIR}/${KERNEL_ELF_NAME}")
+board_runner_args(renode-robot "--renode-robot-arg=--variable=RESC:@${RENODE_SCRIPT}")
+board_runner_args(renode-robot "--renode-robot-arg=--variable=UART:${RENODE_UART}")
+board_runner_args(renode-robot "--renode-robot-arg=--variable=KEYWORDS:${ZEPHYR_BASE}/tests/robot/common.robot")
+board_runner_args(renode-robot "--renode-robot-arg=--variable=RESULTS_DIR:${APPLICATION_BINARY_DIR}")
+
+board_finalize_runner_args(renode-robot)

--- a/boards/ite/it8xxx2_evb/support/it8xxx2_evb.resc
+++ b/boards/ite/it8xxx2_evb/support/it8xxx2_evb.resc
@@ -12,6 +12,6 @@ cpu PerformanceInMips 80
 
 macro reset
 """
-    sysbus LoadELF $bin
+    sysbus LoadELF $elf
 """
 runMacro $reset

--- a/boards/microchip/m2gl025_miv/board.cmake
+++ b/boards/microchip/m2gl025_miv/board.cmake
@@ -5,4 +5,6 @@ set(RENODE_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/support/m2gl025_miv.resc)
 set(RENODE_UART sysbus.uart)
 
 set_ifndef(BOARD_SIM_RUNNER renode)
+set_ifndef(BOARD_ROBOT_RUNNER renode-robot)
 include(${ZEPHYR_BASE}/boards/common/renode.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/renode_robot.board.cmake)

--- a/boards/microchip/m2gl025_miv/board.cmake
+++ b/boards/microchip/m2gl025_miv/board.cmake
@@ -3,3 +3,6 @@
 set(SUPPORTED_EMU_PLATFORMS renode)
 set(RENODE_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/support/m2gl025_miv.resc)
 set(RENODE_UART sysbus.uart)
+
+set_ifndef(BOARD_SIM_RUNNER renode)
+include(${ZEPHYR_BASE}/boards/common/renode.board.cmake)

--- a/boards/microchip/m2gl025_miv/m2gl025_miv.yaml
+++ b/boards/microchip/m2gl025_miv/m2gl025_miv.yaml
@@ -12,4 +12,7 @@ testing:
   ignore_tags:
     - net
     - bluetooth
+  renode:
+    uart: sysbus.uart
+    resc: boards/microchip/m2gl025_miv/support/m2gl025_miv.resc
 vendor: microchip

--- a/boards/microchip/m2gl025_miv/support/m2gl025_miv.resc
+++ b/boards/microchip/m2gl025_miv/support/m2gl025_miv.resc
@@ -12,6 +12,6 @@ cpu PerformanceInMips 4
 
 macro reset
 """
-    sysbus LoadELF $bin
+    sysbus LoadELF $elf
 """
 runMacro $reset

--- a/boards/microchip/mpfs_icicle/support/mpfs250t.resc
+++ b/boards/microchip/mpfs_icicle/support/mpfs250t.resc
@@ -12,6 +12,6 @@ e51 PerformanceInMips 80
 
 macro reset
 """
-    sysbus LoadELF $bin
+    sysbus LoadELF $elf
 """
 runMacro $reset

--- a/boards/renode/riscv32_virtual/riscv32_virtual.yaml
+++ b/boards/renode/riscv32_virtual/riscv32_virtual.yaml
@@ -12,5 +12,8 @@ testing:
   ignore_tags:
     - net
     - bluetooth
+  renode:
+    uart: sysbus.uart0
+    resc: boards/renode/riscv32_virtual/support/riscv32_virtual.resc
 supported:
   - uart

--- a/boards/renode/riscv32_virtual/support/riscv32_virtual.resc
+++ b/boards/renode/riscv32_virtual/support/riscv32_virtual.resc
@@ -12,6 +12,6 @@ cpu PerformanceInMips 4
 
 macro reset
 """
-    sysbus LoadELF $bin
+    sysbus LoadELF $elf
 """
 runMacro $reset

--- a/boards/sifive/hifive1/board.cmake
+++ b/boards/sifive/hifive1/board.cmake
@@ -28,3 +28,6 @@ elseif("${BOARD_REVISION}" STREQUAL "B")
   board_runner_args(jlink "--tool-opt=-autoconnect 1")
   include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 endif()
+
+set_ifndef(BOARD_SIM_RUNNER renode)
+include(${ZEPHYR_BASE}/boards/common/renode.board.cmake)

--- a/boards/sifive/hifive1/board.cmake
+++ b/boards/sifive/hifive1/board.cmake
@@ -30,4 +30,6 @@ elseif("${BOARD_REVISION}" STREQUAL "B")
 endif()
 
 set_ifndef(BOARD_SIM_RUNNER renode)
+set_ifndef(BOARD_ROBOT_RUNNER renode-robot)
 include(${ZEPHYR_BASE}/boards/common/renode.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/renode_robot.board.cmake)

--- a/boards/sifive/hifive1/hifive1.yaml
+++ b/boards/sifive/hifive1/hifive1.yaml
@@ -19,4 +19,7 @@ testing:
     - bluetooth
     - flash
     - newlib
+  renode:
+    uart: sysbus.uart0
+    resc: boards/sifive/hifive1/support/hifive1.resc
 vendor: sifive

--- a/boards/sifive/hifive1/support/hifive1.resc
+++ b/boards/sifive/hifive1/support/hifive1.resc
@@ -23,6 +23,6 @@ showAnalyzer uart0
 
 macro reset
 """
-    sysbus LoadELF $bin
+    sysbus LoadELF $elf
 """
 runMacro $reset

--- a/boards/sifive/hifive_unleashed/hifive_unleashed.yaml
+++ b/boards/sifive/hifive_unleashed/hifive_unleashed.yaml
@@ -14,6 +14,9 @@ testing:
     - flash
     - newlib
     - crypto
+  renode:
+    uart: sysbus.uart0
+    resc: boards/sifive/hifive_unleashed/support/hifive_unleashed.resc
 supported:
   - gpio
   - spi

--- a/boards/sifive/hifive_unleashed/support/hifive_unleashed.resc
+++ b/boards/sifive/hifive_unleashed/support/hifive_unleashed.resc
@@ -20,6 +20,6 @@ showAnalyzer uart0
 
 macro reset
 """
-    sysbus LoadELF $bin
+    sysbus LoadELF $elf
 """
 runMacro $reset

--- a/boards/sifive/hifive_unmatched/hifive_unmatched.yaml
+++ b/boards/sifive/hifive_unmatched/hifive_unmatched.yaml
@@ -11,6 +11,9 @@ testing:
   ignore_tags:
     - net
     - bluetooth
+  renode:
+    uart: sysbus.uart0
+    resc: boards/sifive/hifive_unmatched/support/hifive_unmatched.resc
 supported:
   - spi
   - memc

--- a/boards/sifive/hifive_unmatched/support/hifive_unmatched.resc
+++ b/boards/sifive/hifive_unmatched/support/hifive_unmatched.resc
@@ -20,6 +20,6 @@ showAnalyzer uart0
 
 macro reset
 """
-    sysbus LoadELF $bin
+    sysbus LoadELF $elf
 """
 runMacro $reset

--- a/cmake/emu/renode.cmake
+++ b/cmake/emu/renode.cmake
@@ -22,40 +22,7 @@ add_custom_target(run_renode
   COMMAND
   ${RENODE}
   ${RENODE_FLAGS}
-  -e '$$bin=@${APPLICATION_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME}\; include @${RENODE_SCRIPT}\; ${RENODE_OVERLAY} s'
-  WORKING_DIRECTORY ${APPLICATION_BINARY_DIR}
-  DEPENDS ${logical_target_for_zephyr_elf}
-  USES_TERMINAL
-  )
-
-find_program(
-  RENODE_TEST
-  renode-test
-  )
-
-set(RENODE_TEST_FLAGS
-  --variable ELF:@${APPLICATION_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME}
-  --variable RESC:@${RENODE_SCRIPT}
-  --variable UART:${RENODE_UART}
-  --variable KEYWORDS:${ZEPHYR_BASE}/tests/robot/common.robot
-  --results-dir ${APPLICATION_BINARY_DIR}
-  )
-
-add_custom_target(run_renode_test
-  COMMAND /bin/sh -c "\
-    if [ -z $$ROBOT_FILES ] \;\
-    then\
-        echo ''\;\
-        echo '--- Error: Robot file path is required to run Robot tests in Renode. To provide the path please set the ROBOT_FILES variable.'\;\
-        echo '--- To rerun the test with west execute:'\;\
-        echo '--- ROBOT_FILES=\\<FILES\\> west build -p -b \\<BOARD\\> -s \\<SOURCE_DIR\\> -t run_renode_test'\;\
-        echo ''\;\
-        exit 1\;\
-    fi\;"
-  COMMAND
-  ${RENODE_TEST}
-  ${RENODE_TEST_FLAGS}
-  ${APPLICATION_SOURCE_DIR}/$$ROBOT_FILES
+  -e '$$bin=@${PROJECT_BINARY_DIR}/${KERNEL_ELF_NAME}\; include @${RENODE_SCRIPT}\; ${RENODE_OVERLAY} s'
   WORKING_DIRECTORY ${APPLICATION_BINARY_DIR}
   DEPENDS ${logical_target_for_zephyr_elf}
   USES_TERMINAL

--- a/cmake/emu/renode.cmake
+++ b/cmake/emu/renode.cmake
@@ -22,7 +22,7 @@ add_custom_target(run_renode
   COMMAND
   ${RENODE}
   ${RENODE_FLAGS}
-  -e '$$bin=@${PROJECT_BINARY_DIR}/${KERNEL_ELF_NAME}\; include @${RENODE_SCRIPT}\; ${RENODE_OVERLAY} s'
+  -e '$$elf=@${PROJECT_BINARY_DIR}/${KERNEL_ELF_NAME}\; include @${RENODE_SCRIPT}\; ${RENODE_OVERLAY} s'
   WORKING_DIRECTORY ${APPLICATION_BINARY_DIR}
   DEPENDS ${logical_target_for_zephyr_elf}
   USES_TERMINAL

--- a/cmake/flash/CMakeLists.txt
+++ b/cmake/flash/CMakeLists.txt
@@ -97,6 +97,10 @@ function(create_runners_yaml)
     runners_yaml_append("\n# Default debug runner if --runner is not given.")
     runners_yaml_append("debug-runner: ${BOARD_DEBUG_RUNNER}")
   endif()
+  if(DEFINED BOARD_SIM_RUNNER)
+    runners_yaml_append("\n# Default simulation runner if --runner is not given.")
+    runners_yaml_append("sim-runner: ${BOARD_SIM_RUNNER}")
+  endif()
 
   # Sets up common runner configuration values.
   runners_yaml_append_config()

--- a/cmake/flash/CMakeLists.txt
+++ b/cmake/flash/CMakeLists.txt
@@ -101,6 +101,10 @@ function(create_runners_yaml)
     runners_yaml_append("\n# Default simulation runner if --runner is not given.")
     runners_yaml_append("sim-runner: ${BOARD_SIM_RUNNER}")
   endif()
+  if(DEFINED BOARD_ROBOT_RUNNER)
+    runners_yaml_append("\n# Default test runner if --runner is not given.")
+    runners_yaml_append("robot-runner: ${BOARD_ROBOT_RUNNER}")
+  endif()
 
   # Sets up common runner configuration values.
   runners_yaml_append_config()

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -705,7 +705,7 @@ endfunction()
 # This section provides glue between CMake and the Python code that
 # manages the runners.
 
-set(TYPES "FLASH" "DEBUG" "SIM")
+set(TYPES "FLASH" "DEBUG" "SIM" "ROBOT")
 function(_board_check_runner_type type) # private helper
   if (NOT "${type}" IN_LIST TYPES)
     message(FATAL_ERROR "invalid type ${type}; should be one of: ${TYPES}")
@@ -724,7 +724,7 @@ endfunction()
 #
 # This would set the board's flash runner to "pyocd".
 #
-# In general, "type" is FLASH, DEBUG or SIM and "runner" is
+# In general, "type" is FLASH, DEBUG, SIM or ROBOT and "runner" is
 # the name of a runner.
 function(board_set_runner type runner)
   _board_check_runner_type(${type})
@@ -764,6 +764,11 @@ endmacro()
 # A convenience macro for board_set_runner_ifnset(DEBUG ${runner}).
 macro(board_set_debugger_ifnset runner)
   board_set_runner_ifnset(DEBUG ${runner})
+endmacro()
+
+# A convenience macro for board_set_runner_ifnset(ROBOT ${runner}).
+macro(board_set_robot_runner_ifnset runner)
+  board_set_runner_ifnset(ROBOT ${runner})
 endmacro()
 
 # A convenience macro for board_set_runner_ifnset(SIM ${runner}).

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -705,9 +705,10 @@ endfunction()
 # This section provides glue between CMake and the Python code that
 # manages the runners.
 
+set(TYPES "FLASH" "DEBUG" "SIM")
 function(_board_check_runner_type type) # private helper
-  if (NOT (("${type}" STREQUAL "FLASH") OR ("${type}" STREQUAL "DEBUG")))
-    message(FATAL_ERROR "invalid type ${type}; should be FLASH or DEBUG")
+  if (NOT "${type}" IN_LIST TYPES)
+    message(FATAL_ERROR "invalid type ${type}; should be one of: ${TYPES}")
   endif()
 endfunction()
 
@@ -723,8 +724,8 @@ endfunction()
 #
 # This would set the board's flash runner to "pyocd".
 #
-# In general, "type" is FLASH or DEBUG, and "runner" is the name of a
-# runner.
+# In general, "type" is FLASH, DEBUG or SIM and "runner" is
+# the name of a runner.
 function(board_set_runner type runner)
   _board_check_runner_type(${type})
   if (DEFINED BOARD_${type}_RUNNER)
@@ -763,6 +764,11 @@ endmacro()
 # A convenience macro for board_set_runner_ifnset(DEBUG ${runner}).
 macro(board_set_debugger_ifnset runner)
   board_set_runner_ifnset(DEBUG ${runner})
+endmacro()
+
+# A convenience macro for board_set_runner_ifnset(SIM ${runner}).
+macro(board_set_sim_runner_ifnset runner)
+  board_set_runner_ifnset(SIM ${runner})
 endmacro()
 
 # This function is intended for board.cmake files and application

--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -1347,12 +1347,6 @@ To execute a Robot test suite with twister, run the following command:
 
          python .\scripts\twister --platform hifive1 --test samples/subsys/shell/shell_module/sample.shell.shell_module.robot
 
-It's also possible to run it by `west` directly, with:
-
-.. code-block:: bash
-
-   $ ROBOT_FILES=shell_module.robot west build -p -b hifive1 -s samples/subsys/shell/shell_module -t run_renode_test
-
 Writing Robot tests
 ===================
 

--- a/doc/develop/west/build-flash-debug.rst
+++ b/doc/develop/west/build-flash-debug.rst
@@ -698,6 +698,49 @@ determined by the imported subclasses of ``ZephyrBinaryRunner``.
 runner implementations are in other submodules, such as ``runners.nrfjprog``,
 ``runners.openocd``, etc.
 
+Simulating a board with: ``west simulate``
+******************************************
+
+Basics
+======
+
+Currently the command supports only one runner which is using Renode,
+but can be easily extended by adding other runners.
+
+From a Zephyr build directory, to run the built binary::
+
+  west simulate --runner=renode
+
+This will start Renode and configure simulation based on a default ``.resc`` script
+for the current platform with the zephyr.elf file loaded by default. The simulation
+then can be started by typing "start" or "s" in Renode's Monitor. This can also be
+done by passing a command to Renode, using an argument provided by the runner:
+
+  west simulate --runner=renode --renode-command start
+
+To pass an argument to Renode itself, for example to start Renode in console mode
+intead of a separate window:
+
+  west simulate --runner=renode --renode-arg="--console"
+
+From that point on Renode can be used normally in both console and window modes.
+For details on using Renode see `Renode - documentation`_.
+
+.. _Renode - documentation:
+   http://docs.renode.io
+
+Runner-Specific Overrides
+=========================
+
+To view all of the available options supported by the runners, as well
+as their usage information, use ``--context`` (or``-H``)::
+
+  west simulate --runner=renode --context
+
+To view all available options Renode supports, use::
+
+  west simulate --runner=renode --renode-help
+
 Hacking
 *******
 

--- a/doc/develop/west/build-flash-debug.rst
+++ b/doc/develop/west/build-flash-debug.rst
@@ -698,6 +698,44 @@ determined by the imported subclasses of ``ZephyrBinaryRunner``.
 runner implementations are in other submodules, such as ``runners.nrfjprog``,
 ``runners.openocd``, etc.
 
+Running Robot Framework tests: ``west robot``
+*********************************************
+
+.. tip:: Run ``west robot -h`` for additional help.
+
+Basics
+======
+
+Currently the command supports only one runner which is using ``renode-test``,
+(essentially a wrapper for running Robot tests in Renode), but can be
+easily extended by adding other runners.
+
+From a Zephyr build directory, to run a Robot test suite::
+
+  west robot --runner=renode-robot --testsuite path/to/testsuite.robot
+
+This will run all tests from testsuite.robot and print output provided
+by Robot Framework.
+
+To pass additional parameters to Renode use ``--renode-robot-args`` switch.
+For example to show Renode logs in addition to Robot Framework's output:
+
+  west robot --runner=renode-robot --testsuite path/to/testsuite.robot --renode-robot-arg="--show-log"
+
+Runner-Specific Overrides
+=========================
+
+To view all of the available options for the Robot runners your board
+supports, as well as their usage information, use ``--context`` (or
+``-H``)::
+
+  west robot --runner=renode-robot --context
+
+
+To view all available options "renode-test" runner supports, use::
+
+  west robot --runner=renode-robot --renode-robot-help
+
 Simulating a board with: ``west simulate``
 ******************************************
 

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -152,18 +152,17 @@ class Robot(Harness):
         tc.status = "passed"
 
     def run_robot_test(self, command, handler):
-
         start_time = time.time()
         env = os.environ.copy()
-        env["ROBOT_FILES"] = self.path
 
+        command.append(os.path.join(handler.sourcedir, self.path))
         with subprocess.Popen(command, stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT, cwd=self.instance.build_dir, env=env) as cmake_proc:
-            out, _ = cmake_proc.communicate()
+                stderr=subprocess.STDOUT, cwd=self.instance.build_dir, env=env) as renode_test_proc:
+            out, _ = renode_test_proc.communicate()
 
             self.instance.execution_time = time.time() - start_time
 
-            if cmake_proc.returncode == 0:
+            if renode_test_proc.returncode == 0:
                 self.instance.status = "passed"
                 # all tests in one Robot file are treated as a single test case,
                 # so its status should be set accordingly to the instance status

--- a/scripts/pylib/twister/twisterlib/platform.py
+++ b/scripts/pylib/twister/twisterlib/platform.py
@@ -46,6 +46,8 @@ class Platform:
         self.env = []
         self.env_satisfied = True
         self.filter_data = dict()
+        self.uart = ""
+        self.resc = ""
 
     def load(self, platform_file):
         scp = TwisterConfigParser(platform_file, self.platform_schema)
@@ -63,6 +65,9 @@ class Platform:
         self.only_tags = testing.get("only_tags", [])
         self.default = testing.get("default", False)
         self.binaries = testing.get("binaries", [])
+        renode = testing.get("renode", {})
+        self.uart = renode.get("uart", "")
+        self.resc = renode.get("resc", "")
         # if no flash size is specified by the board, take a default of 512K
         self.flash = data.get("flash", 512)
         self.supported = set()

--- a/scripts/schemas/twister/platform-schema.yaml
+++ b/scripts/schemas/twister/platform-schema.yaml
@@ -100,3 +100,10 @@ mapping:
         type: seq
         seq:
           - type: str
+      "renode":
+        type: map
+        mapping:
+          "uart":
+            type: str
+          "resc":
+            type: str

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -18,10 +18,12 @@ from contextlib import nullcontext
 from importlib import reload
 from serial import SerialException
 from subprocess import CalledProcessError, TimeoutExpired
+from types import SimpleNamespace
 
 import twisterlib.harness
 
-from conftest import ZEPHYR_BASE
+ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
+
 from twisterlib.error import TwisterException
 from twisterlib.handlers import (
     Handler,
@@ -413,7 +415,7 @@ TESTDATA_4 = [
      ['valgrind', '--error-exitcode=2', '--leak-check=full',
       f'--suppressions={ZEPHYR_BASE}/scripts/valgrind.supp',
       '--log-file=build_dir/valgrind.log', '--track-origins=yes',
-      'generator', 'run_renode_test']),
+      'generator']),
     (False, True, False, 123, None, ['generator', 'run', '--seed=123']),
     (False, False, False, None, ['ex1', 'ex2'], ['build_dir/zephyr/zephyr.exe', 'ex1', 'ex2']),
 ]
@@ -437,11 +439,16 @@ def test_binaryhandler_create_command(
     handler.generator_cmd = 'generator'
     handler.binary = 'bin'
     handler.call_make_run = call_make_run
-    handler.options = mock.Mock(enable_valgrind=enable_valgrind)
+    handler.options = SimpleNamespace()
+    handler.options.enable_valgrind = enable_valgrind
+    handler.options.coverage_basedir = "coverage_basedir"
     handler.seed = seed
     handler.extra_test_args = extra_args
     handler.build_dir = 'build_dir'
     handler.instance.testsuite.sysbuild = False
+    handler.platform = SimpleNamespace()
+    handler.platform.resc = "file.resc"
+    handler.platform.uart = "uart"
 
     command = handler._create_command(robot_test)
 

--- a/scripts/tests/twister/test_harness.py
+++ b/scripts/tests/twister/test_harness.py
@@ -166,7 +166,7 @@ TEST_DATA_2 = [("", 0, "passed"), ("Robot test failure: sourcedir for mock_platf
 )
 def test_robot_run_robot_test(tmp_path, caplog, exp_out, returncode, expected_status):
     # Arrange
-    command = "command"
+    command = ["command"]
 
     handler = mock.Mock()
     handler.sourcedir = "sourcedir"

--- a/scripts/west-commands.yml
+++ b/scripts/west-commands.yml
@@ -66,6 +66,11 @@ west-commands:
       - name: bindesc
         class: Bindesc
         help: work with Binary Descriptors
+  - file: scripts/west_commands/robot.py
+    commands:
+      - name: robot
+        class: Robot
+        help: run RobotFramework test suites
   - file: scripts/west_commands/simulate.py
     commands:
       - name: simulate

--- a/scripts/west-commands.yml
+++ b/scripts/west-commands.yml
@@ -66,3 +66,8 @@ west-commands:
       - name: bindesc
         class: Bindesc
         help: work with Binary Descriptors
+  - file: scripts/west_commands/simulate.py
+    commands:
+      - name: simulate
+        class: Simulate
+        help: simulate board

--- a/scripts/west_commands/robot.py
+++ b/scripts/west_commands/robot.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2024 Antmicro <www.antmicro.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from west.commands import WestCommand
+from run_common import add_parser_common, do_run_common
+
+EXPORT_DESCRIPTION = '''\
+Run RobotFramework test suites with a runner of choice.
+'''
+
+
+class Robot(WestCommand):
+
+    def __init__(self):
+        super(Robot, self).__init__(
+            'robot',
+            # Keep this in sync with the string in west-commands.yml.
+            'run RobotFramework test suites',
+            EXPORT_DESCRIPTION,
+            accepts_unknown_args=True)
+
+        self.runner_key = 'robot-runner'  # in runners.yaml
+
+    def do_add_parser(self, parser_adder):
+        return add_parser_common(self, parser_adder)
+
+    def do_run(self, my_args, runner_args):
+        do_run_common(self, my_args, runner_args)

--- a/scripts/west_commands/run_common.py
+++ b/scripts/west_commands/run_common.py
@@ -512,7 +512,7 @@ def runners_yaml_path(build_dir, board):
     ret = Path(build_dir) / 'zephyr' / 'runners.yaml'
     if not ret.is_file():
         log.die(f'either a pristine build is needed, or board {board} '
-                "doesn't support west flash/debug "
+                "doesn't support west flash/debug/simulate "
                 '(no ZEPHYR_RUNNERS_YAML in CMake cache)')
     return ret
 

--- a/scripts/west_commands/runners/__init__.py
+++ b/scripts/west_commands/runners/__init__.py
@@ -49,6 +49,7 @@ _names = [
     'openocd',
     'pyocd',
     'renode',
+    'renode-robot',
     'qemu',
     'silabs_commander',
     'spi_burn',

--- a/scripts/west_commands/runners/__init__.py
+++ b/scripts/west_commands/runners/__init__.py
@@ -48,6 +48,7 @@ _names = [
     'nxp_s32dbg',
     'openocd',
     'pyocd',
+    'renode',
     'qemu',
     'silabs_commander',
     'spi_burn',

--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -200,7 +200,7 @@ class MissingProgram(FileNotFoundError):
         super().__init__(errno.ENOENT, os.strerror(errno.ENOENT), program)
 
 
-_RUNNERCAPS_COMMANDS = {'flash', 'debug', 'debugserver', 'attach'}
+_RUNNERCAPS_COMMANDS = {'flash', 'debug', 'debugserver', 'attach', 'simulate'}
 
 @dataclass
 class RunnerCaps:
@@ -212,7 +212,7 @@ class RunnerCaps:
     Available capabilities:
 
     - commands: set of supported commands; default is {'flash',
-      'debug', 'debugserver', 'attach'}.
+      'debug', 'debugserver', 'attach', 'simulate'}.
 
     - dev_id: whether the runner supports device identifiers, in the form of an
       -i, --dev-id option. This is useful when the user has multiple debuggers

--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -247,6 +247,8 @@ class RunnerCaps:
     - file: whether the runner supports a --file option, which specifies
       exactly the file that should be used to flash, overriding any default
       discovered in the build directory.
+
+    - hide_load_files: whether the elf/hex/bin file arguments should be hidden.
     '''
 
     commands: Set[str] = field(default_factory=lambda: set(_RUNNERCAPS_COMMANDS))
@@ -257,6 +259,7 @@ class RunnerCaps:
     extload: bool = False
     tool_opt: bool = False
     file: bool = False
+    hide_load_files: bool = False
 
     def __post_init__(self):
         if not self.commands.issubset(_RUNNERCAPS_COMMANDS):
@@ -511,18 +514,23 @@ class ZephyrBinaryRunner(abc.ABC):
             parser.add_argument('-f', '--file', help=argparse.SUPPRESS)
             parser.add_argument('-t', '--file-type', help=argparse.SUPPRESS)
 
-        parser.add_argument('--elf-file',
-                        metavar='FILE',
-                        action=(partial(depr_action, cls=cls, replacement='-f/--file') if caps.file else None),
-                        help='path to zephyr.elf' if not caps.file else 'Deprecated, use -f/--file instead.')
-        parser.add_argument('--hex-file',
-                        metavar='FILE',
-                        action=(partial(depr_action, cls=cls, replacement='-f/--file') if caps.file else None),
-                        help='path to zephyr.hex' if not caps.file else 'Deprecated, use -f/--file instead.')
-        parser.add_argument('--bin-file',
-                        metavar='FILE',
-                        action=(partial(depr_action, cls=cls, replacement='-f/--file') if caps.file else None),
-                        help='path to zephyr.bin' if not caps.file else 'Deprecated, use -f/--file instead.')
+        if caps.hide_load_files:
+            parser.add_argument('--elf-file', help=argparse.SUPPRESS)
+            parser.add_argument('--hex-file', help=argparse.SUPPRESS)
+            parser.add_argument('--bin-file', help=argparse.SUPPRESS)
+        else:
+            parser.add_argument('--elf-file',
+                                metavar='FILE',
+                                action=(partial(depr_action, cls=cls, replacement='-f/--file') if caps.file else None),
+                                help='path to zephyr.elf' if not caps.file else 'Deprecated, use -f/--file instead.')
+            parser.add_argument('--hex-file',
+                                metavar='FILE',
+                                action=(partial(depr_action, cls=cls, replacement='-f/--file') if caps.file else None),
+                                help='path to zephyr.hex' if not caps.file else 'Deprecated, use -f/--file instead.')
+            parser.add_argument('--bin-file',
+                                metavar='FILE',
+                                action=(partial(depr_action, cls=cls, replacement='-f/--file') if caps.file else None),
+                                help='path to zephyr.bin' if not caps.file else 'Deprecated, use -f/--file instead.')
 
         parser.add_argument('--erase', '--no-erase', nargs=0,
                             action=_ToggleAction,

--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -200,7 +200,7 @@ class MissingProgram(FileNotFoundError):
         super().__init__(errno.ENOENT, os.strerror(errno.ENOENT), program)
 
 
-_RUNNERCAPS_COMMANDS = {'flash', 'debug', 'debugserver', 'attach', 'simulate'}
+_RUNNERCAPS_COMMANDS = {'flash', 'debug', 'debugserver', 'attach', 'simulate', 'robot'}
 
 @dataclass
 class RunnerCaps:
@@ -212,7 +212,7 @@ class RunnerCaps:
     Available capabilities:
 
     - commands: set of supported commands; default is {'flash',
-      'debug', 'debugserver', 'attach', 'simulate'}.
+      'debug', 'debugserver', 'attach', 'simulate', 'robot'}.
 
     - dev_id: whether the runner supports device identifiers, in the form of an
       -i, --dev-id option. This is useful when the user has multiple debuggers

--- a/scripts/west_commands/runners/nios2.py
+++ b/scripts/west_commands/runners/nios2.py
@@ -4,7 +4,7 @@
 
 '''Runner for NIOS II, based on quartus-flash.py and GDB.'''
 
-from runners.core import ZephyrBinaryRunner, NetworkPortHelper
+from runners.core import ZephyrBinaryRunner, NetworkPortHelper, RunnerCaps
 
 
 class Nios2BinaryRunner(ZephyrBinaryRunner):
@@ -28,6 +28,10 @@ class Nios2BinaryRunner(ZephyrBinaryRunner):
     @classmethod
     def name(cls):
         return 'nios2'
+
+    @classmethod
+    def capabilities(cls):
+        return RunnerCaps(commands={'flash', 'debug', 'debugserver', 'attach'})
 
     @classmethod
     def do_add_parser(cls, parser):

--- a/scripts/west_commands/runners/nsim.py
+++ b/scripts/west_commands/runners/nsim.py
@@ -7,7 +7,7 @@
 
 from os import path
 
-from runners.core import ZephyrBinaryRunner
+from runners.core import ZephyrBinaryRunner, RunnerCaps
 
 DEFAULT_ARC_GDB_PORT = 3333
 DEFAULT_PROPS_FILE = 'nsim_em.props'
@@ -39,6 +39,10 @@ class NsimBinaryRunner(ZephyrBinaryRunner):
     @classmethod
     def name(cls):
         return 'arc-nsim'
+
+    @classmethod
+    def capabilities(cls):
+        return RunnerCaps(commands={'flash', 'debug', 'debugserver', 'attach'})
 
     @classmethod
     def do_add_parser(cls, parser):

--- a/scripts/west_commands/runners/openocd.py
+++ b/scripts/west_commands/runners/openocd.py
@@ -18,7 +18,7 @@ try:
 except ImportError:
     pass
 
-from runners.core import ZephyrBinaryRunner
+from runners.core import ZephyrBinaryRunner, RunnerCaps
 
 DEFAULT_OPENOCD_TCL_PORT = 6333
 DEFAULT_OPENOCD_TELNET_PORT = 4444
@@ -99,6 +99,10 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
     @classmethod
     def name(cls):
         return 'openocd'
+
+    @classmethod
+    def capabilities(cls):
+        return RunnerCaps(commands={'flash', 'debug', 'debugserver', 'attach'})
 
     @classmethod
     def do_add_parser(cls, parser):

--- a/scripts/west_commands/runners/renode-robot.py
+++ b/scripts/west_commands/runners/renode-robot.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2024 Antmicro <www.antmicro.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+'''Runner stub for renode-test.'''
+
+import subprocess
+from runners.core import ZephyrBinaryRunner, RunnerCaps
+
+
+class RenodeRobotRunner(ZephyrBinaryRunner):
+    '''Place-holder for Renode runner customizations.'''
+
+    def __init__(self, cfg, args):
+        super().__init__(cfg)
+        self.testsuite = args.testsuite
+        self.renode_robot_arg = args.renode_robot_arg
+        self.renode_robot_help = args.renode_robot_help
+
+    @classmethod
+    def name(cls):
+        return 'renode-robot'
+
+    @classmethod
+    def capabilities(cls):
+        return RunnerCaps(commands={'robot'}, hide_load_files=True)
+
+    @classmethod
+    def do_add_parser(cls, parser):
+        parser.add_argument('--testsuite',
+                            help='path to Robot test suite')
+        parser.add_argument('--renode-robot-arg',
+                            metavar='ARG',
+                            action='append',
+                            help='additional argument passed to renode-test')
+        parser.add_argument('--renode-robot-help',
+                            default=False,
+                            action='store_true',
+                            help='print all possible `renode-test` arguments')
+
+    @classmethod
+    def do_create(cls, cfg, args):
+        return RenodeRobotRunner(cfg, args)
+
+    def do_run(self, command, **kwargs):
+        self.run_test(**kwargs)
+
+    def run_test(self, **kwargs):
+        cmd = ['renode-test']
+        if self.renode_robot_help is True:
+            cmd.append('--help')
+        else:
+            if self.renode_robot_arg is not None:
+                for arg in self.renode_robot_arg:
+                    cmd.append(arg)
+            if self.testsuite is not None:
+                cmd.append(self.testsuite)
+            else:
+                self.logger.error("No Robot testsuite passed to renode-test! Use the `--testsuite` argument to provide one.")
+        subprocess.run(cmd, check=True)

--- a/scripts/west_commands/runners/renode.py
+++ b/scripts/west_commands/runners/renode.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2024 Antmicro <www.antmicro.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+'''Runner stub for Renode.'''
+
+import subprocess
+from runners.core import ZephyrBinaryRunner, RunnerCaps
+
+
+class RenodeRunner(ZephyrBinaryRunner):
+    '''Place-holder for Renode runner customizations.'''
+
+    def __init__(self, cfg, args):
+        super().__init__(cfg)
+        self.renode_arg = args.renode_arg
+        self.renode_command = args.renode_command
+        self.renode_help = args.renode_help
+
+    @classmethod
+    def name(cls):
+        return 'renode'
+
+    @classmethod
+    def capabilities(cls):
+        return RunnerCaps(commands={'simulate'}, hide_load_files=True)
+
+    @classmethod
+    def do_add_parser(cls, parser):
+        parser.add_argument('--renode-arg',
+                            metavar='ARG',
+                            action='append',
+                            help='additional argument passed to Renode; `--help` will print all possible arguments')
+        parser.add_argument('--renode-command',
+                            metavar='COMMAND',
+                            action='append',
+                            help='additional command passed to Renode\'s simulation')
+        parser.add_argument('--renode-help',
+                            default=False,
+                            action='store_true',
+                            help='print all possible `Renode` arguments')
+
+    @classmethod
+    def do_create(cls, cfg, args):
+        return RenodeRunner(cfg, args)
+
+    def do_run(self, command, **kwargs):
+        self.run_test(**kwargs)
+
+    def run_test(self, **kwargs):
+        cmd = ['renode']
+        if self.renode_help is True:
+            cmd.append('--help')
+        else:
+            if self.renode_arg is not None:
+                for arg in self.renode_arg:
+                    cmd.append(arg)
+            if self.renode_command is not None:
+                for command in self.renode_command:
+                    cmd.append('-e')
+                    cmd.append(command)
+        subprocess.run(cmd, check=True)

--- a/scripts/west_commands/simulate.py
+++ b/scripts/west_commands/simulate.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2024 Antmicro <www.antmicro.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from west.commands import WestCommand
+from run_common import add_parser_common, do_run_common
+
+EXPORT_DESCRIPTION = '''\
+Simulate the board on a runner of choice using generated artifacts.
+'''
+
+
+class Simulate(WestCommand):
+
+    def __init__(self):
+        super(Simulate, self).__init__(
+            'simulate',
+            # Keep this in sync with the string in west-commands.yml.
+            'simulate board',
+            EXPORT_DESCRIPTION,
+            accepts_unknown_args=True)
+
+        self.runner_key = 'sim-runner'  # in runners.yaml
+
+    def do_add_parser(self, parser_adder):
+        return add_parser_common(self, parser_adder)
+
+    def do_run(self, my_args, runner_args):
+        do_run_common(self, my_args, runner_args)

--- a/scripts/west_commands/tests/test_imports.py
+++ b/scripts/west_commands/tests/test_imports.py
@@ -39,6 +39,7 @@ def test_runner_imports():
                     'openocd',
                     'pyocd',
                     'qemu',
+                    'renode',
                     'silabs_commander',
                     'spi_burn',
                     'stm32cubeprogrammer',

--- a/scripts/west_commands/tests/test_imports.py
+++ b/scripts/west_commands/tests/test_imports.py
@@ -40,6 +40,7 @@ def test_runner_imports():
                     'pyocd',
                     'qemu',
                     'renode',
+                    'renode-robot',
                     'silabs_commander',
                     'spi_burn',
                     'stm32cubeprogrammer',

--- a/tests/robot/common.robot
+++ b/tests/robot/common.robot
@@ -2,6 +2,6 @@
 
 *** Keywords ***
 Prepare Machine
-    Execute Command           $bin = ${ELF}
+    Execute Command           $elf = ${ELF}
     Execute Command           include ${RESC}
     Create Terminal Tester    ${UART}


### PR DESCRIPTION
Main changes introduced in this PR:

1. Reworked integration with renode-test in Twister
2. New west command: `simulate`
3. New west command: `robot`

**Reworked integration with renode-test in Twister:**

Initial integration with renode-test was introduced in commit bdf02ff, which added support for calling the `renode-test` command from both west and twister.

The change introduced in this PR removes the custom run_renode_test target used for running Robot tests with the `west build` command and makes twister call `renode-test` directly instead.

**New west command: `simulate`:**

Allows running samples on a simulator of choice using a dedicated runner. Initial implementation consists of a runner for Renode.

**New west command: `robot`:**

Allows running Robot Framework test suites using a dedicated runner. Initial implementation consists of a runner for renode-test, which is a Renode wrapper for running Robot tests.

Changing the custom target into a west extension command was suggested by @tejlmand in https://github.com/zephyrproject-rtos/zephyr/pull/66193#pullrequestreview-1817795562.


