### PR TITLE
cmake: sca: codechecker: Allow processing results even on errors

### DIFF
--- a/cmake/sca/codechecker/sca.cmake
+++ b/cmake/sca/codechecker/sca.cmake
@@ -26,6 +26,7 @@ add_custom_target(codechecker ALL
     --name zephyr # Set a default metadata name
     ${CODECHECKER_ANALYZE_OPTS}
     ${CMAKE_BINARY_DIR}/compile_commands.json
+    || ${CMAKE_COMMAND} -E true # allow to continue processing results
   DEPENDS ${CMAKE_BINARY_DIR}/compile_commands.json ${output_dir}/codechecker.ready
   BYPRODUCTS ${output_dir}/codechecker.plist
   VERBATIM


### PR DESCRIPTION
The analyze step for codechecker can have errors. These are printed out to the console, allow to keep processing results for other succeeded analysis.