### PR TITLE
gdbstub: Ignore indexing warning with -Warray-bounds 

### DIFF
--- a/subsys/debug/gdbstub.c
+++ b/subsys/debug/gdbstub.c
@@ -41,7 +41,7 @@ static bool not_first_start;
 /* Empty memory region array */
 __weak const struct gdb_mem_region gdb_mem_region_array[0];
 
-/* Number of memory regions, default to 0 */
+/* Number of memory regions */
 __weak const size_t gdb_mem_num_regions;
 
 /**
@@ -55,6 +55,12 @@ __weak const size_t gdb_mem_num_regions;
  * @return Pointer to the memory region description if found.
  *         NULL if not found.
  */
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+/* Required due to gdb_mem_region_array having a default size of zero. */
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
+
 static inline const
 struct gdb_mem_region *find_memory_region(const uintptr_t addr, const size_t len)
 {
@@ -75,6 +81,10 @@ struct gdb_mem_region *find_memory_region(const uintptr_t addr, const size_t len
 
 	return ret;
 }
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 bool gdb_mem_can_read(const uintptr_t addr, const size_t len, uint8_t *align)
 {


### PR DESCRIPTION
The current implementation can raise a warning as the compiler sees
an attempt to index an array with a size of zero. This can be fixed by
giving `gdb_mem_num_regions` a default value of zero, but this gets
flagged by CI checks. Disable the warning around the array access.
