### PR TITLE
gdbstub: Add custom backend choice

### DIFF
--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -414,6 +414,11 @@ config GDBSTUB_SERIAL_BACKEND
 	help
 	  Use serial as backend for GDB
 
+config GDBSTUB_CUSTOM_BACKEND
+	bool "Use a custom backend"
+	help
+	  Use a custom backend for GDB
+
 endchoice
 
 config GDBSTUB_BUF_SZ


### PR DESCRIPTION
By default `GDBSTUB_SERIAL_BACKEND` will be selected as it's the only
option here. This can cause problems for code that wants to provide its
own custom backend. Add a choice for a custom backend.