### PR TITLE
arch: riscv: introduce a Kconfig to mask `mhartid`

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -203,6 +203,15 @@ config RV_BOOT_HART
 	  For RISC-V systems such as MPFS and FU540 this would be set to 1 to
 	  skip the E51 HART 0 as it is not usable in SMP configurations.
 
+config RISCV_HART_MASK
+	int
+	default -1
+	help
+	  Configures the mask for the HART ID.
+	  For RISC-V systems with HART ID starting from non-zero value,
+	  i.e. 128, 129, ..(0x80, 8x81, ..), this can be configured to 63 (0x7f)
+	  such that we can extract the bits that start from 0.
+
 config RISCV_PMP
 	bool "RISC-V PMP Support"
 	select THREAD_STACK_INFO

--- a/include/zephyr/arch/riscv/arch_inlines.h
+++ b/include/zephyr/arch/riscv/arch_inlines.h
@@ -14,7 +14,7 @@
 
 static ALWAYS_INLINE uint32_t arch_proc_id(void)
 {
-	return csr_read(mhartid);
+	return csr_read(mhartid) & ((uintptr_t)CONFIG_RISCV_HART_MASK);
 }
 
 static ALWAYS_INLINE _cpu_t *arch_curr_cpu(void)


### PR DESCRIPTION
Configure a new Kconfig (`CONFIG_RISCV_HART_MASK`) so that it
is possible to mask the `mhartid` of a processor. This is
helpful in the cases when the hart id starts from non-zero
value.