### PR TITLE
Revert "pm: Remove CURRENT_CPU macro"

### DIFF
--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -22,6 +22,9 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(pm, CONFIG_PM_LOG_LEVEL);
 
+#define CURRENT_CPU \
+	(COND_CODE_1(CONFIG_SMP, (arch_curr_cpu()->id), (_current_cpu->id)))
+
 static ATOMIC_DEFINE(z_post_ops_required, CONFIG_MP_MAX_NUM_CPUS);
 static sys_slist_t pm_notifiers = SYS_SLIST_STATIC_INIT(&pm_notifiers);
 
@@ -130,7 +133,7 @@ static inline void pm_state_notify(bool entering_state)
 
 void pm_system_resume(void)
 {
-	uint8_t id = _current_cpu->id;
+	uint8_t id = CURRENT_CPU;
 
 	/*
 	 * This notification is called from the ISR of the event
@@ -168,7 +171,7 @@ bool pm_state_force(uint8_t cpu, const struct pm_state_info *info)
 
 bool pm_system_suspend(int32_t ticks)
 {
-	uint8_t id = _current_cpu->id;
+	uint8_t id = CURRENT_CPU;
 	k_spinlock_key_t key;
 
 	SYS_PORT_TRACING_FUNC_ENTER(pm, system_suspend, ticks);


### PR DESCRIPTION
This reverts commit b9d4b9d9aba0489cd31b687afd9f7a7883230d78.

System resume fails occasionally on Intel ACE platform to assert with this patch in place. Revert the change until a proper fix is found.

Link: https://github.com/zephyrproject-rtos/zephyr/issues/69807