### PR TITLE
tests: i2s: sam: Add missing overlays

### DIFF
--- a/tests/drivers/i2s/i2s_api/boards/sam_e70_xplained_same70q21b.overlay
+++ b/tests/drivers/i2s/i2s_api/boards/sam_e70_xplained_same70q21b.overlay
@@ -1,0 +1,11 @@
+/* i2s-node0 is the transmitter/receiver */
+
+/ {
+	aliases {
+		i2s-node0 = &ssc;
+	};
+};
+
+&xdmac {
+	status = "okay";
+};

--- a/tests/drivers/i2s/i2s_api/boards/sam_v71_xult_samv71q21b.overlay
+++ b/tests/drivers/i2s/i2s_api/boards/sam_v71_xult_samv71q21b.overlay
@@ -1,0 +1,11 @@
+/* i2s-node0 is the transmitter/receiver */
+
+/ {
+	aliases {
+		i2s-node0 = &ssc;
+	};
+};
+
+&xdmac {
+	status = "okay";
+};

--- a/tests/drivers/i2s/i2s_speed/boards/sam_e70_xplained_same70q21.overlay
+++ b/tests/drivers/i2s/i2s_speed/boards/sam_e70_xplained_same70q21.overlay
@@ -1,0 +1,11 @@
+/* i2s-node0 is the transmitter/receiver */
+
+/ {
+	aliases {
+		i2s-node0 = &ssc;
+	};
+};
+
+&xdmac {
+	status = "okay";
+};

--- a/tests/drivers/i2s/i2s_speed/boards/sam_e70_xplained_same70q21b.overlay
+++ b/tests/drivers/i2s/i2s_speed/boards/sam_e70_xplained_same70q21b.overlay
@@ -1,0 +1,11 @@
+/* i2s-node0 is the transmitter/receiver */
+
+/ {
+	aliases {
+		i2s-node0 = &ssc;
+	};
+};
+
+&xdmac {
+	status = "okay";
+};

--- a/tests/drivers/i2s/i2s_speed/boards/sam_v71_xult_samv71q21.overlay
+++ b/tests/drivers/i2s/i2s_speed/boards/sam_v71_xult_samv71q21.overlay
@@ -1,0 +1,11 @@
+/* i2s-node0 is the transmitter/receiver */
+
+/ {
+	aliases {
+		i2s-node0 = &ssc;
+	};
+};
+
+&xdmac {
+	status = "okay";
+};

--- a/tests/drivers/i2s/i2s_speed/boards/sam_v71_xult_samv71q21b.overlay
+++ b/tests/drivers/i2s/i2s_speed/boards/sam_v71_xult_samv71q21b.overlay
@@ -1,0 +1,11 @@
+/* i2s-node0 is the transmitter/receiver */
+
+/ {
+	aliases {
+		i2s-node0 = &ssc;
+	};
+};
+
+&xdmac {
+	status = "okay";
+};


### PR DESCRIPTION
Add missing overlays files to allow I2S tests pass on ci.

Fixes #69936