### PR TITLE
tests: coredump: Disable optimizations to prevent unexpected failures

### DIFF
--- a/tests/subsys/debug/coredump/src/main.c
+++ b/tests/subsys/debug/coredump/src/main.c
@@ -29,8 +29,11 @@ void func_3(uint32_t *addr)
 {
 #if defined(CONFIG_BOARD_M2GL025_MIV) || \
 	defined(CONFIG_BOARD_HIFIVE1) || \
+	defined(CONFIG_BOARD_HIFIVE_UNLEASHED) || \
+	defined(CONFIG_BOARD_HIFIVE_UNMATCHED) || \
 	defined(CONFIG_BOARD_LONGAN_NANO) || \
 	defined(CONFIG_BOARD_QEMU_XTENSA) || \
+	defined(CONFIG_BOARD_RISCV32_VIRTUAL) || \
 	defined(CONFIG_SOC_FAMILY_INTEL_ADSP)
 	ARG_UNUSED(addr);
 	/* Call k_panic() directly so Renode doesn't pause execution.

--- a/tests/subsys/debug/coredump/src/main.c
+++ b/tests/subsys/debug/coredump/src/main.c
@@ -25,7 +25,10 @@ void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
 	k_fatal_halt(reason);
 }
 
-void func_3(uint32_t *addr)
+/* Turn off optimizations to prevent the compiler from optimizing this away
+ * due to the null pointer dereference.
+ */
+__no_optimization void func_3(uint32_t *addr)
 {
 #if defined(CONFIG_BOARD_M2GL025_MIV) || \
 	defined(CONFIG_BOARD_HIFIVE1) || \


### PR DESCRIPTION
debug.coredump.logging_backend is currently failing for most of the targets I have tried when building with clang. Depending on the target, func_3 invokes undefined behavior by dereferencing addr (which is NULL) which can lead to the compiler optimizing out significant portions of the code, resulting in unexpected/incorrect failures.

Here, clang seems to inline func_3 into main then marks the inlined implementation as unreachable (due to the UB) and removes it and everything after it in main. So, we fall through to whatever code lies past main, resulting in a test failure (timeout) from what I've seen. GCC seems to do similar things, but creates an invalid opcode instruction so the test still succeeds.

clang is correct in both optimizing this behavior out and leaving buggy code behind, so disable optimizations for func_3 to keep things under control and prevent the incorrect failures.