### PR TITLE
arch: arm64: correct a comment on CONFIG_ARM64_STACK_PROTECTION

### DIFF
--- a/arch/arm64/core/cortex_r/arm_mpu.c
+++ b/arch/arm64/core/cortex_r/arm_mpu.c
@@ -735,7 +735,7 @@ out:
 	atomic_clear(&thread->arch.flushing);
 	return ret < 0 ? ret : 0;
 }
-#endif /* defined(CONFIG_USERSPACE) || defined(CONFIG_HW_STACK_PROTECTION) */
+#endif /* defined(CONFIG_USERSPACE) || defined(CONFIG_ARM64_STACK_PROTECTION) */
 
 #if defined(CONFIG_USERSPACE)
 int arch_mem_domain_max_partitions_get(void)


### PR DESCRIPTION
There is a #endif comment which was incorrectly marked with CONFIG_HW_STACK_PROTECTION instead of
CONFIG_ARM64_STACK_PROTECTION, which is used at #if. So update it.