### PR TITLE
samples: tfm_integration: lpc55s69: Enable tfm samples

### DIFF
--- a/samples/tfm_integration/psa_protected_storage/sample.yaml
+++ b/samples/tfm_integration/psa_protected_storage/sample.yaml
@@ -9,6 +9,7 @@ common:
     - nrf5340dk/nrf5340/cpuapp/ns
     - nrf9160dk/nrf9160/ns
     - bl5340_dvk/nrf5340/cpuapp/ns
+    - lpcxpresso55s69/lpc55s69/cpu0/ns
   integration_platforms:
     - mps2/an521/cpu0/ns
   harness: console

--- a/samples/tfm_integration/tfm_secure_partition/sample.yaml
+++ b/samples/tfm_integration/tfm_secure_partition/sample.yaml
@@ -6,6 +6,7 @@ common:
     - v2m_musca_s1/musca_s1/ns
     - nrf5340dk/nrf5340/cpuapp/ns
     - nrf9160dk/nrf9160/ns
+    - lpcxpresso55s69/lpc55s69/cpu0/ns
   integration_platforms:
     - mps2/an521/cpu0/ns
   harness: console


### PR DESCRIPTION
enalbe lpcxpresso55s69/lpc55s69/cpu0/ns for supported tfm samples