### PR TITLE
boards: nordic: nrf54h20pdk: add debugging support using J-Link

### DIFF
--- a/boards/nordic/nrf54h20pdk/board.cmake
+++ b/boards/nordic/nrf54h20pdk/board.cmake
@@ -1,3 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
+
+if(CONFIG_BOARD_NRF54H20PDK_NRF54H20_CPUAPP OR CONFIG_BOARD_NRF54H20PDK_NRF54H20_CPURAD)
+  if(CONFIG_BOARD_NRF54H20PDK_NRF54H20_CPURAD)
+    set(
+      JLINK_TOOL_OPT
+      "-jlinkscriptfile ${CMAKE_CURRENT_LIST_DIR}/support/nrf54h20_cpurad.JLinkScript"
+    )
+  endif()
+
+  board_runner_args(jlink "--device=CORTEX-M33" "--speed=4000" "--tool-opt=${JLINK_TOOL_OPT}")
+  include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+endif()

--- a/boards/nordic/nrf54h20pdk/support/nrf54h20_cpurad.JLinkScript
+++ b/boards/nordic/nrf54h20pdk/support/nrf54h20_cpurad.JLinkScript
@@ -1,0 +1,4 @@
+void ConfigTargetSettings(void) {
+  JLINK_ExecCommand("CORESIGHT_AddAP = Index=1 Type=AHB-AP");
+  CORESIGHT_IndexAHBAPToUse = 1;
+}


### PR DESCRIPTION
cpuapp/cpurad can be debugged using the J-Link runner.