### PR TITLE
manifest: hal_nordic: update revision to have nrfx 3.4.0 release

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -183,7 +183,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 5470822384781624efb2fda28cbc6a895a227677
+      revision: 13ac55b5b52c905642e9c54f069109d188aa5840
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
New hal_nordic revision contains nrfx 3.4.0 which adds support for nRF54H20 and nRF54L15 devices.