### PR TITLE
soc: nordic: Refactor soc_secure.h

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -25,7 +25,13 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <zephyr/debug/stack.h>
 
 #include <soc.h>
+
+#if defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) && defined(NRF_FICR_S)
 #include <soc_secure.h>
+#else
+#include <hal/nrf_ficr.h>
+#endif
+
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 #include <zephyr/debug/stack.h>
@@ -120,7 +126,12 @@ static void nrf5_get_eui64(uint8_t *mac)
 	mac[index++] = (IEEE802154_NRF5_VENDOR_OUI >> 8) & 0xff;
 	mac[index++] = IEEE802154_NRF5_VENDOR_OUI & 0xff;
 
+#if defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) && defined(NRF_FICR_S)
 	soc_secure_read_deviceid(deviceid);
+#else
+	deviceid[0] = nrf_ficr_deviceid_get(NRF_FICR, 0);
+	deviceid[1] = nrf_ficr_deviceid_get(NRF_FICR, 1);
+#endif
 
 	factoryAddress = (uint64_t)deviceid[EUI64_ADDR_HIGH] << 32;
 	factoryAddress |= deviceid[EUI64_ADDR_LOW];

--- a/soc/nordic/common/soc_secure.h
+++ b/soc/nordic/common/soc_secure.h
@@ -15,6 +15,25 @@ void soc_secure_gpio_pin_mcu_select(uint32_t pin_number, nrf_gpio_pin_sel_t mcu)
 
 int soc_secure_mem_read(void *dst, void *src, size_t len);
 
+#else /* defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) */
+#if NRF_GPIO_HAS_SEL
+static inline void soc_secure_gpio_pin_mcu_select(uint32_t pin_number, nrf_gpio_pin_sel_t mcu)
+{
+	nrf_gpio_pin_control_select(pin_number, mcu);
+}
+#endif /* NRF_GPIO_HAS_SEL */
+
+static inline int soc_secure_mem_read(void *dst, void *src, size_t len)
+{
+	(void)memcpy(dst, src, len);
+	return 0;
+}
+
+#endif /* defined CONFIG_TRUSTED_EXECUTION_NONSECURE */
+
+/* Include these soc_secure_* functions only when the FICR is mapped as secure only */
+#if defined(NRF_FICR_S)
+#if defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
 #if defined(CONFIG_SOC_HFXO_CAP_INTERNAL)
 static inline uint32_t soc_secure_read_xosc32mtrim(void)
 {
@@ -41,31 +60,18 @@ static inline void soc_secure_read_deviceid(uint32_t deviceid[2])
 }
 
 #else /* defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) */
-
-static inline int soc_secure_mem_read(void *dst, void *src, size_t len)
-{
-	(void)memcpy(dst, src, len);
-	return 0;
-}
-
-#if NRF_GPIO_HAS_SEL
-static inline void soc_secure_gpio_pin_mcu_select(uint32_t pin_number,
-						  nrf_gpio_pin_sel_t mcu)
-{
-	nrf_gpio_pin_control_select(pin_number, mcu);
-}
-#endif /* NRF_GPIO_HAS_SEL */
-
 #if defined(CONFIG_SOC_HFXO_CAP_INTERNAL)
 static inline uint32_t soc_secure_read_xosc32mtrim(void)
 {
-	return NRF_FICR->XOSC32MTRIM;
+	return NRF_FICR_S->XOSC32MTRIM;
 }
 #endif /* defined(CONFIG_SOC_HFXO_CAP_INTERNAL) */
 
 static inline void soc_secure_read_deviceid(uint32_t deviceid[2])
 {
-	deviceid[0] = nrf_ficr_deviceid_get(NRF_FICR, 0);
-	deviceid[1] = nrf_ficr_deviceid_get(NRF_FICR, 1);
+	deviceid[0] = nrf_ficr_deviceid_get(NRF_FICR_S, 0);
+	deviceid[1] = nrf_ficr_deviceid_get(NRF_FICR_S, 1);
 }
+
 #endif /* defined CONFIG_TRUSTED_EXECUTION_NONSECURE */
+#endif /* defined(NRF_FICR_S) */


### PR DESCRIPTION
The soc_secure_* function are used by the non-secure application to access hardware resources which are mapped as secure. Using these functions for hardware resources mapped as non-secure is missleading.

We have some soc_secure_* functions which read FICR values. In nRF91 and nRF53 platforms this made sense since FICR has hardware fixed mapping as secure.
For nRF54 though the FICR has hardware fixed mapping as non-secure.

This change refactors the soc_secure.h to exclude the functions which read FICR values from being included when FICR is mapped as non-secure.

Also updates the hwinfo driver to adjust to this change.