### PR TITLE
posix: syslog: Fix uninitialized variable error

### DIFF
--- a/lib/posix/options/syslog.c
+++ b/lib/posix/options/syslog.c
@@ -56,7 +56,7 @@ void syslog(int priority, const char *format, ...)
 
 int setlogmask(int maskpri)
 {
-	int oldpri;
+	int oldpri = -1;
 
 	K_SPINLOCK(&syslog_lock) {
 		oldpri = syslog_mask;
@@ -68,7 +68,7 @@ int setlogmask(int maskpri)
 
 void vsyslog(int priority, const char *format, va_list ap)
 {
-	uint8_t mask;
+	uint8_t mask = 0;
 	int level = syslog_priority_to_zephyr_log_level(priority);
 
 	if (level < 0) {


### PR DESCRIPTION
Seen this in compiler
```
lib/posix/options/syslog.c: In function 'setlogmask': lib/posix/options/syslog.c:66:16: error: 'oldpri' may be used uninitialized
   66 |         return oldpri;
      |                ^~~~~~
lib/posix/options/syslog.c:59:13: note: 'oldpri' was declared here
   59 |         int oldpri;
      |             ^~~~~~
lib/posix/options/syslog.c: In function 'vsyslog':
lib/posix/options/syslog.c:83:33: error: 'mask' may be used uninitialized
   83 |         if ((BIT(level) & mask) == 0) {
      |             ~~~~~~~~~~~~~~~~~~~~^~~~
lib/posix/options/syslog.c:71:17: note: 'mask' was declared here
   71 |         uint8_t mask;
      |                 ^~~~
```