### PR TITLE
nrf5bsim: Update HW models and enable counter tests

### DIFF
--- a/boards/native/nrf_bsim/nrf52_bsim.yaml
+++ b/boards/native/nrf_bsim/nrf52_bsim.yaml
@@ -13,3 +13,4 @@ testing:
     - bsim_skip_CI
 supported:
   - gpio
+  - counter

--- a/tests/drivers/counter/counter_basic_api/boards/nrf52_bsim.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/nrf52_bsim.overlay
@@ -1,0 +1,1 @@
+#include "nrf52833dk_nrf52833.overlay"

--- a/tests/drivers/counter/counter_basic_api/testcase.yaml
+++ b/tests/drivers/counter/counter_basic_api/testcase.yaml
@@ -12,7 +12,9 @@ tests:
       - drivers
       - counter
     depends_on: counter
-    platform_allow: nrf52840dk/nrf52840
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52_bsim
     timeout: 400
     extra_configs:
       - CONFIG_ZERO_LATENCY_IRQS=y

--- a/tests/drivers/counter/counter_nrf_rtc/fixed_top/testcase.yaml
+++ b/tests/drivers/counter/counter_nrf_rtc/fixed_top/testcase.yaml
@@ -4,4 +4,6 @@ tests:
       - drivers
       - counter
     depends_on: counter
-    platform_allow: nrf52840dk/nrf52840
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52_bsim

--- a/west.yml
+++ b/west.yml
@@ -295,7 +295,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 319e3ebd3134935c330980dfac53d05d28c0af9a
+      revision: ffd0ddec0239a47739892f4e705e97b2285a8508
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
       revision: da78aea63159771956fe0c9263f2e6985b66e9d5


### PR DESCRIPTION
* A minor change in the counter_nrfx_rtc driver so it works also in simulation
* Update the HW models to the latest which include more functionality needed for the counter drivers to work fully
* nrf52_bsim: Claim in yaml that counter is supported
* counter driver tests: Enable both tests that run in the nrf52840 to run also in the simulated nrf52 so we have runtime tests in CI

~~Note: This PR sits directly on top of #69966 and #69967 . (#69966 should go in first as it should be backported to 3.6 as it fixes a bug)~~