### PR TITLE
soc: nordic: nrf54l: Remove redundant option

### DIFF
--- a/soc/nordic/nrf54l/Kconfig
+++ b/soc/nordic/nrf54l/Kconfig
@@ -43,12 +43,6 @@ config SOC_NRF54L_VREG_MAIN_DCDC
 config SOC_NRF54L_NORMAL_VOLTAGE_MODE
 	bool "NRF54L Normal Voltage Mode."
 
-config SOC_NRF54L_GLITCHDET_WORKAROUND
-	bool "Workaround that disables glitch detector"
-	default y
-	help
-	  Temporary workaround - disabling glitch detector to limit power consumption.
-
 if NRF_GRTC_TIMER
 
 config ELV_GRTC_LFXO_ALLOWED

--- a/soc/nordic/nrf54l/soc.c
+++ b/soc/nordic/nrf54l/soc.c
@@ -42,10 +42,6 @@ static int nordicsemi_nrf54l_init(void)
 	/* Enable ICACHE */
 	sys_cache_instr_enable();
 
-	if (IS_ENABLED(CONFIG_SOC_NRF54L_GLITCHDET_WORKAROUND)) {
-		nrf_glitchdet_enable_set(NRF_GLITCHDET, false);
-	}
-
 #if DT_ENUM_HAS_VALUE(LFXO_NODE, load_capacitors, internal)
 	uint32_t xosc32ktrim = NRF_FICR->XOSC32KTRIM;
 


### PR DESCRIPTION
The option SOC_NRF54L_GLITCHDET_WORKAROUND is not
needed anymore becuase the glitch detector is already disabled in the Nordic MDK in the hal_nordic repo.

File path in hal_nordic:
nrfx/mdk/system_nrf54l.c