### PR TITLE
tests/flash: Fix nrf52840dk configurations

### DIFF
--- a/tests/drivers/flash/common/boards/nrf52840dk_nrf52840_qspi_nor.conf
+++ b/tests/drivers/flash/common/boards/nrf52840dk_nrf52840_qspi_nor.conf
@@ -1,4 +1,5 @@
 # Minimal configuration for testing flash driver
 # on nrf52840dk/nrf52840 board
 
-CONFIG_MPU_ALLOW_FLASH_WRITE=y
+CONFIG_NORDIC_QSPI_NOR=y
+CONFIG_NORDIC_QSPI_NOR_FLASH_LAYOUT_PAGE_SIZE=4096

--- a/tests/drivers/flash/common/boards/nrf52840dk_nrf52840_soc.conf
+++ b/tests/drivers/flash/common/boards/nrf52840dk_nrf52840_soc.conf
@@ -1,4 +1,5 @@
 # Minimal configuration for testing flash driver
 # on nrf52840dk/nrf52840 board
 
-CONFIG_NORDIC_QSPI_NOR=y
+CONFIG_MPU_ALLOW_FLASH_WRITE=y
+CONFIG_NORDIC_QSPI_NOR=n

--- a/tests/drivers/flash/common/src/main.c
+++ b/tests/drivers/flash/common/src/main.c
@@ -54,6 +54,7 @@ static void *flash_driver_setup(void)
 {
 	int rc;
 
+	TC_PRINT("Test will run on device %s\n", flash_dev->name);
 	zassert_true(device_is_ready(flash_dev));
 
 	flash_params = flash_get_parameters(flash_dev);

--- a/tests/drivers/flash/common/testcase.yaml
+++ b/tests/drivers/flash/common/testcase.yaml
@@ -5,20 +5,20 @@ common:
 tests:
   drivers.flash.common.nrf_qspi_nor:
     platform_allow: nrf52840dk/nrf52840
-    extra_args: OVERLAY_CONFIG=boards/nrf52840_flash_qspi.conf
+    extra_args: OVERLAY_CONFIG=boards/nrf52840dk_nrf52840_qspi_nor.conf
     integration_platforms:
       - nrf52840dk/nrf52840
   drivers.flash.common.nrf_qspi_nor.size_in_bytes:
     platform_allow: nrf52840dk/nrf52840
     extra_args:
-      - OVERLAY_CONFIG=boards/nrf52840_flash_qspi.conf
+      - OVERLAY_CONFIG=boards/nrf52840dk_nrf52840_qspi_nor.conf
       - DTC_OVERLAY_FILE=boards/nrf52840_size_in_bytes.overlay
     integration_platforms:
       - nrf52840dk/nrf52840
   drivers.flash.common.nrf_qspi_nor_4B_addr:
     platform_allow: nrf52840dk/nrf52840
     extra_args:
-      - OVERLAY_CONFIG=boards/nrf52840_flash_qspi.conf
+      - OVERLAY_CONFIG=boards/nrf52840dk_nrf52840_qspi_nor.conf
       - DTC_OVERLAY_FILE=boards/nrf52840dk_mx25l51245g.overlay
     harness_config:
       fixture: external_flash_mx25l51245g
@@ -26,7 +26,7 @@ tests:
       - nrf52840dk/nrf52840
   drivers.flash.common.soc_flash_nrf:
     platform_allow: nrf52840dk/nrf52840
-    extra_args: OVERLAY_CONFIG=boards/nrf52840_flash_soc.conf
+    extra_args: OVERLAY_CONFIG=boards/nrf52840dk_nrf52840_soc.conf
     integration_platforms:
       - nrf52840dk/nrf52840
   drivers.flash.common.default:


### PR DESCRIPTION
The commit disables QSPI in SoC configurations, as QSPI got enabled by default and test never really run on SoC.

In QSPI configuration erase page size is set to 4096 There is not TC_PRINT showing name of device that the test will run on, in test setup.

The nrf52840dk configuration files have been renamed to reflect dk name and SoC.