### PR TITLE
kernel/sched: Don't touch deadline values on queued threads

### DIFF
--- a/tests/kernel/sched/deadline/testcase.yaml
+++ b/tests/kernel/sched/deadline/testcase.yaml
@@ -1,3 +1,7 @@
 tests:
   kernel.scheduler.deadline:
     tags: kernel
+  kernel.scheduler.deadline.scalable:
+    tags: kernel
+    extra_configs:
+      - CONFIG_SCHED_SCALABLE=y


### PR DESCRIPTION
k_thread_deadline_set() would modify the thread's deadline and then, if it was in the run queue, requeue it to put it at the right spot. Sounds right, right?

It's wrong.  The deadline field is part of the thread priority, so this results in a mis-ordered list.  For dlist backends, that's benign as the removal works anyway, but if CONFIG_SCHED_SCALABLE=y we've now broken the sorting order of an in-tree item and corrupted the rbtree! 