### PR TITLE
Add OS_SDK_ZEPHYR definition to LVGL compile defines

### DIFF
--- a/modules/lvgl/CMakeLists.txt
+++ b/modules/lvgl/CMakeLists.txt
@@ -17,6 +17,7 @@ zephyr_include_directories(include)
 
 zephyr_compile_definitions(LV_CONF_INCLUDE_SIMPLE=1)
 zephyr_compile_definitions(LV_CONF_PATH=${CMAKE_CURRENT_SOURCE_DIR}/include/lv_conf.h)
+zephyr_library_compile_definitions(OS_SDK_ZEPHYR=1)
 
 zephyr_library_sources(
     ${LVGL_DIR}/src/core/lv_disp.c


### PR DESCRIPTION
This enables us to use it in NXP's PXP accelerator (and later VGlite) support in LVGL. 

(LVGL supports PXP, but only for freertos right now)

For a little more detail, Zephyr PXP support in LVGL requires two things:

1. For thread safety, LVGL uses a semaphore to tell when pxp completion happens, and so we need to use a zephyr semaphore to do that.  See https://github.com/lvgl/lvgl/blob/master/src/draw/nxp/pxp/lv_pxp_osa.c for what i mean
2. Connecting the interrupt to the LVGL PXP Interrupt handler

To do #1, we need a define we can ifdef off in LVGL.  The current FreeRTOS one is named OS_SDK_FREE_RTOS, so this introduces OS_SDK_ZEPHYR.

The rest of the patches for #1 go upstream, and are small (see https://github.com/zephyrproject-rtos/lvgl/compare/zephyr...dberlin:lvgl:zephyr)

If zephyr is going to stick at 8.x for a bit, i can send backport patches as well

For #2, i'll send a patch to do the irq connect in lvgl_init if pxp  support is enabled.

Note: All of this is unrelated to the current zephyr DMA driver and ELCDIF driver for PXP (which are related to doing hardware accelerated rotation for the display)