### PR TITLE
soc: nxp: imxrt: renable DCDC adjustment for RT11xx

### DIFF
--- a/soc/nxp/imxrt/imxrt11xx/Kconfig
+++ b/soc/nxp/imxrt/imxrt11xx/Kconfig
@@ -70,6 +70,7 @@ config ADJUST_LDO
 	bool "Adjust LDO setting"
 
 config ADJUST_DCDC
+	default y
 	bool "Adjust internal DCDC output"
 
 endif # SOC_SERIES_IMXRT11XX


### PR DESCRIPTION
DCDC adjustment was enabled by default for RT11xx series before HWMv2 transition. Reenable it, as this is needed for some higher power applications (such as display output)