### PR TITLE
drivers: i2s: Fix compilation warning in i2s_mcux_flexcomm

### DIFF
--- a/drivers/i2s/i2s_mcux_flexcomm.c
+++ b/drivers/i2s/i2s_mcux_flexcomm.c
@@ -17,6 +17,8 @@
 #include <zephyr/irq.h>
 #include <zephyr/drivers/pinctrl.h>
 
+#ifdef CONFIG_DT_HAS_NXP_LPC_I2S_ENABLED
+
 LOG_MODULE_REGISTER(i2s_mcux_flexcomm);
 
 #define NUM_RX_DMA_BLOCKS	2
@@ -990,3 +992,4 @@ static int i2s_mcux_init(const struct device *dev)
 	}
 
 DT_INST_FOREACH_STATUS_OKAY(I2S_MCUX_FLEXCOMM_DEVICE)
+#endif /* ifdef CONFIG_DT_HAS_NXP_LPC_I2S_ENABLED */


### PR DESCRIPTION
CONFIG_I2S_MCUX_FLEXCOMM gates compilation of i2s_mcu_flexcomm.c, as well as the mcux-sdk fsl_i2s.c driver file.  If the config is defined but there are no devices that use the driver in the device tree, a few compilation warnings will happen.  Added an ifdef around the code to fix it.