### PR TITLE
boards: sparkfun: Fix sparkfun_pro_micro_rp2040 gpiomap

### DIFF
--- a/boards/adafruit/kb2040/sparkfun_pro_micro_connector.dtsi
+++ b/boards/adafruit/kb2040/sparkfun_pro_micro_connector.dtsi
@@ -11,8 +11,8 @@
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map
-			= <0 0 &gpio0 0 0>		/* D0 */
-			, <1 0 &gpio0 1 0>		/* D1 */
+			= <1 0 &gpio0 0 0>		/* D1 */
+			, <0 0 &gpio0 1 0>		/* D0 */
 			, <2 0 &gpio0 2 0>		/* D2 */
 			, <3 0 &gpio0 3 0>		/* D3 */
 			, <4 0 &gpio0 4 0>		/* D4/A6 */

--- a/boards/sparkfun/pro_micro_rp2040/sparkfun_pro_micro_connector.dtsi
+++ b/boards/sparkfun/pro_micro_rp2040/sparkfun_pro_micro_connector.dtsi
@@ -11,8 +11,8 @@
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map
-			= <0 0 &gpio0 0 0>		/* D0 */
-			, <1 0 &gpio0 1 0>		/* D1 */
+			= <1 0 &gpio0 0 0>		/* D1 */
+			, <0 0 &gpio0 1 0>		/* D0 */
 			, <2 0 &gpio0 2 0>		/* D2 */
 			, <3 0 &gpio0 3 0>		/* D3 */
 			, <4 0 &gpio0 4 0>		/* D4/A6 */

--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -28,6 +28,9 @@ Kernel
 Boards
 ******
 
+* Reordered D1 and D0 in the `pro_micro` connector gpio-map for SparkFun Pro Micro RP2040 to match
+  original Pro Micro definition. Out-of-tree shields must be updated to reflect this change.
+
 Modules
 *******
 

--- a/dts/bindings/gpio/sparkfun-pro-micro-header.yaml
+++ b/dts/bindings/gpio/sparkfun-pro-micro-header.yaml
@@ -16,19 +16,21 @@ description: |
 
     This binding provides a nexus mapping for 18 pins, as depicted below:
 
-        0 TX0                    RAW    -
-        1 RX1                    GND    -
-        - GND                    RST    -
-        - GND                    VCC    -
-        2 D2                     D21/A3 21
-        3 D3                     D20/A2 20
-        4 A4                     D19/A1 19
-        5 D5                     D18/A0 18
-        6 D6                     D15    15
-        7 D7                     D14    14
-        8 D8                     D16    16
-        9 D9                     D10    10
+        1 D1/TXO                 RAW     -
+        0 D0/RXI                 GND     -
+        - GND                    RST     -
+        - GND                    VCC     -
+        2 D2                     D21/A3  21
+        3 D3                     D20/A2  20
+        4 D4/A6                  D19/A1  19
+        5 D5                     D18/A0  18
+        6 D6/A7                  D15     15
+        7 D7                     D14     14
+        8 D8/A8                  D16     16
+        9 D9/A9                  D10/A10 10
 
+    A graphical datasheet of the headers can be seen here:
+    https://cdn.sparkfun.com/assets/f/d/8/0/d/ProMicro16MHzv2.pdf
 
 compatible: "sparkfun,pro-micro-gpio"
 


### PR DESCRIPTION
The SparkFun Pro Micro pins are numbered 1, 0, GND, ... from top left whereas the SparkFun Pro Micro RP2040 and the RP2040 Community Edition boards are numbered 0, 1, GND, ... , so the pro_micro: connector gpio-map should reflect that.

Graphical Datasheet for SparkFun Pro Micro RP2040: https://cdn.sparkfun.com/assets/e/2/7/6/b/ProMicroRP2040_Graphical_Datasheet.pdf

Graphical Datasheet for SparkFun Pro Micro:
https://cdn.sparkfun.com/assets/f/d/8/0/d/ProMicro16MHzv2.pdf