### PR TITLE
boards: seeed: doc: fix links to the device tree files

### DIFF
--- a/boards/seeed/lora_e5_dev_board/doc/lora_e5_dev_board.rst
+++ b/boards/seeed/lora_e5_dev_board/doc/lora_e5_dev_board.rst
@@ -112,8 +112,8 @@ features:
 Other hardware features are not yet supported on this Zephyr port.
 
 The default configuration can be found in:
-- :zephyr_file:`boards/seeed_studio/lora_e5_dev_board/lora_e5_dev_board_defconfig`
-- :zephyr_file:`boards/seeed_studio/lora_e5_dev_board/lora_e5_dev_board.dts`
+- :zephyr_file:`boards/seeed/lora_e5_dev_board/lora_e5_dev_board_defconfig`
+- :zephyr_file:`boards/seeed/lora_e5_dev_board/lora_e5_dev_board.dts`
 
 
 Connections and IOs

--- a/boards/seeed/lora_e5_mini/doc/index.rst
+++ b/boards/seeed/lora_e5_mini/doc/index.rst
@@ -102,8 +102,8 @@ Other hardware features are not yet supported on this Zephyr port.
 
 The default configuration can be found in:
 
-- :zephyr_file:`boards/seeed_studio/lora_e5_mini/lora_e5_mini_defconfig`
-- :zephyr_file:`boards/seeed_studio/lora_e5_mini/lora_e5_mini.dts`
+- :zephyr_file:`boards/seeed/lora_e5_mini/lora_e5_mini_defconfig`
+- :zephyr_file:`boards/seeed/lora_e5_mini/lora_e5_mini.dts`
 
 
 Connections and IOs

--- a/boards/seeed/seeeduino_xiao/doc/index.rst
+++ b/boards/seeed/seeeduino_xiao/doc/index.rst
@@ -59,7 +59,7 @@ features:
 Other hardware features are not currently supported by Zephyr.
 
 The default configuration can be found in the Kconfig file
-:zephyr_file:`boards/seeed_studio/seeeduino_xiao/seeeduino_xiao_defconfig`.
+:zephyr_file:`boards/seeed/seeeduino_xiao/seeeduino_xiao_defconfig`.
 
 Connections and IOs
 ===================

--- a/boards/seeed/wio_terminal/doc/index.rst
+++ b/boards/seeed/wio_terminal/doc/index.rst
@@ -92,7 +92,7 @@ The wio_terminal board configuration supports the following hardware features:
 Other hardware features are not currently supported by Zephyr.
 
 The default configuration can be found in the Kconfig file
-:zephyr_file:`boards/seeed_studio/wio_terminal/wio_terminal_defconfig`.
+:zephyr_file:`boards/seeed/wio_terminal/wio_terminal_defconfig`.
 
 Zephyr can use the default Cortex-M SYSTICK timer or the SAM0 specific RTC.
 To use the RTC, set :kconfig:option:`CONFIG_CORTEX_M_SYSTICK=n` and set

--- a/boards/seeed/xiao_ble/doc/index.rst
+++ b/boards/seeed/xiao_ble/doc/index.rst
@@ -182,7 +182,7 @@ properly with Zephyr:
 
 You can build and flash the examples to make sure Zephyr is running correctly on
 your board. The LED definitions can be found in
-:zephyr_file:`boards/seeed_studio/xiao_ble/xiao_ble_common.dtsi`.
+:zephyr_file:`boards/seeed/xiao_ble/xiao_ble_common.dtsi`.
 
 Testing shell over USB in the XIAO BLE (Sense)
 **********************************************


### PR DESCRIPTION
Fix links to the device tree file in the documentation.