### PR TITLE
input: kbd_matrix: define PRIkbdrow coherently

### DIFF
--- a/drivers/input/input_kbd_matrix.c
+++ b/drivers/input/input_kbd_matrix.c
@@ -217,7 +217,7 @@ static bool input_kbd_matrix_check_key_events(const struct device *dev)
 	key_pressed = input_kbd_matrix_scan(dev);
 
 	for (int c = 0; c < cfg->col_size; c++) {
-		LOG_DBG("c=%2d u=" PRIkbdrow " p=" PRIkbdrow " n=" PRIkbdrow,
+		LOG_DBG("c=%2d u=%" PRIkbdrow " p=%" PRIkbdrow " n=%" PRIkbdrow,
 			c,
 			cfg->matrix_unstable_state[c],
 			cfg->matrix_previous_state[c],

--- a/include/zephyr/input/input_kbd_matrix.h
+++ b/include/zephyr/input/input_kbd_matrix.h
@@ -32,10 +32,10 @@
 /** Row entry data type */
 #if CONFIG_INPUT_KBD_MATRIX_16_BIT_ROW
 typedef uint16_t kbd_row_t;
-#define PRIkbdrow "%04x"
+#define PRIkbdrow "04" PRIx16
 #else
 typedef uint8_t kbd_row_t;
-#define PRIkbdrow "%02x"
+#define PRIkbdrow "02" PRIx8
 #endif
 
 #if defined(CONFIG_INPUT_KBD_ACTUAL_KEY_MASK_DYNAMIC) || defined(__DOXYGEN__)

--- a/subsys/input/input_utils.c
+++ b/subsys/input/input_utils.c
@@ -142,7 +142,7 @@ static void kbd_matrix_state_log_entry(char *header, kbd_row_t *data)
 		char *sep = (i + 1) < cfg->col_size ? " " : "";
 
 		if (data[i] != 0) {
-			ret = snprintf(buf, size, PRIkbdrow "%s", data[i], sep);
+			ret = snprintf(buf, size, "%" PRIkbdrow "%s", data[i], sep);
 		} else {
 			ret = snprintf(buf, size, "%s%s", blank, sep);
 		}

--- a/tests/drivers/input/kbd_matrix/src/main.c
+++ b/tests/drivers/input/kbd_matrix/src/main.c
@@ -80,7 +80,7 @@ void input_kbd_matrix_drive_column_hook(const struct device *dev, int col)
 static void state_set_rows_by_column(kbd_row_t c0, kbd_row_t c1, kbd_row_t c2)
 {
 	memcpy(&state.rows, (kbd_row_t[]){c0, c1, c2}, sizeof(state.rows));
-	TC_PRINT("set state [" PRIkbdrow " " PRIkbdrow " " PRIkbdrow "]\n", c0, c1, c2);
+	TC_PRINT("set state [%" PRIkbdrow " %" PRIkbdrow " %" PRIkbdrow "]\n", c0, c1, c2);
 }
 
 static struct {


### PR DESCRIPTION
It's not supposed to have the "%" in the macro, reuse the existin one for the data type.