### PR TITLE
tests: llext: compile architectures not supported yet

### DIFF
--- a/tests/subsys/llext/simple/CMakeLists.txt
+++ b/tests/subsys/llext/simple/CMakeLists.txt
@@ -15,6 +15,7 @@ target_include_directories(app PRIVATE
   ${ZEPHYR_BASE}/arch/${ARCH}/include
 )
 
+if(NOT LOADER_BUILD_ONLY)
 # generate extension targets foreach extension given by name
 foreach(ext_name hello_world logging relative_jump)
   set(ext_src ${PROJECT_SOURCE_DIR}/src/${ext_name}_ext.c)
@@ -26,3 +27,4 @@ foreach(ext_name hello_world logging relative_jump)
   )
   generate_inc_file_for_target(app ${ext_bin} ${ext_inc})
 endforeach()
+endif()

--- a/tests/subsys/llext/simple/src/test_llext_simple.c
+++ b/tests/subsys/llext/simple/src/test_llext_simple.c
@@ -120,6 +120,8 @@ void load_call_unload(struct llext_test *test_case)
 
 	llext_unload(&ext);
 }
+
+#ifndef LOADER_BUILD_ONLY
 /*
  * Attempt to load, list, list symbols, call a fn, and unload each
  * extension in the test table. This excercises loading, calling into, and
@@ -151,6 +153,7 @@ static LLEXT_CONST uint8_t relative_jump_ext[] __aligned(4) = {
 	#include "relative_jump.inc"
 };
 LLEXT_LOAD_UNLOAD(relative_jump, true)
+#endif /* ! LOADER_BUILD_ONLY */
 
 /*
  * Ensure that EXPORT_SYMBOL does indeed provide a symbol and a valid address

--- a/tests/subsys/llext/simple/testcase.yaml
+++ b/tests/subsys/llext/simple/testcase.yaml
@@ -6,7 +6,25 @@ common:
   platform_exclude:
     - numaker_pfm_m487 # See #63167
     - qemu_cortex_r5 # unsupported relocations
+
 tests:
+  # add_llext_target() supports a fairly limited number of
+  # CONFIG_urations.  For instance, invoking add_llext_target()
+  # currently blocks us from compiling subsys/llext/*.c in 64bits mode;
+  # CMake aborts before even invoking the compiler.
+  #
+  # While there is in practice no value in compiling subsys/llext/*.c
+  # without actually running it to load some extension, let's keep it in
+  # good shape and ready to be used when add_llext_target()
+  # limitations get lifted in the future.
+  llext.simple.loader_build:
+    build_only: true
+    # How to override the above and allow ANY arch?
+    arch_allow: arm arm64 x86 x86_64 xtensa posix
+    extra_args:
+      - LOADER_BUILD_ONLY=1
+      - EXTRA_CFLAGS=-DLOADER_BUILD_ONLY=1
+
   llext.simple.readonly:
     arch_exclude: xtensa # for now
     filter: not CONFIG_MPU and not CONFIG_MMU and not CONFIG_SOC_SERIES_S32ZE


### PR DESCRIPTION
For now llext supports a very limited number of architectures.  This restriction is enforced by add_llext_target() in CMake at configuration time.

Add a new `LOADER_BUILD_ONLY` conditional in `tests/subsys/llext/simple/` and a new `llext.simple.loader_build`, `build_only` test that does not invoke `add_llext_target()` and only compiles the llext framework code.

This helps find and fix bugs in `subsys/llext/*.c` and make it ready to be used when add_llext_target() limitations are lifted.

Note this is pure `tests/` change without any change in the actual llext framework code. The existing test is only modified to conditionally invoke add_llext_target().