### PR TITLE
scripts: kconfig: Prevent KeyError in case of missing WARN_DEPRECATED and WARN_EXPERIMENTAL symbols.

### DIFF
--- a/scripts/kconfig/kconfig.py
+++ b/scripts/kconfig/kconfig.py
@@ -78,6 +78,14 @@ def main():
         check_assigned_sym_values(kconf)
         check_assigned_choice_values(kconf)
 
+    # In case the application provides its own Kconfig file a common mistake
+    # is to forget to "source 'Kconfig.zephyr'" in the Kconfig hierarchy. In
+    # such a case, the below keys in konf.syms do not exist.
+    if 'WARN_DEPRECATED' not in kconf.syms or 'WARN_EXPERIMENTAL' not in kconf.syms:
+        err(f"""\
+Failed to parse {args.kconfig_file}. Please make sure that 'Kconfig.zephyr'
+is sourced once in your Kconfig hierarchy.""")
+
     if kconf.syms.get('WARN_DEPRECATED', kconf.y).tri_value == 2:
         check_deprecated(kconf)
 


### PR DESCRIPTION
When providing `Kconfig` files it is easy to forget to `source Kconfig.zephyr`, which leads to a nasty `KeyError` in `kconfig.py` instead of providing a helpful error message.

Since this seems to be the most common pitfall, I'd suggest providing an error message that hints at a missing `Kconfig.zephyr`. I'm pretty new to the project so there might be other reasons for the keys to be missing, but for me this was the most straight-forward location to include a "fix".