### PR TITLE
kernel: add closing comments to config endifs

### DIFF
--- a/include/zephyr/kernel/internal/mm.h
+++ b/include/zephyr/kernel/internal/mm.h
@@ -39,7 +39,7 @@
 			 (CONFIG_SRAM_BASE_ADDRESS + CONFIG_SRAM_OFFSET))
 #else
 #define Z_MEM_VM_OFFSET	0
-#endif
+#endif /* CONFIG_MMU */
 
 #define Z_MEM_PHYS_ADDR(virt)	((virt) - Z_MEM_VM_OFFSET)
 #define Z_MEM_VIRT_ADDR(phys)	((phys) + Z_MEM_VM_OFFSET)
@@ -70,26 +70,26 @@ static inline uintptr_t z_mem_phys_addr(void *virt)
 	__ASSERT(
 #if CONFIG_KERNEL_VM_BASE != 0
 		 (addr >= CONFIG_KERNEL_VM_BASE) &&
-#endif
+#endif /* CONFIG_KERNEL_VM_BASE != 0 */
 #if (CONFIG_KERNEL_VM_BASE + CONFIG_KERNEL_VM_SIZE) != 0
 		 (addr < (CONFIG_KERNEL_VM_BASE +
 			  (CONFIG_KERNEL_VM_SIZE))),
 #else
 		 false,
-#endif
+#endif /* CONFIG_KERNEL_VM_BASE + CONFIG_KERNEL_VM_SIZE != 0 */
 		 "address %p not in permanent mappings", virt);
 #else
 	/* Should be identity-mapped */
 	__ASSERT(
 #if CONFIG_SRAM_BASE_ADDRESS != 0
 		 (addr >= CONFIG_SRAM_BASE_ADDRESS) &&
-#endif
+#endif /* CONFIG_SRAM_BASE_ADDRESS != 0 */
 #if (CONFIG_SRAM_BASE_ADDRESS + (CONFIG_SRAM_SIZE * 1024UL)) != 0
 		 (addr < (CONFIG_SRAM_BASE_ADDRESS +
 			  (CONFIG_SRAM_SIZE * 1024UL))),
 #else
 		 false,
-#endif
+#endif /* (CONFIG_SRAM_BASE_ADDRESS + (CONFIG_SRAM_SIZE * 1024UL)) != 0 */
 		 "physical address 0x%lx not in RAM",
 		 (unsigned long)addr);
 #endif /* CONFIG_MMU */
@@ -111,15 +111,15 @@ static inline void *z_mem_virt_addr(uintptr_t phys)
 	__ASSERT(
 #if CONFIG_SRAM_BASE_ADDRESS != 0
 		 (phys >= CONFIG_SRAM_BASE_ADDRESS) &&
-#endif
+#endif /* CONFIG_SRAM_BASE_ADDRESS != 0 */
 #if (CONFIG_SRAM_BASE_ADDRESS + (CONFIG_SRAM_SIZE * 1024UL)) != 0
 		 (phys < (CONFIG_SRAM_BASE_ADDRESS +
 			  (CONFIG_SRAM_SIZE * 1024UL))),
 #else
 		 false,
-#endif
+#endif /* (CONFIG_SRAM_BASE_ADDRESS + (CONFIG_SRAM_SIZE * 1024UL)) != 0 */
 		 "physical address 0x%lx not in RAM", (unsigned long)phys);
-#endif
+#endif /* CONFIG_KERNEL_VM_USE_CUSTOM_MEM_RANGE_CHECK */
 
 	/* TODO add assertion that this page frame is pinned to boot mapping,
 	 * the above check won't be sufficient with demand paging

--- a/include/zephyr/kernel/internal/smp.h
+++ b/include/zephyr/kernel/internal/smp.h
@@ -8,4 +8,4 @@
 
 void z_sched_ipi(void);
 
-#endif
+#endif /* ZEPHYR_INCLUDE_KERNEL_INTERNAL_SMP_H_ */

--- a/include/zephyr/kernel/mm.h
+++ b/include/zephyr/kernel/mm.h
@@ -11,7 +11,7 @@
 #include <zephyr/toolchain.h>
 #if defined(CONFIG_ARM_MMU) && defined(CONFIG_ARM64)
 #include <zephyr/arch/arm64/arm_mem.h>
-#endif
+#endif /* CONFIG_ARM_MMU && CONFIG_ARM64 */
 
 #include <zephyr/kernel/internal/mm.h>
 

--- a/include/zephyr/kernel/mm/demand_paging.h
+++ b/include/zephyr/kernel/mm/demand_paging.h
@@ -47,7 +47,7 @@ struct k_mem_paging_stats_t {
 #if !defined(CONFIG_DEMAND_PAGING_ALLOW_IRQ) || defined(__DOXYGEN__)
 		/** Number of page faults while in ISR */
 		unsigned long			in_isr;
-#endif
+#endif /* !CONFIG_DEMAND_PAGING_ALLOW_IRQ */
 	} pagefaults;
 
 	struct {

--- a/include/zephyr/kernel/obj_core.h
+++ b/include/zephyr/kernel/obj_core.h
@@ -76,7 +76,7 @@ struct k_obj_core;
 #else
 #define K_OBJ_CORE_INIT(objp, type)   do { } while (0)
 #define K_OBJ_CORE_LINK(objp)         do { } while (0)
-#endif
+#endif /* CONFIG_OBJ_CORE */
 
 /**
  * INTERNAL_HIDDEN @endcond
@@ -114,7 +114,7 @@ struct k_obj_type {
 #ifdef CONFIG_OBJ_CORE_STATS
 	/** Pointer to object core statistics descriptor */
 	struct k_obj_core_stats_desc *stats_desc;
-#endif
+#endif /* CONFIG_OBJ_CORE_STATS */
 };
 
 /** Object core structure */
@@ -123,7 +123,7 @@ struct k_obj_core {
 	struct k_obj_type *type;   /**< Object type to which object belongs */
 #ifdef CONFIG_OBJ_CORE_STATS
 	void  *stats;              /**< Pointer to kernel object's stats */
-#endif
+#endif /* CONFIG_OBJ_CORE_STATS */
 };
 
 /**
@@ -280,7 +280,7 @@ static inline void k_obj_core_stats_init(struct k_obj_core *obj_core,
 {
 	obj_core->stats = stats;
 }
-#endif
+#endif /* CONFIG_OBJ_CORE_STATS */
 
 /**
  * @brief Register kernel object for gathering statistics

--- a/include/zephyr/kernel/stats.h
+++ b/include/zephyr/kernel/stats.h
@@ -26,8 +26,8 @@ struct k_cycle_stats {
 	uint64_t  longest;      /**< \# of cycles in longest usage window */
 	uint32_t  num_windows;  /**< \# of usage windows */
 	/** @} */
-#endif
+#endif /* CONFIG_SCHED_THREAD_USAGE_ANALYSIS */
 	bool      track_usage;  /**< true if gathering usage stats */
 };
 
-#endif
+#endif /* ZEPHYR_INCLUDE_KERNEL_STATS_H_ */

--- a/include/zephyr/kernel/thread.h
+++ b/include/zephyr/kernel/thread.h
@@ -9,7 +9,7 @@
 
 #ifdef CONFIG_DEMAND_PAGING_THREAD_STATS
 #include <zephyr/kernel/mm/demand_paging.h>
-#endif
+#endif /* CONFIG_DEMAND_PAGING_THREAD_STATS */
 
 #include <zephyr/kernel/stats.h>
 #include <zephyr/sys/arch_interface.h>
@@ -38,7 +38,7 @@ struct __thread_entry {
 	void *parameter2;
 	void *parameter3;
 };
-#endif
+#endif /* CONFIG_THREAD_MONITOR */
 
 struct k_thread;
 
@@ -96,14 +96,14 @@ struct _thread_base {
 #else /* Little Endian */
 			int8_t prio;
 			uint8_t sched_locked;
-#endif
+#endif /* CONFIG_BIG_ENDIAN */
 		};
 		uint16_t preempt;
 	};
 
 #ifdef CONFIG_SCHED_DEADLINE
 	int prio_deadline;
-#endif
+#endif /* CONFIG_SCHED_DEADLINE */
 
 	uint32_t order_key;
 
@@ -117,7 +117,7 @@ struct _thread_base {
 	/* Recursive count of irq_lock() calls */
 	uint8_t global_lock_count;
 
-#endif
+#endif /* CONFIG_SMP */
 
 #ifdef CONFIG_SCHED_CPU_MASK
 	/* "May run on" bits for each CPU */
@@ -125,7 +125,7 @@ struct _thread_base {
 	uint8_t cpu_mask;
 #else
 	uint16_t cpu_mask;
-#endif
+#endif /* CONFIG_MP_MAX_NUM_CPUS */
 #endif /* CONFIG_SCHED_CPU_MASK */
 
 	/* data returned by APIs */
@@ -134,17 +134,17 @@ struct _thread_base {
 #ifdef CONFIG_SYS_CLOCK_EXISTS
 	/* this thread's entry in a timeout queue */
 	struct _timeout timeout;
-#endif
+#endif /* CONFIG_SYS_CLOCK_EXISTS */
 
 #ifdef CONFIG_TIMESLICE_PER_THREAD
 	int32_t slice_ticks;
 	k_thread_timeslice_fn_t slice_expired;
 	void *slice_data;
-#endif
+#endif /* CONFIG_TIMESLICE_PER_THREAD */
 
 #ifdef CONFIG_SCHED_THREAD_USAGE
 	struct k_cycle_stats  usage;   /* Track thread usage statistics */
-#endif
+#endif /* CONFIG_SCHED_THREAD_USAGE */
 };
 
 typedef struct _thread_base _thread_base_t;
@@ -190,9 +190,9 @@ struct _mem_domain_info {
 struct _thread_userspace_local_data {
 #if defined(CONFIG_ERRNO) && !defined(CONFIG_ERRNO_IN_TLS) && !defined(CONFIG_LIBC_ERRNO)
 	int errno_var;
-#endif
+#endif /* CONFIG_ERRNO && !CONFIG_ERRNO_IN_TLS && !CONFIG_LIBC_ERRNO */
 };
-#endif
+#endif /* CONFIG_THREAD_USERSPACE_LOCAL_DATA */
 
 typedef struct k_thread_runtime_stats {
 #ifdef CONFIG_SCHED_THREAD_USAGE
@@ -203,7 +203,7 @@ typedef struct k_thread_runtime_stats {
 	 * as the total # of non-idle cycles. In the context of CPU statistics,
 	 * it refers to the sum of non-idle + idle cycles.
 	 */
-#endif
+#endif /* CONFIG_SCHED_THREAD_USAGE */
 
 #ifdef CONFIG_SCHED_THREAD_USAGE_ANALYSIS
 	/*
@@ -216,7 +216,7 @@ typedef struct k_thread_runtime_stats {
 	uint64_t current_cycles;      /* current # of non-idle cycles */
 	uint64_t peak_cycles;         /* peak # of non-idle cycles */
 	uint64_t average_cycles;      /* average # of non-idle cycles */
-#endif
+#endif /* CONFIG_SCHED_THREAD_USAGE_ANALYSIS */
 
 #ifdef CONFIG_SCHED_THREAD_USAGE_ALL
 	/*
@@ -226,7 +226,7 @@ typedef struct k_thread_runtime_stats {
 	 */
 
 	uint64_t idle_cycles;
-#endif
+#endif /* CONFIG_SCHED_THREAD_USAGE_ALL */
 
 #if defined(__cplusplus) && !defined(CONFIG_SCHED_THREAD_USAGE) &&                                 \
 	!defined(CONFIG_SCHED_THREAD_USAGE_ANALYSIS) && !defined(CONFIG_SCHED_THREAD_USAGE_ALL)
@@ -262,7 +262,7 @@ struct k_thread {
 
 #if defined(CONFIG_POLL)
 	struct z_poller poller;
-#endif
+#endif /* CONFIG_POLL */
 
 #if defined(CONFIG_EVENTS)
 	struct k_thread *next_event_link;
@@ -272,7 +272,7 @@ struct k_thread {
 
 	/** true if timeout should not wake the thread */
 	bool no_wake_on_timeout;
-#endif
+#endif /* CONFIG_EVENTS */
 
 #if defined(CONFIG_THREAD_MONITOR)
 	/** thread entry and parameters description */
@@ -280,28 +280,28 @@ struct k_thread {
 
 	/** next item in list of all threads */
 	struct k_thread *next_thread;
-#endif
+#endif /* CONFIG_THREAD_MONITOR */
 
 #if defined(CONFIG_THREAD_NAME)
 	/** Thread name */
 	char name[CONFIG_THREAD_MAX_NAME_LEN];
-#endif
+#endif /* CONFIG_THREAD_NAME */
 
 #ifdef CONFIG_THREAD_CUSTOM_DATA
 	/** crude thread-local storage */
 	void *custom_data;
-#endif
+#endif /* CONFIG_THREAD_CUSTOM_DATA */
 
 #ifdef CONFIG_THREAD_USERSPACE_LOCAL_DATA
 	struct _thread_userspace_local_data *userspace_local_data;
-#endif
+#endif /* CONFIG_THREAD_USERSPACE_LOCAL_DATA */
 
 #if defined(CONFIG_ERRNO) && !defined(CONFIG_ERRNO_IN_TLS) && !defined(CONFIG_LIBC_ERRNO)
 #ifndef CONFIG_USERSPACE
 	/** per-thread errno variable */
 	int errno_var;
-#endif
-#endif
+#endif /* CONFIG_USERSPACE */
+#endif /* CONFIG_ERRNO && !CONFIG_ERRNO_IN_TLS && !CONFIG_LIBC_ERRNO */
 
 #if defined(CONFIG_THREAD_STACK_INFO)
 	/** Stack Info */
@@ -328,7 +328,7 @@ struct k_thread {
 
 	/** Context handle returned via arch_switch() */
 	void *switch_handle;
-#endif
+#endif /* CONFIG_USE_SWITCH */
 	/** resource pool */
 	struct k_heap *resource_pool;
 
@@ -340,21 +340,21 @@ struct k_thread {
 #ifdef CONFIG_DEMAND_PAGING_THREAD_STATS
 	/** Paging statistics */
 	struct k_mem_paging_stats_t paging_stats;
-#endif
+#endif /* CONFIG_DEMAND_PAGING_THREAD_STATS */
 
 #ifdef CONFIG_PIPES
 	/** Pipe descriptor used with blocking k_pipe operations */
 	struct _pipe_desc pipe_desc;
-#endif
+#endif /* CONFIG_PIPES */
 
 #ifdef CONFIG_OBJ_CORE_THREAD
 	struct k_obj_core  obj_core;
-#endif
+#endif /* CONFIG_OBJ_CORE_THREAD */
 
 #ifdef CONFIG_SMP
 	/** threads waiting in k_thread_suspend() */
 	_wait_q_t  halt_queue;
-#endif
+#endif /* CONFIG_SMP */
 
 	/** arch-specifics: must always be at the end */
 	struct _thread_arch arch;
@@ -363,4 +363,4 @@ struct k_thread {
 typedef struct k_thread _thread_t;
 typedef struct k_thread *k_tid_t;
 
-#endif
+#endif /* ZEPHYR_INCLUDE_KERNEL_THREAD_H_ */

--- a/include/zephyr/kernel/thread_stack.h
+++ b/include/zephyr/kernel/thread_stack.h
@@ -92,7 +92,7 @@ static inline char *z_stack_ptr_align(char *ptr)
 #define K_KERNEL_STACK_RESERVED	((size_t)ARCH_KERNEL_STACK_RESERVED)
 #else
 #define K_KERNEL_STACK_RESERVED	((size_t)0)
-#endif
+#endif /* ARCH_KERNEL_STACK_RESERVED */
 
 #define Z_KERNEL_STACK_SIZE_ADJUST(size) (ROUND_UP(size, \
 						   ARCH_STACK_PTR_ALIGN) + \
@@ -102,7 +102,7 @@ static inline char *z_stack_ptr_align(char *ptr)
 #define Z_KERNEL_STACK_OBJ_ALIGN	ARCH_KERNEL_STACK_OBJ_ALIGN
 #else
 #define Z_KERNEL_STACK_OBJ_ALIGN	ARCH_STACK_PTR_ALIGN
-#endif
+#endif /* ARCH_KERNEL_STACK_OBJ_ALIGN */
 
 #define Z_KERNEL_STACK_LEN(size) \
 	ROUND_UP(Z_KERNEL_STACK_SIZE_ADJUST(size), Z_KERNEL_STACK_OBJ_ALIGN)
@@ -232,7 +232,7 @@ static inline char *z_stack_ptr_align(char *ptr)
 #else
 #define K_KERNEL_PINNED_STACK_DEFINE(sym, size) \
 	Z_KERNEL_STACK_DEFINE_IN(sym, size, __kstackmem)
-#endif
+#endif /* CONFIG_LINKER_USE_PINNED_SECTION */
 
 /**
  * @brief Define a toplevel array of kernel stack memory regions
@@ -265,7 +265,7 @@ static inline char *z_stack_ptr_align(char *ptr)
 #else
 #define K_KERNEL_PINNED_STACK_ARRAY_DEFINE(sym, nmemb, size) \
 	Z_KERNEL_STACK_ARRAY_DEFINE_IN(sym, nmemb, size, __kstackmem)
-#endif
+#endif /* CONFIG_LINKER_USE_PINNED_SECTION */
 
 /**
  * @brief Define an embedded stack memory region
@@ -320,7 +320,7 @@ static inline char *Z_KERNEL_STACK_BUFFER(k_thread_stack_t *sym)
 #define K_THREAD_STACK_RESERVED		((size_t)(ARCH_THREAD_STACK_RESERVED))
 #else
 #define K_THREAD_STACK_RESERVED		((size_t)0U)
-#endif
+#endif /* ARCH_THREAD_STACK_RESERVED */
 
 /**
  * @brief Properly align the lowest address of a stack object
@@ -553,7 +553,7 @@ static inline char *Z_KERNEL_STACK_BUFFER(k_thread_stack_t *sym)
 #else
 #define K_THREAD_PINNED_STACK_DEFINE(sym, size) \
 	K_THREAD_STACK_DEFINE(sym, size)
-#endif
+#endif /* CONFIG_LINKER_USE_PINNED_SECTION */
 
 /**
  * @brief Calculate size of stacks to be allocated in a stack array
@@ -611,7 +611,7 @@ static inline char *Z_KERNEL_STACK_BUFFER(k_thread_stack_t *sym)
 #else
 #define K_THREAD_PINNED_STACK_ARRAY_DEFINE(sym, nmemb, size) \
 	K_THREAD_STACK_ARRAY_DEFINE(sym, nmemb, size)
-#endif
+#endif /* CONFIG_LINKER_USE_PINNED_SECTION */
 
 /**
  * @brief Define an embedded stack memory region

--- a/kernel/atomic_c.c
+++ b/kernel/atomic_c.c
@@ -56,7 +56,7 @@ static struct k_spinlock lock;
 #else
 #define ATOMIC_SYSCALL_HANDLER_TARGET(name)
 #define ATOMIC_SYSCALL_HANDLER_TARGET_VALUE(name)
-#endif
+#endif /* CONFIG_USERSPACE */
 
 /**
  *
@@ -411,4 +411,4 @@ ATOMIC_SYSCALL_HANDLER_TARGET_VALUE(atomic_nand);
 #include <syscalls/atomic_xor_mrsh.c>
 #include <syscalls/atomic_and_mrsh.c>
 #include <syscalls/atomic_nand_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */

--- a/kernel/banner.c
+++ b/kernel/banner.c
@@ -14,15 +14,15 @@
 #define BANNER_POSTFIX " (delayed boot " DELAY_STR "ms)"
 #else
 #define BANNER_POSTFIX ""
-#endif
+#endif /* defined(CONFIG_BOOT_DELAY) && (CONFIG_BOOT_DELAY > 0) */
 
 #ifndef BANNER_VERSION
 #ifdef BUILD_VERSION
 #define BANNER_VERSION STRINGIFY(BUILD_VERSION)
 #else
 #define BANNER_VERSION KERNEL_VERSION_STRING
-#endif
-#endif
+#endif /* BUILD_VERSION */
+#endif /* !BANNER_VERSION */
 
 void boot_banner(void)
 {

--- a/kernel/condvar.c
+++ b/kernel/condvar.c
@@ -14,7 +14,7 @@
 
 #ifdef CONFIG_OBJ_CORE_CONDVAR
 static struct k_obj_type obj_type_condvar;
-#endif
+#endif /* CONFIG_OBJ_CORE_CONDVAR */
 
 static struct k_spinlock lock;
 
@@ -25,7 +25,7 @@ int z_impl_k_condvar_init(struct k_condvar *condvar)
 
 #ifdef CONFIG_OBJ_CORE_CONDVAR
 	k_obj_core_init_and_link(K_OBJ_CORE(condvar), &obj_type_condvar);
-#endif
+#endif /* CONFIG_OBJ_CORE_CONDVAR */
 
 	SYS_PORT_TRACING_OBJ_INIT(k_condvar, condvar, 0);
 
@@ -39,7 +39,7 @@ int z_vrfy_k_condvar_init(struct k_condvar *condvar)
 	return z_impl_k_condvar_init(condvar);
 }
 #include <syscalls/k_condvar_init_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 int z_impl_k_condvar_signal(struct k_condvar *condvar)
 {
@@ -71,7 +71,7 @@ int z_vrfy_k_condvar_signal(struct k_condvar *condvar)
 	return z_impl_k_condvar_signal(condvar);
 }
 #include <syscalls/k_condvar_signal_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 int z_impl_k_condvar_broadcast(struct k_condvar *condvar)
 {
@@ -104,7 +104,7 @@ int z_vrfy_k_condvar_broadcast(struct k_condvar *condvar)
 	return z_impl_k_condvar_broadcast(condvar);
 }
 #include <syscalls/k_condvar_broadcast_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 int z_impl_k_condvar_wait(struct k_condvar *condvar, struct k_mutex *mutex,
 			  k_timeout_t timeout)
@@ -133,7 +133,7 @@ int z_vrfy_k_condvar_wait(struct k_condvar *condvar, struct k_mutex *mutex,
 	return z_impl_k_condvar_wait(condvar, mutex, timeout);
 }
 #include <syscalls/k_condvar_wait_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 #ifdef CONFIG_OBJ_CORE_CONDVAR
 static int init_condvar_obj_core_list(void)
@@ -155,4 +155,4 @@ static int init_condvar_obj_core_list(void)
 
 SYS_INIT(init_condvar_obj_core_list, PRE_KERNEL_1,
 	 CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
-#endif
+#endif /* CONFIG_OBJ_CORE_CONDVAR */

--- a/kernel/cpu_mask.c
+++ b/kernel/cpu_mask.c
@@ -13,7 +13,7 @@ extern struct k_spinlock _sched_spinlock;
 # ifdef CONFIG_SMP
 /* Right now we use a two byte for this mask */
 BUILD_ASSERT(CONFIG_MP_MAX_NUM_CPUS <= 16, "Too many CPUs for mask word");
-# endif
+# endif /* CONFIG_SMP */
 
 
 static int cpu_mask_mod(k_tid_t thread, uint32_t enable_mask, uint32_t disable_mask)
@@ -23,7 +23,7 @@ static int cpu_mask_mod(k_tid_t thread, uint32_t enable_mask, uint32_t disable_m
 #ifdef CONFIG_SCHED_CPU_MASK_PIN_ONLY
 	__ASSERT(z_is_thread_prevented_from_running(thread),
 		 "Running threads cannot change CPU pin");
-#endif
+#endif /* CONFIG_SCHED_CPU_MASK_PIN_ONLY */
 
 	K_SPINLOCK(&_sched_spinlock) {
 		if (z_is_thread_prevented_from_running(thread)) {
@@ -39,7 +39,7 @@ static int cpu_mask_mod(k_tid_t thread, uint32_t enable_mask, uint32_t disable_m
 
 		__ASSERT((m == 0) || ((m & (m - 1)) == 0),
 			 "Only one CPU allowed in mask when PIN_ONLY");
-#endif
+#endif /* defined(CONFIG_ASSERT) && defined(CONFIG_SCHED_CPU_MASK_PIN_ONLY) */
 
 	return ret;
 }

--- a/kernel/dynamic.c
+++ b/kernel/dynamic.c
@@ -20,7 +20,7 @@ LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 #define BA_SIZE CONFIG_DYNAMIC_THREAD_POOL_SIZE
 #else
 #define BA_SIZE 1
-#endif
+#endif /* CONFIG_DYNAMIC_THREAD_POOL_SIZE > 0 */
 
 struct dyn_cb_data {
 	k_tid_t tid;
@@ -71,7 +71,7 @@ static k_thread_stack_t *stack_alloc_dyn(size_t size, int flags)
 		 * enabled we can't proceed.
 		 */
 		return NULL;
-#endif
+#endif /* CONFIG_DYNAMIC_OBJECTS */
 	}
 
 	return z_thread_stack_alloc_dyn(Z_KERNEL_STACK_OBJ_ALIGN,
@@ -106,7 +106,7 @@ static inline k_thread_stack_t *z_vrfy_k_thread_stack_alloc(size_t size, int fla
 	return z_impl_k_thread_stack_alloc(size, flags);
 }
 #include <syscalls/k_thread_stack_alloc_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 static void dyn_cb(const struct k_thread *thread, void *user_data)
 {
@@ -154,7 +154,7 @@ int z_impl_k_thread_stack_free(k_thread_stack_t *stack)
 		}
 #else
 		k_free(stack);
-#endif
+#endif /* CONFIG_USERSPACE */
 	} else {
 		LOG_DBG("Invalid stack %p", stack);
 		return -EINVAL;
@@ -169,4 +169,4 @@ static inline int z_vrfy_k_thread_stack_free(k_thread_stack_t *stack)
 	return z_impl_k_thread_stack_free(stack);
 }
 #include <syscalls/k_thread_stack_free_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */

--- a/kernel/events.c
+++ b/kernel/events.c
@@ -47,7 +47,7 @@ struct event_walk_data {
 
 #ifdef CONFIG_OBJ_CORE_EVENT
 static struct k_obj_type obj_type_event;
-#endif
+#endif /* CONFIG_OBJ_CORE_EVENT */
 
 void z_impl_k_event_init(struct k_event *event)
 {
@@ -62,7 +62,7 @@ void z_impl_k_event_init(struct k_event *event)
 
 #ifdef CONFIG_OBJ_CORE_EVENT
 	k_obj_core_init_and_link(K_OBJ_CORE(event), &obj_type_event);
-#endif
+#endif /* CONFIG_OBJ_CORE_EVENT */
 }
 
 #ifdef CONFIG_USERSPACE
@@ -72,7 +72,7 @@ void z_vrfy_k_event_init(struct k_event *event)
 	z_impl_k_event_init(event);
 }
 #include <syscalls/k_event_init_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 /**
  * @brief determine if desired set of events been satisfied
@@ -191,7 +191,7 @@ uint32_t z_vrfy_k_event_post(struct k_event *event, uint32_t events)
 	return z_impl_k_event_post(event, events);
 }
 #include <syscalls/k_event_post_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 uint32_t z_impl_k_event_set(struct k_event *event, uint32_t events)
 {
@@ -205,7 +205,7 @@ uint32_t z_vrfy_k_event_set(struct k_event *event, uint32_t events)
 	return z_impl_k_event_set(event, events);
 }
 #include <syscalls/k_event_set_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 uint32_t z_impl_k_event_set_masked(struct k_event *event, uint32_t events,
 			       uint32_t events_mask)
@@ -221,7 +221,7 @@ uint32_t z_vrfy_k_event_set_masked(struct k_event *event, uint32_t events,
 	return z_impl_k_event_set_masked(event, events, events_mask);
 }
 #include <syscalls/k_event_set_masked_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 uint32_t z_impl_k_event_clear(struct k_event *event, uint32_t events)
 {
@@ -235,7 +235,7 @@ uint32_t z_vrfy_k_event_clear(struct k_event *event, uint32_t events)
 	return z_impl_k_event_clear(event, events);
 }
 #include <syscalls/k_event_clear_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 static uint32_t k_event_wait_internal(struct k_event *event, uint32_t events,
 				      unsigned int options, k_timeout_t timeout)
@@ -321,7 +321,7 @@ uint32_t z_vrfy_k_event_wait(struct k_event *event, uint32_t events,
 	return z_impl_k_event_wait(event, events, reset, timeout);
 }
 #include <syscalls/k_event_wait_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 /**
  * Wait for all of the specified events
@@ -343,7 +343,7 @@ uint32_t z_vrfy_k_event_wait_all(struct k_event *event, uint32_t events,
 	return z_impl_k_event_wait_all(event, events, reset, timeout);
 }
 #include <syscalls/k_event_wait_all_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 #ifdef CONFIG_OBJ_CORE_EVENT
 static int init_event_obj_core_list(void)
@@ -364,4 +364,4 @@ static int init_event_obj_core_list(void)
 
 SYS_INIT(init_event_obj_core_list, PRE_KERNEL_1,
 	 CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
-#endif
+#endif /* CONFIG_OBJ_CORE_EVENT */

--- a/kernel/fatal.c
+++ b/kernel/fatal.c
@@ -108,7 +108,7 @@ void z_fatal_error(unsigned int reason, const z_arch_esf_t *esf)
 	if ((esf != NULL) && arch_is_in_nested_exception(esf)) {
 		LOG_ERR("Fault during interrupt handling\n");
 	}
-#endif
+#endif /* CONFIG_ARCH_HAS_NESTED_EXCEPTION_DETECTION */
 
 	LOG_ERR("Current thread: %p (%s)", thread,
 		thread_name_get(thread));

--- a/kernel/idle.c
+++ b/kernel/idle.c
@@ -30,7 +30,7 @@ void z_pm_save_idle_exit(void)
 #endif	/* CONFIG_PM */
 #ifdef CONFIG_SYS_CLOCK_EXISTS
 	sys_clock_idle_exit();
-#endif
+#endif /* CONFIG_SYS_CLOCK_EXISTS */
 }
 
 void idle(void *unused1, void *unused2, void *unused3)
@@ -87,7 +87,7 @@ void idle(void *unused1, void *unused2, void *unused3)
 		}
 #else
 		k_cpu_idle();
-#endif
+#endif /* CONFIG_PM */
 
 #if !defined(CONFIG_PREEMPT_ENABLED)
 # if !defined(CONFIG_USE_SWITCH) || defined(CONFIG_SPARC)
@@ -103,8 +103,8 @@ void idle(void *unused1, void *unused2, void *unused3)
 		if (_kernel.ready_q.cache != _current) {
 			z_swap_unlocked();
 		}
-# endif
-#endif
+# endif /* !defined(CONFIG_USE_SWITCH) || defined(CONFIG_SPARC) */
+#endif /* !defined(CONFIG_PREEMPT_ENABLED) */
 	}
 }
 

--- a/kernel/include/kernel_arch_interface.h
+++ b/kernel/include/kernel_arch_interface.h
@@ -37,7 +37,7 @@ extern "C" {
  * @param usec_to_wait Wait period, in microseconds
  */
 void arch_busy_wait(uint32_t usec_to_wait);
-#endif
+#endif /* CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT */
 
 /** @} */
 
@@ -154,7 +154,7 @@ int arch_swap(unsigned int key);
  */
 static ALWAYS_INLINE void
 arch_thread_return_value_set(struct k_thread *thread, unsigned int value);
-#endif /* CONFIG_USE_SWITCH i*/
+#endif /* CONFIG_USE_SWITCH */
 
 #ifdef CONFIG_ARCH_HAS_CUSTOM_SWAP_TO_MAIN
 /**

--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -43,7 +43,7 @@ static inline void z_data_copy(void)
 {
 	/* Do nothing */
 }
-#endif
+#endif /* CONFIG_XIP */
 
 #ifdef CONFIG_LINKER_USE_BOOT_SECTION
 void z_bss_zero_boot(void);
@@ -52,7 +52,7 @@ static inline void z_bss_zero_boot(void)
 {
 	/* Do nothing */
 }
-#endif
+#endif /* CONFIG_LINKER_USE_BOOT_SECTION */
 
 #ifdef CONFIG_LINKER_USE_PINNED_SECTION
 void z_bss_zero_pinned(void);
@@ -61,7 +61,7 @@ static inline void z_bss_zero_pinned(void)
 {
 	/* Do nothing */
 }
-#endif
+#endif /* CONFIG_LINKER_USE_PINNED_SECTION */
 
 FUNC_NORETURN void z_cstart(void);
 
@@ -135,27 +135,27 @@ z_thread_return_value_set_with_data(struct k_thread *thread,
 extern void z_smp_init(void);
 #ifdef CONFIG_SYS_CLOCK_EXISTS
 extern void smp_timer_init(void);
-#endif
-#endif
+#endif /* CONFIG_SYS_CLOCK_EXISTS */
+#endif /* CONFIG_SMP */
 
 extern void z_early_rand_get(uint8_t *buf, size_t length);
 
 #if CONFIG_STACK_POINTER_RANDOM
 extern int z_stack_adjust_initialized;
-#endif
+#endif /* CONFIG_STACK_POINTER_RANDOM */
 
 extern struct k_thread z_main_thread;
 
 
 #ifdef CONFIG_MULTITHREADING
 extern struct k_thread z_idle_threads[CONFIG_MP_MAX_NUM_CPUS];
-#endif
+#endif /* CONFIG_MULTITHREADING */
 K_KERNEL_PINNED_STACK_ARRAY_DECLARE(z_interrupt_stacks, CONFIG_MP_MAX_NUM_CPUS,
 				    CONFIG_ISR_STACK_SIZE);
 
 #ifdef CONFIG_GEN_PRIV_STACKS
 extern uint8_t *z_priv_stack_find(k_thread_stack_t *stack);
-#endif
+#endif /* CONFIG_GEN_PRIV_STACKS */
 
 /* Calculate stack usage. */
 int z_stack_space_get(const uint8_t *stack_start, size_t size, size_t *unused_ptr);
@@ -189,7 +189,7 @@ struct gdb_ctx;
  * and synchronously communicate with gdb on host.
  */
 extern int z_gdb_main_loop(struct gdb_ctx *ctx);
-#endif
+#endif /* CONFIG_GDBSTUB */
 
 #ifdef CONFIG_INSTRUMENT_THREAD_SWITCHING
 void z_thread_mark_switched_in(void);
@@ -263,7 +263,7 @@ bool pm_system_suspend(int32_t ticks);
  */
 void pm_system_resume(void);
 
-#endif
+#endif /* CONFIG_PM */
 
 #ifdef CONFIG_DEMAND_PAGING_TIMING_HISTOGRAM
 /**
@@ -287,7 +287,7 @@ int z_thread_stats_query(struct k_obj_core *obj_core, void *stats);
 int z_thread_stats_reset(struct k_obj_core *obj_core);
 int z_thread_stats_disable(struct k_obj_core *obj_core);
 int z_thread_stats_enable(struct k_obj_core *obj_core);
-#endif
+#endif /* CONFIG_OBJ_CORE_STATS_THREAD */
 
 #ifdef CONFIG_OBJ_CORE_STATS_SYSTEM
 int z_cpu_stats_raw(struct k_obj_core *obj_core, void *stats);
@@ -295,7 +295,7 @@ int z_cpu_stats_query(struct k_obj_core *obj_core, void *stats);
 
 int z_kernel_stats_raw(struct k_obj_core *obj_core, void *stats);
 int z_kernel_stats_query(struct k_obj_core *obj_core, void *stats);
-#endif
+#endif /* CONFIG_OBJ_CORE_STATS_SYSTEM */
 
 #ifdef __cplusplus
 }

--- a/kernel/include/kernel_offsets.h
+++ b/kernel/include/kernel_offsets.h
@@ -34,23 +34,23 @@ GEN_OFFSET_SYM(_kernel_t, cpus);
 
 #if defined(CONFIG_FPU_SHARING)
 GEN_OFFSET_SYM(_cpu_t, fp_ctx);
-#endif
+#endif /* CONFIG_FPU_SHARING */
 
 #ifdef CONFIG_PM
 GEN_OFFSET_SYM(_kernel_t, idle);
-#endif
+#endif /* CONFIG_PM */
 
 #ifndef CONFIG_SCHED_CPU_MASK_PIN_ONLY
 GEN_OFFSET_SYM(_kernel_t, ready_q);
-#endif
+#endif /* CONFIG_SCHED_CPU_MASK_PIN_ONLY */
 
 #ifndef CONFIG_SMP
 GEN_OFFSET_SYM(_ready_q_t, cache);
-#endif
+#endif /* CONFIG_SMP */
 
 #ifdef CONFIG_FPU_SHARING
 GEN_OFFSET_SYM(_kernel_t, current_fp);
-#endif
+#endif /* CONFIG_FPU_SHARING */
 
 GEN_OFFSET_SYM(_thread_base_t, user_options);
 
@@ -60,15 +60,15 @@ GEN_OFFSET_SYM(_thread_t, arch);
 
 #ifdef CONFIG_USE_SWITCH
 GEN_OFFSET_SYM(_thread_t, switch_handle);
-#endif
+#endif /* CONFIG_USE_SWITCH */
 
 #ifdef CONFIG_THREAD_STACK_INFO
 GEN_OFFSET_SYM(_thread_t, stack_info);
-#endif
+#endif /* CONFIG_THREAD_STACK_INFO */
 
 #ifdef CONFIG_THREAD_LOCAL_STORAGE
 GEN_OFFSET_SYM(_thread_t, tls);
-#endif
+#endif /* CONFIG_THREAD_LOCAL_STORAGE */
 
 GEN_ABSOLUTE_SYM(__z_interrupt_stack_SIZEOF, sizeof(z_interrupt_stacks[0]));
 
@@ -76,12 +76,12 @@ GEN_ABSOLUTE_SYM(__z_interrupt_stack_SIZEOF, sizeof(z_interrupt_stacks[0]));
 #ifdef CONFIG_DEVICE_DEPS
 GEN_ABSOLUTE_SYM(_DEVICE_STRUCT_HANDLES_OFFSET,
 		 offsetof(struct device, deps));
-#endif
+#endif /* CONFIG_DEVICE_DEPS */
 
 #ifdef CONFIG_PM_DEVICE
 GEN_ABSOLUTE_SYM(_DEVICE_STRUCT_PM_OFFSET,
 		 offsetof(struct device, pm));
-#endif
+#endif /* CONFIG_PM_DEVICE */
 
 /* member offsets in the pm_device structure. Used in image post-processing */
 

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -34,7 +34,7 @@ BUILD_ASSERT(K_LOWEST_APPLICATION_THREAD_PRIO
 #else
 #define Z_VALID_PRIO(prio, entry_point) ((prio) == -1)
 #define Z_ASSERT_VALID_PRIO(prio, entry_point) __ASSERT((prio) == -1, "")
-#endif
+#endif /* CONFIG_MULTITHREADING */
 
 void z_sched_init(void);
 void z_move_thread_to_end_of_prio_q(struct k_thread *thread);
@@ -80,7 +80,7 @@ static inline bool z_is_idle_thread_object(struct k_thread *thread)
 	return thread->base.is_idle;
 #else
 	return thread == &z_idle_threads[0];
-#endif
+#endif /* CONFIG_SMP */
 #else
 	return false;
 #endif /* CONFIG_MULTITHREADING */
@@ -417,7 +417,7 @@ static inline void z_sched_usage_switch(struct k_thread *thread)
 #ifdef CONFIG_SCHED_THREAD_USAGE
 	z_sched_usage_stop();
 	z_sched_usage_start(thread);
-#endif
+#endif /* CONFIG_SCHED_THREAD_USAGE */
 }
 
 #endif /* ZEPHYR_KERNEL_INCLUDE_KSCHED_H_ */

--- a/kernel/include/kswap.h
+++ b/kernel/include/kswap.h
@@ -15,7 +15,7 @@
 extern void z_check_stack_sentinel(void);
 #else
 #define z_check_stack_sentinel() /**/
-#endif
+#endif /* CONFIG_STACK_SENTINEL */
 
 extern struct k_spinlock _sched_spinlock;
 
@@ -63,7 +63,7 @@ static inline void z_sched_switch_spin(struct k_thread *thread)
 	 * non-null.
 	 */
 	barrier_dmem_fence_full();
-#endif
+#endif /* CONFIG_SMP */
 }
 
 /* New style context switching.  arch_switch() is a lower level
@@ -99,8 +99,8 @@ static ALWAYS_INLINE unsigned int do_swap(unsigned int key,
 	__ASSERT(arch_irq_unlocked(key) ||
 		 _current->base.thread_state & (_THREAD_DUMMY | _THREAD_DEAD),
 		 "Context switching while holding lock!");
-# endif
-#endif
+# endif /* CONFIG_ARM64 */
+#endif /* CONFIG_SPIN_VALIDATE */
 
 	old_thread = _current;
 
@@ -131,18 +131,18 @@ static ALWAYS_INLINE unsigned int do_swap(unsigned int key,
 		if (!is_spinlock) {
 			z_smp_release_global_lock(new_thread);
 		}
-#endif
+#endif /* CONFIG_SMP */
 		z_thread_mark_switched_out();
 		z_sched_switch_spin(new_thread);
 		_current_cpu->current = new_thread;
 
 #ifdef CONFIG_TIMESLICING
 		z_reset_time_slice(new_thread);
-#endif
+#endif /* CONFIG_TIMESLICING */
 
 #ifdef CONFIG_SPIN_VALIDATE
 		z_spin_lock_set_owner(&_sched_spinlock);
-#endif
+#endif /* CONFIG_SPIN_VALIDATE */
 
 		arch_cohere_stacks(old_thread, NULL, new_thread);
 
@@ -152,7 +152,7 @@ static ALWAYS_INLINE unsigned int do_swap(unsigned int key,
 		 * time.  See z_sched_switch_spin().
 		 */
 		z_requeue_current(old_thread);
-#endif
+#endif /* CONFIG_SMP */
 		void *newsh = new_thread->switch_handle;
 
 		if (IS_ENABLED(CONFIG_SMP)) {
@@ -241,24 +241,24 @@ static inline void z_dummy_thread_init(struct k_thread *dummy_thread)
 	dummy_thread->base.thread_state = _THREAD_DUMMY;
 #ifdef CONFIG_SCHED_CPU_MASK
 	dummy_thread->base.cpu_mask = -1;
-#endif
+#endif /* CONFIG_SCHED_CPU_MASK */
 	dummy_thread->base.user_options = K_ESSENTIAL;
 #ifdef CONFIG_THREAD_STACK_INFO
 	dummy_thread->stack_info.start = 0U;
 	dummy_thread->stack_info.size = 0U;
-#endif
+#endif /* CONFIG_THREAD_STACK_INFO */
 #ifdef CONFIG_USERSPACE
 	dummy_thread->mem_domain_info.mem_domain = &k_mem_domain_default;
-#endif
+#endif /* CONFIG_USERSPACE */
 #if (K_HEAP_MEM_POOL_SIZE > 0)
 	k_thread_system_pool_assign(dummy_thread);
 #else
 	dummy_thread->resource_pool = NULL;
-#endif
+#endif /* K_HEAP_MEM_POOL_SIZE */
 
 #ifdef CONFIG_TIMESLICE_PER_THREAD
 	dummy_thread->base.slice_ticks = 0;
-#endif
+#endif /* CONFIG_TIMESLICE_PER_THREAD */
 
 	_current_cpu->current = dummy_thread;
 }

--- a/kernel/include/kthread.h
+++ b/kernel/include/kthread.h
@@ -17,7 +17,7 @@
  * thread->next_thread (until NULL)
  */
 extern struct k_spinlock z_thread_monitor_lock;
-#endif
+#endif /* CONFIG_THREAD_MONITOR */
 
 /* clean up when a thread is aborted */
 
@@ -42,8 +42,8 @@ static inline void thread_schedule_new(struct k_thread *thread, k_timeout_t dela
 #else
 	ARG_UNUSED(delay);
 	k_thread_start(thread);
-#endif
+#endif /* CONFIG_SYS_CLOCK_EXISTS */
 }
-#endif
+#endif /* CONFIG_MULTITHREADING */
 
 #endif /* ZEPHYR_KERNEL_INCLUDE_THREAD_H_ */

--- a/kernel/include/mmu.h
+++ b/kernel/include/mmu.h
@@ -54,7 +54,7 @@
 #define Z_FREE_VM_START	Z_BOOT_PHYS_TO_VIRT(Z_PHYS_RAM_END)
 #else
 #define Z_FREE_VM_START	Z_KERNEL_VIRT_END
-#endif
+#endif /* CONFIG_ARCH_MAPS_ALL_RAM */
 
 /*
  * Macros and data structures for physical page frame accounting,
@@ -121,7 +121,7 @@ struct z_page_frame {
 } __aligned(4);
 #else
 } __packed;
-#endif
+#endif /* CONFIG_XTENSA */
 
 static inline bool z_page_frame_is_pinned(struct z_page_frame *pf)
 {
@@ -237,7 +237,7 @@ void z_page_frames_dump(void);
 				     CONFIG_MMU_PAGE_SIZE))
 #else
 #define Z_VM_RESERVED	0
-#endif
+#endif /* CONFIG_DEMAND_PAGING */
 
 #ifdef CONFIG_DEMAND_PAGING
 /*

--- a/kernel/include/priority_q.h
+++ b/kernel/include/priority_q.h
@@ -16,7 +16,7 @@
 #  define _priq_run_best	_priq_dumb_mask_best
 # else
 #  define _priq_run_best	z_priq_dumb_best
-# endif
+# endif /* CONFIG_SCHED_CPU_MASK */
 /* Scalable Scheduling */
 #elif defined(CONFIG_SCHED_SCALABLE)
 #define _priq_run_add		z_priq_rb_add

--- a/kernel/include/timeout_q.h
+++ b/kernel/include/timeout_q.h
@@ -73,7 +73,7 @@ static inline void z_add_thread_timeout(struct k_thread *thread, k_timeout_t tic
 	ARG_UNUSED(ticks);
 }
 
-#endif
+#endif /* CONFIG_SYS_CLOCK_EXISTS */
 
 #ifdef __cplusplus
 }

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -85,7 +85,7 @@ static void z_init_static_threads(void)
 					      pos->thread);
 		}
 	}
-#endif
+#endif /* CONFIG_USERSPACE */
 
 	/*
 	 * Non-legacy static threads may be started immediately or
@@ -128,12 +128,12 @@ enum init_level {
 	INIT_LEVEL_APPLICATION,
 #ifdef CONFIG_SMP
 	INIT_LEVEL_SMP,
-#endif
+#endif /* CONFIG_SMP */
 };
 
 #ifdef CONFIG_SMP
 extern const struct init_entry __init_SMP_start[];
-#endif
+#endif /* CONFIG_SMP */
 
 /*
  * storage space for the interrupt stack
@@ -173,8 +173,8 @@ static struct k_obj_core_stats_desc  kernel_stats_desc = {
 	.disable = NULL,
 	.enable  = NULL,
 };
-#endif
-#endif
+#endif /* CONFIG_OBJ_CORE_STATS_SYSTEM */
+#endif /* CONFIG_OBJ_CORE_SYSTEM */
 
 /* LCOV_EXCL_START
  *
@@ -245,7 +245,7 @@ void z_bss_zero(void)
 #ifdef CONFIG_COVERAGE_GCOV
 	z_early_memset(&__gcov_bss_start, 0,
 		       ((uintptr_t) &__gcov_bss_end - (uintptr_t) &__gcov_bss_start));
-#endif
+#endif /* CONFIG_COVERAGE_GCOV */
 }
 
 #ifdef CONFIG_LINKER_USE_BOOT_SECTION
@@ -279,7 +279,7 @@ void z_bss_zero_boot(void)
 __boot_func
 #else
 __pinned_func
-#endif
+#endif /* CONFIG_LINKER_USE_BOOT_SECTION */
 void z_bss_zero_pinned(void)
 {
 	z_early_memset(&lnkr_pinned_bss_start, 0,
@@ -293,7 +293,7 @@ void z_bss_zero_pinned(void)
 extern __thread volatile uintptr_t __stack_chk_guard;
 #else
 extern volatile uintptr_t __stack_chk_guard;
-#endif
+#endif /* CONFIG_STACK_CANARIES_TLS */
 #endif /* CONFIG_STACK_CANARIES */
 
 /* LCOV_EXCL_STOP */
@@ -322,7 +322,7 @@ static void z_sys_init_run_level(enum init_level level)
 		__init_APPLICATION_start,
 #ifdef CONFIG_SMP
 		__init_SMP_start,
-#endif
+#endif /* CONFIG_SMP */
 		/* End marker */
 		__init_end,
 	};
@@ -391,13 +391,13 @@ static void bg_thread_main(void *unused1, void *unused2, void *unused3)
 	z_sys_init_run_level(INIT_LEVEL_POST_KERNEL);
 #if CONFIG_STACK_POINTER_RANDOM
 	z_stack_adjust_initialized = 1;
-#endif
+#endif /* CONFIG_STACK_POINTER_RANDOM */
 	boot_banner();
 
 #if defined(CONFIG_CPP)
 	void z_cpp_init_static(void);
 	z_cpp_init_static();
-#endif
+#endif /* CONFIG_CPP */
 
 	/* Final init level before app starts */
 	z_sys_init_run_level(INIT_LEVEL_APPLICATION);
@@ -406,14 +406,14 @@ static void bg_thread_main(void *unused1, void *unused2, void *unused3)
 
 #ifdef CONFIG_KERNEL_COHERENCE
 	__ASSERT_NO_MSG(arch_mem_coherent(&_kernel));
-#endif
+#endif /* CONFIG_KERNEL_COHERENCE */
 
 #ifdef CONFIG_SMP
 	if (!IS_ENABLED(CONFIG_SMP_BOOT_DELAY)) {
 		z_smp_init();
 	}
 	z_sys_init_run_level(INIT_LEVEL_SMP);
-#endif
+#endif /* CONFIG_SMP */
 
 #ifdef CONFIG_MMU
 	z_mem_manage_boot_finish();
@@ -429,7 +429,7 @@ static void bg_thread_main(void *unused1, void *unused2, void *unused3)
 #ifdef CONFIG_COVERAGE_DUMP
 	/* Dump coverage data once the main() has exited. */
 	gcov_coverage_dump();
-#endif
+#endif /* CONFIG_COVERAGE_DUMP */
 } /* LCOV_EXCL_LINE ... because we just dumped final coverage data */
 
 #if defined(CONFIG_MULTITHREADING)
@@ -446,7 +446,7 @@ static void init_idle_thread(int i)
 	snprintk(tname, 8, "idle %02d", i);
 #else
 	char *tname = "idle";
-#endif
+#endif /* CONFIG_MP_MAX_NUM_CPUS */
 
 #else
 	char *tname = NULL;
@@ -460,7 +460,7 @@ static void init_idle_thread(int i)
 
 #ifdef CONFIG_SMP
 	thread->base.is_idle = 1U;
-#endif
+#endif /* CONFIG_SMP */
 }
 
 void z_init_cpu(int id)
@@ -524,7 +524,7 @@ static char *prepare_multithreading(void)
 	 *   to work as intended
 	 */
 	_kernel.ready_q.cache = &z_main_thread;
-#endif
+#endif /* CONFIG_SMP */
 	stack_ptr = z_setup_new_thread(&z_main_thread, z_main_stack,
 				       CONFIG_MAIN_STACK_SIZE, bg_thread_main,
 				       NULL, NULL, NULL,
@@ -551,7 +551,7 @@ static FUNC_NORETURN void switch_to_main_thread(char *stack_ptr)
 	 * will never be rescheduled in.
 	 */
 	z_swap_unlocked();
-#endif
+#endif /* CONFIG_ARCH_HAS_CUSTOM_SWAP_TO_MAIN */
 	CODE_UNREACHABLE; /* LCOV_EXCL_LINE */
 }
 #endif /* CONFIG_MULTITHREADING */
@@ -573,7 +573,7 @@ void __weak z_early_rand_get(uint8_t *buf, size_t length)
 			buf += rc;
 		}
 	}
-#endif
+#endif /* CONFIG_ENTROPY_HAS_DRIVER */
 
 	while (length > 0) {
 		uint32_t val;
@@ -621,7 +621,7 @@ FUNC_NORETURN void z_cstart(void)
 	struct k_thread dummy_thread;
 
 	z_dummy_thread_init(&dummy_thread);
-#endif
+#endif /* CONFIG_MULTITHREADING */
 	/* do any necessary initialization of static devices */
 	z_device_state_init();
 
@@ -640,7 +640,7 @@ FUNC_NORETURN void z_cstart(void)
 #ifdef CONFIG_TIMING_FUNCTIONS_NEED_AT_BOOT
 	timing_init();
 	timing_start();
-#endif
+#endif /* CONFIG_TIMING_FUNCTIONS_NEED_AT_BOOT */
 
 #ifdef CONFIG_MULTITHREADING
 	switch_to_main_thread(prepare_multithreading());
@@ -661,7 +661,7 @@ FUNC_NORETURN void z_cstart(void)
 	while (true) {
 	}
 	/* LCOV_EXCL_STOP */
-#endif
+#endif /* ARCH_SWITCH_TO_MAIN_NO_MULTITHREADING */
 #endif /* CONFIG_MULTITHREADING */
 
 	/*
@@ -683,7 +683,7 @@ static int init_cpu_obj_core_list(void)
 
 #ifdef CONFIG_OBJ_CORE_STATS_SYSTEM
 	k_obj_type_stats_init(&obj_type_cpu, &cpu_stats_desc);
-#endif
+#endif /* CONFIG_OBJ_CORE_STATS_SYSTEM */
 
 	return 0;
 }
@@ -697,13 +697,13 @@ static int init_kernel_obj_core_list(void)
 
 #ifdef CONFIG_OBJ_CORE_STATS_SYSTEM
 	k_obj_type_stats_init(&obj_type_kernel, &kernel_stats_desc);
-#endif
+#endif /* CONFIG_OBJ_CORE_STATS_SYSTEM */
 
 	k_obj_core_init_and_link(K_OBJ_CORE(&_kernel), &obj_type_kernel);
 #ifdef CONFIG_OBJ_CORE_STATS_SYSTEM
 	k_obj_core_stats_register(K_OBJ_CORE(&_kernel), _kernel.usage,
 				  sizeof(_kernel.usage));
-#endif
+#endif /* CONFIG_OBJ_CORE_STATS_SYSTEM */
 
 	return 0;
 }
@@ -713,4 +713,4 @@ SYS_INIT(init_cpu_obj_core_list, PRE_KERNEL_1,
 
 SYS_INIT(init_kernel_obj_core_list, PRE_KERNEL_1,
 	 CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
-#endif
+#endif /* CONFIG_OBJ_CORE_SYSTEM */

--- a/kernel/irq_offload.c
+++ b/kernel/irq_offload.c
@@ -19,5 +19,5 @@ void irq_offload(irq_offload_routine_t routine, const void *parameter)
 	k_sem_take(&offload_sem, K_FOREVER);
 	arch_irq_offload(routine, parameter);
 	k_sem_give(&offload_sem);
-#endif
+#endif /* CONFIG_IRQ_OFFLOAD_NESTED */
 }

--- a/kernel/mailbox.c
+++ b/kernel/mailbox.c
@@ -22,7 +22,7 @@
 
 #ifdef CONFIG_OBJ_CORE_MAILBOX
 static struct k_obj_type  obj_type_mailbox;
-#endif
+#endif /* CONFIG_OBJ_CORE_MAILBOX */
 
 #if (CONFIG_NUM_MBOX_ASYNC_MSGS > 0)
 
@@ -97,7 +97,7 @@ void k_mbox_init(struct k_mbox *mbox)
 
 #ifdef CONFIG_OBJ_CORE_MAILBOX
 	k_obj_core_init_and_link(K_OBJ_CORE(mbox), &obj_type_mailbox);
-#endif
+#endif /* CONFIG_OBJ_CORE_MAILBOX */
 
 	SYS_PORT_TRACING_OBJ_INIT(k_mbox, mbox);
 }
@@ -189,7 +189,7 @@ static void mbox_message_dispose(struct k_mbox_msg *rx_msg)
 		}
 		return;
 	}
-#endif
+#endif /* CONFIG_NUM_MBOX_ASYNC_MSGS */
 
 	/* synchronous send: wake up sending thread */
 	arch_thread_return_value_set(sending_thread, 0);
@@ -256,7 +256,7 @@ static int mbox_message_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg,
 				z_reschedule(&mbox->lock, key);
 				return 0;
 			}
-#endif
+#endif /* CONFIG_NUM_MBOX_ASYNC_MSGS */
 			SYS_PORT_TRACING_OBJ_FUNC_BLOCKING(k_mbox, message_put, mbox, timeout);
 
 			/*
@@ -286,7 +286,7 @@ static int mbox_message_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg,
 		k_spin_unlock(&mbox->lock, key);
 		return 0;
 	}
-#endif
+#endif /* CONFIG_NUM_MBOX_ASYNC_MSGS */
 	SYS_PORT_TRACING_OBJ_FUNC_BLOCKING(k_mbox, message_put, mbox, timeout);
 
 	/* synchronous send: sender waits on tx queue for receiver or timeout */
@@ -335,7 +335,7 @@ void k_mbox_async_put(struct k_mbox *mbox, struct k_mbox_msg *tx_msg,
 	(void)mbox_message_put(mbox, &async->tx_msg, K_FOREVER);
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_mbox, async_put, mbox, sem);
 }
-#endif
+#endif /* CONFIG_NUM_MBOX_ASYNC_MSGS */
 
 void k_mbox_data_get(struct k_mbox_msg *rx_msg, void *buffer)
 {
@@ -463,4 +463,4 @@ static int init_mailbox_obj_core_list(void)
 
 SYS_INIT(init_mailbox_obj_core_list, PRE_KERNEL_1,
 	 CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
-#endif
+#endif /* CONFIG_OBJ_CORE_MAILBOX */

--- a/kernel/mem_domain.c
+++ b/kernel/mem_domain.c
@@ -43,7 +43,7 @@ static bool check_add_partition(struct k_mem_domain *domain,
 			part->start);
 		return false;
 	}
-#endif
+#endif /* CONFIG_EXECUTE_XOR_WRITE */
 
 	if (part->size == 0U) {
 		LOG_ERR("zero sized partition at %p with base 0x%lx",
@@ -124,7 +124,7 @@ int k_mem_domain_init(struct k_mem_domain *domain, uint8_t num_parts,
 		ret = -ENOMEM;
 		goto unlock_out;
 	}
-#endif
+#endif /* CONFIG_ARCH_MEM_DOMAIN_DATA */
 	if (num_parts != 0U) {
 		uint32_t i;
 
@@ -145,7 +145,7 @@ int k_mem_domain_init(struct k_mem_domain *domain, uint8_t num_parts,
 			CHECKIF(ret2 != 0) {
 				ret = ret2;
 			}
-#endif
+#endif /* CONFIG_ARCH_MEM_DOMAIN_SYNCHRONOUS_API */
 		}
 	}
 
@@ -200,7 +200,7 @@ int k_mem_domain_add_partition(struct k_mem_domain *domain,
 
 #ifdef CONFIG_ARCH_MEM_DOMAIN_SYNCHRONOUS_API
 	ret = arch_mem_domain_partition_add(domain, p_idx);
-#endif
+#endif /* CONFIG_ARCH_MEM_DOMAIN_SYNCHRONOUS_API */
 
 unlock_out:
 	k_spin_unlock(&z_mem_domain_lock, key);
@@ -242,7 +242,7 @@ int k_mem_domain_remove_partition(struct k_mem_domain *domain,
 
 #ifdef CONFIG_ARCH_MEM_DOMAIN_SYNCHRONOUS_API
 	ret = arch_mem_domain_partition_remove(domain, p_idx);
-#endif
+#endif /* CONFIG_ARCH_MEM_DOMAIN_SYNCHRONOUS_API */
 
 	/* A zero-sized partition denotes it's a free partition */
 	domain->partitions[p_idx].size = 0U;
@@ -271,7 +271,7 @@ static int add_thread_locked(struct k_mem_domain *domain,
 
 #ifdef CONFIG_ARCH_MEM_DOMAIN_SYNCHRONOUS_API
 	ret = arch_mem_domain_thread_add(thread);
-#endif
+#endif /* CONFIG_ARCH_MEM_DOMAIN_SYNCHRONOUS_API */
 
 	return ret;
 }
@@ -287,7 +287,7 @@ static int remove_thread_locked(struct k_thread *thread)
 
 #ifdef CONFIG_ARCH_MEM_DOMAIN_SYNCHRONOUS_API
 	ret = arch_mem_domain_thread_remove(thread);
-#endif
+#endif /* CONFIG_ARCH_MEM_DOMAIN_SYNCHRONOUS_API */
 
 	return ret;
 }

--- a/kernel/mem_slab.c
+++ b/kernel/mem_slab.c
@@ -55,7 +55,7 @@ static int k_mem_slab_stats_query(struct k_obj_core *obj_core, void *stats)
 	ptr->max_allocated_bytes = slab->info.max_used * slab->info.block_size;
 #else
 	ptr->max_allocated_bytes = 0;
-#endif
+#endif /* CONFIG_MEM_SLAB_TRACE_MAX_UTILIZATION */
 	k_spin_unlock(&slab->lock, key);
 
 	return 0;
@@ -73,7 +73,7 @@ static int k_mem_slab_stats_reset(struct k_obj_core *obj_core)
 
 #ifdef CONFIG_MEM_SLAB_TRACE_MAX_UTILIZATION
 	slab->info.max_used = slab->info.num_used;
-#endif
+#endif /* CONFIG_MEM_SLAB_TRACE_MAX_UTILIZATION */
 
 	k_spin_unlock(&slab->lock, key);
 
@@ -89,8 +89,8 @@ static struct k_obj_core_stats_desc mem_slab_stats_desc = {
 	.disable = NULL,
 	.enable = NULL,
 };
-#endif
-#endif
+#endif /* CONFIG_OBJ_CORE_STATS_MEM_SLAB */
+#endif /* CONFIG_OBJ_CORE_MEM_SLAB */
 
 /**
  * @brief Initialize kernel memory slab subsystem.
@@ -141,8 +141,8 @@ static int init_mem_slab_obj_core_list(void)
 			offsetof(struct k_mem_slab, obj_core));
 #ifdef CONFIG_OBJ_CORE_STATS_MEM_SLAB
 	k_obj_type_stats_init(&obj_type_mem_slab, &mem_slab_stats_desc);
-#endif
-#endif
+#endif /* CONFIG_OBJ_CORE_STATS_MEM_SLAB */
+#endif /* CONFIG_OBJ_CORE_MEM_SLAB */
 
 	/* Initialize statically defined mem_slabs */
 
@@ -158,8 +158,8 @@ static int init_mem_slab_obj_core_list(void)
 #ifdef CONFIG_OBJ_CORE_STATS_MEM_SLAB
 		k_obj_core_stats_register(K_OBJ_CORE(slab), &slab->info,
 					  sizeof(struct k_mem_slab_info));
-#endif
-#endif
+#endif /* CONFIG_OBJ_CORE_STATS_MEM_SLAB */
+#endif /* CONFIG_OBJ_CORE_MEM_SLAB */
 	}
 
 out:
@@ -182,7 +182,7 @@ int k_mem_slab_init(struct k_mem_slab *slab, void *buffer,
 
 #ifdef CONFIG_MEM_SLAB_TRACE_MAX_UTILIZATION
 	slab->info.max_used = 0U;
-#endif
+#endif /* CONFIG_MEM_SLAB_TRACE_MAX_UTILIZATION */
 
 	rc = create_free_list(slab);
 	if (rc < 0) {
@@ -191,11 +191,11 @@ int k_mem_slab_init(struct k_mem_slab *slab, void *buffer,
 
 #ifdef CONFIG_OBJ_CORE_MEM_SLAB
 	k_obj_core_init_and_link(K_OBJ_CORE(slab), &obj_type_mem_slab);
-#endif
+#endif /* CONFIG_OBJ_CORE_MEM_SLAB */
 #ifdef CONFIG_OBJ_CORE_STATS_MEM_SLAB
 	k_obj_core_stats_register(K_OBJ_CORE(slab), &slab->info,
 				  sizeof(struct k_mem_slab_info));
-#endif
+#endif /* CONFIG_OBJ_CORE_STATS_MEM_SLAB */
 
 	z_waitq_init(&slab->wait_q);
 	k_object_init(slab);
@@ -221,7 +221,7 @@ int k_mem_slab_alloc(struct k_mem_slab *slab, void **mem, k_timeout_t timeout)
 #ifdef CONFIG_MEM_SLAB_TRACE_MAX_UTILIZATION
 		slab->info.max_used = MAX(slab->info.num_used,
 					  slab->info.max_used);
-#endif
+#endif /* CONFIG_MEM_SLAB_TRACE_MAX_UTILIZATION */
 
 		result = 0;
 	} else if (K_TIMEOUT_EQ(timeout, K_NO_WAIT) ||
@@ -298,7 +298,7 @@ int k_mem_slab_runtime_stats_get(struct k_mem_slab *slab, struct sys_memory_stat
 				     slab->info.block_size;
 #else
 	stats->max_allocated_bytes = 0;
-#endif
+#endif /* CONFIG_MEM_SLAB_TRACE_MAX_UTILIZATION */
 
 	k_spin_unlock(&slab->lock, key);
 
@@ -320,4 +320,4 @@ int k_mem_slab_runtime_stats_reset_max(struct k_mem_slab *slab)
 
 	return 0;
 }
-#endif
+#endif /* CONFIG_MEM_SLAB_TRACE_MAX_UTILIZATION */

--- a/kernel/mempool.c
+++ b/kernel/mempool.c
@@ -119,7 +119,7 @@ void k_thread_system_pool_assign(struct k_thread *thread)
 }
 #else
 #define _SYSTEM_HEAP	NULL
-#endif
+#endif /* K_HEAP_MEM_POOL_SIZE */
 
 void *z_thread_aligned_alloc(size_t align, size_t size)
 {

--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -22,7 +22,7 @@ LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
 #ifdef CONFIG_DEMAND_PAGING
 #include <zephyr/kernel/mm/demand_paging.h>
-#endif
+#endif /* CONFIG_DEMAND_PAGING */
 
 /*
  * General terminology:
@@ -74,7 +74,7 @@ static bool page_frames_initialized;
 #define COLOR(x)	printk(_CONCAT(ANSI_, x))
 #else
 #define COLOR(x)	do { } while (false)
-#endif
+#endif /* COLOR_PAGE_FRAMES */
 
 /* LCOV_EXCL_START */
 static void page_frame_dump(struct z_page_frame *pf)
@@ -722,7 +722,7 @@ size_t k_mem_free_get(void)
 	}
 #else
 	ret = z_free_page_count;
-#endif
+#endif /* CONFIG_DEMAND_PAGING */
 	k_spin_unlock(&z_mm_lock, key);
 
 	return ret * (size_t)CONFIG_MMU_PAGE_SIZE;
@@ -760,7 +760,7 @@ void z_phys_map(uint8_t **virt_ptr, uintptr_t phys, size_t size, uint32_t flags)
 
 #ifndef CONFIG_KERNEL_DIRECT_MAP
 	__ASSERT(!(flags & K_MEM_DIRECT_MAP), "The direct-map is not enabled");
-#endif
+#endif /* CONFIG_KERNEL_DIRECT_MAP */
 	addr_offset = k_mem_region_align(&aligned_phys, &aligned_size,
 					 phys, size,
 					 CONFIG_MMU_PAGE_SIZE);
@@ -952,12 +952,12 @@ void z_mem_manage_init(void)
 	 * boot process. Will be un-pinned once boot process completes.
 	 */
 	mark_linker_section_pinned(lnkr_boot_start, lnkr_boot_end, true);
-#endif
+#endif /* CONFIG_LINKER_USE_BOOT_SECTION */
 
 #ifdef CONFIG_LINKER_USE_PINNED_SECTION
 	/* Pin the page frames correspondng to the pinned symbols */
 	mark_linker_section_pinned(lnkr_pinned_start, lnkr_pinned_end, true);
-#endif
+#endif /* CONFIG_LINKER_USE_PINNED_SECTION */
 
 	/* Any remaining pages that aren't mapped, reserved, or pinned get
 	 * added to the free pages list
@@ -972,10 +972,10 @@ void z_mem_manage_init(void)
 #ifdef CONFIG_DEMAND_PAGING
 #ifdef CONFIG_DEMAND_PAGING_TIMING_HISTOGRAM
 	z_paging_histogram_init();
-#endif
+#endif /* CONFIG_DEMAND_PAGING_TIMING_HISTOGRAM */
 	k_mem_paging_backing_store_init();
 	k_mem_paging_eviction_init();
-#endif
+#endif /* CONFIG_DEMAND_PAGING */
 #if __ASSERT_ON
 	page_frames_initialized = true;
 #endif
@@ -989,7 +989,7 @@ void z_mem_manage_init(void)
 	 * memory to be cleared.
 	 */
 	z_bss_zero();
-#endif
+#endif /* CONFIG_LINKER_GENERIC_SECTIONS_PRESENT_AT_BOOT */
 }
 
 void z_mem_manage_boot_finish(void)
@@ -999,7 +999,7 @@ void z_mem_manage_boot_finish(void)
 	 * as they don't need to be in memory all the time anymore.
 	 */
 	mark_linker_section_pinned(lnkr_boot_start, lnkr_boot_end, false);
-#endif
+#endif /* CONFIG_LINKER_USE_BOOT_SECTION */
 }
 
 #ifdef CONFIG_DEMAND_PAGING
@@ -1009,7 +1009,7 @@ struct k_mem_paging_stats_t paging_stats;
 extern struct k_mem_paging_histogram_t z_paging_histogram_eviction;
 extern struct k_mem_paging_histogram_t z_paging_histogram_backing_store_page_in;
 extern struct k_mem_paging_histogram_t z_paging_histogram_backing_store_page_out;
-#endif
+#endif /* CONFIG_DEMAND_PAGING_STATS */
 
 static inline void do_backing_store_page_in(uintptr_t location)
 {
@@ -1155,7 +1155,7 @@ static int page_frame_prepare_locked(struct z_page_frame *pf, bool *dirty_ptr,
 	__ASSERT(!z_page_frame_is_busy(pf), "page frame 0x%lx is already busy",
 		 phys);
 	pf->flags |= Z_PAGE_FRAME_BUSY;
-#endif
+#endif /* CONFIG_DEMAND_PAGING_ALLOW_IRQ */
 	/* Update dirty parameter, since we set to true if it wasn't backed
 	 * even if otherwise clean
 	 */
@@ -1313,7 +1313,7 @@ static inline void paging_stats_faults_inc(struct k_thread *faulting_thread,
 	}
 #else
 	ARG_UNUSED(faulting_thread);
-#endif
+#endif /* CONFIG_DEMAND_PAGING_THREAD_STATS */
 
 #ifndef CONFIG_DEMAND_PAGING_ALLOW_IRQ
 	if (k_is_in_isr()) {
@@ -1321,7 +1321,7 @@ static inline void paging_stats_faults_inc(struct k_thread *faulting_thread,
 
 #ifdef CONFIG_DEMAND_PAGING_THREAD_STATS
 		faulting_thread->paging_stats.pagefaults.in_isr++;
-#endif
+#endif /* CONFIG_DEMAND_PAGING_THREAD_STATS */
 	}
 #endif /* CONFIG_DEMAND_PAGING_ALLOW_IRQ */
 #endif /* CONFIG_DEMAND_PAGING_STATS */

--- a/kernel/msg_q.c
+++ b/kernel/msg_q.c
@@ -27,7 +27,7 @@
 
 #ifdef CONFIG_OBJ_CORE_MSGQ
 static struct k_obj_type obj_type_msgq;
-#endif
+#endif /* CONFIG_OBJ_CORE_MSGQ */
 
 #ifdef CONFIG_POLL
 static inline void handle_poll_events(struct k_msgq *msgq, uint32_t state)
@@ -55,7 +55,7 @@ void k_msgq_init(struct k_msgq *msgq, char *buffer, size_t msg_size,
 
 #ifdef CONFIG_OBJ_CORE_MSGQ
 	k_obj_core_init_and_link(K_OBJ_CORE(msgq), &obj_type_msgq);
-#endif
+#endif /* CONFIG_OBJ_CORE_MSGQ */
 
 	SYS_PORT_TRACING_OBJ_INIT(k_msgq, msgq);
 
@@ -98,7 +98,7 @@ int z_vrfy_k_msgq_alloc_init(struct k_msgq *msgq, size_t msg_size,
 	return z_impl_k_msgq_alloc_init(msgq, msg_size, max_msgs);
 }
 #include <syscalls/k_msgq_alloc_init_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 int k_msgq_cleanup(struct k_msgq *msgq)
 {
@@ -193,7 +193,7 @@ static inline int z_vrfy_k_msgq_put(struct k_msgq *msgq, const void *data,
 	return z_impl_k_msgq_put(msgq, data, timeout);
 }
 #include <syscalls/k_msgq_put_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 void z_impl_k_msgq_get_attrs(struct k_msgq *msgq, struct k_msgq_attrs *attrs)
 {
@@ -211,7 +211,7 @@ static inline void z_vrfy_k_msgq_get_attrs(struct k_msgq *msgq,
 	z_impl_k_msgq_get_attrs(msgq, attrs);
 }
 #include <syscalls/k_msgq_get_attrs_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 int z_impl_k_msgq_get(struct k_msgq *msgq, void *data, k_timeout_t timeout)
 {
@@ -291,7 +291,7 @@ static inline int z_vrfy_k_msgq_get(struct k_msgq *msgq, void *data,
 	return z_impl_k_msgq_get(msgq, data, timeout);
 }
 #include <syscalls/k_msgq_get_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 int z_impl_k_msgq_peek(struct k_msgq *msgq, void *data)
 {
@@ -325,7 +325,7 @@ static inline int z_vrfy_k_msgq_peek(struct k_msgq *msgq, void *data)
 	return z_impl_k_msgq_peek(msgq, data);
 }
 #include <syscalls/k_msgq_peek_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 int z_impl_k_msgq_peek_at(struct k_msgq *msgq, void *data, uint32_t idx)
 {
@@ -371,7 +371,7 @@ static inline int z_vrfy_k_msgq_peek_at(struct k_msgq *msgq, void *data, uint32_
 	return z_impl_k_msgq_peek_at(msgq, data, idx);
 }
 #include <syscalls/k_msgq_peek_at_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 void z_impl_k_msgq_purge(struct k_msgq *msgq)
 {
@@ -416,7 +416,7 @@ static inline uint32_t z_vrfy_k_msgq_num_used_get(struct k_msgq *msgq)
 }
 #include <syscalls/k_msgq_num_used_get_mrsh.c>
 
-#endif
+#endif /* CONFIG_USERSPACE */
 
 #ifdef CONFIG_OBJ_CORE_MSGQ
 static int init_msgq_obj_core_list(void)
@@ -438,4 +438,4 @@ static int init_msgq_obj_core_list(void)
 SYS_INIT(init_msgq_obj_core_list, PRE_KERNEL_1,
 	 CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
 
-#endif
+#endif /* CONFIG_OBJ_CORE_MSGQ */

--- a/kernel/mutex.c
+++ b/kernel/mutex.c
@@ -49,7 +49,7 @@ static struct k_spinlock lock;
 
 #ifdef CONFIG_OBJ_CORE_MUTEX
 static struct k_obj_type obj_type_mutex;
-#endif
+#endif /* CONFIG_OBJ_CORE_MUTEX */
 
 int z_impl_k_mutex_init(struct k_mutex *mutex)
 {
@@ -62,7 +62,7 @@ int z_impl_k_mutex_init(struct k_mutex *mutex)
 
 #ifdef CONFIG_OBJ_CORE_MUTEX
 	k_obj_core_init_and_link(K_OBJ_CORE(mutex), &obj_type_mutex);
-#endif
+#endif /* CONFIG_OBJ_CORE_MUTEX */
 
 	SYS_PORT_TRACING_OBJ_INIT(k_mutex, mutex, 0);
 
@@ -76,7 +76,7 @@ static inline int z_vrfy_k_mutex_init(struct k_mutex *mutex)
 	return z_impl_k_mutex_init(mutex);
 }
 #include <syscalls/k_mutex_init_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 static int32_t new_prio_for_inheritance(int32_t target, int32_t limit)
 {
@@ -206,7 +206,7 @@ static inline int z_vrfy_k_mutex_lock(struct k_mutex *mutex,
 	return z_impl_k_mutex_lock(mutex, timeout);
 }
 #include <syscalls/k_mutex_lock_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 int z_impl_k_mutex_unlock(struct k_mutex *mutex)
 {
@@ -291,7 +291,7 @@ static inline int z_vrfy_k_mutex_unlock(struct k_mutex *mutex)
 	return z_impl_k_mutex_unlock(mutex);
 }
 #include <syscalls/k_mutex_unlock_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 #ifdef CONFIG_OBJ_CORE_MUTEX
 static int init_mutex_obj_core_list(void)
@@ -312,4 +312,4 @@ static int init_mutex_obj_core_list(void)
 
 SYS_INIT(init_mutex_obj_core_list, PRE_KERNEL_1,
 	 CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
-#endif
+#endif /* CONFIG_OBJ_CORE_MUTEX */

--- a/kernel/obj_core.c
+++ b/kernel/obj_core.c
@@ -28,7 +28,7 @@ void k_obj_core_init(struct k_obj_core *obj_core, struct k_obj_type *type)
 	obj_core->type = type;
 #ifdef CONFIG_OBJ_CORE_STATS
 	obj_core->stats = NULL;
-#endif
+#endif /* CONFIG_OBJ_CORE_STATS */
 }
 
 void k_obj_core_link(struct k_obj_core *obj_core)
@@ -324,4 +324,4 @@ int k_obj_core_stats_enable(struct k_obj_core *obj_core)
 
 	return rv;
 }
-#endif
+#endif /* CONFIG_OBJ_CORE_STATS */

--- a/kernel/pipes.c
+++ b/kernel/pipes.c
@@ -33,7 +33,7 @@ static int pipe_get_internal(k_spinlock_key_t key, struct k_pipe *pipe,
 			     k_timeout_t timeout);
 #ifdef CONFIG_OBJ_CORE_PIPE
 static struct k_obj_type obj_type_pipe;
-#endif
+#endif /* CONFIG_OBJ_CORE_PIPE */
 
 
 void k_pipe_init(struct k_pipe *pipe, unsigned char *buffer, size_t size)
@@ -52,12 +52,12 @@ void k_pipe_init(struct k_pipe *pipe, unsigned char *buffer, size_t size)
 
 #if defined(CONFIG_POLL)
 	sys_dlist_init(&pipe->poll_events);
-#endif
+#endif /* CONFIG_POLL */
 	k_object_init(pipe);
 
 #ifdef CONFIG_OBJ_CORE_PIPE
 	k_obj_core_init_and_link(K_OBJ_CORE(pipe), &obj_type_pipe);
-#endif
+#endif /* CONFIG_OBJ_CORE_PIPE */
 }
 
 int z_impl_k_pipe_alloc_init(struct k_pipe *pipe, size_t size)
@@ -94,7 +94,7 @@ static inline int z_vrfy_k_pipe_alloc_init(struct k_pipe *pipe, size_t size)
 	return z_impl_k_pipe_alloc_init(pipe, size);
 }
 #include <syscalls/k_pipe_alloc_init_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 static inline void handle_poll_events(struct k_pipe *pipe)
 {
@@ -102,7 +102,7 @@ static inline void handle_poll_events(struct k_pipe *pipe)
 	z_handle_obj_poll_events(&pipe->poll_events, K_POLL_STATE_PIPE_DATA_AVAILABLE);
 #else
 	ARG_UNUSED(pipe);
-#endif
+#endif /* CONFIG_POLL */
 }
 
 void z_impl_k_pipe_flush(struct k_pipe *pipe)
@@ -127,7 +127,7 @@ void z_vrfy_k_pipe_flush(struct k_pipe *pipe)
 	z_impl_k_pipe_flush(pipe);
 }
 #include <syscalls/k_pipe_flush_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 void z_impl_k_pipe_buffer_flush(struct k_pipe *pipe)
 {
@@ -154,7 +154,7 @@ void z_vrfy_k_pipe_buffer_flush(struct k_pipe *pipe)
 
 	z_impl_k_pipe_buffer_flush(pipe);
 }
-#endif
+#endif /* CONFIG_USERSPACE */
 
 int k_pipe_cleanup(struct k_pipe *pipe)
 {
@@ -526,7 +526,7 @@ int z_vrfy_k_pipe_put(struct k_pipe *pipe, const void *data,
 				 timeout);
 }
 #include <syscalls/k_pipe_put_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 static int pipe_get_internal(k_spinlock_key_t key, struct k_pipe *pipe,
 			     void *data, size_t bytes_to_read,
@@ -734,7 +734,7 @@ int z_vrfy_k_pipe_get(struct k_pipe *pipe, void *data, size_t bytes_to_read,
 				timeout);
 }
 #include <syscalls/k_pipe_get_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 size_t z_impl_k_pipe_read_avail(struct k_pipe *pipe)
 {
@@ -771,7 +771,7 @@ size_t z_vrfy_k_pipe_read_avail(struct k_pipe *pipe)
 	return z_impl_k_pipe_read_avail(pipe);
 }
 #include <syscalls/k_pipe_read_avail_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 size_t z_impl_k_pipe_write_avail(struct k_pipe *pipe)
 {
@@ -808,7 +808,7 @@ size_t z_vrfy_k_pipe_write_avail(struct k_pipe *pipe)
 	return z_impl_k_pipe_write_avail(pipe);
 }
 #include <syscalls/k_pipe_write_avail_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 #ifdef CONFIG_OBJ_CORE_PIPE
 static int init_pipe_obj_core_list(void)
@@ -829,4 +829,4 @@ static int init_pipe_obj_core_list(void)
 
 SYS_INIT(init_pipe_obj_core_list, PRE_KERNEL_1,
 	 CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
-#endif
+#endif /* CONFIG_OBJ_CORE_PIPE */

--- a/kernel/poll.c
+++ b/kernel/poll.c
@@ -93,7 +93,7 @@ static inline bool is_condition_met(struct k_poll_event *event, uint32_t *state)
 			*state = K_POLL_STATE_PIPE_DATA_AVAILABLE;
 			return true;
 		}
-#endif
+#endif /* CONFIG_PIPES */
 	case K_POLL_TYPE_IGNORE:
 		break;
 	default:
@@ -159,7 +159,7 @@ static inline void register_event(struct k_poll_event *event,
 		__ASSERT(event->pipe != NULL, "invalid pipe\n");
 		add_event(&event->pipe->poll_events, event, poller);
 		break;
-#endif
+#endif /* CONFIG_PIPES */
 	case K_POLL_TYPE_IGNORE:
 		/* nothing to do */
 		break;
@@ -200,7 +200,7 @@ static inline void clear_event_registration(struct k_poll_event *event)
 		__ASSERT(event->pipe != NULL, "invalid pipe\n");
 		remove_event = true;
 		break;
-#endif
+#endif /* CONFIG_PIPES */
 	case K_POLL_TYPE_IGNORE:
 		/* nothing to do */
 		break;
@@ -417,7 +417,7 @@ static inline int z_vrfy_k_poll(struct k_poll_event *events,
 		case K_POLL_TYPE_PIPE_DATA_AVAILABLE:
 			K_OOPS(K_SYSCALL_OBJ(e->pipe, K_OBJ_PIPE));
 			break;
-#endif
+#endif /* CONFIG_PIPES */
 		default:
 			ret = -EINVAL;
 			goto out_free;
@@ -435,7 +435,7 @@ oops_free:
 	K_OOPS(1);
 }
 #include <syscalls/k_poll_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 /* must be called with interrupts locked */
 static int signal_poll_event(struct k_poll_event *event, uint32_t state)
@@ -494,7 +494,7 @@ static inline void z_vrfy_k_poll_signal_init(struct k_poll_signal *sig)
 	z_impl_k_poll_signal_init(sig);
 }
 #include <syscalls/k_poll_signal_init_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 void z_impl_k_poll_signal_reset(struct k_poll_signal *sig)
 {
@@ -522,7 +522,7 @@ void z_vrfy_k_poll_signal_check(struct k_poll_signal *sig,
 	z_impl_k_poll_signal_check(sig, signaled, result);
 }
 #include <syscalls/k_poll_signal_check_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 int z_impl_k_poll_signal_raise(struct k_poll_signal *sig, int result)
 {
@@ -565,7 +565,7 @@ static inline void z_vrfy_k_poll_signal_reset(struct k_poll_signal *sig)
 }
 #include <syscalls/k_poll_signal_reset_mrsh.c>
 
-#endif
+#endif /* CONFIG_USERSPACE */
 
 static void triggered_work_handler(struct k_work *work)
 {

--- a/kernel/queue.c
+++ b/kernel/queue.c
@@ -76,7 +76,7 @@ static inline void z_vrfy_k_queue_init(struct k_queue *queue)
 	z_impl_k_queue_init(queue);
 }
 #include <syscalls/k_queue_init_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 static void prepare_thread_to_run(struct k_thread *thread, void *data)
 {
@@ -91,7 +91,7 @@ static inline void handle_poll_events(struct k_queue *queue, uint32_t state)
 #else
 	ARG_UNUSED(queue);
 	ARG_UNUSED(state);
-#endif
+#endif /* CONFIG_POLL */
 }
 
 void z_impl_k_queue_cancel_wait(struct k_queue *queue)
@@ -118,7 +118,7 @@ static inline void z_vrfy_k_queue_cancel_wait(struct k_queue *queue)
 	z_impl_k_queue_cancel_wait(queue);
 }
 #include <syscalls/k_queue_cancel_wait_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 static int32_t queue_insert(struct k_queue *queue, void *prev, void *data,
 			    bool alloc, bool is_append)
@@ -221,7 +221,7 @@ static inline int32_t z_vrfy_k_queue_alloc_append(struct k_queue *queue,
 	return z_impl_k_queue_alloc_append(queue, data);
 }
 #include <syscalls/k_queue_alloc_append_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 int32_t z_impl_k_queue_alloc_prepend(struct k_queue *queue, void *data)
 {
@@ -242,7 +242,7 @@ static inline int32_t z_vrfy_k_queue_alloc_prepend(struct k_queue *queue,
 	return z_impl_k_queue_alloc_prepend(queue, data);
 }
 #include <syscalls/k_queue_alloc_prepend_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 int k_queue_append_list(struct k_queue *queue, void *head, void *tail)
 {
@@ -454,7 +454,7 @@ static int init_fifo_obj_core_list(void)
 
 SYS_INIT(init_fifo_obj_core_list, PRE_KERNEL_1,
 	 CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
-#endif
+#endif /* CONFIG_OBJ_CORE_FIFO */
 
 #ifdef CONFIG_OBJ_CORE_LIFO
 struct k_obj_type _obj_type_lifo;
@@ -477,4 +477,4 @@ static int init_lifo_obj_core_list(void)
 
 SYS_INIT(init_lifo_obj_core_list, PRE_KERNEL_1,
 	 CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
-#endif
+#endif /* CONFIG_OBJ_CORE_LIFO */

--- a/kernel/sem.c
+++ b/kernel/sem.c
@@ -40,7 +40,7 @@ static struct k_spinlock lock;
 
 #ifdef CONFIG_OBJ_CORE_SEM
 static struct k_obj_type obj_type_sem;
-#endif
+#endif /* CONFIG_OBJ_CORE_SEM */
 
 int z_impl_k_sem_init(struct k_sem *sem, unsigned int initial_count,
 		      unsigned int limit)
@@ -62,12 +62,12 @@ int z_impl_k_sem_init(struct k_sem *sem, unsigned int initial_count,
 	z_waitq_init(&sem->wait_q);
 #if defined(CONFIG_POLL)
 	sys_dlist_init(&sem->poll_events);
-#endif
+#endif /* CONFIG_POLL */
 	k_object_init(sem);
 
 #ifdef CONFIG_OBJ_CORE_SEM
 	k_obj_core_init_and_link(K_OBJ_CORE(sem), &obj_type_sem);
-#endif
+#endif /* CONFIG_OBJ_CORE_SEM */
 
 	return 0;
 }
@@ -80,7 +80,7 @@ int z_vrfy_k_sem_init(struct k_sem *sem, unsigned int initial_count,
 	return z_impl_k_sem_init(sem, initial_count, limit);
 }
 #include <syscalls/k_sem_init_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 static inline bool handle_poll_events(struct k_sem *sem)
 {
@@ -90,7 +90,7 @@ static inline bool handle_poll_events(struct k_sem *sem)
 #else
 	ARG_UNUSED(sem);
 	return false;
-#endif
+#endif /* CONFIG_POLL */
 }
 
 void z_impl_k_sem_give(struct k_sem *sem)
@@ -127,7 +127,7 @@ static inline void z_vrfy_k_sem_give(struct k_sem *sem)
 	z_impl_k_sem_give(sem);
 }
 #include <syscalls/k_sem_give_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 int z_impl_k_sem_take(struct k_sem *sem, k_timeout_t timeout)
 {
@@ -207,7 +207,7 @@ static inline unsigned int z_vrfy_k_sem_count_get(struct k_sem *sem)
 }
 #include <syscalls/k_sem_count_get_mrsh.c>
 
-#endif
+#endif /* CONFIG_USERSPACE */
 
 #ifdef CONFIG_OBJ_CORE_SEM
 static int init_sem_obj_core_list(void)
@@ -228,4 +228,4 @@ static int init_sem_obj_core_list(void)
 
 SYS_INIT(init_sem_obj_core_list, PRE_KERNEL_1,
 	 CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
-#endif
+#endif /* CONFIG_OBJ_CORE_SEM */

--- a/kernel/smp.c
+++ b/kernel/smp.c
@@ -49,7 +49,7 @@ static struct cpu_start_cb {
 #ifdef CONFIG_SYS_CLOCK_EXISTS
 	/** True if smp_timer_init() needs to be called. */
 	bool reinit_timer;
-#endif
+#endif /* CONFIG_SYS_CLOCK_EXISTS */
 } cpu_start_fn;
 
 static struct k_spinlock cpu_start_lock;
@@ -130,7 +130,7 @@ static inline void smp_init_top(void *arg)
 	if ((arg == NULL) || csc.reinit_timer) {
 		smp_timer_init();
 	}
-#endif
+#endif /* CONFIG_SYS_CLOCK_EXISTS */
 
 	/* Do additional initialization steps if needed. */
 	if (csc.fn != NULL) {
@@ -177,7 +177,7 @@ void k_smp_cpu_start(int id, smp_init_fn fn, void *arg)
 
 #ifdef CONFIG_SYS_CLOCK_EXISTS
 	cpu_start_fn.reinit_timer = true;
-#endif
+#endif /* CONFIG_SYS_CLOCK_EXISTS */
 
 	/* We are only starting one CPU so we do not need to synchronize
 	 * across all CPUs using the start_flag. So just set it to 1.
@@ -206,7 +206,7 @@ void k_smp_cpu_resume(int id, smp_init_fn fn, void *arg,
 	cpu_start_fn.reinit_timer = reinit_timer;
 #else
 	ARG_UNUSED(reinit_timer);
-#endif
+#endif /* CONFIG_SYS_CLOCK_EXISTS */
 
 	/* We are only starting one CPU so we do not need to synchronize
 	 * across all CPUs using the start_flag. So just set it to 1.

--- a/kernel/stack.c
+++ b/kernel/stack.c
@@ -21,7 +21,7 @@
 
 #ifdef CONFIG_OBJ_CORE_STACK
 static struct k_obj_type obj_type_stack;
-#endif
+#endif /* CONFIG_OBJ_CORE_STACK */
 
 void k_stack_init(struct k_stack *stack, stack_data_t *buffer,
 		  uint32_t num_entries)
@@ -36,7 +36,7 @@ void k_stack_init(struct k_stack *stack, stack_data_t *buffer,
 
 #ifdef CONFIG_OBJ_CORE_STACK
 	k_obj_core_init_and_link(K_OBJ_CORE(stack), &obj_type_stack);
-#endif
+#endif /* CONFIG_OBJ_CORE_STACK */
 }
 
 int32_t z_impl_k_stack_alloc_init(struct k_stack *stack, uint32_t num_entries)
@@ -69,7 +69,7 @@ static inline int32_t z_vrfy_k_stack_alloc_init(struct k_stack *stack,
 	return z_impl_k_stack_alloc_init(stack, num_entries);
 }
 #include <syscalls/k_stack_alloc_init_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 int k_stack_cleanup(struct k_stack *stack)
 {
@@ -137,7 +137,7 @@ static inline int z_vrfy_k_stack_push(struct k_stack *stack, stack_data_t data)
 	return z_impl_k_stack_push(stack, data);
 }
 #include <syscalls/k_stack_push_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 int z_impl_k_stack_pop(struct k_stack *stack, stack_data_t *data,
 		       k_timeout_t timeout)
@@ -192,7 +192,7 @@ static inline int z_vrfy_k_stack_pop(struct k_stack *stack,
 	return z_impl_k_stack_pop(stack, data, timeout);
 }
 #include <syscalls/k_stack_pop_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 #ifdef CONFIG_OBJ_CORE_STACK
 static int init_stack_obj_core_list(void)
@@ -213,4 +213,4 @@ static int init_stack_obj_core_list(void)
 
 SYS_INIT(init_stack_obj_core_list, PRE_KERNEL_1,
 	 CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
-#endif
+#endif /* CONFIG_OBJ_CORE_STACK */

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -105,7 +105,7 @@ void z_add_timeout(struct _timeout *to, _timeout_func_t fn,
 
 #ifdef CONFIG_KERNEL_COHERENCE
 	__ASSERT_NO_MSG(arch_mem_coherent(to));
-#endif
+#endif /* CONFIG_KERNEL_COHERENCE */
 
 	__ASSERT(!sys_dnode_is_linked(&to->node), "");
 	to->fn = fn;
@@ -255,7 +255,7 @@ void sys_clock_announce(int32_t ticks)
 
 #ifdef CONFIG_TIMESLICING
 	z_time_slice();
-#endif
+#endif /* CONFIG_TIMESLICING */
 }
 
 int64_t sys_clock_tick_get(void)
@@ -274,7 +274,7 @@ uint32_t sys_clock_tick_get_32(void)
 	return (uint32_t)sys_clock_tick_get();
 #else
 	return (uint32_t)curr_tick;
-#endif
+#endif /* CONFIG_TICKLESS_KERNEL */
 }
 
 int64_t z_impl_k_uptime_ticks(void)
@@ -288,7 +288,7 @@ static inline int64_t z_vrfy_k_uptime_ticks(void)
 	return z_impl_k_uptime_ticks();
 }
 #include <syscalls/k_uptime_ticks_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 k_timepoint_t sys_timepoint_calc(k_timeout_t timeout)
 {
@@ -337,4 +337,4 @@ void z_vrfy_sys_clock_tick_set(uint64_t tick)
 {
 	z_impl_sys_clock_tick_set(tick);
 }
-#endif
+#endif /* CONFIG_ZTEST */

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -17,7 +17,7 @@ static struct k_spinlock lock;
 
 #ifdef CONFIG_OBJ_CORE_TIMER
 static struct k_obj_type obj_type_timer;
-#endif
+#endif /* CONFIG_OBJ_CORE_TIMER */
 
 /**
  * @brief Handle expiration of a kernel timer object.
@@ -72,7 +72,7 @@ void z_timer_expiration_handler(struct _timeout *t)
 		 * down" behavior on timeout addition).
 		 */
 		next = K_TIMEOUT_ABS_TICKS(k_uptime_ticks() + 1 + next.ticks);
-#endif
+#endif /* CONFIG_TIMEOUT_64BIT */
 		z_add_timeout(&timer->timeout, z_timer_expiration_handler,
 			      next);
 	}
@@ -132,7 +132,7 @@ void k_timer_init(struct k_timer *timer,
 
 #ifdef CONFIG_OBJ_CORE_TIMER
 	k_obj_core_init_and_link(K_OBJ_CORE(timer), &obj_type_timer);
-#endif
+#endif /* CONFIG_OBJ_CORE_TIMER */
 }
 
 
@@ -189,7 +189,7 @@ static inline void z_vrfy_k_timer_start(struct k_timer *timer,
 	z_impl_k_timer_start(timer, duration, period);
 }
 #include <syscalls/k_timer_start_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 void z_impl_k_timer_stop(struct k_timer *timer)
 {
@@ -222,7 +222,7 @@ static inline void z_vrfy_k_timer_stop(struct k_timer *timer)
 	z_impl_k_timer_stop(timer);
 }
 #include <syscalls/k_timer_stop_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 uint32_t z_impl_k_timer_status_get(struct k_timer *timer)
 {
@@ -242,7 +242,7 @@ static inline uint32_t z_vrfy_k_timer_status_get(struct k_timer *timer)
 	return z_impl_k_timer_status_get(timer);
 }
 #include <syscalls/k_timer_status_get_mrsh.c>
-#endif
+#endif /* CONFIG_USERSPACE */
 
 uint32_t z_impl_k_timer_status_sync(struct k_timer *timer)
 {
@@ -342,7 +342,7 @@ static inline void z_vrfy_k_timer_user_data_set(struct k_timer *timer,
 }
 #include <syscalls/k_timer_user_data_set_mrsh.c>
 
-#endif
+#endif /* CONFIG_USERSPACE */
 
 #ifdef CONFIG_OBJ_CORE_TIMER
 static int init_timer_obj_core_list(void)
@@ -362,4 +362,4 @@ static int init_timer_obj_core_list(void)
 }
 SYS_INIT(init_timer_obj_core_list, PRE_KERNEL_1,
 	 CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
-#endif
+#endif /* CONFIG_OBJ_CORE_TIMER */

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -25,7 +25,7 @@
 
 #ifdef Z_LIBC_PARTITION_EXISTS
 K_APPMEM_PARTITION_DEFINE(z_libc_partition);
-#endif
+#endif /* Z_LIBC_PARTITION_EXISTS */
 
 /* TODO: Find a better place to put this. Since we pull the entire
  * lib..__modules__crypto__mbedtls.a  globals into app shared memory
@@ -33,7 +33,7 @@ K_APPMEM_PARTITION_DEFINE(z_libc_partition);
  */
 #ifdef CONFIG_MBEDTLS
 K_APPMEM_PARTITION_DEFINE(k_mbedtls_partition);
-#endif
+#endif /* CONFIG_MBEDTLS */
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
@@ -68,14 +68,14 @@ static struct k_spinlock objfree_lock;     /* k_object_free */
 #define STACK_ELEMENT_DATA_SIZE(size) Z_THREAD_STACK_SIZE_ADJUST(size)
 #endif /* CONFIG_GEN_PRIV_STACKS */
 
-#endif
+#endif /* CONFIG_DYNAMIC_OBJECTS */
 static struct k_spinlock obj_lock;         /* kobj struct data */
 
 #define MAX_THREAD_BITS		(CONFIG_MAX_THREAD_BYTES * 8)
 
 #ifdef CONFIG_DYNAMIC_OBJECTS
 extern uint8_t _thread_idx_map[CONFIG_MAX_THREAD_BYTES];
-#endif
+#endif /* CONFIG_DYNAMIC_OBJECTS */
 
 static void clear_perms_cb(struct k_object *ko, void *ctx_ptr);
 
@@ -102,7 +102,7 @@ const char *otype_to_str(enum k_objects otype)
 #else
 	ARG_UNUSED(otype);
 	ret = NULL;
-#endif
+#endif /* CONFIG_LOG */
 	return ret;
 }
 
@@ -147,7 +147,7 @@ uint8_t *z_priv_stack_find(k_thread_stack_t *stack)
 #define DYN_OBJ_DATA_ALIGN_K_THREAD	(ARCH_DYNAMIC_OBJ_K_THREAD_ALIGNMENT)
 #else
 #define DYN_OBJ_DATA_ALIGN_K_THREAD	(sizeof(void *))
-#endif
+#endif /* ARCH_DYNAMIC_OBJ_K_THREAD_ALIGNMENT */
 
 #ifdef CONFIG_DYNAMIC_THREAD_STACK_SIZE
 #ifndef CONFIG_MPU_STACK_GUARD
@@ -211,7 +211,7 @@ static size_t obj_align_get(enum k_objects otype)
 		ret = ARCH_DYNAMIC_OBJ_K_THREAD_ALIGNMENT;
 #else
 		ret = __alignof(struct dyn_obj);
-#endif
+#endif /* ARCH_DYNAMIC_OBJ_K_THREAD_ALIGNMENT */
 		break;
 	default:
 		ret = __alignof(struct dyn_obj);
@@ -349,11 +349,11 @@ static struct k_object *dynamic_object_create(enum k_objects otype, size_t align
 			  Z_THREAD_STACK_OBJ_ALIGN(size));
 #else
 		dyn->kobj.name = dyn->data;
-#endif
+#endif /* CONFIG_ARM_MPU || CONFIG_ARC_MPU */
 #else
 		dyn->kobj.name = dyn->data;
 		dyn->kobj.data.stack_size = adjusted_size;
-#endif
+#endif /* CONFIG_GEN_PRIV_STACKS */
 	} else {
 		dyn->data = z_thread_aligned_alloc(align, obj_size_get(otype) + size);
 		if (dyn->data == NULL) {
@@ -561,7 +561,7 @@ static void unref_check(struct k_object *ko, uintptr_t index)
 	case K_OBJ_PIPE:
 		k_pipe_cleanup((struct k_pipe *)ko->name);
 		break;
-#endif
+#endif /* CONFIG_PIPES */
 	case K_OBJ_MSGQ:
 		k_msgq_cleanup((struct k_msgq *)ko->name);
 		break;
@@ -577,7 +577,7 @@ static void unref_check(struct k_object *ko, uintptr_t index)
 	k_free(dyn->data);
 	k_free(dyn);
 out:
-#endif
+#endif /* CONFIG_DYNAMIC_OBJECTS */
 	k_spin_unlock(&obj_lock, key);
 }
 

--- a/kernel/userspace_handler.c
+++ b/kernel/userspace_handler.c
@@ -25,7 +25,7 @@ static struct k_object *validate_kernel_object(const void *obj,
 	if (ret != 0) {
 #ifdef CONFIG_LOG
 		k_object_dump_error(ret, obj, ko, otype);
-#endif
+#endif /* CONFIG_LOG */
 		return NULL;
 	}
 

--- a/kernel/work.c
+++ b/kernel/work.c
@@ -471,7 +471,7 @@ bool k_work_flush(struct k_work *work,
 	__ASSERT_NO_MSG(sync != NULL);
 #ifdef CONFIG_KERNEL_COHERENCE
 	__ASSERT_NO_MSG(arch_mem_coherent(sync));
-#endif
+#endif /* CONFIG_KERNEL_COHERENCE */
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_work, flush, work);
 
@@ -583,7 +583,7 @@ bool k_work_cancel_sync(struct k_work *work,
 	__ASSERT_NO_MSG(!k_is_in_isr());
 #ifdef CONFIG_KERNEL_COHERENCE
 	__ASSERT_NO_MSG(arch_mem_coherent(sync));
-#endif
+#endif /* CONFIG_KERNEL_COHERENCE */
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_work, cancel_sync, work, sync);
 
@@ -1066,7 +1066,7 @@ bool k_work_cancel_delayable_sync(struct k_work_delayable *dwork,
 	__ASSERT_NO_MSG(!k_is_in_isr());
 #ifdef CONFIG_KERNEL_COHERENCE
 	__ASSERT_NO_MSG(arch_mem_coherent(sync));
-#endif
+#endif /* CONFIG_KERNEL_COHERENCE */
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_work, cancel_delayable_sync, dwork, sync);
 
@@ -1098,7 +1098,7 @@ bool k_work_flush_delayable(struct k_work_delayable *dwork,
 	__ASSERT_NO_MSG(!k_is_in_isr());
 #ifdef CONFIG_KERNEL_COHERENCE
 	__ASSERT_NO_MSG(arch_mem_coherent(sync));
-#endif
+#endif /* CONFIG_KERNEL_COHERENCE */
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_work, flush_delayable, dwork, sync);
 


### PR DESCRIPTION
No functional changes.
Just adding closing comments to the endifs with the configuration information to make it easier to navigate the code.