### PR TITLE
boards/Kconfig: $BOARD_REVISION -> $(BOARD_REVISION)

### DIFF
--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -12,7 +12,7 @@ config BOARD
 	  soc/<arch>/<family>/<series>
 
 config BOARD_REVISION
-	def_string "$BOARD_REVISION"
+	def_string "$(BOARD_REVISION)"
 	help
 	  If the BOARD has a revision field set, this is the revision.
 	  Otherwise, it is the empty string. For example, if BOARD is

--- a/share/sysbuild/Kconfig.v2
+++ b/share/sysbuild/Kconfig.v2
@@ -13,7 +13,7 @@ config BOARD
 	  soc/<arch>/<family>/<series>
 
 config BOARD_REVISION
-	def_string "$BOARD_REVISION"
+	def_string "$(BOARD_REVISION)"
 	help
 	  If the BOARD has a revision field set, this is the revision.
 	  Otherwise, it is the empty string. For example, if BOARD is


### PR DESCRIPTION
Add parentheses missing around $BOARD_REVISION.

The syntax without parentheses has been deprecated for at least 5 years: https://github.com/ulfalizer/Kconfiglib/commit/374f48873424f9

That same documentation states "Using the old syntax with an undefined environment variable keeps the string as is." This what actually happens on Windows where `build/zephyr/.config` looks like this:

  CONFIG_BOARD_REVISION="$BOARD_REVISION"

I found this because **the behavior differs on Linux** where the same, "old" syntax produces this instead:

  CONFIG_BOARD_REVISION=""

This could be because environment variables work differently? (BOARD_REVISION is passed from kconfig.cmake to kconfiglib.py thanks to cmake -E env)

Let's not try to debug this and just drop the deprecated syntax. It **aligns both Windows and Linux** on the same, expected, empty string behavior.

Note these are the only two `def_string` found across all Kconfig files right now.

Fixes commit c11b7852d15c ("Kconfig: add CONFIG_BOARD_REVISION")
Fixes commit e2ff2a88ba76 ("sysbuild: include HWMv2 Kconfig in sysbuild")