### PR TITLE
shell: fix index out bound issue

### DIFF
--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -288,8 +288,8 @@ static bool tab_prepare(const struct shell *sh,
 	/* If last command is not completed (followed by space) it is treated
 	 * as uncompleted one.
 	 */
-	int space = isspace((int)sh->ctx->cmd_buff[
-						sh->ctx->cmd_buff_pos - 1]);
+	int space = (sh->ctx->cmd_buff_pos > 0) ?
+		     isspace((int)sh->ctx->cmd_buff[sh->ctx->cmd_buff_pos - 1]) : 0;
 
 	/* root command completion */
 	if ((*argc == 0) || ((space == 0) && (*argc == 1))) {


### PR DESCRIPTION
In order to prevent index out of bounds access of the sh->ctx->cmd_buff
array when sh->ctx->cmd_buff_pos is 0, it has been added a check for
the value of sh->ctx->cmd_buff_pos.

This ensures that the array will not be accessed beyond its boundaries.