### PR TITLE
net: context: Fix the ICMP error on udp

### DIFF
--- a/subsys/net/ip/connection.c
+++ b/subsys/net/ip/connection.c
@@ -457,6 +457,30 @@ int net_conn_unregister(struct net_conn_handle *handle)
 	return 0;
 }
 
+int net_conn_update(struct net_conn_handle *handle,
+		    net_conn_cb_t cb,
+		    void *user_data,
+		    const struct sockaddr *remote_addr,
+		    uint16_t remote_port)
+{
+	struct net_conn *conn = (struct net_conn *)handle;
+	int ret;
+
+	if (conn < &conns[0] || conn > &conns[CONFIG_NET_MAX_CONN]) {
+		return -EINVAL;
+	}
+
+	if (!(conn->flags & NET_CONN_IN_USE)) {
+		return -ENOENT;
+	}
+
+	net_conn_change_callback(conn, cb, user_data);
+
+	ret = net_conn_change_remote(conn, remote_addr, remote_port);
+
+	return ret;
+}
+
 static bool conn_addr_cmp(struct net_pkt *pkt,
 			  union net_ip_header *ip_hdr,
 			  struct sockaddr *addr,

--- a/subsys/net/ip/connection.h
+++ b/subsys/net/ip/connection.h
@@ -157,6 +157,24 @@ static inline int net_conn_unregister(struct net_conn_handle *handle)
 #endif
 
 /**
+ * @brief Update the callback, user data, remote address, and port
+ * for a registered connection handle.
+ *
+ * @param handle A handle registered with net_conn_register()
+ * @param cb Callback to be called
+ * @param user_data User data supplied by caller.
+ * @param remote_addr Remote address
+ * @param remote_port Remote port
+ *
+ * @return Return 0 if the the change succeed, <0 otherwise.
+ */
+int net_conn_update(struct net_conn_handle *handle,
+		    net_conn_cb_t cb,
+		    void *user_data,
+		    const struct sockaddr *remote_addr,
+		    uint16_t remote_port);
+
+/**
  * @brief Called by net_core.c when a network packet is received.
  *
  * @param pkt Network packet holding received data

--- a/subsys/net/ip/connection.h
+++ b/subsys/net/ip/connection.h
@@ -157,19 +157,6 @@ static inline int net_conn_unregister(struct net_conn_handle *handle)
 #endif
 
 /**
- * @brief Change the callback and user_data for a registered connection
- * handle.
- *
- * @param handle A handle registered with net_conn_register()
- * @param cb Callback to be called
- * @param user_data User data supplied by caller.
- *
- * @return Return 0 if the the change succeed, <0 otherwise.
- */
-int net_conn_change_callback(struct net_conn_handle *handle,
-			     net_conn_cb_t cb, void *user_data);
-
-/**
  * @brief Called by net_core.c when a network packet is received.
  *
  * @param pkt Network packet holding received data

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -2401,9 +2401,24 @@ static int recv_udp(struct net_context *context,
 
 	ARG_UNUSED(timeout);
 
+	/* If the context already has a connection handler, it means it's
+	 * already registered. In that case, all we have to do is 1) update
+	 * the callback registered in the net_context and 2) update the
+	 * user_data and remote address and port using net_conn_update().
+	 *
+	 * The callback function passed to net_conn_update() must be the same
+	 * function as the one passed to net_conn_register(), not the callback
+	 * set for the net context passed by recv_udp().
+	 */
 	if (context->conn_handler) {
-		net_conn_unregister(context->conn_handler);
-		context->conn_handler = NULL;
+		context->recv_cb = cb;
+		ret = net_conn_update(context->conn_handler,
+				      net_context_packet_received,
+				      user_data,
+				      context->flags & NET_CONTEXT_REMOTE_ADDR_SET ?
+						&context->remote : NULL,
+				      ntohs(net_sin(&context->remote)->sin_port));
+		return ret;
 	}
 
 	ret = bind_default(context);


### PR DESCRIPTION
This commit fixes the ##70020.

When receiving a UDP packet, net_conn_input() searches for a matching connection within `conn_used`.

However, when receiving UDP packets simultaneously from multiple clients, we may encounter a situation where the connection that was supposed to be bound cannot be found within `conn_used`, and raise the ICMP error.

This is because, within recv_udp(), to avoid the failure of bind_default(), we temporarily remove it from `conn_used` using net_conn_unregister().

If the context already has a connection handler, it means it's already registered. In that case, all we have to do is 1) update the callback registered in the net_context and 2) update the user_data using net_conn_change_callback().

Since net_conn_change_callback() takes the _other_ callback function, net_context_packet_received() (I know it's confusing), this must be the same function passed in net_conn_register() down below.

-----

Fixes #70020