### PR TITLE
Add support to configure BSSID in Wi-Fi connect command

### DIFF
--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -179,6 +179,14 @@ Networking
   used to read the inner IPv4/IPv6 packets in an IP tunnel. This incoming tunnel read is now
   implemented in `recv` callback. (:github:`70549`)
 
+* Modified the ``wifi connect`` command to use key-value format for the arguments. In the
+  previous implementation, we were identifying an option using its position in the argument string.
+  This made it difficult to deal with optional arguments or extending the support
+  for other options. Having this key-value format makes it easier to extend the options that
+  can be passed to the connect command.
+  ``wifi -h`` will give more information about the usage of connect command.
+  (:github:`70024`)
+
 Other Subsystems
 ****************
 

--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -359,6 +359,8 @@ struct wifi_connect_req_params {
 	enum wifi_security_type security;
 	/** MFP options */
 	enum wifi_mfp_options mfp;
+	/** BSSID */
+	uint8_t bssid[WIFI_MAC_ADDR_LEN];
 	/** Connect timeout in seconds, SYS_FOREVER_MS for no timeout */
 	int timeout;
 };

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -477,7 +477,7 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 	params->security = WIFI_SECURITY_TYPE_NONE;
 	params->mfp = WIFI_MFP_OPTIONAL;
 
-	while ((opt = getopt_long(argc, argv, "s:p:k:w:b:c:h", long_options, &opt_index)) != -1) {
+	while ((opt = getopt_long(argc, argv, "s:p:k:w:b:c:m:h", long_options, &opt_index)) != -1) {
 		state = getopt_state_get();
 		switch (opt) {
 		case 's':
@@ -561,6 +561,12 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 			}
 			params->mfp = atoi(optarg);
 			break;
+		case 'm':
+			sscanf(optarg, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
+				&params->bssid[0], &params->bssid[1],
+				&params->bssid[2], &params->bssid[3],
+				&params->bssid[4], &params->bssid[5]);
+			break;
 		case 'h':
 			shell_help(sh);
 			break;
@@ -570,6 +576,7 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 			return -EINVAL;
 		}
 	}
+
 	return 0;
 }
 
@@ -1858,9 +1865,11 @@ SHELL_STATIC_SUBCMD_SET_CREATE(wifi_commands,
 		  "[-k, --key-mgmt]: Key Management type (valid only for secure SSIDs)\n"
 		  "0:None, 1:WPA2-PSK, 2:WPA2-PSK-256, 3:SAE, 4:WAPI, 5:EAP, 6:WEP, 7: WPA-PSK\n"
 		  "[-w, --ieee-80211w]: MFP (optional: needs security type to be specified)\n"
-		  ": 0:Disable, 1:Optional, 2:Required.\n",
+		  ": 0:Disable, 1:Optional, 2:Required.\n"
+		  "[-m, --bssid]: MAC address of the AP (BSSID).\n"
+		  "[-h, --help]: Print out the help for the connect command.\n",
 		  cmd_wifi_connect,
-		  2, 5),
+		  2, 7),
 	SHELL_CMD_ARG(disconnect, NULL, "Disconnect from the Wi-Fi AP.\n",
 		  cmd_wifi_disconnect,
 		  1, 0),


### PR DESCRIPTION
1.  Use getopt API to process the arguments passed with connect command.
2.  Add support for BSSID configuration in connect call.