### PR TITLE
net: zperf: fix download ipv6 bind fail on specific ip address

### DIFF
--- a/subsys/net/lib/zperf/zperf_tcp_receiver.c
+++ b/subsys/net/lib/zperf/zperf_tcp_receiver.c
@@ -278,12 +278,15 @@ out:
 static int zperf_tcp_receiver_init(void)
 {
 	int ret;
+	int family;
 
 	for (int i = 0; i < ARRAY_SIZE(fds); i++) {
 		fds[i].fd = -1;
 	}
 
-	if (IS_ENABLED(CONFIG_NET_IPV4)) {
+	family = tcp_server_addr.sa_family;
+
+	if (IS_ENABLED(CONFIG_NET_IPV4) && (family == AF_INET || family == AF_UNSPEC)) {
 		struct sockaddr_in *in4_addr = zperf_get_sin();
 		const struct in_addr *addr = NULL;
 
@@ -329,7 +332,7 @@ use_any_ipv4:
 		}
 	}
 
-	if (IS_ENABLED(CONFIG_NET_IPV6)) {
+	if (IS_ENABLED(CONFIG_NET_IPV6) && (family == AF_INET6 || family == AF_UNSPEC)) {
 		struct sockaddr_in6 *in6_addr = zperf_get_sin6();
 		const struct in6_addr *addr = NULL;
 

--- a/subsys/net/lib/zperf/zperf_udp_receiver.c
+++ b/subsys/net/lib/zperf/zperf_udp_receiver.c
@@ -311,12 +311,15 @@ static void udp_svc_handler(struct k_work *work)
 static int zperf_udp_receiver_init(void)
 {
 	int ret;
+	int family;
 
 	for (int i = 0; i < ARRAY_SIZE(fds); i++) {
 		fds[i].fd = -1;
 	}
 
-	if (IS_ENABLED(CONFIG_NET_IPV4)) {
+	family = udp_server_addr.sa_family;
+
+	if (IS_ENABLED(CONFIG_NET_IPV4) && (family == AF_INET || family == AF_UNSPEC)) {
 		const struct in_addr *in4_addr = NULL;
 
 		in4_addr_my = zperf_get_sin();
@@ -365,7 +368,7 @@ use_any_ipv4:
 		fds[SOCK_ID_IPV4].events = ZSOCK_POLLIN;
 	}
 
-	if (IS_ENABLED(CONFIG_NET_IPV6)) {
+	if (IS_ENABLED(CONFIG_NET_IPV6) && (family == AF_INET6 || family == AF_UNSPEC)) {
 		const struct in6_addr *in6_addr = NULL;
 
 		in6_addr_my = zperf_get_sin6();


### PR DESCRIPTION
For command zperf udp download 5001 192.168.10.1,
zperf will bind both ipv4 and ipv6 sockets on ipv4 address. But bind ipv6 socket will fail, thus command return fail.

Fix it by check ip address when zperf download.
For ipv4 address only bind ipv4 socket.
For ipv6 address only bind ipv6 socket.
For unspecific address bind both ipv4 and ipv6 sockets.