### PR TITLE
doc/develop api_lifecycle: Mention adding the arch review label

### DIFF
--- a/doc/develop/api/api_lifecycle.rst
+++ b/doc/develop/api/api_lifecycle.rst
@@ -166,6 +166,8 @@ The Pull Request must include the following:
   upcoming release
 - The labels ``API``, ``Breaking API Change`` and ``Release Notes``, as well as
   any others that are applicable
+- The label ``Architecture Review`` if the RFC was not yet discussed and agreed upon in `Zephyr
+  Architecture meeting`_
 
 Once the steps above have been completed, the outcome of the proposal will
 depend on the approval of the actual Pull Request by the maintainer of the


### PR DESCRIPTION
For breaking API changes, let's mention explicity the PR should be labelled with the "Architecture Review" label, as that is the one we base the automation on.
As otherwise it is not clear enough for developers that they should add it, and without it (and the automation surrounding it), it is too easy for a PR to be merged by mistake.