### PR TITLE
tests: arch: common: ramfunc: add nrf54h20pdk cpuapp overlays

### DIFF
--- a/tests/arch/common/ramfunc/boards/nrf54h20pdk_nrf54h20_cpuapp.overlay
+++ b/tests/arch/common/ramfunc/boards/nrf54h20pdk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&cpuapp_ram0x_region {
+	perm-execute;
+};


### PR DESCRIPTION
On nRF54H20, we need to configure RAM with execution permissions to execute code from it. This patch adds overlays for the nRF54H20 PDK cpuapp cores so that RAM0X region is given execution permissions and so the test runs successfully.