### PR TITLE
Bluetooth: controller: Sync ISO Establishment fixes

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -503,6 +503,9 @@ struct event_done_extra {
 				struct {
 					uint16_t trx_cnt;
 					uint8_t  crc_valid:1;
+#if defined(CONFIG_BT_CTLR_SYNC_ISO)
+					uint8_t  estab_failed:1;
+#endif /* CONFIG_BT_CTLR_SYNC_ISO */
 #if defined(CONFIG_BT_CTLR_SYNC_PERIODIC_CTE_TYPE_FILTERING) && \
 	defined(CONFIG_BT_CTLR_CTEINLINE_SUPPORT)
 					/* Used to inform ULL that periodic

--- a/subsys/bluetooth/controller/ll_sw/lll_sync_iso.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_sync_iso.h
@@ -55,6 +55,8 @@ struct lll_sync_iso {
 
 	uint8_t stream_curr:5;
 
+	uint8_t establish_events:3;
+
 	uint8_t next_chan_use;
 
 	/* Encryption */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
@@ -456,6 +456,7 @@ static void isr_rx_estab(void *param)
 	LL_ASSERT(e);
 
 	e->type = EVENT_DONE_EXTRA_TYPE_SYNC_ISO_ESTAB;
+	e->estab_failed = 0U;
 	e->trx_cnt = trx_cnt;
 	e->crc_valid = crc_ok;
 


### PR DESCRIPTION
- Introduce variable in lll_sync_iso for sync establishment timeout
- Introduce estab_failed flag in event_done_extra struct to convey
  establishment failure from LLL.
- Fix ull_sync_iso_estab_done always sending success