### PR TITLE
Bluetooth: Host: Add macros for continuous scanning

### DIFF
--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -2126,6 +2126,18 @@ struct bt_le_scan_cb {
 					   BT_GAP_SCAN_FAST_WINDOW)
 
 /**
+ * @brief Helper macro to enable active scanning to discover new devices with window == interval.
+ *
+ * Continuous scanning should be used to maximize the chances of receiving advertising packets.
+ */
+#define BT_LE_SCAN_ACTIVE_CONTINUOUS BT_LE_SCAN_PARAM(BT_LE_SCAN_TYPE_ACTIVE, \
+						      BT_LE_SCAN_OPT_FILTER_DUPLICATE, \
+						      BT_GAP_SCAN_FAST_INTERVAL_MIN, \
+						      BT_GAP_SCAN_FAST_WINDOW)
+BUILD_ASSERT(BT_GAP_SCAN_FAST_WINDOW == BT_GAP_SCAN_FAST_INTERVAL_MIN,
+	     "Continuous scanning is requested by setting window and interval equal.");
+
+/**
  * @brief Helper macro to enable passive scanning to discover new devices.
  *
  * This macro should be used if information required for device identification
@@ -2135,6 +2147,19 @@ struct bt_le_scan_cb {
 					    BT_LE_SCAN_OPT_FILTER_DUPLICATE, \
 					    BT_GAP_SCAN_FAST_INTERVAL, \
 					    BT_GAP_SCAN_FAST_WINDOW)
+
+/**
+ * @brief Helper macro to enable passive scanning to discover new devices with window==interval.
+ *
+ * This macro should be used if information required for device identification
+ * (e.g., UUID) are known to be placed in Advertising Data.
+ */
+#define BT_LE_SCAN_PASSIVE_CONTINUOUS BT_LE_SCAN_PARAM(BT_LE_SCAN_TYPE_PASSIVE, \
+						       BT_LE_SCAN_OPT_FILTER_DUPLICATE, \
+						       BT_GAP_SCAN_FAST_INTERVAL_MIN, \
+						       BT_GAP_SCAN_FAST_WINDOW)
+BUILD_ASSERT(BT_GAP_SCAN_FAST_WINDOW == BT_GAP_SCAN_FAST_INTERVAL_MIN,
+	     "Continuous scanning is requested by setting window and interval equal.");
 
 /**
  * @brief Helper macro to enable active scanning to discover new devices.

--- a/include/zephyr/bluetooth/gap.h
+++ b/include/zephyr/bluetooth/gap.h
@@ -708,6 +708,7 @@ extern "C" {
  * @name Defined GAP timers
  * @{
  */
+#define BT_GAP_SCAN_FAST_INTERVAL_MIN           0x0030  /* 30 ms    */
 #define BT_GAP_SCAN_FAST_INTERVAL               0x0060  /* 60 ms    */
 #define BT_GAP_SCAN_FAST_WINDOW                 0x0030  /* 30 ms    */
 #define BT_GAP_SCAN_SLOW_INTERVAL_1             0x0800  /* 1.28 s   */

--- a/tests/bsim/bluetooth/host/att/pipeline/dut/src/main.c
+++ b/tests/bsim/bluetooth/host/att/pipeline/dut/src/main.c
@@ -151,16 +151,10 @@ static struct bt_conn *connect(void)
 {
 	int err;
 	struct bt_conn *conn;
-	struct bt_le_scan_param scan_param = {
-		.type = BT_LE_SCAN_TYPE_ACTIVE,
-		.options = BT_LE_SCAN_OPT_NONE,
-		.interval = BT_GAP_SCAN_FAST_INTERVAL,
-		.window = BT_GAP_SCAN_FAST_WINDOW,
-	};
 
 	UNSET_FLAG(is_connected);
 
-	err = bt_le_scan_start(&scan_param, device_found);
+	err = bt_le_scan_start(BT_LE_SCAN_ACTIVE_CONTINUOUS, device_found);
 	ASSERT(!err, "Scanning failed to start (err %d)\n", err);
 
 	LOG_DBG("Central initiating connection...");

--- a/tests/bsim/bluetooth/ll/cis/src/main.c
+++ b/tests/bsim/bluetooth/ll/cis/src/main.c
@@ -45,9 +45,6 @@ static K_SEM_DEFINE(sem_iso_data, CONFIG_BT_ISO_TX_BUF_COUNT,
 				   CONFIG_BT_ISO_TX_BUF_COUNT);
 static bt_addr_le_t peer_addr;
 
-#define SCAN_INTERVAL        0x0010
-#define SCAN_WINDOW          0x0010
-
 #define CREATE_CONN_INTERVAL 0x0010
 #define CREATE_CONN_WINDOW   0x0010
 
@@ -68,12 +65,6 @@ static bt_addr_le_t peer_addr;
 
 #define ADV_INTERVAL_MIN     0x0020
 #define ADV_INTERVAL_MAX     0x0020
-
-#define BT_LE_SCAN_CUSTOM \
-	BT_LE_SCAN_PARAM(BT_LE_SCAN_TYPE_PASSIVE, \
-			 BT_LE_SCAN_OPT_NONE, \
-			 SCAN_INTERVAL, \
-			 SCAN_WINDOW)
 
 #define BT_CONN_LE_CREATE_CONN_CUSTOM  \
 	BT_CONN_LE_CREATE_PARAM(BT_CONN_LE_OPT_NONE, \
@@ -451,7 +442,7 @@ static void test_cis_central(void)
 		int chan;
 
 		printk("Start scanning (%d)...", i);
-		err = bt_le_scan_start(BT_LE_SCAN_CUSTOM, NULL);
+		err = bt_le_scan_start(BT_LE_SCAN_PASSIVE_CONTINUOUS, NULL);
 		if (err) {
 			FAIL("Could not start scan: %d\n", err);
 			return;


### PR DESCRIPTION
It is often desired to maximize the chances of receiving advertising
when scanning. To achieve this, the scanner should be enabled all the time.

Some controller implementations (like Nordic's SoftDevice Controller)
handle scheduling differently when scan_window = scan_interval.
Having a macro that defines this scanning configuration simplifies
writing applications.