### PR TITLE
Bluetooth: controller: Fix ISO Broadcast control subevent channel

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll_adv.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_adv.h
@@ -74,7 +74,6 @@ struct lll_adv_iso {
 	uint8_t term_ack:1;
 	uint8_t term_reason;
 
-	uint8_t  ctrl_chan_use;
 	uint8_t  ctrl_expire;
 	uint16_t ctrl_instant;
 

--- a/subsys/bluetooth/controller/ll_sw/lll_sync_iso.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_sync_iso.h
@@ -66,7 +66,6 @@ struct lll_sync_iso {
 
 	uint8_t term_reason;
 
-	uint8_t ctrl_chan_use;
 	uint16_t ctrl_instant;
 
 	uint8_t stream_count;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
@@ -255,7 +255,6 @@ static int prepare_cb_common(struct lll_prepare_param *p)
 					   lll->data_chan_count,
 					   &lll->data_chan_prn_s,
 					   &lll->data_chan_remap_idx);
-	lll->ctrl_chan_use = data_chan_use;
 
 	/* Initialize stream current */
 	lll->stream_curr = 0U;
@@ -876,7 +875,15 @@ isr_rx_next_subevent:
 
 	/* Set the channel to use */
 	if (!bis) {
-		data_chan_use = lll->ctrl_chan_use;
+		const uint16_t event_counter =
+				(lll->payload_count / lll->bn) - 1U;
+
+		/* Calculate the radio channel to use for ISO event */
+		data_chan_use = lll_chan_iso_event(event_counter, data_chan_id,
+						   lll->data_chan_map,
+						   lll->data_chan_count,
+						   &lll->data_chan_prn_s,
+						   &lll->data_chan_remap_idx);
 	} else if (!skipped) {
 		data_chan_use = lll->next_chan_use;
 	} else {


### PR DESCRIPTION
- Calculate broadcaster channel for control subevent
- Calculate sync receiver channel for control subevent
- Fix broadcast CSTF only set in first subevent
- Remove ctrl_chan_use from LLL, as there is no longer a reason for storing it.