### PR TITLE
Bluetooth: controller: Allow any valid ISO sync receiver BIG handle

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll_sync_iso.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_sync_iso.h
@@ -90,7 +90,7 @@ int lll_sync_iso_reset(void);
 void lll_sync_iso_create_prepare(void *param);
 void lll_sync_iso_prepare(void *param);
 
-extern uint8_t ull_sync_iso_lll_handle_get(struct lll_sync_iso *lll);
+extern uint8_t ull_sync_iso_lll_index_get(struct lll_sync_iso *lll);
 extern struct lll_sync_iso_stream *ull_sync_iso_lll_stream_get(uint16_t handle);
 extern void ll_iso_rx_put(memq_link_t *link, void *rx);
 extern void ll_rx_sched(void);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
@@ -375,7 +375,7 @@ static int prepare_cb_common(struct lll_prepare_param *p)
 	uint32_t overhead;
 
 	overhead = lll_preempt_calc(ull, (TICKER_ID_SCAN_SYNC_ISO_BASE +
-					  ull_sync_iso_lll_handle_get(lll)), ticks_at_event);
+					  ull_sync_iso_lll_index_get(lll)), ticks_at_event);
 	/* check if preempt to start has changed */
 	if (overhead) {
 		LL_ASSERT_OVERHEAD(overhead);

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_types.h
@@ -115,6 +115,7 @@ struct ll_sync_iso_set {
 	uint16_t timeout;
 	uint16_t volatile timeout_reload; /* Non-zero when sync established */
 	uint16_t timeout_expire; /* timeout countdown */
+	uint8_t big_handle;
 
 	/* Encryption */
 	uint8_t gltk[16];


### PR DESCRIPTION
The BIG handle for an ISO sync receiver is provided by the host. The valid range is [0x00..0xEF], and this requires the controller to allow non-consecutive handle numbering. This means that even if only one sync set is supported, a BIG handle of ex. value 2 must be supported.

As the code uses indexing and range checking directly by handle, this needs to be changed. Introducing the handle index, which sequnces the handles such that index = 0 is always the "first handle", regardless of value.