### PR TITLE
uart_native_tty: Polling thread fix

### DIFF
--- a/drivers/serial/uart_native_tty.c
+++ b/drivers/serial/uart_native_tty.c
@@ -289,9 +289,11 @@ void native_tty_uart_irq_function(void *arg1, void *arg2, void *arg3)
 			} else {
 				k_sleep(K_MSEC(1));
 			}
-		} else if (data->tx_irq_enabled) {
+		}
+		if (data->tx_irq_enabled) {
 			native_tty_uart_irq_handler(dev);
-		} else {
+		}
+		if (data->tx_irq_enabled == false && data->rx_irq_enabled == false) {
 			k_sleep(K_MSEC(10));
 		}
 	}


### PR DESCRIPTION
This pull request addresses an issue within the uart_native_tty module, where attempts to transmit data fail under certain conditions. The identified cause of this failure is the handling of the rx_irq_enable and tx_irq_enable flags, which inadvertently prevents any data from being transmitted.