### PR TITLE
ISO sync receiver disable and parameter check

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_iso.c
@@ -189,6 +189,9 @@ uint8_t ll_read_iso_tx_sync(uint16_t handle, uint16_t *seq,
 		}
 
 		return BT_HCI_ERR_SUCCESS;
+
+	} else if (IS_SYNC_ISO_HANDLE(handle)) {
+		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
 
 	return BT_HCI_ERR_UNKNOWN_CONN_ID;

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -454,10 +454,27 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 		/* Periodic Advertising Channel Map Indication */
 		ull_sync_chm_update(rx->handle, ptr, acad_len);
 
+#if defined(CONFIG_BT_CTLR_SYNC_ISO)
+		struct ll_sync_set *sync_set;
+		struct pdu_big_info *bi;
+		uint8_t bi_size;
+
+		sync_set = HDR_LLL2ULL(sync_lll);
+
+		/* Provide encryption information for BIG sync creation */
+		bi_size = ptr[PDU_ADV_DATA_HEADER_LEN_OFFSET] -
+			  PDU_ADV_DATA_HEADER_TYPE_SIZE;
+		sync_set->enc = (bi_size == PDU_BIG_INFO_ENCRYPTED_SIZE);
+
+		/* Store number of BISes in the BIG */
+		bi = (void *)&ptr[PDU_ADV_DATA_HEADER_DATA_OFFSET];
+		sync_set->num_bis = PDU_BIG_INFO_NUM_BIS_GET(bi);
+
 		/* Broadcast ISO synchronize */
-		if (IS_ENABLED(CONFIG_BT_CTLR_SYNC_ISO) && sync_iso) {
+		if (sync_iso) {
 			ull_sync_iso_setup(sync_iso, rx, ptr, acad_len);
 		}
+#endif /* CONFIG_BT_CTLR_SYNC_ISO */
 	}
 
 	/* Do not ULL schedule auxiliary PDU reception if no aux pointer

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -201,6 +201,10 @@ uint8_t ll_sync_create(uint8_t options, uint8_t sid, uint8_t adv_addr_type,
 	sync->skip = skip;
 	sync->is_stop = 0U;
 
+#if defined(CONFIG_BT_CTLR_SYNC_ISO)
+	sync->enc = 0U;
+#endif /* CONFIG_BT_CTLR_SYNC_ISO */
+
 	/* NOTE: Use timeout not zero to represent sync context used for sync
 	 * create.
 	 */
@@ -1492,7 +1496,6 @@ static struct pdu_cte_info *pdu_cte_info_get(struct pdu_adv *pdu)
 {
 	struct pdu_adv_com_ext_adv *com_hdr;
 	struct pdu_adv_ext_hdr *hdr;
-	uint8_t *dptr;
 
 	com_hdr = &pdu->adv_ext_ind;
 	hdr = &com_hdr->ext_hdr;
@@ -1500,9 +1503,6 @@ static struct pdu_cte_info *pdu_cte_info_get(struct pdu_adv *pdu)
 	if (!com_hdr->ext_hdr_len || (com_hdr->ext_hdr_len != 0 && !hdr->cte_info)) {
 		return NULL;
 	}
-
-	/* Skip flags in extended advertising header */
-	dptr = hdr->data;
 
 	/* Make sure there are no fields that are not allowd for AUX_SYNC_IND and AUX_CHAIN_IND */
 	LL_ASSERT(!hdr->adv_addr);

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_types.h
@@ -57,6 +57,11 @@ struct ll_sync_set {
 	uint8_t is_stop:1; /* sync terminate or cancel requested */
 	uint8_t sync_expire:3; /* countdown of 6 before fail to establish */
 
+#if defined(CONFIG_BT_CTLR_SYNC_ISO)
+	uint8_t enc : 1;
+	uint8_t num_bis : 5;
+#endif /* CONFIG_BT_CTLR_SYNC_ISO */
+
 #if defined(CONFIG_BT_CTLR_CHECK_SAME_PEER_SYNC)
 	uint8_t sid;
 #endif /* CONFIG_BT_CTLR_CHECK_SAME_PEER_SYNC */


### PR DESCRIPTION
**Bluetooth: controller: Parameter check for ISO sync recv qualification**
Add HCI input parameter validation according to spec for passing
qualification tests.

- Conditional compile of LE Set PA Receive Enable feature
- Store BIGinfo encryption state and number of streams
- Do not report BIGinfo if phy is invalid or unsupported
- Return disallowed ll_read_iso_tx_sync uses sync recever handle
- Validate BIS indices in ll_big_sync_create

**Bluetooth: controller: Add handling of HCI reset for sync_iso**
Properly shut down ticker and initialize data at HCI reset.