### PR TITLE
boards: nrf54l15pdk_nrf54l15_cpuapp: enable DCDC mode by default

### DIFF
--- a/boards/nordic/nrf54l15pdk/Kconfig
+++ b/boards/nordic/nrf54l15pdk/Kconfig
@@ -1,0 +1,13 @@
+# nRF54L15 PDK board configuration
+
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_NRF54L15PDK_NRF54L15_CPUAPP
+
+config BOARD_ENABLE_DCDC
+	bool "DCDC mode"
+	select SOC_NRF54L_VREG_MAIN_DCDC
+	default y
+
+endif # BOARD_NRF54L15PDK_NRF54L15_CPUAPP


### PR DESCRIPTION
Inductor is present on nRF54L15 PDK so it should be enabled by default.