### PR TITLE
net: lwm2m: Handle empty URI

### DIFF
--- a/subsys/net/lib/lwm2m/CMakeLists.txt
+++ b/subsys/net/lib/lwm2m/CMakeLists.txt
@@ -2,6 +2,8 @@
 
 zephyr_library()
 
+zephyr_library_compile_definitions(_POSIX_C_SOURCE=200809L)
+
 zephyr_include_directories(.)
 
 zephyr_library_sources(

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
@@ -305,13 +305,14 @@ static int package_uri_write_cb(uint16_t obj_inst_id, uint16_t res_id,
 
 #ifdef CONFIG_LWM2M_FIRMWARE_UPDATE_PULL_SUPPORT
 	uint8_t state = lwm2m_firmware_get_update_state_inst(obj_inst_id);
+	bool empty_uri = data_len == 0 || strnlen(data, data_len) == 0;
 
 	if (state == STATE_IDLE) {
-		if (data_len > 0) {
+		if (!empty_uri) {
 			lwm2m_firmware_set_update_state_inst(obj_inst_id, STATE_DOWNLOADING);
 			lwm2m_firmware_start_transfer(obj_inst_id, package_uri[obj_inst_id]);
 		}
-	} else if (state == STATE_DOWNLOADED && data_len == 0U) {
+	} else if (state == STATE_DOWNLOADED && empty_uri) {
 		/* reset to state idle and result default */
 		lwm2m_firmware_set_update_result_inst(obj_inst_id, RESULT_DEFAULT);
 	}


### PR DESCRIPTION
On some content-types, it might be impossible to
send strings with size of zero.
Therefore empty URI should also allow cases
where strlen() is zero.