### PR TITLE
dts: arm: nordic: Add qdec label for nRF5340 and nRF54L15

### DIFF
--- a/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
@@ -458,7 +458,7 @@ mutex: mutex@30000 {
 	status = "okay";
 };
 
-qdec0: qdec@33000 {
+qdec: qdec0: qdec@33000 {
 	compatible = "nordic,nrf-qdec";
 	reg = <0x33000 0x1000>;
 	interrupts = <51 NRF_DEFAULT_IRQ_PRIORITY>;

--- a/dts/arm/nordic/nrf54l15_cpuapp_peripherals.dtsi
+++ b/dts/arm/nordic/nrf54l15_cpuapp_peripherals.dtsi
@@ -311,7 +311,7 @@ i2s20: i2s@dd000 {
 	status = "disabled";
 };
 
-qdec20: qdec@e0000 {
+qdec: qdec20: qdec@e0000 {
 	compatible = "nordic,nrf-qdec";
 	reg = <0xe0000 0x1000>;
 	interrupts = <224 NRF_DEFAULT_IRQ_PRIORITY>;

--- a/soc/nordic/validate_base_addresses.c
+++ b/soc/nordic/validate_base_addresses.c
@@ -171,7 +171,11 @@ CHECK_DT_REG(pwm0, NRF_PWM0);
 CHECK_DT_REG(pwm1, NRF_PWM1);
 CHECK_DT_REG(pwm2, NRF_PWM2);
 CHECK_DT_REG(pwm3, NRF_PWM3);
+#if !defined(CONFIG_SOC_SERIES_NRF54LX)
 CHECK_DT_REG(qdec, NRF_QDEC0);	/* this should be the same node as qdec0 */
+#else
+CHECK_DT_REG(qdec, NRF_QDEC20);	/* nRF54L does not have qdec0, use qdec20 instead */
+#endif
 CHECK_DT_REG(qdec0, NRF_QDEC0);
 CHECK_DT_REG(qdec1, NRF_QDEC1);
 CHECK_DT_REG(radio, NRF_RADIO);


### PR DESCRIPTION
The "qdec" label allows referring default QDEC in consistent way.