### PR TITLE
drivers: ethernet: esp32: add DMA Kconfig values

### DIFF
--- a/drivers/ethernet/Kconfig.esp32
+++ b/drivers/ethernet/Kconfig.esp32
@@ -22,4 +22,27 @@ config ETH_ESP32_RX_THREAD_PRIORITY
 	int "ESP32 Ethernet receive thread priority"
 	default 2
 
+config ETH_DMA_BUFFER_SIZE
+	int "ESP32 Ethernet DMA buffer size (Byte)"
+	range 256 1600
+	default 512
+	help
+	  Set the size of each buffer used by Ethernet MAC DMA.
+
+config ETH_DMA_RX_BUFFER_NUM
+	int "Amount of Ethernet DMA Rx buffers"
+	range 3 30
+	default 10
+	help
+	  Number of DMA receive buffers. Each buffer's size is ETH_DMA_BUFFER_SIZE.
+	  Larger number of buffers could increase throughput somehow.
+
+config ETH_DMA_TX_BUFFER_NUM
+	int "Amount of Ethernet DMA Tx buffers"
+	range 3 30
+	default 10
+	help
+	 Number of DMA transmit buffers. Each buffer's size is ETH_DMA_BUFFER_SIZE.
+	  Larger number of buffers could increase throughput somehow.
+
 endif # ETH_ESP32


### PR DESCRIPTION
Allows defining custom TX and RX buffers attached to Ethernet peripheral.