### PR TITLE
modules: hal_nordic: nrfx: include config for nrf54l15

### DIFF
--- a/modules/hal_nordic/nrfx/nrfx_config.h
+++ b/modules/hal_nordic/nrfx/nrfx_config.h
@@ -848,7 +848,7 @@
     #include <nrfx_config_nrf54h20_enga_ppr.h>
 #elif defined(NRF9120_XXAA) || defined(NRF9160_XXAA)
     #include <nrfx_config_nrf91.h>
-#elif defined(NRF54L15_ENGA_XXAA) && defined(NRF_APPLICATION)
+#elif (defined(NRF54L15_XXAA) || defined(NRF54L15_ENGA_XXAA)) && defined(NRF_APPLICATION)
     #include <nrfx_config_nrf54l15_enga_application.h>
 #else
     #error "Unknown device."


### PR DESCRIPTION
Both nRF54L15 and nRF54L15 EngA uses same nrfx config file.