### PR TITLE
soc: atmel: saml2x: Don't do a GCLK SWRST

### DIFF
--- a/soc/atmel/sam0/common/soc_saml2x.c
+++ b/soc/atmel/sam0/common/soc_saml2x.c
@@ -31,10 +31,6 @@
 
 static inline void gclk_reset(void)
 {
-	GCLK->CTRLA.bit.SWRST = 1;
-	while (GCLK->SYNCBUSY.bit.SWRST) {
-	}
-
 	/* by default, OSC16M will be enabled at 4 MHz, and the CPU will
 	 * run from it. to permit initialization, the CPU is temporarily
 	 * clocked from OSCULP32K, and OSC16M is disabled


### PR DESCRIPTION
When using mcuboot, the z_arm_platform_init is executed. When an application is started by mcuboot, it will hang if z_arm_platform_init is run again.

This change will cause the z_arm_platfrom_init code to only be run if CONFIG_BOOTLOADER_MCUBOOT is not set