### PR TITLE
Bluetooth: BAP: Shell: Fix issue with stopping broadcast sink

### DIFF
--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -2451,7 +2451,6 @@ static void stream_stopped_cb(struct bt_bap_stream *stream, uint8_t reason)
 		if (default_broadcast_sink.stream_cnt == 0) {
 			/* All streams in the broadcast sink has been terminated */
 			default_broadcast_sink.syncable = true;
-			default_broadcast_sink.bap_sink = NULL;
 			memset(&default_broadcast_sink.received_base, 0,
 			       sizeof(default_broadcast_sink.received_base));
 			default_broadcast_sink.broadcast_id = 0;


### PR DESCRIPTION
When the broadcast sink is stopped, the sink was also set to NULL via

default_broadcast_sink.bap_sink = NULL;

However the lifetime of the broadcast sink does not follow the state of the streams, and it still exists afterwards. The broadcast sink can only be terminated (deleted) via the term_broadcast_sink command.