### PR TITLE
include: system: utils: Avoid compiler warning about mismatched types

### DIFF
--- a/include/zephyr/sys/byteorder.h
+++ b/include/zephyr/sys/byteorder.h
@@ -307,8 +307,8 @@
  */
 static inline void sys_put_be16(uint16_t val, uint8_t dst[2])
 {
-	dst[0] = val >> 8;
-	dst[1] = val;
+	dst[0] = (uint8_t)(val >> 8);
+	dst[1] = (uint8_t)val;
 }
 
 /**
@@ -322,8 +322,8 @@ static inline void sys_put_be16(uint16_t val, uint8_t dst[2])
  */
 static inline void sys_put_be24(uint32_t val, uint8_t dst[3])
 {
-	dst[0] = val >> 16;
-	sys_put_be16(val, &dst[1]);
+	dst[0] = (uint8_t)(val >> 16);
+	sys_put_be16((uint16_t)val, &dst[1]);
 }
 
 /**
@@ -337,8 +337,8 @@ static inline void sys_put_be24(uint32_t val, uint8_t dst[3])
  */
 static inline void sys_put_be32(uint32_t val, uint8_t dst[4])
 {
-	sys_put_be16(val >> 16, dst);
-	sys_put_be16(val, &dst[2]);
+	sys_put_be16((uint16_t)(val >> 16), dst);
+	sys_put_be16((uint16_t)val, &dst[2]);
 }
 
 /**
@@ -352,8 +352,8 @@ static inline void sys_put_be32(uint32_t val, uint8_t dst[4])
  */
 static inline void sys_put_be48(uint64_t val, uint8_t dst[6])
 {
-	sys_put_be16(val >> 32, dst);
-	sys_put_be32(val, &dst[2]);
+	sys_put_be16((uint16_t)(val >> 32), dst);
+	sys_put_be32((uint32_t)val, &dst[2]);
 }
 
 /**
@@ -367,8 +367,8 @@ static inline void sys_put_be48(uint64_t val, uint8_t dst[6])
  */
 static inline void sys_put_be64(uint64_t val, uint8_t dst[8])
 {
-	sys_put_be32(val >> 32, dst);
-	sys_put_be32(val, &dst[4]);
+	sys_put_be32((uint32_t)(val >> 32), dst);
+	sys_put_be32((uint32_t)val, &dst[4]);
 }
 
 /**
@@ -382,8 +382,8 @@ static inline void sys_put_be64(uint64_t val, uint8_t dst[8])
  */
 static inline void sys_put_le16(uint16_t val, uint8_t dst[2])
 {
-	dst[0] = val;
-	dst[1] = val >> 8;
+	dst[0] = (uint8_t)val;
+	dst[1] = (uint8_t)(val >> 8);
 }
 
 /**
@@ -397,8 +397,8 @@ static inline void sys_put_le16(uint16_t val, uint8_t dst[2])
  */
 static inline void sys_put_le24(uint32_t val, uint8_t dst[3])
 {
-	sys_put_le16(val, dst);
-	dst[2] = val >> 16;
+	sys_put_le16((uint16_t)val, dst);
+	dst[2] = (uint8_t)(val >> 16);
 }
 
 /**
@@ -412,8 +412,8 @@ static inline void sys_put_le24(uint32_t val, uint8_t dst[3])
  */
 static inline void sys_put_le32(uint32_t val, uint8_t dst[4])
 {
-	sys_put_le16(val, dst);
-	sys_put_le16(val >> 16, &dst[2]);
+	sys_put_le16((uint16_t)val, dst);
+	sys_put_le16((uint16_t)(val >> 16), &dst[2]);
 }
 
 /**
@@ -427,8 +427,8 @@ static inline void sys_put_le32(uint32_t val, uint8_t dst[4])
  */
 static inline void sys_put_le48(uint64_t val, uint8_t dst[6])
 {
-	sys_put_le32(val, dst);
-	sys_put_le16(val >> 32, &dst[4]);
+	sys_put_le32((uint32_t)val, dst);
+	sys_put_le16((uint16_t)(val >> 32), &dst[4]);
 }
 
 /**
@@ -442,8 +442,8 @@ static inline void sys_put_le48(uint64_t val, uint8_t dst[6])
  */
 static inline void sys_put_le64(uint64_t val, uint8_t dst[8])
 {
-	sys_put_le32(val, dst);
-	sys_put_le32(val >> 32, &dst[4]);
+	sys_put_le32((uint32_t)val, dst);
+	sys_put_le32((uint32_t)(val >> 32), &dst[4]);
 }
 
 /**

--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -538,7 +538,10 @@ size_t hex2bin(const char *hex, size_t hexlen, uint8_t *buf, size_t buflen);
  */
 static inline uint8_t bcd2bin(uint8_t bcd)
 {
-	return ((10 * (bcd >> 4)) + (bcd & 0x0F));
+	uint32_t t = bcd;
+
+	t = (10 * (t >> 4)) + (t & 0x0F);
+	return (uint8_t)t;
 }
 
 /**


### PR DESCRIPTION
**This is a breakdown of https://github.com/zephyrproject-rtos/zephyr/pull/69440 to fix casting variables to correct type to avoid compilation warnings for system utilities.
Here are the warnings:
include/zephyr/sys/byteorder.h:**
```
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/sys/byteorder.h: In function 'sys_put_be16':
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/sys/byteorder.h:311:18: warning: conversion from 'int' to 'uint8_t' {aka 'unsigned char'} may change value [-Wconversion]
  311 |         dst[0] = val >> 8;
      |                  ^~~
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/sys/byteorder.h:312:18: warning: conversion from 'uint16_t' {aka 'short unsigned int'} to 'uint8_t' {aka 'unsigned char'} may change value [-Wconversion]
  312 |         dst[1] = val;
      |                  ^~~
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/sys/byteorder.h: In function 'sys_put_be24':
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/sys/byteorder.h:326:18: warning: conversion from 'uint32_t' {aka 'unsigned int'} to 'uint8_t' {aka 'unsigned char'} may change value [-Wconversion]
  326 |         dst[0] = val >> 16;
      |                  ^~~
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/sys/byteorder.h:327:22: warning: conversion from 'uint32_t' {aka 'unsigned int'} to 'uint16_t' {aka 'short unsigned int'} may change value [-Wconversion]
  327 |         sys_put_be16(val, &dst[1]);
      |                      ^~~
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/sys/byteorder.h: In function 'sys_put_be32':
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/sys/byteorder.h:341:26: warning: conversion from 'uint32_t' {aka 'unsigned int'} to 'uint16_t' {aka 'short unsigned int'} may change value [-Wconversion]
  341 |         sys_put_be16(val >> 16, dst);
      |                      ~~~~^~~~~
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/sys/byteorder.h:342:22: warning: conversion from 'uint32_t' {aka 'unsigned int'} to 'uint16_t' {aka 'short unsigned int'} may change value [-Wconversion]
  342 |         sys_put_be16(val, &dst[2]);
      |                      ^~~
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/sys/byteorder.h: In function 'sys_put_be48':
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/sys/byteorder.h:356:26: warning: conversion from 'uint64_t' {aka 'long long unsigned int'} to 'uint16_t' {aka 'short unsigned int'} may change value [-Wconversion]
  356 |         sys_put_be16(val >> 32, dst);
      |                      ~~~~^~~~~
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/sys/byteorder.h:357:22: warning: conversion from 'uint64_t' {aka 'long long unsigned int'} to 'uint32_t' {aka 'unsigned int'} may change value [-Wconversion]
  357 |         sys_put_be32(val, &dst[2]);
      |                      ^~~
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/sys/byteorder.h: In function 'sys_put_be64':
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/sys/byteorder.h:371:26: warning: conversion from 'uint64_t' {aka 'long long unsigned int'} to 'uint32_t' {aka 'unsigned int'} may change value [-Wconversion]
  371 |         sys_put_be32(val >> 32, dst);
      |                      ~~~~^~~~~
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/sys/byteorder.h:372:22: warning: conversion from 'uint64_t' {aka 'long long unsigned int'} to 'uint32_t' {aka 'unsigned int'} may change value [-Wconversion]
  372 |         sys_put_be32(val, &dst[4]);
      |                      ^~~
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/sys/byteorder.h: In function 'sys_put_le16':
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/sys/byteorder.h:386:18: warning: conversion from 'uint16_t' {aka 'short unsigned int'} to 'uint8_t' {aka 'unsigned char'} may change value [-Wconversion]
  386 |         dst[0] = val;
      |                  ^~~
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/sys/byteorder.h:387:18: warning: conversion from 'int' to 'uint8_t' {aka 'unsigned char'} may change value [-Wconversion]
  387 |         dst[1] = val >> 8;
      |                  ^~~
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/sys/byteorder.h: In function 'sys_put_le24':
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/sys/byteorder.h:401:22: warning: conversion from 'uint32_t' {aka 'unsigned int'} to 'uint16_t' {aka 'short unsigned int'} may change value [-Wconversion]
  401 |         sys_put_le16(val, dst);
      |                      ^~~
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/sys/byteorder.h:402:18: warning: conversion from 'uint32_t' {aka 'unsigned int'} to 'uint8_t' {aka 'unsigned char'} may change value [-Wconversion]
  402 |         dst[2] = val >> 16;
      |                  ^~~
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/sys/byteorder.h: In function 'sys_put_le32':
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/sys/byteorder.h:416:22: warning: conversion from 'uint32_t' {aka 'unsigned int'} to 'uint16_t' {aka 'short unsigned int'} may change value [-Wconversion]
  416 |         sys_put_le16(val, dst);
      |                      ^~~
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/sys/byteorder.h:417:26: warning: conversion from 'uint32_t' {aka 'unsigned int'} to 'uint16_t' {aka 'short unsigned int'} may change value [-Wconversion]
  417 |         sys_put_le16(val >> 16, &dst[2]);
      |                      ~~~~^~~~~
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/sys/byteorder.h: In function 'sys_put_le48':
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/sys/byteorder.h:431:22: warning: conversion from 'uint64_t' {aka 'long long unsigned int'} to 'uint32_t' {aka 'unsigned int'} may change value [-Wconversion]
  431 |         sys_put_le32(val, dst);
      |                      ^~~
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/sys/byteorder.h:432:26: warning: conversion from 'uint64_t' {aka 'long long unsigned int'} to 'uint16_t' {aka 'short unsigned int'} may change value [-Wconversion]
  432 |         sys_put_le16(val >> 32, &dst[4]);
      |                      ~~~~^~~~~
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/sys/byteorder.h: In function 'sys_put_le64':
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/sys/byteorder.h:446:22: warning: conversion from 'uint64_t' {aka 'long long unsigned int'} to 'uint32_t' {aka 'unsigned int'} may change value [-Wconversion]
  446 |         sys_put_le32(val, dst);
      |                      ^~~
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/sys/byteorder.h:447:26: warning: conversion from 'uint64_t' {aka 'long long unsigned int'} to 'uint32_t' {aka 'unsigned int'} may change value [-Wconversion]
  447 |         sys_put_le32(val >> 32, &dst[4]);
      |                      ~~~~^~~~~
```
**include/zephyr/sys/util.h:**
```
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/sys/util.h: In function 'bcd2bin':
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/sys/util.h:503:36: warning: conversion from 'int' to 'uint8_t' {aka 'unsigned char'} may change value [-Wconversion]
  503 |         return  ((10 * (bcd >> 4)) + (bcd & 0x0F));
      |                 ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
```