### PR TITLE
include: posix: Avoid compiler warning about return type mismatched

### DIFF
--- a/include/zephyr/posix/time.h
+++ b/include/zephyr/posix/time.h
@@ -83,7 +83,7 @@ extern "C" {
 
 static inline int32_t _ts_to_ms(const struct timespec *to)
 {
-	return (to->tv_sec * MSEC_PER_SEC) + (to->tv_nsec / NSEC_PER_MSEC);
+	return (int32_t)(to->tv_sec * MSEC_PER_SEC) + (int32_t)(to->tv_nsec / NSEC_PER_MSEC);
 }
 
 int clock_gettime(clockid_t clock_id, struct timespec *ts);


### PR DESCRIPTION
**This is a breakdown of https://github.com/zephyrproject-rtos/zephyr/pull/69440 to fix casting correct type to avoid compilation warnings for posix.
Here is the warning:**
```
include/zephyr/posix/time.h:

/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/posix/time.h: In function '_t      s_to_ms':
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/posix/time.h:82:44: warning:       conversion from 'time_t' {aka 'long long int'} to 'int32_t' {aka 'int'} may change value [-Wconversion]
   82 |         return (to->tv_sec * MSEC_PER_SEC) + (to->tv_nsec / NSEC_PER_MSEC);
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```