### PR TITLE
include: net: Avoid compiler warning about unused variable and unsupported type

### DIFF
--- a/include/zephyr/net/buf.h
+++ b/include/zephyr/net/buf.h
@@ -963,7 +963,7 @@ struct net_buf_simple_state {
 static inline void net_buf_simple_save(struct net_buf_simple *buf,
 				       struct net_buf_simple_state *state)
 {
-	state->offset = net_buf_simple_headroom(buf);
+	state->offset = (uint16_t)net_buf_simple_headroom(buf);
 	state->len = buf->len;
 }
 

--- a/include/zephyr/net/net_context.h
+++ b/include/zephyr/net/net_context.h
@@ -442,7 +442,7 @@ static inline void net_context_set_accepting(struct net_context *context,
 	if (accepting) {
 		context->flags |= NET_CONTEXT_ACCEPTING_SOCK;
 	} else {
-		context->flags &= ~NET_CONTEXT_ACCEPTING_SOCK;
+		context->flags &= (uint16_t)~NET_CONTEXT_ACCEPTING_SOCK;
 	}
 }
 
@@ -474,7 +474,7 @@ static inline void net_context_set_closing(struct net_context *context,
 	if (closing) {
 		context->flags |= NET_CONTEXT_CLOSING_SOCK;
 	} else {
-		context->flags &= ~NET_CONTEXT_CLOSING_SOCK;
+		context->flags &= (uint16_t)~NET_CONTEXT_CLOSING_SOCK;
 	}
 }
 
@@ -554,7 +554,7 @@ static inline void net_context_set_family(struct net_context *context,
 	if (family == AF_UNSPEC || family == AF_INET || family == AF_INET6 ||
 	    family == AF_PACKET || family == AF_CAN) {
 		/* Family is in BIT(4), BIT(5) and BIT(6) */
-		flag = family << 3;
+		flag = (uint8_t)(family << 3);
 	}
 
 	context->flags |= flag;
@@ -596,7 +596,7 @@ static inline void net_context_set_type(struct net_context *context,
 
 	if (type == SOCK_DGRAM || type == SOCK_STREAM || type == SOCK_RAW) {
 		/* Type is in BIT(6) and BIT(7)*/
-		flag = type << 6;
+		flag = (uint16_t)(type << 6);
 	}
 
 	context->flags |= flag;
@@ -714,7 +714,7 @@ static inline void net_context_set_iface(struct net_context *context,
 {
 	NET_ASSERT(iface);
 
-	context->iface = net_if_get_by_iface(iface);
+	context->iface = (uint8_t)net_if_get_by_iface(iface);
 }
 
 /**

--- a/include/zephyr/net/net_ip.h
+++ b/include/zephyr/net/net_ip.h
@@ -687,7 +687,7 @@ static inline bool net_ipv6_is_prefix(const uint8_t *addr1,
 	}
 
 	/* Create a mask that has remaining most significant bits set */
-	mask = ((0xff << (8 - remain)) ^ 0xff) << remain;
+	mask = (uint8_t)((0xff << (8 - remain)) ^ 0xff) << remain;
 
 	return (addr1[bytes] & mask) == (addr2[bytes] & mask);
 }


### PR DESCRIPTION
This is a breakdown of #69440 to fix the following for network header files:
Use ARG_UNUSED on unused variable
Cast variables to correct type to avoid compilation warnings.
Here are the warnings:
**include/zephyr/net/buf.h:**
```
In file included from /b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/net/net      _l2.h:16,
                  from /b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/net/net      _if.h:29:
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/net/buf.h: In function 'net_b      uf_simple_save':
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/net/buf.h:868:25: warning: co      nversion from 'size_t' {aka 'unsigned int'} to 'uint16_t' {aka 'short unsigned int'} may change value [-Wconve      rsion]
  868 |         state->offset = net_buf_simple_headroom(buf);
      |                         ^~~~~~~~~~~~~~~~~~~~~~~
```
**include/zephyr/net/hostname.h:**
```
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/net/hostname.h: In function '      net_hostname_set_postfix':
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/net/hostname.h:74:59: warning      : unused parameter 'hostname_postfix' [-Wunused-parameter]
   74 | static inline int net_hostname_set_postfix(const uint8_t *hostname_postfix,
      |                                            ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/net/hostname.h:75:48: warning      : unused parameter 'postfix_len' [-Wunused-parameter]
   75 |                                            int postfix_len)
      |                                            ~~~~^~~~~~~~~~~
```
**include/zephyr/net/net_context.h:**
```
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/net/net_context.h: In functio      n 'net_context_set_accepting':
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/net/net_context.h:397:35: war      ning: conversion from 'long unsigned int' to 'uint16_t' {aka 'short unsigned int'} changes the value of '42949      66783' [-Wconversion]
  397 |                 context->flags &= ~NET_CONTEXT_ACCEPTING_SOCK;
      |                                   ^
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/net/net_context.h: In functio      n 'net_context_set_closing':
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/net/net_context.h:429:35: war      ning: conversion from 'long unsigned int' to 'uint16_t' {aka 'short unsigned int'} changes the value of '42949      66271' [-Wconversion]
  429 |                 context->flags &= ~NET_CONTEXT_CLOSING_SOCK;
      |                                   ^
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/net/net_context.h: In functio      n 'net_context_set_family':
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/net/net_context.h:509:24: war      ning: conversion from 'int' to 'uint8_t' {aka 'unsigned char'} may change value [-Wconversion]
  509 |                 flag = family << 3;
      |                        ^~~~~~
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/net/net_context.h: In functio      n 'net_context_set_iface':
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/net/net_context.h:669:26: war      ning: conversion from 'int' to 'int8_t' {aka 'signed char'} may change value [-Wconversion]
  669 |         context->iface = net_if_get_by_iface(iface);
      |                          ^~~~~~~~~~~~~~~~~~~
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/net/net_context.h: In functio      n 'net_context_is_proxy_enabled':
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/net/net_context.h:713:69: war      ning: unused parameter 'context' [-Wunused-parameter]
  713 | static inline bool net_context_is_proxy_enabled(struct net_context *context)
      |                                                 ~~~~~~~~~~~~~~~~~~~~^~~~~~~
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/net/net_context.h: In functio      n 'net_context_create_ipv6_new':
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/net/net_context.h:826:67: war      ning: unused parameter 'context' [-Wunused-parameter]
  826 | static inline int net_context_create_ipv6_new(struct net_context *context,
      |                                               ~~~~~~~~~~~~~~~~~~~~^~~~~~~
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/net/net_context.h:827:63: war      ning: unused parameter 'pkt' [-Wunused-parameter]
  827 |                                               struct net_pkt *pkt,
      |                                               ~~~~~~~~~~~~~~~~^~~
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/net/net_context.h:828:70: war      ning: unused parameter 'src' [-Wunused-parameter]
  828 |                                               const struct in6_addr *src,
      |                                               ~~~~~~~~~~~~~~~~~~~~~~~^~~
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/net/net_context.h:829:70: war      ning: unused parameter 'dst' [-Wunused-parameter]
  829 |                                               const struct in6_addr *dst)
      |                                               ~~~~~~~~~~~~~~~~~~~~~~~^~~
```
**include/zephyr/net/net_if.h:**
```
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/net/net_if.h: In function 'ne      t_if_oper_state_set':
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/net/net_if.h:731:24: warning:       comparison is always true due to limited range of data type [-Wtype-limits]
  731 |         if (oper_state >= NET_IF_OPER_UNKNOWN && oper_state <= NET_IF_OPER_UP) {
      |                        ^~
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/net/net_if.h: In function 'ne      t_if_ipv6_set_base_reachable_time':
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/net/net_if.h:1643:71: warning      : unused parameter 'iface' [-Wunused-parameter]
 1643 | static inline void net_if_ipv6_set_base_reachable_time(struct net_if *iface,
      |                                                        ~~~~~~~~~~~~~~~^~~~~
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/net/net_if.h:1644:65: warning      : unused parameter 'reachable_time' [-Wunused-parameter]
 1644 |                                                        uint32_t reachable_time)
      |                                                        ~~~~~~~~~^~~~~~~~~~~~~~
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/net/net_if.h: In function 'ne      t_if_ipv6_get_reachable_time':
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/net/net_if.h:1664:70: warning      : unused parameter 'iface' [-Wunused-parameter]
 1664 | static inline uint32_t net_if_ipv6_get_reachable_time(struct net_if *iface)
      |                                                       ~~~~~~~~~~~~~~~^~~~~
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/net/net_if.h: In function 'ne      t_if_ipv6_set_reachable_time':
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/net/net_if.h:1694:71: warning      : unused parameter 'ipv6' [-Wunused-parameter]
 1694 | static inline void net_if_ipv6_set_reachable_time(struct net_if_ipv6 *ipv6)
      |                                                   ~~~~~~~~~~~~~~~~~~~~^~~~
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/net/net_if.h: In function 'ne      t_if_ipv6_set_retrans_timer':
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/net/net_if.h:1711:65: warning      : unused parameter 'iface' [-Wunused-parameter]
 1711 | static inline void net_if_ipv6_set_retrans_timer(struct net_if *iface,
      |                                                  ~~~~~~~~~~~~~~~^~~~~
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/net/net_if.h:1712:59: warning      : unused parameter 'retrans_timer' [-Wunused-parameter]
 1712 |                                                  uint32_t retrans_timer)
      |                                                  ~~~~~~~~~^~~~~~~~~~~~~
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/net/net_if.h: In function 'ne      t_if_ipv6_get_retrans_timer':
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/net/net_if.h:1732:69: warning      : unused parameter 'iface' [-Wunused-parameter]
 1732 | static inline uint32_t net_if_ipv6_get_retrans_timer(struct net_if *iface)
      |                                                      ~~~~~~~~~~~~~~~^~~~~
```
**include/zephyr/net/net_ip.h**
```
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/net/net_ip.h: In function 'net_ipv6_is_prefix':
/b/mros/no_zephyr_patch/microros_ws/firmware/zephyrproject/zephyr/include/zephyr/net/net_ip.h:686:16: warning: conversion from 'int' to 'uint8_t' {aka 'unsigned char'} may change value [-Wconversion]
  686 |         mask = ((0xff << (8 - remain)) ^ 0xff) << remain;
      |                ^