### PR TITLE
drivers: rtc: nucleo_wb55rg: Fix RTC callback issue when using power management config

### DIFF
--- a/drivers/counter/counter_ll_stm32_rtc.c
+++ b/drivers/counter/counter_ll_stm32_rtc.c
@@ -240,6 +240,12 @@ tick_t rtc_stm32_read(const struct device *dev)
 #endif /* CONFIG_COUNTER_RTC_STM32_SUBSECONDS */
 	ARG_UNUSED(dev);
 
+	/* Enable Backup access */
+#if defined(PWR_CR_DBP) || defined(PWR_CR1_DBP) || \
+	defined(PWR_DBPCR_DBP) || defined(PWR_DBPR_DBP)
+	LL_PWR_EnableBkUpAccess();
+#endif /* PWR_CR_DBP || PWR_CR1_DBP || PWR_DBPR_DBP */
+
 	/* Read time and date registers. Make sure value of the previous register
 	 * hasn't been changed while reading the next one.
 	 */
@@ -294,6 +300,12 @@ tick_t rtc_stm32_read(const struct device *dev)
 	uint32_t rtc_time, ticks;
 
 	ARG_UNUSED(dev);
+
+	/* Enable Backup access */
+#if defined(PWR_CR_DBP) || defined(PWR_CR1_DBP) || \
+	defined(PWR_DBPCR_DBP) || defined(PWR_DBPR_DBP)
+	LL_PWR_EnableBkUpAccess();
+#endif /* PWR_CR_DBP || PWR_CR1_DBP || PWR_DBPR_DBP */
 
 	rtc_time = LL_RTC_TIME_Get(RTC);
 


### PR DESCRIPTION
It is found that when we use CONFIG_COUNTER and CONFIG_PM concurrently, the RTC alarm callback can be used only once (in some cases, it just won't work at all, e.g., using CONFIG_BT). By set the `DBP` bit on `PWR control register 1` via `LL_PWR_EnableBkUpAccess` function to temporarily disable write protection every time we assign RTC alarm, we can register alarm callback correctly. Tested on Nucleo WB55RG.

Fixes: #68673