### PR TITLE
drivers: mbox: fix build failures when userspace enabled

### DIFF
--- a/drivers/mbox/mbox_handlers.c
+++ b/drivers/mbox/mbox_handlers.c
@@ -15,7 +15,7 @@ static inline int z_vrfy_mbox_send(const struct device *dev,
 	K_OOPS(K_SYSCALL_MEMORY_READ(msg, sizeof(struct mbox_msg)));
 	K_OOPS(K_SYSCALL_MEMORY_READ(msg->data, msg->size));
 
-	return z_impl_mbox_send(channel, msg);
+	return z_impl_mbox_send(dev, channel_id, msg);
 }
 #include <syscalls/mbox_send_mrsh.c>
 
@@ -41,6 +41,6 @@ static inline int z_vrfy_mbox_set_enabled(const struct device *dev,
 {
 	K_OOPS(K_SYSCALL_DRIVER_MBOX(dev, set_enabled));
 
-	return z_impl_mbox_set_enabled(channel_id, enabled);
+	return z_impl_mbox_set_enabled(dev, channel_id, enabled);
 }
 #include <syscalls/mbox_set_enabled_mrsh.c>


### PR DESCRIPTION
Fix build failures due to using wrong arguments when calling the implementation functions

Fix: https://github.com/zephyrproject-rtos/zephyr/issues/70079

```
PS D:\upstream\zephyr> west build -p -b s32z2xxdc2/s32z270/rtu0 .\tests\drivers\build_all\ethernet\
-- west build: generating a build system
Loading Zephyr default modules (Zephyr base).
-- Application: D:/upstream/zephyr/tests/drivers/build_all/ethernet
-- CMake version: 3.27.9
-- Found Python3: C:/Users/datnd14/AppData/Local/Programs/Python/Python39/python.exe (found suitable version "3.9.6", minimum required is "3.8") found components: Interpreter
-- Cache files will be written to: D:/upstream/zephyr/.cache
-- Zephyr version: 3.6.99 (D:/upstream/zephyr)
-- Found west (found suitable version "1.0.0", minimum required is "0.14.0")
-- Board: s32z2xxdc2, Revision: B, identifier: s32z270/rtu0
-- Found host-tools: zephyr 0.16.3 (D:/Tools/zephyr-sdk-0.16.3_windows-x86_64/zephyr-sdk-0.16.3)
-- Found toolchain: zephyr 0.16.3 (D:/Tools/zephyr-sdk-0.16.3_windows-x86_64/zephyr-sdk-0.16.3)
-- Found Dtc: C:/ProgramData/chocolatey/bin/dtc.exe (found suitable version "1.5.0", minimum required is "1.4.6") 
-- Found BOARD.dts: D:/upstream/zephyr/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu0.dts
-- Found devicetree overlay: D:/upstream/zephyr/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu0_B.overlay
-- Generated zephyr.dts: D:/upstream/zephyr/build/zephyr/zephyr.dts
-- Generated devicetree_generated.h: D:/upstream/zephyr/build/zephyr/include/generated/devicetree_generated.h
-- Including generated dts.cmake file: D:/upstream/zephyr/build/zephyr/dts.cmake

Load components for S32Z270:
driver_common component is included.
driver_reset component is included.
device_CMSIS component is included.
device_system component is included.
CMake Warning at D:/upstream/zephyr/CMakeLists.txt:864 (message):
  No SOURCES given to Zephyr library: lib__posix__shell
 
  Excluding target from build.
 
 
-- Configuring done (17.7s)
-- Generating done (0.5s)
-- Build files have been written to: D:/upstream/zephyr/build
-- west build: building application
[1/230] Generating include/generated/version.h
-- Zephyr version: 3.6.99 (D:/upstream/zephyr), build: v3.6.0-646-gf0faefffec5b
[229/230] Linking C executable zephyr\zephyr.elf
Memory region         Used Size  Region Size  %age Used
           FLASH:          0 GB         0 GB
             RAM:      609988 B         1 MB     58.17%
        IDT_LIST:          0 GB        32 KB      0.00%
Generating files from D:/upstream/zephyr/build/zephyr/zephyr.elf for board: s32z2xxdc2
[230/230] cmd.exe /C "cd /D D:\upstream\zephyr\build\zephyr && C:\Users\...nit_priorities.py --elf-file=D:/upstream/zephyr/build/zephyr/zephyr.elf"
```