### PR TITLE
ITE: drivers/i2c: Change GPIO output type to open-drain in recovery mode

### DIFF
--- a/drivers/i2c/i2c_ite_enhance.c
+++ b/drivers/i2c/i2c_ite_enhance.c
@@ -1272,9 +1272,9 @@ static int i2c_enhance_recover_bus(const struct device *dev)
 	int i, status;
 
 	/* Set SCL of I2C as GPIO pin */
-	gpio_pin_configure_dt(&config->scl_gpios, GPIO_OUTPUT);
+	gpio_pin_configure_dt(&config->scl_gpios, GPIO_OUTPUT | GPIO_OPEN_DRAIN);
 	/* Set SDA of I2C as GPIO pin */
-	gpio_pin_configure_dt(&config->sda_gpios, GPIO_OUTPUT);
+	gpio_pin_configure_dt(&config->sda_gpios, GPIO_OUTPUT | GPIO_OPEN_DRAIN);
 
 	/*
 	 * In I2C recovery bus, 1ms sleep interval for bitbanging i2c

--- a/drivers/i2c/i2c_ite_it8xxx2.c
+++ b/drivers/i2c/i2c_ite_it8xxx2.c
@@ -1191,9 +1191,9 @@ static int i2c_it8xxx2_recover_bus(const struct device *dev)
 	int i, status;
 
 	/* Set SCL of I2C as GPIO pin */
-	gpio_pin_configure_dt(&config->scl_gpios, GPIO_OUTPUT);
+	gpio_pin_configure_dt(&config->scl_gpios, GPIO_OUTPUT | GPIO_OPEN_DRAIN);
 	/* Set SDA of I2C as GPIO pin */
-	gpio_pin_configure_dt(&config->sda_gpios, GPIO_OUTPUT);
+	gpio_pin_configure_dt(&config->sda_gpios, GPIO_OUTPUT | GPIO_OPEN_DRAIN);
 
 	/*
 	 * In I2C recovery bus, 1ms sleep interval for bitbanging i2c


### PR DESCRIPTION
If I2C recovery mode uses GPIO push-pull to drive(3.3v), it will result leakage in a pull-up voltage of 1.8V on the power rail, leading to damage to 1.8V devices, including SoC, sensors.
Therefore, the recovery mode should be changed to GPIO open-drain type to avoid this.