### PR TITLE
opentitan board updates

### DIFF
--- a/boards/lowrisc/opentitan_earlgrey/opentitan_earlgrey_defconfig
+++ b/boards/lowrisc/opentitan_earlgrey/opentitan_earlgrey_defconfig
@@ -6,3 +6,5 @@ CONFIG_SERIAL=y
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y
 CONFIG_BUILD_OUTPUT_BIN=n
+# TODO: verilator boot broken when multi-threading is enabled.
+CONFIG_MULTITHREADING=n

--- a/dts/riscv/lowrisc/opentitan_earlgrey.dtsi
+++ b/dts/riscv/lowrisc/opentitan_earlgrey.dtsi
@@ -76,7 +76,7 @@
 			interrupts-extended = <&hlic 11>;
 			reg = <0x48000000 0x04000000>;
 			riscv,max-priority = <7>;
-			riscv,ndev = <184>;
+			riscv,ndev = <182>;
 			status = "okay";
 		};
 

--- a/soc/lowrisc/opentitan/rom_header.S
+++ b/soc/lowrisc/opentitan/rom_header.S
@@ -6,16 +6,18 @@
 
 #include <zephyr/toolchain.h>
 
-/* imports */
-GTEXT(__start)
+/* exports */
+GTEXT(__rom_header)
 
-/* OpenTitan manifest consists of 896 bytes (224 words) containing signature,
- * device ID, version info, etc. The test ROM ignores all of these fields
- * except for entry point (final word in manifest).
+/* OpenTitan manifest consists of 964 bytes (226 words, plus 15 words
+ * of manifest extenstion) containing signature, device ID, version
+ * info, etc. The test ROM ignores all of these fields except for entry
+ * point (final word in the base manifest).
  */
 SECTION_FUNC(rom_header, __rom_header)
-	.rept(223)
-	.word 0
-	.endr
-	/* Entry point is relative to the beginning of manifest. */
-	.word(__start - __rom_header)
+        .rept(225)
+        .word 0
+        .endr
+        /* Entry point is relative to the beginning of manifest. */
+        .word(__reset - __rom_header)
+        /* TODO: extensions entry table goes here. */


### PR DESCRIPTION
This patch set includes a couple of updates to the opentitan-earlgrey board.  

Patch (1) updates the linker section to conform to the latest opentitan signed-header manifest format.

Patch (2) does two things: 
- disable multithreading temprarily, since thread initialization is hanging.  all indications are that the `mtimer` setup is to blame.  suggestions on how to debug this are welcome.   
- update the number of interrupts supported by the PLIC (from `184` to `182`) per the current OT spec.

Verilator output:
```
I00001 test_rom.c:158] kChipInfo: scm_revision=606f9cb2
I00002 test_rom.c:230] Test ROM complete, jumping to flash (addr: 20000800)!
*** Booting Zephyr OS build v3.6.0-737-gb80e130248d0 ***
Hello World! opentitan_earlgrey
```