### PR TITLE
tests/bsim (several): Increase realtime timeout

### DIFF
--- a/tests/bsim/bluetooth/audio/test_scripts/mcs_mcc.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/mcs_mcc.sh
@@ -8,7 +8,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 SIMULATION_ID="mcs_mcc"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=20
+EXECUTE_TIMEOUT=50
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio_samples/broadcast_audio_sink/tests_scripts/broadcast_audio.sh
+++ b/tests/bsim/bluetooth/audio_samples/broadcast_audio_sink/tests_scripts/broadcast_audio.sh
@@ -12,7 +12,7 @@ verbosity_level=2
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-EXECUTE_TIMEOUT=100
+EXECUTE_TIMEOUT=200
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/mesh/_mesh_test.sh
+++ b/tests/bsim/bluetooth/mesh/_mesh_test.sh
@@ -3,7 +3,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-EXECUTE_TIMEOUT=300
+EXECUTE_TIMEOUT=600
 
 function Skip(){
   for i in "${SKIP[@]}" ; do


### PR DESCRIPTION
These tests have been seen failing in older slower computers due to timeouts, let's increase their timeout so we don't break in those cases.
Note this timeout is just a safety to eventually kill hung simulations even if nobody presses Ctrl+C.

----

Seen timing out here (new type of CI runner):
https://github.com/zephyrproject-rtos/zephyr/actions/runs/8226719915/job/22498524226#step:13:634
https://github.com/zephyrproject-rtos/zephyr/actions/runs/8226719915/job/22496881183 (takes *very* long to load)