### PR TITLE
net: arp: Fix failed to add the arp table in stress test

### DIFF
--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -416,6 +416,13 @@ struct net_pkt *net_arp_prepare(struct net_pkt *pkt,
 			NET_DBG("Resending ARP %p", req);
 		}
 
+		if (!req && entry) {
+			/* Add the arp entry back to arp_free_entries, to avoid the
+			 * arp entry is leak due to ARP packet allocated failed.
+			 */
+			sys_slist_prepend(&arp_free_entries, &entry->node);
+		}
+
 		k_mutex_unlock(&arp_mutex);
 		return req;
 	}


### PR DESCRIPTION
During stress test with WiFi connect, disconnect, ping and throughput traffic, ARP table updating failed issue may occur. Two modifications:
1. in arp_prepare(), if packet allocate failed, should add the arp entry back to arp_free_entries, to avoid this entry is leak forever.
2. in ethernet_send(), if ARP packets sent failed, it will clear the ARP pending queue and ARP entry here, but the entry isn't removed from the arp_pending_entries until the ARP request timeout. Within this period, this ARP pending entry can't be found due to the addr mismatch. But if add the entry remove and append action here, it will induce more risk, as it needs to add arp_mutex protection, but net_arp_update() has arp_mutex already and it will also call the ethernet_send. So the better way is just remove the net_arp_clear_pending() here and let the ARP request timeout do the entry cleanup and remove at same time.