### PR TITLE
Bluetooth: conn: Don't deadlock on `BT_RECV_WORKQ_SYS`

### DIFF
--- a/tests/bsim/bluetooth/host/l2cap/compile.sh
+++ b/tests/bsim/bluetooth/host/l2cap/compile.sh
@@ -22,6 +22,7 @@ source ${ZEPHYR_BASE}/tests/bsim/compile.source
 app=tests/bsim/bluetooth/host/l2cap/general compile
 app=tests/bsim/bluetooth/host/l2cap/userdata compile
 app=tests/bsim/bluetooth/host/l2cap/stress compile
+app=tests/bsim/bluetooth/host/l2cap/stress conf_file=prj_syswq.conf compile
 app=tests/bsim/bluetooth/host/l2cap/split/dut compile
 app=tests/bsim/bluetooth/host/l2cap/split/tester compile
 app=tests/bsim/bluetooth/host/l2cap/credits compile

--- a/tests/bsim/bluetooth/host/l2cap/stress/prj_syswq.conf
+++ b/tests/bsim/bluetooth/host/l2cap/stress/prj_syswq.conf
@@ -1,0 +1,57 @@
+CONFIG_BT=y
+CONFIG_BT_CENTRAL=y
+CONFIG_BT_PERIPHERAL=y
+CONFIG_BT_DEVICE_NAME="L2CAP stress test"
+
+CONFIG_BT_EATT=n
+CONFIG_BT_L2CAP_ECRED=n
+
+CONFIG_BT_SMP=y # Next config depends on it
+CONFIG_BT_L2CAP_DYNAMIC_CHANNEL=y
+
+# Disable auto-initiated procedures so they don't
+# mess with the test's execution.
+CONFIG_BT_AUTO_PHY_UPDATE=n
+CONFIG_BT_AUTO_DATA_LEN_UPDATE=n
+CONFIG_BT_GAP_AUTO_UPDATE_CONN_PARAMS=n
+
+# L2CAP MPS
+# 23+27+27=77 makes exactly three full packets
+CONFIG_BT_L2CAP_TX_MTU=77
+
+# Use this to send L2CAP PDUs without any fragmentation.
+# In this particular case, we prefer fragmenting to test that code path.
+# CONFIG_BT_BUF_ACL_TX_SIZE=81
+
+# L2CAP PDUs will be fragmented in 3 ACL packets.
+CONFIG_BT_BUF_ACL_TX_SIZE=27
+
+CONFIG_BT_BUF_ACL_TX_COUNT=4
+
+# The minimum value for this is
+# L2AP MPS + L2CAP header (4)
+CONFIG_BT_BUF_ACL_RX_SIZE=81
+
+# Governs BT_CONN_TX_MAX, and so must be >= than the max number of
+# peers, since we attempt to send one SDU per peer. The test execution
+# is a bit slowed down by having this at the very minimum, but we want
+# to keep it that way as to stress the stack as much as possible.
+CONFIG_BT_L2CAP_TX_BUF_COUNT=6
+
+CONFIG_BT_CTLR_DATA_LENGTH_MAX=27
+CONFIG_BT_CTLR_RX_BUFFERS=10
+
+CONFIG_BT_MAX_CONN=10
+
+CONFIG_LOG=y
+CONFIG_ASSERT=y
+CONFIG_NET_BUF_POOL_USAGE=y
+
+CONFIG_BT_L2CAP_LOG_LEVEL_DBG=y
+# CONFIG_BT_CONN_LOG_LEVEL_DBG=y
+CONFIG_LOG_THREAD_ID_PREFIX=y
+CONFIG_THREAD_NAME=y
+
+CONFIG_ARCH_POSIX_TRAP_ON_FATAL=y
+
+CONFIG_BT_RECV_WORKQ_SYS=y

--- a/tests/bsim/bluetooth/host/l2cap/stress/tests_scripts/l2cap_syswq.sh
+++ b/tests/bsim/bluetooth/host/l2cap/stress/tests_scripts/l2cap_syswq.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Copyright (c) 2022 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+# EATT test
+simulation_id="l2cap_stress_syswq"
+verbosity_level=2
+EXECUTE_TIMEOUT=120
+
+cd ${BSIM_OUT_PATH}/bin
+
+bsim_exe=./bs_${BOARD}_tests_bsim_bluetooth_host_l2cap_stress_prj_syswq_conf
+
+Execute "${bsim_exe}" -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central -rs=43
+
+Execute "${bsim_exe}" -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral -rs=42
+Execute "${bsim_exe}" -v=${verbosity_level} -s=${simulation_id} -d=2 -testid=peripheral -rs=10
+Execute "${bsim_exe}" -v=${verbosity_level} -s=${simulation_id} -d=3 -testid=peripheral -rs=23
+Execute "${bsim_exe}" -v=${verbosity_level} -s=${simulation_id} -d=4 -testid=peripheral -rs=7884
+Execute "${bsim_exe}" -v=${verbosity_level} -s=${simulation_id} -d=5 -testid=peripheral -rs=230
+Execute "${bsim_exe}" -v=${verbosity_level} -s=${simulation_id} -d=6 -testid=peripheral -rs=9
+
+Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} -D=7 -sim_length=400e6 $@
+
+wait_for_background_jobs


### PR DESCRIPTION
My recent change overlooked this configuration, which is not tested in CI currently.

If someone had enabled it, they would've just gotten an unfixable assert.

The correct test would be checking if the current thread is the system wq, but I think the compiler can't know that and can't remove the "dead" code.