### PR TITLE
LLEXT: Add reloc support for `R_ARM_THM_CALL` (BL and BLX instructions)

### DIFF
--- a/arch/arm/core/elf.c
+++ b/arch/arm/core/elf.c
@@ -26,6 +26,9 @@ void arch_elf_relocate(elf_rela_t *rel, uintptr_t opaddr, uintptr_t opval)
 
 	switch (reloc_type) {
 	case R_ARM_ABS32:
+		/* Add the addend stored at opaddr to opval */
+		opval += *((uint32_t *)opaddr);
+
 		/* Update the absolute address of a load/store instruction */
 		*((uint32_t *)opaddr) = (uint32_t)opval;
 		break;

--- a/arch/arm/core/elf.c
+++ b/arch/arm/core/elf.c
@@ -7,8 +7,47 @@
 #include <zephyr/llext/elf.h>
 #include <zephyr/llext/llext.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/util.h>
 
 LOG_MODULE_REGISTER(elf, CONFIG_LLEXT_LOG_LEVEL);
+
+#define ARM_BL_BLX_UPPER_S_BIT BIT(10)
+#define ARM_BL_BLX_ADDEND_OFFSET 0
+#define ARM_BL_BLX_ADDEND_SIZE 11
+#define ARM_BL_BLX_ADDEND_MASK 0x7FF
+#define ARM_BL_BLX_HDR_MASK 0xF800
+#define ARM_BL_BLX_LOWER_T1T2_BIT BIT(12)
+
+static int32_t arm_bl_blx_decode_addend(uintptr_t opaddr)
+{
+	uint16_t upper = *((uint16_t *)opaddr);
+	uint16_t lower = *(((uint16_t *)opaddr) + 1);
+
+	int32_t addend = upper & ARM_BL_BLX_UPPER_S_BIT ? UINT32_MAX : 0;
+
+	addend <<= ARM_BL_BLX_ADDEND_SIZE;
+	addend |= upper & ARM_BL_BLX_ADDEND_MASK;
+	addend <<= ARM_BL_BLX_ADDEND_SIZE;
+	addend |= lower & ARM_BL_BLX_ADDEND_MASK;
+
+	return lower & ARM_BL_BLX_LOWER_T1T2_BIT ? addend << 1 : addend << 2;
+}
+
+static void arm_bl_blx_encode_addend(uintptr_t opaddr, int32_t addend)
+{
+	uint16_t upper = *((uint16_t *)opaddr);
+	uint16_t lower = *(((uint16_t *)opaddr) + 1);
+
+	addend = upper & ARM_BL_BLX_UPPER_S_BIT ? addend >> 1 : addend >> 2;
+
+	upper &= ARM_BL_BLX_HDR_MASK;
+	lower &= ARM_BL_BLX_HDR_MASK;
+	upper |= (addend >> ARM_BL_BLX_ADDEND_SIZE) & ARM_BL_BLX_ADDEND_MASK;
+	lower |= addend & ARM_BL_BLX_ADDEND_MASK;
+
+	*((uint16_t *)opaddr) = upper;
+	*(((uint16_t *)opaddr) + 1) = lower;
+}
 
 /**
  * @brief Architecture specific function for relocating partially linked (static) elf
@@ -31,6 +70,16 @@ void arch_elf_relocate(elf_rela_t *rel, uintptr_t opaddr, uintptr_t opval)
 
 		/* Update the absolute address of a load/store instruction */
 		*((uint32_t *)opaddr) = (uint32_t)opval;
+		break;
+	case R_ARM_THM_CALL:
+		/* Decode the initial addend */
+		int32_t addend = arm_bl_blx_decode_addend(opaddr);
+
+		/* Calculate and add the branch offset (addend) */
+		addend += ((int32_t)opval) - ((int32_t)opaddr);
+
+		/* Encode the addend */
+		arm_bl_blx_encode_addend(opaddr, addend);
 		break;
 	default:
 		LOG_DBG("Unsupported ARM elf relocation type %d at address %lx",

--- a/include/zephyr/llext/elf.h
+++ b/include/zephyr/llext/elf.h
@@ -371,6 +371,7 @@ struct elf64_rela {
 #define R_ARM_ABS32 2
 #define R_ARM_REL32 3
 #define R_ARM_COPY 4
+#define R_ARM_THM_CALL 10
 #define R_ARM_CALL 28
 #define R_ARM_V4BX 40
 

--- a/subsys/llext/llext.c
+++ b/subsys/llext/llext.c
@@ -769,10 +769,9 @@ static int llext_link(struct llext_loader *ldr, struct llext *ext, bool do_local
 				}
 			} else if (ELF_ST_TYPE(sym.st_info) == STT_SECTION ||
 				   ELF_ST_TYPE(sym.st_info) == STT_FUNC) {
-				/* Current relocation location holds an offset into the section */
+				/* Link address is relative to the start of the section */
 				link_addr = (uintptr_t)ext->mem[ldr->sect_map[sym.st_shndx]]
-					+ sym.st_value
-					+ *((uintptr_t *)op_loc);
+					+ sym.st_value;
 
 				LOG_INF("found section symbol %s addr 0x%lx", name, link_addr);
 			} else {

--- a/tests/subsys/llext/simple/CMakeLists.txt
+++ b/tests/subsys/llext/simple/CMakeLists.txt
@@ -16,7 +16,7 @@ target_include_directories(app PRIVATE
 )
 
 # generate extension targets foreach extension given by name
-foreach(ext_name hello_world logging)
+foreach(ext_name hello_world logging relative_jump)
   set(ext_src ${PROJECT_SOURCE_DIR}/src/${ext_name}_ext.c)
   set(ext_bin ${ZEPHYR_BINARY_DIR}/${ext_name}.llext)
   set(ext_inc ${ZEPHYR_BINARY_DIR}/include/generated/${ext_name}.inc)

--- a/tests/subsys/llext/simple/src/relative_jump_ext.c
+++ b/tests/subsys/llext/simple/src/relative_jump_ext.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2024 Trackunit Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * This test is designed to test linking global symbols, which for some architectures
+ * like ARM generate relative jumps rather than jumping to absolute addresses. Multiple
+ * global functions are created to hopefully generate both positive and negative relative
+ * jumps.
+ */
+
+#include <stdint.h>
+#include <zephyr/llext/symbol.h>
+#include <zephyr/sys/printk.h>
+
+void test_relative_jump_1(void);
+void test_relative_jump_2(void);
+void test_relative_jump_3(void);
+void test_relative_jump_4(void);
+void test_relative_jump_5(void);
+
+void test_relative_jump_5(void)
+{
+	printk("relative jump 5\n");
+}
+
+void test_relative_jump_4(void)
+{
+	printk("relative jump 4\n");
+	test_relative_jump_5();
+}
+
+void test_relative_jump_2(void)
+{
+	printk("relative jump 2\n");
+	test_relative_jump_3();
+}
+
+void test_relative_jump_1(void)
+{
+	printk("relative jump 1\n");
+	test_relative_jump_2();
+}
+
+void test_relative_jump_3(void)
+{
+	printk("relative jump 3\n");
+	test_relative_jump_4();
+}
+
+void test_entry(void)
+{
+	printk("enter\n");
+	test_relative_jump_1();
+	printk("exit\n");
+}
+LL_EXTENSION_SYMBOL(test_entry);

--- a/tests/subsys/llext/simple/src/test_llext_simple.c
+++ b/tests/subsys/llext/simple/src/test_llext_simple.c
@@ -147,6 +147,11 @@ static LLEXT_CONST uint8_t logging_ext[] __aligned(4) = {
 };
 LLEXT_LOAD_UNLOAD(logging, true)
 
+static LLEXT_CONST uint8_t relative_jump_ext[] __aligned(4) = {
+	#include "relative_jump.inc"
+};
+LLEXT_LOAD_UNLOAD(relative_jump, true)
+
 /*
  * Ensure that EXPORT_SYMBOL does indeed provide a symbol and a valid address
  * to it.

--- a/tests/subsys/llext/simple/testcase.yaml
+++ b/tests/subsys/llext/simple/testcase.yaml
@@ -16,7 +16,7 @@ tests:
   llext.simple.readonly_mpu:
     min_ram: 128
     arch_exclude: xtensa # for now
-    filter: CONFIG_CPU_HAS_MPU
+    filter: CONFIG_ARCH_HAS_USERSPACE
     extra_configs:
       - CONFIG_USERSPACE=y
       - CONFIG_LLEXT_STORAGE_WRITABLE=n
@@ -50,7 +50,7 @@ tests:
       - CONFIG_MODULES=y
       - CONFIG_LLEXT_TEST_HELLO=m
   llext.simple.modules_enabled_readonly_mpu:
-    filter: CONFIG_CPU_HAS_MPU
+    filter: CONFIG_ARCH_HAS_USERSPACE
     arch_exclude: xtensa # for now
     platform_key:
       - simulation


### PR DESCRIPTION
Add support for the relocation type R_ARM_ARM_THM_CALL which is
produced for the ARM Thumb BL and BLX (branch immediate)
instructions.

These instructions are used for non-static functions like
```
void test1(void)
{
}

void main(void)
{
        test1();
}
```
Without support for this relocation, test1() has to be static, otherwise the extension simply gets stuck in a forever loop.

The PR also adds a test which generate this relocation type. The output from the test is as follows:
```
enter
relative jump 1
relative jump 2
relative jump 3
relative jump 4
relative jump 5
exit
```
The functions are placed in an order which hopefully makes the compiler place them in an order resulting in relative jumps in both directions, but we don't actually have control over that :)