### PR TITLE
bluetooth: audio: broadcast source: Add missing check condition

### DIFF
--- a/subsys/bluetooth/audio/bap_broadcast_source.c
+++ b/subsys/bluetooth/audio/bap_broadcast_source.c
@@ -594,7 +594,8 @@ static bool valid_broadcast_source_param(const struct bt_bap_broadcast_source_pa
 				return false;
 			}
 
-			CHECKIF(subgroup_param->codec_cfg->id == BT_HCI_CODING_FORMAT_LC3 &&
+			CHECKIF(stream_param->data != NULL &&
+				subgroup_param->codec_cfg->id == BT_HCI_CODING_FORMAT_LC3 &&
 				!bt_audio_valid_ltv(stream_param->data, stream_param->data_len)) {
 				LOG_DBG("subgroup_params[%zu].stream_params[%zu]->data not valid "
 					"LTV",


### PR DESCRIPTION
There is no need to validate `stream_param->data` if `stream_param->data_len` is 0. The `bt_audio_valid_ltv()` returns `false` if `stream_param->data` is NULL.
Fixes failing PTS BAP/BSRC test cases