### PR TITLE
west.yml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -282,7 +282,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 8b4c70ab6dc03d2826c166dedb56541950defa8c
+      revision: 9fb7ce5d026db42768d63f04cc60ce022d27b555
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  9fb7ce5d026db42768d63f04cc60ce022d27b555

Brings following Zephyr relevant fixes:
 - 9fb7ce5d boot: zephyr: Fix estimated size calculation
 - 7ace8bd4 zephyr: boards: Remove CONFIG_FPROTECT from nrf54l15

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.