### PR TITLE
Bluetooth: Host: Add NULL check for callback_list

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2434,6 +2434,11 @@ int bt_conn_cb_unregister(struct bt_conn_cb *cb)
 		return -EINVAL;
 	}
 
+	if (callback_list == NULL) {
+		/* No callsback registered */
+		return -ENOENT;
+	}
+
 	if (callback_list == cb) {
 		callback_list = callback_list->_next;
 		return 0;


### PR DESCRIPTION
If no callbacks have been registered then callback_list is NULL, in which case we can skip searching.

This also fixes a NULL-pointer acces in the while loop as previous_callback would be NULL when it gets
dereferenced as previous_callback->_next.