### PR TITLE
net: lwm2m: removes redundant newline from shell_* calls.

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_shell.c
+++ b/subsys/net/lib/lwm2m/lwm2m_shell.c
@@ -57,7 +57,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 static void send_cb(enum lwm2m_send_status status)
 {
-	LOG_INF("SEND status: %d\n", status);
+	LOG_INF("SEND status: %d", status);
 }
 
 static int cmd_send(const struct shell *sh, size_t argc, char **argv)
@@ -68,12 +68,12 @@ static int cmd_send(const struct shell *sh, size_t argc, char **argv)
 	struct lwm2m_obj_path lwm2m_path_list[CONFIG_LWM2M_COMPOSITE_PATH_LIST_SIZE];
 
 	if (!ctx) {
-		shell_error(sh, "no lwm2m context yet\n");
+		shell_error(sh, "no lwm2m context yet");
 		return -ENOEXEC;
 	}
 
 	if (argc < 2) {
-		shell_error(sh, "no path(s)\n");
+		shell_error(sh, "no path(s)");
 		shell_help(sh);
 		return -EINVAL;
 	}
@@ -94,7 +94,7 @@ static int cmd_send(const struct shell *sh, size_t argc, char **argv)
 	ret = lwm2m_send_cb(ctx, lwm2m_path_list, path_cnt, send_cb);
 
 	if (ret < 0) {
-		shell_error(sh, "can't do send operation, request failed (%d)\n", ret);
+		shell_error(sh, "can't do send operation, request failed (%d)", ret);
 		return -ENOEXEC;
 	}
 	return 0;
@@ -105,7 +105,7 @@ static int cmd_exec(const struct shell *sh, size_t argc, char **argv)
 	struct lwm2m_ctx *ctx = lwm2m_rd_client_ctx();
 
 	if (!ctx) {
-		shell_error(sh, "no lwm2m context yet\n");
+		shell_error(sh, "no lwm2m context yet");
 		return -ENOEXEC;
 	}
 
@@ -114,19 +114,19 @@ static int cmd_exec(const struct shell *sh, size_t argc, char **argv)
 	int ret = lwm2m_string_to_path(pathstr, &path, '/'); /* translate path -> path_obj */
 
 	if (ret < 0) {
-		shell_error(sh, "Illegal path (PATH %s)\n", pathstr);
+		shell_error(sh, "Illegal path (PATH %s)", pathstr);
 		return -EINVAL;
 	}
 
 	struct lwm2m_engine_res *res = lwm2m_engine_get_res(&path);
 
 	if (res == NULL) {
-		shell_error(sh, "Resource not found\n");
+		shell_error(sh, "Resource not found");
 		return -EINVAL;
 	}
 
 	if (!res->execute_cb) {
-		shell_error(sh, "No execute callback\n!");
+		shell_error(sh, "No execute callback!");
 		return -EINVAL;
 	}
 
@@ -136,7 +136,7 @@ static int cmd_exec(const struct shell *sh, size_t argc, char **argv)
 
 	ret = res->execute_cb(path.obj_inst_id, param, param_len);
 	if (ret < 0) {
-		shell_error(sh, "returned (err %d)\n", ret);
+		shell_error(sh, "returned (err %d)", ret);
 		return -ENOEXEC;
 	}
 
@@ -148,12 +148,12 @@ static int cmd_read(const struct shell *sh, size_t argc, char **argv)
 	struct lwm2m_ctx *ctx = lwm2m_rd_client_ctx();
 
 	if (!ctx) {
-		shell_error(sh, "no lwm2m context yet\n");
+		shell_error(sh, "no lwm2m context yet");
 		return -ENOEXEC;
 	}
 
 	if (argc < 2) {
-		shell_error(sh, "no arguments or path(s)\n");
+		shell_error(sh, "no arguments or path(s)");
 		shell_help(sh);
 		return -EINVAL;
 	}
@@ -189,7 +189,7 @@ static int cmd_read(const struct shell *sh, size_t argc, char **argv)
 		if (ret != 0) {
 			goto out;
 		}
-		shell_print(sh, "%.*s\n", buff_len, buff);
+		shell_print(sh, "%.*s", buff_len, buff);
 	} else if (strcmp(dtype, "-s8") == 0) {
 		int8_t temp = 0;
 
@@ -197,7 +197,7 @@ static int cmd_read(const struct shell *sh, size_t argc, char **argv)
 		if (ret != 0) {
 			goto out;
 		}
-		shell_print(sh, "%d\n", temp);
+		shell_print(sh, "%d", temp);
 	} else if (strcmp(dtype, "-s16") == 0) {
 		int16_t temp = 0;
 
@@ -205,7 +205,7 @@ static int cmd_read(const struct shell *sh, size_t argc, char **argv)
 		if (ret != 0) {
 			goto out;
 		}
-		shell_print(sh, "%d\n", temp);
+		shell_print(sh, "%d", temp);
 	} else if (strcmp(dtype, "-s32") == 0) {
 		int32_t temp = 0;
 
@@ -213,7 +213,7 @@ static int cmd_read(const struct shell *sh, size_t argc, char **argv)
 		if (ret != 0) {
 			goto out;
 		}
-		shell_print(sh, "%d\n", temp);
+		shell_print(sh, "%d", temp);
 	} else if (strcmp(dtype, "-s64") == 0) {
 		int64_t temp = 0;
 
@@ -221,7 +221,7 @@ static int cmd_read(const struct shell *sh, size_t argc, char **argv)
 		if (ret != 0) {
 			goto out;
 		}
-		shell_print(sh, "%lld\n", temp);
+		shell_print(sh, "%lld", temp);
 	} else if (strcmp(dtype, "-u8") == 0) {
 		uint8_t temp = 0;
 
@@ -229,7 +229,7 @@ static int cmd_read(const struct shell *sh, size_t argc, char **argv)
 		if (ret != 0) {
 			goto out;
 		}
-		shell_print(sh, "%d\n", temp);
+		shell_print(sh, "%d", temp);
 	} else if (strcmp(dtype, "-u16") == 0) {
 		uint16_t temp = 0;
 
@@ -237,7 +237,7 @@ static int cmd_read(const struct shell *sh, size_t argc, char **argv)
 		if (ret != 0) {
 			goto out;
 		}
-		shell_print(sh, "%d\n", temp);
+		shell_print(sh, "%d", temp);
 	} else if (strcmp(dtype, "-u32") == 0) {
 		uint32_t temp = 0;
 
@@ -245,7 +245,7 @@ static int cmd_read(const struct shell *sh, size_t argc, char **argv)
 		if (ret != 0) {
 			goto out;
 		}
-		shell_print(sh, "%d\n", temp);
+		shell_print(sh, "%d", temp);
 	} else if (strcmp(dtype, "-f") == 0) {
 		double temp = 0;
 
@@ -253,7 +253,7 @@ static int cmd_read(const struct shell *sh, size_t argc, char **argv)
 		if (ret != 0) {
 			goto out;
 		}
-		shell_print(sh, "%f\n", temp);
+		shell_print(sh, "%f", temp);
 	} else if (strcmp(dtype, "-b") == 0) {
 		bool temp;
 
@@ -261,7 +261,7 @@ static int cmd_read(const struct shell *sh, size_t argc, char **argv)
 		if (ret != 0) {
 			goto out;
 		}
-		shell_print(sh, "%d\n", temp);
+		shell_print(sh, "%d", temp);
 	} else if (strcmp(dtype, "-t") == 0) {
 		time_t temp;
 
@@ -269,15 +269,15 @@ static int cmd_read(const struct shell *sh, size_t argc, char **argv)
 		if (ret != 0) {
 			goto out;
 		}
-		shell_print(sh, "%lld\n", temp);
+		shell_print(sh, "%lld", temp);
 	} else {
-		shell_error(sh, "can't recognize data type %s\n", dtype);
+		shell_error(sh, "can't recognize data type %s", dtype);
 		shell_help(sh);
 		return -EINVAL;
 	}
 	return 0;
 out:
-	shell_error(sh, "can't do read operation, request failed (err %d)\n", ret);
+	shell_error(sh, "can't do read operation, request failed (err %d)", ret);
 	return -EINVAL;
 }
 
@@ -286,12 +286,12 @@ static int cmd_write(const struct shell *sh, size_t argc, char **argv)
 	struct lwm2m_ctx *ctx = lwm2m_rd_client_ctx();
 
 	if (!ctx) {
-		shell_error(sh, "no lwm2m context yet\n");
+		shell_error(sh, "no lwm2m context yet");
 		return -ENOEXEC;
 	}
 
 	if (argc < 3) {
-		shell_error(sh, "no arguments or path(s)\n");
+		shell_error(sh, "no arguments or path(s)");
 		shell_help(sh);
 		return -EINVAL;
 	}
@@ -346,13 +346,13 @@ static int cmd_write(const struct shell *sh, size_t argc, char **argv)
 		} else if (strcmp(dtype, "-t") == 0) {
 			ret = lwm2m_set_time(&path, strtoll(value, &e, 10));
 		} else {
-			shell_error(sh, "can't recognize data type %s\n",
+			shell_error(sh, "can't recognize data type %s",
 				    dtype);
 			shell_help(sh);
 			return -EINVAL;
 		}
 		if (*e != '\0') {
-			shell_error(sh, "Invalid number: %s\n", value);
+			shell_error(sh, "Invalid number: %s", value);
 			shell_help(sh);
 			return -EINVAL;
 		}
@@ -361,7 +361,7 @@ static int cmd_write(const struct shell *sh, size_t argc, char **argv)
 	if (ret < 0) {
 		shell_error(
 			sh,
-			"can't do write operation, request failed (err %d)\n",
+			"can't do write operation, request failed (err %d)",
 			ret);
 		return -ENOEXEC;
 	}
@@ -375,14 +375,14 @@ static int cmd_create_or_delete(const struct shell *sh, bool delete, size_t argc
 	int ret;
 
 	if (argc < 2) {
-		shell_error(sh, "No object ID given\n");
+		shell_error(sh, "No object ID given");
 		shell_help(sh);
 		return -EINVAL;
 	}
 
 	ret = lwm2m_string_to_path(argv[1], &path, '/');
 	if (ret < 0) {
-		shell_error(sh, "failed to read path (%d)\n", ret);
+		shell_error(sh, "failed to read path (%d)", ret);
 		return -ENOEXEC;
 	}
 
@@ -411,7 +411,7 @@ static int cmd_create_or_delete(const struct shell *sh, bool delete, size_t argc
 	}
 
 	if (ret < 0) {
-		shell_error(sh, "operation failed, %d\n", ret);
+		shell_error(sh, "operation failed, %d", ret);
 		return -ENOEXEC;
 	}
 
@@ -433,18 +433,18 @@ static int cmd_start(const struct shell *sh, size_t argc, char **argv)
 	struct lwm2m_ctx *ctx = lwm2m_rd_client_ctx();
 
 	if (!ctx) {
-		shell_error(sh, "no lwm2m context yet\n");
+		shell_error(sh, "no lwm2m context yet");
 		return -ENOEXEC;
 	}
 	uint32_t bootstrap_flag = 0;
 
 	if (argc == 3) {
-		shell_error(sh, "no specifier or value\n");
+		shell_error(sh, "no specifier or value");
 		shell_help(sh);
 		return -EINVAL;
 	} else if (argc == 4) {
 		if (strcmp(argv[2], "-b") != 0) {
-			shell_error(sh, "unknown specifier %s\n", argv[2]);
+			shell_error(sh, "unknown specifier %s", argv[2]);
 			shell_help(sh);
 			return -EINVAL;
 		}
@@ -453,7 +453,7 @@ static int cmd_start(const struct shell *sh, size_t argc, char **argv)
 
 		bootstrap_flag = strtol(argv[3], &e, 10);
 		if (*e != '\0') {
-			shell_error(sh, "Invalid number: %s\n", argv[3]);
+			shell_error(sh, "Invalid number: %s", argv[3]);
 			shell_help(sh);
 			return -EINVAL;
 		}
@@ -463,7 +463,7 @@ static int cmd_start(const struct shell *sh, size_t argc, char **argv)
 	if (ret < 0) {
 		shell_error(
 			sh,
-			"can't do start operation, request failed (err %d)\n",
+			"can't do start operation, request failed (err %d)",
 			ret);
 		return -ENOEXEC;
 	}
@@ -475,14 +475,14 @@ static int cmd_stop(const struct shell *sh, size_t argc, char **argv)
 	struct lwm2m_ctx *ctx = lwm2m_rd_client_ctx();
 
 	if (!ctx) {
-		shell_error(sh, "no lwm2m context yet\n");
+		shell_error(sh, "no lwm2m context yet");
 		return -ENOEXEC;
 	}
 	bool forcefully = true;
 
 	if (argc == 2) {
 		if (strcmp(argv[1], "-f") != 0) {
-			shell_error(sh, "can't recognize specifier %s\n",
+			shell_error(sh, "can't recognize specifier %s",
 				    argv[1]);
 			shell_help(sh);
 			return -EINVAL;
@@ -494,7 +494,7 @@ static int cmd_stop(const struct shell *sh, size_t argc, char **argv)
 	if (ret < 0) {
 		shell_error(
 			sh,
-			"can't do stop operation, request failed (err %d)\n",
+			"can't do stop operation, request failed (err %d)",
 			ret);
 		return -ENOEXEC;
 	}
@@ -508,7 +508,7 @@ static int cmd_update(const struct shell *sh, size_t argc, char **argv)
 	struct lwm2m_ctx *ctx = lwm2m_rd_client_ctx();
 
 	if (!ctx) {
-		shell_error(sh, "no lwm2m context yet\n");
+		shell_error(sh, "no lwm2m context yet");
 		return -ENOEXEC;
 	}
 	lwm2m_rd_client_update();
@@ -562,7 +562,7 @@ static int cmd_cache(const struct shell *sh, size_t argc, char **argv)
 	struct lwm2m_obj_path obj_path;
 
 	if (argc != 3) {
-		shell_error(sh, "wrong parameters\n");
+		shell_error(sh, "wrong parameters");
 		return -EINVAL;
 	}
 
@@ -573,30 +573,30 @@ static int cmd_cache(const struct shell *sh, size_t argc, char **argv)
 	}
 
 	if (obj_path.level < 3) {
-		shell_error(sh, "Path string not correct\n");
+		shell_error(sh, "Path string not correct");
 		return -EINVAL;
 	}
 
 	if (lwm2m_cache_entry_get_by_object(&obj_path)) {
-		shell_error(sh, "Cache already enabled for %s\n", argv[1]);
+		shell_error(sh, "Cache already enabled for %s", argv[1]);
 		return -ENOEXEC;
 	}
 
 	elems = atoi(argv[2]);
 	if (elems < 1) {
-		shell_error(sh, "Size must be 1 or more (given %d)\n", elems);
+		shell_error(sh, "Size must be 1 or more (given %d)", elems);
 		return -EINVAL;
 	}
 
 	cache = k_malloc(sizeof(struct lwm2m_time_series_elem) * elems);
 	if (!cache) {
-		shell_error(sh, "Out of memory\n");
+		shell_error(sh, "Out of memory");
 		return -ENOEXEC;
 	}
 
 	rc = lwm2m_enable_cache(&obj_path, cache, elems);
 	if (rc) {
-		shell_error(sh, "lwm2m_enable_cache(%u/%u/%u/%u, %p, %d) returned %d\n",
+		shell_error(sh, "lwm2m_enable_cache(%u/%u/%u/%u, %p, %d) returned %d",
 			    obj_path.obj_id, obj_path.obj_inst_id, obj_path.res_id,
 			    obj_path.res_inst_id, cache, elems, rc);
 		k_free(cache);
@@ -605,7 +605,7 @@ static int cmd_cache(const struct shell *sh, size_t argc, char **argv)
 
 	return 0;
 #else
-	shell_error(sh, "No heap configured\n");
+	shell_error(sh, "No heap configured");
 	return -ENOEXEC;
 #endif
 }


### PR DESCRIPTION
All shell_* macro functions add a newline already.