### PR TITLE
Bluetooth: Audio: Increase PA sync timeouts

### DIFF
--- a/samples/bluetooth/public_broadcast_sink/src/main.c
+++ b/samples/bluetooth/public_broadcast_sink/src/main.c
@@ -25,7 +25,7 @@
 
 #define SEM_TIMEOUT K_SECONDS(10)
 #define PA_SYNC_SKIP         5
-#define SYNC_RETRY_COUNT     6 /* similar to retries for connections */
+#define PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO 20 /* Set the timeout relative to interval */
 #define INVALID_BROADCAST_ID 0xFFFFFFFF
 
 static bool pbs_found;
@@ -114,19 +114,16 @@ static struct bt_pacs_cap cap = {
 static uint16_t interval_to_sync_timeout(uint16_t interval)
 {
 	uint32_t interval_ms;
-	uint16_t timeout;
-
-	/* Ensure that the following calculation does not overflow silently */
-	__ASSERT(SYNC_RETRY_COUNT < 10, "SYNC_RETRY_COUNT shall be less than 10");
+	uint32_t timeout;
 
 	/* Add retries and convert to unit in 10's of ms */
 	interval_ms = BT_GAP_PER_ADV_INTERVAL_TO_MS(interval);
-	timeout = (interval_ms * SYNC_RETRY_COUNT) / 10;
+	timeout = (interval_ms * PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO) / 10;
 
 	/* Enforce restraints */
 	timeout = CLAMP(timeout, BT_GAP_PER_ADV_MIN_TIMEOUT, BT_GAP_PER_ADV_MAX_TIMEOUT);
 
-	return timeout;
+	return (uint16_t)timeout;
 }
 
 static void sync_broadcast_pa(const struct bt_le_scan_recv_info *info,

--- a/samples/bluetooth/tmap_bmr/src/bap_broadcast_sink.c
+++ b/samples/bluetooth/tmap_bmr/src/bap_broadcast_sink.c
@@ -15,7 +15,7 @@
 
 #define SEM_TIMEOUT K_SECONDS(10)
 #define PA_SYNC_SKIP         5
-#define SYNC_RETRY_COUNT     6 /* similar to retries for connections */
+#define PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO 20 /* Set the timeout relative to interval */
 #define INVALID_BROADCAST_ID 0xFFFFFFFF
 
 static bool tmap_bms_found;
@@ -102,20 +102,16 @@ static struct bt_pacs_cap cap = {
 static uint16_t interval_to_sync_timeout(uint16_t interval)
 {
 	uint32_t interval_ms;
-	uint16_t timeout;
-
-	/* Ensure that the following calculation does not overflow silently */
-	__ASSERT(SYNC_RETRY_COUNT < 10, "SYNC_RETRY_COUNT shall be less than 10");
+	uint32_t timeout;
 
 	/* Add retries and convert to unit in 10's of ms */
 	interval_ms = BT_GAP_PER_ADV_INTERVAL_TO_MS(interval);
-	timeout = (interval_ms * SYNC_RETRY_COUNT) / 10;
+	timeout = (interval_ms * PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO) / 10;
 
 	/* Enforce restraints */
-	timeout = CLAMP(timeout, BT_GAP_PER_ADV_MIN_TIMEOUT,
-			BT_GAP_PER_ADV_MAX_TIMEOUT);
+	timeout = CLAMP(timeout, BT_GAP_PER_ADV_MIN_TIMEOUT, BT_GAP_PER_ADV_MAX_TIMEOUT);
 
-	return timeout;
+	return (uint16_t)timeout;
 }
 
 static void sync_broadcast_pa(const struct bt_le_scan_recv_info *info,

--- a/tests/bluetooth/tester/src/btp_bap_broadcast.c
+++ b/tests/bluetooth/tester/src/btp_bap_broadcast.c
@@ -30,7 +30,7 @@ static struct btp_bap_broadcast_remote_source *broadcast_source_to_sync;
 /* A mask for the maximum BIS we can sync to. +1 since the BIS indexes start from 1. */
 static const uint32_t bis_index_mask = BIT_MASK(CONFIG_BT_BAP_BROADCAST_SNK_STREAM_COUNT + 1);
 #define INVALID_BROADCAST_ID      (BT_AUDIO_BROADCAST_ID_MAX + 1)
-#define SYNC_RETRY_COUNT          6 /* similar to retries for connections */
+#define PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO 20 /* Set the timeout relative to interval */
 #define PA_SYNC_SKIP              5
 static struct bt_bap_bass_subgroup
 	delegator_subgroups[CONFIG_BT_BAP_BASS_MAX_SUBGROUPS];

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
@@ -652,15 +652,15 @@ static uint16_t interval_to_sync_timeout(uint16_t pa_interval)
 		/* Use maximum value to maximize chance of success */
 		pa_timeout = BT_GAP_PER_ADV_MAX_TIMEOUT;
 	} else {
-		/* Ensure that the following calculation does not overflow silently */
-		__ASSERT(SYNC_RETRY_COUNT < 10, "SYNC_RETRY_COUNT shall be less than 10");
+		uint32_t interval_ms;
+		uint32_t timeout;
 
 		/* Add retries and convert to unit in 10's of ms */
-		pa_timeout = ((uint32_t)pa_interval * SYNC_RETRY_COUNT) / 10;
+		interval_ms = BT_GAP_PER_ADV_INTERVAL_TO_MS(pa_interval);
+		timeout = (interval_ms * PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO) / 10;
 
 		/* Enforce restraints */
-		pa_timeout =
-			CLAMP(pa_timeout, BT_GAP_PER_ADV_MIN_TIMEOUT, BT_GAP_PER_ADV_MAX_TIMEOUT);
+		pa_timeout = CLAMP(timeout, BT_GAP_PER_ADV_MIN_TIMEOUT, BT_GAP_PER_ADV_MAX_TIMEOUT);
 	}
 
 	return pa_timeout;

--- a/tests/bsim/bluetooth/audio/src/bap_scan_delegator_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_scan_delegator_test.c
@@ -14,7 +14,7 @@
 
 extern enum bst_result_t bst_result;
 
-#define SYNC_RETRY_COUNT          6 /* similar to retries for connections */
+#define PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO 20 /* Set the timeout relative to interval */
 #define PA_SYNC_SKIP              5
 
 CREATE_FLAG(flag_pa_synced);
@@ -99,16 +99,15 @@ static uint16_t interval_to_sync_timeout(uint16_t pa_interval)
 		/* Use maximum value to maximize chance of success */
 		pa_timeout = BT_GAP_PER_ADV_MAX_TIMEOUT;
 	} else {
-		/* Ensure that the following calculation does not overflow silently */
-		__ASSERT(SYNC_RETRY_COUNT < 10,
-			 "SYNC_RETRY_COUNT shall be less than 10");
+		uint32_t interval_ms;
+		uint32_t timeout;
 
 		/* Add retries and convert to unit in 10's of ms */
-		pa_timeout = ((uint32_t)pa_interval * SYNC_RETRY_COUNT) / 10;
+		interval_ms = BT_GAP_PER_ADV_INTERVAL_TO_MS(pa_interval);
+		timeout = (interval_ms * PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO) / 10;
 
 		/* Enforce restraints */
-		pa_timeout = CLAMP(pa_timeout, BT_GAP_PER_ADV_MIN_TIMEOUT,
-				   BT_GAP_PER_ADV_MAX_TIMEOUT);
+		pa_timeout = CLAMP(timeout, BT_GAP_PER_ADV_MIN_TIMEOUT, BT_GAP_PER_ADV_MAX_TIMEOUT);
 	}
 
 	return pa_timeout;

--- a/tests/bsim/bluetooth/audio/src/cap_acceptor_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_acceptor_test.c
@@ -758,15 +758,15 @@ static uint16_t interval_to_sync_timeout(uint16_t pa_interval)
 		/* Use maximum value to maximize chance of success */
 		pa_timeout = BT_GAP_PER_ADV_MAX_TIMEOUT;
 	} else {
-		/* Ensure that the following calculation does not overflow silently */
-		__ASSERT(SYNC_RETRY_COUNT < 10, "SYNC_RETRY_COUNT shall be less than 10");
+		uint32_t interval_ms;
+		uint32_t timeout;
 
 		/* Add retries and convert to unit in 10's of ms */
-		pa_timeout = ((uint32_t)pa_interval * SYNC_RETRY_COUNT) / 10;
+		interval_ms = BT_GAP_PER_ADV_INTERVAL_TO_MS(pa_interval);
+		timeout = (interval_ms * PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO) / 10;
 
 		/* Enforce restraints */
-		pa_timeout =
-			CLAMP(pa_timeout, BT_GAP_PER_ADV_MIN_TIMEOUT, BT_GAP_PER_ADV_MAX_TIMEOUT);
+		pa_timeout = CLAMP(timeout, BT_GAP_PER_ADV_MIN_TIMEOUT, BT_GAP_PER_ADV_MAX_TIMEOUT);
 	}
 
 	return pa_timeout;

--- a/tests/bsim/bluetooth/audio/src/common.h
+++ b/tests/bsim/bluetooth/audio/src/common.h
@@ -102,7 +102,7 @@ static const uint8_t mock_iso_data[] = {
 #define AD_SIZE 1
 
 #define INVALID_BROADCAST_ID (BT_AUDIO_BROADCAST_ID_MAX + 1)
-#define SYNC_RETRY_COUNT     6 /* similar to retries for connections */
+#define PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO 20 /* Set the timeout relative to interval */
 #define PA_SYNC_SKIP         5
 
 #define PBP_STREAMS_TO_SEND  2

--- a/tests/bsim/bluetooth/audio/src/common.h
+++ b/tests/bsim/bluetooth/audio/src/common.h
@@ -68,7 +68,7 @@ static const uint8_t mock_iso_data[] = {
 };
 
 #define MIN_SEND_COUNT 100
-#define WAIT_SECONDS 60 /* seconds */
+#define WAIT_SECONDS   100                           /* seconds */
 #define WAIT_TIME (WAIT_SECONDS * USEC_PER_SEC) /* microseconds*/
 
 #define WAIT_FOR_COND(cond) while (!(cond)) { k_sleep(K_MSEC(1)); }

--- a/tests/bsim/bluetooth/audio/src/pbp_public_broadcast_source_test.c
+++ b/tests/bsim/bluetooth/audio/src/pbp_public_broadcast_source_test.c
@@ -339,8 +339,8 @@ static void test_main(void)
 			sent_cb(&broadcast_stream->bap_stream);
 		}
 
-		/* Keeping running for a little while */
-		k_sleep(K_SECONDS(3));
+		/* Wait for other devices to let us know when we can stop the source */
+		printk("Waiting for signal from receiver to stop\n"); backchannel_sync_wait_any();
 
 		err = bt_cap_initiator_broadcast_audio_stop(broadcast_source);
 		if (err != 0) {

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio.sh
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=20
+EXECUTE_TIMEOUT=50
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_assistant.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_assistant.sh
@@ -6,7 +6,7 @@
 
 SIMULATION_ID="bap_broadcast_audio_assistant"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=20
+EXECUTE_TIMEOUT=50
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/pbp.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/pbp.sh
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=20
+EXECUTE_TIMEOUT=50
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/pbp.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/pbp.sh
@@ -23,6 +23,6 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_audio_prj_conf \
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
-  -D=2 -sim_length=70e6 $@
+  -D=2 -sim_length=100e6 $@
 
 wait_for_background_jobs


### PR DESCRIPTION
Increase the timeouts to be 60 instead of 6.
The reason for this is that some controllers (like the Zephyr controller) will reserve some of these to ensure stability, and in fact with skip = 5 and retry = 6, it would still send the PA reports at every interval.

To accomodate a higher timeout value, the functions used to convert PA intervals to PA timeouts have been updated.