### PR TITLE
net: dns: Fix timeout calculation with DNS retransmissions

### DIFF
--- a/subsys/net/lib/sockets/getaddrinfo.c
+++ b/subsys/net/lib/sockets/getaddrinfo.c
@@ -133,7 +133,7 @@ static int exec_query(const char *host, int family,
 	}
 
 again:
-	timeout_ms = k_ticks_to_ms_floor32(timeout.ticks);
+	timeout_ms = k_ticks_to_ms_ceil32(timeout.ticks);
 
 	NET_DBG("Timeout %d", timeout_ms);
 


### PR DESCRIPTION
With recently introduced DNS retransmission mechanism, a certain bug could occur when calculating query timeout.

If the time until the final DNS timeout (as indicated by CONFIG_NET_SOCKETS_DNS_TIMEOUT) was less than 1 millisecond, the actual millisecond timeout value was rounded down, resulting in 0 ms timeout. This in order was interpreted as invalid argument by dns_get_addr_info() function, so in result, instead of reporting query timeout, the function reported invalid argument error.

Fix this by rounding the millisecond timeout up, instead of down, so that in any case, if the final timeout is not due, we always provide non-zero timeout to dns_get_addr_info().

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/70101