### PR TITLE
soc: nxp: imxrt: correct FCB offset for iMXRT1011 SOC to 0x400

### DIFF
--- a/soc/nxp/imxrt/Kconfig
+++ b/soc/nxp/imxrt/Kconfig
@@ -88,7 +88,7 @@ endchoice # BOOT_DEVICE
 
 config FLEXSPI_CONFIG_BLOCK_OFFSET
 	hex "FlexSPI config block offset"
-	default 0x400 if SOC_SERIES_IMXRT5XX || SOC_SERIES_IMXRT6XX
+	default 0x400 if SOC_SERIES_IMXRT5XX || SOC_SERIES_IMXRT6XX || SOC_MIMXRT1011
 	default 0x0 if BOOT_FLEXSPI_NOR
 	help
 	  FlexSPI configuration block consists of parameters regarding specific


### PR DESCRIPTION
Unlike the remainder of the RT10xx series, the RT1011 SOC requires that the flash configuration block be placed at an offset of 0x400 bytes, instead of the start of the flash.

Fixes #70090