### PR TITLE
dts: opentitan: update plic interrupt count to match spec

### DIFF
--- a/dts/riscv/lowrisc/opentitan_earlgrey.dtsi
+++ b/dts/riscv/lowrisc/opentitan_earlgrey.dtsi
@@ -76,7 +76,7 @@
 			interrupts-extended = <&hlic 11>;
 			reg = <0x48000000 0x04000000>;
 			riscv,max-priority = <7>;
-			riscv,ndev = <184>;
+			riscv,ndev = <182>;
 			status = "okay";
 		};
 


### PR DESCRIPTION
previously `184`, update to `182`, per:
https://opentitan.org/book/hw/top_earlgrey/ip_autogen/rv_plic/