### PR TITLE
arm/cortex-m, posix: add tracing to custom thread abort func

### DIFF
--- a/arch/arm/core/cortex_m/thread_abort.c
+++ b/arch/arm/core/cortex_m/thread_abort.c
@@ -25,6 +25,8 @@
 
 void z_impl_k_thread_abort(k_tid_t thread)
 {
+	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_thread, abort, thread);
+
 	if (_current == thread) {
 		if (arch_is_in_isr()) {
 			/* ARM is unlike most arches in that this is true
@@ -49,4 +51,6 @@ void z_impl_k_thread_abort(k_tid_t thread)
 	}
 
 	z_thread_abort(thread);
+
+	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_thread, abort, thread);
 }

--- a/arch/posix/core/thread.c
+++ b/arch/posix/core/thread.c
@@ -20,6 +20,11 @@
 #include "posix_core.h"
 #include <zephyr/arch/posix/posix_soc_if.h>
 
+#ifdef CONFIG_TRACING
+#include <zephyr/tracing/tracing_macros.h>
+#include <zephyr/tracing/tracing.h>
+#endif
+
 /* Note that in this arch we cheat quite a bit: we use as stack a normal
  * pthreads stack and therefore we ignore the stack size
  */
@@ -62,6 +67,8 @@ void z_impl_k_thread_abort(k_tid_t thread)
 	unsigned int key;
 	int thread_idx;
 
+	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_thread, abort, thread);
+
 	posix_thread_status_t *tstatus =
 					(posix_thread_status_t *)
 					thread->callee_saved.thread_status;
@@ -103,5 +110,7 @@ void z_impl_k_thread_abort(k_tid_t thread)
 
 	/* The abort handler might have altered the ready queue. */
 	z_reschedule_irqlock(key);
+
+	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_thread, abort, thread);
 }
 #endif

--- a/subsys/tracing/sysview/tracing_sysview.h
+++ b/subsys/tracing/sysview/tracing_sysview.h
@@ -78,6 +78,12 @@ void sys_trace_thread_info(struct k_thread *thread);
 #define sys_port_trace_k_thread_abort(thread)                                                      \
 	SEGGER_SYSVIEW_RecordU32(TID_THREAD_ABORT, (uint32_t)(uintptr_t)thread)
 
+#define sys_port_trace_k_thread_abort_enter(thread)                                                \
+	SEGGER_SYSVIEW_RecordU32(TID_THREAD_ABORT, (uint32_t)(uintptr_t)thread)
+
+#define sys_port_trace_k_thread_abort_exit(thread)                                                 \
+	SEGGER_SYSVIEW_RecordEndCall(TID_THREAD_ABORT)
+
 #define sys_port_trace_k_thread_suspend_enter(thread)                                              \
 	SEGGER_SYSVIEW_RecordU32(TID_THREAD_SUSPEND, (uint32_t)(uintptr_t)thread)
 


### PR DESCRIPTION
ARM/Cortex-M and POSIX both have custom implementations for thread abort (z_impl_k_thread_abort) which lacks the	tracing function calls as in the generic version. So add them.