### PR TITLE
list_hardware.py: sort rglob(SOC_YML) HWMv2 results

### DIFF
--- a/scripts/list_hardware.py
+++ b/scripts/list_hardware.py
@@ -173,7 +173,7 @@ def find_v2_systems(args):
     yml_files = []
     systems = Systems()
     for root in args.soc_roots:
-        yml_files.extend((root / 'soc').rglob(SOC_YML))
+        yml_files.extend(sorted((root / 'soc').rglob(SOC_YML)))
 
     for soc_yml in yml_files:
         if soc_yml.is_file():


### PR DESCRIPTION
This makes .config, autoconf.h, and configs.c deterministic again.

Directory listing is not deterministic, it must always be sorted. https://reproducible-builds.org/docs/stable-inputs/

Fixes commit 61bbfb5ba25f ("scripts: introduce list_hardware.py for listing of architectures and SoCs") in collab-hwm branch which was squashed in mega HWMv2 commit 8dc3f856229c ("hwmv2: Introduce Hardware model version 2 and convert devices")

SOF CI builds with both Windows and Linux and compares the outputs. This catches practically 100% of build reproducibility issues and caught this one too:

 https://github.com/thesofproject/sof/actions/runs/8241692987/job/22539664560

HWMv2 was a "big bang" integration on both the Zephyr and SOF sides. So this `rglob()` was a needle in a haystack but with hindsight, this issue is really trivial to reproduce and verify:

```
apt-get install disorderfs
mkdir disorderedWorkspace/
disorderfs --shuffle-dirents=yes  workspace/ disorderedWorkspace/
```

... then just build `samples/hello_world/` twice in disorderedWorkspace/ with any --board and compare the build directories.

cc:
- #14593