### PR TITLE
samples: drivers: mbox: fix nRF54H20 vevif/bellboard regexes

### DIFF
--- a/samples/drivers/mbox/sample.yaml
+++ b/samples/drivers/mbox/sample.yaml
@@ -42,7 +42,6 @@ tests:
       ordered: false
       regex:
         - "Ping \\(on channel 4\\)"
-        - "Pong \\(on channel 4\\)"
 
   sample.drivers.mbox.nrf54h20_bellboard:
     platform_allow:
@@ -61,7 +60,6 @@ tests:
       type: multi_line
       ordered: false
       regex:
-        - "Ping \\(on channel 0\\)"
         - "Pong \\(on channel 0\\)"
 
   sample.drivers.mbox.simu:


### PR DESCRIPTION
Both VEVIF and BELLBOARD test cases are unidirectional from the core executing the test (cpuapp). For VEVIF, cpuapp pings, and for BELLBOARD, cpuapp pongs.