### PR TITLE
doc: misc HTTP 404 fixes

### DIFF
--- a/boards/aconno/acn52832/doc/index.rst
+++ b/boards/aconno/acn52832/doc/index.rst
@@ -23,8 +23,7 @@ nRF52832 ARM Cortex-M4F CPU and the following devices:
 * :abbr:`UART (Universal asynchronous receiver-transmitter)`
 * :abbr:`WDT (Watchdog Timer)`
 
-See `acn52832 website`_ for more information about the board and `Nordic infocenter`_ for more
-information about the SoC.
+See `Nordic infocenter`_ for more information about the SoC.
 
 Hardware
 ********
@@ -130,5 +129,4 @@ References
 **********
 .. target-notes::
 
-.. _acn52832 website: https://aconno.de/products/acn52832/
 .. _Nordic infocenter: https://infocenter.nordicsemi.com/

--- a/boards/altr/max10/doc/index.rst
+++ b/boards/altr/max10/doc/index.rst
@@ -92,11 +92,11 @@ Reference CPU
 =============
 
 A reference CPU design of a Nios II/f core is included in the Zephyr tree
-in the :zephyr_file:`soc/altera/zephyr_nios2f/cpu` directory.
+in the :zephyr_file:`soc/altr/zephyr_nios2f/cpu` directory.
 
 Flash this CPU using the ``nios2-configure-sof`` SDK tool with the FPGA
 configuration file
-:zephyr_file:`soc/altera/zephyr_nios2f/cpu/ghrd_10m50da.sof`:
+:zephyr_file:`soc/altr/zephyr_nios2f/cpu/ghrd_10m50da.sof`:
 
 .. code-block:: console
 

--- a/boards/arduino/nicla_sense_me/doc/index.rst
+++ b/boards/arduino/nicla_sense_me/doc/index.rst
@@ -131,13 +131,13 @@ References
 .. target-notes::
 
 .. _Arduino Nicla Sense ME:
-    https://docs.arduino.cc/hardware/nicla-sense-me
+   https://docs.arduino.cc/hardware/nicla-sense-me
 
 .. _datasheet:
    https://docs.arduino.cc/resources/datasheets/ABX00050-datasheet.pdf
 
 .. _full pinout:
-    https://docs.arduino.cc/static/b35956b631d757a0455c286da441641b/ABX00050-full-pinout.pdf
+   https://docs.arduino.cc/resources/pinouts/ABX00050-full-pinout.pdf
 
 .. _schematics:
-    https://docs.arduino.cc/static/ebd652e859efba8536a7e275c79d5f79/ABX00050-schematics.pdf
+   https://docs.arduino.cc/resources/schematics/ABX00050-schematics.pdf

--- a/boards/brcm/bcm958401m2/doc/index.rst
+++ b/boards/brcm/bcm958401m2/doc/index.rst
@@ -32,7 +32,7 @@ features:
 Other hardware features have not been enabled yet for this board.
 
 The default configuration can be found in
-:zephyr_file:`boards/broadcom/bcm958401m2/bcm958401m2_defconfig`
+:zephyr_file:`boards/brcm/bcm958401m2/bcm958401m2_defconfig`
 
 Connections and IOs
 ===================

--- a/boards/brcm/bcm958402m2/doc/a72.rst
+++ b/boards/brcm/bcm958402m2/doc/a72.rst
@@ -32,7 +32,7 @@ hardware features:
 Other hardware features have not been enabled yet for this board.
 
 The default configuration can be found in
-:zephyr_file:`boards/broadcom/bcm958402m2/bcm958402m2_bcm58402_a72_defconfig`
+:zephyr_file:`boards/brcm/bcm958402m2/bcm958402m2_bcm58402_a72_defconfig`
 
 Programming and Debugging
 *************************

--- a/boards/brcm/bcm958402m2/doc/m7.rst
+++ b/boards/brcm/bcm958402m2/doc/m7.rst
@@ -32,7 +32,7 @@ hardware features:
 Other hardware features have not been enabled yet for this board.
 
 The default configuration can be found in
-:zephyr_file:`boards/broadcom/bcm958402m2/bcm958402m2_bcm58402_m7_defconfig`
+:zephyr_file:`boards/brcm/bcm958402m2/bcm958402m2_bcm58402_m7_defconfig`
 
 Programming and Debugging
 *************************

--- a/boards/ebyte/e73_tbb/doc/index.rst
+++ b/boards/ebyte/e73_tbb/doc/index.rst
@@ -218,5 +218,5 @@ References
 
 .. target-notes::
 
-.. _E73-TBB website: https://www.ebyte.com/en/product-view-news.html?id=889
+.. _E73-TBB website: https://www.cdebyte.com/products/E73-TBB
 .. _Nordic Semiconductor Infocenter: https://infocenter.nordicsemi.com

--- a/boards/intel/adsp/doc/chromebooks_adsp.rst
+++ b/boards/intel/adsp/doc/chromebooks_adsp.rst
@@ -408,7 +408,7 @@ Upstream documentation from which these instructions were drawn:
 
 This page has the best reference for the boot process:
 
-http://www.chromium.org/chromium-os/chromiumos-design-docs/disk-format
+https://www.chromium.org/chromium-os/developer-library/reference/device/disk-format
 
 This is great too, with an eye toward booting things other than ChromeOS:
 

--- a/boards/lairdconnect/bl652_dvk/doc/bl652_dvk.rst
+++ b/boards/lairdconnect/bl652_dvk/doc/bl652_dvk.rst
@@ -260,7 +260,7 @@ the board are working properly with Zephyr:
 
 You can build and flash the examples to make sure Zephyr is running correctly on
 your board. The button and LED definitions can be found in
-:zephyr_file:`boards/laird_connect/bl652_dvk/bl652_dvk.dts`.
+:zephyr_file:`boards/lairdconnect/bl652_dvk/bl652_dvk.dts`.
 
 References
 **********

--- a/boards/lairdconnect/bl653_dvk/doc/bl653_dvk.rst
+++ b/boards/lairdconnect/bl653_dvk/doc/bl653_dvk.rst
@@ -167,7 +167,7 @@ the board are working properly with Zephyr:
 
 You can build and flash the examples to make sure Zephyr is running correctly on
 your board. The button and LED definitions can be found in
-:zephyr_file:`boards/laird_connect/bl653_dvk/bl653_dvk.dts`.
+:zephyr_file:`boards/lairdconnect/bl653_dvk/bl653_dvk.dts`.
 
 Using UART1
 ***********

--- a/boards/lairdconnect/bl654_dvk/doc/bl654_dvk.rst
+++ b/boards/lairdconnect/bl654_dvk/doc/bl654_dvk.rst
@@ -173,7 +173,7 @@ the board are working properly with Zephyr:
 
 You can build and flash the examples to make sure Zephyr is running correctly on
 your board. The button and LED definitions can be found in
-:zephyr_file:`boards/laird_connect/bl654_dvk/bl654_dvk.dts`.
+:zephyr_file:`boards/lairdconnect/bl654_dvk/bl654_dvk.dts`.
 
 
 References

--- a/boards/lairdconnect/bl654_sensor_board/doc/bl654_sensor_board.rst
+++ b/boards/lairdconnect/bl654_sensor_board/doc/bl654_sensor_board.rst
@@ -238,7 +238,7 @@ the board are working properly with Zephyr:
 
 You can build and flash the examples to make sure Zephyr is running correctly on
 your board. The button and LED definitions can be found in
-:zephyr_file:`boards/laird_connect/bl654_sensor_board/bl654_sensor_board.dts`.
+:zephyr_file:`boards/lairdconnect/bl654_sensor_board/bl654_sensor_board.dts`.
 
 
 References

--- a/boards/lairdconnect/bl654_usb/doc/bl654_usb.rst
+++ b/boards/lairdconnect/bl654_usb/doc/bl654_usb.rst
@@ -105,7 +105,7 @@ Applications for the ``bl654_usb`` board configuration can be
 built in the usual way (see :ref:`build_an_application` for more details). The
 ``bl654_usb`` board cannot be used for debugging. The compatible BL654 DVK
 board can be used for development. Documentation can be found at the :ref:`bl654_dvk`
-site and :zephyr_file:`boards/laird_connect/bl654_dvk/doc/bl654_dvk.rst`
+site and :zephyr_file:`boards/lairdconnect/bl654_dvk/doc/bl654_dvk.rst`
 
 Flashing
 ========
@@ -175,7 +175,7 @@ the board is working properly with Zephyr:
 
 You can build and flash the example to make sure Zephyr is running correctly on
 your board. The LED definitions can be found in
-:zephyr_file:`boards/laird_connect/bl654_usb/bl654_usb.dts`.
+:zephyr_file:`boards/lairdconnect/bl654_usb/bl654_usb.dts`.
 
 
 References

--- a/boards/lairdconnect/bt510/doc/bt510.rst
+++ b/boards/lairdconnect/bt510/doc/bt510.rst
@@ -244,7 +244,7 @@ the board are working properly with Zephyr:
 
 You can build and flash the examples to make sure Zephyr is running correctly on
 your board. The button, LED and sensor device definitions can be found in
-:zephyr_file:`boards/laird_connect/bt510/bt510.dts`.
+:zephyr_file:`boards/lairdconnect/bt510/bt510.dts`.
 
 
 References

--- a/boards/lairdconnect/bt610/doc/bt610.rst
+++ b/boards/lairdconnect/bt610/doc/bt610.rst
@@ -598,7 +598,7 @@ on the board are working properly with Zephyr:
 
 You can build and flash the examples to make sure Zephyr is running correctly
 on your board. The button, LED and sensor device definitions can be found in
-:zephyr_file:`boards/laird_connect/bt610/bt610.dts`.
+:zephyr_file:`boards/lairdconnect/bt610/bt610.dts`.
 
 
 References

--- a/boards/lairdconnect/bt610/doc/bt610.rst
+++ b/boards/lairdconnect/bt610/doc/bt610.rst
@@ -612,4 +612,4 @@ References
 .. _TI TMUX1204 datasheet: https://www.ti.com/lit/gpn/TMUX1204
 .. _TI TCA9538 datasheet: https://www.ti.com/lit/gpn/TCA9538
 .. _Macronix MX25R6435FZNIL0 datasheet: https://www.macronix.com/Lists/Datasheet/Attachments/7913/MX25R6435F,%20Wide%20Range,%2064Mb,%20v1.5.pdf
-.. _BT610 Zephyr Application Thermistor Calibration: https://www.lairdconnect.com/documentation/application-note-bt610-zephyr-application-thermistor-calibration
+.. _BT610 Zephyr Application Thermistor Calibration: https://www.lairdconnect.com/technology/bt610-thermistor-coefficient-calculator

--- a/boards/lairdconnect/mg100/doc/index.rst
+++ b/boards/lairdconnect/mg100/doc/index.rst
@@ -231,7 +231,7 @@ the board are working properly with Zephyr:
 
 You can build and flash the examples to make sure Zephyr is running correctly on
 your board. The button and LED definitions can be found in
-:zephyr_file:`boards/laird_connect/mg100/mg100.dts`.
+:zephyr_file:`boards/lairdconnect/mg100/mg100.dts`.
 
 References
 **********

--- a/boards/nordic/nrf9160dk/doc/index.rst
+++ b/boards/nordic/nrf9160dk/doc/index.rst
@@ -250,7 +250,7 @@ the board are working properly with Zephyr:
 
 You can build and flash the examples to make sure Zephyr is running correctly on
 your board. The button and LED definitions can be found in
-:zephyr_file:`boards/nordic_nrf/nrf9160dk/nrf9160dk_nrf9160_common.dtsi`.
+:zephyr_file:`boards/nordic/nrf9160dk/nrf9160dk_nrf9160_common.dtsi`.
 
 .. _nrf9160dk_nrf52840:
 
@@ -498,8 +498,8 @@ following:
    };
 
 A few helper .dtsi files are provided in the directories
-:zephyr_file:`boards/nordic_nrf/nrf9160dk/dts/nrf52840` and
-:zephyr_file:`boards/nordic_nrf/nrf9160dk/dts/nrf9160`. They can serve as examples of
+:zephyr_file:`boards/nordic/nrf9160dk/dts/nrf52840` and
+:zephyr_file:`boards/nordic/nrf9160dk/dts/nrf9160`. They can serve as examples of
 how to configure and use the above routings. You can also include them from
 respective devicetree overlay files in your applications to conveniently
 configure the signal routing between nRF9160 and nRF52840 on the nRF9160 DK.

--- a/boards/nxp/lpcxpresso11u68/doc/index.rst
+++ b/boards/nxp/lpcxpresso11u68/doc/index.rst
@@ -109,7 +109,7 @@ probe (based on a NXP LPC43xx MCU). This MCU provides either a CMSIS-DAP or
 a J-Link interface. It depends on the embedded firmware image. The default
 OpenOCD configuration supports the CMSIS-DAP interface. If you want to
 switch to J-Link, then you need to edit the
-``boards/arm/lpcxpresso11u68/support/openocd.cfg`` file and to replace::
+:zephyr_file:`boards/nxp/lpcxpresso11u68/support/openocd.cfg` file and to replace::
 
    source [find interface/cmsis-dap.cfg]
 

--- a/boards/nxp/lpcxpresso55s28/doc/index.rst
+++ b/boards/nxp/lpcxpresso55s28/doc/index.rst
@@ -88,7 +88,7 @@ already supported, which can also be re-used on this lpcxpresso55s28 board:
 Other hardware features are not currently enabled.
 
 The default configuration file
-``boards/arm/lpcxpresso55s28/lpcxpresso55s28_defconfig``
+:zephyr_file:`boards/nxp/lpcxpresso55s28/lpcxpresso55s28_defconfig`
 
 Connections and IOs
 ===================

--- a/boards/nxp/lpcxpresso55s69/doc/index.rst
+++ b/boards/nxp/lpcxpresso55s69/doc/index.rst
@@ -108,7 +108,7 @@ Targets available
 ==================
 
 The default configuration file
-``boards/arm/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0_defconfig``
+:zephyr_file:`boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0_defconfig`
 only enables the first core.
 CPU0 is the only target that can run standalone.
 

--- a/boards/nxp/mimxrt1010_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1010_evk/doc/index.rst
@@ -102,7 +102,7 @@ already supported, which can also be re-used on this mimxrt1010_evk board:
 +-----------+------------+-------------------------------------+
 
 The default configuration can be found in the defconfig file:
-``boards/arm/mimxrt1010_evk/mimxrt1010_evk_defconfig``
+:zephyr_file:`boards/nxp/mimxrt1010_evk/mimxrt1010_evk_defconfig`
 
 Other hardware features are not currently supported by the port.
 

--- a/boards/nxp/mimxrt1015_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1015_evk/doc/index.rst
@@ -100,7 +100,7 @@ already supported, which can also be re-used on this mimxrt1015_evk board:
 +-----------+------------+-------------------------------------+
 
 The default configuration can be found in the defconfig file:
-``boards/arm/mimxrt1015_evk/mimxrt1015_evk_defconfig``
+:zephyr_file:`boards/nxp/mimxrt1015_evk/mimxrt1015_evk_defconfig`
 
 Other hardware features are not currently supported by the port.
 

--- a/boards/nxp/mimxrt1020_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1020_evk/doc/index.rst
@@ -120,7 +120,7 @@ already supported, which can also be re-used on this mimxrt1020_evk board:
 +-----------+------------+-------------------------------------+
 
 The default configuration can be found in the defconfig file:
-``boards/arm/mimxrt1020_evk/mimxrt1020_evk_defconfig``
+:zephyr_file:`boards/nxp/mimxrt1020_evk/mimxrt1020_evk_defconfig`
 
 Other hardware features are not currently supported by the port.
 

--- a/boards/nxp/mimxrt1024_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1024_evk/doc/index.rst
@@ -125,7 +125,7 @@ already supported, which can also be re-used on this mimxrt1024_evk board:
 +-----------+------------+-------------------------------------+
 
 The default configuration can be found in the defconfig file:
-``boards/arm/mimxrt1024_evk/mimxrt1024_evk_defconfig``
+:zephyr_file:`boards/nxp/mimxrt1024_evk/mimxrt1024_evk_defconfig`
 
 Other hardware features are not currently supported by the port.
 

--- a/boards/nxp/mimxrt1040_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1040_evk/doc/index.rst
@@ -121,7 +121,7 @@ already supported, which can also be re-used on this mimxrt1040_evk board:
 
 The default configuration can be found in the defconfig file:
 
-	``boards/arm/mimxrt1040_evk/mimxrt1040_evk_defconfig``
+	:zephyr_file:`boards/nxp/mimxrt1040_evk/mimxrt1040_evk_defconfig`
 
 Other hardware features are not currently supported by the port.
 

--- a/boards/nxp/mimxrt1050_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1050_evk/doc/index.rst
@@ -147,7 +147,7 @@ already supported, which can also be re-used on this mimxrt1050_evk board:
 
 The default configuration can be found in the defconfig file:
 
-	``boards/arm/mimxrt1050_evk/mimxrt1050_evk_defconfig``
+	:zephyr_file:`boards/nxp/mimxrt1050_evk/mimxrt1050_evk_defconfig`
 
 Other hardware features are not currently supported by the port.
 

--- a/boards/nxp/mimxrt1060_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1060_evk/doc/index.rst
@@ -154,7 +154,7 @@ already supported, which can also be re-used on this mimxrt1060_evk board:
 +-----------+------------+-------------------------------------+
 
 The default configuration can be found in the defconfig file:
-``boards/arm/mimxrt1060_evk/mimxrt1060_evk_defconfig``
+:zephyr_file:`boards/nxp/mimxrt1060_evk/mimxrt1060_evk_defconfig`
 
 Other hardware features are not currently supported by the port.
 

--- a/boards/nxp/mimxrt1062_fmurt6/doc/index.rst
+++ b/boards/nxp/mimxrt1062_fmurt6/doc/index.rst
@@ -122,7 +122,7 @@ already supported, which can also be re-used on this mimxrt1060_evk board:
 +-----------+------------+-------------------------------------+
 
 The default configuration can be found in the defconfig file:
-``boards/arm/mimxrt1062_fmurt6/mimxrt1062_fmurt6_defconfig``
+:zephyr_file:`boards/nxp/mimxrt1062_fmurt6/mimxrt1062_fmurt6_defconfig`
 
 Other hardware features are not currently supported by the port.
 

--- a/boards/nxp/mimxrt1064_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1064_evk/doc/index.rst
@@ -152,7 +152,7 @@ configuration supports the following hardware features:
 +-----------+------------+-------------------------------------+
 
 The default configuration can be found in the defconfig file:
-``boards/arm/mimxrt1064_evk/mimxrt1064_evk_defconfig``
+:zephyr_file:`boards/nxp/mimxrt1064_evk/mimxrt1064_evk_defconfig`
 
 Other hardware features are not currently supported by the port.
 

--- a/boards/nxp/mimxrt685_evk/doc/index.rst
+++ b/boards/nxp/mimxrt685_evk/doc/index.rst
@@ -111,7 +111,7 @@ already supported, which can also be re-used on this mimxrt685_evk board:
 
 The default configuration can be found in the defconfig file:
 
-	``boards/arm/mimxrt685_evk/mimxrt685_evk_defconfig``
+	:zephyr_file:`boards/nxp/mimxrt685_evk/mimxrt685_evk_defconfig`
 
 Other hardware features are not currently supported by the port.
 

--- a/boards/nxp/vmu_rt1170/doc/index.rst
+++ b/boards/nxp/vmu_rt1170/doc/index.rst
@@ -125,7 +125,7 @@ following hardware features:
 +-----------+------------+-------------------------------------+
 
 The default configuration can be found in the defconfig file:
-``boards/arm/vmu_rt1170/vmu_rt1170_defconfig``
+:zephyr_file:`boards/nxp/vmu_rt1170/vmu_rt1170_defconfig`
 
 Other hardware features are not currently supported by the port.
 

--- a/boards/pjrc/teensy4/doc/index.rst
+++ b/boards/pjrc/teensy4/doc/index.rst
@@ -69,7 +69,7 @@ features:
 
 
 The default configuration can be found in the defconfig file:
-``boards/arm/teensy4/teensy40_defconfig``
+:zephyr_file:`boards/pjrc/teensy4/teensy40_defconfig`
 
 
 The teensy41 board configuration supports additional hardware
@@ -85,7 +85,7 @@ features:
 
 
 The default configuration can be found in the defconfig file:
-``boards/arm/teensy4/teensy41_defconfig``
+:zephyr_file:`boards/pjrc/teensy4/teensy41_defconfig`
 
 Other hardware features are not currently supported by the port.
 

--- a/boards/qorvo/decawave_dwm1001_dev/doc/index.rst
+++ b/boards/qorvo/decawave_dwm1001_dev/doc/index.rst
@@ -11,8 +11,9 @@ connector and charging circuit, LEDs, buttons, Raspberry-Pi and USB
 connector. In addition, the board comes with J-Link OB adding
 debugging and Virtual COM Port capabilities.
 
-See `Decawave DWM1001-DEV website`_ for more information about the development
-board, `Decawave DWM1001 website`_ about the board itself, and `nRF52832 website`_ for the official reference on the IC itself.
+See `Qorvo (Decawave) DWM1001-DEV website`_ for more information about the development
+board, `Qorvo (Decawave) DWM1001 website`_ about the board itself, and `nRF52832 website`_ for the
+official reference on the IC itself.
 
 Programming and Debugging
 *************************
@@ -53,5 +54,5 @@ References
 .. target-notes::
 
 .. _nRF52832 website: https://www.nordicsemi.com/Products/Low-power-short-range-wireless/nRF52832
-.. _Decawave DWM1001 website: https://www.decawave.com/product/dwm1001-module
-.. _Decawave DWM1001-DEV website: https://www.decawave.com/product/dwm1001-development-board
+.. _Qorvo (Decawave) DWM1001 website: https://www.qorvo.com/products/p/DWM1001C
+.. _Qorvo (Decawave) DWM1001-DEV website: https://www.qorvo.com/products/p/DWM1001-DEV

--- a/boards/raspberrypi/rpi_4b/doc/index.rst
+++ b/boards/raspberrypi/rpi_4b/doc/index.rst
@@ -35,7 +35,7 @@ hardware features:
 Other hardware features have not been enabled yet for this board.
 
 The default configuration can be found in
-:zephyr_file:`boards/raspberry_pi/rpi_4b/rpi_4b_defconfig`
+:zephyr_file:`boards/raspberrypi/rpi_4b/rpi_4b_defconfig`
 
 Programming and Debugging
 *************************

--- a/boards/renesas/rcar_h3ulcb/doc/rcar_h3ulcb_a57.rst
+++ b/boards/renesas/rcar_h3ulcb/doc/rcar_h3ulcb_a57.rst
@@ -62,7 +62,7 @@ hardware features:
 Other hardware features have not been enabled yet for this board.
 
 The default configuration can be found in
-:zephyr_file:`boards/renesas/rcar_h3ulcb/rcar_h3ulcb_r8a77951_a57_defconfig``
+:zephyr_file:`boards/renesas/rcar_h3ulcb/rcar_h3ulcb_r8a77951_a57_defconfig`
 
 Programming and Debugging
 *************************

--- a/boards/seagate/faze/doc/index.rst
+++ b/boards/seagate/faze/doc/index.rst
@@ -102,7 +102,7 @@ Flashing
 
 The NXP LPC11U67 MCU can be flashed by connecting an external debug probe to
 the SWD port (on-board 4-pins J2 header). In the default OpenOCD configuration
-(``boards/arm/faze/support/openocd.cfg``) the ST Link interface is selected.
+(:zephyr_file:`boards/seagate/faze/support/openocd.cfg`) the ST Link interface is selected.
 You may need to replace it with the interface of your debug probe.
 
 Once the debug probe is connected to both the FaZe board and your host computer

--- a/boards/seeed/lora_e5_mini/doc/index.rst
+++ b/boards/seeed/lora_e5_mini/doc/index.rst
@@ -102,8 +102,8 @@ Other hardware features are not yet supported on this Zephyr port.
 
 The default configuration can be found in:
 
-- :zephyr_file:`boards/seeed_studio/lora_e5_mini/lora_e5_mini_defconfig`
-- :zephyr_file:`boards/seeed_studio/lora_e5_mini/lora_e5_mini.dts`
+- :zephyr_file:`boards/seeed/lora_e5_mini/lora_e5_mini_defconfig`
+- :zephyr_file:`boards/seeed/lora_e5_mini/lora_e5_mini.dts`
 
 
 Connections and IOs

--- a/boards/seeed/seeeduino_xiao/doc/index.rst
+++ b/boards/seeed/seeeduino_xiao/doc/index.rst
@@ -59,7 +59,7 @@ features:
 Other hardware features are not currently supported by Zephyr.
 
 The default configuration can be found in the Kconfig file
-:zephyr_file:`boards/seeed_studio/seeeduino_xiao/seeeduino_xiao_defconfig`.
+:zephyr_file:`boards/seeed/seeeduino_xiao/seeeduino_xiao_defconfig`.
 
 Connections and IOs
 ===================

--- a/boards/seeed/wio_terminal/doc/index.rst
+++ b/boards/seeed/wio_terminal/doc/index.rst
@@ -92,7 +92,7 @@ The wio_terminal board configuration supports the following hardware features:
 Other hardware features are not currently supported by Zephyr.
 
 The default configuration can be found in the Kconfig file
-:zephyr_file:`boards/seeed_studio/wio_terminal/wio_terminal_defconfig`.
+:zephyr_file:`boards/seeed/wio_terminal/wio_terminal_defconfig`.
 
 Zephyr can use the default Cortex-M SYSTICK timer or the SAM0 specific RTC.
 To use the RTC, set :kconfig:option:`CONFIG_CORTEX_M_SYSTICK=n` and set

--- a/boards/seeed/xiao_ble/doc/index.rst
+++ b/boards/seeed/xiao_ble/doc/index.rst
@@ -182,7 +182,7 @@ properly with Zephyr:
 
 You can build and flash the examples to make sure Zephyr is running correctly on
 your board. The LED definitions can be found in
-:zephyr_file:`boards/seeed_studio/xiao_ble/xiao_ble_common.dtsi`.
+:zephyr_file:`boards/seeed/xiao_ble/xiao_ble_common.dtsi`.
 
 Testing shell over USB in the XIAO BLE (Sense)
 **********************************************

--- a/boards/shields/mcp2515/doc/index.rst
+++ b/boards/shields/mcp2515/doc/index.rst
@@ -374,7 +374,7 @@ example:
    https://www.microchip.com/en-us/product/MCP2515
 
 .. _Keyestudio Website:
-   https://www.keyestudio.com/products/2019new-keyestudio-can-bus-shield-mcp2551-chip-with-sd-socket-for-arduino-uno-r3
+   https://www.keyestudio.com/2019new-keyestudio-can-bus-shield-mcp2551-chip-with-sd-socket-for-arduino-uno-r3-p0543.html
 
 .. _Keyestudio Wiki:
    https://wiki.keyestudio.com/KS0411_keyestudio_CAN-BUS_Shield

--- a/boards/silabs/efr32_radio/doc/brd4187c.rst
+++ b/boards/silabs/efr32_radio/doc/brd4187c.rst
@@ -97,7 +97,7 @@ means Pin number 2 on PORTA, as used in the board's datasheets and manuals.
 +-------+-------------+-------------------------------------+
 
 The default configuration can be found in
-:zephyr_file:`boards/silabs/efr32_radio/efr32_radio_efr32mg24b220f1536im48_defconfig``
+:zephyr_file:`boards/silabs/efr32_radio/efr32_radio_efr32mg24b220f1536im48_defconfig`
 
 System Clock
 ============

--- a/boards/silabs/efr32mg_sltb004a/doc/index.rst
+++ b/boards/silabs/efr32mg_sltb004a/doc/index.rst
@@ -83,7 +83,7 @@ The efr32mg_sltb004a board configuration supports the following hardware feature
 +-----------+------------+-------------------------------------+
 
 The default configuration can be found in
-:zephyr_file:`boards/silabs/efr32mg_sltb004a/efr32mg_sltb004a_defconfig``
+:zephyr_file:`boards/silabs/efr32mg_sltb004a/efr32mg_sltb004a_defconfig`
 
 Other hardware features are currently not supported by the port.
 

--- a/boards/st/nucleo_h723zg/doc/index.rst
+++ b/boards/st/nucleo_h723zg/doc/index.rst
@@ -119,7 +119,7 @@ features:
 Other hardware features are not yet supported on this Zephyr port.
 
 The default configuration can be found in the defconfig files:
-:zephyr_file:`boards/st/nucleo_h723zg/nucleo_h723zg_defconfig``
+:zephyr_file:`boards/st/nucleo_h723zg/nucleo_h723zg_defconfig`
 
 For more details please refer to `STM32 Nucleo-144 board User Manual`_.
 

--- a/boards/u-blox/ubx_bmd300eval/doc/index.rst
+++ b/boards/u-blox/ubx_bmd300eval/doc/index.rst
@@ -387,7 +387,7 @@ There are 2 samples that allow you to test that the buttons
 
 You can build and flash the examples to make sure Zephyr is
 running correctly on your board. The button and LED definitions
-can be found in :zephyr_file:`boards/ublox/ubx_bmd300eval/ubx_bmd300eval_nrf52832.dts`.
+can be found in :zephyr_file:`boards/u-blox/ubx_bmd300eval/ubx_bmd300eval_nrf52832.dts`.
 
 References
 **********

--- a/boards/u-blox/ubx_bmd330eval/doc/index.rst
+++ b/boards/u-blox/ubx_bmd330eval/doc/index.rst
@@ -378,7 +378,7 @@ There are 2 samples that allow you to test that the buttons
 
 You can build and flash the examples to make sure Zephyr is
 running correctly on your board. The button and LED definitions
-can be found in :zephyr_file:`boards/ublox/ubx_bmd330eval/ubx_bmd330eval_nrf52810.dts`.
+can be found in :zephyr_file:`boards/u-blox/ubx_bmd330eval/ubx_bmd330eval_nrf52810.dts`.
 
 References
 **********

--- a/boards/u-blox/ubx_bmd340eval/doc/index.rst
+++ b/boards/u-blox/ubx_bmd340eval/doc/index.rst
@@ -448,7 +448,7 @@ There are 2 samples that allow you to test that the buttons
 You can build and flash the examples to make sure Zephyr is running
 correctly on your board. The button and LED definitions can be found
 in
-:zephyr_file:`boards/ublox/ubx_bmd340eval/ubx_bmd340eval_nrf52840.dts`.
+:zephyr_file:`boards/u-blox/ubx_bmd340eval/ubx_bmd340eval_nrf52840.dts`.
 
 Using UART1
 ***********

--- a/boards/u-blox/ubx_bmd345eval/doc/index.rst
+++ b/boards/u-blox/ubx_bmd345eval/doc/index.rst
@@ -460,7 +460,7 @@ There are 2 samples that allow you to test that the buttons
 You can build and flash the examples to make sure Zephyr is running
 correctly on your board. The button and LED definitions can be found
 in
-:zephyr_file:`boards/ublox/ubx_bmd345eval/ubx_bmd345eval_nrf52840.dts`.
+:zephyr_file:`boards/u-blox/ubx_bmd345eval/ubx_bmd345eval_nrf52840.dts`.
 
 Using UART1
 ***********

--- a/boards/u-blox/ubx_bmd360eval/doc/index.rst
+++ b/boards/u-blox/ubx_bmd360eval/doc/index.rst
@@ -376,7 +376,7 @@ There are 2 samples that allow you to test that the buttons
 
 You can build and flash the examples to make sure Zephyr is
 running correctly on your board. The button and LED definitions
-can be found in :zephyr_file:`boards/ublox/ubx_bmd360eval/ubx_bmd360eval_nrf52811.dts`.
+can be found in :zephyr_file:`boards/u-blox/ubx_bmd360eval/ubx_bmd360eval_nrf52811.dts`.
 
 References
 **********

--- a/boards/u-blox/ubx_bmd380eval/doc/index.rst
+++ b/boards/u-blox/ubx_bmd380eval/doc/index.rst
@@ -445,7 +445,7 @@ There are 2 samples that allow you to test that the buttons
 
 You can build and flash the examples to make sure Zephyr is running
 correctly on your board. The button and LED definitions can be found in
-:zephyr_file:`boards/ublox/ubx_bmd340eval/ubx_bmd340eval_nrf52840.dts`.
+:zephyr_file:`boards/u-blox/ubx_bmd340eval/ubx_bmd340eval_nrf52840.dts`.
 
 Using UART1
 ***********

--- a/boards/u-blox/ubx_evkannab1/doc/index.rst
+++ b/boards/u-blox/ubx_evkannab1/doc/index.rst
@@ -150,7 +150,7 @@ and LEDs on the board are working properly with Zephyr:
 
 You can build and flash the examples to make sure Zephyr is running
 correctly on your board. The button and LED definitions can be found in
-:zephyr_file:`boards/ublox/ubx_evkannab1/ubx_evkannab1_nrf52832.dts`.
+:zephyr_file:`boards/u-blox/ubx_evkannab1/ubx_evkannab1_nrf52832.dts`.
 
 Note that the buttons on the EVK-ANNA-B1 are marked SW1 and SW2, which
 are named sw0 and sw1 in the dts file.

--- a/boards/u-blox/ubx_evkninab1/doc/index.rst
+++ b/boards/u-blox/ubx_evkninab1/doc/index.rst
@@ -158,7 +158,7 @@ and LEDs on the board are working properly with Zephyr:
 
 You can build and flash the examples to make sure Zephyr is running
 correctly on your board. The button and LED definitions can be found in
-:zephyr_file:`boards/ublox/ubx_evkninab1/ubx_evkninab1_nrf52832.dts`.
+:zephyr_file:`boards/u-blox/ubx_evkninab1/ubx_evkninab1_nrf52832.dts`.
 
 Note that the buttons on the EVK-NINA-B1 are marked SW1 and SW2, which
 are named sw0 and sw1 in the dts file.

--- a/boards/u-blox/ubx_evkninab3/doc/index.rst
+++ b/boards/u-blox/ubx_evkninab3/doc/index.rst
@@ -261,7 +261,7 @@ There are 2 samples that allow you to test that the buttons
 
 You can build and flash the examples to make sure Zephyr is running correctly on
 your board. The button and LED definitions can be found in
-:zephyr_file:`boards/ublox/ubx_evkninab3/ubx_evkninab3_nrf52840.dts`.
+:zephyr_file:`boards/u-blox/ubx_evkninab3/ubx_evkninab3_nrf52840.dts`.
 
 Using UART1
 ***********

--- a/boards/u-blox/ubx_evkninab4/doc/index.rst
+++ b/boards/u-blox/ubx_evkninab4/doc/index.rst
@@ -153,7 +153,7 @@ and LEDs on the board are working properly with Zephyr:
 
 You can build and flash the examples to make sure Zephyr is running
 correctly on your board. The button and LED definitions can be found in
-:zephyr_file:`boards/ublox/ubx_evkninab4/ubx_evkninab4_nrf52833.dts`.
+:zephyr_file:`boards/u-blox/ubx_evkninab4/ubx_evkninab4_nrf52833.dts`.
 
 Note that the buttons on the EVK-NINA-B4 are marked SW1 and SW2, which
 are named sw0 and sw1 in the dts file.

--- a/boards/we/proteus2ev/doc/index.rst
+++ b/boards/we/proteus2ev/doc/index.rst
@@ -150,7 +150,7 @@ the board are working properly with Zephyr:
 
 You can build and flash the examples to make sure Zephyr is running correctly on
 your board. The button and LED definitions can be found in
-:zephyr_file:`boards/wurth_elektronik/proteus2ev/we_proteus2ev_nrf52832.dts`.
+:zephyr_file:`boards/we/proteus2ev/we_proteus2ev_nrf52832.dts`.
 
 References
 **********

--- a/boards/we/proteus3ev/doc/index.rst
+++ b/boards/we/proteus3ev/doc/index.rst
@@ -151,7 +151,7 @@ LEDs on the board are working properly with Zephyr:
 
 You can build and flash the examples to make sure Zephyr is running correctly
 on your board. The button and LED definitions can be found in
-:zephyr_file:`boards/wurth_elektronik/proteus3ev/we_proteus3ev_nrf52840.dts`.
+:zephyr_file:`boards/we/proteus3ev/we_proteus3ev_nrf52840.dts`.
 
 References
 **********

--- a/doc/build/dts/intro-input-output.rst
+++ b/doc/build/dts/intro-input-output.rst
@@ -34,7 +34,7 @@ The devicetree files inside the :file:`zephyr` directory look like this:
 
 Generally speaking, every supported board has a :file:`BOARD.dts` file
 describing its hardware. For example, the ``reel_board`` has
-:zephyr_file:`boards/arm/reel_board/reel_board.dts`.
+:zephyr_file:`boards/phytec/reel_board/reel_board.dts`.
 
 :file:`BOARD.dts` includes one or more ``.dtsi`` files. These ``.dtsi`` files
 describe the CPU or system-on-chip Zephyr runs on, perhaps by including other

--- a/doc/connectivity/bluetooth/api/shell/cap.rst
+++ b/doc/connectivity/bluetooth/api/shell/cap.rst
@@ -39,7 +39,7 @@ Setting a new SIRK
 ------------------
 
 This command can modify the currently used SIRK. To get the new RSI to advertise on air,
-:code:`bt adv-data`` or :code:`bt advertise` must be called again to set the new advertising data.
+:code:`bt adv-data` or :code:`bt advertise` must be called again to set the new advertising data.
 If :code:`CONFIG_BT_CSIP_SET_MEMBER_NOTIFIABLE` is enabled, this will also notify connected
 clients.
 

--- a/doc/connectivity/bluetooth/api/shell/csip.rst
+++ b/doc/connectivity/bluetooth/api/shell/csip.rst
@@ -169,7 +169,7 @@ Setting a new SIRK
 ------------------
 
 This command can modify the currently used SIRK. To get the new RSI to advertise on air,
-:code:`bt adv-data`` or :code:`bt advertise` must be called again to set the new advertising data.
+:code:`bt adv-data` or :code:`bt advertise` must be called again to set the new advertising data.
 If :code:`CONFIG_BT_CSIP_SET_MEMBER_NOTIFIABLE` is enabled, this will also notify connected
 clients.
 

--- a/doc/contribute/documentation/guidelines.rst
+++ b/doc/contribute/documentation/guidelines.rst
@@ -263,12 +263,12 @@ markup (double backticks) to indicate a ``filename``.
 For references to files that are in the Zephyr GitHub tree, a special
 role can be used that creates a hyperlink to that file.  For example a
 reference to the reST file used to create this document can be generated
-using ``:zephyr_file:`doc/contribute/documentation/index.rst```  that will
-show up as :zephyr_file:`doc/contribute/documentation/index.rst`, a link to
+using ``:zephyr_file:`doc/contribute/documentation/guidelines.rst```  that will
+show up as :zephyr_file:`doc/contribute/documentation/guidelines.rst`, a link to
 the "blob" file in the github repo.  There's also a
-``:zephyr_raw:`doc/guides/documentation/index.rst``` role that will
+``:zephyr_raw:`doc/contribute/documentation/guidelines.rst``` role that will
 link to the "raw" content,
-:zephyr_raw:`doc/contribute/documentation/index.rst`. (You can click on
+:zephyr_raw:`doc/contribute/documentation/guidelines.rst`. (You can click on
 these links to see the difference.)
 
 .. _internal-linking:

--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -170,7 +170,7 @@ The current minimum required version for the main dependencies are:
       #. `Install chocolatey`_.
 
       #. Open a ``cmd.exe`` terminal window as **Administrator**. To do so, press the Windows key,
-         type ``cmd.exe``, right-click the :guilabel:`Command Prompt`` search result, and choose
+         type ``cmd.exe``, right-click the :guilabel:`Command Prompt` search result, and choose
          :guilabel:`Run as Administrator`.
 
       #. Disable global confirmation to avoid having to confirm the

--- a/doc/hardware/porting/board_porting.rst
+++ b/doc/hardware/porting/board_porting.rst
@@ -448,8 +448,8 @@ This section contains concrete examples related to writing your board's
 devicetree.
 
 The FRDM-K64F and Hexiwear K64 board devicetrees are defined in
-:zephyr_file:`frdm_k64fs.dts <boards/arm/frdm_k64f/frdm_k64f.dts>` and
-:zephyr_file:`hexiwear_k64.dts <boards/arm/hexiwear_k64/hexiwear_k64.dts>`
+:zephyr_file:`frdm_k64fs.dts <boards/nxp/frdm_k64f/frdm_k64f.dts>` and
+:zephyr_file:`hexiwear_k64.dts <boards/nxp/hexiwear/hexiwear_mk64f12.dts>`
 respectively. Both boards have NXP SoCs from the same Kinetis SoC family, the
 K6X.
 

--- a/samples/drivers/ht16k33/README.rst
+++ b/samples/drivers/ht16k33/README.rst
@@ -40,4 +40,4 @@ References
 
 .. target-notes::
 
-.. _Holtek HT16K33: http://www.holtek.com/productdetail/-/vg/HT16K33
+.. _Holtek HT16K33: https://www.holtek.com/page/vg/HT16K33A

--- a/samples/sensor/adt7420/README.rst
+++ b/samples/sensor/adt7420/README.rst
@@ -18,7 +18,7 @@ upper and lower window boundaries.
 References
 **********
 
- - ADT7420: http://www.analog.com/adt7420
+ - ADT7420: https://www.analog.com/adt7420
 
 Wiring
 *******


### PR DESCRIPTION
This fixes dozens of dead links, either due to forgotten renames during hwmv2 migration, or just plain dead links to discontinued products etc.

Still quite a few to go through but since it will already ping a lot of folks due to touching many files, it might not be a bad idea to follow up with more PRs in the future.