### PR TITLE
dts: nrf54h20: correct nRF54H20 configuration with missing grtc, dppic, ipct items

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
@@ -60,9 +60,6 @@
 
 &grtc {
 	status = "okay";
-	child-owned-channels = <8 9 10 11 12>;
-	nonsecure-channels = <8 9 10 11 12>;
-	owned-channels = <7 8 9 10 11 12 13 14>;
 };
 
 &uart135 {

--- a/dts/arm/nordic/nrf54h20_cpurad.dtsi
+++ b/dts/arm/nordic/nrf54h20_cpurad.dtsi
@@ -54,3 +54,23 @@ cpuppr_vevif: &cpuppr_vevif_remote {};
 		     <109 NRF_DEFAULT_IRQ_PRIORITY>,
 		     <110 NRF_DEFAULT_IRQ_PRIORITY>;
 };
+
+&dppic130 {
+	owned-channels = <0>;
+	sink-channels = <0>;
+	nonsecure-channels = <0>;
+	status = "okay";
+};
+
+&dppic132 {
+	owned-channels = <0>;
+	source-channels = <0>;
+	nonsecure-channels = <0>;
+	status = "okay";
+};
+
+&ipct130 {
+	owned-channels = <0>;
+	source-channel-links = <0 3 0>;
+	status = "okay";
+};

--- a/dts/arm/nordic/nrf54h20_cpurad.dtsi
+++ b/dts/arm/nordic/nrf54h20_cpurad.dtsi
@@ -47,6 +47,10 @@ cpuppr_vevif: &cpuppr_vevif_remote {};
 };
 
 &grtc {
+	owned-channels = <7 8 9 10 11 12 13 14>;
+	child-owned-channels = <8 9 10 11 12>;
+	nonsecure-channels = <8 9 10 11 12>;
 	interrupts = <109 NRF_DEFAULT_IRQ_PRIORITY>,
-		     <108 NRF_DEFAULT_IRQ_PRIORITY>;
+		     <109 NRF_DEFAULT_IRQ_PRIORITY>,
+		     <110 NRF_DEFAULT_IRQ_PRIORITY>;
 };


### PR DESCRIPTION
Move GRTC channel allocation and IRQs for nRF54h20 radio core to SOC DTS files. The configuration is not board specific but SOC specific.
Add missing global DPPIC, IPCT configuration of channels for nRF54H20 radio domain to allow delivery of events from global peripherals like GRTC.