### PR TITLE
llext: symbol.h: Add explicit typecast to `EXPORT_SYMBOL` macros

### DIFF
--- a/include/zephyr/llext/symbol.h
+++ b/include/zephyr/llext/symbol.h
@@ -76,12 +76,12 @@ struct llext_symtable {
  */
 #define EXPORT_SYMBOL(x)							\
 	static const STRUCT_SECTION_ITERABLE(llext_const_symbol, x ## _sym) = {	\
-		.name = STRINGIFY(x), .addr = &x,				\
+		.name = STRINGIFY(x), .addr = (const void *)&x,			\
 	}
 
 #define LL_EXTENSION_SYMBOL(x)							\
 	struct llext_symbol Z_GENERIC_SECTION(".exported_sym") __used		\
-		symbol_##x = {STRINGIFY(x), &x}
+		symbol_##x = {STRINGIFY(x), (void *)&x}
 
 /**
  * @brief Export a system call to a table of symbols


### PR DESCRIPTION
Some compilers (especially C++ compilers) will complain with invalid conversion (-fpermissive) if the void pointers are not explicitly typecast. This PR adds said typecast.