### PR TITLE
manifest: hal_silabs: update module

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -219,7 +219,7 @@ manifest:
       groups:
         - hal
     - name: hal_silabs
-      revision: 59c6c6e2e8862f0ff5c6087ef055793bed125778
+      revision: 442d0fb1d02cc4b2bb159fbff378029998b89049
       path: modules/hal/silabs
       groups:
         - hal


### PR DESCRIPTION
Brings the following fix:
gecko/cmake: replace `SOC_GECKO_SERIESx` with `SOC_FAMILY_SILABS_Sx`

Fixes: #69902