### PR TITLE
Bluetooth: Controller: Fix Broadcast ISO context get function

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
@@ -1002,7 +1002,7 @@ static int init_reset(void)
 
 static struct ll_adv_iso_set *adv_iso_get(uint8_t handle)
 {
-	if (handle >= CONFIG_BT_CTLR_ADV_SET) {
+	if (handle >= CONFIG_BT_CTLR_ADV_ISO_SET) {
 		return NULL;
 	}
 


### PR DESCRIPTION
Fix Broadcast ISO context get function for out-of-bound access.