### PR TITLE
drivers: sensor: qdec_stm32: fix inverted polarity

### DIFF
--- a/drivers/sensor/qdec_stm32/qdec_stm32.c
+++ b/drivers/sensor/qdec_stm32/qdec_stm32.c
@@ -108,8 +108,8 @@ static int qdec_stm32_initialize(const struct device *dev)
 	LL_TIM_ENCODER_StructInit(&init_props);
 
 	if (dev_cfg->is_input_polarity_inverted) {
-		init_props.IC1ActiveInput = LL_TIM_IC_POLARITY_FALLING;
-		init_props.IC2ActiveInput = LL_TIM_IC_POLARITY_FALLING;
+		init_props.IC1Polarity = LL_TIM_IC_POLARITY_FALLING;
+		init_props.IC2Polarity = LL_TIM_IC_POLARITY_FALLING;
 	}
 
 	init_props.IC1Filter = dev_cfg->input_filtering_level * LL_TIM_IC_FILTER_FDIV1_N2;


### PR DESCRIPTION
Use the Polarity member instead of the ActivityInput.