### PR TITLE
drivers: bluetooth: hci: Apply workaround for HW anomaly on nRF53

### DIFF
--- a/drivers/bluetooth/hci/nrf53_support.c
+++ b/drivers/bluetooth/hci/nrf53_support.c
@@ -6,6 +6,7 @@
 
 #include <soc.h>
 #include <zephyr/device.h>
+#include <hal/nrf_reset.h>
 #if defined(CONFIG_BT_CTLR_DEBUG_PINS_CPUAPP)
 #include <../subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/debug.h>
 #else
@@ -19,9 +20,9 @@ LOG_MODULE_REGISTER(bt_hci_nrf53_support);
 int bt_hci_transport_teardown(const struct device *dev)
 {
 	ARG_UNUSED(dev);
-    /* Put core into reset */
-	NRF_RESET->NETWORK.FORCEOFF = RESET_NETWORK_FORCEOFF_FORCEOFF_Hold;
-	LOG_DBG("Network MCU reseted.");
+    /* Put the Network MCU in Forced-OFF mode. */
+	nrf_reset_network_force_off(NRF_RESET, true);
+	LOG_DBG("Network MCU placed in Forced-OFF mode");
 
 	return 0;
 }
@@ -41,7 +42,8 @@ int bt_hci_transport_setup(const struct device *dev)
 	NRF_SPU->EXTDOMAIN[0].PERM = 1 << 4;
 #endif /* !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) */
 
-	NRF_RESET->NETWORK.FORCEOFF = RESET_NETWORK_FORCEOFF_FORCEOFF_Release;
+	/* Release the Network MCU, 'Release force off signal' */
+	nrf_reset_network_force_off(NRF_RESET, false);
 
 	return 0;
 }


### PR DESCRIPTION
Use the nrf_reset_network_force_off() function to release and set the force-off signal.This ensures that the workaround for errata 161 is applied.