### PR TITLE
drivers: watchdog: wdt_nrfx.c: Fix error code value

### DIFF
--- a/drivers/watchdog/wdt_nrfx.c
+++ b/drivers/watchdog/wdt_nrfx.c
@@ -65,7 +65,8 @@ static int wdt_nrf_disable(const struct device *dev)
 	err_code = nrfx_wdt_stop(&config->wdt);
 
 	if (err_code != NRFX_SUCCESS) {
-		return -ENOTSUP;
+		/* This can only happen if wdt_nrf_setup() is not called first. */
+		return -EFAULT;
 	}
 
 	return 0;


### PR DESCRIPTION
Align driver implementation to the watchdog driver API. https://docs.zephyrproject.org/latest/hardware/peripherals/watchdog.html

int wdt_disable(const struct device *dev)
shall return:
    0 – If successful.
    -EFAULT – If watchdog instance is not enabled.
    -EPERM – If watchdog can not be disabled directly by application code.
    -errno – In case of any other failure.