### PR TITLE
ci: Ensure twister steps use the bsim version from the manifest

### DIFF
--- a/.github/workflows/bsim-tests.yaml
+++ b/.github/workflows/bsim-tests.yaml
@@ -145,8 +145,7 @@ jobs:
           echo "Manifest points to bsim sha $BSIM_VERSION"
           cd /opt/bsim_west/bsim
           git fetch -n origin ${BSIM_VERSION}
-          git config --global advice.detachedHead false
-          git checkout ${BSIM_VERSION}
+          git -c advice.detachedHead=false checkout ${BSIM_VERSION}
           west update
           make everything -s -j 8
 

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -89,6 +89,17 @@ jobs:
           ccache -p
           ccache -z -s -vv
 
+      - name: Update BabbleSim to manifest revision
+        run: |
+          export BSIM_VERSION=$( west list bsim -f {revision} )
+          echo "Manifest points to bsim sha $BSIM_VERSION"
+          cd /opt/bsim_west/bsim
+          git fetch -n origin ${BSIM_VERSION}
+          git config --global advice.detachedHead false
+          git checkout ${BSIM_VERSION}
+          west update
+          make everything -s -j 8
+
       - name: Run Tests with Twister
         id: twister
         run: |

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -95,8 +95,7 @@ jobs:
           echo "Manifest points to bsim sha $BSIM_VERSION"
           cd /opt/bsim_west/bsim
           git fetch -n origin ${BSIM_VERSION}
-          git config --global advice.detachedHead false
-          git checkout ${BSIM_VERSION}
+          git -c advice.detachedHead=false checkout ${BSIM_VERSION}
           west update
           make everything -s -j 8
 

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -91,8 +91,7 @@ jobs:
           echo "Manifest points to bsim sha $BSIM_VERSION"
           cd /opt/bsim_west/bsim
           git fetch -n origin ${BSIM_VERSION}
-          git config --global advice.detachedHead false
-          git checkout ${BSIM_VERSION}
+          git -c advice.detachedHead=false checkout ${BSIM_VERSION}
           west update
           make everything -s -j 8
 

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -85,6 +85,17 @@ jobs:
           ccache -p
           ccache -z -s -vv
 
+      - name: Update BabbleSim to manifest revision
+        run: |
+          export BSIM_VERSION=$( west list bsim -f {revision} )
+          echo "Manifest points to bsim sha $BSIM_VERSION"
+          cd /opt/bsim_west/bsim
+          git fetch -n origin ${BSIM_VERSION}
+          git config --global advice.detachedHead false
+          git checkout ${BSIM_VERSION}
+          west update
+          make everything -s -j 8
+
       - name: Run Tests with Twister (Push)
         continue-on-error: true
         run: |

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -219,8 +219,7 @@ jobs:
           echo "Manifest points to bsim sha $BSIM_VERSION"
           cd /opt/bsim_west/bsim
           git fetch -n origin ${BSIM_VERSION}
-          git config --global advice.detachedHead false
-          git checkout ${BSIM_VERSION}
+          git -c advice.detachedHead=false checkout ${BSIM_VERSION}
           west update
           make everything -s -j 8
 

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -213,6 +213,17 @@ jobs:
           ccache -p
           ccache -z -s -vv
 
+      - name: Update BabbleSim to manifest revision
+        run: |
+          export BSIM_VERSION=$( west list bsim -f {revision} )
+          echo "Manifest points to bsim sha $BSIM_VERSION"
+          cd /opt/bsim_west/bsim
+          git fetch -n origin ${BSIM_VERSION}
+          git config --global advice.detachedHead false
+          git checkout ${BSIM_VERSION}
+          west update
+          make everything -s -j 8
+
       - if: github.event_name == 'push'
         name: Run Tests with Twister (Push)
         run: |


### PR DESCRIPTION
The west manifest may point to a newer version of bsim than the one avaliable in the docker image. Let's ensure we run with that one.
This is equivalent to the change done in 933d338c9783cce55466fed000baf2f3beeac891 for the bsim-tests workflow.
(The twister workflows are normally less sensitive to running on an older bsim version due to not having radio activity, but eventually things fail)

Note that the update and rebuild is incremental, so if the docker image already has the right version the operation is very fast (~1 second)

-----

Docker version update to the latest version: https://github.com/zephyrproject-rtos/docker-image/pull/178 (which after this PR can come calmly, and without this PR we are in a hurry to get into use )