### PR TITLE
net: buf (buf_simple): Add support for 40 bit data type

### DIFF
--- a/include/zephyr/net/buf.h
+++ b/include/zephyr/net/buf.h
@@ -300,6 +300,30 @@ void net_buf_simple_add_le32(struct net_buf_simple *buf, uint32_t val);
 void net_buf_simple_add_be32(struct net_buf_simple *buf, uint32_t val);
 
 /**
+ * @brief Add 40-bit value at the end of the buffer
+ *
+ * Adds 40-bit value in little endian format at the end of buffer.
+ * Increments the data length of a buffer to account for more data
+ * at the end.
+ *
+ * @param buf Buffer to update.
+ * @param val 40-bit value to be added.
+ */
+void net_buf_simple_add_le40(struct net_buf_simple *buf, uint64_t val);
+
+/**
+ * @brief Add 40-bit value at the end of the buffer
+ *
+ * Adds 40-bit value in big endian format at the end of buffer.
+ * Increments the data length of a buffer to account for more data
+ * at the end.
+ *
+ * @param buf Buffer to update.
+ * @param val 40-bit value to be added.
+ */
+void net_buf_simple_add_be40(struct net_buf_simple *buf, uint64_t val);
+
+/**
  * @brief Add 48-bit value at the end of the buffer
  *
  * Adds 48-bit value in little endian format at the end of buffer.
@@ -442,6 +466,30 @@ uint32_t net_buf_simple_remove_le32(struct net_buf_simple *buf);
  * @return 32-bit value converted from big endian to host endian.
  */
 uint32_t net_buf_simple_remove_be32(struct net_buf_simple *buf);
+
+/**
+ * @brief Remove and convert 40 bits from the end of the buffer.
+ *
+ * Same idea as with net_buf_simple_remove_mem(), but a helper for operating
+ * on 40-bit little endian data.
+ *
+ * @param buf A valid pointer on a buffer.
+ *
+ * @return 40-bit value converted from little endian to host endian.
+ */
+uint64_t net_buf_simple_remove_le40(struct net_buf_simple *buf);
+
+/**
+ * @brief Remove and convert 40 bits from the end of the buffer.
+ *
+ * Same idea as with net_buf_simple_remove_mem(), but a helper for operating
+ * on 40-bit big endian data.
+ *
+ * @param buf A valid pointer on a buffer.
+ *
+ * @return 40-bit value converted from big endian to host endian.
+ */
+uint64_t net_buf_simple_remove_be40(struct net_buf_simple *buf);
 
 /**
  * @brief Remove and convert 48 bits from the end of the buffer.
@@ -596,6 +644,28 @@ void net_buf_simple_push_le32(struct net_buf_simple *buf, uint32_t val);
 void net_buf_simple_push_be32(struct net_buf_simple *buf, uint32_t val);
 
 /**
+ * @brief Push 40-bit value to the beginning of the buffer
+ *
+ * Adds 40-bit value in little endian format to the beginning of the
+ * buffer.
+ *
+ * @param buf Buffer to update.
+ * @param val 40-bit value to be pushed to the buffer.
+ */
+void net_buf_simple_push_le40(struct net_buf_simple *buf, uint64_t val);
+
+/**
+ * @brief Push 40-bit value to the beginning of the buffer
+ *
+ * Adds 40-bit value in big endian format to the beginning of the
+ * buffer.
+ *
+ * @param buf Buffer to update.
+ * @param val 40-bit value to be pushed to the buffer.
+ */
+void net_buf_simple_push_be40(struct net_buf_simple *buf, uint64_t val);
+
+/**
  * @brief Push 48-bit value to the beginning of the buffer
  *
  * Adds 48-bit value in little endian format to the beginning of the
@@ -748,6 +818,30 @@ uint32_t net_buf_simple_pull_le32(struct net_buf_simple *buf);
  * @return 32-bit value converted from big endian to host endian.
  */
 uint32_t net_buf_simple_pull_be32(struct net_buf_simple *buf);
+
+/**
+ * @brief Remove and convert 40 bits from the beginning of the buffer.
+ *
+ * Same idea as with net_buf_simple_pull(), but a helper for operating
+ * on 40-bit little endian data.
+ *
+ * @param buf A valid pointer on a buffer.
+ *
+ * @return 40-bit value converted from little endian to host endian.
+ */
+uint64_t net_buf_simple_pull_le40(struct net_buf_simple *buf);
+
+/**
+ * @brief Remove and convert 40 bits from the beginning of the buffer.
+ *
+ * Same idea as with net_buf_simple_pull(), but a helper for operating
+ * on 40-bit big endian data.
+ *
+ * @param buf A valid pointer on a buffer.
+ *
+ * @return 40-bit value converted from big endian to host endian.
+ */
+uint64_t net_buf_simple_pull_be40(struct net_buf_simple *buf);
 
 /**
  * @brief Remove and convert 48 bits from the beginning of the buffer.

--- a/include/zephyr/net/buf.h
+++ b/include/zephyr/net/buf.h
@@ -1715,6 +1715,36 @@ static inline void net_buf_add_be32(struct net_buf *buf, uint32_t val)
 }
 
 /**
+ * @brief Add 40-bit value at the end of the buffer
+ *
+ * Adds 40-bit value in little endian format at the end of buffer.
+ * Increments the data length of a buffer to account for more data
+ * at the end.
+ *
+ * @param buf Buffer to update.
+ * @param val 40-bit value to be added.
+ */
+static inline void net_buf_add_le40(struct net_buf *buf, uint64_t val)
+{
+	net_buf_simple_add_le40(&buf->b, val);
+}
+
+/**
+ * @brief Add 40-bit value at the end of the buffer
+ *
+ * Adds 40-bit value in big endian format at the end of buffer.
+ * Increments the data length of a buffer to account for more data
+ * at the end.
+ *
+ * @param buf Buffer to update.
+ * @param val 40-bit value to be added.
+ */
+static inline void net_buf_add_be40(struct net_buf *buf, uint64_t val)
+{
+	net_buf_simple_add_be40(&buf->b, val);
+}
+
+/**
  * @brief Add 48-bit value at the end of the buffer
  *
  * Adds 48-bit value in little endian format at the end of buffer.
@@ -1892,6 +1922,36 @@ static inline uint32_t net_buf_remove_le32(struct net_buf *buf)
 static inline uint32_t net_buf_remove_be32(struct net_buf *buf)
 {
 	return net_buf_simple_remove_be32(&buf->b);
+}
+
+/**
+ * @brief Remove and convert 40 bits from the end of the buffer.
+ *
+ * Same idea as with net_buf_remove_mem(), but a helper for operating on
+ * 40-bit little endian data.
+ *
+ * @param buf A valid pointer on a buffer.
+ *
+ * @return 40-bit value converted from little endian to host endian.
+ */
+static inline uint64_t net_buf_remove_le40(struct net_buf *buf)
+{
+	return net_buf_simple_remove_le40(&buf->b);
+}
+
+/**
+ * @brief Remove and convert 40 bits from the end of the buffer.
+ *
+ * Same idea as with net_buf_remove_mem(), but a helper for operating on
+ * 40-bit big endian data.
+ *
+ * @param buf A valid pointer on a buffer
+ *
+ * @return 40-bit value converted from big endian to host endian.
+ */
+static inline uint64_t net_buf_remove_be40(struct net_buf *buf)
+{
+	return net_buf_simple_remove_be40(&buf->b);
 }
 
 /**
@@ -2086,6 +2146,34 @@ static inline void net_buf_push_be32(struct net_buf *buf, uint32_t val)
 }
 
 /**
+ * @brief Push 40-bit value to the beginning of the buffer
+ *
+ * Adds 40-bit value in little endian format to the beginning of the
+ * buffer.
+ *
+ * @param buf Buffer to update.
+ * @param val 40-bit value to be pushed to the buffer.
+ */
+static inline void net_buf_push_le40(struct net_buf *buf, uint64_t val)
+{
+	net_buf_simple_push_le40(&buf->b, val);
+}
+
+/**
+ * @brief Push 40-bit value to the beginning of the buffer
+ *
+ * Adds 40-bit value in big endian format to the beginning of the
+ * buffer.
+ *
+ * @param buf Buffer to update.
+ * @param val 40-bit value to be pushed to the buffer.
+ */
+static inline void net_buf_push_be40(struct net_buf *buf, uint64_t val)
+{
+	net_buf_simple_push_be40(&buf->b, val);
+}
+
+/**
  * @brief Push 48-bit value to the beginning of the buffer
  *
  * Adds 48-bit value in little endian format to the beginning of the
@@ -2276,6 +2364,36 @@ static inline uint32_t net_buf_pull_le32(struct net_buf *buf)
 static inline uint32_t net_buf_pull_be32(struct net_buf *buf)
 {
 	return net_buf_simple_pull_be32(&buf->b);
+}
+
+/**
+ * @brief Remove and convert 40 bits from the beginning of the buffer.
+ *
+ * Same idea as with net_buf_pull(), but a helper for operating on
+ * 40-bit little endian data.
+ *
+ * @param buf A valid pointer on a buffer.
+ *
+ * @return 40-bit value converted from little endian to host endian.
+ */
+static inline uint64_t net_buf_pull_le40(struct net_buf *buf)
+{
+	return net_buf_simple_pull_le40(&buf->b);
+}
+
+/**
+ * @brief Remove and convert 40 bits from the beginning of the buffer.
+ *
+ * Same idea as with net_buf_pull(), but a helper for operating on
+ * 40-bit big endian data.
+ *
+ * @param buf A valid pointer on a buffer
+ *
+ * @return 40-bit value converted from big endian to host endian.
+ */
+static inline uint64_t net_buf_pull_be40(struct net_buf *buf)
+{
+	return net_buf_simple_pull_be40(&buf->b);
 }
 
 /**

--- a/include/zephyr/sys/byteorder.h
+++ b/include/zephyr/sys/byteorder.h
@@ -24,6 +24,11 @@
 				   (((x) >> 8) & 0xff00) | \
 				   (((x) & 0xff00) << 8) | \
 				   (((x) & 0xff) << 24)))
+#define BSWAP_40(x) ((uint64_t) ((((x) >> 32) & 0xff) | \
+				   (((x) >> 16) & 0xff00) | \
+				   (((x)) & 0xff0000) | \
+				   (((x) & 0xff00) << 16) | \
+				   (((x) & 0xff) << 32)))
 #define BSWAP_48(x) ((uint64_t) ((((x) >> 40) & 0xff) | \
 				   (((x) >> 24) & 0xff00) | \
 				   (((x) >> 8) & 0xff0000) | \
@@ -217,6 +222,8 @@
 #define sys_cpu_to_le24(val) (val)
 #define sys_le32_to_cpu(val) (val)
 #define sys_cpu_to_le32(val) (val)
+#define sys_le40_to_cpu(val) (val)
+#define sys_cpu_to_le40(val) (val)
 #define sys_le48_to_cpu(val) (val)
 #define sys_cpu_to_le48(val) (val)
 #define sys_le64_to_cpu(val) (val)
@@ -227,6 +234,8 @@
 #define sys_cpu_to_be24(val) BSWAP_24(val)
 #define sys_be32_to_cpu(val) BSWAP_32(val)
 #define sys_cpu_to_be32(val) BSWAP_32(val)
+#define sys_be40_to_cpu(val) BSWAP_40(val)
+#define sys_cpu_to_be40(val) BSWAP_40(val)
 #define sys_be48_to_cpu(val) BSWAP_48(val)
 #define sys_cpu_to_be48(val) BSWAP_48(val)
 #define sys_be64_to_cpu(val) BSWAP_64(val)
@@ -259,6 +268,8 @@
 #define sys_cpu_to_le24(val) BSWAP_24(val)
 #define sys_le32_to_cpu(val) BSWAP_32(val)
 #define sys_cpu_to_le32(val) BSWAP_32(val)
+#define sys_le40_to_cpu(val) BSWAP_40(val)
+#define sys_cpu_to_le40(val) BSWAP_40(val)
 #define sys_le48_to_cpu(val) BSWAP_48(val)
 #define sys_cpu_to_le48(val) BSWAP_48(val)
 #define sys_le64_to_cpu(val) BSWAP_64(val)
@@ -269,6 +280,8 @@
 #define sys_cpu_to_be24(val) (val)
 #define sys_be32_to_cpu(val) (val)
 #define sys_cpu_to_be32(val) (val)
+#define sys_be40_to_cpu(val) (val)
+#define sys_cpu_to_be40(val) (val)
 #define sys_be48_to_cpu(val) (val)
 #define sys_cpu_to_be48(val) (val)
 #define sys_be64_to_cpu(val) (val)
@@ -339,6 +352,20 @@ static inline void sys_put_be32(uint32_t val, uint8_t dst[4])
 {
 	sys_put_be16(val >> 16, dst);
 	sys_put_be16(val, &dst[2]);
+}
+/**
+ *  @brief Put a 40-bit integer as big-endian to arbitrary location.
+ *
+ *  Put a 40-bit integer, originally in host endianness, to a
+ *  potentially unaligned memory location in big-endian format.
+ *
+ *  @param val 40-bit integer in host endianness.
+ *  @param dst Destination memory address to store the result.
+ */
+static inline void sys_put_be40(uint64_t val, uint8_t dst[5])
+{
+	dst[0] = val >> 32;
+	sys_put_be32(val, &dst[1]);
 }
 
 /**
@@ -417,6 +444,21 @@ static inline void sys_put_le32(uint32_t val, uint8_t dst[4])
 }
 
 /**
+ *  @brief Put a 40-bit integer as little-endian to arbitrary location.
+ *
+ *  Put a 40-bit integer, originally in host endianness, to a
+ *  potentially unaligned memory location in little-endian format.
+ *
+ *  @param val 40-bit integer in host endianness.
+ *  @param dst Destination memory address to store the result.
+ */
+static inline void sys_put_le40(uint64_t val, uint8_t dst[5])
+{
+	sys_put_le32(val, dst);
+	dst[4] = val >> 32;
+}
+
+/**
  *  @brief Put a 48-bit integer as little-endian to arbitrary location.
  *
  *  Put a 48-bit integer, originally in host endianness, to a
@@ -492,6 +534,21 @@ static inline uint32_t sys_get_be32(const uint8_t src[4])
 }
 
 /**
+ *  @brief Get a 40-bit integer stored in big-endian format.
+ *
+ *  Get a 40-bit integer, stored in big-endian format in a potentially
+ *  unaligned memory location, and convert it to the host endianness.
+ *
+ *  @param src Location of the big-endian 40-bit integer to get.
+ *
+ *  @return 40-bit integer in host endianness.
+ */
+static inline uint64_t sys_get_be40(const uint8_t src[5])
+{
+	return ((uint64_t)sys_get_be32(&src[0]) << 8) | src[4];
+}
+
+/**
  *  @brief Get a 48-bit integer stored in big-endian format.
  *
  *  Get a 48-bit integer, stored in big-endian format in a potentially
@@ -564,6 +621,21 @@ static inline uint32_t sys_get_le24(const uint8_t src[3])
 static inline uint32_t sys_get_le32(const uint8_t src[4])
 {
 	return ((uint32_t)sys_get_le16(&src[2]) << 16) | sys_get_le16(&src[0]);
+}
+
+/**
+ *  @brief Get a 40-bit integer stored in little-endian format.
+ *
+ *  Get a 40-bit integer, stored in little-endian format in a potentially
+ *  unaligned memory location, and convert it to the host endianness.
+ *
+ *  @param src Location of the little-endian 40-bit integer to get.
+ *
+ *  @return 40-bit integer in host endianness.
+ */
+static inline uint64_t sys_get_le40(const uint8_t src[5])
+{
+	return ((uint64_t)sys_get_le32(&src[1]) << 8) | src[0];
 }
 
 /**

--- a/subsys/net/buf_simple.c
+++ b/subsys/net/buf_simple.c
@@ -127,6 +127,20 @@ void net_buf_simple_add_be32(struct net_buf_simple *buf, uint32_t val)
 	sys_put_be32(val, net_buf_simple_add(buf, sizeof(val)));
 }
 
+void net_buf_simple_add_le40(struct net_buf_simple *buf, uint64_t val)
+{
+	NET_BUF_SIMPLE_DBG("buf %p val %" PRIu64, buf, val);
+
+	sys_put_le40(val, net_buf_simple_add(buf, 5));
+}
+
+void net_buf_simple_add_be40(struct net_buf_simple *buf, uint64_t val)
+{
+	NET_BUF_SIMPLE_DBG("buf %p val %" PRIu64, buf, val);
+
+	sys_put_be40(val, net_buf_simple_add(buf, 5));
+}
+
 void net_buf_simple_add_le48(struct net_buf_simple *buf, uint64_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %" PRIu64, buf, val);
@@ -246,6 +260,32 @@ uint32_t net_buf_simple_remove_be32(struct net_buf_simple *buf)
 	return sys_be32_to_cpu(val);
 }
 
+uint64_t net_buf_simple_remove_le40(struct net_buf_simple *buf)
+{
+	struct uint40 {
+		uint64_t u40: 40;
+	} __packed val;
+	void *ptr;
+
+	ptr = net_buf_simple_remove_mem(buf, sizeof(val));
+	val = UNALIGNED_GET((struct uint40 *)ptr);
+
+	return sys_le40_to_cpu(val.u40);
+}
+
+uint64_t net_buf_simple_remove_be40(struct net_buf_simple *buf)
+{
+	struct uint40 {
+		uint64_t u40: 40;
+	} __packed val;
+	void *ptr;
+
+	ptr = net_buf_simple_remove_mem(buf, sizeof(val));
+	val = UNALIGNED_GET((struct uint40 *)ptr);
+
+	return sys_be40_to_cpu(val.u40);
+}
+
 uint64_t net_buf_simple_remove_le48(struct net_buf_simple *buf)
 {
 	struct uint48 {
@@ -360,6 +400,20 @@ void net_buf_simple_push_be32(struct net_buf_simple *buf, uint32_t val)
 	NET_BUF_SIMPLE_DBG("buf %p val %u", buf, val);
 
 	sys_put_be32(val, net_buf_simple_push(buf, sizeof(val)));
+}
+
+void net_buf_simple_push_le40(struct net_buf_simple *buf, uint64_t val)
+{
+	NET_BUF_SIMPLE_DBG("buf %p val %" PRIu64, buf, val);
+
+	sys_put_le40(val, net_buf_simple_push(buf, 5));
+}
+
+void net_buf_simple_push_be40(struct net_buf_simple *buf, uint64_t val)
+{
+	NET_BUF_SIMPLE_DBG("buf %p val %" PRIu64, buf, val);
+
+	sys_put_be40(val, net_buf_simple_push(buf, 5));
 }
 
 void net_buf_simple_push_le48(struct net_buf_simple *buf, uint64_t val)
@@ -486,6 +540,30 @@ uint32_t net_buf_simple_pull_be32(struct net_buf_simple *buf)
 	net_buf_simple_pull(buf, sizeof(val));
 
 	return sys_be32_to_cpu(val);
+}
+
+uint64_t net_buf_simple_pull_le40(struct net_buf_simple *buf)
+{
+	struct uint40 {
+		uint64_t u40: 40;
+	} __packed val;
+
+	val = UNALIGNED_GET((struct uint40 *)buf->data);
+	net_buf_simple_pull(buf, sizeof(val));
+
+	return sys_le40_to_cpu(val.u40);
+}
+
+uint64_t net_buf_simple_pull_be40(struct net_buf_simple *buf)
+{
+	struct uint40 {
+		uint64_t u40: 40;
+	} __packed val;
+
+	val = UNALIGNED_GET((struct uint40 *)buf->data);
+	net_buf_simple_pull(buf, sizeof(val));
+
+	return sys_be40_to_cpu(val.u40);
 }
 
 uint64_t net_buf_simple_pull_le48(struct net_buf_simple *buf)

--- a/tests/kernel/common/src/byteorder.c
+++ b/tests/kernel/common/src/byteorder.c
@@ -107,6 +107,40 @@ ZTEST(byteorder, test_sys_put_be64)
 }
 
 /**
+ * @brief Test sys_get_be40() functionality
+ *
+ * @details Test if sys_get_be40() correctly handles endianness.
+ *
+ * @see sys_get_be40()
+ */
+ZTEST(byteorder, test_sys_get_be40)
+{
+	uint64_t val = 0xf0e1d2c3b4, tmp;
+	uint8_t buf[] = {0xf0, 0xe1, 0xd2, 0xc3, 0xb4};
+
+	tmp = sys_get_be40(buf);
+
+	zassert_equal(tmp, val, "sys_get_be64() failed");
+}
+
+/**
+ * @brief Test sys_put_be40() functionality
+ *
+ * @details Test if sys_put_be40() correctly handles endianness.
+ *
+ * @see sys_put_be40()
+ */
+ZTEST(byteorder, test_sys_put_be40)
+{
+	uint64_t val = 0xf0e1d2c3b4;
+	uint8_t buf[] = {0xf0, 0xe1, 0xd2, 0xc3, 0xb4};
+	uint8_t tmp[sizeof(buf)];
+
+	sys_put_be40(val, tmp);
+	zassert_mem_equal(tmp, buf, sizeof(buf), "sys_put_be40() failed");
+}
+
+/**
  * @brief Test sys_get_be48() functionality
  *
  * @details Test if sys_get_be48() correctly handles endianness.
@@ -376,6 +410,41 @@ ZTEST(byteorder, test_sys_put_le32)
 	sys_put_le32(val, tmp);
 
 	zassert_mem_equal(tmp, buf, sizeof(uint32_t), "sys_put_le32() failed");
+}
+
+/**
+ * @brief Test sys_get_le40() functionality
+ *
+ * @details Test if sys_get_le40() correctly handles endianness.
+ *
+ * @see sys_get_le40()
+ */
+ZTEST(byteorder, test_sys_get_le40)
+{
+	uint64_t val = 0xf0e1d2c3b4, tmp;
+	uint8_t buf[] = {0xb4, 0xc3, 0xd2, 0xe1, 0xf0};
+
+	tmp = sys_get_le40(buf);
+
+	zassert_equal(tmp, val, "sys_get_le40() failed");
+}
+
+/**
+ * @brief Test sys_put_le40() functionality
+ *
+ * @details Test if sys_put_le40() correctly handles endianness.
+ *
+ * @see sys_put_le40()
+ */
+ZTEST(byteorder, test_sys_put_le40)
+{
+	uint64_t val = 0xf0e1d2c3b4;
+	uint8_t buf[] = {0xb4, 0xc3, 0xd2, 0xe1, 0xf0};
+	uint8_t tmp[sizeof(uint64_t)];
+
+	sys_put_le40(val, tmp);
+
+	zassert_mem_equal(tmp, buf, sizeof(buf), "sys_put_le40() failed");
 }
 
 /**

--- a/tests/net/buf/src/main.c
+++ b/tests/net/buf/src/main.c
@@ -479,6 +479,8 @@ ZTEST(net_buf_tests, test_net_buf_byte_order)
 	uint8_t be24[3] = { 0x01, 0x02, 0x03 };
 	uint8_t le32[4] = { 0x04, 0x03, 0x02, 0x01 };
 	uint8_t be32[4] = { 0x01, 0x02, 0x03, 0x04 };
+	uint8_t le40[5] = { 0x05, 0x04, 0x03, 0x02, 0x01 };
+	uint8_t be40[5] = { 0x01, 0x02, 0x03, 0x04, 0x05 };
 	uint8_t le48[6] = { 0x06, 0x05, 0x04, 0x03, 0x02, 0x01 };
 	uint8_t be48[6] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06 };
 	uint8_t le64[8] = { 0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01 };
@@ -545,6 +547,24 @@ ZTEST(net_buf_tests, test_net_buf_byte_order)
 			  sizeof(le32), "Invalid 32 bits byte order");
 	zassert_mem_equal(be32, net_buf_pull_mem(buf, sizeof(be32)),
 			  sizeof(be32), "Invalid 32 bits byte order");
+
+	net_buf_reset(buf);
+
+	net_buf_add_mem(buf, &le40, sizeof(le40));
+	net_buf_add_mem(buf, &be40, sizeof(be40));
+
+	u64 = net_buf_pull_le40(buf);
+	zassert_equal(u64, net_buf_pull_be40(buf), "Invalid 40 bits byte order");
+
+	net_buf_reset(buf);
+
+	net_buf_add_le40(buf, u64);
+	net_buf_add_be40(buf, u64);
+
+	zassert_mem_equal(le40, net_buf_pull_mem(buf, sizeof(le40)), sizeof(le40),
+			  "Invalid 40 bits byte order");
+	zassert_mem_equal(be40, net_buf_pull_mem(buf, sizeof(be40)), sizeof(be40),
+			  "Invalid 40 bits byte order");
 
 	net_buf_reset(buf);
 
@@ -647,6 +667,26 @@ ZTEST(net_buf_tests, test_net_buf_byte_order)
 			  sizeof(le32), "Invalid 32 bits byte order");
 	zassert_mem_equal(be32, net_buf_remove_mem(buf, sizeof(be32)),
 			  sizeof(be32), "Invalid 32 bits byte order");
+
+	net_buf_reset(buf);
+	net_buf_reserve(buf, 16);
+
+	net_buf_push_mem(buf, &le40, sizeof(le40));
+	net_buf_push_mem(buf, &be40, sizeof(be40));
+
+	u64 = net_buf_remove_le40(buf);
+	zassert_equal(u64, net_buf_remove_be40(buf), "Invalid 40 bits byte order");
+
+	net_buf_reset(buf);
+	net_buf_reserve(buf, 16);
+
+	net_buf_push_le40(buf, u64);
+	net_buf_push_be40(buf, u64);
+
+	zassert_mem_equal(le40, net_buf_remove_mem(buf, sizeof(le40)), sizeof(le40),
+			  "Invalid 40 bits byte order");
+	zassert_mem_equal(be40, net_buf_remove_mem(buf, sizeof(be40)), sizeof(be40),
+			  "Invalid 40 bits byte order");
 
 	net_buf_reset(buf);
 	net_buf_reserve(buf, 16);

--- a/tests/net/buf_simple/src/main.c
+++ b/tests/net/buf_simple/src/main.c
@@ -18,6 +18,8 @@ static const uint8_t le24[3] = { 0x03, 0x02, 0x01 };
 static const uint8_t be24[3] = { 0x01, 0x02, 0x03 };
 static const uint8_t le32[4] = { 0x04, 0x03, 0x02, 0x01 };
 static const uint8_t be32[4] = { 0x01, 0x02, 0x03, 0x04 };
+static const uint8_t le40[5] = { 0x05, 0x04, 0x03, 0x02, 0x01 };
+static const uint8_t be40[5] = { 0x01, 0x02, 0x03, 0x04, 0x05 };
 static const uint8_t le48[6] = { 0x06, 0x05, 0x04, 0x03, 0x02, 0x01 };
 static const uint8_t be48[6] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06 };
 static const uint8_t le64[8] = { 0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01 };
@@ -25,6 +27,7 @@ static const uint8_t be64[8] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 
 static const uint16_t u16 = 0x0102;
 static const uint32_t u24 = 0x010203;
 static const uint32_t u32 = 0x01020304;
+static const uint64_t u40 = 0x0102030405;
 static const uint64_t u48 = 0x010203040506;
 static const uint64_t u64 = 0x0102030405060708;
 
@@ -139,6 +142,38 @@ ZTEST(net_buf_simple_test_suite, test_net_buf_simple_add_be32)
 
 	zassert_mem_equal(be32, net_buf_simple_pull_mem(&buf, sizeof(be32)),
 			  sizeof(be32), "Invalid 32 bits byte order");
+}
+
+ZTEST(net_buf_simple_test_suite, test_net_buf_simple_pull_le40)
+{
+	net_buf_simple_add_mem(&buf, &le40, sizeof(le40));
+
+	zassert_equal(u40, net_buf_simple_pull_le40(&buf),
+		      "Invalid 40 bits byte order");
+}
+
+ZTEST(net_buf_simple_test_suite, test_net_buf_simple_pull_be40)
+{
+	net_buf_simple_add_mem(&buf, &be40, sizeof(be40));
+
+	zassert_equal(u40, net_buf_simple_pull_be40(&buf),
+		      "Invalid 40 bits byte order");
+}
+
+ZTEST(net_buf_simple_test_suite, test_net_buf_simple_add_le40)
+{
+	net_buf_simple_add_le40(&buf, u40);
+
+	zassert_mem_equal(le40, net_buf_simple_pull_mem(&buf, sizeof(le40)),
+			  sizeof(le40), "Invalid 40 bits byte order");
+}
+
+ZTEST(net_buf_simple_test_suite, test_net_buf_simple_add_be40)
+{
+	net_buf_simple_add_be40(&buf, u40);
+
+	zassert_mem_equal(be40, net_buf_simple_pull_mem(&buf, sizeof(be40)),
+			  sizeof(be40), "Invalid 40 bits byte order");
 }
 
 ZTEST(net_buf_simple_test_suite, test_net_buf_simple_pull_le48)
@@ -323,6 +358,44 @@ ZTEST(net_buf_simple_test_suite, test_net_buf_simple_push_be32)
 
 	zassert_mem_equal(be32, net_buf_simple_remove_mem(&buf, sizeof(be32)),
 			  sizeof(be32), "Invalid 32 bits byte order");
+}
+
+ZTEST(net_buf_simple_test_suite, test_net_buf_simple_remove_le40)
+{
+	net_buf_simple_reserve(&buf, 16);
+
+	net_buf_simple_push_mem(&buf, &le40, sizeof(le40));
+
+	zassert_equal(u40, net_buf_simple_remove_le40(&buf), "Invalid 40 bits byte order");
+}
+
+ZTEST(net_buf_simple_test_suite, test_net_buf_simple_remove_be40)
+{
+	net_buf_simple_reserve(&buf, 16);
+
+	net_buf_simple_push_mem(&buf, &be40, sizeof(be40));
+
+	zassert_equal(u40, net_buf_simple_remove_be40(&buf), "Invalid 40 bits byte order");
+}
+
+ZTEST(net_buf_simple_test_suite, test_net_buf_simple_push_le40)
+{
+	net_buf_simple_reserve(&buf, 16);
+
+	net_buf_simple_push_le40(&buf, u40);
+
+	zassert_mem_equal(le40, net_buf_simple_remove_mem(&buf, sizeof(le40)), sizeof(le40),
+			  "Invalid 40 bits byte order");
+}
+
+ZTEST(net_buf_simple_test_suite, test_net_buf_simple_push_be40)
+{
+	net_buf_simple_reserve(&buf, 16);
+
+	net_buf_simple_push_be40(&buf, u40);
+
+	zassert_mem_equal(be40, net_buf_simple_remove_mem(&buf, sizeof(be40)), sizeof(be40),
+			  "Invalid 40 bits byte order");
 }
 
 ZTEST(net_buf_simple_test_suite, test_net_buf_simple_remove_le48)


### PR DESCRIPTION
This enables pulling and pushing values in 40 bit format.

Notes:
 - My original motivation for this is a use case in a proprietary Sub-GHz RF driver.
 - Could quite simply do also a 56 bit variant, so that all byte-aligned sizes up to 64 bits are covered.