### PR TITLE
Renesas: Smartbond: Fix Display Configuration Conflicts 

### DIFF
--- a/boards/renesas/da1469x_dk_pro/Kconfig.defconfig
+++ b/boards/renesas/da1469x_dk_pro/Kconfig.defconfig
@@ -12,15 +12,15 @@ config LV_Z_BITS_PER_PIXEL
 
 # LCDC imposes display buffer's stride be word aligned
 config LV_Z_AREA_X_ALIGNMENT_WIDTH
-	default 2
+	default 2 if MIPI_DBI_SMARTBOND
 
 config LV_Z_FLUSH_THREAD
-	default y
+	default y if DISPLAY_RENESAS_LCDC
 
 # Use double buffering to avoid visual artifacts as long as
 # the DMA is copying data into driver's frame buffer.
 config LV_Z_DOUBLE_VDB
-	default y
+	default y if DISPLAY_RENESAS_LCDC
 
 endif # LVGL
 

--- a/boards/renesas/da1469x_dk_pro/dts/da1469x_dk_pro_lcdc.overlay
+++ b/boards/renesas/da1469x_dk_pro/dts/da1469x_dk_pro_lcdc.overlay
@@ -23,6 +23,16 @@
     status = "okay";
 };
 
+&pinctrl {
+    i2c2_default: i2c2_default {
+        group1 {
+            pinmux = <SMARTBOND_PINMUX(I2C2_SDA, 0, 19)>,
+                <SMARTBOND_PINMUX(I2C2_SCL, 0, 18)>;
+            bias-pull-up;
+        };
+    };
+};
+
 &i2c2 {
     clock-frequency = <400000>;
 


### PR DESCRIPTION
This commit should fix configuration conflicts that came up upon merging both MIPI DBI and display panel drivers.

1. Board's display/LVGL Kconfigs should be enabled when needed based on the selected display interface.
2. Overwrite the touch controller's I2C pins to avoid conflicts with the display panel signals.