### PR TITLE
west: Update west boards formatter and fish shell completion

### DIFF
--- a/scripts/west_commands/boards.py
+++ b/scripts/west_commands/boards.py
@@ -53,6 +53,7 @@ class Boards(WestCommand):
             - arch: board architecture (deprecated)
                     (arch is ambiguous for boards described in new hw model)
             - dir: directory that contains the board definition
+            - vendor: board vendor
             '''))
 
         # Remember to update west-completion.bash if you add or remove
@@ -93,5 +94,12 @@ class Boards(WestCommand):
         for board in list_boards.find_v2_boards(args):
             if name_re is not None and not name_re.search(board.name):
                 continue
-            log.inf(args.format.format(name=board.name, arch='', dir=board.dir, hwm=board.hwm,
-                                       qualifiers=list_boards.board_v2_qualifiers_csv(board)))
+            log.inf(
+                args.format.format(
+                    name=board.name,
+                    dir=board.dir,
+                    hwm=board.hwm,
+                    vendor=board.vendor,
+                    qualifiers=list_boards.board_v2_qualifiers_csv(board),
+                )
+            )


### PR DESCRIPTION
This PR is a follow up to that discussion: https://github.com/zephyrproject-rtos/zephyr/pull/69336#discussion_r1500512829.
Its adding the `vendor` boards formatter argument and update the board completion for fish shell as described in the comment. 

That fixes #69387.

This PR also fix an issue described in that PR https://github.com/zephyrproject-rtos/zephyr/pull/69336 where the board completion is extremely slow (several seconds). To resolve that issue, the second commit introduce a simple boards caching system. With it, displaying the board is nearly instantaneous.