### PR TITLE
drivers: eswifi: Add option for maximum data size

### DIFF
--- a/drivers/wifi/eswifi/Kconfig.eswifi
+++ b/drivers/wifi/eswifi/Kconfig.eswifi
@@ -30,6 +30,14 @@ config WIFI_ESWIFI_BUS_UART
 
 endchoice
 
+config WIFI_ESWIFI_MAX_DATA_SIZE
+	int "esWiFi message size"
+	default 1600
+	range 500 4000
+	help
+	  This option sets the size of the esWiFi message buffer.
+	  It can be increased to handle larger messages, like scan results.
+
 config WIFI_ESWIFI_THREAD_PRIO
 	int "esWiFi threads priority"
 	default 2

--- a/drivers/wifi/eswifi/eswifi.h
+++ b/drivers/wifi/eswifi/eswifi.h
@@ -16,8 +16,6 @@
 
 #include "eswifi_offload.h"
 
-#define MAX_DATA_SIZE 1600
-
 #define AT_OK_STR "\r\nOK\r\n> "
 #define AT_OK_STR_LEN 8
 #define AT_RSP_DELIMITER "\r\n"
@@ -71,7 +69,7 @@ struct eswifi_dev {
 	enum eswifi_request req;
 	enum eswifi_role role;
 	uint8_t mac[6];
-	char buf[MAX_DATA_SIZE];
+	char buf[CONFIG_WIFI_ESWIFI_MAX_DATA_SIZE];
 	struct k_mutex mutex;
 	atomic_val_t mutex_owner;
 	unsigned int mutex_depth;

--- a/drivers/wifi/eswifi/eswifi_core.c
+++ b/drivers/wifi/eswifi/eswifi_core.c
@@ -141,6 +141,13 @@ int eswifi_at_cmd_rsp(struct eswifi_dev *eswifi, char *cmd, char **rsp)
 		return -EIO;
 	}
 
+	if (len >= CONFIG_WIFI_ESWIFI_MAX_DATA_SIZE) {
+		LOG_WRN("Buffer might be too small for response!");
+		LOG_WRN("Data length %d", len);
+		LOG_WRN("See CONFIG_WIFI_ESWIFI_MAX_DATA_SIZE (in build: %d)",
+			CONFIG_WIFI_ESWIFI_MAX_DATA_SIZE);
+	}
+
 	/*
 	 * Check response, format should be "\r\n[DATA]\r\nOK\r\n>"
 	 * Data is in arbitrary format (not only ASCII)


### PR DESCRIPTION
Default MAX_DATA_SIZE might be too small depending on application (e.g. handling the scan result with 12 APs detected) 
Added config option for MAX_DATA_SIZE and warning for the user
Range for MAX_DATA_SIZE from 500 to 4000 should cover every case. With 12 APs with long SSIDs detected, the data size should be around 2000.