### PR TITLE
dts: bindings: vendor-prefixes: Add moortec prefix

### DIFF
--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -415,6 +415,7 @@ minix	MINIX Technology Ltd.
 miramems	MiraMEMS Sensing Technology Co., Ltd.
 mitsubishi	Mitsubishi Electric Corporation
 modtronix	Modtronix Engineering
+moortec	Moortec Semiconductor Ltd.
 mosaixtech	Mosaix Technologies, Inc.
 motorola	Motorola, Inc.
 moxa	Moxa Inc.


### PR DESCRIPTION
Moortec (now part of Synopsys) is a semiconductor company which provides process, voltage, and temperature (PVT) monitoring IP for SoCs.