### PR TITLE
ITE: soc: it8xxx2: Add missing Kconfig file of it82302ax variant

### DIFF
--- a/soc/ite/ec/it8xxx2/Kconfig.defconfig.it82302ax
+++ b/soc/ite/ec/it8xxx2/Kconfig.defconfig.it82302ax
@@ -1,0 +1,9 @@
+# Copyright (c) 2024 ITE Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_IT82302_AX
+
+config SOC_IT8XXX2_GPIO_GROUP_K_L_DEFAULT_PULL_DOWN
+	default n
+
+endif


### PR DESCRIPTION
Previous adjustments to hwmv2 lost this Kconfig file.

Test: west build -p always -b it82xx2_evb samples/hello_world

Kconfig.it82xx2_evb: 
config BOARD_IT82XX2_EVB
   select SOC_IT82302_AX