### PR TITLE
include: drivers: led: Correct comment for `struct led_info`

### DIFF
--- a/include/zephyr/drivers/led.h
+++ b/include/zephyr/drivers/led.h
@@ -36,9 +36,9 @@ extern "C" {
 struct led_info {
 	/** LED label */
 	const char *label;
-	/** Number of colors per LED */
-	uint32_t index;
 	/** Index of the LED on the controller */
+	uint32_t index;
+	/** Number of colors per LED */
 	uint8_t num_colors;
 	/** Mapping of the LED colors */
 	const uint8_t *color_mapping;


### PR DESCRIPTION
The comments for `index` and `num_colors` in `struct led_info` were mistakenly swapped. This commit corrects them to accurately reflect their actual purpose.