### PR TITLE
drivers: led: led_gpio: Add support for multi-color LEDs

### DIFF
--- a/drivers/led/led_gpio.c
+++ b/drivers/led/led_gpio.c
@@ -15,28 +15,56 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/device.h>
 #include <zephyr/kernel.h>
+#include <zephyr/dt-bindings/led/led.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(led_gpio, CONFIG_LED_LOG_LEVEL);
 
+struct led_gpio_child {
+	const struct gpio_dt_spec *gpio;
+	struct led_info info;
+};
+
 struct led_gpio_config {
 	size_t num_leds;
-	const struct gpio_dt_spec *led;
+	const struct led_gpio_child *led;
 };
+
+static int led_gpio_get_info(const struct device *dev, uint32_t led, const struct led_info **info)
+{
+	const struct led_gpio_config *config = dev->config;
+
+	if (led >= config->num_leds) {
+		return -EINVAL;
+	}
+
+	*info = &config->led[led].info;
+
+	return 0;
+}
 
 static int led_gpio_set_brightness(const struct device *dev, uint32_t led, uint8_t value)
 {
 
 	const struct led_gpio_config *config = dev->config;
-	const struct gpio_dt_spec *led_gpio;
+	const struct led_gpio_child *led_child;
+	int err = 0;
 
 	if ((led >= config->num_leds) || (value > 100)) {
 		return -EINVAL;
 	}
 
-	led_gpio = &config->led[led];
+	for (uint8_t i = 0; i < config->led[led].info.num_colors && !err; i++) {
+		led_child = &config->led[led];
 
-	return gpio_pin_set_dt(led_gpio, value > 0);
+		err = gpio_pin_set_dt(&led_child->gpio[i], value > 0);
+
+		if (err) {
+			LOG_ERR("Cannot set GPIO (err %d)", err);
+		}
+	}
+
+	return err;
 }
 
 static int led_gpio_on(const struct device *dev, uint32_t led)
@@ -49,9 +77,38 @@ static int led_gpio_off(const struct device *dev, uint32_t led)
 	return led_gpio_set_brightness(dev, led, 0);
 }
 
+static int led_gpio_set_color(const struct device *dev, uint32_t led, uint8_t num_colors,
+			      const uint8_t *color)
+{
+	const struct led_gpio_config *config = dev->config;
+	const struct led_gpio_child *led_child;
+	int err = 0;
+
+	if (led >= config->num_leds) {
+		return -EINVAL;
+	}
+
+	led_child = &config->led[led];
+
+	if (num_colors > led_child->info.num_colors) {
+		return -EINVAL;
+	}
+
+	for (uint8_t i = 0; i < num_colors && !err; i++) {
+		err = gpio_pin_set_dt(&led_child->gpio[i], color[i]);
+
+		if (err) {
+			LOG_ERR("Cannot set GPIO (err %d)", err);
+		}
+	}
+
+	return err;
+}
+
 static int led_gpio_init(const struct device *dev)
 {
 	const struct led_gpio_config *config = dev->config;
+	const struct gpio_dt_spec *led;
 	int err = 0;
 
 	if (!config->num_leds) {
@@ -60,17 +117,19 @@ static int led_gpio_init(const struct device *dev)
 	}
 
 	for (size_t i = 0; (i < config->num_leds) && !err; i++) {
-		const struct gpio_dt_spec *led = &config->led[i];
+		for (uint8_t j = 0; (j < config->led[i].info.num_colors) && !err; j++) {
+			led = &config->led[i].gpio[j];
 
-		if (device_is_ready(led->port)) {
-			err = gpio_pin_configure_dt(led, GPIO_OUTPUT_INACTIVE);
+			if (device_is_ready(led->port)) {
+				err = gpio_pin_configure_dt(led, GPIO_OUTPUT_INACTIVE);
 
-			if (err) {
-				LOG_ERR("Cannot configure GPIO (err %d)", err);
+				if (err) {
+					LOG_ERR("Cannot configure GPIO (err %d)", err);
+				}
+			} else {
+				LOG_ERR("%s: GPIO device not ready", dev->name);
+				err = -ENODEV;
 			}
-		} else {
-			LOG_ERR("%s: GPIO device not ready", dev->name);
-			err = -ENODEV;
 		}
 	}
 
@@ -78,20 +137,49 @@ static int led_gpio_init(const struct device *dev)
 }
 
 static const struct led_driver_api led_gpio_api = {
+	.get_info	= led_gpio_get_info,
 	.on		= led_gpio_on,
 	.off		= led_gpio_off,
 	.set_brightness	= led_gpio_set_brightness,
+	.set_color	= led_gpio_set_color,
 };
+
+#define LED_GPIO_CHILD_GPIO_GET(idx, node_id)			\
+	GPIO_DT_SPEC_GET_BY_IDX(node_id, gpios, idx)
+
+#define LED_GPIO_CHILD_GPIO(node_id, i)				\
+static const struct gpio_dt_spec gpio_dt_spec_##i##_##node_id[] = { \
+	LISTIFY(DT_PROP_LEN(node_id, gpios),			\
+		LED_GPIO_CHILD_GPIO_GET, (,), node_id)		\
+};
+
+#define LED_GPIO_CHILD_COLOR_MAPPING(node_id, i)		\
+static const uint8_t color_mapping_##i##_##node_id[] =		\
+	DT_PROP_OR(node_id, color_mapping, {LED_COLOR_ID_WHITE});
+
+#define LED_GPIO_CHILD(node_id, i)				\
+	{							\
+		.gpio = gpio_dt_spec_##i##_##node_id,		\
+		.info = {					\
+			.label = DT_PROP_OR(node_id, label, NULL), \
+			.index = DT_NODE_CHILD_IDX(node_id),	\
+			.num_colors = DT_PROP_LEN_OR(node_id, color_mapping, 1), \
+			.color_mapping = color_mapping_##i##_##node_id, \
+		},						\
+	}
 
 #define LED_GPIO_DEVICE(i)					\
 								\
-static const struct gpio_dt_spec gpio_dt_spec_##i[] = {		\
-	DT_INST_FOREACH_CHILD_SEP_VARGS(i, GPIO_DT_SPEC_GET, (,), gpios) \
+DT_INST_FOREACH_CHILD_VARGS(i, LED_GPIO_CHILD_GPIO, i)		\
+DT_INST_FOREACH_CHILD_VARGS(i, LED_GPIO_CHILD_COLOR_MAPPING, i)	\
+								\
+static const struct led_gpio_child led_gpio_child_##i[] = {	\
+	DT_INST_FOREACH_CHILD_SEP_VARGS(i, LED_GPIO_CHILD, (,), i) \
 };								\
 								\
 static const struct led_gpio_config led_gpio_config_##i = {	\
-	.num_leds	= ARRAY_SIZE(gpio_dt_spec_##i),	\
-	.led		= gpio_dt_spec_##i,			\
+	.num_leds	= ARRAY_SIZE(led_gpio_child_##i),	\
+	.led		= led_gpio_child_##i,			\
 };								\
 								\
 DEVICE_DT_INST_DEFINE(i, &led_gpio_init, NULL,			\

--- a/dts/bindings/led/gpio-leds.yaml
+++ b/dts/bindings/led/gpio-leds.yaml
@@ -3,8 +3,8 @@
 
 description: |
   This allows you to define a group of LEDs. Each LED in the group is
-  controlled by a GPIO. Each LED is defined in a child node of the
-  gpio-leds node.
+  controlled by one (single-color) or more (multi-color) GPIOs. Each LED is
+  defined in a child node of the gpio-leds node.
 
   Here is an example which defines three LEDs in the node /leds:
 
@@ -20,6 +20,14 @@ description: |
   		led_2 {
   			gpios = <&gpio1 15 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
   		};
+      led_3 {
+        gpios = <&gpio2 0 GPIO_ACTIVE_LOW>,
+                <&gpio2 1 GPIO_ACTIVE_LOW>,
+                <&gpio2 2 GPIO_ACTIVE_LOW>;
+        color-mapping = <LED_COLOR_ID_RED
+                         LED_COLOR_ID_GREEN
+                         LED_COLOR_ID_BLUE>;
+      };
   	};
   };
 
@@ -31,6 +39,10 @@ description: |
     and off when it is low.
   - led_2 is pin 15 on gpio1. The LED is on when the pin is low,
     and the pin's internal pull-up resistor should be enabled.
+  - led_3 is controlled by three pins on gpio2. The LED is a common-anode
+    RGB LED, with the red, green, and blue channels connected to pins 0, 1,
+    and 2, respectively. Each channel is on when the corresponding pin is
+    low, and off when the pin is high.
 
 compatible: "gpio-leds"
 
@@ -40,6 +52,20 @@ child-binding:
     gpios:
       type: phandle-array
       required: true
+    color-mapping:
+      type: array
+      description: |
+        Channel to color mapping (or pixel order). The number of elements
+        in the array must match the number of gpios.
+
+        This property is only required for multi-color LEDs. For single-color
+        LEDs, this property should be omitted.
+
+        For example a GRB channel to color mapping would be
+
+           color-mapping = <LED_COLOR_ID_GREEN
+                            LED_COLOR_ID_RED
+                            LED_COLOR_ID_BLUE>;
     label:
       type: string
       description: |


### PR DESCRIPTION
The current implementation comes with a `set_brightness` which simply turns the LED on for any brightness level higher than 0. Building on this concept, this commit introduces `set_color`, which allows driving either common-anode or common-cathode RGB LEDs with a single API call.