### PR TITLE
drivers: misc: nordic_vpr_launcher: Update src/exec memory size check

### DIFF
--- a/drivers/misc/nordic_vpr_launcher/nordic_vpr_launcher.c
+++ b/drivers/misc/nordic_vpr_launcher/nordic_vpr_launcher.c
@@ -22,7 +22,7 @@ struct nordic_vpr_launcher_config {
 	uintptr_t exec_addr;
 #if DT_ANY_INST_HAS_PROP_STATUS_OKAY(source_memory)
 	uintptr_t src_addr;
-	size_t src_size;
+	size_t size;
 #endif
 };
 
@@ -31,10 +31,10 @@ static int nordic_vpr_launcher_init(const struct device *dev)
 	const struct nordic_vpr_launcher_config *config = dev->config;
 
 #if DT_ANY_INST_HAS_PROP_STATUS_OKAY(source_memory)
-	if (config->src_size > 0U) {
+	if (config->size > 0U) {
 		LOG_DBG("Loading VPR (%p) from %p to %p (%zu bytes)", config->vpr,
-			(void *)config->src_addr, (void *)config->exec_addr, config->src_size);
-		memcpy((void *)config->exec_addr, (void *)config->src_addr, config->src_size);
+			(void *)config->src_addr, (void *)config->exec_addr, config->size);
+		memcpy((void *)config->exec_addr, (void *)config->src_addr, config->size);
 	}
 #endif
 
@@ -51,19 +51,17 @@ static int nordic_vpr_launcher_init(const struct device *dev)
 	 COND_CODE_0(DT_FIXED_PARTITION_EXISTS(node_id), (0), (DT_REG_ADDR(DT_GPARENT(node_id)))))
 
 #define NORDIC_VPR_LAUNCHER_DEFINE(inst)                                                           \
-	COND_CODE_1(DT_NODE_HAS_PROP(inst, source_memory),                                         \
-		    (BUILD_ASSERT((DT_REG_SIZE(DT_INST_PHANDLE(inst, execution_memory)) ==         \
-				   DT_REG_SIZE(DT_INST_PHANDLE(inst, source_memory))),             \
-				  "Source/execution memory sizes mismatch");),                     \
-		    ())                                                                            \
+	IF_ENABLED(DT_INST_NODE_HAS_PROP(inst, source_memory),                                     \
+		   (BUILD_ASSERT((DT_REG_SIZE(DT_INST_PHANDLE(inst, execution_memory)) <=          \
+				  DT_REG_SIZE(DT_INST_PHANDLE(inst, source_memory))),              \
+				 "Execution memory exceeds source memory size");))                 \
                                                                                                    \
 	static const struct nordic_vpr_launcher_config config##inst = {                            \
 		.vpr = (NRF_VPR_Type *)DT_INST_REG_ADDR(inst),                                     \
 		.exec_addr = VPR_ADDR(DT_INST_PHANDLE(inst, execution_memory)),                    \
-		COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, source_memory),                            \
-			    (.src_addr = VPR_ADDR(DT_INST_PHANDLE(inst, source_memory)),           \
-			     .src_size = DT_REG_SIZE(DT_INST_PHANDLE(inst, source_memory)),),      \
-			    ())};                                                                  \
+		IF_ENABLED(DT_INST_NODE_HAS_PROP(inst, source_memory),                             \
+			   (.src_addr = VPR_ADDR(DT_INST_PHANDLE(inst, source_memory)),            \
+			    .size = DT_REG_SIZE(DT_INST_PHANDLE(inst, execution_memory)),))};      \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(inst, nordic_vpr_launcher_init, NULL, NULL, &config##inst,           \
 			      POST_KERNEL, CONFIG_NORDIC_VPR_LAUNCHER_INIT_PRIORITY, NULL);


### PR DESCRIPTION
Firstly, build-asserting the execution/source memory sizes to be equal wasn't working, due to the wrong (non-inst) DT API being used.

Secondly, this assert can be relaxed so that the source memory region only needs to have greater than or equal size to the execution region, as VPR firmware needs to fit into execution memory first and foremost. This will come in handy, since MRAM partitions (typical source memory) have stricter alignment requirements than RAM regions.