### PR TITLE
soc: nordic: Fix validation of base addresses

### DIFF
--- a/soc/nordic/validate_base_addresses.c
+++ b/soc/nordic/validate_base_addresses.c
@@ -90,7 +90,7 @@
  */
 #define CHECK_DT_REG(lbl, mdk_addr)					\
 	BUILD_ASSERT(							\
-		UTIL_OR(UTIL_NOT(DT_NODE_EXISTS(DT_NODELABEL(lbl))),	\
+		UTIL_OR(UTIL_NOT(DT_REG_HAS_IDX(DT_NODELABEL(lbl), 0)),	\
 			(DT_REG_ADDR(DT_NODELABEL(lbl)) == (uint32_t)(mdk_addr))))
 
 /**


### PR DESCRIPTION
Use `DT_REG_HAS_IDX()` instead of `DT_NODE_EXISTS()` when checking if for a given nodelabel the base address of the associated node should be validated, so that the validation is performed only if the base address is available. This prevents build failures in cases like the os_mgmt_datetime test where the `rtc` nodelabel is used for an emulated RTC.

Fixes #70135.