### PR TITLE
mgmt: hawkbit: add support for custom device identity callback

### DIFF
--- a/include/zephyr/mgmt/hawkbit.h
+++ b/include/zephyr/mgmt/hawkbit.h
@@ -96,6 +96,26 @@ enum hawkbit_response hawkbit_probe(void);
 void hawkbit_reboot(void);
 
 /**
+ * @brief Callback to get the device identity.
+ *
+ * @param id Pointer to the buffer to store the device identity
+ * @param id_max_len The maximum length of the buffer
+ */
+typedef bool (*hawkbit_get_device_identity_cb_handler_t)(char *id, int id_max_len);
+
+/**
+ * @brief Set the device identity callback.
+ *
+ * @details This function is used to set a custom device identity callback.
+ *
+ * @param cb The callback function.
+ *
+ * @return 0 on success.
+ * @return -EINVAL if the callback is NULL.
+ */
+int hawkbit_set_device_identity_cb(hawkbit_get_device_identity_cb_handler_t cb);
+
+/**
  * @}
  */
 

--- a/subsys/mgmt/hawkbit/Kconfig
+++ b/subsys/mgmt/hawkbit/Kconfig
@@ -92,6 +92,20 @@ config HAWKBIT_STATUS_BUFFER_SIZE
 	  json strings, that are sent to the hawkBit server. It might
 	  be increased if the custom attributes are used extensively.
 
+config HAWKBIT_CUSTOM_DEVICE_ID
+	bool "Custom device id through callback function"
+	help
+	  Be able to customize the device id during runtime to a custom value,
+	  by configuring the callback function. See `hawkbit_set_device_identity_cb`
+
+config HAWKBIT_DEVICE_ID_MAX_LENGTH
+	int "Maximum length of the device id"
+	depends on HAWKBIT_CUSTOM_DEVICE_ID
+	range 1 128
+	default 32
+	help
+	  Maximum length of the device id.
+
 module = HAWKBIT
 module-str = Log Level for hawkbit
 module-help = Enables logging for hawkBit code.

--- a/subsys/mgmt/hawkbit/hawkbit_device.c
+++ b/subsys/mgmt/hawkbit/hawkbit_device.c
@@ -5,8 +5,19 @@
  */
 #include "hawkbit_device.h"
 #include <string.h>
+#include <zephyr/mgmt/hawkbit.h>
+
+static bool hawkbit_get_device_identity_default(char *id, int id_max_len);
+
+static hawkbit_get_device_identity_cb_handler_t hawkbit_get_device_identity_cb_handler =
+	hawkbit_get_device_identity_default;
 
 bool hawkbit_get_device_identity(char *id, int id_max_len)
+{
+	return hawkbit_get_device_identity_cb_handler(id, id_max_len);
+}
+
+static bool hawkbit_get_device_identity_default(char *id, int id_max_len)
 {
 	uint8_t hwinfo_id[DEVICE_ID_BIN_MAX_SIZE];
 	ssize_t length;
@@ -21,3 +32,16 @@ bool hawkbit_get_device_identity(char *id, int id_max_len)
 
 	return length > 0;
 }
+
+#ifdef CONFIG_HAWKBIT_CUSTOM_DEVICE_ID
+int hawkbit_set_device_identity_cb(hawkbit_get_device_identity_cb_handler_t cb)
+{
+	if (cb == NULL) {
+		return -EINVAL;
+	}
+
+	hawkbit_get_device_identity_cb_handler = cb;
+
+	return 0;
+}
+#endif /* CONFIG_HAWKBIT_CUSTOM_DEVICE_ID */

--- a/subsys/mgmt/hawkbit/hawkbit_device.h
+++ b/subsys/mgmt/hawkbit/hawkbit_device.h
@@ -10,8 +10,13 @@
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/hwinfo.h>
 
+#ifdef CONFIG_HAWKBIT_CUSTOM_DEVICE_ID
+#define DEVICE_ID_BIN_MAX_SIZE	(CONFIG_HAWKBIT_DEVICE_ID_MAX_LENGTH / 2)
+#define DEVICE_ID_HEX_MAX_SIZE	(CONFIG_HAWKBIT_DEVICE_ID_MAX_LENGTH + 1)
+#else
 #define DEVICE_ID_BIN_MAX_SIZE	16
 #define DEVICE_ID_HEX_MAX_SIZE	((DEVICE_ID_BIN_MAX_SIZE * 2) + 1)
+#endif
 
 bool hawkbit_get_device_identity(char *id, int id_max_len);
 


### PR DESCRIPTION
add support for custom device identity callback in hawkbit. This is useful, when the user doesn't want to use the value of `hwinfo_get_device_id()` and instead want to use a custom value, like a serial number.