### PR TITLE
drivers: watchdog: wdt_nrfx.c Fix channel id check in wdt_feed()

### DIFF
--- a/drivers/watchdog/wdt_nrfx.c
+++ b/drivers/watchdog/wdt_nrfx.c
@@ -128,7 +128,7 @@ static int wdt_nrf_feed(const struct device *dev, int channel_id)
 	const struct wdt_nrfx_config *config = dev->config;
 	struct wdt_nrfx_data *data = dev->data;
 
-	if (channel_id > data->m_allocated_channels) {
+	if ((channel_id >= data->m_allocated_channels) || (channel_id < 0)) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
A Bug in the watchdog driver code allows an unconfigured
WDT timer channel to be feed.

The first configured WDT timer channel has an id of zero.
At this point, data->m_allocated_channels is equal to one.
The condition of the if statement is invalid and allows
channel one to be feed.

Change the test condition from greater to greater-or-equal.
Add check if channel id is less than zero.