### PR TITLE
drivers: mbox: Fix nxp,mbox kconfig depends on

### DIFF
--- a/drivers/mbox/Kconfig.nxp_mailbox
+++ b/drivers/mbox/Kconfig.nxp_mailbox
@@ -4,6 +4,6 @@
 config MBOX_NXP_MAILBOX
 	bool "NXP Mailbox driver for MBOX"
 	default y
-	depends on DT_HAS_NXP_LPC_MAILBOX_ENABLED
+	depends on DT_HAS_NXP_MBOX_MAILBOX_ENABLED
 	help
 	  Driver for NXP Mailbox Unit around MBOX.


### PR DESCRIPTION
This commit fixes Kconfig.nxp_mailbox depends on is now set to correct value DT_HAS_NXP_MBOX_MAILBOX_ENABLED.