### PR TITLE
boards/starfive/visionfive2: use `riscv` in the `arch` field

### DIFF
--- a/boards/starfive/visionfive2/visionfive2.yaml
+++ b/boards/starfive/visionfive2/visionfive2.yaml
@@ -1,7 +1,7 @@
 identifier: visionfive2
 name: Visionfive JH7110 (NON-SMP)
 type: mcu
-arch: riscv64
+arch: riscv
 toolchain:
   - zephyr
   - cross-compile


### PR DESCRIPTION
This PR changes the value of the `arch` from `riscv64` to `riscv`, so that it is in line with the rest of the RISC-V boards.