### PR TITLE
drivers: watchdog: wdt_nrfx.c: Unistall timeouts in wdt_disable()

### DIFF
--- a/drivers/watchdog/wdt_nrfx.c
+++ b/drivers/watchdog/wdt_nrfx.c
@@ -60,7 +60,9 @@ static int wdt_nrf_disable(const struct device *dev)
 {
 #if NRFX_WDT_HAS_STOP
 	const struct wdt_nrfx_config *config = dev->config;
+	struct wdt_nrfx_data *data = dev->data;
 	nrfx_err_t err_code;
+	int channel_id;
 
 	err_code = nrfx_wdt_stop(&config->wdt);
 
@@ -68,6 +70,13 @@ static int wdt_nrf_disable(const struct device *dev)
 		/* This can only happen if wdt_nrf_setup() is not called first. */
 		return -EFAULT;
 	}
+
+	nrfx_wdt_channels_free(&config->wdt);
+
+	for (channel_id = 0; channel_id < data->m_allocated_channels; channel_id++) {
+		data->m_callbacks[channel_id] = NULL;
+	}
+	data->m_allocated_channels = 0;
 
 	return 0;
 #else


### PR DESCRIPTION
According to API description, wdt_disable() shall
automatically uninstall all timeouts.
https://docs.zephyrproject.org/latest/hardware/peripherals/watchdog.html

Implement missing wdt_disable() functionality:
- disable WDT RR channels;
- remove callback from timeout channels;
- set data->m_allocated_channels to zero.