### PR TITLE
intel_adsp: adsp_memory: add lpsram and hpsram struct definition

### DIFF
--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -110,6 +110,17 @@
 	};
 
 	soc {
+
+		lsbpm: lsbpm@71d80 {
+			compatible = "intel,adsp-lsbpm";
+			reg = <0x71d80 0x0008>;
+		};
+
+		hsbpm: hsbpm@17a800 {
+			compatible = "intel,adsp-hsbpm";
+			reg = <0x17a800 0x0008>;
+		};
+
 		core_intc: core_intc@0 {
 			compatible = "cdns,xtensa-core-intc";
 			reg = <0x00 0x400>;

--- a/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
@@ -129,6 +129,17 @@
 	};
 
 	soc {
+
+		lsbpm: lsbpm@71d80 {
+			compatible = "intel,adsp-lsbpm";
+			reg = <0x71d80 0x0008>;
+		};
+
+		hsbpm: hsbpm@17a800 {
+			compatible = "intel,adsp-hsbpm";
+			reg = <0x17a800 0x0008>;
+		};
+
 		core_intc: core_intc@0 {
 			compatible = "cdns,xtensa-core-intc";
 			reg = <0x00 0x400>;

--- a/dts/xtensa/intel/intel_adsp_cavs25.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs25.dtsi
@@ -106,6 +106,16 @@
 	};
 
 	soc {
+		lsbpm: lsbpm@71d50 {
+			compatible = "intel,adsp-lsbpm";
+			reg = <0x71d50 0x10>;
+		};
+
+		hsbpm: hsbpm@71d10 {
+			compatible = "intel,adsp-hsbpm";
+			reg = <0x71d10 0x10>;
+		};
+
 		shim: shim@71f00 {
 			compatible = "intel,adsp-shim";
 			reg = <0x71f00 0x100>;

--- a/dts/xtensa/intel/intel_adsp_cavs25_tgph.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs25_tgph.dtsi
@@ -92,6 +92,16 @@
 	};
 
 	soc {
+		lsbpm: lsbpm@71d50 {
+			compatible = "intel,adsp-lsbpm";
+			reg = <0x71d50 0x10>;
+		};
+
+		hsbpm: hsbpm@71d10 {
+			compatible = "intel,adsp-hsbpm";
+			reg = <0x71d10 0x10>;
+		};
+
 		shim: shim@71f00 {
 			compatible = "intel,adsp-shim";
 			reg = <0x71f00 0x100>;

--- a/soc/intel/intel_adsp/ace/include/ace15_mtpm/adsp_memory.h
+++ b/soc/intel/intel_adsp/ace/include/ace15_mtpm/adsp_memory.h
@@ -161,17 +161,17 @@ struct ace_lpsram_regs {
 #endif
 
 /* These registers are for the L2 HP SRAM bank power management control and status.*/
-#define L2HSBPM_REG					0x17A800
-#define L2HSBPM_REG_SIZE			0x0008
+#define L2_HSBPM_BASE (DT_REG_ADDR(DT_NODELABEL(hsbpm)))
+#define L2_HSBPM_SIZE (DT_REG_SIZE(DT_NODELABEL(hsbpm)))
 
 #define HPSRAM_REGS(block_idx)		((volatile struct ace_hpsram_regs *const) \
-	(L2HSBPM_REG + L2HSBPM_REG_SIZE * (block_idx)))
+	(L2_HSBPM_BASE + L2_HSBPM_SIZE * (block_idx)))
 
 /* These registers are for the L2 LP SRAM bank power management control and status.*/
-#define L2LSBPM_REG				0x71D80
-#define L2LSBPM_REG_SIZE			0x0008
+#define L2_LSBPM_BASE (DT_REG_ADDR(DT_NODELABEL(lsbpm)))
+#define L2_LSBPM_SIZE (DT_REG_SIZE(DT_NODELABEL(lsbpm)))
 
 #define LPSRAM_REGS(block_idx)		((volatile struct ace_lpsram_regs *const) \
-	(L2LSBPM_REG + L2LSBPM_REG_SIZE * (block_idx)))
+	(L2_LSBPM_BASE + L2_LSBPM_SIZE * (block_idx)))
 
 #endif /* ZEPHYR_SOC_INTEL_ADSP_MEMORY_H_ */

--- a/soc/intel/intel_adsp/ace/include/ace20_lnl/adsp_memory.h
+++ b/soc/intel/intel_adsp/ace/include/ace20_lnl/adsp_memory.h
@@ -159,17 +159,17 @@ struct ace_lpsram_regs {
 #endif
 
 /* These registers are for the L2 HP SRAM bank power management control and status.*/
-#define L2HSBPM_REG					0x17A800
-#define L2HSBPM_REG_SIZE			0x0008
+#define L2_HSBPM_BASE (DT_REG_ADDR(DT_NODELABEL(hsbpm)))
+#define L2_HSBPM_SIZE (DT_REG_SIZE(DT_NODELABEL(hsbpm)))
 
 #define HPSRAM_REGS(block_idx)		((volatile struct ace_hpsram_regs *const) \
-	(L2HSBPM_REG + L2HSBPM_REG_SIZE * (block_idx)))
+	(L2_HSBPM_BASE + L2_HSBPM_SIZE * (block_idx)))
 
 /* These registers are for the L2 LP SRAM bank power management control and status.*/
-#define L2LSBPM_REG				0x71D80
-#define L2LSBPM_REG_SIZE			0x0008
+#define L2_LSBPM_BASE (DT_REG_ADDR(DT_NODELABEL(lsbpm)))
+#define L2_LSBPM_SIZE (DT_REG_SIZE(DT_NODELABEL(lsbpm)))
 
 #define LPSRAM_REGS(block_idx)		((volatile struct ace_lpsram_regs *const) \
-	(L2LSBPM_REG + L2LSBPM_REG_SIZE * (block_idx)))
+	(L2_LSBPM_BASE + L2_LSBPM_SIZE * (block_idx)))
 
 #endif /* ZEPHYR_SOC_INTEL_ADSP_MEMORY_H_ */

--- a/soc/intel/intel_adsp/cavs/include/cavs25/adsp_memory.h
+++ b/soc/intel/intel_adsp/cavs/include/cavs25/adsp_memory.h
@@ -65,5 +65,40 @@
 /* The number of set associative cache way supported on L1 Instruction Cache */
 #define ADSP_CxL1CCAP_ICMWC ((ADSP_CxL1CCAP_REG >> 20) & 7)
 
+#ifndef _ASMLANGUAGE
+/* L2 Local Memory Management */
+
+struct cavs_hpsram_regs {
+	/** @brief power gating control */
+	uint32_t HSxPGCTL;
+	/** @brief retention mode control */
+	uint32_t HSxRMCTL;
+	/** @brief power gating status */
+	uint32_t HSxPGISTS;
+};
+
+struct cavs_lpsram_regs {
+	/** @brief power gating control */
+	uint32_t USxPGCTL;
+	/** @brief retention mode control */
+	uint32_t USxRMCTL;
+	/** @brief power gating status */
+	uint32_t USxPGISTS;
+};
+#endif /* _ASMLANGUAGE */
+
+/* These registers are for the L2 HP SRAM bank power management control and status.*/
+#define L2_HSBPM_BASE (DT_REG_ADDR(DT_NODELABEL(hsbpm)))
+#define L2_HSBPM_SIZE (DT_REG_SIZE(DT_NODELABEL(hsbpm)))
+
+#define HPSRAM_REGS(block_idx)		((volatile struct cavs_hpsram_regs *const) \
+	(L2_HSBPM_BASE + L2_HSBPM_SIZE * (block_idx)))
+
+/* These registers are for the L2 LP SRAM bank power management control and status.*/
+#define L2_LSBPM_BASE (DT_REG_ADDR(DT_NODELABEL(lsbpm)))
+#define L2_LSBPM_SIZE (DT_REG_SIZE(DT_NODELABEL(lsbpm)))
+
+#define LPSRAM_REGS(block_idx)		((volatile struct cavs_lpsram_regs *const) \
+	(L2_LSBPM_BASE + L2_LSBPM_SIZE * (block_idx)))
 
 #endif /* ZEPHYR_SOC_INTEL_ADSP_MEMORY_H_ */


### PR DESCRIPTION
Added new structures and definitions for power management control and status in adsp_memory.h.

This change will allow the removal of address definitions for lpsram and hpsram outside of the Zephyr part.