### PR TITLE
Fixes for ieee802154 on nRF54H20

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
@@ -26,6 +26,7 @@
 		zephyr,shell-uart = &uart136;
 		zephyr,ieee802154 = &cpuapp_ieee802154;
 		zephyr,bt-hci-ipc = &ipc0;
+		nordic,802154-spinel-ipc = &ipc0;
 	};
 
 	aliases {

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
@@ -24,6 +24,7 @@
 		zephyr,flash = &mram1x;
 		zephyr,sram = &cpuapp_data;
 		zephyr,shell-uart = &uart136;
+		zephyr,ieee802154 = &cpuapp_ieee802154;
 		zephyr,bt-hci-ipc = &ipc0;
 	};
 
@@ -223,4 +224,8 @@ ipc0: &cpuapp_cpurad_ipc {
 		t-enter-dpd = <10000>;
 		t-exit-dpd = <30000>;
 	};
+};
+
+&cpuapp_ieee802154 {
+	status = "okay";
 };

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
@@ -25,6 +25,7 @@
 		zephyr,flash = &mram1x;
 		zephyr,sram = &cpurad_ram0;
 		zephyr,shell-uart = &uart135;
+		zephyr,ieee802154 = &cpurad_ieee802154;
 		zephyr,bt-hci-ipc = &ipc0;
 	};
 };
@@ -97,4 +98,8 @@ ipc0: &cpuapp_cpurad_ipc {
 	pinctrl-0 = <&uart136_default>;
 	pinctrl-1 = <&uart136_sleep>;
 	pinctrl-names = "default", "sleep";
+};
+
+&cpurad_ieee802154 {
+	status = "okay";
 };

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
@@ -27,6 +27,7 @@
 		zephyr,shell-uart = &uart135;
 		zephyr,ieee802154 = &cpurad_ieee802154;
 		zephyr,bt-hci-ipc = &ipc0;
+		nordic,802154-spinel-ipc = &ipc0;
 	};
 };
 

--- a/drivers/ieee802154/Kconfig.nrf5
+++ b/drivers/ieee802154/Kconfig.nrf5
@@ -72,7 +72,7 @@ config IEEE802154_NRF5_FCS_IN_LENGTH
 
 config IEEE802154_NRF5_DELAY_TRX_ACC
 	int "Clock accuracy for delayed operations"
-	default CLOCK_CONTROL_NRF_ACCURACY if CLOCK_CONTROL_NRF_ACCURACY < 255
+	default CLOCK_CONTROL_NRF_ACCURACY if (CLOCK_CONTROL_NRF && (CLOCK_CONTROL_NRF_ACCURACY < 255))
 	default 255
 	help
 	  Accuracy of the clock used for scheduling radio delayed operations (delayed transmission

--- a/dts/common/nordic/nrf54h20.dtsi
+++ b/dts/common/nordic/nrf54h20.dtsi
@@ -182,6 +182,11 @@
 				status = "disabled";
 				interrupts = <21 NRF_DEFAULT_IRQ_PRIORITY>;
 			};
+
+			cpuapp_ieee802154: ieee802154 {
+				compatible = "nordic,nrf-ieee802154";
+				status = "disabled";
+			};
 		};
 
 		cpurad_peripherals: peripheral@53000000 {

--- a/modules/hal_nordic/nrfx/nrfx_glue.h
+++ b/modules/hal_nordic/nrfx/nrfx_glue.h
@@ -368,6 +368,10 @@ void nrfx_busy_wait(uint32_t usec_to_wait);
 #include <../src/nrf_802154_peripherals_nrf54l.h>
 #define NRFX_PPI_CHANNELS_USED_BY_802154_DRV   NRF_802154_DPPI_CHANNELS_USED_MASK
 #define NRFX_PPI_GROUPS_USED_BY_802154_DRV     NRF_802154_DPPI_GROUPS_USED_MASK
+#elif defined(NRF54H_SERIES)
+#include <../src/nrf_802154_peripherals_nrf54h.h>
+#define NRFX_PPI_CHANNELS_USED_BY_802154_DRV   NRF_802154_DPPI_CHANNELS_USED_MASK
+#define NRFX_PPI_GROUPS_USED_BY_802154_DRV     NRF_802154_DPPI_GROUPS_USED_MASK
 #else
 #error Unsupported chip family
 #endif


### PR DESCRIPTION
The fixes suggested in this PR still not allow to build any ieee802154-based application for nRF54H20 but hopefully they're a step in the right direction.