### PR TITLE
twister: use enum for the `arch` field in Twister platform schema

### DIFF
--- a/scripts/schemas/twister/platform-schema.yaml
+++ b/scripts/schemas/twister/platform-schema.yaml
@@ -41,6 +41,23 @@ mapping:
     type: str
   "arch":
     type: str
+    enum:
+      [
+        # architectures
+        "arc",
+        "arm",
+        "arm64",
+        "mips",
+        "nios2",
+        "posix",
+        "riscv",
+        "sparc",
+        "x86",
+        "xtensa",
+
+        # unit testing
+        "unit",
+      ]
   "vendor":
     type: str
   "tier":


### PR DESCRIPTION
This commit adds an enum to the `arch` field of the Twister platform schema. This helps better filter boards for testcases which use architecture-based filters, and helps maintain uniformity in naming convetion.