### PR TITLE
soc: rcar_gen3: set correct NUM_IRQS for ARM64 R-Car Gen3 boards

### DIFF
--- a/soc/renesas/rcar/rcar_gen3/Kconfig.defconfig
+++ b/soc/renesas/rcar/rcar_gen3/Kconfig.defconfig
@@ -6,8 +6,7 @@
 if SOC_SERIES_RCAR_GEN3
 
 config NUM_IRQS
-	default 512 if SOC_R8A77951_R7
-	default 240 if SOC_R8A77961 || SOC_R8A77951_A57
+	default 512
 
 config PINCTRL
 	default y


### PR DESCRIPTION
Align number of interrupts for ARM64 R-Car Gen3 boards with the documentation.