### PR TITLE
Bluetooth: Mesh: Warn if can't listen to unprov beacons until provisioned

### DIFF
--- a/subsys/bluetooth/mesh/shell/shell.c
+++ b/subsys/bluetooth/mesh/shell/shell.c
@@ -726,6 +726,11 @@ static int cmd_beacon_listen(const struct shell *sh, size_t argc,
 		return err;
 	}
 
+	if (!bt_mesh_is_provisioned()) {
+		shell_error(sh, "Not yet provisioned");
+		return -EINVAL;
+	}
+
 	if (val) {
 		bt_mesh_shell_prov.unprovisioned_beacon = print_unprovisioned_beacon;
 #if defined(CONFIG_BT_MESH_PB_GATT_CLIENT)


### PR DESCRIPTION
When calling `mesh prov beacon-listen on` shell command before provisioning the local device, the stack won't report unprovisioned beacons. This is because the scanner has not been started yet. This behavior confuses users. Print a warning that the device needs to be provisioned first before it can listen to unprovisioned beacons.