### PR TITLE
samples: hello_world: Use full board target string for hwmv2 boards

### DIFF
--- a/samples/hello_world/src/main.c
+++ b/samples/hello_world/src/main.c
@@ -8,6 +8,13 @@
 
 int main(void)
 {
-	printf("Hello World! %s\n", CONFIG_BOARD);
+	printf("Hello World! %s\n",
+#ifdef CONFIG_BOARD_TARGET
+	       CONFIG_BOARD_TARGET
+#else
+	       CONFIG_BOARD
+#endif
+	);
+
 	return 0;
 }


### PR DESCRIPTION
Outputs the full board target string (including qualifiers) when using a hwmv2 board