### PR TITLE
lib: posix: shell: Fix compiler warning of lib__posix__shell

### DIFF
--- a/lib/posix/CMakeLists.txt
+++ b/lib/posix/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_subdirectory(options)
-add_subdirectory(shell)
+add_subdirectory_ifdef(CONFIG_POSIX_SHELL shell)


### PR DESCRIPTION
This PR fixes the following compiler warning:
No SOURCES given to Zephyr library: lib__posix__shell