### PR TITLE
mgmt: hawkbit: Add support for reboot after update

### DIFF
--- a/include/zephyr/mgmt/hawkbit.h
+++ b/include/zephyr/mgmt/hawkbit.h
@@ -64,6 +64,11 @@ void hawkbit_autohandler(void);
 enum hawkbit_response hawkbit_probe(void);
 
 /**
+ * @brief Request system to reboot.
+ */
+void hawkbit_reboot(void);
+
+/**
  * @}
  */
 

--- a/subsys/mgmt/hawkbit/hawkbit.c
+++ b/subsys/mgmt/hawkbit/hawkbit.c
@@ -961,6 +961,12 @@ static bool send_request(enum http_method method, enum hawkbit_http_request type
 	return true;
 }
 
+void hawkbit_reboot(void)
+{
+	LOG_PANIC();
+	sys_reboot(SYS_REBOOT_WARM);
+}
+
 enum hawkbit_response hawkbit_probe(void)
 {
 	int ret;
@@ -1203,8 +1209,7 @@ static void autohandler(struct k_work *work)
 		LOG_ERR("Rebooting to previous confirmed image");
 		LOG_ERR("If this image is flashed using a hardware tool");
 		LOG_ERR("Make sure that it is a confirmed image");
-		k_sleep(K_SECONDS(1));
-		sys_reboot(SYS_REBOOT_WARM);
+		hawkbit_reboot();
 		break;
 
 	case HAWKBIT_NO_UPDATE:
@@ -1220,7 +1225,8 @@ static void autohandler(struct k_work *work)
 		break;
 
 	case HAWKBIT_UPDATE_INSTALLED:
-		LOG_INF("Update installed, please reboot");
+		LOG_INF("Update installed");
+		hawkbit_reboot();
 		break;
 
 	case HAWKBIT_DOWNLOAD_ERROR:

--- a/subsys/mgmt/hawkbit/shell.c
+++ b/subsys/mgmt/hawkbit/shell.c
@@ -8,7 +8,6 @@
 #include <zephyr/drivers/flash.h>
 #include <zephyr/dfu/mcuboot.h>
 #include <zephyr/dfu/flash_img.h>
-#include <zephyr/sys/reboot.h>
 #include <zephyr/mgmt/hawkbit.h>
 #include "hawkbit_firmware.h"
 #include "hawkbit_device.h"
@@ -25,7 +24,7 @@ static void cmd_run(const struct shell *sh, size_t argc, char **argv)
 			sh, SHELL_ERROR,
 			"Image is unconfirmed."
 			"Rebooting to revert back to previous confirmed image\n");
-		sys_reboot(SYS_REBOOT_WARM);
+		hawkbit_reboot();
 		break;
 
 	case HAWKBIT_CANCEL_UPDATE:
@@ -43,6 +42,7 @@ static void cmd_run(const struct shell *sh, size_t argc, char **argv)
 
 	case HAWKBIT_UPDATE_INSTALLED:
 		shell_fprintf(sh, SHELL_INFO, "Update Installed\n");
+		hawkbit_reboot();
 		break;
 
 	case HAWKBIT_DOWNLOAD_ERROR:


### PR DESCRIPTION
Add support for reboot after successful update completion. Normally you want to reboot the device to apply the new firmware after a successful update.