### PR TITLE
boards: frdm_mcxn947: Move the GPIO button nodes to the common file

### DIFF
--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
@@ -11,6 +11,8 @@
 		led0 = &red_led;
 		led1 = &green_led;
 		led2 = &blue_led;
+		sw0 = &user_button_2;
+		sw1 = &user_button_3;
 	};
 
 	leds {
@@ -28,6 +30,20 @@
 		red_led: led_3 {
 			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			label = "Red LED";
+			status = "disabled";
+		};
+	};
+
+	gpio_keys {
+		compatible = "gpio-keys";
+		user_button_2: button_0 {
+			label = "User SW2";
+			gpios = <&gpio0 23 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			status = "disabled";
+		};
+		user_button_3: button_1 {
+			label = "User SW3";
+			gpios = <&gpio0 6 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 			status = "disabled";
 		};
 	};

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.dts
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.dts
@@ -17,29 +17,12 @@
 		/delete-node/ cpu@1;
 	};
 
-	aliases{
-		sw0 = &user_button_3;
-		sw1 = &user_button_2;
-	};
-
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash;
 		zephyr,flash-controller = &fmu;
 		zephyr,console = &flexcomm4_lpuart4;
 		zephyr,shell-uart = &flexcomm4_lpuart4;
-	};
-
-	gpio_keys {
-		compatible = "gpio-keys";
-		user_button_2: button_0 {
-			label = "User SW2";
-			gpios = <&gpio0 29 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
-		};
-		user_button_3: button_1 {
-			label = "User SW3";
-			gpios = <&gpio0 6 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
-		};
 	};
 };
 
@@ -74,6 +57,10 @@
 };
 
 &red_led {
+	status = "okay";
+};
+
+&user_button_2 {
 	status = "okay";
 };
 


### PR DESCRIPTION
Move the GPIO button dts nodes to the common dts file so it be selected by either cpu core.
Also fix an error in the GPIO setting for one of the switches.