### PR TITLE
soc: nxp: imxrt: fix dependencies of NXP_IMXRT_BOOT_HEADER for RT11xx

### DIFF
--- a/soc/nxp/imxrt/imxrt11xx/Kconfig.defconfig
+++ b/soc/nxp/imxrt/imxrt11xx/Kconfig.defconfig
@@ -29,7 +29,8 @@ if SECOND_CORE_MCUX
 
 # RT Boot header is only needed on primary core
 config NXP_IMXRT_BOOT_HEADER
-	depends on CPU_CORTEX_M7
+	default y
+	depends on !(CPU_CORTEX_M4 || BOOTLOADER_MCUBOOT)
 
 endif
 endif


### PR DESCRIPTION
Dependencies of NXP_IMXRT_BOOT_HEADER were set incorrectly for the RT11xx series part when building a dual core image. The boot header should be enabled by default for the primary M7 core, and always disabled when MCUBOOT is used or the M4 core is targeted