### PR TITLE
boards: rd_rw612_bga: Enable entropy

### DIFF
--- a/boards/nxp/rd_rw612_bga/doc/index.rst
+++ b/boards/nxp/rd_rw612_bga/doc/index.rst
@@ -45,6 +45,8 @@ Supported Features
 +-----------+------------+-----------------------------------+
 | I2C       | on-chip    | i2c                               |
 +-----------+------------+-----------------------------------+
+| TRNG      | on-chip    | entropy                           |
++-----------+------------+-----------------------------------+
 
 
 The default configuration can be found in the defconfig file:

--- a/boards/nxp/rd_rw612_bga/rd_rw612_bga.yaml
+++ b/boards/nxp/rd_rw612_bga/rd_rw612_bga.yaml
@@ -19,3 +19,4 @@ supported:
   - gpio
   - spi
   - i2c
+  - entropy

--- a/dts/arm/nxp/nxp_rw6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rw6xx_common.dtsi
@@ -10,6 +10,10 @@
 #include <dt-bindings/i2c/i2c.h>
 
 / {
+	chosen {
+		zephyr,entropy = &trng;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -63,6 +67,13 @@
 		compatible = "nxp,lpc-syscon";
 		reg = <0x21000 0x1000>;
 		#clock-cells = <1>;
+	};
+
+	trng: random@14000 {
+		compatible = "nxp,kinetis-trng";
+		reg = <0x14000 0x1000>;
+		status = "okay";
+		interrupts = <123 0>;
 	};
 
 	hsgpio0: hsgpio@0 {


### PR DESCRIPTION
Enable entropy on RW6XX soc and indicate support on the reference board.