### PR TITLE
Bluetooth: CAP: Fix issue with codec_cfg in CAP uni start

### DIFF
--- a/include/zephyr/bluetooth/audio/cap.h
+++ b/include/zephyr/bluetooth/audio/cap.h
@@ -226,6 +226,9 @@ struct bt_cap_unicast_audio_start_stream_param {
 	 * The @p codec_cfg.meta shall include a list of CCIDs
 	 * (@ref BT_AUDIO_METADATA_TYPE_CCID_LIST) as well as a non-0
 	 * stream context (@ref BT_AUDIO_METADATA_TYPE_STREAM_CONTEXT) bitfield.
+	 *
+	 * This value is assigned to the @p stream, and shall remain valid while the stream is
+	 * non-idle.
 	 */
 	struct bt_audio_codec_cfg *codec_cfg;
 };

--- a/subsys/bluetooth/audio/cap_initiator.c
+++ b/subsys/bluetooth/audio/cap_initiator.c
@@ -507,8 +507,7 @@ static int cap_initiator_unicast_audio_configure(
 		active_proc->proc_param.initiator[i].stream = cap_stream;
 		active_proc->proc_param.initiator[i].start.ep = stream_param->ep;
 		active_proc->proc_param.initiator[i].start.conn = conn;
-		memcpy(&active_proc->proc_param.initiator[i].start.codec_cfg,
-		       stream_param->codec_cfg, sizeof(*stream_param->codec_cfg));
+		active_proc->proc_param.initiator[i].start.codec_cfg = stream_param->codec_cfg;
 	}
 
 	/* Store the information about the active procedure so that we can
@@ -519,7 +518,7 @@ static int cap_initiator_unicast_audio_configure(
 
 	proc_param = &active_proc->proc_param.initiator[0];
 	bap_stream = &proc_param->stream->bap_stream;
-	codec_cfg = &proc_param->start.codec_cfg;
+	codec_cfg = proc_param->start.codec_cfg;
 	conn = proc_param->start.conn;
 	ep = proc_param->start.ep;
 	active_proc->proc_initiated_cnt++;
@@ -603,7 +602,7 @@ void bt_cap_initiator_codec_configured(struct bt_cap_stream *cap_stream)
 		next_cap_stream = proc_param->stream;
 		conn = proc_param->start.conn;
 		ep = proc_param->start.ep;
-		codec_cfg = &proc_param->start.codec_cfg;
+		codec_cfg = proc_param->start.codec_cfg;
 		bap_stream = &next_cap_stream->bap_stream;
 		active_proc->proc_initiated_cnt++;
 

--- a/subsys/bluetooth/audio/cap_internal.h
+++ b/subsys/bluetooth/audio/cap_internal.h
@@ -59,7 +59,7 @@ struct bt_cap_initiator_proc_param {
 		struct {
 			struct bt_conn *conn;
 			struct bt_bap_ep *ep;
-			struct bt_audio_codec_cfg codec_cfg;
+			struct bt_audio_codec_cfg *codec_cfg;
 		} start;
 		struct {
 			/** Codec Specific Capabilities Metadata count */


### PR DESCRIPTION
The codecs used for the bap bt_bap_stream_config was only valid for the lifetime of the procedure, which meant that by the end of the procedure the stream->codec_cfg became invalid.

This is fixed by using the pointer provided to the CAP API, and documentating the lifetime of the codec_cfg.