### PR TITLE
twister: qemu: Fix device tests skipped when QEMU not installed

### DIFF
--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -215,7 +215,7 @@ class TestInstance:
                 return False
 
             # check presence of QEMU on Windows
-            if 'QEMU_BIN_PATH' not in os.environ:
+            if self.platform.simulation == 'qemu' and 'QEMU_BIN_PATH' not in os.environ:
                 return False
 
         # we asked for build-only on the command line


### PR DESCRIPTION
https://github.com/zephyrproject-rtos/zephyr/pull/67595 introduces a bug where if QEMU_BIN_PATH is not set on a Windows PC, on-device tests are skipped. This fixes that issue.