### PR TITLE
west_commands: sign: suppress imgtool prints when `args.quiet`

### DIFF
--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -299,7 +299,7 @@ class ImgtoolSigner(Signer):
                 log.inf(f'unsigned bin: {in_bin}')
                 log.inf(f'signed bin:   {out_bin}')
                 log.dbg(quote_sh_list(sign_bin))
-            subprocess.check_call(sign_bin)
+            subprocess.check_call(sign_bin, stdout=subprocess.PIPE if args.quiet else None)
         if in_hex:
             out_hex = args.shex or str(b / 'zephyr' / 'zephyr.signed.hex')
             sign_hex = sign_base + [in_hex, out_hex]
@@ -307,7 +307,7 @@ class ImgtoolSigner(Signer):
                 log.inf(f'unsigned hex: {in_hex}')
                 log.inf(f'signed hex:   {out_hex}')
                 log.dbg(quote_sh_list(sign_hex))
-            subprocess.check_call(sign_hex)
+            subprocess.check_call(sign_hex, stdout=subprocess.PIPE if args.quiet else None)
 
     @staticmethod
     def find_imgtool(command, args):


### PR DESCRIPTION
If `args.quiet` is set, suppress the useless `print` statements output by `imgtool` (mcuboot script) by capturing `stdout`.

Old output:
```
[44/44] Linking C executable zephyr/zephyr.elf
Memory region         Used Size  Region Size  %age Used
           FLASH:      415192 B       824 KB     49.21%
             RAM:      163124 B       256 KB     62.23%
        IDT_LIST:          0 GB         2 KB      0.00%
image.py: sign the payload
image.py: sign the payload
```
New output:
```
[44/44] Linking C executable zephyr/zephyr.elf
Memory region         Used Size  Region Size  %age Used
           FLASH:      415192 B       824 KB     49.21%
             RAM:      163124 B       256 KB     62.23%
        IDT_LIST:          0 GB         2 KB      0.00%
```