### PR TITLE
net: ipv6: fix link local ping fail with default router

### DIFF
--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -866,6 +866,8 @@ ignore_frag_error:
 	if (net_if_ipv6_addr_onlink(&iface, (struct in6_addr *)ip_hdr->dst)) {
 		nexthop = (struct in6_addr *)ip_hdr->dst;
 		net_pkt_set_iface(pkt, iface);
+	} else if (net_ipv6_is_ll_addr((struct in6_addr *)ip_hdr->dst)) {
+		nexthop = (struct in6_addr *)ip_hdr->dst;
 	} else {
 		/* We need to figure out where the destination
 		 * host is located.


### PR DESCRIPTION
When we receive Router Advertisement with life time, we will add this as default router.
Then when we ping ipv6 neighbour link local address, which is never on link, we will use default router. And we will find another neighbour to send ping echo request. And we will not get reply so ping fail.

Fix it by link local address does not check route.