### PR TITLE
logging: backends: multidomain: Fix compilation warning

### DIFF
--- a/subsys/logging/backends/log_multidomain_backend.c
+++ b/subsys/logging/backends/log_multidomain_backend.c
@@ -32,13 +32,16 @@ static void process(const struct log_backend *const backend,
 		return;
 	}
 
-	/* Need to ensure that package is aligned to a pointer size. */
+	/* Need to ensure that package is aligned to a pointer size even though
+	 * it is in the packed structured.
+	 */
 	uint32_t msg_len = Z_LOG_MSG_LEN(fsc_plen, dlen);
 	uint8_t buf[msg_len + sizeof(void *)] __aligned(sizeof(void *));
 	size_t msg_offset = offsetof(struct log_multidomain_msg, data);
 	struct log_multidomain_msg *out_msg =
 		(struct log_multidomain_msg *)&buf[sizeof(void *) - msg_offset];
-	struct log_msg *out_log_msg = (struct log_msg *)out_msg->data.log_msg.data;
+	uintptr_t out_log_msg_ptr = (uintptr_t)out_msg->data.log_msg.data;
+	struct log_msg *out_log_msg = (struct log_msg *)out_log_msg_ptr;
 
 	/* Set ipc message id. */
 	out_msg->id = Z_LOG_MULTIDOMAIN_ID_MSG;


### PR DESCRIPTION
Fix compilation warning due to taking member from a packed structure and assigning it to a pointer. Compiler warns that it may be unaligned. However, it is ensured that it will be aligned by operations preceding this assignment.