### PR TITLE
net: igmp: Fix double unref of igmp packet

### DIFF
--- a/subsys/net/ip/igmp.c
+++ b/subsys/net/ip/igmp.c
@@ -255,7 +255,6 @@ static int igmp_send(struct net_pkt *pkt)
 	ret = net_send_data(pkt);
 	if (ret < 0) {
 		net_stats_update_ipv4_igmp_drop(net_pkt_iface(pkt));
-		net_pkt_unref(pkt);
 		return ret;
 	}
 


### PR DESCRIPTION
If send the igmp packet when lower interface is down, the packet will be freed twice and show error log. Remove the net_pkt_unref in igmp_send(), and let the caller free it.