### PR TITLE
boards: lairdconnect: bl5340_dvk: Fix file name

### DIFF
--- a/boards/lairdconnect/bl5340_dvk/CMakeLists.txt
+++ b/boards/lairdconnect/bl5340_dvk/CMakeLists.txt
@@ -5,7 +5,7 @@
 if((CONFIG_BOARD_BL5340_DVK_NRF5340_CPUAPP OR CONFIG_BOARD_BL5340_DVK_NRF5340_CPUAPP_NS)
    AND CONFIG_BOARD_ENABLE_CPUNET)
   zephyr_library()
-  zephyr_library_sources(bl5340_dvk_cpunet_reset.c)
+  zephyr_library_sources(bl5340_dvk_nrf5340_cpunet_reset.c)
 
   if(CONFIG_BUILD_WITH_TFM)
     zephyr_library_include_directories(


### PR DESCRIPTION
Fixes an wrong file name for a file that had been renamed as part of the hwmv2 port