### PR TITLE
ITE: drivers/i2c/target: Remove hardware reset setting

### DIFF
--- a/drivers/i2c/i2c_ite_enhance.c
+++ b/drivers/i2c/i2c_ite_enhance.c
@@ -1045,10 +1045,6 @@ static void target_i2c_isr_dma(const struct device *dev,
 
 	/* Write clear the peripheral status */
 	IT8XXX2_I2C_IRQ_ST(base) = interrupt_status;
-	if (interrupt_status & IT8XXX2_I2C_INT_ANY) {
-		/* Hardware reset */
-		IT8XXX2_I2C_CTR(base) |= IT8XXX2_I2C_HALT;
-	}
 }
 
 static int target_i2c_isr_pio(const struct device *dev,

--- a/soc/ite/ec/common/chip_chipregs.h
+++ b/soc/ite/ec/common/chip_chipregs.h
@@ -1433,8 +1433,6 @@ enum chip_pll_mode {
 #define IT8XXX2_I2C_IDR_CLR           BIT(2)
 #define IT8XXX2_I2C_SLVDATAFLG        BIT(1)
 #define IT8XXX2_I2C_P_CLR             BIT(0)
-#define IT8XXX2_I2C_INT_ANY           (IT8XXX2_I2C_CNT_HOLD | IT8XXX2_I2C_IDW_CLR | \
-				       IT8XXX2_I2C_IDR_CLR | IT8XXX2_I2C_SLVDATAFLG)
 /* 0x13: Nack Status */
 #define IT8XXX2_I2C_NST_CNS           BIT(7)
 #define IT8XXX2_I2C_NST_ID_NACK       BIT(3)


### PR DESCRIPTION
In the interrupt pending routine, only the interrupt status needs to be cleared at the end of the interrupt routine. There is no need to do a hardware reset(HALT) to avoid clearing the next transfer interrupt when the current transfer is completed.

Test: Testing this function does not cause I2C data/clk to get stuck on the system platform.