### PR TITLE
logging: log: add `LOG_WRN_ONCE`

### DIFF
--- a/doc/services/logging/index.rst
+++ b/doc/services/logging/index.rst
@@ -46,7 +46,7 @@ There are four severity levels available in the system: error, warning, info
 and debug. For each severity level the logging API (:zephyr_file:`include/zephyr/logging/log.h`)
 has set of dedicated macros. Logger API also has macros for logging data.
 
-For each level following set of macros are available:
+For each level the following set of macros are available:
 
 - ``LOG_X`` for standard printf-like messages, e.g. :c:macro:`LOG_ERR`.
 - ``LOG_HEXDUMP_X`` for dumping data, e.g. :c:macro:`LOG_HEXDUMP_WRN`.
@@ -54,6 +54,10 @@ For each level following set of macros are available:
   particular instance, e.g. :c:macro:`LOG_INST_INF`.
 - ``LOG_INST_HEXDUMP_X`` for dumping data associated with the particular
   instance, e.g. :c:macro:`LOG_HEXDUMP_INST_DBG`
+
+The warning level also exposes the following additional macro:
+
+- :c:macro:`LOG_WRN_ONCE` for warnings where only the first occurrence is of interest.
 
 There are two configuration categories: configurations per module and global
 configuration. When logging is enabled globally, it works for modules. However,

--- a/include/zephyr/logging/log.h
+++ b/include/zephyr/logging/log.h
@@ -73,6 +73,24 @@ extern "C" {
 #define LOG_DBG(...)    Z_LOG(LOG_LEVEL_DBG, __VA_ARGS__)
 
 /**
+ * @brief Writes a WARNING level message to the log on the first execution only.
+ *
+ * @details It's meant for situations that warrant investigation but could clutter
+ * the logs if output on every execution.
+ *
+ * @param ... A string optionally containing printk valid conversion specifier,
+ * followed by as many values as specifiers.
+ */
+#define LOG_WRN_ONCE(...)					\
+	do {							\
+		static uint8_t __warned;			\
+		if (unlikely(__warned == 0)) {			\
+			Z_LOG(LOG_LEVEL_WRN, __VA_ARGS__);	\
+			__warned = 1;				\
+		}						\
+	} while (0)
+
+/**
  * @brief Unconditionally print raw log message.
  *
  * The result is same as if printk was used but it goes through logging

--- a/tests/subsys/logging/log_api/src/main.c
+++ b/tests/subsys/logging/log_api/src/main.c
@@ -797,6 +797,29 @@ ZTEST(test_log_api, test_log_arg_evaluation)
 #undef TEST_MSG_0_PREFIX
 }
 
+static void log_wrn_once_run(int i)
+{
+	LOG_WRN_ONCE("once %d", i);
+}
+
+ZTEST(test_log_api, test_log_wrn_once)
+{
+	log_timestamp_t exp_timestamp = TIMESTAMP_INIT_VAL;
+
+	log_setup(false);
+
+	mock_log_frontend_record(LOG_CURRENT_MODULE_ID(), LOG_LEVEL_WRN, "once 0");
+	mock_log_backend_record(&backend1, LOG_CURRENT_MODULE_ID(),
+				Z_LOG_LOCAL_DOMAIN_ID, LOG_LEVEL_WRN,
+				exp_timestamp++, "once 0");
+
+	log_wrn_once_run(0);
+	log_wrn_once_run(1);
+	log_wrn_once_run(2);
+
+	process_and_validate(false, false);
+}
+
 ZTEST(test_log_api, test_log_override_level)
 {
 	log_timestamp_t exp_timestamp = TIMESTAMP_INIT_VAL;


### PR DESCRIPTION
Add an equivalent to the linux `WARN_ONCE` macro. This is intended for
use when the developer should be notified of an event, but may occur a
multitude of times in quick succession.

Using `LOG_WRN` could result in either cluttered logs or recursive
logging (i.e. in serial drivers).

Proposed in the discussion of #65112