### PR TITLE
subsys: input: rename the internal callback struct to input_callback

### DIFF
--- a/cmake/linker_script/common/common-rom.cmake
+++ b/cmake/linker_script/common/common-rom.cmake
@@ -207,7 +207,7 @@ if (CONFIG_HTTP_SERVER)
 endif()
 
 if(CONFIG_INPUT)
-  zephyr_iterable_section(NAME input_listener KVMA RAM_REGION GROUP RODATA_REGION SUBALIGN 4)
+  zephyr_iterable_section(NAME input_callback KVMA RAM_REGION GROUP RODATA_REGION SUBALIGN 4)
 endif()
 
 if(CONFIG_USBD_MSC_CLASS)

--- a/include/zephyr/input/input.h
+++ b/include/zephyr/input/input.h
@@ -50,7 +50,7 @@ struct input_event {
 /**
  * @brief Report a new input event.
  *
- * This causes all the listeners for the specified device to be triggered,
+ * This causes all the callbacks for the specified device to be executed,
  * either synchronously or through the input thread if utilized.
  *
  * @param dev Device generating the event or NULL.
@@ -116,9 +116,9 @@ static inline int input_report_abs(const struct device *dev,
 bool input_queue_empty(void);
 
 /**
- * @brief Input listener callback structure.
+ * @brief Input callback structure.
  */
-struct input_listener {
+struct input_callback {
 	/** @ref device pointer or NULL. */
 	const struct device *dev;
 	/** The callback function. */
@@ -136,8 +136,8 @@ struct input_listener {
  * @param _callback The callback function.
  */
 #define INPUT_CALLBACK_DEFINE(_dev, _callback)                                 \
-	static const STRUCT_SECTION_ITERABLE(input_listener,                   \
-					     _input_listener__##_callback) = { \
+	static const STRUCT_SECTION_ITERABLE(input_callback,                   \
+					     _input_callback__##_callback) = { \
 		.dev = _dev,                                                   \
 		.callback = _callback,                                         \
 	}

--- a/include/zephyr/linker/common-rom/common-rom-misc.ld
+++ b/include/zephyr/linker/common-rom/common-rom-misc.ld
@@ -27,7 +27,7 @@
 #endif
 
 #if defined(CONFIG_INPUT)
-	ITERABLE_SECTION_ROM(input_listener, 4)
+	ITERABLE_SECTION_ROM(input_callback, 4)
 #endif
 
 #if defined(CONFIG_EMUL)

--- a/subsys/input/input.c
+++ b/subsys/input/input.c
@@ -20,9 +20,9 @@ K_MSGQ_DEFINE(input_msgq, sizeof(struct input_event),
 
 static void input_process(struct input_event *evt)
 {
-	STRUCT_SECTION_FOREACH(input_listener, listener) {
-		if (listener->dev == NULL || listener->dev == evt->dev) {
-			listener->callback(evt);
+	STRUCT_SECTION_FOREACH(input_callback, callback) {
+		if (callback->dev == NULL || callback->dev == evt->dev) {
+			callback->callback(evt);
 		}
 	}
 }


### PR DESCRIPTION
Rename the internal input callback structure to input_callback. This is for coherency with "INPUT_CALLBACK_DEFINE" and other similar code paths in Zephyr, and also to avoid confusion with terminology.

This is an internal structure, applications should not have any references to it so there should be no need for any release note entries.