### PR TITLE
Bluetooth: Controller: Correct PPI->Timer start delay for simulation

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5.h
@@ -86,4 +86,8 @@
 #endif
 
 /* This is delay between PPI task START and timer actual start counting. */
+#if !defined(CONFIG_SOC_SERIES_BSIM_NRFXX)
 #define HAL_RADIO_TMR_START_DELAY_US 1U
+#else /* For simulated targets there is no delay for the PPI task -> TIMER start */
+#define HAL_RADIO_TMR_START_DELAY_US 0U
+#endif


### PR DESCRIPTION
In the simulated bsim boards there is no jittery delay from a (D)PPI event until a TIMER starts.
The timer starts instantaneously so we do not need to compensate for it.