### PR TITLE
nxp: sai: add support for passing TX/RX data line through DTS

### DIFF
--- a/dts/bindings/dai/nxp,dai-sai.yaml
+++ b/dts/bindings/dai/nxp,dai-sai.yaml
@@ -84,3 +84,28 @@ properties:
       If this property is not specified, the receiver will be set to ASYNC.
       If one side is SYNC then the other MUST be ASYNC. Failing to meet this
       condition will result in a failed BUILD_ASSERT().
+  tx-dataline:
+    type: int
+    description: |
+      Use this property to specify which transmission data line the SAI should
+      use. To find out which transmission line you should use you can:
+        1) Check the TRM and see if your SAI instance is multiline. If not then
+        you're going to use transmission line 0.
+        2) If your SAI is multiline then you need to check the datasheet and see
+        the index of the transmission line that's connected to your consumer
+        (e.g: the codec).
+      The indexing of the data line starts at 0. If this property is not specified
+      then the index of the transmission data line will be 0.
+      Please note that "channel" and "data line" are synnonyms in this context.
+  rx-dataline:
+    type: int
+    description: |
+      Use this property to specify which receive transmission data line the SAI should
+      use. To find out which receive line you should use you can:
+        1) Check the TRM and see if your SAI instance is multiline. If not then
+        you're going to use receive line 0.
+        2) If your SAI is multiline then you need to check the datasheet and see
+        the index of the receive line that's connected to your consumer (e.g: the codec).
+      The indexing of the data line starts at 0. If this property is not specified
+      then the index of the receive data line will be 0.
+      Please note that "channel" and "data line" are synnonyms in this context.


### PR DESCRIPTION
Some SAI instances are multiline, meaning they can have multiple TX/RX data line (channels). Depending on the board, the index of the TX/RX data lines that are connected to the consumer (e.g: the codec) may not always be 0. This commit fixes this issue by adding support for passing the index of the used TX/RX data lines through the DTS.