### PR TITLE
boards/nxp/frdm_mcxn947: Fix twister yaml

### DIFF
--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.yaml
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.yaml
@@ -15,6 +15,5 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
-  - arduino_serial
   - gpio
 vendor: nxp


### PR DESCRIPTION
This board's twister yaml file claims to support the arduino-serial tests, but it does not provide
the necessary DTS node, which is causing failures in CI.
Let's remove the tag from the twister board definition.

Fixes #70291