### PR TITLE
boards: use unique names

### DIFF
--- a/boards/actinius/icarus/actinius_icarus_nrf9160_1_4_0.yaml
+++ b/boards/actinius/icarus/actinius_icarus_nrf9160_1_4_0.yaml
@@ -1,5 +1,5 @@
 identifier: actinius_icarus@1.4.0/nrf9160
-name: Actinius Icarus
+name: Actinius Icarus (rev. 1.4.0)
 type: mcu
 arch: arm
 toolchain:

--- a/boards/actinius/icarus/actinius_icarus_nrf9160_2_0_0.yaml
+++ b/boards/actinius/icarus/actinius_icarus_nrf9160_2_0_0.yaml
@@ -1,5 +1,5 @@
 identifier: actinius_icarus@2.0.0/nrf9160
-name: Actinius Icarus
+name: Actinius Icarus (rev. 2.0.0)
 type: mcu
 arch: arm
 toolchain:

--- a/boards/actinius/icarus/actinius_icarus_nrf9160_ns_1_4_0.yaml
+++ b/boards/actinius/icarus/actinius_icarus_nrf9160_ns_1_4_0.yaml
@@ -1,5 +1,5 @@
 identifier: actinius_icarus@1.4.0/nrf9160/ns
-name: Actinius Icarus Non-Secure
+name: Actinius Icarus Non-Secure (rev. 1.4.0)
 type: mcu
 arch: arm
 toolchain:

--- a/boards/actinius/icarus/actinius_icarus_nrf9160_ns_2_0_0.yaml
+++ b/boards/actinius/icarus/actinius_icarus_nrf9160_ns_2_0_0.yaml
@@ -1,5 +1,5 @@
 identifier: actinius_icarus@2.0.0/nrf9160/ns
-name: Actinius Icarus Non-Secure
+name: Actinius Icarus Non-Secure (rev. 2.0.0)
 type: mcu
 arch: arm
 toolchain:

--- a/boards/cypress/cy8ckit_062_ble/cy8ckit_062_ble_cy8c6347_m0_0_0_0.yaml
+++ b/boards/cypress/cy8ckit_062_ble/cy8ckit_062_ble_cy8c6347_m0_0_0_0.yaml
@@ -6,7 +6,7 @@
 #
 
 identifier: cy8ckit_062_ble@0.0.0/cy8c6347/m0
-name: Cypress PSoC6 BLE Pioneer Kit (M0)
+name: Cypress PSoC6 BLE Pioneer Kit (M0, rev. 0.0.0)
 type: mcu
 arch: arm
 ram: 288

--- a/boards/cypress/cy8ckit_062_ble/cy8ckit_062_ble_cy8c6347_m0_1_0_0.yaml
+++ b/boards/cypress/cy8ckit_062_ble/cy8ckit_062_ble_cy8c6347_m0_1_0_0.yaml
@@ -6,7 +6,7 @@
 #
 
 identifier: cy8ckit_062_ble@1.0.0/cy8c6347/m0
-name: Cypress PSoC6 BLE Pioneer Kit (M0)
+name: Cypress PSoC6 BLE Pioneer Kit (M0, rev. 1.0.0)
 type: mcu
 arch: arm
 ram: 288

--- a/boards/cypress/cy8ckit_062_ble/cy8ckit_062_ble_cy8c6347_m4_0_0_0.yaml
+++ b/boards/cypress/cy8ckit_062_ble/cy8ckit_062_ble_cy8c6347_m4_0_0_0.yaml
@@ -6,7 +6,7 @@
 #
 
 identifier: cy8ckit_062_ble@0.0.0/cy8c6347/m4
-name: Cypress PSoC6 BLE Pioneer Kit (M4)
+name: Cypress PSoC6 BLE Pioneer Kit (M4, rev. 0.0.0)
 type: mcu
 arch: arm
 ram: 288

--- a/boards/cypress/cy8ckit_062_ble/cy8ckit_062_ble_cy8c6347_m4_1_0_0.yaml
+++ b/boards/cypress/cy8ckit_062_ble/cy8ckit_062_ble_cy8c6347_m4_1_0_0.yaml
@@ -6,7 +6,7 @@
 #
 
 identifier: cy8ckit_062_ble@1.0.0/cy8c6347/m4
-name: Cypress PSoC6 BLE Pioneer Kit (M4)
+name: Cypress PSoC6 BLE Pioneer Kit (M4, rev. 1.0.0)
 type: mcu
 arch: arm
 ram: 288

--- a/boards/espressif/esp32_devkitc_wrover/esp32_devkitc_wrover_appcpu.yaml
+++ b/boards/espressif/esp32_devkitc_wrover/esp32_devkitc_wrover_appcpu.yaml
@@ -1,5 +1,5 @@
 identifier: esp32_devkitc_wrover/esp32/appcpu
-name: ESP32-DevkitC-WROVER-E
+name: ESP32-DevkitC-WROVER-E APPCPU
 type: mcu
 arch: xtensa
 toolchain:

--- a/boards/espressif/esp32_devkitc_wrover/esp32_devkitc_wrover_procpu.yaml
+++ b/boards/espressif/esp32_devkitc_wrover/esp32_devkitc_wrover_procpu.yaml
@@ -1,5 +1,5 @@
 identifier: esp32_devkitc_wrover/esp32/procpu
-name: ESP32-DevkitC-WROVER-E
+name: ESP32-DevkitC-WROVER-E PROCPU
 type: mcu
 arch: xtensa
 toolchain:

--- a/boards/espressif/esp32_ethernet_kit/esp32_ethernet_kit_appcpu.yaml
+++ b/boards/espressif/esp32_ethernet_kit/esp32_ethernet_kit_appcpu.yaml
@@ -1,5 +1,5 @@
 identifier: esp32_ethernet_kit/esp32/appcpu
-name: ESP32 ETHERNET KIT
+name: ESP32 ETHERNET KIT APPCPU
 type: mcu
 arch: xtensa
 toolchain:

--- a/boards/espressif/esp32_ethernet_kit/esp32_ethernet_kit_procpu.yaml
+++ b/boards/espressif/esp32_ethernet_kit/esp32_ethernet_kit_procpu.yaml
@@ -1,5 +1,5 @@
 identifier: esp32_ethernet_kit/esp32/procpu
-name: ESP32 ETHERNET KIT
+name: ESP32 ETHERNET KIT PROCPU
 type: mcu
 arch: xtensa
 toolchain:

--- a/boards/espressif/esp_wrover_kit/esp_wrover_kit_appcpu.yaml
+++ b/boards/espressif/esp_wrover_kit/esp_wrover_kit_appcpu.yaml
@@ -1,5 +1,5 @@
 identifier: esp_wrover_kit/esp32/appcpu
-name: ESP WROVER KIT
+name: ESP WROVER KIT APPCPU
 type: mcu
 arch: xtensa
 toolchain:

--- a/boards/espressif/esp_wrover_kit/esp_wrover_kit_procpu.yaml
+++ b/boards/espressif/esp_wrover_kit/esp_wrover_kit_procpu.yaml
@@ -1,5 +1,5 @@
 identifier: esp_wrover_kit/esp32/procpu
-name: ESP WROVER KIT
+name: ESP WROVER KIT PROCPU
 type: mcu
 arch: xtensa
 toolchain:

--- a/boards/hardkernel/odroid_go/odroid_go_appcpu.yaml
+++ b/boards/hardkernel/odroid_go/odroid_go_appcpu.yaml
@@ -1,5 +1,5 @@
 identifier: odroid_go/esp32/appcpu
-name: ODROID-GO
+name: ODROID-GO APPCPU
 type: mcu
 arch: xtensa
 toolchain:

--- a/boards/hardkernel/odroid_go/odroid_go_procpu.yaml
+++ b/boards/hardkernel/odroid_go/odroid_go_procpu.yaml
@@ -1,5 +1,5 @@
 identifier: odroid_go/esp32/procpu
-name: ODROID-GO
+name: ODROID-GO PROCPU
 type: mcu
 arch: xtensa
 toolchain:

--- a/boards/heltec/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2_appcpu.yaml
+++ b/boards/heltec/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2_appcpu.yaml
@@ -1,5 +1,5 @@
 identifier: heltec_wifi_lora32_v2/esp32/appcpu
-name: ESP32 DEVKITC WROVER APPCPU
+name: HELTEC WiFi LoRa 32 (V2) Board APPCPU
 type: mcu
 arch: xtensa
 toolchain:

--- a/boards/heltec/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2_procpu.yaml
+++ b/boards/heltec/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2_procpu.yaml
@@ -1,5 +1,5 @@
 identifier: heltec_wifi_lora32_v2/esp32/procpu
-name: HELTEC WiFi LoRa 32 (V2) Board
+name: HELTEC WiFi LoRa 32 (V2) Board PROCPU
 type: mcu
 arch: xtensa
 toolchain:

--- a/boards/heltec/heltec_wireless_stick_lite_v3/heltec_wireless_stick_lite_v3_appcpu.yaml
+++ b/boards/heltec/heltec_wireless_stick_lite_v3/heltec_wireless_stick_lite_v3_appcpu.yaml
@@ -1,5 +1,5 @@
 identifier: heltec_wireless_stick_lite_v3/esp32s3/appcpu
-name: ESP32-S3 DevKitM APPCPU
+name: Heltec Wireless Stick Lite (V3) APPCPU
 type: mcu
 arch: xtensa
 toolchain:

--- a/boards/kincony/kincony_kc868_a32/kincony_kc868_a32_appcpu.yaml
+++ b/boards/kincony/kincony_kc868_a32/kincony_kc868_a32_appcpu.yaml
@@ -1,5 +1,5 @@
 identifier: kincony_kc868_a32/esp32/appcpu
-name: ESP32 DEVKITC WROVER APPCPU
+name: KINCONY-KC868-A32 APPCPU
 type: mcu
 arch: xtensa
 toolchain:

--- a/boards/kincony/kincony_kc868_a32/kincony_kc868_a32_procpu.yaml
+++ b/boards/kincony/kincony_kc868_a32/kincony_kc868_a32_procpu.yaml
@@ -1,5 +1,5 @@
 identifier: kincony_kc868_a32/esp32/procpu
-name: KINCONY-KC868-A32
+name: KINCONY-KC868-A32 PROCPU
 type: mcu
 arch: xtensa
 toolchain:

--- a/boards/luatos/esp32s3_luatos_core/esp32s3_luatos_core_appcpu.yaml
+++ b/boards/luatos/esp32s3_luatos_core/esp32s3_luatos_core_appcpu.yaml
@@ -1,5 +1,5 @@
 identifier: esp32s3_luatos_core/esp32s3/appcpu
-name: ESP32-S3 LuatOS Core
+name: ESP32-S3 LuatOS Core APPCPU
 type: mcu
 arch: xtensa
 toolchain:

--- a/boards/luatos/esp32s3_luatos_core/esp32s3_luatos_core_appcpu_usb.yaml
+++ b/boards/luatos/esp32s3_luatos_core/esp32s3_luatos_core_appcpu_usb.yaml
@@ -1,5 +1,5 @@
 identifier: esp32s3_luatos_core/esp32s3/appcpu/usb
-name: ESP32-S3 LuatOS Core USB
+name: ESP32-S3 LuatOS Core APPCPU USB
 type: mcu
 arch: xtensa
 toolchain:

--- a/boards/luatos/esp32s3_luatos_core/esp32s3_luatos_core_procpu.yaml
+++ b/boards/luatos/esp32s3_luatos_core/esp32s3_luatos_core_procpu.yaml
@@ -1,5 +1,5 @@
 identifier: esp32s3_luatos_core/esp32s3/procpu
-name: ESP32-S3 LuatOS Core
+name: ESP32-S3 LuatOS Core PROCPU
 type: mcu
 arch: xtensa
 toolchain:

--- a/boards/luatos/esp32s3_luatos_core/esp32s3_luatos_core_procpu_usb.yaml
+++ b/boards/luatos/esp32s3_luatos_core/esp32s3_luatos_core_procpu_usb.yaml
@@ -1,5 +1,5 @@
 identifier: esp32s3_luatos_core/esp32s3/procpu/usb
-name: ESP32-S3 LuatOS Core USB
+name: ESP32-S3 LuatOS Core PROCPU USB
 type: mcu
 arch: xtensa
 toolchain:

--- a/boards/m5stack/m5stack_atoms3/m5stack_atoms3_appcpu.yaml
+++ b/boards/m5stack/m5stack_atoms3/m5stack_atoms3_appcpu.yaml
@@ -1,5 +1,5 @@
 identifier: m5stack_atoms3/esp32s3/appcpu
-name: M5Stack AtomS3
+name: M5Stack AtomS3 APPCPU
 type: mcu
 arch: xtensa
 toolchain:

--- a/boards/m5stack/m5stack_atoms3/m5stack_atoms3_procpu.yaml
+++ b/boards/m5stack/m5stack_atoms3/m5stack_atoms3_procpu.yaml
@@ -1,5 +1,5 @@
 identifier: m5stack_atoms3/esp32s3/procpu
-name: M5Stack AtomS3
+name: M5Stack AtomS3 PROCPU
 type: mcu
 arch: xtensa
 toolchain:

--- a/boards/m5stack/m5stack_atoms3_lite/m5stack_atoms3_lite_appcpu.yaml
+++ b/boards/m5stack/m5stack_atoms3_lite/m5stack_atoms3_lite_appcpu.yaml
@@ -1,5 +1,5 @@
 identifier: m5stack_atoms3_lite/esp32s3/appcpu
-name: M5Stack AtomS3-Lite
+name: M5Stack AtomS3-Lite APPCPU
 type: mcu
 arch: xtensa
 toolchain:

--- a/boards/m5stack/m5stack_atoms3_lite/m5stack_atoms3_lite_procpu.yaml
+++ b/boards/m5stack/m5stack_atoms3_lite/m5stack_atoms3_lite_procpu.yaml
@@ -1,5 +1,5 @@
 identifier: m5stack_atoms3_lite/esp32s3/procpu
-name: M5Stack AtomS3-Lite
+name: M5Stack AtomS3-Lite PROCPU
 type: mcu
 arch: xtensa
 toolchain:

--- a/boards/m5stack/m5stack_core2/m5stack_core2_appcpu.yaml
+++ b/boards/m5stack/m5stack_core2/m5stack_core2_appcpu.yaml
@@ -1,5 +1,5 @@
 identifier: m5stack_core2/esp32/appcpu
-name: M5Stack Core2
+name: M5Stack Core2 APPCPU
 type: mcu
 arch: xtensa
 toolchain:

--- a/boards/m5stack/m5stack_core2/m5stack_core2_procpu.yaml
+++ b/boards/m5stack/m5stack_core2/m5stack_core2_procpu.yaml
@@ -1,5 +1,5 @@
 identifier: m5stack_core2/esp32/procpu
-name: M5Stack Core2
+name: M5Stack Core2 PROCPU
 type: mcu
 arch: xtensa
 toolchain:

--- a/boards/m5stack/m5stack_stamps3/m5stack_stamps3_appcpu.yaml
+++ b/boards/m5stack/m5stack_stamps3/m5stack_stamps3_appcpu.yaml
@@ -1,5 +1,5 @@
 identifier: m5stack_stamps3/esp32s3/appcpu
-name: M5Stack StampS3
+name: M5Stack StampS3 APPCPU
 type: mcu
 arch: xtensa
 toolchain:

--- a/boards/m5stack/m5stack_stamps3/m5stack_stamps3_procpu.yaml
+++ b/boards/m5stack/m5stack_stamps3/m5stack_stamps3_procpu.yaml
@@ -1,5 +1,5 @@
 identifier: m5stack_stamps3/esp32s3/procpu
-name: M5Stack StampS3
+name: M5Stack StampS3 PROCPU
 type: mcu
 arch: xtensa
 toolchain:

--- a/boards/m5stack/m5stickc_plus/m5stickc_plus_appcpu.yaml
+++ b/boards/m5stack/m5stickc_plus/m5stickc_plus_appcpu.yaml
@@ -1,5 +1,5 @@
 identifier: m5stickc_plus/esp32/appcpu
-name: M5StickC PLUS
+name: M5StickC PLUS APPCPU
 type: mcu
 arch: xtensa
 toolchain:

--- a/boards/m5stack/m5stickc_plus/m5stickc_plus_procpu.yaml
+++ b/boards/m5stack/m5stickc_plus/m5stickc_plus_procpu.yaml
@@ -1,5 +1,5 @@
 identifier: m5stickc_plus/esp32/procpu
-name: M5StickC PLUS
+name: M5StickC PLUS PROCPU
 type: mcu
 arch: xtensa
 toolchain:

--- a/boards/nordic/nrf9160dk/nrf9160dk_nrf52840_0_7_0.yaml
+++ b/boards/nordic/nrf9160dk/nrf9160dk_nrf52840_0_7_0.yaml
@@ -1,5 +1,5 @@
 identifier: nrf9160dk@0.7.0/nrf52840
-name: nRF9160-DK-NRF52840
+name: nRF9160-DK-NRF52840 (rev. 0.7.0)
 type: mcu
 arch: arm
 ram: 64

--- a/boards/nordic/nrf9160dk/nrf9160dk_nrf9160_0_7_0.yaml
+++ b/boards/nordic/nrf9160dk/nrf9160dk_nrf9160_0_7_0.yaml
@@ -1,5 +1,5 @@
 identifier: nrf9160dk@0.7.0/nrf9160
-name: nRF9160-DK-NRF9160
+name: nRF9160-DK-NRF9160 (rev. 0.7.0)
 type: mcu
 arch: arm
 toolchain:

--- a/boards/nordic/nrf9160dk/nrf9160dk_nrf9160_ns_0_7_0.yaml
+++ b/boards/nordic/nrf9160dk/nrf9160dk_nrf9160_ns_0_7_0.yaml
@@ -1,5 +1,5 @@
 identifier: nrf9160dk@0.7.0/nrf9160/ns
-name: nRF9160-DK-NRF9160-Non-Secure
+name: nRF9160-DK-NRF9160-Non-Secure (rev. 0.7.0)
 type: mcu
 arch: arm
 toolchain:

--- a/boards/nordic/nrf9161dk/nrf9161dk_nrf9161_0_7_0.yaml
+++ b/boards/nordic/nrf9161dk/nrf9161dk_nrf9161_0_7_0.yaml
@@ -1,5 +1,5 @@
 identifier: nrf9161dk@0.7.0/nrf9161
-name: nRF9161-DK-NRF9161
+name: nRF9161-DK-NRF9161 (rev. 0.7.0)
 type: mcu
 arch: arm
 toolchain:

--- a/boards/nordic/nrf9161dk/nrf9161dk_nrf9161_ns_0_7_0.yaml
+++ b/boards/nordic/nrf9161dk/nrf9161dk_nrf9161_ns_0_7_0.yaml
@@ -1,5 +1,5 @@
 identifier: nrf9161dk@0.7.0/nrf9161/ns
-name: nRF9161-DK-NRF9161-Non-Secure
+name: nRF9161-DK-NRF9161-Non-Secure (rev. 0.7.0)
 type: mcu
 arch: arm
 toolchain:

--- a/boards/olimex/lora_stm32wl_devkit/olimex_lora_stm32wl_devkit_D.yaml
+++ b/boards/olimex/lora_stm32wl_devkit/olimex_lora_stm32wl_devkit_D.yaml
@@ -1,5 +1,5 @@
 identifier: olimex_lora_stm32wl_devkit@D
-name: Olimex LoRa STM32WL DevKit
+name: Olimex LoRa STM32WL DevKit (rev. D)
 type: mcu
 arch: arm
 toolchain:

--- a/boards/olimex/olimex_esp32_evb/olimex_esp32_evb_appcpu.yaml
+++ b/boards/olimex/olimex_esp32_evb/olimex_esp32_evb_appcpu.yaml
@@ -1,5 +1,5 @@
 identifier: olimex_esp32_evb/esp32/appcpu
-name: Olimex ESP32-EVB
+name: Olimex ESP32-EVB APPCPU
 type: mcu
 arch: xtensa
 toolchain:

--- a/boards/olimex/olimex_esp32_evb/olimex_esp32_evb_procpu.yaml
+++ b/boards/olimex/olimex_esp32_evb/olimex_esp32_evb_procpu.yaml
@@ -1,5 +1,5 @@
 identifier: olimex_esp32_evb/esp32/procpu
-name: Olimex ESP32-EVB
+name: Olimex ESP32-EVB PROCPU
 type: mcu
 arch: xtensa
 toolchain:

--- a/boards/others/stm32_min_dev/stm32_min_dev_black.yaml
+++ b/boards/others/stm32_min_dev/stm32_min_dev_black.yaml
@@ -1,5 +1,5 @@
 identifier: stm32_min_dev@black
-name: STM32 Minimum Development Board
+name: STM32 Minimum Development Board (black)
 type: mcu
 arch: arm
 toolchain:

--- a/boards/others/stm32_min_dev/stm32_min_dev_blue.yaml
+++ b/boards/others/stm32_min_dev/stm32_min_dev_blue.yaml
@@ -1,5 +1,5 @@
 identifier: stm32_min_dev@blue
-name: STM32 Minimum Development Board
+name: STM32 Minimum Development Board (blue)
 type: mcu
 arch: arm
 toolchain:

--- a/boards/phytec/reel_board/reel_board_nrf52840_2.yaml
+++ b/boards/phytec/reel_board/reel_board_nrf52840_2.yaml
@@ -1,5 +1,5 @@
 identifier: reel_board@2
-name: reel-board
+name: reel-board (rev. 2)
 type: mcu
 arch: arm
 ram: 512

--- a/boards/seagate/legend/legend_stm32f070xb_25hdd.yaml
+++ b/boards/seagate/legend/legend_stm32f070xb_25hdd.yaml
@@ -1,5 +1,5 @@
 identifier: legend@25hdd
-name: Legend
+name: Legend (25hdd)
 type: mcu
 arch: arm
 ram: 16

--- a/boards/seagate/legend/legend_stm32f070xb_25ssd.yaml
+++ b/boards/seagate/legend/legend_stm32f070xb_25ssd.yaml
@@ -1,5 +1,5 @@
 identifier: legend@25ssd
-name: Legend
+name: Legend (25sdd)
 type: mcu
 arch: arm
 ram: 16

--- a/boards/seagate/legend/legend_stm32f070xb_35.yaml
+++ b/boards/seagate/legend/legend_stm32f070xb_35.yaml
@@ -1,5 +1,5 @@
 identifier: legend@35
-name: Legend
+name: Legend (35)
 type: mcu
 arch: arm
 ram: 16

--- a/boards/seeed/xiao_esp32s3/xiao_esp32s3_appcpu.yaml
+++ b/boards/seeed/xiao_esp32s3/xiao_esp32s3_appcpu.yaml
@@ -1,5 +1,5 @@
 identifier: xiao_esp32s3/esp32s3/appcpu
-name: XIAO ESP32S3
+name: XIAO ESP32S3 APPCPU
 type: mcu
 arch: xtensa
 toolchain:

--- a/boards/seeed/xiao_esp32s3/xiao_esp32s3_procpu.yaml
+++ b/boards/seeed/xiao_esp32s3/xiao_esp32s3_procpu.yaml
@@ -1,5 +1,5 @@
 identifier: xiao_esp32s3/esp32s3/procpu
-name: XIAO ESP32S3
+name: XIAO ESP32S3 PROCPU
 type: mcu
 arch: xtensa
 toolchain:

--- a/boards/snps/em_starterkit/em_starterkit_emsk_em7d_2_2.yaml
+++ b/boards/snps/em_starterkit/em_starterkit_emsk_em7d_2_2.yaml
@@ -1,5 +1,5 @@
 identifier: em_starterkit@2.2/emsk_em7d
-name: EM Starterkit EM7D
+name: EM Starterkit EM7D (rev. 2.2)
 type: mcu
 arch: arc
 toolchain:

--- a/boards/st/nucleo_f030r8/nucleo_f030r8_2.yaml
+++ b/boards/st/nucleo_f030r8/nucleo_f030r8_2.yaml
@@ -1,5 +1,5 @@
 identifier: nucleo_f030r8@2
-name: ST Nucleo F030R8
+name: ST Nucleo F030R8 (rev. 2)
 type: mcu
 arch: arm
 toolchain:

--- a/boards/st/stm32f411e_disco/stm32f411e_disco_stm32f411xe_B.yaml
+++ b/boards/st/stm32f411e_disco/stm32f411e_disco_stm32f411xe_B.yaml
@@ -1,5 +1,5 @@
 identifier: stm32f411e_disco@B
-name: ST STM32F411E Discovery
+name: ST STM32F411E Discovery (rev. B)
 type: mcu
 arch: arm
 toolchain:

--- a/boards/vcc-gnd/yd_esp32/yd_esp32_appcpu.yaml
+++ b/boards/vcc-gnd/yd_esp32/yd_esp32_appcpu.yaml
@@ -1,5 +1,5 @@
 identifier: yd_esp32/esp32/appcpu
-name: ESP32 DEVKITC WROVER APPCPU
+name: YD-ESP32 APPCPU
 type: mcu
 arch: xtensa
 toolchain:

--- a/boards/vcc-gnd/yd_esp32/yd_esp32_procpu.yaml
+++ b/boards/vcc-gnd/yd_esp32/yd_esp32_procpu.yaml
@@ -1,5 +1,5 @@
 identifier: yd_esp32/esp32/procpu
-name: YD-ESP32
+name: YD-ESP32 PROCPU
 type: mcu
 arch: xtensa
 toolchain:


### PR DESCRIPTION
The pretty names specified in the YAML files of each board are not unique.
Let's rename them.