### PR TITLE
scripts: pylib: twister: twisterlib: prevent empty gcda files

### DIFF
--- a/scripts/pylib/twister/twisterlib/coverage.py
+++ b/scripts/pylib/twister/twisterlib/coverage.py
@@ -122,8 +122,9 @@ class CoverageTool:
 
             try:
                 hexdump_val = self.merge_hexdumps(hexdumps)
+                hex_bytes = bytes.fromhex(hexdump_val)
                 with open(filename, 'wb') as fp:
-                    fp.write(bytes.fromhex(hexdump_val))
+                    fp.write(hex_bytes)
             except ValueError:
                 logger.exception("Unable to convert hex data for file: {}".format(filename))
                 gcda_created = False


### PR DESCRIPTION
In case of problem with parsing hex data from coverage dump, do not create empty gcda file.
Such empty file will break gcovr parsing.