### PR TITLE
Fix lptim sys clock driver

### DIFF
--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -69,7 +69,7 @@ static uint32_t lptim_clock_freq = CONFIG_STM32_LPTIM_CLOCK;
 static uint32_t lptim_clock_presc = DT_PROP(DT_DRV_INST(0), st_prescaler);
 
 /* Minimum nb of clock cycles to have to set autoreload register correctly */
-#define LPTIM_GUARD_VALUE 2
+#define LPTIM_GUARD_VALUE 1
 
 /* A 32bit value cannot exceed 0xFFFFFFFF/LPTIM_TIMEBASE counting cycles.
  * This is for example about of 65000 x 2000ms when clocked by LSI
@@ -303,8 +303,6 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	else if (next_arr < (lp_time + LPTIM_GUARD_VALUE)) {
 		next_arr = lp_time + LPTIM_GUARD_VALUE;
 	}
-	/* with slow lptim_clock_freq, LPTIM_GUARD_VALUE of 1 is enough */
-	next_arr = next_arr - 1;
 
 	/* Update autoreload register */
 	lptim_set_autoreload(next_arr);

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -152,6 +152,7 @@ static void lptim_irq_handler(const struct device *unused)
 				* CONFIG_SYS_CLOCK_TICKS_PER_SEC)
 				/ lptim_clock_freq;
 
+		autoreload_ready = false;
 		sys_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL)
 				? dticks : (dticks > 0));
 	}


### PR DESCRIPTION
I use Zephyr with a stm32wl and lptim as the system clock source.
With Zephyr 3.6 I encountered 2 problems that I solved with these PR commits.

## Product never sleeping more than a few ticks

Caused by the line "next_arr = next_arr - 1;" making the condition "((autoreload - lp_time) < LPTIM_GUARD_VALUE)" line 276 always true which cause the timer to never reconfigure.

## Wrong Time measurement when using prescaler

When using the prescaler (tested with 16 and 128 with the SYS_CLOCK_TICKS_PER_SEC configured by default), I realized the time measurement was wrong (hours printed on the logs in few seconds of real time).
Saw accumulated_lptim_cnt getting wrongly incremented with MAX_UINT16 line 146. 
So far I understood that when sys_clock_announce is called line 156 in the isr, it ends up calling sys_clock_set_timeout with the max timeout possible and if autoreload_ready is true it does not reconfigure immediately the ARR. 
I fixed it by adding "autoreload_ready = false;" line 155.
  
This pr is fixing the two problems on my side.


