### PR TITLE
sensor: tmag5273: fix switched mask/value argument in FIELD_GET

### DIFF
--- a/drivers/sensor/tmag5273/tmag5273.c
+++ b/drivers/sensor/tmag5273/tmag5273.c
@@ -941,7 +941,7 @@ static inline int tmag5273_init_device_config(const struct device *dev)
 		(int)drv_cfg->temperature;
 
 	drv_data->conversion_time_us = TMAG5273_T_CONVERSION_US(
-		(FIELD_GET(regdata, TMAG5273_CONV_AVB_MSK)), (nb_captured_channels));
+		(FIELD_GET(TMAG5273_CONV_AVB_MSK, regdata)), (nb_captured_channels));
 
 	regdata |= TMAG5273_I2C_READ_MODE_STANDARD;
 


### PR DESCRIPTION
This somehow worked without problems during the test runs, but we found a corner case where this leads to an error during some testings to reduce power consumption.