### PR TITLE
kernel: system_work_q: Mark queue thread as essential

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -4002,6 +4002,11 @@ struct k_work_queue_config {
 	 * control.
 	 */
 	bool no_yield;
+
+	/** Control whether the work queue thread should be marked as
+	 * essential thread.
+	 */
+	bool essential;
 };
 
 /** @brief A structure used to hold work until it can be processed. */

--- a/kernel/system_work_q.c
+++ b/kernel/system_work_q.c
@@ -24,6 +24,7 @@ static int k_sys_work_q_init(void)
 	struct k_work_queue_config cfg = {
 		.name = "sysworkq",
 		.no_yield = IS_ENABLED(CONFIG_SYSTEM_WORKQUEUE_NO_YIELD),
+		.essential = true,
 	};
 
 	k_work_queue_start(&k_sys_work_q,

--- a/kernel/work.c
+++ b/kernel/work.c
@@ -761,6 +761,10 @@ void k_work_queue_start(struct k_work_q *queue,
 		k_thread_name_set(&queue->thread, cfg->name);
 	}
 
+	if ((cfg != NULL) && (cfg->essential)) {
+		queue->thread.base.user_options |= K_ESSENTIAL;
+	}
+
 	k_thread_start(&queue->thread);
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_work_queue, start, queue);


### PR DESCRIPTION
Fixes #70293 
Marking sysworkq as essential, so when it fails, the system will halt instead of continuously working, and dependent components stay in a broken state.