### PR TITLE
x86: x86_64: fix tls setup in early boot

### DIFF
--- a/arch/x86/core/intel64/locore.S
+++ b/arch/x86/core/intel64/locore.S
@@ -260,13 +260,16 @@ enter_code64:
 	rep stosq
 #endif
 
-	/* Enter C domain now that we have a stack set up, never to return */
-	movq %rbp, %rdi
 #ifdef CONFIG_STACK_CANARIES_TLS
+	movq %rsp, %rdi
 	pushq %rsp
 	call z_x86_early_tls_update_gdt
 	popq %rsp
 #endif
+
+	/* Enter C domain now that we have a stack set up, never to return */
+	movq %rbp, %rdi
+
 	call z_x86_cpu_init
 
 	/* 64 bit OS entry point, used by EFI support.  UEFI


### PR DESCRIPTION
During early boot in assembly, the function parameter to z_x86_early_tls_update_gdt() should be the pointer to the interrupt stack. However, what was passed instead was the pointer to the x86_cpuboot struct. So fix it to actually pass the stack pointer (which is stashed inside the x86_cpuboot struct).