### PR TITLE
samples/basic/hash_map: Remove clarification sentence

### DIFF
--- a/samples/basic/hash_map/Kconfig
+++ b/samples/basic/hash_map/Kconfig
@@ -18,9 +18,6 @@ config TEST_LIB_HASH_MAP_MAX_ENTRIES
 
 	  CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE
 
-	  For native_sim, the number of entries can be configured
-	  independently of the arena size since the native libc is used.
-
 config TEST_LIB_HASH_MAP_DURATION_S
 	int "Duration of test (in seconds)"
 	default 3


### PR DESCRIPTION
This current sentence would need to be clarified a bit further to be really correct:
It is only when building with the host C library that it applies, but with native_sim we can build with other libC's.
The twister tests definitions are testing only with embedded C libraries,
and there is anyway no harm if somebody defines the heap size even if using the host libC.
So as such it would seem better to just remove this sentence.