### PR TITLE
boards: fix openocd deprecated configuration

### DIFF
--- a/boards/adafruit/itsybitsy_m4_express/support/openocd.cfg
+++ b/boards/adafruit/itsybitsy_m4_express/support/openocd.cfg
@@ -7,7 +7,7 @@ source [find target/atsame5x.cfg]
 
 # TODO(http://openocd.zylin.com/#/c/5706/): lower the clock speed to workaround
 # an erase timeout.
-adapter_khz 500
+adapter speed 500
 reset_config srst_only
 
 $_TARGETNAME configure -event gdb-attach {

--- a/boards/arm/v2m_beetle/support/openocd.cfg
+++ b/boards/arm/v2m_beetle/support/openocd.cfg
@@ -22,7 +22,7 @@ if { [info exists CPUTAPID] } {
     set _CPUTAPID 0x2ba01477
 }
 
-adapter_khz 1000
+adapter speed 1000
 
 set _TARGETNAME $_CHIPNAME.cpu
 

--- a/boards/digilent/arty_a7/support/openocd_arty_a7_arm_designstart_m1.cfg
+++ b/boards/digilent/arty_a7/support/openocd_arty_a7_arm_designstart_m1.cfg
@@ -1,7 +1,7 @@
 source [find interface/cmsis-dap.cfg]
 source [find target/swj-dp.tcl]
 
-adapter_khz 5000
+adapter speed 5000
 
 set _CHIPNAME cortex_m1
 set _ENDIAN little

--- a/boards/digilent/arty_a7/support/openocd_arty_a7_arm_designstart_m3.cfg
+++ b/boards/digilent/arty_a7/support/openocd_arty_a7_arm_designstart_m3.cfg
@@ -1,7 +1,7 @@
 source [find interface/cmsis-dap.cfg]
 source [find target/swj-dp.tcl]
 
-adapter_khz 5000
+adapter speed 5000
 
 set _CHIPNAME cortex_m3
 set _ENDIAN little

--- a/boards/espressif/esp32c3_devkitm/support/openocd.cfg
+++ b/boards/espressif/esp32c3_devkitm/support/openocd.cfg
@@ -8,4 +8,4 @@ set ESP_RTOS none
 source [find interface/ftdi/esp32_devkitj_v1.cfg]
 
 source [find target/esp32c3.cfg]
-adapter_khz 5000
+adapter speed 5000

--- a/boards/luatos/esp32c3_luatos_core/support/openocd.cfg
+++ b/boards/luatos/esp32c3_luatos_core/support/openocd.cfg
@@ -9,4 +9,4 @@ source [find interface/esp_usb_jtag.cfg]
 # source [find interface/ftdi/esp32_devkitj_v1.cfg]
 
 source [find target/esp32c3.cfg]
-adapter_khz 5000
+adapter speed 5000

--- a/boards/m5stack/stamp_c3/support/openocd.cfg
+++ b/boards/m5stack/stamp_c3/support/openocd.cfg
@@ -6,4 +6,4 @@ set ESP_RTOS none
 source [find interface/esp_usb_jtag.cfg]
 
 source [find target/esp32c3.cfg]
-adapter_khz 5000
+adapter speed 5000

--- a/boards/mikroe/mini_m4_for_stm32/support/openocd.cfg
+++ b/boards/mikroe/mini_m4_for_stm32/support/openocd.cfg
@@ -6,8 +6,8 @@ transport select hla_swd
 
 source [find target/stm32f4x.cfg]
 
-adapter_khz 1000
-adapter_nsrst_delay 100
+adapter speed 1000
+adapter srst delay 100
 jtag_ntrst_delay 100
 
 reset_config srst_only srst_nogate connect_assert_srst

--- a/boards/nxp/lpcxpresso11u68/support/openocd.cfg
+++ b/boards/nxp/lpcxpresso11u68/support/openocd.cfg
@@ -39,4 +39,4 @@ $_TARGETNAME configure -event reset-end {
 # Enable Zephyr thread awareness.
 $_TARGETNAME configure -rtos Zephyr
 
-adapter_khz 100
+adapter speed 100

--- a/boards/olimex/stm32_e407/support/openocd.cfg
+++ b/boards/olimex/stm32_e407/support/openocd.cfg
@@ -1,13 +1,12 @@
-source [find interface/stlink.cfg]
+source [find interface/ftdi/olimex-arm-usb-tiny-h.cfg]
+# source [find interface/stlink.cfg]
 
 set WORKAREASIZE 0x10000
 
-transport select hla_swd
-
 source [find target/stm32f4x.cfg]
 
-adapter_khz 1000
-adapter_nsrst_delay 100
+adapter speed 1000
+adapter srst delay 100
 jtag_ntrst_delay 100
 
 reset_config srst_only srst_nogate

--- a/boards/olimex/stm32_h103/support/openocd_olimex_jtag.cfg
+++ b/boards/olimex/stm32_h103/support/openocd_olimex_jtag.cfg
@@ -4,8 +4,8 @@ transport select jtag
 
 source [find board/olimex_stm32_h103.cfg]
 
-adapter_khz 1000
-adapter_nsrst_delay 100
+adapter speed 1000
+adapter srst delay 100
 jtag_ntrst_delay 100
 
 reset_config srst_only srst_nogate

--- a/boards/olimex/stm32_h405/support/openocd.cfg
+++ b/boards/olimex/stm32_h405/support/openocd.cfg
@@ -6,8 +6,8 @@ transport select hla_swd
 
 source [find target/stm32f4x.cfg]
 
-adapter_khz 1000
-adapter_nsrst_delay 100
+adapter speed 1000
+adapter srst delay 100
 jtag_ntrst_delay 100
 
 reset_config srst_only srst_nogate

--- a/boards/olimex/stm32_h407/support/openocd.cfg
+++ b/boards/olimex/stm32_h407/support/openocd.cfg
@@ -6,8 +6,8 @@ transport select jtag
 
 source [find target/stm32f4x.cfg]
 
-adapter_khz 1000
-adapter_nsrst_delay 100
+adapter speed 1000
+adapter srst delay 100
 jtag_ntrst_delay 100
 
 reset_config srst_only srst_nogate

--- a/boards/olimex/stm32_p405/support/openocd.cfg
+++ b/boards/olimex/stm32_p405/support/openocd.cfg
@@ -6,8 +6,8 @@ transport select hla_swd
 
 source [find target/stm32f4x.cfg]
 
-adapter_khz 1000
-adapter_nsrst_delay 100
+adapter speed 1000
+adapter srst delay 100
 jtag_ntrst_delay 100
 
 reset_config srst_only srst_nogate

--- a/boards/openisa/rv32m1_vega/support/openocd_rv32m1_vega_ri5cy.cfg
+++ b/boards/openisa/rv32m1_vega/support/openocd_rv32m1_vega_ri5cy.cfg
@@ -3,7 +3,7 @@
 
 set _WORKAREASIZE 0x2000
 
-adapter_khz 1000
+adapter speed 1000
 
 interface jlink
 transport select jtag

--- a/boards/openisa/rv32m1_vega/support/openocd_rv32m1_vega_zero_riscy.cfg
+++ b/boards/openisa/rv32m1_vega/support/openocd_rv32m1_vega_zero_riscy.cfg
@@ -3,7 +3,7 @@
 
 set _WORKAREASIZE 0x2000
 
-adapter_khz 1000
+adapter speed 1000
 
 interface jlink
 transport select jtag

--- a/boards/others/icev_wireless/support/openocd.cfg
+++ b/boards/others/icev_wireless/support/openocd.cfg
@@ -3,4 +3,4 @@ set ESP_RTOS none
 source [find interface/esp_usb_jtag.cfg]
 
 source [find target/esp32c3.cfg]
-adapter_khz 5000
+adapter speed 5000

--- a/boards/seagate/faze/support/openocd.cfg
+++ b/boards/seagate/faze/support/openocd.cfg
@@ -36,4 +36,4 @@ $_TARGETNAME configure -event reset-end {
 # Enable Zephyr thread awareness.
 $_TARGETNAME configure -rtos Zephyr
 
-adapter_khz 100
+adapter speed 100

--- a/boards/seeed/wio_terminal/support/openocd.cfg
+++ b/boards/seeed/wio_terminal/support/openocd.cfg
@@ -8,7 +8,7 @@ set CHIPNAME atsamd51p19
 
 source [find target/atsame5x.cfg]
 
-adapter_khz 500
+adapter speed 500
 reset_config srst_only
 
 $_TARGETNAME configure -event gdb-attach {

--- a/boards/seeed/xiao_esp32c3/support/openocd.cfg
+++ b/boards/seeed/xiao_esp32c3/support/openocd.cfg
@@ -3,4 +3,4 @@ set ESP_RTOS none
 source [find interface/esp_usb_jtag.cfg]
 
 source [find target/esp32c3.cfg]
-adapter_khz 5000
+adapter speed 5000

--- a/boards/sipeed/longan_nano/support/openocd.cfg
+++ b/boards/sipeed/longan_nano/support/openocd.cfg
@@ -13,7 +13,7 @@ ftdi_vid_pid 0x0403 0x6010
 ftdi_layout_init 0x0008 0x001b
 ftdi_layout_signal nSRST -oe 0x0020 -data 0x0020
 
-adapter_khz 2000
+adapter speed 2000
 transport select jtag
 
 proc gd32vf103-pre-load {} {

--- a/boards/st/st25dv_mb1283_disco/support/openocd.cfg
+++ b/boards/st/st25dv_mb1283_disco/support/openocd.cfg
@@ -4,7 +4,7 @@ transport select hla_swd
 
 source [find target/stm32f4x.cfg]
 
-adapter_khz 1000
+adapter speed 1000
 
 reset_config srst_only
 

--- a/boards/ti/cc1352r_sensortag/support/openocd.cfg
+++ b/boards/ti/cc1352r_sensortag/support/openocd.cfg
@@ -1,4 +1,4 @@
 source [find board/ti_cc13x2_launchpad.cfg]
 # Workaround for #21372. This allows OpenOCD to flash correctly
 # with newer 3.x XDS firmware
-adapter_khz 1500
+adapter speed 1500


### PR DESCRIPTION
Replace deprecated settings:
  adapter_khz  -->  adapter speed
  adapter_nsrst  -->  adapter srst delay

Tested on olimex stm32_e407 board with olimex arm-usb-tiny-h adapter