### PR TITLE
tflite-micro: update README to pull optional module

### DIFF
--- a/samples/modules/tflite-micro/hello_world/README.rst
+++ b/samples/modules/tflite-micro/hello_world/README.rst
@@ -34,6 +34,13 @@ Building and Running
 The sample should work on most boards since it does not rely
 on any sensors.
 
+Add the tflite-micro module to your West manifest and pull it:
+
+.. code-block:: console
+
+    west config manifest.project-filter -- +tflite-micro
+    west update
+
 The reference kernel application can be built and executed on QEMU as follows:
 
 .. zephyr-app-commands::

--- a/samples/modules/tflite-micro/magic_wand/README.rst
+++ b/samples/modules/tflite-micro/magic_wand/README.rst
@@ -24,6 +24,13 @@ from an accelerometer.
 Building and Running
 ********************
 
+Add the tflite-micro module to your West manifest and pull it:
+
+.. code-block:: console
+
+    west config manifest.project-filter -- +tflite-micro
+    west update
+
 The application can be built for the :ref:`litex-vexriscv` for
 emulation in Renode as follows:
 

--- a/samples/modules/tflite-micro/tflm_ethosu/README.rst
+++ b/samples/modules/tflite-micro/tflm_ethosu/README.rst
@@ -19,6 +19,13 @@ Ethos-U custom operator.
 Building and running
 ********************
 
+Add the tflite-micro module to your West manifest and pull it:
+
+.. code-block:: console
+
+    west config manifest.project-filter -- +tflite-micro
+    west update
+
 This application can be built and run on any Arm Ethos-U capable platform, for
 example Corstone(TM)-300. A reference implementation of Corstone-300 can be
 downloaded either as a FPGA bitfile for the


### PR DESCRIPTION
tflite-micro is an optional module now, and needs to be pulled for the sample to build.

Fixes #69942 