### PR TITLE
drivers: mdio: fix incorrect return usage in `mdio_bus_enable/disable`

### DIFF
--- a/include/zephyr/drivers/mdio.h
+++ b/include/zephyr/drivers/mdio.h
@@ -73,7 +73,7 @@ static inline void z_impl_mdio_bus_enable(const struct device *dev)
 	const struct mdio_driver_api *api =
 		(const struct mdio_driver_api *)dev->api;
 
-	return api->bus_enable(dev);
+	api->bus_enable(dev);
 }
 
 /**
@@ -89,7 +89,7 @@ static inline void z_impl_mdio_bus_disable(const struct device *dev)
 	const struct mdio_driver_api *api =
 		(const struct mdio_driver_api *)dev->api;
 
-	return api->bus_disable(dev);
+	api->bus_disable(dev);
 }
 
 /**


### PR DESCRIPTION
Remove incorrect return statements in the `z_impl_mdio_bus_enable` and `z_impl_mdio_bus_disable` functions within the MDIO driver API. These functions are intended to call the `bus_enable` and `bus_disable` methods of the MDIO driver API without returning a value, as they are defined to return void.