### PR TITLE
drivers: timer: riscv_machine_timer: add support for Sophgo SoCs

### DIFF
--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -38,6 +38,9 @@
 #elif DT_HAS_COMPAT_STATUS_OKAY(sifive_clint0)
 #define DT_DRV_COMPAT sifive_clint0
 
+#if DT_INST_PROP(0, use_32bit)
+#undef CONFIG_64BIT
+#endif
 #define MTIME_REG	(DT_INST_REG_ADDR(0) + 0xbff8U)
 #define MTIMECMP_REG	(DT_INST_REG_ADDR(0) + 0x4000U)
 #define TIMER_IRQN	DT_INST_IRQ_BY_IDX(0, 1, irq)

--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -41,7 +41,11 @@
 #if DT_INST_PROP(0, use_32bit)
 #undef CONFIG_64BIT
 #endif
+#if DT_INST_PROP(0, mtime_use_csr)
+#define MTIME_USE_CSR
+#else
 #define MTIME_REG	(DT_INST_REG_ADDR(0) + 0xbff8U)
+#endif
 #define MTIMECMP_REG	(DT_INST_REG_ADDR(0) + 0x4000U)
 #define TIMER_IRQN	DT_INST_IRQ_BY_IDX(0, 1, irq)
 /* telink,machine-timer */
@@ -125,7 +129,9 @@ static void set_divider(void)
 
 static uint64_t mtime(void)
 {
-#ifdef CONFIG_64BIT
+#if defined(MTIME_USE_CSR)
+	return csr_read(time);
+#elif defined(CONFIG_64BIT)
 	return *(volatile uint64_t *)MTIME_REG;
 #else
 	volatile uint32_t *r = (uint32_t *)MTIME_REG;

--- a/dts/bindings/timer/sifive,clint0.yaml
+++ b/dts/bindings/timer/sifive,clint0.yaml
@@ -15,3 +15,8 @@ properties:
     type: boolean
     description: |
       Access registers using 32-bit instructions on a 64-bit CPU.
+
+  mtime-use-csr:
+    type: boolean
+    description: |
+      Use CSR time register to access the mtime value.

--- a/dts/bindings/timer/sifive,clint0.yaml
+++ b/dts/bindings/timer/sifive,clint0.yaml
@@ -10,3 +10,8 @@ include: base.yaml
 properties:
   reg:
     required: true
+
+  use-32bit:
+    type: boolean
+    description: |
+      Access registers using 32-bit instructions on a 64-bit CPU.


### PR DESCRIPTION
These set of patches addresses the quirks of the clint timer implementation of the Sophgo CV180x/SG200x SoCs