### PR TITLE
tests/drivers/build_all/w1: Add gpio dependency

### DIFF
--- a/tests/drivers/build_all/w1/testcase.yaml
+++ b/tests/drivers/build_all/w1/testcase.yaml
@@ -7,5 +7,7 @@ tests:
     tags:
       - drivers
       - w1
+    depends_on:
+      - gpio
     integration_platforms:
       - native_posix


### PR DESCRIPTION
This driver enables CONFIG_GPIO, so if we try to target a board which does not support it, it will fail.
Let's add the required tag in the testcase yaml.

Fixes #70336