### PR TITLE
tests/drivers/build_all/w1: Run on native_sim instead of native_posix

### DIFF
--- a/tests/drivers/build_all/w1/testcase.yaml
+++ b/tests/drivers/build_all/w1/testcase.yaml
@@ -10,4 +10,4 @@ tests:
     depends_on:
       - gpio
     integration_platforms:
-      - native_posix
+      - native_sim


### PR DESCRIPTION
native_posix is being replaced with native_sim, let's have these tests be run on native_sim instead.
