### PR TITLE
boards: Update Xiao_BLE Sense DTS for on board pdm microphone

### DIFF
--- a/boards/seeed/xiao_ble/xiao_ble-pinctrl.dtsi
+++ b/boards/seeed/xiao_ble/xiao_ble-pinctrl.dtsi
@@ -52,6 +52,21 @@
 		};
 	};
 
+	pdm0_default: pdm0_default {
+		group1 {
+			psels = <NRF_PSEL(PDM_CLK, 1, 00)>,
+				<NRF_PSEL(PDM_DIN, 0, 16)>;
+		};
+	};
+
+	pdm0_sleep: pdm0_sleep {
+		group1 {
+			psels = <NRF_PSEL(PDM_CLK, 1, 00)>,
+				<NRF_PSEL(PDM_DIN, 0, 16)>;
+				low-power-enable;
+		};
+	};
+
 	pwm0_default: pwm0_default {
 		group1 {
 			psels = <NRF_PSEL(PWM_OUT0, 0, 17)>;

--- a/boards/seeed/xiao_ble/xiao_ble_nrf52840_sense.dts
+++ b/boards/seeed/xiao_ble/xiao_ble_nrf52840_sense.dts
@@ -13,6 +13,12 @@
 	model = "Seeed XIAO BLE Sense";
 	compatible = "seeed,xiao-ble", "seeed,xiao-ble-sense";
 
+	msm261d3526hicpm-c-en {
+		compatible = "regulator-fixed";
+		enable-gpios = <&gpio1 10 (NRF_GPIO_DRIVE_S0H1 | GPIO_ACTIVE_HIGH)>;
+		regulator-name = "MSM261D3526HICPM-C-EN";
+	};
+
 	lsm6ds3tr-c-en {
 		compatible = "regulator-fixed-sync", "regulator-fixed";
 		enable-gpios = <&gpio1 8 (NRF_GPIO_DRIVE_S0H1 | GPIO_ACTIVE_HIGH)>;
@@ -37,4 +43,11 @@
 		irq-gpios = <&gpio0 11 GPIO_ACTIVE_HIGH>;
 		status = "okay";
 	};
+};
+
+&pdm0 {
+	pinctrl-0 = <&pdm0_default>;
+	pinctrl-1 = <&pdm0_sleep>;
+	pinctrl-names = "default", "sleep";
+	clock-source = "PCLK32M";
 };

--- a/samples/drivers/audio/dmic/boards/xiao_ble_nrf52840_sense.overlay
+++ b/samples/drivers/audio/dmic/boards/xiao_ble_nrf52840_sense.overlay
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/ {
+	msm261d3526hicpm-c-en {
+		regulator-boot-on;
+	};
+};
+
+dmic_dev: &pdm0 {
+	status = "okay";
+};


### PR DESCRIPTION
Create regulator on GPIO for microphone supply
Set pdm data and clk pins in pinctrl
Add xiao_ble_nrf54840_sense.overlay for dmic sample support 
Change the default mono channel in the sample from left to  right to work with 
the hardware configuration of the Xiao