### PR TITLE
twister: add linkserver support with hardwaremap

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -514,6 +514,11 @@ class DeviceHandler(Handler):
                         command_extra_args.append("cmsis_dap_serial %s" % board_id)
                     elif runner == "jlink":
                         command.append("--tool-opt=-SelectEmuBySN  %s" % board_id)
+                    elif runner == "linkserver":
+                        # for linkserver
+                        # --probe=#<number> select by probe index
+                        # --probe=<serial number> select by probe serial number
+                        command.append("--probe=%s" % board_id)
                     elif runner == "stm32cubeprogrammer":
                         command.append("--tool-opt=sn=%s" % board_id)
 


### PR DESCRIPTION
in hardwaremap the dev-id is used to select debug probe and linkserver accept the --probe. so and this support