### PR TITLE
Bluetooth: Host: Change __line__ to __LINE__

### DIFF
--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -397,7 +397,7 @@ struct net_buf *bt_conn_create_pdu_timeout_debug(struct net_buf_pool *pool,
 
 #define bt_conn_create_pdu(_pool, _reserve) \
 	bt_conn_create_pdu_timeout_debug(_pool, _reserve, K_FOREVER, \
-					 __func__, __line__)
+					 __func__, __LINE__)
 #else
 struct net_buf *bt_conn_create_pdu_timeout(struct net_buf_pool *pool,
 					   size_t reserve, k_timeout_t timeout);

--- a/subsys/bluetooth/host/iso_internal.h
+++ b/subsys/bluetooth/host/iso_internal.h
@@ -117,7 +117,7 @@ struct net_buf *bt_iso_create_pdu_timeout_debug(struct net_buf_pool *pool,
 
 #define bt_iso_create_pdu(_pool, _reserve) \
 	bt_iso_create_pdu_timeout_debug(_pool, _reserve, K_FOREVER, \
-					__func__, __line__)
+					__func__, __LINE__)
 #else
 struct net_buf *bt_iso_create_pdu_timeout(struct net_buf_pool *pool,
 					  size_t reserve, k_timeout_t timeout);


### PR DESCRIPTION
The building error is reported in Ubuntu if CONFIG_NET_BUF_LOG is true.

![image](https://github.com/zephyrproject-rtos/zephyr/assets/47838210/c96331af-db99-4c1f-9b6e-de07fb88581e)

Change `__line__` to `__LINE__` to fix building error.