### PR TITLE
json: add support to include a already encoded object to a object

### DIFF
--- a/include/zephyr/data/json.h
+++ b/include/zephyr/data/json.h
@@ -45,6 +45,7 @@ enum json_tokens {
 	JSON_TOK_FLOAT = '1',
 	JSON_TOK_OPAQUE = '2',
 	JSON_TOK_OBJ_ARRAY = '3',
+	JSON_TOK_ENCODED_OBJ = '4',
 	JSON_TOK_TRUE = 't',
 	JSON_TOK_FALSE = 'f',
 	JSON_TOK_NULL = 'n',

--- a/lib/utils/json.c
+++ b/lib/utils/json.c
@@ -1002,6 +1002,13 @@ static int opaque_string_encode(struct json_obj_token *opaque, json_append_bytes
 	return append_bytes("\"", 1, data);
 }
 
+static int encoded_obj_encode(const char **str, json_append_bytes_t append_bytes, void *data)
+{
+	size_t len = strlen(*str);
+
+	return append_bytes(*str, len, data);
+}
+
 static int bool_encode(const bool *value, json_append_bytes_t append_bytes,
 		       void *data)
 {
@@ -1036,6 +1043,8 @@ static int encode(const struct json_obj_descr *descr, const void *val,
 		return float_ascii_encode(ptr, append_bytes, data);
 	case JSON_TOK_OPAQUE:
 		return opaque_string_encode(ptr, append_bytes, data);
+	case JSON_TOK_ENCODED_OBJ:
+		return encoded_obj_encode(ptr, append_bytes, data);
 	default:
 		return -EINVAL;
 	}

--- a/tests/lib/json/src/main.c
+++ b/tests/lib/json/src/main.c
@@ -143,6 +143,16 @@ static const struct json_obj_descr array_2dim_extra_named_descr[] = {
 				   ARRAY_SIZE(obj_array_descr)),
 };
 
+struct test_json_tok_encoded_obj {
+	const char *encoded_obj;
+	int ok;
+};
+
+static const struct json_obj_descr test_json_tok_encoded_obj_descr[] = {
+	JSON_OBJ_DESCR_PRIM(struct test_json_tok_encoded_obj, encoded_obj, JSON_TOK_ENCODED_OBJ),
+	JSON_OBJ_DESCR_PRIM(struct test_json_tok_encoded_obj, ok, JSON_TOK_NUMBER),
+};
+
 ZTEST(lib_json_test, test_json_encoding)
 {
 	struct test_struct ts = {
@@ -1207,6 +1217,25 @@ ZTEST(lib_json_test, test_large_descriptor)
 	zassert_true(ret & ((int64_t)1 << 21), "Field int21 not decoded");
 	zassert_true(ret & ((int64_t)1 << 31), "Field int31 not decoded");
 	zassert_true(ret & ((int64_t)1 << 39), "Field int39 not decoded");
+}
+
+ZTEST(lib_json_test, test_json_encoded_object_tok_encoding)
+{
+	static const char encoded[] =
+		"{\"encoded_obj\":{\"test\":{\"nested\":\"yes\"}},\"ok\":1234}";
+	const struct test_json_tok_encoded_obj obj = {
+		.encoded_obj = "{\"test\":{\"nested\":\"yes\"}}",
+		.ok = 1234,
+	};
+	char buffer[sizeof(encoded)];
+	int ret;
+
+	ret = json_obj_encode_buf(test_json_tok_encoded_obj_descr,
+				  ARRAY_SIZE(test_json_tok_encoded_obj_descr), &obj, buffer,
+				  sizeof(buffer));
+
+	zassert_equal(ret, 0, "Encoding function failed");
+	zassert_mem_equal(buffer, encoded, sizeof(encoded), "Encoded contents not consistent");
 }
 
 ZTEST_SUITE(lib_json_test, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
add support to include a already encoded object to a object.
~~This is needed in #69293~~