### PR TITLE
ztest: define _POSIX_C_SOURCE macro

### DIFF
--- a/subsys/testsuite/ztest/CMakeLists.txt
+++ b/subsys/testsuite/ztest/CMakeLists.txt
@@ -15,6 +15,10 @@ if(DEFINED TC_RUNID)
 endif()
 
 zephyr_library()
+
+# For strtok_r() and strdup()
+zephyr_library_compile_options(-D_POSIX_C_SOURCE=200809L)
+
 zephyr_library_sources(
   src/ztest.c
   src/ztest_error_hook.c

--- a/subsys/testsuite/ztest/src/ztest_posix.c
+++ b/subsys/testsuite/ztest/src/ztest_posix.c
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#undef _POSIX_C_SOURCE
-#define _POSIX_C_SOURCE 200809L
-
 #include <stdio.h>
 #include <stdlib.h>
 #include "cmdline.h" /* native_posix command line options header */


### PR DESCRIPTION
Add declaration of the _POSIX_C_SOURCE < 200809L for ztest library for
declaration of strtok_r and strdup functions.
