### PR TITLE
soc: esp32s3: appcpu: add sram dts information

### DIFF
--- a/dts/xtensa/espressif/esp32s3/esp32s3_appcpu.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_appcpu.dtsi
@@ -5,3 +5,8 @@
  */
 
 #include "esp32s3_common.dtsi"
+
+&sram0 {
+	reg = <0x3fc88000 DT_SIZE_K(10)>;
+	status = "okay";
+};


### PR DESCRIPTION
Make sure SoC has defined RAM size.