### PR TITLE
soc: esp32: make SCHED_CPU_MASK depend on SCHED_DUMB

### DIFF
--- a/soc/espressif/esp32/Kconfig.defconfig
+++ b/soc/espressif/esp32/Kconfig.defconfig
@@ -27,7 +27,7 @@ config SCHED_IPI_SUPPORTED
 	default y
 
 config SCHED_CPU_MASK
-	default y
+	default y if SCHED_DUMB
 
 config MP_MAX_NUM_CPUS
 	default 2


### PR DESCRIPTION
Forcing SCHED_CPU_MASK without SCHED_DUMB results in a global warning
from Kconfig.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
