### PR TITLE
stm32 xspi reference  to replace the ospi for stm32x mcu

### DIFF
--- a/boards/st/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
+++ b/boards/st/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
@@ -256,8 +256,8 @@ zephyr_udc0: &usbotg_fs {
 		compatible = "st,stm32-ospi-nor";
 		reg = <0x90000000 DT_SIZE_M(8)>; /* 64 Megabits */
 		ospi-max-frequency = <DT_FREQ_M(26)>; /* for Voltage Range 2 */
-		spi-bus-width = <OSPI_QUAD_MODE>;
-		data-rate = <OSPI_STR_TRANSFER>;
+		spi-bus-width = <XSPI_QUAD_MODE>;
+		data-rate = <XSPI_STR_TRANSFER>;
 		writeoc="PP_1_4_4";
 
 		status = "okay";

--- a/boards/st/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
+++ b/boards/st/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
@@ -135,8 +135,8 @@ stm32_lp_tick_source: &lptim1 {
 		compatible = "st,stm32-ospi-nor";
 		reg = <0x70000000 DT_SIZE_M(64)>; /* 512 Mbits */
 		ospi-max-frequency = <DT_FREQ_M(50)>;
-		spi-bus-width = <OSPI_OPI_MODE>;
-		data-rate = <OSPI_DTR_TRANSFER>;
+		spi-bus-width = <XSPI_OCTO_MODE>;
+		data-rate = <XSPI_DTR_TRANSFER>;
 		four-byte-opcodes;
 		status = "okay";
 

--- a/boards/st/stm32h573i_dk/stm32h573i_dk.dts
+++ b/boards/st/stm32h573i_dk/stm32h573i_dk.dts
@@ -250,8 +250,8 @@
 		compatible = "st,stm32-ospi-nor";
 		reg = <0x90000000 DT_SIZE_M(64)>; /* 512 Mbits */
 		ospi-max-frequency = <DT_FREQ_M(50)>;
-		spi-bus-width = <OSPI_OPI_MODE>;
-		data-rate = <OSPI_DTR_TRANSFER>;
+		spi-bus-width = <XSPI_OCTO_MODE>;
+		data-rate = <XSPI_DTR_TRANSFER>;
 		four-byte-opcodes;
 		status = "okay";
 

--- a/boards/st/stm32h735g_disco/stm32h735g_disco.dts
+++ b/boards/st/stm32h735g_disco/stm32h735g_disco.dts
@@ -169,8 +169,8 @@
 		compatible = "st,stm32-ospi-nor";
 		reg = <0x90000000 DT_SIZE_M(64)>; /* 512 Mbits */
 		ospi-max-frequency = <DT_FREQ_M(50)>;
-		spi-bus-width = <OSPI_OPI_MODE>;
-		data-rate = <OSPI_DTR_TRANSFER>;
+		spi-bus-width = <XSPI_OCTO_MODE>;
+		data-rate = <XSPI_DTR_TRANSFER>;
 		status = "okay";
 
 		partitions {

--- a/boards/st/stm32h7b3i_dk/stm32h7b3i_dk.dts
+++ b/boards/st/stm32h7b3i_dk/stm32h7b3i_dk.dts
@@ -255,8 +255,8 @@
 		compatible = "st,stm32-ospi-nor";
 		reg = <0x90000000 DT_SIZE_M(64)>; /* 512 Mbits */
 		ospi-max-frequency = <DT_FREQ_M(50)>;
-		spi-bus-width = <OSPI_OPI_MODE>;
-		data-rate = <OSPI_DTR_TRANSFER>;
+		spi-bus-width = <XSPI_OCTO_MODE>;
+		data-rate = <XSPI_DTR_TRANSFER>;
 		status = "okay";
 
 		partitions {

--- a/boards/st/stm32l4r9i_disco/stm32l4r9i_disco.dts
+++ b/boards/st/stm32l4r9i_disco/stm32l4r9i_disco.dts
@@ -229,8 +229,8 @@ zephyr_udc0: &usbotg_fs {
 		compatible = "st,stm32-ospi-nor";
 		reg = <0x90000000 DT_SIZE_M(64)>; /* 512 Mbits */
 		ospi-max-frequency = <DT_FREQ_M(25)>;
-		spi-bus-width = <OSPI_OPI_MODE>;
-		data-rate = <OSPI_STR_TRANSFER>;
+		spi-bus-width = <XSPI_OCTO_MODE>;
+		data-rate = <XSPI_STR_TRANSFER>;
 		four-byte-opcodes;
 		sfdp-bfp = [
 			53 46 44 50 06 01 02 ff

--- a/boards/st/stm32l562e_dk/stm32l562e_dk_common.dtsi
+++ b/boards/st/stm32l562e_dk/stm32l562e_dk_common.dtsi
@@ -139,8 +139,8 @@ stm32_lp_tick_source: &lptim1 {
 		compatible = "st,stm32-ospi-nor";
 		reg = <0x90000000 DT_SIZE_M(64)>; /* 512 Mbits */
 		ospi-max-frequency = <DT_FREQ_M(50)>;
-		spi-bus-width = <OSPI_OPI_MODE>;
-		data-rate = <OSPI_DTR_TRANSFER>;
+		spi-bus-width = <XSPI_OCTO_MODE>;
+		data-rate = <XSPI_DTR_TRANSFER>;
 		four-byte-opcodes;
 		status = "okay";
 		sfdp-bfp = [

--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -114,6 +114,8 @@ Display
 Flash
 =====
 
+* The STM32 octoSPI driver has a common reference to XSPI constant definition. Values prefixed with XSPI_xxx are used instead of OSPI_xxx
+
 General Purpose I/O (GPIO)
 ==========================
 

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -6,6 +6,7 @@
 
 #include <st/h5/stm32h5.dtsi>
 #include <zephyr/dt-bindings/flash_controller/ospi.h>
+#include <zephyr/dt-bindings/flash_controller/xspi.h>
 
 / {
 	clocks {

--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -9,6 +9,7 @@
 #include <st/h7/stm32h7.dtsi>
 #include <zephyr/dt-bindings/display/panel.h>
 #include <zephyr/dt-bindings/flash_controller/ospi.h>
+#include <zephyr/dt-bindings/flash_controller/xspi.h>
 
 / {
 	soc {

--- a/dts/arm/st/h7/stm32h7a3.dtsi
+++ b/dts/arm/st/h7/stm32h7a3.dtsi
@@ -7,6 +7,7 @@
 #include <st/h7/stm32h7.dtsi>
 #include <zephyr/dt-bindings/display/panel.h>
 #include <zephyr/dt-bindings/flash_controller/ospi.h>
+#include <zephyr/dt-bindings/flash_controller/xspi.h>
 
 /delete-node/ &adc3;
 

--- a/dts/arm/st/l4/stm32l4p5.dtsi
+++ b/dts/arm/st/l4/stm32l4p5.dtsi
@@ -7,6 +7,7 @@
 #include <mem.h>
 #include <st/l4/stm32l4.dtsi>
 #include <zephyr/dt-bindings/flash_controller/ospi.h>
+#include <zephyr/dt-bindings/flash_controller/xspi.h>
 
 /delete-node/ &quadspi;
 

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -17,6 +17,7 @@
 #include <zephyr/dt-bindings/reset/stm32g4_l4_5_reset.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/flash_controller/ospi.h>
+#include <zephyr/dt-bindings/flash_controller/xspi.h>
 #include <freq.h>
 
 / {

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -14,6 +14,7 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/flash_controller/ospi.h>
+#include <zephyr/dt-bindings/flash_controller/xspi.h>
 #include <zephyr/dt-bindings/reset/stm32u5_reset.h>
 #include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <zephyr/dt-bindings/memory-controller/stm32-fmc-nor-psram.h>

--- a/dts/bindings/flash_controller/st,stm32-ospi-nor.yaml
+++ b/dts/bindings/flash_controller/st,stm32-ospi-nor.yaml
@@ -9,8 +9,8 @@ description: |
         mx25lm51245: ospi-nor-flash@70000000 {
                 compatible = "st,stm32-ospi-nor";
                 reg = <0x70000000 DT_SIZE_M(64)>; /* 512 Mbits */
-                data-mode = <OSPI_OPI_MODE>; /* access on 8 data lines */
-                data-rate = <OSPI_DTR_TRANSFER>; /* access in DTR */
+                data-mode = <XSPI_OCTO_MODE>; /* access on 8 data lines */
+                data-rate = <XSPI_DTR_TRANSFER>; /* access in DTR */
                 ospi-max-frequency = <DT_FREQ_M(50)>;
                 status = "okay";
         };
@@ -39,10 +39,10 @@ properties:
      The width of (Octo)SPI bus to which flash memory is connected.
 
      Possible values are :
-      - OSPI_SPI_MODE  <1> = SPI mode on 1 data line
-      - OSPI_DUAL_MODE <2> = Dual mode on 2 data lines
-      - OSPI_QUAD_MODE <4> = Quad mode on 4 data lines
-      - OSPI_OPI_MODE  <8> = Octo mode on 8 data lines
+      - XSPI_SPI_MODE  <1> = SPI mode on 1 data line
+      - XSPI_DUAL_MODE <2> = Dual mode on 2 data lines
+      - XSPI_QUAD_MODE <4> = Quad mode on 4 data lines
+      - XSPI_OCTO_MODE  <8> = Octo mode on 8 data lines
     enum:
       - 1
       - 2
@@ -55,8 +55,8 @@ properties:
      The SPI data Rate is STR or DTR
 
      Possible values are :
-      - OSPI_STR_TRANSFER <1> = Single Rate Transfer
-      - OSPI_DTR_TRANSFER <2> = Dual Rate Transfer (only with OSPI_OPI_MODE)
+      - XSPI_STR_TRANSFER <1> = Single Rate Transfer
+      - XSPI_DTR_TRANSFER <2> = Dual Rate Transfer (only with XSPI_OCTO_MODE)
     enum:
       - 1
       - 2
@@ -75,14 +75,14 @@ properties:
       tables, hence it has been assumed that NOR flash memory
       supporting 1-4-4 mode also would support fast page programming.
 
-      Intended for modes other than OSPI_OPI_MODE.
+      Intended for modes other than XSPI_OCTO_MODE.
 
       If absent, then program page opcode is determined by the
       `spi-bus-width`:
 
-      * OSPI_SPI_MODE -> PP 1-1-1 (0x02)
-      * OSPI_DUAL_MODE -> PP 1-1-2 (0xA2)
-      * OSPI_QUAD_MODE -> PP 1-4-4 (0x38)
+      * OXSPI_SPI_MODE -> PP 1-1-1 (0x02)
+      * XSPI_DUAL_MODE -> PP 1-1-2 (0xA2)
+      * XSPI_QUAD_MODE -> PP 1-4-4 (0x38)
   four-byte-opcodes:
     type: boolean
     description: |

--- a/include/zephyr/dt-bindings/flash_controller/xspi.h
+++ b/include/zephyr/dt-bindings/flash_controller/xspi.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_XSPI_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_XSPI_H_
+
+/**
+ * @name XSPI definition for the OctoSPI peripherals
+ * Note that the possible combination is
+ *  SPI mode in STR transfer rate
+ *  OPI mode in STR transfer rate
+ *  OPI mode in DTR transfer rate
+ */
+
+/* XSPI mode operating on 1 line, 2 lines, 4 lines or 8 lines */
+/* 1 Cmd Line, 1 Address Line and 1 Data Line    */
+#define XSPI_SPI_MODE                     1
+/* 2 Cmd Lines, 2 Address Lines and 2 Data Lines */
+#define XSPI_DUAL_MODE                    2
+/* 4 Cmd Lines, 4 Address Lines and 4 Data Lines */
+#define XSPI_QUAD_MODE                    4
+/* 8 Cmd Lines, 8 Address Lines and 8 Data Lines */
+#define XSPI_OCTO_MODE                    8
+
+/* XSPI mode operating on Single or Double Transfer Rate */
+/* Single Transfer Rate */
+#define XSPI_STR_TRANSFER                 1
+/* Double Transfer Rate */
+#define XSPI_DTR_TRANSFER                 2
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_XSPI_H_ */


### PR DESCRIPTION
This change is for preparing the future stm32 series that could have spi/quad/octo/hexa spi peripheral and gives more flexibility to stm32 devices

The OSPI_xxx constant are renamed with XSPI_ prefix

The XSPI constants are common values to the existing zephyr  flash_stm32_qspi or flash_stm32_ospi.

requires https://github.com/zephyrproject-rtos/zephyr/pull/70434
