### PR TITLE
arch: riscv: disable interrupts before `wfi`

### DIFF
--- a/arch/riscv/core/cpu_idle.c
+++ b/arch/riscv/core/cpu_idle.c
@@ -10,13 +10,13 @@
 void __weak arch_cpu_idle(void)
 {
 	sys_trace_idle();
-	irq_unlock(MSTATUS_IEN);
 	__asm__ volatile("wfi");
+	irq_unlock(MSTATUS_IEN);
 }
 
 void __weak arch_cpu_atomic_idle(unsigned int key)
 {
 	sys_trace_idle();
-	irq_unlock(key);
 	__asm__ volatile("wfi");
+	irq_unlock(key);
 }

--- a/soc/nordic/common/vpr/CMakeLists.txt
+++ b/soc/nordic/common/vpr/CMakeLists.txt
@@ -3,6 +3,6 @@
 
 zephyr_include_directories(.)
 
-zephyr_library_sources(soc_irq.S soc_irq.c vector.S)
+zephyr_library_sources(soc_idle.c soc_irq.S soc_irq.c vector.S)
 
 set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/riscv/common/linker.ld CACHE INTERNAL "")

--- a/soc/nordic/common/vpr/Kconfig
+++ b/soc/nordic/common/vpr/Kconfig
@@ -15,5 +15,6 @@ config RISCV_CORE_NORDIC_VPR
 	select RISCV_SOC_HAS_ISR_STACKING
 	select RISCV_SOC_CONTEXT_SAVE
 	select HAS_FLASH_LOAD_OFFSET
+	select ARCH_CPU_IDLE_CUSTOM
 	help
 	  Enable support for the RISC-V Nordic VPR core.

--- a/soc/nordic/common/vpr/soc_idle.c
+++ b/soc/nordic/common/vpr/soc_idle.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2024 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/irq.h>
+#include <zephyr/tracing/tracing.h>
+
+/*
+ * Due to a HW issue, VPR requires MSTATUS.MIE to be enabled when entering sleep.
+ * Otherwise it would not wake up.
+ */
+void arch_cpu_idle(void)
+{
+	sys_trace_idle();
+	irq_unlock(MSTATUS_IEN);
+	__asm__ volatile("wfi");
+}
+
+void arch_cpu_atomic_idle(unsigned int key)
+{
+	sys_trace_idle();
+	irq_unlock(MSTATUS_IEN);
+	__asm__ volatile("wfi");
+
+	/* Disable interrupts if needed. */
+	__asm__ volatile ("csrc mstatus, %0"
+			  :
+			  : "r" (~key & MSTATUS_IEN)
+			  : "memory");
+}


### PR DESCRIPTION
According to RISC-V Instruction Set Manual Chapter 3.3.2:

> The operation of WFI must be unaffected by the global interrupt bits in mstatus
> [...]
> WFI is also required to resume execution for locally enabled interrupts pending at any privilege level,
> regardless of the global interrupt enable at each privilege level.

Disabling interrupts before executing `wfi` prevents a corner case where an IRQ is presented
just before executing `wfi`, which would cause it to return directly into `wfi` and potentially
get stuck in sleep, instead of continuing to background processing.

When execution is resumed, interrupts are reenabled and appropriate IRQ Handlers should be executed.