### PR TITLE
native_posix -> native_sim transition: Minor cleanup

### DIFF
--- a/arch/posix/CMakeLists.txt
+++ b/arch/posix/CMakeLists.txt
@@ -197,7 +197,7 @@ endif()
 # This is due to some tests using _Static_assert which is a 2011 feature, but
 # otherwise relying on compilers supporting it also when set to C99.
 # This was in general ok, but with some host compilers and C library versions
-# it led to problems. So we override it to 2011 for native_posix.
+# it led to problems. So we override it to 2011 for the native targets.
 set_property(GLOBAL PROPERTY CSTD c11)
 
 add_subdirectory(core)

--- a/arch/posix/include/posix_cheats.h
+++ b/arch/posix/include/posix_cheats.h
@@ -16,7 +16,7 @@
  * If you do see a link error telling you that zap_something is undefined, it is
  * likely that you forgot to select the corresponding Zephyr POSIX API.
  *
- * This header is included automatically when targeting POSIX ARCH boards
+ * This header is included automatically when targeting some POSIX ARCH boards
  * (for ex. native_posix).
  * It will be included in _all_ Zephyr and application source files
  * (it is passed with the option "-include" to the compiler call)

--- a/cmake/compiler/clang/compiler_flags.cmake
+++ b/cmake/compiler/clang/compiler_flags.cmake
@@ -10,8 +10,8 @@ set_compiler_property(PROPERTY security_fortify_run_time)
 # No printf-return-value optimizations in clang
 set_compiler_property(PROPERTY no_printf_return_value)
 
-# No property flag, this is used by the native_posix, clang has problems
-# compiling the native_posix with -fno-freestanding.
+# No property flag, this is used by the POSIX arch based targets when building with the host libC,
+# But clang has problems compiling these with -fno-freestanding.
 check_set_compiler_property(PROPERTY hosted)
 
 # clang flags for coverage generation

--- a/doc/develop/application/index.rst
+++ b/doc/develop/application/index.rst
@@ -706,20 +706,20 @@ Given the following example project layout:
    ├── prj.conf
    ├── prj_mouse.conf
    ├── boards
-   │   ├── native_posix.overlay
+   │   ├── native_sim.overlay
    │   └── qemu_cortex_m3_mouse.overlay
    └── src
        └── main.c
 
-* If this is built normally without ``FILE_SUFFIX`` being defined for ``native_posix`` then
-  ``prj.conf`` and ``boards/native_posix.overlay`` will be used.
+* If this is built normally without ``FILE_SUFFIX`` being defined for ``native_sim`` then
+  ``prj.conf`` and ``boards/native_sim.overlay`` will be used.
 
 * If this is build normally without ``FILE_SUFFIX`` being defined for ``qemu_cortex_m3`` then
   ``prj.conf`` will be used, no application devicetree overlay will be used.
 
-* If this is built with ``FILE_SUFFIX`` set to ``mouse`` for ``native_posix`` then
-  ``prj_mouse.conf`` and ``boards/native_posix.overlay`` will be used (there is no
-  ``native_posix_mouse.overlay`` file so it falls back to ``native_posix.overlay``).
+* If this is built with ``FILE_SUFFIX`` set to ``mouse`` for ``native_sim`` then
+  ``prj_mouse.conf`` and ``boards/native_sim.overlay`` will be used (there is no
+  ``native_sim_mouse.overlay`` file so it falls back to ``native_sim.overlay``).
 
 * If this is build with ``FILE_SUFFIX`` set to ``mouse`` for ``qemu_cortex_m3`` then
   ``prj_mouse.conf`` will be used and ``boards/qemu_cortex_m3_mouse.overlay`` will be used.

--- a/drivers/gpio/Kconfig.emul
+++ b/drivers/gpio/Kconfig.emul
@@ -15,5 +15,5 @@ config GPIO_EMUL
 	  available in drivers/gpio/gpio_emul.h . Configuration for each
 	  GPIO instance is accomplished using device tree and an example of
 	  such a configuration is in
-	  tests/drivers/gpio/gpio_basic_api/boards/native_posix_64.overlay
+	  tests/drivers/gpio/gpio_basic_api/boards/native_sim.overlay
 	  If unsure, say N.

--- a/drivers/sensor/bma4xx/Kconfig
+++ b/drivers/sensor/bma4xx/Kconfig
@@ -28,4 +28,4 @@ config EMUL_BMA4XX
 	depends on EMUL
 	help
 	  Enable the hardware emulator for the BMA4XX. Doing so allows exercising
-	  sensor APIs for this sensor in native_posix and qemu.
+	  sensor APIs for this sensor in native_sim and qemu.

--- a/include/zephyr/drivers/gpio/gpio_emul.h
+++ b/include/zephyr/drivers/gpio/gpio_emul.h
@@ -36,7 +36,7 @@ extern "C" {
  *   @ref gpio_emul_input_set_masked in order to emulate GPIO events
  *
  * An example of an appropriate Device Tree overlay file is in
- * tests/drivers/gpio/gpio_basic_api/boards/native_posix_64.overlay.
+ * tests/drivers/gpio/gpio_basic_api/boards/native_sim.overlay.
  *
  * An example of registering a callback to emulate "wiring" as well as
  * an example of calling @ref gpio_emul_input_set is in the file

--- a/scripts/net/README.txt
+++ b/scripts/net/README.txt
@@ -46,7 +46,7 @@ User can see what samples are supported like this:
    $ZEPHYR_BASE/scripts/net/run-sample-tests.sh --scan
 
 The Docker container and a corresponding 'net-tools0' Docker network is started
-by the script, as well as Zephyr using native_posix board. IP addresses are
+by the script, as well as Zephyr using native_sim board. IP addresses are
 assigned to the Docker network, which is a Linux network bridge interface.
 The default IP addresses are:
 

--- a/subsys/testsuite/ztest/src/ztest_posix.c
+++ b/subsys/testsuite/ztest/src/ztest_posix.c
@@ -9,7 +9,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "cmdline.h" /* native_posix command line options header */
+#include "cmdline.h" /* native_sim command line options header */
 #include "soc.h"
 #include <zephyr/tc_util.h>
 #include <zephyr/ztest_test.h>

--- a/tests/net/checksum_offload/src/main.c
+++ b/tests/net/checksum_offload/src/main.c
@@ -72,7 +72,7 @@ static struct in_addr in4addr_dst = { { { 192, 0, 2, 2 } } };
 static struct in_addr in4addr_my2 = { { { 192, 0, 42, 1 } } };
 static struct in_addr in4addr_dst2 = { { { 192, 0, 42, 2 } } };
 
-/* Keep track of all ethernet interfaces. For native_posix board, we need
+/* Keep track of all ethernet interfaces. For native_sim board, we need
  * to increase the count as it has one extra network interface defined in
  * eth_native_posix driver.
  */

--- a/tests/net/iface/src/main.c
+++ b/tests/net/iface/src/main.c
@@ -297,7 +297,7 @@ static void iface_cb(struct net_if *iface, void *user_data)
 		const struct ethernet_api *api =
 			net_if_get_device(iface)->api;
 
-		/* As native_posix board will introduce another ethernet
+		/* As native_sim board will introduce another ethernet
 		 * interface, make sure that we only use our own in this test.
 		 */
 		if (api->get_capabilities ==

--- a/tests/net/promiscuous/src/main.c
+++ b/tests/net/promiscuous/src/main.c
@@ -178,7 +178,7 @@ static void iface_cb(struct net_if *iface, void *user_data)
 		const struct ethernet_api *api =
 			net_if_get_device(iface)->api;
 
-		/* As native_posix board will introduce another ethernet
+		/* As native_sim board will introduce another ethernet
 		 * interface, make sure that we only use our own in this test.
 		 */
 		if (api->get_capabilities ==


### PR DESCRIPTION
* Clarify some references to native_posix which apply to all native targets, or not
* Replace native_posix w native_sim in documentation examples
* Fix 2 references in comments/kconfig help messages to overlays that were renamed
* Replace native_posix w native_sim in a couple of code comments (even though the comments apply also to native_posix, we will eventually remove native_posix, so just to not need to remove native_posix after)

---- 

~CI failure is due to:~
* https://github.com/zephyrproject-rtos/zephyr/issues/70380