### PR TITLE
input: analog_axis: rework deadzone calibration code

### DIFF
--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -120,6 +120,12 @@ General Purpose I/O (GPIO)
 Input
 =====
 
+* The ``analog-axis`` deadzone calibration value has been changed to be
+  relative to the raw ADC values, similarly to min and max. The data structures
+  and properties have been renamed to reflect that (from ``out-deadzone`` to
+  ``in-deadzone``) and when migrating to the new definition the value should be
+  scaled accordingly.
+
 Interrupt Controller
 ====================
 

--- a/drivers/input/input_analog_axis.c
+++ b/drivers/input/input_analog_axis.c
@@ -249,7 +249,7 @@ static int analog_axis_init(const struct device *dev)
 		analog_axis_channel_data_##inst[ARRAY_SIZE(analog_axis_channel_cfg_##inst)];	\
 												\
 	static struct analog_axis_calibration							\
-		analog_axis_calibration##inst[ARRAY_SIZE(analog_axis_channel_cfg_##inst)] = {	\
+		analog_axis_calibration_##inst[ARRAY_SIZE(analog_axis_channel_cfg_##inst)] = {	\
 			DT_INST_FOREACH_CHILD_STATUS_OKAY_SEP(					\
 				inst, ANALOG_AXIS_CHANNEL_CAL_DEF, (,))				\
 		};										\
@@ -258,7 +258,7 @@ static int analog_axis_init(const struct device *dev)
 		.poll_period_ms = DT_INST_PROP(inst, poll_period_ms),				\
 		.channel_cfg = analog_axis_channel_cfg_##inst,					\
 		.channel_data = analog_axis_channel_data_##inst,				\
-		.calibration = analog_axis_calibration##inst,					\
+		.calibration = analog_axis_calibration_##inst,					\
 		.num_channels = ARRAY_SIZE(analog_axis_channel_cfg_##inst),			\
 	};											\
 												\

--- a/drivers/input/input_analog_axis_settings.c
+++ b/drivers/input/input_analog_axis_settings.c
@@ -27,7 +27,7 @@ static void analog_axis_calibration_log(const struct device *dev)
 		analog_axis_calibration_get(dev, i, &cal);
 
 		LOG_INF("%s: ch: %d min: %d max: %d deadzone: %d",
-			dev->name, i, cal.in_min, cal.in_max, cal.out_deadzone);
+			dev->name, i, cal.in_min, cal.in_max, cal.in_deadzone);
 	}
 }
 

--- a/dts/bindings/input/analog-axis.yaml
+++ b/dts/bindings/input/analog-axis.yaml
@@ -16,7 +16,7 @@ description: |
           poll-period-ms = <15>;
           axis-x {
                   io-channels = <&adc 0>;
-                  out-deadzone = <8>;
+                  in-deadzone = <50>;
                   in-min = <100>;
                   in-max = <800>;
                   zephyr,axis = <INPUT_ABS_X>;
@@ -56,13 +56,13 @@ child-binding:
         Maximum value to output on input events. Defaults to 255 if
         unspecified.
 
-    out-deadzone:
+    in-deadzone:
       type: int
       default: 0
       description: |
-        Deadzone for the output center value. If specified output values
-        between the center of the range plus or minus this value will be
-        reported as center. Defaults to 0, no deadzone.
+        Deadzone for the input center value. If specified input values between
+        the center of the range plus or minus this value will be reported as
+        center. Defaults to 0, no deadzone.
 
     in-min:
       type: int

--- a/include/zephyr/input/input_analog_axis.h
+++ b/include/zephyr/input/input_analog_axis.h
@@ -29,8 +29,8 @@ struct analog_axis_calibration {
 	int16_t in_min;
 	/** Input value that corresponds to the maximum output value. */
 	int16_t in_max;
-	/** Output value deadzone relative to the output range. */
-	uint16_t out_deadzone;
+	/** Input value center deadzone. */
+	uint16_t in_deadzone;
 };
 
 /**

--- a/tests/drivers/build_all/input/app.overlay
+++ b/tests/drivers/build_all/input/app.overlay
@@ -136,7 +136,7 @@
 				io-channels = <&test_adc 0>;
 				out-min = <(-127)>;
 				out-max = <127>;
-				out-deadzone = <8>;
+				in-deadzone = <8>;
 				in-min = <(-100)>;
 				in-max = <100>;
 				zephyr,axis = <0>;


### PR DESCRIPTION
Rework the data scaling algorithm for the "deadzone" mode so that the deadzone is subtracted from the input rather than from the output. This makes the whole output range usable rather than making the output jump from the center value to the minimum deadzone range.

This changes the calibration data structure as well so now all values in the calibration data structure refer to the input data, which is more coherent.