### PR TITLE
mgmt: mcumgr: Add Kconfig option to manage SMP service registration

### DIFF
--- a/samples/subsys/mgmt/mcumgr/smp_svr/sample.yaml
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/sample.yaml
@@ -15,6 +15,16 @@ tests:
     integration_platforms:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
+  sample.mcumgr.smp_svr.bt_static_svc:
+    extra_args: OVERLAY_CONFIG="overlay-bt.conf"
+    extra_configs:
+      - CONFIG_MCUMGR_TRANSPORT_BT_DYNAMIC_SVC_REGISTRATION=n
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - pinnacle_100_dvk
+      - mg100
+    integration_platforms:
+      - nrf52840dk/nrf52840
   sample.mcumgr.smp_svr.udp:
     extra_args: OVERLAY_CONFIG="overlay-udp.conf"
     platform_allow: frdm_k64f

--- a/subsys/mgmt/mcumgr/transport/Kconfig.bluetooth
+++ b/subsys/mgmt/mcumgr/transport/Kconfig.bluetooth
@@ -12,7 +12,6 @@
 menuconfig MCUMGR_TRANSPORT_BT
 	bool "Bluetooth mcumgr SMP transport"
 	depends on BT_PERIPHERAL
-	select BT_GATT_DYNAMIC_DB
 	help
 	  Enables handling of SMP commands received over Bluetooth.
 
@@ -91,5 +90,14 @@ config MCUMGR_TRANSPORT_BT_CONN_PARAM_CONTROL_RETRY_TIME
 	  option specifies the time of the next update attempt.
 
 endif # MCUMGR_TRASNPORT_BT_CONN_PARAM_CONTROL
+
+config MCUMGR_TRANSPORT_BT_DYNAMIC_SVC_REGISTRATION
+	bool "Register SMP service at runtime"
+	select BT_GATT_DYNAMIC_DB
+	default y
+	help
+	  When enabled, the SMP service will be automatically registered at boot time
+	  and can then be dynamically registered/unregistered using a dedicated API.
+	  Otherwise, the SMP service will be statically defined and registered.
 
 endif # MCUMGR_TRANSPORT_BT


### PR DESCRIPTION
Added the CONFIG_MCUMGR_TRANSPORT_BT_DYNAMIC_SVC_REGISTRATION Kconfig option to manage how the SMP service should be registered. By default the SMP service must be registered at runtime. If this Kconfig option is disabled, the SMP service is statically defined and registered.

This change allows to opt out of using the CONFIG_BT_GATT_DYNAMIC_DB Kconfig option and as a result, lower the memory usage.

CC: @kapi-no @MarekPieta @zycz