### PR TITLE
devicetree.h: Rework DT_ANY_INST_HAS_PROP_STATUS_OKAY

### DIFF
--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -4190,7 +4190,7 @@
  * @endcode
  */
 #define DT_ANY_INST_HAS_PROP_STATUS_OKAY(prop) \
-	(DT_INST_FOREACH_STATUS_OKAY_VARGS(DT_INST_NODE_HAS_PROP_AND_OR, prop) 0)
+	COND_CODE_1(IS_EMPTY(DT_ANY_INST_HAS_PROP_STATUS_OKAY_(prop)), (0), (1))
 
 /**
  * @brief Call @p fn on all nodes with compatible `DT_DRV_COMPAT`
@@ -4424,6 +4424,34 @@
  */
 
 /** @cond INTERNAL_HIDDEN */
+
+/** @brief Helper for DT_ANY_INST_HAS_PROP_STATUS_OKAY_
+ *
+ * This macro generates token "1," for instance of a device,
+ * identified by index @p idx, if instance has property @p prop.
+ *
+ * @param idx instance number
+ * @param prop property to check for
+ *
+ * @return Macro evaluates to `1,` if instance has the property,
+ * otherwise it evaluates to literal nothing.
+ */
+#define DT_ANY_INST_HAS_PROP_STATUS_OKAY__(idx, prop)	\
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(idx, prop), (1,), ())
+/** @brief Helper for DT_ANY_INST_HAS_PROP_STATUS_OKAY
+ *
+ * This macro uses DT_ANY_INST_HAS_PROP_STATUS_OKAY_ with
+ * DT_INST_FOREACH_STATUS_OKAY_VARG to generate comma separated list of 1,
+ * where each 1 on the list represents instance that has a property
+ * @p prop; the list may be empty, and the upper bound on number of
+ * list elements is number of device instances.
+ *
+ * @param prop property to check
+ *
+ * @return Evaluates to list of 1s (e.g: 1,1,1,) or nothing.
+ */
+#define DT_ANY_INST_HAS_PROP_STATUS_OKAY_(prop)	\
+	DT_INST_FOREACH_STATUS_OKAY_VARGS(DT_ANY_INST_HAS_PROP_STATUS_OKAY__, prop)
 
 #define DT_PATH_INTERNAL(...) \
 	UTIL_CAT(DT_ROOT, MACRO_MAP_CAT(DT_S_PREFIX, __VA_ARGS__))

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -190,6 +190,25 @@ ZTEST(devicetree_api, test_any_inst_prop)
 	zassert_equal(DT_ANY_INST_HAS_PROP_STATUS_OKAY(bar), 1, "");
 	zassert_equal(DT_ANY_INST_HAS_PROP_STATUS_OKAY(baz), 0, "");
 	zassert_equal(DT_ANY_INST_HAS_PROP_STATUS_OKAY(does_not_exist), 0, "");
+
+	zassert_equal(COND_CODE_1(DT_ANY_INST_HAS_PROP_STATUS_OKAY(foo),
+				  (5), (6)),
+		      5, "");
+	zassert_equal(COND_CODE_0(DT_ANY_INST_HAS_PROP_STATUS_OKAY(foo),
+				  (5), (6)),
+		      6, "");
+	zassert_equal(COND_CODE_1(DT_ANY_INST_HAS_PROP_STATUS_OKAY(baz),
+				  (5), (6)),
+		      6, "");
+	zassert_equal(COND_CODE_0(DT_ANY_INST_HAS_PROP_STATUS_OKAY(baz),
+				  (5), (6)),
+		      5, "");
+	zassert_true(IS_ENABLED(DT_ANY_INST_HAS_PROP_STATUS_OKAY(foo)), "");
+	zassert_true(!IS_ENABLED(DT_ANY_INST_HAS_PROP_STATUS_OKAY(baz)), "");
+	zassert_equal(IF_ENABLED(DT_ANY_INST_HAS_PROP_STATUS_OKAY(foo), (1)) + 1,
+		      2, "");
+	zassert_equal(IF_ENABLED(DT_ANY_INST_HAS_PROP_STATUS_OKAY(baz), (1)) + 1,
+		      1, "");
 }
 
 ZTEST(devicetree_api, test_default_prop_access)


### PR DESCRIPTION
The macro is searching for all instances of specific device that contain specific property and evaluates to true (1) if any device does.
The macro used to do that by generating, using
DT_ANY_INST_HAS_PROP_STATUS_OKAY, a logical expression like (0 || 1 || 0), where each digit represented existence of property (1) or lack of it (0).
Unfortunately other util macros, like IS_ENABLED, were not able to evaluate such expression, as they often simply expect something they can evaluate to 0 or 1.

The commit here changes DT_ANY_INST_HAS_PROP_STATUS_OKAY to generate a list of tokens (1) where token is added to list only for instance of a device that has the property; then such list is processed using IS_EMPTY() macro and in the end 0 or 1 is generated, depending on whether any enabled instance of a device has the property or not. This change allows result of DT_ANY_INST_HAS_PROP_STATUS_OKAY to be used with macros like IS_ENABLED, IF_ENABLED or COND_CODE_x.