### PR TITLE
pm/device: lock: Remove state lock API

### DIFF
--- a/include/zephyr/pm/device.h
+++ b/include/zephyr/pm/device.h
@@ -44,8 +44,6 @@ enum pm_device_flag {
 	PM_DEVICE_FLAG_WS_ENABLED,
 	/** Indicates if device runtime is enabled  */
 	PM_DEVICE_FLAG_RUNTIME_ENABLED,
-	/** Indicates if the device pm is locked.  */
-	PM_DEVICE_FLAG_STATE_LOCKED,
 	/** Indicates if the device is used as a power domain */
 	PM_DEVICE_FLAG_PD,
 	/** Indicates if device runtime PM should be automatically enabled */
@@ -566,43 +564,6 @@ bool pm_device_wakeup_is_enabled(const struct device *dev);
 bool pm_device_wakeup_is_capable(const struct device *dev);
 
 /**
- * @brief Lock current device state.
- *
- * This function locks the current device power state. Once
- * locked the device power state will not be changed by
- * system power management or device runtime power
- * management until unlocked.
- *
- * @note The given device should not have device runtime enabled.
- *
- * @see pm_device_state_unlock
- *
- * @param dev Device instance.
- */
-void pm_device_state_lock(const struct device *dev);
-
-/**
- * @brief Unlock the current device state.
- *
- * Unlocks a previously locked device pm.
- *
- * @see pm_device_state_lock
- *
- * @param dev Device instance.
- */
-void pm_device_state_unlock(const struct device *dev);
-
-/**
- * @brief Check if the device pm is locked.
- *
- * @param dev Device instance.
- *
- * @retval true If device is locked.
- * @retval false If device is not locked.
- */
-bool pm_device_state_is_locked(const struct device *dev);
-
-/**
  * @brief Check if the device is on a switchable power domain.
  *
  * @param dev Device instance.
@@ -715,19 +676,6 @@ static inline bool pm_device_wakeup_is_enabled(const struct device *dev)
 	return false;
 }
 static inline bool pm_device_wakeup_is_capable(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-	return false;
-}
-static inline void pm_device_state_lock(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-}
-static inline void pm_device_state_unlock(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-}
-static inline bool pm_device_state_is_locked(const struct device *dev)
 {
 	ARG_UNUSED(dev);
 	return false;

--- a/soc/intel/intel_adsp/common/ipc.c
+++ b/soc/intel/intel_adsp/common/ipc.c
@@ -285,7 +285,6 @@ static int ipc_pm_action(const struct device *dev, enum pm_device_action action)
 
 	switch (action) {
 	case PM_DEVICE_ACTION_SUSPEND:
-		pm_device_state_lock(dev);
 		if (api->suspend_fn) {
 			ret = api->suspend_fn(dev, api->suspend_fn_args);
 			if (!ret) {
@@ -294,7 +293,6 @@ static int ipc_pm_action(const struct device *dev, enum pm_device_action action)
 		}
 		break;
 	case PM_DEVICE_ACTION_RESUME:
-		pm_device_state_lock(dev);
 		irq_enable(DT_IRQN(INTEL_ADSP_IPC_HOST_DTNODE));
 		if (!irq_is_enabled(DT_IRQN(INTEL_ADSP_IPC_HOST_DTNODE))) {
 			ret = -EINTR;
@@ -314,7 +312,6 @@ static int ipc_pm_action(const struct device *dev, enum pm_device_action action)
 		return -ENOTSUP;
 	}
 
-	pm_device_state_unlock(dev);
 	return ret;
 }
 

--- a/soc/intel/intel_adsp/common/ipc.c
+++ b/soc/intel/intel_adsp/common/ipc.c
@@ -143,10 +143,6 @@ int intel_adsp_ipc_send_message(const struct device *dev,
 	}
 #endif
 
-	if (pm_device_state_is_locked(INTEL_ADSP_IPC_HOST_DEV)) {
-		return -EAGAIN;
-	}
-
 	pm_device_busy_set(dev);
 	const struct intel_adsp_ipc_config *config = dev->config;
 	struct intel_adsp_ipc_data *devdata = dev->data;

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -49,10 +49,6 @@ int pm_device_action_run(const struct device *dev,
 		return -ENOSYS;
 	}
 
-	if (pm_device_state_is_locked(dev)) {
-		return -EPERM;
-	}
-
 	/* Validate action against current state */
 	if (pm->state == action_target_state[action]) {
 		return -EALREADY;
@@ -325,36 +321,6 @@ bool pm_device_wakeup_is_capable(const struct device *dev)
 
 	return atomic_test_bit(&pm->flags,
 			       PM_DEVICE_FLAG_WS_CAPABLE);
-}
-
-void pm_device_state_lock(const struct device *dev)
-{
-	struct pm_device_base *pm = dev->pm_base;
-
-	if ((pm != NULL) && !pm_device_runtime_is_enabled(dev)) {
-		atomic_set_bit(&pm->flags, PM_DEVICE_FLAG_STATE_LOCKED);
-	}
-}
-
-void pm_device_state_unlock(const struct device *dev)
-{
-	struct pm_device_base *pm = dev->pm_base;
-
-	if (pm != NULL) {
-		atomic_clear_bit(&pm->flags, PM_DEVICE_FLAG_STATE_LOCKED);
-	}
-}
-
-bool pm_device_state_is_locked(const struct device *dev)
-{
-	struct pm_device_base *pm = dev->pm_base;
-
-	if (pm == NULL) {
-		return false;
-	}
-
-	return atomic_test_bit(&pm->flags,
-			       PM_DEVICE_FLAG_STATE_LOCKED);
 }
 
 bool pm_device_on_power_domain(const struct device *dev)

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -421,11 +421,6 @@ int pm_device_runtime_enable(const struct device *dev)
 		goto end;
 	}
 
-	if (pm_device_state_is_locked(dev)) {
-		ret = -EPERM;
-		goto end;
-	}
-
 	if (atomic_test_bit(&dev->pm_base->flags, PM_DEVICE_FLAG_ISR_SAFE)) {
 		ret = runtime_enable_sync(dev);
 		goto end;

--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -66,7 +66,6 @@ static int pm_suspend_devices(void)
 		 * devices with runtime PM enabled.
 		 */
 		if (!device_is_ready(dev) || pm_device_is_busy(dev) ||
-		    pm_device_state_is_locked(dev) ||
 		    pm_device_wakeup_is_enabled(dev) ||
 		    pm_device_runtime_is_enabled(dev)) {
 			continue;

--- a/tests/subsys/pm/device_runtime_api/src/main.c
+++ b/tests/subsys/pm/device_runtime_api/src/main.c
@@ -250,18 +250,6 @@ ZTEST(device_runtime_api, test_api)
 	/* Put operation should fail due the state be locked. */
 	ret = pm_device_runtime_disable(test_dev);
 	zassert_equal(ret, 0);
-
-	pm_device_state_lock(test_dev);
-
-	/* This operation should not succeed.  */
-	ret = pm_device_runtime_enable(test_dev);
-	zassert_equal(ret, -EPERM);
-
-	/* After unlock the state, enable runtime should work. */
-	pm_device_state_unlock(test_dev);
-
-	ret = pm_device_runtime_enable(test_dev);
-	zassert_equal(ret, 0);
 }
 
 DEVICE_DEFINE(pm_unsupported_device, "PM Unsupported", NULL, NULL, NULL, NULL,

--- a/tests/subsys/pm/power_mgmt/src/main.c
+++ b/tests/subsys/pm/power_mgmt/src/main.c
@@ -437,21 +437,6 @@ ZTEST(power_management_1cpu, test_busy)
 	zassert_false(busy);
 }
 
-ZTEST(power_management_1cpu, test_device_state_lock)
-{
-	pm_device_state_lock(device_a);
-	zassert_true(pm_device_state_is_locked(device_a));
-
-	testing_device_lock = true;
-	enter_low_power = true;
-
-	k_sleep(SLEEP_TIMEOUT);
-
-	pm_device_state_unlock(device_a);
-
-	testing_device_lock = false;
-}
-
 ZTEST(power_management_1cpu, test_empty_states)
 {
 	const struct pm_state_info *cpu_states;


### PR DESCRIPTION
- pm device runtime is not respecting state lock and the fact that there is no known issue because of this is a good indication that this functionality is not being used.
- Setting a device busy implements the same functionality basically

- The only place using it in the code base is doing it unnecessarily