### PR TITLE
doc: board: ip_k66f: Update doc with LLDP DSA example information

### DIFF
--- a/boards/segger/ip_k66f/doc/index.rst
+++ b/boards/segger/ip_k66f/doc/index.rst
@@ -62,8 +62,8 @@ The ip_k66f board configuration supports the following hardware features:
 The default configuration can be found in
 :zephyr_file:`boards/segger/ip_k66f/ip_k66f_defconfig`
 
-Micrel/Microchip KSZ8794CNX Ethernet Switch is not currently
-supported.
+Micrel/Microchip KSZ8794CNX Ethernet Switch is supported
+(see :zephyr:code-sample:`dsa` sample).
 
 Connections and IOs
 ===================


### PR DESCRIPTION
The ip_k66f now supports its KSZ8794CNX switch IC via DSA subsystem.

With the samples/net/dsa it is possible to handle LLDP frames on this board.