### PR TITLE
net: dsa: Fix DSA driver for KSZ8xxx to correctly initialize LAN devices

### DIFF
--- a/drivers/ethernet/dsa_ksz8xxx.c
+++ b/drivers/ethernet/dsa_ksz8xxx.c
@@ -16,6 +16,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME, CONFIG_ETHERNET_LOG_LEVEL);
 #include <zephyr/sys/util.h>
 #include <zephyr/net/ethernet.h>
 #include <zephyr/linker/sections.h>
+#include <zephyr/toolchain/common.h>
 
 #if defined(CONFIG_DSA_SPI)
 #include <zephyr/drivers/spi.h>
@@ -1065,7 +1066,8 @@ static struct dsa_api dsa_api_f = {
 	const struct dsa_slave_config dsa_0_slave_##slave##_config = {     \
 		.mac_addr = DT_PROP_OR(slave, local_mac_address, {0})      \
 	};                                                                 \
-	NET_DEVICE_DT_DEFINE_INSTANCE(slave,                               \
+	NET_DEVICE_INIT_INSTANCE(CONCAT(dsa_slave_port_, slave),           \
+	"lan" STRINGIFY(n),                                                \
 	n,                                                                 \
 	dsa_port_init,                                                     \
 	NULL,                                                              \


### PR DESCRIPTION
The commit "drivers: ethernet: dsa_ksz8xxx: use
NET_DEVICE_DT_DEFINE_INSTANCE"
(SHA1: f78a0810667b3b17706596a0ad2c53eb53a9400b) replaced NET_DEVICE_INIT_INSTANCE() with NET_DEVICE_DT_DEFINE_INSTANCE() to facilitate the removal of deprecated (from Zephyr's 3.2 release) DT_LABEL() macro.

Unfortunately, the per LAN port initialization is necessary for correct operation of the DSA driver - otherwise following errors were visible when LLDP DSA sample (samples/net/dsa/src) was run on ip_k66f board:

<wrn> net_if: iface 0x20001440 is down
<inf> net_dsa_lldp_sample: LLDP pkt recv -> lan1
<inf> net_dsa_lldp_sample:   CHASSIS ID:     38:05:43:69:XX:ZZ
<inf> net_dsa_lldp_sample:   PORT ID:        38:05:43:69:XX:ZZ
<inf> net_dsa_lldp_sample:   TTL:            120s
<inf> net_dsa_lldp_sample:   SYSTEM NAME:    mtt
<err> net_dsa_lldp_sample: Failed to send, errno 115

The fix is to use again NET_DEVICE_INIT_INSTANCE() with "lan"X name assigned (to avoid too long names when recommended DT_PROP() is used instead of DT_LABEL()).

Fixes: f78a0810667b3b17706596a0ad2c53eb53a9400b