### PR TITLE
linker: lld: riscv: Enable gp relaxation for lld

### DIFF
--- a/cmake/linker/lld/target_base.cmake
+++ b/cmake/linker/lld/target_base.cmake
@@ -31,6 +31,14 @@ macro(toolchain_ld_base)
     )
   endif()
 
+  # Global pointer relaxation is off by default in lld. Explicitly enable it if
+  # linker relaxations and gp usage are both allowed.
+  if (CONFIG_LINKER_USE_RELAX AND CONFIG_RISCV_GP)
+    zephyr_ld_options(
+      ${LINKERFLAGPREFIX},--relax-gp
+    )
+  endif()
+
   if(CONFIG_CPP)
     # LLVM lld complains:
     #   error: section: init_array is not contiguous with other relro sections


### PR DESCRIPTION
Unlike GNU ld, lld's gp relaxation is disabled by default and must be explicitly enabled via `--relax-gp`. Pass this flag to enable gp relaxation for lld when both linker relaxations and gp usage for RISC-V are enabled.