### PR TITLE
include: Avoid compiler warning about unused variables

### DIFF
--- a/include/zephyr/net/hostname.h
+++ b/include/zephyr/net/hostname.h
@@ -103,6 +103,8 @@ int net_hostname_set_postfix(const uint8_t *hostname_postfix,
 static inline int net_hostname_set_postfix(const uint8_t *hostname_postfix,
 					   int postfix_len)
 {
+	ARG_UNUSED(hostname_postfix);
+	ARG_UNUSED(postfix_len);
 	return -EMSGSIZE;
 }
 #endif /* CONFIG_NET_HOSTNAME_UNIQUE */

--- a/include/zephyr/net/net_context.h
+++ b/include/zephyr/net/net_context.h
@@ -888,6 +888,7 @@ static inline bool net_context_is_proxy_enabled(struct net_context *context)
 #else
 static inline bool net_context_is_proxy_enabled(struct net_context *context)
 {
+	ARG_UNUSED(context);
 	return false;
 }
 #endif
@@ -1004,6 +1005,10 @@ static inline int net_context_create_ipv6_new(struct net_context *context,
 					      const struct in6_addr *src,
 					      const struct in6_addr *dst)
 {
+	ARG_UNUSED(context);
+	ARG_UNUSED(pkt);
+	ARG_UNUSED(src);
+	ARG_UNUSED(dst);
 	return -1;
 }
 #endif /* CONFIG_NET_IPV6 */

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -1788,6 +1788,10 @@ static inline void net_if_ipv6_set_base_reachable_time(struct net_if *iface,
 	}
 
 	iface->config.ip.ipv6->base_reachable_time = reachable_time;
+#else
+	ARG_UNUSED(iface);
+	ARG_UNUSED(reachable_time);
+
 #endif
 }
 
@@ -1809,6 +1813,7 @@ static inline uint32_t net_if_ipv6_get_reachable_time(struct net_if *iface)
 
 	return iface->config.ip.ipv6->reachable_time;
 #else
+	ARG_UNUSED(iface);
 	return 0;
 #endif
 }
@@ -1836,6 +1841,8 @@ static inline void net_if_ipv6_set_reachable_time(struct net_if_ipv6 *ipv6)
 	}
 
 	ipv6->reachable_time = net_if_ipv6_calc_reachable_time(ipv6);
+#else
+	ARG_UNUSED(ipv6);
 #endif
 }
 
@@ -1856,6 +1863,9 @@ static inline void net_if_ipv6_set_retrans_timer(struct net_if *iface,
 	}
 
 	iface->config.ip.ipv6->retrans_timer = retrans_timer;
+#else
+	ARG_UNUSED(iface);
+	ARG_UNUSED(retrans_timer);
 #endif
 }
 
@@ -1877,6 +1887,7 @@ static inline uint32_t net_if_ipv6_get_retrans_timer(struct net_if *iface)
 
 	return iface->config.ip.ipv6->retrans_timer;
 #else
+	ARG_UNUSED(iface);
 	return 0;
 #endif
 }


### PR DESCRIPTION
Use ARG_UNUSED on unused variable.