### PR TITLE
ite/it8xxx2: avoid cpu entering deep doze mode when JTAG is enabled

### DIFF
--- a/soc/ite/ec/it8xxx2/linker.ld
+++ b/soc/ite/ec/it8xxx2/linker.ld
@@ -130,6 +130,26 @@ SECTIONS
 		KEEP(*(.reset.*))
     } GROUP_LINK_IN(ROMABLE_REGION)
 
+#ifdef CONFIG_SOC_IT8XXX2_JTAG_DEBUG_INTERFACE
+#define JTAG_DEBUG_RESERVED_ADDR_START 0x80000800
+#define JTAG_DEBUG_RESERVED_ADDR_END 0x800008FF
+	/* The CPU address from 0x80000800 to 0x800008FF is reserved for JTAG
+	 * debug usage. */
+	SECTION_PROLOGUE(jtag_dbg,,)
+	{
+		__jtag_dbg_pad_start = ABSOLUTE(.);
+		ASSERT((__jtag_dbg_pad_start < JTAG_DEBUG_RESERVED_ADDR_START),
+			"The start address of jtag debug section is incorrect.");
+
+		__jtag_dbg_pad_size = JTAG_DEBUG_RESERVED_ADDR_END - __jtag_dbg_pad_start;
+		. = . + __jtag_dbg_pad_size;
+
+		__jtag_dbg_pad_end = ABSOLUTE(.);
+		ASSERT((__jtag_dbg_pad_end == JTAG_DEBUG_RESERVED_ADDR_END),
+			"The end address of jtag debug section is incorrect.");
+	} GROUP_LINK_IN(ROMABLE_REGION)
+#endif
+
 #ifndef CONFIG_SOC_IT8XXX2_EXCEPTIONS_IN_RAM
     SECTION_PROLOGUE(_EXCEPTION_SECTION_NAME,,)
 	{

--- a/soc/ite/ec/it8xxx2/soc.c
+++ b/soc/ite/ec/it8xxx2/soc.c
@@ -239,8 +239,10 @@ void riscv_idle(enum chip_pll_mode mode, unsigned int key)
 	chip_pll_ctrl(mode);
 
 	do {
+#ifndef CONFIG_SOC_IT8XXX2_JTAG_DEBUG_INTERFACE
 		/* Wait for interrupt */
 		__asm__ volatile ("wfi");
+#endif
 		/*
 		 * Sometimes wfi instruction may fail due to CPU's MTIP@mip
 		 * register is non-zero.


### PR DESCRIPTION
Prevent the CPU from entering deep doze mode when JTAG debug is enabled. Additionally, The CPU address from 0x80000800 to 0x800008FF should be reserved for JTAG debug usage. This commit reserves the area from the end of the reset section to 0x800008FF if JTAG debug is enabled.

Tested with:
- west build -p always -b it82xx2_evb samples/hello_world/ -DCONFIG_SOC_IT8XXX2_JTAG_DEBUG_INTERFACE=y