### PR TITLE
tests: llext: fix conflict between BUILD_ONLY and "object" case

### DIFF
--- a/tests/subsys/llext/simple/src/test_llext_simple.c
+++ b/tests/subsys/llext/simple/src/test_llext_simple.c
@@ -153,12 +153,12 @@ static LLEXT_CONST uint8_t relative_jump_ext[] __aligned(4) = {
 	#include "relative_jump.inc"
 };
 LLEXT_LOAD_UNLOAD(relative_jump, true)
-#endif /* ! LOADER_BUILD_ONLY */
 
 static LLEXT_CONST uint8_t object_ext[] __aligned(4) = {
 	#include "object.inc"
 };
 LLEXT_LOAD_UNLOAD(object, true)
+#endif /* ! LOADER_BUILD_ONLY */
 
 /*
  * Ensure that EXPORT_SYMBOL does indeed provide a symbol and a valid address


### PR DESCRIPTION
Fix conflict between commit ce243944375e ("llext: add object test case") and commit 1408d1e5b8ce ("tests: llext: compile architectures not supported yet") which were tested separately but merged at the same time.

Github "Merge Queues" can avoid this (and save resources) but:
- they're not used by Zephyr CI
- they provide confusing feedback