### PR TITLE
tests/bsim/bt l2cap/stress: Increase runtime timeout

### DIFF
--- a/tests/bsim/bluetooth/host/l2cap/stress/tests_scripts/l2cap.sh
+++ b/tests/bsim/bluetooth/host/l2cap/stress/tests_scripts/l2cap.sh
@@ -7,7 +7,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # EATT test
 simulation_id="l2cap_stress"
 verbosity_level=2
-EXECUTE_TIMEOUT=120
+EXECUTE_TIMEOUT=240
 
 cd ${BSIM_OUT_PATH}/bin
 


### PR DESCRIPTION
This test has been seen failing in the new runners due to a (realtime) timeout.
Let's double the timeout so it does not.