### PR TITLE
drivers: can: loopback: remove info log at driver initialization

### DIFF
--- a/drivers/can/can_loopback.c
+++ b/drivers/can/can_loopback.c
@@ -439,8 +439,6 @@ static int can_loopback_init(const struct device *dev)
 		return -1;
 	}
 
-	LOG_INF("Init of %s done", dev->name);
-
 	return 0;
 }
 


### PR DESCRIPTION
Remove the LOG_INF() at driver initialization.