### PR TITLE
soc: nordic: vpr: remove enabling `MSTATUS.MIE` in boot time

### DIFF
--- a/soc/nordic/common/vpr/vector.S
+++ b/soc/nordic/common/vpr/vector.S
@@ -20,9 +20,5 @@ SECTION_FUNC(vectors, __start)
 	la t0, _irq_vector_table
 	csrw 0x307, t0
 
-	/* Enable mstatus.mie */
-	li t0, 0x1888
-	csrw mstatus, t0
-
 	/* Call into Zephyr initialization. */
 	tail __initialize


### PR DESCRIPTION
Interrupts should not be enabled this early in boot time. Driver initializations expect IRQs not to arrive when setting up HW.
Remove enabling `MSTATUS.MIE` in `__start`.
It will be enabled when main thread is switched to, as threads by default start with enabled `MSTATUS.MIE`.