### PR TITLE
posix: rwlock: implement pthread_rwlockattr_setpshared()

### DIFF
--- a/doc/services/portability/posix/conformance/index.rst
+++ b/doc/services/portability/posix/conformance/index.rst
@@ -64,7 +64,7 @@ POSIX System Interfaces
     :ref:`_POSIX_CLOCK_SELECTION<posix_option_group_clock_selection>`, 200809L, :kconfig:option:`CONFIG_POSIX_CLOCK`
     _POSIX_MAPPED_FILES, -1, :ref:`†<posix_undefined_behaviour>`
     _POSIX_MEMORY_PROTECTION, -1, :ref:`†<posix_undefined_behaviour>`
-    :ref:`_POSIX_READER_WRITER_LOCKS<posix_option_reader_writer_locks>`, -1, :kconfig:option:`CONFIG_PTHREAD_IPC`
+    :ref:`_POSIX_READER_WRITER_LOCKS<posix_option_reader_writer_locks>`, 200809L, :kconfig:option:`CONFIG_PTHREAD_IPC`
     _POSIX_REALTIME_SIGNALS, -1, :ref:`†<posix_undefined_behaviour>`
     :ref:`_POSIX_SEMAPHORES<posix_option_group_semaphores>`, 200809L, :kconfig:option:`CONFIG_PTHREAD_IPC`
     :ref:`_POSIX_SPIN_LOCKS<posix_option_group_spin_locks>`, 200809L, :kconfig:option:`CONFIG_PTHREAD_SPINLOCK`

--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -401,9 +401,9 @@ _POSIX_READER_WRITER_LOCKS
     pthread_rwlock_unlock(),yes
     pthread_rwlock_wrlock(),yes
     pthread_rwlockattr_destroy(),yes
-    pthread_rwlockattr_getpshared(),
+    pthread_rwlockattr_getpshared(),yes
     pthread_rwlockattr_init(),yes
-    pthread_rwlockattr_setpshared(),
+    pthread_rwlockattr_setpshared(),yes
 
 .. _posix_option_thread_attr_stackaddr:
 

--- a/include/zephyr/posix/pthread.h
+++ b/include/zephyr/posix/pthread.h
@@ -390,22 +390,14 @@ int pthread_equal(pthread_t pt1, pthread_t pt2);
  *
  * See IEEE 1003.1
  */
-static inline int pthread_rwlockattr_destroy(pthread_rwlockattr_t *attr)
-{
-	ARG_UNUSED(attr);
-	return 0;
-}
+int pthread_rwlockattr_destroy(pthread_rwlockattr_t *attr);
 
 /**
  * @brief initialize the read-write lock attributes object.
  *
  * See IEEE 1003.1
  */
-static inline int pthread_rwlockattr_init(pthread_rwlockattr_t *attr)
-{
-	ARG_UNUSED(attr);
-	return 0;
-}
+int pthread_rwlockattr_init(pthread_rwlockattr_t *attr);
 
 int pthread_attr_getguardsize(const pthread_attr_t *ZRESTRICT attr, size_t *ZRESTRICT guardsize);
 int pthread_attr_getstacksize(const pthread_attr_t *attr, size_t *stacksize);

--- a/include/zephyr/posix/pthread.h
+++ b/include/zephyr/posix/pthread.h
@@ -399,6 +399,10 @@ int pthread_rwlockattr_destroy(pthread_rwlockattr_t *attr);
  */
 int pthread_rwlockattr_init(pthread_rwlockattr_t *attr);
 
+int pthread_rwlockattr_getpshared(const pthread_rwlockattr_t *ZRESTRICT attr,
+				  int *ZRESTRICT pshared);
+int pthread_rwlockattr_setpshared(pthread_rwlockattr_t *attr, int pshared);
+
 int pthread_attr_getguardsize(const pthread_attr_t *ZRESTRICT attr, size_t *ZRESTRICT guardsize);
 int pthread_attr_getstacksize(const pthread_attr_t *attr, size_t *stacksize);
 int pthread_attr_setguardsize(pthread_attr_t *attr, size_t guardsize);

--- a/lib/posix/options/rwlock.c
+++ b/lib/posix/options/rwlock.c
@@ -21,6 +21,10 @@ struct posix_rwlock {
 	k_tid_t wr_owner;
 };
 
+struct posix_rwlockattr {
+	bool initialized: 1;
+};
+
 int64_t timespec_to_timeoutms(const struct timespec *abstime);
 static uint32_t read_lock_acquire(struct posix_rwlock *rwl, int32_t timeout);
 static uint32_t write_lock_acquire(struct posix_rwlock *rwl, int32_t timeout);
@@ -383,4 +387,32 @@ static uint32_t write_lock_acquire(struct posix_rwlock *rwl, int32_t timeout)
 		ret = EBUSY;
 	}
 	return ret;
+}
+
+int pthread_rwlockattr_init(pthread_rwlockattr_t *attr)
+{
+	struct posix_rwlockattr *const a = (struct posix_rwlockattr *)attr;
+
+	if (a == NULL) {
+		return EINVAL;
+	}
+
+	*a = (struct posix_rwlockattr){
+		.initialized = true,
+	};
+
+	return 0;
+}
+
+int pthread_rwlockattr_destroy(pthread_rwlockattr_t *attr)
+{
+	struct posix_rwlockattr *const a = (struct posix_rwlockattr *)attr;
+
+	if (a == NULL || !a->initialized) {
+		return EINVAL;
+	}
+
+	*a = (struct posix_rwlockattr){0};
+
+	return 0;
 }

--- a/tests/posix/common/src/rwlock.c
+++ b/tests/posix/common/src/rwlock.c
@@ -117,6 +117,33 @@ ZTEST(rwlock, test_rw_lock)
 	zassert_ok(pthread_rwlock_destroy(&rwlock), "Failed to destroy rwlock");
 }
 
+static void test_pthread_rwlockattr_pshared_common(bool set, int pshared)
+{
+	int tmp_pshared = 4242;
+	pthread_rwlockattr_t attr;
+
+	zassert_ok(pthread_rwlockattr_init(&attr));
+	zassert_ok(pthread_rwlockattr_getpshared(&attr, &tmp_pshared));
+	zassert_equal(tmp_pshared, PTHREAD_PROCESS_PRIVATE);
+	if (set) {
+		zassert_ok(pthread_rwlockattr_setpshared(&attr, pshared));
+		zassert_ok(pthread_rwlockattr_getpshared(&attr, &tmp_pshared));
+		zassert_equal(tmp_pshared, pshared);
+	}
+	zassert_ok(pthread_rwlockattr_destroy(&attr));
+}
+
+ZTEST(rwlock, test_pthread_rwlockattr_getpshared)
+{
+	test_pthread_rwlockattr_pshared_common(false, 0);
+}
+
+ZTEST(rwlock, test_pthread_rwlockattr_setpshared)
+{
+	test_pthread_rwlockattr_pshared_common(true, PTHREAD_PROCESS_PRIVATE);
+	test_pthread_rwlockattr_pshared_common(true, PTHREAD_PROCESS_SHARED);
+}
+
 static void before(void *arg)
 {
 	ARG_UNUSED(arg);


### PR DESCRIPTION
Implement `pthread_rwlockattr_setpshared()` and `pthread_rwlockattr_getpshared()`.

Both functions are required by the `_POSIX_READER_WRITER_LOCKS` Option as detailed in Section E.1 of IEEE-1003.1-2017.

The `_POSIX_READER_WRITER_LOCKS` Option is required for PSE51, PSE52, PSE53, and PSE54 conformance, and is otherwise mandatory for any POSIX conforming system as per Section A.2.1.3 of IEEE-1003-1.2017.

Fixes #66964
Fixes #66965