### PR TITLE
doc: posix: aep: mark POSIX_SINGLE_PROCESS as supported

### DIFF
--- a/doc/services/portability/posix/aep/index.rst
+++ b/doc/services/portability/posix/aep/index.rst
@@ -30,7 +30,7 @@ Minimal Realtime System Profile (PSE51)
     POSIX_DEVICE_IO,, :ref:`†<posix_undefined_behaviour>`
     POSIX_FILE_LOCKING,,
     POSIX_SIGNALS,, :ref:`†<posix_undefined_behaviour>`
-    POSIX_SINGLE_PROCESS,, :ref:`†<posix_undefined_behaviour>`
+    POSIX_SINGLE_PROCESS, yes, :ref:`†<posix_undefined_behaviour>`
     POSIX_THREADS_BASE, yes, :ref:`†<posix_undefined_behaviour>`
     XSI_THREADS_EXT, yes, :ref:`†<posix_undefined_behaviour>`
 
@@ -82,7 +82,7 @@ Realtime Controller System Profile (PSE52)
     POSIX_FILE_LOCKING,,
     POSIX_FILE_SYSTEM,,
     POSIX_SIGNALS,, :ref:`†<posix_undefined_behaviour>`
-    POSIX_SINGLE_PROCESS,, :ref:`†<posix_undefined_behaviour>`
+    POSIX_SINGLE_PROCESS, yes, :ref:`†<posix_undefined_behaviour>`
     POSIX_THREADS_BASE, yes, :ref:`†<posix_undefined_behaviour>`
     XSI_THREADS_EXT, yes, :ref:`†<posix_undefined_behaviour>`
 
@@ -143,7 +143,7 @@ Dedicated Realtime System Profile (PSE53)
     POSIX_PIPE,, :ref:`†<posix_undefined_behaviour>`
     POSIX_SIGNALS,, :ref:`†<posix_undefined_behaviour>`
     POSIX_SIGNAL_JUMP,, :ref:`†<posix_undefined_behaviour>`
-    POSIX_SINGLE_PROCESS,, :ref:`†<posix_undefined_behaviour>`
+    POSIX_SINGLE_PROCESS, yes, :ref:`†<posix_undefined_behaviour>`
     POSIX_THREADS_BASE, yes, :ref:`†<posix_undefined_behaviour>`
     XSI_THREADS_EXT, yes, :ref:`†<posix_undefined_behaviour>`
 


### PR DESCRIPTION
Mark the `POSIX_SINGLE_PROCESS` Option Group as supported in PSE51, PSE52, and PSE53 Application Environment Profiles.