### PR TITLE
sys: `atomic_builtin.h`: Add missing include

### DIFF
--- a/include/zephyr/sys/atomic_builtin.h
+++ b/include/zephyr/sys/atomic_builtin.h
@@ -11,6 +11,7 @@
 #define ZEPHYR_INCLUDE_SYS_ATOMIC_BUILTIN_H_
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <zephyr/sys/atomic_types.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
`atomic_builtin.h` uses `NULL`, which is defined in `stddef.h`.