### PR TITLE
kconfig: lto: Disable when data relocation is enabled

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -429,7 +429,9 @@ endchoice
 
 config LTO
 	bool "Link Time Optimization [EXPERIMENTAL]"
-	depends on (!(GEN_ISR_TABLES || GEN_IRQ_VECTOR_TABLE) || ISR_TABLES_LOCAL_DECLARATION) && !NATIVE_LIBRARY
+	depends on (!(GEN_ISR_TABLES || GEN_IRQ_VECTOR_TABLE) || ISR_TABLES_LOCAL_DECLARATION) \
+	  && !NATIVE_LIBRARY \
+	  && !CODE_DATA_RELOCATION
 	select EXPERIMENTAL
 	help
 	  This option enables Link Time Optimization.


### PR DESCRIPTION
As per issue #69730, building arch.shared_interrupt.lto and kernel.common.lto for mimxrt685_evk or mimxrt595_evk/mimxrt595s/cm33 is currently broken due to their usage of CONFIG_CODE_DATA_RELOCATION.

This commit disables LTO when CODE_DATA_RELOCATION is enabled, allowing PRs with changes in the kernel code to pass the CI check.

On the down side, builds affected by this change produce a new warning:

> warning: LTO (defined at Kconfig.zephyr:430) was assigned the value
> 'y' but got the value 'n'. Check these unsatisfied dependencies:
> (!CODE_DATA_RELOCATION) (=n)

Hint: https://github.com/zephyrproject-rtos/zephyr/pull/70305 tries to resolve the same issue.