### PR TITLE
drivers: eth: stellaris: Fix driver poll all packtes from ethernet

### DIFF
--- a/drivers/ethernet/eth_stellaris.c
+++ b/drivers/ethernet/eth_stellaris.c
@@ -202,7 +202,7 @@ error:
 	return NULL;
 }
 
-static void eth_stellaris_rx(const struct device *dev)
+static int eth_stellaris_rx(const struct device *dev)
 {
 	struct eth_stellaris_runtime *dev_data = dev->data;
 	struct net_if *iface = dev_data->iface;
@@ -219,19 +219,21 @@ static void eth_stellaris_rx(const struct device *dev)
 		goto pkt_unref;
 	}
 
-	return;
+	return 0;
 
 pkt_unref:
 	net_pkt_unref(pkt);
 
 err_mem:
 	eth_stellaris_rx_error(iface);
+	return -EIO;
 }
 
 static void eth_stellaris_isr(const struct device *dev)
 {
 	struct eth_stellaris_runtime *dev_data = dev->data;
 	int isr_val = sys_read32(REG_MACRIS);
+	int num_packets;
 	uint32_t lock;
 
 	lock = irq_lock();
@@ -240,7 +242,18 @@ static void eth_stellaris_isr(const struct device *dev)
 	sys_write32(isr_val, REG_MACRIS);
 
 	if (isr_val & BIT_MACRIS_RXINT) {
-		eth_stellaris_rx(dev);
+		/*
+		 * When multiple packets are received by the Ethernet,
+		 * only one interrupt may be dispatched to the driver
+		 * Therefore, it is necessary to obtain the register NP value
+		 * to get how many packets are in the Ethernet.
+		 */
+		num_packets = sys_read32(REG_MACNP);
+		for (int i = 0; i < np; i++) {
+			if (eth_stellaris_rx(dev) != 0) {
+				break;
+			}
+		}
 	}
 
 	if (isr_val & BIT_MACRIS_TXEMP) {


### PR DESCRIPTION
The number of interrupts received by the driver maybe less than the number of data packets received by Ethernet,
so the driver should read the packets using the 'np' value.