### PR TITLE
tracing: add intel ADSP memory window backend

### DIFF
--- a/soc/intel/intel_adsp/common/include/adsp_debug_window.h
+++ b/soc/intel/intel_adsp/common/include/adsp_debug_window.h
@@ -41,12 +41,16 @@
 #define ADSP_DW_SLOT_SIZE		ADSP_DW_PAGE_SIZE
 #define ADSP_DW_SLOT_COUNT		15
 
+/* debug window slots usage */
+#define ADSP_DW_SLOT_NUM_TRACE		1
+
 /* debug log slot types */
 #define ADSP_DW_SLOT_UNUSED		0x00000000
 #define ADSP_DW_SLOT_CRITICAL_LOG	0x54524300
 #define ADSP_DW_SLOT_DEBUG_LOG		0x474f4c00 /* byte 0: core ID */
 #define ADSP_DW_SLOT_GDB_STUB		0x42444700
 #define ADSP_DW_SLOT_TELEMETRY		0x4c455400
+#define ADSP_DW_SLOT_TRACE		0x54524143
 #define ADSP_DW_SLOT_BROKEN		0x44414544
 
  /* for debug and critical types */

--- a/subsys/tracing/CMakeLists.txt
+++ b/subsys/tracing/CMakeLists.txt
@@ -41,6 +41,11 @@ zephyr_sources_ifdef(
   tracing_backend_ram.c
   )
 
+zephyr_sources_ifdef(
+  CONFIG_TRACING_BACKEND_ADSP_MEMORY_WINDOW
+  tracing_backend_adsp_memory_window.c
+  )
+
 endif()
 
 if(NOT CONFIG_PERCEPIO_TRACERECORDER AND NOT CONFIG_TRACING_CTF

--- a/subsys/tracing/Kconfig
+++ b/subsys/tracing/Kconfig
@@ -160,6 +160,14 @@ config TRACING_BACKEND_RAM
 	  Use a ram buffer to output tracing data which can
 	  be dumped to a file at runtime with a debugger.
 	  See gdb dump binary memory documentation for example.
+
+config TRACING_BACKEND_ADSP_MEMORY_WINDOW
+	bool "Memory window in RAM"
+	depends on SOC_FAMILY_INTEL_ADSP
+	depends on TRACING_SYNC
+	help
+	  Use ADSP memory debug memory window to output tracing data
+
 endchoice
 
 config RAM_TRACING_BUFFER_SIZE

--- a/subsys/tracing/tracing_backend_adsp_memory_window.c
+++ b/subsys/tracing/tracing_backend_adsp_memory_window.c
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <ctype.h>
+#include <zephyr/kernel.h>
+#include <string.h>
+#include <tracing_core.h>
+#include <tracing_buffer.h>
+#include <tracing_backend.h>
+
+#include <adsp_memory.h>
+#include <adsp_debug_window.h>
+
+/* structure of memory window */
+struct tracing_backend_adsp_memory_window {
+	uint32_t head_offset;	/* offset of the first not used byte in data[] */
+	uint8_t data[];		/* tracing data */
+} __packed __aligned(8);
+
+#define ADSP_TRACING_WINDOW_DATA_SIZE		\
+	(ADSP_DW_SLOT_SIZE - offsetof(struct tracing_backend_adsp_memory_window, data))
+
+static volatile struct tracing_backend_adsp_memory_window *mem_window;
+
+static void tracing_backend_adsp_memory_window_output(
+		const struct tracing_backend *backend,
+		uint8_t *data, uint32_t length)
+{
+	/* copy data to ring buffer,
+	 * to make FW part fast, there's no sync with the data reader
+	 * the reader MUST read data before they got overwritten
+	 */
+	size_t to_copy = MIN(length, ADSP_TRACING_WINDOW_DATA_SIZE - mem_window->head_offset);
+
+	memcpy((void *)(mem_window->data + mem_window->head_offset), data, to_copy);
+
+	length -= to_copy;
+	if (length) {
+		memcpy((void *)mem_window->data, data + to_copy, length);
+		mem_window->head_offset = length;
+	} else
+		mem_window->head_offset += to_copy;
+}
+
+static void tracing_backend_adsp_memory_window_init(void)
+{
+	volatile struct adsp_debug_window *window = ADSP_DW;
+
+	window->descs[ADSP_DW_SLOT_NUM_TRACE].type = ADSP_DW_SLOT_TRACE;
+	window->descs[ADSP_DW_SLOT_NUM_TRACE].resource_id = 0;
+	mem_window = (struct tracing_backend_adsp_memory_window *)
+			ADSP_DW->slots[ADSP_DW_SLOT_NUM_TRACE];
+
+	mem_window->head_offset = 0;
+}
+
+const struct tracing_backend_api tracing_backend_adsp_memory_window_api = {
+	.init = tracing_backend_adsp_memory_window_init,
+	.output  = tracing_backend_adsp_memory_window_output
+};
+
+TRACING_BACKEND_DEFINE(tracing_backend_adsp_memory_window, tracing_backend_adsp_memory_window_api);

--- a/subsys/tracing/tracing_core.c
+++ b/subsys/tracing/tracing_core.c
@@ -29,6 +29,8 @@
 #define TRACING_BACKEND_NAME "tracing_backend_posix"
 #elif defined CONFIG_TRACING_BACKEND_RAM
 #define TRACING_BACKEND_NAME "tracing_backend_ram"
+#elif defined CONFIG_TRACING_BACKEND_ADSP_MEMORY_WINDOW
+#define TRACING_BACKEND_NAME "tracing_backend_adsp_memory_window"
 #else
 #define TRACING_BACKEND_NAME ""
 #endif


### PR DESCRIPTION
This commits adds a tracing backend based on Intel ADSP debug memory window