### PR TITLE
drivers: flash: stm32 ospi flash driver the correct erase instruction

### DIFF
--- a/drivers/flash/flash_stm32_ospi.c
+++ b/drivers/flash/flash_stm32_ospi.c
@@ -1108,11 +1108,11 @@ static int flash_stm32_ospi_erase(const struct device *dev, off_t addr,
 							? SPI_NOR_CMD_SE_4B
 							: SPI_NOR_CMD_SE;
 					}
-					/* Avoid using wrong erase type,
-					 * if zero entries are found in erase_types
-					 */
-					bet = NULL;
 				}
+				/* Avoid using wrong erase type,
+				 * if zero entries are found in erase_types
+				 */
+				bet = NULL;
 			}
 			LOG_DBG("Sector/Block Erase addr 0x%x, asize 0x%x amode 0x%x  instr 0x%x",
 				cmd_erase.Address, cmd_erase.AddressSize,

--- a/samples/drivers/spi_flash/src/main.c
+++ b/samples/drivers/spi_flash/src/main.c
@@ -30,6 +30,8 @@
 #define SPI_FLASH_MULTI_SECTOR_TEST
 #endif
 
+const uint8_t erased[] = { 0xff, 0xff, 0xff, 0xff };
+
 void single_sector_test(const struct device *flash_dev)
 {
 	const uint8_t expected[] = { 0x55, 0xaa, 0x66, 0x99 };
@@ -53,9 +55,20 @@ void single_sector_test(const struct device *flash_dev)
 	if (rc != 0) {
 		printf("Flash erase failed! %d\n", rc);
 	} else {
+		/* Check erased pattern */
+		memset(buf, 0, len);
+		rc = flash_read(flash_dev, SPI_FLASH_TEST_REGION_OFFSET, buf, len);
+		if (rc != 0) {
+			printf("Flash read failed! %d\n", rc);
+			return;
+		}
+		if (memcmp(erased, buf, len) != 0) {
+			printf("Flash erase failed at offset 0x%x got 0x%x\n",
+				SPI_FLASH_TEST_REGION_OFFSET, *(uint32_t *)buf);
+			return;
+		}
 		printf("Flash erase succeeded!\n");
 	}
-
 	printf("\nTest 2: Flash write\n");
 
 	printf("Attempting to write %zu bytes\n", len);
@@ -98,7 +111,7 @@ void multi_sector_test(const struct device *flash_dev)
 	uint8_t buf[sizeof(expected)];
 	int rc;
 
-	printf("\nPerform test on multiple consequtive sectors");
+	printf("\nPerform test on multiple consecutive sectors");
 
 	/* Write protection needs to be disabled before each write or
 	 * erase, since the flash component turns on write protection
@@ -125,9 +138,9 @@ void multi_sector_test(const struct device *flash_dev)
 				printf("Flash read failed! %d\n", rc);
 				return;
 			}
-			if (buf[0] != 0xff) {
+			if (memcmp(erased, buf, len) != 0) {
 				printf("Flash erase failed at offset 0x%x got 0x%x\n",
-				offs, buf[0]);
+				offs, *(uint32_t *)buf);
 				return;
 			}
 			offs += SPI_FLASH_SECTOR_SIZE;


### PR DESCRIPTION
Use the most adapted instruction for the sector erase command It can be 0x20 or ox21 or 0x21DE in octo - DTR mode. The value is given by the SFDP table and  filled in the erase_types  table the during the SFDP discovery process.

This PR fixes an error found in the https://github.com/zephyrproject-rtos/zephyr/pull/66229

