### PR TITLE
include: zephyr: sys: util: add common is_null_no_warn() utility function and use it to squelch warning with CONFIG_COMPILER_SAVE_TEMPS=y

### DIFF
--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -717,7 +717,7 @@ struct can_device_state {
 		stats_init(&state->stats.s_hdr, STATS_SIZE_32, 8,	\
 			   STATS_NAME_INIT_PARMS(can));			\
 		stats_register(dev->name, &(state->stats.s_hdr));	\
-		if (init_fn != NULL) {					\
+		if (!is_null_no_warn(init_fn)) {			\
 			return init_fn(dev);				\
 		}							\
 									\

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -613,7 +613,7 @@ static inline void i2c_xfer_stats(const struct device *dev, struct i2c_msg *msgs
 		stats_init(&state->stats.s_hdr, STATS_SIZE_32, 4,	\
 			   STATS_NAME_INIT_PARMS(i2c));			\
 		stats_register(dev->name, &(state->stats.s_hdr));	\
-		if (init_fn != NULL) {					\
+		if (!is_null_no_warn(init_fn)) {			\
 			return init_fn(dev);				\
 		}							\
 									\

--- a/include/zephyr/sys/cbprintf_internal.h
+++ b/include/zephyr/sys/cbprintf_internal.h
@@ -757,20 +757,6 @@ do { \
 		 _name##_buf32)))
 #endif
 
-/* When the first argument of Z_CBPRINTF_STATIC_PACKAGE_GENERIC() is a
- * static memory location, some compiler warns you if you compare the
- * location against NULL.  ___is_null() is used to kill this warning.
- *
- * The warnings would be visible when you built with -save-temps=obj,
- * our standard debugging tip for macro problems.
- *
- * https://github.com/zephyrproject-rtos/zephyr/issues/51528
- */
-static ALWAYS_INLINE bool ___is_null(void *p)
-{
-	return p == NULL;
-}
-
 /** @brief Statically package a formatted string with arguments.
  *
  * @param buf buffer. If null then only length is calculated.
@@ -819,7 +805,7 @@ do { \
 	Z_CBPRINTF_ON_STACK_ALLOC(_ros_pos_buf, _ros_cnt); \
 	uint8_t *_rws_buffer; \
 	Z_CBPRINTF_ON_STACK_ALLOC(_rws_buffer, 2 * _rws_cnt); \
-	size_t _pmax = !___is_null(buf) ? _inlen : INT32_MAX; \
+	size_t _pmax = !is_null_no_warn(buf) ? _inlen : INT32_MAX; \
 	int _pkg_len = 0; \
 	int _total_len = 0; \
 	int _pkg_offset = _align_offset; \

--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -422,6 +422,30 @@ static inline bool is_power_of_two(unsigned int x)
 }
 
 /**
+ * @brief Is @p p equal to ``NULL``?
+ *
+ * Some macros may need to check their arguments against NULL to support
+ * multiple use-cases, but NULL checks can generate warnings if such a macro
+ * is used in contexts where that particular argument can never be NULL.
+ *
+ * The warnings can be triggered if:
+ * a) all macros are expanded (e.g. when using CONFIG_COMPILER_SAVE_TEMPS=y)
+ * or
+ * b) tracking of macro expansions are turned off (-ftrack-macro-expansion=0)
+ *
+ * The warnings can be circumvented by using this inline function for doing
+ * the NULL check within the macro. The compiler is still able to optimize the
+ * NULL check out at a later stage.
+ *
+ * @param p Pointer to check
+ * @return true if @p p is equal to ``NULL``, false otherwise
+ */
+static ALWAYS_INLINE bool is_null_no_warn(void *p)
+{
+	return p == NULL;
+}
+
+/**
  * @brief Arithmetic shift right
  * @param value value to shift
  * @param shift number of bits to shift


### PR DESCRIPTION
Some macros may need to check their arguments against NULL to support multiple use-cases, but NULL checks can generate warnings for a given use of those macros (where that particular argument can never be NULL).
    
This can happen if:
a) all macros are expanded (e.g. when using `CONFIG_COMPILER_SAVE_TEMPS=y`)
or
b) tracking of macro expansions are turned off (`-ftrack-macro-expansion=0`)
    
This warning can be circumvented by passing the argument to be checked to an inlined function for doing the NULL check. The compiler is still able to  optimize this out at a later stage.
    
Move the private `___is_null()` helper function introduced in d51f874158038b1bc3b087604971132ebaaeb0f8 to `include/zephyr/sys/utils.h` and rename it to `is_null_no_warn()` to facilitate reuse.

Use the function to squelch the warning in both `can.h` and `i2c.h`.

Fixes: #70390