### PR TITLE
Use -Oz for optimization_size in clang

### DIFF
--- a/cmake/compiler/clang/compiler_flags.cmake
+++ b/cmake/compiler/clang/compiler_flags.cmake
@@ -30,6 +30,9 @@ set_compiler_property(PROPERTY save_temps -save-temps)
 # clang doesn't handle the -T flag
 set_compiler_property(PROPERTY linker_script -Wl,-T)
 
+# clang's best size optimization is -Oz not -Os
+set_compiler_property(PROPERTY optimization_size  -Oz)
+
 #######################################################
 # This section covers flags related to warning levels #
 #######################################################


### PR DESCRIPTION
The clang compiler's best optimization for size is -Oz, not -Os. Even with that flag, the binaries are bigger than GCC, but it is at least much closer.