### PR TITLE
drivers: can: mcan: fix transmitter delay compensation support

### DIFF
--- a/drivers/can/Kconfig.mcan
+++ b/drivers/can/Kconfig.mcan
@@ -1,4 +1,4 @@
-# Bosch m_can configuration options
+# Bosch M_CAN configuration options
 
 # Copyright (c) 2020 Alexander Wachter
 # SPDX-License-Identifier: Apache-2.0
@@ -6,17 +6,4 @@
 config CAN_MCAN
 	bool
 	help
-	  Enable Bosch m_can driver.
-	  This driver supports the Bosch m_can IP. This IP is built into the
-	  STM32G4, STM32G0, STM32H7, and the Microchip SAM controllers with
-	  CAN FD.
-
-if CAN_MCAN
-
-config CAN_DELAY_COMP
-	bool "Transceiver delay compensation"
-	default y
-	help
-	  Enable the automatic transceiver delay compensation.
-
-endif #CAN_MCAN
+	  Enable the Bosch M_CAN CAN IP module driver backend.

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -1427,32 +1427,6 @@ int can_mcan_init(const struct device *dev)
 		return err;
 	}
 
-#if defined(CONFIG_CAN_DELAY_COMP) && defined(CONFIG_CAN_FD_MODE)
-	err = can_mcan_read_reg(dev, CAN_MCAN_DBTP, &reg);
-	if (err != 0) {
-		return err;
-	}
-
-	reg |= CAN_MCAN_DBTP_TDC;
-
-	err = can_mcan_write_reg(dev, CAN_MCAN_DBTP, reg);
-	if (err != 0) {
-		return err;
-	}
-
-	err = can_mcan_read_reg(dev, CAN_MCAN_TDCR, &reg);
-	if (err != 0) {
-		return err;
-	}
-
-	reg |= FIELD_PREP(CAN_MCAN_TDCR_TDCO, config->tx_delay_comp_offset);
-
-	err = can_mcan_write_reg(dev, CAN_MCAN_TDCR, reg);
-	if (err != 0) {
-		return err;
-	}
-#endif /* defined(CONFIG_CAN_DELAY_COMP) && defined(CONFIG_CAN_FD_MODE) */
-
 	err = can_mcan_read_reg(dev, CAN_MCAN_GFC, &reg);
 	if (err != 0) {
 		return err;

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -225,8 +225,10 @@ unlock:
 #ifdef CONFIG_CAN_FD_MODE
 int can_mcan_set_timing_data(const struct device *dev, const struct can_timing *timing_data)
 {
+	const uint8_t tdco_max = FIELD_GET(CAN_MCAN_TDCR_TDCO, CAN_MCAN_TDCR_TDCO);
 	struct can_mcan_data *data = dev->data;
 	uint32_t dbtp = 0U;
+	uint8_t tdco;
 	int err;
 
 	if (data->common.started) {
@@ -239,6 +241,23 @@ int can_mcan_set_timing_data(const struct device *dev, const struct can_timing *
 		FIELD_PREP(CAN_MCAN_DBTP_DTSEG1, timing_data->phase_seg1 - 1UL) |
 		FIELD_PREP(CAN_MCAN_DBTP_DTSEG2, timing_data->phase_seg2 - 1UL) |
 		FIELD_PREP(CAN_MCAN_DBTP_DBRP, timing_data->prescaler - 1UL);
+
+	if (timing_data->prescaler == 1U || timing_data->prescaler == 2U) {
+		/* TDC can only be enabled if DBRP = { 0, 1 } */
+		dbtp |= CAN_MCAN_DBTP_TDC;
+
+		/* Set TDC offset for correct location of the Secondary Sample Point (SSP) */
+		tdco = CAN_CALC_TDCO(timing_data, 0U, tdco_max);
+		LOG_DBG("TDC enabled, using TDCO %u", tdco);
+
+		err = can_mcan_write_reg(dev, CAN_MCAN_TDCR, FIELD_PREP(CAN_MCAN_TDCR_TDCO, tdco));
+		if (err != 0) {
+			goto unlock;
+		}
+	} else {
+		LOG_DBG("TDC cannot be enabled, prescaler value %u too high",
+			timing_data->prescaler);
+	}
 
 	err = can_mcan_write_reg(dev, CAN_MCAN_DBTP, dbtp);
 	if (err != 0) {

--- a/dts/bindings/can/can-fd-controller.yaml
+++ b/dts/bindings/can/can-fd-controller.yaml
@@ -16,6 +16,3 @@ properties:
       If this is unset (or if it is set to 0), the initial sample point will default to 75.0% for
       bitrates over 800 kbit/s, 80.0% for bitrates over 500 kbit/s, and 87.5% for all other
       bitrates.
-  tx-delay-comp-offset:
-    type: int
-    default: 0

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -323,6 +323,23 @@ typedef void (*can_state_change_callback_t)(const struct device *dev,
  */
 
 /**
+ * @brief Calculate Transmitter Delay Compensation Offset from data phase timing parameters.
+ *
+ * Calculates the TDC Offset in minimum time quanta (mtq) using the sample point and CAN core clock
+ * prescaler specified by a set of data phase timing parameters.
+ *
+ * The result is clamped to the minimum/maximum supported TDC Offset values provided.
+ *
+ * @param _timing_data Pointer to data phase timing parameters.
+ * @param _tdco_min    Minimum supported TDC Offset value in mtq.
+ * @param _tdco_max    Maximum supported TDC Offset value in mtq.
+ * @return             Calculated TDC Offset value in mtq.
+ */
+#define CAN_CALC_TDCO(_timing_data, _tdco_min, _tdco_max)                                          \
+	CLAMP((1U + _timing_data->prop_seg + _timing_data->phase_seg1) * _timing_data->prescaler,  \
+	      _tdco_min, _tdco_max)
+
+/**
  * @brief Common CAN controller driver configuration.
  *
  * This structure is common to all CAN controller drivers and is expected to be the first element in

--- a/include/zephyr/drivers/can/can_mcan.h
+++ b/include/zephyr/drivers/can/can_mcan.h
@@ -1237,9 +1237,6 @@ struct can_mcan_config {
 	uint16_t mram_elements[CAN_MCAN_MRAM_CFG_NUM_CELLS];
 	uint16_t mram_offsets[CAN_MCAN_MRAM_CFG_NUM_CELLS];
 	size_t mram_size;
-#ifdef CONFIG_CAN_FD_MODE
-	uint8_t tx_delay_comp_offset;
-#endif
 	const void *custom;
 };
 
@@ -1300,7 +1297,6 @@ struct can_mcan_config {
 		.mram_elements = CAN_MCAN_DT_MRAM_ELEMENTS_GET(node_id),                           \
 		.mram_offsets = CAN_MCAN_DT_MRAM_OFFSETS_GET(node_id),                             \
 		.mram_size = CAN_MCAN_DT_MRAM_ELEMENTS_SIZE(node_id),                              \
-		.tx_delay_comp_offset = DT_PROP(node_id, tx_delay_comp_offset),                    \
 		.custom = _custom,                                                                 \
 	}
 #else /* CONFIG_CAN_FD_MODE */


### PR DESCRIPTION
- Remove broken support for Transmitter Delay Compensation from the Bosch M_CAN backend driver. Even if this was enabled via Kconfig, the TDC bit in the DBTP register set during driver initialization is overwritten in can_mcan_set_timing_data(), turning TDC off.
-  Remove the unused "tx-delay-comp-offset" property from the base CAN FD controller devicetree binding. Having a static Transmitter Delay Compensation (TDC) offset is useless. The offset needs to match the data phase timing parameters in order to properly configure the second sample point when transmitting CAN FD frames with BRS enabled.
- Add a utility macro for calculating the Transmitter Delay Compensation (TDC) Offset using the sample point and CAN core clock prescaler specified by a set of data phase timing parameters.
- Enable Transmitter Delay Compensation in the Bosch M_CAN IP backend driver whenever the data phase timing parameters allow it.    

Fixes: #70447



