### PR TITLE
ci: doc-build: increase timeout for doc build jobs

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -59,7 +59,7 @@ jobs:
         ( needs.doc-file-check.outputs.file_check == 'true' || github.event_name != 'pull_request' )
     runs-on:
       group: zephyr-runner-v2-linux-x64-4xlarge
-    timeout-minutes: 45
+    timeout-minutes: 90
     concurrency:
       group: doc-build-html-${{ github.ref }}
       cancel-in-progress: true
@@ -186,7 +186,7 @@ jobs:
     runs-on:
       group: zephyr-runner-v2-linux-x64-4xlarge
     container: texlive/texlive:latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     concurrency:
       group: doc-build-pdf-${{ github.ref }}
       cancel-in-progress: true


### PR DESCRIPTION
With the introduction of the new runners, the time it takes to build the documentation in CI has slowed down to the point that the job often times out
Applied a conservative 2x factor to the timeouts that were in place.

Note: This is causing deployment of the documentation to docs.zephyrproject.org to regularly fail [1] so proposing this as a hotfix.

[1] https://github.com/zephyrproject-rtos/zephyr/actions/workflows/doc-build.yml?query=event%3Aschedule