### PR TITLE
scripts: test for imported ELFFile instead of setting it to None

### DIFF
--- a/scripts/west_commands/runners/intel_cyclonev.py
+++ b/scripts/west_commands/runners/intel_cyclonev.py
@@ -11,11 +11,6 @@ import os
 from os import path
 from pathlib import Path
 
-try:
-    from elftools.elf.elffile import ELFFile
-except ImportError:
-    ELFFile = None
-
 from runners.core import ZephyrBinaryRunner, RunnerCaps
 
 DEFAULT_OPENOCD_TCL_PORT = 6333
@@ -195,7 +190,7 @@ class IntelCycloneVBinaryRunner(ZephyrBinaryRunner):
     def read_version(self):
         self.require(self.openocd_cmd[0])
 
-	# OpenOCD prints in stderr, need redirect to get output
+        # OpenOCD prints in stderr, need redirect to get output
         out = self.check_output([self.openocd_cmd[0], '--version'],
                                 stderr=subprocess.STDOUT).decode()
 
@@ -210,9 +205,6 @@ class IntelCycloneVBinaryRunner(ZephyrBinaryRunner):
 
     def do_run(self, command, **kwargs):
         self.require(self.openocd_cmd[0])
-        if ELFFile is None:
-            raise RuntimeError(
-                'elftools missing; please "pip3 install elftools"')
 
         self.cfg_cmd = []
         if self.openocd_config is not None:
@@ -272,11 +264,11 @@ class IntelCycloneVBinaryRunner(ZephyrBinaryRunner):
         self.require(gdb_cmd[0])
         self.print_gdbserver_message()
 
-        cmd1 = (echo + server_cmd)
+        cmd1 = echo + server_cmd
         self.check_call(cmd1)
-        cmd2 = (echo + gdb_cmd)
+        cmd2 = echo + gdb_cmd
         self.check_call(cmd2)
-        cmd3 = (echo + gdb_cmd2)
+        cmd3 = echo + gdb_cmd2
         self.check_call(cmd3)
 
         self.run_server_and_client(server_cmd, gdb_cmd)

--- a/scripts/west_commands/runners/openocd.py
+++ b/scripts/west_commands/runners/openocd.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017 Linaro Limited.
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# pylint: disable=duplicate-code
 
 '''Runner for openocd.'''
 
@@ -13,7 +15,7 @@ from pathlib import Path
 try:
     from elftools.elf.elffile import ELFFile
 except ImportError:
-    ELFFile = None
+    pass
 
 from runners.core import ZephyrBinaryRunner
 
@@ -189,7 +191,7 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
     def read_version(self):
         self.require(self.openocd_cmd[0])
 
-	# OpenOCD prints in stderr, need redirect to get output
+        # OpenOCD prints in stderr, need redirect to get output
         out = self.check_output([self.openocd_cmd[0], '--version'],
                                 stderr=subprocess.STDOUT).decode()
 
@@ -204,7 +206,7 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
 
     def do_run(self, command, **kwargs):
         self.require(self.openocd_cmd[0])
-        if ELFFile is None:
+        if globals().get('ELFFile') is None:
             raise RuntimeError(
                 'elftools missing; please "pip3 install elftools"')
 


### PR DESCRIPTION
Several PRs are affected by a mypy update.

Merging this PR removes the need for similar patch in multiple other PRs.

--------------------------

mypy fails with:
Incompatible types in assignment
        (expression has type "None", variable has type "Type[ELFFile]")

this happens because of the code:
    try:
        from elftools.elf.elffile import ELFFile
    except ImportError:
        ELFFile = None

ELFFile is set to None to allow later code to check if ELFFile was imported by checking against None. Instead of setting ELFFile to None, then update testing code to check if the class has been loaded, as:
    if globals().get('ELFFile') is None:

Update the try-catch to `pass`.

Removed ELFFile cargo cult from intel_cyclonev.py and fix pylint warnings.

Disable duplicate code check. The intel_cyclonev.py is already based upon openocd.py, so although the duplication detection is correct then this should not prevent other code changes / fixes to those files from being applied.