### PR TITLE
tests/kernel/userspace: Remove tests for undocumented/legacy behavior

### DIFF
--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -505,66 +505,6 @@ ZTEST_USER(userspace, test_start_kernel_thread)
 	zassert_unreachable("Create a kernel thread did not fault");
 }
 
-static void uthread_read_body(void *p1, void *p2, void *p3)
-{
-	unsigned int *vptr = p1;
-
-	set_fault(K_ERR_CPU_EXCEPTION);
-	printk("%u\n", *vptr);
-	zassert_unreachable("Read from other thread stack did not fault");
-}
-
-static void uthread_write_body(void *p1, void *p2, void *p3)
-{
-	unsigned int *vptr = p1;
-
-	set_fault(K_ERR_CPU_EXCEPTION);
-	*vptr = 2U;
-	zassert_unreachable("Write to other thread stack did not fault");
-}
-
-/**
- * @brief Test to read from another thread's stack
- *
- * @ingroup kernel_memprotect_tests
- */
-ZTEST_USER(userspace, test_read_other_stack)
-{
-	/* Try to read from another thread's stack. */
-	unsigned int val;
-
-#ifdef CONFIG_MMU
-	ztest_test_skip();
-#endif
-	k_thread_create(&test_thread, test_stack, STACKSIZE,
-			uthread_read_body, &val, NULL, NULL,
-			-1, K_USER | K_INHERIT_PERMS,
-			K_NO_WAIT);
-
-	k_thread_join(&test_thread, K_FOREVER);
-}
-
-
-/**
- * @brief Test to write to other thread's stack
- *
- * @ingroup kernel_memprotect_tests
- */
-ZTEST_USER(userspace, test_write_other_stack)
-{
-	/* Try to write to another thread's stack. */
-	unsigned int val;
-
-#ifdef CONFIG_MMU
-	ztest_test_skip();
-#endif
-	k_thread_create(&test_thread, test_stack, STACKSIZE,
-			uthread_write_body, &val, NULL, NULL,
-			-1, K_USER | K_INHERIT_PERMS,
-			K_NO_WAIT);
-	k_thread_join(&test_thread, K_FOREVER);
-}
-
 /**
  * @brief Test to revoke access to kobject without permission
  *


### PR DESCRIPTION
The test_{read,write}_other_stack() cases would launch a thread synchronously into the parent mem_domain and expect that memory access to the "foreign" thread would fail.

In fact that's not the documented behavior.  Threads in the same mem_domain should have the same view of memory and SHOULD be able to access the stacks of other threads in the same domain.  These are validating in exactly the wrong direction!

The only platforms on which this test can pass are legacy MPU implementations that handle stacks specially and not according to the domain mapping.  MMU systems are configured to skip the tests, as they implement access correctly per docs.

Just remove the tests, there's no value here.  See bug #70457 for dicsussion about how to address the inconsistent userspace stack behavior.