### PR TITLE
boards lpcxpresso55s36: Provisionally disable in twister

### DIFF
--- a/boards/nxp/lpcxpresso55s36/lpcxpresso55s36.yaml
+++ b/boards/nxp/lpcxpresso55s36/lpcxpresso55s36.yaml
@@ -20,3 +20,8 @@ supported:
   - pwm
   - dac
 vendor: nxp
+env: # Provisional hack to prevent tests being run in this board, as it fails in many test & samples
+  - LPCXPRESSO55S36_TWISTER_ENABLE
+  # Twister won't run tests in this board unless LPCXPRESSO55S36_TWISTER_ENABLE is set in the
+  # environment, which it normally won't.
+  # Once https://github.com/zephyrproject-rtos/zephyr/issues/69961 is fixed this should be removed


### PR DESCRIPTION
This board fails to build for a multitude of samples & tests which is blocking CI.
Let's provisionally disable it until the matter is properly resolved.
The issue was introduced with the NXP HAL update to 2.15: e4e463af812e61bb5bfb4b1087d48e1dbcd9d8d5

See #69961 for more information

Fixes #70476
