### PR TITLE
soc: ti: simplelink: cc13x2_cc26x2: allow basic BT without zepyhr stack

### DIFF
--- a/soc/ti/simplelink/cc13x2_cc26x2/Kconfig
+++ b/soc/ti/simplelink/cc13x2_cc26x2/Kconfig
@@ -60,3 +60,10 @@ config CC13X2_CC26X2_BOOTLOADER_BACKDOOR_LEVEL
 	  Set the active level of the pin selected for the bootloader backdoor.
 
 endmenu
+
+config CC13X2_CC26X2_BASIC_BT
+	bool "Baremetal Bluetooth support"
+	depends on SOC_CC1352P
+	help
+	  Enable Bluetooth support for the CC13X2 and CC26X2 series of MCUs
+	  using the TI driverlib without the Zephyr or TI Bluetooth stack.

--- a/soc/ti/simplelink/cc13x2_cc26x2/Kconfig.defconfig
+++ b/soc/ti/simplelink/cc13x2_cc26x2/Kconfig.defconfig
@@ -30,12 +30,12 @@ config IEEE802154_CC13XX_CC26XX_SUB_GHZ
 
 endif # IEEE802154
 
-if BT
+if BT || CC13X2_CC26X2_BASIC_BT
 
 config BLE_CC13XX_CC26XX
 	bool
 	default y
 
-endif # BT
+endif # BT || CC13X2_CC26X2_BASIC_BT
 
 endif # SOC_SERIES_CC13X2_CC26X2


### PR DESCRIPTION
Allow developer to use the baremetal Bluetooth functionalities of the CC13X2 and CC26X2 series SoCs without having to use the full Zephyr Bluetooth stack as porting the TI API to the Zephyr Bluetooth stack seems to be a huge undertaking for now.

Signed-off-by: Benedikt Streicher