### PR TITLE
[DNM] manifest: hal-ti: HwiP: added AUX software event interrupts

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -239,7 +239,7 @@ manifest:
       groups:
         - hal
     - name: hal_ti
-      revision: b85f86e51fc4d47c4c383d320d64d52d4d371ae4
+      revision: pull/52/head
       path: modules/hal/ti
       groups:
         - hal


### PR DESCRIPTION
Related to [zephyrproject-rtos/hal_ti#52](https://github.com/zephyrproject-rtos/hal_ti/pull/52)