### PR TITLE
dts: nxp: rw: Add DMA channels to flexcomm nodes

### DIFF
--- a/dts/arm/nxp/nxp_rw6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rw6xx_common.dtsi
@@ -99,6 +99,8 @@
 		reg = <0x106000 0x1000>;
 		interrupts = <14 0>;
 		clocks = <&clkctl1 MCUX_FLEXCOMM0_CLK>;
+		dmas = <&dma0 0>, <&dma0 1>;
+		dma-names = "rx", "tx";
 		status = "disabled";
 	};
 
@@ -107,6 +109,8 @@
 		reg = <0x107000 0x1000>;
 		interrupts = <15 0>;
 		clocks = <&clkctl1 MCUX_FLEXCOMM1_CLK>;
+		dmas = <&dma0 2>, <&dma0 3>;
+		dma-names = "rx", "tx";
 		status = "disabled";
 	};
 
@@ -115,6 +119,8 @@
 		reg = <0x108000 0x1000>;
 		interrupts = <16 0>;
 		clocks = <&clkctl1 MCUX_FLEXCOMM2_CLK>;
+		dmas = <&dma0 4>, <&dma0 5>;
+		dma-names = "rx", "tx";
 		status = "disabled";
 	};
 
@@ -123,6 +129,8 @@
 		reg = <0x109000 0x1000>;
 		interrupts = <17 0>;
 		clocks = <&clkctl1 MCUX_FLEXCOMM3_CLK>;
+		dmas = <&dma0 6>, <&dma0 7>;
+		dma-names = "rx", "tx";
 		status = "disabled";
 	};
 
@@ -131,6 +139,8 @@
 		reg = <0x126000 0x2000>;
 		interrupts = <20 0>;
 		clocks = <&clkctl1 MCUX_FLEXCOMM14_CLK>;
+		dmas = <&dma0 26>, <&dma0 27>;
+		dma-names = "rx", "tx";
 		status = "disabled";
 	};
 


### PR DESCRIPTION
Add dma channel descriptions to the flexcomm nodes on RW SOC.