### PR TITLE
MAINTAINERS: Update paths for NXP Platforms (MPU)

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3383,6 +3383,7 @@ NXP Platforms (MPU):
     - decsny
     - yvanderv
   files:
+    - dts/arm64/nxp/
     - soc/nxp/imx/
     - soc/nxp/layerscape/
   files-regex:


### PR DESCRIPTION
Files around dts/arm64/nxp should belong to NXP Platforms (MPU) group.