### PR TITLE
cmake: sca: codechecker: search for 'CodeChecker' and 'codechecker'

### DIFF
--- a/cmake/sca/codechecker/sca.cmake
+++ b/cmake/sca/codechecker/sca.cmake
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2023, Basalte bv
 
-find_program(CODECHECKER_EXE CodeChecker REQUIRED)
+find_program(CODECHECKER_EXE NAMES CodeChecker codechecker REQUIRED)
 message(STATUS "Found SCA: CodeChecker (${CODECHECKER_EXE})")
 
 # CodeChecker uses the compile_commands.json as input


### PR DESCRIPTION
Minor fix: Let find_program in codechecker/sca.cmake search for both 'CodeChecker' and 'codechecker'. Before this change, I wasn't able to run CodeChecker because cmake couldn't find it. (Ubuntu 23.10, cmake 3.27.4, CodeChecker 6.21.0 installed via snap)