### PR TITLE
Simple boot support for Espressif SoCs

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -905,15 +905,6 @@ config BOOTLOADER_SRAM_SIZE_DEPRECATED
 	  Non-prompt symbol to indicate that the deprecated BOOTLOADER_SRAM_SIZE Kconfig has a
 	  non-0 value. Please transition to using devicetree.
 
-config BOOTLOADER_ESP_IDF
-	bool "ESP-IDF bootloader support"
-	depends on SOC_FAMILY_ESPRESSIF_ESP32 && !BOOTLOADER_MCUBOOT && !MCUBOOT
-	default	y
-	help
-	  This option will trigger the compilation of the ESP-IDF bootloader
-	  inside the build folder.
-	  At flash time, the bootloader will be flashed with the zephyr image
-
 config BOOTLOADER_BOSSA
 	bool "BOSSA bootloader support"
 	select USE_DT_CODE_PARTITION

--- a/boards/espressif/esp32_devkitc_wroom/doc/index.rst
+++ b/boards/espressif/esp32_devkitc_wroom/doc/index.rst
@@ -115,7 +115,91 @@ below to retrieve those files.
    It is recommended running the command above after :file:`west update`.
 
 Building & Flashing
--------------------
+*******************
+
+Simple boot
+===========
+
+The board could be loaded using the single binary image, without 2nd stage bootloader.
+It is the default option when building the application without additional configuration.
+
+.. note::
+
+   Simple boot does not provide any security features nor OTA updates.
+
+MCUboot bootloader
+==================
+
+User may choose to use MCUboot bootloader instead. In that case the bootloader
+must be build (and flash) at least once.
+
+There are two options to be used when building an application:
+
+1. Sysbuild
+2. Manual build
+
+.. note::
+
+   User can select the MCUboot bootloader by adding the following line
+   to the board default configuration file.
+   ```
+   CONFIG_BOOTLOADER_MCUBOOT=y
+   ```
+
+Sysbuild
+========
+
+The sysbuild makes possible to build and flash all necessary images needed to
+bootstrap the board with the ESP32 SoC.
+
+To build the sample application using sysbuild use the command:
+
+.. zephyr-app-commands::
+   :tool: west
+   :app: samples/hello_world
+   :board: esp_wrover_kit
+   :goals: build
+   :west-args: --sysbuild
+   :compact:
+
+By default, the ESP32 sysbuild creates bootloader (MCUboot) and application
+images. But it can be configured to create other kind of images.
+
+Build directory structure created by sysbuild is different from traditional
+Zephyr build. Output is structured by the domain subdirectories:
+
+.. code-block::
+
+  build/
+  ├── hello_world
+  │   └── zephyr
+  │       ├── zephyr.elf
+  │       └── zephyr.bin
+  ├── mcuboot
+  │    └── zephyr
+  │       ├── zephyr.elf
+  │       └── zephyr.bin
+  └── domains.yaml
+
+.. note::
+
+   With ``--sysbuild`` option the bootloader will be re-build and re-flash
+   every time the pristine build is used.
+
+For more information about the system build please read the :ref:`sysbuild` documentation.
+
+Manual build
+============
+
+During the development cycle, it is intended to build & flash as quickly possible.
+For that reason, images can be build one at a time using traditional build.
+
+The instructions following are relevant for both manual build and sysbuild.
+The only difference is the structure of the build directory.
+
+.. note::
+
+   Remember that bootloader (MCUboot) needs to be flash at least once.
 
 Build and flash applications as usual (see :ref:`build_an_application` and
 :ref:`application_run` for more details).
@@ -149,7 +233,7 @@ message in the monitor:
    Hello World! esp32_devkitc_wroom
 
 Debugging
----------
+*********
 
 ESP32-DEVKITC-WROOM support on OpenOCD is available upstream as of version 0.12.0.
 Download and install OpenOCD from `OpenOCD`_.

--- a/boards/espressif/esp32_devkitc_wrover/doc/index.rst
+++ b/boards/espressif/esp32_devkitc_wrover/doc/index.rst
@@ -117,12 +117,15 @@ below to retrieve those files.
 Building & Flashing
 *******************
 
-ESP-IDF bootloader
-==================
+Simple boot
+===========
 
-The board is using the ESP-IDF bootloader as the default 2nd stage bootloader.
-It is build as a subproject at each application build. No further attention
-is expected from the user.
+The board could be loaded using the single binary image, without 2nd stage bootloader.
+It is the default option when building the application without additional configuration.
+
+.. note::
+
+   Simple boot does not provide any security features nor OTA updates.
 
 MCUboot bootloader
 ==================

--- a/boards/espressif/esp32_ethernet_kit/doc/index.rst
+++ b/boards/espressif/esp32_ethernet_kit/doc/index.rst
@@ -438,12 +438,15 @@ below to retrieve those files.
 Building & Flashing
 *******************
 
-ESP-IDF bootloader
-==================
+Simple boot
+===========
 
-The board is using the ESP-IDF bootloader as the default 2nd stage bootloader.
-It is build as a subproject at each application build. No further attention
-is expected from the user.
+The board could be loaded using the single binary image, without 2nd stage bootloader.
+It is the default option when building the application without additional configuration.
+
+.. note::
+
+   Simple boot does not provide any security features nor OTA updates.
 
 MCUboot bootloader
 ==================

--- a/boards/espressif/esp32c3_devkitm/doc/index.rst
+++ b/boards/espressif/esp32c3_devkitm/doc/index.rst
@@ -92,12 +92,15 @@ below to retrieve those files.
 Building & Flashing
 *******************
 
-ESP-IDF bootloader
-==================
+Simple boot
+===========
 
-The board is using the ESP-IDF bootloader as the default 2nd stage bootloader.
-It is build as a subproject at each application build. No further attention
-is expected from the user.
+The board could be loaded using the single binary image, without 2nd stage bootloader.
+It is the default option when building the application without additional configuration.
+
+.. note::
+
+   Simple boot does not provide any security features nor OTA updates.
 
 MCUboot bootloader
 ==================

--- a/boards/espressif/esp32s2_saola/doc/index.rst
+++ b/boards/espressif/esp32s2_saola/doc/index.rst
@@ -88,12 +88,15 @@ below to retrieve those files.
 Building & Flashing
 *******************
 
-ESP-IDF bootloader
-==================
+Simple boot
+===========
 
-The board is using the ESP-IDF bootloader as the default 2nd stage bootloader.
-It is build as a subproject at each application build. No further attention
-is expected from the user.
+The board could be loaded using the single binary image, without 2nd stage bootloader.
+It is the default option when building the application without additional configuration.
+
+.. note::
+
+   Simple boot does not provide any security features nor OTA updates.
 
 MCUboot bootloader
 ==================

--- a/boards/espressif/esp32s3_devkitm/doc/index.rst
+++ b/boards/espressif/esp32s3_devkitm/doc/index.rst
@@ -137,12 +137,15 @@ below to retrieve those files.
 Building & Flashing
 *******************
 
-ESP-IDF bootloader
-==================
+Simple boot
+===========
 
-The board is using the ESP-IDF bootloader as the default 2nd stage bootloader.
-It is build as a subproject at each application build. No further attention
-is expected from the user.
+The board could be loaded using the single binary image, without 2nd stage bootloader.
+It is the default option when building the application without additional configuration.
+
+.. note::
+
+   Simple boot does not provide any security features nor OTA updates.
 
 MCUboot bootloader
 ==================

--- a/boards/espressif/esp_wrover_kit/doc/index.rst
+++ b/boards/espressif/esp_wrover_kit/doc/index.rst
@@ -503,12 +503,15 @@ below to retrieve those files.
 Building & Flashing
 *******************
 
-ESP-IDF bootloader
-==================
+Simple boot
+===========
 
-The board is using the ESP-IDF bootloader as the default 2nd stage bootloader.
-It is build as a subproject at each application build. No further attention
-is expected from the user.
+The board could be loaded using the single binary image, without 2nd stage bootloader.
+It is the default option when building the application without additional configuration.
+
+.. note::
+
+   Simple boot does not provide any security features nor OTA updates.
 
 MCUboot bootloader
 ==================

--- a/boards/franzininho/esp32s2_franzininho/doc/index.rst
+++ b/boards/franzininho/esp32s2_franzininho/doc/index.rst
@@ -54,12 +54,15 @@ below to retrieve those files.
 Building & Flashing
 *******************
 
-ESP-IDF bootloader
-==================
+Simple boot
+===========
 
-The board is using the ESP-IDF bootloader as the default 2nd stage bootloader.
-It is build as a subproject at each application build. No further attention
-is expected from the user.
+The board could be loaded using the single binary image, without 2nd stage bootloader.
+It is the default option when building the application without additional configuration.
+
+.. note::
+
+   Simple boot does not provide any security features nor OTA updates.
 
 MCUboot bootloader
 ==================

--- a/boards/heltec/heltec_wifi_lora32_v2/doc/index.rst
+++ b/boards/heltec/heltec_wifi_lora32_v2/doc/index.rst
@@ -42,12 +42,15 @@ below to retrieve those files.
 Building & Flashing
 *******************
 
-ESP-IDF bootloader
-==================
+Simple boot
+===========
 
-The board is using the ESP-IDF bootloader as the default 2nd stage bootloader.
-It is build as a subproject at each application build. No further attention
-is expected from the user.
+The board could be loaded using the single binary image, without 2nd stage bootloader.
+It is the default option when building the application without additional configuration.
+
+.. note::
+
+   Simple boot does not provide any security features nor OTA updates.
 
 MCUboot bootloader
 ==================

--- a/boards/heltec/heltec_wireless_stick_lite_v3/doc/index.rst
+++ b/boards/heltec/heltec_wireless_stick_lite_v3/doc/index.rst
@@ -156,12 +156,15 @@ below to retrieve those files.
 Programming and Debugging
 *************************
 
-ESP-IDF bootloader
-==================
+Simple boot
+===========
 
-The board is using the ESP-IDF bootloader as the default 2nd stage bootloader.
-It is build as a subproject at each application build. No further attention
-is expected from the user.
+The board could be loaded using the single binary image, without 2nd stage bootloader.
+It is the default option when building the application without additional configuration.
+
+.. note::
+
+   Simple boot does not provide any security features nor OTA updates.
 
 MCUboot bootloader
 ==================

--- a/boards/luatos/esp32c3_luatos_core/doc/index.rst
+++ b/boards/luatos/esp32c3_luatos_core/doc/index.rst
@@ -110,12 +110,15 @@ below to retrieve those files.
 Building & Flashing
 *******************
 
-ESP-IDF bootloader
-==================
+Simple boot
+===========
 
-The board is using the ESP-IDF bootloader as the default 2nd stage bootloader.
-It is build as a subproject at each application build. No further attention
-is expected from the user.
+The board could be loaded using the single binary image, without 2nd stage bootloader.
+It is the default option when building the application without additional configuration.
+
+.. note::
+
+   Simple boot does not provide any security features nor OTA updates.
 
 MCUboot bootloader
 ==================

--- a/boards/luatos/esp32s3_luatos_core/doc/index.rst
+++ b/boards/luatos/esp32s3_luatos_core/doc/index.rst
@@ -136,12 +136,15 @@ below to retrieve those files.
 Building & Flashing
 *******************
 
-ESP-IDF bootloader
-==================
+Simple boot
+===========
 
-The board is using the ESP-IDF bootloader as the default 2nd stage bootloader.
-It is build as a subproject at each application build. No further attention
-is expected from the user.
+The board could be loaded using the single binary image, without 2nd stage bootloader.
+It is the default option when building the application without additional configuration.
+
+.. note::
+
+   Simple boot does not provide any security features nor OTA updates.
 
 MCUboot bootloader
 ==================

--- a/boards/olimex/olimex_esp32_evb/doc/index.rst
+++ b/boards/olimex/olimex_esp32_evb/doc/index.rst
@@ -111,12 +111,15 @@ below to retrieve those files.
 Building & Flashing
 *******************
 
-ESP-IDF bootloader
-==================
+Simple boot
+===========
 
-The board is using the ESP-IDF bootloader as the default 2nd stage bootloader.
-It is build as a subproject at each application build. No further attention
-is expected from the user.
+The board could be loaded using the single binary image, without 2nd stage bootloader.
+It is the default option when building the application without additional configuration.
+
+.. note::
+
+   Simple boot does not provide any security features nor OTA updates.
 
 MCUboot bootloader
 ==================

--- a/boards/others/icev_wireless/doc/index.rst
+++ b/boards/others/icev_wireless/doc/index.rst
@@ -98,12 +98,15 @@ incredibly easy 🎉 following the steps below.
 Building and Flashing
 *********************
 
-ESP-IDF bootloader
-==================
+Simple boot
+===========
 
-The board is using the ESP-IDF bootloader as the default 2nd stage bootloader.
-It is build as a subproject at each application build. No further attention
-is expected from the user.
+The board could be loaded using the single binary image, without 2nd stage bootloader.
+It is the default option when building the application without additional configuration.
+
+.. note::
+
+   Simple boot does not provide any security features nor OTA updates.
 
 MCUboot bootloader
 ==================

--- a/boards/seeed/xiao_esp32c3/doc/index.rst
+++ b/boards/seeed/xiao_esp32c3/doc/index.rst
@@ -80,12 +80,15 @@ below to retrieve those files.
 Building & Flashing
 *******************
 
-ESP-IDF bootloader
-==================
+Simple boot
+===========
 
-The board is using the ESP-IDF bootloader as the default 2nd stage bootloader.
-It is build as a subproject at each application build. No further attention
-is expected from the user.
+The board could be loaded using the single binary image, without 2nd stage bootloader.
+It is the default option when building the application without additional configuration.
+
+.. note::
+
+   Simple boot does not provide any security features nor OTA updates.
 
 MCUboot bootloader
 ==================

--- a/boards/seeed/xiao_esp32s3/doc/index.rst
+++ b/boards/seeed/xiao_esp32s3/doc/index.rst
@@ -96,12 +96,15 @@ below to retrieve those files.
 Building & Flashing
 *******************
 
-ESP-IDF bootloader
-==================
+Simple boot
+===========
 
-The board is using the ESP-IDF bootloader as the default 2nd stage bootloader.
-It is build as a subproject at each application build. No further attention
-is expected from the user.
+The board could be loaded using the single binary image, without 2nd stage bootloader.
+It is the default option when building the application without additional configuration.
+
+.. note::
+
+   Simple boot does not provide any security features nor OTA updates.
 
 MCUboot bootloader
 ==================

--- a/boards/vcc-gnd/yd_esp32/doc/index.rst
+++ b/boards/vcc-gnd/yd_esp32/doc/index.rst
@@ -117,12 +117,15 @@ below to retrieve those files.
 Building & Flashing
 *******************
 
-ESP-IDF bootloader
-==================
+Simple boot
+===========
 
-The board is using the ESP-IDF bootloader as the default 2nd stage bootloader.
-It is build as a subproject at each application build. No further attention
-is expected from the user.
+The board could be loaded using the single binary image, without 2nd stage bootloader.
+It is the default option when building the application without additional configuration.
+
+.. note::
+
+   Simple boot does not provide any security features nor OTA updates.
 
 MCUboot bootloader
 ==================

--- a/drivers/clock_control/clock_control_esp32.c
+++ b/drivers/clock_control/clock_control_esp32.c
@@ -35,6 +35,7 @@
 #include <soc/rtc.h>
 #endif /* CONFIG_SOC_SERIES_ESP32xx */
 
+#include <esp_rom_caps.h>
 #include <esp_rom_sys.h>
 #include <esp_rom_uart.h>
 #include <soc/rtc.h>
@@ -518,6 +519,9 @@ static int clock_control_esp32_init(const struct device *dev)
 	rtc_cpu_freq_config_t new_config;
 	bool res;
 
+	/* wait uart output to be cleared */
+	esp_rom_uart_tx_wait_idle(ESP_CONSOLE_UART_NUM);
+
 	/* reset default config to use dts config */
 	if (rtc_clk_apb_freq_get() < APB_CLK_FREQ || rtc_get_reset_reason(0) != CPU_RESET_REASON) {
 		rtc_clk_config_t clk_cfg = RTC_CLK_CONFIG_DEFAULT();
@@ -541,9 +545,6 @@ static int clock_control_esp32_init(const struct device *dev)
 		return -ENOTSUP;
 	}
 
-	/* wait uart output to be cleared */
-	esp_rom_uart_tx_wait_idle(0);
-
 	if (cfg->xtal_div >= 0) {
 		new_config.div = cfg->xtal_div;
 	}
@@ -564,10 +565,10 @@ static int clock_control_esp32_init(const struct device *dev)
 #if ESP_ROM_UART_CLK_IS_XTAL
 	clock_hz = esp_clk_xtal_freq();
 #endif
-	esp_rom_uart_tx_wait_idle(ESP_CONSOLE_UART_NUM);
 
 #if !defined(ESP_CONSOLE_UART_NONE)
-	esp_rom_uart_set_clock_baudrate(ESP_CONSOLE_UART_NUM, clock_hz, ESP_CONSOLE_UART_BAUDRATE);
+	esp_rom_uart_set_clock_baudrate(ESP_CONSOLE_UART_NUM,
+			clock_hz, ESP_CONSOLE_UART_BAUDRATE);
 #endif
 	return 0;
 }

--- a/soc/espressif/common/Kconfig.flash
+++ b/soc/espressif/common/Kconfig.flash
@@ -127,4 +127,12 @@ config SPI_FLASH_HPM_ENABLE
 	  This option is invisible, and will be selected automatically
 	  when ``ESPTOOLPY_FLASHFREQ_120M`` is selected.
 
+config ESP_SIMPLE_BOOT
+	bool "Simple Boot method"
+	default y if !BOOTLOADER_MCUBOOT
+	help
+	  The Simple Boot is a method of booting that doesn't depend on a
+	  2nd stage bootloader. Please note that some of the bootloader features
+	  are not available using simple boot, such secure boot and OTA.
+
 endif # SOC_FAMILY_ESPRESSIF_ESP32

--- a/soc/espressif/common/loader.c
+++ b/soc/espressif/common/loader.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Espressif Systems (Shanghai) Co., Ltd.
+ * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -12,29 +12,64 @@
 #include <hal/cache_hal.h>
 #include <rom/cache.h>
 #include <esp_rom_sys.h>
+#include <esp_err.h>
 
 #define MMU_FLASH_MASK    (~(CONFIG_MMU_PAGE_SIZE - 1))
 
-#ifdef CONFIG_BOOTLOADER_MCUBOOT
+#include <esp_app_format.h>
 #include <zephyr/storage/flash_map.h>
 #include "esp_rom_uart.h"
+#include "esp_flash.h"
+#include "esp_log.h"
+#include "bootloader_init.h"
+
+#define TAG "boot"
+
+#define CHECKSUM_ALIGN 16
+#define IS_PADD(addr) (addr == 0)
+#define IS_DRAM(addr) (addr >= SOC_DRAM_LOW && addr < SOC_DRAM_HIGH)
+#define IS_IRAM(addr) (addr >= SOC_IRAM_LOW && addr < SOC_IRAM_HIGH)
+#define IS_IROM(addr) (addr >= SOC_IROM_LOW && addr < SOC_IROM_HIGH)
+#define IS_DROM(addr) (addr >= SOC_DROM_LOW && addr < SOC_DROM_HIGH)
+#define IS_SRAM(addr) (IS_IRAM(addr) || IS_DRAM(addr))
+#define IS_MMAP(addr) (IS_IROM(addr) || IS_DROM(addr))
+#define IS_NONE(addr) (!IS_IROM(addr) && !IS_DROM(addr) \
+			&& !IS_IRAM(addr) && !IS_DRAM(addr) && !IS_PADD(addr))
 
 #define BOOT_LOG_INF(_fmt, ...) \
 	ets_printf("[" CONFIG_SOC_SERIES "] [INF] " _fmt "\n\r", ##__VA_ARGS__)
+#define BOOT_LOG_ERR(_fmt, ...) \
+	ets_printf("[" CONFIG_SOC_SERIES "] [ERR] " _fmt "\n\r", ##__VA_ARGS__)
 
 #define HDR_ATTR __attribute__((section(".entry_addr"))) __attribute__((used))
 
 void __start(void);
-
 static HDR_ATTR void (*_entry_point)(void) = &__start;
 
+extern esp_image_header_t bootloader_image_hdr;
 extern uint32_t _image_irom_start, _image_irom_size, _image_irom_vaddr;
 extern uint32_t _image_drom_start, _image_drom_size, _image_drom_vaddr;
+
+static uint32_t _app_irom_start = (FIXED_PARTITION_OFFSET(slot0_partition) +
+						(uint32_t)&_image_irom_start);
+static uint32_t _app_irom_size = (uint32_t)&_image_irom_size;
+static uint32_t _app_irom_vaddr = ((uint32_t)&_image_irom_vaddr);
+
+static uint32_t _app_drom_start = (FIXED_PARTITION_OFFSET(slot0_partition) +
+						(uint32_t)&_image_drom_start);
+static uint32_t _app_drom_size = (uint32_t)&_image_drom_size;
+static uint32_t _app_drom_vaddr = ((uint32_t)&_image_drom_vaddr);
+
+#ifndef CONFIG_BOOTLOADER_MCUBOOT
+static esp_err_t spi_flash_read(uint32_t address, void *buffer, size_t length)
+{
+	return esp_flash_read(NULL, buffer, address, length);
+}
 #endif /* CONFIG_BOOTLOADER_MCUBOOT */
 
 void map_rom_segments(uint32_t app_drom_start, uint32_t app_drom_vaddr,
-				uint32_t app_drom_size, uint32_t app_irom_start,
-				uint32_t app_irom_vaddr, uint32_t app_irom_size)
+			uint32_t app_drom_size, uint32_t app_irom_start,
+			uint32_t app_irom_vaddr, uint32_t app_irom_size)
 {
 	uint32_t app_irom_start_aligned = app_irom_start & MMU_FLASH_MASK;
 	uint32_t app_irom_vaddr_aligned = app_irom_vaddr & MMU_FLASH_MASK;
@@ -43,12 +78,74 @@ void map_rom_segments(uint32_t app_drom_start, uint32_t app_drom_vaddr,
 	uint32_t app_drom_vaddr_aligned = app_drom_vaddr & MMU_FLASH_MASK;
 	uint32_t actual_mapped_len = 0;
 
+#ifndef CONFIG_BOOTLOADER_MCUBOOT
+	esp_image_segment_header_t WORD_ALIGNED_ATTR segment_hdr;
+	size_t offset = FIXED_PARTITION_OFFSET(boot_partition);
+	bool checksum = false;
+	unsigned int segments = 0;
+	unsigned int ram_segments = 0;
+
+	/* Using already fetched bootloader image header from bootloader_init */
+	offset += sizeof(esp_image_header_t);
+
+	while (segments++ < 16) {
+
+		if (spi_flash_read(offset, &segment_hdr,
+				sizeof(esp_image_segment_header_t)) != ESP_OK) {
+			BOOT_LOG_ERR("Failed to read segment header at %x", offset);
+			abort();
+		}
+
+		/* TODO: Find better end-of-segment detection */
+		if (IS_NONE(segment_hdr.load_addr)) {
+			/* Total segment count = (segments - 1) */
+			break;
+		}
+
+		BOOT_LOG_INF("%s: lma 0x%08x vma 0x%08x len 0x%-6x (%u)",
+			IS_NONE(segment_hdr.load_addr) ? "???" :
+			 IS_MMAP(segment_hdr.load_addr) ?
+			  IS_IROM(segment_hdr.load_addr) ? "IMAP" : "DMAP" :
+			   IS_PADD(segment_hdr.load_addr) ? "padd" :
+			    IS_DRAM(segment_hdr.load_addr) ? "DRAM" : "IRAM",
+			offset + sizeof(esp_image_segment_header_t),
+			segment_hdr.load_addr, segment_hdr.data_len, segment_hdr.data_len);
+
+		/* Fix drom and irom produced be the linker, as it could
+		 * be invalidated by the elf2image and flash load offset
+		 */
+		if (segment_hdr.load_addr == _app_drom_vaddr) {
+			app_drom_start = offset + sizeof(esp_image_segment_header_t);
+			app_drom_start_aligned = app_drom_start & MMU_FLASH_MASK;
+		}
+		if (segment_hdr.load_addr == _app_irom_vaddr) {
+			app_irom_start = offset + sizeof(esp_image_segment_header_t);
+			app_irom_start_aligned = app_irom_start & MMU_FLASH_MASK;
+		}
+		if (IS_SRAM(segment_hdr.load_addr)) {
+			ram_segments++;
+		}
+		offset += sizeof(esp_image_segment_header_t) + segment_hdr.data_len;
+
+		if (ram_segments == bootloader_image_hdr.segment_count && !checksum) {
+			offset += (CHECKSUM_ALIGN - 1) - (offset % CHECKSUM_ALIGN) + 1;
+			checksum = true;
+		}
+	}
+	if (segments == 0 || segments == 16) {
+		BOOT_LOG_ERR("Error parsing segments");
+		abort();
+	}
+
+	BOOT_LOG_INF("Image with %d segments", segments - 1);
+#endif /* !CONFIG_BOOTLOADER_MCUBOOT */
+
 #if CONFIG_SOC_SERIES_ESP32
 	Cache_Read_Disable(0);
 	Cache_Flush(0);
 #else
 	cache_hal_disable(CACHE_TYPE_ALL);
-#endif
+#endif /* CONFIG_SOC_SERIES_ESP32 */
 
 	/* Clear the MMU entries that are already set up,
 	 * so the new app only has the mappings it creates.
@@ -58,31 +155,33 @@ void map_rom_segments(uint32_t app_drom_start, uint32_t app_drom_vaddr,
 #if CONFIG_SOC_SERIES_ESP32
 	int rc = 0;
 	uint32_t drom_page_count =
-				(app_drom_size + CONFIG_MMU_PAGE_SIZE - 1) / CONFIG_MMU_PAGE_SIZE;
+			(app_drom_size + CONFIG_MMU_PAGE_SIZE - 1) / CONFIG_MMU_PAGE_SIZE;
 
 	rc |= cache_flash_mmu_set(0, 0, app_drom_vaddr_aligned,
-						app_drom_start_aligned, 64, drom_page_count);
+					app_drom_start_aligned, 64, drom_page_count);
 	rc |= cache_flash_mmu_set(1, 0, app_drom_vaddr_aligned,
-						app_drom_start_aligned, 64, drom_page_count);
+					app_drom_start_aligned, 64, drom_page_count);
 
 	uint32_t irom_page_count =
-				(app_irom_size + CONFIG_MMU_PAGE_SIZE - 1) / CONFIG_MMU_PAGE_SIZE;
+			(app_irom_size + CONFIG_MMU_PAGE_SIZE - 1) / CONFIG_MMU_PAGE_SIZE;
 
 	rc |= cache_flash_mmu_set(0, 0, app_irom_vaddr_aligned,
-						app_irom_start_aligned, 64, irom_page_count);
+					app_irom_start_aligned, 64, irom_page_count);
 	rc |= cache_flash_mmu_set(1, 0, app_irom_vaddr_aligned,
-						app_irom_start_aligned, 64, irom_page_count);
+					app_irom_start_aligned, 64, irom_page_count);
 	if (rc != 0) {
-		esp_rom_printf("Failed to setup XIP, aborting\n");
+		BOOT_LOG_ERR("Failed to setup XIP, aborting");
 		abort();
 	}
 #else
-	mmu_hal_map_region(0, MMU_TARGET_FLASH0, app_drom_vaddr_aligned, app_drom_start_aligned,
+	mmu_hal_map_region(0, MMU_TARGET_FLASH0,
+				app_drom_vaddr_aligned, app_drom_start_aligned,
 				app_drom_size, &actual_mapped_len);
 
-	mmu_hal_map_region(0, MMU_TARGET_FLASH0, app_irom_vaddr_aligned, app_irom_start_aligned,
+	mmu_hal_map_region(0, MMU_TARGET_FLASH0,
+				app_irom_vaddr_aligned, app_irom_start_aligned,
 				app_irom_size, &actual_mapped_len);
-#endif
+#endif /* CONFIG_SOC_SERIES_ESP32 */
 
 	/* ----------------------Enable corresponding buses---------------- */
 	cache_bus_mask_t bus_mask = cache_ll_l1_get_bus(0, app_drom_vaddr_aligned, app_drom_size);
@@ -103,31 +202,42 @@ void map_rom_segments(uint32_t app_drom_start, uint32_t app_drom_vaddr,
 	Cache_Read_Enable(0);
 #else
 	cache_hal_enable(CACHE_TYPE_ALL);
-#endif
+#endif /* CONFIG_SOC_SERIES_ESP32 */
+
+	/* Show map segments continue using same log format as during MCUboot phase */
+	BOOT_LOG_INF("DROM segment: paddr=%08xh, vaddr=%08xh, size=%05Xh (%6d) map",
+			app_drom_start_aligned, app_drom_vaddr_aligned,
+			app_drom_size, app_drom_size);
+	BOOT_LOG_INF("IROM segment: paddr=%08xh, vaddr=%08xh, size=%05Xh (%6d) map\r\n",
+			app_irom_start_aligned, app_irom_vaddr_aligned,
+			app_irom_size, app_irom_size);
+	esp_rom_uart_tx_wait_idle(0);
 }
 
 void __start(void)
 {
-#ifdef CONFIG_BOOTLOADER_MCUBOOT
-	size_t _partition_offset = FIXED_PARTITION_OFFSET(slot0_partition);
-	uint32_t _app_irom_start = (_partition_offset + (uint32_t)&_image_irom_start);
-	uint32_t _app_irom_size = (uint32_t)&_image_irom_size;
-	uint32_t _app_irom_vaddr = ((uint32_t)&_image_irom_vaddr);
+#ifdef CONFIG_RISCV_GP
+	/* Configure the global pointer register
+	 * (This should be the first thing startup does, as any other piece of code could be
+	 * relaxed by the linker to access something relative to __global_pointer$)
+	 */
+	__asm__ __volatile__(".option push\n"
+				".option norelax\n"
+				"la gp, __global_pointer$\n"
+				".option pop");
+#endif /* CONFIG_RISCV_GP */
 
-	uint32_t _app_drom_start = (_partition_offset + (uint32_t)&_image_drom_start);
-	uint32_t _app_drom_size = (uint32_t)&_image_drom_size;
-	uint32_t _app_drom_vaddr = ((uint32_t)&_image_drom_vaddr);
-	uint32_t actual_mapped_len = 0;
+#ifndef CONFIG_BOOTLOADER_MCUBOOT
+	/* Init fundamental components */
+	if (bootloader_init()) {
+		BOOT_LOG_ERR("HW init failed, aborting");
+		abort();
+	}
+#endif
 
+#ifndef CONFIG_MCUBOOT
 	map_rom_segments(_app_drom_start, _app_drom_vaddr, _app_drom_size,
-				_app_irom_start, _app_irom_vaddr, _app_irom_size);
-
-	/* Show map segments continue using same log format as during MCUboot phase */
-	BOOT_LOG_INF("DROM segment: paddr=%08Xh, vaddr=%08Xh, size=%05Xh (%6d) map",
-		_app_drom_start, _app_drom_vaddr, _app_drom_size, _app_drom_size);
-	BOOT_LOG_INF("IROM segment: paddr=%08Xh, vaddr=%08Xh, size=%05Xh (%6d) map\r\n",
-		_app_irom_start, _app_irom_vaddr, _app_irom_size, _app_irom_size);
-	esp_rom_uart_tx_wait_idle(0);
+			 _app_irom_start, _app_irom_vaddr, _app_irom_size);
 #endif
 	__esp_platform_start();
 }

--- a/soc/espressif/esp32/CMakeLists.txt
+++ b/soc/espressif/esp32/CMakeLists.txt
@@ -22,39 +22,26 @@ zephyr_library_sources_ifdef(CONFIG_POWEROFF poweroff.c)
 # get flash size to use in esptool as string
 math(EXPR esptoolpy_flashsize "${CONFIG_FLASH_SIZE} / 0x100000")
 
-if(CONFIG_BOOTLOADER_ESP_IDF)
-
-  set(bootloader_dir "${ZEPHYR_HAL_ESPRESSIF_MODULE_DIR}/zephyr/blobs/lib/${CONFIG_SOC_SERIES}")
-
-  if(EXISTS "${bootloader_dir}/bootloader-${CONFIG_SOC_SERIES}.bin")
-    file(COPY "${bootloader_dir}/bootloader-${CONFIG_SOC_SERIES}.bin" DESTINATION ${CMAKE_BINARY_DIR})
-    file(RENAME "${CMAKE_BINARY_DIR}/bootloader-${CONFIG_SOC_SERIES}.bin" "${CMAKE_BINARY_DIR}/bootloader.bin")
-  endif()
-
-  if(EXISTS "${bootloader_dir}/partition-table-${CONFIG_SOC_SERIES}.bin")
-    file(COPY "${bootloader_dir}/partition-table-${CONFIG_SOC_SERIES}.bin" DESTINATION ${CMAKE_BINARY_DIR})
-    file(RENAME "${CMAKE_BINARY_DIR}/partition-table-${CONFIG_SOC_SERIES}.bin" "${CMAKE_BINARY_DIR}/partition-table.bin")
-  endif()
-  board_finalize_runner_args(esp32 "--esp-flash-bootloader=${CMAKE_BINARY_DIR}/bootloader.bin")
-
-  board_finalize_runner_args(esp32 "--esp-flash-partition_table=${CMAKE_BINARY_DIR}/partition-table.bin")
-
-  board_finalize_runner_args(esp32 "--esp-partition-table-address=0x8000")
-
-endif()
-
-if(CONFIG_MCUBOOT OR CONFIG_BOOTLOADER_ESP_IDF)
+# This includes CONFIG_MCUBOOT and CONFIG_ESP_SIMPLE_BOOT
+if(NOT CONFIG_BOOTLOADER_MCUBOOT)
 
   if(CONFIG_BUILD_OUTPUT_BIN)
+
+    set(ESPTOOL_PY ${ESP_IDF_PATH}/tools/esptool_py/esptool.py)
+    message("esptool path: ${ESPTOOL_PY}")
+
+    set(ELF2IMAGE_ARG "")
+    if(NOT CONFIG_MCUBOOT)
+      set(ELF2IMAGE_ARG "--ram-only-header")
+    endif()
+
     set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
-      COMMAND ${PYTHON_EXECUTABLE} ${ESP_IDF_PATH}/tools/esptool_py/esptool.py
-      ARGS --chip esp32 elf2image --flash_mode dio --flash_freq 40m --flash_size ${esptoolpy_flashsize}MB
+      COMMAND ${PYTHON_EXECUTABLE} ${ESPTOOL_PY}
+      ARGS --chip esp32 elf2image ${ELF2IMAGE_ARG}
+      --flash_mode dio --flash_freq 40m
+      --flash_size ${esptoolpy_flashsize}MB
       -o ${CMAKE_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.bin
       ${CMAKE_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.elf)
-  endif()
-
-  if(CONFIG_MCUBOOT)
-    board_finalize_runner_args(esp32 "--esp-flash-bootloader=${CMAKE_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.bin")
   endif()
 
 endif()
@@ -71,18 +58,36 @@ if (CONFIG_SOC_ESP32_APPCPU)
   endif()
 
 else()
-  set_property(TARGET bintools PROPERTY disassembly_flag_inline_source)
 
-  # get code-partition slot0 address
-  dt_nodelabel(dts_partition_path NODELABEL "slot0_partition")
-  dt_reg_addr(img_0_off PATH ${dts_partition_path})
+  set_property(TARGET bintools PROPERTY disassembly_flag_inline_source)
 
   # get code-partition boot address
   dt_nodelabel(dts_partition_path NODELABEL "boot_partition")
   dt_reg_addr(boot_off PATH ${dts_partition_path})
 
-  board_finalize_runner_args(esp32 "--esp-boot-address=${boot_off}")
-  board_finalize_runner_args(esp32 "--esp-app-address=${img_0_off}")
+  # get code-partition slot0 address
+  dt_nodelabel(dts_partition_path NODELABEL "slot0_partition")
+  dt_reg_addr(img_0_off PATH ${dts_partition_path})
+
+  if(CONFIG_ESP_SIMPLE_BOOT)
+    board_finalize_runner_args(esp32 "--esp-app-address=${boot_off}")
+  else()
+    board_finalize_runner_args(esp32 "--esp-app-address=${img_0_off}")
+  endif()
+
+endif()
+
+if(CONFIG_MCUBOOT)
+    # search from cross references between bootloader sections
+    message("check_callgraph using: ${ESP_IDF_PATH}/tools/ci/check_callgraph.py")
+    set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+      COMMAND
+        ${PYTHON_EXECUTABLE} ${ESP_IDF_PATH}/tools/ci/check_callgraph.py
+      ARGS
+        --rtl-dirs ${CMAKE_BINARY_DIR}/zephyr
+	--elf-file ${CMAKE_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.elf
+        find-refs --from-section=.iram0.iram_loader --to-section=.iram0.text
+        --exit-code)
 endif()
 
 if(CONFIG_MCUBOOT)

--- a/soc/espressif/esp32/default.ld
+++ b/soc/espressif/esp32/default.ld
@@ -1,15 +1,8 @@
 /*
  * Copyright (c) 2016 Cadence Design Systems, Inc.
  * Copyright (c) 2017 Intel Corporation
- * Copyright (c) 2020 Espressif Systems (Shanghai) Co., Ltd.
+ * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
  * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
- * @file
- * @brief Linker command/script file
- *
- * Linker script for the Xtensa platform.
  */
 
 #include <zephyr/devicetree.h>
@@ -17,34 +10,39 @@
 #include <zephyr/linker/linker-defs.h>
 #include <zephyr/linker/linker-tool.h>
 
-#define RAMABLE_REGION dram0_0_seg
-#ifdef CONFIG_SOC_ENABLE_APPCPU
-#define RAMABLE_REGION_1 dram0_0_seg
-#else
-#define RAMABLE_REGION_1 dram0_1_seg
-#endif
-#define RODATA_REGION drom0_0_seg
-#define IRAM_REGION iram0_0_seg
-#define FLASH_CODE_REGION irom0_0_seg
+#include "memory.h"
 
-#define ROMABLE_REGION ROM
-
-#ifdef CONFIG_FLASH_SIZE
-#define FLASH_SIZE CONFIG_FLASH_SIZE
+/* The "user_iram_end" represents the 2nd stage bootloader
+ * "dram_seg" end address (that should not be overlapped).
+ * If no bootloader is used we extend it to gain more user ram.
+ */
+#ifdef CONFIG_ESP_SIMPLE_BOOT
+user_iram_end = SRAM1_DRAM_IRAM_CALC(SRAM1_DRAM_USABLE_START);
 #else
-#define FLASH_SIZE 0x400000
+user_iram_end = SRAM1_DRAM_IRAM_CALC(BOOTLOADER_DRAM_SEG_END);
 #endif
 
-#ifdef CONFIG_BOOTLOADER_ESP_IDF
-#define IROM_SEG_ORG 0x400D0020
-#define IROM_SEG_LEN FLASH_SIZE-0x20
-#define IROM_SEG_ALIGN 0x4
+/* User available SRAM memory segments */
+user_iram_seg_org = (SRAM0_IRAM_START + SRAM0_CACHE_SIZE);
+user_iram_seg_len = user_iram_end - user_iram_seg_org;
+user_dram_seg_org = SRAM2_DRAM_USABLE_START;
+user_dram_seg_len = SRAM2_USABLE_SIZE;
+user_dram_2_seg_org = SRAM1_DRAM_USABLE_START;
+user_dram_2_seg_len = SRAM1_USABLE_SIZE;
+
+/* Aliases */
+#define FLASH_CODE_REGION   irom0_0_seg
+#define RODATA_REGION       drom0_0_seg
+#define IRAM_REGION         iram0_0_seg
+#define DRAM_REGION         dram0_0_seg
+#define RAMABLE_REGION      dram0_0_seg
+#define ROMABLE_REGION      FLASH
+
+#ifndef CONFIG_SOC_ESP32_PROCPU
+#define RAMABLE_REGION_1    dram0_1_seg
 #else
-#define IROM_SEG_ORG 0x400D0000
-#define IROM_SEG_LEN FLASH_SIZE
-#define IROM_SEG_ALIGN 0x10000
+#define RAMABLE_REGION_1    dram0_0_seg
 #endif
-#define IRAM_SEG_LEN 0x20000
 
 /* Flash segments (rodata and text) should be mapped in virtual address space by providing VMA.
  * Executing directly from LMA is not possible. */
@@ -53,57 +51,53 @@
 
 MEMORY
 {
-  mcuboot_hdr (RX): org = 0x0, len = 0x20
-  metadata (RX): org = 0x20, len = 0x20
-  ROM (RX): org = 0x40, len = FLASH_SIZE - 0x40
+#ifdef CONFIG_BOOTLOADER_MCUBOOT
+  mcuboot_hdr (R): org = 0x0,  len = 0x20
+  metadata (R):    org = 0x20, len = 0x20
+  FLASH (R):       org = 0x40, len = FLASH_SIZE - 0x40
+#else
+  /* Make safety margin in the FLASH memory size so the
+   * (esp_img_header + (n*esp_seg_headers)) would fit */
+  FLASH (R):       org = 0x0,  len = FLASH_SIZE - 0x100
+#endif /* CONFIG_BOOTLOADER_MCUBOOT */
 
-  #ifdef CONFIG_SOC_ENABLE_APPCPU
-  iram0_0_seg(RX): org = 0x40080000, len = 0x08000
-  #else
-  iram0_0_seg(RX): org = 0x40080000, len = IRAM_SEG_LEN
-  #endif
+#ifndef CONFIG_SOC_ESP32_APPCPU
+  iram0_0_seg(RX): org = user_iram_seg_org, len = user_iram_seg_len
+#else
+  iram0_0_seg(RX): org = user_iram_seg_org, len = 0x8000
+#endif /* CONFIG_SOC_ESP32_APPCPU */
+
+  dram0_0_seg(RW): org = user_dram_seg_org + CONFIG_ESP32_BT_RESERVE_DRAM,
+                   len = user_dram_seg_len - CONFIG_ESP32_BT_RESERVE_DRAM
+
+#ifdef CONFIG_SOC_ESP32_PROCPU
+  /* shared RAM reserved for IPM */
+  dram0_shm0_seg(RW): org = 0x3ffe5230, len = 2K
+  /* shared data reserved for IPM data header */
+  dram0_sem0_seg(RW): org = 0x3ffe5a30, len = 8
+  /* for AMP builds dram0_1 is reserved for network core */
+  dram0_1_seg(RW):    org = 0x3ffe5a38, len = 0K
+#else
+  /* skip data for APP CPU initialization usage */
+  dram0_1_seg(RW):    org = user_dram_2_seg_org, len = user_dram_2_seg_len
+#endif /* CONFIG_SOC_ESP32_PROCPU */
 
   irom0_0_seg(RX): org = IROM_SEG_ORG, len = IROM_SEG_LEN
-  /*
-   * Following is DRAM memory split with reserved address ranges in ESP32:
-   *
-   * 0x3FFA_E000 - 0x3FFB_0000 (Reserved: data memory for ROM functions)
-   * 0x3FFB_0000 - 0x3FFE_0000 (RAM bank 1 for application usage)
-   * 0x3FFE_0000 - 0x3FFE_0440 (Reserved: data memory for ROM PRO CPU)
-   * 0x3FFE_3F20 - 0x3FFE_4350 (Reserved: data memory for ROM APP CPU)
-   * 0x3FFE_4350 - 0x3F10_0000 (RAM bank 2 for application usage)
-   *
-   * FIXME:
-   *  - Utilize available memory regions to full capacity
-   */
-  dram0_0_seg(RW): org = 0x3FFB0000 + CONFIG_ESP32_BT_RESERVE_DRAM, len = 0x2c200 - CONFIG_ESP32_BT_RESERVE_DRAM
+  drom0_0_seg(R):  org = DROM_SEG_ORG, len = DROM_SEG_LEN
 
-  #ifdef CONFIG_SOC_ENABLE_APPCPU
-  dram0_shm0_seg(RW): org = 0x3FFE5230, len = 2K /* shared RAM reserved for IPM */
-  dram0_sem0_seg(RW): org = 0x3FFE5A30, len = 8 /* shared data reserved for IPM data header */
-  dram0_1_seg(RW): org = 0x3FFE5A38, len = 0K /* for AMP builds dram0_1 is reserved for network core */
-  #else
-  dram0_1_seg(RW): org = 0x3FFE5230, len = 0x1BCB0 - 0xEE0 /* skip data for APP CPU initialization usage */
-  #endif
+  rtc_iram_seg(RWX): org = 0x400c0000, len = 0x2000
+  rtc_slow_seg(RW):  org = 0x50000000, len = 0x1000
 
-  /* DROM is the first segment placed in generated binary.
-   * MCUboot binary for ESP32 has image header of 0x20 bytes.
-   * Additional load header of 0x20 bytes are appended to the image.
-   * Hence, an offset of 0x40 is added to DROM segment origin.
-   */
-  drom0_0_seg(R): org = 0x3F400040, len = 0x400000 - 0x40
-  rtc_iram_seg(RWX): org = 0x400C0000, len = 0x2000
-  rtc_slow_seg(RW): org = 0x50000000, len = 0x1000
-#if defined(CONFIG_ESP_SPIRAM)
-  ext_ram_seg(RW): org = 0x3F800000, len = CONFIG_ESP_SPIRAM_SIZE
-#endif
+#ifdef CONFIG_ESP_SPIRAM
+  ext_ram_seg(RW): org = 0x3f800000, len = CONFIG_ESP_SPIRAM_SIZE
+#endif /* CONFIG_ESP_SPIRAM */
+
 #ifdef CONFIG_GEN_ISR_TABLES
   IDT_LIST(RW): org = 0x3ebfe010, len = 0x2000
-#endif
+#endif /* CONFIG_GEN_ISR_TABLES */
 }
 
 /*  Default entry point:  */
-PROVIDE ( _ResetVector = 0x40000400 );
 ENTRY(CONFIG_KERNEL_ENTRY)
 
 _rom_store_table = 0;
@@ -111,8 +105,15 @@ _rom_store_table = 0;
 PROVIDE(_memmap_vecbase_reset = 0x40000450);
 PROVIDE(_memmap_reset_vector = 0x40000400);
 
+#ifdef CONFIG_BT
+_heap_sentry = SRAM1_DRAM_USABLE_START;
+#else
+_heap_sentry = DRAM1_BT_SHM_BUFFERS_START; /* was 0x3ffe3f20; */
+#endif
+
 SECTIONS
 {
+#ifdef CONFIG_BOOTLOADER_MCUBOOT
   /* Reserve space for MCUboot header in the binary */
   .mcuboot_header :
   {
@@ -123,211 +124,91 @@ SECTIONS
   } > mcuboot_hdr
   .metadata :
   {
-    /* Magic byte for load header */
+    /* 0. Magic byte for load header */
     LONG(0xace637d3)
 
-    /* Application entry point address */
+    /* 1. Application entry point address */
     KEEP(*(.entry_addr))
 
-    /* IRAM metadata:
-     * - Destination address (VMA) for IRAM region
-     * - Flash offset (LMA) for start of IRAM region
-     * - Size of IRAM region
+    /* IRAM load:
+     * 2. Destination address (VMA) for IRAM region
+     * 3. Flash offset (LMA) for start of IRAM region
+     * 4. Size of IRAM region
      */
-
     LONG(ADDR(.iram0.vectors))
     LONG(LOADADDR(.iram0.vectors))
-    LONG(LOADADDR(_TEXT_SECTION_NAME) + SIZEOF(_TEXT_SECTION_NAME) - LOADADDR(.iram0.vectors))
+    LONG(LOADADDR(.iram0.text) + SIZEOF(.iram0.text) - LOADADDR(.iram0.vectors))
 
-    /* DRAM metadata:
-     * - Destination address (VMA) for DRAM region
-     * - Flash offset (LMA) for start of DRAM region
-     * - Size of DRAM region
+    /* DRAM load:
+     * 5. Destination address (VMA) for DRAM region
+     * 6. Flash offset (LMA) for start of DRAM region
+     * 7. Size of DRAM region
      */
-
     LONG(ADDR(.dram0.data))
     LONG(LOADADDR(.dram0.data))
     LONG(LOADADDR(.dram0.end) + SIZEOF(.dram0.end) - LOADADDR(.dram0.data))
   } > metadata
+#endif /* CONFIG_BOOTLOADER_MCUBOOT */
 
-#include <zephyr/linker/rel-sections.ld>
+  #include <zephyr/linker/rel-sections.ld>
 
-  _image_drom_start = LOADADDR(_RODATA_SECTION_NAME);
-  _image_drom_size = LOADADDR(_RODATA_SECTION_END) + SIZEOF(_RODATA_SECTION_END)  - _image_drom_start;
-  _image_drom_vaddr = ADDR(_RODATA_SECTION_NAME);
+  /* --- RTC BEGIN --- */
 
-  /* NOTE: .rodata section should be the first section in the linker script and no
-   * other section should appear before .rodata section. This is the requirement
-   * to align ROM section to 64K page offset.
-   * Adding .rodata as first section helps to reduce size of generated binary by
-   * few kBs.
+  /* RTC fast memory holds RTC wake stub code,
+   * including from any source file named rtc_wake_stub*.c
    */
-  SECTION_PROLOGUE(_RODATA_SECTION_NAME,,)
-  {
-    __rodata_region_start = ABSOLUTE(.);
-    _rodata_reserved_start = ABSOLUTE(.);  /* This is a symbol marking the flash.rodata start, this can be used for mmu driver to maintain virtual address */
-
-    . = ALIGN(4);
-    #include <snippets-rodata.ld>
-
-    . = ALIGN(4);
-    *(EXCLUDE_FILE (*libarch__xtensa__core.a:* *libkernel.a:fatal.* *libkernel.a:init.* *libzephyr.a:cbprintf_complete* *libzephyr.a:log_core.* *libzephyr.a:log_backend_uart.* *libdrivers__flash.a:esp32_mp.* *libzephyr.a:log_output.* *libzephyr.a:loader.* *libdrivers__flash.a:flash_esp32.* *libdrivers__serial.a:uart_esp32.* *libzephyr.a:spi_flash_rom_patch.*) .rodata)
-    *(EXCLUDE_FILE (*libarch__xtensa__core.a:* *libkernel.a:fatal.* *libkernel.a:init.* *libzephyr.a:cbprintf_complete* *libzephyr.a:log_core.* *libzephyr.a:log_backend_uart.* *libdrivers__flash.a:esp32_mp.* *libzephyr.a:log_output.* *libzephyr.a:loader.* *libdrivers__flash.a:flash_esp32.* *libdrivers__serial.a:uart_esp32.* *libzephyr.a:spi_flash_rom_patch.*) .rodata.*)
-
-    *(.irom1.text) /* catch stray ICACHE_RODATA_ATTR */
-    *(.gnu.linkonce.r.*)
-    *(.rodata1)
-    __XT_EXCEPTION_TABLE_ = ABSOLUTE(.);
-    *(.xt_except_table)
-    *(.gcc_except_table .gcc_except_table.*)
-    *(.gnu.linkonce.e.*)
-    *(.gnu.version_r)
-    . = (. + 3) & ~ 3;
-    __eh_frame = ABSOLUTE(.);
-    KEEP(*(.eh_frame))
-    . = (. + 7) & ~ 3;
-
-    /*  C++ exception handlers table:  */
-    __XT_EXCEPTION_DESCS_ = ABSOLUTE(.);
-    *(.xt_except_desc)
-    *(.gnu.linkonce.h.*)
-    __XT_EXCEPTION_DESCS_END__ = ABSOLUTE(.);
-    *(.xt_except_desc_end)
-    *(.dynamic)
-    *(.gnu.version_d)
-    . = ALIGN(4);
-    __rodata_region_end = ABSOLUTE(.);
-    /* Literals are also RO data. */
-    _lit4_start = ABSOLUTE(.);
-    *(*.lit4)
-    *(.lit4.*)
-    *(.gnu.linkonce.lit4.*)
-    _lit4_end = ABSOLUTE(.);
-    . = ALIGN(4);
-    *(.rodata_wlog)
-    *(.rodata_wlog*)
-    . = ALIGN(4);
-  } GROUP_DATA_LINK_IN(RODATA_REGION, ROMABLE_REGION)
-
-  #include <zephyr/linker/common-rom/common-rom-cpp.ld>
-  #include <zephyr/linker/common-rom/common-rom-kernel-devices.ld>
-  #include <zephyr/linker/common-rom/common-rom-ztest.ld>
-  #include <zephyr/linker/common-rom/common-rom-net.ld>
-  #include <zephyr/linker/common-rom/common-rom-bt.ld>
-  #include <zephyr/linker/common-rom/common-rom-debug.ld>
-  #include <zephyr/linker/common-rom/common-rom-misc.ld>
-  #include <zephyr/linker/thread-local-storage.ld>
-  #include <snippets-sections.ld>
-
-  /* Create an explicit section at the end of all the data that shall be mapped into drom.
-   * This is used to calculate the size of the _image_drom_size variable */
-  SECTION_PROLOGUE(_RODATA_SECTION_END,,)
+  .rtc.text :
   {
     . = ALIGN(4);
-    _image_rodata_end = ABSOLUTE(.);
-    _rodata_reserved_end = ABSOLUTE(.);
-  } GROUP_DATA_LINK_IN(RODATA_REGION, ROMABLE_REGION)
+    *(.rtc.literal .rtc.text)
+    *rtc_wake_stub*.o(.literal .text .literal.* .text.*)
+  } GROUP_DATA_LINK_IN(rtc_iram_seg, ROMABLE_REGION)
 
-  _image_dram_start = LOADADDR(.dram0.data);
-  _image_dram_size = LOADADDR(.dram0.end) + SIZEOF(.dram0.end) - _image_dram_start;
-  _image_dram_vaddr = ADDR(.dram0.data);
-
-  .dram0.data :
+  /* RTC slow memory holds RTC wake stub
+   * data/rodata, including from any source file
+   * named rtc_wake_stub*.c
+   */
+  .rtc.data :
   {
-    __data_start = ABSOLUTE(.);
+    _rtc_data_start = ABSOLUTE(.);
+    *(.rtc.data)
+    *(.rtc.rodata)
+    *rtc_wake_stub*.o(.data .rodata .data.* .rodata.* .bss .bss.*)
+    _rtc_data_end = ABSOLUTE(.);
+  } GROUP_DATA_LINK_IN(rtc_slow_seg, ROMABLE_REGION)
 
-    _btdm_data_start = ABSOLUTE(.);
-    *libbtdm_app.a:(.data .data.*)
-    . = ALIGN (4);
-    _btdm_data_end = ABSOLUTE(.);
+  /* RTC bss, from any source file named rtc_wake_stub*.c */
+  .rtc.bss (NOLOAD) :
+  {
+    _rtc_bss_start = ABSOLUTE(.);
+    *rtc_wake_stub*.o(.bss .bss.*)
+    *rtc_wake_stub*.o(COMMON)
+    _rtc_bss_end = ABSOLUTE(.);
+  } GROUP_LINK_IN(rtc_slow_seg)
 
-    *(.data)
-    *(.data.*)
-    *(.gnu.linkonce.d.*)
-    *(.data1)
-    *(.sdata)
-    *(.sdata.*)
-    *(.gnu.linkonce.s.*)
-    *(.sdata2)
-    *(.sdata2.*)
-    *(.gnu.linkonce.s2.*)
-    /* rodata for panic handler(libarch__xtensa__core.a) and all
-     * dependent functions should be placed in DRAM to avoid issue
-     * when flash cache is disabled */
-    *libarch__xtensa__core.a:(.rodata .rodata.*)
-    *libkernel.a:fatal.*(.rodata .rodata.*)
-    *libkernel.a:init.*(.rodata .rodata.*)
-    *libzephyr.a:cbprintf_complete*(.rodata .rodata.*)
-    *libzephyr.a:log_core.*(.rodata .rodata.*)
-    *libzephyr.a:log_backend_uart.*(.rodata .rodata.*)
-    *libzephyr.a:log_output.*(.rodata .rodata.*)
-    *libzephyr.a:mmu_hal.*(.rodata .rodata.*)
-    *libzephyr.a:loader.*(.rodata .rodata.*)
-    *libdrivers__flash.a:flash_esp32.*(.rodata .rodata.*)
-    *libzephyr.a:spi_flash_rom_patch.*(.rodata  .rodata.*)
-    *libdrivers__serial.a:uart_esp32.*(.rodata .rodata.*)
-    *libzephyr.a:esp_memory_utils.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:rtc_clk.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-
-    *libzephyr.a:cache_esp32.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:esp_cache.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:esp_rom_spiflash.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:esp_err.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:i2c_hal_iram.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:ledc_hal_iram.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:mmu_hal.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:spi_flash_encrypt_hal_iram.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:spi_flash_hal_iram.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:spi_flash_hal_common.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:spi_hal_iram.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:spi_slave_hal_iram.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:wdt_hal_iram.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:flash_brownout_hook.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:memspi_host_driver.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:spi_flash_chip_boya.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:spi_flash_chip_gd.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:spi_flash_chip_generic.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:spi_flash_chip_issi.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:spi_flash_chip_mxic.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:spi_flash_chip_th.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:spi_flash_chip_winbond.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:spi_flash_wrap.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:heap_caps_zephyr.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-
-    KEEP(*(.jcr))
-    *(.dram1 .dram1.*)
-    . = ALIGN(4);
-  } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
-
-  #include <zephyr/linker/cplusplus-rom.ld>
-  #include <snippets-data-sections.ld>
-  #include <zephyr/linker/common-ram.ld>
-  #include <snippets-ram-sections.ld>
-  #include <zephyr/linker/cplusplus-ram.ld>
-
-  /* logging sections should be placed in RAM area to avoid flash cache disabled issues */
-  #pragma push_macro("GROUP_ROM_LINK_IN")
-  #undef GROUP_ROM_LINK_IN
-  #define GROUP_ROM_LINK_IN GROUP_DATA_LINK_IN
-  #include <zephyr/linker/common-rom/common-rom-logging.ld>
-  #pragma pop_macro("GROUP_ROM_LINK_IN")
-
-  .dram0.end :
+  /* This section located in RTC SLOW Memory area.
+   * It holds data marked with RTC_SLOW_ATTR attribute.
+   * See the file "esp_attr.h" for more information.
+   */
+  .rtc.force_slow :
   {
     . = ALIGN(4);
-    #include <snippets-rwdata.ld>
-    . = ALIGN(4);
-    _end = ABSOLUTE(.);
-    __data_end = ABSOLUTE(.);
-  } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+    _rtc_force_slow_start = ABSOLUTE(.);
+    *(.rtc.force_slow .rtc.force_slow.*)
+    . = ALIGN(4) ;
+    _rtc_force_slow_end = ABSOLUTE(.);
+  } > rtc_slow_seg
 
-  _image_iram_start = LOADADDR(.iram0.vectors);
-  _image_iram_size = LOADADDR(_TEXT_SECTION_NAME) + SIZEOF(_TEXT_SECTION_NAME) - _image_iram_start;
-  _image_iram_vaddr = ADDR(.iram0.vectors);
+  /* Get size of rtc slow data */
+  _rtc_slow_length = (_rtc_force_slow_end - _rtc_data_start);
 
-  /* Send .iram0 code to iram */
+  /* --- RTC END --- */
+
+  /* --- IRAM BEGIN --- */
+
   .iram0.vectors : ALIGN(4)
   {
+    _iram_start = ABSOLUTE(.);
     /* Vectors go to IRAM */
     _init_start = ABSOLUTE(.);
     /* Vectors according to builds/RF-2015.2-win32/esp108_v1_2_s5_512int_2/config.html */
@@ -361,175 +242,424 @@ SECTIONS
     *(.init.literal)
     *(.init)
     _init_end = ABSOLUTE(.);
-
-    /* This goes here, not at top of linker script, so addr2line finds it last,
-       and uses it in preference to the first symbol in IRAM */
-    _iram_start = ABSOLUTE(0);
   } GROUP_DATA_LINK_IN(IRAM_REGION, ROMABLE_REGION)
 
-  SECTION_PROLOGUE(_TEXT_SECTION_NAME, , ALIGN(4))
+  .iram0.text : ALIGN(4)
   {
     /* Code marked as running out of IRAM */
     _iram_text_start = ABSOLUTE(.);
     *(.iram1 .iram1.*)
     *(.iram0.literal .iram.literal .iram.text.literal .iram0.text .iram.text)
-    *libesp32.a:panic.*(.literal .text .literal.* .text.*)
-    *librtc.a:(.literal .text .literal.* .text.*)
     *libarch__xtensa__core.a:(.literal .text .literal.* .text.*)
     *libkernel.a:(.literal .text .literal.* .text.*)
-    *libsoc.a:rtc_*.*(.literal .text .literal.* .text.*)
-    *libsoc.a:cpu_util.*(.literal .text .literal.* .text.*)
     *libgcc.a:lib2funcs.*(.literal .text .literal.* .text.*)
-    *libdrivers__flash.a:flash_esp32.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:spi_flash_rom_patch.*(.literal .text .literal.* .text.*)
     *libzephyr.a:windowspill_asm.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:log_noos.*(.literal .text .literal.* .text.*)
-    *libdrivers__timer.a:xtensa_sys_timer.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:log_core.*(.literal .text .literal.* .text.*)
     *libzephyr.a:cbprintf_complete.*(.literal .text .literal.* .text.*)
     *libzephyr.a:printk.*(.literal.printk .literal.vprintk .literal.char_out .text.printk .text.vprintk .text.char_out)
+    *libzephyr.a:log_noos.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:log_core.*(.literal .text .literal.* .text.*)
     *libzephyr.a:log_msg.*(.literal .text .literal.* .text.*)
     *libzephyr.a:log_list.*(.literal .text .literal.* .text.*)
-    *libdrivers__console.a:uart_console.*(.literal.console_out .text.console_out)
     *libzephyr.a:log_output.*(.literal .text .literal.* .text.*)
     *libzephyr.a:log_backend_uart.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:mmu_hal.*(.literal .text .literal.* .text.*)
     *libzephyr.a:loader.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:rtc_*.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:cpu_util.*(.literal .text .literal.* .text.*)
+    *libdrivers__flash.a:flash_esp32.*(.literal .text .literal.* .text.*)
+    *libdrivers__timer.a:xtensa_sys_timer.*(.literal .text .literal.* .text.*)
+    *libdrivers__console.a:uart_console.*(.literal.console_out .text.console_out)
+    *liblib__libc__picolib.a:abort.*(.literal .text .literal.* .text.*)
     *liblib__libc__minimal.a:string.*(.literal .text .literal.* .text.*)
     *liblib__libc__newlib.a:string.*(.literal .text .literal.* .text.*)
     *libc.a:*(.literal .text .literal.* .text.*)
     *libphy.a:( .phyiram .phyiram.*)
     *libgcov.a:(.literal .text .literal.* .text.*)
-    *libzephyr.a:cpu.*(.literal.esp_cpu_compare_and_set .text.esp_cpu_compare_and_set)
-    *libzephyr.a:cpu.*(.literal.esp_cpu_reset .text.esp_cpu_reset)
-    *libzephyr.a:cpu.*(.literal.esp_cpu_stall .text.esp_cpu_stall)
-    *libzephyr.a:cpu.*(.literal.esp_cpu_unstall .text.esp_cpu_unstall)
-    *libzephyr.a:cpu.*(.literal.esp_cpu_wait_for_intr .text.esp_cpu_wait_for_intr)
-    *libzephyr.a:esp_gpio_reserve.*(.literal.esp_gpio_is_pin_reserved .text.esp_gpio_is_pin_reserved)
-    *libzephyr.a:esp_gpio_reserve.*(.literal.esp_gpio_reserve_pins .text.esp_gpio_reserve_pins)
-    *libzephyr.a:esp_memory_utils.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:periph_ctrl.*(.literal.periph_module_reset .text.periph_module_reset)
-    *libzephyr.a:periph_ctrl.*(.literal.wifi_module_disable .text.wifi_module_disable)
-    *libzephyr.a:periph_ctrl.*(.literal.wifi_module_enable .text.wifi_module_enable)
-    *libzephyr.a:rtc_clk.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:rtc_sleep.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:rtc_time.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:rtc_wdt.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:sar_periph_ctrl.*(.literal.sar_periph_ctrl_power_enable .text.sar_periph_ctrl_power_enable)
-    *libzephyr.a:cache_esp32.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:esp_cache.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:esp_rom_spiflash.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:esp_err.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:esp_system_chip.*(.literal.esp_system_abort .text.esp_system_abort)
-    *libzephyr.a:i2c_hal_iram.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:ledc_hal_iram.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:spi_flash_rom_patch.*(.literal .text .literal.* .text.*)
+
+    /* [mapping:esp_psram] */
+    *libzephyr.a:mmu_psram_flash.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:esp_psram_impl_quad.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:esp_psram_impl_octal.*(.literal .literal.* .text .text.*)
+
+    /* [mapping:hal] */
     *libzephyr.a:mmu_hal.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:spi_flash_encrypt_hal_iram.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:spi_flash_hal_iram.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:spi_flash_hal_common.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:spi_hal_iram.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:spi_slave_hal_iram.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:cache_hal.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:ledc_hal_iram.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:i2c_hal_iram.*(.literal .literal.* .text .text.*)
     *libzephyr.a:wdt_hal_iram.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:flash_brownout_hook.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:memspi_host_driver.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:spi_flash_hal_iram.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:spi_flash_encrypt_hal_iram.*(.literal .literal.* .text .text.*)
+
+    /* [mapping:soc] */
+    *libzephyr.a:lldesc.*(.literal .literal.* .text .text.*)
+
+    /* [mapping:log] */
+    *(.literal.esp_log_write .text.esp_log_write)
+    *(.literal.esp_log_timestamp .text.esp_log_timestamp)
+    *(.literal.esp_log_early_timestamp .text.esp_log_early_timestamp)
+    *(.literal.esp_log_impl_lock .text.esp_log_impl_lock)
+    *(.literal.esp_log_impl_lock_timeout .text.esp_log_impl_lock_timeout)
+    *(.literal.esp_log_impl_unlock .text.esp_log_impl_unlock)
+
+    /* [mapping:spi_flash] */
     *libzephyr.a:spi_flash_chip_boya.*(.literal .literal.* .text .text.*)
     *libzephyr.a:spi_flash_chip_gd.*(.literal .literal.* .text .text.*)
     *libzephyr.a:spi_flash_chip_generic.*(.literal .literal.* .text .text.*)
     *libzephyr.a:spi_flash_chip_issi.*(.literal .literal.* .text .text.*)
     *libzephyr.a:spi_flash_chip_mxic.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:spi_flash_chip_mxic_opi.*(.literal .literal.* .text .text.*)
     *libzephyr.a:spi_flash_chip_th.*(.literal .literal.* .text .text.*)
     *libzephyr.a:spi_flash_chip_winbond.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:memspi_host_driver.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:flash_brownout_hook.*(.literal .literal.* .text .text.*)
     *libzephyr.a:spi_flash_wrap.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:spi_flash_hpm_enable.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:spi_flash_oct_flash_init*(.literal .literal.* .text .text.*)
+
+    /* [mapping:esp_system] */
+    *libzephyr.a:esp_err.*(.literal .literal.* .text .text.*)
+    *(.literal.esp_system_abort .text.esp_system_abort)
+
+    /* [mapping:esp_hw_support] */
+    *(.literal.esp_cpu_stall .text.esp_cpu_stall)
+    *(.literal.esp_cpu_unstall .text.esp_cpu_unstall)
+    *(.literal.esp_cpu_reset .text.esp_cpu_reset)
+    *(.literal.esp_cpu_wait_for_intr .text.esp_cpu_wait_for_intr)
+    *(.literal.esp_cpu_compare_and_set .text.esp_cpu_compare_and_set)
+    *(.literal.esp_gpio_reserve_pins .text.esp_gpio_reserve_pins)
+    *(.literal.esp_gpio_is_pin_reserved .text.esp_gpio_is_pin_reserved)
+    *(.literal.rtc_vddsdio_get_config .text.rtc_vddsdio_get_config)
+    *(.literal.rtc_vddsdio_set_config .text.rtc_vddsdio_set_config)
+    *libzephyr.a:esp_memory_utils.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:rtc_init.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:rtc_clk.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:rtc_clk_init.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:rtc_sleep.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:rtc_time.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:systimer.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:mspi_timing_config.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:mspi_timing_tuning.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:periph_ctrl.*(.literal .text .literal.* .text.*)
+    *(.literal.sar_periph_ctrl_power_enable .text.sar_periph_ctrl_power_enable)
+
+/*  TODO: optimize SRAM usage
+    *libzephyr.a:periph_ctrl.*(.literal.periph_module_reset .text.periph_module_reset)
+    *libzephyr.a:periph_ctrl.*(.literal.wifi_module_disable .text.wifi_module_disable)
+    *libzephyr.a:periph_ctrl.*(.literal.wifi_module_enable .text.wifi_module_enable)
+    *libzephyr.a:rtc_wdt.*(.literal .literal.* .text .text.*)
+*/
+    *libzephyr.a:esp_system_chip.*(.literal.esp_system_abort .text.esp_system_abort)
+    *libzephyr.a:spi_hal_iram.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:spi_slave_hal_iram.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:flash_brownout_hook.*(.literal .literal.* .text .text.*)
     *libzephyr.a:heap_caps_zephyr.*(.literal .literal.* .text .text.*)
+
+    /* [mapping:soc_pm] */
+    *(.literal.GPIO_HOLD_MASK .text.GPIO_HOLD_MASK)
+
+    /* [mapping:esp_rom] */
+    *libzephyr.a:esp_rom_spiflash.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:esp_rom_systimer.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:esp_rom_wdt.*(.literal .literal.* .text .text.*)
+
+    /* [mapping:esp_mm] */
+    *libzephyr.a:esp_cache.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:cache_esp32.*(.literal .literal.* .text .text.*)
 
 #if defined(CONFIG_ESP32_WIFI_IRAM_OPT)
     *libnet80211.a:( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.*)
     *libpp.a:( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.* .wifiorslpiram .wifiorslpiram.*)
-#endif
+
+    /* [mapping:esp_wifi] */
+    *(.literal.wifi_clock_enable_wrapper .text.wifi_clock_enable_wrapper)
+    *(.literal.wifi_clock_disable_wrapper .text.wifi_clock_disable_wrapper)
+
+    /* [mapping:esp_phy] */
+    *(.literal.esp_phy_enable .text.esp_phy_enable)
+    *(.literal.esp_phy_disable .text.esp_phy_disable)
+    *(.literal.esp_wifi_bt_power_domain_off .text.esp_wifi_bt_power_domain_off)
+#endif /* CONFIG_ESP32_WIFI_IRAM_OPT */
 
 #if defined(CONFIG_ESP32_WIFI_RX_IRAM_OPT)
     *libnet80211.a:( .wifirxiram  .wifirxiram.* .wifislprxiram .wifislprxiram.*)
     *libpp.a:( .wifirxiram  .wifirxiram.* .wifislprxiram .wifislprxiram.*)
-#endif
+#endif /* CONFIG_ESP32_WIFI_RX_IRAM_OPT */
 
-    _iram_text_end = ABSOLUTE(.);
     . = ALIGN(4);
-    _iram_end = ABSOLUTE(.);
+
   } GROUP_DATA_LINK_IN(IRAM_REGION, ROMABLE_REGION)
 
-  /* RTC fast memory holds RTC wake stub code,
-     including from any source file named rtc_wake_stub*.c
-  */
-  .rtc.text :
+#ifdef CONFIG_ESP_SIMPLE_BOOT
+  .loader.text :
+  {
+    . =  ALIGN(4);
+    *libzephyr.a:bootloader_soc.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_init.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_esp32.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_clock_init.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_wdt.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_flash.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_flash_config_esp32.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_clock_loader.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_common_loader.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_common.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_mem.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_random.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_random*.*(.literal.bootloader_random_disable .text.bootloader_random_disable)
+    *libzephyr.a:bootloader_random*.*(.literal.bootloader_random_enable .text.bootloader_random_enable)
+    *libzephyr.a:bootloader_efuse.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_utility.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_sha.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_console.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_panic.*(.literal .text .literal.* .text.*)
+
+    *libzephyr.a:esp_image_format.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:flash_encrypt.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:flash_encryption_secure_features.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:flash_partitions.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:spi_flash_hal.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:spi_flash_hal_common.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:esp_flash_api.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:esp_flash_spi_init.*(.literal .text .literal.* .text.*)
+
+    *libzephyr.a:secure_boot.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:secure_boot_secure_features.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:secure_boot_signatures_bootloader.*(.literal .text .literal.* .text.*)
+
+    *libzephyr.a:efuse_hal.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:esp_efuse_table.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:esp_efuse_fields.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:esp_efuse_api.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:esp_efuse_utility.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:esp_efuse_api_key_esp32.*(.literal .text .literal.* .text.*)
+
+    *libzephyr.a:app_cpu_start.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:mpu_hal.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:cpu_region_protect.*(.literal .text .literal.* .text.*)
+
+    /* to overcome the bug in esptool making Simple boot compatible image */
+    . += 16;
+    . = ALIGN(16);
+  } GROUP_DATA_LINK_IN(IRAM_REGION, ROMABLE_REGION)
+#endif /* CONFIG_ESP_SIMPLE_BOOT */
+
+  /* Marks the end of IRAM code segment */
+  .iram0.text_end (NOLOAD) :
+  {
+    /* ESP32 memprot requires 16B padding for possible CPU
+     * prefetch and 256B alignment for PMS split lines */
+    . += 16;
+    . = ALIGN(0x100);
+    _iram_text_end = ABSOLUTE(.);
+  } GROUP_LINK_IN(IRAM_REGION)
+
+  .iram0.data :
+  {
+    . = ALIGN(16);
+    *(.iram.data)
+    *(.iram.data*)
+  } GROUP_DATA_LINK_IN(IRAM_REGION, ROMABLE_REGION)
+
+  .iram0.bss (NOLOAD) :
+  {
+    . = ALIGN(16);
+    _iram_bss_start = ABSOLUTE(.);
+    *(.iram.bss)
+    *(.iram.bss.*)
+    _iram_bss_end = ABSOLUTE(.);
+
+    . = ALIGN(4);
+    _iram_end = ABSOLUTE(.);
+  } GROUP_LINK_IN(IRAM_REGION)
+
+  /* --- IRAM END --- */
+
+  /* --- DRAM BEGIN --- */
+
+  .dram0.data :
+  {
+    _dram_data_start = ABSOLUTE(.);
+    _data_start = ABSOLUTE(.);
+
+    _btdm_data_start = ABSOLUTE(.);
+    *libbtdm_app.a:(.data .data.*)
+    . = ALIGN (4);
+    _btdm_data_end = ABSOLUTE(.);
+
+    *(.data)
+    *(.data.*)
+    *(.gnu.linkonce.d.*)
+    *(.data1)
+    *(.sdata)
+    *(.sdata.*)
+    *(.gnu.linkonce.s.*)
+    *(.sdata2)
+    *(.sdata2.*)
+    *(.gnu.linkonce.s2.*)
+    /* rodata for panic handler(libarch__xtensa__core.a) and all
+     * dependent functions should be placed in DRAM to avoid issue
+     * when flash cache is disabled */
+    *libarch__xtensa__core.a:(.rodata .rodata.*)
+    *libkernel.a:fatal.*(.rodata .rodata.*)
+    *libkernel.a:init.*(.rodata .rodata.*)
+    *libzephyr.a:cbprintf_complete*(.rodata .rodata.*)
+    *libzephyr.a:log_core.*(.rodata .rodata.*)
+    *libzephyr.a:log_backend_uart.*(.rodata .rodata.*)
+    *libzephyr.a:log_output.*(.rodata .rodata.*)
+    *libzephyr.a:loader.*(.rodata .rodata.*)
+    *libdrivers__flash.a:flash_esp32.*(.rodata .rodata.*)
+    *libzephyr.a:spi_flash_rom_patch.*(.rodata .rodata.*)
+    *libdrivers__serial.a:uart_esp32.*(.rodata .rodata.*)
+    *libzephyr.a:esp_memory_utils.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+
+    /* [mapping:esp_psram] */
+    *libzephyr.a:mmu_psram_flash.*(.rodata .rodata.*)
+    *libzephyr.a:esp_psram_impl_octal.*(.rodata .rodata.*)
+    *libzephyr.a:esp_psram_impl_quad.*(.rodata .rodata.*)
+
+    /* [mapping:hal] */
+    *libzephyr.a:mmu_hal.*(.rodata .rodata.*)
+    *libzephyr.a:spi_flash_hal_iram.*(.rodata .rodata.*)
+    *libzephyr.a:spi_flash_encrypt_hal_iram.*(.rodata .rodata.*)
+    *libzephyr.a:cache_hal.*(.rodata .rodata.*)
+    *libzephyr.a:ledc_hal_iram.*(.rodata .rodata.*)
+    *libzephyr.a:i2c_hal_iram.*(.rodata .rodata.*)
+    *libzephyr.a:wdt_hal_iram.*(.rodata .rodata.*)
+    *libzephyr.a:systimer_hal.*(.rodata .rodata.*)
+    *libzephyr.a:spi_flash_hal_gpspi.*(.rodata .rodata.*)
+
+    /* [mapping:soc] */
+    *libzephyr.a:lldesc.*(.rodata .rodata.*)
+
+    /* [mapping:log] */
+    *(.rodata.esp_log_write)
+    *(.rodata.esp_log_timestamp)
+    *(.rodata.esp_log_early_timestamp)
+    *(.rodata.esp_log_impl_lock)
+    *(.rodata.esp_log_impl_lock_timeout)
+    *(.rodata.esp_log_impl_unlock)
+
+    /* [mapping:spi_flash] */
+    *libzephyr.a:spi_flash_chip_boya.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:spi_flash_chip_gd.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:spi_flash_chip_generic.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:spi_flash_chip_issi.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:spi_flash_chip_mxic.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:spi_flash_chip_mxic_opi.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:spi_flash_chip_th.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:spi_flash_chip_winbond.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:memspi_host_driver.*(.rodata .rodata.*)
+    *libzephyr.a:flash_brownout_hook.*(.rodata .rodata.*)
+    *libzephyr.a:spi_flash_wrap.*(.rodata .rodata.*)
+    *libzephyr.a:spi_flash_hpm_enable.*(.rodata .rodata.*)
+    *libzephyr.a:spi_flash_oct_flash_init.*(.rodata .rodata.*)
+
+    /* [mapping:esp_mm] */
+    *libzephyr.a:esp_cache.*(.rodata .rodata.*)
+
+    /* [mapping:esp_hw_support] */
+    *(.rodata.esp_cpu_stall)
+    *(.rodata.esp_cpu_unstall)
+    *(.rodata.esp_cpu_reset)
+    *(.rodata.esp_cpu_wait_for_intr)
+    *(.rodata.esp_cpu_compare_and_set)
+    *(.rodata.esp_gpio_reserve_pins)
+    *(.rodata.esp_gpio_is_pin_reserved)
+    *(.rodata.rtc_vddsdio_get_config)
+    *(.rodata.rtc_vddsdio_set_config)
+    *libzephyr.a:esp_memory_utils.*(.rodata .rodata.*)
+    *libzephyr.a:rtc_clk.*(.rodata .rodata.*)
+    *libzephyr.a:rtc_clk_init.*(.rodata .rodata.*)
+    *libzephyr.a:systimer.*(.rodata .rodata.*)
+    *libzephyr.a:mspi_timing_config.*(.rodata .rodata.*)
+    *libzephyr.a:mspi_timing_tuning.*(.rodata .rodata.*)
+    *(.rodata.sar_periph_ctrl_power_enable)
+
+    *libzephyr.a:cache_esp32.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:esp_cache.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:esp_err.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:i2c_hal_iram.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:ledc_hal_iram.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:mmu_hal.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:spi_flash_encrypt_hal_iram.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:spi_flash_hal.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:spi_flash_hal_iram.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:spi_flash_hal_common.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:spi_hal_iram.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:spi_slave_hal_iram.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:flash_brownout_hook.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:memspi_host_driver.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:spi_flash_wrap.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    /* TODO: fix other socs */
+    *libzephyr.a:heap_caps_zephyr.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+
+    /* [mapping:esp_rom] */
+    *libzephyr.a:esp_rom_spiflash.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:esp_rom_systimer.*(.rodata .rodata.*)
+    *libzephyr.a:esp_rom_wdt.*(.rodata .rodata.*)
+
+    KEEP(*(.jcr))
+    *(.dram1 .dram1.*)
+
+    . = ALIGN(4);
+    #include <snippets-rwdata.ld>
+    . = ALIGN(4);
+  } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+
+#ifdef CONFIG_ESP_SIMPLE_BOOT
+  .loader.data :
   {
     . = ALIGN(4);
-    *(.rtc.literal .rtc.text)
-    *rtc_wake_stub*.o(.literal .text .literal.* .text.*)
-  } GROUP_DATA_LINK_IN(rtc_iram_seg, ROMABLE_REGION)
+    _loader_data_start = ABSOLUTE(.);
+    *libzephyr.a:bootloader_init.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:bootloader_esp32.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:bootloader_clock_init.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:bootloader_wdt.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:bootloader_flash.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:bootloader_flash_config_esp32.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:bootloader_common.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:bootloader_common_loader.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:bootloader_efuse.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
 
-  /* RTC slow memory holds RTC wake stub
-     data/rodata, including from any source file
-     named rtc_wake_stub*.c
-  */
-  .rtc.data :
-  {
-    _rtc_data_start = ABSOLUTE(.);
-    *(.rtc.data)
-    *(.rtc.rodata)
-    *rtc_wake_stub*.o(.data .rodata .data.* .rodata.* .bss .bss.*)
-    _rtc_data_end = ABSOLUTE(.);
-  } GROUP_DATA_LINK_IN(rtc_slow_seg, ROMABLE_REGION)
+    *libzephyr.a:cpu_util.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:clk.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:esp_clk.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:rtc_clk_init.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:rtc_time.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:efuse_hal.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:cpu_region_protect.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
 
-  /* RTC bss, from any source file named rtc_wake_stub*.c */
-  .rtc.bss (NOLOAD) :
-  {
-    _rtc_bss_start = ABSOLUTE(.);
-    *rtc_wake_stub*.o(.bss .bss.*)
-    *rtc_wake_stub*.o(COMMON)
-    _rtc_bss_end = ABSOLUTE(.);
-  } GROUP_LINK_IN(rtc_slow_seg)
+    *libzephyr.a:periph_ctrl.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
 
-  /* This section located in RTC SLOW Memory area.
-     It holds data marked with RTC_SLOW_ATTR attribute.
-     See the file "esp_attr.h" for more information.
-  */
-  .rtc.force_slow :
-  {
+    *libzephyr.a:esp_flash_api.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:esp_flash_spi_init.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+
     . = ALIGN(4);
-    _rtc_force_slow_start = ABSOLUTE(.);
-    *(.rtc.force_slow .rtc.force_slow.*)
-    . = ALIGN(4) ;
-    _rtc_force_slow_end = ABSOLUTE(.);
-  } > rtc_slow_seg
+    _loader_data_end = ABSOLUTE(.);
+  } GROUP_DATA_LINK_IN(DRAM_REGION, ROMABLE_REGION)
+#endif /* CONFIG_ESP_SIMPLE_BOOT */
 
-  /* Get size of rtc slow data */
-  _rtc_slow_length = (_rtc_force_slow_end - _rtc_data_start);
+  #include <zephyr/linker/cplusplus-rom.ld>
+  #include <snippets-data-sections.ld>
+  #include <zephyr/linker/common-ram.ld>
+  #include <snippets-ram-sections.ld>
+  #include <zephyr/linker/cplusplus-ram.ld>
 
-#if defined(CONFIG_ESP_SPIRAM)
-  .ext_ram.bss (NOLOAD):
+  /* logging sections should be placed in RAM area to avoid flash cache disabled issues */
+  #pragma push_macro("GROUP_ROM_LINK_IN")
+  #undef GROUP_ROM_LINK_IN
+  #define GROUP_ROM_LINK_IN GROUP_DATA_LINK_IN
+  #include <zephyr/linker/common-rom/common-rom-logging.ld>
+  #pragma pop_macro("GROUP_ROM_LINK_IN")
+
+  .dram0.end :
   {
-    _ext_ram_data_start = ABSOLUTE(.);
-
-#if defined(CONFIG_ESP32_WIFI_NET_ALLOC_SPIRAM)
-    *libdrivers__wifi.a:(.noinit .noinit.*)
-    *libsubsys__net__l2__ethernet.a:(.noinit .noinit.*)
-    *libsubsys__net__lib__config.a:(.noinit .noinit.*)
-    *libsubsys__net__ip.a:(.noinit .noinit.*)
-    *libsubsys__net.a:(.noinit .noinit.*)
-#endif
-    _ext_ram_bss_start = ABSOLUTE(.);
-    *(.ext_ram.bss*)
-    _ext_ram_bss_end = ABSOLUTE(.);
-
-    _spiram_heap_start = ABSOLUTE(.);
-    . = . + CONFIG_ESP_SPIRAM_HEAP_SIZE;
-
-    _ext_ram_data_end = ABSOLUTE(.);
-  } GROUP_LINK_IN(ext_ram_seg)
-#endif
+    __data_end = ABSOLUTE(.);
+    _data_end = ABSOLUTE(.);
+  } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
   /* Shared RAM */
-  SECTION_DATA_PROLOGUE(_BSS_SECTION_NAME,(NOLOAD),)
+  .dram0.bss (NOLOAD) :
   {
     . = ALIGN (8);
     _bss_start = ABSOLUTE(.); /* required by bluetooth library */
@@ -559,13 +689,13 @@ SECTIONS
     *(COMMON)
     . = ALIGN (8);
     __bss_end = ABSOLUTE(.);
-    _end = ABSOLUTE(.);
+    _bss_end = ABSOLUTE(.);
   } GROUP_LINK_IN(RAMABLE_REGION)
 
   ASSERT(((__bss_end - ORIGIN(dram0_0_seg)) <= LENGTH(dram0_0_seg)),
           "DRAM segment data does not fit.")
 
-  SECTION_DATA_PROLOGUE(_NOINIT_SECTION_NAME, (NOLOAD),)
+  .dram0.noinit (NOLOAD) :
   {
     . = ALIGN (8);
     *(.noinit)
@@ -573,40 +703,173 @@ SECTIONS
     . = ALIGN (8);
   } GROUP_LINK_IN(RAMABLE_REGION_1)
 
+  .dram0.end (NOLOAD) :
+  {
+    . = ALIGN(4);
+    _end = ABSOLUTE(.);
+  } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+
+  /* TODO: Provide total SRAM usage, including IRAM and DRAM */
+  /* _image_ram_start = _iram_start - IRAM_DRAM_OFFSET; */
+  /* #include <zephyr/linker/ram-end.ld> */
+
+  /* --- DRAM END --- */
+
+  /* --- SPIRAM BEGIN --- */
+
+#ifdef CONFIG_ESP_SPIRAM
+  .ext_ram.bss (NOLOAD):
+  {
+    _ext_ram_data_start = ABSOLUTE(.);
+
+#ifdef CONFIG_ESP32_WIFI_NET_ALLOC_SPIRAM
+    *libdrivers__wifi.a:(.noinit .noinit.*)
+    *libsubsys__net__l2__ethernet.a:(.noinit .noinit.*)
+    *libsubsys__net__lib__config.a:(.noinit .noinit.*)
+    *libsubsys__net__ip.a:(.noinit .noinit.*)
+    *libsubsys__net.a:(.noinit .noinit.*)
+#endif /* CONFIG_ESP32_WIFI_NET_ALLOC_SPIRAM */
+
+    _ext_ram_bss_start = ABSOLUTE(.);
+    *(.ext_ram.bss*)
+    _ext_ram_bss_end = ABSOLUTE(.);
+    _spiram_heap_start = ABSOLUTE(.);
+    . = . + CONFIG_ESP_SPIRAM_HEAP_SIZE;
+
+    _ext_ram_data_end = ABSOLUTE(.);
+  } GROUP_LINK_IN(ext_ram_seg)
+#endif /* CONFIG_ESP_SPIRAM */
+
+  /* --- SPIRAM END --- */
+
+  /* --- RODATA BEGIN --- */
+
+  .flash.rodata_dummy (NOLOAD) :
+  {
+    . = ALIGN(CACHE_ALIGN);
+  } GROUP_LINK_IN(ROMABLE_REGION)
+
+  _image_drom_start = LOADADDR(.flash.rodata);
+  _image_drom_size = LOADADDR(.flash.rodata_end) - LOADADDR(.flash.rodata);
+  _image_drom_vaddr = ADDR(.flash.rodata);
+
+  .flash.rodata : ALIGN(CACHE_ALIGN)
+  {
+    _rodata_start = ABSOLUTE(.);
+    _rodata_reserved_start = ABSOLUTE(.);
+
+    . = ALIGN(4);
+    #include <snippets-rodata.ld>
+    . = ALIGN(4);
+
+    *(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.* )
+
+    _flash_rodata_start = ABSOLUTE(.);
+    __rodata_region_start = ABSOLUTE(.);
+
+    *(.irom1.text) /* catch stray ICACHE_RODATA_ATTR */
+    *(.gnu.linkonce.r.*)
+    *(.rodata1)
+    __XT_EXCEPTION_TABLE_ = ABSOLUTE(.);
+    *(.xt_except_table)
+    *(.gcc_except_table .gcc_except_table.*)
+    *(.gnu.linkonce.e.*)
+    *(.gnu.version_r)
+    . = (. + 3) & ~ 3;
+    __eh_frame = ABSOLUTE(.);
+    KEEP(*(.eh_frame))
+    . = (. + 7) & ~ 3;
+
+    /* C++ exception handlers table:  */
+    __XT_EXCEPTION_DESCS_ = ABSOLUTE(.);
+    *(.xt_except_desc)
+    *(.gnu.linkonce.h.*)
+    __XT_EXCEPTION_DESCS_END__ = ABSOLUTE(.);
+    *(.xt_except_desc_end)
+    *(.dynamic)
+    *(.gnu.version_d)
+    . = ALIGN(4);
+    _rodata_end = ABSOLUTE(.);
+    __rodata_region_end = ABSOLUTE(.);
+    /* Literals are also RO data. */
+    _lit4_start = ABSOLUTE(.);
+    *(*.lit4)
+    *(.lit4.*)
+    *(.gnu.linkonce.lit4.*)
+    _lit4_end = ABSOLUTE(.);
+    . = ALIGN(4);
+
+    *(.rodata_wlog)
+    *(.rodata_wlog*)
+    . = ALIGN(4);
+  } GROUP_DATA_LINK_IN(RODATA_REGION, ROMABLE_REGION)
+
+  #include <zephyr/linker/common-rom/common-rom-cpp.ld>
+  #include <zephyr/linker/common-rom/common-rom-kernel-devices.ld>
+  #include <zephyr/linker/common-rom/common-rom-ztest.ld>
+  #include <zephyr/linker/common-rom/common-rom-net.ld>
+  #include <zephyr/linker/common-rom/common-rom-bt.ld>
+  #include <zephyr/linker/common-rom/common-rom-debug.ld>
+  #include <zephyr/linker/common-rom/common-rom-misc.ld>
+  #include <zephyr/linker/thread-local-storage.ld>
+  #include <snippets-sections.ld>
+
+  /* Create an explicit section at the end of all the data that shall be mapped into drom.
+   * This is used to calculate the size of the _image_drom_size variable */
+  .flash.rodata_end :
+  {
+    /* This is a symbol marking the flash.rodata end, this
+     * can be used for mmu driver to maintain virtual address
+     * We don't need to include the noload rodata in this section
+     */
+    . = ALIGN(CONFIG_MMU_PAGE_SIZE);
+
+    _rodata_end = ABSOLUTE(.);
+    _rodata_reserved_end = ABSOLUTE(.);
+  } GROUP_DATA_LINK_IN(RODATA_REGION, ROMABLE_REGION)
+
+  /* --- RODATA END --- */
+
+  /* --- FLASH TEXT BEGIN --- */
+
+  .flash.text_dummy (NOLOAD):
+  {
+    . = ALIGN(CACHE_ALIGN);
+  } GROUP_LINK_IN(ROMABLE_REGION)
+
   _image_irom_start = LOADADDR(.flash.text);
   _image_irom_size = LOADADDR(.flash.text) + SIZEOF(.flash.text) - _image_irom_start;
   _image_irom_vaddr = ADDR(.flash.text);
 
-  .flash.text : ALIGN(IROM_SEG_ALIGN)
+  .flash.text : ALIGN(CACHE_ALIGN)
   {
     _stext = .;
     _instruction_reserved_start = ABSOLUTE(.);  /* This is a symbol marking the flash.text start, this can be used for mmu driver to maintain virtual address */
     _text_start = ABSOLUTE(.);
 
-#if !defined(CONFIG_ESP32_WIFI_IRAM_OPT)
+#ifndef CONFIG_ESP32_WIFI_IRAM_OPT
     *libnet80211.a:( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.*)
     *libpp.a:( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.* .wifiorslpiram .wifiorslpiram.*)
 #endif
 
-#if !defined(CONFIG_ESP32_WIFI_RX_IRAM_OPT)
+#ifndef CONFIG_ESP32_WIFI_RX_IRAM_OPT
     *libnet80211.a:( .wifirxiram  .wifirxiram.* .wifislprxiram .wifislprxiram.*)
     *libpp.a:( .wifirxiram  .wifirxiram.* .wifislprxiram .wifislprxiram.*)
 #endif
+
+    *(.fini.literal)
+    *(.fini)
 
     *(.literal .text .literal.* .text.*)
     . = ALIGN(4);
     _text_end = ABSOLUTE(.);
     _instruction_reserved_end = ABSOLUTE(.);  /* This is a symbol marking the flash.text end, this can be used for mmu driver to maintain virtual address */
     _etext = .;
-
-    /* Similar to _iram_start, this symbol goes here so it is
-       resolved by addr2line in preference to the first symbol in
-       the flash.text segment.
-    */
-    _flash_cache_start = ABSOLUTE(0);
   } GROUP_DATA_LINK_IN(FLASH_CODE_REGION, ROMABLE_REGION)
 
-_heap_sentry = 0x3ffe3f20;
+  /* --- FLASH TEXT END --- */
+
+  /* --- XTENSA GLUE AND DEBUG BEGIN --- */
 
 #include <zephyr/linker/debug-sections.ld>
 
@@ -650,10 +913,12 @@ _heap_sentry = 0x3ffe3f20;
 
 }
 
+  /* --- XTENSA GLUE AND DEBUG END --- */
+
 ASSERT(((_iram_end - ORIGIN(iram0_0_seg)) <= LENGTH(iram0_0_seg)),
           "IRAM0 segment data does not fit.")
 
-#if defined(CONFIG_ESP_SPIRAM)
+#ifdef CONFIG_ESP_SPIRAM
 ASSERT(((_ext_ram_data_end - _ext_ram_data_start) <= CONFIG_ESP_SPIRAM_SIZE),
           "External SPIRAM overflowed.")
 #endif /* CONFIG_ESP_SPIRAM */

--- a/soc/espressif/esp32/mcuboot.ld
+++ b/soc/espressif/esp32/mcuboot.ld
@@ -1,19 +1,14 @@
 /*
- * Copyright (c) 2023 Espressif Systems (Shanghai) Co., Ltd.
+ * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
  * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
- * @file
- * @brief Linker command/script file
- *
- * Linker script for the MCUboot on Xtensa platform.
  */
 
 #include <zephyr/devicetree.h>
 #include <zephyr/linker/sections.h>
 #include <zephyr/linker/linker-defs.h>
 #include <zephyr/linker/linker-tool.h>
+
+#include "memory.h"
 
 #ifdef CONFIG_XIP
 #error "Xtensa bootloader cannot use XIP"
@@ -23,22 +18,20 @@
 #undef GROUP_DATA_LINK_IN
 #define GROUP_DATA_LINK_IN(vregion, lregion) > vregion
 
-#define RAMABLE_REGION dram_seg
-#define RAMABLE_REGION_1 dram_seg
-
-#define RODATA_REGION dram_seg
-#define ROMABLE_REGION dram_seg
-
-#define IRAM_REGION iram_seg
-#define FLASH_CODE_REGION iram_seg
-
-#define IROM_SEG_ALIGN 16
+/* Aliases */
+#define RAMABLE_REGION    dram_seg
+#define RAMABLE_REGION_1  dram_seg
+#define RODATA_REGION     dram_seg
+#define ROMABLE_REGION    dram_seg
 
 MEMORY
 {
-  iram_loader_seg (RWX) : org = 0x40078000, len = 0x4000
-  iram_seg        (RWX) : org = 0x4009C000, len = 0x8000
-  dram_seg        (RW)  : org = 0x3FFF0000, len = 0x6400
+  iram_loader_seg (RWX) : org = BOOTLOADER_IRAM_LOADER_SEG_START,
+                          len = BOOTLOADER_IRAM_LOADER_SEG_LEN
+  iram_seg        (RWX) : org = BOOTLOADER_IRAM_SEG_START,
+                          len = BOOTLOADER_IRAM_SEG_LEN
+  dram_seg        (RW)  : org = BOOTLOADER_DRAM_SEG_START,
+                          len = BOOTLOADER_DRAM_SEG_LEN
 
 #ifdef CONFIG_GEN_ISR_TABLES
   IDT_LIST(RW): org = 0x3ebfe010, len = 0x2000
@@ -49,19 +42,145 @@ ENTRY(CONFIG_KERNEL_ENTRY)
 
 SECTIONS
 {
-  /* NOTE: .rodata section should be the first section in the linker script and no
-   * other section should appear before .rodata section. This is the requirement
-   * to align ROM section to 64K page offset.
-   * Adding .rodata as first section helps to reduce size of generated binary by
-   * few kBs.
-   */
-  SECTION_PROLOGUE(_RODATA_SECTION_NAME,,)
+  .iram0.loader_text :
   {
-    __rodata_region_start = ABSOLUTE(.);
+    _loader_text_start = ABSOLUTE(.);
+    *(.stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
 
+    *libarch__xtensa__core.a:xtensa_asm2_util.*(.literal .text .literal.* .text.*)
+    *liblib__libc__common.a:abort.*(.literal .text .literal.* .text.*)
+    *libdrivers__timer.a:xtensa_sys_timer.*(.literal .text .literal.* .text.*)
+    *libarch__common.a:dynamic_isr.*(.literal .text .literal.* .text.*)
+    *libarch__common.a:sw_isr_common.*(.literal .text .literal.* .text.*)
+
+    *libapp.a:flash_map_extended.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:printk.*(.literal.printk .literal.vprintk .literal.char_out .text.printk .text.vprintk .text.char_out)
+    *libzephyr.a:cbprintf_nano.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:cpu.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:mmu_hal.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:cache_esp32.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:flash_map.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:esp_rom_spiflash.*(.literal .text .literal.* .text.*)
+
+    *libzephyr.a:heap.*(.literal .text .literal.* .text.*)
+
+    *libkernel.a:kheap.*(.literal .text .literal.* .text.*)
+    *libkernel.a:mempool.*(.literal .text .literal.* .text.*)
+    *libkernel.a:device.*(.literal .text .literal.* .text.*)
+    *libkernel.a:timeout.*(.literal .text .literal.* .text.*)
+
+    *(.literal.bootloader_mmap .text.bootloader_mmap)
+    *(.literal.bootloader_munmap .text.bootloader_munmap)
+
+    *libzephyr.a:esp_loader.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:mmu_hal.*(.literal .text .literal.* .text.*)
+
+    *(.literal.esp_intr_disable .literal.esp_intr_disable.* .text.esp_intr_disable .text.esp_intr_disable.*)
+    *(.literal.default_intr_handler .text.default_intr_handler .iram1.*.default_intr_handler)
+    *(.literal.esp_log_timestamp .text.esp_log_timestamp)
+    *(.literal.esp_log_early_timestamp .text.esp_log_early_timestamp)
+    *(.literal.esp_system_abort .text.esp_system_abort)
+
+    *(.fini.literal)
+    *(.fini)
+    *(.gnu.version)
+
+    /* CPU will try to prefetch up to 16 bytes of
+     * of instructions. This means that any configuration (e.g. MMU, PMS) must allow
+     * safe access to up to 16 bytes after the last real instruction, add
+     * dummy bytes to ensure this
+     */
+    . += 16;
+
+    _text_end = ABSOLUTE(.);
+    _etext = .;
+    . = ALIGN(4) + 16;
+    _loader_text_end = ABSOLUTE(.);
+    _iram_text_end = ABSOLUTE(.);
+    _iram_end = ABSOLUTE(.);
+  } > iram_loader_seg
+
+  .iram0.vectors : ALIGN(4)
+  {
+    /* Vectors go to IRAM */
+    _init_start = ABSOLUTE(.);
+    /* Vectors according to builds/RF-2015.2-win32/esp108_v1_2_s5_512int_2/config.html */
+    . = 0x0;
+    KEEP(*(.WindowVectors.text));
+    . = 0x180;
+    KEEP(*(.Level2InterruptVector.text));
+    . = 0x1c0;
+    KEEP(*(.Level3InterruptVector.text));
+    . = 0x200;
+    KEEP(*(.Level4InterruptVector.text));
+    . = 0x240;
+    KEEP(*(.Level5InterruptVector.text));
+    . = 0x280;
+    KEEP(*(.DebugExceptionVector.text));
+    . = 0x2c0;
+    KEEP(*(.NMIExceptionVector.text));
+    . = 0x300;
+    KEEP(*(.KernelExceptionVector.text));
+    . = 0x340;
+    KEEP(*(.UserExceptionVector.text));
+    . = 0x3C0;
+    KEEP(*(.DoubleExceptionVector.text));
+    . = 0x400;
+    _invalid_pc_placeholder = ABSOLUTE(.);
+    *(.*Vector.literal)
+
+    *(.UserEnter.literal);
+    *(.UserEnter.text);
+    . = ALIGN (16);
+    *(.entry.text)
+    *(.init.literal)
+    *(.init)
+    . = ALIGN (4);
+    _init_end = ABSOLUTE(.);
+
+    _iram_start = ABSOLUTE(.);
+  } > iram_seg
+
+  .iram0.text :
+  {
     . = ALIGN(4);
-    #include <snippets-rodata.ld>
 
+    *(.iram1 .iram1.*)
+    *(.iram0.literal .iram.literal .iram.text.literal .iram0.text .iram.text)
+
+    *(.literal .text .literal.* .text.*)
+    . = ALIGN(4);
+
+    *(.irom0.text) /* catch stray ICACHE_RODATA_ATTR */
+    . = ALIGN(4) + 16;
+  } > iram_seg
+
+  .dram0.data : ALIGN(16)
+  {
+    . = ALIGN(4);
+    __data_start = ABSOLUTE(.);
+
+    #include <snippets-rodata.ld>
+    . = ALIGN(4);
+
+    #include <snippets-rwdata.ld>
+    . = ALIGN(4);
+
+    *(.data)
+    *(.data.*)
+    *(.gnu.linkonce.d.*)
+    *(.data1)
+    *(.sdata)
+    *(.sdata.*)
+    *(.gnu.linkonce.s.*)
+    *(.sdata2)
+    *(.sdata2.*)
+    *(.gnu.linkonce.s2.*)
+    *libzephyr.a:mmu_hal.*(.rodata .rodata.*)
+    *libzephyr.a:rtc_clk.*(.rodata .rodata.*)
+
+    KEEP(*(.jcr))
+    *(.dram1 .dram1.*)
     . = ALIGN(4);
     *(.rodata)
     *(.rodata.*)
@@ -96,49 +215,16 @@ SECTIONS
     *(.gnu.linkonce.lit4.*)
     _lit4_end = ABSOLUTE(.);
     . = ALIGN(4);
-    _thread_local_start = ABSOLUTE(.);
-    *(.tdata)
-    *(.tdata.*)
-    *(.tbss)
-    *(.tbss.*)
     *(.rodata_wlog)
     *(.rodata_wlog*)
     _thread_local_end = ABSOLUTE(.);
     . = ALIGN(4);
-  } GROUP_DATA_LINK_IN(RODATA_REGION, ROMABLE_REGION)
+  } > dram_seg
 
-  #include <zephyr/linker/common-rom/common-rom-cpp.ld>
   #include <zephyr/linker/common-rom/common-rom-kernel-devices.ld>
   #include <zephyr/linker/common-rom/common-rom-debug.ld>
   #include <zephyr/linker/common-rom/common-rom-misc.ld>
   #include <snippets-sections.ld>
-
-  .dram0.data :
-  {
-    __data_start = ABSOLUTE(.);
-
-    _btdm_data_start = ABSOLUTE(.);
-    *libbtdm_app.a:(.data .data.*)
-    . = ALIGN (4);
-    _btdm_data_end = ABSOLUTE(.);
-
-    *(.data)
-    *(.data.*)
-    *(.gnu.linkonce.d.*)
-    *(.data1)
-    *(.sdata)
-    *(.sdata.*)
-    *(.gnu.linkonce.s.*)
-    *(.sdata2)
-    *(.sdata2.*)
-    *(.gnu.linkonce.s2.*)
-    *libzephyr.a:mmu_hal.*(.rodata .rodata.*)
-    *libzephyr.a:rtc_clk.*(.rodata .rodata.*)
-
-    KEEP(*(.jcr))
-    *(.dram1 .dram1.*)
-    . = ALIGN(4);
-  } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
   #include <zephyr/linker/cplusplus-rom.ld>
   #include <snippets-data-sections.ld>
@@ -147,133 +233,20 @@ SECTIONS
   #include <zephyr/linker/cplusplus-ram.ld>
   #include <zephyr/linker/common-rom/common-rom-logging.ld>
 
-  .dram0.end :
+  .noinit (NOLOAD):
   {
-    . = ALIGN(4);
-    #include <snippets-rwdata.ld>
-    . = ALIGN(4);
-    _end = ABSOLUTE(.);
-    __data_end = ABSOLUTE(.);
-  } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
-
-  /* Send .iram0 code to iram */
-  .iram0.vectors : ALIGN(4)
-  {
-    /* Vectors go to IRAM */
-    _init_start = ABSOLUTE(.);
-    /* Vectors according to builds/RF-2015.2-win32/esp108_v1_2_s5_512int_2/config.html */
-    . = 0x0;
-    KEEP(*(.WindowVectors.text));
-    . = 0x180;
-    KEEP(*(.Level2InterruptVector.text));
-    . = 0x1c0;
-    KEEP(*(.Level3InterruptVector.text));
-    . = 0x200;
-    KEEP(*(.Level4InterruptVector.text));
-    . = 0x240;
-    KEEP(*(.Level5InterruptVector.text));
-    . = 0x280;
-    KEEP(*(.DebugExceptionVector.text));
-    . = 0x2c0;
-    KEEP(*(.NMIExceptionVector.text));
-    . = 0x300;
-    KEEP(*(.KernelExceptionVector.text));
-    . = 0x340;
-    KEEP(*(.UserExceptionVector.text));
-    . = 0x3C0;
-    KEEP(*(.DoubleExceptionVector.text));
-    . = 0x400;
-    *(.*Vector.literal)
-
-    *(.UserEnter.literal);
-    *(.UserEnter.text);
-    . = ALIGN (16);
-    *(.entry.text)
-    *(.init.literal)
-    *(.init)
-    _init_end = ABSOLUTE(.);
-
-    /* This goes here, not at top of linker script, so addr2line finds it last,
-     * and uses it in preference to the first symbol in IRAM
-     */
-    _iram_start = ABSOLUTE(0);
-  } GROUP_DATA_LINK_IN(IRAM_REGION, ROMABLE_REGION)
-
-  .iram_loader.text :
-  {
-    . = ALIGN (16);
-    _loader_text_start = ABSOLUTE(.);
-    *(.stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
-    *(.iram1 .iram1.*) /* catch stray IRAM_ATTR */
-    *libzephyr.a:bootloader_flash.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_flash_config_esp32.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_clock_loader.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_common_loader.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_init_common.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_flash.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_random.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_random*.*(.literal.bootloader_random_disable .text.bootloader_random_disable)
-    *libzephyr.a:bootloader_random*.*(.literal.bootloader_random_enable .text.bootloader_random_enable)
-    *libzephyr.a:bootloader_efuse_esp32.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_utility.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_sha.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_console.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_console_loader.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_panic.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_soc.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:esp_image_format.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:flash_encrypt.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:flash_encryption_secure_features.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:flash_partitions.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:secure_boot.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:secure_boot_secure_features.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:secure_boot_signatures_bootloader.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:wdt_hal_iram.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:esp_efuse_table.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:esp_efuse_fields.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:esp_efuse_api.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:esp_efuse_utility.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:esp_efuse_api_key_esp32.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:app_cpu_start.*(.literal .text .literal.* .text.*)
-    *esp_mcuboot.*(.literal .text .literal.* .text.*)
-    *esp_loader.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:mmu_hal.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:rtc_clk.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:rtc_clk_init.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:rtc_time.*(.literal .literal.* .text .text.*)
-
-    *(.fini.literal)
-    *(.fini)
-    *(.gnu.version)
-    _loader_text_end = ABSOLUTE(.);
-  } > iram_loader_seg
-
-  SECTION_PROLOGUE(_TEXT_SECTION_NAME, , ALIGN(4))
-  {
-    /* Code marked as running out of IRAM */
-    _iram_text_start = ABSOLUTE(.);
-    *(.iram1 .iram1.*)
-    *(.iram0.literal .iram.literal .iram.text.literal .iram0.text .iram.text)
-
-    . = ALIGN(4);
-    _iram_text_end = ABSOLUTE(.);
-    _iram_end = ABSOLUTE(.);
-  } GROUP_DATA_LINK_IN(IRAM_REGION, ROMABLE_REGION)
+    . = ALIGN(8);
+    *(.noinit)
+    *(.noinit.*)
+    . = ALIGN(8) ;
+  } > dram_seg
 
   /* Shared RAM */
-  SECTION_DATA_PROLOGUE(_BSS_SECTION_NAME,(NOLOAD),)
+  .bss (NOLOAD):
   {
     . = ALIGN (8);
     _bss_start = ABSOLUTE(.); /* required by bluetooth library */
     __bss_start = ABSOLUTE(.);
-
-    _btdm_bss_start = ABSOLUTE(.);
-    *libbtdm_app.a:(.bss .bss.* COMMON)
-    . = ALIGN (4);
-    _btdm_bss_end = ABSOLUTE(.);
-
-    /* Buffer for system heap should be placed in dram_seg */
-    *libkernel.a:mempool.*(.noinit.kheap_buf__system_heap .noinit.*.kheap_buf__system_heap)
 
     *(.dynsbss)
     *(.sbss)
@@ -293,35 +266,9 @@ SECTIONS
     __bss_end = ABSOLUTE(.);
     _bss_end = ABSOLUTE(.);
     _end = ABSOLUTE(.);
-  } GROUP_LINK_IN(RAMABLE_REGION)
+  } > dram_seg
 
-  ASSERT(((__bss_end - ORIGIN(RAMABLE_REGION)) <= LENGTH(RAMABLE_REGION)),
-          "DRAM segment data does not fit.")
-
-  SECTION_DATA_PROLOGUE(_NOINIT_SECTION_NAME, (NOLOAD),)
-  {
-    . = ALIGN (8);
-    *(.noinit)
-    *(.noinit.*)
-    . = ALIGN (8);
-  } GROUP_LINK_IN(RAMABLE_REGION_1)
-
-  .flash.text : ALIGN(IROM_SEG_ALIGN)
-  {
-    _stext = .;
-    _text_start = ABSOLUTE(.);
-
-    *(.literal .text .literal.* .text.*)
-    . = ALIGN(4);
-    _text_end = ABSOLUTE(.);
-    _etext = .;
-
-    /* Similar to _iram_start, this symbol goes here so it is
-     * resolved by addr2line in preference to the first symbol in
-     * the flash.text segment.
-     */
-    _flash_cache_start = ABSOLUTE(0);
-  } GROUP_DATA_LINK_IN(FLASH_CODE_REGION, ROMABLE_REGION)
+  ASSERT(((__bss_end - ORIGIN(dram_seg)) <= LENGTH(dram_seg)), "DRAM segment data does not fit.")
 
 #include <zephyr/linker/debug-sections.ld>
 
@@ -362,8 +309,4 @@ SECTIONS
 #ifdef CONFIG_GEN_ISR_TABLES
 #include <zephyr/linker/intlist.ld>
 #endif
-
 }
-
-ASSERT(((_iram_end - ORIGIN(IRAM_REGION)) <= LENGTH(IRAM_REGION)),
-          "IRAM0 segment data does not fit.")

--- a/soc/espressif/esp32/memory.h
+++ b/soc/espressif/esp32/memory.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+/* SRAM0 (64k+128k)  instruction cache+memory */
+#define SRAM0_IRAM_START    0x40070000
+#define SRAM0_CACHE_SIZE    0x10000
+#define SRAM0_SIZE          0x30000
+
+/* SRAM1 (128k) instruction/data memory */
+#define SRAM1_IRAM_START    0x400a0000
+#define SRAM1_DRAM_START    0x3ffe0000
+#define SRAM1_SIZE          0x20000
+#define SRAM1_DRAM_PROAPP_PRIV_SIZE 0x8000
+#define SRAM1_DRAM_USABLE_START 0x3ffe8000  /* Can be optimised - 0x3ffe5230 (?) */
+#define SRAM1_USABLE_SIZE   (0x40000000 - SRAM1_DRAM_USABLE_START)
+
+/* SRAM2 (200k) data memory */
+#define SRAM2_DRAM_START    0x3ffae000
+#define SRAM2_SIZE          0x32000
+#define SRAM2_DRAM_SHM_PRIV_SIZE 0x2000
+#define SRAM2_DRAM_USABLE_START  0x3ffb0000
+#define SRAM2_USABLE_SIZE   (SRAM1_DRAM_START - SRAM2_DRAM_USABLE_START)
+
+/** Simplified memory map for the bootloader.
+ *  Make sure the bootloader can load into main memory without overwriting itself.
+ *
+ *  ESP32 ROM static data usage is as follows:
+ *  - 0x3ffae000 - 0x3ffb0000 (Reserved: data memory for ROM functions)
+ *  - 0x3ffb0000 - 0x3ffe0000 (RAM bank 1 for application usage)
+ *  - 0x3ffe0000 - 0x3ffe0440 (Reserved: data memory for ROM PRO CPU)
+ *  - 0x3ffe3f20 - 0x3ffe4350 (Reserved: data memory for ROM APP CPU)
+ *  - 0x3ffe4350 - 0x3ffe5230 (BT shm buffers)
+ *  - 0x3ffe8000 - 0x3fffffff (RAM bank 2 for application usage)
+ */
+
+#define DRAM1_PROCPU_RESERVED_START 0x3ffe0000
+#define DRAM1_APPCPU_RESERVED_START 0x3ffe3f20
+#define DRAM1_BT_SHM_BUFFERS_START  0x3ffe4350
+#define DRAM1_BT_SHM_BUFFERS_END    0x3ffe5230
+
+/* Conversion beween IRAM and DRAM in SRAM1 memory */
+#define SRAM1_IRAM_DRAM_CALC(addr_iram) \
+	(SRAM1_SIZE - ((addr_iram) - SRAM1_IRAM_START) + SRAM1_DRAM_START)
+#define SRAM1_DRAM_IRAM_CALC(addr_dram) \
+	(SRAM1_SIZE - ((addr_dram) - SRAM1_DRAM_START) + SRAM1_IRAM_START)
+
+/* For safety margin between bootloader data section and startup stacks */
+#define BOOTLOADER_DRAM_SEG_LEN        0x6400
+#define BOOTLOADER_IRAM_LOADER_SEG_LEN 0x4000
+#define BOOTLOADER_IRAM_SEG_LEN        0x9500
+
+/* Start of the lower region is determined by region size and the end of the higher region */
+#define BOOTLOADER_DRAM_SEG_START  0x3fff0000
+#define BOOTLOADER_DRAM_SEG_END    (BOOTLOADER_DRAM_SEG_START + BOOTLOADER_DRAM_SEG_LEN)
+#define BOOTLOADER_IRAM_LOADER_SEG_START 0x40078000
+/* TODO: It should be possible to have this @ 0x40080400
+ * but due a bug we need to use different memory location.
+ */
+#define BOOTLOADER_IRAM_SEG_START     0x400a0000
+
+/* Flash */
+#ifdef CONFIG_FLASH_SIZE
+#define FLASH_SIZE          CONFIG_FLASH_SIZE
+#else
+#define FLASH_SIZE          0x400000
+#endif
+
+/* Cached memories */
+#define CACHE_ALIGN        CONFIG_MMU_PAGE_SIZE
+#define IROM_SEG_ORG       0x400d0000
+#define IROM_SEG_LEN       (FLASH_SIZE - 0x1000)
+#define DROM_SEG_ORG       0x3f400000
+#define DROM_SEG_LEN       (FLASH_SIZE - 0x1000)
+
+/* AMP: TODO utilise memory for APPCPU */
+#ifndef CONFIG_SOC_ESP32_PROCPU
+#define APPCPU_IRAM_SIZE   0x20000
+#else
+#define APPCPU_IRAM_SIZE   0x8000
+#endif

--- a/soc/espressif/esp32/soc.c
+++ b/soc/espressif/esp32/soc.c
@@ -97,7 +97,7 @@ void IRAM_ATTR esp_start_appcpu(void)
  * Zephyr is being booted by the Espressif bootloader.  With it, the C stack
  * is already set up.
  */
-void __attribute__((section(".iram1"))) __esp_platform_start(void)
+void IRAM_ATTR __esp_platform_start(void)
 {
 	extern uint32_t _init_start;
 
@@ -129,12 +129,7 @@ void __attribute__((section(".iram1"))) __esp_platform_start(void)
 
 	esp_reset_reason_init();
 
-#ifdef CONFIG_MCUBOOT
-	/* MCUboot early initialisation. */
-	if (bootloader_init()) {
-		abort();
-	}
-#else
+#ifndef CONFIG_MCUBOOT
 	/* ESP-IDF/MCUboot 2nd stage bootloader enables RTC WDT to check
 	 * on startup sequence related issues in application. Hence disable that
 	 * as we are about to start Zephyr environment.
@@ -187,7 +182,7 @@ void __attribute__((section(".iram1"))) __esp_platform_start(void)
 
 	memset(&_ext_ram_bss_start, 0,
 	       (&_ext_ram_bss_end - &_ext_ram_bss_start) * sizeof(_ext_ram_bss_start));
-#endif
+#endif /* CONFIG_ESP_SPIRAM */
 
 /* Scheduler is not started at this point. Hence, guard functions
  * must be initialized after esp_spiram_init_cache which internally
@@ -198,7 +193,7 @@ void __attribute__((section(".iram1"))) __esp_platform_start(void)
 	spi_flash_guard_set(&g_flash_guard_default_ops);
 #endif
 
-#endif /* CONFIG_MCUBOOT */
+#endif /* !CONFIG_MCUBOOT */
 
 	esp_intr_initialize();
 

--- a/soc/espressif/esp32c3/CMakeLists.txt
+++ b/soc/espressif/esp32c3/CMakeLists.txt
@@ -13,6 +13,33 @@ zephyr_include_directories(.)
 zephyr_library_sources_ifdef(CONFIG_PM power.c)
 zephyr_library_sources_ifdef(CONFIG_POWEROFF poweroff.c)
 
+# get flash size to use in esptool as string
+math(EXPR esptoolpy_flashsize "${CONFIG_FLASH_SIZE} / 0x100000")
+
+if(NOT CONFIG_BOOTLOADER_MCUBOOT)
+
+  if(CONFIG_BUILD_OUTPUT_BIN)
+    # make ESP ROM loader compatible image
+    message("ESP-IDF path: ${ESP_IDF_PATH}")
+
+    set(ESPTOOL_PY ${ESP_IDF_PATH}/tools/esptool_py/esptool.py)
+    message("esptool path: ${ESPTOOL_PY}")
+
+    set(ELF2IMAGE_ARG "")
+    if(NOT CONFIG_MCUBOOT)
+      set(ELF2IMAGE_ARG "--ram-only-header")
+    endif()
+
+    set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+      COMMAND ${PYTHON_EXECUTABLE} ${ESPTOOL_PY}
+      ARGS --chip esp32c3 elf2image ${ELF2IMAGE_ARG}
+      --flash_mode dio --flash_freq 40m --flash_size ${esptoolpy_flashsize}MB
+      -o ${CMAKE_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.bin
+      ${CMAKE_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.elf)
+  endif()
+
+endif()
+
 # get code-partition slot0 address
 dt_nodelabel(dts_partition_path NODELABEL "slot0_partition")
 dt_reg_addr(img_0_off PATH ${dts_partition_path})
@@ -21,50 +48,24 @@ dt_reg_addr(img_0_off PATH ${dts_partition_path})
 dt_nodelabel(dts_partition_path NODELABEL "boot_partition")
 dt_reg_addr(boot_off PATH ${dts_partition_path})
 
-# get flash size to use in esptool as string
-math(EXPR esptoolpy_flashsize "${CONFIG_FLASH_SIZE} / 0x100000")
-
-if(CONFIG_BOOTLOADER_ESP_IDF)
-
-  set(bootloader_dir "${ZEPHYR_HAL_ESPRESSIF_MODULE_DIR}/zephyr/blobs/lib/${CONFIG_SOC_SERIES}")
-
-  if(EXISTS "${bootloader_dir}/bootloader-${CONFIG_SOC_SERIES}.bin")
-    file(COPY "${bootloader_dir}/bootloader-${CONFIG_SOC_SERIES}.bin" DESTINATION ${CMAKE_BINARY_DIR})
-    file(RENAME "${CMAKE_BINARY_DIR}/bootloader-${CONFIG_SOC_SERIES}.bin" "${CMAKE_BINARY_DIR}/bootloader.bin")
-  endif()
-
-  if(EXISTS "${bootloader_dir}/partition-table-${CONFIG_SOC_SERIES}.bin")
-    file(COPY "${bootloader_dir}/partition-table-${CONFIG_SOC_SERIES}.bin" DESTINATION ${CMAKE_BINARY_DIR})
-    file(RENAME "${CMAKE_BINARY_DIR}/partition-table-${CONFIG_SOC_SERIES}.bin" "${CMAKE_BINARY_DIR}/partition-table.bin")
-  endif()
-
-  board_finalize_runner_args(esp32 "--esp-flash-bootloader=${CMAKE_BINARY_DIR}/bootloader.bin")
-
-  board_finalize_runner_args(esp32 "--esp-flash-partition_table=${CMAKE_BINARY_DIR}/partition-table.bin")
-
-  board_finalize_runner_args(esp32 "--esp-partition-table-address=0x8000")
-
+if(CONFIG_ESP_SIMPLE_BOOT)
+  board_finalize_runner_args(esp32 "--esp-app-address=${boot_off}")
+else()
+  board_finalize_runner_args(esp32 "--esp-app-address=${img_0_off}")
 endif()
 
-if(CONFIG_MCUBOOT OR CONFIG_BOOTLOADER_ESP_IDF)
-
-  if(CONFIG_BUILD_OUTPUT_BIN)
+if(CONFIG_MCUBOOT)
+    # search from cross references between bootloader sections
+    message("check_callgraph using: ${ESP_IDF_PATH}/tools/ci/check_callgraph.py")
     set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
-      COMMAND ${PYTHON_EXECUTABLE} ${ESP_IDF_PATH}/tools/esptool_py/esptool.py
-      ARGS --chip esp32c3 elf2image --flash_mode dio --flash_freq 40m --flash_size ${esptoolpy_flashsize}MB
-      -o ${CMAKE_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.bin
-      ${CMAKE_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.elf)
-  endif()
-
-  if(CONFIG_MCUBOOT)
-    board_finalize_runner_args(esp32 "--esp-flash-bootloader=${CMAKE_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.bin")
-  endif()
-
+      COMMAND
+        ${PYTHON_EXECUTABLE} ${ESP_IDF_PATH}/tools/ci/check_callgraph.py
+      ARGS
+        --rtl-dirs ${CMAKE_BINARY_DIR}/zephyr
+	--elf-file ${CMAKE_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.elf
+        find-refs --from-section=.iram0.iram_loader --to-section=.iram0.text
+        --exit-code)
 endif()
-
-board_finalize_runner_args(esp32 "--esp-boot-address=${boot_off}")
-
-board_finalize_runner_args(esp32 "--esp-app-address=${img_0_off}")
 
 if(CONFIG_MCUBOOT)
   set(SOC_LINKER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/mcuboot.ld CACHE INTERNAL "")

--- a/soc/espressif/esp32c3/default.ld
+++ b/soc/espressif/esp32c3/default.ld
@@ -1,13 +1,6 @@
 /*
- * Copyright (c) 2021 Espressif Systems (Shanghai) Co., Ltd.
+ * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
  * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
- * @file
- * @brief Linker command/script file
- *
- * Linker script for the esp32c3 platform.
  */
 
 #include <zephyr/devicetree.h>
@@ -15,41 +8,35 @@
 #include <zephyr/linker/linker-defs.h>
 #include <zephyr/linker/linker-tool.h>
 
-#define RAMABLE_REGION dram0_0_seg
-#define RODATA_REGION drom0_0_seg
-#define IRAM_REGION  iram0_0_seg
-#define FLASH_CODE_REGION irom0_0_seg
+#include "memory.h"
 
-#define ROMABLE_REGION ROM
-
-#define SRAM_IRAM_START     0x4037C000
-#define SRAM_DRAM_START     0x3FC7C000
-#define ICACHE_SIZE         0x4000 /* ICache size is fixed to 16KB on ESP32-C3 */
-#define I_D_SRAM_OFFSET     (SRAM_IRAM_START - SRAM_DRAM_START)
-/* SRAM_DRAM_END is equivalent 2nd stage bootloader iram_loader_seg
-   start address (that should not be overlapped) */
-#define SRAM_DRAM_END       0x403D0000 - I_D_SRAM_OFFSET
-#define SRAM_IRAM_ORG       (SRAM_IRAM_START + ICACHE_SIZE)
-#define SRAM_DRAM_ORG       (SRAM_DRAM_START + ICACHE_SIZE)
-#define I_D_SRAM_SIZE       SRAM_DRAM_END - SRAM_DRAM_ORG
-
-#ifdef CONFIG_FLASH_SIZE
-#define FLASH_SIZE CONFIG_FLASH_SIZE
+/* The "user_iram_end" represents the 2nd stage bootloader
+ * "iram_loader_seg" start address (that should not be overlapped).
+ * If no bootloader is used, we can extend it to gain more user ram.
+ */
+#ifdef CONFIG_ESP_SIMPLE_BOOT
+user_iram_end = (DRAM_BUFFERS_START + IRAM_DRAM_OFFSET);
 #else
-#define FLASH_SIZE 0x400000
+user_iram_end = BOOTLOADER_IRAM_LOADER_SEG_START;
 #endif
 
-#ifdef CONFIG_BOOTLOADER_ESP_IDF
-#define IROM_SEG_ORG 0x42000020
-#define IROM_SEG_LEN (FLASH_SIZE-0x20)
-#define IROM_SEG_ALIGN 0x4
-#else
-#define IROM_SEG_ORG 0x42000000
-#define IROM_SEG_LEN FLASH_SIZE
-#define IROM_SEG_ALIGN 0x10000
-#endif
+/* User available SRAM memory segments */
+user_iram_seg_org = SRAM1_IRAM_START;
+user_dram_seg_org = SRAM1_DRAM_START;
+user_dram_end = (user_iram_end - IRAM_DRAM_OFFSET);
+user_idram_size = (user_dram_end - user_dram_seg_org);
+user_iram_seg_len = user_idram_size;
+user_dram_seg_len = user_idram_size;
 
-/* Flash segments (rodata and text) should be mapped in virtual address space by providing VMA.
+/* Aliases */
+#define FLASH_CODE_REGION  irom0_0_seg
+#define RODATA_REGION      drom0_0_seg
+#define IRAM_REGION        iram0_0_seg
+#define DRAM_REGION        dram0_0_seg
+#define RAMABLE_REGION     dram0_0_seg
+#define ROMABLE_REGION     FLASH
+
+/* Flash segments (rodata and text) should be mapped in the virtual address spaces.
  * Executing directly from LMA is not possible. */
 #undef GROUP_ROM_LINK_IN
 #define GROUP_ROM_LINK_IN(vregion, lregion) > RODATA_REGION AT > lregion
@@ -57,15 +44,21 @@
 /* Global symbols required for espressif hal build */
 MEMORY
 {
-  mcuboot_hdr (RX): org = 0x0, len = 0x20
-  metadata (RX): org = 0x20, len = 0x20
-  ROM (RX): org = 0x40, len = FLASH_SIZE - 0x40
+#ifdef CONFIG_BOOTLOADER_MCUBOOT
+  mcuboot_hdr (R): org = 0x0,  len = 0x20
+  metadata (R):    org = 0x20, len = 0x20
+  FLASH (R):       org = 0x40, len = FLASH_SIZE - 0x40
+#else
+  /* Make safety margin in the FLASH memory size so the
+   * (esp_img_header + (n*esp_seg_headers)) would fit */
+  FLASH (R): org = 0x0, len = FLASH_SIZE - 0x100
+#endif
 
-  iram0_0_seg(RX): org = SRAM_IRAM_ORG, len = I_D_SRAM_SIZE
+  iram0_0_seg(RX): org = user_iram_seg_org, len = user_iram_seg_len
+  dram0_0_seg(RW): org = user_dram_seg_org, len = user_dram_seg_len
+
   irom0_0_seg(RX): org = IROM_SEG_ORG, len = IROM_SEG_LEN
-
-  drom0_0_seg (R) : org = 0x3C000040, len = FLASH_SIZE - 0x40
-  dram0_0_seg(RW): org = SRAM_DRAM_ORG, len = I_D_SRAM_SIZE
+  drom0_0_seg (R): org = DROM_SEG_ORG, len = DROM_SEG_LEN
 
   rtc_iram_seg(RWX): org = 0x50000000, len = 0x2000
 
@@ -73,7 +66,6 @@ MEMORY
   IDT_LIST(RW): org = 0x3ebfe010, len = 0x2000
 #endif
 }
-
 
 /* The line below defines location alias for .rtc.data section
  * As C3 only has RTC fast memory, this is not configurable like
@@ -86,8 +78,11 @@ ENTRY(CONFIG_KERNEL_ENTRY)
 
 _rom_store_table = 0;
 
+_iram_dram_offset = IRAM_DRAM_OFFSET;
+
 SECTIONS
 {
+#ifdef CONFIG_BOOTLOADER_MCUBOOT
   /* Reserve space for MCUboot header in the binary */
   .mcuboot_header :
   {
@@ -98,37 +93,564 @@ SECTIONS
   } > mcuboot_hdr
   .metadata :
   {
-    /* Magic byte for load header */
+    /* 0. Magic byte for load header */
     LONG(0xace637d3)
 
-    /* Application entry point address */
+    /* 1. Application entry point address */
     KEEP(*(.entry_addr))
 
     /* IRAM metadata:
-     * - Destination address (VMA) for IRAM region
-     * - Flash offset (LMA) for start of IRAM region
-     * - Size of IRAM region
+     * 2. Destination address (VMA) for IRAM region
+     * 3. Flash offset (LMA) for start of IRAM region
+     * 4. Size of IRAM region
      */
     LONG(ADDR(.iram0.text))
     LONG(LOADADDR(.iram0.text))
-    LONG(SIZEOF(.iram0.text))
+    LONG(LOADADDR(.iram0.data) - LOADADDR(.iram0.text))
 
     /* DRAM metadata:
-     * - Destination address (VMA) for DRAM region
-     * - Flash offset (LMA) for start of DRAM region
-     * - Size of DRAM region
+     * 5. Destination address (VMA) for DRAM region
+     * 6. Flash offset (LMA) for start of DRAM region
+     * 7. Size of DRAM region
      */
     LONG(ADDR(.dram0.data))
     LONG(LOADADDR(.dram0.data))
-    LONG(LOADADDR(.dummy.dram.data) + SIZEOF(.dummy.dram.data) - LOADADDR(.dram0.data))
+    LONG(LOADADDR(.dram0.end) - LOADADDR(.dram0.data))
   } > metadata
+#endif /* CONFIG_BOOTLOADER_MCUBOOT */
 
-#include <zephyr/linker/rel-sections.ld>
-  _image_drom_start = LOADADDR(_RODATA_SECTION_NAME);
-  _image_drom_size = LOADADDR(_RODATA_SECTION_END) + SIZEOF(_RODATA_SECTION_END)  - _image_drom_start;
-  _image_drom_vaddr = ADDR(_RODATA_SECTION_NAME);
+  iram_vma = ADDR(.iram0.text);
+  iram_lma = LOADADDR(.iram0.text);
+  iram_size_field = LOADADDR(.iram0.data) - LOADADDR(.iram0.text);
 
-  SECTION_PROLOGUE(_RODATA_SECTION_NAME,,)
+  dram_vma = ADDR(.dram0.data);
+  dram_lma = LOADADDR(.dram0.data);
+  dram_size_field = LOADADDR(.dram0.end) - LOADADDR(.dram0.data);
+
+  #include <zephyr/linker/rel-sections.ld>
+
+  /* --- START OF RTC --- */
+
+  .rtc.text :
+  {
+    . = ALIGN(4);
+    *(.rtc.literal .rtc.text)
+    *rtc_wake_stub*.o(.literal .text .literal.* .text.*)
+  } GROUP_DATA_LINK_IN(rtc_iram_seg, ROMABLE_REGION)
+
+  /* This section is required to skip rtc.text area because the text and
+   * data segments reflect the same address space on different buses.
+   */
+  .rtc.dummy (NOLOAD):
+  {
+    . = SIZEOF(.rtc.text);
+  } GROUP_LINK_IN(rtc_iram_seg)
+
+  .rtc.data :
+  {
+    _rtc_data_start = ABSOLUTE(.);
+    *(.rtc.data)
+    *(.rtc.rodata)
+    *rtc_wake_stub*.o(.data .rodata .data.* .rodata.* .bss .bss.*)
+    _rtc_data_end = ABSOLUTE(.);
+  } GROUP_DATA_LINK_IN(rtc_iram_seg, ROMABLE_REGION)
+
+  .rtc.bss (NOLOAD) :
+  {
+    _rtc_bss_start = ABSOLUTE(.);
+    *rtc_wake_stub*.o(.bss .bss.*)
+    *rtc_wake_stub*.o(COMMON)
+    _rtc_bss_end = ABSOLUTE(.);
+  } GROUP_LINK_IN(rtc_iram_seg)
+
+  /* This section located in RTC SLOW Memory area.
+   * It holds data marked with RTC_SLOW_ATTR attribute.
+   * See the file "esp_attr.h" for more information.
+   */
+  .rtc.force_slow :
+  {
+    . = ALIGN(4);
+    _rtc_force_slow_start = ABSOLUTE(.);
+    *(.rtc.force_slow .rtc.force_slow.*)
+    . = ALIGN(4) ;
+    _rtc_force_slow_end = ABSOLUTE(.);
+  } > rtc_slow_seg
+
+  /* Get size of rtc slow data */
+  _rtc_slow_length = (_rtc_force_slow_end - _rtc_data_start);
+
+  /* --- END OF RTC --- */
+
+  /* --- START OF IRAM --- */
+
+  .iram0.text : ALIGN(4)
+  {
+    /* Vectors go to IRAM */
+    _iram_start = ABSOLUTE(.);
+    _init_start = ABSOLUTE(.);
+
+    KEEP(*(.exception_vectors.text));
+    . = ALIGN(256);
+
+    _invalid_pc_placeholder = ABSOLUTE(.);
+
+    KEEP(*(.exception.entry*)); /* contains _isr_wrapper */
+    *(.exception.other*)
+    . = ALIGN(4);
+
+    *(.entry.text)
+    *(.init.literal)
+    *(.init)
+    . = ALIGN(4);
+
+    _init_end = ABSOLUTE(.);
+    _iram_text_start = ABSOLUTE(.);
+
+    *(.iram1 .iram1.*)
+    *(.iram0.literal .iram.literal .iram.text.literal .iram0.text .iram.text)
+    *libzephyr.a:panic.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:loader.*(.literal .text .literal.* .text.*)
+    *libarch__riscv__core.a:(.literal .text .literal.* .text.*)
+    *libsubsys__net__l2__ethernet.a:(.literal .text .literal.* .text.*)
+    *libsubsys__net__lib__config.a:(.literal .text .literal.* .text.*)
+    *libsubsys__net__ip.a:(.literal .text .literal.* .text.*)
+    *libsubsys__net.a:(.literal .text .literal.* .text.*)
+    *libkernel.a:(.literal .text .literal.* .text.*)
+    *libgcc.a:lib2funcs.*(.literal .text .literal.* .text.*)
+    *libdrivers__flash.a:flash_esp32.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:spi_flash_rom_patch.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:log_noos.*(.literal .text .literal.* .text.*)
+    *libdrivers__timer.a:esp32c3_sys_timer.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:log_core.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:cbprintf_complete.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:printk.*(.literal.printk .literal.vprintk .literal.char_out .text.printk .text.vprintk .text.char_out)
+    *libzephyr.a:log_msg.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:log_list.*(.literal .text .literal.* .text.*)
+    *libdrivers__console.a:uart_console.*(.literal.console_out .text.console_out)
+    *libzephyr.a:log_output.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:log_backend_uart.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:rtc_*.*(.literal .text .literal.* .text.*)
+    *liblib__libc__newlib.a:string.*(.literal .text .literal.* .text.*)
+    *liblib__libc__minimal.a:string.*(.literal .text .literal.* .text.*)
+    *liblib__libc__picolib.a:string.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:periph_ctrl.*(.literal .text .literal.* .text.*)
+    *libgcov.a:(.literal .text .literal.* .text.*)
+    *libphy.a:( .phyiram .phyiram.*)
+    *libc.a:*(.literal .text .literal.* .text.*)
+
+    /* [mapping:hal] */
+    *libzephyr.a:mmu_hal.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:spi_flash_hal_iram.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:spi_flash_encrypt_hal_iram.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:cache_hal.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:ledc_hal_iram.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:i2c_hal_iram.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:wdt_hal_iram.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:systimer_hal.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:spi_flash_hal_gpspi.*(.literal .literal.* .text .text.*)
+
+    /* [mapping:soc] */
+    *libzephyr.a:lldesc.*(.literal .literal.* .text .text.*)
+
+    /* [mapping:log] */
+    *(.literal.esp_log_write .text.esp_log_write)
+    *(.literal.esp_log_timestamp .text.esp_log_timestamp)
+    *(.literal.esp_log_early_timestamp .text.esp_log_early_timestamp)
+    *(.literal.esp_log_impl_lock .text.esp_log_impl_lock)
+    *(.literal.esp_log_impl_lock_timeout .text.esp_log_impl_lock_timeout)
+    *(.literal.esp_log_impl_unlock .text.esp_log_impl_unlock)
+
+    /* [mapping:spi_flash] */
+    *libzephyr.a:spi_flash_chip_boya.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:spi_flash_chip_gd.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:spi_flash_chip_generic.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:spi_flash_chip_issi.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:spi_flash_chip_mxic.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:spi_flash_chip_mxic_opi.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:spi_flash_chip_th.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:spi_flash_chip_winbond.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:memspi_host_driver.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:flash_brownout_hook.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:spi_flash_wrap.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:spi_flash_hpm_enable.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:spi_flash_oct_flash_init*(.literal .literal.* .text .text.*)
+
+    /* [mapping:esp_system] */
+    *libzephyr.a:esp_err.*(.literal .literal.* .text .text.*)
+    *(.literal.esp_system_abort .text.esp_system_abort)
+
+    /* [mapping:esp_hw_support] */
+    *(.literal.esp_cpu_stall .text.esp_cpu_stall)
+    *(.literal.esp_cpu_unstall .text.esp_cpu_unstall)
+    *(.literal.esp_cpu_reset .text.esp_cpu_reset)
+    *(.literal.esp_cpu_wait_for_intr .text.esp_cpu_wait_for_intr)
+    *(.literal.esp_cpu_compare_and_set .text.esp_cpu_compare_and_set)
+    *(.literal.esp_gpio_reserve_pins .text.esp_gpio_reserve_pins)
+    *(.literal.esp_gpio_is_pin_reserved .text.esp_gpio_is_pin_reserved)
+    *(.literal.rtc_vddsdio_get_config .text.rtc_vddsdio_get_config)
+    *(.literal.rtc_vddsdio_set_config .text.rtc_vddsdio_set_config)
+    *libzephyr.a:esp_memory_utils.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:rtc_clk.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:rtc_clk_init.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:rtc_time.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:rtc_sleep.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:systimer.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:mspi_timing_config.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:mspi_timing_tuning.*(.literal .literal.* .text .text.*)
+    *(.literal.sar_periph_ctrl_power_enable .text.sar_periph_ctrl_power_enable)
+
+    /* [mapping:soc_pm] */
+    *(.literal.GPIO_HOLD_MASK .text.GPIO_HOLD_MASK)
+
+    /* [mapping:esp_rom] */
+    *libzephyr.a:esp_rom_spiflash.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:esp_rom_systimer.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:esp_rom_wdt.*(.literal .literal.* .text .text.*)
+
+    /* [mapping:esp_mm] */
+    *libzephyr.a:esp_cache.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:cache_utils.*(.literal .text .literal.* .text.*)
+
+#if defined(CONFIG_ESP32_WIFI_IRAM_OPT)
+    *libnet80211.a:( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.*)
+    *libpp.a:( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.*)
+    *libcoexist.a:(.wifi_slp_iram .wifi_slp_iram.*)
+
+    /* [mapping:esp_wifi] */
+    *(.literal.wifi_clock_enable_wrapper .text.wifi_clock_enable_wrapper)
+    *(.literal.wifi_clock_disable_wrapper .text.wifi_clock_disable_wrapper)
+
+    /* [mapping:esp_phy] */
+    *(.literal.esp_phy_enable .text.esp_phy_enable)
+    *(.literal.esp_phy_disable .text.esp_phy_disable)
+    *(.literal.esp_wifi_bt_power_domain_off .text.esp_wifi_bt_power_domain_off)
+#endif /* CONFIG_ESP32_WIFI_IRAM_OPT */
+
+#if defined(CONFIG_ESP32_WIFI_RX_IRAM_OPT)
+    *libnet80211.a:( .wifirxiram  .wifirxiram.* .wifislprxiram .wifislprxiram.*)
+    *libpp.a:( .wifirxiram  .wifirxiram.* .wifislprxiram .wifislprxiram.*)
+#endif /* CONFIG_ESP32_WIFI_RX_IRAM_OPT */
+
+    . = ALIGN(4) + 16;
+
+  } GROUP_DATA_LINK_IN(IRAM_REGION, ROMABLE_REGION)
+
+#ifdef CONFIG_ESP_SIMPLE_BOOT
+  .loader.text :
+  {
+    . =  ALIGN(4);
+    _loader_text_start = ABSOLUTE(.);
+    *libzephyr.a:bootloader_soc.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_init.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_esp32c3.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_clock_init.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_wdt.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_flash.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_flash_config_esp32c3.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_clock_loader.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_common_loader.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_panic.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_mem.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_random.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_random*.*(.literal.bootloader_random_disable .text.bootloader_random_disable)
+    *libzephyr.a:bootloader_random*.*(.literal.bootloader_random_enable .text.bootloader_random_enable)
+    *libzephyr.a:bootloader_efuse.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_utility.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_sha.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_console.*(.literal .text .literal.* .text.*)
+
+    *libzephyr.a:esp_image_format.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:flash_ops.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:flash_ops_esp32c3.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:flash_encrypt.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:flash_encryption_secure_features.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:flash_partitions.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:spi_flash_hal.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:spi_flash_hal_common.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:esp_flash_api.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:esp_flash_spi_init.*(.literal .text .literal.* .text.*)
+
+    *libzephyr.a:esp_efuse_table.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:esp_efuse_fields.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:esp_efuse_api.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:esp_efuse_utility.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:esp_efuse_api_key_esp32xx.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:secure_boot.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:secure_boot_secure_features.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:secure_boot_signatures_bootloader.*(.literal .text .literal.* .text.*)
+
+    *libzephyr.a:cpu_region_protect.*(.literal .text .literal.* .text.*)
+
+    /* ??? */
+    *libzephyr.a:esp_gpio_reserve.*(.literal .text .literal.* .text.*)
+
+    . = ALIGN(0x10) + 0x10;
+    _loader_text_end = ABSOLUTE(.);
+  } GROUP_DATA_LINK_IN(IRAM_REGION, ROMABLE_REGION)
+#endif /* CONFIG_ESP_SIMPLE_BOOT */
+
+  .iram0.text_end (NOLOAD) :
+  {
+    /* C3 memprot requires 512 B alignment for split lines */
+    . = ALIGN (16);
+    _iram_text_end = ABSOLUTE(.);
+  } GROUP_LINK_IN(IRAM_REGION)
+
+  .iram0.data :
+  {
+    . = ALIGN(16);
+    *(.iram.data)
+    *(.iram.data*)
+  } GROUP_DATA_LINK_IN(IRAM_REGION, ROMABLE_REGION)
+
+  .iram0.bss (NOLOAD) :
+  {
+    . = ALIGN(16);
+    *(.iram.bss)
+    *(.iram.bss*)
+
+    . = ALIGN(16);
+    _iram_end = ABSOLUTE(.);
+  } GROUP_LINK_IN(IRAM_REGION)
+
+  /* --- END OF IRAM --- */
+
+  /* --- START OF DRAM --- */
+
+  .dram0.dummy (NOLOAD):
+  {
+    /* Spacer section is required to skip .iram0.text area because
+     * iram0_0_seg and dram0_0_seg reflect the same address space on different buses.
+     */
+    . = ORIGIN(dram0_0_seg) + MAX(_iram_end, user_iram_seg_org) - user_iram_seg_org;
+    . = ALIGN(16) + 16;
+  } GROUP_LINK_IN(RAMABLE_REGION)
+
+  .dram0.data :
+  {
+    . = ALIGN(4);
+    _data_start = ABSOLUTE(.);
+    __data_start = ABSOLUTE(.);
+
+    *(.data)
+    *(.data.*)
+    *(.gnu.linkonce.d.*)
+    *(.data1)
+
+#ifdef CONFIG_RISCV_GP
+    . = ALIGN(8);
+    __global_pointer$ = . + 0x800;
+#endif /* CONFIG_RISCV_GP */
+
+    *(.sdata)
+    *(.sdata.*)
+    *(.gnu.linkonce.s.*)
+    *(.sdata2)
+    *(.sdata2.*)
+    *(.gnu.linkonce.s2.*)
+
+    /* All dependent functions should be placed in DRAM to avoid issue
+     * when flash cache is disabled */
+    *libkernel.a:fatal.*(.rodata .rodata.* .srodata .srodata.*)
+    *libkernel.a:init.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:cbprintf_complete*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:log_core.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:log_backend_uart.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:log_output.*(.rodata .rodata.* .srodata .srodata.*)
+    *libdrivers__flash.a:flash_esp32.*(.rodata  .rodata.* .srodata .srodata.*)
+    *libdrivers__serial.a:uart_esp32.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:spi_flash_rom_patch.*(.rodata  .rodata.* .srodata .srodata.*)
+    *libzephyr.a:periph_ctrl.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:loader.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:cache_utils.*(.rodata .rodata.* .srodata .srodata.*)
+
+    /* [mapping:hal] */
+    *libzephyr.a:mmu_hal.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:spi_flash_hal_iram.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:spi_flash_encrypt_hal_iram.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:cache_hal.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:ledc_hal_iram.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:i2c_hal_iram.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:wdt_hal_iram.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:systimer_hal.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:spi_flash_hal_gpspi.*(.rodata .rodata.* .srodata .srodata.*)
+
+    /* [mapping:soc] */
+    *libzephyr.a:lldesc.*(.rodata .rodata.* .srodata .srodata.*)
+
+    /* [mapping:log] */
+    *(.rodata.esp_log_write)
+    *(.rodata.esp_log_timestamp)
+    *(.rodata.esp_log_early_timestamp)
+    *(.rodata.esp_log_impl_lock)
+    *(.rodata.esp_log_impl_lock_timeout)
+    *(.rodata.esp_log_impl_unlock)
+
+    /* [mapping:spi_flash] */
+    *libzephyr.a:spi_flash_chip_boya.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:spi_flash_chip_gd.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:spi_flash_chip_generic.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:spi_flash_chip_issi.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:spi_flash_chip_mxic.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:spi_flash_chip_mxic_opi.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:spi_flash_chip_th.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:spi_flash_chip_winbond.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:memspi_host_driver.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:flash_brownout_hook.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:spi_flash_wrap.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:spi_flash_hpm_enable.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:spi_flash_oct_flash_init.*(.rodata .rodata.* .srodata .srodata.*)
+
+    /* [mapping:esp_mm] */
+    *libzephyr.a:esp_cache.*(.rodata .rodata.* .srodata .srodata.*)
+
+    /* [mapping:esp_hw_support] */
+    *(.rodata.esp_cpu_stall)
+    *(.rodata.esp_cpu_unstall)
+    *(.rodata.esp_cpu_reset)
+    *(.rodata.esp_cpu_wait_for_intr)
+    *(.rodata.esp_cpu_compare_and_set)
+    *(.rodata.esp_gpio_reserve_pins)
+    *(.rodata.esp_gpio_is_pin_reserved)
+    *(.rodata.rtc_vddsdio_get_config)
+    *(.rodata.rtc_vddsdio_set_config)
+    *libzephyr.a:esp_memory_utils.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:rtc_clk.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:rtc_clk_init.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:systimer.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:mspi_timing_config.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:mspi_timing_tuning.*(.rodata .rodata.* .srodata .srodata.*)
+    *(.rodata.sar_periph_ctrl_power_enable)
+
+    /* [mapping:esp_system] */
+    *libzephyr.a:esp_err.*(.rodata .rodata.*)
+    *(.rodata.esp_system_abort)
+
+    . = ALIGN(4);
+    #include <snippets-rwdata.ld>
+    . = ALIGN(4);
+
+    KEEP(*(.jcr))
+    *(.dram1 .dram1.*)
+    . = ALIGN(4);
+  } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+
+#ifdef CONFIG_ESP_SIMPLE_BOOT
+  /* Secondary loader sections */
+  .loader.data :
+  {
+    . = ALIGN(4);
+    _loader_data_start = ABSOLUTE(.);
+    *libzephyr.a:bootloader_soc.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:bootloader_init.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:bootloader_esp32c3.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:bootloader_clock_init.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:bootloader_wdt.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:bootloader_flash.*(.srodata .srodata.* .rodata .rodata.*)
+    *libzephyr.a:bootloader_flash_config_esp32c3.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:bootloader_clock_loader.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:bootloader_common_loader.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:bootloader_panic.*(.rodata .rodata.* .srodata .srodata.*)
+
+    *libzephyr.a:cpu_region_protect.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:clk.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:esp_clk.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:flash_mmap.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:flash_ops.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:flash_ops_esp32c3.*(.rodata .rodata.* .srodata .srodata.*)
+
+    *libzephyr.a:esp_gpio_reserve.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:spi_flash_hal.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:spi_flash_hal_common.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:esp_flash_api.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:esp_flash_spi_init.*(.rodata .rodata.* .srodata .srodata.*)
+
+    . = ALIGN(16);
+    _loader_data_end = ABSOLUTE(.);
+  } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+#endif /* CONFIG_ESP_SIMPLE_BOOT */
+
+  #include <snippets-data-sections.ld>
+  #include <zephyr/linker/common-ram.ld>
+  #include <snippets-ram-sections.ld>
+  #include <zephyr/linker/cplusplus-ram.ld>
+
+  /* logging sections should be placed in RAM area to avoid flash cache disabled issues */
+  #pragma push_macro("GROUP_ROM_LINK_IN")
+  #undef GROUP_ROM_LINK_IN
+  #define GROUP_ROM_LINK_IN GROUP_DATA_LINK_IN
+  #include <zephyr/linker/common-rom/common-rom-logging.ld>
+  #pragma pop_macro("GROUP_ROM_LINK_IN")
+
+  .dram0.end :
+  {
+    . = ALIGN(4);
+    _data_end = ABSOLUTE(.);
+    __data_end = ABSOLUTE(.);
+  } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+
+  .dram0.noinit (NOLOAD):
+  {
+    . = ALIGN(4);
+    *(.noinit)
+    *(.noinit.*)
+    . = ALIGN(4);
+  } GROUP_LINK_IN(RAMABLE_REGION)
+
+  /* Shared RAM */
+  .dram0.bss (NOLOAD) :
+  {
+    . = ALIGN (8);
+    __bss_start = ABSOLUTE(.);
+    _bss_start = ABSOLUTE(.);
+
+    /*  bluetooth library requires this symbol to be defined */
+    _btdm_bss_start = ABSOLUTE(.);
+    *libbtdm_app.a:(.bss .bss.* COMMON)
+    . = ALIGN (4);
+    _btdm_bss_end = ABSOLUTE(.);
+
+    *(.dynsbss)
+    *(.sbss)
+    *(.sbss.*)
+    *(.gnu.linkonce.sb.*)
+    *(.scommon)
+    *(.sbss2)
+    *(.sbss2.*)
+    *(.gnu.linkonce.sb2.*)
+    *(.dynbss)
+    *(.bss)
+    *(.bss.*)
+    *(.share.mem)
+    *(.gnu.linkonce.b.*)
+    *(COMMON)
+    . = ALIGN (16);
+    __bss_end = ABSOLUTE(.);
+    _bss_end = ABSOLUTE(.);
+  } GROUP_LINK_IN(RAMABLE_REGION)
+
+  /* Provide total SRAM usage, including IRAM and DRAM */
+  _image_ram_start = _iram_start - IRAM_DRAM_OFFSET;
+  #include <zephyr/linker/ram-end.ld>
+
+  ASSERT(((__bss_end - ORIGIN(dram0_0_seg)) <= LENGTH(dram0_0_seg)), "DRAM segment data does not fit.")
+
+  /* --- END OF DRAM --- */
+
+  /* --- START OF .rodata --- */
+
+  /* Align next section to 64k to allow mapping */
+  .flash.rodata_dummy (NOLOAD) :
+  {
+    . = ALIGN(CACHE_ALIGN);
+  } GROUP_LINK_IN(ROMABLE_REGION)
+
+  /* Symbols used during the application memory mapping */
+  _image_drom_start = LOADADDR(.flash.rodata);
+  _image_drom_size = LOADADDR(.flash.rodata_end) + SIZEOF(.flash.rodata_end) - _image_drom_start;
+  _image_drom_vaddr = ADDR(.flash.rodata);
+
+  .flash.rodata : ALIGN(0x10)
   {
     _rodata_reserved_start = ABSOLUTE(.);
     _rodata_start = ABSOLUTE(.);
@@ -140,10 +662,6 @@ SECTIONS
 
     . = ALIGN(4);
     #include <snippets-rodata.ld>
-
-    . = ALIGN(4);
-    *(EXCLUDE_FILE (*libarch__riscv__core.a:* *libkernel.a:fatal.* *libkernel.a:init.* *libzephyr.a:cbprintf_complete* *libzephyr.a:log_core.* *libzephyr.a:log_backend_uart.* *libdrivers__flash.a:esp32_mp.* *libzephyr.a:log_output.* *libzephyr.a:loader.* *libdrivers__flash.a:flash_esp32.* *libdrivers__serial.a:uart_esp32.* *libzephyr.a:spi_flash_rom_patch.*) .rodata)
-    *(EXCLUDE_FILE (*libarch__riscv__core.a:* *libkernel.a:fatal.* *libkernel.a:init.* *libzephyr.a:cbprintf_complete* *libzephyr.a:log_core.* *libzephyr.a:log_backend_uart.* *libdrivers__flash.a:esp32_mp.* *libzephyr.a:log_output.* *libzephyr.a:loader.* *libdrivers__flash.a:flash_esp32.* *libdrivers__serial.a:uart_esp32.* *libzephyr.a:spi_flash_rom_patch.*) .rodata.*)
 
     *(.irom1.text) /* catch stray ICACHE_RODATA_ATTR */
     *(.gnu.linkonce.r.*)
@@ -184,6 +702,7 @@ SECTIONS
     . = ALIGN(4);
   } GROUP_DATA_LINK_IN(RODATA_REGION, ROMABLE_REGION)
 
+  #include <zephyr/linker/cplusplus-rom.ld>
   #include <zephyr/linker/common-rom/common-rom-cpp.ld>
   #include <zephyr/linker/common-rom/common-rom-kernel-devices.ld>
   #include <zephyr/linker/common-rom/common-rom-ztest.ld>
@@ -196,236 +715,54 @@ SECTIONS
 
   /* Create an explicit section at the end of all the data that shall be mapped into drom.
    * This is used to calculate the size of the _image_drom_size variable */
-  SECTION_PROLOGUE(_RODATA_SECTION_END,,)
+  .flash.rodata_end : ALIGN(0x10)
   {
-    _rodata_reserved_end = ABSOLUTE(.);
     . = ALIGN(4);
+    _rodata_reserved_end = ABSOLUTE(.);
     _image_rodata_end = ABSOLUTE(.);
   } GROUP_DATA_LINK_IN(RODATA_REGION, ROMABLE_REGION)
 
-  .iram0.text : ALIGN(4)
-  {
-    /* Vectors go to IRAM */
-    _iram_start = ABSOLUTE(.);
-    _init_start = ABSOLUTE(.);
+  /* --- END OF .rodata --- */
 
-    KEEP(*(.exception_vectors.text));
-    . = ALIGN(256);
+  /* --- START OF .flash.text --- */
 
-    _invalid_pc_placeholder = ABSOLUTE(.);
-
-    _iram_text_start = ABSOLUTE(.);
-
-    KEEP(*(.exception.entry*)); /* contains _isr_wrapper */
-    *(.exception.other*)
-    . = ALIGN(4);
-
-    *(.entry.text)
-    *(.init.literal)
-    *(.init)
-    . = ALIGN(4);
-    *(.iram1 .iram1.*)
-    *(.iram0.literal .iram.literal .iram.text.literal .iram0.text .iram.text)
-    *libesp32.a:panic.*(.literal .text .literal.* .text.*)
-    *librtc.a:(.literal .text .literal.* .text.*)
-    *libarch__riscv__core.a:(.literal .text .literal.* .text.*)
-    *libsubsys__net__l2__ethernet.a:(.literal .text .literal.* .text.*)
-    *libsubsys__net__lib__config.a:(.literal .text .literal.* .text.*)
-    *libsubsys__net__ip.a:(.literal .text .literal.* .text.*)
-    *libsubsys__net.a:(.literal .text .literal.* .text.*)
-    *libkernel.a:(.literal .text .literal.* .text.*)
-    *libgcc.a:lib2funcs.*(.literal .text .literal.* .text.*)
-    *libdrivers__flash.a:flash_esp32.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:spi_flash_rom_patch.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:log_noos.*(.literal .text .literal.* .text.*)
-    *libdrivers__timer.a:esp32_sys_timer.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:log_core.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:cbprintf_complete.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:printk.*(.literal.printk .literal.vprintk .literal.char_out .text.printk .text.vprintk .text.char_out)
-    *libzephyr.a:log_msg.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:log_list.*(.literal .text .literal.* .text.*)
-    *libdrivers__console.a:uart_console.*(.literal.console_out .text.console_out)
-    *libzephyr.a:log_output.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:log_backend_uart.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:cache_hal.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:mmu_hal.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:loader.*(.literal .text .literal.* .text.*)
-    *libsoc.a:rtc_*.*(.literal .text .literal.* .text.*)
-    *libsoc.a:cpu_util.*(.literal .text .literal.* .text.*)
-    *liblib__libc__newlib.a:string.*(.literal .text .literal.* .text.*)
-    *liblib__libc__minimal.a:string.*(.literal .text .literal.* .text.*)
-    *libc.a:*(.literal .text .literal.* .text.*)
-    *libphy.a:( .phyiram .phyiram.*)
-    *libgcov.a:(.literal .text .literal.* .text.*)
-
-#if defined(CONFIG_ESP32_WIFI_IRAM_OPT)
-    *libnet80211.a:( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.*)
-    *libpp.a:( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.*)
-#endif
-
-#if defined(CONFIG_ESP32_WIFI_RX_IRAM_OPT)
-    *libnet80211.a:( .wifirxiram  .wifirxiram.* .wifislprxiram .wifislprxiram.*)
-    *libpp.a:( .wifirxiram  .wifirxiram.* .wifislprxiram .wifislprxiram.*)
-#endif
-    . = ALIGN(4);
-    _init_end = ABSOLUTE(.);
-  } GROUP_DATA_LINK_IN(IRAM_REGION, ROMABLE_REGION)
-
-  .dram0.dummy (NOLOAD):
-  {
-    /**
-    * This section is required to skip .iram0.text area because iram0_0_seg and
-    * dram0_0_seg reflect the same address space on different buses.
-    */
-    . = ORIGIN(dram0_0_seg) + _iram_end - _iram_start;
-  } GROUP_LINK_IN(RAMABLE_REGION)
-
- /* Shared RAM */
-  SECTION_DATA_PROLOGUE(_BSS_SECTION_NAME,(NOLOAD),)
-  {
-    . = ALIGN (8);
-    __bss_start = ABSOLUTE(.);
-    *(.dynsbss)
-    *(.sbss)
-    *(.sbss.*)
-    *(.gnu.linkonce.sb.*)
-    *(.scommon)
-    *(.sbss2)
-    *(.sbss2.*)
-    *(.gnu.linkonce.sb2.*)
-    *(.dynbss)
-    *(.bss)
-    *(.bss.*)
-    *(.share.mem)
-    *(.gnu.linkonce.b.*)
-    *(COMMON)
-    . = ALIGN (8);
-    __bss_end = ABSOLUTE(.);
-  } GROUP_LINK_IN(RAMABLE_REGION)
-
-  SECTION_DATA_PROLOGUE(_NOINIT_SECTION_NAME, (NOLOAD),)
-  {
-    . = ALIGN(4);
-    *(.noinit)
-    *(.noinit.*)
-    . = ALIGN(4);
-  } GROUP_LINK_IN(RAMABLE_REGION)
-
-  .dram0.data :
-  {
-    . = ALIGN(4);
-    _data_start = ABSOLUTE(.);
-    *(.data)
-    *(.data.*)
-    *(.gnu.linkonce.d.*)
-    *(.data1)
-#ifdef CONFIG_RISCV_GP
-    __global_pointer$ = . + 0x800;
-#endif /* CONFIG_RISCV_GP */
-    *(.sdata)
-    *(.sdata.*)
-    *(.gnu.linkonce.s.*)
-    *(.sdata2)
-    *(.sdata2.*)
-    *(.gnu.linkonce.s2.*)
-
-    /* All dependent functions should be placed in DRAM to avoid issue
-     * when flash cache is disabled */
-    *libkernel.a:fatal.*(.rodata .rodata.*)
-    *libkernel.a:init.*(.rodata .rodata.*)
-    *libzephyr.a:cbprintf_complete*(.rodata .rodata.*)
-    *libzephyr.a:log_core.*(.rodata .rodata.*)
-    *libzephyr.a:log_backend_uart.*(.rodata .rodata.*)
-    *libzephyr.a:log_output.*(.rodata .rodata.*)
-    *libzephyr.a:cache_hal.*(.rodata .rodata.*)
-    *libzephyr.a:mmu_hal.*(.rodata .rodata.*)
-    *libzephyr.a:loader.*(.rodata .rodata.*)
-    *libdrivers__flash.a:flash_esp32.*(.rodata  .rodata.*)
-    *libdrivers__serial.a:uart_esp32.*(.rodata .rodata.*)
-    *libzephyr.a:spi_flash_rom_patch.*(.rodata  .rodata.*)
-
-
-    KEEP(*(.jcr))
-    *(.dram1 .dram1.*)
-    . = ALIGN(4);
-  } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
-
-  #include <zephyr/linker/cplusplus-rom.ld>
-  #include <zephyr/linker/thread-local-storage.ld>
-  #include <snippets-data-sections.ld>
-  #include <zephyr/linker/common-ram.ld>
-  #include <snippets-ram-sections.ld>
-  #include <zephyr/linker/cplusplus-ram.ld>
-
-  /* logging sections should be placed in RAM area to avoid flash cache disabled issues */
-  #pragma push_macro("GROUP_ROM_LINK_IN")
-  #undef GROUP_ROM_LINK_IN
-  #define GROUP_ROM_LINK_IN GROUP_DATA_LINK_IN
-  #include <zephyr/linker/common-rom/common-rom-logging.ld>
-  #pragma pop_macro("GROUP_ROM_LINK_IN")
-
-  .dummy.dram.data :
-  {
-    . = ALIGN(4);
-    #include <snippets-rwdata.ld>
-    _end = ABSOLUTE(.);
-    _data_end = ABSOLUTE(.);
-  } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
-
-  .iram0.text_end (NOLOAD) :
-  {
-    /* C3 memprot requires 512 B alignment for split lines */
-    . = ALIGN (16);
-  } GROUP_LINK_IN(IRAM_REGION)
-
-  .iram0.data :
-  {
-    . = ALIGN(16);
-    *(.iram.data)
-    *(.iram.data*)
-  } GROUP_DATA_LINK_IN(IRAM_REGION, ROMABLE_REGION)
-
-  .iram0.bss (NOLOAD) :
-  {
-    . = ALIGN(16);
-    *(.iram.bss)
-    *(.iram.bss*)
-
-    . = ALIGN(16);
-    _iram_end = ABSOLUTE(.);
-  } GROUP_LINK_IN(IRAM_REGION)
-
+  /* Symbols used during the application memory mapping */
   _image_irom_start = LOADADDR(.flash.text);
   _image_irom_size = LOADADDR(.flash.text) + SIZEOF(.flash.text) - _image_irom_start;
   _image_irom_vaddr = ADDR(.flash.text);
 
-  .flash_text_dummy (NOLOAD): ALIGN(IROM_SEG_ALIGN)
+  .flash.text_dummy (NOLOAD):
   {
-    . = SIZEOF(_RODATA_SECTION_NAME);
-    . = ALIGN(0x10000) + 0x20;
-  } GROUP_LINK_IN(FLASH_CODE_REGION)
+    /* Spacer in the IROM address to avoid interfering with the DROM address
+     * because DROM and IROM regions share the same address space */
+    . += _image_rodata_end - _rodata_start;
+    . = ALIGN(CACHE_ALIGN);
+  } GROUP_DATA_LINK_IN(FLASH_CODE_REGION, ROMABLE_REGION)
 
-  .flash.text : ALIGN(IROM_SEG_ALIGN)
+  .flash.text : ALIGN(CACHE_ALIGN)
   {
     _stext = .;
     _instruction_reserved_start = ABSOLUTE(.);
     _text_start = ABSOLUTE(.);
+    _instruction_reserved_start = ABSOLUTE(.);
 
 #if !defined(CONFIG_ESP32_WIFI_IRAM_OPT)
     *libnet80211.a:( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.*)
     *libpp.a:( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.*)
-#endif
+#endif /* CONFIG_ESP32_WIFI_IRAM_OPT */
 
 #if !defined(CONFIG_ESP32_WIFI_RX_IRAM_OPT)
     *libnet80211.a:( .wifirxiram  .wifirxiram.* .wifislprxiram .wifislprxiram.*)
     *libpp.a:( .wifirxiram  .wifirxiram.* .wifislprxiram .wifislprxiram.*)
-#endif
+#endif /* CONFIG_ESP32_WIFI_RX_IRAM_OPT */
 
     *(.literal .text .literal.* .text.*)
     *(.stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
     *(.irom0.text) /* catch stray ICACHE_RODATA_ATTR */
+
     *(.fini.literal)
     *(.fini)
+
     *(.gnu.version)
 
     /** CPU will try to prefetch up to 16 bytes of
@@ -435,6 +772,7 @@ SECTIONS
       */
     . += 16;
 
+    _instruction_reserved_end = ABSOLUTE(.);
     _text_end = ABSOLUTE(.);
     _instruction_reserved_end = ABSOLUTE(.);
     _etext = .;
@@ -444,63 +782,16 @@ SECTIONS
      * resolved by addr2line in preference to the first symbol in
      * the flash.text segment.
      */
-    _flash_cache_start = ABSOLUTE(0);
+    //_flash_cache_start = ABSOLUTE(0);
   } GROUP_DATA_LINK_IN(FLASH_CODE_REGION, ROMABLE_REGION)
 
-  .rtc.text :
-  {
-    . = ALIGN(4);
-    *(.rtc.literal .rtc.text)
-    *rtc_wake_stub*.o(.literal .text .literal.* .text.*)
-  } GROUP_DATA_LINK_IN(rtc_iram_seg, ROMABLE_REGION)
-
-  /* This section is required to skip rtc.text area because the text and
-   * data segments reflect the same address space on different buses.
-   */
-  .rtc.dummy (NOLOAD):
-  {
-    . = SIZEOF(.rtc.text);
-  } GROUP_LINK_IN(rtc_iram_seg)
-
-  .rtc.data :
-  {
-    _rtc_data_start = ABSOLUTE(.);
-    *(.rtc.data)
-    *(.rtc.rodata)
-    *rtc_wake_stub*.o(.data .rodata .data.* .rodata.* .bss .bss.*)
-    _rtc_data_end = ABSOLUTE(.);
-  } GROUP_DATA_LINK_IN(rtc_iram_seg, ROMABLE_REGION)
-
-  .rtc.bss (NOLOAD) :
-  {
-    _rtc_bss_start = ABSOLUTE(.);
-    *rtc_wake_stub*.o(.bss .bss.*)
-    *rtc_wake_stub*.o(COMMON)
-    _rtc_bss_end = ABSOLUTE(.);
-  } GROUP_LINK_IN(rtc_iram_seg)
-
-  /**
-   * This section located in RTC SLOW Memory area.
-   * It holds data marked with RTC_SLOW_ATTR attribute.
-   * See the file "esp_attr.h" for more information.
-   */
-  .rtc.force_slow :
-  {
-    . = ALIGN(4);
-    _rtc_force_slow_start = ABSOLUTE(.);
-    *(.rtc.force_slow .rtc.force_slow.*)
-    . = ALIGN(4) ;
-    _rtc_force_slow_end = ABSOLUTE(.);
-  } > rtc_slow_seg
-
-  /* Get size of rtc slow data */
-  _rtc_slow_length = (_rtc_force_slow_end - _rtc_data_start);
+  /* --- END OF .flash.text --- */
 
 #ifdef CONFIG_GEN_ISR_TABLES
-#include <zephyr/linker/intlist.ld>
+  #include <zephyr/linker/intlist.ld>
 #endif
 
-#include <zephyr/linker/debug-sections.ld>
+  #include <zephyr/linker/debug-sections.ld>
   /DISCARD/ : { *(.note.GNU-stack) }
 
   SECTION_PROLOGUE(.riscv.attributes, 0,)

--- a/soc/espressif/esp32c3/mcuboot.ld
+++ b/soc/espressif/esp32c3/mcuboot.ld
@@ -1,19 +1,14 @@
 /*
- * Copyright (c) 2023 Espressif Systems (Shanghai) Co., Ltd.
+ * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
  * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
- * @file
- * @brief Linker command/script file
- *
- * Linker script for the esp32c3 platform.
  */
 
 #include <zephyr/devicetree.h>
 #include <zephyr/linker/sections.h>
 #include <zephyr/linker/linker-defs.h>
 #include <zephyr/linker/linker-tool.h>
+
+#include "memory.h"
 
 #ifdef CONFIG_XIP
 #error "ESP32C3 bootloader cannot use XIP"
@@ -24,20 +19,18 @@
 #define GROUP_DATA_LINK_IN(vregion, lregion) > vregion
 
 #define RAMABLE_REGION dram_seg
-#define RODATA_REGION dram_seg
-
-#define IRAM_REGION iram_seg
-#define IRAM_LOADER_REGION iram_loader_seg
-
+#define RODATA_REGION  dram_seg
 #define ROMABLE_REGION dram_seg
-#define IROM_SEG_ALIGN 0x4
 
 /* Global symbols required for espressif hal build */
 MEMORY
 {
-  iram_seg        (RX) : org = 0x403CA000, len = 0x9000
-  iram_loader_seg (RX) : org = 0x403D3000, len = 0x4000
-  dram_seg        (RW) : org = 0x3FCD8000, len = 0x9000
+  iram_seg        (RX) : org = BOOTLOADER_IRAM_SEG_START,
+                         len = BOOTLOADER_IRAM_SEG_LEN
+  iram_loader_seg (RX) : org = BOOTLOADER_IRAM_LOADER_SEG_START,
+                         len = BOOTLOADER_IRAM_LOADER_SEG_LEN
+  dram_seg        (RW) : org = BOOTLOADER_DRAM_SEG_START,
+                         len = BOOTLOADER_DRAM_SEG_LEN
 
 #ifdef CONFIG_GEN_ISR_TABLES
   IDT_LIST(RW): org = 0x3ebfe010, len = 0x2000
@@ -49,14 +42,134 @@ ENTRY(CONFIG_KERNEL_ENTRY)
 
 SECTIONS
 {
-  SECTION_PROLOGUE(_RODATA_SECTION_NAME,,)
+  .iram0.loader_text :
   {
-    _rodata_start = ABSOLUTE(.);
+    . = ALIGN (16);
+    _loader_text_start = ABSOLUTE(.);
+    *(.stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
+
+    /* TODO: cross-segments calls in the libzephyr.a:device.* */
+
+    *libapp.a:flash_map_extended.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:cbprintf_nano.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:cpu.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:mmu_hal.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:cache_hal.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:flash_map.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:esp_rom_spiflash.*(.literal .text .literal.* .text.*)
+
+    *libzephyr.a:heap.*(.literal .text .literal.* .text.*)
+
+    *libkernel.a:kheap.*(.literal .text .literal.* .text.*)
+    *libkernel.a:mempool.*(.literal .text .literal.* .text.*)
+
+    *(.literal.bootloader_mmap .text.bootloader_mmap)
+    *(.literal.bootloader_munmap .text.bootloader_munmap)
+
+    *libzephyr.a:esp_loader.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:mmu_hal.*(.literal .text .literal.* .text.*)
+
+    *(.literal.esp_intr_disable .literal.esp_intr_disable.* .text.esp_intr_disable .text.esp_intr_disable.*)
+    *(.literal.default_intr_handler .text.default_intr_handler .iram1.*.default_intr_handler)
+    *(.literal.esp_log_timestamp .text.esp_log_timestamp)
+    *(.literal.esp_log_early_timestamp .text.esp_log_early_timestamp)
+    *(.literal.esp_system_abort .text.esp_system_abort)
+
+    *(.fini.literal)
+    *(.fini)
+    *(.gnu.version)
+    _loader_text_end = ABSOLUTE(.);
+    _iram_end = ABSOLUTE(.);
+  } > iram_loader_seg
+
+  .iram0.text :
+  {
+    /* Vectors go to IRAM */
+    _iram_start = ABSOLUTE(.);
+    _init_start = ABSOLUTE(.);
+
+    KEEP(*(.exception_vectors.text));
+    . = ALIGN(256);
+
+    _invalid_pc_placeholder = ABSOLUTE(.);
+
+    _iram_text_start = ABSOLUTE(.);
+
+    KEEP(*(.exception.entry*)); /* contains _isr_wrapper */
+    *(.exception.other*)
+    . = ALIGN(4);
+
+    *(.entry.text)
+    *(.init.literal)
+    *(.init)
+    . = ALIGN(4);
+    *(.iram1 .iram1.*)
+    *(.iram0.literal .iram.literal .iram.text.literal .iram0.text .iram.text)
+
+    /* C3 memprot requires 512 B alignment for split lines */
+    . = ALIGN (16);
+    _init_end = ABSOLUTE(.);
+    . = ALIGN(16);
+    *(.iram.data)
+    *(.iram.data*)
+    . = ALIGN(16);
+    *(.iram.bss)
+    *(.iram.bss*)
+
+    . = ALIGN(16);
+
+    *(.literal .text .literal.* .text.*)
+    *(.stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
+    *(.irom0.text) /* catch stray ICACHE_RODATA_ATTR */
+    *(.fini.literal)
+    *(.fini)
+    *(.gnu.version)
+
+    /* CPU will try to prefetch up to 16 bytes of
+     * of instructions. This means that any configuration (e.g. MMU, PMS) must allow
+     * safe access to up to 16 bytes after the last real instruction, add
+     * dummy bytes to ensure this
+     */
+    . += 16;
+
+    _text_end = ABSOLUTE(.);
+    _etext = .;
+
+    /* Similar to _iram_start, this symbol goes here so it is
+     * resolved by addr2line in preference to the first symbol in
+     * the flash.text segment.
+     */
+    _flash_cache_start = ABSOLUTE(0);
+  } > iram_seg
+
+  .dram0.data :
+  {
+    . = ALIGN(4);
+    __data_start = ABSOLUTE(.);
+    *(.data)
+    *(.data.*)
+    *(.gnu.linkonce.d.*)
+    *(.data1)
+#ifdef CONFIG_RISCV_GP
+    __global_pointer$ = . + 0x800;
+#endif /* CONFIG_RISCV_GP */
+    *(.sdata)
+    *(.sdata.*)
+    *(.gnu.linkonce.s.*)
+    *(.sdata2)
+    *(.sdata2.*)
+    *(.gnu.linkonce.s2.*)
+    *libzephyr.a:mmu_hal.*(.rodata .rodata.*)
+    *libzephyr.a:rtc_clk.*(.rodata .rodata.*)
+    KEEP(*(.jcr))
+    *(.dram1 .dram1.*)
+    . = ALIGN(4);
+
+    #include <snippets-rwdata.ld>
+    . = ALIGN(4);
 
     *(.rodata_desc .rodata_desc.*)
     *(.rodata_custom_desc .rodata_custom_desc.*)
-
-    __rodata_region_start = .;
 
     . = ALIGN(4);
     #include <snippets-rodata.ld>
@@ -108,38 +221,13 @@ SECTIONS
     _thread_local_end = ABSOLUTE(.);
     /* _rodata_reserved_end = ABSOLUTE(.); */
     . = ALIGN(4);
-  } GROUP_DATA_LINK_IN(RODATA_REGION, ROMABLE_REGION)
+  } > dram_seg
 
   #include <zephyr/linker/common-rom/common-rom-cpp.ld>
   #include <zephyr/linker/common-rom/common-rom-kernel-devices.ld>
   #include <zephyr/linker/common-rom/common-rom-debug.ld>
   #include <zephyr/linker/common-rom/common-rom-misc.ld>
-
   #include <snippets-sections.ld>
-
-  .dram0.data :
-  {
-    . = ALIGN(4);
-    __data_start = ABSOLUTE(.);
-    *(.data)
-    *(.data.*)
-    *(.gnu.linkonce.d.*)
-    *(.data1)
-#ifdef CONFIG_RISCV_GP
-    __global_pointer$ = . + 0x800;
-#endif /* CONFIG_RISCV_GP */
-    *(.sdata)
-    *(.sdata.*)
-    *(.gnu.linkonce.s.*)
-    *(.sdata2)
-    *(.sdata2.*)
-    *(.gnu.linkonce.s2.*)
-    *libzephyr.a:mmu_hal.*(.rodata .rodata.*)
-    *libzephyr.a:rtc_clk.*(.rodata .rodata.*)
-    KEEP(*(.jcr))
-    *(.dram1 .dram1.*)
-    . = ALIGN(4);
-  } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
   #include <zephyr/linker/cplusplus-rom.ld>
   #include <zephyr/linker/thread-local-storage.ld>
@@ -150,17 +238,16 @@ SECTIONS
 
   #include <zephyr/linker/common-rom/common-rom-logging.ld>
 
-  .dram0.end :
+  .noinit (NOLOAD):
   {
     . = ALIGN(4);
-    #include <snippets-rwdata.ld>
+    *(.noinit)
+    *(.noinit.*)
     . = ALIGN(4);
-    _end = ABSOLUTE(.);
-    __data_end = ABSOLUTE(.);
-  } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+  } > dram_seg
 
   /* Shared RAM */
-  SECTION_DATA_PROLOGUE(_BSS_SECTION_NAME,(NOLOAD),)
+  .bss (NOLOAD):
   {
     . = ALIGN (8);
     _bss_start = ABSOLUTE(.);
@@ -182,155 +269,13 @@ SECTIONS
     . = ALIGN (8);
     __bss_end = ABSOLUTE(.);
     _bss_end = ABSOLUTE(.);
-  } GROUP_LINK_IN(RAMABLE_REGION)
-
-  SECTION_DATA_PROLOGUE(_NOINIT_SECTION_NAME, (NOLOAD),)
-  {
-    . = ALIGN(4);
-    *(.noinit)
-    *(.noinit.*)
-    . = ALIGN(4);
-  } GROUP_LINK_IN(RAMABLE_REGION)
-
-  .iram_loader.text :
-  {
-    . = ALIGN (16);
-    _loader_text_start = ABSOLUTE(.);
-    *(.stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
-    *(.iram1 .iram1.*) /* catch stray IRAM_ATTR */
-    *libzephyr.a:bootloader_flash.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_flash_config_esp32c3.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_clock_loader.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_common_loader.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_init_common.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_random.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_random*.*(.literal.bootloader_random_disable .text.bootloader_random_disable)
-    *libzephyr.a:bootloader_random*.*(.literal.bootloader_random_enable .text.bootloader_random_enable)
-    *libzephyr.a:bootloader_efuse_esp32c3.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_utility.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_sha.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_console.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_console_loader.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_panic.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_soc.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:esp_image_format.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:flash_encrypt.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:flash_encryption_secure_features.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:flash_partitions.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:secure_boot.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:secure_boot_secure_features.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:secure_boot_signatures_bootloader.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:wdt_hal_iram.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:esp_efuse_table.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:esp_efuse_fields.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:esp_efuse_api.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:esp_efuse_utility.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:esp_efuse_api_key_esp32xx.*(.literal .text .literal.* .text.*)
-    *esp_mcuboot.*(.literal .text .literal.* .text.*)
-    *esp_loader.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:mmu_hal.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:rtc_clk.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:rtc_clk_init.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:rtc_time.*(.literal .literal.* .text .text.*)
-    *(.fini.literal)
-    *(.fini)
-    *(.gnu.version)
-    _loader_text_end = ABSOLUTE(.);
-  } > iram_loader_seg
-
-  /* .iram0.text : ALIGN(4) */
-  SECTION_PROLOGUE(_TEXT_SECTION_NAME, , ALIGN(4))
-  {
-    /* Vectors go to IRAM */
-    _iram_start = ABSOLUTE(.);
-    _init_start = ABSOLUTE(.);
-
-    KEEP(*(.exception_vectors.text));
-    . = ALIGN(256);
-
-    _invalid_pc_placeholder = ABSOLUTE(.);
-
-    _iram_text_start = ABSOLUTE(.);
-
-    KEEP(*(.exception.entry*)); /* contains _isr_wrapper */
-    *(.exception.other*)
-    . = ALIGN(4);
-
-    *(.entry.text)
-    *(.init.literal)
-    *(.init)
-    . = ALIGN(4);
-    *(.iram1 .iram1.*)
-    *(.iram0.literal .iram.literal .iram.text.literal .iram0.text .iram.text)
-
-    . = ALIGN(4);
-    _init_end = ABSOLUTE(.);
-  } GROUP_DATA_LINK_IN(IRAM_LOADER_REGION, ROMABLE_REGION)
-
-  .iram0.text_end (NOLOAD) :
-  {
-    /* C3 memprot requires 512 B alignment for split lines */
-    . = ALIGN (16);
-  } GROUP_LINK_IN(IRAM_LOADER_REGION)
-
-  .iram0.data :
-  {
-    . = ALIGN(16);
-    *(.iram.data)
-    *(.iram.data*)
-  } GROUP_DATA_LINK_IN(IRAM_LOADER_REGION, ROMABLE_REGION)
-
-  .iram0.bss (NOLOAD) :
-  {
-    . = ALIGN(16);
-    *(.iram.bss)
-    *(.iram.bss*)
-
-    . = ALIGN(16);
-    _iram_end = ABSOLUTE(.);
-  } GROUP_LINK_IN(IRAM_LOADER_REGION)
-
-  .flash_text_dummy (NOLOAD): ALIGN(IROM_SEG_ALIGN)
-  {
-    . = SIZEOF(_RODATA_SECTION_NAME);
-    . = ALIGN(4) + 0x20;
-    _rodata_reserved_start = .;
-  } GROUP_LINK_IN(IRAM_REGION)
-
-  .flash.text : ALIGN(IROM_SEG_ALIGN)
-  {
-    _stext = .;
-    _text_start = ABSOLUTE(.);
-
-    *(.literal .text .literal.* .text.*)
-    *(.stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
-    *(.irom0.text) /* catch stray ICACHE_RODATA_ATTR */
-    *(.fini.literal)
-    *(.fini)
-    *(.gnu.version)
-
-    /* CPU will try to prefetch up to 16 bytes of
-     * of instructions. This means that any configuration (e.g. MMU, PMS) must allow
-     * safe access to up to 16 bytes after the last real instruction, add
-     * dummy bytes to ensure this
-     */
-    . += 16;
-
-    _text_end = ABSOLUTE(.);
-    _etext = .;
-
-    /* Similar to _iram_start, this symbol goes here so it is
-     * resolved by addr2line in preference to the first symbol in
-     * the flash.text segment.
-     */
-    _flash_cache_start = ABSOLUTE(0);
-  } GROUP_DATA_LINK_IN(IRAM_REGION, ROMABLE_REGION)
+  } > dram_seg
 
   /* linker rel sections*/
   #include <zephyr/linker/rel-sections.ld>
 
 #ifdef CONFIG_GEN_ISR_TABLES
-#include <zephyr/linker/intlist.ld>
+  #include <zephyr/linker/intlist.ld>
 #endif
 
 #include <zephyr/linker/debug-sections.ld>

--- a/soc/espressif/esp32c3/memory.h
+++ b/soc/espressif/esp32c3/memory.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+/* SRAM0 (16kB) memory */
+#define SRAM0_IRAM_START   0x4037c000
+#define SRAM0_SIZE         0x4000
+/* SRAM1 (384kB) memory */
+#define SRAM1_DRAM_START   0x3fc80000
+#define SRAM1_IRAM_START   0x40380000
+/* ICache size is fixed to 16KB on ESP32-C3 */
+#define ICACHE_SIZE        SRAM0_SIZE
+
+/** Simplified memory map for the bootloader.
+ *  Make sure the bootloader can load into main memory without overwriting itself.
+ *
+ *  ESP32-C3 ROM static data usage is as follows:
+ *  - 0x3fccae00 - 0x3fcdc710: Shared buffers, used in UART/USB/SPI download mode only
+ *  - 0x3fcdc710 - 0x3fcde710: PRO CPU stack, can be reclaimed as heap after RTOS startup
+ *  - 0x3fcde710 - 0x3fce0000: ROM .bss and .data (not easily reclaimable)
+ *
+ *  The 2nd stage bootloader can take space up to the end of ROM shared
+ *  buffers area (0x3fcdc710).
+ */
+
+/* The offset between Dbus and Ibus.
+ * Used to convert between 0x403xxxxx and 0x3fcxxxxx addresses.
+ */
+#define IRAM_DRAM_OFFSET         0x700000
+#define DRAM_BUFFERS_START       0x3fccae00
+#define DRAM_STACK_START         0x3fcdc710
+#define DRAM_ROM_BSS_DATA_START  0x3fcde710
+
+/* Base address used for calculating memory layout
+ * counted from Dbus backwards and back to the Ibus
+ */
+#define BOOTLOADER_USABLE_DRAM_END DRAM_BUFFERS_START
+
+/* For safety margin between bootloader data section and startup stacks */
+#define BOOTLOADER_STACK_OVERHEAD      0x0
+/* These lengths can be adjusted, if necessary: */
+#define BOOTLOADER_DRAM_SEG_LEN        0x9000
+#define BOOTLOADER_IRAM_LOADER_SEG_LEN 0x3000
+#define BOOTLOADER_IRAM_SEG_LEN        0x8000
+
+/* Start of the lower region is determined by region size and the end of the higher region */
+#define BOOTLOADER_DRAM_SEG_END   (BOOTLOADER_USABLE_DRAM_END + BOOTLOADER_STACK_OVERHEAD)
+#define BOOTLOADER_DRAM_SEG_START (BOOTLOADER_DRAM_SEG_END - BOOTLOADER_DRAM_SEG_LEN)
+#define BOOTLOADER_IRAM_LOADER_SEG_START (BOOTLOADER_DRAM_SEG_START - \
+					BOOTLOADER_IRAM_LOADER_SEG_LEN + IRAM_DRAM_OFFSET)
+#define BOOTLOADER_IRAM_SEG_START (BOOTLOADER_IRAM_LOADER_SEG_START - BOOTLOADER_IRAM_SEG_LEN)
+
+/* Flash */
+#ifdef CONFIG_FLASH_SIZE
+#define FLASH_SIZE         CONFIG_FLASH_SIZE
+#else
+#define FLASH_SIZE         0x400000
+#endif
+
+/* Cached memory */
+#define CACHE_ALIGN        CONFIG_MMU_PAGE_SIZE
+#define IROM_SEG_ORG       0x42000000
+#define IROM_SEG_LEN       FLASH_SIZE
+#define DROM_SEG_ORG       0x3c000000
+#define DROM_SEG_LEN       FLASH_SIZE

--- a/soc/espressif/esp32c3/soc.c
+++ b/soc/espressif/esp32c3/soc.c
@@ -43,17 +43,6 @@ extern void esp_reset_reason_init(void);
  */
 void __attribute__((section(".iram1"))) __esp_platform_start(void)
 {
-#ifdef CONFIG_RISCV_GP
-	/* Configure the global pointer register
-	 * (This should be the first thing startup does, as any other piece of code could be
-	 * relaxed by the linker to access something relative to __global_pointer$)
-	 */
-	__asm__ __volatile__(".option push\n"
-						".option norelax\n"
-						"la gp, __global_pointer$\n"
-						".option pop");
-#endif /* CONFIG_RISCV_GP */
-
 	__asm__ __volatile__("la t0, _esp32c3_vector_table\n"
 						"csrw mtvec, t0\n");
 
@@ -64,12 +53,7 @@ void __attribute__((section(".iram1"))) __esp_platform_start(void)
 
 	esp_reset_reason_init();
 
-#ifdef CONFIG_MCUBOOT
-	/* MCUboot early initialisation.
-	 */
-	bootloader_init();
-
-#else
+#ifndef CONFIG_MCUBOOT
 	/* ESP-IDF 2nd stage bootloader enables RTC WDT to check on startup sequence
 	 * related issues in application. Hence disable that as we are about to start
 	 * Zephyr environment.
@@ -103,13 +87,13 @@ void __attribute__((section(".iram1"))) __esp_platform_start(void)
 #ifdef CONFIG_SOC_FLASH_ESP32
 	esp_mspi_pin_init();
 
-    /**
-     * This function initialise the Flash chip to the user-defined settings.
-     *
-     * In bootloader, we only init Flash (and MSPI) to a preliminary state, for being flexible to
-     * different chips.
-     * In this stage, we re-configure the Flash (and MSPI) to required configuration
-     */
+	/**
+	 * This function initialise the Flash chip to the user-defined settings.
+	 *
+	 * In bootloader, we only init Flash (and MSPI) to a preliminary
+	 * state, for being flexible to different chips.
+	 * In this stage, we re-configure the Flash (and MSPI) to required configuration
+	 */
 	spi_flash_init_chip_state();
 
 	esp_mmu_map_init();
@@ -127,7 +111,7 @@ void __attribute__((section(".iram1"))) __esp_platform_start(void)
 	spi_flash_guard_set(&g_flash_guard_default_ops);
 #endif
 
-#endif /* CONFIG_MCUBOOT */
+#endif /* !CONFIG_MCUBOOT */
 
 	/*Initialize the esp32c3 interrupt controller */
 	esp_intr_initialize();

--- a/soc/espressif/esp32s2/CMakeLists.txt
+++ b/soc/espressif/esp32s2/CMakeLists.txt
@@ -13,57 +13,60 @@ zephyr_library_sources_ifdef(CONFIG_NEWLIB_LIBC newlib_fix.c)
 zephyr_library_sources_ifdef(CONFIG_PM power.c)
 zephyr_library_sources_ifdef(CONFIG_POWEROFF poweroff.c)
 
-# get code-partition slot0 address
-dt_nodelabel(dts_partition_path NODELABEL "slot0_partition")
-dt_reg_addr(img_0_off PATH ${dts_partition_path})
-
-# get code-partition boot address
-dt_nodelabel(dts_partition_path NODELABEL "boot_partition")
-dt_reg_addr(boot_off PATH ${dts_partition_path})
-
 # get flash size to use in esptool as string
 math(EXPR esptoolpy_flashsize "${CONFIG_FLASH_SIZE} / 0x100000")
 
-if(CONFIG_BOOTLOADER_ESP_IDF)
-
-  set(bootloader_dir "${ZEPHYR_HAL_ESPRESSIF_MODULE_DIR}/zephyr/blobs/lib/${CONFIG_SOC_SERIES}")
-
-  if(EXISTS "${bootloader_dir}/bootloader-${CONFIG_SOC_SERIES}.bin")
-    file(COPY "${bootloader_dir}/bootloader-${CONFIG_SOC_SERIES}.bin" DESTINATION ${CMAKE_BINARY_DIR})
-    file(RENAME "${CMAKE_BINARY_DIR}/bootloader-${CONFIG_SOC_SERIES}.bin" "${CMAKE_BINARY_DIR}/bootloader.bin")
-  endif()
-
-  if(EXISTS "${bootloader_dir}/partition-table-${CONFIG_SOC_SERIES}.bin")
-    file(COPY "${bootloader_dir}/partition-table-${CONFIG_SOC_SERIES}.bin" DESTINATION ${CMAKE_BINARY_DIR})
-    file(RENAME "${CMAKE_BINARY_DIR}/partition-table-${CONFIG_SOC_SERIES}.bin" "${CMAKE_BINARY_DIR}/partition-table.bin")
-  endif()
-  board_finalize_runner_args(esp32 "--esp-flash-bootloader=${CMAKE_BINARY_DIR}/bootloader.bin")
-
-  board_finalize_runner_args(esp32 "--esp-flash-partition_table=${CMAKE_BINARY_DIR}/partition-table.bin")
-
-  board_finalize_runner_args(esp32 "--esp-partition-table-address=0x8000")
-
-endif()
-
-if(CONFIG_MCUBOOT OR CONFIG_BOOTLOADER_ESP_IDF)
+if(NOT CONFIG_BOOTLOADER_MCUBOOT)
 
   if(CONFIG_BUILD_OUTPUT_BIN)
+    # make ESP ROM loader compatible image
+    message("ESP-IDF path: ${ESP_IDF_PATH}")
+
+    set(ESPTOOL_PY ${ESP_IDF_PATH}/tools/esptool_py/esptool.py)
+    message("esptool path: ${ESPTOOL_PY}")
+
+    set(ELF2IMAGE_ARG "")
+    if(NOT CONFIG_MCUBOOT)
+      set(ELF2IMAGE_ARG "--ram-only-header")
+    endif()
+
     set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
-      COMMAND ${PYTHON_EXECUTABLE} ${ESP_IDF_PATH}/tools/esptool_py/esptool.py
-      ARGS --chip esp32s2 elf2image --flash_mode dio --flash_freq 40m --flash_size ${esptoolpy_flashsize}MB
+      COMMAND ${PYTHON_EXECUTABLE} ${ESPTOOL_PY}
+      ARGS --chip esp32s2 elf2image ${ELF2IMAGE_ARG}
+      --flash_mode dio --flash_freq 40m
+      --flash_size ${esptoolpy_flashsize}MB
       -o ${CMAKE_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.bin
       ${CMAKE_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.elf)
   endif()
 
-  if(CONFIG_MCUBOOT)
-    board_finalize_runner_args(esp32 "--esp-flash-bootloader=${CMAKE_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.bin")
-  endif()
-
 endif()
 
-board_finalize_runner_args(esp32 "--esp-boot-address=${boot_off}")
+# Get code-partition boot address
+dt_nodelabel(dts_partition_path NODELABEL "boot_partition")
+dt_reg_addr(boot_off PATH ${dts_partition_path})
 
-board_finalize_runner_args(esp32 "--esp-app-address=${img_0_off}")
+# Get code-partition slot0 address
+dt_nodelabel(dts_partition_path NODELABEL "slot0_partition")
+dt_reg_addr(img_0_off PATH ${dts_partition_path})
+
+if(CONFIG_ESP_SIMPLE_BOOT)
+  board_finalize_runner_args(esp32 "--esp-app-address=${boot_off}")
+else()
+  board_finalize_runner_args(esp32 "--esp-app-address=${img_0_off}")
+endif()
+
+if(CONFIG_MCUBOOT)
+    # search from cross references between bootloader sections
+    message("check_callgraph using: ${ESP_IDF_PATH}/tools/ci/check_callgraph.py")
+    set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+      COMMAND
+        ${PYTHON_EXECUTABLE} ${ESP_IDF_PATH}/tools/ci/check_callgraph.py
+      ARGS
+        --rtl-dirs ${CMAKE_BINARY_DIR}/zephyr
+	--elf-file ${CMAKE_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.elf
+        find-refs --from-section=.iram0.iram_loader --to-section=.iram0.text
+        --exit-code)
+endif()
 
 if(CONFIG_MCUBOOT)
   set(SOC_LINKER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/mcuboot.ld CACHE INTERNAL "")

--- a/soc/espressif/esp32s2/default.ld
+++ b/soc/espressif/esp32s2/default.ld
@@ -1,13 +1,8 @@
 /*
- * Copyright (c) 2021 Espressif Systems (Shanghai) Co., Ltd.
+ * Copyright (c) 2016 Cadence Design Systems, Inc.
+ * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
  * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
- * @file
- * @brief Linker command/script file
- *
- * Linker script for the esp32s2 platform.
  */
 
 #include <zephyr/devicetree.h>
@@ -15,78 +10,93 @@
 #include <zephyr/linker/linker-defs.h>
 #include <zephyr/linker/linker-tool.h>
 
-#define RAM_IRAM_START    0x40020000
-#define RAM_DRAM_START    0x3ffb0000
+#include "memory.h"
 
-/* DATA_RAM_END is equivalent 2nd stage bootloader iram_loader_seg
-   start address (that should not be overlapped) */
-#define DATA_RAM_END      0x3FFE0000
-
-#define IRAM_ORG    (RAM_IRAM_START + CONFIG_ESP32S2_INSTRUCTION_CACHE_SIZE \
-                                    + CONFIG_ESP32S2_DATA_CACHE_SIZE)
-
-#define DRAM_ORG    (RAM_DRAM_START + CONFIG_ESP32S2_INSTRUCTION_CACHE_SIZE \
-                                    + CONFIG_ESP32S2_DATA_CACHE_SIZE)
-
-#define I_D_RAM_SIZE   DATA_RAM_END - DRAM_ORG
-
-#define RAMABLE_REGION dram0_0_seg
-#define RODATA_REGION drom0_0_seg
-#define IRAM_REGION iram0_0_seg
-#define FLASH_CODE_REGION irom0_0_seg
-
-#define ROMABLE_REGION ROM
-
-#ifdef CONFIG_FLASH_SIZE
-#define FLASH_SIZE CONFIG_FLASH_SIZE
+/* The "user_iram_end" represents the 2nd stage bootloader
+ * "iram_loader_seg" start address (that should not be overlapped).
+ * If no bootloader is used, we can extend it to gain more user ram.
+ */
+#ifdef CONFIG_ESP_SIMPLE_BOOT
+user_iram_end = (DRAM_BUFFERS_START + IRAM_DRAM_OFFSET);
 #else
-#define FLASH_SIZE 0x400000
+user_iram_end = BOOTLOADER_IRAM_LOADER_SEG_START;
 #endif
 
-#ifdef CONFIG_BOOTLOADER_ESP_IDF
-#define IROM_SEG_ORG 0x40080020
-#define IROM_SEG_LEN (FLASH_SIZE-0x20)
-#define IROM_SEG_ALIGN 0x4
-#else
-#define IROM_SEG_ORG 0x40080000
-#define IROM_SEG_LEN FLASH_SIZE
-#define IROM_SEG_ALIGN 0x10000
-#endif
+/* User available SRAM memory segments */
+user_iram_seg_org = (SRAM_IRAM_START + SRAM_CACHE_SIZE);
+user_dram_seg_org = (SRAM_DRAM_START + SRAM_CACHE_SIZE);
+user_dram_end = (user_iram_end - IRAM_DRAM_OFFSET);
+user_idram_size = (user_dram_end - user_dram_seg_org);
+user_iram_seg_len = user_idram_size;
+user_dram_seg_len = user_idram_size;
+
+/* Aliases */
+#define ROTEXT_REGION     irom0_0_seg
+#define RODATA_REGION     drom0_0_seg
+#define IRAM_REGION       iram0_0_seg
+#define RAMABLE_REGION    dram0_0_seg
+#define ROMABLE_REGION    FLASH
 
 /* Flash segments (rodata and text) should be mapped in virtual address space by providing VMA.
  * Executing directly from LMA is not possible. */
 #undef GROUP_ROM_LINK_IN
 #define GROUP_ROM_LINK_IN(vregion, lregion) > RODATA_REGION AT > lregion
 
+/* TODO */
+#define RESERVE_RTC_MEM 0
+
 MEMORY
 {
-  mcuboot_hdr (RX): org = 0x0, len = 0x20
-  metadata (RX): org = 0x20, len = 0x20
-  ROM (RX): org = 0x40, len = FLASH_SIZE - 0x40
-  iram0_0_seg(RX): org = IRAM_ORG, len = I_D_RAM_SIZE
-  irom0_0_seg(RX): org = IROM_SEG_ORG, len = IROM_SEG_LEN
-  dram0_0_seg(RW): org = DRAM_ORG, len = I_D_RAM_SIZE
-  drom0_0_seg(R): org = 0x3f000040, len = FLASH_SIZE - 0x40
-
-  rtc_iram_seg(RWX): org = 0x40070000, len = 0x2000
-  rtc_slow_seg(RW): org = 0x50000000, len = 0x2000
-#if defined(CONFIG_ESP_SPIRAM)
-  ext_ram_seg(RW): org = 0x3f800000, len = CONFIG_ESP_SPIRAM_SIZE
+#ifdef CONFIG_BOOTLOADER_MCUBOOT
+  mcuboot_hdr (R): org = 0x0, len = 0x20
+  metadata (R):    org = 0x20, len = 0x20
+  FLASH (R):       org = 0x40, len = FLASH_SIZE
+#else
+  /* Make safety margin in the FLASH memory size so the
+   * (esp_img_header + (n*esp_seg_headers)) would fit */
+  FLASH (R): org = 0x0, len = FLASH_SIZE - 0x100
 #endif
+
+  iram0_0_seg(RX): org = user_iram_seg_org, len = user_iram_seg_len
+  dram0_0_seg(RW): org = user_dram_seg_org, len = user_dram_seg_len
+
+  irom0_0_seg(RX): org = IROM_SEG_ORG, len = IROM_SEG_LEN
+  drom0_0_seg(R):  org = DROM_SEG_ORG, len = DROM_SEG_LEN
+
+  rtc_iram_seg(RWX): org = 0x40070000, len = 0x2000 - RESERVE_RTC_MEM
+  rtc_slow_seg(RW):  org = 0x50000000, len = 0x2000
+  /* RTC fast memory (same block as above, rtc_iram_seg), viewed from data bus */
+  rtc_data_seg(RW) : org = 0x3ff9e000, len = 0x2000 - RESERVE_RTC_MEM
+  /* We reduced the size of rtc_data_seg and rtc_iram_seg by RESERVE_RTC_MEM value.
+   * It reserves the amount of RTC fast memory that we use for this memory segment.
+   * This segment is intended for keeping:
+   *  - (lower addr) rtc timer data (s_rtc_timer_retain_mem, see esp_clk.c files).
+   *  - (higher addr) bootloader rtc data (s_bootloader_retain_mem, when a Kconfig option is on).
+   * The aim of this is to keep data that will not be moved around and have a fixed address.
+   */
+  rtc_reserved_seg(RW) : org = 0x3ff9e000 + 0x2000 - RESERVE_RTC_MEM, len = RESERVE_RTC_MEM
+#ifdef CONFIG_ESP_SPIRAM
+  ext_data_ram_seg(RW): org = 0x3f800000, len = CONFIG_ESP_SPIRAM_SIZE /* OR 0x780000 */
+#endif /* CONFIG_ESP_SPIRAM */
+
 #ifdef CONFIG_GEN_ISR_TABLES
   IDT_LIST(RW): org = 0x3ebfe010, len = 0x2000
 #endif
 }
 
-/*  Default entry point:  */
+/* Default entry point:  */
 ENTRY(CONFIG_KERNEL_ENTRY)
 
 _rom_store_table = 0;
 
-_heap_sentry = 0x3fffe710;
+/* Used as a pointer to the heap end */
+_heap_sentry = DRAM_BUFFERS_START;
 
 SECTIONS
 {
+  _iram_dram_offset = IRAM_DRAM_OFFSET;
+
+#ifdef CONFIG_BOOTLOADER_MCUBOOT
   /* Reserve space for MCUboot header in the binary */
   .mcuboot_header :
   {
@@ -97,109 +107,163 @@ SECTIONS
   } > mcuboot_hdr
   .metadata :
   {
-    /* Magic byte for load header */
+    /* 0. Magic byte for load header */
     LONG(0xace637d3)
 
-    /* Application entry point address */
+    /* 1. Application entry point address */
     KEEP(*(.entry_addr))
 
-    /* IRAM metadata:
-     * - Destination address (VMA) for IRAM region
-     * - Flash offset (LMA) for start of IRAM region
-     * - Size of IRAM region
+    /* IRAM load:
+     * 2. Destination address (VMA) for IRAM region
+     * 3. Flash offset (LMA) for start of IRAM region
+     * 4. Size of IRAM region
      */
     LONG(ADDR(.iram0.vectors))
     LONG(LOADADDR(.iram0.vectors))
     LONG(LOADADDR(.iram0.text) + SIZEOF(.iram0.text) - LOADADDR(.iram0.vectors))
 
-    /* DRAM metadata:
-     * - Destination address (VMA) for DRAM region
-     * - Flash offset (LMA) for start of DRAM region
-     * - Size of DRAM region
+    /* DRAM load:
+     * 5. Destination address (VMA) for DRAM region
+     * 6. Flash offset (LMA) for start of DRAM region
+     * 7. Size of DRAM region
      */
     LONG(ADDR(.dram0.data))
     LONG(LOADADDR(.dram0.data))
-    LONG(LOADADDR(.dummy.dram.data) + SIZEOF(.dummy.dram.data) - LOADADDR(.dram0.data))
+    LONG(LOADADDR(.dram0.data_end) - LOADADDR(.dram0.data))
   } > metadata
+#endif /* CONFIG_BOOTLOADER_MCUBOOT */
 
+/* Virtual non-loadable sections */
 #include <zephyr/linker/rel-sections.ld>
-  _image_drom_start = LOADADDR(_RODATA_SECTION_NAME);
-  _image_drom_size = LOADADDR(_RODATA_SECTION_END) + SIZEOF(_RODATA_SECTION_END)  - _image_drom_start;
-  _image_drom_vaddr = ADDR(_RODATA_SECTION_NAME);
 
-  /* NOTE: .rodata section should be the first section in the linker script and no
-   * other section should appear before .rodata section. This is the requirement
-   * to align ROM section to 64K page offset.
-   * Adding .rodata as first section helps to reduce size of generated binary by
-   * few kBs.
+  /* --- START OF RTC --- */
+
+  /* RTC fast memory holds RTC wake stub code,
+   * including from any source file named rtc_wake_stub*.c
    */
-  SECTION_PROLOGUE(_RODATA_SECTION_NAME,,ALIGN(4))
+  .rtc.text :
   {
-    _rodata_reserved_start = ABSOLUTE(.);
-    __rodata_region_start = ABSOLUTE(.);
-    _rodata_reserved_start = ABSOLUTE(.);  /* This is a symbol marking the flash.rodata start, this can be used for mmu driver to maintain virtual address */
-
+    _rtc_text_start = ABSOLUTE(.);
     . = ALIGN(4);
-    #include <snippets-rodata.ld>
 
-    . = ALIGN(4);
-    *(EXCLUDE_FILE (*libarch__xtensa__core.a:* *libkernel.a:fatal.* *libkernel.a:init.* *libzephyr.a:cbprintf_complete* *libzephyr.a:log_core.* *libzephyr.a:log_backend_uart.* *libdrivers__flash.a:esp32_mp.* *libzephyr.a:log_output.* *libzephyr.a:loader.* *libdrivers__flash.a:flash_esp32.* *libdrivers__serial.a:uart_esp32.* *libzephyr.a:spi_flash_rom_patch.*) .rodata)
-    *(EXCLUDE_FILE (*libarch__xtensa__core.a:* *libkernel.a:fatal.* *libkernel.a:init.* *libzephyr.a:cbprintf_complete* *libzephyr.a:log_core.* *libzephyr.a:log_backend_uart.* *libdrivers__flash.a:esp32_mp.* *libzephyr.a:log_output.* *libzephyr.a:loader.* *libdrivers__flash.a:flash_esp32.* *libdrivers__serial.a:uart_esp32.* *libzephyr.a:spi_flash_rom_patch.*) .rodata.*)
+    _rtc_code_start = .;
 
-    *(.irom1.text) /* catch stray ICACHE_RODATA_ATTR */
-    *(.gnu.linkonce.r.*)
-    *(.rodata1)
-    __XT_EXCEPTION_TABLE_ = ABSOLUTE(.);
-    *(.xt_except_table)
-    *(.gcc_except_table .gcc_except_table.*)
-    *(.gnu.linkonce.e.*)
-    *(.gnu.version_r)
-    . = (. + 3) & ~ 3;
-    __eh_frame = ABSOLUTE(.);
-    KEEP(*(.eh_frame))
-    . = (. + 7) & ~ 3;
+    /* mapping[rtc_text] */
 
-    /*  C++ exception handlers table:  */
-    __XT_EXCEPTION_DESCS_ = ABSOLUTE(.);
-    *(.xt_except_desc)
-    *(.gnu.linkonce.h.*)
-    __XT_EXCEPTION_DESCS_END__ = ABSOLUTE(.);
-    *(.xt_except_desc_end)
-    *(.dynamic)
-    *(.gnu.version_d)
-    . = ALIGN(4);
-    __rodata_region_end = ABSOLUTE(.);
-    /* Literals are also RO data. */
-    _lit4_start = ABSOLUTE(.);
-    *(*.lit4)
-    *(.lit4.*)
-    *(.gnu.linkonce.lit4.*)
-    _lit4_end = ABSOLUTE(.);
-    . = ALIGN(4);
-    *(.rodata_wlog)
-    *(.rodata_wlog*)
-    . = ALIGN(4);
-  } GROUP_DATA_LINK_IN(RODATA_REGION, ROMABLE_REGION)
+    *rtc_wake_stub*.*(.literal .text .literal.* .text.*)
+    _rtc_code_end = .;
 
-  #include <zephyr/linker/common-rom/common-rom-cpp.ld>
-  #include <zephyr/linker/common-rom/common-rom-kernel-devices.ld>
-  #include <zephyr/linker/common-rom/common-rom-ztest.ld>
-  #include <zephyr/linker/common-rom/common-rom-net.ld>
-  #include <zephyr/linker/common-rom/common-rom-debug.ld>
-  #include <zephyr/linker/common-rom/common-rom-misc.ld>
-  #include <zephyr/linker/thread-local-storage.ld>
-  #include <snippets-sections.ld>
+    /* possibly align + add 16B for CPU dummy speculative instr. fetch */
+    . = ((_rtc_code_end - _rtc_code_start) == 0) ? ALIGN(0) : ALIGN(4) + 16;
 
-  /* Create an explicit section at the end of all the data that shall be mapped into drom.
-   * This is used to calculate the size of the _image_drom_size variable */
-  SECTION_PROLOGUE(_RODATA_SECTION_END,,ALIGN(0x10))
+    _rtc_text_end = ABSOLUTE(.);
+  } GROUP_DATA_LINK_IN(rtc_iram_seg, ROMABLE_REGION)
+
+  /*
+   * This section is required to skip rtc.text area because rtc_iram_seg and
+   * rtc_data_seg are reflect the same address space on different buses.
+   */
+  .rtc.dummy :
   {
-    _rodata_reserved_end = ABSOLUTE(.);
-    . = ALIGN(4);
-    _image_rodata_end = ABSOLUTE(.);
-    _rodata_reserved_end = ABSOLUTE(.);
+    _rtc_dummy_start = ABSOLUTE(.);
+    _rtc_fast_start = ABSOLUTE(.);
+    . = SIZEOF(.rtc.text);
+    _rtc_dummy_end = ABSOLUTE(.);
+  } GROUP_DATA_LINK_IN(rtc_iram_seg, ROMABLE_REGION)
 
-  } GROUP_DATA_LINK_IN(RODATA_REGION, ROMABLE_REGION)
+  /* This section located in RTC FAST Memory area.
+   *  It holds data marked with RTC_FAST_ATTR attribute.
+   *  See the file "esp_attr.h" for more information.
+   */
+  .rtc.force_fast :
+  {
+    . = ALIGN(4);
+    _rtc_force_fast_start = ABSOLUTE(.);
+
+    /* mapping[rtc_force_fast] */
+
+    *(.rtc.force_fast .rtc.force_fast.*)
+    . = ALIGN(4) ;
+    _rtc_force_fast_end = ABSOLUTE(.);
+  } > rtc_data_seg
+
+  /* RTC data section holds RTC wake stub
+   *  data/rodata, including from any source file
+   *  named rtc_wake_stub*.c and the data marked with
+   *  RTC_DATA_ATTR, RTC_RODATA_ATTR attributes.
+   */
+  .rtc.data :
+  {
+    _rtc_data_start = ABSOLUTE(.);
+
+    /* mapping[rtc_data] */
+
+    *rtc_wake_stub*.*(.data .rodata .data.* .rodata.*)
+    _rtc_data_end = ABSOLUTE(.);
+  } > rtc_data_seg
+
+  /* RTC bss, from any source file named rtc_wake_stub*.c */
+  .rtc.bss (NOLOAD) :
+  {
+    _rtc_bss_start = ABSOLUTE(.);
+    *rtc_wake_stub*.*(.bss .bss.*)
+    *rtc_wake_stub*.*(COMMON)
+
+    /* mapping[rtc_bss] */
+
+    _rtc_bss_end = ABSOLUTE(.);
+  } > rtc_data_seg
+
+  /* This section holds data that should not be initialized at power up
+   *  and will be retained during deep sleep.
+   *  User data marked with RTC_NOINIT_ATTR will be placed
+   *  into this section. See the file "esp_attr.h" for more information.
+   */
+  .rtc_noinit (NOLOAD):
+  {
+    . = ALIGN(4);
+    _rtc_noinit_start = ABSOLUTE(.);
+    *(.rtc_noinit .rtc_noinit.*)
+    . = ALIGN(4) ;
+    _rtc_noinit_end = ABSOLUTE(.);
+  } > rtc_data_seg
+
+  /* This section located in RTC SLOW Memory area.
+   *  It holds data marked with RTC_SLOW_ATTR attribute.
+   *  See the file "esp_attr.h" for more information.
+   */
+  .rtc.force_slow :
+  {
+    . = ALIGN(4);
+    _rtc_force_slow_start = ABSOLUTE(.);
+    *(.rtc.force_slow .rtc.force_slow.*)
+    . = ALIGN(4) ;
+    _rtc_force_slow_end = ABSOLUTE(.);
+  } > rtc_slow_seg
+
+  /**
+   * This section holds RTC data that should have fixed addresses.
+   * The data are not initialized at power-up and are retained during deep sleep.
+   */
+  .rtc_reserved (NOLOAD):
+  {
+    . = ALIGN(4);
+    _rtc_reserved_start = ABSOLUTE(.);
+    /* New data can only be added here to ensure existing data are not moved.
+       Because data have adhered to the end of the segment and code is relied on it.
+       >> put new data here << */
+
+    *(.rtc_timer_data_in_rtc_mem .rtc_timer_data_in_rtc_mem.*)
+    KEEP(*(.bootloader_data_rtc_mem .bootloader_data_rtc_mem.*))
+    _rtc_reserved_end = ABSOLUTE(.);
+  } > rtc_reserved_seg
+
+  /* Get size of rtc slow data */
+  _rtc_slow_length = (_rtc_force_slow_end - _rtc_data_start);
+
+  /* --- END OF RTC --- */
+
+  /* --- START OF IRAM --- */
 
   /* Send .iram0 code to iram */
   .iram0.vectors : ALIGN(4)
@@ -238,92 +302,134 @@ SECTIONS
     *(.init.literal)
     *(.init)
     _init_end = ABSOLUTE(.);
-
-    /* This goes here, not at top of linker script, so addr2line finds it last,
-       and uses it in preference to the first symbol in IRAM */
   } GROUP_DATA_LINK_IN(IRAM_REGION, ROMABLE_REGION)
 
   .iram0.text : ALIGN(4)
   {
-    . = ALIGN(8);
     /* Code marked as running out of IRAM */
+    _iram_text_start = ABSOLUTE(.);
     *(.iram1 .iram1.*)
     *(.iram0.literal .iram.literal .iram.text.literal .iram0.text .iram.text)
     *libesp32.a:panic.*(.literal .text .literal.* .text.*)
     *librtc.a:(.literal .text .literal.* .text.*)
     *libarch__xtensa__core.a:(.literal .text .literal.* .text.*)
     *libkernel.a:(.literal .text .literal.* .text.*)
-    *libsoc.a:rtc_*.*(.literal .text .literal.* .text.*)
-    *libsoc.a:cpu_util.*(.literal .text .literal.* .text.*)
     *libgcc.a:lib2funcs.*(.literal .text .literal.* .text.*)
     *libzephyr.a:windowspill_asm.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:log_noos.*(.literal .text .literal.* .text.*)
-    *libdrivers__timer.a:xtensa_sys_timer.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:log_core.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:cbprintf_packaged.*(.literal .text .literal.* .text.*)
     *libzephyr.a:cbprintf_complete.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:log_noos.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:log_core.*(.literal .text .literal.* .text.*)
     *libzephyr.a:printk.*(.literal.printk .literal.vprintk .literal.char_out .text.printk .text.vprintk .text.char_out)
     *libzephyr.a:log_msg.*(.literal .text .literal.* .text.*)
     *libzephyr.a:log_list.*(.literal .text .literal.* .text.*)
-    *libdrivers__console.a:uart_console.*(.literal.console_out .text.console_out)
     *libzephyr.a:log_output.*(.literal .text .literal.* .text.*)
     *libzephyr.a:log_backend_uart.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:cache_hal.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:mmu_hal.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:log_minimal.*(.literal .literal.* .text .text.*)
     *libzephyr.a:loader.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:esp_mmu_map.*(.literal .literal.* .text .text.*)
+    *libdrivers__flash.a:flash_esp32.*(.literal .text .literal.* .text.*)
+    *libdrivers__timer.a:xtensa_sys_timer.*(.literal .text .literal.* .text.*)
+    *libdrivers__console.a:uart_console.*(.literal.console_out .text.console_out)
+    *libdrivers__interrupt_controller.a:(.literal .literal.* .text .text.*)
     *liblib__libc__minimal.a:string.*(.literal .text .literal.* .text.*)
     *liblib__libc__newlib.a:string.*(.literal .text .literal.* .text.*)
-    *libc.a:*(.literal .text .literal.* .text.*)
-    *libphy.a:( .phyiram .phyiram.*)
+    *liblib__libc__picolibc.a:string.*(.literal .text .literal.* .text.*)
+    *libphy.a:(.phyiram .phyiram.*)
     *libgcov.a:(.literal .text .literal.* .text.*)
-    *libzephyr.a:cpu.*(.literal.esp_cpu_compare_and_set .text.esp_cpu_compare_and_set)
-    *libzephyr.a:cpu.*(.literal.esp_cpu_reset .text.esp_cpu_reset)
-    *libzephyr.a:cpu.*(.literal.esp_cpu_stall .text.esp_cpu_stall)
-    *libzephyr.a:cpu.*(.literal.esp_cpu_unstall .text.esp_cpu_unstall)
-    *libzephyr.a:cpu.*(.literal.esp_cpu_wait_for_intr .text.esp_cpu_wait_for_intr)
-    *libzephyr.a:esp_gpio_reserve.*(.literal.esp_gpio_is_pin_reserved .text.esp_gpio_is_pin_reserved)
-    *libzephyr.a:esp_gpio_reserve.*(.literal.esp_gpio_reserve_pins .text.esp_gpio_reserve_pins)
-    *libzephyr.a:esp_memory_utils.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:periph_ctrl.*(.literal.periph_module_reset .text.periph_module_reset)
-    *libzephyr.a:periph_ctrl.*(.literal.wifi_module_disable .text.wifi_module_disable)
-    *libzephyr.a:periph_ctrl.*(.literal.wifi_module_enable .text.wifi_module_enable)
-    *libzephyr.a:rtc_clk.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:rtc_sleep.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:rtc_time.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:rtc_wdt.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:sar_periph_ctrl.*(.literal.sar_periph_ctrl_power_enable .text.sar_periph_ctrl_power_enable)
-    *libzephyr.a:systimer.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:esp_cache.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:esp_rom_cache_esp32s2_esp32s3.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:esp_rom_spiflash.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:esp_rom_systimer.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:esp_err.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:esp_system_chip.*(.literal.esp_system_abort .text.esp_system_abort)
-    *libzephyr.a:cache_hal.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:i2c_hal_iram.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:ledc_hal_iram.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:mmu_hal.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:spi_flash_encrypt_hal_iram.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:spi_flash_hal_gpspi.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:spi_flash_hal_iram.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:spi_flash_init.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:spi_hal_iram.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:spi_slave_hal_iram.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:systimer_hal.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:wdt_hal_iram.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:flash_brownout_hook.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:memspi_host_driver.*(.literal .literal.* .text .text.*)
+
+    /* [mapping:esp_psram] */
+    *libzephyr.a:mmu_psram_flash.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:esp_psram_impl_quad.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:esp_psram_impl_octal.*(.literal .literal.* .text .text.*)
+
+    /* [mapping:hal] */
+    *libzephyr.a:mmu_hal.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:cache_hal.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:ledc_hal_iram.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:i2c_hal_iram.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:wdt_hal_iram.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:systimer_hal.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:spi_flash_hal_iram.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:spi_flash_encrypt_hal_iram.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:spi_flash_hal_gpspi.*(.literal .text .literal.* .text.*)
+
+    /* [mapping:soc] */
+    *libzephyr.a:lldesc.*(.literal .literal.* .text .text.*)
+
+    /* [mapping:log] */
+    *(.literal.esp_log_write .text.esp_log_write)
+    *(.literal.esp_log_timestamp .text.esp_log_timestamp)
+    *(.literal.esp_log_early_timestamp .text.esp_log_early_timestamp)
+    *(.literal.esp_log_impl_lock .text.esp_log_impl_lock)
+    *(.literal.esp_log_impl_lock_timeout .text.esp_log_impl_lock_timeout)
+    *(.literal.esp_log_impl_unlock .text.esp_log_impl_unlock)
+
+    /* [mapping:spi_flash] */
     *libzephyr.a:spi_flash_chip_boya.*(.literal .literal.* .text .text.*)
     *libzephyr.a:spi_flash_chip_gd.*(.literal .literal.* .text .text.*)
     *libzephyr.a:spi_flash_chip_generic.*(.literal .literal.* .text .text.*)
     *libzephyr.a:spi_flash_chip_issi.*(.literal .literal.* .text .text.*)
     *libzephyr.a:spi_flash_chip_mxic.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:spi_flash_chip_mxic_opi.*(.literal .literal.* .text .text.*)
     *libzephyr.a:spi_flash_chip_th.*(.literal .literal.* .text .text.*)
     *libzephyr.a:spi_flash_chip_winbond.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:memspi_host_driver.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:flash_brownout_hook.*(.literal .literal.* .text .text.*)
     *libzephyr.a:spi_flash_wrap.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:spi_flash_hpm_enable.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:spi_flash_oct_flash_init*(.literal .literal.* .text .text.*)
+
+    /* [mapping:esp_system] */
+    *libzephyr.a:esp_err.*(.literal .literal.* .text .text.*)
+    *(.literal.esp_system_abort .text.esp_system_abort)
+
+    /* [mapping:esp_hw_support] */
+    *(.literal.esp_cpu_stall .text.esp_cpu_stall)
+    *(.literal.esp_cpu_unstall .text.esp_cpu_unstall)
+    *(.literal.esp_cpu_reset .text.esp_cpu_reset)
+    *(.literal.esp_cpu_wait_for_intr .text.esp_cpu_wait_for_intr)
+    *(.literal.esp_cpu_compare_and_set .text.esp_cpu_compare_and_set)
+    *(.literal.esp_gpio_reserve_pins .text.esp_gpio_reserve_pins)
+    *(.literal.esp_gpio_is_pin_reserved .text.esp_gpio_is_pin_reserved)
+    *(.literal.rtc_vddsdio_get_config .text.rtc_vddsdio_get_config)
+    *(.literal.rtc_vddsdio_set_config .text.rtc_vddsdio_set_config)
+    *libzephyr.a:esp_memory_utils.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:rtc_clk.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:rtc_clk_init.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:rtc_sleep.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:rtc_time.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:systimer.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:mspi_timing_config.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:mspi_timing_tuning.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:periph_ctrl.*(.literal .text .literal.* .text.*)
+    *(.literal.sar_periph_ctrl_power_enable .text.sar_periph_ctrl_power_enable)
+
+    /* [mapping:soc_pm] */
+    *(.literal.GPIO_HOLD_MASK .text.GPIO_HOLD_MASK)
+
+    /* [mapping:esp_rom] */
+    *libzephyr.a:esp_rom_cache_esp32s2_esp32s3.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:esp_rom_spiflash.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:esp_rom_systimer.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:esp_rom_wdt.*(.literal .literal.* .text .text.*)
+
+    /* [mapping:esp_mm] */
+    *libzephyr.a:esp_cache.*(.literal .literal.* .text .text.*)
 
 #if defined(CONFIG_ESP32_WIFI_IRAM_OPT)
-    *libnet80211.a:( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.*)
-    *libpp.a:( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.* .wifiorslpiram .wifiorslpiram.*)
+    *libnet80211.a:(.wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.*)
+    *libpp.a:(.wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.* .wifiorslpiram .wifiorslpiram.*)
+    *libcoexist.a:(.wifi_slp_iram  .wifi_slp_iram.*)
+
+    /* [mapping:esp_wifi] */
+    *(.literal.wifi_clock_enable_wrapper .text.wifi_clock_enable_wrapper)
+    *(.literal.wifi_clock_disable_wrapper .text.wifi_clock_disable_wrapper)
+
+    /* [mapping:esp_phy] */
+    *(.literal.esp_phy_enable .text.esp_phy_enable)
+    *(.literal.esp_phy_disable .text.esp_phy_disable)
+    *(.literal.esp_wifi_bt_power_domain_off .text.esp_wifi_bt_power_domain_off)
 #endif
 
 #if defined(CONFIG_ESP32_WIFI_RX_IRAM_OPT)
@@ -333,25 +439,297 @@ SECTIONS
 
     /* align + add 16B for CPU dummy speculative instr. fetch */
     . = ALIGN(4) + 16;
-    _iram_text = ABSOLUTE(.);
+
   } GROUP_DATA_LINK_IN(IRAM_REGION, ROMABLE_REGION)
+
+#ifdef CONFIG_ESP_SIMPLE_BOOT
+  .loader.text :
+  {
+    . =  ALIGN(4);
+    _loader_text_start = ABSOLUTE(.);
+    *libzephyr.a:bootloader_soc.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_init.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_esp32s2.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_clock_init.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_wdt.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_flash.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_flash_config_esp32s2.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_clock_loader.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_common_loader.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_common.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_mem.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_random.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_random*.*(.literal.bootloader_random_disable .text.bootloader_random_disable)
+    *libzephyr.a:bootloader_random*.*(.literal.bootloader_random_enable .text.bootloader_random_enable)
+    *libzephyr.a:bootloader_efuse.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_utility.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_sha.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_console.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_panic.*(.literal .text .literal.* .text.*)
+
+    *libzephyr.a:esp_image_format.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:flash_encrypt.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:flash_encryption_secure_features.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:flash_partitions.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:spi_flash_hal.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:spi_flash_hal_common.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:esp_flash_api.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:esp_flash_spi_init.*(.literal .text .literal.* .text.*)
+
+    *libzephyr.a:secure_boot.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:secure_boot_secure_features.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:secure_boot_signatures_bootloader.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:efuse_hal.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:esp_efuse_table.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:esp_efuse_fields.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:esp_efuse_api.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:esp_efuse_utility.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:esp_efuse_api_key_esp32xx.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:mpu_hal.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:cpu_region_protect.*(.literal .text .literal.* .text.*)
+
+    *(.fini.literal)
+    *(.fini)
+
+    . =  ALIGN(4);
+    _loader_text_end = ABSOLUTE(.);
+  } GROUP_DATA_LINK_IN(IRAM_REGION, ROMABLE_REGION)
+#endif /* CONFIG_ESP_SIMPLE_BOOT */
+
+  .iram0.text_end (NOLOAD) :
+  {
+    . = ALIGN(16);
+    _iram_text_end_end = ABSOLUTE(.);
+  } GROUP_LINK_IN(IRAM_REGION)
+
+  .iram0.data :
+  {
+    . = ALIGN(16);
+    *(.iram.data)
+    *(.iram.data*)
+  } GROUP_DATA_LINK_IN(IRAM_REGION, ROMABLE_REGION)
+
+  .iram0.bss (NOLOAD) :
+  {
+    . = ALIGN(16);
+    _iram_bss_start = ABSOLUTE(.);
+    *(.iram.bss)
+    *(.iram.bss.*)
+    _iram_bss_end = ABSOLUTE(.);
+
+    . = ALIGN(4);
+    _iram_end = ABSOLUTE(.);
+  } GROUP_LINK_IN(IRAM_REGION)
+
+  /* --- END OF IRAM --- */
+
+  /* --- START OF DRAM --- */
 
   .dram0.dummy (NOLOAD):
   {
-    /**
-    * This section is required to skip .iram0.text area because iram0_0_seg and
-    * dram0_0_seg reflect the same address space on different buses.
-    */
-    . = ALIGN (8);
-    . = ORIGIN(dram0_0_seg) + _iram_end - _iram_start;
+    /* This section is required to skip .iram0.text area because iram0_0_seg and
+     * dram0_0_seg reflect the same address space on different buses.
+     */
+    . = ORIGIN(dram0_0_seg) + MAX(_iram_end, user_iram_seg_org) - user_iram_seg_org;
+    . = ALIGN(4) + 16;
   } GROUP_LINK_IN(RAMABLE_REGION)
 
-  /* Shared RAM */
-  SECTION_DATA_PROLOGUE(_BSS_SECTION_NAME,(NOLOAD),)
+  .dram0.data :
   {
     . = ALIGN (8);
-    _bss_start = ABSOLUTE(.);
+    _data_start = ABSOLUTE(.);
+    __data_start = ABSOLUTE(.);
+
+    /*  bluetooth library requires this symbol to be defined */
+    _btdm_data_start = ABSOLUTE(.);
+    *libbtdm_app.a:(.data .data.*)
+    . = ALIGN (4);
+    _btdm_data_end = ABSOLUTE(.);
+
+    *(.data)
+    *(.data.*)
+    *(.gnu.linkonce.d.*)
+    *(.data1)
+    *(.sdata)
+    *(.sdata.*)
+    *(.gnu.linkonce.s.*)
+    *(.sdata2)
+    *(.sdata2.*)
+    *(.gnu.linkonce.s2.*)
+    *(.srodata)
+    *(.srodata.*)
+    /* rodata for panic handler(libarch__xtensa__core.a) and all
+     * dependent functions should be placed in DRAM to avoid issue
+     * when flash cache is disabled */
+    *libarch__xtensa__core.a:(.rodata .rodata.*)
+    *libkernel.a:fatal.*(.rodata .rodata.*)
+    *libkernel.a:init.*(.rodata .rodata.*)
+    *libzephyr.a:cbprintf_complete.*(.rodata .rodata.*)
+    *libzephyr.a:log_core.*(.rodata .rodata.*)
+    *libzephyr.a:log_backend_uart.*(.rodata .rodata.*)
+    *libzephyr.a:log_output.*(.rodata .rodata.*)
+    *libzephyr.a:log_minimal.*(.rodata .rodata.*)
+    *libzephyr.a:loader.*(.rodata .rodata.*)
+    *libdrivers__serial.a:uart_esp32.*(.rodata .rodata.*)
+    *libdrivers__flash.a:flash_esp32.*(.rodata .rodata.*)
+    *libzephyr.a:esp_mmu_map.*(.rodata .rodata.*)
+    *libdrivers__interrupt_controller.a:(.rodata .rodata.*)
+
+    /* [mapping:esp_psram] */
+    *libzephyr.a:mmu_psram_flash.*(.rodata .rodata.*)
+    *libzephyr.a:esp_psram_impl_octal.*(.rodata .rodata.*)
+    *libzephyr.a:esp_psram_impl_quad.*(.rodata .rodata.*)
+
+    /* [mapping:hal] */
+    *libzephyr.a:mmu_hal.*(.rodata .rodata.*)
+    *libzephyr.a:spi_flash_hal_iram.*(.rodata .rodata.*)
+    *libzephyr.a:spi_flash_encrypt_hal_iram.*(.rodata .rodata.*)
+    *libzephyr.a:cache_hal.*(.rodata .rodata.*)
+    *libzephyr.a:ledc_hal_iram.*(.rodata .rodata.*)
+    *libzephyr.a:i2c_hal_iram.*(.rodata .rodata.*)
+    *libzephyr.a:wdt_hal_iram.*(.rodata .rodata.*)
+    *libzephyr.a:systimer_hal.*(.rodata .rodata.*)
+    *libzephyr.a:spi_flash_hal_gpspi.*(.rodata .rodata.*)
+
+    /* [mapping:soc] */
+    *libzephyr.a:lldesc.*(.rodata .rodata.*)
+
+    /* [mapping:log] */
+    *(.rodata.esp_log_write)
+    *(.rodata.esp_log_timestamp)
+    *(.rodata.esp_log_early_timestamp)
+    *(.rodata.esp_log_impl_lock)
+    *(.rodata.esp_log_impl_lock_timeout)
+    *(.rodata.esp_log_impl_unlock)
+
+    /* [mapping:spi_flash] */
+    *libzephyr.a:spi_flash_chip_boya.*(.rodata .rodata.*)
+    *libzephyr.a:spi_flash_chip_gd.*(.rodata .rodata.*)
+    *libzephyr.a:spi_flash_chip_generic.*(.rodata .rodata.*)
+    *libzephyr.a:spi_flash_chip_issi.*(.rodata .rodata.*)
+    *libzephyr.a:spi_flash_chip_mxic.*(.rodata .rodata.*)
+    *libzephyr.a:spi_flash_chip_mxic_opi.*(.rodata .rodata.*)
+    *libzephyr.a:spi_flash_chip_th.*(.rodata .rodata.*)
+    *libzephyr.a:spi_flash_chip_winbond.*(.rodata .rodata.*)
+    *libzephyr.a:memspi_host_driver.*(.rodata .rodata.*)
+    *libzephyr.a:flash_brownout_hook.*(.rodata .rodata.*)
+    *libzephyr.a:spi_flash_wrap.*(.rodata .rodata.*)
+    *libzephyr.a:spi_flash_hpm_enable.*(.rodata .rodata.*)
+    *libzephyr.a:spi_flash_oct_flash_init.*(.rodata .rodata.*)
+
+    /* [mapping:esp_mm] */
+    *libzephyr.a:esp_cache.*(.rodata .rodata.*)
+
+    /* [mapping:esp_hw_support] */
+    *(.rodata.esp_cpu_stall)
+    *(.rodata.esp_cpu_unstall)
+    *(.rodata.esp_cpu_reset)
+    *(.rodata.esp_cpu_wait_for_intr)
+    *(.rodata.esp_cpu_compare_and_set)
+    *(.rodata.esp_gpio_reserve_pins)
+    *(.rodata.esp_gpio_is_pin_reserved)
+    *(.rodata.rtc_vddsdio_get_config)
+    *(.rodata.rtc_vddsdio_set_config)
+    *libzephyr.a:esp_memory_utils.*(.rodata .rodata.*)
+    *libzephyr.a:rtc_clk.*(.rodata .rodata.*)
+    *libzephyr.a:rtc_clk_init.*(.rodata .rodata.*)
+    *libzephyr.a:systimer.*(.rodata .rodata.*)
+    *libzephyr.a:mspi_timing_config.*(.rodata .rodata.*)
+    *libzephyr.a:mspi_timing_tuning.*(.rodata .rodata.*)
+    *(.rodata.sar_periph_ctrl_power_enable)
+    *libzephyr.a:periph_ctrl.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+
+    /* [mapping:soc_pm] */
+    *(.rodata.GPIO_HOLD_MASK)
+
+    /* [mapping:esp_rom] */
+    *libzephyr.a:esp_rom_cache_esp32s2_esp32s3.*(.rodata .rodata.*)
+    *libzephyr.a:esp_rom_spiflash.*(.rodata .rodata.*)
+    *libzephyr.a:esp_rom_systimer.*(.rodata .rodata.*)
+    *libzephyr.a:esp_rom_wdt.*(.rodata .rodata.*)
+
+    /* [mapping:esp_system] */
+    *libzephyr.a:esp_err.*(.rodata .rodata.*)
+    *(.rodata.esp_system_abort)
+
+#if defined(CONFIG_ESP32_WIFI_IRAM_OPT)
+    /* [mapping:esp_wifi] */
+    *(.rodata.wifi_clock_enable_wrapper)
+    *(.rodata.wifi_clock_disable_wrapper)
+
+    /* [mapping:esp_phy] */
+    *(.rodata.esp_phy_enable)
+    *(.rodata.esp_phy_disable)
+    *(.rodata.esp_wifi_bt_power_domain_off)
+#endif
+
+    . = ALIGN(4);
+
+    KEEP(*(.jcr))
+    *(.dram1 .dram1.*)
+
+    . = ALIGN(4);
+    #include <snippets-rwdata.ld>
+    . = ALIGN(4);
+
+  } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+
+#ifdef CONFIG_ESP_SIMPLE_BOOT
+  .loader.data :
+  {
+    . = ALIGN(4);
+    _loader_data_start = ABSOLUTE(.);
+    *libzephyr.a:bootloader_init.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:bootloader_esp32s3.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:bootloader_clock_init.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:bootloader_wdt.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:bootloader_flash.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:bootloader_flash_config_esp32s2.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:bootloader_efuse.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:bootloader_random_esp32s2.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+
+    *libzephyr.a:cpu_util.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:clk.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:esp_clk.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:cpu_region_protect.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+
+    *libzephyr.a:spi_flash_hal.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:spi_flash_hal_common.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:esp_flash_api.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:esp_flash_spi_init.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+
+    *libzephyr.a:efuse_hal.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+
+    . = ALIGN(4);
+    _loader_data_end = ABSOLUTE(.);
+  } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+#endif /* !CONFIG_BOOTLOADER_MCUBOOT */
+
+  #include <snippets-data-sections.ld>
+  #include <zephyr/linker/common-ram.ld>
+  #include <snippets-ram-sections.ld>
+  #include <zephyr/linker/cplusplus-ram.ld>
+
+  /* logging sections should be placed in RAM area to avoid flash cache disabled issues */
+  #pragma push_macro("GROUP_ROM_LINK_IN")
+  #undef GROUP_ROM_LINK_IN
+  #define GROUP_ROM_LINK_IN GROUP_DATA_LINK_IN
+  #include <zephyr/linker/common-rom/common-rom-logging.ld>
+  #pragma pop_macro("GROUP_ROM_LINK_IN")
+
+  .dram0.data_end :
+  {
+    . = ALIGN(4);
+    _data_end = ABSOLUTE(.);
+    _dram_data_end = ABSOLUTE(.);
+  } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+
+  /* .bss */
+  .dram0.bss (NOLOAD) :
+  {
+    . = ALIGN (8);
     __bss_start = ABSOLUTE(.);
+    _bss_start = ABSOLUTE(.);
 
     *(.dynsbss)
     *(.sbss)
@@ -369,36 +747,38 @@ SECTIONS
     *(COMMON)
     . = ALIGN (8);
     __bss_end = ABSOLUTE(.);
+    _bss_end = ABSOLUTE(.);
   } GROUP_LINK_IN(RAMABLE_REGION)
 
-#if defined(CONFIG_ESP_SPIRAM)
+#ifdef CONFIG_ESP_SPIRAM
   /* This section holds .ext_ram.bss data, and will be put in PSRAM */
-  .ext_ram.bss (NOLOAD) :
+  .ext_ram.bss (NOLOAD):
   {
     _ext_ram_data_start = ABSOLUTE(.);
     _ext_ram_bss_start = ABSOLUTE(.);
     *(.ext_ram.bss*)
     . = ALIGN(4);
     _ext_ram_bss_end = ABSOLUTE(.);
-  } > ext_ram_seg
+  } > ext_data_ram_seg
 
   .ext_ram_noinit (NOLOAD) :
   {
-#if defined(CONFIG_ESP32_WIFI_NET_ALLOC_SPIRAM)
+#ifdef CONFIG_ESP32_WIFI_NET_ALLOC_SPIRAM
     *libdrivers__wifi.a:(.noinit .noinit.*)
     *libsubsys__net__l2__ethernet.a:(.noinit .noinit.*)
     *libsubsys__net__lib__config.a:(.noinit .noinit.*)
     *libsubsys__net__ip.a:(.noinit .noinit.*)
     *libsubsys__net.a:(.noinit .noinit.*)
-#endif
+#endif /* CONFIG_ESP32_WIFI_NET_ALLOC_SPIRAM */
+
     _spiram_heap_start = ABSOLUTE(.);
-    . = . + CONFIG_ESP_SPIRAM_HEAP_SIZE;
+    . += CONFIG_ESP_SPIRAM_HEAP_SIZE;
 
     _ext_ram_data_end = ABSOLUTE(.);
-  } > ext_ram_seg
-#endif
+  } > ext_data_ram_seg
+#endif /* CONFIG_ESP_SPIRAM */
 
-  SECTION_DATA_PROLOGUE(_NOINIT_SECTION_NAME, (NOLOAD),)
+  .dram0.noinit (NOLOAD) :
   {
     . = ALIGN(8);
     *(.noinit)
@@ -406,188 +786,149 @@ SECTIONS
     . = ALIGN(8);
   } GROUP_LINK_IN(RAMABLE_REGION)
 
-  .dram0.data :
-  {
-    . = ALIGN (8);
-    __data_start = ABSOLUTE(.);
-    *(.data)
-    *(.data.*)
-    *(.gnu.linkonce.d.*)
-    *(.data1)
-    *(.sdata)
-    *(.sdata.*)
-    *(.gnu.linkonce.s.*)
-    *(.sdata2)
-    *(.sdata2.*)
-    *(.gnu.linkonce.s2.*)
-    /* rodata for panic handler(libarch__xtensa__core.a) and all
-     * dependent functions should be placed in DRAM to avoid issue
-     * when flash cache is disabled */
-    *libarch__xtensa__core.a:(.rodata .rodata.*)
-    *libkernel.a:fatal.*(.rodata .rodata.*)
-    *libkernel.a:init.*(.rodata .rodata.*)
-    *libzephyr.a:cbprintf_complete*(.rodata .rodata.*)
-    *libzephyr.a:log_core.*(.rodata .rodata.*)
-    *libzephyr.a:log_backend_uart.*(.rodata .rodata.*)
-    *libzephyr.a:log_output.*(.rodata .rodata.*)
-    *libzephyr.a:mmu_hal.*(.rodata .rodata.*)
-    *libzephyr.a:loader.*(.rodata .rodata.*)
-    *libdrivers__flash.a:flash_esp32.*(.rodata .rodata.*)
-    *libzephyr.a:spi_flash_rom_patch.*(.rodata .rodata.*)
-    *libdrivers__serial.a:uart_esp32.*(.rodata .rodata.*)
-    *libzephyr.a:esp_memory_utils.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:rtc_clk.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:systimer.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:esp_cache.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:esp_rom_cache_esp32s2_esp32s3.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:esp_rom_spiflash.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:esp_rom_systimer.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:esp_err.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:cache_hal.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:i2c_hal_iram.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:ledc_hal_iram.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:mmu_hal.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:spi_flash_encrypt_hal_iram.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:spi_flash_hal_gpspi.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:spi_flash_hal_iram.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:spi_flash_init.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:spi_hal_iram.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:spi_slave_hal_iram.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:systimer_hal.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:wdt_hal_iram.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:flash_brownout_hook.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:memspi_host_driver.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:spi_flash_chip_boya.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:spi_flash_chip_gd.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:spi_flash_chip_generic.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:spi_flash_chip_issi.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:spi_flash_chip_mxic.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:spi_flash_chip_th.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:spi_flash_chip_winbond.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:spi_flash_wrap.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+  /* Provide total SRAM usage, including IRAM and DRAM */
+  _image_ram_start = _iram_start - IRAM_DRAM_OFFSET;
+  #include <zephyr/linker/ram-end.ld>
 
-    KEEP(*(.jcr))
-    *(.dram1 .dram1.*)
+  ASSERT(((__bss_end - ORIGIN(dram0_0_seg)) <= LENGTH(dram0_0_seg)), "DRAM segment data does not fit.")
+
+  /* --- END OF DRAM --- */
+
+  /* --- START OF .rodata --- */
+
+  _image_drom_start = LOADADDR(.flash.rodata);
+  _image_drom_size = LOADADDR(.flash.rodata_end) + SIZEOF(.flash.rodata_end)  - _image_drom_start;
+  _image_drom_vaddr = ADDR(.flash.rodata);
+
+  /* Align next section to 64k to allow mapping */
+  .flash.rodata_dummy (NOLOAD) :
+  {
+    . = ALIGN(CACHE_ALIGN);
+  } GROUP_LINK_IN(ROMABLE_REGION)
+
+  .flash.rodata : ALIGN(16)
+  {
+    _flash_rodata_start = ABSOLUTE(.);
+    _rodata_reserved_start = ABSOLUTE(.);  /* This is a symbol marking the flash.rodata start, this can be used for mmu driver to maintain virtual address */
+    _rodata_start = ABSOLUTE(.);
+    __rodata_region_start = ABSOLUTE(.);
     . = ALIGN(4);
-  } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+    #include <snippets-rodata.ld>
+
+    *(.irom1.text) /* catch stray ICACHE_RODATA_ATTR */
+    *(.gnu.linkonce.r.*)
+    *(.rodata)
+    *(.rodata.*)
+    *(.rodata1)
+    __XT_EXCEPTION_TABLE_ = ABSOLUTE(.);
+    *(.xt_except_table)
+    *(.gcc_except_table .gcc_except_table.*)
+    *(.gnu.linkonce.e.*)
+    *(.gnu.version_r)
+    . = (. + 3) & ~ 3;
+    __eh_frame = ABSOLUTE(.);
+    KEEP(*(.eh_frame))
+    . = (. + 7) & ~ 3;
+
+    /*  C++ exception handlers table:  */
+    __XT_EXCEPTION_DESCS_ = ABSOLUTE(.);
+    *(.xt_except_desc)
+    *(.gnu.linkonce.h.*)
+    __XT_EXCEPTION_DESCS_END__ = ABSOLUTE(.);
+    *(.xt_except_desc_end)
+    *(.dynamic)
+    *(.gnu.version_d)
+    . = ALIGN(4);
+    __rodata_region_end = ABSOLUTE(.);
+    /* Literals are also RO data. */
+    _lit4_start = ABSOLUTE(.);
+    *(*.lit4)
+    *(.lit4.*)
+    *(.gnu.linkonce.lit4.*)
+    _lit4_end = ABSOLUTE(.);
+    . = ALIGN(4);
+    *(.rodata_wlog)
+    *(.rodata_wlog*)
+    . = ALIGN(4);
+  } GROUP_DATA_LINK_IN(RODATA_REGION, ROMABLE_REGION)
 
   #include <zephyr/linker/cplusplus-rom.ld>
-  #include <snippets-data-sections.ld>
-  #include <zephyr/linker/common-ram.ld>
-  #include <snippets-ram-sections.ld>
-  #include <zephyr/linker/cplusplus-ram.ld>
+  #include <zephyr/linker/common-rom/common-rom-cpp.ld>
+  #include <zephyr/linker/common-rom/common-rom-kernel-devices.ld>
+  #include <zephyr/linker/common-rom/common-rom-ztest.ld>
+  #include <zephyr/linker/common-rom/common-rom-net.ld>
+  #include <zephyr/linker/common-rom/common-rom-debug.ld>
+  #include <zephyr/linker/common-rom/common-rom-misc.ld>
+  #include <zephyr/linker/thread-local-storage.ld>
+  #include <snippets-sections.ld>
 
-  /* logging sections should be placed in RAM area to avoid flash cache disabled issues */
-  #pragma push_macro("GROUP_ROM_LINK_IN")
-  #undef GROUP_ROM_LINK_IN
-  #define GROUP_ROM_LINK_IN GROUP_DATA_LINK_IN
-  #include <zephyr/linker/common-rom/common-rom-logging.ld>
-  #pragma pop_macro("GROUP_ROM_LINK_IN")
-
-  .dummy.dram.data :
+  /* Create an explicit section at the end of all the data that shall be mapped into drom.
+   * This is used to calculate the size of the _image_drom_size variable */
+  .flash.rodata_end :
   {
-    . = ALIGN(4);
-    #include <snippets-rwdata.ld>
-    . = ALIGN(4);
-    _end = ABSOLUTE(.);
-    __data_end = ABSOLUTE(.);
-  } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+    . = ALIGN(CACHE_ALIGN);
+    _image_rodata_end = ABSOLUTE(.);
+    _rodata_region_end = ABSOLUTE(.);
+    _rodata_reserved_end = ABSOLUTE(.);
 
-  .iram0.text_end (NOLOAD) :
-  {
-    . = ALIGN(4);
-    _iram_end = ABSOLUTE(.);
-  } GROUP_LINK_IN(IRAM_REGION)
+  } GROUP_DATA_LINK_IN(RODATA_REGION, ROMABLE_REGION)
+
+  /* --- END OF .rodata --- */
+
+  /* --- START OF .flash.text --- */
 
   _image_irom_start = LOADADDR(.flash.text);
   _image_irom_size = LOADADDR(.flash.text) + SIZEOF(.flash.text) - _image_irom_start;
   _image_irom_vaddr = ADDR(.flash.text);
 
-  .flash_text_dummy (NOLOAD): ALIGN(IROM_SEG_ALIGN)
+  .flash.text_dummy (NOLOAD):
   {
-    . = ALIGN(4);
-    . = SIZEOF(_RODATA_SECTION_NAME);
-  } GROUP_LINK_IN(FLASH_CODE_REGION)
+    . = ALIGN(CACHE_ALIGN+CACHE_ALIGN);
+  } GROUP_LINK_IN(ROMABLE_REGION)
 
-  .flash.text : ALIGN(IROM_SEG_ALIGN)
+  .flash.text : ALIGN(4)
   {
-    . = ALIGN(8);
     _stext = .;
-    _instruction_reserved_start = ABSOLUTE(.);  /* This is a symbol marking the flash.text start, this can be used for mmu driver to maintain virtual address */
+    _instruction_reserved_start = ABSOLUTE(.);
     _text_start = ABSOLUTE(.);
 
 #if !defined(CONFIG_ESP32_WIFI_IRAM_OPT)
     *libnet80211.a:( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.*)
     *libpp.a:( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.* .wifiorslpiram .wifiorslpiram.*)
+
 #endif
 
-    . = ALIGN(8);
 #if !defined(CONFIG_ESP32_WIFI_RX_IRAM_OPT)
     *libnet80211.a:( .wifirxiram  .wifirxiram.* .wifislprxiram .wifislprxiram.*)
     *libpp.a:( .wifirxiram  .wifirxiram.* .wifislprxiram .wifislprxiram.*)
 #endif
 
-    . = ALIGN(8);
+    *(.stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
+    *(.irom0.text) /* catch stray ICACHE_RODATA_ATTR */
+    *(.fini.literal)
+    *(.fini)
+    *(.gnu.version)
     *(.literal .text .literal.* .text.*)
-    . = ALIGN(8);
+
+    /* CPU will try to prefetch up to 16 bytes of
+     * of instructions. This means that any configuration (e.g. MMU, PMS) must allow
+     * safe access to up to 16 bytes after the last real instruction, add
+     * dummy bytes to ensure this
+     */
+    . += 16;
+
     _text_end = ABSOLUTE(.);
-    _instruction_reserved_end = ABSOLUTE(.);
+    _instruction_reserved_end = ABSOLUTE(.);  /* This is a symbol marking the flash.text end, this can be used for mmu driver to maintain virtual address */
     _etext = .;
 
     /* Similar to _iram_start, this symbol goes here so it is
-       resolved by addr2line in preference to the first symbol in
-       the flash.text segment.
-    */
-    _flash_cache_start = ABSOLUTE(0);
-  } GROUP_DATA_LINK_IN(FLASH_CODE_REGION, ROMABLE_REGION)
+     * resolved by addr2line in preference to the first symbol in
+     * the flash.text segment.
+     */
+     _flash_cache_start = ABSOLUTE(0);
+  } GROUP_DATA_LINK_IN(ROTEXT_REGION, ROMABLE_REGION)
 
-  /* RTC fast memory holds RTC wake stub code,
-     including from any source file named rtc_wake_stub*.c
-  */
-  .rtc.text :
-  {
-    . = ALIGN(4);
-    *(.rtc.literal .rtc.text)
-    *rtc_wake_stub*.o(.literal .text .literal.* .text.*)
-  } GROUP_DATA_LINK_IN(rtc_iram_seg, ROMABLE_REGION)
-
-  /* RTC slow memory holds RTC wake stub
-     data/rodata, including from any source file
-     named rtc_wake_stub*.c
-  */
-  .rtc.data :
-  {
-    _rtc_data_start = ABSOLUTE(.);
-    *(.rtc.data)
-    *(.rtc.rodata)
-    *rtc_wake_stub*.o(.data .rodata .data.* .rodata.* .bss .bss.*)
-    _rtc_data_end = ABSOLUTE(.);
-  } GROUP_DATA_LINK_IN(rtc_slow_seg, ROMABLE_REGION)
-
-  /* RTC bss, from any source file named rtc_wake_stub*.c */
-  .rtc.bss (NOLOAD) :
-  {
-    _rtc_bss_start = ABSOLUTE(.);
-    *rtc_wake_stub*.o(.bss .bss.*)
-    *rtc_wake_stub*.o(COMMON)
-    _rtc_bss_end = ABSOLUTE(.);
-  } GROUP_LINK_IN(rtc_slow_seg)
-
-  /* This section located in RTC SLOW Memory area.
-     It holds data marked with RTC_SLOW_ATTR attribute.
-     See the file "esp_attr.h" for more information.
-  */
-  .rtc.force_slow :
-  {
-    . = ALIGN(4);
-    _rtc_force_slow_start = ABSOLUTE(.);
-    *(.rtc.force_slow .rtc.force_slow.*)
-    . = ALIGN(4) ;
-    _rtc_force_slow_end = ABSOLUTE(.);
-  } > rtc_slow_seg
-
-  /* Get size of rtc slow data */
-  _rtc_slow_length = (_rtc_force_slow_end - _rtc_data_start);
+  /* --- END OF .flash.text --- */
 
 #ifdef CONFIG_GEN_ISR_TABLES
 #include <zephyr/linker/intlist.ld>
@@ -636,7 +977,7 @@ ASSERT(((__bss_end - ORIGIN(dram0_0_seg)) <= LENGTH(dram0_0_seg)),
 ASSERT(((_iram_end - ORIGIN(iram0_0_seg)) <= LENGTH(iram0_0_seg)),
           "IRAM0 segment data does not fit.")
 
-#if defined(CONFIG_ESP_SPIRAM)
+#ifdef CONFIG_ESP_SPIRAM
 ASSERT(((_ext_ram_data_end - _ext_ram_data_start) <= CONFIG_ESP_SPIRAM_SIZE),
           "External SPIRAM overflowed.")
 #endif /* CONFIG_ESP_SPIRAM */

--- a/soc/espressif/esp32s2/mcuboot.ld
+++ b/soc/espressif/esp32s2/mcuboot.ld
@@ -1,13 +1,6 @@
 /*
- * Copyright (c) 2023 Espressif Systems (Shanghai) Co., Ltd.
+ * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
  * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
- * @file
- * @brief Linker command/script file
- *
- * Linker script for the MCUboot on Xtensa platform.
  */
 
 #include <zephyr/devicetree.h>
@@ -15,54 +8,180 @@
 #include <zephyr/linker/linker-defs.h>
 #include <zephyr/linker/linker-tool.h>
 
+#include "memory.h"
+
 #ifdef CONFIG_XIP
 #error "Xtensa bootloader cannot use XIP"
-#endif /* CONFIG_XIP */
+#endif
 
 /* Disable all romable LMA */
-#udef GROUP_DATA_LINK_IN
+#undef GROUP_DATA_LINK_IN
 #define GROUP_DATA_LINK_IN(vregion, lregion) > vregion
 
-#define RAMABLE_REGION dram_seg
-#define RAMABLE_REGION_1 dram_seg
-
-#define RODATA_REGION dram_seg
-#define ROMABLE_REGION dram_seg
-
-#define IRAM_REGION iram_seg
-#define FLASH_CODE_REGION iram_seg
-
-#define IROM_SEG_ALIGN 16
+/* Aliases for zephyr scripts */
+#define RAMABLE_REGION    dram_seg
+#define RODATA_REGION     dram_seg
+#define ROMABLE_REGION    dram_seg
 
 MEMORY
 {
-  iram_seg        (RWX) : org = 0x40040000, len = 0x7000
-  iram_loader_seg (RWX) : org = 0x40047000, len = 0x3000
-  dram_seg        (RW) : org = 0x3FFE6000, len = 0x6000
+  iram_seg (RWX) :        org = BOOTLOADER_IRAM_SEG_START,
+                          len = BOOTLOADER_IRAM_SEG_LEN
+  iram_loader_seg (RWX) : org = BOOTLOADER_IRAM_LOADER_SEG_START,
+                          len = BOOTLOADER_IRAM_LOADER_SEG_LEN
+  dram_seg (RW) :         org = BOOTLOADER_DRAM_SEG_START,
+                          len = BOOTLOADER_DRAM_SEG_LEN
 
 #ifdef CONFIG_GEN_ISR_TABLES
   IDT_LIST(RW): org = 0x3ebfe010, len = 0x2000
 #endif
-
 }
 
+/*  Default entry point:  */
 ENTRY(CONFIG_KERNEL_ENTRY)
 
 SECTIONS
 {
-  /* NOTE: .rodata section should be the first section in the linker script and no
-   * other section should appear before .rodata section. This is the requirement
-   * to align ROM section to 64K page offset.
-   * Adding .rodata as first section helps to reduce size of generated binary by
-   * few kBs.
-   */
-  SECTION_PROLOGUE(_RODATA_SECTION_NAME,,)
+  .iram0.loader_text :
   {
-    __rodata_region_start = ABSOLUTE(.);
+    _loader_text_start = ABSOLUTE(.);
+    *(.stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
 
+    *libarch__xtensa__core.a:xtensa_asm2_util.*(.literal .text .literal.* .text.*)
+    *liblib__libc__common.a:abort.*(.literal .text .literal.* .text.*)
+    *libdrivers__timer.a:xtensa_sys_timer.*(.literal .text .literal.* .text.*)
+    *libarch__common.a:dynamic_isr.*(.literal .text .literal.* .text.*)
+    *libarch__common.a:sw_isr_common.*(.literal .text .literal.* .text.*)
+
+    *libapp.a:flash_map_extended.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:printk.*(.literal.printk .literal.vprintk .literal.char_out .text.printk .text.vprintk .text.char_out)
+    *libzephyr.a:cbprintf_nano.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:cpu.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:mmu_hal.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:cache_hal.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:flash_map.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:esp_rom_spiflash.*(.literal .text .literal.* .text.*)
+
+    *libzephyr.a:heap.*(.literal .text .literal.* .text.*)
+
+    *libkernel.a:kheap.*(.literal .text .literal.* .text.*)
+    *libkernel.a:mempool.*(.literal .text .literal.* .text.*)
+    *libkernel.a:device.*(.literal .text .literal.* .text.*)
+    *libkernel.a:timeout.*(.literal .text .literal.* .text.*)
+
+    *(.literal.bootloader_mmap .text.bootloader_mmap)
+    *(.literal.bootloader_munmap .text.bootloader_munmap)
+
+    *libzephyr.a:esp_loader.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:mmu_hal.*(.literal .text .literal.* .text.*)
+
+    *(.literal.esp_intr_disable .literal.esp_intr_disable.* .text.esp_intr_disable .text.esp_intr_disable.*)
+    *(.literal.default_intr_handler .text.default_intr_handler .iram1.*.default_intr_handler)
+    *(.literal.esp_log_timestamp .text.esp_log_timestamp)
+    *(.literal.esp_log_early_timestamp .text.esp_log_early_timestamp)
+    *(.literal.esp_system_abort .text.esp_system_abort)
+
+    *(.fini.literal)
+    *(.fini)
+    *(.gnu.version)
+
+    /* CPU will try to prefetch up to 16 bytes of
+     * of instructions. This means that any configuration (e.g. MMU, PMS) must allow
+     * safe access to up to 16 bytes after the last real instruction, add
+     * dummy bytes to ensure this
+     */
+    . += 16;
+
+    _text_end = ABSOLUTE(.);
+    _etext = .;
     . = ALIGN(4);
+    _loader_text_end = ABSOLUTE(.);
+    _iram_text_end = ABSOLUTE(.);
+    _iram_end = ABSOLUTE(.);
+  } > iram_loader_seg
+
+  .iram0.vectors : ALIGN(4)
+  {
+    _iram_start = ABSOLUTE(.);
+    /* Vectors go to IRAM */
+    _init_start = ABSOLUTE(.);
+    /* Vectors according to builds/RF-2015.2-win32/esp108_v1_2_s5_512int_2/config.html */
+    . = 0x0;
+    KEEP(*(.WindowVectors.text));
+    . = 0x180;
+    KEEP(*(.Level2InterruptVector.text));
+    . = 0x1c0;
+    KEEP(*(.Level3InterruptVector.text));
+    . = 0x200;
+    KEEP(*(.Level4InterruptVector.text));
+    . = 0x240;
+    KEEP(*(.Level5InterruptVector.text));
+    . = 0x280;
+    KEEP(*(.DebugExceptionVector.text));
+    . = 0x2c0;
+    KEEP(*(.NMIExceptionVector.text));
+    . = 0x300;
+    KEEP(*(.KernelExceptionVector.text));
+    . = 0x340;
+    KEEP(*(.UserExceptionVector.text));
+    . = 0x3C0;
+    KEEP(*(.DoubleExceptionVector.text));
+    . = 0x400;
+    _invalid_pc_placeholder = ABSOLUTE(.);
+    *(.*Vector.literal)
+
+    *(.UserEnter.literal);
+    *(.UserEnter.text);
+    . = ALIGN (16);
+    *(.entry.text)
+    *(.init.literal)
+    *(.init)
+    . = ALIGN (4);
+    _init_end = ABSOLUTE(.);
+
+    _iram_start = ABSOLUTE(.);
+  } > iram_seg
+
+  .iram0.text :
+  {
+    . = ALIGN(4);
+
+    *(.iram1 .iram1.*)
+    *(.iram0.literal .iram.literal .iram.text.literal .iram0.text .iram.text)
+
+    *(.literal .text .literal.* .text.*)
+    . = ALIGN(4);
+
+    *(.irom0.text) /* catch stray ICACHE_RODATA_ATTR */
+    . = ALIGN(4);
+  } > iram_seg
+
+  .dram0.data : ALIGN(16)
+  {
+    . = ALIGN(4);
+    __data_start = ABSOLUTE(.);
+
     #include <snippets-rodata.ld>
 
+    . = ALIGN(4);
+    #include <snippets-rwdata.ld>
+    . = ALIGN(4);
+
+    *(.data)
+    *(.data.*)
+    *(.gnu.linkonce.d.*)
+    *(.data1)
+    *(.sdata)
+    *(.sdata.*)
+    *(.gnu.linkonce.s.*)
+    *(.sdata2)
+    *(.sdata2.*)
+    *(.gnu.linkonce.s2.*)
+    *libzephyr.a:mmu_hal.*(.rodata .rodata.*)
+    *libzephyr.a:rtc_clk.*(.rodata .rodata.*)
+
+    KEEP(*(.jcr))
+    *(.dram1 .dram1.*)
     . = ALIGN(4);
     *(.rodata)
     *(.rodata.*)
@@ -97,51 +216,16 @@ SECTIONS
     *(.gnu.linkonce.lit4.*)
     _lit4_end = ABSOLUTE(.);
     . = ALIGN(4);
-    _thread_local_start = ABSOLUTE(.);
-    *(.tdata)
-    *(.tdata.*)
-    *(.tbss)
-    *(.tbss.*)
     *(.rodata_wlog)
     *(.rodata_wlog*)
     _thread_local_end = ABSOLUTE(.);
     . = ALIGN(4);
-  } GROUP_DATA_LINK_IN(RODATA_REGION, ROMABLE_REGION)
+  } > dram_seg
 
-  #include <zephyr/linker/common-rom/common-rom-cpp.ld>
   #include <zephyr/linker/common-rom/common-rom-kernel-devices.ld>
-  #include <zephyr/linker/common-rom/common-rom-ztest.ld>
-  #include <zephyr/linker/common-rom/common-rom-net.ld>
-  #include <zephyr/linker/common-rom/common-rom-bt.ld>
   #include <zephyr/linker/common-rom/common-rom-debug.ld>
   #include <zephyr/linker/common-rom/common-rom-misc.ld>
   #include <snippets-sections.ld>
-
-  .dram0.data :
-  {
-    __data_start = ABSOLUTE(.);
-
-    _btdm_data_start = ABSOLUTE(.);
-    *libbtdm_app.a:(.data .data.*)
-    . = ALIGN (4);
-    _btdm_data_end = ABSOLUTE(.);
-
-    *(.data)
-    *(.data.*)
-    *(.gnu.linkonce.d.*)
-    *(.data1)
-    *(.sdata)
-    *(.sdata.*)
-    *(.gnu.linkonce.s.*)
-    *(.sdata2)
-    *(.sdata2.*)
-    *(.gnu.linkonce.s2.*)
-    *libzephyr.a:mmu_hal.*(.rodata .rodata.*)
-    *libzephyr.a:rtc_clk.*(.rodata .rodata.*)
-    KEEP(*(.jcr))
-    *(.dram1 .dram1.*)
-    . = ALIGN(4);
-  } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
   #include <zephyr/linker/cplusplus-rom.ld>
   #include <snippets-data-sections.ld>
@@ -150,131 +234,20 @@ SECTIONS
   #include <zephyr/linker/cplusplus-ram.ld>
   #include <zephyr/linker/common-rom/common-rom-logging.ld>
 
-  .dram0.end :
+  .noinit (NOLOAD):
   {
-    . = ALIGN(4);
-    #include <snippets-rwdata.ld>
-    . = ALIGN(4);
-    _end = ABSOLUTE(.);
-    __data_end = ABSOLUTE(.);
-  } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
-
-  /* Send .iram0 code to iram */
-  .iram0.vectors : ALIGN(4)
-  {
-    /* Vectors go to IRAM */
-    _init_start = ABSOLUTE(.);
-    /* Vectors according to builds/RF-2015.2-win32/esp108_v1_2_s5_512int_2/config.html */
-    . = 0x0;
-    KEEP(*(.WindowVectors.text));
-    . = 0x180;
-    KEEP(*(.Level2InterruptVector.text));
-    . = 0x1c0;
-    KEEP(*(.Level3InterruptVector.text));
-    . = 0x200;
-    KEEP(*(.Level4InterruptVector.text));
-    . = 0x240;
-    KEEP(*(.Level5InterruptVector.text));
-    . = 0x280;
-    KEEP(*(.DebugExceptionVector.text));
-    . = 0x2c0;
-    KEEP(*(.NMIExceptionVector.text));
-    . = 0x300;
-    KEEP(*(.KernelExceptionVector.text));
-    . = 0x340;
-    KEEP(*(.UserExceptionVector.text));
-    . = 0x3C0;
-    KEEP(*(.DoubleExceptionVector.text));
-    . = 0x400;
-    *(.*Vector.literal)
-
-    *(.UserEnter.literal);
-    *(.UserEnter.text);
-    . = ALIGN (16);
-    *(.entry.text)
-    *(.init.literal)
-    *(.init)
-    _init_end = ABSOLUTE(.);
-
-    /* This goes here, not at top of linker script, so addr2line finds it last,
-       and uses it in preference to the first symbol in IRAM */
-    _iram_start = ABSOLUTE(0);
-  } GROUP_DATA_LINK_IN(IRAM_REGION, ROMABLE_REGION)
-
-  .iram_loader.text :
-  {
-    . = ALIGN (16);
-    _loader_text_start = ABSOLUTE(.);
-    *(.stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
-    *(.iram1 .iram1.*) /* catch stray IRAM_ATTR */
-    *libzephyr.a:bootloader_flash.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_flash_config_esp32s2.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_clock_loader.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_common_loader.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_init_common.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_flash.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_random.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_random*.*(.literal.bootloader_random_disable .text.bootloader_random_disable)
-    *libzephyr.a:bootloader_random*.*(.literal.bootloader_random_enable .text.bootloader_random_enable)
-    *libzephyr.a:bootloader_efuse_esp32s2.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_utility.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_sha.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_console.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_console_loader.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_panic.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_soc.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:esp_image_format.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:flash_encrypt.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:flash_encryption_secure_features.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:flash_partitions.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:secure_boot.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:secure_boot_secure_features.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:secure_boot_signatures_bootloader.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:wdt_hal_iram.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:esp_efuse_table.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:esp_efuse_fields.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:esp_efuse_api.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:esp_efuse_utility.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:esp_efuse_api_key_esp32xx.*(.literal .text .literal.* .text.*)
-    *esp_mcuboot.*(.literal .text .literal.* .text.*)
-    *esp_loader.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:mmu_hal.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:rtc_clk.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:rtc_clk_init.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:rtc_time.*(.literal .literal.* .text .text.*)
-    *(.fini.literal)
-    *(.fini)
-    *(.gnu.version)
-    _loader_text_end = ABSOLUTE(.);
-  } > iram_loader_seg
-
-  SECTION_PROLOGUE(_TEXT_SECTION_NAME, , ALIGN(4))
-  {
-    /* Code marked as running out of IRAM */
-    _iram_text_start = ABSOLUTE(.);
-
-    *(.iram1 .iram1.*)
-    *(.iram0.literal .iram.literal .iram.text.literal .iram0.text .iram.text)
-
-    . = ALIGN(4);
-    _iram_text_end = ABSOLUTE(.);
-    _iram_end = ABSOLUTE(.);
-  } GROUP_DATA_LINK_IN(IRAM_REGION, ROMABLE_REGION)
+    . = ALIGN(8);
+    *(.noinit)
+    *(.noinit.*)
+    . = ALIGN(8) ;
+  } > dram_seg
 
   /* Shared RAM */
-  SECTION_DATA_PROLOGUE(_BSS_SECTION_NAME,(NOLOAD),)
+  .bss (NOLOAD):
   {
     . = ALIGN (8);
     _bss_start = ABSOLUTE(.); /* required by bluetooth library */
     __bss_start = ABSOLUTE(.);
-
-    _btdm_bss_start = ABSOLUTE(.);
-    *libbtdm_app.a:(.bss .bss.* COMMON)
-    . = ALIGN (4);
-    _btdm_bss_end = ABSOLUTE(.);
-
-    /* Buffer for system heap should be placed in dram_seg */
-    *libkernel.a:mempool.*(.noinit.kheap_buf__system_heap .noinit.*.kheap_buf__system_heap)
 
     *(.dynsbss)
     *(.sbss)
@@ -294,35 +267,9 @@ SECTIONS
     __bss_end = ABSOLUTE(.);
     _bss_end = ABSOLUTE(.);
     _end = ABSOLUTE(.);
-  } GROUP_LINK_IN(RAMABLE_REGION)
+  } > dram_seg
 
-  ASSERT(((__bss_end - ORIGIN(RAMABLE_REGION)) <= LENGTH(RAMABLE_REGION)),
-          "DRAM segment data does not fit.")
-
-  SECTION_DATA_PROLOGUE(_NOINIT_SECTION_NAME, (NOLOAD),)
-  {
-    . = ALIGN (8);
-    *(.noinit)
-    *(.noinit.*)
-    . = ALIGN (8);
-  } GROUP_LINK_IN(RAMABLE_REGION_1)
-
-  .flash.text : ALIGN(IROM_SEG_ALIGN)
-  {
-    _stext = .;
-    _text_start = ABSOLUTE(.);
-
-    *(.literal .text .literal.* .text.*)
-    . = ALIGN(4);
-    _text_end = ABSOLUTE(.);
-    _etext = .;
-
-    /* Similar to _iram_start, this symbol goes here so it is
-     * resolved by addr2line in preference to the first symbol in
-     *  the flash.text segment.
-    */
-    _flash_cache_start = ABSOLUTE(0);
-  } GROUP_DATA_LINK_IN(FLASH_CODE_REGION, ROMABLE_REGION)
+  ASSERT(((__bss_end - ORIGIN(dram_seg)) <= LENGTH(dram_seg)), "DRAM segment data does not fit.")
 
 #include <zephyr/linker/debug-sections.ld>
 
@@ -363,8 +310,4 @@ SECTIONS
 #ifdef CONFIG_GEN_ISR_TABLES
 #include <zephyr/linker/intlist.ld>
 #endif
-
 }
-
-ASSERT(((_iram_end - ORIGIN(IRAM_REGION)) <= LENGTH(IRAM_REGION)),
-          "IRAM0 segment data does not fit.")

--- a/soc/espressif/esp32s2/memory.h
+++ b/soc/espressif/esp32s2/memory.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+/* SRAM0 (32k) with adjacted SRAM1 (288k)
+ * Ibus and Dbus address space
+ */
+#define SRAM_IRAM_START  0x40020000
+#define SRAM_DRAM_START  0x3ffb0000
+#define SRAM_CACHE_SIZE  (CONFIG_ESP32S2_INSTRUCTION_CACHE_SIZE \
+			+ CONFIG_ESP32S2_DATA_CACHE_SIZE)
+
+/** Simplified memory map for the bootloader.
+ *  Make sure the bootloader can load into main memory without overwriting itself.
+ *
+ *  ESP32-S2 ROM static data usage is as follows:
+ *  - 0x3ffeab00 - 0x3fffc410: Shared buffers, used in UART/USB/SPI download mode only
+ *  - 0x3fffc410 - 0x3fffe710: CPU stack, can be reclaimed as heap after RTOS startup
+ *  - 0x3fffe710 - 0x40000000: ROM .bss and .data (not easily reclaimable)
+ *
+ *  The 2nd stage bootloader can take space up to the end of ROM shared
+ *  buffers area (0x3fffc410). For alignment purpose we shall use value (0x3fce9700).
+ */
+
+/* The offset between Dbus and Ibus.
+ * Used to convert between 0x4002xxxx and 0x3ffbxxxx addresses.
+ */
+#define IRAM_DRAM_OFFSET         0x70000
+#define DRAM_BUFFERS_START       0x3ffeab00
+#define DRAM_STACK_START         0x3fffc410
+#define DRAM_ROM_BSS_DATA_START  0x3fffe710
+
+/* Base address used for calculating memory layout
+ * counted from Dbus backwards and back to the Ibus
+ */
+#define BOOTLOADER_USABLE_DRAM_END  DRAM_BUFFERS_START
+
+/* For safety margin between bootloader data section and startup stacks */
+#define BOOTLOADER_STACK_OVERHEAD      0x0
+#define BOOTLOADER_DRAM_SEG_LEN        0x6000
+#define BOOTLOADER_IRAM_LOADER_SEG_LEN 0x2800
+#define BOOTLOADER_IRAM_SEG_LEN        0x8000
+
+/* Start of the lower region is determined by region size and the end of the higher region */
+#define BOOTLOADER_DRAM_SEG_END   (BOOTLOADER_USABLE_DRAM_END - BOOTLOADER_STACK_OVERHEAD)
+#define BOOTLOADER_DRAM_SEG_START (BOOTLOADER_DRAM_SEG_END - BOOTLOADER_DRAM_SEG_LEN)
+#define BOOTLOADER_IRAM_LOADER_SEG_START (BOOTLOADER_DRAM_SEG_START - \
+					BOOTLOADER_IRAM_LOADER_SEG_LEN + IRAM_DRAM_OFFSET)
+#define BOOTLOADER_IRAM_SEG_START (BOOTLOADER_IRAM_LOADER_SEG_START - BOOTLOADER_IRAM_SEG_LEN)
+
+/* Flash */
+#ifdef CONFIG_FLASH_SIZE
+#define FLASH_SIZE        CONFIG_FLASH_SIZE
+#else
+#define FLASH_SIZE        0x400000
+#endif
+
+/* Cached memories */
+#define CACHE_ALIGN       CONFIG_MMU_PAGE_SIZE
+#define IROM_SEG_ORG      0x40080000
+#define IROM_SEG_LEN      0x780000
+#define DROM_SEG_ORG      0x3f000000
+#define DROM_SEG_LEN      FLASH_SIZE

--- a/soc/espressif/esp32s2/soc.c
+++ b/soc/espressif/esp32s2/soc.c
@@ -75,12 +75,7 @@ void __attribute__((section(".iram1"))) __esp_platform_start(void)
 
 	esp_reset_reason_init();
 
-#ifdef CONFIG_MCUBOOT
-	/* MCUboot early initialisation. */
-	if (bootloader_init()) {
-		abort();
-	}
-#else
+#ifndef CONFIG_MCUBOOT
 	/* ESP-IDF 2nd stage bootloader enables RTC WDT to check on startup sequence
 	 * related issues in application. Hence disable that as we are about to start
 	 * Zephyr environment.
@@ -110,7 +105,7 @@ void __attribute__((section(".iram1"))) __esp_platform_start(void)
 #ifdef CONFIG_SOC_FLASH_ESP32
 	esp_mspi_pin_init();
 	spi_flash_init_chip_state();
-#endif /*CONFIG_SOC_FLASH_ESP32*/
+#endif /* CONFIG_SOC_FLASH_ESP32 */
 
 	esp_mmu_map_init();
 
@@ -152,7 +147,7 @@ void __attribute__((section(".iram1"))) __esp_platform_start(void)
 #if CONFIG_SOC_FLASH_ESP32 || CONFIG_ESP_SPIRAM
 	spi_flash_guard_set(&g_flash_guard_default_ops);
 #endif
-#endif /* CONFIG_MCUBOOT */
+#endif /* !CONFIG_MCUBOOT */
 
 	esp_intr_initialize();
 	/* Start Zephyr */

--- a/soc/espressif/esp32s3/CMakeLists.txt
+++ b/soc/espressif/esp32s3/CMakeLists.txt
@@ -19,42 +19,29 @@ zephyr_library_sources_ifdef(CONFIG_NEWLIB_LIBC newlib_fix.c)
 zephyr_library_sources_ifdef(CONFIG_PM power.c)
 zephyr_library_sources_ifdef(CONFIG_POWEROFF poweroff.c)
 
-# get flash size to use in esptool as string
+# Get flash size to use in esptool as string
 math(EXPR esptoolpy_flashsize "${CONFIG_FLASH_SIZE} / 0x100000")
 
-if(CONFIG_BOOTLOADER_ESP_IDF)
-
-  set(bootloader_dir "${ZEPHYR_HAL_ESPRESSIF_MODULE_DIR}/zephyr/blobs/lib/${CONFIG_SOC_SERIES}")
-
-  if(EXISTS "${bootloader_dir}/bootloader-${CONFIG_SOC_SERIES}.bin")
-    file(COPY "${bootloader_dir}/bootloader-${CONFIG_SOC_SERIES}.bin" DESTINATION ${CMAKE_BINARY_DIR})
-    file(RENAME "${CMAKE_BINARY_DIR}/bootloader-${CONFIG_SOC_SERIES}.bin" "${CMAKE_BINARY_DIR}/bootloader.bin")
-  endif()
-
-  if(EXISTS "${bootloader_dir}/partition-table-${CONFIG_SOC_SERIES}.bin")
-    file(COPY "${bootloader_dir}/partition-table-${CONFIG_SOC_SERIES}.bin" DESTINATION ${CMAKE_BINARY_DIR})
-    file(RENAME "${CMAKE_BINARY_DIR}/partition-table-${CONFIG_SOC_SERIES}.bin" "${CMAKE_BINARY_DIR}/partition-table.bin")
-  endif()
-  board_finalize_runner_args(esp32 "--esp-flash-bootloader=${CMAKE_BINARY_DIR}/bootloader.bin")
-
-  board_finalize_runner_args(esp32 "--esp-flash-partition_table=${CMAKE_BINARY_DIR}/partition-table.bin")
-
-  board_finalize_runner_args(esp32 "--esp-partition-table-address=0x8000")
-
-endif()
-
-if(CONFIG_MCUBOOT OR CONFIG_BOOTLOADER_ESP_IDF)
+# Make rom loader compatible binary file
+if(NOT CONFIG_BOOTLOADER_MCUBOOT)
 
   if(CONFIG_BUILD_OUTPUT_BIN)
+
+    set(ESPTOOL_PY ${ESP_IDF_PATH}/tools/esptool_py/esptool.py)
+    message("esptool path: ${ESPTOOL_PY}")
+
+    set(ELF2IMAGE_ARG "")
+    if(NOT CONFIG_MCUBOOT)
+      set(ELF2IMAGE_ARG "--ram-only-header")
+    endif()
+
     set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
-      COMMAND ${PYTHON_EXECUTABLE} ${ESP_IDF_PATH}/tools/esptool_py/esptool.py
-      ARGS --chip esp32s3 elf2image --flash_mode dio --flash_freq 40m --flash_size ${esptoolpy_flashsize}MB
+      COMMAND ${PYTHON_EXECUTABLE} ${ESPTOOL_PY}
+      ARGS --chip esp32s3 elf2image ${ELF2IMAGE_ARG}
+      --flash_mode dio --flash_freq 40m
+      --flash_size ${esptoolpy_flashsize}MB
       -o ${CMAKE_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.bin
       ${CMAKE_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.elf)
-  endif()
-
-  if(CONFIG_MCUBOOT)
-    board_finalize_runner_args(esp32 "--esp-flash-bootloader=${CMAKE_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.bin")
   endif()
 
 endif()
@@ -74,17 +61,19 @@ else()
 
   set_property(TARGET bintools PROPERTY disassembly_flag_inline_source)
 
-  # get code-partition slot0 address
-  dt_nodelabel(dts_partition_path NODELABEL "slot0_partition")
-  dt_reg_addr(img_0_off PATH ${dts_partition_path})
-
-  # get code-partition boot address
+  # Get code-partition boot address
   dt_nodelabel(dts_partition_path NODELABEL "boot_partition")
   dt_reg_addr(boot_off PATH ${dts_partition_path})
 
-  board_finalize_runner_args(esp32 "--esp-boot-address=${boot_off}")
+  # Get code-partition slot0 address
+  dt_nodelabel(dts_partition_path NODELABEL "slot0_partition")
+  dt_reg_addr(img_0_off PATH ${dts_partition_path})
 
-  board_finalize_runner_args(esp32 "--esp-app-address=${img_0_off}")
+  if(NOT CONFIG_BOOTLOADER_MCUBOOT)
+    board_finalize_runner_args(esp32 "--esp-app-address=${boot_off}")
+  else()
+    board_finalize_runner_args(esp32 "--esp-app-address=${img_0_off}")
+  endif()
 
 endif()
 

--- a/soc/espressif/esp32s3/default.ld
+++ b/soc/espressif/esp32s3/default.ld
@@ -1,13 +1,6 @@
 /*
- * Copyright (c) 2023 Espressif Systems (Shanghai) Co., Ltd.
+ * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
  * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
- * @file
- * @brief Linker command/script file
- *
- * Linker script for the ESP32S3 platform.
  */
 
 #include <zephyr/devicetree.h>
@@ -15,83 +8,63 @@
 #include <zephyr/linker/linker-defs.h>
 #include <zephyr/linker/linker-tool.h>
 
-#define SRAM_IRAM_START     0x40370000
-#define SRAM_DIRAM_I_START  0x40378000
-/* SRAM_IRAM_END is equivalent 2nd stage bootloader iram_loader_seg
-   start address (that should not be overlapped) */
-#define SRAM_IRAM_END       0x403BA000
-#define I_D_SRAM_OFFSET     (SRAM_DIRAM_I_START - SRAM_DRAM_START)
+#include "memory.h"
 
-#define SRAM_DRAM_START     0x3FC88000
-#define SRAM_DRAM_END       (SRAM_IRAM_END - I_D_SRAM_OFFSET)
-#define I_D_SRAM_SIZE       (SRAM_DRAM_END - SRAM_DRAM_START)
-
-#define ICACHE_SIZE         0x8000
-#define SRAM_IRAM_ORG       (SRAM_IRAM_START + CONFIG_ESP32S3_INSTRUCTION_CACHE_SIZE)
-#define SRAM_IRAM_SIZE      (I_D_SRAM_SIZE + ICACHE_SIZE - CONFIG_ESP32S3_INSTRUCTION_CACHE_SIZE)
-
-#define SRAM_DRAM_ORG       (SRAM_DRAM_START)
-
-#define DRAM0_0_SEG_LEN I_D_SRAM_SIZE
-
-#define FLASH_CODE_REGION irom0_0_seg
-#define RODATA_REGION drom0_0_seg
-#define IRAM_REGION iram0_0_seg
-#define RAMABLE_REGION dram0_0_seg
-#define ROMABLE_REGION ROM
-
-#ifdef CONFIG_FLASH_SIZE
-#define FLASH_SIZE CONFIG_FLASH_SIZE
+/* The "user_iram_end" represents the 2nd stage bootloader
+ * "iram_loader_seg" start address (that should not be overlapped).
+ * If no bootloader is used, we can extend it to gain more user ram.
+ */
+#ifdef CONFIG_ESP_SIMPLE_BOOT
+user_iram_end = (DRAM_BUFFERS_START + IRAM_DRAM_OFFSET);
 #else
-#define FLASH_SIZE 0x800000
+user_iram_end = BOOTLOADER_IRAM_LOADER_SEG_START;
 #endif
 
-#ifdef CONFIG_BOOTLOADER_ESP_IDF
-#define IROM_SEG_ORG 0x42000020
-#define IROM_SEG_LEN FLASH_SIZE-0x20
-#define IROM_SEG_ALIGN 0x10
-#else
-#define IROM_SEG_ORG 0x42000000
-#define IROM_SEG_LEN FLASH_SIZE
-/* MCUBoot requires MMU page size alignment */
-#define IROM_SEG_ALIGN 0x10000
-#endif
+/* User available SRAM memory segments */
+user_dram_seg_org = SRAM1_DRAM_START;
+user_iram_seg_org = (SRAM0_IRAM_START + CONFIG_ESP32S3_INSTRUCTION_CACHE_SIZE);
+user_dram_end = (user_iram_end - IRAM_DRAM_OFFSET);
+user_idram_size = (user_dram_end - SRAM1_DRAM_START);
+sram0_iram_size = (SRAM0_SIZE - CONFIG_ESP32S3_INSTRUCTION_CACHE_SIZE);
+user_iram_seg_len = (user_idram_size + sram0_iram_size);
+user_dram_seg_len = user_idram_size;
 
-#ifdef CONFIG_SOC_ENABLE_APPCPU
-#define APPCPU_IRAM_SIZE CONFIG_ESP32S3_APPCPU_IRAM
-#define APPCPU_DRAM_SIZE CONFIG_ESP32S3_APPCPU_DRAM
-#else
-#define APPCPU_IRAM_SIZE 0x0
-#define APPCPU_DRAM_SIZE 0x0
-#endif
+/* Aliases */
+#define FLASH_CODE_REGION  irom0_0_seg
+#define RODATA_REGION      drom0_0_seg
+#define IRAM_REGION        iram0_0_seg
+#define RAMABLE_REGION     dram0_0_seg
+#define ROMABLE_REGION     FLASH
 
-/* Flash segments (rodata and text) should be mapped in virtual address space by providing VMA.
+/* Flash segments (rodata and text) should be mapped in the virtual address spaces.
  * Executing directly from LMA is not possible. */
 #undef GROUP_ROM_LINK_IN
 #define GROUP_ROM_LINK_IN(vregion, lregion) > RODATA_REGION AT > lregion
 
 MEMORY
 {
-  mcuboot_hdr (RX): org = 0x0, len = 0x20
-  metadata (RX): org = 0x20, len = 0x20
-  ROM (RX): org = 0x40, len = FLASH_SIZE - 0x40
-  iram0_0_seg(RX): org = SRAM_IRAM_ORG, len = SRAM_IRAM_SIZE - APPCPU_IRAM_SIZE
-  dram0_0_seg(RW): org = SRAM_DRAM_ORG, len = DRAM0_0_SEG_LEN - APPCPU_DRAM_SIZE
+#ifdef CONFIG_BOOTLOADER_MCUBOOT
+  mcuboot_hdr (R):  org = 0x0,  len = 0x20
+  metadata (R):     org = 0x20, len = 0x20
+  FLASH (R):        org = 0x40, len = FLASH_SIZE - 0x40
+#else
+  /* Make safety margin in the FLASH memory size so the
+   * (esp_img_header + (n*esp_seg_headers)) would fit */
+  FLASH (R):        org = 0x0, len = FLASH_SIZE - 0x100
+#endif /* CONFIG_BOOTLOADER_MCUBOOT */
+
+  iram0_0_seg(RX): org = user_iram_seg_org, len = user_iram_seg_len - APPCPU_IRAM_SIZE
+  dram0_0_seg(RW): org = user_dram_seg_org, len = user_dram_seg_len - APPCPU_DRAM_SIZE
 
   irom0_0_seg(RX): org = IROM_SEG_ORG, len = IROM_SEG_LEN
-
-   /* MCUboot binary for ESP32 has image header of 0x20 bytes.
-   * Additional load header of 0x20 bytes are appended to the image.
-   * Hence, an offset of 0x40 is added to DROM segment origin.
-   */
-  drom0_0_seg(R): org = 0x3C000040, len = FLASH_SIZE - 0x40
+  drom0_0_seg(R):  org = DROM_SEG_ORG, len = DROM_SEG_LEN
 
   /**
    * `ext_ram_seg` and `drom0_0_seg` share the same bus and the address region.
    * A dummy section is used to avoid overlap. See `.ext_ram.dummy` in `sections.ld.in`
    */
 #if defined(CONFIG_ESP_SPIRAM)
-  ext_ram_seg(RWX): org = 0x3C000040, len = CONFIG_ESP_SPIRAM_SIZE - 0x40
+  ext_ram_seg(RWX): org = DROM_SEG_ORG, len = CONFIG_ESP_SPIRAM_SIZE - 0x40
 #endif
 
   /* RTC fast memory (executable). Persists over deep sleep.
@@ -111,13 +84,17 @@ MEMORY
 #endif
 }
 
-_esp_mmu_block_size = (CONFIG_MMU_PAGE_SIZE);
-
 /*  Default entry point:  */
 ENTRY(CONFIG_KERNEL_ENTRY)
 
+/* Used as a pointer to the heap end */
+_heap_sentry = DRAM_BUFFERS_START;
+
 SECTIONS
 {
+  _iram_dram_offset =  IRAM_DRAM_OFFSET;
+
+#ifdef CONFIG_BOOTLOADER_MCUBOOT
   /* Reserve space for MCUboot header in the binary */
   .mcuboot_header :
   {
@@ -128,32 +105,37 @@ SECTIONS
   } > mcuboot_hdr
   .metadata :
   {
-    /* Magic byte for load header */
+    /* 0. Magic byte for load header */
     LONG(0xace637d3)
 
-    /* Application entry point address */
+    /* 1. Application entry point address */
     KEEP(*(.entry_addr))
 
     /* IRAM metadata:
-     * - Destination address (VMA) for IRAM region
-     * - Flash offset (LMA) for start of IRAM region
-     * - Size of IRAM region
+     * 2. Destination address (VMA) for IRAM region
+     * 3. Flash offset (LMA) for start of IRAM region
+     * 4. Size of IRAM region
      */
     LONG(ADDR(.iram0.vectors))
     LONG(LOADADDR(.iram0.vectors))
     LONG(LOADADDR(.iram0.text) + SIZEOF(.iram0.text) - LOADADDR(.iram0.vectors))
 
     /* DRAM metadata:
-     * - Destination address (VMA) for DRAM region
-     * - Flash offset (LMA) for start of DRAM region
-     * - Size of DRAM region
+     * 5. Destination address (VMA) for DRAM region
+     * 6. Flash offset (LMA) for start of DRAM region
+     * 7. Size of DRAM region
      */
     LONG(ADDR(.dram0.data))
     LONG(LOADADDR(.dram0.data))
     LONG(LOADADDR(.dram0.end) + SIZEOF(.dram0.end) - LOADADDR(.dram0.data))
   } > metadata
+#endif /* CONFIG_BOOTLOADER_MCUBOOT */
 
-  #include <zephyr/linker/rel-sections.ld>
+
+/* Virtual non-loadable sections */
+#include <zephyr/linker/rel-sections.ld>
+
+  /* --- START OF RTC --- */
 
   /* RTC fast memory holds RTC wake stub code */
   .rtc.text :
@@ -224,7 +206,7 @@ SECTIONS
     . = ALIGN(4);
     _rtc_force_slow_start = ABSOLUTE(.);
     *(.rtc.force_slow .rtc.force_slow.*)
-    . = ALIGN(4) ;
+    . = ALIGN(4);
     _rtc_force_slow_end = ABSOLUTE(.);
   } GROUP_DATA_LINK_IN(rtc_slow_seg, ROMABLE_REGION)
 
@@ -234,6 +216,10 @@ SECTIONS
 
   ASSERT((_rtc_slow_length <= LENGTH(rtc_slow_seg)), "RTC_SLOW segment data does not fit.")
   ASSERT((_rtc_fast_length <= LENGTH(rtc_data_seg)), "RTC_FAST segment data does not fit.")
+
+  /* --- END OF RTC --- */
+
+  /* --- START OF IRAM --- */
 
   /* Send .iram0 code to iram */
   .iram0.vectors : ALIGN(4)
@@ -365,6 +351,7 @@ SECTIONS
     *(.literal.rtc_vddsdio_set_config .text.rtc_vddsdio_set_config)
     *libzephyr.a:esp_memory_utils.*(.literal .literal.* .text .text.*)
     *libzephyr.a:rtc_clk.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:rtc_clk_init.*(.literal .text .literal.* .text.*)
     *libzephyr.a:rtc_sleep.*(.literal .literal.* .text .text.*)
     *libzephyr.a:rtc_time.*(.literal .literal.* .text .text.*)
     *libzephyr.a:systimer.*(.literal .literal.* .text .text.*)
@@ -377,7 +364,6 @@ SECTIONS
 
     /* [mapping:esp_rom] */
     *libzephyr.a:esp_rom_cache_esp32s2_esp32s3.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:esp_rom_cache_writeback_esp32s3.*(.literal .literal.* .text .text.*)
     *libzephyr.a:esp_rom_spiflash.*(.literal .literal.* .text .text.*)
     *libzephyr.a:esp_rom_systimer.*(.literal .literal.* .text .text.*)
     *libzephyr.a:esp_rom_wdt.*(.literal .literal.* .text .text.*)
@@ -404,25 +390,109 @@ SECTIONS
     *libnet80211.a:( .wifirxiram  .wifirxiram.* .wifislprxiram .wifislprxiram.*)
     *libpp.a:( .wifirxiram  .wifirxiram.* .wifislprxiram .wifislprxiram.*)
 #endif
-
-    . = ALIGN(4) + 16;
+    . = ALIGN(4);
 
   } GROUP_DATA_LINK_IN(IRAM_REGION, ROMABLE_REGION)
 
-  /**
-   * This section is required to skip .iram0.text area because iram0_0_seg and
-   * dram0_0_seg reflect the same address space on different buses.
-   */
+#ifdef CONFIG_ESP_SIMPLE_BOOT
+  .loader.text :
+  {
+    . =  ALIGN(4);
+    _loader_text_start = ABSOLUTE(.);
+    *libzephyr.a:bootloader_soc.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_init.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_esp32s3.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_clock_init.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_wdt.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_flash.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_flash_config_esp32s3.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_clock_loader.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_common_loader.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_mem.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_random.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_random*.*(.literal.bootloader_random_disable .text.bootloader_random_disable)
+    *libzephyr.a:bootloader_random*.*(.literal.bootloader_random_enable .text.bootloader_random_enable)
+    *libzephyr.a:bootloader_efuse.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_utility.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_sha.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_console.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:bootloader_panic.*(.literal .text .literal.* .text.*)
+
+    *libzephyr.a:esp_image_format.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:flash_encrypt.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:flash_encryption_secure_features.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:flash_partitions.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:spi_flash_hal.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:spi_flash_hal_common.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:esp_flash_api.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:esp_flash_spi_init.*(.literal .text .literal.* .text.*)
+
+    *libzephyr.a:secure_boot.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:secure_boot_secure_features.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:secure_boot_signatures_bootloader.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:esp_efuse_table.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:esp_efuse_fields.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:esp_efuse_api.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:esp_efuse_utility.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:esp_efuse_api_key_esp32xx.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:mpu_hal.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:cpu_region_protect.*(.literal .text .literal.* .text.*)
+
+    *(.fini.literal)
+    *(.fini)
+
+    . = ALIGN(4);
+    _loader_text_end = ABSOLUTE(.);
+  } GROUP_DATA_LINK_IN(IRAM_REGION, ROMABLE_REGION)
+#endif /* CONFIG_ESP_SIMPLE_BOOT */
+
+  /* Marks the end of IRAM code segment */
+  .iram0.text_end (NOLOAD) :
+  {
+    /* ESP32-S3 memprot requires 16B padding for possible CPU prefetch and 256B alignment for PMS split lines */
+    . = ALIGN(4) + 16;
+    _iram_text_end = ABSOLUTE(.);
+  } GROUP_LINK_IN(IRAM_REGION)
+
+  .iram0.data :
+  {
+    . = ALIGN(4);
+    _iram_data_start = ABSOLUTE(.);
+    *(.iram.data)
+    *(.iram.data*)
+    _iram_data_end = ABSOLUTE(.);
+  } GROUP_DATA_LINK_IN(IRAM_REGION, ROMABLE_REGION)
+
+  .iram0.bss (NOLOAD) :
+  {
+    . = ALIGN(4);
+    _iram_bss_start = ABSOLUTE(.);
+    *(.iram.bss)
+    *(.iram.bss*)
+    _iram_bss_end = ABSOLUTE(.);
+    . = ALIGN(4);
+    _iram_end = ABSOLUTE(.);
+  } GROUP_LINK_IN(IRAM_REGION)
+
+  /* --- END OF IRAM --- */
+
+  /* --- START OF DRAM --- */
+
   .dram0.dummy (NOLOAD):
   {
-    . = ORIGIN(dram0_0_seg) + MAX(_iram_end, SRAM_DIRAM_I_START) - SRAM_DIRAM_I_START;
+    /* Spacer section is required to skip .iram0.text area because
+     * iram0_0_seg and dram0_0_seg reflect the same address space on different buses.
+     */
+    . = ORIGIN(dram0_0_seg) + MAX(_iram_end, SRAM1_IRAM_START) - SRAM1_IRAM_START;
+    . = ALIGN(4) + 16;
   } GROUP_LINK_IN(RAMABLE_REGION)
 
   .dram0.data :
   {
     . = ALIGN (8);
+    _data_start = ABSOLUTE(.);
     __data_start = ABSOLUTE(.);
-    _image_ram_start = ABSOLUTE(.);
+
     /*  bluetooth library requires this symbol to be defined */
     _btdm_data_start = ABSOLUTE(.);
     *libbtdm_app.a:(.data .data.*)
@@ -515,6 +585,7 @@ SECTIONS
     *(.rodata.rtc_vddsdio_set_config)
     *libzephyr.a:esp_memory_utils.*(.rodata .rodata.*)
     *libzephyr.a:rtc_clk.*(.rodata .rodata.*)
+    *libzephyr.a:rtc_clk_init.*(.rodata .rodata.*)
     *libzephyr.a:systimer.*(.rodata .rodata.*)
     *libzephyr.a:mspi_timing_config.*(.rodata .rodata.*)
     *libzephyr.a:mspi_timing_tuning.*(.rodata .rodata.*)
@@ -525,7 +596,6 @@ SECTIONS
 
     /* [mapping:esp_rom] */
     *libzephyr.a:esp_rom_cache_esp32s2_esp32s3.*(.rodata .rodata.*)
-    *libzephyr.a:esp_rom_cache_writeback_esp32s3.*(.rodata .rodata.*)
     *libzephyr.a:esp_rom_spiflash.*(.rodata .rodata.*)
     *libzephyr.a:esp_rom_systimer.*(.rodata .rodata.*)
     *libzephyr.a:esp_rom_wdt.*(.rodata .rodata.*)
@@ -545,12 +615,43 @@ SECTIONS
     *(.rodata.esp_wifi_bt_power_domain_off)
 #endif
 
+    . = ALIGN(4);
+    #include <snippets-rwdata.ld>
+    . = ALIGN(4);
+
     KEEP(*(.jcr))
     *(.dram1 .dram1.*)
     . = ALIGN(4);
   } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
-  #include <zephyr/linker/cplusplus-rom.ld>
+#ifdef CONFIG_ESP_SIMPLE_BOOT
+  .loader.data :
+  {
+    . = ALIGN(4);
+    _loader_data_start = ABSOLUTE(.);
+    *libzephyr.a:bootloader_init.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:bootloader_esp32s3.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:bootloader_clock_init.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:bootloader_wdt.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:bootloader_flash.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:bootloader_flash_config_esp32s3.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:bootloader_efuse.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+
+    *libzephyr.a:cpu_util.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:clk.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:esp_clk.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:cpu_region_protect.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+
+    *libzephyr.a:spi_flash_hal.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:spi_flash_hal_common.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:esp_flash_api.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:esp_flash_spi_init.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+
+    . = ALIGN(4);
+    _loader_data_end = ABSOLUTE(.);
+  } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+#endif /* CONFIG_ESP_SIMPLE_BOOT */
+
   #include <snippets-data-sections.ld>
   #include <zephyr/linker/common-ram.ld>
   #include <snippets-ram-sections.ld>
@@ -566,13 +667,11 @@ SECTIONS
 
   .dram0.end :
   {
-    . = ALIGN(4);
-    #include <snippets-rwdata.ld>
-    . = ALIGN(4);
     __data_end = ABSOLUTE(.);
+    _data_end = ABSOLUTE(.);
   } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
-  .noinit (NOLOAD):
+  .dram0.noinit (NOLOAD):
   {
     . = ALIGN(4);
     *(.noinit)
@@ -580,7 +679,7 @@ SECTIONS
     . = ALIGN(4) ;
   } GROUP_LINK_IN(RAMABLE_REGION)
 
- /* Shared RAM */
+  /* Shared RAM */
   .dram0.bss (NOLOAD) :
   {
     . = ALIGN (8);
@@ -608,18 +707,39 @@ SECTIONS
     *(.gnu.linkonce.b.*)
     *(COMMON)
     . = ALIGN (8);
+    _bss_end = ABSOLUTE(.);
     __bss_end = ABSOLUTE(.);
   } GROUP_LINK_IN(RAMABLE_REGION)
 
-#include <zephyr/linker/ram-end.ld>
+  .dram0.heap_start (NOLOAD) :
+  {
+    . = ALIGN (8);
+    /* Lowest possible start address for the heap */
+    _heap_start = ABSOLUTE(.);
+  } GROUP_LINK_IN(RAMABLE_REGION)
+
+  /* Provide total SRAM usage, including IRAM and DRAM */
+  _image_ram_start = _iram_start - IRAM_DRAM_OFFSET;
+  #include <zephyr/linker/ram-end.ld>
 
   ASSERT(((__bss_end - ORIGIN(dram0_0_seg)) <= LENGTH(dram0_0_seg)), "DRAM segment data does not fit.")
 
+  /* --- END OF DRAM --- */
+
+  /* --- START OF IROM --- */
+
+  /* Symbols used during the application memory mapping */
   _image_irom_start = LOADADDR(.flash.text);
   _image_irom_size = LOADADDR(.flash.text) + SIZEOF(.flash.text) - _image_irom_start;
   _image_irom_vaddr = ADDR(.flash.text);
 
-  .flash.text : ALIGN(IROM_SEG_ALIGN)
+  /* Align next section to 64k to allow mapping */
+  .flash.text_dummy (NOLOAD) :
+  {
+    . = ALIGN(CACHE_ALIGN);
+  } GROUP_LINK_IN(ROMABLE_REGION)
+
+  .flash.text : ALIGN(0x10)
   {
     _stext = .;
     _instruction_reserved_start = ABSOLUTE(.);
@@ -628,7 +748,6 @@ SECTIONS
 #if !defined(CONFIG_ESP32_WIFI_IRAM_OPT)
     *libnet80211.a:( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.*)
     *libpp.a:( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.* .wifiorslpiram .wifiorslpiram.*)
-
 #endif
 
 #if !defined(CONFIG_ESP32_WIFI_RX_IRAM_OPT)
@@ -658,35 +777,30 @@ SECTIONS
      * resolved by addr2line in preference to the first symbol in
      * the flash.text segment.
      */
-    _flash_cache_start = ABSOLUTE(0);
+    //_flash_cache_start = ABSOLUTE(0);
   } GROUP_DATA_LINK_IN(FLASH_CODE_REGION, ROMABLE_REGION)
 
-  /**
-   * This dummy section represents the .flash.text section but in default_rodata_seg.
+  /* This dummy section represents the .flash.text section but in default_rodata_seg.
    * Thus, it must have its alignment and (at least) its size.
    */
-  .flash_rodata_dummy (NOLOAD):
+  .flash.rodata_dummy (NOLOAD):
   {
     _flash_rodata_dummy_start = ABSOLUTE(.);
-    /* Start at the same alignment constraint than .flash.text */
-    . = ALIGN(ALIGNOF(.flash.text));
-    /* Create an empty gap as big as .flash.text section */
-    . = . + SIZEOF(.flash.text);
-    /* Prepare the alignment of the section above. Few bytes (0x20) must be
-     * added for the mapping header. */
-    . = ALIGN(_esp_mmu_block_size) + 0x40;
+    . += SIZEOF(.flash.text);
+    . = ALIGN(CACHE_ALIGN);
   } GROUP_LINK_IN(RODATA_REGION)
 
   _image_drom_start = LOADADDR(.flash.rodata);
   _image_drom_size = LOADADDR(.flash.rodata_end) + SIZEOF(.flash.rodata_end) - _image_drom_start;
   _image_drom_vaddr = ADDR(.flash.rodata);
 
-  .flash.rodata : ALIGN(IROM_SEG_ALIGN)
+  .flash.rodata : ALIGN(CACHE_ALIGN)
   {
     _flash_rodata_start = ABSOLUTE(.);
     _rodata_reserved_start = ABSOLUTE(.);  /* This is a symbol marking the flash.rodata start, this can be used for mmu driver to maintain virtual address */
     _rodata_start = ABSOLUTE(.);
     __rodata_region_start = ABSOLUTE(.);
+
     . = ALIGN(4);
     #include <snippets-rodata.ld>
 
@@ -727,6 +841,7 @@ SECTIONS
     . = ALIGN(4);
   } GROUP_DATA_LINK_IN(RODATA_REGION, ROMABLE_REGION)
 
+  #include <zephyr/linker/cplusplus-rom.ld>
   #include <zephyr/linker/common-rom/common-rom-cpp.ld>
   #include <zephyr/linker/common-rom/common-rom-kernel-devices.ld>
   #include <zephyr/linker/common-rom/common-rom-ztest.ld>
@@ -755,7 +870,7 @@ SECTIONS
   .ext_ram.dummy (NOLOAD):
   {
     . = ORIGIN(ext_ram_seg) + (_rodata_reserved_end - _flash_rodata_dummy_start);
-    . = ALIGN (0x10000);
+    . = ALIGN (CACHE_ALIGN);
   } GROUP_LINK_IN(ext_ram_seg)
 
   /* This section holds .ext_ram.bss data, and will be put in PSRAM */
@@ -774,47 +889,10 @@ SECTIONS
 
 #endif /* CONFIG_ESP_SPIRAM */
 
-  /* Marks the end of IRAM code segment */
-  .iram0.text_end (NOLOAD) :
-  {
-    /* ESP32-S3 memprot requires 16B padding for possible CPU prefetch and 256B alignment for PMS split lines */
-    . += 16;
-    _iram_text_end = ABSOLUTE(.);
-  } GROUP_LINK_IN(IRAM_REGION)
-
-  .iram0.data :
-  {
-    . = ALIGN(4);
-     _iram_data_start = ABSOLUTE(.);
-    *(.iram.data)
-    *(.iram.data*)
-    _iram_data_end = ABSOLUTE(.);
-  } GROUP_DATA_LINK_IN(IRAM_REGION, ROMABLE_REGION)
-
-  .iram0.bss (NOLOAD) :
-  {
-    . = ALIGN(4);
-    _iram_bss_start = ABSOLUTE(.);
-    *(.iram.bss)
-    *(.iram.bss*)
-    _iram_bss_end = ABSOLUTE(.);
-    . = ALIGN(4);
-    _iram_end = ABSOLUTE(.);
-  } GROUP_LINK_IN(IRAM_REGION)
-
-  /* Marks the end of data, bss and possibly rodata  */
-  .dram0.heap_start (NOLOAD) :
-  {
-    . = ALIGN (8);
-    /* Lowest possible start address for the heap */
-    _heap_start = ABSOLUTE(.);
-  } GROUP_LINK_IN(RAMABLE_REGION)
 
 #ifdef CONFIG_GEN_ISR_TABLES
 #include <zephyr/linker/intlist.ld>
 #endif
-
-_heap_sentry = 0x3fceb910;
 
 #include <zephyr/linker/debug-sections.ld>
 

--- a/soc/espressif/esp32s3/mcuboot.ld
+++ b/soc/espressif/esp32s3/mcuboot.ld
@@ -1,19 +1,14 @@
 /*
- * Copyright (c) 2023 Espressif Systems (Shanghai) Co., Ltd.
+ * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
  * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
- * @file
- * @brief Linker command/script file
- *
- * Linker script for the Xtensa platform.
  */
 
 #include <zephyr/devicetree.h>
 #include <zephyr/linker/sections.h>
 #include <zephyr/linker/linker-defs.h>
 #include <zephyr/linker/linker-tool.h>
+
+#include "memory.h"
 
 #ifdef CONFIG_XIP
 #error "Xtensa bootloader cannot use XIP"
@@ -23,52 +18,19 @@
 #undef GROUP_DATA_LINK_IN
 #define GROUP_DATA_LINK_IN(vregion, lregion) > vregion
 
-#define RAMABLE_REGION dram_seg
-#define RAMABLE_REGION_1 dram_seg
+/* Aliases for zephyr scripts */
+#define RAMABLE_REGION    dram_seg
+#define RODATA_REGION     dram_seg
+#define ROMABLE_REGION    dram_seg
 
-#define RODATA_REGION dram_seg
-#define ROMABLE_REGION dram_seg
-
-#define IRAM_REGION iram_seg
-#define FLASH_CODE_REGION iram_seg
-
-#define IROM_SEG_ALIGN 16
-
-/** Simplified memory map for the bootloader.
- *  Make sure the bootloader can load into main memory without overwriting itself.
- *
- *  ESP32-S3 ROM static data usage is as follows:
- *  - 0x3fcd7e00 - 0x3fce9704: Shared buffers, used in UART/USB/SPI download mode only
- *  - 0x3fce9710 - 0x3fceb710: PRO CPU stack, can be reclaimed as heap after RTOS startup
- *  - 0x3fceb710 - 0x3fced710: APP CPU stack, can be reclaimed as heap after RTOS startup
- *  - 0x3fced710 - 0x3fcf0000: ROM .bss and .data (not easily reclaimable)
- *
- *  The 2nd stage bootloader can take space up to the end of ROM shared
- *  buffers area (0x3fce9704). For alignment purpose we shall use value (0x3fce9700).
- */
-/* The offset between Dbus and Ibus. Used to convert between 0x403xxxxx and 0x3fcxxxxx addresses. */
-iram_dram_offset = 0x6f0000;
-
-bootloader_usable_dram_end = 0x3fce9700;
-
-bootloader_stack_overhead = 0x2000; /* For safety margin between bootloader data section and startup stacks */
-bootloader_dram_seg_len = 0x6600;
-bootloader_iram_loader_seg_len = 0x3000;
-bootloader_iram_seg_len = 0x9000;
-
-/* Start of the lower region is determined by region size and the end of the higher region */
-bootloader_dram_seg_end = bootloader_usable_dram_end - bootloader_stack_overhead;
-/* bootloader_dram_seg_start = bootloader_dram_seg_end - bootloader_dram_seg_len; */
-/* We move the dram start to 0x3FCA0000 */
-bootloader_dram_seg_start = 0x3FCA0000;
-bootloader_iram_loader_seg_start = bootloader_dram_seg_start - bootloader_iram_loader_seg_len + iram_dram_offset;
-bootloader_iram_seg_start = bootloader_iram_loader_seg_start - bootloader_iram_seg_len;
+_bootloader_dram_seg_end = BOOTLOADER_DRAM_SEG_END;
+_bootloader_iram_loader_seg_start = BOOTLOADER_IRAM_LOADER_SEG_START;
 
 MEMORY
 {
-  iram_seg (RWX) :                  org = bootloader_iram_seg_start, len = bootloader_iram_seg_len
-  iram_loader_seg (RWX) :           org = bootloader_iram_loader_seg_start, len = bootloader_iram_loader_seg_len
-  dram_seg (RW) :                   org = bootloader_dram_seg_start, len = bootloader_dram_seg_len
+  iram_seg (RWX) :        org = BOOTLOADER_IRAM_SEG_START,        len = BOOTLOADER_IRAM_SEG_LEN
+  iram_loader_seg (RWX) : org = BOOTLOADER_IRAM_LOADER_SEG_START, len = BOOTLOADER_IRAM_LOADER_SEG_LEN
+  dram_seg (RW) :         org = BOOTLOADER_DRAM_SEG_START,        len = BOOTLOADER_DRAM_SEG_LEN
 
 #ifdef CONFIG_GEN_ISR_TABLES
   IDT_LIST(RW): org = 0x3ebfe010, len = 0x2000
@@ -80,14 +42,148 @@ ENTRY(CONFIG_KERNEL_ENTRY)
 
 SECTIONS
 {
-
-  SECTION_PROLOGUE(_RODATA_SECTION_NAME,,ALIGN(0x10))
+  .iram0.loader_text :
   {
-    __rodata_region_start = ABSOLUTE(.);
+    _loader_text_start = ABSOLUTE(.);
+    *(.stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
 
+    *libarch__xtensa__core.a:xtensa_asm2_util.*(.literal .text .literal.* .text.*)
+    *liblib__libc__common.a:abort.*(.literal .text .literal.* .text.*)
+    *libdrivers__timer.a:xtensa_sys_timer.*(.literal .text .literal.* .text.*)
+    *libarch__common.a:dynamic_isr.*(.literal .text .literal.* .text.*)
+    *libarch__common.a:sw_isr_common.*(.literal .text .literal.* .text.*)
+
+    *libapp.a:flash_map_extended.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:printk.*(.literal.printk .literal.vprintk .literal.char_out .text.printk .text.vprintk .text.char_out)
+    *libzephyr.a:cbprintf_nano.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:cpu.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:mmu_hal.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:cache_hal.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:flash_map.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:esp_rom_spiflash.*(.literal .text .literal.* .text.*)
+
+    *libzephyr.a:heap.*(.literal .text .literal.* .text.*)
+
+    *libkernel.a:kheap.*(.literal .text .literal.* .text.*)
+    *libkernel.a:mempool.*(.literal .text .literal.* .text.*)
+    *libkernel.a:device.*(.literal .text .literal.* .text.*)
+    *libkernel.a:timeout.*(.literal .text .literal.* .text.*)
+
+    *(.literal.bootloader_mmap .text.bootloader_mmap)
+    *(.literal.bootloader_munmap .text.bootloader_munmap)
+
+    *libzephyr.a:esp_loader.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:mmu_hal.*(.literal .text .literal.* .text.*)
+
+    *(.literal.esp_intr_disable .literal.esp_intr_disable.* .text.esp_intr_disable .text.esp_intr_disable.*)
+    *(.literal.default_intr_handler .text.default_intr_handler .iram1.*.default_intr_handler)
+    *(.literal.esp_log_timestamp .text.esp_log_timestamp)
+    *(.literal.esp_log_early_timestamp .text.esp_log_early_timestamp)
+    *(.literal.esp_system_abort .text.esp_system_abort)
+
+    *(.fini.literal)
+    *(.fini)
+    *(.gnu.version)
+
+    /* CPU will try to prefetch up to 16 bytes of
+     * of instructions. This means that any configuration (e.g. MMU, PMS) must allow
+     * safe access to up to 16 bytes after the last real instruction, add
+     * dummy bytes to ensure this
+     */
+    . += 16;
+
+    _text_end = ABSOLUTE(.);
+    _etext = .;
     . = ALIGN(4);
+    _loader_text_end = ABSOLUTE(.);
+    _iram_text_end = ABSOLUTE(.);
+    _iram_end = ABSOLUTE(.);
+  } > iram_loader_seg
+
+  .iram0.vectors : ALIGN(4)
+  {
+    /* Vectors go to IRAM */
+    _init_start = ABSOLUTE(.);
+    /* Vectors according to builds/RF-2015.2-win32/esp108_v1_2_s5_512int_2/config.html */
+    . = 0x0;
+    KEEP(*(.WindowVectors.text));
+    . = 0x180;
+    KEEP(*(.Level2InterruptVector.text));
+    . = 0x1c0;
+    KEEP(*(.Level3InterruptVector.text));
+    . = 0x200;
+    KEEP(*(.Level4InterruptVector.text));
+    . = 0x240;
+    KEEP(*(.Level5InterruptVector.text));
+    . = 0x280;
+    KEEP(*(.DebugExceptionVector.text));
+    . = 0x2c0;
+    KEEP(*(.NMIExceptionVector.text));
+    . = 0x300;
+    KEEP(*(.KernelExceptionVector.text));
+    . = 0x340;
+    KEEP(*(.UserExceptionVector.text));
+    . = 0x3C0;
+    KEEP(*(.DoubleExceptionVector.text));
+    . = 0x400;
+    _invalid_pc_placeholder = ABSOLUTE(.);
+    *(.*Vector.literal)
+
+    *(.UserEnter.literal);
+    *(.UserEnter.text);
+    . = ALIGN (16);
+    *(.entry.text)
+    *(.init.literal)
+    *(.init)
+    . = ALIGN (4);
+    _init_end = ABSOLUTE(.);
+
+    /* This goes here, not at top of linker script, so addr2line finds it last,
+     * and uses it in preference to the first symbol in IRAM
+     */
+    _iram_start = ABSOLUTE(.);
+  } > iram_seg
+
+  .iram0.text :
+  {
+    . = ALIGN(4);
+
+    *(.iram1 .iram1.*)
+    *(.iram0.literal .iram.literal .iram.text.literal .iram0.text .iram.text)
+
+    *(.literal .text .literal.* .text.*)
+    . = ALIGN(4);
+
+    *(.irom0.text) /* catch stray ICACHE_RODATA_ATTR */
+    . = ALIGN(4);
+  } > iram_seg
+
+  .dram0.data : ALIGN(16)
+  {
+    . = ALIGN(4);
+    __data_start = ABSOLUTE(.);
+
     #include <snippets-rodata.ld>
 
+    . = ALIGN(4);
+    #include <snippets-rwdata.ld>
+    . = ALIGN(4);
+
+    *(.data)
+    *(.data.*)
+    *(.gnu.linkonce.d.*)
+    *(.data1)
+    *(.sdata)
+    *(.sdata.*)
+    *(.gnu.linkonce.s.*)
+    *(.sdata2)
+    *(.sdata2.*)
+    *(.gnu.linkonce.s2.*)
+    *libzephyr.a:mmu_hal.*(.rodata .rodata.*)
+    *libzephyr.a:rtc_clk.*(.rodata .rodata.*)
+
+    KEEP(*(.jcr))
+    *(.dram1 .dram1.*)
     . = ALIGN(4);
     *(.rodata)
     *(.rodata.*)
@@ -125,36 +221,13 @@ SECTIONS
     *(.rodata_wlog)
     *(.rodata_wlog*)
     _thread_local_end = ABSOLUTE(.);
-    /* _rodata_reserved_end = ABSOLUTE(.); */
     . = ALIGN(4);
-  } GROUP_DATA_LINK_IN(RODATA_REGION, ROMABLE_REGION)
+  } > dram_seg
 
   #include <zephyr/linker/common-rom/common-rom-kernel-devices.ld>
   #include <zephyr/linker/common-rom/common-rom-debug.ld>
   #include <zephyr/linker/common-rom/common-rom-misc.ld>
   #include <snippets-sections.ld>
-
-  .dram0.data :
-  {
-    __data_start = ABSOLUTE(.);
-
-    *(.data)
-    *(.data.*)
-    *(.gnu.linkonce.d.*)
-    *(.data1)
-    *(.sdata)
-    *(.sdata.*)
-    *(.gnu.linkonce.s.*)
-    *(.sdata2)
-    *(.sdata2.*)
-    *(.gnu.linkonce.s2.*)
-    *libzephyr.a:mmu_hal.*(.rodata .rodata.*)
-    *libzephyr.a:rtc_clk.*(.rodata .rodata.*)
-
-    KEEP(*(.jcr))
-    *(.dram1 .dram1.*)
-    . = ALIGN(4);
-  } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
   #include <zephyr/linker/cplusplus-rom.ld>
   #include <snippets-data-sections.ld>
@@ -163,124 +236,16 @@ SECTIONS
   #include <zephyr/linker/cplusplus-ram.ld>
   #include <zephyr/linker/common-rom/common-rom-logging.ld>
 
-  .dram0.end :
+  .noinit (NOLOAD):
   {
-    . = ALIGN(4);
-    #include <snippets-rwdata.ld>
-    . = ALIGN(4);
-    _end = ABSOLUTE(.);
-    _heap_sentry = .;
-    __data_end = ABSOLUTE(.);
-  } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
-
-  /* Send .iram0 code to iram */
-  .iram0.vectors : ALIGN(4)
-  {
-    /* Vectors go to IRAM */
-    _init_start = ABSOLUTE(.);
-    /* Vectors according to builds/RF-2015.2-win32/esp108_v1_2_s5_512int_2/config.html */
-    . = 0x0;
-    KEEP(*(.WindowVectors.text));
-    . = 0x180;
-    KEEP(*(.Level2InterruptVector.text));
-    . = 0x1c0;
-    KEEP(*(.Level3InterruptVector.text));
-    . = 0x200;
-    KEEP(*(.Level4InterruptVector.text));
-    . = 0x240;
-    KEEP(*(.Level5InterruptVector.text));
-    . = 0x280;
-    KEEP(*(.DebugExceptionVector.text));
-    . = 0x2c0;
-    KEEP(*(.NMIExceptionVector.text));
-    . = 0x300;
-    KEEP(*(.KernelExceptionVector.text));
-    . = 0x340;
-    KEEP(*(.UserExceptionVector.text));
-    . = 0x3C0;
-    KEEP(*(.DoubleExceptionVector.text));
-    . = 0x400;
-    _invalid_pc_placeholder = ABSOLUTE(.);
-    *(.*Vector.literal)
-
-    *(.UserEnter.literal);
-    *(.UserEnter.text);
-    . = ALIGN (16);
-    *(.entry.text)
-    *(.init.literal)
-    *(.init)
-    _init_end = ABSOLUTE(.);
-
-    /* This goes here, not at top of linker script, so addr2line finds it last,
-     * and uses it in preference to the first symbol in IRAM
-     */
-    _iram_start = ABSOLUTE(0);
-  } GROUP_DATA_LINK_IN(IRAM_REGION, ROMABLE_REGION)
-
-  .iram_loader.text :
-  {
-    . = ALIGN (16);
-    _loader_text_start = ABSOLUTE(.);
-    *(.stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
-     *(.iram1 .iram1.*) /* catch stray IRAM_ATTR */
-    *libzephyr.a:bootloader_flash.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_flash_config_esp32s3.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_clock_loader.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_common_loader.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_init_common.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_flash.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_random.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_random*.*(.literal.bootloader_random_disable .text.bootloader_random_disable)
-    *libzephyr.a:bootloader_random*.*(.literal.bootloader_random_enable .text.bootloader_random_enable)
-    *libzephyr.a:bootloader_efuse_esp32s3.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_utility.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_sha.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_console.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_console_loader.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_panic.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:bootloader_soc.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:esp_image_format.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:flash_encrypt.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:flash_encryption_secure_features.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:flash_partitions.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:secure_boot.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:secure_boot_secure_features.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:secure_boot_signatures_bootloader.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:wdt_hal_iram.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:esp_efuse_table.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:esp_efuse_fields.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:esp_efuse_api.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:esp_efuse_utility.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:esp_efuse_api_key_esp32xx.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:app_cpu_start.*(.literal .text .literal.* .text.*)
-    *esp_mcuboot.*(.literal .text .literal.* .text.*)
-    *esp_loader.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:mmu_hal.*(.literal .text .literal.* .text.*)
-    *libzephyr.a:rtc_clk.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:rtc_clk_init.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:rtc_time.*(.literal .literal.* .text .text.*)
-
-    *(.fini.literal)
-    *(.fini)
-    *(.gnu.version)
-    _loader_text_end = ABSOLUTE(.);
-  } > iram_loader_seg
-
-  SECTION_PROLOGUE(_TEXT_SECTION_NAME, , ALIGN(4))
-  {
-    /* Code marked as running out of IRAM */
-    _iram_text_start = ABSOLUTE(.);
-
-    *(.iram1 .iram1.*)
-    *(.iram0.literal .iram.literal .iram.text.literal .iram0.text .iram.text)
-
-    . = ALIGN(16);
-    _iram_text_end = ABSOLUTE(.); */
-    _iram_end = ABSOLUTE(.);
-  } GROUP_DATA_LINK_IN(IRAM_REGION, ROMABLE_REGION)
+    . = ALIGN(8);
+    *(.noinit)
+    *(.noinit.*)
+    . = ALIGN(8) ;
+  } > dram_seg
 
   /* Shared RAM */
-  SECTION_DATA_PROLOGUE(_BSS_SECTION_NAME,(NOLOAD),)
+  .bss (NOLOAD):
   {
     . = ALIGN (8);
     _bss_start = ABSOLUTE(.); /* required by bluetooth library */
@@ -304,48 +269,9 @@ SECTIONS
     __bss_end = ABSOLUTE(.);
     _bss_end = ABSOLUTE(.);
     _end = ABSOLUTE(.);
-  } GROUP_LINK_IN(RAMABLE_REGION)
+  } > dram_seg
 
   ASSERT(((__bss_end - ORIGIN(dram_seg)) <= LENGTH(dram_seg)), "DRAM segment data does not fit.")
-
-  SECTION_DATA_PROLOGUE(_NOINIT_SECTION_NAME, (NOLOAD),)
-  {
-    . = ALIGN(8);
-    *(.noinit)
-    *(.noinit.*)
-    . = ALIGN(8) ;
-  } GROUP_LINK_IN(RAMABLE_REGION)
-
-  .flash.text :
-  {
-    _stext = .;
-    _text_start = ABSOLUTE(.);
-
-    *(.literal .text .literal.* .text.*)
-    . = ALIGN(4);
-
-    *(.stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
-    *(.irom0.text) /* catch stray ICACHE_RODATA_ATTR */
-    *(.fini.literal)
-    *(.fini)
-    *(.gnu.version)
-
-    /* CPU will try to prefetch up to 16 bytes of
-     * of instructions. This means that any configuration (e.g. MMU, PMS) must allow
-     * safe access to up to 16 bytes after the last real instruction, add
-     * dummy bytes to ensure this
-     */
-    . += 16;
-
-    _text_end = ABSOLUTE(.);
-    _etext = .;
-
-    /* Similar to _iram_start, this symbol goes here so it is
-     * resolved by addr2line in preference to the first symbol in
-     * the flash.text segment.
-     */
-    _flash_cache_start = ABSOLUTE(0);
-  } GROUP_DATA_LINK_IN(FLASH_CODE_REGION, ROMABLE_REGION)
 
 #include <zephyr/linker/debug-sections.ld>
 
@@ -386,8 +312,4 @@ SECTIONS
 #ifdef CONFIG_GEN_ISR_TABLES
 #include <zephyr/linker/intlist.ld>
 #endif
-
 }
-
-ASSERT(((_iram_end - ORIGIN(IRAM_REGION)) <= LENGTH(IRAM_REGION)),
-          "IRAM0 segment data does not fit.")

--- a/soc/espressif/esp32s3/memory.h
+++ b/soc/espressif/esp32s3/memory.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+/* SRAM0 (64k), SRAM1 (416k), SRAM2 (64k) memories
+ * Ibus and Dbus address space
+ */
+#define SRAM0_IRAM_START    0x40370000
+#define SRAM0_SIZE          0x8000
+#define SRAM1_DRAM_START    0x3fc88000
+/* IRAM equivalent address where DRAM actually start */
+#define SRAM1_IRAM_START    (SRAM0_IRAM_START + SRAM0_SIZE)
+#define SRAM2_DRAM_START    0x3fcf0000
+#define SRAM2_SIZE          0x10000
+
+/** Simplified memory map for the bootloader.
+ *  Make sure the bootloader can load into main memory without overwriting itself.
+ *
+ *  ESP32-S3 ROM static data usage is as follows:
+ *  - 0x3fcd7e00 - 0x3fce9704: Shared buffers, used in UART/USB/SPI download mode only
+ *  - 0x3fce9710 - 0x3fceb710: PRO CPU stack, can be reclaimed as heap after RTOS startup
+ *  - 0x3fceb710 - 0x3fced710: APP CPU stack, can be reclaimed as heap after RTOS startup
+ *  - 0x3fced710 - 0x3fcf0000: ROM .bss and .data (not easily reclaimable)
+ *
+ *  The 2nd stage bootloader can take space up to the end of ROM shared
+ *  buffers area (0x3fce9704). For alignment purpose we shall use value (0x3fce9700).
+ */
+
+/* The offset between Dbus and Ibus.
+ * Used to convert between 0x403xxxxx and 0x3fcxxxxx addresses.
+ */
+#define IRAM_DRAM_OFFSET         0x6f0000
+#define DRAM_BUFFERS_START       0x3fcd7e00
+#define DRAM_PROCPU_STACK_START  0x3fce9710
+#define DRAM_STACK_START DRAM_PROCPU_STACK_START
+#define DRAM_APPCPU_STACK_START  0x3fceb710
+#define DRAM_ROM_BSS_DATA_START  0x3fcf0000
+
+/* Base address used for calculating memory layout
+ * counted from Dbus backwards and back to the Ibus
+ */
+#define BOOTLOADER_USABLE_DRAM_END DRAM_BUFFERS_START
+
+/* For safety margin between bootloader data section and startup stacks */
+#define BOOTLOADER_STACK_OVERHEAD      0x0
+#define BOOTLOADER_DRAM_SEG_LEN        0x6600
+#define BOOTLOADER_IRAM_LOADER_SEG_LEN 0x2c00
+#define BOOTLOADER_IRAM_SEG_LEN        0x9000
+
+/* Start of the lower region is determined by region size and the end of the higher region */
+#define BOOTLOADER_DRAM_SEG_END      (BOOTLOADER_USABLE_DRAM_END - BOOTLOADER_STACK_OVERHEAD)
+#define BOOTLOADER_DRAM_SEG_START (BOOTLOADER_DRAM_SEG_END - BOOTLOADER_DRAM_SEG_LEN)
+#define BOOTLOADER_IRAM_LOADER_SEG_START (BOOTLOADER_DRAM_SEG_START - \
+					BOOTLOADER_IRAM_LOADER_SEG_LEN + IRAM_DRAM_OFFSET)
+#define BOOTLOADER_IRAM_SEG_START (BOOTLOADER_IRAM_LOADER_SEG_START - BOOTLOADER_IRAM_SEG_LEN)
+
+/* Flash */
+#ifdef CONFIG_FLASH_SIZE
+#define FLASH_SIZE         CONFIG_FLASH_SIZE
+#else
+#define FLASH_SIZE         0x800000
+#endif
+
+/* Cached memory */
+#define CACHE_ALIGN        CONFIG_MMU_PAGE_SIZE
+#define IROM_SEG_ORG       0x42000000
+#define IROM_SEG_LEN       FLASH_SIZE
+#define DROM_SEG_ORG       0x3c000000
+#define DROM_SEG_LEN       FLASH_SIZE
+
+/* AMP */
+#ifdef CONFIG_SOC_ENABLE_APPCPU
+#define APPCPU_IRAM_SIZE  CONFIG_ESP32S3_APPCPU_IRAM
+#define APPCPU_DRAM_SIZE  CONFIG_ESP32S3_APPCPU_DRAM
+#else
+#define APPCPU_IRAM_SIZE  0
+#define APPCPU_DRAM_SIZE  0
+#endif

--- a/soc/espressif/esp32s3/soc.c
+++ b/soc/espressif/esp32s3/soc.c
@@ -143,12 +143,7 @@ void IRAM_ATTR __esp_platform_start(void)
 	 */
 	__asm__ __volatile__("wsr.MISC0 %0; rsync" : : "r"(&_kernel.cpus[0]));
 
-#ifdef CONFIG_MCUBOOT
-	/* MCUboot early initialisation. */
-	if (bootloader_init()) {
-		abort();
-	}
-#else
+#ifndef CONFIG_MCUBOOT
 	/* Configure the mode of instruction cache : cache size, cache line size. */
 	esp_config_instruction_cache_mode();
 
@@ -189,6 +184,7 @@ void IRAM_ATTR __esp_platform_start(void)
 	       (&_ext_ram_bss_end - &_ext_ram_bss_start) * sizeof(_ext_ram_bss_start));
 
 #endif /* CONFIG_ESP_SPIRAM */
+
 	/* Apply SoC patches */
 	esp_errata();
 
@@ -216,7 +212,7 @@ void IRAM_ATTR __esp_platform_start(void)
 #if CONFIG_SOC_FLASH_ESP32
 	spi_flash_guard_set(&g_flash_guard_default_ops);
 #endif
-#endif /* CONFIG_MCUBOOT */
+#endif /* !CONFIG_MCUBOOT */
 
 	esp_intr_initialize();
 

--- a/west.yml
+++ b/west.yml
@@ -152,7 +152,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: 742df6bfc595591603361eb703ac9462ed6384c6
+      revision: dddb7cf318d931c25623c34ecde20f3150d7f987
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
This PR includes changes, which bring simple boot support for the ESP32 SoCs:

- add the Simple Boot option for building applications without the need of 2nd stage bootloader
- optimized linker scripts for the default application and the MCUboot (Zephyr port)
- optimized memory usage for simple boot and the MCUboot+Application
- updated building instructions for all Espressif boards
- remove multiple binary builds from Espressif boards
- remove ESP_IDF bootloader builds/binaries
- fixes the console output during the booting on some targets


depends on #68760
