### PR TITLE
net: tcp: Fix ACK check in LAST_ACK state

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -3006,6 +3006,7 @@ next_state:
 
 			conn_ack(conn, + 1);
 			tcp_out(conn, FIN | ACK);
+			conn_seq(conn, + 1);
 			next = TCP_LAST_ACK;
 			verdict = NET_OK;
 			keep_alive_timer_stop(conn);
@@ -3032,6 +3033,7 @@ next_state:
 
 			conn_ack(conn, + len + 1);
 			tcp_out(conn, FIN | ACK);
+			conn_seq(conn, + 1);
 			next = TCP_LAST_ACK;
 			keep_alive_timer_stop(conn);
 			tcp_setup_last_ack_timer(conn);
@@ -3224,11 +3226,12 @@ next_state:
 		break;
 	case TCP_CLOSE_WAIT:
 		tcp_out(conn, FIN);
+		conn_seq(conn, + 1);
 		next = TCP_LAST_ACK;
 		tcp_setup_last_ack_timer(conn);
 		break;
 	case TCP_LAST_ACK:
-		if (th && FL(&fl, ==, ACK, th_seq(th) == conn->ack)) {
+		if (th && FL(&fl, ==, ACK, th_ack(th) == conn->seq)) {
 			tcp_send_timer_cancel(conn);
 			do_close = true;
 			verdict = NET_OK;


### PR DESCRIPTION
The final ACK check during passive close was wrong - we should not compare its SEQ number with the ACK number we've sent last, but rather compare that the ACK number it acknowledges matches our current SEQ number on the connection. This ensures, that the ACK received is really acknowledging the FIN packet we've sent from our side, and is not just some earlier retransmission. Currently the latter could be the case, and we've closed the connection prematurely. In result, when the real "final ACK" arrived, the TCP stack replied with RST.

Subsequently, we should increment the SEQ number on the connection after sending FIN packet, so that we are able to identify final ACK correctly, just as it's done in active close cases.