### PR TITLE
Bluetooth: host: remove `CONFIG_BT_RECV_BLOCKING`

### DIFF
--- a/drivers/bluetooth/hci/h4.c
+++ b/drivers/bluetooth/hci/h4.c
@@ -278,7 +278,6 @@ static size_t h4_discard(const struct device *uart, size_t len)
 static inline void read_payload(void)
 {
 	struct net_buf *buf;
-	uint8_t evt_flags;
 	int read;
 
 	if (!rx.buf) {
@@ -331,26 +330,15 @@ static inline void read_payload(void)
 	rx.buf = NULL;
 
 	if (rx.type == H4_EVT) {
-		evt_flags = bt_hci_evt_get_flags(rx.evt.evt);
 		bt_buf_set_type(buf, BT_BUF_EVT);
 	} else {
-		evt_flags = BT_HCI_EVT_FLAG_RECV;
 		bt_buf_set_type(buf, BT_BUF_ACL_IN);
 	}
 
 	reset_rx();
 
-	if (IS_ENABLED(CONFIG_BT_RECV_BLOCKING) &&
-	    (evt_flags & BT_HCI_EVT_FLAG_RECV_PRIO)) {
-		LOG_DBG("Calling bt_recv_prio(%p)", buf);
-		bt_recv_prio(buf);
-	}
-
-	if ((evt_flags & BT_HCI_EVT_FLAG_RECV) ||
-	    !IS_ENABLED(CONFIG_BT_RECV_BLOCKING)) {
-		LOG_DBG("Putting buf %p to rx fifo", buf);
-		net_buf_put(&rx.fifo, buf);
-	}
+	LOG_DBG("Putting buf %p to rx fifo", buf);
+	net_buf_put(&rx.fifo, buf);
 }
 
 static inline void read_header(void)

--- a/drivers/bluetooth/hci/slz_hci.c
+++ b/drivers/bluetooth/hci/slz_hci.c
@@ -55,7 +55,6 @@ uint32_t hci_common_transport_transmit(uint8_t *data, int16_t len)
 {
 	struct net_buf *buf;
 	uint8_t packet_type = data[0];
-	uint8_t flags;
 	uint8_t event_code;
 
 	LOG_HEXDUMP_DBG(data, len, "host packet data:");
@@ -67,7 +66,6 @@ uint32_t hci_common_transport_transmit(uint8_t *data, int16_t len)
 	switch (packet_type) {
 	case h4_event:
 		event_code = data[0];
-		flags = bt_hci_evt_get_flags(event_code);
 		buf = bt_buf_get_evt(event_code, false, K_FOREVER);
 		break;
 	case h4_acl:
@@ -79,12 +77,7 @@ uint32_t hci_common_transport_transmit(uint8_t *data, int16_t len)
 	}
 
 	net_buf_add_mem(buf, data, len);
-	if (IS_ENABLED(CONFIG_BT_RECV_BLOCKING) &&
-	    (packet_type == h4_event) && (flags & BT_HCI_EVT_FLAG_RECV_PRIO)) {
-		bt_recv_prio(buf);
-	} else {
-		bt_recv(buf);
-	}
+	bt_recv(buf);
 
 	sl_btctrl_hci_transmit_complete(0);
 

--- a/include/zephyr/bluetooth/buf.h
+++ b/include/zephyr/bluetooth/buf.h
@@ -103,7 +103,7 @@ struct bt_buf_data {
 /** Allocate a buffer for incoming data
  *
  *  This will set the buffer type so bt_buf_set_type() does not need to
- *  be explicitly called before bt_recv_prio().
+ *  be explicitly called.
  *
  *  @param type    Type of buffer. Only BT_BUF_EVT, BT_BUF_ACL_IN and BT_BUF_ISO_IN
  *                 are allowed.
@@ -116,7 +116,7 @@ struct net_buf *bt_buf_get_rx(enum bt_buf_type type, k_timeout_t timeout);
 /** Allocate a buffer for outgoing data
  *
  *  This will set the buffer type so bt_buf_set_type() does not need to
- *  be explicitly called before bt_send().
+ *  be explicitly called.
  *
  *  @param type    Type of buffer. Only BT_BUF_CMD, BT_BUF_ACL_OUT or
  *                 BT_BUF_H4, when operating on H:4 mode, are allowed.
@@ -132,7 +132,7 @@ struct net_buf *bt_buf_get_tx(enum bt_buf_type type, k_timeout_t timeout,
 /** Allocate a buffer for an HCI Event
  *
  *  This will set the buffer type so bt_buf_set_type() does not need to
- *  be explicitly called before bt_recv_prio() or bt_recv().
+ *  be explicitly called.
  *
  *  @param evt          HCI event code
  *  @param discardable  Whether the driver considers the event discardable.

--- a/include/zephyr/drivers/bluetooth/hci_driver.h
+++ b/include/zephyr/drivers/bluetooth/hci_driver.h
@@ -39,9 +39,7 @@ enum {
 
 #define IS_BT_QUIRK_NO_AUTO_DLE(bt_dev) ((bt_dev)->drv->quirks & BT_QUIRK_NO_AUTO_DLE)
 
-/* @brief The HCI event shall be given to bt_recv_prio */
 #define BT_HCI_EVT_FLAG_RECV_PRIO BIT(0)
-/* @brief  The HCI event shall be given to bt_recv. */
 #define BT_HCI_EVT_FLAG_RECV      BIT(1)
 
 /** @brief Get HCI event flags.
@@ -88,25 +86,6 @@ static inline uint8_t bt_hci_evt_get_flags(uint8_t evt)
  * @return 0 on success or negative error number on failure.
  */
 int bt_recv(struct net_buf *buf);
-
-/**
- * @brief Receive high priority data from the controller/HCI driver.
- *
- * This is the same as bt_recv(), except that it should be used for
- * so-called high priority HCI events. There's a separate
- * bt_hci_evt_get_flags() helper that can be used to identify which events
- * have the BT_HCI_EVT_FLAG_RECV_PRIO flag set.
- *
- * As with bt_recv(), the buffer needs to have its type set with the help of
- * bt_buf_set_type() before calling this API. The only exception is so called
- * high priority HCI events which should be delivered to the host stack through
- * bt_recv_prio() instead.
- *
- * @param buf Network buffer containing data from the controller.
- *
- * @return 0 on success or negative error number on failure.
- */
-int bt_recv_prio(struct net_buf *buf);
 
 /** @brief Read static addresses from the controller.
  *

--- a/include/zephyr/drivers/bluetooth/hci_driver.h
+++ b/include/zephyr/drivers/bluetooth/hci_driver.h
@@ -49,10 +49,6 @@ enum {
  * Helper for the HCI driver to get HCI event flags that describes rules that.
  * must be followed.
  *
- * When @kconfig{CONFIG_BT_RECV_BLOCKING} is enabled the flags
- * BT_HCI_EVT_FLAG_RECV and BT_HCI_EVT_FLAG_RECV_PRIO indicates if the event
- * should be given to bt_recv or bt_recv_prio.
- *
  * @param evt HCI event code.
  *
  * @return HCI event flags for the specified event.
@@ -84,10 +80,6 @@ static inline uint8_t bt_hci_evt_get_flags(uint8_t evt)
  * This is the main function through which the HCI driver provides the
  * host with data from the controller. The buffer needs to have its type
  * set with the help of bt_buf_set_type() before calling this API.
- *
- * When @kconfig{CONFIG_BT_RECV_BLOCKING} is defined then this API should not be used
- * for so-called high priority HCI events, which should instead be delivered to
- * the host stack through bt_recv_prio().
  *
  * @note This function must only be called from a cooperative thread.
  *
@@ -176,10 +168,6 @@ struct bt_hci_driver {
 	 * return until the transport is ready for operation, meaning it
 	 * is safe to start calling the send() handler.
 	 *
-	 * If the driver uses its own RX thread, i.e.
-	 * @kconfig{CONFIG_BT_RECV_BLOCKING} is set, then this
-	 * function is expected to start that thread.
-	 *
 	 * @return 0 on success or negative error number on failure.
 	 */
 	int (*open)(void);
@@ -190,9 +178,6 @@ struct bt_hci_driver {
 	 * Closes the HCI transport. This function must not return until the
 	 * transport is closed.
 	 *
-	 * If the driver uses its own RX thread, i.e.
-	 * @kconfig{CONFIG_BT_RECV_BLOCKING} is set, then this
-	 * function is expected to abort that thread.
 	 * @return 0 on success or negative error number on failure.
 	 */
 	int (*close)(void);

--- a/include/zephyr/drivers/bluetooth/hci_driver.h
+++ b/include/zephyr/drivers/bluetooth/hci_driver.h
@@ -39,39 +39,6 @@ enum {
 
 #define IS_BT_QUIRK_NO_AUTO_DLE(bt_dev) ((bt_dev)->drv->quirks & BT_QUIRK_NO_AUTO_DLE)
 
-#define BT_HCI_EVT_FLAG_RECV_PRIO BIT(0)
-#define BT_HCI_EVT_FLAG_RECV      BIT(1)
-
-/** @brief Get HCI event flags.
- *
- * Helper for the HCI driver to get HCI event flags that describes rules that.
- * must be followed.
- *
- * @param evt HCI event code.
- *
- * @return HCI event flags for the specified event.
- */
-static inline uint8_t bt_hci_evt_get_flags(uint8_t evt)
-{
-	switch (evt) {
-	case BT_HCI_EVT_DISCONN_COMPLETE:
-		return BT_HCI_EVT_FLAG_RECV | BT_HCI_EVT_FLAG_RECV_PRIO;
-		/* fallthrough */
-#if defined(CONFIG_BT_CONN) || defined(CONFIG_BT_ISO)
-	case BT_HCI_EVT_NUM_COMPLETED_PACKETS:
-#if defined(CONFIG_BT_CONN)
-	case BT_HCI_EVT_DATA_BUF_OVERFLOW:
-		__fallthrough;
-#endif /* defined(CONFIG_BT_CONN) */
-#endif /* CONFIG_BT_CONN ||  CONFIG_BT_ISO */
-	case BT_HCI_EVT_CMD_COMPLETE:
-	case BT_HCI_EVT_CMD_STATUS:
-		return BT_HCI_EVT_FLAG_RECV_PRIO;
-	default:
-		return BT_HCI_EVT_FLAG_RECV;
-	}
-}
-
 /**
  * @brief Receive data from the controller/HCI driver.
  *

--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -95,7 +95,6 @@ config BT_BUF_ACL_RX_SIZE
 config BT_BUF_ACL_RX_COUNT
 	int "Number of incoming ACL data buffers"
 	default NET_BUF_RX_COUNT if NET_L2_BT
-	default 3 if BT_RECV_BLOCKING
 	default 6
 	range 1 64
 	help
@@ -126,7 +125,6 @@ config BT_BUF_EVT_RX_SIZE
 
 config BT_BUF_EVT_RX_COUNT
 	int "Number of HCI Event buffers"
-	default 3 if BT_RECV_BLOCKING
 	default 20 if (BT_MESH && !(BT_BUF_EVT_DISCARDABLE_COUNT > 0))
 	default 10
 	range 2 255

--- a/subsys/bluetooth/controller/hci/hci_driver.c
+++ b/subsys/bluetooth/controller/hci/hci_driver.c
@@ -73,7 +73,7 @@ struct k_thread prio_recv_thread_data;
 static K_KERNEL_STACK_DEFINE(prio_recv_thread_stack,
 			     CONFIG_BT_CTLR_RX_PRIO_STACK_SIZE);
 struct k_thread recv_thread_data;
-static K_KERNEL_STACK_DEFINE(recv_thread_stack, CONFIG_BT_RX_STACK_SIZE);
+static K_KERNEL_STACK_DEFINE(recv_thread_stack, CONFIG_BT_CTLR_RX_PRIO_STACK_SIZE);
 
 #if defined(CONFIG_BT_HCI_ACL_FLOW_CONTROL)
 static struct k_poll_signal hbuf_signal;
@@ -81,11 +81,10 @@ static sys_slist_t hbuf_pend;
 static int32_t hbuf_count;
 #endif
 
-#if !defined(CONFIG_BT_RECV_BLOCKING)
 /* Copied here from `hci_raw.c`, which would be used in
  * conjunction with this driver when serializing HCI over wire.
- * This serves as a converter from the more complicated
- * `CONFIG_BT_RECV_BLOCKING` API to the normal single-receiver
+ * This serves as a converter from the historical (removed from
+ * tree) 'recv blocking' API to the normal single-receiver
  * `bt_recv` API.
  */
 int bt_recv_prio(struct net_buf *buf)
@@ -103,7 +102,6 @@ int bt_recv_prio(struct net_buf *buf)
 
 	return bt_recv(buf);
 }
-#endif /* CONFIG_BT_RECV_BLOCKING */
 
 #if defined(CONFIG_BT_CTLR_ISO)
 

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -95,7 +95,7 @@ config BT_HCI_RESERVE
 
 choice BT_RECV_CONTEXT
 	prompt "BT RX Thread Selection"
-	default BT_RECV_BLOCKING if BT_LL_SW_SPLIT || BT_H4
+	default BT_RECV_WORKQ_SYS if SOC_SERIES_NRF51X
 	default BT_RECV_WORKQ_BT
 	help
 	  Selects in which context incoming low priority HCI packets are processed.
@@ -103,13 +103,6 @@ choice BT_RECV_CONTEXT
 	  High priority events are always processed in the context of the caller of bt_recv()
 	  or bt_recv_prio(). The choice will influence RAM usage and how fast incoming HCI
 	  packets are processed.
-
-config BT_RECV_BLOCKING
-	bool "Process HCI packets in the context of bt_recv() and bt_recv_prio()"
-	help
-	  When this option is selected, the host will not have its own RX thread.
-	  With this option it is the responsibility of the HCI driver to call
-	  bt_recv_prio from a higher priority context than bt_recv() in order to avoid deadlocks.
 
 config BT_RECV_WORKQ_SYS
 	bool "Process low priority HCI packets in the system work queue"

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2724,6 +2724,40 @@ static const struct event_handler normal_events[] = {
 		      sizeof(struct bt_hci_evt_hardware_error)),
 };
 
+
+#define BT_HCI_EVT_FLAG_RECV_PRIO BIT(0)
+#define BT_HCI_EVT_FLAG_RECV      BIT(1)
+
+/** @brief Get HCI event flags.
+ *
+ * Helper for the HCI driver to get HCI event flags that describes rules that.
+ * must be followed.
+ *
+ * @param evt HCI event code.
+ *
+ * @return HCI event flags for the specified event.
+ */
+static inline uint8_t bt_hci_evt_get_flags(uint8_t evt)
+{
+	switch (evt) {
+	case BT_HCI_EVT_DISCONN_COMPLETE:
+		return BT_HCI_EVT_FLAG_RECV | BT_HCI_EVT_FLAG_RECV_PRIO;
+		/* fallthrough */
+#if defined(CONFIG_BT_CONN) || defined(CONFIG_BT_ISO)
+	case BT_HCI_EVT_NUM_COMPLETED_PACKETS:
+#if defined(CONFIG_BT_CONN)
+	case BT_HCI_EVT_DATA_BUF_OVERFLOW:
+		__fallthrough;
+#endif /* defined(CONFIG_BT_CONN) */
+#endif /* CONFIG_BT_CONN ||  CONFIG_BT_ISO */
+	case BT_HCI_EVT_CMD_COMPLETE:
+	case BT_HCI_EVT_CMD_STATUS:
+		return BT_HCI_EVT_FLAG_RECV_PRIO;
+	default:
+		return BT_HCI_EVT_FLAG_RECV;
+	}
+}
+
 static void hci_event(struct net_buf *buf)
 {
 	struct bt_hci_evt_hdr *hdr;

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -66,14 +66,12 @@ LOG_MODULE_REGISTER(bt_hci_core);
 #define HCI_CMD_TIMEOUT      K_SECONDS(10)
 
 /* Stacks for the threads */
-#if !defined(CONFIG_BT_RECV_BLOCKING)
 static void rx_work_handler(struct k_work *work);
 static K_WORK_DEFINE(rx_work, rx_work_handler);
 #if defined(CONFIG_BT_RECV_WORKQ_BT)
 static struct k_work_q bt_workq;
 static K_KERNEL_STACK_DEFINE(rx_thread_stack, CONFIG_BT_RX_STACK_SIZE);
 #endif /* CONFIG_BT_RECV_WORKQ_BT */
-#endif /* !CONFIG_BT_RECV_BLOCKING */
 static struct k_thread tx_thread_data;
 static K_KERNEL_STACK_DEFINE(tx_thread_stack, CONFIG_BT_HCI_TX_STACK_SIZE);
 
@@ -3834,7 +3832,6 @@ void hci_event_prio(struct net_buf *buf)
 	}
 }
 
-#if !defined(CONFIG_BT_RECV_BLOCKING)
 static void rx_queue_put(struct net_buf *buf)
 {
 	net_buf_slist_put(&bt_dev.rx_queue, buf);
@@ -3848,7 +3845,6 @@ static void rx_queue_put(struct net_buf *buf)
 		LOG_ERR("Could not submit rx_work: %d", err);
 	}
 }
-#endif /* !CONFIG_BT_RECV_BLOCKING */
 
 int bt_recv(struct net_buf *buf)
 {
@@ -3859,18 +3855,11 @@ int bt_recv(struct net_buf *buf)
 	switch (bt_buf_get_type(buf)) {
 #if defined(CONFIG_BT_CONN)
 	case BT_BUF_ACL_IN:
-#if defined(CONFIG_BT_RECV_BLOCKING)
-		hci_acl(buf);
-#else
 		rx_queue_put(buf);
-#endif
 		return 0;
 #endif /* BT_CONN */
 	case BT_BUF_EVT:
 	{
-#if defined(CONFIG_BT_RECV_BLOCKING)
-		hci_event(buf);
-#else
 		struct bt_hci_evt_hdr *hdr = (void *)buf->data;
 		uint8_t evt_flags = bt_hci_evt_get_flags(hdr->evt);
 
@@ -3881,17 +3870,12 @@ int bt_recv(struct net_buf *buf)
 		if (evt_flags & BT_HCI_EVT_FLAG_RECV) {
 			rx_queue_put(buf);
 		}
-#endif
-		return 0;
 
+		return 0;
 	}
 #if defined(CONFIG_BT_ISO)
 	case BT_BUF_ISO_IN:
-#if defined(CONFIG_BT_RECV_BLOCKING)
-		hci_iso(buf);
-#else
 		rx_queue_put(buf);
-#endif
 		return 0;
 #endif /* CONFIG_BT_ISO */
 	default:
@@ -3900,19 +3884,6 @@ int bt_recv(struct net_buf *buf)
 		return -EINVAL;
 	}
 }
-
-#if defined(CONFIG_BT_RECV_BLOCKING)
-int bt_recv_prio(struct net_buf *buf)
-{
-	bt_monitor_send(bt_monitor_opcode(buf), buf->data, buf->len);
-
-	BT_ASSERT(bt_buf_get_type(buf) == BT_BUF_EVT);
-
-	hci_event_prio(buf);
-
-	return 0;
-}
-#endif /* CONFIG_BT_RECV_BLOCKING */
 
 int bt_hci_driver_register(const struct bt_hci_driver *drv)
 {
@@ -3991,7 +3962,6 @@ static void init_work(struct k_work *work)
 	}
 }
 
-#if !defined(CONFIG_BT_RECV_BLOCKING)
 static void rx_work_handler(struct k_work *work)
 {
 	int err;
@@ -4043,7 +4013,6 @@ static void rx_work_handler(struct k_work *work)
 		}
 	}
 }
-#endif /* !CONFIG_BT_RECV_BLOCKING */
 
 #if defined(CONFIG_BT_TESTING)
 k_tid_t bt_testing_tx_tid_get(void)

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -366,10 +366,8 @@ struct bt_dev {
 	/* Last sent HCI command */
 	struct net_buf		*sent_cmd;
 
-#if !defined(CONFIG_BT_RECV_BLOCKING)
 	/* Queue for incoming HCI events & ACL data */
 	sys_slist_t rx_queue;
-#endif
 
 	/* Queue for outgoing HCI commands */
 	struct k_fifo		cmd_tx_queue;

--- a/subsys/bluetooth/host/hci_ecc.c
+++ b/subsys/bluetooth/host/hci_ecc.c
@@ -92,11 +92,7 @@ static void send_cmd_status(uint16_t opcode, uint8_t status)
 	evt->opcode = sys_cpu_to_le16(opcode);
 	evt->status = status;
 
-	if (IS_ENABLED(CONFIG_BT_RECV_BLOCKING)) {
-		bt_recv_prio(buf);
-	} else {
-		bt_recv(buf);
-	}
+	bt_recv(buf);
 }
 
 static uint8_t generate_keys(void)

--- a/subsys/bluetooth/host/hci_raw.c
+++ b/subsys/bluetooth/host/hci_raw.c
@@ -215,22 +215,6 @@ int bt_recv(struct net_buf *buf)
 	return 0;
 }
 
-int bt_recv_prio(struct net_buf *buf)
-{
-	if (bt_buf_get_type(buf) == BT_BUF_EVT) {
-		struct bt_hci_evt_hdr *hdr = (void *)buf->data;
-		uint8_t evt_flags = bt_hci_evt_get_flags(hdr->evt);
-
-		if ((evt_flags & BT_HCI_EVT_FLAG_RECV_PRIO) &&
-		    (evt_flags & BT_HCI_EVT_FLAG_RECV)) {
-			/* Avoid queuing the event twice */
-			return 0;
-		}
-	}
-
-	return bt_recv(buf);
-}
-
 static void bt_cmd_complete_ext(uint16_t op, uint8_t status)
 {
 	struct net_buf *buf;

--- a/tests/bsim/bluetooth/host/misc/conn_stress/central/prj.conf
+++ b/tests/bsim/bluetooth/host/misc/conn_stress/central/prj.conf
@@ -32,9 +32,6 @@ CONFIG_ASSERT_ON_ERRORS=y
 CONFIG_BT_RECV_WORKQ_BT=y
 # CONFIG_BT_RECV_WORKQ_SYS=y
 
-# errors out getting event flags in hci_core.c
-# CONFIG_BT_RECV_BLOCKING=y
-
 # TODO: remove when test is stable
 CONFIG_BT_AUTO_PHY_UPDATE=n
 CONFIG_BT_AUTO_DATA_LEN_UPDATE=n

--- a/tests/bsim/bluetooth/host/misc/hfc/src/main.c
+++ b/tests/bsim/bluetooth/host/misc/hfc/src/main.c
@@ -81,6 +81,13 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 	struct bt_conn *conn;
 	int err;
 
+	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, addr);
+	if (conn) {
+		LOG_DBG("Old connection is not yet purged");
+		bt_conn_unref(conn);
+		return;
+	}
+
 	err = bt_le_scan_stop();
 	if (err) {
 		FAIL("Stop LE scan failed (err %d)", err);


### PR DESCRIPTION
This config selects a variant of the HCI driver interface that spills out host internals unto the drivers and even the Zephyr controller. It will now be removed in favor of driver interfaces that hide the internals of the host.

The new default is `CONFIG_BT_RECV_WORKQ_BT`.

Any out-of-tree driver using the removed interface can be easily adapted by copying the following implementations into the driver as private functions:

 - `hci_driver.h:BT_HCI_EVT_FLAG_RECV_PRIO`
 - `hci_driver.h:BT_HCI_EVT_FLAG_RECV`
 - `hci_driver.h:bt_hci_evt_get_flags`
 - `hci_raw.c:bt_recv_prio`

In combination these symbols function as a interface adapter. These symbols only make sense in conjunction with `bt_recv_prio`, so they are also removed in this PR.

See individual commits for a digestible diff.