### PR TITLE
arch: Fix assert logic for installing shared interrupt handler

### DIFF
--- a/arch/common/shared_irq.c
+++ b/arch/common/shared_irq.c
@@ -92,8 +92,8 @@ void z_isr_install(unsigned int irq, void (*routine)(const void *),
 	for (i = 0; i < shared_entry->client_num; i++) {
 		client = &shared_entry->clients[i];
 
-		__ASSERT(client->isr != routine && client->arg != param,
-			 "trying to register duplicate ISR/arg pair");
+		__ASSERT((client->isr == routine && client->arg == param) == false,
+			 "ISR/arg combination is already registered");
 	}
 
 	shared_entry->clients[shared_entry->client_num].isr = routine;


### PR DESCRIPTION
With this commit, it is now allowed to register any ISR and arg combination for the same IRQ, except the case when the exact same ISR-arg combination is already registered.

The previous assert logic had a restriction where the same ISR could not be registered multiple times with different arguments.