### PR TITLE
Revert "manifest: optional: Update nanopb"

### DIFF
--- a/submanifests/optional.yaml
+++ b/submanifests/optional.yaml
@@ -22,7 +22,7 @@ manifest:
       groups:
         - optional
     - name: nanopb
-      revision: 671672b4d7994a9b07a307ae654885c7202ae886
+      revision: 65cbefb4695bc7af1cb733ced99618afb3586b20
       path: modules/lib/nanopb
       remote: upstream
       groups:


### PR DESCRIPTION
Upstream repo has made changes to the cmake module, which breaks non-`native_sim` builds.

This reverts commit d737e5d8e3606b1e1879e03535cf7dcf34b83317.

Will look into a proper fix.

Fixes #70516