### PR TITLE
net: buf: Include user data when cloning

### DIFF
--- a/include/zephyr/net/buf.h
+++ b/include/zephyr/net/buf.h
@@ -1536,7 +1536,7 @@ struct net_buf * __must_check net_buf_ref(struct net_buf *buf);
 /**
  * @brief Clone buffer
  *
- * Duplicate given buffer including any data and headers currently stored.
+ * Duplicate given buffer including any (user) data and headers currently stored.
  *
  * @param buf A valid pointer on a buffer
  * @param timeout Affects the action taken should the pool be empty.

--- a/subsys/net/buf.c
+++ b/subsys/net/buf.c
@@ -539,6 +539,11 @@ struct net_buf *net_buf_clone(struct net_buf *buf, k_timeout_t timeout)
 		net_buf_add_mem(clone, buf->data, buf->len);
 	}
 
+	/* user_data_size should be the same for buffers from the same pool */
+	__ASSERT(buf->user_data_size == clone->user_data_size, "Unexpected user data size");
+
+	memcpy(clone->user_data, buf->user_data, clone->user_data_size);
+
 	return clone;
 }
 

--- a/tests/net/buf/src/main.c
+++ b/tests/net/buf/src/main.c
@@ -464,6 +464,25 @@ ZTEST(net_buf_tests, test_net_buf_clone_reference_counted_zero_sized_buffer)
 	zassert_not_null(clone, "Failed to clone zero sized buffer");
 
 	net_buf_unref(buf);
+}
+
+ZTEST(net_buf_tests, test_net_buf_clone_user_data)
+{
+	struct net_buf *original, *clone;
+	uint32_t *buf_user_data, *clone_user_data;
+
+	/* Requesting size 1 because all we are interested in are the user data */
+	original = net_buf_alloc_len(&bufs_pool, 1, K_NO_WAIT);
+	zassert_not_null(original, "Failed to get buffer");
+	buf_user_data = net_buf_user_data(original);
+	*buf_user_data = 0xAABBCCDD;
+
+	clone = net_buf_clone(original, K_NO_WAIT);
+	zassert_not_null(clone, "Failed to get clone buffer");
+	clone_user_data = net_buf_user_data(clone);
+	zexpect_equal(*clone_user_data, 0xAABBCCDD, "User data copy is invalid");
+
+	net_buf_unref(original);
 	net_buf_unref(clone);
 }
 


### PR DESCRIPTION
net_buf_user_data() is supposed to copy any data, which includes the user data.