### PR TITLE
posix: clock: implement clock_getres()

### DIFF
--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -332,7 +332,7 @@ POSIX_TIMERS
    :header: API, Supported
    :widths: 50,10
 
-    clock_getres(),
+    clock_getres(),yes
     clock_gettime(),yes
     clock_settime(),yes
     nanosleep(),yes

--- a/include/zephyr/posix/time.h
+++ b/include/zephyr/posix/time.h
@@ -87,6 +87,7 @@ static inline int32_t _ts_to_ms(const struct timespec *to)
 }
 
 int clock_gettime(clockid_t clock_id, struct timespec *ts);
+int clock_getres(clockid_t clock_id, struct timespec *ts);
 int clock_settime(clockid_t clock_id, const struct timespec *ts);
 int clock_getcpuclockid(pid_t pid, clockid_t *clock_id);
 /* Timer APIs */

--- a/lib/posix/options/clock.c
+++ b/lib/posix/options/clock.c
@@ -97,6 +97,28 @@ int clock_gettime(clockid_t clock_id, struct timespec *ts)
 	return 0;
 }
 
+int clock_getres(clockid_t clock_id, struct timespec *res)
+{
+	BUILD_ASSERT(CONFIG_SYS_CLOCK_TICKS_PER_SEC > 0 &&
+			     CONFIG_SYS_CLOCK_TICKS_PER_SEC <= NSEC_PER_SEC,
+		     "CONFIG_SYS_CLOCK_TICKS_PER_SEC must be > 0 and <= NSEC_PER_SEC");
+
+	if (!(clock_id == CLOCK_MONOTONIC || clock_id == CLOCK_REALTIME ||
+	      clock_id == CLOCK_PROCESS_CPUTIME_ID)) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	if (res != NULL) {
+		*res = (struct timespec){
+			.tv_sec = 0,
+			.tv_nsec = NSEC_PER_SEC / CONFIG_SYS_CLOCK_TICKS_PER_SEC,
+		};
+	}
+
+	return 0;
+}
+
 /**
  * @brief Set the time of the specified clock.
  *


### PR DESCRIPTION
Add an implementation of `clock_getres()`. Clock resolution is currently limited to the inverse of `CLOCK_TICKS_PER_SECOND` as there is no direct relationship between hardware clocks and the POSIX variety in Zephyr.

The `clock_getres()` function is required by the `POSIX_TIMERS` Option Group as detailed in Section E.1 of IEEE-1003.1-2017.

The `POSIX_TIMERS` Option Group is required for PSE51, PSE52, PSE53, and PSE54 conformance, and is otherwise mandatory for any POSIX conforming system as per Section A.2.1.3 of IEEE-1003-1.2017.

With this, we have complete support for the `POSIX_TIMERS` Option Group.

Fixes #59955