### PR TITLE
doc: posix: mark _POSIX_CPUTIME as supported

### DIFF
--- a/doc/services/portability/posix/conformance/index.rst
+++ b/doc/services/portability/posix/conformance/index.rst
@@ -79,7 +79,7 @@ POSIX System Interfaces
    :widths: 50, 10, 50
 
     _POSIX_ADVISORY_INFO, -1,
-    _POSIX_CPUTIME, -1,
+    _POSIX_CPUTIME, 200809L, :kconfig:option:`CONFIG_POSIX_CLOCK`
     _POSIX_FSYNC, -1,
     _POSIX_IPV6, 200809L, :kconfig:option:`CONFIG_NET_IPV6`
     _POSIX_MEMLOCK, -1,


### PR DESCRIPTION
The `_POSIX_CPUTIME` interface requires `CLOCK_PROCESS_CPUTIME_ID` and `clock_getcpuclockid()` to be present. Both of those are now available and therefore we can mark `_POSIX_CPUTIME` as supported for PSE53.