### PR TITLE
intel_adsp/ace: power: No pending transaction before power gate

### DIFF
--- a/drivers/power_domain/power_domain_intel_adsp.c
+++ b/drivers/power_domain/power_domain_intel_adsp.c
@@ -36,10 +36,10 @@ static int pd_intel_adsp_set_power_enable(struct pg_bits *bits, bool power_enabl
 		}
 	} else {
 #if CONFIG_SOC_INTEL_ACE15_MTPM
-		extern uint32_t g_key_read_holder;
+		extern uint32_t adsp_pending_buffer;
 
 		if (bits->SPA_bit == INTEL_ADSP_HST_DOMAIN_BIT) {
-			volatile uint32_t *key_read_ptr = &g_key_read_holder;
+			volatile uint32_t *key_read_ptr = &adsp_pending_buffer;
 			uint32_t key_value = *key_read_ptr;
 
 			if (key_value != INTEL_ADSP_ACE15_MAGIC_KEY)

--- a/soc/intel/intel_adsp/ace/multiprocessing.c
+++ b/soc/intel/intel_adsp/ace/multiprocessing.c
@@ -27,11 +27,6 @@
 
 #define ACE_INTC_IRQ DT_IRQN(DT_NODELABEL(ace_intc))
 
-#if CONFIG_SOC_INTEL_ACE15_MTPM
-/* .bss is uncached, we further check it below */
-uint32_t g_key_read_holder;
-#endif /* CONFIG_SOC_INTEL_ACE15_MTPM */
-
 static void ipc_isr(void *arg)
 {
 	uint32_t cpu_id = arch_proc_id();
@@ -88,17 +83,6 @@ void soc_mp_init(void)
 
 	/* Set the core 0 active */
 	soc_cpus_active[0] = true;
-#if CONFIG_SOC_INTEL_ACE15_MTPM
-#if defined(CONFIG_SMP) && (CONFIG_MP_MAX_NUM_CPUS > 1)
-	/*
-	 * Only when more than 1 CPUs is enabled, then this is in uncached area.
-	 * Otherwise, this is in cached area and will fail this test.
-	 */
-	__ASSERT(!sys_cache_is_ptr_cached(&g_key_read_holder),
-		 "g_key_read_holder must be uncached");
-#endif /* defined(CONFIG_SMP) && (CONFIG_MP_MAX_NUM_CPUS > 1) */
-	g_key_read_holder = INTEL_ADSP_ACE15_MAGIC_KEY;
-#endif /* CONFIG_SOC_INTEL_ACE15_MTPM */
 }
 
 static int host_runtime_get(void)

--- a/soc/intel/intel_adsp/ace/power.c
+++ b/soc/intel/intel_adsp/ace/power.c
@@ -25,6 +25,13 @@
 #define SRAM_ALIAS_BASE         0xA0000000
 #define SRAM_ALIAS_MASK         0xF0000000
 
+#if CONFIG_SOC_INTEL_ACE15_MTPM
+/* Used to force any pending transaction by HW issuing an upstream read before
+ * power down host domain.
+ */
+uint8_t adsp_pending_buffer[CONFIG_DCACHE_LINE_SIZE] __aligned(CONFIG_DCACHE_LINE_SIZE);
+#endif /* CONFIG_SOC_INTEL_ACE15_MTPM */
+
 __imr void power_init(void)
 {
 #if CONFIG_ADSP_IDLE_CLOCK_GATING
@@ -34,6 +41,13 @@ __imr void power_init(void)
 	/* Disable idle power and clock gating */
 	DSPCS.bootctl[0].bctl |= DSPBR_BCTL_WAITIPCG | DSPBR_BCTL_WAITIPPG;
 #endif /* CONFIG_ADSP_IDLE_CLOCK_GATING */
+
+#if CONFIG_SOC_INTEL_ACE15_MTPM
+	*((uint32_t *)sys_cache_cached_ptr_get(&adsp_pending_buffer)) =
+		INTEL_ADSP_ACE15_MAGIC_KEY;
+	cache_data_flush_range(sys_cache_cached_ptr_get(&adsp_pending_buffer),
+			sizeof(adsp_pending_buffer));
+#endif /* CONFIG_SOC_INTEL_ACE15_MTPM */
 }
 
 #ifdef CONFIG_PM


### PR DESCRIPTION
Issue an upstream read transaction through uncached memory to flush out all pending transactions before power down the host domain.

Note: It also fixes a problem in the host power domain when using only one core.