### PR TITLE
doc: posix: correct note of XSI_THREADS_EXT

### DIFF
--- a/doc/services/portability/posix/aep/index.rst
+++ b/doc/services/portability/posix/aep/index.rst
@@ -32,7 +32,7 @@ Minimal Realtime System Profile (PSE51)
     POSIX_SIGNALS,, :ref:`†<posix_undefined_behaviour>`
     POSIX_SINGLE_PROCESS,, :ref:`†<posix_undefined_behaviour>`
     POSIX_THREADS_BASE, yes, :ref:`†<posix_undefined_behaviour>`
-    XSI_THREADS_EXT, yes, :ref:`†<posix_undefined_behaviour>`
+    XSI_THREADS_EXT, yes,
 
 .. csv-table:: PSE51 Option Requirements
    :header: Symbol, Support, Remarks


### PR DESCRIPTION
Previously, XSI_THREADS_EXT included a note aboutundefined behaviour. However, the required functions `pthread_attr_getstack()`, `pthread_attr_setstack()`,
`pthread_getconcurrency()`, and `pthread_setconcurrency()` are all conformant.

Remove the unneeded note.