### PR TITLE
drivers: bluetooth: hci: Fix userchan insufficient buf cause dead-loop.

### DIFF
--- a/drivers/bluetooth/hci/userchan.c
+++ b/drivers/bluetooth/hci/userchan.c
@@ -220,7 +220,7 @@ static void rx_thread(void *p1, void *p2, void *p3)
 			buf = get_rx(frame_start);
 			if (!buf) {
 				LOG_DBG("Discard adv report due to insufficient buf");
-				continue;
+				goto next;
 			}
 
 			buf_tailroom = net_buf_tailroom(buf);
@@ -229,7 +229,7 @@ static void rx_thread(void *p1, void *p2, void *p3)
 				LOG_ERR("Not enough space in buffer %zu/%zu",
 					buf_add_len, buf_tailroom);
 				net_buf_unref(buf);
-				continue;
+				goto next;
 			}
 
 			net_buf_add_mem(buf, frame_start + sizeof(packet_type), buf_add_len);
@@ -237,6 +237,8 @@ static void rx_thread(void *p1, void *p2, void *p3)
 			LOG_DBG("Calling bt_recv(%p)", buf);
 
 			bt_recv(buf);
+
+next:
 			len -= decoded_len;
 			frame_start += decoded_len;
 		}


### PR DESCRIPTION
If insufficient buf for given event, will cause dead-loop.

![img_v2_6987a392-7304-4655-b24b-5f83a3c2864l](https://github.com/zephyrproject-rtos/zephyr/assets/26378606/8208ac8d-6bdb-49e1-a86d-23275751766f)
