### PR TITLE
Implement the sbc encoder and decoder based on Bluedroid SBC

### DIFF
--- a/include/zephyr/libsbc/sbc.h
+++ b/include/zephyr/libsbc/sbc.h
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+#if defined(CONFIG_LIBSBC_ENCODER)
+#include "sbc_encoder.h"
+#endif
+#if defined(CONFIG_LIBSBC_DECODER)
+#include "oi_codec_sbc.h"
+#include "oi_status.h"
+#endif
+
+enum sbc_ch_mode {
+	SBC_CH_MODE_MONO,
+	SBC_CH_MODE_DUAL_CHANNEL,
+	SBC_CH_MODE_STEREO,
+	SBC_CH_MODE_JOINT_STEREO,
+};
+
+enum sbc_alloc_mthd {
+	SBC_ALLOC_MTHD_LOUDNESS,
+	SBC_ALLOC_MTHD_SNR,
+};
+
+#if defined(CONFIG_LIBSBC_ENCODER)
+struct sbc_encoder {
+	SBC_ENC_PARAMS sbc_encoder_params;
+};
+#endif
+
+#if defined(CONFIG_LIBSBC_DECODER)
+struct sbc_decoder {
+	OI_CODEC_SBC_DECODER_CONTEXT context;
+	uint32_t context_data[CODEC_DATA_WORDS(2, SBC_CODEC_FAST_FILTER_BUFFERS)];
+};
+#endif
+
+#if defined(CONFIG_LIBSBC_ENCODER)
+/**
+ * Setup encoder
+ * encoder     Handle of the encoder.
+ * samp_freq   sampling frequency in Hz, 16000, 32000, 44100 or 48000.
+ * ch_mode     channel mode, enum sbc_ch_mode.
+ * blk_len     block length, 4, 8, 12 or 16.
+ * subband     number of subbands, 4 or 8.
+ * alloc_mthd  allocation method, enum sbc_alloc_mthd.
+ * bit_rate    the resulting bit rate, kb/s
+ * return	  0: On success  -1: Wrong parameters
+ */
+int sbc_setup_encoder(struct sbc_encoder *encoder, uint32_t samp_freq, enum sbc_ch_mode ch_mode,
+		uint8_t blk_len, uint8_t subband, enum sbc_alloc_mthd alloc_mthd,
+		uint32_t bit_rate);
+
+/**
+ * Encode a frame
+ * encoder     Handle of the encoder
+ * pcm         Input PCM samples
+ * nbytes      Target size, in bytes, of the frame
+ * out         Output buffer of `nbytes` size
+ * return      0: On success  -1: Wrong parameters
+ */
+int sbc_encode(struct sbc_encoder *encoder, const void *pcm, uint32_t nbytes, void *out);
+
+/**
+ * Return the number of PCM samples in a frame
+ * encoder     Handle of the encoder.
+ * return      Number of PCM samples, -1 on bad parameters
+ */
+int sbc_frame_samples(struct sbc_encoder *encoder);
+
+/**
+ * Return the number of PCM bytes in a frame
+ * encoder     Handle of the encoder.
+ * return      Number of PCM bytes, -1 on bad parameters
+ */
+int sbc_frame_bytes(struct sbc_encoder *encoder);
+
+/**
+ * Return the encoded size of one frame
+ * encoder     Handle of the encoder.
+ * return      The encoded size in bytes of one frame, -1 on bad parameters
+ */
+int sbc_frame_encoded_bytes(struct sbc_encoder *encoder);
+#endif
+
+#if defined(CONFIG_LIBSBC_DECODER)
+/**
+ * Setup decoder
+ * decoder     Handle of the decoder
+ *
+ * return	  0: On success  -1: Wrong parameters
+ */
+int sbc_setup_decoder(struct sbc_decoder *decoder);
+
+/**
+ * Decode a frame
+ * decoder         Handle of the decoder
+ * in              Input bitstream
+ * in_nbytes       Input data size in bytes, it is decreased after decode one frame
+ * pcm             Output PCM samples
+ * out_nbytes      Output data size in bytes
+ * return          0: On success  -1: Wrong parameters
+ */
+int sbc_decode(struct sbc_decoder *decoder, const void *in, uint32_t *in_nbytes,
+		void *pcm, uint32_t *out_nbytes);
+#endif

--- a/modules/Kconfig
+++ b/modules/Kconfig
@@ -67,6 +67,9 @@ comment "hal_nordic module not available."
 comment "liblc3 module not available."
 	depends on !ZEPHYR_LIBLC3_MODULE
 
+comment "libsbc module not available."
+	depends on !ZEPHYR_LIBSBC_MODULE
+
 comment "LittleFS module not available."
 	depends on !ZEPHYR_LITTLEFS_MODULE
 

--- a/modules/libsbc/CMakeLists.txt
+++ b/modules/libsbc/CMakeLists.txt
@@ -1,0 +1,50 @@
+if(CONFIG_LIBSBC_ENCODER OR CONFIG_LIBSBC_DECODER)
+
+zephyr_library_named(libsbc)
+zephyr_library_compile_options(-O3 -std=c11 -ffast-math -Wno-array-bounds)
+
+zephyr_compile_definitions(SBC_FOR_EMBEDDED_LINUX)
+zephyr_compile_definitions(SBC_NO_PCM_CPY_OPTION)
+zephyr_include_directories(.)
+zephyr_library_sources(sbc.c)
+
+if(CONFIG_LIBSBC_ENCODER)
+zephyr_library_sources(
+  ${ZEPHYR_LIBSBC_MODULE_DIR}/encoder/srce/sbc_analysis.c
+  ${ZEPHYR_LIBSBC_MODULE_DIR}/encoder/srce/sbc_dct.c
+  ${ZEPHYR_LIBSBC_MODULE_DIR}/encoder/srce/sbc_dct_coeffs.c
+  ${ZEPHYR_LIBSBC_MODULE_DIR}/encoder/srce/sbc_enc_bit_alloc_mono.c
+  ${ZEPHYR_LIBSBC_MODULE_DIR}/encoder/srce/sbc_enc_bit_alloc_ste.c
+  ${ZEPHYR_LIBSBC_MODULE_DIR}/encoder/srce/sbc_enc_coeffs.c
+  ${ZEPHYR_LIBSBC_MODULE_DIR}/encoder/srce/sbc_encoder.c
+  ${ZEPHYR_LIBSBC_MODULE_DIR}/encoder/srce/sbc_packing.c
+  )
+zephyr_include_directories(
+    ${ZEPHYR_LIBSBC_MODULE_DIR}/encoder/include
+  )
+endif()
+
+if(CONFIG_LIBSBC_DECODER)
+zephyr_library_sources(
+  ${ZEPHYR_LIBSBC_MODULE_DIR}/decoder/srce/alloc.c
+  ${ZEPHYR_LIBSBC_MODULE_DIR}/decoder/srce/bitalloc.c
+  ${ZEPHYR_LIBSBC_MODULE_DIR}/decoder/srce/bitalloc-sbc.c
+  ${ZEPHYR_LIBSBC_MODULE_DIR}/decoder/srce/bitstream-decode.c
+  ${ZEPHYR_LIBSBC_MODULE_DIR}/decoder/srce/decoder-oina.c
+  ${ZEPHYR_LIBSBC_MODULE_DIR}/decoder/srce/decoder-private.c
+  ${ZEPHYR_LIBSBC_MODULE_DIR}/decoder/srce/decoder-sbc.c
+  ${ZEPHYR_LIBSBC_MODULE_DIR}/decoder/srce/dequant.c
+  ${ZEPHYR_LIBSBC_MODULE_DIR}/decoder/srce/framing.c
+  ${ZEPHYR_LIBSBC_MODULE_DIR}/decoder/srce/framing-sbc.c
+  ${ZEPHYR_LIBSBC_MODULE_DIR}/decoder/srce/oi_codec_version.c
+  ${ZEPHYR_LIBSBC_MODULE_DIR}/decoder/srce/readsamplesjoint.inc
+  ${ZEPHYR_LIBSBC_MODULE_DIR}/decoder/srce/synthesis-8-generated.c
+  ${ZEPHYR_LIBSBC_MODULE_DIR}/decoder/srce/synthesis-dct8.c
+  ${ZEPHYR_LIBSBC_MODULE_DIR}/decoder/srce/synthesis-sbc.c
+  )
+zephyr_include_directories(
+  ${ZEPHYR_LIBSBC_MODULE_DIR}/decoder/include
+  ${ZEPHYR_LIBSBC_MODULE_DIR}/decoder/srce
+  )
+endif()
+endif()

--- a/modules/libsbc/Kconfig
+++ b/modules/libsbc/Kconfig
@@ -1,0 +1,15 @@
+# Copyright (c) 2024 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+config ZEPHYR_LIBSBC_MODULE
+	bool
+
+config LIBSBC_ENCODER
+	bool "libsbc encoder Support"
+	help
+	  This option enables the Android SBC encoder library for Bluetooth A2DP
+
+config LIBSBC_DECODER
+	bool "libsbc decoder Support"
+	help
+	  This option enables the Android SBC decoder library for Bluetooth A2DP

--- a/modules/libsbc/data_types.h
+++ b/modules/libsbc/data_types.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* only for the bluedroid sbc porting */
+typedef unsigned long UINT32;
+typedef unsigned short UINT16;
+typedef unsigned char UINT8;
+#define SBC_API
+#define APPL_TRACE_EVENT(a, b, c)

--- a/modules/libsbc/sbc.c
+++ b/modules/libsbc/sbc.c
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/libsbc/sbc.h>
+
+#if defined(CONFIG_LIBSBC_ENCODER)
+int sbc_setup_encoder(struct sbc_encoder *encoder, uint32_t samp_freq, enum sbc_ch_mode ch_mode,
+		uint8_t blk_len, uint8_t subband, enum sbc_alloc_mthd alloc_mthd,
+		uint32_t bit_rate)
+{
+	if (encoder == NULL) {
+		return -1;
+	}
+
+	memset(encoder, 0, sizeof(struct sbc_encoder));
+	encoder->sbc_encoder_params.s16ChannelMode = (SINT16)ch_mode;
+	encoder->sbc_encoder_params.s16NumOfSubBands = (SINT16)subband;
+	encoder->sbc_encoder_params.s16NumOfBlocks = (SINT16)blk_len;
+	encoder->sbc_encoder_params.s16AllocationMethod = (SINT16)alloc_mthd;
+	switch (samp_freq) {
+	case 16000u:
+		encoder->sbc_encoder_params.s16SamplingFreq = 0;
+		break;
+	case 32000u:
+		encoder->sbc_encoder_params.s16SamplingFreq = 1;
+		break;
+	case 44100u:
+		encoder->sbc_encoder_params.s16SamplingFreq = 2;
+		break;
+	case 48000u:
+		encoder->sbc_encoder_params.s16SamplingFreq = 3;
+		break;
+	default:
+		return -1;
+	}
+	encoder->sbc_encoder_params.u16BitRate = bit_rate;
+	SBC_Encoder_Init(&encoder->sbc_encoder_params);
+
+	return 0;
+}
+
+/**
+ * Encode a SBC frame
+ */
+int sbc_encode(struct sbc_encoder *encoder, const void *pcm, uint32_t nbytes, void *out)
+{
+	if ((encoder == NULL) || (pcm == NULL) || (out == NULL)) {
+		return -1;
+	}
+
+	encoder->sbc_encoder_params.ps16PcmBuffer = (int16_t *)pcm;
+	encoder->sbc_encoder_params.pu8Packet = out;
+	SBC_Encoder(&encoder->sbc_encoder_params);
+	if (encoder->sbc_encoder_params.u16PacketLength != nbytes) {
+		return -1;
+	}
+	return 0;
+}
+
+int sbc_frame_samples(struct sbc_encoder *encoder)
+{
+	if (encoder == NULL) {
+		return -1;
+	}
+
+	return encoder->sbc_encoder_params.s16NumOfSubBands *
+		encoder->sbc_encoder_params.s16NumOfBlocks;
+}
+
+int sbc_frame_bytes(struct sbc_encoder *encoder)
+{
+	if (encoder == NULL) {
+		return -1;
+	}
+
+	return sbc_frame_samples(encoder) * 2 *
+		(encoder->sbc_encoder_params.s16ChannelMode == SBC_CH_MODE_MONO ? 1 : 2);
+}
+
+int sbc_frame_encoded_bytes(struct sbc_encoder *encoder)
+{
+	int size = 4;
+	int channel_num = 2;
+
+	if (encoder == NULL) {
+		return -1;
+	}
+
+	if (encoder->sbc_encoder_params.s16ChannelMode == SBC_CH_MODE_MONO) {
+		channel_num = 1;
+	}
+
+	size += (4 * encoder->sbc_encoder_params.s16NumOfSubBands * channel_num) / 8;
+	if ((encoder->sbc_encoder_params.s16ChannelMode == SBC_CH_MODE_MONO) ||
+	    (encoder->sbc_encoder_params.s16ChannelMode == SBC_CH_MODE_DUAL_CHANNEL)) {
+		size += ((encoder->sbc_encoder_params.s16NumOfBlocks * channel_num *
+			encoder->sbc_encoder_params.s16BitPool + 7) / 8);
+	} else if (encoder->sbc_encoder_params.s16ChannelMode == SBC_CH_MODE_STEREO) {
+		size += ((encoder->sbc_encoder_params.s16NumOfBlocks *
+			encoder->sbc_encoder_params.s16BitPool + 7) / 8);
+	} else {
+		size += ((encoder->sbc_encoder_params.s16NumOfSubBands +
+			encoder->sbc_encoder_params.s16NumOfBlocks *
+			encoder->sbc_encoder_params.s16BitPool + 7) / 8);
+	}
+
+	return size;
+}
+#endif
+
+#if defined(CONFIG_LIBSBC_DECODER)
+/**
+ * Setup decoder
+ */
+int sbc_setup_decoder(struct sbc_decoder *decoder)
+{
+	OI_STATUS status;
+
+	if (decoder == NULL) {
+		return -1;
+	}
+
+	memset(decoder, 0, sizeof(struct sbc_decoder));
+
+	status = OI_CODEC_SBC_DecoderReset(
+			&decoder->context,
+			(OI_UINT32 *)&decoder->context_data[0],
+			sizeof(decoder->context_data),
+			2, 2, FALSE);
+	if (!OI_SUCCESS(status)) {
+		return -1;
+	}
+	return 0;
+}
+
+/**
+ * Decode a frame
+ */
+int sbc_decode(struct sbc_decoder *decoder, const void *in, uint32_t *in_nbytes,
+		void *pcm, uint32_t *out_nbytes)
+{
+	OI_STATUS status;
+
+	if (decoder == NULL) {
+		return -1;
+	}
+
+	status = OI_CODEC_SBC_DecodeFrame(&decoder->context,
+					(const OI_BYTE**)&in,
+					(OI_UINT32 *)in_nbytes,
+					pcm,
+					(OI_UINT32 *)out_nbytes
+					);
+	if (!OI_SUCCESS(status)) {
+		return -1;
+	} else {
+		return 0;
+	}
+}
+#endif

--- a/west.yml
+++ b/west.yml
@@ -270,6 +270,10 @@ manifest:
     - name: liblc3
       revision: 1a5938ebaca4f13fe79ce074f5dee079783aa29f
       path: modules/lib/liblc3
+    - name: libsbc
+      revision: 14609a5ca90334a8fde24983a8773001b9a323b7
+      path: modules/lib/libsbc
+      url: https://github.com/MarkWangChinese/libsbc.git
     - name: littlefs
       path: modules/fs/littlefs
       groups:


### PR DESCRIPTION
- It is based on Bluedroid SBC.
- The bluedroid SBC is being proposed as an external library in submodule repo (libsbc). https://github.com/zephyrproject-rtos/zephyr/issues/67705
- sbc.c is used to call the bluedroid SBC encoder and decoder.
- data_types.h is used to pass building for Bluedroid SBC.
