### PR TITLE
Bluetooth:tester: Support BREDR GAP, SDP and L2CAP auto-pts test

### DIFF
--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -630,9 +630,24 @@ struct bt_hci_cp_host_num_completed_packets {
 	struct bt_hci_handle_count h[0];
 } __packed;
 
+#define BT_HCI_OP_WRITE_CURRENT_IAC_LAP         BT_OP(BT_OGF_BASEBAND, 0x003A) /* 0x0c3A */
+struct bt_hci_cp_write_current_iac_lap {
+	uint8_t  num_current_iac;
+	struct
+	{
+		uint8_t iac[3];
+	} lap[0];
+} __packed;
+
 #define BT_HCI_OP_WRITE_INQUIRY_MODE            BT_OP(BT_OGF_BASEBAND, 0x0045) /* 0x0c45 */
 struct bt_hci_cp_write_inquiry_mode {
 	uint8_t  mode;
+} __packed;
+
+#define BT_HCI_OP_WRITE_EXTENDED_INQUIRY_RESPONSE   BT_OP(BT_OGF_BASEBAND, 0x0052) /* 0x0c52 */
+struct bt_hci_cp_write_extended_inquiry_response {
+	uint8_t fec_required;
+	uint8_t Extended_Inquiry_Response[240];
 } __packed;
 
 #define BT_HCI_OP_WRITE_SSP_MODE                BT_OP(BT_OGF_BASEBAND, 0x0056) /* 0x0c56 */

--- a/include/zephyr/bluetooth/l2cap.h
+++ b/include/zephyr/bluetooth/l2cap.h
@@ -239,6 +239,8 @@ struct bt_l2cap_br_endpoint {
 	uint16_t				cid;
 	/** Endpoint Maximum Transmission Unit */
 	uint16_t				mtu;
+	/** Endpoint Maximum PDU payload Size */
+	uint16_t				mps;
 };
 
 /** @brief BREDR L2CAP Channel structure. */

--- a/tests/bluetooth/tester/CMakeLists.txt
+++ b/tests/bluetooth/tester/CMakeLists.txt
@@ -94,3 +94,7 @@ endif()
 if(CONFIG_BT_TMAP)
     target_sources(app PRIVATE src/btp_tmap.c)
 endif()
+
+if(CONFIG_BT_CLASSIC)
+    target_sources(app PRIVATE src/btp_sdp.c)
+endif()

--- a/tests/bluetooth/tester/src/btp/btp.h
+++ b/tests/bluetooth/tester/src/btp/btp.h
@@ -3,6 +3,7 @@
 /*
  * Copyright (c) 2015-2016 Intel Corporation
  * Copyright (c) 2022 Codecoup
+ * Copyright 2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -73,8 +74,9 @@
 #define BTP_SERVICE_ID_CAP	26
 #define BTP_SERVICE_ID_TBS	27
 #define BTP_SERVICE_ID_TMAP	28
+#define BTP_SERVICE_ID_SDP	31
 
-#define BTP_SERVICE_ID_MAX	BTP_SERVICE_ID_TMAP
+#define BTP_SERVICE_ID_MAX	BTP_SERVICE_ID_SDP
 
 #define BTP_STATUS_SUCCESS	0x00
 #define BTP_STATUS_FAILED	0x01

--- a/tests/bluetooth/tester/src/btp/btp_gap.h
+++ b/tests/bluetooth/tester/src/btp/btp_gap.h
@@ -3,6 +3,7 @@
 /*
  * Copyright (c) 2015-2016 Intel Corporation
  * Copyright (c) 2022 Codecoup
+ * Copyright 2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -141,9 +142,12 @@ struct btp_gap_start_discovery_cmd {
 #define BTP_GAP_STOP_DISCOVERY			0x0d
 
 #define BTP_GAP_CONNECT				0x0e
+#define BTP_GAP_CONNECT_LE			0x00
+#define BTP_GAP_CONNECT_BREDR		0x01
 struct btp_gap_connect_cmd {
 	bt_addr_le_t address;
 	uint8_t own_addr_type;
+    uint8_t transport;
 } __packed;
 
 #define BTP_GAP_DISCONNECT			0x0f
@@ -319,6 +323,11 @@ struct btp_gap_padv_sync_transfer_recv_cmd {
 	uint8_t flags;
 } __packed;
 
+#define BTP_SM_AUTH				0x2a
+struct btp_sm_auth_cmd {
+	bt_addr_le_t address;
+    uint8_t   useh7;
+} __packed;
 /* events */
 #define BTP_GAP_EV_NEW_SETTINGS			0x80
 struct btp_gap_new_settings_ev {

--- a/tests/bluetooth/tester/src/btp/btp_l2cap.h
+++ b/tests/bluetooth/tester/src/btp/btp_l2cap.h
@@ -3,6 +3,7 @@
 /*
  * Copyright (c) 2015-2016 Intel Corporation
  * Copyright (c) 2022 Codecoup
+ * Copyright 2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -36,11 +37,13 @@ struct btp_l2cap_connect_rp {
 #define BTP_L2CAP_DISCONNECT				0x03
 struct btp_l2cap_disconnect_cmd {
 	uint8_t chan_id;
+	uint8_t transport;
 } __packed;
 
 #define BTP_L2CAP_SEND_DATA				0x04
 struct btp_l2cap_send_data_cmd {
 	uint8_t chan_id;
+	uint8_t transport;
 	uint16_t data_len;
 	uint8_t data[];
 } __packed;
@@ -53,6 +56,7 @@ struct btp_l2cap_send_data_cmd {
 #define BTP_L2CAP_CONNECTION_RESPONSE_INSUFF_AUTHOR	0x02
 #define BTP_L2CAP_CONNECTION_RESPONSE_INSUFF_ENC_KEY	0x03
 #define BTP_L2CAP_CONNECTION_RESPONSE_INSUFF_ENCRYPTION 0x04
+#define BTP_L2CAP_CONNECTION_RESPONSE_MODE4_LEVEL4  0x05
 
 #define BTP_L2CAP_LISTEN				0x05
 struct btp_l2cap_listen_cmd {
@@ -70,8 +74,10 @@ struct btp_l2cap_accept_connection_cmd {
 
 #define BTP_L2CAP_RECONFIGURE				0x07
 struct btp_l2cap_reconfigure_cmd {
+	uint8_t transport;
 	bt_addr_le_t address;
 	uint16_t mtu;
+	uint16_t mps;
 	uint8_t num;
 	uint8_t chan_id[];
 } __packed;
@@ -79,12 +85,26 @@ struct btp_l2cap_reconfigure_cmd {
 #define BTP_L2CAP_CREDITS				0x08
 struct btp_l2cap_credits_cmd {
 	uint8_t chan_id;
+	uint8_t transport;
 } __packed;
 
 #define BTP_L2CAP_DISCONNECT_EATT_CHANS			0x09
 struct btp_l2cap_disconnect_eatt_chans_cmd {
 	bt_addr_le_t address;
 	uint8_t count;
+} __packed;
+
+#define BTP_L2CAP_ECHO			0x0a
+struct btp_l2cap_echo_cmd {
+	bt_addr_t address;
+	uint16_t data_length;
+	uint8_t data[];
+} __packed;
+
+#define BTP_L2CAP_RX_FLOW_REQ			0x0b
+struct btp_l2cap_rx_flow_req_cmd {
+	uint8_t chan_id;
+	uint8_t flow;
 } __packed;
 
 /* events */

--- a/tests/bluetooth/tester/src/btp/btp_sdp.h
+++ b/tests/bluetooth/tester/src/btp/btp_sdp.h
@@ -1,0 +1,15 @@
+/* btp_ias.h - Bluetooth tester headers */
+
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+
+/* events */
+#define BTP_IAS_EV_OUT_ALERT_ACTION 0x80
+struct btp_ias_alert_action_ev {
+	uint8_t alert_lvl;
+} __packed;

--- a/tests/bluetooth/tester/src/btp/bttester.h
+++ b/tests/bluetooth/tester/src/btp/bttester.h
@@ -3,6 +3,7 @@
 /*
  * Copyright (c) 2015-2016 Intel Corporation
  * Copyright (c) 2022 Codecoup
+ * Copyright 2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -135,3 +136,6 @@ uint8_t tester_unregister_tbs(void);
 
 uint8_t tester_init_tmap(void);
 uint8_t tester_unregister_tmap(void);
+
+uint8_t tester_init_sdp(void);
+uint8_t tester_unregister_sdp(void);

--- a/tests/bluetooth/tester/src/btp_core.c
+++ b/tests/bluetooth/tester/src/btp_core.c
@@ -3,6 +3,7 @@
 /*
  * Copyright (c) 2015-2016 Intel Corporation
  * Copyright (c) 2023 Codecoup
+ * Copyright 2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -108,7 +109,11 @@ static uint8_t supported_services(const void *cmd, uint16_t cmd_len,
 	tester_set_bit(rp->data, BTP_SERVICE_ID_TMAP);
 #endif /* CONFIG_BT_TMAP */
 
-	*rsp_len = sizeof(*rp) + 2;
+#if defined(CONFIG_BT_CLASSIC)
+	tester_set_bit(rp->data, BTP_SERVICE_ID_SDP);
+#endif /* CONFIG_BT_CLASSIC */
+
+	*rsp_len = sizeof(*rp) + (BTP_SERVICE_ID_MAX)/8;
 
 	return BTP_STATUS_SUCCESS;
 }
@@ -245,6 +250,11 @@ static uint8_t register_service(const void *cmd, uint16_t cmd_len,
 		status = tester_init_tmap();
 		break;
 #endif /* CONFIG_BT_TMAP */
+#if defined(CONFIG_BT_CLASSIC)
+	case BTP_SERVICE_ID_SDP:
+		status = tester_init_sdp();
+		break;
+#endif /* CONFIG_BT_CLASSIC */
 	default:
 		LOG_WRN("unknown id: 0x%02x", cp->id);
 		status = BTP_STATUS_FAILED;
@@ -387,6 +397,11 @@ static uint8_t unregister_service(const void *cmd, uint16_t cmd_len,
 		status = tester_unregister_tmap();
 		break;
 #endif /* CONFIG_BT_TMAP */
+#if defined(CONFIG_BT_CLASSIC)
+	case BTP_SERVICE_ID_SDP:
+		status = tester_unregister_sdp();
+		break;
+#endif /* CONFIG_BT_CLASSIC */
 	default:
 		LOG_WRN("unknown id: 0x%x", cp->id);
 		status = BTP_STATUS_FAILED;

--- a/tests/bluetooth/tester/src/btp_l2cap.c
+++ b/tests/bluetooth/tester/src/btp_l2cap.c
@@ -2,6 +2,7 @@
 
 /*
  * Copyright (c) 2016 Intel Corporation
+ * Copyright 2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -12,6 +13,8 @@
 #include <zephyr/bluetooth/l2cap.h>
 #include <zephyr/bluetooth/att.h>
 #include <zephyr/sys/byteorder.h>
+#include "../../../../subsys/bluetooth/host/conn_internal.h"
+#include "../../../../subsys/bluetooth/host/smp.h"
 
 #include <zephyr/logging/log.h>
 #define LOG_MODULE_NAME bttester_l2cap
@@ -23,7 +26,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME, CONFIG_BTTESTER_LOG_LEVEL);
 #define DATA_MTU 256
 #define DATA_BUF_SIZE BT_L2CAP_SDU_BUF_SIZE(DATA_MTU)
 #define CHANNELS 2
-#define SERVERS 1
+#define SERVERS  2
 
 NET_BUF_POOL_FIXED_DEFINE(data_pool, CHANNELS, DATA_BUF_SIZE, 8, NULL);
 
@@ -38,8 +41,24 @@ static struct channel {
 	struct net_buf *pending_credit;
 } channels[CHANNELS];
 
+static struct br_channel {
+	uint8_t chan_id; /* Internal number that identifies L2CAP channel. */
+	struct bt_l2cap_br_chan br;
+	bool in_use;
+	bool hold_credit;
+	struct net_buf *pending_credit;
+} br_channels[CHANNELS];
+
 /* TODO Extend to support multiple servers */
 static struct bt_l2cap_server servers[SERVERS];
+
+#if defined(CONFIG_BT_CLASSIC)
+extern struct bt_conn *bt_conn_lookup_addr_br(const bt_addr_t *peer);
+#endif
+
+#if defined(CONFIG_BT_CLASSIC)
+static struct bt_l2cap_server *get_server(uint16_t psm);
+#endif
 
 static struct net_buf *alloc_buf_cb(struct bt_l2cap_chan *chan)
 {
@@ -60,7 +79,7 @@ static int recv_cb(struct bt_l2cap_chan *l2cap_chan, struct net_buf *buf)
 	memcpy(ev->data, buf->data, buf->len);
 
 	tester_event(BTP_SERVICE_ID_L2CAP, BTP_L2CAP_EV_DATA_RECEIVED,
-		     recv_cb_buf, sizeof(*ev) + buf->len);
+			 recv_cb_buf, sizeof(*ev) + buf->len);
 
 	if (chan->hold_credit && !chan->pending_credit) {
 		/* no need for extra ref, as when returning EINPROGRESS user
@@ -79,13 +98,18 @@ static void connected_cb(struct bt_l2cap_chan *l2cap_chan)
 	struct bt_l2cap_le_chan *l2cap_le_chan = CONTAINER_OF(
 			l2cap_chan, struct bt_l2cap_le_chan, chan);
 	struct channel *chan = CONTAINER_OF(l2cap_le_chan, struct channel, le);
+#if defined(CONFIG_BT_CLASSIC)
+	struct bt_l2cap_br_chan *l2cap_br_chan = CONTAINER_OF(
+			l2cap_chan, struct bt_l2cap_br_chan, chan);
+	struct br_channel *br_chan = CONTAINER_OF(l2cap_br_chan, struct br_channel, br);
+#endif /* CONFIG_BT_CLASSIC */
 	struct bt_conn_info info;
-
-	ev.chan_id = chan->chan_id;
+	(void)memset(&ev, 0, sizeof(ev));
 	/* TODO: ev.psm */
 	if (!bt_conn_get_info(l2cap_chan->conn, &info)) {
 		switch (info.type) {
 		case BT_CONN_TYPE_LE:
+			ev.chan_id = chan->chan_id;
 			ev.mtu_remote = sys_cpu_to_le16(chan->le.tx.mtu);
 			ev.mps_remote = sys_cpu_to_le16(chan->le.tx.mps);
 			ev.mtu_local = sys_cpu_to_le16(chan->le.rx.mtu);
@@ -93,6 +117,16 @@ static void connected_cb(struct bt_l2cap_chan *l2cap_chan)
 			bt_addr_le_copy(&ev.address, info.le.dst);
 			break;
 		case BT_CONN_TYPE_BR:
+#if defined(CONFIG_BT_CLASSIC)
+			ev.chan_id = br_chan->chan_id;
+			ev.psm = br_chan->br.psm;
+			ev.mtu_remote = sys_cpu_to_le16(br_chan->br.tx.mtu);
+			ev.mps_remote = sys_cpu_to_le16(br_chan->br.tx.mps);
+			ev.mtu_local = sys_cpu_to_le16(br_chan->br.rx.mtu);
+			ev.mps_local = sys_cpu_to_le16(br_chan->br.rx.mps);
+			bt_addr_copy(&ev.address.a, info.br.dst);
+			break;
+#endif /* CONFIG_BT_CLASSIC */
 		default:
 			/* TODO figure out how (if) want to handle BR/EDR */
 			return;
@@ -108,6 +142,11 @@ static void disconnected_cb(struct bt_l2cap_chan *l2cap_chan)
 	struct bt_l2cap_le_chan *l2cap_le_chan = CONTAINER_OF(
 			l2cap_chan, struct bt_l2cap_le_chan, chan);
 	struct channel *chan = CONTAINER_OF(l2cap_le_chan, struct channel, le);
+#if defined(CONFIG_BT_CLASSIC)
+	struct bt_l2cap_br_chan *l2cap_br_chan = CONTAINER_OF(
+			l2cap_chan, struct bt_l2cap_br_chan, chan);
+	struct br_channel *br_chan = CONTAINER_OF(l2cap_br_chan, struct br_channel, br);
+#endif /* CONFIG_BT_CLASSIC */
 	struct bt_conn_info info;
 
 	/* release netbuf on premature disconnection */
@@ -119,21 +158,28 @@ static void disconnected_cb(struct bt_l2cap_chan *l2cap_chan)
 	(void)memset(&ev, 0, sizeof(struct btp_l2cap_disconnected_ev));
 
 	/* TODO: ev.result */
-	ev.chan_id = chan->chan_id;
 	/* TODO: ev.psm */
 	if (!bt_conn_get_info(l2cap_chan->conn, &info)) {
 		switch (info.type) {
 		case BT_CONN_TYPE_LE:
+			ev.chan_id = chan->chan_id;
+			ev.psm = chan->le.psm;
 			bt_addr_le_copy(&ev.address, info.le.dst);
+			chan->in_use = false;
 			break;
 		case BT_CONN_TYPE_BR:
+#if defined(CONFIG_BT_CLASSIC)
+			ev.chan_id = br_chan->chan_id;
+			ev.psm = br_chan->br.psm;
+			br_chan->in_use = false;
+			bt_addr_copy(&ev.address.a, info.br.dst);
+			break;
+#endif /* CONFIG_BT_CLASSIC */
 		default:
 			/* TODO figure out how (if) want to handle BR/EDR */
 			return;
 		}
 	}
-
-	chan->in_use = false;
 
 	tester_event(BTP_SERVICE_ID_L2CAP, BTP_L2CAP_EV_DISCONNECTED, &ev, sizeof(ev));
 }
@@ -142,19 +188,119 @@ static void disconnected_cb(struct bt_l2cap_chan *l2cap_chan)
 static void reconfigured_cb(struct bt_l2cap_chan *l2cap_chan)
 {
 	struct btp_l2cap_reconfigured_ev ev;
-	struct bt_l2cap_le_chan *l2cap_le_chan = CONTAINER_OF(
-			l2cap_chan, struct bt_l2cap_le_chan, chan);
-	struct channel *chan = CONTAINER_OF(l2cap_le_chan, struct channel, le);
+#if defined(CONFIG_BT_CLASSIC)
+	struct bt_conn_info info;
+#endif /* CONFIG_BT_CLASSIC */
+	struct bt_l2cap_le_chan *l2cap_le_chan;
+	struct channel *chan;
+#if defined(CONFIG_BT_CLASSIC)
+	struct bt_l2cap_br_chan *l2cap_br_chan;
+	struct br_channel *br_chan;
+#endif /* CONFIG_BT_CLASSIC */
 
 	(void)memset(&ev, 0, sizeof(ev));
 
-	ev.chan_id = chan->chan_id;
-	ev.mtu_remote = sys_cpu_to_le16(chan->le.tx.mtu);
-	ev.mps_remote = sys_cpu_to_le16(chan->le.tx.mps);
-	ev.mtu_local = sys_cpu_to_le16(chan->le.rx.mtu);
-	ev.mps_local = sys_cpu_to_le16(chan->le.rx.mps);
+#if defined(CONFIG_BT_CLASSIC)
+	(void)bt_conn_get_info(l2cap_chan->conn, &info);
+
+	if (BT_CONN_TYPE_BR == info.type) {
+		l2cap_br_chan = CONTAINER_OF(l2cap_chan, struct bt_l2cap_br_chan, chan);
+		br_chan = CONTAINER_OF(l2cap_br_chan, struct br_channel, br);
+
+		ev.chan_id = br_chan->chan_id;
+		ev.mtu_remote = sys_cpu_to_le16(br_chan->br.tx.mtu);
+		ev.mps_remote = sys_cpu_to_le16(br_chan->br.tx.mps);
+		ev.mtu_local = sys_cpu_to_le16(br_chan->br.rx.mtu);
+		ev.mps_local = sys_cpu_to_le16(br_chan->br.rx.mps);
+	} else if (BT_CONN_TYPE_LE ==  info.type)
+#endif /* CONFIG_BT_CLASSIC */
+	{
+		l2cap_le_chan = CONTAINER_OF(l2cap_chan, struct bt_l2cap_le_chan, chan);
+		chan = CONTAINER_OF(l2cap_le_chan, struct channel, le);
+
+		ev.chan_id = chan->chan_id;
+		ev.mtu_remote = sys_cpu_to_le16(chan->le.tx.mtu);
+		ev.mps_remote = sys_cpu_to_le16(chan->le.tx.mps);
+		ev.mtu_local = sys_cpu_to_le16(chan->le.rx.mtu);
+		ev.mps_local = sys_cpu_to_le16(chan->le.rx.mps);
+	}
+#if defined(CONFIG_BT_CLASSIC)
+	else {
+		/* misra rule */
+	}
+#endif /* CONFIG_BT_CLASSIC */
 
 	tester_event(BTP_SERVICE_ID_L2CAP, BTP_L2CAP_EV_RECONFIGURED, &ev, sizeof(ev));
+}
+#endif
+
+#if (defined(CONFIG_BT_L2CAP_IFRAME_SUPPORT) && (CONFIG_BT_L2CAP_IFRAME_SUPPORT > 0U))
+#if (defined(CONFIG_BT_L2CAP_MODE_SELECT) && (CONFIG_BT_L2CAP_MODE_SELECT > 0U))
+/* support L2CAP Enhanced Retransmission Mode */
+static struct bt_l2cap_retrans_fc en_retrans_fc = {
+	.mode = L2CAP_MODE_ERTM,
+	.tx_window_size = 10U,
+	.max_transmit = 20U,
+	.retrans_time_out = 10000U,
+	.monitor_time_out = 2000U,
+	.max_pdu = 200U,
+};
+
+/* support L2CAP Streaming Mode */
+static struct bt_l2cap_retrans_fc sm_fc = {
+	.mode = L2CAP_MODE_SM,
+	.tx_window_size = 7U,
+	.max_transmit = 5U,
+	.retrans_time_out = 10000U,
+	.monitor_time_out = 2000U,
+	.max_pdu = 100U,
+};
+#endif /* CONFIG_BT_L2CAP_MODE_SELECT */
+
+#if (defined(CONFIG_BT_L2CAP_NO_FCS) && (CONFIG_BT_L2CAP_NO_FCS > 0U))
+static uint8_t no_fcs_type = 0x00;
+#endif /* CONFIG_BT_L2CAP_NO_FCS */
+
+void get_configuration(struct bt_l2cap_chan *chan, struct bt_l2cap_cfg_options *cfg)
+{
+	if(NULL != cfg->retrans_fc) {
+		switch(cfg->retrans_fc->mode) {
+		case L2CAP_MODE_ERTM:
+		  memcpy(cfg->retrans_fc, &en_retrans_fc, sizeof(struct bt_l2cap_retrans_fc));
+		  break;
+
+		case L2CAP_MODE_SM:
+		  memcpy(cfg->retrans_fc, &sm_fc, sizeof(struct bt_l2cap_retrans_fc));
+		  break;
+
+		default:
+		  break;
+	  }
+	} else {
+		/* get channel's configuration from application */
+#if (defined(CONFIG_BT_L2CAP_MODE_SELECT) && (CONFIG_BT_L2CAP_MODE_SELECT > 3U))
+		cfg->retrans_fc = &sm_fc;
+#elif (defined(CONFIG_BT_L2CAP_MODE_SELECT) && (CONFIG_BT_L2CAP_MODE_SELECT > 2U))
+		cfg->retrans_fc = &en_retrans_fc;
+#else
+		cfg->retrans_fc = NULL;
+#endif
+
+#if (defined(CONFIG_BT_L2CAP_NO_FCS) && (CONFIG_BT_L2CAP_NO_FCS > 0U))
+		cfg->fcs_type = &no_fcs_type;
+#endif
+	}
+}
+
+void configuration_request(struct bt_l2cap_chan *chan, struct bt_l2cap_cfg_options *cfg, struct bt_l2cap_cfg_options *rsp)
+{
+	/* configuration request is received from peer device */
+	memcpy(rsp, cfg, sizeof(struct bt_l2cap_cfg_options));
+}
+
+void configuration_response(struct bt_l2cap_chan *chan, struct bt_l2cap_cfg_options *rsp)
+{
+	/* configuration response is received from peer device */
 }
 #endif
 
@@ -165,6 +311,11 @@ static const struct bt_l2cap_chan_ops l2cap_ops = {
 	.disconnected	= disconnected_cb,
 #if defined(CONFIG_BT_L2CAP_ECRED)
 	.reconfigured	= reconfigured_cb,
+#endif
+#if defined(CONFIG_BT_L2CAP_IFRAME_SUPPORT)
+	.get_cfg = get_configuration,
+	.cfg_req = configuration_request,
+	.cfg_rsp = configuration_response,
 #endif
 };
 
@@ -191,46 +342,124 @@ static struct channel *get_free_channel()
 	return NULL;
 }
 
+#if defined(CONFIG_BT_CLASSIC)
+static struct br_channel *get_free_br_channel()
+{
+	uint8_t i;
+	struct br_channel *chan = NULL;
+
+	for (i = 0U; i < CHANNELS; i++) {
+		if (br_channels[i].in_use) {
+			continue;
+		}
+
+		chan = &br_channels[i];
+
+		(void)memset(chan, 0, sizeof(*chan));
+		chan->chan_id = i;
+
+		br_channels[i].in_use = true;
+
+		break;
+	}
+
+	return chan;
+}
+#endif
+
 static uint8_t connect(const void *cmd, uint16_t cmd_len,
-		       void *rsp, uint16_t *rsp_len)
+			   void *rsp, uint16_t *rsp_len)
 {
 	const struct btp_l2cap_connect_cmd *cp = cmd;
 	struct btp_l2cap_connect_rp *rp = rsp;
 	struct bt_conn *conn;
 	struct channel *chan = NULL;
+#if defined(CONFIG_BT_CLASSIC)
+	struct br_channel *br_chan = NULL;
+	struct bt_l2cap_server *server = NULL;
+#endif /* CONFIG_BT_CLASSIC */
 	struct bt_l2cap_chan *allocated_channels[5] = {};
 	uint16_t mtu = sys_le16_to_cpu(cp->mtu);
 	uint16_t psm = sys_le16_to_cpu(cp->psm);
 	uint8_t i = 0;
 	bool ecfc = cp->options & BTP_L2CAP_CONNECT_OPT_ECFC;
 	int err;
+	struct bt_conn_info info = {0};
 
 	if (cp->num == 0 || cp->num > CHANNELS || mtu > DATA_MTU_INITIAL) {
 		return BTP_STATUS_FAILED;
 	}
 
 	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
+#if defined(CONFIG_BT_CLASSIC)
+	if (NULL == conn)
+	{
+		conn = bt_conn_lookup_addr_br(&cp->address.a);
+	}
+
+	server = get_server(psm);
+	if (NULL == server)
+	{
+		return BTP_STATUS_FAILED;
+	}
+#endif /* CONFIG_BT_CLASSIC */
+
 	if (!conn) {
 		return BTP_STATUS_FAILED;
 	}
 
-	for (i = 0U; i < cp->num; i++) {
-		chan = get_free_channel();
-		if (!chan) {
-			goto fail;
-		}
-		chan->le.chan.ops = &l2cap_ops;
-		chan->le.rx.mtu = mtu;
-		rp->chan_id[i] = chan->chan_id;
-		allocated_channels[i] = &chan->le.chan;
+	(void)bt_conn_get_info(conn, &info);
 
-		chan->hold_credit = cp->options & BTP_L2CAP_CONNECT_OPT_HOLD_CREDIT;
+	for (i = 0U; i < cp->num; i++) {
+#if defined(CONFIG_BT_CLASSIC)
+		if (BT_CONN_TYPE_BR == info.type)
+		{
+			br_chan = get_free_br_channel();
+			if (!br_chan)
+			{
+				goto fail;
+			}
+			br_chan->br.chan.ops = &l2cap_ops;
+			br_chan->br.rx.mtu = mtu;
+			rp->chan_id[i] = br_chan->chan_id;
+	#if (defined(CONFIG_BT_L2CAP_ECRED) && (CONFIG_BT_L2CAP_ECRED == 1)) || \
+		(defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL) && (CONFIG_BT_L2CAP_DYNAMIC_CHANNEL > 0U))
+			allocated_channels[i] = &br_chan->br.chan;
+	#endif /* CONFIG_BT_L2CAP_ECRED || CONFIG_BT_L2CAP_DYNAMIC_CHANNEL */
+			br_chan->hold_credit = cp->options & BTP_L2CAP_CONNECT_OPT_HOLD_CREDIT;
+		}
+		else
+#endif /* CONFIG_BT_CLASSIC */
+		{
+			chan = get_free_channel();
+			if (!chan) {
+				goto fail;
+			}
+			chan->le.chan.ops = &l2cap_ops;
+			chan->le.rx.mtu = mtu;
+			rp->chan_id[i] = chan->chan_id;
+			allocated_channels[i] = &chan->le.chan;
+
+			chan->hold_credit = cp->options & BTP_L2CAP_CONNECT_OPT_HOLD_CREDIT;
+		}
 	}
 
 	if (cp->num == 1 && !ecfc) {
-		err = bt_l2cap_chan_connect(conn, &chan->le.chan, psm);
-		if (err < 0) {
-			goto fail;
+#if defined(CONFIG_BT_CLASSIC)
+		if (BT_CONN_TYPE_BR == info.type)
+		{
+			err = bt_l2cap_chan_connect(conn, &br_chan->br.chan, psm);
+			if (err < 0) {
+				goto fail;
+			}
+		}
+		else
+#endif /* CONFIG_BT_CLASSIC */
+		{
+			err = bt_l2cap_chan_connect(conn, &chan->le.chan, psm);
+			if (err < 0) {
+				goto fail;
+			}
 		}
 	} else if (ecfc) {
 #if defined(CONFIG_BT_L2CAP_ECRED)
@@ -250,14 +479,25 @@ static uint8_t connect(const void *cmd, uint16_t cmd_len,
 	rp->num = cp->num;
 	*rsp_len = sizeof(*rp) + (rp->num * sizeof(rp->chan_id[0]));
 
+	bt_conn_unref(conn);
 	return BTP_STATUS_SUCCESS;
 
 fail:
 	for (i = 0U; i < ARRAY_SIZE(allocated_channels); i++) {
 		if (allocated_channels[i]) {
-			channels[BT_L2CAP_LE_CHAN(allocated_channels[i])->ident].in_use = false;
+#if defined(CONFIG_BT_CLASSIC)
+			if (BT_CONN_TYPE_BR == info.type)
+			{
+				CONTAINER_OF(CONTAINER_OF(allocated_channels[i], struct bt_l2cap_br_chan, chan), struct br_channel, br)->in_use = false;
+			}
+			else
+#endif /* CONFIG_BT_CLASSIC */
+			{
+				channels[BT_L2CAP_LE_CHAN(allocated_channels[i])->ident].in_use = false;
+			}
 		}
 	}
+	bt_conn_unref(conn);
 	return BTP_STATUS_FAILED;
 }
 
@@ -266,34 +506,48 @@ static uint8_t disconnect(const void *cmd, uint16_t cmd_len,
 {
 	const struct btp_l2cap_disconnect_cmd *cp = cmd;
 	struct channel *chan;
+#if defined(CONFIG_BT_CLASSIC)
+	struct br_channel *br_chan;
+#endif /* CONFIG_BT_CLASSIC */
 	int err;
 
 	if (cp->chan_id >= CHANNELS) {
 		return BTP_STATUS_FAILED;
 	}
+#if defined(CONFIG_BT_CLASSIC)
+	if(BTP_L2CAP_TRANSPORT_BREDR == cp->transport) {
+		/* BR/EDR transport */
 
-	chan = &channels[cp->chan_id];
+		br_chan = &br_channels[cp->chan_id];
 
-	err = bt_l2cap_chan_disconnect(&chan->le.chan);
-	if (err) {
-		return BTP_STATUS_FAILED;
+		err = bt_l2cap_chan_disconnect(&br_chan->br.chan);
 	}
+	else
+#endif /* CONFIG_BT_CLASSIC */
+	{
+		/* LE transport */
+		chan = &channels[cp->chan_id];
 
+		err = bt_l2cap_chan_disconnect(&chan->le.chan);
+		if (err) {
+			return BTP_STATUS_FAILED;
+		}
+	}
 	return BTP_STATUS_SUCCESS;
 }
 
 #if defined(CONFIG_BT_L2CAP_ECRED)
 static uint8_t reconfigure(const void *cmd, uint16_t cmd_len,
-			   void *rsp, uint16_t *rsp_len)
+							void *rsp, uint16_t *rsp_len)
 {
 	const struct btp_l2cap_reconfigure_cmd *cp = cmd;
-	uint16_t mtu;
+	uint16_t mtu, mps;
 	struct bt_conn *conn;
 	int err;
 	struct bt_l2cap_chan *reconf_channels[CHANNELS + 1] = {};
 
 	if (cmd_len < sizeof(*cp) ||
-	    cmd_len != sizeof(*cp) + cp->num) {
+		cmd_len != sizeof(*cp) + cp->num) {
 		return BTP_STATUS_FAILED;
 	}
 
@@ -306,20 +560,46 @@ static uint8_t reconfigure(const void *cmd, uint16_t cmd_len,
 		return BTP_STATUS_FAILED;
 	}
 
+	mps = sys_le16_to_cpu(cp->mps);
+
 	for (int i = 0; i < cp->num; i++) {
 		if (cp->chan_id[i] > CHANNELS) {
 			return BTP_STATUS_FAILED;
 		}
 
-		reconf_channels[i] = &channels[cp->chan_id[i]].le.chan;
+		if (BTP_L2CAP_TRANSPORT_BREDR == cp->transport) {
+			/* bredr */
+			reconf_channels[i] = &br_channels[cp->chan_id[i]].br.chan;
+		} else if (BTP_L2CAP_TRANSPORT_LE == cp->transport) {
+			/* le */
+			reconf_channels[i] = &channels[cp->chan_id[i]].le.chan;
+		} else {
+			/* invalid transport type */
+		}
 	}
 
-	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
+#if defined(CONFIG_BT_CLASSIC)
+	if (BTP_L2CAP_TRANSPORT_BREDR == cp->transport) {
+		/* bredr */
+		conn = bt_conn_lookup_addr_br(&cp->address.a);
+	} else 
+#endif
+	if (BTP_L2CAP_TRANSPORT_LE == cp->transport) {
+		/* le */
+		conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &cp->address);
+	} else {
+		/* invalid transport type */
+		conn = NULL;
+	}
 	if (!conn) {
 		LOG_ERR("Unknown connection");
 		return BTP_STATUS_FAILED;
 	}
 
+#if 0
+	/* support CONFIG_BT_CLASSIC */
+	err = bt_l2cap_ecred_chan_reconfigure(reconf_channels, mtu, mps);
+#endif
 	err = bt_l2cap_ecred_chan_reconfigure(reconf_channels, mtu);
 	if (err) {
 		bt_conn_unref(conn);
@@ -333,7 +613,7 @@ static uint8_t reconfigure(const void *cmd, uint16_t cmd_len,
 
 #if defined(CONFIG_BT_EATT)
 static uint8_t disconnect_eatt_chans(const void *cmd, uint16_t cmd_len,
-				     void *rsp, uint16_t *rsp_len)
+					void *rsp, uint16_t *rsp_len)
 {
 	const struct btp_l2cap_disconnect_eatt_chans_cmd *cp = cmd;
 	struct bt_conn *conn;
@@ -364,12 +644,15 @@ static uint8_t send_data(const void *cmd, uint16_t cmd_len,
 {
 	const struct btp_l2cap_send_data_cmd *cp = cmd;
 	struct channel *chan;
+#if defined(CONFIG_BT_CLASSIC)
+	struct br_channel *br_chan;
+#endif /* CONFIG_BT_CLASSIC */
 	struct net_buf *buf;
 	uint16_t data_len;
 	int ret;
 
 	if (cmd_len < sizeof(*cp) ||
-	    cmd_len != sizeof(*cp) + sys_le16_to_cpu(cp->data_len)) {
+		cmd_len != sizeof(*cp) + sys_le16_to_cpu(cp->data_len)) {
 		return BTP_STATUS_FAILED;
 	}
 
@@ -377,25 +660,58 @@ static uint8_t send_data(const void *cmd, uint16_t cmd_len,
 		return BTP_STATUS_FAILED;
 	}
 
-	chan = &channels[cp->chan_id];
-	data_len = sys_le16_to_cpu(cp->data_len);
+#if defined(CONFIG_BT_CLASSIC)
+	if(BTP_L2CAP_TRANSPORT_BREDR == cp->transport) {
+		/* BR/EDR transport */
+		br_chan = &br_channels[cp->chan_id];
+		data_len = sys_le16_to_cpu(cp->data_len);
 
+		/* FIXME: For now, fail if data length exceeds buffer length */
+		if (data_len > DATA_MTU) {
+			return BTP_STATUS_FAILED;
+		}
 
-	/* FIXME: For now, fail if data length exceeds buffer length */
-	if (data_len > DATA_MTU) {
-		return BTP_STATUS_FAILED;
+		/* FIXME: For now, fail if data length exceeds remote's L2CAP SDU */
+		if (data_len > br_chan->br.tx.mtu) {
+			return BTP_STATUS_FAILED;
+		}
 	}
+	else
+#endif /* CONFIG_BT_CLASSIC */
+	{
+		/* LE transport */
+		chan = &channels[cp->chan_id];
+		data_len = sys_le16_to_cpu(cp->data_len);
 
-	/* FIXME: For now, fail if data length exceeds remote's L2CAP SDU */
-	if (data_len > chan->le.tx.mtu) {
-		return BTP_STATUS_FAILED;
+
+		/* FIXME: For now, fail if data length exceeds buffer length */
+		if (data_len > DATA_MTU) {
+			return BTP_STATUS_FAILED;
+		}
+
+		/* FIXME: For now, fail if data length exceeds remote's L2CAP SDU */
+		if (data_len > chan->le.tx.mtu) {
+			return BTP_STATUS_FAILED;
+		}
 	}
 
 	buf = net_buf_alloc(&data_pool, K_FOREVER);
 	net_buf_reserve(buf, BT_L2CAP_SDU_CHAN_SEND_RESERVE);
 
 	net_buf_add_mem(buf, cp->data, data_len);
-	ret = bt_l2cap_chan_send(&chan->le.chan, buf);
+
+#if defined(CONFIG_BT_CLASSIC)
+	if(BTP_L2CAP_TRANSPORT_BREDR == cp->transport) {
+		/* BR/EDR transport */
+		ret = bt_l2cap_chan_send(&br_chan->br.chan, buf);
+	}
+	else
+#endif /* CONFIG_BT_CLASSIC */
+	{
+		/* LE transport */
+		ret = bt_l2cap_chan_send(&chan->le.chan, buf);
+	}
+
 	if (ret < 0) {
 		LOG_ERR("Unable to send data: %d", -ret);
 		net_buf_unref(buf);
@@ -420,6 +736,23 @@ static struct bt_l2cap_server *get_free_server(void)
 	return NULL;
 }
 
+#if defined(CONFIG_BT_CLASSIC)
+static struct bt_l2cap_server *get_server(uint16_t psm)
+{
+	uint8_t i;
+	struct bt_l2cap_server *pFreeServer = NULL;
+
+	for (i = 0U; i < SERVERS ; i++) {
+		if (servers[i].psm == psm) {
+			pFreeServer = &servers[i];
+			break;
+		}
+	}
+
+	return pFreeServer;
+}
+#endif
+
 static bool is_free_psm(uint16_t psm)
 {
 	uint8_t i;
@@ -437,6 +770,10 @@ static int accept(struct bt_conn *conn, struct bt_l2cap_server *server,
 		  struct bt_l2cap_chan **l2cap_chan)
 {
 	struct channel *chan;
+#if defined(CONFIG_BT_CLASSIC)
+	struct br_channel *br_chan;
+#endif /* CONFIG_BT_CLASSIC */
+	struct bt_conn_info info;
 
 	if (bt_conn_enc_key_size(conn) < req_keysize) {
 		return -EPERM;
@@ -446,21 +783,39 @@ static int accept(struct bt_conn *conn, struct bt_l2cap_server *server,
 		return -EACCES;
 	}
 
-	chan = get_free_channel();
-	if (!chan) {
-		return -ENOMEM;
+	(void)bt_conn_get_info(conn, &info);
+
+#if defined(CONFIG_BT_CLASSIC)
+	if (BT_CONN_TYPE_BR == info.type) {
+		br_chan = get_free_br_channel();
+		if (!br_chan) {
+			return -ENOMEM;
+		}
+
+		br_chan->br.chan.ops = &l2cap_ops;
+		br_chan->br.rx.mtu = DATA_MTU_INITIAL;
+
+		*l2cap_chan = &br_chan->br.chan;
 	}
+	else
+#endif /* CONFIG_BT_CLASSIC */
+	{
+		chan = get_free_channel();
+		if (!chan) {
+			return -ENOMEM;
+		}
 
-	chan->le.chan.ops = &l2cap_ops;
-	chan->le.rx.mtu = DATA_MTU_INITIAL;
+		chan->le.chan.ops = &l2cap_ops;
+		chan->le.rx.mtu = DATA_MTU_INITIAL;
 
-	*l2cap_chan = &chan->le.chan;
+		*l2cap_chan = &chan->le.chan;
+	}
 
 	return 0;
 }
 
 static uint8_t listen(const void *cmd, uint16_t cmd_len,
-		      void *rsp, uint16_t *rsp_len)
+			  void *rsp, uint16_t *rsp_len)
 {
 	const struct btp_l2cap_listen_cmd *cp = cmd;
 	struct bt_l2cap_server *server;
@@ -479,9 +834,19 @@ static uint8_t listen(const void *cmd, uint16_t cmd_len,
 
 	server->accept = accept;
 	server->psm = psm;
+#if (defined(CONFIG_BT_L2CAP_IFRAME_SUPPORT) && (CONFIG_BT_L2CAP_IFRAME_SUPPORT > 0U))\
+	/* support L2CAP Enhanced Retransmission Mode and Streaming Mode */
+	server->feature_mask = 0x18; 
+#endif
 
 	switch (cp->response) {
 	case BTP_L2CAP_CONNECTION_RESPONSE_SUCCESS:
+#if defined(CONFIG_BT_CLASSIC)
+		if (BTP_L2CAP_TRANSPORT_BREDR == cp->transport)
+		{
+			server->sec_level = BT_SECURITY_L2;
+		}
+#endif /* CONFIG_BT_CLASSIC */
 		break;
 	case BTP_L2CAP_CONNECTION_RESPONSE_INSUFF_ENC_KEY:
 		/* TSPX_psm_encryption_key_size_required */
@@ -496,45 +861,139 @@ static uint8_t listen(const void *cmd, uint16_t cmd_len,
 	case BTP_L2CAP_CONNECTION_RESPONSE_INSUFF_ENCRYPTION:
 		server->sec_level = BT_SECURITY_L2;
 		break;
+	case BTP_L2CAP_CONNECTION_RESPONSE_MODE4_LEVEL4:
+		server->sec_level = BT_SECURITY_L4;
+		break;
 	default:
 		return BTP_STATUS_FAILED;
 	}
 
-	if (bt_l2cap_server_register(server) < 0) {
-		server->psm = 0U;
-		return BTP_STATUS_FAILED;
+#if defined(CONFIG_BT_CLASSIC)
+	if (BTP_L2CAP_TRANSPORT_BREDR == cp->transport)
+	{
+		if (psm > 0x1000) {
+			/* Dynamic BR/EDR PSM */
+			if (bt_l2cap_br_server_register(server) < 0) {
+				server->psm = 0U;
+				return BTP_STATUS_FAILED;
+			}
+		} 
+#if (defined(CONFIG_BT_L2CAP_ECRED) && (CONFIG_BT_L2CAP_ECRED > 0U))
+		else if ((psm >= 0x80) && (psm <= 0xFF)) {
+			/* Dynamic SPSM */
+#if 0
+			if (bt_l2cap_ecbfc_server_register(server) < 0) {
+				server->psm = 0U;
+				return BTP_STATUS_FAILED;
+			}
+#else
+			return BTP_STATUS_FAILED;
+#endif
+		} 
+#endif
+		else {
+			/* invalid PSM */
+		}
+	}
+	else
+#endif /* CONFIG_BT_CLASSIC */
+	{
+		if (bt_l2cap_server_register(server) < 0) {
+			server->psm = 0U;
+			return BTP_STATUS_FAILED;
+		}
 	}
 
 	return BTP_STATUS_SUCCESS;
 }
 
 static uint8_t credits(const void *cmd, uint16_t cmd_len,
-		      void *rsp, uint16_t *rsp_len)
+			  void *rsp, uint16_t *rsp_len)
 {
 	const struct btp_l2cap_credits_cmd *cp = cmd;
 	struct channel *chan;
+#if defined(CONFIG_BT_CLASSIC)
+	struct br_channel *br_chan;
+#endif
 
 	if (cp->chan_id >= CHANNELS) {
 		return BTP_STATUS_FAILED;
 	}
 
-	chan = &channels[cp->chan_id];
+#if defined(CONFIG_BT_CLASSIC)
+	if (BTP_L2CAP_TRANSPORT_BREDR == cp->transport) {
+		br_chan = &br_channels[cp->chan_id];
 
-	if (!chan->in_use) {
-		return BTP_STATUS_FAILED;
-	}
-
-	if (chan->pending_credit) {
-		if (bt_l2cap_chan_recv_complete(&chan->le.chan,
-						chan->pending_credit) < 0) {
+		if (!br_chan->in_use) {
 			return BTP_STATUS_FAILED;
 		}
 
-		chan->pending_credit = NULL;
+		if (br_chan->pending_credit) {
+			if (bt_l2cap_chan_recv_complete(&br_chan->br.chan,
+							br_chan->pending_credit) < 0) {
+				return BTP_STATUS_FAILED;
+			}
+
+			br_chan->pending_credit = NULL;
+		}
+	} else 
+#endif
+	{
+		chan = &channels[cp->chan_id];
+
+		if (!chan->in_use) {
+			return BTP_STATUS_FAILED;
+		}
+
+		if (chan->pending_credit) {
+			if (bt_l2cap_chan_recv_complete(&chan->le.chan,
+							chan->pending_credit) < 0) {
+				return BTP_STATUS_FAILED;
+			}
+
+			chan->pending_credit = NULL;
+		}
 	}
 
 	return BTP_STATUS_SUCCESS;
 }
+
+#if defined(CONFIG_BT_CLASSIC)
+static uint8_t echo(const void *cmd, uint16_t cmd_len,
+			  void *rsp, uint16_t *rsp_len)
+{
+#if 0
+	const struct btp_l2cap_echo_cmd *cp = cmd;
+
+	if(0U != l2ca_ping_req((UCHAR *)((void *)cp->address.val), (UCHAR *)((void *)cp->data), cp->data_length)) {
+		return BTP_STATUS_FAILED;
+	}
+#endif
+	return BTP_STATUS_SUCCESS;
+}
+
+static uint8_t rx_flow_req(const void *cmd, uint16_t cmd_len,
+			  void *rsp, uint16_t *rsp_len)
+{
+#if 0
+	const struct btp_l2cap_rx_flow_req_cmd *cp = cmd;
+	struct br_channel *br_chan;
+
+	if (cp->chan_id >= CHANNELS) {
+		return BTP_STATUS_FAILED;
+	}
+
+	br_chan = &br_channels[cp->chan_id];
+
+	if(0 == cp->flow) {
+		l2ca_rx_flow_req(br_chan->br.rx.cid, L2CAP_FEC_RX_FLOW_ON);
+	} else {
+		l2ca_rx_flow_req(br_chan->br.rx.cid, L2CAP_FEC_RX_FLOW_OFF);
+	}
+#endif
+	return BTP_STATUS_SUCCESS;
+}
+#endif
 
 static uint8_t supported_commands(const void *cmd, uint16_t cmd_len,
 				  void *rsp, uint16_t *rsp_len)
@@ -603,6 +1062,18 @@ static const struct btp_handler handlers[] = {
 		.expect_len = sizeof(struct btp_l2cap_disconnect_eatt_chans_cmd),
 		.func = disconnect_eatt_chans,
 	},
+#if defined(CONFIG_BT_CLASSIC)
+	{
+		.opcode = BTP_L2CAP_ECHO,
+		.expect_len = sizeof(struct btp_l2cap_echo_cmd),
+		.func = echo,
+	},
+	{
+		.opcode = BTP_L2CAP_RX_FLOW_REQ,
+		.expect_len = sizeof(struct btp_l2cap_rx_flow_req_cmd),
+		.func = rx_flow_req,
+	},
+#endif
 };
 
 uint8_t tester_init_l2cap(void)

--- a/tests/bluetooth/tester/src/btp_sdp.c
+++ b/tests/bluetooth/tester/src/btp_sdp.c
@@ -1,0 +1,234 @@
+/* btp_ias.c - Bluetooth IAS Server Tester */
+
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#if defined(CONFIG_BT_CLASSIC)
+
+#include <zephyr/bluetooth/classic/sdp.h>
+
+#include "btp/btp.h"
+#include <zephyr/sys/byteorder.h>
+#include <stdint.h>
+
+#include <zephyr/logging/log.h>
+#define LOG_MODULE_NAME bttester_sdp
+LOG_MODULE_REGISTER(LOG_MODULE_NAME, CONFIG_BTTESTER_LOG_LEVEL);
+
+static struct bt_sdp_attribute a2dp_sink_attrs[] = {
+    BT_SDP_NEW_SERVICE,
+    BT_SDP_LIST(
+        BT_SDP_ATTR_SVCLASS_ID_LIST,
+        BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 3), //35 03
+        BT_SDP_DATA_ELEM_LIST(
+        {
+            BT_SDP_TYPE_SIZE(BT_SDP_UUID16), //19
+            BT_SDP_ARRAY_16(BT_SDP_AUDIO_SINK_SVCLASS) //11 0B
+        },
+        )
+    ),
+    BT_SDP_LIST(
+        BT_SDP_ATTR_PROTO_DESC_LIST,
+        BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 16),//35 10
+        BT_SDP_DATA_ELEM_LIST(
+        {
+            BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 6),// 35 06
+            BT_SDP_DATA_ELEM_LIST(
+            {
+                BT_SDP_TYPE_SIZE(BT_SDP_UUID16), //19
+                BT_SDP_ARRAY_16(BT_SDP_PROTO_L2CAP) // 01 00
+            },
+            {
+                BT_SDP_TYPE_SIZE(BT_SDP_UINT16), //09
+                BT_SDP_ARRAY_16(BT_UUID_AVDTP_VAL) // 00 19
+            },
+            )
+        },
+        {
+            BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 6),// 35 06
+            BT_SDP_DATA_ELEM_LIST(
+            {
+                BT_SDP_TYPE_SIZE(BT_SDP_UUID16), //19
+                BT_SDP_ARRAY_16(BT_UUID_AVDTP_VAL) // 00 19
+            },
+            {
+                BT_SDP_TYPE_SIZE(BT_SDP_UINT16), //09
+                BT_SDP_ARRAY_16(0X0100u) //AVDTP version: 01 00
+            },
+            )
+        },
+        )
+    ),
+    BT_SDP_LIST(
+        BT_SDP_ATTR_PROFILE_DESC_LIST,
+        BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 8), //35 08
+        BT_SDP_DATA_ELEM_LIST(
+        {
+            BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 6), //35 06
+            BT_SDP_DATA_ELEM_LIST(
+            {
+                BT_SDP_TYPE_SIZE(BT_SDP_UUID16), //19
+                BT_SDP_ARRAY_16(BT_SDP_ADVANCED_AUDIO_SVCLASS) //11 0d
+            },
+            {
+                BT_SDP_TYPE_SIZE(BT_SDP_UINT16), //09
+                BT_SDP_ARRAY_16(0x0103U) //01 03
+            },
+            )
+        },
+        )
+    ),
+    BT_SDP_SERVICE_NAME("A2DPSink"),
+    BT_SDP_SUPPORTED_FEATURES(0x0001U),
+};
+
+static struct bt_sdp_record a2dp_sink_rec = BT_SDP_RECORD(a2dp_sink_attrs);
+
+#define SDP_SPP_SERVICE(channel) static struct bt_sdp_attribute spp_##channel##_attrs[] = { \
+    BT_SDP_NEW_SERVICE,                                                           \
+    BT_SDP_LIST(                                                                  \
+        BT_SDP_ATTR_SVCLASS_ID_LIST,                                              \
+        BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 3),                                     \
+        BT_SDP_DATA_ELEM_LIST(                                                    \
+        {                                                                         \
+            BT_SDP_TYPE_SIZE(BT_SDP_UUID16),                                      \
+            BT_SDP_ARRAY_16(BT_SDP_SERIAL_PORT_SVCLASS)                           \
+        },                                                                        \
+        )                                                                         \
+    ),                                                                            \
+    BT_SDP_LIST(                                                                  \
+        BT_SDP_ATTR_PROTO_DESC_LIST,                                              \
+        BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 12),                                    \
+        BT_SDP_DATA_ELEM_LIST(                                                    \
+        {                                                                         \
+            BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 3),                                 \
+            BT_SDP_DATA_ELEM_LIST(                                                \
+            {                                                                     \
+                BT_SDP_TYPE_SIZE(BT_SDP_UUID16),                                  \
+                BT_SDP_ARRAY_16(BT_SDP_PROTO_L2CAP)                               \
+            },                                                                    \
+            )                                                                     \
+        },                                                                        \
+        {                                                                         \
+            BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 5),                                 \
+            BT_SDP_DATA_ELEM_LIST(                                                \
+            {                                                                     \
+                BT_SDP_TYPE_SIZE(BT_SDP_UUID16),                                  \
+                BT_SDP_ARRAY_16(BT_UUID_RFCOMM_VAL)                               \
+            },                                                                    \
+            {                                                                     \
+                BT_SDP_TYPE_SIZE(BT_SDP_UINT8),                                   \
+                BT_SDP_ARRAY_16(channel)                                          \
+            },                                                                    \
+            )                                                                     \
+        },                                                                        \
+        )                                                                         \
+    ),                                                                            \
+    BT_SDP_LIST(                                                                  \
+        BT_SDP_ATTR_PROFILE_DESC_LIST,                                            \
+        BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 8),                                     \
+        BT_SDP_DATA_ELEM_LIST(                                                    \
+        {                                                                         \
+            BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 6),                                 \
+            BT_SDP_DATA_ELEM_LIST(                                                \
+            {                                                                     \
+                BT_SDP_TYPE_SIZE(BT_SDP_UUID16),                                  \
+                BT_SDP_ARRAY_16(BT_SDP_SERIAL_PORT_SVCLASS)                       \
+            },                                                                    \
+            {                                                                     \
+                BT_SDP_TYPE_SIZE(BT_SDP_UINT16),                                  \
+                BT_SDP_ARRAY_16(0x0102U)                                          \
+            },                                                                    \
+            )                                                                     \
+        },                                                                        \
+        )                                                                         \
+    ),                                                                            \
+    BT_SDP_SERVICE_NAME("COM"#channel),                                           \
+}
+
+SDP_SPP_SERVICE(1);
+SDP_SPP_SERVICE(2);
+SDP_SPP_SERVICE(3);
+SDP_SPP_SERVICE(4);
+SDP_SPP_SERVICE(5);
+SDP_SPP_SERVICE(6);
+SDP_SPP_SERVICE(7);
+SDP_SPP_SERVICE(8);
+SDP_SPP_SERVICE(9);
+SDP_SPP_SERVICE(10);
+SDP_SPP_SERVICE(11);
+SDP_SPP_SERVICE(12);
+SDP_SPP_SERVICE(13);
+SDP_SPP_SERVICE(14);
+SDP_SPP_SERVICE(15);
+SDP_SPP_SERVICE(16);
+
+static struct bt_sdp_record spp_rec[] = {
+    BT_SDP_RECORD(spp_1_attrs),
+    BT_SDP_RECORD(spp_2_attrs),
+    BT_SDP_RECORD(spp_3_attrs),
+    BT_SDP_RECORD(spp_4_attrs),
+    BT_SDP_RECORD(spp_5_attrs),
+    BT_SDP_RECORD(spp_6_attrs),
+    BT_SDP_RECORD(spp_7_attrs),
+    BT_SDP_RECORD(spp_8_attrs),
+    BT_SDP_RECORD(spp_9_attrs),
+    BT_SDP_RECORD(spp_10_attrs),
+    BT_SDP_RECORD(spp_11_attrs),
+    BT_SDP_RECORD(spp_12_attrs),
+    BT_SDP_RECORD(spp_13_attrs),
+    BT_SDP_RECORD(spp_14_attrs),
+    BT_SDP_RECORD(spp_15_attrs),
+    BT_SDP_RECORD(spp_16_attrs),
+};
+
+
+static struct bt_sdp_attribute bqb_pts_test_attrs[] = {
+    BT_SDP_NEW_SERVICE,
+    BT_SDP_LIST(
+        BT_SDP_ATTR_SVCLASS_ID_LIST,
+        BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 3), //35 03
+        BT_SDP_DATA_ELEM_LIST(
+        {
+            BT_SDP_TYPE_SIZE(BT_SDP_UUID16), //19
+            BT_SDP_ARRAY_16(0xBDDB) //BD DB
+        },
+        )
+    ),
+};
+
+static struct bt_sdp_record bqb_pts_test_rec = BT_SDP_RECORD(bqb_pts_test_attrs);
+
+static uint8_t supported_commands(const void *cmd, uint16_t cmd_len,
+				  void *rsp, uint16_t *rsp_len)
+{
+	return BTP_STATUS_UNKNOWN_CMD;
+}
+
+static const struct btp_handler handlers[] = {
+	{
+		.opcode = 0,
+		.index = BTP_INDEX_NONE,
+		.expect_len = 0,
+		.func = supported_commands,
+	},
+};
+
+uint8_t tester_init_sdp(void)
+{
+	tester_register_command_handlers(BTP_SERVICE_ID_SDP, handlers,
+					 ARRAY_SIZE(handlers));
+
+    bt_sdp_register_service(&a2dp_sink_rec);
+
+	return BTP_STATUS_SUCCESS;
+}
+
+uint8_t tester_unregister_sdp(void)
+{
+	return BTP_STATUS_SUCCESS;
+}
+#endif  /* CONFIG_BT_CLASSIC */


### PR DESCRIPTION
Update bluetooth bt_tester to support bredr GAP, SDP and L2CAP auto-pts test.

To support these BREDR auto-pts test, auto-pts repo should also be updated, here's my for auto-pts repo update: https://github.com/auto-pts/auto-pts/pull/1131