### PR TITLE
drivers: clock_control: stm32: clock_control_on

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -200,6 +200,7 @@ static inline int stm32_clock_control_on(const struct device *dev,
 					 clock_control_subsys_t sub_system)
 {
 	struct stm32_pclken *pclken = (struct stm32_pclken *)(sub_system);
+	volatile int temp;
 
 	ARG_UNUSED(dev);
 
@@ -210,6 +211,11 @@ static inline int stm32_clock_control_on(const struct device *dev,
 
 	sys_set_bits(DT_REG_ADDR(DT_NODELABEL(rcc)) + pclken->bus,
 		     pclken->enr);
+	/* Delay after enabling the clock, to allow it to become active.
+	 * See (for example) RM0440 7.2.17
+	 */
+	temp = sys_read32(DT_REG_ADDR(DT_NODELABEL(rcc)) + pclken->bus);
+	UNUSED(temp);
 
 	return 0;
 }

--- a/drivers/clock_control/clock_stm32_ll_h5.c
+++ b/drivers/clock_control/clock_stm32_ll_h5.c
@@ -145,6 +145,7 @@ static inline int stm32_clock_control_on(const struct device *dev,
 					 clock_control_subsys_t sub_system)
 {
 	struct stm32_pclken *pclken = (struct stm32_pclken *)(sub_system);
+	volatile int temp;
 
 	ARG_UNUSED(dev);
 
@@ -155,6 +156,9 @@ static inline int stm32_clock_control_on(const struct device *dev,
 
 	sys_set_bits(DT_REG_ADDR(DT_NODELABEL(rcc)) + pclken->bus,
 		     pclken->enr);
+	/* Delay after enabling the clock, to allow it to become active */
+	temp = sys_read32(DT_REG_ADDR(DT_NODELABEL(rcc)) + pclken->bus);
+	UNUSED(temp);
 
 	return 0;
 }

--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -360,6 +360,7 @@ static inline int stm32_clock_control_on(const struct device *dev,
 					 clock_control_subsys_t sub_system)
 {
 	struct stm32_pclken *pclken = (struct stm32_pclken *)(sub_system);
+	volatile int temp;
 
 	ARG_UNUSED(dev);
 
@@ -371,6 +372,11 @@ static inline int stm32_clock_control_on(const struct device *dev,
 	z_stm32_hsem_lock(CFG_HW_RCC_SEMID, HSEM_LOCK_DEFAULT_RETRY);
 
 	sys_set_bits(STM32H7_BUS_CLK_REG + pclken->bus, pclken->enr);
+	/* Delay after enabling the clock, to allow it to become active.
+	 * See RM0433 8.5.10 "Clock enabling delays"
+	 */
+	temp = sys_read32(STM32H7_BUS_CLK_REG + pclken->bus);
+	UNUSED(temp);
 
 	z_stm32_hsem_unlock(CFG_HW_RCC_SEMID);
 

--- a/drivers/clock_control/clock_stm32_ll_u5.c
+++ b/drivers/clock_control/clock_stm32_ll_u5.c
@@ -149,6 +149,7 @@ static inline int stm32_clock_control_on(const struct device *dev,
 					 clock_control_subsys_t sub_system)
 {
 	struct stm32_pclken *pclken = (struct stm32_pclken *)(sub_system);
+	volatile int temp;
 
 	ARG_UNUSED(dev);
 
@@ -159,6 +160,9 @@ static inline int stm32_clock_control_on(const struct device *dev,
 
 	sys_set_bits(DT_REG_ADDR(DT_NODELABEL(rcc)) + pclken->bus,
 		     pclken->enr);
+	/* Delay after enabling the clock, to allow it to become active */
+	temp = sys_read32(DT_REG_ADDR(DT_NODELABEL(rcc)) + pclken->bus);
+	UNUSED(temp);
 
 	return 0;
 }

--- a/drivers/clock_control/clock_stm32_ll_wba.c
+++ b/drivers/clock_control/clock_stm32_ll_wba.c
@@ -62,6 +62,7 @@ static inline int stm32_clock_control_on(const struct device *dev,
 					 clock_control_subsys_t sub_system)
 {
 	struct stm32_pclken *pclken = (struct stm32_pclken *)(sub_system);
+	volatile int temp;
 
 	ARG_UNUSED(dev);
 
@@ -72,6 +73,10 @@ static inline int stm32_clock_control_on(const struct device *dev,
 
 	sys_set_bits(DT_REG_ADDR(DT_NODELABEL(rcc)) + pclken->bus,
 		     pclken->enr);
+	/* Delay after enabling the clock, to allow it to become active */
+	temp = sys_read32(DT_REG_ADDR(DT_NODELABEL(rcc)) + pclken->bus);
+	UNUSED(temp);
+
 	return 0;
 }
 


### PR DESCRIPTION
Make clock_control_on for STM32H7 behave the same as the HAL, delaying after enabling peripheral clocks. Otherwise it may return before the clock is actually enabled, causing subsequent writes to peripheral registers to be silently ignored.

This is the cause of #70376, where enabling the hardware RNG (sometimes) fails immediately after enabling the clock for the RNG.