### PR TITLE
modules: lvgl: Fix coordinate handling for invert-{x,y} and swap-xy

### DIFF
--- a/modules/lvgl/input/lvgl_keypad_input.c
+++ b/modules/lvgl/input/lvgl_keypad_input.c
@@ -40,8 +40,7 @@ static void lvgl_keypad_process_event(const struct device *dev, struct input_eve
 	}
 
 	data->pending_event.state = evt->value ? LV_INDEV_STATE_PR : LV_INDEV_STATE_REL;
-	if (k_msgq_put(cfg->common_config.event_msgq, &data->pending_event,
-		       K_NO_WAIT) != 0) {
+	if (k_msgq_put(cfg->common_config.event_msgq, &data->pending_event, K_NO_WAIT) != 0) {
 		LOG_WRN("Could not put input data into keypad queue");
 	}
 }


### PR DESCRIPTION
This patch fixes two issue in the coordinate handling of the `zephyr,lvgl-pointer-input` compatible:
- If the swap-xy flag is set the coordinates need to be swapped even before the sync event is received.
- If the invert-{x,y} property is set the coordinates should only be inverted when the state is pressed. This is because the pointer saves the coordinates of a previous press event and upon release event it reuses them, causing the inversion to be applied twice.

Resolves issue #70539.