### PR TITLE
modules: lvgl: support linking memory pool to custom section

### DIFF
--- a/modules/lvgl/Kconfig.memory
+++ b/modules/lvgl/Kconfig.memory
@@ -39,6 +39,15 @@ config LV_Z_MEM_POOL_SIZE
 	help
 	  Size of the memory pool in bytes
 
+config LV_Z_MEMORY_POOL_CUSTOM_SECTION
+	bool "Link memory pool to custom section"
+	depends on LV_Z_MEM_POOL_SYS_HEAP
+	help
+	  Place LVGL memory pool in custom section, with tag ".lvgl_heap".
+	  This can be used by custom linker scripts to relocate the LVGL
+	  memory pool to a custom location, such as tightly coupled or
+	  external memory.
+
 config LV_Z_VDB_SIZE
 	int "Rendering buffer size"
 	default 100 if LV_Z_FULL_REFRESH

--- a/modules/lvgl/lvgl_mem.c
+++ b/modules/lvgl/lvgl_mem.c
@@ -10,7 +10,13 @@
 #include <zephyr/init.h>
 #include <zephyr/sys/sys_heap.h>
 
-static char lvgl_heap_mem[CONFIG_LV_Z_MEM_POOL_SIZE] __aligned(8);
+#ifdef CONFIG_LV_Z_MEMORY_POOL_CUSTOM_SECTION
+#define HEAP_MEM_ATTRIBUTES Z_GENERIC_SECTION(.lvgl_heap) __aligned(8)
+#else
+#define HEAP_MEM_ATTRIBUTES __aligned(8)
+#endif /* CONFIG_LV_Z_MEMORY_POOL_CUSTOM_SECTION */
+static char lvgl_heap_mem[CONFIG_LV_Z_MEM_POOL_SIZE] HEAP_MEM_ATTRIBUTES;
+
 static struct sys_heap lvgl_heap;
 static struct k_spinlock lvgl_heap_lock;
 


### PR DESCRIPTION
This patch adds a kconfig option `LV_Z_MEMORY_POOL_CUSTOM_SECTION` which allows to place the buffer the memory pool is backed by into a section with the label ".lvgl_heap".

Fixes #66494.