### PR TITLE
cmake: add --dirty flag to APP_BUILD_VERSION command

### DIFF
--- a/cmake/gen_version_h.cmake
+++ b/cmake/gen_version_h.cmake
@@ -13,7 +13,7 @@ if(NOT DEFINED ${BUILD_VERSION_NAME})
   find_package(Git QUIET)
   if(GIT_FOUND)
     execute_process(
-      COMMAND ${GIT_EXECUTABLE} describe --abbrev=12 --always
+      COMMAND ${GIT_EXECUTABLE} describe --abbrev=12 --always --dirty
       WORKING_DIRECTORY                ${work_dir}
       OUTPUT_VARIABLE                  ${BUILD_VERSION_NAME}
       OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/doc/build/version/index.rst
+++ b/doc/build/version/index.rst
@@ -109,7 +109,8 @@ following defines are available:
 |                             |                   | ``PATCHLEVEL``, |br|                                 |                         |
 |                             |                   | ``VERSION_TWEAK`` |br|                               |                         |
 +-----------------------------+-------------------+------------------------------------------------------+-------------------------+
-| APP_BUILD_VERSION           | String (unquoted) | None (value of ``git describe --abbrev=12 --always`` | v3.3.0-18-g2c85d9224fca |
+| APP_BUILD_VERSION           | String (unquoted) | None (value of                                       |                         |
+|                             |                   | ``git describe --abbrev=12 --always --dirty``        | v3.3.0-18-g2c85d9224fca |
 |                             |                   | from application repository)                         |                         |
 +-----------------------------+-------------------+------------------------------------------------------+-------------------------+
 


### PR DESCRIPTION
Without this it is possible to make the incorrect assumption that the repo was in a clean state when the code was compiled. With this flag it is clear when a build is dirty or not.