### PR TITLE
net: l2: Add channel valid check for wifi AP

### DIFF
--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -541,6 +541,11 @@ static int __wifi_args_to_params(size_t argc, char *argv[],
 		idx++;
 	}
 
+	if ((idx == 1) && (iface_mode == WIFI_MODE_AP)) {
+		PR_ERROR("Invalid channel: %s\n", argv[idx]);
+		return -EINVAL;
+	}
+
 	/* PSK (optional) */
 	if (idx < argc) {
 		params->psk = argv[idx];


### PR DESCRIPTION
Channel is mandatory for AP mode. It is processed only if its less than or equal to three characters. Otherwise we need to throw error for channel in AP mode.