### PR TITLE
manifest: hal_stm32: remove conflicting legacy PAGESIZE

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -229,7 +229,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 60c9634f61c697e1c310ec648d33529712806069
+      revision: pull/199/head
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Previously, legacy headers in hal_stm32 defined PAGESIZE to be a synonym of FLASH_PAGE_SIZE.

Typically, PAGESIZE is reserved by POSIX and refers to the granularity of virtual memory regions.

This change updates the hal_stm32 revision to the commit that has removed the conflicting definition from legacy headers.

Fixes #70136