### PR TITLE
twister: fix platform len check for --device-testing

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -783,10 +783,10 @@ def parse_arguments(parser, args, options = None):
         logger.error("valgrind enabled but valgrind executable not found")
         sys.exit(1)
 
-    if options.device_testing and (options.device_serial or options.device_serial_pty) and len(options.platform) > 1:
-        logger.error("""When --device-testing is used with
-                        --device-serial or --device-serial-pty,
-                        only one platform is allowed""")
+    if options.device_testing and (options.device_serial or options.device_serial_pty) and len(options.platform) != 1:
+        logger.error("When --device-testing is used with --device-serial "
+                     "or --device-serial-pty, exactly one platform must "
+                     "be specified")
         sys.exit(1)
 
     if options.device_flash_with_test and not options.device_testing:

--- a/scripts/tests/twister/test_environment.py
+++ b/scripts/tests/twister/test_environment.py
@@ -63,13 +63,27 @@ TESTDATA_1 = [
             '--device-testing',
             '--device-serial',
             'dummy',
+        ],
+        'When --device-testing is used with --device-serial' \
+        ' or --device-serial-pty, exactly one platform must' \
+        ' be specified'
+    ),
+    (
+        None,
+        None,
+        None,
+        [
+            '--device-testing',
+            '--device-serial',
+            'dummy',
             '--platform',
             'dummy_platform1',
             '--platform',
             'dummy_platform2'
         ],
         'When --device-testing is used with --device-serial' \
-        ' or --device-serial-pty, only one platform is allowed'
+        ' or --device-serial-pty, exactly one platform must' \
+        ' be specified'
     ),
 # Note the underscore.
     (
@@ -124,6 +138,7 @@ TESTDATA_1 = [
         'west runner without west flash',
         'west-flash without device-testing',
         'valgrind without executable',
+        'device serial without platform',
         'device serial with multiple platforms',
         'device flash with test without device testing',
         'shuffle-tests without subset',


### PR DESCRIPTION
Managed to make twister crash at line 175 here:
https://github.com/zephyrproject-rtos/zephyr/blob/d248b7bf07bf444278f6e4cef4ef1cede8dad340/scripts/pylib/twister/twisterlib/hardwaremap.py#L174-L176
with the following command line:
```
west twister -T samples/basic/blinky --device-testing --device-serial /dev/ttyACM0
```

since the argument parser did not have a check that (at least) one platform was provided. 

* Adjusted the current check so that _exactly one_ platform must be provided;
* Converted the docstring to separate strings to fix the strange indentation of that message;
* Added no platform test case and fixed expected message to comply with above changes.