### PR TITLE
timer: adsp: control timer interrupt broadcast on MP systems

### DIFF
--- a/drivers/timer/Kconfig
+++ b/drivers/timer/Kconfig
@@ -39,6 +39,14 @@ config SYSTEM_CLOCK_INIT_PRIORITY
 	  the clock to be running already, you should let the default value as it
 	  is (0).
 
+config SYSTEM_CLOCK_MP_BROADCAST
+	bool "select whether or not the timer is broadcast"
+	depends on SMP
+	help
+	  Used to select if we serve the timer interrupt on all cores.
+	  Some users might want to serve the timer interrupt on only the
+	  primary core and use a different mechanism to notify other cores.
+
 # Hidden option to be selected by individual SoC.
 config TICKLESS_CAPABLE
 	bool

--- a/drivers/timer/Kconfig.cavs
+++ b/drivers/timer/Kconfig.cavs
@@ -28,3 +28,8 @@ config INTEL_ADSP_TIMER
 	  It is not as fast as the internal core clock, but provides
 	  a common and synchronized counter for all CPU cores (which
 	  is useful for SMP).
+
+if INTEL_ADSP_TIMER
+config SYSTEM_CLOCK_MP_BROADCAST
+	def_bool y
+endif

--- a/drivers/timer/intel_adsp_timer.c
+++ b/drivers/timer/intel_adsp_timer.c
@@ -210,6 +210,14 @@ static void irq_init(void)
 
 void smp_timer_init(void)
 {
+	/* This is called from the secondary CPU boot path, so we need to
+	 * set up the timer interrupt for this CPU.
+	 * Some users might want to serve the timer interrupt on only the
+	 * primary core and use a different mechanism to notify other cores.
+	 */
+#ifdef CONFIG_SYSTEM_CLOCK_MP_BROADCAST
+	irq_init();
+#endif
 }
 
 /* Runs on core 0 only */

--- a/modules/Kconfig.sof
+++ b/modules/Kconfig.sof
@@ -9,3 +9,9 @@ config SOF
 	depends on ZEPHYR_SOF_MODULE
 	help
 	  Build Sound Open Firmware (SOF) support.
+
+
+if SOF
+config SYSTEM_CLOCK_MP_BROADCAST
+	default n
+endif


### PR DESCRIPTION
- driver: timer: broadcast timer interrupt based on config
- modules: sof: disable SYSTEM_CLOCK_MP_BROADCAST

fixes #70494
