### PR TITLE
tests|samples/bluetooth: Fix sysbuild due to BOAD_IDENTIFIER

### DIFF
--- a/samples/bluetooth/broadcast_audio_sink/Kconfig.sysbuild
+++ b/samples/bluetooth/broadcast_audio_sink/Kconfig.sysbuild
@@ -7,8 +7,7 @@ config NET_CORE_BOARD
 	string
 	default "nrf5340dk/nrf5340/cpunet" if "$(BOARD)" = "nrf5340dk"
 	default "nrf5340_audio_dk/nrf5340/cpunet" if "$(BOARD)" = "nrf5340_audio_dk"
-	default "nrf5340bsim_nrf5340_cpunet" if "$(BOARD)" = "nrf5340bsim_nrf5340_cpuapp"
-	default "nrf5340bsim/nrf5340/cpunet" if "$(BOARD)$(BOARD_IDENTIFIER)" = "nrf5340bsim/nrf5340/cpuapp"
+	default "nrf5340bsim/nrf5340/cpunet" if $(BOARD_TARGET_STRING) = "NRF5340BSIM_NRF5340_CPUAPP"
 
 config NET_CORE_IMAGE_HCI_IPC
 	bool "HCI IPC image on network core"

--- a/samples/bluetooth/broadcast_audio_source/Kconfig.sysbuild
+++ b/samples/bluetooth/broadcast_audio_source/Kconfig.sysbuild
@@ -7,8 +7,7 @@ config NET_CORE_BOARD
 	string
 	default "nrf5340dk/nrf5340/cpunet" if "$(BOARD)" = "nrf5340dk"
 	default "nrf5340_audio_dk/nrf5340/cpunet" if "$(BOARD)" = "nrf5340_audio_dk"
-	default "nrf5340bsim_nrf5340_cpunet" if "$(BOARD)" = "nrf5340bsim_nrf5340_cpuapp"
-	default "nrf5340bsim/nrf5340/cpunet" if "$(BOARD)$(BOARD_IDENTIFIER)" = "nrf5340bsim/nrf5340/cpuapp"
+	default "nrf5340bsim/nrf5340/cpunet" if $(BOARD_TARGET_STRING) = "NRF5340BSIM_NRF5340_CPUAPP"
 
 config NET_CORE_IMAGE_HCI_IPC
 	bool "HCI IPC image on network core"

--- a/samples/bluetooth/public_broadcast_sink/Kconfig.sysbuild
+++ b/samples/bluetooth/public_broadcast_sink/Kconfig.sysbuild
@@ -7,8 +7,7 @@ config NET_CORE_BOARD
 	string
 	default "nrf5340dk/nrf5340/cpunet" if "$(BOARD)" = "nrf5340dk"
 	default "nrf5340_audio_dk/nrf5340/cpunet" if "$(BOARD)" = "nrf5340_audio_dk"
-	default "nrf5340bsim_nrf5340_cpunet" if "$(BOARD)" = "nrf5340bsim_nrf5340_cpuapp"
-	default "nrf5340bsim/nrf5340/cpunet" if "$(BOARD)$(BOARD_IDENTIFIER)" = "nrf5340bsim/nrf5340/cpuapp"
+	default "nrf5340bsim/nrf5340/cpunet" if "$(BOARD_TARGET_STRING)" = "NRF5340BSIM_NRF5340_CPUAPP"
 
 config NET_CORE_IMAGE_HCI_IPC
 	bool "HCI IPC image on network core"

--- a/samples/bluetooth/public_broadcast_source/Kconfig.sysbuild
+++ b/samples/bluetooth/public_broadcast_source/Kconfig.sysbuild
@@ -7,8 +7,7 @@ config NET_CORE_BOARD
 	string
 	default "nrf5340dk/nrf5340/cpunet" if "$(BOARD)" = "nrf5340dk"
 	default "nrf5340_audio_dk/nrf5340/cpunet" if "$(BOARD)" = "nrf5340_audio_dk"
-	default "nrf5340bsim_nrf5340_cpunet" if "$(BOARD)" = "nrf5340bsim_nrf5340_cpuapp"
-	default "nrf5340bsim/nrf5340/cpunet" if $(BOARD)$(BOARD_IDENTIFIER) = "nrf5340bsim/nrf5340/cpuapp"
+	default "nrf5340bsim/nrf5340/cpunet" if $(BOARD_TARGET_STRING) = "NRF5340BSIM_NRF5340_CPUAPP"
 
 config NET_CORE_IMAGE_HCI_IPC
 	bool "HCI IPC image on network core"

--- a/samples/bluetooth/unicast_audio_client/Kconfig.sysbuild
+++ b/samples/bluetooth/unicast_audio_client/Kconfig.sysbuild
@@ -7,8 +7,7 @@ config NET_CORE_BOARD
 	string
 	default "nrf5340dk/nrf5340/cpunet" if "$(BOARD)" = "nrf5340dk"
 	default "nrf5340_audio_dk/nrf5340/cpunet" if "$(BOARD)" = "nrf5340_audio_dk"
-	default "nrf5340bsim_nrf5340_cpunet" if "$(BOARD)" = "nrf5340bsim_nrf5340_cpuapp"
-	default "nrf5340bsim/nrf5340/cpunet" if $(BOARD)$(BOARD_IDENTIFIER) = "nrf5340bsim/nrf5340/cpuapp"
+	default "nrf5340bsim/nrf5340/cpunet" if $(BOARD_TARGET_STRING) = "NRF5340BSIM_NRF5340_CPUAPP"
 
 config NET_CORE_IMAGE_HCI_IPC
 	bool "HCI IPC image on network core"

--- a/samples/bluetooth/unicast_audio_server/Kconfig.sysbuild
+++ b/samples/bluetooth/unicast_audio_server/Kconfig.sysbuild
@@ -7,8 +7,7 @@ config NET_CORE_BOARD
 	string
 	default "nrf5340dk/nrf5340/cpunet" if "$(BOARD)" = "nrf5340dk"
 	default "nrf5340_audio_dk/nrf5340/cpunet" if "$(BOARD)" = "nrf5340_audio_dk"
-	default "nrf5340bsim_nrf5340_cpunet" if "$(BOARD)" = "nrf5340bsim_nrf5340_cpuapp"
-	default "nrf5340bsim/nrf5340/cpunet" if $(BOARD)$(BOARD_IDENTIFIER) = "nrf5340bsim/nrf5340/cpuapp"
+	default "nrf5340bsim/nrf5340/cpunet" if $(BOARD_TARGET_STRING) = "NRF5340BSIM_NRF5340_CPUAPP"
 
 config NET_CORE_IMAGE_HCI_IPC
 	bool "HCI IPC image on network core"

--- a/samples/boards/nrf/nrf53_sync_rtc/CMakeLists.txt
+++ b/samples/boards/nrf/nrf53_sync_rtc/CMakeLists.txt
@@ -8,9 +8,9 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 if(("${BOARD}" STREQUAL "nrf5340dk") OR
-	("${BOARD}${BOARD_IDENTIFIER}" STREQUAL "nrf5340bsim/nrf5340/cpuapp") OR
+	("${BOARD}${BOARD_QUALIFIERS}" STREQUAL "nrf5340bsim/nrf5340/cpuapp") OR
 	("${BOARD}" STREQUAL "nrf5340bsim_nrf5340_cpuapp"))
-	message(INFO " ${BOARD}${BOARD_IDENTIFIER} used for Application Core")
+	message(INFO " ${BOARD}${BOARD_QUALIFIERS} used for Application Core")
 else()
 	message(FATAL_ERROR "${BOARD} is not supported for this sample")
 endif()

--- a/samples/boards/nrf/nrf53_sync_rtc/Kconfig.sysbuild
+++ b/samples/boards/nrf/nrf53_sync_rtc/Kconfig.sysbuild
@@ -7,5 +7,4 @@ source "share/sysbuild/Kconfig"
 config NET_CORE_BOARD
 string
 	default "nrf5340dk/nrf5340/cpunet" if $(BOARD) = "nrf5340dk"
-	default "nrf5340bsim_nrf5340_cpunet" if $(BOARD) = "nrf5340bsim_nrf5340_cpuapp"
-	default "nrf5340bsim/nrf5340/cpunet" if $(BOARD)$(BOARD_IDENTIFIER) = "nrf5340bsim/nrf5340/cpuapp"
+	default "nrf5340bsim/nrf5340/cpunet" if $(BOARD_TARGET_STRING) = "NRF5340BSIM_NRF5340_CPUAPP"

--- a/samples/boards/nrf/nrf53_sync_rtc/net/CMakeLists.txt
+++ b/samples/boards/nrf/nrf53_sync_rtc/net/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 if(("${BOARD}" STREQUAL "nrf5340dk") OR
 	("${BOARD}" STREQUAL "nrf5340bsim_nrf5340_cpunet") OR
 	("${BOARD}" STREQUAL "nrf5340bsim"))
-	message(INFO " ${BOARD}${BOARD_IDENTIFIER} used for Network Core")
+	message(INFO " ${BOARD}${BOARD_QUALIFIERS} used for Network Core")
 else()
 	message(FATAL_ERROR "${BOARD} is not supported for this sample")
 endif()

--- a/samples/drivers/mbox/CMakeLists.txt
+++ b/samples/drivers/mbox/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 set(REMOTE_ZEPHYR_DIR ${CMAKE_CURRENT_BINARY_DIR}/../remote/zephyr)
 
 if(("${BOARD}" STREQUAL "nrf5340dk") OR
-   ("${BOARD}${BOARD_IDENTIFIER}" STREQUAL "nrf5340bsim/nrf5340/cpuapp") OR
+   ("${BOARD}${BOARD_QUALIFIERS}" STREQUAL "nrf5340bsim/nrf5340/cpuapp") OR
    ("${BOARD}" STREQUAL "nrf5340bsim_nrf5340_cpuapp") OR
    ("${BOARD}" STREQUAL "adp_xc7k") OR
    ("${BOARD}" STREQUAL "mimxrt1170_evkb") OR
@@ -20,7 +20,7 @@ if(("${BOARD}" STREQUAL "nrf5340dk") OR
    ("${BOARD}" STREQUAL "mimxrt1160_evk") OR
    ("${BOARD}" STREQUAL "lpcxpresso55s69") OR
    ("${BOARD}" STREQUAL "nrf54h20dk"))
-  message(STATUS "${BOARD}${BOARD_IDENTIFIER} compile as Main in this sample")
+  message(STATUS "${BOARD}${BOARD_QUALIFIERS} compile as Main in this sample")
 else()
   message(FATAL_ERROR "${BOARD} is not supported for this sample")
 endif()

--- a/samples/drivers/mbox/Kconfig.sysbuild
+++ b/samples/drivers/mbox/Kconfig.sysbuild
@@ -8,8 +8,7 @@ source "share/sysbuild/Kconfig"
 config REMOTE_BOARD
 string
 	default "nrf5340dk/nrf5340/cpunet" if $(BOARD) = "nrf5340dk"
-	default "nrf5340bsim_nrf5340_cpunet" if $(BOARD) = "nrf5340bsim_nrf5340_cpuapp"
-	default "nrf5340bsim/nrf5340/cpunet" if $(BOARD)$(BOARD_IDENTIFIER) = "nrf5340bsim/nrf5340/cpuapp"
+	default "nrf5340bsim/nrf5340/cpunet" if $(BOARD_TARGET_STRING) = "NRF5340BSIM_NRF5340_CPUAPP"
 	default "adp_xc7k/ae350" if $(BOARD) = "adp_xc7k"
 	default "mimxrt1170_evkb/mimxrt1176/cm4" if $(BOARD) = "mimxrt1170_evkb"
 	default "mimxrt1170_evk/mimxrt1176/cm4" if $(BOARD) = "mimxrt1170_evk"

--- a/samples/drivers/mbox/remote/CMakeLists.txt
+++ b/samples/drivers/mbox/remote/CMakeLists.txt
@@ -18,7 +18,7 @@ if(("${BOARD}" STREQUAL "nrf5340dk") OR
   ("${BOARD}" STREQUAL "lpcxpresso55s69") OR
   ("${BOARD}" STREQUAL "adp_xc7k") OR
   ("${BOARD}" STREQUAL "nrf54h20dk"))
-  message(STATUS "${BOARD}${BOARD_IDENTIFIER} compile as remote in this sample")
+  message(STATUS "${BOARD}${BOARD_QUALIFIERS} compile as remote in this sample")
 else()
   message(FATAL_ERROR "${BOARD} is not supported for this sample")
 endif()

--- a/samples/subsys/logging/multidomain/CMakeLists.txt
+++ b/samples/subsys/logging/multidomain/CMakeLists.txt
@@ -9,9 +9,9 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 if(NOT(("${BOARD}" STREQUAL "nrf5340dk")
-    OR ("${BOARD}${BOARD_IDENTIFIER}" STREQUAL "nrf5340bsim/nrf5340/cpuapp")
+    OR ("${BOARD}${BOARD_QUALIFIERS}" STREQUAL "nrf5340bsim/nrf5340/cpuapp")
     OR ("${BOARD}" STREQUAL "nrf5340bsim_nrf5340_cpuapp")))
-  message(FATAL_ERROR "${BOARD}${BOARD_IDENTIFIER} is not supported for this sample")
+  message(FATAL_ERROR "${BOARD}${BOARD_QUALIFIERS} is not supported for this sample")
 endif()
 
 project(log_multidomain)

--- a/samples/subsys/logging/multidomain/Kconfig.sysbuild
+++ b/samples/subsys/logging/multidomain/Kconfig.sysbuild
@@ -7,5 +7,4 @@ source "share/sysbuild/Kconfig"
 config NET_CORE_BOARD
 string
 	default "nrf5340dk/nrf5340/cpunet" if $(BOARD) = "nrf5340dk"
-	default "nrf5340bsim_nrf5340_cpunet" if $(BOARD) = "nrf5340bsim_nrf5340_cpuapp"
-	default "nrf5340bsim/nrf5340/cpunet" if $(BOARD)$(BOARD_IDENTIFIER) = "nrf5340bsim/nrf5340/cpuapp"
+	default "nrf5340bsim/nrf5340/cpunet" if $(BOARD_TARGET_STRING) = "NRF5340BSIM_NRF5340_CPUAPP"

--- a/tests/bsim/bluetooth/ll/bis/Kconfig.sysbuild
+++ b/tests/bsim/bluetooth/ll/bis/Kconfig.sysbuild
@@ -5,8 +5,7 @@ source "share/sysbuild/Kconfig"
 
 config NET_CORE_BOARD
 	string
-	default "nrf5340bsim_nrf5340_cpunet" if $(BOARD) = "nrf5340bsim_nrf5340_cpuapp"
-	default "nrf5340bsim/nrf5340/cpunet" if $(BOARD)$(BOARD_IDENTIFIER) = "nrf5340bsim/nrf5340/cpuapp"
+	default "nrf5340bsim/nrf5340/cpunet" if $(BOARD_TARGET_STRING) = "NRF5340BSIM_NRF5340_CPUAPP"
 
 config NATIVE_SIMULATOR_PRIMARY_MCU_INDEX
 	int

--- a/tests/bsim/bluetooth/ll/cis/Kconfig.sysbuild
+++ b/tests/bsim/bluetooth/ll/cis/Kconfig.sysbuild
@@ -5,8 +5,7 @@ source "share/sysbuild/Kconfig"
 
 config NET_CORE_BOARD
 	string
-	default "nrf5340bsim_nrf5340_cpunet" if $(BOARD) = "nrf5340bsim_nrf5340_cpuapp"
-	default "nrf5340bsim/nrf5340/cpunet" if $(BOARD)$(BOARD_IDENTIFIER) = "nrf5340bsim/nrf5340/cpuapp"
+	default "nrf5340bsim/nrf5340/cpunet" if $(BOARD_TARGET_STRING) = "NRF5340BSIM_NRF5340_CPUAPP"
 
 config NATIVE_SIMULATOR_PRIMARY_MCU_INDEX
 	int

--- a/tests/bsim/bluetooth/ll/conn/Kconfig.sysbuild
+++ b/tests/bsim/bluetooth/ll/conn/Kconfig.sysbuild
@@ -5,8 +5,7 @@ source "share/sysbuild/Kconfig"
 
 config NET_CORE_BOARD
 	string
-	default "nrf5340bsim_nrf5340_cpunet" if $(BOARD) = "nrf5340bsim_nrf5340_cpuapp"
-	default "nrf5340bsim/nrf5340/cpunet" if $(BOARD)$(BOARD_IDENTIFIER) = "nrf5340bsim/nrf5340/cpuapp"
+	default "nrf5340bsim/nrf5340/cpunet" if $(BOARD_TARGET_STRING) = "NRF5340BSIM_NRF5340_CPUAPP"
 
 config NATIVE_SIMULATOR_PRIMARY_MCU_INDEX
 	int


### PR DESCRIPTION
After https://github.com/zephyrproject-rtos/zephyr/pull/70438 got merged simultaneously with https://github.com/zephyrproject-rtos/zephyr/pull/70435
all these tests stopped building properly due to the change of avaliable variables in Kconfig & cmake.
Let's fix them.
As a bonus, as for kconfig the BOARD_TARGET_STRING is the same for the hwmv1 backwards compatible name, let's
just remove the check for the old names. 

Fixes #70566
