### PR TITLE
tests: bsim: 10x the watchdog timeout

### DIFF
--- a/tests/bsim/bluetooth/audio/test_scripts/_csip_notify.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/_csip_notify.sh
@@ -8,7 +8,6 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 SIMULATION_ID="csip_notify"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_bass_client_sync.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_bass_client_sync.sh
@@ -6,7 +6,6 @@
 
 SIMULATION_ID="bass_client_sync"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=20
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio.sh
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=50
+EXECUTE_TIMEOUT=500
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_assistant.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_assistant.sh
@@ -6,7 +6,7 @@
 
 SIMULATION_ID="bap_broadcast_audio_assistant"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=50
+EXECUTE_TIMEOUT=500
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_unicast_audio.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_unicast_audio.sh
@@ -6,7 +6,6 @@
 
 SIMULATION_ID="unicast_audio"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=20
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_unicast_audio_acl_disconnect.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_unicast_audio_acl_disconnect.sh
@@ -6,7 +6,6 @@
 
 SIMULATION_ID="unicast_audio_acl_disconnect"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=20
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast.sh
@@ -6,7 +6,6 @@
 
 SIMULATION_ID="cap_broadcast"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=20
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast_ac_12.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast_ac_12.sh
@@ -6,7 +6,7 @@
 
 SIMULATION_ID="cap_broadcast_ac_12"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=600
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast_ac_13.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast_ac_13.sh
@@ -6,7 +6,7 @@
 
 SIMULATION_ID="cap_broadcast_ac_13"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=600
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast_ac_14.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast_ac_14.sh
@@ -6,7 +6,7 @@
 
 SIMULATION_ID="cap_broadcast_ac_14"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=600
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_capture_and_render.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_capture_and_render.sh
@@ -6,7 +6,6 @@
 
 SIMULATION_ID="cap_capture_and_render"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=20
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast.sh
@@ -6,7 +6,6 @@
 
 SIMULATION_ID="cap_unicast"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=20
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_1.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_1.sh
@@ -6,7 +6,7 @@
 
 SIMULATION_ID="cap_unicast_ac_1"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=600
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_10.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_10.sh
@@ -6,7 +6,7 @@
 
 SIMULATION_ID="cap_unicast_ac_10"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=600
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_11_i.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_11_i.sh
@@ -6,7 +6,7 @@
 
 SIMULATION_ID="cap_unicast_ac_11_i"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=600
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_11_ii.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_11_ii.sh
@@ -6,7 +6,7 @@
 
 SIMULATION_ID="cap_unicast_ac_11_ii"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=600
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_2.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_2.sh
@@ -6,7 +6,7 @@
 
 SIMULATION_ID="cap_unicast_ac_2"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=600
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_3.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_3.sh
@@ -6,7 +6,7 @@
 
 SIMULATION_ID="cap_unicast_ac_3"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=600
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_4.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_4.sh
@@ -6,7 +6,7 @@
 
 SIMULATION_ID="cap_unicast_ac_4"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=600
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_5.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_5.sh
@@ -6,7 +6,7 @@
 
 SIMULATION_ID="cap_unicast_ac_5"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=600
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_6_i.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_6_i.sh
@@ -6,7 +6,7 @@
 
 SIMULATION_ID="cap_unicast_ac_6_i"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=600
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_6_ii.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_6_ii.sh
@@ -6,7 +6,7 @@
 
 SIMULATION_ID="cap_unicast_ac_6_ii"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=600
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_7_i.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_7_i.sh
@@ -6,7 +6,7 @@
 
 SIMULATION_ID="cap_unicast_ac_7_i"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=600
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_7_ii.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_7_ii.sh
@@ -6,7 +6,7 @@
 
 SIMULATION_ID="cap_unicast_ac_7_ii"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=600
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_8_i.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_8_i.sh
@@ -6,7 +6,7 @@
 
 SIMULATION_ID="cap_unicast_ac_8_i"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=600
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_8_ii.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_8_ii.sh
@@ -6,7 +6,7 @@
 
 SIMULATION_ID="cap_unicast_ac_8_ii"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=600
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_9_i.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_9_i.sh
@@ -6,7 +6,7 @@
 
 SIMULATION_ID="cap_unicast_ac_9_i"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=600
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_9_ii.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_9_ii.sh
@@ -6,7 +6,7 @@
 
 SIMULATION_ID="cap_unicast_ac_9_ii"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=600
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_inval.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_inval.sh
@@ -6,7 +6,6 @@
 
 SIMULATION_ID="cap_unicast_inval"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=20
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_timeout.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_timeout.sh
@@ -6,7 +6,6 @@
 
 SIMULATION_ID="cap_unicast_timeout"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=20
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/csip.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip.sh
@@ -10,7 +10,6 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/csip_encrypted_sirk.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip_encrypted_sirk.sh
@@ -9,7 +9,6 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/csip_forced_release.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip_forced_release.sh
@@ -9,7 +9,6 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/csip_new_sirk.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip_new_sirk.sh
@@ -10,7 +10,6 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/csip_no_lock.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip_no_lock.sh
@@ -9,7 +9,6 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/csip_no_rank.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip_no_rank.sh
@@ -9,7 +9,6 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/csip_no_size.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip_no_size.sh
@@ -9,7 +9,6 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/gmap_broadcast_ac_12.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/gmap_broadcast_ac_12.sh
@@ -6,7 +6,7 @@
 
 SIMULATION_ID="gmap_broadcast_ac_12"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=600
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/gmap_broadcast_ac_13.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/gmap_broadcast_ac_13.sh
@@ -6,7 +6,7 @@
 
 SIMULATION_ID="gmap_broadcast_ac_13"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=600
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/gmap_broadcast_ac_14.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/gmap_broadcast_ac_14.sh
@@ -6,7 +6,7 @@
 
 SIMULATION_ID="gmap_broadcast_ac_14"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=600
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/gmap_unicast_ac_1.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/gmap_unicast_ac_1.sh
@@ -6,7 +6,7 @@
 
 SIMULATION_ID="gmap_unicast_ac_1"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=600
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/gmap_unicast_ac_11_i.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/gmap_unicast_ac_11_i.sh
@@ -6,7 +6,7 @@
 
 SIMULATION_ID="gmap_unicast_ac_11_i"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=600
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/gmap_unicast_ac_11_ii.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/gmap_unicast_ac_11_ii.sh
@@ -6,7 +6,7 @@
 
 SIMULATION_ID="gmap_unicast_ac_11_ii"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=600
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/gmap_unicast_ac_2.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/gmap_unicast_ac_2.sh
@@ -6,7 +6,7 @@
 
 SIMULATION_ID="gmap_unicast_ac_2"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=600
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/gmap_unicast_ac_3.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/gmap_unicast_ac_3.sh
@@ -6,7 +6,7 @@
 
 SIMULATION_ID="gmap_unicast_ac_3"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=600
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/gmap_unicast_ac_4.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/gmap_unicast_ac_4.sh
@@ -6,7 +6,7 @@
 
 SIMULATION_ID="gmap_unicast_ac_4"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=600
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/gmap_unicast_ac_5.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/gmap_unicast_ac_5.sh
@@ -6,7 +6,7 @@
 
 SIMULATION_ID="gmap_unicast_ac_5"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=600
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/gmap_unicast_ac_6_i.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/gmap_unicast_ac_6_i.sh
@@ -6,7 +6,7 @@
 
 SIMULATION_ID="gmap_unicast_ac_6_i"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=600
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/gmap_unicast_ac_6_ii.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/gmap_unicast_ac_6_ii.sh
@@ -6,7 +6,7 @@
 
 SIMULATION_ID="gmap_unicast_ac_6_ii"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=600
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/gmap_unicast_ac_7_ii.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/gmap_unicast_ac_7_ii.sh
@@ -6,7 +6,7 @@
 
 SIMULATION_ID="gmap_unicast_ac_7_ii"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=600
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/gmap_unicast_ac_8_i.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/gmap_unicast_ac_8_i.sh
@@ -6,7 +6,7 @@
 
 SIMULATION_ID="gmap_unicast_ac_8_i"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=600
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/gmap_unicast_ac_8_ii.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/gmap_unicast_ac_8_ii.sh
@@ -6,7 +6,7 @@
 
 SIMULATION_ID="gmap_unicast_ac_8_ii"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=600
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/has.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/has.sh
@@ -8,7 +8,6 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 SIMULATION_ID="has"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=20
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/has_offline.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/has_offline.sh
@@ -8,7 +8,6 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 SIMULATION_ID="has_offline_behavior"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=20
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/ias.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/ias.sh
@@ -8,7 +8,6 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 SIMULATION_ID="ias"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=20
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/mcs_mcc.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/mcs_mcc.sh
@@ -8,7 +8,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 SIMULATION_ID="mcs_mcc"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=50
+EXECUTE_TIMEOUT=500
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/media_controller.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/media_controller.sh
@@ -8,7 +8,6 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 SIMULATION_ID="media_controller"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=20
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/micp.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/micp.sh
@@ -8,7 +8,6 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 SIMULATION_ID="micp"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=20
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/pacs_notify.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/pacs_notify.sh
@@ -8,7 +8,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 SIMULATION_ID="pacs_notify"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=200
+EXECUTE_TIMEOUT=2000
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/pbp.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/pbp.sh
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=50
+EXECUTE_TIMEOUT=500
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/tbs.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/tbs.sh
@@ -9,7 +9,6 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 SIMULATION_ID="tbs_ccp"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=20
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/tmap.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/tmap.sh
@@ -6,7 +6,6 @@
 
 SIMULATION_ID="tmap"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=30
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/vcp.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/vcp.sh
@@ -8,7 +8,6 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 SIMULATION_ID="vcp"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=20
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio_samples/broadcast_audio_sink/tests_scripts/broadcast_audio.sh
+++ b/tests/bsim/bluetooth/audio_samples/broadcast_audio_sink/tests_scripts/broadcast_audio.sh
@@ -12,7 +12,7 @@ verbosity_level=2
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-EXECUTE_TIMEOUT=200
+EXECUTE_TIMEOUT=2000
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio_samples/unicast_audio_client/tests_scripts/unicast_client.sh
+++ b/tests/bsim/bluetooth/audio_samples/unicast_audio_client/tests_scripts/unicast_client.sh
@@ -12,7 +12,6 @@ verbosity_level=2
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-EXECUTE_TIMEOUT=100
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/hci_uart/tests_scripts/basic_conn_split_hci_uart.sh
+++ b/tests/bsim/bluetooth/hci_uart/tests_scripts/basic_conn_split_hci_uart.sh
@@ -10,7 +10,6 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # connected over UART. The controller is the HCI UART sample.
 simulation_id="basic_conn_split_hci_uart"
 verbosity_level=2
-EXECUTE_TIMEOUT=20
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/hci_uart/tests_scripts/basic_conn_split_hci_uart_async.sh
+++ b/tests/bsim/bluetooth/hci_uart/tests_scripts/basic_conn_split_hci_uart_async.sh
@@ -10,7 +10,6 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # connected over UART. The controller is the HCI UART async sample.
 simulation_id="basic_conn_split_hci_uart_async"
 verbosity_level=2
-EXECUTE_TIMEOUT=20
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/host/att/eatt/tests_scripts/autoconnect.sh
+++ b/tests/bsim/bluetooth/host/att/eatt/tests_scripts/autoconnect.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 simulation_id="connection"
 verbosity_level=2
-EXECUTE_TIMEOUT=120
+EXECUTE_TIMEOUT=1200
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/host/att/eatt/tests_scripts/collision.sh
+++ b/tests/bsim/bluetooth/host/att/eatt/tests_scripts/collision.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 simulation_id="collision"
 verbosity_level=2
-EXECUTE_TIMEOUT=120
+EXECUTE_TIMEOUT=1200
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/host/att/eatt/tests_scripts/lowres.sh
+++ b/tests/bsim/bluetooth/host/att/eatt/tests_scripts/lowres.sh
@@ -6,7 +6,6 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 simulation_id="lowres"
 verbosity_level=2
-EXECUTE_TIMEOUT=20
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/host/att/eatt/tests_scripts/multiple_conn.sh
+++ b/tests/bsim/bluetooth/host/att/eatt/tests_scripts/multiple_conn.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 simulation_id="multiple_conn"
 verbosity_level=2
-EXECUTE_TIMEOUT=120
+EXECUTE_TIMEOUT=1200
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/host/att/eatt/tests_scripts/reconfigure.sh
+++ b/tests/bsim/bluetooth/host/att/eatt/tests_scripts/reconfigure.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 simulation_id="reconfigure"
 verbosity_level=2
-EXECUTE_TIMEOUT=120
+EXECUTE_TIMEOUT=1200
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/host/att/eatt_notif/test_scripts/eatt_notif.sh
+++ b/tests/bsim/bluetooth/host/att/eatt_notif/test_scripts/eatt_notif.sh
@@ -8,7 +8,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 simulation_id="eatt_notif"
 verbosity_level=2
-EXECUTE_TIMEOUT=120
+EXECUTE_TIMEOUT=1200
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/host/att/open_close/test_scripts/run.sh
+++ b/tests/bsim/bluetooth/host/att/open_close/test_scripts/run.sh
@@ -10,7 +10,7 @@ test_path=$(guess_test_long_name)
 dev_exe="bs_${BOARD_TS}_${test_path}_prj_conf"
 simulation_id="${test_path}"
 
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=600
 
 cd "${BSIM_OUT_PATH}/bin"
 

--- a/tests/bsim/bluetooth/host/gatt/authorization/test_scripts/gatt.sh
+++ b/tests/bsim/bluetooth/host/gatt/authorization/test_scripts/gatt.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 simulation_id="gatt_authorization"
 verbosity_level=2
-EXECUTE_TIMEOUT=120
+EXECUTE_TIMEOUT=1200
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/host/gatt/caching/test_scripts/_run_test.sh
+++ b/tests/bsim/bluetooth/host/gatt/caching/test_scripts/_run_test.sh
@@ -5,7 +5,7 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 verbosity_level=2
-EXECUTE_TIMEOUT=120
+EXECUTE_TIMEOUT=1200
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/host/gatt/general/test_scripts/gatt.sh
+++ b/tests/bsim/bluetooth/host/gatt/general/test_scripts/gatt.sh
@@ -10,7 +10,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 simulation_id="gatt"
 verbosity_level=2
-EXECUTE_TIMEOUT=120
+EXECUTE_TIMEOUT=1200
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/host/gatt/notify/test_scripts/_run_test.sh
+++ b/tests/bsim/bluetooth/host/gatt/notify/test_scripts/_run_test.sh
@@ -6,7 +6,6 @@ set -eu
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 verbosity_level=2
-EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/host/gatt/notify_multiple/test_scripts/notify.sh
+++ b/tests/bsim/bluetooth/host/gatt/notify_multiple/test_scripts/notify.sh
@@ -7,7 +7,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 simulation_id="notify_multiple"
 verbosity_level=2
-EXECUTE_TIMEOUT=120
+EXECUTE_TIMEOUT=1200
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/host/gatt/sc_indicate/test_scripts/sc_indicate.sh
+++ b/tests/bsim/bluetooth/host/gatt/sc_indicate/test_scripts/sc_indicate.sh
@@ -8,7 +8,6 @@ test_name='sc_indicate'
 test_exe="bs_${BOARD_TS}_tests_bsim_bluetooth_host_gatt_${test_name}_prj_conf"
 simulation_id="${test_name}"
 verbosity_level=2
-EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/host/gatt/settings/test_scripts/run_gatt_settings.sh
+++ b/tests/bsim/bluetooth/host/gatt/settings/test_scripts/run_gatt_settings.sh
@@ -7,7 +7,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 simulation_id="settings"
 verbosity_level=2
-EXECUTE_TIMEOUT=120
+EXECUTE_TIMEOUT=1200
 test_exe="./bs_${BOARD_TS}_$(guess_test_long_name)_prj_conf"
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/host/gatt/settings/test_scripts/run_gatt_settings_2.sh
+++ b/tests/bsim/bluetooth/host/gatt/settings/test_scripts/run_gatt_settings_2.sh
@@ -7,7 +7,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 simulation_id="settings_2"
 verbosity_level=2
-EXECUTE_TIMEOUT=120
+EXECUTE_TIMEOUT=1200
 test_2_exe="./bs_${BOARD_TS}_$(guess_test_long_name)_prj_2_conf"
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/host/iso/cis/tests_scripts/cis.sh
+++ b/tests/bsim/bluetooth/host/iso/cis/tests_scripts/cis.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 simulation_id="iso_cis"
 verbosity_level=2
-EXECUTE_TIMEOUT=120
+EXECUTE_TIMEOUT=1200
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/host/l2cap/general/tests_scripts/l2cap.sh
+++ b/tests/bsim/bluetooth/host/l2cap/general/tests_scripts/l2cap.sh
@@ -7,7 +7,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # EATT test
 simulation_id="l2cap_ecred"
 verbosity_level=2
-EXECUTE_TIMEOUT=120
+EXECUTE_TIMEOUT=1200
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/host/l2cap/send_on_connect/tests_scripts/l2cap.sh
+++ b/tests/bsim/bluetooth/host/l2cap/send_on_connect/tests_scripts/l2cap.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 simulation_id="l2cap_send_on_connect"
 verbosity_level=2
-EXECUTE_TIMEOUT=120
+EXECUTE_TIMEOUT=1200
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/host/l2cap/stress/tests_scripts/l2cap.sh
+++ b/tests/bsim/bluetooth/host/l2cap/stress/tests_scripts/l2cap.sh
@@ -7,7 +7,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # EATT test
 simulation_id="l2cap_stress"
 verbosity_level=2
-EXECUTE_TIMEOUT=240
+EXECUTE_TIMEOUT=2400
 
 bsim_exe=./bs_${BOARD_TS}_tests_bsim_bluetooth_host_l2cap_stress_prj_conf
 

--- a/tests/bsim/bluetooth/host/l2cap/stress/tests_scripts/l2cap_syswq.sh
+++ b/tests/bsim/bluetooth/host/l2cap/stress/tests_scripts/l2cap_syswq.sh
@@ -7,8 +7,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # EATT test
 simulation_id="l2cap_stress_syswq"
 verbosity_level=2
-EXECUTE_TIMEOUT=240
-
+EXECUTE_TIMEOUT=2400
 bsim_exe=./bs_${BOARD_TS}_tests_bsim_bluetooth_host_l2cap_stress_prj_syswq_conf
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/host/l2cap/userdata/tests_scripts/l2cap.sh
+++ b/tests/bsim/bluetooth/host/l2cap/userdata/tests_scripts/l2cap.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 simulation_id="l2cap_ecred_userdata"
 verbosity_level=2
-EXECUTE_TIMEOUT=120
+EXECUTE_TIMEOUT=1200
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/host/misc/disable/tests_scripts/disable.sh
+++ b/tests/bsim/bluetooth/host/misc/disable/tests_scripts/disable.sh
@@ -7,7 +7,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # Disable test: bt_enable and bt_disable are called in a loop.
 simulation_id="disable_test"
 verbosity_level=2
-EXECUTE_TIMEOUT=120
+EXECUTE_TIMEOUT=1200
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/host/misc/disable/tests_scripts/disable_with_gatt.sh
+++ b/tests/bsim/bluetooth/host/misc/disable/tests_scripts/disable_with_gatt.sh
@@ -10,7 +10,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # peripheral then disable bluetooth and the test repeats.
 simulation_id="disable_with_gatt"
 verbosity_level=2
-EXECUTE_TIMEOUT=120
+EXECUTE_TIMEOUT=1200
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/host/misc/hfc/test_scripts/run.sh
+++ b/tests/bsim/bluetooth/host/misc/hfc/test_scripts/run.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 simulation_id="misc_hfc"
 verbosity_level=2
-EXECUTE_TIMEOUT=120
+EXECUTE_TIMEOUT=1200
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/advx/tests_scripts/basic_advx.sh
+++ b/tests/bsim/bluetooth/ll/advx/tests_scripts/basic_advx.sh
@@ -8,7 +8,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # notification, using the split controller (ULL LLL)
 simulation_id="basic_advx"
 verbosity_level=2
-EXECUTE_TIMEOUT=120
+EXECUTE_TIMEOUT=1200
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/advx/tests_scripts/basic_advx_ticker_expire_info.sh
+++ b/tests/bsim/bluetooth/ll/advx/tests_scripts/basic_advx_ticker_expire_info.sh
@@ -8,7 +8,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # notification, using the split controller (ULL LLL)
 simulation_id="basic_advx_ticker_expire_info"
 verbosity_level=2
-EXECUTE_TIMEOUT=120
+EXECUTE_TIMEOUT=1200
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso.sh
+++ b/tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso.sh
@@ -8,7 +8,6 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # to the BIS.
 simulation_id="broadcast_iso"
 verbosity_level=2
-EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_ticker_expire_info.sh
+++ b/tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_ticker_expire_info.sh
@@ -8,7 +8,6 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # to the BIS.
 simulation_id="broadcast_iso_ticker_expire_info"
 verbosity_level=2
-EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_vs_dp.sh
+++ b/tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_vs_dp.sh
@@ -8,7 +8,6 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # to the BIS, and recevied SDUs are emitted via vendor data path implementation.
 simulation_id="broadcast_iso_vs_dp"
 verbosity_level=2
-EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso.sh
+++ b/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso.sh
@@ -8,7 +8,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # 1 CIS each to 9 Peripherals (9 CIS in a CIG)
 simulation_id="connected_iso"
 verbosity_level=2
-EXECUTE_TIMEOUT=200
+EXECUTE_TIMEOUT=2000
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_acl_first.sh
+++ b/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_acl_first.sh
@@ -8,7 +8,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # 1 CIS each to 9 Peripherals (9 CIS in a CIG)
 simulation_id="connected_iso_acl_first"
 verbosity_level=2
-EXECUTE_TIMEOUT=200
+EXECUTE_TIMEOUT=2000
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_acl_first_ft_cen_skip_2_se.sh
+++ b/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_acl_first_ft_cen_skip_2_se.sh
@@ -8,7 +8,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # FT=2, skips 2 subevents in the central
 simulation_id="connected_iso_acl_first_ft_cen_skip_2_se"
 verbosity_level=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=600
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_acl_first_ft_cen_skip_4_se.sh
+++ b/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_acl_first_ft_cen_skip_4_se.sh
@@ -8,7 +8,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # FT=2, skips 4 subevents in the central
 simulation_id="connected_iso_acl_first_ft_cen_skip_4_se"
 verbosity_level=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=600
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_acl_first_ft_per_skip_2_se.sh
+++ b/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_acl_first_ft_per_skip_2_se.sh
@@ -8,7 +8,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # FT=2, skips 2 subevents in the peripheral
 simulation_id="connected_iso_acl_first_ft_per_skip_2_se"
 verbosity_level=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=600
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_acl_first_ft_per_skip_4_se.sh
+++ b/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_acl_first_ft_per_skip_4_se.sh
@@ -8,7 +8,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # FT=2, skips 4 subevents in the peripheral
 simulation_id="connected_iso_acl_first_ft_per_skip_4_se"
 verbosity_level=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=600
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_acl_group.sh
+++ b/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_acl_group.sh
@@ -8,7 +8,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # 1 CIS each to 9 Peripherals (9 CIS in a CIG)
 simulation_id="connected_iso_acl_group"
 verbosity_level=2
-EXECUTE_TIMEOUT=200
+EXECUTE_TIMEOUT=2000
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_acl_group_acl_first.sh
+++ b/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_acl_group_acl_first.sh
@@ -8,7 +8,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # 1 CIS each to 9 Peripherals (9 CIS in a CIG)
 simulation_id="connected_iso_acl_group_acl_first"
 verbosity_level=2
-EXECUTE_TIMEOUT=200
+EXECUTE_TIMEOUT=2000
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_legacy_adv.sh
+++ b/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_legacy_adv.sh
@@ -8,7 +8,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # 1 CIS each to 9 Peripherals (9 CIS in a CIG)
 simulation_id="connected_iso_legacy_adv"
 verbosity_level=2
-EXECUTE_TIMEOUT=200
+EXECUTE_TIMEOUT=2000
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_legacy_adv_acl_first.sh
+++ b/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_legacy_adv_acl_first.sh
@@ -8,7 +8,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # 1 CIS each to 9 Peripherals (9 CIS in a CIG)
 simulation_id="connected_iso_legacy_adv_acl_first"
 verbosity_level=2
-EXECUTE_TIMEOUT=200
+EXECUTE_TIMEOUT=2000
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_peripheral_cis.sh
+++ b/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_peripheral_cis.sh
@@ -7,7 +7,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # Basic Connected ISO test: multiple peripheral CIS establishment
 simulation_id="connected_iso_peripheral_cis"
 verbosity_level=2
-EXECUTE_TIMEOUT=100
+EXECUTE_TIMEOUT=1000
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_encrypted_split.sh
+++ b/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_encrypted_split.sh
@@ -8,7 +8,6 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # notification
 simulation_id="basic_conn_encr_split"
 verbosity_level=2
-EXECUTE_TIMEOUT=5
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_encrypted_split_privacy.sh
+++ b/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_encrypted_split_privacy.sh
@@ -8,7 +8,6 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # notification
 simulation_id="basic_conn_encr_split_privacy"
 verbosity_level=2
-EXECUTE_TIMEOUT=5
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_encrypted_split_single_timer.sh
+++ b/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_encrypted_split_single_timer.sh
@@ -8,7 +8,6 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # notification
 simulation_id="basic_conn_encr_split_single_timer"
 verbosity_level=2
-EXECUTE_TIMEOUT=5
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_split.sh
+++ b/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_split.sh
@@ -8,7 +8,6 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # notification, using the split controller (ULL LLL)
 simulation_id="basic_conn_split"
 verbosity_level=2
-EXECUTE_TIMEOUT=5
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_split_low_lat.sh
+++ b/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_split_low_lat.sh
@@ -8,7 +8,6 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # notification, using the split controller (ULL LLL) in Low Latency Variant
 simulation_id="basic_conn_split_low_lat"
 verbosity_level=2
-EXECUTE_TIMEOUT=5
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/edtt/tests_scripts/gatt.llcp.sh
+++ b/tests/bsim/bluetooth/ll/edtt/tests_scripts/gatt.llcp.sh
@@ -7,7 +7,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # GATT regression tests based on the EDTTool
 SIMULATION_ID="edtt_gatt_llcp"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=300
+EXECUTE_TIMEOUT=3000
 
 CWD="$(cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P)"
 

--- a/tests/bsim/bluetooth/ll/multiple_id/tests_scripts/multiple.sh
+++ b/tests/bsim/bluetooth/ll/multiple_id/tests_scripts/multiple.sh
@@ -7,7 +7,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # Multiple connection between two devices with multiple peripheral identity
 simulation_id="multiple"
 verbosity_level=2
-EXECUTE_TIMEOUT=1800
+EXECUTE_TIMEOUT=18000
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/throughput/tests_scripts/gatt_write.sh
+++ b/tests/bsim/bluetooth/ll/throughput/tests_scripts/gatt_write.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 simulation_id="ll-throughput"
 verbosity_level=2
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=600
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/mesh/_mesh_test.sh
+++ b/tests/bsim/bluetooth/mesh/_mesh_test.sh
@@ -3,7 +3,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-EXECUTE_TIMEOUT=600
+EXECUTE_TIMEOUT=6000
 
 function Skip(){
   for i in "${SKIP[@]}" ; do

--- a/tests/bsim/net/sockets/echo_test/tests_scripts/echo_test_802154.sh
+++ b/tests/bsim/net/sockets/echo_test/tests_scripts/echo_test_802154.sh
@@ -13,7 +13,7 @@ verbosity_level=2
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-EXECUTE_TIMEOUT=100
+EXECUTE_TIMEOUT=1000
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/net/sockets/echo_test/tests_scripts/echo_test_ot.sh
+++ b/tests/bsim/net/sockets/echo_test/tests_scripts/echo_test_ot.sh
@@ -13,7 +13,7 @@ verbosity_level=2
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-EXECUTE_TIMEOUT=100
+EXECUTE_TIMEOUT=1000
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/sh_common.source
+++ b/tests/bsim/sh_common.source
@@ -43,7 +43,7 @@ function check_program_exists() {
 }
 
 function Execute() {
-  EXECUTE_TIMEOUT="${EXECUTE_TIMEOUT:-30}"
+  EXECUTE_TIMEOUT="${EXECUTE_TIMEOUT:-300}"
 
   check_program_exists $1
   run_in_background timeout --kill-after=5 -v ${EXECUTE_TIMEOUT} $@


### PR DESCRIPTION
Why: CI runners are now paid less, so they work less fast :p

Seriously though, we are starting to get intermittent failures in CI because the tests run slightly slower than on the previous runners. This timeout value is set too conservatively, it should be okay to increase it.

Here's why:

We always start the bsim PHY with a given test run-time. The PHY will stop the simulation after that time.

This timeout value is another layer on top of this, and will abort all the spawned processes in case something goes very wrong.