### PR TITLE
twister bsim harness: Fix for hwmv2 platfrom names

### DIFF
--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -706,8 +706,9 @@ class Bsim(Harness):
             new_exe_name = f'bs_{self.instance.platform.name}_{new_exe_name}'
         else:
             new_exe_name = self.instance.name
-            new_exe_name = new_exe_name.replace(os.path.sep, '_').replace('.', '_')
             new_exe_name = f'bs_{new_exe_name}'
+
+        new_exe_name = new_exe_name.replace(os.path.sep, '_').replace('.', '_').replace('@', '_')
 
         new_exe_path: str = os.path.join(bsim_out_path, 'bin', new_exe_name)
         logger.debug(f'Copying executable from {original_exe_path} to {new_exe_path}')


### PR DESCRIPTION
The new hwmv2 platform names have "/" and "@" in
their names, we need to replace those with "_".
Otherwise the harness will produce a FileNotFoundError exception when trying to create the executable.

Fixes #70571