### PR TITLE
flash: POC support devices that can skip erase - DO NOT REVIEW

### DIFF
--- a/drivers/disk/flashdisk.c
+++ b/drivers/disk/flashdisk.c
@@ -208,13 +208,17 @@ end:
 
 static int flashdisk_cache_commit(struct flashdisk_data *ctx)
 {
+	const struct flash_parameters *fpar = flash_get_parameters(ctx->info.dev);
+
 	if (!ctx->cache_valid || !ctx->cache_dirty) {
 		/* Either no cached data or cache matches flash data */
 		return 0;
 	}
 
-	if (flash_erase(ctx->info.dev, ctx->cached_addr, ctx->page_size) < 0) {
-		return -EIO;
+	if (!fpar->skip_erase) {
+		if (flash_erase(ctx->info.dev, ctx->cached_addr, ctx->page_size) < 0) {
+			return -EIO;
+		}
 	}
 
 	/* write data to flash */

--- a/dts/bindings/flash_controller/zephyr,sim-flash.yaml
+++ b/dts/bindings/flash_controller/zephyr,sim-flash.yaml
@@ -15,3 +15,7 @@ properties:
     description: |
       Memory region used by the simulated flash memory. If this option is used
       the memory that is used by the simulated flash memory is not erased.
+  skip-erase:
+    type: boolean
+    description: |
+      If set, indicates that erase of flash can be skipped.

--- a/include/zephyr/drivers/flash.h
+++ b/include/zephyr/drivers/flash.h
@@ -57,6 +57,7 @@ struct flash_pages_layout {
 struct flash_parameters {
 	const size_t write_block_size;
 	uint8_t erase_value; /* Byte value of erased flash */
+	const bool skip_erase;
 };
 
 /**

--- a/tests/subsys/fs/fat_fs_api/boards/native_sim.overlay
+++ b/tests/subsys/fs/fat_fs_api/boards/native_sim.overlay
@@ -6,6 +6,7 @@
 
 &flashcontroller0 {
 	reg = <0x00000000 DT_SIZE_K(2048)>;
+	skip-erase;
 };
 
 &flash0 {


### PR DESCRIPTION
A short POC of how flash devices could receive a skip erase flag for devices that do not require erase.
Support is added for the flash simulator,
Flashdisk is modified,
Tested on tests/subsys/fs/fat_fs_api
To disable skip erase the property can be removed in native_sim.overlay.