### PR TITLE
drivers: display: convert st7735r to MIPI DBI API

### DIFF
--- a/boards/shields/st7735r/st7735r_ada_160x128.overlay
+++ b/boards/shields/st7735r/st7735r_ada_160x128.overlay
@@ -4,38 +4,48 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/mipi_dbi/mipi_dbi.h>
+
 / {
 	chosen {
 		zephyr,display = &st7735r_st7735r_ada_160x128;
+	};
+
+	mipi_dbi_st7735r_ada_160x128 {
+		compatible = "zephyr,mipi-dbi-spi";
+		spi-dev = <&arduino_spi>;
+		dc-gpios = <&arduino_header 15 GPIO_ACTIVE_HIGH>;	/* D9 */
+		reset-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>;	/* D8 */
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		st7735r_st7735r_ada_160x128: st7735r@0 {
+			compatible = "sitronix,st7735r";
+			mipi-max-frequency = <20000000>;
+			mipi-mode = <MIPI_DBI_MODE_SPI_4WIRE>;
+			reg = <0>;
+			width = <160>;
+			height = <128>;
+			x-offset = <0>;
+			y-offset = <0>;
+			madctl = <0x60>;
+			colmod = <0x55>;
+			vmctr1 = <0x0e>;
+			pwctr1 = [a2 02 84];
+			pwctr2 = [c5];
+			pwctr3 = [0a 00];
+			pwctr4 = [8a 2a];
+			pwctr5 = [8a ee];
+			frmctr1 = [01 2c 2d];
+			frmctr2 = [01 2c 2d];
+			frmctr3 = [01 2c 2d 01 2c 2d];
+			gamctrp1 = [02 1c 07 12 37 32 29 2d 29 25 2b 39 00 01 03 10];
+			gamctrn1 = [03 1d 07 06 2e 2c 29 2d 2e 2e 37 3f 00 00 02 10];
+		};
 	};
 };
 
 &arduino_spi {
 	status = "okay";
 	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>;	/* D10 */
-
-	st7735r_st7735r_ada_160x128: st7735r@0 {
-		compatible = "sitronix,st7735r";
-		spi-max-frequency = <20000000>;
-		reg = <0>;
-		cmd-data-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>;	/* D9 */
-		reset-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>;	/* D8 */
-		width = <160>;
-		height = <128>;
-		x-offset = <0>;
-		y-offset = <0>;
-		madctl = <0x60>;
-		colmod = <0x55>;
-		vmctr1 = <0x0e>;
-		pwctr1 = [a2 02 84];
-		pwctr2 = [c5];
-		pwctr3 = [0a 00];
-		pwctr4 = [8a 2a];
-		pwctr5 = [8a ee];
-		frmctr1 = [01 2c 2d];
-		frmctr2 = [01 2c 2d];
-		frmctr3 = [01 2c 2d 01 2c 2d];
-		gamctrp1 = [02 1c 07 12 37 32 29 2d 29 25 2b 39 00 01 03 10];
-		gamctrn1 = [03 1d 07 06 2e 2c 29 2d 2e 2e 37 3f 00 00 02 10];
-	};
 };

--- a/boards/sipeed/longan_nano/longan_nano-common.dtsi
+++ b/boards/sipeed/longan_nano/longan_nano-common.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/mipi_dbi/mipi_dbi.h>
 
 / {
 	chosen {
@@ -65,6 +66,50 @@
 		sw0 = &button_boot0;
 		watchdog0 = &fwdgt;
 	};
+
+	mipi_dbi {
+		compatible = "zephyr,mipi-dbi-spi";
+		reset-gpios = <&gpiob 1 GPIO_ACTIVE_LOW>;
+		dc-gpios = <&gpiob 0 GPIO_ACTIVE_HIGH>;
+		spi-dev = <&spi0>;
+		write-only;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		/* longan nano has LCD with st7735s controller.
+		 * It can use with st7735r driver.
+		 */
+		lcd0: lcd@0 {
+			compatible = "sitronix,st7735r";
+			reg = <0>;
+			status = "okay";
+			width = <160>;
+			height = <80>;
+			inversion-on;
+			rgb-is-inverted;
+			x-offset = <1>;
+			y-offset = <26>;
+			pwctr1 = [62 02 04];
+			pwctr2 = [C0];
+			pwctr3 = [0D 00];
+			pwctr4 = [8D 6A];
+			pwctr5 = [8D EE];
+			invctr = <3>;
+			frmctr1 = [05 3A 3A];
+			frmctr2 = [05 3A 3A];
+			frmctr3 = [05 3A 3A 05 3A 3A];
+			vmctr1 = <14>;
+			gamctrp1 = [10 0E 02 03 0E 07 02 07 0A 12 27 37 00 0D 0E 10];
+			gamctrn1 = [10 0E 03 03 0F 06 02 08 0A 13 26 36 00 0D 0E 10];
+			colmod = <5>;
+			madctl = <120>;
+			caset = [00 01 00 a0];
+			raset = [00 1a 00 69];
+
+			mipi-mode = <MIPI_DBI_MODE_SPI_4WIRE>;
+			mipi-max-frequency = <4000000>;
+		};
+	};
 };
 
 &gpioa {
@@ -109,41 +154,6 @@
 	pinctrl-names = "default";
 
 	cs-gpios = <&gpiob 2 GPIO_ACTIVE_LOW>;
-
-	/* longan nano has LCD with st7735s controller.
-	 * It can use with st7735r driver.
-	 */
-	lcd0: lcd@0 {
-		compatible = "sitronix,st7735r";
-		reg = <0>;
-		status = "okay";
-		reset-gpios = <&gpiob 1 GPIO_ACTIVE_LOW>;
-		cmd-data-gpios = <&gpiob 0 GPIO_ACTIVE_LOW>;
-		width = <160>;
-		height = <80>;
-		inversion-on;
-		rgb-is-inverted;
-		x-offset = <1>;
-		y-offset = <26>;
-		pwctr1 = [62 02 04];
-		pwctr2 = [C0];
-		pwctr3 = [0D 00];
-		pwctr4 = [8D 6A];
-		pwctr5 = [8D EE];
-		invctr = <3>;
-		frmctr1 = [05 3A 3A];
-		frmctr2 = [05 3A 3A];
-		frmctr3 = [05 3A 3A 05 3A 3A];
-		vmctr1 = <14>;
-		gamctrp1 = [10 0E 02 03 0E 07 02 07 0A 12 27 37 00 0D 0E 10];
-		gamctrn1 = [10 0E 03 03 0F 06 02 08 0A 13 26 36 00 0D 0E 10];
-		colmod = <5>;
-		madctl = <120>;
-		caset = [00 01 00 a0];
-		raset = [00 1a 00 69];
-
-		spi-max-frequency = <4000000>;
-	};
 };
 
 &spi1 {

--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -204,6 +204,49 @@ Controller Area Network (CAN)
 Display
 =======
 
+* ST7735R based displays now use the MIPI DBI driver class. These displays
+  must now be declared within a MIPI DBI driver wrapper device, which will
+  manage interfacing with the display. Note that the `cmd-data-gpios` pin has
+  changed polarity with this update, to align better with the new
+  `dc-gpios` name. For an example, see below:
+
+  .. code-block:: devicetree
+
+    /* Legacy ST7735R display definition */
+    &spi0 {
+        st7735r: st7735r@0 {
+            compatible = "sitronix,st7735r";
+            reg = <0>;
+            spi-max-frequency = <32000000>;
+            reset-gpios = <&gpio0 6 GPIO_ACTIVE_LOW>;
+            cmd-data-gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+            ...
+        };
+    };
+
+    /* New display definition with MIPI DBI device */
+
+    #include <zephyr/dt-bindings/mipi_dbi/mipi_dbi.h>
+
+    ...
+
+    mipi_dbi {
+        compatible = "zephyr,mipi-dbi-spi";
+        reset-gpios = <&gpio0 6 GPIO_ACTIVE_LOW>;
+        dc-gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
+        spi-dev = <&spi0>;
+        #address-cells = <1>;
+        #size-cells = <0>;
+
+        st7735r: st7735r@0 {
+            compatible = "sitronix,st7735r";
+            reg = <0>;
+            mipi-max-frequency = <32000000>;
+            mipi-mode = <MIPI_DBI_MODE_SPI_4WIRE>;
+            ...
+        };
+    };
+
 Enhanced Serial Peripheral Interface (eSPI)
 ===========================================
 

--- a/drivers/display/Kconfig.st7735r
+++ b/drivers/display/Kconfig.st7735r
@@ -7,6 +7,6 @@ config ST7735R
 	bool "ST7735R/ST7735S display driver"
 	default y
 	depends on DT_HAS_SITRONIX_ST7735R_ENABLED
-	select SPI
+	select MIPI_DBI
 	help
 	  Enable driver for ST7735R/ST7735S display driver.

--- a/drivers/mipi_dbi/mipi_dbi_spi.c
+++ b/drivers/mipi_dbi/mipi_dbi_spi.c
@@ -66,21 +66,21 @@ static int mipi_dbi_spi_write_helper(const struct device *dev,
 
 	if (dbi_config->mode == MIPI_DBI_MODE_SPI_3WIRE &&
 	    IS_ENABLED(CONFIG_MIPI_DBI_SPI_3WIRE)) {
-		struct spi_config tmp_cfg;
-		/* We have to emulate 3 wire mode by packing the data/command
-		 * bit into the upper bit of the SPI transfer.
-		 * switch SPI to 9 bit mode, and write the transfer
+		/* 9 bit word mode must be used, as the command/data bit
+		 * is stored before the data word.
 		 */
-		memcpy(&tmp_cfg, &dbi_config->config, sizeof(tmp_cfg));
-		tmp_cfg.operation &= ~SPI_WORD_SIZE_MASK;
-		tmp_cfg.operation |= SPI_WORD_SET(9);
+		if ((dbi_config->config.operation & SPI_WORD_SIZE_MASK)
+		    != SPI_WORD_SET(9)) {
+			return -ENOTSUP;
+		}
 		buffer.buf = &data->spi_byte;
-		buffer.len = 1;
+		buffer.len = 2;
 
 		/* Send command */
 		if (cmd_present) {
 			data->spi_byte = cmd;
-			ret = spi_write(config->spi_dev, &tmp_cfg, &buf_set);
+			ret = spi_write(config->spi_dev, &dbi_config->config,
+					&buf_set);
 			if (ret < 0) {
 				goto out;
 			}
@@ -88,7 +88,8 @@ static int mipi_dbi_spi_write_helper(const struct device *dev,
 		/* Write data, byte by byte */
 		for (size_t i = 0; i < len; i++) {
 			data->spi_byte = MIPI_DBI_DC_BIT | data_buf[i];
-			ret = spi_write(config->spi_dev, &tmp_cfg, &buf_set);
+			ret = spi_write(config->spi_dev, &dbi_config->config,
+					&buf_set);
 			if (ret < 0) {
 				goto out;
 			}

--- a/dts/bindings/display/sitronix,st7735r.yaml
+++ b/dts/bindings/display/sitronix,st7735r.yaml
@@ -5,26 +5,9 @@ description: ST7735R/ST7735S 160x128 (max) display controller
 
 compatible: "sitronix,st7735r"
 
-include: [spi-device.yaml, display-controller.yaml]
+include: [mipi-dbi-spi-device.yaml, display-controller.yaml]
 
 properties:
-  reset-gpios:
-    type: phandle-array
-    description: RESET pin.
-
-      The RESET pin of ST7735R is active low.
-      If connected directly the MCU pin should be configured
-      as active low.
-
-  cmd-data-gpios:
-    type: phandle-array
-    required: true
-    description: D/CX pin.
-
-      The D/CX pin of ST7735R is active low (transmission command byte).
-      If connected directly the MCU pin should be configured
-      as active low.
-
   x-offset:
     type: int
     required: true

--- a/tests/drivers/build_all/display/app.overlay
+++ b/tests/drivers/build_all/display/app.overlay
@@ -11,6 +11,7 @@
  */
 
 #include <zephyr/dt-bindings/led/led.h>
+#include <zephyr/dt-bindings/mipi_dbi/mipi_dbi.h>
 
 / {
 	test {
@@ -55,6 +56,20 @@
 				pgc = [F0 06 0B 07 06 05 2E 33 47 3A 17 16 2E 31];
 				ngc = [F0 09 0D 09 08 23 2E 33 46 38 13 13 2C 32];
 			};
+
+			test_mipi_dbi_st7735r: st7735t@2 {
+				compatible = "sitronix,st7735r";
+				mipi-max-frequency = <250000000>;
+				mipi-mode = <MIPI_DBI_MODE_SPI_4WIRE>;
+				reg = <2>;
+				/* Arbitrary values */
+				x-offset = <0>;
+				y-offset = <0>;
+				gamctrp1 = [10 0E 02 03 0E 07 02 07 0A 12 27 37 00 0D 0E 10];
+				gamctrn1 = [10 0E 03 03 0F 06 02 08 0A 13 26 36 00 0D 0E 10];
+				width = <160>;
+				height = <128>;
+			};
 		};
 
 
@@ -67,7 +82,7 @@
 			clock-frequency = <2000000>;
 
 			/* one entry for every devices at spi.dtsi */
-			cs-gpios = <&test_gpio 0 0 &test_gpio 0 1>;
+			cs-gpios = <&test_gpio 0 0 &test_gpio 0 1 &test_gpio 0 2>;
 
 			test_spi_gc9x01x: gc9x01x@1 {
 				compatible = "galaxycore,gc9x01x";


### PR DESCRIPTION
This PR converts the ST7735R to the MIPI DBI API. Boards using this display have also been updated.

Additionally, this PR adds support for a new API in the MIPI DBI driver, `mipi_dbi_release`. This API mirrors the functionality of `spi_release`, and is added because some displays depend on the `SPI_HOLD_ON_CS` functionality in order to work correctly- therefore, the MIPI DBI API needs to offer a similar ability to hold the CS signal low.


~In draft until https://github.com/zephyrproject-rtos/zephyr/pull/71454 merges~