### PR TITLE
tests: net: buf: Fix cloning of zero-sized buffers

### DIFF
--- a/subsys/net/buf.c
+++ b/subsys/net/buf.c
@@ -519,7 +519,7 @@ struct net_buf *net_buf_clone(struct net_buf *buf, k_timeout_t timeout)
 	 * we need to allocate new data and make a copy.
 	 */
 	if (pool->alloc->cb->ref && !(buf->flags & NET_BUF_EXTERNAL_DATA)) {
-		clone->__buf = data_ref(buf, buf->__buf);
+		clone->__buf = buf->__buf ? data_ref(buf, buf->__buf) : NULL;
 		clone->data = buf->data;
 		clone->len = buf->len;
 		clone->size = buf->size;

--- a/tests/net/buf/src/main.c
+++ b/tests/net/buf/src/main.c
@@ -452,6 +452,21 @@ ZTEST(net_buf_tests, test_net_buf_clone_no_ref_count)
 	zassert_equal(destroy_called, 2, "Incorrect destroy callback count");
 }
 
+/* Regression test: Zero sized buffers must be copy-able, not trigger a NULL pointer dereference */
+ZTEST(net_buf_tests, test_net_buf_clone_reference_counted_zero_sized_buffer)
+{
+	struct net_buf *buf, *clone;
+
+	buf = net_buf_alloc_len(&var_pool, 0, K_NO_WAIT);
+	zassert_not_null(buf, "Failed to get buffer");
+
+	clone = net_buf_clone(buf, K_NO_WAIT);
+	zassert_not_null(clone, "Failed to clone zero sized buffer");
+
+	net_buf_unref(buf);
+	net_buf_unref(clone);
+}
+
 ZTEST(net_buf_tests, test_net_buf_fixed_pool)
 {
 	struct net_buf *buf;


### PR DESCRIPTION
For zero sized buffers, instead of pointing to a buffer, net_buf->__buf
is NULL. For this reason, when cloning a buffer, the code needs to check
__buf before dereferencing it.