### PR TITLE
Lwm2m first block reset prev transfer

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -2055,11 +2055,15 @@ static int parse_write_op(struct lwm2m_message *msg, uint16_t format)
 
 		block_num = GET_BLOCK_NUM(block_opt);
 
-		/* Try to retrieve existing block context. If one not exists,
-		 * and we've received first block, allocate new context.
+		/*
+		 * RFC7959: 2.5. Using the Block1 Option
+		 * If we've received first block, replace old context (if any) with a new one.
 		 */
 		r = get_block_ctx(&msg->path, &block_ctx);
-		if (r < 0 && block_num == 0) {
+		if (block_num == 0) {
+			/* free block context for previous incomplete transfer */
+			free_block_ctx(block_ctx);
+
 			r = init_block_ctx(&msg->path, &block_ctx);
 		}
 

--- a/subsys/net/lib/lwm2m/lwm2m_obj_swmgmt.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_swmgmt.c
@@ -209,7 +209,7 @@ static void set_sw_update_state(struct lwm2m_swmgmt_data *instance, uint8_t stat
 						   instance->obj_inst_id,
 						   SWMGMT_UPDATE_STATE_ID);
 
-	ret = lwm2m_set_u8(obj_path, state);
+	ret = lwm2m_set_u8(&obj_path, state);
 	if (ret != 0) {
 		LOG_ERR("Could not set state");
 	}


### PR DESCRIPTION
While testing the LwM2M firmware object in push mode, I found out that it is not possible to interrupt an ongoing block-wise transfer.

This PR allows to restart an ongoing block-wise transfer that might be interrupted for multiple reasons, including:
- need to transfer a different file
- LwM2M registration timed-out and a new full registration is performed (block transfers don't continue across full registrastrations)

Additionally, this PR fixes a build error when using the LwM2M SW Management object. 

Fix: https://github.com/zephyrproject-rtos/zephyr/issues/70591