### PR TITLE
dts: intel_adsp: ace: update host dma copy alignment

### DIFF
--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -460,7 +460,7 @@
 			dma-channels = <9>;
 			dma-buf-addr-alignment = <128>;
 			dma-buf-size-alignment = <32>;
-			dma-copy-alignment = <32>;
+			dma-copy-alignment = <16>;
 			power-domain = <&io0_domain>;
 			status = "okay";
 		};
@@ -472,7 +472,7 @@
 			dma-channels = <10>;
 			dma-buf-addr-alignment = <128>;
 			dma-buf-size-alignment = <32>;
-			dma-copy-alignment = <32>;
+			dma-copy-alignment = <16>;
 			power-domain = <&io0_domain>;
 			status = "okay";
 		};
@@ -484,7 +484,7 @@
 			dma-channels = <9>;
 			dma-buf-addr-alignment = <128>;
 			dma-buf-size-alignment = <32>;
-			dma-copy-alignment = <32>;
+			dma-copy-alignment = <16>;
 			power-domain = <&hst_domain>;
 			interrupts = <13 0 0>;
 			interrupt-parent = <&ace_intc>;
@@ -498,7 +498,7 @@
 			dma-channels = <10>;
 			dma-buf-addr-alignment = <128>;
 			dma-buf-size-alignment = <32>;
-			dma-copy-alignment = <32>;
+			dma-copy-alignment = <16>;
 			power-domain = <&hst_domain>;
 			interrupts = <12 0 0>;
 			interrupt-parent = <&ace_intc>;

--- a/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
@@ -371,7 +371,7 @@
 			dma-channels = <9>;
 			dma-buf-addr-alignment = <128>;
 			dma-buf-size-alignment = <32>;
-			dma-copy-alignment = <32>;
+			dma-copy-alignment = <16>;
 			interrupts = <13 0 0>;
 			interrupt-parent = <&ace_intc>;
 			status = "okay";
@@ -384,7 +384,7 @@
 			dma-channels = <11>;
 			dma-buf-addr-alignment = <128>;
 			dma-buf-size-alignment = <32>;
-			dma-copy-alignment = <32>;
+			dma-copy-alignment = <16>;
 			interrupts = <12 0 0>;
 			interrupt-parent = <&ace_intc>;
 			status = "okay";
@@ -405,7 +405,7 @@
 			dma-channels = <9>;
 			dma-buf-addr-alignment = <128>;
 			dma-buf-size-alignment = <32>;
-			dma-copy-alignment = <32>;
+			dma-copy-alignment = <16>;
 			status = "okay";
 		};
 
@@ -416,7 +416,7 @@
 			dma-channels = <11>;
 			dma-buf-addr-alignment = <128>;
 			dma-buf-size-alignment = <32>;
-			dma-copy-alignment = <32>;
+			dma-copy-alignment = <16>;
 			status = "okay";
 		};
 


### PR DESCRIPTION
This will update host dma copy alignment as with current high value in some cases it was not possible to fully empty the buffer