### PR TITLE
samples/bluetooth/unicast_audio_server: Fix nrf5340bsim board name

### DIFF
--- a/samples/bluetooth/unicast_audio_server/README.rst
+++ b/samples/bluetooth/unicast_audio_server/README.rst
@@ -78,6 +78,6 @@ Building for a simulated nrf5340bsim
 
 .. zephyr-app-commands::
    :zephyr-app: samples/bluetooth/unicast_audio_server/
-   :board: nrf5340bsim_nrf5340_cpuapp
+   :board: nrf5340bsim/nrf5340/cpuapp
    :goals: build
    :west-args: --sysbuild


### PR DESCRIPTION
The nrf5340bsim_nrf5340_cpuapp hwmv1 board name was replaced with nrf5340bsim/nrf5340/cpuapp in hwmv2.
This example in the docs with the old name was missed. Let's fix it