### PR TITLE
boards nrf5340bsim: Remove hwmv1 compatible board definitions

### DIFF
--- a/boards/deprecated.cmake
+++ b/boards/deprecated.cmake
@@ -446,6 +446,12 @@ set(nrf5340_audio_dk_nrf5340_cpuapp_ns_DEPRECATED
 set(nrf5340_audio_dk_nrf5340_cpunet_DEPRECATED
     nrf5340_audio_dk/nrf5340/cpunet
 )
+set(nrf5340bsim_nrf5340_cpuapp_DEPRECATED
+    nrf5340bsim/nrf5340/cpuapp
+)
+set(nrf5340bsim_nrf5340_cpunet_DEPRECATED
+    nrf5340bsim/nrf5340/cpunet
+)
 set(nrf5340dk_nrf5340_cpuapp_DEPRECATED
     nrf5340dk/nrf5340/cpuapp
 )

--- a/boards/native/nrf_bsim/Kconfig.nrf5340bsim_nrf5340_cpuapp
+++ b/boards/native/nrf_bsim/Kconfig.nrf5340bsim_nrf5340_cpuapp
@@ -1,5 +1,0 @@
-# Copyright (c) 2024 Nordic Semiconductor ASA
-# SPDX-License-Identifier: Apache-2.0
-
-config BOARD_NRF5340BSIM_NRF5340_CPUAPP
-	select SOC_POSIX

--- a/boards/native/nrf_bsim/Kconfig.nrf5340bsim_nrf5340_cpunet
+++ b/boards/native/nrf_bsim/Kconfig.nrf5340bsim_nrf5340_cpunet
@@ -1,5 +1,0 @@
-# Copyright (c) 2024 Nordic Semiconductor ASA
-# SPDX-License-Identifier: Apache-2.0
-
-config BOARD_NRF5340BSIM_NRF5340_CPUNET
-	select SOC_POSIX

--- a/boards/native/nrf_bsim/board.yml
+++ b/boards/native/nrf_bsim/board.yml
@@ -9,15 +9,3 @@ boards:
   # Note this is referring to the real SOC yaml, but we only use its name and cpu-cluster definition
   # In practice this board uses the same native SOC (SOC_POSIX) as the nrf52_bsim
   - name: nrf5340
-
-# These two board definitions below, together with their respective
-# Kconfig.nrf5340bsim_nrf5340_cpu[app,net] exist for backwards compatibility with hwmv1 usage
-# Once all their usage in tree is removed, or aliases have been introduced they can be removed.
-- name: nrf5340bsim_nrf5340_cpuapp
-  vendor: zephyr
-  socs:
-  - name: native
-- name: nrf5340bsim_nrf5340_cpunet
-  vendor: zephyr
-  socs:
-  - name: native

--- a/tests/bsim/bluetooth/audio_samples/broadcast_audio_sink/Kconfig.sysbuild
+++ b/tests/bsim/bluetooth/audio_samples/broadcast_audio_sink/Kconfig.sysbuild
@@ -7,5 +7,4 @@ config NATIVE_SIMULATOR_PRIMARY_MCU_INDEX
 	int
 	# Let's pass the test arguments to the application MCU test
 	# otherwise by default they would have gone to the net core.
-	default 0 if $(BOARD) = "nrf5340bsim_nrf5340_cpuapp"
 	default 0 if $(BOARD) = "nrf5340bsim"

--- a/tests/bsim/bluetooth/audio_samples/unicast_audio_client/Kconfig.sysbuild
+++ b/tests/bsim/bluetooth/audio_samples/unicast_audio_client/Kconfig.sysbuild
@@ -7,5 +7,4 @@ config NATIVE_SIMULATOR_PRIMARY_MCU_INDEX
 	int
 	# Let's pass the test arguments to the application MCU test
 	# otherwise by default they would have gone to the net core.
-	default 0 if $(BOARD) = "nrf5340bsim_nrf5340_cpuapp"
 	default 0 if $(BOARD) = "nrf5340bsim"

--- a/tests/bsim/bluetooth/ll/bis/Kconfig.sysbuild
+++ b/tests/bsim/bluetooth/ll/bis/Kconfig.sysbuild
@@ -11,5 +11,4 @@ config NATIVE_SIMULATOR_PRIMARY_MCU_INDEX
 	int
 	# Let's pass the test arguments to the application MCU test
 	# otherwise by default they would have gone to the net core.
-	default 0 if $(BOARD) = "nrf5340bsim_nrf5340_cpuapp"
 	default 0 if $(BOARD) = "nrf5340bsim"

--- a/tests/bsim/bluetooth/ll/cis/Kconfig.sysbuild
+++ b/tests/bsim/bluetooth/ll/cis/Kconfig.sysbuild
@@ -11,5 +11,4 @@ config NATIVE_SIMULATOR_PRIMARY_MCU_INDEX
 	int
 	# Let's pass the test arguments to the application MCU test
 	# otherwise by default they would have gone to the net core.
-	default 0 if $(BOARD) = "nrf5340bsim_nrf5340_cpuapp"
 	default 0 if $(BOARD) = "nrf5340bsim"

--- a/tests/bsim/bluetooth/ll/conn/Kconfig.sysbuild
+++ b/tests/bsim/bluetooth/ll/conn/Kconfig.sysbuild
@@ -11,5 +11,4 @@ config NATIVE_SIMULATOR_PRIMARY_MCU_INDEX
 	int
 	# Let's pass the test arguments to the application MCU test
 	# otherwise by default they would have gone to the net core.
-	default 0 if $(BOARD) = "nrf5340bsim_nrf5340_cpuapp"
 	default 0 if $(BOARD) = "nrf5340bsim"


### PR DESCRIPTION
Final PR in the cleanup of the nrf5340bsim hwmv1 board names use

* Using the old hwmv1 board names is not supported anymore. So we don't need to handle them specially in the sysbuild
    files.
* To use this functionality one must now use the hwmv2 naming    (nrf5340bsim/nrf5340/cpu{app,net}).
    The old hwmv1 compatible names for these targets, were left provisionally while all tests in tree were ported. 
    That being now done, these old names can be removed.

----

~Note: This requires, and sits on top of:~
* #70564

~Only the last 2 commits are relevant in this PR~
