### PR TITLE
Add missing configuration for Bluetooth and storage partition for settings

### DIFF
--- a/boards/nordic/nrf54h20dk/Kconfig.defconfig
+++ b/boards/nordic/nrf54h20dk/Kconfig.defconfig
@@ -1,0 +1,17 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_NRF54H20DK_NRF54H20_CPUAPP
+
+choice BT_HCI_BUS_TYPE
+	default BT_HCI_IPC if BT
+endchoice
+
+endif # BOARD_NRF54H20DK_NRF54H20_CPUAPP
+
+if BOARD_NRF54H20DK_NRF54H20_CPURAD
+
+config BT_CTLR
+	default y if BT
+
+endif # BOARD_NRF54H20DK_NRF54H20_CPURAD

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-memory_map.dtsi
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-memory_map.dtsi
@@ -181,4 +181,18 @@
 			reg = <0x126000 DT_SIZE_K(64)>;
 		};
 	};
+
+	cpuapp_rw_partitions: cpuapp-rw-partitions {
+		compatible = "nordic,owned-partitions", "fixed-partitions";
+		status = "disabled";
+		perm-read;
+		perm-write;
+		perm-secure;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		storage_partition: partition@136000 {
+			reg = <0x136000 DT_SIZE_K(24)>;
+		};
+	};
 };

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
@@ -130,6 +130,10 @@
 	status = "okay";
 };
 
+&cpuapp_rw_partitions {
+	status = "okay";
+};
+
 &cpuppr_vpr {
 	execution-memory = <&cpuppr_code_data>;
 	source-memory = <&cpuppr_code_partition>;

--- a/samples/bluetooth/hci_ipc/boards/nrf54h20dk_nrf54h20_cpurad.overlay
+++ b/samples/bluetooth/hci_ipc/boards/nrf54h20dk_nrf54h20_cpurad.overlay
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,bt-hci-ipc = &ipc0;
+	};
+};
+
+ipc0: &cpuapp_cpurad_ipc {
+	status = "okay";
+};
+
+&cpuapp_cpurad_ram0x_region {
+	status = "okay";
+};
+
+&cpurad_bellboard {
+	status = "okay";
+};
+
+&cpuapp_bellboard {
+	status = "okay";
+};


### PR DESCRIPTION
There is missing default Kconfig configuration related with Bluetooth protocol for nRF54h20 DK.
There is missing storage partition configuration for settings subsystem for nRF54h20 DK.
There is missing nRF54H20 DK configuration in hci_ipc Bluetooth sample.

Add missing items.