### PR TITLE
MAINTAINERS: Tweak nRF BSIM exclude filter

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2806,8 +2806,11 @@ nRF BSIM:
     - boards/native/nrf_bsim/
     - tests/boards/nrf52_bsim/
     - tests/bsim/
-  files-exclude:
-    - tests/bsim/*/
+    - doc/develop/test/bsim.rst
+    - .github/workflows/bsim-tests*
+  files-regex-exclude:
+    - tests\/bsim\/.*\/.*\.([ch]|conf)
+    - tests\/bsim\/.*\/(CMakeLists|Kconfig).*
   labels:
     - "platform: nRF BSIM"
   tests:


### PR DESCRIPTION
The exclusion filter for bsim tests is currently too broad.
There is "infrastructure" files inside these folders (not just in the top level folder) and users may add more.
So let's change the filter to exclude tests source, cmake and kconfig files, but catch the rest.