### PR TITLE
Restrict encoding of source code files [scripts: compliance: add a file encoding check]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ BinaryFiles.txt
 BoardYml.txt
 Checkpatch.txt
 DevicetreeBindings.txt
+FileEncoding.txt
 GitDiffCheck.txt
 Gitlint.txt
 Identity.txt

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1448,6 +1448,58 @@ class KeepSorted(ComplianceTest):
             with open(file, "r") as fp:
                 self.check_file(file, fp)
 
+class FileEncoding(ComplianceTest):
+    """
+    Check the encoding for source files.
+    """
+    name = "FileEncoding"
+    doc = "Check the encoding for source files."
+    path_hint = "<git-top>"
+
+    MATCH_FILES = [
+            r'.*\.c$',
+            r'.*\.h$',
+            ]
+
+    def match_file(self, file):
+        for match in self.MATCH_FILES:
+            if re.match(match, file):
+                return True
+
+        return False
+
+    def check_file(self, file, fp):
+        if not self.match_file(str(file)):
+            return
+
+        for line_num, line in enumerate(fp.readlines(), start=1):
+            line = line.strip()
+
+            if not line:
+                continue
+
+            if "Copyright" in line:
+                continue
+
+            if not line.isascii():
+                #self.fmtd_failure("error", self.name, file, line_num,
+                #                  desc="Invalid encoding")
+                print("!!!", file, line)
+
+    def run(self):
+        path = Path(ZEPHYR_BASE)
+        for file in path.glob("**/*"):
+            # hack hack
+            if not file.is_file():
+                continue
+            with open(file, "r") as fp:
+                self.check_file(file, fp)
+            # hack hack
+
+        for file in get_files(filter="d"):
+            with open(file, "r") as fp:
+                self.check_file(file, fp)
+
 def init_logs(cli_arg):
     # Initializes logging
 


### PR DESCRIPTION
## Introduction

Add a compliance check to limit the use of non-ASCII character in source code files.

### Problem description

There's few issue to keep the encoding of source code files under control, accessibility concerns for users of editors with no support for extended characters (terminals, exitors or even braille reader), incoherent usage of punctuations (... vs …, u vs µ, ' or ’ etc), emojis in code (which is what started this).

### Proposed change

Add a compliance check to flag these automatically, only allow selected exception such as copyright text (detected as lines that cotains the word "Copyright".

Limit the check to C source code files and Kconfig/CMake files, mainly because the top concern is these ending up in log messages and other things that lands in a terminal, but also extended characters are somewhat accepted in documentation, emails list and other stuff that is probably not worth tracking down individually.

Any opinions?

The PR contains the proposed code for checking this, hacked to check all the files, if we want to go ahead with this I'll obviously fix all of them before proceeding.

List: https://gist.github.com/fabiobaltieri/44c3639556bea390860b89b73383f048