### PR TITLE
net: if: Set default interface name if needed

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -5244,14 +5244,20 @@ void net_if_init(void)
 	net_tc_tx_init();
 
 	STRUCT_SECTION_FOREACH(net_if, iface) {
+#if defined(CONFIG_NET_INTERFACE_NAME)
+		memset(net_if_get_config(iface)->name, 0,
+		       sizeof(iface->config.name));
+#endif
 
 		init_iface(iface);
 
 #if defined(CONFIG_NET_INTERFACE_NAME)
-		memset(net_if_get_config(iface)->name, 0,
-		       sizeof(iface->config.name));
-
-		set_default_name(iface);
+		/* If the driver did not set the name, then set
+		 * a default name for the network interface.
+		 */
+		if (net_if_get_config(iface)->name[0] == '\0') {
+			set_default_name(iface);
+		}
 #endif
 
 		if_count++;


### PR DESCRIPTION
If the driver does not set the interface name, then set a default name for it.

This is related to recent fix in commit dceff4a98fed9cf93d711c703658a6f8a3f70fd7 where the name initialization ordering was changed. Now I saw a case where the name set in the driver init is overwritten by default name. The solution is simple, if the driver does not set the name, then the default name can be set. For some reason I missed this simple solution earlier.
