### PR TITLE
modules: hal_nordic: Add missing nrfx_config entries for nRF54L15

### DIFF
--- a/modules/hal_nordic/nrfx/nrfx_config_nrf54l15_enga_application.h
+++ b/modules/hal_nordic/nrfx/nrfx_config_nrf54l15_enga_application.h
@@ -250,6 +250,33 @@
 #endif
 
 /**
+ * @brief NRFX_GRTC_CONFIG_SLEEP_ALLOWED
+ *
+ * Boolean. Accepted values: 0 and 1.
+ */
+#ifndef NRFX_GRTC_CONFIG_SLEEP_ALLOWED
+#define NRFX_GRTC_CONFIG_SLEEP_ALLOWED 0
+#endif
+
+/**
+ * @brief NRFX_GRTC_CONFIG_AUTOEN
+ *
+ * Boolean. Accepted values: 0 and 1.
+ */
+#ifndef NRFX_GRTC_CONFIG_AUTOEN
+#define NRFX_GRTC_CONFIG_AUTOEN 0
+#endif
+
+/**
+ * @brief NRFX_GRTC_CONFIG_AUTOSTART
+ *
+ * Boolean. Accepted values: 0 and 1.
+ */
+#ifndef NRFX_GRTC_CONFIG_AUTOSTART
+#define NRFX_GRTC_CONFIG_AUTOSTART 1
+#endif
+
+/**
  * @brief NRFX_GRTC_CONFIG_NUM_OF_CC_CHANNELS
  *
  * Integer value.


### PR DESCRIPTION
Add nrfx_grtc related entries that were introduced in nrfx 3.4.0, especially NRFX_GRTC_CONFIG_AUTOSTART that should be by default set to 1.