### PR TITLE
drivers: serial: rpi_pico: Enable uart FIFO

### DIFF
--- a/drivers/serial/uart_rpi_pico.c
+++ b/drivers/serial/uart_rpi_pico.c
@@ -191,7 +191,6 @@ static int uart_rpi_init(const struct device *dev)
 	data->uart_config.parity = UART_CFG_PARITY_NONE;
 	data->uart_config.stop_bits = UART_CFG_STOP_BITS_1;
 	uart_rpi_set_format(dev, &data->uart_config);
-	hw_clear_bits(&uart_hw->lcr_h, UART_UARTLCR_H_FEN_BITS);
 	uart_hw->dr = 0U;
 
 	if (data->uart_config.flow_ctrl == UART_CFG_FLOW_CTRL_RTS_CTS) {


### PR DESCRIPTION
A few lines above this change explicitly enable the UART FIFO.  Then this line, goes and disables it.  This seems to be from a workaround where the parity and stop bits are not coming in correctly in the config.  Fixing that will be another patch.  But, the FIFO should always be enabled.  This is visible when trying to use bit rates that are reasonably fast.  Even in IRQ mode, with a sufficient bit rate, bytes are readily dropped.

Tested on a Sparkfun Promicro rp2040 board.