### PR TITLE
west: openocd: find path intree

### DIFF
--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
@@ -81,6 +81,9 @@ class HardwareAdapter(DeviceAdapter):
             elif runner == 'openocd' and self.device_config.product == 'EDBG CMSIS-DAP':
                 extra_args.append('--cmd-pre-init')
                 extra_args.append(f'cmsis_dap_serial {board_id}')
+            elif runner == "openocd" and self.device_config.product == "LPC-LINK2 CMSIS-DAP":
+                extra_args.append("--cmd-pre-init")
+                extra_args.append(f'adapter serial {board_id}')
             elif runner == 'jlink':
                 base_args.append(f'--tool-opt=-SelectEmuBySN {board_id}')
             elif runner == 'stm32cubeprogrammer':

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -516,6 +516,9 @@ class DeviceHandler(Handler):
                     elif runner == "openocd" and product == "EDBG CMSIS-DAP":
                         command_extra_args.append("--cmd-pre-init")
                         command_extra_args.append("cmsis_dap_serial %s" % board_id)
+                    elif runner == "openocd" and product == "LPC-LINK2 CMSIS-DAP":
+                        command_extra_args.append("--cmd-pre-init")
+                        command_extra_args.append("adapter serial %s" % board_id)
                     elif runner == "jlink":
                         command.append("--tool-opt=-SelectEmuBySN  %s" % board_id)
                     elif runner == "linkserver":

--- a/scripts/west_commands/runners/openocd.py
+++ b/scripts/west_commands/runners/openocd.py
@@ -11,6 +11,7 @@ import re
 
 from os import path
 from pathlib import Path
+from zephyr_ext_common import ZEPHYR_BASE
 
 try:
     from elftools.elf.elffile import ELFFile
@@ -40,7 +41,14 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
                  target_handle=DEFAULT_OPENOCD_TARGET_HANDLE):
         super().__init__(cfg)
 
-        support = path.join(cfg.board_dir, 'support')
+        if not path.exists(cfg.board_dir):
+            # try to find the board support in-tree
+            cfg_board_path = path.normpath(cfg.board_dir)
+            _temp_path = cfg_board_path.split("boards/")[1]
+            support = path.join(ZEPHYR_BASE, "boards", _temp_path, 'support')
+        else:
+            support = path.join(cfg.board_dir, 'support')
+
 
         if not config:
             default = path.join(support, 'openocd.cfg')


### PR DESCRIPTION
when run package from another PC, the openocd path may not the same, so try to use ZEPHYR_BASE when
not aligned
and add LPC CMSIS-DAP support