### PR TITLE
samples: external_lib: Include `--target` in exported build flags

### DIFF
--- a/samples/application_development/external_lib/CMakeLists.txt
+++ b/samples/application_development/external_lib/CMakeLists.txt
@@ -19,8 +19,12 @@ zephyr_get_system_include_directories_for_lang_as_string(C system_includes)
 zephyr_get_compile_definitions_for_lang_as_string(       C definitions)
 zephyr_get_compile_options_for_lang_as_string(           C options)
 
+if(DEFINED CMAKE_C_COMPILER_TARGET)
+  set(target_flag "--target=${CMAKE_C_COMPILER_TARGET}")
+endif()
+
 set(external_project_cflags
-  "${includes} ${definitions} ${options} ${system_includes}"
+  "${target_flag} ${includes} ${definitions} ${options} ${system_includes}"
   )
 
 include(ExternalProject)


### PR DESCRIPTION
Appropriately setting the `--target` flag is necessary when using clang and building for a target other than the default. Zephyr generally accomplishes this by setting the `CMAKE_<LANG>_COMPILER_TARGET` variables and allowing cmake to automatically provide the `--target` flag when building.

For the external_lib sample, however, cmake can't add the flag and it was not otherwise exported. As such, clang typically threw errors when building this sample for any non-default targets due to mismatches between target-specific flags and the default target.

To fix this, ensure we select the correct target by checking if CMAKE_C_COMPILER_TARGET has been defined and adding `--target=<triple>` to the list of flags that are exported if so.