### PR TITLE
drivers: i3c: i3c_mcux: Fix bug in do_one_xfer

### DIFF
--- a/drivers/i3c/i3c_mcux.c
+++ b/drivers/i3c/i3c_mcux.c
@@ -1031,7 +1031,7 @@ static int mcux_i3c_do_one_xfer(I3C_Type *base, struct mcux_i3c_data *data,
 		ret = mcux_i3c_do_one_xfer_write(base, buf, buf_sz, no_ending);
 	}
 
-	if (ret) {
+	if (ret < 0) {
 		goto out_one_xfer;
 	}
 


### PR DESCRIPTION
Error check was incorrect, causing wait for complete not to be done. This can result in emit stop not
working on writes because controller won't do the stop if it is still busy processing transmit.