### PR TITLE
boards: nxp: mr_canhubk3: add devicetree nodes for CAN LEDs

### DIFF
--- a/boards/nxp/mr_canhubk3/doc/index.rst
+++ b/boards/nxp/mr_canhubk3/doc/index.rst
@@ -100,6 +100,20 @@ led1 / user_led1_green   Green  PTA27  FXIO D5 / EMIOS1 CH10 / EMIOS2 CH10
 led2 / user_led1_blue    Blue   PTE12  FXIO D8 / EMIOS1 CH5
 =======================  =====  =====  ===================================
 
+In addition to the RGB LED, the MR-CANHUBK3 board has six red LEDs, each located
+next to one of the CAN connectors:
+
+=======================  =====  =====  ===================================
+Devicetree node          Color  Pin    Pin Functions
+=======================  =====  =====  ===================================
+can_led0                 Red    PTC18  FXIO D6 / FXIO D12 / EMIOS2 CH12
+can_led1                 Red    PTE5   FXIO D7 / EMIOS1 CH5 / EMIOS0 CH 19
+can_led2                 Red    PTD20  EMIOS1 CH17 / EMIOS2 CH0
+can_led3                 Red    PTB24  FXIO D5 / EMIOS1 CH20 / EMIOS2 CH20
+can_led4                 Red    PTB26  FXIO D7 / EMIOS1 CH22 / EMIOS2 CH22
+can_led5                 Red    PTD31  FXIO D6 / EMIOS2 CH22
+=======================  =====  =====  ===================================
+
 The user can control the LEDs in any way. An output of ``0`` illuminates the LED.
 
 Buttons

--- a/boards/nxp/mr_canhubk3/mr_canhubk3.dts
+++ b/boards/nxp/mr_canhubk3/mr_canhubk3.dts
@@ -60,6 +60,30 @@
 			gpios = <&gpioe_l 14 GPIO_ACTIVE_LOW>;
 			label = "User RGB LED1 RED";
 		};
+		can_led0: can_led0 {
+			gpios = <&gpioc_h 2 GPIO_ACTIVE_LOW>;
+			label = "CAN LED0";
+		};
+		can_led1: can_led1 {
+			gpios = <&gpioe_l 5 GPIO_ACTIVE_LOW>;
+			label = "CAN LED1";
+		};
+		can_led2: can_led2 {
+			gpios = <&gpiod_h 4 GPIO_ACTIVE_LOW>;
+			label = "CAN LED2";
+		};
+		can_led3: can_led3 {
+			gpios = <&gpiob_h 8 GPIO_ACTIVE_LOW>;
+			label = "CAN LED3";
+		};
+		can_led4: can_led4 {
+			gpios = <&gpiob_h 10 GPIO_ACTIVE_LOW>;
+			label = "CAN LED4";
+		};
+		can_led5: can_led5 {
+			gpios = <&gpiod_h 15 GPIO_ACTIVE_LOW>;
+			label = "CAN LED5";
+		};
 	};
 
 	/* gpio-leds and pwm-leds are the same RGB LED and cannot be used at the same time. */
@@ -201,7 +225,11 @@
 	status = "okay";
 };
 
-/* Enable gpio to control the CAN transceivers */
+/* Enable gpio to control the CAN transceivers and LEDs */
+
+&gpiob_h {
+	status = "okay";
+};
 
 &gpioc_h {
 	status = "okay";


### PR DESCRIPTION
Add devicetree nodes for the six red CAN LEDs present on the NXP MR-CANHUBK344 board.