### PR TITLE
doc: board_porting: Update hierarchy presentation

### DIFF
--- a/doc/hardware/porting/board_porting.rst
+++ b/doc/hardware/porting/board_porting.rst
@@ -70,16 +70,10 @@ complete conversion reference.
 Hardware support hierarchy
 **************************
 
-Zephyr's hardware support hierarchy has the following levels, from most to least
-specific:
-
-- :term:`board`, which has one or more
-- :term:`SoC`, each of which optionally belong to a
-- :term:`SoC series`, which in turn may optionally belong to an
-- :term:`SoC family`. Each SoC has one or more
-- :term:`CPU cluster`, each containing one or more
-- :term:`CPU core`, of a particular
-- :term:`architecture`
+Zephyr's hardware support is based on a series of hierarchical abstractions.
+Primarily, each :term:`board` has one or more :term:`SoC`.
+Each SoC can be optionally classed into an :term:`SoC series`, which in turn may optionally belong to an :term:`SoC family`.
+Each SoC has one or more :term:`CPU cluster`, each containing one or more :term:`CPU core` of a particular :term:`architecture`.
 
 You can visualize the hierarchy in the diagram below:
 


### PR DESCRIPTION
Update the presentation of the hardware hierarchy description so that it does not appear to have missing words at the end of the bullet points, by using a paragraph instead. And tweak the wording slightly.