### PR TITLE
input: Add absolute input code for multitouch slot

### DIFF
--- a/include/zephyr/dt-bindings/input/input-event-codes.h
+++ b/include/zephyr/dt-bindings/input/input-event-codes.h
@@ -232,6 +232,7 @@
  */
 #define INPUT_ABS_BRAKE 0x0a            /**< Absolute brake position */
 #define INPUT_ABS_GAS 0x09              /**< Absolute gas position */
+#define INPUT_ABS_MT_SLOT 0x2f          /**< Absolute multitouch slot identifier */
 #define INPUT_ABS_RUDDER 0x07           /**< Absolute rudder position */
 #define INPUT_ABS_RX 0x03               /**< Absolute rotation around X axis */
 #define INPUT_ABS_RY 0x04               /**< Absolute rotation around Y axis */


### PR DESCRIPTION
To support multitouch, input devices can report an absolute value to identify the specific slot to which the subsequent data is linked. Add a new code for `INPUT_ABS_MT_SLOT` for this purpose.