### PR TITLE
drivers: misc: devmux: Include sys/types.h for better libc compatibility

### DIFF
--- a/include/zephyr/drivers/misc/devmux/devmux.h
+++ b/include/zephyr/drivers/misc/devmux/devmux.h
@@ -13,6 +13,7 @@
 #define INCLUDE_ZEPHYR_DRIVERS_MISC_DEVMUX_H_
 
 #include <stdint.h>
+#include <sys/types.h>
 
 #include <zephyr/device.h>
 #include <zephyr/kernel.h>


### PR DESCRIPTION
ssize_t seems to be defined in sys/types.h which was incidentally being included into devmux.h when building with picolibc (see #70632 for details). However, this file was not included in the same way when using minimal libc, resulting in build failures that ssize_t was an unknown type.

As ssize_t is directly used in devmux.h, include sys/types.h to avoid this issue and enable building with minimal libc.

Fixes: #70632