### PR TITLE
doc: posix: remove unneeded notes about XSI_THREADS_EXT

### DIFF
--- a/doc/services/portability/posix/aep/index.rst
+++ b/doc/services/portability/posix/aep/index.rst
@@ -84,7 +84,7 @@ Realtime Controller System Profile (PSE52)
     POSIX_SIGNALS,, :ref:`†<posix_undefined_behaviour>`
     POSIX_SINGLE_PROCESS, yes,
     POSIX_THREADS_BASE, yes, :ref:`†<posix_undefined_behaviour>`
-    XSI_THREADS_EXT, yes, :ref:`†<posix_undefined_behaviour>`
+    XSI_THREADS_EXT, yes,
 
 .. csv-table:: PSE52 Option Requirements
    :header: Symbol, Support, Remarks
@@ -145,7 +145,7 @@ Dedicated Realtime System Profile (PSE53)
     POSIX_SIGNAL_JUMP,, :ref:`†<posix_undefined_behaviour>`
     POSIX_SINGLE_PROCESS, yes,
     POSIX_THREADS_BASE, yes, :ref:`†<posix_undefined_behaviour>`
-    XSI_THREADS_EXT, yes, :ref:`†<posix_undefined_behaviour>`
+    XSI_THREADS_EXT, yes,
 
 .. csv-table:: PSE53 Option Requirements
    :header: Symbol, Support, Remarks


### PR DESCRIPTION
Previously, XSI_THREADS_EXT included a note aboutundefined behaviour. However, the required functions pthread_attr_getstack(), pthread_attr_setstack(), pthread_getconcurrency(), and pthread_setconcurrency() are all conformant.

Remove the unneeded note (all of them)

(fixes those missed in #70528)