### PR TITLE
samples: bluetooth: mesh: fix sample for esp32_devkitc_wroom

### DIFF
--- a/samples/bluetooth/mesh/Kconfig
+++ b/samples/bluetooth/mesh/Kconfig
@@ -1,0 +1,15 @@
+# Copyright (c) 2024 Andreas Kurz
+# SPDX-License-Identifier: Apache-2.0
+
+menu "BLE Mesh sample settings"
+
+config BLE_MESH_SAMPLE_ENABLE_SELF_PROVISIONING
+	bool "Enable self provisioning"
+	default y
+	help
+	  This will allow self provisioning with arbitrary keys
+	  on button press if not already provisioned.
+
+endmenu
+
+source "Kconfig.zephyr"

--- a/samples/bluetooth/mesh/boards/esp32_devkitc_wroom.conf
+++ b/samples/bluetooth/mesh/boards/esp32_devkitc_wroom.conf
@@ -1,0 +1,9 @@
+# Enable legacy support
+CONFIG_BT_EXT_ADV_LEGACY_SUPPORT=y
+CONFIG_BT_MESH_ADV_LEGACY=y
+
+# Enable entropy generator
+CONFIG_ENTROPY_GENERATOR=y
+
+# Disable self-provisioning
+CONFIG_BLE_MESH_SAMPLE_ENABLE_SELF_PROVISIONING=n

--- a/samples/bluetooth/mesh/src/main.c
+++ b/samples/bluetooth/mesh/src/main.c
@@ -325,13 +325,9 @@ static int gen_onoff_send(bool val)
 	return bt_mesh_model_send(&models[3], &ctx, &buf, NULL, NULL);
 }
 
-static void button_pressed(struct k_work *work)
+#ifdef CONFIG_BLE_MESH_SAMPLE_ENABLE_SELF_PROVISIONING
+static void self_provision_device(void)
 {
-	if (bt_mesh_is_provisioned()) {
-		(void)gen_onoff_send(!onoff.val);
-		return;
-	}
-
 	/* Self-provision with an arbitrary address.
 	 *
 	 * NOTE: This should never be done in a production environment.
@@ -372,6 +368,25 @@ static void button_pressed(struct k_work *work)
 	models[3].keys[0] = 0;
 
 	printk("Provisioned and configured!\n");
+}
+#endif
+
+static void button_pressed(struct k_work *work)
+{
+	bool is_provisioned = bt_mesh_is_provisioned();
+
+#ifdef CONFIG_BLE_MESH_SAMPLE_ENABLE_SELF_PROVISIONING
+	if (!is_provisioned) {
+		self_provision_device();
+		return;
+	}
+#endif
+
+	if (is_provisioned) {
+		(void)gen_onoff_send(!onoff.val);
+	} else {
+		printk("Must be provisioned before using!\n");
+	}
 }
 
 static void bt_ready(int err)


### PR DESCRIPTION
While playing around with BLE Mesh on the esp32 wroom I found some issues why the device is not showing up in Mesh provisioing apps.

One was the self provisioning feature of the sample which interferes with the BOOT button on reset after flashing the image.
The other one is that I had to enable the legacy advertising to be able to see this board in Mesh provisioing apps (I tried around 3 or 4 different ones).

These changes are designed to be backwards compatible as self provisioning is enabled by default and the custom settings went into the board configuration file for the esp32 wroom to allow building and flashing this example with ease.