### PR TITLE
Support NXP LPADC and regulator(VREF) in MCXN

### DIFF
--- a/boards/nxp/frdm_mcxn947/board.c
+++ b/boards/nxp/frdm_mcxn947/board.c
@@ -205,6 +205,11 @@ static int frdm_mcxn947_init(void)
 	flexspi_clock_set_freq(MCUX_FLEXSPI_CLK, MHZ(50));
 #endif
 
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(vref), okay)
+	CLOCK_EnableClock(kCLOCK_Vref);
+	SPC_EnableActiveModeAnalogModules(SPC0, kSPC_controlVref);
+#endif
+
 	/* Set SystemCoreClock variable. */
 	SystemCoreClock = CLOCK_INIT_CORE_CLOCK;
 

--- a/boards/nxp/frdm_mcxn947/board.c
+++ b/boards/nxp/frdm_mcxn947/board.c
@@ -210,6 +210,11 @@ static int frdm_mcxn947_init(void)
 	SPC_EnableActiveModeAnalogModules(SPC0, kSPC_controlVref);
 #endif
 
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(lpadc0), okay)
+	CLOCK_SetClkDiv(kCLOCK_DivAdc0Clk, 1U);
+	CLOCK_AttachClk(kFRO_HF_to_ADC0);
+#endif
+
 	/* Set SystemCoreClock variable. */
 	SystemCoreClock = CLOCK_INIT_CORE_CLOCK;
 

--- a/boards/nxp/frdm_mcxn947/doc/index.rst
+++ b/boards/nxp/frdm_mcxn947/doc/index.rst
@@ -86,6 +86,8 @@ The FRDM-MCXN947 board configuration supports the following hardware features:
 +-----------+------------+-------------------------------------+
 | VREF      | on-chip    | REGULATOR                           |
 +-----------+------------+-------------------------------------+
+| ADC       | on-chip    | adc                                 |
++-----------+------------+-------------------------------------+
 
 Targets available
 ==================

--- a/boards/nxp/frdm_mcxn947/doc/index.rst
+++ b/boards/nxp/frdm_mcxn947/doc/index.rst
@@ -84,6 +84,8 @@ The FRDM-MCXN947 board configuration supports the following hardware features:
 +-----------+------------+-------------------------------------+
 | USDHC     | on-chip    | sdhc                                |
 +-----------+------------+-------------------------------------+
+| VREF      | on-chip    | REGULATOR                           |
++-----------+------------+-------------------------------------+
 
 Targets available
 ==================

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947-pinctrl.dtsi
@@ -148,4 +148,13 @@
 			input-enable;
 		};
 	};
+	pinmux_lpadc0: pinmux_lpadc0 {
+		group0 {
+			pinmux = <ADC0_A2_PIO4_23>,
+				<ADC0_A1_PIO4_15>,
+				<ADC0_B1_PIO4_19>;
+			slew-rate = "fast";
+			drive-strength = "low";
+		};
+	};
 };

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
@@ -183,3 +183,8 @@
 	pinctrl-names = "default", "slow", "med";
 	no-1-8-v;
 };
+
+&lpadc0 {
+	pinctrl-0 = <&pinmux_lpadc0>;
+	pinctrl-names = "default";
+};

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.dts
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.dts
@@ -157,3 +157,7 @@
 &vref {
 	status = "okay";
 };
+
+&lpadc0 {
+	status = "okay";
+};

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.dts
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.dts
@@ -153,3 +153,7 @@
 		status = "okay";
 	};
 };
+
+&vref {
+	status = "okay";
+};

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.yaml
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.yaml
@@ -25,4 +25,5 @@ supported:
   - counter
   - sdhc
   - regulator
+  - adc
 vendor: nxp

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.yaml
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.yaml
@@ -24,4 +24,5 @@ supported:
   - pwm
   - counter
   - sdhc
+  - regulator
 vendor: nxp

--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -278,6 +278,14 @@ Serial
 Timer
 =====
 
+regulator
+=========
+
+* The :dtcompatible:`nxp,vref` driver no longer supports the ground selection function,
+  as this setting should not be modified by the user. The DT property ``nxp,ground-select``
+  has been removed, users should remove this property from their devicetree if it is present.
+  (:github:`70642`)
+
 Bluetooth
 *********
 

--- a/drivers/regulator/regulator_nxp_vref.c
+++ b/drivers/regulator/regulator_nxp_vref.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 NXP
+ * Copyright 2023-2024 NXP
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -165,7 +165,7 @@ static int regulator_nxp_vref_get_voltage(const struct device *dev,
 	/* Linear range index is the register value */
 	idx = (base->UTRIM & VREF_UTRIM_TRIM2V1_MASK) >> VREF_UTRIM_TRIM2V1_SHIFT;
 
-	ret = linear_range_get_value(&utrim_range, base->UTRIM, volt_uv);
+	ret = linear_range_get_value(&utrim_range, idx, volt_uv);
 
 	return ret;
 }

--- a/drivers/regulator/regulator_nxp_vref.c
+++ b/drivers/regulator/regulator_nxp_vref.c
@@ -24,7 +24,6 @@ struct regulator_nxp_vref_data {
 struct regulator_nxp_vref_config {
 	struct regulator_common_config common;
 	VREF_Type *base;
-	uint8_t gnd_sel;
 	uint16_t buf_start_delay;
 	uint16_t bg_start_time;
 };
@@ -183,15 +182,9 @@ static const struct regulator_driver_api api = {
 
 static int regulator_nxp_vref_init(const struct device *dev)
 {
-	const struct regulator_nxp_vref_config *config = dev->config;
-	VREF_Type *base = config->base;
 	int ret;
 
 	regulator_common_data_init(dev);
-
-	/* Select ground */
-	base->CSR &= ~VREF_CSR_REFL_GRD_SEL_MASK;
-	base->CSR |= config->gnd_sel;
 
 	ret = regulator_nxp_vref_disable(dev);
 	if (ret < 0) {
@@ -207,7 +200,6 @@ static int regulator_nxp_vref_init(const struct device *dev)
 	static const struct regulator_nxp_vref_config config_##inst = {		\
 		.common = REGULATOR_DT_INST_COMMON_CONFIG_INIT(inst),		\
 		.base = (VREF_Type *) DT_INST_REG_ADDR(inst),			\
-		.gnd_sel = DT_INST_ENUM_IDX_OR(inst, nxp_ground_select, 0),	\
 		.buf_start_delay = DT_INST_PROP(inst,				\
 				nxp_buffer_startup_delay_us),			\
 		.bg_start_time = DT_INST_PROP(inst,				\

--- a/dts/arm/nxp/nxp_mcxn94x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn94x_common.dtsi
@@ -796,6 +796,17 @@
 		max-bus-freq = <52000000>;
 		min-bus-freq = <400000>;
 	};
+
+	vref: vref@111000 {
+		compatible = "nxp,vref";
+		regulator-name = "mcxn94x-vref";
+		reg = <0x111000 0x14>;
+		status = "disabled";
+		nxp,buffer-startup-delay-us = <400>;
+		nxp,bandgap-startup-time-us = <20>;
+		regulator-min-microvolt = <1000000>;
+		regulator-max-microvolt = <2100000>;
+	};
 };
 
 &systick {

--- a/dts/arm/nxp/nxp_mcxn94x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn94x_common.dtsi
@@ -807,6 +807,39 @@
 		regulator-min-microvolt = <1000000>;
 		regulator-max-microvolt = <2100000>;
 	};
+
+	lpadc0: lpadc@10d000 {
+		compatible = "nxp,lpc-lpadc";
+		reg = <0x10d000 0x1000>;
+		interrupts = <45 0>;
+		status = "disabled";
+		clk-divider = <1>;
+		clk-source = <0>;
+		voltage-ref= <1>;
+		calibration-average = <128>;
+		power-level = <0>;
+		offset-value-a = <0>;
+		offset-value-b = <0>;
+		#io-channel-cells = <1>;
+		clocks = <&syscon MCUX_LPADC1_CLK>;
+		nxp,reference-supply = <&vref>;
+	};
+
+	lpadc1: lpadc@10e000 {
+		compatible = "nxp,lpc-lpadc";
+		reg = <0x10e000 0x1000>;
+		interrupts = <46 0>;
+		status = "disabled";
+		clk-divider = <1>;
+		clk-source = <0>;
+		voltage-ref= <0>;
+		calibration-average = <128>;
+		power-level = <1>;
+		offset-value-a = <0>;
+		offset-value-b = <0>;
+		#io-channel-cells = <1>;
+		clocks = <&syscon MCUX_LPADC2_CLK>;
+	};
 };
 
 &systick {

--- a/dts/bindings/regulator/nxp,vref.yaml
+++ b/dts/bindings/regulator/nxp,vref.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 NXP
+# Copyright 2023-2024 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 description: NXP VREF SOC peripheral
@@ -19,12 +19,6 @@ include:
 properties:
   reg:
     required: true
-
-  nxp,ground-select:
-    type: string
-    enum:
-      - "VREFL3V" # 0
-      - "VSSA" # 1
 
   nxp,buffer-startup-delay-us:
     type: int

--- a/samples/drivers/adc/adc_dt/boards/frdm_mcxn947_mcxn947_cpu0.overlay
+++ b/samples/drivers/adc/adc_dt/boards/frdm_mcxn947_mcxn947_cpu0.overlay
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/adc/mcux-lpadc.h>
+
+/ {
+	zephyr,user {
+		/* adjust channel number according to pinmux in board.dts */
+		io-channels = <&lpadc0 0>, <&lpadc0 1>;
+	};
+};
+
+&lpadc0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	/*
+	 * To use this sample:
+	 * LPADC0 CH1A and CH1B are set up in differential mode (B-A)
+	 * - Connect LPADC0 CH1A signal to voltage between 0~1.8V (J8 pin 20)
+	 * - Connect LPADC0 CH1B signal to voltage between 0~1.8V (J8 pin 24)
+	 * LPADC0 CH2A is set up in single ended mode
+	 * - Connect LPADC0 CH2A signal to voltage between 0~1.8V (J8 pin 28)
+	 */
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_EXTERNAL1";
+		zephyr,vref-mv = <1800>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <13>;
+		zephyr,input-positive = <MCUX_LPADC_CH1B>;
+		zephyr,input-negative = <MCUX_LPADC_CH1A>;
+	};
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_EXTERNAL1";
+		zephyr,vref-mv = <1800>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <MCUX_LPADC_CH2A>;
+	};
+};

--- a/tests/drivers/adc/adc_api/boards/frdm_mcxn947_mcxn947_cpu0.overlay
+++ b/tests/drivers/adc/adc_api/boards/frdm_mcxn947_mcxn947_cpu0.overlay
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 NXP
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/adc/mcux-lpadc.h>
+
+/ {
+	zephyr,user {
+		io-channels = <&lpadc0 0>, <&lpadc0 1>;
+	};
+};
+
+&lpadc0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_EXTERNAL1";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <MCUX_LPADC_CH1A>;
+	};
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_EXTERNAL1";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <MCUX_LPADC_CH2A>;
+	};
+};

--- a/tests/drivers/regulator/voltage/boards/frdm_mcxn947_mcxn947_cpu0.overlay
+++ b/tests/drivers/regulator/voltage/boards/frdm_mcxn947_mcxn947_cpu0.overlay
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 NXP
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/adc/mcux-lpadc.h>
+#include <zephyr/dt-bindings/regulator/nxp_vref.h>
+
+/* To do this test, connect LPADC0 channel 2A(J8 pin 28) to VREF_OUT (TP1) */
+
+/ {
+	resources: resources {
+		compatible = "test-regulator-voltage";
+		regulators = <&vref>;
+		tolerance-microvolt = <10000>;
+		set-read-delay-ms = <1>;
+		adc-avg-count = <10>;
+		io-channels = <&lpadc0 0>;
+		min-microvolt = <1000000>;
+		max-microvolt = <2100000>;
+	};
+};
+
+&vref {
+	regulator-initial-mode = <NXP_VREF_MODE_INTERNAL_REGULATOR>;
+};
+
+&lpadc0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	/* In this case, the LPADC reference source cannot be set to VREFO,
+	 * switch the reference source to VDD_ANA.
+	 */
+	voltage-ref= <2>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_EXTERNAL0";
+		zephyr,vref-mv = <3300>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <MCUX_LPADC_CH2A>;
+	};
+};


### PR DESCRIPTION
Support NXP LPADC and regulator(VREF) in MCXN.
The VREF provides the bias current for LPADC, and the VREF output could be selected as LPADC reference.
In this PR, the LPADC selects the VREF output as the reference, and the VREF output is 1.8v. The user could use the new property **nxp,reference-supply-value** of LPADC to set the VREF output.