### PR TITLE
boards: nxp: mr_canhubk3: add ssd1306 display devicetree node

### DIFF
--- a/boards/nxp/mr_canhubk3/doc/index.rst
+++ b/boards/nxp/mr_canhubk3/doc/index.rst
@@ -214,6 +214,8 @@ P4.3       PTD14  LPI2C0_SCL
 P4.4       PTD13  LPI2C0_SDA
 =========  =====  ============
 
+The accompanying display board can be connected to ``lpi2c0`` via connector ``P4``.
+
 ADC
 ===
 

--- a/boards/nxp/mr_canhubk3/mr_canhubk3.dts
+++ b/boards/nxp/mr_canhubk3/mr_canhubk3.dts
@@ -27,6 +27,7 @@
 		zephyr,shell-uart = &lpuart2;
 		zephyr,flash-controller = &mx25l6433f;
 		zephyr,canbus = &flexcan0;
+		zephyr,display = &ssd1306;
 	};
 
 	aliases {
@@ -378,6 +379,22 @@
 	pinctrl-0 = <&lpi2c0_default>;
 	pinctrl-names = "default";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
+	status = "okay";
+
+	ssd1306: ssd1306@3c {
+		compatible = "solomon,ssd1306fb";
+		reg = <0x3c>;
+		width = <128>;
+		height = <32>;
+		segment-offset = <0>;
+		page-offset = <0>;
+		display-offset = <0>;
+		multiplex-ratio = <31>;
+		segment-remap;
+		com-invdir;
+		com-sequential;
+		prechargep = <0x22>;
+	};
 };
 
 &lpi2c1 {

--- a/boards/nxp/mr_canhubk3/mr_canhubk3.yaml
+++ b/boards/nxp/mr_canhubk3/mr_canhubk3.yaml
@@ -20,4 +20,5 @@ supported:
   - netif:eth
   - pwm
   - dma
+  - display
 vendor: nxp


### PR DESCRIPTION
Add devicetree node for the accompanying, ssd1306-based display board connected to connector P4.