### PR TITLE
net: if: Make sure no other interface has same name

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -5130,6 +5130,18 @@ int net_if_set_name(struct net_if *iface, const char *buf)
 		return -ENAMETOOLONG;
 	}
 
+	STRUCT_SECTION_FOREACH(net_if, iface_check) {
+		if (iface_check == iface) {
+			continue;
+		}
+
+		if (memcmp(net_if_get_config(iface_check)->name,
+			   buf,
+			   name_len + 1) == 0) {
+			return -EALREADY;
+		}
+	}
+
 	/* Copy string and null terminator */
 	memcpy(net_if_get_config(iface)->name, buf, name_len + 1);
 

--- a/tests/net/iface/src/main.c
+++ b/tests/net/iface/src/main.c
@@ -1301,6 +1301,16 @@ ZTEST(net_iface, test_interface_name)
 	ret = net_if_set_name(iface, name);
 	zassert_equal(ret, 0, "Unexpected value (%d) returned", ret);
 
+	name = "abc0";
+	ret = net_if_set_name(iface2, name);
+	zassert_equal(ret, -EALREADY, "Unexpected value (%d) returned", ret);
+
+	name = "abc";
+	ret = net_if_set_name(iface2, name);
+	zassert_equal(ret, 0, "Unexpected value (%d) returned", ret);
+
+	name = "abc0";
+
 	ret = net_if_get_name(iface, buf, 1);
 	zassert_equal(ret, -ERANGE, "Unexpected value (%d) returned", ret);
 
@@ -1308,7 +1318,8 @@ ZTEST(net_iface, test_interface_name)
 	zassert_equal(ret, -ERANGE, "Unexpected value (%d) returned", ret);
 
 	ret = net_if_get_name(iface, buf, sizeof(buf) - 1);
-	zassert_equal(ret, strlen(name), "Unexpected value (%d) returned", ret);
+	zassert_equal(ret, strlen(name), "Unexpected value (%d) returned, expected %d",
+		      ret, strlen(name));
 
 	ret = net_if_get_by_name(name);
 	zassert_equal(ret, net_if_get_by_iface(iface), "Unexpected value (%d) returned", ret);


### PR DESCRIPTION
When setting a name to a network interface, verify that no other interface has the same name as that would make very difficult to select an interface by a name.