### PR TITLE
doc: Bluetooth: move AutoPTS setup pages

### DIFF
--- a/doc/connectivity/bluetooth/autopts/autopts-linux.rst
+++ b/doc/connectivity/bluetooth/autopts/autopts-linux.rst
@@ -3,9 +3,6 @@
 AutoPTS on Linux
 ################
 
-Overview
-========
-
 This tutorial shows how to setup AutoPTS client on Linux with AutoPTS server running on Windows 10
 virtual machine. Tested with Ubuntu 20.4 and Linux Mint 20.4.
 
@@ -22,8 +19,12 @@ Supported methods to test zephyr bluetooth host:
 
 For running with QEMU or :ref:`native_sim <native_sim>`, see :ref:`bluetooth_qemu_native`.
 
+.. contents::
+    :local:
+    :depth: 2
+
 Setup Linux
-===========================
+===========
 
 Install nrftools (only required in the actual hardware test mode)
 =================================================================

--- a/doc/connectivity/bluetooth/autopts/autopts-win10.rst
+++ b/doc/connectivity/bluetooth/autopts/autopts-win10.rst
@@ -3,13 +3,14 @@
 AutoPTS on Windows 10 with nRF52 board
 #######################################
 
-Overview
-========
-
 This tutorial shows how to setup AutoPTS client and server to run both on
 Windows 10. We use WSL1 with Ubuntu only to build a Zephyr project to
 an elf file, because Zephyr SDK is not available on Windows yet.
 Tutorial covers only nrf52840dk.
+
+.. contents::
+    :local:
+    :depth: 2
 
 Update Windows and drivers
 ===========================

--- a/doc/connectivity/bluetooth/bluetooth-qual.rst
+++ b/doc/connectivity/bluetooth/bluetooth-qual.rst
@@ -3,6 +3,22 @@
 Bluetooth Qualification
 #######################
 
+Qualification setup
+*******************
+
+The Zephyr Bluetooth host can be qualified using Bluetooth's PTS (Profile Tuning
+Suite) software. It is originally a manual process, but is automated by using
+the `AutoPTS automation software <https://github.com/auto-pts/auto-pts>`_.
+
+The setup is described in more details in the pages linked below.
+
+.. toctree::
+   :maxdepth: 1
+
+   autopts/autopts-win10.rst
+   autopts/autopts-linux.rst
+
+
 Qualification Listings
 **********************
 

--- a/doc/connectivity/bluetooth/index.rst
+++ b/doc/connectivity/bluetooth/index.rst
@@ -20,7 +20,5 @@ hardware, as well as portions of a Classical Bluetooth (BR/EDR) Host layer.
    bluetooth-qual.rst
    bluetooth-tools.rst
    bluetooth-dev.rst
-   autopts/autopts-win10.rst
-   autopts/autopts-linux.rst
    api/index.rst
    bluetooth-shell.rst

--- a/doc/connectivity/bluetooth/overview.rst
+++ b/doc/connectivity/bluetooth/overview.rst
@@ -35,10 +35,10 @@ Bluetooth stack.
     * Host-only over UART, SPI, and IPC (shared memory)
     * Combined (Host + Controller)
 
-* Bluetooth-SIG qualified
+* Bluetooth-SIG qualifiable
 
-  * Controller on Nordic Semiconductor hardware
-  * Conformance tests run regularly on all layers
+  * Conformance tests run regularly on all layers (Controller and Host, except
+    BT Classic) on Nordic Semiconductor hardware.
 
 * Bluetooth Low Energy Controller support (LE Link Layer)
 


### PR DESCRIPTION
In preparation of further cleanup commits.
Removes noise in the navigation pane in the rendered docs.

https://builds.zephyrproject.io/zephyr/pr/70656/docs/connectivity/bluetooth/bluetooth-qual.html