### PR TITLE
modules: nanopb: Fix building with upstream c_std_11

### DIFF
--- a/modules/nanopb/Kconfig
+++ b/modules/nanopb/Kconfig
@@ -6,6 +6,8 @@ config ZEPHYR_NANOPB_MODULE
 
 menuconfig NANOPB
 	bool "Nanopb Support"
+	# Nanopb requires c_std_11 compiler features like _Static_assert
+	select REQUIRES_STD_C11
 	help
 	  This option enables the Nanopb library and generator.
 

--- a/submanifests/optional.yaml
+++ b/submanifests/optional.yaml
@@ -22,7 +22,7 @@ manifest:
       groups:
         - optional
     - name: nanopb
-      revision: 65cbefb4695bc7af1cb733ced99618afb3586b20
+      revision: f6187b05a5eaf753faa0e29a5acd77dd0544d474
       path: modules/lib/nanopb
       remote: upstream
       groups:


### PR DESCRIPTION
Enable `c_std_11` compiler features, which is set by upstream `nanopb`.

Depends on #71024