### PR TITLE
driver: ssp: update Intel SSP DAI driver to support dynamic SSP link management

### DIFF
--- a/drivers/dai/intel/ssp/ssp.h
+++ b/drivers/dai/intel/ssp/ssp.h
@@ -316,6 +316,10 @@ struct dai_intel_ssp_plat_fifo_data {
 };
 
 struct dai_intel_ssp_plat_data {
+	uint32_t ssp_index;
+	int acquire_count;
+	bool is_initialized;
+	bool is_power_en;
 	uint32_t base;
 	uint32_t ip_base;
 	uint32_t shim_base;
@@ -330,24 +334,25 @@ struct dai_intel_ssp_plat_data {
 	struct dai_intel_ssp_mn *mn_inst;
 	struct dai_intel_ssp_freq_table *ftable;
 	uint32_t *fsources;
+	uint32_t clk_active;
+	struct dai_intel_ipc3_ssp_params params;
 };
 
 struct dai_intel_ssp_pdata {
 	uint32_t sscr0;
 	uint32_t sscr1;
 	uint32_t psp;
-	uint32_t state[2];
-	uint32_t clk_active;
 	struct dai_config config;
 	struct dai_properties props;
-	struct dai_intel_ipc3_ssp_params params;
 };
 
 struct dai_intel_ssp {
-	uint32_t index;		/**< index */
+	uint32_t dai_index;
+	uint32_t ssp_index;
+	uint32_t state[2];
 	struct k_spinlock lock;	/**< locking mechanism */
 	int sref;		/**< simple ref counter, guarded by lock */
-	struct dai_intel_ssp_plat_data plat_data;
+	struct dai_intel_ssp_plat_data *ssp_plat_data;
 	void *priv_data;
 };
 

--- a/dts/bindings/i2s/intel,ssp-dai.yaml
+++ b/dts/bindings/i2s/intel,ssp-dai.yaml
@@ -1,8 +1,7 @@
-# Copyright (c) 2022 Intel Corporation
-#
+# Copyright (c) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-description: Intel SSP DAI controller
+description: Intel SSP DAI node
 
 compatible: "intel,ssp-dai"
 
@@ -11,18 +10,3 @@ include: base.yaml
 properties:
   reg:
     required: true
-
-  interrupts:
-    required: true
-
-  interrupt-parent:
-    required: true
-
-  dmas:
-    required: true
-
-  dma-names:
-    required: true
-
-  i2svss:
-    type: array

--- a/dts/bindings/i2s/intel,ssp.yaml
+++ b/dts/bindings/i2s/intel,ssp.yaml
@@ -1,0 +1,32 @@
+# Copyright (c) 2024 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: Intel SSP DAI controller
+
+compatible: "intel,ssp"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true
+
+  interrupts:
+    required: true
+
+  interrupt-parent:
+    required: true
+
+  dmas:
+    required: true
+
+  dma-names:
+    required: true
+
+  i2svss:
+    type: array
+
+  ssp-index:
+    type: int
+    required: true

--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -243,10 +243,15 @@
 			status = "okay";
 		};
 
+		sspbase: ssp_base@28800 {
+			compatible = "intel,ssp-sspbase";
+			reg = <0x28800 0x1000>;
+		};
+
 		ssp0: ssp@28000 {
-			compatible = "intel,ssp-dai";
 			#address-cells = <1>;
 			#size-cells = <0>;
+			compatible = "intel,ssp";
 			reg = <0x00028000 0x1000
 				   0x00079C00 0x200>;
 			interrupts = <0x00 0 0>;
@@ -255,16 +260,18 @@
 					&lpgpdma0 3>;
 			dma-names = "tx", "rx";
 			power-domain = <&io0_domain>;
+			ssp-index = <0>;
 			status = "okay";
-		};
 
-		sspbase: ssp_base@28800 {
-			compatible = "intel,ssp-sspbase";
-			reg = <0x28800 0x1000>;
+			ssp00: ssp@0 {
+				compatible = "intel,ssp-dai";
+				status = "okay";
+				reg = <0x0>;
+			};
 		};
 
 		ssp1: ssp@29000 {
-			compatible = "intel,ssp-dai";
+			compatible = "intel,ssp";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x00029000 0x1000
@@ -275,11 +282,18 @@
 					&lpgpdma0 5>;
 			dma-names = "tx", "rx";
 			power-domain = <&io0_domain>;
+			ssp-index = <1>;
 			status = "okay";
+
+			ssp10: ssp@10 {
+				compatible = "intel,ssp-dai";
+				status = "okay";
+				reg = <0x10>;
+			};
 		};
 
 		ssp2: ssp@2a000 {
-			compatible = "intel,ssp-dai";
+			compatible = "intel,ssp";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x0002a000 0x1000
@@ -290,7 +304,14 @@
 					&lpgpdma0 7>;
 			dma-names = "tx", "rx";
 			power-domain = <&io0_domain>;
+			ssp-index = <2>;
 			status = "okay";
+
+			ssp20: ssp@20 {
+				compatible = "intel,ssp-dai";
+				status = "okay";
+				reg = <0x20>;
+			};
 		};
 
 		mem_window0: mem_window@70200 {

--- a/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
@@ -178,7 +178,7 @@
 		};
 
 		ssp0: ssp@28100 {
-			compatible = "intel,ssp-dai";
+			compatible = "intel,ssp";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x00028100 0x1000
@@ -190,11 +190,18 @@
 				&hda_link_in 1>;
 			dma-names = "tx", "rx";
 			power-domain = <&io0_domain>;
+			ssp-index = <0>;
 			status = "okay";
+
+			ssp00: ssp@0 {
+				compatible = "intel,ssp-dai";
+				status = "okay";
+				reg = <0x0>;
+			};
 		};
 
 		ssp1: ssp@29100 {
-			compatible = "intel,ssp-dai";
+			compatible = "intel,ssp";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x00029100 0x1000
@@ -206,11 +213,18 @@
 				&hda_link_in 2>;
 			dma-names = "tx", "rx";
 			power-domain = <&io0_domain>;
+			ssp-index = <1>;
 			status = "okay";
+
+			ssp10: ssp@10 {
+				compatible = "intel,ssp-dai";
+				status = "okay";
+				reg = <0x10>;
+			};
 		};
 
 		ssp2: ssp@2a100 {
-			compatible = "intel,ssp-dai";
+			compatible = "intel,ssp";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x0002a100 0x1000
@@ -222,7 +236,14 @@
 				&hda_link_in 3>;
 			dma-names = "tx", "rx";
 			power-domain = <&io0_domain>;
+			ssp-index = <2>;
 			status = "okay";
+
+			ssp20: ssp@20 {
+				compatible = "intel,ssp-dai";
+				status = "okay";
+				reg = <0x20>;
+			};
 		};
 
 		mem_window0: mem_window@70200 {

--- a/dts/xtensa/intel/intel_adsp_cavs25.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs25.dtsi
@@ -217,7 +217,7 @@
 		};
 
 		ssp0: ssp@77000 {
-			compatible = "intel,ssp-dai";
+			compatible = "intel,ssp";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x00077000 0x200
@@ -227,12 +227,18 @@
 			dmas = <&lpgpdma0 2
 				&lpgpdma0 3>;
 			dma-names = "tx", "rx";
-
+			ssp-index = <0>;
 			status = "okay";
+
+			ssp00: ssp@0 {
+				compatible = "intel,ssp-dai";
+				reg = <0x0>;
+				status = "okay";
+			};
 		};
 
 		ssp1: ssp@77200 {
-			compatible = "intel,ssp-dai";
+			compatible = "intel,ssp";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x00077200 0x200
@@ -242,12 +248,18 @@
 			dmas = <&lpgpdma0 4
 				&lpgpdma0 5>;
 			dma-names = "tx", "rx";
-
+			ssp-index = <1>;
 			status = "okay";
+
+			ssp10: ssp@10 {
+				compatible = "intel,ssp-dai";
+				reg = <0x10>;
+				status = "okay";
+			};
 		};
 
 		ssp2: ssp@77400 {
-			compatible = "intel,ssp-dai";
+			compatible = "intel,ssp";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x00077400 0x200
@@ -257,12 +269,18 @@
 			dmas = <&lpgpdma0 6
 				&lpgpdma0 7>;
 			dma-names = "tx", "rx";
-
+			ssp-index = <2>;
 			status = "okay";
+
+			ssp20: ssp@20 {
+				compatible = "intel,ssp-dai";
+				reg = <0x20>;
+				status = "okay";
+			};
 		};
 
 		ssp3: ssp@77600 {
-			compatible = "intel,ssp-dai";
+			compatible = "intel,ssp";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x00077600 0x200
@@ -272,12 +290,18 @@
 			dmas = <&lpgpdma0 8
 				&lpgpdma0 9>;
 			dma-names = "tx", "rx";
-
+			ssp-index = <3>;
 			status = "okay";
+
+			ssp30: ssp@30 {
+				compatible = "intel,ssp-dai";
+				reg = <0x30>;
+				status = "okay";
+			};
 		};
 
 		ssp4: ssp@77800 {
-			compatible = "intel,ssp-dai";
+			compatible = "intel,ssp";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x00077800 0x200
@@ -287,12 +311,18 @@
 			dmas = <&lpgpdma0 10
 				&lpgpdma0 11>;
 			dma-names = "tx", "rx";
-
+			ssp-index = <4>;
 			status = "okay";
+
+			ssp40: ssp@40 {
+				compatible = "intel,ssp-dai";
+				reg = <0x40>;
+				status = "okay";
+			};
 		};
 
 		ssp5: ssp@77a00 {
-			compatible = "intel,ssp-dai";
+			compatible = "intel,ssp";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x00077A00 0x200
@@ -302,8 +332,14 @@
 			dmas = <&lpgpdma0 12
 				&lpgpdma0 13>;
 			dma-names = "tx", "rx";
-
+			ssp-index = <5>;
 			status = "okay";
+
+			ssp50: ssp@50 {
+				compatible = "intel,ssp-dai";
+				reg = <0x50>;
+				status = "okay";
+			};
 		};
 
 		/*

--- a/dts/xtensa/intel/intel_adsp_cavs25_tgph.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs25_tgph.dtsi
@@ -242,7 +242,7 @@
 		};
 
 		ssp0: ssp@77000 {
-			compatible = "intel,ssp-dai";
+			compatible = "intel,ssp";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x00077000 0x200
@@ -252,12 +252,18 @@
 			dmas = <&lpgpdma0 2
 				&lpgpdma0 3>;
 			dma-names = "tx", "rx";
-
+			ssp-index = <0>;
 			status = "okay";
+
+			ssp00: ssp@0 {
+				compatible = "intel,ssp-dai";
+				reg = <0x0>;
+				status = "okay";
+			};
 		};
 
 		ssp1: ssp@77200 {
-			compatible = "intel,ssp-dai";
+			compatible = "intel,ssp";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x00077200 0x200
@@ -267,12 +273,18 @@
 			dmas = <&lpgpdma0 4
 				&lpgpdma0 5>;
 			dma-names = "tx", "rx";
-
+			ssp-index = <1>;
 			status = "okay";
+
+			ssp10: ssp@10 {
+				compatible = "intel,ssp-dai";
+				reg = <0x10>;
+				status = "okay";
+			};
 		};
 
 		ssp2: ssp@77400 {
-			compatible = "intel,ssp-dai";
+			compatible = "intel,ssp";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x00077400 0x200
@@ -282,8 +294,14 @@
 			dmas = <&lpgpdma0 6
 				&lpgpdma0 7>;
 			dma-names = "tx", "rx";
-
+			ssp-index = <2>;
 			status = "okay";
+
+			ssp20: ssp@20 {
+				compatible = "intel,ssp-dai";
+				reg = <0x20>;
+				status = "okay";
+			};
 		};
 	};
 

--- a/tests/boards/intel_adsp/ssp/src/main.c
+++ b/tests/boards/intel_adsp/ssp/src/main.c
@@ -44,7 +44,7 @@ struct sof_dai_ssp_params {
 } __packed;
 
 static const struct device *const dev_dai_ssp =
-	DEVICE_DT_GET(DT_NODELABEL(ssp0));
+	DEVICE_DT_GET(DT_NODELABEL(ssp00));
 static const struct device *const dev_dma_dw =
 	DEVICE_DT_GET(DT_NODELABEL(lpgpdma0));
 


### PR DESCRIPTION
This commit refactors the Intel SSP DAI driver to support dynamic management of SSP links. The changes include the introduction of a new structure `intel_ssp_link` to encapsulate SSP link-specific data.

Key changes:
- Add new static functions to manage SSP link power.
- Update the DAI SSP configuration functions to use the new link management approach.
- Update device tree bindings and instances to reflect the new SSP link management mechanism.

The new approach allows for more flexible and maintainable management of SSP links.

Related, necessary changes: 

- [ ] https://github.com/thesofproject/sof/pull/8980