### PR TITLE
MAINTAINERS: Add aescolar as collaborator for the C library

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -556,6 +556,7 @@ C library:
   maintainers:
     - stephanosio
   collaborators:
+    - aescolar
     - nashif
     - keith-packard
     - cfriedt


### PR DESCRIPTION
Add aescolar as collaborator for the C library.
Note that as maintainer of the "native" ports,
I have been taking care of the host C library integration in Zephyr.