### PR TITLE
drivers: display: Add definition for display common config (backlight)

### DIFF
--- a/drivers/display/CMakeLists.txt
+++ b/drivers/display/CMakeLists.txt
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_library()
+zephyr_library_sources_ifdef(CONFIG_DISPLAY_BACKLIGHT display_backlight.c)
 zephyr_library_sources_ifdef(CONFIG_DISPLAY_MCUX_ELCDIF	display_mcux_elcdif.c)
 zephyr_library_sources_ifdef(CONFIG_DISPLAY_NRF_LED_MATRIX display_nrf_led_matrix.c)
 zephyr_library_sources_ifdef(CONFIG_DUMMY_DISPLAY	display_dummy.c)

--- a/drivers/display/Kconfig
+++ b/drivers/display/Kconfig
@@ -20,6 +20,7 @@ module = DISPLAY
 module-str = display
 source "subsys/logging/Kconfig.template.log_config"
 
+source "drivers/display/Kconfig.display_backlight"
 source "drivers/display/Kconfig.mcux_elcdif"
 source "drivers/display/Kconfig.microbit"
 source "drivers/display/Kconfig.nrf_led_matrix"

--- a/drivers/display/Kconfig.display_backlight
+++ b/drivers/display/Kconfig.display_backlight
@@ -1,0 +1,21 @@
+# Copyright 2024 Fabian Blatz <fabianblatz@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+config DISPLAY_BACKLIGHT
+	bool
+	help
+	  Enable library used for display backlight drivers.
+
+if DISPLAY_BACKLIGHT
+
+config DISPLAY_BACKLIGHT_CONTROL_ENABLE_GPIO
+	bool "Gpio enable pin for display backlight"
+	help
+	  Enable support for gpio enable pin.
+
+config DISPLAY_BACKLIGHT_CONTROL_PWM
+	bool "Control display brightness via PWM"
+	help
+	  Enable brightness control via external PWM.
+
+endif # DISPLAY_BACKLIGHT

--- a/drivers/display/display_backlight.c
+++ b/drivers/display/display_backlight.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2024 Fabian Blatz <fabianblatz@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/display/display_backlight.h>
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(display_backlight, CONFIG_DISPLAY_LOG_LEVEL);
+
+int display_backlight_init(const struct device *dev)
+{
+	const struct display_backlight_common_config *config = dev->config;
+
+#ifdef CONFIG_DISPLAY_BACKLIGHT_CONTROL_PWM
+	if (!pwm_is_ready_dt(&config->backlight_pwms)) {
+		LOG_ERR("PWM device %s is not ready", config->backlight_pwms.dev->name);
+		return -ENODEV;
+	}
+#endif /* CONFIG_DISPLAY_BACKLIGHT_CONTROL_PWM */
+
+#ifdef CONFIG_DISPLAY_BACKLIGHT_CONTROL_ENABLE_GPIO
+	if (!gpio_is_ready_dt(&config->backlight_enable_gpios)) {
+		LOG_ERR("GPIO device %s is not ready", config->backlight_enable_gpios.port->name);
+		return -ENODEV;
+	}
+
+	if (gpio_pin_configure_dt(&config->backlight_enable_gpios, GPIO_OUTPUT) < 0) {
+		LOG_ERR("Failed to configure GPIO device %s",
+			config->backlight_enable_gpios.port->name);
+		return -EIO;
+	}
+#endif /* CONFIG_DISPLAY_BACKLIGHT_CONTROL_ENABLE_GPIO */
+
+	if (config->default_brightness) {
+		return display_backlight_set_brightness(dev, config->default_brightness);
+	}
+
+	return 0;
+}
+
+int display_backlight_set_brightness(const struct device *dev, uint8_t brightness)
+{
+	const struct display_backlight_common_config *config = dev->config;
+	int ret;
+
+#ifdef CONFIG_DISPLAY_BACKLIGHT_CONTROL_PWM
+	uint32_t duty_cycle = (brightness * config->backlight_pwms.period) / 255;
+
+	ret = pwm_set_pulse_dt(&config->backlight_pwms, duty_cycle);
+	if (ret < 0) {
+		LOG_ERR("Failed to set PWM duty cycle");
+		return ret;
+	}
+#endif /* CONFIG_DISPLAY_BACKLIGHT_CONTROL_PWM */
+
+#ifdef CONFIG_DISPLAY_BACKLIGHT_CONTROL_ENABLE_GPIO
+	ret = gpio_pin_set_dt(&config->backlight_enable_gpios, 1);
+	if (ret < 0) {
+		LOG_ERR("Failed to set GPIO pin");
+		return ret;
+	}
+#endif /* CONFIG_DISPLAY_BACKLIGHT_CONTROL_ENABLE_GPIO */
+
+	return 0;
+}

--- a/dts/bindings/display/display-backlight-common.yaml
+++ b/dts/bindings/display/display-backlight-common.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) 2024 Fabian Blatz <fabianblatz@gmail.com>
+# Common fields for display backlights
+
+include: base.yaml
+
+properties:
+  default-brightness:
+    type: int
+    description: |
+      Brightness applied on display initialization in the range 0-255.
+      If not specified, the default value is 0.
+
+  backlight-enable-gpios:
+    type: phandle-array
+    description: |
+      External GPIO handles for enabling the backlight.
+      The backlight is enabled when the GPIO is set to the active state.
+
+  backlight-pwms:
+    type: phandle-array
+    description: |
+      External PWM handles for controlling the backlight.

--- a/include/zephyr/display/display_backlight.h
+++ b/include/zephyr/display/display_backlight.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2024 Fabian Blatz <fabianblatz@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DISPLAY_BACKLIGHT_H_
+#define ZEPHYR_INCLUDE_DISPLAY_BACKLIGHT_H_
+
+/**
+ * @brief Display Backlight API
+ * @defgroup display_backlight Display Backlight API
+ * @ingroup io_interfaces
+ * @{
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/pwm.h>
+
+/**
+ * @brief Common display backlight config.
+ */
+struct display_backlight_common_config {
+#ifdef CONFIG_DISPLAY_BACKLIGHT_CONTROL_ENABLE_GPIO
+	/* GPIO pin to enable the backlight */
+	struct gpio_dt_spec backlight_enable_gpios;
+#endif /* CONFIG_DISPLAY_BACKLIGHT_CONTROL_ENABLE_GPIO */
+#ifdef CONFIG_DISPLAY_BACKLIGHT_CONTROL_PWM
+	/* PWM device to control the backlight */
+	struct pwm_dt_spec backlight_pwms;
+#endif /* CONFIG_DISPLAY_BACKLIGHT_CONTROL_PWM */
+	/* Default brightness level */
+	uint8_t default_brightness;
+};
+
+/**
+ * @brief Initialize common backlight config from devicetree.
+ *
+ * @param node_id The devicetree node identifier.
+ * @param api Pointer to a @ref display_backlight_api structure.
+ */
+#define DISPLAY_BACKLIGHT_DT_COMMON_CONFIG_INIT(node_id)                                           \
+	{IS_ENABLED(CONFIG_DISPLAY_BACKLIGHT_CONTROL_ENABLE_GPIO)                                  \
+	 ?.backlight_enable_gpios = GPIO_DT_SPEC_GET_OR(node_id, backlight_enable_gpios, {0}),     \
+	 IS_ENABLED(CONFIG_DISPLAY_BACKLIGHT_CONTROL_PWM)                                          \
+	 ?.backlight_pwms = PWM_DT_SPEC_GET_OR(node_id, backlight_pwms, {0}),                      \
+	 .default_brightness = DT_PROP_OR(node_id, default_brightness, 0), }
+
+/**
+ * @brief Initialize common backlight config from devicetree instance.
+ *
+ * @param inst Instance.
+ */
+#define DISPLAY_BACKLIGHT_DT_INST_COMMON_CONFIG_INIT(inst)                                         \
+	DISPLAY_BACKLIGHT_DT_COMMON_CONFIG_INIT(DT_DRV_INST(inst))
+
+/**
+ * @brief Validate the offset of the common data structures.
+ *
+ * @param config Name of the config structure.
+ */
+#define DISPLAY_BACKLIGHT_STRUCT_CHECK(config)                                                     \
+	BUILD_ASSERT(offsetof(config, common_backlight) == 0,                                      \
+		     "struct display_backlight_common_config must be placed first");
+
+/**
+ * @brief Common function to initialize a display backlight device at init time.
+ *
+ * This function must be called at the end of the device init function.
+ *
+ * @param dev Display backlight device instance.
+ *
+ * @retval 0 If initialized successfully.
+ * @retval -errno Negative errno in case of failure.
+ */
+int display_backlight_init(const struct device *dev);
+
+/**
+ * @brief Set the brightness of the backlight.
+ *
+ * @param dev Pointer to device structure for driver instance.
+ * @param brightness Brightness level to set.
+ *
+ * @retval 0 If initialized successfully.
+ * @retval -errno Negative errno in case of failure.
+ */
+int display_backlight_set_brightness(const struct device *dev, uint8_t brightness);
+
+/** @} */
+
+#endif /* ZEPHYR_INCLUDE_DISPLAY_BACKLIGHT_H_ */

--- a/include/zephyr/drivers/display.h
+++ b/include/zephyr/drivers/display.h
@@ -359,7 +359,8 @@ static inline int display_blanking_off(const struct device *dev)
  * @brief Set the brightness of the display
  *
  * Set the brightness of the display in steps of 1/256, where 255 is full
- * brightness and 0 is minimal.
+ * brightness and 0 is minimal. If @ref CONFIG_DISPLAY_BACKLIGHT is enabled
+ * the brightness of the backlight is set.
  *
  * @param dev Pointer to device structure
  * @param brightness Brightness in steps of 1/256
@@ -372,6 +373,10 @@ static inline int display_set_brightness(const struct device *dev,
 {
 	struct display_driver_api *api =
 		(struct display_driver_api *)dev->api;
+
+#ifdef CONFIG_DISPLAY_BACKLIGHT
+	return display_backlight_set_brightness(dev, brightness);
+#endif /* CONFIG_DISPLAY_BACKLIGHT */
 
 	if (api->set_brightness == NULL) {
 		return -ENOSYS;


### PR DESCRIPTION
Following the discussion in a PR, I took some time and drafted @fabiobaltieri suggestion for the display backlight support:
[https://github.com/zephyrproject-rtos/zephyr/pull/68522#issuecomment-1933884036](https://github.com/zephyrproject-rtos/zephyr/pull/68522#issuecomment-1933884036)

Maybe for the time being it would make sense to hide this behind a Kconfig flag, to avoid out of tree breakage?

TODOs once the initial approach looks good:

- [ ] Go through all drivers and add the structure
- [ ] Add a migration note that all out of tree drivers need to be aware of this