### PR TITLE
boards: infineon: s/cypress/infineon

### DIFF
--- a/boards/infineon/index.rst
+++ b/boards/infineon/index.rst
@@ -1,4 +1,4 @@
-.. _boards-cypress:
+.. _boards-infineon:
 
 Infineon Technologies
 #####################


### PR DESCRIPTION
Sphinx reference used cypress instead of infineon. This causes build warnings, as the same tag is part of boards/cypress/index.rst.