### PR TITLE
drivers: serial: bt: Make TX flush non-deferrable

### DIFF
--- a/drivers/serial/uart_bt.c
+++ b/drivers/serial/uart_bt.c
@@ -169,7 +169,7 @@ static void uart_bt_poll_out(const struct device *dev, unsigned char c)
 		 * data, so more than one byte is transmitted (e.g: when poll_out is
 		 * called inside a for-loop).
 		 */
-		k_work_reschedule(&dev_data->uart.tx_work, K_MSEC(1));
+		k_work_schedule(&dev_data->uart.tx_work, K_MSEC(1));
 	}
 }
 


### PR DESCRIPTION
As a follow-up to #69881, based on feedback. This change prevents postponing data flush until filling fifo. Now the flush will occur at the scheduled time, regardless of subsequent poll_out reqs.