### PR TITLE
Samples: Bluetooth: HCI: add missed callback pointer

### DIFF
--- a/samples/bluetooth/hci_usb/src/main.c
+++ b/samples/bluetooth/hci_usb/src/main.c
@@ -14,7 +14,7 @@
 
 static int enable_usb_device_next(void)
 {
-	struct usbd_contex *sample_usbd = sample_usbd_init_device();
+	struct usbd_contex *sample_usbd = sample_usbd_init_device(NULL);
 
 	if (sample_usbd == NULL) {
 		printk("Failed to initialize USB device");


### PR DESCRIPTION
USB initialization function mandates pointer to
callback. Seems this pointer was missed in hci_usb sample. Commit fixes this.