### PR TITLE
drivers: clock_control: stm32: fix typo and clean up unnecessary code

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -205,7 +205,7 @@ static inline int stm32_clock_control_on(const struct device *dev,
 	ARG_UNUSED(dev);
 
 	if (IN_RANGE(pclken->bus, STM32_PERIPH_BUS_MIN, STM32_PERIPH_BUS_MAX) == 0) {
-		/* Attemp to change a wrong periph clock bit */
+		/* Attempt to change a wrong periph clock bit */
 		return -ENOTSUP;
 	}
 
@@ -228,7 +228,7 @@ static inline int stm32_clock_control_off(const struct device *dev,
 	ARG_UNUSED(dev);
 
 	if (IN_RANGE(pclken->bus, STM32_PERIPH_BUS_MIN, STM32_PERIPH_BUS_MAX) == 0) {
-		/* Attemp to toggle a wrong periph clock bit */
+		/* Attempt to toggle a wrong periph clock bit */
 		return -ENOTSUP;
 	}
 
@@ -750,7 +750,7 @@ int stm32_clock_control_init(const struct device *dev)
 	}
 #endif /* FLASH_ACR_LATENCY */
 
-	/* Set up indiviual enabled clocks */
+	/* Set up individual enabled clocks */
 	set_up_fixed_clock_sources();
 
 	/* Set up PLLs */

--- a/drivers/clock_control/clock_stm32_ll_h5.c
+++ b/drivers/clock_control/clock_stm32_ll_h5.c
@@ -150,7 +150,7 @@ static inline int stm32_clock_control_on(const struct device *dev,
 	ARG_UNUSED(dev);
 
 	if (IN_RANGE(pclken->bus, STM32_PERIPH_BUS_MIN, STM32_PERIPH_BUS_MAX) == 0) {
-		/* Attemp to toggle a wrong periph clock bit */
+		/* Attempt to toggle a wrong periph clock bit */
 		return -ENOTSUP;
 	}
 
@@ -171,7 +171,7 @@ static inline int stm32_clock_control_off(const struct device *dev,
 	ARG_UNUSED(dev);
 
 	if (IN_RANGE(pclken->bus, STM32_PERIPH_BUS_MIN, STM32_PERIPH_BUS_MAX) == 0) {
-		/* Attemp to toggle a wrong periph clock bit */
+		/* Attempt to toggle a wrong periph clock bit */
 		return -ENOTSUP;
 	}
 
@@ -722,7 +722,7 @@ int stm32_clock_control_init(const struct device *dev)
 		return r;
 	}
 
-	/* Set peripheral busses prescalers */
+	/* Set peripheral buses prescalers */
 	LL_RCC_SetAHBPrescaler(ahb_prescaler(STM32_AHB_PRESCALER));
 	LL_RCC_SetAPB1Prescaler(apb1_prescaler(STM32_APB1_PRESCALER));
 	LL_RCC_SetAPB2Prescaler(apb2_prescaler(STM32_APB2_PRESCALER));

--- a/drivers/clock_control/clock_stm32_ll_h5.c
+++ b/drivers/clock_control/clock_stm32_ll_h5.c
@@ -696,8 +696,8 @@ static void set_up_fixed_clock_sources(void)
 
 int stm32_clock_control_init(const struct device *dev)
 {
-	uint32_t old_hclk_freq = 0;
-	int r = 0;
+	uint32_t old_hclk_freq;
+	int r;
 
 	ARG_UNUSED(dev);
 

--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -835,8 +835,8 @@ int stm32_clock_control_init(const struct device *dev)
 	int r = 0;
 
 #if defined(CONFIG_CPU_CORTEX_M7)
-	uint32_t old_hclk_freq = 0;
-	uint32_t new_hclk_freq = 0;
+	uint32_t old_hclk_freq;
+	uint32_t new_hclk_freq;
 
 	/* HW semaphore Clock enable */
 #if defined(CONFIG_SOC_STM32H7A3XX) || defined(CONFIG_SOC_STM32H7A3XXQ) || \

--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -142,7 +142,7 @@
 #error "SYS clock frequency for M7 core doesn't match CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC"
 #endif
 
-/* end of clock feasability check */
+/* end of clock feasibility check */
 #endif /* CONFIG_CPU_CORTEX_M7 */
 
 
@@ -329,7 +329,7 @@ static uint32_t get_vco_output_range(uint32_t vco_input_range)
 
 #endif /* ! CONFIG_CPU_CORTEX_M4 */
 
-/** @brief Verifies clock is part of actve clock configuration */
+/** @brief Verifies clock is part of active clock configuration */
 static int enabled_clock(uint32_t src_clk)
 {
 
@@ -365,7 +365,7 @@ static inline int stm32_clock_control_on(const struct device *dev,
 	ARG_UNUSED(dev);
 
 	if (IN_RANGE(pclken->bus, STM32_PERIPH_BUS_MIN, STM32_PERIPH_BUS_MAX) == 0) {
-		/* Attemp to toggle a wrong periph clock bit */
+		/* Attempt to toggle a wrong periph clock bit */
 		return -ENOTSUP;
 	}
 
@@ -391,7 +391,7 @@ static inline int stm32_clock_control_off(const struct device *dev,
 	ARG_UNUSED(dev);
 
 	if (IN_RANGE(pclken->bus, STM32_PERIPH_BUS_MIN, STM32_PERIPH_BUS_MAX) == 0) {
-		/* Attemp to toggle a wrong periph clock bit */
+		/* Attempt to toggle a wrong periph clock bit */
 		return -ENOTSUP;
 	}
 
@@ -416,7 +416,7 @@ static inline int stm32_clock_control_configure(const struct device *dev,
 
 	err = enabled_clock(pclken->bus);
 	if (err < 0) {
-		/* Attemp to configure a src clock not available or not valid */
+		/* Attempt to configure a src clock not available or not valid */
 		return err;
 	}
 
@@ -852,7 +852,7 @@ int stm32_clock_control_init(const struct device *dev)
 	/* Configure MCO1/MCO2 based on Kconfig */
 	stm32_clock_control_mco_init();
 
-	/* Set up indiviual enabled clocks */
+	/* Set up individual enabled clocks */
 	set_up_fixed_clock_sources();
 
 	/* Set up PLLs */
@@ -877,7 +877,7 @@ int stm32_clock_control_init(const struct device *dev)
 		LL_SetFlashLatency(new_hclk_freq);
 	}
 
-	/* Preset the prescalers prior to chosing SYSCLK */
+	/* Preset the prescalers prior to choosing SYSCLK */
 	/* Prevents APB clock to go over limits */
 	/* Set buses (Sys,AHB, APB1, APB2 & APB4) prescalers */
 	LL_RCC_SetSysPrescaler(sysclk_prescaler(STM32_D1CPRE));

--- a/drivers/clock_control/clock_stm32_ll_u5.c
+++ b/drivers/clock_control/clock_stm32_ll_u5.c
@@ -125,7 +125,7 @@ static int enabled_clock(uint32_t src_clk)
 	if ((src_clk == STM32_SRC_SYSCLK) ||
 	    ((src_clk == STM32_SRC_HSE) && IS_ENABLED(STM32_HSE_ENABLED)) ||
 	    ((src_clk == STM32_SRC_HSI16) && IS_ENABLED(STM32_HSI_ENABLED)) ||
-+	    ((src_clk == STM32_SRC_HSI48) && IS_ENABLED(STM32_HSI48_ENABLED)) ||
+	    ((src_clk == STM32_SRC_HSI48) && IS_ENABLED(STM32_HSI48_ENABLED)) ||
 	    ((src_clk == STM32_SRC_LSE) && IS_ENABLED(STM32_LSE_ENABLED)) ||
 	    ((src_clk == STM32_SRC_LSI) && IS_ENABLED(STM32_LSI_ENABLED)) ||
 	    ((src_clk == STM32_SRC_MSIS) && IS_ENABLED(STM32_MSIS_ENABLED)) ||
@@ -154,7 +154,7 @@ static inline int stm32_clock_control_on(const struct device *dev,
 	ARG_UNUSED(dev);
 
 	if (IN_RANGE(pclken->bus, STM32_PERIPH_BUS_MIN, STM32_PERIPH_BUS_MAX) == 0) {
-		/* Attemp to toggle a wrong periph clock bit */
+		/* Attempt to toggle a wrong periph clock bit */
 		return -ENOTSUP;
 	}
 
@@ -175,7 +175,7 @@ static inline int stm32_clock_control_off(const struct device *dev,
 	ARG_UNUSED(dev);
 
 	if (IN_RANGE(pclken->bus, STM32_PERIPH_BUS_MIN, STM32_PERIPH_BUS_MAX) == 0) {
-		/* Attemp to toggle a wrong periph clock bit */
+		/* Attempt to toggle a wrong periph clock bit */
 		return -ENOTSUP;
 	}
 
@@ -715,7 +715,7 @@ static void set_up_fixed_clock_sources(void)
 		while (!LL_RCC_LSE_IsReady()) {
 		}
 
-		/* Enable LSESYS additionnally */
+		/* Enable LSESYS additionally */
 		LL_RCC_LSE_EnablePropagation();
 		/* Wait till LSESYS is ready */
 		while (!LL_RCC_LSESYS_IsReady()) {
@@ -830,7 +830,7 @@ int stm32_clock_control_init(const struct device *dev)
 		return r;
 	}
 
-	/* Set peripheral busses prescalers */
+	/* Set peripheral buses prescalers */
 	LL_RCC_SetAHBPrescaler(ahb_prescaler(STM32_AHB_PRESCALER));
 	LL_RCC_SetAPB1Prescaler(apb1_prescaler(STM32_APB1_PRESCALER));
 	LL_RCC_SetAPB2Prescaler(apb2_prescaler(STM32_APB2_PRESCALER));

--- a/drivers/clock_control/clock_stm32_ll_u5.c
+++ b/drivers/clock_control/clock_stm32_ll_u5.c
@@ -804,8 +804,8 @@ static void set_up_fixed_clock_sources(void)
 
 int stm32_clock_control_init(const struct device *dev)
 {
-	uint32_t old_hclk_freq = 0;
-	int r = 0;
+	uint32_t old_hclk_freq;
+	int r;
 
 	ARG_UNUSED(dev);
 

--- a/drivers/clock_control/clock_stm32_ll_wba.c
+++ b/drivers/clock_control/clock_stm32_ll_wba.c
@@ -67,7 +67,7 @@ static inline int stm32_clock_control_on(const struct device *dev,
 	ARG_UNUSED(dev);
 
 	if (IN_RANGE(pclken->bus, STM32_PERIPH_BUS_MIN, STM32_PERIPH_BUS_MAX) == 0) {
-		/* Attemp to toggle a wrong periph clock bit */
+		/* Attempt to toggle a wrong periph clock bit */
 		return -ENOTSUP;
 	}
 
@@ -88,7 +88,7 @@ static inline int stm32_clock_control_off(const struct device *dev,
 	ARG_UNUSED(dev);
 
 	if (IN_RANGE(pclken->bus, STM32_PERIPH_BUS_MIN, STM32_PERIPH_BUS_MAX) == 0) {
-		/* Attemp to toggle a wrong periph clock bit */
+		/* Attempt to toggle a wrong periph clock bit */
 		return -ENOTSUP;
 	}
 
@@ -484,7 +484,7 @@ static void set_up_fixed_clock_sources(void)
 			/* Wait for LSE ready */
 		}
 
-		/* Enable LSESYS additionnally */
+		/* Enable LSESYS additionally */
 		LL_RCC_LSE_EnablePropagation();
 		/* Wait till LSESYS is ready */
 		while (!LL_RCC_LSE_IsPropagationReady()) {

--- a/drivers/clock_control/clock_stm32_ll_wba.c
+++ b/drivers/clock_control/clock_stm32_ll_wba.c
@@ -507,7 +507,7 @@ static void set_up_fixed_clock_sources(void)
 int stm32_clock_control_init(const struct device *dev)
 {
 	uint32_t old_flash_freq;
-	int r = 0;
+	int r;
 
 	ARG_UNUSED(dev);
 


### PR DESCRIPTION
- Use a code spell-checking tool to scan and correct spelling errors
- Removes unnecessary initialization of the local variable
where its value is guaranteed to be overwritten by subsequent operations.