### PR TITLE
Samples: Bluetooth: Fix PAwR sample failed to set subevent data

### DIFF
--- a/samples/bluetooth/periodic_adv_rsp/src/main.c
+++ b/samples/bluetooth/periodic_adv_rsp/src/main.c
@@ -295,7 +295,8 @@ int main(void)
 	}
 
 	while (num_synced < MAX_SYNCS) {
-		err = bt_le_scan_start(BT_LE_SCAN_PASSIVE, device_found);
+		/* Enable continuous scanning */
+		err = bt_le_scan_start(BT_LE_SCAN_PASSIVE_CONTINUOUS, device_found);
 		if (err) {
 			printk("Scanning failed to start (err %d)\n", err);
 			return 0;


### PR DESCRIPTION
Be respectful of PAwR subevents while scheduling scan activities. The radio will be swtiched from scan to PAwR when it is closed to the next subevent interval.