### PR TITLE
dts: bindings: display: gc9x01x: make 'reset-gpios' optional

### DIFF
--- a/dts/bindings/display/galaxycore,gc9x01x.yaml
+++ b/dts/bindings/display/galaxycore,gc9x01x.yaml
@@ -34,7 +34,6 @@ include: [spi-device.yaml, display-controller.yaml, lcd-controller.yaml]
 properties:
   reset-gpios:
     type: phandle-array
-    required: true
     description: |
       RESET pin of the GC9X01X.
       If connected directly the MCU pin should be configured


### PR DESCRIPTION
Driver already handles the case when `reset-gpios` is not provided, so
remove `required: true` from bindings to allow boards / shields definition
without reset signal being connected to any Zephyr controlled GPIO.