### PR TITLE
samples: logging: logger: Add harness to the BT configuration

### DIFF
--- a/samples/subsys/logging/logger/sample.yaml
+++ b/samples/subsys/logging/logger/sample.yaml
@@ -38,6 +38,7 @@ tests:
       - logging
       - bluetooth
     filter: CONFIG_DT_HAS_ZEPHYR_NUS_UART_ENABLED
+    harness: bluetooth_nus
     arch_exclude:
       - posix
     extra_args:


### PR DESCRIPTION
Add harness as twister by default looks into ztest results and in bluetooth configuration they won't be find.