### PR TITLE
Fix display pixelclk active

### DIFF
--- a/boards/shields/rk055hdmipi4m/rk055hdmipi4m.overlay
+++ b/boards/shields/rk055hdmipi4m/rk055hdmipi4m.overlay
@@ -49,7 +49,7 @@
 		hsync-active = <0>;
 		vsync-active = <0>;
 		de-active = <1>;
-		pixelclk-active = <1>;
+		pixelclk-active = <0>;
 		/*
 		 * Pixel clock is given by the following formula:
 		 * (height + vsync-len + vfront-porch + vback-porch) *

--- a/boards/shields/rk055hdmipi4ma0/rk055hdmipi4ma0.overlay
+++ b/boards/shields/rk055hdmipi4ma0/rk055hdmipi4ma0.overlay
@@ -49,7 +49,7 @@
 		hsync-active = <0>;
 		vsync-active = <0>;
 		de-active = <1>;
-		pixelclk-active = <1>;
+		pixelclk-active = <0>;
 		/*
 		 * Pixel clock is given by the following formula:
 		 * (height + vsync-len + vfront-porch + vback-porch) *


### PR DESCRIPTION
On the RT1170-EVKB, the framebuffer displays incorrectly (shifted by about 1/4 of the screen width). This is because pixelclk-active was set to 1 which corresponds to kELCDIF_DriveDataOnRisingClkEdge.
According to the HX8394 datasheet, it should be set to 0 which corresponds to kELCDIF_DriveDataOnFallingClkEdge.