### PR TITLE
doc: release: migration guide v3.6.0: Fix GH link

### DIFF
--- a/doc/releases/migration-guide-3.6.rst
+++ b/doc/releases/migration-guide-3.6.rst
@@ -638,7 +638,7 @@ Shell
 * :kconfig:option:`CONFIG_SHELL_BACKEND_SERIAL_API` now does not automatically default to
   :kconfig:option:`CONFIG_SHELL_BACKEND_SERIAL_API_ASYNC` when
   :kconfig:option:`CONFIG_UART_ASYNC_API` is enabled, :kconfig:option:`CONFIG_SHELL_ASYNC_API`
-  also has to be enabled in order to use the asynchronous serial shell (:github: `68475`).
+  also has to be enabled in order to use the asynchronous serial shell (:github:`68475`).
 
 ZBus
 ====


### PR DESCRIPTION
Putting a space between :github: and the PR number causes the rendered text to not link to the issue.