### PR TITLE
xtensa: mmu: Remove unused variabes

### DIFF
--- a/arch/xtensa/core/ptables.c
+++ b/arch/xtensa/core/ptables.c
@@ -108,9 +108,6 @@ extern char _heap_end[];
 extern char _heap_start[];
 extern char __data_start[];
 extern char __data_end[];
-extern char _bss_start[];
-extern char _bss_end[];
-
 /*
  * Static definition of all code & data memory regions of the
  * current Zephyr image. This information must be available &

--- a/arch/xtensa/core/ptables.c
+++ b/arch/xtensa/core/ptables.c
@@ -106,8 +106,6 @@ static sys_slist_t xtensa_domain_list;
 
 extern char _heap_end[];
 extern char _heap_start[];
-extern char __data_start[];
-extern char __data_end[];
 /*
  * Static definition of all code & data memory regions of the
  * current Zephyr image. This information must be available &


### PR DESCRIPTION
__data_* and _bss_* are not needed in ptables.c