### PR TITLE
boards: nxp: frdm_mcxn947: fix debug access to secure RAM and peripherals

### DIFF
--- a/boards/nxp/frdm_mcxn947/board.cmake
+++ b/boards/nxp/frdm_mcxn947/board.cmake
@@ -6,9 +6,18 @@
 
 if(CONFIG_SOC_MCXN947_CPU0)
   board_runner_args(jlink "--device=MCXN947_M33_0" "--reset-after-load")
-  board_runner_args(linkserver  "--device=MCXN947:MCX-N9XX-EVK:cm33_core0")
+  board_runner_args(linkserver  "--device=MCXN947:FRDM-MCXN947:cm33_core0")
   board_runner_args(linkserver  "--override=/device/memory/1/flash-driver=MCXN9xx_S.cfx")
   board_runner_args(linkserver  "--override=/device/memory/1/location=0x10000000")
+  # Linkserver v1.4.85 and earlier do not include the secure regions in the
+  # MCXN947 memory map, so we add them here
+  board_runner_args(linkserver "--override=/device/memory/-=\{\"location\":\"0x30000000\",\
+                               \"size\":\"0x00060000\",\"type\":\"RAM\"\}")
+  board_runner_args(linkserver "--override=/device/memory/-=\{\"location\":\"0x30060000\",\
+                               \"size\":\"0x00008000\",\"type\":\"RAM\"\}")
+  # Define region for peripherals
+  board_runner_args(linkserver "--override=/device/memory/-=\{\"location\":\"0x50000000\",\
+                               \"size\":\"0x00140000\",\"type\":\"RAM\"\}")
 else()
   message(FATAL_ERROR "Support for cpu1 not available yet")
 endif()


### PR DESCRIPTION
By default, LinkServer's memory map for the MCXN947 does not define memory regions for the SRAM or peripheral bus in secure mode. This results in gdb failing to read from these memory regions unless explicitly told ignore the debugger memory map via "set mem inaccessible-by-default off".

To resolve this, define memory regions for SRAM and peripherals in secure mode via the commandline arguments passed to LinkServer in board.cmake.