### PR TITLE
samples: sensor: Relax twister constraints on thermometer sample

### DIFF
--- a/boards/adi/eval_adin1110ebz/adi_eval_adin1110ebz.dts
+++ b/boards/adi/eval_adin1110ebz/adi_eval_adin1110ebz.dts
@@ -55,6 +55,7 @@
 		led0 = &green_led;
 		watchdog0 = &iwdg;
 		spi-flash0 = &mx25r6435f;
+		ambient-temp0 = &adt7420;
 	};
 
 	soc {
@@ -181,7 +182,7 @@
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 
-	adt7420@48 {
+	adt7420: adt7420@48 {
 		compatible = "adi,adt7420";
 		reg = <0x48>;
 	};

--- a/samples/sensor/thermometer/sample.yaml
+++ b/samples/sensor/thermometer/sample.yaml
@@ -4,6 +4,9 @@ tests:
   sample.sensor.thermometer:
     tags: sensors
     harness: sensor
+    filter: dt_alias_exists("ambient-temp0")
     integration_platforms:
-      - nrf52840dk/nrf52840
-    platform_allow: nrf52840dk/nrf52840 frdm_k22f
+      - nrf52840dk/nrf52840   # mcp9700a
+      - frdm_k22f             # tcn75a
+      - robokit1              # ntc_thermistor
+      - adi_eval_adin1110ebz  # adt7420


### PR DESCRIPTION
The thermometer sensor sample application can support any board that
defines the `ambient-temp0` devicetree alias, but the restrictive
`platform_allow` list prevented twister from running on all but two
selected boards. Use a more flexible `dt_alias_exists` filter instead to
allow running this sample on additional boards.

Signed-off-by: Maureen Helm <maureen.helm@analog.com>

cc @jpmur 