### PR TITLE
tests bsim: run_parallel: Print how long tests took

### DIFF
--- a/tests/bsim/run_parallel.sh
+++ b/tests/bsim/run_parallel.sh
@@ -75,9 +75,12 @@ echo -n "" > $tmp_res_file
 if [ `command -v parallel` ]; then
   parallel '
   echo "<testcase name=\"{}\" time=\"0\">"
+  start=$(date +%s%N)
   {} $@ &> {#}.log
+  dur=$(($(date +%s%N) - $start))
+  dur_s=$(echo "scale=3; $dur/1000000000" | bc)
   if [ $? -ne 0 ]; then
-    (>&2 echo -e "\e[91m{} FAILED\e[39m")
+    (>&2 echo -e "\e[91m{} FAILED\e[39m ($dur_s s)")
     (>&2 cat {#}.log)
     echo "<failure message=\"failed\" type=\"failure\">"
     cat {#}.log | eval $CLEAN_XML
@@ -86,7 +89,7 @@ if [ `command -v parallel` ]; then
     echo "</testcase>"
     exit 1
   else
-    (>&2 echo -e "{} PASSED")
+    (>&2 echo -e "{} PASSED ($dur_s s)")
     rm {#}.log
     echo "</testcase>"
   fi


### PR DESCRIPTION
To give an idea of which tests are taken too long either on CI or locally.

Just a trivial change to the script so we keep getting this info.