### PR TITLE
Bluetooth: Audio: Remove !found dbg log in codec.c

### DIFF
--- a/subsys/bluetooth/audio/codec.c
+++ b/subsys/bluetooth/audio/codec.c
@@ -309,7 +309,6 @@ int bt_audio_codec_cfg_get_val(const struct bt_audio_codec_cfg *codec_cfg,
 	}
 
 	if (!param.found) {
-		LOG_DBG("Could not find the type %u", type);
 		return -ENODATA;
 	}
 
@@ -621,7 +620,6 @@ static int codec_meta_get_val(const uint8_t meta[], size_t meta_len,
 	}
 
 	if (!param.found) {
-		LOG_DBG("Could not find the type %u", type);
 		return -ENODATA;
 	}
 
@@ -1823,7 +1821,6 @@ int bt_audio_codec_cap_get_val(const struct bt_audio_codec_cap *codec_cap,
 	}
 
 	if (!param.found) {
-		LOG_DBG("Could not find the type %u", type);
 		return -ENODATA;
 	}
 


### PR DESCRIPTION
It is a common occurance that a specific type is not found in the codec configuration, and the main way of knowing that is by calling the function.

The debug log does not help debug anything (as it does also return a specific error code), but rather just clutters up the log if enabled.