### PR TITLE
Bluetooth: BAP: Shell: Add tracking of empty SDUs

### DIFF
--- a/subsys/bluetooth/audio/shell/audio.h
+++ b/subsys/bluetooth/audio/shell/audio.h
@@ -85,6 +85,7 @@ struct shell_stream {
 #endif /* CONFIG_BT_AUDIO_TX */
 #if defined(CONFIG_BT_AUDIO_RX)
 	struct bt_iso_recv_info last_info;
+	size_t empty_sdu_pkts;
 	size_t lost_pkts;
 	size_t err_pkts;
 	size_t dup_psn;


### PR DESCRIPTION
There are devices that will send empty SDUs instead of empty PDUs, and while that should be harmless, it is nice to know what is going on, and we may want to deal with empty SDUs and empty PDUs differently.