### PR TITLE
drivers: dma_mcux_lpc: Fix omitted interrupt config

### DIFF
--- a/drivers/dma/dma_mcux_lpc.c
+++ b/drivers/dma/dma_mcux_lpc.c
@@ -849,6 +849,8 @@ static int dma_mcux_lpc_init(const struct device *dev)
 	DMA_Init(DEV_BASE(dev));
 	INPUTMUX_Init(INPUTMUX);
 
+	config->irq_config_func(dev);
+
 	return 0;
 }
 


### PR DESCRIPTION
During the effort of getting audio playback and capture to work on the RT685's HiFi 4 DSP domain, it was discovered that the `dma_mcux_lpc` driver omits interrupt configuration (ISR attachment and enable of the interrupt itself), which results in the DSP not servicing interrupt coming from the driven DMA peripheral. Consequently, when used by the `i2s_mcux_flexcomm` driver, following DMA transfers simply don't happen and the data FIFO of the driven Flexcomm peripheral simply underflows, as a result of no data being copied by the DMA peripheral.

This PR adds that invocation and resolves that issue, making audio playback and capture functional on the target platform. 

Somewhat related to https://github.com/zephyrproject-rtos/zephyr/pull/65229.