### PR TITLE
net: lwm2m: Fix socket hints for block transfer

### DIFF
--- a/include/zephyr/net/coap.h
+++ b/include/zephyr/net/coap.h
@@ -758,6 +758,15 @@ bool coap_has_descriptive_block_option(struct coap_packet *cpkt);
 int coap_remove_descriptive_block_option(struct coap_packet *cpkt);
 
 /**
+ * @brief Check if BLOCK1 or BLOCK2 option has more flag set
+ *
+ * @param cpkt Packet to be checked.
+ * @return true If more flag is set in BLOCK1 or BLOCK2
+ * @return false If MORE flag is not set or BLOCK header not found.
+ */
+bool coap_block_has_more(struct coap_packet *cpkt);
+
+/**
  * @brief Append BLOCK1 option to the packet.
  *
  * @param cpkt Packet to be updated

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -1257,6 +1257,22 @@ int coap_remove_descriptive_block_option(struct coap_packet *cpkt)
 	}
 }
 
+bool coap_block_has_more(struct coap_packet *cpkt)
+{
+	bool more = false;
+	int opt;
+
+	if (coap_packet_is_request(cpkt)) {
+		opt = coap_get_option_int(cpkt, COAP_OPTION_BLOCK1);
+	} else {
+		opt = coap_get_option_int(cpkt, COAP_OPTION_BLOCK2);
+	}
+	if (opt >= 0) {
+		more = GET_MORE(opt);
+	}
+	return more;
+}
+
 int coap_append_block1_option(struct coap_packet *cpkt,
 			      struct coap_block_context *ctx)
 {

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -663,7 +663,9 @@ static void hint_socket_state(struct lwm2m_ctx *ctx, struct lwm2m_message *ongoi
 			empty = false;
 		}
 
-		if (!empty) {
+		bool ongoing_block_tx = coap_block_has_more(&ongoing_tx->cpkt);
+
+		if (!empty || ongoing_block_tx) {
 			ctx->set_socket_state(ctx->sock_fd, LWM2M_SOCKET_STATE_ONGOING);
 		} else if (ongoing_tx->type == COAP_TYPE_CON) {
 			ctx->set_socket_state(ctx->sock_fd, LWM2M_SOCKET_STATE_ONE_RESPONSE);

--- a/tests/net/lib/lwm2m/lwm2m_engine/src/stubs.c
+++ b/tests/net/lib/lwm2m/lwm2m_engine/src/stubs.c
@@ -43,6 +43,7 @@ DEFINE_FAKE_VOID_FUNC(lwm2m_clear_block_contexts);
 DEFINE_FAKE_VALUE_FUNC(int, lwm2m_security_mode, struct lwm2m_ctx *);
 DEFINE_FAKE_VALUE_FUNC(int, z_impl_zsock_setsockopt, int, int, int, const void *, socklen_t);
 DEFINE_FAKE_VOID_FUNC(engine_update_tx_time);
+DEFINE_FAKE_VALUE_FUNC(bool, coap_block_has_more, struct coap_packet *);
 
 static sys_slist_t obs_obj_path_list = SYS_SLIST_STATIC_INIT(&obs_obj_path_list);
 sys_slist_t *lwm2m_obs_obj_path_list(void)

--- a/tests/net/lib/lwm2m/lwm2m_engine/src/stubs.h
+++ b/tests/net/lib/lwm2m/lwm2m_engine/src/stubs.h
@@ -58,6 +58,7 @@ DECLARE_FAKE_VALUE_FUNC(int, z_impl_zsock_connect, int, const struct sockaddr *,
 DECLARE_FAKE_VALUE_FUNC(int, lwm2m_security_mode, struct lwm2m_ctx *);
 DECLARE_FAKE_VALUE_FUNC(int, z_impl_zsock_setsockopt, int, int, int, const void *, socklen_t);
 DECLARE_FAKE_VOID_FUNC(engine_update_tx_time);
+DECLARE_FAKE_VALUE_FUNC(bool, coap_block_has_more, struct coap_packet *);
 
 #define DO_FOREACH_FAKE(FUNC)                                                                      \
 	do {                                                                                       \
@@ -89,6 +90,7 @@ DECLARE_FAKE_VOID_FUNC(engine_update_tx_time);
 		FUNC(lwm2m_security_mode)                                                          \
 		FUNC(z_impl_zsock_setsockopt)                                                      \
 		FUNC(engine_update_tx_time)                                                        \
+		FUNC(coap_block_has_more)							   \
 	} while (0)
 
 #endif /* STUBS_H */


### PR DESCRIPTION
Outgoing block-transfers now set the socket hint
to ONGOING as long as the BLOCK1/BLOCK2 header has MORE flag set to true.
This means as only the last packet in the block-transfer set the socket hint to LAST or ONE_RESPONSE.

