### PR TITLE
Bluetooth: Audio: Shell: clear static buffers for ad data

### DIFF
--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -3730,6 +3730,8 @@ ssize_t audio_pa_data_add(struct bt_data *data_array,
 		NET_BUF_SIMPLE_DEFINE_STATIC(base_buf, UINT8_MAX);
 		int err;
 
+		net_buf_simple_reset(&base_buf);
+
 		err = bt_bap_broadcast_source_get_base(default_source.bap_source, &base_buf);
 		if (err != 0) {
 			printk("Unable to get BASE: %d\n", err);

--- a/subsys/bluetooth/audio/shell/cap_initiator.c
+++ b/subsys/bluetooth/audio/shell/cap_initiator.c
@@ -1459,6 +1459,8 @@ ssize_t cap_initiator_pa_data_add(struct bt_data *data_array, const size_t data_
 		NET_BUF_SIMPLE_DEFINE_STATIC(base_buf, UINT8_MAX);
 		int err;
 
+		net_buf_simple_reset(&base_buf);
+
 		err = bt_cap_initiator_broadcast_get_base(default_source.cap_source, &base_buf);
 		if (err != 0) {
 			printk("Unable to get BASE: %d\n", err);

--- a/subsys/bluetooth/audio/shell/pbp.c
+++ b/subsys/bluetooth/audio/shell/pbp.c
@@ -48,6 +48,8 @@ size_t pbp_ad_data_add(struct bt_data data[], size_t data_size)
 {
 	int err;
 
+	net_buf_simple_reset(&pbp_ad_buf);
+
 	err = bt_pbp_get_announcement(pba_metadata,
 				      ARRAY_SIZE(pba_metadata),
 				      pbp_features,


### PR DESCRIPTION
The buffers for the PBP advertising data as well as the buffers for the BASE periodic advertising data were not cleared, so calling the functions multiple times would simply append the data rather than just setting the new data.