### PR TITLE
Bluetooth: BAP: Shell: Fix documentation for broadcast_code

### DIFF
--- a/doc/connectivity/bluetooth/api/shell/bap_broadcast_assistant.rst
+++ b/doc/connectivity/bluetooth/api/shell/bap_broadcast_assistant.rst
@@ -41,7 +41,7 @@ subscribe to all notifications.
                         [bis_index [bis_index [bix_index [...]]]]>
    mod_src           : Set sync <src_id> <sync_pa> [<pa_interval>] [<sync_bis>]
                         [<metadata>]
-   broadcast_code    : Send a space separated broadcast code of up to 16 bytes
+   broadcast_code    : Send a string-based broadcast code of up to 16 bytes
                         <src_id> <broadcast code>
    rem_src           : Remove a source <src_id>
    read_state        : Remove a source <index>
@@ -115,3 +115,13 @@ Modifying a receive state:
    BASS recv state: src_id 0, addr 1E:4D:0A:AA:6E:49 (random), sid 0, sync_state 2, encrypt_state 0
          [0]: BIS sync 0x0001, metadata_len 4
                   Metadata length 2, type 2, data: 0100
+
+Supplying a broadcast code:
+---------------------------
+
+.. code-block:: console
+
+   uart:~$ bap_broadcast_assistant broadcast_code 0 secretCode
+   Sending broadcast code:
+   00000000: 73 65 63 72 65 74 43 6f 64 65 00 00 00 00 00 00 |secretCo de....|
+   uart:~$ BASS broadcast code successful

--- a/subsys/bluetooth/audio/shell/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/shell/bap_broadcast_assistant.c
@@ -1042,7 +1042,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      "[<sync_bis>] [<metadata>]",
 		      cmd_bap_broadcast_assistant_mod_src, 3, 2),
 	SHELL_CMD_ARG(broadcast_code, NULL,
-		      "Send a space separated broadcast code of up to 16 bytes "
+		      "Send a string-based broadcast code of up to 16 bytes "
 		      "<src_id> <broadcast code>",
 		      cmd_bap_broadcast_assistant_broadcast_code, 3, 0),
 	SHELL_CMD_ARG(rem_src, NULL, "Remove a source <src_id>",


### PR DESCRIPTION
The documentation for the command
bap_broadcast_assistant broadcast_code
was incorrect and has been fixed.

Additionally, and example of the command has been added in the shell documentation.