### PR TITLE
Bluetooth: Audio: Shell: Fix snk_chan_cnt for AC_5

### DIFF
--- a/subsys/bluetooth/audio/shell/cap_initiator.c
+++ b/subsys/bluetooth/audio/shell/cap_initiator.c
@@ -896,7 +896,7 @@ static int cmd_cap_ac_5(const struct shell *sh, size_t argc, char **argv)
 		.conn_cnt = 1U,
 		.snk_cnt = {1U},
 		.src_cnt = {1U},
-		.snk_chan_cnt = 1U,
+		.snk_chan_cnt = 2U,
 		.src_chan_cnt = 1U,
 	};
 

--- a/subsys/bluetooth/audio/shell/gmap.c
+++ b/subsys/bluetooth/audio/shell/gmap.c
@@ -326,7 +326,7 @@ static int cmd_gmap_ac_5(const struct shell *sh, size_t argc, char **argv)
 		.conn_cnt = 1U,
 		.snk_cnt = {1U},
 		.src_cnt = {1U},
-		.snk_chan_cnt = 1U,
+		.snk_chan_cnt = 2U,
 		.src_chan_cnt = 1U,
 	};
 


### PR DESCRIPTION
The audio configuration 5 is defined to have 2 sink channels per stream and 1 source channel per stream.