### PR TITLE
Bluetooth: BAP: Shell: Fix bad err check for PAST sync

### DIFF
--- a/subsys/bluetooth/audio/shell/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/shell/bap_scan_delegator.c
@@ -451,7 +451,7 @@ static int cmd_bap_scan_delegator_sync_pa(const struct shell *sh, size_t argc,
 		shell_info(sh, "Syncing with PAST");
 
 		err = pa_sync_past(state->conn, state, state->pa_interval);
-		if (err != 0) {
+		if (err == 0) {
 			err = bt_bap_scan_delegator_set_pa_state(src_id,
 								 BT_BAP_PA_STATE_INFO_REQ);
 			if (err != 0) {


### PR DESCRIPTION
If pa_sync_past returns 0 then that means we are ready to sync to past, and the BT_BAP_PA_STATE_INFO_REQ state should be set.