### PR TITLE
Increase bsim tests watchdog deadline

### DIFF
--- a/tests/bsim/bluetooth/audio/test_scripts/_csip_notify.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/_csip_notify.sh
@@ -8,7 +8,6 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 SIMULATION_ID="csip_notify"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_bass_client_sync.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_bass_client_sync.sh
@@ -6,7 +6,6 @@
 
 SIMULATION_ID="bass_client_sync"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=20
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio.sh
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=50
+EXECUTE_TIMEOUT=100
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_assistant.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_assistant.sh
@@ -6,7 +6,7 @@
 
 SIMULATION_ID="bap_broadcast_audio_assistant"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=50
+EXECUTE_TIMEOUT=100
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_unicast_audio.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_unicast_audio.sh
@@ -6,7 +6,6 @@
 
 SIMULATION_ID="unicast_audio"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=20
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_unicast_audio_acl_disconnect.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_unicast_audio_acl_disconnect.sh
@@ -6,7 +6,6 @@
 
 SIMULATION_ID="unicast_audio_acl_disconnect"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=20
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast.sh
@@ -6,7 +6,6 @@
 
 SIMULATION_ID="cap_broadcast"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=20
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_capture_and_render.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_capture_and_render.sh
@@ -6,7 +6,6 @@
 
 SIMULATION_ID="cap_capture_and_render"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=20
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast.sh
@@ -6,7 +6,6 @@
 
 SIMULATION_ID="cap_unicast"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=20
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_inval.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_inval.sh
@@ -6,7 +6,6 @@
 
 SIMULATION_ID="cap_unicast_inval"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=20
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_timeout.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_timeout.sh
@@ -6,7 +6,6 @@
 
 SIMULATION_ID="cap_unicast_timeout"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=20
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/csip.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip.sh
@@ -10,7 +10,7 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=30
+EXECUTE_TIMEOUT=100
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/csip_encrypted_sirk.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip_encrypted_sirk.sh
@@ -9,7 +9,6 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/csip_forced_release.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip_forced_release.sh
@@ -9,7 +9,6 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/csip_new_sirk.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip_new_sirk.sh
@@ -10,7 +10,6 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/csip_no_lock.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip_no_lock.sh
@@ -9,7 +9,6 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/csip_no_rank.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip_no_rank.sh
@@ -9,7 +9,6 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/csip_no_size.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip_no_size.sh
@@ -9,7 +9,7 @@
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=30
+EXECUTE_TIMEOUT=60
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/has.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/has.sh
@@ -8,7 +8,6 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 SIMULATION_ID="has"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=20
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/has_offline.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/has_offline.sh
@@ -8,7 +8,6 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 SIMULATION_ID="has_offline_behavior"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=20
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/ias.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/ias.sh
@@ -8,7 +8,6 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 SIMULATION_ID="ias"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=20
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/media_controller.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/media_controller.sh
@@ -8,7 +8,6 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 SIMULATION_ID="media_controller"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=20
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/micp.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/micp.sh
@@ -8,7 +8,6 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 SIMULATION_ID="micp"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=20
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/pbp.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/pbp.sh
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=50
+EXECUTE_TIMEOUT=100
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/tbs.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/tbs.sh
@@ -9,7 +9,6 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 SIMULATION_ID="tbs_ccp"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=20
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/audio/test_scripts/tmap.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/tmap.sh
@@ -6,7 +6,6 @@
 
 SIMULATION_ID="tmap"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=30
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/vcp.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/vcp.sh
@@ -8,7 +8,6 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 SIMULATION_ID="vcp"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=20
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/hci_uart/tests_scripts/basic_conn_split_hci_uart.sh
+++ b/tests/bsim/bluetooth/hci_uart/tests_scripts/basic_conn_split_hci_uart.sh
@@ -10,7 +10,6 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # connected over UART. The controller is the HCI UART sample.
 simulation_id="basic_conn_split_hci_uart"
 verbosity_level=2
-EXECUTE_TIMEOUT=20
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/hci_uart/tests_scripts/basic_conn_split_hci_uart_async.sh
+++ b/tests/bsim/bluetooth/hci_uart/tests_scripts/basic_conn_split_hci_uart_async.sh
@@ -10,7 +10,6 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # connected over UART. The controller is the HCI UART async sample.
 simulation_id="basic_conn_split_hci_uart_async"
 verbosity_level=2
-EXECUTE_TIMEOUT=20
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/host/att/eatt/tests_scripts/lowres.sh
+++ b/tests/bsim/bluetooth/host/att/eatt/tests_scripts/lowres.sh
@@ -6,7 +6,6 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 simulation_id="lowres"
 verbosity_level=2
-EXECUTE_TIMEOUT=20
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/host/att/open_close/test_scripts/run.sh
+++ b/tests/bsim/bluetooth/host/att/open_close/test_scripts/run.sh
@@ -10,7 +10,7 @@ test_path=$(guess_test_long_name)
 dev_exe="bs_${BOARD_TS}_${test_path}_prj_conf"
 simulation_id="${test_path}"
 
-EXECUTE_TIMEOUT=60
+EXECUTE_TIMEOUT=120
 
 cd "${BSIM_OUT_PATH}/bin"
 

--- a/tests/bsim/bluetooth/host/gatt/notify/test_scripts/_run_test.sh
+++ b/tests/bsim/bluetooth/host/gatt/notify/test_scripts/_run_test.sh
@@ -6,7 +6,6 @@ set -eu
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 verbosity_level=2
-EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/host/gatt/sc_indicate/test_scripts/sc_indicate.sh
+++ b/tests/bsim/bluetooth/host/gatt/sc_indicate/test_scripts/sc_indicate.sh
@@ -8,7 +8,6 @@ test_name='sc_indicate'
 test_exe="bs_${BOARD_TS}_tests_bsim_bluetooth_host_gatt_${test_name}_prj_conf"
 simulation_id="${test_name}"
 verbosity_level=2
-EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/host/misc/hfc/test_scripts/run.sh
+++ b/tests/bsim/bluetooth/host/misc/hfc/test_scripts/run.sh
@@ -6,7 +6,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 simulation_id="misc_hfc"
 verbosity_level=2
-EXECUTE_TIMEOUT=120
+EXECUTE_TIMEOUT=240
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/host/privacy/central/test_scripts/run_test.sh
+++ b/tests/bsim/bluetooth/host/privacy/central/test_scripts/run_test.sh
@@ -5,6 +5,7 @@ set -eu
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
+EXECUTE_TIMEOUT=100
 verbosity_level=2
 simulation_id="$(guess_test_long_name)"
 

--- a/tests/bsim/bluetooth/host/privacy/peripheral/test_scripts/run_test.sh
+++ b/tests/bsim/bluetooth/host/privacy/peripheral/test_scripts/run_test.sh
@@ -7,6 +7,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 verbosity_level=2
 simulation_id="host_privacy_peripheral"
+EXECUTE_TIMEOUT=100
 
 central_exe="${BSIM_OUT_PATH}/bin/bs_${BOARD_TS}_$(guess_test_long_name)_prj_conf"
 peripheral_exe="${central_exe}"

--- a/tests/bsim/bluetooth/host/privacy/peripheral/test_scripts/run_test_rpa_expired.sh
+++ b/tests/bsim/bluetooth/host/privacy/peripheral/test_scripts/run_test_rpa_expired.sh
@@ -7,6 +7,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 verbosity_level=2
 simulation_id="rpa_expired"
+EXECUTE_TIMEOUT=100
 
 central_exe_rpa_expired="\
 ${BSIM_OUT_PATH}/bin/bs_${BOARD_TS}_$(guess_test_long_name)_prj_rpa_expired_conf"

--- a/tests/bsim/bluetooth/host/privacy/peripheral/test_scripts/run_test_rpa_sharing.sh
+++ b/tests/bsim/bluetooth/host/privacy/peripheral/test_scripts/run_test_rpa_sharing.sh
@@ -7,6 +7,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 verbosity_level=2
 simulation_id="$(guess_test_long_name)_rpa_sharing"
+EXECUTE_TIMEOUT=60
 
 central_exe_rpa_sharing="\
 ${BSIM_OUT_PATH}/bin/bs_${BOARD_TS}_$(guess_test_long_name)_prj_rpa_sharing_conf"

--- a/tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso.sh
+++ b/tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso.sh
@@ -8,7 +8,6 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # to the BIS.
 simulation_id="broadcast_iso"
 verbosity_level=2
-EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_ticker_expire_info.sh
+++ b/tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_ticker_expire_info.sh
@@ -8,7 +8,6 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # to the BIS.
 simulation_id="broadcast_iso_ticker_expire_info"
 verbosity_level=2
-EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_vs_dp.sh
+++ b/tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_vs_dp.sh
@@ -8,7 +8,6 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # to the BIS, and recevied SDUs are emitted via vendor data path implementation.
 simulation_id="broadcast_iso_vs_dp"
 verbosity_level=2
-EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_encrypted_split.sh
+++ b/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_encrypted_split.sh
@@ -8,7 +8,6 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # notification
 simulation_id="basic_conn_encr_split"
 verbosity_level=2
-EXECUTE_TIMEOUT=5
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_encrypted_split_privacy.sh
+++ b/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_encrypted_split_privacy.sh
@@ -8,7 +8,6 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # notification
 simulation_id="basic_conn_encr_split_privacy"
 verbosity_level=2
-EXECUTE_TIMEOUT=5
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_encrypted_split_single_timer.sh
+++ b/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_encrypted_split_single_timer.sh
@@ -8,7 +8,6 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # notification
 simulation_id="basic_conn_encr_split_single_timer"
 verbosity_level=2
-EXECUTE_TIMEOUT=5
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_split.sh
+++ b/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_split.sh
@@ -8,7 +8,6 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # notification, using the split controller (ULL LLL)
 simulation_id="basic_conn_split"
 verbosity_level=2
-EXECUTE_TIMEOUT=5
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_split_low_lat.sh
+++ b/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_split_low_lat.sh
@@ -8,7 +8,6 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # notification, using the split controller (ULL LLL) in Low Latency Variant
 simulation_id="basic_conn_split_low_lat"
 verbosity_level=2
-EXECUTE_TIMEOUT=5
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/edtt/tests_scripts/_controller_tests_inner.sh
+++ b/tests/bsim/bluetooth/ll/edtt/tests_scripts/_controller_tests_inner.sh
@@ -58,7 +58,7 @@ function _Execute(){
     rr="rr record -o ${out}"
   fi
   check_program_exists $1
-  run_in_background timeout 300 ${rr} $@
+  run_in_background timeout --kill-after=5 -v 800 ${rr} $@
 }
 
 

--- a/tests/bsim/bluetooth/ll/multiple_id/tests_scripts/multiple.sh
+++ b/tests/bsim/bluetooth/ll/multiple_id/tests_scripts/multiple.sh
@@ -7,7 +7,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # Multiple connection between two devices with multiple peripheral identity
 simulation_id="multiple"
 verbosity_level=2
-EXECUTE_TIMEOUT=1800
+EXECUTE_TIMEOUT=2200
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/mesh/_mesh_test.sh
+++ b/tests/bsim/bluetooth/mesh/_mesh_test.sh
@@ -3,7 +3,7 @@
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-EXECUTE_TIMEOUT=600
+EXECUTE_TIMEOUT=800
 
 function Skip(){
   for i in "${SKIP[@]}" ; do


### PR DESCRIPTION
* Increase bsim tests watchdog deadline / execution timeout to ensure all have a timeout which is at least >3x of a typical CI run.
* Also remove timeouts which are set to be either the same or lower than the default.
* For the EDTT LL tests, ensure we kill processes on timeout just like for the other tests, and increase its time.

Follow up to #70568