### PR TITLE
kernel: timeout: Optimize setting next alarm

### DIFF
--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -135,7 +135,7 @@ void z_add_timeout(struct _timeout *to, _timeout_func_t fn,
 			sys_dlist_append(&timeout_list, &to->node);
 		}
 
-		if (to == first()) {
+		if (to == first() && announce_remaining == 0) {
 			sys_clock_set_timeout(next_timeout(), false);
 		}
 	}


### PR DESCRIPTION
Next timeout was set unconditionally at the end of sys_clock_announce. However, if one of the current expired timeouts was setting a new timeout which is the first to execute then system clock is already configured and setting it at the end is redundant. This can happen if timeout is used for periodic k_timer or if k_timer handler start new timer (which is the nearest from all configured).

New sys_clock timeout is set only in those two places: when new timeout is added and after the announcement so it is possible to track currently configured timeout and skip setting at the end of the announcement if it is redundant.

If timeouts are frequent this optimization can reduce CPU load. In many cases setting the new sys_clock timeout is the most time consuming operation in the sys_clock isr handler. As an example, on the target I used setting new sys_clock timeout is taking 6 uS of 9 uS spent in the isr and it takes 16 uS with the redundant call.