### PR TITLE
net: wifi: Fix the Wi-Fi state check

### DIFF
--- a/include/zephyr/net/wifi.h
+++ b/include/zephyr/net/wifi.h
@@ -138,6 +138,18 @@ enum wifi_iface_state {
 	WIFI_STATE_UNKNOWN
 };
 
+/* We rely on the strict order of the enum values, so, let's check it */
+BUILD_ASSERT(WIFI_STATE_DISCONNECTED < WIFI_STATE_INTERFACE_DISABLED &&
+	     WIFI_STATE_INTERFACE_DISABLED < WIFI_STATE_INACTIVE &&
+	     WIFI_STATE_INACTIVE < WIFI_STATE_SCANNING &&
+	     WIFI_STATE_SCANNING < WIFI_STATE_AUTHENTICATING &&
+	     WIFI_STATE_AUTHENTICATING < WIFI_STATE_ASSOCIATING &&
+	     WIFI_STATE_ASSOCIATING < WIFI_STATE_ASSOCIATED &&
+	     WIFI_STATE_ASSOCIATED < WIFI_STATE_4WAY_HANDSHAKE &&
+	     WIFI_STATE_4WAY_HANDSHAKE < WIFI_STATE_GROUP_HANDSHAKE &&
+	     WIFI_STATE_GROUP_HANDSHAKE < WIFI_STATE_COMPLETED);
+
+
 /** Helper function to get user-friendly interface state name. */
 const char *wifi_state_txt(enum wifi_iface_state state);
 

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -504,7 +504,7 @@ static int wifi_set_power_save(uint32_t mgmt_request, struct net_if *iface,
 			return -EIO;
 		}
 
-		if (info.state == WIFI_STATE_COMPLETED) {
+		if (info.state >= WIFI_STATE_ASSOCIATED) {
 			ps_params->fail_reason =
 				WIFI_PS_PARAM_FAIL_DEVICE_CONNECTED;
 			return -ENOTSUP;


### PR DESCRIPTION
Once Wi-Fi is associated few parameters like listen interval and power-save mode cannot be changed. The state for association is "ASSOCIATED" and not completed. Even after state transitions to COMPLETE, it can still go back to other states, e.g., PTK/GTK renewal.

Fix the state check.