### PR TITLE
drivers: sensor: dht: Add lock IRQ option

### DIFF
--- a/drivers/sensor/dht/Kconfig
+++ b/drivers/sensor/dht/Kconfig
@@ -3,10 +3,21 @@
 # Copyright (c) 2016 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-config DHT
+menuconfig DHT
 	bool "DHT Temperature and Humidity Sensor"
 	default y
 	depends on DT_HAS_AOSONG_DHT_ENABLED
 	depends on GPIO
 	help
 	  Enable driver for the DHT temperature and humidity sensor family.
+
+if DHT
+
+config DHT_LOCK_IRQS
+	bool "Lock IRQs for sensor measurement"
+	help
+	  Locks IRQs when taking sensor readings, this greatly improves the chances of getting a
+	  reading successfully from the sensor at the cost of delayed interrupt servicing (e.g.
+	  Bluetooth). Note that other systems might need to be adjusted to account for this.
+
+endif # DHT

--- a/drivers/sensor/dht/dht.c
+++ b/drivers/sensor/dht/dht.c
@@ -67,10 +67,18 @@ static int dht_sample_fetch(const struct device *dev,
 	uint8_t buf[5];
 	unsigned int i, j;
 
+#if defined(CONFIG_DHT_LOCK_IRQS)
+	int lock;
+#endif
+
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL);
 
 	/* assert to send start signal */
 	gpio_pin_set_dt(&cfg->dio_gpio, true);
+
+#if defined(CONFIG_DHT_LOCK_IRQS)
+	lock = irq_lock();
+#endif
 
 	k_busy_wait(DHT_START_SIGNAL_DURATION);
 
@@ -156,6 +164,10 @@ static int dht_sample_fetch(const struct device *dev,
 	}
 
 cleanup:
+#if defined(CONFIG_DHT_LOCK_IRQS)
+	irq_unlock(lock);
+#endif
+
 	/* Switch to output inactive until next fetch. */
 	gpio_pin_configure_dt(&cfg->dio_gpio, GPIO_OUTPUT_INACTIVE);
 


### PR DESCRIPTION
Adds an option that allows for locking all interrupts when reading the data from this sensor, this can be used alongside systems like Bluetooth to vastly increase chances of getting a reading from the sensor successfully, at the risk of losing Bluetooth packets.

![image](https://github.com/zephyrproject-rtos/zephyr/assets/1551104/9dd0449f-a2de-44cc-93cf-4dae0ed28e30)
