### PR TITLE
Add support for stm32l152c-discovery board

### DIFF
--- a/boards/st/stm32l1_disco/Kconfig.stm32l152c_disco
+++ b/boards/st/stm32l1_disco/Kconfig.stm32l152c_disco
@@ -1,0 +1,5 @@
+# Copyright (c) 2024 Maxin John
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_STM32L152C_DISCO
+	select SOC_STM32L152XC

--- a/boards/st/stm32l1_disco/board.yml
+++ b/boards/st/stm32l1_disco/board.yml
@@ -1,5 +1,9 @@
-board:
-  name: stm32l1_disco
-  vendor: st
-  socs:
-    - name: stm32l151xb
+boards:
+  - name: stm32l1_disco
+    vendor: st
+    socs:
+      - name: stm32l151xb
+  - name: stm32l152c_disco
+    vendor: st
+    socs:
+      - name: stm32l152xc

--- a/boards/st/stm32l1_disco/doc/index.rst
+++ b/boards/st/stm32l1_disco/doc/index.rst
@@ -16,12 +16,13 @@ packaged software examples.
 There
 are two variants of the board:
 
-- STM32LDISCOVERY targets STM32L152RBT6, with 128K flash, 16K RAM
-- 32L152CDISCOVERY targets STM32L152RCT6, with 256K flash, 32K RAM
+- STM32LDISCOVERY targets STM32L152RBT6, with 128K flash, 16K RAM, 4K EEPROM
+- STM32L152CDISCOVERY targets STM32L152RCT6, with 256K flash, 32K RAM, 8K EEPROM
 
-The STM32LDISCOVERY is no longer sold, but was widely available.  The current
-configuration assumes only 128K flash and 16K RAM, so it builds and runs
-on both variants out of the box.
+The STM32LDISCOVERY is no longer sold, but was widely available.
+stm32l1_disco configuration enables support for STM32LDISCOVERY board and
+stm32l152c_disco configuration enables support for STM32L152CDISCOVERY board.
+
 
 .. image:: img/stm32l1_disco.jpg
      :align: center
@@ -53,7 +54,8 @@ More information about STM32L151x can be found in the `STM32L1x reference manual
 Supported Features
 ==================
 
-The Zephyr stm32l1_disco board configuration supports the following hardware features:
+The Zephyr stm32l1_disco and stm32l152c_disco board configurations support
+the following hardware features:
 
 .. list-table:: Supported hardware
    :header-rows: 1
@@ -92,8 +94,11 @@ The Zephyr stm32l1_disco board configuration supports the following hardware fea
 
 Other hardware features are not yet supported in this Zephyr port.
 
-The default configuration can be found in
+The configuration of stm32l1_disco can be found in
 :zephyr_file:`boards/st/stm32l1_disco/stm32l1_disco_defconfig`
+
+Configuration of stm32l152c_disco can be found in
+:zephyr_file:`boards/st/stm32l1_disco/stm32l152c_disco_defconfig`
 
 Connections and IOs
 ===================
@@ -137,8 +142,9 @@ flashed in the usual way (see :ref:`build_an_application` and
 Flashing
 ========
 
-STM32L1DISCOVERY board includes an ST-LINK/V2 embedded debug tool interface.
-This interface is supported by the openocd version included in the Zephyr SDK.
+STM32L1DISCOVERY and STM32L152CDISCOVERY boards include an ST-LINK/V2 embedded
+debug tool interface. This interface is supported by the openocd version
+included in the Zephyr SDK.
 
 Flashing an application
 -----------------------
@@ -177,3 +183,6 @@ References
 
 .. _STM32L1DISCOVERY board User Manual:
    https://www.st.com/resource/en/user_manual/dm00027954.pdf
+
+.. _STM32L152CDISCOVERY board User Manual:
+   https://www.st.com/resource/en/user_manual/um1079-discovery-kit-with-stm32l152rc-mcu-stmicroelectronics.pdf

--- a/boards/st/stm32l1_disco/stm32l152c_disco.dts
+++ b/boards/st/stm32l1_disco/stm32l152c_disco.dts
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2024 Maxin John
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+#include <st/l1/stm32l152Xc.dtsi>
+#include <st/l1/stm32l152r(6-8-b)tx-pinctrl.dtsi>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
+
+/ {
+	model = "STMicroelectronics STM32L152CDISCOVERY board";
+	compatible = "st,stm32l1discovery";
+
+	chosen {
+		zephyr,console = &usart1;
+		zephyr,shell-uart = &usart1;
+		zephyr,sram = &sram0;
+		zephyr,flash = &flash0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		green_led: ld3 {
+			gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
+			label = "User LD3";
+		};
+		blue_led: ld4 {
+			gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+			label = "User LD4";
+		};
+	};
+
+	gpio_keys {
+		compatible = "gpio-keys";
+		user_button: button {
+			label = "User";
+			gpios = <&gpioa 0 GPIO_ACTIVE_LOW>;
+			zephyr,code = <INPUT_KEY_0>;
+		};
+	};
+
+	aliases {
+		led0 = &green_led;
+		led1 = &blue_led;
+		sw0 = &user_button;
+	};
+};
+
+&clk_lsi {
+	status = "okay";
+};
+
+&clk_hsi {
+	status = "okay";
+};
+
+&pll {
+	div = <4>;
+	mul = <8>;
+	/* out of the box, MCO from stlink is not enabled, unlike later discos */
+	clocks = <&clk_hsi>;
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&pll>;
+	clock-frequency = <DT_FREQ_M(32)>;
+	ahb-prescaler = <1>;
+	apb1-prescaler = <1>;
+	apb2-prescaler = <1>;
+};
+
+&usart1 {
+	pinctrl-0 = <&usart1_tx_pa9 &usart1_rx_pa10>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+	status = "okay";
+};
+
+&usart2 {
+	pinctrl-0 = <&usart2_tx_pa2 &usart2_rx_pa3>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+	status = "okay";
+};
+
+&usart3 {
+	pinctrl-0 = <&usart3_tx_pb10 &usart3_rx_pb11>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+	status = "okay";
+};
+
+&i2c1 {
+	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
+	pinctrl-names = "default";
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_FAST>;
+};
+
+&i2c2 {
+	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb11>;
+	pinctrl-names = "default";
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_FAST>;
+};
+
+&spi1 {
+	pinctrl-0 = <&spi1_nss_pa4 &spi1_sck_pa5
+		     &spi1_miso_pa6 &spi1_mosi_pa7>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&spi2 {
+	pinctrl-0 = <&spi2_nss_pb12 &spi2_sck_pb13
+		     &spi2_miso_pb14 &spi2_mosi_pb15>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
+	status = "okay";
+
+	backup_regs {
+		status = "okay";
+	};
+};

--- a/boards/st/stm32l1_disco/stm32l152c_disco.yaml
+++ b/boards/st/stm32l1_disco/stm32l152c_disco.yaml
@@ -1,0 +1,15 @@
+identifier: stm32l152c_disco
+name: ST STM32L152C Discovery
+type: mcu
+arch: arm
+toolchain:
+  - zephyr
+  - gnuarmemb
+  - xtools
+ram: 32
+flash: 256
+supported:
+  - gpio
+  - i2c
+  - spi
+vendor: st

--- a/boards/st/stm32l1_disco/stm32l152c_disco_defconfig
+++ b/boards/st/stm32l1_disco/stm32l152c_disco_defconfig
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# enable uart driver
+CONFIG_SERIAL=y
+
+# enable console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+
+# enable GPIO
+CONFIG_GPIO=y
+
+# Enable Clocks
+CONFIG_CLOCK_CONTROL=y
+
+# enable pin controller
+CONFIG_PINCTRL=y


### PR DESCRIPTION
Add support for STM32L152C-DISCOVERY board. It is similar to STM32L1-DISCOVERY board with more memory ( 256K flash, 32K RAM, 8K EEPROM )

Tested using  samples/philosophers/ 

