### PR TITLE
USB Device App initialization feature

### DIFF
--- a/include/zephyr/usb/usb_device.h
+++ b/include/zephyr/usb/usb_device.h
@@ -4,7 +4,7 @@
  *  LPCUSB, an USB device driver for LPC microcontrollers
  *  Copyright (C) 2006 Bertrik Sikken (bertrik@sikken.nl)
  *  Copyright (c) 2016 Intel Corporation
- *
+  *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
  *
@@ -445,6 +445,19 @@ int usb_wakeup_request(void);
  * @return true if remote wakeup has been enabled by the host, false otherwise.
  */
 bool usb_get_remote_wakeup_status(void);
+
+/**
+ * @brief Initializes the USB Device stack from the Application
+ *
+ * This function exists to provide a mechanism for the application
+ * to initialize the USB device stack. It should be called only from
+ * the application itself. USB_DEVICE_INITIALIZE_BY_APP should be enabled
+ * to allow for this function to be used.
+ *
+ * @return 0 on success, negative errno code on fail
+ */
+int usb_device_init_app(void);
+
 
 /**
  * @}

--- a/subsys/usb/device/Kconfig
+++ b/subsys/usb/device/Kconfig
@@ -158,6 +158,13 @@ config USB_DEVICE_INITIALIZE_AT_BOOT
 	help
 	  Use CDC ACM UART as backend for console, shell, or logging.
 
+config USB_DEVICE_INITIALIZE_BY_APP
+	bool "Initializes Device by Application"
+	help
+	  Enable this to allow the application to manually initialize the USB Device Stack instead of automatically at boot.
+	  For example, this allows delaying initialization until hardware is ready or to load serial or other information
+	  into the descriptors.
+
 source "subsys/usb/device/class/Kconfig"
 
 endif # USB_DEVICE_STACK

--- a/subsys/usb/device/usb_device.c
+++ b/subsys/usb/device/usb_device.c
@@ -1721,4 +1721,13 @@ static int usb_device_init(void)
 	return 0;
 }
 
+int usb_device_init_app(void)
+{
+	return usb_device_init();
+}
+
+
+
+#if !IS_ENABLED(CONFIG_USB_DEVICE_INITIALIZE_BY_APP)
 SYS_INIT(usb_device_init, POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY);
+#endif


### PR DESCRIPTION
By default the USB Device stack is initialized at POST_KERNEL. However, many cases including hardware and serial number retrieval requirements mean that the USB device stack should be initialized later.

This commit adds a new configuration option that if enabled stops the USB Device stack from automatically initializing post kernel init. The function usb_device_init_app() is then be used to manually initialize it later at the application level.

Fixes #71347