### PR TITLE
ci: Switch to CI image v0.26.11

### DIFF
--- a/.github/workflows/bsim-tests.yaml
+++ b/.github/workflows/bsim-tests.yaml
@@ -34,7 +34,7 @@ jobs:
     runs-on:
       group: zephyr-runner-v2-linux-x64-4xlarge
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.26.9.20240223
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.26.11.20240324
       options: '--entrypoint /bin/bash'
     env:
       ZEPHYR_TOOLCHAIN_VARIANT: zephyr

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on:
       group: zephyr-runner-v2-linux-x64-4xlarge
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.26.9.20240223
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.26.11.20240324
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on:
       group: zephyr-runner-v2-linux-x64-4xlarge
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.26.9.20240223
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.26.11.20240324
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false

--- a/.github/workflows/errno.yml
+++ b/.github/workflows/errno.yml
@@ -10,7 +10,7 @@ jobs:
   check-errno:
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.26.9
+      image: ghcr.io/zephyrproject-rtos/ci:v0.26.11
 
     steps:
       - name: Apply container owner mismatch workaround

--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -26,7 +26,7 @@ jobs:
       group: zephyr-runner-v2-linux-x64-4xlarge
     if: github.repository_owner == 'zephyrproject-rtos'
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.26.9.20240223
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.26.11.20240324
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on:
       group: zephyr-runner-v2-linux-x64-4xlarge
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.26.9.20240223
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.26.11.20240324
       options: '--entrypoint /bin/bash'
     outputs:
       subset: ${{ steps.output-services.outputs.subset }}
@@ -129,7 +129,7 @@ jobs:
     needs: twister-build-prep
     if: needs.twister-build-prep.outputs.size != 0
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.26.9.20240223
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.26.11.20240324
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false

--- a/.github/workflows/twister_tests_blackbox.yml
+++ b/.github/workflows/twister_tests_blackbox.yml
@@ -24,7 +24,7 @@ jobs:
         python-version: [3.8, 3.9, '3.10', '3.11', '3.12']
         os: [ubuntu-22.04]
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.26.9
+      image: ghcr.io/zephyrproject-rtos/ci:v0.26.11
 
     steps:
     - name: Apply Container Owner Mismatch Workaround


### PR DESCRIPTION
This commit updates the CI workflows to use the CI image v0.26.11, which includes bsim 2.2 and nrf-regtool 5.1.0.

---

Tested in https://github.com/zephyrproject-rtos/zephyr-testing/actions/runs/8448074890