### PR TITLE
drivers: spi: support for Nuvoton numaker m2l31x

### DIFF
--- a/drivers/spi/spi_numaker.c
+++ b/drivers/spi/spi_numaker.c
@@ -186,6 +186,16 @@ static int spi_numaker_txrx(const struct device *dev)
 		}
 
 		LOG_DBG("%s --> TX [0x%x] done", __func__, tx_frame);
+	} else {
+		/* Write dummy data to TX register */
+		SPI_WRITE_TX(dev_cfg->spi, 0x00U);
+		time_out_cnt = SystemCoreClock; /* 1 second time-out */
+		while (SPI_IS_BUSY(dev_cfg->spi)) {
+			if (--time_out_cnt == 0) {
+				LOG_ERR("Wait for SPI time-out");
+				return -EIO;
+			}
+		}
 	}
 
 	/* Read received data */

--- a/dts/arm/nuvoton/m2l31x.dtsi
+++ b/dts/arm/nuvoton/m2l31x.dtsi
@@ -213,6 +213,50 @@
 			status = "disabled";
 			interrupts = <21 2>;
 		};
+
+		spi0: spi@40061000 {
+			compatible = "nuvoton,numaker-spi";
+			reg = <0x40061000 0x6c>;
+			interrupts = <23 0>;
+			resets = <&rst NUMAKER_SPI0_RST>;
+			clocks = <&pcc NUMAKER_SPI0_MODULE NUMAKER_CLK_CLKSEL2_SPI0SEL_HIRC 0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+		};
+
+		spi1: spi@40062000 {
+			compatible = "nuvoton,numaker-spi";
+			reg = <0x40062000 0x6c>;
+			interrupts = <51 0>;
+			resets = <&rst NUMAKER_SPI1_RST>;
+			clocks = <&pcc NUMAKER_SPI1_MODULE NUMAKER_CLK_CLKSEL2_SPI1SEL_HIRC 0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+		};
+
+		spi2: spi@40063000 {
+			compatible = "nuvoton,numaker-spi";
+			reg = <0x40063000 0x6c>;
+			interrupts = <52 0>;
+			resets = <&rst NUMAKER_SPI2_RST>;
+			clocks = <&pcc NUMAKER_SPI2_MODULE NUMAKER_CLK_CLKSEL3_SPI2SEL_HIRC 0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+		};
+
+		spi3: spi@40064000 {
+			compatible = "nuvoton,numaker-spi";
+			reg = <0x40064000 0x6c>;
+			interrupts = <62 0>;
+			resets = <&rst NUMAKER_SPI3_RST>;
+			clocks = <&pcc NUMAKER_SPI3_MODULE NUMAKER_CLK_CLKSEL3_SPI3SEL_HIRC 0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+		};
 	};
 };
 

--- a/tests/drivers/spi/spi_loopback/boards/numaker_m2l31ki.conf
+++ b/tests/drivers/spi/spi_loopback/boards/numaker_m2l31ki.conf
@@ -1,0 +1,1 @@
+CONFIG_SPI_ASYNC=n

--- a/tests/drivers/spi/spi_loopback/boards/numaker_m2l31ki.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/numaker_m2l31ki.overlay
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+&pinctrl {
+/* EVB's NU5: SS/CLK/MISO/MOSI */
+	spi0_default: spi0_default {
+		group0 {
+			pinmux = <PD3MFP_SPI0_SS>,
+				 <PD2MFP_SPI0_CLK>,
+				 <PD1MFP_SPI0_MISO>,
+				 <PD0MFP_SPI0_MOSI>;
+		};
+	};
+};
+
+&gpioa {
+	status = "okay";
+};
+
+&spi0 {
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <500000>;
+	};
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <16000000>;
+	};
+	status = "okay";
+	pinctrl-0 = <&spi0_default>;
+	pinctrl-names = "default";
+};

--- a/west.yml
+++ b/west.yml
@@ -188,7 +188,7 @@ manifest:
       groups:
         - hal
     - name: hal_nuvoton
-      revision: cf24f9ebd893b349cec439ef7eaac6554a6b6d6f
+      revision: 34efb92e37bd07043a2cab7fff847d8443d930f9
       path: modules/hal/nuvoton
       groups:
         - hal


### PR DESCRIPTION
This PR is to support SPI driver of Nuvoton NuMaker M2L31X series.

This PR depends on https://github.com/zephyrproject-rtos/hal_nuvoton/pull/10 .