### PR TITLE
choosing the stm32 LPTIM clock source

### DIFF
--- a/soc/st/stm32/Kconfig.defconfig
+++ b/soc/st/stm32/Kconfig.defconfig
@@ -44,6 +44,11 @@ config SYS_CLOCK_TICKS_PER_SEC
 	default  250 if "$(dt_node_int_prop_int,$(DT_STM32_LPTIM_PATH),$(DT_ST_PRESCALER))" = 128
 	depends on STM32_LPTIM_TIMER && STM32_LPTIM_CLOCK_LSI
 
+choice STM32_LPTIM_CLOCK
+	default STM32_LPTIM_CLOCK_LSE if "$(dt_node_ph_array_prop_int,$(DT_STM32_LPTIM_PATH),clocks,1,bus)" = 2
+	default STM32_LPTIM_CLOCK_LSI if "$(dt_node_ph_array_prop_int,$(DT_STM32_LPTIM_PATH),clocks,1,bus)" = 3
+endchoice
+
 config CLOCK_CONTROL_STM32_CUBE
 	default y
 	depends on CLOCK_CONTROL


### PR DESCRIPTION
During the migration to the HW model V2
(commit 8dc3f856229ce083c956aa301c31a23e65bd8cd8)

The choice for the LPTIM clock source 
- STM32_LPTIM_CLOCK_LSE
- STM32_LPTIM_CLOCK_LSI

was not correctly reported to the new HW model V2 of the stm32 soc, in the  ./soc/st/stm32/Kconfig.defconfig file
```
choice STM32_LPTIM_CLOCK
	default STM32_LPTIM_CLOCK_LSE if "$(dt_node_ph_array_prop_int,$(DT_STM32_LPTIM_PATH),clocks,1,bus)" = 2
	default STM32_LPTIM_CLOCK_LSI if "$(dt_node_ph_array_prop_int,$(DT_STM32_LPTIM_PATH),clocks,1,bus)" = 3
endchoice
```

The STM32_LPTIM_CLOCK_LSI  was always selected (by default) even if the DTS has
stm32_lp_tick_source: &lptim1 {
	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x80000000>,
		 <&rcc STM32_SRC_LSE LPTIM1_SEL(3)>;
	status = "okay";
};


