### PR TITLE
libC kconfig: Introduce a new option to avoid the native libC

### DIFF
--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -57,11 +57,17 @@ config SUPPORT_MINIMAL_LIBC
 	help
 	  Legacy symbol that selects MINIMAL_LIBC_SUPPORTED
 
+config NATIVE_LIBC_INCOMPATIBLE
+	bool
+	help
+	  Other Kconfig options can select this, if they are not compatible with the
+	  native/host libC, and should only be compiled with an embedded libC
+
 menu "C Library"
 
 choice LIBC_IMPLEMENTATION
 	prompt "C Library Implementation"
-	default EXTERNAL_LIBC if NATIVE_BUILD && !(NATIVE_LIBRARY && POSIX_API)
+	default EXTERNAL_LIBC if NATIVE_BUILD && !(NATIVE_LIBRARY && NATIVE_LIBC_INCOMPATIBLE)
 	default PICOLIBC
 	default NEWLIB_LIBC if REQUIRES_FULL_LIBC
 	default MINIMAL_LIBC

--- a/lib/posix/options/Kconfig
+++ b/lib/posix/options/Kconfig
@@ -8,6 +8,7 @@ menu "POSIX Options"
 config POSIX_API
 	depends on !NATIVE_APPLICATION
 	bool "POSIX APIs"
+	select NATIVE_LIBC_INCOMPATIBLE
 	help
 	  Enable mostly-standards-compliant implementations of
 	  various POSIX (IEEE 1003.1) APIs.


### PR DESCRIPTION
Let's introduce a new option so components which cannot be used with the native libC can select it.
And at this point let's already have POSIX_API select it instead of being used in the libC choice default.