### PR TITLE
soc: nxp: lpc55s69: Add Sleep Mode to CPU0

### DIFF
--- a/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
@@ -31,6 +31,7 @@
 			reg = <0>;
 			#address-cells = <1>;
 			#size-cells = <1>;
+			cpu-power-states = <&sleep>;
 
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv8m-mpu";
@@ -40,6 +41,15 @@
 		cpu@1 {
 			compatible = "arm,cortex-m33";
 			reg = <1>;
+		};
+
+		power-states {
+			sleep: sleep {
+				compatible = "zephyr,power-state";
+				power-state-name = "runtime-idle";
+				min-residency-us = <4>;
+				exit-latency-us = <4>;
+			};
 		};
 	};
 };

--- a/soc/nxp/lpc/lpc55xxx/CMakeLists.txt
+++ b/soc/nxp/lpc/lpc55xxx/CMakeLists.txt
@@ -24,6 +24,10 @@ if(NOT DEFINED CONFIG_LPC55XXX_SRAM_CLOCKS)
 zephyr_compile_definitions(DONT_ENABLE_DISABLED_RAMBANKS=1)
 endif()
 
+if (CONFIG_SOC_LPC55S69_CPU0)
+  zephyr_sources_ifdef(CONFIG_PM power.c)
+endif()
+
 zephyr_include_directories(.)
 
 set(SOC_LINKER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld CACHE INTERNAL "")

--- a/soc/nxp/lpc/lpc55xxx/Kconfig
+++ b/soc/nxp/lpc/lpc55xxx/Kconfig
@@ -68,6 +68,7 @@ config SOC_LPC55S69_CPU0
 	select HAS_MCUX_CTIMER
 	select HAS_MCUX_SCTIMER
 	select HAS_MCUX_RNG
+	select HAS_PM
 
 if SOC_SERIES_LPC55XXX
 

--- a/soc/nxp/lpc/lpc55xxx/Kconfig.defconfig
+++ b/soc/nxp/lpc/lpc55xxx/Kconfig.defconfig
@@ -7,14 +7,6 @@ config NUM_IRQS
 	# must be >= the highest interrupt number used
 	default 60
 
-# In the LPC55XXX Family, this is currently being used to set the
-# core clock value at it's highest frequency which clocks at 150MHz.
-# Note that flash programming operations are limited to 100MHz, and
-# this PLL should not be used as the core clock in those cases.
-config INIT_PLL1
-	default "y"
-	depends on !(SOC_LPC55S06 || FLASH || BUILD_WITH_TFM)
-
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 144000000 if INIT_PLL1
 	default 96000000

--- a/soc/nxp/lpc/lpc55xxx/power.c
+++ b/soc/nxp/lpc/lpc55xxx/power.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/pm/pm.h>
+
+void pm_state_set(enum pm_state state, uint8_t id)
+{
+	ARG_UNUSED(id);
+
+	switch (state) {
+	case PM_STATE_RUNTIME_IDLE:
+		k_cpu_idle();
+		break;
+	default:
+
+		break;
+	}
+}
+
+void pm_state_exit_post_ops(enum pm_state state, uint8_t id)
+{
+	ARG_UNUSED(state);
+	ARG_UNUSED(id);
+}


### PR DESCRIPTION
Add sleep mode (corresponding to runtime idle in zephyr) to CPU0 on LPC55S69 to enable PM subsystem.