### PR TITLE
pm: runtime: fix race when waiting for suspended event

### DIFF
--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -242,9 +242,10 @@ int pm_device_runtime_get(const struct device *dev)
 		 * nothing else we can do but wait until it finishes.
 		 */
 		while (pm->base.state == PM_DEVICE_STATE_SUSPENDING) {
+			k_event_clear(&pm->event, EVENT_MASK);
 			k_sem_give(&pm->lock);
 
-			k_event_wait(&pm->event, EVENT_MASK, true, K_FOREVER);
+			k_event_wait(&pm->event, EVENT_MASK, false, K_FOREVER);
 
 			(void)k_sem_take(&pm->lock, K_FOREVER);
 		}
@@ -520,9 +521,10 @@ int pm_device_runtime_disable(const struct device *dev)
 
 		/* wait until possible async suspend is completed */
 		while (pm->base.state == PM_DEVICE_STATE_SUSPENDING) {
+			k_event_clear(&pm->event, EVENT_MASK);
 			k_sem_give(&pm->lock);
 
-			k_event_wait(&pm->event, EVENT_MASK, true, K_FOREVER);
+			k_event_wait(&pm->event, EVENT_MASK, false, K_FOREVER);
 
 			(void)k_sem_take(&pm->lock, K_FOREVER);
 		}


### PR DESCRIPTION
This fixes a race condition introduced in #52834:

To wait for the asynchronous suspending work item to complete, a combination of semaphores and events is used. First, the semaphore is released, then the events are cleared (through the boolean argument to k_event_wait), then events are awaited.

However, if the event flag happens to be set by the work handler in the short time between k_sem_give and k_event_wait, it is then cleared by k_event_wait and k_event_wait blocks forever waiting for the event.

Make sure that we clear the event flag before releasing the semaphore.