### PR TITLE
boards: google: dragonclaw: Fix SoC model

### DIFF
--- a/boards/google/dragonclaw/board.yml
+++ b/boards/google/dragonclaw/board.yml
@@ -2,4 +2,4 @@ board:
   name: google_dragonclaw
   vendor: google
   socs:
-    - name: stm32f412zx
+    - name: stm32f412cx

--- a/boards/google/dragonclaw/google_dragonclaw.dts
+++ b/boards/google/dragonclaw/google_dragonclaw.dts
@@ -7,7 +7,7 @@
 /dts-v1/;
 
 #include <st/f4/stm32f412Xg.dtsi>
-#include <st/f4/stm32f412z(e-g)tx-pinctrl.dtsi>
+#include <st/f4/stm32f412c(e-g)ux-pinctrl.dtsi>
 
 / {
 	model = "Google Dragonclaw development board";


### PR DESCRIPTION
Google Dragonclaw board uses STM32F412CGU6 MCU, so fix include in DTS and board.yml