### PR TITLE
regulator: cp9314: Adds support for PGOOD pin

### DIFF
--- a/drivers/regulator/regulator_cp9314.c
+++ b/drivers/regulator/regulator_cp9314.c
@@ -269,12 +269,13 @@ static int regulator_cp9314_enable(const struct device *dev)
 
 	if (config->en_pin.port != NULL) {
 		return gpio_pin_set_dt(&config->en_pin, 1);
-	}
-
-	ret = i2c_reg_update_byte_dt(&config->i2c, CP9314_REG_CTRL1, CP9314_CP_EN, CP9314_CP_EN);
-	if (ret < 0) {
-		LOG_ERR("Unable to set CP_EN");
-		return ret;
+	} else {
+		ret = i2c_reg_update_byte_dt(&config->i2c, CP9314_REG_CTRL1, CP9314_CP_EN,
+					     CP9314_CP_EN);
+		if (ret < 0) {
+			LOG_ERR("Unable to set CP_EN");
+			return ret;
+		}
 	}
 
 	return 0;

--- a/drivers/regulator/regulator_cp9314.c
+++ b/drivers/regulator/regulator_cp9314.c
@@ -66,6 +66,16 @@ LOG_MODULE_REGISTER(CP9314, CONFIG_REGULATOR_LOG_LEVEL);
 #define CP9314_MODE_2TO1        1
 #define CP9314_MODE_3TO1        2
 
+#define CP9314_REG_FLT_FLAG   0x12
+#define CP9314_VIN_OVP_FLAG   BIT(1)
+#define CP9314_VOUT_OVP_FLAG  BIT(0)
+
+#define CP9314_REG_COMP_FLAG0 0x2A
+#define CP9314_IIN_OCP_FLAG   BIT(4)
+
+#define CP9314_REG_COMP_FLAG1 0x2C
+#define CP9314_VIN2OUT_OVP_FLAG BIT(0)
+
 #define CP9314_REG_LION_CFG_1  0x31
 #define CP9314_LB2_DELTA_CFG_1 GENMASK(7, 5)
 
@@ -231,6 +241,47 @@ static struct cp9314_reg_patch otp_1_patch[3] = {
 	{CP9314_REG_BST_CP_PD_CFG, CP9314_LB1_BLANK_CFG, CP9314_LB1_BLANK_CFG},
 	{CP9314_REG_TSBAT_CTRL, CP9314_LB1_STOP_PHASE_SEL, CP9314_LB1_STOP_PHASE_SEL},
 };
+
+static int regulator_cp9314_get_error_flags(const struct device *dev,
+					    regulator_error_flags_t *flags)
+{
+	const struct regulator_cp9314_config *config = dev->config;
+	uint8_t val[3];
+	int ret;
+
+	*flags = 0U;
+
+	ret = i2c_reg_read_byte_dt(&config->i2c, CP9314_REG_FLT_FLAG, &val[0]);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (FIELD_GET(CP9314_VIN_OVP_FLAG, val[0]) || FIELD_GET(CP9314_VOUT_OVP_FLAG, val[0])) {
+		*flags |= REGULATOR_ERROR_OVER_VOLTAGE;
+	}
+
+	ret = i2c_reg_read_byte_dt(&config->i2c, CP9314_REG_COMP_FLAG0, &val[1]);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (FIELD_GET(CP9314_IIN_OCP_FLAG, val[1])) {
+		*flags |= REGULATOR_ERROR_OVER_CURRENT;
+	}
+
+	ret = i2c_reg_read_byte_dt(&config->i2c, CP9314_REG_COMP_FLAG1, &val[2]);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (FIELD_GET(CP9314_VIN2OUT_OVP_FLAG, val[2])) {
+		*flags |= REGULATOR_ERROR_OVER_VOLTAGE;
+	}
+
+	LOG_DBG("FLT_FLAG = 0x%x, COMP_FLAG0 = 0x%x, COMP_FLAG1 = 0x%x", val[0], val[1], val[2]);
+
+	return 0;
+}
 
 static int regulator_cp9314_disable(const struct device *dev)
 {
@@ -558,6 +609,7 @@ static int regulator_cp9314_init(const struct device *dev)
 static const struct regulator_driver_api api = {
 	.enable = regulator_cp9314_enable,
 	.disable = regulator_cp9314_disable,
+	.get_error_flags = regulator_cp9314_get_error_flags,
 };
 
 #define REGULATOR_CP9314_DEFINE(inst)                                                              \

--- a/drivers/regulator/regulator_cp9314.c
+++ b/drivers/regulator/regulator_cp9314.c
@@ -156,6 +156,7 @@ LOG_MODULE_REGISTER(CP9314, CONFIG_REGULATOR_LOG_LEVEL);
 
 #define CP9314_SOFT_RESET_DELAY_MSEC 200
 #define CP9314_EN_DEBOUNCE_USEC      3000
+#define CP9314_T_STARTUP_MSEC        120
 
 #define CP9314_DEVICE_MODE_HOST_4GANG_0x78      0x0
 #define CP9314_DEVICE_MODE_HOST_4GANG_0x72      0x1
@@ -184,6 +185,7 @@ struct regulator_cp9314_config {
 	struct regulator_common_config common;
 	struct i2c_dt_spec i2c;
 	struct gpio_dt_spec en_pin;
+	struct gpio_dt_spec pgood_pin;
 	uint8_t initial_op_mode_idx;
 };
 
@@ -268,13 +270,34 @@ static int regulator_cp9314_enable(const struct device *dev)
 	}
 
 	if (config->en_pin.port != NULL) {
-		return gpio_pin_set_dt(&config->en_pin, 1);
+		ret = gpio_pin_set_dt(&config->en_pin, 1);
+		if (ret < 0) {
+			return ret;
+		}
 	} else {
 		ret = i2c_reg_update_byte_dt(&config->i2c, CP9314_REG_CTRL1, CP9314_CP_EN,
 					     CP9314_CP_EN);
 		if (ret < 0) {
 			LOG_ERR("Unable to set CP_EN");
 			return ret;
+		}
+	}
+
+	k_msleep(CP9314_T_STARTUP_MSEC);
+
+	if (config->pgood_pin.port != NULL) {
+		ret = gpio_pin_get_dt(&config->pgood_pin);
+		if (ret < 0) {
+			return ret;
+		} else if (ret == 0) {
+			return -EINVAL;
+		}
+	} else {
+		ret = i2c_reg_read_byte_dt(&config->i2c, CP9314_REG_CONVERTER, &value);
+		if (ret < 0) {
+			return ret;
+		} else if (FIELD_GET(CP9314_PGOOD_PIN_STS, value) == 0U) {
+			return -EINVAL;
 		}
 	}
 
@@ -412,6 +435,17 @@ static int regulator_cp9314_init(const struct device *dev)
 		return -ENOTSUP;
 	}
 
+	if (config->pgood_pin.port != NULL) {
+		if (!gpio_is_ready_dt(&config->pgood_pin)) {
+			return -ENODEV;
+		}
+
+		ret = gpio_pin_configure_dt(&config->pgood_pin, GPIO_INPUT);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
 	if (config->en_pin.port != NULL) {
 		if (!gpio_is_ready_dt(&config->en_pin)) {
 			return -ENODEV;
@@ -533,6 +567,7 @@ static const struct regulator_driver_api api = {
 		.common = REGULATOR_DT_INST_COMMON_CONFIG_INIT(inst),                              \
 		.i2c = I2C_DT_SPEC_INST_GET(inst),                                                 \
 		.en_pin = GPIO_DT_SPEC_INST_GET_OR(inst, cirrus_en_gpios, {}),                     \
+		.pgood_pin = GPIO_DT_SPEC_INST_GET_OR(inst, cirrus_pgood_gpios, {}),               \
 		.initial_op_mode_idx =                                                             \
 			DT_INST_ENUM_IDX_OR(inst, cirrus_initial_switched_capacitor_mode, -1) + 1, \
 	};                                                                                         \

--- a/dts/bindings/regulator/cirrus,cp9314.yaml
+++ b/dts/bindings/regulator/cirrus,cp9314.yaml
@@ -27,6 +27,10 @@ properties:
     type: phandle-array
     description: GPIO tied to EN pin
 
+  cirrus,pgood-gpios:
+    type: phandle-array
+    description: GPIO tied to PGOOD pin
+
   cirrus,initial-switched-capacitor-mode:
     type: string
     enum:


### PR DESCRIPTION
Adds support for the PGOOD pin. This pin is asserted by the regulator when converter startup has completed and the output is stable.