### PR TITLE
intel_adsp: ace: Fix sparse error

### DIFF
--- a/soc/intel/intel_adsp/ace/power.c
+++ b/soc/intel/intel_adsp/ace/power.c
@@ -43,9 +43,10 @@ __imr void power_init(void)
 #endif /* CONFIG_ADSP_IDLE_CLOCK_GATING */
 
 #if CONFIG_SOC_INTEL_ACE15_MTPM
-	*((uint32_t *)sys_cache_cached_ptr_get(&adsp_pending_buffer)) =
+	*((__sparse_force uint32_t *)sys_cache_cached_ptr_get(&adsp_pending_buffer)) =
 		INTEL_ADSP_ACE15_MAGIC_KEY;
-	cache_data_flush_range(sys_cache_cached_ptr_get(&adsp_pending_buffer),
+	cache_data_flush_range((__sparse_force void *)
+			sys_cache_cached_ptr_get(&adsp_pending_buffer),
 			sizeof(adsp_pending_buffer));
 #endif /* CONFIG_SOC_INTEL_ACE15_MTPM */
 }


### PR DESCRIPTION
Fixes the following errors when sparse (SCA) is enabled:

soc/intel/intel_adsp/ace/power.c:46:12: warning:
    cast removes address space '__cache' of expression
/soc/intel/intel_adsp/ace/power.c:48:9: warning:
    incorrect type in argument 1 (different address spaces)

Fixes #70725