### PR TITLE
samples: drivers: led_strip: Correcting document title to 'LED strip'

### DIFF
--- a/samples/drivers/led_strip/README.rst
+++ b/samples/drivers/led_strip/README.rst
@@ -1,5 +1,5 @@
 .. zephyr:code-sample:: led-strip
-   :name: LED strip sample
+   :name: LED strip
    :relevant-api: led_strip_interface
 
    Control an LED strip example.


### PR DESCRIPTION
Other samples do not include 'sample' in the page title, so following that.