### PR TITLE
net: http: client: Timeout the req only if receiving nothing

### DIFF
--- a/include/zephyr/net/http/client.h
+++ b/include/zephyr/net/http/client.h
@@ -194,6 +194,7 @@ struct http_response {
 	uint8_t cl_present : 1;
 	uint8_t body_found : 1;
 	uint8_t message_complete : 1;
+	uint8_t message_begin : 1;
 };
 
 /** HTTP client internal data that the application should not touch


### PR DESCRIPTION
If we receive some data from the server but not actual data, then return 0 from http_client_req() like we used to do earlier before the commit 28a46c0f60aba41f7f0d099a93dfad80436a6d97