### PR TITLE
scripts: Allow certificate binary files in networking samples

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1248,12 +1248,20 @@ class BinaryFiles(ComplianceTest):
         # svg files are always detected as binary, see .gitattributes
         BINARY_ALLOW_EXT = (".jpg", ".jpeg", ".png", ".svg", ".webp")
 
+        # Allow certificate files in networking samples so that the
+        # samples can work properly.
+        NET_BINARY_ALLOW_SAMPLE_PATHS = "samples/net"
+        NET_BINARY_ALLOW_CERT_EXT = ".der"
+
         for stat in git("diff", "--numstat", "--diff-filter=A",
                         COMMIT_RANGE).splitlines():
             added, deleted, fname = stat.split("\t")
             if added == "-" and deleted == "-":
                 if (fname.startswith(BINARY_ALLOW_PATHS) and
                     fname.endswith(BINARY_ALLOW_EXT)):
+                    continue
+                if (fname.startswith(NET_BINARY_ALLOW_SAMPLE_PATHS) and
+                    fname.endswith(NET_BINARY_ALLOW_CERT_EXT)):
                     continue
                 self.failure(f"Binary file not allowed: {fname}")
 


### PR DESCRIPTION
The samples could have certificate files (with .der suffix) like for example in networking samples. Allow these binary files in the samples/net directory.