### PR TITLE
arch: arm: Add hook called when exiting CPU idle state

### DIFF
--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -53,6 +53,12 @@ config ARM_ON_ENTER_CPU_IDLE_HOOK
 	  If needed, this hook can be used to prevent the CPU from actually
 	  entering sleep by skipping the WFE/WFI instruction.
 
+config ARM_ON_EXIT_CPU_IDLE_HOOK
+	bool
+	help
+	  Enables a hook (z_arm_on_exit_cpu_idle()) that is called when
+	  the CPU wakes up from idle (by k_cpu_idle() or k_cpu_atomic_idle()).
+
 config ARM_ON_ENTER_CPU_IDLE_PREPARE_HOOK
 	bool
 	help

--- a/arch/arm/core/cortex_m/cpu_idle.S
+++ b/arch/arm/core/cortex_m/cpu_idle.S
@@ -132,6 +132,12 @@ SECTION_FUNC(TEXT, arch_cpu_idle)
 	/* Enter low power state */
 	_sleep_if_allowed wfi
 
+#if defined(CONFIG_ARM_ON_EXIT_CPU_IDLE_HOOK)
+	push	{r0, lr}
+	bl	z_arm_on_exit_cpu_idle
+	pop	{r0, lr}
+#endif
+
 	/*
 	 * Clear PRIMASK and flush instruction buffer to immediately service
 	 * the wake-up interrupt.
@@ -178,6 +184,11 @@ SECTION_FUNC(TEXT, arch_cpu_atomic_idle)
 	 * (SEVONPEND is set in z_arm_cpu_idle_init())
 	 */
 	_sleep_if_allowed wfe
+#if defined(CONFIG_ARM_ON_EXIT_CPU_IDLE_HOOK)
+	push	{r0, lr}
+	bl	z_arm_on_exit_cpu_idle
+	pop	{r0, lr}
+#endif
 
 	cmp	r0, #0
 	bne	_irq_disabled
@@ -192,6 +203,11 @@ _irq_disabled:
 	msr	BASEPRI, r1
 
 	_sleep_if_allowed wfe
+#if defined(CONFIG_ARM_ON_EXIT_CPU_IDLE_HOOK)
+	push	{r0, lr}
+	bl	z_arm_on_exit_cpu_idle
+	pop	{r0, lr}
+#endif
 
 	msr	BASEPRI, r0
 	cpsie	i

--- a/include/zephyr/arch/arm/misc.h
+++ b/include/zephyr/arch/arm/misc.h
@@ -51,6 +51,14 @@ extern bool z_arm_thread_is_in_user_mode(void);
 bool z_arm_on_enter_cpu_idle(void);
 #endif
 
+#if defined(CONFIG_ARM_ON_EXIT_CPU_IDLE_HOOK)
+/* Prototype of a hook that can be enabled to be called every time the CPU is
+ * waking up from idle (the calls will be done from k_cpu_idle() and k_cpu_atomic_idle()).
+ * It is called with locked interrupts.
+ */
+void z_arm_on_exit_cpu_idle(void);
+#endif
+
 #if defined(CONFIG_ARM_ON_ENTER_CPU_IDLE_PREPARE_HOOK)
 /* Prototype of a hook that can be enabled to be called every time the CPU is
  * made idle (the calls will be done from k_cpu_idle() and k_cpu_atomic_idle()).


### PR DESCRIPTION
Added a hook which is called when CPU exits cpu idle. There is already one optional which is called on entering CPU idle. Those two can be used to track CPU activity.