### PR TITLE
soc: st: stm32 devices: SW JTAG port pins config with hw model V2

### DIFF
--- a/soc/st/stm32/Kconfig
+++ b/soc/st/stm32/Kconfig
@@ -39,6 +39,14 @@ config STM32_ENABLE_DEBUG_SLEEP_STOP
 	  effectivly destroys the use-case of `west attach`. Also
 	  SEGGER RTT and similar technologies need this.
 
+config SWJ_ANALOG_PRIORITY
+	int "SWJ DP port to analog routine initialization priority"
+	default 49
+	help
+	  Initialization priority of the routine within the PRE_KERNEL1 level.
+	  This priority must be greater than GPIO_INIT_PRIORITY and lower than
+	  UART_INIT_PRIORITY.
+
 choice POWER_SUPPLY_CHOICE
 	prompt "STM32 power supply configuration"
 	default POWER_SUPPLY_LDO

--- a/soc/st/stm32/common/CMakeLists.txt
+++ b/soc/st/stm32/common/CMakeLists.txt
@@ -11,3 +11,7 @@ zephyr_linker_sources_ifdef(CONFIG_STM32_CCM SECTIONS ccm.ld)
 
 zephyr_sources_ifdef(CONFIG_STM32_BACKUP_SRAM stm32_backup_sram.c)
 zephyr_linker_sources_ifdef(CONFIG_STM32_BACKUP_SRAM SECTIONS stm32_backup_sram.ld)
+
+if (NOT CONFIG_DEBUG AND CONFIG_PM)
+  zephyr_sources_ifdef(CONFIG_DT_HAS_SWJ_CONNECTOR_ENABLED pm_debug_swj.c)
+endif()

--- a/soc/st/stm32/common/pm_debug_swj.c
+++ b/soc/st/stm32/common/pm_debug_swj.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/pinctrl.h>
+#include <zephyr/init.h>
+
+#define SWJ_NODE DT_NODELABEL(swj_port)
+
+PINCTRL_DT_DEFINE(SWJ_NODE);
+
+const struct pinctrl_dev_config *swj_pcfg = PINCTRL_DT_DEV_CONFIG_GET(SWJ_NODE);
+
+/*
+ * Serial Wire / JTAG port pins are enabled as part of SoC default configuration.
+ * When debug access is not needed and in case power consumption performance is
+ * expected, configure matching pins to analog in order to save power.
+ */
+
+static int swj_to_analog(void)
+{
+	int err;
+
+	/* Set Serial Wire / JTAG port pins to analog mode */
+	err = pinctrl_apply_state(swj_pcfg, PINCTRL_STATE_SLEEP);
+	if (err < 0) {
+		__ASSERT(0, "SWJ pinctrl setup failed");
+		return err;
+	}
+
+	return 0;
+}
+
+/* Run this routine as the earliest pin configuration in the target,
+ * to avoid potential conflicts with devices accessing SWJ-DG pins for
+ * their own needs.
+ */
+SYS_INIT(swj_to_analog, PRE_KERNEL_1, CONFIG_SWJ_ANALOG_PRIORITY);


### PR DESCRIPTION
During the migration to Hw model V2, the PR #63495
was not fully reported.
This change is adding the support Serial Wire / JTAG port pins