### PR TITLE
tests/bsim/run_parallel: Create folder for results xml if missing

### DIFF
--- a/tests/bsim/run_parallel.sh
+++ b/tests/bsim/run_parallel.sh
@@ -63,6 +63,8 @@ tmp_res_file=tmp.xml
 
 all_cases_a=( $all_cases )
 n_cases=$((${#all_cases_a[@]}))
+
+mkdir -p $(dirname ${RESULTS_FILE})
 touch ${RESULTS_FILE}
 echo "Attempting to run ${n_cases} cases (logging to \
  `realpath ${RESULTS_FILE}`)"


### PR DESCRIPTION
Create the folder for the results if it does not exist. Fixes these warnings in CI:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/8437978427/job/23109031046?pr=70750#step:13:511
```
touch: cannot touch '/__w/zephyr/zephyr/./bsim_bt/53_bsim_results.xml': No such file or directory
realpath: /__w/zephyr/zephyr/./bsim_bt/53_bsim_results.xml: No such file or directory
```
And the fact that the xml report was then not available
