### PR TITLE
sysbuild: add VPR launcher bootloader

### DIFF
--- a/share/sysbuild/image_configurations/BOOTLOADER_image_default.cmake
+++ b/share/sysbuild/image_configurations/BOOTLOADER_image_default.cmake
@@ -5,25 +5,27 @@
 # This sysbuild CMake file sets the sysbuild controlled settings as properties
 # on Zephyr MCUboot / bootloader image.
 
-set(keytypes CONFIG_BOOT_SIGNATURE_TYPE_NONE
-             CONFIG_BOOT_SIGNATURE_TYPE_RSA
-             CONFIG_BOOT_SIGNATURE_TYPE_ECDSA_P256
-             CONFIG_BOOT_SIGNATURE_TYPE_ED25519)
+if(SB_CONFIG_BOOTLOADER_MCUBOOT)
+  set(keytypes CONFIG_BOOT_SIGNATURE_TYPE_NONE
+               CONFIG_BOOT_SIGNATURE_TYPE_RSA
+               CONFIG_BOOT_SIGNATURE_TYPE_ECDSA_P256
+               CONFIG_BOOT_SIGNATURE_TYPE_ED25519)
 
-if(SB_CONFIG_BOOT_SIGNATURE_TYPE_NONE)
-  set(keytype CONFIG_BOOT_SIGNATURE_TYPE_NONE)
-elseif(SB_CONFIG_BOOT_SIGNATURE_TYPE_RSA)
-  set(keytype CONFIG_BOOT_SIGNATURE_TYPE_RSA)
-elseif(SB_CONFIG_BOOT_SIGNATURE_TYPE_ECDSA_P256)
-  set(keytype CONFIG_BOOT_SIGNATURE_TYPE_ECDSA_P256)
-elseif(SB_CONFIG_BOOT_SIGNATURE_TYPE_ED25519)
-  set(keytype CONFIG_BOOT_SIGNATURE_TYPE_ED25519)
-endif()
-
-foreach(loopkeytype ${keytypes})
-  if("${loopkeytype}" STREQUAL "${keytype}")
-    set_config_bool(${ZCMAKE_APPLICATION} ${loopkeytype} y)
-  else()
-    set_config_bool(${ZCMAKE_APPLICATION} ${loopkeytype} n)
+  if(SB_CONFIG_BOOT_SIGNATURE_TYPE_NONE)
+    set(keytype CONFIG_BOOT_SIGNATURE_TYPE_NONE)
+  elseif(SB_CONFIG_BOOT_SIGNATURE_TYPE_RSA)
+    set(keytype CONFIG_BOOT_SIGNATURE_TYPE_RSA)
+  elseif(SB_CONFIG_BOOT_SIGNATURE_TYPE_ECDSA_P256)
+    set(keytype CONFIG_BOOT_SIGNATURE_TYPE_ECDSA_P256)
+  elseif(SB_CONFIG_BOOT_SIGNATURE_TYPE_ED25519)
+    set(keytype CONFIG_BOOT_SIGNATURE_TYPE_ED25519)
   endif()
-endforeach()
+
+  foreach(loopkeytype ${keytypes})
+    if("${loopkeytype}" STREQUAL "${keytype}")
+      set_config_bool(${ZCMAKE_APPLICATION} ${loopkeytype} y)
+    else()
+      set_config_bool(${ZCMAKE_APPLICATION} ${loopkeytype} n)
+    endif()
+  endforeach()
+endif()

--- a/share/sysbuild/images/bootloader/CMakeLists.txt
+++ b/share/sysbuild/images/bootloader/CMakeLists.txt
@@ -19,4 +19,26 @@ if(SB_CONFIG_BOOTLOADER_MCUBOOT)
   if(SB_CONFIG_BOOT_ENCRYPTION)
     set_config_string(${image} CONFIG_BOOT_ENCRYPTION_KEY_FILE "${SB_CONFIG_BOOT_ENCRYPTION_KEY_FILE}")
   endif()
+
+# Include VPR laucher if enabled.
+elseif(SB_CONFIG_BOOTLOADER_VPR_LAUNCHER)
+  if((${BOARD} STREQUAL "nrf54h20dk") AND (${BOARD_QUALIFIERS} STREQUAL "/nrf54h20/cpuppr"))
+    set(core nrf54h20dk/nrf54h20/cpuapp)
+  else()
+    message(FATAL_ERROR "Unsupported target for VPR launcher")
+  endif()
+
+  set(image vpr_launcher)
+  ExternalZephyrProject_Add(
+    APPLICATION ${image}
+    SOURCE_DIR ${ZEPHYR_BASE}/samples/basic/minimal
+    APP_TYPE BOOTLOADER
+    BOARD ${core}
+  )
+
+  if(SB_CONFIG_BOOT_XIP)
+    sysbuild_cache_set(VAR ${image}_SNIPPET APPEND REMOVE_DUPLICATES nordic-ppr-xip)
+  else()
+    sysbuild_cache_set(VAR ${image}_SNIPPET APPEND REMOVE_DUPLICATES nordic-ppr)
+  endif()
 endif()

--- a/share/sysbuild/images/bootloader/Kconfig
+++ b/share/sysbuild/images/bootloader/Kconfig
@@ -26,6 +26,10 @@ config BOOTLOADER_MCUBOOT
 	help
 	  Include MCUboot (Zephyr port) as the bootloader to use
 
+config BOOTLOADER_VPR_LAUNCHER
+	bool "VPR launcher"
+	help
+	  Include VPR launcher as the bootloader to use
 endchoice
 
 if BOOTLOADER_MCUBOOT
@@ -79,5 +83,12 @@ config BOOT_ENCRYPTION_KEY_FILE
 	default ""
 	help
 	  Absolute path to encryption key file to use with MCUBoot.
+
+endif
+
+if BOOTLOADER_VPR_LAUNCHER
+
+config BOOT_XIP
+	bool "Use XIP snippet and skip copying to RAM"
 
 endif


### PR DESCRIPTION
Extend sysbuild bootloader mechanism with a new bootloader: VPR launcher, which takes minimal sample and adds `nordic-ppr{-xip}` snippet.
This way, PPR can be easily used with examples (and tests) that do not require any action on APP side.