### PR TITLE
net: dhcpv4: remove conditions in header

### DIFF
--- a/include/zephyr/net/dhcpv4.h
+++ b/include/zephyr/net/dhcpv4.h
@@ -64,8 +64,6 @@ enum net_dhcpv4_msg_type {
 	NET_DHCPV4_MSG_TYPE_INFORM	= 8,
 };
 
-#ifdef CONFIG_NET_DHCPV4_OPTION_CALLBACKS
-
 struct net_dhcpv4_option_callback;
 
 /**
@@ -161,10 +159,6 @@ int net_dhcpv4_add_option_callback(struct net_dhcpv4_option_callback *cb);
  */
 int net_dhcpv4_remove_option_callback(struct net_dhcpv4_option_callback *cb);
 
-#endif /* CONFIG_NET_DHCPV4_OPTION_CALLBACKS */
-
-#ifdef CONFIG_NET_DHCPV4_OPTION_CALLBACKS_VENDOR_SPECIFIC
-
 /**
  * @brief Helper to initialize a struct net_dhcpv4_option_callback for encapsulated vendor-specific
  * options properly
@@ -202,8 +196,6 @@ int net_dhcpv4_add_option_vendor_callback(struct net_dhcpv4_option_callback *cb)
  * @return 0 if successful, negative errno code on failure.
  */
 int net_dhcpv4_remove_option_vendor_callback(struct net_dhcpv4_option_callback *cb);
-
-#endif /* CONFIG_NET_DHCPV4_OPTION_CALLBACKS_VENDOR_SPECIFIC */
 
 /**
  *  @brief Start DHCPv4 client on an iface


### PR DESCRIPTION
Remove conditional compile function declarations from dhcpv4.h.
They are not allowed by [Rule A.1: Conditional Compilation](https://docs.zephyrproject.org/latest/contribute/coding_guidelines/index.html#rule-a-1-conditional-compilation)