### PR TITLE
scripts: west_commands: linkserver: fix probe serial number support

### DIFF
--- a/scripts/west_commands/runners/linkserver.py
+++ b/scripts/west_commands/runners/linkserver.py
@@ -130,7 +130,7 @@ class LinkServerBinaryRunner(ZephyrBinaryRunner):
 
             linkserver_cmd = ([self.linkserver] +
                               ["gdbserver"]    +
-                              ["--probe", "#"+str(self.probe) ] +
+                              ["--probe", str(self.probe) ] +
                               ["--gdb-port", str(self.gdb_port )] +
                               ["--semihost-port", str(self.semihost_port) ] +
                               _cmd_core +


### PR DESCRIPTION
With commit f419ea79909 (runner: linkerserver : remove the probe ID hardcode), support was added to use serial numbers with the linkserver --probe argument. However, one invocation of the argument was missed, and still used the "probe index" syntax. Resolve this issue.