### PR TITLE
boards: nxp: frdm_mcxn947: use core argument to target CPU0

### DIFF
--- a/boards/nxp/frdm_mcxn947/board.cmake
+++ b/boards/nxp/frdm_mcxn947/board.cmake
@@ -6,7 +6,8 @@
 
 if(CONFIG_SOC_MCXN947_CPU0)
   board_runner_args(jlink "--device=MCXN947_M33_0" "--reset-after-load")
-  board_runner_args(linkserver  "--device=MCXN947:FRDM-MCXN947:cm33_core0")
+  board_runner_args(linkserver  "--device=MCXN947:FRDM-MCXN947")
+  board_runner_args(linkserver  "--core=cm33_core0")
   board_runner_args(linkserver  "--override=/device/memory/1/flash-driver=MCXN9xx_S.cfx")
   board_runner_args(linkserver  "--override=/device/memory/1/location=0x10000000")
   # Linkserver v1.4.85 and earlier do not include the secure regions in the


### PR DESCRIPTION
In future versions of Linkserver, specifying the core argument within the device string will not be supported. Therefore, move the FRDM MCXN947 board to specify the core directly instead of using the device string.