### PR TITLE
doc: develop: flash_debug: add note for LinkServer breakpoints

### DIFF
--- a/doc/develop/flash_debug/host-tools.rst
+++ b/doc/develop/flash_debug/host-tools.rst
@@ -270,6 +270,10 @@ LinkServer west runner   ``--probe`` option to pass the probe index.
 
    west flash --runner=linkserver --override /device/memory/5/flash-driver=MIMXRT500_SFDP_MXIC_OSPI_S.cfx
 
+4. LinkServer does not install an implicit breakpoint at the reset handler. If
+   you would like to single step from the start of their application, you
+   will need to add a breakpoint at ``main`` or the reset handler manually.
+
 .. _jlink-debug-host-tools:
 
 J-Link Debug Host Tools


### PR DESCRIPTION
LinkServer does not set a breakpoint at reset by default when debugging platforms, so if the user single steps after loading an application they will likely step through ROM code for the target. Add a note clarifying that users need to set a breakpoint at the reset handler or "main" in order to pause their application there.