### PR TITLE
boards: qemu_x86_tiny: Fix linker script

### DIFF
--- a/boards/qemu/x86/qemu_x86_tiny.ld
+++ b/boards/qemu/x86/qemu_x86_tiny.ld
@@ -165,8 +165,8 @@ MEMORY
 	*intc_loapic.c.obj(.##lsect##.*)				\
 	*intc_system_apic.c.obj(.##lsect)				\
 	*intc_system_apic.c.obj(.##lsect##.*)				\
-	*rand32_timer.c.obj(.##lsect)					\
-	*rand32_timer.c.obj(.##lsect##.*)				\
+	*random_timer.c.obj(.##lsect)					\
+	*random_timer.c.obj(.##lsect##.*)				\
 	*uart_console.c.obj(.##lsect)					\
 	*uart_console.c.obj(.##lsect##.*)
 


### PR DESCRIPTION
s/rand32_timer_*/random_timer_*/. It solves a problem introduced in  85a7b27f97713cb917258ac0a276c851a614c5a6