### PR TITLE
tests: drivers: counter: counter_basic_api

### DIFF
--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -959,6 +959,11 @@ static bool reliable_cancel_capable(const struct device *dev)
 		return true;
 	}
 #endif
+#ifdef CONFIG_COUNTER_AMBIQ
+	if (dev == DEVICE_DT_GET(DT_NODELABEL(counter0))) {
+		return true;
+	}
+#endif
 #ifdef CONFIG_COUNTER_NXP_S32_SYS_TIMER
 	if (single_channel_alarm_capable(dev)) {
 		return true;


### PR DESCRIPTION
Enable reliable_cancel_capable feature for Ambiq counter

Signed-off-by: Richard Wheatley <richard.wheatley@ambiq.com>

