### PR TITLE
gdbstub: Improvements to make extending stub easier

### DIFF
--- a/include/zephyr/debug/gdbstub.h
+++ b/include/zephyr/debug/gdbstub.h
@@ -42,6 +42,15 @@ struct gdb_mem_region {
 };
 
 /**
+ * State of the packet processing loop
+ */
+enum gdb_loop_state {
+	GDB_LOOP_RECEIVING,
+	GDB_LOOP_CONTINUE,
+	GDB_LOOP_ERROR,
+};
+
+/**
  * Memory region descriptions used for GDB memory access.
  *
  * This array specifies which region of memory GDB can access

--- a/subsys/debug/gdbstub.c
+++ b/subsys/debug/gdbstub.c
@@ -607,6 +607,11 @@ static void gdb_q_packet(uint8_t *buf, size_t len, enum gdb_loop_state *next_sta
 	gdb_send_packet(NULL, 0);
 }
 
+static void gdb_v_packet(uint8_t *buf, size_t len, enum gdb_loop_state *next_state)
+{
+	gdb_send_packet(NULL, 0);
+}
+
 /**
  * Synchronously communicate with gdb on the host
  */
@@ -836,6 +841,11 @@ int z_gdb_main_loop(struct gdb_ctx *ctx)
 			__fallthrough;
 		case 'Q':
 			gdb_q_packet(buf, sizeof(buf), &state);
+			break;
+
+		/* v packets */
+		case 'v':
+			gdb_v_packet(buf, sizeof(buf), &state);
 			break;
 
 		/*


### PR DESCRIPTION
Make extending the GDB stub easier by introducing a common place to process query packets and v-packets. This also introduces a place to handle `qSupported` packets so that any optional/extended functionality can be advertised to GDB.