### PR TITLE
kernel: reorgs and renames

### DIFF
--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -86,9 +86,16 @@ list(APPEND kernel_files
 
 if(CONFIG_SMP)
 list(APPEND kernel_files
-     smp.c)
+     smp.c
+     ipi.c)
 endif()
 
+endif()
+
+
+if(CONFIG_TIMESLICING)
+list(APPEND kernel_files
+     timeslicing.c)
 endif()
 
 if(CONFIG_SPIN_VALIDATE)

--- a/kernel/include/ipi.h
+++ b/kernel/include/ipi.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+#ifndef ZEPHYR_KERNEL_INCLUDE_IPI_H_
+#define ZEPHYR_KERNEL_INCLUDE_IPI_H_
+
+/* defined in ipi.c when CONFIG_SMP=y */
+#ifdef CONFIG_SMP
+void flag_ipi(void);
+void signal_pending_ipi(void);
+#else
+#define flag_ipi() do { } while (false)
+#define signal_pending_ipi() do { } while (false)
+#endif /* CONFIG_SMP */
+
+#endif /* ZEPHYR_KERNEL_INCLUDE_IPI_H_ */

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -62,6 +62,8 @@ void z_ready_thread(struct k_thread *thread);
 void z_requeue_current(struct k_thread *curr);
 struct k_thread *z_swap_next_thread(void);
 void z_thread_abort(struct k_thread *thread);
+void move_thread_to_end_of_prio_q(struct k_thread *thread);
+bool thread_is_sliceable(struct k_thread *thread);
 
 static inline void z_reschedule_unlocked(void)
 {

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -39,7 +39,6 @@ BUILD_ASSERT(K_LOWEST_APPLICATION_THREAD_PRIO
 
 void z_sched_init(void);
 void z_move_thread_to_end_of_prio_q(struct k_thread *thread);
-int z_is_thread_time_slicing(struct k_thread *thread);
 void z_unpend_thread_no_timeout(struct k_thread *thread);
 struct k_thread *z_unpend1_no_timeout(_wait_q_t *wait_q);
 int z_pend_curr(struct k_spinlock *lock, k_spinlock_key_t key,

--- a/kernel/include/kthread.h
+++ b/kernel/include/kthread.h
@@ -56,7 +56,7 @@ static inline int is_preempt(struct k_thread *thread)
 }
 
 
-static inline int is_metairq(struct k_thread *thread)
+static inline int thread_is_metairq(struct k_thread *thread)
 {
 #if CONFIG_NUM_METAIRQ_PRIORITIES > 0
 	return (thread->base.prio - K_HIGHEST_THREAD_PRIO)
@@ -209,7 +209,7 @@ static ALWAYS_INLINE bool should_preempt(struct k_thread *thread,
 	/* Otherwise we have to be running a preemptible thread or
 	 * switching to a metairq
 	 */
-	if (is_preempt(_current) || is_metairq(thread)) {
+	if (is_preempt(_current) || thread_is_metairq(thread)) {
 		return true;
 	}
 

--- a/kernel/include/kthread.h
+++ b/kernel/include/kthread.h
@@ -12,6 +12,16 @@
 #include <kernel_internal.h>
 #include <timeout_q.h>
 
+
+#define Z_STATE_STR_DUMMY       "dummy"
+#define Z_STATE_STR_PENDING     "pending"
+#define Z_STATE_STR_PRESTART    "prestart"
+#define Z_STATE_STR_DEAD        "dead"
+#define Z_STATE_STR_SUSPENDED   "suspended"
+#define Z_STATE_STR_ABORTING    "aborting"
+#define Z_STATE_STR_SUSPENDING  "suspending"
+#define Z_STATE_STR_QUEUED      "queued"
+
 #ifdef CONFIG_THREAD_MONITOR
 /* This lock protects the linked list of active threads; i.e. the
  * initial _kernel.threads pointer and the linked list made up of

--- a/kernel/include/kthread.h
+++ b/kernel/include/kthread.h
@@ -49,7 +49,7 @@ static inline void thread_schedule_new(struct k_thread *thread, k_timeout_t dela
 }
 #endif /* CONFIG_MULTITHREADING */
 
-static inline int is_preempt(struct k_thread *thread)
+static inline int thread_is_preemptible(struct k_thread *thread)
 {
 	/* explanation in kernel_struct.h */
 	return thread->base.preempt <= _PREEMPT_THRESHOLD;
@@ -209,7 +209,7 @@ static ALWAYS_INLINE bool should_preempt(struct k_thread *thread,
 	/* Otherwise we have to be running a preemptible thread or
 	 * switching to a metairq
 	 */
-	if (is_preempt(_current) || thread_is_metairq(thread)) {
+	if (thread_is_preemptible(_current) || thread_is_metairq(thread)) {
 		return true;
 	}
 

--- a/kernel/include/kthread.h
+++ b/kernel/include/kthread.h
@@ -9,6 +9,7 @@
 #define ZEPHYR_KERNEL_INCLUDE_THREAD_H_
 
 #include <zephyr/kernel.h>
+#include <kernel_internal.h>
 #include <timeout_q.h>
 
 #ifdef CONFIG_THREAD_MONITOR
@@ -18,6 +19,8 @@
  */
 extern struct k_spinlock z_thread_monitor_lock;
 #endif /* CONFIG_THREAD_MONITOR */
+
+void idle(void *unused1, void *unused2, void *unused3);
 
 /* clean up when a thread is aborted */
 
@@ -45,5 +48,192 @@ static inline void thread_schedule_new(struct k_thread *thread, k_timeout_t dela
 #endif /* CONFIG_SYS_CLOCK_EXISTS */
 }
 #endif /* CONFIG_MULTITHREADING */
+
+static inline int is_preempt(struct k_thread *thread)
+{
+	/* explanation in kernel_struct.h */
+	return thread->base.preempt <= _PREEMPT_THRESHOLD;
+}
+
+
+static inline int is_metairq(struct k_thread *thread)
+{
+#if CONFIG_NUM_METAIRQ_PRIORITIES > 0
+	return (thread->base.prio - K_HIGHEST_THREAD_PRIO)
+		< CONFIG_NUM_METAIRQ_PRIORITIES;
+#else
+	ARG_UNUSED(thread);
+	return 0;
+#endif /* CONFIG_NUM_METAIRQ_PRIORITIES */
+}
+
+#if CONFIG_ASSERT
+static inline bool is_thread_dummy(struct k_thread *thread)
+{
+	return (thread->base.thread_state & _THREAD_DUMMY) != 0U;
+}
+#endif /* CONFIG_ASSERT */
+
+
+static inline bool z_is_thread_suspended(struct k_thread *thread)
+{
+	return (thread->base.thread_state & _THREAD_SUSPENDED) != 0U;
+}
+
+static inline bool z_is_thread_pending(struct k_thread *thread)
+{
+	return (thread->base.thread_state & _THREAD_PENDING) != 0U;
+}
+
+static inline bool z_is_thread_prevented_from_running(struct k_thread *thread)
+{
+	uint8_t state = thread->base.thread_state;
+
+	return (state & (_THREAD_PENDING | _THREAD_PRESTART | _THREAD_DEAD |
+			 _THREAD_DUMMY | _THREAD_SUSPENDED)) != 0U;
+
+}
+
+static inline bool z_is_thread_timeout_active(struct k_thread *thread)
+{
+	return !z_is_inactive_timeout(&thread->base.timeout);
+}
+
+static inline bool z_is_thread_ready(struct k_thread *thread)
+{
+	return !((z_is_thread_prevented_from_running(thread)) != 0U ||
+		 z_is_thread_timeout_active(thread));
+}
+
+static inline bool z_has_thread_started(struct k_thread *thread)
+{
+	return (thread->base.thread_state & _THREAD_PRESTART) == 0U;
+}
+
+static inline bool z_is_thread_state_set(struct k_thread *thread, uint32_t state)
+{
+	return (thread->base.thread_state & state) != 0U;
+}
+
+static inline bool z_is_thread_queued(struct k_thread *thread)
+{
+	return z_is_thread_state_set(thread, _THREAD_QUEUED);
+}
+
+static inline void z_mark_thread_as_suspended(struct k_thread *thread)
+{
+	thread->base.thread_state |= _THREAD_SUSPENDED;
+
+	SYS_PORT_TRACING_FUNC(k_thread, sched_suspend, thread);
+}
+
+static inline void z_mark_thread_as_not_suspended(struct k_thread *thread)
+{
+	thread->base.thread_state &= ~_THREAD_SUSPENDED;
+
+	SYS_PORT_TRACING_FUNC(k_thread, sched_resume, thread);
+}
+
+static inline void z_mark_thread_as_started(struct k_thread *thread)
+{
+	thread->base.thread_state &= ~_THREAD_PRESTART;
+}
+
+static inline void z_mark_thread_as_pending(struct k_thread *thread)
+{
+	thread->base.thread_state |= _THREAD_PENDING;
+}
+
+static inline void z_mark_thread_as_not_pending(struct k_thread *thread)
+{
+	thread->base.thread_state &= ~_THREAD_PENDING;
+}
+
+/*
+ * This function tags the current thread as essential to system operation.
+ * Exceptions raised by this thread will be treated as a fatal system error.
+ */
+static inline void z_thread_essential_set(struct k_thread *thread)
+{
+	thread->base.user_options |= K_ESSENTIAL;
+}
+
+/*
+ * This function tags the current thread as not essential to system operation.
+ * Exceptions raised by this thread may be recoverable.
+ * (This is the default tag for a thread.)
+ */
+static inline void z_thread_essential_clear(struct k_thread *thread)
+{
+	thread->base.user_options &= ~K_ESSENTIAL;
+}
+
+/*
+ * This routine indicates if the current thread is an essential system thread.
+ *
+ * Returns true if current thread is essential, false if it is not.
+ */
+static inline bool z_is_thread_essential(struct k_thread *thread)
+{
+	return (thread->base.user_options & K_ESSENTIAL) == K_ESSENTIAL;
+}
+
+
+static ALWAYS_INLINE bool should_preempt(struct k_thread *thread,
+					 int preempt_ok)
+{
+	/* Preemption is OK if it's being explicitly allowed by
+	 * software state (e.g. the thread called k_yield())
+	 */
+	if (preempt_ok != 0) {
+		return true;
+	}
+
+	__ASSERT(_current != NULL, "");
+
+	/* Or if we're pended/suspended/dummy (duh) */
+	if (z_is_thread_prevented_from_running(_current)) {
+		return true;
+	}
+
+	/* Edge case on ARM where a thread can be pended out of an
+	 * interrupt handler before the "synchronous" swap starts
+	 * context switching.  Platforms with atomic swap can never
+	 * hit this.
+	 */
+	if (IS_ENABLED(CONFIG_SWAP_NONATOMIC)
+	    && z_is_thread_timeout_active(thread)) {
+		return true;
+	}
+
+	/* Otherwise we have to be running a preemptible thread or
+	 * switching to a metairq
+	 */
+	if (is_preempt(_current) || is_metairq(thread)) {
+		return true;
+	}
+
+	return false;
+}
+
+
+static inline bool z_is_idle_thread_entry(void *entry_point)
+{
+	return entry_point == idle;
+}
+
+static inline bool z_is_idle_thread_object(struct k_thread *thread)
+{
+#ifdef CONFIG_MULTITHREADING
+#ifdef CONFIG_SMP
+	return thread->base.is_idle;
+#else
+	return thread == &z_idle_threads[0];
+#endif /* CONFIG_SMP */
+#else
+	return false;
+#endif /* CONFIG_MULTITHREADING */
+}
+
 
 #endif /* ZEPHYR_KERNEL_INCLUDE_THREAD_H_ */

--- a/kernel/ipi.c
+++ b/kernel/ipi.c
@@ -52,7 +52,7 @@ void z_sched_ipi(void)
 #endif /* CONFIG_TRACE_SCHED_IPI */
 
 #ifdef CONFIG_TIMESLICING
-	if (sliceable(_current)) {
+	if (thread_is_sliceable(_current)) {
 		z_time_slice();
 	}
 #endif /* CONFIG_TIMESLICING */

--- a/kernel/ipi.c
+++ b/kernel/ipi.c
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <kswap.h>
+#include <ksched.h>
+#include <ipi.h>
+
+#ifdef CONFIG_TRACE_SCHED_IPI
+extern void z_trace_sched_ipi(void);
+#endif
+
+
+void flag_ipi(void)
+{
+#if defined(CONFIG_SCHED_IPI_SUPPORTED)
+	if (arch_num_cpus() > 1) {
+		_kernel.pending_ipi = true;
+	}
+#endif /* CONFIG_SCHED_IPI_SUPPORTED */
+}
+
+
+void signal_pending_ipi(void)
+{
+	/* Synchronization note: you might think we need to lock these
+	 * two steps, but an IPI is idempotent.  It's OK if we do it
+	 * twice.  All we require is that if a CPU sees the flag true,
+	 * it is guaranteed to send the IPI, and if a core sets
+	 * pending_ipi, the IPI will be sent the next time through
+	 * this code.
+	 */
+#if defined(CONFIG_SCHED_IPI_SUPPORTED)
+	if (arch_num_cpus() > 1) {
+		if (_kernel.pending_ipi) {
+			_kernel.pending_ipi = false;
+			arch_sched_ipi();
+		}
+	}
+#endif /* CONFIG_SCHED_IPI_SUPPORTED */
+}
+
+void z_sched_ipi(void)
+{
+	/* NOTE: When adding code to this, make sure this is called
+	 * at appropriate location when !CONFIG_SCHED_IPI_SUPPORTED.
+	 */
+#ifdef CONFIG_TRACE_SCHED_IPI
+	z_trace_sched_ipi();
+#endif /* CONFIG_TRACE_SCHED_IPI */
+
+#ifdef CONFIG_TIMESLICING
+	if (sliceable(_current)) {
+		z_time_slice();
+	}
+#endif /* CONFIG_TIMESLICING */
+}

--- a/kernel/mailbox.c
+++ b/kernel/mailbox.c
@@ -18,6 +18,7 @@
 #include <zephyr/init.h>
 /* private kernel APIs */
 #include <ksched.h>
+#include <kthread.h>
 #include <wait_q.h>
 
 #ifdef CONFIG_OBJ_CORE_MAILBOX

--- a/kernel/mutex.c
+++ b/kernel/mutex.c
@@ -30,6 +30,7 @@
 #include <zephyr/kernel_structs.h>
 #include <zephyr/toolchain.h>
 #include <ksched.h>
+#include <kthread.h>
 #include <wait_q.h>
 #include <errno.h>
 #include <zephyr/init.h>

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1320,19 +1320,6 @@ static inline k_tid_t z_vrfy_k_sched_current_thread_query(void)
 #include <syscalls/k_sched_current_thread_query_mrsh.c>
 #endif /* CONFIG_USERSPACE */
 
-int z_impl_k_is_preempt_thread(void)
-{
-	return !arch_is_in_isr() && is_preempt(_current);
-}
-
-#ifdef CONFIG_USERSPACE
-static inline int z_vrfy_k_is_preempt_thread(void)
-{
-	return z_impl_k_is_preempt_thread();
-}
-#include <syscalls/k_is_preempt_thread_mrsh.c>
-#endif /* CONFIG_USERSPACE */
-
 static inline void unpend_all(_wait_q_t *wait_q)
 {
 	struct k_thread *thread;

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -334,7 +334,7 @@ static void update_metairq_preempt(struct k_thread *thread)
 #if (CONFIG_NUM_METAIRQ_PRIORITIES > 0) &&                                                         \
 	(CONFIG_NUM_COOP_PRIORITIES > CONFIG_NUM_METAIRQ_PRIORITIES)
 	if (thread_is_metairq(thread) && !thread_is_metairq(_current) &&
-	    !is_preempt(_current)) {
+	    !thread_is_preemptible(_current)) {
 		/* Record new preemption */
 		_current_cpu->metairq_preempted = _current;
 	} else if (!thread_is_metairq(thread) && !z_is_idle_thread_object(thread)) {

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -248,7 +248,7 @@ static ALWAYS_INLINE struct k_thread *next_up(void)
 	 */
 	struct k_thread *mirqp = _current_cpu->metairq_preempted;
 
-	if (mirqp != NULL && (thread == NULL || !is_metairq(thread))) {
+	if (mirqp != NULL && (thread == NULL || !thread_is_metairq(thread))) {
 		if (!z_is_thread_prevented_from_running(mirqp)) {
 			thread = mirqp;
 		} else {
@@ -333,11 +333,11 @@ static void update_metairq_preempt(struct k_thread *thread)
 {
 #if (CONFIG_NUM_METAIRQ_PRIORITIES > 0) &&                                                         \
 	(CONFIG_NUM_COOP_PRIORITIES > CONFIG_NUM_METAIRQ_PRIORITIES)
-	if (is_metairq(thread) && !is_metairq(_current) &&
+	if (thread_is_metairq(thread) && !thread_is_metairq(_current) &&
 	    !is_preempt(_current)) {
 		/* Record new preemption */
 		_current_cpu->metairq_preempted = _current;
-	} else if (!is_metairq(thread) && !z_is_idle_thread_object(thread)) {
+	} else if (!thread_is_metairq(thread) && !z_is_idle_thread_object(thread)) {
 		/* Returning from existing preemption */
 		_current_cpu->metairq_preempted = NULL;
 	}

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1025,20 +1025,6 @@ void z_sched_init(void)
 #endif /* CONFIG_SCHED_CPU_MASK_PIN_ONLY */
 }
 
-int z_impl_k_thread_priority_get(k_tid_t thread)
-{
-	return thread->base.prio;
-}
-
-#ifdef CONFIG_USERSPACE
-static inline int z_vrfy_k_thread_priority_get(k_tid_t thread)
-{
-	K_OOPS(K_SYSCALL_OBJ(thread, K_OBJ_THREAD));
-	return z_impl_k_thread_priority_get(thread);
-}
-#include <syscalls/k_thread_priority_get_mrsh.c>
-#endif /* CONFIG_USERSPACE */
-
 void z_impl_k_thread_priority_set(k_tid_t thread, int prio)
 {
 	/*

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -219,15 +219,6 @@ static size_t copy_bytes(char *dest, size_t dest_size, const char *src, size_t s
 	return bytes_to_copy;
 }
 
-#define Z_STATE_STR_DUMMY       "dummy"
-#define Z_STATE_STR_PENDING     "pending"
-#define Z_STATE_STR_PRESTART    "prestart"
-#define Z_STATE_STR_DEAD        "dead"
-#define Z_STATE_STR_SUSPENDED   "suspended"
-#define Z_STATE_STR_ABORTING    "aborting"
-#define Z_STATE_STR_SUSPENDING  "suspending"
-#define Z_STATE_STR_QUEUED      "queued"
-
 const char *k_thread_state_str(k_tid_t thread_id, char *buf, size_t buf_size)
 {
 	size_t      off = 0;

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -108,6 +108,19 @@ static inline void *z_vrfy_k_thread_custom_data_get(void)
 #endif /* CONFIG_USERSPACE */
 #endif /* CONFIG_THREAD_CUSTOM_DATA */
 
+int z_impl_k_is_preempt_thread(void)
+{
+	return !arch_is_in_isr() && is_preempt(_current);
+}
+
+#ifdef CONFIG_USERSPACE
+static inline int z_vrfy_k_is_preempt_thread(void)
+{
+	return z_impl_k_is_preempt_thread();
+}
+#include <syscalls/k_is_preempt_thread_mrsh.c>
+#endif /* CONFIG_USERSPACE */
+
 int z_impl_k_thread_name_set(struct k_thread *thread, const char *value)
 {
 #ifdef CONFIG_THREAD_NAME

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -121,6 +121,20 @@ static inline int z_vrfy_k_is_preempt_thread(void)
 #include <syscalls/k_is_preempt_thread_mrsh.c>
 #endif /* CONFIG_USERSPACE */
 
+int z_impl_k_thread_priority_get(k_tid_t thread)
+{
+	return thread->base.prio;
+}
+
+#ifdef CONFIG_USERSPACE
+static inline int z_vrfy_k_thread_priority_get(k_tid_t thread)
+{
+	K_OOPS(K_SYSCALL_OBJ(thread, K_OBJ_THREAD));
+	return z_impl_k_thread_priority_get(thread);
+}
+#include <syscalls/k_thread_priority_get_mrsh.c>
+#endif /* CONFIG_USERSPACE */
+
 int z_impl_k_thread_name_set(struct k_thread *thread, const char *value)
 {
 #ifdef CONFIG_THREAD_NAME

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -110,7 +110,7 @@ static inline void *z_vrfy_k_thread_custom_data_get(void)
 
 int z_impl_k_is_preempt_thread(void)
 {
-	return !arch_is_in_isr() && is_preempt(_current);
+	return !arch_is_in_isr() && thread_is_preemptible(_current);
 }
 
 #ifdef CONFIG_USERSPACE

--- a/kernel/timeslicing.c
+++ b/kernel/timeslicing.c
@@ -38,7 +38,7 @@ static inline int slice_time(struct k_thread *thread)
 
 bool thread_is_sliceable(struct k_thread *thread)
 {
-	bool ret = is_preempt(thread)
+	bool ret = thread_is_preemptible(thread)
 		&& slice_time(thread) != 0
 		&& !z_is_prio_higher(thread->base.prio, slice_max_prio)
 		&& !z_is_thread_prevented_from_running(thread)

--- a/kernel/timeslicing.c
+++ b/kernel/timeslicing.c
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2018, 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/kernel.h>
+#include <kswap.h>
+#include <ksched.h>
+#include <ipi.h>
+
+static int slice_ticks = DIV_ROUND_UP(CONFIG_TIMESLICE_SIZE * Z_HZ_ticks, Z_HZ_ms);
+static int slice_max_prio = CONFIG_TIMESLICE_PRIORITY;
+static struct _timeout slice_timeouts[CONFIG_MP_MAX_NUM_CPUS];
+static bool slice_expired[CONFIG_MP_MAX_NUM_CPUS];
+
+#ifdef CONFIG_SWAP_NONATOMIC
+/* If z_swap() isn't atomic, then it's possible for a timer interrupt
+ * to try to timeslice away _current after it has already pended
+ * itself but before the corresponding context switch.  Treat that as
+ * a noop condition in z_time_slice().
+ */
+struct k_thread *pending_current;
+#endif
+
+static inline int slice_time(struct k_thread *thread)
+{
+	int ret = slice_ticks;
+
+#ifdef CONFIG_TIMESLICE_PER_THREAD
+	if (thread->base.slice_ticks != 0) {
+		ret = thread->base.slice_ticks;
+	}
+#else
+	ARG_UNUSED(thread);
+#endif
+	return ret;
+}
+
+bool sliceable(struct k_thread *thread)
+{
+	bool ret = is_preempt(thread)
+		&& slice_time(thread) != 0
+		&& !z_is_prio_higher(thread->base.prio, slice_max_prio)
+		&& !z_is_thread_prevented_from_running(thread)
+		&& !z_is_idle_thread_object(thread);
+
+#ifdef CONFIG_TIMESLICE_PER_THREAD
+	ret |= thread->base.slice_ticks != 0;
+#endif
+
+	return ret;
+}
+
+static void slice_timeout(struct _timeout *timeout)
+{
+	int cpu = ARRAY_INDEX(slice_timeouts, timeout);
+
+	slice_expired[cpu] = true;
+
+	/* We need an IPI if we just handled a timeslice expiration
+	 * for a different CPU.  Ideally this would be able to target
+	 * the specific core, but that's not part of the API yet.
+	 */
+	if (IS_ENABLED(CONFIG_SMP) && cpu != _current_cpu->id) {
+		flag_ipi();
+	}
+}
+
+void z_reset_time_slice(struct k_thread *thread)
+{
+	int cpu = _current_cpu->id;
+
+	z_abort_timeout(&slice_timeouts[cpu]);
+	slice_expired[cpu] = false;
+	if (sliceable(thread)) {
+		z_add_timeout(&slice_timeouts[cpu], slice_timeout,
+			      K_TICKS(slice_time(thread) - 1));
+	}
+}
+
+void k_sched_time_slice_set(int32_t slice, int prio)
+{
+	K_SPINLOCK(&_sched_spinlock) {
+		slice_ticks = k_ms_to_ticks_ceil32(slice);
+		slice_max_prio = prio;
+		z_reset_time_slice(_current);
+	}
+}
+
+#ifdef CONFIG_TIMESLICE_PER_THREAD
+void k_thread_time_slice_set(struct k_thread *thread, int32_t thread_slice_ticks,
+			     k_thread_timeslice_fn_t expired, void *data)
+{
+	K_SPINLOCK(&_sched_spinlock) {
+		thread->base.slice_ticks = thread_slice_ticks;
+		thread->base.slice_expired = expired;
+		thread->base.slice_data = data;
+	}
+}
+#endif
+
+/* Called out of each timer interrupt */
+void z_time_slice(void)
+{
+	k_spinlock_key_t key = k_spin_lock(&_sched_spinlock);
+	struct k_thread *curr = _current;
+
+#ifdef CONFIG_SWAP_NONATOMIC
+	if (pending_current == curr) {
+		z_reset_time_slice(curr);
+		k_spin_unlock(&_sched_spinlock, key);
+		return;
+	}
+	pending_current = NULL;
+#endif
+
+	if (slice_expired[_current_cpu->id] && sliceable(curr)) {
+#ifdef CONFIG_TIMESLICE_PER_THREAD
+		if (curr->base.slice_expired) {
+			k_spin_unlock(&_sched_spinlock, key);
+			curr->base.slice_expired(curr, curr->base.slice_data);
+			key = k_spin_lock(&_sched_spinlock);
+		}
+#endif
+		if (!z_is_thread_prevented_from_running(curr)) {
+			move_thread_to_end_of_prio_q(curr);
+		}
+		z_reset_time_slice(curr);
+	}
+	k_spin_unlock(&_sched_spinlock, key);
+}

--- a/kernel/timeslicing.c
+++ b/kernel/timeslicing.c
@@ -36,7 +36,7 @@ static inline int slice_time(struct k_thread *thread)
 	return ret;
 }
 
-bool sliceable(struct k_thread *thread)
+bool thread_is_sliceable(struct k_thread *thread)
 {
 	bool ret = is_preempt(thread)
 		&& slice_time(thread) != 0
@@ -72,7 +72,7 @@ void z_reset_time_slice(struct k_thread *thread)
 
 	z_abort_timeout(&slice_timeouts[cpu]);
 	slice_expired[cpu] = false;
-	if (sliceable(thread)) {
+	if (thread_is_sliceable(thread)) {
 		z_add_timeout(&slice_timeouts[cpu], slice_timeout,
 			      K_TICKS(slice_time(thread) - 1));
 	}
@@ -114,7 +114,7 @@ void z_time_slice(void)
 	pending_current = NULL;
 #endif
 
-	if (slice_expired[_current_cpu->id] && sliceable(curr)) {
+	if (slice_expired[_current_cpu->id] && thread_is_sliceable(curr)) {
 #ifdef CONFIG_TIMESLICE_PER_THREAD
 		if (curr->base.slice_expired) {
 			k_spin_unlock(&_sched_spinlock, key);

--- a/tests/kernel/threads/thread_apis/src/main.c
+++ b/tests/kernel/threads/thread_apis/src/main.c
@@ -18,7 +18,10 @@
 #include <zephyr/kernel.h>
 #include <kernel_internal.h>
 #include <string.h>
+
+/* internal kernel APIs */
 #include <ksched.h>
+#include <kthread.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(test);

--- a/tests/kernel/threads/thread_apis/src/test_essential_thread.c
+++ b/tests/kernel/threads/thread_apis/src/test_essential_thread.c
@@ -10,6 +10,7 @@
 /* Internal APIs */
 #include <kernel_internal.h>
 #include <ksched.h>
+#include <kthread.h>
 
 struct k_thread kthread_thread;
 struct k_thread kthread_thread1;


### PR DESCRIPTION

- kernel: move thread related helper function kthread.h
- kernel: sched: remove unused prototype: z_is_thread_time_slicing
- kernel: split timeslicing/ipi code out of sched.c
- kernel: rename sliceable -> thread_is_sliceable
- kernel: thread: rename is_metairq
- kernel: thread: move k_is_preempt_thread to thread.c
- kernel: thread: rename is_preempt
- kernel: thread: move k_thread_priority_get
- kernel: thread: move thread states to header
