### PR TITLE
west_commands: sign: imgtool: fix slot size readout

### DIFF
--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -406,7 +406,7 @@ class ImgtoolSigner(Signer):
 
         # The partitions node, and its subnode, must provide
         # the size of slot1_partition or slot0_partition partition via the regs property.
-        slot_key = 'slot0_partition' if 'slot1_partition' in slots else 'slot0_partition'
+        slot_key = 'slot1_partition' if 'slot1_partition' in slots else 'slot0_partition'
         if not slots[slot_key].regs:
             log.die(f'{slot_key} flash partition has no regs property;',
                     "can't determine size of slot")


### PR DESCRIPTION
This fixes wrong slot selection when reading partition size. According to the comment in code, `slot1_partition` size should be preferred:

> [...] slot1_partition size is used, when available, because in swap-move mode it can be one sector smaller. When not available, fallback to slot0_partition (single slot dfu). [...]

This fixes a typo in the if statement which currently always results in use of `slot0_partition` size:

```
slot_key = 'slot0_partition' if 'slot1_partition' in slots else 'slot0_partition'
```

Fixes: 86c4b4caa91 (@de-nordic).