### PR TITLE
net: dhcpv6: Add configurable DUID buffer length

### DIFF
--- a/include/zephyr/net/dhcpv6.h
+++ b/include/zephyr/net/dhcpv6.h
@@ -38,11 +38,14 @@ enum net_dhcpv6_state {
 } __packed;
 
 #define DHCPV6_TID_SIZE 3
-#define DHCPV6_DUID_MAX_SIZE 20
+
+#ifndef CONFIG_NET_DHCPV6_DUID_MAX_LEN
+#define CONFIG_NET_DHCPV6_DUID_MAX_LEN 22
+#endif
 
 struct net_dhcpv6_duid_raw {
 	uint16_t type;
-	uint8_t buf[DHCPV6_DUID_MAX_SIZE];
+	uint8_t buf[CONFIG_NET_DHCPV6_DUID_MAX_LEN];
 } __packed;
 
 struct net_dhcpv6_duid_storage {

--- a/subsys/net/lib/dhcpv6/Kconfig
+++ b/subsys/net/lib/dhcpv6/Kconfig
@@ -15,6 +15,13 @@ config NET_DHCPV6
 	select NET_MGMT_EVENT
 	depends on NET_IPV6 && NET_UDP
 
+config NET_DHCPV6_DUID_MAX_LEN
+	int "The maximum DUID length (not including a type code)"
+	range 1 128
+	default 22
+	help
+	  This will set the available number of bytes for the DUID.
+
 if NET_DHCPV6
 module = NET_DHCPV6
 module-dep = NET_LOG


### PR DESCRIPTION
According to the `RFC8415` the length of the DUID is at least 1 octet up to 128 octets. Now a user can choose buffer length without the need for source code modification.
Real use case when the DUID buffer length modification is needed:
```
    Server Identifier
        Option: Server Identifier (2)
        Length: 24
        DUID: 000103012d8e0b1e2a02a304000001ffdcb8048c9ca7bf59
        DUID Type: link-layer address plus time (1)                                       <----DUID-LLT
        Hardware type: IP6IP6 tunnel (769)
        DUID Time: Mar 20, 2024 22:01:18.000000000 CET                        <---- 4 additional octets for time value 
        Link-layer address: 2a02a304000001ffdcb8048c9ca7bf59
```
**NOTE:** I set `default` value in `Kconfig` to 22 octets in order to cover the DUID-LLT case.