### PR TITLE
tests: pm/device_runtime: Run in native_sim only

### DIFF
--- a/tests/subsys/pm/device_runtime_api/testcase.yaml
+++ b/tests/subsys/pm/device_runtime_api/testcase.yaml
@@ -1,11 +1,12 @@
+common:
+  tags: pm
+
 tests:
   pm.device_runtime.api:
-    tags: pm
-    integration_platforms:
-      - native_sim
+    platform_allow:
+    - native_sim
   pm.device_runtime.isr_safe.api:
-    tags: pm
-    integration_platforms:
-      - native_sim
+    platform_allow:
+    - native_sim
     extra_configs:
-      - CONFIG_TEST_PM_DEVICE_ISR_SAFE=y
+    - CONFIG_TEST_PM_DEVICE_ISR_SAFE=y


### PR DESCRIPTION
This is an API test and it was not designed to run in a real target. Some attempts to run this test in devices cause the device to hang after the test execution because the device sleeps and no wake up source is set.

Fixes #68453