### PR TITLE
Normalize GNULD_LINKER path

### DIFF
--- a/cmake/modules/FindGnuLd.cmake
+++ b/cmake/modules/FindGnuLd.cmake
@@ -48,6 +48,7 @@ execute_process(COMMAND ${CMAKE_C_COMPILER} --print-prog-name=ld.bfd
                 OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 if(EXISTS "${GNULD_LINKER}")
+  cmake_path(NORMAL_PATH GNULD_LINKER)
   set(GNULD_LINKER_IS_BFD ON CACHE BOOL "Linker BFD compatibility (compiler reported)" FORCE)
 else()
   # Need to clear it or else find_program() won't replace the value.


### PR DESCRIPTION
So instead of 

`c:/portable/zephyr/zephyr-sdk-0.16.5/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/../../../../arm-zephyr-eabi/bin/ld.bfd.exe`

we get a clean

`c:/portable/zephyr/zephyr-sdk-0.16.5/arm-zephyr-eabi/arm-zephyr-eabi/bin/ld.bfd.exe`