### PR TITLE
Make enable_language() clear about what it is actually doing

### DIFF
--- a/cmake/modules/kernel.cmake
+++ b/cmake/modules/kernel.cmake
@@ -131,7 +131,7 @@ project(Zephyr-Kernel VERSION ${PROJECT_VERSION})
 # because clang from OneApi can't recognize them as asm files on
 # windows now.
 list(APPEND CMAKE_ASM_SOURCE_FILE_EXTENSIONS "S")
-enable_language(C CXX ASM)
+enable_language(ASM)
 
 # The setup / configuration of the toolchain itself and the configuration of
 # supported compilation flags are now split, as this allows to use the toolchain


### PR DESCRIPTION
That call to enable_languages() is passed C CXX ASM which misleads the reader into thinking that the three languages are enabled in that call but at that point only ASM is actually because C and CXX were already implicitly enabled by the call to project() above. The suggested change removes the misleading C CXX arguments but we could as well make it clear in the project() call by passing LANGUAGES C CXX.