### PR TITLE
boards: st: nucleo_wb55rg: Add led1 alias

### DIFF
--- a/boards/st/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/st/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -61,6 +61,7 @@
 
 	aliases {
 		led0 = &green_led_2;
+		led1 = &blue_led_1;
 		sw0 = &user_button_1;
 		sw1 = &user_button_2;
 		sw2 = &user_button_3;


### PR DESCRIPTION
This board is missing the led1 alias, which prevents to use some samples such as basic/threads.