### PR TITLE
samples: subsys: task_wdt on the IWDG of the stm32f4

### DIFF
--- a/samples/subsys/task_wdt/boards/nucleo_f401re.overlay
+++ b/samples/subsys/task_wdt/boards/nucleo_f401re.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2024 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * stm32F4 has a WWDG clock by APB1 where the APB1 prescaler is 1..16
+ * this is too low to configure the WWDG clock for this sample.
+ * Thus, use the IWDG instead for running this sample.
+ */
+
+&wwdg {
+	status = "disabled";
+};
+
+&iwdg {
+	status = "okay";
+};

--- a/samples/subsys/task_wdt/boards/nucleo_f411re.overlay
+++ b/samples/subsys/task_wdt/boards/nucleo_f411re.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2024 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * stm32F4 has a WWDG clock by APB1 where the APB1 prescaler is 1..16
+ * this is too low to configure the WWDG clock for this sample.
+ * Thus, use the IWDG instead for running this sample.
+ */
+
+&wwdg {
+	status = "disabled";
+};
+
+&iwdg {
+	status = "okay";
+};


### PR DESCRIPTION
Run the sample on the IWDG of stm32f4 nucleo boards instead of WWDG because the APB1 prescaler cannot
set a WWDG input clock source matching the wd timeout


when running on the WWDG:
```
*** Booting Zephyr OS build v3.6.0-443-g78c40fe31bf2 ***                                                                                               
Task watchdog sample application.                                                                                                                       
[00:00:00.008,000] <dbg> wdt_wwdg_stm32: wwdg_stm32_install_timeout: prescaler: 8                                                                       
[00:00:00.015,000] <dbg> wdt_wwdg_stm32: wwdg_stm32_install_timeout: Desired WDT: 700000 us                                                             
[00:00:00.024,000] <dbg> wdt_wwdg_stm32: wwdg_stm32_install_timeout: Set WDT:     43690 us                                                              
[00:00:00.033,000] <err> task_wdt: hw_wdt install timeout failed: -22                                                                                   
task wdt init failure: -22     
``` 

When running on the IWDG:
```
*** Booting Zephyr OS build v3.6.0-1434-g0301ae65ee9d ***                                                                                               
Task watchdog sample application.                                                                                                                       
Main thread still alive...                                                                                                                              
Control thread started.                                                                                                                                 
Main thread still alive...                                                                                                                              
Main thread still alive...                                                                                                                              
Main thread still alive...                                                                                                                              
Control thread getting stuck...                                                                                                                         
Task watchdog channel 1 callback, thread: control                                                                                                       
Resetting device...�*** Booting Zephyr OS build v3.6.0-1434-g0301ae65ee9d ***                                                                           

```