### PR TITLE
boards: st: nucleo_wb55rg: add mcuboot-{led0,button0} aliases

### DIFF
--- a/boards/st/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/st/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -68,6 +68,8 @@
 		die-temp0 = &die_temp;
 		volt-sensor0 = &vref;
 		volt-sensor1 = &vbat;
+		mcuboot-led0 = &blue_led_1;
+		mcuboot-button0 = &user_button_1;
 	};
 };
 


### PR DESCRIPTION
This adds DT aliases for LED and button used in recovery mode of the **MCUboot** bootloader, on the `nucleo_wb55rg` board.