### PR TITLE
tests: thrift: build_only until c++11 threads are in sdk

### DIFF
--- a/tests/modules/thrift/ThriftTest/testcase.yaml
+++ b/tests/modules/thrift/ThriftTest/testcase.yaml
@@ -1,4 +1,5 @@
 common:
+  build_only: true
   tags:
     - thrift
     - cpp


### PR DESCRIPTION
There was a make-shift mutex implementation added to thrift while waiting for C++11 thread support in the SDK. This was fairly racey and would cause issues in CI regularly.

Make the tests build-only for now until C++11 thread, mutex, etc support is stabilized.

C++11 thread support is being added in https://github.com/zephyrproject-rtos/sdk-ng/pull/735 and tests are in https://github.com/zephyrproject-rtos/zephyr/pull/43729.