### PR TITLE
[xtensa]: Xtensa stack is not 16-bytes aligned in irq/exc

### DIFF
--- a/arch/xtensa/core/offsets/offsets.c
+++ b/arch/xtensa/core/offsets/offsets.c
@@ -9,7 +9,7 @@
 
 #include <xtensa_asm2_context.h>
 
-GEN_ABSOLUTE_SYM(___xtensa_irq_bsa_t_SIZEOF, sizeof(_xtensa_irq_bsa_t));
+GEN_ABSOLUTE_SYM(___xtensa_irq_bsa_t_SIZEOF, ROUND_UP(sizeof(_xtensa_irq_bsa_t), 16));
 GEN_ABSOLUTE_SYM(___xtensa_irq_stack_frame_raw_t_SIZEOF, sizeof(_xtensa_irq_stack_frame_raw_t));
 GEN_ABSOLUTE_SYM(___xtensa_irq_stack_frame_a15_t_SIZEOF, sizeof(_xtensa_irq_stack_frame_a15_t));
 GEN_ABSOLUTE_SYM(___xtensa_irq_stack_frame_a11_t_SIZEOF, sizeof(_xtensa_irq_stack_frame_a11_t));

--- a/arch/xtensa/core/xtensa_asm2_util.S
+++ b/arch/xtensa/core/xtensa_asm2_util.S
@@ -83,7 +83,7 @@ _high_gpr_spill_done:
 	 * time how many registers were spilled, then return, leaving the
 	 * modified SP in A1.
 	 */
-	addi a1, a1, -4
+	addi a1, a1, -16
 	s32i a3, a1, 0
 
 	ret
@@ -101,7 +101,7 @@ _high_gpr_spill_done:
 xtensa_restore_high_regs:
 	/* pop our "original" stack pointer into a2, stash in a3 also */
 	l32i a2, a1, 0
-	addi a1, a1, 4
+	addi a1, a1, 16
 	mov a3, a2
 
 	beq a1, a2, _high_restore_done


### PR DESCRIPTION
When entering interrupt stack pointer is not 16-bytes aligned, because in arch/xtensa/core/xtensa_asm2_util.S we shifting it by 4 bytes.

Fixes #70908