### PR TITLE
cmake: sca: Enable CodeChecker error exit status

### DIFF
--- a/cmake/sca/codechecker/sca.cmake
+++ b/cmake/sca/codechecker/sca.cmake
@@ -40,6 +40,14 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E rm ${output_dir}/codechecker.ready
 )
 
+# If 'codechecker parse' returns an exit status of '2', it means more than 0
+# issues were detected. Suppress the exit status by default, but permit opting
+# in to the failure.
+if(NOT CODECHECKER_PARSE_EXIT_STATUS)
+  set(CODECHECKER_PARSE_OPTS ${CODECHECKER_PARSE_OPTS} || ${CMAKE_COMMAND} -E true)
+endif()
+
+
 if(CODECHECKER_EXPORT)
   string(REPLACE "," ";" export_list ${CODECHECKER_EXPORT})
 
@@ -53,7 +61,6 @@ if(CODECHECKER_EXPORT)
         --export ${export_item}
         --output ${output_dir}/codechecker.${export_item}
         ${CODECHECKER_PARSE_OPTS}
-        || ${CMAKE_COMMAND} -E true # parse has exit code 2 if a report is emitted by an analyzer
       BYPRODUCTS ${output_dir}/codechecker.${export_item}
       VERBATIM
       USES_TERMINAL
@@ -67,7 +74,6 @@ else()
     COMMAND ${CODECHECKER_EXE} parse
       ${output_dir}/codechecker.plist
       ${CODECHECKER_PARSE_OPTS}
-      || ${CMAKE_COMMAND} -E true # parse has exit code 2 if a report is emitted by an analyzer
     VERBATIM
     USES_TERMINAL
     COMMAND_EXPAND_LISTS

--- a/doc/develop/sca/codechecker.rst
+++ b/doc/develop/sca/codechecker.rst
@@ -74,3 +74,15 @@ Optional parser configuration arguments can be passed using the
 
     west build -b mimxrt1064_evk samples/basic/blinky -- -DZEPHYR_SCA_VARIANT=codechecker \
     -DCODECHECKER_EXPORT=html,json -DCODECHECKER_PARSE_OPTS="--trim-path-prefix;$PWD"
+
+Failing the build on CodeChecker issues
+***************************************
+
+By default, CodeChecker identified issues will not fail the build, only generate
+a report. To fail the build if any issues are found (for example, for use in
+CI), pass the ``CODECHECKER_PARSE_EXIT_STATUS=y`` parameter, e.g.
+
+.. code-block:: shell
+
+    west build -b mimxrt1064_evk samples/basic/blinky -- -DZEPHYR_SCA_VARIANT=codechecker \
+    -DCODECHECKER_PARSE_EXIT_STATUS=y


### PR DESCRIPTION
Normally the return code of `CodeChecker analyze` and `CodeChecker parse`
is suppressed, so all the enabled commands can execute instead of
crashing the build.

Add a new option, `CODECHECKER_PARSE_EXIT_STATUS`, to permit failing the
build if `CodeChecker parse` returns non-zero.

Signed-off-by: Noah Pendleton <noah.pendleton@gmail.com>