### PR TITLE
Lib: SMF: Add UML-Style transition logic

### DIFF
--- a/lib/smf/Kconfig
+++ b/lib/smf/Kconfig
@@ -9,7 +9,7 @@ config SMF
 if SMF
 
 config SMF_ANCESTOR_SUPPORT
-	bool "States to have 1 or more ancestors"
+	bool "States may have one or more ancestors"
 	help
 	   If y, then the state machine framework includes ancestor state support
 
@@ -18,5 +18,13 @@ config SMF_INITIAL_TRANSITION
 	bool "Support initial transitions for ancestor states"
 	help
 	   If y, then each state can have an initial transition to a sub-state
+
+config SMF_UML_HSM
+	bool "Use UML Hierarchical State Machine rules"
+	select SMF_INITIAL_TRANSITION
+	select SMF_ANCESTOR_SUPPORT
+	help
+	   If y, then each transitions from parent state follow UML rules.
+	   smf_ctx objects use slightly more memory
 
 endif # SMF

--- a/lib/smf/smf.c
+++ b/lib/smf/smf.c
@@ -9,24 +9,26 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(smf);
 
-/*
- * Private structure (to this file) used to track state machine context.
- * The structure is not used directly, but instead to cast the "internal"
- * member of the smf_ctx structure.
+/**
+ * @brief Private structure (to this file) used to track state machine context.
+ *        The structure is not used directly, but instead to cast the "internal"
+ *        member of the smf_ctx structure.
  */
 struct internal_ctx {
 	bool new_state : 1;
 	bool terminate : 1;
 	bool exit      : 1;
 	bool handled   : 1;
+	bool uml_trans : 1;
+#ifdef CONFIG_SMF_UML_HSM
+	bool entry     : 1;
+#endif
 };
 
-static bool share_paren(const struct smf_state *test_state,
-			const struct smf_state *target_state)
+__unused static bool share_paren(const struct smf_state *test_state,
+				 const struct smf_state *target_state)
 {
-	for (const struct smf_state *state = test_state;
-	     state != NULL;
-	     state = state->parent) {
+	for (const struct smf_state *state = test_state; state != NULL; state = state->parent) {
 		if (target_state == state) {
 			return true;
 		}
@@ -35,8 +37,8 @@ static bool share_paren(const struct smf_state *test_state,
 	return false;
 }
 
-static bool last_state_share_paren(struct smf_ctx *const ctx,
-				   const struct smf_state *state)
+__unused static bool last_state_share_paren(struct smf_ctx *const ctx,
+					    const struct smf_state *state)
 {
 	/* Get parent state of previous state */
 	if (!ctx->previous) {
@@ -46,10 +48,10 @@ static bool last_state_share_paren(struct smf_ctx *const ctx,
 	return share_paren(ctx->previous->parent, state);
 }
 
-static const struct smf_state *get_child_of(const struct smf_state *states,
-					    const struct smf_state *parent)
+__unused static const struct smf_state *get_child_of(const struct smf_state *states,
+						     const struct smf_state *parent)
 {
-	for (const struct smf_state *tmp = states; ; tmp = tmp->parent) {
+	for (const struct smf_state *tmp = states;; tmp = tmp->parent) {
 		if (tmp->parent == parent) {
 			return tmp;
 		}
@@ -62,9 +64,33 @@ static const struct smf_state *get_child_of(const struct smf_state *states,
 	return NULL;
 }
 
-static const struct smf_state *get_last_of(const struct smf_state *states)
+__unused static const struct smf_state *get_last_of(const struct smf_state *states)
 {
 	return get_child_of(states, NULL);
+}
+
+/**
+ * @brief Find the Least Common Ancestor (LCA) of two states
+ *
+ * @param source transition source
+ * @param dest transition destination
+ * @return LCA state, or NULL if states have no LCA.
+ */
+__unused static const struct smf_state *get_lca_of(const struct smf_state *source,
+						   const struct smf_state *dest)
+{
+	for (const struct smf_state *ancestor = source->parent; ancestor != NULL;
+	     ancestor = ancestor->parent) {
+		if (share_paren(dest, ancestor)) {
+			if (ancestor == dest) {
+				/* share_paren get confused if dest is a parent of source */
+				return ancestor->parent;
+			}
+			return ancestor;
+		}
+	}
+
+	return NULL;
 }
 
 /**
@@ -74,10 +100,10 @@ static const struct smf_state *get_last_of(const struct smf_state *states)
  * @param target The entry actions of this target's ancestors are executed
  * @return true if the state machine should terminate, else false
  */
-__unused static bool smf_execute_ancestor_entry_actions(
-		struct smf_ctx *const ctx, const struct smf_state *target)
+__unused static bool smf_execute_ancestor_entry_actions_classic(struct smf_ctx *const ctx,
+								const struct smf_state *target)
 {
-	struct internal_ctx * const internal = (void *) &ctx->internal;
+	struct internal_ctx *const internal = (void *)&ctx->internal;
 
 	for (const struct smf_state *to_execute = get_last_of(target);
 	     to_execute != NULL && to_execute != target;
@@ -105,7 +131,7 @@ __unused static bool smf_execute_ancestor_entry_actions(
  */
 __unused static bool smf_execute_ancestor_run_actions(struct smf_ctx *ctx)
 {
-	struct internal_ctx * const internal = (void *) &ctx->internal;
+	struct internal_ctx *const internal = (void *)&ctx->internal;
 	/* Execute all run actions in reverse order */
 
 	/* Return if the current state switched states */
@@ -126,9 +152,12 @@ __unused static bool smf_execute_ancestor_run_actions(struct smf_ctx *ctx)
 	}
 
 	/* Try to run parent run actions */
-	for (const struct smf_state *tmp_state = ctx->current->parent;
-	     tmp_state != NULL;
+	for (const struct smf_state *tmp_state = ctx->current->parent; tmp_state != NULL;
 	     tmp_state = tmp_state->parent) {
+#ifdef CONFIG_SMF_UML_HSM
+		/* Keep track of where we are */
+		ctx->executing = tmp_state;
+#endif
 		/* Execute parent run action */
 		if (tmp_state->run) {
 			tmp_state->run(ctx);
@@ -162,15 +191,18 @@ __unused static bool smf_execute_ancestor_run_actions(struct smf_ctx *ctx)
  * @param target The exit actions of this target's ancestors are executed
  * @return true if the state machine should terminate, else false
  */
-__unused static bool smf_execute_ancestor_exit_actions(
-		struct smf_ctx *const ctx, const struct smf_state *target)
+__unused static bool smf_execute_ancestor_exit_actions_classic(struct smf_ctx *const ctx,
+							       const struct smf_state *target)
 {
-	struct internal_ctx * const internal = (void *) &ctx->internal;
+	struct internal_ctx *const internal = (void *)&ctx->internal;
+
+	/* Handles the case where smf_set_state() is called with a NULL target */
+	if (target == NULL) {
+		return false;
+	}
 
 	/* Execute all parent exit actions in reverse order */
-
-	for (const struct smf_state *tmp_state = ctx->current->parent;
-	     tmp_state != NULL;
+	for (const struct smf_state *tmp_state = ctx->current->parent; tmp_state != NULL;
 	     tmp_state = tmp_state->parent) {
 		if ((target == NULL || !share_paren(target->parent, tmp_state)) &&
 		    tmp_state->exit) {
@@ -185,10 +217,84 @@ __unused static bool smf_execute_ancestor_exit_actions(
 	return false;
 }
 
+#ifdef CONFIG_SMF_UML_HSM
+/**
+ * @brief Executes all exit actions from ctx->current to the direct child of topmost
+ *
+ * @param ctx State machine context
+ * @param topmost State we are exiting to. Its exit action is not executed
+ * @return true if the state machine should terminate, else false
+ */
+__unused static bool smf_execute_uml_exit_actions(struct smf_ctx *const ctx,
+						  const struct smf_state *topmost)
+{
+	struct internal_ctx *const internal = (void *)&ctx->internal;
+
+	for (const struct smf_state *to_execute = ctx->current; to_execute != topmost;
+	     to_execute = to_execute->parent) {
+		if (to_execute->exit) {
+			to_execute->exit(ctx);
+
+			/* No need to continue if terminate was set in the exit action */
+			if (internal->terminate) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+/**
+ * @brief Executes all entry actions from the direct child of topmost to the new state
+ *
+ * @param ctx State machine context
+ * @param new_state State we are transitioning to
+ * @param topmost State we are entering from. Its entry action is not executed
+ * @return true if the state machine should terminate, else false
+ */
+__unused static bool smf_execute_uml_entry_actions(struct smf_ctx *const ctx,
+						   const struct smf_state *new_state,
+						   const struct smf_state *topmost)
+{
+	struct internal_ctx *const internal = (void *)&ctx->internal;
+
+	if (new_state == topmost) {
+		/* There are no child states, so do nothing */
+		return false;
+	}
+
+	for (const struct smf_state *to_execute = get_child_of(new_state, topmost);
+	     to_execute != NULL && to_execute != new_state;
+	     to_execute = get_child_of(new_state, to_execute)) {
+		/* Execute every entry action EXCEPT that of the topmost state */
+		if (to_execute->entry) {
+			to_execute->entry(ctx);
+
+			/* No need to continue if terminate was set */
+			if (internal->terminate) {
+				return true;
+			}
+		}
+	}
+
+	/* and execute the child entry action */
+	if (new_state->entry) {
+		new_state->entry(ctx);
+
+		/* No need to continue if terminate was set */
+		if (internal->terminate) {
+			return true;
+		}
+	}
+
+	return false;
+}
+#endif
+
 void smf_set_initial(struct smf_ctx *ctx, const struct smf_state *init_state)
 {
-	struct internal_ctx * const internal = (void *) &ctx->internal;
-
+	struct internal_ctx *const internal = (void *)&ctx->internal;
 
 #ifdef CONFIG_SMF_INITIAL_TRANSITION
 	/*
@@ -201,6 +307,7 @@ void smf_set_initial(struct smf_ctx *ctx, const struct smf_state *init_state)
 #endif
 	internal->exit = false;
 	internal->terminate = false;
+	internal->uml_trans = false;
 	ctx->current = init_state;
 	ctx->previous = NULL;
 	ctx->terminate_val = 0;
@@ -208,7 +315,7 @@ void smf_set_initial(struct smf_ctx *ctx, const struct smf_state *init_state)
 	if (IS_ENABLED(CONFIG_SMF_ANCESTOR_SUPPORT)) {
 		internal->new_state = false;
 
-		if (smf_execute_ancestor_entry_actions(ctx, init_state)) {
+		if (smf_execute_ancestor_entry_actions_classic(ctx, init_state)) {
 			return;
 		}
 	}
@@ -219,9 +326,146 @@ void smf_set_initial(struct smf_ctx *ctx, const struct smf_state *init_state)
 	}
 }
 
-void smf_set_state(struct smf_ctx *const ctx, const struct smf_state *target)
+#ifdef CONFIG_SMF_UML_HSM
+void smf_set_initial_uml(struct smf_ctx *ctx, const struct smf_state *init_state)
 {
-	struct internal_ctx * const internal = (void *) &ctx->internal;
+	struct internal_ctx *const internal = (void *)&ctx->internal;
+
+	/*
+	 * The final target will be the deepest leaf state that
+	 * the target contains. Set that as the real target.
+	 */
+	while (init_state->initial) {
+		init_state = init_state->initial;
+	}
+
+	internal->exit = false;
+	internal->terminate = false;
+	internal->uml_trans = true;
+	ctx->current = init_state;
+	ctx->previous = NULL;
+	ctx->terminate_val = 0;
+	ctx->executing = init_state;
+
+	const struct smf_state *topmost = get_last_of(init_state);
+
+	internal->entry = true;
+
+	/* Execute topmost state entry action, since smf_execute_uml_entry_actions() doesn't*/
+	if (topmost->entry) {
+		topmost->entry(ctx);
+		if (internal->terminate) {
+			/* No need to continue if terminate was set */
+			return;
+		}
+	}
+
+	if (smf_execute_uml_entry_actions(ctx, init_state, topmost)) {
+		/* No need to continue if terminate was set */
+		return;
+	}
+
+	internal->entry = false;
+}
+
+__unused static void smf_set_state_uml(struct smf_ctx *const ctx, const struct smf_state *new_state)
+{
+	struct internal_ctx *const internal = (void *)&ctx->internal;
+
+	if (new_state == NULL) {
+		LOG_ERR("new_state cannot be NULL in UML mode");
+		return;
+	}
+
+	/*
+	 * It does not make sense to call smf_set_state_uml in an exit phase of a state
+	 * since we are already in a transition; we would always ignore the
+	 * intended state to transition into.
+	 */
+	if (internal->exit) {
+		LOG_ERR("Calling %s from exit action", __func__);
+		return;
+	}
+	if (internal->entry) {
+		/*
+		 * unlike basic SMF, cannot call from an entry action as ctx->immediate is
+		 * invalid
+		 */
+		LOG_ERR("Calling %s from entry action", __func__);
+		return;
+	}
+
+	const struct smf_state *topmost;
+
+	if (share_paren(ctx->executing, new_state)) {
+		/* new state is a parent of where we are now*/
+		topmost = new_state;
+	} else if (share_paren(new_state, ctx->executing)) {
+		/* we are a parent of the new state */
+		topmost = ctx->executing;
+	} else {
+		/* not directly related, find LCA */
+		topmost = get_lca_of(ctx->executing, new_state);
+	}
+
+	internal->exit = true;
+	internal->new_state = true;
+
+	/* call all exit actions up to (but not including) the topmost */
+	if (smf_execute_uml_exit_actions(ctx, topmost)) {
+		/* No need to continue if terminate was set in the exit action */
+		return;
+	}
+
+	/* if self-transition, call the exit action */
+	if ((ctx->executing == new_state) && (new_state->exit)) {
+		new_state->exit(ctx);
+
+		/* No need to continue if terminate was set in the exit action */
+		if (internal->terminate) {
+			return;
+		}
+	}
+
+	internal->exit = false;
+	internal->entry = true;
+
+	/* if self transition, call the entry action */
+	if ((ctx->executing == new_state) && (new_state->entry)) {
+		new_state->entry(ctx);
+
+		/* No need to continue if terminate was set in the entry action */
+		if (internal->terminate) {
+			return;
+		}
+	}
+
+	/*
+	 * The final target will be the deepest leaf state that
+	 * the target contains. Set that as the real target.
+	 */
+	while (new_state->initial) {
+		new_state = new_state->initial;
+	}
+
+	/* update the state variables */
+	ctx->previous = ctx->current;
+	ctx->current = new_state;
+
+	/* call all entry actions (except those of topmost) */
+	if (smf_execute_uml_entry_actions(ctx, new_state, topmost)) {
+		/* No need to continue if terminate was set in the entry action */
+		return;
+	}
+
+	internal->entry = false;
+}
+#endif
+
+__unused static void smf_set_state_classic(struct smf_ctx *const ctx,
+					   const struct smf_state *target)
+{
+	struct internal_ctx *const internal = (void *)&ctx->internal;
 
 	/*
 	 * It does not make sense to call set_state in an exit phase of a state
@@ -251,7 +495,7 @@ void smf_set_state(struct smf_ctx *const ctx, const struct smf_state *target)
 	if (IS_ENABLED(CONFIG_SMF_ANCESTOR_SUPPORT)) {
 		internal->new_state = true;
 
-		if (smf_execute_ancestor_exit_actions(ctx, target)) {
+		if (smf_execute_ancestor_exit_actions_classic(ctx, target)) {
 			return;
 		}
 	}
@@ -273,7 +517,7 @@ void smf_set_state(struct smf_ctx *const ctx, const struct smf_state *target)
 	ctx->current = target;
 
 	if (IS_ENABLED(CONFIG_SMF_ANCESTOR_SUPPORT)) {
-		if (smf_execute_ancestor_entry_actions(ctx, target)) {
+		if (smf_execute_ancestor_entry_actions_classic(ctx, target)) {
 			return;
 		}
 	}
@@ -288,9 +532,24 @@ void smf_set_state(struct smf_ctx *const ctx, const struct smf_state *target)
 	}
 }
 
+void smf_set_state(struct smf_ctx *const ctx, const struct smf_state *new_state)
+{
+#ifdef CONFIG_SMF_UML_HSM
+	struct internal_ctx *const internal = (void *)&ctx->internal;
+
+	if (internal->uml_trans) {
+		smf_set_state_uml(ctx, new_state);
+	} else {
+		smf_set_state_classic(ctx, new_state);
+	}
+#else
+	smf_set_state_classic(ctx, new_state);
+#endif
+}
+
 void smf_set_terminate(struct smf_ctx *ctx, int32_t val)
 {
-	struct internal_ctx * const internal = (void *) &ctx->internal;
+	struct internal_ctx *const internal = (void *)&ctx->internal;
 
 	internal->terminate = true;
 	ctx->terminate_val = val;
@@ -305,13 +564,15 @@ void smf_set_handled(struct smf_ctx *ctx)
 
 int32_t smf_run_state(struct smf_ctx *const ctx)
 {
-	struct internal_ctx * const internal = (void *) &ctx->internal;
+	struct internal_ctx *const internal = (void *)&ctx->internal;
 
 	/* No need to continue if terminate was set */
 	if (internal->terminate) {
 		return ctx->terminate_val;
 	}
-
+#ifdef CONFIG_SMF_UML_HSM
+	ctx->executing = ctx->current;
+#endif
 	if (ctx->current->run) {
 		ctx->current->run(ctx);
 	}

--- a/tests/lib/smf/CMakeLists.txt
+++ b/tests/lib/smf/CMakeLists.txt
@@ -6,7 +6,9 @@ project(smf)
 
 target_sources(app PRIVATE src/main.c)
 
-if(CONFIG_SMF_INITIAL_TRANSITION)
+if(CONFIG_SMF_UML_HSM)
+  target_sources(app PRIVATE src/test_lib_uml_hsm_smf.c)
+elseif(CONFIG_SMF_INITIAL_TRANSITION)
   target_sources(app PRIVATE src/test_lib_initial_transitions_smf.c)
 elseif(CONFIG_SMF_ANCESTOR_SUPPORT)
   target_sources(app PRIVATE src/test_lib_hierarchical_smf.c

--- a/tests/lib/smf/src/main.c
+++ b/tests/lib/smf/src/main.c
@@ -10,5 +10,4 @@
 #include <zephyr/smf.h>
 #include "test_lib_smf.h"
 
-
 ZTEST_SUITE(smf_tests, NULL, NULL, NULL, NULL, NULL);

--- a/tests/lib/smf/src/test_lib_smf.h
+++ b/tests/lib/smf/src/test_lib_smf.h
@@ -11,5 +11,6 @@ void test_smf_flat(void);
 void test_smf_hierarchical(void);
 void test_smf_hierarchical_5_ancestors(void);
 void test_smf_initial_transitions(void);
+void test_smf_uml_hsm(void);
 
 #endif /* ZEPHYR_TEST_LIB_SMF_H_ */

--- a/tests/lib/smf/src/test_lib_uml_hsm_smf.c
+++ b/tests/lib/smf/src/test_lib_uml_hsm_smf.c
@@ -1,0 +1,580 @@
+/*
+ * Copyright 2024 Glenn Andrews
+ * based on test_lib_hierarchical_smf.c
+ * Copyright 2021 The Chromium OS Authors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/ztest.h>
+#include <zephyr/smf.h>
+
+/*
+ * UML Hierarchical Test Transition:
+ *
+ * This implements a hierarchical state machine using UML rules and
+ * demonstrates both transitions to self (in PARENT_C) and
+ * smf_set_handled (in STATE_B)
+ *
+ * The order of entry, exit and run actions is given in the ordering of the test_value[] array.
+ */
+
+#define TEST_OBJECT(o) ((struct test_object *)o)
+
+#define SMF_RUN 5
+
+/* Initial Setup: Testing initial transitions */
+#define ROOT_ENTRY_BIT      BIT(0)
+#define PARENT_AB_ENTRY_BIT BIT(1)
+#define STATE_A_ENTRY_BIT   BIT(2)
+
+/* Run 0: normal state transition */
+#define STATE_A_RUN_BIT   BIT(3)
+#define STATE_A_EXIT_BIT  BIT(4)
+#define STATE_B_ENTRY_BIT BIT(5)
+
+/* Run 1: Test smf_set_handled() */
+#define STATE_B_1ST_RUN_BIT BIT(6)
+
+/* Run 2: Normal state transition via parent */
+#define STATE_B_2ND_RUN_BIT    BIT(7)
+#define PARENT_AB_RUN_BIT      BIT(8)
+#define STATE_B_EXIT_BIT       BIT(9)
+#define PARENT_AB_EXIT_BIT     BIT(10)
+#define PARENT_C_1ST_ENTRY_BIT BIT(11)
+#define STATE_C_1ST_ENTRY_BIT  BIT(12)
+
+/* Run 3: PARENT_C executes transition to self  */
+#define STATE_C_1ST_RUN_BIT    BIT(13)
+#define PARENT_C_RUN_BIT       BIT(14)
+#define STATE_C_1ST_EXIT_BIT   BIT(15)
+#define PARENT_C_1ST_EXIT_BIT  BIT(16)
+#define PARENT_C_2ND_ENTRY_BIT BIT(17)
+#define STATE_C_2ND_ENTRY_BIT  BIT(18)
+
+/* Run 4: Test transition from parent state */
+#define STATE_C_2ND_RUN_BIT   BIT(19)
+#define STATE_C_2ND_EXIT_BIT  BIT(20)
+#define PARENT_C_2ND_EXIT_BIT BIT(21)
+
+/* Unused functions: Error checks if set */
+#define ROOT_RUN_BIT  BIT(22)
+#define ROOT_EXIT_BIT BIT(23)
+
+/* Number of state transitions for each test: */
+#define TEST_VALUE_NUM              22
+#define TEST_PARENT_ENTRY_VALUE_NUM 1
+#define TEST_PARENT_RUN_VALUE_NUM   8
+#define TEST_PARENT_EXIT_VALUE_NUM  10
+#define TEST_ENTRY_VALUE_NUM        2
+#define TEST_RUN_VALUE_NUM          6
+#define TEST_EXIT_VALUE_NUM         15
+
+static uint32_t test_value[] = {
+	/* Initial Setup */
+	0x000000, /* ROOT_ENTRY_BIT */
+	0x000001, /* PARENT_AB_ENTRY_BIT */
+	0x000003, /* STATE_A_ENTRY_BIT */
+	/* Run 0 */
+	0x000007, /* STATE_A_RUN_BIT */
+	0x00000f, /* STATE_A_EXIT_BIT */
+	0x00001f, /* STATE_B_ENTRY_BIT */
+	/* Run 1 */
+	0x00003f, /* STATE_B_1ST_RUN_BIT */
+	/* Run 2 */
+	0x00007f, /* STATE_B_2ND_RUN_BIT */
+	0x0000ff, /* PARENT_AB_RUN_BIT */
+	0x0001ff, /* STATE_B_EXIT_BIT */
+	0x0003ff, /* PARENT_AB_EXIT_BIT */
+	0x0007ff, /* PARENT_C_1ST_ENTRY_BIT */
+	0x000fff, /* STATE_C_1ST_ENTRY_BIT */
+	/* Run 3 */
+	0x001fff, /* STATE_C_1ST_RUN_BIT */
+	0x003fff, /* PARENT_C_RUN_BIT */
+	0x007fff, /* STATE_C_1ST_EXIT_BIT */
+	0x00ffff, /* PARENT_C_1ST_EXIT_BIT */
+	0x01ffff, /* PARENT_C_2ND_ENTRY_BIT */
+	0x03ffff, /* STATE_C_2ND_ENTRY_BIT */
+	/* Run 4 */
+	0x07ffff, /* STATE_C_2ND_RUN_BIT */
+	0x0fffff, /* STATE_C_2ND_EXIT_BIT */
+	0x1fffff, /* PARENT_C_2ND_EXIT_BIT */
+	/* Post-run Check */
+	0x3fffff, /* FINAL_VALUE */
+};
+
+/* Forward declaration of test_states */
+static const struct smf_state test_states[];
+
+/* List of all TypeC-level states */
+enum test_state {
+	ROOT,
+	PARENT_AB,
+	PARENT_C,
+	STATE_A,
+	STATE_B,
+	STATE_C,
+	STATE_D
+};
+
+enum terminate_action {
+	NONE,
+	ROOT_ENTRY,
+	PARENT_ENTRY,
+	PARENT_RUN,
+	PARENT_EXIT,
+	ENTRY,
+	RUN,
+	EXIT
+};
+
+#define B_ENTRY_FIRST_TIME        BIT(0)
+#define B_RUN_FIRST_TIME          BIT(1)
+#define PARENT_C_ENTRY_FIRST_TIME BIT(2)
+#define C_RUN_FIRST_TIME          BIT(3)
+#define C_ENTRY_FIRST_TIME        BIT(4)
+#define C_EXIT_FIRST_TIME         BIT(5)
+
+#define FIRST_TIME_BITS                                                                            \
+	(B_ENTRY_FIRST_TIME | B_RUN_FIRST_TIME | PARENT_C_ENTRY_FIRST_TIME | C_RUN_FIRST_TIME |    \
+	 C_ENTRY_FIRST_TIME | C_EXIT_FIRST_TIME)
+
+static struct test_object {
+	struct smf_ctx ctx;
+	uint32_t transition_bits;
+	uint32_t tv_idx;
+	enum terminate_action terminate;
+	uint32_t first_time;
+} test_obj;
+
+static void root_entry(void *obj)
+{
+	struct test_object *o = TEST_OBJECT(obj);
+
+	o->tv_idx = 0;
+
+	zassert_equal(o->transition_bits, test_value[o->tv_idx], "Test Root entry failed");
+
+	if (o->terminate == ROOT_ENTRY) {
+		smf_set_terminate(obj, -1);
+		return;
+	}
+
+	o->transition_bits |= ROOT_ENTRY_BIT;
+}
+
+static void root_run(void *obj)
+{
+	struct test_object *o = TEST_OBJECT(obj);
+
+	o->tv_idx++;
+
+	zassert_equal(o->transition_bits, test_value[o->tv_idx], "Test Root run failed");
+
+	o->transition_bits |= ROOT_RUN_BIT;
+
+	/* Return to parent run state */
+}
+
+static void root_exit(void *obj)
+{
+	struct test_object *o = TEST_OBJECT(obj);
+
+	o->tv_idx++;
+
+	zassert_equal(o->transition_bits, test_value[o->tv_idx], "Test Root exit failed");
+	o->transition_bits |= ROOT_EXIT_BIT;
+}
+
+static void parent_ab_entry(void *obj)
+{
+	struct test_object *o = TEST_OBJECT(obj);
+
+	o->tv_idx++;
+
+	zassert_equal(o->transition_bits, test_value[o->tv_idx], "Test Parent AB entry failed");
+
+	if (o->terminate == PARENT_ENTRY) {
+		smf_set_terminate(obj, -1);
+		return;
+	}
+
+	o->transition_bits |= PARENT_AB_ENTRY_BIT;
+}
+
+static void parent_ab_run(void *obj)
+{
+	struct test_object *o = TEST_OBJECT(obj);
+
+	o->tv_idx++;
+
+	zassert_equal(o->transition_bits, test_value[o->tv_idx], "Test Parent AB run failed");
+
+	if (o->terminate == PARENT_RUN) {
+		smf_set_terminate(obj, -1);
+		return;
+	}
+
+	o->transition_bits |= PARENT_AB_RUN_BIT;
+
+	smf_set_state(SMF_CTX(obj), &test_states[STATE_C]);
+}
+
+static void parent_ab_exit(void *obj)
+{
+	struct test_object *o = TEST_OBJECT(obj);
+
+	o->tv_idx++;
+
+	zassert_equal(o->transition_bits, test_value[o->tv_idx], "Test Parent AB exit failed");
+
+	if (o->terminate == PARENT_EXIT) {
+		smf_set_terminate(obj, -1);
+		return;
+	}
+
+	o->transition_bits |= PARENT_AB_EXIT_BIT;
+}
+
+static void parent_c_entry(void *obj)
+{
+	struct test_object *o = TEST_OBJECT(obj);
+
+	o->tv_idx++;
+
+	zassert_equal(o->transition_bits, test_value[o->tv_idx], "Test Parent C entry failed");
+	if (o->first_time & PARENT_C_ENTRY_FIRST_TIME) {
+		o->first_time &= ~PARENT_C_ENTRY_FIRST_TIME;
+		o->transition_bits |= PARENT_C_1ST_ENTRY_BIT;
+	} else {
+		o->transition_bits |= PARENT_C_2ND_ENTRY_BIT;
+	}
+}
+
+static void parent_c_run(void *obj)
+{
+	struct test_object *o = TEST_OBJECT(obj);
+
+	o->tv_idx++;
+
+	zassert_equal(o->transition_bits, test_value[o->tv_idx], "Test Parent C run failed");
+
+	o->transition_bits |= PARENT_C_RUN_BIT;
+
+	smf_set_state(SMF_CTX(obj), &test_states[PARENT_C]);
+}
+
+static void parent_c_exit(void *obj)
+{
+	struct test_object *o = TEST_OBJECT(obj);
+
+	o->tv_idx++;
+
+	zassert_equal(o->transition_bits, test_value[o->tv_idx], "Test Parent C exit failed");
+
+	if (o->first_time & B_ENTRY_FIRST_TIME) {
+		o->first_time &= ~B_ENTRY_FIRST_TIME;
+		o->transition_bits |= PARENT_C_1ST_EXIT_BIT;
+	} else {
+		o->transition_bits |= PARENT_C_2ND_EXIT_BIT;
+	}
+}
+
+static void state_a_entry(void *obj)
+{
+	struct test_object *o = TEST_OBJECT(obj);
+
+	o->tv_idx++;
+
+	zassert_equal(o->transition_bits, test_value[o->tv_idx], "Test State A entry failed");
+
+	if (o->terminate == ENTRY) {
+		smf_set_terminate(obj, -1);
+		return;
+	}
+
+	o->transition_bits |= STATE_A_ENTRY_BIT;
+}
+
+static void state_a_run(void *obj)
+{
+	struct test_object *o = TEST_OBJECT(obj);
+
+	o->tv_idx++;
+
+	zassert_equal(o->transition_bits, test_value[o->tv_idx], "Test State A run failed");
+
+	o->transition_bits |= STATE_A_RUN_BIT;
+
+	smf_set_state(SMF_CTX(obj), &test_states[STATE_B]);
+}
+
+static void state_a_exit(void *obj)
+{
+	struct test_object *o = TEST_OBJECT(obj);
+
+	o->tv_idx++;
+
+	zassert_equal(o->transition_bits, test_value[o->tv_idx], "Test State A exit failed");
+	o->transition_bits |= STATE_A_EXIT_BIT;
+}
+
+static void state_b_entry(void *obj)
+{
+	struct test_object *o = TEST_OBJECT(obj);
+
+	o->tv_idx++;
+
+	zassert_equal(o->transition_bits, test_value[o->tv_idx], "Test State B entry failed");
+
+	o->transition_bits |= STATE_B_ENTRY_BIT;
+}
+
+static void state_b_run(void *obj)
+{
+	struct test_object *o = TEST_OBJECT(obj);
+
+	o->tv_idx++;
+
+	zassert_equal(o->transition_bits, test_value[o->tv_idx], "Test State B run failed");
+
+	if (o->terminate == RUN) {
+		smf_set_terminate(obj, -1);
+		return;
+	}
+
+	if (o->first_time & B_RUN_FIRST_TIME) {
+		o->first_time &= ~B_RUN_FIRST_TIME;
+		o->transition_bits |= STATE_B_1ST_RUN_BIT;
+		smf_set_handled(SMF_CTX(obj));
+	} else {
+		o->transition_bits |= STATE_B_2ND_RUN_BIT;
+		/* bubble up to PARENT_AB */
+	}
+}
+
+static void state_b_exit(void *obj)
+{
+	struct test_object *o = TEST_OBJECT(obj);
+
+	o->tv_idx++;
+
+	zassert_equal(o->transition_bits, test_value[o->tv_idx], "Test State B exit failed");
+
+	o->transition_bits |= STATE_B_EXIT_BIT;
+}
+
+static void state_c_entry(void *obj)
+{
+	struct test_object *o = TEST_OBJECT(obj);
+
+	o->tv_idx++;
+
+	zassert_equal(o->transition_bits, test_value[o->tv_idx], "Test State C entry failed");
+	if (o->first_time & C_ENTRY_FIRST_TIME) {
+		o->first_time &= ~C_ENTRY_FIRST_TIME;
+		o->transition_bits |= STATE_C_1ST_ENTRY_BIT;
+	} else {
+		o->transition_bits |= STATE_C_2ND_ENTRY_BIT;
+	}
+}
+
+static void state_c_run(void *obj)
+{
+	struct test_object *o = TEST_OBJECT(obj);
+
+	o->tv_idx++;
+
+	zassert_equal(o->transition_bits, test_value[o->tv_idx], "Test State C run failed");
+
+	if (o->first_time & C_RUN_FIRST_TIME) {
+		o->first_time &= ~C_RUN_FIRST_TIME;
+		o->transition_bits |= STATE_C_1ST_RUN_BIT;
+		/* Do nothing, Let parent handle it */
+	} else {
+		o->transition_bits |= STATE_C_2ND_RUN_BIT;
+		smf_set_state(SMF_CTX(obj), &test_states[STATE_D]);
+	}
+}
+
+static void state_c_exit(void *obj)
+{
+	struct test_object *o = TEST_OBJECT(obj);
+
+	o->tv_idx++;
+
+	zassert_equal(o->transition_bits, test_value[o->tv_idx], "Test State C exit failed");
+
+	if (o->terminate == EXIT) {
+		smf_set_terminate(obj, -1);
+		return;
+	}
+
+	if (o->first_time & C_EXIT_FIRST_TIME) {
+		o->first_time &= ~C_EXIT_FIRST_TIME;
+		o->transition_bits |= STATE_C_1ST_EXIT_BIT;
+	} else {
+		o->transition_bits |= STATE_C_2ND_EXIT_BIT;
+	}
+}
+
+static void state_d_entry(void *obj)
+{
+	struct test_object *o = TEST_OBJECT(obj);
+
+	o->tv_idx++;
+}
+
+static void state_d_run(void *obj)
+{
+	/* Do nothing */
+}
+
+static void state_d_exit(void *obj)
+{
+	/* Do nothing */
+}
+
+static const struct smf_state test_states[] = {
+	[ROOT] = SMF_CREATE_STATE(root_entry, root_run, root_exit, NULL, &test_states[PARENT_AB]),
+	[PARENT_AB] = SMF_CREATE_STATE(parent_ab_entry, parent_ab_run, parent_ab_exit,
+				       &test_states[ROOT], &test_states[STATE_A]),
+	[PARENT_C] = SMF_CREATE_STATE(parent_c_entry, parent_c_run, parent_c_exit,
+				      &test_states[ROOT], &test_states[STATE_C]),
+	[STATE_A] = SMF_CREATE_STATE(state_a_entry, state_a_run, state_a_exit,
+				     &test_states[PARENT_AB], NULL),
+	[STATE_B] = SMF_CREATE_STATE(state_b_entry, state_b_run, state_b_exit,
+				     &test_states[PARENT_AB], NULL),
+	[STATE_C] = SMF_CREATE_STATE(state_c_entry, state_c_run, state_c_exit,
+				     &test_states[PARENT_C], NULL),
+	[STATE_D] = SMF_CREATE_STATE(state_d_entry, state_d_run, state_d_exit, &test_states[ROOT],
+				     NULL),
+};
+
+ZTEST(smf_tests, test_smf_uml_hsm)
+{
+	/* A) Test state transitions */
+
+	test_obj.transition_bits = 0;
+	test_obj.first_time = FIRST_TIME_BITS;
+	test_obj.terminate = NONE;
+	smf_set_initial_uml((struct smf_ctx *)&test_obj, &test_states[PARENT_AB]);
+
+	for (int i = 0; i < SMF_RUN; i++) {
+		if (smf_run_state((struct smf_ctx *)&test_obj) < 0) {
+			break;
+		}
+	}
+
+	zassert_equal(TEST_VALUE_NUM, test_obj.tv_idx, "Incorrect test value index");
+	zassert_equal(test_obj.transition_bits, test_value[test_obj.tv_idx],
+		      "Final state not reached");
+
+	/* B) Test termination in parent entry action */
+
+	test_obj.transition_bits = 0;
+	test_obj.first_time = FIRST_TIME_BITS;
+	test_obj.terminate = PARENT_ENTRY;
+	smf_set_initial_uml((struct smf_ctx *)&test_obj, &test_states[PARENT_AB]);
+
+	for (int i = 0; i < SMF_RUN; i++) {
+		if (smf_run_state((struct smf_ctx *)&test_obj) < 0) {
+			break;
+		}
+	}
+
+	zassert_equal(TEST_PARENT_ENTRY_VALUE_NUM, test_obj.tv_idx,
+		      "Incorrect test value index for parent entry termination");
+	zassert_equal(test_obj.transition_bits, test_value[test_obj.tv_idx],
+		      "Final parent entry termination state not reached");
+
+	/* C) Test termination in parent run action */
+
+	test_obj.transition_bits = 0;
+	test_obj.first_time = FIRST_TIME_BITS;
+	test_obj.terminate = PARENT_RUN;
+	smf_set_initial_uml((struct smf_ctx *)&test_obj, &test_states[PARENT_AB]);
+
+	for (int i = 0; i < SMF_RUN; i++) {
+		if (smf_run_state((struct smf_ctx *)&test_obj) < 0) {
+			break;
+		}
+	}
+
+	zassert_equal(TEST_PARENT_RUN_VALUE_NUM, test_obj.tv_idx,
+		      "Incorrect test value index for parent run termination");
+	zassert_equal(test_obj.transition_bits, test_value[test_obj.tv_idx],
+		      "Final parent run termination state not reached");
+
+	/* D) Test termination in parent exit action */
+
+	test_obj.transition_bits = 0;
+	test_obj.first_time = FIRST_TIME_BITS;
+	test_obj.terminate = PARENT_EXIT;
+	smf_set_initial_uml((struct smf_ctx *)&test_obj, &test_states[PARENT_AB]);
+
+	for (int i = 0; i < SMF_RUN; i++) {
+		if (smf_run_state((struct smf_ctx *)&test_obj) < 0) {
+			break;
+		}
+	}
+
+	zassert_equal(TEST_PARENT_EXIT_VALUE_NUM, test_obj.tv_idx,
+		      "Incorrect test value index for parent exit termination");
+	zassert_equal(test_obj.transition_bits, test_value[test_obj.tv_idx],
+		      "Final parent exit termination state not reached");
+
+	/* E) Test termination in child entry action */
+
+	test_obj.transition_bits = 0;
+	test_obj.first_time = FIRST_TIME_BITS;
+	test_obj.terminate = ENTRY;
+	smf_set_initial_uml((struct smf_ctx *)&test_obj, &test_states[PARENT_AB]);
+
+	for (int i = 0; i < SMF_RUN; i++) {
+		if (smf_run_state((struct smf_ctx *)&test_obj) < 0) {
+			break;
+		}
+	}
+
+	zassert_equal(TEST_ENTRY_VALUE_NUM, test_obj.tv_idx,
+		      "Incorrect test value index for entry termination");
+	zassert_equal(test_obj.transition_bits, test_value[test_obj.tv_idx],
+		      "Final entry termination state not reached");
+
+	/* F) Test termination in child run action */
+
+	test_obj.transition_bits = 0;
+	test_obj.first_time = FIRST_TIME_BITS;
+	test_obj.terminate = RUN;
+	smf_set_initial_uml((struct smf_ctx *)&test_obj, &test_states[PARENT_AB]);
+
+	for (int i = 0; i < SMF_RUN; i++) {
+		if (smf_run_state((struct smf_ctx *)&test_obj) < 0) {
+			break;
+		}
+	}
+
+	zassert_equal(TEST_RUN_VALUE_NUM, test_obj.tv_idx,
+		      "Incorrect test value index for run termination");
+	zassert_equal(test_obj.transition_bits, test_value[test_obj.tv_idx],
+		      "Final run termination state not reached");
+
+	/* G) Test termination in child exit action */
+
+	test_obj.transition_bits = 0;
+	test_obj.first_time = FIRST_TIME_BITS;
+	test_obj.terminate = EXIT;
+	smf_set_initial_uml((struct smf_ctx *)&test_obj, &test_states[PARENT_AB]);
+
+	for (int i = 0; i < SMF_RUN; i++) {
+		if (smf_run_state((struct smf_ctx *)&test_obj) < 0) {
+			break;
+		}
+	}
+
+	zassert_equal(TEST_EXIT_VALUE_NUM, test_obj.tv_idx,
+		      "Incorrect test value index for exit termination");
+	zassert_equal(test_obj.transition_bits, test_value[test_obj.tv_idx],
+		      "Final exit termination state not reached");
+}

--- a/tests/lib/smf/testcase.yaml
+++ b/tests/lib/smf/testcase.yaml
@@ -12,3 +12,6 @@ tests:
     extra_configs:
       - CONFIG_SMF_ANCESTOR_SUPPORT=y
       - CONFIG_SMF_INITIAL_TRANSITION=y
+  libraries.smf.uml_hsm:
+    extra_configs:
+      - CONFIG_SMF_UML_HSM=y


### PR DESCRIPTION
Add a configuration option (`CONFIG_SMF_UML_HSM`) to make the SMF follow UML-style transitions.

This fixes https://github.com/zephyrproject-rtos/zephyr/issues/66341

If `CONFIG_SMF_UML_HSM` is not set, SMF transitions act as before.