### PR TITLE
posix: convert static inline functions to library functions

### DIFF
--- a/include/zephyr/posix/arpa/inet.h
+++ b/include/zephyr/posix/arpa/inet.h
@@ -17,25 +17,12 @@
 extern "C" {
 #endif
 
-#ifndef CONFIG_NET_SOCKETS_POSIX_NAMES
-
-static inline char *inet_ntop(sa_family_t family, const void *src, char *dst,
-			      size_t size)
-{
-	return zsock_inet_ntop(family, src, dst, size);
-}
-
-static inline int inet_pton(sa_family_t family, const char *src, void *dst)
-{
-	return zsock_inet_pton(family, src, dst);
-}
-
-#endif /* CONFIG_NET_SOCKETS_POSIX_NAMES */
-
 typedef uint32_t in_addr_t;
 
 in_addr_t inet_addr(const char *cp);
 char *inet_ntoa(struct in_addr in);
+char *inet_ntop(sa_family_t family, const void *src, char *dst, size_t size);
+int inet_pton(sa_family_t family, const char *src, void *dst);
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/posix/netdb.h
+++ b/include/zephyr/posix/netdb.h
@@ -57,42 +57,19 @@ struct servent {
 	char *s_proto;
 };
 
-#ifndef CONFIG_NET_SOCKETS_POSIX_NAMES
-
 #define addrinfo zsock_addrinfo
-
-static inline int getaddrinfo(const char *host, const char *service,
-			      const struct zsock_addrinfo *hints,
-			      struct zsock_addrinfo **res)
-{
-	return zsock_getaddrinfo(host, service, hints, res);
-}
-
-static inline void freeaddrinfo(struct zsock_addrinfo *ai)
-{
-	zsock_freeaddrinfo(ai);
-}
-
-static inline const char *gai_strerror(int errcode)
-{
-	return zsock_gai_strerror(errcode);
-}
-
-static inline int getnameinfo(const struct sockaddr *addr, socklen_t addrlen,
-			      char *host, socklen_t hostlen,
-			      char *serv, socklen_t servlen, int flags)
-{
-	return zsock_getnameinfo(addr, addrlen, host, hostlen,
-				 serv, servlen, flags);
-}
-
-#endif /* CONFIG_NET_SOCKETS_POSIX_NAMES */
 
 void endhostent(void);
 void endnetent(void);
 void endprotoent(void);
 void endservent(void);
+void freeaddrinfo(struct zsock_addrinfo *ai);
+const char *gai_strerror(int errcode);
+int getaddrinfo(const char *host, const char *service, const struct zsock_addrinfo *hints,
+		struct zsock_addrinfo **res);
 struct hostent *gethostent(void);
+int getnameinfo(const struct sockaddr *addr, socklen_t addrlen, char *host, socklen_t hostlen,
+		char *serv, socklen_t servlen, int flags);
 struct netent *getnetbyaddr(uint32_t net, int type);
 struct netent *getnetbyname(const char *name);
 struct netent *getnetent(void);

--- a/include/zephyr/posix/poll.h
+++ b/include/zephyr/posix/poll.h
@@ -12,8 +12,6 @@
 extern "C" {
 #endif
 
-#ifndef CONFIG_NET_SOCKETS_POSIX_NAMES
-
 #define pollfd zsock_pollfd
 
 #define POLLIN ZSOCK_POLLIN
@@ -22,12 +20,7 @@ extern "C" {
 #define POLLHUP ZSOCK_POLLHUP
 #define POLLNVAL ZSOCK_POLLNVAL
 
-static inline int poll(struct pollfd *fds, int nfds, int timeout)
-{
-	return zsock_poll(fds, nfds, timeout);
-}
-
-#endif /* CONFIG_NET_SOCKETS_POSIX_NAMES */
+int poll(struct pollfd *fds, int nfds, int timeout);
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/posix/sys/select.h
+++ b/include/zephyr/posix/sys/select.h
@@ -13,8 +13,6 @@
 extern "C" {
 #endif
 
-#ifndef CONFIG_NET_SOCKETS_POSIX_NAMES
-
 #define fd_set zsock_fd_set
 #define FD_SETSIZE ZSOCK_FD_SETSIZE
 #define FD_ZERO ZSOCK_FD_ZERO
@@ -24,15 +22,7 @@ extern "C" {
 
 struct timeval;
 
-static inline int select(int nfds, fd_set *readfds,
-			 fd_set *writefds, fd_set *exceptfds,
-			 struct timeval *timeout)
-{
-	return zsock_select(nfds, readfds, writefds, exceptfds,
-			    (struct zsock_timeval *)timeout);
-}
-
-#endif /* CONFIG_NET_SOCKETS_POSIX_NAMES */
+int select(int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds, struct timeval *timeout);
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/posix/sys/socket.h
+++ b/include/zephyr/posix/sys/socket.h
@@ -9,6 +9,17 @@
 #include <sys/types.h>
 #include <zephyr/net/socket.h>
 
+#ifndef CONFIG_NET_SOCKETS_POSIX_NAMES
+
+#define SHUT_RD   ZSOCK_SHUT_RD
+#define SHUT_WR   ZSOCK_SHUT_WR
+#define SHUT_RDWR ZSOCK_SHUT_RDWR
+
+#define MSG_PEEK     ZSOCK_MSG_PEEK
+#define MSG_TRUNC    ZSOCK_MSG_TRUNC
+#define MSG_DONTWAIT ZSOCK_MSG_DONTWAIT
+#define MSG_WAITALL  ZSOCK_MSG_WAITALL
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -17,8 +28,6 @@ struct linger {
 	int  l_onoff;
 	int  l_linger;
 };
-
-#ifndef CONFIG_NET_SOCKETS_POSIX_NAMES
 
 static inline int socket(int family, int type, int proto)
 {
@@ -29,15 +38,6 @@ static inline int socketpair(int family, int type, int proto, int sv[2])
 {
 	return zsock_socketpair(family, type, proto, sv);
 }
-
-#define SHUT_RD ZSOCK_SHUT_RD
-#define SHUT_WR ZSOCK_SHUT_WR
-#define SHUT_RDWR ZSOCK_SHUT_RDWR
-
-#define MSG_PEEK ZSOCK_MSG_PEEK
-#define MSG_TRUNC ZSOCK_MSG_TRUNC
-#define MSG_DONTWAIT ZSOCK_MSG_DONTWAIT
-#define MSG_WAITALL ZSOCK_MSG_WAITALL
 
 static inline int shutdown(int sock, int how)
 {

--- a/include/zephyr/posix/sys/socket.h
+++ b/include/zephyr/posix/sys/socket.h
@@ -9,8 +9,6 @@
 #include <sys/types.h>
 #include <zephyr/net/socket.h>
 
-#ifndef CONFIG_NET_SOCKETS_POSIX_NAMES
-
 #define SHUT_RD   ZSOCK_SHUT_RD
 #define SHUT_WR   ZSOCK_SHUT_WR
 #define SHUT_RDWR ZSOCK_SHUT_RDWR
@@ -29,103 +27,26 @@ struct linger {
 	int  l_linger;
 };
 
-static inline int socket(int family, int type, int proto)
-{
-	return zsock_socket(family, type, proto);
-}
-
-static inline int socketpair(int family, int type, int proto, int sv[2])
-{
-	return zsock_socketpair(family, type, proto, sv);
-}
-
-static inline int shutdown(int sock, int how)
-{
-	return zsock_shutdown(sock, how);
-}
-
-static inline int bind(int sock, const struct sockaddr *addr, socklen_t addrlen)
-{
-	return zsock_bind(sock, addr, addrlen);
-}
-
-static inline int connect(int sock, const struct sockaddr *addr,
-			  socklen_t addrlen)
-{
-	return zsock_connect(sock, addr, addrlen);
-}
-
-static inline int listen(int sock, int backlog)
-{
-	return zsock_listen(sock, backlog);
-}
-
-static inline int accept(int sock, struct sockaddr *addr, socklen_t *addrlen)
-{
-	return zsock_accept(sock, addr, addrlen);
-}
-
-static inline ssize_t send(int sock, const void *buf, size_t len, int flags)
-{
-	return zsock_send(sock, buf, len, flags);
-}
-
-static inline ssize_t recv(int sock, void *buf, size_t max_len, int flags)
-{
-	return zsock_recv(sock, buf, max_len, flags);
-}
-
-static inline ssize_t sendto(int sock, const void *buf, size_t len, int flags,
-			     const struct sockaddr *dest_addr,
-			     socklen_t addrlen)
-{
-	return zsock_sendto(sock, buf, len, flags, dest_addr, addrlen);
-}
-
-static inline ssize_t sendmsg(int sock, const struct msghdr *message,
-			      int flags)
-{
-	return zsock_sendmsg(sock, message, flags);
-}
-
-static inline ssize_t recvmsg(int sock, struct msghdr *msg, int flags)
-{
-	return zsock_recvmsg(sock, msg, flags);
-}
-
-static inline ssize_t recvfrom(int sock, void *buf, size_t max_len, int flags,
-			       struct sockaddr *src_addr, socklen_t *addrlen)
-{
-	return zsock_recvfrom(sock, buf, max_len, flags, src_addr, addrlen);
-}
-
-static inline int getsockopt(int sock, int level, int optname,
-			     void *optval, socklen_t *optlen)
-{
-	return zsock_getsockopt(sock, level, optname, optval, optlen);
-}
-
-static inline int setsockopt(int sock, int level, int optname,
-			     const void *optval, socklen_t optlen)
-{
-	return zsock_setsockopt(sock, level, optname, optval, optlen);
-}
-
-static inline int getpeername(int sock, struct sockaddr *addr,
-			      socklen_t *addrlen)
-{
-	return zsock_getpeername(sock, addr, addrlen);
-}
-
-static inline int getsockname(int sock, struct sockaddr *addr,
-			      socklen_t *addrlen)
-{
-	return zsock_getsockname(sock, addr, addrlen);
-}
-
-#endif /* CONFIG_NET_SOCKETS_POSIX_NAMES */
-
+int accept(int sock, struct sockaddr *addr, socklen_t *addrlen);
+int bind(int sock, const struct sockaddr *addr, socklen_t addrlen);
+int connect(int sock, const struct sockaddr *addr, socklen_t addrlen);
+int getpeername(int sock, struct sockaddr *addr, socklen_t *addrlen);
+int getsockname(int sock, struct sockaddr *addr, socklen_t *addrlen);
+int getsockopt(int sock, int level, int optname, void *optval, socklen_t *optlen);
+int listen(int sock, int backlog);
+ssize_t recv(int sock, void *buf, size_t max_len, int flags);
+ssize_t recvfrom(int sock, void *buf, size_t max_len, int flags, struct sockaddr *src_addr,
+		 socklen_t *addrlen);
+ssize_t recvmsg(int sock, struct msghdr *msg, int flags);
+ssize_t send(int sock, const void *buf, size_t len, int flags);
+ssize_t sendmsg(int sock, const struct msghdr *message, int flags);
+ssize_t sendto(int sock, const void *buf, size_t len, int flags, const struct sockaddr *dest_addr,
+	       socklen_t addrlen);
+int setsockopt(int sock, int level, int optname, const void *optval, socklen_t optlen);
+int shutdown(int sock, int how);
 int sockatmark(int s);
+int socket(int family, int type, int proto);
+int socketpair(int family, int type, int proto, int sv[2]);
 
 #ifdef __cplusplus
 }

--- a/lib/posix/options/net.c
+++ b/lib/posix/options/net.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2019 Linaro Limited
  * Copyright (c) 2024, Friedt Professional Engineering Services, Inc
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -12,6 +13,11 @@
 #include <zephyr/posix/arpa/inet.h>
 #include <zephyr/posix/netinet/in.h>
 #include <zephyr/posix/net/if.h>
+#include <zephyr/posix/poll.h>
+#include <zephyr/posix/sys/select.h>
+#include <zephyr/posix/sys/socket.h>
+
+/* From arpa/inet.h */
 
 in_addr_t inet_addr(const char *cp)
 {
@@ -79,6 +85,18 @@ char *inet_ntoa(struct in_addr in)
 
 	return buf;
 }
+
+char *inet_ntop(sa_family_t family, const void *src, char *dst, size_t size)
+{
+	return zsock_inet_ntop(family, src, dst, size);
+}
+
+int inet_pton(sa_family_t family, const char *src, void *dst)
+{
+	return zsock_inet_pton(family, src, dst);
+}
+
+/* From net/if.h */
 
 char *if_indextoname(unsigned int ifindex, char *ifname)
 {
@@ -175,6 +193,8 @@ unsigned int if_nametoindex(const char *ifname)
 	return ret;
 }
 
+/* From netdb.h */
+
 void endhostent(void)
 {
 }
@@ -191,9 +211,31 @@ void endservent(void)
 {
 }
 
+void freeaddrinfo(struct zsock_addrinfo *ai)
+{
+	zsock_freeaddrinfo(ai);
+}
+
+const char *gai_strerror(int errcode)
+{
+	return zsock_gai_strerror(errcode);
+}
+
+int getaddrinfo(const char *host, const char *service, const struct zsock_addrinfo *hints,
+		struct zsock_addrinfo **res)
+{
+	return zsock_getaddrinfo(host, service, hints, res);
+}
+
 struct hostent *gethostent(void)
 {
 	return NULL;
+}
+
+int getnameinfo(const struct sockaddr *addr, socklen_t addrlen, char *host, socklen_t hostlen,
+		char *serv, socklen_t servlen, int flags)
+{
+	return zsock_getnameinfo(addr, addrlen, host, hostlen, serv, servlen, flags);
 }
 
 struct netent *getnetbyaddr(uint32_t net, int type)
@@ -214,6 +256,11 @@ struct netent *getnetbyname(const char *name)
 struct netent *getnetent(void)
 {
 	return NULL;
+}
+
+int getpeername(int sock, struct sockaddr *addr, socklen_t *addrlen)
+{
+	return zsock_getpeername(sock, addr, addrlen);
 }
 
 struct protoent *getprotobyname(const char *name)
@@ -276,10 +323,104 @@ void setservent(int stayopen)
 	ARG_UNUSED(stayopen);
 }
 
+/* From sys/socket.h */
+
+int accept(int sock, struct sockaddr *addr, socklen_t *addrlen)
+{
+	return zsock_accept(sock, addr, addrlen);
+}
+
+int bind(int sock, const struct sockaddr *addr, socklen_t addrlen)
+{
+	return zsock_bind(sock, addr, addrlen);
+}
+
+int connect(int sock, const struct sockaddr *addr, socklen_t addrlen)
+{
+	return zsock_connect(sock, addr, addrlen);
+}
+
+int getsockname(int sock, struct sockaddr *addr, socklen_t *addrlen)
+{
+	return zsock_getsockname(sock, addr, addrlen);
+}
+
+int getsockopt(int sock, int level, int optname, void *optval, socklen_t *optlen)
+{
+	return zsock_getsockopt(sock, level, optname, optval, optlen);
+}
+
+int listen(int sock, int backlog)
+{
+	return zsock_listen(sock, backlog);
+}
+
+int poll(struct pollfd *fds, int nfds, int timeout)
+{
+	return zsock_poll(fds, nfds, timeout);
+}
+
+ssize_t recv(int sock, void *buf, size_t max_len, int flags)
+{
+	return zsock_recv(sock, buf, max_len, flags);
+}
+
+ssize_t recvfrom(int sock, void *buf, size_t max_len, int flags, struct sockaddr *src_addr,
+		 socklen_t *addrlen)
+{
+	return zsock_recvfrom(sock, buf, max_len, flags, src_addr, addrlen);
+}
+
+ssize_t recvmsg(int sock, struct msghdr *msg, int flags)
+{
+	return zsock_recvmsg(sock, msg, flags);
+}
+
+int select(int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds, struct timeval *timeout)
+{
+	return zsock_select(nfds, readfds, writefds, exceptfds, (struct zsock_timeval *)timeout);
+}
+
+ssize_t send(int sock, const void *buf, size_t len, int flags)
+{
+	return zsock_send(sock, buf, len, flags);
+}
+
+ssize_t sendmsg(int sock, const struct msghdr *message, int flags)
+{
+	return zsock_sendmsg(sock, message, flags);
+}
+
+ssize_t sendto(int sock, const void *buf, size_t len, int flags, const struct sockaddr *dest_addr,
+	       socklen_t addrlen)
+{
+	return zsock_sendto(sock, buf, len, flags, dest_addr, addrlen);
+}
+
+int setsockopt(int sock, int level, int optname, const void *optval, socklen_t optlen)
+{
+	return zsock_setsockopt(sock, level, optname, optval, optlen);
+}
+
+int shutdown(int sock, int how)
+{
+	return zsock_shutdown(sock, how);
+}
+
 int sockatmark(int s)
 {
 	ARG_UNUSED(s);
 
 	errno = ENOSYS;
 	return -1;
+}
+
+int socket(int family, int type, int proto)
+{
+	return zsock_socket(family, type, proto);
+}
+
+int socketpair(int family, int type, int proto, int sv[2])
+{
+	return zsock_socketpair(family, type, proto, sv);
 }


### PR DESCRIPTION
With `CONFIG_NET_SOCKETS_POSIX_NAMES` being deprecated, convert static inlines in headers to prototypes, and move implementations to `lib/posix/options/net.c`.

Since select and poll should technically also operate on non-socket file descriptors, these may be relocated in the future.