### PR TITLE
modules: segger: Add Kconfig option to use CCM for data

### DIFF
--- a/modules/segger/Kconfig
+++ b/modules/segger/Kconfig
@@ -79,6 +79,9 @@ config SEGGER_RTT_SECTION_NONE
 config SEGGER_RTT_SECTION_DTCM
 	bool "Place RTT data in the DTCM linker section"
 
+config SEGGER_RTT_SECTION_CCM
+	bool "Place RTT data in the CCM linker section"
+
 endchoice
 
 endif

--- a/west.yml
+++ b/west.yml
@@ -312,7 +312,7 @@ manifest:
       path: modules/lib/picolibc
       revision: 764ef4e401a8f4c6a86ab723533841f072885a5b
     - name: segger
-      revision: 9d0191285956cef43daf411edc2f1a7788346def
+      revision: b011c45b585e097d95d9cf93edf4f2e01588d3cd
       path: modules/debug/segger
       groups:
         - debug


### PR DESCRIPTION
SEGGER RTT module supports to use CCM for output data. This add the necessary Kconfig option (choice).