### PR TITLE
Samples: SMF: Add sample for SMF framework

### DIFF
--- a/samples/subsys/smf/hsm_psicc2/CMakeLists.txt
+++ b/samples/subsys/smf/hsm_psicc2/CMakeLists.txt
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(smf_hsm_psicc2)
+
+target_sources(app PRIVATE
+  src/main.c
+  src/hsm_psicc2_console_cmds.c
+  src/hsm_psicc2_thread.c
+)

--- a/samples/subsys/smf/hsm_psicc2/README.rst
+++ b/samples/subsys/smf/hsm_psicc2/README.rst
@@ -1,0 +1,51 @@
+.. zephyr:code-sample:: smf_hsm_psicc2
+   :name: Hierarchical State Machine Demo based on example from PSiCC2
+   :relevant-api: smf
+
+   Implement an event-driven hierarchical state machine using State Machine Framework (SMF).
+
+Overview
+********
+
+This sample demonstrates the :ref:`State Machine Framework <smf>` subsystem.
+
+Building and Running
+********************
+
+It should be possible to build and run this sample on almost any board or emulator.
+
+Building and Running for ST Disco L475 IOT01 (B-L475E-IOT01A)
+=============================================================
+The sample can be built and executed for the :ref:`disco_l475_iot1_board` as follows:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/subsys/smf/psicc2
+   :board: disco_l475_iot1
+   :goals: build flash
+   :compact:
+
+For other boards just replace the board name.
+
+Instructions for Use
+====================
+This application implements the statechart shown in Figure 2.11 of
+Practical UML Statecharts in C/C++, 2nd Edition, by Miro Samek (PSiCC2). Ebook available from
+https://www.state-machine.com/psicc2 This demo was chosen as it contains all possible transition
+topologies up to four levels of state nesting and is used with permission of the author.
+
+For each state, the entry, run, and exit actions are logged to the console, as well as logging
+when a state handles an event, or explicitly ignores it and passes it up to the parent state.
+
+There are two shell commands defined for controlling the operation.
+
+* ``psicc2 event <event>`` sends the event (from A to I) to the state machine. These correspond to
+  events A through I in PSiCC2 Figure 2.11
+* ``psicc2 terminate`` sends the ``EVENT_TERMINATE`` event to terminate the state machine. There
+  is no way to restart the state machine once terminated, and future events are ignored.
+
+Comparison to PSiCC2 Output
+===========================
+Not all transitions modelled in UML may be supported by the :ref:`State Machine Framework <smf>`.
+Unsupported transitions may lead to results different to the example run of the application in
+PSiCC2 Section 2.3.15. The differences will not be listed here as it is hoped :ref:`SMF <smf>`
+will support these transitions in the future and the list would become outdated.

--- a/samples/subsys/smf/hsm_psicc2/prj.conf
+++ b/samples/subsys/smf/hsm_psicc2/prj.conf
@@ -1,0 +1,11 @@
+CONFIG_LOG=y
+CONFIG_SHELL=y
+
+# Needed for boards that enable RTT backends for logging
+# e.g. nrf52840dk/nrf52840 and any others that enable it
+CONFIG_LOG_BACKEND_RTT=n
+
+# Enable the state machine framework
+CONFIG_SMF=y
+CONFIG_SMF_ANCESTOR_SUPPORT=y
+CONFIG_SMF_INITIAL_TRANSITION=y

--- a/samples/subsys/smf/hsm_psicc2/sample.yaml
+++ b/samples/subsys/smf/hsm_psicc2/sample.yaml
@@ -1,0 +1,19 @@
+sample:
+  name: SMF HSM PSiCC2 Demo
+common:
+  tags:
+    - smf
+  integration_platforms:
+    - native_sim
+  harness: console
+  harness_config:
+    type: multi_line
+    ordered: true
+    regex:
+      - ".*<inf> hsm_psicc2_thread: initial_entry.*"
+      - ".*<inf> hsm_psicc2_thread: s_entry.*"
+      - ".*<inf> hsm_psicc2_thread: s2_entry.*"
+      - ".*<inf> hsm_psicc2_thread: s21_entry.*"
+      - ".*<inf> hsm_psicc2_thread: s211_entry.*"
+tests:
+  sample.smf.hsm_psicc2: {}

--- a/samples/subsys/smf/hsm_psicc2/src/hsm_psicc2_console_cmds.c
+++ b/samples/subsys/smf/hsm_psicc2/src/hsm_psicc2_console_cmds.c
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2023 Glenn Andrews
+ * State Machine example copyright (c) Miro Samek
+ *
+ * Implementation of the statechart in Figure 2.11 of
+ * Practical UML Statecharts in C/C++, 2nd Edition by Miro Samek
+ * https://www.state-machine.com/psicc2
+ * Used with permission of the author.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/shell/shell.h>
+#include "hsm_psicc2_thread.h"
+#include <stdlib.h>
+#include <ctype.h>
+
+static int cmd_hsm_psicc2_event(const struct shell *sh, size_t argc, char **argv)
+{
+	struct hsm_psicc2_event event;
+	int event_id = toupper(argv[1][0]);
+
+	switch (event_id) {
+	case 'A':
+		event.event_id = EVENT_A;
+		break;
+	case 'B':
+		event.event_id = EVENT_B;
+		break;
+	case 'C':
+		event.event_id = EVENT_C;
+		break;
+	case 'D':
+		event.event_id = EVENT_D;
+		break;
+	case 'E':
+		event.event_id = EVENT_E;
+		break;
+	case 'F':
+		event.event_id = EVENT_F;
+		break;
+	case 'G':
+		event.event_id = EVENT_G;
+		break;
+	case 'H':
+		event.event_id = EVENT_H;
+		break;
+	case 'I':
+		event.event_id = EVENT_I;
+		break;
+	default:
+		shell_error(sh, "Invalid argument %s", argv[1]);
+		return -1;
+	}
+
+	int rc = k_msgq_put(&hsm_psicc2_msgq, &event, K_NO_WAIT);
+
+	if (rc == 0) {
+		shell_print(sh, "Event %c posted", event_id);
+	} else {
+		shell_error(sh, "error posting event: %d", rc);
+	}
+	return rc;
+}
+
+static int cmd_hsm_psicc2_terminate(const struct shell *sh, size_t argc, char **argv)
+{
+	struct hsm_psicc2_event event = {.event_id = EVENT_TERMINATE};
+	int rc = k_msgq_put(&hsm_psicc2_msgq, &event, K_NO_WAIT);
+
+	if (rc == 0) {
+		shell_print(sh, "Terminate event posted");
+	} else {
+		shell_error(sh, "error posting terminate event: %d", rc);
+	}
+	return rc;
+}
+
+/* Creating subcommands (level 1 command) array for command "demo". */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_hsm_psicc2,
+			       SHELL_CMD_ARG(event, NULL, "Send event to State Machine",
+					     cmd_hsm_psicc2_event, 2, 0),
+			       SHELL_CMD_ARG(terminate, NULL,
+					     "Send terminate event to State Machine",
+					     cmd_hsm_psicc2_terminate, 1, 0),
+			       SHELL_SUBCMD_SET_END);
+
+/* Creating root (level 0) command "demo" */
+SHELL_CMD_REGISTER(hsm_psicc2, &sub_hsm_psicc2, "PSICC2 demo hierarchical state machine commands",
+		   NULL);

--- a/samples/subsys/smf/hsm_psicc2/src/hsm_psicc2_thread.c
+++ b/samples/subsys/smf/hsm_psicc2/src/hsm_psicc2_thread.c
@@ -1,0 +1,336 @@
+/*
+ * Copyright (c) 2024 Glenn Andrews
+ * State Machine example copyright (c) Miro Samek
+ *
+ * Implementation of the statechart in Figure 2.11 of
+ * Practical UML Statecharts in C/C++, 2nd Edition by Miro Samek
+ * https://www.state-machine.com/psicc2
+ * Used with permission of the author.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/smf.h>
+#include <stdbool.h>
+#include "hsm_psicc2_thread.h"
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(hsm_psicc2_thread);
+
+/* User defined object */
+struct s_object {
+	/* This must be first */
+	struct smf_ctx ctx;
+
+	/* Other state specific data add here */
+	struct hsm_psicc2_event event;
+	int foo;
+} s_obj;
+
+/* Declaration of possible states */
+enum demo_states {
+	STATE_INITIAL,
+	STATE_S,
+	STATE_S1,
+	STATE_S2,
+	STATE_S11,
+	STATE_S21,
+	STATE_S211,
+};
+
+/* Forward declaration of state table */
+static const struct smf_state demo_states[];
+
+/********* STATE_INITIAL *********/
+static void initial_entry(void *o)
+{
+	LOG_INF("%s", __func__);
+	struct s_object *obj = (struct s_object *)o;
+
+	obj->foo = false;
+}
+
+static void initial_run(void *o)
+{
+	LOG_INF("%s", __func__);
+}
+
+static void initial_exit(void *o)
+{
+	LOG_INF("%s", __func__);
+}
+
+/********* STATE_S *********/
+static void s_entry(void *o)
+{
+	LOG_INF("%s", __func__);
+}
+
+static void s_run(void *o)
+{
+	LOG_INF("%s", __func__);
+	struct s_object *obj = (struct s_object *)o;
+
+	switch (obj->event.event_id) {
+	case EVENT_E:
+		LOG_INF("%s received EVENT_E", __func__);
+		smf_set_state(SMF_CTX(obj), &demo_states[STATE_S11]);
+		break;
+	case EVENT_I:
+		if (obj->foo) {
+			LOG_INF("%s received EVENT_I and set foo false", __func__);
+			obj->foo = false;
+		} else {
+			LOG_INF("%s received EVENT_I and did nothing", __func__);
+		}
+		smf_set_handled(SMF_CTX(obj));
+		break;
+	case EVENT_TERMINATE:
+		LOG_INF("%s received SMF_EVENT_TERMINATE. Terminating", __func__);
+		smf_set_terminate(SMF_CTX(obj), -1);
+	}
+}
+
+static void s_exit(void *o)
+{
+	LOG_INF("%s", __func__);
+}
+
+/********* STATE_S1 *********/
+static void s1_entry(void *o)
+{
+	LOG_INF("%s", __func__);
+}
+
+static void s1_run(void *o)
+{
+	LOG_INF("%s", __func__);
+	struct s_object *obj = (struct s_object *)o;
+
+	switch (obj->event.event_id) {
+	case EVENT_A:
+		LOG_INF("%s received EVENT_A", __func__);
+		smf_set_state(SMF_CTX(obj), &demo_states[STATE_S1]);
+		break;
+	case EVENT_B:
+		LOG_INF("%s received EVENT_B", __func__);
+		smf_set_state(SMF_CTX(obj), &demo_states[STATE_S11]);
+		break;
+	case EVENT_C:
+		LOG_INF("%s received EVENT_C", __func__);
+		smf_set_state(SMF_CTX(obj), &demo_states[STATE_S2]);
+		break;
+	case EVENT_D:
+		if (!obj->foo) {
+			LOG_INF("%s received EVENT_D and acted on it", __func__);
+			obj->foo = true;
+			smf_set_state(SMF_CTX(obj), &demo_states[STATE_S]);
+		} else {
+			LOG_INF("%s received EVENT_D and ignored it", __func__);
+		}
+		break;
+	case EVENT_F:
+		LOG_INF("%s received EVENT_F", __func__);
+		smf_set_state(SMF_CTX(obj), &demo_states[STATE_S211]);
+		break;
+	case EVENT_I:
+		LOG_INF("%s received EVENT_I", __func__);
+		smf_set_handled(SMF_CTX(obj));
+		break;
+	}
+}
+
+static void s1_exit(void *o)
+{
+	LOG_INF("%s", __func__);
+}
+
+/********* STATE_S11 *********/
+static void s11_entry(void *o)
+{
+	LOG_INF("%s", __func__);
+}
+
+static void s11_run(void *o)
+{
+	LOG_INF("%s", __func__);
+	struct s_object *obj = (struct s_object *)o;
+
+	switch (obj->event.event_id) {
+	case EVENT_D:
+		if (obj->foo) {
+			LOG_INF("%s received EVENT_D and acted upon it", __func__);
+			obj->foo = false;
+			smf_set_state(SMF_CTX(obj), &demo_states[STATE_S1]);
+		} else {
+			LOG_INF("%s received EVENT_D and ignored it", __func__);
+		}
+		break;
+	case EVENT_G:
+		LOG_INF("%s received EVENT_G", __func__);
+		smf_set_state(SMF_CTX(obj), &demo_states[STATE_S21]);
+		break;
+	case EVENT_H:
+		LOG_INF("%s received EVENT_H", __func__);
+		smf_set_state(SMF_CTX(obj), &demo_states[STATE_S]);
+		break;
+	}
+}
+
+static void s11_exit(void *o)
+{
+	LOG_INF("%s", __func__);
+}
+
+/********* STATE_S2 *********/
+static void s2_entry(void *o)
+{
+	LOG_INF("%s", __func__);
+}
+
+static void s2_run(void *o)
+{
+	LOG_INF("%s", __func__);
+	struct s_object *obj = (struct s_object *)o;
+
+	switch (obj->event.event_id) {
+	case EVENT_C:
+		LOG_INF("%s received EVENT_C", __func__);
+		smf_set_state(SMF_CTX(obj), &demo_states[STATE_S1]);
+		break;
+	case EVENT_F:
+		LOG_INF("%s received EVENT_F", __func__);
+		smf_set_state(SMF_CTX(obj), &demo_states[STATE_S11]);
+		break;
+	case EVENT_I:
+		if (!obj->foo) {
+			LOG_INF("%s received EVENT_I and set foo true", __func__);
+			obj->foo = true;
+			smf_set_handled(SMF_CTX(obj));
+		} else {
+			LOG_INF("%s received EVENT_I and did nothing", __func__);
+		}
+		break;
+	}
+}
+
+static void s2_exit(void *o)
+{
+	LOG_INF("%s", __func__);
+}
+
+/********* STATE_S21 *********/
+static void s21_entry(void *o)
+{
+	LOG_INF("%s", __func__);
+}
+
+static void s21_run(void *o)
+{
+	LOG_INF("%s", __func__);
+	struct s_object *obj = (struct s_object *)o;
+
+	switch (obj->event.event_id) {
+	case EVENT_A:
+		LOG_INF("%s received EVENT_A", __func__);
+		smf_set_state(SMF_CTX(obj), &demo_states[STATE_S21]);
+		break;
+	case EVENT_B:
+		LOG_INF("%s received EVENT_B", __func__);
+		smf_set_state(SMF_CTX(obj), &demo_states[STATE_S211]);
+		break;
+	case EVENT_G:
+		LOG_INF("%s received EVENT_G", __func__);
+		smf_set_state(SMF_CTX(obj), &demo_states[STATE_S1]);
+		break;
+	}
+}
+
+static void s21_exit(void *o)
+{
+	LOG_INF("%s", __func__);
+}
+
+/********* STATE_S211 *********/
+static void s211_entry(void *o)
+{
+	LOG_INF("%s", __func__);
+}
+
+static void s211_run(void *o)
+{
+	LOG_INF("%s", __func__);
+	struct s_object *obj = (struct s_object *)o;
+
+	switch (obj->event.event_id) {
+	case EVENT_D:
+		LOG_INF("%s received EVENT_D", __func__);
+		smf_set_state(SMF_CTX(obj), &demo_states[STATE_S21]);
+		break;
+	case EVENT_H:
+		LOG_INF("%s received EVENT_H", __func__);
+		smf_set_state(SMF_CTX(obj), &demo_states[STATE_S]);
+		break;
+	}
+}
+
+static void s211_exit(void *o)
+{
+	LOG_INF("%s", __func__);
+}
+
+/* State storage: handler functions, parent states and initial transition states */
+static const struct smf_state demo_states[] = {
+	[STATE_INITIAL] = SMF_CREATE_STATE(initial_entry, initial_run, initial_exit, NULL,
+					   &demo_states[STATE_S2]),
+	[STATE_S] = SMF_CREATE_STATE(s_entry, s_run, s_exit, &demo_states[STATE_INITIAL],
+				     &demo_states[STATE_S11]),
+	[STATE_S1] = SMF_CREATE_STATE(s1_entry, s1_run, s1_exit, &demo_states[STATE_S],
+				      &demo_states[STATE_S11]),
+	[STATE_S2] = SMF_CREATE_STATE(s2_entry, s2_run, s2_exit, &demo_states[STATE_S],
+				      &demo_states[STATE_S211]),
+	[STATE_S11] = SMF_CREATE_STATE(s11_entry, s11_run, s11_exit, &demo_states[STATE_S1], NULL),
+	[STATE_S21] = SMF_CREATE_STATE(s21_entry, s21_run, s21_exit, &demo_states[STATE_S2],
+				       &demo_states[STATE_S211]),
+	[STATE_S211] =
+		SMF_CREATE_STATE(s211_entry, s211_run, s211_exit, &demo_states[STATE_S21], NULL),
+};
+
+K_THREAD_STACK_DEFINE(hsm_psicc2_thread_stack, HSM_PSICC2_THREAD_STACK_SIZE);
+K_MSGQ_DEFINE(hsm_psicc2_msgq, sizeof(struct hsm_psicc2_event), HSM_PSICC2_THREAD_EVENT_QUEUE_SIZE,
+	      1);
+
+static struct k_thread hsm_psicc2_thread_data;
+static k_tid_t hsm_psicc2_thread_tid;
+
+static void hsm_psicc2_thread(void *arg1, void *arg2, void *arg3)
+{
+	smf_set_initial(SMF_CTX(&s_obj), &demo_states[STATE_INITIAL]);
+	while (1) {
+		int rc = k_msgq_get(&hsm_psicc2_msgq, &s_obj.event, K_FOREVER);
+
+		if (rc == 0) {
+			/* Run state machine with given message */
+			rc = smf_run_state(SMF_CTX(&s_obj));
+
+			if (rc) {
+				/* State machine terminates if a non-zero value is returned */
+				LOG_INF("%s terminating state machine thread", __func__);
+				break;
+			}
+		} else {
+			LOG_ERR("Waiting for event failed, code %d", rc);
+		}
+	}
+}
+
+void hsm_psicc2_thread_run(void)
+{
+	hsm_psicc2_thread_tid =
+		k_thread_create(&hsm_psicc2_thread_data, hsm_psicc2_thread_stack,
+				K_THREAD_STACK_SIZEOF(hsm_psicc2_thread_stack), hsm_psicc2_thread,
+				NULL, NULL, NULL, HSM_PSICC2_THREAD_PRIORITY, 0, K_NO_WAIT);
+
+	k_thread_name_set(hsm_psicc2_thread_tid, "psicc2_thread");
+}

--- a/samples/subsys/smf/hsm_psicc2/src/hsm_psicc2_thread.h
+++ b/samples/subsys/smf/hsm_psicc2/src/hsm_psicc2_thread.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024 Glenn Andrews
+ * State Machine example copyright (c) Miro Samek
+ *
+ * Implementation of the statechart in Figure 2.11 of
+ * Practical UML Statecharts in C/C++, 2nd Edition by Miro Samek
+ * https://www.state-machine.com/psicc2
+ * Used with permission of the author.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _HSM_PSICC2_THREAD_H
+#define _HSM_PSICC2_THREAD_H
+
+#define HSM_PSICC2_THREAD_STACK_SIZE       1024
+#define HSM_PSICC2_THREAD_PRIORITY         7
+#define HSM_PSICC2_THREAD_EVENT_QUEUE_SIZE 10
+
+/**
+ * @brief Event to be sent to an event queue
+ */
+struct hsm_psicc2_event {
+	uint32_t event_id;
+};
+
+/**
+ * @brief List of events that can be sent to the state machine
+ */
+enum demo_events {
+	EVENT_A,
+	EVENT_B,
+	EVENT_C,
+	EVENT_D,
+	EVENT_E,
+	EVENT_F,
+	EVENT_G,
+	EVENT_H,
+	EVENT_I,
+	EVENT_TERMINATE,
+};
+
+/* event queue to post messages to */
+extern struct k_msgq hsm_psicc2_msgq;
+
+/**
+ * @brief Initializes and starts the PSICC2 demo thread
+ * @param None
+ */
+void hsm_psicc2_thread_run(void);
+
+#endif /* _HSM_PSICC2_THREAD_H */

--- a/samples/subsys/smf/hsm_psicc2/src/main.c
+++ b/samples/subsys/smf/hsm_psicc2/src/main.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2024 Glenn Andrews
+ * State Machine example copyright (c) Miro Samek
+ *
+ * Implementation of the statechart in Figure 2.11 of
+ * Practical UML Statecharts in C/C++, 2nd Edition by Miro Samek
+ * https://www.state-machine.com/psicc2
+ * Used with permission of the author.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include "hsm_psicc2_thread.h"
+
+int main(void)
+{
+	printk("State Machine Framework Demo\n");
+	printk("See PSiCC2 Fig 2.11 for the statechart\n");
+	printk("https://www.state-machine.com/psicc2\n\n");
+	hsm_psicc2_thread_run();
+	return 0;
+}

--- a/samples/subsys/smf/smf.rst
+++ b/samples/subsys/smf/smf.rst
@@ -1,0 +1,10 @@
+.. _smf-samples:
+
+State Machine Framework Samples
+###############################
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   **/*


### PR DESCRIPTION
Note: Resubmission of https://github.com/zephyrproject-rtos/zephyr/pull/70641, which I thoroughly mangled.

This PR adds a sample demonstrating the use of the State Machine Framework (SMF)

Instructions are in the README.rst for the sample.

Miro Samek was contacted and gave approval to use the state diagram in this demo.