### PR TITLE
Bluetooth: host: tweak up the bluetooth thread names

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -4128,7 +4128,7 @@ int bt_enable(bt_ready_cb_t cb)
 	k_work_queue_start(&bt_workq, rx_thread_stack,
 			   CONFIG_BT_RX_STACK_SIZE,
 			   K_PRIO_COOP(CONFIG_BT_RX_PRIO), NULL);
-	k_thread_name_set(&bt_workq.thread, "BT RX");
+	k_thread_name_set(&bt_workq.thread, "BT RX WQ");
 #endif
 
 	err = bt_dev.drv->open();

--- a/subsys/bluetooth/host/long_wq.c
+++ b/subsys/bluetooth/host/long_wq.c
@@ -29,7 +29,7 @@ int bt_long_wq_submit(struct k_work *work)
 static int long_wq_init(void)
 {
 
-	const struct k_work_queue_config cfg = {.name = "BT_LW_WQ"};
+	const struct k_work_queue_config cfg = {.name = "BT LW WQ"};
 
 	k_work_queue_init(&bt_long_wq);
 


### PR DESCRIPTION
Change the receive workque name to "BT RX WQ" to distinguish it from the receive thread, and the long workque one to "BT LW WQ" to make the format consistent with the other Bluetooth threads.

On an nRF52 now "kernel stacks" looks like:

```
0x200016c8 BT RX                    (real size  448):   unused  280    )
0x20001780 BT RX pri                (real size  448):   unused  224    )
0x200012c0 BT RX WQ                 (real size 2240):   unused 1360    )
0x20001208 BT TX                    (real size  768):   unused  408    )
0x20001130 BT LW WQ                 (real size 1344):   unused  408    )
```