### PR TITLE
driver: watchdog: prevent floating point usage

### DIFF
--- a/drivers/watchdog/wdt_ene_kb1200.c
+++ b/drivers/watchdog/wdt_ene_kb1200.c
@@ -82,7 +82,7 @@ static int wdt_kb1200_install_timeout(const struct device *dev,
 		data->timeout_installed = false;
 		return -EINVAL;
 	}
-	cfg->wdt->WDTM = (config->window.max) / WDT_SAMPLE_TIME;
+	cfg->wdt->WDTM = (config->window.max * 1000) / WDT_TICK_TIME_US;
 	/* (HW design) The counter match value must be >= 3 */
 	if (cfg->wdt->WDTM < WDT_MIN_CNT) {
 		data->timeout_installed = false;

--- a/soc/ene/kb1200/reg/wdt.h
+++ b/soc/ene/kb1200/reg/wdt.h
@@ -24,7 +24,7 @@ struct wdt_regs {
 };
 
 #define WDT_MIN_CNT                         3U
-#define WDT_SAMPLE_TIME                     31.25
+#define WDT_TICK_TIME_US                    31250
 
 #define WDT_RESET_WHOLE_CHIP_WO_GPIO        0
 #define WDT_RESET_WHOLE_CHIP                1


### PR DESCRIPTION
Prevent the use of floating point operations