### PR TITLE
input: utils: rename the input dump callback

### DIFF
--- a/subsys/input/input_utils.c
+++ b/subsys/input/input_utils.c
@@ -51,7 +51,7 @@ static bool input_dump_enabled(void)
 }
 #endif /* CONFIG_INPUT_SHELL */
 
-static void input_cb(struct input_event *evt)
+static void input_dump_cb(struct input_event *evt)
 {
 	if (!input_dump_enabled()) {
 		return;
@@ -64,7 +64,7 @@ static void input_cb(struct input_event *evt)
 		evt->code,
 		evt->value);
 }
-INPUT_CALLBACK_DEFINE(NULL, input_cb);
+INPUT_CALLBACK_DEFINE(NULL, input_dump_cb);
 #endif /* CONFIG_INPUT_EVENT_DUMP */
 
 #ifdef CONFIG_INPUT_SHELL


### PR DESCRIPTION
Change the input callback function name to make it easier to identify what it belongs to. This clears some ambiguity when observing the symbol names corresponding to the function pointers in the callback section.