### PR TITLE
boards: st: stm32l1_disco: enable eeprom and watchdog

### DIFF
--- a/boards/st/stm32l1_disco/doc/index.rst
+++ b/boards/st/stm32l1_disco/doc/index.rst
@@ -80,6 +80,9 @@ The Zephyr stm32l1_disco board configuration supports the following hardware fea
    * - FLASH
      - on-chip
      - flash memory
+   * - EEPROM
+     - on-chip
+     - eeprom
    * - WATCHDOG
      - on-chip
      - window watchdog

--- a/boards/st/stm32l1_disco/stm32l1_disco.dts
+++ b/boards/st/stm32l1_disco/stm32l1_disco.dts
@@ -45,6 +45,8 @@
 		led0 = &green_led;
 		led1 = &blue_led;
 		sw0 = &user_button;
+		eeprom-0 = &eeprom;
+		watchdog0 = &iwdg;
 	};
 };
 
@@ -129,4 +131,12 @@
 	backup_regs {
 		status = "okay";
 	};
+};
+
+&eeprom {
+		status = "okay";
+};
+
+&iwdg {
+		status = "okay";
 };

--- a/boards/st/stm32l1_disco/stm32l1_disco.yaml
+++ b/boards/st/stm32l1_disco/stm32l1_disco.yaml
@@ -12,4 +12,6 @@ supported:
   - gpio
   - i2c
   - spi
+  - eeprom
+  - watchdog
 vendor: st


### PR DESCRIPTION
stm32l1_disco board from STMicroelectronics has eeprom and watchdog. Enable those peripherals.

Tested using:
1. samples/drivers/eeprom
2. samples/drivers/watchdog