### PR TITLE
Updated mipi_dbi.rst with a newline to display the list correctly

### DIFF
--- a/doc/hardware/peripherals/mipi_dbi.rst
+++ b/doc/hardware/peripherals/mipi_dbi.rst
@@ -7,6 +7,7 @@ The MIPI DBI driver class implements support for MIPI DBI compliant display
 controllers.
 
 MIPI DBI defines 3 interface types:
+
 * Type A: Motorola 6800 parallel bus
 
 * Type B: Intel 8080 parallel bus


### PR DESCRIPTION
This was fixed by an example from another [doc](https://github.com/zephyrproject-rtos/zephyr/blob/main/doc/hardware/peripherals/i3c.rst?plain=1#L213)

Resolves #70936