### PR TITLE
samples: net: Disable native_posix netusb target in samples

### DIFF
--- a/samples/net/sockets/dumb_http_server/sample.yaml
+++ b/samples/net/sockets/dumb_http_server/sample.yaml
@@ -23,6 +23,8 @@ tests:
     platform_exclude:
       - native_sim
       - native_sim/native/64
+      - native_posix
+      - native_posix/native/64
   sample.net.sockets.dumb_http_server.netusb_zeroconf:
     depends_on: usb_device
     harness: net
@@ -32,3 +34,5 @@ tests:
     platform_exclude:
       - native_sim
       - native_sim/native/64
+      - native_posix
+      - native_posix/native/64

--- a/samples/net/sockets/echo_server/sample.yaml
+++ b/samples/net/sockets/echo_server/sample.yaml
@@ -90,6 +90,8 @@ tests:
     platform_exclude:
       - native_sim
       - native_sim/native/64
+      - native_posix
+      - native_posix/native/64
   sample.net.sockets.echo_server.nrf_openthread:
     extra_args: OVERLAY_CONFIG="overlay-ot.conf"
     slow: true

--- a/samples/net/sockets/net_mgmt/sample.yaml
+++ b/samples/net/sockets/net_mgmt/sample.yaml
@@ -20,5 +20,6 @@ tests:
     tags: userspace
     extra_configs:
       - CONFIG_USERSPACE=y
+      - CONFIG_MAX_THREAD_BYTES=3
     platform_exclude:
       - ip_k66f

--- a/samples/net/sockets/net_mgmt/sample.yaml
+++ b/samples/net/sockets/net_mgmt/sample.yaml
@@ -6,6 +6,9 @@ common:
     - net
     - socket
     - mgmt
+  platform_exclude:
+    - native_posix
+    - native_posix/native/64
 sample:
   description: Test network management socket sample
   name: net_mgmt socket

--- a/samples/net/zperf/sample.yaml
+++ b/samples/net/zperf/sample.yaml
@@ -44,6 +44,8 @@ tests:
     platform_exclude:
       - native_sim
       - native_sim/native/64
+      - native_posix
+      - native_posix/native/64
   sample.net.zperf.device_next_ecm:
     harness: net
     extra_args: OVERLAY_CONFIG="overlay-usbd_next_ecm.conf"
@@ -66,6 +68,8 @@ tests:
     platform_exclude:
       - native_sim
       - native_sim/native/64
+      - native_posix
+      - native_posix/native/64
   sample.net.zperf.netusb_rndis:
     harness: net
     extra_args: OVERLAY_CONFIG="overlay-netusb.conf"
@@ -81,6 +85,8 @@ tests:
     platform_exclude:
       - native_sim
       - native_sim/native/64
+      - native_posix
+      - native_posix/native/64
   sample.net.zperf.shield:
     harness: net
     platform_allow: reel_board


### PR DESCRIPTION
The native_posix netusb compilations fail with various socket errors like this:

samples/net/sockets/echo_server/src/udp.c:45:26: error: implicit \
 declaration of function ‘socket’ [-Werror=implicit-function-declaration]
 45 |         data->udp.sock = socket(bind_addr->sa_family, SOCK_DGRAM,
    |                                 IPPROTO_UDP);

Disable the netusb support from networking samples for native_posix board for now so that CI can pass.