### PR TITLE
soc: nuvoton: numaker: disable DWT in Kconfig

### DIFF
--- a/soc/nuvoton/numaker/m2l31x/Kconfig
+++ b/soc/nuvoton/numaker/m2l31x/Kconfig
@@ -6,7 +6,6 @@ config SOC_SERIES_M2L31X
 	select ARM
 	select CPU_CORTEX_M23
 	select CPU_CORTEX_M_HAS_SYSTICK
-	select CPU_CORTEX_M_HAS_DWT
 	select CPU_CORTEX_M_HAS_VTOR
 	select CPU_HAS_ARM_MPU
 


### PR DESCRIPTION
This PR is to fix issue #70929.

Arm-Cortex-M23 only support DWT_CTRL, DWT_PCSR and DWT_COMP & DWT_FUNCTION registers. It can't meet the requirement of timing function, so to remove CPU_CORTEX_M_HAS_DWT.