### PR TITLE
Check for the existence of pthread_rwlockattr_getpshared() and pthread_rwlockattr_setpshared() seems missing.

### DIFF
--- a/tests/posix/headers/src/pthread_h.c
+++ b/tests/posix/headers/src/pthread_h.c
@@ -143,9 +143,9 @@ ZTEST(posix_headers, test_pthread_h)
 		zassert_not_null(pthread_rwlock_unlock);
 		zassert_not_null(pthread_rwlock_wrlock);
 		zassert_not_null(pthread_rwlockattr_destroy);
-		/* zassert_not_null(pthread_rwlockattr_getpshared); */ /* not implemented */
+		zassert_not_null(pthread_rwlockattr_getpshared);
 		zassert_not_null(pthread_rwlockattr_init);
-		/* zassert_not_null(pthread_rwlockattr_setpshared); */ /* not implemented */
+		zassert_not_null(pthread_rwlockattr_setpshared);
 		zassert_not_null(pthread_self);
 		zassert_not_null(pthread_setcancelstate);
 		zassert_not_null(pthread_setcanceltype);


### PR DESCRIPTION
This PR aims to add the check for the existence of pthread_rwlockattr_getpshared() and pthread_rwlockattr_setpshared().

I checked the [PR](https://github.com/zephyrproject-rtos/zephyr/pull/70421) that merged the functions and found out that the test header check was missing.