### PR TITLE
MAINTAINERS: Add additional files to Bluetooth Audio

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -445,7 +445,17 @@ Bluetooth Audio:
     - include/zephyr/bluetooth/audio/
     - tests/bluetooth/audio/
     - tests/bsim/bluetooth/audio/
-    - tests/bluetooth/shell/audio*
+    - tests/bluetooth/shell/audio.conf
+    - doc/connectivity/bluetooth/img/ble_audio_arch.svg
+    - doc/connectivity/bluetooth/img/cap_proc.svg
+    - doc/connectivity/bluetooth/img/gaf.svg
+    - doc/connectivity/bluetooth/img/zephyr_gaf.svg
+    - doc/connectivity/bluetooth/bluetooth-le-audio-arch.rst
+    - samples/bluetooth/broadcast_audio*/
+    - samples/bluetooth/hap*/
+    - samples/bluetooth/public_broadcast*/
+    - samples/bluetooth/tmap*/
+    - samples/bluetooth/unicast_audio*/
   labels:
     - "area: Bluetooth Audio"
     - "area: Bluetooth"


### PR DESCRIPTION
Neither samples nor documentation have a file structure that allows us to easily add the Bluetooth Audio label and reviewers to PRs that modify these files, so they have been added more explicitly.

Any future files will need to be added to this list as well, unless the structure change to make this easier.