### PR TITLE
samples: net: net_mgmt: Fix build failure on mr_canhubk3

### DIFF
--- a/samples/net/sockets/net_mgmt/sample.yaml
+++ b/samples/net/sockets/net_mgmt/sample.yaml
@@ -17,5 +17,6 @@ tests:
     tags: userspace
     extra_configs:
       - CONFIG_USERSPACE=y
+      - CONFIG_MAX_THREAD_BYTES=3
     platform_exclude:
       - ip_k66f


### PR DESCRIPTION
The CONFIG_MAX_THREAD_BYTES=3 needs to be set for this board to fix this build failure.

Too many thread objects (18)
Increase CONFIG_MAX_THREAD_BYTES to 3

Fixes #70955