### PR TITLE
tests: fs: fcb: Make fixed endmarker test optional

### DIFF
--- a/tests/subsys/fs/fcb/CMakeLists.txt
+++ b/tests/subsys/fs/fcb/CMakeLists.txt
@@ -5,5 +5,8 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(fs_fcb)
 
 FILE(GLOB app_sources src/*.c)
+if(NOT CONFIG_FCB_ALLOW_FIXED_ENDMARKER)
+  list(REMOVE_ITEM "src/fcb_test_crc_disabled_after_enabled.c")
+endif()
 target_sources(app PRIVATE ${app_sources})
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/fs/fcb)

--- a/tests/subsys/fs/fcb/src/fcb_test.h
+++ b/tests/subsys/fs/fcb/src/fcb_test.h
@@ -24,7 +24,9 @@ extern "C" {
 #define TEST_FCB_FLASH_AREA_ID		FIXED_PARTITION_ID(TEST_FCB_FLASH_AREA)
 
 extern struct fcb test_fcb;
+#if defined(CONFIG_FCB_ALLOW_FIXED_ENDMARKER)
 extern struct fcb test_fcb_crc_disabled;
+#endif
 
 extern struct flash_sector test_fcb_sector[];
 

--- a/tests/subsys/fs/fcb/src/main.c
+++ b/tests/subsys/fs/fcb/src/main.c
@@ -14,7 +14,9 @@
 #include <zephyr/device.h>
 
 struct fcb test_fcb = {0};
+#if defined(CONFIG_FCB_ALLOW_FIXED_ENDMARKER)
 struct fcb test_fcb_crc_disabled = { .f_flags = FCB_FLAGS_CRC_DISABLED };
+#endif
 
 uint8_t fcb_test_erase_value;
 
@@ -139,7 +141,11 @@ static void fcb_pretest_4_sectors(void *data)
 
 static void fcb_pretest_crc_disabled(void *data)
 {
+#if defined(CONFIG_FCB_ALLOW_FIXED_ENDMARKER)
 	fcb_tc_pretest(2, &test_fcb_crc_disabled);
+#else
+	ztest_test_skip();
+#endif
 }
 
 /*

--- a/tests/subsys/fs/fcb/testcase.yaml
+++ b/tests/subsys/fs/fcb/testcase.yaml
@@ -18,6 +18,18 @@ tests:
   filesystem.fcb.native_sim.no_erase:
     extra_args: CONFIG_FLASH_SIMULATOR_EXPLICIT_ERASE=n
     platform_allow: native_sim
+  filesystem.fcb.fixed_endmarker:
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf52dk/nrf52832
+      - nrf51dk/nrf51822
+      - native_sim
+      - native_sim/native/64
+      - mr_canhubk3
+    tags: flash_circural_buffer
+    integration_platforms:
+      - nrf52840dk/nrf52840
+    extra_args: CONFIG_FCB_ALLOW_FIXED_ENDMARKER=y
   filesystem.fcb.native_sim.fcb_0x00:
     extra_args: DTC_OVERLAY_FILE=boards/native_sim_ev_0x00.overlay
     platform_allow: native_sim


### PR DESCRIPTION
The commit splits default FCB scenario into one with endmarker enabled, the original one, and one with disabled.
This allows to test the FCB in cases when CONFIG_FCB_ALLOW_FIXED_ENDMARKER is set and not set.