### PR TITLE
drivers/sensor: lps22hh: Enable fetching individual sensor channels

### DIFF
--- a/drivers/sensor/st/lps22hh/lps22hh.c
+++ b/drivers/sensor/st/lps22hh/lps22hh.c
@@ -39,15 +39,36 @@ static int lps22hh_sample_fetch(const struct device *dev,
 	uint32_t raw_press;
 	int16_t raw_temp;
 
-	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL);
+	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL
+			|| chan == SENSOR_CHAN_PRESS
+			|| chan == SENSOR_CHAN_AMBIENT_TEMP);
 
-	if (lps22hh_pressure_raw_get(ctx, &raw_press) < 0) {
-		LOG_DBG("Failed to read sample");
-		return -EIO;
-	}
-	if (lps22hh_temperature_raw_get(ctx, &raw_temp) < 0) {
-		LOG_DBG("Failed to read sample");
-		return -EIO;
+	switch (chan) {
+	case SENSOR_CHAN_PRESS:
+		if (lps22hh_pressure_raw_get(ctx, &raw_press) < 0) {
+			LOG_DBG("Failed to read sample");
+			return -EIO;
+		}
+		break;
+	case SENSOR_CHAN_AMBIENT_TEMP:
+		if (lps22hh_temperature_raw_get(ctx, &raw_temp) < 0) {
+			LOG_DBG("Failed to read sample");
+			return -EIO;
+		}
+		break;
+	case SENSOR_CHAN_ALL:
+		if (lps22hh_pressure_raw_get(ctx, &raw_press) < 0) {
+			LOG_DBG("Failed to read sample");
+			return -EIO;
+		}
+		if (lps22hh_temperature_raw_get(ctx, &raw_temp) < 0) {
+			LOG_DBG("Failed to read sample");
+			return -EIO;
+		}
+		break;
+	default:
+		LOG_ERR("Unsupported sensor channel");
+		return -ENOTSUP;
 	}
 
 	data->sample_press = raw_press;


### PR DESCRIPTION
Add the possibility to fetch specific sensor channels independently, either pressure data with SENSOR_CHAN_PRESS or temperature data with SENSOR_CHAN_AMBIENT_TEMP. Additionally, the option to fetch both channels simultaneously remains available using SENSOR_CHAN_ALL, thus not breaking any samples.