### PR TITLE
modules: mbedtls: option for `MBEDTLS_HKDF_C`

### DIFF
--- a/modules/mbedtls/Kconfig.tls-generic
+++ b/modules/mbedtls/Kconfig.tls-generic
@@ -118,6 +118,9 @@ config MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
 	bool "ECJPAKE based ciphersuite modes"
 	depends on MBEDTLS_ECJPAKE_C
 
+config MBEDTLS_HKDF_C
+	bool "HMAC-based Extract-and-Expand Key Derivation Function"
+
 comment "Elliptic curve libraries"
 
 config MBEDTLS_ECDH_C

--- a/modules/mbedtls/configs/config-tls-generic.h
+++ b/modules/mbedtls/configs/config-tls-generic.h
@@ -138,6 +138,10 @@
 #define MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
 #endif
 
+#if defined(CONFIG_MBEDTLS_HKDF_C)
+#define MBEDTLS_HKDF_C
+#endif
+
 /* Supported cipher modes */
 
 #if defined(CONFIG_MBEDTLS_CIPHER_AES_ENABLED)


### PR DESCRIPTION
Add kconfig option to enable `MBEDTLS_HKDF_C`, HMAC-based Extract-and-Expand Key Derivation Function.