### PR TITLE
samples: sensor: dht_polling run sample on sensor present

### DIFF
--- a/samples/sensor/dht_polling/README.rst
+++ b/samples/sensor/dht_polling/README.rst
@@ -23,7 +23,17 @@ be aliased as ``dhtN`` where ``N`` goes from ``0`` to ``9``. For example:
 		};
 	};
 
-Make sure the aliases are in devicetree, then build and run with:
+
+Make sure the aliases are in devicetree.
+
+It also requires a correct fixture setup when the sensor is present.
+For the correct execution of that sample in twister, add into boards's
+map-file next fixture settings::
+
+      - fixture: fixture_i2c_hs300x
+
+
+Then build and run with:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/sensor/dht_polling

--- a/samples/sensor/dht_polling/sample.yaml
+++ b/samples/sensor/dht_polling/sample.yaml
@@ -15,6 +15,7 @@ tests:
       - nucleo_f401re
     harness: console
     harness_config:
+      fixture: fixture_i2c_hs300x
       type: one_line
       regex:
         - "[0-9A-Za-z_,+-.]*@[0-9A-Fa-f]*: temp is (.*) °C humidity is (.*) %RH"


### PR DESCRIPTION
Add a fixture to run the sample only when the DHT sensor HX330x is present (shield) on the nucleo_f40re board 'fixture_i2c_hs300x'
The stm32f401 Nucleo board itself has no sensor mounted.
--> sample is not executable unless the fixture is explicitly set

Then without fixture the sample is not valid and could give an error
```
*** Booting Zephyr OS build v3.6.0-1947-g0714052c74bf ***
hs300x@44: sensor_sample_fetch() failed: -5
```

