### PR TITLE
twister: footprint: Improve command-line arguments

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -68,8 +68,6 @@ Artificially long but functional example:
                                  __/fifo_api/testcase.yaml
     """)
 
-    compare_group_option = parser.add_mutually_exclusive_group()
-
     platform_group_option = parser.add_mutually_exclusive_group()
 
     run_group_option = parser.add_mutually_exclusive_group()
@@ -83,6 +81,10 @@ Artificially long but functional example:
     test_xor_generator = case_select.add_mutually_exclusive_group()
 
     valgrind_asan_group = parser.add_mutually_exclusive_group()
+
+    footprint_group = parser.add_argument_group(
+       title="Memory footprint",
+       description="Collect and report ROM/RAM size footprint for the test instance images built.")
 
     case_select.add_argument(
         "-E",
@@ -123,14 +125,6 @@ Artificially long but functional example:
 
     case_select.add_argument("--test-tree", action="store_true",
                              help="""Output the test plan in a tree form""")
-
-    compare_group_option.add_argument("--compare-report",
-                        help="Use this report file for size comparison")
-
-    compare_group_option.add_argument(
-        "-m", "--last-metrics", action="store_true",
-        help="Compare with the results of the previous twister "
-             "invocation")
 
     platform_group_option.add_argument(
         "-G",
@@ -333,22 +327,12 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
              "and do the selection based on existing filters.")
 
     parser.add_argument(
-        "-D", "--all-deltas", action="store_true",
-        help="Show all footprint deltas, positive or negative. Implies "
-             "--footprint-threshold=0")
-
-    parser.add_argument(
         "--device-serial-baud", action="store", default=None,
         help="Serial device baud rate (default 115200)")
 
     parser.add_argument("--disable-asserts", action="store_false",
                         dest="enable_asserts",
                         help="deprecated, left for compatibility")
-
-    parser.add_argument(
-        "--disable-unrecognized-section-test", action="store_true",
-        default=False,
-        help="Skip the 'unrecognized section' test.")
 
     parser.add_argument(
         "--disable-suite-name-check", action="store_true", default=False,
@@ -379,14 +363,6 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
         binaries such as those generated for the native_sim configuration.
         """)
 
-    parser.add_argument("--enable-size-report", action="store_true",
-                        help="Enable expensive computation of RAM/ROM segment sizes.")
-
-    parser.add_argument("--create-rom-ram-report", action="store_true",
-                        help="Generate detailed ram/rom json reports for "
-                             "each build, via cmake build calls with the "
-                             "`--target footprint` argument")
-
     parser.add_argument(
         "--filter", choices=['buildable', 'runnable'],
         default='buildable',
@@ -407,12 +383,73 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
                         help="Path to the gcov tool to use for code coverage "
                              "reports")
 
+    footprint_group.add_argument(
+        "--create-rom-ram-report",
+        action="store_true",
+        help="Generate detailed json reports with ROM/RAM symbol sizes for each test image built "
+             "using additional build option `--target footprint`.")
+
+    footprint_group.add_argument(
+        "--enable-size-report",
+        action="store_true",
+        help="Collect and report ROM/RAM section sizes for each test image built.")
+
     parser.add_argument(
-        "-H", "--footprint-threshold", type=float, default=5,
-        help="When checking test case footprint sizes, warn the user if "
-             "the new app size is greater then the specified percentage "
-             "from the last release. Default is 5. 0 to warn on any "
-             "increase on app size.")
+        "--disable-unrecognized-section-test",
+        action="store_true",
+        default=False,
+        help="Don't error on unrecognized sections in the binary images.")
+
+    footprint_group.add_argument(
+        "--footprint-from-buildlog",
+        action = "store_true",
+        help="Take ROM/RAM sections footprint summary values from the 'build.log' "
+             "instead of 'objdump' results used otherwise."
+             "Requires --enable-size-report or one of the baseline comparison modes.")
+
+    compare_group_option = footprint_group.add_mutually_exclusive_group()
+
+    compare_group_option.add_argument(
+        "-m", "--last-metrics",
+        action="store_true",
+        help="Compare footprints to the previous twister invocation as a baseline "
+             "running in the same output directory. "
+             "Implies --enable-size-report option.")
+
+    compare_group_option.add_argument(
+        "--compare-report",
+        help="Use this report file as a baseline for footprint comparison. "
+             "The file should be of 'twister.json' schema. "
+             "Implies --enable-size-report option.")
+
+    footprint_group.add_argument(
+        "--show-footprint",
+        action="store_true",
+        help="With footprint comparison to a baseline, log ROM/RAM section deltas. ")
+
+    footprint_group.add_argument(
+        "-H", "--footprint-threshold",
+        type=float,
+        default=5.0,
+        help="With footprint comparison to a baseline, "
+             "warn the user for any of the footprint metric change which is greater or equal "
+             "to the specified percentage value. "
+             "Default is %(default)s for %(default)s%% delta from the new footprint value. "
+             "Use zero to warn on any footprint metric increase.")
+
+    footprint_group.add_argument(
+        "-D", "--all-deltas",
+        action="store_true",
+        help="With footprint comparison to a baseline, "
+             "warn on any footprint change, increase or decrease. "
+             "Implies --footprint-threshold=0")
+
+    footprint_group.add_argument(
+        "-z", "--size",
+        action="append",
+        metavar='FILENAME',
+        help="Ignore all other command line options and just produce a report to "
+             "stdout with ROM/RAM section sizes on the specified binary images.")
 
     parser.add_argument(
         "-i", "--inline-logs", action="store_true",
@@ -626,13 +663,6 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
              "'--ninja' argument (to use Ninja build generator).")
 
     parser.add_argument(
-        "--show-footprint",
-        action="store_true",
-        required = "--footprint-from-buildlog" in sys.argv,
-        help="Show footprint statistics and deltas since last release."
-    )
-
-    parser.add_argument(
         "-t", "--tag", action="append",
         help="Specify tags to restrict which tests to run by tag value. "
              "Default is to not do any tag filtering. Multiple invocations "
@@ -712,18 +742,6 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
         directory (testplan.json).
         """)
 
-    parser.add_argument(
-        "-z", "--size", action="append",
-        help="Don't run twister. Instead, produce a report to "
-             "stdout detailing RAM/ROM sizes on the specified filenames. "
-             "All other command line arguments ignored.")
-
-    parser.add_argument(
-        "--footprint-from-buildlog",
-        action = "store_true",
-        help="Get information about memory footprint from generated build.log. "
-             "Requires using --show-footprint option.")
-
     parser.add_argument("extra_test_args", nargs=argparse.REMAINDER,
         help="Additional args following a '--' are passed to the test binary")
 
@@ -772,7 +790,7 @@ def parse_arguments(parser, args, options = None):
             options.testsuite_root = [os.path.join(ZEPHYR_BASE, "tests"),
                                      os.path.join(ZEPHYR_BASE, "samples")]
 
-    if options.show_footprint or options.compare_report:
+    if options.last_metrics or options.compare_report:
         options.enable_size_report = True
 
     if options.aggressive_no_clean:
@@ -827,6 +845,10 @@ def parse_arguments(parser, args, options = None):
             sc = SizeCalculator(fn, [])
             sc.size_report()
         sys.exit(0)
+
+    if options.footprint_from_buildlog and not options.enable_size_report:
+        logger.error("--footprint-from-buildlog requires --enable-size-report")
+        sys.exit(1)
 
     if len(options.extra_test_args) > 0:
         # extra_test_args is a list of CLI args that Twister did not recognize

--- a/scripts/tests/twister/test_environment.py
+++ b/scripts/tests/twister/test_environment.py
@@ -225,7 +225,7 @@ def test_parse_arguments_warnings(caplog):
 
 
 TESTDATA_2 = [
-    (['--show-footprint']),
+    (['--enable-size-report']),
     (['--compare-report', 'dummy']),
 ]
 

--- a/scripts/tests/twister_blackbox/test_footprint.py
+++ b/scripts/tests/twister_blackbox/test_footprint.py
@@ -14,6 +14,7 @@ import pytest
 import sys
 import re
 
+# pylint: disable=no-name-in-module
 from conftest import ZEPHYR_BASE, TEST_DATA, testsuite_filename_mock, clear_log_in_test
 from twisterlib.testplan import TestPlan
 

--- a/scripts/tests/twister_blackbox/test_output.py
+++ b/scripts/tests/twister_blackbox/test_output.py
@@ -14,6 +14,7 @@ import pytest
 import sys
 import json
 
+# pylint: disable=no-name-in-module
 from conftest import ZEPHYR_BASE, TEST_DATA, testsuite_filename_mock, clear_log_in_test
 from twisterlib.testplan import TestPlan
 

--- a/scripts/tests/twister_blackbox/test_output.py
+++ b/scripts/tests/twister_blackbox/test_output.py
@@ -118,12 +118,16 @@ class TestOutput:
             r'-DTC_RUNID=[0-9a-zA-Z]+',
             # Remove variable order CMake flags
             r'-I[0-9a-zA-Z/\\]+',
+            # Remove duration-sensitive entries
+            r'-- Configuring done \([0-9.]+s\)',
+            r'-- Generating done \([0-9.]+s\)',
             # Cache location may vary between CI runs
             r'^.*-- Cache files will be written to:.*$'
         ]
         for pattern in removal_patterns:
-            inline_twister_log = re.sub(pattern, '', inline_twister_log, flags=re.MULTILINE)
-            build_log = re.sub(pattern, '', build_log, flags=re.MULTILINE)
+            c_pattern = re.compile(pattern, flags=re.MULTILINE)
+            inline_twister_log = re.sub(c_pattern, '', inline_twister_log)
+            build_log = re.sub(c_pattern, '', build_log)
 
         split_build_log = build_log.split('\n')
         for r in split_build_log:


### PR DESCRIPTION
Improve Twister command line arguments for memory footprint:

 * group and order footprint arguments meaningfully,
 * clearer help descriptions,
 * resolve logical inconsistences for combinations of arguments, in particular:
   `--last-metrics` now forces `--enable-size-report`,
   `--show-footprint` now controls only detailed log output of footprint deltas in comparison modes.
* align twister tests accordingly,
 * exclude time-sensitive log entries at `test_output` to avoid false negatives comparing build logs.