### PR TITLE
wifi: airoc: remove dependency on CYHAL

### DIFF
--- a/drivers/wifi/infineon/airoc_whd_hal.c
+++ b/drivers/wifi/infineon/airoc_whd_hal.c
@@ -11,6 +11,7 @@
 #include <bus_protocols/whd_bus.h>
 #include <bus_protocols/whd_sdio.h>
 #include <zephyr/sd/sd.h>
+#include <cy_utils.h>
 
 #define DT_DRV_COMPAT infineon_airoc_wifi
 
@@ -103,14 +104,14 @@ int airoc_wifi_power_on(const struct device *dev)
 	}
 
 	/* Allow CBUCK regulator to discharge */
-	(void)cyhal_system_delay_ms(WLAN_CBUCK_DISCHARGE_MS);
+	(void)k_msleep(WLAN_CBUCK_DISCHARGE_MS);
 
 	/* WIFI power on */
 	ret = gpio_pin_set_dt(&config->wifi_reg_on_gpio, 1);
 	if (ret) {
 		return ret;
 	}
-	(void)cyhal_system_delay_ms(WLAN_POWER_UP_DELAY_MS);
+	(void)k_msleep(WLAN_POWER_UP_DELAY_MS);
 #endif /* DT_INST_NODE_HAS_PROP(0, reg_on_gpios) */
 
 	return 0;

--- a/drivers/wifi/infineon/airoc_wifi.h
+++ b/drivers/wifi/infineon/airoc_wifi.h
@@ -10,7 +10,7 @@
 #include <zephyr/sd/sdio.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/net/wifi_mgmt.h>
-#include <cyhal.h>
+#include <cy_utils.h>
 
 struct airoc_wifi_data {
 	struct sd_card card;

--- a/modules/hal_infineon/CMakeLists.txt
+++ b/modules/hal_infineon/CMakeLists.txt
@@ -39,6 +39,12 @@ endif()
 ## Add Wi-Fi assets for AIROC devices
 if (CONFIG_WIFI_AIROC)
   add_subdirectory(wifi-host-driver)
+
+  ## Add core-lib sources for CAT1 devices
+  add_subdirectory_ifndef(CONFIG_SOC_FAMILY_INFINEON_CAT1 core-lib)
+
+  ## Add abstraction-rtos sources
+  add_subdirectory_ifndef(CONFIG_SOC_FAMILY_INFINEON_CAT1 abstraction-rtos)
 endif()
 
 ## Add BT assets for AIROC devices

--- a/modules/hal_infineon/Kconfig
+++ b/modules/hal_infineon/Kconfig
@@ -72,14 +72,14 @@ config USE_INFINEON_WDT
 	  Enable WATCHDOG TIMER (WDT) HAL module
 	  driver for Infineon devices
 
-config USE_INFINEON_ABSTRACTION_RTOS
-	bool "Abstraction RTOS component (Zephyr support)"
-	help
-	  Enable Abstraction RTOS component with Zephyr support
-
 config USE_INFINEON_FLASH
 	bool
 	help
 	  Enable Flash HAL module driver for Infineon devices
 
 endif # SOC_FAMILY_PSOC6
+
+config USE_INFINEON_ABSTRACTION_RTOS
+	bool "Abstraction RTOS component (Zephyr support)"
+	help
+	  Enable Abstraction RTOS component with Zephyr support


### PR DESCRIPTION
Removing dependency on cyhal in airoc wifi driver.

It need to build airoc wifi driver with different than PSoC 6 Soc like STM32