### PR TITLE
scripts: set_maintainer: add log messages for skipped collabs

### DIFF
--- a/scripts/set_assignees.py
+++ b/scripts/set_assignees.py
@@ -191,9 +191,15 @@ def process_pr(gh, maintainer_file, number):
         for collaborator in collab:
             try:
                 gh_user = gh.get_user(collaborator)
-                if pr.user != gh_user and gh_repo.has_in_collaborators(gh_user):
-                    if gh_user not in existing_reviewers and gh_user not in self_removal:
-                        reviewers.append(collaborator)
+                if pr.user == gh_user or gh_user in existing_reviewers:
+                    continue
+                if not gh_repo.has_in_collaborators(gh_user):
+                    log(f"Skip '{collaborator}': not in collaborators")
+                    continue
+                if gh_user in self_removal:
+                    log(f"Skip '{collaborator}': self removed")
+                    continue
+                reviewers.append(collaborator)
             except UnknownObjectException as e:
                 log(f"Can't get user '{collaborator}', account does not exist anymore? ({e})")
 


### PR DESCRIPTION
Refactor the skip collaborator logic to add log messages when a collaborator is skipped because they self removed of not part of the org.