### PR TITLE
nvmp: a flash_map replacement

### DIFF
--- a/dts/bindings/misc/zephyr,eeprom-nvmp-fixed-partitions.yaml
+++ b/dts/bindings/misc/zephyr,eeprom-nvmp-fixed-partitions.yaml
@@ -1,0 +1,20 @@
+description: |
+  This binding is used to describe fixed non volatile partitions on eeprom.
+  Here is an example:
+    &eeprom0 {
+            nvmp_partitions {
+                    compatible = "zephyr,eeprom-nvmp-fixed-partitions";
+                    #address-cells = <1>;
+                    #size-cells = <1>;
+                    partition0: partition@0 {
+                            reg = <0x00000000 0x0000C000>;
+                    };
+                    partition1: partition@c000 {
+                            reg = <0x0000C000 0x00076000>;
+                    };
+            };
+    };
+
+compatible: "zephyr,eeprom-nvmp-fixed-partitions"
+
+include: zephyr,nvmp-fixed-partitions.yaml

--- a/dts/bindings/misc/zephyr,flash-nvmp-fixed-partitions.yaml
+++ b/dts/bindings/misc/zephyr,flash-nvmp-fixed-partitions.yaml
@@ -1,0 +1,20 @@
+description: |
+  This binding is used to describe fixed non volatile partitions on flash.
+  Here is an example:
+    &flash0 {
+            nvmp_partitions {
+                    compatible = "zephyr,flash-nvmp-fixed-partitions";
+                    #address-cells = <1>;
+                    #size-cells = <1>;
+                    partition0: partition@0 {
+                            reg = <0x00000000 0x0000C000>;
+                    };
+                    partition1: partition@c000 {
+                            reg = <0x0000C000 0x00076000>;
+                    };
+            };
+    };
+
+compatible: "zephyr,flash-nvmp-fixed-partitions"
+
+include: zephyr,nvmp-fixed-partitions.yaml

--- a/dts/bindings/misc/zephyr,nvmp-fixed-partitions.yaml
+++ b/dts/bindings/misc/zephyr,nvmp-fixed-partitions.yaml
@@ -1,0 +1,49 @@
+description: |
+  This binding is used to describe non volatile partitions.
+
+properties:
+  "#address-cells":
+    type: int
+    description: |
+      Number of cells required to represent a child node's
+      reg property address. This must be large enough to
+      represent the start offset of each partition.
+  "#size-cells":
+    type: int
+    description: |
+      Number of cells required to represent a child node's
+      reg property address. This must be large enough to
+      represent the size of each partition in bytes.
+child-binding:
+  description: |
+    Each child node of the fixed-partitions node represents
+    an individual partition. These should usually look like
+    this:
+      partition_nodelabel: partition@START_OFFSET {
+              label = "human-readable-name";
+              reg = <0xSTART_OFFSET 0xSIZE>;
+      };
+  properties:
+    label:
+      type: string
+      description: |
+        Human readable string describing the partition.
+    read-only:
+      type: boolean
+      description: set this property if the partition is read-only
+    block-size:
+      type: int
+      description: set this property to specify a block-size
+    write-block-size:
+      type: int
+      description: set this property to specify a write-block-size
+    reg:
+      type: array
+      description: |
+        This should be in the format <OFFSET SIZE>, where OFFSET
+        is the offset of the partition relative to the base
+        address of the parent memory, and SIZE is the size of
+        the partition in bytes.
+      required: true
+
+include: base.yaml

--- a/include/zephyr/storage/nvmp.h
+++ b/include/zephyr/storage/nvmp.h
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2024 Laczen
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Public API for non volatile memory and partitions
+ */
+
+#ifndef ZEPHYR_INCLUDE_NVMP_H_
+#define ZEPHYR_INCLUDE_NVMP_H_
+
+/**
+ * @brief Abstraction over non volatile memory and its partitions on non
+ *	  volatile memory and their drivers
+ *
+ * @defgroup nvmp_part_api nvmp interface
+ * @{
+ */
+
+/*
+ * This API makes it possible to operate on non volatile memory and its
+ * partitions easily and effectively.
+ */
+
+#include <errno.h>
+#include <sys/types.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * The nvmp subsystem provide an abstraction layer between non volatile memory
+ * specific drivers and higher-level applications for non volatile memory and
+ * its partitions. On non volatile memory and its partitions 3 routines for
+ * operation are provided: read, write and erase.
+ *
+ */
+
+/**
+ * @brief Retrieve a pointer to the non volatile info struct of non volatile
+ *        memory.
+ *
+ * A non volatile memory or one of its partition with nodelabel "nodelabel" is
+ * retrieved as:
+ * const struct nbmp_info *nvmp = NVMP_GET(nodelabel)
+ *
+ * @param nodelabel of the non volatile memory or one of its partitions.
+ */
+#define NVMP_GET(nodelabel) &UTIL_CAT(nvmp_info_, DT_NODELABEL(nodelabel))
+
+struct nvmp_info;
+/**
+ * @brief nvmp_info represents a nvmp item.
+ */
+struct nvmp_info {
+	/** nvmp store */
+	const void *store;
+	/** nvmp size */
+	const size_t size;
+	/** nvmp block-size */
+	const size_t block_size;
+	/** nvmp write-block-size */
+	const size_t write_block_size;
+	/** nvmp routines */
+	int (*const open)(const struct nvmp_info *info);
+	int (*const read)(const struct nvmp_info *info, size_t start, void *data,
+			  size_t len);
+	int (*const write)(const struct nvmp_info *info, size_t start,
+			   const void *data, size_t len);
+	int (*const erase)(const struct nvmp_info *info, size_t start,
+			   size_t len);
+	int (*const clear)(const struct nvmp_info *info, void *data, size_t len);
+	int (*const close)(const struct nvmp_info *info);
+};
+
+/**
+ * @brief Get the size in byte of a nvmp item.
+ *
+ * @param[in] info nvmp item
+ * @return the size.
+ */
+size_t nvmp_get_size(const struct nvmp_info *info);
+
+/**
+ * @brief Get the block-size in byte of a nvmp item.
+ *
+ * @param[in] info nvmp item
+ * @return the size.
+ */
+size_t nvmp_get_block_size(const struct nvmp_info *info);
+
+/**
+ * @brief Get the write-block-size in byte of a nvmp item.
+ *
+ * @param[in] info nvmp item
+ * @return the size.
+ */
+size_t nvmp_get_write_block_size(const struct nvmp_info *info);
+
+/**
+ * @brief Open a nvmp item.
+ *
+ * @param[in] info nvmp item
+ *
+ * @return  0 on success, negative errno code on fail.
+ */
+int nvmp_open(const struct nvmp_info *info);
+
+/**
+ * @brief Read data from nvmp item. Read boundaries are verified before read
+ * request is executed.
+ *
+ *
+ * @param[in] info nvmp item
+ * @param[in] start point relative from beginning of nvmp item
+ * @param[out] data Buffer to store read data
+ * @param[in] len Size to read
+ *
+ * @return  0 on success, negative errno code on fail.
+ */
+int nvmp_read(const struct nvmp_info *info, size_t start, void *data,
+	      size_t len);
+
+/**
+ * @brief Write data to nvmp item. Write boundaries are verified before write
+ * request is executed.
+ *
+ * @param[in] info nvmp item
+ * @param[in] start point relative from beginning of nvmp item
+ * @param[out] data Buffer with data to be written
+ * @param[in] len Size to read
+ *
+ * @return  0 on success, negative errno code on fail.
+ */
+int nvmp_write(const struct nvmp_info *info, size_t start, const void *data,
+	       size_t len);
+
+/**
+ * @brief Erase range on nvmp item. Erase boundaries are verified before erase
+ * is executed.
+ *
+ * @param[in] info nvmp item
+ * @param[in] start point relative from beginning of nvmp item
+ * @param[in] len Size to erase
+ *
+ * @return  0 on success, negative errno code on fail.
+ */
+int nvmp_erase(const struct nvmp_info *info, size_t start, size_t len);
+
+/**
+ * @brief Clear a buffer by setting the value to the nvmp item erase value.
+ *
+ *
+ * @param[in] info nvmp item
+ * @param[in] data Buffer to clear
+ * @param[in] len Size to clear
+ *
+ * @return  0 on success, negative errno code on fail.
+ */
+int nvmp_clear(const struct nvmp_info *info, void *data, size_t len);
+
+/**
+ * @brief Close a nvmp item.
+ *
+ * @param[in] info nvmp item
+ *
+ * @return  0 on success, negative errno code on fail.
+ */
+int nvmp_close(const struct nvmp_info *info);
+
+/** @cond INTERNAL_HIDDEN */
+
+#define NVMP_DECLARE_ITEM(n) extern const struct nvmp_info nvmp_info_##n;
+#define NVMP_DECLARE(inst) DT_FOREACH_CHILD_STATUS_OKAY(inst, NVMP_DECLARE_ITEM)
+
+#ifdef CONFIG_NVMP_EEPROM
+DT_FOREACH_STATUS_OKAY(zephyr_eeprom_nvmp_fixed_partitions, NVMP_DECLARE)
+#endif
+
+#ifdef CONFIG_NVMP_FLASH
+DT_FOREACH_STATUS_OKAY(zephyr_flash_nvmp_fixed_partitions, NVMP_DECLARE)
+#endif
+
+/** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* ZEPHYR_INCLUDE_NVMP_H_ */

--- a/subsys/storage/CMakeLists.txt
+++ b/subsys/storage/CMakeLists.txt
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_subdirectory_ifdef(CONFIG_FLASH_MAP  flash_map)
+add_subdirectory_ifdef(CONFIG_NVMP nvmp)
 add_subdirectory_ifdef(CONFIG_STREAM_FLASH stream)

--- a/subsys/storage/Kconfig
+++ b/subsys/storage/Kconfig
@@ -6,6 +6,7 @@
 menu "Storage"
 
 source "subsys/storage/flash_map/Kconfig"
+source "subsys/storage/nvmp/Kconfig"
 source "subsys/storage/stream/Kconfig"
 
 endmenu

--- a/subsys/storage/nvmp/CMakeLists.txt
+++ b/subsys/storage/nvmp/CMakeLists.txt
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+zephyr_library_sources(nvmp.c)
+zephyr_library_sources_ifdef(CONFIG_NVMP_EEPROM nvmp_eeprom.c)
+zephyr_library_sources_ifdef(CONFIG_NVMP_FLASH nvmp_flash.c)

--- a/subsys/storage/nvmp/Kconfig
+++ b/subsys/storage/nvmp/Kconfig
@@ -1,0 +1,42 @@
+# Copyright (c) 2024, Laczen
+# SPDX-License-Identifier: Apache-2.0
+
+menuconfig NVMP
+	bool "nvmp support"
+	help
+	  Enables support for the nvmp system, which enables using unified
+	  routines to read/write and erase non volatile memory.
+
+if NVMP
+
+config NVMP_FLASH
+	bool "nvmp support for flash devices"
+	default y if DT_HAS_ZEPHYR_FLASH_NVMP_FIXED_PARTITIONS_ENABLED
+	depends on FLASH
+	help
+	  Enables nvmp support for flash devices.
+
+if NVMP_FLASH
+
+config NVMP_FLASH_RUNTIME_VERIFY
+	bool "runtime verification of flash properties"
+	default n
+	help
+	  Enable runtime verification that block size is multiple of the flash
+	  erase block size, that write block size is a multiple of the flash
+	  write block size, and that the erase-value is correct.
+
+endif #NVMP_FLASH
+
+config NVMP_EEPROM
+	bool "nvmp support for eeprom devices"
+	default y if DT_HAS_ZEPHYR_EEPROM_NVMP_FIXED_PARTITIONS_ENABLED
+	depends on EEPROM
+	help
+	  Enables nvmp support for eeprom devices.
+
+module = NVMP
+module-str = nvmp
+source "subsys/logging/Kconfig.template.log_config"
+
+endif #NVMP

--- a/subsys/storage/nvmp/nvmp.c
+++ b/subsys/storage/nvmp/nvmp.c
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2023, Laczen
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/storage/nvmp.h>
+
+size_t nvmp_get_size(const struct nvmp_info *info)
+{
+	if (info == NULL) {
+		return 0U;
+	}
+
+	return info->size;
+}
+
+size_t nvmp_get_block_size(const struct nvmp_info *info)
+{
+	if (info == NULL) {
+		return 0U;
+	}
+
+	return info->block_size;
+}
+
+size_t nvmp_get_write_block_size(const struct nvmp_info *info)
+{
+	if (info == NULL) {
+		return 0U;
+	}
+
+	return info->write_block_size;
+}
+
+int nvmp_open(const struct nvmp_info *info)
+{
+	if (info == NULL) {
+		return -EINVAL;
+	}
+
+	if (info->open == NULL) {
+		return -ENOTSUP;
+	}
+
+	return info->open(info);
+}
+
+int nvmp_read(const struct nvmp_info *info, size_t start, void *data, size_t len)
+{
+	if (info == NULL) {
+		return -EINVAL;
+	}
+
+	if (info->read == NULL) {
+		return -ENOTSUP;
+	}
+
+	if ((start + len) > info->size) {
+		return -EINVAL;
+	}
+
+	return info->read(info, start, data, len);
+}
+
+int nvmp_write(const struct nvmp_info *info, size_t start, const void *data,
+	       size_t len)
+{
+	if (info == NULL) {
+		return -EINVAL;
+	}
+
+	if (info->write == NULL) {
+		return -ENOTSUP;
+	}
+
+	if ((start + len) > info->size) {
+		return -EINVAL;
+	}
+
+	return info->write(info, start, data, len);
+}
+
+int nvmp_erase(const struct nvmp_info *info, size_t start, size_t len)
+{
+	if (info == NULL) {
+		return -EINVAL;
+	}
+
+	if (info->erase == NULL) {
+		return -ENOTSUP;
+	}
+
+	if ((start + len) > info->size) {
+		return -EINVAL;
+	}
+
+	return info->erase(info, start, len);
+}
+
+int nvmp_clear(const struct nvmp_info *info, void *data, size_t len)
+{
+	if (info == NULL) {
+		return -EINVAL;
+	}
+
+	if (info->clear == NULL) {
+		return -ENOTSUP;
+	}
+
+	return info->clear(info, data, len);
+}
+
+int nvmp_close(const struct nvmp_info *info)
+{
+	if (info == NULL) {
+		return -EINVAL;
+	}
+
+	if (info->close == NULL) {
+		return -ENOTSUP;
+	}
+
+	return info->close(info);
+}

--- a/subsys/storage/nvmp/nvmp_define.h
+++ b/subsys/storage/nvmp/nvmp_define.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024 Laczen
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef NVMP_DEFINE_H_
+#define NVMP_DEFINE_H_
+
+#define NVMP_INFO_DEFINE(inst, _store, _size, _block_size, _write_block_size,   \
+			 _open, _read, _write, _erase, _clear, _close)          \
+	const struct nvmp_info nvmp_info_##inst = {                             \
+		.store = _store,                                                \
+		.size = _size,                                                  \
+		.block_size = _block_size,                                      \
+		.write_block_size = _write_block_size,                          \
+		.open = _open,                                                  \
+		.read = _read,                                                  \
+		.write = _write,                                                \
+		.erase = _erase,                                                \
+		.clear = _clear,                                                \
+		.close = _close,                                                \
+	}
+
+#define NVMP_RO(inst)                                                           \
+	COND_CODE_1(DT_NODE_HAS_PROP(inst, read_only),                          \
+		    (DT_PROP(inst, read_only)), (false))
+
+#define NVMP_SIZE(inst) DT_REG_SIZE(inst)
+#define NVMP_OFF(inst)  DT_REG_ADDR(inst)
+
+#define NVMP_PRO(inst) NVMP_RO(inst) || NVMP_RO(DT_GPARENT(inst))
+
+#endif /* NVMP_DEFINE_H_ */

--- a/subsys/storage/nvmp/nvmp_eeprom.c
+++ b/subsys/storage/nvmp/nvmp_eeprom.c
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2024, Laczen
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/logging/log.h>
+#include <zephyr/storage/nvmp.h>
+#include <zephyr/drivers/eeprom.h>
+
+LOG_MODULE_REGISTER(nvmp_eeprom, CONFIG_NVMP_LOG_LEVEL);
+
+struct eeprom_store {
+	const struct device *dev;
+	size_t offset;
+};
+
+static int nvmp_eeprom_open(const struct nvmp_info *info)
+{
+	const struct eeprom_store *st = (const struct eeprom_store *)info->store;
+	int rc = 0;
+
+	if (!device_is_ready(st->dev)) {
+		rc = -ENODEV;
+	}
+
+	return rc;
+}
+
+static int nvmp_eeprom_read(const struct nvmp_info *info, size_t start,
+			    void *data, size_t len)
+{
+	const struct eeprom_store *st = (const struct eeprom_store *)info->store;
+
+	LOG_DBG("read %d byte at 0x%x", len, start);
+	start += st->offset;
+	return eeprom_read(st->dev, (off_t)start, data, len);
+}
+
+static int nvmp_eeprom_write(const struct nvmp_info *info, size_t start,
+			     const void *data, size_t len)
+{
+	const struct eeprom_store *st = (const struct eeprom_store *)info->store;
+
+	LOG_DBG("write %d byte at 0x%x", len, start);
+	start += st->offset;
+	return eeprom_write(st->dev, (off_t)start, data, len);
+}
+
+static int nvmp_eeprom_close(const struct nvmp_info *info)
+{
+	return 0;
+}
+
+#include "nvmp_define.h"
+
+#define NVMP_EEPROM_DEV(inst)    DEVICE_DT_GET(DT_GPARENT(inst))
+#define NVMP_EEPROM_BSIZE(inst)  DT_PROP_OR(inst, block_size, (NVMP_SIZE(inst)))
+#define NVMP_EEPROM_WBSIZE(inst) DT_PROP_OR(inst, write_block_size, 1U)
+
+#define NVMP_EEPROM_ITEM_DEFINE(inst)                                           \
+	const struct eeprom_store eeprom_store_##inst = {                       \
+		.dev = NVMP_EEPROM_DEV(inst),                                   \
+		.offset = NVMP_OFF(inst),                                       \
+	};                                                                      \
+	NVMP_INFO_DEFINE(inst, (void *)&eeprom_store_##inst, NVMP_SIZE(inst),   \
+			 NVMP_EEPROM_BSIZE(inst), NVMP_EEPROM_WBSIZE(inst),     \
+			 nvmp_eeprom_open, nvmp_eeprom_read,                    \
+			 NVMP_PRO(inst) ? NULL : nvmp_eeprom_write, NULL, NULL, \
+			 nvmp_eeprom_close);
+
+#define NVMP_EEPROM_DEFINE(inst) DT_FOREACH_CHILD(inst, NVMP_EEPROM_ITEM_DEFINE)
+
+DT_FOREACH_STATUS_OKAY(zephyr_eeprom_nvmp_fixed_partitions, NVMP_EEPROM_DEFINE)

--- a/subsys/storage/nvmp/nvmp_flash.c
+++ b/subsys/storage/nvmp/nvmp_flash.c
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2024, Laczen
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/logging/log.h>
+#include <zephyr/storage/nvmp.h>
+#include <zephyr/drivers/flash.h>
+#include <string.h>
+
+LOG_MODULE_REGISTER(nvmp_flash, CONFIG_NVMP_LOG_LEVEL);
+
+struct flash_store {
+	const struct device *dev;
+	size_t offset;
+	uint8_t erase_value;
+};
+
+static int nvmp_flash_open(const struct nvmp_info *info)
+{
+	const struct flash_store *st = (const struct flash_store *)info->store;
+	int rc = 0;
+
+	if (!device_is_ready(st->dev)) {
+		rc = -ENODEV;
+	}
+
+	if (IS_ENABLED(CONFIG_NVMP_FLASH_RUNTIME_VERIFY)) {
+		const struct flash_parameters *flash_parameters =
+			flash_get_parameters(st->dev);
+		const size_t wbs = flash_parameters->write_block_size;
+		const uint8_t erase_value = flash_parameters->erase_value;
+		struct flash_pages_info page = {
+			.start_offset = st->offset,
+		};
+
+		while (page.start_offset < (st->offset + info->size)) {
+			rc = flash_get_page_info_by_offs(
+				st->dev, page.start_offset, &page);
+			if (rc != 0) {
+				LOG_ERR("Failed to get flash page info");
+				break;
+			}
+
+			if ((info->block_size % page.size) != 0U) {
+				LOG_ERR("Block size configuration error");
+				rc = -EINVAL;
+				break;
+			}
+
+			page.start_offset += page.size;
+		}
+
+		if ((info->write_block_size % wbs) != 0U) {
+			LOG_ERR("Write block size configuration error");
+			rc = -EINVAL;
+		}
+
+		if (st->erase_value != erase_value) {
+			LOG_ERR("Erase value configuration error");
+			rc = -EINVAL;
+		}
+	}
+
+	return rc;
+}
+
+static int nvmp_flash_read(const struct nvmp_info *info, size_t start,
+			   void *data, size_t len)
+{
+	const struct flash_store *st = (const struct flash_store *)info->store;
+
+	LOG_DBG("read %d byte at 0x%x", len, start);
+	start += st->offset;
+	return flash_read(st->dev, (off_t)start, data, len);
+}
+
+static int nvmp_flash_write(const struct nvmp_info *info, size_t start,
+			    const void *data, size_t len)
+{
+	const struct flash_store *st = (const struct flash_store *)info->store;
+
+	LOG_DBG("write %d byte at 0x%x", len, start);
+	start += st->offset;
+	return flash_write(st->dev, (off_t)start, data, len);
+}
+
+static int nvmp_flash_erase(const struct nvmp_info *info, size_t start,
+			    size_t len)
+{
+	const struct flash_store *st = (const struct flash_store *)info->store;
+
+	LOG_DBG("write %d byte at 0x%x", len, start);
+	start += st->offset;
+	return flash_erase(st->dev, (off_t)start, len);
+}
+
+static int nvmp_flash_clear(const struct nvmp_info *info, void *data,
+			    size_t len)
+{
+	const struct flash_store *st = (const struct flash_store *)info->store;
+
+	memset(data, st->erase_value, len);
+	return 0;
+}
+
+static int nvmp_flash_close(const struct nvmp_info *info)
+{
+	return 0;
+}
+
+#include "nvmp_define.h"
+
+#define NVMP_FLASH_GPDEV(inst)                                                  \
+	COND_CODE_1(DT_NODE_HAS_COMPAT(inst, soc_nv_flash),                     \
+		    (DEVICE_DT_GET(DT_PARENT(inst))), (DEVICE_DT_GET(inst)))
+#define NVMP_FLASH_DEV(inst) NVMP_FLASH_GPDEV(DT_GPARENT(inst))
+#define NVMP_FLASH_GPERASEVALUE(inst)                                           \
+	COND_CODE_1(DT_NODE_HAS_COMPAT(inst, soc_nv_flash),                     \
+		    (DT_PROP_OR(DT_PARENT(inst), erase_value, (0xF0))),         \
+		    (DT_PROP_OR(inst, erase_value, (0xF0))))
+#define NVMP_FLASH_ERASEVALUE(inst) NVMP_FLASH_GPERASEVALUE(DT_GPARENT(inst))
+#define NVMP_FLASH_BSIZE(inst)                                                  \
+	DT_PROP_OR(inst, block_size,                                            \
+		   (DT_PROP_OR(DT_GPARENT(inst), erase_block_size,              \
+			       (NVMP_SIZE(inst)))))
+#define NVMP_FLASH_WBSIZE(inst)                                                 \
+	DT_PROP_OR(inst, write_block_size,                                      \
+		   (DT_PROP_OR(DT_GPARENT(inst), write_block_size,              \
+			       (NVMP_FLASH_BSIZE(inst)))))
+
+#define NVMP_FLASH_ITEM_DEFINE(inst)                                            \
+	BUILD_ASSERT((NVMP_FLASH_ERASEVALUE(inst) == 0xFF) ||                   \
+		     (NVMP_FLASH_ERASEVALUE(inst) == 0x00),                     \
+		     "Invalid erase value, check dts definition");              \
+	const struct flash_store flash_store_##inst = {                         \
+		.dev = NVMP_FLASH_DEV(inst),                                    \
+		.offset = NVMP_OFF(inst),                                       \
+		.erase_value = NVMP_FLASH_ERASEVALUE(inst),			\
+	};                                                                      \
+	NVMP_INFO_DEFINE(inst, (void *)&flash_store_##inst, NVMP_SIZE(inst),    \
+			 NVMP_FLASH_BSIZE(inst), NVMP_FLASH_WBSIZE(inst),       \
+			 nvmp_flash_open, nvmp_flash_read,                      \
+			 NVMP_PRO(inst) ? NULL : nvmp_flash_write,              \
+			 NVMP_PRO(inst) ? NULL : nvmp_flash_erase,              \
+			 nvmp_flash_clear, nvmp_flash_close);
+
+#define NVMP_FLASH_DEFINE(inst) DT_FOREACH_CHILD(inst, NVMP_FLASH_ITEM_DEFINE)
+
+DT_FOREACH_STATUS_OKAY(zephyr_flash_nvmp_fixed_partitions, NVMP_FLASH_DEFINE)

--- a/tests/subsys/storage/nvmp/CMakeLists.txt
+++ b/tests/subsys/storage/nvmp/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright (c) 2024 Laczen
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(nvmp_test)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/subsys/storage/nvmp/boards/native_sim.overlay
+++ b/tests/subsys/storage/nvmp/boards/native_sim.overlay
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2024 Laczen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&flash0 {
+        compatible = "soc-nv-flash";
+
+	nvmp_partitions {
+		compatible = "zephyr,flash-nvmp-fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		flash0_partition0: partition@0 {
+			reg = <0x00000000 0x00002000>;
+                        block-size = <DT_SIZE_K(8)>;
+		};
+
+                flash0_partition1: partition@2000 {
+			reg = <0x00002000 0x00002000>;
+			write-block-size = <4>;
+		};
+	};
+};
+
+&eeprom0 {
+        compatible = "zephyr,sim-eeprom";
+
+	nvmp_partitions {
+		compatible = "zephyr,eeprom-nvmp-fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		eeprom0_partition0: partition@0 {
+			reg = <0x00000000 0x00000800>;
+                        block-size = <DT_SIZE_K(1)>;
+			status = "okay";
+		};
+
+		eeprom0_partition1: partition@800 {
+			reg = <0x00000800 0x00000800>;
+			status = "okay";
+		};
+
+	};
+};

--- a/tests/subsys/storage/nvmp/prj.conf
+++ b/tests/subsys/storage/nvmp/prj.conf
@@ -1,0 +1,7 @@
+# Copyright (c) 2024 Laczen
+# SPDX-License-Identifier: Apache-2.0
+CONFIG_NVMP=y
+CONFIG_FLASH=y
+CONFIG_EEPROM=y
+CONFIG_USERSPACE=n
+CONFIG_ZTEST=y

--- a/tests/subsys/storage/nvmp/src/main.c
+++ b/tests/subsys/storage/nvmp/src/main.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2012-2014 Wind River Systems, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <string.h>
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+#include <zephyr/storage/nvmp.h>
+
+#define NVMP_FLASH_PARTITION_NODE0  flash0_partition0
+#define NVMP_FLASH_PARTITION_NODE1  flash0_partition1
+#define NVMP_EEPROM_PARTITION_NODE0 eeprom0_partition0
+#define NVMP_EEPROM_PARTITION_NODE1 eeprom0_partition1
+
+ZTEST_BMEM static const struct nvmp_info *nvmp;
+
+static void *nvmp_api_setup(void)
+{
+	return NULL;
+}
+
+ZTEST_USER(nvmp_api, test_read_write_erase)
+{
+	uint8_t *wr = "/a9/9a/a9/9a";
+	uint8_t rd[sizeof(wr)];
+	int rc = 0;
+
+	memset(rd, 0, sizeof(rd));
+
+	rc = nvmp_open(nvmp);
+	zassert_equal(rc, 0, "open returned [%d]", rc);
+
+	TC_PRINT("nvmp props: size %d, block-size %d, write-block-size %d\n",
+		 nvmp->size, nvmp->block_size, nvmp->write_block_size);
+
+	rc = nvmp_read(nvmp, 0, rd, sizeof(rd));
+	zassert_equal(rc, 0, "read returned [%d]", rc);
+
+	rc = nvmp_write(nvmp, 0, wr, sizeof(wr));
+	zassert_equal(rc, 0, "write returned [%d]", rc);
+
+	rc = nvmp_read(nvmp, 0, rd, sizeof(rd));
+	zassert_equal(rc, 0, "read returned [%d]", rc);
+
+	zassert_equal(memcmp(wr, rd, sizeof(rd)), 0, "read/write data differ");
+
+	if (nvmp->erase != NULL) {
+		rc = nvmp_erase(nvmp, 0, nvmp->block_size);
+		zassert_equal(rc, 0, "erase returned [%d]", rc);
+	}
+
+	if (nvmp->clear != NULL) {
+		rc = nvmp_clear(nvmp, rd, sizeof(rd));
+		zassert_equal(rc, 0, "clear returned [%d]", rc);
+	}
+}
+
+ZTEST_SUITE(nvmp_api, NULL, nvmp_api_setup, NULL, NULL, NULL);
+
+/* Run all of our tests on the given nvmp */
+static void run_tests_on_nvmp(const struct nvmp_info *info)
+{
+	nvmp = info;
+	ztest_run_all(NULL, false, 1, 1);
+}
+
+void test_main(void)
+{
+#ifdef CONFIG_NVMP_FLASH
+	run_tests_on_nvmp(NVMP_GET(NVMP_FLASH_PARTITION_NODE0));
+	run_tests_on_nvmp(NVMP_GET(NVMP_FLASH_PARTITION_NODE1));
+#endif
+
+#ifdef CONFIG_NVMP_EEPROM
+	run_tests_on_nvmp(NVMP_GET(NVMP_EEPROM_PARTITION_NODE0));
+	run_tests_on_nvmp(NVMP_GET(NVMP_EEPROM_PARTITION_NODE1));
+#endif
+	ztest_verify_all_test_suites_ran();
+}

--- a/tests/subsys/storage/nvmp/testcase.yaml
+++ b/tests/subsys/storage/nvmp/testcase.yaml
@@ -1,0 +1,13 @@
+common:
+  depends_on:
+    - nvmp
+    - flash
+    - eeprom
+  tags: nvmp
+tests:
+  storage.nvmp.native_sim.api:
+    platform_allow:
+      - native_sim
+    integration_platforms:
+      - native_sim
+    timeout: 60


### PR DESCRIPTION
flash_map is used by several subsystems to allow access to flash devices in a unified way. Flash_map is by design directed and limited towards flash devices and does not provide support for other non volatile memories (e.g. eeprom).

nvmp (non volatile memory and partitioning) is proposed as an alternative for flash_map that provides a path to solve many problems that are caused by flash_map (e.g. https://github.com/zephyrproject-rtos/zephyr/issues/52395, the need to use flash_page interface for block-size, the ability to override the flash page size with a multiple, ...).

The proposal is easily extended to other types of memory that would use a dedicated driver solution (e.g. fram, mram, rram that could have a driver similar to eeprom). It can also be extended to disks and even files.

nvmp is an alternative for https://github.com/zephyrproject-rtos/zephyr/pull/67687 and https://github.com/zephyrproject-rtos/zephyr/pull/70828.