### PR TITLE
linker: nxp: add orphan linker section

### DIFF
--- a/soc/nxp/imx/imx8m/adsp/linker.ld
+++ b/soc/nxp/imx/imx8m/adsp/linker.ld
@@ -529,4 +529,5 @@ SECTIONS
   } >fw_metadata_seg :metadata_entries_phdr
 
   #include <snippets-sections.ld>
+  /DISCARD/ : { *(.note.GNU-stack) }
 }


### PR DESCRIPTION
Add missing linker section to avoid warning
about orphans when building with host compiler.