### PR TITLE
boards: xenvm: return userspace testcases for XenVM board

### DIFF
--- a/boards/xen/xenvm/xenvm.yaml
+++ b/boards/xen/xenvm/xenvm.yaml
@@ -7,6 +7,3 @@ toolchain:
   - cross-compile
 ram: 16384
 vendor: xen
-testing:
-  ignore_tags:
-    - userspace

--- a/boards/xen/xenvm/xenvm_xenvm_gicv3.yaml
+++ b/boards/xen/xenvm/xenvm_xenvm_gicv3.yaml
@@ -7,6 +7,3 @@ toolchain:
   - cross-compile
 ram: 16384
 vendor: xen
-testing:
-  ignore_tags:
-    - userspace


### PR DESCRIPTION
XenVM boards were mark as unsupported for twister testcases related to userspace. After additional investigation no problems were found for builds, so there are no reason to exclude it from test runs.

This was removed by #70129.