### PR TITLE
twister: pytest: escape expected command regex

### DIFF
--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/helpers/shell.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/helpers/shell.py
@@ -58,7 +58,7 @@ class Shell:
         timeout = timeout or self.base_timeout
         command_ext = f'{command}\n\n'
         regex_prompt = re.escape(self.prompt)
-        regex_command = f'.*{command}'
+        regex_command = f'.*{re.escape(command)}'
         self._device.clear_buffer()
         self._device.write(command_ext.encode())
         lines: list[str] = []


### PR DESCRIPTION
When sending commands containing something like `AT+CFUN` the expected
regex was not escaped and as a result such regex never matched what has
been echoed over serial.

Escape all commands with `re.escape()` so that echoed shell commands are
always matched, even when they contain special characters (like '+' in the
example above).