### PR TITLE
[Backport v3.6-branch] drivers: can: mcan: fix transmitter delay compensation support

### DIFF
--- a/drivers/can/Kconfig.mcan
+++ b/drivers/can/Kconfig.mcan
@@ -1,4 +1,4 @@
-# Bosch m_can configuration options
+# Bosch M_CAN configuration options
 
 # Copyright (c) 2020 Alexander Wachter
 # SPDX-License-Identifier: Apache-2.0
@@ -6,17 +6,4 @@
 config CAN_MCAN
 	bool
 	help
-	  Enable Bosch m_can driver.
-	  This driver supports the Bosch m_can IP. This IP is built into the
-	  STM32G4, STM32G0, STM32H7, and the Microchip SAM controllers with
-	  CAN FD.
-
-if CAN_MCAN
-
-config CAN_DELAY_COMP
-	bool "Transceiver delay compensation"
-	default y
-	help
-	  Enable the automatic transceiver delay compensation.
-
-endif #CAN_MCAN
+	  Enable the Bosch M_CAN CAN IP module driver backend.

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -225,8 +225,10 @@ unlock:
 #ifdef CONFIG_CAN_FD_MODE
 int can_mcan_set_timing_data(const struct device *dev, const struct can_timing *timing_data)
 {
+	const uint8_t tdco_max = FIELD_GET(CAN_MCAN_TDCR_TDCO, CAN_MCAN_TDCR_TDCO);
 	struct can_mcan_data *data = dev->data;
 	uint32_t dbtp = 0U;
+	uint8_t tdco;
 	int err;
 
 	if (data->common.started) {
@@ -239,6 +241,23 @@ int can_mcan_set_timing_data(const struct device *dev, const struct can_timing *
 		FIELD_PREP(CAN_MCAN_DBTP_DTSEG1, timing_data->phase_seg1 - 1UL) |
 		FIELD_PREP(CAN_MCAN_DBTP_DTSEG2, timing_data->phase_seg2 - 1UL) |
 		FIELD_PREP(CAN_MCAN_DBTP_DBRP, timing_data->prescaler - 1UL);
+
+	if (timing_data->prescaler == 1U || timing_data->prescaler == 2U) {
+		/* TDC can only be enabled if DBRP = { 0, 1 } */
+		dbtp |= CAN_MCAN_DBTP_TDC;
+
+		/* Set TDC offset for correct location of the Secondary Sample Point (SSP) */
+		tdco = CAN_CALC_TDCO(timing_data, 0U, tdco_max);
+		LOG_DBG("TDC enabled, using TDCO %u", tdco);
+
+		err = can_mcan_write_reg(dev, CAN_MCAN_TDCR, FIELD_PREP(CAN_MCAN_TDCR_TDCO, tdco));
+		if (err != 0) {
+			goto unlock;
+		}
+	} else {
+		LOG_DBG("TDC cannot be enabled, prescaler value %u too high",
+			timing_data->prescaler);
+	}
 
 	err = can_mcan_write_reg(dev, CAN_MCAN_DBTP, dbtp);
 	if (err != 0) {

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -1416,32 +1416,6 @@ int can_mcan_init(const struct device *dev)
 		return err;
 	}
 
-#if defined(CONFIG_CAN_DELAY_COMP) && defined(CONFIG_CAN_FD_MODE)
-	err = can_mcan_read_reg(dev, CAN_MCAN_DBTP, &reg);
-	if (err != 0) {
-		return err;
-	}
-
-	reg |= CAN_MCAN_DBTP_TDC;
-
-	err = can_mcan_write_reg(dev, CAN_MCAN_DBTP, reg);
-	if (err != 0) {
-		return err;
-	}
-
-	err = can_mcan_read_reg(dev, CAN_MCAN_TDCR, &reg);
-	if (err != 0) {
-		return err;
-	}
-
-	reg |= FIELD_PREP(CAN_MCAN_TDCR_TDCO, config->tx_delay_comp_offset);
-
-	err = can_mcan_write_reg(dev, CAN_MCAN_TDCR, reg);
-	if (err != 0) {
-		return err;
-	}
-#endif /* defined(CONFIG_CAN_DELAY_COMP) && defined(CONFIG_CAN_FD_MODE) */
-
 	err = can_mcan_read_reg(dev, CAN_MCAN_GFC, &reg);
 	if (err != 0) {
 		return err;

--- a/dts/bindings/can/can-fd-controller.yaml
+++ b/dts/bindings/can/can-fd-controller.yaml
@@ -47,6 +47,3 @@ properties:
     description: |
       Initial time quanta of phase buffer 2 segment for the data phase (ISO11898-1:2015). Deprecated
       in favor of setting advanced timing parameters from the application.
-  tx-delay-comp-offset:
-    type: int
-    default: 0

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -318,6 +318,23 @@ typedef void (*can_state_change_callback_t)(const struct device *dev,
  */
 
 /**
+ * @brief Calculate Transmitter Delay Compensation Offset from data phase timing parameters.
+ *
+ * Calculates the TDC Offset in minimum time quanta (mtq) using the sample point and CAN core clock
+ * prescaler specified by a set of data phase timing parameters.
+ *
+ * The result is clamped to the minimum/maximum supported TDC Offset values provided.
+ *
+ * @param _timing_data Pointer to data phase timing parameters.
+ * @param _tdco_min    Minimum supported TDC Offset value in mtq.
+ * @param _tdco_max    Maximum supported TDC Offset value in mtq.
+ * @return             Calculated TDC Offset value in mtq.
+ */
+#define CAN_CALC_TDCO(_timing_data, _tdco_min, _tdco_max)                                          \
+	CLAMP((1U + _timing_data->prop_seg + _timing_data->phase_seg1) * _timing_data->prescaler,  \
+	      _tdco_min, _tdco_max)
+
+/**
  * @brief Common CAN controller driver configuration.
  *
  * This structure is common to all CAN controller drivers and is expected to be the first element in

--- a/include/zephyr/drivers/can/can_mcan.h
+++ b/include/zephyr/drivers/can/can_mcan.h
@@ -1240,12 +1240,9 @@ struct can_mcan_config {
 	uint16_t sjw;
 	uint16_t prop_ts1;
 	uint16_t ts2;
-#ifdef CONFIG_CAN_FD_MODE
 	uint8_t sjw_data;
 	uint8_t prop_ts1_data;
 	uint8_t ts2_data;
-	uint8_t tx_delay_comp_offset;
-#endif
 	const void *custom;
 };
 
@@ -1313,7 +1310,6 @@ struct can_mcan_config {
 		.prop_ts1_data = DT_PROP_OR(node_id, prop_seg_data, 0) +                           \
 				 DT_PROP_OR(node_id, phase_seg1_data, 0),                          \
 		.ts2_data = DT_PROP_OR(node_id, phase_seg2_data, 0),                               \
-		.tx_delay_comp_offset = DT_PROP(node_id, tx_delay_comp_offset),                    \
 		.custom = _custom,                                                                 \
 	}
 #else /* CONFIG_CAN_FD_MODE */


### PR DESCRIPTION
Backport bfad7bc00e734010d059d5ba7eb4cd2187eb1c8d~4..bfad7bc00e734010d059d5ba7eb4cd2187eb1c8d from #70449.

Fixes: #70447
Fixes: #70825