### PR TITLE
cmake: Fix invalid calls of set_compiler_property

### DIFF
--- a/cmake/compiler/compiler_flags_template.cmake
+++ b/cmake/compiler/compiler_flags_template.cmake
@@ -51,7 +51,7 @@ set_compiler_property(PROPERTY nostdinc)
 set_compiler_property(PROPERTY nostdinc_include)
 
 # Compiler flags for disabling C++ standard include.
-set_compiler_property(TARGET compiler-cpp PROPERTY nostdincxx)
+set_property(TARGET compiler-cpp PROPERTY nostdincxx)
 
 # Required C++ flags when compiling C++ code
 set_property(TARGET compiler-cpp PROPERTY required)

--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -121,7 +121,7 @@ endif()
 
 set_compiler_property(PROPERTY no_printf_return_value -fno-printf-return-value)
 
-set_compiler_property(TARGET compiler-cpp PROPERTY nostdincxx "-nostdinc++")
+set_property(TARGET compiler-cpp PROPERTY nostdincxx "-nostdinc++")
 
 # Required C++ flags when using gcc
 set_property(TARGET compiler-cpp PROPERTY required "-fcheck-new")


### PR DESCRIPTION
set_compiler_property does not accept a TARGET argument. Only set_property does but they are easy to confuse. This patch fixes the wrong instances of set_compiler_property that should have been set_property. But the underlying issue that allowed such a mistake to pass unnoticed is not addressed. I would then recommend a separate patch that modifies set_compiler_property so that:

1) we set single_args to empty, or remove it altogether, so it does not pick a
   random value from the parent scope by accident
2) check COMPILER_PROPERTY_UNPARSED_ARGUMENTS is empty and raise a fatal error
   if not to help pick wrong uses again since set_property and
   set_compiler_property are too similar and easy to confuse
3) remove set(APPEND-CPP "APPEND") since APPEND-CPP is not used

Let me know if the recommendations are acceptable and I can submit a second PR.