### PR TITLE
MAINTAINERS: STM32 Platforms: Reflect recent changes

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3541,10 +3541,9 @@ STM32 Platforms:
   maintainers:
     - erwango
   collaborators:
-    - ABOSTM
+    - ajarmouni-st
     - FRASTM
     - gautierg-st
-    - Desvauxm-st
     - GeorgeCGV
   files:
     - boards/st/


### PR DESCRIPTION
@Desvauxm-st is now retired and @ABOSTM is not working anymore on Zephyr since some time now. Remove them and add @ajarmouni-st, which has been contributing for some time now.

List of contributions for @ajarmouni-st: [here](https://github.com/zephyrproject-rtos/zephyr/issues?q=author%3Aajarmouni-st+)