### PR TITLE
posix: pthread: implement pthread_setschedprio

### DIFF
--- a/include/zephyr/posix/pthread.h
+++ b/include/zephyr/posix/pthread.h
@@ -447,6 +447,7 @@ int pthread_attr_setschedparam(pthread_attr_t *attr,
 			       const struct sched_param *schedparam);
 int pthread_setschedparam(pthread_t pthread, int policy,
 			  const struct sched_param *param);
+int pthread_setschedprio(pthread_t thread, int prio);
 int pthread_rwlock_destroy(pthread_rwlock_t *rwlock);
 int pthread_rwlock_init(pthread_rwlock_t *rwlock,
 			const pthread_rwlockattr_t *attr);

--- a/tests/posix/common/src/pthread.c
+++ b/tests/posix/common/src/pthread.c
@@ -539,6 +539,32 @@ ZTEST(pthread, test_pthread_testcancel)
 	zassert_false(testcancel_failed);
 }
 
+static void *test_pthread_setschedprio_fn(void *arg)
+{
+	int policy;
+	int prio = 0;
+	struct sched_param param;
+	pthread_t self = pthread_self();
+
+	zassert_equal(pthread_setschedprio(self, PRIO_INVALID), EINVAL, "EINVAL was expected");
+	zassert_equal(pthread_setschedprio(PTHREAD_INVALID, prio), ESRCH, "ESRCH was expected");
+
+	zassert_ok(pthread_setschedprio(self, prio));
+	param.sched_priority = ~prio;
+	zassert_ok(pthread_getschedparam(self, &policy, &param));
+	zassert_equal(param.sched_priority, prio, "Priority unchanged");
+
+	return NULL;
+}
+
+ZTEST(pthread, test_pthread_setschedprio)
+{
+	pthread_t th;
+
+	zassert_ok(pthread_create(&th, NULL, test_pthread_setschedprio_fn, NULL));
+	zassert_ok(pthread_join(th, NULL));
+}
+
 static void before(void *arg)
 {
 	ARG_UNUSED(arg);

--- a/tests/posix/headers/src/pthread_h.c
+++ b/tests/posix/headers/src/pthread_h.c
@@ -151,7 +151,7 @@ ZTEST(posix_headers, test_pthread_h)
 		zassert_not_null(pthread_setcanceltype);
 		zassert_not_null(pthread_setconcurrency);
 		zassert_not_null(pthread_setschedparam);
-		/* zassert_not_null(pthread_setschedprio); */ /* not implemented */
+		zassert_not_null(pthread_setschedprio);
 		zassert_not_null(pthread_setspecific);
 		zassert_not_null(pthread_spin_destroy);
 		zassert_not_null(pthread_spin_init);


### PR DESCRIPTION
I noticed that pthread_setschedprio() was mentioned in the documentation but hasn't actually been implemented yet :
https://github.com/search?q=repo%3Azephyrproject-rtos%2Fzephyr+setschedprio&type=code
![image](https://github.com/zephyrproject-rtos/zephyr/assets/6190795/a2d8a243-792c-4051-bb87-20973fbcb38b)

Therefore, I decided to implement it based on the information provided here: :
https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_setschedprio.html