### PR TITLE
soc: st: Add support for STOP mode on STM32H5 devices

### DIFF
--- a/boards/st/nucleo_h563zi/nucleo_h563zi-common.dtsi
+++ b/boards/st/nucleo_h563zi/nucleo_h563zi-common.dtsi
@@ -190,3 +190,13 @@ zephyr_udc0: &usb {
 &vbat {
 	status = "okay";
 };
+
+&clk_lsi {
+	status = "okay";
+};
+
+stm32_lp_tick_source: &lptim4 {
+	clocks = <&rcc STM32_CLOCK_BUS_APB3 0x2000>,
+		 <&rcc STM32_SRC_LSI LPTIM4_SEL(4)>;
+	status = "okay";
+};

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -401,12 +401,8 @@ static int sys_clock_driver_init(void)
 		return -EIO;
 	}
 
-#if defined(LL_APB1_GRP1_PERIPH_LPTIM1)
-	LL_APB1_GRP1_ReleaseReset(LL_APB1_GRP1_PERIPH_LPTIM1);
-#elif defined(LL_APB3_GRP1_PERIPH_LPTIM1)
+#if defined(LL_SRDAMR_GRP1_PERIPH_LPTIM1AMEN)
 	LL_SRDAMR_GRP1_EnableAutonomousClock(LL_SRDAMR_GRP1_PERIPH_LPTIM1AMEN);
-#elif defined(LL_APB7_GRP1_PERIPH_LPTIM1)
-	LL_APB7_GRP1_ReleaseReset(LL_APB7_GRP1_PERIPH_LPTIM1);
 #endif
 
 	/* Enable LPTIM clock source */

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -478,6 +478,7 @@ static int sys_clock_driver_init(void)
 	LL_LPTIM_SetPrescaler(LPTIM, (__CLZ(__RBIT(lptim_clock_presc)) << LPTIM_CFGR_PRESC_Pos));
 
 #if defined(CONFIG_SOC_SERIES_STM32U5X) || \
+	defined(CONFIG_SOC_SERIES_STM32H5X) || \
 	defined(CONFIG_SOC_SERIES_STM32WBAX)
 	LL_LPTIM_OC_SetPolarity(LPTIM, LL_LPTIM_CHANNEL_CH1,
 				LL_LPTIM_OUTPUT_POLARITY_REGULAR);
@@ -491,6 +492,7 @@ static int sys_clock_driver_init(void)
 	LL_LPTIM_TrigSw(LPTIM);
 
 #if defined(CONFIG_SOC_SERIES_STM32U5X) || \
+	defined(CONFIG_SOC_SERIES_STM32H5X) || \
 	defined(CONFIG_SOC_SERIES_STM32WBAX)
 	/* Enable the LPTIM before proceeding with configuration */
 	LL_LPTIM_Enable(LPTIM);
@@ -516,6 +518,7 @@ static int sys_clock_driver_init(void)
 	LL_LPTIM_ClearFlag_ARROK(LPTIM);
 
 #if !defined(CONFIG_SOC_SERIES_STM32U5X) && \
+	!defined(CONFIG_SOC_SERIES_STM32H5X) && \
 	!defined(CONFIG_SOC_SERIES_STM32WBAX)
 	/* Enable the LPTIM counter */
 	LL_LPTIM_Enable(LPTIM);

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -30,6 +30,7 @@
 			device_type = "cpu";
 			compatible = "arm,cortex-m33";
 			reg = <0>;
+			cpu-power-states = <&stop>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 
@@ -113,6 +114,15 @@
 				erase-block-size = <8192>;
 				/* maximum erase time(ms) for a 8K sector */
 				max-erase-time = <5>;
+			};
+		};
+
+		power-states {
+			stop: state0 {
+				compatible = "zephyr,power-state";
+				power-state-name = "suspend-to-idle";
+				substate-id = <1>;
+				min-residency-us = <20>;
 			};
 		};
 

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -206,6 +206,28 @@
 			};
 		};
 
+		lptim1: timers@44004400 {
+			compatible = "st,stm32-lptim";
+			clocks = <&rcc STM32_CLOCK_BUS_APB3 0x800>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x44004400 0x400>;
+			interrupts = <64 1>;
+			interrupt-names = "wakeup";
+			status = "disabled";
+		};
+
+		lptim2: timers@40009400 {
+			compatible = "st,stm32-lptim";
+			clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x20>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40009400 0x400>;
+			interrupts = <70 1>;
+			interrupt-names = "wakeup";
+			status = "disabled";
+		};
+
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -54,6 +54,50 @@
 			};
 		};
 
+		lptim3: timers@44004800 {
+			compatible = "st,stm32-lptim";
+			clocks = <&rcc STM32_CLOCK_BUS_APB3 0x1000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x44004800 0x400>;
+			interrupts = <127 1>;
+			interrupt-names = "wakeup";
+			status = "disabled";
+		};
+
+		lptim4: timers@44004C00 {
+			compatible = "st,stm32-lptim";
+			clocks = <&rcc STM32_CLOCK_BUS_APB3 0x2000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x44004C00 0x400>;
+			interrupts = <128 1>;
+			interrupt-names = "wakeup";
+			status = "disabled";
+		};
+
+		lptim5: timers@44005000 {
+			compatible = "st,stm32-lptim";
+			clocks = <&rcc STM32_CLOCK_BUS_APB3 0x4000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x44005000 0x400>;
+			interrupts = <129 1>;
+			interrupt-names = "wakeup";
+			status = "disabled";
+		};
+
+		lptim6: timers@44005400 {
+			compatible = "st,stm32-lptim";
+			clocks = <&rcc STM32_CLOCK_BUS_APB3 0x8000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x44005400 0x400>;
+			interrupts = <130 1>;
+			interrupt-names = "wakeup";
+			status = "disabled";
+		};
+
 		uart4: serial@40004c00 {
 			compatible = "st,stm32-uart";
 			reg = <0x40004c00 0x400>;

--- a/samples/boards/stm32/power_mgmt/serial_wakeup/boards/nucleo_h563zi.overlay
+++ b/samples/boards/stm32/power_mgmt/serial_wakeup/boards/nucleo_h563zi.overlay
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2024 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&usart3 {
+	/* Set domain clock to HSI to allow wakeup from Stop mode */
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00040000>,
+		 <&rcc STM32_SRC_HSI USART3_SEL(3)>;
+
+	/* Configure device as wakeup source */
+	wakeup-source;
+
+	/* Configure sleep pinctrl configuration which will be used when
+	 * device is not configured as wakeup source by the application.
+	 * This use case is only applicable in PM_DEVICE mode.
+	 */
+	pinctrl-1 = <&analog_pd8 &analog_pd9>;
+	pinctrl-names = "default", "sleep";
+};
+
+&clk_hsi {
+	/* Make sure HSI is enabled */
+	status = "okay";
+};

--- a/soc/st/stm32/stm32h5x/CMakeLists.txt
+++ b/soc/st/stm32/stm32h5x/CMakeLists.txt
@@ -5,6 +5,10 @@ zephyr_sources(
   soc.c
   )
 
+zephyr_sources_ifdef(CONFIG_PM
+  power.c
+  )
+
 zephyr_include_directories(.)
 
 set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/linker.ld CACHE INTERNAL "")

--- a/soc/st/stm32/stm32h5x/Kconfig
+++ b/soc/st/stm32/stm32h5x/Kconfig
@@ -14,3 +14,4 @@ config SOC_SERIES_STM32H5X
 	select CPU_CORTEX_M_HAS_DWT
 	select HAS_STM32CUBE
 	select HAS_SWO
+	select HAS_PM

--- a/soc/st/stm32/stm32h5x/power.c
+++ b/soc/st/stm32/stm32h5x/power.c
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2024 STMicroelectronics.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/kernel.h>
+#include <zephyr/pm/pm.h>
+#include <soc.h>
+#include <zephyr/init.h>
+
+#include <stm32h5xx_ll_cortex.h>
+#include <stm32h5xx_ll_pwr.h>
+#include <clock_control/clock_stm32_ll_common.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
+
+/* Invoke Low Power/System Off specific Tasks */
+void pm_state_set(enum pm_state state, uint8_t substate_id)
+{
+	if (state != PM_STATE_SUSPEND_TO_IDLE) {
+		LOG_DBG("Unsupported power state %u", state);
+		return;
+	}
+
+	switch (substate_id) {
+	case 1: /* this corresponds to the STOP mode: */
+		/* enter STOP mode */
+		LL_PWR_SetPowerMode(LL_PWR_STOP_MODE);
+		LL_LPM_EnableDeepSleep();
+		/* enter SLEEP mode : WFE or WFI */
+		k_cpu_idle();
+		break;
+	default:
+		LOG_DBG("Unsupported power state substate-id %u",
+			substate_id);
+		break;
+	}
+}
+
+/* Handle SOC specific activity after Low Power Mode Exit */
+void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
+{
+	if (state != PM_STATE_SUSPEND_TO_IDLE) {
+		LOG_DBG("Unsupported power substate %u", state);
+	} else {
+		switch (substate_id) {
+		case 1:	/* STOP */
+			LL_LPM_DisableSleepOnExit();
+			/* Clear SLEEPDEEP bit */
+			LL_LPM_EnableSleep();
+			break;
+		default:
+			LOG_DBG("Unsupported power substate-id %u",
+				substate_id);
+			break;
+		}
+		/* need to restore the clock */
+		stm32_clock_control_init(NULL);
+	}
+
+	/*
+	 * System is now in active mode.
+	 * Reenable interrupts which were disabled
+	 * when OS started idling code.
+	 */
+	irq_unlock(0);
+}
+
+/* Initialize STM32 Power */
+static int stm32_power_init(void)
+{
+	return 0;
+}
+
+SYS_INIT(stm32_power_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);


### PR DESCRIPTION
Adds support for STOP mode on STM32H5 devices.
Also adds support for STM32H5 to LPTIM driver.
The functionality can be tested in samples/boards/stm32/power_mgmt/blinky and samples/boards/stm32/power_mgmt/serial_wakeup example.