### PR TITLE
kernel: move nothread support to own file

### DIFF
--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -58,10 +58,7 @@ list(APPEND kernel_files
   kheap.c
   mem_slab.c
   float.c
-  thread.c
   version.c
-  priority_queues.c
-  sched.c
   )
 
 if(CONFIG_SCHED_CPU_MASK)
@@ -82,16 +79,20 @@ list(APPEND kernel_files
   system_work_q.c
   work.c
   condvar.c
+  priority_queues.c
+  thread.c
+  sched.c
   )
-
 if(CONFIG_SMP)
 list(APPEND kernel_files
      smp.c
      ipi.c)
 endif()
-
-endif()
-
+else() # CONFIG_MULTITHREADING
+list(APPEND kernel_files
+  nothread.c
+  )
+endif() # CONFIG_MULTITHREADING
 
 if(CONFIG_TIMESLICING)
 list(APPEND kernel_files

--- a/kernel/include/kthread.h
+++ b/kernel/include/kthread.h
@@ -43,7 +43,6 @@ void z_thread_monitor_exit(struct k_thread *thread);
 #endif /* CONFIG_THREAD_MONITOR */
 
 
-#ifdef CONFIG_MULTITHREADING
 static inline void thread_schedule_new(struct k_thread *thread, k_timeout_t delay)
 {
 #ifdef CONFIG_SYS_CLOCK_EXISTS
@@ -57,7 +56,6 @@ static inline void thread_schedule_new(struct k_thread *thread, k_timeout_t dela
 	k_thread_start(thread);
 #endif /* CONFIG_SYS_CLOCK_EXISTS */
 }
-#endif /* CONFIG_MULTITHREADING */
 
 static inline int thread_is_preemptible(struct k_thread *thread)
 {

--- a/kernel/nothread.c
+++ b/kernel/nothread.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <kernel_internal.h>
+
+/* We are not building thread.c when MULTITHREADING=n, so we
+ * need to provide a few stubs here.
+ */
+bool k_is_in_isr(void)
+{
+	return arch_is_in_isr();
+}
+
+/* This is a fallback implementation of k_sleep() for when multi-threading is
+ * disabled. The main implementation is in sched.c.
+ */
+int32_t z_impl_k_sleep(k_timeout_t timeout)
+{
+	k_ticks_t ticks;
+	uint32_t expected_wakeup_ticks;
+
+	__ASSERT(!arch_is_in_isr(), "");
+
+	SYS_PORT_TRACING_FUNC_ENTER(k_thread, sleep, timeout);
+
+	/* in case of K_FOREVER, we suspend */
+	if (K_TIMEOUT_EQ(timeout, K_FOREVER)) {
+		/* In Single Thread, just wait for an interrupt saving power */
+		k_cpu_idle();
+		SYS_PORT_TRACING_FUNC_EXIT(k_thread, sleep, timeout, (int32_t) K_TICKS_FOREVER);
+
+		return (int32_t) K_TICKS_FOREVER;
+	}
+
+	ticks = timeout.ticks;
+	if (Z_TICK_ABS(ticks) <= 0) {
+		expected_wakeup_ticks = ticks + sys_clock_tick_get_32();
+	} else {
+		expected_wakeup_ticks = Z_TICK_ABS(ticks);
+	}
+	/* busy wait to be time coherent since subsystems may depend on it */
+	z_impl_k_busy_wait(k_ticks_to_us_ceil32(expected_wakeup_ticks));
+
+	int32_t ret = k_ticks_to_ms_ceil64(0);
+
+	SYS_PORT_TRACING_FUNC_EXIT(k_thread, sleep, timeout, ret);
+
+	return ret;
+}

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -307,8 +307,6 @@ static inline int z_vrfy_k_thread_name_copy(k_tid_t thread,
 #include <syscalls/k_thread_name_copy_mrsh.c>
 #endif /* CONFIG_USERSPACE */
 
-
-#ifdef CONFIG_MULTITHREADING
 #ifdef CONFIG_STACK_SENTINEL
 /* Check that the stack sentinel is still present
  *
@@ -357,8 +355,6 @@ static inline void z_vrfy_k_thread_start(struct k_thread *thread)
 }
 #include <syscalls/k_thread_start_mrsh.c>
 #endif /* CONFIG_USERSPACE */
-#endif /* CONFIG_MULTITHREADING */
-
 
 #if CONFIG_STACK_POINTER_RANDOM
 int z_stack_adjust_initialized;
@@ -616,7 +612,7 @@ char *z_setup_new_thread(struct k_thread *new_thread,
 	return stack_ptr;
 }
 
-#ifdef CONFIG_MULTITHREADING
+
 k_tid_t z_impl_k_thread_create(struct k_thread *new_thread,
 			      k_thread_stack_t *stack,
 			      size_t stack_size, k_thread_entry_t entry,
@@ -634,7 +630,6 @@ k_tid_t z_impl_k_thread_create(struct k_thread *new_thread,
 
 	return new_thread;
 }
-
 
 #ifdef CONFIG_USERSPACE
 bool z_stack_is_user_capable(k_thread_stack_t *stack)
@@ -708,8 +703,6 @@ k_tid_t z_vrfy_k_thread_create(struct k_thread *new_thread,
 }
 #include <syscalls/k_thread_create_mrsh.c>
 #endif /* CONFIG_USERSPACE */
-#endif /* CONFIG_MULTITHREADING */
-
 
 void z_init_thread_base(struct _thread_base *thread_base, int priority,
 		       uint32_t initial_state, unsigned int options)


### PR DESCRIPTION
Do not build threading support when CONFIG_MULTITHREADING=n is set and
move needed calls to a new file with the changes needed instead of the
ifdef party in sched.c

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
