### PR TITLE
samples: shell: shell_module: Add harness to the Bluetooth config

### DIFF
--- a/samples/subsys/shell/shell_module/sample.yaml
+++ b/samples/subsys/shell/shell_module/sample.yaml
@@ -53,6 +53,7 @@ tests:
       - shell
       - bluetooth
     filter: CONFIG_DT_HAS_ZEPHYR_NUS_UART_ENABLED
+    harness: bluetooth_nus
     arch_exclude:
       - posix
     extra_args:


### PR DESCRIPTION
Add a harness to avoid twister waiting for results on the UART, which won't happen unless there is a connection established to a remote Bluetooth device.