### PR TITLE
boards: nxp: vmu_rt1170: Fix USDHC by setting PWR and CD gpio's correctly

### DIFF
--- a/boards/nxp/vmu_rt1170/vmu_rt1170-pinctrl.dtsi
+++ b/boards/nxp/vmu_rt1170/vmu_rt1170-pinctrl.dtsi
@@ -128,6 +128,11 @@
 		};
 	};
 
+	pinmux_user: pinmux_user {
+		group0 {
+			pinmux = <&iomuxc_gpio_emc_b1_24_gpio_mux1_io24>;
+		};
+	};
 
 	pinmux_flexspi1: pinmux_flexspi1 {
 		group0 {
@@ -346,10 +351,14 @@
 			input-enable;
 		};
 		group1 {
-			pinmux = <&iomuxc_gpio_sd_b1_01_usdhc1_clk>,
-				<&iomuxc_gpio_ad_32_usdhc1_cd_b>;
+			pinmux = <&iomuxc_gpio_sd_b1_01_usdhc1_clk>;
 			drive-strength = "high";
 			slew-rate = "fast";
+		};
+		group2 {
+			pinmux = <&iomuxc_gpio_ad_32_usdhc1_cd_b>;
+			bias-pull-down;
+			input-enable;
 		};
 	};
 

--- a/boards/nxp/vmu_rt1170/vmu_rt1170.dts
+++ b/boards/nxp/vmu_rt1170/vmu_rt1170.dts
@@ -19,6 +19,7 @@
 		led1 = &red_led;
 		watchdog0 = &wdog1;
 		sdhc0 = &usdhc1;
+		sw0 = &arming_button;
 	};
 
 	chosen {
@@ -34,13 +35,13 @@
 		zephyr,code-partition = &slot0_partition;
 	};
 
-	/* This regulator controls VDD_3V3_SD_CARD onboard supply */
-	reg-3v3-sdcard {
-		compatible = "regulator-fixed";
-		regulator-name = "reg-3v3-sdcard";
-		enable-gpios = <&gpio1 1 GPIO_ACTIVE_HIGH>;
-		regulator-always-on;
-		status = "okay";
+	/* This is the Button on the included GPS module for 10 pin JST-GH */
+	buttons {
+		compatible = "gpio-keys";
+		arming_button: button_0 {
+			label = "Arming Switch";
+			gpios = <&gpio1 24 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;
+		};
 	};
 
 	/* This regulator controls VDD_5V_PERIPH onboard supply */
@@ -397,6 +398,8 @@
 
 &usdhc1 {
 	status = "okay";
+	no-1-8-v;
+	pwr-gpios = <&gpio1 1 GPIO_ACTIVE_HIGH>;
 	sdmmc {
 		compatible = "zephyr,sdmmc-disk";
 		status = "okay";


### PR DESCRIPTION
SD card wasn't working on vmu_rt1170.

This PR includes some pinctrl dts fixes to fix it again

```
uart:~$ *** Booting Zephyr OS build v3.6.0-1976-g8a88cd4805b0 ***
Running TESTSUITE disk_driver
===================================================================
Disk reports 15138816 sectors
Disk reports sector size 512
START - test_read
Testing reads of 8 sectors
Testing reads of 1 sectors
Testing reads of 29 sectors
Testing reads of 31 sectors
 PASS - test_read in 0.025 seconds
===================================================================
START - test_write
Testing writes of 8 sectors
Testing writes of 1 sectors
Testing writes of 29 sectors
Testing writes of 31 sectors
 PASS - test_write in 0.153 seconds
===================================================================
TESTSUITE disk_driver succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [disk_driver]: pass = 2, fail = 0, skip = 0, total = 2 duration = 0.178 seconds
 - PASS - [disk_driver.test_read] duration = 0.025 seconds
 - PASS - [disk_driver.test_write] duration = 0.153 seconds

------ TESTSUITE SUMMARY END ------

```