### PR TITLE
Fix missing includes for seeed_xiao_expansion_board

### DIFF
--- a/boards/shields/seeed_xiao_expansion_board/seeed_xiao_expansion_board.overlay
+++ b/boards/shields/seeed_xiao_expansion_board/seeed_xiao_expansion_board.overlay
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/input/input-event-codes.h>
+
 / {
 	chosen {
 		zephyr,display = &ssd1306_128x64;


### PR DESCRIPTION
boards: shields: seeed_xiao_expansion_board: fix missing include

Was getting the error "parse error: expected number or parenthesized expression" when trying to compile with the -DSHIELD=seeed_xiao_expansion_board flag. It looks like INPUT_KEY_0 was missing the necessary include file so I added it in.