### PR TITLE
net: if: No error if mcast group join fails because iface down

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -1104,7 +1104,7 @@ static void join_mcast_allnodes(struct net_if *iface)
 	net_ipv6_addr_create_ll_allnodes_mcast(&addr);
 
 	ret = net_ipv6_mld_join(iface, &addr);
-	if (ret < 0 && ret != -EALREADY) {
+	if (ret < 0 && ret != -EALREADY && ret != -ENETDOWN) {
 		NET_ERR("Cannot join all nodes address %s for %d (%d)",
 			net_sprint_ipv6_addr(&addr),
 			net_if_get_by_iface(iface), ret);
@@ -1121,10 +1121,12 @@ static void join_mcast_solicit_node(struct net_if *iface,
 	net_ipv6_addr_create_solicited_node(my_addr, &addr);
 
 	ret = net_ipv6_mld_join(iface, &addr);
-	if (ret < 0 && ret != -EALREADY) {
-		NET_ERR("Cannot join solicit node address %s for %d (%d)",
-			net_sprint_ipv6_addr(&addr),
-			net_if_get_by_iface(iface), ret);
+	if (ret < 0) {
+		if (ret != -EALREADY && ret != -ENETDOWN) {
+			NET_ERR("Cannot join solicit node address %s for %d (%d)",
+				net_sprint_ipv6_addr(&addr),
+				net_if_get_by_iface(iface), ret);
+		}
 	} else {
 		NET_DBG("Join solicit node address %s (ifindex %d)",
 			net_sprint_ipv6_addr(&addr),


### PR DESCRIPTION
If we fail to join all nodes or solicit node multicast groups when the interface is down, then there is no need to print an error message. The groups are automatically re-joined when the interface comes up.