### PR TITLE
mgmt: hawkbit: optimize poll_sleep

### DIFF
--- a/subsys/mgmt/hawkbit/hawkbit.c
+++ b/subsys/mgmt/hawkbit/hawkbit.c
@@ -59,11 +59,7 @@ LOG_MODULE_REGISTER(hawkbit, CONFIG_HAWKBIT_LOG_LEVEL);
 #define STORAGE_DEV FIXED_PARTITION_DEVICE(STORAGE_LABEL)
 #define STORAGE_OFFSET FIXED_PARTITION_OFFSET(STORAGE_LABEL)
 
-#if ((CONFIG_HAWKBIT_POLL_INTERVAL > 1) && (CONFIG_HAWKBIT_POLL_INTERVAL < 43200))
-static uint32_t poll_sleep = (CONFIG_HAWKBIT_POLL_INTERVAL * 60 * MSEC_PER_SEC);
-#else
-static uint32_t poll_sleep = (300 * MSEC_PER_SEC);
-#endif
+static uint32_t poll_sleep = (CONFIG_HAWKBIT_POLL_INTERVAL * SEC_PER_MIN);
 
 static struct nvs_fs fs;
 
@@ -353,16 +349,16 @@ static int hawkbit_device_acid_update(int32_t new_value)
  */
 static void hawkbit_update_sleep(struct hawkbit_ctl_res *hawkbit_res)
 {
-	uint32_t sleep_time;
+	int sleep_time;
 	const char *sleep = hawkbit_res->config.polling.sleep;
 
 	if (strlen(sleep) != HAWKBIT_SLEEP_LENGTH) {
 		LOG_ERR("Invalid poll sleep: %s", sleep);
 	} else {
 		sleep_time = hawkbit_time2sec(sleep);
-		if (sleep_time > 0 && poll_sleep != (MSEC_PER_SEC * sleep_time)) {
+		if (sleep_time > 0 && poll_sleep != sleep_time) {
 			LOG_DBG("New poll sleep %d seconds", sleep_time);
-			poll_sleep = sleep_time * MSEC_PER_SEC;
+			poll_sleep = (uint32_t)sleep_time;
 		}
 	}
 }
@@ -1238,7 +1234,7 @@ static void autohandler(struct k_work *work)
 		break;
 	}
 
-	k_work_reschedule(&hawkbit_work_handle, K_MSEC(poll_sleep));
+	k_work_reschedule(&hawkbit_work_handle, K_SECONDS(poll_sleep));
 }
 
 void hawkbit_autohandler(void)


### PR DESCRIPTION
-  remove unnecessary condition for CONFIG_HAWKBIT_POLL_INTERVAL, this is already enforced by the Kconfig `range 1 43200`, so it does not have to be checked again in `hawkbit.c`
- changes poll_sleep to be in seconds,
- change type of sleep_time in hawkbit_update_sleep(), so the return value of hawkbit_time2sec() can be interpreted correctly.