### PR TITLE
random: use appropriate functions

### DIFF
--- a/drivers/ethernet/eth.h
+++ b/drivers/ethernet/eth.h
@@ -32,10 +32,6 @@
 
 static inline void gen_random_mac(uint8_t *mac_addr, uint8_t b0, uint8_t b1, uint8_t b2)
 {
-	uint32_t entropy;
-
-	entropy = sys_rand32_get();
-
 	mac_addr[0] = b0;
 	mac_addr[1] = b1;
 	mac_addr[2] = b2;
@@ -43,9 +39,7 @@ static inline void gen_random_mac(uint8_t *mac_addr, uint8_t b0, uint8_t b1, uin
 	/* Set MAC address locally administered, unicast (LAA) */
 	mac_addr[0] |= 0x02;
 
-	mac_addr[3] = (entropy >> 16) & 0xff;
-	mac_addr[4] = (entropy >>  8) & 0xff;
-	mac_addr[5] = (entropy >>  0) & 0xff;
+	sys_rand_get(&mac_addr[3], 3U);
 }
 
 #endif /* ZEPHYR_DRIVERS_ETHERNET_ETH_H_ */

--- a/drivers/ethernet/eth_ivshmem.c
+++ b/drivers/ethernet/eth_ivshmem.c
@@ -390,10 +390,7 @@ static const struct ethernet_api eth_ivshmem_api = {
 #define ETH_IVSHMEM_RANDOM_MAC_ADDR(inst)						\
 	static void generate_mac_addr_##inst(uint8_t mac_addr[6])			\
 	{										\
-		uint32_t entropy = sys_rand32_get();					\
-		mac_addr[0] = (entropy >> 16) & 0xff;					\
-		mac_addr[1] = (entropy >>  8) & 0xff;					\
-		mac_addr[2] = (entropy >>  0) & 0xff;					\
+		sys_rand_get(mac_addr, 3U);						\
 		/* Clear multicast bit */						\
 		mac_addr[0] &= 0xFE;							\
 		gen_random_mac(mac_addr, mac_addr[0], mac_addr[1], mac_addr[2]);	\

--- a/drivers/ieee802154/ieee802154_b91.c
+++ b/drivers/ieee802154/ieee802154_b91.c
@@ -110,11 +110,7 @@ static inline uint8_t *b91_get_mac(const struct device *dev)
 	struct b91_data *b91 = dev->data;
 
 #if defined(CONFIG_IEEE802154_B91_RANDOM_MAC)
-	uint32_t *ptr = (uint32_t *)(b91->mac_addr);
-
-	UNALIGNED_PUT(sys_rand32_get(), ptr);
-	ptr = (uint32_t *)(b91->mac_addr + 4);
-	UNALIGNED_PUT(sys_rand32_get(), ptr);
+	sys_rand_get(b91->mac_addr, sizeof(b91->mac_addr));
 
 	/*
 	 * Clear bit 0 to ensure it isn't a multicast address and set

--- a/drivers/ieee802154/ieee802154_cc1200.c
+++ b/drivers/ieee802154/ieee802154_cc1200.c
@@ -129,9 +129,7 @@ static inline uint8_t *get_mac(const struct device *dev)
 	struct cc1200_context *cc1200 = dev->data;
 
 #if defined(CONFIG_IEEE802154_CC1200_RANDOM_MAC)
-	uint32_t *ptr = (uint32_t *)(cc1200->mac_addr + 4);
-
-	UNALIGNED_PUT(sys_rand32_get(), ptr);
+	sys_rand_get(&cc1200->mac_addr[4], 4U);
 
 	cc1200->mac_addr[7] = (cc1200->mac_addr[7] & ~0x01) | 0x02;
 #else

--- a/drivers/ieee802154/ieee802154_cc2520.c
+++ b/drivers/ieee802154/ieee802154_cc2520.c
@@ -279,9 +279,7 @@ static inline uint8_t *get_mac(const struct device *dev)
 	struct cc2520_context *cc2520 = dev->data;
 
 #if defined(CONFIG_IEEE802154_CC2520_RANDOM_MAC)
-	uint32_t *ptr = (uint32_t *)(cc2520->mac_addr + 4);
-
-	UNALIGNED_PUT(sys_rand32_get(), ptr);
+	sys_rand_get(&cc2520->mac_addr[4], 4U);
 
 	cc2520->mac_addr[7] = (cc2520->mac_addr[7] & ~0x01) | 0x02;
 #else

--- a/drivers/ieee802154/ieee802154_dw1000.c
+++ b/drivers/ieee802154/ieee802154_dw1000.c
@@ -1633,11 +1633,8 @@ static int dw1000_init(const struct device *dev)
 static inline uint8_t *get_mac(const struct device *dev)
 {
 	struct dwt_context *dw1000 = dev->data;
-	uint32_t *ptr = (uint32_t *)(dw1000->mac_addr);
 
-	UNALIGNED_PUT(sys_rand32_get(), ptr);
-	ptr = (uint32_t *)(dw1000->mac_addr + 4);
-	UNALIGNED_PUT(sys_rand32_get(), ptr);
+	sys_rand_get(dw1000->mac_addr, sizeof(dw1000->mac_addr));
 
 	dw1000->mac_addr[0] = (dw1000->mac_addr[0] & ~0x01) | 0x02;
 

--- a/drivers/ieee802154/ieee802154_kw41z.c
+++ b/drivers/ieee802154/ieee802154_kw41z.c
@@ -935,11 +935,7 @@ static inline uint8_t *get_mac(const struct device *dev)
 	 *       and how to allow for a OUI portion?
 	 */
 
-	uint32_t *ptr = (uint32_t *)(kw41z->mac_addr);
-
-	UNALIGNED_PUT(sys_rand32_get(), ptr);
-	ptr = (uint32_t *)(kw41z->mac_addr + 4);
-	UNALIGNED_PUT(sys_rand32_get(), ptr);
+	sys_rand_get(kw41z->mac_addr, sizeof(kw41z->mac_addr));
 
 	/*
 	 * Clear bit 0 to ensure it isn't a multicast address and set

--- a/drivers/ieee802154/ieee802154_mcr20a.c
+++ b/drivers/ieee802154/ieee802154_mcr20a.c
@@ -515,11 +515,8 @@ static inline int16_t mcr20a_get_rssi(uint8_t lqi)
 static inline uint8_t *get_mac(const struct device *dev)
 {
 	struct mcr20a_context *mcr20a = dev->data;
-	uint32_t *ptr = (uint32_t *)(mcr20a->mac_addr);
 
-	UNALIGNED_PUT(sys_rand32_get(), ptr);
-	ptr = (uint32_t *)(mcr20a->mac_addr + 4);
-	UNALIGNED_PUT(sys_rand32_get(), ptr);
+	sys_rand_get(mcr20a->mac_addr, sizeof(mcr20a->mac_addr));
 
 	mcr20a->mac_addr[0] = (mcr20a->mac_addr[0] & ~0x01) | 0x02;
 

--- a/drivers/ieee802154/ieee802154_rf2xx.c
+++ b/drivers/ieee802154/ieee802154_rf2xx.c
@@ -347,12 +347,9 @@ static inline uint8_t *get_mac(const struct device *dev)
 {
 	const struct rf2xx_config *conf = dev->config;
 	struct rf2xx_context *ctx = dev->data;
-	uint32_t *ptr = (uint32_t *)(ctx->mac_addr);
 
 	if (!conf->has_mac) {
-		UNALIGNED_PUT(sys_rand32_get(), ptr);
-		ptr = (uint32_t *)(ctx->mac_addr + 4);
-		UNALIGNED_PUT(sys_rand32_get(), ptr);
+		sys_rand_get(ctx->mac_addr, sizeof(ctx->mac_addr));
 	}
 
 	/*

--- a/drivers/ieee802154/ieee802154_uart_pipe.c
+++ b/drivers/ieee802154/ieee802154_uart_pipe.c
@@ -357,8 +357,7 @@ static inline uint8_t *get_mac(const struct device *dev)
 	upipe->mac_addr[3] = 0x30;
 
 #if defined(CONFIG_IEEE802154_UPIPE_RANDOM_MAC)
-	UNALIGNED_PUT(sys_cpu_to_be32(sys_rand32_get()),
-		      (uint32_t *) ((uint8_t *)upipe->mac_addr+4));
+	sys_rand_get(&upipe->mac_addr[4], 4U);
 #else
 	upipe->mac_addr[4] = CONFIG_IEEE802154_UPIPE_MAC4;
 	upipe->mac_addr[5] = CONFIG_IEEE802154_UPIPE_MAC5;

--- a/drivers/modem/wncm14a2a.c
+++ b/drivers/modem/wncm14a2a.c
@@ -1760,8 +1760,7 @@ static inline uint8_t *wncm14a2a_get_mac(const struct device *dev)
 	ctx->mac_addr[0] = 0x00;
 	ctx->mac_addr[1] = 0x10;
 
-	UNALIGNED_PUT(sys_cpu_to_be32(sys_rand32_get()),
-		      (uint32_t *)(ctx->mac_addr + 2));
+	sys_rand_get(&ctx->mac_addr[2], 4U);
 
 	return ctx->mac_addr;
 }

--- a/drivers/net/ppp.c
+++ b/drivers/net/ppp.c
@@ -955,7 +955,7 @@ use_random_mac:
 		ppp->mac_addr[2] = 0x5E;
 		ppp->mac_addr[3] = 0x00;
 		ppp->mac_addr[4] = 0x53;
-		ppp->mac_addr[5] = sys_rand32_get();
+		ppp->mac_addr[5] = sys_rand8_get();
 	}
 
 	net_if_set_link_addr(iface, ll_addr->addr, ll_addr->len,

--- a/drivers/net/slip.c
+++ b/drivers/net/slip.c
@@ -407,7 +407,7 @@ use_random_mac:
 		slip->mac_addr[2] = 0x5E;
 		slip->mac_addr[3] = 0x00;
 		slip->mac_addr[4] = 0x53;
-		slip->mac_addr[5] = sys_rand32_get();
+		slip->mac_addr[5] = sys_rand8_get();
 	}
 	net_if_set_link_addr(iface, ll_addr->addr, ll_addr->len,
 			     NET_LINK_ETHERNET);

--- a/subsys/jwt/jwt.c
+++ b/subsys/jwt/jwt.c
@@ -255,11 +255,7 @@ static int setup_prng(void)
 
 	uint8_t entropy[TC_AES_KEY_SIZE + TC_AES_BLOCK_SIZE];
 
-	for (int i = 0; i < sizeof(entropy); i += sizeof(uint32_t)) {
-		uint32_t rv = sys_rand32_get();
-
-		memcpy(entropy + i, &rv, sizeof(uint32_t));
-	}
+	sys_rand_get(entropy, sizeof(entropy));
 
 	int res = tc_ctr_prng_init(&prng_state,
 				   (const uint8_t *) &entropy, sizeof(entropy),

--- a/subsys/net/ip/icmp.c
+++ b/subsys/net/ip/icmp.c
@@ -360,7 +360,7 @@ static struct net_icmp_ping_params *get_default_params(void)
 {
 	static struct net_icmp_ping_params params = { 0 };
 
-	params.identifier = sys_rand32_get();
+	params.identifier = sys_rand16_get();
 
 	return &params;
 }

--- a/subsys/net/ip/ipv4_autoconf.c
+++ b/subsys/net/ip/ipv4_autoconf.c
@@ -199,8 +199,8 @@ static void ipv4_autoconf_send(struct net_if_ipv4_autoconf *ipv4auto)
 		(void)memset(&ipv4auto->current_ip, 0, sizeof(struct in_addr));
 		ipv4auto->requested_ip.s4_addr[0] = 169U;
 		ipv4auto->requested_ip.s4_addr[1] = 254U;
-		ipv4auto->requested_ip.s4_addr[2] = sys_rand32_get() % 254;
-		ipv4auto->requested_ip.s4_addr[3] = sys_rand32_get() % 254;
+		ipv4auto->requested_ip.s4_addr[2] = sys_rand8_get() % 254;
+		ipv4auto->requested_ip.s4_addr[3] = sys_rand8_get() % 254;
 
 		NET_DBG("%s: Starting probe for 169.254.%d.%d", "Init",
 			ipv4auto->requested_ip.s4_addr[2],

--- a/subsys/net/ip/ipv4_fragment.c
+++ b/subsys/net/ip/ipv4_fragment.c
@@ -538,7 +538,7 @@ int net_ipv4_send_fragmented_pkt(struct net_if *iface, struct net_pkt *pkt,
 	}
 
 	/* Generate a random ID to be used for packet identification, ensuring that it is not 0 */
-	uint16_t rand_id = (uint16_t)sys_rand32_get();
+	uint16_t rand_id = sys_rand16_get();
 
 	if (rand_id == 0) {
 		rand_id = 1;

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -312,7 +312,7 @@ static uint16_t find_available_port(struct net_context *context,
 	uint16_t local_port;
 
 	do {
-		local_port = sys_rand32_get() | 0x8000;
+		local_port = sys_rand16_get() | 0x8000;
 	} while (check_used_port(NULL, net_context_get_proto(context),
 				 htons(local_port), addr, false, false) == -EEXIST);
 

--- a/subsys/net/l2/ethernet/gptp/gptp.c
+++ b/subsys/net/l2/ethernet/gptp/gptp.c
@@ -490,10 +490,10 @@ static void gptp_init_port_ds(int port)
 	port_ds->compute_neighbor_prop_delay = true;
 
 	/* Random Sequence Numbers. */
-	port_ds->sync_seq_id = (uint16_t)sys_rand32_get();
-	port_ds->pdelay_req_seq_id = (uint16_t)sys_rand32_get();
-	port_ds->announce_seq_id = (uint16_t)sys_rand32_get();
-	port_ds->signaling_seq_id = (uint16_t)sys_rand32_get();
+	port_ds->sync_seq_id = sys_rand16_get();
+	port_ds->pdelay_req_seq_id = sys_rand16_get();
+	port_ds->announce_seq_id = sys_rand16_get();
+	port_ds->signaling_seq_id = sys_rand16_get();
 
 #if defined(CONFIG_NET_GPTP_STATISTICS)
 	/* Initialize stats data set. */

--- a/subsys/net/l2/virtual/virtual.c
+++ b/subsys/net/l2/virtual/virtual.c
@@ -169,11 +169,7 @@ NET_L2_INIT(VIRTUAL_L2, virtual_recv, virtual_send, virtual_enable,
 
 static void random_linkaddr(uint8_t *linkaddr, size_t len)
 {
-	int i;
-
-	for (i = 0; i < len; i++) {
-		linkaddr[i] = sys_rand32_get();
-	}
+	sys_rand_get(linkaddr, len);
 
 	linkaddr[0] |= 0x02; /* force LAA bit */
 }

--- a/subsys/net/lib/dhcpv4/dhcpv4.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4.c
@@ -407,7 +407,7 @@ static uint32_t dhcpv4_update_message_timeout(struct net_if_dhcpv4 *dhcpv4)
 	}
 
 	/* +1/-1 second randomization */
-	timeout += (sys_rand32_get() % 3U) - 1;
+	timeout += (sys_rand8_get() % 3U) - 1;
 
 	dhcpv4->attempts++;
 	dhcpv4_set_timeout(dhcpv4, timeout);

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -1245,7 +1245,7 @@ try_resolve:
 		goto quit;
 	}
 
-	ctx->queries[i].id = sys_rand32_get();
+	ctx->queries[i].id = sys_rand16_get();
 
 	/* If mDNS is enabled, then send .local queries only to multicast
 	 * address. For mDNS the id should be set to 0, see RFC 6762 ch. 18.1


### PR DESCRIPTION
With #70513 merged, in our code we should use the appropriate `sys_randXX_get()` or where it makes sense to use `sys_rand_get()` directly.