### PR TITLE
modules: hal_nordic: Extend SPI configuration for all instances

### DIFF
--- a/modules/hal_nordic/nrfx/nrfx_config.h
+++ b/modules/hal_nordic/nrfx/nrfx_config.h
@@ -357,8 +357,10 @@
 #ifdef CONFIG_NRFX_SPIM4
 #define NRFX_SPIM4_ENABLED 1
 #endif
-#if (DT_PROP(DT_NODELABEL(spi3), rx_delay_supported) || \
-	DT_PROP(DT_NODELABEL(spi4), rx_delay_supported))
+
+#define NRFX_SPIM_DT_HAS_RX_DELAY(node) DT_PROP(node, rx_delay_supported) +
+
+#if DT_FOREACH_STATUS_OKAY(nordic_nrf_spim, NRFX_SPIM_DT_HAS_RX_DELAY) 0
 #define NRFX_SPIM_EXTENDED_ENABLED 1
 #endif
 #ifdef CONFIG_NRFX_SPIM00


### PR DESCRIPTION
Iterate over all instances to get the information about extended feature support in SPIM driver.