### PR TITLE
drivers: net: nsos: fix compatibility with CONFIG_POSIX_API=n

### DIFF
--- a/drivers/net/nsos_sockets.c
+++ b/drivers/net/nsos_sockets.c
@@ -678,7 +678,7 @@ static int nsos_recvfrom_with_poll(struct nsos_socket *sock, void *buf, size_t l
 	int sock_flags;
 	bool non_blocking;
 
-	if (flags & MSG_DONTWAIT) {
+	if (flags & ZSOCK_MSG_DONTWAIT) {
 		non_blocking = true;
 	} else {
 		sock_flags = nsos_adapt_fcntl_getfl(sock->pollfd.fd);
@@ -890,7 +890,7 @@ static int nsos_getaddrinfo(const char *node, const char *service,
 	ret = addrinfo_from_nsos_mid(res_mid, res);
 	if (ret < 0) {
 		errno = -ret;
-		return EAI_SYSTEM;
+		return DNS_EAI_SYSTEM;
 	}
 
 	return ret;


### PR DESCRIPTION
Improve code consistency and fix `CONFIG_POSIX_API=n` compatibility with use
of `ZSOCK_*` and `DNS_*` macros.