### PR TITLE
drivers: can: transceiver: gpio: automatically select GPIO

### DIFF
--- a/boards/nxp/mr_canhubk3/Kconfig.defconfig
+++ b/boards/nxp/mr_canhubk3/Kconfig.defconfig
@@ -23,13 +23,6 @@ config WDT_NXP_FS26_INIT_PRIORITY
 endif # WDT_NXP_FS26
 endif # SPI
 
-if CAN
-
-config GPIO
-	default y
-
-endif # CAN
-
 if NETWORKING
 
 config NET_L2_ETHERNET

--- a/boards/nxp/ucans32k1sic/Kconfig.defconfig
+++ b/boards/nxp/ucans32k1sic/Kconfig.defconfig
@@ -10,11 +10,4 @@ config UART_CONSOLE
 
 endif # SERIAL
 
-if CAN
-
-config GPIO
-	default y
-
-endif # CAN
-
 endif # BOARD_UCANS32K1SIC

--- a/drivers/can/transceiver/Kconfig
+++ b/drivers/can/transceiver/Kconfig
@@ -15,7 +15,7 @@ config CAN_TRANSCEIVER_GPIO
 	bool "GPIO controlled CAN transceiver"
 	default y
 	depends on DT_HAS_CAN_TRANSCEIVER_GPIO_ENABLED
-	depends on GPIO
+	select GPIO
 	help
 	  Enable support for GPIO controlled CAN transceivers.
 


### PR DESCRIPTION
Automatically select CONFIG_GPIO when the GPIO-controlled CAN transceiver driver is enabled. Update board configurations to benefit from this.