### PR TITLE
Bluetooth: Controller: Ignore bit 1 set in Initiating_PHYs

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -4096,6 +4096,15 @@ static void le_ext_create_connection(struct net_buf *buf, struct net_buf **evt)
 	}
 
 	phys = cmd->phys;
+
+	/* Ignore Scan Interval and Scan Window, and ignore scanning if
+	 * Initiating PHY is set for LE 2M PHY
+	 * Refer to Bluetooth Core Specification Version 5.4 Vol 4, Part E
+	 * 7.8.66 LE Extended Create Connection command
+	 */
+	phys &= ~BT_HCI_LE_EXT_SCAN_PHY_2M;
+
+	/* Check if unsupported PHY requested for scanning */
 	if (IS_ENABLED(CONFIG_BT_CTLR_PARAM_CHECK) &&
 	    (((phys & phys_bitmask) == 0) || (phys & ~phys_bitmask))) {
 		*evt = cmd_status(BT_HCI_ERR_UNSUPP_FEATURE_PARAM_VAL);


### PR DESCRIPTION
Ignore LE 2M PHY being set in Initiating_PHYs of the LE Extended Create Connection command.