### PR TITLE
scripts: pylib: twister: Fix the unrecognized section test

### DIFF
--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -621,18 +621,11 @@ class Reporting:
             )
             logger.info("-+" * 40)
 
-    def summary(self, results, ignore_unrecognized_sections, duration):
+    def summary(self, results, duration):
         failed = 0
         run = 0
         for instance in self.instances.values():
             if instance.status == TwisterStatus.FAIL:
-                failed += 1
-            elif not ignore_unrecognized_sections and instance.metrics.get("unrecognized"):
-                logger.error(
-                    f"{Fore.RED}FAILED{Fore.RESET}:"
-                    f" {instance.name} has unrecognized binary sections:"
-                    f" {instance.metrics.get('unrecognized', [])!s}"
-                )
                 failed += 1
 
             # FIXME: need a better way to identify executed tests

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -1060,6 +1060,15 @@ class ProjectBuilder(FilterBuilder):
         elif op == "gather_metrics":
             try:
                 ret = self.gather_metrics(self.instance)
+                if (
+                    self.instance.metrics.get("unrecognized")
+                    and not self.options.disable_unrecognized_section_test
+                ):
+                    logger.warning(
+                        f"{Fore.RED}FAILED{Fore.RESET}:"
+                        f" {self.instance.name} has unrecognized binary sections:"
+                        f" {self.instance.metrics.get('unrecognized')}"
+                    )
                 if not ret or ret.get('returncode', 1) > 0:
                     self.instance.status = TwisterStatus.ERROR
                     self.instance.reason = "Build Failure at gather_metrics."
@@ -1822,7 +1831,7 @@ class TwisterRunner:
                 else:
                     inst.metrics.update(self.instances[inst.name].metrics)
                     inst.metrics["handler_time"] = inst.execution_time
-                    inst.metrics["unrecognized"] = []
+                    inst.metrics.setdefault("unrecognized", [])
                     self.instances[inst.name] = inst
 
             print("")

--- a/scripts/pylib/twister/twisterlib/twister_main.py
+++ b/scripts/pylib/twister/twisterlib/twister_main.py
@@ -212,7 +212,7 @@ def main(options: argparse.Namespace, default_options: argparse.Namespace):
     if options.verbose > 1:
         runner.results.summary()
 
-    report.summary(runner.results, options.disable_unrecognized_section_test, duration)
+    report.summary(runner.results, duration)
 
     coverage_completed = True
     if options.coverage:


### PR DESCRIPTION
Current implementation of the unrecognized section test does not work at all. Here we move its handling into the runner.py's process() method so it's not scattered across three different files, which could be one of the reasons for its failure before.

Failure of the test was replaced by a warning, as the recognised section list has been out of date since the test stopped working.

Additionally, a blackbox test was added to prove correctness.

Fixes #70860 