### PR TITLE
soc: riscv-privileged: support SoCs without reset vector

### DIFF
--- a/soc/common/riscv-privileged/vector.S
+++ b/soc/common/riscv-privileged/vector.S
@@ -97,5 +97,10 @@ SECTION_FUNC(vectors, __start)
 
 #endif /* CONFIG_RISCV_VECTORED_MODE */
 
+#if CONFIG_INCLUDE_RESET_VECTOR
 	/* Jump to __reset */
 	tail __reset
+#else
+	/* Jump to __initialize */
+	tail __initialize
+#endif


### PR DESCRIPTION
RISCV_PRIVILEGED implicitly depends on INCLUDE_RESET_VECTOR. Remove that dependency by adding support for SoCs that do not need the `__reset` stub.