### PR TITLE
samples: tests: random: use appropriate functions

### DIFF
--- a/samples/arch/smp/pktqueue/src/main.c
+++ b/samples/arch/smp/pktqueue/src/main.c
@@ -45,7 +45,7 @@ void init_datagram_queue(struct phdr_desc_queue *queue, int queue_num)
 		for (int j = 0; j < SIZE_OF_HEADER; j++) {
 			/* leave crc field zeroed */
 			if (j < CRC_BYTE_1 || j > CRC_BYTE_2) {
-				descriptors[queue_num][i].ptr[j] = (uint8_t)sys_rand32_get();
+				descriptors[queue_num][i].ptr[j] = sys_rand8_get();
 			} else {
 				descriptors[queue_num][i].ptr[j] = 0;
 			}

--- a/samples/bluetooth/peripheral_csc/src/main.c
+++ b/samples/bluetooth/peripheral_csc/src/main.c
@@ -304,18 +304,18 @@ static uint16_t lcet; /* Last Crank Event Time */
 static void csc_simulation(void)
 {
 	static uint8_t i;
-	uint32_t rand = sys_rand32_get();
+	uint8_t rnd = sys_rand8_get();
 	bool nfy_crank = false, nfy_wheel = false;
 
 	/* Measurements don't have to be updated every second */
 	if (!(i % 2)) {
-		lwet += 1050 + rand % 50;
+		lwet += 1050 + rnd % 50;
 		c_wheel_revs += 2U;
 		nfy_wheel = true;
 	}
 
 	if (!(i % 3)) {
-		lcet += 1000 + rand % 50;
+		lcet += 1000 + rnd % 50;
 		ccr += 1U;
 		nfy_crank = true;
 	}

--- a/samples/net/cloud/mqtt_azure/src/main.c
+++ b/samples/net/cloud/mqtt_azure/src/main.c
@@ -298,7 +298,7 @@ static int publish(struct mqtt_client *client, enum mqtt_qos qos)
 	param.message.topic.topic.size = len;
 	param.message.payload.data = payload;
 	param.message.payload.len = strlen(payload);
-	param.message_id = sys_rand32_get();
+	param.message_id = sys_rand16_get();
 	param.dup_flag = 0U;
 	param.retain_flag = 0U;
 
@@ -324,7 +324,7 @@ static void poll_mqtt(void)
  */
 static uint8_t timeout_for_publish(void)
 {
-	return (10 + sys_rand32_get() % 5);
+	return (10 + sys_rand8_get() % 5);
 }
 
 static void publish_timeout(struct k_work *work)

--- a/samples/net/mqtt_publisher/src/main.c
+++ b/samples/net/mqtt_publisher/src/main.c
@@ -219,7 +219,7 @@ static char *get_mqtt_payload(enum mqtt_qos qos)
 	static APP_BMEM char payload[30];
 
 	snprintk(payload, sizeof(payload), "{d:{temperature:%d}}",
-		 (uint8_t)sys_rand32_get());
+		 sys_rand8_get());
 #else
 	static APP_DMEM char payload[] = "DOORS:OPEN_QoSx";
 
@@ -250,7 +250,7 @@ static int publish(struct mqtt_client *client, enum mqtt_qos qos)
 	param.message.payload.data = get_mqtt_payload(qos);
 	param.message.payload.len =
 			strlen(param.message.payload.data);
-	param.message_id = sys_rand32_get();
+	param.message_id = sys_rand16_get();
 	param.dup_flag = 0U;
 	param.retain_flag = 0U;
 

--- a/samples/net/wpan_serial/src/main.c
+++ b/samples/net/wpan_serial/src/main.c
@@ -448,14 +448,12 @@ static void init_tx_queue(void)
  */
 static uint8_t *get_mac(const struct device *dev)
 {
-	uint32_t *ptr = (uint32_t *)mac_addr;
-
 	mac_addr[7] = 0x00;
 	mac_addr[6] = 0x12;
 	mac_addr[5] = 0x4b;
-
 	mac_addr[4] = 0x00;
-	UNALIGNED_PUT(sys_rand32_get(), ptr);
+
+	sys_rand_get(mac_addr, 4U);
 
 	mac_addr[0] = (mac_addr[0] & ~0x01) | 0x02;
 

--- a/samples/subsys/usb/hid-cdc/src/main.c
+++ b/samples/subsys/usb/hid-cdc/src/main.c
@@ -652,8 +652,8 @@ int main(void)
 			case GPIO_BUTTON_0:
 			{
 				/* Move the mouse in random direction */
-				uint8_t rep[] = {0x00, sys_rand32_get(),
-					      sys_rand32_get(), 0x00};
+				uint8_t rep[] = {0x00, sys_rand8_get(),
+					      sys_rand8_get(), 0x00};
 
 				k_sem_take(&usb_sem, K_FOREVER);
 				hid_int_ep_write(hid0_dev, rep,

--- a/subsys/testsuite/ztest/src/ztress.c
+++ b/subsys/testsuite/ztest/src/ztress.c
@@ -216,7 +216,7 @@ static k_timeout_t randomize_t(k_timeout_t t)
 static void microdelay(void)
 {
 	static volatile int microdelay_cnt;
-	uint32_t repeat = sys_rand32_get() & 0xff;
+	uint8_t repeat = sys_rand8_get();
 
 	for (int i = 0; i < repeat; i++) {
 		microdelay_cnt++;

--- a/tests/benchmarks/mbedtls/src/benchmark.c
+++ b/tests/benchmarks/mbedtls/src/benchmark.c
@@ -244,25 +244,11 @@ do {                                                                  \
 
 static int myrand(void *rng_state, unsigned char *output, size_t len)
 {
-	size_t use_len;
-	int rnd;
-
 	if (rng_state != NULL) {
 		rng_state  = NULL;
 	}
 
-	while (len > 0) {
-		use_len = len;
-
-		if (use_len > sizeof(int)) {
-			use_len = sizeof(int);
-		}
-
-		rnd = sys_rand32_get();
-		memcpy(output, &rnd, use_len);
-		output += use_len;
-		len -= use_len;
-	}
+	sys_rand_get(output, len);
 
 	return(0);
 }

--- a/tests/crypto/tinycrypt/src/ecc_dsa.c
+++ b/tests/crypto/tinycrypt/src/ecc_dsa.c
@@ -616,14 +616,7 @@ int default_CSPRNG(uint8_t *dest, unsigned int size)
 	/* This is not a CSPRNG, but it's the only thing available in the
 	 * system at this point in time.  */
 
-	while (size) {
-		uint32_t len = size >= sizeof(uint32_t) ? sizeof(uint32_t) : size;
-		uint32_t rv = sys_rand32_get();
-
-		memcpy(dest, &rv, len);
-		dest += len;
-		size -= len;
-	}
+	sys_rand_get(dest, size);
 
 	return 1;
 }

--- a/tests/drivers/smbus/smbus_emul/src/smbus.c
+++ b/tests/drivers/smbus/smbus_emul/src/smbus.c
@@ -113,7 +113,7 @@ ZTEST(test_smbus_emul, test_byte)
 	ret = smbus_quick(dev, PERIPH_ADDR, 1);
 	zassert_ok(ret, "SMBus Quick failed");
 
-	snd_byte = (uint8_t)sys_rand32_get();
+	snd_byte = sys_rand8_get();
 
 	ret = smbus_byte_write(dev, PERIPH_ADDR, snd_byte);
 	zassert_ok(ret, "SMBus Byte Write failed");
@@ -141,7 +141,7 @@ ZTEST(test_smbus_emul, test_word)
 
 	zassert_not_null(dev, "Device not found");
 
-	snd_word = (uint16_t)sys_rand32_get();
+	snd_word = sys_rand16_get();
 
 	ret = smbus_word_data_write(dev, PERIPH_ADDR, 0, snd_word);
 	zassert_ok(ret, "SMBus Word Data Write failed");
@@ -153,7 +153,7 @@ ZTEST(test_smbus_emul, test_word)
 
 	/* Test 2 byte writes following word read */
 
-	snd_byte = (uint8_t)sys_rand32_get();
+	snd_byte = sys_rand8_get();
 
 	ret = smbus_byte_data_write(dev, PERIPH_ADDR, 0, snd_byte);
 	zassert_ok(ret, "SMBus Byte Data Write failed");
@@ -174,7 +174,7 @@ ZTEST(test_smbus_emul, test_proc_call)
 
 	zassert_not_null(dev, "Device not found");
 
-	snd_word = (uint16_t)sys_rand32_get();
+	snd_word = sys_rand16_get();
 	zassert_not_equal(snd_word, 0, "Random number generator misconfgured");
 
 	ret = smbus_pcall(dev, PERIPH_ADDR, 0x0, snd_word, &rcv_word);
@@ -194,9 +194,7 @@ ZTEST(test_smbus_emul, test_block)
 
 	zassert_not_null(dev, "Device not found");
 
-	for (int i = 0; i < sizeof(snd_block); i++) {
-		snd_block[i] = (uint8_t)sys_rand32_get();
-	}
+	sys_rand_get(snd_block, sizeof(snd_block));
 
 	snd_count = sizeof(snd_block);
 
@@ -221,9 +219,7 @@ ZTEST(test_smbus_emul, test_block_pcall)
 
 	zassert_not_null(dev, "Device not found");
 
-	for (int i = 0; i < sizeof(snd_block); i++) {
-		snd_block[i] = (uint8_t)sys_rand32_get();
-	}
+	sys_rand_get(snd_block, sizeof(snd_block));
 
 	snd_count = SMBUS_BLOCK_BYTES_MAX / 2;
 	ret = smbus_block_pcall(dev, PERIPH_ADDR, 0, snd_count, snd_block,

--- a/tests/drivers/uart/uart_mix_fifo_poll/src/main.c
+++ b/tests/drivers/uart/uart_mix_fifo_poll/src/main.c
@@ -294,7 +294,7 @@ static void poll_out_timer_handler(struct k_timer *timer)
 		k_timer_stop(timer);
 		k_sem_give(&data->sem);
 	} else {
-		k_timer_start(timer, K_USEC(250 + (sys_rand32_get() % 800)),
+		k_timer_start(timer, K_USEC(250 + (sys_rand16_get() % 800)),
 				K_NO_WAIT);
 	}
 }

--- a/tests/lib/p4workq/src/main.c
+++ b/tests/lib/p4workq/src/main.c
@@ -72,7 +72,7 @@ static void stress_handler(struct k_p4wq_work *item)
 	/* Pick 0-3 random item slots and submit them if they aren't
 	 * already.  Make sure we always have at least one active.
 	 */
-	int num_tries = sys_rand32_get() % 4;
+	int num_tries = sys_rand8_get() % 4;
 
 	for (int i = 0; (active_items == 0) || (i < num_tries); i++) {
 		int ii = sys_rand32_get() % MAX_ITEMS;

--- a/tests/lib/spsc_pbuf/src/main.c
+++ b/tests/lib/spsc_pbuf/src/main.c
@@ -424,7 +424,7 @@ bool stress_read(void *user_data, uint32_t cnt, bool last, int prio)
 	struct stress_data *ctx = (struct stress_data *)user_data;
 	char buf[128];
 	int len;
-	int rpt = (sys_rand32_get() & 3) + 1;
+	int rpt = (sys_rand8_get() & 3) + 1;
 
 	for (int i = 0; i < rpt; i++) {
 		len = spsc_pbuf_read(ctx->pbuf, buf, (uint16_t)sizeof(buf));
@@ -447,8 +447,8 @@ bool stress_write(void *user_data, uint32_t cnt, bool last, int prio)
 {
 	struct stress_data *ctx = (struct stress_data *)user_data;
 	char buf[128];
-	uint16_t len = 1 + (sys_rand32_get() % (ctx->capacity / 4));
-	int rpt = (sys_rand32_get() & 1) + 1;
+	uint16_t len = 1 + (sys_rand16_get() % (ctx->capacity / 4));
+	int rpt = (sys_rand8_get() & 1) + 1;
 
 	zassert_true(len < sizeof(buf), "len:%d %d", len, ctx->capacity);
 
@@ -490,7 +490,7 @@ bool stress_claim_free(void *user_data, uint32_t cnt, bool last, int prio)
 	struct stress_data *ctx = (struct stress_data *)user_data;
 	char *buf;
 	uint16_t len;
-	int rpt = sys_rand32_get() % 0x3;
+	int rpt = sys_rand8_get() % 0x3;
 
 	for (int i = 0; i < rpt; i++) {
 		len = spsc_pbuf_claim(ctx->pbuf, &buf);
@@ -512,7 +512,7 @@ bool stress_claim_free(void *user_data, uint32_t cnt, bool last, int prio)
 bool stress_alloc_commit(void *user_data, uint32_t cnt, bool last, int prio)
 {
 	struct stress_data *ctx = (struct stress_data *)user_data;
-	uint32_t rnd = sys_rand32_get();
+	uint16_t rnd = sys_rand16_get();
 	uint16_t len = 1 + (rnd % (ctx->capacity / 4));
 	int rpt = rnd % 0x3;
 	char *buf;

--- a/tests/net/arp/src/main.c
+++ b/tests/net/arp/src/main.c
@@ -70,7 +70,7 @@ static uint8_t *net_arp_get_mac(const struct device *dev)
 		context->mac_addr[2] = 0x5E;
 		context->mac_addr[3] = 0x00;
 		context->mac_addr[4] = 0x53;
-		context->mac_addr[5] = sys_rand32_get();
+		context->mac_addr[5] = sys_rand8_get();
 	}
 
 	return context->mac_addr;

--- a/tests/net/checksum_offload/src/main.c
+++ b/tests/net/checksum_offload/src/main.c
@@ -446,7 +446,7 @@ static void generate_mac(uint8_t *mac_addr)
 	mac_addr[2] = 0x5E;
 	mac_addr[3] = 0x00;
 	mac_addr[4] = 0x53;
-	mac_addr[5] = sys_rand32_get();
+	mac_addr[5] = sys_rand8_get();
 }
 
 static int eth_init(const struct device *dev)

--- a/tests/net/context/src/main.c
+++ b/tests/net/context/src/main.c
@@ -983,7 +983,7 @@ static uint8_t *net_context_get_mac(const struct device *dev)
 		context->mac_addr[2] = 0x5E;
 		context->mac_addr[3] = 0x00;
 		context->mac_addr[4] = 0x53;
-		context->mac_addr[5] = sys_rand32_get();
+		context->mac_addr[5] = sys_rand8_get();
 	}
 
 	return context->mac_addr;

--- a/tests/net/hostname/src/main.c
+++ b/tests/net/hostname/src/main.c
@@ -82,7 +82,7 @@ static uint8_t *net_iface_get_mac(const struct device *dev)
 		data->mac_addr[2] = 0x5E;
 		data->mac_addr[3] = 0x00;
 		data->mac_addr[4] = 0x53;
-		data->mac_addr[5] = sys_rand32_get();
+		data->mac_addr[5] = sys_rand8_get();
 	}
 
 	data->ll_addr.addr = data->mac_addr;
@@ -173,7 +173,7 @@ static void eth_fake_iface_init(struct net_if *iface)
 	ctx->mac_address[2] = 0x5E;
 	ctx->mac_address[3] = 0x00;
 	ctx->mac_address[4] = 0x53;
-	ctx->mac_address[5] = sys_rand32_get();
+	ctx->mac_address[5] = sys_rand8_get();
 
 	net_if_set_link_addr(iface, ctx->mac_address,
 			     sizeof(ctx->mac_address),

--- a/tests/net/iface/src/main.c
+++ b/tests/net/iface/src/main.c
@@ -88,7 +88,7 @@ static uint8_t *net_iface_get_mac(const struct device *dev)
 		data->mac_addr[2] = 0x5E;
 		data->mac_addr[3] = 0x00;
 		data->mac_addr[4] = 0x53;
-		data->mac_addr[5] = sys_rand32_get();
+		data->mac_addr[5] = sys_rand8_get();
 	}
 
 	data->ll_addr.addr = data->mac_addr;

--- a/tests/net/igmp/src/main.c
+++ b/tests/net/igmp/src/main.c
@@ -84,7 +84,7 @@ static uint8_t *net_test_get_mac(const struct device *dev)
 		context->mac_addr[2] = 0x5E;
 		context->mac_addr[3] = 0x00;
 		context->mac_addr[4] = 0x53;
-		context->mac_addr[5] = sys_rand32_get();
+		context->mac_addr[5] = sys_rand8_get();
 	}
 
 	return context->mac_addr;

--- a/tests/net/ip-addr/src/main.c
+++ b/tests/net/ip-addr/src/main.c
@@ -129,7 +129,7 @@ static uint8_t *net_test_get_mac(const struct device *dev)
 		context->mac_addr[2] = 0x5E;
 		context->mac_addr[3] = 0x00;
 		context->mac_addr[4] = 0x53;
-		context->mac_addr[5] = sys_rand32_get();
+		context->mac_addr[5] = sys_rand8_get();
 	}
 
 	return context->mac_addr;

--- a/tests/net/ipv6/src/main.c
+++ b/tests/net/ipv6/src/main.c
@@ -169,7 +169,7 @@ static uint8_t *net_test_get_mac(const struct device *dev)
 		context->mac_addr[2] = 0x5E;
 		context->mac_addr[3] = 0x00;
 		context->mac_addr[4] = 0x53;
-		context->mac_addr[5] = sys_rand32_get();
+		context->mac_addr[5] = sys_rand8_get();
 	}
 
 	return context->mac_addr;
@@ -1179,7 +1179,7 @@ ZTEST(net_ipv6, test_change_ll_addr)
 	ll_iface->addr[2] = 0x5E;
 	ll_iface->addr[3] = 0x00;
 	ll_iface->addr[4] = 0x53;
-	ll_iface->addr[5] = sys_rand32_get();
+	ll_iface->addr[5] = sys_rand8_get();
 }
 
 ZTEST(net_ipv6, test_dad_timeout)

--- a/tests/net/ipv6_fragment/src/main.c
+++ b/tests/net/ipv6_fragment/src/main.c
@@ -938,7 +938,7 @@ static uint8_t *net_iface_get_mac(const struct device *dev)
 		data->mac_addr[2] = 0x5E;
 		data->mac_addr[3] = 0x00;
 		data->mac_addr[4] = 0x53;
-		data->mac_addr[5] = sys_rand32_get();
+		data->mac_addr[5] = sys_rand8_get();
 	}
 
 	data->ll_addr.addr = data->mac_addr;

--- a/tests/net/lib/dns_addremove/src/main.c
+++ b/tests/net/lib/dns_addremove/src/main.c
@@ -91,7 +91,7 @@ static uint8_t *net_iface_get_mac(const struct device *dev)
 		data->mac_addr[2] = 0x5E;
 		data->mac_addr[3] = 0x00;
 		data->mac_addr[4] = 0x53;
-		data->mac_addr[5] = sys_rand32_get();
+		data->mac_addr[5] = sys_rand8_get();
 	}
 
 	return data->mac_addr;

--- a/tests/net/lib/dns_resolve/src/main.c
+++ b/tests/net/lib/dns_resolve/src/main.c
@@ -89,7 +89,7 @@ static uint8_t *net_iface_get_mac(const struct device *dev)
 		data->mac_addr[2] = 0x5E;
 		data->mac_addr[3] = 0x00;
 		data->mac_addr[4] = 0x53;
-		data->mac_addr[5] = sys_rand32_get();
+		data->mac_addr[5] = sys_rand8_get();
 	}
 
 	data->ll_addr.addr = data->mac_addr;

--- a/tests/net/lib/mqtt_publisher/src/test_mqtt_publish.c
+++ b/tests/net/lib/mqtt_publisher/src/test_mqtt_publish.c
@@ -193,7 +193,7 @@ static int publish(enum mqtt_qos qos)
 	param.message.payload.data = get_mqtt_payload(qos);
 	param.message.payload.len =
 			strlen(param.message.payload.data);
-	param.message_id = sys_rand32_get();
+	param.message_id = sys_rand16_get();
 	param.dup_flag = 0U;
 	param.retain_flag = 0U;
 

--- a/tests/net/lib/mqtt_pubsub/src/test_mqtt_pubsub.c
+++ b/tests/net/lib/mqtt_pubsub/src/test_mqtt_pubsub.c
@@ -325,7 +325,7 @@ static int test_subscribe(void)
 	topic.qos = MQTT_QOS_1_AT_LEAST_ONCE;
 	sub.list = &topic;
 	sub.list_count = 1U;
-	sub.message_id = sys_rand32_get();
+	sub.message_id = sys_rand16_get();
 
 	rc = mqtt_subscribe(&client_ctx, &sub);
 	if (rc != 0) {
@@ -354,7 +354,7 @@ static int test_publish(enum mqtt_qos qos)
 			strlen(param.message.topic.topic.utf8);
 	param.message.payload.data = (uint8_t *)payload;
 	param.message.payload.len = payload_left;
-	param.message_id = sys_rand32_get();
+	param.message_id = sys_rand16_get();
 	param.dup_flag = 0U;
 	param.retain_flag = 0U;
 
@@ -388,7 +388,7 @@ static int test_unsubscribe(void)
 	topic.topic.size = strlen(topic.topic.utf8);
 	unsub.list = &topic;
 	unsub.list_count = 1U;
-	unsub.message_id = sys_rand32_get();
+	unsub.message_id = sys_rand16_get();
 
 	rc = mqtt_unsubscribe(&client_ctx, &unsub);
 	if (rc != 0) {

--- a/tests/net/lib/mqtt_subscriber/src/test_mqtt_subscribe.c
+++ b/tests/net/lib/mqtt_subscriber/src/test_mqtt_subscribe.c
@@ -251,7 +251,7 @@ static int test_subscribe(void)
 	topic.qos = MQTT_QOS_1_AT_LEAST_ONCE;
 	sub.list = &topic;
 	sub.list_count = 1U;
-	sub.message_id = sys_rand32_get();
+	sub.message_id = sys_rand16_get();
 
 	rc = mqtt_subscribe(&client_ctx, &sub);
 	if (rc != 0) {
@@ -274,7 +274,7 @@ static int test_unsubscribe(void)
 	topic.topic.size = strlen(topic.topic.utf8);
 	unsub.list = &topic;
 	unsub.list_count = 1U;
-	unsub.message_id = sys_rand32_get();
+	unsub.message_id = sys_rand16_get();
 
 	rc = mqtt_unsubscribe(&client_ctx, &unsub);
 	if (rc != 0) {

--- a/tests/net/mld/src/main.c
+++ b/tests/net/mld/src/main.c
@@ -87,7 +87,7 @@ static uint8_t *net_test_get_mac(const struct device *dev)
 		context->mac_addr[2] = 0x5E;
 		context->mac_addr[3] = 0x00;
 		context->mac_addr[4] = 0x53;
-		context->mac_addr[5] = sys_rand32_get();
+		context->mac_addr[5] = sys_rand8_get();
 	}
 
 	return context->mac_addr;

--- a/tests/net/net_pkt/src/main.c
+++ b/tests/net/net_pkt/src/main.c
@@ -35,7 +35,7 @@ static void fake_dev_iface_init(struct net_if *iface)
 		mac_addr[2] = 0x5E;
 		mac_addr[3] = 0x00;
 		mac_addr[4] = 0x53;
-		mac_addr[5] = sys_rand32_get();
+		mac_addr[5] = sys_rand8_get();
 	}
 
 	net_if_set_link_addr(iface, mac_addr, 6, NET_LINK_ETHERNET);

--- a/tests/net/pm/src/main.c
+++ b/tests/net/pm/src/main.c
@@ -66,7 +66,7 @@ static uint8_t *fake_dev_get_mac(struct fake_dev_context *ctx)
 		ctx->mac_addr[2] = 0x5E;
 		ctx->mac_addr[3] = 0x00;
 		ctx->mac_addr[4] = 0x53;
-		ctx->mac_addr[5] = sys_rand32_get();
+		ctx->mac_addr[5] = sys_rand8_get();
 	}
 
 	return ctx->mac_addr;

--- a/tests/net/ptp/clock/src/main.c
+++ b/tests/net/ptp/clock/src/main.c
@@ -147,7 +147,7 @@ static void generate_mac(uint8_t *mac_addr)
 	mac_addr[2] = 0x5E;
 	mac_addr[3] = 0x00;
 	mac_addr[4] = 0x53;
-	mac_addr[5] = sys_rand32_get();
+	mac_addr[5] = sys_rand8_get();
 }
 
 static int eth_init(const struct device *dev)

--- a/tests/net/route/src/main.c
+++ b/tests/net/route/src/main.c
@@ -113,7 +113,7 @@ static uint8_t *net_route_get_mac(const struct device *dev)
 		route->mac_addr[2] = 0x5E;
 		route->mac_addr[3] = 0x00;
 		route->mac_addr[4] = 0x53;
-		route->mac_addr[5] = sys_rand32_get();
+		route->mac_addr[5] = sys_rand8_get();
 	}
 
 	route->ll_addr.addr = route->mac_addr;
@@ -285,7 +285,7 @@ static void test_init(void)
 		       sizeof(struct in6_addr));
 
 		dest_addresses[i].s6_addr[14] = i + 1;
-		dest_addresses[i].s6_addr[15] = sys_rand32_get();
+		dest_addresses[i].s6_addr[15] = sys_rand8_get();
 	}
 }
 

--- a/tests/net/route_mcast/src/main.c
+++ b/tests/net/route_mcast/src/main.c
@@ -154,7 +154,7 @@ static uint8_t *net_route_mcast_get_mac(const struct device *dev)
 		cfg->mac_addr[2] = 0x5E;
 		cfg->mac_addr[3] = 0x00;
 		cfg->mac_addr[4] = 0x53;
-		cfg->mac_addr[5] = sys_rand32_get();
+		cfg->mac_addr[5] = sys_rand8_get();
 	}
 
 	cfg->ll_addr.addr = cfg->mac_addr;

--- a/tests/net/shell/src/main.c
+++ b/tests/net/shell/src/main.c
@@ -78,7 +78,7 @@ static uint8_t *net_udp_get_mac(const struct device *dev)
 		context->mac_addr[2] = 0x5E;
 		context->mac_addr[3] = 0x00;
 		context->mac_addr[4] = 0x53;
-		context->mac_addr[5] = sys_rand32_get();
+		context->mac_addr[5] = sys_rand8_get();
 	}
 
 	return context->mac_addr;

--- a/tests/net/socket/af_packet_ipproto_raw/src/main.c
+++ b/tests/net/socket/af_packet_ipproto_raw/src/main.c
@@ -56,7 +56,7 @@ static uint8_t *fake_dev_get_mac(struct fake_dev_context *ctx)
 		ctx->mac_addr[2] = 0x5E;
 		ctx->mac_addr[3] = 0x00;
 		ctx->mac_addr[4] = 0x53;
-		ctx->mac_addr[5] = sys_rand32_get();
+		ctx->mac_addr[5] = sys_rand8_get();
 	}
 
 	return ctx->mac_addr;

--- a/tests/net/traffic_class/src/main.c
+++ b/tests/net/traffic_class/src/main.c
@@ -254,7 +254,7 @@ static void generate_mac(uint8_t *mac_addr)
 	mac_addr[2] = 0x5E;
 	mac_addr[3] = 0x00;
 	mac_addr[4] = 0x53;
-	mac_addr[5] = sys_rand32_get();
+	mac_addr[5] = sys_rand8_get();
 }
 
 static int eth_init(const struct device *dev)

--- a/tests/net/tx_timestamp/src/main.c
+++ b/tests/net/tx_timestamp/src/main.c
@@ -141,7 +141,7 @@ static void generate_mac(uint8_t *mac_addr)
 	mac_addr[2] = 0x5E;
 	mac_addr[3] = 0x00;
 	mac_addr[4] = 0x53;
-	mac_addr[5] = sys_rand32_get();
+	mac_addr[5] = sys_rand8_get();
 }
 
 static int eth_init(const struct device *dev)

--- a/tests/net/udp/src/main.c
+++ b/tests/net/udp/src/main.c
@@ -80,7 +80,7 @@ static uint8_t *net_udp_get_mac(const struct device *dev)
 		context->mac_addr[2] = 0x5E;
 		context->mac_addr[3] = 0x00;
 		context->mac_addr[4] = 0x53;
-		context->mac_addr[5] = sys_rand32_get();
+		context->mac_addr[5] = sys_rand8_get();
 	}
 
 	return context->mac_addr;

--- a/tests/net/virtual/src/main.c
+++ b/tests/net/virtual/src/main.c
@@ -175,7 +175,7 @@ static void generate_mac(uint8_t *mac_addr)
 	mac_addr[2] = 0x5E;
 	mac_addr[3] = 0x00;
 	mac_addr[4] = 0x53;
-	mac_addr[5] = sys_rand32_get();
+	mac_addr[5] = sys_rand8_get();
 }
 
 static int eth_init(const struct device *dev)
@@ -209,7 +209,7 @@ static uint8_t *net_iface_get_mac(const struct device *dev)
 		data->mac_addr[2] = 0x5E;
 		data->mac_addr[3] = 0x00;
 		data->mac_addr[4] = 0x53;
-		data->mac_addr[5] = sys_rand32_get();
+		data->mac_addr[5] = sys_rand8_get();
 	}
 
 	data->ll_addr.addr = data->mac_addr;
@@ -533,12 +533,12 @@ static bool add_to_arp(struct net_if *iface, struct in_addr *addr)
 #if defined(CONFIG_NET_ARP)
 	struct net_eth_addr lladdr;
 
-	lladdr.addr[0] = sys_rand32_get();
+	lladdr.addr[0] = sys_rand8_get();
 	lladdr.addr[1] = 0x08;
 	lladdr.addr[2] = 0x09;
 	lladdr.addr[3] = 0x10;
 	lladdr.addr[4] = 0x11;
-	lladdr.addr[5] = sys_rand32_get();
+	lladdr.addr[5] = sys_rand8_get();
 
 	return arp_add(iface, addr, &lladdr);
 #else

--- a/tests/net/vlan/src/main.c
+++ b/tests/net/vlan/src/main.c
@@ -179,7 +179,7 @@ static void generate_mac(uint8_t *mac_addr)
 	mac_addr[2] = 0x5E;
 	mac_addr[3] = 0x00;
 	mac_addr[4] = 0x53;
-	mac_addr[5] = sys_rand32_get();
+	mac_addr[5] = sys_rand8_get();
 }
 
 static int eth_vlan_init(const struct device *dev)
@@ -225,7 +225,7 @@ static uint8_t *net_iface_get_mac(const struct device *dev)
 	data->mac_addr[2] = 0x5E;
 	data->mac_addr[3] = 0x00;
 	data->mac_addr[4] = 0x53;
-	data->mac_addr[5] = sys_rand32_get();
+	data->mac_addr[5] = sys_rand8_get();
 
 	data->ll_addr.addr = data->mac_addr;
 	data->ll_addr.len = 6U;

--- a/tests/net/wifi/wifi_nm/src/main.c
+++ b/tests/net/wifi/wifi_nm/src/main.c
@@ -87,7 +87,7 @@ static void generate_mac(uint8_t *mac_addr)
 	mac_addr[2] = 0x5E;
 	mac_addr[3] = 0x00;
 	mac_addr[4] = 0x53;
-	mac_addr[5] = sys_rand32_get();
+	mac_addr[5] = sys_rand8_get();
 }
 
 static int wifi_init(const struct device *dev)

--- a/tests/subsys/ipc/pbuf/src/main.c
+++ b/tests/subsys/ipc/pbuf/src/main.c
@@ -211,7 +211,7 @@ bool stress_read(void *user_data, uint32_t cnt, bool last, int prio)
 	struct stress_data *ctx = (struct stress_data *)user_data;
 	char buf[STRESS_LEN_MAX];
 	int len;
-	int rpt = (sys_rand32_get() & 3) + 1;
+	int rpt = (sys_rand8_get() & 3) + 1;
 
 	for (int i = 0; i < rpt; i++) {
 		len = pbuf_read(ctx->pbuf, buf, (uint16_t)sizeof(buf));
@@ -235,8 +235,8 @@ bool stress_write(void *user_data, uint32_t cnt, bool last, int prio)
 	struct stress_data *ctx = (struct stress_data *)user_data;
 	char buf[STRESS_LEN_MAX];
 
-	uint16_t len = STRESS_LEN_MIN + (sys_rand32_get() % STRESS_LEN_MOD);
-	int rpt = (sys_rand32_get() & 1) + 1;
+	uint16_t len = STRESS_LEN_MIN + (sys_rand8_get() % STRESS_LEN_MOD);
+	int rpt = (sys_rand8_get() & 1) + 1;
 
 	zassert_true(len < sizeof(buf));
 

--- a/tests/subsys/logging/log_stress/src/main.c
+++ b/tests/subsys/logging/log_stress/src/main.c
@@ -116,7 +116,7 @@ static bool context_handler(void *user_data, uint32_t cnt, bool last, int prio)
 
 	uint32_t i = cnt | (prio << CNT_BITS);
 
-	switch (sys_rand32_get() % 4) {
+	switch (sys_rand8_get() % 4) {
 	case 0:
 		LOG_INF("%u", i);
 		break;


### PR DESCRIPTION
Same as #71032, but for all samples and tests.

Use the appropriate sys_randX_get() or where it makes sense to use sys_rand_get() directly.