### PR TITLE
llext: invalidate instruction cache after loading extension

### DIFF
--- a/subsys/llext/llext.c
+++ b/subsys/llext/llext.c
@@ -801,6 +801,7 @@ static int llext_link(struct llext_loader *ldr, struct llext *ext, bool do_local
 	for (i = 0; i < LLEXT_MEM_COUNT; ++i) {
 		if (ext->mem[i]) {
 			sys_cache_data_flush_range(ext->mem[i], ext->mem_size[i]);
+			sys_cache_instr_invd_range(ext->mem[i], ext->mem_size[i]);
 		}
 	}
 #endif


### PR DESCRIPTION
In addition to flushing the dcache, to ensure that the new code is actually read by the CPU when loading an extension, the icache must be invalidated as well.
Without this, some tests are failing in hardware because the CPU is executing stale code from its instruction cache.

Fixes #70906 on `arduino_giga_r1/stm32h747xx/m7`.