### PR TITLE
hawkbit: fix compilation error, add more tests & cleanup headers

### DIFF
--- a/samples/subsys/mgmt/hawkbit/sample.yaml
+++ b/samples/subsys/mgmt/hawkbit/sample.yaml
@@ -1,14 +1,32 @@
 common:
   filter: CONFIG_FULL_LIBC_SUPPORTED
+  harness: net
+  tags: net
+  depends_on: netif
+  build_only: true
+  platform_allow: frdm_k64f
+  integration_platforms:
+    - frdm_k64f
 sample:
   description: Hawkbit Firmware Over-the-Air (FOTA)
   name: hawkbit
 tests:
-  sample.net.hawkbit:
-    harness: net
-    tags: net
-    depends_on: netif
-    build_only: true
-    platform_allow: frdm_k64f
-    integration_platforms:
-      - frdm_k64f
+  sample.net.hawkbit.default: {}
+  sample.net.hawkbit.manual:
+    extra_configs:
+      - CONFIG_HAWKBIT_MANUAL=y
+  sample.net.hawkbit.shell:
+    extra_configs:
+      - CONFIG_SHELL=y
+      - CONFIG_HAWKBIT_SHELL=y
+  sample.net.hawkbit.ddi.target:
+    extra_configs:
+      - CONFIG_HAWKBIT_DDI_TARGET_SECURITY=y
+      - CONFIG_HAWKBIT_DDI_SECURITY_TOKEN="abcd1234"
+  sample.net.hawkbit.ddi.gateway:
+    extra_configs:
+      - CONFIG_HAWKBIT_DDI_GATEWAY_SECURITY=y
+      - CONFIG_HAWKBIT_DDI_SECURITY_TOKEN="abcd1234"
+  sample.net.hawkbit.tls:
+    extra_configs:
+      - CONFIG_NET_SOCKETS_SOCKOPT_TLS=y

--- a/subsys/mgmt/hawkbit/hawkbit.c
+++ b/subsys/mgmt/hawkbit/hawkbit.c
@@ -8,35 +8,35 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/logging/log.h>
-
-LOG_MODULE_REGISTER(hawkbit, CONFIG_HAWKBIT_LOG_LEVEL);
-
 #include <stdio.h>
-#include <zephyr/kernel.h>
-#include <string.h>
 #include <stdlib.h>
-#include <zephyr/fs/nvs.h>
-#include <zephyr/data/json.h>
-#include <zephyr/net/net_ip.h>
-#include <zephyr/net/socket.h>
-#include <zephyr/net/net_mgmt.h>
-#include <zephyr/sys/reboot.h>
-#include <zephyr/drivers/flash.h>
-#include <zephyr/net/http/client.h>
-#include <zephyr/net/dns_resolve.h>
-#include <zephyr/logging/log_ctrl.h>
-#include <zephyr/storage/flash_map.h>
+#include <string.h>
 
-#include "hawkbit_priv.h"
-#include "hawkbit_device.h"
+#include <zephyr/data/json.h>
+#include <zephyr/drivers/flash.h>
+#include <zephyr/fs/nvs.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/logging/log_ctrl.h>
 #include <zephyr/mgmt/hawkbit.h>
+#include <zephyr/net/dns_resolve.h>
+#include <zephyr/net/http/client.h>
+#include <zephyr/net/net_ip.h>
+#include <zephyr/net/net_mgmt.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/storage/flash_map.h>
+#include <zephyr/sys/reboot.h>
+
+#include "hawkbit_device.h"
 #include "hawkbit_firmware.h"
+#include "hawkbit_priv.h"
 
 #if defined(CONFIG_NET_SOCKETS_SOCKOPT_TLS)
 #define CA_CERTIFICATE_TAG 1
 #include <zephyr/net/tls_credentials.h>
 #endif
+
+LOG_MODULE_REGISTER(hawkbit, CONFIG_HAWKBIT_LOG_LEVEL);
 
 #define ADDRESS_ID 1
 

--- a/subsys/mgmt/hawkbit/hawkbit.c
+++ b/subsys/mgmt/hawkbit/hawkbit.c
@@ -246,14 +246,14 @@ static bool start_http_client(void)
 		CA_CERTIFICATE_TAG,
 	};
 
-	if (setsockopt(hb_context.sock, SOL_TLS, TLS_SEC_TAG_LIST, sec_tag_opt,
-		       sizeof(sec_tag_opt)) < 0) {
+	if (zsock_setsockopt(hb_context.sock, SOL_TLS, TLS_SEC_TAG_LIST, sec_tag_opt,
+			     sizeof(sec_tag_opt)) < 0) {
 		LOG_ERR("Failed to set TLS_TAG option");
 		goto err_sock;
 	}
 
-	if (setsockopt(hb_context.sock, SOL_TLS, TLS_HOSTNAME, CONFIG_HAWKBIT_SERVER,
-		       sizeof(CONFIG_HAWKBIT_SERVER)) < 0) {
+	if (zsock_setsockopt(hb_context.sock, SOL_TLS, TLS_HOSTNAME, CONFIG_HAWKBIT_SERVER,
+			     sizeof(CONFIG_HAWKBIT_SERVER)) < 0) {
 		goto err_sock;
 	}
 #endif


### PR DESCRIPTION
While trying to test every configuration of hawkBit, found that it doesn't compile when `CONFIG_NET_SOCKETS_SOCKOPT_TLS` is enabled, so fix that.

Also rearranged the includes alphabetically while I'm here, should look less random now.