### PR TITLE
Fix types in OpenAMP resource table

### DIFF
--- a/lib/open-amp/resource_table.c
+++ b/lib/open-amp/resource_table.c
@@ -74,8 +74,8 @@ static struct fw_resource_table __resource resource_table = {
 #endif
 };
 
-void rsc_table_get(void **table_ptr, int *length)
+void rsc_table_get(struct fw_resource_table **table_ptr, int *length)
 {
-	*table_ptr = (void *)&resource_table;
+	*table_ptr = &resource_table;
 	*length = sizeof(resource_table);
 }

--- a/lib/open-amp/resource_table.c
+++ b/lib/open-amp/resource_table.c
@@ -34,8 +34,10 @@ extern char ram_console[];
 #define __resource Z_GENERIC_SECTION(.resource_table)
 
 static struct fw_resource_table __resource resource_table = {
-	.ver = 1,
-	.num = RSC_TABLE_NUM_ENTRY,
+	.hdr = {
+		.ver = 1,
+		.num = RSC_TABLE_NUM_ENTRY,
+	},
 	.offset = {
 
 #if (CONFIG_OPENAMP_RSC_TABLE_NUM_RPMSG_BUFF > 0)

--- a/lib/open-amp/resource_table.h
+++ b/lib/open-amp/resource_table.h
@@ -41,10 +41,8 @@ enum rsc_table_entries {
 };
 
 struct fw_resource_table {
-	unsigned int ver;
-	unsigned int num;
-	unsigned int reserved[2];
-	unsigned int offset[RSC_TABLE_NUM_ENTRY];
+	struct resource_table hdr;
+	uint32_t offset[RSC_TABLE_NUM_ENTRY];
 
 #if (CONFIG_OPENAMP_RSC_TABLE_NUM_RPMSG_BUFF > 0)
 	struct fw_rsc_vdev vdev;

--- a/lib/open-amp/resource_table.h
+++ b/lib/open-amp/resource_table.h
@@ -56,23 +56,23 @@ struct fw_resource_table {
 #endif
 } METAL_PACKED_END;
 
-void rsc_table_get(void **table_ptr, int *length);
+void rsc_table_get(struct fw_resource_table **table_ptr, int *length);
 
 #if (CONFIG_OPENAMP_RSC_TABLE_NUM_RPMSG_BUFF > 0)
 
-inline struct fw_rsc_vdev *rsc_table_to_vdev(void *rsc_table)
+inline struct fw_rsc_vdev *rsc_table_to_vdev(struct fw_resource_table *rsc_table)
 {
-	return &((struct fw_resource_table *)rsc_table)->vdev;
+	return &rsc_table->vdev;
 }
 
-inline struct fw_rsc_vdev_vring *rsc_table_get_vring0(void *rsc_table)
+inline struct fw_rsc_vdev_vring *rsc_table_get_vring0(struct fw_resource_table *rsc_table)
 {
-	return &((struct fw_resource_table *)rsc_table)->vring0;
+	return &rsc_table->vring0;
 }
 
-inline struct fw_rsc_vdev_vring *rsc_table_get_vring1(void *rsc_table)
+inline struct fw_rsc_vdev_vring *rsc_table_get_vring1(struct fw_resource_table *rsc_table)
 {
-	return &((struct fw_resource_table *)rsc_table)->vring1;
+	return &rsc_table->vring1;
 }
 
 #endif


### PR DESCRIPTION
Update the resource table struct to use fixed width types and use the `fw_resource_table` type when we can.