### PR TITLE
xtensa: dc233c: Fix build warning in DTS on leading zeros

### DIFF
--- a/dts/xtensa/dc233c.dtsi
+++ b/dts/xtensa/dc233c.dtsi
@@ -22,7 +22,7 @@
 	 * Although RAM is of size 128MB (0x08000000), limit this to 16MB so
 	 * fewer L2 page table entries are needed when MMU is enabled.
 	 */
-	sram0: memory@00000000 {
+	sram0: memory@0 {
 		device_type = "memory";
 		compatible = "mmio-sram";
 		reg = <0x00000000 0x01000000>;


### PR DESCRIPTION
Leading zeros removed from unit name.


Fixes this warning:
 Warning (unit_address_format): /memory@00000000: unit name should not have leading 0s

You can get one on unfixed code with:
```
twister -p qemu_xtensa/dc233c/mmu   -T  zephyr//tests/subsys/fs/fs_api/
```
and see the log