### PR TITLE
xtensa: make it work with DTLB misses during interrupt handling

### DIFF
--- a/arch/xtensa/core/gen_zsr.py
+++ b/arch/xtensa/core/gen_zsr.py
@@ -31,7 +31,7 @@ args = parse_args()
 
 NEEDED = ["A0SAVE", "CPU"]
 if args.mmu:
-    NEEDED += ["MMU_0", "MMU_1", "DBLEXC"]
+    NEEDED += ["MMU_0", "MMU_1", "DBLEXC", "EXCCAUSE_SAVE"]
 if args.coherence:
     NEEDED += ["FLUSH"]
 


### PR DESCRIPTION
If there is a data TLB misses during interrupt handling, the double exception vector will be triggered for the miss and the EXCCAUSE overwritten. The DTLB miss will be handled and execution returned to the original vector code. Because of this, the EXCCAUSE read in the C handler thus is not the one that triggered the original vector code (for example, level-1 interrupt). So stash the EXCCAUSE and use it in this scenario such that we can process it correctly.

Note that the moving of assembly in the vector code is due to space constraint in the vector area. Or else it would be too large to fit there.