### PR TITLE
tracing: full reset during init

### DIFF
--- a/subsys/tracing/tracing_backend_ram.c
+++ b/subsys/tracing/tracing_backend_ram.c
@@ -35,6 +35,8 @@ static void tracing_backend_ram_output(
 static void tracing_backend_ram_init(void)
 {
 	memset(ram_tracing, 0, CONFIG_RAM_TRACING_BUFFER_SIZE);
+	pos = 0;
+	buffer_full = false;
 }
 
 const struct tracing_backend_api tracing_backend_ram_api = {


### PR DESCRIPTION
I am using the tracing module using the RAM backend on a system with
limited RAM & a buffer that can only store 300ms of tracing data. Current
tracing module starts recording during boot-up & we run out of memory prior
to executing code we actually want to trace.

By reseting buffer metadata here, I can call init() at an arbitrary point
of program execution & the tracing module will reset & start tracing.

I tested on E2E on an ARM M-class MCU by calling init & then reading
buffered tracing data via GDB