### PR TITLE
stm32h5: Enable SDMMC support

### DIFF
--- a/boards/st/stm32h573i_dk/Kconfig.defconfig
+++ b/boards/st/stm32h573i_dk/Kconfig.defconfig
@@ -14,4 +14,11 @@ config NET_L2_ETHERNET
 
 endif # NETWORKING
 
+if DISK_DRIVER_SDMMC
+
+config SDMMC_STM32_CLOCK_CHECK
+	default n
+
+endif # DISK_DRIVER_SDMMC
+
 endif # BOARD_STM32H573I_DK

--- a/boards/st/stm32h573i_dk/doc/index.rst
+++ b/boards/st/stm32h573i_dk/doc/index.rst
@@ -193,8 +193,11 @@ hardware features:
 +-----------+------------+-------------------------------------+
 | AES       | on-chip    | crypto                              |
 +-----------+------------+-------------------------------------+
+| SDMMC     | on-chip    | disk access                         |
++-----------+------------+-------------------------------------+
 | USB       | on-chip    | USB full-speed host/device bus      |
 +-----------+------------+-------------------------------------+
+
 
 Other hardware features are not yet supported on this Zephyr port.
 

--- a/boards/st/stm32h573i_dk/stm32h573i_dk.dts
+++ b/boards/st/stm32h573i_dk/stm32h573i_dk.dts
@@ -275,6 +275,16 @@
 	};
 };
 
+&sdmmc1 {
+	pinctrl-0 = <&sdmmc1_d0_pc8 &sdmmc1_d1_pc9
+		     &sdmmc1_d2_pc10 &sdmmc1_d3_pc11
+		     &sdmmc1_ck_pc12 &sdmmc1_cmd_pd2>;
+	pinctrl-names = "default";
+	cd-gpios = <&gpioh 14 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+	status = "okay";
+};
+
+
 zephyr_udc0: &usb {
 	pinctrl-0 = <&usb_dm_pa11 &usb_dp_pa12>;
 	pinctrl-names = "default";

--- a/boards/st/stm32h573i_dk/stm32h573i_dk.yaml
+++ b/boards/st/stm32h573i_dk/stm32h573i_dk.yaml
@@ -24,4 +24,5 @@ supported:
   - usb_device
   - usb
   - i2c
+  - sdhc
 vendor: st

--- a/drivers/disk/Kconfig.sdmmc
+++ b/drivers/disk/Kconfig.sdmmc
@@ -52,7 +52,8 @@ config SDMMC_STM32
 config SDMMC_STM32_HWFC
 	bool "STM32 SDMMC Hardware Flow control"
 	depends on SDMMC_STM32
-	depends on SOC_SERIES_STM32H7X || \
+	depends on SOC_SERIES_STM32H5X || \
+		   SOC_SERIES_STM32H7X || \
 		   SOC_SERIES_STM32F7X || \
 		   SOC_SERIES_STM32L4X || \
 		   SOC_SERIES_STM32L5X

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -332,6 +332,16 @@
 			bosch,mram-cfg = <0x350 28 8 3 3 0 3 3>;
 			status = "disabled";
 		};
+
+		sdmmc1: sdmmc@46008000 {
+			compatible = "st,stm32-sdmmc";
+			reg = <0x46008000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB4 0x00000800>,
+				 <&rcc STM32_SRC_PLL1_Q SDMMC1_SEL(0)>;
+			resets = <&rctl STM32_RESET(AHB4, 11U)>;
+			interrupts = <79 0>;
+			status = "disabled";
+		};
 	};
 
 	smbus3: smbus3 {

--- a/dts/arm/st/h5/stm32h563.dtsi
+++ b/dts/arm/st/h5/stm32h563.dtsi
@@ -9,5 +9,15 @@
 / {
 	soc {
 		compatible = "st,stm32h563", "st,stm32h5", "simple-bus";
+
+		sdmmc2: sdmmc@46008c00 {
+			compatible = "st,stm32-sdmmc";
+			reg = <0x46008c00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB4 0x00001000>,
+				 <&rcc STM32_SRC_PLL1_Q SDMMC2_SEL(0)>;
+			resets = <&rctl STM32_RESET(AHB4, 12U)>;
+			interrupts = <102 0>;
+			status = "disabled";
+		};
 	};
 };


### PR DESCRIPTION
- Provide SDMMC description in device tree
- Enable SDMMC1 on stm32h573i_dk
- Provide stm32h573i_dk configuration to run fs_sample on this board