### PR TITLE
samples: sensor: qdec: Add nRF54L15 to platform allow

### DIFF
--- a/samples/sensor/qdec/sample.yaml
+++ b/samples/sensor/qdec/sample.yaml
@@ -5,17 +5,18 @@ common:
   tags: sensors
   timeout: 5
   harness: console
-  harness_config:
-    type: multi_line
-    ordered: true
-    regex:
-      - "Quadrature decoder sensor test"
-      - "Position = (.*) degrees"
+
 tests:
   sample.sensor.qdec_sensor:
     platform_allow: nucleo_f401re
     harness_config:
       fixture: fixture_mech_encoder
+      type: multi_line
+      ordered: true
+      regex:
+        - "Quadrature decoder sensor test"
+        - "Position = (.*) degrees"
+
   sample.sensor.nrf_qdec_sensor:
     platform_allow:
       - nrf52840dk/nrf52840
@@ -27,3 +28,8 @@ tests:
       - nrf54l15pdk/nrf54l15/cpuapp
     harness_config:
       fixture: gpio_loopback
+      type: multi_line
+      ordered: true
+      regex:
+        - "Quadrature decoder sensor test"
+        - "Position = (.*) degrees"

--- a/samples/sensor/qdec/sample.yaml
+++ b/samples/sensor/qdec/sample.yaml
@@ -20,8 +20,10 @@ tests:
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15pdk/nrf54l15/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15pdk/nrf54l15/cpuapp
     harness_config:
       fixture: gpio_loopback


### PR DESCRIPTION
Add nRF54L15 to platform_allow and integration_platforms in the sample.yaml.
Overlay file for that target already exists in the boards directory.