### PR TITLE
[RFC] Replace __subsystem tag with DEVICE_API

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -26,6 +26,7 @@ AttributeMacros:
   - __syscall
   - __syscall_always_inline
   - __subsystem
+  - DEVICE_API
 BitFieldColonSpacing: After
 BreakBeforeBraces: Linux
 ColumnLimit: 100

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -268,6 +268,7 @@ cpp_id_attributes = [
     "__DEPRECATED_MACRO",
     "FUNC_NORETURN",
     "__subsystem",
+    "DEVICE_API",
     "ALWAYS_INLINE",
 ]
 c_id_attributes = cpp_id_attributes

--- a/include/zephyr/crypto/crypto.h
+++ b/include/zephyr/crypto/crypto.h
@@ -65,7 +65,7 @@
 /* More flags to be added as necessary */
 
 /** @brief Crypto driver API definition. */
-__subsystem struct crypto_driver_api {
+DEVICE_API struct crypto_driver_api {
 	int (*query_hw_caps)(const struct device *dev);
 
 	/* Setup a crypto session */

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -70,6 +70,15 @@ typedef int16_t device_handle_t;
 #define DEVICE_HANDLE_NULL 0
 
 /**
+ * @brief Device API struct tag.
+ *
+ * This definition is used to tag structures that define the API ops for a
+ * certain device class. Tagging is required for features like
+ * @kconfig{CONFIG_USERSPACE}.
+ */
+#define DEVICE_API
+
+/**
  * @brief Expands to the name of a global device object.
  *
  * Return the full name of a device object symbol created by DEVICE_DEFINE(),

--- a/include/zephyr/drivers/adc.h
+++ b/include/zephyr/drivers/adc.h
@@ -698,7 +698,7 @@ typedef int (*adc_api_read_async)(const struct device *dev,
  *
  * This is the mandatory API any ADC driver needs to expose.
  */
-__subsystem struct adc_driver_api {
+DEVICE_API struct adc_driver_api {
 	adc_api_channel_setup channel_setup;
 	adc_api_read          read;
 #ifdef CONFIG_ADC_ASYNC

--- a/include/zephyr/drivers/auxdisplay.h
+++ b/include/zephyr/drivers/auxdisplay.h
@@ -285,7 +285,7 @@ typedef int (*auxdisplay_write_t)(const struct device *dev, const uint8_t *data,
 typedef int (*auxdisplay_custom_command_t)(const struct device *dev,
 					   struct auxdisplay_custom_data *command);
 
-__subsystem struct auxdisplay_driver_api {
+DEVICE_API struct auxdisplay_driver_api {
 	auxdisplay_display_on_t display_on;
 	auxdisplay_display_off_t display_off;
 	auxdisplay_cursor_set_enabled_t cursor_set_enabled;

--- a/include/zephyr/drivers/bbram.h
+++ b/include/zephyr/drivers/bbram.h
@@ -72,7 +72,7 @@ typedef int (*bbram_api_read_t)(const struct device *dev, size_t offset, size_t 
 typedef int (*bbram_api_write_t)(const struct device *dev, size_t offset, size_t size,
 			       const uint8_t *data);
 
-__subsystem struct bbram_driver_api {
+DEVICE_API struct bbram_driver_api {
 	bbram_api_check_invalid_t check_invalid;
 	bbram_api_check_standby_power_t check_standby_power;
 	bbram_api_check_power_t check_power;

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -509,7 +509,7 @@ typedef int (*can_get_core_clock_t)(const struct device *dev, uint32_t *rate);
  */
 typedef int (*can_get_max_filters_t)(const struct device *dev, bool ide);
 
-__subsystem struct can_driver_api {
+DEVICE_API struct can_driver_api {
 	can_get_capabilities_t get_capabilities;
 	can_start_t start;
 	can_stop_t stop;

--- a/include/zephyr/drivers/can/transceiver.h
+++ b/include/zephyr/drivers/can/transceiver.h
@@ -41,7 +41,7 @@ typedef int (*can_transceiver_enable_t)(const struct device *dev, can_mode_t mod
  */
 typedef int (*can_transceiver_disable_t)(const struct device *dev);
 
-__subsystem struct can_transceiver_driver_api {
+DEVICE_API struct can_transceiver_driver_api {
 	can_transceiver_enable_t enable;
 	can_transceiver_disable_t disable;
 };

--- a/include/zephyr/drivers/cellular.h
+++ b/include/zephyr/drivers/cellular.h
@@ -110,7 +110,7 @@ typedef int (*cellular_api_get_registration_status)(const struct device *dev,
 						    enum cellular_registration_status *status);
 
 /** Cellular driver API */
-__subsystem struct cellular_driver_api {
+DEVICE_API struct cellular_driver_api {
 	cellular_api_configure_networks configure_networks;
 	cellular_api_get_supported_networks get_supported_networks;
 	cellular_api_get_signal get_signal;

--- a/include/zephyr/drivers/charger.h
+++ b/include/zephyr/drivers/charger.h
@@ -330,7 +330,7 @@ typedef int (*charger_charge_enable_t)(const struct device *dev, const bool enab
  *
  * Caching is entirely on the onus of the client
  */
-__subsystem struct charger_driver_api {
+DEVICE_API struct charger_driver_api {
 	charger_get_property_t get_property;
 	charger_set_property_t set_property;
 	charger_charge_enable_t charge_enable;

--- a/include/zephyr/drivers/console/uart_mux.h
+++ b/include/zephyr/drivers/console/uart_mux.h
@@ -44,7 +44,7 @@ typedef void (*uart_mux_attach_cb_t)(const struct device *mux,
 				     bool connected, void *user_data);
 
 /** @brief UART mux driver API structure. */
-__subsystem struct uart_mux_driver_api {
+DEVICE_API struct uart_mux_driver_api {
 	/**
 	 * The uart_driver_api must be placed in first position in this
 	 * struct so that we are compatible with uart API. Note that currently

--- a/include/zephyr/drivers/coredump.h
+++ b/include/zephyr/drivers/coredump.h
@@ -90,7 +90,7 @@ typedef bool (*coredump_device_register_callback_t)(const struct device *dev,
 /*
  * API which a coredump pseudo-device driver should expose
  */
-__subsystem struct coredump_driver_api {
+DEVICE_API struct coredump_driver_api {
 	coredump_device_dump_t              dump;
 	coredump_device_register_memory_t   register_memory;
 	coredump_device_unregister_memory_t unregister_memory;

--- a/include/zephyr/drivers/counter.h
+++ b/include/zephyr/drivers/counter.h
@@ -231,7 +231,7 @@ typedef int (*counter_api_set_guard_period)(const struct device *dev,
 						uint32_t flags);
 typedef uint32_t (*counter_api_get_freq)(const struct device *dev);
 
-__subsystem struct counter_driver_api {
+DEVICE_API struct counter_driver_api {
 	counter_api_start start;
 	counter_api_stop stop;
 	counter_api_get_value get_value;

--- a/include/zephyr/drivers/dac.h
+++ b/include/zephyr/drivers/dac.h
@@ -67,7 +67,7 @@ typedef int (*dac_api_write_value)(const struct device *dev,
  *
  * This is the mandatory API any DAC driver needs to expose.
  */
-__subsystem struct dac_driver_api {
+DEVICE_API struct dac_driver_api {
 	dac_api_channel_setup channel_setup;
 	dac_api_write_value   write_value;
 };

--- a/include/zephyr/drivers/dai.h
+++ b/include/zephyr/drivers/dai.h
@@ -307,7 +307,7 @@ struct dai_ts_data {
  *
  * For internal use only, skip these in public documentation.
  */
-__subsystem struct dai_driver_api {
+DEVICE_API struct dai_driver_api {
 	int (*probe)(const struct device *dev);
 	int (*remove)(const struct device *dev);
 	int (*config_set)(const struct device *dev, const struct dai_config *cfg,

--- a/include/zephyr/drivers/dma.h
+++ b/include/zephyr/drivers/dma.h
@@ -352,7 +352,7 @@ typedef int (*dma_api_get_attribute)(const struct device *dev, uint32_t type, ui
 typedef bool (*dma_api_chan_filter)(const struct device *dev,
 				int channel, void *filter_param);
 
-__subsystem struct dma_driver_api {
+DEVICE_API struct dma_driver_api {
 	dma_api_config config;
 	dma_api_reload reload;
 	dma_api_start start;

--- a/include/zephyr/drivers/edac.h
+++ b/include/zephyr/drivers/edac.h
@@ -47,7 +47,7 @@ typedef void (*edac_notify_callback_f)(const struct device *dev, void *data);
  *
  * This is the mandatory API any EDAC driver needs to expose.
  */
-__subsystem struct edac_driver_api {
+DEVICE_API struct edac_driver_api {
 	/* Error Injection API is disabled by default */
 	int (*inject_set_param1)(const struct device *dev, uint64_t value);
 	int (*inject_get_param1)(const struct device *dev, uint64_t *value);

--- a/include/zephyr/drivers/eeprom.h
+++ b/include/zephyr/drivers/eeprom.h
@@ -61,7 +61,7 @@ typedef int (*eeprom_api_write)(const struct device *dev, off_t offset,
  */
 typedef size_t (*eeprom_api_size)(const struct device *dev);
 
-__subsystem struct eeprom_driver_api {
+DEVICE_API struct eeprom_driver_api {
 	eeprom_api_read read;
 	eeprom_api_write write;
 	eeprom_api_size size;

--- a/include/zephyr/drivers/emul_bbram.h
+++ b/include/zephyr/drivers/emul_bbram.h
@@ -23,7 +23,7 @@
  * These are for internal use only, so skip these in public documentation.
  */
 
-__subsystem struct emul_bbram_backend_api {
+DEVICE_API struct emul_bbram_backend_api {
 	/** Sets the data */
 	int (*set_data)(const struct emul *target, size_t offset, size_t count,
 			const uint8_t *data);

--- a/include/zephyr/drivers/emul_fuel_gauge.h
+++ b/include/zephyr/drivers/emul_fuel_gauge.h
@@ -32,7 +32,7 @@ extern "C" {
  *
  * These are for internal use only, so skip these in public documentation.
  */
-__subsystem struct fuel_gauge_emul_driver_api {
+DEVICE_API struct fuel_gauge_emul_driver_api {
 	int (*set_battery_charging)(const struct emul *emul, uint32_t uV, int uA);
 	int (*is_battery_cutoff)(const struct emul *emul, bool *cutoff);
 };

--- a/include/zephyr/drivers/emul_sensor.h
+++ b/include/zephyr/drivers/emul_sensor.h
@@ -25,7 +25,7 @@
 /**
  * @brief Collection of function pointers implementing a common backend API for sensor emulators
  */
-__subsystem struct emul_sensor_backend_api {
+DEVICE_API struct emul_sensor_backend_api {
 	/** Sets a given fractional value for a given sensor channel. */
 	int (*set_channel)(const struct emul *target, enum sensor_channel ch, const q31_t *value,
 			   int8_t shift);

--- a/include/zephyr/drivers/entropy.h
+++ b/include/zephyr/drivers/entropy.h
@@ -62,7 +62,7 @@ typedef int (*entropy_get_entropy_isr_t)(const struct device *dev,
  *
  * This is the mandatory API any Entropy driver needs to expose.
  */
-__subsystem struct entropy_driver_api {
+DEVICE_API struct entropy_driver_api {
 	entropy_get_entropy_t     get_entropy;
 	entropy_get_entropy_isr_t get_entropy_isr;
 };

--- a/include/zephyr/drivers/espi.h
+++ b/include/zephyr/drivers/espi.h
@@ -455,7 +455,7 @@ typedef int (*espi_api_manage_callback)(const struct device *dev,
 					struct espi_callback *callback,
 					bool set);
 
-__subsystem struct espi_driver_api {
+DEVICE_API struct espi_driver_api {
 	espi_api_config config;
 	espi_api_get_channel_status get_channel_status;
 	espi_api_read_request read_request;

--- a/include/zephyr/drivers/espi_saf.h
+++ b/include/zephyr/drivers/espi_saf.h
@@ -152,7 +152,7 @@ typedef int (*espi_saf_api_manage_callback)(const struct device *dev,
 					    struct espi_callback *callback,
 					    bool set);
 
-__subsystem struct espi_saf_driver_api {
+DEVICE_API struct espi_saf_driver_api {
 	espi_saf_api_config config;
 	espi_saf_api_set_protection_regions set_protection_regions;
 	espi_saf_api_activate activate;

--- a/include/zephyr/drivers/flash.h
+++ b/include/zephyr/drivers/flash.h
@@ -130,7 +130,7 @@ typedef int (*flash_api_read_jedec_id)(const struct device *dev, uint8_t *id);
 typedef int (*flash_api_ex_op)(const struct device *dev, uint16_t code,
 			       const uintptr_t in, void *out);
 
-__subsystem struct flash_driver_api {
+DEVICE_API struct flash_driver_api {
 	flash_api_read read;
 	flash_api_write write;
 	flash_api_erase erase;

--- a/include/zephyr/drivers/fpga.h
+++ b/include/zephyr/drivers/fpga.h
@@ -36,7 +36,7 @@ typedef int (*fpga_api_on)(const struct device *dev);
 typedef int (*fpga_api_off)(const struct device *dev);
 typedef const char *(*fpga_api_get_info)(const struct device *dev);
 
-__subsystem struct fpga_driver_api {
+DEVICE_API struct fpga_driver_api {
 	fpga_api_get_status get_status;
 	fpga_api_reset reset;
 	fpga_api_load load;

--- a/include/zephyr/drivers/fuel_gauge.h
+++ b/include/zephyr/drivers/fuel_gauge.h
@@ -236,7 +236,7 @@ typedef int (*fuel_gauge_battery_cutoff_t)(const struct device *dev);
 
 /* Caching is entirely on the onus of the client */
 
-__subsystem struct fuel_gauge_driver_api {
+DEVICE_API struct fuel_gauge_driver_api {
 	/**
 	 * Note: Historically this API allowed drivers to implement a custom multi-get/set property
 	 * function, this was added so drivers could potentially optimize batch read with their

--- a/include/zephyr/drivers/gnss.h
+++ b/include/zephyr/drivers/gnss.h
@@ -180,7 +180,7 @@ struct gnss_time {
 };
 
 /** GNSS API structure */
-__subsystem struct gnss_driver_api {
+DEVICE_API struct gnss_driver_api {
 	gnss_set_fix_rate_t set_fix_rate;
 	gnss_get_fix_rate_t get_fix_rate;
 	gnss_set_periodic_config_t set_periodic_config;

--- a/include/zephyr/drivers/gpio.h
+++ b/include/zephyr/drivers/gpio.h
@@ -789,7 +789,7 @@ enum gpio_int_trig {
 	GPIO_INT_TRIG_WAKE = GPIO_INT_WAKEUP,
 };
 
-__subsystem struct gpio_driver_api {
+DEVICE_API struct gpio_driver_api {
 	int (*pin_configure)(const struct device *port, gpio_pin_t pin,
 			     gpio_flags_t flags);
 #ifdef CONFIG_GPIO_GET_CONFIG

--- a/include/zephyr/drivers/hwspinlock.h
+++ b/include/zephyr/drivers/hwspinlock.h
@@ -49,7 +49,7 @@ typedef void (*hwspinlock_api_unlock)(const struct device *dev, uint32_t id);
  */
 typedef uint32_t (*hwspinlock_api_get_max_id)(const struct device *dev);
 
-__subsystem struct hwspinlock_driver_api {
+DEVICE_API struct hwspinlock_driver_api {
 	hwspinlock_api_trylock trylock;
 	hwspinlock_api_lock lock;
 	hwspinlock_api_unlock unlock;

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -241,7 +241,7 @@ typedef void (*i2c_api_iodev_submit)(const struct device *dev,
 
 typedef int (*i2c_api_recover_bus_t)(const struct device *dev);
 
-__subsystem struct i2c_driver_api {
+DEVICE_API struct i2c_driver_api {
 	i2c_api_configure_t configure;
 	i2c_api_get_config_t get_config;
 	i2c_api_full_io_t transfer;

--- a/include/zephyr/drivers/i2s.h
+++ b/include/zephyr/drivers/i2s.h
@@ -318,7 +318,7 @@ struct i2s_config {
  *
  * For internal use only, skip these in public documentation.
  */
-__subsystem struct i2s_driver_api {
+DEVICE_API struct i2s_driver_api {
 	int (*configure)(const struct device *dev, enum i2s_dir dir,
 			 const struct i2s_config *cfg);
 	const struct i2s_config *(*config_get)(const struct device *dev,

--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -575,7 +575,7 @@ struct i3c_device_id;
 struct i3c_i2c_device_desc;
 struct i3c_target_config;
 
-__subsystem struct i3c_driver_api {
+DEVICE_API struct i3c_driver_api {
 	/**
 	 * For backward compatibility to I2C API.
 	 *

--- a/include/zephyr/drivers/interrupt_controller/gicv3_its.h
+++ b/include/zephyr/drivers/interrupt_controller/gicv3_its.h
@@ -24,7 +24,7 @@ typedef int (*its_api_map_intid_t)(const struct device *dev, uint32_t device_id,
 typedef int (*its_api_send_int_t)(const struct device *dev, uint32_t device_id, uint32_t event_id);
 typedef uint32_t (*its_api_get_msi_addr_t)(const struct device *dev);
 
-__subsystem struct its_driver_api {
+DEVICE_API struct its_driver_api {
 	its_api_alloc_intid_t alloc_intid;
 	its_api_setup_deviceid_t setup_deviceid;
 	its_api_map_intid_t map_intid;

--- a/include/zephyr/drivers/ipm.h
+++ b/include/zephyr/drivers/ipm.h
@@ -97,7 +97,7 @@ typedef int (*ipm_set_enabled_t)(const struct device *ipmdev, int enable);
  */
 typedef void (*ipm_complete_t)(const struct device *ipmdev);
 
-__subsystem struct ipm_driver_api {
+DEVICE_API struct ipm_driver_api {
 	ipm_send_t send;
 	ipm_register_callback_t register_callback;
 	ipm_max_data_size_get_t max_data_size_get;

--- a/include/zephyr/drivers/kscan.h
+++ b/include/zephyr/drivers/kscan.h
@@ -59,7 +59,7 @@ typedef int (*kscan_config_t)(const struct device *dev,
 typedef int (*kscan_disable_callback_t)(const struct device *dev);
 typedef int (*kscan_enable_callback_t)(const struct device *dev);
 
-__subsystem struct kscan_driver_api {
+DEVICE_API struct kscan_driver_api {
 	kscan_config_t config;
 	kscan_disable_callback_t disable_callback;
 	kscan_enable_callback_t enable_callback;

--- a/include/zephyr/drivers/led.h
+++ b/include/zephyr/drivers/led.h
@@ -111,7 +111,7 @@ typedef int (*led_api_write_channels)(const struct device *dev,
 /**
  * @brief LED driver API
  */
-__subsystem struct led_driver_api {
+DEVICE_API struct led_driver_api {
 	/* Mandatory callbacks. */
 	led_api_on on;
 	led_api_off off;

--- a/include/zephyr/drivers/mbox.h
+++ b/include/zephyr/drivers/mbox.h
@@ -219,7 +219,7 @@ typedef int (*mbox_set_enabled_t)(const struct device *dev,
  */
 typedef uint32_t (*mbox_max_channels_get_t)(const struct device *dev);
 
-__subsystem struct mbox_driver_api {
+DEVICE_API struct mbox_driver_api {
 	mbox_send_t send;
 	mbox_register_callback_t register_callback;
 	mbox_mtu_get_t mtu_get;

--- a/include/zephyr/drivers/mdio.h
+++ b/include/zephyr/drivers/mdio.h
@@ -33,7 +33,7 @@ extern "C" {
  * These are for internal use only, so skip these in
  * public documentation.
  */
-__subsystem struct mdio_driver_api {
+DEVICE_API struct mdio_driver_api {
 	/** Enable the MDIO bus device */
 	void (*bus_enable)(const struct device *dev);
 

--- a/include/zephyr/drivers/mipi_dbi.h
+++ b/include/zephyr/drivers/mipi_dbi.h
@@ -122,7 +122,7 @@ struct mipi_dbi_config {
 
 
 /** MIPI-DBI host driver API */
-__subsystem struct mipi_dbi_driver_api {
+DEVICE_API struct mipi_dbi_driver_api {
 	int (*command_write)(const struct device *dev,
 			     const struct mipi_dbi_config *config, uint8_t cmd,
 			     const uint8_t *data, size_t len);

--- a/include/zephyr/drivers/mipi_dsi.h
+++ b/include/zephyr/drivers/mipi_dsi.h
@@ -119,7 +119,7 @@ struct mipi_dsi_msg {
 };
 
 /** MIPI-DSI host driver API. */
-__subsystem struct mipi_dsi_driver_api {
+DEVICE_API struct mipi_dsi_driver_api {
 	int (*attach)(const struct device *dev, uint8_t channel,
 		      const struct mipi_dsi_device *mdev);
 	ssize_t (*transfer)(const struct device *dev, uint8_t channel,

--- a/include/zephyr/drivers/misc/timeaware_gpio/timeaware_gpio.h
+++ b/include/zephyr/drivers/misc/timeaware_gpio/timeaware_gpio.h
@@ -49,7 +49,7 @@ enum tgpio_pin_polarity {
  * (Internal use only.)
  */
 
-__subsystem struct tgpio_driver_api {
+DEVICE_API struct tgpio_driver_api {
 	int (*pin_disable)(const struct device *dev, uint32_t pin);
 	int (*get_time)(const struct device *dev, uint64_t *current_time);
 	int (*cyc_per_sec)(const struct device *dev, uint32_t *cycles);

--- a/include/zephyr/drivers/pcie/controller.h
+++ b/include/zephyr/drivers/pcie/controller.h
@@ -171,7 +171,7 @@ void pcie_generic_ctrl_enumerate(const struct device *dev, pcie_bdf_t bdf_start)
 /** @brief Structure providing callbacks to be implemented for devices
  * that supports the PCI Express Controller API
  */
-__subsystem struct pcie_ctrl_driver_api {
+DEVICE_API struct pcie_ctrl_driver_api {
 	pcie_ctrl_conf_read_t conf_read;
 	pcie_ctrl_conf_write_t conf_write;
 	pcie_ctrl_region_allocate_t region_allocate;

--- a/include/zephyr/drivers/peci.h
+++ b/include/zephyr/drivers/peci.h
@@ -251,7 +251,7 @@ typedef int (*peci_transfer_t)(const struct device *dev, struct peci_msg *msg);
 typedef int (*peci_disable_t)(const struct device *dev);
 typedef int (*peci_enable_t)(const struct device *dev);
 
-__subsystem struct peci_driver_api {
+DEVICE_API struct peci_driver_api {
 	peci_config_t config;
 	peci_disable_t disable;
 	peci_enable_t enable;

--- a/include/zephyr/drivers/ps2.h
+++ b/include/zephyr/drivers/ps2.h
@@ -52,7 +52,7 @@ typedef int (*ps2_write_t)(const struct device *dev, uint8_t value);
 typedef int (*ps2_disable_callback_t)(const struct device *dev);
 typedef int (*ps2_enable_callback_t)(const struct device *dev);
 
-__subsystem struct ps2_driver_api {
+DEVICE_API struct ps2_driver_api {
 	ps2_config_t config;
 	ps2_read_t read;
 	ps2_write_t write;

--- a/include/zephyr/drivers/ptp_clock.h
+++ b/include/zephyr/drivers/ptp_clock.h
@@ -22,7 +22,7 @@ extern "C" {
 #define PTP_CLOCK_NAME "PTP_CLOCK"
 #endif
 
-__subsystem struct ptp_clock_driver_api {
+DEVICE_API struct ptp_clock_driver_api {
 	int (*set)(const struct device *dev, struct net_ptp_time *tm);
 	int (*get)(const struct device *dev, struct net_ptp_time *tm);
 	int (*adjust)(const struct device *dev, int increment);

--- a/include/zephyr/drivers/pwm.h
+++ b/include/zephyr/drivers/pwm.h
@@ -435,7 +435,7 @@ typedef int (*pwm_disable_capture_t)(const struct device *dev,
 #endif /* CONFIG_PWM_CAPTURE */
 
 /** @brief PWM driver API definition. */
-__subsystem struct pwm_driver_api {
+DEVICE_API struct pwm_driver_api {
 	pwm_set_cycles_t set_cycles;
 	pwm_get_cycles_per_sec_t get_cycles_per_sec;
 #ifdef CONFIG_PWM_CAPTURE

--- a/include/zephyr/drivers/regulator.h
+++ b/include/zephyr/drivers/regulator.h
@@ -65,7 +65,7 @@ typedef int (*regulator_dvs_state_set_t)(const struct device *dev,
 typedef int (*regulator_ship_mode_t)(const struct device *dev);
 
 /** @brief Driver-specific API functions to support parent regulator control. */
-__subsystem struct regulator_parent_driver_api {
+DEVICE_API struct regulator_parent_driver_api {
 	regulator_dvs_state_set_t dvs_state_set;
 	regulator_ship_mode_t ship_mode;
 };
@@ -98,7 +98,7 @@ typedef int (*regulator_get_error_flags_t)(
 	const struct device *dev, regulator_error_flags_t *flags);
 
 /** @brief Driver-specific API functions to support regulator control. */
-__subsystem struct regulator_driver_api {
+DEVICE_API struct regulator_driver_api {
 	regulator_enable_t enable;
 	regulator_disable_t disable;
 	regulator_count_voltages_t count_voltages;

--- a/include/zephyr/drivers/reset.h
+++ b/include/zephyr/drivers/reset.h
@@ -139,7 +139,7 @@ typedef int (*reset_api_line_toggle)(const struct device *dev, uint32_t id);
 /**
  * @brief Reset Controller driver API
  */
-__subsystem struct reset_driver_api {
+DEVICE_API struct reset_driver_api {
 	reset_api_status status;
 	reset_api_line_assert line_assert;
 	reset_api_line_deassert line_deassert;

--- a/include/zephyr/drivers/retained_mem.h
+++ b/include/zephyr/drivers/retained_mem.h
@@ -77,7 +77,7 @@ typedef int (*retained_mem_clear_api)(const struct device *dev);
  *
  * Note that drivers must implement all functions, none of the functions are optional.
  */
-__subsystem struct retained_mem_driver_api {
+DEVICE_API struct retained_mem_driver_api {
 	retained_mem_size_api size;
 	retained_mem_read_api read;
 	retained_mem_write_api write;

--- a/include/zephyr/drivers/rtc.h
+++ b/include/zephyr/drivers/rtc.h
@@ -164,7 +164,7 @@ typedef int (*rtc_api_get_calibration)(const struct device *dev, int32_t *calibr
 /**
  * @brief RTC driver API
  */
-__subsystem struct rtc_driver_api {
+DEVICE_API struct rtc_driver_api {
 	rtc_api_set_time set_time;
 	rtc_api_get_time get_time;
 #if defined(CONFIG_RTC_ALARM) || defined(__DOXYGEN__)

--- a/include/zephyr/drivers/sdhc.h
+++ b/include/zephyr/drivers/sdhc.h
@@ -256,7 +256,7 @@ enum sdhc_interrupt_source {
 typedef void (*sdhc_interrupt_cb_t)(const struct device *dev, int reason,
 				    const void *user_data);
 
-__subsystem struct sdhc_driver_api {
+DEVICE_API struct sdhc_driver_api {
 	int (*reset)(const struct device *dev);
 	int (*request)(const struct device *dev,
 		       struct sdhc_command *cmd,

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -661,7 +661,7 @@ extern const struct sensor_decoder_api __sensor_default_decoder;
 /* The default sensor iodev API */
 extern const struct rtio_iodev_api __sensor_iodev_api;
 
-__subsystem struct sensor_driver_api {
+DEVICE_API struct sensor_driver_api {
 	sensor_attr_set_t attr_set;
 	sensor_attr_get_t attr_get;
 	sensor_trigger_set_t trigger_set;

--- a/include/zephyr/drivers/sip_svc/sip_svc_driver.h
+++ b/include/zephyr/drivers/sip_svc/sip_svc_driver.h
@@ -91,7 +91,7 @@ typedef uint32_t (*sip_svc_plat_get_error_code_t)(const struct device *dev,
  * @brief  API structure for sip_svc driver.
  *
  */
-__subsystem struct svc_driver_api {
+DEVICE_API struct svc_driver_api {
 	sip_supervisory_call_t sip_supervisory_call;
 	sip_svc_plat_func_id_valid_t sip_svc_plat_func_id_valid;
 	sip_svc_plat_format_trans_id_t sip_svc_plat_format_trans_id;

--- a/include/zephyr/drivers/smbus.h
+++ b/include/zephyr/drivers/smbus.h
@@ -378,7 +378,7 @@ typedef int (*smbus_api_smbalert_cb_t)(const struct device *dev,
 typedef int (*smbus_api_host_notify_cb_t)(const struct device *dev,
 					  struct smbus_callback *cb);
 
-__subsystem struct smbus_driver_api {
+DEVICE_API struct smbus_driver_api {
 	smbus_api_configure_t configure;
 	smbus_api_get_config_t get_config;
 	smbus_api_quick_t smbus_quick;

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -648,7 +648,7 @@ typedef int (*spi_api_release)(const struct device *dev,
  * @brief SPI driver API
  * This is the mandatory API any SPI driver needs to expose.
  */
-__subsystem struct spi_driver_api {
+DEVICE_API struct spi_driver_api {
 	spi_api_io transceive;
 #ifdef CONFIG_SPI_ASYNC
 	spi_api_io_async transceive_async;

--- a/include/zephyr/drivers/syscon.h
+++ b/include/zephyr/drivers/syscon.h
@@ -59,7 +59,7 @@ typedef int (*syscon_api_get_size)(const struct device *dev, size_t *size);
 /**
  * @brief System Control (syscon) register driver API
  */
-__subsystem struct syscon_driver_api {
+DEVICE_API struct syscon_driver_api {
 	syscon_api_read_reg read;
 	syscon_api_write_reg write;
 	syscon_api_get_base get_base;

--- a/include/zephyr/drivers/uart.h
+++ b/include/zephyr/drivers/uart.h
@@ -335,7 +335,7 @@ typedef void (*uart_callback_t)(const struct device *dev,
  */
 
 /** @brief Driver API structure. */
-__subsystem struct uart_driver_api {
+DEVICE_API struct uart_driver_api {
 
 #ifdef CONFIG_UART_ASYNC_API
 

--- a/include/zephyr/drivers/usb/emul_bc12.h
+++ b/include/zephyr/drivers/usb/emul_bc12.h
@@ -31,7 +31,7 @@ extern "C" {
  *
  * These are for internal use only, so skip these in public documentation.
  */
-__subsystem struct bc12_emul_driver_api {
+DEVICE_API struct bc12_emul_driver_api {
 	int (*set_charging_partner)(const struct emul *emul, enum bc12_type partner_type);
 	int (*set_pd_partner)(const struct emul *emul, bool connected);
 };

--- a/include/zephyr/drivers/usb/usb_bc12.h
+++ b/include/zephyr/drivers/usb/usb_bc12.h
@@ -130,7 +130,7 @@ typedef void (*bc12_callback_t)(const struct device *dev, struct bc12_partner_st
  *
  * These are for internal use only, so skip these in public documentation.
  */
-__subsystem struct bc12_driver_api {
+DEVICE_API struct bc12_driver_api {
 	int (*set_role)(const struct device *dev, enum bc12_role role);
 	int (*set_result_cb)(const struct device *dev, bc12_callback_t cb, void *user_data);
 };

--- a/include/zephyr/drivers/usb_c/usbc_ppc.h
+++ b/include/zephyr/drivers/usb_c/usbc_ppc.h
@@ -50,7 +50,7 @@ enum usbc_ppc_event {
 typedef void (*usbc_ppc_event_cb_t)(const struct device *dev, void *data, enum usbc_ppc_event ev);
 
 /** Structure with pointers to the functions implemented by driver */
-__subsystem struct usbc_ppc_drv {
+DEVICE_API struct usbc_ppc_drv {
 	int (*is_dead_battery_mode)(const struct device *dev);
 	int (*exit_dead_battery_mode)(const struct device *dev);
 	int (*is_vbus_source)(const struct device *dev);

--- a/include/zephyr/drivers/usb_c/usbc_tcpc.h
+++ b/include/zephyr/drivers/usb_c/usbc_tcpc.h
@@ -125,7 +125,7 @@ typedef	int (*tcpc_vconn_discharge_cb_t)(const struct device *dev,
 typedef void (*tcpc_alert_handler_cb_t)(const struct device *dev, void *data,
 		enum tcpc_alert alert);
 
-__subsystem struct tcpc_driver_api {
+DEVICE_API struct tcpc_driver_api {
 	int (*init)(const struct device *dev);
 	int (*get_cc)(const struct device *dev, enum tc_cc_voltage_state *cc1,
 			enum tc_cc_voltage_state *cc2);

--- a/include/zephyr/drivers/virtualization/ivshmem.h
+++ b/include/zephyr/drivers/virtualization/ivshmem.h
@@ -64,7 +64,7 @@ typedef int (*ivshmem_enable_interrupts_f)(const struct device *dev,
 
 #endif /* CONFIG_IVSHMEM_V2 */
 
-__subsystem struct ivshmem_driver_api {
+DEVICE_API struct ivshmem_driver_api {
 	ivshmem_get_mem_f get_mem;
 	ivshmem_get_id_f get_id;
 	ivshmem_get_vectors_f get_vectors;

--- a/include/zephyr/drivers/w1.h
+++ b/include/zephyr/drivers/w1.h
@@ -97,7 +97,7 @@ typedef int (*w1_configure_t)(const struct device *dev,
 			      enum w1_settings_type type, uint32_t value);
 typedef int (*w1_change_bus_lock_t)(const struct device *dev, bool lock);
 
-__subsystem struct w1_driver_api {
+DEVICE_API struct w1_driver_api {
 	w1_reset_bus_t reset_bus;
 	w1_read_bit_t read_bit;
 	w1_write_bit_t write_bit;

--- a/include/zephyr/drivers/watchdog.h
+++ b/include/zephyr/drivers/watchdog.h
@@ -133,7 +133,7 @@ typedef int (*wdt_api_install_timeout)(const struct device *dev,
  */
 typedef int (*wdt_api_feed)(const struct device *dev, int channel_id);
 
-__subsystem struct wdt_driver_api {
+DEVICE_API struct wdt_driver_api {
 	wdt_api_setup setup;
 	wdt_api_disable disable;
 	wdt_api_install_timeout install_timeout;

--- a/include/zephyr/mgmt/ec_host_cmd/backend.h
+++ b/include/zephyr/mgmt/ec_host_cmd/backend.h
@@ -103,7 +103,7 @@ typedef int (*ec_host_cmd_backend_api_init)(const struct ec_host_cmd_backend *ba
  */
 typedef int (*ec_host_cmd_backend_api_send)(const struct ec_host_cmd_backend *backend);
 
-__subsystem struct ec_host_cmd_backend_api {
+DEVICE_API struct ec_host_cmd_backend_api {
 	ec_host_cmd_backend_api_init init;
 	ec_host_cmd_backend_api_send send;
 };

--- a/include/zephyr/net/phy.h
+++ b/include/zephyr/net/phy.h
@@ -73,7 +73,7 @@ typedef void (*phy_callback_t)(const struct device *dev,
  * These are for internal use only, so skip these in
  * public documentation.
  */
-__subsystem struct ethphy_driver_api {
+DEVICE_API struct ethphy_driver_api {
 	/** Get link state */
 	int (*get_link)(const struct device *dev,
 			struct phy_link_state *state);

--- a/include/zephyr/toolchain/common.h
+++ b/include/zephyr/toolchain/common.h
@@ -160,7 +160,7 @@
  */
 
 /* Indicates this is a driver subsystem */
-#define __subsystem
+#define __subsystem __DEPRECATED_MACRO
 
 /* Indicates this is a network socket object */
 #define __net_socket

--- a/samples/userspace/prod_consumer/src/sample_driver.h
+++ b/samples/userspace/prod_consumer/src/sample_driver.h
@@ -24,7 +24,7 @@ typedef int (*sample_driver_set_callback_t)(const struct device *dev,
 typedef int (*sample_driver_state_set_t)(const struct device *dev,
 					 bool active);
 
-__subsystem struct sample_driver_api {
+DEVICE_API struct sample_driver_api {
 	sample_driver_write_t write;
 	sample_driver_set_callback_t set_callback;
 	sample_driver_state_set_t state_set;

--- a/scripts/build/gen_kobject_list.py
+++ b/scripts/build/gen_kobject_list.py
@@ -125,7 +125,7 @@ def kobject_to_enum(kobj):
 
     return "K_OBJ_%s" % name.upper()
 
-# Names of all structs tagged with __subsystem, found by parse_syscalls.py
+# Names of all structs tagged with __subsystem or DEVICE_API, found by parse_syscalls.py
 subsystems = [ ]
 
 # Names of all structs tagged with __net_socket, found by parse_syscalls.py
@@ -969,6 +969,7 @@ def parse_subsystems_list_file(path):
     with open(path, "r") as fp:
         subsys_list = json.load(fp)
     subsystems.extend(subsys_list["__subsystem"])
+    subsystems.extend(subsys_list["DEVICE_API"])
     net_sockets.extend(subsys_list["__net_socket"])
 
 def parse_args():

--- a/scripts/build/gen_kobject_list.py
+++ b/scripts/build/gen_kobject_list.py
@@ -125,14 +125,8 @@ def kobject_to_enum(kobj):
 
     return "K_OBJ_%s" % name.upper()
 
-subsystems = [
-    # Editing the list is deprecated, add the __subsystem sentinel to your driver
-    # api declaration instead. e.x.
-    #
-    # __subsystem struct my_driver_api {
-    #    ....
-    #};
-]
+# Names of all structs tagged with __subsystem, found by parse_syscalls.py
+subsystems = [ ]
 
 # Names of all structs tagged with __net_socket, found by parse_syscalls.py
 net_sockets = [ ]

--- a/scripts/build/parse_syscalls.py
+++ b/scripts/build/parse_syscalls.py
@@ -14,8 +14,8 @@ C or header files, and building up a database of system calls and their
 function call prototypes. This information is emitted to a generated
 JSON file for further processing.
 
-This script also scans for struct definitions such as __subsystem and
-__net_socket, emitting a JSON dictionary mapping tags to all the struct
+This script also scans for struct definitions such as __subsystem, DEVICE_API,
+and __net_socket, emitting a JSON dictionary mapping tags to all the struct
 declarations found that were tagged with them.
 
 If the output JSON file already exists, its contents are checked against
@@ -41,7 +41,7 @@ syscall_regex = re.compile(r'''
 [)]                                        # Closing parenthesis
 ''', regex_flags)
 
-struct_tags = ["__subsystem", "__net_socket"]
+struct_tags = ["__subsystem", "DEVICE_API", "__net_socket"]
 
 tagged_struct_decl_template = r'''
 %s\s+                           # tag, must be first


### PR DESCRIPTION
Introduce a new tag for device API structs: DEVICE_API. Until now,
__subsystem has been used, however, the name is misleading as devices have nothing to do with subsystems.

An alternative I've considered, which would require some more changes:

```c
/* device.h */
#define DEVICE_API(class) struct class##_device_api
#define DEVICE_API_GET(dev, class) ((const DEVICE_API(class) *)(dev)->api)
...

/* drivers/i2c.h */
DEVICE_API(i2c) {
    i2c_op_1_t op1;
    ....
};


int i2c_op1(const struct device *dev)
{
    const DEVICE_API(i2c) *api = DEVICE_API_GET(dev, i2c);
    
    return api->op1(dev);
}
```