### PR TITLE
gitlint: do not allow treewide as an area in commit messages

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -26,7 +26,7 @@ extra-path=scripts/gitlint
 # max-line-count=200
 
 [title-starts-with-subsystem]
-regex = ^(?!subsys:)(([^:]+):)(\s([^:]+):)*\s(.+)$
+regex = ^(?!subsys:)(?!treewide:)(([^:]+):)(\s([^:]+):)*\s(.+)$
 
 [title-must-not-contain-word]
 # Comma-separated list of words that should not occur in the title. Matching is case

--- a/scripts/ci/twister_ignore.txt
+++ b/scripts/ci/twister_ignore.txt
@@ -45,3 +45,4 @@ scripts/checkpatch.pl
 scripts/ci/pylintrc
 scripts/footprint/*
 scripts/set_assignees.py
+scripts/gitlint/zephyr_commit_rules.py

--- a/scripts/gitlint/zephyr_commit_rules.py
+++ b/scripts/gitlint/zephyr_commit_rules.py
@@ -95,7 +95,7 @@ class TitleStartsWithSubsystem(LineRule):
     def validate(self, title, _commit):
         regex = self.options['regex'].value
         pattern = re.compile(regex, re.UNICODE)
-        violation_message = "Commit title does not follow [subsystem]: [subject] (and should not start with literal subsys:)"
+        violation_message = "Commit title does not follow [subsystem]: [subject] (and should not start with literal subsys or treewide)"
         if not pattern.search(title):
             return [RuleViolation(self.id, violation_message, title)]
 


### PR DESCRIPTION
Treewide changes touching a single area or topic should have the
area/subsystem at the start of the commit message. Treewide is very
ambigous.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
