### PR TITLE
Tests: i2s: add support for STM32H5 family

### DIFF
--- a/drivers/dma/dma_stm32u5.c
+++ b/drivers/dma/dma_stm32u5.c
@@ -544,11 +544,9 @@ static int dma_stm32_reload(const struct device *dev, uint32_t id,
 				src, dst);
 
 	if (stream->source_periph) {
-		LL_DMA_SetBlkDataLength(dma, dma_stm32_id_to_stream(id),
-				     size / stream->src_size);
+		LL_DMA_SetBlkDataLength(dma, dma_stm32_id_to_stream(id), size);
 	} else {
-		LL_DMA_SetBlkDataLength(dma, dma_stm32_id_to_stream(id),
-				     size / stream->dst_size);
+		LL_DMA_SetBlkDataLength(dma, dma_stm32_id_to_stream(id), size);
 	}
 
 	/* When reloading the dma, the stream is busy again before enabling */

--- a/drivers/i2s/i2s_ll_stm32.c
+++ b/drivers/i2s/i2s_ll_stm32.c
@@ -174,9 +174,6 @@ static int i2s_stm32_configure(const struct device *dev, enum i2s_dir dir,
 	int ret;
 
 	if (dir == I2S_DIR_RX) {
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_i2s)
-		return -ENOSYS;
-#endif
 		stream = &dev_data->rx;
 	} else if (dir == I2S_DIR_TX) {
 		stream = &dev_data->tx;
@@ -652,11 +649,6 @@ static uint32_t i2s_stm32_irq_udr_count;
 static void i2s_stm32_isr(const struct device *dev)
 {
 	const struct i2s_stm32_cfg *cfg = dev->config;
-	struct i2s_stm32_data *const dev_data = dev->data;
-	struct stream *stream = &dev_data->rx;
-
-	LOG_ERR("%s: err=%d", __func__, (int)LL_I2S_ReadReg(cfg->i2s, SR));
-	stream->state = I2S_STATE_ERROR;
 
 	/* OVR error must be explicitly cleared */
 	if (LL_I2S_IsActiveFlag_OVR(cfg->i2s)) {

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -491,6 +491,48 @@
 			status = "disabled";
 		};
 
+		i2s1: i2s@40013000 {
+			compatible = "st,stm32h7-i2s", "st,stm32-i2s";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40013000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00001000>,
+				<&rcc STM32_SRC_PLL1_Q SPI1_SEL(0)>;
+			dmas = <&gpdma1 0 7 STM32_DMA_PERIPH_TX
+				&gpdma1 1 6 STM32_DMA_PERIPH_RX>;
+			dma-names = "tx", "rx";
+			interrupts = <55 3>;
+			status = "disabled";
+		};
+
+		i2s2: i2s@40003800 {
+			compatible = "st,stm32h7-i2s", "st,stm32-i2s";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40003800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00004000>,
+				<&rcc STM32_SRC_PLL1_Q SPI2_SEL(0)>;
+			dmas = <&gpdma1 0 9 STM32_DMA_PERIPH_TX
+				&gpdma1 1 8 STM32_DMA_PERIPH_RX>;
+			dma-names = "tx", "rx";
+			interrupts = <56 3>;
+			status = "disabled";
+		};
+
+		i2s3: i2s@40003c00 {
+			compatible = "st,stm32h7-i2s", "st,stm32-i2s";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40003c00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00008000>,
+				<&rcc STM32_SRC_PLL1_Q SPI3_SEL(0)>;
+			dmas = <&gpdma1 0 11 STM32_DMA_PERIPH_TX
+				&gpdma1 1 10 STM32_DMA_PERIPH_RX>;
+			dma-names = "tx", "rx";
+			interrupts = <57 3>;
+			status = "disabled";
+		};
+
 		usb: usb@40016000 {
 			compatible = "st,stm32-usb";
 			reg = <0x40016000 0x400>;

--- a/tests/drivers/i2s/i2s_speed/boards/stm32h573i_dk.conf
+++ b/tests/drivers/i2s/i2s_speed/boards/stm32h573i_dk.conf
@@ -1,0 +1,6 @@
+#
+# Copyright (c) 2024 STMicroelectronics
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+CONFIG_I2S_TEST_SEPARATE_DEVICES=y

--- a/tests/drivers/i2s/i2s_speed/boards/stm32h573i_dk.overlay
+++ b/tests/drivers/i2s/i2s_speed/boards/stm32h573i_dk.overlay
@@ -1,0 +1,74 @@
+/* i2s-node0 is the receiver    */
+/* i2s-node1 is the transmitter */
+/ {
+	aliases {
+		i2s-node0 = &i2s1;
+		i2s-node1 = &i2s2;
+	};
+};
+
+&pll1 {
+	div-m = <5>;
+	mul-n = <64>;
+	div-p = <2>;
+	div-q = <4>;
+	div-r = <2>;
+	clocks = <&clk_hse>;
+	status = "okay";
+};
+
+&i2s1 {
+	pinctrl-0 = <&i2s1_ws_pa4 &i2s1_ck_pa5 &spi1_miso_pa6 &spi1_mosi_pb5>;
+	pinctrl-names = "default";
+	interrupts = <55 3>;
+	dmas = <&gpdma1 0 7 STM32_DMA_PERIPH_TX
+		&gpdma1 1 6 (STM32_DMA_PERIPH_RX | STM32_DMA_MEM_INC | STM32_DMA_PERIPH_16BITS | \
+			STM32_DMA_MEM_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+	dma-names = "tx", "rx";
+	status = "okay";
+};
+
+&i2s2 {
+	pinctrl-0 = <&i2s2_ws_pa3 &i2s2_ck_pi1 &spi2_miso_pi2 &spi2_mosi_pb15>;
+	pinctrl-names = "default";
+	interrupts = <56 3>;
+	dmas = <&gpdma1 2 9 (STM32_DMA_PERIPH_TX | STM32_DMA_MEM_INC | STM32_DMA_PERIPH_16BITS | \
+			STM32_DMA_MEM_16BITS | STM32_DMA_PRIORITY_HIGH)
+		&gpdma1 3 8 STM32_DMA_PERIPH_RX>;
+	dma-names = "tx", "rx";
+	status = "okay";
+};
+
+&i2s3 {
+	pinctrl-0 = <&i2s3_ws_pa15 &i2s3_ck_pb3 &spi3_miso_pb4 &spi3_mosi_pc12>;
+	pinctrl-names = "default";
+	interrupts = <57 3>;
+	dmas = <&gpdma1 4 11 (STM32_DMA_PERIPH_TX  | STM32_DMA_MEM_INC | STM32_DMA_PERIPH_16BITS \
+			| STM32_DMA_MEM_16BITS | STM32_DMA_PRIORITY_HIGH)
+		&gpdma1 5 10 STM32_DMA_PERIPH_RX>;
+	dma-names = "tx", "rx";
+	status = "disabled";
+};
+
+&spi1 {
+	status = "disabled";
+};
+
+&spi2 {
+	status = "disabled";
+};
+
+&spi3 {
+	status = "disabled";
+};
+
+/* DMA Tx interrupt 0 has a higher Prio than Rx Dma interrupt 1 */
+&gpdma1 {
+	interrupts = <27 1 28 2 29 1 30 1 31 1 32 1 33 1 34 1>;
+	status = "okay";
+};
+
+&gpdma2 {
+	interrupts = <90 1 91 1 92 1 93 1 94 1 95 1 96 1 97 1>;
+	status = "okay";
+};


### PR DESCRIPTION
add the STM32H5 family support for the test I2s_speed