### PR TITLE
sensors: Add channel specifiers

### DIFF
--- a/drivers/sensor/amd_sb_tsi/sb_tsi_emul.c
+++ b/drivers/sensor/amd_sb_tsi/sb_tsi_emul.c
@@ -99,7 +99,7 @@ static int sb_tsi_emul_init(const struct emul *target, const struct device *pare
 	return 0;
 }
 
-static int sb_tsi_emul_set_channel(const struct emul *target, enum sensor_channel chan,
+static int sb_tsi_emul_set_channel(const struct emul *target, struct sensor_chan_spec ch,
 				   const q31_t *value, int8_t shift)
 {
 	struct sb_tsi_emul_data *data = target->data;
@@ -107,7 +107,7 @@ static int sb_tsi_emul_set_channel(const struct emul *target, enum sensor_channe
 	int32_t millicelsius;
 	int32_t reg_value;
 
-	if (chan != SENSOR_CHAN_AMBIENT_TEMP) {
+	if (ch.chan_type != SENSOR_CHAN_AMBIENT_TEMP && ch.chan_idx != 0) {
 		return -ENOTSUP;
 	}
 
@@ -121,10 +121,10 @@ static int sb_tsi_emul_set_channel(const struct emul *target, enum sensor_channe
 	return 0;
 }
 
-static int sb_tsi_emul_get_sample_range(const struct emul *target, enum sensor_channel chan,
+static int sb_tsi_emul_get_sample_range(const struct emul *target, struct sensor_chan_spec ch,
 					q31_t *lower, q31_t *upper, q31_t *epsilon, int8_t *shift)
 {
-	if (chan != SENSOR_CHAN_AMBIENT_TEMP) {
+	if (ch.chan_type != SENSOR_CHAN_AMBIENT_TEMP || ch.chan_idx != 0) {
 		return -ENOTSUP;
 	}
 

--- a/drivers/sensor/asahi_kasei/akm09918c/akm09918c_decoder.c
+++ b/drivers/sensor/asahi_kasei/akm09918c/akm09918c_decoder.c
@@ -5,22 +5,22 @@
 
 #include "akm09918c.h"
 
-static int akm09918c_decoder_get_frame_count(const uint8_t *buffer, enum sensor_channel channel,
-					     size_t channel_idx, uint16_t *frame_count)
+static int akm09918c_decoder_get_frame_count(const uint8_t *buffer,
+					     struct sensor_chan_spec chan_spec,
+					     uint16_t *frame_count)
 {
 	ARG_UNUSED(buffer);
-	ARG_UNUSED(channel);
-	ARG_UNUSED(channel_idx);
+	ARG_UNUSED(chan_spec);
 
 	/* This sensor lacks a FIFO; there will always only be one frame at a time. */
 	*frame_count = 1;
 	return 0;
 }
 
-static int akm09918c_decoder_get_size_info(enum sensor_channel channel, size_t *base_size,
+static int akm09918c_decoder_get_size_info(struct sensor_chan_spec chan_spec, size_t *base_size,
 					   size_t *frame_size)
 {
-	switch (channel) {
+	switch (chan_spec.chan_type) {
 	case SENSOR_CHAN_MAGN_X:
 	case SENSOR_CHAN_MAGN_Y:
 	case SENSOR_CHAN_MAGN_Z:
@@ -48,9 +48,8 @@ static int akm09918c_convert_raw_to_q31(int16_t reading, q31_t *out)
 	return 0;
 }
 
-static int akm09918c_decoder_decode(const uint8_t *buffer, enum sensor_channel channel,
-				    size_t channel_idx, uint32_t *fit,
-				    uint16_t max_count, void *data_out)
+static int akm09918c_decoder_decode(const uint8_t *buffer, struct sensor_chan_spec chan_spec,
+				    uint32_t *fit, uint16_t max_count, void *data_out)
 {
 	const struct akm09918c_encoded_data *edata = (const struct akm09918c_encoded_data *)buffer;
 
@@ -58,7 +57,7 @@ static int akm09918c_decoder_decode(const uint8_t *buffer, enum sensor_channel c
 		return 0;
 	}
 
-	switch (channel) {
+	switch (chan_spec.chan_type) {
 	case SENSOR_CHAN_MAGN_X:
 	case SENSOR_CHAN_MAGN_Y:
 	case SENSOR_CHAN_MAGN_Z:

--- a/drivers/sensor/asahi_kasei/akm09918c/akm09918c_emul.c
+++ b/drivers/sensor/asahi_kasei/akm09918c/akm09918c_emul.c
@@ -133,7 +133,7 @@ static int akm09918c_emul_init(const struct emul *target, const struct device *p
 	return 0;
 }
 
-static int akm09918c_emul_backend_set_channel(const struct emul *target, enum sensor_channel ch,
+static int akm09918c_emul_backend_set_channel(const struct emul *target, struct sensor_chan_spec ch,
 					      const q31_t *value, int8_t shift)
 {
 	if (!target || !target->data) {
@@ -143,7 +143,7 @@ static int akm09918c_emul_backend_set_channel(const struct emul *target, enum se
 	struct akm09918c_emul_data *data = target->data;
 	uint8_t reg;
 
-	switch (ch) {
+	switch (ch.chan_type) {
 	case SENSOR_CHAN_MAGN_X:
 		reg = AKM09918C_REG_HXL;
 		break;
@@ -178,7 +178,7 @@ static int akm09918c_emul_backend_set_channel(const struct emul *target, enum se
 }
 
 static int akm09918c_emul_backend_get_sample_range(const struct emul *target,
-						   enum sensor_channel ch, q31_t *lower,
+						   struct sensor_chan_spec ch, q31_t *lower,
 						   q31_t *upper, q31_t *epsilon, int8_t *shift)
 {
 	ARG_UNUSED(target);
@@ -187,7 +187,7 @@ static int akm09918c_emul_backend_get_sample_range(const struct emul *target,
 		return -EINVAL;
 	}
 
-	switch (ch) {
+	switch (ch.chan_type) {
 	case SENSOR_CHAN_MAGN_X:
 	case SENSOR_CHAN_MAGN_Y:
 	case SENSOR_CHAN_MAGN_Z:

--- a/drivers/sensor/bosch/bma4xx/bma4xx_emul.c
+++ b/drivers/sensor/bosch/bma4xx/bma4xx_emul.c
@@ -216,7 +216,7 @@ void bma4xx_emul_set_accel_data(const struct emul *target, q31_t value, int8_t s
 	data->regs[reg + 1] = FIELD_GET(GENMASK(11, 4), reg_val);
 }
 
-static int bma4xx_emul_backend_set_channel(const struct emul *target, enum sensor_channel ch,
+static int bma4xx_emul_backend_set_channel(const struct emul *target, struct sensor_chan_spec ch,
 					   const q31_t *value, int8_t shift)
 {
 
@@ -226,7 +226,7 @@ static int bma4xx_emul_backend_set_channel(const struct emul *target, enum senso
 
 	struct bma4xx_emul_data *data = target->data;
 
-	switch (ch) {
+	switch (ch.chan_type) {
 	case SENSOR_CHAN_ACCEL_X:
 		bma4xx_emul_set_accel_data(target, value[0], shift, BMA4XX_REG_DATA_8);
 		break;
@@ -250,15 +250,15 @@ static int bma4xx_emul_backend_set_channel(const struct emul *target, enum senso
 	return 0;
 }
 
-static int bma4xx_emul_backend_get_sample_range(const struct emul *target, enum sensor_channel ch,
-						q31_t *lower, q31_t *upper, q31_t *epsilon,
-						int8_t *shift)
+static int bma4xx_emul_backend_get_sample_range(const struct emul *target,
+						struct sensor_chan_spec ch, q31_t *lower,
+						q31_t *upper, q31_t *epsilon, int8_t *shift)
 {
 	if (!lower || !upper || !epsilon || !shift) {
 		return -EINVAL;
 	}
 
-	switch (ch) {
+	switch (ch.chan_type) {
 	case SENSOR_CHAN_ACCEL_X:
 	case SENSOR_CHAN_ACCEL_Y:
 	case SENSOR_CHAN_ACCEL_Z:

--- a/drivers/sensor/bosch/bmi160/emul_bmi160.c
+++ b/drivers/sensor/bosch/bmi160/emul_bmi160.c
@@ -279,7 +279,7 @@ static struct i2c_emul_api bmi160_emul_api_i2c = {
 };
 #endif
 
-static int bmi160_emul_backend_set_channel(const struct emul *target, enum sensor_channel ch,
+static int bmi160_emul_backend_set_channel(const struct emul *target, struct sensor_chan_spec ch,
 					   const q31_t *value, int8_t shift)
 {
 	const struct bmi160_emul_cfg *cfg = target->cfg;
@@ -288,11 +288,11 @@ static int bmi160_emul_backend_set_channel(const struct emul *target, enum senso
 	int8_t scale_shift = 0;
 	int reg_lsb;
 
-	switch (ch) {
+	switch (ch.chan_type) {
 	case SENSOR_CHAN_ACCEL_X:
 	case SENSOR_CHAN_ACCEL_Y:
 	case SENSOR_CHAN_ACCEL_Z:
-		reg_lsb = BMI160_REG_DATA_ACC_X + (ch - SENSOR_CHAN_ACCEL_X) * 2;
+		reg_lsb = BMI160_REG_DATA_ACC_X + (ch.chan_type - SENSOR_CHAN_ACCEL_X) * 2;
 		scale = 0x4e7404ea;
 
 		switch (FIELD_GET(GENMASK(3, 0), cfg->reg[BMI160_REG_ACC_RANGE])) {
@@ -313,7 +313,7 @@ static int bmi160_emul_backend_set_channel(const struct emul *target, enum senso
 	case SENSOR_CHAN_GYRO_X:
 	case SENSOR_CHAN_GYRO_Y:
 	case SENSOR_CHAN_GYRO_Z:
-		reg_lsb = BMI160_REG_DATA_GYR_X + (ch - SENSOR_CHAN_GYRO_X) * 2;
+		reg_lsb = BMI160_REG_DATA_GYR_X + (ch.chan_type - SENSOR_CHAN_GYRO_X) * 2;
 		scale = 0x45d02bea;
 
 		switch (FIELD_GET(GENMASK(2, 0), cfg->reg[BMI160_REG_GYR_RANGE])) {
@@ -353,7 +353,7 @@ static int bmi160_emul_backend_set_channel(const struct emul *target, enum senso
 		intermediate <<= shift - scale_shift;
 	}
 
-	if (ch == SENSOR_CHAN_DIE_TEMP) {
+	if (ch.chan_type == SENSOR_CHAN_DIE_TEMP) {
 		/* Need to subtract 23C */
 		intermediate -= INT64_C(23) << (31 - scale_shift);
 	}
@@ -366,13 +366,13 @@ static int bmi160_emul_backend_set_channel(const struct emul *target, enum senso
 	return 0;
 }
 
-static int bmi160_emul_backend_get_sample_range(const struct emul *target, enum sensor_channel ch,
-						q31_t *lower, q31_t *upper, q31_t *epsilon,
-						int8_t *shift)
+static int bmi160_emul_backend_get_sample_range(const struct emul *target,
+						struct sensor_chan_spec ch, q31_t *lower,
+						q31_t *upper, q31_t *epsilon, int8_t *shift)
 {
 	const struct bmi160_emul_cfg *cfg = target->cfg;
 
-	switch (ch) {
+	switch (ch.chan_type) {
 	case SENSOR_CHAN_ACCEL_X:
 	case SENSOR_CHAN_ACCEL_Y:
 	case SENSOR_CHAN_ACCEL_Z:
@@ -440,10 +440,10 @@ static int bmi160_emul_backend_get_sample_range(const struct emul *target, enum 
 	}
 }
 
-static int bmi160_emul_backend_set_offset(const struct emul *target, enum sensor_channel ch,
+static int bmi160_emul_backend_set_offset(const struct emul *target, struct sensor_chan_spec ch,
 					  const q31_t *values, int8_t shift)
 {
-	if (ch != SENSOR_CHAN_ACCEL_XYZ && ch != SENSOR_CHAN_GYRO_XYZ) {
+	if (ch.chan_type != SENSOR_CHAN_ACCEL_XYZ && ch.chan_type != SENSOR_CHAN_GYRO_XYZ) {
 		return -EINVAL;
 	}
 
@@ -452,20 +452,20 @@ static int bmi160_emul_backend_set_offset(const struct emul *target, enum sensor
 	int8_t scale_shift = 0;
 
 	if (values[0] == 0 && values[1] == 0 && values[2] == 0) {
-		if (ch == SENSOR_CHAN_ACCEL_XYZ) {
+		if (ch.chan_type == SENSOR_CHAN_ACCEL_XYZ) {
 			cfg->reg[BMI160_REG_OFFSET_EN] &= ~BIT(BMI160_ACC_OFS_EN_POS);
 		} else {
 			cfg->reg[BMI160_REG_OFFSET_EN] &= ~BIT(BMI160_GYR_OFS_EN_POS);
 		}
 	} else {
-		if (ch == SENSOR_CHAN_ACCEL_XYZ) {
+		if (ch.chan_type == SENSOR_CHAN_ACCEL_XYZ) {
 			cfg->reg[BMI160_REG_OFFSET_EN] |= BIT(BMI160_ACC_OFS_EN_POS);
 		} else {
 			cfg->reg[BMI160_REG_OFFSET_EN] |= BIT(BMI160_GYR_OFS_EN_POS);
 		}
 	}
 
-	if (ch == SENSOR_CHAN_ACCEL_XYZ) {
+	if (ch.chan_type == SENSOR_CHAN_ACCEL_XYZ) {
 		/*
 		 * bits = (values[i]mps2 / 9.80665g/mps2) / 0.0039g
 		 *      = values[i] / 0.038245935mps2/bit
@@ -493,11 +493,11 @@ static int bmi160_emul_backend_set_offset(const struct emul *target, enum sensor
 
 		int64_t reg_value = intermediate / scale;
 
-		__ASSERT_NO_MSG(ch != SENSOR_CHAN_ACCEL_XYZ ||
+		__ASSERT_NO_MSG(ch.chan_type != SENSOR_CHAN_ACCEL_XYZ ||
 				(reg_value >= INT8_MIN && reg_value <= INT8_MAX));
-		__ASSERT_NO_MSG(ch != SENSOR_CHAN_GYRO_XYZ ||
+		__ASSERT_NO_MSG(ch.chan_type != SENSOR_CHAN_GYRO_XYZ ||
 				(reg_value >= -0x1ff - 1 && reg_value <= 0x1ff));
-		if (ch == SENSOR_CHAN_ACCEL_XYZ) {
+		if (ch.chan_type == SENSOR_CHAN_ACCEL_XYZ) {
 			cfg->reg[BMI160_REG_OFFSET_ACC_X + i] = reg_value & 0xff;
 		} else {
 			cfg->reg[BMI160_REG_OFFSET_GYR_X + i] = reg_value & 0xff;
@@ -510,11 +510,11 @@ static int bmi160_emul_backend_set_offset(const struct emul *target, enum sensor
 	return 0;
 }
 
-static int bmi160_emul_backend_set_attribute(const struct emul *target, enum sensor_channel ch,
+static int bmi160_emul_backend_set_attribute(const struct emul *target, struct sensor_chan_spec ch,
 					     enum sensor_attribute attribute, const void *value)
 {
 	if (attribute == SENSOR_ATTR_OFFSET &&
-	    (ch == SENSOR_CHAN_ACCEL_XYZ || ch == SENSOR_CHAN_GYRO_XYZ)) {
+	    (ch.chan_type == SENSOR_CHAN_ACCEL_XYZ || ch.chan_type == SENSOR_CHAN_GYRO_XYZ)) {
 		const struct sensor_three_axis_attribute *attribute_value = value;
 
 		return bmi160_emul_backend_set_offset(target, ch, attribute_value->values,
@@ -524,12 +524,12 @@ static int bmi160_emul_backend_set_attribute(const struct emul *target, enum sen
 }
 
 static int bmi160_emul_backend_get_attribute_metadata(const struct emul *target,
-						      enum sensor_channel ch,
+						      struct sensor_chan_spec ch,
 						      enum sensor_attribute attribute, q31_t *min,
 						      q31_t *max, q31_t *increment, int8_t *shift)
 {
 	ARG_UNUSED(target);
-	switch (ch) {
+	switch (ch.chan_type) {
 	case SENSOR_CHAN_ACCEL_X:
 	case SENSOR_CHAN_ACCEL_Y:
 	case SENSOR_CHAN_ACCEL_Z:

--- a/drivers/sensor/default_rtio_sensor.c
+++ b/drivers/sensor/default_rtio_sensor.c
@@ -13,10 +13,10 @@
 LOG_MODULE_REGISTER(sensor_compat, CONFIG_SENSOR_LOG_LEVEL);
 
 /*
- * Ensure that the size of the generic header aligns with the sensor channel enum. If it doesn't,
- * then cores that require aligned memory access will fail to read channel[0].
+ * Ensure that the size of the generic header aligns with the sensor channel specifier . If it
+ * doesn't, then cores that require aligned memory access will fail to read channel[0].
  */
-BUILD_ASSERT((sizeof(struct sensor_data_generic_header) % sizeof(enum sensor_channel)) == 0);
+BUILD_ASSERT((sizeof(struct sensor_data_generic_header) % sizeof(struct sensor_chan_spec)) == 0);
 
 static void sensor_submit_fallback(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe);
 
@@ -46,12 +46,13 @@ const struct rtio_iodev_api __sensor_iodev_api = {
  * @param[in] num_channels Number of channels on the @p channels array
  * @return The number of samples required to read the given channels
  */
-static inline int compute_num_samples(const enum sensor_channel *channels, size_t num_channels)
+static inline int compute_num_samples(const struct sensor_chan_spec *const channels,
+				      size_t num_channels)
 {
 	int num_samples = 0;
 
 	for (size_t i = 0; i < num_channels; ++i) {
-		num_samples += SENSOR_CHANNEL_3_AXIS(channels[i]) ? 3 : 1;
+		num_samples += SENSOR_CHANNEL_3_AXIS(channels[i].chan_type) ? 3 : 1;
 	}
 
 	return num_samples;
@@ -68,7 +69,7 @@ static inline int compute_num_samples(const enum sensor_channel *channels, size_
 static inline uint32_t compute_header_size(int num_output_samples)
 {
 	uint32_t size = sizeof(struct sensor_data_generic_header) +
-			(num_output_samples * sizeof(enum sensor_channel));
+			(num_output_samples * sizeof(struct sensor_chan_spec));
 	return (size + 3) & ~0x3;
 }
 
@@ -92,12 +93,12 @@ static inline uint32_t compute_min_buf_len(int num_output_samples)
  * @return Index of the @p channel if found or negative if not found
  */
 static inline int check_header_contains_channel(const struct sensor_data_generic_header *header,
-						enum sensor_channel channel, int num_channels)
+						struct sensor_chan_spec chan_spec, int num_channels)
 {
-	__ASSERT_NO_MSG(!SENSOR_CHANNEL_3_AXIS(channel));
+	__ASSERT_NO_MSG(!SENSOR_CHANNEL_3_AXIS(chan_spec.chan_type));
 
 	for (int i = 0; i < num_channels; ++i) {
-		if (header->channels[i] == channel) {
+		if (sensor_chan_spec_eq(header->channels[i], chan_spec)) {
 			return i;
 		}
 	}
@@ -113,7 +114,7 @@ static inline int check_header_contains_channel(const struct sensor_data_generic
 static void sensor_submit_fallback(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
 {
 	const struct sensor_read_config *cfg = iodev_sqe->sqe.iodev->data;
-	const enum sensor_channel *const channels = cfg->channels;
+	const struct sensor_chan_spec *const channels = cfg->channels;
 	const int num_output_samples = compute_num_samples(channels, cfg->count);
 	uint32_t min_buf_len = compute_min_buf_len(num_output_samples);
 	uint64_t timestamp_ns = k_ticks_to_ns_floor64(k_uptime_ticks());
@@ -148,23 +149,34 @@ static void sensor_submit_fallback(const struct device *dev, struct rtio_iodev_s
 	/* Populate values, update shift, and set channels */
 	for (size_t i = 0, sample_idx = 0; i < cfg->count; ++i) {
 		struct sensor_value value[3];
-		const int num_samples = SENSOR_CHANNEL_3_AXIS(channels[i]) ? 3 : 1;
+		const int num_samples = SENSOR_CHANNEL_3_AXIS(channels[i].chan_type) ? 3 : 1;
 
 		/* Get the current channel requested by the user */
-		rc = sensor_channel_get(dev, channels[i], value);
+		rc = sensor_channel_get(dev, channels[i].chan_type, value);
 
 		if (num_samples == 3) {
-			header->channels[sample_idx++] =
-				rc == 0 ? channels[i] - 3 : SENSOR_CHAN_MAX;
-			header->channels[sample_idx++] =
-				rc == 0 ? channels[i] - 2 : SENSOR_CHAN_MAX;
-			header->channels[sample_idx++] =
-				rc == 0 ? channels[i] - 1 : SENSOR_CHAN_MAX;
+			header->channels[sample_idx++] = (struct sensor_chan_spec) {
+				rc == 0 ? channels[i].chan_type - 3 : SENSOR_CHAN_MAX,
+				0
+			};
+			header->channels[sample_idx++] = (struct sensor_chan_spec) {
+				rc == 0 ? channels[i].chan_type - 2 : SENSOR_CHAN_MAX,
+				0
+			};
+			header->channels[sample_idx++] = (struct sensor_chan_spec) {
+				rc == 0 ? channels[i].chan_type - 1 : SENSOR_CHAN_MAX,
+				0
+			};
 		} else {
-			header->channels[sample_idx++] = rc == 0 ? channels[i] : SENSOR_CHAN_MAX;
+			header->channels[sample_idx++] = (struct sensor_chan_spec) {
+				rc == 0 ? channels[i].chan_type : SENSOR_CHAN_MAX,
+				0
+			};
 		}
 
 		if (rc != 0) {
+			LOG_DBG("Failed to get channel (type: %d, index %d), skipping",
+				channels[i].chan_type, channels[i].chan_idx);
 			continue;
 		}
 
@@ -277,45 +289,41 @@ void sensor_processing_with_callback(struct rtio *ctx, sensor_processing_callbac
  * @param[out] frame_count The number of frames in the buffer (always 1)
  * @return 0 in all cases
  */
-static int get_frame_count(const uint8_t *buffer, enum sensor_channel channel, size_t channel_idx,
+static int get_frame_count(const uint8_t *buffer, struct sensor_chan_spec channel,
 			   uint16_t *frame_count)
 {
 	struct sensor_data_generic_header *header = (struct sensor_data_generic_header *)buffer;
-	size_t count = 0;
 
-	switch (channel) {
+	switch (channel.chan_type) {
 	case SENSOR_CHAN_ACCEL_XYZ:
-		channel = SENSOR_CHAN_ACCEL_X;
+		channel.chan_type = SENSOR_CHAN_ACCEL_X;
 		break;
 	case SENSOR_CHAN_GYRO_XYZ:
-		channel = SENSOR_CHAN_GYRO_X;
+		channel.chan_type = SENSOR_CHAN_GYRO_X;
 		break;
 	case SENSOR_CHAN_MAGN_XYZ:
-		channel = SENSOR_CHAN_MAGN_X;
+		channel.chan_type = SENSOR_CHAN_MAGN_X;
 		break;
 	default:
 		break;
 	}
 	for (size_t i = 0; i < header->num_channels; ++i) {
-		if (header->channels[i] == channel) {
-			if (channel_idx == count) {
-				*frame_count = 1;
-				return 0;
-			}
-			++count;
+		if (sensor_chan_spec_eq(header->channels[i], channel)) {
+			*frame_count = 1;
+			return 0;
 		}
 	}
 
 	return -ENOTSUP;
 }
 
-int sensor_natively_supported_channel_size_info(enum sensor_channel channel, size_t *base_size,
+int sensor_natively_supported_channel_size_info(struct sensor_chan_spec channel, size_t *base_size,
 						size_t *frame_size)
 {
 	__ASSERT_NO_MSG(base_size != NULL);
 	__ASSERT_NO_MSG(frame_size != NULL);
 
-	switch (channel) {
+	switch (channel.chan_type) {
 	case SENSOR_CHAN_ACCEL_X:
 	case SENSOR_CHAN_ACCEL_Y:
 	case SENSOR_CHAN_ACCEL_Z:
@@ -391,19 +399,13 @@ int sensor_natively_supported_channel_size_info(enum sensor_channel channel, siz
 }
 
 static int get_q31_value(const struct sensor_data_generic_header *header, const q31_t *values,
-			 enum sensor_channel channel, size_t channel_idx, q31_t *out)
+			 struct sensor_chan_spec chan_spec, q31_t *out)
 {
-	size_t count = 0;
-
 	for (size_t i = 0; i < header->num_channels; ++i) {
-		if (channel != header->channels[i]) {
-			continue;
-		}
-		if (count == channel_idx) {
+		if (sensor_chan_spec_eq(chan_spec, header->channels[i])) {
 			*out = values[i];
 			return 0;
 		}
-		++count;
 	}
 	return -EINVAL;
 }
@@ -419,15 +421,18 @@ static int decode_three_axis(const struct sensor_data_generic_header *header, co
 	data_out->shift = header->shift;
 	data_out->readings[0].timestamp_delta = 0;
 
-	rc = get_q31_value(header, values, x, channel_idx, &data_out->readings[0].values[0]);
+	rc = get_q31_value(header, values, (struct sensor_chan_spec){x, channel_idx},
+			   &data_out->readings[0].values[0]);
 	if (rc < 0) {
 		return rc;
 	}
-	rc = get_q31_value(header, values, y, channel_idx, &data_out->readings[0].values[1]);
+	rc = get_q31_value(header, values, (struct sensor_chan_spec){y, channel_idx},
+			   &data_out->readings[0].values[1]);
 	if (rc < 0) {
 		return rc;
 	}
-	rc = get_q31_value(header, values, z, channel_idx, &data_out->readings[0].values[2]);
+	rc = get_q31_value(header, values, (struct sensor_chan_spec){z, channel_idx},
+			   &data_out->readings[0].values[2]);
 	if (rc < 0) {
 		return rc;
 	}
@@ -435,8 +440,7 @@ static int decode_three_axis(const struct sensor_data_generic_header *header, co
 }
 
 static int decode_q31(const struct sensor_data_generic_header *header, const q31_t *values,
-		      struct sensor_q31_data *data_out, enum sensor_channel channel,
-		      size_t channel_idx)
+		      struct sensor_q31_data *data_out, struct sensor_chan_spec chan_spec)
 {
 	int rc;
 
@@ -445,7 +449,7 @@ static int decode_q31(const struct sensor_data_generic_header *header, const q31
 	data_out->shift = header->shift;
 	data_out->readings[0].timestamp_delta = 0;
 
-	rc = get_q31_value(header, values, channel, channel_idx, &data_out->readings[0].value);
+	rc = get_q31_value(header, values, chan_spec, &data_out->readings[0].value);
 	if (rc < 0) {
 		return rc;
 	}
@@ -469,7 +473,7 @@ static int decode_q31(const struct sensor_data_generic_header *header, const q31
  * @return >0 the number of decoded frames
  * @return <0 on error
  */
-static int decode(const uint8_t *buffer, enum sensor_channel channel, size_t channel_idx,
+static int decode(const uint8_t *buffer, struct sensor_chan_spec chan_spec,
 		  uint32_t *fit, uint16_t max_count, void *data_out)
 {
 	const struct sensor_data_generic_header *header =
@@ -482,33 +486,37 @@ static int decode(const uint8_t *buffer, enum sensor_channel channel, size_t cha
 	}
 
 	/* Check for 3d channel mappings */
-	switch (channel) {
+	switch (chan_spec.chan_type) {
 	case SENSOR_CHAN_ACCEL_X:
 	case SENSOR_CHAN_ACCEL_Y:
 	case SENSOR_CHAN_ACCEL_Z:
 	case SENSOR_CHAN_ACCEL_XYZ:
 		count = decode_three_axis(header, q, data_out, SENSOR_CHAN_ACCEL_X,
-					  SENSOR_CHAN_ACCEL_Y, SENSOR_CHAN_ACCEL_Z, channel_idx);
+					  SENSOR_CHAN_ACCEL_Y, SENSOR_CHAN_ACCEL_Z,
+					  chan_spec.chan_idx);
 		break;
 	case SENSOR_CHAN_GYRO_X:
 	case SENSOR_CHAN_GYRO_Y:
 	case SENSOR_CHAN_GYRO_Z:
 	case SENSOR_CHAN_GYRO_XYZ:
 		count = decode_three_axis(header, q, data_out, SENSOR_CHAN_GYRO_X,
-					  SENSOR_CHAN_GYRO_Y, SENSOR_CHAN_GYRO_Z, channel_idx);
+					  SENSOR_CHAN_GYRO_Y, SENSOR_CHAN_GYRO_Z,
+					  chan_spec.chan_idx);
 		break;
 	case SENSOR_CHAN_MAGN_X:
 	case SENSOR_CHAN_MAGN_Y:
 	case SENSOR_CHAN_MAGN_Z:
 	case SENSOR_CHAN_MAGN_XYZ:
 		count = decode_three_axis(header, q, data_out, SENSOR_CHAN_MAGN_X,
-					  SENSOR_CHAN_MAGN_Y, SENSOR_CHAN_MAGN_Z, channel_idx);
+					  SENSOR_CHAN_MAGN_Y, SENSOR_CHAN_MAGN_Z,
+					  chan_spec.chan_idx);
 		break;
 	case SENSOR_CHAN_POS_DX:
 	case SENSOR_CHAN_POS_DY:
 	case SENSOR_CHAN_POS_DZ:
 		count = decode_three_axis(header, q, data_out, SENSOR_CHAN_POS_DX,
-					  SENSOR_CHAN_POS_DY, SENSOR_CHAN_POS_DZ, channel_idx);
+					  SENSOR_CHAN_POS_DY, SENSOR_CHAN_POS_DZ,
+					  chan_spec.chan_idx);
 		break;
 	case SENSOR_CHAN_DIE_TEMP:
 	case SENSOR_CHAN_AMBIENT_TEMP:
@@ -550,7 +558,7 @@ static int decode(const uint8_t *buffer, enum sensor_channel channel, size_t cha
 	case SENSOR_CHAN_GAUGE_DESIGN_VOLTAGE:
 	case SENSOR_CHAN_GAUGE_DESIRED_VOLTAGE:
 	case SENSOR_CHAN_GAUGE_DESIRED_CHARGING_CURRENT:
-		count = decode_q31(header, q, data_out, channel, channel_idx);
+		count = decode_q31(header, q, data_out, chan_spec);
 		break;
 	default:
 		break;

--- a/drivers/sensor/f75303/f75303_emul.c
+++ b/drivers/sensor/f75303/f75303_emul.c
@@ -103,7 +103,7 @@ static int f75303_emul_init(const struct emul *target, const struct device *pare
 	return 0;
 }
 
-static int f75303_emul_set_channel(const struct emul *target, enum sensor_channel chan,
+static int f75303_emul_set_channel(const struct emul *target, struct sensor_chan_spec ch,
 				   const q31_t *value, int8_t shift)
 {
 	struct f75303_emul_data *data = target->data;
@@ -112,7 +112,7 @@ static int f75303_emul_set_channel(const struct emul *target, enum sensor_channe
 	int32_t reg_value;
 	uint8_t reg_h, reg_l;
 
-	switch ((int32_t)chan) {
+	switch ((int32_t)ch.chan_type) {
 	case SENSOR_CHAN_AMBIENT_TEMP:
 		reg_h = F75303_LOCAL_TEMP_H;
 		reg_l = F75303_LOCAL_TEMP_L;
@@ -139,12 +139,12 @@ static int f75303_emul_set_channel(const struct emul *target, enum sensor_channe
 	return 0;
 }
 
-static int f75303_emul_get_sample_range(const struct emul *target, enum sensor_channel chan,
+static int f75303_emul_get_sample_range(const struct emul *target, struct sensor_chan_spec ch,
 					q31_t *lower, q31_t *upper, q31_t *epsilon, int8_t *shift)
 {
-	if (chan != SENSOR_CHAN_AMBIENT_TEMP &&
-	    chan != (enum sensor_channel)SENSOR_CHAN_F75303_REMOTE1 &&
-	    chan != (enum sensor_channel)SENSOR_CHAN_F75303_REMOTE2) {
+	if (ch.chan_type != SENSOR_CHAN_AMBIENT_TEMP &&
+	    ch.chan_type != (enum sensor_channel)SENSOR_CHAN_F75303_REMOTE1 &&
+	    ch.chan_type != (enum sensor_channel)SENSOR_CHAN_F75303_REMOTE2) {
 		return -ENOTSUP;
 	}
 

--- a/drivers/sensor/tdk/icm42688/icm42688_decoder.h
+++ b/drivers/sensor/tdk/icm42688/icm42688_decoder.h
@@ -36,7 +36,7 @@ struct icm42688_encoded_data {
 	int16_t readings[7];
 };
 
-int icm42688_encode(const struct device *dev, const enum sensor_channel *const channels,
+int icm42688_encode(const struct device *dev, const struct sensor_chan_spec *const channels,
 		    const size_t num_channels, uint8_t *buf);
 
 int icm42688_get_decoder(const struct device *dev, const struct sensor_decoder_api **decoder);

--- a/drivers/sensor/tdk/icm42688/icm42688_emul.c
+++ b/drivers/sensor/tdk/icm42688/icm42688_emul.c
@@ -295,15 +295,15 @@ static void icm42688_emul_get_gyro_ranges(const struct emul *target, q31_t *lowe
 	*lower = -*upper;
 }
 
-static int icm42688_emul_backend_get_sample_range(const struct emul *target, enum sensor_channel ch,
-						  q31_t *lower, q31_t *upper, q31_t *epsilon,
-						  int8_t *shift)
+static int icm42688_emul_backend_get_sample_range(const struct emul *target,
+						  struct sensor_chan_spec ch, q31_t *lower,
+						  q31_t *upper, q31_t *epsilon, int8_t *shift)
 {
 	if (!lower || !upper || !epsilon || !shift) {
 		return -EINVAL;
 	}
 
-	switch (ch) {
+	switch (ch.chan_type) {
 	case SENSOR_CHAN_DIE_TEMP:
 		/* degrees C = ([16-bit signed temp_data register] / 132.48) + 25 */
 		*shift = 9;
@@ -328,7 +328,7 @@ static int icm42688_emul_backend_get_sample_range(const struct emul *target, enu
 	return 0;
 }
 
-static int icm42688_emul_backend_set_channel(const struct emul *target, enum sensor_channel ch,
+static int icm42688_emul_backend_set_channel(const struct emul *target, struct sensor_chan_spec ch,
 					     const q31_t *value, int8_t shift)
 {
 	if (!target || !target->data) {
@@ -343,7 +343,7 @@ static int icm42688_emul_backend_set_channel(const struct emul *target, enum sen
 	int64_t value_unshifted =
 		shift < 0 ? ((int64_t)*value >> -shift) : ((int64_t)*value << shift);
 
-	switch (ch) {
+	switch (ch.chan_type) {
 	case SENSOR_CHAN_DIE_TEMP:
 		reg_addr = REG_TEMP_DATA1;
 		reg_val = ((value_unshifted - (25 * Q31_SCALE)) * 13248) / (100 * Q31_SCALE);
@@ -351,7 +351,7 @@ static int icm42688_emul_backend_set_channel(const struct emul *target, enum sen
 	case SENSOR_CHAN_ACCEL_X:
 	case SENSOR_CHAN_ACCEL_Y:
 	case SENSOR_CHAN_ACCEL_Z:
-		switch (ch) {
+		switch (ch.chan_type) {
 		case SENSOR_CHAN_ACCEL_X:
 			reg_addr = REG_ACCEL_DATA_X1;
 			break;
@@ -370,7 +370,7 @@ static int icm42688_emul_backend_set_channel(const struct emul *target, enum sen
 	case SENSOR_CHAN_GYRO_X:
 	case SENSOR_CHAN_GYRO_Y:
 	case SENSOR_CHAN_GYRO_Z:
-		switch (ch) {
+		switch (ch.chan_type) {
 		case SENSOR_CHAN_GYRO_X:
 			reg_addr = REG_GYRO_DATA_X1;
 			break;

--- a/drivers/sensor/tdk/icm42688/icm42688_rtio.c
+++ b/drivers/sensor/tdk/icm42688/icm42688_rtio.c
@@ -46,7 +46,7 @@ static int icm42688_rtio_sample_fetch(const struct device *dev, int16_t readings
 static int icm42688_submit_one_shot(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
 {
 	const struct sensor_read_config *cfg = iodev_sqe->sqe.iodev->data;
-	const enum sensor_channel *const channels = cfg->channels;
+	const struct sensor_chan_spec *const channels = cfg->channels;
 	const size_t num_channels = cfg->count;
 	uint32_t min_buf_len = sizeof(struct icm42688_encoded_data);
 	int rc;

--- a/include/zephyr/drivers/emul_sensor.h
+++ b/include/zephyr/drivers/emul_sensor.h
@@ -27,16 +27,16 @@
  */
 __subsystem struct emul_sensor_driver_api {
 	/** Sets a given fractional value for a given sensor channel. */
-	int (*set_channel)(const struct emul *target, enum sensor_channel ch, const q31_t *value,
-			   int8_t shift);
+	int (*set_channel)(const struct emul *target, struct sensor_chan_spec ch,
+			   const q31_t *value, int8_t shift);
 	/** Retrieve a range of sensor values to use with test. */
-	int (*get_sample_range)(const struct emul *target, enum sensor_channel ch, q31_t *lower,
+	int (*get_sample_range)(const struct emul *target, struct sensor_chan_spec ch, q31_t *lower,
 				q31_t *upper, q31_t *epsilon, int8_t *shift);
 	/** Set the attribute value(s) of a given chanel. */
-	int (*set_attribute)(const struct emul *target, enum sensor_channel ch,
+	int (*set_attribute)(const struct emul *target, struct sensor_chan_spec ch,
 			     enum sensor_attribute attribute, const void *value);
 	/** Get metadata about an attribute. */
-	int (*get_attribute_metadata)(const struct emul *target, enum sensor_channel ch,
+	int (*get_attribute_metadata)(const struct emul *target, struct sensor_chan_spec ch,
 				      enum sensor_attribute attribute, q31_t *min, q31_t *max,
 				      q31_t *increment, int8_t *shift);
 };
@@ -68,8 +68,9 @@ static inline bool emul_sensor_backend_is_supported(const struct emul *target)
  * @return -ENOTSUP if no backend API or if channel not supported by emul
  * @return -ERANGE if provided value is not in the sensor's supported range
  */
-static inline int emul_sensor_backend_set_channel(const struct emul *target, enum sensor_channel ch,
-						  const q31_t *value, int8_t shift)
+static inline int emul_sensor_backend_set_channel(const struct emul *target,
+						  struct sensor_chan_spec ch, const q31_t *value,
+						  int8_t shift)
 {
 	if (!target || !target->backend_api) {
 		return -ENOTSUP;
@@ -101,7 +102,7 @@ static inline int emul_sensor_backend_set_channel(const struct emul *target, enu
  *
  */
 static inline int emul_sensor_backend_get_sample_range(const struct emul *target,
-						       enum sensor_channel ch, q31_t *lower,
+						       struct sensor_chan_spec ch, q31_t *lower,
 						       q31_t *upper, q31_t *epsilon, int8_t *shift)
 {
 	if (!target || !target->backend_api) {
@@ -127,7 +128,7 @@ static inline int emul_sensor_backend_get_sample_range(const struct emul *target
  * @return < 0 on error
  */
 static inline int emul_sensor_backend_set_attribute(const struct emul *target,
-						    enum sensor_channel ch,
+						    struct sensor_chan_spec ch,
 						    enum sensor_attribute attribute,
 						    const void *value)
 {
@@ -161,7 +162,7 @@ static inline int emul_sensor_backend_set_attribute(const struct emul *target,
  * @return < 0 on error
  */
 static inline int emul_sensor_backend_get_attribute_metadata(const struct emul *target,
-							     enum sensor_channel ch,
+							     struct sensor_chan_spec ch,
 							     enum sensor_attribute attribute,
 							     q31_t *min, q31_t *max,
 							     q31_t *increment, int8_t *shift)

--- a/tests/drivers/build_all/sensor/src/generic_test.c
+++ b/tests/drivers/build_all/sensor/src/generic_test.c
@@ -30,7 +30,7 @@ union sensor_data_union {
  * Set up an RTIO context that can be shared for all sensors
  */
 
-static enum sensor_channel iodev_all_channels[SENSOR_CHAN_ALL];
+static struct sensor_chan_spec iodev_all_channels[SENSOR_CHAN_ALL];
 static struct sensor_read_config iodev_read_config = {
 	.channels = iodev_all_channels,
 	.max = SENSOR_CHAN_ALL,
@@ -110,8 +110,9 @@ static void run_generic_test(const struct device *dev)
 
 		q31_t lower, upper;
 		int8_t shift;
+		struct sensor_chan_spec ch_spec = {.chan_type = ch, .chan_idx = 0};
 
-		if (emul_sensor_backend_get_sample_range(emul, ch, &lower, &upper,
+		if (emul_sensor_backend_get_sample_range(emul, ch_spec, &lower, &upper,
 							 &channel_table[ch].epsilon, &shift) == 0) {
 			/* This channel is supported */
 			channel_table[ch].supported = true;
@@ -120,7 +121,7 @@ static void run_generic_test(const struct device *dev)
 				channel_table[ch].epsilon, shift);
 
 			/* Add to the list of channels to read */
-			iodev_all_channels[iodev_read_config.count++] = ch;
+			iodev_all_channels[iodev_read_config.count++].chan_type = ch;
 
 			/* Generate a set of CONFIG_GENERIC_SENSOR_TEST_NUM_EXPECTED_VALS test
 			 * values.
@@ -155,16 +156,18 @@ static void run_generic_test(const struct device *dev)
 
 		/* Set this iteration's expected values in emul for every supported channel */
 		for (size_t i = 0; i < iodev_read_config.count; i++) {
-			enum sensor_channel ch = iodev_all_channels[i];
+			struct sensor_chan_spec ch_spec = iodev_all_channels[i];
 
 			rv = emul_sensor_backend_set_channel(
-				emul, ch, &channel_table[ch].expected_values[iteration],
-				channel_table[ch].expected_value_shift);
-			zassert_ok(
-				rv,
-				"Cannot set value 0x%08x on channel %d (error %d, iteration %d/%d)",
-				channel_table[i].expected_values[iteration], ch, rv, iteration + 1,
-				CONFIG_GENERIC_SENSOR_TEST_NUM_EXPECTED_VALS);
+				emul, ch_spec,
+				&channel_table[ch_spec.chan_type].expected_values[iteration],
+				channel_table[ch_spec.chan_type].expected_value_shift);
+			zassert_ok(rv,
+				   "Cannot set value 0x%08x on channel (type: %d, index: %d) "
+				   "(error %d, iteration %d/%d)",
+				   channel_table[i].expected_values[iteration], ch_spec.chan_type,
+				   ch_spec.chan_idx, rv, iteration + 1,
+				   CONFIG_GENERIC_SENSOR_TEST_NUM_EXPECTED_VALS);
 		}
 
 		/* Perform the actual sensor read */

--- a/tests/drivers/sensor/bmi160/src/fixture.c
+++ b/tests/drivers/sensor/bmi160/src/fixture.c
@@ -33,7 +33,9 @@ static void sensor_bmi160_setup_emulator(const struct device *dev, const struct 
 	zassert_ok(sensor_attr_set(dev, SENSOR_CHAN_GYRO_XYZ, SENSOR_ATTR_FULL_SCALE, &scale));
 
 	for (size_t i = 0; i < ARRAY_SIZE(values); ++i) {
-		zassert_ok(emul_sensor_backend_set_channel(emulator, values[i].channel,
+		struct sensor_chan_spec chan_spec = {.chan_type = values[i].channel, .chan_idx = 0};
+
+		zassert_ok(emul_sensor_backend_set_channel(emulator, chan_spec,
 							   &values[i].value, 3));
 	}
 }


### PR DESCRIPTION
Use a structured channel specifier rather than a single enum when specifying channels to read in the new read/decoder API.

Implements a slight variation of #63830 