### PR TITLE
 tests: drivers: uart_async_api: enable for frdm_mcxn947

### DIFF
--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947-pinctrl.dtsi
@@ -31,6 +31,16 @@
 		};
 	};
 
+	pinmux_flexcomm2_lpuart: pinmux_flexcomm2_lpuart {
+		group0 {
+			pinmux = <FC2_P2_PIO4_2>,
+				<FC2_P3_PIO4_3>;
+			slew-rate = "fast";
+			drive-strength = "low";
+			input-enable;
+		};
+	};
+
 	pinmux_flexcomm4_lpuart: pinmux_flexcomm4_lpuart {
 		group0 {
 			pinmux = <FC4_P0_PIO1_8>,

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
@@ -61,6 +61,12 @@
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 };
 
+&flexcomm2_lpuart2 {
+	current-speed = <115200>;
+	pinctrl-0 = <&pinmux_flexcomm2_lpuart>;
+	pinctrl-names = "default";
+};
+
 &flexcomm4_lpuart4 {
 	current-speed = <115200>;
 	pinctrl-0 = <&pinmux_flexcomm4_lpuart>;

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.dts
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.dts
@@ -85,6 +85,14 @@
 	status = "okay";
 };
 
+/*
+ *LPFLEXCOMM supports UART and I2C on the same instance, enable this for
+ * LFLEXCOMM2
+ */
+&flexcomm2_lpuart2 {
+	status = "okay";
+};
+
 &flexcomm4 {
 	status = "okay";
 };

--- a/dts/arm/nxp/nxp_mcxn94x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn94x_common.dtsi
@@ -256,6 +256,9 @@
 			compatible = "nxp,kinetis-lpuart";
 			reg = <0x94000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM2_CLK>;
+			/* DMA channels 4 and 5, muxed to LPUART2 RX and TX */
+			dmas = <&edma0 4 73>, <&edma0 5 74>;
+			dma-names = "rx", "tx";
 			status = "disabled";
 		};
 		flexcomm2_lpspi2: lpspi@94000 {
@@ -324,6 +327,9 @@
 			compatible = "nxp,kinetis-lpuart";
 			reg = <0xb4000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM4_CLK>;
+			/* DMA channels 2 and 3, muxed to LPUART4 RX and TX */
+			dmas = <&edma0 2 77>, <&edma0 3 78>;
+			dma-names = "rx", "tx";
 			status = "disabled";
 		};
 		flexcomm4_lpspi4: lpspi@b4000 {

--- a/tests/drivers/uart/uart_async_api/boards/frdm_mcxn947_mcxn947_cpu0.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/frdm_mcxn947_mcxn947_cpu0.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2024 NXP
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * To test this sample connect P4_2 to P4_3
+ */
+dut: &flexcomm2_lpuart2 {};


### PR DESCRIPTION
Enable the UART async API test for the frdm_mcxn947 board.

This also enables support for DMA with the LPUART driver on the frdm_mcxn947 board