### PR TITLE
boards: shields: Add nRF9160 DK overlay for arduino_uno_click shield

### DIFF
--- a/boards/shields/arduino_uno_click/boards/nrf9160dk_nrf9160.overlay
+++ b/boards/shields/arduino_uno_click/boards/nrf9160dk_nrf9160.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2024 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "nrf9160dk_nrf9160_arduino_uno_click_common.dtsi"

--- a/boards/shields/arduino_uno_click/boards/nrf9160dk_nrf9160_arduino_uno_click_common.dtsi
+++ b/boards/shields/arduino_uno_click/boards/nrf9160dk_nrf9160_arduino_uno_click_common.dtsi
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	/*
+	 * The original Arduino Uno provides the same SCL/SDA on two sets of
+	 * pins, but the nRF9160 DK maps these pins to two different pairs of
+	 * GPIO. When using the Arduino Uno Click Shield board with the nRF9160
+	 * DK, the P0.18/P0.19 pair must be used.
+	 */
+	i2c2_default: i2c2_default {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 0, 18)>,
+				<NRF_PSEL(TWIM_SCL, 0, 19)>;
+		};
+	};
+
+	i2c2_sleep: i2c2_sleep {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 0, 18)>,
+				<NRF_PSEL(TWIM_SCL, 0, 19)>;
+			low-power-enable;
+		};
+	};
+
+	/*
+	 * The default pin group for the nRF9160 DK includes RTS/CTS HW flow
+	 * control, but the Arduino Uno Click Shield board does not connect
+	 * these pins (only TX/RX are connected on the shield). This keeps RX/TX
+	 * on the same pins, but just removes RTS/CTS from the pin groups.
+	 */
+	uart1_default: uart1_default {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 0, 1)>,
+				<NRF_PSEL(UART_RX, 0, 0)>;
+		};
+	};
+
+	uart1_sleep: uart1_sleep {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 0, 1)>,
+				<NRF_PSEL(UART_RX, 0, 0)>;
+			low-power-enable;
+		};
+	};
+};

--- a/boards/shields/arduino_uno_click/boards/nrf9160dk_nrf9160_ns.overlay
+++ b/boards/shields/arduino_uno_click/boards/nrf9160dk_nrf9160_ns.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2024 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "nrf9160dk_nrf9160_arduino_uno_click_common.dtsi"


### PR DESCRIPTION
The original Arduino Uno provides the same SCL/SDA signals on two sets of pins, but the nRF9160 DK maps these pins to two different pairs of GPIO on the nRF9160 SIP. As a result, when using the Arduino Uno Click Shield board with the nRF9160 DK, the `P0.18`/`P0.19` pair must be used.

<img width="755" alt="image" src="https://github.com/zephyrproject-rtos/zephyr/assets/14631/a58b54ed-499d-4051-b6e5-cdae2b53f721">

<img width="680" alt="image" src="https://github.com/zephyrproject-rtos/zephyr/assets/14631/a2689e2c-4fd7-4819-bc80-b02cfef4c455">

<img width="605" alt="image" src="https://github.com/zephyrproject-rtos/zephyr/assets/14631/4e70bad4-7fc9-4a9f-a5a1-e272717715b4">

Also, the default pin group for the nRF9160 DK includes `RTS`/`CTS` HW flow control, but the Arduino Uno Click Shield board does not connect these pins (only `TX`/`RX` are connected on the shield). This keeps `RX`/`TX` on the same pins, but just removes `RTS`/`CTS` from the pin groups.

<img width="585" alt="image" src="https://github.com/zephyrproject-rtos/zephyr/assets/14631/d3703afd-9e14-4e08-9aef-963a816581c3">

**How I tested this**

I don't have any of the in-tree MikroE Click shields to test this with, so I used a MikroE [Weather Click](https://www.mikroe.com/weather-click) board I had on hand.

![IMG_3444](https://github.com/zephyrproject-rtos/zephyr/assets/14631/e25fda32-43a5-47ac-941f-8aa893716881)

I added a new shield definition for the Weather Click in https://github.com/zephyrproject-rtos/zephyr/pull/71076 so by merging that PR together with this one:

```sh
west build -p -b nrf9160dk/nrf9160/ns samples/sensor/bme280 -- -DSHIELD="arduino_uno_click mikroe_weather_click"
west flash
```

```
*** Booting Zephyr OS build 98f9b57243cc ***
Found device "bme280@76", getting sensor data
temp: 21.130000; press: 99.427671; humidity: 48.135742
temp: 21.130000; press: 99.427671; humidity: 48.135742
temp: 21.120000; press: 99.426781; humidity: 48.124023
...
```

**References**

 - Arduino Uno R3 pinout: https://docs.arduino.cc/resources/pinouts/A000066-full-pinout.pdf

 - Arduino UNO click shield schematic: https://download.mikroe.com/documents/add-on-boards/click-shields/arduino-uno/arduino-uno-click-shield-schematic-v101.pdf