### PR TITLE
Test fixes

### DIFF
--- a/tests/drivers/gpio/gpio_basic_api/src/test_config_trigger.c
+++ b/tests/drivers/gpio/gpio_basic_api/src/test_config_trigger.c
@@ -40,7 +40,12 @@ ZTEST(after_flash_gpio_config_trigger, test_gpio_config_twice_trigger)
 
 	/* 2. Enable PIN callback as both edges */
 	ret = gpio_pin_interrupt_configure(dev, PIN_IN, GPIO_INT_EDGE_BOTH);
-	zassert_ok(ret, "enable callback failed");
+	if (ret == -ENOTSUP) {
+		TC_PRINT("Both edge GPIO interrupt not supported.\n");
+		gpio_remove_callback(dev, &drv_data->gpio_cb);
+	} else {
+		zassert_ok(ret, "enable callback failed");
+	}
 
 	/* 3. Configure PIN_OUT as open drain, internal pull-up (may trigger
 	 * callback)
@@ -87,7 +92,12 @@ ZTEST(after_flash_gpio_config_trigger, test_gpio_config_trigger)
 
 	/* 2. Enable PIN callback as both edges */
 	ret = gpio_pin_interrupt_configure(dev, PIN_IN, GPIO_INT_EDGE_BOTH);
-	zassert_ok(ret, "enable callback failed");
+	if (ret == -ENOTSUP) {
+		TC_PRINT("Both edge GPIO interrupt not supported.\n");
+		gpio_remove_callback(dev, &drv_data->gpio_cb);
+	} else {
+		zassert_ok(ret, "enable callback failed");
+	}
 
 	/* 3. Configure PIN_OUT as open drain, internal pull-up (may trigger
 	 * callback)

--- a/tests/drivers/rtc/rtc_api/src/test_alarm.c
+++ b/tests/drivers/rtc/rtc_api/src/test_alarm.c
@@ -116,10 +116,10 @@ ZTEST(rtc_api, test_alarm)
 		zassert_equal(alarm_time_mask_get, alarm_time_mask_set,
 			      "Incorrect alarm time mask");
 
-		zassert_equal(alarm_time_get.tm_min, alarm_time_get.tm_min,
+		zassert_equal(alarm_time_get.tm_min, alarm_time_set.tm_min,
 			      "Incorrect alarm time minute field");
 
-		zassert_equal(alarm_time_get.tm_hour, alarm_time_get.tm_hour,
+		zassert_equal(alarm_time_get.tm_hour, alarm_time_set.tm_hour,
 			      "Incorrect alarm time hour field");
 	}
 


### PR DESCRIPTION
Correct time check for get/set
Previous check would always pass as it checked get/get.
Update to remove failure on GPIO_INT_EDGE_BOTH
when devices return -ENOTSUP

Signed-off-by: Richard Wheatley <richard.wheatley@ambiq.com>