### PR TITLE
Fixes Master Mode for I2C DW Driver

### DIFF
--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -252,7 +252,9 @@ static inline void i2c_dw_data_ask(const struct device *dev)
 			data |= IC_DATA_CMD_STOP;
 		}
 
+#ifdef CONFIG_I2C_TARGET
 		clear_bit_intr_mask_tx_empty(reg_base);
+#endif /* CONFIG_I2C_TARGET */
 
 		write_cmd_data(data, reg_base);
 
@@ -413,6 +415,7 @@ static void i2c_dw_isr(const struct device *port)
 			i2c_dw_data_read(port);
 		}
 
+#ifdef CONFIG_I2C_TARGET
 		/* Check if the TX FIFO is ready for commands.
 		 * TX FIFO also serves as command queue where read requests
 		 * are written to TX FIFO.
@@ -421,6 +424,7 @@ static void i2c_dw_isr(const struct device *port)
 			    == I2C_MSG_READ) {
 			set_bit_intr_mask_tx_empty(reg_base);
 		}
+#endif /* CONFIG_I2C_TARGET */
 
 		if (intr_stat.bits.tx_empty) {
 			if ((dw->xfr_flags & I2C_MSG_RW_MASK)


### PR DESCRIPTION
PR [42513](https://github.com/zephyrproject-rtos/zephyr/pull/42513) adds Slave Support for the Designware I2C Driver. The change carefully uses `CONFIG_I2C_SLAVE` (now `CONFIG_I2C_TARGET` after PR [43166](https://github.com/zephyrproject-rtos/zephyr/pull/43166)) to support this as opposed to the default Master mode. 

However, there are two cases where it seems like the author forgot to guard the changes with `CONFIG_I2C_SLAVE`. I've found a regression that is fixed when these guards are added, thus the present PR.

Thanks! 