### PR TITLE
GNSS: Increase size of hdop

### DIFF
--- a/drivers/gnss/gnss_nmea0183.c
+++ b/drivers/gnss/gnss_nmea0183.c
@@ -530,7 +530,7 @@ int gnss_nmea0183_parse_gga(const char **argv, uint16_t argc, struct gnss_data *
 
 	/* Parse HDOP */
 	if ((gnss_parse_dec_to_milli(argv[8], &tmp64) < 0) ||
-	    (tmp64 > UINT16_MAX) ||
+	    (tmp64 > UINT32_MAX) ||
 	    (tmp64 < 0)) {
 		return -EINVAL;
 	}

--- a/include/zephyr/drivers/gnss.h
+++ b/include/zephyr/drivers/gnss.h
@@ -156,7 +156,7 @@ struct gnss_info {
 	/** Number of satellites being tracked */
 	uint16_t satellites_cnt;
 	/** Horizontal dilution of precision in 1/1000 */
-	uint16_t hdop;
+	uint32_t hdop;
 	/** The fix status */
 	enum gnss_fix_status fix_status;
 	/** The fix quality */


### PR DESCRIPTION
The valid range of hdop (horizontal diffusion of precision) goes from 0-100000, but because we are using a uint16_t, we truncate anything above UINT16_MAX.

This fix changes the size of the hdop member to a uint32_t, which allows us to capture valid (but admittedly very poor) readings.