### PR TITLE
boards: nucleo_h563zi: Fix APB3 bus clock

### DIFF
--- a/boards/st/nucleo_h563zi/nucleo_h563zi-common.dtsi
+++ b/boards/st/nucleo_h563zi/nucleo_h563zi-common.dtsi
@@ -84,7 +84,7 @@
 	ahb-prescaler = <1>;
 	apb1-prescaler = <2>;
 	apb2-prescaler = <1>;
-	apb3-prescaler = <1>;
+	apb3-prescaler = <2>;
 };
 
 &lpuart1 {


### PR DESCRIPTION
240MHz as APB3 bus clock is too fast to set I2C base bus speed.
Set bus pre-scaler to 2 and reach a safe 120MHz.

This commit is very similar to
456183f982923446d8b40b32d79a9a2d24d37ab8.