### PR TITLE
tests: drivers: clock_control: Add nRF54L15 to platform allow

### DIFF
--- a/tests/drivers/clock_control/clock_control_api/testcase.yaml
+++ b/tests/drivers/clock_control/clock_control_api/testcase.yaml
@@ -8,6 +8,7 @@ tests:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
       - nrf9160dk/nrf9160
+      - nrf54l15pdk/nrf54l15/cpuapp
     integration_platforms:
       - nrf51dk/nrf51822
   drivers.clock.clock_control_nrf5_lfclk_rc:
@@ -18,6 +19,7 @@ tests:
       - nrf51dk/nrf51822
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
+      - nrf54l15pdk/nrf54l15/cpuapp
     integration_platforms:
       - nrf51dk/nrf51822
     extra_args: CONF_FILE="nrf_lfclk_rc.conf"

--- a/tests/drivers/clock_control/nrf_clock_calibration/testcase.yaml
+++ b/tests/drivers/clock_control/nrf_clock_calibration/testcase.yaml
@@ -7,5 +7,6 @@ tests:
       - nrf51dk/nrf51822
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
+      - nrf54l15pdk/nrf54l15/cpuapp
     integration_platforms:
       - nrf51dk/nrf51822

--- a/tests/drivers/clock_control/nrf_lf_clock_start/testcase.yaml
+++ b/tests/drivers/clock_control/nrf_lf_clock_start/testcase.yaml
@@ -13,6 +13,7 @@ tests:
       - nrf9160dk/nrf9160
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpunet
+      - nrf54l15pdk/nrf54l15/cpuapp
     extra_configs:
       - CONFIG_SYSTEM_CLOCK_WAIT_FOR_STABILITY=y
       - CONFIG_CLOCK_CONTROL_NRF_K32SRC_XTAL=y
@@ -27,6 +28,7 @@ tests:
       - nrf9160dk/nrf9160
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpunet
+      - nrf54l15pdk/nrf54l15/cpuapp
     extra_configs:
       - CONFIG_SYSTEM_CLOCK_WAIT_FOR_AVAILABILITY=y
       - CONFIG_CLOCK_CONTROL_NRF_K32SRC_XTAL=y
@@ -41,6 +43,7 @@ tests:
       - nrf9160dk/nrf9160
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpunet
+      - nrf54l15pdk/nrf54l15/cpuapp
     integration_platforms:
       - nrf51dk/nrf51822
     extra_configs:
@@ -54,6 +57,7 @@ tests:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpunet
+      - nrf54l15pdk/nrf54l15/cpuapp
     integration_platforms:
       - nrf51dk/nrf51822
     extra_configs:
@@ -67,6 +71,7 @@ tests:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpunet
+      - nrf54l15pdk/nrf54l15/cpuapp
     integration_platforms:
       - nrf51dk/nrf51822
     extra_configs:
@@ -80,6 +85,7 @@ tests:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpunet
+      - nrf54l15pdk/nrf54l15/cpuapp
     integration_platforms:
       - nrf51dk/nrf51822
     extra_configs:
@@ -93,6 +99,7 @@ tests:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpunet
+      - nrf54l15pdk/nrf54l15/cpuapp
     integration_platforms:
       - nrf51dk/nrf51822
     extra_configs:
@@ -106,6 +113,7 @@ tests:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpunet
+      - nrf54l15pdk/nrf54l15/cpuapp
     integration_platforms:
       - nrf51dk/nrf51822
     extra_configs:
@@ -119,6 +127,7 @@ tests:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpunet
+      - nrf54l15pdk/nrf54l15/cpuapp
     integration_platforms:
       - nrf51dk/nrf51822
     extra_configs:

--- a/tests/drivers/clock_control/onoff/testcase.yaml
+++ b/tests/drivers/clock_control/onoff/testcase.yaml
@@ -7,6 +7,7 @@ tests:
       - nrf51dk/nrf51822
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
+      - nrf54l15pdk/nrf54l15/cpuapp
       - nrf9160dk/nrf9160
     integration_platforms:
       - nrf51dk/nrf51822


### PR DESCRIPTION
Add nRF54L15 to platform_allow in the sample.yaml:
- clock_control_api,
- nrf_clock_calibration,
- nrf_lf_clock_start,
- onoff.