### PR TITLE
cmake: extensions: introduce zephyr_syscall_include_directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -840,7 +840,7 @@ add_subdirectory(kernel)
 get_property(
   syscalls_file_list
   TARGET syscalls_interface
-  PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+  PROPERTY INTERFACE_SOURCES
 )
 file(CONFIGURE OUTPUT ${syscalls_file_list_output}
      CONTENT "@syscalls_file_list@" @ONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -694,6 +694,13 @@ if(CONFIG_ZTEST)
 
 endif()
 
+get_property(
+  syscalls_include_list
+  TARGET syscalls_interface
+  PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+)
+list(APPEND SYSCALL_INCLUDE_DIRS ${syscalls_include_list})
+
 foreach(d ${SYSCALL_INCLUDE_DIRS})
   list(APPEND parse_syscalls_include_args
     --include ${d}

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -1632,10 +1632,6 @@ function(zephyr_syscall_header)
       syscalls_interface INTERFACE
       ${header_file}
     )
-    target_include_directories(
-      syscalls_interface INTERFACE
-      ${header_file}
-    )
     add_dependencies(
       syscalls_interface
       ${header_file}

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -1617,6 +1617,30 @@ function(zephyr_build_string outvar)
   set(${outvar} ${${outvar}} PARENT_SCOPE)
 endfunction()
 
+# Function to add one or more directories to the include list passed to the syscall generator.
+function(zephyr_syscall_include_directories)
+  foreach(one_dir ${ARGV})
+    if(EXISTS ${one_dir})
+      set(include_dir ${one_dir})
+    elseif(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${one_dir})
+      set(include_dir ${CMAKE_CURRENT_SOURCE_DIR}/${one_dir})
+    else()
+      message(FATAL_ERROR "Syscall include directory not found: ${one_dir}")
+    endif()
+
+    target_include_directories(
+      syscalls_interface INTERFACE
+      ${include_dir}
+    )
+    add_dependencies(
+      syscalls_interface
+      ${include_dir}
+    )
+
+    unset(include_dir)
+  endforeach()
+endfunction()
+
 # Function to add header file(s) to the list to be passed to syscall generator.
 function(zephyr_syscall_header)
   foreach(one_file ${ARGV})


### PR DESCRIPTION
Add a new CMake helper to add new include directories to be parsed by
the syscall machinery. This helper complements the existing
zephyr_syscall_header, which works at a header-level.

Until now, something like this was required:

```
list(APPEND SYSCALL_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include)
set(SYSCALL_INCLUDE_DIRS ${SYSCALL_INCLUDE_DIRS} PARENT_SCOPE)
```

With this new option, we could also deprecate `CONFIG_APPLICATION_DEFINED_SYSCALL`, which doesn't work for all application topologies anyway.

