### PR TITLE
Fix Renesas RA pinctrl and dts settings

### DIFF
--- a/drivers/clock_control/clock_control_renesas_ra.c
+++ b/drivers/clock_control/clock_control_renesas_ra.c
@@ -194,7 +194,7 @@ static int clock_control_ra_on(const struct device *dev, clock_control_subsys_t 
 	int lock = irq_lock();
 
 	MSTP_write(MSTPCRA_OFFSET + RA_CLOCK_GROUP(clkid),
-		   MSTP_read(MSTPCRB_OFFSET) & ~RA_CLOCK_BIT(clkid));
+		   MSTP_read(MSTPCRA_OFFSET + RA_CLOCK_GROUP(clkid)) & ~RA_CLOCK_BIT(clkid));
 	irq_unlock(lock);
 
 	return 0;
@@ -206,7 +206,7 @@ static int clock_control_ra_off(const struct device *dev, clock_control_subsys_t
 	int lock = irq_lock();
 
 	MSTP_write(MSTPCRA_OFFSET + RA_CLOCK_GROUP(clkid),
-		   MSTP_read(MSTPCRB_OFFSET) | RA_CLOCK_BIT(clkid));
+		   MSTP_read(MSTPCRA_OFFSET + RA_CLOCK_GROUP(clkid)) | RA_CLOCK_BIT(clkid));
 	irq_unlock(lock);
 
 	return 0;

--- a/drivers/gpio/gpio_renesas_ra.c
+++ b/drivers/gpio/gpio_renesas_ra.c
@@ -414,10 +414,13 @@ static const struct gpio_driver_api gpio_ra_driver_api = {
 
 #define GPIO_RA_INIT(idx)                                                                          \
 	static struct gpio_ra_data gpio_ra_data_##idx = {};                                        \
-	DT_INST_FOREACH_PROP_ELEM(idx, interrupt_names, GPIO_RA_DECL_PINS);                        \
-	DT_INST_FOREACH_PROP_ELEM(idx, interrupt_names, GPIO_RA_ISR_DECL);                         \
-	struct gpio_ra_irq_info gpio_ra_irq_info_##idx[] = {                                       \
-		DT_INST_FOREACH_PROP_ELEM(idx, interrupt_names, GPIO_RA_IRQ_INFO)};                \
+	IF_ENABLED(DT_INST_NODE_HAS_PROP(idx, interrupt_names),                                    \
+		   (DT_INST_FOREACH_PROP_ELEM(idx, interrupt_names, GPIO_RA_DECL_PINS);            \
+		    DT_INST_FOREACH_PROP_ELEM(idx, interrupt_names, GPIO_RA_ISR_DECL);))           \
+	static struct gpio_ra_irq_info gpio_ra_irq_info_##idx[] = {                                \
+		IF_ENABLED(DT_INST_NODE_HAS_PROP(idx, interrupt_names),                            \
+			   (DT_INST_FOREACH_PROP_ELEM(idx, interrupt_names, GPIO_RA_IRQ_INFO)))    \
+	};                                                                                         \
 	static struct gpio_ra_config gpio_ra_config_##idx = {                                      \
 		.common = {                                                                        \
 			.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(idx),                     \

--- a/drivers/pinctrl/renesas/ra/pinctrl_renesas_ra.c
+++ b/drivers/pinctrl/renesas/ra/pinctrl_renesas_ra.c
@@ -47,11 +47,12 @@ static void pinctrl_ra_configure_pfs(const pinctrl_soc_pin_t *pinc)
 	pincfg.port = 0;
 
 	/* Clear PMR bits before configuring */
-	if ((pincfg.config & PmnPFS_PMR_POS)) {
+	if ((pincfg.config & BIT(PmnPFS_PMR_POS))) {
 		uint32_t val = pinctrl_ra_read_PmnFPS(pinc->port, pinc->pin);
 
 		pinctrl_ra_write_PmnFPS(pinc->port, pinc->pin, val & ~(BIT(PmnPFS_PMR_POS)));
-		pinctrl_ra_write_PmnFPS(pinc->port, pinc->pin, pincfg.config & ~PmnPFS_PMR_POS);
+		pinctrl_ra_write_PmnFPS(pinc->port, pinc->pin,
+					pincfg.config & ~(BIT(PmnPFS_PMR_POS)));
 	}
 
 	pinctrl_ra_write_PmnFPS(pinc->port, pinc->pin, pincfg.config);

--- a/dts/arm/renesas/ra/ra-cm4-common.dtsi
+++ b/dts/arm/renesas/ra/ra-cm4-common.dtsi
@@ -169,10 +169,9 @@
 			interrupts = <RA_ICU_IRQ_UNSPECIFIED 0 RA_ICU_PORT_IRQ0>,
 				     <RA_ICU_IRQ_UNSPECIFIED 0 RA_ICU_PORT_IRQ1>,
 				     <RA_ICU_IRQ_UNSPECIFIED 0 RA_ICU_PORT_IRQ2>,
-				     <RA_ICU_IRQ_UNSPECIFIED 0 RA_ICU_PORT_IRQ3>,
-				     <RA_ICU_IRQ_UNSPECIFIED 0 RA_ICU_PORT_IRQ9>;
+				     <RA_ICU_IRQ_UNSPECIFIED 0 RA_ICU_PORT_IRQ3>;
 			interrupt-names = "port-irq0", "port-irq1", "port-irq2",
-					  "port-irq3", "port-irq9";
+					  "port-irq3";
 			port-irq0-pins = <6>;
 			port-irq1-pins = <5>;
 			port-irq2-pins = <13>;

--- a/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-ra-common.h
+++ b/include/zephyr/dt-bindings/pinctrl/renesas/pinctrl-ra-common.h
@@ -10,7 +10,7 @@
 #define PORT4_POS  29
 #define PORT4_MASK 0x1
 #define PSEL_POS   24
-#define PSEL_MASK  0x5
+#define PSEL_MASK  0x1f
 #define PORT_POS   21
 #define PORT_MASK  0x7
 #define PIN_POS    17


### PR DESCRIPTION
There was a problem with the pinctrl driver and dts settings for Renesas RA that I previously submitted, so I will fix it.
Corrected pinctrl bit judgment error and dts setting inconsistency.