### PR TITLE
Correctly reset sample_index when using ADC with repeat and extra_samplings

### DIFF
--- a/drivers/adc/adc_context.h
+++ b/drivers/adc/adc_context.h
@@ -255,6 +255,7 @@ static inline void adc_context_on_sampling_done(struct adc_context *ctx,
 		switch (action) {
 		case ADC_ACTION_REPEAT:
 			repeat = true;
+			ctx->sampling_index = 0U;
 			break;
 		case ADC_ACTION_FINISH:
 			finish = true;


### PR DESCRIPTION
When using ADC with adc_sequence_options.extra_samplings > 0 and repeating ADC sampling, the sample index was not reset back to 0.
Instead, sample_index reached the value of adc_sequence_options.extra_samplings and was stuck on that value.