### PR TITLE
bluetooth: controller: refactor node_rx_pdu for memory optimization

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -2966,7 +2966,7 @@ static void le_df_connectionless_iq_report(struct pdu_data *pdu_rx,
 		return;
 	}
 
-	lll = iq_report->hdr.rx_ftr.param;
+	lll = iq_report->rx.rx_ftr.param;
 
 	/* If there is not LLL context and CONFIG_BT_CTLR_DTM_HCI_DF_IQ_REPORT is enabled
 	 * the controller is in the Direct Test Mode and may generate
@@ -3018,7 +3018,7 @@ static void le_df_connectionless_iq_report(struct pdu_data *pdu_rx,
 		       (sizeof(*sep) +
 			(samples_cnt * sizeof(struct bt_hci_le_iq_sample))));
 
-	rssi = RSSI_DBM_TO_DECI_DBM(iq_report->hdr.rx_ftr.rssi);
+	rssi = RSSI_DBM_TO_DECI_DBM(iq_report->rx.rx_ftr.rssi);
 
 
 	sep->sync_handle = sys_cpu_to_le16(sync_handle);
@@ -3116,7 +3116,7 @@ static void le_df_connection_iq_report(struct node_rx_pdu *node_rx, struct net_b
 		return;
 	}
 
-	lll = iq_report->hdr.rx_ftr.param;
+	lll = iq_report->rx.rx_ftr.param;
 
 #if defined(CONFIG_BT_CTLR_PHY)
 	phy_rx = lll->phy_rx;
@@ -3149,9 +3149,9 @@ static void le_df_connection_iq_report(struct node_rx_pdu *node_rx, struct net_b
 	sep = meta_evt(buf, BT_HCI_EVT_LE_CONNECTION_IQ_REPORT,
 		       (sizeof(*sep) + (samples_cnt * sizeof(struct bt_hci_le_iq_sample))));
 
-	rssi = RSSI_DBM_TO_DECI_DBM(iq_report->hdr.rx_ftr.rssi);
+	rssi = RSSI_DBM_TO_DECI_DBM(iq_report->rx.rx_ftr.rssi);
 
-	sep->conn_handle = sys_cpu_to_le16(iq_report->hdr.handle);
+	sep->conn_handle = sys_cpu_to_le16(iq_report->rx.hdr.handle);
 	sep->rx_phy = phy_rx;
 	sep->rssi = sys_cpu_to_le16(rssi);
 	sep->rssi_ant_id = iq_report->rssi_ant_id;
@@ -4228,7 +4228,7 @@ static void le_cis_established(struct pdu_data *pdu_data,
 		return;
 	}
 
-	cis = node_rx->hdr.rx_ftr.param;
+	cis = node_rx->rx_ftr.param;
 	cig = cis->group;
 
 	sep = meta_evt(buf, BT_HCI_EVT_LE_CIS_ESTABLISHED, sizeof(*sep));
@@ -5149,7 +5149,7 @@ static void vs_le_df_connectionless_iq_report(struct pdu_data *pdu_rx, struct no
 		return;
 	}
 
-	lll = iq_report->hdr.rx_ftr.param;
+	lll = iq_report->rx.rx_ftr.param;
 
 	sync = HDR_LLL2ULL(lll);
 
@@ -5183,7 +5183,7 @@ static void vs_le_df_connectionless_iq_report(struct pdu_data *pdu_rx, struct no
 	sep = vs_event(buf, BT_HCI_EVT_VS_LE_CONNECTIONLESS_IQ_REPORT,
 		       (sizeof(*sep) + (samples_cnt * sizeof(struct bt_hci_le_iq_sample16))));
 
-	rssi = RSSI_DBM_TO_DECI_DBM(iq_report->hdr.rx_ftr.rssi);
+	rssi = RSSI_DBM_TO_DECI_DBM(iq_report->rx.rx_ftr.rssi);
 
 	sep->sync_handle = sys_cpu_to_le16(sync_handle);
 	sep->rssi = sys_cpu_to_le16(rssi);
@@ -5235,7 +5235,7 @@ static void vs_le_df_connection_iq_report(struct node_rx_pdu *node_rx, struct ne
 		return;
 	}
 
-	lll = iq_report->hdr.rx_ftr.param;
+	lll = iq_report->rx.rx_ftr.param;
 
 #if defined(CONFIG_BT_CTLR_PHY)
 	phy_rx = lll->phy_rx;
@@ -5268,9 +5268,9 @@ static void vs_le_df_connection_iq_report(struct node_rx_pdu *node_rx, struct ne
 	sep = vs_event(buf, BT_HCI_EVT_VS_LE_CONNECTION_IQ_REPORT,
 			(sizeof(*sep) + (samples_cnt * sizeof(struct bt_hci_le_iq_sample16))));
 
-	rssi = RSSI_DBM_TO_DECI_DBM(iq_report->hdr.rx_ftr.rssi);
+	rssi = RSSI_DBM_TO_DECI_DBM(iq_report->rx.rx_ftr.rssi);
 
-	sep->conn_handle = sys_cpu_to_le16(iq_report->hdr.handle);
+	sep->conn_handle = sys_cpu_to_le16(iq_report->rx.hdr.handle);
 	sep->rx_phy = phy_rx;
 	sep->rssi = sys_cpu_to_le16(rssi);
 	sep->rssi_ant_id = iq_report->rssi_ant_id;
@@ -6347,8 +6347,8 @@ static inline void le_mesh_scan_report(struct pdu_adv *adv,
 		return;
 	}
 
-	chan = node_rx->hdr.rx_ftr.chan;
-	instant = node_rx->hdr.rx_ftr.anchor_ticks;
+	chan = node_rx->rx_ftr.chan;
+	instant = node_rx->rx_ftr.anchor_ticks;
 
 	mep = mesh_evt(buf, BT_HCI_EVT_MESH_SCANNING_REPORT,
 			    sizeof(*mep) + sizeof(*sr));
@@ -6386,12 +6386,12 @@ static void le_advertising_report(struct pdu_data *pdu_data,
 #endif /* CONFIG_BT_CTLR_EXT_SCAN_FP */
 	int8_t *prssi;
 
-	rssi = -(node_rx->hdr.rx_ftr.rssi);
+	rssi = -(node_rx->rx_ftr.rssi);
 #if defined(CONFIG_BT_CTLR_PRIVACY)
-	rl_idx = node_rx->hdr.rx_ftr.rl_idx;
+	rl_idx = node_rx->rx_ftr.rl_idx;
 #endif /* CONFIG_BT_CTLR_PRIVACY */
 #if defined(CONFIG_BT_CTLR_EXT_SCAN_FP)
-	direct_report = node_rx->hdr.rx_ftr.direct;
+	direct_report = node_rx->rx_ftr.direct;
 #endif /* CONFIG_BT_CTLR_EXT_SCAN_FP */
 
 #if defined(CONFIG_BT_CTLR_PRIVACY)
@@ -6515,10 +6515,10 @@ static void le_ext_adv_legacy_report(struct pdu_data *pdu_data,
 	}
 
 	/* The Link Layer currently returns RSSI as an absolute value */
-	rssi = -(node_rx->hdr.rx_ftr.rssi);
+	rssi = -(node_rx->rx_ftr.rssi);
 
 #if defined(CONFIG_BT_CTLR_PRIVACY)
-	rl_idx = node_rx->hdr.rx_ftr.rl_idx;
+	rl_idx = node_rx->rx_ftr.rl_idx;
 #endif /* CONFIG_BT_CTLR_PRIVACY */
 
 #if defined(CONFIG_BT_CTLR_PRIVACY)
@@ -6712,7 +6712,7 @@ static void node_rx_extra_list_release(struct node_rx_pdu *node_rx_extra)
 		struct node_rx_pdu *node_rx_curr;
 
 		node_rx_curr = node_rx_extra;
-		node_rx_extra = node_rx_curr->hdr.rx_ftr.extra;
+		node_rx_extra = node_rx_curr->rx_ftr.extra;
 
 		node_rx_curr->hdr.next = NULL;
 		ll_rx_mem_release((void **)&node_rx_curr);
@@ -6841,7 +6841,7 @@ static void ext_adv_data_frag(const struct node_rx_pdu *node_rx_data,
 				 data, buf, evt_buf);
 
 		/* Check if more PDUs in the list */
-		node_rx_data = node_rx_data->hdr.rx_ftr.extra;
+		node_rx_data = node_rx_data->rx_ftr.extra;
 		if (node_rx_data) {
 			if (*data_len >= data_len_total) {
 				/* Last fragment restricted to maximum scan
@@ -6918,7 +6918,7 @@ static void le_ext_adv_report(struct pdu_data *pdu_data,
 	 */
 	if (!(event_mask & BT_EVT_MASK_LE_META_EVENT) ||
 	    !(le_event_mask & BT_EVT_MASK_LE_EXT_ADVERTISING_REPORT)) {
-		node_rx_extra_list_release(node_rx->hdr.rx_ftr.extra);
+		node_rx_extra_list_release(node_rx->rx_ftr.extra);
 		return;
 	}
 
@@ -6928,7 +6928,7 @@ static void le_ext_adv_report(struct pdu_data *pdu_data,
 
 	adv = (void *)pdu_data;
 	node_rx_curr = node_rx;
-	node_rx_next = node_rx_curr->hdr.rx_ftr.extra;
+	node_rx_next = node_rx_curr->rx_ftr.extra;
 	do {
 		int8_t tx_pwr_curr = BT_HCI_LE_ADV_TX_POWER_NO_PREF;
 		struct pdu_adv_adi *adi_curr = NULL;
@@ -6948,22 +6948,22 @@ static void le_ext_adv_report(struct pdu_data *pdu_data,
 		uint8_t *ptr;
 
 #if defined(CONFIG_BT_CTLR_EXT_SCAN_FP)
-		bool direct_report_curr = node_rx_curr->hdr.rx_ftr.direct;
+		bool direct_report_curr = node_rx_curr->rx_ftr.direct;
 #endif /* CONFIG_BT_CTLR_EXT_SCAN_FP */
 
 #if defined(CONFIG_BT_CTLR_PRIVACY)
-		uint8_t rl_idx_curr = node_rx_curr->hdr.rx_ftr.rl_idx;
+		uint8_t rl_idx_curr = node_rx_curr->rx_ftr.rl_idx;
 
-		direct_resolved_curr = node_rx_curr->hdr.rx_ftr.direct_resolved;
+		direct_resolved_curr = node_rx_curr->rx_ftr.direct_resolved;
 #endif /* CONFIG_BT_CTLR_PRIVACY */
 
 #if defined(CONFIG_BT_CTLR_SYNC_PERIODIC) && \
 	defined(CONFIG_BT_CTLR_FILTER_ACCEPT_LIST)
-		const bool devmatch_curr = node_rx_curr->hdr.rx_ftr.devmatch;
+		const bool devmatch_curr = node_rx_curr->rx_ftr.devmatch;
 #endif /* CONFIG_BT_CTLR_SYNC_PERIODIC && CONFIG_BT_CTLR_FILTER_ACCEPT_LIST */
 
 		/* The Link Layer currently returns RSSI as an absolute value */
-		rssi = -(node_rx_curr->hdr.rx_ftr.rssi);
+		rssi = -(node_rx_curr->rx_ftr.rssi);
 
 		LOG_DBG("phy= 0x%x, type= 0x%x, len= %u, tat= %u, rat= %u,"
 		       " rssi=%d dB", phy, adv->type, adv->len, adv->tx_addr,
@@ -6988,7 +6988,7 @@ static void le_ext_adv_report(struct pdu_data *pdu_data,
 		if (h->adv_addr) {
 			/* AdvA is RFU in AUX_CHAIN_IND */
 			if (node_rx_curr == node_rx ||
-			    node_rx_curr == node_rx->hdr.rx_ftr.extra) {
+			    node_rx_curr == node_rx->rx_ftr.extra) {
 				bt_addr_le_t addr;
 
 				adv_addr_type_curr = adv->tx_addr;
@@ -7006,11 +7006,11 @@ static void le_ext_adv_report(struct pdu_data *pdu_data,
 		if (h->tgt_addr) {
 			/* TargetA is RFU in AUX_CHAIN_IND */
 			if (node_rx_curr == node_rx ||
-			    node_rx_curr == node_rx->hdr.rx_ftr.extra) {
+			    node_rx_curr == node_rx->rx_ftr.extra) {
 				struct lll_scan *lll;
 				bt_addr_le_t addr;
 
-				lll = node_rx->hdr.rx_ftr.param;
+				lll = node_rx->rx_ftr.param;
 
 #if defined(CONFIG_BT_CTLR_EXT_SCAN_FP)
 				direct_addr_type_curr =
@@ -7056,7 +7056,7 @@ static void le_ext_adv_report(struct pdu_data *pdu_data,
 			struct pdu_adv_aux_ptr *aux_ptr;
 
 			/* AuxPtr is RFU for connectable or scannable AUX_ADV_IND */
-			if (node_rx_curr != node_rx->hdr.rx_ftr.extra ||
+			if (node_rx_curr != node_rx->rx_ftr.extra ||
 			    evt_type_curr == 0U) {
 				uint8_t aux_phy;
 
@@ -7071,7 +7071,7 @@ static void le_ext_adv_report(struct pdu_data *pdu_data,
 				    PDU_ADV_AUX_PTR_PHY_GET(aux_ptr) > EXT_ADV_AUX_PHY_LE_CODED) {
 					struct node_rx_ftr *ftr;
 
-					ftr = &node_rx->hdr.rx_ftr;
+					ftr = &node_rx->rx_ftr;
 					node_rx_extra_list_release(ftr->extra);
 					return;
 				}
@@ -7190,7 +7190,7 @@ no_ext_hdr:
 			/* TODO: Validate current value with previous */
 
 			/* Detect the scan response in the list of node_rx */
-			if (node_rx_curr->hdr.rx_ftr.scan_rsp) {
+			if (node_rx_curr->rx_ftr.scan_rsp) {
 				node_rx_scan_data = node_rx_curr;
 				if (sec_phy_curr) {
 					sec_phy_scan = sec_phy_curr;
@@ -7255,14 +7255,14 @@ no_ext_hdr:
 		}
 
 		node_rx_curr = node_rx_next;
-		node_rx_next = node_rx_curr->hdr.rx_ftr.extra;
+		node_rx_next = node_rx_curr->rx_ftr.extra;
 		adv = (void *)node_rx_curr->pdu;
 	} while (1);
 
 	if (IS_ENABLED(CONFIG_BT_CTLR_SYNC_PERIODIC) &&
 	    IS_ENABLED(CONFIG_BT_CTLR_FILTER_ACCEPT_LIST) &&
 	    !devmatch) {
-		node_rx_extra_list_release(node_rx->hdr.rx_ftr.extra);
+		node_rx_extra_list_release(node_rx->rx_ftr.extra);
 		return;
 	}
 
@@ -7271,7 +7271,7 @@ no_ext_hdr:
 		if (dup_scan &&
 		    dup_found(PDU_ADV_TYPE_EXT_IND, adv_addr_type, adv_addr,
 			      (evt_type & BIT_MASK(2)), adi, data_status)) {
-			node_rx_extra_list_release(node_rx->hdr.rx_ftr.extra);
+			node_rx_extra_list_release(node_rx->rx_ftr.extra);
 			return;
 		}
 	}
@@ -7290,7 +7290,7 @@ no_ext_hdr:
 			 * is present or if Tx pwr and/or data is present from
 			 * anonymous device.
 			 */
-			node_rx_extra_list_release(node_rx->hdr.rx_ftr.extra);
+			node_rx_extra_list_release(node_rx->rx_ftr.extra);
 			return;
 		}
 	}
@@ -7329,7 +7329,7 @@ no_ext_hdr:
 
 	/* If scan response event to be constructed */
 	if (!scan_data) {
-		node_rx_extra_list_release(node_rx->hdr.rx_ftr.extra);
+		node_rx_extra_list_release(node_rx->rx_ftr.extra);
 
 		return;
 	}
@@ -7370,7 +7370,7 @@ no_ext_hdr:
 			  scan_rsp_tx_pwr, rssi, interval_le16, adi,
 			  scan_data_len, scan_data, evt_buf);
 
-	node_rx_extra_list_release(node_rx->hdr.rx_ftr.extra);
+	node_rx_extra_list_release(node_rx->rx_ftr.extra);
 }
 
 static void le_adv_ext_report(struct pdu_data *pdu_data,
@@ -7449,7 +7449,7 @@ static void le_per_adv_sync_established(struct pdu_data *pdu_data,
 		return;
 	}
 
-	scan = node_rx->hdr.rx_ftr.param;
+	scan = node_rx->rx_ftr.param;
 
 #if (CONFIG_BT_CTLR_DUP_FILTER_LEN > 0) && \
 	defined(CONFIG_BT_CTLR_SYNC_PERIODIC_ADI_SUPPORT)
@@ -7476,7 +7476,7 @@ static void le_per_adv_sync_report(struct pdu_data *pdu_data,
 				   struct node_rx_pdu *node_rx,
 				   struct net_buf *buf)
 {
-	struct node_rx_ftr *ftr = &node_rx->hdr.rx_ftr;
+	struct node_rx_ftr *ftr = &node_rx->rx_ftr;
 	int8_t tx_pwr = BT_HCI_LE_ADV_TX_POWER_NO_PREF;
 	struct pdu_adv *adv = (void *)pdu_data;
 	struct pdu_adv_aux_ptr *aux_ptr = NULL;
@@ -7520,10 +7520,10 @@ static void le_per_adv_sync_report(struct pdu_data *pdu_data,
 		return;
 	}
 
-	data_len_total = node_rx->hdr.rx_ftr.aux_data_len;
+	data_len_total = ftr->aux_data_len;
 
 	if ((le_event_mask & BT_EVT_MASK_LE_PER_ADVERTISING_REPORT) &&
-	    (node_rx->hdr.rx_ftr.aux_failed || data_len_total > CONFIG_BT_CTLR_SCAN_DATA_LEN_MAX)) {
+	    (ftr->aux_failed || data_len_total > CONFIG_BT_CTLR_SCAN_DATA_LEN_MAX)) {
 		struct bt_hci_evt_le_per_advertising_report *sep;
 
 		sep = meta_evt(buf,
@@ -7541,7 +7541,7 @@ static void le_per_adv_sync_report(struct pdu_data *pdu_data,
 	}
 
 	/* The Link Layer currently returns RSSI as an absolute value */
-	rssi = -(node_rx->hdr.rx_ftr.rssi);
+	rssi = -(ftr->rssi);
 
 	LOG_DBG("len = %u, rssi = %d", adv->len, rssi);
 
@@ -7844,7 +7844,7 @@ static void le_big_sync_established(struct pdu_data *pdu,
 		return;
 	}
 
-	sync_iso = node_rx->hdr.rx_ftr.param;
+	sync_iso = node_rx->rx_ftr.param;
 	lll = &sync_iso->lll;
 
 	evt_size = sizeof(*sep) + (lll->num_bis * sizeof(uint16_t));
@@ -7918,12 +7918,12 @@ static void le_adv_ext_terminate(struct pdu_data *pdu_data,
 	}
 
 	sep = meta_evt(buf, BT_HCI_EVT_LE_ADV_SET_TERMINATED, sizeof(*sep));
-	sep->status = node_rx->hdr.rx_ftr.param_adv_term.status;
+	sep->status = node_rx->rx_ftr.param_adv_term.status;
 	sep->adv_handle = ll_adv_set_hci_handle_get(node_rx->hdr.handle & 0xff);
 	sep->conn_handle =
-		sys_cpu_to_le16(node_rx->hdr.rx_ftr.param_adv_term.conn_handle);
+		sys_cpu_to_le16(node_rx->rx_ftr.param_adv_term.conn_handle);
 	sep->num_completed_ext_adv_evts =
-		node_rx->hdr.rx_ftr.param_adv_term.num_events;
+		node_rx->rx_ftr.param_adv_term.num_events;
 }
 
 #if defined(CONFIG_BT_CTLR_ADV_ISO)
@@ -7936,7 +7936,7 @@ static void le_big_complete(struct pdu_data *pdu_data,
 	struct lll_adv_iso *lll;
 	size_t evt_size;
 
-	adv_iso = node_rx->hdr.rx_ftr.param;
+	adv_iso = node_rx->rx_ftr.param;
 	lll = &adv_iso->lll;
 
 	evt_size = sizeof(*sep) + (lll->num_bis * sizeof(uint16_t));
@@ -8015,7 +8015,7 @@ static void le_scan_req_received(struct pdu_data *pdu_data,
 		       sizeof(bt_addr_t));
 
 		/* The Link Layer currently returns RSSI as an absolute value */
-		rssi = -(node_rx->hdr.rx_ftr.rssi);
+		rssi = -(node_rx->rx_ftr.rssi);
 
 		LOG_DBG("handle: %d, addr: %s, rssi: %d dB.", handle, bt_addr_le_str(&addr), rssi);
 
@@ -8029,7 +8029,7 @@ static void le_scan_req_received(struct pdu_data *pdu_data,
 	       sizeof(bt_addr_t));
 
 #if defined(CONFIG_BT_CTLR_PRIVACY)
-	rl_idx = node_rx->hdr.rx_ftr.rl_idx;
+	rl_idx = node_rx->rx_ftr.rl_idx;
 	if (rl_idx < ll_rl_size_get()) {
 		/* Store identity address */
 		ll_rl_id_addr_get(rl_idx, &sep->addr.type,
@@ -8069,7 +8069,7 @@ static void le_vs_scan_req_received(struct pdu_data *pdu,
 	       sizeof(bt_addr_t));
 
 #if defined(CONFIG_BT_CTLR_PRIVACY)
-	rl_idx = node_rx->hdr.rx_ftr.rl_idx;
+	rl_idx = node_rx->rx_ftr.rl_idx;
 	if (rl_idx < ll_rl_size_get()) {
 		/* Store identity address */
 		ll_rl_id_addr_get(rl_idx, &sep->addr.type,
@@ -8086,7 +8086,7 @@ static void le_vs_scan_req_received(struct pdu_data *pdu,
 	}
 
 	/* The Link Layer currently returns RSSI as an absolute value */
-	sep->rssi = -(node_rx->hdr.rx_ftr.rssi);
+	sep->rssi = -(node_rx->rx_ftr.rssi);
 }
 #endif /* CONFIG_BT_CTLR_VS_SCAN_REQ_RX */
 #endif /* CONFIG_BT_CTLR_SCAN_REQ_NOTIFY */

--- a/subsys/bluetooth/controller/hci/hci_driver.c
+++ b/subsys/bluetooth/controller/hci/hci_driver.c
@@ -462,7 +462,7 @@ static inline struct net_buf *encode_node(struct node_rx_pdu *node_rx,
 				if (dp && dp->path_id == BT_HCI_DATAPATH_ID_HCI) {
 					/* If HCI datapath pass to ISO AL here */
 					struct isoal_pdu_rx pckt_meta = {
-						.meta = &node_rx->hdr.rx_iso_meta,
+						.meta = &node_rx->rx_iso_meta,
 						.pdu  = (void *)&node_rx->pdu[0],
 					};
 
@@ -491,7 +491,7 @@ static inline struct net_buf *encode_node(struct node_rx_pdu *node_rx,
 			 */
 			if (stream && stream->dp &&
 			    (stream->dp->path_id == BT_HCI_DATAPATH_ID_HCI)) {
-				isoal_rx.meta = &node_rx->hdr.rx_iso_meta;
+				isoal_rx.meta = &node_rx->rx_iso_meta;
 				isoal_rx.pdu = (void *)node_rx->pdu;
 				err = isoal_rx_pdu_recombine(stream->dp->sink_hdl, &isoal_rx);
 

--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -409,11 +409,19 @@ struct node_rx_hdr {
 		memq_link_t *link;    /* Supply memq_link from ULL to LLL */
 		uint8_t     ack_last; /* Tx ack queue index at this node rx */
 	};
-
 	enum node_rx_type type;
 	uint8_t           user_meta; /* User metadata */
 	uint16_t          handle;    /* State/Role instance handle */
+};
 
+
+/* Template node rx type with memory aligned offset to PDU buffer.
+ * NOTE: offset to memory aligned pdu buffer location is used to reference
+ *       node rx type specific information, like, terminate or sync lost reason
+ *       from a dedicated node rx structure storage location.
+ */
+struct node_rx_pdu {
+	struct node_rx_hdr hdr;
 	union {
 		struct node_rx_ftr rx_ftr;
 #if defined(CONFIG_BT_CTLR_SYNC_ISO) || defined(CONFIG_BT_CTLR_CONN_ISO)
@@ -423,15 +431,6 @@ struct node_rx_hdr {
 		lll_rx_pdu_meta_t  rx_pdu_meta;
 #endif /* CONFIG_BT_CTLR_RX_PDU_META */
 	};
-};
-
-/* Template node rx type with memory aligned offset to PDU buffer.
- * NOTE: offset to memory aligned pdu buffer location is used to reference
- *       node rx type specific information, like, terminate or sync lost reason
- *       from a dedicated node rx structure storage location.
- */
-struct node_rx_pdu {
-	struct node_rx_hdr hdr;
 	union {
 		uint8_t    pdu[0] __aligned(4);
 	};

--- a/subsys/bluetooth/controller/ll_sw/lll_adv.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_adv.h
@@ -195,7 +195,7 @@ struct lll_adv {
 	struct lll_adv_pdu scan_rsp;
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
-	struct node_rx_hdr *node_rx_adv_term;
+	struct node_rx_pdu *node_rx_adv_term;
 	struct lll_adv_aux *aux;
 
 #if defined(CONFIG_BT_CTLR_ADV_PERIODIC)

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -725,10 +725,10 @@ int lll_adv_scan_req_report(struct lll_adv *lll, struct pdu_adv *pdu_adv_rx,
 	node_rx->hdr.type = NODE_RX_TYPE_SCAN_REQ;
 	node_rx->hdr.handle = ull_adv_lll_handle_get(lll);
 
-	node_rx->hdr.rx_ftr.rssi = (rssi_ready) ? radio_rssi_get() :
+	node_rx->rx_ftr.rssi = (rssi_ready) ? radio_rssi_get() :
 						  BT_HCI_LE_RSSI_NOT_AVAILABLE;
 #if defined(CONFIG_BT_CTLR_PRIVACY)
-	node_rx->hdr.rx_ftr.rl_idx = rl_idx;
+	node_rx->rx_ftr.rl_idx = rl_idx;
 #endif
 
 	ull_rx_put_sched(node_rx->hdr.link, node_rx);
@@ -1387,15 +1387,15 @@ static void isr_done(void *param)
 	}
 
 #if defined(CONFIG_BT_CTLR_ADV_INDICATION)
-	struct node_rx_hdr *node_rx = ull_pdu_rx_alloc_peek(3);
+	struct node_rx_pdu *node_rx = ull_pdu_rx_alloc_peek(3);
 
 	if (node_rx) {
 		ull_pdu_rx_alloc();
 
 		/* TODO: add other info by defining a payload struct */
-		node_rx->type = NODE_RX_TYPE_ADV_INDICATION;
+		node_rx->hdr.type = NODE_RX_TYPE_ADV_INDICATION;
 
-		ull_rx_put_sched(node_rx->link, node_rx);
+		ull_rx_put_sched(node_rx->hdr.link, node_rx);
 	}
 #endif /* CONFIG_BT_CTLR_ADV_INDICATION */
 
@@ -1641,7 +1641,7 @@ static inline int isr_rx_pdu(struct lll_adv *lll,
 		rx->hdr.type = NODE_RX_TYPE_CONNECTION;
 		rx->hdr.handle = 0xffff;
 
-		ftr = &(rx->hdr.rx_ftr);
+		ftr = &(rx->rx_ftr);
 		ftr->param = lll;
 		ftr->ticks_anchor = radio_tmr_start_get();
 		ftr->radio_end_us = radio_tmr_end_get() -

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -788,7 +788,7 @@ static inline int isr_rx_pdu(struct lll_adv_aux *lll_aux, uint8_t phy_flags_rx,
 		rx->hdr.type = NODE_RX_TYPE_CONNECTION;
 		rx->hdr.handle = 0xffff;
 
-		ftr = &(rx->hdr.rx_ftr);
+		ftr = &(rx->rx_ftr);
 		ftr->param = lll;
 		ftr->ticks_anchor = radio_tmr_start_get();
 		ftr->radio_end_us = radio_tmr_end_get() -
@@ -862,7 +862,7 @@ static void isr_tx_connect_rsp(void *param)
 	bool is_done;
 
 	rx = param;
-	ftr = &(rx->hdr.rx_ftr);
+	ftr = &(rx->rx_ftr);
 	lll = ftr->param;
 
 	is_done = radio_is_done();

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_iso.c
@@ -839,7 +839,7 @@ static void isr_done_term(void *param)
 			sync_lll = adv_lll->sync;
 			if (sync_lll->iso_chm_done_req ==
 			    sync_lll->iso_chm_done_ack) {
-				struct node_rx_hdr *rx;
+				struct node_rx_pdu *rx;
 
 				/* Request ULL to update the channel map in the
 				 * BIGInfo struct present in the current PDU of
@@ -855,10 +855,10 @@ static void isr_done_term(void *param)
 				rx = ull_pdu_rx_alloc();
 				LL_ASSERT(rx);
 
-				rx->type = NODE_RX_TYPE_BIG_CHM_COMPLETE;
+				rx->hdr.type = NODE_RX_TYPE_BIG_CHM_COMPLETE;
 				rx->rx_ftr.param = lll;
 
-				ull_rx_put_sched(rx->link, rx);
+				ull_rx_put_sched(rx->hdr.link, rx);
 			}
 
 			/* Use new channel map */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
@@ -311,7 +311,7 @@ static void isr_done(void *param)
 	 */
 	if ((lll->chm_first != lll->chm_last) &&
 	    is_instant_or_past(lll->event_counter, lll->chm_instant)) {
-		struct node_rx_hdr *rx;
+		struct node_rx_pdu *rx;
 
 		/* Allocate, prepare and dispatch Channel Map Update
 		 * complete message towards ULL, then subsequently to
@@ -320,10 +320,10 @@ static void isr_done(void *param)
 		rx = ull_pdu_rx_alloc();
 		LL_ASSERT(rx);
 
-		rx->type = NODE_RX_TYPE_SYNC_CHM_COMPLETE;
+		rx->hdr.type = NODE_RX_TYPE_SYNC_CHM_COMPLETE;
 		rx->rx_ftr.param = lll;
 
-		ull_rx_put_sched(rx->link, rx);
+		ull_rx_put_sched(rx->hdr.link, rx);
 	}
 
 	lll_isr_done(lll);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
@@ -764,7 +764,7 @@ static void isr_rx(void *param)
 			/* Enqueue Rx ISO PDU */
 			node_rx->hdr.type = NODE_RX_TYPE_ISO_PDU;
 			node_rx->hdr.handle = cis_lll->handle;
-			iso_meta = &node_rx->hdr.rx_iso_meta;
+			iso_meta = &node_rx->rx_iso_meta;
 			iso_meta->payload_number = cis_lll->rx.payload_count +
 						   cis_lll->rx.bn_curr - 1U;
 			iso_meta->timestamp =

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -1095,7 +1095,7 @@ static inline bool create_iq_report(struct lll_conn *lll, uint8_t rssi_ready, ui
 		ant = radio_df_pdu_antenna_switch_pattern_get();
 		iq_report = ull_df_iq_report_alloc();
 
-		iq_report->hdr.type = NODE_RX_TYPE_CONN_IQ_SAMPLE_REPORT;
+		iq_report->rx.hdr.type = NODE_RX_TYPE_CONN_IQ_SAMPLE_REPORT;
 		iq_report->sample_count = radio_df_iq_samples_amount_get();
 		iq_report->packet_status = packet_status;
 		iq_report->rssi_ant_id = ant;
@@ -1106,11 +1106,11 @@ static inline bool create_iq_report(struct lll_conn *lll, uint8_t rssi_ready, ui
 		 */
 		iq_report->event_counter = lll->event_counter - 1;
 
-		ftr = &iq_report->hdr.rx_ftr;
+		ftr = &iq_report->rx.rx_ftr;
 		ftr->param = lll;
 		ftr->rssi = ((rssi_ready) ? radio_rssi_get() : BT_HCI_LE_RSSI_NOT_AVAILABLE);
 
-		ull_rx_put(iq_report->hdr.link, iq_report);
+		ull_rx_put(iq_report->rx.hdr.link, iq_report);
 
 		return true;
 	}

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df_types.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df_types.h
@@ -96,11 +96,11 @@ struct iq_sample {
 
 /* Receive node aimed to report collected IQ samples during CTE receive */
 struct node_rx_iq_report {
-	/* hdr member must be a first member of the structure. It can't be moved because
+	/* node_rx_pdu member must be a first member of the structure. It can't be moved because
 	 * it is expected to be in the beginning of a node memory for common handling of
 	 * all node_rx_xxx types.
 	 */
-	struct node_rx_hdr hdr;
+	struct node_rx_pdu rx;
 	uint8_t sample_count;
 	struct pdu_cte_info cte_info;
 	uint8_t local_slot_durations;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
@@ -594,7 +594,7 @@ static void isr_rx(void *param)
 			/* Enqueue Rx ISO PDU */
 			node_rx->hdr.type = NODE_RX_TYPE_ISO_PDU;
 			node_rx->hdr.handle = cis_lll->handle;
-			iso_meta = &node_rx->hdr.rx_iso_meta;
+			iso_meta = &node_rx->rx_iso_meta;
 			iso_meta->payload_number = cis_lll->rx.payload_count +
 						   cis_lll->rx.bn_curr - 1U;
 			iso_meta->timestamp = cis_lll->offset +

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -1040,7 +1040,7 @@ static void isr_done_cleanup(void *param)
 			  TICKER_ID_SCAN_STOP, NULL, NULL);
 
 #if defined(CONFIG_BT_CTLR_SCAN_INDICATION)
-	struct node_rx_hdr *node_rx;
+	struct node_rx_pdu *node_rx;
 
 	/* Check if there are enough free node rx available:
 	 * 1. For generating this scan indication
@@ -1053,9 +1053,9 @@ static void isr_done_cleanup(void *param)
 		ull_pdu_rx_alloc();
 
 		/* TODO: add other info by defining a payload struct */
-		node_rx->type = NODE_RX_TYPE_SCAN_INDICATION;
+		node_rx->hdr.type = NODE_RX_TYPE_SCAN_INDICATION;
 
-		ull_rx_put_sched(node_rx->link, node_rx);
+		ull_rx_put_sched(node_rx->hdr.link, node_rx);
 	}
 #endif /* CONFIG_BT_CTLR_SCAN_INDICATION */
 
@@ -1097,7 +1097,7 @@ static void isr_done_cleanup(void *param)
 
 		node_rx2->hdr.type = NODE_RX_TYPE_EXT_AUX_RELEASE;
 
-		node_rx2->hdr.rx_ftr.param = lll;
+		node_rx2->rx_ftr.param = lll;
 
 		ull_rx_put_sched(node_rx2->hdr.link, node_rx2);
 	}
@@ -1249,7 +1249,7 @@ static inline int isr_rx_pdu(struct lll_scan *lll, struct pdu_adv *pdu_adv_rx,
 		pdu_adv_rx = (void *)rx->pdu;
 		pdu_adv_rx->chan_sel = pdu_adv_rx_chan_sel;
 
-		ftr = &(rx->hdr.rx_ftr);
+		ftr = &(rx->rx_ftr);
 
 		ftr->param = lll;
 		ftr->ticks_anchor = radio_tmr_start_get();
@@ -1547,7 +1547,7 @@ static int isr_rx_scan_report(struct lll_scan *lll, uint8_t devmatch_ok,
 			{
 				struct node_rx_ftr *ftr;
 
-				ftr = &(node_rx->hdr.rx_ftr);
+				ftr = &(node_rx->rx_ftr);
 				ftr->param = lll;
 				ftr->ticks_anchor = radio_tmr_start_get();
 				ftr->radio_end_us =
@@ -1572,32 +1572,32 @@ static int isr_rx_scan_report(struct lll_scan *lll, uint8_t devmatch_ok,
 		node_rx->hdr.type = NODE_RX_TYPE_REPORT;
 	}
 
-	node_rx->hdr.rx_ftr.rssi = (rssi_ready) ? radio_rssi_get() :
+	node_rx->rx_ftr.rssi = (rssi_ready) ? radio_rssi_get() :
 						  BT_HCI_LE_RSSI_NOT_AVAILABLE;
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 	/* save the resolving list index. */
-	node_rx->hdr.rx_ftr.rl_idx = irkmatch_ok ? rl_idx : FILTER_IDX_NONE;
+	node_rx->rx_ftr.rl_idx = irkmatch_ok ? rl_idx : FILTER_IDX_NONE;
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
-	node_rx->hdr.rx_ftr.direct_resolved = (rl_idx != FILTER_IDX_NONE);
+	node_rx->rx_ftr.direct_resolved = (rl_idx != FILTER_IDX_NONE);
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
 #endif /* CONFIG_BT_CTLR_PRIVACY */
 
 #if defined(CONFIG_BT_CTLR_EXT_SCAN_FP)
 	/* save the directed adv report flag */
-	node_rx->hdr.rx_ftr.direct = dir_report;
+	node_rx->rx_ftr.direct = dir_report;
 #endif /* CONFIG_BT_CTLR_EXT_SCAN_FP */
 
 #if defined(CONFIG_BT_CTLR_SYNC_PERIODIC) && \
 	defined(CONFIG_BT_CTLR_FILTER_ACCEPT_LIST)
-	node_rx->hdr.rx_ftr.devmatch = devmatch_ok;
+	node_rx->rx_ftr.devmatch = devmatch_ok;
 #endif /* CONFIG_BT_CTLR_SYNC_PERIODIC && CONFIG_BT_CTLR_FILTER_ACCEPT_LIST */
 
 #if defined(CONFIG_BT_HCI_MESH_EXT)
 	if (node_rx->hdr.type == NODE_RX_TYPE_MESH_REPORT) {
 		/* save channel and anchor point ticks. */
-		node_rx->hdr.rx_ftr.chan = _radio.scanner.chan - 1;
-		node_rx->hdr.rx_ftr.ticks_anchor = _radio.ticks_anchor;
+		node_rx->rx_ftr.chan = _radio.scanner.chan - 1;
+		node_rx->rx_ftr.ticks_anchor = _radio.ticks_anchor;
 	}
 #endif /* CONFIG_BT_CTLR_EXT_SCAN_FP */
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -227,7 +227,7 @@ uint8_t lll_scan_aux_setup(struct pdu_adv *pdu, uint8_t pdu_phy,
 	LL_ASSERT(node_rx);
 
 	/* Store the lll context, aux_ptr and start of PDU in footer */
-	ftr = &(node_rx->hdr.rx_ftr);
+	ftr = &(node_rx->rx_ftr);
 	ftr->param = param;
 	ftr->aux_ptr = aux_ptr;
 	ftr->radio_end_us = radio_tmr_end_get() -
@@ -258,7 +258,7 @@ void lll_scan_aux_isr_aux_setup(void *param)
 	lll_isr_status_reset();
 
 	node_rx = param;
-	ftr = &node_rx->hdr.rx_ftr;
+	ftr = &node_rx->rx_ftr;
 	aux_ptr = ftr->aux_ptr;
 	phy_aux = BIT(PDU_ADV_AUX_PTR_PHY_GET(aux_ptr));
 	ftr->aux_phy = phy_aux;
@@ -683,8 +683,8 @@ static void isr_done(void *param)
 
 		node_rx->hdr.type = NODE_RX_TYPE_EXT_AUX_RELEASE;
 
-		node_rx->hdr.rx_ftr.param = lll;
-		node_rx->hdr.rx_ftr.aux_failed = 1U;
+		node_rx->rx_ftr.param = lll;
+		node_rx->rx_ftr.aux_failed = 1U;
 
 		ull_rx_put_sched(node_rx->hdr.link, node_rx);
 
@@ -716,8 +716,8 @@ static void isr_rx_lll_schedule(void *param)
 	uint8_t phy_aux;
 
 	node_rx = param;
-	lll = node_rx->hdr.rx_ftr.param;
-	phy_aux = node_rx->hdr.rx_ftr.aux_phy; /* PHY remembered in node rx */
+	lll = node_rx->rx_ftr.param;
+	phy_aux = node_rx->rx_ftr.aux_phy; /* PHY remembered in node rx */
 
 	/* scan context has used LLL scheduling for aux reception */
 	if (lll->is_aux_sched) {
@@ -866,7 +866,7 @@ isr_rx_do_close:
 			 * under race, if ULL execution did assign one, it will
 			 * free it.
 			 */
-			node_rx2->hdr.rx_ftr.param = lll;
+			node_rx2->rx_ftr.param = lll;
 
 			ull_rx_put_sched(node_rx2->hdr.link, node_rx2);
 		}
@@ -1061,7 +1061,7 @@ static int isr_rx_pdu(struct lll_scan *lll, struct lll_scan_aux *lll_aux,
 		pdu = (void *)rx->pdu;
 		pdu->chan_sel = 1;
 
-		ftr = &(rx->hdr.rx_ftr);
+		ftr = &(rx->rx_ftr);
 		ftr->param = lll;
 		ftr->ticks_anchor = radio_tmr_start_get();
 		ftr->radio_end_us = conn_space_us;
@@ -1177,7 +1177,7 @@ static int isr_rx_pdu(struct lll_scan *lll, struct lll_scan_aux *lll_aux,
 
 		node_rx->hdr.type = NODE_RX_TYPE_EXT_AUX_REPORT;
 
-		ftr = &(node_rx->hdr.rx_ftr);
+		ftr = &(node_rx->rx_ftr);
 		if (lll_aux) {
 			ftr->param = lll_aux;
 			radio_isr_set(isr_tx_scan_req_ull_schedule,
@@ -1231,7 +1231,7 @@ static int isr_rx_pdu(struct lll_scan *lll, struct lll_scan_aux *lll_aux,
 					   &dir_report)) {
 #endif /* !CONFIG_BT_CENTRAL */
 
-		ftr = &(node_rx->hdr.rx_ftr);
+		ftr = &(node_rx->rx_ftr);
 		if (lll_aux) {
 			ftr->param = lll_aux;
 			ftr->scan_rsp = lll_aux->state;
@@ -1409,7 +1409,7 @@ static void isr_tx_scan_req_lll_schedule(void *param)
 	struct node_rx_pdu *node_rx;
 	struct lll_scan *lll;
 
-	lll = node_rx_adv->hdr.rx_ftr.param;
+	lll = node_rx_adv->rx_ftr.param;
 
 	node_rx = ull_pdu_rx_alloc_peek(1);
 	LL_ASSERT(node_rx);
@@ -1508,7 +1508,7 @@ static void isr_rx_connect_rsp(void *param)
 		/* Dont stop initiating events on primary channels */
 		lll->is_stop = 0U;
 
-		ftr = &(rx->hdr.rx_ftr);
+		ftr = &(rx->rx_ftr);
 
 		rx->hdr.type = NODE_RX_TYPE_RELEASE;
 		ull_rx_put(rx->hdr.link, rx);
@@ -1548,7 +1548,7 @@ static void isr_rx_connect_rsp(void *param)
 		(void)memcpy(pdu->connect_ind.adv_addr,
 			     &pdu_rx->adv_ext_ind.ext_hdr.data[ADVA_OFFSET],
 			     BDADDR_SIZE);
-		ftr = &(rx->hdr.rx_ftr);
+		ftr = &(rx->rx_ftr);
 		ftr->rl_idx = rl_idx;
 	}
 #endif /* CONFIG_BT_CTLR_PRIVACY */
@@ -1569,7 +1569,7 @@ isr_rx_connect_rsp_do_close:
 
 		node_rx->hdr.type = NODE_RX_TYPE_EXT_AUX_RELEASE;
 
-		node_rx->hdr.rx_ftr.param = lll->lll_aux;
+		node_rx->rx_ftr.param = lll->lll_aux;
 
 		ull_rx_put_sched(node_rx->hdr.link, node_rx);
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -660,7 +660,7 @@ static void isr_aux_setup(void *param)
 	lll_isr_status_reset();
 
 	node_rx = param;
-	ftr = &node_rx->hdr.rx_ftr;
+	ftr = &node_rx->rx_ftr;
 	aux_ptr = ftr->aux_ptr;
 	phy_aux = BIT(PDU_ADV_AUX_PTR_PHY_GET(aux_ptr));
 	ftr->aux_phy = phy_aux;
@@ -817,7 +817,7 @@ static int isr_rx(struct lll_sync *lll, uint8_t node_type, uint8_t crc_ok,
 
 			node_rx->hdr.type = node_type;
 
-			ftr = &(node_rx->hdr.rx_ftr);
+			ftr = &(node_rx->rx_ftr);
 			ftr->param = lll;
 			ftr->aux_failed = 0U;
 			ftr->rssi = (rssi_ready) ? radio_rssi_get() :
@@ -977,7 +977,7 @@ static void isr_rx_adv_sync_estab(void *param)
 
 			node_rx->hdr.type = NODE_RX_TYPE_SYNC;
 
-			ftr = &node_rx->hdr.rx_ftr;
+			ftr = &node_rx->rx_ftr;
 			ftr->param = lll;
 			ftr->sync_status = SYNC_STAT_TERM;
 
@@ -1132,8 +1132,8 @@ isr_rx_aux_chain_done:
 
 		node_rx->hdr.type = NODE_RX_TYPE_EXT_AUX_RELEASE;
 
-		node_rx->hdr.rx_ftr.param = lll;
-		node_rx->hdr.rx_ftr.aux_failed = 1U;
+		node_rx->rx_ftr.param = lll;
+		node_rx->rx_ftr.aux_failed = 1U;
 
 		ull_rx_put(node_rx->hdr.link, node_rx);
 
@@ -1227,8 +1227,8 @@ static void isr_done(void *param)
 
 		node_rx->hdr.type = NODE_RX_TYPE_EXT_AUX_RELEASE;
 
-		node_rx->hdr.rx_ftr.param = lll;
-		node_rx->hdr.rx_ftr.aux_failed = 1U;
+		node_rx->rx_ftr.param = lll;
+		node_rx->rx_ftr.aux_failed = 1U;
 
 		ull_rx_put_sched(node_rx->hdr.link, node_rx);
 	}
@@ -1247,7 +1247,7 @@ static void iq_report_create(struct lll_sync *lll, uint8_t rssi_ready, uint8_t p
 	cte_info = radio_df_cte_status_get();
 	ant = radio_df_pdu_antenna_switch_pattern_get();
 
-	iq_report->hdr.type = NODE_RX_TYPE_SYNC_IQ_SAMPLE_REPORT;
+	iq_report->rx.hdr.type = NODE_RX_TYPE_SYNC_IQ_SAMPLE_REPORT;
 	iq_report->sample_count = radio_df_iq_samples_amount_get();
 	iq_report->packet_status = packet_status;
 	iq_report->rssi_ant_id = ant;
@@ -1258,7 +1258,7 @@ static void iq_report_create(struct lll_sync *lll, uint8_t rssi_ready, uint8_t p
 	 */
 	iq_report->event_counter = lll->event_counter - 1;
 
-	ftr = &iq_report->hdr.rx_ftr;
+	ftr = &iq_report->rx.rx_ftr;
 	ftr->param = lll;
 	ftr->rssi =
 		((rssi_ready) ? radio_rssi_get() : BT_HCI_LE_RSSI_NOT_AVAILABLE);
@@ -1268,7 +1268,7 @@ static void iq_report_incomplete_create(struct lll_sync *lll, struct node_rx_iq_
 {
 	struct node_rx_ftr *ftr;
 
-	iq_report->hdr.type = NODE_RX_TYPE_SYNC_IQ_SAMPLE_REPORT;
+	iq_report->rx.hdr.type = NODE_RX_TYPE_SYNC_IQ_SAMPLE_REPORT;
 	iq_report->sample_count = 0;
 	iq_report->packet_status = BT_HCI_LE_CTE_INSUFFICIENT_RESOURCES;
 	/* Event counter is updated to next value during event preparation,
@@ -1288,7 +1288,7 @@ static void iq_report_incomplete_create(struct lll_sync *lll, struct node_rx_iq_
 		(struct pdu_cte_info){.time = 0, .rfu = 0, .type = 0};
 	iq_report->local_slot_durations = 0;
 
-	ftr = &iq_report->hdr.rx_ftr;
+	ftr = &iq_report->rx.rx_ftr;
 	ftr->param = lll;
 
 	ftr->rssi = BT_HCI_LE_RSSI_NOT_AVAILABLE;
@@ -1337,7 +1337,7 @@ static int iq_report_create_put(struct lll_sync *lll, uint8_t rssi_ready, uint8_
 	}
 
 	if (!err) {
-		ull_rx_put(iq_report->hdr.link, iq_report);
+		ull_rx_put(iq_report->rx.hdr.link, iq_report);
 
 		cfg->cte_count += 1U;
 	}
@@ -1363,7 +1363,7 @@ static int iq_report_incomplete_create_put(struct lll_sync *lll)
 			iq_report_incomplete_create(lll, iq_report);
 
 			lll->node_cte_incomplete = NULL;
-			ull_rx_put(iq_report->hdr.link, iq_report);
+			ull_rx_put(iq_report->rx.hdr.link, iq_report);
 
 			return 0;
 		} else {
@@ -1381,9 +1381,9 @@ static void iq_report_incomplete_release_put(struct lll_sync *lll)
 	if (lll->node_cte_incomplete) {
 		struct node_rx_iq_report *iq_report = lll->node_cte_incomplete;
 
-		iq_report->hdr.type = NODE_RX_TYPE_IQ_SAMPLE_REPORT_LLL_RELEASE;
+		iq_report->rx.hdr.type = NODE_RX_TYPE_IQ_SAMPLE_REPORT_LLL_RELEASE;
 
-		ull_rx_put(iq_report->hdr.link, iq_report);
+		ull_rx_put(iq_report->rx.hdr.link, iq_report);
 		lll->node_cte_incomplete = NULL;
 	}
 }

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
@@ -1264,7 +1264,7 @@ static void isr_rx_iso_data_valid(const struct lll_sync_iso *const lll,
 	node_rx->hdr.type = NODE_RX_TYPE_ISO_PDU;
 	node_rx->hdr.handle = handle;
 
-	iso_meta = &node_rx->hdr.rx_iso_meta;
+	iso_meta = &node_rx->rx_iso_meta;
 	iso_meta->payload_number = lll->payload_count + (lll->bn_curr - 1U) +
 				   (lll->ptc_curr * lll->pto) - lll->bn;
 
@@ -1293,7 +1293,7 @@ static void isr_rx_iso_data_invalid(const struct lll_sync_iso *const lll,
 	node_rx->hdr.type = NODE_RX_TYPE_ISO_PDU;
 	node_rx->hdr.handle = handle;
 
-	iso_meta = &node_rx->hdr.rx_iso_meta;
+	iso_meta = &node_rx->rx_iso_meta;
 	iso_meta->payload_number = lll->payload_count - bn - 1U;
 
 	stream = ull_sync_iso_lll_stream_get(lll->stream_handle[0]);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_test.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_test.c
@@ -151,7 +151,7 @@ static int create_iq_report(bool crc_ok)
 		return -ENOBUFS;
 	}
 
-	iq_report->hdr.type = NODE_RX_TYPE_DTM_IQ_SAMPLE_REPORT;
+	iq_report->rx.hdr.type = NODE_RX_TYPE_DTM_IQ_SAMPLE_REPORT;
 	iq_report->sample_count = sample_cnt;
 	iq_report->packet_status = ((crc_ok) ? BT_HCI_LE_CTE_CRC_OK :
 					       BT_HCI_LE_CTE_CRC_ERR_CTE_BASED_TIME);
@@ -160,11 +160,11 @@ static int create_iq_report(bool crc_ok)
 	iq_report->local_slot_durations = test_slot_duration;
 	iq_report->chan_idx = test_chan;
 
-	ftr = &iq_report->hdr.rx_ftr;
+	ftr = &iq_report->rx.rx_ftr;
 	ftr->param = NULL;
 	ftr->rssi = BT_HCI_LE_RSSI_NOT_AVAILABLE;
 
-	ull_rx_put(iq_report->hdr.link, iq_report);
+	ull_rx_put(iq_report->rx.hdr.link, iq_report);
 
 	return 0;
 }

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
@@ -654,7 +654,7 @@ isr_rx_do_close:
 
 static void isr_done(void *param)
 {
-	struct node_rx_hdr *node_rx;
+	struct node_rx_pdu *node_rx;
 	struct lll_adv *lll = param;
 
 	/* TODO: MOVE to a common interface, isr_lll_radio_status? */
@@ -728,9 +728,9 @@ static void isr_done(void *param)
 		ull_pdu_rx_alloc();
 
 		/* TODO: add other info by defining a payload struct */
-		node_rx->type = NODE_RX_TYPE_ADV_INDICATION;
+		node_rx->hdr.type = NODE_RX_TYPE_ADV_INDICATION;
 
-		ull_rx_put_sched(node_rx->link, node_rx);
+		ull_rx_put_sched(node_rx->hdr.link, node_rx);
 	}
 #else /* !CONFIG_BT_CTLR_ADV_INDICATION */
 	ARG_UNUSED(node_rx);
@@ -927,7 +927,7 @@ static inline int isr_rx_pdu(struct lll_adv *lll,
 		memcpy(rx->pdu, pdu_rx, (offsetof(struct pdu_adv, connect_ind) +
 					 sizeof(struct pdu_adv_connect_ind)));
 
-		ftr = &(rx->hdr.rx_ftr);
+		ftr = &(rx->rx_ftr);
 		ftr->param = lll;
 		ftr->ticks_anchor = radio_tmr_start_get();
 		ftr->radio_end_us = radio_tmr_end_get() -
@@ -1001,7 +1001,7 @@ static inline int isr_rx_sr_report(struct pdu_adv *pdu_adv_rx,
 	pdu_len = offsetof(struct pdu_adv, payload) + pdu_adv_rx->len;
 	memcpy(pdu_adv, pdu_adv_rx, pdu_len);
 
-	node_rx->hdr.rx_ftr.rssi = (rssi_ready) ? (radio_rssi_get() & 0x7f) :
+	node_rx->rx_ftr.rssi = (rssi_ready) ? (radio_rssi_get() & 0x7f) :
 						  0x7f;
 
 	ull_rx_put_sched(node_rx->hdr.link, node_rx);

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
@@ -591,7 +591,7 @@ static void isr_abort(void *param)
 static void isr_cleanup(void *param)
 {
 	struct lll_scan *lll = param;
-	struct node_rx_hdr *node_rx;
+	struct node_rx_pdu *node_rx;
 	int err;
 
 	if (lll_is_done(param)) {
@@ -617,9 +617,9 @@ static void isr_cleanup(void *param)
 		ull_pdu_rx_alloc();
 
 		/* TODO: add other info by defining a payload struct */
-		node_rx->type = NODE_RX_TYPE_SCAN_INDICATION;
+		node_rx->hdr.type = NODE_RX_TYPE_SCAN_INDICATION;
 
-		ull_rx_put_sched(node_rx->link, node_rx);
+		ull_rx_put_sched(node_rx->hdr.link, node_rx);
 	}
 #else /* !CONFIG_BT_CTLR_SCAN_INDICATION */
 	ARG_UNUSED(node_rx);
@@ -843,7 +843,7 @@ static inline uint32_t isr_rx_pdu(struct lll_scan *lll, uint8_t devmatch_ok,
 		pdu_adv_rx = (void *)rx->pdu;
 		pdu_adv_rx->chan_sel = pdu_adv_rx_chan_sel;
 
-		ftr = &(rx->hdr.rx_ftr);
+		ftr = &(rx->rx_ftr);
 
 		ftr->param = lll;
 		ftr->ticks_anchor = radio_tmr_start_get();
@@ -1121,22 +1121,22 @@ static uint32_t isr_rx_scan_report(struct lll_scan *lll, uint8_t rssi_ready,
 
 	pdu_adv_rx = (void *)node_rx->pdu;
 
-	node_rx->hdr.rx_ftr.rssi = (rssi_ready) ?
+	node_rx->rx_ftr.rssi = (rssi_ready) ?
 				   (radio_rssi_get() & 0x7f)
 				   : 0x7f;
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 	/* save the resolving list index. */
-	node_rx->hdr.rx_ftr.rl_idx = rl_idx;
+	node_rx->rx_ftr.rl_idx = rl_idx;
 #endif /* CONFIG_BT_CTLR_PRIVACY */
 #if defined(CONFIG_BT_CTLR_EXT_SCAN_FP)
 	/* save the directed adv report flag */
-	node_rx->hdr.rx_ftr.direct = dir_report;
+	node_rx->rx_ftr.direct = dir_report;
 #endif /* CONFIG_BT_CTLR_EXT_SCAN_FP */
 #if defined(CONFIG_BT_HCI_MESH_EXT)
 	if (node_rx->hdr.type == NODE_RX_TYPE_MESH_REPORT) {
 		/* save channel and anchor point ticks. */
-		node_rx->hdr.rx_ftr.chan = _radio.scanner.chan - 1;
-		node_rx->hdr.rx_ftr.ticks_anchor = _radio.ticks_anchor;
+		node_rx->rx_ftr.chan = _radio.scanner.chan - 1;
+		node_rx->rx_ftr.ticks_anchor = _radio.ticks_anchor;
 	}
 #endif /* CONFIG_BT_CTLR_EXT_SCAN_FP */
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -861,7 +861,7 @@ uint8_t ll_adv_enable(uint8_t enable)
 				}
 
 				/* Check advertising not terminated */
-				type = &adv->lll.node_rx_adv_term->type;
+				type = &adv->lll.node_rx_adv_term->hdr.type;
 				if (*type == NODE_RX_TYPE_NONE) {
 					/* Reset event counter, update duration,
 					 * and max events
@@ -1089,7 +1089,7 @@ uint8_t ll_adv_enable(uint8_t enable)
 		/* NOTE: use allocated link for generating dedicated
 		 * terminate ind rx node
 		 */
-		conn->llcp_terminate.node_rx.hdr.link = link;
+		conn->llcp_terminate.node_rx.rx.hdr.link = link;
 
 #if defined(CONFIG_BT_CTLR_PHY)
 		conn->phy_pref_tx = ull_conn_default_phy_tx_get();
@@ -1952,7 +1952,7 @@ void ull_adv_done(struct node_rx_event_done *done)
 {
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 	struct lll_adv_aux *lll_aux;
-	struct node_rx_hdr *rx_hdr;
+	struct node_rx_pdu *rx;
 	uint8_t handle;
 	uint32_t ret;
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
@@ -2042,15 +2042,15 @@ void ull_adv_done(struct node_rx_event_done *done)
 	if (adv->max_events && (adv->event_counter >= adv->max_events)) {
 		adv->max_events = 0U;
 
-		rx_hdr = (void *)lll->node_rx_adv_term;
-		rx_hdr->rx_ftr.param_adv_term.status = BT_HCI_ERR_LIMIT_REACHED;
+		rx = (void *)lll->node_rx_adv_term;
+		rx->rx_ftr.param_adv_term.status = BT_HCI_ERR_LIMIT_REACHED;
 	} else if (adv->remain_duration_us &&
 		   (adv->remain_duration_us <=
 		    ((uint64_t)adv->interval * ADV_INT_UNIT_US))) {
 		adv->remain_duration_us = 0U;
 
-		rx_hdr = (void *)lll->node_rx_adv_term;
-		rx_hdr->rx_ftr.param_adv_term.status = BT_HCI_ERR_ADV_TIMEOUT;
+		rx = (void *)lll->node_rx_adv_term;
+		rx->rx_ftr.param_adv_term.status = BT_HCI_ERR_ADV_TIMEOUT;
 	} else {
 		return;
 	}
@@ -2058,10 +2058,10 @@ void ull_adv_done(struct node_rx_event_done *done)
 	handle = ull_adv_handle_get(adv);
 	LL_ASSERT(handle < BT_CTLR_ADV_SET);
 
-	rx_hdr->type = NODE_RX_TYPE_EXT_ADV_TERMINATE;
-	rx_hdr->handle = handle;
-	rx_hdr->rx_ftr.param_adv_term.conn_handle = 0xffff;
-	rx_hdr->rx_ftr.param_adv_term.num_events = adv->event_counter;
+	rx->hdr.type = NODE_RX_TYPE_EXT_ADV_TERMINATE;
+	rx->hdr.handle = handle;
+	rx->rx_ftr.param_adv_term.conn_handle = 0xffff;
+	rx->rx_ftr.param_adv_term.num_events = adv->event_counter;
 
 	lll_aux = lll->aux;
 	if (lll_aux) {
@@ -2546,7 +2546,7 @@ static void disabled_cb(void *param)
 	memset(cc, 0x00, sizeof(struct node_rx_cc));
 	cc->status = BT_HCI_ERR_ADV_TIMEOUT;
 
-	rx->hdr.rx_ftr.param = param;
+	rx->rx_ftr.param = param;
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 	if (adv->lll.node_rx_adv_term) {
@@ -2560,9 +2560,9 @@ static void disabled_cb(void *param)
 		rx = (void *)adv->lll.node_rx_adv_term;
 		rx->hdr.type = NODE_RX_TYPE_EXT_ADV_TERMINATE;
 		rx->hdr.handle = handle;
-		rx->hdr.rx_ftr.param_adv_term.status = BT_HCI_ERR_ADV_TIMEOUT;
-		rx->hdr.rx_ftr.param_adv_term.conn_handle = 0xffff;
-		rx->hdr.rx_ftr.param_adv_term.num_events = adv->event_counter;
+		rx->rx_ftr.param_adv_term.status = BT_HCI_ERR_ADV_TIMEOUT;
+		rx->rx_ftr.param_adv_term.conn_handle = 0xffff;
+		rx->rx_ftr.param_adv_term.num_events = adv->event_counter;
 
 		link = rx->hdr.link;
 	}
@@ -2727,18 +2727,18 @@ static void ext_disable(void *param)
 static void ext_disabled_cb(void *param)
 {
 	struct lll_adv *lll = (void *)param;
-	struct node_rx_hdr *rx_hdr = (void *)lll->node_rx_adv_term;
+	struct node_rx_pdu *rx = lll->node_rx_adv_term;
 
 	/* Under race condition, if a connection has been established then
 	 * node_rx is already utilized to send terminate event on connection
 	 */
-	if (!rx_hdr) {
+	if (!rx) {
 		return;
 	}
 
 	/* NOTE: parameters are already populated on disable, just enqueue here
 	 */
-	ll_rx_put_sched(rx_hdr->link, rx_hdr);
+	ll_rx_put_sched(rx->hdr.link, rx);
 }
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
@@ -261,7 +261,7 @@ uint8_t ull_adv_sync_time_update(struct ll_adv_sync_set *sync,
 uint8_t ull_adv_sync_chm_update(void);
 
 /* helper function to cleanup after channel map update indications complete */
-void ull_adv_sync_chm_complete(struct node_rx_hdr *rx);
+void ull_adv_sync_chm_complete(struct node_rx_pdu *rx);
 
 /* helper function to fill initial value of sync_info structure */
 void ull_adv_sync_info_fill(struct ll_adv_sync_set *sync,
@@ -302,7 +302,7 @@ struct ll_adv_iso_set *ull_adv_iso_get(uint8_t handle);
 uint8_t ull_adv_iso_chm_update(void);
 
 /* helper function to cleanup after channel map update complete */
-void ull_adv_iso_chm_complete(struct node_rx_hdr *rx);
+void ull_adv_iso_chm_complete(struct node_rx_pdu *rx);
 
 /* helper function to schedule a mayfly to get BIG offset */
 void ull_adv_iso_offset_get(struct ll_adv_sync_set *sync);

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
@@ -552,7 +552,7 @@ ll_big_create_rtn_retry:
 
 	/* Store the link buffer for ISO create and terminate complete event */
 	adv_iso->node_rx_complete.hdr.link = link_cmplt;
-	adv_iso->node_rx_terminate.hdr.link = link_term;
+	adv_iso->node_rx_terminate.rx.hdr.link = link_term;
 
 	/* Initialise LLL header members */
 	lll_hdr_init(lll_adv_iso, adv_iso);
@@ -681,7 +681,7 @@ uint8_t ll_big_terminate(uint8_t big_handle, uint8_t reason)
 	node_rx = (void *)&adv_iso->node_rx_terminate;
 	node_rx->hdr.type = NODE_RX_TYPE_BIG_TERMINATE;
 	node_rx->hdr.handle = big_handle;
-	node_rx->hdr.rx_ftr.param = adv_iso;
+	node_rx->rx_ftr.param = adv_iso;
 
 	if (reason == BT_HCI_ERR_REMOTE_USER_TERM_CONN) {
 		*((uint8_t *)node_rx->pdu) = BT_HCI_ERR_LOCALHOST_TERM_CONN;
@@ -740,7 +740,7 @@ uint8_t ull_adv_iso_chm_update(void)
 	return 0;
 }
 
-void ull_adv_iso_chm_complete(struct node_rx_hdr *rx)
+void ull_adv_iso_chm_complete(struct node_rx_pdu *rx)
 {
 	struct lll_adv_sync *sync_lll;
 	struct lll_adv_iso *iso_lll;
@@ -868,7 +868,7 @@ void ull_adv_iso_done_complete(struct node_rx_event_done *done)
 {
 	struct ll_adv_iso_set *adv_iso;
 	struct lll_adv_iso *lll;
-	struct node_rx_hdr *rx;
+	struct node_rx_pdu *rx;
 	memq_link_t *link;
 
 	/* switch to normal prepare */
@@ -880,7 +880,7 @@ void ull_adv_iso_done_complete(struct node_rx_event_done *done)
 
 	/* Prepare BIG complete event */
 	rx = (void *)&adv_iso->node_rx_complete;
-	link = rx->link;
+	link = rx->hdr.link;
 	if (!link) {
 		/* NOTE: When BIS events have overlapping prepare placed in
 		 *       in the pipeline, more than one done complete event
@@ -889,10 +889,10 @@ void ull_adv_iso_done_complete(struct node_rx_event_done *done)
 		 */
 		return;
 	}
-	rx->link = NULL;
+	rx->hdr.link = NULL;
 
-	rx->type = NODE_RX_TYPE_BIG_COMPLETE;
-	rx->handle = lll->handle;
+	rx->hdr.type = NODE_RX_TYPE_BIG_COMPLETE;
+	rx->hdr.handle = lll->handle;
 	rx->rx_ftr.param = adv_iso;
 
 	ll_rx_put_sched(link, rx);

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -1274,7 +1274,7 @@ uint8_t ull_adv_sync_chm_update(void)
 	return 0;
 }
 
-void ull_adv_sync_chm_complete(struct node_rx_hdr *rx)
+void ull_adv_sync_chm_complete(struct node_rx_pdu *rx)
 {
 	uint8_t hdr_data[ULL_ADV_HDR_DATA_LEN_SIZE +
 			 ULL_ADV_HDR_DATA_ACAD_PTR_SIZE];

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_types.h
@@ -106,16 +106,12 @@ struct ll_adv_iso_set {
 				 * clock.
 				 */
 
-	struct {
-		struct node_rx_hdr hdr;
-	} node_rx_complete;
+	struct node_rx_pdu node_rx_complete;
 
 	struct {
-		struct node_rx_hdr hdr;
-		union {
-			uint8_t    pdu[0] __aligned(4);
-			uint8_t    reason;
-		};
+		struct node_rx_pdu rx;
+		/* Dummy declaration to ensure space allocated to hold one pdu bytes */
+		uint8_t  dummy;
 	} node_rx_terminate;
 
 #if defined(CONFIG_BT_CTLR_HCI_ADV_HANDLE_MAPPING)

--- a/subsys/bluetooth/controller/ll_sw/ull_central_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_central_internal.h
@@ -5,8 +5,8 @@
  */
 
 int ull_central_reset(void);
-void ull_central_cleanup(struct node_rx_hdr *rx_free);
-void ull_central_setup(struct node_rx_hdr *rx, struct node_rx_ftr *ftr,
+void ull_central_cleanup(struct node_rx_pdu *rx_free);
+void ull_central_setup(struct node_rx_pdu *rx, struct node_rx_ftr *ftr,
 		      struct lll_conn *lll);
 void ull_central_ticker_cb(uint32_t ticks_at_expire, uint32_t ticks_drift,
 			  uint32_t remainder, uint16_t lazy, uint8_t force,

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -819,7 +819,7 @@ bool ull_conn_peer_connected(uint8_t const own_id_addr_type,
 }
 #endif /* CONFIG_BT_CTLR_CHECK_SAME_PEER_CONN */
 
-void ull_conn_setup(memq_link_t *rx_link, struct node_rx_hdr *rx)
+void ull_conn_setup(memq_link_t *rx_link, struct node_rx_pdu *rx)
 {
 	struct node_rx_ftr *ftr;
 	struct ull_hdr *hdr;
@@ -827,7 +827,7 @@ void ull_conn_setup(memq_link_t *rx_link, struct node_rx_hdr *rx)
 	/* Store the link in the node rx so that when done event is
 	 * processed it can be used to enqueue node rx towards LL context
 	 */
-	rx->link = rx_link;
+	rx->hdr.link = rx_link;
 
 	/* NOTE: LLL conn context SHALL be after lll_hdr in
 	 *       struct lll_adv and struct lll_scan.
@@ -1683,7 +1683,7 @@ static void ticker_start_conn_op_cb(uint32_t status, void *param)
 static void conn_setup_adv_scan_disabled_cb(void *param)
 {
 	struct node_rx_ftr *ftr;
-	struct node_rx_hdr *rx;
+	struct node_rx_pdu *rx;
 	struct lll_conn *lll;
 
 	/* NOTE: LLL conn context SHALL be after lll_hdr in
@@ -1809,7 +1809,7 @@ static void conn_cleanup(struct ll_conn *conn, uint8_t reason)
 	 * value and handle through the mayfly scheduling of the
 	 * tx_lll_flush.
 	 */
-	rx = (void *)&conn->llcp_terminate.node_rx;
+	rx = (void *)&conn->llcp_terminate.node_rx.rx;
 	rx->hdr.handle = conn->lll.handle;
 	rx->hdr.type = NODE_RX_TYPE_TERMINATE;
 	*((uint8_t *)rx->pdu) = reason;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_internal.h
@@ -21,7 +21,7 @@ bool ull_conn_peer_connected(uint8_t const own_id_addr_type,
 			     uint8_t const *const own_id_addr,
 			     uint8_t const peer_id_addr_type,
 			     uint8_t const *const peer_id_addr);
-void ull_conn_setup(memq_link_t *rx_link, struct node_rx_hdr *rx);
+void ull_conn_setup(memq_link_t *rx_link, struct node_rx_pdu *rx);
 void ull_conn_rx(memq_link_t *link, struct node_rx_pdu **rx);
 int ull_conn_llcp(struct ll_conn *conn, uint32_t ticks_at_expire,
 		  uint32_t remainder, uint16_t lazy);

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
@@ -163,15 +163,15 @@ struct ll_conn {
 
 	struct {
 		uint8_t reason_final;
-		/* node rx type with memory aligned storage for terminate
+		/* node rx type with dummy uint8_t to ensure room for terminate
 		 * reason.
 		 * HCI will reference the value using the pdu member of
 		 * struct node_rx_pdu.
+		 *
 		 */
 		struct {
-			struct node_rx_hdr hdr;
-
-			uint8_t reason __aligned(4);
+			struct node_rx_pdu rx;
+			uint8_t dummy_reason;
 		} node_rx;
 	} llcp_terminate;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_df.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_df.c
@@ -569,7 +569,7 @@ void *ull_df_iq_report_alloc(void)
 	return MFIFO_DEQUEUE(iq_report_free);
 }
 
-void ull_df_iq_report_mem_release(struct node_rx_hdr *rx)
+void ull_df_iq_report_mem_release(struct node_rx_pdu *rx)
 {
 #if defined(CONFIG_BT_CTLR_DF_DEBUG_ENABLE)
 	IF_SINGLE_ADV_SYNC_SET(iq_report_alloc_count--);

--- a/subsys/bluetooth/controller/ll_sw/ull_df_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_df_internal.h
@@ -10,7 +10,7 @@ int ull_df_reset(void);
 /* Release link to node_rx_iq_report memory. */
 void ull_df_iq_report_link_release(memq_link_t *link);
 /* Release memory of node_rx_iq_report. */
-void ull_df_iq_report_mem_release(struct node_rx_hdr *rx);
+void ull_df_iq_report_mem_release(struct node_rx_pdu *rx);
 /* Change quota of free node_iq_report links. Delta may be negative,
  * then it will decrease number of free link elements.
  */

--- a/subsys/bluetooth/controller/ll_sw/ull_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_iso.c
@@ -1634,7 +1634,7 @@ static void iso_rx_demux(void *param)
 					 * HCI context.
 					 */
 					struct isoal_pdu_rx pckt_meta = {
-						.meta = &rx_pdu->hdr.rx_iso_meta,
+						.meta = &rx_pdu->rx_iso_meta,
 						.pdu  = (struct pdu_iso *)&rx_pdu->pdu[0]
 					};
 

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_cc.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_cc.c
@@ -68,7 +68,7 @@ static void cc_ntf_established(struct ll_conn *conn, struct proc_ctx *ctx)
 
 	ntf->hdr.type = NODE_RX_TYPE_CIS_ESTABLISHED;
 	ntf->hdr.handle = conn->lll.handle;
-	ntf->hdr.rx_ftr.param = ll_conn_iso_stream_get(ctx->data.cis_create.cis_handle);
+	ntf->rx_ftr.param = ll_conn_iso_stream_get(ctx->data.cis_create.cis_handle);
 
 	pdu = (struct node_rx_conn_iso_estab *)ntf->pdu;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral_internal.h
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-void ull_periph_setup(struct node_rx_hdr *rx, struct node_rx_ftr *ftr,
+void ull_periph_setup(struct node_rx_pdu *rx, struct node_rx_ftr *ftr,
 		     struct lll_conn *lll);
 void ull_periph_latency_cancel(struct ll_conn *conn, uint16_t handle);
 void ull_periph_ticker_cb(uint32_t ticks_at_expire, uint32_t ticks_drift,

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_internal.h
@@ -76,7 +76,7 @@ int ull_scan_aux_init(void);
 int ull_scan_aux_reset(void);
 
 /* Helper to setup scanning on auxiliary channel */
-void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx);
+void ull_scan_aux_setup(memq_link_t *link, struct node_rx_pdu *rx);
 
 /* Helper to clean up auxiliary channel scanning */
 void ull_scan_aux_done(struct node_rx_event_done *done);
@@ -88,7 +88,7 @@ struct ll_scan_aux_set *ull_scan_aux_set_get(uint8_t handle);
 struct ll_scan_aux_set *ull_scan_aux_is_valid_get(struct ll_scan_aux_set *aux);
 
 /* Helper function to flush and release incomplete auxiliary PDU chaining */
-void ull_scan_aux_release(memq_link_t *link, struct node_rx_hdr *rx);
+void ull_scan_aux_release(memq_link_t *link, struct node_rx_pdu *rx);
 
 /* Helper function to stop auxiliary scan context */
 int ull_scan_aux_stop(struct ll_scan_aux_set *aux);

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_types.h
@@ -11,7 +11,7 @@ struct ll_scan_set {
 	uint32_t ticks_window;
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
-	struct node_rx_hdr *node_rx_scan_term;
+	struct node_rx_pdu *node_rx_scan_term;
 	uint16_t duration_lazy;
 
 	uint8_t is_stop:1;
@@ -47,12 +47,12 @@ struct ll_scan_aux_set {
 	/* lll_scan or lll_sync */
 	void *volatile parent;
 
-	struct node_rx_hdr *rx_head;
-	struct node_rx_hdr *rx_last;
+	struct node_rx_pdu *rx_head;
+	struct node_rx_pdu *rx_last;
 
 	uint16_t data_len;
 
 #if defined(CONFIG_BT_CTLR_SYNC_PERIODIC)
-	struct node_rx_hdr *rx_incomplete;
+	struct node_rx_pdu *rx_incomplete;
 #endif
 };

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -100,7 +100,7 @@ uint8_t ll_sync_create(uint8_t options, uint8_t sid, uint8_t adv_addr_type,
 	struct ll_scan_set *scan_coded;
 	memq_link_t *link_sync_estab;
 	memq_link_t *link_sync_lost;
-	struct node_rx_hdr *node_rx;
+	struct node_rx_pdu *node_rx;
 	struct lll_sync *lll_sync;
 	struct ll_scan_set *scan;
 	struct ll_sync_set *sync;
@@ -180,8 +180,8 @@ uint8_t ll_sync_create(uint8_t options, uint8_t sid, uint8_t adv_addr_type,
 	}
 
 	/* Initialize sync context */
-	node_rx->link = link_sync_estab;
-	sync->node_rx_lost.hdr.link = link_sync_lost;
+	node_rx->hdr.link = link_sync_estab;
+	sync->node_rx_lost.rx.hdr.link = link_sync_lost;
 
 	/* Make sure that the node_rx_sync_establ hasn't got anything assigned. It is used to
 	 * mark when sync establishment is in progress.
@@ -360,9 +360,9 @@ uint8_t ll_sync_create_cancel(void **rx)
 		sync->timeout = 0U;
 	}
 
-	node_rx = (void *)sync->node_rx_sync_estab;
+	node_rx = sync->node_rx_sync_estab;
 	link_sync_estab = node_rx->hdr.link;
-	link_sync_lost = sync->node_rx_lost.hdr.link;
+	link_sync_lost = sync->node_rx_lost.rx.hdr.link;
 
 	ll_rx_link_release(link_sync_lost);
 	ll_rx_link_release(link_sync_estab);
@@ -386,7 +386,7 @@ uint8_t ll_sync_create_cancel(void **rx)
 	/* NOTE: Since NODE_RX_TYPE_SYNC is only generated from ULL context,
 	 *       pass ULL sync context as parameter.
 	 */
-	node_rx->hdr.rx_ftr.param = sync;
+	node_rx->rx_ftr.param = sync;
 
 	*rx = node_rx;
 
@@ -431,7 +431,7 @@ uint8_t ll_sync_terminate(uint16_t handle)
 		LL_ASSERT(!aux->parent);
 	}
 
-	link_sync_lost = sync->node_rx_lost.hdr.link;
+	link_sync_lost = sync->node_rx_lost.rx.hdr.link;
 	ll_rx_link_release(link_sync_lost);
 
 	/* Mark sync context not sync established */
@@ -568,15 +568,15 @@ void ull_sync_release(struct ll_sync_set *sync)
 
 	if (lll->node_cte_incomplete) {
 		const uint8_t release_cnt = 1U;
-		struct node_rx_hdr *node_hdr;
+		struct node_rx_pdu *node_rx;
 		memq_link_t *link;
 
-		node_hdr = &lll->node_cte_incomplete->hdr;
-		link = node_hdr->link;
+		node_rx = &lll->node_cte_incomplete->rx;
+		link = node_rx->hdr.link;
 
 		ll_rx_link_release(link);
 		ull_iq_report_link_inc_quota(release_cnt);
-		ull_df_iq_report_mem_release(node_hdr);
+		ull_df_iq_report_mem_release(node_rx);
 		ull_df_rx_iq_report_alloc(release_cnt);
 
 		lll->node_cte_incomplete = NULL;
@@ -661,7 +661,7 @@ bool ull_sync_setup_sid_match(struct ll_scan_set *scan, uint8_t sid)
 }
 
 void ull_sync_setup(struct ll_scan_set *scan, struct ll_scan_aux_set *aux,
-		    struct node_rx_hdr *node_rx, struct pdu_adv_sync_info *si)
+		    struct node_rx_pdu *node_rx, struct pdu_adv_sync_info *si)
 {
 	uint32_t ticks_slot_overhead;
 	uint32_t ticks_slot_offset;
@@ -802,7 +802,7 @@ void ull_sync_setup(struct ll_scan_set *scan, struct ll_scan_aux_set *aux,
 	rx = (void *)sync->node_rx_sync_estab;
 	rx->hdr.type = NODE_RX_TYPE_SYNC;
 	rx->hdr.handle = sync_handle;
-	rx->hdr.rx_ftr.param = scan;
+	rx->rx_ftr.param = scan;
 	se = (void *)rx->pdu;
 	se->interval = interval;
 	se->phy = lll->phy;
@@ -911,7 +911,7 @@ void ull_sync_setup_reset(struct ll_scan_set *scan)
 	}
 }
 
-void ull_sync_established_report(memq_link_t *link, struct node_rx_hdr *rx)
+void ull_sync_established_report(memq_link_t *link, struct node_rx_pdu *rx)
 {
 	struct node_rx_pdu *rx_establ;
 	struct ll_sync_set *sync;
@@ -936,7 +936,7 @@ void ull_sync_established_report(memq_link_t *link, struct node_rx_hdr *rx)
 #else
 	struct pdu_cte_info *rx_cte_info;
 
-	rx_cte_info = pdu_cte_info_get((struct pdu_adv *)((struct node_rx_pdu *)rx)->pdu);
+	rx_cte_info = pdu_cte_info_get((struct pdu_adv *)rx->pdu);
 	if (rx_cte_info != NULL) {
 		sync_status = lll_sync_cte_is_allowed(lll->cte_type, lll->filter_policy,
 						      rx_cte_info->time, rx_cte_info->type);
@@ -964,7 +964,7 @@ void ull_sync_established_report(memq_link_t *link, struct node_rx_hdr *rx)
 #endif /* !CONFIG_BT_CTLR_SYNC_PERIODIC_CTE_TYPE_FILTERING */
 
 		/* Prepare and dispatch sync notification */
-		rx_establ = (void *)sync->node_rx_sync_estab;
+		rx_establ = sync->node_rx_sync_estab;
 		rx_establ->hdr.type = NODE_RX_TYPE_SYNC;
 		rx_establ->hdr.handle = ull_sync_handle_get(sync);
 		se = (void *)rx_establ->pdu;
@@ -1005,10 +1005,10 @@ void ull_sync_established_report(memq_link_t *link, struct node_rx_hdr *rx)
 		/* Change node type to appropriately handle periodic
 		 * advertising PDU report.
 		 */
-		rx->type = NODE_RX_TYPE_SYNC_REPORT;
+		rx->hdr.type = NODE_RX_TYPE_SYNC_REPORT;
 		ull_scan_aux_setup(link, rx);
 	} else {
-		rx->type = NODE_RX_TYPE_RELEASE;
+		rx->hdr.type = NODE_RX_TYPE_RELEASE;
 		ll_rx_put_sched(link, rx);
 	}
 }
@@ -1441,7 +1441,7 @@ static void sync_lost(void *param)
 	rx = (void *)&sync->node_rx_lost;
 	rx->hdr.handle = ull_sync_handle_get(sync);
 	rx->hdr.type = NODE_RX_TYPE_SYNC_LOST;
-	rx->hdr.rx_ftr.param = sync;
+	rx->rx_ftr.param = sync;
 
 	/* Enqueue the sync lost towards ULL context */
 	ll_rx_put_sched(rx->hdr.link, rx);

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_internal.h
@@ -13,9 +13,9 @@ void ull_sync_setup_addr_check(struct ll_scan_set *scan, uint8_t addr_type,
 			       uint8_t *addr, uint8_t rl_idx);
 bool ull_sync_setup_sid_match(struct ll_scan_set *scan, uint8_t sid);
 void ull_sync_setup(struct ll_scan_set *scan, struct ll_scan_aux_set *aux,
-		    struct node_rx_hdr *node_rx, struct pdu_adv_sync_info *si);
+		    struct node_rx_pdu *node_rx, struct pdu_adv_sync_info *si);
 void ull_sync_setup_reset(struct ll_scan_set *scan);
-void ull_sync_established_report(memq_link_t *link, struct node_rx_hdr *rx);
+void ull_sync_established_report(memq_link_t *link, struct node_rx_pdu *rx);
 void ull_sync_done(struct node_rx_event_done *done);
 void ull_sync_chm_update(uint8_t sync_handle, uint8_t *acad, uint8_t acad_len);
 int ull_sync_slot_update(struct ll_sync_set *sync, uint32_t slot_plus_us,

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_iso_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_iso_internal.h
@@ -10,7 +10,7 @@ struct ll_sync_iso_set *ull_sync_iso_by_stream_get(uint16_t handle);
 struct lll_sync_iso_stream *ull_sync_iso_stream_get(uint16_t handle);
 void ull_sync_iso_stream_release(struct ll_sync_iso_set *sync_iso);
 void ull_sync_iso_setup(struct ll_sync_iso_set *sync_iso,
-			struct node_rx_hdr *node_rx,
+			struct node_rx_pdu *node_rx,
 			uint8_t *acad, uint8_t acad_len);
 void ull_sync_iso_estab_done(struct node_rx_event_done *done);
 void ull_sync_iso_done(struct node_rx_event_done *done);

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_types.h
@@ -71,21 +71,19 @@ struct ll_sync_set {
 	 * struct node_rx_pdu.
 	 */
 	struct {
-		struct node_rx_hdr hdr;
-		union {
-			uint8_t    pdu[0] __aligned(4);
-			uint8_t    reason;
-		};
+		struct node_rx_pdu rx;
+		/* Dummy declaration to ensure space allocated to hold one pdu bytes */
+		uint8_t dummy;
 	} node_rx_lost;
 
 	/* Not-Null when sync was setup and Controller is waiting for first AUX_SYNC_IND PDU.
 	 * It means the sync was not estalished yet.
 	 */
-	struct node_rx_hdr *node_rx_sync_estab;
+	struct node_rx_pdu *node_rx_sync_estab;
 
 #if defined(CONFIG_BT_CTLR_SYNC_ISO)
 	struct {
-		struct node_rx_hdr *node_rx_estab;
+		struct node_rx_pdu *node_rx_estab;
 
 		/* Non-Null when creating sync, reset in ISR context on
 		 * synchronisation state and checked in Thread context when
@@ -126,14 +124,9 @@ struct ll_sync_iso_set {
 	 * struct node_rx_pdu.
 	 */
 	struct {
-		struct node_rx_hdr hdr;
-		union {
-			uint8_t pdu[0] __aligned(4);
-			struct {
-				uint8_t handle;
-				uint8_t reason;
-			};
-		};
+		struct node_rx_pdu rx;
+		/* Dummy declaration to ensure space allocated to hold two pdu bytes */
+		uint8_t dummy[2];
 	} node_rx_lost;
 };
 

--- a/tests/bluetooth/controller/common/src/helper_pdu.c
+++ b/tests/bluetooth/controller/common/src/helper_pdu.c
@@ -406,7 +406,7 @@ void helper_pdu_encode_zero(struct pdu_data *pdu, void *param)
 
 void helper_node_encode_cte_rsp(struct node_rx_pdu *rx, void *param)
 {
-	rx->hdr.rx_ftr.iq_report = (struct cte_conn_iq_report *)param;
+	rx->rx_ftr.iq_report = (struct cte_conn_iq_report *)param;
 }
 
 void helper_pdu_encode_cis_req(struct pdu_data *pdu, void *param)
@@ -1054,7 +1054,7 @@ void helper_node_verify_cte_rsp(const char *file, uint32_t line, struct node_rx_
 				void *param)
 {
 	struct cte_conn_iq_report *p_iq_report = param;
-	struct cte_conn_iq_report *rx_iq_report = rx->hdr.rx_ftr.iq_report;
+	struct cte_conn_iq_report *rx_iq_report = rx->rx_ftr.iq_report;
 
 	zassert_equal(rx_iq_report->cte_info.time, p_iq_report->cte_info.time,
 		      "CTE Time mismatch.\nCalled at %s:%d\n", file, line);

--- a/tests/bluetooth/controller/ctrl_cis_create/src/main.c
+++ b/tests/bluetooth/controller/ctrl_cis_create/src/main.c
@@ -272,7 +272,7 @@ ZTEST(cis_create, test_cc_create_periph_rem_host_accept)
 	event_done(&conn);
 
 	/* NODE_CIS_ESTABLISHED carry extra information in header rx footer param field */
-	zassert_equal_ptr(ntf->hdr.rx_ftr.param, &cis_mock);
+	zassert_equal_ptr(ntf->rx_ftr.param, &cis_mock);
 
 	zassert_equal(llcp_ctx_buffers_free(), test_ctx_buffers_cnt(),
 		      "Free CTX buffers %d", llcp_ctx_buffers_free());

--- a/tests/bluetooth/controller/mock_ctrl/src/ull_central.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/ull_central.c
@@ -20,7 +20,7 @@
 #include "lll/lll_df_types.h"
 #include "lll_conn.h"
 
-void ull_central_setup(memq_link_t *link, struct node_rx_hdr *rx, struct node_rx_ftr *ftr,
+void ull_central_setup(memq_link_t *link, struct node_rx_pdu *rx, struct node_rx_ftr *ftr,
 		      struct lll_conn *lll)
 {
 }

--- a/tests/bluetooth/controller/mock_ctrl/src/ull_peripheral.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/ull_peripheral.c
@@ -22,7 +22,7 @@
 #include "lll_conn.h"
 #include "ull_conn_types.h"
 
-void ull_periph_setup(memq_link_t *link, struct node_rx_hdr *rx, struct node_rx_ftr *ftr,
+void ull_periph_setup(memq_link_t *link, struct node_rx_pdu *rx, struct node_rx_ftr *ftr,
 		     struct lll_conn *lll)
 {
 }

--- a/tests/bsim/bluetooth/ll/bis/src/main.c
+++ b/tests/bsim/bluetooth/ll/bis/src/main.c
@@ -850,7 +850,7 @@ static void test_iso_recv_main(void)
 	printk("success.\n");
 
 	printk("Terminating BIG Sync...");
-	struct node_rx_hdr *node_rx = NULL;
+	struct node_rx_pdu *node_rx = NULL;
 	err = ll_big_sync_terminate(big_handle, (void **)&node_rx);
 	if (err) {
 		FAIL("Could not terminate BIG sync: %d\n", err);
@@ -883,7 +883,7 @@ static void test_iso_recv_main(void)
 	printk("success.\n");
 
 	if (node_rx) {
-		node_rx->next = NULL;
+		node_rx->hdr.next = NULL;
 		ll_rx_mem_release((void **)&node_rx);
 	}
 #else


### PR DESCRIPTION
Generic node_rx_hdr struct contains data not used for done event, so this pdu specific data is moved to node_rx_pdu to minimize memory usage for MFIFO_done alloc.

This however calls for a considerable write-through replacing the generic node_rx_hdr with node_rx_pdu when relevant and needed.