### PR TITLE
Prevent kernel crash on STM32 ADC sampling using extra_samples and repeat

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -949,6 +949,9 @@ static int start_read(const struct device *dev,
 	int err;
 
 	data->buffer = sequence->buffer;
+
+	/* store the buffer address to be used in a repeat */
+	data->repeat_buffer = data->buffer;
 	data->channels = sequence->channels;
 	data->channel_count = POPCOUNT(data->channels);
 	data->samples_count = 0;
@@ -1058,8 +1061,6 @@ static void adc_context_start_sampling(struct adc_context *ctx)
 	/* Remove warning for some series */
 	ARG_UNUSED(adc);
 
-	data->repeat_buffer = data->buffer;
-
 #ifdef CONFIG_ADC_STM32_DMA
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32f4_adc)
 	/* Make sure DMA bit of ADC register CR2 is set to 0 before starting a DMA transfer */
@@ -1077,6 +1078,7 @@ static void adc_context_update_buffer_pointer(struct adc_context *ctx,
 		CONTAINER_OF(ctx, struct adc_stm32_data, ctx);
 
 	if (repeat_sampling) {
+		/* when repeating, set the original buffer address again */
 		data->buffer = data->repeat_buffer;
 	}
 }


### PR DESCRIPTION
As the `data->buffer` pointer is incremented every sample ISR, it's usually not pointing to the start of the initial buffer.
When a ADC read with `extra_samples` > 0 is repeated, `adc_context_start_sampling` is called by adc_context.h and the current `data->buffer` pointer is copied into the `data->repeat_buffer` pointer.

This pointer isn't pointing towards the original start of the buffer, and hence in `adc_context_update_buffer_pointer`, the data->buffer pointer receives an incremented pointer.

When used with STM32H7 ADC3 (BDMA driver), the target address is checked to be inside of SRAM4 (and then nicely stops), for ADC1/2 there is no such check because it can be placed in any SRAM. This causes a kernel crash.  