### PR TITLE
net: gptp: fixes related to multiple ports management

### DIFF
--- a/subsys/net/l2/ethernet/gptp/gptp_md.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_md.c
@@ -29,11 +29,14 @@ static void gptp_md_sync_prepare(struct net_pkt *pkt,
 }
 
 static void gptp_md_follow_up_prepare(struct net_pkt *pkt,
+				      struct net_pkt *sync,
 				      struct gptp_md_sync_info *sync_send,
 				      int port_number)
 {
 	struct gptp_hdr *hdr;
 	struct gptp_follow_up *fup;
+	uint64_t sync_ts_ns, delay_ns;
+	struct net_ptp_time *sync_ts = net_pkt_timestamp(sync);
 
 	hdr = GPTP_HDR(pkt);
 	fup = GPTP_FOLLOW_UP(pkt);
@@ -45,6 +48,48 @@ static void gptp_md_follow_up_prepare(struct net_pkt *pkt,
 
 	hdr->log_msg_interval = sync_send->log_msg_interval;
 
+	if (memcmp(GPTP_GLOBAL_DS()->gm_priority.root_system_id.grand_master_id,
+			  GPTP_DEFAULT_DS()->clk_id, GPTP_CLOCK_ID_LEN) == 0 &&
+			  GPTP_GLOBAL_DS()->gm_present) {
+		/*
+		 * Time aware system acting as the Grand Master.
+		 *
+		 * Get preciseOriginTimestamp from previous sync message
+		 * according to IEEE802.1AS 11.4.4.2.1 syncEventEgressTimestamp
+		 */
+		fup->prec_orig_ts_secs_high = htons(sync_ts->_sec.high);
+		fup->prec_orig_ts_secs_low = htonl(sync_ts->_sec.low);
+		fup->prec_orig_ts_nsecs = htonl(sync_ts->nanosecond);
+		/*
+		 * Grand master clock should keep correction_field at zero,
+		 * according to IEEE802.1AS Table 11-6 and 10.6.2.2.9
+		 */
+		hdr->correction_field = 0LL;
+	} else {
+		/*
+		 * Time aware system acting as a bridge.
+		 */
+		fup->prec_orig_ts_secs_high =
+			htons(sync_send->precise_orig_ts._sec.high);
+		fup->prec_orig_ts_secs_low = htonl(sync_send->precise_orig_ts._sec.low);
+		fup->prec_orig_ts_nsecs = htonl(sync_send->precise_orig_ts.nanosecond);
+		/*
+		 * According to IEEE802.AS 11.1.3 and 11.2.14.2.3, when time aware
+		 * system is operating as a transparent clock also called a bridge, it
+		 * shall compute the sum of link propagation delay and residence time,
+		 * expressed in grand master time base. Then this quantity shall be
+		 * added to last received fup correction field to build value of
+		 * correction field.
+		 */
+		sync_ts_ns = sync_ts->second;
+		sync_ts_ns *= NSEC_PER_SEC;
+		sync_ts_ns += sync_ts->nanosecond;
+		delay_ns = sync_ts_ns - sync_send->upstream_tx_time;
+
+		hdr->correction_field = sync_send->follow_up_correction_field +
+			(int64_t)(sync_send->rate_ratio * delay_ns);
+		hdr->correction_field = htonll(hdr->correction_field << 16);
+	}
 	fup->tlv_hdr.type = htons(GPTP_TLV_ORGANIZATION_EXT);
 	fup->tlv_hdr.len = htons(sizeof(struct gptp_follow_up_tlv));
 	fup->tlv.org_id[0] = GPTP_FUP_TLV_ORG_ID_BYTE_0;
@@ -852,6 +897,7 @@ static void gptp_md_sync_send_state_machine(int port)
 			pkt = gptp_prepare_follow_up(port, state->sync_ptr);
 			if (pkt) {
 				gptp_md_follow_up_prepare(pkt,
+							 state->sync_ptr,
 							 state->sync_send_ptr,
 							 port);
 				gptp_send_follow_up(port, pkt);

--- a/subsys/net/l2/ethernet/gptp/gptp_messages.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_messages.c
@@ -16,10 +16,10 @@ LOG_MODULE_DECLARE(net_gptp, CONFIG_NET_GPTP_LOG_LEVEL);
 
 #define NET_BUF_TIMEOUT K_MSEC(100)
 
-static struct net_if_timestamp_cb sync_timestamp_cb;
-static struct net_if_timestamp_cb pdelay_response_timestamp_cb;
-static bool sync_cb_registered;
-static bool ts_cb_registered;
+static struct net_if_timestamp_cb sync_timestamp_cb[CONFIG_NET_GPTP_NUM_PORTS];
+static struct net_if_timestamp_cb pdelay_response_timestamp_cb[CONFIG_NET_GPTP_NUM_PORTS];
+static bool sync_cb_registered[CONFIG_NET_GPTP_NUM_PORTS];
+static bool ts_cb_registered[CONFIG_NET_GPTP_NUM_PORTS];
 
 static const struct net_eth_addr gptp_multicast_eth_addr = {
 	{ 0x01, 0x80, 0xc2, 0x00, 0x00, 0x0e } };
@@ -98,8 +98,8 @@ static void gptp_sync_timestamp_callback(struct net_pkt *pkt)
 	if (hdr->message_type == GPTP_SYNC_MESSAGE) {
 		state->md_sync_timestamp_avail = true;
 
-		net_if_unregister_timestamp_cb(&sync_timestamp_cb);
-		sync_cb_registered = false;
+		net_if_unregister_timestamp_cb(&sync_timestamp_cb[port - 1]);
+		sync_cb_registered[port - 1] = false;
 
 		/* The pkt was ref'ed in gptp_send_sync() */
 		net_pkt_unref(pkt);
@@ -129,8 +129,8 @@ static void gptp_pdelay_response_timestamp_callback(struct net_pkt *pkt)
 			goto out;
 		}
 
-		net_if_unregister_timestamp_cb(&pdelay_response_timestamp_cb);
-		ts_cb_registered = false;
+		net_if_unregister_timestamp_cb(&pdelay_response_timestamp_cb[port - 1]);
+		ts_cb_registered[port - 1] = false;
 
 		gptp_send_pdelay_follow_up(port, follow_up,
 					   net_pkt_timestamp(pkt));
@@ -624,13 +624,13 @@ void gptp_handle_pdelay_req(int port, struct net_pkt *pkt)
 
 	GPTP_STATS_INC(port, rx_pdelay_req_count);
 
-	if (ts_cb_registered == true) {
+	if (ts_cb_registered[port - 1] == true) {
 		NET_WARN("Multiple pdelay requests");
 
-		net_if_unregister_timestamp_cb(&pdelay_response_timestamp_cb);
-		net_pkt_unref(pdelay_response_timestamp_cb.pkt);
+		net_if_unregister_timestamp_cb(&pdelay_response_timestamp_cb[port - 1]);
+		net_pkt_unref(pdelay_response_timestamp_cb[port - 1].pkt);
 
-		ts_cb_registered = false;
+		ts_cb_registered[port - 1] = false;
 	}
 
 	/* Prepare response and send */
@@ -639,7 +639,7 @@ void gptp_handle_pdelay_req(int port, struct net_pkt *pkt)
 		return;
 	}
 
-	net_if_register_timestamp_cb(&pdelay_response_timestamp_cb,
+	net_if_register_timestamp_cb(&pdelay_response_timestamp_cb[port - 1],
 				     reply,
 				     net_pkt_iface(pkt),
 				     gptp_pdelay_response_timestamp_callback);
@@ -650,7 +650,7 @@ void gptp_handle_pdelay_req(int port, struct net_pkt *pkt)
 	 */
 	net_pkt_ref(reply);
 
-	ts_cb_registered = true;
+	ts_cb_registered[port - 1] = true;
 
 	gptp_send_pdelay_resp(port, reply, net_pkt_timestamp(pkt));
 }
@@ -806,12 +806,12 @@ void gptp_handle_signaling(int port, struct net_pkt *pkt)
 
 void gptp_send_sync(int port, struct net_pkt *pkt)
 {
-	if (!sync_cb_registered) {
-		net_if_register_timestamp_cb(&sync_timestamp_cb,
+	if (!sync_cb_registered[port - 1]) {
+		net_if_register_timestamp_cb(&sync_timestamp_cb[port - 1],
 					     pkt,
 					     net_pkt_iface(pkt),
 					     gptp_sync_timestamp_callback);
-		sync_cb_registered = true;
+		sync_cb_registered[port - 1] = true;
 	}
 
 	GPTP_STATS_INC(port, tx_sync_count);

--- a/subsys/net/l2/ethernet/gptp/gptp_messages.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_messages.c
@@ -241,7 +241,6 @@ struct net_pkt *gptp_prepare_follow_up(int port, struct net_pkt *sync)
 	struct gptp_follow_up *fup;
 	struct net_if *iface;
 	struct net_pkt *pkt;
-	struct net_ptp_time *sync_ts;
 
 	NET_ASSERT(sync);
 	NET_ASSERT((port >= GPTP_PORT_START) && (port <= GPTP_PORT_END));
@@ -259,7 +258,6 @@ struct net_pkt *gptp_prepare_follow_up(int port, struct net_pkt *sync)
 	hdr = GPTP_HDR(pkt);
 	fup = GPTP_FOLLOW_UP(pkt);
 	sync_hdr = GPTP_HDR(sync);
-	sync_ts = net_pkt_timestamp(sync);
 
 	/*
 	 * Header configuration.
@@ -271,11 +269,6 @@ struct net_pkt *gptp_prepare_follow_up(int port, struct net_pkt *sync)
 	hdr->ptp_version = GPTP_VERSION;
 	hdr->sequence_id = sync_hdr->sequence_id;
 	hdr->domain_number = 0U;
-	/*
-	 * Grand master clock should keep correction_field at zero,
-	 * according to IEEE802.1AS Table 11-6 and 10.6.2.2.9
-	 */
-	hdr->correction_field = 0LL;
 	hdr->flags.octets[0] = 0U;
 	hdr->flags.octets[1] = GPTP_FLAG_PTP_TIMESCALE;
 	hdr->message_length = htons(sizeof(struct gptp_hdr) +
@@ -286,14 +279,6 @@ struct net_pkt *gptp_prepare_follow_up(int port, struct net_pkt *sync)
 	hdr->reserved0 = 0U;
 	hdr->reserved1 = 0U;
 	hdr->reserved2 = 0U;
-
-	/*
-	 * Get preciseOriginTimestamp from previous sync message
-	 * according to IEEE802.1AS 11.4.4.2.1 syncEventEgressTimestamp
-	 */
-	fup->prec_orig_ts_secs_high = htons(sync_ts->_sec.high);
-	fup->prec_orig_ts_secs_low = htonl(sync_ts->_sec.low);
-	fup->prec_orig_ts_nsecs = htonl(sync_ts->nanosecond);
 
 	/* PTP configuration will be set by the MDSyncSend state machine. */
 

--- a/subsys/net/l2/ethernet/gptp/gptp_mi.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_mi.c
@@ -960,12 +960,17 @@ static void gptp_mi_set_ps_sync_cmss(void)
 	sync_info->precise_orig_ts.second = current_time / NSEC_PER_SEC;
 	sync_info->precise_orig_ts.nanosecond = current_time % NSEC_PER_SEC;
 
-	/* TODO calculate correction field properly, rate_ratio is also set to
-	 * zero instead of being copied from global_ds as it affects the final
-	 * value of FUP correction field.
+	/* TODO calculate rate ratio and correction field properly.
+	 * Whenever time aware system is the grand master clock, we currently
+	 * make the following shortcuts:
+	 * - assuming that clock source is the local clock,
+	 *   rate_ratio is set to 1.0 instead of being copied from global_ds.
+	 * - considering that precise origin timestamp is directly inherited
+	 *   from sync egress timestamp in gptp_md_follow_up_prepare(),
+	 *   follow_up_correction_field is set to 0.
 	 */
 	sync_info->follow_up_correction_field = 0;
-	sync_info->rate_ratio = 0;
+	sync_info->rate_ratio = 1.0;
 
 	memcpy(&sync_info->src_port_id.clk_id,
 	       GPTP_DEFAULT_DS()->clk_id,

--- a/subsys/net/l2/ethernet/gptp/gptp_mi.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_mi.c
@@ -2014,7 +2014,22 @@ void gptp_mi_state_machines(void)
 	gptp_mi_port_role_selection_state_machine();
 	gptp_mi_clk_master_sync_offset_state_machine();
 #if defined(CONFIG_NET_GPTP_GM_CAPABLE)
-	gptp_mi_clk_master_sync_snd_state_machine();
+	/*
+	 * Only call ClockMasterSyncSend state machine in case a Grand Master clock
+	 * is present and is this time aware system.
+	 * This check is not described by IEEE802.1AS. Instead, according to
+	 * 10.2.9.3, the SiteSyncSync state machine shall not take into account
+	 * information from ClockMasterSyncSend in case this time aware system is
+	 * not grand-master capable. Current implementation of ClockMasterSyncSend
+	 * state machine send sync indication to the PortSync entities, instead of
+	 * sending it to the SiteSyncSync entity. And the SiteSyncSync state machine
+	 * does not make sanity check.
+	 */
+	if (memcmp(GPTP_GLOBAL_DS()->gm_priority.root_system_id.grand_master_id,
+			  GPTP_DEFAULT_DS()->clk_id, GPTP_CLOCK_ID_LEN) == 0 &&
+			  GPTP_GLOBAL_DS()->gm_present) {
+		gptp_mi_clk_master_sync_snd_state_machine();
+	}
 #endif
 	gptp_mi_clk_master_sync_rcv_state_machine();
 }


### PR DESCRIPTION
Hello, first let me introduce myself ;)
I am a software engineer working on automotive SoC that embed a TSN Ethernet switch. I am doing some tests using the Zephyr L2 gPTP stack. And well, I must thank all the contributors for this very nice job.

That is said, I met some issues especially whenever several gPTP ports are enabled:

1) Whenever my device under test behave as a transparent clock (so when SYNC/FUP messages must be forwarded from one gPTP slave port to another gPTP master port), I met an issue related to correction field of FUP message that was not properly updated (it was systematically set to 0 instead of taking link propagation delay & residence time into account). So  I did the following patch:

net: gptp: fix again computation of follow up correction field

2) I also noticed SYNC/FUP could be mistakenly generated by ClockMasterSyncSend state machine event if time aware system is not acting as the grand master clock (but is just a transparent clock). So this patch:

net: gptp: do not run clock master sync send SM if we are not the GM clock

3) Then, in case time aware system is the Grand Master clock, I saw that computation of scaled_rate_offset variable
    in gptp_md_follow_up_prepare() looks not correct. So this patch:

net: gptp: fix rate_ratio in gptp_mi_set_ps_sync_cmss()

4) Finally, if the device is acting as a Grand Master clock (while having several gPTP master ports as capable), I noticed that SYNC/FUP messages were only transmitted to one port after a couple of time. So I did this patch:

net: gptp: fix race condition on timestamp callback

While it seems to build on latest HEAD of main branch, I only tested it on a quite old revision of Zephyr kernel (that is compatible with my DUT).  Transparent-clock & GM clock test-cases with multiple ports of our DUT connected to certified tools looks ok at first sight.

But those patches may not be perfect for sure. So feel free to challenge of course!
Regards, Jean-Nicolas.