### PR TITLE
tests: drivers: wdt_basic_api: Allow testing without PAUSE_HALTED_BY_DBG

### DIFF
--- a/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
+++ b/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
@@ -216,6 +216,10 @@ static int test_wdt_no_callback(void)
 	}
 
 	err = wdt_setup(wdt, WDT_OPT_PAUSE_HALTED_BY_DBG);
+	if (err == -ENOTSUP) {
+		TC_PRINT("- pausing watchdog by debugger is not supported\n");
+		err = wdt_setup(wdt, 0);
+	}
 	if (err < 0) {
 		TC_PRINT("Watchdog setup error\n");
 		return TC_FAIL;
@@ -270,6 +274,10 @@ static int test_wdt_callback_1(void)
 	}
 
 	err = wdt_setup(wdt, WDT_OPT_PAUSE_HALTED_BY_DBG);
+	if (err == -ENOTSUP) {
+		TC_PRINT("- pausing watchdog by debugger is not supported\n");
+		err = wdt_setup(wdt, 0);
+	}
 	if (err < 0) {
 		TC_PRINT("Watchdog setup error\n");
 		return TC_FAIL;
@@ -330,6 +338,10 @@ static int test_wdt_callback_2(void)
 	}
 
 	err = wdt_setup(wdt, WDT_OPT_PAUSE_HALTED_BY_DBG);
+	if (err == -ENOTSUP) {
+		TC_PRINT("- pausing watchdog by debugger is not supported\n");
+		err = wdt_setup(wdt, 0);
+	}
 	if (err < 0) {
 		TC_PRINT("Watchdog setup error\n");
 		return TC_FAIL;

--- a/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
+++ b/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
@@ -212,11 +212,13 @@ static int test_wdt_no_callback(void)
 	err = wdt_install_timeout(wdt, &m_cfg_wdt0);
 	if (err < 0) {
 		TC_PRINT("Watchdog install error\n");
+		return TC_FAIL;
 	}
 
 	err = wdt_setup(wdt, WDT_OPT_PAUSE_HALTED_BY_DBG);
 	if (err < 0) {
 		TC_PRINT("Watchdog setup error\n");
+		return TC_FAIL;
 	}
 
 	TC_PRINT("Waiting to restart MCU\n");


### PR DESCRIPTION
This is a follow-up to commit e53e5448eee2257ad360457ecfd79541381bba89.

In the above commit, the calls to `wdt_setup()` were modified to use the `WDT_OPT_PAUSE_HALTED_BY_DBG` option to prevent problems with flashing of boards after this test was executed on them (the still active watchdog could interrupt such flashing), but this option is not essential to the test itself. And if a watchdog driver does not support pausing when the CPU is halted by a debugger (this is the case for example for wdt_counter), it is not able to pass the test because of that option. Add then the possibility to continue the test when pausing by debugger is not supported.

Fixes #70659