### PR TITLE
sensors: Blocking read with new API

### DIFF
--- a/drivers/sensor/sensor_shell.c
+++ b/drivers/sensor/sensor_shell.c
@@ -561,7 +561,7 @@ static int cmd_get_sensor(const struct shell *sh, size_t argc, char *argv[])
 
 	ctx.dev = dev;
 	ctx.sh = sh;
-	err = sensor_read(&iodev_sensor_shell_read, &sensor_read_rtio, &ctx);
+	err = sensor_read_async_mempool(&iodev_sensor_shell_read, &sensor_read_rtio, &ctx);
 	if (err < 0) {
 		shell_error(sh, "Failed to read sensor: %d", err);
 	}

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -639,7 +639,7 @@ struct sensor_read_config {
  *     { SENSOR_CHAN_GYRO_XYZ, 0 });
  *
  * int main(void) {
- *   sensor_read(&icm42688_accelgyro, &rtio);
+ *   sensor_read_async_mempool(&icm42688_accelgyro, &rtio);
  * }
  * @endcode
  */
@@ -1025,7 +1025,50 @@ static inline int sensor_stream(struct rtio_iodev *iodev, struct rtio *ctx, void
 }
 
 /**
- * @brief Read data from a sensor.
+ * @brief Blocking one shot read of samples from a sensor into a buffer
+ *
+ * Using @p cfg, read data from the device by using the provided RTIO context
+ * @p ctx. This call will generate a @ref rtio_sqe that will be given the provided buffer. The call
+ * will wait for the read to complete before returning to the caller.
+ *
+ * @param[in] iodev The iodev created by @ref SENSOR_DT_READ_IODEV
+ * @param[in] ctx The RTIO context to service the read
+ * @param[in] buf Pointer to memory to read sample data into
+ * @param[in] buf_len Size in bytes of the given memory that are valid to read into
+ * @return 0 on success
+ * @return < 0 on error
+ */
+static inline int sensor_read(struct rtio_iodev *iodev, struct rtio *ctx, uint8_t *buf,
+			      size_t buf_len)
+{
+	if (IS_ENABLED(CONFIG_USERSPACE)) {
+		struct rtio_sqe sqe;
+
+		rtio_sqe_prep_read(&sqe, iodev, RTIO_PRIO_NORM, buf, buf_len, buf);
+		rtio_sqe_copy_in(ctx, &sqe, 1);
+	} else {
+		struct rtio_sqe *sqe = rtio_sqe_acquire(ctx);
+
+		if (sqe == NULL) {
+			return -ENOMEM;
+		}
+		rtio_sqe_prep_read(sqe, iodev, RTIO_PRIO_NORM, buf, buf_len, buf);
+	}
+	rtio_submit(ctx, 1);
+
+	struct rtio_cqe *cqe = rtio_cqe_consume(ctx);
+	int res = cqe->result;
+
+	__ASSERT(cqe->userdata != buf,
+		 "consumed non-matching completion for sensor read into buffer %p\n", buf);
+
+	rtio_cqe_release(ctx, cqe);
+
+	return res;
+}
+
+/**
+ * @brief One shot non-blocking read with pool allocated buffer
  *
  * Using @p cfg, read one snapshot of data from the device by using the provided RTIO context
  * @p ctx. This call will generate a @ref rtio_sqe that will leverage the RTIO's internal
@@ -1037,7 +1080,8 @@ static inline int sensor_stream(struct rtio_iodev *iodev, struct rtio *ctx, void
  * @return 0 on success
  * @return < 0 on error
  */
-static inline int sensor_read(struct rtio_iodev *iodev, struct rtio *ctx, void *userdata)
+static inline int sensor_read_async_mempool(struct rtio_iodev *iodev, struct rtio *ctx,
+					    void *userdata)
 {
 	if (IS_ENABLED(CONFIG_USERSPACE)) {
 		struct rtio_sqe sqe;
@@ -1065,7 +1109,7 @@ static inline int sensor_read(struct rtio_iodev *iodev, struct rtio *ctx, void *
  * @param[in] result The result code of the read (0 being success)
  * @param[in] buf The data buffer holding the sensor data
  * @param[in] buf_len The length (in bytes) of the @p buf
- * @param[in] userdata The optional userdata passed to sensor_read()
+ * @param[in] userdata The optional userdata passed to sensor_read_async_mempool()
  */
 typedef void (*sensor_processing_callback_t)(int result, uint8_t *buf, uint32_t buf_len,
 					     void *userdata);

--- a/subsys/sensing/sensor_mgmt.c
+++ b/subsys/sensing/sensor_mgmt.c
@@ -285,7 +285,7 @@ static void sensing_sensor_polling_timer(struct k_timer *timer_id)
 			struct sensing_sensor, timer);
 
 	/* TODO: move it into sensing_runtime_thread */
-	sensor_read(sensor->iodev, &sensing_rtio_ctx, sensor);
+	sensor_read_async_mempool(sensor->iodev, &sensing_rtio_ctx, sensor);
 }
 
 static int init_sensor(struct sensing_sensor *sensor)

--- a/tests/drivers/build_all/sensor/src/generic_test.c
+++ b/tests/drivers/build_all/sensor/src/generic_test.c
@@ -171,7 +171,7 @@ static void run_generic_test(const struct device *dev)
 		}
 
 		/* Perform the actual sensor read */
-		rv = sensor_read(&iodev_read, &sensor_read_rtio_ctx, NULL);
+		rv = sensor_read_async_mempool(&iodev_read, &sensor_read_rtio_ctx, NULL);
 		zassert_ok(rv, "Could not read sensor (error %d, iteration %d/%d)", rv,
 			   iteration + 1, CONFIG_GENERIC_SENSOR_TEST_NUM_EXPECTED_VALS);
 


### PR DESCRIPTION
Rename the current sensor_read to sensor_read_async_mempool and create a new blocking sensor_read helper.

Depends on #71093 