### PR TITLE
Updated west.yml to Fix FlexPWM for LPC55XXX

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -193,7 +193,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 6b252c34eef7d0fdd2dee8261ab68086522c4435
+      revision: 14160a1c14c06ce5a918cd550989555d832a636f
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Updated the west.yml file
to add nxp_hal update for pwm
definitions used by devices
LPC5534, LPC5536 and LPC55S36.
The nxp_hal changes lets the PWM
driver be aware that these devices
contain a WAITEN bit in their PWM
register which can be used when setting
up the PWM on init phase.