### PR TITLE
ARCMWDT: Fix building under hwmv2 model

### DIFF
--- a/cmake/bintools/arcmwdt/target.cmake
+++ b/cmake/bintools/arcmwdt/target.cmake
@@ -20,9 +20,16 @@ SET(CMAKE_C_ARCHIVE_FINISH "<CMAKE_AR> -sq <TARGET>")
 
 find_program(CMAKE_GDB     ${CROSS_COMPILE}mdb     PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
 
-# MWDT binutils don't support required features like section renaming, so we
-# temporarily had to use GNU objcopy instead
-find_program(CMAKE_OBJCOPY ${ZEPHYR_SDK_CROSS_COMPILE}objcopy PATHS ${ZEPHYR_SDK_INSTALL_DIR} NO_DEFAULT_PATH)
-message(STATUS "Found GNU objcopy helper for MWDT: ${CMAKE_OBJCOPY} (Zephyr SDK ${SDK_VERSION})")
+function(zephyr_sdk_target_cmake)
+  # Scoped loading of variables set by Zephyr SDK target.cmake.
+  include(${ZEPHYR_SDK_INSTALL_DIR}/cmake/zephyr/target.cmake)
+
+  # MWDT binutils don't support required features like section renaming, so we
+  # temporarily had to use GNU objcopy instead
+  find_program(CMAKE_OBJCOPY ${CROSS_COMPILE}objcopy PATHS ${ZEPHYR_SDK_INSTALL_DIR} NO_DEFAULT_PATH)
+  message(STATUS "Found GNU objcopy helper for MWDT: ${CMAKE_OBJCOPY} (Zephyr SDK ${SDK_VERSION})")
+endfunction()
+
+zephyr_sdk_target_cmake()
 
 include(${ZEPHYR_BASE}/cmake/bintools/arcmwdt/target_bintools.cmake)

--- a/cmake/toolchain/arcmwdt/generic.cmake
+++ b/cmake/toolchain/arcmwdt/generic.cmake
@@ -23,7 +23,17 @@ find_package(Zephyr-sdk 0.15 REQUIRED)
 # https://github.com/zephyrproject-rtos/sdk-ng/pull/682 got merged and we switch to proper SDK
 # version.
 set(TOOLCHAIN_HOME ${ZEPHYR_SDK_INSTALL_DIR})
-include(${ZEPHYR_SDK_INSTALL_DIR}/cmake/zephyr/target.cmake)
+
+# On very early stage build system needs to get access to DTC preprocessor.
+# MWDT has no it's own preprocessor, so here zephyr-SDK preprocessor is used.
+# At the same time zephyr-SDK requires ARCH variable to be initialized before include "generic.cmake",
+# but in hew HWMv2 model ARCH variable will be initialized more later.
+# This workaround uses any (first awailable, independent on ARCH) toolchain from SDK for DTC preprocessing only.
+# For other build stages ARCMWDT will be used.
+include(${ZEPHYR_SDK_INSTALL_DIR}/cmake/zephyr/generic.cmake)
+unset(TOOLCHAIN_HAS_NEWLIB CACHE)
+unset(TOOLCHAIN_HAS_PICOLIBC CACHE)
+
 set(ZEPHYR_SDK_CROSS_COMPILE ${CROSS_COMPILE})
 # Handling to be improved in Zephyr SDK, to avoid overriding ZEPHYR_TOOLCHAIN_VARIANT by
 # find_package(Zephyr-sdk) if it's already set


### PR DESCRIPTION
On very early stage build system needs to get access to DTC preprocessor.
MWDT has no it's own preprocessor, so here zephyr-SDK preprocessor is used.
On latest build stages zephyr-SDK objcoby also required as MWDT binutils
don't support all features. This at the same time requires that
ZEPHYR_SDK_INSTALL_DIR must be initialized with valid arch-dependent prefix.

Zephyr-SDK requires ARCH variable to be initialized before
include "generic.cmake", but in hew HWMv2 model ARCH variable will be
initialized more later. This workaround uses any (first available,
independent on ARCH) toolchain from SDK for DTC preprocessing only.
For other build stages ARCMWDT will be used.