### PR TITLE
drivers: can: can_stm32_bxcan.c: Failed to exit sleep mode

### DIFF
--- a/drivers/can/can_stm32_bxcan.c
+++ b/drivers/can/can_stm32_bxcan.c
@@ -632,15 +632,15 @@ static int can_stm32_init(const struct device *dev)
 		return ret;
 	}
 
-	ret = can_stm32_leave_sleep_mode(can);
-	if (ret) {
-		LOG_ERR("Failed to exit sleep mode");
-		return ret;
-	}
-
 	ret = can_stm32_enter_init_mode(can);
 	if (ret) {
 		LOG_ERR("Failed to enter init mode");
+		return ret;
+	}
+
+	ret = can_stm32_leave_sleep_mode(can);
+	if (ret) {
+		LOG_ERR("Failed to exit sleep mode");
 		return ret;
 	}
 


### PR DESCRIPTION
Fixes the issue of CAN failing to exit sleep mode inside can_stm32_init() when a software reset is done

Fixes: #71142