### PR TITLE
drivers: spi: spi_xlnx_axi_quadspi: optimizations and STARTUP block support

### DIFF
--- a/drivers/spi/Kconfig.xlnx
+++ b/drivers/spi/Kconfig.xlnx
@@ -7,5 +7,6 @@ config SPI_XLNX_AXI_QUADSPI
 	bool "Xilinx AXI Quad SPI driver"
 	default y
 	depends on DT_HAS_XLNX_XPS_SPI_2_00_A_ENABLED
+	select EVENTS
 	help
 	  Enable Xilinx AXI Quad SPI v3.2 driver.

--- a/dts/bindings/spi/xlnx,xps-spi-2.00.a.yaml
+++ b/dts/bindings/spi/xlnx,xps-spi-2.00.a.yaml
@@ -49,3 +49,11 @@ properties:
       transaction to the SPI flash device to ensure the STARTUP block is
       disengaged and allow the SPI core to control the CCLK line properly.
       The dummy READ_ID transaction will be issued to chip select 0.
+
+  fifo-size:
+    type: int
+    description: |
+      FIFO size configured in SPI core. 0 indicates no FIFO.
+      If not specified, 0 is assumed.
+      Used to optimize TX/RX read handling. If the FIFO size is 0, the driver
+      will check for FIFO full/empty after every word.

--- a/dts/bindings/spi/xlnx,xps-spi-2.00.a.yaml
+++ b/dts/bindings/spi/xlnx,xps-spi-2.00.a.yaml
@@ -37,3 +37,15 @@ properties:
       - 32
     description: |
       Number of bits per transfer
+
+  xlnx,startup-block:
+    type: boolean
+    description: |
+      Indicates the core is instantiated with the STARTUP block option, as is
+      typically used when interfacing with the FPGA's configuration flash
+      device. In this configuration the SPI clock is routed through the
+      STARTUP block rather than normal signal routing.
+      In this case, a workaround is required to issue a dummy
+      transaction to the SPI flash device to ensure the STARTUP block is
+      disengaged and allow the SPI core to control the CCLK line properly.
+      The dummy READ_ID transaction will be issued to chip select 0.


### PR DESCRIPTION
Add support for configurations where the FPGA's STARTUP block is used to interface with the clock line for the FPGA configuration flash device.

Also some optimizations to reduce unnecessary reads of the status register, and reduce the amount of work being performed in the IRQ handler for the non-async SPI case.