### PR TITLE
drivers: adc: tla2021: Fix reference voltage

### DIFF
--- a/drivers/adc/adc_tla2021.c
+++ b/drivers/adc/adc_tla2021.c
@@ -288,7 +288,7 @@ static int tla2021_init(const struct device *dev)
 static const struct adc_driver_api tla2021_driver_api = {
 	.channel_setup = tla2021_channel_setup,
 	.read = tla2021_read,
-	.ref_internal = 2048,
+	.ref_internal = 4096,
 #ifdef CONFIG_ADC_ASYNC
 	.read_async = tla2021_read_async,
 #endif


### PR DESCRIPTION
This fixes the issue that `adc_raw_to_millivolts` in half the actual voltage.