### PR TITLE
drivers: can: validate the use of CAN IDs and CAN ID masks before passing them to the drivers

### DIFF
--- a/drivers/can/can_common.c
+++ b/drivers/can/can_common.c
@@ -70,6 +70,34 @@ int z_impl_can_send(const struct device *dev, const struct can_frame *frame,
 	return api->send(dev, frame, timeout, callback, user_data);
 }
 
+int can_add_rx_filter(const struct device *dev, can_rx_callback_t callback,
+		      void *user_data, const struct can_filter *filter)
+{
+	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
+	uint32_t id_mask;
+
+	if (filter == NULL) {
+		return -EINVAL;
+	}
+
+	if ((filter->flags & CAN_FILTER_IDE) != 0U) {
+		id_mask = CAN_EXT_ID_MASK;
+	} else {
+		id_mask = CAN_STD_ID_MASK;
+	}
+
+	if (((filter->id & ~(id_mask)) != 0U) || ((filter->mask & ~(id_mask)) != 0U)) {
+		LOG_ERR("invalid filter with %s (%d-bit) CAN ID 0x%0*x, CAN ID mask 0x%0*x",
+			(filter->flags & CAN_FILTER_IDE) != 0 ? "extended" : "standard",
+			(filter->flags & CAN_FILTER_IDE) != 0 ? 29 : 11,
+			(filter->flags & CAN_FILTER_IDE) != 0 ? 8 : 3, filter->id,
+			(filter->flags & CAN_FILTER_IDE) != 0 ? 8 : 3, filter->mask);
+		return -EINVAL;
+	}
+
+	return api->add_rx_filter(dev, callback, user_data, filter);
+}
+
 static void can_msgq_put(const struct device *dev, struct can_frame *frame, void *user_data)
 {
 	struct k_msgq *msgq = (struct k_msgq *)user_data;

--- a/drivers/can/can_common.c
+++ b/drivers/can/can_common.c
@@ -35,6 +35,21 @@ int z_impl_can_send(const struct device *dev, const struct can_frame *frame,
 		    void *user_data)
 {
 	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
+	uint32_t id_mask;
+
+	if ((frame->flags & CAN_FRAME_IDE) != 0U) {
+		id_mask = CAN_EXT_ID_MASK;
+	} else {
+		id_mask = CAN_STD_ID_MASK;
+	}
+
+	if ((frame->id & ~(id_mask)) != 0U) {
+		LOG_ERR("invalid frame with %s (%d-bit) CAN ID 0x%0*x",
+			(frame->flags & CAN_FRAME_IDE) != 0 ? "extended" : "standard",
+			(frame->flags & CAN_FRAME_IDE) != 0 ? 29 : 11,
+			(frame->flags & CAN_FRAME_IDE) != 0 ? 8 : 3, frame->id);
+		return -EINVAL;
+	}
 
 	if (callback == NULL) {
 		struct can_tx_default_cb_ctx ctx;

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -1336,17 +1336,8 @@ __syscall int can_send(const struct device *dev, const struct can_frame *frame,
  * @retval -EINVAL if the requested filter type is invalid.
  * @retval -ENOTSUP if the requested filter type is not supported.
  */
-static inline int can_add_rx_filter(const struct device *dev, can_rx_callback_t callback,
-				    void *user_data, const struct can_filter *filter)
-{
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
-
-	if (filter == NULL) {
-		return -EINVAL;
-	}
-
-	return api->add_rx_filter(dev, callback, user_data, filter);
-}
+int can_add_rx_filter(const struct device *dev, can_rx_callback_t callback,
+		      void *user_data, const struct can_filter *filter);
 
 /**
  * @brief Statically define and initialize a CAN RX message queue.

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -213,14 +213,11 @@ struct can_frame {
  */
 struct can_filter {
 	/** CAN identifier to match. */
-	uint32_t id           : 29;
-	/** @cond INTERNAL_HIDDEN */
-	uint32_t res0         : 3;
-	/** @endcond */
+	uint32_t id;
 	/** CAN identifier matching mask. If a bit in this mask is 0, the value
 	 * of the corresponding bit in the ``id`` field is ignored by the filter.
 	 */
-	uint32_t mask         : 29;
+	uint32_t mask;
 	/** Flags. @see @ref CAN_FILTER_FLAGS. */
 	uint8_t flags;
 };

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -167,10 +167,7 @@ enum can_state {
  */
 struct can_frame {
 	/** Standard (11-bit) or extended (29-bit) CAN identifier. */
-	uint32_t id  : 29;
-	/** @cond INTERNAL_HIDDEN */
-	uint8_t res0 : 3; /* reserved/padding. */
-	/** @endcond */
+	uint32_t id;
 	/** Data Length Code (DLC) indicating data length in bytes. */
 	uint8_t dlc;
 	/** Flags. @see @ref CAN_FRAME_FLAGS. */
@@ -186,7 +183,8 @@ struct can_frame {
 	uint16_t timestamp;
 #else
 	/** @cond INTERNAL_HIDDEN */
-	uint16_t res1;  /* reserved/padding. */
+	/** Padding. */
+	uint16_t reserved;
 	/** @endcond */
 #endif
 	/** The frame payload data. */
@@ -207,7 +205,6 @@ struct can_frame {
 
 /** Filter matches frames with extended (29-bit) CAN IDs */
 #define CAN_FILTER_IDE  BIT(0)
-
 
 /** @} */
 

--- a/subsys/canbus/isotp/isotp.c
+++ b/subsys/canbus/isotp/isotp.c
@@ -595,8 +595,10 @@ static inline int add_ff_sf_filter(struct isotp_recv_ctx *rctx)
 
 	if ((rctx->rx_addr.flags & ISOTP_MSG_FIXED_ADDR) != 0) {
 		mask = ISOTP_FIXED_ADDR_RX_MASK;
-	} else {
+	} else if ((rctx->rx_addr.flags & ISOTP_MSG_IDE) != 0) {
 		mask = CAN_EXT_ID_MASK;
+	} else {
+		mask = CAN_STD_ID_MASK;
 	}
 
 	prepare_filter(&filter, &rctx->rx_addr, mask);
@@ -1167,8 +1169,15 @@ static void send_work_handler(struct k_work *item)
 static inline int add_fc_filter(struct isotp_send_ctx *sctx)
 {
 	struct can_filter filter;
+	uint32_t mask;
 
-	prepare_filter(&filter, &sctx->rx_addr, CAN_EXT_ID_MASK);
+	if ((sctx->rx_addr.flags & ISOTP_MSG_IDE) != 0) {
+		mask = CAN_EXT_ID_MASK;
+	} else {
+		mask = CAN_STD_ID_MASK;
+	}
+
+	prepare_filter(&filter, &sctx->rx_addr, mask);
 
 	sctx->filter_id = can_add_rx_filter(sctx->can_dev, send_can_rx_cb, sctx,
 					   &filter);

--- a/tests/drivers/can/api/src/classic.c
+++ b/tests/drivers/can/api/src/classic.c
@@ -393,9 +393,9 @@ static void send_receive(const struct can_filter *filter1,
  * @param data_frame  CAN data frame
  * @param rtr_frame   CAN RTR frame
  */
-void send_receive_rtr(const struct can_filter *filter,
-		      const struct can_frame *data_frame,
-		      const struct can_frame *rtr_frame)
+static void send_receive_rtr(const struct can_filter *filter,
+			     const struct can_frame *data_frame,
+			     const struct can_frame *rtr_frame)
 {
 	struct can_frame frame;
 	int filter_id;
@@ -717,6 +717,45 @@ ZTEST(can_classic, test_send_callback)
 
 	err = k_sem_take(&tx_callback_sem, TEST_SEND_TIMEOUT);
 	zassert_equal(err, 0, "missing TX callback");
+}
+
+/**
+ * @brief Test sending an invalid CAN frame.
+ *
+ * @param dev   Pointer to the device structure for the driver instance.
+ * @param frame Pointer to the CAN frame to send.
+ */
+static void send_invalid_frame(const struct device *dev, const struct can_frame *frame)
+{
+	int err;
+
+	err = can_send(dev, frame, TEST_SEND_TIMEOUT, NULL, NULL);
+	zassert_equal(err, -EINVAL, "wrong error on sending invalid frame (err %d)", err);
+}
+
+/**
+ * @brief Test sending frame with standard (11-bit) CAN ID out-of-range.
+ */
+ZTEST(can_classic, test_send_std_id_out_of_range)
+{
+	struct can_frame frame = {
+		.id = CAN_STD_ID_MASK + 1U,
+	};
+
+	send_invalid_frame(can_dev, &frame);
+}
+
+/**
+ * @brief Test sending frame with extended (29-bit) CAN ID out-of-range.
+ */
+ZTEST(can_classic, test_send_ext_id_out_of_range)
+{
+	struct can_frame frame = {
+		.flags = CAN_FRAME_IDE,
+		.id = CAN_EXT_ID_MASK + 1U,
+	};
+
+	send_invalid_frame(can_dev, &frame);
 }
 
 /**

--- a/tests/drivers/can/api/src/classic.c
+++ b/tests/drivers/can/api/src/classic.c
@@ -626,6 +626,56 @@ ZTEST(can_classic, test_add_filter)
 }
 
 /**
+ * @brief Test adding an invalid CAN RX filter.
+ *
+ * @param dev   Pointer to the device structure for the driver instance.
+ * @param frame Pointer to the CAN RX filter.
+ */
+static void add_invalid_rx_filter(const struct device *dev, const struct can_filter *filter)
+{
+	int filter_id;
+
+	filter_id = can_add_rx_filter(dev, rx_std_callback_1, NULL, filter);
+	zassert_equal(filter_id, -EINVAL, "added invalid filter");
+}
+
+/**
+ * @brief Test adding invalid standard (11-bit) filters.
+ */
+ZTEST(can_classic, test_add_invalid_std_filter)
+{
+	struct can_filter filter = {
+		.flags = 0U,
+	};
+
+	filter.id = CAN_STD_ID_MASK;
+	filter.mask = CAN_STD_ID_MASK + 1U;
+	add_invalid_rx_filter(can_dev, &filter);
+
+	filter.id = CAN_STD_ID_MASK + 1U;
+	filter.mask = CAN_STD_ID_MASK;
+	add_invalid_rx_filter(can_dev, &filter);
+}
+
+/**
+ * @brief Test adding invalid extended (29-bit) filters.
+ */
+ZTEST(can_classic, test_add_invalid_ext_filter)
+{
+	struct can_filter filter = {
+		.flags = CAN_FILTER_IDE,
+	};
+
+	filter.id = CAN_EXT_ID_MASK;
+	filter.mask = CAN_EXT_ID_MASK + 1U;
+	add_invalid_rx_filter(can_dev, &filter);
+
+	filter.id = CAN_EXT_ID_MASK + 1U;
+	filter.mask = CAN_EXT_ID_MASK;
+	add_invalid_rx_filter(can_dev, &filter);
+}
+
+/**
  * @brief Test adding up to and above the maximum number of RX filters.
  *
  * @param ide standard (11-bit) CAN ID filters if false, or extended (29-bit) CAN ID filters if


### PR DESCRIPTION
- Validate the CAN ID used in the can_frame struct before passing it to the drivers.
- Validate the CAN ID and CAN ID mask used in the can_filter struct before passing it to the drivers.
- Remove the use of bitfields in the can_frame struct.
- Remove the use of bitfields in the can_filter struct.
- Add tests for sending CAN frames with invalid CAN IDs.
- Add tests for adding CAN RX filters with invalid CAN IDs and CAN ID masks.

The above changes in validation revealed an issue with the CAN ISO-TP protocol implementation, which was using 29-bit CAN ID masks regardless of the type of CAN RX filter.