### PR TITLE
drivers: can: validate the use of CAN IDs and CAN ID masks before passing them to the drivers

### DIFF
--- a/drivers/can/can_loopback.c
+++ b/drivers/can/can_loopback.c
@@ -112,8 +112,6 @@ static int can_loopback_send(const struct device *dev,
 	uint8_t max_dlc = CAN_MAX_DLC;
 	int ret;
 
-	__ASSERT_NO_MSG(callback != NULL);
-
 	LOG_DBG("Sending %d bytes on %s. Id: 0x%x, ID type: %s %s",
 		frame->dlc, dev->name, frame->id,
 		(frame->flags & CAN_FRAME_IDE) != 0 ? "extended" : "standard",

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -921,8 +921,6 @@ int can_mcan_send(const struct device *dev, const struct can_frame *frame, k_tim
 		(frame->flags & CAN_FRAME_FDF) != 0U ? "FD frame" : "",
 		(frame->flags & CAN_FRAME_BRS) != 0U ? "BRS" : "");
 
-	__ASSERT_NO_MSG(callback != NULL);
-
 #ifdef CONFIG_CAN_FD_MODE
 	if ((frame->flags & ~(CAN_FRAME_IDE | CAN_FRAME_RTR | CAN_FRAME_FDF | CAN_FRAME_BRS)) !=
 	    0) {
@@ -1163,10 +1161,6 @@ int can_mcan_add_rx_filter(const struct device *dev, can_rx_callback_t callback,
 	const struct can_mcan_config *config = dev->config;
 	const struct can_mcan_callbacks *cbs = config->callbacks;
 	int filter_id;
-
-	if (callback == NULL) {
-		return -EINVAL;
-	}
 
 	if ((filter->flags & ~(CAN_FILTER_IDE)) != 0U) {
 		LOG_ERR("unsupported CAN filter flags 0x%02x", filter->flags);

--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -537,8 +537,6 @@ static int mcp2515_send(const struct device *dev,
 	uint8_t len;
 	uint8_t tx_frame[MCP2515_FRAME_LEN];
 
-	__ASSERT_NO_MSG(callback != NULL);
-
 	if (frame->dlc > CAN_MAX_DLC) {
 		LOG_ERR("DLC of %d exceeds maximum (%d)",
 			frame->dlc, CAN_MAX_DLC);

--- a/drivers/can/can_mcp251xfd.c
+++ b/drivers/can/can_mcp251xfd.c
@@ -496,8 +496,6 @@ static int mcp251xfd_send(const struct device *dev, const struct can_frame *msg,
 		msg->flags & CAN_FRAME_FDF ? "FD frame" : "",
 		msg->flags & CAN_FRAME_BRS ? "BRS" : "");
 
-	__ASSERT_NO_MSG(callback != NULL);
-
 	if (!dev_data->common.started) {
 		return -ENETDOWN;
 	}
@@ -559,7 +557,6 @@ static int mcp251xfd_add_rx_filter(const struct device *dev, can_rx_callback_t r
 	int filter_idx;
 	int ret;
 
-	__ASSERT(rx_cb != NULL, "rx_cb can not be null");
 	k_mutex_lock(&dev_data->mutex, K_FOREVER);
 
 	for (filter_idx = 0; filter_idx < CONFIG_CAN_MAX_FILTER ; filter_idx++) {

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -671,8 +671,6 @@ static int mcux_flexcan_send(const struct device *dev,
 	uint8_t max_dlc = CAN_MAX_DLC;
 	int alloc;
 
-	__ASSERT_NO_MSG(callback != NULL);
-
 	if (UTIL_AND(IS_ENABLED(CONFIG_CAN_MCUX_FLEXCAN_FD),
 		     ((data->common.mode & CAN_MODE_FD) != 0U))) {
 		if ((frame->flags & ~(CAN_FRAME_IDE | CAN_FRAME_RTR |
@@ -771,8 +769,6 @@ static int mcux_flexcan_add_rx_filter(const struct device *dev,
 	uint32_t mask;
 	int alloc = -ENOSPC;
 	int i;
-
-	__ASSERT_NO_MSG(callback);
 
 	if ((filter->flags & ~(CAN_FILTER_IDE)) != 0) {
 		LOG_ERR("unsupported CAN filter flags 0x%02x", filter->flags);

--- a/drivers/can/can_native_linux.c
+++ b/drivers/can/can_native_linux.c
@@ -138,8 +138,6 @@ static int can_native_linux_send(const struct device *dev, const struct can_fram
 		(frame->flags & CAN_FRAME_IDE) != 0 ? "extended" : "standard",
 		(frame->flags & CAN_FRAME_RTR) != 0 ? ", RTR frame" : "");
 
-	__ASSERT_NO_MSG(callback != NULL);
-
 #ifdef CONFIG_CAN_FD_MODE
 	if ((frame->flags & ~(CAN_FRAME_IDE | CAN_FRAME_RTR |
 		CAN_FRAME_FDF | CAN_FRAME_BRS)) != 0) {

--- a/drivers/can/can_nxp_s32_canxl.c
+++ b/drivers/can/can_nxp_s32_canxl.c
@@ -464,8 +464,6 @@ static int can_nxp_s32_add_rx_filter(const struct device *dev,
 	int mb_indx;
 	uint32_t mask;
 
-	__ASSERT_NO_MSG(callback != NULL);
-
 	if ((filter->flags & ~(CAN_FILTER_IDE)) != 0) {
 		LOG_ERR("unsupported CAN filter flags 0x%02x", filter->flags);
 		return -ENOTSUP;
@@ -554,8 +552,6 @@ static int can_nxp_s32_send(const struct device *dev,
 	Canexcel_Ip_StatusType status;
 	enum can_state state;
 	int alloc, mb_indx;
-
-	__ASSERT_NO_MSG(callback != NULL);
 
 #ifdef CAN_NXP_S32_FD_MODE
 	if ((frame->flags & ~(CAN_FRAME_IDE | CAN_FRAME_FDF | CAN_FRAME_BRS)) != 0) {

--- a/drivers/can/can_rcar.c
+++ b/drivers/can/can_rcar.c
@@ -888,9 +888,6 @@ static int can_rcar_send(const struct device *dev, const struct can_frame *frame
 		"extended" : "standard"
 		, (frame->flags & CAN_FRAME_RTR) != 0 ? "yes" : "no");
 
-	__ASSERT_NO_MSG(callback != NULL);
-	__ASSERT(frame->dlc == 0U || frame->data != NULL, "Dataptr is null");
-
 	if (frame->dlc > CAN_MAX_DLC) {
 		LOG_ERR("DLC of %d exceeds maximum (%d)",
 			frame->dlc, CAN_MAX_DLC);

--- a/drivers/can/can_sja1000.c
+++ b/drivers/can/can_sja1000.c
@@ -378,8 +378,6 @@ int can_sja1000_send(const struct device *dev, const struct can_frame *frame, k_
 	uint8_t cmr;
 	uint8_t sr;
 
-	__ASSERT_NO_MSG(callback != NULL);
-
 	if (frame->dlc > CAN_MAX_DLC) {
 		LOG_ERR("TX frame DLC %u exceeds maximum (%d)", frame->dlc, CAN_MAX_DLC);
 		return -EINVAL;

--- a/drivers/can/can_stm32_bxcan.c
+++ b/drivers/can/can_stm32_bxcan.c
@@ -774,9 +774,6 @@ static int can_stm32_send(const struct device *dev, const struct can_frame *fram
 		    , (frame->flags & CAN_FRAME_IDE) != 0 ? "extended" : "standard"
 		    , (frame->flags & CAN_FRAME_RTR) != 0 ? "yes" : "no");
 
-	__ASSERT_NO_MSG(callback != NULL);
-	__ASSERT(frame->dlc == 0U || frame->data != NULL, "Dataptr is null");
-
 	if (frame->dlc > CAN_MAX_DLC) {
 		LOG_ERR("DLC of %d exceeds maximum (%d)", frame->dlc, CAN_MAX_DLC);
 		return -EINVAL;

--- a/drivers/can/can_xmc4xxx.c
+++ b/drivers/can/can_xmc4xxx.c
@@ -156,8 +156,6 @@ static int can_xmc4xxx_send(const struct device *dev, const struct can_frame *ms
 		msg->flags & CAN_FRAME_FDF ? "FD frame" : "",
 		msg->flags & CAN_FRAME_BRS ? "BRS" : "");
 
-	__ASSERT_NO_MSG(callback != NULL);
-
 	if (msg->dlc > CAN_XMC4XXX_MAX_DLC) {
 		return -EINVAL;
 	}

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -1336,17 +1336,8 @@ __syscall int can_send(const struct device *dev, const struct can_frame *frame,
  * @retval -EINVAL if the requested filter type is invalid.
  * @retval -ENOTSUP if the requested filter type is not supported.
  */
-static inline int can_add_rx_filter(const struct device *dev, can_rx_callback_t callback,
-				    void *user_data, const struct can_filter *filter)
-{
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
-
-	if (filter == NULL) {
-		return -EINVAL;
-	}
-
-	return api->add_rx_filter(dev, callback, user_data, filter);
-}
+int can_add_rx_filter(const struct device *dev, can_rx_callback_t callback,
+		      void *user_data, const struct can_filter *filter);
 
 /**
  * @brief Statically define and initialize a CAN RX message queue.

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -213,14 +213,11 @@ struct can_frame {
  */
 struct can_filter {
 	/** CAN identifier to match. */
-	uint32_t id           : 29;
-	/** @cond INTERNAL_HIDDEN */
-	uint32_t res0         : 3;
-	/** @endcond */
+	uint32_t id;
 	/** CAN identifier matching mask. If a bit in this mask is 0, the value
 	 * of the corresponding bit in the ``id`` field is ignored by the filter.
 	 */
-	uint32_t mask         : 29;
+	uint32_t mask;
 	/** Flags. @see @ref CAN_FILTER_FLAGS. */
 	uint8_t flags;
 };

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -167,10 +167,7 @@ enum can_state {
  */
 struct can_frame {
 	/** Standard (11-bit) or extended (29-bit) CAN identifier. */
-	uint32_t id  : 29;
-	/** @cond INTERNAL_HIDDEN */
-	uint8_t res0 : 3; /* reserved/padding. */
-	/** @endcond */
+	uint32_t id;
 	/** Data Length Code (DLC) indicating data length in bytes. */
 	uint8_t dlc;
 	/** Flags. @see @ref CAN_FRAME_FLAGS. */
@@ -186,7 +183,8 @@ struct can_frame {
 	uint16_t timestamp;
 #else
 	/** @cond INTERNAL_HIDDEN */
-	uint16_t res1;  /* reserved/padding. */
+	/** Padding. */
+	uint16_t reserved;
 	/** @endcond */
 #endif
 	/** The frame payload data. */
@@ -207,7 +205,6 @@ struct can_frame {
 
 /** Filter matches frames with extended (29-bit) CAN IDs */
 #define CAN_FILTER_IDE  BIT(0)
-
 
 /** @} */
 

--- a/subsys/canbus/isotp/isotp.c
+++ b/subsys/canbus/isotp/isotp.c
@@ -595,8 +595,10 @@ static inline int add_ff_sf_filter(struct isotp_recv_ctx *rctx)
 
 	if ((rctx->rx_addr.flags & ISOTP_MSG_FIXED_ADDR) != 0) {
 		mask = ISOTP_FIXED_ADDR_RX_MASK;
-	} else {
+	} else if ((rctx->rx_addr.flags & ISOTP_MSG_IDE) != 0) {
 		mask = CAN_EXT_ID_MASK;
+	} else {
+		mask = CAN_STD_ID_MASK;
 	}
 
 	prepare_filter(&filter, &rctx->rx_addr, mask);
@@ -1167,8 +1169,15 @@ static void send_work_handler(struct k_work *item)
 static inline int add_fc_filter(struct isotp_send_ctx *sctx)
 {
 	struct can_filter filter;
+	uint32_t mask;
 
-	prepare_filter(&filter, &sctx->rx_addr, CAN_EXT_ID_MASK);
+	if ((sctx->rx_addr.flags & ISOTP_MSG_IDE) != 0) {
+		mask = CAN_EXT_ID_MASK;
+	} else {
+		mask = CAN_STD_ID_MASK;
+	}
+
+	prepare_filter(&filter, &sctx->rx_addr, mask);
 
 	sctx->filter_id = can_add_rx_filter(sctx->can_dev, send_can_rx_cb, sctx,
 					   &filter);

--- a/tests/drivers/can/api/src/classic.c
+++ b/tests/drivers/can/api/src/classic.c
@@ -393,9 +393,9 @@ static void send_receive(const struct can_filter *filter1,
  * @param data_frame  CAN data frame
  * @param rtr_frame   CAN RTR frame
  */
-void send_receive_rtr(const struct can_filter *filter,
-		      const struct can_frame *data_frame,
-		      const struct can_frame *rtr_frame)
+static void send_receive_rtr(const struct can_filter *filter,
+			     const struct can_frame *data_frame,
+			     const struct can_frame *rtr_frame)
 {
 	struct can_frame frame;
 	int filter_id;
@@ -717,6 +717,55 @@ ZTEST(can_classic, test_send_callback)
 
 	err = k_sem_take(&tx_callback_sem, TEST_SEND_TIMEOUT);
 	zassert_equal(err, 0, "missing TX callback");
+}
+
+/**
+ * @brief Test sending an invalid CAN frame.
+ *
+ * @param dev   Pointer to the device structure for the driver instance.
+ * @param frame Pointer to the CAN frame to send.
+ */
+static void send_invalid_frame(const struct device *dev, const struct can_frame *frame)
+{
+	int err;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_RUNTIME_ERROR_CHECKS);
+
+	err = can_send(dev, frame, TEST_SEND_TIMEOUT, NULL, NULL);
+	zassert_equal(err, -EINVAL, "wrong error on sending invalid frame (err %d)", err);
+}
+
+/**
+ * @brief Test sending NULL frame.
+ */
+ZTEST(can_classic, test_send_null_frame)
+{
+	send_invalid_frame(can_dev, NULL);
+}
+
+/**
+ * @brief Test sending frame with standard (11-bit) CAN ID out-of-range.
+ */
+ZTEST(can_classic, test_send_std_id_out_of_range)
+{
+	struct can_frame frame = {
+		.id = CAN_STD_ID_MASK + 1U,
+	};
+
+	send_invalid_frame(can_dev, &frame);
+}
+
+/**
+ * @brief Test sending frame with extended (29-bit) CAN ID out-of-range.
+ */
+ZTEST(can_classic, test_send_ext_id_out_of_range)
+{
+	struct can_frame frame = {
+		.flags = CAN_FRAME_IDE,
+		.id = CAN_EXT_ID_MASK + 1U,
+	};
+
+	send_invalid_frame(can_dev, &frame);
 }
 
 /**

--- a/tests/drivers/can/api/src/classic.c
+++ b/tests/drivers/can/api/src/classic.c
@@ -626,6 +626,66 @@ ZTEST(can_classic, test_add_filter)
 }
 
 /**
+ * @brief Test adding an invalid CAN RX filter.
+ *
+ * @param dev   Pointer to the device structure for the driver instance.
+ * @param frame Pointer to the CAN RX filter.
+ */
+static void add_invalid_rx_filter(const struct device *dev, const struct can_filter *filter)
+{
+	int filter_id;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_RUNTIME_ERROR_CHECKS);
+
+	filter_id = can_add_rx_filter(dev, rx_std_callback_1, NULL, filter);
+	zassert_equal(filter_id, -EINVAL, "added invalid filter");
+}
+
+/**
+ * @brief Test adding NULL filter.
+ */
+ZTEST(can_classic, test_add_invalid_null_filter)
+{
+	add_invalid_rx_filter(can_dev, NULL);
+}
+
+/**
+ * @brief Test adding invalid standard (11-bit) filters.
+ */
+ZTEST(can_classic, test_add_invalid_std_filter)
+{
+	struct can_filter filter = {
+		.flags = 0U,
+	};
+
+	filter.id = CAN_STD_ID_MASK;
+	filter.mask = CAN_STD_ID_MASK + 1U;
+	add_invalid_rx_filter(can_dev, &filter);
+
+	filter.id = CAN_STD_ID_MASK + 1U;
+	filter.mask = CAN_STD_ID_MASK;
+	add_invalid_rx_filter(can_dev, &filter);
+}
+
+/**
+ * @brief Test adding invalid extended (29-bit) filters.
+ */
+ZTEST(can_classic, test_add_invalid_ext_filter)
+{
+	struct can_filter filter = {
+		.flags = CAN_FILTER_IDE,
+	};
+
+	filter.id = CAN_EXT_ID_MASK;
+	filter.mask = CAN_EXT_ID_MASK + 1U;
+	add_invalid_rx_filter(can_dev, &filter);
+
+	filter.id = CAN_EXT_ID_MASK + 1U;
+	filter.mask = CAN_EXT_ID_MASK;
+	add_invalid_rx_filter(can_dev, &filter);
+}
+
+/**
  * @brief Test adding up to and above the maximum number of RX filters.
  *
  * @param ide standard (11-bit) CAN ID filters if false, or extended (29-bit) CAN ID filters if


### PR DESCRIPTION
- Validate the CAN ID used in the can_frame struct before passing it to the drivers.
- Validate the CAN ID and CAN ID mask used in the can_filter struct before passing it to the drivers.
- Remove the use of bitfields in the can_frame struct.
- Remove the use of bitfields in the can_filter struct.
- Add tests for sending CAN frames with invalid CAN IDs.
- Add tests for adding CAN RX filters with invalid CAN IDs and CAN ID masks.

The above changes in validation revealed an issue with the CAN ISO-TP protocol implementation, which was using 29-bit CAN ID masks regardless of the type of CAN RX filter.