### PR TITLE
net: zperf: Fix net_socket_service blocked traffic

### DIFF
--- a/subsys/net/lib/zperf/zperf_tcp_receiver.c
+++ b/subsys/net/lib/zperf/zperf_tcp_receiver.c
@@ -189,8 +189,11 @@ static int tcp_recv_data(struct net_socket_service_event *pev)
 		}
 
 	} else {
-		ret = zsock_recv(pev->event.fd, buf, sizeof(buf), 0);
+		ret = zsock_recv(pev->event.fd, buf, sizeof(buf), ZSOCK_MSG_DONTWAIT);
 		if (ret < 0) {
+			if (errno == EAGAIN) {
+				return 0;
+			}
 			(void)zsock_getsockopt(pev->event.fd, SOL_SOCKET,
 					       SO_DOMAIN, &family, &optlen);
 			NET_ERR("recv failed on IPv%d socket (%d)",

--- a/subsys/net/lib/zperf/zperf_udp_receiver.c
+++ b/subsys/net/lib/zperf/zperf_udp_receiver.c
@@ -336,9 +336,12 @@ static int udp_recv_data(struct net_socket_service_event *pev)
 		return 0;
 	}
 
-	ret = zsock_recvfrom(pev->event.fd, buf, sizeof(buf), 0,
+	ret = zsock_recvfrom(pev->event.fd, buf, sizeof(buf), ZSOCK_MSG_DONTWAIT,
 			     &addr, &addrlen);
 	if (ret < 0) {
+		if (errno == EAGAIN) {
+			return 0;
+		}
 		ret = -errno;
 		(void)zsock_getsockopt(pev->event.fd, SOL_SOCKET,
 				       SO_DOMAIN, &family, &optlen);


### PR DESCRIPTION
If run the TCP RX traffic for both WiFi STA interface from external AP's backend PC, and uAP interface from external STA at the same time, then stop the uAP network, the TCP traffic will decrease to zero for STA interface, and some net packets are not freed in socket layer. The root cause is the net_socket_service thread has two places to suspend itself, one is socket_service_thread-> zsock_poll, another one is tcp_svc_handler -> tcp_recv_data-> zsock_recv, and when the uAP network stopped, this thread will wait forever in zsock_recv as the uAP ctx->recv_q is empty, which will also block the STA traffic and cache the net packets. For tcp_recv_data or udp_recv_data, when call the zsock_recvfrom, should use flag ZSOCK_MSG_DONTWAIT to avoid thread pending here.