### PR TITLE
Bluetooth: Controller: Introduce ASSERT_OVERHEAD_START_SCAN_AUX 

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -671,6 +671,19 @@ config BT_CTLR_ASSERT_OVERHEAD_START
 	  otherwise leading to remote supervision timeout and possible missing
 	  local disconnect events.
 
+config BT_CTLR_ASSERT_OVERHEAD_START_SCAN_AUX
+	bool "Assert on Prepare Latency for Auxiliary PDU reception"
+	help
+	  Introduce BT_CTLR_ASSERT_OVERHEAD_START_SCAN_AUX workaround
+	  to handle assertion due to detected overhead scanning for
+	  auxiliary PDU in ULL scheduling.
+
+	  For unknown reasons the preempt timeout is being setup
+	  beyond its expire. This is only happening when unreserved
+	  scanning on both 1M and Coded PHY is enabled.
+
+	  Remove/revert this workaround when a fix is identified.
+
 config BT_CTLR_CENTRAL_SPACING
 	int "Central Connection Spacing"
 	depends on BT_CTLR_SCHED_ADVANCED

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -566,12 +566,20 @@ sync_aux_prepare_done:
 					  ull_scan_aux_lll_handle_get(lll_aux)), ticks_at_event);
 	/* check if preempt to start has changed */
 	if (overhead) {
-		LL_ASSERT_OVERHEAD(overhead);
+		int err;
+
+		if (IS_ENABLED(CONFIG_BT_CTLR_ASSERT_OVERHEAD_START_SCAN_AUX)) {
+			LL_ASSERT_OVERHEAD(overhead);
+
+			err = -ECANCELED;
+		} else {
+			err = 0;
+		}
 
 		radio_isr_set(isr_done, lll_aux);
 		radio_disable();
 
-		return -ECANCELED;
+		return err;
 	}
 #endif /* !CONFIG_BT_CTLR_XTAL_ADVANCED */
 

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -2072,12 +2072,16 @@ void ull_prepare_dequeue(uint8_t caller_id)
 	void *param_resume_head = NULL;
 	void *param_resume_next = NULL;
 	struct lll_event *next;
+	uint8_t loop = 10U;
 
 	next = ull_prepare_dequeue_get();
 	while (next) {
 		void *param = next->prepare_param.param;
 		uint8_t is_aborted = next->is_aborted;
 		uint8_t is_resume = next->is_resume;
+
+		LL_ASSERT(loop);
+		loop--;
 
 		/* Let LLL invoke the `prepare` interface if radio not in active
 		 * use. Otherwise, enqueue at end of the prepare pipeline queue.


### PR DESCRIPTION
Introduce BT_CTLR_ASSERT_OVERHEAD_START_SCAN_AUX
workaround to handle assertion due to detected
overhead scanning for auxiliary PDU in ULL
scheduling.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>