### PR TITLE
Voltage divider off on delay

### DIFF
--- a/drivers/sensor/voltage_divider/voltage.c
+++ b/drivers/sensor/voltage_divider/voltage.c
@@ -132,7 +132,8 @@ static int voltage_init(const struct device *dev)
 
 		ret = gpio_pin_configure_dt(&config->gpio_power, GPIO_OUTPUT_ACTIVE);
 		if (ret != 0) {
-			LOG_ERR("failed to initialize GPIO for reset");
+			LOG_ERR("failed to initialize GPIO for power");
+			return ret;
 		}
 	}
 

--- a/drivers/sensor/voltage_divider/voltage.c
+++ b/drivers/sensor/voltage_divider/voltage.c
@@ -76,8 +76,8 @@ static int get(const struct device *dev, enum sensor_channel chan, struct sensor
 	/* Note if full_ohms is not specified then unscaled voltage is returned */
 	(void)voltage_divider_scale_dt(&config->voltage, &v_mv);
 
-	LOG_DBG("%d of %d, %dmV, voltage:%dmV", data->raw,
-		(1 << data->sequence.resolution) - 1, raw_val, v_mv);
+	LOG_DBG("%d of %d, %dmV, voltage:%dmV", data->raw, (1 << data->sequence.resolution) - 1,
+		raw_val, v_mv);
 	val->val1 = v_mv / 1000;
 	val->val2 = (v_mv * 1000) % 1000000;
 

--- a/drivers/sensor/voltage_divider/voltage.c
+++ b/drivers/sensor/voltage_divider/voltage.c
@@ -126,15 +126,24 @@ static int voltage_init(const struct device *dev)
 	}
 
 	if (config->gpio_power.port != NULL) {
+		int power_gpio_state = GPIO_OUTPUT_ACTIVE;
+
+		if (IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)) {
+			power_gpio_state = GPIO_OUTPUT_INACTIVE;
+		}
+
 		if (!gpio_is_ready_dt(&config->gpio_power)) {
 			LOG_ERR("Power GPIO is not ready");
 			return -ENODEV;
 		}
-
-		ret = gpio_pin_configure_dt(&config->gpio_power, GPIO_OUTPUT_ACTIVE);
+		ret = gpio_pin_configure_dt(&config->gpio_power, power_gpio_state);
 		if (ret != 0) {
 			LOG_ERR("failed to initialize GPIO for power");
 			return ret;
+		}
+
+		if (IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)) {
+			pm_device_init_suspended(dev);
 		}
 	}
 

--- a/drivers/sensor/voltage_divider/voltage.c
+++ b/drivers/sensor/voltage_divider/voltage.c
@@ -17,9 +17,7 @@ LOG_MODULE_REGISTER(voltage, CONFIG_SENSOR_LOG_LEVEL);
 
 struct voltage_config {
 	struct voltage_divider_dt_spec voltage;
-#ifdef CONFIG_PM_DEVICE
 	struct gpio_dt_spec gpio_power;
-#endif
 };
 
 struct voltage_data {
@@ -126,7 +124,6 @@ static int voltage_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-#ifdef CONFIG_PM_DEVICE
 	if (config->gpio_power.port != NULL) {
 		if (!gpio_is_ready_dt(&config->gpio_power)) {
 			LOG_ERR("Power GPIO is not ready");
@@ -138,7 +135,6 @@ static int voltage_init(const struct device *dev)
 			LOG_ERR("failed to initialize GPIO for reset");
 		}
 	}
-#endif
 
 	ret = adc_channel_setup_dt(&config->voltage.port);
 	if (ret != 0) {
@@ -158,18 +154,12 @@ static int voltage_init(const struct device *dev)
 	return 0;
 }
 
-#ifdef CONFIG_PM_DEVICE
-#define POWER_GPIOS(inst) .gpio_power = GPIO_DT_SPEC_INST_GET_OR(inst, power_gpios, {0}),
-#else
-#define POWER_GPIOS(inst)
-#endif
-
 #define VOLTAGE_INIT(inst)                                                                         \
 	static struct voltage_data voltage_##inst##_data;                                          \
                                                                                                    \
 	static const struct voltage_config voltage_##inst##_config = {                             \
 		.voltage = VOLTAGE_DIVIDER_DT_SPEC_GET(DT_DRV_INST(inst)),                         \
-		POWER_GPIOS(inst)                                                                  \
+		.gpio_power = GPIO_DT_SPEC_INST_GET_OR(inst, power_gpios, {0}),                    \
 	};                                                                                         \
                                                                                                    \
 	PM_DEVICE_DT_INST_DEFINE(inst, pm_action);                                                 \

--- a/dts/bindings/iio/afe/voltage-divider.yaml
+++ b/dts/bindings/iio/afe/voltage-divider.yaml
@@ -36,3 +36,12 @@ properties:
 
       If present the corresponding GPIO must be set to an active level
       to enable the divider input.
+
+  off-on-delay-us:
+    type: int
+    default: 0
+    description: |
+      Off to on delay time, in microseconds.
+
+      If non-zero the driver waits the configured delay after enabling
+      the power-gpios.


### PR DESCRIPTION
In many cases, voltage rise time is needed after enabling voltage divider power-gpios. So, add possibility to configure such delay per voltage-divider instance.
    
The delay is waited on device init when pm device runtime is not enabled, and only on pm_action function when it is enabled since it is possible to initialize the voltage divider as suspended then.

See also discussion at https://github.com/zephyrproject-rtos/zephyr/pull/70640#discussion_r1551142089