### PR TITLE
soc: st: stm32: stm32l4x: enable ART flash cache accelerator

### DIFF
--- a/soc/st/stm32/stm32l4x/soc.c
+++ b/soc/st/stm32/stm32l4x/soc.c
@@ -15,6 +15,7 @@
 #include <zephyr/logging/log.h>
 
 #include <cmsis_core.h>
+#include <stm32_ll_system.h>
 
 #define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
 LOG_MODULE_REGISTER(soc);
@@ -30,6 +31,11 @@ LOG_MODULE_REGISTER(soc);
  */
 static int stm32l4_init(void)
 {
+	/* Enable the ART Accelerator I-cache, D-cache and prefetch */
+	LL_FLASH_EnableInstCache();
+	LL_FLASH_EnableDataCache();
+	LL_FLASH_EnablePrefetch();
+
 	/* Update CMSIS SystemCoreClock variable (HCLK) */
 	/* At reset, system core clock is set to 4 MHz from MSI */
 	SystemCoreClock = 4000000;


### PR DESCRIPTION
Enable instruction cache, data cache and prefetching.

I am using an stm32l412 based board as an I²C target and noticed that there was quite a bit of clock stretching happening. Enabling the ART Accelerator improves the situation significantly, likely because the CPU is no longer stalling while fetching code/data from the flash.

I don't know why stm32l4x wasn't part of https://github.com/zephyrproject-rtos/zephyr/pull/36277. I looked at RM0394 and didn't see anything to indicate that ART Accelerator is unsupported on any of the STM32L4x models. The flash_stm32l4x.c driver flushes the data/instruction caches on erase, but this has been a no-op until now.