### PR TITLE
fs: ext2: Fix calculating fs_memory in ext2_format

### DIFF
--- a/subsys/fs/ext2/ext2_format.c
+++ b/subsys/fs/ext2/ext2_format.c
@@ -117,6 +117,8 @@ int ext2_format(struct ext2_data *fs, struct ext2_cfg *cfg)
 		return -ENOSPC;
 	}
 
+	/* Assume whole disk may be used minus CONFIG_EXT2_DISK_STARTING_SECTOR sectors. */
+	fs_memory -= CONFIG_EXT2_DISK_STARTING_SECTOR * fs->write_size;
 
 	uint32_t blocks_count = fs_memory / cfg->block_size;
 	uint32_t blocks_per_group = cfg->block_size * 8;

--- a/tests/subsys/fs/ext2/src/utils.c
+++ b/tests/subsys/fs/ext2/src/utils.c
@@ -72,5 +72,6 @@ size_t get_partition_size(uintptr_t id)
 
 	sectors_info(name, &sector_size, &sector_count);
 
-	return sector_size * sector_count;
+	/* Assume that partition occupies sectors from CONFIG_EXT2_DISK_STARTING_SECTOR to last. */
+	return sector_size * (sector_count - CONFIG_EXT2_DISK_STARTING_SECTOR);
 }


### PR DESCRIPTION
First sector starts at `CONFIG_EXT2_DISK_STARTING_SECTOR`. This commit fixes calculating free space, based on that value.