### PR TITLE
fs: ext2: Fix removing indirect blocks

### DIFF
--- a/subsys/fs/ext2/ext2_diskops.c
+++ b/subsys/fs/ext2/ext2_diskops.c
@@ -669,9 +669,11 @@ int64_t ext2_inode_remove_blocks(struct ext2_inode *inode, uint32_t first)
 
 	max_lvl = get_level_offsets(inode->i_fs, first, offsets);
 
-	if (all_zero(offsets, max_lvl)) {
-		/* We remove also the first block because all blocks referenced from it will be
-		 * deleted.
+	if (all_zero(&offsets[1], max_lvl)) {
+		/* The first block to remove is either:
+		 *  - one of the first 12 blocks in the indode
+		 *  - the first referenced block in the indirect block list;
+		 *    we remove also the indirect block
 		 */
 		start = offsets[0];
 	} else {


### PR DESCRIPTION
These changes fix removing indirect blocks (marking them as 0) in the inode structure. Previous version of the code was removing the top-level blocks only when the first removed block was one of the first 12 direct blocks. However, when the first removed block is the first block in the referenced block list, its parent (indirect block) should also be removed.

Not marking it as removed may result in removing the same block twice - which will cause the [assert fail](https://github.com/zephyrproject-rtos/zephyr/blob/main/subsys/fs/ext2/ext2_bitmap.c#L51). Please note it is an edge case which occurs for specific card capacities (for example for `0x20000` bytes). I added regression test to detect such situation in the future.


