### PR TITLE
RFC: drivers: can: change signature of `can_get_{min,max}_bitrate()`

### DIFF
--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -87,6 +87,10 @@ Drivers and Sensors
   * Deprecated the :c:func:`can_calc_prescaler` API function, as it allows for bitrate
     errors. Bitrate errors between nodes on the same network leads to them drifting apart after the
     start-of-frame (SOF) synchronization has taken place, leading to bus errors.
+  * Added :c:func:`can_get_bitrate_min` and :c:func:`can_get_bitrate_max` for retrieving the minimum
+    and maximum supported bitrate for a given CAN controller/CAN transceiver combination, reflecting
+    that retrieving the bitrate limits can no longer fail. Deprecated the existing
+    :c:func:`can_get_min_bitrate` and :c:func:`can_get_max_bitrate` API functions.
   * Extended support for automatic sample point location to also cover :c:func:`can_calc_timing` and
     :c:func:`can_calc_timing_data`.
   * Added optional ``min-bitrate`` devicetree property for CAN transceivers.

--- a/drivers/can/can_common.c
+++ b/drivers/can/can_common.c
@@ -351,22 +351,12 @@ int z_impl_can_set_timing(const struct device *dev,
 int z_impl_can_set_bitrate(const struct device *dev, uint32_t bitrate)
 {
 	struct can_timing timing = { 0 };
-	uint32_t min_bitrate;
-	uint32_t max_bitrate;
+	uint32_t min = can_get_bitrate_min(dev);
+	uint32_t max = can_get_bitrate_max(dev);
 	uint16_t sample_pnt;
 	int ret;
 
-	(void)can_get_min_bitrate(dev, &min_bitrate);
-
-	ret = can_get_max_bitrate(dev, &max_bitrate);
-	if (ret == -ENOSYS) {
-		/* Maximum bitrate unknown */
-		max_bitrate = 0;
-	} else if (ret < 0) {
-		return ret;
-	}
-
-	if ((bitrate < min_bitrate) || (((max_bitrate > 0) && (bitrate > max_bitrate)))) {
+	if ((bitrate < min) || (bitrate > max)) {
 		return -ENOTSUP;
 	}
 
@@ -407,22 +397,12 @@ int z_impl_can_set_timing_data(const struct device *dev,
 int z_impl_can_set_bitrate_data(const struct device *dev, uint32_t bitrate_data)
 {
 	struct can_timing timing_data = { 0 };
-	uint32_t min_bitrate;
-	uint32_t max_bitrate;
+	uint32_t min = can_get_bitrate_min(dev);
+	uint32_t max = can_get_bitrate_max(dev);
 	uint16_t sample_pnt;
 	int ret;
 
-	(void)can_get_min_bitrate(dev, &min_bitrate);
-
-	ret = can_get_max_bitrate(dev, &max_bitrate);
-	if (ret == -ENOSYS) {
-		/* Maximum bitrate unknown */
-		max_bitrate = 0;
-	} else if (ret < 0) {
-		return ret;
-	}
-
-	if ((bitrate_data < min_bitrate) || ((max_bitrate > 0) && (bitrate_data > max_bitrate))) {
+	if ((bitrate_data < min) || (bitrate_data > max)) {
 		return -ENOTSUP;
 	}
 

--- a/drivers/can/can_fake.c
+++ b/drivers/can/can_fake.c
@@ -146,16 +146,22 @@ static const struct can_driver_api fake_can_driver_api = {
 #endif /* CONFIG_CAN_FD_MODE */
 };
 
-#define FAKE_CAN_INIT(inst)						     \
-	static const struct fake_can_config fake_can_config_##inst = {	     \
-		.common = CAN_DT_DRIVER_CONFIG_INST_GET(inst, 0, 0),	     \
-	};								     \
-									     \
-	static struct fake_can_data fake_can_data_##inst;		     \
-									     \
-	CAN_DEVICE_DT_INST_DEFINE(inst, NULL, NULL, &fake_can_data_##inst,   \
-				  &fake_can_config_##inst, POST_KERNEL,	     \
-				  CONFIG_CAN_INIT_PRIORITY,                  \
+#ifdef CONFIG_CAN_FD_MODE
+#define FAKE_CAN_MAX_BITRATE 8000000
+#else /* CONFIG_CAN_FD_MODE */
+#define FAKE_CAN_MAX_BITRATE 1000000
+#endif /* !CONFIG_CAN_FD_MODE */
+
+#define FAKE_CAN_INIT(inst)						                \
+	static const struct fake_can_config fake_can_config_##inst = {	                \
+		.common = CAN_DT_DRIVER_CONFIG_INST_GET(inst, 0, FAKE_CAN_MAX_BITRATE), \
+	};								                \
+									                \
+	static struct fake_can_data fake_can_data_##inst;		                \
+									                \
+	CAN_DEVICE_DT_INST_DEFINE(inst, NULL, NULL, &fake_can_data_##inst,              \
+				  &fake_can_config_##inst, POST_KERNEL,	                \
+				  CONFIG_CAN_INIT_PRIORITY,                             \
 				  &fake_can_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(FAKE_CAN_INIT)

--- a/drivers/can/can_handlers.c
+++ b/drivers/can/can_handlers.c
@@ -45,25 +45,21 @@ static inline int z_vrfy_can_get_core_clock(const struct device *dev,
 }
 #include <syscalls/can_get_core_clock_mrsh.c>
 
-static inline int z_vrfy_can_get_min_bitrate(const struct device *dev,
-					     uint32_t *min_bitrate)
+static inline uint32_t z_vrfy_can_get_bitrate_min(const struct device *dev)
 {
 	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_CAN));
-	K_OOPS(K_SYSCALL_MEMORY_WRITE(min_bitrate, sizeof(*min_bitrate)));
 
-	return z_impl_can_get_min_bitrate(dev, min_bitrate);
+	return z_impl_can_get_bitrate_min(dev);
 }
-#include <syscalls/can_get_min_bitrate_mrsh.c>
+#include <syscalls/can_get_bitrate_min_mrsh.c>
 
-static inline int z_vrfy_can_get_max_bitrate(const struct device *dev,
-					     uint32_t *max_bitrate)
+static inline uint32_t z_vrfy_can_get_bitrate_max(const struct device *dev)
 {
 	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_CAN));
-	K_OOPS(K_SYSCALL_MEMORY_WRITE(max_bitrate, sizeof(*max_bitrate)));
 
-	return z_impl_can_get_max_bitrate(dev, max_bitrate);
+	return z_impl_can_get_bitrate_max(dev);
 }
-#include <syscalls/can_get_max_bitrate_mrsh.c>
+#include <syscalls/can_get_bitrate_max_mrsh.c>
 
 static inline const struct can_timing *z_vrfy_can_get_timing_min(const struct device *dev)
 {

--- a/drivers/can/can_loopback.c
+++ b/drivers/can/can_loopback.c
@@ -442,17 +442,23 @@ static int can_loopback_init(const struct device *dev)
 	return 0;
 }
 
-#define CAN_LOOPBACK_INIT(inst)							\
-	static const struct can_loopback_config can_loopback_config_##inst = {	\
-		.common = CAN_DT_DRIVER_CONFIG_INST_GET(inst, 0, 0),		\
-	};									\
-										\
-	static struct can_loopback_data can_loopback_data_##inst;		\
-										\
-	CAN_DEVICE_DT_INST_DEFINE(inst, can_loopback_init, NULL,		\
-				  &can_loopback_data_##inst,			\
-				  &can_loopback_config_##inst,			\
-				  POST_KERNEL, CONFIG_CAN_INIT_PRIORITY,	\
+#ifdef CONFIG_CAN_FD_MODE
+#define CAN_LOOPBACK_MAX_BITRATE 8000000
+#else /* CONFIG_CAN_FD_MODE */
+#define CAN_LOOPBACK_MAX_BITRATE 1000000
+#endif /* !CONFIG_CAN_FD_MODE */
+
+#define CAN_LOOPBACK_INIT(inst)									\
+	static const struct can_loopback_config can_loopback_config_##inst = {			\
+		.common = CAN_DT_DRIVER_CONFIG_INST_GET(inst, 0, CAN_LOOPBACK_MAX_BITRATE),	\
+	};											\
+												\
+	static struct can_loopback_data can_loopback_data_##inst;				\
+												\
+	CAN_DEVICE_DT_INST_DEFINE(inst, can_loopback_init, NULL,				\
+				  &can_loopback_data_##inst,					\
+				  &can_loopback_config_##inst,					\
+				  POST_KERNEL, CONFIG_CAN_INIT_PRIORITY,			\
 				  &can_loopback_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(CAN_LOOPBACK_INIT)

--- a/drivers/can/can_shell.c
+++ b/drivers/can/can_shell.c
@@ -280,9 +280,9 @@ static int cmd_can_show(const struct shell *sh, size_t argc, char **argv)
 	const struct can_timing *timing_max;
 	struct can_bus_err_cnt err_cnt;
 	enum can_state state;
-	uint32_t max_bitrate = 0;
-	int max_std_filters = 0;
-	int max_ext_filters = 0;
+	uint32_t bitrate_max;
+	int max_std_filters;
+	int max_ext_filters;
 	uint32_t core_clock;
 	can_mode_t cap;
 	int err;
@@ -298,11 +298,7 @@ static int cmd_can_show(const struct shell *sh, size_t argc, char **argv)
 		return err;
 	}
 
-	err = can_get_max_bitrate(dev, &max_bitrate);
-	if (err != 0 && err != -ENOSYS) {
-		shell_error(sh, "failed to get maximum bitrate (err %d)", err);
-		return err;
-	}
+	bitrate_max = can_get_bitrate_max(dev);
 
 	max_std_filters = can_get_max_filters(dev, false);
 	if (max_std_filters < 0 && max_std_filters != -ENOSYS) {
@@ -329,7 +325,7 @@ static int cmd_can_show(const struct shell *sh, size_t argc, char **argv)
 	}
 
 	shell_print(sh, "core clock:      %d Hz", core_clock);
-	shell_print(sh, "max bitrate:     %d bps", max_bitrate);
+	shell_print(sh, "max bitrate:     %d bps", bitrate_max);
 	shell_print(sh, "max std filters: %d", max_std_filters);
 	shell_print(sh, "max ext filters: %d", max_ext_filters);
 

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -836,18 +836,33 @@ static inline int z_impl_can_get_core_clock(const struct device *dev, uint32_t *
  * Get the minimum supported bitrate for the CAN controller/transceiver combination.
  *
  * @param dev Pointer to the device structure for the driver instance.
+ * @return Minimum supported bitrate in bits/s
+ */
+__syscall uint32_t can_get_bitrate_min(const struct device *dev);
+
+static inline uint32_t z_impl_can_get_bitrate_min(const struct device *dev)
+{
+	const struct can_driver_config *common = (const struct can_driver_config *)dev->config;
+
+	return common->min_bitrate;
+}
+
+/**
+ * @brief Get minimum supported bitrate
+ *
+ * Get the minimum supported bitrate for the CAN controller/transceiver combination.
+ *
+ * @deprecated Use @a can_get_bitrate_min() instead.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
  * @param[out] min_bitrate Minimum supported bitrate in bits/s
  *
  * @retval -EIO General input/output error.
  * @retval -ENOSYS If this function is not implemented by the driver.
  */
-__syscall int can_get_min_bitrate(const struct device *dev, uint32_t *min_bitrate);
-
-static inline int z_impl_can_get_min_bitrate(const struct device *dev, uint32_t *min_bitrate)
+__deprecated static inline int can_get_min_bitrate(const struct device *dev, uint32_t *min_bitrate)
 {
-	const struct can_driver_config *common = (const struct can_driver_config *)dev->config;
-
-	*min_bitrate = common->min_bitrate;
+	*min_bitrate = can_get_bitrate_min(dev);
 
 	return 0;
 }
@@ -858,23 +873,34 @@ static inline int z_impl_can_get_min_bitrate(const struct device *dev, uint32_t 
  * Get the maximum supported bitrate for the CAN controller/transceiver combination.
  *
  * @param dev Pointer to the device structure for the driver instance.
+ * @return Maximum supported bitrate in bits/s
+ */
+__syscall uint32_t can_get_bitrate_max(const struct device *dev);
+
+static inline uint32_t z_impl_can_get_bitrate_max(const struct device *dev)
+{
+	const struct can_driver_config *common = (const struct can_driver_config *)dev->config;
+
+	return common->max_bitrate;
+}
+
+/**
+ * @brief Get maximum supported bitrate
+ *
+ * Get the maximum supported bitrate for the CAN controller/transceiver combination.
+ *
+ * @deprecated Use @a can_get_bitrate_max() instead.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
  * @param[out] max_bitrate Maximum supported bitrate in bits/s
  *
  * @retval 0 If successful.
  * @retval -EIO General input/output error.
  * @retval -ENOSYS If this function is not implemented by the driver.
  */
-__syscall int can_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate);
-
-static inline int z_impl_can_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate)
+__deprecated static inline int can_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate)
 {
-	const struct can_driver_config *common = (const struct can_driver_config *)dev->config;
-
-	if (common->max_bitrate == 0U) {
-		return -ENOSYS;
-	}
-
-	*max_bitrate = common->max_bitrate;
+	*max_bitrate = can_get_bitrate_max(dev);
 
 	return 0;
 }

--- a/tests/drivers/can/api/src/canfd.c
+++ b/tests/drivers/can/api/src/canfd.c
@@ -397,22 +397,14 @@ ZTEST_USER(canfd, test_set_timing_data_min)
  */
 ZTEST_USER(canfd, test_set_bitrate_too_high)
 {
-	uint32_t max = 8000000U;
-	int expected = -EINVAL;
+	uint32_t max = can_get_bitrate_max(can_dev);
 	int err;
-
-	err = can_get_max_bitrate(can_dev, &max);
-	if (err != -ENOSYS) {
-		zassert_equal(err, 0, "failed to get max bitrate (err %d)", err);
-		zassert_not_equal(max, 0, "max bitrate is 0");
-		expected = -ENOTSUP;
-	}
 
 	err = can_stop(can_dev);
 	zassert_equal(err, 0, "failed to stop CAN controller (err %d)", err);
 
 	err = can_set_bitrate_data(can_dev, max + 1);
-	zassert_equal(err, expected, "too high data phase bitrate accepted");
+	zassert_equal(err, -ENOTSUP, "too high data phase bitrate accepted");
 
 	err = can_start(can_dev);
 	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);

--- a/tests/drivers/can/api/src/classic.c
+++ b/tests/drivers/can/api/src/classic.c
@@ -480,19 +480,8 @@ ZTEST(can_classic, test_set_state_change_callback)
  */
 ZTEST_USER(can_classic, test_bitrate_limits)
 {
-	uint32_t min = 0U;
-	uint32_t max = 0U;
-	int err;
-
-	err = can_get_min_bitrate(can_dev, &min);
-	zassert_equal(err, 0, "failed to get min bitrate (err %d)", err);
-
-	err = can_get_max_bitrate(can_dev, &max);
-	if (err == -ENOSYS) {
-		ztest_test_skip();
-	}
-
-	zassert_equal(err, 0, "failed to get max bitrate (err %d)", err);
+	uint32_t min = can_get_bitrate_min(can_dev);
+	uint32_t max = can_get_bitrate_max(can_dev);
 
 	zassert_true(min <= max, "min bitrate must be lower or equal to max bitrate");
 }
@@ -502,22 +491,14 @@ ZTEST_USER(can_classic, test_bitrate_limits)
  */
 ZTEST_USER(can_classic, test_set_bitrate_too_high)
 {
-	uint32_t max = 1000000U;
-	int expected = -EINVAL;
+	uint32_t max = can_get_bitrate_max(can_dev);
 	int err;
-
-	err = can_get_max_bitrate(can_dev, &max);
-	if (err != -ENOSYS) {
-		zassert_equal(err, 0, "failed to get max bitrate (err %d)", err);
-		zassert_not_equal(max, 0, "max bitrate is 0");
-		expected = -ENOTSUP;
-	}
 
 	err = can_stop(can_dev);
 	zassert_equal(err, 0, "failed to stop CAN controller (err %d)", err);
 
 	err = can_set_bitrate(can_dev, max + 1);
-	zassert_equal(err, expected, "too high bitrate accepted");
+	zassert_equal(err, -ENOTSUP, "too high bitrate accepted");
 
 	err = can_start(can_dev);
 	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);


### PR DESCRIPTION
Add new API functions can_get_bitrate_min() and can_get_bitrate_max() which directly return the minimum/maximum supported bitrate. Deprecate the existing `can_get_min_bitrate()` and `can_get_max_bitrate()`.

Since the minimum/maximum supported bitrates are now stored in the common CAN controller driver configuration struct,  retrieving these can no longer fail.

RFC: #71211
