### PR TITLE
net: connection: Log an error when running out of contexts

### DIFF
--- a/subsys/net/ip/connection.c
+++ b/subsys/net/ip/connection.c
@@ -352,6 +352,8 @@ int net_conn_register(uint16_t proto, uint8_t family,
 
 	conn = conn_get_unused();
 	if (!conn) {
+		NET_ERR("Not enough connection contexts. "
+			"Consider increasing CONFIG_NET_MAX_CONN.");
 		return -ENOENT;
 	}
 


### PR DESCRIPTION
Running out of connection contexts is most likely due to app misconfiguration, therefore it's useful to get an explicit information that context allocation failed.