### PR TITLE
Fix typo in example code

### DIFF
--- a/dts/bindings/input/espressif,esp32-touch-sensor.yaml
+++ b/dts/bindings/input/espressif,esp32-touch-sensor.yaml
@@ -28,8 +28,8 @@ description: |
          filter-smooth-level = <ESP32_TOUCH_FILTER_SMOOTH_MODE_IIR_2>;
 
          touch_sensor_0 {
-                 channel_num = <1>;
-                 channel_sens = <20>;
+                 channel-num = <1>;
+                 channel-sens = <20>;
                  zephyr,code = <INPUT_KEY_0>;
          };
   };


### PR DESCRIPTION
dts: bindings: input: espressif: esp32-touch-sensor.yaml: fix typo

The documentation example code contains incorrect characters. 
This PR fixes this.

Fixes #71197

Signed-off-by: Owen O'Hehir <oo.hehir@gmail.com>