### PR TITLE
[Backport v3.6-branch] pm: runtime: fix race when waiting for suspended event

### DIFF
--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -242,9 +242,10 @@ int pm_device_runtime_get(const struct device *dev)
 		 * nothing else we can do but wait until it finishes.
 		 */
 		while (pm->base.state == PM_DEVICE_STATE_SUSPENDING) {
+			k_event_clear(&pm->event, EVENT_MASK);
 			k_sem_give(&pm->lock);
 
-			k_event_wait(&pm->event, EVENT_MASK, true, K_FOREVER);
+			k_event_wait(&pm->event, EVENT_MASK, false, K_FOREVER);
 
 			(void)k_sem_take(&pm->lock, K_FOREVER);
 		}
@@ -520,9 +521,10 @@ int pm_device_runtime_disable(const struct device *dev)
 
 		/* wait until possible async suspend is completed */
 		while (pm->base.state == PM_DEVICE_STATE_SUSPENDING) {
+			k_event_clear(&pm->event, EVENT_MASK);
 			k_sem_give(&pm->lock);
 
-			k_event_wait(&pm->event, EVENT_MASK, true, K_FOREVER);
+			k_event_wait(&pm->event, EVENT_MASK, false, K_FOREVER);
 
 			(void)k_sem_take(&pm->lock, K_FOREVER);
 		}


### PR DESCRIPTION
Backport https://github.com/zephyrproject-rtos/zephyr/commit/d83c63eccebdfcc1dae856102ebb125110d3c010 from https://github.com/zephyrproject-rtos/zephyr/pull/70798

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/71217