### PR TITLE
drivers/sensor: use sensor APIs to convert to units

### DIFF
--- a/drivers/sensor/st/iis2iclx/iis2iclx.c
+++ b/drivers/sensor/st/iis2iclx/iis2iclx.c
@@ -281,10 +281,8 @@ static inline void iis2iclx_accel_convert(struct sensor_value *val, int raw_val,
 
 	/* Sensitivity is exposed in ug/LSB */
 	/* Convert to m/s^2 */
-	dval = (int64_t)(raw_val) * sensitivity * SENSOR_G_DOUBLE;
-	val->val1 = (int32_t)(dval / 1000000);
-	val->val2 = (int32_t)(dval % 1000000);
-
+	dval = (int64_t)(raw_val) * sensitivity;
+	sensor_ug_to_ms2(dval, val);
 }
 
 static inline int iis2iclx_accel_get_channel(enum sensor_channel chan,
@@ -336,7 +334,7 @@ static inline void iis2iclx_magn_convert(struct sensor_value *val, int raw_val,
 {
 	double dval;
 
-	/* Sensitivity is exposed in mgauss/LSB */
+	/* Sensitivity is exposed in ugauss/LSB */
 	dval = (double)(raw_val * sensitivity);
 	val->val1 = (int32_t)dval / 1000000;
 	val->val2 = (int32_t)dval % 1000000;

--- a/drivers/sensor/st/iis2iclx/iis2iclx.h
+++ b/drivers/sensor/st/iis2iclx/iis2iclx.h
@@ -32,10 +32,6 @@
 /* Accel sensor sensitivity grain is 15 ug/LSB */
 #define GAIN_UNIT_XL				(15LL)
 
-#define SENSOR_PI_DOUBLE			(SENSOR_PI / 1000000.0)
-#define SENSOR_DEG2RAD_DOUBLE			(SENSOR_PI_DOUBLE / 180)
-#define SENSOR_G_DOUBLE				(SENSOR_G / 1000000.0)
-
 struct iis2iclx_config {
 	stmdev_ctx_t ctx;
 	union {

--- a/drivers/sensor/st/ism330dhcx/ism330dhcx.c
+++ b/drivers/sensor/st/ism330dhcx/ism330dhcx.c
@@ -382,9 +382,8 @@ static inline void ism330dhcx_accel_convert(struct sensor_value *val, int raw_va
 
 	/* Sensitivity is exposed in ug/LSB */
 	/* Convert to m/s^2 */
-	dval = (int64_t)(raw_val) * sensitivity * SENSOR_G_DOUBLE;
-	val->val1 = (int32_t)(dval / 1000000);
-	val->val2 = (int32_t)(dval % 1000000);
+	dval = (int64_t)(raw_val) * sensitivity;
+	sensor_ug_to_ms2(dval, val);
 
 }
 
@@ -430,10 +429,9 @@ static inline void ism330dhcx_gyro_convert(struct sensor_value *val, int raw_val
 	int64_t dval;
 
 	/* Sensitivity is exposed in udps/LSB */
-	/* Convert to rad/s */
-	dval = (int64_t)(raw_val) * sensitivity * SENSOR_DEG2RAD_DOUBLE;
-	val->val1 = (int32_t)(dval / 1000000);
-	val->val2 = (int32_t)(dval % 1000000);
+	/* So, calculate value in 10 udps unit and then to rad/s */
+	dval = (int64_t)(raw_val) * sensitivity / 10;
+	sensor_10udegrees_to_rad(dval, val);
 }
 
 static inline int ism330dhcx_gyro_get_channel(const struct device *dev, enum sensor_channel chan,
@@ -490,7 +488,7 @@ static inline void ism330dhcx_magn_convert(struct sensor_value *val, int raw_val
 {
 	double dval;
 
-	/* Sensitivity is exposed in mgauss/LSB */
+	/* Sensitivity is exposed in ugauss/LSB */
 	dval = (double)(raw_val * sensitivity);
 	val->val1 = (int32_t)dval / 1000000;
 	val->val2 = (int32_t)dval % 1000000;

--- a/drivers/sensor/st/ism330dhcx/ism330dhcx.h
+++ b/drivers/sensor/st/ism330dhcx/ism330dhcx.h
@@ -30,10 +30,6 @@
 /* Gyro sensor sensitivity grain is 4.375 udps/LSB */
 #define GAIN_UNIT_G				(4375LL)
 
-#define SENSOR_PI_DOUBLE			(SENSOR_PI / 1000000.0)
-#define SENSOR_DEG2RAD_DOUBLE			(SENSOR_PI_DOUBLE / 180)
-#define SENSOR_G_DOUBLE				(SENSOR_G / 1000000.0)
-
 struct ism330dhcx_config {
 	int (*bus_init)(const struct device *dev);
 	uint8_t accel_odr;

--- a/drivers/sensor/st/lsm6dso/lsm6dso.c
+++ b/drivers/sensor/st/lsm6dso/lsm6dso.c
@@ -402,10 +402,8 @@ static inline void lsm6dso_accel_convert(struct sensor_value *val, int raw_val,
 
 	/* Sensitivity is exposed in ug/LSB */
 	/* Convert to m/s^2 */
-	dval = (int64_t)(raw_val) * sensitivity * SENSOR_G_DOUBLE;
-	val->val1 = (int32_t)(dval / 1000000);
-	val->val2 = (int32_t)(dval % 1000000);
-
+	dval = (int64_t)(raw_val) * sensitivity;
+	sensor_ug_to_ms2(dval, val);
 }
 
 static inline int lsm6dso_accel_get_channel(enum sensor_channel chan,
@@ -450,10 +448,9 @@ static inline void lsm6dso_gyro_convert(struct sensor_value *val, int raw_val,
 	int64_t dval;
 
 	/* Sensitivity is exposed in udps/LSB */
-	/* Convert to rad/s */
-	dval = (int64_t)(raw_val) * sensitivity * SENSOR_DEG2RAD_DOUBLE;
-	val->val1 = (int32_t)(dval / 1000000);
-	val->val2 = (int32_t)(dval % 1000000);
+	/* So, calculate value in 10 udps unit and then to rad/s */
+	dval = (int64_t)(raw_val) * sensitivity / 10;
+	sensor_10udegrees_to_rad(dval, val);
 }
 
 static inline int lsm6dso_gyro_get_channel(enum sensor_channel chan,
@@ -508,7 +505,7 @@ static inline void lsm6dso_magn_convert(struct sensor_value *val, int raw_val,
 {
 	double dval;
 
-	/* Sensitivity is exposed in mgauss/LSB */
+	/* Sensitivity is exposed in ugauss/LSB */
 	dval = (double)(raw_val * sensitivity);
 	val->val1 = (int32_t)dval / 1000000;
 	val->val2 = (int32_t)dval % 1000000;

--- a/drivers/sensor/st/lsm6dso/lsm6dso.h
+++ b/drivers/sensor/st/lsm6dso/lsm6dso.h
@@ -36,10 +36,6 @@
 /* Gyro sensor sensitivity grain is 4.375 udps/LSB */
 #define GAIN_UNIT_G				(4375LL)
 
-#define SENSOR_PI_DOUBLE			(SENSOR_PI / 1000000.0)
-#define SENSOR_DEG2RAD_DOUBLE			(SENSOR_PI_DOUBLE / 180)
-#define SENSOR_G_DOUBLE				(SENSOR_G / 1000000.0)
-
 struct lsm6dso_config {
 	stmdev_ctx_t ctx;
 	union {

--- a/drivers/sensor/st/lsm6dso16is/lsm6dso16is.c
+++ b/drivers/sensor/st/lsm6dso16is/lsm6dso16is.c
@@ -426,9 +426,8 @@ static inline void lsm6dso16is_accel_convert(struct sensor_value *val, int raw_v
 
 	/* Sensitivity is exposed in ug/LSB */
 	/* Convert to m/s^2 */
-	dval = (int64_t)(raw_val) * sensitivity * SENSOR_G_DOUBLE;
-	val->val1 = (int32_t)(dval / 1000000);
-	val->val2 = (int32_t)(dval % 1000000);
+	dval = (int64_t)(raw_val) * sensitivity;
+	sensor_ug_to_ms2(dval, val);
 
 }
 
@@ -474,10 +473,9 @@ static inline void lsm6dso16is_gyro_convert(struct sensor_value *val, int raw_va
 	int64_t dval;
 
 	/* Sensitivity is exposed in udps/LSB */
-	/* Convert to rad/s */
-	dval = (int64_t)(raw_val) * sensitivity * SENSOR_DEG2RAD_DOUBLE;
-	val->val1 = (int32_t)(dval / 1000000);
-	val->val2 = (int32_t)(dval % 1000000);
+	/* So, calculate value in 10 udps unit and then to rad/s */
+	dval = (int64_t)(raw_val) * sensitivity / 10;
+	sensor_10udegrees_to_rad(dval, val);
 }
 
 static inline int lsm6dso16is_gyro_get_channel(enum sensor_channel chan,
@@ -538,7 +536,7 @@ static inline void lsm6dso16is_magn_convert(struct sensor_value *val, int raw_va
 {
 	double dval;
 
-	/* Sensitivity is exposed in mgauss/LSB */
+	/* Sensitivity is exposed in ugauss/LSB */
 	dval = (double)(raw_val * sensitivity);
 	val->val1 = (int32_t)dval / 1000000;
 	val->val2 = (int32_t)dval % 1000000;

--- a/drivers/sensor/st/lsm6dso16is/lsm6dso16is.h
+++ b/drivers/sensor/st/lsm6dso16is/lsm6dso16is.h
@@ -35,10 +35,6 @@
 /* Gyro sensor sensitivity grain is 4.375 udps/LSB */
 #define GAIN_UNIT_G				(4375LL)
 
-#define SENSOR_PI_DOUBLE			(SENSOR_PI / 1000000.0)
-#define SENSOR_DEG2RAD_DOUBLE			(SENSOR_PI_DOUBLE / 180)
-#define SENSOR_G_DOUBLE				(SENSOR_G / 1000000.0)
-
 struct lsm6dso16is_config {
 	stmdev_ctx_t ctx;
 	union {

--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.c
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.c
@@ -473,10 +473,8 @@ static inline void lsm6dsv16x_accel_convert(struct sensor_value *val, int raw_va
 
 	/* Sensitivity is exposed in ug/LSB */
 	/* Convert to m/s^2 */
-	dval = (int64_t)(raw_val) * sensitivity * SENSOR_G_DOUBLE;
-	val->val1 = (int32_t)(dval / 1000000);
-	val->val2 = (int32_t)(dval % 1000000);
-
+	dval = (int64_t)(raw_val) * sensitivity;
+	sensor_ug_to_ms2(dval, val);
 }
 
 static inline int lsm6dsv16x_accel_get_channel(enum sensor_channel chan,
@@ -521,10 +519,9 @@ static inline void lsm6dsv16x_gyro_convert(struct sensor_value *val, int raw_val
 	int64_t dval;
 
 	/* Sensitivity is exposed in udps/LSB */
-	/* Convert to rad/s */
-	dval = (int64_t)(raw_val) * sensitivity * SENSOR_DEG2RAD_DOUBLE;
-	val->val1 = (int32_t)(dval / 1000000);
-	val->val2 = (int32_t)(dval % 1000000);
+	/* So, calculate value in 10 udps unit and then to rad/s */
+	dval = (int64_t)(raw_val) * sensitivity / 10;
+	sensor_10udegrees_to_rad(dval, val);
 }
 
 static inline int lsm6dsv16x_gyro_get_channel(enum sensor_channel chan,
@@ -585,7 +582,7 @@ static inline void lsm6dsv16x_magn_convert(struct sensor_value *val, int raw_val
 {
 	double dval;
 
-	/* Sensitivity is exposed in mgauss/LSB */
+	/* Sensitivity is exposed in ugauss/LSB */
 	dval = (double)(raw_val * sensitivity);
 	val->val1 = (int32_t)dval / 1000000;
 	val->val2 = (int32_t)dval % 1000000;

--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.h
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.h
@@ -35,10 +35,6 @@
 /* Gyro sensor sensitivity grain is 4.375 udps/LSB */
 #define GAIN_UNIT_G				(4375LL)
 
-#define SENSOR_PI_DOUBLE			(SENSOR_PI / 1000000.0)
-#define SENSOR_DEG2RAD_DOUBLE			(SENSOR_PI_DOUBLE / 180)
-#define SENSOR_G_DOUBLE				(SENSOR_G / 1000000.0)
-
 struct lsm6dsv16x_config {
 	stmdev_ctx_t ctx;
 	union {


### PR DESCRIPTION
Make use of sensor_ug_to_ms2() and sensor_10udegrees_to_rad() APIs to convert from raw values into proper units (i.e. m/s^2 for accel and rad/s for gyro).

TESTED on x_nucleo_iks4a1/x_nucleo_iks02a1/x_nucleo_iks01a3 shields.