### PR TITLE
drivers: sensor: ite_cvmp_it8xxx2: Move init priority into if check

### DIFF
--- a/drivers/sensor/ite/ite_vcmp_it8xxx2/Kconfig
+++ b/drivers/sensor/ite/ite_vcmp_it8xxx2/Kconfig
@@ -13,13 +13,13 @@ config VCMP_IT8XXX2
 	  it8xxx2 supports six 10-bit resolution voltage comparator
 	  channels, and the input of each comparator comes from ADC pin.
 
+if VCMP_IT8XXX2
+
 config VCMP_IT8XXX2_INIT_PRIORITY
 	int "ITE it8xxx2 voltage comparator device instance init priority"
 	default SENSOR_INIT_PRIORITY
 	help
 	  This option sets ITE voltage comparator device instance init priority.
-
-if VCMP_IT8XXX2
 
 config VCMP_IT8XXX2_WORKQUEUE
 	bool "ITE it8xxx2 voltage comparator threshold detection uses internal work queue"


### PR DESCRIPTION
Moves a Kconfig that appears everywhere in the wrong place so that it is enclosed if if statment check, so it only shows for device that have the driver enabled