### PR TITLE
drivers: wifi: esp_at: do not connect socket on bind(INADDR_ANY)

### DIFF
--- a/drivers/wifi/esp_at/esp_offload.c
+++ b/drivers/wifi/esp_at/esp_offload.c
@@ -110,7 +110,13 @@ static int esp_bind(struct net_context *context, const struct sockaddr *addr,
 	}
 
 	if (IS_ENABLED(CONFIG_NET_IPV4) && addr->sa_family == AF_INET) {
+		struct sockaddr_in *addr4 = (struct sockaddr_in *)addr;
+
 		LOG_DBG("link %d", sock->link_id);
+
+		if (addr4->sin_addr.s_addr == INADDR_ANY) {
+			return 0;
+		}
 
 		if (esp_socket_connected(sock)) {
 			return -EISCONN;


### PR DESCRIPTION
All connect() syscalls result in `EISCONN` error, since underlying
`_sock_connect()` is attempted to be called twice. Once from `net_context.c`'s
`bind_default()` (with `INADDR_ANY`) as part of `esp_bind()` and second time as
part of `esp_connect()`.

Do not call `_sock_connect()` from `esp_bind(INADDR_ANY)`, which happens as
part of `connect()`.

Fixes: dbf3d6e9110a ("drivers: esp_at: implement bind() and recvfrom() for
  UDP sockets")
Fixes: #69530