### PR TITLE
tests/stream_flash: Replace one-line config overlays with extra_configs

### DIFF
--- a/tests/subsys/storage/stream/stream_flash/mpu_allow_flash_write.overlay
+++ b/tests/subsys/storage/stream/stream_flash/mpu_allow_flash_write.overlay
@@ -1,7 +1,0 @@
-#
-# Copyright (c) 2020 Nordic Semiconductor ASA
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-
-CONFIG_MPU_ALLOW_FLASH_WRITE=y

--- a/tests/subsys/storage/stream/stream_flash/no_erase.overlay
+++ b/tests/subsys/storage/stream/stream_flash/no_erase.overlay
@@ -1,7 +1,0 @@
-#
-# Copyright (c) 2020 Nordic Semiconductor ASA
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-
-CONFIG_STREAM_FLASH_ERASE=n

--- a/tests/subsys/storage/stream/stream_flash/testcase.yaml
+++ b/tests/subsys/storage/stream/stream_flash/testcase.yaml
@@ -13,10 +13,12 @@ tests:
     extra_args: DTC_OVERLAY_FILE=unaligned_flush.overlay
     tags: stream_flash
   storage.stream_flash.no_erase:
-    extra_args: OVERLAY_CONFIG=no_erase.overlay
+    extra_configs:
+      - CONFIG_STREAM_FLASH_ERASE=n
     tags: stream_flash
   storage.stream_flash.mpu_allow_flash_write:
-    extra_args: OVERLAY_CONFIG=mpu_allow_flash_write.overlay
+    extra_configs:
+      - CONFIG_MPU_ALLOW_FLASH_WRITE=y
     platform_allow:
       - nrf52840dk/nrf52840
     integration_platforms:


### PR DESCRIPTION
The commit removes one-line overlay files, when copyrights excluded, with direct Kconfig options selection inside testcase.yaml. The overlays have been removed.