### PR TITLE
drivers: espi: npcx: support multi-byte for dp80

### DIFF
--- a/drivers/espi/Kconfig.npcx
+++ b/drivers/espi/Kconfig.npcx
@@ -45,7 +45,7 @@ config ESPI_NPCX_BYPASS_CH_ENABLE_FATAL_ERROR
 
 config ESPI_NPCX_PERIPHERAL_DEBUG_PORT_80_MULTI_BYTE
 	bool "Host can write 1/2/4 bytes of Port80 data in a eSPI transaction"
-	depends on SOC_SERIES_NPCX9 && ESPI_PERIPHERAL_DEBUG_PORT_80
+	depends on (SOC_SERIES_NPCX9 || SOC_SERIES_NPCX4) && ESPI_PERIPHERAL_DEBUG_PORT_80
 	help
 	  EC can accept 1/2/4 bytes of Port 80 data written from the Host in an
 	  eSPI transaction.


### PR DESCRIPTION
This CL adds multi-byte support for debug port 80 on npcx4.