### PR TITLE
twister: pytest: use runner_params from hardware map YAML file

### DIFF
--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
@@ -66,6 +66,8 @@ class HardwareAdapter(DeviceAdapter):
         extra_args: list[str] = []
         runner = self.device_config.runner
         base_args.extend(['--runner', runner])
+        for param in self.device_config.runner_params:
+            extra_args.append(param)
         if board_id := self.device_config.id:
             if runner == 'pyocd':
                 extra_args.append('--board-id')

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/plugin.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/plugin.py
@@ -68,6 +68,11 @@ def pytest_addoption(parser: pytest.Parser):
         help='Use the specified west runner (pyocd, nrfjprog, etc.).'
     )
     twister_harness_group.addoption(
+        '--runner-params',
+        action='append',
+        help='Use the specified west runner params.'
+    )
+    twister_harness_group.addoption(
         '--device-id',
         help='ID of connected hardware device (for example 000682459367).'
     )

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/twister_harness_config.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/twister_harness_config.py
@@ -22,6 +22,7 @@ class DeviceConfig:
     serial: str = ''
     baud: int = 115200
     runner: str = ''
+    runner_params: list[str] = field(default_factory=list, repr=False)
     id: str = ''
     product: str = ''
     serial_pty: str = ''
@@ -46,6 +47,9 @@ class TwisterHarnessConfig:
         west_flash_extra_args: list[str] = []
         if config.option.west_flash_extra_args:
             west_flash_extra_args = [w.strip() for w in config.option.west_flash_extra_args.split(',')]
+        runner_params: list[str] = []
+        if config.option.runner_params:
+            runner_params = [w.strip() for w in config.option.runner_params]
         device_from_cli = DeviceConfig(
             type=config.option.device_type,
             build_dir=_cast_to_path(config.option.build_dir),
@@ -54,6 +58,7 @@ class TwisterHarnessConfig:
             serial=config.option.device_serial,
             baud=config.option.device_serial_baud,
             runner=config.option.runner,
+            runner_params=runner_params,
             id=config.option.device_id,
             product=config.option.device_product,
             serial_pty=config.option.device_serial_pty,

--- a/scripts/pylib/pytest-twister-harness/tests/device/hardware_adapter_test.py
+++ b/scripts/pylib/pytest-twister-harness/tests/device/hardware_adapter_test.py
@@ -129,6 +129,43 @@ def test_if_get_command_returns_proper_string_8(patched_which, device: HardwareA
 
 
 @mock.patch('shutil.which', return_value='west')
+def test_if_get_command_returns_proper_string_with_runner_params_1(patched_which, device: HardwareAdapter) -> None:
+    device.device_config.build_dir = Path('build')
+    device.device_config.runner_params = ['--runner-param1', 'runner-param2']
+    device.generate_command()
+    assert isinstance(device.command, list)
+    assert device.command == [
+        'west', 'flash', '--skip-rebuild', '--build-dir', 'build',
+        '--runner', 'runner', '--', '--runner-param1', 'runner-param2'
+    ]
+
+
+@mock.patch('shutil.which', return_value='west')
+def test_if_get_command_returns_proper_string_with_runner_params_2(patched_which, device: HardwareAdapter) -> None:
+    device.device_config.build_dir = Path('build')
+    device.device_config.runner = 'openocd'
+    device.device_config.runner_params = [
+        '--cmd-pre-init', 'adapter serial FT1LRSRD',
+        '--cmd-pre-init', 'source [find interface/ftdi/jtag-lock-pick_tiny_2.cfg]',
+        '--cmd-pre-init', 'transport select swd',
+        '--cmd-pre-init', 'source [find target/nrf52.cfg]',
+        '--cmd-pre-init', 'adapter speed 10000',
+    ]
+    device.device_config.product = 'JTAG-lock-pick Tiny 2'
+    device.generate_command()
+    assert isinstance(device.command, list)
+    assert device.command == [
+        'west', 'flash', '--skip-rebuild', '--build-dir', 'build',
+        '--runner', 'openocd', '--',
+        '--cmd-pre-init', 'adapter serial FT1LRSRD',
+        '--cmd-pre-init', 'source [find interface/ftdi/jtag-lock-pick_tiny_2.cfg]',
+        '--cmd-pre-init', 'transport select swd',
+        '--cmd-pre-init', 'source [find target/nrf52.cfg]',
+        '--cmd-pre-init', 'adapter speed 10000',
+    ]
+
+
+@mock.patch('shutil.which', return_value='west')
 def test_if_get_command_returns_proper_string_with_west_flash_extra_args(
     patched_which, device: HardwareAdapter
 ) -> None:

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -382,6 +382,9 @@ class Pytest(Harness):
         if runner := hardware.runner or options.west_runner:
             command.append(f'--runner={runner}')
 
+        for param in hardware.runner_params:
+            command.append(f'--runner-params={param}')
+
         if options.west_flash and options.west_flash != []:
             command.append(f'--west-flash-extra-args={options.west_flash}')
 

--- a/scripts/tests/twister/test_harness.py
+++ b/scripts/tests/twister/test_harness.py
@@ -316,6 +316,7 @@ def test_pytest__generate_parameters_for_hardware(tmp_path, pty_value, hardware_
     hardware.serial = 'serial'
     hardware.baud = 115200
     hardware.runner = "runner"
+    hardware.runner_params = ["--runner-param1", "runner-param2"]
 
     options = handler.options
     options.west_flash = "args"
@@ -349,6 +350,8 @@ def test_pytest__generate_parameters_for_hardware(tmp_path, pty_value, hardware_
             assert '--device-serial=serial' in command
             assert '--device-serial-baud=115200' in command
         assert '--runner=runner' in command
+        assert '--runner-params=--runner-param1' in command
+        assert '--runner-params=runner-param2' in command
         assert '--west-flash-extra-args=args' in command
         assert '--device-id=123' in command
         assert '--device-product=product' in command


### PR DESCRIPTION
Use `runner_params` specified in hardware map YAML file. This allows to
configure custom params (like openocd's adapter configuration for
FT232-based probe) when used with pytest harness.