### PR TITLE
Few fixes in uart_async_rx and uart_async_to_irq 

### DIFF
--- a/drivers/serial/uart_async_rx.c
+++ b/drivers/serial/uart_async_rx.c
@@ -126,6 +126,9 @@ void uart_async_rx_reset(struct uart_async_rx *rx_data)
 {
 	rx_data->free_buf_cnt = rx_data->config->buf_cnt;
 	rx_data->rd_idx = 0;
+	rx_data->rd_buf_idx = 0;
+	rx_data->drv_buf_idx = 0;
+	rx_data->pending_bytes = 0;
 	for (uint8_t i = 0; i < rx_data->config->buf_cnt; i++) {
 		buf_reset(get_buf(rx_data, i));
 	}

--- a/drivers/serial/uart_async_to_irq.c
+++ b/drivers/serial/uart_async_to_irq.c
@@ -107,6 +107,10 @@ static void on_rx_dis(const struct device *dev, struct uart_async_to_irq_data *d
 	if (data->flags & A2I_RX_ENABLE) {
 		int err;
 
+		if (data->rx.async_rx.pending_bytes == 0) {
+			uart_async_rx_reset(&data->rx.async_rx);
+		}
+
 		err = try_rx_enable(dev, data);
 		if (err == 0) {
 			data->rx.pending_buf_req = 0;
@@ -331,7 +335,6 @@ int uart_async_to_irq_rx_enable(const struct device *dev)
 		return err;
 	}
 
-	uart_async_rx_reset(&data->rx.async_rx);
 
 	err = try_rx_enable(dev, data);
 	if (err == 0) {
@@ -354,6 +357,8 @@ int uart_async_to_irq_rx_disable(const struct device *dev)
 		}
 		k_sem_take(&data->rx.sem, K_FOREVER);
 	}
+
+	uart_async_rx_reset(&data->rx.async_rx);
 
 	return 0;
 }


### PR DESCRIPTION
Add missing cleaning of internal data to `uart_async_rx_reset()`.
Move resetting (call to `uart_async_rx_reset()`) from RX enabling function to RX disabling function and adding state resetting to RX disabled event if there is no pending bytes.