### PR TITLE
Add support for nrf54l15pdk and nrf54h20dk in uart_pm test

### DIFF
--- a/tests/drivers/uart/uart_pm/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/uart/uart_pm/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	uart135_default_alt: uart135_default_alt {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 0, 6)>,
+				<NRF_PSEL(UART_RX, 0, 7)>;
+		};
+	};
+
+	uart135_sleep_alt: uart135_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 0, 6)>,
+				<NRF_PSEL(UART_RX, 0, 7)>;
+			low-power-enable;
+		};
+	};
+};
+
+dut: &uart135 {
+	status = "okay";
+	current-speed = <115200>;
+	pinctrl-0 = <&uart135_default_alt>;
+	pinctrl-1 = <&uart135_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+	memory-regions = <&cpuapp_dma_region>;
+};

--- a/tests/drivers/uart/uart_pm/src/main.c
+++ b/tests/drivers/uart/uart_pm/src/main.c
@@ -34,7 +34,10 @@ static void polling_verify(const struct device *dev, bool is_async, bool active)
 
 	for (int i = 0; i < ARRAY_SIZE(outs); i++) {
 		uart_poll_out(dev, outs[i]);
-		k_busy_wait(1000);
+		/* We need to wait until receiver gets the data. Receiver may have
+		 * RX timeout so data is not received instantly.
+		 */
+		k_busy_wait(5000);
 
 		if (active) {
 			err = uart_poll_in(dev, &c);
@@ -78,6 +81,12 @@ static bool async_verify(const struct device *dev, bool active)
 
 	zassert_equal(err, 0, "Unexpected err: %d", err);
 
+	/* Wait a bit to ensure that polling transfer is already finished otherwise
+	 * receiver might be enabled when there is an ongoing transfer and bytes
+	 * will get corrupted.
+	 */
+	k_busy_wait(1000);
+
 	if (!DISABLED_RX) {
 		err = uart_rx_enable(dev, rxbuf, sizeof(rxbuf), 1 * USEC_PER_MSEC);
 		zassert_equal(err, 0, "Unexpected err: %d", err);
@@ -90,7 +99,7 @@ static bool async_verify(const struct device *dev, bool active)
 
 	if (!DISABLED_RX) {
 		err = uart_rx_disable(dev);
-		zassert_equal(err, 0, "Unexpected err: %d", err);
+		zassert_true((err == 0) || (err == -EFAULT));
 
 		k_busy_wait(10000);
 

--- a/tests/drivers/uart/uart_pm/testcase.yaml
+++ b/tests/drivers/uart/uart_pm/testcase.yaml
@@ -6,6 +6,7 @@ common:
   platform_allow:
     - nrf52840dk/nrf52840
     - nrf54l15pdk/nrf54l15/cpuapp
+    - nrf54h20dk/nrf54h20/cpuapp
     - nrf52_bsim
   harness_config:
     fixture: gpio_loopback
@@ -27,6 +28,7 @@ tests:
     extra_args: DTC_OVERLAY_FILE="boards/nrf52840dk_nrf52840.overlay;nrf_rx_disable.overlay"
     platform_exclude:
       - nrf54l15pdk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
 
   drivers.uart.pm.enhanced_poll:
     extra_configs:
@@ -36,6 +38,7 @@ tests:
       - CONFIG_UART_NRFX_UARTE_LEGACY_SHIM=y
     platform_exclude:
       - nrf54l15pdk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
 
   drivers.uart.pm.int_driven:
     extra_configs:
@@ -54,6 +57,7 @@ tests:
       - CONFIG_UART_NRFX_UARTE_LEGACY_SHIM=y
     platform_exclude:
       - nrf54l15pdk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
 
   drivers.uart.pm.async:
     extra_configs:
@@ -78,3 +82,4 @@ tests:
       - CONFIG_UART_NRFX_UARTE_LEGACY_SHIM=y
     platform_exclude:
       - nrf54l15pdk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp

--- a/tests/drivers/uart/uart_pm/testcase.yaml
+++ b/tests/drivers/uart/uart_pm/testcase.yaml
@@ -5,6 +5,7 @@ common:
   harness: ztest
   platform_allow:
     - nrf52840dk/nrf52840
+    - nrf54l15pdk/nrf54l15/cpuapp
     - nrf52_bsim
   harness_config:
     fixture: gpio_loopback
@@ -24,6 +25,8 @@ tests:
       - CONFIG_UART_0_ENHANCED_POLL_OUT=n
       - CONFIG_UART_NRFX_UARTE_LEGACY_SHIM=y
     extra_args: DTC_OVERLAY_FILE="boards/nrf52840dk_nrf52840.overlay;nrf_rx_disable.overlay"
+    platform_exclude:
+      - nrf54l15pdk/nrf54l15/cpuapp
 
   drivers.uart.pm.enhanced_poll:
     extra_configs:
@@ -31,6 +34,8 @@ tests:
       - CONFIG_UART_ASYNC_API=n
       - CONFIG_UART_0_ENHANCED_POLL_OUT=y
       - CONFIG_UART_NRFX_UARTE_LEGACY_SHIM=y
+    platform_exclude:
+      - nrf54l15pdk/nrf54l15/cpuapp
 
   drivers.uart.pm.int_driven:
     extra_configs:
@@ -47,6 +52,8 @@ tests:
       - CONFIG_UART_ASYNC_API=n
       - CONFIG_UART_0_ENHANCED_POLL_OUT=y
       - CONFIG_UART_NRFX_UARTE_LEGACY_SHIM=y
+    platform_exclude:
+      - nrf54l15pdk/nrf54l15/cpuapp
 
   drivers.uart.pm.async:
     extra_configs:
@@ -69,3 +76,5 @@ tests:
       - CONFIG_NRFX_TIMER2=y
       - CONFIG_UART_0_ENHANCED_POLL_OUT=y
       - CONFIG_UART_NRFX_UARTE_LEGACY_SHIM=y
+    platform_exclude:
+      - nrf54l15pdk/nrf54l15/cpuapp

--- a/west.yml
+++ b/west.yml
@@ -183,7 +183,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: fc2bab706f195c64d40016c9855b8acd7c235ded
+      revision: f8e4d73a78316ea9ef85f09f24a3a229e40c1a80
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
PR is based on #71255 and #71254.

PR contains:
- changes in the test to make it work for new shim
- Some fixes in the driver and hal_nordic
- Configuration for nrf54h20dk and filtering in the `testcase.yaml`