### PR TITLE
boards: dts: nordic: SysCtrl IPC configuration

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3456,7 +3456,7 @@ nRF Platforms:
     - drivers/*/*nrfx*.c
     - soc/nordic/
     - samples/boards/nrf/
-    - dts/arm/nordic/
+    - dts/*/nordic/
     - dts/bindings/*/nordic,*
     - tests/drivers/timer/nrf_rtc_timer/
   labels:

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-ipc_conf.dtsi
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-ipc_conf.dtsi
@@ -26,11 +26,25 @@
 				 <&cpurad_bellboard 12>;
 		};
 
+		cpuapp_cpusys_ipc: ipc-2-12 {
+			compatible = "zephyr,ipc-icmsg";
+			status = "disabled";
+			mboxes = <&cpuapp_bellboard 6>,
+				 <&cpusys_vevif 12>;
+		};
+
 		cpuapp_cpuppr_ipc: ipc-2-13 {
 			compatible = "zephyr,ipc-icmsg";
 			status = "disabled";
 			mboxes = <&cpuapp_bellboard 13>,
 				 <&cpuppr_vevif 12>;
+		};
+
+		cpurad_cpusys_ipc: ipc-3-12 {
+			compatible = "zephyr,ipc-icmsg";
+			status = "disabled";
+			mboxes = <&cpurad_bellboard 6>,
+				 <&cpusys_vevif 18>;
 		};
 	};
 };

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
@@ -11,6 +11,7 @@
 #include "nrf54h20dk_nrf54h20-ipc_conf.dtsi"
 #include "nrf54h20dk_nrf54h20-pinctrl.dtsi"
 
+/delete-node/ &cpurad_cpusys_ipc;
 /delete-node/ &cpusec_cpurad_ipc;
 
 / {
@@ -100,8 +101,8 @@
 &cpuapp_bellboard {
 	interrupts = <96 NRF_DEFAULT_IRQ_PRIORITY>;
 	interrupt-names = "irq0";
-	/* irq0: 0: cpuapp-cpusec, 13: cpuapp-cpuppr, 18: cpuapp-cpurad */
-	nordic,interrupt-mapping = <0x00042001 0>;
+	/* irq0: 0: cpuapp-cpusec, 6: cpuapp-cpusys, 13: cpuapp-cpuppr, 18: cpuapp-cpurad */
+	nordic,interrupt-mapping = <0x00042041 0>;
 };
 
 &cpusec_cpuapp_ipc {
@@ -115,6 +116,12 @@
 	mbox-names = "rx", "tx";
 	tx-region = <&cpuapp_cpurad_ipc_shm>;
 	rx-region = <&cpurad_cpuapp_ipc_shm>;
+};
+
+&cpuapp_cpusys_ipc {
+	mbox-names = "rx", "tx";
+	tx-region = <&cpuapp_cpusys_ipc_shm>;
+	rx-region = <&cpusys_cpuapp_ipc_shm>;
 };
 
 &cpuapp_cpuppr_ipc {

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuppr.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuppr.dts
@@ -12,6 +12,8 @@
 #include "nrf54h20dk_nrf54h20-pinctrl.dtsi"
 
 /delete-node/ &cpuapp_cpurad_ipc;
+/delete-node/ &cpuapp_cpusys_ipc;
+/delete-node/ &cpurad_cpusys_ipc;
 /delete-node/ &cpusec_cpuapp_ipc;
 /delete-node/ &cpusec_cpurad_ipc;
 

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
@@ -12,6 +12,7 @@
 #include "nrf54h20dk_nrf54h20-pinctrl.dtsi"
 
 /delete-node/ &cpuapp_cpuppr_ipc;
+/delete-node/ &cpuapp_cpusys_ipc;
 /delete-node/ &cpusec_cpuapp_ipc;
 
 / {
@@ -34,8 +35,8 @@
 &cpurad_bellboard {
 	interrupts = <96 NRF_DEFAULT_IRQ_PRIORITY>;
 	interrupt-names = "irq0";
-	/* irq0: 0: cpurad-cpusec, 12: cpurad-cpuapp */
-	nordic,interrupt-mapping = <0x00001001 0>;
+	/* irq0: 0: cpurad-cpusec, 6: cpurad-cpusys, 12: cpurad-cpuapp */
+	nordic,interrupt-mapping = <0x00001041 0>;
 };
 
 &cpusec_cpurad_ipc {
@@ -49,6 +50,12 @@
 	mbox-names = "tx", "rx";
 	tx-region = <&cpurad_cpuapp_ipc_shm>;
 	rx-region = <&cpuapp_cpurad_ipc_shm>;
+};
+
+&cpurad_cpusys_ipc {
+	mbox-names = "rx", "tx";
+	tx-region = <&cpurad_cpusys_ipc_shm>;
+	rx-region = <&cpusys_cpurad_ipc_shm>;
 };
 
 &cpurad_dma_region {

--- a/dts/arm/nordic/nrf54h20_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf54h20_cpuapp.dtsi
@@ -10,6 +10,7 @@ cpu: &cpuapp {};
 systick: &cpuapp_systick {};
 nvic: &cpuapp_nvic {};
 cpuppr_vevif: &cpuppr_vevif_remote {};
+cpusys_vevif: &cpusys_vevif_remote {};
 
 /delete-node/ &cpuppr;
 /delete-node/ &cpurad;

--- a/dts/arm/nordic/nrf54h20_cpurad.dtsi
+++ b/dts/arm/nordic/nrf54h20_cpurad.dtsi
@@ -10,6 +10,7 @@ cpu: &cpurad {};
 systick: &cpurad_systick {};
 nvic: &cpurad_nvic {};
 cpuppr_vevif: &cpuppr_vevif_remote {};
+cpusys_vevif: &cpusys_vevif_remote {};
 
 /delete-node/ &cpuapp;
 /delete-node/ &cpuapp_peripherals;

--- a/dts/common/nordic/nrf54h20.dtsi
+++ b/dts/common/nordic/nrf54h20.dtsi
@@ -318,6 +318,15 @@
 				#mbox-cells = <1>;
 			};
 
+			cpusys_vevif_remote: mailbox@8c8000 {
+				compatible = "nordic,nrf-vevif-remote";
+				reg = <0x8c8000 0x1000>;
+				status = "disabled";
+				#mbox-cells = <1>;
+				nordic,tasks = <32>;
+				nordic,tasks-mask = <0xfffff0ff>;
+			};
+
 			ipct120: ipct@8d1000 {
 				compatible = "nordic,nrf-ipct-global";
 				reg = <0x8d1000 0x1000>;

--- a/dts/riscv/nordic/nrf54h20_cpuppr.dtsi
+++ b/dts/riscv/nordic/nrf54h20_cpuppr.dtsi
@@ -9,6 +9,7 @@
 cpu: &cpuppr {};
 clic: &cpuppr_clic {};
 cpuppr_vevif: &cpuppr_vevif_local {};
+cpusys_vevif: &cpusys_vevif_remote {};
 
 /delete-node/ &cpuapp;
 /delete-node/ &cpuapp_peripherals;


### PR DESCRIPTION
Add DT nodes to be used for communicating with SysCtrl on nRF54H20.