### PR TITLE
net: lib: lwm2m: fix formula for expected next block

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -2100,12 +2100,12 @@ static int parse_write_op(struct lwm2m_message *msg, uint16_t format)
 
 		block_ctx->last_block = last_block;
 
-		/* Initial block sent by the server might be larger than
-		 * our block size therefore it is needed to take this
-		 * into account when calculating next expected block
-		 * number.
+		/* Initial block sent by the server might be larger or smaller than
+		 * our block size, therefore it is needed to take this into account
+		 * when calculating next expected block number.
 		 */
-		block_ctx->expected += GET_BLOCK_SIZE(block_opt) - block_ctx->ctx.block_size + 1;
+		block_ctx->expected +=
+			1 << MAX(0, GET_BLOCK_SIZE(block_opt) - block_ctx->ctx.block_size);
 	}
 
 	r = do_write_op(msg, format);


### PR DESCRIPTION
Block size is a 3-bit value mapping values [0, 6] to powers of 2 in the range [16, 1024]. Value 7 is invalid.
The previous formula was not working in case the client's preferred size was 4 (or more) times bigger than the server's.
This commit takes into account also the case the client's preferred size is smaller than the server's.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/71272