### PR TITLE
twister: fix NXP hw detection in hardware map

### DIFF
--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -120,6 +120,7 @@ class HardwareMap:
         'Atmel Corp.',
         'Texas Instruments',
         'Silicon Labs',
+        'NXP',
         'NXP Semiconductors',
         'Microchip Technology Inc.',
         'FTDI',


### PR DESCRIPTION
Some NXP boards are not detected by twister when creating hardware map, because manufacture name is NXP instead of NXP Semiconductors expected by twister.
Fix it by adding NXP to manufacturers list.