### PR TITLE
Bluetooth: Mesh: Update models metadata API

### DIFF
--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -167,6 +167,14 @@ Bluetooth Mesh
   got ``const`` qualifier too. The model's metadata structure and metadata raw value
   can be declared as permanent constants in the non-volatile memory. (:github:`69679`)
 
+* The model metadata pointer declaration of :c:struct:`bt_mesh_model` has been changed
+  to a single ``const *`` and redundant metadata pointer from :c:struct:`bt_mesh_health_srv`
+  is removed. Consequently, :code:`BT_MESH_MODEL_HEALTH_SRV` definition is changed
+  to use variable argument notation. (:github:`71281`). Now, when your implementation
+  supports :kconfig:option:`CONFIG_BT_MESH_LARGE_COMP_DATA_SRV` and when you need to
+  specify metadata for Health Server model, simply pass metadata as the last argument
+  to the :code:`BT_MESH_MODEL_HEALTH_SRV` macro, otherwise omit the last argument.
+
 Bluetooth Audio
 ===============
 

--- a/include/zephyr/bluetooth/mesh/access.h
+++ b/include/zephyr/bluetooth/mesh/access.h
@@ -506,7 +506,8 @@ struct bt_mesh_model_op {
  *  @param _pub       Model publish parameters.
  *  @param _user_data User data for the model.
  *  @param _cb        Callback structure, or NULL to keep no callbacks.
- *  @param _metadata  Metadata structure.
+ *  @param _metadata  Metadata structure. Used if @kconfig{CONFIG_BT_MESH_LARGE_COMP_DATA_SRV}
+ *		      is enabled.
  */
 #if defined(CONFIG_BT_MESH_LARGE_COMP_DATA_SRV)
 #define BT_MESH_MODEL_METADATA_CB(_id, _op, _pub, _user_data, _cb, _metadata)                    \
@@ -560,8 +561,10 @@ struct bt_mesh_model_op {
  *  @param _pub       Model publish parameters.
  *  @param _user_data User data for the model.
  *  @param _cb        Callback structure, or NULL to keep no callbacks.
- *  @param _metadata  Metadata structure.
+ *  @param _metadata  Metadata structure. Used if @kconfig{CONFIG_BT_MESH_LARGE_COMP_DATA_SRV}
+ *		      is enabled.
  */
+#if defined(CONFIG_BT_MESH_LARGE_COMP_DATA_SRV)
 #define BT_MESH_MODEL_VND_METADATA_CB(_company, _id, _op, _pub, _user_data, _cb, _metadata)      \
 {                                                                            \
 	.vnd.company = (_company),                                           \
@@ -577,7 +580,10 @@ struct bt_mesh_model_op {
 	.cb = _cb,                                                           \
 	.metadata = _metadata,                                               \
 }
-
+#else
+#define BT_MESH_MODEL_VND_METADATA_CB(_company, _id, _op, _pub, _user_data, _cb, _metadata)      \
+	BT_MESH_MODEL_VND_CB(_company, _id, _op, _pub, _user_data, _cb)
+#endif
 /**
  *  @brief Composition data SIG model entry.
  *
@@ -924,7 +930,7 @@ struct bt_mesh_model {
 
 #if defined(CONFIG_BT_MESH_LARGE_COMP_DATA_SRV) || defined(__DOXYGEN__)
 	/* Pointer to the array of model metadata entries. */
-	const struct bt_mesh_models_metadata_entry * const * const metadata;
+	const struct bt_mesh_models_metadata_entry * const metadata;
 #endif
 };
 

--- a/include/zephyr/bluetooth/mesh/health_srv.h
+++ b/include/zephyr/bluetooth/mesh/health_srv.h
@@ -156,11 +156,6 @@ struct bt_mesh_health_srv {
 
 	/** Attention Timer state */
 	struct k_work_delayable attn_timer;
-
-#ifdef CONFIG_BT_MESH_LARGE_COMP_DATA_SRV
-	/** Pointer to the array with Health Test Info Metadata */
-	const struct bt_mesh_models_metadata_entry *metadata;
-#endif
 };
 
 /**
@@ -171,18 +166,18 @@ struct bt_mesh_health_srv {
  *
  *  @param srv Pointer to a unique struct bt_mesh_health_srv.
  *  @param pub Pointer to a unique struct bt_mesh_model_pub.
+ *  @param ... Optional Health Server metadata if application is compiled with
+ *	       Large Composition Data Server support, otherwise this parameter
+ *	       is ignored.
  *
  *  @return New mesh model instance.
  */
-#ifdef CONFIG_BT_MESH_LARGE_COMP_DATA_SRV
-#define BT_MESH_MODEL_HEALTH_SRV(srv, pub)                                              \
-	BT_MESH_MODEL_METADATA_CB(BT_MESH_MODEL_ID_HEALTH_SRV, bt_mesh_health_srv_op,   \
-			 pub, srv, &bt_mesh_health_srv_cb, &(srv)->metadata)
-#else
-#define BT_MESH_MODEL_HEALTH_SRV(srv, pub)                                     \
-	BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_HEALTH_SRV, bt_mesh_health_srv_op,   \
-			 pub, srv, &bt_mesh_health_srv_cb)
-#endif
+#define BT_MESH_MODEL_HEALTH_SRV(srv, pub, ...)                        \
+	BT_MESH_MODEL_METADATA_CB(BT_MESH_MODEL_ID_HEALTH_SRV,         \
+				  bt_mesh_health_srv_op,               \
+				  pub,                                 \
+				  srv,                                 \
+				  &bt_mesh_health_srv_cb, __VA_ARGS__)
 
 /**
  *

--- a/include/zephyr/bluetooth/mesh/shell.h
+++ b/include/zephyr/bluetooth/mesh/shell.h
@@ -38,6 +38,9 @@ struct bt_mesh_shell_target {
 /** @brief External reference to health server */
 extern struct bt_mesh_health_srv bt_mesh_shell_health_srv;
 
+/** @brief External reference to health server metadata */
+extern const struct bt_mesh_models_metadata_entry health_srv_meta[];
+
 /** @brief External reference to health client */
 extern struct bt_mesh_health_cli bt_mesh_shell_health_cli;
 

--- a/subsys/bluetooth/mesh/access.c
+++ b/subsys/bluetooth/mesh/access.c
@@ -220,7 +220,7 @@ static size_t metadata_model_size(const struct bt_mesh_model *mod,
 
 	size += sizeof(uint8_t);
 
-	for (entry = *mod->metadata; entry && entry->len; ++entry) {
+	for (entry = mod->metadata; entry && entry->len; ++entry) {
 		size += sizeof(entry->len) + sizeof(entry->id) + entry->len;
 	}
 
@@ -286,7 +286,7 @@ static int metadata_add_model(const struct bt_mesh_model *mod,
 	count_ptr = data_buf_add_u8_offset(buf, 0, offset);
 
 	if (mod->metadata) {
-		for (entry = *mod->metadata; entry && entry->data != NULL; ++entry) {
+		for (entry = mod->metadata; entry && entry->data != NULL; ++entry) {
 			data_buf_add_le16_offset(buf, entry->len, offset);
 			data_buf_add_le16_offset(buf, entry->id, offset);
 			data_buf_add_mem_offset(buf, entry->data, entry->len, offset);

--- a/subsys/bluetooth/mesh/shell/shell.c
+++ b/subsys/bluetooth/mesh/shell/shell.c
@@ -144,13 +144,13 @@ static const struct bt_mesh_health_srv_cb health_srv_cb = {
 };
 #endif /* CONFIG_BT_MESH_SHELL_HEALTH_SRV_INSTANCE */
 
-#ifdef CONFIG_BT_MESH_LARGE_COMP_DATA_SRV
+#if defined(CONFIG_BT_MESH_LARGE_COMP_DATA_SRV)
 static const uint8_t health_tests[] = {
 	BT_MESH_HEALTH_TEST_INFO(COMPANY_ID_LF, 6, 0x01, 0x02, 0x03, 0x04, 0x34, 0x15),
 	BT_MESH_HEALTH_TEST_INFO(COMPANY_ID_NORDIC_SEMI, 3, 0x01, 0x02, 0x03),
 };
 
-static const struct bt_mesh_models_metadata_entry health_srv_meta[] = {
+const struct bt_mesh_models_metadata_entry health_srv_meta[] = {
 	BT_MESH_HEALTH_TEST_INFO_METADATA(health_tests),
 	BT_MESH_MODELS_METADATA_END,
 };
@@ -159,9 +159,6 @@ static const struct bt_mesh_models_metadata_entry health_srv_meta[] = {
 struct bt_mesh_health_srv bt_mesh_shell_health_srv = {
 #if defined(CONFIG_BT_MESH_SHELL_HEALTH_SRV_INSTANCE)
 	.cb = &health_srv_cb,
-#endif
-#ifdef CONFIG_BT_MESH_LARGE_COMP_DATA_SRV
-	.metadata = health_srv_meta,
 #endif
 };
 

--- a/tests/bluetooth/mesh_shell/src/main.c
+++ b/tests/bluetooth/mesh_shell/src/main.c
@@ -46,7 +46,8 @@ BT_MESH_SHELL_HEALTH_PUB_DEFINE(health_pub);
 static const struct bt_mesh_model root_models[] = {
 	BT_MESH_MODEL_CFG_SRV,
 	BT_MESH_MODEL_CFG_CLI(&cfg_cli),
-	BT_MESH_MODEL_HEALTH_SRV(&bt_mesh_shell_health_srv, &health_pub),
+	BT_MESH_MODEL_HEALTH_SRV(&bt_mesh_shell_health_srv, &health_pub,
+				 health_srv_meta),
 	BT_MESH_MODEL_HEALTH_CLI(&bt_mesh_shell_health_cli),
 #if defined(CONFIG_BT_MESH_DFD_SRV)
 	BT_MESH_MODEL_DFD_SRV(&dfd_srv),

--- a/tests/bsim/bluetooth/mesh/src/mesh_test.c
+++ b/tests/bsim/bluetooth/mesh/src/mesh_test.c
@@ -10,6 +10,8 @@
 #include <zephyr/bluetooth/hci.h>
 
 #define LOG_MODULE_NAME mesh_test
+#define COMPANY_ID_LF 0x05F1
+#define COMPANY_ID_NORDIC_SEMI 0x05F9
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);
@@ -162,6 +164,15 @@ static struct bt_mesh_health_srv health_srv;
 static struct bt_mesh_model_pub health_pub = {
 	.msg = NET_BUF_SIMPLE(BT_MESH_TX_SDU_MAX),
 };
+static const uint8_t health_tests[] = {
+	BT_MESH_HEALTH_TEST_INFO(COMPANY_ID_LF, 6, 0x01, 0x02, 0x03, 0x04, 0x34, 0x15),
+	BT_MESH_HEALTH_TEST_INFO(COMPANY_ID_NORDIC_SEMI, 3, 0x01, 0x02, 0x03),
+};
+
+const struct bt_mesh_models_metadata_entry health_srv_meta[] = {
+	BT_MESH_HEALTH_TEST_INFO_METADATA(health_tests),
+	BT_MESH_MODELS_METADATA_END,
+};
 
 #if defined(CONFIG_BT_MESH_SAR_CFG)
 static struct bt_mesh_sar_cfg_cli sar_cfg_cli;
@@ -179,7 +190,7 @@ static const struct bt_mesh_model models[] = {
 	BT_MESH_MODEL_CFG_SRV,
 	BT_MESH_MODEL_CFG_CLI(&cfg_cli),
 	BT_MESH_MODEL_CB(TEST_MOD_ID, model_op, &pub, NULL, &test_model_cb),
-	BT_MESH_MODEL_HEALTH_SRV(&health_srv, &health_pub),
+	BT_MESH_MODEL_HEALTH_SRV(&health_srv, &health_pub, health_srv_meta),
 #if defined(CONFIG_BT_MESH_SAR_CFG)
 	BT_MESH_MODEL_SAR_CFG_SRV,
 	BT_MESH_MODEL_SAR_CFG_CLI(&sar_cfg_cli),

--- a/tests/bsim/bluetooth/mesh/src/test_lcd.c
+++ b/tests/bsim/bluetooth/mesh/src/test_lcd.c
@@ -86,7 +86,7 @@ static void test_args_parse(int argc, char *argv[])
 	bs_args_parse_all_cmd_line(argc, argv, args_struct);
 }
 
-static const struct bt_mesh_models_metadata_entry *dummy_meta_entry[] = {};
+static const struct bt_mesh_models_metadata_entry dummy_meta_entry[1];
 
 /* Empty elements to create large composition/meta data */
 #define DUMMY_ELEM(i, _) BT_MESH_ELEM((i) + 2,	\


### PR DESCRIPTION
Bluetooth: Mesh: Update models metadata API

This commit updates models metadata API to simplify the usage and
removes the metadata pointer in health server model context.