### PR TITLE
drivers: can: bump API version from 1.0.0 to 1.1.0

### DIFF
--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -31,7 +31,7 @@ extern "C" {
  * @brief CAN Interface
  * @defgroup can_interface CAN Interface
  * @since 1.12
- * @version 1.0.0
+ * @version 1.1.0
  * @ingroup io_interfaces
  * @{
  */


### PR DESCRIPTION
Bump the CAN controller API version from 1.0.0 to 1.1.0 to reflect bus recovery API changes introduced for v3.7.0.