### PR TITLE
Sensor api adding context field to sensor_trigger for high level api

### DIFF
--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -286,6 +286,8 @@ struct sensor_trigger {
 	enum sensor_trigger_type type;
 	/** Channel the trigger is set on. */
 	enum sensor_channel chan;
+	/** Channel context pointer. */
+	void* context;
 };
 
 /**


### PR DESCRIPTION
When writing a sensor api in C++, I encountered a problem that there was no connection between the callback and its configuration area. To solve the problem, I suggest adding a context pointer to the trigger structure; this will allow you to both pass a pointer to a variable to save the results obtained, and pass a pointer to a class in the case of using several sensors of the same type and processed by one class. This change does not affect existing drivers and examples.