### PR TITLE
boards: silabs: Added support for Counter and Watchdog in efr32xg24_dk2601b 

### DIFF
--- a/boards/silabs/efr32xg24_dk2601b/efr32xg24_dk2601b.dts
+++ b/boards/silabs/efr32xg24_dk2601b/efr32xg24_dk2601b.dts
@@ -27,6 +27,7 @@
 		led2 = &blue_led;
 		sw0 = &button0;
 		sw1 = &button1;
+		watchdog0 = &wdog0;
 	};
 
 	leds {
@@ -170,5 +171,9 @@
 };
 
 &adc0 {
+	status = "okay";
+};
+
+&stimer0 {
 	status = "okay";
 };

--- a/boards/silabs/efr32xg24_dk2601b/efr32xg24_dk2601b.yaml
+++ b/boards/silabs/efr32xg24_dk2601b/efr32xg24_dk2601b.yaml
@@ -8,8 +8,10 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
+  - counter
   - gpio
   - uart
+  - watchdog
 testing:
   ignore_tags:
     - net

--- a/west.yml
+++ b/west.yml
@@ -219,7 +219,7 @@ manifest:
       groups:
         - hal
     - name: hal_silabs
-      revision: 442d0fb1d02cc4b2bb159fbff378029998b89049
+      revision: 0c39ee28be31c59a98ed490c3811f68caa1fcbd3
       path: modules/hal/silabs
       groups:
         - hal


### PR DESCRIPTION
Added the support for counter and watchdog in efr32xg24_dk2601b board. Updated the peripheral_sysrtc.h, peripheral_sysrtc.c and added peripheral_sysrtc_compat.h. The files are taken from gecko_sdk 4.4.0 (https://github.com/SiliconLabs/gecko_sdk). These files are required for counter support in silabs boards.

PR in hal_silabs : https://github.com/zephyrproject-rtos/hal_silabs/pull/62