### PR TITLE
drivers: eth: stellaris: Fix build error

### DIFF
--- a/drivers/ethernet/eth_stellaris.c
+++ b/drivers/ethernet/eth_stellaris.c
@@ -249,7 +249,7 @@ static void eth_stellaris_isr(const struct device *dev)
 		 * to get how many packets are in the Ethernet.
 		 */
 		num_packets = sys_read32(REG_MACNP);
-		for (int i = 0; i < np; i++) {
+		for (int i = 0; i < num_packets; i++) {
 			if (eth_stellaris_rx(dev) != 0) {
 				break;
 			}


### PR DESCRIPTION
Apparently there was a typo in the last commit.
Looks like it was refactored without trying to build.
This was refactored in https://github.com/zephyrproject-rtos/zephyr/pull/70428

**Build error:**
```
/home/st/src/ncs/zephyr/drivers/ethernet/eth_stellaris.c: In function 'eth_stellaris_isr':
/home/st/src/ncs/zephyr/drivers/ethernet/eth_stellaris.c:252:37: error: 'np' undeclared (first use in this function)
  252 |                 for (int i = 0; i < np; i++) {
      |                                     ^~
/home/seta/src/ncs/zephyr/drivers/ethernet/eth_stellaris.c:252:37: note: each undeclared identifier is reported only once for each function it ap
```
