### PR TITLE
net: vlan: Fix net_eth_get_vlan_tag() to check correct interface

### DIFF
--- a/subsys/net/l2/ethernet/vlan.c
+++ b/subsys/net/l2/ethernet/vlan.c
@@ -317,18 +317,17 @@ bool net_eth_is_vlan_enabled(struct ethernet_context *ctx,
 uint16_t net_eth_get_vlan_tag(struct net_if *iface)
 {
 	uint16_t tag = NET_VLAN_TAG_UNSPEC;
-	struct vlan_context *ctx;
 
 	k_mutex_lock(&lock, K_FOREVER);
 
-	ctx = get_vlan_ctx(iface, tag, true);
-	if (ctx != NULL) {
-		/* The Ethernet interface does not have a tag so if user
-		 * tried to use the main interface, then do not return
-		 * the tag.
-		 */
-		if (ctx->attached_to != iface) {
-			tag = ctx->tag;
+	ARRAY_FOR_EACH(vlan_ctx, i) {
+		if (vlan_ctx[i] == NULL || !vlan_ctx[i]->is_used) {
+			continue;
+		}
+
+		if (vlan_ctx[i]->iface == iface) {
+			tag = vlan_ctx[i]->tag;
+			break;
 		}
 	}
 

--- a/tests/net/vlan/src/main.c
+++ b/tests/net/vlan/src/main.c
@@ -574,6 +574,23 @@ static void test_vlan_enable(void)
 	ret = net_eth_vlan_enable(iface, VLAN_TAG_1);
 	zassert_equal(ret, -EALREADY, "VLAN tag %d enabled for iface 1 (%d)",
 		      VLAN_TAG_1, ret);
+
+	for (int i = VLAN_TAG_1; i <= VLAN_TAG_5; i += 100) {
+		iface = net_eth_get_vlan_iface(NULL, i);
+
+		ARRAY_FOR_EACH_PTR(vlan_interfaces, vlan_iface) {
+			uint16_t tag;
+
+			if (*vlan_iface == iface) {
+				tag = net_eth_get_vlan_tag(*vlan_iface);
+
+				zassert_equal(tag, i,
+					      "Could not get the VLAN interface (%d)",
+					      net_if_get_by_iface(*vlan_iface));
+				break;
+			}
+		}
+	}
 }
 
 static void test_vlan_disable(void)
@@ -628,13 +645,13 @@ static void test_vlan_enable_all(void)
 	int ret;
 
 	ret = net_eth_vlan_enable(eth_interfaces[0], VLAN_TAG_1);
-	zassert_equal(ret, 0, "Cannot enable %d", VLAN_TAG_1);
+	zassert_true(ret == 0 || ret == -EALREADY, "Cannot enable %d", VLAN_TAG_1);
 	ret = net_eth_vlan_enable(eth_interfaces[0], VLAN_TAG_2);
-	zassert_equal(ret, 0, "Cannot enable %d", VLAN_TAG_2);
+	zassert_true(ret == 0 || ret == -EALREADY, "Cannot enable %d", VLAN_TAG_2);
 	ret = net_eth_vlan_enable(eth_interfaces[0], VLAN_TAG_3);
-	zassert_equal(ret, 0, "Cannot enable %d", VLAN_TAG_3);
+	zassert_true(ret == 0 || ret == -EALREADY, "Cannot enable %d", VLAN_TAG_3);
 	ret = net_eth_vlan_enable(eth_interfaces[0], VLAN_TAG_4);
-	zassert_equal(ret, 0, "Cannot enable %d", VLAN_TAG_4);
+	zassert_true(ret == 0 || ret == -EALREADY, "Cannot enable %d", VLAN_TAG_4);
 
 	eth_ctx = net_if_l2_data(eth_interfaces[0]);
 


### PR DESCRIPTION
The network interface parameter for net_eth_get_vlan_tag() should be the VLAN interface so use the search loop properly. Earlier the main interface could be checked.

Add also test cases for this so that we can catch that the func works properly.