### PR TITLE
boards: nrf_bsim: bst hooks: Call tests delete only once

### DIFF
--- a/boards/native/nrf_bsim/common/bstests_entry.c
+++ b/boards/native/nrf_bsim/common/bstests_entry.c
@@ -224,6 +224,13 @@ void bst_main(void)
  */
 uint8_t bst_delete(void)
 {
+	static bool already_deleted;
+
+	if (already_deleted) {
+		return bst_result;
+	}
+	already_deleted = true;
+
 	if (current_test && current_test->test_delete_f) {
 		current_test->test_delete_f();
 	}


### PR DESCRIPTION
bst_delete() is called from an ON_EXIT hook, which can be called several times if an exit hook itself fails and calls exit on its own.
This is not what most tests destructors will expect, and they may do weird things in this case. So let's not call into it again.