### PR TITLE
scripts: logging: support native_posix dictionary logging

### DIFF
--- a/scripts/logging/dictionary/database_gen.py
+++ b/scripts/logging/dictionary/database_gen.py
@@ -143,7 +143,7 @@ def find_elf_sections(elf, sh_name):
 def get_kconfig_symbols(elf):
     """Get kconfig symbols from the ELF file"""
     for section in elf.iter_sections():
-        if isinstance(section, SymbolTableSection):
+        if isinstance(section, SymbolTableSection) and section['sh_type'] != 'SHT_DYNSYM':
             return {sym.name: sym.entry.st_value
                     for sym in section.iter_symbols()
                        if sym.name.startswith("CONFIG_")}
@@ -254,6 +254,9 @@ def process_kconfigs(elf, database):
         if arch['kconfig'] in kconfigs:
             database.set_arch(name)
             break
+    else:
+        logger.error("Did not found architecture")
+        sys.exit(1)
 
     # Put some kconfigs into the database
     #

--- a/scripts/logging/dictionary/dictionary_parser/log_database.py
+++ b/scripts/logging/dictionary/dictionary_parser/log_database.py
@@ -46,6 +46,9 @@ ARCHS = {
         # for explanation.
         "extra_string_section": ['datas'],
     },
+    "posix" : {
+        "kconfig": "CONFIG_ARCH_POSIX",
+    },
     "riscv" : {
         "kconfig": "CONFIG_RISCV",
     },


### PR DESCRIPTION
Dictionary logging is not building with native_posix boards. For example:

```
west build -b native_posix_64 zephyr/samples/subsys/logging/dictionary -- \
    -DCONFIG_LOG_BACKEND_NATIVE_POSIX_OUTPUT_DICTIONARY=y
```

Gives an error:
```
FAILED: zephyr/log_dictionary.json .../zephyr/log_dictionary.json                            
cd .../build/zephyr && .../zephyr-venv/bin/python3 .../zephyr/scripts/logging/dictionary/database_gen.py zephyr.elf --json=.../build/zephyr/log_dictionary.json --build-header .../build/zephyr/include/generated/version.h
Traceback (most recent call last):
  File ".../zephyr/scripts/logging/dictionary/database_gen.py", line 586, in <module>
    main()
  File ".../zephyr/scripts/logging/dictionary/database_gen.py", line 554, in main
    string_mappings = extract_static_strings(elf, database, section_extraction)
  File ".../zephyr/scripts/logging/dictionary/database_gen.py", line 481, in extract_static_strings
    arch_data = dictionary_parser.log_database.ARCHS[database.get_arch()]
KeyError: None
ninja: build stopped: subcommand failed.
```

There are two issues preventing the build to pass:

1. There is no architecture deduction rule defined for native_posix boards.
2. Kconfig symbol search fails to search symbols from the correct section if the elf file contains `.dynsym` table. 

So, fix the issues to get build passing.

Although it might make rarely sense to use dictionary logging to console / UART on native_posix, my use case is to look file system logging backend using dictionary logging while keeping the text based logging on console.