### PR TITLE
ioctl return value & eventfd internal flag reset fixes

### DIFF
--- a/lib/posix/options/eventfd.c
+++ b/lib/posix/options/eventfd.c
@@ -247,7 +247,9 @@ static int eventfd_ioctl_op(void *obj, unsigned int request, va_list args)
 			errno = EINVAL;
 			ret = -1;
 		} else {
-			efd->flags = flags;
+			int prev_flags = efd->flags & ~EFD_FLAGS_SET_INTERNAL;
+
+			efd->flags = flags | prev_flags;
 			ret = 0;
 		}
 	} break;

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -3204,7 +3204,8 @@ static int ztls_poll_update_ctx(struct tls_context *ctx,
 			ret = z_fdtable_call_ioctl(vtable, obj,
 						   ZFD_IOCTL_POLL_PREPARE,
 						   pfd, pev, *pev + 1);
-			if (ret != 0 && ret != -EALREADY) {
+			if (ret != 0 && errno != EALREADY) {
+				ret = -errno;
 				goto out;
 			}
 


### PR DESCRIPTION
This MRQ contains fixes for two related bugs:

- Calling F_SETFL ioctl operation on an eventfd resulted in the internal flags being wiped, leading to the eventfd being seen as "unused"
- ioctl return values not being handled correctly by zsock_poll implementation, which in turn returned -EPERM (-1) on a correctly implemented ioctl function

Related because the latter bug masked the first one when I was debugging this.

To fix the first bug, the previous state of the internal flags is saved in a local variable and or-ed with the to-be-set flags. To fix the second bug, error returning in ioctl implementations in sockets and sockets-tls are fixed to the Unix ioctl API, and subsequent error handling is corrected.