### PR TITLE
doc: device_mgmt: Fix typo in link text

### DIFF
--- a/doc/services/device_mgmt/mcumgr.rst
+++ b/doc/services/device_mgmt/mcumgr.rst
@@ -31,7 +31,7 @@ systems.
 The management subsystem is located in :zephyr_file:`subsys/mgmt/` inside of
 the Zephyr tree.
 
-Additionally, there is a :zephyr:code-sample:`sample <smp-svr>` sample that provides
+Additionally, there is a :zephyr:code-sample:`sample <smp-svr>` server that provides
 management functionality over BLE and serial.
 
 .. _mcumgr_tools_libraries:


### PR DESCRIPTION
Previously it read "there is a sample sample that..."