### PR TITLE
net: lwm2m: Allow CoAP block size to be changed

### DIFF
--- a/include/zephyr/net/coap.h
+++ b/include/zephyr/net/coap.h
@@ -27,7 +27,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <zephyr/net/net_ip.h>
-
+#include <zephyr/sys/math_extras.h>
 #include <zephyr/sys/slist.h>
 
 #ifdef __cplusplus
@@ -694,6 +694,27 @@ static inline uint16_t coap_block_size_to_bytes(
 	enum coap_block_size block_size)
 {
 	return (1 << (block_size + 4));
+}
+
+/**
+ * @brief Helper for converting block size in bytes to enumeration.
+ *
+ * NOTE: Only valid CoAP block sizes map correctly.
+ *
+ * @param bytes CoAP block size in bytes.
+ * @return enum coap_block_size
+ */
+static inline enum coap_block_size coap_bytes_to_block_size(uint16_t bytes)
+{
+	int sz = u32_count_trailing_zeros(bytes) - 4;
+
+	if (sz < COAP_BLOCK_16) {
+		return COAP_BLOCK_16;
+	}
+	if (sz > COAP_BLOCK_1024) {
+		return COAP_BLOCK_1024;
+	}
+	return sz;
 }
 
 /**

--- a/tests/net/lib/lwm2m/block_transfer/src/main.c
+++ b/tests/net/lib/lwm2m/block_transfer/src/main.c
@@ -11,7 +11,8 @@
 
 /* Declaration of 'private' function */
 int prepare_msg_for_send(struct lwm2m_message *msg);
-int build_msg_block_for_send(struct lwm2m_message *msg, uint16_t block_num);
+int build_msg_block_for_send(struct lwm2m_message *msg, uint16_t block_num,
+			     enum coap_block_size block_size);
 int request_output_block_ctx(struct coap_block_context **ctx);
 void release_output_block_ctx(struct coap_block_context ** const ctx);
 
@@ -270,7 +271,7 @@ ZTEST_F(net_block_transfer, test_build_blocks_for_send_exactly_2_blocks)
 		      "Last byte in payload wrong");
 
 	/* block 1 */
-	ret = build_msg_block_for_send(msg, 1);
+	ret = build_msg_block_for_send(msg, 1, COAP_BLOCK_64);
 	zassert_equal(ret, 0, "Could not create second block");
 
 	ret = coap_get_option_int(&msg->cpkt, COAP_OPTION_BLOCK1);
@@ -285,7 +286,7 @@ ZTEST_F(net_block_transfer, test_build_blocks_for_send_exactly_2_blocks)
 		      "Last byte in payload wrong");
 
 	/* block 2 doesn't exist */
-	ret = build_msg_block_for_send(msg, 2);
+	ret = build_msg_block_for_send(msg, 2, COAP_BLOCK_64);
 	zassert_equal(ret, -EINVAL, "Could not create second block");
 }
 
@@ -346,7 +347,7 @@ ZTEST_F(net_block_transfer, test_build_blocks_for_send_more_than_2_blocks)
 		      "Last byte in payload wrong");
 
 	/* block 1 */
-	ret = build_msg_block_for_send(msg, 1);
+	ret = build_msg_block_for_send(msg, 1, COAP_BLOCK_64);
 	zassert_equal(ret, 0, "Could not create second block");
 
 	ret = coap_get_option_int(&msg->cpkt, COAP_OPTION_BLOCK1);
@@ -361,7 +362,7 @@ ZTEST_F(net_block_transfer, test_build_blocks_for_send_more_than_2_blocks)
 		      "Last byte in payload wrong");
 
 	/* block 2 */
-	ret = build_msg_block_for_send(msg, 2);
+	ret = build_msg_block_for_send(msg, 2, COAP_BLOCK_64);
 	zassert_equal(ret, 0, "Could not create second block");
 
 	ret = coap_get_option_int(&msg->cpkt, COAP_OPTION_BLOCK1);
@@ -374,7 +375,7 @@ ZTEST_F(net_block_transfer, test_build_blocks_for_send_more_than_2_blocks)
 	zassert_equal(0x80, payload[0], "First (and only) byte in payload wrong");
 
 	/* block 3 doesn't exist */
-	ret = build_msg_block_for_send(msg, 3);
+	ret = build_msg_block_for_send(msg, 3, COAP_BLOCK_64);
 	zassert_equal(ret, -EINVAL, "Could not create second block");
 }
 


### PR DESCRIPTION
Allow changing the CoAP Block-wise transfers block-size for subsequent GET requests.

It looks like Leshan switches block size back to its configured value, if it is smaller.
So even when we send block N=0 with size of 512, Leshan seem to handle that properly but still asks N=2 with block size 256(if that is configured).

I found this issue while verifying for https://github.com/zephyrproject-rtos/zephyr/pull/71273
Looks like that PR fixes the write part, but I was still unable to read as our block sizes did not match.
So I found a way to fix the reading part as well.


@marco85mars20  and @nixward  Please review.
