### PR TITLE
boards: nordic: nrf54h20dk: enable HWFC

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
@@ -173,4 +173,5 @@
 	pinctrl-0 = <&uart136_default>;
 	pinctrl-1 = <&uart136_sleep>;
 	pinctrl-names = "default", "sleep";
+	hw-flow-control;
 };

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuppr.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuppr.dts
@@ -46,6 +46,7 @@
 	pinctrl-0 = <&uart135_default>;
 	pinctrl-1 = <&uart135_sleep>;
 	pinctrl-names = "default", "sleep";
+	hw-flow-control;
 };
 
 &uart136 {

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
@@ -69,6 +69,7 @@
 	pinctrl-0 = <&uart135_default>;
 	pinctrl-1 = <&uart135_sleep>;
 	pinctrl-names = "default", "sleep";
+	hw-flow-control;
 };
 
 &uart136 {


### PR DESCRIPTION
For both UARTs connected to debugger chip.