### PR TITLE
Subg overlay do not disable TCP

### DIFF
--- a/samples/net/sockets/echo_client/overlay-802154-subg.conf
+++ b/samples/net/sockets/echo_client/overlay-802154-subg.conf
@@ -1,7 +1,6 @@
 CONFIG_BT=n
 
-# Disable TCP and IPv4 (TCP disabled to avoid heavy traffic)
-CONFIG_NET_TCP=n
+# Disable IPv4
 CONFIG_NET_IPV4=n
 
 CONFIG_NET_CONFIG_NEED_IPV6=y

--- a/samples/net/sockets/echo_server/overlay-802154-subg.conf
+++ b/samples/net/sockets/echo_server/overlay-802154-subg.conf
@@ -1,7 +1,6 @@
 CONFIG_BT=n
 
-# Disable TCP and IPv4 (TCP disabled to avoid heavy traffic)
-CONFIG_NET_TCP=n
+# Disable IPv4
 CONFIG_NET_IPV4=n
 
 CONFIG_NET_CONFIG_NEED_IPV6=y


### PR DESCRIPTION
Overlay to enable Subg should not disable TCP by default, especially not in samples that are used to test if networking is working. That should be left to the user

It is possible for UDP to work without TCP working (as was found in https://github.com/zephyrproject-rtos/zephyr/issues/71191)