### PR TITLE
drivers: spi: spi_mcux_lpspi: Support DMA and data cache

### DIFF
--- a/drivers/spi/Kconfig.mcux_lpspi
+++ b/drivers/spi/Kconfig.mcux_lpspi
@@ -16,6 +16,7 @@ if SPI_MCUX_LPSPI
 config SPI_MCUX_LPSPI_DMA
 	bool "MCUX LPSPI SPI DMA Support"
 	select DMA
+	select CACHE_MANAGEMENT if DCACHE
 	help
 	  Enable the SPI DMA mode for SPI instances
 	  that enable dma channels in their device tree node.


### PR DESCRIPTION
If data cache and DMA is enabled, we need to call the appropriate flush and invalidate cache functions.