### PR TITLE
nRF53 network CPU on-off management

### DIFF
--- a/boards/lairdconnect/bl5340_dvk/bl5340_dvk_nrf5340_cpunet_reset.c
+++ b/boards/lairdconnect/bl5340_dvk/bl5340_dvk_nrf5340_cpunet_reset.c
@@ -10,7 +10,7 @@
 #include <zephyr/logging/log.h>
 
 #include <soc.h>
-#include <hal/nrf_reset.h>
+#include <nrf53_cpunet_mgmt.h>
 
 LOG_MODULE_REGISTER(bl5340_dvk_cpuapp, CONFIG_LOG_DEFAULT_LEVEL);
 
@@ -50,7 +50,7 @@ static int remoteproc_mgr_boot(void)
 	 */
 
 	/* Release the Network MCU, 'Release force off signal' */
-	nrf_reset_network_force_off(NRF_RESET, false);
+	nrf53_cpunet_enable(true);
 
 	LOG_DBG("Network MCU released.");
 #endif /* !CONFIG_TRUSTED_EXECUTION_SECURE */

--- a/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_cpunet_reset.c
+++ b/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_cpunet_reset.c
@@ -9,7 +9,7 @@
 #include <zephyr/logging/log.h>
 
 #include <soc.h>
-#include <hal/nrf_reset.h>
+#include <nrf53_cpunet_mgmt.h>
 #include <hal/nrf_gpiote.h>
 
 LOG_MODULE_REGISTER(nrf5340_audio_dk_nrf5340_cpuapp, CONFIG_LOG_DEFAULT_LEVEL);
@@ -71,7 +71,7 @@ static int remoteproc_mgr_boot(void)
 	 */
 
 	/* Release the Network MCU, 'Release force off signal' */
-	nrf_reset_network_force_off(NRF_RESET, false);
+	nrf53_cpunet_enable(true);
 
 	LOG_DBG("Network MCU released.");
 #endif /* !CONFIG_TRUSTED_EXECUTION_SECURE */

--- a/boards/nordic/nrf5340dk/nrf5340_cpunet_reset.c
+++ b/boards/nordic/nrf5340dk/nrf5340_cpunet_reset.c
@@ -9,7 +9,7 @@
 #include <zephyr/logging/log.h>
 
 #include <soc.h>
-#include <hal/nrf_reset.h>
+#include <nrf53_cpunet_mgmt.h>
 
 LOG_MODULE_REGISTER(nrf5340dk_nrf5340_cpuapp, CONFIG_LOG_DEFAULT_LEVEL);
 
@@ -49,7 +49,7 @@ static int remoteproc_mgr_boot(void)
 	 */
 
 	/* Release the Network MCU, 'Release force off signal' */
-	nrf_reset_network_force_off(NRF_RESET, false);
+	nrf53_cpunet_enable(true);
 
 	LOG_DBG("Network MCU released.");
 #endif /* !CONFIG_TRUSTED_EXECUTION_SECURE */

--- a/boards/nordic/thingy53/board.c
+++ b/boards/nordic/thingy53/board.c
@@ -8,7 +8,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <soc.h>
-#include <hal/nrf_reset.h>
+#include <nrf53_cpunet_mgmt.h>
 
 LOG_MODULE_REGISTER(thingy53_board_init);
 
@@ -52,7 +52,7 @@ static void enable_cpunet(void)
 	 */
 
 	/* Release the Network MCU, 'Release force off signal' */
-	nrf_reset_network_force_off(NRF_RESET, false);
+	nrf53_cpunet_enable(true);
 
 	LOG_DBG("Network MCU released.");
 #endif /* !CONFIG_TRUSTED_EXECUTION_SECURE */

--- a/boards/panasonic/pan1783/pan1783_nrf5340_cpunet_reset.c
+++ b/boards/panasonic/pan1783/pan1783_nrf5340_cpunet_reset.c
@@ -9,7 +9,7 @@
 #include <zephyr/logging/log.h>
 
 #include <soc.h>
-#include <hal/nrf_reset.h>
+#include <nrf53_cpunet_mgmt.h>
 
 #if defined(CONFIG_BOARD_PAN1783_EVB_NRF5340_CPUAPP)
 LOG_MODULE_REGISTER(pan1783_evb_cpuapp, CONFIG_LOG_DEFAULT_LEVEL);
@@ -42,7 +42,7 @@ static int remoteproc_mgr_boot(void)
 	remoteproc_mgr_config();
 
 	/* Release the Network MCU, 'Release force off signal' */
-	nrf_reset_network_force_off(NRF_RESET, false);
+	nrf53_cpunet_enable(true);
 
 	LOG_DBG("Network MCU released.");
 

--- a/boards/raytac/mdbt53_db_40/raytac_mdbt53_db_40_nrf5340_cpunet_reset.c
+++ b/boards/raytac/mdbt53_db_40/raytac_mdbt53_db_40_nrf5340_cpunet_reset.c
@@ -10,6 +10,7 @@
 #include <zephyr/logging/log.h>
 
 #include <soc.h>
+#include <nrf53_cpunet_mgmt.h>
 
 LOG_MODULE_REGISTER(raytac_mdbt53_db_40_nrf5340_cpuapp, CONFIG_LOG_DEFAULT_LEVEL);
 
@@ -49,7 +50,7 @@ static int remoteproc_mgr_boot(const struct device *dev)
 	 */
 
 	/* Release the Network MCU, 'Release force off signal' */
-	NRF_RESET->NETWORK.FORCEOFF = RESET_NETWORK_FORCEOFF_FORCEOFF_Release;
+	nrf53_cpunet_enable(true);
 
 	LOG_DBG("Network MCU released.");
 #endif /* !CONFIG_TRUSTED_EXECUTION_SECURE */

--- a/boards/raytac/mdbt53v_db_40/raytac_mdbt53v_db_40_nrf5340_cpunet_reset.c
+++ b/boards/raytac/mdbt53v_db_40/raytac_mdbt53v_db_40_nrf5340_cpunet_reset.c
@@ -49,7 +49,7 @@ static int remoteproc_mgr_boot(const struct device *dev)
 	 */
 
 	/* Release the Network MCU, 'Release force off signal' */
-	NRF_RESET->NETWORK.FORCEOFF = RESET_NETWORK_FORCEOFF_FORCEOFF_Release;
+	nrf53_cpunet_enable(true);
 
 	LOG_DBG("Network MCU released.");
 #endif /* !CONFIG_TRUSTED_EXECUTION_SECURE */

--- a/drivers/bluetooth/hci/nrf53_support.c
+++ b/drivers/bluetooth/hci/nrf53_support.c
@@ -6,7 +6,7 @@
 
 #include <soc.h>
 #include <zephyr/device.h>
-#include <hal/nrf_reset.h>
+#include <nrf53_cpunet_mgmt.h>
 #if defined(CONFIG_BT_CTLR_DEBUG_PINS_CPUAPP)
 #include <../subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/debug.h>
 #else
@@ -21,7 +21,7 @@ int bt_hci_transport_teardown(const struct device *dev)
 {
 	ARG_UNUSED(dev);
     /* Put the Network MCU in Forced-OFF mode. */
-	nrf_reset_network_force_off(NRF_RESET, true);
+	nrf53_cpunet_enable(false);
 	LOG_DBG("Network MCU placed in Forced-OFF mode");
 
 	return 0;
@@ -43,7 +43,7 @@ int bt_hci_transport_setup(const struct device *dev)
 #endif /* !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) */
 
 	/* Release the Network MCU, 'Release force off signal' */
-	nrf_reset_network_force_off(NRF_RESET, false);
+	nrf53_cpunet_enable(true);
 
 	return 0;
 }

--- a/samples/subsys/ipc/ipc_service/icmsg/src/main.c
+++ b/samples/subsys/ipc/ipc_service/icmsg/src/main.c
@@ -8,7 +8,7 @@
 #include <zephyr/device.h>
 
 #include <zephyr/ipc/ipc_service.h>
-#include <hal/nrf_reset.h>
+#include <nrf53_cpunet_mgmt.h>
 #include <string.h>
 
 #include "common.h"
@@ -130,7 +130,7 @@ int main(void)
 	k_msleep(500);
 
 	LOG_INF("Stop network core");
-	nrf_reset_network_force_off(NRF_RESET, true);
+	nrf53_cpunet_enable(false);
 
 	LOG_INF("Reset IPC service");
 
@@ -158,7 +158,7 @@ int main(void)
 	}
 
 	LOG_INF("Run network core");
-	nrf_reset_network_force_off(NRF_RESET, false);
+	nrf53_cpunet_enable(true);
 
 	k_sem_take(&bound_sem, K_FOREVER);
 

--- a/soc/nordic/nrf53/CMakeLists.txt
+++ b/soc/nordic/nrf53/CMakeLists.txt
@@ -3,6 +3,7 @@
 zephyr_library_sources(soc.c)
 zephyr_include_directories(.)
 
+zephyr_library_sources_ifdef(CONFIG_SOC_NRF53_CPUNET_MGMT nrf53_cpunet_mgmt.c)
 zephyr_library_sources_ifdef(CONFIG_NRF53_SYNC_RTC sync_rtc.c)
 
 if (CONFIG_SOC_NRF53_ANOMALY_160_WORKAROUND_NEEDED AND

--- a/soc/nordic/nrf53/Kconfig
+++ b/soc/nordic/nrf53/Kconfig
@@ -24,6 +24,7 @@ config SOC_NRF5340_CPUAPP
 	select ARMV8_M_DSP
 	select HAS_POWEROFF
 	select SOC_COMPATIBLE_NRF5340_CPUAPP
+	select SOC_NRF53_CPUNET_MGMT
 	imply SOC_NRF53_RTC_PRETICK
 	imply SOC_NRF53_ANOMALY_168_WORKAROUND
 
@@ -137,6 +138,12 @@ config SOC_NRF_GPIO_FORWARDER_FOR_NRF5340
 	depends on NRF_SOC_SECURE_SUPPORTED
 	help
 	  hidden option for including the nRF GPIO pin forwarding
+
+config SOC_NRF53_CPUNET_MGMT
+	bool
+	select ONOFF
+	help
+	  hidden option for including the nRF53 network CPU management
 
 if !TRUSTED_EXECUTION_NONSECURE || BUILD_WITH_TFM
 

--- a/soc/nordic/nrf53/nrf53_cpunet_mgmt.c
+++ b/soc/nordic/nrf53/nrf53_cpunet_mgmt.c
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file Nordic Semiconductor nRF53 processors family management helper for the network CPU.
+ */
+
+#include <nrf53_cpunet_mgmt.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/init.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/notify.h>
+#include <zephyr/sys/onoff.h>
+
+#include <hal/nrf_reset.h>
+
+static struct onoff_manager cpunet_mgr;
+
+static void onoff_start(struct onoff_manager *mgr, onoff_notify_fn notify)
+{
+	nrf_reset_network_force_off(NRF_RESET, false);
+
+	notify(mgr, 0);
+}
+
+static void onoff_stop(struct onoff_manager *mgr, onoff_notify_fn notify)
+{
+	nrf_reset_network_force_off(NRF_RESET, true);
+
+	notify(mgr, 0);
+}
+
+static int nrf53_cpunet_mgmt_init(void)
+{
+	static const struct onoff_transitions transitions = {
+		.start = onoff_start,
+		.stop = onoff_stop
+	};
+
+	return onoff_manager_init(&cpunet_mgr, &transitions);
+}
+
+SYS_INIT(nrf53_cpunet_mgmt_init, PRE_KERNEL_1, 0);
+
+void nrf53_cpunet_enable(bool on)
+{
+	int ret;
+	int ignored;
+	struct onoff_client cli;
+
+	if (on) {
+		sys_notify_init_spinwait(&cli.notify);
+
+		ret = onoff_request(&cpunet_mgr, &cli);
+		__ASSERT_NO_MSG(ret >= 0);
+
+		/* The transition is synchronous and shall take effect immediately. */
+		ret = sys_notify_fetch_result(&cli.notify, &ignored);
+	} else {
+		ret = onoff_release(&cpunet_mgr);
+	}
+
+	__ASSERT_NO_MSG(ret >= 0);
+}

--- a/soc/nordic/nrf53/nrf53_cpunet_mgmt.h
+++ b/soc/nordic/nrf53/nrf53_cpunet_mgmt.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file Nordic Semiconductor nRF53 processors family management helper for the network CPU.
+ */
+
+#ifndef NRF53_CPUNET_MGMT_H__
+#define NRF53_CPUNET_MGMT_H__
+
+#include <stdbool.h>
+
+/**
+ * @brief Enables or disables nRF53 network CPU.
+ *
+ * This function shall be used to control the network CPU exclusively. Internally, it keeps track of
+ * the requests to enable or disable nRF53 network CPU. It guarantees to enable the network CPU if
+ * at least one user requests it and to keep it enabled until all users release it.
+ *
+ * In conseqeuence, if @p on equals @c true then the network CPU is guaranteed to be enabled when
+ * this function returns. If @p on equals @c false then nothing can be inferred about the state of
+ * the network CPU when the function returns.
+ *
+ * @param on indicates whether the network CPU shall be powered on or off.
+ */
+void nrf53_cpunet_enable(bool on);
+
+#endif /* NRF53_CPUNET_MGMT_H__ */


### PR DESCRIPTION
This PR addresses the problem of safely sharing nRF53 network CPU as a shared resource used by multiple users on the application CPU. The current solution, where every user controls the network CPU directly, scales poorly and leads to hidden dependencies between those users.