### PR TITLE
posix: eventfd: Fix unsetting internal flags in ioctl

### DIFF
--- a/lib/posix/options/eventfd.c
+++ b/lib/posix/options/eventfd.c
@@ -247,7 +247,9 @@ static int eventfd_ioctl_op(void *obj, unsigned int request, va_list args)
 			errno = EINVAL;
 			ret = -1;
 		} else {
-			efd->flags = flags;
+			int prev_flags = efd->flags & ~EFD_FLAGS_SET_INTERNAL;
+
+			efd->flags = flags | prev_flags;
 			ret = 0;
 		}
 	} break;

--- a/tests/posix/eventfd/src/ioctl.c
+++ b/tests/posix/eventfd/src/ioctl.c
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2024 Celina Sophie Kalus
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "_main.h"
+#include <zephyr/posix/sys/ioctl.h>
+
+#define EFD_IN_USE_INTERNAL 0x1
+
+ZTEST_F(eventfd, test_set_flags)
+{
+	eventfd_t val;
+	int ret;
+	int flags;
+	short event;
+
+	/* Get current flags; Expect blocking, non-semaphore. */
+	flags = ioctl(fixture->fd, F_GETFL, 0);
+	zassert_equal(flags, 0, "flags == %d", flags);
+
+	event = POLLIN;
+	ret = is_blocked(fixture->fd, &event);
+	zassert_equal(ret, 1, "eventfd read not blocked");
+
+	/* Try writing and reading. Should not fail. */
+	ret = eventfd_write(fixture->fd, 3);
+	zassert_ok(ret);
+
+	ret = eventfd_read(fixture->fd, &val);
+	zassert_ok(ret);
+	zassert_equal(val, 3, "val == %d", val);
+
+
+	/* Set nonblocking without reopening. */
+	ret = ioctl(fixture->fd, F_SETFL, O_NONBLOCK);
+	zassert_ok(ret);
+
+	flags = ioctl(fixture->fd, F_GETFL, 0);
+	zassert_equal(flags, O_NONBLOCK, "flags == %d", flags);
+
+	event = POLLOUT;
+	ret = is_blocked(fixture->fd, &event);
+	zassert_equal(ret, 0, "eventfd write blocked");
+
+
+	/* Try writing and reading again. */
+	ret = eventfd_write(fixture->fd, 19);
+	zassert_ok(ret);
+
+	ret = eventfd_read(fixture->fd, &val);
+	zassert_ok(ret);
+	zassert_equal(val, 19, "val == %d", val);
+
+
+	/* Set back to blocking. */
+	ret = ioctl(fixture->fd, F_SETFL, 0);
+	zassert_ok(ret);
+
+	flags = ioctl(fixture->fd, F_GETFL, 0);
+	zassert_equal(flags, 0, "flags == %d", flags);
+
+	event = POLLIN;
+	ret = is_blocked(fixture->fd, &event);
+	zassert_equal(ret, 1, "eventfd read not blocked");
+
+
+	/* Try writing and reading again. */
+	ret = eventfd_write(fixture->fd, 10);
+	zassert_ok(ret);
+
+	ret = eventfd_read(fixture->fd, &val);
+	zassert_ok(ret);
+	zassert_equal(val, 10, "val == %d", val);
+
+
+	/* Test setting internal in-use-flag. Should fail. */
+	ret = ioctl(fixture->fd, F_SETFL, EFD_IN_USE_INTERNAL);
+	zassert_not_ok(ret);
+
+
+	/* File descriptor should still be valid and working. */
+	ret = eventfd_write(fixture->fd, 97);
+	zassert_ok(ret);
+
+	ret = eventfd_read(fixture->fd, &val);
+	zassert_ok(ret);
+	zassert_equal(val, 97, "val == %d", val);
+}


### PR DESCRIPTION
Commit e6eb0a705bc8 ("posix: eventfd: revise locking, signaling, and allocation") introduced a regression where the internal flags of an event file descriptor would be erased when calling the F_SETFL ioctl operation.

This includes the flag EFD_IN_USE_INTERNAL which determines whether this file descriptor has been opened, thus effectively closing the eventfd whenever one tries to change a flag.

Fixes #71399 