### PR TITLE
drivers: interrupt_controller: enable PINT-irq when deepsleep is not used

### DIFF
--- a/drivers/interrupt_controller/intc_nxp_pint.c
+++ b/drivers/interrupt_controller/intc_nxp_pint.c
@@ -99,6 +99,7 @@ int nxp_pint_pin_enable(uint8_t pin, enum nxp_pint_trigger trigger, bool wake)
 		EnableDeepSleepIRQ(pint_irq_cfg[slot].irq);
 	} else {
 		DisableDeepSleepIRQ(pint_irq_cfg[slot].irq);
+		irq_enable(pint_irq_cfg[slot].irq);
 	}
 #endif
 	return 0;


### PR DESCRIPTION
DisableDeepSleepIRQ() disables the NVIC irq, while PINT need it to fire an event when the interrupt is used. So while the interrupt is not used in DeepSleep mode, it should still be available to be used.

fixes #71345 