### PR TITLE
Regulator single threaded sleep clean up

### DIFF
--- a/drivers/regulator/regulator_common.c
+++ b/drivers/regulator/regulator_common.c
@@ -10,11 +10,7 @@
 static void regulator_delay(uint32_t delay_us)
 {
 	if (delay_us > 0U) {
-#ifdef CONFIG_MULTITHREADING
 		k_sleep(K_USEC(delay_us));
-#else
-		k_busy_wait(delay_us);
-#endif
 	}
 }
 

--- a/drivers/regulator/regulator_cp9314.c
+++ b/drivers/regulator/regulator_cp9314.c
@@ -338,11 +338,7 @@ static int cp9314_do_soft_reset(const struct device *dev)
 		return ret;
 	}
 
-#ifdef CONFIG_MULTITHREADING
 	k_msleep(CP9314_SOFT_RESET_DELAY_MSEC);
-#else
-	k_busy_wait(CP9314_SOFT_RESET_DELAY_MSEC * USEC_PER_MSEC);
-#endif
 
 	return 0;
 }
@@ -421,11 +417,7 @@ static int regulator_cp9314_init(const struct device *dev)
 			return ret;
 		}
 
-#ifdef CONFIG_MULTITHREADING
 		k_usleep(CP9314_EN_DEBOUNCE_USEC);
-#else
-		k_busy_wait(CP9314_EN_DEBOUNCE_USEC);
-#endif
 	}
 
 	ret = cp9314_do_soft_reset(dev);


### PR DESCRIPTION
The regulator subsystem is required to support single and multithreaded platforms.

#63994 eliminates the need to use conditional preprocessor directives to call `k_busy_wait` on single threaded platforms.