### PR TITLE
drivers: wifi: esp_at: fix missing channel in scan result

### DIFF
--- a/drivers/wifi/esp_at/esp.c
+++ b/drivers/wifi/esp_at/esp.c
@@ -382,6 +382,8 @@ MODEM_CMD_DIRECT_DEFINE(on_cmd_cwlap)
 		return err;
 	}
 
+	res.channel = strtol(channel, NULL, 10);
+
 	if (dev->scan_cb) {
 		dev->scan_cb(dev->net_iface, 0, &res);
 	}


### PR DESCRIPTION
WiFi scan results were not updated with information about channel, after
scan results parsing was updated. Fix that.

Fixes: a6b06004c221 ("drivers: wifi: esp_at: handle commas in SSIDs during
  scan and status")