### PR TITLE
Revert "ipc: intel_adsp: Ensure IPC completion before runtime idle"

### DIFF
--- a/soc/intel/intel_adsp/common/ipc.c
+++ b/soc/intel/intel_adsp/common/ipc.c
@@ -10,7 +10,6 @@
 #include <zephyr/pm/state.h>
 #include <zephyr/pm/pm.h>
 #include <zephyr/pm/device.h>
-#include <zephyr/pm/policy.h>
 #include <errno.h>
 
 void intel_adsp_ipc_set_message_handler(const struct device *dev,
@@ -74,10 +73,6 @@ void z_intel_adsp_ipc_isr(const void *devarg)
 			external_completion = devdata->done_notify(dev, devdata->done_arg);
 		}
 		devdata->tx_ack_pending = false;
-		/* Allow the system to enter the runtime idle state after the IPC acknowledgment
-		 * is received.
-		 */
-		pm_policy_state_lock_get(PM_STATE_RUNTIME_IDLE, PM_ALL_SUBSTATES);
 		k_sem_give(&devdata->sem);
 
 		/* IPC completion registers will be set externally */
@@ -159,8 +154,6 @@ int intel_adsp_ipc_send_message(const struct device *dev,
 	}
 
 	k_sem_init(&devdata->sem, 0, 1);
-	/* Prevent entering runtime idle state until IPC acknowledgment is received. */
-	pm_policy_state_lock_put(PM_STATE_RUNTIME_IDLE, PM_ALL_SUBSTATES);
 	devdata->tx_ack_pending = true;
 	config->regs->idd = ext_data;
 	config->regs->idr = data | INTEL_ADSP_IPC_BUSY;


### PR DESCRIPTION
This reverts commit d5897a48aaab546751a6a5bb71cf4d441c229c1c.

Following error is hit with this commit:
--cut--
ASSERTION FAIL [cnt >= 1] @ ZEPHYR_BASE/subsys/pm/policy.c:225
        Unbalanced state lock get/put
--cut--

This is seen in SOF tests where pm_policy_state_lock_get() is called to handle SOF_IPC4_MOD_SET_D0IX IPC message.