### PR TITLE
drivers: dai: intel: ssp: fix LOG_ERR level / false positive

### DIFF
--- a/drivers/dai/intel/ssp/ssp.c
+++ b/drivers/dai/intel/ssp/ssp.c
@@ -1764,7 +1764,7 @@ static void dai_ssp_set_reg_config(struct dai_intel_ssp *dp, const struct dai_co
 	ssrsa = SSRSA_GET(regs->ssrsa);
 	sscr1 = regs->ssc1 & ~(SSCR1_RSRE | SSCR1_TSRE);
 
-	LOG_ERR("SSP%d configuration:", dp->index);
+	LOG_INF("SSP%d configuration:", dp->index);
 	if (regs->sstsa & SSTSA_TXEN || regs->ssrsa & SSRSA_RXEN ||
 	    regs->ssc1 & (SSCR1_RSRE | SSCR1_TSRE)) {
 		LOG_INF(" Ignoring %s%s%s%sfrom blob",


### PR DESCRIPTION
There's no way this log level was intentional: this line is just the title / prefix of a multi-line section with mostly LOG_INF statements.

Fixes commit 6423bc3bc885 ("drivers: dai: intel: ssp: Improve logging output") which was very large hence error-prone.

Fixes SOF bug https://github.com/thesofproject/sof/issues/9026