### PR TITLE
soc: esp32c3: add `__text_region_start` & `__text_region_end`

### DIFF
--- a/soc/espressif/esp32c3/default.ld
+++ b/soc/espressif/esp32c3/default.ld
@@ -743,6 +743,7 @@ SECTIONS
   {
     _stext = .;
     _instruction_reserved_start = ABSOLUTE(.);
+    __text_region_start = .;
     _text_start = ABSOLUTE(.);
     _instruction_reserved_start = ABSOLUTE(.);
 
@@ -774,6 +775,7 @@ SECTIONS
 
     _instruction_reserved_end = ABSOLUTE(.);
     _text_end = ABSOLUTE(.);
+    __text_region_end = .;
     _instruction_reserved_end = ABSOLUTE(.);
     _etext = .;
 

--- a/soc/espressif/esp32c3/mcuboot.ld
+++ b/soc/espressif/esp32c3/mcuboot.ld
@@ -133,6 +133,7 @@ SECTIONS
     . += 16;
 
     _text_end = ABSOLUTE(.);
+    __text_region_end = .;
     _etext = .;
 
     /* Similar to _iram_start, this symbol goes here so it is


### PR DESCRIPTION
Add these to the esp32c3 linker scripts to make the implementations consistent across for RISCV SOCs.

This is spinned off from #69912