### PR TITLE
drivers: serial: nrf: Adapt config dependencies to nrf54h20

### DIFF
--- a/drivers/serial/Kconfig.nrfx_uart_instance
+++ b/drivers/serial/Kconfig.nrfx_uart_instance
@@ -87,7 +87,7 @@ config UART_$(nrfx_uart_num)_TX_CACHE_SIZE
 config UART_$(nrfx_uart_num)_RX_CACHE_SIZE
 	int "RX cache buffer size"
 	depends on !UART_NRFX_UARTE_LEGACY_SHIM
-	default 32 if $(dt_nodelabel_has_compat,ram3x,$(DT_COMPAT_MMIO_SRAM))
+	default 32 if $(dt_nodelabel_has_compat,shared_ram3x_region,$(DT_COMPAT_NORDIC_OWNED_MEMORY))
 	default 5
 	range 5 255
 	help

--- a/modules/hal_nordic/nrfx/Kconfig
+++ b/modules/hal_nordic/nrfx/Kconfig
@@ -886,7 +886,7 @@ config NRFX_UARTE_CONFIG_TX_LINK
 
 config NRFX_UARTE_CONFIG_RX_CACHE_ENABLED
 	bool "UARTE RX caching support"
-	default y if $(dt_nodelabel_has_compat,ram3x,$(DT_COMPAT_MMIO_SRAM))
+	default y if $(dt_nodelabel_has_compat,shared_ram3x_region,$(DT_COMPAT_NORDIC_OWNED_MEMORY))
 	depends on NRFX_UARTE
 	help
 	  Feature might be enabled on platforms which has limitations regarding addresses


### PR DESCRIPTION
DT nodes and compatible had been renamed and Kconfig option was relying on the names that do not exists.