### PR TITLE
ieee802154: document expected behavior for invalid ACKs

### DIFF
--- a/include/zephyr/net/ieee802154_radio.h
+++ b/include/zephyr/net/ieee802154_radio.h
@@ -1670,7 +1670,7 @@ struct ieee802154_radio_api {
 	 * @retval -EBUSY The frame could not be sent because the medium was
 	 * busy (CSMA/CA or CCA offloading feature only).
 	 * @retval -ENOMSG The frame was not confirmed by an ACK packet (TX ACK
-	 * offloading feature only).
+	 * offloading feature only) or the received ACK packet was invalid.
 	 * @retval -ENOBUFS The frame could not be scheduled due to missing
 	 * internal resources (timed TX offloading feature only).
 	 * @retval -ENETDOWN The interface is not "UP".


### PR DESCRIPTION
Extend ieee802154 transmit function documentation with the expected return code for correctly received invalid ACK packets.

Addresses https://github.com/zephyrproject-rtos/zephyr/pull/69388#issuecomment-2045201899