### PR TITLE
boards: nrf54l15pdk_nrf54l15_cpuapp: add twister yaml for PDK 0.3.0

### DIFF
--- a/boards/nordic/nrf54l15pdk/nrf54l15pdk_nrf54l15_cpuapp_0_3_0.yaml
+++ b/boards/nordic/nrf54l15pdk/nrf54l15pdk_nrf54l15_cpuapp_0_3_0.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+identifier: nrf54l15pdk@0.3.0/nrf54l15/cpuapp
+name: nRF54l15-PDK-nRF54l15-Application
+type: mcu
+arch: arm
+toolchain:
+  - gnuarmemb
+  - xtools
+  - zephyr
+ram: 256
+flash: 1536
+supported:
+  - counter
+  - gpio
+  - i2c
+  - spi
+  - watchdog
+  - i2s


### PR DESCRIPTION
add twister yaml to support PDK 0.3.0 in tests