### PR TITLE
mgmt: smp: fix smp client with shell transport

### DIFF
--- a/subsys/mgmt/mcumgr/transport/src/smp_shell.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp_shell.c
@@ -242,7 +242,7 @@ int smp_shell_init(void)
 	rc = smp_transport_init(&smp_shell_transport);
 #ifdef CONFIG_SMP_CLIENT
 	if (rc == 0) {
-		smp_client_transport.smpt = &CONFIG_SMP_CLIENT;
+		smp_client_transport.smpt = &smp_shell_transport;
 		smp_client_transport.smpt_type = SMP_SHELL_TRANSPORT;
 		smp_client_transport_register(&smp_client_transport);
 	}


### PR DESCRIPTION
Fixing an issue in mcumgr shell transport when SMP client support is enabled.

The build would fail if both are enabled, for example:

```
$ west build -b nrf52840dk_nrf52840 zephyr/samples/subsys/mgmt/mcumgr/smp_svr/ -DOVERLAY_CONFIG="overlay-shell.conf" -DCONFIG_SMP_CLIENT=y

[...]

zephyr/subsys/mgmt/mcumgr/transport/src/smp_shell.c: In function 'smp_shell_init':
zephyr/subsys/mgmt/mcumgr/transport/src/smp_shell.c:245:45: error: lvalue required as unary '&' operand
  245 |                 smp_client_transport.smpt = &CONFIG_SMP_CLIENT;
      |                                             ^
```

Note that I didn't actually test SMP client working over the shell, in my case the client uses the UART and the server would use the shell.