### PR TITLE
Fix LLVM fuzzer sample for native_sim

### DIFF
--- a/arch/posix/CMakeLists.txt
+++ b/arch/posix/CMakeLists.txt
@@ -176,6 +176,7 @@ endif()
 
 if(CONFIG_ARCH_POSIX_LIBFUZZER)
   list(APPEND LLVM_SANITIZERS "fuzzer")
+  target_compile_options(native_simulator INTERFACE "-DNSI_NO_MAIN=1")
   if(NOT CONFIG_64BIT)
     # On i386, libfuzzer seems to dynamically relocate the binary, so
     # we need to emit PIC code.  This limitation is undocumented and

--- a/arch/posix/Kconfig
+++ b/arch/posix/Kconfig
@@ -27,7 +27,7 @@ menuconfig ARCH_POSIX_LIBFUZZER
 	help
 	  Build the posix app as a LLVM libfuzzer target.  Requires
 	  support from the toolchain (currently only clang works, and
-	  only on native_posix/native/64), and should normally be used in
+	  only on native_{posix,sim}[//64]), and should normally be used in
 	  concert with some of CONFIG_ASAN/UBSAN/MSAN for validation.
 	  The application needs to implement the
 	  LLVMFuzzerTestOneInput() entry point, which runs in the host

--- a/arch/posix/Kconfig
+++ b/arch/posix/Kconfig
@@ -22,10 +22,10 @@ config ARCH_POSIX_RECOMMENDED_STACK_SIZE
 	  thread stack, the real stack is the native underlying pthread stack.
 	  Therefore the allocated stack can be limited to this size)
 
-menuconfig ARCH_POSIX_LIBFUZZER
+config ARCH_POSIX_LIBFUZZER
 	bool "Build fuzz test target"
 	help
-	  Build the posix app as a LLVM libfuzzer target.  Requires
+	  Build as an LLVM libfuzzer target. Requires
 	  support from the toolchain (currently only clang works, and
 	  only on native_{posix,sim}[//64]), and should normally be used in
 	  concert with some of CONFIG_ASAN/UBSAN/MSAN for validation.
@@ -34,28 +34,6 @@ menuconfig ARCH_POSIX_LIBFUZZER
 	  environment "outside" the OS.  See Zephyr documentation and
 	  sample and https://llvm.org/docs/LibFuzzer.html for more
 	  information.
-
-if ARCH_POSIX_LIBFUZZER
-
-config ARCH_POSIX_FUZZ_IRQ
-	int "OS interrupt via which to deliver fuzz cases"
-	default 3
-	help
-	  When using libfuzzer, new fuzz cases are delivered to Zephyr
-	  via interrupts.  The IRQ should be otherwise unused, but can
-	  be any value desired by the app.
-
-config ARCH_POSIX_FUZZ_TICKS
-	int "Ticks to allow for fuzz case processing"
-	default 2
-	help
-	  Fuzz interrupts are delivered, from the perspective of the
-	  OS, at a steady cadence in simulated time.  In general most
-	  apps won't require much time to reach an idle state
-	  following a unit-test style case, so the default is short to
-	  prevent interaction with regular timer workloads.
-
-endif # CONFIG_ARCH_POSIX_LIBFUZZER
 
 config ARCH_POSIX_TRAP_ON_FATAL
 	bool "Raise a SIGTRAP on fatal error"

--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -317,5 +317,11 @@ Architectures
     are deprecated. Use :kconfig:option:`CONFIG_X86_DISABLE_SSBD` and
     :kconfig:option:`CONFIG_X86_ENABLE_EXTENDED_IBRS` instead.
 
+* POSIX arch:
+
+  * LLVM fuzzing support has been refactored. A test application now needs to provide its own
+    ``LLVMFuzzerTestOneInput()`` hook instead of relying on a board provided one. Check
+    ``samples/subsys/debug/fuzz/`` for an example.
+
 Xtensa
 ======

--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -86,6 +86,8 @@ Boards & SoC Support
 
 * Made these changes for native/POSIX boards:
 
+  * LLVM fuzzing support has been refactored while adding support for it in native_sim.
+
 * Added support for these following shields:
 
 Build system and Infrastructure

--- a/samples/subsys/debug/fuzz/Kconfig
+++ b/samples/subsys/debug/fuzz/Kconfig
@@ -1,0 +1,22 @@
+# Copyright (c) 2017 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+config ARCH_POSIX_FUZZ_IRQ
+	int "OS interrupt via which to deliver fuzz cases"
+	default 31
+	help
+	  In this sample, new fuzz cases are delivered to Zephyr
+	  via interrupts.  The IRQ should be otherwise unused, but can
+	  be any value desired by the app.
+
+config ARCH_POSIX_FUZZ_TICKS
+	int "Ticks to allow for fuzz case processing"
+	default 2
+	help
+	  Fuzz interrupts are delivered, from the perspective of the
+	  OS, at a steady cadence in simulated time.  In general most
+	  apps won't require much time to reach an idle state
+	  following a unit-test style case, so the default is short to
+	  prevent interaction with regular timer workloads.
+
+source "Kconfig.zephyr"

--- a/samples/subsys/debug/fuzz/README.rst
+++ b/samples/subsys/debug/fuzz/README.rst
@@ -24,7 +24,7 @@ toolchain is installed in your host environment, and build with:
    Thread model: posix
    InstalledDir: /usr/bin
    $ export ZEPHYR_TOOLCHAIN_VARIANT=llvm
-   $ west build -t run -b native_posix/native/64 samples/subsys/debug/fuzz
+   $ west build -t run -b native_sim/native/64 samples/subsys/debug/fuzz
 
 Over 10-20 seconds or so (runtimes can be quite variable) you will see
 it discover and recurse deeper into the test's deliberately
@@ -43,7 +43,7 @@ Example output:
    INFO: Loaded 1 PC tables (2112 PCs): 2112 [0x55cbe336f498,0x55cbe3377898),
    INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 4096 bytes
    *** Booting Zephyr OS build zephyr-v3.1.0-3976-g806034e02865  ***
-   Hello World! native_posix/native/64
+   Hello World! native_sim/native/64
    INFO: A corpus is not provided, starting from an empty corpus
    #2	INITED cov: 101 ft: 102 corp: 1/1b exec/s: 0 rss: 30Mb
    #

--- a/scripts/native_simulator/common/src/include/nsi_main_semipublic.h
+++ b/scripts/native_simulator/common/src/include/nsi_main_semipublic.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef NSI_COMMON_SRC_INCL_NSI_MAIN_SEMIPUBLIC_H
+#define NSI_COMMON_SRC_INCL_NSI_MAIN_SEMIPUBLIC_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * These APIs are exposed for special use cases in which a developer needs to
+ * replace the native simulator main loop.
+ * An example of such a case is LLVMs fuzzing support. For this one sets
+ * NSI_NO_MAIN, and provides an specialized main() or hooks into the tooling
+ * provided main().
+ *
+ * These APIs should be used with care, and not be used when the native
+ * simulator main() is built in.
+ *
+ * Check nsi_main.c for more information.
+ */
+
+void nsi_init(int argc, char *argv[]);
+void nsi_exec_for(uint64_t us);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NSI_COMMON_SRC_INCL_NSI_MAIN_SEMIPUBLIC_H */


### PR DESCRIPTION
Get the fuzzer sample working on native_sim[//64]

Move the LLVM fuzzing specific code out of the board main file and into the sample.
That way we avoid needing to duplicate it for native_sim and avoid having a very adhoc interface between the fuzzer test
and runner code.

Note that the plan is to deprecate native_posix in 4.0 and remove it in 4.1 the ifdef'ing in the sample for native_posix will disappear at that time.
