### PR TITLE
sysbuild: cmake: fix sysbuild_cache_set() function

### DIFF
--- a/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
@@ -615,9 +615,7 @@ function(sysbuild_cache_set)
     # Search for these exact items in the existing value and prevent adding
     # them if they are already present which avoids issues with double addition
     # when cmake is reran.
-    string(FIND "$CACHE{${VARS_VAR}}" "${VARS_UNPARSED_ARGUMENTS}" index)
-
-    if(NOT ${index} EQUAL -1)
+    if("${VARS_UNPARSED_ARGUMENTS}" IN_LIST var_new)
       return()
     endif()
 


### PR DESCRIPTION
The sysbuild_cache_set() supports setting variables in a dedicated sysbuild image cache. When appending to a list, the list is checked for existance of the variable to avoid appending it again on reruns.

This was done be checking with `string(FIND ...)`, but that will also return an index on a partial match.

A much safer approach is to use the `if(<val> IN_LIST <list>)` approach to check for existance.