### PR TITLE
samples: bluetooth: Increase sync timeout to allow packet loss

### DIFF
--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -2058,7 +2058,7 @@ struct bt_le_scan_recv_info {
 	uint16_t adv_props;
 
 	/**
-	 * @brief Periodic advertising interval.
+	 * @brief Periodic advertising interval (N * 1.25 ms).
 	 *
 	 * If 0 there is no periodic advertising.
 	 */

--- a/samples/bluetooth/central_past/src/main.c
+++ b/samples/bluetooth/central_past/src/main.c
@@ -16,6 +16,7 @@ static bool per_adv_found;
 static bt_addr_le_t per_addr;
 static uint8_t per_sid;
 static struct bt_conn *default_conn;
+static uint32_t per_adv_interval_ms;
 
 static K_SEM_DEFINE(sem_conn, 0, 1);
 static K_SEM_DEFINE(sem_conn_lost, 0, 1);
@@ -105,6 +106,7 @@ static void scan_recv(const struct bt_le_scan_recv_info *info,
 		/* If info->interval it is a periodic advertiser, mark for sync */
 		if (!per_adv_found && info->interval) {
 			per_adv_found = true;
+			per_adv_interval_ms = BT_GAP_PER_ADV_INTERVAL_TO_MS(info->interval);
 
 			per_sid = info->sid;
 			bt_addr_le_copy(&per_addr, info->addr);
@@ -293,7 +295,7 @@ int main(void)
 		sync_create_param.options = 0;
 		sync_create_param.sid = per_sid;
 		sync_create_param.skip = 0;
-		sync_create_param.timeout = 0xaa;
+		sync_create_param.timeout = per_adv_interval_ms * 10 / 10; /* 10 attempts */
 		err = bt_le_per_adv_sync_create(&sync_create_param, &sync);
 		if (err != 0) {
 			printk("failed (err %d)\n", err);

--- a/samples/bluetooth/direction_finding_connectionless_rx/src/main.c
+++ b/samples/bluetooth/direction_finding_connectionless_rx/src/main.c
@@ -263,7 +263,7 @@ static void create_sync(void)
 	sync_create_param.options = BT_LE_PER_ADV_SYNC_OPT_SYNC_ONLY_CONST_TONE_EXT;
 	sync_create_param.sid = per_sid;
 	sync_create_param.skip = 0;
-	sync_create_param.timeout = 0xaa;
+	sync_create_param.timeout = sync_create_timeout_ms * 10 / 10; /* 10 attempts */
 	err = bt_le_per_adv_sync_create(&sync_create_param, &adv_sync);
 	if (err != 0) {
 		printk("failed (err %d)\n", err);

--- a/samples/bluetooth/periodic_sync/src/main.c
+++ b/samples/bluetooth/periodic_sync/src/main.c
@@ -14,6 +14,7 @@
 
 static bool         per_adv_found;
 static bt_addr_le_t per_addr;
+static uint32_t     per_adv_interval_ms;
 static uint8_t      per_sid;
 
 static K_SEM_DEFINE(sem_per_adv, 0, 1);
@@ -97,6 +98,7 @@ static void scan_recv(const struct bt_le_scan_recv_info *info,
 
 	if (!per_adv_found && info->interval) {
 		per_adv_found = true;
+		per_adv_interval_ms = BT_GAP_PER_ADV_INTERVAL_TO_MS(info->interval);
 
 		per_sid = info->sid;
 		bt_addr_le_copy(&per_addr, info->addr);
@@ -233,7 +235,7 @@ int main(void)
 		sync_create_param.options = 0;
 		sync_create_param.sid = per_sid;
 		sync_create_param.skip = 0;
-		sync_create_param.timeout = 0xaa;
+		sync_create_param.timeout = per_adv_interval_ms * 10 / 10; /* 10 attempts */
 		err = bt_le_per_adv_sync_create(&sync_create_param, &sync);
 		if (err) {
 			printk("failed (err %d)\n", err);


### PR DESCRIPTION
The periodic advertiser samples use a periodic advertising interval in the range of 1 to 1.2 seconds.

Previously the sync timeout of 1.7 seconds would cause the sync to be lost after failing to receive a single periodic advertising packet. This change therefore aims to improve the user experience.