### PR TITLE
soc: nordic: nrf54h: Remove redundant ICACHE Kconfig and add enabling DCACHE

### DIFF
--- a/soc/nordic/nrf54h/Kconfig
+++ b/soc/nordic/nrf54h/Kconfig
@@ -31,11 +31,3 @@ config SOC_NRF54H20_CPURAD
 
 config SOC_NRF54H20_CPUPPR
 	depends on RISCV_CORE_NORDIC_VPR
-
-if SOC_NRF54H20
-
-config NRF_ENABLE_ICACHE
-	bool "Instruction cache (I-Cache)"
-	default y
-
-endif # SOC_NRF54H20

--- a/soc/nordic/nrf54h/soc.c
+++ b/soc/nordic/nrf54h/soc.c
@@ -82,9 +82,7 @@ static int trim_hsfll(void)
 
 static int nordicsemi_nrf54h_init(void)
 {
-#if defined(CONFIG_NRF_ENABLE_ICACHE)
 	sys_cache_instr_enable();
-#endif
 
 	power_domain_init();
 

--- a/soc/nordic/nrf54h/soc.c
+++ b/soc/nordic/nrf54h/soc.c
@@ -83,6 +83,7 @@ static int trim_hsfll(void)
 static int nordicsemi_nrf54h_init(void)
 {
 	sys_cache_instr_enable();
+	sys_cache_data_enable();
 
 	power_domain_init();
 


### PR DESCRIPTION
DCACHE is by default enabled for nrf54h20.