### PR TITLE
llext: document positive return values of llext_load()

### DIFF
--- a/include/zephyr/llext/llext.h
+++ b/include/zephyr/llext/llext.h
@@ -141,6 +141,7 @@ struct llext_load_param {
  * @param[in] ldr_parm Loader parameters
  *
  * @retval 0 Success
+ * @retval > 0 extension use count
  * @retval -ENOMEM Not enough memory
  * @retval -EINVAL Invalid ELF stream
  */


### PR DESCRIPTION
llext_load() can return positive values when the respective llext use count is positive. Add the missing documentation.