### PR TITLE
scripts: twister: Isolate statuses into a separate class

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -342,7 +342,7 @@ class BinaryHandler(Handler):
             proc.wait()
             self.returncode = proc.returncode
             if proc.returncode != 0:
-                self.instance.status = "error"
+                self.instance.status = TwisterStatus.ERROR
                 self.instance.reason = "BinaryHandler returned {}".format(proc.returncode)
             self.try_kill_process_by_pid()
 

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -18,6 +18,7 @@ import json
 from twisterlib.error import ConfigurationError
 from twisterlib.environment import ZEPHYR_BASE, PYTEST_PLUGIN_INSTALLED
 from twisterlib.handlers import Handler, terminate_process, SUPPORTED_SIMS_IN_PYTEST
+from twisterlib.statuses import HarnessStatus, ReportStatus, TestCaseStatus, TestInstanceStatus
 from twisterlib.testinstance import TestInstance
 
 
@@ -38,14 +39,14 @@ class Harness:
 
 
     ztest_to_status = {
-        'PASS': 'passed',
-        'SKIP': 'skipped',
-        'BLOCK': 'blocked',
-        'FAIL': 'failed'
+        'PASS': TestCaseStatus.PASS,
+        'SKIP': TestCaseStatus.SKIP,
+        'BLOCK': TestCaseStatus.BLOCK,
+        'FAIL': TestCaseStatus.FAIL
         }
 
     def __init__(self):
-        self.state = None
+        self.state = HarnessStatus.NONE
         self.reason = None
         self.type = None
         self.regex = []
@@ -132,13 +133,13 @@ class Harness:
 
         if self.RUN_PASSED in line:
             if self.fault:
-                self.state = "failed"
+                self.state = HarnessStatus.FAIL
                 self.reason = "Fault detected while running test"
             else:
-                self.state = "passed"
+                self.state = HarnessStatus.PASS
 
         if self.RUN_FAILED in line:
-            self.state = "failed"
+            self.state = HarnessStatus.FAIL
             self.reason = "Testsuite failed"
 
         if self.fail_on_fault:
@@ -169,9 +170,9 @@ class Robot(Harness):
             handle is trying to give a PASS or FAIL to avoid timeout, nothing
             is writen into handler.log
         '''
-        self.instance.state = "passed"
+        self.instance.state = TestInstanceStatus.PASS
         tc = self.instance.get_case_or_create(self.id)
-        tc.status = "passed"
+        tc.status = TestCaseStatus.PASS
 
     def run_robot_test(self, command, handler):
         start_time = time.time()
@@ -202,16 +203,16 @@ class Robot(Harness):
             self.instance.execution_time = time.time() - start_time
 
             if renode_test_proc.returncode == 0:
-                self.instance.status = "passed"
+                self.instance.status = TestInstanceStatus.PASS
                 # all tests in one Robot file are treated as a single test case,
                 # so its status should be set accordingly to the instance status
                 # please note that there should be only one testcase in testcases list
-                self.instance.testcases[0].status = "passed"
+                self.instance.testcases[0].status = TestCaseStatus.PASS
             else:
                 logger.error("Robot test failure: %s for %s" %
                              (handler.sourcedir, self.instance.platform.name))
-                self.instance.status = "failed"
-                self.instance.testcases[0].status = "failed"
+                self.instance.status = TestInstanceStatus.FAIL
+                self.instance.testcases[0].status = TestCaseStatus.FAIL
 
             if out:
                 with open(os.path.join(self.instance.build_dir, handler.log), "wt") as log:
@@ -236,10 +237,10 @@ class Console(Harness):
     def configure(self, instance):
         super(Console, self).configure(instance)
         if self.regex is None or len(self.regex) == 0:
-            self.state = "failed"
+            self.state = HarnessStatus.FAIL
             tc = self.instance.set_case_status_by_name(
                 self.get_testcase_name(),
-                "failed",
+                TestCaseStatus.FAIL,
                 f"HARNESS:{self.__class__.__name__}:no regex patterns configured."
             )
             raise ConfigurationError(self.instance.name, tc.reason)
@@ -252,10 +253,10 @@ class Console(Harness):
                 self.patterns.append(re.compile(r))
             self.patterns_expected = len(self.patterns)
         else:
-            self.state = "failed"
+            self.state = HarnessStatus.FAIL
             tc = self.instance.set_case_status_by_name(
                 self.get_testcase_name(),
-                "failed",
+                TestCaseStatus.FAIL,
                 f"HARNESS:{self.__class__.__name__}:incorrect type={self.type}"
             )
             raise ConfigurationError(self.instance.name, tc.reason)
@@ -267,7 +268,7 @@ class Console(Harness):
                 logger.debug(f"HARNESS:{self.__class__.__name__}:EXPECTED:"
                              f"'{self.pattern.pattern}'")
                 self.next_pattern += 1
-                self.state = "passed"
+                self.state = HarnessStatus.PASS
         elif self.type == "multi_line" and self.ordered:
             if (self.next_pattern < len(self.patterns) and
                 self.patterns[self.next_pattern].search(line)):
@@ -276,7 +277,7 @@ class Console(Harness):
                              f"'{self.patterns[self.next_pattern].pattern}'")
                 self.next_pattern += 1
                 if self.next_pattern >= len(self.patterns):
-                    self.state = "passed"
+                    self.state = HarnessStatus.PASS
         elif self.type == "multi_line" and not self.ordered:
             for i, pattern in enumerate(self.patterns):
                 r = self.regex[i]
@@ -286,7 +287,7 @@ class Console(Harness):
                                  f"{len(self.matches)}/{self.patterns_expected}):"
                                  f"'{pattern.pattern}'")
             if len(self.matches) == len(self.regex):
-                self.state = "passed"
+                self.state = HarnessStatus.PASS
         else:
             logger.error("Unknown harness_config type")
 
@@ -300,31 +301,35 @@ class Console(Harness):
             self.capture_coverage = False
 
         self.process_test(line)
-        # Reset the resulting test state to 'failed' when not all of the patterns were
+        # Reset the resulting test state to FAIL when not all of the patterns were
         # found in the output, but just ztest's 'PROJECT EXECUTION SUCCESSFUL'.
         # It might happen because of the pattern sequence diverged from the
         # test code, the test platform has console issues, or even some other
         # test image was executed.
         # TODO: Introduce explicit match policy type to reject
         # unexpected console output, allow missing patterns, deny duplicates.
-        if self.state == "passed" and self.ordered and self.next_pattern < self.patterns_expected:
+        if self.state == HarnessStatus.PASS and \
+           self.ordered and \
+           self.next_pattern < self.patterns_expected:
             logger.error(f"HARNESS:{self.__class__.__name__}: failed with"
                          f" {self.next_pattern} of {self.patterns_expected}"
                          f" expected ordered patterns.")
-            self.state = "failed"
+            self.state = HarnessStatus.FAIL
             self.reason = "patterns did not match (ordered)"
-        if self.state == "passed" and not self.ordered and len(self.matches) < self.patterns_expected:
+        if self.state == HarnessStatus.PASS and \
+           not self.ordered and \
+           len(self.matches) < self.patterns_expected:
             logger.error(f"HARNESS:{self.__class__.__name__}: failed with"
                          f" {len(self.matches)} of {self.patterns_expected}"
                          f" expected unordered patterns.")
-            self.state = "failed"
+            self.state = HarnessStatus.FAIL
             self.reason = "patterns did not match (unordered)"
 
         tc = self.instance.get_case_or_create(self.get_testcase_name())
-        if self.state == "passed":
-            tc.status = "passed"
+        if self.state == HarnessStatus.PASS:
+            tc.status = TestCaseStatus.PASS
         else:
-            tc.status = "failed"
+            tc.status = TestCaseStatus.FAIL
 
 
 class PytestHarnessException(Exception):
@@ -347,7 +352,7 @@ class Pytest(Harness):
             self.run_command(cmd, timeout)
         except PytestHarnessException as pytest_exception:
             logger.error(str(pytest_exception))
-            self.state = 'failed'
+            self.state = HarnessStatus.FAIL
             self.instance.reason = str(pytest_exception)
         finally:
             if self.reserved_serial:
@@ -481,10 +486,10 @@ class Pytest(Harness):
                     logger.warning('Timeout has occurred. Can be extended in testspec file. '
                                    f'Currently set to {timeout} seconds.')
                     self.instance.reason = 'Pytest timeout'
-                    self.state = 'failed'
+                    self.state = HarnessStatus.FAIL
                 proc.wait(timeout)
             except subprocess.TimeoutExpired:
-                self.state = 'failed'
+                self.state = HarnessStatus.FAIL
                 proc.kill()
 
     @staticmethod
@@ -520,36 +525,37 @@ class Pytest(Harness):
         proc.communicate()
 
     def _update_test_status(self):
-        if not self.state:
+        if self.state == HarnessStatus.NONE:
             self.instance.testcases = []
             try:
                 self._parse_report_file(self.report_file)
             except Exception as e:
                 logger.error(f'Error when parsing file {self.report_file}: {e}')
-                self.state = 'failed'
+                self.state = HarnessStatus.FAIL
             finally:
                 if not self.instance.testcases:
                     self.instance.init_cases()
 
-        self.instance.status = self.state or 'failed'
-        if self.instance.status in ['error', 'failed']:
+        self.instance.status = self.state if self.state != HarnessStatus.NONE else \
+                               TestInstanceStatus.FAIL
+        if self.instance.status in [TestInstanceStatus.ERROR, TestInstanceStatus.FAIL]:
             self.instance.reason = self.instance.reason or 'Pytest failed'
-            self.instance.add_missing_case_status('blocked', self.instance.reason)
+            self.instance.add_missing_case_status(TestCaseStatus.BLOCK, self.instance.reason)
 
     def _parse_report_file(self, report):
         tree = ET.parse(report)
         root = tree.getroot()
         if elem_ts := root.find('testsuite'):
             if elem_ts.get('failures') != '0':
-                self.state = 'failed'
+                self.state = HarnessStatus.FAIL
                 self.instance.reason = f"{elem_ts.get('failures')}/{elem_ts.get('tests')} pytest scenario(s) failed"
             elif elem_ts.get('errors') != '0':
-                self.state = 'error'
+                self.state = HarnessStatus.ERROR
                 self.instance.reason = 'Error during pytest execution'
             elif elem_ts.get('skipped') == elem_ts.get('tests'):
-                self.state = 'skipped'
+                self.state = HarnessStatus.SKIP
             else:
-                self.state = 'passed'
+                self.state = HarnessStatus.PASS
             self.instance.execution_time = float(elem_ts.get('time'))
 
             for elem_tc in elem_ts.findall('testcase'):
@@ -557,18 +563,18 @@ class Pytest(Harness):
                 tc.duration = float(elem_tc.get('time'))
                 elem = elem_tc.find('*')
                 if elem is None:
-                    tc.status = 'passed'
+                    tc.status = TestCaseStatus.PASS
                 else:
-                    if elem.tag == 'skipped':
-                        tc.status = 'skipped'
-                    elif elem.tag == 'failure':
-                        tc.status = 'failed'
+                    if elem.tag == ReportStatus.SKIP:
+                        tc.status = TestCaseStatus.SKIP
+                    elif elem.tag == ReportStatus.FAIL:
+                        tc.status = TestCaseStatus.FAIL
                     else:
-                        tc.status = 'error'
+                        tc.status = TestCaseStatus.ERROR
                     tc.reason = elem.get('message')
                     tc.output = elem.text
         else:
-            self.state = 'skipped'
+            self.state = HarnessStatus.SKIP
             self.instance.reason = 'No tests collected'
 
 
@@ -589,7 +595,7 @@ class Gtest(Harness):
         # Strip the ANSI characters, they mess up the patterns
         non_ansi_line = self.ANSI_ESCAPE.sub('', line)
 
-        if self.state:
+        if self.state != HarnessStatus.NONE:
             return
 
         # Check if we started running a new test
@@ -615,7 +621,7 @@ class Gtest(Harness):
             # Create the test instance and set the context
             tc = self.instance.get_case_or_create(name)
             self.tc = tc
-            self.tc.status = "started"
+            self.tc.status = TestCaseStatus.STARTED
             self.testcase_output += line + "\n"
             self._match = True
 
@@ -624,16 +630,16 @@ class Gtest(Harness):
         if finished_match:
             tc = self.instance.get_case_or_create(self.id)
             if self.has_failures or self.tc is not None:
-                self.state = "failed"
-                tc.status = "failed"
+                self.state = HarnessStatus.FAIL
+                tc.status = TestCaseStatus.FAIL
             else:
-                self.state = "passed"
-                tc.status = "passed"
+                self.state = HarnessStatus.PASS
+                tc.status = TestCaseStatus.PASS
             return
 
         # Check if the individual test finished
         state, name = self._check_result(non_ansi_line)
-        if state is None or name is None:
+        if state == TestCaseStatus.NONE or name is None:
             # Nothing finished, keep processing lines
             return
 
@@ -648,7 +654,7 @@ class Gtest(Harness):
 
         # Update the status of the test
         tc.status = state
-        if tc.status == "failed":
+        if tc.status == TestCaseStatus.FAIL:
             self.has_failures = True
             tc.output = self.testcase_output
         self.testcase_output = ""
@@ -657,13 +663,25 @@ class Gtest(Harness):
     def _check_result(self, line):
         test_pass_match = re.search(self.TEST_PASS_PATTERN, line)
         if test_pass_match:
-            return "passed", "{}.{}.{}".format(self.id, test_pass_match.group("suite_name"), test_pass_match.group("test_name"))
+            return TestCaseStatus.PASS, \
+                   "{}.{}.{}".format(
+                        self.id, test_pass_match.group("suite_name"),
+                        test_pass_match.group("test_name")
+                    )
         test_skip_match = re.search(self.TEST_SKIP_PATTERN, line)
         if test_skip_match:
-            return "skipped", "{}.{}.{}".format(self.id, test_skip_match.group("suite_name"), test_skip_match.group("test_name"))
+            return TestCaseStatus.SKIP, \
+                   "{}.{}.{}".format(
+                       self.id, test_skip_match.group("suite_name"),
+                       test_skip_match.group("test_name")
+                    )
         test_fail_match = re.search(self.TEST_FAIL_PATTERN, line)
         if test_fail_match:
-            return "failed", "{}.{}.{}".format(self.id, test_fail_match.group("suite_name"), test_fail_match.group("test_name"))
+            return TestCaseStatus.FAIL, \
+                   "{}.{}.{}".format(
+                       self.id, test_fail_match.group("suite_name"),
+                       test_fail_match.group("test_name")
+                    )
         return None, None
 
 
@@ -687,7 +705,7 @@ class Test(Harness):
             # Mark the test as started, if something happens here, it is mostly
             # due to this tests, for example timeout. This should in this case
             # be marked as failed and not blocked (not run).
-            tc.status = "started"
+            tc.status = TestCaseStatus.STARTED
 
         if testcase_match or self._match:
             self.testcase_output += line + "\n"
@@ -706,10 +724,10 @@ class Test(Harness):
             name = "{}.{}".format(self.id, result_match.group(3))
             tc = self.instance.get_case_or_create(name)
             tc.status = self.ztest_to_status[matched_status]
-            if tc.status == "skipped":
+            if tc.status == TestCaseStatus.SKIP:
                 tc.reason = "ztest skip"
             tc.duration = float(result_match.group(4))
-            if tc.status == "failed":
+            if tc.status == TestCaseStatus.FAIL:
                 tc.output = self.testcase_output
             self.testcase_output = ""
             self._match = False
@@ -720,10 +738,10 @@ class Test(Harness):
             name = "{}.{}".format(self.id, summary_match.group(4))
             tc = self.instance.get_case_or_create(name)
             tc.status = self.ztest_to_status[matched_status]
-            if tc.status == "skipped":
+            if tc.status == TestCaseStatus.SKIP:
                 tc.reason = "ztest skip"
             tc.duration = float(summary_match.group(5))
-            if tc.status == "failed":
+            if tc.status == TestCaseStatus.FAIL:
                 tc.output = self.testcase_output
             self.testcase_output = ""
             self._match = False
@@ -731,13 +749,13 @@ class Test(Harness):
 
         self.process_test(line)
 
-        if not self.ztest and self.state:
+        if not self.ztest and self.state != HarnessStatus.NONE:
             logger.debug(f"not a ztest and no state for {self.id}")
             tc = self.instance.get_case_or_create(self.id)
-            if self.state == "passed":
-                tc.status = "passed"
+            if self.state == HarnessStatus.PASS:
+                tc.status = TestCaseStatus.PASS
             else:
-                tc.status = "failed"
+                tc.status = TestCaseStatus.FAIL
                 tc.reason = "Test failure"
 
 

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 from asyncio.log import logger
+from enum import Enum
 import platform
 import re
 import os
@@ -15,10 +16,11 @@ import time
 import shutil
 import json
 
+from twisterlib.reports import ReportStatus
 from twisterlib.error import ConfigurationError
 from twisterlib.environment import ZEPHYR_BASE, PYTEST_PLUGIN_INSTALLED
 from twisterlib.handlers import Handler, terminate_process, SUPPORTED_SIMS_IN_PYTEST
-from twisterlib.statuses import HarnessStatus, ReportStatus, TestCaseStatus, TestInstanceStatus
+from twisterlib.statuses import TwisterStatus
 from twisterlib.testinstance import TestInstance
 
 
@@ -37,16 +39,8 @@ class Harness:
     RUN_FAILED = "PROJECT EXECUTION FAILED"
     run_id_pattern = r"RunID: (?P<run_id>.*)"
 
-
-    ztest_to_status = {
-        'PASS': TestCaseStatus.PASS,
-        'SKIP': TestCaseStatus.SKIP,
-        'BLOCK': TestCaseStatus.BLOCK,
-        'FAIL': TestCaseStatus.FAIL
-        }
-
     def __init__(self):
-        self.state = HarnessStatus.NONE
+        self._status = TwisterStatus.NONE
         self.reason = None
         self.type = None
         self.regex = []
@@ -69,6 +63,21 @@ class Harness:
         self.instance: TestInstance | None = None
         self.testcase_output = ""
         self._match = False
+
+    @property
+    def status(self) -> TwisterStatus:
+        return self._status
+
+    @status.setter
+    def status(self, value : TwisterStatus) -> None:
+        # Check for illegal assignments by value
+        try:
+            key = value.name if isinstance(value, Enum) else value
+            self._status = TwisterStatus[key]
+        except KeyError:
+            logger.warning(f'Harness assigned status "{value}"'
+                           f' without an equivalent in TwisterStatus.'
+                           f' Assignment was ignored.')
 
     def configure(self, instance):
         self.instance = instance
@@ -133,13 +142,13 @@ class Harness:
 
         if self.RUN_PASSED in line:
             if self.fault:
-                self.state = HarnessStatus.FAIL
+                self.status = TwisterStatus.FAIL
                 self.reason = "Fault detected while running test"
             else:
-                self.state = HarnessStatus.PASS
+                self.status = TwisterStatus.PASS
 
         if self.RUN_FAILED in line:
-            self.state = HarnessStatus.FAIL
+            self.status = TwisterStatus.FAIL
             self.reason = "Testsuite failed"
 
         if self.fail_on_fault:
@@ -170,9 +179,9 @@ class Robot(Harness):
             handle is trying to give a PASS or FAIL to avoid timeout, nothing
             is writen into handler.log
         '''
-        self.instance.state = TestInstanceStatus.PASS
+        self.instance.status = TwisterStatus.PASS
         tc = self.instance.get_case_or_create(self.id)
-        tc.status = TestCaseStatus.PASS
+        tc.status = TwisterStatus.PASS
 
     def run_robot_test(self, command, handler):
         start_time = time.time()
@@ -203,16 +212,16 @@ class Robot(Harness):
             self.instance.execution_time = time.time() - start_time
 
             if renode_test_proc.returncode == 0:
-                self.instance.status = TestInstanceStatus.PASS
+                self.instance.status = TwisterStatus.PASS
                 # all tests in one Robot file are treated as a single test case,
                 # so its status should be set accordingly to the instance status
                 # please note that there should be only one testcase in testcases list
-                self.instance.testcases[0].status = TestCaseStatus.PASS
+                self.instance.testcases[0].status = TwisterStatus.PASS
             else:
                 logger.error("Robot test failure: %s for %s" %
                              (handler.sourcedir, self.instance.platform.name))
-                self.instance.status = TestInstanceStatus.FAIL
-                self.instance.testcases[0].status = TestCaseStatus.FAIL
+                self.instance.status = TwisterStatus.FAIL
+                self.instance.testcases[0].status = TwisterStatus.FAIL
 
             if out:
                 with open(os.path.join(self.instance.build_dir, handler.log), "wt") as log:
@@ -237,10 +246,10 @@ class Console(Harness):
     def configure(self, instance):
         super(Console, self).configure(instance)
         if self.regex is None or len(self.regex) == 0:
-            self.state = HarnessStatus.FAIL
+            self.status = TwisterStatus.FAIL
             tc = self.instance.set_case_status_by_name(
                 self.get_testcase_name(),
-                TestCaseStatus.FAIL,
+                TwisterStatus.FAIL,
                 f"HARNESS:{self.__class__.__name__}:no regex patterns configured."
             )
             raise ConfigurationError(self.instance.name, tc.reason)
@@ -253,10 +262,10 @@ class Console(Harness):
                 self.patterns.append(re.compile(r))
             self.patterns_expected = len(self.patterns)
         else:
-            self.state = HarnessStatus.FAIL
+            self.status = TwisterStatus.FAIL
             tc = self.instance.set_case_status_by_name(
                 self.get_testcase_name(),
-                TestCaseStatus.FAIL,
+                TwisterStatus.FAIL,
                 f"HARNESS:{self.__class__.__name__}:incorrect type={self.type}"
             )
             raise ConfigurationError(self.instance.name, tc.reason)
@@ -268,7 +277,7 @@ class Console(Harness):
                 logger.debug(f"HARNESS:{self.__class__.__name__}:EXPECTED:"
                              f"'{self.pattern.pattern}'")
                 self.next_pattern += 1
-                self.state = HarnessStatus.PASS
+                self.status = TwisterStatus.PASS
         elif self.type == "multi_line" and self.ordered:
             if (self.next_pattern < len(self.patterns) and
                 self.patterns[self.next_pattern].search(line)):
@@ -277,7 +286,7 @@ class Console(Harness):
                              f"'{self.patterns[self.next_pattern].pattern}'")
                 self.next_pattern += 1
                 if self.next_pattern >= len(self.patterns):
-                    self.state = HarnessStatus.PASS
+                    self.status = TwisterStatus.PASS
         elif self.type == "multi_line" and not self.ordered:
             for i, pattern in enumerate(self.patterns):
                 r = self.regex[i]
@@ -287,7 +296,7 @@ class Console(Harness):
                                  f"{len(self.matches)}/{self.patterns_expected}):"
                                  f"'{pattern.pattern}'")
             if len(self.matches) == len(self.regex):
-                self.state = HarnessStatus.PASS
+                self.status = TwisterStatus.PASS
         else:
             logger.error("Unknown harness_config type")
 
@@ -308,28 +317,28 @@ class Console(Harness):
         # test image was executed.
         # TODO: Introduce explicit match policy type to reject
         # unexpected console output, allow missing patterns, deny duplicates.
-        if self.state == HarnessStatus.PASS and \
+        if self.status == TwisterStatus.PASS and \
            self.ordered and \
            self.next_pattern < self.patterns_expected:
             logger.error(f"HARNESS:{self.__class__.__name__}: failed with"
                          f" {self.next_pattern} of {self.patterns_expected}"
                          f" expected ordered patterns.")
-            self.state = HarnessStatus.FAIL
+            self.status = TwisterStatus.FAIL
             self.reason = "patterns did not match (ordered)"
-        if self.state == HarnessStatus.PASS and \
+        if self.status == TwisterStatus.PASS and \
            not self.ordered and \
            len(self.matches) < self.patterns_expected:
             logger.error(f"HARNESS:{self.__class__.__name__}: failed with"
                          f" {len(self.matches)} of {self.patterns_expected}"
                          f" expected unordered patterns.")
-            self.state = HarnessStatus.FAIL
+            self.status = TwisterStatus.FAIL
             self.reason = "patterns did not match (unordered)"
 
         tc = self.instance.get_case_or_create(self.get_testcase_name())
-        if self.state == HarnessStatus.PASS:
-            tc.status = TestCaseStatus.PASS
+        if self.status == TwisterStatus.PASS:
+            tc.status = TwisterStatus.PASS
         else:
-            tc.status = TestCaseStatus.FAIL
+            tc.status = TwisterStatus.FAIL
 
 
 class PytestHarnessException(Exception):
@@ -352,7 +361,7 @@ class Pytest(Harness):
             self.run_command(cmd, timeout)
         except PytestHarnessException as pytest_exception:
             logger.error(str(pytest_exception))
-            self.state = HarnessStatus.FAIL
+            self.status = TwisterStatus.FAIL
             self.instance.reason = str(pytest_exception)
         finally:
             if self.reserved_serial:
@@ -486,10 +495,10 @@ class Pytest(Harness):
                     logger.warning('Timeout has occurred. Can be extended in testspec file. '
                                    f'Currently set to {timeout} seconds.')
                     self.instance.reason = 'Pytest timeout'
-                    self.state = HarnessStatus.FAIL
+                    self.status = TwisterStatus.FAIL
                 proc.wait(timeout)
             except subprocess.TimeoutExpired:
-                self.state = HarnessStatus.FAIL
+                self.status = TwisterStatus.FAIL
                 proc.kill()
 
     @staticmethod
@@ -525,37 +534,37 @@ class Pytest(Harness):
         proc.communicate()
 
     def _update_test_status(self):
-        if self.state == HarnessStatus.NONE:
+        if self.status == TwisterStatus.NONE:
             self.instance.testcases = []
             try:
                 self._parse_report_file(self.report_file)
             except Exception as e:
                 logger.error(f'Error when parsing file {self.report_file}: {e}')
-                self.state = HarnessStatus.FAIL
+                self.status = TwisterStatus.FAIL
             finally:
                 if not self.instance.testcases:
                     self.instance.init_cases()
 
-        self.instance.status = self.state if self.state != HarnessStatus.NONE else \
-                               TestInstanceStatus.FAIL
-        if self.instance.status in [TestInstanceStatus.ERROR, TestInstanceStatus.FAIL]:
+        self.instance.status = self.status if self.status != TwisterStatus.NONE else \
+                               TwisterStatus.FAIL
+        if self.instance.status in [TwisterStatus.ERROR, TwisterStatus.FAIL]:
             self.instance.reason = self.instance.reason or 'Pytest failed'
-            self.instance.add_missing_case_status(TestCaseStatus.BLOCK, self.instance.reason)
+            self.instance.add_missing_case_status(TwisterStatus.BLOCK, self.instance.reason)
 
     def _parse_report_file(self, report):
         tree = ET.parse(report)
         root = tree.getroot()
         if elem_ts := root.find('testsuite'):
             if elem_ts.get('failures') != '0':
-                self.state = HarnessStatus.FAIL
+                self.status = TwisterStatus.FAIL
                 self.instance.reason = f"{elem_ts.get('failures')}/{elem_ts.get('tests')} pytest scenario(s) failed"
             elif elem_ts.get('errors') != '0':
-                self.state = HarnessStatus.ERROR
+                self.status = TwisterStatus.ERROR
                 self.instance.reason = 'Error during pytest execution'
             elif elem_ts.get('skipped') == elem_ts.get('tests'):
-                self.state = HarnessStatus.SKIP
+                self.status = TwisterStatus.SKIP
             else:
-                self.state = HarnessStatus.PASS
+                self.status = TwisterStatus.PASS
             self.instance.execution_time = float(elem_ts.get('time'))
 
             for elem_tc in elem_ts.findall('testcase'):
@@ -563,18 +572,18 @@ class Pytest(Harness):
                 tc.duration = float(elem_tc.get('time'))
                 elem = elem_tc.find('*')
                 if elem is None:
-                    tc.status = TestCaseStatus.PASS
+                    tc.status = TwisterStatus.PASS
                 else:
                     if elem.tag == ReportStatus.SKIP:
-                        tc.status = TestCaseStatus.SKIP
+                        tc.status = TwisterStatus.SKIP
                     elif elem.tag == ReportStatus.FAIL:
-                        tc.status = TestCaseStatus.FAIL
+                        tc.status = TwisterStatus.FAIL
                     else:
-                        tc.status = TestCaseStatus.ERROR
+                        tc.status = TwisterStatus.ERROR
                     tc.reason = elem.get('message')
                     tc.output = elem.text
         else:
-            self.state = HarnessStatus.SKIP
+            self.status = TwisterStatus.SKIP
             self.instance.reason = 'No tests collected'
 
 
@@ -595,7 +604,7 @@ class Gtest(Harness):
         # Strip the ANSI characters, they mess up the patterns
         non_ansi_line = self.ANSI_ESCAPE.sub('', line)
 
-        if self.state != HarnessStatus.NONE:
+        if self.status != TwisterStatus.NONE:
             return
 
         # Check if we started running a new test
@@ -621,7 +630,7 @@ class Gtest(Harness):
             # Create the test instance and set the context
             tc = self.instance.get_case_or_create(name)
             self.tc = tc
-            self.tc.status = TestCaseStatus.STARTED
+            self.tc.status = TwisterStatus.STARTED
             self.testcase_output += line + "\n"
             self._match = True
 
@@ -630,16 +639,16 @@ class Gtest(Harness):
         if finished_match:
             tc = self.instance.get_case_or_create(self.id)
             if self.has_failures or self.tc is not None:
-                self.state = HarnessStatus.FAIL
-                tc.status = TestCaseStatus.FAIL
+                self.status = TwisterStatus.FAIL
+                tc.status = TwisterStatus.FAIL
             else:
-                self.state = HarnessStatus.PASS
-                tc.status = TestCaseStatus.PASS
+                self.status = TwisterStatus.PASS
+                tc.status = TwisterStatus.PASS
             return
 
         # Check if the individual test finished
         state, name = self._check_result(non_ansi_line)
-        if state == TestCaseStatus.NONE or name is None:
+        if state == TwisterStatus.NONE or name is None:
             # Nothing finished, keep processing lines
             return
 
@@ -654,7 +663,7 @@ class Gtest(Harness):
 
         # Update the status of the test
         tc.status = state
-        if tc.status == TestCaseStatus.FAIL:
+        if tc.status == TwisterStatus.FAIL:
             self.has_failures = True
             tc.output = self.testcase_output
         self.testcase_output = ""
@@ -663,21 +672,21 @@ class Gtest(Harness):
     def _check_result(self, line):
         test_pass_match = re.search(self.TEST_PASS_PATTERN, line)
         if test_pass_match:
-            return TestCaseStatus.PASS, \
+            return TwisterStatus.PASS, \
                    "{}.{}.{}".format(
                         self.id, test_pass_match.group("suite_name"),
                         test_pass_match.group("test_name")
                     )
         test_skip_match = re.search(self.TEST_SKIP_PATTERN, line)
         if test_skip_match:
-            return TestCaseStatus.SKIP, \
+            return TwisterStatus.SKIP, \
                    "{}.{}.{}".format(
                        self.id, test_skip_match.group("suite_name"),
                        test_skip_match.group("test_name")
                     )
         test_fail_match = re.search(self.TEST_FAIL_PATTERN, line)
         if test_fail_match:
-            return TestCaseStatus.FAIL, \
+            return TwisterStatus.FAIL, \
                    "{}.{}.{}".format(
                        self.id, test_fail_match.group("suite_name"),
                        test_fail_match.group("test_name")
@@ -705,7 +714,7 @@ class Test(Harness):
             # Mark the test as started, if something happens here, it is mostly
             # due to this tests, for example timeout. This should in this case
             # be marked as failed and not blocked (not run).
-            tc.status = TestCaseStatus.STARTED
+            tc.status = TwisterStatus.STARTED
 
         if testcase_match or self._match:
             self.testcase_output += line + "\n"
@@ -723,11 +732,11 @@ class Test(Harness):
             matched_status = result_match.group(1)
             name = "{}.{}".format(self.id, result_match.group(3))
             tc = self.instance.get_case_or_create(name)
-            tc.status = self.ztest_to_status[matched_status]
-            if tc.status == TestCaseStatus.SKIP:
+            tc.status = TwisterStatus[matched_status]
+            if tc.status == TwisterStatus.SKIP:
                 tc.reason = "ztest skip"
             tc.duration = float(result_match.group(4))
-            if tc.status == TestCaseStatus.FAIL:
+            if tc.status == TwisterStatus.FAIL:
                 tc.output = self.testcase_output
             self.testcase_output = ""
             self._match = False
@@ -737,11 +746,11 @@ class Test(Harness):
             self.detected_suite_names.append(summary_match.group(2))
             name = "{}.{}".format(self.id, summary_match.group(4))
             tc = self.instance.get_case_or_create(name)
-            tc.status = self.ztest_to_status[matched_status]
-            if tc.status == TestCaseStatus.SKIP:
+            tc.status = TwisterStatus[matched_status]
+            if tc.status == TwisterStatus.SKIP:
                 tc.reason = "ztest skip"
             tc.duration = float(summary_match.group(5))
-            if tc.status == TestCaseStatus.FAIL:
+            if tc.status == TwisterStatus.FAIL:
                 tc.output = self.testcase_output
             self.testcase_output = ""
             self._match = False
@@ -749,13 +758,13 @@ class Test(Harness):
 
         self.process_test(line)
 
-        if not self.ztest and self.state != HarnessStatus.NONE:
+        if not self.ztest and self.status != TwisterStatus.NONE:
             logger.debug(f"not a ztest and no state for {self.id}")
             tc = self.instance.get_case_or_create(self.id)
-            if self.state == HarnessStatus.PASS:
-                tc.status = TestCaseStatus.PASS
+            if self.status == TwisterStatus.PASS:
+                tc.status = TwisterStatus.PASS
             else:
-                tc.status = TestCaseStatus.FAIL
+                tc.status = TwisterStatus.FAIL
                 tc.reason = "Test failure"
 
 

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -75,7 +75,7 @@ class Harness:
             key = value.name if isinstance(value, Enum) else value
             self._status = TwisterStatus[key]
         except KeyError:
-            logger.warning(f'Harness assigned status "{value}"'
+            logger.error(f'Harness assigned status "{value}"'
                            f' without an equivalent in TwisterStatus.'
                            f' Assignment was ignored.')
 

--- a/scripts/pylib/twister/twisterlib/package.py
+++ b/scripts/pylib/twister/twisterlib/package.py
@@ -7,6 +7,8 @@ import tarfile
 import json
 import os
 
+from twisterlib.statuses import TestSuiteStatus
+
 class Artifacts:
 
     def __init__(self, env):
@@ -25,7 +27,7 @@ class Artifacts:
         with open(os.path.join(self.options.outdir, "twister.json"), "r") as json_test_plan:
             jtp = json.load(json_test_plan)
             for t in jtp['testsuites']:
-                if t['status'] != "filtered":
+                if t['status'] != TestSuiteStatus.FILTER:
                     p = t['platform']
                     normalized  = p.replace("/", "_")
                     dirs.append(os.path.join(self.options.outdir, normalized, t['name']))

--- a/scripts/pylib/twister/twisterlib/package.py
+++ b/scripts/pylib/twister/twisterlib/package.py
@@ -7,7 +7,7 @@ import tarfile
 import json
 import os
 
-from twisterlib.statuses import TestSuiteStatus
+from twisterlib.statuses import TwisterStatus
 
 class Artifacts:
 
@@ -27,7 +27,7 @@ class Artifacts:
         with open(os.path.join(self.options.outdir, "twister.json"), "r") as json_test_plan:
             jtp = json.load(json_test_plan)
             for t in jtp['testsuites']:
-                if t['status'] != TestSuiteStatus.FILTER:
+                if t['status'] != TwisterStatus.FILTER:
                     p = t['platform']
                     normalized  = p.replace("/", "_")
                     dirs.append(os.path.join(self.options.outdir, normalized, t['name']))

--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -283,13 +283,15 @@ class Reporting:
         for instance in self.instances.values():
             if platform and platform != instance.platform.name:
                 continue
-            if instance.status == "filtered" and not self.env.options.report_filtered:
+            if instance.status == TwisterStatus.FILTER and not self.env.options.report_filtered:
                 continue
-            if (filters and 'allow_status' in filters and instance.status not in filters['allow_status']):
+            if (filters and 'allow_status' in filters and \
+                instance.status not in [TwisterStatus[s] for s in filters['allow_status']]):
                 logger.debug(f"Skip test suite '{instance.testsuite.name}' status '{instance.status}' "
                              f"not allowed for {filename}")
                 continue
-            if (filters and 'deny_status' in filters and instance.status in filters['deny_status']):
+            if (filters and 'deny_status' in filters and \
+                instance.status in [TwisterStatus[s] for s in filters['deny_status']]):
                 logger.debug(f"Skip test suite '{instance.testsuite.name}' status '{instance.status}' "
                              f"denied for {filename}")
                 continue
@@ -399,7 +401,7 @@ class Reporting:
                 suite['recording'] = instance.recording
 
             if (instance.status
-                    and instance.status not in ["error", "filtered"]
+                    and instance.status not in [TwisterStatus.ERROR, TwisterStatus.FILTER]
                     and self.env.options.create_rom_ram_report
                     and self.env.options.footprint_report is not None):
                 # Init as empty data preparing for filtering properties.

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -1019,7 +1019,7 @@ class ProjectBuilder(FilterBuilder):
                 else:
                     more_info = "build"
 
-                if ( instance.status in [TestInstanceStatus.ERROR, TestInstanceStatus.FAIL, TestInstanceStatus.TIMEOUT, TestInstanceStatus.FLASH]
+                if ( instance.status in [TestInstanceStatus.ERROR, TestInstanceStatus.FAIL]
                      and hasattr(self.instance.handler, 'seed')
                      and self.instance.handler.seed is not None ):
                     more_info += "/seed: " + str(self.options.seed)
@@ -1027,7 +1027,7 @@ class ProjectBuilder(FilterBuilder):
                 results.done, total_tests_width, total_to_do , instance.platform.name,
                 instance.testsuite.name, status, more_info))
 
-            if instance.status in [TestInstanceStatus.ERROR, TestInstanceStatus.FAIL, TestInstanceStatus.TIMEOUT]:
+            if instance.status in [TestInstanceStatus.ERROR, TestInstanceStatus.FAIL]:
                 self.log_info_file(self.options.inline_logs)
         else:
             completed_perc = 0

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -677,7 +677,7 @@ class ProjectBuilder(FilterBuilder):
         elif op == "gather_metrics":
             ret = self.gather_metrics(self.instance)
             if not ret or ret.get('returncode', 1) > 0:
-                self.instance.status = "error"
+                self.instance.status = TwisterStatus.ERROR
                 self.instance.reason = "Build Failure at gather_metrics."
                 pipeline.put({"op": "report", "test": self.instance})
             elif self.instance.run and self.instance.handler.ready:
@@ -1302,7 +1302,7 @@ class TwisterRunner:
 
             no_retry_statuses = [TwisterStatus.PASS, TwisterStatus.SKIP, TwisterStatus.FILTER]
             if not retry_build_errors:
-                no_retry_statuses.append("error")
+                no_retry_statuses.append(TwisterStatus.ERROR)
 
             if instance.status not in no_retry_statuses:
                 logger.debug(f"adding {instance.name}")

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -26,6 +26,7 @@ from domains import Domains
 from twisterlib.cmakecache import CMakeCache
 from twisterlib.environment import canonical_zephyr_base
 from twisterlib.error import BuildError, ConfigurationError
+from twisterlib.statuses import TestCaseStatus, TestInstanceStatus
 
 import elftools
 from elftools.elf.elffile import ELFFile
@@ -284,9 +285,9 @@ class CMake:
             msg = f"Finished building {self.source_dir} for {self.platform.name} in {duration:.2f} seconds"
             logger.debug(msg)
 
-            self.instance.status = "passed"
+            self.instance.status = TestInstanceStatus.PASS
             if not self.instance.run:
-                self.instance.add_missing_case_status("skipped", "Test was built only")
+                self.instance.add_missing_case_status(TestCaseStatus.SKIP, "Test was built only")
             ret = {"returncode": p.returncode}
 
             if out:
@@ -308,15 +309,15 @@ class CMake:
                 imgtool_overflow_found = re.findall(r"Error: Image size \(.*\) \+ trailer \(.*\) exceeds requested size", log_msg)
                 if overflow_found and not self.options.overflow_as_errors:
                     logger.debug("Test skipped due to {} Overflow".format(overflow_found[0]))
-                    self.instance.status = "skipped"
+                    self.instance.status = TestInstanceStatus.SKIP
                     self.instance.reason = "{} overflow".format(overflow_found[0])
                     change_skip_to_error_if_integration(self.options, self.instance)
                 elif imgtool_overflow_found and not self.options.overflow_as_errors:
-                    self.instance.status = "skipped"
+                    self.instance.status = TestInstanceStatus.SKIP
                     self.instance.reason = "imgtool overflow"
                     change_skip_to_error_if_integration(self.options, self.instance)
                 else:
-                    self.instance.status = "error"
+                    self.instance.status = TestInstanceStatus.ERROR
                     self.instance.reason = "Build failure"
 
             ret = {
@@ -415,7 +416,7 @@ class CMake:
                     'filter': filter_results
                     }
         else:
-            self.instance.status = "error"
+            self.instance.status = TestInstanceStatus.ERROR
             self.instance.reason = "Cmake build failure"
 
             for tc in self.instance.testcases:
@@ -607,16 +608,16 @@ class ProjectBuilder(FilterBuilder):
 
         if op == "filter":
             ret = self.cmake(filter_stages=self.instance.filter_stages)
-            if self.instance.status in ["failed", "error"]:
+            if self.instance.status in [TestInstanceStatus.FAIL, TestInstanceStatus.ERROR]:
                 pipeline.put({"op": "report", "test": self.instance})
             else:
                 # Here we check the dt/kconfig filter results coming from running cmake
                 if self.instance.name in ret['filter'] and ret['filter'][self.instance.name]:
                     logger.debug("filtering %s" % self.instance.name)
-                    self.instance.status = "filtered"
+                    self.instance.status = TestInstanceStatus.FILTER
                     self.instance.reason = "runtime filter"
                     results.skipped_runtime += 1
-                    self.instance.add_missing_case_status("skipped")
+                    self.instance.add_missing_case_status(TestCaseStatus.SKIP)
                     pipeline.put({"op": "report", "test": self.instance})
                 else:
                     pipeline.put({"op": "cmake", "test": self.instance})
@@ -624,20 +625,20 @@ class ProjectBuilder(FilterBuilder):
         # The build process, call cmake and build with configured generator
         elif op == "cmake":
             ret = self.cmake()
-            if self.instance.status in ["failed", "error"]:
+            if self.instance.status in [TestInstanceStatus.FAIL, TestInstanceStatus.ERROR]:
                 pipeline.put({"op": "report", "test": self.instance})
             elif self.options.cmake_only:
-                if self.instance.status is None:
-                    self.instance.status = "passed"
+                if self.instance.status == TestInstanceStatus.NONE:
+                    self.instance.status = TestInstanceStatus.PASS
                 pipeline.put({"op": "report", "test": self.instance})
             else:
                 # Here we check the runtime filter results coming from running cmake
                 if self.instance.name in ret['filter'] and ret['filter'][self.instance.name]:
                     logger.debug("filtering %s" % self.instance.name)
-                    self.instance.status = "filtered"
+                    self.instance.status = TestInstanceStatus.FILTER
                     self.instance.reason = "runtime filter"
                     results.skipped_runtime += 1
-                    self.instance.add_missing_case_status("skipped")
+                    self.instance.add_missing_case_status(TestCaseStatus.SKIP)
                     pipeline.put({"op": "report", "test": self.instance})
                 else:
                     pipeline.put({"op": "build", "test": self.instance})
@@ -646,18 +647,18 @@ class ProjectBuilder(FilterBuilder):
             logger.debug("build test: %s" % self.instance.name)
             ret = self.build()
             if not ret:
-                self.instance.status = "error"
+                self.instance.status = TestInstanceStatus.ERROR
                 self.instance.reason = "Build Failure"
                 pipeline.put({"op": "report", "test": self.instance})
             else:
                 # Count skipped cases during build, for example
                 # due to ram/rom overflow.
-                if  self.instance.status == "skipped":
+                if  self.instance.status == TestInstanceStatus.SKIP:
                     results.skipped_runtime += 1
-                    self.instance.add_missing_case_status("skipped", self.instance.reason)
+                    self.instance.add_missing_case_status(TestCaseStatus.SKIP, self.instance.reason)
 
                 if ret.get('returncode', 1) > 0:
-                    self.instance.add_missing_case_status("blocked", self.instance.reason)
+                    self.instance.add_missing_case_status(TestCaseStatus.BLOCK, self.instance.reason)
                     pipeline.put({"op": "report", "test": self.instance})
                 else:
                     if self.instance.testsuite.harness in ['ztest', 'test']:
@@ -667,7 +668,7 @@ class ProjectBuilder(FilterBuilder):
                             pipeline.put({"op": "gather_metrics", "test": self.instance})
                         except BuildError as e:
                             logger.error(str(e))
-                            self.instance.status = "error"
+                            self.instance.status = TestInstanceStatus.ERROR
                             self.instance.reason = str(e)
                             pipeline.put({"op": "report", "test": self.instance})
                     else:
@@ -713,7 +714,7 @@ class ProjectBuilder(FilterBuilder):
             if not self.options.coverage:
                 if self.options.prep_artifacts_for_testing:
                     pipeline.put({"op": "cleanup", "mode": "device", "test": self.instance})
-                elif self.options.runtime_artifact_cleanup == "pass" and self.instance.status == "passed":
+                elif self.options.runtime_artifact_cleanup == "pass" and self.instance.status == TestInstanceStatus.PASS:
                     pipeline.put({"op": "cleanup", "mode": "passed", "test": self.instance})
                 elif self.options.runtime_artifact_cleanup == "all":
                     pipeline.put({"op": "cleanup", "mode": "all", "test": self.instance})
@@ -966,8 +967,8 @@ class ProjectBuilder(FilterBuilder):
         if results.iteration == 1:
             results.cases += len(instance.testcases)
 
-        if instance.status in ["error", "failed"]:
-            if instance.status == "error":
+        if instance.status in [TestInstanceStatus.ERROR, TestInstanceStatus.FAIL]:
+            if instance.status == TestInstanceStatus.ERROR:
                 results.error += 1
                 txt = " ERROR "
             else:
@@ -986,17 +987,17 @@ class ProjectBuilder(FilterBuilder):
                         instance.reason))
             if not self.options.verbose:
                 self.log_info_file(self.options.inline_logs)
-        elif instance.status in ["skipped", "filtered"]:
+        elif instance.status in [TestInstanceStatus.SKIP, TestInstanceStatus.FILTER]:
             status = Fore.YELLOW + "SKIPPED" + Fore.RESET
             results.skipped_configs += 1
             # test cases skipped at the test instance level
             results.skipped_cases += len(instance.testsuite.testcases)
-        elif instance.status == "passed":
+        elif instance.status == TestInstanceStatus.PASS:
             status = Fore.GREEN + "PASSED" + Fore.RESET
             results.passed += 1
             for case in instance.testcases:
                 # test cases skipped at the test case level
-                if case.status == 'skipped':
+                if case.status == TestCaseStatus.SKIP:
                     results.skipped_cases += 1
         else:
             logger.debug(f"Unknown status = {instance.status}")
@@ -1005,7 +1006,7 @@ class ProjectBuilder(FilterBuilder):
         if self.options.verbose:
             if self.options.cmake_only:
                 more_info = "cmake"
-            elif instance.status in ["skipped", "filtered"]:
+            elif instance.status in [TestInstanceStatus.SKIP, TestInstanceStatus.FILTER]:
                 more_info = instance.reason
             else:
                 if instance.handler.ready and instance.run:
@@ -1018,7 +1019,7 @@ class ProjectBuilder(FilterBuilder):
                 else:
                     more_info = "build"
 
-                if ( instance.status in ["error", "failed", "timeout", "flash_error"]
+                if ( instance.status in [TestInstanceStatus.ERROR, TestInstanceStatus.FAIL, TestInstanceStatus.TIMEOUT, TestInstanceStatus.FLASH]
                      and hasattr(self.instance.handler, 'seed')
                      and self.instance.handler.seed is not None ):
                     more_info += "/seed: " + str(self.options.seed)
@@ -1026,7 +1027,7 @@ class ProjectBuilder(FilterBuilder):
                 results.done, total_tests_width, total_to_do , instance.platform.name,
                 instance.testsuite.name, status, more_info))
 
-            if instance.status in ["error", "failed", "timeout"]:
+            if instance.status in [TestInstanceStatus.ERROR, TestInstanceStatus.FAIL, TestInstanceStatus.TIMEOUT]:
                 self.log_info_file(self.options.inline_logs)
         else:
             completed_perc = 0
@@ -1109,7 +1110,7 @@ class ProjectBuilder(FilterBuilder):
                 harness.instance = self.instance
                 harness.build()
         except ConfigurationError as error:
-            self.instance.status = "error"
+            self.instance.status = TestInstanceStatus.ERROR
             self.instance.reason = str(error)
             logger.error(self.instance.reason)
             return
@@ -1121,7 +1122,7 @@ class ProjectBuilder(FilterBuilder):
 
         if instance.handler.ready:
             logger.debug(f"Reset instance status from '{instance.status}' to None before run.")
-            instance.status = None
+            instance.status = TestInstanceStatus.NONE
 
             if instance.handler.type_str == "device":
                 instance.handler.duts = self.duts
@@ -1139,7 +1140,7 @@ class ProjectBuilder(FilterBuilder):
             try:
                 harness.configure(instance)
             except ConfigurationError as error:
-                instance.status = "error"
+                instance.status = TestInstanceStatus.ERROR
                 instance.reason = str(error)
                 logger.error(instance.reason)
                 return
@@ -1167,7 +1168,7 @@ class ProjectBuilder(FilterBuilder):
 
     @staticmethod
     def calc_size(instance: TestInstance, from_buildlog: bool):
-        if instance.status not in ["error", "failed", "skipped"]:
+        if instance.status not in [TestInstanceStatus.ERROR, TestInstanceStatus.FAIL, TestInstanceStatus.SKIP]:
             if not instance.platform.type in ["native", "qemu", "unit"]:
                 generate_warning = bool(instance.platform.type == "mcu")
                 size_calc = instance.calculate_sizes(from_buildlog=from_buildlog, generate_warning=generate_warning)
@@ -1278,12 +1279,12 @@ class TwisterRunner:
         the static filter stats. So need to prepare them before pipline starts.
         '''
         for instance in self.instances.values():
-            if instance.status == 'filtered' and not instance.reason == 'runtime filter':
+            if instance.status == TestInstanceStatus.FILTER and not instance.reason == 'runtime filter':
                 self.results.skipped_filter += 1
                 self.results.skipped_configs += 1
                 self.results.skipped_cases += len(instance.testsuite.testcases)
                 self.results.cases += len(instance.testsuite.testcases)
-            elif instance.status == 'error':
+            elif instance.status == TestInstanceStatus.ERROR:
                 self.results.error += 1
 
     def show_brief(self):
@@ -1299,15 +1300,15 @@ class TwisterRunner:
             if build_only:
                 instance.run = False
 
-            no_retry_statuses = ['passed', 'skipped', 'filtered']
+            no_retry_statuses = [TestInstanceStatus.PASS, TestInstanceStatus.SKIP, TestInstanceStatus.FILTER]
             if not retry_build_errors:
                 no_retry_statuses.append("error")
 
             if instance.status not in no_retry_statuses:
                 logger.debug(f"adding {instance.name}")
-                if instance.status:
+                if instance.status != TestInstanceStatus.NONE:
                     instance.retries += 1
-                instance.status = None
+                instance.status = TestInstanceStatus.NONE
 
                 # Check if cmake package_helper script can be run in advance.
                 instance.filter_stages = []

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -26,7 +26,7 @@ from domains import Domains
 from twisterlib.cmakecache import CMakeCache
 from twisterlib.environment import canonical_zephyr_base
 from twisterlib.error import BuildError, ConfigurationError
-from twisterlib.statuses import TestCaseStatus, TestInstanceStatus
+from twisterlib.statuses import TwisterStatus
 
 import elftools
 from elftools.elf.elffile import ELFFile
@@ -285,9 +285,9 @@ class CMake:
             msg = f"Finished building {self.source_dir} for {self.platform.name} in {duration:.2f} seconds"
             logger.debug(msg)
 
-            self.instance.status = TestInstanceStatus.PASS
+            self.instance.status = TwisterStatus.PASS
             if not self.instance.run:
-                self.instance.add_missing_case_status(TestCaseStatus.SKIP, "Test was built only")
+                self.instance.add_missing_case_status(TwisterStatus.SKIP, "Test was built only")
             ret = {"returncode": p.returncode}
 
             if out:
@@ -309,15 +309,15 @@ class CMake:
                 imgtool_overflow_found = re.findall(r"Error: Image size \(.*\) \+ trailer \(.*\) exceeds requested size", log_msg)
                 if overflow_found and not self.options.overflow_as_errors:
                     logger.debug("Test skipped due to {} Overflow".format(overflow_found[0]))
-                    self.instance.status = TestInstanceStatus.SKIP
+                    self.instance.status = TwisterStatus.SKIP
                     self.instance.reason = "{} overflow".format(overflow_found[0])
                     change_skip_to_error_if_integration(self.options, self.instance)
                 elif imgtool_overflow_found and not self.options.overflow_as_errors:
-                    self.instance.status = TestInstanceStatus.SKIP
+                    self.instance.status = TwisterStatus.SKIP
                     self.instance.reason = "imgtool overflow"
                     change_skip_to_error_if_integration(self.options, self.instance)
                 else:
-                    self.instance.status = TestInstanceStatus.ERROR
+                    self.instance.status = TwisterStatus.ERROR
                     self.instance.reason = "Build failure"
 
             ret = {
@@ -416,7 +416,7 @@ class CMake:
                     'filter': filter_results
                     }
         else:
-            self.instance.status = TestInstanceStatus.ERROR
+            self.instance.status = TwisterStatus.ERROR
             self.instance.reason = "Cmake build failure"
 
             for tc in self.instance.testcases:
@@ -608,16 +608,16 @@ class ProjectBuilder(FilterBuilder):
 
         if op == "filter":
             ret = self.cmake(filter_stages=self.instance.filter_stages)
-            if self.instance.status in [TestInstanceStatus.FAIL, TestInstanceStatus.ERROR]:
+            if self.instance.status in [TwisterStatus.FAIL, TwisterStatus.ERROR]:
                 pipeline.put({"op": "report", "test": self.instance})
             else:
                 # Here we check the dt/kconfig filter results coming from running cmake
                 if self.instance.name in ret['filter'] and ret['filter'][self.instance.name]:
                     logger.debug("filtering %s" % self.instance.name)
-                    self.instance.status = TestInstanceStatus.FILTER
+                    self.instance.status = TwisterStatus.FILTER
                     self.instance.reason = "runtime filter"
                     results.skipped_runtime += 1
-                    self.instance.add_missing_case_status(TestCaseStatus.SKIP)
+                    self.instance.add_missing_case_status(TwisterStatus.SKIP)
                     pipeline.put({"op": "report", "test": self.instance})
                 else:
                     pipeline.put({"op": "cmake", "test": self.instance})
@@ -625,20 +625,20 @@ class ProjectBuilder(FilterBuilder):
         # The build process, call cmake and build with configured generator
         elif op == "cmake":
             ret = self.cmake()
-            if self.instance.status in [TestInstanceStatus.FAIL, TestInstanceStatus.ERROR]:
+            if self.instance.status in [TwisterStatus.FAIL, TwisterStatus.ERROR]:
                 pipeline.put({"op": "report", "test": self.instance})
             elif self.options.cmake_only:
-                if self.instance.status == TestInstanceStatus.NONE:
-                    self.instance.status = TestInstanceStatus.PASS
+                if self.instance.status == TwisterStatus.NONE:
+                    self.instance.status = TwisterStatus.PASS
                 pipeline.put({"op": "report", "test": self.instance})
             else:
                 # Here we check the runtime filter results coming from running cmake
                 if self.instance.name in ret['filter'] and ret['filter'][self.instance.name]:
                     logger.debug("filtering %s" % self.instance.name)
-                    self.instance.status = TestInstanceStatus.FILTER
+                    self.instance.status = TwisterStatus.FILTER
                     self.instance.reason = "runtime filter"
                     results.skipped_runtime += 1
-                    self.instance.add_missing_case_status(TestCaseStatus.SKIP)
+                    self.instance.add_missing_case_status(TwisterStatus.SKIP)
                     pipeline.put({"op": "report", "test": self.instance})
                 else:
                     pipeline.put({"op": "build", "test": self.instance})
@@ -647,18 +647,18 @@ class ProjectBuilder(FilterBuilder):
             logger.debug("build test: %s" % self.instance.name)
             ret = self.build()
             if not ret:
-                self.instance.status = TestInstanceStatus.ERROR
+                self.instance.status = TwisterStatus.ERROR
                 self.instance.reason = "Build Failure"
                 pipeline.put({"op": "report", "test": self.instance})
             else:
                 # Count skipped cases during build, for example
                 # due to ram/rom overflow.
-                if  self.instance.status == TestInstanceStatus.SKIP:
+                if  self.instance.status == TwisterStatus.SKIP:
                     results.skipped_runtime += 1
-                    self.instance.add_missing_case_status(TestCaseStatus.SKIP, self.instance.reason)
+                    self.instance.add_missing_case_status(TwisterStatus.SKIP, self.instance.reason)
 
                 if ret.get('returncode', 1) > 0:
-                    self.instance.add_missing_case_status(TestCaseStatus.BLOCK, self.instance.reason)
+                    self.instance.add_missing_case_status(TwisterStatus.BLOCK, self.instance.reason)
                     pipeline.put({"op": "report", "test": self.instance})
                 else:
                     if self.instance.testsuite.harness in ['ztest', 'test']:
@@ -668,7 +668,7 @@ class ProjectBuilder(FilterBuilder):
                             pipeline.put({"op": "gather_metrics", "test": self.instance})
                         except BuildError as e:
                             logger.error(str(e))
-                            self.instance.status = TestInstanceStatus.ERROR
+                            self.instance.status = TwisterStatus.ERROR
                             self.instance.reason = str(e)
                             pipeline.put({"op": "report", "test": self.instance})
                     else:
@@ -714,7 +714,7 @@ class ProjectBuilder(FilterBuilder):
             if not self.options.coverage:
                 if self.options.prep_artifacts_for_testing:
                     pipeline.put({"op": "cleanup", "mode": "device", "test": self.instance})
-                elif self.options.runtime_artifact_cleanup == "pass" and self.instance.status == TestInstanceStatus.PASS:
+                elif self.options.runtime_artifact_cleanup == "pass" and self.instance.status == TwisterStatus.PASS:
                     pipeline.put({"op": "cleanup", "mode": "passed", "test": self.instance})
                 elif self.options.runtime_artifact_cleanup == "all":
                     pipeline.put({"op": "cleanup", "mode": "all", "test": self.instance})
@@ -967,8 +967,8 @@ class ProjectBuilder(FilterBuilder):
         if results.iteration == 1:
             results.cases += len(instance.testcases)
 
-        if instance.status in [TestInstanceStatus.ERROR, TestInstanceStatus.FAIL]:
-            if instance.status == TestInstanceStatus.ERROR:
+        if instance.status in [TwisterStatus.ERROR, TwisterStatus.FAIL]:
+            if instance.status == TwisterStatus.ERROR:
                 results.error += 1
                 txt = " ERROR "
             else:
@@ -987,17 +987,17 @@ class ProjectBuilder(FilterBuilder):
                         instance.reason))
             if not self.options.verbose:
                 self.log_info_file(self.options.inline_logs)
-        elif instance.status in [TestInstanceStatus.SKIP, TestInstanceStatus.FILTER]:
+        elif instance.status in [TwisterStatus.SKIP, TwisterStatus.FILTER]:
             status = Fore.YELLOW + "SKIPPED" + Fore.RESET
             results.skipped_configs += 1
             # test cases skipped at the test instance level
             results.skipped_cases += len(instance.testsuite.testcases)
-        elif instance.status == TestInstanceStatus.PASS:
+        elif instance.status == TwisterStatus.PASS:
             status = Fore.GREEN + "PASSED" + Fore.RESET
             results.passed += 1
             for case in instance.testcases:
                 # test cases skipped at the test case level
-                if case.status == TestCaseStatus.SKIP:
+                if case.status == TwisterStatus.SKIP:
                     results.skipped_cases += 1
         else:
             logger.debug(f"Unknown status = {instance.status}")
@@ -1006,7 +1006,7 @@ class ProjectBuilder(FilterBuilder):
         if self.options.verbose:
             if self.options.cmake_only:
                 more_info = "cmake"
-            elif instance.status in [TestInstanceStatus.SKIP, TestInstanceStatus.FILTER]:
+            elif instance.status in [TwisterStatus.SKIP, TwisterStatus.FILTER]:
                 more_info = instance.reason
             else:
                 if instance.handler.ready and instance.run:
@@ -1019,7 +1019,7 @@ class ProjectBuilder(FilterBuilder):
                 else:
                     more_info = "build"
 
-                if ( instance.status in [TestInstanceStatus.ERROR, TestInstanceStatus.FAIL]
+                if ( instance.status in [TwisterStatus.ERROR, TwisterStatus.FAIL]
                      and hasattr(self.instance.handler, 'seed')
                      and self.instance.handler.seed is not None ):
                     more_info += "/seed: " + str(self.options.seed)
@@ -1027,7 +1027,7 @@ class ProjectBuilder(FilterBuilder):
                 results.done, total_tests_width, total_to_do , instance.platform.name,
                 instance.testsuite.name, status, more_info))
 
-            if instance.status in [TestInstanceStatus.ERROR, TestInstanceStatus.FAIL]:
+            if instance.status in [TwisterStatus.ERROR, TwisterStatus.FAIL]:
                 self.log_info_file(self.options.inline_logs)
         else:
             completed_perc = 0
@@ -1110,7 +1110,7 @@ class ProjectBuilder(FilterBuilder):
                 harness.instance = self.instance
                 harness.build()
         except ConfigurationError as error:
-            self.instance.status = TestInstanceStatus.ERROR
+            self.instance.status = TwisterStatus.ERROR
             self.instance.reason = str(error)
             logger.error(self.instance.reason)
             return
@@ -1122,7 +1122,7 @@ class ProjectBuilder(FilterBuilder):
 
         if instance.handler.ready:
             logger.debug(f"Reset instance status from '{instance.status}' to None before run.")
-            instance.status = TestInstanceStatus.NONE
+            instance.status = TwisterStatus.NONE
 
             if instance.handler.type_str == "device":
                 instance.handler.duts = self.duts
@@ -1140,7 +1140,7 @@ class ProjectBuilder(FilterBuilder):
             try:
                 harness.configure(instance)
             except ConfigurationError as error:
-                instance.status = TestInstanceStatus.ERROR
+                instance.status = TwisterStatus.ERROR
                 instance.reason = str(error)
                 logger.error(instance.reason)
                 return
@@ -1168,7 +1168,7 @@ class ProjectBuilder(FilterBuilder):
 
     @staticmethod
     def calc_size(instance: TestInstance, from_buildlog: bool):
-        if instance.status not in [TestInstanceStatus.ERROR, TestInstanceStatus.FAIL, TestInstanceStatus.SKIP]:
+        if instance.status not in [TwisterStatus.ERROR, TwisterStatus.FAIL, TwisterStatus.SKIP]:
             if not instance.platform.type in ["native", "qemu", "unit"]:
                 generate_warning = bool(instance.platform.type == "mcu")
                 size_calc = instance.calculate_sizes(from_buildlog=from_buildlog, generate_warning=generate_warning)
@@ -1279,12 +1279,12 @@ class TwisterRunner:
         the static filter stats. So need to prepare them before pipline starts.
         '''
         for instance in self.instances.values():
-            if instance.status == TestInstanceStatus.FILTER and not instance.reason == 'runtime filter':
+            if instance.status == TwisterStatus.FILTER and not instance.reason == 'runtime filter':
                 self.results.skipped_filter += 1
                 self.results.skipped_configs += 1
                 self.results.skipped_cases += len(instance.testsuite.testcases)
                 self.results.cases += len(instance.testsuite.testcases)
-            elif instance.status == TestInstanceStatus.ERROR:
+            elif instance.status == TwisterStatus.ERROR:
                 self.results.error += 1
 
     def show_brief(self):
@@ -1300,15 +1300,15 @@ class TwisterRunner:
             if build_only:
                 instance.run = False
 
-            no_retry_statuses = [TestInstanceStatus.PASS, TestInstanceStatus.SKIP, TestInstanceStatus.FILTER]
+            no_retry_statuses = [TwisterStatus.PASS, TwisterStatus.SKIP, TwisterStatus.FILTER]
             if not retry_build_errors:
                 no_retry_statuses.append("error")
 
             if instance.status not in no_retry_statuses:
                 logger.debug(f"adding {instance.name}")
-                if instance.status != TestInstanceStatus.NONE:
+                if instance.status != TwisterStatus.NONE:
                     instance.retries += 1
-                instance.status = TestInstanceStatus.NONE
+                instance.status = TwisterStatus.NONE
 
                 # Check if cmake package_helper script can be run in advance.
                 instance.filter_stages = []

--- a/scripts/pylib/twister/twisterlib/statuses.py
+++ b/scripts/pylib/twister/twisterlib/statuses.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Status classes to be used instead of str statuses.
+"""
+
+from enum import Enum
+
+
+class TestInstanceStatus(str, Enum):
+    def __str__(self):
+        return str(self.value)
+
+    NONE = None  # to preserve old functionality
+    ERROR = 'error'
+    FAIL = 'failed'
+    FILTER = 'filtered'
+    FLASH = 'flash_error'
+    PASS = 'passed'
+    SKIP = 'skipped'
+    TIMEOUT = 'timeout'
+
+
+# Possible direct assignments:
+#   * TestSuiteStatus <- TestInstanceStatus
+class TestSuiteStatus(str, Enum):
+    def __str__(self):
+        return str(self.value)
+
+    NONE = None  # to preserve old functionality
+    FILTER = 'filtered'
+    PASS = 'passed'
+    SKIP = 'skipped'
+
+
+# Possible direct assignments:
+#    * TestCaseStatus <- TestInstanceStatus
+class TestCaseStatus(str, Enum):
+    def __str__(self):
+        return str(self.value)
+
+    NONE = None  # to preserve old functionality
+    BLOCK = 'blocked'
+    ERROR = 'error'
+    FAIL = 'failed'
+    FILTER = 'filtered'
+    PASS = 'passed'
+    SKIP = 'skipped'
+    STARTED = 'started'
+
+
+# Possible direct assignments:
+#   * OutputStatus <- HarnessStatus
+class OutputStatus(str, Enum):
+    def __str__(self):
+        return str(self.value)
+
+    NONE = None  # to preserve old functionality
+    BYTE = 'unexpected byte'
+    EOF = 'unexpected eof'
+    FAIL = 'failed'
+    TIMEOUT = 'timeout'
+
+
+# Possible direct assignments:
+#   * TestInstanceStatus <- HarnessStatus
+class HarnessStatus(str, Enum):
+    def __str__(self):
+        return str(self.value)
+
+    NONE = None  # to preserve old functionality
+    ERROR = 'error'
+    FAIL = 'failed'
+    PASS = 'passed'
+    SKIP = 'skipped'
+
+
+class ReportStatus(str, Enum):
+    def __str__(self):
+        return str(self.value)
+
+    ERROR = 'error'
+    FAIL = 'failure'  # Note the difference!
+    SKIP = 'skipped'

--- a/scripts/pylib/twister/twisterlib/statuses.py
+++ b/scripts/pylib/twister/twisterlib/statuses.py
@@ -17,10 +17,8 @@ class TestInstanceStatus(str, Enum):
     ERROR = 'error'
     FAIL = 'failed'
     FILTER = 'filtered'
-    FLASH = 'flash_error'
     PASS = 'passed'
     SKIP = 'skipped'
-    TIMEOUT = 'timeout'
 
 
 # Possible direct assignments:

--- a/scripts/pylib/twister/twisterlib/statuses.py
+++ b/scripts/pylib/twister/twisterlib/statuses.py
@@ -9,76 +9,21 @@ Status classes to be used instead of str statuses.
 from enum import Enum
 
 
-class TestInstanceStatus(str, Enum):
+class TwisterStatus(str, Enum):
     def __str__(self):
         return str(self.value)
 
-    NONE = None  # to preserve old functionality
-    ERROR = 'error'
-    FAIL = 'failed'
-    FILTER = 'filtered'
-    PASS = 'passed'
-    SKIP = 'skipped'
-
-
-# Possible direct assignments:
-#   * TestSuiteStatus <- TestInstanceStatus
-class TestSuiteStatus(str, Enum):
-    def __str__(self):
-        return str(self.value)
-
-    NONE = None  # to preserve old functionality
-    FILTER = 'filtered'
-    PASS = 'passed'
-    SKIP = 'skipped'
-
-
-# Possible direct assignments:
-#    * TestCaseStatus <- TestInstanceStatus
-class TestCaseStatus(str, Enum):
-    def __str__(self):
-        return str(self.value)
-
-    NONE = None  # to preserve old functionality
+    # All statuses below this comment can be used for TestCase
     BLOCK = 'blocked'
-    ERROR = 'error'
-    FAIL = 'failed'
-    FILTER = 'filtered'
-    PASS = 'passed'
-    SKIP = 'skipped'
     STARTED = 'started'
 
+    # All statuses below this comment can be used for TestSuite
+    # All statuses below this comment can be used for TestInstance
+    FILTER = 'filtered'
 
-# Possible direct assignments:
-#   * OutputStatus <- HarnessStatus
-class OutputStatus(str, Enum):
-    def __str__(self):
-        return str(self.value)
-
-    NONE = None  # to preserve old functionality
-    BYTE = 'unexpected byte'
-    EOF = 'unexpected eof'
-    FAIL = 'failed'
-    TIMEOUT = 'timeout'
-
-
-# Possible direct assignments:
-#   * TestInstanceStatus <- HarnessStatus
-class HarnessStatus(str, Enum):
-    def __str__(self):
-        return str(self.value)
-
-    NONE = None  # to preserve old functionality
+    # All statuses below this comment can be used for Harness
+    NONE = None
     ERROR = 'error'
     FAIL = 'failed'
     PASS = 'passed'
-    SKIP = 'skipped'
-
-
-class ReportStatus(str, Enum):
-    def __str__(self):
-        return str(self.value)
-
-    ERROR = 'error'
-    FAIL = 'failure'  # Note the difference!
     SKIP = 'skipped'

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -16,6 +16,7 @@ from twisterlib.testsuite import TestCase, TestSuite
 from twisterlib.platform import Platform
 from twisterlib.error import BuildError
 from twisterlib.size_calc import SizeCalculator
+from twisterlib.statuses import TestCaseStatus, TestInstanceStatus
 from twisterlib.handlers import (
     Handler,
     SimulationHandler,
@@ -46,7 +47,7 @@ class TestInstance:
         self.testsuite: TestSuite = testsuite
         self.platform: Platform = platform
 
-        self.status = None
+        self.status = TestInstanceStatus.NONE
         self.reason = "Unknown"
         self.metrics = dict()
         self.handler = None
@@ -94,7 +95,7 @@ class TestInstance:
 
     def add_filter(self, reason, filter_type):
         self.filters.append({'type': filter_type, 'reason': reason })
-        self.status = "filtered"
+        self.status = TestInstanceStatus.FILTER
         self.reason = reason
         self.filter_type = filter_type
 
@@ -124,9 +125,9 @@ class TestInstance:
 
     def add_missing_case_status(self, status, reason=None):
         for case in self.testcases:
-            if case.status == 'started':
-                case.status = "failed"
-            elif not case.status:
+            if case.status == TestCaseStatus.STARTED:
+                case.status = TestCaseStatus.FAIL
+            elif case.status == TestCaseStatus.NONE:
                 case.status = status
                 if reason:
                     case.reason = reason

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -4,6 +4,7 @@
 # Copyright 2022 NXP
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
+from enum import Enum
 import os
 import hashlib
 import random
@@ -16,7 +17,7 @@ from twisterlib.testsuite import TestCase, TestSuite
 from twisterlib.platform import Platform
 from twisterlib.error import BuildError
 from twisterlib.size_calc import SizeCalculator
-from twisterlib.statuses import TestCaseStatus, TestInstanceStatus
+from twisterlib.statuses import TwisterStatus
 from twisterlib.handlers import (
     Handler,
     SimulationHandler,
@@ -47,7 +48,7 @@ class TestInstance:
         self.testsuite: TestSuite = testsuite
         self.platform: Platform = platform
 
-        self.status = TestInstanceStatus.NONE
+        self._status = TwisterStatus.NONE
         self.reason = "Unknown"
         self.metrics = dict()
         self.handler = None
@@ -93,9 +94,24 @@ class TestInstance:
                 cw.writeheader()
                 cw.writerows(self.recording)
 
+    @property
+    def status(self) -> TwisterStatus:
+        return self._status
+
+    @status.setter
+    def status(self, value : TwisterStatus) -> None:
+        # Check for illegal assignments by value
+        try:
+            key = value.name if isinstance(value, Enum) else value
+            self._status = TwisterStatus[key]
+        except KeyError:
+            logger.warning(f'TestInstance assigned status "{value}"'
+                           f' without an equivalent in TwisterStatus.'
+                           f' Assignment was ignored.')
+
     def add_filter(self, reason, filter_type):
         self.filters.append({'type': filter_type, 'reason': reason })
-        self.status = TestInstanceStatus.FILTER
+        self.status = TwisterStatus.FILTER
         self.reason = reason
         self.filter_type = filter_type
 
@@ -125,9 +141,9 @@ class TestInstance:
 
     def add_missing_case_status(self, status, reason=None):
         for case in self.testcases:
-            if case.status == TestCaseStatus.STARTED:
-                case.status = TestCaseStatus.FAIL
-            elif case.status == TestCaseStatus.NONE:
+            if case.status == TwisterStatus.STARTED:
+                case.status = TwisterStatus.FAIL
+            elif case.status == TwisterStatus.NONE:
                 case.status = status
                 if reason:
                     case.reason = reason

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -105,7 +105,7 @@ class TestInstance:
             key = value.name if isinstance(value, Enum) else value
             self._status = TwisterStatus[key]
         except KeyError:
-            logger.warning(f'TestInstance assigned status "{value}"'
+            logger.error(f'TestInstance assigned status "{value}"'
                            f' without an equivalent in TwisterStatus.'
                            f' Assignment was ignored.')
 

--- a/scripts/pylib/twister/twisterlib/testsuite.py
+++ b/scripts/pylib/twister/twisterlib/testsuite.py
@@ -11,9 +11,11 @@ import contextlib
 import mmap
 import glob
 from typing import List
+
 from twisterlib.mixins import DisablePyTestCollectionMixin
 from twisterlib.environment import canonical_zephyr_base
 from twisterlib.error import TwisterException, TwisterRuntimeError
+from twisterlib.statuses import TestCaseStatus
 
 logger = logging.getLogger('twister')
 logger.setLevel(logging.DEBUG)
@@ -357,7 +359,7 @@ class TestCase(DisablePyTestCollectionMixin):
     def __init__(self, name=None, testsuite=None):
         self.duration = 0
         self.name = name
-        self.status = None
+        self.status = TestCaseStatus.NONE
         self.reason = None
         self.testsuite = testsuite
         self.output = ""

--- a/scripts/pylib/twister/twisterlib/testsuite.py
+++ b/scripts/pylib/twister/twisterlib/testsuite.py
@@ -377,7 +377,7 @@ class TestCase(DisablePyTestCollectionMixin):
             key = value.name if isinstance(value, Enum) else value
             self._status = TwisterStatus[key]
         except KeyError:
-            logger.warning(f'TestCase assigned status "{value}"'
+            logger.error(f'TestCase assigned status "{value}"'
                            f' without an equivalent in TwisterStatus.'
                            f' Assignment was ignored.')
 
@@ -445,7 +445,7 @@ class TestSuite(DisablePyTestCollectionMixin):
             key = value.name if isinstance(value, Enum) else value
             self._status = TwisterStatus[key]
         except KeyError:
-            logger.warning(f'TestSuite assigned status "{value}"'
+            logger.error(f'TestSuite assigned status "{value}"'
                            f' without an equivalent in TwisterStatus.'
                            f' Assignment was ignored.')
 

--- a/scripts/pylib/twister/twisterlib/twister_main.py
+++ b/scripts/pylib/twister/twisterlib/twister_main.py
@@ -12,6 +12,7 @@ import time
 
 from colorama import Fore
 
+from twisterlib.statuses import TestInstanceStatus
 from twisterlib.testplan import TestPlan
 from twisterlib.reports import Reporting
 from twisterlib.hardwaremap import HardwareMap
@@ -141,7 +142,7 @@ def main(options, default_options):
         # command line
 
         for i in tplan.instances.values():
-            if i.status == "filtered":
+            if i.status == TestInstanceStatus.FILTER:
                 if options.platform and i.platform.name not in options.platform:
                     continue
                 logger.debug(

--- a/scripts/pylib/twister/twisterlib/twister_main.py
+++ b/scripts/pylib/twister/twisterlib/twister_main.py
@@ -12,7 +12,7 @@ import time
 
 from colorama import Fore
 
-from twisterlib.statuses import TestInstanceStatus
+from twisterlib.statuses import TwisterStatus
 from twisterlib.testplan import TestPlan
 from twisterlib.reports import Reporting
 from twisterlib.hardwaremap import HardwareMap
@@ -142,7 +142,7 @@ def main(options, default_options):
         # command line
 
         for i in tplan.instances.values():
-            if i.status == TestInstanceStatus.FILTER:
+            if i.status == TwisterStatus.FILTER:
                 if options.platform and i.platform.name not in options.platform:
                     continue
                 logger.debug(

--- a/scripts/tests/twister/pytest_integration/test_harness_pytest.py
+++ b/scripts/tests/twister/pytest_integration/test_harness_pytest.py
@@ -169,7 +169,7 @@ def test_if_report_is_parsed(pytester, testinstance: TestInstance):
 
     pytest_harness._update_test_status()
 
-    assert pytest_harness.state == "passed"
+    assert pytest_harness.status == "passed"
     assert testinstance.status == "passed"
     assert len(testinstance.testcases) == 2
     for tc in testinstance.testcases:
@@ -199,7 +199,7 @@ def test_if_report_with_error(pytester, testinstance: TestInstance):
 
     pytest_harness._update_test_status()
 
-    assert pytest_harness.state == "failed"
+    assert pytest_harness.status == "failed"
     assert testinstance.status == "failed"
     assert len(testinstance.testcases) == 2
     for tc in testinstance.testcases:
@@ -235,7 +235,7 @@ def test_if_report_with_skip(pytester, testinstance: TestInstance):
 
     pytest_harness._update_test_status()
 
-    assert pytest_harness.state == "skipped"
+    assert pytest_harness.status == "skipped"
     assert testinstance.status == "skipped"
     assert len(testinstance.testcases) == 2
     for tc in testinstance.testcases:
@@ -265,7 +265,7 @@ def test_if_report_with_filter(pytester, testinstance: TestInstance):
     pytest_harness.configure(testinstance)
     pytest_harness.report_file = report_file
     pytest_harness._update_test_status()
-    assert pytest_harness.state == "passed"
+    assert pytest_harness.status == "passed"
     assert testinstance.status == "passed"
     assert len(testinstance.testcases) == 1
 
@@ -291,5 +291,5 @@ def test_if_report_with_no_collected(pytester, testinstance: TestInstance):
     pytest_harness.configure(testinstance)
     pytest_harness.report_file = report_file
     pytest_harness._update_test_status()
-    assert pytest_harness.state == "skipped"
+    assert pytest_harness.status == "skipped"
     assert testinstance.status == "skipped"

--- a/scripts/tests/twister/test_harness.py
+++ b/scripts/tests/twister/test_harness.py
@@ -13,18 +13,24 @@ import pytest
 import re
 import logging as logger
 
-ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
+#ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
+from conftest import ZEPHYR_BASE
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
 
-from twisterlib.harness import Gtest, Bsim
-from twisterlib.harness import Harness
-from twisterlib.harness import Robot
-from twisterlib.harness import Test
+#from scripts.pylib.twister.twisterlib.statuses import HarnessStatus, TestCaseStatus, TestInstanceStatus
+from twisterlib.harness import (
+    Bsim,
+    Console,
+    Gtest,
+    Harness,
+    HarnessImporter,
+    Pytest,
+    PytestHarnessException,
+    Robot,
+    Test
+)
+from twisterlib.statuses import HarnessStatus, TestCaseStatus, TestInstanceStatus
 from twisterlib.testinstance import TestInstance
-from twisterlib.harness import Console
-from twisterlib.harness import Pytest
-from twisterlib.harness import PytestHarnessException
-from twisterlib.harness import HarnessImporter
 
 GTEST_START_STATE = " RUN      "
 GTEST_PASS_STATE = "       OK "
@@ -87,13 +93,14 @@ def test_harness_parse_record(lines, pattern, expected_records, as_json):
     assert harness.recording == expected_records
 
 
-TEST_DATA_1 = [('RunID: 12345', False, False, False, None, True),
-                ('PROJECT EXECUTION SUCCESSFUL', False, False, False, 'passed', False),
-                ('PROJECT EXECUTION SUCCESSFUL', True, False, False, 'failed', False),
-                ('PROJECT EXECUTION FAILED', False, False, False, 'failed', False),
-                ('ZEPHYR FATAL ERROR', False, True, False, None, False),
-                ('GCOV_COVERAGE_DUMP_START', None, None, True, None, False),
-                ('GCOV_COVERAGE_DUMP_END', None, None, False, None, False),]
+TEST_DATA_1 = [('RunID: 12345', False, False, False, HarnessStatus.NONE, True),
+                ('PROJECT EXECUTION SUCCESSFUL', False, False, False, HarnessStatus.PASS, False),
+                ('PROJECT EXECUTION SUCCESSFUL', True, False, False, HarnessStatus.FAIL, False),
+                ('PROJECT EXECUTION FAILED', False, False, False, HarnessStatus.FAIL, False),
+                ('ZEPHYR FATAL ERROR', False, True, False, HarnessStatus.NONE, False),
+                ('GCOV_COVERAGE_DUMP_START', None, None, True, HarnessStatus.NONE, False),
+                ('GCOV_COVERAGE_DUMP_END', None, None, False, HarnessStatus.NONE, False),]
+
 @pytest.mark.parametrize(
     "line, fault, fail_on_fault, cap_cov, exp_stat, exp_id",
     TEST_DATA_1,
@@ -103,7 +110,7 @@ def test_harness_process_test(line, fault, fail_on_fault, cap_cov, exp_stat, exp
     #Arrange
     harness = Harness()
     harness.run_id = 12345
-    harness.state = None
+    harness.state = HarnessStatus.NONE
     harness.fault = fault
     harness.fail_on_fault = fail_on_fault
     mock.patch.object(Harness, 'parse_record', return_value=None)
@@ -173,11 +180,14 @@ def test_robot_handle(tmp_path):
     tc = instance.get_case_or_create('test_case_1')
 
     #Assert
-    assert instance.state == "passed"
-    assert tc.status == "passed"
+    assert instance.state == TestInstanceStatus.PASS
+    assert tc.status == TestCaseStatus.PASS
 
 
-TEST_DATA_2 = [("", 0, "passed"), ("Robot test failure: sourcedir for mock_platform", 1, "failed"),]
+TEST_DATA_2 = [
+    ("", 0, TestInstanceStatus.PASS),
+    ("Robot test failure: sourcedir for mock_platform", 1, TestInstanceStatus.FAIL),
+]
 @pytest.mark.parametrize(
     "exp_out, returncode, expected_status",
     TEST_DATA_2,
@@ -272,13 +282,13 @@ def test_console_configure(tmp_path, type, num_patterns):
         assert console.pattern.pattern == 'pattern1'
 
 
-TEST_DATA_4 = [("one_line", True, "passed", "line", False, False),
-                ("multi_line", True, "passed", "line", False, False),
-                ("multi_line", False, "passed", "line", False, False),
-                ("invalid_type", False, None, "line", False, False),
-                ("invalid_type", False, None, "ERROR", True, False),
-                ("invalid_type", False, None, "COVERAGE_START", False, True),
-                ("invalid_type", False, None, "COVERAGE_END", False, False)]
+TEST_DATA_4 = [("one_line", True, HarnessStatus.PASS, "line", False, False),
+                ("multi_line", True, HarnessStatus.PASS, "line", False, False),
+                ("multi_line", False, HarnessStatus.PASS, "line", False, False),
+                ("invalid_type", False, HarnessStatus.NONE, "line", False, False),
+                ("invalid_type", False, HarnessStatus.NONE, "ERROR", True, False),
+                ("invalid_type", False, HarnessStatus.NONE, "COVERAGE_START", False, True),
+                ("invalid_type", False, HarnessStatus.NONE, "COVERAGE_END", False, False)]
 @pytest.mark.parametrize(
     "line_type, ordered_val, exp_state, line, exp_fault, exp_capture",
     TEST_DATA_4,
@@ -304,7 +314,7 @@ def test_console_handle(tmp_path, line_type, ordered_val, exp_state, line, exp_f
     console.patterns = [re.compile("pattern1"), re.compile("pattern2")]
     console.pattern = re.compile("pattern")
     console.patterns_expected = 0
-    console.state = None
+    console.state = HarnessStatus.NONE
     console.fail_on_fault = True
     console.FAULT = "ERROR"
     console.GCOV_START = "COVERAGE_START"
@@ -461,7 +471,7 @@ def test_pytest_run(tmp_path, caplog):
     # Act
     test_obj.pytest_run(timeout)
     # Assert
-    assert test_obj.state == 'failed'
+    assert test_obj.state == HarnessStatus.FAIL
     assert exp_out in caplog.text
 
 
@@ -483,13 +493,13 @@ def test_get_harness(name):
     assert isinstance(harness_class, Test)
 
 
-TEST_DATA_7 = [("", "Running TESTSUITE suite_name", ['suite_name'], None, True, None),
-            ("", "START - test_testcase", [], "started", True, None),
-            ("", "PASS - test_example in 0 seconds", [], "passed", True, None),
-            ("", "SKIP - test_example in 0 seconds", [], "skipped", True, None),
-            ("", "FAIL - test_example in 0 seconds", [], "failed", True, None),
-            ("not a ztest and no state for test_id", "START - test_testcase", [], "passed", False, "passed"),
-            ("not a ztest and no state for test_id", "START - test_testcase", [], "failed", False, "failed")]
+TEST_DATA_7 = [("", "Running TESTSUITE suite_name", ['suite_name'], TestCaseStatus.NONE, True, HarnessStatus.NONE),
+            ("", "START - test_testcase", [], TestCaseStatus.STARTED, True, HarnessStatus.NONE),
+            ("", "PASS - test_example in 0 seconds", [], TestCaseStatus.PASS, True, HarnessStatus.NONE),
+            ("", "SKIP - test_example in 0 seconds", [], TestCaseStatus.SKIP, True, HarnessStatus.NONE),
+            ("", "FAIL - test_example in 0 seconds", [], TestCaseStatus.FAIL, True, HarnessStatus.NONE),
+            ("not a ztest and no state for test_id", "START - test_testcase", [], TestCaseStatus.PASS, False, HarnessStatus.PASS),
+            ("not a ztest and no state for test_id", "START - test_testcase", [], TestCaseStatus.FAIL, False, HarnessStatus.FAIL)]
 @pytest.mark.parametrize(
    "exp_out, line, exp_suite_name, exp_status, ztest, state",
    TEST_DATA_7,
@@ -553,7 +563,7 @@ def gtest(tmp_path):
 def test_gtest_start_test_no_suites_detected(gtest):
     process_logs(gtest, [SAMPLE_GTEST_START])
     assert len(gtest.detected_suite_names) == 0
-    assert gtest.state is None
+    assert gtest.state == HarnessStatus.NONE
 
 
 def test_gtest_start_test(gtest):
@@ -566,12 +576,12 @@ def test_gtest_start_test(gtest):
             ),
         ],
     )
-    assert gtest.state is None
+    assert gtest.state == HarnessStatus.NONE
     assert len(gtest.detected_suite_names) == 1
     assert gtest.detected_suite_names[0] == "suite_name"
     assert gtest.instance.get_case_by_name("id.suite_name.test_name") is not None
     assert (
-        gtest.instance.get_case_by_name("id.suite_name.test_name").status == "started"
+        gtest.instance.get_case_by_name("id.suite_name.test_name").status == TestCaseStatus.STARTED
     )
 
 
@@ -588,11 +598,11 @@ def test_gtest_pass(gtest):
             ),
         ],
     )
-    assert gtest.state is None
+    assert gtest.state == HarnessStatus.NONE
     assert len(gtest.detected_suite_names) == 1
     assert gtest.detected_suite_names[0] == "suite_name"
-    assert gtest.instance.get_case_by_name("id.suite_name.test_name") is not None
-    assert gtest.instance.get_case_by_name("id.suite_name.test_name").status == "passed"
+    assert gtest.instance.get_case_by_name("id.suite_name.test_name") != TestCaseStatus.NONE
+    assert gtest.instance.get_case_by_name("id.suite_name.test_name").status == TestCaseStatus.PASS
 
 
 def test_gtest_failed(gtest):
@@ -608,11 +618,11 @@ def test_gtest_failed(gtest):
             ),
         ],
     )
-    assert gtest.state is None
+    assert gtest.state == HarnessStatus.NONE
     assert len(gtest.detected_suite_names) == 1
     assert gtest.detected_suite_names[0] == "suite_name"
-    assert gtest.instance.get_case_by_name("id.suite_name.test_name") is not None
-    assert gtest.instance.get_case_by_name("id.suite_name.test_name").status == "failed"
+    assert gtest.instance.get_case_by_name("id.suite_name.test_name") != TestCaseStatus.NONE
+    assert gtest.instance.get_case_by_name("id.suite_name.test_name").status == TestCaseStatus.FAIL
 
 
 def test_gtest_skipped(gtest):
@@ -628,11 +638,11 @@ def test_gtest_skipped(gtest):
             ),
         ],
     )
-    assert gtest.state is None
+    assert gtest.state == HarnessStatus.NONE
     assert len(gtest.detected_suite_names) == 1
     assert gtest.detected_suite_names[0] == "suite_name"
-    assert gtest.instance.get_case_by_name("id.suite_name.test_name") is not None
-    assert gtest.instance.get_case_by_name("id.suite_name.test_name").status == "skipped"
+    assert gtest.instance.get_case_by_name("id.suite_name.test_name") != TestCaseStatus.NONE
+    assert gtest.instance.get_case_by_name("id.suite_name.test_name").status == TestCaseStatus.SKIP
 
 
 def test_gtest_all_pass(gtest):
@@ -649,11 +659,11 @@ def test_gtest_all_pass(gtest):
             SAMPLE_GTEST_END,
         ],
     )
-    assert gtest.state == "passed"
+    assert gtest.state == HarnessStatus.PASS
     assert len(gtest.detected_suite_names) == 1
     assert gtest.detected_suite_names[0] == "suite_name"
-    assert gtest.instance.get_case_by_name("id.suite_name.test_name") is not None
-    assert gtest.instance.get_case_by_name("id.suite_name.test_name").status == "passed"
+    assert gtest.instance.get_case_by_name("id.suite_name.test_name") != TestCaseStatus.NONE
+    assert gtest.instance.get_case_by_name("id.suite_name.test_name").status == TestCaseStatus.PASS
 
 
 def test_gtest_one_skipped(gtest):
@@ -676,13 +686,13 @@ def test_gtest_one_skipped(gtest):
             SAMPLE_GTEST_END,
         ],
     )
-    assert gtest.state == "passed"
+    assert gtest.state == HarnessStatus.PASS
     assert len(gtest.detected_suite_names) == 1
     assert gtest.detected_suite_names[0] == "suite_name"
-    assert gtest.instance.get_case_by_name("id.suite_name.test_name") is not None
-    assert gtest.instance.get_case_by_name("id.suite_name.test_name").status == "passed"
-    assert gtest.instance.get_case_by_name("id.suite_name.test_name1") is not None
-    assert gtest.instance.get_case_by_name("id.suite_name.test_name1").status == "skipped"
+    assert gtest.instance.get_case_by_name("id.suite_name.test_name") != TestCaseStatus.NONE
+    assert gtest.instance.get_case_by_name("id.suite_name.test_name").status == TestCaseStatus.PASS
+    assert gtest.instance.get_case_by_name("id.suite_name.test_name1") != TestCaseStatus.NONE
+    assert gtest.instance.get_case_by_name("id.suite_name.test_name1").status == TestCaseStatus.SKIP
 
 
 def test_gtest_one_fail(gtest):
@@ -705,13 +715,13 @@ def test_gtest_one_fail(gtest):
             SAMPLE_GTEST_END,
         ],
     )
-    assert gtest.state == "failed"
+    assert gtest.state == HarnessStatus.FAIL
     assert len(gtest.detected_suite_names) == 1
     assert gtest.detected_suite_names[0] == "suite_name"
-    assert gtest.instance.get_case_by_name("id.suite_name.test0") is not None
-    assert gtest.instance.get_case_by_name("id.suite_name.test0").status == "passed"
-    assert gtest.instance.get_case_by_name("id.suite_name.test1") is not None
-    assert gtest.instance.get_case_by_name("id.suite_name.test1").status == "failed"
+    assert gtest.instance.get_case_by_name("id.suite_name.test0") != TestCaseStatus.NONE
+    assert gtest.instance.get_case_by_name("id.suite_name.test0").status == TestCaseStatus.PASS
+    assert gtest.instance.get_case_by_name("id.suite_name.test1") != TestCaseStatus.NONE
+    assert gtest.instance.get_case_by_name("id.suite_name.test1").status == TestCaseStatus.FAIL
 
 
 def test_gtest_missing_result(gtest):

--- a/scripts/tests/twister/test_harness.py
+++ b/scripts/tests/twister/test_harness.py
@@ -17,7 +17,6 @@ import logging as logger
 from conftest import ZEPHYR_BASE
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
 
-#from scripts.pylib.twister.twisterlib.statuses import HarnessStatus, TestCaseStatus, TestInstanceStatus
 from twisterlib.harness import (
     Bsim,
     Console,
@@ -29,7 +28,7 @@ from twisterlib.harness import (
     Robot,
     Test
 )
-from twisterlib.statuses import HarnessStatus, TestCaseStatus, TestInstanceStatus
+from twisterlib.statuses import TwisterStatus
 from twisterlib.testinstance import TestInstance
 
 GTEST_START_STATE = " RUN      "
@@ -93,13 +92,13 @@ def test_harness_parse_record(lines, pattern, expected_records, as_json):
     assert harness.recording == expected_records
 
 
-TEST_DATA_1 = [('RunID: 12345', False, False, False, HarnessStatus.NONE, True),
-                ('PROJECT EXECUTION SUCCESSFUL', False, False, False, HarnessStatus.PASS, False),
-                ('PROJECT EXECUTION SUCCESSFUL', True, False, False, HarnessStatus.FAIL, False),
-                ('PROJECT EXECUTION FAILED', False, False, False, HarnessStatus.FAIL, False),
-                ('ZEPHYR FATAL ERROR', False, True, False, HarnessStatus.NONE, False),
-                ('GCOV_COVERAGE_DUMP_START', None, None, True, HarnessStatus.NONE, False),
-                ('GCOV_COVERAGE_DUMP_END', None, None, False, HarnessStatus.NONE, False),]
+TEST_DATA_1 = [('RunID: 12345', False, False, False, TwisterStatus.NONE, True),
+                ('PROJECT EXECUTION SUCCESSFUL', False, False, False, TwisterStatus.PASS, False),
+                ('PROJECT EXECUTION SUCCESSFUL', True, False, False, TwisterStatus.FAIL, False),
+                ('PROJECT EXECUTION FAILED', False, False, False, TwisterStatus.FAIL, False),
+                ('ZEPHYR FATAL ERROR', False, True, False, TwisterStatus.NONE, False),
+                ('GCOV_COVERAGE_DUMP_START', None, None, True, TwisterStatus.NONE, False),
+                ('GCOV_COVERAGE_DUMP_END', None, None, False, TwisterStatus.NONE, False),]
 
 @pytest.mark.parametrize(
     "line, fault, fail_on_fault, cap_cov, exp_stat, exp_id",
@@ -110,7 +109,7 @@ def test_harness_process_test(line, fault, fail_on_fault, cap_cov, exp_stat, exp
     #Arrange
     harness = Harness()
     harness.run_id = 12345
-    harness.state = HarnessStatus.NONE
+    harness.status = TwisterStatus.NONE
     harness.fault = fault
     harness.fail_on_fault = fail_on_fault
     mock.patch.object(Harness, 'parse_record', return_value=None)
@@ -120,7 +119,7 @@ def test_harness_process_test(line, fault, fail_on_fault, cap_cov, exp_stat, exp
 
     #Assert
     assert harness.matched_run_id == exp_id
-    assert harness.state == exp_stat
+    assert harness.status == exp_stat
     assert harness.capture_coverage == cap_cov
     assert harness.recording == []
 
@@ -180,13 +179,13 @@ def test_robot_handle(tmp_path):
     tc = instance.get_case_or_create('test_case_1')
 
     #Assert
-    assert instance.state == TestInstanceStatus.PASS
-    assert tc.status == TestCaseStatus.PASS
+    assert instance.status == TwisterStatus.PASS
+    assert tc.status == TwisterStatus.PASS
 
 
 TEST_DATA_2 = [
-    ("", 0, TestInstanceStatus.PASS),
-    ("Robot test failure: sourcedir for mock_platform", 1, TestInstanceStatus.FAIL),
+    ("", 0, TwisterStatus.PASS),
+    ("Robot test failure: sourcedir for mock_platform", 1, TwisterStatus.FAIL),
 ]
 @pytest.mark.parametrize(
     "exp_out, returncode, expected_status",
@@ -282,13 +281,13 @@ def test_console_configure(tmp_path, type, num_patterns):
         assert console.pattern.pattern == 'pattern1'
 
 
-TEST_DATA_4 = [("one_line", True, HarnessStatus.PASS, "line", False, False),
-                ("multi_line", True, HarnessStatus.PASS, "line", False, False),
-                ("multi_line", False, HarnessStatus.PASS, "line", False, False),
-                ("invalid_type", False, HarnessStatus.NONE, "line", False, False),
-                ("invalid_type", False, HarnessStatus.NONE, "ERROR", True, False),
-                ("invalid_type", False, HarnessStatus.NONE, "COVERAGE_START", False, True),
-                ("invalid_type", False, HarnessStatus.NONE, "COVERAGE_END", False, False)]
+TEST_DATA_4 = [("one_line", True, TwisterStatus.PASS, "line", False, False),
+                ("multi_line", True, TwisterStatus.PASS, "line", False, False),
+                ("multi_line", False, TwisterStatus.PASS, "line", False, False),
+                ("invalid_type", False, TwisterStatus.NONE, "line", False, False),
+                ("invalid_type", False, TwisterStatus.NONE, "ERROR", True, False),
+                ("invalid_type", False, TwisterStatus.NONE, "COVERAGE_START", False, True),
+                ("invalid_type", False, TwisterStatus.NONE, "COVERAGE_END", False, False)]
 @pytest.mark.parametrize(
     "line_type, ordered_val, exp_state, line, exp_fault, exp_capture",
     TEST_DATA_4,
@@ -314,7 +313,7 @@ def test_console_handle(tmp_path, line_type, ordered_val, exp_state, line, exp_f
     console.patterns = [re.compile("pattern1"), re.compile("pattern2")]
     console.pattern = re.compile("pattern")
     console.patterns_expected = 0
-    console.state = HarnessStatus.NONE
+    console.status = TwisterStatus.NONE
     console.fail_on_fault = True
     console.FAULT = "ERROR"
     console.GCOV_START = "COVERAGE_START"
@@ -337,7 +336,7 @@ def test_console_handle(tmp_path, line_type, ordered_val, exp_state, line, exp_f
     line2 = "pattern2"
     console.handle(line1)
     console.handle(line2)
-    assert console.state == exp_state
+    assert console.status == exp_state
     with pytest.raises(Exception):
         console.handle(line)
         assert logger.error.called
@@ -471,7 +470,7 @@ def test_pytest_run(tmp_path, caplog):
     # Act
     test_obj.pytest_run(timeout)
     # Assert
-    assert test_obj.state == HarnessStatus.FAIL
+    assert test_obj.status == TwisterStatus.FAIL
     assert exp_out in caplog.text
 
 
@@ -493,13 +492,13 @@ def test_get_harness(name):
     assert isinstance(harness_class, Test)
 
 
-TEST_DATA_7 = [("", "Running TESTSUITE suite_name", ['suite_name'], TestCaseStatus.NONE, True, HarnessStatus.NONE),
-            ("", "START - test_testcase", [], TestCaseStatus.STARTED, True, HarnessStatus.NONE),
-            ("", "PASS - test_example in 0 seconds", [], TestCaseStatus.PASS, True, HarnessStatus.NONE),
-            ("", "SKIP - test_example in 0 seconds", [], TestCaseStatus.SKIP, True, HarnessStatus.NONE),
-            ("", "FAIL - test_example in 0 seconds", [], TestCaseStatus.FAIL, True, HarnessStatus.NONE),
-            ("not a ztest and no state for test_id", "START - test_testcase", [], TestCaseStatus.PASS, False, HarnessStatus.PASS),
-            ("not a ztest and no state for test_id", "START - test_testcase", [], TestCaseStatus.FAIL, False, HarnessStatus.FAIL)]
+TEST_DATA_7 = [("", "Running TESTSUITE suite_name", ['suite_name'], TwisterStatus.NONE, True, TwisterStatus.NONE),
+            ("", "START - test_testcase", [], TwisterStatus.STARTED, True, TwisterStatus.NONE),
+            ("", "PASS - test_example in 0 seconds", [], TwisterStatus.PASS, True, TwisterStatus.NONE),
+            ("", "SKIP - test_example in 0 seconds", [], TwisterStatus.SKIP, True, TwisterStatus.NONE),
+            ("", "FAIL - test_example in 0 seconds", [], TwisterStatus.FAIL, True, TwisterStatus.NONE),
+            ("not a ztest and no state for test_id", "START - test_testcase", [], TwisterStatus.PASS, False, TwisterStatus.PASS),
+            ("not a ztest and no state for test_id", "START - test_testcase", [], TwisterStatus.FAIL, False, TwisterStatus.FAIL)]
 @pytest.mark.parametrize(
    "exp_out, line, exp_suite_name, exp_status, ztest, state",
    TEST_DATA_7,
@@ -525,7 +524,7 @@ def test_test_handle(tmp_path, caplog, exp_out, line, exp_suite_name, exp_status
     test_obj.configure(instance)
     test_obj.id = "test_id"
     test_obj.ztest = ztest
-    test_obj.state = state
+    test_obj.status = state
     test_obj.id = 'test_id'
     #Act
     test_obj.handle(line)
@@ -563,7 +562,7 @@ def gtest(tmp_path):
 def test_gtest_start_test_no_suites_detected(gtest):
     process_logs(gtest, [SAMPLE_GTEST_START])
     assert len(gtest.detected_suite_names) == 0
-    assert gtest.state == HarnessStatus.NONE
+    assert gtest.status == TwisterStatus.NONE
 
 
 def test_gtest_start_test(gtest):
@@ -576,12 +575,12 @@ def test_gtest_start_test(gtest):
             ),
         ],
     )
-    assert gtest.state == HarnessStatus.NONE
+    assert gtest.status == TwisterStatus.NONE
     assert len(gtest.detected_suite_names) == 1
     assert gtest.detected_suite_names[0] == "suite_name"
     assert gtest.instance.get_case_by_name("id.suite_name.test_name") is not None
     assert (
-        gtest.instance.get_case_by_name("id.suite_name.test_name").status == TestCaseStatus.STARTED
+        gtest.instance.get_case_by_name("id.suite_name.test_name").status == TwisterStatus.STARTED
     )
 
 
@@ -598,11 +597,11 @@ def test_gtest_pass(gtest):
             ),
         ],
     )
-    assert gtest.state == HarnessStatus.NONE
+    assert gtest.status == TwisterStatus.NONE
     assert len(gtest.detected_suite_names) == 1
     assert gtest.detected_suite_names[0] == "suite_name"
-    assert gtest.instance.get_case_by_name("id.suite_name.test_name") != TestCaseStatus.NONE
-    assert gtest.instance.get_case_by_name("id.suite_name.test_name").status == TestCaseStatus.PASS
+    assert gtest.instance.get_case_by_name("id.suite_name.test_name") != TwisterStatus.NONE
+    assert gtest.instance.get_case_by_name("id.suite_name.test_name").status == TwisterStatus.PASS
 
 
 def test_gtest_failed(gtest):
@@ -618,11 +617,11 @@ def test_gtest_failed(gtest):
             ),
         ],
     )
-    assert gtest.state == HarnessStatus.NONE
+    assert gtest.status == TwisterStatus.NONE
     assert len(gtest.detected_suite_names) == 1
     assert gtest.detected_suite_names[0] == "suite_name"
-    assert gtest.instance.get_case_by_name("id.suite_name.test_name") != TestCaseStatus.NONE
-    assert gtest.instance.get_case_by_name("id.suite_name.test_name").status == TestCaseStatus.FAIL
+    assert gtest.instance.get_case_by_name("id.suite_name.test_name") != TwisterStatus.NONE
+    assert gtest.instance.get_case_by_name("id.suite_name.test_name").status == TwisterStatus.FAIL
 
 
 def test_gtest_skipped(gtest):
@@ -638,11 +637,11 @@ def test_gtest_skipped(gtest):
             ),
         ],
     )
-    assert gtest.state == HarnessStatus.NONE
+    assert gtest.status == TwisterStatus.NONE
     assert len(gtest.detected_suite_names) == 1
     assert gtest.detected_suite_names[0] == "suite_name"
-    assert gtest.instance.get_case_by_name("id.suite_name.test_name") != TestCaseStatus.NONE
-    assert gtest.instance.get_case_by_name("id.suite_name.test_name").status == TestCaseStatus.SKIP
+    assert gtest.instance.get_case_by_name("id.suite_name.test_name") != TwisterStatus.NONE
+    assert gtest.instance.get_case_by_name("id.suite_name.test_name").status == TwisterStatus.SKIP
 
 
 def test_gtest_all_pass(gtest):
@@ -659,11 +658,11 @@ def test_gtest_all_pass(gtest):
             SAMPLE_GTEST_END,
         ],
     )
-    assert gtest.state == HarnessStatus.PASS
+    assert gtest.status == TwisterStatus.PASS
     assert len(gtest.detected_suite_names) == 1
     assert gtest.detected_suite_names[0] == "suite_name"
-    assert gtest.instance.get_case_by_name("id.suite_name.test_name") != TestCaseStatus.NONE
-    assert gtest.instance.get_case_by_name("id.suite_name.test_name").status == TestCaseStatus.PASS
+    assert gtest.instance.get_case_by_name("id.suite_name.test_name") != TwisterStatus.NONE
+    assert gtest.instance.get_case_by_name("id.suite_name.test_name").status == TwisterStatus.PASS
 
 
 def test_gtest_one_skipped(gtest):
@@ -686,13 +685,13 @@ def test_gtest_one_skipped(gtest):
             SAMPLE_GTEST_END,
         ],
     )
-    assert gtest.state == HarnessStatus.PASS
+    assert gtest.status == TwisterStatus.PASS
     assert len(gtest.detected_suite_names) == 1
     assert gtest.detected_suite_names[0] == "suite_name"
-    assert gtest.instance.get_case_by_name("id.suite_name.test_name") != TestCaseStatus.NONE
-    assert gtest.instance.get_case_by_name("id.suite_name.test_name").status == TestCaseStatus.PASS
-    assert gtest.instance.get_case_by_name("id.suite_name.test_name1") != TestCaseStatus.NONE
-    assert gtest.instance.get_case_by_name("id.suite_name.test_name1").status == TestCaseStatus.SKIP
+    assert gtest.instance.get_case_by_name("id.suite_name.test_name") != TwisterStatus.NONE
+    assert gtest.instance.get_case_by_name("id.suite_name.test_name").status == TwisterStatus.PASS
+    assert gtest.instance.get_case_by_name("id.suite_name.test_name1") != TwisterStatus.NONE
+    assert gtest.instance.get_case_by_name("id.suite_name.test_name1").status == TwisterStatus.SKIP
 
 
 def test_gtest_one_fail(gtest):
@@ -715,13 +714,13 @@ def test_gtest_one_fail(gtest):
             SAMPLE_GTEST_END,
         ],
     )
-    assert gtest.state == HarnessStatus.FAIL
+    assert gtest.status == TwisterStatus.FAIL
     assert len(gtest.detected_suite_names) == 1
     assert gtest.detected_suite_names[0] == "suite_name"
-    assert gtest.instance.get_case_by_name("id.suite_name.test0") != TestCaseStatus.NONE
-    assert gtest.instance.get_case_by_name("id.suite_name.test0").status == TestCaseStatus.PASS
-    assert gtest.instance.get_case_by_name("id.suite_name.test1") != TestCaseStatus.NONE
-    assert gtest.instance.get_case_by_name("id.suite_name.test1").status == TestCaseStatus.FAIL
+    assert gtest.instance.get_case_by_name("id.suite_name.test0") != TwisterStatus.NONE
+    assert gtest.instance.get_case_by_name("id.suite_name.test0").status == TwisterStatus.PASS
+    assert gtest.instance.get_case_by_name("id.suite_name.test1") != TwisterStatus.NONE
+    assert gtest.instance.get_case_by_name("id.suite_name.test1").status == TwisterStatus.FAIL
 
 
 def test_gtest_missing_result(gtest):

--- a/scripts/tests/twister/test_runner.py
+++ b/scripts/tests/twister/test_runner.py
@@ -1976,23 +1976,14 @@ TESTDATA_13 = [
         ['Unknown status = unknown status'],
         'INFO    - Total complete:   20/  25  80%  skipped:    3,' \
         ' failed:    2, error:    1\r'
-    ),
-    (
-        TestInstanceStatus.TIMEOUT, True, False, True,
-        ['INFO      20/25 dummy platform' \
-         '            dummy.testsuite.name' \
-         '                               UNKNOWN' \
-         ' (dummy handler type: dummy dut, 60.000s/seed: 123)'],
-        None
-    ),
+    )
 ]
 
 @pytest.mark.parametrize(
     'status, verbose, cmake_only, ready_run, expected_logs, expected_out',
     TESTDATA_13,
     ids=['verbose error cmake only', 'failed', 'verbose skipped', 'filtered',
-         'verbose passed ready run', 'verbose passed', 'unknown status',
-         'timeout']
+         'verbose passed ready run', 'verbose passed', 'unknown status']
 )
 def test_projectbuilder_report_out(
     capfd,

--- a/scripts/tests/twister/test_runner.py
+++ b/scripts/tests/twister/test_runner.py
@@ -24,6 +24,7 @@ from typing import List
 ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
 
+from twisterlib.statuses import TestCaseStatus, TestInstanceStatus
 from twisterlib.error import BuildError
 from twisterlib.harness import Pytest
 
@@ -253,15 +254,15 @@ TESTDATA_1_1 = [
 ]
 TESTDATA_1_2 = [
     (0, False, 'dummy out',
-     True, True, 'passed', None, False, True),
+     True, True, TestInstanceStatus.PASS, None, False, True),
     (0, True, '',
-     False, False, 'passed', None, False, False),
+     False, False, TestInstanceStatus.PASS, None, False, False),
     (1, True, 'ERROR: region `FLASH\' overflowed by 123 MB',
-     True,  True, 'skipped', 'FLASH overflow', True, False),
+     True,  True, TestInstanceStatus.SKIP, 'FLASH overflow', True, False),
     (1, True, 'Error: Image size (99 B) + trailer (1 B) exceeds requested size',
-     True, True, 'skipped', 'imgtool overflow', True, False),
+     True, True, TestInstanceStatus.SKIP, 'imgtool overflow', True, False),
     (1, True, 'mock.ANY',
-     True, True, 'error', 'Build failure', False, False)
+     True, True, TestInstanceStatus.ERROR, 'Build failure', False, False)
 ]
 
 @pytest.mark.parametrize(
@@ -306,7 +307,7 @@ def test_cmake_run_build(
     instance_mock = mock.Mock(add_missing_case_status=mock.Mock())
     instance_mock.build_time = 0
     instance_mock.run = is_instance_run
-    instance_mock.status = None
+    instance_mock.status = TestInstanceStatus.NONE
     instance_mock.reason = None
 
     cmake = CMake(testsuite_mock, platform_mock, source_dir, build_dir,
@@ -354,7 +355,7 @@ def test_cmake_run_build(
 
     if expected_add_missing:
         cmake.instance.add_missing_case_status.assert_called_once_with(
-            'skipped', 'Test was built only'
+            TestInstanceStatus.SKIP, 'Test was built only'
         )
 
 
@@ -366,7 +367,7 @@ TESTDATA_2_2 = [
     (True, ['dummy_stage_1', 'ds2'],
      0, False, '',
      True, True, False,
-     None, None,
+     TestInstanceStatus.NONE, None,
      [os.path.join('dummy', 'cmake'),
       '-B' + os.path.join('build', 'dir'), '-DTC_RUNID=1',
       '-DSB_CONFIG_COMPILER_WARNINGS_AS_ERRORS=y',
@@ -380,7 +381,7 @@ TESTDATA_2_2 = [
     (False, [],
      1, True, 'ERROR: region `FLASH\' overflowed by 123 MB',
      True, False, True,
-     'error', 'Cmake build failure',
+     TestInstanceStatus.ERROR, 'Cmake build failure',
      [os.path.join('dummy', 'cmake'),
       '-B' + os.path.join('build', 'dir'), '-DTC_RUNID=1',
       '-DSB_CONFIG_COMPILER_WARNINGS_AS_ERRORS=n',
@@ -438,13 +439,13 @@ def test_cmake_run_cmake(
     instance_mock.run = is_instance_run
     instance_mock.run_id = 1
     instance_mock.build_time = 0
-    instance_mock.status = None
+    instance_mock.status = TestInstanceStatus.NONE
     instance_mock.reason = None
     instance_mock.testsuite = mock.Mock()
     instance_mock.testsuite.required_snippets = ['dummy snippet 1', 'ds2']
     instance_mock.testcases = [mock.Mock(), mock.Mock()]
-    instance_mock.testcases[0].status = None
-    instance_mock.testcases[1].status = None
+    instance_mock.testcases[0].status = TestCaseStatus.NONE
+    instance_mock.testcases[1].status = TestCaseStatus.NONE
 
     cmake = CMake(testsuite_mock, platform_mock, source_dir, build_dir,
                   jobserver_mock)
@@ -859,7 +860,7 @@ def test_projectbuilder_log_info_file(
 TESTDATA_6 = [
     (
         {'op': 'filter'},
-        'failed',
+        TestInstanceStatus.FAIL,
         'Failed',
         mock.ANY,
         mock.ANY,
@@ -874,14 +875,14 @@ TESTDATA_6 = [
         mock.ANY,
         [],
         {'op': 'report', 'test': mock.ANY},
-        'failed',
+        TestInstanceStatus.FAIL,
         'Failed',
         0,
         None
     ),
     (
         {'op': 'filter'},
-        'passed',
+        TestInstanceStatus.PASS,
         mock.ANY,
         mock.ANY,
         mock.ANY,
@@ -896,14 +897,14 @@ TESTDATA_6 = [
         mock.ANY,
         ['filtering dummy instance name'],
         {'op': 'report', 'test': mock.ANY},
-        'filtered',
+        TestInstanceStatus.FILTER,
         'runtime filter',
         1,
-        ('skipped',)
+        (TestCaseStatus.SKIP,)
     ),
     (
         {'op': 'filter'},
-        'passed',
+        TestInstanceStatus.PASS,
         mock.ANY,
         mock.ANY,
         mock.ANY,
@@ -918,14 +919,14 @@ TESTDATA_6 = [
         mock.ANY,
         [],
         {'op': 'cmake', 'test': mock.ANY},
-        'passed',
+        TestInstanceStatus.PASS,
         mock.ANY,
         0,
         None
     ),
     (
         {'op': 'cmake'},
-        'error',
+        TestInstanceStatus.ERROR,
         'dummy error',
         mock.ANY,
         mock.ANY,
@@ -940,14 +941,14 @@ TESTDATA_6 = [
         mock.ANY,
         [],
         {'op': 'report', 'test': mock.ANY},
-        'error',
+        TestInstanceStatus.ERROR,
         'dummy error',
         0,
         None
     ),
     (
         {'op': 'cmake'},
-        None,
+        TestInstanceStatus.NONE,
         mock.ANY,
         mock.ANY,
         mock.ANY,
@@ -962,7 +963,7 @@ TESTDATA_6 = [
         mock.ANY,
         [],
         {'op': 'report', 'test': mock.ANY},
-        'passed',
+        TestInstanceStatus.PASS,
         mock.ANY,
         0,
         None
@@ -1006,10 +1007,10 @@ TESTDATA_6 = [
         mock.ANY,
         ['filtering dummy instance name'],
         {'op': 'report', 'test': mock.ANY},
-        'filtered',
+        TestInstanceStatus.FILTER,
         'runtime filter',
         1,
-        ('skipped',)
+        (TestCaseStatus.SKIP,)
     ),
     (
         {'op': 'cmake'},
@@ -1050,14 +1051,14 @@ TESTDATA_6 = [
         mock.ANY,
         ['build test: dummy instance name'],
         {'op': 'report', 'test': mock.ANY},
-        'error',
+        TestInstanceStatus.ERROR,
         'Build Failure',
         0,
         None
     ),
     (
         {'op': 'build'},
-        'skipped',
+        TestInstanceStatus.SKIP,
         mock.ANY,
         mock.ANY,
         mock.ANY,
@@ -1076,11 +1077,11 @@ TESTDATA_6 = [
         mock.ANY,
         mock.ANY,
         1,
-        ('skipped', mock.ANY)
+        (TestCaseStatus.SKIP, mock.ANY)
     ),
     (
         {'op': 'build'},
-        'passed',
+        TestInstanceStatus.PASS,
         mock.ANY,
         mock.ANY,
         mock.ANY,
@@ -1095,10 +1096,10 @@ TESTDATA_6 = [
         mock.ANY,
         ['build test: dummy instance name'],
         {'op': 'report', 'test': mock.ANY},
-        'passed',
+        TestInstanceStatus.PASS,
         mock.ANY,
         0,
-        ('blocked', mock.ANY)
+        (TestCaseStatus.BLOCK, mock.ANY)
     ),
     (
         {'op': 'build'},
@@ -1141,7 +1142,7 @@ TESTDATA_6 = [
         ['build test: dummy instance name',
          'Determine test cases for test instance: dummy instance name'],
         {'op': 'report', 'test': mock.ANY},
-        'error',
+        TestInstanceStatus.ERROR,
         'Determine Testcases Error!',
         0,
         None
@@ -1237,7 +1238,7 @@ TESTDATA_6 = [
     ),
     (
         {'op': 'run'},
-        'failed',
+        TestInstanceStatus.FAIL,
         mock.ANY,
         mock.ANY,
         mock.ANY,
@@ -1254,7 +1255,7 @@ TESTDATA_6 = [
          'run status: dummy instance name failed',
          'RuntimeError: Pipeline Error!'],
         None,
-        'failed',
+        TestInstanceStatus.FAIL,
         mock.ANY,
         0,
         None
@@ -1283,7 +1284,7 @@ TESTDATA_6 = [
     ),
     (
         {'op': 'report'},
-        'passed',
+        TestInstanceStatus.PASS,
         mock.ANY,
         mock.ANY,
         mock.ANY,
@@ -1928,14 +1929,14 @@ def test_projectbuilder_sanitize_zephyr_base_from_files(
 
 TESTDATA_13 = [
     (
-        'error', True, True, False,
+        TestInstanceStatus.ERROR, True, True, False,
         ['INFO      20/25 dummy platform' \
          '            dummy.testsuite.name' \
          '                                ERROR dummy reason (cmake)'],
         None
     ),
     (
-        'failed', False, False, False,
+        TestInstanceStatus.FAIL, False, False, False,
         ['ERROR     dummy platform' \
          '            dummy.testsuite.name' \
          '                                FAILED : dummy reason'],
@@ -1943,20 +1944,20 @@ TESTDATA_13 = [
         ' failed:    3, error:    1'
     ),
     (
-        'skipped', True, False, False,
+        TestInstanceStatus.SKIP, True, False, False,
         ['INFO      20/25 dummy platform' \
          '            dummy.testsuite.name' \
          '                               SKIPPED (dummy reason)'],
         None
     ),
     (
-        'filtered', False, False, False,
+        TestInstanceStatus.FILTER, False, False, False,
         [],
         'INFO    - Total complete:   20/  25  80%  skipped:    4,' \
         ' failed:    2, error:    1'
     ),
     (
-        'passed', True, False, True,
+        TestInstanceStatus.PASS, True, False, True,
         ['INFO      20/25 dummy platform' \
          '            dummy.testsuite.name' \
          '                               PASSED' \
@@ -1964,7 +1965,7 @@ TESTDATA_13 = [
         None
     ),
     (
-        'passed', True, False, False,
+        TestInstanceStatus.PASS, True, False, False,
         ['INFO      20/25 dummy platform' \
          '            dummy.testsuite.name' \
          '                               PASSED (build)'],
@@ -1977,7 +1978,7 @@ TESTDATA_13 = [
         ' failed:    2, error:    1\r'
     ),
     (
-        'timeout', True, False, True,
+        TestInstanceStatus.TIMEOUT, True, False, True,
         ['INFO      20/25 dummy platform' \
          '            dummy.testsuite.name' \
          '                               UNKNOWN' \
@@ -2017,7 +2018,7 @@ def test_projectbuilder_report_out(
     instance_mock.testsuite.name = 'dummy.testsuite.name'
     instance_mock.testsuite.testcases = [mock.Mock() for _ in range(25)]
     instance_mock.testcases = [mock.Mock() for _ in range(24)] + \
-                              [mock.Mock(status='skipped')]
+                              [mock.Mock(status=TestCaseStatus.SKIP)]
     env_mock = mock.Mock()
 
     pb = ProjectBuilder(instance_mock, env_mock, mocked_jobserver)
@@ -2309,14 +2310,14 @@ def test_projectbuilder_gather_metrics(
 
 
 TESTDATA_16 = [
-    ('error', mock.ANY, False, False, False),
-    ('failed', mock.ANY, False, False, False),
-    ('skipped', mock.ANY, False, False, False),
-    ('filtered', 'native', False, False, True),
-    ('passed', 'qemu', False, False, True),
-    ('filtered', 'unit', False, False, True),
-    ('filtered', 'mcu', True, True, False),
-    ('passed', 'frdm_k64f', False, True, False),
+    (TestInstanceStatus.ERROR, mock.ANY, False, False, False),
+    (TestInstanceStatus.FAIL, mock.ANY, False, False, False),
+    (TestInstanceStatus.SKIP, mock.ANY, False, False, False),
+    (TestInstanceStatus.FILTER, 'native', False, False, True),
+    (TestInstanceStatus.PASS, 'qemu', False, False, True),
+    (TestInstanceStatus.FILTER, 'unit', False, False, True),
+    (TestInstanceStatus.FILTER, 'mcu', True, True, False),
+    (TestInstanceStatus.PASS, 'frdm_k64f', False, True, False),
 ]
 
 @pytest.mark.parametrize(
@@ -2474,35 +2475,35 @@ def test_twisterrunner_run(
 def test_twisterrunner_update_counting_before_pipeline():
     instances = {
         'dummy1': mock.Mock(
-            status='filtered',
+            status=TestInstanceStatus.FILTER,
             reason='runtime filter',
             testsuite=mock.Mock(
                 testcases=[mock.Mock()]
             )
         ),
         'dummy2': mock.Mock(
-            status='filtered',
+            status=TestInstanceStatus.FILTER,
             reason='static filter',
             testsuite=mock.Mock(
                 testcases=[mock.Mock(), mock.Mock(), mock.Mock(), mock.Mock()]
             )
         ),
         'dummy3': mock.Mock(
-            status='error',
+            status=TestInstanceStatus.ERROR,
             reason='error',
             testsuite=mock.Mock(
                 testcases=[mock.Mock()]
             )
         ),
         'dummy4': mock.Mock(
-            status='passed',
+            status=TestInstanceStatus.PASS,
             reason='OK',
             testsuite=mock.Mock(
                 testcases=[mock.Mock()]
             )
         ),
         'dummy5': mock.Mock(
-            status='skipped',
+            status=TestInstanceStatus.SKIP,
             reason=None,
             testsuite=mock.Mock(
                 testcases=[mock.Mock()]
@@ -2589,11 +2590,11 @@ def test_twisterrunner_add_tasks_to_queue(
         return [filter]
 
     instances = {
-        'dummy1': mock.Mock(run=True, retries=0, status='passed', build_dir="/tmp"),
-        'dummy2': mock.Mock(run=True, retries=0, status='skipped', build_dir="/tmp"),
-        'dummy3': mock.Mock(run=True, retries=0, status='filtered', build_dir="/tmp"),
-        'dummy4': mock.Mock(run=True, retries=0, status='error', build_dir="/tmp"),
-        'dummy5': mock.Mock(run=True, retries=0, status='failed', build_dir="/tmp")
+        'dummy1': mock.Mock(run=True, retries=0, status=TestInstanceStatus.PASS, build_dir="/tmp"),
+        'dummy2': mock.Mock(run=True, retries=0, status=TestInstanceStatus.SKIP, build_dir="/tmp"),
+        'dummy3': mock.Mock(run=True, retries=0, status=TestInstanceStatus.FILTER, build_dir="/tmp"),
+        'dummy4': mock.Mock(run=True, retries=0, status=TestInstanceStatus.ERROR, build_dir="/tmp"),
+        'dummy5': mock.Mock(run=True, retries=0, status=TestInstanceStatus.FAIL, build_dir="/tmp")
     }
     instances['dummy4'].testsuite.filter = 'some'
     instances['dummy5'].testsuite.filter = 'full'

--- a/scripts/tests/twister/test_runner.py
+++ b/scripts/tests/twister/test_runner.py
@@ -24,7 +24,7 @@ from typing import List
 ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
 
-from twisterlib.statuses import TestCaseStatus, TestInstanceStatus
+from twisterlib.statuses import TwisterStatus
 from twisterlib.error import BuildError
 from twisterlib.harness import Pytest
 
@@ -254,15 +254,15 @@ TESTDATA_1_1 = [
 ]
 TESTDATA_1_2 = [
     (0, False, 'dummy out',
-     True, True, TestInstanceStatus.PASS, None, False, True),
+     True, True, TwisterStatus.PASS, None, False, True),
     (0, True, '',
-     False, False, TestInstanceStatus.PASS, None, False, False),
+     False, False, TwisterStatus.PASS, None, False, False),
     (1, True, 'ERROR: region `FLASH\' overflowed by 123 MB',
-     True,  True, TestInstanceStatus.SKIP, 'FLASH overflow', True, False),
+     True,  True, TwisterStatus.SKIP, 'FLASH overflow', True, False),
     (1, True, 'Error: Image size (99 B) + trailer (1 B) exceeds requested size',
-     True, True, TestInstanceStatus.SKIP, 'imgtool overflow', True, False),
+     True, True, TwisterStatus.SKIP, 'imgtool overflow', True, False),
     (1, True, 'mock.ANY',
-     True, True, TestInstanceStatus.ERROR, 'Build failure', False, False)
+     True, True, TwisterStatus.ERROR, 'Build failure', False, False)
 ]
 
 @pytest.mark.parametrize(
@@ -307,7 +307,7 @@ def test_cmake_run_build(
     instance_mock = mock.Mock(add_missing_case_status=mock.Mock())
     instance_mock.build_time = 0
     instance_mock.run = is_instance_run
-    instance_mock.status = TestInstanceStatus.NONE
+    instance_mock.status = TwisterStatus.NONE
     instance_mock.reason = None
 
     cmake = CMake(testsuite_mock, platform_mock, source_dir, build_dir,
@@ -355,7 +355,7 @@ def test_cmake_run_build(
 
     if expected_add_missing:
         cmake.instance.add_missing_case_status.assert_called_once_with(
-            TestInstanceStatus.SKIP, 'Test was built only'
+            TwisterStatus.SKIP, 'Test was built only'
         )
 
 
@@ -367,7 +367,7 @@ TESTDATA_2_2 = [
     (True, ['dummy_stage_1', 'ds2'],
      0, False, '',
      True, True, False,
-     TestInstanceStatus.NONE, None,
+     TwisterStatus.NONE, None,
      [os.path.join('dummy', 'cmake'),
       '-B' + os.path.join('build', 'dir'), '-DTC_RUNID=1',
       '-DSB_CONFIG_COMPILER_WARNINGS_AS_ERRORS=y',
@@ -381,7 +381,7 @@ TESTDATA_2_2 = [
     (False, [],
      1, True, 'ERROR: region `FLASH\' overflowed by 123 MB',
      True, False, True,
-     TestInstanceStatus.ERROR, 'Cmake build failure',
+     TwisterStatus.ERROR, 'Cmake build failure',
      [os.path.join('dummy', 'cmake'),
       '-B' + os.path.join('build', 'dir'), '-DTC_RUNID=1',
       '-DSB_CONFIG_COMPILER_WARNINGS_AS_ERRORS=n',
@@ -439,13 +439,13 @@ def test_cmake_run_cmake(
     instance_mock.run = is_instance_run
     instance_mock.run_id = 1
     instance_mock.build_time = 0
-    instance_mock.status = TestInstanceStatus.NONE
+    instance_mock.status = TwisterStatus.NONE
     instance_mock.reason = None
     instance_mock.testsuite = mock.Mock()
     instance_mock.testsuite.required_snippets = ['dummy snippet 1', 'ds2']
     instance_mock.testcases = [mock.Mock(), mock.Mock()]
-    instance_mock.testcases[0].status = TestCaseStatus.NONE
-    instance_mock.testcases[1].status = TestCaseStatus.NONE
+    instance_mock.testcases[0].status = TwisterStatus.NONE
+    instance_mock.testcases[1].status = TwisterStatus.NONE
 
     cmake = CMake(testsuite_mock, platform_mock, source_dir, build_dir,
                   jobserver_mock)
@@ -860,7 +860,7 @@ def test_projectbuilder_log_info_file(
 TESTDATA_6 = [
     (
         {'op': 'filter'},
-        TestInstanceStatus.FAIL,
+        TwisterStatus.FAIL,
         'Failed',
         mock.ANY,
         mock.ANY,
@@ -875,14 +875,14 @@ TESTDATA_6 = [
         mock.ANY,
         [],
         {'op': 'report', 'test': mock.ANY},
-        TestInstanceStatus.FAIL,
+        TwisterStatus.FAIL,
         'Failed',
         0,
         None
     ),
     (
         {'op': 'filter'},
-        TestInstanceStatus.PASS,
+        TwisterStatus.PASS,
         mock.ANY,
         mock.ANY,
         mock.ANY,
@@ -897,14 +897,14 @@ TESTDATA_6 = [
         mock.ANY,
         ['filtering dummy instance name'],
         {'op': 'report', 'test': mock.ANY},
-        TestInstanceStatus.FILTER,
+        TwisterStatus.FILTER,
         'runtime filter',
         1,
-        (TestCaseStatus.SKIP,)
+        (TwisterStatus.SKIP,)
     ),
     (
         {'op': 'filter'},
-        TestInstanceStatus.PASS,
+        TwisterStatus.PASS,
         mock.ANY,
         mock.ANY,
         mock.ANY,
@@ -919,14 +919,14 @@ TESTDATA_6 = [
         mock.ANY,
         [],
         {'op': 'cmake', 'test': mock.ANY},
-        TestInstanceStatus.PASS,
+        TwisterStatus.PASS,
         mock.ANY,
         0,
         None
     ),
     (
         {'op': 'cmake'},
-        TestInstanceStatus.ERROR,
+        TwisterStatus.ERROR,
         'dummy error',
         mock.ANY,
         mock.ANY,
@@ -941,14 +941,14 @@ TESTDATA_6 = [
         mock.ANY,
         [],
         {'op': 'report', 'test': mock.ANY},
-        TestInstanceStatus.ERROR,
+        TwisterStatus.ERROR,
         'dummy error',
         0,
         None
     ),
     (
         {'op': 'cmake'},
-        TestInstanceStatus.NONE,
+        TwisterStatus.NONE,
         mock.ANY,
         mock.ANY,
         mock.ANY,
@@ -963,7 +963,7 @@ TESTDATA_6 = [
         mock.ANY,
         [],
         {'op': 'report', 'test': mock.ANY},
-        TestInstanceStatus.PASS,
+        TwisterStatus.PASS,
         mock.ANY,
         0,
         None
@@ -1007,10 +1007,10 @@ TESTDATA_6 = [
         mock.ANY,
         ['filtering dummy instance name'],
         {'op': 'report', 'test': mock.ANY},
-        TestInstanceStatus.FILTER,
+        TwisterStatus.FILTER,
         'runtime filter',
         1,
-        (TestCaseStatus.SKIP,)
+        (TwisterStatus.SKIP,)
     ),
     (
         {'op': 'cmake'},
@@ -1051,14 +1051,14 @@ TESTDATA_6 = [
         mock.ANY,
         ['build test: dummy instance name'],
         {'op': 'report', 'test': mock.ANY},
-        TestInstanceStatus.ERROR,
+        TwisterStatus.ERROR,
         'Build Failure',
         0,
         None
     ),
     (
         {'op': 'build'},
-        TestInstanceStatus.SKIP,
+        TwisterStatus.SKIP,
         mock.ANY,
         mock.ANY,
         mock.ANY,
@@ -1077,11 +1077,11 @@ TESTDATA_6 = [
         mock.ANY,
         mock.ANY,
         1,
-        (TestCaseStatus.SKIP, mock.ANY)
+        (TwisterStatus.SKIP, mock.ANY)
     ),
     (
         {'op': 'build'},
-        TestInstanceStatus.PASS,
+        TwisterStatus.PASS,
         mock.ANY,
         mock.ANY,
         mock.ANY,
@@ -1096,10 +1096,10 @@ TESTDATA_6 = [
         mock.ANY,
         ['build test: dummy instance name'],
         {'op': 'report', 'test': mock.ANY},
-        TestInstanceStatus.PASS,
+        TwisterStatus.PASS,
         mock.ANY,
         0,
-        (TestCaseStatus.BLOCK, mock.ANY)
+        (TwisterStatus.BLOCK, mock.ANY)
     ),
     (
         {'op': 'build'},
@@ -1142,7 +1142,7 @@ TESTDATA_6 = [
         ['build test: dummy instance name',
          'Determine test cases for test instance: dummy instance name'],
         {'op': 'report', 'test': mock.ANY},
-        TestInstanceStatus.ERROR,
+        TwisterStatus.ERROR,
         'Determine Testcases Error!',
         0,
         None
@@ -1238,7 +1238,7 @@ TESTDATA_6 = [
     ),
     (
         {'op': 'run'},
-        TestInstanceStatus.FAIL,
+        TwisterStatus.FAIL,
         mock.ANY,
         mock.ANY,
         mock.ANY,
@@ -1255,7 +1255,7 @@ TESTDATA_6 = [
          'run status: dummy instance name failed',
          'RuntimeError: Pipeline Error!'],
         None,
-        TestInstanceStatus.FAIL,
+        TwisterStatus.FAIL,
         mock.ANY,
         0,
         None
@@ -1284,7 +1284,7 @@ TESTDATA_6 = [
     ),
     (
         {'op': 'report'},
-        TestInstanceStatus.PASS,
+        TwisterStatus.PASS,
         mock.ANY,
         mock.ANY,
         mock.ANY,
@@ -1929,14 +1929,14 @@ def test_projectbuilder_sanitize_zephyr_base_from_files(
 
 TESTDATA_13 = [
     (
-        TestInstanceStatus.ERROR, True, True, False,
+        TwisterStatus.ERROR, True, True, False,
         ['INFO      20/25 dummy platform' \
          '            dummy.testsuite.name' \
          '                                ERROR dummy reason (cmake)'],
         None
     ),
     (
-        TestInstanceStatus.FAIL, False, False, False,
+        TwisterStatus.FAIL, False, False, False,
         ['ERROR     dummy platform' \
          '            dummy.testsuite.name' \
          '                                FAILED : dummy reason'],
@@ -1944,20 +1944,20 @@ TESTDATA_13 = [
         ' failed:    3, error:    1'
     ),
     (
-        TestInstanceStatus.SKIP, True, False, False,
+        TwisterStatus.SKIP, True, False, False,
         ['INFO      20/25 dummy platform' \
          '            dummy.testsuite.name' \
          '                               SKIPPED (dummy reason)'],
         None
     ),
     (
-        TestInstanceStatus.FILTER, False, False, False,
+        TwisterStatus.FILTER, False, False, False,
         [],
         'INFO    - Total complete:   20/  25  80%  skipped:    4,' \
         ' failed:    2, error:    1'
     ),
     (
-        TestInstanceStatus.PASS, True, False, True,
+        TwisterStatus.PASS, True, False, True,
         ['INFO      20/25 dummy platform' \
          '            dummy.testsuite.name' \
          '                               PASSED' \
@@ -1965,7 +1965,7 @@ TESTDATA_13 = [
         None
     ),
     (
-        TestInstanceStatus.PASS, True, False, False,
+        TwisterStatus.PASS, True, False, False,
         ['INFO      20/25 dummy platform' \
          '            dummy.testsuite.name' \
          '                               PASSED (build)'],
@@ -2009,7 +2009,7 @@ def test_projectbuilder_report_out(
     instance_mock.testsuite.name = 'dummy.testsuite.name'
     instance_mock.testsuite.testcases = [mock.Mock() for _ in range(25)]
     instance_mock.testcases = [mock.Mock() for _ in range(24)] + \
-                              [mock.Mock(status=TestCaseStatus.SKIP)]
+                              [mock.Mock(status=TwisterStatus.SKIP)]
     env_mock = mock.Mock()
 
     pb = ProjectBuilder(instance_mock, env_mock, mocked_jobserver)
@@ -2301,14 +2301,14 @@ def test_projectbuilder_gather_metrics(
 
 
 TESTDATA_16 = [
-    (TestInstanceStatus.ERROR, mock.ANY, False, False, False),
-    (TestInstanceStatus.FAIL, mock.ANY, False, False, False),
-    (TestInstanceStatus.SKIP, mock.ANY, False, False, False),
-    (TestInstanceStatus.FILTER, 'native', False, False, True),
-    (TestInstanceStatus.PASS, 'qemu', False, False, True),
-    (TestInstanceStatus.FILTER, 'unit', False, False, True),
-    (TestInstanceStatus.FILTER, 'mcu', True, True, False),
-    (TestInstanceStatus.PASS, 'frdm_k64f', False, True, False),
+    (TwisterStatus.ERROR, mock.ANY, False, False, False),
+    (TwisterStatus.FAIL, mock.ANY, False, False, False),
+    (TwisterStatus.SKIP, mock.ANY, False, False, False),
+    (TwisterStatus.FILTER, 'native', False, False, True),
+    (TwisterStatus.PASS, 'qemu', False, False, True),
+    (TwisterStatus.FILTER, 'unit', False, False, True),
+    (TwisterStatus.FILTER, 'mcu', True, True, False),
+    (TwisterStatus.PASS, 'frdm_k64f', False, True, False),
 ]
 
 @pytest.mark.parametrize(
@@ -2466,35 +2466,35 @@ def test_twisterrunner_run(
 def test_twisterrunner_update_counting_before_pipeline():
     instances = {
         'dummy1': mock.Mock(
-            status=TestInstanceStatus.FILTER,
+            status=TwisterStatus.FILTER,
             reason='runtime filter',
             testsuite=mock.Mock(
                 testcases=[mock.Mock()]
             )
         ),
         'dummy2': mock.Mock(
-            status=TestInstanceStatus.FILTER,
+            status=TwisterStatus.FILTER,
             reason='static filter',
             testsuite=mock.Mock(
                 testcases=[mock.Mock(), mock.Mock(), mock.Mock(), mock.Mock()]
             )
         ),
         'dummy3': mock.Mock(
-            status=TestInstanceStatus.ERROR,
+            status=TwisterStatus.ERROR,
             reason='error',
             testsuite=mock.Mock(
                 testcases=[mock.Mock()]
             )
         ),
         'dummy4': mock.Mock(
-            status=TestInstanceStatus.PASS,
+            status=TwisterStatus.PASS,
             reason='OK',
             testsuite=mock.Mock(
                 testcases=[mock.Mock()]
             )
         ),
         'dummy5': mock.Mock(
-            status=TestInstanceStatus.SKIP,
+            status=TwisterStatus.SKIP,
             reason=None,
             testsuite=mock.Mock(
                 testcases=[mock.Mock()]
@@ -2581,11 +2581,11 @@ def test_twisterrunner_add_tasks_to_queue(
         return [filter]
 
     instances = {
-        'dummy1': mock.Mock(run=True, retries=0, status=TestInstanceStatus.PASS, build_dir="/tmp"),
-        'dummy2': mock.Mock(run=True, retries=0, status=TestInstanceStatus.SKIP, build_dir="/tmp"),
-        'dummy3': mock.Mock(run=True, retries=0, status=TestInstanceStatus.FILTER, build_dir="/tmp"),
-        'dummy4': mock.Mock(run=True, retries=0, status=TestInstanceStatus.ERROR, build_dir="/tmp"),
-        'dummy5': mock.Mock(run=True, retries=0, status=TestInstanceStatus.FAIL, build_dir="/tmp")
+        'dummy1': mock.Mock(run=True, retries=0, status=TwisterStatus.PASS, build_dir="/tmp"),
+        'dummy2': mock.Mock(run=True, retries=0, status=TwisterStatus.SKIP, build_dir="/tmp"),
+        'dummy3': mock.Mock(run=True, retries=0, status=TwisterStatus.FILTER, build_dir="/tmp"),
+        'dummy4': mock.Mock(run=True, retries=0, status=TwisterStatus.ERROR, build_dir="/tmp"),
+        'dummy5': mock.Mock(run=True, retries=0, status=TwisterStatus.FAIL, build_dir="/tmp")
     }
     instances['dummy4'].testsuite.filter = 'some'
     instances['dummy5'].testsuite.filter = 'full'

--- a/scripts/tests/twister/test_testinstance.py
+++ b/scripts/tests/twister/test_testinstance.py
@@ -16,6 +16,7 @@ import mock
 ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
 
+from twisterlib.statuses import TestCaseStatus, TestInstanceStatus
 from twisterlib.testinstance import TestInstance
 from twisterlib.error import BuildError
 from twisterlib.runner import TwisterRunner
@@ -265,7 +266,7 @@ def test_testinstance_add_filter(testinstance):
     testinstance.add_filter(reason, filter_type)
 
     assert {'type': filter_type, 'reason': reason} in testinstance.filters
-    assert testinstance.status == 'filtered'
+    assert testinstance.status == TestInstanceStatus.FILTER
     assert testinstance.reason == reason
     assert testinstance.filter_type == filter_type
 
@@ -310,17 +311,17 @@ TESTDATA_2 = [
 def test_testinstance_add_missing_case_status(testinstance, reason, expected_reason):
     testinstance.reason = 'dummy reason'
 
-    status = 'passed'
+    status = TestCaseStatus.PASS
 
     assert len(testinstance.testcases) > 1, 'Selected testsuite does not have enough testcases.'
 
-    testinstance.testcases[0].status = 'started'
-    testinstance.testcases[-1].status = None
+    testinstance.testcases[0].status = TestCaseStatus.STARTED
+    testinstance.testcases[-1].status = TestCaseStatus.NONE
 
     testinstance.add_missing_case_status(status, reason)
 
-    assert testinstance.testcases[0].status == 'failed'
-    assert testinstance.testcases[-1].status == 'passed'
+    assert testinstance.testcases[0].status == TestCaseStatus.FAIL
+    assert testinstance.testcases[-1].status == TestCaseStatus.PASS
     assert testinstance.testcases[-1].reason == expected_reason
 
 

--- a/scripts/tests/twister/test_testinstance.py
+++ b/scripts/tests/twister/test_testinstance.py
@@ -16,7 +16,7 @@ import mock
 ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
 
-from twisterlib.statuses import TestCaseStatus, TestInstanceStatus
+from twisterlib.statuses import TwisterStatus
 from twisterlib.testinstance import TestInstance
 from twisterlib.error import BuildError
 from twisterlib.runner import TwisterRunner
@@ -266,7 +266,7 @@ def test_testinstance_add_filter(testinstance):
     testinstance.add_filter(reason, filter_type)
 
     assert {'type': filter_type, 'reason': reason} in testinstance.filters
-    assert testinstance.status == TestInstanceStatus.FILTER
+    assert testinstance.status == TwisterStatus.FILTER
     assert testinstance.reason == reason
     assert testinstance.filter_type == filter_type
 
@@ -311,17 +311,17 @@ TESTDATA_2 = [
 def test_testinstance_add_missing_case_status(testinstance, reason, expected_reason):
     testinstance.reason = 'dummy reason'
 
-    status = TestCaseStatus.PASS
+    status = TwisterStatus.PASS
 
     assert len(testinstance.testcases) > 1, 'Selected testsuite does not have enough testcases.'
 
-    testinstance.testcases[0].status = TestCaseStatus.STARTED
-    testinstance.testcases[-1].status = TestCaseStatus.NONE
+    testinstance.testcases[0].status = TwisterStatus.STARTED
+    testinstance.testcases[-1].status = TwisterStatus.NONE
 
     testinstance.add_missing_case_status(status, reason)
 
-    assert testinstance.testcases[0].status == TestCaseStatus.FAIL
-    assert testinstance.testcases[-1].status == TestCaseStatus.PASS
+    assert testinstance.testcases[0].status == TwisterStatus.FAIL
+    assert testinstance.testcases[-1].status == TwisterStatus.PASS
     assert testinstance.testcases[-1].reason == expected_reason
 
 
@@ -356,7 +356,7 @@ def test_testinstance_dunders(all_testsuites_dict, class_testplan, platforms_lis
 @pytest.mark.parametrize('testinstance', [{'testsuite_kind': 'tests'}], indirect=True)
 def test_testinstance_set_case_status_by_name(testinstance):
     name = 'test_a.check_1.2a'
-    status = 'dummy status'
+    status = TwisterStatus.PASS
     reason = 'dummy reason'
 
     tc = testinstance.set_case_status_by_name(name, status, reason)

--- a/scripts/tests/twister/test_testplan.py
+++ b/scripts/tests/twister/test_testplan.py
@@ -16,6 +16,7 @@ from contextlib import nullcontext
 ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
 
+from twisterlib.statuses import TestInstanceStatus
 from twisterlib.testplan import TestPlan, change_skip_to_error_if_integration
 from twisterlib.testinstance import TestInstance
 from twisterlib.testsuite import TestSuite
@@ -180,7 +181,7 @@ def test_apply_filters_part1(class_testplan, all_testsuites_dict, platforms_list
         plan.apply_filters(exclude_platform=['demo_board_1'],
                                                  platform=['demo_board_2'])
 
-    filtered_instances = list(filter(lambda item:  item.status == "filtered", plan.instances.values()))
+    filtered_instances = list(filter(lambda item:  item.status == TestInstanceStatus.FILTER, plan.instances.values()))
     for d in filtered_instances:
         assert d.reason == expected_discards
 
@@ -214,7 +215,7 @@ def test_apply_filters_part2(class_testplan, all_testsuites_dict,
             ]
         }
     class_testplan.apply_filters(**kwargs)
-    filtered_instances = list(filter(lambda item:  item.status == "filtered", class_testplan.instances.values()))
+    filtered_instances = list(filter(lambda item:  item.status == TestInstanceStatus.FILTER, class_testplan.instances.values()))
     for d in filtered_instances:
         assert d.reason == expected_discards
 
@@ -245,7 +246,7 @@ def test_apply_filters_part3(class_testplan, all_testsuites_dict, platforms_list
     class_testplan.apply_filters(exclude_platform=['demo_board_1'],
                                              platform=['demo_board_2'])
 
-    filtered_instances = list(filter(lambda item:  item.status == "filtered", class_testplan.instances.values()))
+    filtered_instances = list(filter(lambda item:  item.status == TestInstanceStatus.FILTER, class_testplan.instances.values()))
     assert not filtered_instances
 
 def test_add_instances_short(tmp_path, class_env, all_testsuites_dict, platforms_list):
@@ -338,16 +339,16 @@ def test_quarantine_short(class_testplan, platforms_list, test_data,
     for testname, instance in class_testplan.instances.items():
         if quarantine_verify:
             if testname in expected_val:
-                assert not instance.status
+                assert instance.status == TestInstanceStatus.NONE
             else:
-                assert instance.status == 'filtered'
+                assert instance.status == TestInstanceStatus.FILTER
                 assert instance.reason == "Not under quarantine"
         else:
             if testname in expected_val:
-                assert instance.status == 'filtered'
+                assert instance.status == TestInstanceStatus.FILTER
                 assert instance.reason == "Quarantine: " + expected_val[testname]
             else:
-                assert not instance.status
+                assert instance.status == TestInstanceStatus.NONE
 
 
 TESTDATA_PART4 = [
@@ -392,7 +393,7 @@ def test_required_snippets_short(
     plan.apply_filters()
 
     filtered_instances = list(
-        filter(lambda item: item.status == "filtered", plan.instances.values())
+        filter(lambda item: item.status == TestInstanceStatus.FILTER, plan.instances.values())
     )
     if expected_filtered_len is not None:
         assert len(filtered_instances) == expected_filtered_len
@@ -808,14 +809,14 @@ def test_testplan_generate_subset(
         shuffle_tests_seed=seed
     )
     testplan.instances = {
-        'plat1/testA': mock.Mock(status=None),
-        'plat1/testB': mock.Mock(status=None),
-        'plat1/testC': mock.Mock(status=None),
-        'plat2/testA': mock.Mock(status=None),
-        'plat2/testB': mock.Mock(status=None),
-        'plat3/testA': mock.Mock(status='skipped'),
-        'plat3/testB': mock.Mock(status='skipped'),
-        'plat3/testC': mock.Mock(status='error'),
+        'plat1/testA': mock.Mock(status=TestInstanceStatus.NONE),
+        'plat1/testB': mock.Mock(status=TestInstanceStatus.NONE),
+        'plat1/testC': mock.Mock(status=TestInstanceStatus.NONE),
+        'plat2/testA': mock.Mock(status=TestInstanceStatus.NONE),
+        'plat2/testB': mock.Mock(status=TestInstanceStatus.NONE),
+        'plat3/testA': mock.Mock(status=TestInstanceStatus.SKIP),
+        'plat3/testB': mock.Mock(status=TestInstanceStatus.SKIP),
+        'plat3/testC': mock.Mock(status=TestInstanceStatus.ERROR),
     }
 
     testplan.generate_subset(subset, sets)
@@ -1567,7 +1568,7 @@ def test_testplan_load_from_file(caplog, device_testing, expected_tfilter):
             'retries': 0,
             'testcases': {
                 'TS1.tc1': {
-                    'status': 'passed',
+                    'status': TestInstanceStatus.PASS,
                     'reason': None,
                     'duration': 60.0,
                     'output': ''
@@ -1596,13 +1597,13 @@ def test_testplan_load_from_file(caplog, device_testing, expected_tfilter):
             'retries': 1,
             'testcases': {
                     'TS3.tc1': {
-                        'status': 'error',
+                        'status': TestInstanceStatus.ERROR,
                         'reason': None,
                         'duration': 360.0,
                         'output': '[ERROR]: File \'dummy.yaml\' not found!\nClosing...'
                     },
                     'TS3.tc2': {
-                        'status': None,
+                        'status': TestInstanceStatus.NONE,
                         'reason': None,
                         'duration': 0,
                         'output': ''
@@ -1620,7 +1621,7 @@ def test_testplan_load_from_file(caplog, device_testing, expected_tfilter):
             'retries': 0,
             'testcases': {
                 'TS4.tc1': {
-                    'status': 'skipped',
+                    'status': TestInstanceStatus.SKIP,
                     'reason': 'Not in requested test list.',
                     'duration': 360.0,
                     'output': '[INFO] Parsing...'
@@ -1721,9 +1722,9 @@ def test_testplan_create_build_dir_links(exists):
         instances_linked.append(instance)
 
     instances = {
-        'inst0': mock.Mock(status='passed'),
-        'inst1': mock.Mock(status='skipped'),
-        'inst2': mock.Mock(status='error'),
+        'inst0': mock.Mock(status=TestInstanceStatus.PASS),
+        'inst1': mock.Mock(status=TestInstanceStatus.SKIP),
+        'inst2': mock.Mock(status=TestInstanceStatus.ERROR),
     }
     expected_instances = [instances['inst0'], instances['inst2']]
 
@@ -1788,7 +1789,7 @@ TESTDATA_14 = [
     ('bad platform', 'dummy reason', [],
      'dummy status', 'dummy reason'),
     ('good platform', 'quarantined', [],
-     'error', 'quarantined but is one of the integration platforms'),
+     TestInstanceStatus.ERROR, 'quarantined but is one of the integration platforms'),
     ('good platform', 'dummy reason', [{'type': 'command line filter'}],
      'dummy status', 'dummy reason'),
     ('good platform', 'dummy reason', [{'type': 'Skip filter'}],
@@ -1800,7 +1801,7 @@ TESTDATA_14 = [
     ('good platform', 'dummy reason', [{'type': 'Module filter'}],
      'dummy status', 'dummy reason'),
     ('good platform', 'dummy reason', [{'type': 'testsuite filter'}],
-     'error', 'dummy reason but is one of the integration platforms'),
+     TestInstanceStatus.ERROR, 'dummy reason but is one of the integration platforms'),
 ]
 
 @pytest.mark.parametrize(

--- a/scripts/tests/twister/test_testplan.py
+++ b/scripts/tests/twister/test_testplan.py
@@ -16,7 +16,7 @@ from contextlib import nullcontext
 ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
 
-from twisterlib.statuses import TestInstanceStatus
+from twisterlib.statuses import TwisterStatus
 from twisterlib.testplan import TestPlan, change_skip_to_error_if_integration
 from twisterlib.testinstance import TestInstance
 from twisterlib.testsuite import TestSuite
@@ -181,7 +181,7 @@ def test_apply_filters_part1(class_testplan, all_testsuites_dict, platforms_list
         plan.apply_filters(exclude_platform=['demo_board_1'],
                                                  platform=['demo_board_2'])
 
-    filtered_instances = list(filter(lambda item:  item.status == TestInstanceStatus.FILTER, plan.instances.values()))
+    filtered_instances = list(filter(lambda item:  item.status == TwisterStatus.FILTER, plan.instances.values()))
     for d in filtered_instances:
         assert d.reason == expected_discards
 
@@ -215,7 +215,7 @@ def test_apply_filters_part2(class_testplan, all_testsuites_dict,
             ]
         }
     class_testplan.apply_filters(**kwargs)
-    filtered_instances = list(filter(lambda item:  item.status == TestInstanceStatus.FILTER, class_testplan.instances.values()))
+    filtered_instances = list(filter(lambda item:  item.status == TwisterStatus.FILTER, class_testplan.instances.values()))
     for d in filtered_instances:
         assert d.reason == expected_discards
 
@@ -246,7 +246,7 @@ def test_apply_filters_part3(class_testplan, all_testsuites_dict, platforms_list
     class_testplan.apply_filters(exclude_platform=['demo_board_1'],
                                              platform=['demo_board_2'])
 
-    filtered_instances = list(filter(lambda item:  item.status == TestInstanceStatus.FILTER, class_testplan.instances.values()))
+    filtered_instances = list(filter(lambda item:  item.status == TwisterStatus.FILTER, class_testplan.instances.values()))
     assert not filtered_instances
 
 def test_add_instances_short(tmp_path, class_env, all_testsuites_dict, platforms_list):
@@ -339,16 +339,16 @@ def test_quarantine_short(class_testplan, platforms_list, test_data,
     for testname, instance in class_testplan.instances.items():
         if quarantine_verify:
             if testname in expected_val:
-                assert instance.status == TestInstanceStatus.NONE
+                assert instance.status == TwisterStatus.NONE
             else:
-                assert instance.status == TestInstanceStatus.FILTER
+                assert instance.status == TwisterStatus.FILTER
                 assert instance.reason == "Not under quarantine"
         else:
             if testname in expected_val:
-                assert instance.status == TestInstanceStatus.FILTER
+                assert instance.status == TwisterStatus.FILTER
                 assert instance.reason == "Quarantine: " + expected_val[testname]
             else:
-                assert instance.status == TestInstanceStatus.NONE
+                assert instance.status == TwisterStatus.NONE
 
 
 TESTDATA_PART4 = [
@@ -393,7 +393,7 @@ def test_required_snippets_short(
     plan.apply_filters()
 
     filtered_instances = list(
-        filter(lambda item: item.status == TestInstanceStatus.FILTER, plan.instances.values())
+        filter(lambda item: item.status == TwisterStatus.FILTER, plan.instances.values())
     )
     if expected_filtered_len is not None:
         assert len(filtered_instances) == expected_filtered_len
@@ -809,14 +809,14 @@ def test_testplan_generate_subset(
         shuffle_tests_seed=seed
     )
     testplan.instances = {
-        'plat1/testA': mock.Mock(status=TestInstanceStatus.NONE),
-        'plat1/testB': mock.Mock(status=TestInstanceStatus.NONE),
-        'plat1/testC': mock.Mock(status=TestInstanceStatus.NONE),
-        'plat2/testA': mock.Mock(status=TestInstanceStatus.NONE),
-        'plat2/testB': mock.Mock(status=TestInstanceStatus.NONE),
-        'plat3/testA': mock.Mock(status=TestInstanceStatus.SKIP),
-        'plat3/testB': mock.Mock(status=TestInstanceStatus.SKIP),
-        'plat3/testC': mock.Mock(status=TestInstanceStatus.ERROR),
+        'plat1/testA': mock.Mock(status=TwisterStatus.NONE),
+        'plat1/testB': mock.Mock(status=TwisterStatus.NONE),
+        'plat1/testC': mock.Mock(status=TwisterStatus.NONE),
+        'plat2/testA': mock.Mock(status=TwisterStatus.NONE),
+        'plat2/testB': mock.Mock(status=TwisterStatus.NONE),
+        'plat3/testA': mock.Mock(status=TwisterStatus.SKIP),
+        'plat3/testB': mock.Mock(status=TwisterStatus.SKIP),
+        'plat3/testC': mock.Mock(status=TwisterStatus.ERROR),
     }
 
     testplan.generate_subset(subset, sets)
@@ -1568,7 +1568,7 @@ def test_testplan_load_from_file(caplog, device_testing, expected_tfilter):
             'retries': 0,
             'testcases': {
                 'TS1.tc1': {
-                    'status': TestInstanceStatus.PASS,
+                    'status': TwisterStatus.PASS,
                     'reason': None,
                     'duration': 60.0,
                     'output': ''
@@ -1597,13 +1597,13 @@ def test_testplan_load_from_file(caplog, device_testing, expected_tfilter):
             'retries': 1,
             'testcases': {
                     'TS3.tc1': {
-                        'status': TestInstanceStatus.ERROR,
+                        'status': TwisterStatus.ERROR,
                         'reason': None,
                         'duration': 360.0,
                         'output': '[ERROR]: File \'dummy.yaml\' not found!\nClosing...'
                     },
                     'TS3.tc2': {
-                        'status': TestInstanceStatus.NONE,
+                        'status': TwisterStatus.NONE,
                         'reason': None,
                         'duration': 0,
                         'output': ''
@@ -1621,7 +1621,7 @@ def test_testplan_load_from_file(caplog, device_testing, expected_tfilter):
             'retries': 0,
             'testcases': {
                 'TS4.tc1': {
-                    'status': TestInstanceStatus.SKIP,
+                    'status': TwisterStatus.SKIP,
                     'reason': 'Not in requested test list.',
                     'duration': 360.0,
                     'output': '[INFO] Parsing...'
@@ -1722,9 +1722,9 @@ def test_testplan_create_build_dir_links(exists):
         instances_linked.append(instance)
 
     instances = {
-        'inst0': mock.Mock(status=TestInstanceStatus.PASS),
-        'inst1': mock.Mock(status=TestInstanceStatus.SKIP),
-        'inst2': mock.Mock(status=TestInstanceStatus.ERROR),
+        'inst0': mock.Mock(status=TwisterStatus.PASS),
+        'inst1': mock.Mock(status=TwisterStatus.SKIP),
+        'inst2': mock.Mock(status=TwisterStatus.ERROR),
     }
     expected_instances = [instances['inst0'], instances['inst2']]
 
@@ -1789,7 +1789,7 @@ TESTDATA_14 = [
     ('bad platform', 'dummy reason', [],
      'dummy status', 'dummy reason'),
     ('good platform', 'quarantined', [],
-     TestInstanceStatus.ERROR, 'quarantined but is one of the integration platforms'),
+     TwisterStatus.ERROR, 'quarantined but is one of the integration platforms'),
     ('good platform', 'dummy reason', [{'type': 'command line filter'}],
      'dummy status', 'dummy reason'),
     ('good platform', 'dummy reason', [{'type': 'Skip filter'}],
@@ -1801,7 +1801,7 @@ TESTDATA_14 = [
     ('good platform', 'dummy reason', [{'type': 'Module filter'}],
      'dummy status', 'dummy reason'),
     ('good platform', 'dummy reason', [{'type': 'testsuite filter'}],
-     TestInstanceStatus.ERROR, 'dummy reason but is one of the integration platforms'),
+     TwisterStatus.ERROR, 'dummy reason but is one of the integration platforms'),
 ]
 
 @pytest.mark.parametrize(

--- a/scripts/tests/twister/test_testsuite.py
+++ b/scripts/tests/twister/test_testsuite.py
@@ -17,6 +17,7 @@ from contextlib import nullcontext
 ZEPHYR_BASE = os.getenv('ZEPHYR_BASE')
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, 'scripts', 'pylib', 'twister'))
 
+from twisterlib.statuses import TwisterStatus
 from twisterlib.testsuite import (
     _find_src_dir_path,
     _get_search_area_boundary,
@@ -856,11 +857,11 @@ def test_testsuite_load(
 def test_testcase_dunders():
     case_lesser = TestCase(name='A lesser name')
     case_greater = TestCase(name='a greater name')
-    case_greater.status = 'success'
+    case_greater.status = TwisterStatus.FAIL
 
     assert case_lesser < case_greater
     assert str(case_greater) == 'a greater name'
-    assert repr(case_greater) == '<TestCase a greater name with success>'
+    assert repr(case_greater) == f'<TestCase a greater name with {str(TwisterStatus.FAIL)}>'
 
 
 TESTDATA_11 = [

--- a/scripts/tests/twister_blackbox/test_tooling.py
+++ b/scripts/tests/twister_blackbox/test_tooling.py
@@ -14,7 +14,9 @@ import pytest
 import sys
 import json
 
+# pylint: disable=no-name-in-module
 from conftest import ZEPHYR_BASE, TEST_DATA, sample_filename_mock, testsuite_filename_mock
+from twisterlib.statuses import TestCaseStatus
 from twisterlib.testplan import TestPlan
 
 
@@ -83,7 +85,7 @@ class TestTooling:
 
         # Normally, board not supporting our toolchain would be filtered, so we check against that
         assert len(filtered_j) == 1
-        assert filtered_j[0][3] != 'filtered'
+        assert filtered_j[0][3] != TestCaseStatus.FILTER
 
     @pytest.mark.parametrize(
         'test_path, test_platforms',

--- a/scripts/tests/twister_blackbox/test_tooling.py
+++ b/scripts/tests/twister_blackbox/test_tooling.py
@@ -14,9 +14,8 @@ import pytest
 import sys
 import json
 
-# pylint: disable=no-name-in-module
 from conftest import ZEPHYR_BASE, TEST_DATA, sample_filename_mock, testsuite_filename_mock
-from twisterlib.statuses import TestCaseStatus
+from twisterlib.statuses import TwisterStatus
 from twisterlib.testplan import TestPlan
 
 
@@ -85,7 +84,7 @@ class TestTooling:
 
         # Normally, board not supporting our toolchain would be filtered, so we check against that
         assert len(filtered_j) == 1
-        assert filtered_j[0][3] != TestCaseStatus.FILTER
+        assert filtered_j[0][3] != TwisterStatus.FILTER
 
     @pytest.mark.parametrize(
         'test_path, test_platforms',


### PR DESCRIPTION
Now statuses are not just an `str` that can be easily mistyped or assigned wrong. Now they are an `Enum`.

Every object that can have a status has a separate `Status` class. It is probably an overkill, but we want a gradual change of current status handling system.