### PR TITLE
[RFC] Introduce K_SYSCALL_INLINE

### DIFF
--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -2408,7 +2408,8 @@ PREDEFINED             = __DOXYGEN__ \
                          __syscall= \
                          __syscall_always_inline= \
                          __must_check= \
-                         "ATOMIC_DEFINE(x, y)=atomic_t x[ATOMIC_BITMAP_SIZE(y)]"
+                         "ATOMIC_DEFINE(x, y)=atomic_t x[ATOMIC_BITMAP_SIZE(y)]" \
+                         "K_SYSCALL_INLINE(ret, name, ...)=ret name(__VA_ARGS__)"
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -19,6 +19,7 @@
 #include <zephyr/types.h>
 #include <zephyr/device.h>
 #include <zephyr/kernel.h>
+#include <zephyr/syscall.h>
 #include <string.h>
 #include <zephyr/sys_clock.h>
 #include <zephyr/sys/util.h>
@@ -825,9 +826,7 @@ struct can_device_state {
  *
  * @return 0 on success, or a negative error code on error
  */
-__syscall int can_get_core_clock(const struct device *dev, uint32_t *rate);
-
-static inline int z_impl_can_get_core_clock(const struct device *dev, uint32_t *rate)
+K_SYSCALL_INLINE(int, can_get_core_clock, const struct device *dev, uint32_t *rate)
 {
 	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
 

--- a/include/zephyr/syscall.h
+++ b/include/zephyr/syscall.h
@@ -48,6 +48,36 @@ extern "C" {
  */
 
 /**
+ * @brief Utility macro to define an inline system call.
+ *
+ * Example:
+ *
+ * @code{.c}
+ * K_SYSCALL_INLINE(int, foo, int bar)
+ * {
+ *	...
+ * }
+ * @endcode
+ *
+ * expands to:
+ *
+ * @code{.c}
+ * int foo(int bar);
+ * static inline int z_impl_foo(int bar)
+ * {
+ *     ...
+ * }
+ * @endcode
+ *
+ * @param ret Return type
+ * @param name Function name
+ * @param ... Function arguments
+ */
+#define K_SYSCALL_INLINE(ret, name, ...) \
+	static inline ret name(__VA_ARGS__); \
+	static inline ret z_impl_##name(__VA_ARGS__)
+
+/**
  * @typedef _k_syscall_handler_t
  * @brief System call handler function type
  *


### PR DESCRIPTION
Add a new utility macro to define inline syscalls. This is an
alternative to the existing way of defining inline syscalls, ie

```c
K_SYSCALL_INLINE(int, foo, int bar)
{
    ...
}
```

instead of:

```c
__syscall int foo(int bar);

static inline int z_impl_foo(int bar)
{
    ...
}
```

This solution has several advantages:

- Less verbose
- Non-breaking change, can co-exist with current solution
- Hides implementation details (ie, z_impl_...) from header files
- Opens the door to skip the generation of syscall files by just expanding `K_SYSCALL_INLINE()` to a single `static inline ...` call if `CONFIG_USERSPACE=n` (not done for now), thus speeding up builds. (not tested, but unless I've missed something this should be possible)