### PR TITLE
kernel: Remove duplicate execution_cycles write and improve docstring

### DIFF
--- a/include/zephyr/kernel/thread.h
+++ b/include/zephyr/kernel/thread.h
@@ -206,13 +206,12 @@ struct _thread_userspace_local_data {
 
 typedef struct k_thread_runtime_stats {
 #ifdef CONFIG_SCHED_THREAD_USAGE
-	uint64_t execution_cycles;
-	uint64_t total_cycles;        /* total # of non-idle cycles */
 	/*
-	 * In the context of thread statistics, [execution_cycles] is the same
-	 * as the total # of non-idle cycles. In the context of CPU statistics,
-	 * it refers to the sum of non-idle + idle cycles.
+	 * For CPU stats, execution_cycles is the sum of non-idle + idle cycles.
+	 * For thread stats, execution_cycles = total_cycles.
 	 */
+	uint64_t execution_cycles;    /* total # of cycles (cpu: non-idle + idle) */
+	uint64_t total_cycles;        /* total # of non-idle cycles */
 #endif /* CONFIG_SCHED_THREAD_USAGE */
 
 #ifdef CONFIG_SCHED_THREAD_USAGE_ANALYSIS

--- a/kernel/usage.c
+++ b/kernel/usage.c
@@ -220,7 +220,6 @@ void z_sched_thread_usage(struct k_thread *thread,
 #ifdef CONFIG_SCHED_THREAD_USAGE_ALL
 	stats->idle_cycles = 0;
 #endif /* CONFIG_SCHED_THREAD_USAGE_ALL */
-	stats->execution_cycles = thread->base.usage.total;
 
 	k_spin_unlock(&usage_lock, key);
 }


### PR DESCRIPTION
There is a duplicate write to `execution_cycles` in `z_sched_thread_usage()` that can be removed. Also modified the docstrings to `k_thread_runtime_stats` to help better describe the differences between execution_cycles and total_cycles when getting stats for the CPU or a thread