### PR TITLE
llext: fix llext_find_sym() not to return a "const" value

### DIFF
--- a/include/zephyr/llext/llext.h
+++ b/include/zephyr/llext/llext.h
@@ -163,7 +163,7 @@ int llext_unload(struct llext **ext);
  * @retval NULL if no symbol found
  * @retval addr Address of symbol in memory if found
  */
-const void * const llext_find_sym(const struct llext_symtable *sym_table, const char *sym_name);
+const void *llext_find_sym(const struct llext_symtable *sym_table, const char *sym_name);
 
 /**
  * @brief Call a function by name

--- a/subsys/llext/llext.c
+++ b/subsys/llext/llext.c
@@ -114,7 +114,7 @@ int llext_iterate(int (*fn)(struct llext *ext, void *arg), void *arg)
 	return ret;
 }
 
-const void * const llext_find_sym(const struct llext_symtable *sym_table, const char *sym_name)
+const void *llext_find_sym(const struct llext_symtable *sym_table, const char *sym_name)
 {
 	if (sym_table == NULL) {
 		/* Built-in symbol table */


### PR DESCRIPTION
Returned values are copies, so trying to "const" return values cannot have any effect.

Fixes the following compiler warning:
```
llext.h:165: warning: type qualifiers ignored on function return type
```

Fixes commit 41e0a4a37141 ("llext: Linkable loadable extensions")