### PR TITLE
toolchain: gcc: GEN_ABSOLUTE_SYM: set global with %0 instead of %c0

### DIFF
--- a/include/zephyr/toolchain/gcc.h
+++ b/include/zephyr/toolchain/gcc.h
@@ -496,7 +496,7 @@ do {                                                                    \
 #define GEN_ABSOLUTE_SYM(name, value)                                                              \
 	do {                                                                                       \
 		__asm__(".global " #name);                                                         \
-		__asm__(".set " #name ", %c0" ::"n"(value));                                       \
+		__asm__(".set " #name ", %0" ::"n"(value));                                        \
 		__asm__(".type " #name ", STT_OBJECT");                                            \
 	} while (false)
 


### PR DESCRIPTION
I don't understand why but this fixes commit 87779e73f877 ("toolchain: gcc: Simplify `GEN_ABSOLUTE_SYM` and `GEN_ABSOLUTE_SYM_KCONFIG`") when compiling with our GPLv2, pre-C11 gcc-based toolchain.

I also tested this fix with GCC 12 in the Zephyr SDK and Clang 10 (which _does_ seem to use toolchain/gcc.h) and in both cases it made absolutely zero difference in generated Xtensa code.

Better commit message wanted!

Thanks Daniel Leung for the help offline.