### PR TITLE
ITE: dts: it82xx2: Add missing extend setting of alternate function

### DIFF
--- a/dts/riscv/ite/it82xx2.dtsi
+++ b/dts/riscv/ite/it82xx2.dtsi
@@ -467,10 +467,14 @@
 		pinctrlb: pinctrl@f01668 {
 			compatible = "ite,it8xxx2-pinctrl-func";
 			reg = <0x00f01668 8>;   /* GPCR */
-			func3-gcr =     <0xf03e15 0xf03e15 0xf03e16 NO_FUNC
+			func3-gcr =     <0xf03e15 0xf03e15 0xf03e11 NO_FUNC
+					 NO_FUNC  0xf03e11 NO_FUNC  NO_FUNC>;
+			func3-en-mask = <0x01     0x02     0x20     0
+					 0        0x20     0        0      >;
+			func3-ext =     <NO_FUNC  NO_FUNC  0xf03e16 NO_FUNC
 					 NO_FUNC  0xf03e16 NO_FUNC  NO_FUNC>;
-			func3-en-mask = <0x01     0x02     0x40     0
-					 0        0x40     0        0      >;
+			func3-ext-mask = <0       0        0x40     0
+					  0       0x40     0        0      >;
 			func4-gcr =     <NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC
 					 NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC>;
 			func4-en-mask = <0        0        0        0


### PR DESCRIPTION
If I2C3 switches from GPH1/GPH2 to GPB2/GPB5, extend setting is required.

Test: Accessing I2C is normal if I2C2, I2C3, I2C5 are switched.