### PR TITLE
boards: ti: sk_am62: Add OpenOCD support

### DIFF
--- a/boards/phytec/phyboard_lyra/board.cmake
+++ b/boards/phytec/phyboard_lyra/board.cmake
@@ -1,0 +1,10 @@
+# PHYTEC phyBOARD-Lyra AM62x M4/A53
+#
+# Copyright (c) 2024, PHYTEC Messtechnik GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+if(CONFIG_SOC_AM6234_M4)
+  board_runner_args(openocd "--no-init" "--no-halt" "--no-targets" "--gdb-client-port=3339")
+  include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+endif()

--- a/boards/phytec/phyboard_lyra/doc/phyboard_lyra_am62xx_m4.rst
+++ b/boards/phytec/phyboard_lyra/doc/phyboard_lyra_am62xx_m4.rst
@@ -131,6 +131,21 @@ The board should boot into Linux and the binary will run and print Hello world t
 port.
 
 
+Debugging
+*********
+
+The board is equipped with an XDS110 JTAG debugger. To debug a binary, utilize the `debug` build target:
+
+.. zephyr-app-commands::
+   :zephyr-app: <my_app>
+   :board: phyboard_lyra/am6234/m4
+   :maybe-skip-config:
+   :goals: debug
+
+.. hint::
+   To utilize this feature, you'll need OpenOCD version 0.12 or higher. Due to the possibility of
+   older versions being available in package feeds, it's advisable to `build OpenOCD from source`_.
+
 
 .. _PHYTEC AM62x Product Page:
    https://www.phytec.com/product/phycore-am62x/
@@ -143,3 +158,6 @@ port.
 
 .. _phyBOARD SD Card Booting Essentials:
    https://docs.phytec.com/projects/yocto-phycore-am62x/en/bsp-yocto-ampliphy-am62x-pd23.2.1/bootingessentials/sdcard.html
+
+.. _build OpenOCD from source:
+   https://docs.u-boot.org/en/latest/board/ti/k3.html#building-openocd-from-source

--- a/boards/phytec/phyboard_lyra/support/openocd.cfg
+++ b/boards/phytec/phyboard_lyra/support/openocd.cfg
@@ -1,0 +1,7 @@
+# PHYTEC phyBOARD-Lyra AM62x M4/A53
+#
+# Copyright (c) 2024, PHYTEC Messtechnik GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+source [find board/ti_am625evm.cfg]

--- a/boards/ti/sk_am62/board.cmake
+++ b/boards/ti/sk_am62/board.cmake
@@ -1,0 +1,10 @@
+# Texas Instruments Sitara AM62x-SK-M4 EVM
+#
+# Copyright (c) 2024, PHYTEC Messtechnik GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+if(CONFIG_SOC_AM6234_M4)
+  board_runner_args(openocd "--no-init" "--no-halt" "--no-targets" "--gdb-client-port=3339")
+  include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+endif()

--- a/boards/ti/sk_am62/doc/index.rst
+++ b/boards/ti/sk_am62/doc/index.rst
@@ -119,6 +119,21 @@ To allow the board to boot using the SD card, set the boot pins to the SD Card b
 After changing the boot mode, the board should go through the boot sequence on powering up.
 The binary will run and print Hello world to the MCU_UART0 port.
 
+Debugging
+*********
+
+The board is equipped with an XDS110 JTAG debugger. To debug a binary, utilize the `debug` build target:
+
+.. zephyr-app-commands::
+   :zephyr-app: <my_app>
+   :board: sk_am62/am6234/m4
+   :maybe-skip-config:
+   :goals: debug
+
+.. hint::
+   To utilize this feature, you'll need OpenOCD version 0.12 or higher. Due to the possibility of
+   older versions being available in package feeds, it's advisable to `build OpenOCD from source`_.
+
 References
 **********
 
@@ -136,3 +151,6 @@ AM62x SK EVM TRM:
 
 .. _EVM Setup Page:
    https://software-dl.ti.com/mcu-plus-sdk/esd/AM62X/08_06_00_18/exports/docs/api_guide_am62x/EVM_SETUP_PAGE.html
+
+.. _build OpenOCD from source:
+   https://docs.u-boot.org/en/latest/board/ti/k3.html#building-openocd-from-source

--- a/boards/ti/sk_am62/support/openocd.cfg
+++ b/boards/ti/sk_am62/support/openocd.cfg
@@ -1,0 +1,7 @@
+# Texas Instruments Sitara AM62x-SK-M4 EVM
+#
+# Copyright (c) 2024, PHYTEC Messtechnik GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+source [find board/ti_am625evm.cfg]

--- a/scripts/west_commands/runners/openocd.py
+++ b/scripts/west_commands/runners/openocd.py
@@ -37,6 +37,7 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
                  tcl_port=DEFAULT_OPENOCD_TCL_PORT,
                  telnet_port=DEFAULT_OPENOCD_TELNET_PORT,
                  gdb_port=DEFAULT_OPENOCD_GDB_PORT,
+                 gdb_client_port=DEFAULT_OPENOCD_GDB_PORT,
                  gdb_init=None, no_load=False,
                  target_handle=DEFAULT_OPENOCD_TARGET_HANDLE):
         super().__init__(cfg)
@@ -85,6 +86,7 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
         self.tcl_port = tcl_port
         self.telnet_port = telnet_port
         self.gdb_port = gdb_port
+        self.gdb_client_port = gdb_client_port
         self.gdb_cmd = [cfg.gdb] if cfg.gdb else None
         self.tui_arg = ['-tui'] if tui else []
         self.halt_arg = [] if no_halt else ['-c halt']
@@ -142,6 +144,9 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
                             help='openocd telnet port, defaults to 4444')
         parser.add_argument('--gdb-port', default=DEFAULT_OPENOCD_GDB_PORT,
                             help='openocd gdb port, defaults to 3333')
+        parser.add_argument('--gdb-client-port', default=DEFAULT_OPENOCD_GDB_PORT,
+                            help='''openocd gdb client port if multiple ports come
+                            up, defaults to 3333''')
         parser.add_argument('--gdb-init', action='append',
                             help='if given, add GDB init commands')
         parser.add_argument('--no-halt', action='store_true',
@@ -170,8 +175,8 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
             use_elf=args.use_elf, no_halt=args.no_halt, no_init=args.no_init,
             no_targets=args.no_targets, tcl_port=args.tcl_port,
             telnet_port=args.telnet_port, gdb_port=args.gdb_port,
-            gdb_init=args.gdb_init, no_load=args.no_load,
-            target_handle=args.target_handle)
+            gdb_client_port=args.gdb_client_port, gdb_init=args.gdb_init,
+            no_load=args.no_load, target_handle=args.target_handle)
 
     def print_gdbserver_message(self):
         if not self.thread_info_enabled:
@@ -347,7 +352,7 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
                       pre_init_cmd + self.init_arg + self.targets_arg +
                       self.halt_arg)
         gdb_cmd = (self.gdb_cmd + self.tui_arg +
-                   ['-ex', 'target extended-remote :{}'.format(self.gdb_port),
+                   ['-ex', 'target extended-remote :{}'.format(self.gdb_client_port),
                     self.elf_name])
         if command == 'debug':
             gdb_cmd.extend(self.load_arg)

--- a/soc/ti/k3/am6x/Kconfig.defconfig
+++ b/soc/ti/k3/am6x/Kconfig.defconfig
@@ -42,4 +42,7 @@ endif # SERIAL
 config BUILD_OUTPUT_BIN
 	default n if SOC_SERIES_AM6X_M4
 
+config BUILD_NO_GAP_FILL
+	default y if SOC_SERIES_AM6X_M4
+
 endif # SOC_SERIES_AM6X


### PR DESCRIPTION
This patch series adds an additional parameter to the openocd runner `--gdb-port-offset` and all required files to run `west debug` with the TI AM62 EVM.