### PR TITLE
manifest: Update nRF hw models to latest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -295,7 +295,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: c8fd53aab0c52b3898e5b89ca7c3e1a96e299306
+      revision: 123d37db9cae528d51530c61ba0422192bc03bda
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
       revision: da78aea63159771956fe0c9263f2e6985b66e9d5


### PR DESCRIPTION
Update the HW models module to 123d37db9cae528d51530c61ba0422192bc03bda

Including the following:
* 123d37d RTC: Fix for TASKS_TRIGOVRFLW with stopped counter