### PR TITLE
boards/nordic/nrf54l15pdk: added mx25r64 flash DTS

### DIFF
--- a/boards/nordic/nrf54l15pdk/nrf54l15pdk_nrf54l15-pinctrl.dtsi
+++ b/boards/nordic/nrf54l15pdk/nrf54l15pdk_nrf54l15-pinctrl.dtsi
@@ -47,4 +47,21 @@
 			low-power-enable;
 		};
 	};
+
+	/omit-if-no-ref/ spi00_default: spi00_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 2, 1)>,
+				<NRF_PSEL(SPIM_MOSI, 2, 2)>,
+				<NRF_PSEL(SPIM_MISO, 2, 4)>;
+		};
+	};
+
+	/omit-if-no-ref/ spi00_sleep: spi00_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 2, 1)>,
+				<NRF_PSEL(SPIM_MOSI, 2, 2)>,
+				<NRF_PSEL(SPIM_MISO, 2, 4)>;
+				low-power-enable;
+		};
+	};
 };

--- a/boards/nordic/nrf54l15pdk/nrf54l15pdk_nrf54l15_cpuapp.dts
+++ b/boards/nordic/nrf54l15pdk/nrf54l15pdk_nrf54l15_cpuapp.dts
@@ -22,6 +22,10 @@
 		zephyr,sram = &cpuapp_sram;
 		zephyr,ieee802154 = &ieee802154;
 	};
+
+	aliases {
+		spi-flash0 = &mx25r64;
+	};
 };
 
 &cpuapp_sram {
@@ -117,4 +121,30 @@
 
 &clock {
 	status = "okay";
+};
+
+&spi00 {
+	status = "okay";
+	cs-gpios = <&gpio2 5 GPIO_ACTIVE_LOW>;
+	pinctrl-0 = <&spi00_default>;
+	pinctrl-1 = <&spi00_sleep>;
+	pinctrl-names = "default", "sleep";
+
+	mx25r64: mx25r6435f@0 {
+		compatible = "jedec,spi-nor";
+		status = "disabled";
+		reg = <0>;
+		spi-max-frequency = <8000000>;
+		jedec-id = [c2 28 17];
+		sfdp-bfp = [
+			e5 20 f1 ff  ff ff ff 03  44 eb 08 6b  08 3b 04 bb
+			ee ff ff ff  ff ff 00 ff  ff ff 00 ff  0c 20 0f 52
+			10 d8 00 ff  23 72 f5 00  82 ed 04 cc  44 83 48 44
+			30 b0 30 b0  f7 c4 d5 5c  00 be 29 ff  f0 d0 ff ff
+		];
+		size = <67108864>;
+		has-dpd;
+		t-enter-dpd = <10000>;
+		t-exit-dpd = <35000>;
+	};
 };


### PR DESCRIPTION
Added DTS of PDK's mx25r64 flash memory.
Memory is described under spi00 peripheral and
can be controlled used flash spi_nor driver.

Added Kconfig indicator boolean for HW instance of GPIO2.