### PR TITLE
tests: drivers: clock_control: nrf_lf_clock_start: Fix SYNTH test

### DIFF
--- a/tests/drivers/clock_control/nrf_lf_clock_start/src/main.c
+++ b/tests/drivers/clock_control/nrf_lf_clock_start/src/main.c
@@ -38,15 +38,12 @@ static void rc_check(bool on, nrf_clock_lfclk_t type)
 
 static void synth_check(bool on, nrf_clock_lfclk_t type)
 {
-	#if !defined(CLOCK_LFCLKSRC_SRC_Synth) && \
-	    !defined(CLOCK_LFCLKSRC_SRC_LFSYNT)
-	#define NRF_CLOCK_LFCLK_SYNTH 0
-	#endif
-
+#ifdef CONFIG_CLOCK_CONTROL_NRF_K32SRC_SYNTH
 	if (!IS_ENABLED(CONFIG_SYSTEM_CLOCK_NO_WAIT)) {
 		zassert_true(on, "Clock should be on");
 		zassert_equal(type, NRF_CLOCK_LFCLK_SYNTH);
 	}
+#endif
 }
 
 ZTEST(nrf_lf_clock_start, test_clock_check)


### PR DESCRIPTION
Test was not covering nrf54l15 which had Synth source bitfield renamed. Changing the test to use Kconfig to determine if Synth is present.