### PR TITLE
llext: remove build restrictions on tests

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -5328,7 +5328,8 @@ function(add_llext_target target_name)
     # output a relocatable file. The output file suffix is changed so
     # the result looks like the object file it actually is.
     add_executable(${llext_lib_target} EXCLUDE_FROM_ALL ${source_files})
-    target_link_options(${llext_lib_target} PRIVATE -r)
+    target_link_options(${llext_lib_target} PRIVATE
+      $<TARGET_PROPERTY:linker,partial_linking>)
     set_target_properties(${llext_lib_target} PROPERTIES
       SUFFIX ${CMAKE_C_OUTPUT_EXTENSION})
     set(llext_lib_output $<TARGET_FILE:${llext_lib_target}>)

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -5302,6 +5302,11 @@ function(add_llext_target target_name)
        OUTPUT_VARIABLE llext_remove_flags_regexp
   )
   string(REPLACE ";" "|" llext_remove_flags_regexp "${llext_remove_flags_regexp}")
+  if ("${llext_remove_flags_regexp}" STREQUAL "")
+    # an empty regexp would match anything, we actually need the opposite
+    # so set it to match empty strings
+    set(llext_remove_flags_regexp "^$")
+  endif()
   set(zephyr_flags
       "$<TARGET_PROPERTY:zephyr_interface,INTERFACE_COMPILE_OPTIONS>"
   )

--- a/tests/subsys/llext/simple/CMakeLists.txt
+++ b/tests/subsys/llext/simple/CMakeLists.txt
@@ -15,34 +15,32 @@ target_include_directories(app PRIVATE
   ${ZEPHYR_BASE}/arch/${ARCH}/include
 )
 
-if(NOT LOADER_BUILD_ONLY)
-  set(ext_names hello_world logging relative_jump object syscalls threads_kernel_objects)
+set(ext_names hello_world logging relative_jump object syscalls threads_kernel_objects)
 
-  if(CONFIG_ARM)
-    if(NOT CONFIG_CPU_CORTEX_M0 AND NOT CONFIG_CPU_CORTEX_M0PLUS AND NOT CONFIG_CPU_CORTEX_M1)
-      list(APPEND ext_names movwmovt)
-    endif()
+if(CONFIG_ARM)
+  if(NOT CONFIG_CPU_CORTEX_M0 AND NOT CONFIG_CPU_CORTEX_M0PLUS AND NOT CONFIG_CPU_CORTEX_M1)
+    list(APPEND ext_names movwmovt)
   endif()
-
-  # generate extension targets foreach extension given by 'ext_names'
-  foreach(ext_name ${ext_names})
-    set(ext_src ${PROJECT_SOURCE_DIR}/src/${ext_name}_ext.c)
-    set(ext_bin ${ZEPHYR_BINARY_DIR}/${ext_name}.llext)
-    set(ext_inc ${ZEPHYR_BINARY_DIR}/include/generated/${ext_name}.inc)
-    add_llext_target(${ext_name}_ext
-      OUTPUT  ${ext_bin}
-      SOURCES ${ext_src}
-    )
-    generate_inc_file_for_target(app ${ext_bin} ${ext_inc})
-  endforeach()
-
-  # Add a dummy custom processing command to test add_llext_command
-  get_target_property(proc_in_file hello_world_ext lib_output)
-  get_target_property(proc_out_file hello_world_ext pkg_input)
-  add_llext_command(
-    TARGET hello_world_ext
-    POST_BUILD
-    COMMAND echo "dummy patching ${proc_in_file} to create ${proc_out_file}"
-    COMMAND ${CMAKE_COMMAND} -E copy ${proc_in_file} ${proc_out_file}
-  )
 endif()
+
+# generate extension targets foreach extension given by 'ext_names'
+foreach(ext_name ${ext_names})
+  set(ext_src ${PROJECT_SOURCE_DIR}/src/${ext_name}_ext.c)
+  set(ext_bin ${ZEPHYR_BINARY_DIR}/${ext_name}.llext)
+  set(ext_inc ${ZEPHYR_BINARY_DIR}/include/generated/${ext_name}.inc)
+  add_llext_target(${ext_name}_ext
+    OUTPUT  ${ext_bin}
+    SOURCES ${ext_src}
+  )
+  generate_inc_file_for_target(app ${ext_bin} ${ext_inc})
+endforeach()
+
+# Add a dummy custom processing command to test add_llext_command
+get_target_property(proc_in_file hello_world_ext lib_output)
+get_target_property(proc_out_file hello_world_ext pkg_input)
+add_llext_command(
+  TARGET hello_world_ext
+  POST_BUILD
+  COMMAND echo "dummy patching ${proc_in_file} to create ${proc_out_file}"
+  COMMAND ${CMAKE_COMMAND} -E copy ${proc_in_file} ${proc_out_file}
+)

--- a/tests/subsys/llext/simple/src/test_llext_simple.c
+++ b/tests/subsys/llext/simple/src/test_llext_simple.c
@@ -180,7 +180,6 @@ void load_call_unload(struct llext_test *test_case)
 	llext_unload(&ext);
 }
 
-#ifndef LOADER_BUILD_ONLY
 /*
  * Attempt to load, list, list symbols, call a fn, and unload each
  * extension in the test table. This excercises loading, calling into, and
@@ -230,7 +229,6 @@ static LLEXT_CONST uint8_t threads_kernel_objects_ext[] __aligned(4) = {
 };
 LLEXT_LOAD_UNLOAD(threads_kernel_objects, true, threads_objects_perm_setup)
 #endif
-#endif /* ! LOADER_BUILD_ONLY */
 
 
 /*

--- a/tests/subsys/llext/simple/testcase.yaml
+++ b/tests/subsys/llext/simple/testcase.yaml
@@ -8,22 +8,14 @@ common:
     - qemu_cortex_r5 # unsupported relocations
 
 tests:
-  # add_llext_target() supports a fairly limited number of
-  # CONFIG_urations.  For instance, invoking add_llext_target()
-  # currently blocks us from compiling subsys/llext/*.c in 64bits mode;
-  # CMake aborts before even invoking the compiler.
-  #
   # While there is in practice no value in compiling subsys/llext/*.c
   # without actually running it to load some extension, let's keep it in
-  # good shape and ready to be used when add_llext_target()
-  # limitations get lifted in the future.
+  # good shape and ready to be used by additional architectures in the
+  # future.
   llext.simple.loader_build:
     build_only: true
     # How to override the above and allow ANY arch?
     arch_allow: arm arm64 x86 x86_64 xtensa posix
-    extra_args:
-      - LOADER_BUILD_ONLY=1
-      - EXTRA_CFLAGS=-DLOADER_BUILD_ONLY=1
 
   llext.simple.readonly:
     arch_exclude: xtensa # for now

--- a/tests/subsys/llext/simple/testcase.yaml
+++ b/tests/subsys/llext/simple/testcase.yaml
@@ -50,9 +50,8 @@ tests:
   llext.simple.modules_enabled_writable_relocatable:
     arch_exclude: arm arm64
     filter: not CONFIG_MPU and not CONFIG_MMU
-    platform_key:
-      - simulation
-      - arch
+    integration_platforms:
+      - qemu_xtensa
     extra_configs:
       - CONFIG_MODULES=y
       - CONFIG_LLEXT_STORAGE_WRITABLE=y


### PR DESCRIPTION
This PR improves #71279 by fixing an issue that was preventing, on architectures not currently supported by llext, an `add_llext_target` command to at least complete a build successfully. This makes it possible to remove gates that had to be added in commit 1408d1e5b8ce to support the same functionality for testing purposes.

Also introduces two other minor tweaks:
- uses a toolchain-independent relocatable flag instead of hardcoding `-r`;
- relaxes the `modules_writable_relocatable` test limits so CI picks it up properly (thanks to @lyakh  for spotting this!).

Note: the only change in `tests/subsys/llext/simple/CMakeLists.txt` is the removal of the `if(LOADER_BUILD_ONLY)`/`endif()` gate, but the indent change makes GitHub uneasy. View [the diff ignoring whitespace](https://github.com/zephyrproject-rtos/zephyr/pull/71430/files?diff=split&w=1) instead.