### PR TITLE
dts: sifive: Update SoC compats

### DIFF
--- a/dts/riscv/sifive/riscv64-fu540.dtsi
+++ b/dts/riscv/sifive/riscv64-fu540.dtsi
@@ -51,7 +51,7 @@
 	soc {
 		#address-cells = <1>;
 		#size-cells = <1>;
-		compatible = "simple-bus";
+		compatible = "fu540-soc", "sifive-soc", "simple-bus";
 		ranges;
 
 		modeselect: rom@1000 {

--- a/dts/riscv/sifive/riscv64-fu740.dtsi
+++ b/dts/riscv/sifive/riscv64-fu740.dtsi
@@ -102,7 +102,7 @@
 	soc {
 		#address-cells = <2>;
 		#size-cells = <2>;
-		compatible = "simple-bus";
+		compatible = "fu740-soc", "sifive-soc", "simple-bus";
 		ranges;
 
 		modeselect: rom@1000 {


### PR DESCRIPTION
The SiFive SoCs have inconsistent compat strings. I want to improve the information saved there and add two new compat strings (`"fu540-soc", "sifive-soc"` and `"fu740-soc", "sifive-soc"`), to make these fields consistent across all SiFive SoCs.
