### PR TITLE
net: l2: ppp: Fix terminate requests

### DIFF
--- a/subsys/net/l2/ppp/ppp_l2.c
+++ b/subsys/net/l2/ppp/ppp_l2.c
@@ -231,7 +231,9 @@ static int ppp_lcp_close(struct ppp_context *ctx)
 
 	k_sem_reset(&ctx->wait_ppp_link_terminated);
 	ppp_lcp->close(ctx, "L2 Disabled");
-	return k_sem_take(&ctx->wait_ppp_link_terminated, K_MSEC(CONFIG_NET_L2_PPP_TIMEOUT));
+	return k_sem_take(&ctx->wait_ppp_link_terminated,
+			  K_MSEC(CONFIG_NET_L2_PPP_TIMEOUT *
+				 (1 + CONFIG_NET_L2_PPP_MAX_TERMINATE_REQ_RETRANSMITS)));
 }
 
 static void ppp_lcp_lower_down_async(struct ppp_context *ctx)


### PR DESCRIPTION
When PPP moves to the 'Closing' state it sends up to configured number of 'Terminate-Request' packets. It only moves to the 'Initial' state, after running out of retransmits or when it receives a 'Terminate-Ack' packet.

Edit: This causes `net_if_down()` to exit with EALREADY when there is no remote PPP client or it does not answer to the first 'Terminate-Request' packet. 