### PR TITLE
tests: intel_adsp: ssp: fix segfault in test_adsp_ssp_transfer()

### DIFF
--- a/tests/boards/intel_adsp/ssp/src/main.c
+++ b/tests/boards/intel_adsp/ssp/src/main.c
@@ -330,6 +330,9 @@ ZTEST(adsp_ssp, test_adsp_ssp_transfer)
 		return;
 	}
 
+	k_msleep(50);
+
+	TC_PRINT("waiting for xfer_sem\n");
 
 	if (k_sem_take(&xfer_sem, K_MSEC(1000)) != 0) {
 		TC_PRINT("timed out waiting for xfers\n");


### PR DESCRIPTION
Add delay before we call k_sem_take(). For some reason, this avoids a segfault.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/61789