### PR TITLE
drivers: mipi_dbi: add release API, and allow mode to be set via devicetree

### DIFF
--- a/drivers/mipi_dbi/mipi_dbi_spi.c
+++ b/drivers/mipi_dbi/mipi_dbi_spi.c
@@ -266,6 +266,14 @@ static int mipi_dbi_spi_reset(const struct device *dev, uint32_t delay)
 	return gpio_pin_set_dt(&config->reset, 0);
 }
 
+static int mipi_dbi_spi_release(const struct device *dev,
+				const struct mipi_dbi_config *dbi_config)
+{
+	const struct mipi_dbi_spi_config *config = dev->config;
+
+	return spi_release(config->spi_dev, &dbi_config->config);
+}
+
 static int mipi_dbi_spi_init(const struct device *dev)
 {
 	const struct mipi_dbi_spi_config *config = dev->config;
@@ -308,6 +316,7 @@ static struct mipi_dbi_driver_api mipi_dbi_spi_driver_api = {
 	.reset = mipi_dbi_spi_reset,
 	.command_write = mipi_dbi_spi_command_write,
 	.write_display = mipi_dbi_spi_write_display,
+	.release = mipi_dbi_spi_release,
 #if MIPI_DBI_SPI_READ_REQUIRED
 	.command_read = mipi_dbi_spi_command_read,
 #endif

--- a/dts/bindings/mipi-dbi/mipi-dbi-device.yaml
+++ b/dts/bindings/mipi-dbi/mipi-dbi-device.yaml
@@ -11,3 +11,14 @@ properties:
   mipi-max-frequency:
     type: int
     description: Maximum clock frequency of device's MIPI interface in Hz
+
+  mipi-mode:
+    type: int
+    description: |
+      MIPI DBI mode in use. Use the macros not the actual enum value, here is
+      the concordance list (see dt-bindings/mipi_dbi/mipi_dbi.h)
+        1     MIPI_DBI_MODE_SPI_3WIRE
+        2     MIPI_DBI_MODE_SPI_4WIRE
+    enum:
+      - 1
+      - 2

--- a/include/zephyr/drivers/mipi_dbi.h
+++ b/include/zephyr/drivers/mipi_dbi.h
@@ -34,50 +34,11 @@
 #include <zephyr/drivers/display.h>
 #include <zephyr/display/mipi_display.h>
 #include <zephyr/drivers/spi.h>
+#include <zephyr/dt-bindings/mipi_dbi/mipi_dbi.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * SPI 3 wire (Type C1). Uses 9 write clocks to send a byte of data.
- * The bit sent on the 9th clock indicates whether the byte is a
- * command or data byte
- *
- *
- *           .---.   .---.   .---.   .---.   .---.   .---.   .---.   .---.
- *     SCK  -'   '---'   '---'   '---'   '---'   '---'   '---'   '---'   '---
- *
- *          -.---.---.---.---.---.---.---.---.---.---.---.---.---.---.---.
- *     DOUT  |D/C| D7| D6| D5| D4| D3| D2| D1| D0|D/C| D7| D6| D5| D4|...|
- *          -'---'---'---'---'---'---'---'---'---'---'---'---'---'---'---'
- *           | Word 1                            | Word n
- *
- *          -.								 .--
- *     CS    '-----------------------------------------------------------'
- */
-#define MIPI_DBI_MODE_SPI_3WIRE 0x1
-/**
- * SPI 4 wire (Type C3). Uses 8 write clocks to send a byte of data.
- * an additional C/D pin will be use to indicate whether the byte is a
- * command or data byte
- *
- *           .---.   .---.   .---.   .---.   .---.   .---.   .---.   .---.
- *     SCK  -'   '---'   '---'   '---'   '---'   '---'   '---'   '---'   '---
- *
- *          -.---.---.---.---.---.---.---.---.---.---.---.---.---.---.---.---.
- *     DOUT  | D7| D6| D5| D4| D3| D2| D1| D0| D7| D6| D5| D4| D3| D2| D1| D0|
- *          -'---'---'---'---'---'---'---'---'---'---'---'---'---'---'---'---'
- *           | Word 1                        | Word n
- *
- *          -.								     .--
- *     CS    '---------------------------------------------------------------'
- *
- *          -.-------------------------------.-------------------------------.-
- *     CD    |             D/C               |             D/C               |
- *          -'-------------------------------'-------------------------------'-
- */
-#define MIPI_DBI_MODE_SPI_4WIRE 0x2
 
 /**
  * @brief initialize a MIPI DBI SPI configuration struct from devicetree
@@ -120,6 +81,36 @@ extern "C" {
  */
 #define MIPI_DBI_SPI_CONFIG_DT_INST(inst, operation_, delay_)		\
 	MIPI_DBI_SPI_CONFIG_DT(DT_DRV_INST(inst), operation_, delay_)
+
+/**
+ * @brief Initialize a MIPI DBI configuration from devicetree
+ *
+ * This helper allows drivers to initialize a MIPI DBI configuration
+ * structure from devicetree. It sets the MIPI DBI mode, as well
+ * as configuration fields in the SPI configuration structure
+ * @param node_id Devicetree node identifier for the MIPI DBI device to
+ *                initialize
+ * @param operation_ the desired operation field in the struct spi_config
+ * @param delay_ the desired delay field in the struct spi_config's
+ *               spi_cs_control, if there is one
+ */
+#define MIPI_DBI_CONFIG_DT(node_id, operation_, delay_)			\
+	{								\
+		.mode = DT_PROP(node_id, mipi_mode),			\
+		.config = MIPI_DBI_SPI_CONFIG_DT(node_id, operation_, delay_), \
+	}
+
+/**
+ * @brief Initialize a MIPI DBI configuration from device instance
+ *
+ * Equivalent to MIPI_DBI_CONFIG_DT(DT_DRV_INST(inst), operation_, delay_)
+ * @param inst Instance of the device to initialize a MIPI DBI configuration for
+ * @param operation_ the desired operation field in the struct spi_config
+ * @param delay_ the desired delay field in the struct spi_config's
+ *               spi_cs_control, if there is one
+ */
+#define MIPI_DBI_CONFIG_DT_INST(inst, operation_, delay_)		\
+	MIPI_DBI_CONFIG_DT(DT_DRV_INST(inst), operation_, delay_)
 
 /**
  * @brief MIPI DBI controller configuration

--- a/include/zephyr/drivers/mipi_dbi.h
+++ b/include/zephyr/drivers/mipi_dbi.h
@@ -94,7 +94,7 @@ extern "C" {
 	{								\
 		.frequency = DT_PROP(node_id, mipi_max_frequency),	\
 		.operation = (operation_) |				\
-			DT_PROP(node_id, duplex) |			\
+			DT_PROP_OR(node_id, duplex, 0) |			\
 			COND_CODE_1(DT_PROP(node_id, mipi_cpol), SPI_MODE_CPOL, (0)) |	\
 			COND_CODE_1(DT_PROP(node_id, mipi_cpha), SPI_MODE_CPHA, (0)) |	\
 			COND_CODE_1(DT_PROP(node_id, mipi_hold_cs), SPI_HOLD_ON_CS, (0)),	\
@@ -107,6 +107,19 @@ extern "C" {
 			.delay = (delay_),				\
 		},							\
 	}
+
+/**
+ * @brief Initialize a MIPI DBI SPI configuration from devicetree instance
+ *
+ * This helper initializes a MIPI DBI SPI configuration from a devicetree
+ * instance. It is equivalent to MIPI_DBI_SPI_CONFIG_DT(DT_DRV_INST(inst))
+ * @param inst Instance number to initialize configuration from
+ * @param operation_ the desired operation field in the struct spi_config
+ * @param delay_ the desired delay field in the struct spi_config's
+ *               spi_cs_control, if there is one
+ */
+#define MIPI_DBI_SPI_CONFIG_DT_INST(inst, operation_, delay_)		\
+	MIPI_DBI_SPI_CONFIG_DT(DT_DRV_INST(inst), operation_, delay_)
 
 /**
  * @brief MIPI DBI controller configuration

--- a/include/zephyr/dt-bindings/mipi_dbi/mipi_dbi.h
+++ b/include/zephyr/dt-bindings/mipi_dbi/mipi_dbi.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MIPI_DBI_MIPI_DBI_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_MIPI_DBI_MIPI_DBI_H_
+
+/**
+ * @brief MIPI-DBI driver APIs
+ * @defgroup mipi_dbi_interface MIPI-DBI driver APIs
+ * @ingroup io_interfaces
+ * @{
+ */
+
+/**
+ * SPI 3 wire (Type C1). Uses 9 write clocks to send a byte of data.
+ * The bit sent on the 9th clock indicates whether the byte is a
+ * command or data byte
+ *
+ *
+ *           .---.   .---.   .---.   .---.   .---.   .---.   .---.   .---.
+ *     SCK  -'   '---'   '---'   '---'   '---'   '---'   '---'   '---'   '---
+ *
+ *          -.---.---.---.---.---.---.---.---.---.---.---.---.---.---.---.
+ *     DOUT  |D/C| D7| D6| D5| D4| D3| D2| D1| D0|D/C| D7| D6| D5| D4|...|
+ *          -'---'---'---'---'---'---'---'---'---'---'---'---'---'---'---'
+ *           | Word 1                            | Word n
+ *
+ *          -.								 .--
+ *     CS    '-----------------------------------------------------------'
+ */
+#define MIPI_DBI_MODE_SPI_3WIRE 0x1
+/**
+ * SPI 4 wire (Type C3). Uses 8 write clocks to send a byte of data.
+ * an additional C/D pin will be use to indicate whether the byte is a
+ * command or data byte
+ *
+ *           .---.   .---.   .---.   .---.   .---.   .---.   .---.   .---.
+ *     SCK  -'   '---'   '---'   '---'   '---'   '---'   '---'   '---'   '---
+ *
+ *          -.---.---.---.---.---.---.---.---.---.---.---.---.---.---.---.---.
+ *     DOUT  | D7| D6| D5| D4| D3| D2| D1| D0| D7| D6| D5| D4| D3| D2| D1| D0|
+ *          -'---'---'---'---'---'---'---'---'---'---'---'---'---'---'---'---'
+ *           | Word 1                        | Word n
+ *
+ *          -.								     .--
+ *     CS    '---------------------------------------------------------------'
+ *
+ *          -.-------------------------------.-------------------------------.-
+ *     CD    |             D/C               |             D/C               |
+ *          -'-------------------------------'-------------------------------'-
+ */
+#define MIPI_DBI_MODE_SPI_4WIRE 0x2
+
+/**
+ * @}
+ */
+
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_MIPI_DBI_MIPI_DBI_H_ */


### PR DESCRIPTION
This PR contains a few improvements for the MIPI DBI subsystem:

### Add MIPI DBI Release API

Some SPI based displays expect the ability to lock the SPI bus after a
transaction completes, or to hold CS low. In order to accommodate this
within the MIPI DBI layer, add the mipi_dbi_release API, which allows
SPI displays to hold then release the SPI bus used by the MIPI
abstraction layer.


### Allow MIPI mode to be set via devicetree

Enable MIPI mode to be set via devicetree, for displays that support
multiple MIPI DBI modes. This commit also adds new helpers for displays
that allow drivers to initialize the entire MIPI DBI configuration
structure from devicetree


Since these two improvements are distinct from one another, I'm happy to separate this PR if desired.