### PR TITLE
Fix incorrect memory mapping and size in device tree for STM32L475Xe

### DIFF
--- a/dts/arm/st/l4/stm32l475Xe.dtsi
+++ b/dts/arm/st/l4/stm32l475Xe.dtsi
@@ -8,7 +8,10 @@
 
 / {
 	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(128)>;
+		reg = <0x20000000 DT_SIZE_K(96)>;
+	};
+	sram1: memory@10000000 {
+		reg = <0x10000000 DT_SIZE_K(32)>;
 	};
 
 	soc {


### PR DESCRIPTION
This commit corrects an issue in the device tree configuration for the STM32L475, where the SRAM size and memory mapping were incorrectly specified. Previously, the device tree only included a single SRAM block (sram0) with 128K size. This setup was causing system initialization failures at startup due to incorrect memory mapping.

Changes made:
- The size of `sram0` has been reduced from 128K to 96K.
- Added a new memory block `sram1` at address `0x10000000` with a size of 32K to correct the mapping and size discrepancies.

These adjustments are based on the specifications outlined in the STM32L475XE datasheet, specifically in section 3.5, Embedded SRAM, which confirms the presence and configuration of multiple SRAM blocks. This reference can be found here: [STM32L475XE Datasheet](https://www.st.com/resource/en/datasheet/stm32l475ve.pdf).

The modifications ensure that the system memory map accurately reflects the actual hardware configuration, preventing initialization errors and improving system stability.
