### PR TITLE
mbedtls: compile FFDH support in PSA mode

### DIFF
--- a/modules/mbedtls/CMakeLists.txt
+++ b/modules/mbedtls/CMakeLists.txt
@@ -119,6 +119,7 @@ zephyr_interface_library_named(mbedTLS)
         ${ZEPHYR_CURRENT_MODULE_DIR}/library/psa_crypto_cipher.c
         ${ZEPHYR_CURRENT_MODULE_DIR}/library/psa_crypto_driver_wrappers_no_static.c
         ${ZEPHYR_CURRENT_MODULE_DIR}/library/psa_crypto_ecp.c
+        ${ZEPHYR_CURRENT_MODULE_DIR}/library/psa_crypto_ffdh.c
         ${ZEPHYR_CURRENT_MODULE_DIR}/library/psa_crypto_hash.c
         ${ZEPHYR_CURRENT_MODULE_DIR}/library/psa_crypto_mac.c
         ${ZEPHYR_CURRENT_MODULE_DIR}/library/psa_crypto_rsa.c


### PR DESCRIPTION
Include `psa_crypto_ffdh.c` when compiling MbedTLS with PSA support, as `MBEDTLS_PSA_BUILTIN_KEY_TYPE_DH_PUBLIC_KEY` references the included functions.

`MBEDTLS_PSA_BUILTIN_KEY_TYPE_DH_PUBLIC_KEY` is automatically enabled with `MBEDTLS_DHM_C`, which in turn is enabled by `MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED` or `MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED`. Both of which are selected by `MBEDTLS_KEY_EXCHANGE_ALL_ENABLED`.