### PR TITLE
posix: signal: only define `sigset_t` if not defined

### DIFF
--- a/include/zephyr/posix/signal.h
+++ b/include/zephyr/posix/signal.h
@@ -52,9 +52,12 @@ extern "C" {
 
 BUILD_ASSERT(RTSIG_MAX >= 0);
 
+#if !defined(_SIGSET_T_DECLARED)
+#define _SIGSET_T_DECLARED
 typedef struct {
 	unsigned long sig[DIV_ROUND_UP(_NSIG, BITS_PER_LONG)];
 } sigset_t;
+#endif
 
 #ifndef SIGEV_NONE
 #define SIGEV_NONE 1


### PR DESCRIPTION
Only define `sigset_t` if it has not already been defined externally, for example in `picolibc/include/sys/signal.h`.

This appears to be standard way of preventing redefinitions, see:
* https://github.com/f32c/arduino/blob/7d8cbb33fab873e2d2c6660be4eb42e09ac3eee0/hardware/fpga/f32c/system/include/sys/select.h#L47
* https://github.com/bminor/newlib/blob/730703bdb8e1ae671517efaa0b9e273eef52d724/newlib/libc/include/sys/select.h#L18
* https://github.com/picolibc/picolibc/blob/58d6157cc2135df5043d62c3e89feedc20ffcd57/newlib/libc/include/sys/signal.h#L45