### PR TITLE
logging: multidomain_link: fix crash caused by drop notification

### DIFF
--- a/subsys/logging/log_multidomain_link.c
+++ b/subsys/logging/log_multidomain_link.c
@@ -76,11 +76,13 @@ void log_multidomain_link_on_recv_cb(struct log_multidomain_link *link_remote,
 	case Z_LOG_MULTIDOMAIN_ID_SET_RUNTIME_LEVEL:
 		link_remote->dst.set_runtime_level.level = msg->data.set_rt_level.runtime_level;
 		break;
+	case Z_LOG_MULTIDOMAIN_ID_DROPPED:
+		return;
 	case Z_LOG_MULTIDOMAIN_ID_READY:
 		break;
 	default:
 		__ASSERT(0, "Unexpected message");
-		break;
+		return;
 	}
 
 exit:


### PR DESCRIPTION
The remote domain may send unsolicited `Z_LOG_MULTIDOMAIN_ID_DROPPED` IPC messages, which are not handled in `log_multidomain_link_on_recv_cb()`. With `CONFIG_ASSERT=y`, this will cause an assertion failure. With asserts disabled, this message is treated as a reply to any in progress request, giving `rdy_sem` and thereby causing `getter_msg_process()` to return early. In turn, this can cause various kinds of memory corruption when the real reply arrives and the callback reads/writes stack variables that are no longer valid. Because the real reply will also give `rdy_sem` and nobody is waiting to take it, the next call to `getter_msg_process()` will return immediately, and the cycle repeats from there, until eventually something important gets corrupted.

In my case, this bug caused a crash in code that was not obviously related:
```
#0  0x080bf0fc in z_snode_next_peek (node=0x1f007265)
    at <...>/zephyr/include/zephyr/sys/slist.h:213
#1  0x080bff5f in sys_slist_get_not_empty (list=0x825d808 <sname_cache+8>)
    at <...>/zephyr/include/zephyr/sys/slist.h:379
#2  0x080c7ec6 in sys_slist_get (list=0x825d808 <sname_cache+8>)
    at <...>/zephyr/include/zephyr/sys/slist.h:392
#3  0x080c8706 in log_cache_get (cache=0x825d800 <sname_cache>, id=131073, data=0xf7b3c0a8)
    at <...>/zephyr/subsys/logging/log_cache.c:74
#4  0x080c7224 in link_source_name_get (domain_id=1 '\001', source_id=2)
    at <...>/zephyr/subsys/logging/log_mgmt.c:224
#5  0x080c72f8 in log_source_name_get (domain_id=1, source_id=2)
    at <...>/zephyr/subsys/logging/log_mgmt.c:253
```

Fix this by explicitly ignoring `Z_LOG_MULTIDOMAIN_ID_DROPPED`, and also don't treat unrecognized message types as replies.

Fixes #68120

cc @nordic-krch @bogdanm