### PR TITLE
logging: consistently retrieve source ID from remote messages

### DIFF
--- a/include/zephyr/logging/log_msg.h
+++ b/include/zephyr/logging/log_msg.h
@@ -788,6 +788,14 @@ static inline const void *log_msg_get_source(struct log_msg *msg)
 	return msg->hdr.source;
 }
 
+/** @brief Get log message source ID.
+ *
+ * @param msg Log message.
+ *
+ * @return Source ID, or -1 if not available.
+ */
+int16_t log_msg_get_source_id(struct log_msg *msg);
+
 /** @brief Get timestamp.
  *
  * @param msg Log message.

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -466,18 +466,16 @@ static bool msg_filter_check(struct log_backend const *backend,
 	uint8_t level;
 	uint8_t domain_id;
 	int16_t source_id;
-	struct log_source_dynamic_data *source;
 
-	source = (struct log_source_dynamic_data *)log_msg_get_source(&msg->log);
 	level = log_msg_get_level(&msg->log);
 	domain_id = log_msg_get_domain(&msg->log);
+	source_id = log_msg_get_source_id(&msg->log);
 
 	/* Accept all non-logging messages. */
 	if (level == LOG_LEVEL_NONE) {
 		return true;
 	}
-	if (source) {
-		source_id = log_dynamic_source_id(source);
+	if (source_id >= 0) {
 		backend_level = log_filter_get(backend, domain_id, source_id, true);
 
 		return (level <= backend_level);

--- a/subsys/logging/log_msg.c
+++ b/subsys/logging/log_msg.c
@@ -389,3 +389,21 @@ void z_log_msg_runtime_vcreate(uint8_t domain_id, const void *source,
 		z_log_msg_finalize(msg, source, desc, data);
 	}
 }
+
+int16_t log_msg_get_source_id(struct log_msg *msg)
+{
+	if (!z_log_is_local_domain(log_msg_get_domain(msg))) {
+		/* Remote domain is converting source pointer to ID */
+		return (int16_t)(uintptr_t)log_msg_get_source(msg);
+	}
+
+	void *source = (void *)log_msg_get_source(msg);
+
+	if (source != NULL) {
+		return IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING)
+					? log_dynamic_source_id(source)
+					: log_const_source_id(source);
+	}
+
+	return -1;
+}

--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -717,22 +717,7 @@ void log_output_msg_process(const struct log_output *output,
 	log_timestamp_t timestamp = log_msg_get_timestamp(msg);
 	uint8_t level = log_msg_get_level(msg);
 	uint8_t domain_id = log_msg_get_domain(msg);
-	int16_t source_id;
-
-	if (IS_ENABLED(CONFIG_LOG_MULTIDOMAIN) && domain_id != Z_LOG_LOCAL_DOMAIN_ID) {
-		/* Remote domain is converting source pointer to ID */
-		source_id = (int16_t)(uintptr_t)log_msg_get_source(msg);
-	} else {
-		void *source = (void *)log_msg_get_source(msg);
-
-		if (source != NULL) {
-			source_id = IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ?
-					log_dynamic_source_id(source) :
-					log_const_source_id(source);
-		} else {
-			source_id = -1;
-		}
-	}
+	int16_t source_id = log_msg_get_source_id(msg);
 
 	const char *sname = source_id >= 0 ? log_source_name_get(domain_id, source_id) : NULL;
 	size_t plen, dlen;


### PR DESCRIPTION
The log message header `source` field for messages received from a remote domain contains the source ID, rather than a pointer to the source data (which would not be valid in the local domain).

`msg_filter_check()` did not handle this case and obtained a garbage source ID for remote log messages. This caused an assertion failure in `filter_get()`.

Consistently handle this by adding a `log_msg_get_source_id()` function that returns the source ID for both local and remote messages. This function was implemented based on code factored out of `log_output_msg_process()`.

cc @nordic-krch 