### PR TITLE
drivers: pwm: mcux_ftm: allow to select clock source

### DIFF
--- a/boards/nxp/frdm_k22f/frdm_k22f.dts
+++ b/boards/nxp/frdm_k22f/frdm_k22f.dts
@@ -154,6 +154,7 @@ arduino_spi: &spi0 {
 	#pwm-cells = <3>;
 	pinctrl-0 = <&ftm0_default>;
 	pinctrl-names = "default";
+	clock-source = "fixed";
 };
 
 &uart1 {

--- a/boards/nxp/frdm_k64f/frdm_k64f.dts
+++ b/boards/nxp/frdm_k64f/frdm_k64f.dts
@@ -174,6 +174,7 @@ arduino_spi: &spi0 {
 	#pwm-cells = <3>;
 	pinctrl-0 = <&ftm0_default>;
 	pinctrl-names = "default";
+	clock-source = "fixed";
 };
 
 &ftm3 {
@@ -182,6 +183,7 @@ arduino_spi: &spi0 {
 	#pwm-cells = <3>;
 	pinctrl-0 = <&ftm3_default>;
 	pinctrl-names = "default";
+	clock-source = "fixed";
 };
 
 &uart0 {

--- a/boards/nxp/frdm_k82f/frdm_k82f.dts
+++ b/boards/nxp/frdm_k82f/frdm_k82f.dts
@@ -209,6 +209,7 @@
 	#pwm-cells = <3>;
 	pinctrl-0 = <&ftm3_default>;
 	pinctrl-names = "default";
+	clock-source = "fixed";
 };
 
 &spi1 {

--- a/boards/nxp/hexiwear/hexiwear_mk64f12.dts
+++ b/boards/nxp/hexiwear/hexiwear_mk64f12.dts
@@ -106,6 +106,7 @@
 	#pwm-cells = <3>;
 	pinctrl-0 = <&ftm3_default>;
 	pinctrl-names = "default";
+	clock-source = "fixed";
 };
 
 &i2c0 {

--- a/boards/nxp/rddrone_fmuk66/rddrone_fmuk66.dts
+++ b/boards/nxp/rddrone_fmuk66/rddrone_fmuk66.dts
@@ -145,6 +145,7 @@
 	#pwm-cells = <3>;
 	pinctrl-0 = <&ftm0_default>;
 	pinctrl-names = "default";
+	clock-source = "fixed";
 };
 
 
@@ -155,6 +156,7 @@
 	#pwm-cells = <3>;
 	pinctrl-0 = <&ftm3_default>;
 	pinctrl-names = "default";
+	clock-source = "fixed";
 };
 
 /* LPUART connected to debug header */

--- a/boards/nxp/twr_ke18f/twr_ke18f.dts
+++ b/boards/nxp/twr_ke18f/twr_ke18f.dts
@@ -226,6 +226,7 @@
 	#pwm-cells = <3>;
 	pinctrl-0 = <&ftm0_default>;
 	pinctrl-names = "default";
+	clock-source = "fixed";
 };
 
 &ftm3 {
@@ -234,6 +235,7 @@
 	#pwm-cells = <3>;
 	pinctrl-0 = <&ftm3_default>;
 	pinctrl-names = "default";
+	clock-source = "fixed";
 };
 
 &lpi2c0 {

--- a/boards/nxp/ucans32k1sic/ucans32k1sic.dts
+++ b/boards/nxp/ucans32k1sic/ucans32k1sic.dts
@@ -149,7 +149,8 @@
 	compatible = "nxp,kinetis-ftm-pwm";
 	pinctrl-0 = <&ftm0_default>;
 	pinctrl-names = "default";
-	prescaler = <128>;
+	clock-source = "system";
+	prescaler = <4>;
 	#pwm-cells = <3>;
 	status = "okay";
 };
@@ -158,6 +159,8 @@
 	compatible = "nxp,kinetis-ftm-pwm";
 	pinctrl-0 = <&ftm1_default>;
 	pinctrl-names = "default";
+	clock-source = "system";
+	prescaler = <4>;
 	#pwm-cells = <3>;
 	status = "okay";
 };
@@ -166,6 +169,8 @@
 	compatible = "nxp,kinetis-ftm-pwm";
 	pinctrl-0 = <&ftm2_default>;
 	pinctrl-names = "default";
+	clock-source = "system";
+	prescaler = <4>;
 	#pwm-cells = <3>;
 	status = "okay";
 };

--- a/drivers/pwm/pwm_mcux_ftm.c
+++ b/drivers/pwm/pwm_mcux_ftm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NXP
+ * Copyright 2017, 2024 NXP
  * Copyright (c) 2020-2021 Vestas Wind Systems A/S
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -578,7 +578,7 @@ static const struct mcux_ftm_config mcux_ftm_config_##n = { \
 	.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)), \
 	.clock_subsys = (clock_control_subsys_t) \
 		DT_INST_CLOCKS_CELL(n, name), \
-	.ftm_clock_source = kFTM_FixedClock, \
+	.ftm_clock_source = (ftm_clock_source_t)(DT_INST_ENUM_IDX(n, clock_source) + 1U), \
 	.prescale = TO_FTM_PRESCALE_DIVIDE(DT_INST_PROP(n, prescaler)),\
 	.channel_count = FSL_FEATURE_FTM_CHANNEL_COUNTn((FTM_Type *) \
 		DT_INST_REG_ADDR(n)), \

--- a/dts/arm/nxp/nxp_s32k1xx.dtsi
+++ b/dts/arm/nxp/nxp_s32k1xx.dtsi
@@ -243,7 +243,7 @@
 			reg = <0x40038000 0x1000>;
 			interrupts = <99 0>, <100 0>, <101 0>, <102 0>, <104 0>;
 			interrupt-names = "0-1", "2-3", "4-5", "6-7", "overflow";
-			clocks = <&clock NXP_S32_RTC_CLK>;
+			clocks = <&clock NXP_S32_FTM0_CLK>;
 			prescaler = <1>;
 			status = "disabled";
 		};
@@ -253,7 +253,7 @@
 			reg = <0x40039000 0x1000>;
 			interrupts = <105 0>, <106 0>, <107 0>, <108 0>, <110 0>;
 			interrupt-names = "0-1", "2-3", "4-5", "6-7", "overflow";
-			clocks = <&clock NXP_S32_RTC_CLK>;
+			clocks = <&clock NXP_S32_FTM1_CLK>;
 			prescaler = <1>;
 			status = "disabled";
 		};
@@ -263,7 +263,7 @@
 			reg = <0x4003a000 0x1000>;
 			interrupts = <111 0>, <112 0>, <113 0>, <114 0>, <116 0>;
 			interrupt-names = "0-1", "2-3", "4-5", "6-7", "overflow";
-			clocks = <&clock NXP_S32_RTC_CLK>;
+			clocks = <&clock NXP_S32_FTM2_CLK>;
 			prescaler = <1>;
 			status = "disabled";
 		};
@@ -273,7 +273,7 @@
 			reg = <0x40026000 0x1000>;
 			interrupts = <117 0>, <118 0>, <119 0>, <120 0>, <122 0>;
 			interrupt-names = "0-1", "2-3", "4-5", "6-7", "overflow";
-			clocks = <&clock NXP_S32_RTC_CLK>;
+			clocks = <&clock NXP_S32_FTM3_CLK>;
 			prescaler = <1>;
 			status = "disabled";
 		};
@@ -283,7 +283,7 @@
 			reg = <0x4006e000 0x1000>;
 			interrupts = <123 0>, <124 0>, <125 0>, <126 0>, <128 0>;
 			interrupt-names = "0-1", "2-3", "4-5", "6-7", "overflow";
-			clocks = <&clock NXP_S32_RTC_CLK>;
+			clocks = <&clock NXP_S32_FTM4_CLK>;
 			prescaler = <1>;
 			status = "disabled";
 		};
@@ -293,7 +293,7 @@
 			reg = <0x4006f000 0x1000>;
 			interrupts = <129 0>, <130 0>, <131 0>, <132 0>, <134 0>;
 			interrupt-names = "0-1", "2-3", "4-5", "6-7", "overflow";
-			clocks = <&clock NXP_S32_RTC_CLK>;
+			clocks = <&clock NXP_S32_FTM5_CLK>;
 			prescaler = <1>;
 			status = "disabled";
 		};
@@ -303,7 +303,6 @@
 			reg = <0x40070000 0x1000>;
 			interrupts = <135 0>, <136 0>, <137 0>, <138 0>, <140 0>;
 			interrupt-names = "0-1", "2-3", "4-5", "6-7", "overflow";
-			clocks = <&clock NXP_S32_RTC_CLK>;
 			prescaler = <1>;
 			status = "disabled";
 		};
@@ -313,7 +312,6 @@
 			reg = <0x40071000 0x1000>;
 			interrupts = <141 0>, <142 0>, <143 0>, <144 0>, <146 0>;
 			interrupt-names = "0-1", "2-3", "4-5", "6-7", "overflow";
-			clocks = <&clock NXP_S32_RTC_CLK>;
 			prescaler = <1>;
 			status = "disabled";
 		};

--- a/dts/arm/nxp/nxp_s32k1xx.dtsi
+++ b/dts/arm/nxp/nxp_s32k1xx.dtsi
@@ -323,8 +323,8 @@
 			reg = <0x4003d000 0x1000>;
 			interrupts = <46 0>, <47 0>;
 			interrupt-names = "alarm", "seconds";
-			clock-frequency = <32768>;
-			prescaler = <32768>;
+			clock-frequency = <32000>;
+			prescaler = <32000>;
 		};
 	};
 };

--- a/dts/bindings/pwm/nxp,kinetis-ftm-pwm.yaml
+++ b/dts/bindings/pwm/nxp,kinetis-ftm-pwm.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, NXP
+# Copyright 2017, 2024 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 description: Kinetis FTM PWM
@@ -13,6 +13,25 @@ properties:
 
   pinctrl-0:
     required: true
+
+  clock-source:
+    type: string
+    required: true
+    enum:
+      - "system"
+      - "fixed"
+      - "external"
+    description: |
+      Select one of three possible clock sources for the FTM counter:
+        * system: it's the bus interface clock driving the FTM module. Usually
+          provides higher timer resolution than the other two clock sources.
+        * fixed: it's a fixed clock defined by chip integration.
+        * external: it's a clock that can be accessed externally to the chip and
+          passes through a sychronizer clocked by the FTM bus interface clock.
+
+      This clock source selection is independent of the bus interface clock
+      driving the FTM module. Refer to the chip specific documentation for
+      further information.
 
 pwm-cells:
   - channel

--- a/samples/basic/blinky_pwm/boards/ucans32k1sic.overlay
+++ b/samples/basic/blinky_pwm/boards/ucans32k1sic.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&ftm0 {
+	clock-source = "fixed";
+	clocks = <&clock NXP_S32_RTC_CLK>;
+	prescaler = <1>;
+};

--- a/samples/basic/fade_led/boards/ucans32k1sic.overlay
+++ b/samples/basic/fade_led/boards/ucans32k1sic.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&ftm0 {
+	clock-source = "fixed";
+	clocks = <&clock NXP_S32_RTC_CLK>;
+	prescaler = <1>;
+};

--- a/samples/basic/rgb_led/boards/ucans32k1sic.overlay
+++ b/samples/basic/rgb_led/boards/ucans32k1sic.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&ftm0 {
+	clock-source = "fixed";
+	clocks = <&clock NXP_S32_RTC_CLK>;
+	prescaler = <1>;
+};

--- a/samples/drivers/led_pwm/boards/ucans32k1sic.overlay
+++ b/samples/drivers/led_pwm/boards/ucans32k1sic.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&ftm0 {
+	clock-source = "fixed";
+	clocks = <&clock NXP_S32_RTC_CLK>;
+	prescaler = <1>;
+};

--- a/tests/drivers/pwm/pwm_loopback/boards/twr_ke18f.overlay
+++ b/tests/drivers/pwm/pwm_loopback/boards/twr_ke18f.overlay
@@ -46,4 +46,5 @@
 	#pwm-cells = <3>;
 	pinctrl-0 = <&ftm2_default>;
 	pinctrl-names = "default";
+	clock-source = "fixed";
 };

--- a/west.yml
+++ b/west.yml
@@ -193,7 +193,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: f6c7108caf50684742689bfab838048208963f4f
+      revision: cd046faf8a3dc879982ff6079fc48a80a0d53e7c
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Set RTC clock source to the internal 32 KHz LPO. Currently RTC clock is used to source RTC counter and FTM counter.
Fixes #71289

FTM internal counter can be clocked by one of three clock sources independent of the module bus clock. This patch introduces a DT property to perform the clock selection from DT.
DT sources are updated to keep the current clock selection for all boards, with exception of ucans32k1sic board which is migrated to use system by default, as this seems to be a better choice for most cases. Some PWM LED samples require slower clock so overlays are added for those cases.
