### PR TITLE
subsys: net: ip: fix ipv6 ping failed issue

### DIFF
--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -588,7 +588,8 @@ enum net_verdict net_ipv6_input(struct net_pkt *pkt, bool is_loopback)
 
 	if (net_ipv6_is_addr_mcast((struct in6_addr *)hdr->dst) &&
 	    !(net_ipv6_is_addr_mcast_iface((struct in6_addr *)hdr->dst) ||
-	      net_ipv6_is_addr_mcast_link_all_nodes((struct in6_addr *)hdr->dst))) {
+	      net_ipv6_is_addr_mcast_link_all_nodes((struct in6_addr *)hdr->dst)) &&
+	    !(net_ipv6_is_addr_solicited_node((struct in6_addr *)hdr->dst))) {
 		/* If we receive a packet with a interface-local or
 		 * link-local all-nodes multicast destination address we
 		 * always have to pass it to the upper layer.


### PR DESCRIPTION
For ipv6 ping case, the ipv6 input handler drop Neighbor Solicitation pakcet. Fix it by check received ipv6 data is Neighbor Solicitation pakcet or not if data is mcast.