### PR TITLE
tests: actually test NVMe disk access

### DIFF
--- a/tests/drivers/disk/disk_access/src/main.c
+++ b/tests/drivers/disk/disk_access/src/main.c
@@ -24,12 +24,15 @@
 #define DISK_NAME_PHYS CONFIG_SDMMC_VOLUME_NAME
 #elif IS_ENABLED(CONFIG_DISK_DRIVER_MMC)
 #define DISK_NAME_PHYS CONFIG_MMC_VOLUME_NAME
-#elif IS_ENABLED(CONFIG_DISK_DRIVER_RAM)
-#define DISK_NAME_PHYS "RAM"
 #elif IS_ENABLED(CONFIG_DISK_DRIVER_FLASH)
 #define DISK_NAME_PHYS "NAND"
 #elif IS_ENABLED(CONFIG_NVME)
 #define DISK_NAME_PHYS "nvme0n0"
+#elif IS_ENABLED(CONFIG_DISK_DRIVER_RAM)
+/* Since ramdisk is enabled by default on e.g. qemu boards, it needs to be checked last to not
+ * override other backends.
+ */
+#define DISK_NAME_PHYS "RAM"
 #else
 #error "No disk device defined, is your board supported?"
 #endif


### PR DESCRIPTION
RAM disk access is always enabled on `qemu_x86_64`, so checking for it first means that NVMe is never selected.