### PR TITLE
west.yaml: hal_stm32: STM32Cube packages update

### DIFF
--- a/drivers/counter/counter_ll_stm32_timer.c
+++ b/drivers/counter/counter_ll_stm32_timer.c
@@ -42,8 +42,7 @@ static void(*const set_timer_compare[TIMER_MAX_CH])(TIM_TypeDef *,
 };
 
 /** Channel to compare get function mapping. */
-#if !defined(CONFIG_SOC_SERIES_STM32F4X) && \
-	!defined(CONFIG_SOC_SERIES_STM32G4X) && \
+#if !defined(CONFIG_SOC_SERIES_STM32G4X) && \
 	!defined(CONFIG_SOC_SERIES_STM32MP1X)
 static uint32_t(*const get_timer_compare[TIMER_MAX_CH])(const TIM_TypeDef *) = {
 	LL_TIM_OC_GetCompareCH1, LL_TIM_OC_GetCompareCH2,
@@ -69,8 +68,7 @@ static void(*const disable_it[TIMER_MAX_CH])(TIM_TypeDef *) = {
 
 #ifdef CONFIG_ASSERT
 /** Channel to interrupt enable check function mapping. */
-#if !defined(CONFIG_SOC_SERIES_STM32F4X) && \
-	!defined(CONFIG_SOC_SERIES_STM32G4X) && \
+#if !defined(CONFIG_SOC_SERIES_STM32G4X) && \
 	!defined(CONFIG_SOC_SERIES_STM32MP1X)
 static uint32_t(*const check_it_enabled[TIMER_MAX_CH])(const TIM_TypeDef *) = {
 	LL_TIM_IsEnabledIT_CC1, LL_TIM_IsEnabledIT_CC2,

--- a/drivers/counter/counter_ll_stm32_timer.c
+++ b/drivers/counter/counter_ll_stm32_timer.c
@@ -42,8 +42,7 @@ static void(*const set_timer_compare[TIMER_MAX_CH])(TIM_TypeDef *,
 };
 
 /** Channel to compare get function mapping. */
-#if !defined(CONFIG_SOC_SERIES_STM32G4X) && \
-	!defined(CONFIG_SOC_SERIES_STM32MP1X)
+#if !defined(CONFIG_SOC_SERIES_STM32MP1X)
 static uint32_t(*const get_timer_compare[TIMER_MAX_CH])(const TIM_TypeDef *) = {
 	LL_TIM_OC_GetCompareCH1, LL_TIM_OC_GetCompareCH2,
 	LL_TIM_OC_GetCompareCH3, LL_TIM_OC_GetCompareCH4,
@@ -68,8 +67,7 @@ static void(*const disable_it[TIMER_MAX_CH])(TIM_TypeDef *) = {
 
 #ifdef CONFIG_ASSERT
 /** Channel to interrupt enable check function mapping. */
-#if !defined(CONFIG_SOC_SERIES_STM32G4X) && \
-	!defined(CONFIG_SOC_SERIES_STM32MP1X)
+#if !defined(CONFIG_SOC_SERIES_STM32MP1X)
 static uint32_t(*const check_it_enabled[TIMER_MAX_CH])(const TIM_TypeDef *) = {
 	LL_TIM_IsEnabledIT_CC1, LL_TIM_IsEnabledIT_CC2,
 	LL_TIM_IsEnabledIT_CC3, LL_TIM_IsEnabledIT_CC4,

--- a/drivers/dma/dma_stm32.h
+++ b/drivers/dma/dma_stm32.h
@@ -52,7 +52,11 @@ uint32_t dma_stm32_slot_to_channel(uint32_t id);
 #endif
 
 typedef void (*dma_stm32_clear_flag_func)(DMA_TypeDef *DMAx);
+#if !defined(CONFIG_SOC_SERIES_STM32G0X)
 typedef uint32_t (*dma_stm32_check_flag_func)(DMA_TypeDef *DMAx);
+#else
+typedef uint32_t (*dma_stm32_check_flag_func)(const DMA_TypeDef *DMAx);
+#endif
 
 bool dma_stm32_is_tc_active(DMA_TypeDef *DMAx, uint32_t id);
 void dma_stm32_clear_tc(DMA_TypeDef *DMAx, uint32_t id);

--- a/drivers/dma/dmamux_stm32.c
+++ b/drivers/dma/dmamux_stm32.c
@@ -70,19 +70,24 @@ uint32_t table_ll_channel[] = {
 	LISTIFY(DT_INST_PROP(0, dma_channels), DMAMUX_CHANNEL, (,))
 };
 
-uint32_t (*func_ll_is_active_so[])(DMAMUX_Channel_TypeDef *DMAMUXx) = {
+#if !defined(CONFIG_SOC_SERIES_STM32G0X)
+#define dmamux_channel_typedef DMAMUX_Channel_TypeDef
+#else
+#define dmamux_channel_typedef const DMAMUX_Channel_TypeDef
+#endif
+uint32_t (*func_ll_is_active_so[])(dmamux_channel_typedef * DMAMUXx) = {
 	LISTIFY(DT_INST_PROP(0, dma_channels), IS_ACTIVE_FLAG_SOX, (,))
 };
 
-void (*func_ll_clear_so[])(DMAMUX_Channel_TypeDef *DMAMUXx) = {
+void (*func_ll_clear_so[])(dmamux_channel_typedef * DMAMUXx) = {
 	LISTIFY(DT_INST_PROP(0, dma_channels), CLEAR_FLAG_SOX, (,))
 };
 
-uint32_t (*func_ll_is_active_rgo[])(DMAMUX_Channel_TypeDef *DMAMUXx) = {
+uint32_t (*func_ll_is_active_rgo[])(dmamux_channel_typedef * DMAMUXx) = {
 	LISTIFY(DT_INST_PROP(0, dma_generators), IS_ACTIVE_FLAG_RGOX, (,))
 };
 
-void (*func_ll_clear_rgo[])(DMAMUX_Channel_TypeDef *DMAMUXx) = {
+void (*func_ll_clear_rgo[])(dmamux_channel_typedef * DMAMUXx) = {
 	LISTIFY(DT_INST_PROP(0, dma_generators), CLEAR_FLAG_RGOX, (,))
 };
 

--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -141,8 +141,7 @@ static void (*const set_timer_compare[TIMER_MAX_CH])(TIM_TypeDef *,
 };
 
 /** Channel to capture get function mapping. */
-#if !defined(CONFIG_SOC_SERIES_STM32F4X) && \
-	!defined(CONFIG_SOC_SERIES_STM32G4X) && \
+#if !defined(CONFIG_SOC_SERIES_STM32G4X) && \
 	!defined(CONFIG_SOC_SERIES_STM32MP1X)
 static uint32_t __maybe_unused (*const get_channel_capture[])(const TIM_TypeDef *) = {
 #else
@@ -166,8 +165,7 @@ static void __maybe_unused (*const disable_capture_interrupt[])(TIM_TypeDef *) =
 };
 
 /** Channel to is capture active flag mapping. */
-#if !defined(CONFIG_SOC_SERIES_STM32F4X) && \
-	!defined(CONFIG_SOC_SERIES_STM32G4X) && \
+#if !defined(CONFIG_SOC_SERIES_STM32G4X) && \
 	!defined(CONFIG_SOC_SERIES_STM32MP1X)
 static uint32_t __maybe_unused (*const is_capture_active[])(const TIM_TypeDef *) = {
 #else

--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -141,8 +141,7 @@ static void (*const set_timer_compare[TIMER_MAX_CH])(TIM_TypeDef *,
 };
 
 /** Channel to capture get function mapping. */
-#if !defined(CONFIG_SOC_SERIES_STM32G4X) && \
-	!defined(CONFIG_SOC_SERIES_STM32MP1X)
+#if !defined(CONFIG_SOC_SERIES_STM32MP1X)
 static uint32_t __maybe_unused (*const get_channel_capture[])(const TIM_TypeDef *) = {
 #else
 static uint32_t __maybe_unused (*const get_channel_capture[])(TIM_TypeDef *) = {
@@ -165,8 +164,7 @@ static void __maybe_unused (*const disable_capture_interrupt[])(TIM_TypeDef *) =
 };
 
 /** Channel to is capture active flag mapping. */
-#if !defined(CONFIG_SOC_SERIES_STM32G4X) && \
-	!defined(CONFIG_SOC_SERIES_STM32MP1X)
+#if !defined(CONFIG_SOC_SERIES_STM32MP1X)
 static uint32_t __maybe_unused (*const is_capture_active[])(const TIM_TypeDef *) = {
 #else
 static uint32_t __maybe_unused (*const is_capture_active[])(TIM_TypeDef *) = {

--- a/west.yml
+++ b/west.yml
@@ -229,7 +229,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 60c9634f61c697e1c310ec648d33529712806069
+      revision: ed93098718d5c727d2fac5ef27023a2a14763e32
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
update stm32u5 to cube version V1.5.0
update stm32wb to cube version V1.19.0
update stm32f4 to cube version V1.28.0
update stm32g0 to cube version V1.6.2
update stm32h5 to cube version V1.2.0
update stm32l5 to cube version V1.5.1
update stm32g4 to cube version V1.5.2
update stm32h7 to cube version V1.11.2

Update of lib/stm32/stm32wb package to version V1.19.0

Removed:
update stm32wba to cube version V1.3.1
Update of lib/stm32/stm32wba package to version V1.3.1
