### PR TITLE
samples: net: Disable native_posix target in more samples

### DIFF
--- a/samples/net/sockets/can/sample.yaml
+++ b/samples/net/sockets/can/sample.yaml
@@ -8,6 +8,10 @@ common:
   filter: dt_chosen_enabled("zephyr,canbus") and not dt_compat_enabled("kvaser,pcican")
   depends_on: can
   harness: console
+  # native_posix does not work with CONFIG_POSIX_API
+  platform_exclude:
+    - native_posix
+    - native_posix/native/64
 tests:
   sample.net.sockets.can.one_socket:
     extra_configs:

--- a/samples/net/sockets/dumb_http_server_mt/sample.yaml
+++ b/samples/net/sockets/dumb_http_server_mt/sample.yaml
@@ -9,6 +9,10 @@ common:
     - net
     - socket
     - http
+  # native_posix does not work with CONFIG_POSIX_API
+  platform_exclude:
+    - native_posix
+    - native_posix/native/64
 tests:
   sample.net.sockets.dumb_http_server_mt:
     extra_configs:

--- a/samples/net/sockets/http_client/sample.yaml
+++ b/samples/net/sockets/http_client/sample.yaml
@@ -5,6 +5,10 @@ common:
     - http_client
   min_ram: 32
   depends_on: netif
+  # native_posix does not work with CONFIG_POSIX_API
+  platform_exclude:
+    - native_posix
+    - native_posix/native/64
 sample:
   description: HTTP client sample
   name: http_client

--- a/samples/net/sockets/packet/sample.yaml
+++ b/samples/net/sockets/packet/sample.yaml
@@ -5,8 +5,6 @@ tests:
   sample.net.sockets.packet:
     harness: net
     platform_allow:
-      - native_posix
-      - native_posix/native/64
       - native_sim
       - native_sim/native/64
     integration_platforms:

--- a/samples/net/sockets/txtime/sample.yaml
+++ b/samples/net/sockets/txtime/sample.yaml
@@ -3,8 +3,6 @@ common:
   depends_on: netif
   # We can only run this in platforms that support PTP clock and TXTIME
   platform_allow:
-    - native_posix
-    - native_posix/native/64
     - native_sim
     - native_sim/native/64
     - qemu_x86

--- a/samples/net/sockets/websocket_client/sample.yaml
+++ b/samples/net/sockets/websocket_client/sample.yaml
@@ -7,6 +7,10 @@ common:
     - websocket
   min_ram: 35
   depends_on: netif
+  # native_posix does not work with CONFIG_POSIX_API
+  platform_exclude:
+    - native_posix
+    - native_posix/native/64
 sample:
   description: Websocket client sample
   name: websocket_client


### PR DESCRIPTION
The native_posix compilations fail with various socket errors like this:

samples/net/sockets/can/src/main.c:65:9: error: implicit \
     declaration of function ‘send’ [-Werror=implicit-function-declaration]
     65 |   ret = send(fd, &sframe, sizeof(sframe), 0);
        |         ^~~~

So disable the native_posix board from networking samples as native_posix board is not compatible with CONFIG_POSIX_API

This is related to commit b8fc1c4c3e ("samples: net: Disable native_posix target in samples") but disables more network samples for native_posix board.