### PR TITLE
board: cy8cproto_062_4343w: Enable HW Flow control for HCI H4

### DIFF
--- a/boards/cypress/cy8cproto_062_4343w/cy8cproto_062_4343w.dts
+++ b/boards/cypress/cy8cproto_062_4343w/cy8cproto_062_4343w.dts
@@ -45,15 +45,18 @@ uart5: &scb5 {
 uart2: &scb2 {
 	compatible = "infineon,cat1-uart";
 	status = "okay";
+
 	/* The UART bus speed (current_speed) for zephyr_bt_uart should be the same
 	 * as the default baudrate defined in CYW43xx firmware (default 115200).
 	 */
-
 	current-speed = <115200>;
 
 	/* HCI-UART pins */
 	pinctrl-0 = <&p3_1_scb2_uart_tx &p3_0_scb2_uart_rx &p3_2_scb2_uart_rts &p3_3_scb2_uart_cts>;
 	pinctrl-names = "default";
+
+	/* HW Flow control must be enabled for HCI H4 */
+	hw-flow-control;
 
 	bt-hci {
 		status = "okay";

--- a/drivers/bluetooth/hci/cyw43xxx.c
+++ b/drivers/bluetooth/hci/cyw43xxx.c
@@ -26,6 +26,9 @@ LOG_MODULE_REGISTER(cyw43xxx_driver);
 
 #include <stdint.h>
 
+BUILD_ASSERT(DT_PROP(DT_CHOSEN(zephyr_bt_uart), hw_flow_control) == 1,
+		"hw_flow_control must be enabled for HCI H4 UART");
+
 #define DT_DRV_COMPAT infineon_cyw43xxx_bt_hci
 
 /* BT settling time after power on */

--- a/dts/bindings/bluetooth/infineon,cyw43xxx-bt-hci.yaml
+++ b/dts/bindings/bluetooth/infineon,cyw43xxx-bt-hci.yaml
@@ -18,6 +18,9 @@ description: |
                      &p3_2_scb2_uart_rts &p3_3_scb2_uart_cts>;
         pinctrl-names = "default";
 
+        /* HW Flow control must be enabled for HCI H4 */
+        hw-flow-control;
+
         bt-hci {
           status = "okay";
           compatible = "infineon,cyw43xxx-bt-hci";


### PR DESCRIPTION
HW Flow control must be enabled for HCI H4 UART communication.

Signed-off-by: Nazar Palamar <nazar.palamar@infineon.com>
