### PR TITLE
modem_chat: reset chat parser before script is started

### DIFF
--- a/subsys/modem/modem_chat.c
+++ b/subsys/modem/modem_chat.c
@@ -774,6 +774,7 @@ int modem_chat_run_script_async(struct modem_chat *chat, const struct modem_chat
 		return -EBUSY;
 	}
 
+	modem_chat_parse_reset(chat);
 	chat->pending_script = script;
 	k_work_submit(&chat->script_run_work);
 	return 0;


### PR DESCRIPTION
I have been having some issues with the chat script parser retaining old state when the various chat script objects are being reused. Resetting the parser before running the script solves all of these issues. 

In terms of general argument safety and code hygiene, I think this change makes sense on its own anyway.