### PR TITLE
drivers: cache: nrf: Fixes and optimization in the driver

### DIFF
--- a/drivers/cache/Kconfig.nrf
+++ b/drivers/cache/Kconfig.nrf
@@ -7,3 +7,9 @@ config CACHE_NRF_CACHE
 	depends on HAS_NRFX && CACHE_MANAGEMENT
 	help
 	  Enable support for the nRF cache driver.
+
+config CACHE_NRF_PATCH_LINEADDR
+	bool "Patch lineaddr"
+	default y if SOC_NRF54H20
+	help
+	  Manually set 28th bit in the LINEADDR in Trustzone Secure build.

--- a/drivers/cache/cache_nrf.c
+++ b/drivers/cache/cache_nrf.c
@@ -144,7 +144,17 @@ static inline int _cache_range(NRF_CACHE_Type *cache, enum k_nrf_cache_op op, vo
 			       size_t size)
 {
 	uintptr_t line_addr = (uintptr_t)addr;
-	uintptr_t end_addr = line_addr + size;
+	uintptr_t end_addr;
+
+	/* Some SOCs has a bug that requires to set 28th bit in the address on
+	 * Trustzone secure builds.
+	 */
+	if (IS_ENABLED(CONFIG_CACHE_NRF_PATCH_LINEADDR) &&
+	    !IS_ENABLED(CONFIG_TRUSTED_EXECUTION_NONSECURE)) {
+		line_addr |= BIT(28);
+	}
+
+	end_addr = line_addr + size;
 
 	/*
 	 * Align address to line size

--- a/drivers/cache/cache_nrf.c
+++ b/drivers/cache/cache_nrf.c
@@ -68,14 +68,6 @@ static inline int _cache_all(NRF_CACHE_Type *cache, enum k_nrf_cache_op op)
 		return -ENOTSUP;
 	}
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
-
-	/*
-	 * Invalidating the whole cache is dangerous. For good measure
-	 * disable the cache.
-	 */
-	nrf_cache_disable(cache);
-
 	wait_for_cache(cache);
 
 	switch (op) {
@@ -101,10 +93,6 @@ static inline int _cache_all(NRF_CACHE_Type *cache, enum k_nrf_cache_op op)
 	}
 
 	wait_for_cache(cache);
-
-	nrf_cache_enable(cache);
-
-	k_spin_unlock(&lock, key);
 
 	return 0;
 }
@@ -202,11 +190,6 @@ void cache_data_enable(void)
 	nrf_cache_enable(NRF_DCACHE);
 }
 
-void cache_data_disable(void)
-{
-	nrf_cache_disable(NRF_DCACHE);
-}
-
 int cache_data_flush_all(void)
 {
 #if NRF_CACHE_HAS_TASK_CLEAN
@@ -214,6 +197,14 @@ int cache_data_flush_all(void)
 #else
 	return -ENOTSUP;
 #endif
+}
+
+void cache_data_disable(void)
+{
+	if (nrf_cache_enable_check(NRF_DCACHE)) {
+		(void)cache_data_flush_all();
+	}
+	nrf_cache_disable(NRF_DCACHE);
 }
 
 int cache_data_invd_all(void)

--- a/drivers/cache/cache_nrf.c
+++ b/drivers/cache/cache_nrf.c
@@ -14,7 +14,6 @@ LOG_MODULE_REGISTER(cache_nrfx, CONFIG_CACHE_LOG_LEVEL);
 #define NRF_ICACHE NRF_CACHE
 #endif
 
-#define CACHE_LINE_SIZE		     32
 #define CACHE_BUSY_RETRY_INTERVAL_US 10
 
 
@@ -145,11 +144,11 @@ static inline int _cache_range(NRF_CACHE_Type *cache, enum k_nrf_cache_op op, vo
 	/*
 	 * Align address to line size
 	 */
-	line_addr &= ~(CACHE_LINE_SIZE - 1);
+	line_addr &= ~(CONFIG_DCACHE_LINE_SIZE - 1);
 
 	do {
 		_cache_line(cache, op, line_addr);
-		line_addr += CACHE_LINE_SIZE;
+		line_addr += CONFIG_DCACHE_LINE_SIZE;
 	} while (line_addr < end_addr);
 
 	wait_for_cache(cache);

--- a/west.yml
+++ b/west.yml
@@ -183,7 +183,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 827224f29e99972cd3b999dba913ae4649790671
+      revision: bdef8b66d5f59d95c09889918a04ddaecce322c8
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
Fixes:
- Hanging when performing full cache operations
- Lack of data cache flush before disabling

Optimization:
- Remove busy wait from status polling
- Remove spin lock from line operations. Using LINEADDR readout to detect preemption

Additionally, use Kconfig DCACHE line size instead of fixed value in the driver.