### PR TITLE
boards: nordic: nRF54h20: Change default IPC Service backend

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-ipc_conf.dtsi
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-ipc_conf.dtsi
@@ -21,6 +21,7 @@
 		};
 
 		cpuapp_cpurad_ipc: ipc-2-3 {
+			compatible = "zephyr,ipc-icbmsg";
 			status = "disabled";
 			mboxes = <&cpuapp_bellboard 18>,
 				 <&cpurad_bellboard 12>;

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
@@ -110,10 +110,11 @@
 };
 
 &cpuapp_cpurad_ipc {
-	compatible = "zephyr,ipc-icmsg-me-initiator";
 	mbox-names = "rx", "tx";
 	tx-region = <&cpuapp_cpurad_ipc_shm>;
 	rx-region = <&cpurad_cpuapp_ipc_shm>;
+	tx-blocks = <32>;
+	rx-blocks = <32>;
 };
 
 &cpuapp_cpuppr_ipc {

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
@@ -44,10 +44,11 @@
 };
 
 &cpuapp_cpurad_ipc {
-	compatible = "zephyr,ipc-icmsg-me-follower";
 	mbox-names = "tx", "rx";
 	tx-region = <&cpurad_cpuapp_ipc_shm>;
 	rx-region = <&cpuapp_cpurad_ipc_shm>;
+	tx-blocks = <32>;
+	rx-blocks = <32>;
 };
 
 &cpurad_dma_region {

--- a/subsys/ipc/ipc_service/backends/ipc_icbmsg.c
+++ b/subsys/ipc/ipc_service/backends/ipc_icbmsg.c
@@ -75,6 +75,9 @@
  * data messages, it calls bound endpoint and it is ready to send data.
  */
 
+#undef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L /* For strnlen() */
+
 #include <string.h>
 
 #include <zephyr/logging/log.h>


### PR DESCRIPTION
This PR change default IPC Service backend for nRF54h20 Application and Radio core to icbmsg which is more future proof than legacy icmsg_me backend. The PR contains also fix for strnlen warnings