### PR TITLE
kconfig: Enable CODING_GUIDELINE_CHECK by default

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -340,6 +340,7 @@ menu "Compiler Options"
 
 config CODING_GUIDELINE_CHECK
 	bool "Enforce coding guideline rules"
+	default y
 	help
 	  Use available compiler flags to check coding guideline rules during
 	  the build.


### PR DESCRIPTION
Enforce more compiler options by default.

Reading the comments, it appears that there are compiler options to verify coding guidelines, but not enforced. 
For example, `gcc`:
```
-Werror=vla
-Wimplicit-fallthrough=2
-Wconversion
-Woverride-init
```

Is it still the intention to force these, as the current codebase does not comply?