### PR TITLE
Devicetree: Devicetree Bindings: Support enums for array like dt props

### DIFF
--- a/dts/bindings/test/vnd,enum-int-array-holder.yaml
+++ b/dts/bindings/test/vnd,enum-int-array-holder.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2020 Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+description: Test enum property container
+
+compatible: "vnd,enum-int-array-holder"
+
+include: [base.yaml]
+
+properties:
+  val:
+    type: array
+    enum:
+      - 7
+      - 6
+      - 5
+      - 4
+      - 3
+      - 2
+      - 1
+      - 0

--- a/dts/bindings/test/vnd,enum-string-array-holder.yaml
+++ b/dts/bindings/test/vnd,enum-string-array-holder.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2020 Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+description: Test enum property container
+
+compatible: "vnd,enum-string-array-holder"
+
+include: [base.yaml]
+
+properties:
+  val:
+    type: string-array
+    enum:
+      - foo
+      - bar
+      - baz
+      - zoo

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -29,7 +29,7 @@
  * @brief devicetree.h API
  * @defgroup devicetree Devicetree
  * @since 2.2
- * @version 1.1.0
+ * @version 1.2.0
  * @{
  * @}
  */
@@ -827,55 +827,92 @@
 		    (DT_PROP(node_id, prop)), (default_value))
 
 /**
- * @brief Get a property value's index into its enumeration values
+ * @brief Get a property array value's index into its enumeration values
  *
  * The return values start at zero.
  *
  * Example devicetree fragment:
  *
  * @code{.dts}
- *     usb1: usb@12340000 {
- *             maximum-speed = "full-speed";
- *     };
- *     usb2: usb@12341000 {
- *             maximum-speed = "super-speed";
+ *     some_node: some-node {
+ *         compat = "vend,enum-string-array";
+ *         foos =
+ *             <&phandle val1>,
+ *             <&phandle val2>,
+ *             <&phandle val3>;
+ *         foo-names = "default", "option3", "option1";
  *     };
  * @endcode
  *
  * Example bindings fragment:
  *
  * @code{.yaml}
- *     properties:
- *       maximum-speed:
- *         type: string
- *         enum:
- *            - "low-speed"
- *            - "full-speed"
- *            - "high-speed"
- *            - "super-speed"
+ * compatible: vend,enum-string-array
+ * properties:
+ *   foos:
+ *     type: phandle-array
+ *     description: |
+ *       Explanation about what this phandle-array exactly is for.
+ *
+ *   foo-names:
+ *     type: string-array
+ *     description: |
+ *       Some explanation about the available options
+ *       default: explain default
+ *       option1: explain option1
+ *       option2: explain option2
+ *       option3: explain option3
+ *     enum:
+ *       - default
+ *       - option1
+ *       - option2
+ *       - option3
  * @endcode
  *
  * Example usage:
  *
  * @code{.c}
- *     DT_ENUM_IDX(DT_NODELABEL(usb1), maximum_speed) // 1
- *     DT_ENUM_IDX(DT_NODELABEL(usb2), maximum_speed) // 3
+ *     DT_ENUM_IDX_BY_IDX(DT_NODELABEL(some_node), foo_names, 0) // 0
+ *     DT_ENUM_IDX_BY_IDX(DT_NODELABEL(some_node), foo_names, 2) // 1
  * @endcode
  *
  * @param node_id node identifier
  * @param prop lowercase-and-underscores property name
+ * @param idx the index to get
  * @return zero-based index of the property's value in its enum: list
  */
-#define DT_ENUM_IDX(node_id, prop) DT_CAT4(node_id, _P_, prop, _ENUM_IDX)
+#define DT_ENUM_IDX_BY_IDX(node_id, prop, idx) \
+	DT_CAT6(node_id, _P_, prop, _IDX_, idx, _ENUM_IDX)
 
 /**
- * @brief Like DT_ENUM_IDX(), but with a fallback to a default enum index
+ * @brief Equivalent to @ref DT_ENUM_IDX_BY_IDX(node_id, prop, 0).
+ * @param node_id node identifier
+ * @param prop lowercase-and-underscores property name
+ * @return zero-based index of the property's value in its enum: list
+ */
+#define DT_ENUM_IDX(node_id, prop) DT_ENUM_IDX_BY_IDX(node_id, prop, 0)
+
+/**
+ * @brief Like DT_ENUM_IDX_BY_IDX(), but with a fallback to a default enum index
  *
  * If the value exists, this expands to its zero based index value thanks to
- * DT_ENUM_IDX(node_id, prop).
+ * DT_ENUM_IDX_BY_IDX(node_id, prop, idx).
  *
  * Otherwise, this expands to provided default index enum value.
  *
+ * @param node_id node identifier
+ * @param prop lowercase-and-underscores property name
+ * @param idx the index to get
+ * @param default_idx_value a fallback index value to expand to
+ * @return zero-based index of the property's value in its enum if present,
+ *         default_idx_value otherwise
+ */
+#define DT_ENUM_IDX_BY_IDX_OR(node_id, prop, idx, default_idx_value) \
+	COND_CODE_1(DT_PROP_HAS_IDX(node_id, prop, idx), \
+		    (DT_ENUM_IDX_BY_IDX(node_id, prop, idx)), (default_idx_value))
+
+/**
+ * @brief Equivalent to DT_ENUM_IDX_BY_IDX_OR(node_id, prop, 0, default_idx_value).
  * @param node_id node identifier
  * @param prop lowercase-and-underscores property name
  * @param default_idx_value a fallback index value to expand to
@@ -883,19 +920,29 @@
  *         default_idx_value otherwise
  */
 #define DT_ENUM_IDX_OR(node_id, prop, default_idx_value) \
-	COND_CODE_1(DT_NODE_HAS_PROP(node_id, prop), \
-		    (DT_ENUM_IDX(node_id, prop)), (default_idx_value))
+	DT_ENUM_IDX_BY_IDX_OR(node_id, prop, 0, default_idx_value)
 
 /**
- * @brief Does a node enumeration property have a given value?
+ * @brief Does a node enumeration property array have a given value?
  *
+ * @param node_id node identifier
+ * @param prop lowercase-and-underscores property name
+ * @param idx the index to get
+ * @param value lowercase-and-underscores enumeration value
+ * @return 1 if the node property has the value @a value, 0 otherwise.
+ */
+#define DT_ENUM_HAS_VALUE_BY_IDX(node_id, prop, idx, value) \
+	IS_ENABLED(DT_CAT8(node_id, _P_, prop, _IDX_, idx, _ENUM_VAL_, value, _EXISTS))
+
+/**
+ * @brief Equivalent to DT_ENUM_HAS_VALUE_BY_IDX(node_id, prop, 0, value).
  * @param node_id node identifier
  * @param prop lowercase-and-underscores property name
  * @param value lowercase-and-underscores enumeration value
  * @return 1 if the node property has the value @a value, 0 otherwise.
  */
 #define DT_ENUM_HAS_VALUE(node_id, prop, value) \
-	IS_ENABLED(DT_CAT6(node_id, _P_, prop, _ENUM_VAL_, value, _EXISTS))
+	DT_ENUM_HAS_VALUE_BY_IDX(node_id, prop, 0, value)
 
 /**
  * @brief Get a string property's value as a token.
@@ -3879,6 +3926,16 @@
 	DT_FOREACH_CHILD_STATUS_OKAY_SEP_VARGS(DT_DRV_INST(inst), fn, sep, __VA_ARGS__)
 
 /**
+ * @brief Get a `DT_DRV_COMPAT` property array value's index into its enumeration values
+ * @param inst instance number
+ * @param prop lowercase-and-underscores property name
+ * @param idx the index to get
+ * @return zero-based index of the property's value in its enum: list
+ */
+#define DT_INST_ENUM_IDX_BY_IDX(inst, prop, idx) \
+	DT_ENUM_IDX_BY_IDX(DT_DRV_INST(inst), prop, idx)
+
+/**
  * @brief Get a `DT_DRV_COMPAT` value's index into its enumeration values
  * @param inst instance number
  * @param prop lowercase-and-underscores property name
@@ -3886,6 +3943,18 @@
  */
 #define DT_INST_ENUM_IDX(inst, prop) \
 	DT_ENUM_IDX(DT_DRV_INST(inst), prop)
+
+/**
+ * @brief Like DT_INST_ENUM_IDX_BY_IDX(), but with a fallback to a default enum index
+ * @param inst instance number
+ * @param prop lowercase-and-underscores property name
+ * @param idx the index to get
+ * @param default_idx_value a fallback index value to expand to
+ * @return zero-based index of the property's value in its enum if present,
+ *         default_idx_value otherwise
+ */
+#define DT_INST_ENUM_IDX_BY_IDX_OR(inst, prop, idx, default_idx_value) \
+	DT_ENUM_IDX_BY_IDX_OR(DT_DRV_INST(inst), prop, idx, default_idx_value)
 
 /**
  * @brief Like DT_INST_ENUM_IDX(), but with a fallback to a default enum index
@@ -3897,6 +3966,17 @@
  */
 #define DT_INST_ENUM_IDX_OR(inst, prop, default_idx_value) \
 	DT_ENUM_IDX_OR(DT_DRV_INST(inst), prop, default_idx_value)
+
+/**
+ * @brief Does a `DT_DRV_COMPAT` enumeration property have a given value by index?
+ * @param inst instance number
+ * @param prop lowercase-and-underscores property name
+ * @param idx the index to get
+ * @param value lowercase-and-underscores enumeration value
+ * @return zero-based index of the property's value in its enum
+ */
+#define DT_INST_ENUM_HAS_VALUE_BY_IDX(inst, prop, idx, value) \
+	DT_ENUM_HAS_VALUE_BY_IDX(DT_DRV_INST(inst), prop, idx, value)
 
 /**
  * @brief Does a `DT_DRV_COMPAT` enumeration property have a given value?

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -582,12 +582,7 @@ def write_vanilla_props(node: edtlib.Node) -> None:
             macro2val[macro] = val
 
         if prop.spec.type == 'string':
-            # DT_N_<node-id>_P_<prop-id>_IDX_<i>_STRING_UNQUOTED
-            macro2val[macro + "_STRING_UNQUOTED"] = escape_unquoted(prop.val)
-            # DT_N_<node-id>_P_<prop-id>_IDX_<i>_STRING_TOKEN
-            macro2val[macro + "_STRING_TOKEN"] = prop.val_as_token
-            # DT_N_<node-id>_P_<prop-id>_IDX_<i>_STRING_UPPER_TOKEN
-            macro2val[macro + "_STRING_UPPER_TOKEN"] = prop.val_as_token.upper()
+            macro2val.update(string_macros(macro, prop.val))
             # DT_N_<node-id>_P_<prop-id>_IDX_0:
             # DT_N_<node-id>_P_<prop-id>_IDX_0_EXISTS:
             # Allows treating the string like a degenerate case of a
@@ -595,45 +590,13 @@ def write_vanilla_props(node: edtlib.Node) -> None:
             macro2val[macro + "_IDX_0"] = quote_str(prop.val)
             macro2val[macro + "_IDX_0_EXISTS"] = 1
 
-        if prop.enum_index is not None:
-            # DT_N_<node-id>_P_<prop-id>_ENUM_IDX
-            macro2val[macro + "_ENUM_IDX"] = prop.enum_index
-            spec = prop.spec
-
-            if spec.enum_tokenizable:
-                as_token = prop.val_as_token
-
-                # DT_N_<node-id>_P_<prop-id>_ENUM_VAL_<val>_EXISTS 1
-                macro2val[macro + f"_ENUM_VAL_{as_token}_EXISTS"] = 1
-                # DT_N_<node-id>_P_<prop-id>_ENUM_TOKEN
-                macro2val[macro + "_ENUM_TOKEN"] = as_token
-
-                if spec.enum_upper_tokenizable:
-                    # DT_N_<node-id>_P_<prop-id>_ENUM_UPPER_TOKEN
-                    macro2val[macro + "_ENUM_UPPER_TOKEN"] = as_token.upper()
-            else:
-                # DT_N_<node-id>_P_<prop-id>_ENUM_VAL_<val>_EXISTS 1
-                macro2val[macro + f"_ENUM_VAL_{prop.val}_EXISTS"] = 1
+        if prop.enum_indices is not None:
+            macro2val.update(enum_macros(prop, macro))
 
         if "phandle" in prop.type:
             macro2val.update(phandle_macros(prop, macro))
         elif "array" in prop.type:
-            for i, subval in enumerate(prop.val):
-                # DT_N_<node-id>_P_<prop-id>_IDX_<i>
-                # DT_N_<node-id>_P_<prop-id>_IDX_<i>_EXISTS
-
-                if isinstance(subval, str):
-                    macro2val[macro + f"_IDX_{i}"] = quote_str(subval)
-                    subval_as_token = edtlib.str_as_token(subval)
-                    # DT_N_<node-id>_P_<prop-id>_IDX_<i>_STRING_UNQUOTED
-                    macro2val[macro + f"_IDX_{i}_STRING_UNQUOTED"] = escape_unquoted(subval)
-                    # DT_N_<node-id>_P_<prop-id>_IDX_<i>_STRING_TOKEN
-                    macro2val[macro + f"_IDX_{i}_STRING_TOKEN"] = subval_as_token
-                    # DT_N_<node-id>_P_<prop-id>_IDX_<i>_STRING_UPPER_TOKEN
-                    macro2val[macro + f"_IDX_{i}_STRING_UPPER_TOKEN"] = subval_as_token.upper()
-                else:
-                    macro2val[macro + f"_IDX_{i}"] = subval
-                macro2val[macro + f"_IDX_{i}_EXISTS"] = 1
+            macro2val.update(array_macros(prop, macro))
 
         plen = prop_len(prop)
         if plen is not None:
@@ -673,6 +636,66 @@ def write_vanilla_props(node: edtlib.Node) -> None:
             out_dt_define(macro, val)
     else:
         out_comment("(No generic property macros)")
+
+
+def string_macros(macro: str, val: str):
+    # Returns a dict of macros for a string 'val'.
+    # The 'macro' argument is the N_<node-id>_P_<prop-id>... part.
+
+    as_token = edtlib.str_as_token(val)
+    return {
+        # DT_N_<node-id>_P_<prop-id>_IDX_<i>_STRING_UNQUOTED
+        f"{macro}_STRING_UNQUOTED": escape_unquoted(val),
+        # DT_N_<node-id>_P_<prop-id>_IDX_<i>_STRING_TOKEN
+        f"{macro}_STRING_TOKEN": as_token,
+        # DT_N_<node-id>_P_<prop-id>_IDX_<i>_STRING_UPPER_TOKEN
+        f"{macro}_STRING_UPPER_TOKEN": as_token.upper()}
+
+
+def enum_macros(prop: edtlib.Property, macro: str):
+    # Returns a dict of macros for property 'prop' with a defined enum in their dt-binding.
+    # The 'macro' argument is the N_<node-id>_P_<prop-id> part.
+
+    spec = prop.spec
+    # DT_N_<node-id>_P_<prop-id>_IDX_<i>_ENUM_IDX
+    ret = {f"{macro}_IDX_{i}_ENUM_IDX": index for i, index in enumerate(prop.enum_indices)}
+    val = prop.val_as_tokens if spec.enum_tokenizable else (prop.val if isinstance(prop.val, list) else [prop.val])
+
+    for i, subval in enumerate(val):
+        # DT_N_<node-id>_P_<prop-id>_IDX_<i>_EXISTS
+        ret[macro + f"_IDX_{i}_EXISTS"] = 1
+        # DT_N_<node-id>_P_<prop-id>_IDX_<i>_ENUM_VAL_<val>_EXISTS 1
+        ret[macro + f"_IDX_{i}_ENUM_VAL_{subval}_EXISTS"] = 1
+        if not spec.enum_tokenizable:
+            continue
+
+        # DT_N_<node-id>_P_<prop-id>_IDX_<i>_ENUM_TOKEN
+        ret[macro + f"_IDX_{i}_ENUM_TOKEN"] = subval
+        if spec.enum_upper_tokenizable:
+            # DT_N_<node-id>_P_<prop-id>_IDX_<i>_ENUM_UPPER_TOKEN
+            ret[macro + f"_IDX_{i}_ENUM_UPPER_TOKEN"] = subval.upper()
+
+    return ret
+
+
+def array_macros(prop: edtlib.Property, macro: str):
+    # Returns a dict of macros for array property 'prop'.
+    # The 'macro' argument is the N_<node-id>_P_<prop-id> part.
+
+    ret = {}
+    for i, subval in enumerate(prop.val):
+        # DT_N_<node-id>_P_<prop-id>_IDX_<i>_EXISTS
+        ret[macro + f"_IDX_{i}_EXISTS"] = 1
+
+        # DT_N_<node-id>_P_<prop-id>_IDX_<i>
+        if isinstance(subval, str):
+            ret[macro + f"_IDX_{i}"] = quote_str(subval)
+            # DT_N_<node-id>_P_<prop-id>_IDX_<i>_STRING_...
+            ret.update(string_macros(macro + f"_IDX_{i}", subval))
+        else:
+            ret[macro + f"_IDX_{i}"] = subval
+
+    return ret
 
 
 def write_dep_info(node: edtlib.Node) -> None:

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -601,10 +601,11 @@ class PropertySpec:
       True if enum is not None and all the values in it are tokenizable;
       False otherwise.
 
-      A property must have string type and an "enum:" in its binding to be
-      tokenizable. Additionally, the "enum:" values must be unique after
-      converting all non-alphanumeric characters to underscores (so "foo bar"
-      and "foo_bar" in the same "enum:" would not be tokenizable).
+      A property must have string or string-array type and an "enum:" in its
+      binding to be tokenizable. Additionally, the "enum:" values must be
+      unique after converting all non-alphanumeric characters to underscores
+      (so "foo bar" and "foo_bar" in the same "enum:" would not be
+      tokenizable).
 
     enum_upper_tokenizable:
       Like 'enum_tokenizable', with the additional restriction that the
@@ -659,7 +660,7 @@ class PropertySpec:
     def enum_tokenizable(self) -> bool:
         "See the class docstring"
         if not hasattr(self, '_enum_tokenizable'):
-            if self.type != 'string' or self.enum is None:
+            if self.type not in {'string', 'string-array'} or self.enum is None:
                 self._enum_tokenizable = False
             else:
                 # Saving _as_tokens here lets us reuse it in
@@ -764,14 +765,14 @@ class Property:
     type:
       Convenience for spec.type.
 
-    val_as_token:
-      The value of the property as a token, i.e. with non-alphanumeric
+    val_as_tokens:
+      The value of the property as a list of tokens, i.e. with non-alphanumeric
       characters replaced with underscores. This is only safe to access
       if 'spec.enum_tokenizable' returns True.
 
-    enum_index:
-      The index of 'val' in 'spec.enum' (which comes from the 'enum:' list
-      in the binding), or None if spec.enum is None.
+    enum_indices:
+      A list of indices of 'val' in 'spec.enum' (which comes from the 'enum:'
+      list in the binding), or None if spec.enum is None.
     """
 
     spec: PropertySpec
@@ -794,16 +795,20 @@ class Property:
         return self.spec.type
 
     @property
-    def val_as_token(self) -> str:
+    def val_as_tokens(self) -> List[str]:
         "See the class docstring"
-        assert isinstance(self.val, str)
-        return str_as_token(self.val)
+        ret = []
+        for subval in self.val if isinstance(self.val, list) else [self.val]:
+            assert isinstance(subval, str)
+            ret.append(str_as_token(subval))
+        return ret
 
     @property
-    def enum_index(self) -> Optional[int]:
+    def enum_indices(self) -> Optional[List[int]]:
         "See the class docstring"
         enum = self.spec.enum
-        return enum.index(self.val) if enum else None
+        val = self.val if isinstance(self.val, list) else [self.val]
+        return [enum.index(subval) for subval in val] if enum else None
 
 
 @dataclass
@@ -1519,10 +1524,11 @@ class Node:
             return
 
         enum = prop_spec.enum
-        if enum and val not in enum:
-            _err(f"value of property '{name}' on {self.path} in "
-                 f"{self.edt.dts_path} ({val!r}) is not in 'enum' list in "
-                 f"{self.binding_path} ({enum!r})")
+        for subval in val if isinstance(val, list) else [val]:
+            if enum and subval not in enum:
+                _err(f"value of property '{name}' on {self.path} in "
+                    f"{self.edt.dts_path} ({subval!r}) is not in 'enum' list in "
+                    f"{self.binding_path} ({enum!r})")
 
         const = prop_spec.const
         if const is not None and val != const:

--- a/scripts/dts/python-devicetree/tests/test-bindings/enums.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings/enums.yaml
@@ -32,5 +32,20 @@ properties:
       - whitespace is ok
       - 123 is ok
 
+  array-enum:
+    type: array
+    enum:
+      - 0
+      - 10
+      - 20
+      - 30
+      - 40
+
+  string-array-enum:            # tokenizable string-array
+    type: string-array
+    enum:
+      - bar
+      - foo
+
   no-enum:
     type: string

--- a/scripts/dts/python-devicetree/tests/test.dts
+++ b/scripts/dts/python-devicetree/tests/test.dts
@@ -432,6 +432,8 @@
 		string-enum = "foo_bar";
 		tokenizable-enum = "123 is ok";
 		tokenizable-lower-enum = "bar";
+		array-enum = <0 40 40 10>;
+		string-array-enum = "foo", "bar";
 		no-enum = "baz";
 	};
 

--- a/scripts/dts/python-devicetree/tests/test_edtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib.py
@@ -572,31 +572,44 @@ def test_prop_enums():
     string_enum = props['string-enum']
     tokenizable_enum = props['tokenizable-enum']
     tokenizable_lower_enum = props['tokenizable-lower-enum']
+    array_enum = props['array-enum']
+    string_array_enum = props['string-array-enum']
     no_enum = props['no-enum']
 
     assert int_enum.val == 1
-    assert int_enum.enum_index == 0
+    assert int_enum.enum_indices[0] == 0
     assert not int_enum.spec.enum_tokenizable
     assert not int_enum.spec.enum_upper_tokenizable
 
     assert string_enum.val == 'foo_bar'
-    assert string_enum.enum_index == 1
+    assert string_enum.enum_indices[0] == 1
     assert not string_enum.spec.enum_tokenizable
     assert not string_enum.spec.enum_upper_tokenizable
 
     assert tokenizable_enum.val == '123 is ok'
-    assert tokenizable_enum.val_as_token == '123_is_ok'
-    assert tokenizable_enum.enum_index == 2
+    assert tokenizable_enum.val_as_tokens[0] == '123_is_ok'
+    assert tokenizable_enum.enum_indices[0] == 2
     assert tokenizable_enum.spec.enum_tokenizable
     assert tokenizable_enum.spec.enum_upper_tokenizable
 
     assert tokenizable_lower_enum.val == 'bar'
-    assert tokenizable_lower_enum.val_as_token == 'bar'
-    assert tokenizable_lower_enum.enum_index == 0
+    assert tokenizable_lower_enum.val_as_tokens[0] == 'bar'
+    assert tokenizable_lower_enum.enum_indices[0] == 0
     assert tokenizable_lower_enum.spec.enum_tokenizable
     assert not tokenizable_lower_enum.spec.enum_upper_tokenizable
 
-    assert no_enum.enum_index is None
+    assert array_enum.val == [0, 40, 40, 10]
+    assert array_enum.enum_indices == [0, 4, 4, 1]
+    assert not array_enum.spec.enum_tokenizable
+    assert not array_enum.spec.enum_upper_tokenizable
+
+    assert string_array_enum.val == ["foo", "bar"]
+    assert string_array_enum.val_as_tokens == ["foo", "bar"]
+    assert string_array_enum.enum_indices == [1, 0]
+    assert string_array_enum.spec.enum_tokenizable
+    assert string_array_enum.spec.enum_upper_tokenizable
+
+    assert no_enum.enum_indices is None
     assert not no_enum.spec.enum_tokenizable
     assert not no_enum.spec.enum_upper_tokenizable
 

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -114,6 +114,16 @@
 			compatible = "vnd,enum-required-false-holder-inst";
 		};
 
+		test_enum_string_array: enum-8 {
+			compatible = "vnd,enum-string-array-holder";
+			val = "foo", "zoo", "foo";
+		};
+
+		test_enum_int_array: enum-9 {
+			compatible = "vnd,enum-int-array-holder";
+			val = <4 3 4 0>;
+		};
+
 		/*
 		 * disabled/reserved should be the only nodes with their
 		 * compatible in the tree.

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -2010,6 +2010,41 @@ ZTEST(devicetree_api, test_enums)
 	zassert_true(DT_ENUM_HAS_VALUE(DT_NODELABEL(test_enum_int_default_0), val, 5), "");
 	zassert_false(DT_ENUM_HAS_VALUE(DT_NODELABEL(test_enum_int_default_0), val, 6), "");
 	zassert_false(DT_ENUM_HAS_VALUE(DT_NODELABEL(test_enum_int_default_0), val, 7), "");
+
+	/* DT_ENUM_IDX_BY_IDX and DT_ENUM_HAS_VALUE_BY_IDX on string-array enum */
+	zassert_equal(DT_ENUM_IDX_BY_IDX(DT_NODELABEL(test_enum_string_array), val, 0), 0);
+	zassert_equal(DT_ENUM_IDX_BY_IDX(DT_NODELABEL(test_enum_string_array), val, 1), 3);
+	zassert_equal(DT_ENUM_IDX_BY_IDX(DT_NODELABEL(test_enum_string_array), val, 2), 0);
+	zassert_true(DT_ENUM_HAS_VALUE_BY_IDX(DT_NODELABEL(test_enum_string_array), val, 0, foo));
+	zassert_false(DT_ENUM_HAS_VALUE_BY_IDX(DT_NODELABEL(test_enum_string_array), val, 0, bar));
+	zassert_false(DT_ENUM_HAS_VALUE_BY_IDX(DT_NODELABEL(test_enum_string_array), val, 0, baz));
+	zassert_false(DT_ENUM_HAS_VALUE_BY_IDX(DT_NODELABEL(test_enum_string_array), val, 0, zoo));
+	zassert_true(DT_ENUM_HAS_VALUE_BY_IDX(DT_NODELABEL(test_enum_string_array), val, 1, zoo));
+	zassert_false(DT_ENUM_HAS_VALUE_BY_IDX(DT_NODELABEL(test_enum_string_array), val, 1, foo));
+	zassert_false(DT_ENUM_HAS_VALUE_BY_IDX(DT_NODELABEL(test_enum_string_array), val, 1, bar));
+	zassert_false(DT_ENUM_HAS_VALUE_BY_IDX(DT_NODELABEL(test_enum_string_array), val, 1, baz));
+	zassert_true(DT_ENUM_HAS_VALUE_BY_IDX(DT_NODELABEL(test_enum_string_array), val, 2, foo));
+	zassert_false(DT_ENUM_HAS_VALUE_BY_IDX(DT_NODELABEL(test_enum_string_array), val, 2, baz));
+	zassert_false(DT_ENUM_HAS_VALUE_BY_IDX(DT_NODELABEL(test_enum_string_array), val, 2, bar));
+	zassert_false(DT_ENUM_HAS_VALUE_BY_IDX(DT_NODELABEL(test_enum_string_array), val, 2, zoo));
+
+	/* DT_ENUM_IDX_BY_IDX and DT_ENUM_HAS_VALUE_BY_IDX on int-array enum */
+	zassert_equal(DT_ENUM_IDX_BY_IDX(DT_NODELABEL(test_enum_int_array), val, 0), 3);
+	zassert_equal(DT_ENUM_IDX_BY_IDX(DT_NODELABEL(test_enum_int_array), val, 1), 4);
+	zassert_equal(DT_ENUM_IDX_BY_IDX(DT_NODELABEL(test_enum_int_array), val, 2), 3);
+	zassert_equal(DT_ENUM_IDX_BY_IDX(DT_NODELABEL(test_enum_int_array), val, 3), 7);
+	zassert_true(DT_ENUM_HAS_VALUE_BY_IDX(DT_NODELABEL(test_enum_int_array), val, 0, 4));
+	zassert_false(DT_ENUM_HAS_VALUE_BY_IDX(DT_NODELABEL(test_enum_int_array), val, 0, 5));
+	zassert_false(DT_ENUM_HAS_VALUE_BY_IDX(DT_NODELABEL(test_enum_int_array), val, 0, 6));
+	zassert_true(DT_ENUM_HAS_VALUE_BY_IDX(DT_NODELABEL(test_enum_int_array), val, 1, 3));
+	zassert_false(DT_ENUM_HAS_VALUE_BY_IDX(DT_NODELABEL(test_enum_int_array), val, 1, 0));
+	zassert_false(DT_ENUM_HAS_VALUE_BY_IDX(DT_NODELABEL(test_enum_int_array), val, 1, 1));
+	zassert_true(DT_ENUM_HAS_VALUE_BY_IDX(DT_NODELABEL(test_enum_int_array), val, 2, 4));
+	zassert_false(DT_ENUM_HAS_VALUE_BY_IDX(DT_NODELABEL(test_enum_int_array), val, 2, 3));
+	zassert_false(DT_ENUM_HAS_VALUE_BY_IDX(DT_NODELABEL(test_enum_int_array), val, 2, 7));
+	zassert_true(DT_ENUM_HAS_VALUE_BY_IDX(DT_NODELABEL(test_enum_int_array), val, 3, 0));
+	zassert_false(DT_ENUM_HAS_VALUE_BY_IDX(DT_NODELABEL(test_enum_int_array), val, 3, 2));
+	zassert_false(DT_ENUM_HAS_VALUE_BY_IDX(DT_NODELABEL(test_enum_int_array), val, 3, 1));
 }
 #undef TO_MY_ENUM
 #undef TO_MY_ENUM_2
@@ -2028,6 +2063,18 @@ ZTEST(devicetree_api, test_enums_required_false)
 	zassert_equal(DT_ENUM_IDX_OR(DT_NODELABEL(test_enum_int_default_1),
 				     val, 4),
 		      4, "");
+	/* DT_ENUM_IDX_OR on string-array value */
+	zassert_equal(DT_ENUM_IDX_BY_IDX_OR(DT_NODELABEL(test_enum_string_array), val, 0, 2),
+		      0, "");
+	zassert_equal(DT_ENUM_IDX_BY_IDX_OR(DT_NODELABEL(test_enum_string_array), val, 5, 2),
+		      2, "");
+	/* DT_ENUM_IDX_OR on int-array value */
+	zassert_equal(DT_ENUM_IDX_BY_IDX_OR(DT_NODELABEL(test_enum_int_array),
+				     val, 0, 7),
+		      3, "");
+	zassert_equal(DT_ENUM_IDX_BY_IDX_OR(DT_NODELABEL(test_enum_int_array),
+				     val, 4, 7),
+		      7, "");
 }
 
 ZTEST(devicetree_api, test_inst_enums)
@@ -2046,6 +2093,29 @@ ZTEST(devicetree_api, test_inst_enums)
 	zassert_false(DT_INST_ENUM_HAS_VALUE(0, val, zero), "");
 	zassert_false(DT_INST_ENUM_HAS_VALUE(0, val, one), "");
 	zassert_false(DT_INST_ENUM_HAS_VALUE(0, val, two), "");
+
+	/* Also add tests for these:
+	 * DT_INST_ENUM_IDX_BY_IDX
+	 * DT_INST_ENUM_IDX_BY_IDX_OR
+	 * DT_INST_ENUM_HAS_VALUE_BY_IDX
+	 */
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT vnd_enum_string_array_holder
+	zassert_equal(DT_INST_ENUM_IDX_BY_IDX(0, val, 0), 0, "");
+	zassert_equal(DT_INST_ENUM_IDX_BY_IDX(0, val, 1), 3, "");
+	zassert_true(DT_INST_ENUM_HAS_VALUE_BY_IDX(0, val, 0, foo), "");
+	zassert_false(DT_INST_ENUM_HAS_VALUE_BY_IDX(0, val, 0, zoo), "");
+	zassert_true(DT_INST_ENUM_HAS_VALUE_BY_IDX(0, val, 1, zoo), "");
+	zassert_false(DT_INST_ENUM_HAS_VALUE_BY_IDX(0, val, 2, baz), "");
+	zassert_equal(DT_INST_ENUM_IDX_BY_IDX_OR(0, val, 0, 10), 0, "");
+	zassert_equal(DT_INST_ENUM_IDX_BY_IDX_OR(0, val, 4, 10), 10, "");
+
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT vnd_enum_int_array_holder
+	zassert_equal(DT_INST_ENUM_IDX_BY_IDX(0, val, 0), 3, "");
+	zassert_equal(DT_INST_ENUM_IDX_BY_IDX(0, val, 3), 7, "");
+	zassert_equal(DT_INST_ENUM_IDX_BY_IDX_OR(0, val, 1, 10), 4, "");
+	zassert_equal(DT_INST_ENUM_IDX_BY_IDX_OR(0, val, 123654, 10), 10, "");
 }
 
 #undef DT_DRV_COMPAT


### PR DESCRIPTION
It is currently impossible to use enum with any array like type (i.e. string-array and array, these are the only ones that make sense) in the devicetree and dt-bindings. However, there is no such remark in the dt-bindings section of the docs. Since this is a feature that comes in very handy and is implemented fairly easily, I adjusted the scripts for this.
- Update the edtlib.py and gen_defines.py scripts to support these types.
- Update enum.yaml, test.dts, and test_edtlib.py to test the newly added feature.
- Update devicetree.h to support the newly added feature.

It is now possible to do something like this.
```yaml
compatible = "enums"

properties:
  array-enum:
    type: string-array
    enum:
      - bar
      - foo
      - baz
      - zoo
```
```dts
/ {
	enums {
		compatible = "enums";
		array-enum = "foo", "bar";
	};
};
```