### PR TITLE
fpga: improve handling of incomplete drivers

### DIFF
--- a/drivers/fpga/fpga_shell.c
+++ b/drivers/fpga/fpga_shell.c
@@ -93,8 +93,11 @@ static int cmd_load(const struct shell *sh, size_t argc, char **argv)
 
 	shell_print(sh, "%s: loading bitstream", dev->name);
 
-	fpga_load(dev, (uint32_t *)strtol(argv[2], NULL, 0),
-		  (uint32_t)atoi(argv[3]));
+	err = fpga_load(dev, (uint32_t *)strtol(argv[2], NULL, 0),
+			(uint32_t)atoi(argv[3]));
+	if (err) {
+		shell_error(sh, "Error: %d", err);
+	}
 
 	return err;
 }

--- a/include/zephyr/drivers/fpga.h
+++ b/include/zephyr/drivers/fpga.h
@@ -58,6 +58,13 @@ static inline enum FPGA_status fpga_get_status(const struct device *dev)
 	const struct fpga_driver_api *api =
 		(const struct fpga_driver_api *)dev->api;
 
+	if (api->get_status == NULL) {
+		/* assume it can never be reprogrammed if it
+		 * doesn't support the get_status callback
+		 */
+		return FPGA_STATUS_INACTIVE;
+	}
+
 	return api->get_status(dev);
 }
 
@@ -73,6 +80,10 @@ static inline int fpga_reset(const struct device *dev)
 {
 	const struct fpga_driver_api *api =
 		(const struct fpga_driver_api *)dev->api;
+
+	if (api->reset == NULL) {
+		return -ENOTSUP;
+	}
 
 	return api->reset(dev);
 }
@@ -92,6 +103,10 @@ static inline int fpga_load(const struct device *dev, uint32_t *image_ptr,
 {
 	const struct fpga_driver_api *api =
 		(const struct fpga_driver_api *)dev->api;
+
+	if (api->load == NULL) {
+		return -ENOTSUP;
+	}
 
 	return api->load(dev, image_ptr, img_size);
 }
@@ -116,6 +131,8 @@ static inline int fpga_on(const struct device *dev)
 	return api->on(dev);
 }
 
+#define FPGA_GET_INFO_DEFAULT "n/a"
+
 /**
  * @brief Returns information about the FPGA.
  *
@@ -127,6 +144,10 @@ static inline const char *fpga_get_info(const struct device *dev)
 {
 	const struct fpga_driver_api *api =
 		(const struct fpga_driver_api *)dev->api;
+
+	if (api->get_info == NULL) {
+		return FPGA_GET_INFO_DEFAULT;
+	}
 
 	return api->get_info(dev);
 }


### PR DESCRIPTION
The changes proposed here should make it simpler for fpga drivers that do not implement the whole API (see #71360 as an example of such driver).