### PR TITLE
tests: drivers: timer: nrf_grtc_timer: add nRF54H20 target

### DIFF
--- a/tests/drivers/timer/nrf_grtc_timer/testcase.yaml
+++ b/tests/drivers/timer/nrf_grtc_timer/testcase.yaml
@@ -1,4 +1,7 @@
 tests:
   drivers.timer.nrf_grtc_timer:
     tags: drivers
-    platform_allow: nrf54l15pdk/nrf54l15/cpuapp
+    platform_allow:
+      - nrf54l15pdk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54h20dk/nrf54h20/cpurad


### PR DESCRIPTION
GRTC peripheral is present on nRF54H20,
so the tests should be executed on this target as well.