### PR TITLE
tests/bsim: Fix not detecting failures and hotfix l2cap buffer leak

### DIFF
--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -2017,7 +2017,7 @@ static int l2cap_chan_le_send_sdu(struct bt_l2cap_le_chan *ch,
 		sent += ret;
 
 		/* If the current buffer has been fully consumed, destroy it */
-		if (ret == rem_len) {
+		if (sent == rem_len) {
 			net_buf_unref(buf);
 		}
 	}

--- a/tests/bsim/run_parallel.sh
+++ b/tests/bsim/run_parallel.sh
@@ -78,10 +78,10 @@ if [ `command -v parallel` ]; then
   parallel '
   echo "<testcase name=\"{}\" time=\"0\">"
   start=$(date +%s%N)
-  {} $@ &> {#}.log
+  {} $@ &> {#}.log ; result=$?
   dur=$(($(date +%s%N) - $start))
   dur_s=$(awk -vdur=$dur "BEGIN { printf(\"%0.3f\", dur/1000000000)}")
-  if [ $? -ne 0 ]; then
+  if [ $result -ne 0 ]; then
     (>&2 echo -e "\e[91m{} FAILED\e[39m ($dur_s s)")
     (>&2 cat {#}.log)
     echo "<failure message=\"failed\" type=\"failure\">"


### PR DESCRIPTION
b0339136c1813f616e766ff04f88d08d7cabf418
Broke the check for failed bsim tests.
Let's fix it.

---

And while CI was not failing, 43de309b3e72e7784da9557d091a9bd71a46d7dc.
broke 2 l2cap bsim tests. => Let's fix the issue

Fixes #71508
Fixes #71507