### PR TITLE
samples: application_development: code_relocation_nocopy: Fix build

### DIFF
--- a/samples/application_development/code_relocation_nocopy/linker_arm_nocopy.ld
+++ b/samples/application_development/code_relocation_nocopy/linker_arm_nocopy.ld
@@ -26,6 +26,9 @@
 #define EXTFLASH_SIZE	DT_PROP_OR(EXTFLASH_NODE, size_in_bytes, \
 				   DT_PROP(EXTFLASH_NODE, size) / 8)
 
+/* Let SystemInit() be called in place of z_arm_platform_init() by default. */
+PROVIDE(z_arm_platform_init = SystemInit);
+
 #else
 
 /*


### PR DESCRIPTION
Fixes an issue when building this sample for the
nrf5340dk/nrf5340/cpuapp board target due to changes in the underlying linker file

Fixes #71511