### PR TITLE
samples: net: tftp_client: do not allow native_posix

### DIFF
--- a/samples/net/tftp_client/sample.yaml
+++ b/samples/net/tftp_client/sample.yaml
@@ -6,7 +6,6 @@ tests:
     harness: net
     depends_on: netif
     platform_allow:
-      - native_posix
       - native_sim
     integration_platforms:
       - native_sim


### PR DESCRIPTION
Because CONFIG_POSIX_API (required) cannot be selected on that platform, resulting in build failures.