### PR TITLE
scripts: support soc/boards in Zephyr modules

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -363,6 +363,27 @@ class KconfigCheck(ComplianceTest):
                 ))
             fp_module_file.write(content)
 
+    def get_module_setting_root(self, root, settings_file):
+        """
+        Parse the Zephyr module generated settings file given by 'settings_file'
+        and return all root settings defined by 'root'.
+        """
+        # Invoke the script directly using the Python executable since this is
+        # not a module nor a pip-installed Python utility
+        root_paths = []
+
+        if os.path.exists(settings_file):
+            with open(settings_file, 'r') as fp_setting_file:
+                content = fp_setting_file.read()
+
+            lines = content.strip().split('\n')
+            for line in lines:
+                root = root.upper()
+                if line.startswith(f'"{root}_ROOT":'):
+                    _, root_path = line.split(":", 1)
+                    root_paths.append(Path(root_path.strip('"')))
+        return root_paths
+
     def get_kconfig_dts(self, kconfig_dts_file, settings_file):
         """
         Generate the Kconfig.dts using dts/bindings as the source.
@@ -377,15 +398,9 @@ class KconfigCheck(ComplianceTest):
         binding_paths = []
         binding_paths.append(os.path.join(ZEPHYR_BASE, "dts", "bindings"))
 
-        if os.path.exists(settings_file):
-            with open(settings_file, 'r') as fp_setting_file:
-                content = fp_setting_file.read()
-
-            lines = content.strip().split('\n')
-            for line in lines:
-                if line.startswith('"DTS_ROOT":'):
-                    _, dts_root_path = line.split(":", 1)
-                    binding_paths.append(os.path.join(dts_root_path.strip('"'), "dts", "bindings"))
+        dts_root_paths = self.get_module_setting_root('dts', settings_file)
+        for p in dts_root_paths:
+            binding_paths.append(p / "dts" / "bindings")
 
         cmd = [sys.executable, zephyr_drv_kconfig_path,
                '--kconfig-out', kconfig_dts_file, '--bindings-dirs']
@@ -423,7 +438,7 @@ class KconfigCheck(ComplianceTest):
                     fp_kconfig_v1_syms_file.write('\n\t' + kconfiglib.TYPE_TO_STR[s.type])
                     fp_kconfig_v1_syms_file.write('\n\n')
 
-    def get_v2_model(self, kconfig_dir):
+    def get_v2_model(self, kconfig_dir, settings_file):
         """
         Get lists of v2 boards and SoCs and put them in a file that is parsed by
         Kconfig
@@ -435,8 +450,12 @@ class KconfigCheck(ComplianceTest):
         kconfig_boards_file = os.path.join(kconfig_dir, 'boards', 'Kconfig.boards')
         kconfig_defconfig_file = os.path.join(kconfig_dir, 'boards', 'Kconfig.defconfig')
 
-        root_args = argparse.Namespace(**{'board_roots': [Path(ZEPHYR_BASE)],
-                                          'soc_roots': [Path(ZEPHYR_BASE)], 'board': None})
+        board_roots = self.get_module_setting_root('board', settings_file)
+        board_roots.insert(0, Path(ZEPHYR_BASE))
+        soc_roots = self.get_module_setting_root('soc', settings_file)
+        soc_roots.insert(0, Path(ZEPHYR_BASE))
+        root_args = argparse.Namespace(**{'board_roots': board_roots,
+                                          'soc_roots': soc_roots, 'board': None})
         v2_boards = list_boards.find_v2_boards(root_args)
 
         with open(kconfig_defconfig_file, 'w') as fp:
@@ -542,7 +561,7 @@ class KconfigCheck(ComplianceTest):
         os.makedirs(os.path.join(kconfiglib_dir, 'arch'), exist_ok=True)
 
         os.environ["BOARD_DIR"] = kconfiglib_boards_dir
-        self.get_v2_model(kconfiglib_dir)
+        self.get_v2_model(kconfiglib_dir, os.path.join(kconfiglib_dir, "settings_file.txt"))
 
         # Tells Kconfiglib to generate warnings for all references to undefined
         # symbols within Kconfig files


### PR DESCRIPTION
Extend check_compliance with support for soc and boards defined Zephyr modules.