### PR TITLE
logging: Fix backend filter setting

### DIFF
--- a/subsys/logging/log_mgmt.c
+++ b/subsys/logging/log_mgmt.c
@@ -450,7 +450,8 @@ uint32_t filter_set(int id, uint32_t domain_id, int16_t source_id, uint32_t leve
 
 		STRUCT_SECTION_COUNT(log_backend, &backend_cnt);
 		for (size_t i = 0; i < backend_cnt; i++) {
-			uint32_t current = filter_set(i, domain_id, source_id, level);
+			uint32_t current = filter_set(log_backend_id_get(log_backend_get(i)),
+							domain_id, source_id, level);
 
 			max = MAX(current, max);
 		}


### PR DESCRIPTION
I think I stumbled over a bug in the `log_filter_set` function.

When setting the log filter level on all backends using `log_filter_set(NULL, ...` the filtering is not set on the correct slot.

I think the issue is that recursive call to `filter_set` uses the index of the backend instead of the id.

prj.conf
```
CONFIG_LOG_BACKEND_UART=y
CONFIG_LOG=y
CONFIG_LOG_RUNTIME_FILTERING=y
```

main.c
```
LOG_MODULE_REGISTER(mylogger, LOG_LEVEL_DBG);

int main(void){
    log_init();
    log_filter_set(NULL, CONFIG_LOG_DOMAIN_ID, log_source_id_get("mylogger"), LOG_LEVEL_ERR);
    k_msleep(1000);
    LOG_DBG(" Debug LOG");
    return 0;
}
```