### PR TITLE
linker: Add more DWARF 5 debug sections

### DIFF
--- a/cmake/linker_script/common/debug-sections.cmake
+++ b/cmake/linker_script/common/debug-sections.cmake
@@ -1,4 +1,4 @@
-# Content of this file originates from include/linker/debug-sections.ld
+# Content of this file originates from include/zephyr/linker/debug-sections.ld
 # Following sections are obtained via 'ld --verbose'
 
 # Stabs debugging sections.
@@ -37,7 +37,7 @@ zephyr_linker_section(NAME  .debug_str ADDRESS 0)
 zephyr_linker_section(NAME  .debug_loc ADDRESS 0)
 zephyr_linker_section(NAME  .debug_macinfo ADDRESS 0)
 
- #SGI/MIPS DWARF 2 extensions
+# SGI/MIPS DWARF 2 extensions
 zephyr_linker_section(NAME  .debug_weaknames ADDRESS 0)
 zephyr_linker_section(NAME  .debug_funcnames ADDRESS 0)
 zephyr_linker_section(NAME  .debug_typenames ADDRESS 0)
@@ -46,5 +46,13 @@ zephyr_linker_section(NAME  .debug_varnames ADDRESS 0)
 # DWARF 3
 zephyr_linker_section(NAME  .debug_pubtypes ADDRESS 0)
 zephyr_linker_section(NAME  .debug_ranges ADDRESS 0)
-# DWARF Extension.
+
+# DWARF 5
+zephyr_linker_section(NAME  .debug_addr ADDRESS 0)
+zephyr_linker_section(NAME  .debug_line_str ADDRESS 0)
+zephyr_linker_section(NAME  .debug_loclists ADDRESS 0)
 zephyr_linker_section(NAME  .debug_macro ADDRESS 0)
+zephyr_linker_section(NAME  .debug_names ADDRESS 0)
+zephyr_linker_section(NAME  .debug_rnglists ADDRESS 0)
+zephyr_linker_section(NAME  .debug_str_offsets ADDRESS 0)
+zephyr_linker_section(NAME  .debug_sup ADDRESS 0)

--- a/include/zephyr/linker/debug-sections.ld
+++ b/include/zephyr/linker/debug-sections.ld
@@ -39,9 +39,12 @@
 	/* DWARF 3 */
 	SECTION_PROLOGUE(.debug_pubtypes, 0,)  { *(.debug_pubtypes) }
 	SECTION_PROLOGUE(.debug_ranges, 0,)    { *(.debug_ranges) }
-	/* DWARF Extension. */
-	SECTION_PROLOGUE(.debug_macro, 0,)     { *(.debug_macro) }
 	/* DWARF 5 */
+	SECTION_PROLOGUE(.debug_addr, 0,)      { *(.debug_addr) }
 	SECTION_PROLOGUE(.debug_line_str, 0,)  { *(.debug_line_str) }
 	SECTION_PROLOGUE(.debug_loclists, 0,)  { *(.debug_loclists) }
+	SECTION_PROLOGUE(.debug_macro, 0,)     { *(.debug_macro) }
+	SECTION_PROLOGUE(.debug_names, 0,)     { *(.debug_names) }
 	SECTION_PROLOGUE(.debug_rnglists, 0,)  { *(.debug_rnglists) }
+	SECTION_PROLOGUE(.debug_str_offsets, 0,) { *(.debug_str_offsets) }
+	SECTION_PROLOGUE(.debug_sup, 0,)       { *(.debug_sup) }


### PR DESCRIPTION
These sections were reported by 'GNU ld (GNU Binutils) 2.41.0' using 'ld --verbose'.