### PR TITLE
tests: drivers: can: api: use common test setup function

### DIFF
--- a/tests/drivers/can/api/src/canfd.c
+++ b/tests/drivers/can/api/src/canfd.c
@@ -491,19 +491,7 @@ static bool canfd_predicate(const void *state)
 
 void *canfd_setup(void)
 {
-	int err;
-
-	k_sem_init(&rx_callback_sem, 0, 2);
-	k_sem_init(&tx_callback_sem, 0, 2);
-
-	(void)can_stop(can_dev);
-
-	err = can_set_mode(can_dev, CAN_MODE_LOOPBACK | CAN_MODE_FD);
-	zassert_equal(err, 0, "failed to set CAN FD loopback mode (err %d)", err);
-	zassert_equal(CAN_MODE_LOOPBACK | CAN_MODE_FD, can_get_mode(can_dev));
-
-	err = can_start(can_dev);
-	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);
+	can_common_test_setup(CAN_MODE_LOOPBACK | CAN_MODE_FD);
 
 	return NULL;
 }

--- a/tests/drivers/can/api/src/classic.c
+++ b/tests/drivers/can/api/src/classic.c
@@ -1205,24 +1205,7 @@ ZTEST_USER(can_classic, test_set_mode_while_started)
 
 void *can_classic_setup(void)
 {
-	int err;
-
-	k_sem_init(&rx_callback_sem, 0, 2);
-	k_sem_init(&tx_callback_sem, 0, 2);
-
-	k_object_access_grant(&can_msgq, k_current_get());
-	k_object_access_grant(can_dev, k_current_get());
-
-	zassert_true(device_is_ready(can_dev), "CAN device not ready");
-
-	(void)can_stop(can_dev);
-
-	err = can_set_mode(can_dev, CAN_MODE_LOOPBACK);
-	zassert_equal(err, 0, "failed to set loopback mode (err %d)", err);
-	zassert_equal(CAN_MODE_LOOPBACK, can_get_mode(can_dev));
-
-	err = can_start(can_dev);
-	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);
+	can_common_test_setup(CAN_MODE_LOOPBACK);
 
 	return NULL;
 }

--- a/tests/drivers/can/api/src/common.c
+++ b/tests/drivers/can/api/src/common.c
@@ -222,3 +222,25 @@ void assert_frame_equal(const struct can_frame *frame1,
 				  "Received data differ");
 	}
 }
+
+void can_common_test_setup(can_mode_t initial_mode)
+{
+	int err;
+
+	k_sem_init(&rx_callback_sem, 0, 2);
+	k_sem_init(&tx_callback_sem, 0, 2);
+
+	k_object_access_grant(&can_msgq, k_current_get());
+	k_object_access_grant(can_dev, k_current_get());
+
+	zassert_true(device_is_ready(can_dev), "CAN device not ready");
+
+	(void)can_stop(can_dev);
+
+	err = can_set_mode(can_dev, initial_mode);
+	zassert_equal(err, 0, "failed to set initial mode (err %d)", err);
+	zassert_equal(initial_mode, can_get_mode(can_dev));
+
+	err = can_start(can_dev);
+	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);
+}

--- a/tests/drivers/can/api/src/common.h
+++ b/tests/drivers/can/api/src/common.h
@@ -163,3 +163,10 @@ extern const struct can_filter test_std_some_filter;
 void assert_frame_equal(const struct can_frame *frame1,
 			const struct can_frame *frame2,
 			uint32_t id_mask);
+
+/**
+ * @brief Common setup function for the CAN controller device under test.
+ *
+ * @param initial_mode Initial CAN controller operational mode.
+ */
+void can_common_test_setup(can_mode_t initial_mode);


### PR DESCRIPTION
Use a common test setup function between the classic and CAN FD test suites.