### PR TITLE
cmake: add control over inline source code disassembly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1704,7 +1704,7 @@ endif()
 if(CONFIG_OUTPUT_DISASSEMBLY)
 if(CONFIG_OUTPUT_DISASSEMBLE_ALL)
     set(disassembly_type "$<TARGET_PROPERTY:bintools,disassembly_flag_all>")
-  else()
+  elseif (CONFIG_OUTPUT_DISASSEMBLY_WITH_SOURCE)
     set(disassembly_type "$<TARGET_PROPERTY:bintools,disassembly_flag_inline_source>")
   endif()
   list(APPEND

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -567,6 +567,17 @@ config OUTPUT_DISASSEMBLE_ALL
 	  The .lst file will contain complete disassembly of the firmware
 	  not just those expected to contain instructions including zeros
 
+config OUTPUT_DISASSEMBLY_WITH_SOURCE
+	bool "Include source code in output disassembly file"
+	default y
+	depends on OUTPUT_DISASSEMBLY && !OUTPUT_DISASSEMBLE_ALL
+	help
+	  The .lst file will also contain the source code. Having
+	  control over this can be useful for reproducible builds
+	  since it can be used to remove one of the elements of
+	  the .lst file that can vary across platforms because
+	  of reasons such as having ".." include paths.
+
 config OUTPUT_PRINT_MEMORY_USAGE
 	bool "Print memory usage to stdout"
 	default y


### PR DESCRIPTION
By default, the generated disassembly file (i.e: the .lst file) also contains inline source code. This has the potential to become problematic when attempting to compare the generated .lst files accross platforms since they may differ for various reasons. As such, add the option to control whether the disassembly file should contain inline source code or not.

Relevant SOF issue: https://github.com/thesofproject/sof/issues/9034