### PR TITLE
modules: hal_nordic: Fix NRF_GRTC_HAS_EXTENDED

### DIFF
--- a/modules/hal_nordic/nrfx/CMakeLists.txt
+++ b/modules/hal_nordic/nrfx/CMakeLists.txt
@@ -128,7 +128,7 @@ if(CONFIG_NRFX_TWI OR CONFIG_NRFX_TWIM)
 endif()
 
 if (CONFIG_NRF_GRTC_TIMER AND CONFIG_NRF_GRTC_TIMER_CLOCK_MANAGEMENT)
-  zephyr_library_compile_definitions(NRF_GRTC_HAS_EXTENDED=1)
+  zephyr_compile_definitions(NRF_GRTC_HAS_EXTENDED=1)
 endif()
 
 # Inject HAL "CONFIG_NFCT_PINS_AS_GPIOS" definition if user requests to


### PR DESCRIPTION
This definition is used in nrfx header files, so it shouldn't be added using `zephyr_library_compile_definitions()`. This would cause the GRTC driver to fail the build when CONFIG_NRF_GRTC_START_SYSCOUNTER=y.