### PR TITLE
tests/bsim: sysbuild: Set primary MCU idx properly

### DIFF
--- a/tests/bsim/bluetooth/audio_samples/broadcast_audio_sink/Kconfig.sysbuild
+++ b/tests/bsim/bluetooth/audio_samples/broadcast_audio_sink/Kconfig.sysbuild
@@ -7,4 +7,4 @@ config NATIVE_SIMULATOR_PRIMARY_MCU_INDEX
 	int
 	# Let's pass the test arguments to the application MCU test
 	# otherwise by default they would have gone to the net core.
-	default 0 if $(BOARD) = "nrf5340bsim"
+	default 0 if $(BOARD_TARGET_STRING) = "NRF5340BSIM_NRF5340_CPUAPP"

--- a/tests/bsim/bluetooth/audio_samples/unicast_audio_client/Kconfig.sysbuild
+++ b/tests/bsim/bluetooth/audio_samples/unicast_audio_client/Kconfig.sysbuild
@@ -7,4 +7,4 @@ config NATIVE_SIMULATOR_PRIMARY_MCU_INDEX
 	int
 	# Let's pass the test arguments to the application MCU test
 	# otherwise by default they would have gone to the net core.
-	default 0 if $(BOARD) = "nrf5340bsim"
+	default 0 if $(BOARD_TARGET_STRING) = "NRF5340BSIM_NRF5340_CPUAPP"

--- a/tests/bsim/bluetooth/ll/bis/Kconfig.sysbuild
+++ b/tests/bsim/bluetooth/ll/bis/Kconfig.sysbuild
@@ -11,4 +11,4 @@ config NATIVE_SIMULATOR_PRIMARY_MCU_INDEX
 	int
 	# Let's pass the test arguments to the application MCU test
 	# otherwise by default they would have gone to the net core.
-	default 0 if $(BOARD) = "nrf5340bsim"
+	default 0 if $(BOARD_TARGET_STRING) = "NRF5340BSIM_NRF5340_CPUAPP"

--- a/tests/bsim/bluetooth/ll/cis/Kconfig.sysbuild
+++ b/tests/bsim/bluetooth/ll/cis/Kconfig.sysbuild
@@ -11,4 +11,4 @@ config NATIVE_SIMULATOR_PRIMARY_MCU_INDEX
 	int
 	# Let's pass the test arguments to the application MCU test
 	# otherwise by default they would have gone to the net core.
-	default 0 if $(BOARD) = "nrf5340bsim"
+	default 0 if $(BOARD_TARGET_STRING) = "NRF5340BSIM_NRF5340_CPUAPP"

--- a/tests/bsim/bluetooth/ll/conn/Kconfig.sysbuild
+++ b/tests/bsim/bluetooth/ll/conn/Kconfig.sysbuild
@@ -11,4 +11,4 @@ config NATIVE_SIMULATOR_PRIMARY_MCU_INDEX
 	int
 	# Let's pass the test arguments to the application MCU test
 	# otherwise by default they would have gone to the net core.
-	default 0 if $(BOARD) = "nrf5340bsim"
+	default 0 if $(BOARD_TARGET_STRING) = "NRF5340BSIM_NRF5340_CPUAPP"


### PR DESCRIPTION
When using sysbuild,
set the primary MCU index to be the app core
only when we are building the test app in the app core.

Otherwise, if the test app is build in the net core, the test command line parameters won't be sent by default to it, and tests will fail.

Luckily, these tests are only built in CI using sysbuild when we target the 5340bsim app core, and in all but 2, even if sysbuild was used, this setting was propagated to the zephyr build only if we had separate net and app core images.
The issue was introduced during the transition to hwmv2.