### PR TITLE
twister: handler: optimize handler testsuite check

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -133,10 +133,12 @@ class Handler:
             return
         if not detected_suite_names:
             self._missing_suite_name(expected_suite_names, handler_time)
-        for detected_suite_name in detected_suite_names:
-            if detected_suite_name not in expected_suite_names:
+            return
+        # compare the expect and detect from end one by one without order
+        _d_suite = detected_suite_names[-len(expected_suite_names):]
+        if set(_d_suite) != set(expected_suite_names):
+            if not set(_d_suite).issubset(set(expected_suite_names)):
                 self._missing_suite_name(expected_suite_names, handler_time)
-                break
 
     def _missing_suite_name(self, expected_suite_names, handler_time):
         """


### PR DESCRIPTION
in many platforms, before  the debuger flash, the former testsuite many already executed, so we will see some old testsuite name. and we should not compare them directly, instead if we compare in reverse order then we can avoid such mis-judge.

see below log

```
DEBUG   - DEVICE: ------ TESTSUITE SUMMARY END ------
DEBUG   - DEVICE:
DEBUG   - DEVICE: ===================================================================
DEBUG   - DEVICE: RunID: c16329269d819466809d81610753a0fa
DEBUG   - DEVICE: PROJECT EXECUTION SUCCESSFUL
DEBUG   - -- west flash: using runner linkserver
-- runners.linkserver: LinkServer: /usr/local/LinkServer/LinkServer, version v1.4.85

DEBUG   - Expected suite names:['lib_heap_align', 'lib_heap_align']
DEBUG   - Detected suite names:['onoff_api', 'lib_heap_align', 'lib_heap_align']
DEBUG   - Test suite names were not printed or some of them in output do not correspond with expected: ['lib_heap_align', 'lib_heap_align']
DEBUG   - run status: frdm_mcxn947/mcxn947/cpu0/tests/lib/heap_align/libraries.heap_align failed
INFO    - 1207/1745 frdm_mcxn947/mcxn947/cpu0 tests/lib/heap_align/libraries.heap_align           FAILED Testsuite mismatch (device: #1, 7.110s)
ERROR   - see: /home/ubuntu/nxp/frdm_mcxn947/temp/frdm_mcxn947_mcxn947_cpu0_twister_test_only/twister-out/frdm_mcxn947_mcxn947_cpu0/tests/lib/heap_a


nners.linkserver: LinkServer: /usr/local/LinkServer/LinkServer, version v1.4.85

DEBUG   - Expected suite names:['hash_map', 'hash_map']
DEBUG   - Detected suite names:['hash*** Booting Zephyr OS build v3.6.0-2211-g25812289779f ***', 'hash_map', 'hash_map', 'hash_map', 'hash_map', 'hash_map', 'hash_map', 'hash_map', 'hash_map', 'hash_map', 'hash_map', 'hash_map', 'hash_map', 'hash_map', 'hash_map', 'hash_map']
DEBUG   - Test suite names were not printed or some of them in output do not correspond with expected: ['hash_map', 'hash_map']
DEBUG   - run status: frdm_mcxn947/mcxn947/cpu0/tests/lib/hash_map/libraries.hash_map.separate_chaining.djb2 failed
INFO    - 1226/1745 frdm_mcxn947/mcxn947/cpu0 tests/lib/hash_map/libraries.hash_map.separate_chaining.djb2  FAILED Testsuite mismatch (device: #1, 6.896s)
ERROR   - see: /home/ubuntu/nxp/frdm_mcxn947/temp/frdm_mcxn947_mcxn947_cpu0_twister_test_only/twister-out/frdm_mcxn947_mcxn947_cpu0/tests/lib/hash_map/libr

```