### PR TITLE
cortex_m: linker: lld: Handle symtab/strtab/shstrtab to fix warnings

### DIFF
--- a/include/zephyr/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/zephyr/arch/arm/cortex_m/scripts/linker.ld
@@ -469,6 +469,15 @@ GROUP_END(DTCM)
 	KEEP(*(.gnu.attributes))
 	}
 
+/* Output section descriptions are needed for these sections to suppress
+ * warnings when "--orphan-handling=warn" is set for lld.
+ */
+#if defined(CONFIG_LLVM_USE_LLD)
+    SECTION_PROLOGUE(.symtab, 0,) { *(.symtab) }
+    SECTION_PROLOGUE(.strtab, 0,) { *(.strtab) }
+    SECTION_PROLOGUE(.shstrtab, 0,) { *(.shstrtab) }
+#endif
+
     /* Sections generated from 'zephyr,memory-region' nodes */
     LINKER_DT_SECTIONS()
 


### PR DESCRIPTION
LLD produces warnings about orphaned sections if there are no matching rules in the linker script:

ld.lld: warning: <internal>:(.symtab) is being placed in '.symtab'
ld.lld: warning: <internal>:(.shstrtab) is being placed in '.shstrtab'
ld.lld: warning: <internal>:(.strtab) is being placed in '.strtab'

Handle these sections when building with LLD to prevent the warnings.