### PR TITLE
Bluetooth: Controller: Use reschedule margin as minimum ticks_slot

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -1091,7 +1091,7 @@ config BT_TICKER_EXT
 config BT_TICKER_EXT_SLOT_WINDOW_YIELD
 	bool "Tickers with slot window always yields"
 	depends on BT_TICKER_EXT
-	default y if BT_CTLR_ADV_ISO
+	default y if BT_MESH || BT_CTLR_ADV_ISO
 	help
 	  This options forces tickers with slot window extensions to yield to
 	  normal tickers and be placed at the end of their slot window.

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/ticker.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/ticker.h
@@ -68,8 +68,9 @@
 	HAL_TICKER_TICKS_TO_US(HAL_TICKER_PSEC_PER_USEC)
 
 /* Macro defining the margin for positioning re-scheduled nodes */
+#define HAL_TICKER_RESCHEDULE_MARGIN_US 150U
 #define HAL_TICKER_RESCHEDULE_MARGIN \
-	HAL_TICKER_US_TO_TICKS(150)
+	HAL_TICKER_US_TO_TICKS(HAL_TICKER_RESCHEDULE_MARGIN_US)
 
 /* Remove ticks and return positive remainder value in microseconds */
 static inline void hal_ticker_remove_jitter(uint32_t *ticks,

--- a/tests/bsim/bluetooth/samples/central_hr_peripheral_hr/tests_scripts/central_hr_peripheral_hr.sh
+++ b/tests/bsim/bluetooth/samples/central_hr_peripheral_hr/tests_scripts/central_hr_peripheral_hr.sh
@@ -4,10 +4,9 @@
 
 simulation_id="central_hr_peripheral_hr_test"
 verbosity_level=2
+EXECUTE_TIMEOUT=60
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
-
-EXECUTE_TIMEOUT=10
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -19,6 +18,6 @@ Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_samples_central_hr_peripheral_hr_p
   -testid=central_hr_peripheral_hr
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
-  -D=2 -sim_length=10e6 $@
+  -D=2 -sim_length=12e6 $@
 
 wait_for_background_jobs #Wait for all programs in background and return != 0 if any fails

--- a/tests/bsim/bluetooth/samples/central_hr_peripheral_hr/tests_scripts/central_hr_peripheral_hr_extended.sh
+++ b/tests/bsim/bluetooth/samples/central_hr_peripheral_hr/tests_scripts/central_hr_peripheral_hr_extended.sh
@@ -7,8 +7,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 simulation_id="central_hr_peripheral_hr_extended_test"
 test_long_name="$(guess_test_long_name)"
 verbosity_level=2
-
-EXECUTE_TIMEOUT=10
+EXECUTE_TIMEOUT=60
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -20,6 +19,6 @@ Execute ./bs_${BOARD_TS}_${test_long_name}_prj_conf_overlay-extended_conf \
   -testid=central_hr_peripheral_hr
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
-  -D=2 -sim_length=10e6 $@
+  -D=2 -sim_length=12e6 $@
 
 wait_for_background_jobs #Wait for all programs in background and return != 0 if any fails

--- a/tests/bsim/bluetooth/samples/central_hr_peripheral_hr/tests_scripts/central_hr_peripheral_hr_phy_coded.sh
+++ b/tests/bsim/bluetooth/samples/central_hr_peripheral_hr/tests_scripts/central_hr_peripheral_hr_phy_coded.sh
@@ -7,8 +7,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 simulation_id="central_hr_peripheral_hr_phy_coded_test"
 test_long_name="$(guess_test_long_name)"
 verbosity_level=2
-
-EXECUTE_TIMEOUT=10
+EXECUTE_TIMEOUT=60
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -20,6 +19,6 @@ Execute ./bs_${BOARD_TS}_${test_long_name}_prj_conf_overlay-phy_coded_conf \
   -testid=central_hr_peripheral_hr
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
-  -D=2 -sim_length=10e6 $@
+  -D=2 -sim_length=12e6 $@
 
 wait_for_background_jobs #Wait for all programs in background and return != 0 if any fails


### PR DESCRIPTION
Use reschedule margin as minimum ticks_slot when ticker with
reschedule expires. This will ensure not too many unreserved
tickers expire in close proximity that can lead of pile up
of CPU processing time and eventually causing timeout
callbacks to be delayed. This mitigate possible LL asserts
due to overhead in start of radio events.

Fix short prepare preempt timeout start, such that if there
are any normal prepare before a short prepare in the
pipeline, then find the short prepare and start its preempt
timeout.

Add prepare pipeline assertion checks to detect faults
like stopping preempt timeout without prior start. Also,
check if the preemptor param is correct when preemption
is performed. Check that the prepare pipeline is not
infinitely looping.

Add assertion check for use of scan aux context so that
scan aux context is not assigned again while there is
already an existing LLL scheduling in use by the scan
context.

Fix BT_CTLR_EARLY_ABORT_PREVIOUS_PREPARE to setup new
shorter preempt timeout irrespective of whether there
is a previous prepare enqueued in the prepare pipeline.

Relates to commit https://github.com/zephyrproject-rtos/zephyr/commit/d573951f0daf5f541703293256885fe0e93b7799 ("Bluetooth: Controller:
Revert back early abort of previous prepare").

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>