### PR TITLE
doc: kconfig: fix HAS_CONFIGURABLE_FOO

### DIFF
--- a/doc/build/kconfig/tips.rst
+++ b/doc/build/kconfig/tips.rst
@@ -1060,7 +1060,7 @@ This is logically equivalent to the following:
    See the `optional prompts`_ section for the meaning of the conditions on the
    prompts.
 
-When ``HAS_CONFIGURABLE`` is ``n``, we now get the following configuration
+When ``HAS_CONFIGURABLE_FOO`` is ``n``, we now get the following configuration
 output for the symbols, instead of no output:
 
 .. code-block:: cfg


### PR DESCRIPTION
Use HAS_CONFIGURABLE_FOO instead of wrong HAS_CONFIGURABLE.