### PR TITLE
drivers: net: nsos: implement sendmsg()

### DIFF
--- a/drivers/net/nsos.h
+++ b/drivers/net/nsos.h
@@ -89,6 +89,21 @@ struct nsos_mid_addrinfo {
 	struct nsos_mid_addrinfo *ai_next;
 };
 
+struct nsos_mid_iovec {
+	void  *iov_base;
+	size_t iov_len;
+};
+
+struct nsos_mid_msghdr {
+	void                  *msg_name;       /* optional socket address, big endian */
+	size_t                 msg_namelen;    /* size of socket address */
+	struct nsos_mid_iovec *msg_iov;        /* scatter/gather array */
+	size_t                 msg_iovlen;     /* number of elements in msg_iov */
+	void                  *msg_control;    /* ancillary data */
+	size_t                 msg_controllen; /* ancillary data buffer len */
+	int                    msg_flags;      /* flags on received message */
+};
+
 static inline void nsos_socket_flag_convert(int *flags_a, int flag_a,
 					    int *flags_b, int flag_b)
 {
@@ -108,6 +123,7 @@ int nsos_adapt_listen(int fd, int backlog);
 int nsos_adapt_accept(int fd, struct nsos_mid_sockaddr *addr, size_t *addrlen);
 int nsos_adapt_sendto(int fd, const void *buf, size_t len, int flags,
 		      const struct nsos_mid_sockaddr *addr, size_t addrlen);
+int nsos_adapt_sendmsg(int fd, const struct nsos_mid_msghdr *msg_mid, int flags);
 int nsos_adapt_recvfrom(int fd, void *buf, size_t len, int flags,
 			struct nsos_mid_sockaddr *addr, size_t *addrlen);
 

--- a/drivers/net/nsos_sockets.c
+++ b/drivers/net/nsos_sockets.c
@@ -372,7 +372,7 @@ static int nsos_ioctl(void *obj, unsigned int request, va_list args)
 	return -EINVAL;
 }
 
-static int sockaddr_to_nsos_mid(const struct sockaddr *addr, socklen_t *addrlen,
+static int sockaddr_to_nsos_mid(const struct sockaddr *addr, socklen_t addrlen,
 				struct nsos_mid_sockaddr **addr_mid, size_t *addrlen_mid)
 {
 	if (!addr || !addrlen) {
@@ -389,7 +389,7 @@ static int sockaddr_to_nsos_mid(const struct sockaddr *addr, socklen_t *addrlen,
 		struct nsos_mid_sockaddr_in *addr_in_mid =
 			(struct nsos_mid_sockaddr_in *)*addr_mid;
 
-		if (*addrlen < sizeof(*addr_in)) {
+		if (addrlen < sizeof(*addr_in)) {
 			return -NSOS_MID_EINVAL;
 		}
 
@@ -407,7 +407,7 @@ static int sockaddr_to_nsos_mid(const struct sockaddr *addr, socklen_t *addrlen,
 		struct nsos_mid_sockaddr_in6 *addr_in_mid =
 			(struct nsos_mid_sockaddr_in6 *)*addr_mid;
 
-		if (*addrlen < sizeof(*addr_in)) {
+		if (addrlen < sizeof(*addr_in)) {
 			return -NSOS_MID_EINVAL;
 		}
 
@@ -477,7 +477,7 @@ static int nsos_bind(void *obj, const struct sockaddr *addr, socklen_t addrlen)
 	size_t addrlen_mid;
 	int ret;
 
-	ret = sockaddr_to_nsos_mid(addr, &addrlen, &addr_mid, &addrlen_mid);
+	ret = sockaddr_to_nsos_mid(addr, addrlen, &addr_mid, &addrlen_mid);
 	if (ret < 0) {
 		goto return_ret;
 	}
@@ -501,7 +501,7 @@ static int nsos_connect(void *obj, const struct sockaddr *addr, socklen_t addrle
 	size_t addrlen_mid;
 	int ret;
 
-	ret = sockaddr_to_nsos_mid(addr, &addrlen, &addr_mid, &addrlen_mid);
+	ret = sockaddr_to_nsos_mid(addr, addrlen, &addr_mid, &addrlen_mid);
 	if (ret < 0) {
 		goto return_ret;
 	}
@@ -653,7 +653,7 @@ static ssize_t nsos_sendto(void *obj, const void *buf, size_t len, int flags,
 
 	flags_mid = ret;
 
-	ret = sockaddr_to_nsos_mid(addr, &addrlen, &addr_mid, &addrlen_mid);
+	ret = sockaddr_to_nsos_mid(addr, addrlen, &addr_mid, &addrlen_mid);
 	if (ret < 0) {
 		goto return_ret;
 	}


### PR DESCRIPTION
Implement `sendmsg()` socket API to have increased compatibility with
components like MQTT client.