### PR TITLE
boards: st: b_u585_iot02a: add segger jlink support

### DIFF
--- a/boards/st/b_u585i_iot02a/board.cmake
+++ b/boards/st/b_u585i_iot02a/board.cmake
@@ -19,7 +19,10 @@ board_runner_args(openocd "--tcl-port=6666")
 board_runner_args(openocd --cmd-pre-init "gdb_report_data_abort enable")
 board_runner_args(openocd "--no-halt")
 
+board_runner_args(jlink "--device=STM32U585AI" "--reset-after-load")
+
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 # FIXME: openocd runner requires use of STMicro openocd fork.
 # Check board documentation for more details.
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)


### PR DESCRIPTION
This PR adds the possibility to use the Segger JLink debugger with b_u585_iot02a board