### PR TITLE
modbus_serial: Disable rx interrupt if buffer fills up

### DIFF
--- a/subsys/modbus/modbus_serial.c
+++ b/subsys/modbus/modbus_serial.c
@@ -339,6 +339,12 @@ static void cb_handler_rx(struct modbus_context *ctx)
 	} else {
 		int n;
 
+		if (cfg->uart_buf_ctr == CONFIG_MODBUS_BUFFER_SIZE) {
+			/* Buffer full. Disable interrupt until timeout. */
+			modbus_serial_rx_disable(ctx);
+			return;
+		}
+
 		/* Restart timer on a new character */
 		k_timer_start(&cfg->rtu_timer,
 			      K_USEC(cfg->rtu_timeout), K_NO_WAIT);


### PR DESCRIPTION
On many uarts, the RX interrupt flag is only cleared when reading from the fifo. If no read is performed the interrupt is immediately re-triggered when the ISR exits, causing a busy loop that starves the application.