### PR TITLE
arch: riscv: irq_manage: support ISR_OFFSET in dynamic IRQs

### DIFF
--- a/arch/riscv/core/irq_manage.c
+++ b/arch/riscv/core/irq_manage.c
@@ -43,7 +43,7 @@ int arch_irq_connect_dynamic(unsigned int irq, unsigned int priority,
 			     void (*routine)(const void *parameter),
 			     const void *parameter, uint32_t flags)
 {
-	z_isr_install(irq, routine, parameter);
+	z_isr_install(irq + CONFIG_RISCV_RESERVED_IRQ_ISR_TABLES_OFFSET, routine, parameter);
 
 #if defined(CONFIG_RISCV_HAS_PLIC) || defined(CONFIG_RISCV_HAS_CLIC)
 	z_riscv_irq_priority_set(irq, priority, flags);


### PR DESCRIPTION
`CONFIG_RISCV_RESERVED_IRQ_ISR_TABLES_OFFSET` shoud be taken into account in `arch_irq_connect_dynamic`, same as it is done in `ARCH_IRQ_CONNECT` macro.