### PR TITLE
soc: espressif: Fix the cache size set calls

### DIFF
--- a/soc/espressif/common/loader.c
+++ b/soc/espressif/common/loader.c
@@ -204,6 +204,15 @@ void map_rom_segments(uint32_t app_drom_start, uint32_t app_drom_vaddr,
 	cache_hal_enable(CACHE_TYPE_ALL);
 #endif /* CONFIG_SOC_SERIES_ESP32 */
 
+#if !defined(CONFIG_SOC_SERIES_ESP32) && !defined(CONFIG_SOC_SERIES_ESP32S2)
+	/* Configure the Cache MMU size for instruction and rodata in flash. */
+	uint32_t cache_mmu_irom_size = ((app_irom_size + CONFIG_MMU_PAGE_SIZE - 1) /
+			CONFIG_MMU_PAGE_SIZE) * sizeof(uint32_t);
+
+	/* Split the cache usage by the segment sizes */
+	Cache_Set_IDROM_MMU_Size(cache_mmu_irom_size,
+				CACHE_DROM_MMU_MAX_END - cache_mmu_irom_size);
+#endif
 	/* Show map segments continue using same log format as during MCUboot phase */
 	BOOT_LOG_INF("DROM segment: paddr=%08xh, vaddr=%08xh, size=%05Xh (%6d) map",
 			app_drom_start_aligned, app_drom_vaddr_aligned,

--- a/soc/espressif/esp32/soc.c
+++ b/soc/espressif/esp32/soc.c
@@ -40,9 +40,6 @@
 #include "esp_clk_internal.h"
 #endif /* CONFIG_SOC_ENABLE_APPCPU */
 
-#ifdef CONFIG_MCUBOOT
-#include "bootloader_init.h"
-#endif /* CONFIG_MCUBOOT */
 #include <zephyr/sys/printk.h>
 
 #if CONFIG_ESP_SPIRAM

--- a/soc/espressif/esp32c3/soc.c
+++ b/soc/espressif/esp32c3/soc.c
@@ -30,10 +30,6 @@
 #include <zephyr/toolchain.h>
 #include <soc.h>
 
-#ifdef CONFIG_MCUBOOT
-#include "bootloader_init.h"
-#endif /* CONFIG_MCUBOOT */
-
 extern void esp_reset_reason_init(void);
 
 /*
@@ -63,20 +59,6 @@ void __attribute__((section(".iram1"))) __esp_platform_start(void)
 	wdt_hal_write_protect_disable(&rtc_wdt_ctx);
 	wdt_hal_disable(&rtc_wdt_ctx);
 	wdt_hal_write_protect_enable(&rtc_wdt_ctx);
-
-	/* Configure the Cache MMU size for instruction and rodata in flash. */
-	extern uint32_t esp_rom_cache_set_idrom_mmu_size(uint32_t irom_size,
-			uint32_t drom_size);
-
-	extern int _rodata_reserved_start;
-	uint32_t rodata_reserved_start_align =
-		(uint32_t)&_rodata_reserved_start & ~(CONFIG_MMU_PAGE_SIZE - 1);
-	uint32_t cache_mmu_irom_size =
-		((rodata_reserved_start_align - SOC_DROM_LOW) / CONFIG_MMU_PAGE_SIZE) *
-			sizeof(uint32_t);
-
-	esp_rom_cache_set_idrom_mmu_size(cache_mmu_irom_size,
-		CACHE_DROM_MMU_MAX_END - cache_mmu_irom_size);
 
 	/* Enable wireless phy subsystem clock,
 	 * This needs to be done before the kernel starts

--- a/soc/espressif/esp32s2/soc.c
+++ b/soc/espressif/esp32s2/soc.c
@@ -37,10 +37,6 @@
 #include <esp_clk_internal.h>
 #include <zephyr/sys/printk.h>
 
-#ifdef CONFIG_MCUBOOT
-#include "bootloader_init.h"
-#endif /* CONFIG_MCUBOOT */
-
 extern void rtc_clk_cpu_freq_set_xtal(void);
 extern void esp_reset_reason_init(void);
 

--- a/soc/espressif/esp32s3/soc.c
+++ b/soc/espressif/esp32s3/soc.c
@@ -45,9 +45,6 @@
 #include <esp_clk_internal.h>
 #include <esp_app_format.h>
 
-#ifdef CONFIG_MCUBOOT
-#include "bootloader_init.h"
-#endif /* CONFIG_MCUBOOT */
 #include <zephyr/sys/printk.h>
 
 #if CONFIG_ESP_SPIRAM


### PR DESCRIPTION
Fix the calculation of the cache sizes for ESP32-C3.
Move the cache size set calls to a common file.
Remove includes, that are no longer needed.
