### PR TITLE
modbus_serial: Avoid buffer overflow in cb_handler_rx()

### DIFF
--- a/subsys/modbus/modbus_serial.c
+++ b/subsys/modbus/modbus_serial.c
@@ -527,8 +527,10 @@ int modbus_serial_rx_adu(struct modbus_context *ctx)
 		return -ENOTSUP;
 	}
 
+	unsigned int key = irq_lock();
 	cfg->uart_buf_ctr = 0;
 	cfg->uart_buf_ptr = &cfg->uart_buf[0];
+	irq_unlock(key);
 
 	return rc;
 }


### PR DESCRIPTION
If a uart rx interrupt occurs after uart_buf_ctr is reset, but before uart_buf_ptr is reset, cb_handler_rx() can write past the end of buffer.

Add irq_lock() around the lines to avoid this possibility.

**Details**
The problematic sequence is as follows:

```c
	cfg->uart_buf_ctr = 0;
	cfg->uart_buf_ptr = &cfg->uart_buf[0];
```

1. Start condition: Modbus is configured in RTU mode. `uart_buf_ctr` is CONFIG_MODBUS_BUFFER_SIZE - 1, i.e the buffer is almost full. `uart_buf_ptr` is similarly pointing near the end of the available buffer. 
2. The first line executes, zeroing `uart_buf_ctr`.
3. A uart rx interrupt occurs, calling `uart_cb_handler()`, which in turn calls `cb_handler_rx()`.
4. `cb_handler_rx()` calls:
```c
		n = uart_fifo_read(cfg->dev, cfg->uart_buf_ptr,
				   (CONFIG_MODBUS_BUFFER_SIZE -
				    cfg->uart_buf_ctr));
```
5. This instructs `uart_fifo_read()` to write CONFIG_MODBUS_BUFFER_SIZE bytes to `cfg->uart_buf_ptr`, which still points at the end of the buffer. This causes it to write past the end of `cfg->uart_buf`.
