### PR TITLE
drivers: dai: ssp: fix MN_MDIVCTRL_M_DIV_ENABLE for ACE+ platform

### DIFF
--- a/drivers/dai/intel/ssp/ssp.h
+++ b/drivers/dai/intel/ssp/ssp.h
@@ -242,13 +242,22 @@
 
 /** \brief Offset of MCLK Divider x Ratio Register. */
 #define MN_MDIVR(x) (0x180 + (x) * 0x4)
+
+/** \brief Enables the output of MCLK Divider.
+ *  On ACE+ there is a single divider for all MCLKs
+ */
+#define MN_MDIVCTRL_M_DIV_ENABLE(x) BIT(0)
+
 #else
 #define MN_MDIVCTRL 0x0
 #define MN_MDIVR(x) (0x80 + (x) * 0x4)
-#endif
 
-/** \brief Enables the output of MCLK Divider. */
+/** \brief Enables the output of MCLK Divider.
+ * Each MCLK divider can be enabled separately.
+ */
 #define MN_MDIVCTRL_M_DIV_ENABLE(x) BIT(x)
+
+#endif
 
 /** \brief Bits for setting MCLK source clock. */
 #define MCDSS(x)	DAI_INTEL_SSP_SET_BITS(17, 16, x)


### PR DESCRIPTION
In previous generations, each MCLK divider could be enabled separately.

Starting with ACE, there is a single-bit MDE field to enable a single divider. The existing code would not enable MDE in case MCLK1 is used.