### PR TITLE
Bluetooth: Controller: Fix UBSan error

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -390,7 +390,7 @@ void radio_aa_set(const uint8_t *aa)
 	NRF_RADIO->RXADDRESSES =
 	    ((RADIO_RXADDRESSES_ADDR0_Enabled) << RADIO_RXADDRESSES_ADDR0_Pos);
 	NRF_RADIO->PREFIX0 = aa[3];
-	NRF_RADIO->BASE0 = (aa[2] << 24) | (aa[1] << 16) | (aa[0] << 8);
+	NRF_RADIO->BASE0 = (((uint32_t) aa[2]) << 24) | (aa[1] << 16) | (aa[0] << 8);
 }
 
 void radio_pkt_configure(uint8_t bits_len, uint8_t max_len, uint8_t flags)


### PR DESCRIPTION
UBSan was showing the following error:

```
runtime error: left shift of 137 by 24 places cannot be represented in type 'int'
```

Cast the value to `uint32_t` to make UBSan happy.