### PR TITLE
soc: nordic: Fix undefined z_arm_platform_init

### DIFF
--- a/soc/nordic/CMakeLists.txt
+++ b/soc/nordic/CMakeLists.txt
@@ -2,7 +2,9 @@
 
 zephyr_library()
 
-set(SOC_LINKER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld CACHE INTERNAL "SoC Linker script")
+if(CONFIG_ARM)
+  set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/linker.ld CACHE INTERNAL "SoC Linker script")
+endif()
 
 zephyr_library_sources(
   validate_base_addresses.c

--- a/soc/nordic/common/CMakeLists.txt
+++ b/soc/nordic/common/CMakeLists.txt
@@ -3,6 +3,8 @@
 
 add_subdirectory_ifdef(CONFIG_RISCV_CORE_NORDIC_VPR vpr)
 
+zephyr_linker_sources_ifdef(CONFIG_ARM SECTIONS arm_platform_init.ld)
+
 zephyr_library_sources_ifdef(CONFIG_POWEROFF poweroff.c)
 
 zephyr_include_directories(.)

--- a/soc/nordic/common/arm_platform_init.ld
+++ b/soc/nordic/common/arm_platform_init.ld
@@ -4,16 +4,5 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#if defined(CONFIG_ARM)
-#include <zephyr/arch/arm/cortex_m/scripts/linker.ld>
-
 /* Let SystemInit() be called in place of z_arm_platform_init() by default. */
 PROVIDE(z_arm_platform_init = SystemInit);
-
-#elif defined(CONFIG_RISCV)
-#include <zephyr/arch/riscv/common/linker.ld>
-
-#else
-#error Unsupported architecture
-
-#endif

--- a/soc/nordic/common/vpr/CMakeLists.txt
+++ b/soc/nordic/common/vpr/CMakeLists.txt
@@ -4,3 +4,5 @@
 zephyr_include_directories(.)
 
 zephyr_library_sources(soc_idle.c soc_irq.S soc_irq.c vector.S)
+
+set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/riscv/common/linker.ld CACHE INTERNAL "")


### PR DESCRIPTION
Fixes #71511
Follow-up to #70977

Update the approach by moving the `PROVIDE` directive to a separate linker script added using `zephyr_linker_sources()`. This makes the change more likely to propagate to existing samples which are using CONFIG_CUSTOM_LINKER_SCRIPT.