### PR TITLE
UBSAN: Add macro to set attribute to disable it, and disable in a function with false positive

### DIFF
--- a/boards/native/nrf_bsim/common/bstests_entry.c
+++ b/boards/native/nrf_bsim/common/bstests_entry.c
@@ -74,7 +74,7 @@ static struct bst_test_instance *bst_test_find(struct bst_test_list *tests,
 	return NULL;
 }
 
-void bst_install_tests(void)
+__noubsan void bst_install_tests(void)
 {
 	int idx = 0;
 

--- a/include/zephyr/toolchain/gcc.h
+++ b/include/zephyr/toolchain/gcc.h
@@ -643,6 +643,12 @@ do {                                                                    \
 #define __noasan /**/
 #endif
 
+#if defined(CONFIG_UBSAN)
+#define __noubsan __attribute__((no_sanitize("undefined")))
+#else
+#define __noubsan
+#endif
+
 /**
  * @brief Function attribute to disable stack protector.
  *


### PR DESCRIPTION
    toolchain gcc: Provide a no UBSAN attribute macro
    
    Provide a macro to set the no undefined sanitizer
    attribute in symbols.
    To allow skipping its checks/modifications in symbols
    in which it is known to either cause trouble or report
    false positives.

--------

    boards: nrf*bsim: Disable ubsan in bst_install
    
    UBSAN reports a bogus error in this function:
    "load of address x with insufficient space for an
    object of type '<unknown> *'"
    as it seems unable to determine the size of
    test_installers.
    Let's disable this check in this function.

-----

Notes: the no_sanitize("undefined") attribute is not just a clang attribute, but has existed in gcc since at least v4.9.
About the bogus warning, I confirmed it is bogus both by checking the elf and that at runtime it was pointing to the right thing with the right content and size. Moreover, if the check would have detected a real error there, the code would have segfaulted right away, as it would be trying to call/jump into a garbage address.