### PR TITLE
arch: arm: cortex_m: fix incorrect conversion from ASM to C of cpu_idle operations.

### DIFF
--- a/arch/arm/core/cortex_m/cpu_idle.c
+++ b/arch/arm/core/cortex_m/cpu_idle.c
@@ -35,9 +35,13 @@ void z_arm_cpu_idle_init(void)
 
 #if defined(CONFIG_ARM_ON_ENTER_CPU_IDLE_HOOK)
 #define SLEEP_IF_ALLOWED(wait_instr) do { \
-	if (!z_arm_on_enter_cpu_idle()) { \
+	/* Skip the wait instr if on_enter_cpu_idle returns false */ \
+	if (z_arm_on_enter_cpu_idle()) { \
+		/* Wait for all memory transaction to complete */ \
+		/* before entering low power state. */ \
 		__DSB(); \
 		wait_instr(); \
+		/* Inline the macro provided by SoC-specific code */ \
 		ON_EXIT_IDLE_HOOK; \
 	} \
 } while (false)

--- a/arch/arm/core/cortex_m/cpu_idle.c
+++ b/arch/arm/core/cortex_m/cpu_idle.c
@@ -76,7 +76,7 @@ void arch_cpu_idle(void)
 	__disable_irq();
 
 	/*
-	 * Set wake-up interrupt priority to the lowest and synchronise to
+	 * Set wake-up interrupt priority to the lowest and synchronize to
 	 * ensure that this is visible to the WFI instruction.
 	 */
 	__set_BASEPRI(0);
@@ -91,10 +91,6 @@ void arch_cpu_idle(void)
 	 */
 #endif
 
-	/*
-	 * Wait for all memory transactions to complete before entering low
-	 * power state.
-	 */
 	SLEEP_IF_ALLOWED(__WFI);
 
 	__enable_irq();
@@ -122,11 +118,20 @@ void arch_cpu_atomic_idle(unsigned int key)
 	 * and never touched again.
 	 */
 
-	/*
-	 * Wait for all memory transactions to complete before entering low
-	 * power state.
-	 */
+#if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
+	/* No BASEPRI, call wfe directly. (SEVONPEND is set in z_arm_cpu_idle_init()) */
+#elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
+	/* unlock BASEPRI so wfe gets interrupted by incoming interrupts  */
+	__set_BASEPRI(0);
+	__ISB();
+#else
+#error Unsupported architecture
+#endif
+
 	SLEEP_IF_ALLOWED(__WFE);
 
 	arch_irq_unlock(key);
+#if defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
+	__enable_irq();
+#endif
 }


### PR DESCRIPTION
This mistake was introduced when converting from ASM to C.

The logic related to enterring sleep was swap.
Several irq masking/unmasking operations were also missing.

This change also restores the associated comment from the ASM source.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/71596