### PR TITLE
boards: nordic: nrf54l15pdk: fix flashing for `CPUFLPR_XIP`

### DIFF
--- a/boards/nordic/nrf54l15pdk/board.cmake
+++ b/boards/nordic/nrf54l15pdk/board.cmake
@@ -1,9 +1,9 @@
 # Copyright (c) 2024 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-if (CONFIG_BOARD_NRF54L15PDK_NRF54L15_CPUAPP)
+if (CONFIG_SOC_NRF54L15_ENGA_CPUAPP)
   board_runner_args(jlink "--device=cortex-m33" "--speed=4000")
-elseif (CONFIG_BOARD_NRF54L15PDK_NRF54L15_CPUFLPR)
+elseif (CONFIG_SOC_NRF54L15_ENGA_CPUFLPR)
   board_runner_args(jlink "--speed=4000")
 endif()
 


### PR DESCRIPTION
`board.cmake` specified runner arguments only for the RAM-based variant, use SOC config to support both:
`CONFIG_BOARD_NRF54L15PDK_NRF54L15_CPUFLPR` and
`CONFIG_BOARD_NRF54L15PDK_NRF54L15_CPUFLPR_XIP`.
Also align ARM target so it looks nice.