### PR TITLE
boards: nordic: nrf54l15pdk: enable HWFC

### DIFF
--- a/boards/nordic/nrf54l15pdk/nrf54l15pdk_nrf54l15_cpuapp.dts
+++ b/boards/nordic/nrf54l15pdk/nrf54l15pdk_nrf54l15_cpuapp.dts
@@ -80,6 +80,7 @@
 
 &uart20 {
 	status = "okay";
+	hw-flow-control;
 };
 
 &gpio0 {

--- a/boards/nordic/nrf54l15pdk/nrf54l15pdk_nrf54l15_cpuflpr.dts
+++ b/boards/nordic/nrf54l15pdk/nrf54l15pdk_nrf54l15_cpuflpr.dts
@@ -48,6 +48,7 @@
 
 &uart30 {
 	status = "okay";
+	hw-flow-control;
 };
 
 &gpio0 {


### PR DESCRIPTION
For both UARTs connected to debugger chip.