### PR TITLE
scripts/checkpatch: Improve blank line check after declarations

### DIFF
--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -3544,7 +3544,7 @@ sub process {
 			# known declaration macros
 		      $sline =~ /^\+\s+$declaration_macros/ ||
 			# start of struct or union or enum
-		      $sline =~ /^\+\s+(?:static\s+)?(?:const\s+)?(?:union|struct|enum|typedef)\b/ ||
+		      $sline =~ /^\+\s+(?:volatile\s+)?(?:static\s+)?(?:const\s+)?(?:union|struct|enum|typedef)\b/ ||
 			# start or end of block or continuation of declaration
 		      $sline =~ /^\+\s+(?:$|[\{\}\.\#\"\?\:\(\[])/ ||
 			# bitfield continuation


### PR DESCRIPTION
This adds `volatile` type qualifier to the struct declaration matching when looking for blank line after declarations.

Before this commit, this structure was not accepted by checkpatch:
```
  struct cfg {
         struct gpio_driver_config common;
         volatile struct grgpio_regs *regs;
         int interrupt;
  };
```

checkpatch.pl generated the following warning:
```
  -:158: WARNING:LINE_SPACING: Missing a blank line after declarations
  #158: FILE: drivers/gpio/gpio_grgpio2.c:27:
  +	struct gpio_driver_config common;
  +	volatile struct grgpio_regs *regs;
```

With this commit, the warning is no longer generated.

This fixes a compliance check failure in #65818.