### PR TITLE
samples: mbox_data: Repair mbox-consumer in dt

### DIFF
--- a/samples/drivers/mbox_data/remote/boards/lpcxpresso55s69_lpc55s69_cpu1.overlay
+++ b/samples/drivers/mbox_data/remote/boards/lpcxpresso55s69_lpc55s69_cpu1.overlay
@@ -29,7 +29,7 @@
 
 	mbox-consumer {
 		compatible = "vnd,mbox-consumer";
-		mboxes = <&mbox 2>, <&mbox 3>;
+		mboxes = <&mbox 3>, <&mbox 2>;
 		mbox-names = "tx", "rx";
 	};
 };

--- a/samples/drivers/mbox_data/remote/boards/mimxrt1160_evk_mimxrt1166_cm4.overlay
+++ b/samples/drivers/mbox_data/remote/boards/mimxrt1160_evk_mimxrt1166_cm4.overlay
@@ -43,7 +43,7 @@
 
 	mbox-consumer {
 		compatible = "vnd,mbox-consumer";
-		mboxes = <&mbox 3>, <&mbox 2>;
+		mboxes = <&mbox 2>, <&mbox 3>;
 		mbox-names = "tx", "rx";
 	};
 };

--- a/samples/drivers/mbox_data/remote/boards/mimxrt1170_evk_mimxrt1176_cm4.overlay
+++ b/samples/drivers/mbox_data/remote/boards/mimxrt1170_evk_mimxrt1176_cm4.overlay
@@ -43,7 +43,7 @@
 
 	mbox-consumer {
 		compatible = "vnd,mbox-consumer";
-		mboxes = <&mbox 3>, <&mbox 2>;
+		mboxes = <&mbox 2>, <&mbox 3>;
 		mbox-names = "tx", "rx";
 	};
 };

--- a/samples/drivers/mbox_data/remote/boards/mimxrt1170_evk_mimxrt1176_cm4_B.overlay
+++ b/samples/drivers/mbox_data/remote/boards/mimxrt1170_evk_mimxrt1176_cm4_B.overlay
@@ -43,7 +43,7 @@
 
 	mbox-consumer {
 		compatible = "vnd,mbox-consumer";
-		mboxes = <&mbox 3>, <&mbox 2>;
+		mboxes = <&mbox 2>, <&mbox 3>;
 		mbox-names = "tx", "rx";
 	};
 };


### PR DESCRIPTION
This commit repairs mbox-consumer to corectly select rx and tx channel.