### PR TITLE
boards: frdm_mcxn947: Add clock setup for FlexSPI

### DIFF
--- a/boards/nxp/frdm_mcxn947/board.c
+++ b/boards/nxp/frdm_mcxn947/board.c
@@ -4,6 +4,7 @@
  */
 #include <zephyr/init.h>
 #include <zephyr/device.h>
+#include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
 #include <fsl_clock.h>
 #include <fsl_spc.h>
 #include <soc.h>
@@ -189,6 +190,14 @@ static int frdm_mcxn947_init(void)
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(ctimer4), okay)
 	CLOCK_SetClkDiv(kCLOCK_DivCtimer4Clk, 1U);
 	CLOCK_AttachClk(kPLL0_to_CTIMER4);
+#endif
+
+#if CONFIG_FLASH_MCUX_FLEXSPI_NOR
+	/* We downclock the FlexSPI to 50MHz, it will be set to the
+	 * optimum speed supported by the Flash device during FLEXSPI
+	 * Init
+	 */
+	flexspi_clock_set_freq(MCUX_FLEXSPI_CLK, MHZ(50));
 #endif
 
 	/* Set SystemCoreClock variable. */


### PR DESCRIPTION
The MEMC driver is initialized before the FlexSPI driver and hangs during FlexSPI init. Initialize the FlexSPI clock to 50MHz before the speed is set to the optimum speed by the FlexSPI driver.