### PR TITLE
tests/fs: Add missing native_sim_native_64.overlays

### DIFF
--- a/tests/subsys/fs/ext2/boards/native_sim_native_64.overlay
+++ b/tests/subsys/fs/ext2/boards/native_sim_native_64.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "native_sim.overlay"

--- a/tests/subsys/fs/littlefs/boards/native_sim_native_64.overlay
+++ b/tests/subsys/fs/littlefs/boards/native_sim_native_64.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "native_sim.overlay"


### PR DESCRIPTION
Prevent native_sim/native/64 platforms from failing at build.