### PR TITLE
tests/drivers/flash_simulator: 64bit native_sim/native_posix overlays

### DIFF
--- a/tests/drivers/flash_simulator/boards/native_posix_native_64.overlay
+++ b/tests/drivers/flash_simulator/boards/native_posix_native_64.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "native_posix.overlay"

--- a/tests/drivers/flash_simulator/boards/native_sim_native_64.overlay
+++ b/tests/drivers/flash_simulator/boards/native_sim_native_64.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "native_sim.overlay"


### PR DESCRIPTION
Added missing overlays for native_sim/native/64
and native_posix/native/64 platforms.