### PR TITLE
scripts: west_commands: runners: Add support for probe-rs

### DIFF
--- a/boards/common/probe-rs.board.cmake
+++ b/boards/common/probe-rs.board.cmake
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+
+board_set_flasher_ifnset(probe-rs)
+board_finalize_runner_args(probe-rs)

--- a/boards/st/nucleo_f030r8/board.cmake
+++ b/boards/st/nucleo_f030r8/board.cmake
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(jlink "--device=STM32F030R8" "--speed=4000")
+board_runner_args(probe-rs "--chip=STM32F030R8Tx")
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/probe-rs.board.cmake)

--- a/doc/develop/flash_debug/host-tools.rst
+++ b/doc/develop/flash_debug/host-tools.rst
@@ -460,6 +460,17 @@ afterwards detach the debug session:
 
    west debug --tool-opt='--batch'
 
+probe-rs Debug Host Tools
+*************************
+
+probe-rs is an open-source embedded toolkit written in Rust. It provides
+out-of-the-box support for a variety of debug probes, including CMSIS-DAP,
+ST-Link, SEGGER J-Link, FTDI and built-in USB-JTAG interface on ESP32 devices.
+
+Check `probe-rs Installation`_ for more setup details.
+
+Check if your SoC is listed in `probe-rs Supported Devices`_.
+
 .. _J-Link Software and Documentation Pack:
    https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack
 
@@ -504,3 +515,9 @@ afterwards detach the debug session:
 
 .. _S32 Design Studio for S32 Platform Installation User Guide:
    https://www.nxp.com/webapp/Download?colCode=S32DSIG
+
+.. _probe-rs Installation:
+   https://probe.rs/docs/getting-started/installation/
+
+.. _probe-rs Supported Devices:
+   https://probe.rs/targets/

--- a/scripts/west_commands/runners/__init__.py
+++ b/scripts/west_commands/runners/__init__.py
@@ -47,6 +47,7 @@ _names = [
     'nsim',
     'nxp_s32dbg',
     'openocd',
+    'probe_rs',
     'pyocd',
     'qemu',
     'silabs_commander',

--- a/scripts/west_commands/runners/probe_rs.py
+++ b/scripts/west_commands/runners/probe_rs.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2024 Chen Xingyu <hi@xingrz.me>
+# SPDX-License-Identifier: Apache-2.0
+
+'''Runner for probe-rs.'''
+
+from runners.core import ZephyrBinaryRunner, RunnerCaps
+
+
+class ProbeRsBinaryRunner(ZephyrBinaryRunner):
+    '''Runner front-end for probe-rs.'''
+
+    def __init__(self, cfg, chip,
+                 probe_rs='probe-rs',
+                 dev_id=None,
+                 erase=False,
+                 tool_opt=None):
+        super().__init__(cfg)
+
+        self.probe_rs = probe_rs
+        self.erase = erase
+
+        self.args = ['--chip', chip]
+
+        if dev_id is not None:
+            self.args += ['--probe', dev_id]
+
+        if tool_opt is not None:
+            self.args += tool_opt
+
+        self.elf_name = cfg.elf_file
+
+    @classmethod
+    def name(cls):
+        return 'probe-rs'
+
+    @classmethod
+    def capabilities(cls):
+        return RunnerCaps(commands={'flash'},
+                          dev_id=True,
+                          erase=True,
+                          tool_opt=True)
+
+    @classmethod
+    def do_add_parser(cls, parser):
+        parser.add_argument('--chip', required=True,
+                            help='chip name')
+        parser.add_argument('--probe-rs', default='probe-rs',
+                            help='path to probe-rs tool, default is probe-rs')
+
+    @classmethod
+    def dev_id_help(cls) -> str:
+        return '''select a specific probe, in the form `VID:PID:<Serial>`'''
+
+    @classmethod
+    def tool_opt_help(cls) -> str:
+        return '''additional options for probe-rs,
+                  e.g. --chip-description-path=/path/to/chip.yml'''
+
+    @classmethod
+    def do_create(cls, cfg, args):
+        return ProbeRsBinaryRunner(cfg, args.chip,
+                                   probe_rs=args.probe_rs,
+                                   dev_id=args.dev_id,
+                                   erase=args.erase,
+                                   tool_opt=args.tool_opt)
+
+    def do_run(self, command, **kwargs):
+        self.require(self.probe_rs)
+        if command == 'flash':
+            self.do_flash(**kwargs)
+
+    def do_flash(self, **kwargs):
+        download_args = []
+        if self.erase:
+            download_args += ['--chip-erase']
+        download_args += [self.elf_name]
+
+        self.check_call([self.probe_rs, 'download']
+                        + self.args + download_args)
+
+        self.check_call([self.probe_rs, 'reset']
+                        + self.args)

--- a/scripts/west_commands/tests/test_imports.py
+++ b/scripts/west_commands/tests/test_imports.py
@@ -37,6 +37,7 @@ def test_runner_imports():
                     'nrfutil',
                     'nxp_s32dbg',
                     'openocd',
+                    'probe-rs',
                     'pyocd',
                     'qemu',
                     'silabs_commander',


### PR DESCRIPTION
[probe-rs](https://probe.rs/) is a new programming and debugging tool written in Rust, supports many probes and targets.

This PR introduces initial support for probe-rs to Zephyr.