### PR TITLE
twister: Make --list-tests respect tag filter

### DIFF
--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -349,13 +349,13 @@ class TestPlan:
             print("- {}".format(t))
 
     def report_test_tree(self):
-        all_tests = self.get_all_tests()
+        tests_list = self.get_tests_list()
 
         testsuite = Node("Testsuite")
         samples = Node("Samples", parent=testsuite)
         tests = Node("Tests", parent=testsuite)
 
-        for test in sorted(all_tests):
+        for test in sorted(tests_list):
             if test.startswith("sample."):
                 sec = test.split(".")
                 area = find(samples, lambda node: node.name == sec[1] and node.parent == samples)
@@ -379,13 +379,12 @@ class TestPlan:
             print("%s%s" % (pre, node.name))
 
     def report_test_list(self):
-        cnt = 0
-        all_tests = self.get_all_tests()
+        tests_list = self.get_tests_list()
 
-        for test in sorted(all_tests):
+        cnt = 0
+        for test in sorted(tests_list):
             cnt = cnt + 1
             print(" - {}".format(test))
-
         print("{} total.".format(cnt))
 
     def config(self):
@@ -479,6 +478,26 @@ class TestPlan:
             for case in ts.testcases:
                 testcases.append(case.name)
 
+        return testcases
+
+    def get_tests_list(self):
+        testcases = []
+        if tag_filter := self.options.tag:
+            for _, ts in self.testsuites.items():
+                if ts.tags.intersection(tag_filter):
+                    for case in ts.testcases:
+                        testcases.append(case.name)
+        else:
+            for _, ts in self.testsuites.items():
+                for case in ts.testcases:
+                    testcases.append(case.name)
+
+        if exclude_tag := self.options.exclude_tag:
+            for _, ts in self.testsuites.items():
+                if ts.tags.intersection(exclude_tag):
+                    for case in ts.testcases:
+                        if case.name in testcases:
+                            testcases.remove(case.name)
         return testcases
 
     def add_testsuites(self, testsuite_filter=[]):

--- a/scripts/tests/twister/test_testplan.py
+++ b/scripts/tests/twister/test_testplan.py
@@ -964,7 +964,7 @@ def test_testplan_report_tag_list(capfd):
 
 def test_testplan_report_test_tree(capfd):
     testplan = TestPlan(env=mock.Mock())
-    testplan.get_all_tests = mock.Mock(
+    testplan.get_tests_list = mock.Mock(
         return_value=['1.dummy.case.1', '1.dummy.case.2',
                       '2.dummy.case.1', '2.dummy.case.2',
                       '3.dummy.case.1', '3.dummy.case.2',
@@ -1022,7 +1022,7 @@ Testsuite
 
 def test_testplan_report_test_list(capfd):
     testplan = TestPlan(env=mock.Mock())
-    testplan.get_all_tests = mock.Mock(
+    testplan.get_tests_list = mock.Mock(
         return_value=['4.dummy.case.1', '4.dummy.case.2',
                       '3.dummy.case.2', '2.dummy.case.2',
                       '1.dummy.case.1', '1.dummy.case.2',


### PR DESCRIPTION
Make the --list-tests option output respect the --tag options, so that only the tests for the specified tags are listed.