### PR TITLE
west.yml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -282,7 +282,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 24ac8cc2be9384288829aac7477f522a7a71f3d4
+      revision: 78bfe750cde0f8dfcf81bb4c0a68243d45906def
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  78bfe750cde0f8dfcf81bb4c0a68243d45906def

(MCUboot `v2.1.0-rc1` tagged release)

Brings following Zephyr relevant fixes:
  - 73315f7b bootutil: Fix memory leak in HKDF implementation
  - 453096b1 zephyr: arm: Update reading the flash image reset vector
  - 14961292 boot: zephyr: Add optional MCUboot boot banner
  - 7174dd2b boot: zephyr: boards: actinius: enable multithreading
    in config
  - 556b32a6 boot: Removed unnecessary if-statement
  - da2e2ab4 boot: Enforce TLV entries to be protected
  - ea1cdfde boot: Add tlv query for protected region
  - 8c0e36c8 boot: zephyr: esp32: rename boards to meet hwmv2
  - f06bc711 bootutil/crypto: Builtin ECDSA key support for PSA
    Crypto backend
  - e369784b bootutil: Allow the usage of builtin keys in
    verification
  - c5a528ba New OVERWRITE_ONLY_KEEP_BACKUP option

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.