### PR TITLE
tests: drivers: counter: counter_basic_api: Add nrf54h20 support

### DIFF
--- a/tests/drivers/counter/counter_basic_api/boards/nrf54h20dk_nrf54h20_common.dtsi
+++ b/tests/drivers/counter/counter_basic_api/boards/nrf54h20dk_nrf54h20_common.dtsi
@@ -1,0 +1,60 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+&timer120 {
+	status = "okay";
+	prescaler = <7>;
+};
+
+&timer121 {
+	status = "okay";
+	prescaler = <7>;
+};
+
+&timer130 {
+	status = "okay";
+	prescaler = <4>;
+};
+
+&timer131 {
+	status = "okay";
+	prescaler = <4>;
+};
+
+&timer132 {
+	status = "okay";
+	prescaler = <4>;
+};
+
+&timer133 {
+	status = "okay";
+	prescaler = <4>;
+};
+
+&timer134 {
+	status = "okay";
+	prescaler = <4>;
+};
+
+&timer135 {
+	status = "okay";
+	prescaler = <4>;
+};
+
+&timer136 {
+	status = "okay";
+	prescaler = <4>;
+};
+
+&timer137 {
+	status = "okay";
+	prescaler = <4>;
+};
+
+&rtc130 {
+	status = "okay";
+	ppi-wrap;
+};
+
+&rtc131 {
+	status = "okay";
+};

--- a/tests/drivers/counter/counter_basic_api/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "nrf54h20dk_nrf54h20_common.dtsi"

--- a/tests/drivers/counter/counter_basic_api/boards/nrf54h20dk_nrf54h20_cpurad.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/nrf54h20dk_nrf54h20_cpurad.overlay
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "nrf54h20dk_nrf54h20_common.dtsi"
+
+&timer020 {
+	status = "okay";
+	prescaler = <7>;
+};
+
+&timer021 {
+	status = "okay";
+	prescaler = <7>;
+};
+
+&timer022 {
+	status = "okay";
+	prescaler = <7>;
+};
+
+&rtc {
+	status = "okay";
+};

--- a/tests/drivers/counter/counter_nrf_rtc/fixed_top/boards/nrf54h20dk_nrf54h20_common.dtsi
+++ b/tests/drivers/counter/counter_nrf_rtc/fixed_top/boards/nrf54h20dk_nrf54h20_common.dtsi
@@ -1,0 +1,11 @@
+ /* SPDX-License-Identifier: Apache-2.0 */
+
+&rtc130 {
+	status = "okay";
+	fixed-top;
+};
+
+&rtc131 {
+	status = "okay";
+	fixed-top;
+};

--- a/tests/drivers/counter/counter_nrf_rtc/fixed_top/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/counter/counter_nrf_rtc/fixed_top/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "nrf54h20dk_nrf54h20_common.dtsi"

--- a/tests/drivers/counter/counter_nrf_rtc/fixed_top/boards/nrf54h20dk_nrf54h20_cpurad.overlay
+++ b/tests/drivers/counter/counter_nrf_rtc/fixed_top/boards/nrf54h20dk_nrf54h20_cpurad.overlay
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "nrf54h20dk_nrf54h20_common.dtsi"
+
+&rtc {
+	status = "okay";
+	fixed-top;
+};


### PR DESCRIPTION
Add overlays for nrf54h20dk cpuapp and cpurad.