### PR TITLE
soc: st: stm32: adding option to enable prefetch buffer

### DIFF
--- a/soc/st/stm32/Kconfig
+++ b/soc/st/stm32/Kconfig
@@ -47,6 +47,9 @@ config SWJ_ANALOG_PRIORITY
 	  This priority must be greater than GPIO_INIT_PRIORITY and lower than
 	  UART_INIT_PRIORITY.
 
+config STM32_FLASH_PREFETCH
+	bool "Flash prefetch buffer"
+
 choice POWER_SUPPLY_CHOICE
 	prompt "STM32 power supply configuration"
 	default POWER_SUPPLY_LDO

--- a/soc/st/stm32/stm32wbax/Kconfig.defconfig
+++ b/soc/st/stm32/stm32wbax/Kconfig.defconfig
@@ -10,6 +10,9 @@ rsource "Kconfig.defconfig.stm32wba*"
 config STM32_LPTIM_TIMER
 	default y if PM
 
+config STM32_FLASH_PREFETCH
+	default y
+
 choice BT_HCI_BUS_TYPE
 	default BT_STM32WBA
 	depends on BT

--- a/soc/st/stm32/stm32wbax/soc.c
+++ b/soc/st/stm32/stm32wbax/soc.c
@@ -37,6 +37,9 @@ int stm32wba_init(void)
 	/* Enable instruction cache in 1-way (direct mapped cache) */
 	LL_ICACHE_SetMode(LL_ICACHE_1WAY);
 	LL_ICACHE_Enable();
+#ifdef CONFIG_STM32_FLASH_PREFETCH
+	__HAL_FLASH_PREFETCH_BUFFER_ENABLE();
+#endif
 
 	/* Update CMSIS SystemCoreClock variable (HCLK) */
 	/* At reset, system core clock is set to 16 MHz from HSI */


### PR DESCRIPTION

For more effective code execution on STM32 devices is convenient to enable flash prefetch buffer. To be enabled by default, possible to disable using kconfig.