### PR TITLE
fs: ext2: Use native_sim overlay in native_sim/native/64

### DIFF
--- a/tests/subsys/fs/ext2/boards/native_sim_native_64.overlay
+++ b/tests/subsys/fs/ext2/boards/native_sim_native_64.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2024 Antmicro
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+#include "native_sim.overlay"


### PR DESCRIPTION
This resolves problems with building filesystem.ext2.flash test in #71205. Adding an overlay providing `storage_disk` required by the test.