### PR TITLE
ipc_service: backends: icbmsg: Silence maybe-uninitialized warning

### DIFF
--- a/subsys/ipc/ipc_service/backends/ipc_icbmsg.c
+++ b/subsys/ipc/ipc_service/backends/ipc_icbmsg.c
@@ -461,7 +461,7 @@ static int release_tx_buffer(struct backend_data *dev_data, const uint8_t *buffe
 			     int new_size)
 {
 	const struct icbmsg_config *conf = dev_data->conf;
-	size_t size;
+	size_t size = 0;
 	int tx_block_index;
 
 	tx_block_index = buffer_to_index_validate(&conf->tx, buffer, &size);


### PR DESCRIPTION
If compiling with optimizations (-O2/-Ofast) gcc emits a maybe-uninitialized warning for `size`.

As far as I can tell, `size` will always be initialized in the cases where it is used and only left uninitialized in error cases.

Reproduced on main with the multi_endpoint sample on nrf5340dk/nrf5340/cpuapp.

---

Reproducing on main (1c3edca8d89c7f66d2c0c0f5bec631517a6fe468):
```
west build -b nrf5340dk/nrf5340/cpuapp samples/subsys/ipc/ipc_service/multi_endpoint -- -DDTC_OVERLAY_FILE=boards/nrf5340dk_nrf5340_cpuapp_icbmsg.overlay -DCONFIG_COMPILER_OPT='"-O2 -Werror"'
[...]
[3/9] Building C object zephyr/CMakeFiles/zephyr.dir/subsys/ipc/ipc_service/backends/ipc_icbmsg.c.obj
FAILED: zephyr/CMakeFiles/zephyr.dir/subsys/ipc/ipc_service/backends/ipc_icbmsg.c.obj 
ccache /home/herman/zephyr-sdk-0.16.4/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc -DKERNEL -DK_HEAP_MEM_POOL_SIZE=0 -DNRF5340_XXAA_APPLICATION -DNRF_SKIP_FICR_NS_COPY_TO_RAM -DPICOLIBC_LONG_LONG_PRINTF_SCANF -D__LINUX_ERRNO_EXTENSIONS__ -D__PROGRAM_START -D__ZEPHYR__=1 -I/home/herman/repos/ncs/zephyr/kernel/include -I/home/herman/repos/ncs/zephyr/arch/arm/include -I/home/herman/repos/ncs/zephyr/include -I/home/herman/repos/ncs/zephyr/build/zephyr/include/generated -I/home/herman/repos/ncs/zephyr/soc/nordic -I/home/herman/repos/ncs/zephyr/soc/nordic/nrf53/. -I/home/herman/repos/ncs/zephyr/soc/nordic/common/. -I/home/herman/repos/ncs/modules/hal/cmsis/CMSIS/Core/Include -I/home/herman/repos/ncs/zephyr/modules/cmsis/. -I/home/herman/repos/ncs/modules/hal/nordic/nrfx -I/home/herman/repos/ncs/modules/hal/nordic/nrfx/drivers/include -I/home/herman/repos/ncs/modules/hal/nordic/nrfx/mdk -I/home/herman/repos/ncs/zephyr/modules/hal_nordic/nrfx/. -isystem /home/herman/repos/ncs/zephyr/lib/libc/common/include -fno-strict-aliasing -Os -imacros /home/herman/repos/ncs/zephyr/build/zephyr/include/generated/autoconf.h -fno-printf-return-value -fno-common -g -gdwarf-4 -fdiagnostics-color=always -mcpu=cortex-m33 -mthumb -mabi=aapcs -mfp16-format=ieee -mtp=soft --sysroot=/home/herman/zephyr-sdk-0.16.4/arm-zephyr-eabi/arm-zephyr-eabi -imacros /home/herman/repos/ncs/zephyr/include/zephyr/toolchain/zephyr_stdint.h -Wall -Wformat -Wformat-security -Wno-format-zero-length -Wdouble-promotion -Wno-pointer-sign -Wpointer-arith -Wexpansion-to-defined -Wno-unused-but-set-variable -Werror=implicit-int -fno-pic -fno-pie -fno-asynchronous-unwind-tables -ftls-model=local-exec -O2 -Werror -fno-reorder-functions --param=min-pagesize=0 -fno-defer-pop -fmacro-prefix-map=/home/herman/repos/ncs/zephyr/samples/subsys/ipc/ipc_service/multi_endpoint=CMAKE_SOURCE_DIR -fmacro-prefix-map=/home/herman/repos/ncs/zephyr=ZEPHYR_BASE -fmacro-prefix-map=/home/herman/repos/ncs=WEST_TOPDIR -ffunction-sections -fdata-sections --specs=picolibc.specs -std=c99 -MD -MT zephyr/CMakeFiles/zephyr.dir/subsys/ipc/ipc_service/backends/ipc_icbmsg.c.obj -MF zephyr/CMakeFiles/zephyr.dir/subsys/ipc/ipc_service/backends/ipc_icbmsg.c.obj.d -o zephyr/CMakeFiles/zephyr.dir/subsys/ipc/ipc_service/backends/ipc_icbmsg.c.obj -c /home/herman/repos/ncs/zephyr/subsys/ipc/ipc_service/backends/ipc_icbmsg.c
/home/herman/repos/ncs/zephyr/subsys/ipc/ipc_service/backends/ipc_icbmsg.c: In function 'release_tx_buffer':
/home/herman/repos/ncs/zephyr/subsys/ipc/ipc_service/backends/ipc_icbmsg.c:472:16: error: 'size' may be used uninitialized [-Werror=maybe-uninitialized]
  472 |         return release_tx_blocks(dev_data, tx_block_index, size, new_size);
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/herman/repos/ncs/zephyr/subsys/ipc/ipc_service/backends/ipc_icbmsg.c:464:16: note: 'size' was declared here
  464 |         size_t size;
      |                ^~~~
cc1: all warnings being treated as errors
ninja: build stopped: subcommand failed.
```



