### PR TITLE
boards: nxp: Switch the rest from Swap-Scratch to Swap-Move

### DIFF
--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
@@ -92,18 +92,18 @@
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
 		};
+		/* Note slot 0 has one additional sector,
+		 * this is intended for use with the swap move algorithm
+		 */
 		slot0_partition: partition@10000 {
 			label = "image-0";
-			reg = <0x00010000 DT_SIZE_K(960)>;
+			reg = <0x00010000 DT_SIZE_K(992)>;
 		};
 		slot1_partition: partition@100000 {
 			label = "image-1";
-			reg = <0x00100000 DT_SIZE_K(960)>;
+			reg = <0x00108000 DT_SIZE_K(984)>;
 		};
-		scratch_partition: partition@1f0000 {
-			label = "image-scratch";
-			reg = <0x001f0000 DT_SIZE_K(64)>;
-		};
+		/* storage_partition is placed in WINBOND flash memory*/
 	};
 };
 

--- a/boards/nxp/hexiwear/hexiwear_mk64f12.dts
+++ b/boards/nxp/hexiwear/hexiwear_mk64f12.dts
@@ -186,24 +186,20 @@
 			reg = <0x00000000 0x00010000>;
 			read-only;
 		};
-
-		/*
-		 * The flash starting at 0x00010000 and ending at
-		 * 0x0001ffff (sectors 16-31) is reserved for use
-		 * by the application.
+		/* Note slot 0 has one additional sector,
+		 * this is intended for use with the swap move algorithm
 		 */
-
-		slot0_partition: partition@20000 {
+		slot0_partition: partition@10000 {
 			label = "image-0";
-			reg = <0x00020000 0x00060000>;
+			reg = <0x00010000 0x00069000>;
 		};
-		slot1_partition: partition@80000 {
+		slot1_partition: partition@79000 {
 			label = "image-1";
-			reg = <0x00080000 0x00060000>;
+			reg = <0x00079000 0x00068000>;
 		};
-		scratch_partition: partition@e0000 {
-			label = "image-scratch";
-			reg = <0x000e0000 0x00020000>;
+		storage_partition: partition@e1000 {
+			label = "storage";
+			reg = <0x000e1000 0x0001f000>;
 		};
 	};
 };

--- a/boards/nxp/rddrone_fmuk66/rddrone_fmuk66.dts
+++ b/boards/nxp/rddrone_fmuk66/rddrone_fmuk66.dts
@@ -237,28 +237,20 @@ zephyr_udc0: &usbotg {
 			reg = <0x00000000 0x00010000>;
 			read-only;
 		};
-
-		/*
-		 * The flash starting at 0x00010000 and ending at
-		 * 0x0001ffff (sectors 16-31) is reserved for use
-		 * by the application.
+		/* Note slot 0 has one additional sector,
+		 * this is intended for use with the swap move algorithm
 		 */
-		storage_partition: partition@1e000 {
-			label = "storage";
-			reg = <0x0001e000 0x00002000>;
-		};
-
-		slot0_partition: partition@20000 {
+		slot0_partition: partition@10000 {
 			label = "image-0";
-			reg = <0x00020000 0x00060000>;
+			reg = <0x00010000 0x000E9000>;
 		};
-		slot1_partition: partition@80000 {
+		slot1_partition: partition@F9000 {
 			label = "image-1";
-			reg = <0x00080000 0x00060000>;
+			reg = <0x000F9000 0x000E8000>;
 		};
-		scratch_partition: partition@e0000 {
-			label = "image-scratch";
-			reg = <0x000e0000 0x00020000>;
+		storage_partition: partition@1e1000 {
+			label = "storage";
+			reg = <0x001e1000 0x0001f000>;
 		};
 	};
 };

--- a/boards/nxp/twr_ke18f/twr_ke18f.dts
+++ b/boards/nxp/twr_ke18f/twr_ke18f.dts
@@ -339,21 +339,20 @@
 			label = "mcuboot";
 			reg = <0x00000000 0xc000>;
 		};
+		/* Note slot 0 has one additional sector,
+		 * this is intended for use with the swap move algorithm
+		 */
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000c000 0x32000>;
+			reg = <0x0000c000 0x37000>;
 		};
-		slot1_partition: partition@3e000 {
+		slot1_partition: partition@43000 {
 			label = "image-1";
-			reg = <0x0003e000 0x32000>;
+			reg = <0x00043000 0x36000>;
 		};
-		scratch_partition: partition@70000 {
-			label = "image-scratch";
-			reg = <0x00070000 0xa000>;
-		};
-		storage_partition: partition@7a000 {
+		storage_partition: partition@79000 {
 			label = "storage";
-			reg = <0x0007a000 0x00006000>;
+			reg = <0x00079000 0x00007000>;
 		};
 	};
 };

--- a/boards/nxp/twr_kv58f220m/twr_kv58f220m.dts
+++ b/boards/nxp/twr_kv58f220m/twr_kv58f220m.dts
@@ -118,21 +118,20 @@
 			label = "mcuboot";
 			reg = <0x00000000 0x10000>;
 		};
-		storage_partition: partition@10000 {
-			label = "storage";
-			reg = <0x00010000 0x10000>;
-		};
-		slot0_partition: partition@20000 {
+		/* Note slot 0 has one additional sector,
+		 * this is intended for use with the swap move algorithm
+		 */
+		slot0_partition: partition@10000 {
 			label = "image-0";
-			reg = <0x00020000 0x60000>;
+			reg = <0x00010000 0x68000>;
 		};
-		slot1_partition: partition@80000 {
+		slot1_partition: partition@78000 {
 			label = "image-1";
-			reg = <0x00080000 0x60000>;
+			reg = <0x00078000 0x66000>;
 		};
-		scratch_partition: partition@e0000 {
+		storage_partition: partition@de000 {
 			label = "image-scratch";
-			reg = <0x000e0000 0x20000>;
+			reg = <0x000de000 0x22000>;
 		};
 	};
 };


### PR DESCRIPTION
Switch the default MCUBoot FW Update mode from Swap & Scratch to more preferable Swap & Move for the rest of NXP boards. Delete the scratch partition. Save RAM & ROM.
Slot 0 has one additional sector, for use with
the swap move algorithm.