### PR TITLE
drivers/timer grtc: Fix for ISR prototype

### DIFF
--- a/drivers/timer/nrf_grtc_timer.c
+++ b/drivers/timer/nrf_grtc_timer.c
@@ -492,7 +492,8 @@ static int sys_clock_driver_init(void)
 	nrfy_grtc_waketime_set(NRF_GRTC, WAKETIME);
 #endif /* CONFIG_NRF_GRTC_START_SYSCOUNTER */
 
-	IRQ_CONNECT(DT_IRQN(GRTC_NODE), DT_IRQ(GRTC_NODE, priority), nrfx_grtc_irq_handler, 0, 0);
+	IRQ_CONNECT(DT_IRQN(GRTC_NODE), DT_IRQ(GRTC_NODE, priority), nrfx_isr,
+		    nrfx_grtc_irq_handler, 0);
 
 	err_code = nrfx_grtc_init(0);
 	if (err_code != NRFX_SUCCESS) {


### PR DESCRIPTION
Interrupt handlers are expected to have a pototype void (const void*)
but nrfx_grtc_irq_handler has just a void(void)
(with no input parameter).
Fix it by using a trampoline.

Avoids build warning:
_note: expected ‘void (*)(const void *)’ but argument is of type ‘void (*)(void)’_