### PR TITLE
Bluetooth: conn: Don't wait for buf allocation in syswq

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1471,6 +1471,12 @@ struct net_buf *bt_conn_create_pdu_timeout(struct net_buf_pool *pool,
 	 */
 	__ASSERT_NO_MSG(!k_is_in_isr());
 
+	if (!K_TIMEOUT_EQ(timeout, K_NO_WAIT) &&
+	    k_current_get() == k_work_queue_thread_get(&k_sys_work_q)) {
+		LOG_DBG("Timeout discarded. No blocking in syswq.");
+		timeout = K_NO_WAIT;
+	}
+
 	if (!pool) {
 #if defined(CONFIG_BT_CONN)
 		pool = &acl_tx_pool;


### PR DESCRIPTION
We can't just keep blocking the syswq, people be mad. Override the timeout value so we always have K_NO_WAIT. Also print a message to whomever's listening.