### PR TITLE
arch: arm: Add hook called when exiting CPU idle state

### DIFF
--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -53,6 +53,18 @@ config ARM_ON_ENTER_CPU_IDLE_HOOK
 	  If needed, this hook can be used to prevent the CPU from actually
 	  entering sleep by skipping the WFE/WFI instruction.
 
+config ARM_ON_EXIT_CPU_IDLE_HOOK
+	bool
+	help
+	  Enables a hook (z_arm_on_exit_cpu_idle()) that is called when
+	  the CPU wakes up from idle (by k_cpu_idle() or k_cpu_atomic_idle())
+	  with interrupts locked.
+
+	  Note that ARM_ON_EXIT_CPU_IDLE is similar but it injects exact code
+	  as provided in the macro immediately after wake up which is used
+	  for handling erratas and hook is more generic because it is a C
+	  function call.
+
 config ARM_ON_ENTER_CPU_IDLE_PREPARE_HOOK
 	bool
 	help
@@ -78,6 +90,9 @@ config ARM_ON_EXIT_CPU_IDLE
 	  of the SOC_ON_EXIT_CPU_IDLE is to perform an action that mitigate issues
 	  observed on some SoCs caused by a memory access following WFI/WFE
 	  instructions.
+
+	  For more generic operation use ARM_ON_EXIT_CPU_IDLE_HOOK which provides
+	  option to call a C function.
 
 rsource "core/Kconfig"
 rsource "core/Kconfig.vfp"

--- a/arch/arm/core/cortex_m/cpu_idle.c
+++ b/arch/arm/core/cortex_m/cpu_idle.c
@@ -28,9 +28,15 @@ void z_arm_cpu_idle_init(void)
 }
 
 #if defined(CONFIG_ARM_ON_EXIT_CPU_IDLE)
-#define ON_EXIT_IDLE_HOOK SOC_ON_EXIT_CPU_IDLE
+#define ON_EXIT_IDLE_MACRO_HOOK SOC_ON_EXIT_CPU_IDLE
 #else
-#define ON_EXIT_IDLE_HOOK do {} while (false)
+#define ON_EXIT_IDLE_MACRO_HOOK do {} while (false)
+#endif
+
+#if defined(CONFIG_ARM_ON_EXIT_CPU_IDLE_HOOK)
+#define ON_EXIT_IDLE_FUNC_HOOK z_arm_on_exit_cpu_idle()
+#else
+#define ON_EXIT_IDLE_FUNC_HOOK do {} while (false)
 #endif
 
 #if defined(CONFIG_ARM_ON_ENTER_CPU_IDLE_HOOK)
@@ -42,14 +48,17 @@ void z_arm_cpu_idle_init(void)
 		__DSB(); \
 		wait_instr(); \
 		/* Inline the macro provided by SoC-specific code */ \
-		ON_EXIT_IDLE_HOOK; \
+		ON_EXIT_IDLE_MACRO_HOOK; \
+		/* Customizable function call. */ \
+		ON_EXIT_IDLE_FUNC_HOOK; \
 	} \
 } while (false)
 #else
 #define SLEEP_IF_ALLOWED(wait_instr) do { \
 	__DSB(); \
 	wait_instr(); \
-	ON_EXIT_IDLE_HOOK; \
+	ON_EXIT_IDLE_MACRO_HOOK; \
+	ON_EXIT_IDLE_FUNC_HOOK; \
 } while (false)
 #endif
 

--- a/include/zephyr/arch/arm/misc.h
+++ b/include/zephyr/arch/arm/misc.h
@@ -51,6 +51,15 @@ extern bool z_arm_thread_is_in_user_mode(void);
 bool z_arm_on_enter_cpu_idle(void);
 #endif
 
+#if defined(CONFIG_ARM_ON_EXIT_CPU_IDLE_HOOK)
+/* Prototype of a hook that can be enabled to be called every time the CPU is
+ * waking up from idle (the calls will be done from k_cpu_idle() and k_cpu_atomic_idle()).
+ * It is called with locked interrupts after the on-exit macro is called (see
+ * CONFIG_ARM_ON_EXIT_CPU_IDLE for details).
+ */
+void z_arm_on_exit_cpu_idle(void);
+#endif
+
 #if defined(CONFIG_ARM_ON_ENTER_CPU_IDLE_PREPARE_HOOK)
 /* Prototype of a hook that can be enabled to be called every time the CPU is
  * made idle (the calls will be done from k_cpu_idle() and k_cpu_atomic_idle()).


### PR DESCRIPTION
Added a hook which is called when CPU exits cpu idle. There is already one optional which is called on entering CPU idle. Those two can be used to track CPU activity.

There is already a macro hook which is called immediately after the wake up and it is used to inject specific code where primary use has was HW errata. This hook is more generic since it is a C function which user can implement.