### PR TITLE
spi: shell: fix copyright typo

### DIFF
--- a/drivers/spi/spi_shell.c
+++ b/drivers/spi/spi_shell.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Astroligt
+ * Copyright (c) 2024 Astrolight
  *
  * SPDX-License-Identifier: Apache-2.0
  */


### PR DESCRIPTION
Corrected copyright header.