### PR TITLE
twister: Report ROM/RAM sections data source

### DIFF
--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -275,6 +275,9 @@ class Reporting:
             if used_rom:
                 suite["used_rom"] = used_rom
 
+            if self.env.options.enable_size_report:
+                suite["rom_ram_from_buildlog"] = self.env.options.footprint_from_buildlog
+
             suite['retries'] = instance.retries
 
             if instance.dut:


### PR DESCRIPTION
Add `rom_ram_from_buildlog` test suite property in `twister.json` to complement ROM/RAM sections' size reported and inform what data source was actually used there: either the build log, or objdump (depends on command line option `--footprint_from_buildlog`).