### PR TITLE
bluetooth: OTS: Delay indications to system workqueue

### DIFF
--- a/subsys/bluetooth/services/ots/ots.c
+++ b/subsys/bluetooth/services/ots/ots.c
@@ -442,6 +442,22 @@ void *bt_ots_svc_decl_get(struct bt_ots *ots)
 }
 #endif
 
+static void oacp_indicate_work_handler(struct k_work *work)
+{
+	struct bt_gatt_ots_indicate *ind = CONTAINER_OF(work, struct bt_gatt_ots_indicate, work);
+	struct bt_ots *ots = CONTAINER_OF(ind, struct bt_ots, oacp_ind);
+
+	bt_gatt_indicate(NULL, &ots->oacp_ind.params);
+}
+
+static void olcp_indicate_work_handler(struct k_work *work)
+{
+	struct bt_gatt_ots_indicate *ind = CONTAINER_OF(work, struct bt_gatt_ots_indicate, work);
+	struct bt_ots *ots = CONTAINER_OF(ind, struct bt_ots, olcp_ind);
+
+	bt_gatt_indicate(NULL, &ots->olcp_ind.params);
+}
+
 int bt_ots_init(struct bt_ots *ots,
 		     struct bt_ots_init_param *ots_init)
 {
@@ -505,6 +521,9 @@ int bt_ots_init(struct bt_ots *ots,
 	if (IS_ENABLED(CONFIG_BT_OTS_DIR_LIST_OBJ)) {
 		bt_ots_dir_list_init(&ots->dir_list, ots->obj_manager);
 	}
+
+	k_work_init(&ots->oacp_ind.work, oacp_indicate_work_handler);
+	k_work_init(&ots->olcp_ind.work, olcp_indicate_work_handler);
 
 	LOG_DBG("Initialized OTS");
 

--- a/subsys/bluetooth/services/ots/ots_internal.h
+++ b/subsys/bluetooth/services/ots/ots_internal.h
@@ -16,6 +16,25 @@ extern "C" {
 #include "ots_oacp_internal.h"
 #include "ots_olcp_internal.h"
 
+/**
+ * Both OACP and OLCP have same max size of 7 bytes
+ *
+ * Table 3.10: Format of OACP Response Value
+ * OACP Response Value contains
+ * 1 octet Procedure code
+ * 1 octet Request op code
+ * 1 octet Result Code
+ * 4 octet CRC checksum (if present)
+ *
+ * Table 3.24: Format of the OLCP Response Value
+ * 1 octet Procedure code
+ * 1 octet Request op code
+ * 1 octet Result Code
+ * 0 or 4 octets Response Parameter
+ *
+ **/
+#define OACP_OLCP_RES_MAX_SIZE	7
+
 #define BT_OTS_VALID_OBJ_ID(id) (IN_RANGE((id), BT_OTS_OBJ_ID_MIN, BT_OTS_OBJ_ID_MAX) || \
 				 (id) == OTS_OBJ_ID_DIR_LIST)
 
@@ -103,6 +122,8 @@ struct bt_gatt_ots_indicate {
 	struct bt_gatt_attr attr;
 	struct _bt_gatt_ccc ccc;
 	bool is_enabled;
+	struct k_work work;
+	uint8_t res[OACP_OLCP_RES_MAX_SIZE];
 };
 
 struct bt_ots {

--- a/subsys/bluetooth/services/ots/ots_oacp.c
+++ b/subsys/bluetooth/services/ots/ots_oacp.c
@@ -25,16 +25,6 @@
 LOG_MODULE_DECLARE(bt_ots, CONFIG_BT_OTS_LOG_LEVEL);
 
 #define OACP_PROC_TYPE_SIZE	1
-/**
- * OTS_v10.pdf Table 3.10: Format of OACP Response V
- * OACP Response Value contains
- * 1 octet Procedure code
- * 1 octet Request op code
- * 1 octet Result Code
- * 4 octet CRC checksum (if present)
- * Execute operation is not supported
- **/
-#define OACP_RES_MAX_SIZE	(3 + sizeof(uint32_t))
 
 #if defined(CONFIG_BT_OTS_OACP_WRITE_SUPPORT)
 static ssize_t oacp_write_proc_cb(struct bt_gatt_ots_l2cap *l2cap_ctx,
@@ -644,14 +634,14 @@ static void oacp_ind_cb(struct bt_conn *conn,
 	}
 }
 
-static int oacp_ind_send(const struct bt_gatt_attr *oacp_attr,
+static void oacp_ind_send(const struct bt_gatt_attr *oacp_attr,
 			 struct bt_gatt_ots_oacp_proc oacp_proc,
 			 enum bt_gatt_ots_oacp_res_code oacp_status,
 			 struct net_buf_simple *resp_param)
 {
-	uint8_t oacp_res[OACP_RES_MAX_SIZE];
-	uint16_t oacp_res_len = 0;
 	struct bt_ots *ots = (struct bt_ots *) oacp_attr->user_data;
+	uint8_t *oacp_res = ots->oacp_ind.res;
+	uint16_t oacp_res_len = 0;
 
 	/* Encode OACP Response */
 	oacp_res[oacp_res_len++] = BT_GATT_OTS_OACP_PROC_RESP;
@@ -673,7 +663,8 @@ static int oacp_ind_send(const struct bt_gatt_attr *oacp_attr,
 
 	LOG_DBG("Sending OACP indication");
 
-	return bt_gatt_indicate(NULL, &ots->oacp_ind.params);
+
+	k_work_submit(&ots->oacp_ind.work);
 }
 
 ssize_t bt_gatt_ots_oacp_write(struct bt_conn *conn,
@@ -697,6 +688,11 @@ ssize_t bt_gatt_ots_oacp_write(struct bt_conn *conn,
 	if (offset != 0) {
 		LOG_ERR("Invalid offset of OACP Write Request");
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
+	}
+
+	if (k_work_is_pending(&ots->oacp_ind.work)) {
+		LOG_ERR("OACP Write received before indication sent");
+		return BT_GATT_ERR(BT_ATT_ERR_PROCEDURE_IN_PROGRESS);
 	}
 
 	decode_status = oacp_command_decode(buf, len, &oacp_proc);


### PR DESCRIPTION
OTS requires that indications about state change are sent after response to ATT Write.

OTS Specification p.4.4.4.: "An OLCP or OACP operation is started when the ATT Write Response is received from the Object Server as a result of the Object Client writing an Op Code to a control point to perform some desired action. The control point operation ends when the Object Server sends an indication to the Object Client
 with the Op Code set to Response Code."

fixes https://github.com/zephyrproject-rtos/zephyr/issues/66023