### PR TITLE
tests: Bluetooth: Mesh: reduce blob and dfu models bsim tests execution time

### DIFF
--- a/tests/bsim/bluetooth/mesh/src/dfu_blob_common.c
+++ b/tests/bsim/bluetooth/mesh/src/dfu_blob_common.c
@@ -52,7 +52,7 @@ void common_sar_conf(uint16_t addr)
 	 */
 	struct bt_mesh_sar_tx tx_set = {
 		.seg_int_step = 1,
-		.unicast_retrans_count = 3,
+		.unicast_retrans_count = 0,
 		.unicast_retrans_without_prog_count = 2,
 		.unicast_retrans_int_step = 7,
 		.unicast_retrans_int_inc = 1,

--- a/tests/bsim/bluetooth/mesh/src/test_blob.c
+++ b/tests/bsim/bluetooth/mesh/src/test_blob.c
@@ -924,9 +924,9 @@ static void test_cli_trans_complete(void)
 	blob_cli_inputs_prepare(BLOB_GROUP_ADDR);
 	blob_cli_xfer.xfer.mode =
 		is_pull_mode ? BT_MESH_BLOB_XFER_MODE_PULL : BT_MESH_BLOB_XFER_MODE_PUSH;
-	blob_cli_xfer.xfer.size = CONFIG_BT_MESH_BLOB_BLOCK_SIZE_MAX * 2;
+	blob_cli_xfer.xfer.size = CONFIG_BT_MESH_BLOB_BLOCK_SIZE_MIN * 4;
 	blob_cli_xfer.xfer.id = 1;
-	blob_cli_xfer.xfer.block_size_log = 12;
+	blob_cli_xfer.xfer.block_size_log = 9;
 	blob_cli_xfer.xfer.chunk_size = 377;
 	blob_cli_xfer.inputs.timeout_base = 10;
 
@@ -999,9 +999,9 @@ static void test_cli_trans_resume(void)
 	blob_cli_inputs_prepare(BLOB_GROUP_ADDR);
 	blob_cli_xfer.xfer.mode =
 		is_pull_mode ? BT_MESH_BLOB_XFER_MODE_PULL : BT_MESH_BLOB_XFER_MODE_PUSH;
-	blob_cli_xfer.xfer.size = CONFIG_BT_MESH_BLOB_BLOCK_SIZE_MAX * 2;
+	blob_cli_xfer.xfer.size = CONFIG_BT_MESH_BLOB_BLOCK_SIZE_MIN * 4;
 	blob_cli_xfer.xfer.id = 1;
-	blob_cli_xfer.xfer.block_size_log = 12;
+	blob_cli_xfer.xfer.block_size_log = 9;
 	blob_cli_xfer.xfer.chunk_size = 377;
 	blob_cli_xfer.inputs.timeout_base = 10;
 
@@ -1054,7 +1054,7 @@ static void test_srv_trans_resume(void)
 	bt_mesh_blob_srv_recv(&blob_srv, 1, &blob_io, 0, 10);
 
 	/* Let server receive a couple of chunks from second block before disruption */
-	for (int i = 0; i < 3; i++) {
+	for (int i = 0; i < 2; i++) {
 		if (k_sem_take(&first_block_wr_sem, K_SECONDS(180))) {
 			FAIL("Server did not receive the first BLOB block");
 		}
@@ -1220,9 +1220,9 @@ static void cli_common_fail_on_init(void)
 
 	blob_cli_inputs_prepare(BLOB_GROUP_ADDR);
 	blob_cli_xfer.xfer.mode = BT_MESH_BLOB_XFER_MODE_PUSH;
-	blob_cli_xfer.xfer.size = CONFIG_BT_MESH_BLOB_BLOCK_SIZE_MAX * 1;
+	blob_cli_xfer.xfer.size = CONFIG_BT_MESH_BLOB_BLOCK_SIZE_MIN * 2;
 	blob_cli_xfer.xfer.id = 1;
-	blob_cli_xfer.xfer.block_size_log = 12;
+	blob_cli_xfer.xfer.block_size_log = 9;
 	blob_cli_xfer.xfer.chunk_size = 377;
 	blob_cli_xfer.inputs.timeout_base = 10;
 }
@@ -1422,9 +1422,9 @@ static void cli_stop_setup(void)
 	blob_cli_inputs_prepare(BLOB_GROUP_ADDR);
 	blob_cli_xfer.xfer.mode =
 		is_pull_mode ? BT_MESH_BLOB_XFER_MODE_PULL : BT_MESH_BLOB_XFER_MODE_PUSH;
-	blob_cli_xfer.xfer.size = CONFIG_BT_MESH_BLOB_BLOCK_SIZE_MAX * 2;
+	blob_cli_xfer.xfer.size = CONFIG_BT_MESH_BLOB_BLOCK_SIZE_MIN * 4;
 	blob_cli_xfer.xfer.id = 1;
-	blob_cli_xfer.xfer.block_size_log = 12;
+	blob_cli_xfer.xfer.block_size_log = 9;
 	blob_cli_xfer.xfer.chunk_size = 377;
 	blob_cli_xfer.inputs.timeout_base = 10;
 }
@@ -1444,7 +1444,7 @@ static void test_cli_stop(void)
 {
 	int err;
 
-	bt_mesh_test_cfg_set(NULL, 1000);
+	bt_mesh_test_cfg_set(NULL, 500);
 	k_sem_init(&blob_caps_sem, 0, 1);
 	k_sem_init(&lost_target_sem, 0, 1);
 	k_sem_init(&blob_cli_end_sem, 0, 1);
@@ -1526,8 +1526,8 @@ static void srv_check_reboot_and_continue(void)
 	ASSERT_EQUAL(BLOB_CLI_ADDR, blob_srv.state.cli);
 	ASSERT_EQUAL(1, blob_srv.state.timeout_base);
 	ASSERT_EQUAL(BT_MESH_RX_SDU_MAX - BT_MESH_MIC_SHORT, blob_srv.state.mtu_size);
-	ASSERT_EQUAL(CONFIG_BT_MESH_BLOB_BLOCK_SIZE_MAX * 2, blob_srv.state.xfer.size);
-	ASSERT_EQUAL(12, blob_srv.state.xfer.block_size_log);
+	ASSERT_EQUAL(CONFIG_BT_MESH_BLOB_BLOCK_SIZE_MIN * 4, blob_srv.state.xfer.size);
+	ASSERT_EQUAL(9, blob_srv.state.xfer.block_size_log);
 	ASSERT_EQUAL(1, blob_srv.state.xfer.id);
 	ASSERT_TRUE(blob_srv.state.xfer.mode != BT_MESH_BLOB_XFER_MODE_NONE);
 	/* First block should be already received, second one pending */
@@ -1539,7 +1539,7 @@ static void srv_check_reboot_and_continue(void)
 
 static void test_srv_stop(void)
 {
-	bt_mesh_test_cfg_set(NULL, 1000);
+	bt_mesh_test_cfg_set(NULL, 500);
 	k_sem_init(&blob_srv_end_sem, 0, 1);
 	k_sem_init(&first_block_wr_sem, 0, 1);
 	k_sem_init(&blob_srv_suspend_sem, 0, 1);
@@ -1594,7 +1594,7 @@ static void test_cli_friend_pull(void)
 {
 	int err;
 
-	bt_mesh_test_cfg_set(NULL, 1000);
+	bt_mesh_test_cfg_set(NULL, 500);
 
 	bt_mesh_test_friendship_init(1);
 
@@ -1629,7 +1629,7 @@ static void test_cli_friend_pull(void)
 
 static void test_srv_lpn_pull(void)
 {
-	bt_mesh_test_cfg_set(NULL, 1000);
+	bt_mesh_test_cfg_set(NULL, 500);
 
 	bt_mesh_test_friendship_init(1);
 

--- a/tests/bsim/bluetooth/mesh/tests_scripts/dfu/dfu_srv_recovery.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/dfu/dfu_srv_recovery.sh
@@ -39,18 +39,6 @@ RunTestFlash dfu_dist_recover_phase \
   dfu_cli_stop -flash_rm dfu_target_dfu_stop -flash_rm \
   -- -argstest recover=1 expected-phase=8
 
-# To test recovery from Verify Fail begin new distribution that will end there,
-# reboot devices and continue to Applying.
-overlay=overlay_pst_conf
-RunTestFlash dfu_dist_recover_phase \
-  dfu_cli_stop -flash_erase dfu_target_dfu_stop -flash_erase \
-  -- -argstest recover=0 expected-phase=5
-
-overlay=overlay_pst_conf
-RunTestFlash dfu_dist_recover_phase \
-  dfu_cli_stop -flash_rm dfu_target_dfu_stop -flash_rm \
-  -- -argstest recover=1 expected-phase=6
-
 # The same test but with PSA crypto
 overlay="overlay_pst_conf_overlay_psa_conf"
 RunTestFlash dfu_dist_recover_phase_psa \
@@ -77,15 +65,3 @@ overlay="overlay_pst_conf_overlay_psa_conf"
 RunTestFlash dfu_dist_recover_phase_psa \
   dfu_cli_stop -flash_rm dfu_target_dfu_stop -flash_rm \
   -- -argstest recover=1 expected-phase=8
-
-# To test recovery from Verify Fail begin new distribution that will end there,
-# reboot devices and continue to Applying.
-overlay="overlay_pst_conf_overlay_psa_conf"
-RunTestFlash dfu_dist_recover_phase_psa \
-  dfu_cli_stop -flash_erase dfu_target_dfu_stop -flash_erase \
-  -- -argstest recover=0 expected-phase=5
-
-overlay="overlay_pst_conf_overlay_psa_conf"
-RunTestFlash dfu_dist_recover_phase_psa \
-  dfu_cli_stop -flash_rm dfu_target_dfu_stop -flash_rm \
-  -- -argstest recover=1 expected-phase=6

--- a/tests/bsim/bluetooth/mesh/tests_scripts/dfu/dfu_srv_recovery_verify_fail.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/dfu/dfu_srv_recovery_verify_fail.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Copyright 2024 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
+
+# Note:
+# Tests must be added in pairs and in sequence.
+# First test pair: executes Receive Firmware procedure up to certain point using distributor and
+# target.
+# Second test pair: tests recovery from Verify Fail begin new distribution that will end there,
+# reboot devices and continue to Applying.
+overlay=overlay_pst_conf
+RunTestFlash dfu_dist_recover_verify_fail \
+  dfu_cli_stop -flash_erase dfu_target_dfu_stop -flash_erase \
+  -- -argstest recover=0 expected-phase=5
+
+overlay=overlay_pst_conf
+RunTestFlash dfu_dist_recover_verify_fail \
+  dfu_cli_stop -flash_rm dfu_target_dfu_stop -flash_rm \
+  -- -argstest recover=1 expected-phase=6
+
+# The same test but with PSA crypto
+overlay="overlay_pst_conf_overlay_psa_conf"
+RunTestFlash dfu_dist_recover_verify_fail_psa \
+  dfu_cli_stop -flash_erase dfu_target_dfu_stop -flash_erase \
+  -- -argstest recover=0 expected-phase=5
+
+overlay="overlay_pst_conf_overlay_psa_conf"
+RunTestFlash dfu_dist_recover_verify_fail_psa \
+  dfu_cli_stop -flash_rm dfu_target_dfu_stop -flash_rm \
+  -- -argstest recover=1 expected-phase=6


### PR DESCRIPTION
Improvements those have been done so far:
    1. General transfer size and block sizes are smaller for blob.
    2. Waiting time is shorter for some blob bsim tests.
    3. The long dfu srv persistence test suite has been split into two.
    4. Retransmission for unicast messages has been reduced till zero.
    Table with measurements. 
![Screenshot from 2024-04-19 10-40-14](https://github.com/zephyrproject-rtos/zephyr/assets/47027043/737bfbc4-0db9-4453-86f0-d647daca88ea)
Measurement without improvement has been done on main commit 5dd1cdda3b69f0970466cc4ab232b2cd99dfa247. 