### PR TITLE
arch: arm: rom_start relocation configuration

### DIFF
--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -34,6 +34,71 @@ config ARM_CUSTOM_INTERRUPT_CONTROLLER
 	  is assumed that the custom interrupt control interface implementation
 	  assumes responsibility for handling the NVIC.
 
+config ROMSTART_RELOCATION_ROM
+	bool
+	default n
+	help
+	  Relocates the rom_start region containing the boot-vector data and
+	  irq vectors to the region specified by configurations:
+	  ROMSTART_REGION_ADDRESS and ROMSTART_REGION_SIZE
+
+	  This is useful for the Linux Remoteproc framework that uses the elf-loader
+	  such that it is able to load the correct boot-vector (contained in rom_start)
+	  into the correct memory location independent of the chosen zephyr,flash
+	  ROM region.
+
+	  Most SOCs include an alias for the boot-vector at address 0x00000000
+	  so a default which might be supported by the corresponding Linux rproc driver.
+	  If it is not, additionnal options allows to specify the addresses.
+
+	  In general this option should be chosen if the zephyr,flash chosen node
+	  is not placed into the boot-vector memory area.
+
+	  While this aims at generating a correct zephyr.elf file, it has the side
+	  effect of enlarging the bin file. If the zephyr.bin file is used to boot the
+	  secondary core, this option should be disabled.
+
+	  Example:
+		on IMX7D, the chosen zephyr,flash can be OCRAM/OCRAM_S/TCM/DDR memories
+		for code location. But the boot-vector must be placed into OCRAM_S for the
+		CORTEX-M to boot (alias 0, real 0x00180000/32K available).
+
+if ROMSTART_RELOCATION_ROM
+
+	config ROMSTART_REGION_ADDRESS
+		hex
+		default 0x00000000
+		help
+		  Start address of the rom_start region.
+		  This setting can be derived from a DT node reg property or specified directly.
+
+		  A default value of 0x00000000 might work in most cases as SOCs have an alias
+		  to the right memory region of the boot-vector.
+
+		  Examples:
+		  -IMX7D the boot-vector is OCRAM_S (0x00180000, aliased at 0x0).
+		  -IMX6SX the boot-vector is TCML (0x007F8000, aliased at 0x0).
+		  -IMX8MQ the boot-vector is TCML (0x007E0000, aliased at 0x0).
+		  -IMX8MN the boot-vector is ITCM (0x007E0000, aliased at 0x0).
+
+		  Example of DT definition:
+		  $(dt_nodelabel_reg_addr_hex,ocram_s_sys)
+
+	config ROMSTART_REGION_SIZE
+		hex
+		default 1
+		help
+		  Size of the rom_start region in KB.
+
+		  Default is 1KB which is enough to store the boot and irq vectors.
+
+		  This setting can be derived from a DT node reg property or specified directly.
+
+		  Example for IMX7D that needs the boot-vector into OCRAM_S (0x00180000):
+		  $(dt_nodelabel_reg_size_hex,ocram_s_sys,0,K)
+
+endif
+
 config CODE_DATA_RELOCATION_SRAM
 	bool "Relocate code/data sections to SRAM"
 	depends on CPU_CORTEX_M

--- a/dts/arm/nxp/nxp_imx6sx_m4.dtsi
+++ b/dts/arm/nxp/nxp_imx6sx_m4.dtsi
@@ -29,9 +29,10 @@
 		};
 	};
 
-	tcml:memory@1fff8000 {
+	/* TCML 0x1fff8000 is aliased at 0 */
+	tcml:memory@0 {
 		compatible = "nxp,imx-itcm";
-		reg = <0x1fff8000 DT_SIZE_K(32)>;
+		reg = <0x00000000 DT_SIZE_K(32)>;
 	};
 
 	tcmu:memory@20000000 {

--- a/dts/arm/nxp/nxp_imx7d_m4.dtsi
+++ b/dts/arm/nxp/nxp_imx7d_m4.dtsi
@@ -56,9 +56,10 @@
 			reg = <0x20200000 DT_SIZE_K(128)>;
 		};
 
-		ocram_s_code: code@20180000 {
+		/* OCRAM_S 0x20180000 is aliased at 0 */
+		ocram_s_code: code@0 {
 			compatible = "nxp,imx-code-bus";
-			reg = <0x20180000 DT_SIZE_K(32)>;
+			reg = <0x00000000 DT_SIZE_K(32)>;
 		};
 
 		ocram_s_sys: memory@180000 {

--- a/include/zephyr/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/zephyr/arch/arm/cortex_m/scripts/linker.ld
@@ -26,6 +26,14 @@
 #endif
 #define RAMABLE_REGION RAM
 
+/* Region of the irq vectors and boot-vector SP/PC */
+#if defined(CONFIG_ROMSTART_RELOCATION_ROM)
+#define ROMSTART_ADDR CONFIG_ROMSTART_REGION_ADDRESS
+#define ROMSTART_SIZE (CONFIG_ROMSTART_REGION_SIZE * 1K)
+#else
+#define ROMSTART_REGION ROMABLE_REGION
+#endif
+
 #if !defined(CONFIG_XIP) && (CONFIG_FLASH_SIZE == 0)
 #define ROM_ADDR RAM_ADDR
 #else
@@ -85,6 +93,9 @@ _region_min_align = 4;
 
 MEMORY
     {
+#if defined(CONFIG_ROMSTART_RELOCATION_ROM)
+    ROMSTART_REGION (rx) : ORIGIN = ROMSTART_ADDR, LENGTH = ROMSTART_SIZE
+#endif
     FLASH (rx) : ORIGIN = ROM_ADDR, LENGTH = ROM_SIZE
     RAM   (wx) : ORIGIN = RAM_ADDR, LENGTH = RAM_SIZE
 #if defined(CONFIG_LINKER_DEVNULL_MEMORY)
@@ -129,7 +140,7 @@ SECTIONS
  */
 #include <snippets-rom-start.ld>
 
-	} GROUP_LINK_IN(ROMABLE_REGION)
+	} GROUP_LINK_IN(ROMSTART_REGION)
 
 #ifdef CONFIG_CODE_DATA_RELOCATION
 

--- a/soc/nxp/imx/imx6sx/Kconfig.defconfig.mcimx6x_m4
+++ b/soc/nxp/imx/imx6sx/Kconfig.defconfig.mcimx6x_m4
@@ -8,4 +8,18 @@ if SOC_MCIMX6X_M4
 config FPU
 	default y
 
+
+#-By default ROM_START is relocated to address 0 in a 1K region, allowing imx_rproc
+#  to translate it to TCM_L address
+#-Select the relocation if the chosen flash is not the TCML
+#-Disable this option if you use the bin format as this choice will enlarge it.
+#  This is due to relocation of the irq-vectors in a different memory region than
+#  the chosen zephyr,flash and all the address span in between
+#  will be filled in the bin file.
+config ROMSTART_RELOCATION_ROM
+	default n
+
+config ROMSTART_REGION_ADDRESS
+	default $(dt_nodelabel_reg_addr_hex,tcml)
+
 endif # SOC_MCIMX6X_M4

--- a/soc/nxp/imx/imx7d/Kconfig.defconfig.mcimx7d_m4
+++ b/soc/nxp/imx/imx7d/Kconfig.defconfig.mcimx7d_m4
@@ -11,4 +11,17 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config GPIO
 	default y
 
+#-By default ROM_START is relocated to address 0 in a 1K region, allowing imx_rproc
+#  to translate it to OCRAM_S address
+#-Select the relocation if the chosen flash is not the OCRAM_S
+#-Disable this option if you use the bin format as this choice will enlarge it.
+#  This is due to relocation of the irq-vectors in a different memory region than
+#  the chosen zephyr,flash and all the address span in between
+#  will be filled in the bin file.
+config ROMSTART_RELOCATION_ROM
+	default n
+
+config ROMSTART_REGION_ADDRESS
+	default $(dt_nodelabel_reg_addr_hex,ocram_s_code)
+
 endif # SOC_MCIMX7D_M4


### PR DESCRIPTION
In order to support Linux rproc loading, some SOCs require the boot-vector and irq-vectors to be placed into a defined memory area for the mcu to boot.

This is necessary for NXP's IMX SOCs for instance but can be leveraged by other SOCs that have multiple
zephyr,flash choices.

This PR answers the discussion #71617 