### PR TITLE
Bluetooth: Host: Documentation and renaming of flags and states for connection establishment

### DIFF
--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -921,7 +921,7 @@ static int le_adv_start_add_conn(const struct bt_le_ext_adv *adv,
 			return -ENOMEM;
 		}
 
-		bt_conn_set_state(conn, BT_CONN_CONNECTING_ADV);
+		bt_conn_set_state(conn, BT_CONN_ADV_CONNECTABLE);
 		*out_conn = conn;
 		return 0;
 	}
@@ -935,7 +935,7 @@ static int le_adv_start_add_conn(const struct bt_le_ext_adv *adv,
 		return -ENOMEM;
 	}
 
-	bt_conn_set_state(conn, BT_CONN_CONNECTING_DIR_ADV);
+	bt_conn_set_state(conn, BT_CONN_ADV_DIR_CONNECTABLE);
 	*out_conn = conn;
 	return 0;
 }
@@ -946,10 +946,10 @@ static void le_adv_stop_free_conn(const struct bt_le_ext_adv *adv, uint8_t statu
 
 	if (!adv_is_directed(adv)) {
 		conn = bt_conn_lookup_state_le(adv->id, BT_ADDR_LE_NONE,
-					       BT_CONN_CONNECTING_ADV);
+					       BT_CONN_ADV_CONNECTABLE);
 	} else {
 		conn = bt_conn_lookup_state_le(adv->id, &adv->target_addr,
-					       BT_CONN_CONNECTING_DIR_ADV);
+					       BT_CONN_ADV_DIR_CONNECTABLE);
 	}
 
 	if (conn) {

--- a/subsys/bluetooth/host/classic/br.c
+++ b/subsys/bluetooth/host/classic/br.c
@@ -98,7 +98,7 @@ void bt_hci_conn_req(struct net_buf *buf)
 
 	accept_conn(&evt->bdaddr);
 	conn->role = BT_HCI_ROLE_PERIPHERAL;
-	bt_conn_set_state(conn, BT_CONN_CONNECTING);
+	bt_conn_set_state(conn, BT_CONN_INITIATING);
 	bt_conn_unref(conn);
 }
 

--- a/subsys/bluetooth/host/classic/sco.c
+++ b/subsys/bluetooth/host/classic/sco.c
@@ -312,7 +312,7 @@ uint8_t bt_esco_conn_req(struct bt_hci_evt_conn_request *evt)
 	}
 
 	sco_conn->role = BT_HCI_ROLE_PERIPHERAL;
-	bt_conn_set_state(sco_conn, BT_CONN_CONNECTING);
+	bt_conn_set_state(sco_conn, BT_CONN_INITIATING);
 	bt_conn_unref(sco_conn);
 
 	return BT_HCI_ERR_SUCCESS;
@@ -368,7 +368,7 @@ struct bt_conn *bt_conn_create_sco(const bt_addr_t *peer, struct bt_sco_chan *ch
 	sco_conn = bt_conn_lookup_addr_sco(peer);
 	if (sco_conn) {
 		switch (sco_conn->state) {
-		case BT_CONN_CONNECTING:
+		case BT_CONN_INITIATING:
 		case BT_CONN_CONNECTED:
 			return sco_conn;
 		default:
@@ -391,7 +391,7 @@ struct bt_conn *bt_conn_create_sco(const bt_addr_t *peer, struct bt_sco_chan *ch
 	sco_conn->sco.link_type = link_type;
 
 	bt_sco_chan_add(sco_conn, chan);
-	bt_conn_set_state(chan->sco, BT_CONN_CONNECTING);
+	bt_conn_set_state(chan->sco, BT_CONN_INITIATING);
 	bt_sco_chan_set_state(chan, BT_SCO_STATE_CONNECTING);
 
 	if (sco_setup_sync_conn(sco_conn) < 0) {

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -14,8 +14,29 @@
 typedef enum __packed {
 	BT_CONN_DISCONNECTED,         /* Disconnected, conn is completely down */
 	BT_CONN_DISCONNECT_COMPLETE,  /* Received disconn comp event, transition to DISCONNECTED */
-	BT_CONN_CONNECTING_SCAN,      /* Central passive scanning */
-	BT_CONN_CONNECTING_AUTO,      /* Central connection establishment w/ filter */
+
+	/** Central scans for a device preceding establishing a connection to it.
+	 *
+	 * This can happen when:
+	 * - The application has explicitly configured the stack to connect to the device,
+	 *   but the controller resolving list is too small. The stack therefore first
+	 *   scans to be able to retrieve the currently used (private) address, resolving
+	 *   the address in the host if needed.
+	 * - The stack uses this connection context for automatic connection establishment
+	 *   without the use of filter accept list. Instead of immediately starting
+	 *   the initiator, it first starts scanning. This allows the application to start
+	 *   scanning while automatic connection establishment in ongoing.
+	 *   It also allows the stack to use host based privacy for cases where this is needed.
+	 */
+	BT_CONN_CONNECTING_SCAN,
+
+	/** Central initiates a connection to a device in the filter accept list.
+	 *
+	 * For this type of connection establishment, the controller's initiator is started
+	 * immediately. That is, it is assumed that the controller resolving list
+	 * holds all entries that are part of the filter accept list if private addresses are used.
+	 */
+	BT_CONN_CONNECTING_AUTO,
 	BT_CONN_CONNECTING_ADV,       /* Peripheral connectable advertising */
 	BT_CONN_CONNECTING_DIR_ADV,   /* Peripheral directed advertising */
 	BT_CONN_CONNECTING,           /* Central connection establishment */
@@ -25,6 +46,14 @@ typedef enum __packed {
 
 /* bt_conn flags: the flags defined here represent connection parameters */
 enum {
+	/** The connection context is used for automatic connection establishment
+	 *
+	 * That is, with @ref bt_conn_le_create_auto() or bt_le_set_auto_conn().
+	 * This flag is set even after the connection has been established so
+	 * that the connection can be reestablished once disconnected.
+	 * The connection establishment may be performed with or without the filter
+	 * accept list.
+	 */
 	BT_CONN_AUTO_CONNECT,
 	BT_CONN_BR_LEGACY_SECURE,             /* 16 digits legacy PIN tracker */
 	BT_CONN_USER,                         /* user I/O when pairing */

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -15,6 +15,7 @@ typedef enum __packed {
 	BT_CONN_DISCONNECTED,         /* Disconnected, conn is completely down */
 	BT_CONN_DISCONNECT_COMPLETE,  /* Received disconn comp event, transition to DISCONNECTED */
 
+	BT_CONN_INITIATING,           /* Central connection establishment */
 	/** Central scans for a device preceding establishing a connection to it.
 	 *
 	 * This can happen when:
@@ -28,7 +29,7 @@ typedef enum __packed {
 	 *   scanning while automatic connection establishment in ongoing.
 	 *   It also allows the stack to use host based privacy for cases where this is needed.
 	 */
-	BT_CONN_CONNECTING_SCAN,
+	BT_CONN_SCAN_BEFORE_INITIATING,
 
 	/** Central initiates a connection to a device in the filter accept list.
 	 *
@@ -36,10 +37,10 @@ typedef enum __packed {
 	 * immediately. That is, it is assumed that the controller resolving list
 	 * holds all entries that are part of the filter accept list if private addresses are used.
 	 */
-	BT_CONN_CONNECTING_AUTO,
-	BT_CONN_CONNECTING_ADV,       /* Peripheral connectable advertising */
-	BT_CONN_CONNECTING_DIR_ADV,   /* Peripheral directed advertising */
-	BT_CONN_CONNECTING,           /* Central connection establishment */
+	BT_CONN_INITIATING_FILTER_LIST,
+
+	BT_CONN_ADV_CONNECTABLE,       /* Peripheral connectable advertising */
+	BT_CONN_ADV_DIR_CONNECTABLE,   /* Peripheral directed advertising */
 	BT_CONN_CONNECTED,            /* Peripheral or Central connected */
 	BT_CONN_DISCONNECTING,        /* Peripheral or Central issued disconnection command */
 } bt_conn_state_t;
@@ -355,7 +356,7 @@ static inline bool bt_conn_is_handle_valid(struct bt_conn *conn)
 	case BT_CONN_DISCONNECTING:
 	case BT_CONN_DISCONNECT_COMPLETE:
 		return true;
-	case BT_CONN_CONNECTING:
+	case BT_CONN_INITIATING:
 		/* ISO connection handle assigned at connect state */
 		if (IS_ENABLED(CONFIG_BT_ISO) &&
 		    conn->type == BT_CONN_TYPE_ISO) {

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -906,7 +906,7 @@ static void hci_disconn_complete(struct net_buf *buf)
 
 #if defined(CONFIG_BT_CENTRAL) && !defined(CONFIG_BT_FILTER_ACCEPT_LIST)
 	if (atomic_test_bit(conn->flags, BT_CONN_AUTO_CONNECT)) {
-		bt_conn_set_state(conn, BT_CONN_CONNECTING_SCAN);
+		bt_conn_set_state(conn, BT_CONN_SCAN_BEFORE_INITIATING);
 		bt_le_scan_update(false);
 	}
 #endif /* defined(CONFIG_BT_CENTRAL) && !defined(CONFIG_BT_FILTER_ACCEPT_LIST) */
@@ -1039,11 +1039,11 @@ static struct bt_conn *find_pending_connect(uint8_t role, bt_addr_le_t *peer_add
 	 */
 	if (IS_ENABLED(CONFIG_BT_CENTRAL) && role == BT_HCI_ROLE_CENTRAL) {
 		conn = bt_conn_lookup_state_le(BT_ID_DEFAULT, peer_addr,
-					       BT_CONN_CONNECTING);
+					       BT_CONN_INITIATING);
 		if (IS_ENABLED(CONFIG_BT_FILTER_ACCEPT_LIST) && !conn) {
 			conn = bt_conn_lookup_state_le(BT_ID_DEFAULT,
 						       BT_ADDR_LE_NONE,
-						       BT_CONN_CONNECTING_AUTO);
+						       BT_CONN_INITIATING_FILTER_LIST);
 		}
 
 		return conn;
@@ -1051,11 +1051,11 @@ static struct bt_conn *find_pending_connect(uint8_t role, bt_addr_le_t *peer_add
 
 	if (IS_ENABLED(CONFIG_BT_PERIPHERAL) && role == BT_HCI_ROLE_PERIPHERAL) {
 		conn = bt_conn_lookup_state_le(bt_dev.adv_conn_id, peer_addr,
-					       BT_CONN_CONNECTING_DIR_ADV);
+					       BT_CONN_ADV_DIR_CONNECTABLE);
 		if (!conn) {
 			conn = bt_conn_lookup_state_le(bt_dev.adv_conn_id,
 						       BT_ADDR_LE_NONE,
-						       BT_CONN_CONNECTING_ADV);
+						       BT_CONN_ADV_CONNECTABLE);
 		}
 
 		return conn;
@@ -1174,7 +1174,7 @@ static void le_conn_complete_cancel(uint8_t err)
 		/* Check if device is marked for autoconnect. */
 		if (atomic_test_bit(conn->flags, BT_CONN_AUTO_CONNECT)) {
 			/* Restart passive scanner for device */
-			bt_conn_set_state(conn, BT_CONN_CONNECTING_SCAN);
+			bt_conn_set_state(conn, BT_CONN_SCAN_BEFORE_INITIATING);
 		}
 	} else {
 		if (atomic_test_bit(conn->flags, BT_CONN_AUTO_CONNECT)) {

--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -669,7 +669,7 @@ static void rpa_timeout(struct k_work *work)
 	if (IS_ENABLED(CONFIG_BT_CENTRAL)) {
 		struct bt_conn *conn =
 			bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL,
-						BT_CONN_CONNECTING_SCAN);
+						BT_CONN_SCAN_BEFORE_INITIATING);
 
 		if (conn) {
 			bt_conn_unref(conn);
@@ -998,7 +998,7 @@ void bt_id_add(struct bt_keys *keys)
 		return;
 	}
 
-	conn = bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL, BT_CONN_CONNECTING);
+	conn = bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL, BT_CONN_INITIATING);
 	if (conn) {
 		bt_id_pending_keys_update_set(keys, BT_KEYS_ID_PENDING_ADD);
 		bt_conn_unref(conn);
@@ -1147,7 +1147,7 @@ void bt_id_del(struct bt_keys *keys)
 		return;
 	}
 
-	conn = bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL, BT_CONN_CONNECTING);
+	conn = bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL, BT_CONN_INITIATING);
 	if (conn) {
 		bt_id_pending_keys_update_set(keys, BT_KEYS_ID_PENDING_DEL);
 		bt_conn_unref(conn);
@@ -1985,7 +1985,7 @@ int bt_le_oob_get_local(uint8_t id, struct bt_le_oob *oob)
 			struct bt_conn *conn;
 
 			conn = bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL,
-						       BT_CONN_CONNECTING_SCAN);
+						       BT_CONN_SCAN_BEFORE_INITIATING);
 			if (conn) {
 				/* Cannot set new RPA while creating
 				 * connections.
@@ -2061,7 +2061,7 @@ int bt_le_ext_adv_oob_get_local(struct bt_le_ext_adv *adv,
 
 				conn = bt_conn_lookup_state_le(
 					BT_ID_DEFAULT, NULL,
-					BT_CONN_CONNECTING_SCAN);
+					BT_CONN_SCAN_BEFORE_INITIATING);
 
 				if (conn) {
 					/* Cannot set new RPA while creating

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -1371,7 +1371,7 @@ void hci_le_cis_req(struct net_buf *buf)
 
 	iso->handle = cis_handle;
 	iso->role = BT_HCI_ROLE_PERIPHERAL;
-	bt_conn_set_state(iso, BT_CONN_CONNECTING);
+	bt_conn_set_state(iso, BT_CONN_INITIATING);
 
 	err = hci_le_accept_cis(cis_handle);
 	if (err) {
@@ -2247,7 +2247,7 @@ void bt_iso_security_changed(struct bt_conn *acl, uint8_t hci_status)
 		__ASSERT(cig != NULL, "CIG was NULL");
 		cig->state = BT_ISO_CIG_STATE_ACTIVE;
 
-		bt_conn_set_state(iso_chan->iso, BT_CONN_CONNECTING);
+		bt_conn_set_state(iso_chan->iso, BT_CONN_INITIATING);
 		bt_iso_chan_set_state(iso_chan, BT_ISO_STATE_CONNECTING);
 	}
 }
@@ -2454,7 +2454,7 @@ int bt_iso_chan_connect(const struct bt_iso_connect_param *param, size_t count)
 		}
 
 		iso_chan->iso->iso.acl = bt_conn_ref(param[i].acl);
-		bt_conn_set_state(iso_chan->iso, BT_CONN_CONNECTING);
+		bt_conn_set_state(iso_chan->iso, BT_CONN_INITIATING);
 		bt_iso_chan_set_state(iso_chan, BT_ISO_STATE_CONNECTING);
 
 		cig = get_cig(iso_chan);

--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -335,14 +335,14 @@ int bt_le_scan_update(bool fast_scan)
 
 		/* don't restart scan if we have pending connection */
 		conn = bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL,
-					       BT_CONN_CONNECTING);
+					       BT_CONN_INITIATING);
 		if (conn) {
 			bt_conn_unref(conn);
 			return 0;
 		}
 
 		conn = bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL,
-					       BT_CONN_CONNECTING_SCAN);
+					       BT_CONN_SCAN_BEFORE_INITIATING);
 		if (conn) {
 			atomic_set_bit(bt_dev.flags, BT_DEV_SCAN_FILTER_DUP);
 
@@ -378,7 +378,7 @@ static void check_pending_conn(const bt_addr_le_t *id_addr,
 	}
 
 	conn = bt_conn_lookup_state_le(BT_ID_DEFAULT, id_addr,
-				       BT_CONN_CONNECTING_SCAN);
+				       BT_CONN_SCAN_BEFORE_INITIATING);
 	if (!conn) {
 		return;
 	}
@@ -393,7 +393,7 @@ static void check_pending_conn(const bt_addr_le_t *id_addr,
 		goto failed;
 	}
 
-	bt_conn_set_state(conn, BT_CONN_CONNECTING);
+	bt_conn_set_state(conn, BT_CONN_INITIATING);
 	bt_conn_unref(conn);
 	return;
 

--- a/tests/bluetooth/host/id/bt_id_add/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_add/src/main.c
@@ -119,7 +119,7 @@ ZTEST(bt_id_add, test_conn_lookup_returns_valid_conn_ref)
 
 	bt_id_add(&keys);
 
-	expect_single_call_bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL, BT_CONN_CONNECTING);
+	expect_single_call_bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL, BT_CONN_INITIATING);
 	expect_single_call_bt_conn_unref(&conn_ref);
 
 	zassert_true((keys.state & BT_KEYS_ID_PENDING_ADD) == BT_KEYS_ID_PENDING_ADD,

--- a/tests/bluetooth/host/id/bt_id_del/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_del/src/main.c
@@ -125,7 +125,7 @@ ZTEST(bt_id_del, test_conn_lookup_returns_valid_conn_ref)
 
 	bt_id_del(&keys);
 
-	expect_single_call_bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL, BT_CONN_CONNECTING);
+	expect_single_call_bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL, BT_CONN_INITIATING);
 	expect_single_call_bt_conn_unref(&conn_ref);
 
 	zassert_true((keys.state & BT_KEYS_ID_PENDING_DEL) == BT_KEYS_ID_PENDING_DEL,

--- a/tests/bluetooth/host/id/bt_le_ext_adv_oob_get_local/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/id/bt_le_ext_adv_oob_get_local/src/test_suite_invalid_inputs.c
@@ -115,7 +115,8 @@ ZTEST(bt_le_ext_adv_oob_get_local_invalid_inputs, test_updating_rpa_fails_while_
 
 	err = bt_le_ext_adv_oob_get_local(&adv, &oob);
 
-	expect_single_call_bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL, BT_CONN_CONNECTING_SCAN);
+	expect_single_call_bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL,
+						   BT_CONN_SCAN_BEFORE_INITIATING);
 
 	zassert_true(err == -EINVAL, "Unexpected error code '%d' was returned", err);
 }

--- a/tests/bluetooth/host/id/bt_le_oob_get_local/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/id/bt_le_oob_get_local/src/test_suite_invalid_inputs.c
@@ -113,7 +113,8 @@ ZTEST(bt_le_oob_get_local_invalid_inputs, test_updating_rpa_fails_while_establis
 
 	err = bt_le_oob_get_local(BT_ID_DEFAULT, &oob);
 
-	expect_single_call_bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL, BT_CONN_CONNECTING_SCAN);
+	expect_single_call_bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL,
+						   BT_CONN_SCAN_BEFORE_INITIATING);
 
 	zassert_true(err == -EINVAL, "Unexpected error code '%d' was returned", err);
 }
@@ -156,7 +157,8 @@ ZTEST(bt_le_oob_get_local_invalid_inputs, test_conn_state_checked_with_null_adv)
 	err = bt_le_oob_get_local(BT_ID_DEFAULT, &oob);
 
 	expect_single_call_bt_le_adv_lookup_legacy();
-	expect_single_call_bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL, BT_CONN_CONNECTING_SCAN);
+	expect_single_call_bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL,
+						   BT_CONN_SCAN_BEFORE_INITIATING);
 
 	zassert_true(err == -EINVAL, "Unexpected error code '%d' was returned", err);
 }
@@ -205,7 +207,8 @@ ZTEST(bt_le_oob_get_local_invalid_inputs, test_conn_state_checked_non_matched_id
 	err = bt_le_oob_get_local(BT_ID_DEFAULT, &oob);
 
 	expect_single_call_bt_le_adv_lookup_legacy();
-	expect_single_call_bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL, BT_CONN_CONNECTING_SCAN);
+	expect_single_call_bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL,
+						   BT_CONN_SCAN_BEFORE_INITIATING);
 
 	zassert_true(err == -EINVAL, "Unexpected error code '%d' was returned", err);
 }
@@ -257,7 +260,8 @@ ZTEST(bt_le_oob_get_local_invalid_inputs, test_conn_state_checked_adv_enable_not
 	err = bt_le_oob_get_local(BT_ID_DEFAULT, &oob);
 
 	expect_single_call_bt_le_adv_lookup_legacy();
-	expect_single_call_bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL, BT_CONN_CONNECTING_SCAN);
+	expect_single_call_bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL,
+						   BT_CONN_SCAN_BEFORE_INITIATING);
 
 	zassert_true(err == -EINVAL, "Unexpected error code '%d' was returned", err);
 }
@@ -309,7 +313,8 @@ ZTEST(bt_le_oob_get_local_invalid_inputs, test_conn_state_checked_adv_use_identi
 	err = bt_le_oob_get_local(BT_ID_DEFAULT, &oob);
 
 	expect_single_call_bt_le_adv_lookup_legacy();
-	expect_single_call_bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL, BT_CONN_CONNECTING_SCAN);
+	expect_single_call_bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL,
+						   BT_CONN_SCAN_BEFORE_INITIATING);
 
 	zassert_true(err == -EINVAL, "Unexpected error code '%d' was returned", err);
 }
@@ -361,7 +366,8 @@ ZTEST(bt_le_oob_get_local_invalid_inputs, test_conn_state_checked_public_dev_add
 	err = bt_le_oob_get_local(BT_ID_DEFAULT, &oob);
 
 	expect_single_call_bt_le_adv_lookup_legacy();
-	expect_single_call_bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL, BT_CONN_CONNECTING_SCAN);
+	expect_single_call_bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL,
+						   BT_CONN_SCAN_BEFORE_INITIATING);
 
 	zassert_true(err == -EINVAL, "Unexpected error code '%d' was returned", err);
 }


### PR DESCRIPTION
Some of the flags and states used for connection establishment could be hard to understand for users not that familiar with the code. To make it easier to understand, this PR adds some documentation to these states and renames them accordingly.

Feel free to disagree or propose other names for the renamed states.

Summary of state renaming:
* Add CENTRAL/PERIPHERAL to state names that are exclusive to central or peripheral. Previously it was not necessarily clear that the state `BT_CONN_CONNECTING` was for central only by just looking at where it was used.
* `BT_CONN_CONNECTING_SCAN -> BT_CONN_CENTRAL_SCAN_BEFORE_CONNECTING` to make it more clear that we are not scanning and connecting at the same time. The new name should make it more clear why we are scanning - only with the intention to start the initiator later.
* `BT_CONN_CONNECTING_AUTO -> BT_CONN_CENTRAL_CONNECTING_FILTER_LIST`. This makes it clear that this state is something different than BT_CONN_AUTO_CONNECT.



