### PR TITLE
samples: spi_fujitsu_fram: fixed some logic problems

### DIFF
--- a/samples/drivers/spi_fujitsu_fram/esp32c3_devkitm.overlay
+++ b/samples/drivers/spi_fujitsu_fram/esp32c3_devkitm.overlay
@@ -1,0 +1,7 @@
+&spi2 {
+	status = "okay";
+	cs-gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+	spidev: spi-device@0 {
+		reg = <0>;
+	};
+};


### PR DESCRIPTION
Fixed mb85rs64v_read_id as before it would call mb85rs64v_access with
"cmd = MB85RS64V_MANUFACTURER_ID_CMD". This would only call spi_write
instead of spi_transceive because cmd is neither WRITE_CMD nor READ_CMD.

One other bug in mb85rs64v_access was that if
"cmd = MB85RS64V_WRITE_ENABLE_CMD", bufs[0].len was 0 instead of 1 so
these command were not executed correctly.
This made write_bytes not really write bytes, as writing was still
disabled for the fram module.

Furthermore I set the cs property of spi_config, because it does not work
without setting it. I also included a sample overlay file how to setup
a spi device for the esp32c3_devkitm.