### PR TITLE
Bluetooth: Host: Deprecate `BT_LE_ADV_OPT_USE_NAME` and `BT_LE_ADV_OPT_FORCE_NAME_IN_AD`

### DIFF
--- a/doc/connectivity/bluetooth/bluetooth-shell.rst
+++ b/doc/connectivity/bluetooth/bluetooth-shell.rst
@@ -166,19 +166,20 @@ For example, if you want to create a connectable and scannable advertiser and st
         Advertiser[0] 0x200022f0 set started
 
 You may notice that with this, the custom advertiser does not advertise the device name; you need to
-enable it. Continuing from the previous example:
+add it. Continuing from the previous example:
 
 .. code-block:: console
 
         uart:~$ bt adv-stop
         Advertiser set stopped
-        uart:~$ bt adv-param conn-scan name
+        uart:~$ bt adv-data dev-name
         uart:~$ bt adv-start
         Advertiser[0] 0x200022f0 set started
 
-You should now see the name of the device in the advertising data. You can also set the advertising
-data manually by using the :code:`bt adv-data` command. The following example shows how to set the
-advertiser name with it:
+You should now see the name of the device in the advertising data. You can also set a custom name by
+using :code:`name <custom name>` instead of :code:`dev-name`. It is also possible to set the
+advertising data manually with the :code:`bt adv-data` command. The following example shows how
+to set the advertiser name with it using raw advertising data:
 
 .. code-block:: console
 

--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -178,6 +178,20 @@ Bluetooth Classic
   Removed the :kconfig:option:`CONFIG_BT_BREDR`. It is replaced by new option
   :kconfig:option:`CONFIG_BT_CLASSIC`. (:github:`69651`)
 
+Bluetooth Host
+==============
+
+* The advertiser options :code:`BT_LE_ADV_OPT_USE_NAME` and :code:`BT_LE_ADV_OPT_FORCE_NAME_IN_AD`
+  are deprecated in this release. The application need to include the device name explicitly. One
+  way to do it is by adding the following to the advertising data or scan response data passed to
+  the host:
+
+  .. code-block:: c
+
+   BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1)
+
+  (:github:`71686`)
+
 Networking
 **********
 

--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -28,6 +28,27 @@ https://docs.zephyrproject.org/latest/security/vulnerabilities.html
 * CVE-2024-3077 `Zephyr project bug tracker GHSA-gmfv-4vfh-2mh8
   <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-gmfv-4vfh-2mh8>`_
 
+API Changes
+***********
+
+Deprecated in this release
+==========================
+
+ * Bluetooth advertiser options :code:`BT_LE_ADV_OPT_USE_NAME` and
+   :code:`BT_LE_ADV_OPT_FORCE_NAME_IN_AD` are now deprecated. That means the following macro are
+   deprecated:
+
+    * :c:macro:`BT_LE_ADV_CONN_NAME`
+    * :c:macro:`BT_LE_ADV_CONN_NAME_AD`
+    * :c:macro:`BT_LE_ADV_NCONN_NAME`
+    * :c:macro:`BT_LE_EXT_ADV_CONN_NAME`
+    * :c:macro:`BT_LE_EXT_ADV_SCAN_NAME`
+    * :c:macro:`BT_LE_EXT_ADV_NCONN_NAME`
+    * :c:macro:`BT_LE_EXT_ADV_CODED_NCONN_NAME`
+
+   Application developer will now need to set the advertised name themselves by updating the advertising data
+   or the scan response data.
+
 Architectures
 *************
 

--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -937,6 +937,13 @@ struct bt_le_per_adv_param {
 						 BT_GAP_ADV_FAST_INT_MAX_2, \
 						 NULL)
 
+/** Connectable extended advertising */
+#define BT_LE_EXT_ADV_CONN BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV | \
+					   BT_LE_ADV_OPT_CONNECTABLE, \
+					   BT_GAP_ADV_FAST_INT_MIN_2, \
+					   BT_GAP_ADV_FAST_INT_MAX_2, \
+					   NULL)
+
 /** Connectable extended advertising with @ref BT_LE_ADV_OPT_USE_NAME */
 #define BT_LE_EXT_ADV_CONN_NAME BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV | \
 						BT_LE_ADV_OPT_CONNECTABLE | \
@@ -944,6 +951,13 @@ struct bt_le_per_adv_param {
 						BT_GAP_ADV_FAST_INT_MIN_2, \
 						BT_GAP_ADV_FAST_INT_MAX_2, \
 						NULL)
+
+/** Scannable extended advertising */
+#define BT_LE_EXT_ADV_SCAN BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV | \
+					   BT_LE_ADV_OPT_SCANNABLE, \
+					   BT_GAP_ADV_FAST_INT_MIN_2, \
+					   BT_GAP_ADV_FAST_INT_MAX_2, \
+					   NULL)
 
 /** Scannable extended advertising with @ref BT_LE_ADV_OPT_USE_NAME */
 #define BT_LE_EXT_ADV_SCAN_NAME BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV | \

--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -549,25 +549,29 @@ enum {
 	 */
 	BT_LE_ADV_OPT_USE_IDENTITY = BIT(2),
 
-	/** Advertise using GAP device name.
+	/**
+	 * @deprecated This option will be removed in the near future, see
+	 * https://github.com/zephyrproject-rtos/zephyr/issues/71686
 	 *
-	 *  Include the GAP device name automatically when advertising.
-	 *  By default the GAP device name is put at the end of the scan
-	 *  response data.
-	 *  When advertising using @ref BT_LE_ADV_OPT_EXT_ADV and not
-	 *  @ref BT_LE_ADV_OPT_SCANNABLE then it will be put at the end of the
-	 *  advertising data.
-	 *  If the GAP device name does not fit into advertising data it will be
-	 *  converted to a shortened name if possible.
-	 *  @ref BT_LE_ADV_OPT_FORCE_NAME_IN_AD can be used to force the device
-	 *  name to appear in the advertising data of an advert with scan
-	 *  response data.
+	 * @brief Advertise using GAP device name.
 	 *
-	 *  The application can set the device name itself by including the
-	 *  following in the advertising data.
-	 *  @code
-	 *  BT_DATA(BT_DATA_NAME_COMPLETE, name, sizeof(name) - 1)
-	 *  @endcode
+	 * Include the GAP device name automatically when advertising.
+	 * By default the GAP device name is put at the end of the scan
+	 * response data.
+	 * When advertising using @ref BT_LE_ADV_OPT_EXT_ADV and not
+	 * @ref BT_LE_ADV_OPT_SCANNABLE then it will be put at the end of the
+	 * advertising data.
+	 * If the GAP device name does not fit into advertising data it will be
+	 * converted to a shortened name if possible.
+	 * @ref BT_LE_ADV_OPT_FORCE_NAME_IN_AD can be used to force the device
+	 * name to appear in the advertising data of an advert with scan
+	 * response data.
+	 *
+	 * The application can set the device name itself by including the
+	 * following in the advertising data.
+	 * @code
+	 * BT_DATA(BT_DATA_NAME_COMPLETE, name, sizeof(name) - 1)
+	 * @endcode
 	 */
 	BT_LE_ADV_OPT_USE_NAME = BIT(3),
 
@@ -691,10 +695,13 @@ enum {
 	BT_LE_ADV_OPT_DISABLE_CHAN_39 = BIT(17),
 
 	/**
+	 * @deprecated This option will be removed in the near future, see
+	 * https://github.com/zephyrproject-rtos/zephyr/issues/71686
+	 *
 	 * @brief Put GAP device name into advert data
 	 *
-	 * Will place the GAP device name into the advertising data rather
-	 * than the scan response data.
+	 * Will place the GAP device name into the advertising data rather than
+	 * the scan response data.
 	 *
 	 * @note Requires @ref BT_LE_ADV_OPT_USE_NAME
 	 */
@@ -905,16 +912,26 @@ struct bt_le_per_adv_param {
 				       BT_GAP_ADV_FAST_INT_MIN_2, \
 				       BT_GAP_ADV_FAST_INT_MAX_2, NULL)
 
+/**
+ * @deprecated This macro will be removed in the near future, see
+ * https://github.com/zephyrproject-rtos/zephyr/issues/71686
+ */
 #define BT_LE_ADV_CONN_NAME BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONNECTABLE | \
 					    BT_LE_ADV_OPT_USE_NAME, \
 					    BT_GAP_ADV_FAST_INT_MIN_2, \
-					    BT_GAP_ADV_FAST_INT_MAX_2, NULL)
+					    BT_GAP_ADV_FAST_INT_MAX_2, NULL) \
+					    __DEPRECATED_MACRO
 
+/**
+ * @deprecated This macro will be removed in the near future, see
+ * https://github.com/zephyrproject-rtos/zephyr/issues/71686
+ */
 #define BT_LE_ADV_CONN_NAME_AD BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONNECTABLE | \
 					    BT_LE_ADV_OPT_USE_NAME | \
 					    BT_LE_ADV_OPT_FORCE_NAME_IN_AD, \
 					    BT_GAP_ADV_FAST_INT_MIN_2, \
-					    BT_GAP_ADV_FAST_INT_MAX_2, NULL)
+					    BT_GAP_ADV_FAST_INT_MAX_2, NULL) \
+					    __DEPRECATED_MACRO
 
 #define BT_LE_ADV_CONN_DIR_LOW_DUTY(_peer) \
 	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONNECTABLE | BT_LE_ADV_OPT_ONE_TIME | \
@@ -926,10 +943,16 @@ struct bt_le_per_adv_param {
 #define BT_LE_ADV_NCONN BT_LE_ADV_PARAM(0, BT_GAP_ADV_FAST_INT_MIN_2, \
 					BT_GAP_ADV_FAST_INT_MAX_2, NULL)
 
-/** Non-connectable advertising with @ref BT_LE_ADV_OPT_USE_NAME */
+/**
+ * @deprecated This macro will be removed in the near future, see
+ * https://github.com/zephyrproject-rtos/zephyr/issues/71686
+ *
+ * Non-connectable advertising with @ref BT_LE_ADV_OPT_USE_NAME
+ */
 #define BT_LE_ADV_NCONN_NAME BT_LE_ADV_PARAM(BT_LE_ADV_OPT_USE_NAME, \
 					     BT_GAP_ADV_FAST_INT_MIN_2, \
-					     BT_GAP_ADV_FAST_INT_MAX_2, NULL)
+					     BT_GAP_ADV_FAST_INT_MAX_2, NULL) \
+					     __DEPRECATED_MACRO
 
 /** Non-connectable advertising with @ref BT_LE_ADV_OPT_USE_IDENTITY */
 #define BT_LE_ADV_NCONN_IDENTITY BT_LE_ADV_PARAM(BT_LE_ADV_OPT_USE_IDENTITY, \
@@ -944,13 +967,19 @@ struct bt_le_per_adv_param {
 					   BT_GAP_ADV_FAST_INT_MAX_2, \
 					   NULL)
 
-/** Connectable extended advertising with @ref BT_LE_ADV_OPT_USE_NAME */
+/**
+ * @deprecated This macro will be removed in the near future, see
+ * https://github.com/zephyrproject-rtos/zephyr/issues/71686
+ *
+ * Connectable extended advertising with @ref BT_LE_ADV_OPT_USE_NAME
+ */
 #define BT_LE_EXT_ADV_CONN_NAME BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV | \
 						BT_LE_ADV_OPT_CONNECTABLE | \
 						BT_LE_ADV_OPT_USE_NAME, \
 						BT_GAP_ADV_FAST_INT_MIN_2, \
 						BT_GAP_ADV_FAST_INT_MAX_2, \
-						NULL)
+						NULL) \
+						__DEPRECATED_MACRO
 
 /** Scannable extended advertising */
 #define BT_LE_EXT_ADV_SCAN BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV | \
@@ -959,25 +988,37 @@ struct bt_le_per_adv_param {
 					   BT_GAP_ADV_FAST_INT_MAX_2, \
 					   NULL)
 
-/** Scannable extended advertising with @ref BT_LE_ADV_OPT_USE_NAME */
+/**
+ * @deprecated This macro will be removed in the near future, see
+ * https://github.com/zephyrproject-rtos/zephyr/issues/71686
+ *
+ * Scannable extended advertising with @ref BT_LE_ADV_OPT_USE_NAME
+ */
 #define BT_LE_EXT_ADV_SCAN_NAME BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV | \
 						BT_LE_ADV_OPT_SCANNABLE | \
 						BT_LE_ADV_OPT_USE_NAME, \
 						BT_GAP_ADV_FAST_INT_MIN_2, \
 						BT_GAP_ADV_FAST_INT_MAX_2, \
-						NULL)
+						NULL) \
+						__DEPRECATED_MACRO
 
 /** Non-connectable extended advertising with private address */
 #define BT_LE_EXT_ADV_NCONN BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV, \
 					    BT_GAP_ADV_FAST_INT_MIN_2, \
 					    BT_GAP_ADV_FAST_INT_MAX_2, NULL)
 
-/** Non-connectable extended advertising with @ref BT_LE_ADV_OPT_USE_NAME */
+/**
+ * @deprecated This macro will be removed in the near future, see
+ * https://github.com/zephyrproject-rtos/zephyr/issues/71686
+ *
+ * Non-connectable extended advertising with @ref BT_LE_ADV_OPT_USE_NAME
+ */
 #define BT_LE_EXT_ADV_NCONN_NAME BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV | \
 						 BT_LE_ADV_OPT_USE_NAME, \
 						 BT_GAP_ADV_FAST_INT_MIN_2, \
 						 BT_GAP_ADV_FAST_INT_MAX_2, \
-						 NULL)
+						 NULL) \
+						 __DEPRECATED_MACRO
 
 /** Non-connectable extended advertising with @ref BT_LE_ADV_OPT_USE_IDENTITY */
 #define BT_LE_EXT_ADV_NCONN_IDENTITY \
@@ -993,14 +1034,19 @@ struct bt_le_per_adv_param {
 						  BT_GAP_ADV_FAST_INT_MAX_2, \
 						  NULL)
 
-/** Non-connectable extended advertising on coded PHY with
- *  @ref BT_LE_ADV_OPT_USE_NAME
+/**
+ * @deprecated This macro will be removed in the near future, see
+ * https://github.com/zephyrproject-rtos/zephyr/issues/71686
+ *
+ * Non-connectable extended advertising on coded PHY with
+ * @ref BT_LE_ADV_OPT_USE_NAME
  */
 #define BT_LE_EXT_ADV_CODED_NCONN_NAME \
 		BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV | BT_LE_ADV_OPT_CODED | \
 				BT_LE_ADV_OPT_USE_NAME, \
 				BT_GAP_ADV_FAST_INT_MIN_2, \
-				BT_GAP_ADV_FAST_INT_MAX_2, NULL)
+				BT_GAP_ADV_FAST_INT_MAX_2, NULL) \
+				__DEPRECATED_MACRO
 
 /** Non-connectable extended advertising on coded PHY with
  *  @ref BT_LE_ADV_OPT_USE_IDENTITY

--- a/samples/bluetooth/broadcast_audio_sink/src/main.c
+++ b/samples/bluetooth/broadcast_audio_sink/src/main.c
@@ -1349,11 +1349,13 @@ static int start_adv(void)
 			      BT_UUID_16_ENCODE(BT_UUID_BASS_VAL),
 			      BT_UUID_16_ENCODE(BT_UUID_PACS_VAL)),
 		BT_DATA_BYTES(BT_DATA_SVC_DATA16, BT_UUID_16_ENCODE(BT_UUID_BASS_VAL)),
+		BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME,
+			sizeof(CONFIG_BT_DEVICE_NAME) - 1),
 	};
 	int err;
 
 	/* Create a non-connectable non-scannable advertising set */
-	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_CONN_NAME, NULL, &ext_adv);
+	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_CONN, NULL, &ext_adv);
 	if (err != 0) {
 		printk("Failed to create advertising set (err %d)\n", err);
 

--- a/samples/bluetooth/broadcast_audio_source/src/main.c
+++ b/samples/bluetooth/broadcast_audio_source/src/main.c
@@ -23,7 +23,7 @@ BUILD_ASSERT(strlen(CONFIG_BROADCAST_CODE) <= BT_AUDIO_BROADCAST_CODE_SIZE,
  * interval.
  */
 #define BT_LE_EXT_ADV_CUSTOM                                                                       \
-	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV | BT_LE_ADV_OPT_USE_NAME, 0x0080, 0x0080, NULL)
+	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV, 0x0080, 0x0080, NULL)
 
 /* When BROADCAST_ENQUEUE_COUNT > 1 we can enqueue enough buffers to ensure that
  * the controller is never idle
@@ -432,6 +432,10 @@ static int setup_broadcast_source(struct bt_bap_broadcast_source **source)
 	return 0;
 }
 
+static const struct bt_data ad[] = {
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
+};
+
 int main(void)
 {
 	struct bt_le_ext_adv *adv;
@@ -498,6 +502,12 @@ int main(void)
 		if (err != 0) {
 			printk("Unable to create extended advertising set: %d\n",
 			       err);
+			return 0;
+		}
+
+		err = bt_le_ext_adv_set_data(adv, ad, ARRAY_SIZE(ad), NULL, 0);
+		if (err) {
+			printk("Failed to set advertising data (err %d)\n", err);
 			return 0;
 		}
 

--- a/samples/bluetooth/broadcaster_multiple/src/broadcaster_multiple.c
+++ b/samples/bluetooth/broadcaster_multiple/src/broadcaster_multiple.c
@@ -59,6 +59,7 @@ static const struct bt_data ad[] = {
 #if CONFIG_BT_CTLR_ADV_DATA_LEN_MAX > 255
 	BT_DATA(BT_DATA_MANUFACTURER_DATA, mfg_data, sizeof(mfg_data)),
 #endif
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
 };
 
 static struct bt_le_ext_adv *adv[CONFIG_BT_EXT_ADV_MAX_ADV_SET];
@@ -69,7 +70,7 @@ int broadcaster_multiple(void)
 		.id = BT_ID_DEFAULT,
 		.sid = 0U, /* Supply unique SID when creating advertising set */
 		.secondary_max_skip = 0U,
-		.options = (BT_LE_ADV_OPT_EXT_ADV | BT_LE_ADV_OPT_USE_NAME),
+		.options = BT_LE_ADV_OPT_EXT_ADV,
 		.interval_min = BT_GAP_ADV_FAST_INT_MIN_2,
 		.interval_max = BT_GAP_ADV_FAST_INT_MAX_2,
 		.peer = NULL,

--- a/samples/bluetooth/direct_adv/src/main.c
+++ b/samples/bluetooth/direct_adv/src/main.c
@@ -76,6 +76,7 @@ BT_GATT_SERVICE_DEFINE(primary_service,
 static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
 	BT_DATA_BYTES(BT_DATA_UUID128_ALL, BT_UUID_CUSTOM_SERVICE_VAL),
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
 };
 
 static void connected(struct bt_conn *conn, uint8_t err)
@@ -127,7 +128,7 @@ static void bt_ready(void)
 		adv_param.options |= BT_LE_ADV_OPT_DIR_ADDR_RPA;
 		err = bt_le_adv_start(&adv_param, NULL, 0, NULL, 0);
 	} else {
-		err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
+		err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), NULL, 0);
 	}
 
 	if (err) {

--- a/samples/bluetooth/direction_finding_connectionless_tx/src/main.c
+++ b/samples/bluetooth/direction_finding_connectionless_tx/src/main.c
@@ -31,8 +31,7 @@ static struct bt_le_ext_adv *adv_set;
 
 static struct bt_le_adv_param param =
 		BT_LE_ADV_PARAM_INIT(BT_LE_ADV_OPT_EXT_ADV |
-				     BT_LE_ADV_OPT_USE_IDENTITY |
-				     BT_LE_ADV_OPT_USE_NAME,
+				     BT_LE_ADV_OPT_USE_IDENTITY,
 				     BT_GAP_ADV_FAST_INT_MIN_2,
 				     BT_GAP_ADV_FAST_INT_MAX_2,
 				     NULL);
@@ -63,6 +62,10 @@ struct bt_df_adv_cte_tx_param cte_params = { .cte_len = CTE_LEN,
 					     .num_ant_ids = 0,
 					     .ant_ids = NULL
 #endif /* CONFIG_BT_DF_CTE_TX_AOD */
+};
+
+static const struct bt_data ad[] = {
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
 };
 
 static void adv_sent_cb(struct bt_le_ext_adv *adv,
@@ -96,6 +99,12 @@ int main(void)
 		return 0;
 	}
 	printk("success\n");
+
+	err = bt_le_ext_adv_set_data(adv_set, ad, ARRAY_SIZE(ad), NULL, 0);
+	if (err) {
+		printk("failed (err %d)\n", err);
+		return 0;
+	}
 
 	printk("Update CTE params...");
 	err = bt_df_set_adv_cte_tx_param(adv_set, &cte_params);

--- a/samples/bluetooth/direction_finding_peripheral/src/main.c
+++ b/samples/bluetooth/direction_finding_peripheral/src/main.c
@@ -26,6 +26,7 @@
 static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
 	BT_DATA_BYTES(BT_DATA_LE_SUPPORTED_FEATURES, BT_LE_SUPP_FEAT_24_ENCODE(DF_FEAT_ENABLED)),
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
 };
 
 /* Latency set to zero, to enforce PDU exchange every connection event */
@@ -99,7 +100,7 @@ static void bt_ready(void)
 
 	printk("Bluetooth initialized\n");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);
 		return;

--- a/samples/bluetooth/eddystone/src/main.c
+++ b/samples/bluetooth/eddystone/src/main.c
@@ -38,6 +38,10 @@ static const struct bt_data ad[] = {
 		      0xdf, 0x4b, 0xd3, 0x8e, 0x00, 0x75, 0xc8, 0xa3),
 };
 
+static const struct bt_data sd[] = {
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
+};
+
 /* Eddystone Service Variables */
 /* Service UUID a3c87500-8ed3-4bdf-8a39-a01bebede295 */
 static const struct bt_uuid_128 eds_uuid = BT_UUID_INIT_128(
@@ -427,7 +431,7 @@ static int eds_slot_restart(struct eds_slot *slot, uint8_t type)
 			addr = oob.addr;
 		}
 
-		err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad),
+		err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad),
 				      NULL, 0);
 	} else {
 		size_t count = 1;
@@ -631,7 +635,7 @@ static void bt_ready(int err)
 	printk("Bluetooth initialized\n");
 
 	/* Start advertising */
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);
 		return;

--- a/samples/bluetooth/extended_adv/advertiser/src/main.c
+++ b/samples/bluetooth/extended_adv/advertiser/src/main.c
@@ -84,6 +84,10 @@ static int start_advertising(struct bt_le_ext_adv *adv)
 	return err;
 }
 
+static const struct bt_data ad[] = {
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
+};
+
 int main(void)
 {
 	int err;
@@ -99,10 +103,17 @@ int main(void)
 	}
 
 	/* Create a non-connectable non-scannable advertising set */
-	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_CONN_NAME, NULL, &adv);
+	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_CONN, NULL, &adv);
 	if (err) {
 		printk("Failed to create advertising set (err %d)\n", err);
 		return err;
+	}
+
+	/* Set advertising data to have complete local name set */
+	err = bt_le_ext_adv_set_data(adv, ad, ARRAY_SIZE(ad), NULL, 0);
+	if (err) {
+		printk("Failed to set advertising data (err %d)\n", err);
+		return 0;
 	}
 
 	err = start_advertising(adv);

--- a/samples/bluetooth/hap_ha/src/main.c
+++ b/samples/bluetooth/hap_ha/src/main.c
@@ -45,6 +45,7 @@ static const struct bt_data ad[] = {
 	BT_DATA(BT_DATA_CSIS_RSI, csis_rsi_addata, ARRAY_SIZE(csis_rsi_addata)),
 #endif /* CONFIG_BT_CSIP_SET_MEMBER */
 	BT_DATA(BT_DATA_SVC_DATA16, unicast_server_addata, ARRAY_SIZE(unicast_server_addata)),
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
 };
 
 static struct k_work_delayable adv_work;
@@ -100,7 +101,7 @@ static void adv_work_handler(struct k_work *work)
 
 	if (ext_adv == NULL) {
 		/* Create a non-connectable non-scannable advertising set */
-		err = bt_le_ext_adv_create(BT_LE_EXT_ADV_CONN_NAME, &adv_cb, &ext_adv);
+		err = bt_le_ext_adv_create(BT_LE_EXT_ADV_CONN, &adv_cb, &ext_adv);
 		if (err) {
 			printk("Failed to create advertising set (err %d)\n", err);
 		}

--- a/samples/bluetooth/hci_pwr_ctrl/src/main.c
+++ b/samples/bluetooth/hci_pwr_ctrl/src/main.c
@@ -29,6 +29,10 @@ static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_UUID16_ALL, BT_UUID_16_ENCODE(BT_UUID_HRS_VAL)),
 };
 
+static const struct bt_data sd[] = {
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
+};
+
 #define DEVICE_NAME CONFIG_BT_DEVICE_NAME
 #define DEVICE_NAME_LEN (sizeof(DEVICE_NAME) - 1)
 #define DEVICE_BEACON_TXPOWER_NUM  8
@@ -39,7 +43,7 @@ static K_THREAD_STACK_DEFINE(pwr_thread_stack, 512);
 static const int8_t txpower[DEVICE_BEACON_TXPOWER_NUM] = {4, 0, -3, -8,
 							  -15, -18, -23, -30};
 static const struct bt_le_adv_param *param =
-	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONNECTABLE | BT_LE_ADV_OPT_USE_NAME,
+	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONNECTABLE,
 			0x0020, 0x0020, NULL);
 
 static void read_conn_rssi(uint16_t handle, int8_t *rssi)
@@ -206,7 +210,7 @@ static void bt_ready(int err)
 
 	/* Start advertising */
 	err = bt_le_adv_start(param, ad, ARRAY_SIZE(ad),
-			      NULL, 0);
+			      sd, ARRAY_SIZE(sd));
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);
 		return;

--- a/samples/bluetooth/iso_broadcast/src/main.c
+++ b/samples/bluetooth/iso_broadcast/src/main.c
@@ -82,6 +82,10 @@ static struct bt_iso_big_create_param big_create_param = {
 	.framing = 0, /* 0 - unframed, 1 - framed */
 };
 
+static const struct bt_data ad[] = {
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
+};
+
 int main(void)
 {
 	uint32_t timeout_counter = INITIAL_TIMEOUT_COUNTER;
@@ -102,9 +106,16 @@ int main(void)
 	}
 
 	/* Create a non-connectable non-scannable advertising set */
-	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_NCONN_NAME, NULL, &adv);
+	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_NCONN, NULL, &adv);
 	if (err) {
 		printk("Failed to create advertising set (err %d)\n", err);
+		return 0;
+	}
+
+	/* Set advertising data to have complete local name set */
+	err = bt_le_ext_adv_set_data(adv, ad, ARRAY_SIZE(ad), NULL, 0);
+	if (err) {
+		printk("Failed to set advertising data (err %d)\n", err);
 		return 0;
 	}
 

--- a/samples/bluetooth/iso_broadcast_benchmark/src/broadcaster.c
+++ b/samples/bluetooth/iso_broadcast_benchmark/src/broadcaster.c
@@ -60,6 +60,10 @@ static struct bt_iso_big_create_param big_create_param = {
 #endif /* CONFIG_BT_ISO_TEST_PARAMS */
 };
 
+static const struct bt_data ad[] = {
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
+};
+
 static void iso_connected(struct bt_iso_chan *chan)
 {
 	LOG_INF("ISO Channel %p connected", chan);
@@ -615,10 +619,17 @@ static int create_big(struct bt_le_ext_adv **adv, struct bt_iso_big **big)
 
 	/* Create a non-connectable non-scannable advertising set */
 	LOG_INF("Creating Extended Advertising set");
-	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_NCONN_NAME, NULL, adv);
+	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_NCONN, NULL, adv);
 	if (err != 0) {
 		LOG_ERR("Failed to create advertising set (err %d)", err);
 		return err;
+	}
+
+	/* Set advertising data to have complete local name set */
+	err = bt_le_ext_adv_set_data(*adv, ad, ARRAY_SIZE(ad), NULL, 0);
+	if (err) {
+		LOG_ERR("Failed to set advertising data (err %d)", err);
+		return 0;
 	}
 
 	LOG_INF("Setting Periodic Advertising parameters");

--- a/samples/bluetooth/iso_connected_benchmark/src/main.c
+++ b/samples/bluetooth/iso_connected_benchmark/src/main.c
@@ -137,6 +137,10 @@ static struct bt_iso_cig_param cig_create_param = {
 #endif /* CONFIG_BT_ISO_TEST_PARAMS */
 };
 
+static const struct bt_data sd[] = {
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
+};
+
 static enum benchmark_role device_role_select(void)
 {
 	char role_char;
@@ -1275,11 +1279,9 @@ static int run_peripheral(void)
 
 	LOG_INF("Starting advertising");
 	err = bt_le_adv_start(
-		BT_LE_ADV_PARAM(BT_LE_ADV_OPT_ONE_TIME | BT_LE_ADV_OPT_CONNECTABLE |
-					BT_LE_ADV_OPT_USE_NAME |
-					BT_LE_ADV_OPT_FORCE_NAME_IN_AD,
+		BT_LE_ADV_PARAM(BT_LE_ADV_OPT_ONE_TIME | BT_LE_ADV_OPT_CONNECTABLE,
 				BT_GAP_ADV_FAST_INT_MIN_2, BT_GAP_ADV_FAST_INT_MAX_2, NULL),
-		NULL, 0, NULL, 0);
+		NULL, 0, sd, ARRAY_SIZE(sd));
 	if (err != 0) {
 		LOG_ERR("Advertising failed to start: %d", err);
 		return err;

--- a/samples/bluetooth/mtu_update/peripheral/src/peripheral_mtu_update.c
+++ b/samples/bluetooth/mtu_update/peripheral/src/peripheral_mtu_update.c
@@ -23,7 +23,9 @@ static const struct bt_uuid_128 notify_characteristic_uuid =
 
 static const struct bt_data adv_ad_data[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
-	BT_DATA_BYTES(BT_DATA_UUID128_ALL, MTU_TEST_SERVICE_TYPE)};
+	BT_DATA_BYTES(BT_DATA_UUID128_ALL, MTU_TEST_SERVICE_TYPE),
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
+};
 
 static void ccc_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
 {
@@ -61,8 +63,7 @@ void run_peripheral_sample(uint8_t *notify_data, size_t notify_data_size, uint16
 	struct bt_gatt_attr *notify_crch =
 		bt_gatt_find_by_uuid(mtu_test.attrs, 0xffff, &notify_characteristic_uuid.uuid);
 
-	/* Advertise. Auto include name in adv data. Connectable. */
-	bt_le_adv_start(BT_LE_ADV_CONN_NAME, adv_ad_data, ARRAY_SIZE(adv_ad_data), NULL, 0);
+	bt_le_adv_start(BT_LE_ADV_CONN, adv_ad_data, ARRAY_SIZE(adv_ad_data), NULL, 0);
 
 	bool infinite = seconds == 0;
 

--- a/samples/bluetooth/periodic_adv/src/main.c
+++ b/samples/bluetooth/periodic_adv/src/main.c
@@ -12,6 +12,10 @@ static const struct bt_data ad[] = {
 	BT_DATA(BT_DATA_MANUFACTURER_DATA, mfg_data, 3),
 };
 
+static const struct bt_data sd[] = {
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
+};
+
 int main(void)
 {
 	struct bt_le_ext_adv *adv;
@@ -27,9 +31,16 @@ int main(void)
 	}
 
 	/* Create a non-connectable non-scannable advertising set */
-	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_NCONN_NAME, NULL, &adv);
+	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_NCONN, NULL, &adv);
 	if (err) {
 		printk("Failed to create advertising set (err %d)\n", err);
+		return 0;
+	}
+
+	/* Set advertising data to have complete local name set */
+	err = bt_le_ext_adv_set_data(adv, NULL, 0, sd, ARRAY_SIZE(sd));
+	if (err) {
+		printk("Failed to set advertising data (err %d)\n", err);
 		return 0;
 	}
 

--- a/samples/bluetooth/periodic_adv_conn/src/main.c
+++ b/samples/bluetooth/periodic_adv_conn/src/main.c
@@ -160,6 +160,11 @@ static void init_bufs(void)
 	}
 }
 
+static const struct bt_data ad[] = {
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
+};
+
+
 int main(void)
 {
 	int err;
@@ -177,9 +182,16 @@ int main(void)
 	}
 
 	/* Create a non-connectable non-scannable advertising set */
-	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_NCONN_NAME, &adv_cb, &pawr_adv);
+	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_NCONN, &adv_cb, &pawr_adv);
 	if (err) {
 		printk("Failed to create advertising set (err %d)\n", err);
+		return 0;
+	}
+
+	/* Set advertising data to have complete local name set */
+	err = bt_le_ext_adv_set_data(pawr_adv, ad, ARRAY_SIZE(ad), NULL, 0);
+	if (err) {
+		printk("Failed to set advertising data (err %d)\n", err);
 		return 0;
 	}
 

--- a/samples/bluetooth/periodic_sync_rsp/src/main.c
+++ b/samples/bluetooth/periodic_sync_rsp/src/main.c
@@ -195,6 +195,10 @@ BT_CONN_CB_DEFINE(conn_cb) = {
 	.disconnected = disconnected,
 };
 
+static const struct bt_data sd[] = {
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
+};
+
 int main(void)
 {
 	struct bt_le_per_adv_sync_transfer_param past_param;
@@ -223,11 +227,9 @@ int main(void)
 
 	do {
 		err = bt_le_adv_start(
-			BT_LE_ADV_PARAM(BT_LE_ADV_OPT_ONE_TIME | BT_LE_ADV_OPT_CONNECTABLE |
-						BT_LE_ADV_OPT_USE_NAME |
-						BT_LE_ADV_OPT_FORCE_NAME_IN_AD,
+			BT_LE_ADV_PARAM(BT_LE_ADV_OPT_ONE_TIME | BT_LE_ADV_OPT_CONNECTABLE,
 					BT_GAP_ADV_FAST_INT_MIN_2, BT_GAP_ADV_FAST_INT_MAX_2, NULL),
-			NULL, 0, NULL, 0);
+			NULL, 0, sd, ARRAY_SIZE(sd));
 		if (err && err != -EALREADY) {
 			printk("Advertising failed to start (err %d)\n", err);
 

--- a/samples/bluetooth/peripheral/src/main.c
+++ b/samples/bluetooth/peripheral/src/main.c
@@ -226,6 +226,10 @@ static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_UUID128_ALL, BT_UUID_CUSTOM_SERVICE_VAL),
 };
 
+static const struct bt_data sd[] = {
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
+};
+
 void mtu_updated(struct bt_conn *conn, uint16_t tx, uint16_t rx)
 {
 	printk("Updated MTU: TX: %d RX: %d bytes\n", tx, rx);
@@ -287,7 +291,7 @@ static void bt_ready(void)
 		settings_load();
 	}
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);
 		return;

--- a/samples/bluetooth/peripheral_accept_list/src/main.c
+++ b/samples/bluetooth/peripheral_accept_list/src/main.c
@@ -74,7 +74,8 @@ static const struct bt_data ad[] = {
 };
 
 static const struct bt_data sd[] = {
-	BT_DATA_BYTES(BT_DATA_UUID128_ALL, BT_UUID_CUSTOM_SERVICE_VAL)
+	BT_DATA_BYTES(BT_DATA_UUID128_ALL, BT_UUID_CUSTOM_SERVICE_VAL),
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
 };
 
 static void connected(struct bt_conn *conn, uint8_t err)
@@ -119,7 +120,7 @@ static void bt_ready(void)
 	bond_count = 0;
 	bt_foreach_bond(BT_ID_DEFAULT, add_bonded_addr_to_filter_list, NULL);
 
-	adv_param = *BT_LE_ADV_CONN_NAME;
+	adv_param = *BT_LE_ADV_CONN;
 
 	/* If we have got at least one bond, activate the filter */
 	if (bond_count) {

--- a/samples/bluetooth/peripheral_csc/src/main.c
+++ b/samples/bluetooth/peripheral_csc/src/main.c
@@ -368,13 +368,17 @@ static const struct bt_data ad[] = {
 		      BT_UUID_16_ENCODE(BT_UUID_BAS_VAL))
 };
 
+static const struct bt_data sd[] = {
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
+};
+
 static void bt_ready(void)
 {
 	int err;
 
 	printk("Bluetooth initialized\n");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);
 		return;

--- a/samples/bluetooth/peripheral_dis/src/main.c
+++ b/samples/bluetooth/peripheral_dis/src/main.c
@@ -26,6 +26,10 @@ static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_UUID16_ALL, BT_UUID_16_ENCODE(BT_UUID_DIS_VAL)),
 };
 
+static const struct bt_data sd[] = {
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
+};
+
 static void connected(struct bt_conn *conn, uint8_t err)
 {
 	if (err) {
@@ -96,7 +100,7 @@ int main(void)
 
 	printk("Bluetooth initialized\n");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);
 		return 0;

--- a/samples/bluetooth/peripheral_esp/src/main.c
+++ b/samples/bluetooth/peripheral_esp/src/main.c
@@ -392,6 +392,10 @@ static const struct bt_data ad[] = {
 		      BT_UUID_16_ENCODE(BT_UUID_BAS_VAL)),
 };
 
+static const struct bt_data sd[] = {
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
+};
+
 static void connected(struct bt_conn *conn, uint8_t err)
 {
 	if (err) {
@@ -417,7 +421,7 @@ static void bt_ready(void)
 
 	printk("Bluetooth initialized\n");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);
 		return;

--- a/samples/bluetooth/peripheral_gatt_write/src/peripheral_gatt_write.c
+++ b/samples/bluetooth/peripheral_gatt_write/src/peripheral_gatt_write.c
@@ -20,6 +20,10 @@ static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
 };
 
+static const struct bt_data sd[] = {
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
+};
+
 static void mtu_updated(struct bt_conn *conn, uint16_t tx, uint16_t rx)
 {
 	printk("Updated MTU: TX: %d RX: %d bytes\n", tx, rx);
@@ -62,7 +66,7 @@ uint32_t peripheral_gatt_write(uint32_t count)
 	(void)bt_conn_auth_cb_register(&auth_callbacks);
 #endif /* CONFIG_BT_SMP */
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);
 		return 0U;

--- a/samples/bluetooth/peripheral_hids/src/main.c
+++ b/samples/bluetooth/peripheral_hids/src/main.c
@@ -31,6 +31,10 @@ static const struct bt_data ad[] = {
 		      BT_UUID_16_ENCODE(BT_UUID_BAS_VAL)),
 };
 
+static const struct bt_data sd[] = {
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
+};
+
 static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
@@ -94,7 +98,7 @@ static void bt_ready(int err)
 		settings_load();
 	}
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);
 		return;

--- a/samples/bluetooth/peripheral_hr/src/main.c
+++ b/samples/bluetooth/peripheral_hr/src/main.c
@@ -32,6 +32,10 @@ static const struct bt_data ad[] = {
 		      BT_UUID_16_ENCODE(BT_UUID_DIS_VAL))
 };
 
+static const struct bt_data sd[] = {
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
+};
+
 static void connected(struct bt_conn *conn, uint8_t err)
 {
 	if (err) {
@@ -76,7 +80,7 @@ static void bt_ready(void)
 
 	printk("Bluetooth initialized\n");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);
 		return;

--- a/samples/bluetooth/peripheral_ht/src/main.c
+++ b/samples/bluetooth/peripheral_ht/src/main.c
@@ -31,6 +31,10 @@ static const struct bt_data ad[] = {
 		      BT_UUID_16_ENCODE(BT_UUID_BAS_VAL)),
 };
 
+static const struct bt_data sd[] = {
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
+};
+
 static void connected(struct bt_conn *conn, uint8_t err)
 {
 	if (err) {
@@ -58,7 +62,7 @@ static void bt_ready(void)
 
 	hts_init();
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);
 		return;

--- a/samples/bluetooth/peripheral_identity/src/peripheral_identity.c
+++ b/samples/bluetooth/peripheral_identity/src/peripheral_identity.c
@@ -22,6 +22,10 @@ static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
 };
 
+static const struct bt_data sd[] = {
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
+};
+
 static void adv_start(struct k_work *work)
 {
 	struct bt_le_adv_param adv_param = {
@@ -29,7 +33,6 @@ static void adv_start(struct k_work *work)
 		.sid = 0,
 		.secondary_max_skip = 0,
 		.options = (BT_LE_ADV_OPT_CONNECTABLE |
-			    BT_LE_ADV_OPT_USE_NAME |
 			    BT_LE_ADV_OPT_ONE_TIME),
 		.interval_min = 0x0020, /* 20 ms */
 		.interval_max = 0x0020, /* 20 ms */
@@ -57,7 +60,7 @@ static void adv_start(struct k_work *work)
 	printk("Using current id: %u\n", id_current);
 	adv_param.id = id_current;
 
-	err = bt_le_adv_start(&adv_param, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(&adv_param, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);
 		return;

--- a/samples/bluetooth/peripheral_iso/src/main.c
+++ b/samples/bluetooth/peripheral_iso/src/main.c
@@ -22,6 +22,10 @@ static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
 };
 
+static const struct bt_data sd[] = {
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
+};
+
 static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
@@ -172,7 +176,7 @@ int main(void)
 		return 0;
 	}
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);
 		return 0;

--- a/samples/bluetooth/peripheral_past/src/main.c
+++ b/samples/bluetooth/peripheral_past/src/main.c
@@ -110,6 +110,10 @@ static struct bt_conn_cb conn_callbacks = {
 	.disconnected = disconnected,
 };
 
+static const struct bt_data sd[] = {
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
+};
+
 int main(void)
 {
 	struct bt_le_per_adv_sync_transfer_param past_param;
@@ -142,7 +146,7 @@ int main(void)
 		return 0;
 	}
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, NULL, 0, NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, NULL, 0, sd, ARRAY_SIZE(sd));
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);
 		return 0;

--- a/samples/bluetooth/peripheral_sc_only/src/main.c
+++ b/samples/bluetooth/peripheral_sc_only/src/main.c
@@ -24,6 +24,10 @@ static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
 };
 
+static const struct bt_data sd[] = {
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
+};
+
 static void connected(struct bt_conn *conn, uint8_t err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
@@ -141,7 +145,7 @@ int main(void)
 	bt_conn_auth_cb_register(&auth_cb_display);
 	bt_conn_auth_info_cb_register(&auth_cb_info);
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);
 		return 0;

--- a/samples/bluetooth/public_broadcast_source/src/main.c
+++ b/samples/bluetooth/public_broadcast_source/src/main.c
@@ -49,6 +49,10 @@ static struct bt_bap_lc3_preset broadcast_preset_48_2_1 =
 	BT_BAP_LC3_UNICAST_PRESET_48_2_1(BT_AUDIO_LOCATION_FRONT_LEFT,
 					BT_AUDIO_CONTEXT_TYPE_MEDIA);
 
+static const struct bt_data ad[] = {
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
+};
+
 struct bt_cap_initiator_broadcast_stream_param stream_params;
 struct bt_cap_initiator_broadcast_subgroup_param subgroup_param;
 struct bt_cap_initiator_broadcast_create_param create_param;
@@ -124,11 +128,19 @@ static int setup_extended_adv(struct bt_le_ext_adv **adv)
 	int err;
 
 	/* Create a non-connectable non-scannable advertising set */
-	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_NCONN_NAME, NULL, adv);
+	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_NCONN, NULL, adv);
 	if (err != 0) {
 		printk("Unable to create extended advertising set: %d\n", err);
 
 		return err;
+	}
+
+	/* Set advertising data to have complete local name set */
+	err = bt_le_ext_adv_set_data(*adv, ad, ARRAY_SIZE(ad), NULL, 0);
+	if (err) {
+		printk("Failed to set advertising data (err %d)\n", err);
+
+		return 0;
 	}
 
 	/* Set periodic advertising parameters */

--- a/samples/bluetooth/tmap_bms/src/cap_initiator.c
+++ b/samples/bluetooth/tmap_bms/src/cap_initiator.c
@@ -107,15 +107,26 @@ static struct bt_bap_stream_ops broadcast_stream_ops = {
 	.sent = broadcast_sent_cb
 };
 
+static const struct bt_data ad[] = {
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
+};
+
 static int setup_extended_adv(struct bt_le_ext_adv **adv)
 {
 	int err;
 
 	/* Create a non-connectable non-scannable advertising set */
-	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_NCONN_NAME, NULL, adv);
+	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_NCONN, NULL, adv);
 	if (err != 0) {
 		printk("Unable to create extended advertising set: %d\n", err);
 		return err;
+	}
+
+	/* Set advertising data to have complete local name set */
+	err = bt_le_ext_adv_set_data(*adv, ad, ARRAY_SIZE(ad), NULL, 0);
+	if (err) {
+		printk("Failed to set advertising data (err %d)\n", err);
+		return 0;
 	}
 
 	/* Set periodic advertising parameters */

--- a/samples/bluetooth/tmap_peripheral/src/main.c
+++ b/samples/bluetooth/tmap_peripheral/src/main.c
@@ -62,6 +62,7 @@ static const struct bt_data ad[] = {
 	BT_DATA(BT_DATA_SVC_DATA16, tmap_addata, ARRAY_SIZE(tmap_addata)),
 	BT_DATA(BT_DATA_SVC_DATA16, cap_addata, ARRAY_SIZE(cap_addata)),
 	BT_DATA(BT_DATA_SVC_DATA16, unicast_server_addata, ARRAY_SIZE(unicast_server_addata)),
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
 };
 
 static K_SEM_DEFINE(sem_connected, 0, 1);
@@ -243,7 +244,7 @@ int main(void)
 	}
 	printk("BAP initialized\n");
 
-	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_CONN_NAME, &adv_cb, &adv);
+	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_CONN, &adv_cb, &adv);
 	if (err) {
 		printk("Failed to create advertising set (err %d)\n", err);
 		return err;

--- a/samples/bluetooth/unicast_audio_server/src/main.c
+++ b/samples/bluetooth/unicast_audio_server/src/main.c
@@ -67,6 +67,7 @@ static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
 	BT_DATA_BYTES(BT_DATA_UUID16_ALL, BT_UUID_16_ENCODE(BT_UUID_ASCS_VAL)),
 	BT_DATA(BT_DATA_SVC_DATA16, unicast_server_addata, ARRAY_SIZE(unicast_server_addata)),
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
 };
 
 #define AUDIO_DATA_TIMEOUT_US 1000000UL /* Send data every 1 second */
@@ -750,7 +751,7 @@ int main(void)
 	}
 
 	/* Create a non-connectable non-scannable advertising set */
-	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_CONN_NAME, NULL, &adv);
+	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_CONN, NULL, &adv);
 	if (err) {
 		printk("Failed to create advertising set (err %d)\n", err);
 		return 0;

--- a/samples/boards/bbc_microbit/pong/src/ble.c
+++ b/samples/boards/bbc_microbit/pong/src/ble.c
@@ -42,6 +42,10 @@ static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_UUID128_ALL, PONG_SVC_UUID),
 };
 
+static const struct bt_data sd[] = {
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
+};
+
 static struct bt_conn *default_conn;
 
 static const struct bt_gatt_attr *local_attr;
@@ -467,8 +471,8 @@ static void ble_timeout(struct k_work *work)
 		k_work_reschedule(&ble_work, K_NO_WAIT);
 		break;
 	case BLE_ADV_START:
-		err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad),
-				      NULL, 0);
+		err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad),
+				      sd, ARRAY_SIZE(sd));
 		if (err) {
 			printk("Advertising failed to start (err %d)\n", err);
 			return;

--- a/samples/boards/reel_board/mesh_badge/src/main.c
+++ b/samples/boards/reel_board/mesh_badge/src/main.c
@@ -22,6 +22,10 @@ static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, BT_LE_AD_NO_BREDR),
 };
 
+static const struct bt_data sd[] = {
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
+};
+
 static ssize_t read_name(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			 void *buf, uint16_t len, uint16_t offset)
 {
@@ -176,8 +180,7 @@ static void bt_ready(int err)
 
 	if (!mesh_is_initialized()) {
 		/* Start advertising */
-		err = bt_le_adv_start(BT_LE_ADV_CONN_NAME,
-				      ad, ARRAY_SIZE(ad), NULL, 0);
+		err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 		if (err) {
 			printk("Advertising failed to start (err %d)\n", err);
 			return;

--- a/samples/subsys/logging/ble_backend/src/main.c
+++ b/samples/subsys/logging/ble_backend/src/main.c
@@ -17,11 +17,15 @@ static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_UUID128_ALL, LOGGER_BACKEND_BLE_ADV_UUID_DATA)
 };
 
+static const struct bt_data sd[] = {
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
+};
+
 static void start_adv(void)
 {
 	int err;
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		LOG_ERR("Advertising failed to start (err %d)", err);
 		return;

--- a/samples/subsys/mgmt/mcumgr/smp_svr/src/bluetooth.c
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/src/bluetooth.c
@@ -23,13 +23,17 @@ static const struct bt_data ad[] = {
 		      0xd3, 0x4c, 0xb7, 0x1d, 0x1d, 0xdc, 0x53, 0x8d),
 };
 
+static const struct bt_data sd[] = {
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
+};
+
 static void advertise(struct k_work *work)
 {
 	int rc;
 
 	bt_le_adv_stop();
 
-	rc = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
+	rc = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (rc) {
 		LOG_ERR("Advertising failed to start (rc %d)", rc);
 		return;

--- a/subsys/bluetooth/mesh/pb_gatt_srv.c
+++ b/subsys/bluetooth/mesh/pb_gatt_srv.c
@@ -33,16 +33,9 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_mesh_pb_gatt_srv);
 
-#if defined(CONFIG_BT_MESH_PB_GATT_USE_DEVICE_NAME)
-#define ADV_OPT_USE_NAME BT_LE_ADV_OPT_USE_NAME
-#else
-#define ADV_OPT_USE_NAME 0
-#endif
-
 #define ADV_OPT_PROV                                                           \
 	(BT_LE_ADV_OPT_CONNECTABLE | BT_LE_ADV_OPT_SCANNABLE |                 \
-	 BT_LE_ADV_OPT_ONE_TIME | ADV_OPT_USE_IDENTITY |                       \
-	 ADV_OPT_USE_NAME)
+	 BT_LE_ADV_OPT_ONE_TIME | ADV_OPT_USE_IDENTITY)
 
 #define FAST_ADV_TIME (60LL * MSEC_PER_SEC)
 
@@ -222,8 +215,10 @@ static const struct bt_data prov_ad[] = {
 	BT_DATA(BT_DATA_SVC_DATA16, prov_svc_data, sizeof(prov_svc_data)),
 };
 
-static size_t gatt_prov_adv_create(struct bt_data prov_sd[1])
+static size_t gatt_prov_adv_create(struct bt_data prov_sd[2])
 {
+	size_t prov_sd_len = 0;
+
 	const struct bt_mesh_prov *prov = bt_mesh_prov_get();
 	size_t uri_len;
 
@@ -245,7 +240,17 @@ static size_t gatt_prov_adv_create(struct bt_data prov_sd[1])
 	prov_sd[0].data_len = uri_len;
 	prov_sd[0].data = (const uint8_t *)prov->uri;
 
-	return 1;
+	prov_sd_len += 1;
+
+#if defined(CONFIG_BT_MESH_PB_GATT_USE_DEVICE_NAME)
+	prov_sd[1].type = BT_DATA_NAME_COMPLETE;
+	prov_sd[1].data_len = sizeof(CONFIG_BT_DEVICE_NAME) - 1;
+	prov_sd[1].data = CONFIG_BT_DEVICE_NAME;
+
+	prov_sd_len += 1;
+#endif
+
+	return prov_sd_len;
 }
 
 static int gatt_send(struct bt_conn *conn,
@@ -279,7 +284,7 @@ int bt_mesh_pb_gatt_srv_adv_start(void)
 		.options = ADV_OPT_PROV,
 		ADV_FAST_INT,
 	};
-	struct bt_data prov_sd[1];
+	struct bt_data prov_sd[2];
 	size_t prov_sd_len;
 	int64_t timestamp = fast_adv_timestamp;
 	int64_t elapsed_time = k_uptime_delta(&timestamp);

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -1762,14 +1762,33 @@ static ssize_t ad_init(struct bt_data *data_array, const size_t data_array_size,
 	return ad_len;
 }
 
+void set_ad_name_complete(struct bt_data *ad, const char *name)
+{
+	ad->type = BT_DATA_NAME_COMPLETE;
+	ad->data_len = strlen(name);
+	ad->data = name;
+}
+
+void set_ad_device_name_complete(struct bt_data *ad)
+{
+	const char *name = bt_get_name();
+
+	set_ad_name_complete(ad, name);
+}
+
 static int cmd_advertise(const struct shell *sh, size_t argc, char *argv[])
 {
 	struct bt_le_adv_param param = {};
-	struct bt_data ad[3];
+	struct bt_data ad[4];
+	struct bt_data sd[4];
 	bool discoverable = true;
 	bool appearance = false;
-	ssize_t ad_len;
+	ssize_t ad_len = 0;
+	ssize_t sd_len = 0;
 	int err;
+	bool with_name = true;
+	bool name_ad = false;
+	bool name_sd = true;
 
 	if (!strcmp(argv[1], "off")) {
 		if (bt_le_adv_stop() < 0) {
@@ -1787,10 +1806,7 @@ static int cmd_advertise(const struct shell *sh, size_t argc, char *argv[])
 	param.interval_max = BT_GAP_ADV_FAST_INT_MAX_2;
 
 	if (!strcmp(argv[1], "on")) {
-		param.options = (BT_LE_ADV_OPT_CONNECTABLE |
-				 BT_LE_ADV_OPT_USE_NAME);
-	} else if (!strcmp(argv[1], "scan")) {
-		param.options = BT_LE_ADV_OPT_USE_NAME;
+		param.options = BT_LE_ADV_OPT_CONNECTABLE;
 	} else if (!strcmp(argv[1], "nconn")) {
 		param.options = 0U;
 	} else {
@@ -1816,10 +1832,10 @@ static int cmd_advertise(const struct shell *sh, size_t argc, char *argv[])
 		} else if (!strcmp(arg, "identity")) {
 			param.options |= BT_LE_ADV_OPT_USE_IDENTITY;
 		} else if (!strcmp(arg, "no-name")) {
-			param.options &= ~BT_LE_ADV_OPT_USE_NAME;
+			with_name = false;
 		} else if (!strcmp(arg, "name-ad")) {
-			param.options |= BT_LE_ADV_OPT_USE_NAME;
-			param.options |= BT_LE_ADV_OPT_FORCE_NAME_IN_AD;
+			name_ad = true;
+			name_sd = false;
 		} else if (!strcmp(arg, "one-time")) {
 			param.options |= BT_LE_ADV_OPT_ONE_TIME;
 		} else if (!strcmp(arg, "disable-37")) {
@@ -1833,18 +1849,30 @@ static int cmd_advertise(const struct shell *sh, size_t argc, char *argv[])
 		}
 	}
 
+	if (name_ad && with_name) {
+		set_ad_device_name_complete(&ad[0]);
+		ad_len++;
+	}
+
+	if (name_sd && with_name) {
+		set_ad_device_name_complete(&sd[0]);
+		sd_len++;
+	}
+
 	atomic_clear(adv_opt);
 	atomic_set_bit_to(adv_opt, SHELL_ADV_OPT_CONNECTABLE,
 			  (param.options & BT_LE_ADV_OPT_CONNECTABLE) > 0);
 	atomic_set_bit_to(adv_opt, SHELL_ADV_OPT_DISCOVERABLE, discoverable);
 	atomic_set_bit_to(adv_opt, SHELL_ADV_OPT_APPEARANCE, appearance);
 
-	ad_len = ad_init(ad, ARRAY_SIZE(ad), adv_opt);
+	err = ad_init(&ad[ad_len], ARRAY_SIZE(ad) - ad_len, adv_opt);
 	if (ad_len < 0) {
 		return -ENOEXEC;
 	}
+	ad_len += err;
 
-	err = bt_le_adv_start(&param, ad_len > 0 ? ad : NULL, ad_len, NULL, 0);
+	err = bt_le_adv_start(&param, ad_len > 0 ? ad : NULL, ad_len, sd_len > 0 ? sd : NULL,
+			      sd_len);
 	if (err < 0) {
 		shell_error(sh, "Failed to start advertising (err %d)",
 			    err);
@@ -1954,11 +1982,6 @@ static bool adv_param_parse(size_t argc, char *argv[],
 			param->options |= BT_LE_ADV_OPT_FILTER_CONN;
 		} else if (!strcmp(arg, "identity")) {
 			param->options |= BT_LE_ADV_OPT_USE_IDENTITY;
-		} else if (!strcmp(arg, "name")) {
-			param->options |= BT_LE_ADV_OPT_USE_NAME;
-		} else if (!strcmp(arg, "name-ad")) {
-			param->options |= BT_LE_ADV_OPT_USE_NAME;
-			param->options |= BT_LE_ADV_OPT_FORCE_NAME_IN_AD;
 		} else if (!strcmp(arg, "low")) {
 			param->options |= BT_LE_ADV_OPT_DIR_MODE_LOW_DUTY;
 		} else if (!strcmp(arg, "dir-rpa")) {
@@ -2069,6 +2092,9 @@ static int cmd_adv_data(const struct shell *sh, size_t argc, char *argv[])
 	bool discoverable = false;
 	size_t *data_len;
 	int err;
+	bool name = false;
+	bool dev_name = false;
+	const char *name_value = NULL;
 
 	if (!adv) {
 		return -EINVAL;
@@ -2081,11 +2107,31 @@ static int cmd_adv_data(const struct shell *sh, size_t argc, char *argv[])
 	for (size_t argn = 1; argn < argc; argn++) {
 		const char *arg = argv[argn];
 
-		if (strcmp(arg, "scan-response") &&
-		    *data_len == ARRAY_SIZE(ad)) {
+		if (name && !dev_name && name_value == NULL) {
+			if (*data_len == ARRAY_SIZE(ad)) {
+				/* Maximum entries limit reached. */
+				shell_print(sh, "Failed to set advertising data: "
+						"Maximum entries limit reached");
+
+				return -ENOEXEC;
+			}
+
+			len = strlen(arg);
+			memcpy(&hex_data[hex_data_len], arg, len);
+			name_value = &hex_data[hex_data_len];
+
+			set_ad_name_complete(&data[*data_len], name_value);
+
+			(*data_len)++;
+			hex_data_len += len;
+
+			continue;
+		}
+
+		if (strcmp(arg, "scan-response") && *data_len == ARRAY_SIZE(ad)) {
 			/* Maximum entries limit reached. */
 			shell_print(sh, "Failed to set advertising data: "
-					   "Maximum entries limit reached");
+					"Maximum entries limit reached");
 
 			return -ENOEXEC;
 		}
@@ -2099,19 +2145,24 @@ static int cmd_adv_data(const struct shell *sh, size_t argc, char *argv[])
 		} else if (!strcmp(arg, "scan-response")) {
 			if (data == sd) {
 				shell_print(sh, "Failed to set advertising data: "
-						   "duplicate scan-response option");
+						"duplicate scan-response option");
 				return -ENOEXEC;
 			}
 
 			data = sd;
 			data_len = &sd_len;
+		} else if (!strcmp(arg, "name") && !name) {
+			name = true;
+		} else if (!strcmp(arg, "dev-name")) {
+			name = true;
+			dev_name = true;
 		} else {
 			len = hex2bin(arg, strlen(arg), &hex_data[hex_data_len],
 				      sizeof(hex_data) - hex_data_len);
 
 			if (!len || (len - 1) != (hex_data[hex_data_len])) {
 				shell_print(sh, "Failed to set advertising data: "
-						   "malformed hex data");
+						"malformed hex data");
 				return -ENOEXEC;
 			}
 
@@ -2121,6 +2172,25 @@ static int cmd_adv_data(const struct shell *sh, size_t argc, char *argv[])
 			(*data_len)++;
 			hex_data_len += len;
 		}
+	}
+
+	if (name && !dev_name && name_value == NULL) {
+		shell_error(sh, "Failed to set advertising data: Expected a value for 'name'");
+		return -ENOEXEC;
+	}
+
+	if (name && dev_name && name_value == NULL) {
+		if (*data_len == ARRAY_SIZE(ad)) {
+			/* Maximum entries limit reached. */
+			shell_print(sh, "Failed to set advertising data: "
+					"Maximum entries limit reached");
+
+			return -ENOEXEC;
+		}
+
+		set_ad_device_name_complete(&data[*data_len]);
+
+		(*data_len)++;
 	}
 
 	atomic_set_bit_to(adv_set_opt[selected_adv], SHELL_ADV_OPT_DISCOVERABLE, discoverable);
@@ -2324,7 +2394,7 @@ static int cmd_adv_rpa_expire(const struct shell *sh, size_t argc, char *argv[])
 
 	return 0;
 }
-#endif
+#endif /* CONFIG_BT_PRIVACY */
 
 #if defined(CONFIG_BT_PER_ADV)
 static int cmd_per_adv(const struct shell *sh, size_t argc, char *argv[])
@@ -4472,8 +4542,8 @@ static int cmd_default_handler(const struct shell *sh, size_t argc, char **argv)
 #define EXT_ADV_PARAM                                                                              \
 	"<type: conn-scan conn-nscan, nconn-scan nconn-nscan> "                                    \
 	"[ext-adv] [no-2m] [coded] [anon] [tx-power] [scan-reports] "                              \
-	"[filter-accept-list: fal, fal-scan, fal-conn] [identity] [name] "                         \
-	"[name-ad] [directed " HELP_ADDR_LE "] [mode: low] [dir-rpa] "                             \
+	"[filter-accept-list: fal, fal-scan, fal-conn] [identity] "                                \
+	"[directed " HELP_ADDR_LE "] [mode: low] [dir-rpa] "                                       \
 	"[disable-37] [disable-38] [disable-39]"
 #else
 #define EXT_ADV_SCAN_OPT ""
@@ -4551,7 +4621,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(bt_cmds,
 #endif
 #if defined(CONFIG_BT_BROADCASTER)
 	SHELL_CMD_ARG(advertise, NULL,
-		      "<type: off, on, scan, nconn> [mode: discov, non_discov] "
+		      "<type: off, on, nconn> [mode: discov, non_discov] "
 		      "[filter-accept-list: fal, fal-scan, fal-conn] [identity] [no-name] "
 		      "[one-time] [name-ad] [appearance] "
 		      "[disable-37] [disable-38] [disable-39]",
@@ -4565,7 +4635,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(bt_cmds,
 	SHELL_CMD_ARG(adv-create, NULL, EXT_ADV_PARAM, cmd_adv_create, 2, 11),
 	SHELL_CMD_ARG(adv-param, NULL, EXT_ADV_PARAM, cmd_adv_param, 2, 11),
 	SHELL_CMD_ARG(adv-data, NULL, "<data> [scan-response <data>] "
-				      "<type: discov, hex> [appearance] ",
+				      "<type: discov, hex> [appearance] "
+				      "[name <str>] [dev-name]",
 		      cmd_adv_data, 1, 16),
 	SHELL_CMD_ARG(adv-start, NULL,
 		"[timeout <timeout>] [num-events <num events>]",

--- a/tests/bluetooth/common/testlib/include/testlib/adv.h
+++ b/tests/bluetooth/common/testlib/include/testlib/adv.h
@@ -7,6 +7,6 @@
 
 #include <zephyr/bluetooth/bluetooth.h>
 
-int bt_testlib_adv_conn(struct bt_conn **conn, int id, uint32_t adv_options);
+int bt_testlib_adv_conn(struct bt_conn **conn, int id, const char *name);
 
 #endif /* ZEPHYR_TESTS_BLUETOOTH_COMMON_TESTLIB_INCLUDE_TESTLIB_ADV_H_ */

--- a/tests/bluetooth/common/testlib/src/adv.c
+++ b/tests/bluetooth/common/testlib/src/adv.c
@@ -35,7 +35,7 @@ static void connected_cb(struct bt_le_ext_adv *adv, struct bt_le_ext_adv_connect
 	k_mutex_unlock(&g_ctx_lock);
 }
 
-int bt_testlib_adv_conn(struct bt_conn **conn, int id, uint32_t adv_options)
+int bt_testlib_adv_conn(struct bt_conn **conn, int id, const char *name)
 {
 	int api_err;
 	struct bt_le_ext_adv *adv = NULL;
@@ -51,7 +51,6 @@ int bt_testlib_adv_conn(struct bt_conn **conn, int id, uint32_t adv_options)
 	param.interval_min = BT_GAP_ADV_FAST_INT_MIN_1;
 	param.interval_max = BT_GAP_ADV_FAST_INT_MAX_1;
 	param.options |= BT_LE_ADV_OPT_CONNECTABLE;
-	param.options |= adv_options;
 
 	k_condvar_init(&ctx.done);
 
@@ -60,6 +59,16 @@ int bt_testlib_adv_conn(struct bt_conn **conn, int id, uint32_t adv_options)
 	g_ctx = &ctx;
 
 	api_err = bt_le_ext_adv_create(&param, &cb, &adv);
+	if (!api_err && name != NULL) {
+		struct bt_data ad;
+
+		ad.type = BT_DATA_NAME_COMPLETE;
+		ad.data_len = strlen(name);
+		ad.data = (const uint8_t *)name;
+
+		api_err = bt_le_ext_adv_set_data(adv, &ad, 1, NULL, 0);
+	}
+
 	if (!api_err) {
 		api_err = bt_le_ext_adv_start(adv, BT_LE_EXT_ADV_START_DEFAULT);
 	}

--- a/tests/bluetooth/shell/src/main.c
+++ b/tests/bluetooth/shell/src/main.c
@@ -53,7 +53,7 @@ static int cmd_hrs_simulate(const struct shell *sh,
 		if (!hrs_registered && IS_ENABLED(CONFIG_BT_BROADCASTER)) {
 			shell_print(sh, "Registering HRS Service");
 			hrs_registered = true;
-			err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad,
+			err = bt_le_adv_start(BT_LE_ADV_CONN, ad,
 					      ARRAY_SIZE(ad), NULL, 0);
 			if (err) {
 				shell_error(sh, "Advertising failed to start"

--- a/tests/bluetooth/tester/src/btp_bap_broadcast.c
+++ b/tests/bluetooth/tester/src/btp_bap_broadcast.c
@@ -295,7 +295,7 @@ uint8_t btp_bap_broadcast_source_setup(const void *cmd, uint16_t cmd_len,
 	struct bt_audio_codec_cfg codec_cfg;
 	const struct btp_bap_broadcast_source_setup_cmd *cp = cmd;
 	struct btp_bap_broadcast_source_setup_rp *rp = rsp;
-	struct bt_le_adv_param *param = BT_LE_EXT_ADV_NCONN_NAME;
+	struct bt_le_adv_param *param = BT_LE_EXT_ADV_NCONN;
 
 	/* Only one local source/BIG supported for now */
 	struct btp_bap_broadcast_local_source *source = &local_source;
@@ -305,6 +305,10 @@ uint8_t btp_bap_broadcast_source_setup(const void *cmd, uint16_t cmd_len,
 
 	NET_BUF_SIMPLE_DEFINE(ad_buf, BT_UUID_SIZE_16 + BT_AUDIO_BROADCAST_ID_SIZE);
 	NET_BUF_SIMPLE_DEFINE(base_buf, 128);
+
+	struct bt_data sd;
+
+	const char *dev_name = bt_get_name();
 
 	/* Broadcast Audio Streaming Endpoint advertising data */
 	struct bt_data base_ad;
@@ -347,8 +351,11 @@ uint8_t btp_bap_broadcast_source_setup(const void *cmd, uint16_t cmd_len,
 	base_ad.type = BT_DATA_SVC_DATA16;
 	base_ad.data_len = ad_buf.len;
 	base_ad.data = ad_buf.data;
-	err = tester_gap_create_adv_instance(param, BTP_GAP_ADDR_TYPE_IDENTITY, &base_ad, 1, NULL,
-					     0, &gap_settings);
+	sd.type = BT_DATA_NAME_COMPLETE;
+	sd.data_len = strlen(dev_name);
+	sd.data = (const uint8_t *)dev_name;
+	err = tester_gap_create_adv_instance(param, BTP_GAP_ADDR_TYPE_IDENTITY, &base_ad, 1,
+					     &sd, 1, &gap_settings);
 	if (err != 0) {
 		LOG_DBG("Failed to create extended advertising instance: %d", err);
 

--- a/tests/bluetooth/tester/src/btp_cap.c
+++ b/tests/bluetooth/tester/src/btp_cap.c
@@ -531,10 +531,14 @@ static int cap_broadcast_source_adv_setup(struct btp_bap_broadcast_local_source 
 					  uint32_t *gap_settings)
 {
 	int err;
-	struct bt_le_adv_param *param = BT_LE_EXT_ADV_NCONN_NAME;
+	struct bt_le_adv_param *param = BT_LE_EXT_ADV_NCONN;
 
 	NET_BUF_SIMPLE_DEFINE(ad_buf, BT_UUID_SIZE_16 + BT_AUDIO_BROADCAST_ID_SIZE);
 	NET_BUF_SIMPLE_DEFINE(base_buf, 128);
+
+	struct bt_data sd;
+
+	const char *dev_name = bt_get_name();
 
 	/* Broadcast Audio Streaming Endpoint advertising data */
 	struct bt_data base_ad;
@@ -555,8 +559,11 @@ static int cap_broadcast_source_adv_setup(struct btp_bap_broadcast_local_source 
 	base_ad.type = BT_DATA_SVC_DATA16;
 	base_ad.data_len = ad_buf.len;
 	base_ad.data = ad_buf.data;
-	err = tester_gap_create_adv_instance(param, BTP_GAP_ADDR_TYPE_IDENTITY, &base_ad, 1, NULL,
-					     0, gap_settings);
+	sd.type = BT_DATA_NAME_COMPLETE;
+	sd.data_len = strlen(dev_name);
+	sd.data = (const uint8_t *) dev_name;
+	err = tester_gap_create_adv_instance(param, BTP_GAP_ADDR_TYPE_IDENTITY, &base_ad, 1,
+					     &sd, 1, gap_settings);
 	if (err != 0) {
 		LOG_DBG("Failed to create extended advertising instance: %d", err);
 

--- a/tests/bsim/bluetooth/audio/src/bap_bass_broadcaster_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_bass_broadcaster_test.c
@@ -32,7 +32,7 @@ static void test_main(void)
 	printk("Bluetooth initialized\n");
 
 	/* Create a non-connectable non-scannable advertising set */
-	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_NCONN_NAME, NULL, &adv);
+	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_NCONN, NULL, &adv);
 	if (err) {
 		FAIL("Failed to create advertising set (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
@@ -899,7 +899,7 @@ static void test_start_adv(void)
 	int err;
 
 	/* Create a non-connectable non-scannable advertising set */
-	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_CONN_NAME, NULL, &ext_adv);
+	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_CONN, NULL, &ext_adv);
 	if (err != 0) {
 		FAIL("Failed to create advertising set (err %d)\n", err);
 

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_source_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_source_test.c
@@ -214,7 +214,7 @@ static int setup_extended_adv(struct bt_bap_broadcast_source *source, struct bt_
 	NET_BUF_SIMPLE_DEFINE(ad_buf,
 			      BT_UUID_SIZE_16 + BT_AUDIO_BROADCAST_ID_SIZE);
 	struct bt_le_adv_param adv_param = BT_LE_ADV_PARAM_INIT(
-		BT_LE_ADV_OPT_EXT_ADV | BT_LE_ADV_OPT_USE_NAME, 0x80, 0x80, NULL);
+		BT_LE_ADV_OPT_EXT_ADV, 0x80, 0x80, NULL);
 	NET_BUF_SIMPLE_DEFINE(base_buf, 128);
 	struct bt_data ext_ad;
 	struct bt_data per_ad;

--- a/tests/bsim/bluetooth/audio/src/bap_scan_delegator_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_scan_delegator_test.c
@@ -680,7 +680,7 @@ static int common_init(void)
 	bt_bap_scan_delegator_register_cb(&scan_delegator_cb);
 	bt_le_per_adv_sync_cb_register(&pa_sync_cb);
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, AD_SIZE, NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, AD_SIZE, NULL, 0);
 	if (err) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return err;

--- a/tests/bsim/bluetooth/audio/src/bap_unicast_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_unicast_server_test.c
@@ -491,7 +491,7 @@ static void init(void)
 	}
 
 	/* Create a non-connectable non-scannable advertising set */
-	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_CONN_NAME, NULL, &ext_adv);
+	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_CONN, NULL, &ext_adv);
 	if (err != 0) {
 		FAIL("Failed to create advertising set (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/audio/src/cap_acceptor_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_acceptor_test.c
@@ -616,7 +616,7 @@ static void init(void)
 			bt_cap_stream_ops_register(&unicast_streams[i], &unicast_stream_ops);
 		}
 
-		err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, cap_acceptor_ad,
+		err = bt_le_adv_start(BT_LE_ADV_CONN, cap_acceptor_ad,
 				      ARRAY_SIZE(cap_acceptor_ad), NULL, 0);
 		if (err != 0) {
 			FAIL("Advertising failed to start (err %d)\n", err);

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_broadcast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_broadcast_test.c
@@ -21,8 +21,7 @@
  * Broadcast ISO radio events.
  */
 #define BT_LE_EXT_ADV_CUSTOM \
-		BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV | \
-				BT_LE_ADV_OPT_USE_NAME, \
+		BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV, \
 				0x0080, 0x0080, NULL)
 
 #define BT_LE_PER_ADV_CUSTOM \

--- a/tests/bsim/bluetooth/audio/src/csip_notify_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/csip_notify_server_test.c
@@ -66,7 +66,7 @@ static void test_main(void)
 	}
 
 	printk("Start Advertising\n");
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;
@@ -107,7 +107,7 @@ static void test_main(void)
 	}
 
 	printk("Start Advertising\n");
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/audio/src/csip_set_member_test.c
+++ b/tests/bsim/bluetooth/audio/src/csip_set_member_test.c
@@ -70,7 +70,7 @@ static void bt_ready(int err)
 		return;
 	}
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 	}

--- a/tests/bsim/bluetooth/audio/src/gmap_ugg_test.c
+++ b/tests/bsim/bluetooth/audio/src/gmap_ugg_test.c
@@ -23,8 +23,7 @@
  * Broadcast ISO radio events.
  */
 #define BT_LE_EXT_ADV_CUSTOM \
-		BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV | \
-				BT_LE_ADV_OPT_USE_NAME, \
+		BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV, \
 				0x0080, 0x0080, NULL)
 
 #define BT_LE_PER_ADV_CUSTOM \

--- a/tests/bsim/bluetooth/audio/src/gmap_ugt_test.c
+++ b/tests/bsim/bluetooth/audio/src/gmap_ugt_test.c
@@ -416,7 +416,7 @@ static void test_main(void)
 		return;
 	}
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, gmap_acceptor_ad, ARRAY_SIZE(gmap_acceptor_ad),
+	err = bt_le_adv_start(BT_LE_ADV_CONN, gmap_acceptor_ad, ARRAY_SIZE(gmap_acceptor_ad),
 			      NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)\n", err);

--- a/tests/bsim/bluetooth/audio/src/has_test.c
+++ b/tests/bsim/bluetooth/audio/src/has_test.c
@@ -46,7 +46,7 @@ static void test_common(void)
 
 	LOG_DBG("Bluetooth initialized");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, AD_SIZE, NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, AD_SIZE, NULL, 0);
 	if (err) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/audio/src/ias_test.c
+++ b/tests/bsim/bluetooth/audio/src/ias_test.c
@@ -58,7 +58,7 @@ static void test_main(void)
 		return;
 	}
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, AD_SIZE, NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, AD_SIZE, NULL, 0);
 	if (err) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/audio/src/mcs_test.c
+++ b/tests/bsim/bluetooth/audio/src/mcs_test.c
@@ -22,7 +22,7 @@ static void bt_ready(int err)
 
 	printk("Bluetooth initialized\n");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, AD_SIZE, NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, AD_SIZE, NULL, 0);
 	if (err) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/audio/src/media_controller_test.c
+++ b/tests/bsim/bluetooth/audio/src/media_controller_test.c
@@ -1647,7 +1647,7 @@ void test_media_controller_remote_player(void)
 	initialize_bluetooth();
 	initialize_media();
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, AD_SIZE, NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, AD_SIZE, NULL, 0);
 	if (err) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 	}

--- a/tests/bsim/bluetooth/audio/src/micp_mic_dev_test.c
+++ b/tests/bsim/bluetooth/audio/src/micp_mic_dev_test.c
@@ -420,7 +420,7 @@ static void test_main(void)
 
 	printk("MICP initialized\n");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, AD_SIZE, NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, AD_SIZE, NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/audio/src/pacs_notify_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/pacs_notify_server_test.c
@@ -176,7 +176,7 @@ static void test_main(void)
 	}
 
 	LOG_DBG("Start Advertising");
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)", err);
 		return;
@@ -210,7 +210,7 @@ static void test_main(void)
 	trigger_notifications();
 
 	LOG_DBG("Start Advertising");
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)", err);
 		return;
@@ -227,7 +227,7 @@ static void test_main(void)
 	}
 
 	LOG_DBG("Start Advertising");
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)", err);
 		return;
@@ -261,7 +261,7 @@ static void test_main(void)
 	}
 
 	LOG_DBG("Start Advertising");
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)", err);
 		return;

--- a/tests/bsim/bluetooth/audio/src/pbp_public_broadcast_source_test.c
+++ b/tests/bsim/bluetooth/audio/src/pbp_public_broadcast_source_test.c
@@ -217,7 +217,7 @@ static int setup_extended_adv(struct bt_le_ext_adv **adv)
 	int err;
 
 	/* Create a non-connectable non-scannable advertising set */
-	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_NCONN_NAME, NULL, adv);
+	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_NCONN, NULL, adv);
 	if (err != 0) {
 		printk("Unable to create extended advertising set: %d\n", err);
 

--- a/tests/bsim/bluetooth/audio/src/tbs_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/tbs_client_test.c
@@ -494,7 +494,7 @@ static void test_main(void)
 
 	printk("Audio Server: Bluetooth discovered\n");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, AD_SIZE, NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, AD_SIZE, NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/audio/src/tmap_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/tmap_server_test.c
@@ -53,7 +53,7 @@ static void test_main(void)
 	}
 	printk("TMAP initialized. Start advertising...\n");
 	/* Create a connectable extended advertising set */
-	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_CONN_NAME, NULL, &adv);
+	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_CONN, NULL, &adv);
 	if (err) {
 		printk("Failed to create advertising set (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/audio/src/vcp_vol_rend_test.c
+++ b/tests/bsim/bluetooth/audio/src/vcp_vol_rend_test.c
@@ -1032,7 +1032,7 @@ static void test_main(void)
 
 	printk("VCP initialized\n");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, AD_SIZE, NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, AD_SIZE, NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/host/adv/extended/src/ext_adv_advertiser.c
+++ b/tests/bsim/bluetooth/host/adv/extended/src/ext_adv_advertiser.c
@@ -45,7 +45,7 @@ static void create_ext_adv_set(struct bt_le_ext_adv **adv, bool connectable)
 	printk("Creating extended advertising set...");
 
 	const struct bt_le_adv_param *adv_param = connectable ?
-		BT_LE_EXT_ADV_CONN_NAME : BT_LE_EXT_ADV_NCONN_NAME;
+		BT_LE_EXT_ADV_CONN : BT_LE_EXT_ADV_NCONN;
 
 	err = bt_le_ext_adv_create(adv_param, NULL, adv);
 	if (err) {

--- a/tests/bsim/bluetooth/host/adv/periodic/src/per_adv_advertiser.c
+++ b/tests/bsim/bluetooth/host/adv/periodic/src/per_adv_advertiser.c
@@ -89,7 +89,7 @@ static void create_per_adv_set(struct bt_le_ext_adv **adv)
 	int err;
 
 	printk("Creating extended advertising set...");
-	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_NCONN_NAME, NULL, adv);
+	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_NCONN, NULL, adv);
 	if (err) {
 		printk("Failed to create advertising set: %d\n", err);
 		return;
@@ -111,7 +111,7 @@ static void create_conn_adv_set(struct bt_le_ext_adv **adv)
 	int err;
 
 	printk("Creating connectable extended advertising set...");
-	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_CONN_NAME, NULL, adv);
+	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_CONN, NULL, adv);
 	if (err) {
 		printk("Failed to create advertising set: %d\n", err);
 		return;

--- a/tests/bsim/bluetooth/host/adv/resume2/connectable/main.c
+++ b/tests/bsim/bluetooth/host/adv/resume2/connectable/main.c
@@ -34,9 +34,7 @@ int main(void)
 
 		bt_testlib_conn_wait_free();
 
-		err = bt_testlib_adv_conn(
-			&conn, BT_ID_DEFAULT,
-			(BT_LE_ADV_OPT_USE_NAME | BT_LE_ADV_OPT_FORCE_NAME_IN_AD));
+		err = bt_testlib_adv_conn(&conn, BT_ID_DEFAULT, bt_get_name());
 		__ASSERT_NO_MSG(!err);
 
 		bt_testlib_wait_disconnected(conn);

--- a/tests/bsim/bluetooth/host/adv/resume2/dut/main.c
+++ b/tests/bsim/bluetooth/host/adv/resume2/dut/main.c
@@ -70,13 +70,24 @@ int main(void)
 	err = bt_set_name("dut");
 	__ASSERT_NO_MSG(!err);
 
+	struct bt_data ad[1] = {0};
+
+	const char *dev_name = bt_get_name();
+
+	ad[0].type = BT_DATA_NAME_COMPLETE;
+	ad[0].data_len = strlen(dev_name);
+	ad[0].data = (const uint8_t *)dev_name;
+
 	LOG_INF("---------- Test setup ----------");
 
 	LOG_INF("Environment test: Advertiser fills connection capacity.");
 
 	/* `bt_le_adv_start` is invoked once, and.. */
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME_AD, NULL, 0, NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, NULL, 0, NULL, 0);
+	__ASSERT_NO_MSG(!err);
+
+	err = bt_le_adv_update_data(ad, 1, NULL, 0);
 	__ASSERT_NO_MSG(!err);
 
 	/* .. the advertiser shall autoresume. Since it's not
@@ -154,7 +165,10 @@ int main(void)
 
 	/* With one connection slot taken by the central role, we fill the rest. */
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME_AD, NULL, 0, NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, NULL, 0, NULL, 0);
+	__ASSERT_NO_MSG(!err);
+
+	err = bt_le_adv_update_data(ad, 1, NULL, 0);
 	__ASSERT_NO_MSG(!err);
 
 	LOG_INF("Waiting for connections...");

--- a/tests/bsim/bluetooth/host/att/eatt/src/common.c
+++ b/tests/bsim/bluetooth/host/att/eatt/src/common.c
@@ -140,7 +140,7 @@ void peripheral_setup_and_connect(void)
 		FAIL("Can't enable Bluetooth (err %d)\n", err);
 	}
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 	}

--- a/tests/bsim/bluetooth/host/att/eatt_notif/src/server_test.c
+++ b/tests/bsim/bluetooth/host/att/eatt_notif/src/server_test.c
@@ -190,7 +190,7 @@ static void test_main(void)
 
 	printk("Bluetooth initialized\n");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/host/att/long_read/main.c
+++ b/tests/bsim/bluetooth/host/att/long_read/main.c
@@ -194,9 +194,7 @@ void the_test(void)
 
 	if (peripheral) {
 		EXPECT_ZERO(bt_set_name("peripheral"));
-		EXPECT_ZERO(bt_testlib_adv_conn(
-			&conn, BT_ID_DEFAULT,
-			(BT_LE_ADV_OPT_USE_NAME | BT_LE_ADV_OPT_FORCE_NAME_IN_AD)));
+		EXPECT_ZERO(bt_testlib_adv_conn(&conn, BT_ID_DEFAULT, bt_get_name()));
 	}
 
 	if (central) {

--- a/tests/bsim/bluetooth/host/att/open_close/src/main.c
+++ b/tests/bsim/bluetooth/host/att/open_close/src/main.c
@@ -136,9 +136,7 @@ void a_test_iteration(int i)
 
 	if (peripheral) {
 		EXPECT_ZERO(bt_set_name("peripheral"));
-		EXPECT_ZERO(bt_testlib_adv_conn(
-			&conn, BT_ID_DEFAULT,
-			(BT_LE_ADV_OPT_USE_NAME | BT_LE_ADV_OPT_FORCE_NAME_IN_AD)));
+		EXPECT_ZERO(bt_testlib_adv_conn(&conn, BT_ID_DEFAULT, bt_get_name()));
 	}
 
 	if (central) {

--- a/tests/bsim/bluetooth/host/att/read_fill_buf/server/main.c
+++ b/tests/bsim/bluetooth/host/att/read_fill_buf/server/main.c
@@ -45,8 +45,7 @@ void the_test(void)
 	err = bt_set_name("d1");
 	__ASSERT_NO_MSG(!err);
 
-	err = bt_testlib_adv_conn(NULL, BT_ID_DEFAULT,
-				  (BT_LE_ADV_OPT_USE_NAME | BT_LE_ADV_OPT_FORCE_NAME_IN_AD));
+	err = bt_testlib_adv_conn(NULL, BT_ID_DEFAULT, bt_get_name());
 	__ASSERT_NO_MSG(!err);
 
 	PASS("PASS\n");

--- a/tests/bsim/bluetooth/host/att/retry_on_sec_err/server/main.c
+++ b/tests/bsim/bluetooth/host/att/retry_on_sec_err/server/main.c
@@ -39,8 +39,7 @@ static void test_common(struct bt_conn **conn)
 	err = bt_set_name("d1");
 	__ASSERT_NO_MSG(!err);
 
-	err = bt_testlib_adv_conn(conn, BT_ID_DEFAULT,
-				  (BT_LE_ADV_OPT_USE_NAME | BT_LE_ADV_OPT_FORCE_NAME_IN_AD));
+	err = bt_testlib_adv_conn(conn, BT_ID_DEFAULT, bt_get_name());
 	__ASSERT_NO_MSG(!err);
 }
 

--- a/tests/bsim/bluetooth/host/gatt/authorization/src/gatt_server_test.c
+++ b/tests/bsim/bluetooth/host/gatt/authorization/src/gatt_server_test.c
@@ -339,7 +339,7 @@ static void test_main(void)
 
 	printk("Bluetooth initialized\n");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/host/gatt/caching/src/gatt_server_test.c
+++ b/tests/bsim/bluetooth/host/gatt/caching/src/gatt_server_test.c
@@ -101,7 +101,7 @@ static void test_main_common(bool connect_eatt)
 
 	printk("Bluetooth initialized\n");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 

--- a/tests/bsim/bluetooth/host/gatt/general/src/gatt_server_test.c
+++ b/tests/bsim/bluetooth/host/gatt/general/src/gatt_server_test.c
@@ -159,7 +159,7 @@ static void test_main(void)
 
 	printk("Bluetooth initialized\n");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/host/gatt/notify/src/gatt_server_test.c
+++ b/tests/bsim/bluetooth/host/gatt/notify/src/gatt_server_test.c
@@ -183,7 +183,7 @@ static void setup(void)
 
 	printk("Bluetooth initialized\n");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/host/gatt/notify_multiple/src/gatt_server_test.c
+++ b/tests/bsim/bluetooth/host/gatt/notify_multiple/src/gatt_server_test.c
@@ -145,7 +145,7 @@ static void test_main(void)
 
 	printk("Bluetooth initialized\n");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/host/iso/cis/src/cis_peripheral.c
+++ b/tests/bsim/bluetooth/host/iso/cis/src/cis_peripheral.c
@@ -144,7 +144,7 @@ static void adv_connect(void)
 {
 	int err;
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 

--- a/tests/bsim/bluetooth/host/l2cap/credits/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/credits/src/main.c
@@ -210,15 +210,10 @@ static void disconnect_device(struct bt_conn *conn, void *data)
 	WAIT_FOR_FLAG_UNSET(is_connected);
 }
 
-#define BT_LE_ADV_CONN_NAME_OT BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONNECTABLE | \
-					    BT_LE_ADV_OPT_USE_NAME |	\
-					    BT_LE_ADV_OPT_ONE_TIME,	\
-					    BT_GAP_ADV_FAST_INT_MIN_2, \
-					    BT_GAP_ADV_FAST_INT_MAX_2, NULL)
-
-static const struct bt_data ad[] = {
-	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
-};
+#define BT_LE_ADV_CONN_OT BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONNECTABLE | \
+					  BT_LE_ADV_OPT_ONE_TIME,	\
+					  BT_GAP_ADV_FAST_INT_MIN_2, \
+					  BT_GAP_ADV_FAST_INT_MAX_2, NULL)
 
 static void test_peripheral_main(void)
 {
@@ -238,7 +233,7 @@ static void test_peripheral_main(void)
 
 	LOG_DBG("Peripheral Bluetooth initialized.");
 	LOG_DBG("Connectable advertising...");
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME_OT, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_OT, NULL, 0, NULL, 0);
 	if (err) {
 		FAIL("Advertising failed to start (err %d)", err);
 		return;

--- a/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/src/main.c
@@ -227,14 +227,9 @@ static void disconnect_device(struct bt_conn *conn, void *data)
 	WAIT_FOR_FLAG_UNSET(is_connected);
 }
 
-#define BT_LE_ADV_CONN_NAME_OT                                                                     \
-	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONNECTABLE | BT_LE_ADV_OPT_USE_NAME |                       \
-				BT_LE_ADV_OPT_ONE_TIME,                                            \
+#define BT_LE_ADV_CONN_OT                                                                          \
+	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONNECTABLE | BT_LE_ADV_OPT_ONE_TIME,                        \
 			BT_GAP_ADV_FAST_INT_MIN_2, BT_GAP_ADV_FAST_INT_MAX_2, NULL)
-
-static const struct bt_data ad[] = {
-	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
-};
 
 static void test_peripheral_main(void)
 {
@@ -256,7 +251,7 @@ static void test_peripheral_main(void)
 
 	LOG_DBG("Peripheral Bluetooth initialized.");
 	LOG_DBG("Connectable advertising...");
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME_OT, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_OT, NULL, 0, NULL, 0);
 	if (err) {
 		FAIL("Advertising failed to start (err %d)", err);
 		return;

--- a/tests/bsim/bluetooth/host/l2cap/general/src/main_l2cap_ecred.c
+++ b/tests/bsim/bluetooth/host/l2cap/general/src/main_l2cap_ecred.c
@@ -449,7 +449,7 @@ static void test_peripheral_main(void)
 
 	LOG_DBG("Peripheral Bluetooth initialized.");
 	LOG_DBG("Connectable advertising...");
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err) {
 		FAIL("Advertising failed to start (err %d)", err);
 		return;

--- a/tests/bsim/bluetooth/host/l2cap/send_on_connect/src/main_l2cap_send_on_connect.c
+++ b/tests/bsim/bluetooth/host/l2cap/send_on_connect/src/main_l2cap_send_on_connect.c
@@ -187,7 +187,7 @@ static void test_peripheral_main(void)
 
 	register_l2cap_server();
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/host/l2cap/stress/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/stress/src/main.c
@@ -309,15 +309,10 @@ static void disconnect_device(struct bt_conn *conn, void *data)
 	WAIT_FOR_FLAG_UNSET(is_connected);
 }
 
-#define BT_LE_ADV_CONN_NAME_OT BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONNECTABLE | \
-					    BT_LE_ADV_OPT_USE_NAME |	\
-					    BT_LE_ADV_OPT_ONE_TIME,	\
-					    BT_GAP_ADV_FAST_INT_MIN_2, \
-					    BT_GAP_ADV_FAST_INT_MAX_2, NULL)
-
-static const struct bt_data ad[] = {
-	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
-};
+#define BT_LE_ADV_CONN_OT BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONNECTABLE | \
+					  BT_LE_ADV_OPT_ONE_TIME,	\
+					  BT_GAP_ADV_FAST_INT_MIN_2, \
+					  BT_GAP_ADV_FAST_INT_MAX_2, NULL)
 
 static void test_peripheral_main(void)
 {
@@ -337,7 +332,7 @@ static void test_peripheral_main(void)
 
 	LOG_DBG("Peripheral Bluetooth initialized.");
 	LOG_DBG("Connectable advertising...");
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME_OT, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_OT, NULL, 0, NULL, 0);
 	if (err) {
 		FAIL("Advertising failed to start (err %d)", err);
 		return;

--- a/tests/bsim/bluetooth/host/l2cap/userdata/src/main_l2cap_userdata.c
+++ b/tests/bsim/bluetooth/host/l2cap/userdata/src/main_l2cap_userdata.c
@@ -151,7 +151,7 @@ static void test_peripheral_main(void)
 		return;
 	}
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/host/misc/conn_stress/peripheral/src/main.c
+++ b/tests/bsim/bluetooth/host/misc/conn_stress/peripheral/src/main.c
@@ -400,7 +400,7 @@ void test_peripheral_main(void)
 	sprintf(name, "per-%d", get_device_nbr());
 	bt_set_name(name);
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, NULL, 0, NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, NULL, 0, NULL, 0);
 	if (err) {
 		LOG_ERR("Advertising failed to start (err %d)", err);
 		__ASSERT_NO_MSG(err);

--- a/tests/bsim/bluetooth/host/misc/disable/src/gatt_server_test.c
+++ b/tests/bsim/bluetooth/host/misc/disable/src/gatt_server_test.c
@@ -154,7 +154,7 @@ static void test_main(void)
 
 		printk("Bluetooth initialized\n");
 
-		err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
+		err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), NULL, 0);
 		if (err != 0) {
 			FAIL("Advertising failed to start (err %d)\n", err);
 			return;

--- a/tests/bsim/bluetooth/host/misc/sample_test/src/peer.c
+++ b/tests/bsim/bluetooth/host/misc/sample_test/src/peer.c
@@ -172,8 +172,7 @@ void entrypoint_peer(void)
 
 	LOG_DBG("Bluetooth initialized");
 
-	err = bt_testlib_adv_conn(&conn, BT_ID_DEFAULT,
-				  (BT_LE_ADV_OPT_USE_NAME | BT_LE_ADV_OPT_FORCE_NAME_IN_AD));
+	err = bt_testlib_adv_conn(&conn, BT_ID_DEFAULT, bt_get_name());
 	TEST_ASSERT(!err, "Failed to start connectable advertising (err %d)", err);
 
 	LOG_DBG("Discover test characteristic");

--- a/tests/bsim/bluetooth/host/misc/unregister_conn_cb/src/main.c
+++ b/tests/bsim/bluetooth/host/misc/unregister_conn_cb/src/main.c
@@ -127,7 +127,7 @@ static void test_peripheral_main(void)
 
 	bt_conn_cb_register(&conn_callbacks);
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/host/privacy/central/src/tester.c
+++ b/tests/bsim/bluetooth/host/privacy/central/src/tester.c
@@ -88,7 +88,7 @@ void start_advertising(void)
 	params.sid = 0;
 	params.secondary_max_skip = 0;
 	params.options = BT_LE_ADV_OPT_EXT_ADV | BT_LE_ADV_OPT_SCANNABLE |
-			 BT_LE_ADV_OPT_NOTIFY_SCAN_REQ | BT_LE_ADV_OPT_USE_NAME;
+			 BT_LE_ADV_OPT_NOTIFY_SCAN_REQ;
 	params.interval_min = BT_GAP_ADV_FAST_INT_MIN_1;
 	params.interval_max = BT_GAP_ADV_FAST_INT_MAX_1;
 	params.peer = NULL;

--- a/tests/bsim/bluetooth/ll/advx/src/main.c
+++ b/tests/bsim/bluetooth/ll/advx/src/main.c
@@ -167,6 +167,7 @@ static void test_advx_main(void)
 	struct bt_le_ext_adv_start_param ext_adv_param;
 	struct bt_le_ext_adv *adv;
 	uint8_t num_sent_expected;
+	struct bt_data sd[1];
 	uint16_t evt_prop;
 	uint8_t adv_type;
 	uint16_t handle;
@@ -184,7 +185,7 @@ static void test_advx_main(void)
 	printk("success.\n");
 
 	printk("Connectable advertising...");
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);
 		return;
@@ -299,8 +300,19 @@ static void test_advx_main(void)
 	printk("success.\n");
 
 	printk("Create scannable extended advertising set...");
-	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_SCAN_NAME, &adv_callbacks,
+	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_SCAN, &adv_callbacks,
 				   &adv);
+	if (err) {
+		goto exit;
+	}
+	printk("success.\n");
+
+	/* Scannable advertiser need to have scan response data */
+	printk("Set scan response data...");
+	sd[0].type = BT_DATA_NAME_COMPLETE;
+	sd[0].data_len = sizeof(CONFIG_BT_DEVICE_NAME) - 1;
+	sd[0].data = CONFIG_BT_DEVICE_NAME;
+	err = bt_le_ext_adv_set_data(adv, NULL, 0, sd, 1);
 	if (err) {
 		goto exit;
 	}
@@ -334,7 +346,7 @@ static void test_advx_main(void)
 	printk("Create connectable extended advertising set...");
 	is_connected = false;
 	is_disconnected = false;
-	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_CONN_NAME, &adv_callbacks, &adv);
+	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_CONN, &adv_callbacks, &adv);
 	if (err) {
 		goto exit;
 	}
@@ -389,7 +401,7 @@ static void test_advx_main(void)
 	k_sleep(K_MSEC(1000));
 
 	printk("Create connectable advertising set...");
-	err = bt_le_ext_adv_create(BT_LE_ADV_CONN_NAME, &adv_callbacks, &adv);
+	err = bt_le_ext_adv_create(BT_LE_ADV_CONN, &adv_callbacks, &adv);
 	if (err) {
 		goto exit;
 	}

--- a/tests/bsim/bluetooth/ll/bis/src/main.c
+++ b/tests/bsim/bluetooth/ll/bis/src/main.c
@@ -199,7 +199,7 @@ static void setup_ext_adv(struct bt_le_ext_adv **adv)
 	int err;
 
 	printk("Create advertising set...");
-	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_NCONN_NAME, NULL, adv);
+	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_NCONN, NULL, adv);
 	if (err) {
 		FAIL("Failed to create advertising set (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/ll/cis/src/main.c
+++ b/tests/bsim/bluetooth/ll/cis/src/main.c
@@ -76,16 +76,14 @@ static bt_addr_le_t peer_addr;
 
 #if defined(CONFIG_TEST_USE_LEGACY_ADVERTISING)
 #define BT_LE_ADV_CONN_CUSTOM BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONNECTABLE | \
-					      BT_LE_ADV_OPT_ONE_TIME | \
-					      BT_LE_ADV_OPT_USE_NAME, \
+					      BT_LE_ADV_OPT_ONE_TIME, \
 					      ADV_INTERVAL_MIN, \
 					      ADV_INTERVAL_MAX, \
 					      NULL)
 #else /* !CONFIG_TEST_USE_LEGACY_ADVERTISING */
 #define BT_LE_ADV_CONN_CUSTOM BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONNECTABLE | \
 					      BT_LE_ADV_OPT_EXT_ADV | \
-					      BT_LE_ADV_OPT_ONE_TIME | \
-					      BT_LE_ADV_OPT_USE_NAME, \
+					      BT_LE_ADV_OPT_ONE_TIME, \
 					      ADV_INTERVAL_MIN, \
 					      ADV_INTERVAL_MAX, \
 					      NULL)

--- a/tests/bsim/bluetooth/ll/conn/src/test_connect2.c
+++ b/tests/bsim/bluetooth/ll/conn/src/test_connect2.c
@@ -133,7 +133,7 @@ static void bt_ready(void)
 
 	printk("Peripheral Bluetooth initialized\n");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;


### PR DESCRIPTION
Deprecate `BT_LE_ADV_OPT_USE_NAME` and `BT_LE_ADV_OPT_FORCE_NAME_IN_AD`. Update the code-base to not use those options anymore.

Reasons:

- It is out of place in the advertiser options, as it acts on advertising data and not configuration
- The behavior is not clear. All of these are trick questions:
  - where does the data for the name go?
  - do I have to allocate memory for this?
  - does it work the same in legacy vs extended advertising?
- The trade-off between UX improvement and extra complexity in the host is debatable. Hundreds of lines in the stack to avoid making the user type out less than ten.

See commits message for details.