### PR TITLE
net: if: Do not add IPv6 address lifetime timer twice to list

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -1727,6 +1727,12 @@ void net_address_lifetime_timeout(void)
 
 static void address_start_timer(struct net_if_addr *ifaddr, uint32_t vlifetime)
 {
+	/* Make sure that we do not insert the address twice to
+	 * the lifetime timer list.
+	 */
+	sys_slist_find_and_remove(&active_address_lifetime_timers,
+				  &ifaddr->lifetime.node);
+
 	sys_slist_append(&active_address_lifetime_timers,
 			 &ifaddr->lifetime.node);
 


### PR DESCRIPTION
The IPv6 address lifetime timers are kept in a slist, but the code that adds the entry to the list does not check whether the item is already in the list. This will cause problems when trying to remove the address from the list.

Normally this is not causing issues, but if the function net_if_ipv6_addr_update_lifetime() is called multiple times before the address expires, then the item was added to the slist multiple times.