### PR TITLE
json: Use designated initializers consistently in macro's

### DIFF
--- a/include/zephyr/data/json.h
+++ b/include/zephyr/data/json.h
@@ -191,11 +191,9 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 		.field_name_len = (sizeof(#field_name_) - 1), \
 		.type = JSON_TOK_OBJECT_START, \
 		.offset = offsetof(struct_, field_name_), \
-		{ \
-			.object = { \
-				.sub_descr = sub_descr_, \
-				.sub_descr_len = ARRAY_SIZE(sub_descr_), \
-			}, \
+		.object = { \
+			.sub_descr = sub_descr_, \
+			.sub_descr_len = ARRAY_SIZE(sub_descr_), \
 		}, \
 	}
 
@@ -277,12 +275,10 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 		.field_name_len = sizeof(#field_name_) - 1, \
 		.type = JSON_TOK_ARRAY_START, \
 		.offset = offsetof(struct_, field_name_), \
-		{ \
-			.array = { \
-				.element_descr = Z_JSON_ELEMENT_DESCR(struct_, len_field_, \
-					elem_type_,), \
-				.n_elements = (max_len_), \
-			}, \
+		.array = { \
+			.element_descr = Z_JSON_ELEMENT_DESCR(struct_, len_field_, \
+				elem_type_,), \
+			.n_elements = (max_len_), \
 		}, \
 	}
 
@@ -328,13 +324,11 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 		.field_name_len = sizeof(#field_name_) - 1, \
 		.type = JSON_TOK_ARRAY_START, \
 		.offset = offsetof(struct_, field_name_), \
-		{ \
-			.array = { \
-				.element_descr = Z_JSON_ELEMENT_DESCR(struct_, len_field_, \
-					JSON_TOK_OBJECT_START, \
-					Z_JSON_DESCR_OBJ(elem_descr_, elem_descr_len_)), \
-				.n_elements = (max_len_), \
-			}, \
+		.array = { \
+			.element_descr = Z_JSON_ELEMENT_DESCR(struct_, len_field_, \
+				JSON_TOK_OBJECT_START, \
+				Z_JSON_DESCR_OBJ(elem_descr_, elem_descr_len_)), \
+			.n_elements = (max_len_), \
 		}, \
 	}
 
@@ -389,15 +383,13 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 		.field_name_len = sizeof(#field_name_) - 1, \
 		.type = JSON_TOK_ARRAY_START, \
 		.offset = offsetof(struct_, field_name_), \
-		{ \
-			.array = { \
-				.element_descr = Z_JSON_ELEMENT_DESCR( \
-					struct_, len_field_, JSON_TOK_ARRAY_START, \
-					Z_JSON_DESCR_ARRAY( \
-						elem_descr_, \
-						1 + ZERO_OR_COMPILE_ERROR(elem_descr_len_ == 1))), \
-				.n_elements = (max_len_), \
-			}, \
+		.array = { \
+			.element_descr = Z_JSON_ELEMENT_DESCR( \
+				struct_, len_field_, JSON_TOK_ARRAY_START, \
+				Z_JSON_DESCR_ARRAY( \
+					elem_descr_, \
+					1 + ZERO_OR_COMPILE_ERROR(elem_descr_len_ == 1))), \
+			.n_elements = (max_len_), \
 		}, \
 	}
 
@@ -426,15 +418,13 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 		.field_name_len = sizeof(#json_field_name_) - 1, \
 		.type = JSON_TOK_ARRAY_START, \
 		.offset = offsetof(struct_, struct_field_name_), \
-		{ \
-			.array = { \
-				.element_descr = Z_JSON_ELEMENT_DESCR( \
-					struct_, len_field_, JSON_TOK_ARRAY_START, \
-					Z_JSON_DESCR_ARRAY( \
-						elem_descr_, \
-						1 + ZERO_OR_COMPILE_ERROR(elem_descr_len_ == 1))), \
-				.n_elements = (max_len_), \
-			}, \
+		.array = { \
+			.element_descr = Z_JSON_ELEMENT_DESCR( \
+				struct_, len_field_, JSON_TOK_ARRAY_START, \
+				Z_JSON_DESCR_ARRAY( \
+					elem_descr_, \
+					1 + ZERO_OR_COMPILE_ERROR(elem_descr_len_ == 1))), \
+			.n_elements = (max_len_), \
 		}, \
 	}
 
@@ -483,11 +473,9 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 		.field_name_len = (sizeof(json_field_name_) - 1), \
 		.type = JSON_TOK_OBJECT_START, \
 		.offset = offsetof(struct_, struct_field_name_), \
-		{ \
-			.object = { \
-				.sub_descr = sub_descr_, \
-				.sub_descr_len = ARRAY_SIZE(sub_descr_), \
-			}, \
+		.object = { \
+			.sub_descr = sub_descr_, \
+			.sub_descr_len = ARRAY_SIZE(sub_descr_), \
 		}, \
 	}
 
@@ -516,12 +504,10 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 		.field_name_len = sizeof(json_field_name_) - 1, \
 		.type = JSON_TOK_ARRAY_START, \
 		.offset = offsetof(struct_, struct_field_name_), \
-		{ \
-			.array = { \
-				.element_descr = \
-					Z_JSON_ELEMENT_DESCR(struct_, len_field_, elem_type_,), \
-				.n_elements = (max_len_), \
-			}, \
+		.array = { \
+			.element_descr = \
+				Z_JSON_ELEMENT_DESCR(struct_, len_field_, elem_type_,), \
+			.n_elements = (max_len_), \
 		}, \
 	}
 
@@ -575,13 +561,11 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
 		.field_name_len = sizeof(json_field_name_) - 1, \
 		.type = JSON_TOK_ARRAY_START, \
 		.offset = offsetof(struct_, struct_field_name_), \
-		{ \
-			.array = { \
-				.element_descr = Z_JSON_ELEMENT_DESCR(struct_, len_field_, \
-					JSON_TOK_OBJECT_START, \
-					Z_JSON_DESCR_OBJ(elem_descr_, elem_descr_len_)), \
-				.n_elements = (max_len_), \
-			}, \
+		.array = { \
+			.element_descr = Z_JSON_ELEMENT_DESCR(struct_, len_field_, \
+				JSON_TOK_OBJECT_START, \
+				Z_JSON_DESCR_OBJ(elem_descr_, elem_descr_len_)), \
+			.n_elements = (max_len_), \
 		}, \
 	}
 


### PR DESCRIPTION
This PR updates the json macros to be consistend with C++20
Signed-off-by: Rick Bruyninckx <xactme@gmail.com>