### PR TITLE
net: lwm2m: Add config to always report obj version

### DIFF
--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -492,6 +492,14 @@ config LWM2M_ENGINE_DEFAULT_LIFETIME
 	  This is also a minimum lifetime that client accepts. If server sets lifetime
 	  less than this value, client automatically raises it.
 
+config LWM2M_ENGINE_ALWAYS_REPORT_OBJ_VERSION
+	bool "LwM2M engine always report object version"
+	help
+	  According to LwM2M specification v1.0 and v1.1, non-core object versions other than 1.0
+	  'must' be provided, while all other versions 'may' be provided. With specification v1.2,
+	  a client 'can always attach Object Version Information'. Enable this configuration to
+	  always report all object versions.
+
 config LWM2M_UPDATE_PERIOD
 	int "LwM2M engine update period"
 	default 0

--- a/subsys/net/lib/lwm2m/lwm2m_registry.c
+++ b/subsys/net/lib/lwm2m/lwm2m_registry.c
@@ -2010,6 +2010,10 @@ struct lwm2m_engine_res_inst *lwm2m_engine_get_res_inst(const struct lwm2m_obj_p
 
 bool lwm2m_engine_shall_report_obj_version(const struct lwm2m_engine_obj *obj)
 {
+	if (IS_ENABLED(CONFIG_LWM2M_ENGINE_ALWAYS_REPORT_OBJ_VERSION)) {
+		return true;
+	}
+
 	/* For non-core objects, report version other than 1.0 */
 	if (!obj->is_core) {
 		return obj->version_major != 1 || obj->version_minor != 0;

--- a/tests/net/lib/lwm2m/lwm2m_registry/src/lwm2m_registry.c
+++ b/tests/net/lib/lwm2m/lwm2m_registry/src/lwm2m_registry.c
@@ -599,11 +599,17 @@ ZTEST(lwm2m_registry, test_null_strings)
 
 ZTEST(lwm2m_registry, test_obj_version)
 {
-
+#if defined(CONFIG_LWM2M_ENGINE_ALWAYS_REPORT_OBJ_VERSION)
+	zassert_true(lwm2m_engine_shall_report_obj_version(lwm2m_engine_get_obj(&LWM2M_OBJ(0))));
+	zassert_true(
+		lwm2m_engine_shall_report_obj_version(lwm2m_engine_get_obj(&LWM2M_OBJ(32768))));
+	zassert_true(lwm2m_engine_shall_report_obj_version(lwm2m_engine_get_obj(&LWM2M_OBJ(3303))));
+#else
 	zassert_false(lwm2m_engine_shall_report_obj_version(lwm2m_engine_get_obj(&LWM2M_OBJ(0))));
 	zassert_false(
 		lwm2m_engine_shall_report_obj_version(lwm2m_engine_get_obj(&LWM2M_OBJ(32768))));
 	zassert_true(lwm2m_engine_shall_report_obj_version(lwm2m_engine_get_obj(&LWM2M_OBJ(3303))));
+#endif
 }
 
 ZTEST(lwm2m_registry, test_resource_cache)

--- a/tests/net/lib/lwm2m/lwm2m_registry/testcase.yaml
+++ b/tests/net/lib/lwm2m/lwm2m_registry/testcase.yaml
@@ -7,3 +7,13 @@ tests:
       - net
     integration_platforms:
       - native_sim
+  net.lwm2m.lwm2m_registry.always_report_obj_version:
+    platform_key:
+      - simulation
+    tags:
+      - lwm2m
+      - net
+    integration_platforms:
+      - native_sim
+    extra_configs:
+      - CONFIG_LWM2M_ENGINE_ALWAYS_REPORT_OBJ_VERSION=y


### PR DESCRIPTION
Adds a config that enables sending the object version for all objects.

According to LwM2M specification v1.0 and v1.1, non-core object versions other than 1.0 'must' be provided, while all other versions 'may' be provided. With specification v1.2, a client 'can always attach Object Version Information'. Or in other words, it is OK to always report the object version with all specifications.