### PR TITLE
drivers: mipi_dbi: a few documentation fixes

### DIFF
--- a/dts/bindings/mipi-dbi/mipi-dbi-device.yaml
+++ b/dts/bindings/mipi-dbi/mipi-dbi-device.yaml
@@ -15,7 +15,7 @@ properties:
   mipi-mode:
     type: int
     description: |
-      MIPI DBI mode in use. Use the macros not the actual enum value, here is
+      MIPI DBI mode in use. Use the macros, not the actual enum value. Here is
       the concordance list (see dt-bindings/mipi_dbi/mipi_dbi.h)
         1     MIPI_DBI_MODE_SPI_3WIRE
         2     MIPI_DBI_MODE_SPI_4WIRE

--- a/include/zephyr/drivers/mipi_dbi.h
+++ b/include/zephyr/drivers/mipi_dbi.h
@@ -276,6 +276,10 @@ static inline int mipi_dbi_reset(const struct device *dev, uint32_t delay)
  * locked.
  * @param dev mipi dbi controller
  * @param config MIPI DBI configuration
+ * @retval 0 reset succeeded
+ * @retval -EIO I/O error
+ * @retval -ENOSYS not implemented
+ * @retval -ENOTSUP not supported
  */
 static inline int mipi_dbi_release(const struct device *dev,
 				   const struct mipi_dbi_config *config)


### PR DESCRIPTION
Add a few documentation fixes missed in #71454 for the new `mipi_dbi_release` API.