### PR TITLE
drivers: gnss: Use correct GGA Elevation field

### DIFF
--- a/drivers/gnss/gnss_nmea0183.c
+++ b/drivers/gnss/gnss_nmea0183.c
@@ -538,7 +538,7 @@ int gnss_nmea0183_parse_gga(const char **argv, uint16_t argc, struct gnss_data *
 	data->info.hdop = (uint16_t)tmp64;
 
 	/* Parse altitude */
-	if ((gnss_parse_dec_to_milli(argv[11], &tmp64) < 0) ||
+	if ((gnss_parse_dec_to_milli(argv[9], &tmp64) < 0) ||
 	    (tmp64 > INT32_MAX) ||
 	    (tmp64 < INT32_MIN)) {
 		return -EINVAL;

--- a/tests/drivers/gnss/gnss_nmea0183/src/main.c
+++ b/tests/drivers/gnss/gnss_nmea0183/src/main.c
@@ -330,7 +330,7 @@ ZTEST(gnss_nmea0183, test_parse_gga_fix)
 		      "Incorrectly parsed number of satelites");
 
 	zassert_equal(data.info.hdop, 1410, "Incorrectly parsed HDOP");
-	zassert_equal(data.nav_data.altitude, 42371, "Incorrectly parsed altitude");
+	zassert_equal(data.nav_data.altitude, 15234, "Incorrectly parsed altitude");
 }
 
 ZTEST(gnss_nmea0183, test_snprintk)


### PR DESCRIPTION
Field 9 is MSL Elevation. Field 11 is Geoid Seperation, the difference between field 9 and the Ellipsoid Altitude. Elevation should use 9 (or computer the HAE using both 9 and 11). 

See page 10 of https://www.sparkfun.com/datasheets/GPS/NMEA%20Reference%20Manual-Rev2.1-Dec07.pdf

