### PR TITLE
manifest: update cmsis-nn to v5.0.0

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -124,7 +124,7 @@ manifest:
       revision: 6489e771e9c405f1763b52d64a3f17a1ec488ace
       path: modules/lib/cmsis-dsp
     - name: cmsis-nn
-      revision: 0c8669d81381ccf3b1a01d699f3b68b50134a99f
+      revision: e042bf748ee808f138f4d85b7d690aad445f6367
       path: modules/lib/cmsis-nn
     - name: edtt
       revision: 64e5105ad82390164fb73fc654be3f73a608209a


### PR DESCRIPTION
Update cmsis-nn to version 5.0.0.
Revision history can be found at:
https://arm-software.github.io/CMSIS-NN/latest/rev_hist.html

New upstream revision is the v5.0.0 release tag + `module.yml`  https://github.com/ARM-software/CMSIS-NN/commit/e042bf748ee808f138f4d85b7d690aad445f6367