### PR TITLE
ADC: kb1200: start_read returns uninitialized value

### DIFF
--- a/drivers/adc/adc_ene_kb1200.c
+++ b/drivers/adc/adc_ene_kb1200.c
@@ -67,7 +67,7 @@ static int adc_kb1200_start_read(const struct device *dev, const struct adc_sequ
 {
 	const struct adc_kb1200_config *config = dev->config;
 	struct adc_kb1200_data *data = dev->data;
-	int error;
+	int error = 0;
 
 	if (!sequence->channels || (sequence->channels & ~BIT_MASK(ADC_MAX_CHAN))) {
 		printk("Invalid ADC channels.\n");


### PR DESCRIPTION
Found via static analyis. When `adc_kb1200_start_read` succeeds, no value is set for `error` so it is still uninitialized when it is returned.