### PR TITLE
Can: mcan: Uninitialized access in state_change_handler

### DIFF
--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -463,7 +463,10 @@ static void can_mcan_state_change_handler(const struct device *dev)
 	uint32_t cccr;
 	int err;
 
-	(void)can_mcan_get_state(dev, &state, &err_cnt);
+	err = can_mcan_get_state(dev, &state, &err_cnt);
+	if (err != 0) {
+		return;
+	}
 
 	if (state_cb != NULL) {
 		state_cb(dev, state, err_cnt, state_cb_data);


### PR DESCRIPTION
Found via static analysis. In `can_mcan_state_change_handler`, the return value of `can_mcan_get_state` is not checked for error. In the event of an error, both `err_cnt` and `state` are left unitialized and accessed downstream.

The correct behavior is to return early in that case.