### PR TITLE
Bluetooth: Controller: Move out vendor specific struct ccm

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -46,6 +46,7 @@
 #include "lll/lll_df_types.h"
 #include "ll_sw/lll_sync.h"
 #include "ll_sw/lll_sync_iso.h"
+#include "lll/lll_conn_types.h"
 #include "ll_sw/lll_conn.h"
 #include "ll_sw/lll_conn_iso.h"
 #include "ll_sw/lll_iso_tx.h"

--- a/subsys/bluetooth/controller/hci/hci_driver.c
+++ b/subsys/bluetooth/controller/hci/hci_driver.c
@@ -46,6 +46,7 @@
 #include "ll_sw/lll.h"
 #include "lll/lll_df_types.h"
 #include "ll_sw/lll_sync_iso.h"
+#include "lll/lll_conn_types.h"
 #include "ll_sw/lll_conn.h"
 #include "ll_sw/lll_conn_iso.h"
 #include "ll_sw/isoal.h"

--- a/subsys/bluetooth/controller/ll_sw/ll_feat.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_feat.c
@@ -19,6 +19,7 @@
 
 #include "lll.h"
 #include "lll/lll_df_types.h"
+#include "lll/lll_conn_types.h"
 #include "lll_conn.h"
 
 #include "ull_conn_internal.h"

--- a/subsys/bluetooth/controller/ll_sw/ll_tx_pwr.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_tx_pwr.c
@@ -29,6 +29,7 @@
 #include "lll/lll_adv_pdu.h"
 #include "lll_scan.h"
 #include "lll/lll_df_types.h"
+#include "lll/lll_conn_types.h"
 #include "lll_conn.h"
 
 #include "ll_sw/ull_tx_queue.h"

--- a/subsys/bluetooth/controller/ll_sw/lll_adv.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_adv.h
@@ -79,7 +79,6 @@ struct lll_adv_iso {
 
 	/* Encryption */
 	uint8_t giv[8];
-	struct ccm ccm_tx;
 
 #if defined(CONFIG_BT_TICKER_EXT_EXPIRE_INFO)
 	/* contains the offset in ticks from the adv_sync pointing to this ISO */
@@ -88,6 +87,11 @@ struct lll_adv_iso {
 #endif /* CONFIG_BT_TICKER_EXT_EXPIRE_INFO */
 
 	uint16_t stream_handle[BT_CTLR_ADV_ISO_STREAM_MAX];
+
+	/* Vendor specific data
+	 * Example, nRF CCM `struct ccm`
+	 */
+	struct lll_adv_iso_vendor vendor;
 };
 
 struct lll_adv_sync {

--- a/subsys/bluetooth/controller/ll_sw/lll_adv_iso.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_adv_iso.h
@@ -6,6 +6,7 @@
 
 int lll_adv_iso_init(void);
 int lll_adv_iso_reset(void);
+void lll_adv_iso_enc_param_set(struct lll_adv_iso *lll, uint8_t *gsk);
 void lll_adv_iso_create_prepare(void *param);
 void lll_adv_iso_prepare(void *param);
 

--- a/subsys/bluetooth/controller/ll_sw/lll_conn.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_conn.h
@@ -119,9 +119,6 @@ struct lll_conn {
 #if defined(CONFIG_BT_CTLR_LE_ENC)
 	uint8_t enc_rx:1;
 	uint8_t enc_tx:1;
-
-	struct ccm ccm_rx;
-	struct ccm ccm_tx;
 #endif /* CONFIG_BT_CTLR_LE_ENC */
 
 #if defined(CONFIG_BT_CTLR_SLOT_RESERVATION_UPDATE)
@@ -153,6 +150,11 @@ struct lll_conn {
 #if defined(CONFIG_BT_CTLR_DF_CONN_CTE_TX)
 	struct lll_df_conn_tx_cfg df_tx_cfg;
 #endif /* CONFIG_BT_CTLR_DF_CONN_CTE_TX */
+
+	/* Vendor specific data
+	 * Example, nRF CCM `struct ccm`
+	 */
+	struct lll_conn_vendor vendor;
 };
 
 int lll_conn_init(void);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -38,6 +38,7 @@
 #include "lll_adv_aux.h"
 #include "lll_adv_sync.h"
 #include "lll_df_types.h"
+#include "lll_conn_types.h"
 #include "lll_conn.h"
 #include "lll_chan.h"
 #include "lll_filter.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -30,6 +30,7 @@
 #include "lll_clock.h"
 #include "lll_chan.h"
 #include "lll_df_types.h"
+#include "lll_conn_types.h"
 #include "lll_conn.h"
 #include "lll_adv_types.h"
 #include "lll_adv.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_types.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_types.h
@@ -26,3 +26,14 @@ struct lll_adv_pdu {
 	void             *extra_data[DOUBLE_BUFFER_SIZE];
 #endif /* CONFIG_BT_CTLR_ADV_EXT_PDU_EXTRA_DATA_MEMORY */
 };
+
+/* Vendor specific data in Broadcast ISO context */
+struct lll_adv_iso_vendor {
+	union {
+#if defined(CONFIG_BT_CTLR_BROADCAST_ISO_ENC)
+		struct ccm ccm_tx;
+#endif /* CONFIG_BT_CTLR_BROADCAST_ISO_ENC */
+
+		uint8_t rfi[0];
+	};
+};

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central.c
@@ -29,6 +29,7 @@
 #include "lll_vendor.h"
 #include "lll_clock.h"
 #include "lll_df_types.h"
+#include "lll_conn_types.h"
 #include "lll_conn.h"
 #include "lll_central.h"
 #include "lll_chan.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
@@ -26,6 +26,7 @@
 #include "lll_clock.h"
 #include "lll_chan.h"
 #include "lll_df_types.h"
+#include "lll_conn_types.h"
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 #include "lll_central_iso.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -32,6 +32,7 @@
 #include "lll_clock.h"
 #include "lll_df_types.h"
 #include "lll_df.h"
+#include "lll_conn_types.h"
 #include "lll_conn.h"
 
 #include "lll_internal.h"
@@ -698,12 +699,12 @@ void lll_conn_rx_pkt_set(struct lll_conn *lll)
 	defined(HAL_RADIO_PDU_LEN_MAX) && \
 	(!defined(CONFIG_BT_CTLR_DATA_LENGTH_MAX) || \
 	 (CONFIG_BT_CTLR_DATA_LENGTH_MAX < (HAL_RADIO_PDU_LEN_MAX - 4)))
-		radio_pkt_rx_set(radio_ccm_rx_pkt_set(&lll->ccm_rx, phy,
+		radio_pkt_rx_set(radio_ccm_rx_pkt_set(&lll->vendor.ccm_rx, phy,
 						      radio_pkt_decrypt_get()));
 #elif !defined(HAL_RADIO_PDU_LEN_MAX)
 #error "Undefined HAL_RADIO_PDU_LEN_MAX."
 #else
-		radio_pkt_rx_set(radio_ccm_rx_pkt_set(&lll->ccm_rx, phy,
+		radio_pkt_rx_set(radio_ccm_rx_pkt_set(&lll->vendor.ccm_rx, phy,
 						      pdu_data_rx));
 #endif
 #endif /* CONFIG_BT_CTLR_LE_ENC */
@@ -759,7 +760,7 @@ void lll_conn_tx_pkt_set(struct lll_conn *lll, struct pdu_data *pdu_data_tx)
 		radio_pkt_configure(RADIO_PKT_CONF_LENGTH_8BIT, (max_tx_octets + PDU_MIC_SIZE),
 				    pkt_flags);
 
-		radio_pkt_tx_set(radio_ccm_tx_pkt_set(&lll->ccm_tx, pdu_data_tx));
+		radio_pkt_tx_set(radio_ccm_tx_pkt_set(&lll->vendor.ccm_tx, pdu_data_tx));
 #endif /* CONFIG_BT_CTLR_LE_ENC */
 	} else {
 		radio_pkt_configure(RADIO_PKT_CONF_LENGTH_8BIT, max_tx_octets, pkt_flags);
@@ -977,7 +978,7 @@ static inline int isr_rx_pdu(struct lll_conn *lll, struct pdu_data *pdu_data_rx,
 			if (pdu_data_tx_len != 0U) {
 				/* if encrypted increment tx counter */
 				if (lll->enc_tx) {
-					lll->ccm_tx.counter++;
+					lll->vendor.ccm_tx.counter++;
 				}
 			}
 #endif /* CONFIG_BT_CTLR_LE_ENC */
@@ -1034,7 +1035,7 @@ static inline int isr_rx_pdu(struct lll_conn *lll, struct pdu_data *pdu_data_rx,
 				bool mic_failure = !radio_ccm_mic_is_valid();
 
 				if (mic_failure &&
-				    lll->ccm_rx.counter == 0 &&
+				    lll->vendor.ccm_rx.counter == 0 &&
 				    (pdu_data_rx->ll_id ==
 				     PDU_DATA_LLID_CTRL)) {
 					/* Received an LL control packet in the
@@ -1053,7 +1054,7 @@ static inline int isr_rx_pdu(struct lll_conn *lll, struct pdu_data *pdu_data_rx,
 						       offsetof(struct pdu_data,
 							llctrl));
 						mic_failure = false;
-						lll->ccm_rx.counter--;
+						lll->vendor.ccm_rx.counter--;
 					}
 				}
 
@@ -1065,7 +1066,7 @@ static inline int isr_rx_pdu(struct lll_conn *lll, struct pdu_data *pdu_data_rx,
 				}
 
 				/* Increment counter */
-				lll->ccm_rx.counter++;
+				lll->vendor.ccm_rx.counter++;
 
 				/* Record MIC valid */
 				mic_state = LLL_CONN_MIC_PASS;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn_types.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn_types.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Vendor specific data in connection context */
+struct lll_conn_vendor {
+	union {
+#if defined(CONFIG_BT_CTLR_LE_ENC)
+		struct {
+			struct ccm ccm_tx;
+			struct ccm ccm_rx;
+		};
+#endif /* CONFIG_BT_CTLR_LE_ENC */
+
+		uint8_t rfi[0];
+	};
+};

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral.c
@@ -28,6 +28,7 @@
 #include "lll_vendor.h"
 #include "lll_clock.h"
 #include "lll_df_types.h"
+#include "lll_conn_types.h"
 #include "lll_conn.h"
 #include "lll_peripheral.h"
 #include "lll_chan.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
@@ -26,6 +26,7 @@
 #include "lll/lll_df_types.h"
 #include "lll_chan.h"
 #include "lll_vendor.h"
+#include "lll_conn_types.h"
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 #include "lll_peripheral_iso.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -33,6 +33,7 @@
 #include "lll_df_types.h"
 #include "lll_scan.h"
 #include "lll_sync.h"
+#include "lll_conn_types.h"
 #include "lll_conn.h"
 #include "lll_chan.h"
 #include "lll_filter.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -35,6 +35,7 @@
 #include "lll_df_internal.h"
 #include "lll_sync.h"
 #include "lll_sync_iso.h"
+#include "lll_conn_types.h"
 #include "lll_conn.h"
 #include "lll_sched.h"
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/ull/ull_iso_vendor.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/ull/ull_iso_vendor.c
@@ -19,6 +19,7 @@
 #include "lll/pdu_vendor.h"
 #include "pdu.h"
 #include "lll.h"
+#include "lll/lll_conn_types.h"
 #include "lll_conn.h"
 
 #include "ull_iso_types.h"

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv_types.h
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv_types.h
@@ -17,3 +17,8 @@ struct lll_adv_pdu {
 	uint8_t          last;
 	uint8_t          *pdu[DOUBLE_BUFFER_SIZE];
 };
+
+/* Vendor specific data in Broadcast ISO context */
+struct lll_adv_iso_vendor {
+	uint8_t rfi[0];
+};

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -43,6 +43,7 @@
 #include "lll_sync.h"
 #include "lll_sync_iso.h"
 #include "lll_iso_tx.h"
+#include "lll/lll_conn_types.h"
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 #include "lll_df.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -38,6 +38,7 @@
 #include "lll/lll_adv_pdu.h"
 #include "lll_scan.h"
 #include "lll/lll_df_types.h"
+#include "lll/lll_conn_types.h"
 #include "lll_conn.h"
 #include "lll_filter.h"
 #include "lll_conn_iso.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -34,6 +34,7 @@
 #include "lll/lll_adv_pdu.h"
 #include "lll_adv_aux.h"
 #include "lll/lll_df_types.h"
+#include "lll/lll_conn_types.h"
 #include "lll_conn.h"
 
 #include "ull_adv_types.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
@@ -564,7 +564,6 @@ static uint8_t big_create(uint8_t big_handle, uint8_t adv_handle, uint8_t num_bi
 		const uint8_t BIG1[16] = {0x31, 0x47, 0x49, 0x42, };
 		const uint8_t BIG2[4]  = {0x32, 0x47, 0x49, 0x42};
 		const uint8_t BIG3[4]  = {0x33, 0x47, 0x49, 0x42};
-		struct ccm *ccm_tx;
 		uint8_t igltk[16];
 		uint8_t gltk[16];
 		uint8_t gsk[16];
@@ -585,10 +584,7 @@ static uint8_t big_create(uint8_t big_handle, uint8_t adv_handle, uint8_t num_bi
 		LL_ASSERT(!err);
 
 		/* Prepare the CCM parameters */
-		ccm_tx = &lll_adv_iso->ccm_tx;
-		ccm_tx->direction = 1U;
-		(void)memcpy(&ccm_tx->iv[4], &lll_adv_iso->giv[4], 4U);
-		(void)mem_rcopy(ccm_tx->key, gsk, sizeof(ccm_tx->key));
+		lll_adv_iso_enc_param_set(lll_adv_iso, gsk);
 
 		/* NOTE: counter is filled in LLL */
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -33,6 +33,7 @@
 #include "lll/lll_adv_pdu.h"
 #include "lll_adv_sync.h"
 #include "lll/lll_df_types.h"
+#include "lll/lll_conn_types.h"
 #include "lll_conn.h"
 #include "lll_chan.h"
 

--- a/subsys/bluetooth/controller/ll_sw/ull_central.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central.c
@@ -35,6 +35,7 @@
 #include "lll_chan.h"
 #include "lll_scan.h"
 #include "lll/lll_df_types.h"
+#include "lll/lll_conn_types.h"
 #include "lll_conn.h"
 #include "lll_central.h"
 #include "lll_filter.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
@@ -28,6 +28,7 @@
 #include "lll/lll_vendor.h"
 #include "lll_clock.h"
 #include "lll/lll_df_types.h"
+#include "lll/lll_conn_types.h"
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 #include "lll_central_iso.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_chan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_chan.c
@@ -27,6 +27,7 @@
 #include "lll_adv.h"
 #include "lll/lll_adv_pdu.h"
 #include "lll/lll_df_types.h"
+#include "lll/lll_conn_types.h"
 #include "lll_conn.h"
 
 #include "ull_adv_types.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -31,6 +31,7 @@
 #include "lll.h"
 #include "lll_clock.h"
 #include "lll/lll_df_types.h"
+#include "lll/lll_conn_types.h"
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 #include "lll/lll_vendor.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
@@ -28,6 +28,7 @@
 #include "lll/lll_vendor.h"
 #include "lll_clock.h"
 #include "lll/lll_df_types.h"
+#include "lll/lll_conn_types.h"
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 #include "lll_central_iso.h"
@@ -908,16 +909,16 @@ void ull_conn_iso_start(struct ll_conn *conn, uint16_t cis_handle,
 
 #if defined(CONFIG_BT_CTLR_LE_ENC)
 	if (conn->lll.enc_tx) {
+		struct ccm *ccm_tx = &conn->lll.vendor.ccm_tx;
+
 		/* copy the Session Key */
-		memcpy(cis->lll.tx.ccm.key, conn->lll.ccm_tx.key,
-		       sizeof(cis->lll.tx.ccm.key));
+		memcpy(cis->lll.tx.ccm.key, ccm_tx->key, sizeof(cis->lll.tx.ccm.key));
 
 		/* copy the MSbits of IV Base */
-		memcpy(&cis->lll.tx.ccm.iv[4], &conn->lll.ccm_tx.iv[4], 4);
+		memcpy(&cis->lll.tx.ccm.iv[4], &ccm_tx->iv[4], 4);
 
 		/* XOR the CIS access address to get IV */
-		mem_xor_32(cis->lll.tx.ccm.iv, conn->lll.ccm_tx.iv,
-			   cis->lll.access_addr);
+		mem_xor_32(cis->lll.tx.ccm.iv, ccm_tx->iv, cis->lll.access_addr);
 
 		/* initialise counter */
 		cis->lll.tx.ccm.counter = 0U;
@@ -929,16 +930,16 @@ void ull_conn_iso_start(struct ll_conn *conn, uint16_t cis_handle,
 	}
 
 	if (conn->lll.enc_rx) {
+		struct ccm *ccm_rx = &conn->lll.vendor.ccm_rx;
+
 		/* copy the Session Key */
-		memcpy(cis->lll.rx.ccm.key, conn->lll.ccm_rx.key,
-		       sizeof(cis->lll.rx.ccm.key));
+		memcpy(cis->lll.rx.ccm.key, ccm_rx->key, sizeof(cis->lll.rx.ccm.key));
 
 		/* copy the MSbits of IV Base */
-		memcpy(&cis->lll.rx.ccm.iv[4], &conn->lll.ccm_rx.iv[4], 4);
+		memcpy(&cis->lll.rx.ccm.iv[4], &ccm_rx->iv[4], 4);
 
 		/* XOR the CIS access address to get IV */
-		mem_xor_32(cis->lll.rx.ccm.iv, conn->lll.ccm_rx.iv,
-			   cis->lll.access_addr);
+		mem_xor_32(cis->lll.rx.ccm.iv, ccm_rx->iv, cis->lll.access_addr);
 
 		/* initialise counter */
 		cis->lll.rx.ccm.counter = 0U;

--- a/subsys/bluetooth/controller/ll_sw/ull_df.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_df.c
@@ -31,6 +31,7 @@
 #include "lll/lll_df_types.h"
 #include "lll_sync.h"
 #include "lll_sync_iso.h"
+#include "lll/lll_conn_types.h"
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 #include "lll_df.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_filter.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_filter.c
@@ -30,6 +30,7 @@
 #include "lll/lll_adv_pdu.h"
 #include "lll_scan.h"
 #include "lll/lll_df_types.h"
+#include "lll/lll_conn_types.h"
 #include "lll_conn.h"
 #include "lll_filter.h"
 

--- a/subsys/bluetooth/controller/ll_sw/ull_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_iso.c
@@ -33,6 +33,7 @@
 #include "lll/lll_df_types.h"
 #include "lll_sync.h"
 #include "lll_sync_iso.h"
+#include "lll/lll_conn_types.h"
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 #include "lll_iso_tx.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.c
@@ -30,6 +30,7 @@
 #include "lll.h"
 #include "lll_clock.h"
 #include "lll/lll_df_types.h"
+#include "lll/lll_conn_types.h"
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_cc.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_cc.c
@@ -30,6 +30,7 @@
 
 #include "lll.h"
 #include "lll/lll_df_types.h"
+#include "lll/lll_conn_types.h"
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_chmu.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_chmu.c
@@ -28,6 +28,7 @@
 
 #include "lll.h"
 #include "lll/lll_df_types.h"
+#include "lll/lll_conn_types.h"
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
@@ -29,6 +29,7 @@
 #include "lll.h"
 #include "ll_feat.h"
 #include "lll/lll_df_types.h"
+#include "lll/lll_conn_types.h"
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_conn_upd.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_conn_upd.c
@@ -29,6 +29,7 @@
 
 #include "lll.h"
 #include "lll/lll_df_types.h"
+#include "lll/lll_conn_types.h"
 #include "lll_conn.h"
 
 #include "lll_conn_iso.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_local.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_local.c
@@ -29,6 +29,7 @@
 
 #include "lll.h"
 #include "lll/lll_df_types.h"
+#include "lll/lll_conn_types.h"
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_pdu.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_pdu.c
@@ -30,6 +30,7 @@
 #include "lll.h"
 #include "lll_clock.h"
 #include "lll/lll_df_types.h"
+#include "lll/lll_conn_types.h"
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
@@ -29,6 +29,7 @@
 #include "lll.h"
 #include "ll_feat.h"
 #include "lll/lll_df_types.h"
+#include "lll/lll_conn_types.h"
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
@@ -29,6 +29,7 @@
 
 #include "lll.h"
 #include "lll/lll_df_types.h"
+#include "lll/lll_conn_types.h"
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral.c
@@ -34,6 +34,7 @@
 #include "lll/lll_adv_pdu.h"
 #include "lll_chan.h"
 #include "lll/lll_df_types.h"
+#include "lll/lll_conn_types.h"
 #include "lll_conn.h"
 #include "lll_peripheral.h"
 #include "lll_filter.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
@@ -28,6 +28,7 @@
 #include "lll_clock.h"
 #include "lll/lll_vendor.h"
 #include "lll/lll_df_types.h"
+#include "lll/lll_conn_types.h"
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 #include "lll_peripheral_iso.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -33,6 +33,7 @@
 #include "lll/lll_adv_pdu.h"
 #include "lll_scan.h"
 #include "lll/lll_df_types.h"
+#include "lll/lll_conn_types.h"
 #include "lll_conn.h"
 #include "lll_filter.h"
 

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -27,6 +27,7 @@
 #include "lll_scan.h"
 #include "lll_scan_aux.h"
 #include "lll/lll_df_types.h"
+#include "lll/lll_conn_types.h"
 #include "lll_conn.h"
 #include "lll_sync.h"
 #include "lll_sync_iso.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_sched.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sched.c
@@ -33,6 +33,7 @@
 #include "lll_adv_sync.h"
 #include "lll_scan.h"
 #include "lll/lll_df_types.h"
+#include "lll/lll_conn_types.h"
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -32,6 +32,7 @@
 #include "lll_chan.h"
 #include "lll_scan.h"
 #include "lll/lll_df_types.h"
+#include "lll/lll_conn_types.h"
 #include "lll_conn.h"
 #include "lll_sync.h"
 #include "lll_sync_iso.h"

--- a/tests/bluetooth/controller/mock_ctrl/include/lll/lll_adv_types.h
+++ b/tests/bluetooth/controller/mock_ctrl/include/lll/lll_adv_types.h
@@ -26,3 +26,14 @@ struct lll_adv_pdu {
 	void *extra_data[DOUBLE_BUFFER_SIZE];
 #endif /* CONFIG_BT_CTLR_ADV_EXT_PDU_EXTRA_DATA_MEMORY */
 };
+
+/* Vendor specific data in Broadcast ISO context */
+struct lll_adv_iso_vendor {
+	union {
+#if defined(CONFIG_BT_CTLR_BROADCAST_ISO_ENC)
+		struct ccm ccm_tx;
+#endif /* CONFIG_BT_CTLR_BROADCAST_ISO_ENC */
+
+		uint8_t rfi[0];
+	};
+};

--- a/tests/bluetooth/df/common/src/bt_conn_common.c
+++ b/tests/bluetooth/df/common/src/bt_conn_common.c
@@ -20,6 +20,7 @@
 #include <pdu.h>
 #include <lll.h>
 #include <lll/lll_df_types.h>
+#include <lll/lll_conn_types.h>
 #include <lll_conn.h>
 
 #include <ull_tx_queue.h>


### PR DESCRIPTION
Move the nRF specific CCM structure to vendor specific Lower Link Layer implementation.

Vendor implementation without any need for storage can define a zero size structure:

Example:
struct lll_adv_iso_vendor {
	uint8_t dummy[0];
};

Fixes #71520.