### PR TITLE
drivers: max31865: fix under zero temperature calculation

### DIFF
--- a/drivers/sensor/maxim/max31865/max31865.h
+++ b/drivers/sensor/maxim/max31865/max31865.h
@@ -68,7 +68,7 @@ LOG_MODULE_REGISTER(MAX31865, CONFIG_SENSOR_LOG_LEVEL);
  * For under zero, taken from
  * https://www.analog.com/media/en/technical-documentation/application-notes/AN709_0.pdf
  */
-static const float A[6] = {-242.02, 2.2228, 2.5859e-3, 4.8260e-6, 2.8183e-8, 1.5243e-10};
+static const float A[6] = {-242.02, 2.2228, 2.5859e-3, -4.8260e-6, -2.8183e-8, 1.5243e-10};
 
 struct max31865_data {
 	double temperature;


### PR DESCRIPTION
Fixes the signs on the third- and fourth-order coefficients used to calculate temperatures under zero. 

Verified on PT100 RTD in environmental chamber down to -55degC.

References:

- https://www.analog.com/media/en/technical-documentation/application-notes/AN709_0.pdf [See section on 'Direct Mathematical Method', relevant screenshot included here]

- https://github.com/adafruit/Adafruit_MAX31865/blob/02dd3393d9750ca6e227be84b0e3b795a6941c36/Adafruit_MAX31865.cpp#L281 [Equivalent OSS implementation with correctly signed coefficients]

![image](https://github.com/zephyrproject-rtos/zephyr/assets/1933750/000ed2a0-8812-46b5-b2b2-b5afbc2e6970)
