### PR TITLE
drivers: spi: Align SPI init priority with other devices

### DIFF
--- a/drivers/spi/Kconfig
+++ b/drivers/spi/Kconfig
@@ -54,7 +54,7 @@ config SPI_EXTENDED_MODES
 
 config SPI_INIT_PRIORITY
 	int "Init priority"
-	default 70
+	default KERNEL_INIT_PRIORITY_DEVICE
 	help
 	  Device driver initialization priority.
 


### PR DESCRIPTION
Align the SPI init priority with other devices.
Other bus-devices like UART and I2C are init at standard kernel device level (50), but SPI is at 70 and there appears to not be a reason for it.
GPIO is init at 40 so there should not be an issue to use the default.