### PR TITLE
net: tcp: use PSA functions (if possible) for ISN generation instead of legacy MbedTLS ones 

### DIFF
--- a/modules/mbedtls/Kconfig.tls-generic
+++ b/modules/mbedtls/Kconfig.tls-generic
@@ -327,6 +327,10 @@ config MBEDTLS_MAC_SHA256_ENABLED
 	bool "SHA-224 and SHA-256 hash algorithms"
 	default y
 
+config PSA_WANT_ALG_SHA_256
+	depends on BUILD_WITH_TFM
+	bool "SHA-256 hash algorithm through PSA"
+
 config MBEDTLS_SHA256_SMALLER
 	bool "Smaller SHA-256 implementation"
 	depends on MBEDTLS_MAC_SHA256_ENABLED

--- a/modules/mbedtls/configs/config-tls-generic.h
+++ b/modules/mbedtls/configs/config-tls-generic.h
@@ -288,6 +288,10 @@
 #define MBEDTLS_SHA256_C
 #endif
 
+#if defined(CONFIG_PSA_WANT_ALG_SHA_256)
+#define PSA_WANT_ALG_SHA_256 1
+#endif
+
 #if defined(CONFIG_MBEDTLS_SHA256_SMALLER)
 #define MBEDTLS_SHA256_SMALLER
 #endif

--- a/subsys/net/ip/Kconfig.tcp
+++ b/subsys/net/ip/Kconfig.tcp
@@ -231,7 +231,7 @@ config NET_TCP_ISN_RFC6528
 	depends on NET_TCP
 	select MBEDTLS
 	select MBEDTLS_MD
-	select MBEDTLS_MAC_MD5_ENABLED
+	select MBEDTLS_MAC_SHA256_ENABLED
 	help
 	  Implement Initial Sequence Number calculation as described in
 	  RFC 6528 chapter 3. https://tools.ietf.org/html/rfc6528

--- a/subsys/net/ip/Kconfig.tcp
+++ b/subsys/net/ip/Kconfig.tcp
@@ -231,7 +231,8 @@ config NET_TCP_ISN_RFC6528
 	depends on NET_TCP
 	select MBEDTLS
 	select MBEDTLS_MD
-	select MBEDTLS_MAC_SHA256_ENABLED
+	select MBEDTLS_MAC_SHA256_ENABLED if !BUILD_WITH_TFM
+	select PSA_WANT_ALG_SHA_256 if BUILD_WITH_TFM
 	help
 	  Implement Initial Sequence Number calculation as described in
 	  RFC 6528 chapter 3. https://tools.ietf.org/html/rfc6528

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -2241,8 +2241,15 @@ static uint32_t tcpv6_init_isn(struct in6_addr *saddr,
 	memcpy(buf.key, unique_key, sizeof(buf.key));
 
 #if defined(CONFIG_NET_TCP_ISN_RFC6528)
+#if defined(CONFIG_BUILD_WITH_TFM)
+	size_t hash_len;
+
+	psa_hash_compute(PSA_ALG_SHA_256, (const unsigned char *)&buf, sizeof(buf),
+					 hash, sizeof(hash), &hash_len);
+#else /* CONFIG_BUILD_WITH_TFM */
 	mbedtls_sha256((const unsigned char *)&buf, sizeof(buf), hash, 0);
-#endif
+#endif /* CONFIG_BUILD_WITH_TFM */
+#endif /* CONFIG_NET_TCP_ISN_RFC6528 */
 
 	return seq_scale(UNALIGNED_GET((uint32_t *)&hash[0]));
 }
@@ -2276,8 +2283,15 @@ static uint32_t tcpv4_init_isn(struct in_addr *saddr,
 	memcpy(buf.key, unique_key, sizeof(unique_key));
 
 #if defined(CONFIG_NET_TCP_ISN_RFC6528)
+#if defined(CONFIG_BUILD_WITH_TFM)
+	size_t hash_len;
+
+	psa_hash_compute(PSA_ALG_SHA_256, (const unsigned char *)&buf, sizeof(buf),
+					 hash, sizeof(hash), &hash_len);
+#else /* CONFIG_BUILD_WITH_TFM */
 	mbedtls_sha256((const unsigned char *)&buf, sizeof(buf), hash, 0);
-#endif
+#endif /* CONFIG_BUILD_WITH_TFM */
+#endif /* CONFIG_NET_TCP_ISN_RFC6528 */
 
 	return seq_scale(UNALIGNED_GET((uint32_t *)&hash[0]));
 }

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -2234,7 +2234,11 @@ static uint32_t tcpv6_init_isn(struct in6_addr *saddr,
 	static bool once;
 
 	if (!once) {
+#if defined(CONFIG_CSPRNG_ENABLED)
+		sys_csrand_get(unique_key, sizeof(unique_key));
+#else
 		sys_rand_get(unique_key, sizeof(unique_key));
+#endif
 		once = true;
 	}
 
@@ -2276,7 +2280,11 @@ static uint32_t tcpv4_init_isn(struct in_addr *saddr,
 	static bool once;
 
 	if (!once) {
+#if defined(CONFIG_CSPRNG_ENABLED)
+		sys_csrand_get(unique_key, sizeof(unique_key));
+#else
 		sys_rand_get(unique_key, sizeof(unique_key));
+#endif
 		once = true;
 	}
 

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -14,7 +14,7 @@ LOG_MODULE_REGISTER(net_tcp, CONFIG_NET_TCP_LOG_LEVEL);
 #include <zephyr/random/random.h>
 
 #if defined(CONFIG_NET_TCP_ISN_RFC6528)
-#include <mbedtls/md5.h>
+#include <mbedtls/sha256.h>
 #endif
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_context.h>
@@ -2210,7 +2210,7 @@ static uint32_t seq_scale(uint32_t seq)
 	return seq + (k_ticks_to_ns_floor32(k_uptime_ticks()) >> 6);
 }
 
-static uint8_t unique_key[16]; /* MD5 128 bits as described in RFC6528 */
+static uint8_t unique_key[16]; /* 128 bits as described in RFC6528 */
 
 static uint32_t tcpv6_init_isn(struct in6_addr *saddr,
 			       struct in6_addr *daddr,
@@ -2230,7 +2230,7 @@ static uint32_t tcpv6_init_isn(struct in6_addr *saddr,
 		.dport = dport
 	};
 
-	uint8_t hash[16];
+	uint8_t hash[32];
 	static bool once;
 
 	if (!once) {
@@ -2241,7 +2241,7 @@ static uint32_t tcpv6_init_isn(struct in6_addr *saddr,
 	memcpy(buf.key, unique_key, sizeof(buf.key));
 
 #if defined(CONFIG_NET_TCP_ISN_RFC6528)
-	mbedtls_md5((const unsigned char *)&buf, sizeof(buf), hash);
+	mbedtls_sha256((const unsigned char *)&buf, sizeof(buf), hash, 0);
 #endif
 
 	return seq_scale(UNALIGNED_GET((uint32_t *)&hash[0]));
@@ -2265,7 +2265,7 @@ static uint32_t tcpv4_init_isn(struct in_addr *saddr,
 		.dport = dport
 	};
 
-	uint8_t hash[16];
+	uint8_t hash[32];
 	static bool once;
 
 	if (!once) {
@@ -2276,7 +2276,7 @@ static uint32_t tcpv4_init_isn(struct in_addr *saddr,
 	memcpy(buf.key, unique_key, sizeof(unique_key));
 
 #if defined(CONFIG_NET_TCP_ISN_RFC6528)
-	mbedtls_md5((const unsigned char *)&buf, sizeof(buf), hash);
+	mbedtls_sha256((const unsigned char *)&buf, sizeof(buf), hash, 0);
 #endif
 
 	return seq_scale(UNALIGNED_GET((uint32_t *)&hash[0]));


### PR DESCRIPTION
[RFC6528](https://datatracker.ietf.org/doc/html/rfc6528) suggests to use MD5 as hash algorithm for the ISN, however:

- MD5 is weaker than SHA256;
- MD5 is only used here in Zephyr, so doing this change allows to keep almost always disabled (reducing memory footprint);
- Most of the hardware nowadays support SHA256 so it should be fairly easy to compute;
- TFM is very likely to provide support for SHA256 so in the future we can replace `mbedtls_sha256()` with `psa_xxx()` when `CONFIG_BUILD_WITH_TFM` is enabled.