### PR TITLE
Fixes and improvements to pm policy

### DIFF
--- a/include/zephyr/pm/policy.h
+++ b/include/zephyr/pm/policy.h
@@ -32,7 +32,7 @@ extern "C" {
  * microseconds. SYS_FOREVER_US value lifts the latency constraint. Other values
  * are forbidden.
  */
-typedef void (*pm_policy_latency_changed_cb_t)(int32_t latency);
+typedef void (*pm_policy_latency_changed_cb_t)(uint32_t latency);
 
 /**
  * @brief Latency change subscription.

--- a/subsys/pm/policy.c
+++ b/subsys/pm/policy.c
@@ -50,9 +50,9 @@ static struct k_spinlock latency_lock;
 /** List of maximum latency requests. */
 static sys_slist_t latency_reqs;
 /** Maximum CPU latency in us */
-static int32_t max_latency_us = SYS_FOREVER_US;
+static uint32_t max_latency_us = SYS_FOREVER_US;
 /** Maximum CPU latency in cycles */
-static int32_t max_latency_cyc = -1;
+static uint32_t max_latency_cyc = -1;
 /** List of latency change subscribers. */
 static sys_slist_t latency_subs;
 
@@ -66,26 +66,25 @@ static int64_t next_event_cyc = -1;
 /** @brief Update maximum allowed latency. */
 static void update_max_latency(void)
 {
-	int32_t new_max_latency_us = SYS_FOREVER_US;
+	uint32_t new_max_latency_us = SYS_FOREVER_US;
 	struct pm_policy_latency_request *req;
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&latency_reqs, req, node) {
-		if ((new_max_latency_us == SYS_FOREVER_US) ||
-		    ((int32_t)req->value_us < new_max_latency_us)) {
-			new_max_latency_us = (int32_t)req->value_us;
+		if (req->value_us < new_max_latency_us) {
+			new_max_latency_us = req->value_us;
 		}
 	}
 
 	if (max_latency_us != new_max_latency_us) {
 		struct pm_policy_latency_subscription *sreq;
-		int32_t new_max_latency_cyc = -1;
+		uint32_t new_max_latency_cyc = -1;
 
 		SYS_SLIST_FOR_EACH_CONTAINER(&latency_subs, sreq, node) {
 			sreq->cb(new_max_latency_us);
 		}
 
 		if (new_max_latency_us != SYS_FOREVER_US) {
-			new_max_latency_cyc = (int32_t)k_us_to_cyc_ceil32(new_max_latency_us);
+			new_max_latency_cyc = k_us_to_cyc_ceil32(new_max_latency_us);
 		}
 
 		max_latency_us = new_max_latency_us;


### PR DESCRIPTION
This PR addresses 2 issues:
1. Buggy implementation of the latency requests that result in incorrect max latencies allowed by the system
2. Fix implementation of the next event registration. Since the next event is not registered with the kernel timeout manager, the sleep will be incorrect.