### PR TITLE
scripts: twister: Fix duplicate scans

### DIFF
--- a/scripts/pylib/twister/twisterlib/testsuite.py
+++ b/scripts/pylib/twister/twisterlib/testsuite.py
@@ -310,7 +310,13 @@ def scan_testsuite_path(testsuite_path):
         except ValueError as e:
             logger.error("%s: error parsing source file: %s" % (filename, e))
 
+    src_dir_pathlib_path = Path(src_dir_path)
     for filename in find_c_files_in(testsuite_path):
+        # If we have already scanned those files in the src_dir step, skip them.
+        filename_path = Path(filename)
+        if src_dir_pathlib_path in filename_path.parents:
+            continue
+
         try:
             result: ScanPathResult = scan_file(filename)
             if result.warnings:


### PR DESCRIPTION
If the src_dir_path is a child of testsuite_path, some C files might be scanned twice.

To prevent that, we check for parentage.