### PR TITLE
scripts: twister: Fix duplicate statusless testcases

### DIFF
--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -731,7 +731,7 @@ class ProjectBuilder(FilterBuilder):
                     if matches:
                         for m in matches:
                             # new_ztest_suite = m[0] # not used for now
-                            test_func_name = m[1].replace("test_", "")
+                            test_func_name = m[1].replace("test_", "", 1)
                             testcase_id = f"{yaml_testsuite_name}.{test_func_name}"
                             detected_cases.append(testcase_id)
 


### PR DESCRIPTION
In some cases, Twister would report twice the amount of testcases run than expected, with half of them lacking any status.

This change fixes erroneous ELF testcase name extraction, which deleted every instance of 'test_' in the name, rather than just the first.

To reproduce: `scripts/twister -p qemu_x86 -T tests/net/checksum_offload/ -vvv --timestamps` - tests there contain the phrase `test_` and become duplicated without this fix.