### PR TITLE
drivers: ptp_clock_nxp_enet: misc fixes and fixing build error due to net test disabling ethernet drivers

### DIFF
--- a/drivers/ptp_clock/Kconfig.nxp_enet
+++ b/drivers/ptp_clock/Kconfig.nxp_enet
@@ -5,5 +5,6 @@ config PTP_CLOCK_NXP_ENET
 	bool "NXP ENET PTP Clock driver"
 	default y
 	depends on DT_HAS_NXP_ENET_PTP_CLOCK_ENABLED && NET_L2_PTP
+	depends on ETH_NXP_ENET
 	help
 	  Enable NXP ENET PTP clock support.

--- a/drivers/ptp_clock/ptp_clock_nxp_enet.c
+++ b/drivers/ptp_clock/ptp_clock_nxp_enet.c
@@ -16,7 +16,7 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/ethernet/eth_nxp_enet.h>
 
-#include "fsl_enet.h"
+#include <fsl_enet.h>
 
 struct ptp_clock_nxp_enet_config {
 	ENET_Type *base;

--- a/tests/net/ptp/clock/boards/frdm_k64f.overlay
+++ b/tests/net/ptp/clock/boards/frdm_k64f.overlay
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&enet {
-
-	ptp {
-		status = "ok";
-	};
+&enet_ptp_clock {
+	status = "okay";
 };


### PR DESCRIPTION
1. Correct node label in k64 overlay for ptp test
   - Not sure if this actually matters since it appears that actual hardware is no longer tested in net tests

2. Include fsl_enet with <> instead of "".

3. Build the ptp clock driver only if the ethernet driver is built
   - Technically I think the 1588 timer should be able to be used even if the ethernet mac is not used, but I would imagine this to be an extraordinarily rare, weird, and niche use case, so to fix the current CI error caused by net test disabling ethernet drivers, couple the ptp clock driver to the ethernet driver in the build configuration.

Fixes #71738