### PR TITLE
boards: nxp: Add compatible for RD_RW612_BGA

### DIFF
--- a/boards/nxp/rd_rw612_bga/rd_rw612_bga.dts
+++ b/boards/nxp/rd_rw612_bga/rd_rw612_bga.dts
@@ -11,4 +11,5 @@
 
 / {
 	model = "nxp,rd_rw612_bga";
+	compatible = "nxp,rd_rw612_bga";
 };


### PR DESCRIPTION
Add `compatible` entry for the rd_rw612_bga target.