### PR TITLE
iterable_sections: move to specific header

### DIFF
--- a/subsys/net/l2/wifi/wifi_nm.ld
+++ b/subsys/net/l2/wifi/wifi_nm.ld
@@ -4,4 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/linker/iterable_sections.h>
+
 ITERABLE_SECTION_RAM(wifi_nm_instance, Z_LINK_ITERABLE_SUBALIGN)


### PR DESCRIPTION
Until now iterable sections APIs have been part of the toolchain (common) headers. They are not strictly related to a toolchain, they just rely on linker providing support for sections. Most files relied on indirect includes to access the API, now, it is included as needed.