### PR TITLE
drivers: mdio: Make bus functions optional

### DIFF
--- a/drivers/mdio/mdio_esp32.c
+++ b/drivers/mdio/mdio_esp32.c
@@ -86,16 +86,6 @@ static int mdio_esp32_write(const struct device *dev, uint8_t prtad,
 	return mdio_transfer(dev, prtad, regad, true, data, NULL);
 }
 
-static void mdio_esp32_bus_enable(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-}
-
-static void mdio_esp32_bus_disable(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-}
-
 static int mdio_esp32_initialize(const struct device *dev)
 {
 	const struct mdio_esp32_dev_config *const cfg = dev->config;
@@ -134,8 +124,6 @@ err:
 static const struct mdio_driver_api mdio_esp32_driver_api = {
 	.read = mdio_esp32_read,
 	.write = mdio_esp32_write,
-	.bus_enable = mdio_esp32_bus_enable,
-	.bus_disable = mdio_esp32_bus_disable,
 };
 
 #define MDIO_ESP32_CONFIG(n)						\

--- a/drivers/mdio/mdio_gpio.c
+++ b/drivers/mdio/mdio_gpio.c
@@ -157,21 +157,9 @@ static int mdio_gpio_initialize(const struct device *dev)
 	return 0;
 }
 
-static void mdio_gpio_bus_enable(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-}
-
-static void mdio_gpio_bus_disable(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-}
-
 static const struct mdio_driver_api mdio_gpio_driver_api = {
 	.read = mdio_gpio_read_mmi,
 	.write = mdio_gpio_write_mmi,
-	.bus_enable = mdio_gpio_bus_enable,
-	.bus_disable = mdio_gpio_bus_disable,
 };
 
 #define MDIO_GPIO_CONFIG(inst)                                                                     \

--- a/drivers/mdio/mdio_nxp_enet.c
+++ b/drivers/mdio/mdio_nxp_enet.c
@@ -179,21 +179,9 @@ static int nxp_enet_mdio_write(const struct device *dev,
 	return ret;
 }
 
-/* MDIO bus enable/disable "implementation" */
-static void nxp_enet_mdio_bus_fn(const struct device *dev)
-{
-	/*
-	 * MDIO bus device is actually part of ethernet device, and
-	 * does not support ability to disable/enable MDIO bus hardware
-	 * independently of the ethernet/MAC hardware, so do nothing.
-	 */
-}
-
 static const struct mdio_driver_api nxp_enet_mdio_api = {
 	.read = nxp_enet_mdio_read,
 	.write = nxp_enet_mdio_write,
-	.bus_enable = nxp_enet_mdio_bus_fn,
-	.bus_disable = nxp_enet_mdio_bus_fn,
 };
 
 static void nxp_enet_mdio_isr_cb(const struct device *dev)

--- a/drivers/mdio/mdio_nxp_enet_qos.c
+++ b/drivers/mdio/mdio_nxp_enet_qos.c
@@ -144,17 +144,9 @@ static int nxp_enet_qos_mdio_write(const struct device *dev,
 	return do_transaction(&mdio_write);
 }
 
-static void nxp_enet_qos_mdio_bus_fn(const struct device *dev)
-{
-	/* Intentionally empty. IP does not support this functionality. */
-	ARG_UNUSED(dev);
-}
-
 static const struct mdio_driver_api nxp_enet_qos_mdio_api = {
 	.read = nxp_enet_qos_mdio_read,
 	.write = nxp_enet_qos_mdio_write,
-	.bus_enable = nxp_enet_qos_mdio_bus_fn,
-	.bus_disable = nxp_enet_qos_mdio_bus_fn,
 };
 
 static int nxp_enet_qos_mdio_init(const struct device *dev)

--- a/drivers/mdio/mdio_nxp_s32_gmac.c
+++ b/drivers/mdio/mdio_nxp_s32_gmac.c
@@ -141,19 +141,11 @@ static int mdio_nxp_s32_init(const struct device *dev)
 	return 0;
 }
 
-static void mdio_nxp_s32_noop(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-	/* Controller does not support enabling/disabling MDIO bus */
-}
-
 static const struct mdio_driver_api mdio_nxp_s32_driver_api = {
 	.read = mdio_nxp_s32_read_c22,
 	.write = mdio_nxp_s32_write_c22,
 	.read_c45 = mdio_nxp_s32_read_c45,
 	.write_c45 = mdio_nxp_s32_write_c45,
-	.bus_enable = mdio_nxp_s32_noop,
-	.bus_disable = mdio_nxp_s32_noop,
 };
 
 #define MDIO_NXP_S32_HW_INSTANCE_CHECK(i, n)						\

--- a/drivers/mdio/mdio_nxp_s32_netc.c
+++ b/drivers/mdio/mdio_nxp_s32_netc.c
@@ -67,17 +67,9 @@ static int nxp_s32_mdio_initialize(const struct device *dev)
 	return 0;
 }
 
-static void nxp_s32_mdio_noop(const struct device *dev)
-{
-	/* intentionally left empty */
-}
-
 static const struct mdio_driver_api nxp_s32_mdio_api = {
 	.read = nxp_s32_mdio_read,
 	.write = nxp_s32_mdio_write,
-	/* NETC does not support enabling/disabling EMDIO controller independently */
-	.bus_enable = nxp_s32_mdio_noop,
-	.bus_disable = nxp_s32_mdio_noop,
 };
 
 #define NXP_S32_MDIO_HW_INSTANCE_CHECK(i, n) \

--- a/include/zephyr/drivers/mdio.h
+++ b/include/zephyr/drivers/mdio.h
@@ -73,7 +73,9 @@ static inline void z_impl_mdio_bus_enable(const struct device *dev)
 	const struct mdio_driver_api *api =
 		(const struct mdio_driver_api *)dev->api;
 
-	api->bus_enable(dev);
+	if (api->bus_enable != NULL) {
+		api->bus_enable(dev);
+	}
 }
 
 /**
@@ -89,7 +91,9 @@ static inline void z_impl_mdio_bus_disable(const struct device *dev)
 	const struct mdio_driver_api *api =
 		(const struct mdio_driver_api *)dev->api;
 
-	api->bus_disable(dev);
+	if (api->bus_disable != NULL) {
+		api->bus_disable(dev);
+	}
 }
 
 /**


### PR DESCRIPTION
Most of the MDIO drivers in the tree do not implement the bus_enable and bus_disable functions in the api, so it seems silly to keep making empty functions for these, just check if they are implemented or not in the header