### PR TITLE
arm: irq: Disable clang warning on VFP clobbering

### DIFF
--- a/include/zephyr/arch/arm/irq.h
+++ b/include/zephyr/arch/arm/irq.h
@@ -166,10 +166,24 @@ static inline void arch_isr_direct_footer(int maybe_swap)
 	}
 }
 
+#if defined(__clang__)
+#define ARCH_ISR_DIAG_OFF \
+	_Pragma("clang diagnostic push") \
+	_Pragma("clang diagnostic ignored \"-Wextra\"")
+#define ARCH_ISR_DIAG_ON _Pragma("clang diagnostic pop")
+#elif defined(__GNUC__)
+#define ARCH_ISR_DIAG_OFF \
+	_Pragma("GCC diagnostic push") \
+	_Pragma("GCC diagnostic ignored \"-Wattributes\"")
+#define ARCH_ISR_DIAG_ON _Pragma("GCC diagnostic pop")
+#else
+#define ARCH_ISR_DIAG_OFF
+#define ARCH_ISR_DIAG_ON
+#endif
+
 #define ARCH_ISR_DIRECT_DECLARE(name) \
 	static inline int name##_body(void); \
-	_Pragma("GCC diagnostic push") \
-	_Pragma("GCC diagnostic ignored \"-Wattributes\"") \
+	ARCH_ISR_DIAG_OFF \
 	__attribute__ ((interrupt ("IRQ"))) void name(void) \
 	{ \
 		int check_reschedule; \
@@ -177,7 +191,7 @@ static inline void arch_isr_direct_footer(int maybe_swap)
 		check_reschedule = name##_body(); \
 		ISR_DIRECT_FOOTER(check_reschedule); \
 	} \
-	_Pragma("GCC diagnostic pop") \
+	ARCH_ISR_DIAG_ON \
 	static inline int name##_body(void)
 
 #if defined(CONFIG_DYNAMIC_DIRECT_INTERRUPTS)


### PR DESCRIPTION
Clang warns the user whenever an ISR invokes a function that is not marked with the `interrupt` attribute. This applies to the whole call chain, which makes it unfeasible to add the attribute to add it to all functions.

Instead, disable the clang warning just like it was done for the equivalent GCC one in 5b3f80094ec561758bd506c20c453703b859b8c6.

See also:
https://reviews.llvm.org/D28820