### PR TITLE
bluetooth: host: Fix alignment of gatt_chrc

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -1859,7 +1859,7 @@ struct gatt_chrc {
 	union {
 		uint16_t uuid16;
 		uint8_t  uuid[16];
-	};
+	} __packed;
 } __packed;
 
 uint16_t bt_gatt_attr_value_handle(const struct bt_gatt_attr *attr)


### PR DESCRIPTION
The following warning is issued by clang:

```
warning: field  within 'struct gatt_chrc' is less aligned than'union gatt_chrc::(anonymous at
subsys/bluetooth/host/gatt.c:1859:2)' and is usually due to 'struct gatt_chrc' being packed, 
which can lead to unaligned accesses [-Wunaligned-access]
```

This is due to the fact that the `uint16_t uuid` field requires 2-byte alignment but it is not marked as packed. Since the enclosing struct is indeed packed, the required alignment is not guaranteed and so clang complains. Fix it by ensuring that the union is marked as packed too.