### PR TITLE
MAINTAINERS: Exclude nordic common from DT group

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -783,6 +783,8 @@ Devicetree:
     - include/zephyr/devicetree/
     - scripts/kconfig/kconfigfunctions.py
     - include/zephyr/devicetree.h
+  files-exclude:
+    - dts/common/nordic/
   labels:
     - "area: Devicetree"
   tests:


### PR DESCRIPTION
dts/common/nordic excluded from DT maintainers group (still covered by nrf platform group)