### PR TITLE
drivers: w1: Ensure DQ pin is both input and output.

### DIFF
--- a/drivers/w1/w1_zephyr_gpio.c
+++ b/drivers/w1/w1_zephyr_gpio.c
@@ -289,7 +289,7 @@ static int w1_gpio_init(const struct device *dev)
 
 	if (gpio_is_ready_dt(spec)) {
 		int ret = gpio_pin_configure_dt(spec, GPIO_OUTPUT_INACTIVE | GPIO_OPEN_DRAIN |
-							      GPIO_PULL_UP);
+							      GPIO_INPUT);
 		if (ret < 0) {
 			LOG_ERR("Failed to configure GPIO port %s pin %d", spec->port->name,
 				spec->pin);

--- a/dts/bindings/w1/zephyr,w1-gpio.yaml
+++ b/dts/bindings/w1/zephyr,w1-gpio.yaml
@@ -19,6 +19,12 @@ description: |
     - w1 is pin 13 on gpio0. The gpio is active when the pin is high, is
       configured as an open-drain, and has a pull-up resistor.
 
+  Implementation details:
+    - Most drivers require the selected gpio to support open drain, this enables onewire
+      devices to lower the signal when the SOC set the signal high.
+    - Ensure pullup is strong enough (4.7K according to the specification). Standard pullup in
+      SOC are usually weak, and may not be strong enough.
+
 compatible: "zephyr,w1-gpio"
 
 include: [w1-master.yaml]


### PR DESCRIPTION
Driver did not work on ESP32c3, by specifying pin to be output and input solve the issue. Improve documentation, to highlight that driver is requiring open-drain support.

This is a continuation of PR:
https://github.com/zephyrproject-rtos/zephyr/pull/70956
I messed up my repo, so I needed to restart.