### PR TITLE
tests: drivers: counter: counter_basic_api

### DIFF
--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -181,6 +181,7 @@ static void test_all_instances(counter_test_func_t func,
 			func(devices[i]);
 		} else {
 			TC_PRINT("Skipped for %s\n", devices[i]->name);
+			ztest_test_skip();
 		}
 		counter_tear_down_instance(devices[i]);
 		/* Allow logs to be printed. */


### PR DESCRIPTION
Correctly show skips in final statistics.

Tests should show correct statistics at the end for proper skips.
Before this change, all skipped tests would show up as passed
in the final count.