### PR TITLE
dts: stm32f446: add missing adc2 and adc3

### DIFF
--- a/dts/arm/st/f4/stm32f446.dtsi
+++ b/dts/arm/st/f4/stm32f446.dtsi
@@ -106,6 +106,38 @@
 			status = "disabled";
 		};
 
+		adc2: adc@40012100 {
+			compatible = "st,stm32-adc";
+			reg = <0x40012100 0x050>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000200>;
+			interrupts = <18 0>;
+			status = "disabled";
+			#io-channel-cells = <1>;
+			resolutions = <STM32_ADC_RES(12, 0x00)
+				       STM32_ADC_RES(10, 0x01)
+				       STM32_ADC_RES(8, 0x02)
+				       STM32_ADC_RES(6, 0x03)>;
+			sampling-times = <3 15 28 56 84 112 144 480>;
+			st,adc-clock-source = <SYNC>;
+			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+		};
+
+		adc3: adc@40012200 {
+			compatible = "st,stm32-adc";
+			reg = <0x40012200 0x050>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000400>;
+			interrupts = <18 0>;
+			status = "disabled";
+			#io-channel-cells = <1>;
+			resolutions = <STM32_ADC_RES(12, 0x00)
+				       STM32_ADC_RES(10, 0x01)
+				       STM32_ADC_RES(8, 0x02)
+				       STM32_ADC_RES(6, 0x03)>;
+			sampling-times = <3 15 28 56 84 112 144 480>;
+			st,adc-clock-source = <SYNC>;
+			st,adc-sequencer = <FULLY_CONFIGURABLE>;
+		};
+
 		dac1: dac@40007400 {
 			compatible = "st,stm32-dac";
 			reg = <0x40007400 0x400>;


### PR DESCRIPTION
The STM32F446 product line includes 3 ADCs, but adc2 and adc3 were missing the DTS.

The STM32F446 seems one of the few (only?) product in the F4 family whose DTS is not incrementally based off other intermediate parts in family and is instead based off the STM32F401 directly. Maybe there's an opportunity to restructure this DTS to be based off other ones (maybe STM32F405?) to simplify it. I'll have a deeper look, but for the time being, just adding the missing ADCs so that they can be used.

Thanks!