### PR TITLE
pm: device_runtime: Check busy status in runtime_enable

### DIFF
--- a/include/zephyr/pm/device_runtime.h
+++ b/include/zephyr/pm/device_runtime.h
@@ -49,6 +49,7 @@ int pm_device_runtime_auto_enable(const struct device *dev);
  *
  * @retval 0 If the device runtime PM is enabled successfully.
  * @retval -EPERM If device has power state locked.
+ * @retval -EBUSY If device is busy.
  * @retval -ENOTSUP If the device does not support PM.
  * @retval -errno Other negative errno, result of suspending the device.
  *

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -422,6 +422,11 @@ int pm_device_runtime_enable(const struct device *dev)
 		goto end;
 	}
 
+	if (pm_device_is_busy(dev)) {
+		ret = -EBUSY;
+		goto end;
+	}
+
 	if (atomic_test_bit(&dev->pm_base->flags, PM_DEVICE_FLAG_ISR_SAFE)) {
 		ret = runtime_enable_sync(dev);
 		goto end;


### PR DESCRIPTION
We can't enable device runtime power management in a device that is set busy since it may suspend this device.