### PR TITLE
MAINTAINERS: ARC: remove SiyuanCheng-CN from ARC collaborators

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -135,7 +135,6 @@ ARC arch:
   collaborators:
     - abrodkin
     - evgeniy-paltsev
-    - SiyuanCheng-CN
   files:
     - arch/arc/
     - include/zephyr/arch/arc/


### PR DESCRIPTION
SiyuanCheng-CN is no longer working for Synopsys