### PR TITLE
Bluetooth: BAP: Shell: Add BASS service data to ext-adv

### DIFF
--- a/subsys/bluetooth/audio/shell/audio.h
+++ b/subsys/bluetooth/audio/shell/audio.h
@@ -31,6 +31,7 @@ ssize_t audio_ad_data_add(struct bt_data *data, const size_t data_size, const bo
 ssize_t audio_pa_data_add(struct bt_data *data_array, const size_t data_array_size);
 ssize_t csis_ad_data_add(struct bt_data *data, const size_t data_size, const bool discoverable);
 size_t cap_acceptor_ad_data_add(struct bt_data data[], size_t data_size, bool discoverable);
+size_t bap_scan_delegator_ad_data_add(struct bt_data data[], size_t data_size);
 size_t gmap_ad_data_add(struct bt_data data[], size_t data_size);
 size_t pbp_ad_data_add(struct bt_data data[], size_t data_size);
 ssize_t cap_initiator_ad_data_add(struct bt_data *data_array, const size_t data_array_size,

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -3876,6 +3876,11 @@ static ssize_t connectable_ad_data_add(struct bt_data *data_array,
 		ad_len++;
 	}
 
+	if (IS_ENABLED(CONFIG_BT_BAP_SCAN_DELEGATOR)) {
+		ad_len += bap_scan_delegator_ad_data_add(&data_array[ad_len],
+							 data_array_size - ad_len);
+	}
+
 	if (IS_ENABLED(CONFIG_BT_CAP_ACCEPTOR)) {
 		ad_len += cap_acceptor_ad_data_add(&data_array[ad_len], data_array_size - ad_len,
 						   true);

--- a/subsys/bluetooth/audio/shell/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/shell/bap_scan_delegator.c
@@ -36,6 +36,20 @@ struct sync_state {
 
 static bool past_preference = true;
 
+size_t bap_scan_delegator_ad_data_add(struct bt_data data[], size_t data_size)
+{
+	static uint8_t ad_bap_scan_delegator[2] = {
+		BT_UUID_16_ENCODE(BT_UUID_BASS_VAL),
+	};
+
+	__ASSERT(data_size > 0, "No space for ad_bap_scan_delegator");
+	data[0].type = BT_DATA_SVC_DATA16;
+	data[0].data_len = ARRAY_SIZE(ad_bap_scan_delegator);
+	data[0].data = &ad_bap_scan_delegator[0];
+
+	return 1U;
+}
+
 static struct sync_state *sync_state_get(const struct bt_bap_scan_delegator_recv_state *recv_state)
 {
 	for (size_t i = 0U; i < ARRAY_SIZE(sync_states); i++) {


### PR DESCRIPTION
As per the BAP spec, the scan delegator device should add the BASS service data in the extended advertising data when it requests a broadcast assistant to scan for it. For testing purposes that's usually the case with the shell, extended advertising data shall be populated with the BASS service data.

Fixes #70834 