### PR TITLE
usb: device: Do not claim to be USB 3.2 device

### DIFF
--- a/include/zephyr/usb/usb_ch9.h
+++ b/include/zephyr/usb/usb_ch9.h
@@ -268,6 +268,7 @@ struct usb_association_descriptor {
 /** USB Specification Release Numbers (bcdUSB Descriptor field) */
 #define USB_SRN_1_1			0x0110
 #define USB_SRN_2_0			0x0200
+#define USB_SRN_2_0_1			0x0201
 #define USB_SRN_2_1			0x0210
 
 #define USB_DEC_TO_BCD(dec)	((((dec) / 10) << 4) | ((dec) % 10))

--- a/samples/subsys/usb/webusb/src/main.c
+++ b/samples/subsys/usb/webusb/src/main.c
@@ -164,10 +164,13 @@ USB_DEVICE_BOS_DESC_DEFINE_CAP struct usb_bos_capability_lpm bos_cap_lpm = {
 	.bDescriptorType = USB_DESC_DEVICE_CAPABILITY,
 	.bDevCapabilityType = USB_BOS_CAPABILITY_EXTENSION,
 	/**
+	 * Currently there is not a single device driver in Zephyr that supports
+	 * LPM. Moreover, Zephyr USB stack does not have LPM support, so do not
+	 * falsely claim to support LPM.
 	 * BIT(1) - LPM support
 	 * BIT(2) - BESL support
 	 */
-	.bmAttributes = BIT(1) | BIT(2),
+	.bmAttributes = 0,
 };
 
 /* WebUSB Device Requests */

--- a/subsys/usb/device/usb_descriptor.c
+++ b/subsys/usb/device/usb_descriptor.c
@@ -56,7 +56,7 @@ USBD_DEVICE_DESCR_DEFINE(primary) struct common_descriptor common_desc = {
 		.bLength = sizeof(struct usb_device_descriptor),
 		.bDescriptorType = USB_DESC_DEVICE,
 #ifdef CONFIG_USB_DEVICE_BOS
-		.bcdUSB = sys_cpu_to_le16(USB_SRN_2_1),
+		.bcdUSB = sys_cpu_to_le16(USB_SRN_2_0_1),
 #else
 		.bcdUSB = sys_cpu_to_le16(USB_SRN_2_0),
 #endif


### PR DESCRIPTION
The bcdUSB value 0x0210 defined in USB 3.2 Specification indicates USB 3.2 device operating in one of the USB 2.0 modes. USB 2.0 Link Power Management Addendum defines bcdUSB value 0x0201 to indicate that USB 2.0 device supports the request to read the BOS Descriptor.

The main difference between bcdUSB 0x0210 and 0x0201 is that the USB 3.2 device must support LPM, while USB 2.0 devices can (but are not required to) support LPM.

The difference is respected by USB 3 Gen X Command Verifier (2.3.0.0) Chapter 9 Tests [USB 2 devices], where the test behaves as follows:

      * For bcdUSB 0x0200:
          Checking Device Under Test for LPM L1 Compatibility...
          USB version of device is 2.00.
          DUT is NOT compatible with LPM.
          LPM is NOT required for DUT
          LPM is only supported in USB version 2.01 and above.
    
      * For bcdUSB 0x0201:
          Checking Device Under Test for LPM L1 Compatibility...
          USB version of device is 2.01.
          DUT IS compatible with LPM.
          LPM is NOT required for DUT
          USB 2.0 Extension Descriptor bmAttributes:
            LPM Capable = 0
            BESL and Alternate HIRD Supported = 0
            Baseline BESL Valid = 0
            Deep BESL Valid = 0
            Baseline BESL: 0d
            Deep BESL:  0d
          LPM is not supported
    
      * For bcdUSB 0x0210:
          Checking Device Under Test for LPM L1 Compatibility...
          USB version of device is 2.10.
          DUT IS compatible with LPM.
          LPM IS required for DUT
          USB 2.0 Extension Descriptor bmAttributes:
            LPM Capable = 0
            BESL and Alternate HIRD Supported = 0
            Baseline BESL Valid = 0
            Deep BESL Valid = 0
            Baseline BESL: 0d
            Deep BESL:  0d
          (USB: 9.6.2.1.6) Bit 1 in Attributes field of a USB 2.0 Extension
          descriptor returned in response to a GetDescriptor(BOS) request
          must be 1 for LS/FS/HS devices that support LPM L1.


The test fails when LPM bit is not set in USB 2.0 Extension Descriptor only when bcdUSB is 0x0210. The test failure was incorrectly fixed in commit 312429be3c0c ("usb: samples: Add Extension descriptor to webUSB sample."). Properly fix the issue by changing bcdUSB to 0x0201 and removing the false LPM support claim.

The false LPM claim was leading to device ceasing to work after some time if there was no traffic from host to device (when the host is likely to have executed the LPM L1 transition that was not properly handled by the device).