### PR TITLE
doc: boards: esp32: fix wrong link in M5Stack-Core2 docs

### DIFF
--- a/boards/m5stack/m5stack_core2/doc/index.rst
+++ b/boards/m5stack/m5stack_core2/doc/index.rst
@@ -219,6 +219,6 @@ Related Documents
 
 - `M5Stack-Core2 schematic <https://m5stack.oss-cn-shenzhen.aliyuncs.com/resource/docs/schematic/Core/CORE2_V1.0_SCH.pdf>`_ (PDF)
 - `ESP32-PICO-D4 Datasheet <https://www.espressif.com/sites/default/files/documentation/esp32-pico-d4_datasheet_en.pdf>`_ (PDF)
-- `M5StickC PLUS docs <https://docs.m5stack.com/en/core/m5stickc_plus>`_
+- `M5Stack-Core2 docs <https://docs.m5stack.com/en/core/core2>`_
 - `ESP32 Datasheet <https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf>`_ (PDF)
 - `ESP32 Hardware Reference <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/index.html>`_


### PR DESCRIPTION
fix link to core2 main doc page (was pointing to StickC-Plus)