### PR TITLE
soc: nordic: vpr: remove custom mcause exception mask.

### DIFF
--- a/soc/nordic/common/vpr/Kconfig.defconfig
+++ b/soc/nordic/common/vpr/Kconfig.defconfig
@@ -1,9 +1,6 @@
 # Copyright (c) 2024 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-config RISCV_MCAUSE_EXCEPTION_MASK
-	default 0xFFF
-
 config RISCV_RESERVED_IRQ_ISR_TABLES_OFFSET
 	default 16
 


### PR DESCRIPTION
Custom VPR mcause exception mask has wrong value.
Correct value is 0x7FFFFFFF and is compatible with zephyr/arch/riscv definition so it will be used.'