### PR TITLE
samples: basic: Add overlay for nRF54L15 for basic_pwm example

### DIFF
--- a/samples/basic/blinky_pwm/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
+++ b/samples/basic/blinky_pwm/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,33 @@
+&pinctrl {
+	pwm_default: pwm_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 1, 8)>;
+		};
+	};
+	pwm_sleep: pwm_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 1, 8)>;
+			low-power-enable;
+		};
+	};
+};
+
+&pwm20 {
+	status = "okay";
+	pinctrl-0 = <&pwm_default>;
+	pinctrl-1 = <&pwm_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+/ {
+	pwmleds {
+		compatible = "pwm-leds";
+		pwm_led0: pwm_led_0 {
+			pwms = <&pwm20 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+		};
+	};
+
+	aliases {
+		pwm-led0 = &pwm_led0;
+	};
+};


### PR DESCRIPTION
Adds overlay to use hardware PWM. There is no possilibity to work with all period configuration.
Limitation are pointed in sample's doc.