### PR TITLE
posix pthread: Fix build warning

### DIFF
--- a/lib/posix/options/pthread.c
+++ b/lib/posix/options/pthread.c
@@ -1122,7 +1122,7 @@ int pthread_join(pthread_t pthread, void **status)
 int pthread_detach(pthread_t pthread)
 {
 	int ret = 0;
-	struct posix_thread *t;
+	struct posix_thread *t = NULL;
 
 	SYS_SEM_LOCK(&pthread_pool_lock) {
 		t = to_posix_thread(pthread);


### PR DESCRIPTION
The compiler thinks t may be used unitialized sometimes. Let's initialize it to NULL.

Fixes #71814