### PR TITLE
drivers: video_common: Add aligned allocation API

### DIFF
--- a/drivers/video/video_common.c
+++ b/drivers/video/video_common.c
@@ -19,7 +19,7 @@ struct mem_block {
 
 static struct mem_block video_block[CONFIG_VIDEO_BUFFER_POOL_NUM_MAX];
 
-struct video_buffer *video_buffer_alloc(size_t size)
+struct video_buffer *video_buffer_aligned_alloc(size_t size, size_t align)
 {
 	struct video_buffer *vbuf = NULL;
 	struct mem_block *block;
@@ -39,7 +39,7 @@ struct video_buffer *video_buffer_alloc(size_t size)
 	}
 
 	/* Alloc buffer memory */
-	block->data = k_heap_alloc(&video_buffer_pool, size, K_FOREVER);
+	block->data = k_heap_aligned_alloc(&video_buffer_pool, align, size, K_FOREVER);
 	if (block->data == NULL) {
 		return NULL;
 	}
@@ -49,6 +49,11 @@ struct video_buffer *video_buffer_alloc(size_t size)
 	vbuf->bytesused = 0;
 
 	return vbuf;
+}
+
+struct video_buffer *video_buffer_alloc(size_t size)
+{
+	return video_buffer_aligned_alloc(size, sizeof(void *));
 }
 
 void video_buffer_release(struct video_buffer *vbuf)

--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -561,9 +561,19 @@ static inline int video_set_signal(const struct device *dev,
 }
 
 /**
+ * @brief Allocate aligned video buffer.
+ *
+ * @param size Size of the video buffer (in bytes).
+ * @param align Alignment of the requested memory, must be a power of two.
+ *
+ * @retval pointer to allocated video buffer
+ */
+struct video_buffer *video_buffer_aligned_alloc(size_t size, size_t align);
+
+/**
  * @brief Allocate video buffer.
  *
- * @param size Size of the video buffer.
+ * @param size Size of the video buffer (in bytes).
  *
  * @retval pointer to allocated video buffer
  */


### PR DESCRIPTION
The video buffers generally used to be displayed. For some display hardwares, it is very common that some aligment on the allocated memory is required. For example, the PxP and eLCDIF of NXP require aligned buffers so that their performances can be optimal.

This PR adds a new video_buffer_aligned_alloc() API for these needs. **It does not break anything. The current video_buffer_alloc() API could be used as usual when needed.**