### PR TITLE
Bluetooth: Implement bt_addr_le_is_valid

### DIFF
--- a/include/zephyr/bluetooth/addr.h
+++ b/include/zephyr/bluetooth/addr.h
@@ -288,6 +288,14 @@ int bt_addr_from_str(const char *str, bt_addr_t *addr);
  */
 int bt_addr_le_from_str(const char *str, const char *type, bt_addr_le_t *addr);
 
+/** @brief Check if address is valid.
+ *
+ *  @param[in]  addr  Address of buffer to store the LE Bluetooth address
+ *
+ *  @return True if the address is valid. False otherwise.
+ */
+bool bt_addr_le_is_valid(const bt_addr_le_t *addr);
+
 /**
  * @}
  */

--- a/subsys/bluetooth/host/addr.c
+++ b/subsys/bluetooth/host/addr.c
@@ -120,3 +120,18 @@ bool bt_addr_le_is_resolved(const bt_addr_le_t *addr)
 {
 	return (addr->type & ADDR_RESOLVED_BITMASK) != 0;
 }
+
+bool bt_addr_le_is_valid(const bt_addr_le_t *addr)
+{
+	if (addr == NULL) {
+		return false;
+	}
+
+	if (addr->type != BT_ADDR_LE_PUBLIC && addr->type != BT_ADDR_LE_RANDOM) {
+		return false;
+	}
+
+	/* Additional checks for validity can be added here based on the core spec */
+
+	return true;
+}


### PR DESCRIPTION
Add a `bool bt_addr_le_is_valid` function that verifies if the address provided is valid.
See https://github.com/zephyrproject-rtos/zephyr/issues/71801#