### PR TITLE
west.yml: hal_stm32: Generate I3C pins

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -229,7 +229,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 60c9634f61c697e1c310ec648d33529712806069
+      revision: cac0f68847905aeb8211c57cc83df50b30cc3a2a
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Generate I3C pin definitions.