### PR TITLE
twister: harness: pytest: Check exist of the runner_params

### DIFF
--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
@@ -66,8 +66,9 @@ class HardwareAdapter(DeviceAdapter):
         extra_args: list[str] = []
         runner = self.device_config.runner
         base_args.extend(['--runner', runner])
-        for param in self.device_config.runner_params:
-            extra_args.append(param)
+        if self.device_config.runner_params:
+            for param in self.device_config.runner_params:
+                extra_args.append(param)
         if board_id := self.device_config.id:
             if runner == 'pyocd':
                 extra_args.append('--board-id')

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -382,8 +382,9 @@ class Pytest(Harness):
         if runner := hardware.runner or options.west_runner:
             command.append(f'--runner={runner}')
 
-        for param in hardware.runner_params:
-            command.append(f'--runner-params={param}')
+        if hardware.runner_params:
+            for param in hardware.runner_params:
+                command.append(f'--runner-params={param}')
 
         if options.west_flash and options.west_flash != []:
             command.append(f'--west-flash-extra-args={options.west_flash}')


### PR DESCRIPTION
Pytest harness in Twister tries to get custom parameters to the pytest harnesses. It is required although those do not exist (e.g. Twister uses devices without hw map). This change checks if the custom parameters to the pytest harnesses exists.

Fixes #71817