### PR TITLE
kernel: fatal: log which IRQn is triggering on spurious IRQs

### DIFF
--- a/arch/arm/core/fatal.c
+++ b/arch/arm/core/fatal.c
@@ -73,6 +73,16 @@ void z_arm_fatal_error(unsigned int reason, const z_arch_esf_t *esf)
 		esf_dump(esf);
 	}
 #endif /* CONFIG_EXCEPTION_DEBUG */
+
+	/* LOG the IRQn that was unhandled */
+#if defined(CONFIG_CPU_CORTEX_M)
+	if (reason == K_ERR_SPURIOUS_IRQ) {
+		uint32_t irqn = __get_IPSR() - 16;
+
+		LOG_ERR("Unhandled IRQn: %d", irqn);
+	}
+#endif
+
 	z_fatal_error(reason, esf);
 }
 


### PR DESCRIPTION
LOG which IRQn line is triggering on spurious IRQs as this makes it much easier to debug spurious IRQs.

The new logs with this patch looks like:

<err> os: Unhandled IRQn: 227
<err> os: >>> ZEPHYR FATAL ERROR 1: Unhandled interrupt on CPU 0
<err> os: Current thread: 0x20032c20 (unknown)
<err> os: Halting system