### PR TITLE
posix: pthread: fix uninitialized variable

### DIFF
--- a/lib/posix/options/pthread.c
+++ b/lib/posix/options/pthread.c
@@ -1122,7 +1122,7 @@ int pthread_join(pthread_t pthread, void **status)
 int pthread_detach(pthread_t pthread)
 {
 	int ret = 0;
-	struct posix_thread *t;
+	struct posix_thread *t = NULL;
 
 	SYS_SEM_LOCK(&pthread_pool_lock) {
 		t = to_posix_thread(pthread);


### PR DESCRIPTION
The `t` could be 'uninitialized' before use due to the use of `SYS_SEM_LOCK`, initialize that to NULL like other occurances in the file.

Fixes #71814

```
(.venv) ycsin@ycsin-mba zephyr % twister -p qemu_x86 -T tests/net/all             
INFO    - Using Ninja..
INFO    - Zephyr version: v3.6.0-2853-ga07b4977328f
INFO    - Using 'zephyr' toolchain.
INFO    - Building initial testsuite list...
INFO    - Writing JSON report /Users/ycsin/zephyrproject/zephyr/twister-out/testplan.json
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - Total complete:    2/   2  100%  skipped:    0, failed:    0, error:    0
INFO    - 2 test scenarios (2 test instances) selected, 0 configurations skipped (0 by static filter, 0 at runtime).
INFO    - 2 of 2 test configurations passed (100.00%), 0 failed, 0 errored, 0 skipped with 0 warnings in 65.01 seconds
INFO    - In total 2 test cases were executed, 0 skipped on 1 out of total 718 platforms (0.14%)
INFO    - 0 test configurations executed on platforms, 2 test configurations were only built.
INFO    - Saving reports...
INFO    - Writing JSON report /Users/ycsin/zephyrproject/zephyr/twister-out/twister.json
INFO    - Writing xunit report /Users/ycsin/zephyrproject/zephyr/twister-out/twister.xml...
INFO    - Writing xunit report /Users/ycsin/zephyrproject/zephyr/twister-out/twister_report.xml...
INFO    - Run completed
```