### PR TITLE
tls_credentials: use PSA functions instead of MbedTLS for SHA256 computation

### DIFF
--- a/modules/mbedtls/Kconfig
+++ b/modules/mbedtls/Kconfig
@@ -13,6 +13,7 @@ config MBEDTLS_PROMPTLESS
 	  mbed TLS menu prompt and instead handle the selection of MBEDTLS from
 	  dependent sub-configurations and thus prevent stuck symbol behavior.
 
+rsource "Kconfig.psa"
 
 menuconfig MBEDTLS
 	bool "mbed TLS Support" if !MBEDTLS_PROMPTLESS

--- a/modules/mbedtls/Kconfig.psa
+++ b/modules/mbedtls/Kconfig.psa
@@ -1,0 +1,14 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+config MBEDTLS_PSA_CRYPTO_CLIENT
+	bool
+	default y
+	depends on BUILD_WITH_TFM || MBEDTLS_PSA_CRYPTO_C
+
+if MBEDTLS_PSA_CRYPTO_CLIENT
+
+config PSA_WANT_ALG_SHA_256
+	bool "SHA-256 hash algorithm through PSA"
+
+endif # MBEDTLS_PSA_CRYPTO_CLIENT

--- a/modules/mbedtls/configs/config-tls-generic.h
+++ b/modules/mbedtls/configs/config-tls-generic.h
@@ -496,8 +496,15 @@
 #endif
 
 #if defined(CONFIG_BUILD_WITH_TFM)
-#define MBEDTLS_PSA_CRYPTO_CLIENT
 #undef MBEDTLS_PSA_CRYPTO_C
 #endif /* CONFIG_BUILD_WITH_TFM */
+
+#if defined(CONFIG_MBEDTLS_PSA_CRYPTO_CLIENT)
+#define MBEDTLS_PSA_CRYPTO_CLIENT
+#endif
+
+#if defined(CONFIG_PSA_WANT_ALG_SHA_256)
+#define PSA_WANT_ALG_SHA_256 1
+#endif
 
 #endif /* MBEDTLS_CONFIG_H */

--- a/subsys/net/lib/tls_credentials/Kconfig
+++ b/subsys/net/lib/tls_credentials/Kconfig
@@ -28,6 +28,7 @@ config TLS_CREDENTIALS_BACKEND_VOLATILE
 config TLS_CREDENTIALS_BACKEND_PROTECTED_STORAGE
 	bool "TLS credentials management protected storage backend"
 	depends on BUILD_WITH_TFM
+	select PSA_WANT_ALG_SHA_256
 	help
 	  TLS credentials management backend using the Protected Storage
 	  API to store credentials with integrity check against physical

--- a/subsys/net/lib/tls_credentials/tls_credentials_digest_raw.c
+++ b/subsys/net/lib/tls_credentials/tls_credentials_digest_raw.c
@@ -16,46 +16,7 @@
 #include "tls_internal.h"
 #include "tls_credentials_digest_raw.h"
 
-/* Grab mbedTLS headers if they are available so that we can check whether SHA256 is supported */
-
-#if defined(CONFIG_MBEDTLS)
-#if !defined(CONFIG_MBEDTLS_CFG_FILE)
-#include "mbedtls/config.h"
-#else
-#include CONFIG_MBEDTLS_CFG_FILE
-#endif /* CONFIG_MBEDTLS_CFG_FILE */
-#endif /* CONFIG_MBEDTLS */
-
-#if defined(CONFIG_TINYCRYPT_SHA256) && defined(CONFIG_BASE64)
-
-#include <tinycrypt/sha256.h>
-#include <zephyr/sys/base64.h>
-
-int credential_digest_raw(struct tls_credential *credential, void *dest, size_t *len)
-{
-	int err = 0;
-	size_t written = 0;
-	struct tc_sha256_state_struct sha_state;
-	uint8_t digest_buf[TC_SHA256_DIGEST_SIZE];
-
-	/* Compute digest. */
-	(void)tc_sha256_init(&sha_state);
-	(void)tc_sha256_update(&sha_state, credential->buf, credential->len);
-	(void)tc_sha256_final(digest_buf, &sha_state);
-
-	/* Attempt to encode digest to destination.
-	 * Will return -ENOMEM if there is not enough space in the destination buffer.
-	 */
-	err = base64_encode(dest, *len, &written, digest_buf, sizeof(digest_buf));
-	*len = err ? 0 : written;
-
-	/* Clean up. */
-	memset(&sha_state, 0, sizeof(sha_state));
-	memset(digest_buf, 0, sizeof(digest_buf));
-	return err;
-}
-
-#elif defined(CONFIG_PSA_WANT_ALG_SHA_256) && defined(CONFIG_BASE64)
+#if defined(CONFIG_PSA_WANT_ALG_SHA_256) && defined(CONFIG_BASE64)
 
 #include <psa/crypto.h>
 

--- a/tests/net/lib/tls_credentials/testcase.yaml
+++ b/tests/net/lib/tls_credentials/testcase.yaml
@@ -10,5 +10,5 @@ tests:
     tags:
       - net
       - tls
-      - trusted
-    depends_on: netif
+      - tfm
+      - trusted-firmware-m


### PR DESCRIPTION
Following the general goal to move toward PSA crypto APIs (https://github.com/zephyrproject-rtos/zephyr/issues/43712) this PR:

- replaces MbedTLS with PSA for hash computation
- removes TinyCrypt alternative (as done in #71947)

for the `tls-credentials` module.

**Note** = as stated in a [comment below](https://github.com/zephyrproject-rtos/zephyr/pull/71830#pullrequestreview-2044973741):
> Just a note that the MbedTLS configuration changes come from https://github.com/zephyrproject-rtos/zephyr/pull/71947.