### PR TITLE
 mcumgr/img_mgmt: Fix zcbor logic in os_mgmt_bootloader_info 

### DIFF
--- a/subsys/mgmt/mcumgr/grp/os_mgmt/src/os_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/os_mgmt/src/os_mgmt.c
@@ -469,9 +469,9 @@ os_mgmt_bootloader_info(struct smp_streamer *ctxt)
 
 		ok = zcbor_tstr_put_lit(zse, "mode") &&
 		     zcbor_int32_put(zse, BOOTLOADER_MODE);
-#if IS_ENABLED(CONFIG_MCUBOOT_BOOTLOADER_NO_DOWNGRADE)
-		ok = zcbor_tstr_put_lit(zse, "no-downgrade") &&
-		     zcbor_bool_encode(zse, true);
+#ifdef CONFIG_MCUBOOT_BOOTLOADER_NO_DOWNGRADE
+		ok = ok && zcbor_tstr_put_lit(zse, "no-downgrade") &&
+		     zcbor_bool_encode(zse, &(bool){true});
 #endif
 	} else {
 		return OS_MGMT_ERR_QUERY_YIELDS_NO_ANSWER;


### PR DESCRIPTION
There have been to problems with the code where zcbor_bool_encode
has been fed value instead of expected pointer and the result
of previous zcbor_encode operations has not been taken to evaluate
value of ok status.
The change also replaces usage of  #if IS_ENABLED with #ifdef, as
IS_ENABLED should not be used outside if().