### PR TITLE
tests/settings/fcb: Add missing native_sim_native_64.overlay

### DIFF
--- a/tests/subsys/settings/fcb/boards/native_sim_native_64.overlay
+++ b/tests/subsys/settings/fcb/boards/native_sim_native_64.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "native_sim.overlay"


### PR DESCRIPTION
Added missing overlay for native_sim/native/64 platform.