### PR TITLE
kernel: increase main stack size for ztest

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -156,7 +156,7 @@ config SCHED_CPU_MASK_PIN_ONLY
 config MAIN_STACK_SIZE
 	int "Size of stack for initialization and main thread"
 	default 2048 if COVERAGE_GCOV
-	default 512 if ZTEST && !(RISCV || X86 || ARM)
+	default 512 if ZTEST && !(RISCV || X86 || ARM || ARC)
 	default 1024
 	help
 	  When the initialization is complete, the thread executing it then


### PR DESCRIPTION
stack has been on the edge when using ztest, increase to 1024.

Fixes #71797

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
