### PR TITLE
tests: timer_behavior: increase stdev tolerance for ite platform

### DIFF
--- a/tests/kernel/timer/timer_behavior/Kconfig
+++ b/tests/kernel/timer/timer_behavior/Kconfig
@@ -24,6 +24,7 @@ config TIMER_TEST_PERIOD
 config TIMER_TEST_MAX_STDDEV
 	int "Maximum standard deviation in microseconds allowed"
 	default 33 if NPCX_ITIM_TIMER
+	default 33 if ITE_IT8XXX2_TIMER
 	default 10
 
 config TIMER_TEST_MAX_DRIFT


### PR DESCRIPTION
There might be a deviation of 30.5 microseconds (1 cycle) due to the calculation deviation between free run and event timers. This commit increases stdev to 33 for ite platform.

Fix #67833