### PR TITLE
doc: posix: add aep diagrams and condense aep docs

### DIFF
--- a/doc/services/portability/posix/aep/aep-pse51.svg
+++ b/doc/services/portability/posix/aep/aep-pse51.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" width="225.805" height="225.805" viewBox="-112.9025 -112.9025 225.805 225.805" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="0" fill="#e6e5e3" opacity="0.5" r="100"/>
+  <circle cx="25" fill="#e6e5e3" opacity="0.5" r="75"/>
+  <circle cx="50" fill="#d9913c" r="50"/>
+  <circle cx="75" fill="#e6e5e3" opacity="0.5" r="25"/>
+  /* TODO: Change color based on dark / light modes */
+  <g font-family="Arial" font-size="10" text-anchor="middle">
+    <text y="8">
+      <tspan x="75" dy="-1.2em">System</tspan>
+      <tspan x="75" dy="1.2em">Interfaces</tspan>
+    </text>
+    <text x="25">PSE51</text>
+    <text x="-25">PSE52</text>
+    <text x="-75">PSE53</text>
+  </g>
+</svg>

--- a/doc/services/portability/posix/aep/aep-pse52.svg
+++ b/doc/services/portability/posix/aep/aep-pse52.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" width="225.805" height="225.805" viewBox="-112.9025 -112.9025 225.805 225.805" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="0" fill="#e6e5e3" opacity="0.5" r="100"/>
+  <circle cx="25" fill="#f04f5e" r="75"/>
+  <circle cx="50" fill="#e6e5e3" opacity="0.5" r="50"/>
+  <circle cx="75" fill="#e6e5e3" opacity="0.5" r="25"/>
+  /* TODO: Change color based on dark / light modes */
+  <g font-family="Arial" font-size="10" text-anchor="middle">
+    <text y="8">
+      <tspan x="75" dy="-1.2em">System</tspan>
+      <tspan x="75" dy="1.2em">Interfaces</tspan>
+    </text>
+    <text x="25">PSE51</text>
+    <text x="-25">PSE52</text>
+    <text x="-75">PSE53</text>
+  </g>
+</svg>

--- a/doc/services/portability/posix/aep/aep-pse53.svg
+++ b/doc/services/portability/posix/aep/aep-pse53.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" width="225.805" height="225.805" viewBox="-112.9025 -112.9025 225.805 225.805" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="0" fill="#786bb0" r="100"/>
+  <circle cx="25" fill="#e6e5e3" opacity="0.5" r="75"/>
+  <circle cx="50" fill="#e6e5e3" opacity="0.5" r="50"/>
+  <circle cx="75" fill="#e6e5e3" opacity="0.5" r="25"/>
+  /* TODO: Change color based on dark / light modes */
+  <g font-family="Arial" font-size="10" text-anchor="middle">
+    <text y="8">
+      <tspan x="75" dy="-1.2em">System</tspan>
+      <tspan x="75" dy="1.2em">Interfaces</tspan>
+    </text>
+    <text x="25">PSE51</text>
+    <text x="-25">PSE52</text>
+    <text x="-75">PSE53</text>
+  </g>
+</svg>

--- a/doc/services/portability/posix/aep/index.rst
+++ b/doc/services/portability/posix/aep/index.rst
@@ -14,6 +14,13 @@ System Interfaces
 The required POSIX :ref:`System Interfaces<posix_system_interfaces_required>` are supported for
 each Application Environment Profile.
 
+..  figure:: si.svg
+    :align: center
+    :scale: 150%
+    :alt: Required System Interfaces
+
+    System Interfaces
+
 .. _posix_aep_pse51:
 
 Minimal Realtime System Profile (PSE51)
@@ -21,6 +28,13 @@ Minimal Realtime System Profile (PSE51)
 
 The *Minimal Realtime System Profile* (PSE51) includes all of the
 :ref:`System Interfaces<posix_system_interfaces_required>` along with several additional features.
+
+..  figure:: aep-pse51.svg
+    :align: center
+    :scale: 150%
+    :alt: Minimal Realtime System Profile (PSE51)
+
+    Minimal Realtime System Profile (PSE51)
 
 .. Conforming implementations shall define _POSIX_AEP_REALTIME_MINIMAL to the value 200312L
 
@@ -68,6 +82,13 @@ Realtime Controller System Profile (PSE52)
 The *Realtime Controller System Profile* (PSE52) includes all features from PSE51 and the
 :ref:`System Interfaces<posix_system_interfaces_required>`.
 
+..  figure:: aep-pse52.svg
+    :align: center
+    :scale: 150%
+    :alt: Realtime Controller System Profile (PSE52)
+
+    Realtime Controller System Profile (PSE52)
+
 .. Conforming implementations shall define _POSIX_AEP_REALTIME_CONTROLLER to the value 200312L
 
 .. csv-table:: PSE52 System Interfaces
@@ -100,6 +121,13 @@ Dedicated Realtime System Profile (PSE53)
 
 The *Dedicated Realtime System Profile* (PSE53) includes all features from PSE52, PSE51, and the
 :ref:`System Interfaces<posix_system_interfaces_required>`.
+
+..  figure:: aep-pse53.svg
+    :align: center
+    :scale: 150%
+    :alt: Dedicated Realtime System Profile (PSE53)
+
+    Dedicated Realtime System Profile (PSE53)
 
 .. Conforming implementations shall define _POSIX_AEP_REALTIME_DEDICATED to the value 200312L
 

--- a/doc/services/portability/posix/aep/index.rst
+++ b/doc/services/portability/posix/aep/index.rst
@@ -8,10 +8,19 @@ subprofiling options of `IEEE 1003.1-2017`_. The single-purpose realtime system 
 are listed below, for reference, in terms that agree with the current POSIX-1 standard. PSE54
 is not considered at this time.
 
+System Interfaces
+=================
+
+The required POSIX :ref:`System Interfaces<posix_system_interfaces_required>` are supported for
+each Application Environment Profile.
+
 .. _posix_aep_pse51:
 
 Minimal Realtime System Profile (PSE51)
 =======================================
+
+The *Minimal Realtime System Profile* (PSE51) includes all of the
+:ref:`System Interfaces<posix_system_interfaces_required>` along with several additional features.
 
 .. Conforming implementations shall define _POSIX_AEP_REALTIME_MINIMAL to the value 200312L
 
@@ -25,42 +34,39 @@ Minimal Realtime System Profile (PSE51)
    :header: Symbol, Support, Remarks
    :widths: 50, 10, 50
 
-    POSIX_C_LANG_JUMP, yes, :ref:`POSIX_C_LANG_JUMP <posix_option_group_c_lang_jump>`
-    POSIX_C_LANG_SUPPORT, yes, :ref:`POSIX_C_LANG_SUPPORT <posix_option_group_c_lang_support>`
-    POSIX_DEVICE_IO,, :ref:`†<posix_undefined_behaviour>`
-    POSIX_FILE_LOCKING,,
-    POSIX_SIGNALS,, :ref:`†<posix_undefined_behaviour>`
-    POSIX_SINGLE_PROCESS, yes,
-    POSIX_THREADS_BASE, yes, :ref:`†<posix_undefined_behaviour>`
-    XSI_THREADS_EXT, yes,
+    :ref:`POSIX_C_LANG_JUMP <posix_option_group_c_lang_jump>`, yes,
+    :ref:`POSIX_C_LANG_SUPPORT <posix_option_group_c_lang_support>`, yes,
+    :ref:`POSIX_DEVICE_IO <posix_option_group_device_io>`,,
+    :ref:`POSIX_SIGNALS <posix_option_group_signals>`,,
+    :ref:`POSIX_SINGLE_PROCESS <posix_option_group_single_process>`, yes,
+    :ref:`POSIX_THREADS_BASE <posix_option_group_threads_base>`, yes,
+    :ref:`XSI_THREADS_EXT <posix_option_group_xsi_threads_ext>`, yes,
 
 .. csv-table:: PSE51 Option Requirements
    :header: Symbol, Support, Remarks
    :widths: 50, 10, 50
 
-    _POSIX_CLOCK_SELECTION, 200809L, :kconfig:option:`CONFIG_POSIX_CLOCK`
-    _POSIX_FSYNC, -1,
-    _POSIX_MEMLOCK, -1,
-    _POSIX_MEMLOCK_RANGE, -1,
-    _POSIX_MONOTONIC_CLOCK, 200809L, :kconfig:option:`CONFIG_POSIX_CLOCK`
-    _POSIX_REALTIME_SIGNALS, -1,
-    _POSIX_SEMAPHORES, 200809L, :kconfig:option:`CONFIG_PTHREAD_IPC`
-    _POSIX_SHARED_MEMORY_OBJECTS, -1,
-    _POSIX_SYNCHRONIZED_IO, -1,
-    _POSIX_THREAD_ATTR_STACKADDR, 200809L, :kconfig:option:`CONFIG_PTHREAD`
-    _POSIX_THREAD_ATTR_STACKSIZE, 200809L, :kconfig:option:`CONFIG_PTHREAD`
-    _POSIX_THREAD_CPUTIME, -1,
+    :ref:`_POSIX_FSYNC <posix_option_fsync>`, -1,
+    :ref:`_POSIX_MEMLOCK <posix_option_memlock>`, -1,
+    :ref:`_POSIX_MEMLOCK_RANGE <posix_option_memlock_range>`, -1,
+    :ref:`_POSIX_MONOTONIC_CLOCK <posix_option_monotonic_clock>`, 200809L, :kconfig:option:`CONFIG_POSIX_CLOCK`
+    :ref:`_POSIX_SHARED_MEMORY_OBJECTS <posix_shared_memory_objects>`, -1,
+    :ref:`_POSIX_SYNCHRONIZED_IO <posix_option_synchronized_io>`, -1,
+    :ref:`_POSIX_THREAD_ATTR_STACKADDR<posix_option_thread_attr_stackaddr>`, 200809L, :kconfig:option:`CONFIG_PTHREAD`
+    :ref:`_POSIX_THREAD_ATTR_STACKSIZE<posix_option_thread_attr_stacksize>`, 200809L, :kconfig:option:`CONFIG_PTHREAD`
+    :ref:`_POSIX_THREAD_CPUTIME <posix_option_thread_cputime>`, -1,
     _POSIX_THREAD_PRIO_INHERIT, 200809L, :kconfig:option:`CONFIG_PTHREAD_MUTEX`
     _POSIX_THREAD_PRIO_PROTECT, -1,
-    _POSIX_THREAD_PRIORITY_SCHEDULING, -1, :kconfig:option:`CONFIG_POSIX_PRIORITY_SCHEDULING` (will fail with ``ENOSYS``:ref:`†<posix_undefined_behaviour>`)
+    :ref:`_POSIX_THREAD_PRIORITY_SCHEDULING<posix_option_thread_priority_scheduling>`, 200809L, :kconfig:option:`CONFIG_POSIX_PRIORITY_SCHEDULING` (will fail with ``ENOSYS``:ref:`†<posix_undefined_behaviour>`)
     _POSIX_THREAD_SPORADIC_SERVER, -1,
-    _POSIX_TIMEOUTS, 200809L, :kconfig:option:`CONFIG_PTHREAD_IPC`
-    _POSIX_TIMERS, 200809L, :kconfig:option:`CONFIG_POSIX_CLOCK`
 
 .. _posix_aep_pse52:
 
 Realtime Controller System Profile (PSE52)
 ==========================================
+
+The *Realtime Controller System Profile* (PSE52) includes all features from PSE51 and the
+:ref:`System Interfaces<posix_system_interfaces_required>`.
 
 .. Conforming implementations shall define _POSIX_AEP_REALTIME_CONTROLLER to the value 200312L
 
@@ -74,42 +80,15 @@ Realtime Controller System Profile (PSE52)
    :header: Symbol, Support, Remarks
    :widths: 50, 10, 50
 
-    POSIX_C_LANG_JUMP, yes, :ref:`POSIX_C_LANG_JUMP <posix_option_group_c_lang_jump>`
-    POSIX_C_LANG_MATH, yes, :ref:`POSIX_C_LANG_MATH <posix_option_group_c_lang_math>`
-    POSIX_C_LANG_SUPPORT, yes, :ref:`POSIX_C_LANG_SUPPORT <posix_option_group_c_lang_support>`
-    POSIX_DEVICE_IO,, :ref:`†<posix_undefined_behaviour>`
-    POSIX_FD_MGMT,, :ref:`POSIX_FD_MGMT <posix_option_group_fd_mgmt>`
-    POSIX_FILE_LOCKING,,
-    POSIX_FILE_SYSTEM,,
-    POSIX_SIGNALS,, :ref:`†<posix_undefined_behaviour>`
-    POSIX_SINGLE_PROCESS, yes,
-    POSIX_THREADS_BASE, yes, :ref:`†<posix_undefined_behaviour>`
-    XSI_THREADS_EXT, yes,
+    :ref:`POSIX_C_LANG_MATH <posix_option_group_c_lang_math>`, yes,
+    :ref:`POSIX_FD_MGMT <posix_option_group_fd_mgmt>`,,
+    :ref:`POSIX_FILE_SYSTEM <posix_option_group_file_system>`,,
 
 .. csv-table:: PSE52 Option Requirements
    :header: Symbol, Support, Remarks
    :widths: 50, 10, 50
 
-    _POSIX_CLOCK_SELECTION, 200809L, :kconfig:option:`CONFIG_POSIX_CLOCK`
-    _POSIX_FSYNC, -1,
-    _POSIX_MAPPED_FILES, -1,
-    _POSIX_MEMLOCK, -1,
-    _POSIX_MEMLOCK_RANGE, -1,
-    _POSIX_MESSAGE_PASSING, 200809L, :kconfig:option:`CONFIG_POSIX_MQUEUE`
-    _POSIX_MONOTONIC_CLOCK, 200809L, :kconfig:option:`CONFIG_POSIX_CLOCK`
-    _POSIX_REALTIME_SIGNALS, -1,
-    _POSIX_SEMAPHORES, 200809L, :kconfig:option:`CONFIG_PTHREAD_IPC`
-    _POSIX_SHARED_MEMORY_OBJECTS, -1,
-    _POSIX_SYNCHRONIZED_IO, -1,
-    _POSIX_THREAD_ATTR_STACKADDR, 200809L, :kconfig:option:`CONFIG_PTHREAD`
-    _POSIX_THREAD_ATTR_STACKSIZE, 200809L, :kconfig:option:`CONFIG_PTHREAD`
-    _POSIX_THREAD_CPUTIME, -1,
-    _POSIX_THREAD_PRIO_INHERIT, 200809L, :kconfig:option:`CONFIG_PTHREAD_MUTEX`
-    _POSIX_THREAD_PRIO_PROTECT, -1,
-    _POSIX_THREAD_PRIORITY_SCHEDULING, -1,
-    _POSIX_THREAD_SPORADIC_SERVER, -1,
-    _POSIX_TIMEOUTS, 200809L, :kconfig:option:`CONFIG_PTHREAD_IPC`
-    _POSIX_TIMERS, 200809L, :kconfig:option:`CONFIG_POSIX_CLOCK`
+    :ref:`_POSIX_MESSAGE_PASSING <posix_option_message_passing>`, 200809L, :kconfig:option:`CONFIG_POSIX_MQUEUE`
     _POSIX_TRACE, -1,
     _POSIX_TRACE_EVENT_FILTER, -1,
     _POSIX_TRACE_LOG, -1,
@@ -118,6 +97,9 @@ Realtime Controller System Profile (PSE52)
 
 Dedicated Realtime System Profile (PSE53)
 =========================================
+
+The *Dedicated Realtime System Profile* (PSE53) includes all features from PSE52, PSE51, and the
+:ref:`System Interfaces<posix_system_interfaces_required>`.
 
 .. Conforming implementations shall define _POSIX_AEP_REALTIME_DEDICATED to the value 200312L
 
@@ -131,58 +113,21 @@ Dedicated Realtime System Profile (PSE53)
    :header: Symbol, Support, Remarks
    :widths: 50, 10, 50
 
-    POSIX_C_LANG_JUMP, yes, :ref:`POSIX_C_LANG_JUMP <posix_option_group_c_lang_jump>`
-    POSIX_C_LANG_MATH, yes, :ref:`POSIX_C_LANG_MATH <posix_option_group_c_lang_math>`
-    POSIX_C_LANG_SUPPORT, yes, :ref:`POSIX_C_LANG_SUPPORT <posix_option_group_c_lang_support>`
-    POSIX_DEVICE_IO,, :ref:`†<posix_undefined_behaviour>`
-    POSIX_FD_MGMT,, :ref:`POSIX_FD_MGMT <posix_option_group_fd_mgmt>`
-    POSIX_FILE_LOCKING,,
-    POSIX_FILE_SYSTEM,,
     POSIX_MULTI_PROCESS,, :ref:`†<posix_undefined_behaviour>`
-    POSIX_NETWORKING, yes, :ref:`POSIX_NETWORKING <posix_option_group_networking>`
-    POSIX_PIPE,, :ref:`†<posix_undefined_behaviour>`
-    POSIX_SIGNALS,, :ref:`†<posix_undefined_behaviour>`
-    POSIX_SIGNAL_JUMP,, :ref:`†<posix_undefined_behaviour>`
-    POSIX_SINGLE_PROCESS, yes,
-    POSIX_THREADS_BASE, yes, :ref:`†<posix_undefined_behaviour>`
-    XSI_THREADS_EXT, yes,
+    :ref:`POSIX_NETWORKING <posix_option_group_networking>`, yes,
+    :ref:`POSIX_PIPE <posix_option_group_pipe>`,,
+    :ref:`POSIX_SIGNAL_JUMP <posix_option_group_signal_jump>`,,
 
 .. csv-table:: PSE53 Option Requirements
    :header: Symbol, Support, Remarks
    :widths: 50, 10, 50
 
-    _POSIX_ASYNCHRONOUS_IO, -1,
-    _POSIX_CLOCK_SELECTION, 200809L, :kconfig:option:`CONFIG_POSIX_CLOCK`
     _POSIX_CPUTIME, -1,
-    _POSIX_FSYNC, -1,
-    _POSIX_MAPPED_FILES, -1,
-    _POSIX_MEMLOCK, -1,
-    _POSIX_MEMLOCK_RANGE, -1,
-    _POSIX_MEMORY_PROTECTION, -1,
-    _POSIX_MESSAGE_PASSING, 200809L, :kconfig:option:`CONFIG_POSIX_MQUEUE`
-    _POSIX_MONOTONIC_CLOCK, 200809L, :kconfig:option:`CONFIG_POSIX_CLOCK`
     _POSIX_PRIORITIZED_IO, -1,
-    _POSIX_PRIORITY_SCHEDULING, -1,
+    :ref:`_POSIX_PRIORITY_SCHEDULING <posix_option_priority_scheduling>`, -1,
     _POSIX_RAW_SOCKETS, 200809L, :kconfig:option:`CONFIG_NET_SOCKETS`
-    _POSIX_REALTIME_SIGNALS, -1,
-    _POSIX_SEMAPHORES, 200809L, :kconfig:option:`CONFIG_PTHREAD_IPC`
-    _POSIX_SHARED_MEMORY_OBJECTS, -1,
     _POSIX_SPAWN, -1,
     _POSIX_SPORADIC_SERVER, -1,
-    _POSIX_SYNCHRONIZED_IO, -1,
-    _POSIX_THREAD_ATTR_STACKADDR, 200809L, :kconfig:option:`CONFIG_PTHREAD`
-    _POSIX_THREAD_ATTR_STACKSIZE, 200809L, :kconfig:option:`CONFIG_PTHREAD`
-    _POSIX_THREAD_CPUTIME, -1,
-    _POSIX_THREAD_PRIO_INHERIT, 200809L, :kconfig:option:`CONFIG_PTHREAD_MUTEX`
-    _POSIX_THREAD_PRIO_PROTECT, -1,
-    _POSIX_THREAD_PRIORITY_SCHEDULING, -1,
-    _POSIX_THREAD_PROCESS_SHARED, -1,
-    _POSIX_THREAD_SPORADIC_SERVER, -1,
-    _POSIX_TIMEOUTS, 200809L, :kconfig:option:`CONFIG_PTHREAD_IPC`
-    _POSIX_TIMERS, 200809L, :kconfig:option:`CONFIG_POSIX_CLOCK`
-    _POSIX_TRACE, -1,
-    _POSIX_TRACE_EVENT_FILTER, -1,
-    _POSIX_TRACE_LOG, -1,
 
 .. _IEEE 1003.1-2017: https://standards.ieee.org/ieee/1003.1/7101/
 .. _IEEE 1003.13-2003: https://standards.ieee.org/ieee/1003.13/3322/

--- a/doc/services/portability/posix/aep/si.svg
+++ b/doc/services/portability/posix/aep/si.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" width="225.805" height="225.805" viewBox="-112.9025 -112.9025 225.805 225.805" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="0" fill="#e6e5e3" opacity="0.5" r="100"/>
+  <circle cx="25" fill="#e6e5e3" opacity="0.5" r="75"/>
+  <circle cx="50" fill="#e6e5e3" opacity="0.5" r="50"/>
+  <circle cx="75" fill="#19c3ea" r="25"/>
+  /* TODO: Change color based on dark / light modes */
+  <g font-family="Arial" font-size="10" text-anchor="middle">
+    <text y="8">
+      <tspan x="75" dy="-1.2em">System</tspan>
+      <tspan x="75" dy="1.2em">Interfaces</tspan>
+    </text>
+    <text x="25">PSE51</text>
+    <text x="-25">PSE52</text>
+    <text x="-75">PSE53</text>
+  </g>
+</svg>

--- a/doc/services/portability/posix/conformance/index.rst
+++ b/doc/services/portability/posix/conformance/index.rst
@@ -94,8 +94,8 @@ POSIX System Interfaces
     _POSIX_SPORADIC_SERVER, -1,
     _POSIX_SYNCHRONIZED_IO, -1, :kconfig:option:`CONFIG_POSIX_FS`
     :ref:`_POSIX_THREAD_ATTR_STACKADDR<posix_option_thread_attr_stackaddr>`, 200809L, :kconfig:option:`CONFIG_PTHREAD`
-    _POSIX_THREAD_CPUTIME, -1,
     :ref:`_POSIX_THREAD_ATTR_STACKSIZE<posix_option_thread_attr_stacksize>`, 200809L, :kconfig:option:`CONFIG_PTHREAD`
+    _POSIX_THREAD_CPUTIME, -1,
     _POSIX_THREAD_PRIO_INHERIT, 200809L, :kconfig:option:`CONFIG_PTHREAD_MUTEX`
     _POSIX_THREAD_PRIO_PROTECT, -1,
     :ref:`_POSIX_THREAD_PRIORITY_SCHEDULING<posix_option_thread_priority_scheduling>`, 200809L, :kconfig:option:`CONFIG_PTHREAD`

--- a/doc/services/portability/posix/conformance/index.rst
+++ b/doc/services/portability/posix/conformance/index.rst
@@ -54,6 +54,8 @@ POSIX System Interfaces
    modification is clearly documented. The implementation is not required for PSE51 or PSE52
    and beyond that POSIX async I/O functions are rarely used in practice.
 
+.. _posix_system_interfaces_required:
+
 .. csv-table:: POSIX System Interfaces
    :header: Symbol, Support, Remarks
    :widths: 50, 10, 50

--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -151,6 +151,18 @@ Group.
 For more information on developing Zephyr applications in the C programming language, please refer
 to :ref:`details<language_support>`.
 
+.. _posix_option_group_signal_jump:
+
+POSIX_SIGNAL_JUMP
+=================
+
+.. csv-table:: POSIX_SIGNAL_JUMP
+   :header: API, Supported
+   :widths: 50,10
+
+    siglongjmp(),
+    sigsetjmp(),
+
 .. _posix_option_group_single_process:
 
 POSIX_SINGLE_PROCESS
@@ -289,6 +301,42 @@ POSIX_CLOCK_SELECTION
     pthread_condattr_setclock(),yes
     clock_nanosleep(),yes
 
+.. _posix_option_group_file_system:
+
+POSIX_FILE_SYSTEM
+=================
+
+.. csv-table:: POSIX_FILE_SYSTEM
+   :header: API, Supported
+   :widths: 50,10
+
+    access(),
+    chdir(),
+    closedir(), yes
+    creat(),
+    fchdir(),
+    fpathconf(),
+    fstat(),
+    fstatvfs(),
+    getcwd(),
+    link(),
+    mkdir(), yes
+    mkstemp(),
+    opendir(), yes
+    pathconf(),
+    readdir(), yes
+    remove(),
+    rename(), yes
+    rewinddir(),
+    rmdir(),
+    stat(), yes
+    statvfs(),
+    tmpfile(),
+    tmpnam(),
+    truncate(),
+    unlink(), yes
+    utime(),
+
 .. _posix_option_group_networking:
 
 POSIX_NETWORKING
@@ -352,6 +400,16 @@ POSIX_NETWORKING
     sockatmark(),yes (will fail with ``ENOSYS``:ref:`†<posix_undefined_behaviour>`)
     socketpair(),yes
 
+.. _posix_option_group_pipe:
+
+POSIX_PIPE
+==========
+
+.. csv-table:: POSIX_PIPE
+   :header: API, Supported
+   :widths: 50,10
+
+    pipe(),
 
 .. _posix_option_group_semaphores:
 
@@ -430,6 +488,25 @@ This table lists service support status in Zephyr for `POSIX_FD_MGMT`:
     lseek(),
     rewind(),
 
+.. _posix_option_group_file_locking:
+
+POSIX_FILE_LOCKING
+==================
+
+This table lists service support status in Zephyr for `POSIX_FD_MGMT`:
+
+.. csv-table:: POSIX_FILE_LOCKING
+   :header: API, Supported
+   :widths: 50,10
+
+    flockfile(),
+    ftrylockfile(),
+    funlockfile(),
+    getc_unlocked(),
+    getchar_unlocked(),
+    putc_unlocked(),
+    putchar_unlocked(),
+
 .. _posix_options:
 
 Additional POSIX Options
@@ -445,6 +522,30 @@ _POSIX_FSYNC
    :widths: 50,10
 
     fsync(),yes
+
+.. _posix_option_memlock:
+
+_POSIX_MEMLOCK
+++++++++++++++
+
+.. csv-table:: _POSIX_MEMLOCK
+   :header: API, Supported
+   :widths: 50,10
+
+    mlockall(),
+    munlockall(),
+
+.. _posix_option_memlock_range:
+
+_POSIX_MEMLOCK_RANGE
+++++++++++++++++++++
+
+.. csv-table:: _POSIX_MEMLOCK_RANGE
+   :header: API, Supported
+   :widths: 50,10
+
+    mlock(),
+    munlock(),
 
 .. _posix_option_message_passing:
 
@@ -464,10 +565,21 @@ _POSIX_MESSAGE_PASSING
     mq_setattr(),yes
     mq_unlink(),yes
 
-_POSIX_PRIORITY_SCHEDULING
-++++++++++++++++++++++++++
+.. _posix_option_monotonic_clock:
+
+_POSIX_MONOTONIC_CLOCK
+++++++++++++++++++++++
+
+.. csv-table:: _POSIX_MONOTONIC_CLOCK
+   :header: API, Supported
+   :widths: 50,10
+
+    CLOCK_MONOTONIC,yes
 
 .. _posix_option_priority_scheduling:
+
+_POSIX_PRIORITY_SCHEDULING
+++++++++++++++++++++++++++
 
 .. csv-table:: _POSIX_PRIORITY_SCHEDULING
    :header: API, Supported
@@ -503,6 +615,20 @@ _POSIX_READER_WRITER_LOCKS
     pthread_rwlockattr_init(),yes
     pthread_rwlockattr_setpshared(),yes
 
+.. _posix_shared_memory_objects:
+
+_POSIX_SHARED_MEMORY_OBJECTS
+++++++++++++++++++++++++++++
+
+.. csv-table:: _POSIX_SHARED_MEMORY_OBJECTS
+   :header: API, Supported
+   :widths: 50,10
+
+    mmap(),
+    munmap(),
+    shm_open(),
+    shm_unlink(),
+
 .. _posix_option_synchronized_io:
 
 _POSIX_SYNCHRONIZED_IO
@@ -527,6 +653,18 @@ _POSIX_THREAD_ATTR_STACKADDR
 
     pthread_attr_getstackaddr(),yes
     pthread_attr_setstackaddr(),yes
+
+.. _posix_option_thread_cputime:
+
+_POSIX_THREAD_CPUTIME
++++++++++++++++++++++
+
+.. csv-table:: _POSIX_THREAD_CPUTIME
+   :header: API, Supported
+   :widths: 50,10
+
+    CLOCK_THREAD_CPUTIME_ID,yes
+    pthread_getcpuclockid(),yes
 
 .. _posix_option_thread_attr_stacksize:
 

--- a/doc/services/portability/posix/overview/aep.svg
+++ b/doc/services/portability/posix/overview/aep.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" width="225.805" height="225.805" viewBox="-112.9025 -112.9025 225.805 225.805" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="0" fill="#786bb0" r="100"/>
+  <circle cx="25" fill="#f04f5e" r="75"/>
+  <circle cx="50" fill="#d9913c" r="50"/>
+  <circle cx="75" fill="#19c3ea" r="25"/>
+  /* TODO: Change color based on dark / light modes */
+  <g font-family="Arial" font-size="10" text-anchor="middle">
+    <text y="8">
+      <tspan x="75" dy="-1.2em">System</tspan>
+      <tspan x="75" dy="1.2em">Interfaces</tspan>
+    </text>
+    <text x="25">PSE51</text>
+    <text x="-25">PSE52</text>
+    <text x="-75">PSE53</text>
+  </g>
+</svg>

--- a/doc/services/portability/posix/overview/index.rst
+++ b/doc/services/portability/posix/overview/index.rst
@@ -54,6 +54,13 @@ For that reason, POSIX defined the following :ref:`Application Environment Profi
 as part of `IEEE 1003.13-2003`_ (also known as POSIX.13-2003). Each AEP adds incrementally more
 features over the required :ref:`POSIX System Interfaces <posix_system_interfaces>`.
 
+..  figure:: aep.svg
+    :align: center
+    :scale: 150%
+    :alt: POSIX Application Environment Profiles (AEP)
+
+    POSIX Application Environment Profiles (AEP)
+
 * Minimal Realtime System Profile (:ref:`PSE51 <posix_aep_pse51>`)
 * Realtime Controller System Profile (:ref:`PSE52 <posix_aep_pse52>`)
 * Dedicated Realtime System Profile (:ref:`PSE53 <posix_aep_pse53>`)

--- a/doc/services/portability/posix/overview/index.rst
+++ b/doc/services/portability/posix/overview/index.rst
@@ -51,7 +51,8 @@ and experience limited user interaction. In such systems, full POSIX conformance
 impractical and unnecessary.
 
 For that reason, POSIX defined the following :ref:`Application Environment Profiles (AEP)<posix_aep>`
-as part of `IEEE 1003.13-2003`_ (also known as POSIX.13-2003).
+as part of `IEEE 1003.13-2003`_ (also known as POSIX.13-2003). Each AEP adds incrementally more
+features over the required :ref:`POSIX System Interfaces <posix_system_interfaces>`.
 
 * Minimal Realtime System Profile (:ref:`PSE51 <posix_aep_pse51>`)
 * Realtime Controller System Profile (:ref:`PSE52 <posix_aep_pse52>`)

--- a/doc/services/portability/posix/overview/index.rst
+++ b/doc/services/portability/posix/overview/index.rst
@@ -38,11 +38,12 @@ Benefits of POSIX support in Zephyr include:
 POSIX Subprofiles
 =================
 
-While Zephyr supports running multiple `threads <threads_v2>` (possibly in an `SMP <smp_arch>`
-configuration), as well as `Virtual Memory and MMUs <memory_management_api>`, Zephyr code and data
-normally share a common address space. The Zephyr kernel executable code and the application
-executable code are typically compiled into the same binary artifact. From that perspective, Zephyr
-apps can be seen as running in the context of a single process.
+While Zephyr supports running multiple :ref:`thread <threads_v2>` (possibly in an
+:ref:`SMP <smp_arch>` configuration), as well as
+:ref:`Virtual Memory and MMUs <memory_management_api>`, Zephyr code and data normally share a
+common address space. The Zephyr kernel executable code and the application executable code are
+typically compiled into the same binary artifact. From that perspective, Zephyr apps can be seen
+as running in the context of a single process.
 
 While multi-purpose operating systems (OS) offer full POSIX conformance, Real-Time Operating
 Systems (RTOS) such as Zephyr typically serve a fixed-purpose, have limited hardware resources,


### PR DESCRIPTION
Since each POSIX Application Environment Profile provides an additive feature set over the previous profile, we can reduce the description of each to only the base System Interfaces and then the deltas from one profile to the next.

Doc previews:
* [overview](https://builds.zephyrproject.io/zephyr/pr/71846/docs/services/portability/posix/overview/index.html#posix-subprofiles)
* [aep](https://builds.zephyrproject.io/zephyr/pr/71846/docs/services/portability/posix/aep/index.html)