### PR TITLE
Bluetooth: Add device name in AD instead of SD

### DIFF
--- a/samples/bluetooth/periodic_adv/src/main.c
+++ b/samples/bluetooth/periodic_adv/src/main.c
@@ -8,11 +8,11 @@
 
 static uint8_t mfg_data[] = { 0xff, 0xff, 0x00 };
 
-static const struct bt_data ad[] = {
+static const struct bt_data per_adv_ad[] = {
 	BT_DATA(BT_DATA_MANUFACTURER_DATA, mfg_data, 3),
 };
 
-static const struct bt_data sd[] = {
+static const struct bt_data ad[] = {
 	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
 };
 
@@ -38,7 +38,7 @@ int main(void)
 	}
 
 	/* Set advertising data to have complete local name set */
-	err = bt_le_ext_adv_set_data(adv, NULL, 0, sd, ARRAY_SIZE(sd));
+	err = bt_le_ext_adv_set_data(adv, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err) {
 		printk("Failed to set advertising data (err %d)\n", err);
 		return 0;
@@ -75,7 +75,7 @@ int main(void)
 			mfg_data[2]++;
 
 			printk("Set Periodic Advertising Data...");
-			err = bt_le_per_adv_set_data(adv, ad, ARRAY_SIZE(ad));
+			err = bt_le_per_adv_set_data(adv, per_adv_ad, ARRAY_SIZE(per_adv_ad));
 			if (err) {
 				printk("Failed (err %d)\n", err);
 				return 0;

--- a/tests/bluetooth/tester/src/btp_bap_broadcast.c
+++ b/tests/bluetooth/tester/src/btp_bap_broadcast.c
@@ -306,12 +306,8 @@ uint8_t btp_bap_broadcast_source_setup(const void *cmd, uint16_t cmd_len,
 	NET_BUF_SIMPLE_DEFINE(ad_buf, BT_UUID_SIZE_16 + BT_AUDIO_BROADCAST_ID_SIZE);
 	NET_BUF_SIMPLE_DEFINE(base_buf, 128);
 
-	struct bt_data sd;
-
-	const char *dev_name = bt_get_name();
-
 	/* Broadcast Audio Streaming Endpoint advertising data */
-	struct bt_data base_ad;
+	struct bt_data base_ad[2];
 	struct bt_data per_ad;
 
 	LOG_DBG("");
@@ -348,14 +344,14 @@ uint8_t btp_bap_broadcast_source_setup(const void *cmd, uint16_t cmd_len,
 	/* Setup extended advertising data */
 	net_buf_simple_add_le16(&ad_buf, BT_UUID_BROADCAST_AUDIO_VAL);
 	net_buf_simple_add_le24(&ad_buf, source->broadcast_id);
-	base_ad.type = BT_DATA_SVC_DATA16;
-	base_ad.data_len = ad_buf.len;
-	base_ad.data = ad_buf.data;
-	sd.type = BT_DATA_NAME_COMPLETE;
-	sd.data_len = strlen(dev_name);
-	sd.data = (const uint8_t *)dev_name;
-	err = tester_gap_create_adv_instance(param, BTP_GAP_ADDR_TYPE_IDENTITY, &base_ad, 1,
-					     &sd, 1, &gap_settings);
+	base_ad[0].type = BT_DATA_SVC_DATA16;
+	base_ad[0].data_len = ad_buf.len;
+	base_ad[0].data = ad_buf.data;
+	base_ad[1].type = BT_DATA_NAME_COMPLETE;
+	base_ad[1].data_len = sizeof(CONFIG_BT_DEVICE_NAME) - 1;
+	base_ad[1].data = CONFIG_BT_DEVICE_NAME;
+	err = tester_gap_create_adv_instance(param, BTP_GAP_ADDR_TYPE_IDENTITY, base_ad, 2,
+					     NULL, 0, &gap_settings);
 	if (err != 0) {
 		LOG_DBG("Failed to create extended advertising instance: %d", err);
 

--- a/tests/bluetooth/tester/src/btp_cap.c
+++ b/tests/bluetooth/tester/src/btp_cap.c
@@ -536,12 +536,8 @@ static int cap_broadcast_source_adv_setup(struct btp_bap_broadcast_local_source 
 	NET_BUF_SIMPLE_DEFINE(ad_buf, BT_UUID_SIZE_16 + BT_AUDIO_BROADCAST_ID_SIZE);
 	NET_BUF_SIMPLE_DEFINE(base_buf, 128);
 
-	struct bt_data sd;
-
-	const char *dev_name = bt_get_name();
-
 	/* Broadcast Audio Streaming Endpoint advertising data */
-	struct bt_data base_ad;
+	struct bt_data base_ad[2];
 	struct bt_data per_ad;
 
 	err = bt_cap_initiator_broadcast_get_id(source->cap_broadcast, &source->broadcast_id);
@@ -556,14 +552,14 @@ static int cap_broadcast_source_adv_setup(struct btp_bap_broadcast_local_source 
 	/* Setup extended advertising data */
 	net_buf_simple_add_le16(&ad_buf, BT_UUID_BROADCAST_AUDIO_VAL);
 	net_buf_simple_add_le24(&ad_buf, source->broadcast_id);
-	base_ad.type = BT_DATA_SVC_DATA16;
-	base_ad.data_len = ad_buf.len;
-	base_ad.data = ad_buf.data;
-	sd.type = BT_DATA_NAME_COMPLETE;
-	sd.data_len = strlen(dev_name);
-	sd.data = (const uint8_t *) dev_name;
-	err = tester_gap_create_adv_instance(param, BTP_GAP_ADDR_TYPE_IDENTITY, &base_ad, 1,
-					     &sd, 1, gap_settings);
+	base_ad[0].type = BT_DATA_SVC_DATA16;
+	base_ad[0].data_len = ad_buf.len;
+	base_ad[0].data = ad_buf.data;
+	base_ad[1].type = BT_DATA_NAME_COMPLETE;
+	base_ad[1].data_len = sizeof(CONFIG_BT_DEVICE_NAME) - 1;
+	base_ad[1].data = CONFIG_BT_DEVICE_NAME;
+	err = tester_gap_create_adv_instance(param, BTP_GAP_ADDR_TYPE_IDENTITY, base_ad, 2,
+					     NULL, 0, gap_settings);
 	if (err != 0) {
 		LOG_DBG("Failed to create extended advertising instance: %d", err);
 


### PR DESCRIPTION
With the deprecation of `BT_LE_ADV_OPT_USE_NAME` and `BT_LE_ADV_OPT_FORCE_NAME_IN_AD`, code base has been updated to not use those option anymore and add the device name explicitly in the advertising or scan response data.

There was some mistakes adding the name to the scan response data instead of the advertising data.

Thanks to @sjanc for catching those errors.