### PR TITLE
i2c: target: eeprom_target: add num-address-bytes parameter

### DIFF
--- a/drivers/i2c/target/eeprom_target.c
+++ b/drivers/i2c/target/eeprom_target.c
@@ -22,7 +22,8 @@ struct i2c_eeprom_target_data {
 	uint32_t buffer_size;
 	uint8_t *buffer;
 	uint32_t buffer_idx;
-	bool first_write;
+	uint32_t idx_write_cnt;
+	uint8_t address_width;
 };
 
 struct i2c_eeprom_target_config {
@@ -86,7 +87,7 @@ static int eeprom_target_write_requested(struct i2c_target_config *config)
 
 	LOG_DBG("eeprom: write req");
 
-	data->first_write = true;
+	data->idx_write_cnt = 0;
 
 	return 0;
 }
@@ -121,9 +122,13 @@ static int eeprom_target_write_received(struct i2c_target_config *config,
 	 * I2C controller support
 	 */
 
-	if (data->first_write) {
-		data->buffer_idx = val;
-		data->first_write = false;
+	if (data->idx_write_cnt < (data->address_width >> 3)) {
+		if (data->idx_write_cnt == 0) {
+			data->buffer_idx = 0;
+		}
+
+		data->buffer_idx = val | (data->buffer_idx << 8);
+		data->idx_write_cnt++;
 	} else {
 		data->buffer[data->buffer_idx++] = val;
 	}
@@ -162,7 +167,7 @@ static int eeprom_target_stop(struct i2c_target_config *config)
 
 	LOG_DBG("eeprom: stop");
 
-	data->first_write = true;
+	data->idx_write_cnt = 0;
 
 	return 0;
 }
@@ -246,7 +251,10 @@ static int i2c_eeprom_target_init(const struct device *dev)
 
 #define I2C_EEPROM_INIT(inst)						\
 	static struct i2c_eeprom_target_data				\
-		i2c_eeprom_target_##inst##_dev_data;			\
+		i2c_eeprom_target_##inst##_dev_data = {			\
+			.address_width = DT_INST_PROP_OR(inst,		\
+					address_width, 8),		\
+		};							\
 									\
 	static uint8_t							\
 	i2c_eeprom_target_##inst##_buffer[(DT_INST_PROP(inst, size))];	\

--- a/drivers/i2c/target/eeprom_target.c
+++ b/drivers/i2c/target/eeprom_target.c
@@ -259,6 +259,10 @@ static int i2c_eeprom_target_init(const struct device *dev)
 	static uint8_t							\
 	i2c_eeprom_target_##inst##_buffer[(DT_INST_PROP(inst, size))];	\
 									\
+	BUILD_ASSERT(DT_INST_PROP(inst, size) <=			\
+			(1 << DT_INST_PROP_OR(inst, address_width, 8)), \
+			"size must be <= than 2^address_width");	\
+									\
 	static const struct i2c_eeprom_target_config			\
 		i2c_eeprom_target_##inst##_cfg = {			\
 		.bus = I2C_DT_SPEC_INST_GET(inst),			\

--- a/dts/bindings/mtd/zephyr,i2c-target-eeprom.yaml
+++ b/dts/bindings/mtd/zephyr,i2c-target-eeprom.yaml
@@ -5,3 +5,11 @@ description: Zephyr I2C target EEPROM
 compatible: "zephyr,i2c-target-eeprom"
 
 include: ["eeprom-base.yaml", i2c-device.yaml]
+
+properties:
+  address-width:
+    type: int
+    enum: [8, 16]
+    description: |
+      Number of address bits used to address the EEPROM. If not specified
+      the EEPROM is assumed to have a 8-bit address.

--- a/tests/drivers/i2c/i2c_target_api/boards/b_u585i_iot02a.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/b_u585i_iot02a.overlay
@@ -16,7 +16,7 @@
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
-		size = <1024>;
+		size = <256>;
 	};
 };
 
@@ -24,6 +24,6 @@
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
-		size = <1024>;
+		size = <256>;
 	};
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/efr32bg22_brd4184a.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/efr32bg22_brd4184a.overlay
@@ -4,11 +4,11 @@
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
-		size = <1024>;
+		size = <256>;
 	};
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
-		size = <1024>;
+		size = <256>;
 	};
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/mr_canhubk3.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/mr_canhubk3.overlay
@@ -11,7 +11,7 @@
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
-		size = <1024>;
+		size = <256>;
 	};
 };
 
@@ -20,6 +20,6 @@
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
-		size = <1024>;
+		size = <256>;
 	};
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_f091rc.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_f091rc.overlay
@@ -14,7 +14,7 @@
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
-		size = <1024>;
+		size = <256>;
 	};
 };
 
@@ -25,7 +25,7 @@
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
-		size = <1024>;
+		size = <256>;
 	};
 };
 

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_f207zg.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_f207zg.overlay
@@ -14,7 +14,7 @@
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
-		size = <1024>;
+		size = <256>;
 	};
 };
 
@@ -22,6 +22,6 @@
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
-		size = <1024>;
+		size = <256>;
 	};
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_f401re.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_f401re.overlay
@@ -14,7 +14,7 @@
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
-		size = <1024>;
+		size = <256>;
 	};
 };
 
@@ -22,6 +22,6 @@
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
-		size = <1024>;
+		size = <256>;
 	};
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_f429zi.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_f429zi.overlay
@@ -14,7 +14,7 @@
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
-		size = <1024>;
+		size = <256>;
 	};
 };
 
@@ -22,6 +22,6 @@
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
-		size = <1024>;
+		size = <256>;
 	};
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_f746zg.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_f746zg.overlay
@@ -17,7 +17,7 @@
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
-		size = <1024>;
+		size = <256>;
 	};
 };
 
@@ -25,6 +25,6 @@
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
-		size = <1024>;
+		size = <256>;
 	};
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_g071rb.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_g071rb.overlay
@@ -17,7 +17,7 @@
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
-		size = <1024>;
+		size = <256>;
 	};
 };
 
@@ -25,6 +25,6 @@
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
-		size = <1024>;
+		size = <256>;
 	};
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_g474re.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_g474re.overlay
@@ -14,7 +14,7 @@
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
-		size = <1024>;
+		size = <256>;
 	};
 };
 
@@ -25,6 +25,6 @@
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
-		size = <1024>;
+		size = <256>;
 	};
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_l073rz.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_l073rz.overlay
@@ -14,7 +14,7 @@
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
-		size = <1024>;
+		size = <256>;
 	};
 };
 
@@ -23,6 +23,6 @@
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
-		size = <1024>;
+		size = <256>;
 	};
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_l152re.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_l152re.overlay
@@ -14,7 +14,7 @@
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
-		size = <1024>;
+		size = <256>;
 	};
 };
 
@@ -26,6 +26,6 @@
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
-		size = <1024>;
+		size = <256>;
 	};
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_wb55rg.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_wb55rg.overlay
@@ -14,7 +14,7 @@
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
-		size = <1024>;
+		size = <256>;
 	};
 };
 
@@ -26,6 +26,6 @@
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
-		size = <1024>;
+		size = <256>;
 	};
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_wl55jc.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_wl55jc.overlay
@@ -14,7 +14,7 @@
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
-		size = <1024>;
+		size = <256>;
 	};
 };
 
@@ -26,6 +26,6 @@
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
-		size = <1024>;
+		size = <256>;
 	};
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/rpi_pico.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/rpi_pico.overlay
@@ -18,7 +18,7 @@
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
-		size = <1024>;
+		size = <256>;
 	};
 };
 
@@ -30,6 +30,6 @@
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
-		size = <1024>;
+		size = <256>;
 	};
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/stm32f072b_disco.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/stm32f072b_disco.overlay
@@ -4,7 +4,7 @@
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
-		size = <1024>;
+		size = <256>;
 	};
 };
 
@@ -13,6 +13,6 @@
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
-		size = <1024>;
+		size = <256>;
 	};
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/stm32f3_disco.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/stm32f3_disco.overlay
@@ -16,7 +16,7 @@
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
-		size = <1024>;
+		size = <256>;
 	};
 };
 
@@ -24,7 +24,7 @@
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
-		size = <1024>;
+		size = <256>;
 	};
 
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/stm32h573i_dk.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/stm32h573i_dk.overlay
@@ -17,7 +17,7 @@
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
-		size = <1024>;
+		size = <256>;
 	};
 };
 
@@ -25,6 +25,6 @@
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
-		size = <1024>;
+		size = <256>;
 	};
 };


### PR DESCRIPTION
Add a parameter to allow the configuration of the number of address bytes used by the I2C master. This allows the driver to expose larger buffer sizes.

Implementation similar to https://github.com/torvalds/linux/blob/master/drivers/i2c/i2c-slave-eeprom.c

Tested with standard linux at24 driver.