### PR TITLE
kernel: timeslicing: add time slice reset in slice per thread api

### DIFF
--- a/kernel/timeslicing.c
+++ b/kernel/timeslicing.c
@@ -95,6 +95,7 @@ void k_thread_time_slice_set(struct k_thread *thread, int32_t thread_slice_ticks
 		thread->base.slice_ticks = thread_slice_ticks;
 		thread->base.slice_expired = expired;
 		thread->base.slice_data = data;
+		z_reset_time_slice(thread);
 	}
 }
 #endif


### PR DESCRIPTION
This will reset time slice in k_thread_time_slice_set() when slice per thread api is used.

Currently it will reset it only in standard k_thread_time_slice_set