### PR TITLE
includes: explicit cast of destination bitwidth of left shift

### DIFF
--- a/include/zephyr/dt-bindings/pcie/pcie.h
+++ b/include/zephyr/dt-bindings/pcie/pcie.h
@@ -26,9 +26,15 @@
 #define PCIE_ID_DEV_SHIFT	16U
 #define PCIE_ID_DEV_MASK		0xFFFFU
 
+#ifdef __DTS__
+#define CAST(type, v) (v)
+#else
+#define CAST(type, v) ((type)(v))
+#endif
+
 #define PCIE_ID(vend, dev) \
 	((((vend) & PCIE_ID_VEND_MASK) << PCIE_ID_VEND_SHIFT) | \
-	 (((dev) & PCIE_ID_DEV_MASK) << PCIE_ID_DEV_SHIFT))
+	 (CAST(uint32_t, (dev) & PCIE_ID_DEV_MASK) << PCIE_ID_DEV_SHIFT))
 
 #define PCIE_ID_TO_VEND(id) (((id) >> PCIE_ID_VEND_SHIFT) & PCIE_ID_VEND_MASK)
 #define PCIE_ID_TO_DEV(id)  (((id) >> PCIE_ID_DEV_SHIFT) & PCIE_ID_DEV_MASK)


### PR DESCRIPTION
Fix coding guideline MISRA C:2012 Rule 12.2:

> The right hand operand of a shift operator shall lie in the range zero to one less than the width in bits of the essential type of the left hand operand.

This PR is part of the enhancement issue (https://github.com/zephyrproject-rtos/zephyr/issues/48002) which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main
