### PR TITLE
drivers: can: set default initial bitrates via Kconfig

### DIFF
--- a/boards/arduino/giga_r1/arduino_giga_r1_stm32h747xx_m7.dts
+++ b/boards/arduino/giga_r1/arduino_giga_r1_stm32h747xx_m7.dts
@@ -141,8 +141,6 @@
 	pinctrl-names = "default";
 	clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000100>,
 		 <&rcc STM32_SRC_PLL1_Q FDCAN_SEL(1)>;
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
 };
 
 &flash0 {

--- a/boards/atmel/sam/sam_e70_xplained/sam_e70_xplained-common.dtsi
+++ b/boards/atmel/sam/sam_e70_xplained/sam_e70_xplained-common.dtsi
@@ -206,9 +206,6 @@ zephyr_udc0: &usbhs {
 	pinctrl-0 = <&can0_default>;
 	pinctrl-names = "default";
 
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
-
 	can-transceiver {
 		max-bitrate = <5000000>;
 	};

--- a/boards/atmel/sam/sam_v71_xult/sam_v71_xult-common.dtsi
+++ b/boards/atmel/sam/sam_v71_xult/sam_v71_xult-common.dtsi
@@ -331,9 +331,6 @@ zephyr_udc0: &usbhs {
 	pinctrl-0 = <&can1_default>;
 	pinctrl-names = "default";
 
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
-
 	can-transceiver {
 		max-bitrate = <5000000>;
 	};

--- a/boards/atmel/sam0/samc21n_xpro/samc21n_xpro.dts
+++ b/boards/atmel/sam0/samc21n_xpro/samc21n_xpro.dts
@@ -162,9 +162,6 @@
 	pinctrl-0 = <&can0_default>;
 	pinctrl-names = "default";
 
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
-
 	can-transceiver {
 		max-bitrate = <5000000>;
 	};
@@ -173,9 +170,6 @@
 &can1 {
 	pinctrl-0 = <&can1_default>;
 	pinctrl-names = "default";
-
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
 
 	can-transceiver {
 		max-bitrate = <5000000>;

--- a/boards/espressif/esp32c3_devkitm/esp32c3_devkitm.dts
+++ b/boards/espressif/esp32c3_devkitm/esp32c3_devkitm.dts
@@ -94,7 +94,6 @@
 	status = "disabled";
 	pinctrl-0 = <&twai_default>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
 };
 
 &flash0 {

--- a/boards/espressif/esp32s3_devkitc/esp32s3_devkitc_procpu.dts
+++ b/boards/espressif/esp32s3_devkitc/esp32s3_devkitc_procpu.dts
@@ -112,7 +112,6 @@
 &twai {
 	pinctrl-0 = <&twai_default>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
 };
 
 &timer0 {

--- a/boards/espressif/esp32s3_devkitm/esp32s3_devkitm_procpu.dts
+++ b/boards/espressif/esp32s3_devkitm/esp32s3_devkitm_procpu.dts
@@ -112,7 +112,6 @@
 &twai {
 	pinctrl-0 = <&twai_default>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
 };
 
 &timer0 {

--- a/boards/heltec/heltec_wireless_stick_lite_v3/heltec_wireless_stick_lite_v3_procpu.dts
+++ b/boards/heltec/heltec_wireless_stick_lite_v3/heltec_wireless_stick_lite_v3_procpu.dts
@@ -142,7 +142,6 @@
 &twai {
 	pinctrl-0 = <&twai_default>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
 };
 
 &timer0 {

--- a/boards/infineon/xmc47_relax_kit/xmc47_relax_kit.dts
+++ b/boards/infineon/xmc47_relax_kit/xmc47_relax_kit.dts
@@ -207,7 +207,6 @@
 
 &can_node1 {
 	status = "okay";
-	bus-speed = <125000>;
 	input-src = "RXDC";
 	pinctrl-0 = <&can_tx_p1_12_node1 &can_rx_p1_13_node1>;
 	pinctrl-names = "default";

--- a/boards/luatos/esp32c3_luatos_core/esp32c3_luatos_core.dtsi
+++ b/boards/luatos/esp32c3_luatos_core/esp32c3_luatos_core.dtsi
@@ -94,7 +94,6 @@
 	status = "disabled";
 	pinctrl-0 = <&twai_default>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
 };
 
 &flash0 {

--- a/boards/luatos/esp32s3_luatos_core/esp32s3_luatos_core.dtsi
+++ b/boards/luatos/esp32s3_luatos_core/esp32s3_luatos_core.dtsi
@@ -85,7 +85,6 @@
 &twai {
 	pinctrl-0 = <&twai_default>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
 };
 
 &timer0 {

--- a/boards/m5stack/stamp_c3/stamp_c3.dts
+++ b/boards/m5stack/stamp_c3/stamp_c3.dts
@@ -93,7 +93,6 @@
 	status = "disabled";
 	pinctrl-0 = <&twai_default>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
 };
 
 &flash0 {

--- a/boards/native/native_sim/native_sim.dts
+++ b/boards/native/native_sim/native_sim.dts
@@ -190,7 +190,6 @@
 	can_loopback0: can_loopback0 {
 		status = "okay";
 		compatible = "zephyr,can-loopback";
-		bus-speed = <125000>;
 	};
 
 	can0: can {
@@ -200,7 +199,6 @@
 		 * name, e.g.: sudo ip link property add dev vcan0 altname zcan0
 		 */
 		host-interface = "zcan0";
-		bus-speed = <125000>;
 	};
 
 	rtc: rtc {

--- a/boards/nuvoton/numaker_pfm_m467/numaker_pfm_m467.dts
+++ b/boards/nuvoton/numaker_pfm_m467/numaker_pfm_m467.dts
@@ -111,8 +111,6 @@
 };
 
 &canfd0 {
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
 	pinctrl-0 = <&canfd0_default>;
 	pinctrl-names = "default";
 	status = "okay";

--- a/boards/nxp/frdm_k64f/frdm_k64f.dts
+++ b/boards/nxp/frdm_k64f/frdm_k64f.dts
@@ -286,7 +286,6 @@ zephyr_udc0: &usbotg {
 	status = "okay";
 	pinctrl-0 = <&flexcan0_default>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
 };
 
 &edma0 {

--- a/boards/nxp/lpcxpresso55s06/lpcxpresso55s06_common.dtsi
+++ b/boards/nxp/lpcxpresso55s06/lpcxpresso55s06_common.dtsi
@@ -151,8 +151,6 @@
 
 &can0 {
 	status = "okay";
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
 	pinctrl-0 = <&pinmux_can0>;
 	pinctrl-names = "default";
 

--- a/boards/nxp/lpcxpresso55s16/lpcxpresso55s16_common.dtsi
+++ b/boards/nxp/lpcxpresso55s16/lpcxpresso55s16_common.dtsi
@@ -147,8 +147,6 @@
 
 &can0 {
 	status = "okay";
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
 	pinctrl-0 = <&pinmux_can0>;
 	pinctrl-names = "default";
 

--- a/boards/nxp/lpcxpresso55s36/lpcxpresso55s36.dts
+++ b/boards/nxp/lpcxpresso55s36/lpcxpresso55s36.dts
@@ -126,8 +126,6 @@
 };
 
 &can0 {
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
 	pinctrl-0 = <&pinmux_mcan_can0>;
 	pinctrl-names = "default";
 	status = "okay";

--- a/boards/nxp/mimxrt1024_evk/mimxrt1024_evk.dts
+++ b/boards/nxp/mimxrt1024_evk/mimxrt1024_evk.dts
@@ -168,7 +168,6 @@ arduino_serial: &lpuart2 {
 
 &flexcan1 {
 	status = "okay";
-	bus-speed = <125000>;
 	pinctrl-0 = <&pinmux_flexcan1>;
 	pinctrl-names = "default";
 

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -242,8 +242,6 @@ zephyr_udc0: &usb1 {
 
 &flexcan3 {
 	status = "okay";
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
 	pinctrl-0 = <&pinmux_flexcan3>;
 	pinctrl-names = "default";
 

--- a/boards/nxp/mimxrt1062_fmurt6/mimxrt1062_fmurt6.dts
+++ b/boards/nxp/mimxrt1062_fmurt6/mimxrt1062_fmurt6.dts
@@ -109,7 +109,6 @@
 	status = "okay";
 	pinctrl-0 = <&pinmux_flexcan1>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
 	can-transceiver {
 		max-bitrate = <5000000>;
 	};
@@ -119,7 +118,6 @@
 	status = "disabled";
 	pinctrl-0 = <&pinmux_flexcan2>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
 	can-transceiver {
 		max-bitrate = <5000000>;
 	};
@@ -129,8 +127,6 @@
 	status = "disabled";
 	pinctrl-0 = <&pinmux_flexcan3>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
 	can-transceiver {
 		max-bitrate = <5000000>;
 	};

--- a/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -310,7 +310,6 @@ zephyr_udc0: &usb1 {
 
 &flexcan2 {
 	status = "okay";
-	bus-speed = <125000>;
 	pinctrl-0 = <&pinmux_flexcan2>;
 	pinctrl-names = "default";
 

--- a/boards/nxp/mimxrt1160_evk/mimxrt1160_evk_mimxrt1166_cm7.dts
+++ b/boards/nxp/mimxrt1160_evk/mimxrt1160_evk_mimxrt1166_cm7.dts
@@ -45,8 +45,6 @@
 
 &flexcan3 {
 	status = "okay";
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
 	can-transceiver {
 		max-bitrate = <5000000>;
 	};

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7.dts
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7.dts
@@ -74,8 +74,6 @@ zephyr_mipi_dsi: &mipi_dsi {
 
 &flexcan3 {
 	status = "okay";
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
 	can-transceiver {
 		max-bitrate = <5000000>;
 	};

--- a/boards/nxp/mr_canhubk3/mr_canhubk3.dts
+++ b/boards/nxp/mr_canhubk3/mr_canhubk3.dts
@@ -358,8 +358,6 @@
 	pinctrl-0 = <&flexcan0_default>;
 	pinctrl-names = "default";
 	phys = <&can_phy0>;
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
 	status = "okay";
 };
 
@@ -367,40 +365,30 @@
 	pinctrl-0 = <&flexcan1_default>;
 	pinctrl-names = "default";
 	phys = <&can_phy1>;
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
 };
 
 &flexcan2 {
 	pinctrl-0 = <&flexcan2_default>;
 	pinctrl-names = "default";
 	phys = <&can_phy2>;
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
 };
 
 &flexcan3 {
 	pinctrl-0 = <&flexcan3_default>;
 	pinctrl-names = "default";
 	phys = <&can_phy3>;
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
 };
 
 &flexcan4 {
 	pinctrl-0 = <&flexcan4_default>;
 	pinctrl-names = "default";
 	phys = <&can_phy4>;
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
 };
 
 &flexcan5 {
 	pinctrl-0 = <&flexcan5_default>;
 	pinctrl-names = "default";
 	phys = <&can_phy5>;
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
 };
 
 &lpi2c0 {

--- a/boards/nxp/rddrone_fmuk66/rddrone_fmuk66.dts
+++ b/boards/nxp/rddrone_fmuk66/rddrone_fmuk66.dts
@@ -281,7 +281,6 @@ zephyr_udc0: &usbotg {
 	status = "okay";
 	pinctrl-0 = <&flexcan0_default>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
 	phys = <&transceiver0>;
 };
 
@@ -289,7 +288,6 @@ zephyr_udc0: &usbotg {
 	status = "okay";
 	pinctrl-0 = <&flexcan1_default>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
 	phys = <&transceiver1>;
 };
 

--- a/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270.dtsi
+++ b/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270.dtsi
@@ -34,14 +34,10 @@
 &can0 {
 	pinctrl-0 = <&can0_default>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
 	status = "okay";
 };
 
 &can1 {
 	pinctrl-0 = <&can1_default>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
 };

--- a/boards/nxp/twr_ke18f/twr_ke18f.dts
+++ b/boards/nxp/twr_ke18f/twr_ke18f.dts
@@ -293,7 +293,6 @@
 
 &flexcan0 {
 	status = "okay";
-	bus-speed = <125000>;
 	pinctrl-0 = <&flexcan0_default>;
 	pinctrl-names = "default";
 

--- a/boards/nxp/ucans32k1sic/ucans32k1sic.dts
+++ b/boards/nxp/ucans32k1sic/ucans32k1sic.dts
@@ -179,8 +179,6 @@
 	pinctrl-0 = <&flexcan0_default>;
 	pinctrl-names = "default";
 	phys = <&can_phy0>;
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
 	status = "okay";
 };
 
@@ -188,7 +186,5 @@
 	pinctrl-0 = <&flexcan1_default>;
 	pinctrl-names = "default";
 	phys = <&can_phy1>;
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
 	status = "okay";
 };

--- a/boards/nxp/vmu_rt1170/vmu_rt1170_mimxrt1176_cm7.dts
+++ b/boards/nxp/vmu_rt1170/vmu_rt1170_mimxrt1176_cm7.dts
@@ -175,8 +175,6 @@
 	status = "okay";
 	pinctrl-0 = <&pinmux_flexcan1>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
 	can-transceiver {
 		max-bitrate = <5000000>;
 	};
@@ -186,8 +184,6 @@
 	status = "okay";
 	pinctrl-0 = <&pinmux_flexcan2>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
 	can-transceiver {
 		max-bitrate = <5000000>;
 	};
@@ -197,8 +193,6 @@
 	status = "okay";
 	pinctrl-0 = <&pinmux_flexcan3>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
 	can-transceiver {
 		max-bitrate = <5000000>;
 	};

--- a/boards/olimex/olimex_esp32_evb/olimex_esp32_evb_procpu.dts
+++ b/boards/olimex/olimex_esp32_evb/olimex_esp32_evb_procpu.dts
@@ -100,7 +100,6 @@ uext_spi: &spi2 {};
 	status = "okay";
 	pinctrl-0 = <&twai_default>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
 
 	can-transceiver {
 		max-bitrate = <1000000>;

--- a/boards/olimex/olimexino_stm32/olimexino_stm32.dts
+++ b/boards/olimex/olimexino_stm32/olimexino_stm32.dts
@@ -166,7 +166,6 @@ zephyr_udc0: &usb {
 &can1 {
 	pinctrl-0 = <&can_rx_remap1_pb8 &can_tx_remap1_pb9>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
 	phys = <&transceiver0>;
 	status = "okay";
 };

--- a/boards/olimex/stm32_p405/olimex_stm32_p405.dts
+++ b/boards/olimex/stm32_p405/olimex_stm32_p405.dts
@@ -87,7 +87,6 @@
 &can1 {
 	pinctrl-0 = <&can1_rx_pb8 &can1_tx_pb9>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
 	status = "okay";
 
 	can-transceiver {

--- a/boards/others/black_f407ve/black_f407ve.dts
+++ b/boards/others/black_f407ve/black_f407ve.dts
@@ -126,14 +126,12 @@ zephyr_udc0: &usbotg_fs {
 &can1 {
 	pinctrl-0 = <&can1_rx_pd0 &can1_tx_pd1>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
 	status = "disabled";
 };
 
 &can2 {
 	pinctrl-0 = <&can2_rx_pb12 &can2_tx_pb13>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
 	status = "okay";
 };
 

--- a/boards/others/black_f407zg_pro/black_f407zg_pro.dts
+++ b/boards/others/black_f407zg_pro/black_f407zg_pro.dts
@@ -125,14 +125,12 @@ zephyr_udc0: &usbotg_fs {
 &can1 {
 	pinctrl-0 = <&can1_rx_pd0 &can1_tx_pd1>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
 	status = "disabled";
 };
 
 &can2 {
 	pinctrl-0 = <&can2_rx_pb12 &can2_tx_pb13>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
 	status = "okay";
 };
 

--- a/boards/pjrc/teensy4/teensy40.dts
+++ b/boards/pjrc/teensy4/teensy40.dts
@@ -66,11 +66,6 @@ zephyr_udc0: &usb1 {
 	current-speed = < 115200 >;
 };
 
-&flexcan1 {
-	status = "okay";
-	bus-speed = < 125000 >;
-};
-
 &edma0 {
 	status = "okay";
 };
@@ -98,11 +93,7 @@ zephyr_udc0: &usb1 {
 &flexcan1 {
 	pinctrl-0 = <&pinmux_flexcan1>;
 	pinctrl-names = "default";
-};
-
-&flexcan1 {
-	pinctrl-0 = <&pinmux_flexcan1>;
-	pinctrl-names = "default";
+	status = "okay";
 };
 
 &flexcan2 {

--- a/boards/qemu/x86/qemu_x86.dts
+++ b/boards/qemu/x86/qemu_x86.dts
@@ -61,7 +61,6 @@
 			device-id = <0x8406>;
 			interrupts = <11 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
-			bus-speed = <125000>;
 
 			can-transceiver {
 				max-bitrate = <1000000>;

--- a/boards/renesas/rcar_h3ulcb/rcar_h3ulcb_r8a77951_r7.dts
+++ b/boards/renesas/rcar_h3ulcb/rcar_h3ulcb_r8a77951_r7.dts
@@ -63,7 +63,6 @@
 	pinctrl-0 = <&can0_data_a_tx_default &can0_data_a_rx_default>;
 	pinctrl-names = "default";
 	status = "okay";
-	bus-speed = <125000>;
 
 	can-transceiver {
 		max-bitrate = <5000000>;

--- a/boards/renesas/rcar_salvator_x/rcar_salvator_x_r8a77951_r7.dts
+++ b/boards/renesas/rcar_salvator_x/rcar_salvator_x_r8a77951_r7.dts
@@ -75,7 +75,6 @@
 	pinctrl-0 = <&can0_data_a_tx_default &can0_data_a_rx_default>;
 	pinctrl-names = "default";
 	status = "okay";
-	bus-speed = <125000>;
 };
 
 &scif1 {

--- a/boards/seco/stm32f3_seco_d23/stm32f3_seco_d23.dts
+++ b/boards/seco/stm32f3_seco_d23/stm32f3_seco_d23.dts
@@ -177,7 +177,6 @@ zephyr_udc0: &usb {
 &can1 {
 	pinctrl-0 = <&can_rx_pb8 &can_tx_pb9>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
 	phys = <&transceiver0>;
 	status = "okay";
 };

--- a/boards/seeed/xiao_esp32c3/xiao_esp32c3.dts
+++ b/boards/seeed/xiao_esp32c3/xiao_esp32c3.dts
@@ -83,7 +83,6 @@
 	status = "okay";
 	pinctrl-0 = <&twai_default>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
 };
 
 &wifi {

--- a/boards/seeed/xiao_esp32s3/xiao_esp32s3_procpu.dts
+++ b/boards/seeed/xiao_esp32s3/xiao_esp32s3_procpu.dts
@@ -91,7 +91,6 @@
 &twai {
 	pinctrl-0 = <&twai_default>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
 };
 
 &timer0 {

--- a/boards/shields/mcp2515/adafruit_can_picowbell.overlay
+++ b/boards/shields/mcp2515/adafruit_can_picowbell.overlay
@@ -15,7 +15,6 @@
 		status = "okay";
 		reg = <0x0>;
 		osc-freq = <16000000>;
-		bus-speed = <125000>;
 
 		can-transceiver {
 			max-bitrate = <1000000>;

--- a/boards/shields/mcp2515/dfrobot_can_bus_v2_0.overlay
+++ b/boards/shields/mcp2515/dfrobot_can_bus_v2_0.overlay
@@ -15,7 +15,6 @@
 		status = "okay";
 		reg = <0x0>;
 		osc-freq = <16000000>;
-		bus-speed = <125000>;
 
 		can-transceiver {
 			min-bitrate = <60000>;

--- a/boards/shields/mcp2515/keyestudio_can_bus_ks0411.overlay
+++ b/boards/shields/mcp2515/keyestudio_can_bus_ks0411.overlay
@@ -15,7 +15,6 @@
 		status = "okay";
 		reg = <0x0>;
 		osc-freq = <16000000>;
-		bus-speed = <125000>;
 
 		can-transceiver {
 			max-bitrate = <1000000>;

--- a/boards/shields/mikroe_mcp2518fd_click/mikroe_mcp2518fd_click.overlay
+++ b/boards/shields/mikroe_mcp2518fd_click/mikroe_mcp2518fd_click.overlay
@@ -10,8 +10,6 @@
 		reg = <0x0>;
 		osc-freq = <40000000>;
 
-		bus-speed = <125000>;
-		bus-speed-data = <1000000>;
 	};
 };
 

--- a/boards/shields/tcan4550evm/tcan4550evm.overlay
+++ b/boards/shields/tcan4550evm/tcan4550evm.overlay
@@ -28,8 +28,6 @@
 		reset-gpios = <&arduino_header 14 GPIO_ACTIVE_HIGH>; /* D8 */
 		int-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>; /* D9 */
 		bosch,mram-cfg = <0x0 15 15 7 7 0 10 10>;
-		bus-speed = <125000>;
-		bus-speed-data = <1000000>;
 		status = "okay";
 
 		can-transceiver {

--- a/boards/st/nucleo_f091rc/nucleo_f091rc.dts
+++ b/boards/st/nucleo_f091rc/nucleo_f091rc.dts
@@ -116,7 +116,6 @@
 &can1 {
 	pinctrl-0 = <&can_rx_pa11 &can_tx_pa12>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
 	status = "okay";
 };
 

--- a/boards/st/nucleo_f303re/nucleo_f303re.dts
+++ b/boards/st/nucleo_f303re/nucleo_f303re.dts
@@ -94,7 +94,6 @@
 &can1 {
 	pinctrl-0 = <&can_rx_pb8 &can_tx_pb9>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
 	status = "okay";
 };
 

--- a/boards/st/nucleo_f446re/nucleo_f446re.dts
+++ b/boards/st/nucleo_f446re/nucleo_f446re.dts
@@ -147,14 +147,12 @@
 	/* CAUTION: PB8 and PB9 may conflict with same pins of I2C1 */
 	pinctrl-0 = <&can1_rx_pb8 &can1_tx_pb9>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
 	status = "okay";
 };
 
 &can2 {
 	pinctrl-0 = <&can2_rx_pb12 &can2_tx_pb13>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
 	status = "okay";
 };
 

--- a/boards/st/nucleo_f446ze/nucleo_f446ze.dts
+++ b/boards/st/nucleo_f446ze/nucleo_f446ze.dts
@@ -180,7 +180,6 @@ zephyr_udc0: &usbotg_fs {
 &can1 {
 	pinctrl-0 = <&can1_rx_pd0 &can1_tx_pd1>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
 	status = "okay";
 };
 

--- a/boards/st/nucleo_f722ze/nucleo_f722ze.dts
+++ b/boards/st/nucleo_f722ze/nucleo_f722ze.dts
@@ -123,7 +123,6 @@
 &can1 {
 	pinctrl-0 = <&can1_rx_pd0 &can1_tx_pd1>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
 	status = "okay";
 };
 

--- a/boards/st/nucleo_f746zg/nucleo_f746zg.dts
+++ b/boards/st/nucleo_f746zg/nucleo_f746zg.dts
@@ -166,7 +166,6 @@ zephyr_udc0: &usbotg_fs {
 &can1 {
 	pinctrl-0 = <&can1_rx_pd0 &can1_tx_pd1>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
 	status = "okay";
 };
 

--- a/boards/st/nucleo_f767zi/nucleo_f767zi.dts
+++ b/boards/st/nucleo_f767zi/nucleo_f767zi.dts
@@ -165,7 +165,6 @@ zephyr_udc0: &usbotg_fs {
 &can1 {
 	pinctrl-0 = <&can1_rx_pd0 &can1_tx_pd1>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
 	status = "okay";
 };
 

--- a/boards/st/nucleo_g0b1re/nucleo_g0b1re.dts
+++ b/boards/st/nucleo_g0b1re/nucleo_g0b1re.dts
@@ -183,8 +183,6 @@ zephyr_udc0: &usb {
 		 <&rcc STM32_SRC_PLL_Q FDCAN_SEL(1)>;
 	pinctrl-0 = <&fdcan1_rx_pa11 &fdcan1_tx_pa12>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
 	status = "okay";
 };
 
@@ -193,8 +191,6 @@ zephyr_udc0: &usb {
 		 <&rcc STM32_SRC_PLL_Q FDCAN_SEL(1)>;
 	pinctrl-0 = <&fdcan2_rx_pb0 &fdcan2_tx_pb1>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
 	status = "okay";
 };
 

--- a/boards/st/nucleo_g474re/nucleo_g474re.dts
+++ b/boards/st/nucleo_g474re/nucleo_g474re.dts
@@ -223,8 +223,6 @@ stm32_lp_tick_source: &lptim1 {
 		 <&rcc STM32_SRC_HSE FDCAN_SEL(0)>;
 	pinctrl-0 = <&fdcan1_rx_pa11 &fdcan1_tx_pa12>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
 	status = "okay";
 };
 

--- a/boards/st/nucleo_h743zi/nucleo_h743zi.dts
+++ b/boards/st/nucleo_h743zi/nucleo_h743zi.dts
@@ -172,8 +172,6 @@ zephyr_udc0: &usbotg_fs {
 	pinctrl-names = "default";
 	clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000100>,
 		 <&rcc STM32_SRC_PLL1_Q FDCAN_SEL(1)>;
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
 	status = "okay";
 };
 

--- a/boards/st/nucleo_h753zi/nucleo_h753zi.dts
+++ b/boards/st/nucleo_h753zi/nucleo_h753zi.dts
@@ -149,8 +149,6 @@ zephyr_udc0: &usbotg_fs {
 &fdcan1 {
 	pinctrl-0 = <&fdcan1_rx_pd0 &fdcan1_tx_pd1>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
 	status = "okay";
 };
 

--- a/boards/st/nucleo_l432kc/nucleo_l432kc.dts
+++ b/boards/st/nucleo_l432kc/nucleo_l432kc.dts
@@ -99,7 +99,6 @@
 &can1 {
 	pinctrl-0 = <&can1_rx_pa11 &can1_tx_pa12>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
 	status = "okay";
 };
 

--- a/boards/st/nucleo_l433rc_p/nucleo_l433rc_p.dts
+++ b/boards/st/nucleo_l433rc_p/nucleo_l433rc_p.dts
@@ -118,7 +118,6 @@
 &can1 {
 	pinctrl-0 = <&can1_rx_pa11 &can1_tx_pa12>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
 	status = "okay";
 };
 

--- a/boards/st/nucleo_l452re/nucleo_l452re_common.dtsi
+++ b/boards/st/nucleo_l452re/nucleo_l452re_common.dtsi
@@ -102,7 +102,6 @@
 &can1 {
 	pinctrl-0 = <&can1_rx_pa11 &can1_tx_pa12>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
 	status = "okay";
 };
 

--- a/boards/st/nucleo_u575zi_q/nucleo_u575zi_q-common.dtsi
+++ b/boards/st/nucleo_u575zi_q/nucleo_u575zi_q-common.dtsi
@@ -183,8 +183,6 @@ zephyr_udc0: &usbotg_fs {
 		 <&rcc STM32_SRC_PLL1_Q FDCAN1_SEL(1)>;
 	pinctrl-0 = <&fdcan1_rx_pd0 &fdcan1_tx_pd1>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
 	status = "okay";
 };
 

--- a/boards/st/nucleo_u5a5zj_q/nucleo_u5a5zj_q-common.dtsi
+++ b/boards/st/nucleo_u5a5zj_q/nucleo_u5a5zj_q-common.dtsi
@@ -175,8 +175,6 @@
 		 <&rcc STM32_SRC_PLL1_Q FDCAN1_SEL(1)>;
 	pinctrl-0 = <&fdcan1_rx_pd0 &fdcan1_tx_pd1>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
 	status = "okay";
 };
 

--- a/boards/st/stm32f072b_disco/stm32f072b_disco.dts
+++ b/boards/st/stm32f072b_disco/stm32f072b_disco.dts
@@ -118,7 +118,6 @@
 &can1 {
 	pinctrl-0 = <&can_rx_pb8 &can_tx_pb9>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
 	status = "okay";
 };
 

--- a/boards/st/stm32f3_disco/stm32f3_disco.dts
+++ b/boards/st/stm32f3_disco/stm32f3_disco.dts
@@ -185,7 +185,6 @@ zephyr_udc0: &usb {
 	pinctrl-0 = <&can_rx_pd0 &can_tx_pd1>;
 	pinctrl-names = "default";
 	status = "okay";
-	bus-speed = <125000>;
 };
 
 &flash0 {

--- a/boards/st/stm32f4_disco/stm32f4_disco.dts
+++ b/boards/st/stm32f4_disco/stm32f4_disco.dts
@@ -129,13 +129,11 @@ zephyr_udc0: &usbotg_fs {
 &can1 {
 	pinctrl-0 = <&can1_rx_pb8 &can1_tx_pb9>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
 	status = "disabled";
 };
 
 &can2 {
 	pinctrl-0 = <&can2_rx_pb5 &can2_tx_pb13>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
 	status = "okay";
 };

--- a/boards/st/stm32h573i_dk/stm32h573i_dk.dts
+++ b/boards/st/stm32h573i_dk/stm32h573i_dk.dts
@@ -247,8 +247,6 @@
 		<&rcc STM32_SRC_PLL1_Q FDCAN_SEL(1)>;
 	pinctrl-0 = <&fdcan1_rx_pa11 &fdcan1_tx_pa12>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
 	status = "okay";
 };
 

--- a/boards/st/stm32h735g_disco/stm32h735g_disco.dts
+++ b/boards/st/stm32h735g_disco/stm32h735g_disco.dts
@@ -216,8 +216,6 @@
 	clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000100>,
 		 <&rcc STM32_SRC_PLL2_Q FDCAN_SEL(2)>;
 	status = "okay";
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
 
 	can-transceiver {
 		max-bitrate = <8000000>;
@@ -230,8 +228,6 @@
 	clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000100>,
 		 <&rcc STM32_SRC_PLL2_Q FDCAN_SEL(2)>;
 	status = "okay";
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
 
 	can-transceiver {
 		max-bitrate = <8000000>;
@@ -245,8 +241,6 @@
 		 <&rcc STM32_SRC_PLL2_Q FDCAN_SEL(2)>;
 	/* Solder bridges SB29 and SB30 need to be closed for this to work */
 	status = "disabled";
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
 
 	can-transceiver {
 		max-bitrate = <8000000>;

--- a/boards/st/stm32h745i_disco/stm32h745i_disco_stm32h745xx_m7.dts
+++ b/boards/st/stm32h745i_disco/stm32h745i_disco_stm32h745xx_m7.dts
@@ -214,8 +214,6 @@
 	status = "okay";
 	pinctrl-0 = <&fdcan1_tx_ph13 &fdcan1_rx_ph14>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
 	sample-point = <875>;
 	sample-point-data = <875>;
 	phys = <&transceiver0>;
@@ -225,8 +223,6 @@
 	status = "okay";
 	pinctrl-0 = <&fdcan2_tx_pb13 &fdcan2_rx_pb5>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
 	sample-point = <875>;
 	sample-point-data = <875>;
 	phys = <&transceiver1>;

--- a/boards/st/stm32h7b3i_dk/stm32h7b3i_dk.dts
+++ b/boards/st/stm32h7b3i_dk/stm32h7b3i_dk.dts
@@ -156,8 +156,6 @@
 	clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000100>,
 		 <&rcc STM32_SRC_PLL1_Q FDCAN_SEL(1)>;
 	phys = <&transceiver0>;
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
 	status = "okay";
 };
 

--- a/boards/waveshare/open103z/waveshare_open103z.dts
+++ b/boards/waveshare/open103z/waveshare_open103z.dts
@@ -156,7 +156,6 @@
 	 * reference: RM0008 rev20 page 205
 	 */
 	status = "disabled";
-	bus-speed = <125000>;
 };
 
 zephyr_udc0: &usb {

--- a/doc/hardware/porting/board_porting.rst
+++ b/doc/hardware/porting/board_porting.rst
@@ -488,7 +488,6 @@ controller and sets the bus speed:
 
    &can0 {
         status = "okay";
-        bus-speed = <125000>;
    };
 
 The ``&can0 { ... };`` syntax adds/overrides properties on the node with label

--- a/drivers/can/Kconfig
+++ b/drivers/can/Kconfig
@@ -23,6 +23,21 @@ config CAN_INIT_PRIORITY
 	help
 	  CAN driver device initialization priority.
 
+config CAN_DEFAULT_BITRATE
+	int "Default CAN bitrate"
+	default 125000
+	help
+	  Default initial CAN bitrate in bits/s. This can be overridden per CAN controller using the
+	  "bus-speed" devicetree property.
+
+config CAN_DEFAULT_BITRATE_DATA
+	int "Default CAN data phase bitrate"
+	default 1000000
+	depends on CAN_FD_MODE
+	help
+	  Default initial CAN data phase bitrate in bits/s. This can be overridden per CAN controller
+	  using the "bus-speed-data" devicetree property.
+
 config CAN_SHELL
 	bool "CAN shell"
 	depends on SHELL

--- a/dts/bindings/can/can-controller.yaml
+++ b/dts/bindings/can/can-controller.yaml
@@ -5,9 +5,9 @@ include: base.yaml
 properties:
   bus-speed:
     type: int
-    required: true
     description: |
-      Initial bitrate in bit/s.
+      Initial bitrate in bit/s. If this is unset, the initial bitrate is set to
+      CONFIG_CAN_DEFAULT_BITRATE.
   sample-point:
     type: int
     description: |

--- a/dts/bindings/can/can-fd-controller.yaml
+++ b/dts/bindings/can/can-fd-controller.yaml
@@ -5,9 +5,9 @@ include: can-controller.yaml
 properties:
   bus-speed-data:
     type: int
-    required: true
     description: |
-      Initial data phase bitrate in bit/s.
+      Initial data phase bitrate in bit/s.  If this is unset, the initial data phase bitrate is set
+      to CONFIG_CAN_DEFAULT_BITRATE_DATA.
   sample-point-data:
     type: int
     description: |

--- a/dts/bindings/can/microchip,mcp251xfd.yaml
+++ b/dts/bindings/can/microchip,mcp251xfd.yaml
@@ -19,8 +19,6 @@ description: |
           reg = <0x0>;
           osc-freq = <40000000>;
 
-          bus-speed = <125000>;
-          bus-speed-data = <1000000>;
       };
   };
 

--- a/dts/bindings/can/nxp,flexcan-fd.yaml
+++ b/dts/bindings/can/nxp,flexcan-fd.yaml
@@ -15,8 +15,6 @@ description: |
       interrupt-names = "common";
       clocks = <&ccm IMX_CCM_CAN_CLK 0x84 6>;
       clk-source = <2>;
-      bus-speed = <125000>;
-      bus-speed-data = <1000000>;
       pinctrl-0 = <&pinmux_flexcan3>;
       pinctrl-names = "default";
 

--- a/dts/bindings/can/nxp,flexcan.yaml
+++ b/dts/bindings/can/nxp,flexcan.yaml
@@ -13,7 +13,6 @@ description: |
       interrupt-names = "warning", "error", "wake-up", "mb-0-15";
       clocks = <&scg KINETIS_SCG_BUS_CLK>;
       clk-source = <1>;
-      bus-speed = <125000>;
       pinctrl-0 = <&pinmux_flexcan0>;
       pinctrl-names = "default";
 

--- a/dts/bindings/can/ti,tcan4x5x.yaml
+++ b/dts/bindings/can/ti,tcan4x5x.yaml
@@ -16,8 +16,6 @@ description: |
         reset-gpios = <&gpio0 2 GPIO_ACTIVE_HIGH>;
         int-gpios = <&gpio0 3 GPIO_ACTIVE_LOW>;
         bosch,mram-cfg = <0x0 15 15 5 5 0 10 10>;
-        bus-speed = <125000>;
-        bus-speed-data = <1000000>;
         status = "okay";
 
         can-transceiver {

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -374,10 +374,11 @@ struct can_driver_config {
 		.phy = DEVICE_DT_GET_OR_NULL(DT_PHANDLE(node_id, phys)),			\
 		.min_bitrate = DT_CAN_TRANSCEIVER_MIN_BITRATE(node_id, _min_bitrate),		\
 		.max_bitrate = DT_CAN_TRANSCEIVER_MAX_BITRATE(node_id, _max_bitrate),		\
-		.bus_speed = DT_PROP(node_id, bus_speed),					\
+		.bus_speed = DT_PROP_OR(node_id, bus_speed, CONFIG_CAN_DEFAULT_BITRATE),	\
 		.sample_point = DT_PROP_OR(node_id, sample_point, 0),				\
 		IF_ENABLED(CONFIG_CAN_FD_MODE,							\
-			(.bus_speed_data = DT_PROP_OR(node_id, bus_speed_data, 0),		\
+			(.bus_speed_data = DT_PROP_OR(node_id, bus_speed_data,			\
+						      CONFIG_CAN_DEFAULT_BITRATE_DATA),		\
 			 .sample_point_data = DT_PROP_OR(node_id, sample_point_data, 0),))	\
 	}
 

--- a/samples/modules/canopennode/src/main.c
+++ b/samples/modules/canopennode/src/main.c
@@ -15,7 +15,8 @@
 LOG_MODULE_REGISTER(app);
 
 #define CAN_INTERFACE DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus))
-#define CAN_BITRATE (DT_PROP(DT_CHOSEN(zephyr_canbus), bus_speed) / 1000)
+#define CAN_BITRATE (DT_PROP_OR(DT_CHOSEN(zephyr_canbus), bus_speed, \
+				CONFIG_CAN_DEFAULT_BITRATE) / 1000)
 
 static struct gpio_dt_spec led_green_gpio = GPIO_DT_SPEC_GET_OR(
 		DT_ALIAS(green_led), gpios, {0});

--- a/tests/drivers/can/api/twai-enable.overlay
+++ b/tests/drivers/can/api/twai-enable.overlay
@@ -9,7 +9,6 @@
 	status = "okay";
 	pinctrl-0 = <&twai_default>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
 
 	can-transceiver {
 		max-bitrate = <1000000>;

--- a/tests/drivers/can/shell/app.overlay
+++ b/tests/drivers/can/shell/app.overlay
@@ -8,7 +8,5 @@
 	fake_can: fake_can {
 		compatible = "zephyr,fake-can";
 		status = "okay";
-		bus-speed = <125000>;
-		bus-speed-data = <1000000>;
 	};
 };

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -528,7 +528,6 @@
 		test_can0: can@55553333 {
 			compatible = "vnd,can-controller";
 			reg = < 0x55553333 0x1000 >;
-			bus-speed = <125000>;
 			status = "okay";
 			phys = <&test_transceiver0>;
 		};
@@ -536,7 +535,6 @@
 		test_can1: can@55554444 {
 			compatible = "vnd,can-controller";
 			reg = < 0x55554444 0x1000 >;
-			bus-speed = <125000>;
 			status = "okay";
 
 			can-transceiver {
@@ -548,7 +546,6 @@
 		test_can2: can@55555555 {
 			compatible = "vnd,can-controller";
 			reg = < 0x55555555 0x1000 >;
-			bus-speed = <125000>;
 			status = "okay";
 
 			can-transceiver {
@@ -559,7 +556,6 @@
 		test_can3: can@55557777 {
 			compatible = "vnd,can-controller";
 			reg = < 0x55556666 0x1000 >;
-			bus-speed = <125000>;
 			status = "okay";
 			phys = <&test_transceiver1>;
 		};


### PR DESCRIPTION
- Set the default initial bitrates globally via Kconfig. The initial bitrates can still be overridden using the "bus-speed" and "bus-speed-data" devicetree properties.
- Remove all CAN controller "bus-speed" and "bus-speed-data" properties. These all use the default bitrates set via Kconfig.