### PR TITLE
samples: ipc: rpmsg_service: Add support for stm32h747i_disco

### DIFF
--- a/samples/subsys/ipc/rpmsg_service/Kconfig.sysbuild
+++ b/samples/subsys/ipc/rpmsg_service/Kconfig.sysbuild
@@ -8,3 +8,4 @@ config RPMSG_REMOTE_BOARD
 	string
 	default "mps2/an521/cpu1" if $(BOARD) = "mps2"
 	default "v2m_musca_b1/musca_b1/ns" if $(BOARD) = "v2m_musca_b1"
+	default "stm32h747i_disco/stm32h747xx/m4" if $(BOARD) = "stm32h747i_disco"

--- a/samples/subsys/ipc/rpmsg_service/README.rst
+++ b/samples/subsys/ipc/rpmsg_service/README.rst
@@ -128,3 +128,26 @@ remote) will appear on the corresponding serial ports:
    ...
    Remote core received a message: 98
    RPMsg Service demo ended.
+
+Building the application for stm32h747i_disco/stm32h7xx
+*******************************************************
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/subsys/ipc/rpmsg_service
+   :board: stm32h747i_disco/stm32h7xx/m7
+   :goals: debug
+
+The serial output should now look like this:
+
+.. code-block:: console
+
+    *** Booting Zephyr OS build 15736b7415be ***
+    Starting application thread!
+
+    RPMsg Service [master] demo started
+    Master core received a message: 1
+    Master core received a message: 3
+    Master core received a message: 5
+    ...
+    Master core received a message: 99
+    RPMsg Service demo ended.

--- a/samples/subsys/ipc/rpmsg_service/boards/stm32h747i_disco_stm32h747xx_m7.overlay
+++ b/samples/subsys/ipc/rpmsg_service/boards/stm32h747i_disco_stm32h747xx_m7.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2024 Celina Sophie Kalus <hello@celinakalus.de>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,ipc_shm = &sram4;
+		zephyr,ipc = &mailbox;
+	};
+};
+
+&mailbox {
+	status = "okay";
+};

--- a/samples/subsys/ipc/rpmsg_service/remote/boards/stm32h747i_disco_stm32h747xx_m4.overlay
+++ b/samples/subsys/ipc/rpmsg_service/remote/boards/stm32h747i_disco_stm32h747xx_m4.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2024 Celina Sophie Kalus <hello@celinakalus.de>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,ipc_shm = &sram4;
+		zephyr,ipc = &mailbox;
+	};
+};
+
+&mailbox {
+	status = "okay";
+};


### PR DESCRIPTION
With the changes made in pull request #68741, RPMsg service is supported on stm32h747i_disco using the STM32 HSEM IPM driver. For the sample to work, add device tree overlays to enable the mailbox and set the shared memory appropriately.