### PR TITLE
Bluetooth: Controller: Fix BT_CTLR_BROADCAST_ISO and BT_CTLR_PRIVACY dependencies

### DIFF
--- a/subsys/bluetooth/controller/CMakeLists.txt
+++ b/subsys/bluetooth/controller/CMakeLists.txt
@@ -172,7 +172,7 @@ zephyr_library_include_directories(
   )
 
 zephyr_library_include_directories_ifdef(
-  CONFIG_BT_CTLR_CRYPTO
+  CONFIG_BT_CRYPTO
   ../crypto
   )
 

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -547,6 +547,7 @@ config BT_CTLR_PRIVACY
 	bool "LE Controller-based Privacy"
 	depends on BT_CTLR_PRIVACY_SUPPORT
 	select BT_CTLR_FILTER_ACCEPT_LIST if BT_LL_SW_SPLIT
+	select BT_CTLR_CRYPTO if BT_LL_SW_SPLIT
 	select BT_RPA
 	default y if BT_HCI_RAW || BT_SMP
 	help


### PR DESCRIPTION
Explicit select of BT_CTLR_CRYPTO to support BT_CTLR_PRIVACY.
As privacy feature in the Controller needs random numbers
and AES encryption support.

Fix typo in conditional include path, to include Host
crypto implementation required for encrypted Broadcast ISO.