### PR TITLE
maintainers: move cmsis-dsp and cmsis-nn label to be more specific

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4143,7 +4143,7 @@ West:
   files:
     - modules/cmsis-dsp/
   labels:
-    - "area: ARM"
+    - "area: CMSIS-DSP"
 
 "West project: cmsis-nn":
   status: maintained
@@ -4154,7 +4154,7 @@ West:
   files:
     - modules/cmsis-nn/
   labels:
-    - "area: ARM"
+    - "area: CMSIS-NN"
 
 "West project: edtt":
   status: maintained


### PR DESCRIPTION
Each of them have a matching area so lets use that rather than the catch-all "area: ARM" label.

cc @stephanosio 