### PR TITLE
Native boards defconfig fixes

### DIFF
--- a/boards/native/native_posix/Kconfig.defconfig
+++ b/boards/native/native_posix/Kconfig.defconfig
@@ -27,16 +27,6 @@ choice BT_HCI_BUS_TYPE
 	depends on BT_HCI
 endchoice
 
-if LOG
-
-# For native_posix we can log synchronously without any problem
-# Doing so will be nicer for debugging
-choice LOG_MODE
-	default LOG_MODE_IMMEDIATE
-endchoice
-
-endif # LOG
-
 if CONSOLE
 
 config POSIX_ARCH_CONSOLE

--- a/boards/native/native_posix/Kconfig.defconfig
+++ b/boards/native/native_posix/Kconfig.defconfig
@@ -37,10 +37,6 @@ config UART_CONSOLE
 
 endif # CONSOLE
 
-config USB_NATIVE_POSIX
-	default y
-	depends on USB_DEVICE_DRIVER
-
 if I2C
 
 config EMUL

--- a/boards/native/native_posix/Kconfig.defconfig
+++ b/boards/native/native_posix/Kconfig.defconfig
@@ -47,10 +47,6 @@ config UART_CONSOLE
 
 endif # CONSOLE
 
-config FLASH_SIMULATOR
-	default y
-	depends on FLASH
-
 config USB_NATIVE_POSIX
 	default y
 	depends on USB_DEVICE_DRIVER

--- a/boards/native/native_posix/Kconfig.defconfig
+++ b/boards/native/native_posix/Kconfig.defconfig
@@ -51,10 +51,6 @@ config USB_NATIVE_POSIX
 	default y
 	depends on USB_DEVICE_DRIVER
 
-config EEPROM_SIMULATOR
-	default y
-	depends on EEPROM
-
 if I2C
 
 config EMUL

--- a/boards/native/native_sim/Kconfig.defconfig
+++ b/boards/native/native_sim/Kconfig.defconfig
@@ -37,10 +37,6 @@ config UART_CONSOLE
 
 endif # CONSOLE
 
-config USB_NATIVE_POSIX
-	default y
-	depends on USB_DEVICE_DRIVER
-
 if I2C
 
 config EMUL

--- a/boards/native/native_sim/Kconfig.defconfig
+++ b/boards/native/native_sim/Kconfig.defconfig
@@ -47,10 +47,6 @@ config UART_CONSOLE
 
 endif # CONSOLE
 
-config FLASH_SIMULATOR
-	default y
-	depends on FLASH
-
 config USB_NATIVE_POSIX
 	default y
 	depends on USB_DEVICE_DRIVER

--- a/boards/native/native_sim/Kconfig.defconfig
+++ b/boards/native/native_sim/Kconfig.defconfig
@@ -51,10 +51,6 @@ config USB_NATIVE_POSIX
 	default y
 	depends on USB_DEVICE_DRIVER
 
-config EEPROM_SIMULATOR
-	default y
-	depends on EEPROM
-
 if I2C
 
 config EMUL

--- a/boards/native/native_sim/Kconfig.defconfig
+++ b/boards/native/native_sim/Kconfig.defconfig
@@ -27,16 +27,6 @@ choice BT_HCI_BUS_TYPE
 	depends on BT_HCI
 endchoice
 
-if LOG
-
-# For native_sim we can log synchronously without any problem
-# Doing so will be nicer for debugging
-choice LOG_MODE
-	default LOG_MODE_IMMEDIATE
-endchoice
-
-endif # LOG
-
 if CONSOLE
 
 config POSIX_ARCH_CONSOLE

--- a/boards/native/nrf_bsim/Kconfig.defconfig
+++ b/boards/native/nrf_bsim/Kconfig.defconfig
@@ -70,16 +70,6 @@ endif # BOARD_NRF5340BSIM_NRF5340_CPUAPP
 config NRF_802154_ENCRYPTION
 	default n
 
-if LOG
-
-# For this board we can log synchronously without any problem
-# Doing so will be nicer for debugging
-choice LOG_MODE
-	default LOG_MODE_IMMEDIATE
-endchoice
-
-endif # LOG
-
 if CONSOLE
 
 config POSIX_ARCH_CONSOLE

--- a/drivers/usb/device/Kconfig
+++ b/drivers/usb/device/Kconfig
@@ -225,6 +225,7 @@ endif # USB_DC_NUMAKER
 config USB_NATIVE_POSIX
 	bool "Native Posix USB Device Controller Driver"
 	depends on ARCH_POSIX && EXTERNAL_LIBC
+	default y if BOARD_NATIVE_SIM || BOARD_NATIVE_POSIX
 	help
 	  Native Posix USB Device Controller Driver.
 

--- a/subsys/logging/Kconfig.mode
+++ b/subsys/logging/Kconfig.mode
@@ -4,6 +4,7 @@
 choice LOG_MODE
 	prompt "Mode"
 	depends on !LOG_FRONTEND_ONLY
+	default LOG_MODE_IMMEDIATE if ARCH_POSIX
 	default LOG_MODE_MINIMAL if LOG_DEFAULT_MINIMAL
 	default LOG_MODE_DEFERRED
 


### PR DESCRIPTION
Do not redefine EEPROM_SIMULATOR, FLASH_SIMULATOR, LOG_MODE & USB_NATIVE_POSIX in the boards Kconfig.defconfig

Setting a default in a board Kconfig.defconfig effectively is providing another definition of the option, which "ORs" the dependencies. If those dependencies are not properly duplicated they are in practice bypassed.

So let's not define in these boards Kconfig.defconfig options which we do not need to define, specially if their dependencies have already diverged.
