### PR TITLE
samples shell_module: Avoid setting incompatible options

### DIFF
--- a/samples/subsys/shell/shell_module/overlay-usb.conf
+++ b/samples/subsys/shell/shell_module/overlay-usb.conf
@@ -4,3 +4,9 @@ CONFIG_SHELL_BACKEND_SERIAL_CHECK_DTR=y
 CONFIG_UART_LINE_CTRL=y
 CONFIG_SHELL_BACKEND_SERIAL_INIT_PRIORITY=51
 CONFIG_USB_DEVICE_INITIALIZE_AT_BOOT=n
+
+# POSIX_CLOCK requires an embedded C library while the native USB driver is incompatible with it.
+# So let's disable it. Once USB_NATIVE_POSIX supports embedded C libraries this can be removed.
+CONFIG_POSIX_CLOCK=n
+# DATE_SHELL requires POSIX_CLOCK
+CONFIG_DATE_SHELL=n


### PR DESCRIPTION
Currently the USB configuration of this sample is selecting POSIX_CLOCK and being built by default with USB_NATIVE_POSIX. This combination is currently not possible due to mutually exclusive dependencies (the host C library) which results in a configuration warning and POSIX_CLOCK being forced to 'n'.
Let's instead disable POSIX_CLOCK in this sample USB config overlay, until the USB native driver supports building with embedded C libraries.

As is, this avoid a warning in main for this sample for the integration target (native_sim).
It is also meant to allow fixing, in a follow up PR, some kconfig dependencies around the POSIX subsystem which today result in incompatible combination being selected and cause confusion to users.