### PR TITLE
ci: revert: fix broken microsoft repo

### DIFF
--- a/.github/workflows/coding_guidelines.yml
+++ b/.github/workflows/coding_guidelines.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Install Packages
       run: |
-        sudo apt-get update || true
+        sudo apt-get update
         sudo apt-get install coccinelle
 
     - name: Run Coding Guildeines Checks

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -73,7 +73,7 @@ jobs:
 
     - name: install-pkgs
       run: |
-        sudo apt-get update || true
+        sudo apt-get update
         sudo apt-get install -y wget python3-pip git ninja-build graphviz lcov
         wget --no-verbose "https://github.com/doxygen/doxygen/releases/download/Release_${DOXYGEN_VERSION//./_}/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz"
         sudo tar xf doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz -C /opt

--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Install packages
         run: |
-          sudo apt-get update || true
+          sudo apt-get update
           sudo apt-get install -y python3-venv
           sudo pip3 install -U setuptools wheel pip gitpython
 

--- a/.github/workflows/issue_count.yml
+++ b/.github/workflows/issue_count.yml
@@ -24,7 +24,7 @@ jobs:
 
     - name: install-packages
       run: |
-        sudo apt-get update || true
+        sudo apt-get update
         sudo apt-get install discount
 
     - uses: brcrista/summarize-issues@v3


### PR DESCRIPTION
Reverts zephyrproject-rtos/zephyr#71864

https://github.com/microsoft/linux-package-repositories/issues/130

A repo from microsoft was not available, that lead to ci
actions failing. This hat been fixed, so this workaround
is no longer needed.