### PR TITLE
devicetree: implement `DT_INST_NODE_HAS_COMPAT`

### DIFF
--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -1377,7 +1377,7 @@ static const struct can_driver_api mcux_flexcan_fd_driver_api = {
 
 #ifdef CONFIG_CAN_MCUX_FLEXCAN_FD
 #define FLEXCAN_MAX_BITRATE(id)							\
-	COND_CODE_1(DT_NODE_HAS_COMPAT(DT_DRV_INST(id), FLEXCAN_FD_DRV_COMPAT),	\
+	COND_CODE_1(DT_INST_NODE_HAS_COMPAT(id, FLEXCAN_FD_DRV_COMPAT),		\
 		    (8000000), (1000000))
 #else /* CONFIG_CAN_MCUX_FLEXCAN_FD */
 #define FLEXCAN_MAX_BITRATE(id) 1000000
@@ -1385,7 +1385,7 @@ static const struct can_driver_api mcux_flexcan_fd_driver_api = {
 
 #ifdef CONFIG_CAN_MCUX_FLEXCAN_FD
 #define FLEXCAN_DRIVER_API(id)							\
-	COND_CODE_1(DT_NODE_HAS_COMPAT(DT_DRV_INST(id), FLEXCAN_FD_DRV_COMPAT),	\
+	COND_CODE_1(DT_INST_NODE_HAS_COMPAT(id, FLEXCAN_FD_DRV_COMPAT),		\
 		    (mcux_flexcan_fd_driver_api),				\
 		    (mcux_flexcan_driver_api))
 #else /* CONFIG_CAN_MCUX_FLEXCAN_FD */
@@ -1407,7 +1407,7 @@ static const struct can_driver_api mcux_flexcan_fd_driver_api = {
 			DT_INST_CLOCKS_CELL(id, name),			\
 		.clk_source = DT_INST_PROP(id, clk_source),		\
 		IF_ENABLED(CONFIG_CAN_MCUX_FLEXCAN_FD, (		\
-			.flexcan_fd = DT_NODE_HAS_COMPAT(DT_DRV_INST(id), FLEXCAN_FD_DRV_COMPAT), \
+			.flexcan_fd = DT_INST_NODE_HAS_COMPAT(id, FLEXCAN_FD_DRV_COMPAT), \
 		))							\
 		.irq_config_func = mcux_flexcan_irq_config_##id,	\
 		.irq_enable_func = mcux_flexcan_irq_enable_##id,	\

--- a/drivers/i2c/i2c_xilinx_axi.c
+++ b/drivers/i2c/i2c_xilinx_axi.c
@@ -629,7 +629,7 @@ static const struct i2c_driver_api i2c_xilinx_axi_driver_api = {
 	static const struct i2c_xilinx_axi_config i2c_xilinx_axi_config_##compat##_##n = {         \
 		.base = DT_INST_REG_ADDR(n),                                                       \
 		.irq_config_func = i2c_xilinx_axi_config_func_##compat##_##n,                      \
-		.dyn_read_working = DT_NODE_HAS_COMPAT(DT_DRV_INST(n), xlnx_xps_iic_2_1)};         \
+		.dyn_read_working = DT_INST_NODE_HAS_COMPAT(n, xlnx_xps_iic_2_1)};                 \
                                                                                                    \
 	static struct i2c_xilinx_axi_data i2c_xilinx_axi_data_##compat##_##n;                      \
                                                                                                    \

--- a/drivers/sensor/bosch/bmi270/bmi270.c
+++ b/drivers/sensor/bosch/bmi270/bmi270.c
@@ -793,7 +793,7 @@ static const struct bmi270_feature_config bmi270_feature_base = {
 };
 
 #define BMI270_FEATURE(inst) (						\
-	DT_NODE_HAS_COMPAT(DT_DRV_INST(inst), bosch_bmi270_base) ?	\
+	DT_INST_NODE_HAS_COMPAT(inst, bosch_bmi270_base) ?	        \
 		&bmi270_feature_base :					\
 		&bmi270_feature_max_fifo)
 

--- a/drivers/sensor/st/lis2dh/lis2dh.c
+++ b/drivers/sensor/st/lis2dh/lis2dh.c
@@ -500,7 +500,7 @@ static int lis2dh_pm_action(const struct device *dev,
 			    &lis2dh_driver_api);
 
 #define IS_LSM303AGR_DEV(inst) \
-	DT_NODE_HAS_COMPAT(DT_DRV_INST(inst), st_lsm303agr_accel)
+	DT_INST_NODE_HAS_COMPAT(inst, st_lsm303agr_accel)
 
 #define DISC_PULL_UP(inst) \
 	DT_INST_PROP(inst, disconnect_sdo_sa0_pull_up)
@@ -545,8 +545,8 @@ static int lis2dh_pm_action(const struct device *dev,
  * compat(lis2dh) cannot be used here because it is the base part.
  */
 #define FRACTIONAL_BITS(inst)	\
-	(DT_NODE_HAS_COMPAT(DT_DRV_INST(inst), st_lis2dh12) ||				\
-	 DT_NODE_HAS_COMPAT(DT_DRV_INST(inst), st_lis3dh)) ?				\
+	(DT_INST_NODE_HAS_COMPAT(inst, st_lis2dh12) ||				\
+	 DT_INST_NODE_HAS_COMPAT(inst, st_lis3dh)) ?				\
 		      (IS_ENABLED(CONFIG_LIS2DH_OPER_MODE_LOW_POWER) ? 0 : 2) : \
 		      0
 

--- a/drivers/sensor/st/lps2xdf/lps2xdf.c
+++ b/drivers/sensor/st/lps2xdf/lps2xdf.c
@@ -159,7 +159,7 @@ static const struct sensor_driver_api lps2xdf_driver_api = {
 	.lpf = DT_INST_PROP(inst, lpf),                                        \
 	.avg = DT_INST_PROP(inst, avg),                                        \
 	.chip_api = &name##_chip_api,                                          \
-	IF_ENABLED(DT_NODE_HAS_COMPAT(DT_DRV_INST(inst), st_lps28dfw),         \
+	IF_ENABLED(DT_INST_NODE_HAS_COMPAT(inst, st_lps28dfw),                 \
 		   (.fs = DT_INST_PROP(inst, fs),))                            \
 	IF_ENABLED(DT_INST_NODE_HAS_PROP(inst, drdy_gpios),                    \
 		   (LPS2XDF_CFG_IRQ(inst)))

--- a/drivers/sensor/st/lsm6dso/lsm6dso.c
+++ b/drivers/sensor/st/lsm6dso/lsm6dso.c
@@ -909,7 +909,7 @@ static int lsm6dso_init(const struct device *dev)
 	.accel_pm = DT_INST_PROP(inst, accel_pm),			\
 	.accel_odr = DT_INST_PROP(inst, accel_odr),			\
 	.accel_range = DT_INST_PROP(inst, accel_range) |		\
-		(DT_NODE_HAS_COMPAT(DT_DRV_INST(inst), st_lsm6dso32) ?	\
+		(DT_INST_NODE_HAS_COMPAT(inst, st_lsm6dso32) ?	        \
 			ACCEL_RANGE_DOUBLE : 0),			\
 	.gyro_pm = DT_INST_PROP(inst, gyro_pm),				\
 	.gyro_odr = DT_INST_PROP(inst, gyro_odr),			\

--- a/drivers/serial/uart_rcar.c
+++ b/drivers/serial/uart_rcar.c
@@ -550,7 +550,7 @@ static const struct uart_driver_api uart_rcar_driver_api = {
 		.bus_clk.module = DT_INST_CLOCKS_CELL_BY_IDX(n, 1, module),		\
 		.bus_clk.domain = DT_INST_CLOCKS_CELL_BY_IDX(n, 1, domain),		\
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),				\
-		.is_hscif = DT_NODE_HAS_COMPAT(DT_DRV_INST(n), renesas_rcar_hscif),	\
+		.is_hscif = DT_INST_NODE_HAS_COMPAT(n, renesas_rcar_hscif),	        \
 		IRQ_FUNC_INIT								\
 	}
 

--- a/drivers/usb/device/usb_dc_dw.c
+++ b/drivers/usb/device/usb_dc_dw.c
@@ -128,12 +128,12 @@ static int usb_dw_init_pinctrl(const struct usb_dw_config *const config)
 #define USB_DW_GET_COMPAT_QUIRK_NONE(n)	NULL
 
 #define USB_DW_GET_COMPAT_CLK_QUIRK_0(n)					\
-	COND_CODE_1(DT_NODE_HAS_COMPAT(DT_DRV_INST(n), st_stm32f4_fsotg),	\
+	COND_CODE_1(DT_INST_NODE_HAS_COMPAT(n, st_stm32f4_fsotg),		\
 		    (clk_enable_st_stm32f4_fsotg_##n),				\
 		    USB_DW_GET_COMPAT_QUIRK_NONE(n))
 
 #define USB_DW_GET_COMPAT_PWR_QUIRK_0(n)					\
-	COND_CODE_1(DT_NODE_HAS_COMPAT(DT_DRV_INST(n), st_stm32f4_fsotg),	\
+	COND_CODE_1(DT_INST_NODE_HAS_COMPAT(n, st_stm32f4_fsotg),		\
 		    (pwr_on_st_stm32f4_fsotg),					\
 		    USB_DW_GET_COMPAT_QUIRK_NONE(n))
 

--- a/drivers/usb/device/usb_dc_dw_stm32.h
+++ b/drivers/usb/device/usb_dc_dw_stm32.h
@@ -74,7 +74,7 @@ static inline int pwr_on_st_stm32f4_fsotg(struct usb_dwc2_reg *const base)
 	}
 
 #define USB_DW_QUIRK_ST_STM32F4_FSOTG_DEFINE(n)					\
-	COND_CODE_1(DT_NODE_HAS_COMPAT(DT_DRV_INST(n), st_stm32f4_fsotg),	\
+	COND_CODE_1(DT_INST_NODE_HAS_COMPAT(n, st_stm32f4_fsotg),		\
 		    (QUIRK_ST_STM32F4_FSOTG_DEFINE(n)), ())
 
 #endif /* ZEPHYR_DRIVERS_USB_DEVICE_USB_DC_DW_STM32_H */

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -4358,6 +4358,15 @@
 	DT_NODE_HAS_PROP(DT_DRV_INST(inst), prop)
 
 /**
+ * @brief Does a DT_DRV_COMPAT instance have the compatible?
+ * @param inst instance number
+ * @param compat lowercase-and-underscores compatible, without quotes
+ * @return 1 if the instance matches the compatible, 0 otherwise.
+ */
+#define DT_INST_NODE_HAS_COMPAT(inst, compat) \
+	DT_NODE_HAS_COMPAT(DT_DRV_INST(inst), compat)
+
+/**
  * @brief Does a phandle array have a named cell specifier at an index
  *        for a `DT_DRV_COMPAT` instance?
  * @param inst instance number

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -319,6 +319,10 @@ ZTEST(devicetree_api, test_has_compat)
 		   (TA_HAS_COMPAT(vnd_undefined_compat) << 1) |
 		   (TA_HAS_COMPAT(vnd_not_a_test_array_compat) << 2));
 	zassert_equal(compats, 0x3, "");
+
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT vnd_model1
+	zassert_true(DT_INST_NODE_HAS_COMPAT(0, zephyr_model2));
 }
 
 ZTEST(devicetree_api, test_has_status)


### PR DESCRIPTION
Implement `DT_INST_NODE_HAS_COMPAT` to check if a node has a compatible. This is helpful when a node has more than one compatible, which can be used to enable additional features in the driver.

Updated the devicetree test to play with the new API, and updated existing drivers to use the new API.