### PR TITLE
include: sys: util: implement `NUM_VA_ARGS`

### DIFF
--- a/include/zephyr/sys/util_macro.h
+++ b/include/zephyr/sys/util_macro.h
@@ -636,6 +636,17 @@ extern "C" {
 	10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, ~)
 
 /**
+ * @brief Number of arguments in the variable arguments list.
+ *
+ * @note Supports up to 63 arguments.
+ *
+ * @param ... List of arguments
+ * @return  Number of variadic arguments in the argument list
+ */
+#define NUM_VA_ARGS(...)                                                                           \
+	COND_CODE_1(IS_EMPTY(__VA_ARGS__), (0), (UTIL_INC(NUM_VA_ARGS_LESS_1(__VA_ARGS__))))
+
+/**
  * @brief Mapping macro that pastes results together
  *
  * This is similar to FOR_EACH() in that it invokes a macro repeatedly

--- a/include/zephyr/sys/util_macro.h
+++ b/include/zephyr/sys/util_macro.h
@@ -623,6 +623,8 @@ extern "C" {
 /**
  * @brief Number of arguments in the variable arguments list minus one.
  *
+ * @note Supports up to 64 arguments.
+ *
  * @param ... List of arguments
  * @return  Number of variadic arguments in the argument list, minus one
  */

--- a/tests/lib/sys_util/src/main.c
+++ b/tests/lib/sys_util/src/main.c
@@ -52,6 +52,21 @@ ZTEST(sys_util, test_NUM_VA_ARGS)
 	/* support up to 63 args */
 	zassert_equal(63, NUM_VA_ARGS(LISTIFY(63, ~, (,))));
 }
+
+/**
+ * @brief Test NUM_VA_ARGS_LESS_1 works as expected with typical use cases
+ *
+ * @see NUM_VA_ARGS_LESS_1()
+ */
+
+ZTEST(sys_util, test_NUM_VA_ARGS_LESS_1)
+{
+	zassert_equal(0, NUM_VA_ARGS_LESS_1());
+	zassert_equal(0, NUM_VA_ARGS_LESS_1(_1));
+	zassert_equal(1, NUM_VA_ARGS_LESS_1(_1, _2));
+	/* support up to 64 args */
+	zassert_equal(63, NUM_VA_ARGS_LESS_1(LISTIFY(64, ~, (,))));
+}
 /**
  * @}
  */

--- a/tests/lib/sys_util/src/main.c
+++ b/tests/lib/sys_util/src/main.c
@@ -37,6 +37,21 @@ ZTEST(sys_util, test_wait_for)
 	end = k_cycle_get_32();
 	zassert_true(end-start >= expected, "wait for 1ms");
 }
+
+/**
+ * @brief Test NUM_VA_ARGS works as expected with typical use cases
+ *
+ * @see NUM_VA_ARGS()
+ */
+
+ZTEST(sys_util, test_NUM_VA_ARGS)
+{
+	zassert_equal(0, NUM_VA_ARGS());
+	zassert_equal(1, NUM_VA_ARGS(_1));
+	zassert_equal(2, NUM_VA_ARGS(_1, _2));
+	/* support up to 63 args */
+	zassert_equal(63, NUM_VA_ARGS(LISTIFY(63, ~, (,))));
+}
 /**
  * @}
  */


### PR DESCRIPTION
This macro count the number of arguments in the variable arguments list.

Added test for it in `tests/lib/sys_util`.

[Doc preview](https://builds.zephyrproject.io/zephyr/pr/71890/docs/kernel/util/index.html#c.NUM_VA_ARGS_LESS_1)