### PR TITLE
xtensa: mmu: Avoid unnecessary mapping

### DIFF
--- a/arch/xtensa/core/ptables.c
+++ b/arch/xtensa/core/ptables.c
@@ -737,7 +737,8 @@ static uint32_t *dup_table(uint32_t *source_table)
 	for (i = 0; i < XTENSA_L1_PAGE_TABLE_ENTRIES; i++) {
 		uint32_t *l2_table, *src_l2_table;
 
-		if (is_pte_illegal(source_table[i])) {
+		if (is_pte_illegal(source_table[i]) ||
+			(i == XTENSA_MMU_L1_POS(XTENSA_MMU_PTEVADDR))) {
 			dst_table[i] = XTENSA_MMU_PTE_ILLEGAL;
 			continue;
 		}


### PR DESCRIPTION
When duplicating a page table, we don't need to copy the mapping to the kernel l1 page table virtual address.