### PR TITLE
cmake: kconfig: llvm: arm64: Add baseline clang/llvm support for arm64/aarch64

### DIFF
--- a/cmake/compiler/clang/target.cmake
+++ b/cmake/compiler/clang/target.cmake
@@ -31,6 +31,8 @@ if(NOT "${ARCH}" STREQUAL "posix")
       )
 
     include(${ZEPHYR_BASE}/cmake/compiler/clang/target_arm.cmake)
+  elseif("${ARCH}" STREQUAL "arm64")
+    include(${ZEPHYR_BASE}/cmake/compiler/clang/target_arm64.cmake)
   elseif("${ARCH}" STREQUAL "riscv")
     include(${ZEPHYR_BASE}/cmake/compiler/gcc/target_riscv.cmake)
   endif()

--- a/cmake/compiler/clang/target_arm64.cmake
+++ b/cmake/compiler/clang/target_arm64.cmake
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+if(DEFINED GCC_M_CPU)
+  list(APPEND TOOLCHAIN_C_FLAGS   -mcpu=${GCC_M_CPU})
+  list(APPEND TOOLCHAIN_LD_FLAGS  -mcpu=${GCC_M_CPU})
+endif()
+
+if(DEFINED GCC_M_ARCH)
+  list(APPEND TOOLCHAIN_C_FLAGS   -march=${GCC_M_ARCH})
+  list(APPEND TOOLCHAIN_LD_FLAGS  -march=${GCC_M_ARCH})
+endif()
+
+if(DEFINED GCC_M_TUNE)
+  list(APPEND TOOLCHAIN_C_FLAGS   -mtune=${GCC_M_TUNE})
+  list(APPEND TOOLCHAIN_LD_FLAGS  -mtune=${GCC_M_TUNE})
+endif()

--- a/cmake/toolchain/llvm/Kconfig
+++ b/cmake/toolchain/llvm/Kconfig
@@ -19,7 +19,7 @@ config LLVM_USE_LLD
 endchoice
 
 config TOOLCHAIN_LLVM_SUPPORTS_THREAD_LOCAL_STORAGE
-	depends on RISCV || ARM
+	depends on RISCV || ARM || ARM64
 	def_bool y
 	select TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE
 

--- a/cmake/toolchain/llvm/target.cmake
+++ b/cmake/toolchain/llvm/target.cmake
@@ -25,6 +25,8 @@ if("${ARCH}" STREQUAL "arm")
     # Default ARM target supported by all processors.
     set(triple arm-none-eabi)
   endif()
+elseif("${ARCH}" STREQUAL "arm64")
+  set(triple aarch64-none-elf)
 elseif("${ARCH}" STREQUAL "x86")
   if(CONFIG_64BIT)
     set(triple x86_64-pc-none-elf)


### PR DESCRIPTION
This patch aims to establish a baseline level of support for building with clang/LLVM when targeting aarch64/arm64 by:

1. Making sure clang's --target flag and the -mcpu/-mtune/-mfpu flags are set appropriately when targeting aarch64/arm64
2. Allowing TLS to be configured when building with clang/llvm as TLS seems to be well supported for aarch64 in clang/lld

Currently, when trying to target arm64/aarch64 with clang in Zephyr I see errors along the lines of `error: invalid instruction mnemonic 'mrs'` due to the default target in my clang not being aarch64 (and `--target` not having been set, etc.).