### PR TITLE
drivers: uart_mcux_lpuart: Fix issues with different UART APIs breaking each other

### DIFF
--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -310,7 +310,6 @@ static void mcux_lpuart_irq_rx_enable(const struct device *dev)
 	uint32_t mask = kLPUART_RxDataRegFullInterruptEnable;
 
 	LPUART_EnableInterrupts(config->base, mask);
-	LPUART_EnableRx(config->base, true);
 }
 
 static void mcux_lpuart_irq_rx_disable(const struct device *dev)
@@ -318,7 +317,6 @@ static void mcux_lpuart_irq_rx_disable(const struct device *dev)
 	const struct mcux_lpuart_config *config = dev->config;
 	uint32_t mask = kLPUART_RxDataRegFullInterruptEnable;
 
-	LPUART_EnableRx(config->base, false);
 	LPUART_DisableInterrupts(config->base, mask);
 }
 


### PR DESCRIPTION
This reverts commit https://github.com/zephyrproject-rtos/zephyr/commit/a80fa5163bb162f12614dc792aa17016c0fa1ac6
```
That commit broke the polling API when used with the interrupt driven,
it is completely wrong to disable the receiver from irq_rx_disable,
the uart_basic_api test has been broken on all lpuart platforms because
of this bug.
```

Fixes #59882

In addition, fix the issue that the original commit was trying to fix, by:
```
Handle controller instances wanting to use different
API instances, need to change init flow so that they dont
interfere with each other, trick for now is returning
either the interrupt driven or async apis as not enabled
if the other has already been used on that controller.

Previously, there was an issue where enabling CONFIG_UART_ASYNC_API
would overwrite the init even if controller was meant to use
interrupt driven (as kconfig is global to affect all the controllers)
```