### PR TITLE
snippets: nus-console: Redirect Shell to nus-console

### DIFF
--- a/snippets/nus-console/nus-console.overlay
+++ b/snippets/nus-console/nus-console.overlay
@@ -7,6 +7,7 @@
 / {
 	chosen {
 		zephyr,console = &bt_nus_console_uart;
+		zephyr,shell-uart = &bt_nus_console_uart;
 	};
 
 	bt_nus_console_uart: bt_nus_console_uart {


### PR DESCRIPTION
To allow easily building samples using the shell, without needing to specify additional configurations. Tested with:
```
west build -b nrf52840dk/nrf52840 \
           -S nus-console` \
           samples/subsys/shell/shell_module
```