### PR TITLE
doc: Add Shell-Related documentation

### DIFF
--- a/doc/services/shell/index.rst
+++ b/doc/services/shell/index.rst
@@ -159,6 +159,41 @@ types:
   during compile time. Created in the software module.
 
 
+Commonly-used command groups
+============================
+
+The following list is a set of useful command groups and how to enable them:
+
+GPIO
+----
+
+- :kconfig:option:`CONFIG_GPIO`
+- :kconfig:option:`CONFIG_GPIO_SHELL`
+
+I2C
+---
+
+- :kconfig:option:`CONFIG_I2C`
+- :kconfig:option:`CONFIG_I2C_SHELL`
+
+Sensor
+------
+
+- :kconfig:option:`CONFIG_SENSOR`
+- :kconfig:option:`CONFIG_SENSOR_SHELL`
+
+Flash
+-----
+
+- :kconfig:option:`CONFIG_FLASH`
+- :kconfig:option:`CONFIG_FLASH_SHELL`
+
+File-System
+-----------
+
+- :kconfig:option:`CONFIG_FILE_SYSTEM`
+- :kconfig:option:`CONFIG_FILE_SYSTEM_SHELL`
+
 Creating commands
 =================
 

--- a/doc/services/shell/index.rst
+++ b/doc/services/shell/index.rst
@@ -40,6 +40,11 @@ interaction is required. This module is a Unix-like shell with these features:
 	enable :kconfig:option:`CONFIG_SHELL_MINIMAL` and selectively enable just the
 	features you want.
 
+.. _backends:
+
+Backends
+********
+
 The module can be connected to any transport for command input and output.
 At this point, the following transport layers are implemented:
 
@@ -49,34 +54,12 @@ At this point, the following transport layers are implemented:
 * Telnet
 * UART
 * USB
+* Bluetooth LE (NUS)
+* RPMSG
 * DUMMY - not a physical transport layer.
 
-Connecting to Segger RTT via TCP (on macOS, for example)
-========================================================
-
-On macOS JLinkRTTClient won't let you enter input. Instead, please use following
-procedure:
-
-* Open up a first Terminal window and enter:
-
-  .. code-block:: none
-
-     JLinkRTTLogger -Device NRF52840_XXAA -RTTChannel 1 -if SWD -Speed 4000 ~/rtt.log
-
-  (change device if required)
-
-* Open up a second Terminal window and enter:
-
-  .. code-block:: none
-
-     nc localhost 19021
-
-* Now you should have a network connection to RTT that will let you enter input
-  to the shell.
-
-
-Telnet Backend
-==============
+Telnet
+======
 
 Enabling :kconfig:option:`CONFIG_SHELL_BACKEND_TELNET` will allow users to use telnet
 as a shell backend. Connecting to it can be done using PuTTY or any ``telnet`` client.
@@ -97,6 +80,70 @@ considerably. For that cost, it will enable the line editing,
 `tab completion <tab-feature_>`_, and `history <history-feature_>`_
 features of the shell.
 
+USB CDC ACM
+===========
+
+To configure Shell USB CDC ACM backend, simply add the snippet ``cdc-acm-console``
+to your build:
+
+.. code-block:: console
+
+   west build -S cdc-acm-console [...]
+
+Details on the configuration settings are captured in the following files:
+
+- :zephyr_file:`snippets/cdc-acm-console/cdc-acm-console.conf`.
+- :zephyr_file:`snippets/cdc-acm-console/cdc-acm-console.overlay`.
+
+Bluetooth LE (NUS)
+==================
+
+To configure Bluetooth LE (NUS) backend, simply add the snippet ``nus-console``
+to your build:
+
+.. code-block:: console
+
+   west build -S nus-console [...]
+
+Details on the configuration settings are captured in the following files:
+
+- :zephyr_file:`snippets/nus-console/nus-console.conf`.
+- :zephyr_file:`snippets/nus-console/nus-console.overlay`.
+
+Segget RTT
+==========
+
+To configure Segger RTT backend, add the following configurations to your build:
+
+- :kconfig:option:`CONFIG_USE_SEGGER_RTT`
+- :kconfig:option:`CONFIG_SHELL_BACKEND_RTT`
+- :kconfig:option:`CONFIG_SHELL_BACKEND_SERIAL`
+
+Details on additional configuration settings are captured in:
+:zephyr_file:`samples/subsys/shell/shell_module/prj_minimal_rtt.conf`.
+
+Connecting to Segger RTT via TCP (on macOS, for example)
+--------------------------------------------------------
+
+On macOS JLinkRTTClient won't let you enter input. Instead, please use following
+procedure:
+
+* Open up a first Terminal window and enter:
+
+  .. code-block:: none
+
+     JLinkRTTLogger -Device NRF52840_XXAA -RTTChannel 1 -if SWD -Speed 4000 ~/rtt.log
+
+  (change device if required)
+
+* Open up a second Terminal window and enter:
+
+  .. code-block:: none
+
+     nc localhost 19021
+
+* Now you should have a network connection to RTT that will let you enter input
+  to the shell.
 
 Commands
 ********
@@ -671,17 +718,10 @@ while a script interfaces over channel 1.
 This allows interactive use of the shell through JLinkRTTViewer, while the log
 is written to file.
 
-.. warning::
-	Regardless of the channel selection, the RTT log backend must be explicitly
-	enabled using :kconfig:option:`CONFIG_LOG_BACKEND_RTT` set to ``y``, because it
-	defaults to ``n`` when the Shell RTT backend is also enabled using
-	:kconfig:option:`CONFIG_SHELL_BACKEND_RTT` being set to ``y``.
+See `shell backends <backends_>`_ for details on how to enable RTT as a Shell backend.
 
 Usage
 *****
-
-To create a new shell instance user needs to activate requested
-backend using ``menuconfig``.
 
 The following code shows a simple use case of this library:
 

--- a/samples/subsys/shell/shell_module/README.rst
+++ b/samples/subsys/shell/shell_module/README.rst
@@ -1,0 +1,115 @@
+.. zephyr:code-sample:: shell-module
+   :name: Custom Shell module
+   :relevant-api: shell_api
+
+   Register shell commands using the Shell API
+
+Overview
+********
+
+This is a simple application demonstrating how to write and register commands
+using the :ref:`Shell API <shell_api>`:
+
+Register Static commands
+   ``version`` is a static command that prints the kernel version.
+
+Conditionally Register commands
+   ``login`` and ``logout`` are conditionally registered commands depending
+   on :kconfig:option:`CONFIG_SHELL_START_OBSCURED`.
+
+Register Dynamic commands
+   See ``dynamic`` command and :zephyr_file:`samples/subsys/shell/shell_module/src/dynamic_cmd.c`
+   for details on how dynamic commands are implemented.
+
+Register Dictionary commands
+   ``dictionary`` implements subsect of dictionary commands.
+
+Set a Bypass callback
+   ``bypass`` implements the bypass callback.
+
+Set a Login command
+   ``login`` and ``logout`` implement the login and logout mechanism, respectively.
+
+Obscure user-input with asterisks
+   ``login`` and ``logout`` implement the feature of enabling and disabling
+   this functionality, respectively.
+
+Requirements
+************
+
+* A target configured with the shell interface, exposed through any of
+  its :ref:`backends <backends>`.
+
+Building and Running
+********************
+
+This sample can be found under :zephyr_file:`samples/subsys/shell/shell_module`
+in the Zephyr tree.
+
+The sample can be built for several platforms.
+
+Emulation Targets
+=================
+
+The sample may run on emulation targets. The following commands build the
+application for the qemu_x86.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/subsys/shell/shell_module
+   :host-os: unix
+   :board: qemu_x86
+   :goals: run
+   :compact:
+
+After running the application, the console displays the shell interface, and
+shows the shell prompt, at which point the user may start the interaction.
+
+On-Hardware
+===========
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/subsys/shell/shell_module
+   :host-os: unix
+   :board: nrf52840dk/nrf52840
+   :goals: flash
+   :compact:
+
+Sample Output
+*************
+
+.. code-block:: console
+
+   uart:~$
+     bypass              clear               date
+     demo                device              devmem
+     dynamic             help                history
+     kernel              log                 log_test
+     rem                 resize              retval
+     section_cmd         shell               shell_uart_release
+     stats               version
+   uart:~$ demo
+   demo - Demo commands
+   Subcommands:
+     dictionary  : Dictionary commands
+     hexdump     : Hexdump params command.
+     params      : Print params command.
+     ping        : Ping command.
+     board       : Show board name command.
+   uart:~$ dynamic
+   dynamic - Demonstrate dynamic command usage.
+   Subcommands:
+     add      : Add a new dynamic command.
+               Example usage: [ dynamic add test ] will add a dynamic command
+               'test'.
+               In this example, command name length is limited to 32 chars. You can
+               add up to 20 commands. Commands are automatically sorted to ensure
+               correct shell completion.
+     execute  : Execute a command.
+     remove   : Remove a command.
+     show     : Show all added dynamic commands.
+   uart:~$
+
+Details on Shell Subsystem
+==========================
+
+For more details on the Shell subsystem, check the general :ref:`Shell documentation <shell_api>`.


### PR DESCRIPTION
### Description
Add Shell-Related Documentation:
- General
    - Add Backend configuration options for USB and Bluetooth LE.
    - Add Configuration for commonly-used Shell command groups (GPIO, I2C, Sensors, Flash, File-System).
- Shell module sample
    - Add first version of README describing different types of options registering Shell commands.