### PR TITLE
net: vlan: Add a function to check if interface is VLAN one

### DIFF
--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -971,6 +971,24 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
 }
 #endif
 
+/**
+ * @brief Check if the given interface is a VLAN interface.
+ *
+ * @param iface Network interface
+ *
+ * @return True if this network interface is VLAN one, false if not.
+ */
+#if defined(CONFIG_NET_VLAN)
+bool net_eth_is_vlan_interface(struct net_if *iface);
+#else
+static inline bool net_eth_is_vlan_interface(struct net_if *iface)
+{
+	ARG_UNUSED(iface);
+
+	return false;
+}
+#endif
+
 #if !defined(CONFIG_ETH_DRIVER_RAW_MODE)
 
 #define Z_ETH_NET_DEVICE_INIT_INSTANCE(node_id, dev_id, name, instance,	\

--- a/subsys/net/l2/ethernet/vlan.c
+++ b/subsys/net/l2/ethernet/vlan.c
@@ -336,6 +336,22 @@ uint16_t net_eth_get_vlan_tag(struct net_if *iface)
 	return tag;
 }
 
+bool net_eth_is_vlan_interface(struct net_if *iface)
+{
+	enum virtual_interface_caps caps;
+
+	if (net_if_l2(iface) != &NET_L2_GET_NAME(VIRTUAL)) {
+		return false;
+	}
+
+	caps = net_virtual_get_iface_capabilities(iface);
+	if (!(caps & VIRTUAL_INTERFACE_VLAN)) {
+		return false;
+	}
+
+	return true;
+}
+
 bool net_eth_get_vlan_status(struct net_if *iface)
 {
 	bool status = false;

--- a/tests/net/vlan/src/main.c
+++ b/tests/net/vlan/src/main.c
@@ -581,6 +581,11 @@ static void test_vlan_enable(void)
 		ARRAY_FOR_EACH_PTR(vlan_interfaces, vlan_iface) {
 			uint16_t tag;
 
+			ret = net_eth_is_vlan_interface(*vlan_iface);
+			zassert_equal(ret, true,
+				      "Not identified as VLAN interface %d",
+				      net_if_get_by_iface(*vlan_iface));
+
 			if (*vlan_iface == iface) {
 				tag = net_eth_get_vlan_tag(*vlan_iface);
 


### PR DESCRIPTION
We were missing a helper function that can be used to check whether the given function is the virtual VLAN interface.