### PR TITLE
Allow specifying devices by DT node label in the shell

### DIFF
--- a/doc/build/dts/macros.bnf
+++ b/doc/build/dts/macros.bnf
@@ -88,6 +88,11 @@ node-macro =/ %s"DT_N" path-id %s"_FOREACH_CHILD_STATUS_OKAY"
 node-macro =/ %s"DT_N" path-id %s"_FOREACH_CHILD_STATUS_OKAY_SEP"
 node-macro =/ %s"DT_N" path-id %s"_FOREACH_CHILD_STATUS_OKAY_VARGS"
 node-macro =/ %s"DT_N" path-id %s"_FOREACH_CHILD_STATUS_OKAY_SEP_VARGS"
+; These are used internally by DT_FOREACH_NODELABEL and
+; DT_FOREACH_NODELABEL_VARGS, which iterate over a node's node labels.
+node-macro =/ %s"DT_N" path-id %s"_FOREACH_NODELABEL" [ %s"_VARGS" ]
+; These are used internally by DT_NUM_NODELABELS
+node-macro =/ %s"DT_N" path-id %s"_NODELABEL_NUM"
 ; The node's zero-based index in the list of it's parent's child nodes.
 node-macro =/ %s"DT_N" path-id %s"_CHILD_IDX"
 ; The node's status macro; dt-name in this case is something like "okay"

--- a/drivers/gpio/Kconfig
+++ b/drivers/gpio/Kconfig
@@ -17,6 +17,7 @@ source "subsys/logging/Kconfig.template.log_config"
 config GPIO_SHELL
 	bool "GPIO Shell"
 	depends on SHELL
+	imply DEVICE_DT_METADATA
 	help
 	  Enable GPIO Shell for testing.
 

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -26,7 +26,7 @@ extern "C" {
  * @brief Device Model
  * @defgroup device_model Device Model
  * @since 1.0
- * @version 1.0.0
+ * @version 1.1.0
  * @{
  */
 
@@ -387,6 +387,9 @@ struct device_state {
 struct pm_device_base;
 struct pm_device;
 struct pm_device_isr;
+#if defined(CONFIG_DEVICE_DT_METADATA) || defined(__DOXYGEN__)
+struct device_dt_metadata;
+#endif
 
 #ifdef CONFIG_DEVICE_DEPS_DYNAMIC
 #define Z_DEVICE_DEPS_CONST
@@ -434,6 +437,9 @@ struct device {
 		struct pm_device_isr *pm_isr;
 	};
 #endif
+#if defined(CONFIG_DEVICE_DT_METADATA) || defined(__DOXYGEN__)
+	const struct device_dt_metadata *dt_meta;
+#endif /* CONFIG_DEVICE_DT_METADATA */
 };
 
 /**
@@ -923,6 +929,104 @@ __syscall int device_init(const struct device *dev);
 
 #endif /* CONFIG_PM_POLICY_DEVICE_CONSTRAINTS */
 
+#if defined(CONFIG_DEVICE_DT_METADATA) || defined(__DOXYGEN__)
+/**
+ * @brief Devicetree node labels associated with a device
+ */
+struct device_dt_nodelabels {
+	/* @brief number of elements in the nodelabels array */
+	size_t num_nodelabels;
+	/* @brief array of node labels as strings, exactly as they
+	 *        appear in the final devicetree
+	 */
+	const char *nodelabels[];
+};
+
+/**
+ * @brief Devicetree metadata associated with a device
+ *
+ * This is currently limited to node labels, but the structure is
+ * generic enough to be extended later without requiring breaking
+ * changes.
+ */
+struct device_dt_metadata {
+	/**
+	 * @brief Node labels associated with the device
+	 * @see device_get_dt_nodelabels()
+	 */
+	const struct device_dt_nodelabels *nl;
+};
+
+/**
+ * @brief Get a @ref device reference from a devicetree node label.
+ *
+ * If:
+ *
+ * 1. a device was defined from a devicetree node, for example
+ *    with DEVICE_DT_DEFINE() or another similar macro, and
+ * 2. that devicetree node has @p nodelabel as one of its node labels, and
+ * 3. the device initialized successfully at boot time,
+ *
+ * then this function returns a pointer to the device. Otherwise, it
+ * returns NULL.
+ *
+ * @param nodelabel a devicetree node label
+ * @return a device reference for a device created from a node with that
+ *         node label, or NULL if either no such device exists or the device
+ *         failed to initialize
+ */
+__syscall const struct device *device_get_by_dt_nodelabel(const char *nodelabel);
+
+/**
+ * @brief Get the devicetree node labels associated with a device
+ * @param dev device whose metadata to look up
+ * @return information about the devicetree node labels
+ */
+static inline const struct device_dt_nodelabels *
+device_get_dt_nodelabels(const struct device *dev)
+{
+	return dev->dt_meta->nl;
+}
+
+/**
+ * @brief Maximum devicetree node label length.
+ *
+ * The maximum length is set so that device_get_by_dt_nodelabel() can
+ * be used from userspace.
+ */
+#define Z_DEVICE_MAX_NODELABEL_LEN Z_DEVICE_MAX_NAME_LEN
+
+/**
+ * @brief Name of the identifier for a device's DT metadata structure
+ * @param dev_id device identifier
+ */
+#define Z_DEVICE_DT_METADATA_NAME_GET(dev_id) UTIL_CAT(__dev_dt_meta_, dev_id)
+
+/**
+ * @brief Name of the identifier for the array of node label strings
+ *        saved for a device.
+ */
+#define Z_DEVICE_DT_NODELABELS_NAME_GET(dev_id) UTIL_CAT(__dev_dt_nodelabels_, dev_id)
+
+/**
+ * @brief Initialize an entry in the device DT node label lookup table
+ *
+ * Allocates and initializes a struct device_dt_metadata in the
+ * appropriate iterable section for use finding devices.
+ */
+#define Z_DEVICE_DT_METADATA_DEFINE(node_id, dev_id)			\
+	static const struct device_dt_nodelabels			\
+	Z_DEVICE_DT_NODELABELS_NAME_GET(dev_id) = {			\
+		.num_nodelabels = DT_NUM_NODELABELS(node_id),		\
+		.nodelabels = DT_NODELABEL_STRING_ARRAY(node_id),	\
+	};								\
+									\
+	static const struct device_dt_metadata				\
+	Z_DEVICE_DT_METADATA_NAME_GET(dev_id) = {			\
+		.nl = &Z_DEVICE_DT_NODELABELS_NAME_GET(dev_id),			\
+	};
+#endif  /* CONFIG_DEVICE_DT_METADATA */
+
 /**
  * @brief Init sub-priority of the device
  *
@@ -961,21 +1065,24 @@ __syscall int device_init(const struct device *dev);
  * @param api_ Reference to device API ops.
  * @param state_ Reference to device state.
  * @param deps_ Reference to device dependencies.
+ * @param dev_id_ Device identifier token, as passed to Z_DEVICE_BASE_DEFINE
  */
-#define Z_DEVICE_INIT(name_, pm_, data_, config_, api_, state_, deps_,                   \
-			constraints_size_, constraints_)                                 \
-	{                                                                                \
-		.name = name_,                                                           \
-		.config = (config_),                                                     \
-		.api = (api_),                                                           \
-		.state = (state_),                                                       \
-		.data = (data_),                                                         \
-		IF_ENABLED(CONFIG_DEVICE_DEPS, (.deps = (deps_),)) /**/                  \
-		IF_ENABLED(CONFIG_PM_POLICY_DEVICE_CONSTRAINTS,                          \
-			(.pm_constraints = (constraints_),))                             \
-		IF_ENABLED(CONFIG_PM_POLICY_DEVICE_CONSTRAINTS,                          \
-			(.pm_constraints_size = (constraints_size_),))                   \
-		IF_ENABLED(CONFIG_PM_DEVICE, ({ .pm_base = (pm_),})) /**/                \
+#define Z_DEVICE_INIT(name_, pm_, data_, config_, api_, state_, deps_,			\
+			constraints_size_, constraints_, dev_id_)			\
+	{										\
+		.name = name_,								\
+		.config = (config_),							\
+		.api = (api_),								\
+		.state = (state_),							\
+		.data = (data_),							\
+		IF_ENABLED(CONFIG_DEVICE_DEPS, (.deps = (deps_),)) /**/			\
+		IF_ENABLED(CONFIG_PM_POLICY_DEVICE_CONSTRAINTS,				\
+			(.pm_constraints = (constraints_),))				\
+		IF_ENABLED(CONFIG_PM_POLICY_DEVICE_CONSTRAINTS,				\
+			(.pm_constraints_size = (constraints_size_),))			\
+		IF_ENABLED(CONFIG_PM_DEVICE, ({ .pm_base = (pm_),})) /**/		\
+		IF_ENABLED(CONFIG_DEVICE_DT_METADATA,					\
+			   (.dt_meta = &Z_DEVICE_DT_METADATA_NAME_GET(dev_id_),))	\
 	}
 
 /**
@@ -1011,7 +1118,7 @@ __syscall int device_init(const struct device *dev);
 		device, COND_CODE_1(Z_DEVICE_IS_MUTABLE(node_id), (device_mutable), (device)),     \
 		Z_DEVICE_SECTION_NAME(level, prio), DEVICE_NAME_GET(dev_id)) =                     \
 		Z_DEVICE_INIT(name, pm, data, config, api, state, deps,                            \
-			DT_PROP_LEN_OR(node_id, zephyr_disabling_power_states, 0), constraints)
+		DT_PROP_LEN_OR(node_id, zephyr_disabling_power_states, 0), constraints, dev_id)
 
 /* deprecated device initialization levels */
 #define Z_DEVICE_LEVEL_DEPRECATED_EARLY                                        \
@@ -1098,13 +1205,17 @@ __syscall int device_init(const struct device *dev);
                                                                                 \
 	IF_ENABLED(CONFIG_PM_POLICY_DEVICE_CONSTRAINTS,                         \
 		(Z_DEVICE_PM_CONSTRAINTS_DEFINE(node_id, dev_id, __VA_ARGS__);))\
+                                                                                \
+	IF_ENABLED(CONFIG_DEVICE_DT_METADATA,                                   \
+		   (Z_DEVICE_DT_METADATA_DEFINE(node_id, dev_id);))             \
+                                                                                \
 	Z_DEVICE_BASE_DEFINE(node_id, dev_id, name, pm, data, config, level,    \
 		prio, api, state, Z_DEVICE_DEPS_NAME(dev_id),                   \
 		Z_DEVICE_PM_CONSTRAINTS_NAME(dev_id));                          \
-	COND_CODE_1(DEVICE_DT_DEFER(node_id),                                  \
-		    (Z_DEFER_DEVICE_INIT_ENTRY_DEFINE(node_id, dev_id,         \
-						      init_fn)),               \
-		    (Z_DEVICE_INIT_ENTRY_DEFINE(node_id, dev_id, init_fn,      \
+	COND_CODE_1(DEVICE_DT_DEFER(node_id),                                   \
+		    (Z_DEFER_DEVICE_INIT_ENTRY_DEFINE(node_id, dev_id,          \
+						      init_fn)),                \
+		    (Z_DEVICE_INIT_ENTRY_DEFINE(node_id, dev_id, init_fn,       \
 						level, prio)));
 
 /**

--- a/kernel/Kconfig.device
+++ b/kernel/Kconfig.device
@@ -26,6 +26,13 @@ config DEVICE_MUTABLE
 	  Support mutable devices. Mutable devices are instantiated in SRAM
 	  instead of Flash and are runtime modifiable in kernel mode.
 
+config DEVICE_DT_METADATA
+	bool "Store additional devicetree metadata for each device"
+	help
+	  If enabled, additional data from the devicetree will be stored for
+	  each device. This allows you to use device_get_by_dt_nodelabel(),
+	  device_get_dt_metadata(), etc.
+
 endmenu
 
 menu "Initialization Priorities"

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -132,6 +132,13 @@ def main():
                 out_dt_define(f"{node.z_path_id}_CHILD_IDX",
                               node.parent.child_index(node))
 
+            out_comment("Helpers for dealing with node labels:")
+            out_dt_define(f"{node.z_path_id}_NODELABEL_NUM", len(node.labels))
+            out_dt_define(f"{node.z_path_id}_FOREACH_NODELABEL(fn)",
+                          " ".join(f"fn({nodelabel})" for nodelabel in node.labels))
+            out_dt_define(f"{node.z_path_id}_FOREACH_NODELABEL_VARGS(fn, ...)",
+                          " ".join(f"fn({nodelabel}, __VA_ARGS__)" for nodelabel in node.labels))
+
             write_children(node)
             write_dep_info(node)
             write_idents_and_existence(node)

--- a/subsys/shell/modules/device_service.c
+++ b/subsys/shell/modules/device_service.c
@@ -98,6 +98,20 @@ static int cmd_device_list(const struct shell *sh,
 			(void)device_required_foreach(dev, cmd_device_list_visitor, &ctx);
 		}
 #endif /* CONFIG_DEVICE_DEPS */
+
+#ifdef CONFIG_DEVICE_DT_METADATA
+		const struct device_dt_nodelabels *nl = device_get_dt_nodelabels(dev);
+
+		if (nl->num_nodelabels > 0) {
+			shell_fprintf(sh, SHELL_NORMAL, "  DT node labels:");
+			for (size_t j = 0; j < nl->num_nodelabels; j++) {
+				const char *nodelabel = nl->nodelabels[j];
+
+				shell_fprintf(sh, SHELL_NORMAL, " %s", nodelabel);
+			}
+			shell_fprintf(sh, SHELL_NORMAL, "\n");
+		}
+#endif /* CONFIG_DEVICE_DT_METADATAa */
 	}
 
 	return 0;

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -1600,6 +1600,64 @@ ZTEST(devicetree_api, test_foreach_status_okay)
 #undef BUILD_BUG_ON_EXPANSION
 }
 
+ZTEST(devicetree_api, test_foreach_nodelabel)
+{
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT vnd_adc_temp_sensor
+#define ENTRY(nodelabel) enum_ ## nodelabel,
+#define VAR_PLUS(nodelabel, to_add) int nodelabel ## _added = enum_ ## nodelabel + to_add;
+
+	/* DT_FOREACH_NODELABEL */
+	enum {
+		DT_FOREACH_NODELABEL(DT_NODELABEL(test_nodelabel), ENTRY)
+	};
+	zassert_equal(enum_test_nodelabel, 0, "");
+	zassert_equal(enum_TEST_NODELABEL_ALLCAPS, 1, "");
+	zassert_equal(enum_test_gpio_1, 2, "");
+
+	/* DT_FOREACH_NODELABEL_VARGS */
+	DT_FOREACH_NODELABEL_VARGS(DT_NODELABEL(test_nodelabel), VAR_PLUS, 1);
+	zassert_equal(test_nodelabel_added, 1, "");
+	zassert_equal(TEST_NODELABEL_ALLCAPS_added, 2, "");
+	zassert_equal(test_gpio_1_added, 3, "");
+
+	/* DT_NODELABEL_STRING_ARRAY is tested here since it's closely related */
+	const char *nodelabels[] = DT_NODELABEL_STRING_ARRAY(DT_NODELABEL(test_nodelabel));
+
+	zassert_equal(ARRAY_SIZE(nodelabels), 3);
+	zassert_true(!strcmp(nodelabels[0], "test_nodelabel"), "");
+	zassert_true(!strcmp(nodelabels[1], "TEST_NODELABEL_ALLCAPS"), "");
+	zassert_true(!strcmp(nodelabels[2], "test_gpio_1"), "");
+
+	/* DT_NUM_NODELABELS */
+	zassert_equal(DT_NUM_NODELABELS(DT_NODELABEL(test_nodelabel)), 3, "");
+	zassert_equal(DT_NUM_NODELABELS(DT_PATH(chosen)), 0, "");
+	zassert_equal(DT_NUM_NODELABELS(DT_ROOT), 0, "");
+
+	/* DT_INST_FOREACH_NODELABEL */
+	enum {
+		DT_INST_FOREACH_NODELABEL(0, ENTRY)
+	};
+	zassert_equal(enum_test_temp_sensor, 0, "");
+
+	/* DT_INST_FOREACH_NODELABEL_VARGS */
+	DT_INST_FOREACH_NODELABEL_VARGS(0, VAR_PLUS, 1);
+	zassert_equal(test_temp_sensor_added, 1, "");
+
+	/* DT_INST_NODELABEL_STRING_ARRAY */
+	const char *inst_nodelabels[] = DT_INST_NODELABEL_STRING_ARRAY(0);
+
+	zassert_equal(ARRAY_SIZE(inst_nodelabels), 1);
+	zassert_true(!strcmp(inst_nodelabels[0], "test_temp_sensor"), "");
+
+	/* DT_INST_NUM_NODELABELS */
+	zassert_equal(DT_INST_NUM_NODELABELS(0), 1, "");
+
+#undef VAR_PLUS
+#undef ENTRY
+#undef DT_DRV_COMPAT
+}
+
 ZTEST(devicetree_api, test_foreach_prop_elem)
 {
 #define TIMES_TWO(node_id, prop, idx) \


### PR DESCRIPTION
The purposes of this pull request are:

- resolve a longstanding breakage related to devices getting their names from devicetree node names, which are cumbersome and need not be unique (#51449)
- demonstrate that it can work in a couple of shell implementations (gpio_shell and device_service)

We've all been dealing with this problem for years, ever since the label properties were removed throughout the tree. While handling the fallout of upgrading some internal code to a version of zephyr without label properties, it occurred to me that DT node labels are a perfectly good way to refer to devices, if we had a way to capture them.

This PR gets that done by optionally storing DT node labels alongside their related devices. You can use this to reverse search for a device by DT node label in individual shell commands.

I don't have the bandwidth to update all 66 of our shell command sets, but hopefully by doing the macrobatics necessary to build the infrastructure and updating a couple of subsystem shells for demonstration, individual subsystem maintainers can take it from here.