### PR TITLE
samples: sensor: accel_polling: Add test configuration for for nrf54h20 and nrf54l15

### DIFF
--- a/samples/sensor/accel_polling/sample.yaml
+++ b/samples/sensor/accel_polling/sample.yaml
@@ -39,3 +39,17 @@ tests:
     extra_args:
       - SHIELD=pca63566
     platform_allow: nrf54h20dk/nrf54h20/cpuapp
+
+  sample.sensor.accel_polling.nrf54l:
+    depends_on: spi
+    tags: drivers spi sensors
+    harness: console
+    harness_config:
+      fixture: pca63565
+      type: one_line
+      regex:
+        - "^\\s*[0-9A-Za-z_,+-.]*@[0-9A-Fa-f]* \\[m\/s\\^2\\]:    \
+           \\(\\s*-?[0-9\\.]*,\\s*-?[0-9\\.]*,\\s*-?[0-9\\.]*\\)$"
+    extra_args:
+      - SHIELD=pca63565
+    platform_allow: nrf54l15pdk/nrf54l15/cpuapp

--- a/samples/sensor/accel_polling/sample.yaml
+++ b/samples/sensor/accel_polling/sample.yaml
@@ -25,3 +25,17 @@ tests:
       - b_l4s5i_iot01a                  # lsm6dsl
       - sensortile_box                  # lis2dw12, lsm6dso, iisdhhc
       - thingy53/nrf5340/cpuapp         # adxl362, bmi270
+
+  sample.sensor.accel_polling.nrf54h:
+    depends_on: spi
+    tags: drivers spi sensors
+    harness: console
+    harness_config:
+      fixture: pca63566
+      type: one_line
+      regex:
+        - "^\\s*[0-9A-Za-z_,+-.]*@[0-9A-Fa-f]* \\[m\/s\\^2\\]:    \
+           \\(\\s*-?[0-9\\.]*,\\s*-?[0-9\\.]*,\\s*-?[0-9\\.]*\\)$"
+    extra_args:
+      - SHIELD=pca63566
+    platform_allow: nrf54h20dk/nrf54h20/cpuapp

--- a/samples/sensor/bme680/sample.yaml
+++ b/samples/sensor/bme680/sample.yaml
@@ -11,3 +11,16 @@ tests:
     platform_allow:
       - nrf52840dk/nrf52840
       - adafruit_feather/nrf52840
+
+  sample.sensor.bme680.nrf54l:
+    depends_on: i2c
+    tags: drivers i2c sensors
+    harness: console
+    harness_config:
+      fixture: pca63565
+      type: one_line
+      regex:
+        - "^\\s*T:\\s*-?[0-9\\.]*; P:\\s*-?[0-9\\.]*; H: \\s*-?[0-9\\.]*; G:\\s*-?[0-9\\.]*$"
+    extra_args:
+      - SHIELD=pca63565
+    platform_allow: nrf54l15pdk/nrf54l15/cpuapp


### PR DESCRIPTION
Add test configurations that allow to run:
- samples/sensor/accel_polling on nrf54h20 with PCA63566 SHIELD,
- samples/sensor/accel_polling on nrf54l15 with PCA63565 SHIELD,
- samples/sensor/bme680 on nrf54l15 with PCA63565 SHIELD.