### PR TITLE
net: wifi: Unicast frames statistics

### DIFF
--- a/include/zephyr/net/net_stats.h
+++ b/include/zephyr/net/net_stats.h
@@ -494,6 +494,7 @@ struct net_stats_wifi {
 	struct net_stats_pkts broadcast;
 	struct net_stats_pkts multicast;
 	struct net_stats_pkts errors;
+	struct net_stats_pkts unicast;
 };
 
 #if defined(CONFIG_NET_STATISTICS_USER_API)

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -856,6 +856,8 @@ static void print_wifi_stats(struct net_if *iface, struct net_stats_wifi *data,
 	PR("Mcast sent       : %u\n", data->multicast.tx);
 	PR("Beacons received : %u\n", data->sta_mgmt.beacons_rx);
 	PR("Beacons missed   : %u\n", data->sta_mgmt.beacons_miss);
+	PR("Unicast received : %u\n", data->unicast.rx);
+	PR("Unicast sent     : %u\n", data->unicast.tx);
 }
 #endif /* CONFIG_NET_STATISTICS_WIFI && CONFIG_NET_STATISTICS_USER_API */
 


### PR DESCRIPTION
It represents total number of unicast (any type data, action or any other unicast frames) frames received at firmware level. The actual frames passed to host will be different as firmware may drop packets or some packets may be dropped because of errors.