### PR TITLE
net: lwm2m: Move one Kconfig to engine features submenu

### DIFF
--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -134,6 +134,14 @@ config LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP
 	help
 	  Enabling this setting allows the RD client to support bootstrap mode.
 
+config LWM2M_ENGINE_ALWAYS_REPORT_OBJ_VERSION
+	bool "LwM2M engine always report object version"
+	help
+	  According to LwM2M specification v1.0 and v1.1, non-core object versions other than 1.0
+	  'must' be provided, while all other versions 'may' be provided. With specification v1.2,
+	  a client 'can always attach Object Version Information'. Enable this configuration to
+	  always report all object versions.
+
 choice
 prompt "Socket handling at idle state"
 
@@ -491,14 +499,6 @@ config LWM2M_ENGINE_DEFAULT_LIFETIME
 	  Set the default lifetime (in seconds) for the LwM2M library engine.
 	  This is also a minimum lifetime that client accepts. If server sets lifetime
 	  less than this value, client automatically raises it.
-
-config LWM2M_ENGINE_ALWAYS_REPORT_OBJ_VERSION
-	bool "LwM2M engine always report object version"
-	help
-	  According to LwM2M specification v1.0 and v1.1, non-core object versions other than 1.0
-	  'must' be provided, while all other versions 'may' be provided. With specification v1.2,
-	  a client 'can always attach Object Version Information'. Enable this configuration to
-	  always report all object versions.
 
 config LWM2M_UPDATE_PERIOD
 	int "LwM2M engine update period"


### PR DESCRIPTION
Kconfig option to enable object version reporting should be moved into sub section "Engine features" so
it does not clutter up the main LwM2M menu.

I forgot to mention this in https://github.com/zephyrproject-rtos/zephyr/pull/71710/ where the option was added.

![image](https://github.com/zephyrproject-rtos/zephyr/assets/3104794/a3d567a1-8d3a-4896-ab38-e1a343da576a)
