### PR TITLE
CI: Fix coverage analysis

### DIFF
--- a/scripts/ci/coverage/coverage_analysis.py
+++ b/scripts/ci/coverage/coverage_analysis.py
@@ -13,6 +13,13 @@ class Json_report:
         "components":[]
     }
 
+    simulators = [
+        'unit_testing',
+        'native',
+        'quemu',
+        'mps2/an385'
+    ]
+
     report_json = {}
 
     def __init__(self):
@@ -80,7 +87,7 @@ class Json_report:
                                 test_case = {
                                     "name":testcase_name
                                 }
-                                if 'qemu' in testsuite['platform'] or 'native' in testsuite['platform']:
+                                if any(platform in testsuite['platform'] for platform in self.simulators):
                                     if test_suite['status'] == "":
                                         test_suite['status'] = 'sim_only'
 
@@ -122,7 +129,7 @@ class Json_report:
                                     test_case = {
                                         "name": testcase_name
                                     }
-                                    if 'qemu' in testsuite['platform'] or 'native' in testsuite['platform']:
+                                    if any(platform in testsuite['platform'] for platform in self.simulators):
                                         if test_suite['status'] == "":
                                             test_suite['status'] = 'sim_only'
 
@@ -159,7 +166,7 @@ class Json_report:
                                         test_case  = {
                                             "name": testcase_name
                                         }
-                                        if 'qemu' in testsuite['platform'] or 'native' in testsuite['platform']:
+                                        if any(platform in testsuite['platform'] for platform in self.simulators):
                                             if test_suite['status'] == "":
                                                 test_suite['status'] = 'sim_only'
 
@@ -175,7 +182,7 @@ class Json_report:
                                         test_suite['platforms'].append(testsuite['platform'])
                                         sub_component["test_suites"].append(test_suite)
                                     else:
-                                        if 'qemu' in testsuite['platform'] or 'native' in testsuite['platform']:
+                                        if any(platform in testsuite['platform'] for platform in self.simulators):
                                             if test_suite['status'] == "":
                                                 test_suite['status'] = 'sim_only'
 


### PR DESCRIPTION
Add mps2/an385 and unit_testing to the simulator
criteria while parsing testsuites. These missing names caused that for example utilities were counted as hardware only instead of simulation only.

 Now the testsuites will count as a simulator only where the platform
is quemu*, native*, unit_testing, mps2/an385.