### PR TITLE
Add DT/DT_INST_CHILD_NUM and DT/DT_INST_CHILD_NUM_STATUS_OKAY for the number of child nodes of a given node

### DIFF
--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -552,6 +552,25 @@
 #define DT_NODE_CHILD_IDX(node_id) DT_CAT(node_id, _CHILD_IDX)
 
 /**
+ * @brief Get the number of child nodes of a given node
+ *
+ * @param node_id a node identifier
+ * @return Number of child nodes
+ */
+#define DT_CHILD_NUM(node_id) DT_CAT(node_id, _CHILD_NUM)
+
+
+/**
+ * @brief Get the number of child nodes of a given node
+ *        which child nodes' status are okay
+ *
+ * @param node_id a node identifier
+ * @return Number of child nodes which status are okay
+ */
+#define DT_CHILD_NUM_STATUS_OKAY(node_id) \
+	DT_CAT(node_id, _CHILD_NUM_STATUS_OKAY)
+
+/**
  * @brief Do @p node_id1 and @p node_id2 refer to the same node?
  *
  * Both @p node_id1 and @p node_id2 must be node identifiers for nodes
@@ -3441,6 +3460,29 @@
  */
 #define DT_INST_CHILD(inst, child) \
 	DT_CHILD(DT_DRV_INST(inst), child)
+
+/**
+ * @brief Get the number of child nodes of a given node
+ *
+ * This is equivalent to @see
+ * <tt>DT_CHILD_NUM(DT_DRV_INST(inst))</tt>.
+ *
+ * @param inst Devicetree instance number
+ * @return Number of child nodes
+ */
+#define DT_INST_CHILD_NUM(inst) DT_CHILD_NUM(DT_DRV_INST(inst))
+
+/**
+ * @brief Get the number of child nodes of a given node
+ *
+ * This is equivalent to @see
+ * <tt>DT_CHILD_NUM_STATUS_OKAY(DT_DRV_INST(inst))</tt>.
+ *
+ * @param inst Devicetree instance number
+ * @return Number of child nodes which status are okay
+ */
+#define DT_INST_CHILD_NUM_STATUS_OKAY(inst) \
+	DT_CHILD_NUM_STATUS_OKAY(DT_DRV_INST(inst))
 
 /**
  * @brief Call @p fn on all child nodes of DT_DRV_INST(inst).

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -524,6 +524,15 @@ def write_children(node):
 
     out_comment("Helper macros for child nodes of this node.")
 
+    out_dt_define(f"{node.z_path_id}_CHILD_NUM", len(node.children))
+
+    ok_nodes_num = 0
+    for child in node.children.values():
+        if child.status == "okay":
+            ok_nodes_num = ok_nodes_num + 1
+
+    out_dt_define(f"{node.z_path_id}_CHILD_NUM_STATUS_OKAY", ok_nodes_num)
+
     out_dt_define(f"{node.z_path_id}_FOREACH_CHILD(fn)",
             " ".join(f"fn(DT_{child.z_path_id})" for child in
                 node.children.values()))

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -2210,6 +2210,16 @@ ZTEST(devicetree_api, test_child_nodes_list_varg)
 	#undef TEST_FUNC
 }
 
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT vnd_child_bindings
+ZTEST(devicetree_api, test_child_nodes_number)
+{
+	zassert_equal(DT_CHILD_NUM(TEST_CHILDREN), 3, "");
+	zassert_equal(DT_INST_CHILD_NUM(0), 3, "");
+	zassert_equal(DT_CHILD_NUM_STATUS_OKAY(TEST_CHILDREN), 2, "");
+	zassert_equal(DT_INST_CHILD_NUM_STATUS_OKAY(0), 2, "");
+}
+
 ZTEST(devicetree_api, test_great_grandchild)
 {
 	zassert_equal(DT_PROP(DT_NODELABEL(test_ggc), ggc_prop), 42, "");


### PR DESCRIPTION
Background: https://github.com/zephyrproject-rtos/zephyr/issues/38715

The below macro is first proposed but does not work with macros that takes a number as its parameter at pre-processor time.

`#define DT_NUM_CHILD(node_id) (DT_FOREACH_CHILD_SEP_VARGS(node_id, DT_CAT, (+), _EXISTS))`

A better solution is to create a generated macro with the number of child as a number then derive from it.
`#define DT_N(node-path)_CHILD_NUM` 
`#define DT_CHILD_NUM(node_id) DT_CAT(node_id, _CHILD_NUM)` 

Added another generated macro for the number of child which status is okay.
`#define DT_N(node-path)_CHILD_NUM_STATUS_OKAY`
`#define DT_CHILD_NUM_STATUS_OKAY(node_id) DT_CAT(node_id, _CHILD_NUM_STATUS_OKAY)`
This does not conflict with DT_NUM_INST_STATUS_OKAY as it gets the number of status okay of all child nodes instead of with a given compat.  