### PR TITLE
dts: set the `riscv,isa` property for virt-based targets

### DIFF
--- a/boards/qemu/riscv32/qemu_riscv32.dts
+++ b/boards/qemu/riscv32/qemu_riscv32.dts
@@ -2,7 +2,7 @@
 
 /dts-v1/;
 
-#include <virt.dtsi>
+#include <qemu/virt-riscv32.dtsi>
 
 / {
 	chosen {

--- a/boards/qemu/riscv32/qemu_riscv32_qemu_virt_riscv32_smp.dts
+++ b/boards/qemu/riscv32/qemu_riscv32_qemu_virt_riscv32_smp.dts
@@ -2,7 +2,7 @@
 
 /dts-v1/;
 
-#include <virt.dtsi>
+#include <qemu/virt-riscv32.dtsi>
 
 / {
 	chosen {

--- a/boards/qemu/riscv32e/qemu_riscv32e.dts
+++ b/boards/qemu/riscv32e/qemu_riscv32e.dts
@@ -7,7 +7,7 @@
 
 /dts-v1/;
 
-#include <virt.dtsi>
+#include <qemu/virt-riscv32.dtsi>
 
 / {
 	chosen {

--- a/boards/qemu/riscv64/qemu_riscv64.dts
+++ b/boards/qemu/riscv64/qemu_riscv64.dts
@@ -3,7 +3,7 @@
 
 /dts-v1/;
 
-#include <virt.dtsi>
+#include <qemu/virt-riscv64.dtsi>
 
 / {
 	chosen {

--- a/boards/qemu/riscv64/qemu_riscv64_qemu_virt_riscv64_smp.dts
+++ b/boards/qemu/riscv64/qemu_riscv64_qemu_virt_riscv64_smp.dts
@@ -3,7 +3,7 @@
 
 /dts-v1/;
 
-#include <virt.dtsi>
+#include <qemu/virt-riscv64.dtsi>
 
 / {
 	chosen {

--- a/dts/bindings/cpu/qemu,riscv-virt.yaml
+++ b/dts/bindings/cpu/qemu,riscv-virt.yaml
@@ -1,0 +1,9 @@
+# Copyright (c) 2024 Antmicro <www.antmicro.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: QEMU RISC-V virt machine CPU node
+
+compatible: "qemu,riscv-virt"
+
+include: riscv,cpus.yaml

--- a/dts/riscv/qemu/virt-riscv.dtsi
+++ b/dts/riscv/qemu/virt-riscv.dtsi
@@ -41,7 +41,7 @@
 			device_type = "cpu";
 			reg = < 0x00 >;
 			status = "okay";
-			compatible = "riscv";
+			compatible = "qemu,riscv-virt", "riscv";
 
 			hlic0: interrupt-controller {
 				compatible = "riscv,cpu-intc";
@@ -55,7 +55,7 @@
 			device_type = "cpu";
 			reg = < 0x01 >;
 			status = "okay";
-			compatible = "riscv";
+			compatible = "qemu,riscv-virt", "riscv";
 
 			hlic1: interrupt-controller {
 				compatible = "riscv,cpu-intc";
@@ -69,7 +69,7 @@
 			device_type = "cpu";
 			reg = < 0x02 >;
 			status = "okay";
-			compatible = "riscv";
+			compatible = "qemu,riscv-virt", "riscv";
 
 			hlic2: interrupt-controller {
 				compatible = "riscv,cpu-intc";
@@ -83,7 +83,7 @@
 			device_type = "cpu";
 			reg = < 0x03 >;
 			status = "okay";
-			compatible = "riscv";
+			compatible = "qemu,riscv-virt", "riscv";
 
 			hlic3: interrupt-controller {
 				compatible = "riscv,cpu-intc";
@@ -97,7 +97,7 @@
 			device_type = "cpu";
 			reg = < 0x04 >;
 			status = "okay";
-			compatible = "riscv";
+			compatible = "qemu,riscv-virt", "riscv";
 
 			hlic4: interrupt-controller {
 				compatible = "riscv,cpu-intc";
@@ -111,7 +111,7 @@
 			device_type = "cpu";
 			reg = < 0x05 >;
 			status = "okay";
-			compatible = "riscv";
+			compatible = "qemu,riscv-virt", "riscv";
 
 			hlic5: interrupt-controller {
 				compatible = "riscv,cpu-intc";
@@ -125,7 +125,7 @@
 			device_type = "cpu";
 			reg = < 0x06 >;
 			status = "okay";
-			compatible = "riscv";
+			compatible = "qemu,riscv-virt", "riscv";
 
 			hlic6: interrupt-controller {
 				compatible = "riscv,cpu-intc";
@@ -139,7 +139,7 @@
 			device_type = "cpu";
 			reg = < 0x07 >;
 			status = "okay";
-			compatible = "riscv";
+			compatible = "qemu,riscv-virt", "riscv";
 
 			hlic7: interrupt-controller {
 				compatible = "riscv,cpu-intc";

--- a/dts/riscv/qemu/virt-riscv32.dtsi
+++ b/dts/riscv/qemu/virt-riscv32.dtsi
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2024 Antmicro <www.antmicro.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+
+#include <qemu/virt-riscv.dtsi>
+
+/ {
+	cpus {
+		cpu@0 {
+			riscv,isa = "rv32gc";
+		};
+
+		cpu@1 {
+			riscv,isa = "rv32gc";
+		};
+
+		cpu@2 {
+			riscv,isa = "rv32gc";
+		};
+
+		cpu@3 {
+			riscv,isa = "rv32gc";
+		};
+
+		cpu@4 {
+			riscv,isa = "rv32gc";
+		};
+
+		cpu@5 {
+			riscv,isa = "rv32gc";
+		};
+
+		cpu@6 {
+			riscv,isa = "rv32gc";
+		};
+
+		cpu@7 {
+			riscv,isa = "rv32gc";
+		};
+	};
+};

--- a/dts/riscv/qemu/virt-riscv64.dtsi
+++ b/dts/riscv/qemu/virt-riscv64.dtsi
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2024 Antmicro <www.antmicro.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+
+#include <qemu/virt-riscv.dtsi>
+
+/ {
+	cpus {
+		cpu@0 {
+			riscv,isa = "rv64gc";
+		};
+
+		cpu@1 {
+			riscv,isa = "rv64gc";
+		};
+
+		cpu@2 {
+			riscv,isa = "rv64gc";
+		};
+
+		cpu@3 {
+			riscv,isa = "rv64gc";
+		};
+
+		cpu@4 {
+			riscv,isa = "rv64gc";
+		};
+
+		cpu@5 {
+			riscv,isa = "rv64gc";
+		};
+
+		cpu@6 {
+			riscv,isa = "rv64gc";
+		};
+
+		cpu@7 {
+			riscv,isa = "rv64gc";
+		};
+	};
+};


### PR DESCRIPTION
This PR makes the devicetrees of the targets that are based on the QEMU `virt` machine more consistent with the rest of the RISC-V targets in Zephyr by:
* adding the `riscv,isa` property
* adding a compatible string which uniquely identifies the core that is present in the `virt` machine in QEMU