### PR TITLE
tests: sbs_charger: fix filter

### DIFF
--- a/tests/drivers/charger/sbs_charger/testcase.yaml
+++ b/tests/drivers/charger/sbs_charger/testcase.yaml
@@ -1,12 +1,14 @@
+common:
+  platform_key:
+    - arch
+    - simulation
+  tags:
+    - drivers
+    - charger
 tests:
   # section.subsection
   drivers.charger.sbs.emulated:
-    tags:
-      - drivers
-      - charger
-    filter: >
-      dt_compat_enabled("sbs,sbs-charger") and
-      (CONFIG_QEMU_TARGET or CONFIG_ARCH_POSIX)
+    filter: dt_compat_enabled("sbs,sbs-charger")
     extra_args:
       CONF_FILE="prj.conf;boards/emulated_board.conf"
       DTC_OVERLAY_FILE="boards/emulated_board.overlay"
@@ -21,12 +23,7 @@ tests:
       - rcar_salvator_xs
       - numaker_pfm_m467
   drivers.charger.sbs.emulated_64_bit_i2c_addr:
-    tags:
-      - drivers
-      - charger
-    filter: >
-      dt_compat_enabled("sbs,sbs-charger") and
-      (CONFIG_QEMU_TARGET or CONFIG_ARCH_POSIX)
+    filter: dt_compat_enabled("sbs,sbs-charger")
     platform_allow:
       - qemu_cortex_a53
       - qemu_cortex_a53/qemu_cortex_a53/smp


### PR DESCRIPTION
Use platform key for filtering to avoid cmake issues with unsupported
platforms.

Fixes #71870

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
