### PR TITLE
Bluetooth: Controller: Minor cleanup of struct proc_ctx

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.c
@@ -326,7 +326,6 @@ static struct proc_ctx *create_procedure(enum llcp_proc proc, struct llcp_mem_po
 	}
 
 	ctx->proc = proc;
-	ctx->collision = 0U;
 	ctx->done = 0U;
 	ctx->rx_greedy = 0U;
 	ctx->node_ref.rx = NULL;

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
@@ -158,8 +158,11 @@ struct proc_ctx {
 	/* Last transmitted opcode used for unknown/reject */
 	enum pdu_data_llctrl_type tx_opcode;
 
-	/* Instant collision */
-	int collision;
+	/*
+	 * This flag is set to 1 when we are finished with the control
+	 * procedure and it is safe to release the context ctx
+	 */
+	uint8_t done;
 
 #if defined(LLCP_TX_CTRL_BUF_QUEUE_ENABLE)
 	/* Procedure wait reason */
@@ -176,11 +179,6 @@ struct proc_ctx {
 		/* pre-allocated TX node */
 		struct node_tx *tx;
 	} node_ref;
-	/*
-	 * This flag is set to 1 when we are finished with the control
-	 * procedure and it is safe to release the context ctx
-	 */
-	int done;
 
 	/* Procedure data */
 	union {

--- a/tests/bluetooth/controller/ctrl_api/src/main.c
+++ b/tests/bluetooth/controller/ctrl_api/src/main.c
@@ -464,7 +464,6 @@ ZTEST(internal, test_int_create_proc)
 	zassert_not_null(ctx, NULL);
 
 	zassert_equal(ctx->proc, PROC_VERSION_EXCHANGE);
-	zassert_equal(ctx->collision, 0);
 
 	for (int i = 0U; i < CONFIG_BT_CTLR_LLCP_LOCAL_PROC_CTX_BUF_NUM; i++) {
 		zassert_not_null(ctx, NULL);


### PR DESCRIPTION
Remove unused collision field

Change type of done to uint8_t and move it to avoid padding bytes