### PR TITLE
tests: Bluetooth: Update Host Launch Studio Project and ICS

### DIFF
--- a/tests/bluetooth/qualification/ICS_Zephyr_Bluetooth_Host.pts
+++ b/tests/bluetooth/qualification/ICS_Zephyr_Bluetooth_Host.pts
@@ -2091,6 +2091,10 @@
       </item>
       <item>
         <table>8</table>
+        <row>2</row>
+      </item>
+      <item>
+        <table>8</table>
         <row>1</row>
       </item>
       <item>
@@ -2100,6 +2104,10 @@
       <item>
         <table>8</table>
         <row>8</row>
+      </item>
+      <item>
+        <table>8</table>
+        <row>6</row>
       </item>
       <item>
         <table>8</table>
@@ -2155,6 +2163,14 @@
       </item>
       <item>
         <table>4</table>
+        <row>4</row>
+      </item>
+      <item>
+        <table>4</table>
+        <row>5</row>
+      </item>
+      <item>
+        <table>4</table>
         <row>6</row>
       </item>
       <item>
@@ -2175,15 +2191,15 @@
       </item>
       <item>
         <table>5</table>
-        <row>4</row>
-      </item>
-      <item>
-        <table>5</table>
         <row>5</row>
       </item>
       <item>
         <table>5</table>
         <row>6</row>
+      </item>
+      <item>
+        <table>5</table>
+        <row>9</row>
       </item>
       <item>
         <table>6</table>
@@ -6108,10 +6124,6 @@
         <row>4</row>
       </item>
       <item>
-        <table>33a</table>
-        <row>8</row>
-      </item>
-      <item>
         <table>47</table>
         <row>3</row>
       </item>
@@ -6130,10 +6142,6 @@
       <item>
         <table>73</table>
         <row>6</row>
-      </item>
-      <item>
-        <table>33a</table>
-        <row>4</row>
       </item>
       <item>
         <table>45</table>
@@ -6282,10 +6290,6 @@
       <item>
         <table>22</table>
         <row>9</row>
-      </item>
-      <item>
-        <table>88</table>
-        <row>5</row>
       </item>
       <item>
         <table>68</table>
@@ -6506,10 +6510,6 @@
       <item>
         <table>9a</table>
         <row>4</row>
-      </item>
-      <item>
-        <table>33a</table>
-        <row>5</row>
       </item>
       <item>
         <table>53</table>
@@ -6860,10 +6860,6 @@
         <row>9</row>
       </item>
       <item>
-        <table>33a</table>
-        <row>6</row>
-      </item>
-      <item>
         <table>34</table>
         <row>1</row>
       </item>
@@ -7090,10 +7086,6 @@
       <item>
         <table>9a</table>
         <row>3</row>
-      </item>
-      <item>
-        <table>33a</table>
-        <row>2</row>
       </item>
       <item>
         <table>36</table>

--- a/tests/bluetooth/qualification/Project_Zephyr_Bluetooth_Host.bls
+++ b/tests/bluetooth/qualification/Project_Zephyr_Bluetooth_Host.bls
@@ -2094,6 +2094,10 @@
       </item>
       <item>
         <table>8</table>
+        <row>2</row>
+      </item>
+      <item>
+        <table>8</table>
         <row>1</row>
       </item>
       <item>
@@ -2103,6 +2107,10 @@
       <item>
         <table>8</table>
         <row>8</row>
+      </item>
+      <item>
+        <table>8</table>
+        <row>6</row>
       </item>
       <item>
         <table>8</table>
@@ -2158,6 +2166,14 @@
       </item>
       <item>
         <table>4</table>
+        <row>4</row>
+      </item>
+      <item>
+        <table>4</table>
+        <row>5</row>
+      </item>
+      <item>
+        <table>4</table>
         <row>6</row>
       </item>
       <item>
@@ -2178,15 +2194,15 @@
       </item>
       <item>
         <table>5</table>
-        <row>4</row>
-      </item>
-      <item>
-        <table>5</table>
         <row>5</row>
       </item>
       <item>
         <table>5</table>
         <row>6</row>
+      </item>
+      <item>
+        <table>5</table>
+        <row>9</row>
       </item>
       <item>
         <table>6</table>
@@ -6111,10 +6127,6 @@
         <row>4</row>
       </item>
       <item>
-        <table>33a</table>
-        <row>8</row>
-      </item>
-      <item>
         <table>47</table>
         <row>3</row>
       </item>
@@ -6133,10 +6145,6 @@
       <item>
         <table>73</table>
         <row>6</row>
-      </item>
-      <item>
-        <table>33a</table>
-        <row>4</row>
       </item>
       <item>
         <table>45</table>
@@ -6285,10 +6293,6 @@
       <item>
         <table>22</table>
         <row>9</row>
-      </item>
-      <item>
-        <table>88</table>
-        <row>5</row>
       </item>
       <item>
         <table>68</table>
@@ -6509,10 +6513,6 @@
       <item>
         <table>9a</table>
         <row>4</row>
-      </item>
-      <item>
-        <table>33a</table>
-        <row>5</row>
       </item>
       <item>
         <table>53</table>
@@ -6863,10 +6863,6 @@
         <row>9</row>
       </item>
       <item>
-        <table>33a</table>
-        <row>6</row>
-      </item>
-      <item>
         <table>34</table>
         <row>1</row>
       </item>
@@ -7093,10 +7089,6 @@
       <item>
         <table>9a</table>
         <row>3</row>
-      </item>
-      <item>
-        <table>33a</table>
-        <row>2</row>
       </item>
       <item>
         <table>36</table>


### PR DESCRIPTION
Changes:
 BAP: disable 33a/2, 33a/4, 33a/5, 33a/6 and 33a/8 because the
      Zephyr Host does not allow the client to establish a CIS
      in the QoS Configured state.
 BAP: disable 88/5 due to no PAST support in Zephyr Controller.
 OTS: Adjust to match implementation status (exluding 4/20 which
      needs to be implemented due to MCP dependency)