### PR TITLE
Bluetooth: Audio: Shell: Add encryption to audio shell

### DIFF
--- a/tests/bluetooth/shell/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
+++ b/tests/bluetooth/shell/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
@@ -4,3 +4,4 @@ CONFIG_LIBLC3=y
 # The LC3 codec uses a large amount of stack. This app runs the codec in the work-queue, hence
 # inctease stack size for that thread.
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
+CONFIG_BT_TINYCRYPT_ECC=y


### PR DESCRIPTION
This commit adds support for LESC in the host of audio shell if the controller does not support the public key generation for ECDH.