### PR TITLE
test: mcuboot: enable test for rd_rw612_bga

### DIFF
--- a/tests/boot/test_mcuboot/testcase.yaml
+++ b/tests/boot/test_mcuboot/testcase.yaml
@@ -34,6 +34,7 @@ tests:
       - mimxrt595_evk/mimxrt595s/cm33
       - mimxrt685_evk/mimxrt685s/cm33
       - nrf52840dk/nrf52840
+      - rd_rw612_bga
     integration_platforms:
       - frdm_k64f
       - nrf52840dk/nrf52840


### PR DESCRIPTION
Enable mcuboot test for rd_rw612_bga