### PR TITLE
scripts: twister: Remove Handler dead code

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -72,7 +72,6 @@ class Handler:
         """
         self.options = None
 
-        self.state = "waiting"
         self.run = False
         self.type_str = type_str
 
@@ -86,7 +85,6 @@ class Handler:
         self.build_dir = instance.build_dir
         self.log = os.path.join(self.build_dir, "handler.log")
         self.returncode = 0
-        self.generator = None
         self.generator_cmd = None
         self.suite_name_check = True
         self.ready = False
@@ -178,7 +176,6 @@ class BinaryHandler(Handler):
         """
         super().__init__(instance, type_str)
 
-        self.call_west_flash = False
         self.seed = None
         self.extra_test_args = None
         self.line = b""
@@ -241,8 +238,6 @@ class BinaryHandler(Handler):
             command = [self.generator_cmd, "run_renode_test"]
         elif self.call_make_run:
             command = [self.generator_cmd, "run"]
-        elif self.call_west_flash:
-            command = ["west", "flash", "--skip-rebuild", "-d", self.build_dir]
         else:
             command = [self.binary]
 
@@ -856,7 +851,7 @@ class QEMUHandler(Handler):
             handler.instance.reason = "Unknown"
 
     @staticmethod
-    def _thread(handler, timeout, outdir, logfile, fifo_fn, pid_fn, results,
+    def _thread(handler, timeout, outdir, logfile, fifo_fn, pid_fn,
                 harness, ignore_unexpected_eof=False):
         fifo_in, fifo_out = QEMUHandler._thread_get_fifo_names(fifo_fn)
 
@@ -997,7 +992,6 @@ class QEMUHandler(Handler):
             self.instance.add_missing_case_status("blocked")
 
     def handle(self, harness):
-        self.results = {}
         self.run = True
 
         sysbuild_build_dir = self._get_sysbuild_build_dir()
@@ -1009,7 +1003,7 @@ class QEMUHandler(Handler):
         self.thread = threading.Thread(name=self.name, target=QEMUHandler._thread,
                                        args=(self, self.get_test_timeout(), self.build_dir,
                                              self.log_fn, self.fifo_fn,
-                                             self.pid_fn, self.results, harness,
+                                             self.pid_fn, harness,
                                              self.ignore_unexpected_eof))
 
         self.thread.daemon = True
@@ -1088,7 +1082,6 @@ class QEMUWinHandler(Handler):
         self.pid = 0
         self.thread = None
         self.stop_thread = False
-        self.results = {}
 
         if instance.testsuite.ignore_qemu_crash:
             self.ignore_qemu_crash = True
@@ -1296,7 +1289,6 @@ class QEMUWinHandler(Handler):
         self._stop_qemu_process(self.pid)
 
     def handle(self, harness):
-        self.results = {}
         self.run = True
 
         sysbuild_build_dir = self._get_sysbuild_build_dir()

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -201,7 +201,6 @@ class TestInstance:
         if handler:
             handler.options = options
             handler.generator_cmd = env.generator_cmd
-            handler.generator = env.generator
             handler.suite_name_check = not options.disable_suite_name_check
         self.handler = handler
 

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -442,28 +442,25 @@ def test_binaryhandler_output_handler(
 
 
 TESTDATA_4 = [
-    (True, False, False, True, None, None,
+    (True, False, True, None, None,
      ['valgrind', '--error-exitcode=2', '--leak-check=full',
       f'--suppressions={ZEPHYR_BASE}/scripts/valgrind.supp',
       '--log-file=build_dir/valgrind.log', '--track-origins=yes',
       'generator', 'run_renode_test']),
-    (False, True, False, False, 123, None, ['generator', 'run', '--seed=123']),
-    (False, False, True, False, None, None,
-     ['west', 'flash', '--skip-rebuild', '-d', 'build_dir']),
-    (False, False, False, False, None, ['ex1', 'ex2'], ['bin', 'ex1', 'ex2']),
+    (False, True, False, 123, None, ['generator', 'run', '--seed=123']),
+    (False, False, False, None, ['ex1', 'ex2'], ['bin', 'ex1', 'ex2']),
 ]
 
 @pytest.mark.parametrize(
-    'robot_test, call_make_run, call_west_flash, enable_valgrind, seed,' \
+    'robot_test, call_make_run, enable_valgrind, seed,' \
     ' extra_args, expected',
     TESTDATA_4,
-    ids=['robot, valgrind', 'make run, seed', 'west flash', 'binary, extra']
+    ids=['robot, valgrind', 'make run, seed', 'binary, extra']
 )
 def test_binaryhandler_create_command(
     mocked_instance,
     robot_test,
     call_make_run,
-    call_west_flash,
     enable_valgrind,
     seed,
     extra_args,
@@ -473,7 +470,6 @@ def test_binaryhandler_create_command(
     handler.generator_cmd = 'generator'
     handler.binary = 'bin'
     handler.call_make_run = call_make_run
-    handler.call_west_flash = call_west_flash
     handler.options = mock.Mock(enable_valgrind=enable_valgrind)
     handler.seed = seed
     handler.extra_test_args = extra_args
@@ -1893,7 +1889,6 @@ def test_qemuhandler_thread(
 
     type(mocked_instance.testsuite).timeout = mock.PropertyMock(return_value=timeout)
     handler = QEMUHandler(mocked_instance, 'build')
-    handler.results = {}
     handler.ignore_unexpected_eof = False
     handler.pid_fn = 'pid_fn'
     handler.fifo_fn = 'fifo_fn'
@@ -1953,7 +1948,6 @@ def test_qemuhandler_thread(
             handler.log,
             handler.fifo_fn,
             handler.pid_fn,
-            handler.results,
             harness,
             handler.ignore_unexpected_eof
         )


### PR DESCRIPTION
Removed following fields from relevant Handlers, as they were unused in code:
* `Handler`'s `state`
  * Previously `Handler` could have its own states, used in e.g. `runner.py`'s `process()`
* `Handler`'s `generator`
  * Previously used in `run_cmake()` to construct `cmake_args`.
* `BinaryHandler`'s `call_west_flash`
  * Used for `mdb` between commits 16032b67e85b721d549e44e9de4fe3ffbe958e67 and b78d6740ec3510cc99b41c998544bcac747b4e40.
* `QEMUHandler`'s `results`
  * Set, never used.
* `QEMUWinHandler`'s `results`
  * Set, never used.