### PR TITLE
posix: uname: increase version name length

### DIFF
--- a/lib/posix/options/Kconfig.uname
+++ b/lib/posix/options/Kconfig.uname
@@ -12,7 +12,7 @@ menuconfig POSIX_UNAME
 if POSIX_UNAME
 config POSIX_UNAME_VERSION_LEN
 	int "uname version string length"
-	default 60
+	default 70
 	help
 	  Defines the maximum string length of uname version.
 


### PR DESCRIPTION
Creating this just in case.

Something else has to be done if the hash can go over this length.