### PR TITLE
i2c: RAM test improvements

### DIFF
--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -54,8 +54,15 @@ config I2C_CALLBACK
 	help
 	  API and implementations of i2c_transfer_cb.
 
+config HAS_I2C_RTIO
+	bool
+	help
+	  This option must be selected by I2C controller drivers that optionally implement the RTIO
+	  interface.
+
 config I2C_RTIO
 	bool "I2C RTIO API"
+	depends on HAS_I2C_RTIO
 	select RTIO
 	help
 	  API and implementations of I2C for RTIO

--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -182,6 +182,7 @@ config I2C_MCUX_LPI2C
 	default y
 	depends on DT_HAS_NXP_IMX_LPI2C_ENABLED
 	depends on CLOCK_CONTROL
+	select HAS_I2C_RTIO
 	select PINCTRL
 	help
 	  Enable the mcux LPI2C driver.

--- a/drivers/i2c/Kconfig.sam_twihs
+++ b/drivers/i2c/Kconfig.sam_twihs
@@ -7,5 +7,6 @@ config I2C_SAM_TWIHS
 	bool "Atmel SAM (TWIHS) I2C driver"
 	default y
 	depends on DT_HAS_ATMEL_SAM_I2C_TWIHS_ENABLED
+	select HAS_I2C_RTIO
 	help
 	  Enable Atmel SAM MCU Family (TWIHS) I2C bus driver.

--- a/tests/drivers/i2c/i2c_ram/src/test_i2c_ram.c
+++ b/tests/drivers/i2c/i2c_ram/src/test_i2c_ram.c
@@ -13,6 +13,7 @@
  */
 
 #include <zephyr/drivers/i2c.h>
+#include <zephyr/pm/device_runtime.h>
 #include <zephyr/kernel.h>
 #include <zephyr/ztest.h>
 #include <zephyr/tc_util.h>
@@ -73,6 +74,17 @@ static void i2c_ram_before(void *f)
 	rx_cmd[1] = (addr) & 0xFF;
 	addr += ARRAY_SIZE(tx_data) - TX_DATA_OFFSET;
 	memset(rx_data, 0, ARRAY_SIZE(rx_data));
+
+#ifdef CONFIG_PM_DEVICE_RUNTIME
+	pm_device_runtime_get(i2c_dev);
+#endif
+}
+
+static void i2c_ram_after(void *f)
+{
+#ifdef CONFIG_PM_DEVICE_RUNTIME
+	pm_device_runtime_put(i2c_dev);
+#endif
 }
 
 ZTEST(i2c_ram, test_ram_transfer)
@@ -294,4 +306,4 @@ ZTEST(i2c_ram, test_ram_rtio_isr)
 
 #endif /* CONFIG_I2C_RTIO */
 
-ZTEST_SUITE(i2c_ram, NULL, i2c_ram_setup, i2c_ram_before, NULL, NULL);
+ZTEST_SUITE(i2c_ram, NULL, i2c_ram_setup, i2c_ram_before, i2c_ram_after, NULL);

--- a/tests/drivers/i2c/i2c_ram/testcase.yaml
+++ b/tests/drivers/i2c/i2c_ram/testcase.yaml
@@ -3,7 +3,7 @@ common:
   tags:
     - drivers
     - i2c
-  filter: dt_alias_exists("i2c_ram")
+  filter: dt_alias_exists("i2c-ram")
 tests:
   drivers.i2c.ram:
     depends_on: i2c

--- a/tests/drivers/i2c/i2c_ram/testcase.yaml
+++ b/tests/drivers/i2c/i2c_ram/testcase.yaml
@@ -11,5 +11,19 @@ tests:
       - drivers
       - i2c
   drivers.i2c.ram.rtio:
+    filter: CONFIG_HAS_I2C_RTIO
     extra_configs:
+      - CONFIG_I2C_RTIO=y
+  drivers.i2c.ram.pm:
+    filter: CONFIG_HAS_PM
+    extra_configs:
+      - CONFIG_PM=y
+      - CONFIG_PM_DEVICE=y
+      - CONFIG_PM_DEVICE_RUNTIME=y
+  drivers.i2c.ram.pm.rtio:
+    filter: CONFIG_HAS_PM and CONFIG_HAS_I2C_RTIO
+    extra_configs:
+      - CONFIG_PM=y
+      - CONFIG_PM_DEVICE=y
+      - CONFIG_PM_DEVICE_RUNTIME=y
       - CONFIG_I2C_RTIO=y


### PR DESCRIPTION
Better support i2c ram tests by signaling that a driver supports RTIO (HAS_I2C_RTIO in Kconfig), and supporting power management in the test case.