### PR TITLE
drivers: video: ov2640: add clock rate control property

### DIFF
--- a/drivers/video/ov2640.c
+++ b/drivers/video/ov2640.c
@@ -435,6 +435,7 @@ struct ov2640_config {
 #if DT_INST_NODE_HAS_PROP(0, reset_gpios)
 	struct gpio_dt_spec reset_gpio;
 #endif
+	uint8_t clock_rate_control;
 };
 
 struct ov2640_data {
@@ -821,7 +822,7 @@ static int ov2640_set_resolution(const struct device *dev,
 
 	/* Set CLKRC */
 	ret |= ov2640_write_reg(&cfg->i2c, BANK_SEL, BANK_SEL_SENSOR);
-	ret |= ov2640_write_reg(&cfg->i2c, CLKRC, 0x87);
+	ret |= ov2640_write_reg(&cfg->i2c, CLKRC, cfg->clock_rate_control);
 
 	/* Write DSP input registers */
 	ov2640_write_all(dev, uxga_regs, ARRAY_SIZE(uxga_regs));
@@ -1030,6 +1031,7 @@ static const struct ov2640_config ov2640_cfg_0 = {
 #if DT_INST_NODE_HAS_PROP(0, reset_gpios)
 	.reset_gpio = GPIO_DT_SPEC_INST_GET(0, reset_gpios),
 #endif
+	.clock_rate_control = DT_INST_PROP(0, clock_rate_control),
 };
 static struct ov2640_data ov2640_data_0;
 

--- a/dts/bindings/video/ovti,ov2640.yaml
+++ b/dts/bindings/video/ovti,ov2640.yaml
@@ -12,4 +12,18 @@ properties:
       The RESETn pin is asserted to disable the sensor causing a hard
       reset.  The sensor receives this as an active-low signal.
 
+  clock-rate-control:
+    type: int
+    default: 0x87
+    description: |
+      Define the value to the Clock Rate Control register. By changing
+      the system clock divide ratio and PLL, the frame rate and pixel
+      rate will change together.
+      Bit[7]    Internal frequency doublers ON/OFF selection.
+                0: ON       1: OFF
+      Bit[6]    Reserved
+      Bit[5:0]  Clock divider.
+
+      CLK = XVCLK /(decimal value of CLKRC[5:0] + 1)
+
 include: i2c-device.yaml


### PR DESCRIPTION
Add Clock Rate Control property to OV2640 CMOS video sensor. Changing the system clock divide ratio and PLL will change the frame rate and pixel rate together.

Note: The `0x87` value was kept as default.

Default CLKRC value.

https://github.com/zephyrproject-rtos/zephyr/assets/27859307/33569380-ea36-4b13-99be-78d9c4d270af

CLKRC from https://github.com/zephyrproject-rtos/zephyr/pull/71463 sample.

https://github.com/zephyrproject-rtos/zephyr/assets/27859307/4ea36b1c-56e5-44f7-9358-8d6f36549456


