### PR TITLE
west: linkserver: change to flash command line as required by v1.5.xx

### DIFF
--- a/scripts/west_commands/runners/linkserver.py
+++ b/scripts/west_commands/runners/linkserver.py
@@ -186,12 +186,7 @@ class LinkServerBinaryRunner(ZephyrBinaryRunner):
 
     def flash(self, **kwargs):
 
-        if self.core is not None:
-            _cmd_core = ":"+self.core
-        else:
-            _cmd_core = ""
-
-        linkserver_cmd = ([self.linkserver, "flash"] + ["--probe", str(self.probe)] + self.override_cli + [self.device+_cmd_core])
+        linkserver_cmd = ([self.linkserver, "flash"] + ["--probe", str(self.probe)] + self.override_cli + [self.device])
         self.logger.debug(f'LinkServer cmd:  + {linkserver_cmd}')
 
         if self.erase:


### PR DESCRIPTION
LinkServer v1.5.30 brings changes to the flash command: there is no need to specify the core. This is actually rejected with linkserver v1.5.xx and after. 

This commit brings changes to the west runner for LinkServer to reflect this CLI change.