### PR TITLE
doc: tests: i2c_ram: Specify required Hardware Setup

### DIFF
--- a/tests/drivers/i2c/i2c_ram/README.rst
+++ b/tests/drivers/i2c/i2c_ram/README.rst
@@ -4,3 +4,8 @@ i2c ram test
 Tests an i2c controller driver against a (s/f/nv)ram module doing a simple write and readback.
 
 Excercises most of the i2c controller APIs in the process.
+
+Hardware Setup
+==============
+- Target supporting I2C (with RTIO for the I2C_RTIO test-cases), e.g: mimxrt1010_evk.
+- External I2C RAM chipset connected to the I2C bus, e.g: Fujitsu's MB85 FeRAM.


### PR DESCRIPTION
This test-suite requires an external I2C RAM connected to the I2C bus. Adding section of "Hardware Setup" to provide guidance to users interested in running the suite.
