### PR TITLE
net: lib: dhcpv6: add prefix delegation

### DIFF
--- a/include/zephyr/net/dhcpv6.h
+++ b/include/zephyr/net/dhcpv6.h
@@ -11,6 +11,8 @@
 #ifndef ZEPHYR_INCLUDE_NET_DHCPV6_H_
 #define ZEPHYR_INCLUDE_NET_DHCPV6_H_
 
+#include <zephyr/net/net_ip.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -96,6 +98,39 @@ void net_dhcpv6_stop(struct net_if *iface);
  *  @param iface A valid pointer to a network interface
  */
 void net_dhcpv6_restart(struct net_if *iface);
+
+/**
+ *  @brief Allocates 64-bit subnet prefix
+ *
+ *  @details When CONFIG_NET_CONFIG_DHCPV6_PREFIX_DELEGATION is enabled this
+ *  function allows to allocate a subnet's prefix based on the one received
+ *  from DHCPv6 server.
+ *
+ *  @param iface Network interface that has a bound prefix
+ *  @param prefix Pointer to an address to store the subnet's prefix
+ *
+ *  @return 0 on success
+ *  @return -ENOTSUP If the prefix delegation is disabled
+ *  @return -EINVAL If client does not request a prefix
+ *  @return -EINPROGRESS If a prefix is not yet bound
+ *  @return -ENOBUFS If there are no more subnets to be allocated
+ */
+int net_dhcpv6_subnet_alloc(struct net_if *iface, struct in6_addr *prefix);
+
+/**
+ *  @brief Frees 64-bit subnet prefix
+ *
+ *  @details When CONFIG_NET_CONFIG_DHCPV6_PREFIX_DELEGATION is enabled this
+ *  function allows to free a previously allocated subnet's prefix.
+ *
+ *  @param iface Network interface that allocated the subnet
+ *  @param prefix Subnet's prefix
+ *
+ *  @return 0 on success
+ *  @return -ENOTSUP If the prefix delegation is disabled
+ *  @return -EALREADY If the subnet is not currently allocated
+ */
+int net_dhcpv6_subnet_free(struct net_if *iface, struct in6_addr *prefix);
 
 /** @cond INTERNAL_HIDDEN */
 

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -352,6 +352,11 @@ struct net_if_dhcpv6 {
 	/** Prefix length. */
 	uint8_t prefix_len;
 
+	/** Delegated subnets, used only when
+	 *  NET_CONFIG_DHCPV6_PREFIX_DELEGATION is enabled.
+	 */
+	uint32_t delegated_subnets_mask;
+
 	/** Assigned IPv6 prefix. */
 	struct in6_addr prefix;
 

--- a/subsys/net/ip/CMakeLists.txt
+++ b/subsys/net/ip/CMakeLists.txt
@@ -37,6 +37,7 @@ zephyr_library_sources_ifdef(CONFIG_NET_IPV4_IGMP    igmp.c)
 zephyr_library_sources_ifdef(CONFIG_NET_IPV6         icmpv6.c nbr.c
                                                      ipv6.c ipv6_nbr.c)
 zephyr_library_sources_ifdef(CONFIG_NET_IPV6_MLD     ipv6_mld.c)
+zephyr_library_sources_ifdef(CONFIG_NET_IPV6_AUTOCONF ipv6_autoconf.c)
 zephyr_library_sources_ifdef(CONFIG_NET_IPV6_FRAGMENT     ipv6_fragment.c)
 zephyr_library_sources_ifdef(CONFIG_NET_IPV4_FRAGMENT     ipv4_fragment.c)
 zephyr_library_sources_ifdef(CONFIG_NET_ROUTE        route.c)

--- a/subsys/net/ip/Kconfig.ipv6
+++ b/subsys/net/ip/Kconfig.ipv6
@@ -191,6 +191,13 @@ config NET_MAX_6LO_CONTEXTS
 	  6lowpan context options table size. The value depends on your
 	  network and memory consumption. More 6CO options uses more memory.
 
+config NET_IPV6_AUTOCONF
+	bool
+	default y if NET_DHCPV6 || NET_IPV6_ND
+	help
+	  Hidden value enabling autoconfiguration of IPv6 addresses based on
+	  prefixes received from DHCPv6 server or with Router Advertisements.
+
 if NET_6LO
 module = NET_6LO
 module-dep = NET_LOG

--- a/subsys/net/ip/ipv6.h
+++ b/subsys/net/ip/ipv6.h
@@ -538,6 +538,31 @@ void net_ipv6_mld_init(void);
 #endif
 
 /**
+ * @brief Add auto configured IPv6 address
+ *
+ * @param iface Network interface
+ * @param prefix Subnet prefix
+ * @param valid_lifetime Lifetime of the subnet prefix
+ *
+ * @return Pointer to the address on success, NULL otherwise
+ */
+#if defined(CONFIG_NET_IPV6_AUTOCONF)
+struct net_if_addr *net_ipv6_autoconf_addr_add(struct net_if *iface, const struct in6_addr *prefix,
+					       uint32_t valid_lifetime);
+#else
+static inline
+struct net_if_addr *net_ipv6_autoconf_addr_add(struct net_if *iface, const struct in6_addr *prefix,
+					       uint32_t valid_lifetime)
+{
+	ARG_UNUSED(iface);
+	ARG_UNUSED(prefix);
+	ARG_UNUSED(valid_lifetime);
+
+	return NULL;
+}
+#endif
+
+/**
  * @brief Decode DSCP value from TC field.
  *
  * @param tc TC field value from the IPv6 header.

--- a/subsys/net/ip/ipv6_autoconf.c
+++ b/subsys/net/ip/ipv6_autoconf.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** @file
+ *  @brief IPv6 address autoconfiguration
+ */
+
+#include "ipv6.h"
+
+LOG_MODULE_DECLARE(net_ipv6, CONFIG_NET_IPV6_LOG_LEVEL);
+
+#include "net_private.h"
+
+#define IPV6_SUBNET_BYTES 8
+#define TWO_HOURS (2 * 60 * 60)
+
+static inline uint32_t remaining_lifetime(struct net_if_addr *ifaddr)
+{
+	return net_timeout_remaining(&ifaddr->lifetime, k_uptime_get_32());
+}
+
+struct net_if_addr *net_ipv6_autoconf_addr_add(struct net_if *iface, const struct in6_addr *prefix,
+					       uint32_t valid_lifetime)
+{
+	struct in6_addr addr = { };
+	struct net_if_addr *ifaddr;
+
+	/* Create IPv6 address using the given prefix and iid. We first
+	 * setup link local address, and then copy prefix over first 8
+	 * bytes of that address.
+	 */
+	net_ipv6_addr_create_iid(&addr, net_if_get_link_addr(iface));
+	memcpy(&addr, prefix, IPV6_SUBNET_BYTES);
+
+	ifaddr = net_if_ipv6_addr_lookup(&addr, NULL);
+	if (ifaddr && ifaddr->addr_type == NET_ADDR_AUTOCONF) {
+		if (valid_lifetime == NET_IPV6_ND_INFINITE_LIFETIME) {
+			net_if_addr_set_lf(ifaddr, true);
+			return ifaddr;
+		}
+
+		/* RFC 4862 ch 5.5.3 */
+		if ((valid_lifetime > TWO_HOURS) || (valid_lifetime > remaining_lifetime(ifaddr))) {
+			NET_DBG("Timer updating for address %s long lifetime %u secs",
+				net_sprint_ipv6_addr(&addr), valid_lifetime);
+
+			net_if_ipv6_addr_update_lifetime(ifaddr, valid_lifetime);
+		} else {
+			NET_DBG("Timer updating for address %s lifetime %u secs",
+				net_sprint_ipv6_addr(&addr), TWO_HOURS);
+
+			net_if_ipv6_addr_update_lifetime(ifaddr, TWO_HOURS);
+		}
+
+		net_if_addr_set_lf(ifaddr, false);
+	} else {
+		if (valid_lifetime == NET_IPV6_ND_INFINITE_LIFETIME) {
+			ifaddr = net_if_ipv6_addr_add(iface, &addr, NET_ADDR_AUTOCONF, 0);
+		} else {
+			ifaddr = net_if_ipv6_addr_add(iface, &addr, NET_ADDR_AUTOCONF,
+				 valid_lifetime);
+		}
+	}
+
+	return ifaddr;
+}

--- a/subsys/net/lib/config/Kconfig
+++ b/subsys/net/lib/config/Kconfig
@@ -202,6 +202,23 @@ config NET_CONFIG_DHCPV6_REQUEST_PREFIX
 	  When DHCPv6 is enabled this will configure the DHCPv6 client to
 	  request IPv6 prefix from the DHCPv6 server.
 
+config NET_CONFIG_DHCPV6_PREFIX_DELEGATION
+	bool "Delegate 64-bit IPv6 prefixes"
+	depends on NET_CONFIG_DHCPV6_REQUEST_PREFIX
+	help
+	  Allow delegation of 64-bit subnet prefixes based on prefix
+	  received from DHCPv6 server. Number of available subnets depend
+	  on length of the base prefix delegated by the DHCPv6 server.
+
+config NET_CONFIG_DHCPV6_REQUESTED_PREFIX_LEN
+	int "Requested prefix length"
+	depends on NET_CONFIG_DHCPV6_REQUEST_PREFIX
+	range 1 128
+	range 1 63 if NET_CONFIG_DHCPV6_PREFIX_DELEGATION
+	default 64
+	help
+	  Prefix length option in DHCPv6 request.
+
 endif # NET_DHCPV6
 
 config NET_CONFIG_CLOCK_SNTP_INIT


### PR DESCRIPTION
This PR adds two commits:
1. Autoconfiguration of IPv6 addresses is moved to a separate unit so it can be used also by DHCPv6 module
2. Add option to distribute multiple IPv6 subnets based on a prefix received from DHCPv6 server