### PR TITLE
Userspace: avoid to convert pointers to incomplete type using the pointer to first item 

### DIFF
--- a/include/zephyr/app_memory/app_memdomain.h
+++ b/include/zephyr/app_memory/app_memdomain.h
@@ -128,16 +128,16 @@ struct z_app_region {
 	extern char Z_APP_START(name)[]; \
 	extern char Z_APP_SIZE(name)[]; \
 	struct k_mem_partition name = { \
-		.start = (uintptr_t) &Z_APP_START(name), \
-		.size = (size_t) &Z_APP_SIZE(name), \
+		.start = (uintptr_t) &Z_APP_START(name)[0], \
+		.size = (size_t) &Z_APP_SIZE(name)[0], \
 		.attr = K_MEM_PARTITION_P_RW_U_RW \
 	}; \
 	extern char Z_APP_BSS_START(name)[]; \
 	extern char Z_APP_BSS_SIZE(name)[]; \
 	Z_GENERIC_SECTION(.app_regions.name) \
 	const struct z_app_region name##_region = { \
-		.bss_start = &Z_APP_BSS_START(name), \
-		.bss_size = (size_t) &Z_APP_BSS_SIZE(name) \
+		.bss_start = &Z_APP_BSS_START(name)[0], \
+		.bss_size = (size_t) &Z_APP_BSS_SIZE(name)[0] \
 	}; \
 	Z_APPMEM_PLACEHOLDER(name)
 #else


### PR DESCRIPTION
Fix coding guideline MISRA C:2012 Rule 11.2 in includes:

> Conversions shall not be performed between a pointer to an incomplete type and any other type.

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/9043b65acf61cd2f6dac9450c55f0ad747ea9549