### PR TITLE
kernel: avoid to convert pointers to incomplete type using the pointer to first item

### DIFF
--- a/kernel/include/mmu.h
+++ b/kernel/include/mmu.h
@@ -36,8 +36,8 @@
 #define Z_VIRT_RAM_END		(Z_VIRT_RAM_START + Z_VIRT_RAM_SIZE)
 
 /* Boot-time virtual location of the kernel image. */
-#define Z_KERNEL_VIRT_START	((uint8_t *)(&z_mapped_start))
-#define Z_KERNEL_VIRT_END	((uint8_t *)(&z_mapped_end))
+#define Z_KERNEL_VIRT_START	((uint8_t *)&z_mapped_start[0])
+#define Z_KERNEL_VIRT_END	((uint8_t *)&z_mapped_end[0])
 #define Z_KERNEL_VIRT_SIZE	(Z_KERNEL_VIRT_END - Z_KERNEL_VIRT_START)
 
 #define Z_VM_OFFSET	 ((CONFIG_KERNEL_VM_BASE + CONFIG_KERNEL_VM_OFFSET) - \

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -929,8 +929,8 @@ static int app_shmem_bss_zero(void)
 	struct z_app_region *region, *end;
 
 
-	end = (struct z_app_region *)&__app_shmem_regions_end;
-	region = (struct z_app_region *)&__app_shmem_regions_start;
+	end = (struct z_app_region *)&__app_shmem_regions_end[0];
+	region = (struct z_app_region *)&__app_shmem_regions_start[0];
 
 	for ( ; region < end; region++) {
 #if defined(CONFIG_DEMAND_PAGING) && !defined(CONFIG_LINKER_GENERIC_SECTIONS_PRESENT_AT_BOOT)


### PR DESCRIPTION
Fix coding guideline MISRA C:2012 Rule 11.2 in kernel:

> Conversions shall not be performed between a pointer to an incomplete type and any other type.

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/9043b65acf61cd2f6dac9450c55f0ad747ea9549