### PR TITLE
Bluetooth: CAP: Shell: Fix minors bugs with unicast_stop

### DIFF
--- a/doc/connectivity/bluetooth/api/audio/shell/cap.rst
+++ b/doc/connectivity/bluetooth/api/audio/shell/cap.rst
@@ -86,7 +86,7 @@ The CAP initiator also supports broadcast audio as a source.
                         <cnt> (default 1)] [conns (<cnt> | all) (default 1)]
      unicast_list      : Unicast list streams
      unicast_update    : Unicast Update <all | stream [stream [stream...]]>
-     unicast_stop      :Unicast stop streams [stream [stream [stream...]]] (all by default)
+     unicast_stop      : Unicast stop streams [stream [stream [stream...]]] (all by default)
      unicast_cancel    : Unicast cancel current procedure
      ac_1              : Unicast audio configuration 1
      ac_2              : Unicast audio configuration 2

--- a/subsys/bluetooth/audio/shell/cap_initiator.c
+++ b/subsys/bluetooth/audio/shell/cap_initiator.c
@@ -1344,7 +1344,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      cmd_cap_initiator_unicast_update, 2, CAP_UNICAST_CLIENT_STREAM_COUNT),
 	SHELL_CMD_ARG(unicast_stop, NULL,
 		      "Unicast stop streams [stream [stream [stream...]]] (all by default)",
-		      cmd_cap_initiator_unicast_stop, 2, CAP_UNICAST_CLIENT_STREAM_COUNT),
+		      cmd_cap_initiator_unicast_stop, 1, CAP_UNICAST_CLIENT_STREAM_COUNT),
 	SHELL_CMD_ARG(unicast_cancel, NULL, "Unicast cancel current procedure",
 		      cmd_cap_initiator_unicast_cancel, 1, 0),
 #if UNICAST_SINK_SUPPORTED


### PR DESCRIPTION
The cap_initiator unicast_stop shell command had the wrong minimum parameter count (as it defaults to all).

Some indentation had also gone wrong for it in the documentation.