### PR TITLE
drivers: spi_dw: add HSSI register layout

### DIFF
--- a/drivers/spi/Kconfig.dw
+++ b/drivers/spi/Kconfig.dw
@@ -20,4 +20,10 @@ config SPI_DW_ACCESS_WORD_ONLY
 	  DesignWare SPI only allows word access, byte access will raise
 	  exception.
 
+config SPI_DW_HSSI
+	bool "Designware SPI HSSI variant"
+	help
+	  Use register layout compatible with the SPI DW HSSI variant of the
+	  peripheral.
+
 endif # SPI_DW

--- a/drivers/spi/spi_dw.h
+++ b/drivers/spi/spi_dw.h
@@ -179,18 +179,25 @@ static int reg_test_bit(uint8_t bit, mm_reg_t addr, uint32_t off)
 /* Common registers settings, bits etc... */
 
 /* CTRLR0 settings */
+#if !IS_ENABLED(CONFIG_SPI_DW_HSSI)
 #define DW_SPI_CTRLR0_SCPH_BIT		(6)
 #define DW_SPI_CTRLR0_SCPOL_BIT		(7)
+#define DW_SPI_CTRLR0_TMOD_SHIFT	(8)
+#define DW_SPI_CTRLR0_SLV_OE_BIT	(10)
 #define DW_SPI_CTRLR0_SRL_BIT		(11)
+#else
+/* The register layout is different in the HSSI variant */
+#define DW_SPI_CTRLR0_SCPH_BIT		(8)
+#define DW_SPI_CTRLR0_SCPOL_BIT		(9)
+#define DW_SPI_CTRLR0_TMOD_SHIFT	(10)
+#define DW_SPI_CTRLR0_SLV_OE_BIT	(12)
+#define DW_SPI_CTRLR0_SRL_BIT		(13)
+#endif
 
 #define DW_SPI_CTRLR0_SCPH		BIT(DW_SPI_CTRLR0_SCPH_BIT)
 #define DW_SPI_CTRLR0_SCPOL		BIT(DW_SPI_CTRLR0_SCPOL_BIT)
 #define DW_SPI_CTRLR0_SRL		BIT(DW_SPI_CTRLR0_SRL_BIT)
-
-#define DW_SPI_CTRLR0_SLV_OE_BIT	(10)
 #define DW_SPI_CTRLR0_SLV_OE		BIT(DW_SPI_CTRLR0_SLV_OE_BIT)
-
-#define DW_SPI_CTRLR0_TMOD_SHIFT	(8)
 
 #define DW_SPI_CTRLR0_TMOD_TX_RX	(0)
 #define DW_SPI_CTRLR0_TMOD_TX		(1 << DW_SPI_CTRLR0_TMOD_SHIFT)


### PR DESCRIPTION
The Synopsys Designware SPI peripheral exists in two versions with slightly different register layouts. Added a Kconfig option that makes the driver compatible with the HSSI register layout.