### PR TITLE
STM32 OSPI correct fallback to default erase cmd in erase function

### DIFF
--- a/drivers/flash/flash_stm32_ospi.c
+++ b/drivers/flash/flash_stm32_ospi.c
@@ -1118,7 +1118,11 @@ static int flash_stm32_ospi_erase(const struct device *dev, off_t addr,
 				cmd_erase.Address, cmd_erase.AddressSize,
 				cmd_erase.AddressMode, cmd_erase.Instruction);
 
-			ospi_send_cmd(dev, &cmd_erase);
+			ret = ospi_send_cmd(dev, &cmd_erase);
+			if (ret < 0) {
+				LOG_ERR("Sector/Block Erase addr 0x%x failed", cmd_erase.Address);
+				break;
+			}
 
 			if (bet != NULL) {
 				addr += BIT(bet->exp);

--- a/drivers/flash/flash_stm32_ospi.c
+++ b/drivers/flash/flash_stm32_ospi.c
@@ -1097,23 +1097,22 @@ static int flash_stm32_ospi_erase(const struct device *dev, off_t addr,
 					|| (etp->exp > bet->exp))) {
 					bet = etp;
 					cmd_erase.Instruction = bet->cmd;
-				} else if (bet == NULL) {
-					/* Use the default sector erase cmd */
-					if (dev_cfg->data_mode == OSPI_OPI_MODE) {
-						cmd_erase.Instruction = SPI_NOR_OCMD_SE;
-					} else {
-						cmd_erase.Instruction =
-							(stm32_ospi_hal_address_size(dev) ==
-							HAL_OSPI_ADDRESS_32_BITS)
-							? SPI_NOR_CMD_SE_4B
-							: SPI_NOR_CMD_SE;
-					}
 				}
-				/* Avoid using wrong erase type,
-				 * if zero entries are found in erase_types
-				 */
-				bet = NULL;
 			}
+
+			/* Use default sector erase cmd if nothing fits */
+			if (bet == NULL) {
+				if (dev_cfg->data_mode == OSPI_OPI_MODE) {
+					cmd_erase.Instruction = SPI_NOR_OCMD_SE;
+				} else {
+					cmd_erase.Instruction =
+						(stm32_ospi_hal_address_size(dev) ==
+						HAL_OSPI_ADDRESS_32_BITS)
+						? SPI_NOR_CMD_SE_4B
+						: SPI_NOR_CMD_SE;
+				}
+			}
+
 			LOG_DBG("Sector/Block Erase addr 0x%x, asize 0x%x amode 0x%x  instr 0x%x",
 				cmd_erase.Address, cmd_erase.AddressSize,
 				cmd_erase.AddressMode, cmd_erase.Instruction);


### PR DESCRIPTION
The upstream approach fails to use the correct erase cmd when the last `erase_types` entry is empty.
Even when a valid `bet` is found before the empty entry it is reset to the default command as the `bet` is reset to `null`.

* Modifies the erase function so that the fallback to default erase cmd happens only if nothing suitable is found within the stored JESD216 BFP erase type entries.
* Adds an early break and a log entry when `ospi_send_cmd` fails.