### PR TITLE
coding guidelines: comply with MISRA C:2012 Rule 15.6

### DIFF
--- a/arch/x86/zefi/printf.h
+++ b/arch/x86/zefi/printf.h
@@ -117,8 +117,9 @@ static int vpf(struct _pfr *r, const char *f, va_list ap)
 				int d = (v >> (i*4)) & 0xf;
 
 				sig += !!d;
-				if (sig || i == 0)
+				if (sig || i == 0) {
 					pc(r, "0123456789abcdef"[d]);
+				}
 			}
 			break;
 		}


### PR DESCRIPTION
Fix coding guideline MISRA C:2012 Rule 15.6 in arch:

> added missing braces

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

original commit:
https://github.com/zephyrproject-rtos/zephyr/commit/071def1bf1d472ff121dfbe5e6fad8849b9ad603