### PR TITLE
samples: drivers: counter: alarm: add stm32-rtc test case

### DIFF
--- a/samples/drivers/counter/alarm/sample.yaml
+++ b/samples/drivers/counter/alarm/sample.yaml
@@ -1,11 +1,21 @@
 sample:
   name: Counter RTC Driver Sample
+common:
+  tags:
+    - drivers
+    - counter
+  harness: console
+  harness_config:
+    type: multi_line
+    ordered: true
+    regex:
+      - "Counter alarm sample"
+      - "Set alarm in 2 sec"
+      - "!!! Alarm !!!"
+      - "Now: [2|3]"
+  depends_on: counter
 tests:
   sample.drivers.counter.alarm:
-    tags:
-      - drivers
-      - counter
-    harness: console
     platform_allow:
       - nucleo_f746zg
       - nrf51dk/nrf51822
@@ -28,12 +38,13 @@ tests:
       - rpi_pico
     integration_platforms:
       - nucleo_f746zg
-    harness_config:
-      type: multi_line
-      ordered: true
-      regex:
-        - "Counter alarm sample"
-        - "Set alarm in 2 sec"
-        - "!!! Alarm !!!"
-        - "Now: [2|3]"
-    depends_on: counter
+  sample.drivers.counter.alarm.stm32_rtc:
+    # This test case is needed because when Timer Counter is available,
+    # RTC Counter will never be selected in the test.
+    # CONFIG_COUNTER_RTC_STM32 flag is enabled by default when RTC is enabled.
+    filter: CONFIG_SOC_FAMILY_STM32 and CONFIG_COUNTER_RTC_STM32
+    extra_configs:
+      # Timer Counter flag needs to be disabled for RTC node to be selected
+      - CONFIG_COUNTER_TIMER_STM32=n
+    tags:
+      - rtc

--- a/samples/drivers/counter/alarm/src/main.c
+++ b/samples/drivers/counter/alarm/src/main.c
@@ -53,6 +53,8 @@ struct counter_alarm_cfg alarm_cfg;
 #define TIMER DT_NODELABEL(timer0)
 #elif defined(CONFIG_COUNTER_TIMER_RPI_PICO)
 #define TIMER DT_NODELABEL(timer)
+#else
+#error Unable to find a counter device node in devicetree
 #endif
 
 static void test_counter_interrupt_fn(const struct device *counter_dev,


### PR DESCRIPTION
A specific test case for STM32 RTC is needed because of the way Counter node is selected in preprocessing. It tests STM32 RTC Alarm using `counter_ll_stm32_rtc` driver.
This also clarifies how STM32 RTC Alarm can be used in the `counter/alarm` sample.