### PR TITLE
Le audio shell bis index

### DIFF
--- a/tests/bluetooth/shell/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
+++ b/tests/bluetooth/shell/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
@@ -4,3 +4,4 @@ CONFIG_LIBLC3=y
 # The LC3 codec uses a large amount of stack. This app runs the codec in the work-queue, hence
 # inctease stack size for that thread.
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
+CONFIG_BT_TINYCRYPT_ECC=y

--- a/tests/bluetooth/shell/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
+++ b/tests/bluetooth/shell/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
@@ -3,5 +3,5 @@ CONFIG_FPU=y
 CONFIG_LIBLC3=y
 # The LC3 codec uses a large amount of stack. This app runs the codec in the work-queue, hence
 # inctease stack size for that thread.
-CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=5120
 CONFIG_BT_TINYCRYPT_ECC=y


### PR DESCRIPTION
When calling bap_broadcast_assistant add_pa_sync, it should only set the BIS index field as optional parameters and not to whatever is in the BASE.
    
If setting BIS index which the BASE does not support, then the command should be rejected.
    
This PR fixes https://github.com/zephyrproject-rtos/zephyr/issues/70835
    
