### PR TITLE
arch: riscv: init all initial stack __esf members.

### DIFF
--- a/arch/riscv/core/thread.c
+++ b/arch/riscv/core/thread.c
@@ -9,6 +9,7 @@
 #include <ksched.h>
 #include <zephyr/arch/riscv/csr.h>
 #include <stdio.h>
+#include <string.h>
 #include <pmp.h>
 
 #ifdef CONFIG_USERSPACE
@@ -33,6 +34,8 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	stack_init = (struct __esf *)Z_STACK_PTR_ALIGN(
 				Z_STACK_PTR_TO_FRAME(struct __esf, stack_ptr)
 				);
+
+	memset(stack_init, 0, sizeof(struct __esf));
 
 	/* Setup the initial stack frame */
 	stack_init->a0 = (unsigned long)entry;


### PR DESCRIPTION
Initialize whole initial stack frame for thread.
This prevents from reading uninitialized data
when thread is scheduled in.

more info:
https://discord.com/channels/720317445772017664/733036686195294269/1229683697809363005