### PR TITLE
scripts: twister: Remove Harness repeat field

### DIFF
--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -499,9 +499,6 @@ harness_config: <harness configuration options>
     ordered: <True|False> (default False)
         Check the regular expression strings in orderly or randomly fashion
 
-    repeat: <integer>
-        Number of times to validate the repeated regex expression
-
     record: <recording options> (optional)
       regex: <regular expression> (required)
         The regular expression with named subgroups to match data fields

--- a/samples/boards/mec15xxevb_assy6853/power_management/sample.yaml
+++ b/samples/boards/mec15xxevb_assy6853/power_management/sample.yaml
@@ -13,4 +13,3 @@ tests:
       regex:
         - "Wake from Light Sleep"
         - "Wake from Deep Sleep"
-      repeat: 3

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -49,7 +49,6 @@ class Harness:
         self.regex = []
         self.matches = OrderedDict()
         self.ordered = True
-        self.repeat = 1
         self.id = None
         self.fail_on_fault = True
         self.fault = False
@@ -78,7 +77,6 @@ class Harness:
         if config:
             self.type = config.get('type', None)
             self.regex = config.get('regex', [])
-            self.repeat = config.get('repeat', 1)
             self.ordered = config.get('ordered', True)
             self.record = config.get('record', {})
             if self.record:

--- a/scripts/schemas/twister/testsuite-schema.yaml
+++ b/scripts/schemas/twister/testsuite-schema.yaml
@@ -101,9 +101,6 @@ schema;scenario-schema:
         "ordered":
           type: bool
           required: false
-        "repeat":
-          type: int
-          required: false
         "pytest_root":
           type: seq
           required: false


### PR DESCRIPTION
Removed `Harness`'s `repeat` field.

Added to schemas in e722db14ad27186814fbd2cc82a3b0ec51159d2f, together with the rest of `harness_config`.
Added to `Harness` when it was created.

Now present only in one sample - `mec15xxevb_assy6853` power management sample.

Could not find definitive proof whether it has ever been used.