### PR TITLE
nrf_bsim: Enforce 8-byte alignments for long words

### DIFF
--- a/boards/native/nrf_bsim/CMakeLists.txt
+++ b/boards/native/nrf_bsim/CMakeLists.txt
@@ -15,6 +15,15 @@ zephyr_compile_options(
 # as both the HW models and embedded SW use them.
 target_compile_options(native_simulator INTERFACE -fshort-enums)
 
+# nrf_bsim is used to simulate ARM devices.
+# On these devices doubles and 8 byte words are 8-byte aligned.
+# As different x86 GNU compilers may have different alignment defaults,
+# set the alignment explicitly to match how data is aligned on target.
+zephyr_compile_options(
+  -malign-double
+)
+target_compile_options(native_simulator INTERFACE -malign-double)
+
 zephyr_library_sources(
 	irq_handler.c
 	cpu_wait.c


### PR DESCRIPTION
Different GNU compilers may have different aligment defaults. For example:
4 byte alignment: x86_64-zephyr-elf-gcc (Zephyr SDK 0.16.5-1) 12.2.0 
8 byte alignment: gcc (Ubuntu 9.4.0-1ubuntu1~20.04.2) 9.4.0

This can be seen when defining a struct:
```c
typedef struct {
	uint32_t a;
	uint64_t b;
} my_struct_t;
BUILD_ASSERT(__alignof__(my_struct_t) == 8);
```
To ensure the nrf_bsim board behaves similarly to nrf devices, explicitly set the alignment default to 8 bytes.