### PR TITLE
tests: bsim: Bluetooth: Reduce multiple id test execution iterations

### DIFF
--- a/tests/bsim/bluetooth/ll/multiple_id/prj.conf
+++ b/tests/bsim/bluetooth/ll/multiple_id/prj.conf
@@ -34,7 +34,13 @@ CONFIG_BT_CTLR_DATA_LENGTH_MAX=251
 
 # Each PHY update can pause connections for 6 interval hence to let other
 # parallel connection establishment to succeed increase Rx buffer count.
-CONFIG_BT_CTLR_RX_BUFFERS=6
+# A minimum of 1 Rx buffer is required to receive data PDU, during control
+# procedures Rx buffer could be held, preventing new connections to be
+# established, a value of 3 is tuned based on this test case execution for 2
+# iterations. If there is buffer leak, simulated by using value of 2 here, the
+# test is failing.
+# If there is buffer leak, this test now should catch it.
+CONFIG_BT_CTLR_RX_BUFFERS=3
 
 # Provide enough spacing between connections so that multiple peripheral roles
 # when connected to a single peer device (peripheral_identity sample) have

--- a/tests/bsim/bluetooth/ll/multiple_id/src/main.c
+++ b/tests/bsim/bluetooth/ll/multiple_id/src/main.c
@@ -18,7 +18,12 @@
 #include "time_machine.h"
 #include "bstests.h"
 
-#define ITERATIONS 10
+/* The test case is performing 250 simultaneous connections and managing
+ * parallel control procedures utilizing the available/configured minimum
+ * buffer counts. Hence, two iterations of connect-disconnect should be
+ * sufficient to catch any regressions/buffer leaks.
+ */
+#define ITERATIONS 2
 
 int init_central(uint8_t iterations);
 int init_peripheral(uint8_t iterations);
@@ -81,7 +86,7 @@ exit:
 
 static void test_multiple_init(void)
 {
-	bst_ticker_set_next_tick_absolute(4500e6);
+	bst_ticker_set_next_tick_absolute(1500e6);
 	bst_result = In_progress;
 }
 

--- a/tests/bsim/bluetooth/ll/multiple_id/tests_scripts/multiple.sh
+++ b/tests/bsim/bluetooth/ll/multiple_id/tests_scripts/multiple.sh
@@ -7,7 +7,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # Multiple connection between two devices with multiple peripheral identity
 simulation_id="multiple"
 verbosity_level=2
-EXECUTE_TIMEOUT=2200
+EXECUTE_TIMEOUT=1600
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -18,6 +18,6 @@ Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_ll_multiple_id_prj_conf\
   -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
-  -D=2 -sim_length=4500e6 $@ -argschannel -at=40
+  -D=2 -sim_length=1800e6 $@ -argschannel -at=40
 
 wait_for_background_jobs


### PR DESCRIPTION
Reduce the iterations in multiple id multiple simultaneous connections test, and tune the buffer counts to catch any buffer leak related regressions.