### PR TITLE
drivers: display: sdl: Fix asserts in sdl_display_write

### DIFF
--- a/drivers/display/display_sdl.c
+++ b/drivers/display/display_sdl.c
@@ -235,13 +235,13 @@ static int sdl_display_write(const struct device *dev, const uint16_t x,
 		"Pitch in descriptor is larger than screen size");
 	__ASSERT(desc->height <= config->height,
 		"Height in descriptor is larger than screen size");
-	__ASSERT(x + desc->pitch <= config->width,
+	__ASSERT(x + desc->width <= config->width,
 		 "Writing outside screen boundaries in horizontal direction");
 	__ASSERT(y + desc->height <= config->height,
 		 "Writing outside screen boundaries in vertical direction");
 
 	if (desc->width > desc->pitch ||
-	    x + desc->pitch > config->width ||
+	    x + desc->width > config->width ||
 	    y + desc->height > config->height) {
 		return -EINVAL;
 	}


### PR DESCRIPTION
The asserts and validation code were incorrectly mixing pitch and width.  These incorrect checks were preventing rendering code from re-using a smaller section of a buffer allocated to fit the full screen. We expect to be able to update a portion of the display from a portion of the buffer, in which case pitch must remain the screen width. Expecting x + pitch to be smaller than the screen width is incorrect.