### PR TITLE
boards: nordic: Add PWM support for LEDs on nRF54 DKs

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-pinctrl.dtsi
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-pinctrl.dtsi
@@ -66,4 +66,17 @@
 				<NRF_PSEL(CAN_TX, 9, 5)>;
 		};
 	};
+
+	/omit-if-no-ref/ pwm130_default: pwm130_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 9, 2)>;
+		};
+	};
+
+	/omit-if-no-ref/ pwm130_sleep: pwm130_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 9, 2)>;
+			low-power-enable;
+		};
+	};
 };

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
@@ -36,6 +36,7 @@
 		led2 = &led2;
 		led3 = &led3;
 		resetinfo = &cpuapp_resetinfo;
+		pwm-led0 = &pwm_led2;
 		sw0 = &button0;
 		sw1 = &button1;
 		sw2 = &button2;
@@ -93,6 +94,18 @@
 		led3: led_3 {
 			gpios = <&gpio9 3 GPIO_ACTIVE_HIGH>;
 			label = "Green LED 3";
+		};
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+		/*
+		 * LEDs are connected to GPIO Port 9 - pins 0-3. There is no valid hardware
+		 * configuration to pass PWM signal on pis 0 and 1. First valid config is P9.2.
+		 * Signal on PWM130's channel 0 can be passed directly on GPIO Port 9 pin 2.
+		 */
+		pwm_led2: pwm_led_2 {
+			pwms = <&pwm130 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
 	};
 };
@@ -260,4 +273,12 @@ zephyr_udc0: &usbhs {
 	status = "okay";
 	pinctrl-0 = <&can120_default>;
 	pinctrl-names = "default";
+};
+
+&pwm130 {
+	status = "okay";
+	pinctrl-0 = <&pwm130_default>;
+	pinctrl-1 = <&pwm130_sleep>;
+	pinctrl-names = "default", "sleep";
+	memory-regions = <&cpuapp_dma_region>;
 };

--- a/boards/nordic/nrf54l15pdk/nrf54l15pdk_nrf54l15-common.dtsi
+++ b/boards/nordic/nrf54l15pdk/nrf54l15pdk_nrf54l15-common.dtsi
@@ -27,6 +27,19 @@
 		};
 	};
 
+	pwmleds {
+		compatible = "pwm-leds";
+		/*
+		 * PWM signal can be exposed on GPIO pin only within same domain.
+		 * There is only one domain which contains both PWM and GPIO:
+		 * PWM20/21/22 and GPIO Port P1.
+		 * Only LEDs connected to P1 can work with PWM, for example LED1.
+		 */
+		pwm_led1: pwm_led_1 {
+			pwms = <&pwm20 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+		};
+	};
+
 	buttons {
 		compatible = "gpio-keys";
 		button0: button_0 {
@@ -56,6 +69,7 @@
 		led1 = &led1;
 		led2 = &led2;
 		led3 = &led3;
+		pwm-led0 = &pwm_led1;
 		sw0 = &button0;
 		sw1 = &button1;
 		sw2 = &button2;
@@ -75,5 +89,12 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&uart30_default>;
 	pinctrl-1 = <&uart30_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+&pwm20 {
+	status = "okay";
+	pinctrl-0 = <&pwm20_default>;
+	pinctrl-1 = <&pwm20_sleep>;
 	pinctrl-names = "default", "sleep";
 };

--- a/boards/nordic/nrf54l15pdk/nrf54l15pdk_nrf54l15-pinctrl.dtsi
+++ b/boards/nordic/nrf54l15pdk/nrf54l15pdk_nrf54l15-pinctrl.dtsi
@@ -64,4 +64,17 @@
 				low-power-enable;
 		};
 	};
+
+	/omit-if-no-ref/ pwm20_default: pwm20_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 1, 10)>;
+		};
+	};
+
+	/omit-if-no-ref/ pwm20_sleep: pwm20_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 1, 10)>;
+			low-power-enable;
+		};
+	};
 };

--- a/boards/nordic/nrf54l15pdk/nrf54l15pdk_nrf54l15_common_0_2_1.dtsi
+++ b/boards/nordic/nrf54l15pdk/nrf54l15pdk_nrf54l15_common_0_2_1.dtsi
@@ -35,3 +35,18 @@
 &button3 {
 	gpios = <&gpio2 10 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 };
+
+&pinctrl {
+	/omit-if-no-ref/ pwm20_default: pwm20_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 1, 8)>;
+		};
+	};
+
+	/omit-if-no-ref/ pwm20_sleep: pwm20_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 1, 8)>;
+			low-power-enable;
+		};
+	};
+};


### PR DESCRIPTION
Adds support for first possible LED to be connected with HW PWM.