### PR TITLE
kernel: Update thread cpu in z_get_next_switch_handle()

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -898,6 +898,7 @@ void *z_get_next_switch_handle(void *interrupted)
 			arch_cohere_stacks(old_thread, interrupted, new_thread);
 
 			_current_cpu->swap_ok = 0;
+			new_thread->base.cpu = arch_curr_cpu()->id;
 			set_current(new_thread);
 
 #ifdef CONFIG_TIMESLICING


### PR DESCRIPTION
Updates z_get_next_switch_handle() to set the new thread's base.cpu value as it is done in do_swap(). This helps to ensure that the last CPU on which the thread executed remains current.