### PR TITLE
boards: phytec: Remove Messtechnik GmbH

### DIFF
--- a/boards/phytec/index.rst
+++ b/boards/phytec/index.rst
@@ -1,7 +1,7 @@
 .. _boards-phytec:
 
-PHYTEC Messtechnik GmbH
-#######################
+PHYTEC
+######
 
 .. toctree::
    :maxdepth: 1

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -496,7 +496,7 @@ pda	Precision Design Associates, Inc.
 pericom	Pericom Technology Inc.
 pervasive	Pervasive Displays, Inc.
 phicomm	PHICOMM Co., Ltd.
-phytec	PHYTEC Messtechnik GmbH
+phytec	PHYTEC
 picochip	Picochip Ltd
 pine64	Pine64
 pineriver	Shenzhen PineRiver Designs Co., Ltd.


### PR DESCRIPTION
PHYTEC has multiple offices in different locations like the US, France, India and China. The headquarter is located in Germany. Since now 50% of the PHYTEC boards are from the US office, we should drop 'Messtechnik GmbH', which is the offical title of the German office, and keep the name more general.