### PR TITLE
Bluetooth: Classic: make SMP use L2CAP BR API

### DIFF
--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -238,8 +238,8 @@ static uint8_t l2cap_br_get_ident(void)
 	return ident;
 }
 
-static int l2cap_br_send_cb(struct bt_conn *conn, uint16_t cid, struct net_buf *buf,
-			    bt_conn_tx_cb_t cb, void *user_data)
+int bt_l2cap_br_send_cb(struct bt_conn *conn, uint16_t cid, struct net_buf *buf,
+			bt_conn_tx_cb_t cb, void *user_data)
 {
 	struct bt_l2cap_hdr *hdr;
 
@@ -259,7 +259,7 @@ static int l2cap_br_send_cb(struct bt_conn *conn, uint16_t cid, struct net_buf *
 static inline void l2cap_send(struct bt_conn *conn, uint16_t cid,
 			      struct net_buf *buf)
 {
-	if (l2cap_br_send_cb(conn, cid, buf, NULL, NULL)) {
+	if (bt_l2cap_br_send_cb(conn, cid, buf, NULL, NULL)) {
 		net_buf_unref(buf);
 	}
 }
@@ -268,7 +268,7 @@ static void l2cap_br_chan_send_req(struct bt_l2cap_br_chan *chan,
 				   struct net_buf *buf, k_timeout_t timeout)
 {
 
-	if (l2cap_br_send_cb(chan->chan.conn, BT_L2CAP_CID_BR_SIG, buf,
+	if (bt_l2cap_br_send_cb(chan->chan.conn, BT_L2CAP_CID_BR_SIG, buf,
 			     NULL, NULL)) {
 		net_buf_unref(buf);
 		return;
@@ -1491,7 +1491,7 @@ int bt_l2cap_br_chan_send_cb(struct bt_l2cap_chan *chan, struct net_buf *buf, bt
 		return -EMSGSIZE;
 	}
 
-	return l2cap_br_send_cb(br_chan->chan.conn, br_chan->tx.cid, buf, cb, user_data);
+	return bt_l2cap_br_send_cb(br_chan->chan.conn, br_chan->tx.cid, buf, cb, user_data);
 }
 
 int bt_l2cap_br_chan_send(struct bt_l2cap_chan *chan, struct net_buf *buf)

--- a/subsys/bluetooth/host/classic/l2cap_br_interface.h
+++ b/subsys/bluetooth/host/classic/l2cap_br_interface.h
@@ -32,6 +32,12 @@ int bt_l2cap_br_chan_send(struct bt_l2cap_chan *chan, struct net_buf *buf);
 int bt_l2cap_br_chan_send_cb(struct bt_l2cap_chan *chan, struct net_buf *buf, bt_conn_tx_cb_t cb,
 			     void *user_data);
 
+/* Send a single PDU over a BR channel.
+ * Used by e.g. SMP.
+ */
+int bt_l2cap_br_send_cb(struct bt_conn *conn, uint16_t cid, struct net_buf *buf,
+			bt_conn_tx_cb_t cb, void *user_data);
+
 /*
  * Handle security level changed on link passing HCI status of performed
  * security procedure.

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -37,6 +37,7 @@
 #include "keys.h"
 #include "conn_internal.h"
 #include "l2cap_internal.h"
+#include "classic/l2cap_br_interface.h"
 #include "smp.h"
 
 #define LOG_LEVEL CONFIG_BT_SMP_LOG_LEVEL
@@ -815,7 +816,7 @@ static void smp_br_timeout(struct k_work *work)
 static void smp_br_send(struct bt_smp_br *smp, struct net_buf *buf,
 			bt_conn_tx_cb_t cb)
 {
-	int err = bt_l2cap_send_cb(smp->chan.chan.conn, BT_L2CAP_CID_BR_SMP, buf, cb, NULL);
+	int err = bt_l2cap_br_send_cb(smp->chan.chan.conn, BT_L2CAP_CID_BR_SMP, buf, cb, NULL);
 
 	if (err) {
 		if (err == -ENOBUFS) {
@@ -1397,7 +1398,8 @@ static int smp_br_error(struct bt_smp_br *smp, uint8_t reason)
 	 * SMP timer is not restarted for PairingFailed so don't use
 	 * smp_br_send
 	 */
-	if (bt_l2cap_send(smp->chan.chan.conn, BT_L2CAP_CID_SMP, buf)) {
+	if (bt_l2cap_br_send_cb(smp->chan.chan.conn, BT_L2CAP_CID_SMP, buf,
+				NULL, NULL)) {
 		net_buf_unref(buf);
 	}
 


### PR DESCRIPTION
Make `l2cap_br_send_cb()` semi-public, and make SMP use it when it talks over a BR channel.