### PR TITLE
arch: posix: Undefine operating system specific macros for native_sim

### DIFF
--- a/arch/posix/CMakeLists.txt
+++ b/arch/posix/CMakeLists.txt
@@ -99,11 +99,13 @@ elseif (CONFIG_NATIVE_LIBRARY)
     get_filename_component(COMPILER_OWN_INCLUDE_PATH "${_OUTPUT}" DIRECTORY)
 
     # Do not use the C library from this compiler/host,
-    # but still use the basic compiler headers
+    # but still use the basic compiler headers,
+    # remove all operating system specific predefined macros,
     # no_builtin to avoid the compiler using builtin replacements for std library functions
     zephyr_compile_options(
       -nostdinc
       -isystem ${COMPILER_OWN_INCLUDE_PATH}
+      "SHELL:-include ${ZEPHYR_BASE}/arch/posix/include/undef_system_defines.h"
       $<TARGET_PROPERTY:compiler,freestanding>
       $<TARGET_PROPERTY:compiler,no_builtin>
     )

--- a/arch/posix/include/undef_system_defines.h
+++ b/arch/posix/include/undef_system_defines.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2024 Google LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Undefine all system-specific macros defined internally, by the compiler.
+ * Run 'gcc -dM -E - < /dev/null | sort' to get full list of internally
+ * defined macros.
+ */
+
+#undef __gnu_linux__
+#undef __linux
+#undef __linux__
+#undef linux
+
+#undef __unix
+#undef __unix__
+#undef unix


### PR DESCRIPTION
Compilers predefine system-specific macros which carry information about compiler, target architecture and operating system. It provides basic compiler-dependent information like size of types, their maximal and minimal values, etc. It allows to write common libc headers for multiple architectures and operating systems.

These macros allow code to always determine what is the target operating system. This is a problem when compiling code of modules that supports multiple operating systems (e.g. cryptography libraries).

To avoid confusion we shouldn't leak host operating system macros (e.g. __linux__, __linux, linux, etc.) when compiling for native_sim board.

Unfortunately, there is no single universal switch that disables all operating system macros:
- '-undef' removes also architecture-related macros
- '--target' is only available for Clang compiler

This patch uses '-include' option to include file that undefines all well-known operating system macros.

Run 'gcc -dM -E - < /dev/null | sort' to get full list of predefined macros.