### PR TITLE
STM32 I2C LL V1 Master Receive Handling

### DIFF
--- a/drivers/i2c/i2c_ll_stm32_v1.c
+++ b/drivers/i2c/i2c_ll_stm32_v1.c
@@ -359,6 +359,14 @@ static inline void handle_rxne(const struct device *dev)
 			k_sem_give(&data->device_sync_sem);
 			break;
 		case 2:
+			/*
+			 * 2-byte reception for N > 3 has already set the NACK
+			 * bit, and must not set the POS bit. See pg. 854 in
+			 * the F4 reference manual (RM0090).
+			 */
+			if (data->current.msg->len > 2) {
+				break;
+			}
 			LL_I2C_AcknowledgeNextData(i2c, LL_I2C_NACK);
 			LL_I2C_EnableBitPOS(i2c);
 			__fallthrough;


### PR DESCRIPTION
**Background**
The [STM32F4 reference manual](https://www.st.com/resource/en/reference_manual/dm00031020-stm32f405-415-stm32f407-417-stm32f427-437-and-stm32f429-439-advanced-arm-based-32-bit-mcus-stmicroelectronics.pdf) specifies two different scenarios for handling the last 2 - 3 bytes of an I2C receive (pg. 853-854).

If there are 2 bytes in the I2C receive message:
```
• Wait until ADDR = 1 (SCL stretched low until the ADDR flag is cleared)
• Set ACK low, set POS high
• Clear ADDR flag
• Wait until BTF = 1 (Data 1 in DR, Data2 in shift register, SCL stretched low until a data
1 is read)
• Set STOP high
• Read data 1 and 2
```

If there are more than 2 bytes in the receive message:
```
• Wait until BTF = 1 (data N-2 in DR, data N-1 in shift register, SCL stretched low until
data N-2 is read)
• Set ACK low
• Read data N-2
• Wait until BTF = 1 (data N-1 in DR, data N in shift register, SCL stretched low until a
data N-1 is read)
• Set STOP high
• Read data N-1 and N
```

The driver supports the 2-byte message read correctly, as well as 99% of the N>2 byte reads. However there is one final case: where N>2, but the BTF bit isn't set. In the general case, when there are 2 bytes remaining, these will be handled in `handle_btf`, however since the RXNE bit is set before the BTF bit, there are times when `handle_rxne` may run when `current.len == 2`. This results in running the N == 2 logic, which sets the POS bit, and that results in an ACK for the final byte of the transaction, instead of a NACK and a STOP condition.

**Solution**
Check to see if the original message receive length is greater than 2. If it is, that implies that we need to be running the N > 2 logic, so if we end up in `case 2` in `handle_rxne`, it will break out of it, and await the BTF bit/interrupt.

_Note: this was only tested on a F405 MCU, so I'm looking for feedback from reviewers from ST or those who use other parts which use this driver._