### PR TITLE
drivers: regulator: shell: fix strcmp usage bug in cmd_adset

### DIFF
--- a/drivers/regulator/regulator_shell.c
+++ b/drivers/regulator/regulator_shell.c
@@ -378,9 +378,9 @@ static int cmd_adset(const struct shell *sh, size_t argc, char **argv)
 		return -ENODEV;
 	}
 
-	if (strcmp(argv[2], "enable")) {
+	if (strcmp(argv[2], "enable") == 0) {
 		ad = true;
-	} else if (strcmp(argv[2], "disable")) {
+	} else if (strcmp(argv[2], "disable") == 0) {
 		ad = false;
 	} else {
 		shell_error(sh, "Invalid parameter");


### PR DESCRIPTION
Bug in "enable/disable" argument parsing would cause the oppostive of the requested setting to get
passed to active discharge API invocation.