### PR TITLE
drivers: regulator: shell: print all 6-digits of micro values

### DIFF
--- a/drivers/regulator/regulator_shell.c
+++ b/drivers/regulator/regulator_shell.c
@@ -74,8 +74,7 @@ static int strtomicro(char *inp, char units, int32_t *val)
 static void microtoshell(const struct shell *sh, char unit, int32_t val)
 {
 	if (val > 100000) {
-		shell_print(sh, "%d.%03d %c", val / 1000000,
-			    (val % 1000000) / 1000, unit);
+		shell_print(sh, "%d.%06d %c", val / 1000000, val % 1000000, unit);
 	} else if (val > 1000) {
 		shell_print(sh, "%d.%03d m%c", val / 1000, val % 1000, unit);
 	} else {


### PR DESCRIPTION
Previously only the upper/first 3 digits of a micro value would be printed, dropping the last 3 digits. This could cause misleading output for cmds like vlist.