### PR TITLE
boards: nxp: vmu_rt1170: fix SD card pin control setup

### DIFF
--- a/boards/nxp/vmu_rt1170/vmu_rt1170-pinctrl.dtsi
+++ b/boards/nxp/vmu_rt1170/vmu_rt1170-pinctrl.dtsi
@@ -344,20 +344,9 @@
 				<&iomuxc_gpio_sd_b1_02_usdhc1_data0>,
 				<&iomuxc_gpio_sd_b1_03_usdhc1_data1>,
 				<&iomuxc_gpio_sd_b1_04_usdhc1_data2>,
-				<&iomuxc_gpio_sd_b1_05_usdhc1_data3>;
+				<&iomuxc_gpio_sd_b1_05_usdhc1_data3>,
+				<&iomuxc_gpio_sd_b1_01_usdhc1_clk>;
 			bias-pull-up;
-			drive-strength = "high";
-			slew-rate = "fast";
-			input-enable;
-		};
-		group1 {
-			pinmux = <&iomuxc_gpio_sd_b1_01_usdhc1_clk>;
-			drive-strength = "high";
-			slew-rate = "fast";
-		};
-		group2 {
-			pinmux = <&iomuxc_gpio_ad_32_usdhc1_cd_b>;
-			bias-pull-down;
 			input-enable;
 		};
 	};

--- a/boards/nxp/vmu_rt1170/vmu_rt1170_mimxrt1176_cm7.dts
+++ b/boards/nxp/vmu_rt1170/vmu_rt1170_mimxrt1176_cm7.dts
@@ -402,6 +402,7 @@
 	status = "okay";
 	no-1-8-v;
 	pwr-gpios = <&gpio1 1 GPIO_ACTIVE_HIGH>;
+	cd-gpios = <&gpio3 31 (GPIO_ACTIVE_LOW | GPIO_PULL_DOWN)>;
 	sdmmc {
 		compatible = "zephyr,sdmmc-disk";
 		status = "okay";


### PR DESCRIPTION
Fix SD card pinctrl setup for the VMU RT1170 board. The following changes were made:
- use the "cd-gpios" property over detecting the card using the USDHC card detect register. This should be more reliable.
- bias the clk pin high. This matches setup for the RT1170 EVK SD pinctrl.
- remove the drive strength setting for SD pins to align with the pinctrl settings for low speed SD mode (50 MHz) on the RT1170 EVK.