### PR TITLE
Bluetooth: shell: Fix incorrect check for error return

### DIFF
--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -1866,7 +1866,7 @@ static int cmd_advertise(const struct shell *sh, size_t argc, char *argv[])
 	atomic_set_bit_to(adv_opt, SHELL_ADV_OPT_APPEARANCE, appearance);
 
 	err = ad_init(&ad[ad_len], ARRAY_SIZE(ad) - ad_len, adv_opt);
-	if (ad_len < 0) {
+	if (err < 0) {
 		return -ENOEXEC;
 	}
 	ad_len += err;


### PR DESCRIPTION
This line was clearly intended to check for the value returned by ad_init(). The ad_len is unsigned, so checking for a negative value showed up in a recent Coverity run (no GitHub issue for it yet).