### PR TITLE
mgmt: updatehub: Fix json arrays

### DIFF
--- a/subsys/mgmt/updatehub/updatehub_priv.h
+++ b/subsys/mgmt/updatehub/updatehub_priv.h
@@ -97,15 +97,20 @@ struct resp_probe_objects_array {
 	struct resp_probe_objects objects;
 };
 
+struct resp_probe_objects_array_array {
+	struct resp_probe_objects_array objects[4];
+	size_t objects_len;
+};
+
 struct resp_probe_any_boards {
-	struct resp_probe_objects_array objects[2];
+	struct resp_probe_objects_array_array objects[2];
 	size_t objects_len;
 	const char *product;
 	const char *supported_hardware;
 };
 
 struct resp_probe_some_boards {
-	struct resp_probe_objects_array objects[2];
+	struct resp_probe_objects_array_array objects[2];
 	size_t objects_len;
 	const char *product;
 	const char *supported_hardware[CONFIG_UPDATEHUB_SUPPORTED_HARDWARE_MAX];
@@ -148,6 +153,13 @@ static const struct json_obj_descr recv_probe_objects_descr_array[] = {
 			      objects, recv_probe_objects_descr),
 };
 
+static const struct json_obj_descr recv_probe_objects_descr_array_array[] = {
+	JSON_OBJ_DESCR_ARRAY_ARRAY(struct resp_probe_objects_array_array,
+				   objects, 4, objects_len,
+				   recv_probe_objects_descr_array,
+				   ARRAY_SIZE(recv_probe_objects_descr_array)),
+};
+
 static const struct json_obj_descr recv_probe_sh_string_descr[] = {
 	JSON_OBJ_DESCR_PRIM(struct resp_probe_any_boards,
 			    product, JSON_TOK_STRING),
@@ -156,8 +168,8 @@ static const struct json_obj_descr recv_probe_sh_string_descr[] = {
 				  JSON_TOK_STRING),
 	JSON_OBJ_DESCR_ARRAY_ARRAY(struct resp_probe_any_boards,
 				   objects, 2, objects_len,
-				   recv_probe_objects_descr_array,
-				   ARRAY_SIZE(recv_probe_objects_descr_array)),
+				   recv_probe_objects_descr_array_array,
+				   ARRAY_SIZE(recv_probe_objects_descr_array_array)),
 };
 
 static const struct json_obj_descr recv_probe_sh_array_descr[] = {
@@ -169,8 +181,8 @@ static const struct json_obj_descr recv_probe_sh_array_descr[] = {
 				   supported_hardware_len, JSON_TOK_STRING),
 	JSON_OBJ_DESCR_ARRAY_ARRAY(struct resp_probe_some_boards,
 				   objects, 2, objects_len,
-				   recv_probe_objects_descr_array,
-				   ARRAY_SIZE(recv_probe_objects_descr_array)),
+				   recv_probe_objects_descr_array_array,
+				   ARRAY_SIZE(recv_probe_objects_descr_array_array)),
 };
 
 static const struct json_obj_descr device_identity_descr[] = {


### PR DESCRIPTION
After the changes introduced by #50816 the UpdateHub could not decode anymore the JSON object. This introduce missing parsing definitions to allow JSON parser undertood the correct UpdateHub probe object.

Fixes #69297

Before evaluate it is recommended take a look at [UpdateHub zephyr guide](https://docs.updatehub.io/zephyr-project/zephyr-project-guide) and make sure your device have a network connection. Remember that by default UpdateHub sample get IP automatically.

Steps to Evaluate:

Run updatehub-ce docker
```
sudo docker run -it -p 8080:8080 -p 5683:5683/udp --rm updatehub/updatehub-ce:latest
```

Build SoC bootloader and flash
```
west build -b frdm_k64f -d build/mcuboot-frdm_k64f bootloader/mcuboot/boot/zephyr
west flash -d build/mcuboot-frdm_k64f
```

Build UpdateHub sample, sign and flash
```
west build -b frdm_k64f -d build/app zephyr/samples/subsys/mgmt/updatehub -- -DOVERLAY_CONFIG=overlay-prj.conf
west sign -t imgtool -d build/app -- --version 1.0.0 --pad --key bootloader/mcuboot/root-rsa-2048.pem
west flash -d build/app --hex-file build/app/zephyr/zephyr.signed.hex
```

Sign and package using **uhu**
```
west sign --no-hex --bin -B build/zephyr-2.0.0.bin -t imgtool -d build/app -- --version 2.0.0 --key bootloader/mcuboot/root-rsa-2048.pem
uhu package archive --output build/zephyr-2.0.0.pkg
```

On the UpdateHub-CE UI go to **packages** and upload the `zephyr-2.0.0.pkg`
On the UpdateHub-CE UI go to **rollouts** and create the rollout

CC: @otavio

Note

The below error is on investigation and seems to be unrelated to UpdateHub since it is an internal API provided by dfu subsystem.
```
I: Firmware download complete
E: Could not mark partition to upgrade
```