### PR TITLE
Update readme with information on configuring optional modules

### DIFF
--- a/doc/develop/modules.rst
+++ b/doc/develop/modules.rst
@@ -1148,7 +1148,26 @@ Where 23 in the example above indicated the pull request number submitted to the
 *my_module* repository. Once the module changes are reviewed and merged, the
 revision needs to be changed to the commit hash from the module repository.
 
+.. _optional_modules:
 
+Enabling optional modules
+=========================
+
+Some of the modules are marked as optional. In order to use such modules, they
+need to be explicitly enabled in local west configuration.
+To enable a module run:
+
+.. code-block:: console
+
+    west config manifest.project-filter -- +<module name>
+    west update
+
+e.g. to use LZ4 compression module execute:
+
+.. code-block:: console
+
+    west config manifest.project-filter -- +lz4
+    west update
 
 .. _CMake list: https://cmake.org/cmake/help/latest/manual/cmake-language.7.html#lists
 .. _add_subdirectory(): https://cmake.org/cmake/help/latest/command/add_subdirectory.html

--- a/samples/compression/lz4/README.rst
+++ b/samples/compression/lz4/README.rst
@@ -12,6 +12,13 @@ compress & decompress the user data to the console.
 Building and Running
 ********************
 
+Add the lz4 module to your West manifest and pull it:
+
+.. code-block:: console
+
+    west config manifest.project-filter -- +lz4
+    west update
+
 The sample can be built and executed on nrf52840dk/nrf52840 as follows:
 
 .. zephyr-app-commands::


### PR DESCRIPTION
Since some modules have been made optional, the samples that use them do not build unless modules are enabled. This PR adds steps on enabling LZ4 module to LZ4 compression sample and a general note to the modules section of the documentation