### PR TITLE
boards: sipeed: longan_nano: update SPI documentation

### DIFF
--- a/boards/sipeed/longan_nano/doc/index.rst
+++ b/boards/sipeed/longan_nano/doc/index.rst
@@ -74,6 +74,11 @@ The board configuration supports the following hardware features:
    * - ADC
      - :kconfig:option:`CONFIG_ADC`
      - :dtcompatible:`gd,gd32-adc`
+   * - SPI
+     - :kconfig:option:`CONFIG_SPI`
+     - :dtcompatible:`gd,gd32-spi`
+
+The microSD card reader in Longan Nano board is connected to SPI1.
 
 Serial Port
 ===========


### PR DESCRIPTION
Update SPI documentation for longan_nano. In longan_nano board, spi1 is connected to sdhc0. Verified the functionality using "samples/subsys/fs/fs_sample".

Fixes: #64759