### PR TITLE
soc: imx7d: fix CPP application building error (issue: 64784)

### DIFF
--- a/soc/nxp/imx/imx7d/soc.h
+++ b/soc/nxp/imx/imx7d/soc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NXP
+ * Copyright 2017,2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -9,11 +9,17 @@
 
 #ifndef _ASMLANGUAGE
 
+#include <MCIMX7D_M4.h>
+
+#ifndef __cplusplus
+
 #include "rdc.h"
 #include "rdc_defs_imx7d.h"
 #include "ccm_imx7d.h"
 #include "clock_freq.h"
 #include "soc_clk_freq.h"
+
+#endif /* !__cplusplus */
 
 #endif /* !_ASMLANGUAGE */
 


### PR DESCRIPTION
This patch is to fix issue [64784](https://github.com/zephyrproject-rtos/zephyr/issues/64784)

For CPP application, such as samples/cpp/cpp_synchronization/, it will report the following building errors:

...
zephyrproject/modules/hal/nxp/imx/devices/MCIMX7D/./MCIMX7D_M4.h:5101:51: error:
	'reinterpret_cast<CCM_Type*>(808976384)' is not a constant expression
...

The error is caused by commit: 72312feeadcdffd6e0f5d5d0d73a75110c7109b7 " arch: arm: cortex_m: Use cmsis api instead of inline asm in arch_irq_*" This patch will cause kernel.h includes cmsis_core.h which includes soc.h, so that soc.h will be used by c++ code.

This patch make soc.h can be c++ compatible.