### PR TITLE
maintainers: remove non existing pathes from file

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3563,7 +3563,6 @@ STM32 Platforms:
     - GeorgeCGV
   files:
     - boards/st/
-    - drivers/*/*stm32*/
     - drivers/*/*stm32*.c
     - drivers/*/*stm32*.h
     - drivers/*/*/*stm32*
@@ -3692,7 +3691,6 @@ Infineon Platforms:
     - boards/cypress/
     - boards/infineon/
     - drivers/*/*ifx_cat1*
-    - drivers/*/*xmc*/
     - drivers/*/*xmc*.c
     - drivers/sensor/infineon/
     - dts/arm/infineon/


### PR DESCRIPTION
After some file movement, some entries are not valid anymore.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
