### PR TITLE
Add supports for EUI64 device ID

### DIFF
--- a/drivers/hwinfo/hwinfo_handlers.c
+++ b/drivers/hwinfo/hwinfo_handlers.c
@@ -15,6 +15,14 @@ ssize_t z_vrfy_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 }
 #include <syscalls/hwinfo_get_device_id_mrsh.c>
 
+ssize_t z_vrfy_hwinfo_get_device_eui64(uint8_t *buffer)
+{
+	K_OOPS(K_SYSCALL_MEMORY_WRITE(buffer, 8));
+
+	return z_impl_hwinfo_get_device_eui64((uint8_t *)buffer);
+}
+#include <syscalls/hwinfo_get_device_eui64_mrsh.c>
+
 int z_vrfy_hwinfo_get_reset_cause(uint32_t *cause)
 {
 	int ret;

--- a/drivers/hwinfo/hwinfo_shell.c
+++ b/drivers/hwinfo/hwinfo_shell.c
@@ -38,6 +38,33 @@ static int cmd_get_device_id(const struct shell *sh, size_t argc, char **argv)
 	return 0;
 }
 
+static int cmd_get_device_eui64(const struct shell *sh, size_t argc, char **argv)
+{
+	uint8_t dev_eui64[8];
+	int ret;
+	int i;
+
+	ret = hwinfo_get_device_eui64(dev_eui64);
+
+	if (ret == -ENOSYS) {
+		shell_error(sh, "Not supported by hardware");
+		return -ENOSYS;
+	} else if (ret < 0) {
+		shell_error(sh, "Error: %d", ret);
+		return ret;
+	}
+
+	shell_fprintf(sh, SHELL_NORMAL, "EUI64: 0x");
+
+	for (i = 0 ; i < 8 ; i++) {
+		shell_fprintf(sh, SHELL_NORMAL, "%02x", dev_eui64[i]);
+	}
+
+	shell_fprintf(sh, SHELL_NORMAL, "\n");
+
+	return 0;
+}
+
 static inline const char *cause_to_string(uint32_t cause)
 {
 	switch (cause) {
@@ -188,6 +215,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_reset_cause,
 
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_hwinfo,
 	SHELL_CMD_ARG(devid, NULL, "Show device id", cmd_get_device_id, 1, 0),
+	SHELL_CMD_ARG(deveui64, NULL, "Show device eui64", cmd_get_device_eui64, 1, 0),
 	SHELL_CMD_ARG(reset_cause, &sub_reset_cause, "Reset cause commands",
 		      cmd_show_reset_cause, 1, 0),
 	SHELL_SUBCMD_SET_END /* Array terminated. */

--- a/drivers/hwinfo/hwinfo_stm32.c
+++ b/drivers/hwinfo/hwinfo_stm32.c
@@ -44,6 +44,26 @@ ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 	return length;
 }
 
+#if defined(CONFIG_SOC_SERIES_STM32WBAX) || \
+	defined(CONFIG_SOC_SERIES_STM32WBX) || \
+	defined(CONFIG_SOC_SERIES_STM32WLX)
+struct stm32_eui64 {
+	uint32_t id[2];
+};
+
+int z_impl_hwinfo_get_device_eui64(uint8_t *buffer)
+{
+	struct stm32_eui64 dev_eui64;
+
+	dev_eui64.id[0] = sys_cpu_to_be32(READ_REG(*((uint32_t *)UID64_BASE + 1U)));
+	dev_eui64.id[1] = sys_cpu_to_be32(READ_REG(*((uint32_t *)UID64_BASE)));
+
+	memcpy(buffer, dev_eui64.id, sizeof(dev_eui64));
+
+	return 0;
+}
+#endif
+
 int z_impl_hwinfo_get_reset_cause(uint32_t *cause)
 {
 	uint32_t flags = 0;

--- a/drivers/hwinfo/hwinfo_weak_impl.c
+++ b/drivers/hwinfo/hwinfo_weak_impl.c
@@ -11,6 +11,11 @@ ssize_t __weak z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 	return -ENOSYS;
 }
 
+int __weak z_impl_hwinfo_get_device_eui64(uint8_t *buffer)
+{
+	return -ENOSYS;
+}
+
 int __weak z_impl_hwinfo_get_reset_cause(uint32_t *cause)
 {
 	return -ENOSYS;

--- a/include/zephyr/drivers/hwinfo.h
+++ b/include/zephyr/drivers/hwinfo.h
@@ -96,6 +96,22 @@ __syscall ssize_t hwinfo_get_device_id(uint8_t *buffer, size_t length);
 ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length);
 
 /**
+ * @brief Copy the device EUI64 to a buffer
+ *
+ * This routine copies the device EUI64 (8 bytes) to the buffer.
+ * The EUI64 depends on the hardware and is guaranteed unique.
+ *
+ * @param buffer  Buffer of 8 bytes to write the ID to.
+ *
+ * @retval zero if successful.
+ * @retval -ENOSYS if there is no implementation for the particular device.
+ * @retval any negative value on driver specific errors.
+ */
+__syscall int hwinfo_get_device_eui64(uint8_t *buffer);
+
+int z_impl_hwinfo_get_device_eui64(uint8_t *buffer);
+
+/**
  * @brief      Retrieve cause of device reset.
  *
  * @param      cause  OR'd @ref reset_cause "reset cause" flags


### PR DESCRIPTION
This PR adds support for EUI64 device ID, usually found on MCU with radio support, and an implementation for the STM32 MCUs. This has been tested on STM32WL, where it can be used as the LoraWAN DEVEUI.

I have chosen to not pass the ID length in the API as the size is fixed, but I am opened to alternative suggestions.