### PR TITLE
dts/arm/st: wl: decrease Sub-GHz SPI frequency to 8MHz

### DIFF
--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -333,7 +333,7 @@
 				compatible = "st,stm32wl-subghz-radio";
 				reg = <0>;
 				interrupts = <50 0>;
-				spi-max-frequency = <12000000>;
+				spi-max-frequency = <8000000>;
 				status = "disabled";
 			};
 		};


### PR DESCRIPTION
Commit 246ea739bb03 ("dts/arm/st: wl: increase Sub-GHz SPI frequency to 12MHz") increased the Sub-GHz to 12 MHz. This matches the SX126x datasheet, but there is no information about the maximum speed in the STM32WL datasheet or reference.

This works fine when not using DMA. However with DMA activated (adding entries to the device-tree and enabling CONFIG_SPI_STM32_DMA), I have encountered some rare corruption. When it happens, the read from the Sub-GHz device gets an extra 0x00 byte prepended, which confuses the LoRaMac-node library and causes reception failures. Decreasing the frequency to the next round number, that is 8 MHz (i.e. increasing the prescaler from 4 to 6) fixes all the issues I encountered.