### PR TITLE
sensor: decoder: Use helper API to compute header size

### DIFF
--- a/drivers/sensor/default_rtio_sensor.c
+++ b/drivers/sensor/default_rtio_sensor.c
@@ -474,9 +474,7 @@ static int decode(const uint8_t *buffer, enum sensor_channel channel, size_t cha
 {
 	const struct sensor_data_generic_header *header =
 		(const struct sensor_data_generic_header *)buffer;
-	const q31_t *q =
-		(const q31_t *)(buffer + sizeof(struct sensor_data_generic_header) +
-				header->num_channels * sizeof(enum sensor_channel));
+	const q31_t *q = (const q31_t *)(buffer + compute_header_size(header->num_channels));
 	int count = 0;
 
 	if (*fit != 0 || max_count < 1) {


### PR DESCRIPTION
To be consistent with the computed offset on sensor_submit_fallback() implementation. This prevents falling in misalignment issues when the number of sensor channels changes.

Fixes #72059