### PR TITLE
sensor: default_rtio: Minor improvements to debug log messages

### DIFF
--- a/drivers/sensor/default_rtio_sensor.c
+++ b/drivers/sensor/default_rtio_sensor.c
@@ -230,10 +230,11 @@ static void sensor_submit_fallback(const struct device *dev, struct rtio_iodev_s
 			q[sample_idx + sample] =
 				((value_u * ((INT64_C(1) << 31) - 1)) / 1000000) >> header->shift;
 
-			LOG_DBG("value[%d]=%s%d.%06d, q[%d]@%p=%d", sample, value_u < 0 ? "-" : "",
+			LOG_DBG("value[%d]=%s%d.%06d, q[%d]@%p=%d, shift: %d",
+				sample, value_u < 0 ? "-" : "",
 				abs((int)value[sample].val1), abs((int)value[sample].val2),
 				(int)(sample_idx + sample), (void *)&q[sample_idx + sample],
-				q[sample_idx + sample]);
+				q[sample_idx + sample], header->shift);
 		}
 		sample_idx += num_samples;
 	}

--- a/drivers/sensor/default_rtio_sensor.c
+++ b/drivers/sensor/default_rtio_sensor.c
@@ -165,7 +165,6 @@ static void sensor_submit_fallback(const struct device *dev, struct rtio_iodev_s
 		}
 
 		if (rc != 0) {
-			LOG_DBG("Failed to get channel %d, skipping", channels[i]);
 			continue;
 		}
 


### PR DESCRIPTION
Done in order to verify calculations of the Read Async Shim layer. This was part of the troubleshooting effort to diagnose #72059