### PR TITLE
samples: net: socket: fix twister building error

### DIFF
--- a/samples/net/sockets/echo_client/sample.yaml
+++ b/samples/net/sockets/echo_client/sample.yaml
@@ -101,6 +101,7 @@ tests:
     extra_args:
       - CONFIG_USERSPACE=y
       - OVERLAY_CONFIG="overlay-e1000.conf"
+      - CONFIG_MAX_THREAD_BYTES=3
     platform_allow:
       - qemu_x86
       - qemu_x86_64


### PR DESCRIPTION
Fix the following twister error for building:
west twister -p qemu_x86 -s samples/net/sockets/echo_client/sample .net.sockets.echo_client.userspace

Too many thread objects (17)
	Increase CONFIG_MAX_THREAD_BYTES to 3
	ninja: build stopped: subcommand failed.