### PR TITLE
driver: hwinfo: andes: add missing Kconfig dependency

### DIFF
--- a/drivers/hwinfo/Kconfig
+++ b/drivers/hwinfo/Kconfig
@@ -189,6 +189,7 @@ config HWINFO_ANDES
 	bool "Andes system ID"
 	default y
 	depends on SOC_FAMILY_ANDES_V5
+	depends on SYSCON
 	help
 	  Enable Andes hwinfo driver
 


### PR DESCRIPTION
This PR add a Kconfig dependency to the Andes hwinfo driver which depends on the syscon driver.

Signed-off-by: Wei-Tai Lee [wtlee@andestech.com](mailto:wtlee@andestech.com)