### PR TITLE
doc: releases: 3.5: Fix COFNIG typo

### DIFF
--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -430,7 +430,7 @@ Build system and infrastructure
 * Build time priority checking: enable build time priority checking by default.
   This fails the build if the initialization sequence in the final ELF file
   does not match the devicetree hierarchy. It can be turned off by disabling
-  the :kconfig:option:`COFNIG_CHECK_INIT_PRIORITIES` option.
+  the :kconfig:option:`CONFIG_CHECK_INIT_PRIORITIES` option.
 
 * Added a new ``initlevels`` target for printing the final device and
   :c:macro:`SYS_INIT` initialization sequence from the final ELF file.


### PR DESCRIPTION
Fixing a typo for a `Kconfig` option.