### PR TITLE
drivers: avoid to use undefined macros in #if expressions

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -548,7 +548,7 @@ static void tx_start(const struct device *dev, const uint8_t *buf, size_t len)
 	const struct uarte_nrfx_config *config = dev->config;
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
 
-#if CONFIG_PM_DEVICE
+#ifdef CONFIG_PM_DEVICE
 	enum pm_device_state state;
 
 	(void)pm_device_state_get(dev, &state);


### PR DESCRIPTION
Fix coding guideline MISRA C:2012 Rule 20.9 in drivers:

>  avoid to use undefined macros in #if expressions

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/922cde06dc0be61c7c2f6bbfc18b023fe1759e06