### PR TITLE
arch x86: avoid to use undefined macros in #if expressions

### DIFF
--- a/arch/x86/core/prep_c.c
+++ b/arch/x86/core/prep_c.c
@@ -65,7 +65,7 @@ FUNC_NORETURN void z_prep_c(void *arg)
 #endif
 #endif
 
-#if CONFIG_X86_STACK_PROTECTION
+#ifdef CONFIG_X86_STACK_PROTECTION
 	unsigned int num_cpus = arch_num_cpus();
 
 	for (int i = 0; i < num_cpus; i++) {

--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -1355,7 +1355,7 @@ void z_x86_mmu_init(void)
 #endif
 }
 
-#if CONFIG_X86_STACK_PROTECTION
+#ifdef CONFIG_X86_STACK_PROTECTION
 __pinned_func
 void z_x86_set_stack_guard(k_thread_stack_t *stack)
 {


### PR DESCRIPTION
Fix coding guideline MISRA C:2012 Rule 20.9 in arch:

> All identifiers used in the controlling expression of #if or #elif preprocessing directives shall be #defined before evaluation.

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/922cde06dc0be61c7c2f6bbfc18b023fe1759e06