### PR TITLE
qemu_malta_qemu_malta_be.yaml: Fix 'identifier' typo

### DIFF
--- a/boards/qemu/malta/doc/index.rst
+++ b/boards/qemu/malta/doc/index.rst
@@ -95,7 +95,7 @@ Use this configuration to run :zephyr:code-sample:`synchronization` sample in bi
 .. zephyr-app-commands::
    :zephyr-app: samples/synchronization
    :host-os: unix
-   :board: qemu_malta//be
+   :board: qemu_malta/qemu_malta/be
    :goals: run
 
 

--- a/boards/qemu/malta/qemu_malta_qemu_malta_be.yaml
+++ b/boards/qemu/malta/qemu_malta_qemu_malta_be.yaml
@@ -1,4 +1,4 @@
-identifier: qemu_malta//be
+identifier: qemu_malta/qemu_malta/be
 name: QEMU emulation for MIPS (big endian)
 type: qemu
 simulation: qemu


### PR DESCRIPTION
qemu_malta//be -> qemu_malta/qemu_malta/be

This caused the board not to work with Twister.