### PR TITLE
includes: avoid to use undefined macros in #if expressions

### DIFF
--- a/include/zephyr/linker/common-ram.ld
+++ b/include/zephyr/linker/common-ram.ld
@@ -43,7 +43,7 @@
                 __device_states_end = .;
         } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
-#if CONFIG_PM_DEVICE
+#ifdef CONFIG_PM_DEVICE
 	ITERABLE_SECTION_RAM(pm_device_slots, Z_LINK_ITERABLE_SUBALIGN)
 #endif
 

--- a/include/zephyr/logging/log_msg.h
+++ b/include/zephyr/logging/log_msg.h
@@ -72,7 +72,7 @@ struct log_msg_hdr {
 /* Attempting to keep best alignment. When address is 64 bit and timestamp 32
  * swap the order to have 16 byte header instead of 24 byte.
  */
-#if (INTPTR_MAX > INT32_MAX) && !CONFIG_LOG_TIMESTAMP_64BIT
+#if (INTPTR_MAX > INT32_MAX) && !defined(CONFIG_LOG_TIMESTAMP_64BIT)
 	log_timestamp_t timestamp;
 	const void *source;
 #else

--- a/include/zephyr/sys/__assert.h
+++ b/include/zephyr/sys/__assert.h
@@ -12,12 +12,18 @@
 
 #ifdef CONFIG_ASSERT
 #ifndef __ASSERT_ON
+#ifdef CONFIG_ASSERT_LEVEL
 #define __ASSERT_ON CONFIG_ASSERT_LEVEL
+#endif
 #endif
 #endif
 
 #ifdef CONFIG_FORCE_NO_ASSERT
 #undef __ASSERT_ON
+#define __ASSERT_ON 0
+#endif
+
+#ifndef __ASSERT_ON
 #define __ASSERT_ON 0
 #endif
 


### PR DESCRIPTION
Fix coding guideline MISRA C:2012 Rule 20.9 in includes:

> All identifiers used in the controlling expression of #if or #elif preprocessing directives shall be #defined before evaluation.

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/922cde06dc0be61c7c2f6bbfc18b023fe1759e06