### PR TITLE
kernel: avoid to use undefined macros in #if expressions

### DIFF
--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -140,7 +140,7 @@ extern void smp_timer_init(void);
 
 extern void z_early_rand_get(uint8_t *buf, size_t length);
 
-#if CONFIG_STACK_POINTER_RANDOM
+#if defined(CONFIG_STACK_POINTER_RANDOM) && (CONFIG_STACK_POINTER_RANDOM != 0)
 extern int z_stack_adjust_initialized;
 #endif /* CONFIG_STACK_POINTER_RANDOM */
 

--- a/kernel/include/kthread.h
+++ b/kernel/include/kthread.h
@@ -75,7 +75,7 @@ static inline int thread_is_metairq(struct k_thread *thread)
 #endif /* CONFIG_NUM_METAIRQ_PRIORITIES */
 }
 
-#if CONFIG_ASSERT
+#ifdef CONFIG_ASSERT
 static inline bool is_thread_dummy(struct k_thread *thread)
 {
 	return (thread->base.thread_state & _THREAD_DUMMY) != 0U;

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -424,7 +424,7 @@ static void bg_thread_main(void *unused1, void *unused2, void *unused3)
 	z_sys_post_kernel = true;
 
 	z_sys_init_run_level(INIT_LEVEL_POST_KERNEL);
-#if CONFIG_STACK_POINTER_RANDOM
+#if defined(CONFIG_STACK_POINTER_RANDOM) && (CONFIG_STACK_POINTER_RANDOM != 0)
 	z_stack_adjust_initialized = 1;
 #endif /* CONFIG_STACK_POINTER_RANDOM */
 	boot_banner();

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -356,7 +356,7 @@ static inline void z_vrfy_k_thread_start(struct k_thread *thread)
 #include <syscalls/k_thread_start_mrsh.c>
 #endif /* CONFIG_USERSPACE */
 
-#if CONFIG_STACK_POINTER_RANDOM
+#if defined(CONFIG_STACK_POINTER_RANDOM) && (CONFIG_STACK_POINTER_RANDOM != 0)
 int z_stack_adjust_initialized;
 
 static size_t random_offset(size_t stack_size)
@@ -487,7 +487,7 @@ static char *setup_thread_stack(struct k_thread *new_thread,
 	new_thread->userspace_local_data =
 		(struct _thread_userspace_local_data *)(stack_ptr - delta);
 #endif /* CONFIG_THREAD_USERSPACE_LOCAL_DATA */
-#if CONFIG_STACK_POINTER_RANDOM
+#if defined(CONFIG_STACK_POINTER_RANDOM) && (CONFIG_STACK_POINTER_RANDOM != 0)
 	delta += random_offset(stack_buf_size);
 #endif /* CONFIG_STACK_POINTER_RANDOM */
 	delta = ROUND_UP(delta, ARCH_STACK_PTR_ALIGN);


### PR DESCRIPTION
Fix coding guideline MISRA C:2012 Rule 20.9 in kernel:

> All identifiers used in the controlling expression of #if or #elif preprocessing directives shall be #defined before evaluation.

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/922cde06dc0be61c7c2f6bbfc18b023fe1759e06