### PR TITLE
tests: avoid to use undefined macros in #if expressions

### DIFF
--- a/tests/subsys/logging/log_api/src/mock_backend.c
+++ b/tests/subsys/logging/log_api/src/mock_backend.c
@@ -140,7 +140,7 @@ static void process(const struct log_backend *const backend,
 	}
 
 	zassert_equal(msg->log.hdr.timestamp, exp->timestamp,
-#if CONFIG_LOG_TIMESTAMP_64BIT
+#ifdef CONFIG_LOG_TIMESTAMP_64BIT
 		      "Got: %llu, expected: %llu",
 #else
 		      "Got: %u, expected: %u",


### PR DESCRIPTION
Fix coding guideline MISRA C:2012 Rule 20.9 in tests:

> All identifiers used in the controlling expression of #if or #elif preprocessing directives shall be #defined before evaluation.

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/922cde06dc0be61c7c2f6bbfc18b023fe1759e06


