### PR TITLE
Bluetooth: host: rework TX path and buffer management

### DIFF
--- a/include/zephyr/bluetooth/l2cap.h
+++ b/include/zephyr/bluetooth/l2cap.h
@@ -191,7 +191,7 @@ struct bt_l2cap_le_chan {
 	 */
 	struct bt_l2cap_le_endpoint	tx;
 #if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
-	/** Channel Transmission queue */
+	/** Channel Transmission queue (for SDUs) */
 	struct k_fifo                   tx_queue;
 	/** Channel Pending Transmission buffer  */
 	struct net_buf                  *tx_buf;
@@ -218,6 +218,13 @@ struct bt_l2cap_le_chan {
 	struct k_work_delayable		rtx_work;
 	struct k_work_sync		rtx_sync;
 #endif
+
+	/** @internal To be used with @ref bt_conn.upper_data_ready */
+	sys_snode_t			_pdu_ready;
+	/** @internal To be used with @ref bt_conn.upper_data_ready */
+	atomic_t			_pdu_ready_lock;
+	/** @internal Queue of net bufs not yet sent to lower layer */
+	struct k_fifo			_pdu_tx_queue;
 };
 
 /**
@@ -260,6 +267,13 @@ struct bt_l2cap_br_chan {
 	/* Response Timeout eXpired (RTX) timer */
 	struct k_work_delayable		rtx_work;
 	struct k_work_sync		rtx_sync;
+
+	/** @internal To be used with @ref bt_conn.upper_data_ready */
+	sys_snode_t			_pdu_ready;
+	/** @internal To be used with @ref bt_conn.upper_data_ready */
+	atomic_t			_pdu_ready_lock;
+	/** @internal Queue of net bufs not yet sent to lower layer */
+	struct k_fifo			_pdu_tx_queue;
 };
 
 /** @brief L2CAP Channel operations structure. */

--- a/include/zephyr/bluetooth/l2cap.h
+++ b/include/zephyr/bluetooth/l2cap.h
@@ -190,13 +190,9 @@ struct bt_l2cap_le_chan {
 	 * L2CAP_LE_CREDIT_BASED_CONNECTION_REQ/RSP or L2CAP_CONFIGURATION_REQ.
 	 */
 	struct bt_l2cap_le_endpoint	tx;
-#if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
 	/** Channel Transmission queue (for SDUs) */
 	struct k_fifo                   tx_queue;
-	/** Channel Pending Transmission buffer  */
-	struct net_buf                  *tx_buf;
-	/** Channel Transmission work  */
-	struct k_work_delayable		tx_work;
+#if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
 	/** Segment SDU packet from upper layer */
 	struct net_buf			*_sdu;
 	uint16_t			_sdu_len;
@@ -223,8 +219,8 @@ struct bt_l2cap_le_chan {
 	sys_snode_t			_pdu_ready;
 	/** @internal To be used with @ref bt_conn.upper_data_ready */
 	atomic_t			_pdu_ready_lock;
-	/** @internal Queue of net bufs not yet sent to lower layer */
-	struct k_fifo			_pdu_tx_queue;
+	/** @internal Holds the length of the current PDU/segment */
+	size_t				_pdu_remaining;
 };
 
 /**

--- a/include/zephyr/bluetooth/l2cap.h
+++ b/include/zephyr/bluetooth/l2cap.h
@@ -597,6 +597,7 @@ int bt_l2cap_chan_disconnect(struct bt_l2cap_chan *chan);
  *  @return -EINVAL if `buf` or `chan` is NULL.
  *  @return -EINVAL if `chan` is not either BR/EDR or LE credit-based.
  *  @return -EINVAL if buffer doesn't have enough bytes reserved to fit header.
+ *  @return -EINVAL if buffer's reference counter != 1
  *  @return -EMSGSIZE if `buf` is larger than `chan`'s MTU.
  *  @return -ENOTCONN if underlying conn is disconnected.
  *  @return -ESHUTDOWN if L2CAP channel is disconnected.

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -273,6 +273,14 @@ config BT_CONN_TX_USER_DATA_SIZE
 	  Necessary user_data size for allowing packet fragmentation when
 	  sending over HCI. See `struct tx_meta` in conn.c.
 
+config BT_CONN_FRAG_COUNT
+	int
+	default BT_MAX_CONN if BT_CONN
+	default BT_ISO_MAX_CHAN if BT_ISO
+	help
+	  Internal kconfig that sets the maximum amount of simultaneous data
+	  packets in flight. It should be equal to the number of connections.
+
 if BT_CONN
 
 config BT_CONN_TX_MAX

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -267,8 +267,8 @@ config BT_LIM_ADV_TIMEOUT
 
 config BT_CONN_TX_USER_DATA_SIZE
 	int
-	default 24 if 64BIT
-	default 12
+	default 32 if 64BIT
+	default 16
 	help
 	  Necessary user_data size for allowing packet fragmentation when
 	  sending over HCI. See `struct tx_meta` in conn.c.
@@ -285,12 +285,12 @@ if BT_CONN
 
 config BT_CONN_TX_MAX
 	int "Maximum number of pending TX buffers with a callback"
-	default BT_L2CAP_TX_BUF_COUNT
-	range BT_L2CAP_TX_BUF_COUNT 255
+	default BT_BUF_ACL_TX_COUNT
+	range BT_BUF_ACL_TX_COUNT 255
 	help
 	  Maximum number of pending TX buffers that have an associated
 	  callback. Normally this can be left to the default value, which
-	  is equal to the number of TX buffers in the stack-internal pool.
+	  is equal to the number of TX buffers in the controller.
 
 config BT_CONN_PARAM_ANY
 	bool "Accept any values for connection parameters"

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -267,8 +267,8 @@ config BT_LIM_ADV_TIMEOUT
 
 config BT_CONN_TX_USER_DATA_SIZE
 	int
-	default 16 if 64BIT
-	default 8
+	default 24 if 64BIT
+	default 12
 	help
 	  Necessary user_data size for allowing packet fragmentation when
 	  sending over HCI. See `struct tx_meta` in conn.c.

--- a/subsys/bluetooth/host/Kconfig.l2cap
+++ b/subsys/bluetooth/host/Kconfig.l2cap
@@ -44,18 +44,6 @@ config BT_L2CAP_TX_MTU
 	help
 	  Maximum L2CAP MTU for L2CAP TX buffers.
 
-config BT_L2CAP_RESCHED_MS
-	int
-	default 1000
-	help
-	  Delay between retries for sending L2CAP segment. Necessary because the
-	  stack might not be able to allocate enough conn contexts and might not
-	  have enough credits, leading to a state where an SDU is stuck
-	  mid-transfer and never resumes.
-
-	  Note that this should seldom happen, this is just to work around a few
-	  edge cases.
-
 config BT_L2CAP_DYNAMIC_CHANNEL
 	bool "L2CAP Dynamic Channel support"
 	depends on BT_SMP

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -353,7 +353,7 @@ static int chan_send(struct bt_att_chan *chan, struct net_buf *buf)
 
 	data->att_chan = chan;
 
-	err = bt_l2cap_send(chan->att->conn, BT_L2CAP_CID_ATT, buf);
+	err = bt_l2cap_send_pdu(&chan->chan, buf, NULL, NULL);
 	if (err) {
 		if (err == -ENOBUFS) {
 			LOG_ERR("Ran out of TX buffers or contexts.");

--- a/subsys/bluetooth/host/buf.c
+++ b/subsys/bluetooth/host/buf.c
@@ -164,11 +164,6 @@ struct net_buf *bt_buf_make_view(struct net_buf *view,
 	 */
 	__ASSERT_NO_MSG(net_buf_headroom(parent) > 0);
 
-	/* `parent` should have been just re-used instead of trying to make a
-	 * view into it.
-	 */
-	__ASSERT_NO_MSG(len < parent->len);
-
 	__ASSERT_NO_MSG(!bt_buf_has_view(parent));
 
 	LOG_DBG("make-view %p viewsize %u meta %p", view, len, meta);

--- a/subsys/bluetooth/host/buf_view.h
+++ b/subsys/bluetooth/host/buf_view.h
@@ -1,0 +1,85 @@
+/** @file
+ *  @brief Bluetooth "view" buffer abstraction
+ */
+
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_SUBSYS_BLUETOOTH_HOST_BUF_VIEW_H_
+#define ZEPHYR_SUBSYS_BLUETOOTH_HOST_BUF_VIEW_H_
+
+#include <zephyr/net/buf.h>
+
+
+struct bt_buf_view_meta {
+	struct net_buf *parent;
+	/* saves the data pointers while the parent buffer is locked. */
+	struct net_buf_simple backup;
+};
+
+/** @internal
+ *
+ *  @brief Create a "view" or "window" into an existing buffer.
+ *  - enforces one active view at a time per-buffer
+ *  -> this restriction enables prepending data (ie. for headers)
+ *  - forbids appending data to the view
+ *  - pulls the size of the view from said buffer.
+ *
+ *  The "virtual buffer" that is generated has to be allocated from a buffer
+ *  pool. This is to allow refcounting and attaching a destroy callback. The
+ *  configured size of the buffers in that pool should be zero-length.
+ *
+ *  The user-data size is application-dependent, but should be minimized to save
+ *  memory. user_data is not used by the view API.
+ *
+ *  The view mechanism needs to store extra metadata in order to unlock the
+ *  original buffer when the view is destroyed.
+ *
+ *  The storage and allocation of the view buf pool and the view metadata is the
+ *  application's responsibility.
+ *
+ *  @note The `headroom` param is only used for __ASSERT(). The idea is that
+ *  it's easier to debug a headroom assert failure at allocation time, rather
+ *  than later down the line when a lower layer tries to add its headers and
+ *  fails.
+ *
+ *  @param view         Uninitialized "View" buffer
+ *  @param parent       Buffer data is pulled from into `view`
+ *  @param len          Amount to pull
+ *  @param meta         Uninitialized metadata storage
+ *
+ *  @return view if the operation was successful. NULL on error.
+ */
+struct net_buf *bt_buf_make_view(struct net_buf *view,
+				 struct net_buf *parent,
+				 size_t len,
+				 struct bt_buf_view_meta *meta);
+
+/** @internal
+ *
+ *  @brief Check if if `parent` has view.
+ *
+ *  If `parent` has been passed to @ref bt_buf_make_view() and the resulting
+ *  view buffer has not been destroyed.
+ */
+bool bt_buf_has_view(const struct net_buf *parent);
+
+/** @internal
+ *
+ *  @brief Destroy the view buffer
+ *
+ *  Equivalent of @ref net_buf_destroy.
+ *  It is mandatory to call this from the view pool's `destroy` callback.
+ *
+ *  This frees the parent buffer, and allows calling @ref bt_buf_make_view again.
+ *  The metadata is also freed for re-use.
+ *
+ *  @param view View to destroy
+ *  @param meta Meta that was given to @ref bt_buf_make_view
+ */
+void bt_buf_destroy_view(struct net_buf *view, struct bt_buf_view_meta *meta);
+
+#endif /* ZEPHYR_SUBSYS_BLUETOOTH_HOST_BUF_VIEW_H_ */

--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -19,6 +19,7 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/drivers/bluetooth/hci_driver.h>
 
+#include "host/buf_view.h"
 #include "host/hci_core.h"
 #include "host/conn_internal.h"
 #include "l2cap_br_internal.h"

--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -257,15 +257,13 @@ static void raise_data_ready(struct bt_l2cap_br_chan *br_chan)
 static void lower_data_ready(struct bt_l2cap_br_chan *br_chan)
 {
 	struct bt_conn *conn = br_chan->chan.conn;
-	sys_snode_t *s = sys_slist_get(&conn->l2cap_data_ready);
+	__maybe_unused sys_snode_t *s = sys_slist_get(&conn->l2cap_data_ready);
 
 	__ASSERT_NO_MSG(s == &br_chan->_pdu_ready);
-	(void)s;
 
-	atomic_t old = atomic_set(&br_chan->_pdu_ready_lock, 0);
+	__maybe_unused atomic_t old = atomic_set(&br_chan->_pdu_ready_lock, 0);
 
 	__ASSERT_NO_MSG(old);
-	(void)old;
 }
 
 static void cancel_data_ready(struct bt_l2cap_br_chan *br_chan)
@@ -383,10 +381,9 @@ struct net_buf *l2cap_br_data_pull(struct bt_conn *conn,
 
 	if (last_frag) {
 		LOG_DBG("last frag, removing %p", pdu);
-		struct net_buf *b = k_fifo_get(&br_chan->_pdu_tx_queue, K_NO_WAIT);
+		__maybe_unused struct net_buf *b = k_fifo_get(&br_chan->_pdu_tx_queue, K_NO_WAIT);
 
 		__ASSERT_NO_MSG(b == pdu);
-		(void)b;
 
 		LOG_DBG("chan %p done", br_chan);
 		lower_data_ready(br_chan);

--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -348,7 +348,9 @@ static bool chan_has_data(struct bt_l2cap_br_chan *br_chan)
 	return !k_fifo_is_empty(&br_chan->_pdu_tx_queue);
 }
 
-struct net_buf *l2cap_br_data_pull(struct bt_conn *conn, size_t amount)
+struct net_buf *l2cap_br_data_pull(struct bt_conn *conn,
+				   size_t amount,
+				   size_t *length)
 {
 	const sys_snode_t *pdu_ready = sys_slist_peek_head(&conn->l2cap_data_ready);
 
@@ -395,6 +397,8 @@ struct net_buf *l2cap_br_data_pull(struct bt_conn *conn, size_t amount)
 			raise_data_ready(br_chan);
 		}
 	}
+
+	*length = pdu->len;
 
 	return pdu;
 }

--- a/subsys/bluetooth/host/classic/l2cap_br_interface.h
+++ b/subsys/bluetooth/host/classic/l2cap_br_interface.h
@@ -48,4 +48,6 @@ void l2cap_br_encrypt_change(struct bt_conn *conn, uint8_t hci_status);
 void bt_l2cap_br_recv(struct bt_conn *conn, struct net_buf *buf);
 
 /* Pull HCI fragments from buffers intended for `conn` */
-struct net_buf *l2cap_br_data_pull(struct bt_conn *conn, size_t amount);
+struct net_buf *l2cap_br_data_pull(struct bt_conn *conn,
+				   size_t amount,
+				   size_t *length);

--- a/subsys/bluetooth/host/classic/l2cap_br_interface.h
+++ b/subsys/bluetooth/host/classic/l2cap_br_interface.h
@@ -46,3 +46,6 @@ void l2cap_br_encrypt_change(struct bt_conn *conn, uint8_t hci_status);
 
 /* Handle received data */
 void bt_l2cap_br_recv(struct bt_conn *conn, struct net_buf *buf);
+
+/* Pull HCI fragments from buffers intended for `conn` */
+struct net_buf *l2cap_br_data_pull(struct bt_conn *conn, size_t amount);

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -30,6 +30,7 @@
 #include "common/assert.h"
 #include "common/bt_str.h"
 
+#include "buf_view.h"
 #include "addr_internal.h"
 #include "hci_core.h"
 #include "id.h"
@@ -103,19 +104,6 @@ NET_BUF_POOL_DEFINE(acl_tx_pool, CONFIG_BT_L2CAP_TX_BUF_COUNT,
 		    BT_L2CAP_BUF_SIZE(CONFIG_BT_L2CAP_TX_MTU),
 		    CONFIG_BT_CONN_TX_USER_DATA_SIZE, NULL);
 
-#if CONFIG_BT_L2CAP_TX_FRAG_COUNT > 0
-/* Dedicated pool for fragment buffers in case queued up TX buffers don't
- * fit the controllers buffer size. We can't use the acl_tx_pool for the
- * fragmentation, since it's possible that pool is empty and all buffers
- * are queued up in the TX queue. In such a situation, trying to allocate
- * another buffer from the acl_tx_pool would result in a deadlock.
- */
-NET_BUF_POOL_FIXED_DEFINE(frag_pool, CONFIG_BT_L2CAP_TX_FRAG_COUNT,
-			  BT_BUF_ACL_SIZE(CONFIG_BT_BUF_ACL_TX_SIZE),
-			  CONFIG_BT_CONN_TX_USER_DATA_SIZE, NULL);
-
-#endif /* CONFIG_BT_L2CAP_TX_FRAG_COUNT > 0 */
-
 #if defined(CONFIG_BT_SMP) || defined(CONFIG_BT_CLASSIC)
 const struct bt_conn_auth_cb *bt_auth;
 sys_slist_t bt_auth_info_cbs = SYS_SLIST_STATIC_INIT(&bt_auth_info_cbs);
@@ -131,6 +119,54 @@ static int bt_hci_connect_br_cancel(struct bt_conn *conn);
 static struct bt_conn sco_conns[CONFIG_BT_MAX_SCO_CONN];
 #endif /* CONFIG_BT_CLASSIC */
 #endif /* CONFIG_BT_CONN */
+
+#if defined(CONFIG_BT_CONN_TX)
+void frag_destroy(struct net_buf *buf);
+
+/* Storage for fragments (views) into the upper layers' PDUs. */
+/* TODO: remove user-data requirements */
+NET_BUF_POOL_FIXED_DEFINE(fragments, CONFIG_BT_CONN_FRAG_COUNT, 0,
+			  CONFIG_BT_CONN_TX_USER_DATA_SIZE, frag_destroy);
+
+struct frag_md {
+	struct bt_buf_view_meta view_meta;
+};
+struct frag_md frag_md_pool[CONFIG_BT_CONN_FRAG_COUNT];
+
+struct frag_md *get_frag_md(struct net_buf *fragment)
+{
+	return &frag_md_pool[net_buf_id(fragment)];
+}
+
+void bt_tx_irq_raise(void);
+void frag_destroy(struct net_buf *frag)
+{
+	/* allow next view to be allocated (and unlock the parent buf) */
+	bt_buf_destroy_view(frag, &get_frag_md(frag)->view_meta);
+}
+
+static struct net_buf *get_acl_frag(struct net_buf *outside, size_t winsize)
+{
+	struct net_buf *window;
+
+	__ASSERT_NO_MSG(!bt_buf_has_view(outside));
+
+	/* Keeping a ref is the caller's responsibility */
+	window = net_buf_alloc_len(&fragments, 0, K_NO_WAIT);
+	if (!window) {
+		return window;
+	}
+
+	__ASSERT_NO_MSG(outside->ref == 1);
+
+	window = bt_buf_make_view(window, net_buf_ref(outside),
+				  winsize, &get_frag_md(window)->view_meta);
+
+	LOG_INF("get-acl-frag: outside %p window %p size %d", outside, window, winsize);
+
+	return window;
+}
+#endif /* CONFIG_BT_CONN_TX */
 
 #if defined(CONFIG_BT_ISO)
 extern struct bt_conn iso_conns[CONFIG_BT_ISO_MAX_CHAN];
@@ -661,11 +697,20 @@ fail:
 	return err;
 }
 
-static int send_frag(struct bt_conn *conn,
-		     struct net_buf *buf, struct net_buf *frag,
-		     uint8_t flags)
+static bool fits_single_ctlr_buf(struct net_buf *buf, struct bt_conn *conn)
 {
+	return buf->len <= conn_mtu(conn);
+}
+
+static int send_frag(struct bt_conn *conn, struct net_buf *buf, uint8_t flags)
+{
+	struct net_buf *frag;
 	struct bt_conn_tx *tx = NULL;
+
+	if (bt_buf_has_view(buf)) {
+		LOG_ERR("already have view");
+		return -EWOULDBLOCK;
+	}
 
 	/* Check if the controller can accept ACL packets */
 	if (k_sem_take(bt_conn_get_pkts(conn), K_NO_WAIT)) {
@@ -681,12 +726,25 @@ static int send_frag(struct bt_conn *conn,
 		return -ENOTCONN;
 	}
 
-	/* Add the data to the buffer */
-	if (frag) {
-		uint16_t frag_len = MIN(conn_mtu(conn), net_buf_tailroom(frag));
+	if (!fits_single_ctlr_buf(buf, conn)) {
+		uint16_t frag_len = MIN(conn_mtu(conn), buf->len);
 
-		net_buf_add_mem(frag, buf->data, frag_len);
-		net_buf_pull(buf, frag_len);
+		LOG_DBG("send frag: buf %p len %d", buf, frag_len);
+
+		/* will also do a pull */
+		frag = get_acl_frag(buf, frag_len);
+		/* Fragments never have a TX completion callback */
+		tx_data(frag)->cb = NULL;
+		tx_data(frag)->is_cont = false;
+
+		int err = do_send_frag(conn, frag, flags, tx);
+
+		if (err == -EIO) {
+			net_buf_unref(frag);
+		}
+
+		return err;
+
 	} else {
 		if (tx_data(buf)->cb) {
 			tx = conn_tx_alloc();
@@ -709,41 +767,9 @@ static int send_frag(struct bt_conn *conn,
 		 */
 		buf = net_buf_get(&conn->tx_queue, K_NO_WAIT);
 		frag = buf;
+
+		return do_send_frag(conn, frag, flags, tx);
 	}
-
-	return do_send_frag(conn, frag, flags, tx);
-}
-
-static struct net_buf *create_frag(struct bt_conn *conn, struct net_buf *buf)
-{
-	struct net_buf *frag;
-
-	switch (conn->type) {
-#if defined(CONFIG_BT_ISO)
-	case BT_CONN_TYPE_ISO:
-		frag = bt_iso_create_frag(0);
-		break;
-#endif
-	default:
-#if defined(CONFIG_BT_CONN)
-		frag = bt_conn_create_frag(0);
-#else
-		return NULL;
-#endif /* CONFIG_BT_CONN */
-
-	}
-
-	if (conn->state != BT_CONN_CONNECTED) {
-		net_buf_unref(frag);
-		return NULL;
-	}
-
-	/* Fragments never have a TX completion callback */
-	tx_data(frag)->cb = NULL;
-	tx_data(frag)->is_cont = false;
-	tx_data(frag)->iso_has_ts = tx_data(buf)->iso_has_ts;
-
-	return frag;
 }
 
 /* Tentatively send a buffer to the HCI driver.
@@ -765,19 +791,22 @@ static struct net_buf *create_frag(struct bt_conn *conn, struct net_buf *buf)
  */
 static int send_buf(struct bt_conn *conn, struct net_buf *buf)
 {
-	struct net_buf *frag;
 	uint8_t flags;
 	int err;
 
 	LOG_DBG("conn %p buf %p len %u", conn, buf, buf->len);
 
+	if (bt_buf_has_view(buf)) {
+		LOG_DBG("locked by existing view");
+		return -EWOULDBLOCK;
+	}
+
 	/* Send directly if the packet fits the ACL MTU */
 	if (buf->len <= conn_mtu(conn) && !tx_data(buf)->is_cont) {
 		LOG_DBG("send single");
-		return send_frag(conn, buf, NULL, FRAG_SINGLE);
+		return send_frag(conn, buf, FRAG_SINGLE);
 	}
 
-	LOG_DBG("start fragmenting");
 	/*
 	 * Send the fragments. For the last one simply use the original
 	 * buffer (which works since we've used net_buf_pull on it).
@@ -788,25 +817,22 @@ static int send_buf(struct bt_conn *conn, struct net_buf *buf)
 	}
 
 	while (buf->len > conn_mtu(conn)) {
-		frag = create_frag(conn, buf);
-		if (!frag) {
-			return -ENOMEM;
-		}
-
-		err = send_frag(conn, buf, frag, flags);
+		tx_data(buf)->is_cont = true;
+		err = send_frag(conn, buf, flags);
 		if (err) {
 			LOG_DBG("%p failed, mark as existing frag", buf);
-			tx_data(buf)->is_cont = flags != FRAG_START;
-			net_buf_unref(frag);
 			return err;
 		}
 
 		flags = FRAG_CONT;
 	}
 
-	LOG_DBG("last frag");
-	tx_data(buf)->is_cont = true;
-	return send_frag(conn, buf, NULL, FRAG_END);
+	bool single = flags == FRAG_START;
+
+	LOG_DBG("send %s", single ? "single" : "last");
+
+	/* Frag is either a direct-send or the last in the series. */
+	return send_frag(conn, buf, single ? FRAG_SINGLE : FRAG_END);
 }
 
 static struct k_poll_signal conn_change =
@@ -3370,28 +3396,6 @@ int bt_conn_le_conn_update(struct bt_conn *conn,
 	conn_update->supervision_timeout = sys_cpu_to_le16(param->timeout);
 
 	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_CONN_UPDATE, buf, NULL);
-}
-
-#if defined(CONFIG_NET_BUF_LOG)
-struct net_buf *bt_conn_create_frag_timeout_debug(size_t reserve,
-						  k_timeout_t timeout,
-						  const char *func, int line)
-#else
-struct net_buf *bt_conn_create_frag_timeout(size_t reserve, k_timeout_t timeout)
-#endif
-{
-	struct net_buf_pool *pool = NULL;
-
-#if CONFIG_BT_L2CAP_TX_FRAG_COUNT > 0
-	pool = &frag_pool;
-#endif
-
-#if defined(CONFIG_NET_BUF_LOG)
-	return bt_conn_create_pdu_timeout_debug(pool, reserve, timeout,
-						func, line);
-#else
-	return bt_conn_create_pdu_timeout(pool, reserve, timeout);
-#endif /* CONFIG_NET_BUF_LOG */
 }
 
 #if defined(CONFIG_BT_SMP) || defined(CONFIG_BT_CLASSIC)

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -49,24 +49,10 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_conn);
 
-struct tx_meta {
-	bt_conn_tx_cb_t cb;
-	void *cb_user_data;
-
-	/* This flag indicates if the current buffer has already been partially
-	 * sent to the controller (ie, the next fragments should be sent as
-	 * continuations).
-	 */
-	bool is_cont;
-	/* Indicates whether the ISO PDU contains a timestamp */
-	bool iso_has_ts;
-};
-
-BUILD_ASSERT(sizeof(struct tx_meta) == CONFIG_BT_CONN_TX_USER_DATA_SIZE,
-	     "User data size is wrong!");
-
-#define tx_data(buf) ((struct tx_meta *)net_buf_user_data(buf))
 K_FIFO_DEFINE(free_tx);
+
+void tx_processor(struct k_work *item);
+K_WORK_DELAYABLE_DEFINE(tx_work, tx_processor);
 
 static void tx_free(struct bt_conn_tx *tx);
 
@@ -77,12 +63,16 @@ static void conn_tx_destroy(struct bt_conn *conn, struct bt_conn_tx *tx)
 	bt_conn_tx_cb_t cb = tx->cb;
 	void *user_data = tx->user_data;
 
+	LOG_DBG("conn %p tx %p cb %p ud %p", conn, tx, cb, user_data);
+
 	/* Free up TX metadata before calling callback in case the callback
 	 * tries to allocate metadata
 	 */
 	tx_free(tx);
 
-	cb(conn, user_data, -ESHUTDOWN);
+	if (cb) {
+		cb(conn, user_data, -ESHUTDOWN);
+	}
 }
 
 #if defined(CONFIG_BT_CONN_TX)
@@ -90,6 +80,8 @@ static void tx_complete_work(struct k_work *work);
 #endif /* CONFIG_BT_CONN_TX */
 
 static void notify_recycled_conn_slot(void);
+
+void bt_tx_irq_raise(void);
 
 /* Group Connected BT_CONN only in this */
 #if defined(CONFIG_BT_CONN)
@@ -138,14 +130,18 @@ struct frag_md *get_frag_md(struct net_buf *fragment)
 	return &frag_md_pool[net_buf_id(fragment)];
 }
 
-void bt_tx_irq_raise(void);
 void frag_destroy(struct net_buf *frag)
 {
 	/* allow next view to be allocated (and unlock the parent buf) */
 	bt_buf_destroy_view(frag, &get_frag_md(frag)->view_meta);
+
+	LOG_DBG("");
+
+	/* Kick the TX processor to send the rest of the frags. */
+	bt_tx_irq_raise();
 }
 
-static struct net_buf *get_acl_frag(struct net_buf *outside, size_t winsize)
+static struct net_buf *get_data_frag(struct net_buf *outside, size_t winsize)
 {
 	struct net_buf *window;
 
@@ -162,9 +158,21 @@ static struct net_buf *get_acl_frag(struct net_buf *outside, size_t winsize)
 	window = bt_buf_make_view(window, net_buf_ref(outside),
 				  winsize, &get_frag_md(window)->view_meta);
 
-	LOG_INF("get-acl-frag: outside %p window %p size %d", outside, window, winsize);
+	LOG_DBG("get-acl-frag: outside %p window %p size %d", outside, window, winsize);
 
 	return window;
+}
+#else /* !CONFIG_BT_CONN_TX */
+static struct net_buf *get_data_frag(struct net_buf *outside, size_t winsize)
+{
+	ARG_UNUSED(outside);
+	ARG_UNUSED(winsize);
+
+	/* This will never get called. It's only to allow compilation to take
+	 * place and the later linker stage to remove this implementation.
+	 */
+
+	return NULL;
 }
 #endif /* CONFIG_BT_CONN_TX */
 
@@ -245,7 +253,6 @@ static void tx_free(struct bt_conn_tx *tx)
 	LOG_DBG("%p", tx);
 	tx->cb = NULL;
 	tx->user_data = NULL;
-	tx->pending_no_cb = 0U;
 	k_fifo_put(&free_tx, tx);
 }
 
@@ -265,8 +272,9 @@ static void tx_notify(struct bt_conn *conn)
 
 		key = irq_lock();
 		if (!sys_slist_is_empty(&conn->tx_complete)) {
-			tx = CONTAINER_OF(sys_slist_get_not_empty(&conn->tx_complete),
-					  struct bt_conn_tx, node);
+			const sys_snode_t *node = sys_slist_get_not_empty(&conn->tx_complete);
+
+			tx = CONTAINER_OF(node, struct bt_conn_tx, node);
 		}
 		irq_unlock(key);
 
@@ -287,7 +295,12 @@ static void tx_notify(struct bt_conn *conn)
 		 * allocate new buffers since the TX should have been
 		 * unblocked by tx_free.
 		 */
-		cb(conn, user_data, 0);
+		if (cb) {
+			cb(conn, user_data, 0);
+		}
+
+		LOG_DBG("raise TX IRQ");
+		bt_tx_irq_raise();
 	}
 }
 #endif	/* CONFIG_BT_CONN_TX */
@@ -462,6 +475,11 @@ void bt_conn_recv(struct bt_conn *conn, struct net_buf *buf, uint8_t flags)
 	}
 }
 
+static bool dont_have_tx_context(struct bt_conn *conn)
+{
+	return k_fifo_is_empty(&free_tx);
+}
+
 static struct bt_conn_tx *conn_tx_alloc(void)
 {
 	struct bt_conn_tx *ret = k_fifo_get(&free_tx, K_NO_WAIT);
@@ -469,70 +487,6 @@ static struct bt_conn_tx *conn_tx_alloc(void)
 	LOG_DBG("%p", ret);
 
 	return ret;
-}
-
-int bt_conn_send_iso_cb(struct bt_conn *conn, struct net_buf *buf,
-			bt_conn_tx_cb_t cb, bool has_ts)
-{
-	if (buf->user_data_size < CONFIG_BT_CONN_TX_USER_DATA_SIZE) {
-		LOG_ERR("not enough room in user_data %d < %d",
-			buf->user_data_size,
-			CONFIG_BT_CONN_TX_USER_DATA_SIZE);
-		return -EINVAL;
-	}
-
-	/* Necessary for setting the TS_Flag bit when we pop the buffer from the
-	 * send queue. The flag needs to be set before adding the buffer to the queue.
-	 */
-	tx_data(buf)->iso_has_ts = has_ts;
-
-	int err = bt_conn_send_cb(conn, buf, cb, NULL);
-
-	if (err) {
-		return err;
-	}
-
-	return 0;
-}
-
-int bt_conn_send_cb(struct bt_conn *conn, struct net_buf *buf,
-		    bt_conn_tx_cb_t cb, void *user_data)
-{
-	LOG_DBG("conn handle %u buf len %u cb %p user_data %p", conn->handle, buf->len, cb,
-		user_data);
-
-	if (buf->ref != 1) {
-		/* The host may alter the buf contents when fragmenting. Higher
-		 * layers cannot expect the buf contents to stay intact. Extra
-		 * refs suggests a silent data corruption would occur if not for
-		 * this error.
-		 */
-		LOG_ERR("buf given to conn has other refs");
-		return -EINVAL;
-	}
-
-	if (buf->user_data_size < CONFIG_BT_CONN_TX_USER_DATA_SIZE) {
-		/* To find the pool:
-		 *     gdb --batch -ex 'b main' -ex 'r' -ex 'p net_buf_pool_get(pool_id)'
-		 */
-		LOG_ERR("not enough room in user_data %d < %d (pool id %u)",
-			buf->user_data_size,
-			CONFIG_BT_CONN_TX_USER_DATA_SIZE,
-			buf->pool_id);
-		return -EINVAL;
-	}
-
-	if (conn->state != BT_CONN_CONNECTED) {
-		LOG_ERR("not connected!");
-		return -ENOTCONN;
-	}
-
-	tx_data(buf)->cb = cb;
-	tx_data(buf)->cb_user_data = user_data;
-	tx_data(buf)->is_cont = false;
-
-	net_buf_put(&conn->tx_queue, buf);
-	return 0;
 }
 
 enum {
@@ -571,7 +525,7 @@ static int send_acl(struct bt_conn *conn, struct net_buf *buf, uint8_t flags)
 static int send_iso(struct bt_conn *conn, struct net_buf *buf, uint8_t flags)
 {
 	struct bt_hci_iso_hdr *hdr;
-	bool ts;
+	enum bt_iso_timestamp ts;
 
 	switch (flags) {
 	case FRAG_START:
@@ -590,13 +544,21 @@ static int send_iso(struct bt_conn *conn, struct net_buf *buf, uint8_t flags)
 		return -EINVAL;
 	}
 
+	/* The TS bit is set by `iso.c:conn_iso_send`. This special byte
+	 * prepends the whole SDU, and won't be there for individual fragments.
+	 *
+	 * Conveniently, it is only legal to set the TS bit on the first HCI
+	 * fragment, so we don't have to pass this extra metadata around for
+	 * every fragment, only the first one.
+	 */
+	if (flags == BT_ISO_SINGLE || flags == BT_ISO_START) {
+		ts = (enum bt_iso_timestamp)net_buf_pull_u8(buf);
+	} else {
+		ts = BT_ISO_TS_ABSENT;
+	}
+
 	hdr = net_buf_push(buf, sizeof(*hdr));
-
-	ts = tx_data(buf)->iso_has_ts &&
-		(flags == BT_ISO_START || flags == BT_ISO_SINGLE);
-
 	hdr->handle = sys_cpu_to_le16(bt_iso_handle_pack(conn->handle, flags, ts));
-
 	hdr->len = sys_cpu_to_le16(buf->len - sizeof(*hdr));
 
 	bt_buf_set_type(buf, BT_BUF_ISO_OUT);
@@ -624,240 +586,150 @@ static inline uint16_t conn_mtu(struct bt_conn *conn)
 #endif /* CONFIG_BT_CONN */
 }
 
-static int do_send_frag(struct bt_conn *conn, struct net_buf *buf, uint8_t flags,
-			struct bt_conn_tx *tx)
+static bool is_classic_conn(struct bt_conn *conn)
 {
-	uint32_t *pending_no_cb = NULL;
-	unsigned int key;
-	int err = 0;
-
-	LOG_DBG("conn %p buf %p len %u flags 0x%02x", conn, buf, buf->len,
-		flags);
-
-	/* Add to pending, it must be done before bt_buf_set_type */
-	key = irq_lock();
-	if (tx) {
-		sys_slist_append(&conn->tx_pending, &tx->node);
-	} else {
-		struct bt_conn_tx *tail_tx;
-
-		tail_tx = (void *)sys_slist_peek_tail(&conn->tx_pending);
-		if (tail_tx) {
-			pending_no_cb = &tail_tx->pending_no_cb;
-		} else {
-			pending_no_cb = &conn->pending_no_cb;
-		}
-
-		(*pending_no_cb)++;
-	}
-	irq_unlock(key);
-
-	if (IS_ENABLED(CONFIG_BT_ISO) && conn->type == BT_CONN_TYPE_ISO) {
-		err = send_iso(conn, buf, flags);
-	} else if (IS_ENABLED(CONFIG_BT_CONN)) {
-		err = send_acl(conn, buf, flags);
-	} else {
-		__ASSERT(false, "Invalid connection type %u", conn->type);
-	}
-
-	if (err) {
-		LOG_ERR("Unable to send to driver (err %d)", err);
-		key = irq_lock();
-		/* Roll back the pending TX info */
-		if (tx) {
-			sys_slist_find_and_remove(&conn->tx_pending, &tx->node);
-		} else {
-			__ASSERT_NO_MSG(*pending_no_cb > 0);
-			(*pending_no_cb)--;
-		}
-		irq_unlock(key);
-
-		/* We don't want to end up in a situation where send_acl/iso
-		 * returns the same error code as when we don't get a buffer in
-		 * time.
-		 */
-		err = -EIO;
-		goto fail;
-	}
-
-	return 0;
-
-fail:
-	/* If we get here, something has seriously gone wrong:
-	 * We also need to destroy the `parent` buf.
-	 */
-	k_sem_give(bt_conn_get_pkts(conn));
-	if (tx) {
-		/* `buf` might not get destroyed, and its `tx` pointer will still be reachable.
-		 * Make sure that we don't try to use the destroyed context later.
-		 */
-		conn_tx_destroy(conn, tx);
-	}
-
-	return err;
+	return (IS_ENABLED(CONFIG_BT_CLASSIC) &&
+		conn->type == BT_CONN_TYPE_BR);
 }
 
-static bool fits_single_ctlr_buf(struct net_buf *buf, struct bt_conn *conn)
+static bool is_iso_tx_conn(struct bt_conn *conn)
 {
-	return buf->len <= conn_mtu(conn);
+	return IS_ENABLED(CONFIG_BT_ISO_TX) &&
+		conn->type == BT_CONN_TYPE_ISO;
 }
 
-static int send_frag(struct bt_conn *conn, struct net_buf *buf, uint8_t flags)
+static bool is_le_conn(struct bt_conn *conn)
 {
-	struct net_buf *frag;
+	return IS_ENABLED(CONFIG_BT_CONN) && conn->type == BT_CONN_TYPE_LE;
+}
+
+static bool is_acl_conn(struct bt_conn *conn)
+{
+	return is_le_conn(conn) || is_classic_conn(conn);
+}
+
+static int send_buf(struct bt_conn *conn, struct net_buf *buf,
+		    void *cb, void *ud)
+{
+	struct net_buf *frag = NULL;
 	struct bt_conn_tx *tx = NULL;
+	uint8_t flags;
+	int err;
+
+	if (buf->len == 0) {
+		__ASSERT_NO_MSG(0);
+
+		return -EMSGSIZE;
+	}
 
 	if (bt_buf_has_view(buf)) {
-		LOG_ERR("already have view");
-		return -EWOULDBLOCK;
+		__ASSERT_NO_MSG(0);
+
+		return -EIO;
 	}
 
-	/* Check if the controller can accept ACL packets */
+	LOG_DBG("conn %p buf %p len %u", conn, buf, buf->len);
+
+	/* Acquire the right to send 1 packet to the controller */
 	if (k_sem_take(bt_conn_get_pkts(conn), K_NO_WAIT)) {
-		LOG_DBG("no controller bufs");
-		return -ENOBUFS;
+		/* This shouldn't happen now that we acquire the resources
+		 * before calling `send_buf` (in `get_conn_ready`). We say
+		 * "acquire" as `tx_processor()` is not re-entrant and the
+		 * thread is non-preemptible. So the sem value shouldn't change.
+		 */
+		__ASSERT(0, "No controller bufs");
+
+		return -ENOMEM;
 	}
 
-	/* Check for disconnection. It can't be done higher up (ie `send_buf`)
-	 * as `create_frag` blocks with K_FOREVER and the connection could
-	 * change state after waiting.
-	 */
-	if (conn->state != BT_CONN_CONNECTED) {
-		return -ENOTCONN;
+	/* Allocate and set the TX context */
+	tx = conn_tx_alloc();
+
+	/* See big comment above */
+	if (!tx) {
+		__ASSERT(0, "No TX context");
+
+		return -ENOMEM;
 	}
 
-	if (!fits_single_ctlr_buf(buf, conn)) {
+	tx->cb = cb;
+	tx->user_data = ud;
+
+	/* If the current buffer doesn't fit a controller buffer */
+	if (buf->len > conn_mtu(conn)) {
 		uint16_t frag_len = MIN(conn_mtu(conn), buf->len);
 
 		LOG_DBG("send frag: buf %p len %d", buf, frag_len);
 
-		/* will also do a pull */
-		frag = get_acl_frag(buf, frag_len);
-		/* Fragments never have a TX completion callback */
-		tx_data(frag)->cb = NULL;
-		tx_data(frag)->is_cont = false;
-
-		int err = do_send_frag(conn, frag, flags, tx);
-
-		if (err == -EIO) {
-			net_buf_unref(frag);
-		}
-
-		return err;
-
-	} else {
-		if (tx_data(buf)->cb) {
-			tx = conn_tx_alloc();
-			atomic_set_bit_to(conn->flags, BT_CONN_TX_WOULDBLOCK_FREE_TX, !tx);
-			if (!tx) {
-				LOG_DBG("No available tx context");
-				k_sem_give(bt_conn_get_pkts(conn));
-				return -EWOULDBLOCK;
-			}
-
-			tx->cb = tx_data(buf)->cb;
-			tx->user_data = tx_data(buf)->cb_user_data;
-			tx->pending_no_cb = 0U;
-		}
-
-		/* De-queue the buffer now that we know we can send it.
-		 * Only applies if the buffer to be sent is the original buffer,
-		 * and not one of its fragments.
-		 * This buffer was fetched from the FIFO using a peek operation.
+		/* get a view into `buf`, sized `frag_len`. Also pull
+		 * `frag_len` bytes from `buf`.
 		 */
-		buf = net_buf_get(&conn->tx_queue, K_NO_WAIT);
-		frag = buf;
+		frag = get_data_frag(buf, frag_len);
 
-		return do_send_frag(conn, frag, flags, tx);
-	}
-}
-
-/* Tentatively send a buffer to the HCI driver.
- *
- * This is designed to be async, as in most failures due to lack of resources
- * are not fatal. The caller should call `send_buf()` again later.
- *
- * Return values:
- *
- * - 0: `buf` sent. `buf` ownership transferred to lower layers.
- *
- * - -EIO: buffer failed to send due to HCI error. `buf` ownership returned to
- *    caller BUT `buf` is popped from the TX queue. The caller shall destroy
- *    `buf` and its TX context.
- *
- * - Any other error: buffer failed to send. `buf` ownership returned to caller
- *   and `buf` is still the head of the TX queue
- *
- */
-static int send_buf(struct bt_conn *conn, struct net_buf *buf)
-{
-	uint8_t flags;
-	int err;
-
-	LOG_DBG("conn %p buf %p len %u", conn, buf, buf->len);
-
-	if (bt_buf_has_view(buf)) {
-		LOG_DBG("locked by existing view");
-		return -EWOULDBLOCK;
+		flags = conn->next_is_frag ? FRAG_CONT : FRAG_START;
+		conn->next_is_frag = true;
+	} else {
+		flags = conn->next_is_frag ? FRAG_END : FRAG_SINGLE;
+		conn->next_is_frag = false;
 	}
 
-	/* Send directly if the packet fits the ACL MTU */
-	if (buf->len <= conn_mtu(conn) && !tx_data(buf)->is_cont) {
-		LOG_DBG("send single");
-		return send_frag(conn, buf, FRAG_SINGLE);
-	}
-
-	/*
-	 * Send the fragments. For the last one simply use the original
-	 * buffer (which works since we've used net_buf_pull on it).
+	/* At this point, the buffer is either a fragment or a full HCI packet.
+	 * The flags are also valid.
 	 */
-	flags = FRAG_START;
-	if (tx_data(buf)->is_cont) {
-		flags = FRAG_CONT;
+	LOG_DBG("conn %p buf %p len %u flags 0x%02x",
+		conn, frag ? frag : buf, buf->len, flags);
+
+	/* Keep track of sent buffers. We have to append _before_
+	 * sending, as we might get pre-empted if the HCI driver calls
+	 * k_yield() before returning.
+	 *
+	 * In that case, the controller could also send a num-complete-packets
+	 * event and our handler will be confused that there is no corresponding
+	 * callback node in the `tx_pending` list.
+	 */
+	atomic_inc(&conn->in_ll);
+	sys_slist_append(&conn->tx_pending, &tx->node);
+
+	if (is_iso_tx_conn(conn)) {
+		err = send_iso(conn, frag ? frag : buf, flags);
+	} else if (is_acl_conn(conn)) {
+		err = send_acl(conn, frag ? frag : buf, flags);
+	} else {
+		err = -EINVAL;	/* Some animals disable asserts (╯°□°）╯︵ ┻━┻ */
+		__ASSERT(false, "Invalid connection type %u", conn->type);
 	}
 
-	while (buf->len > conn_mtu(conn)) {
-		tx_data(buf)->is_cont = true;
-		err = send_frag(conn, buf, flags);
-		if (err) {
-			LOG_DBG("%p failed, mark as existing frag", buf);
-			return err;
-		}
-
-		flags = FRAG_CONT;
+	if (!err) {
+		return 0;
 	}
 
-	bool single = flags == FRAG_START;
+	/* Remove buf from pending list */
+	atomic_dec(&conn->in_ll);
+	(void)sys_slist_find_and_remove(&conn->tx_pending, &tx->node);
 
-	LOG_DBG("send %s", single ? "single" : "last");
+	LOG_ERR("Unable to send to driver (err %d)", err);
 
-	/* Frag is either a direct-send or the last in the series. */
-	return send_frag(conn, buf, single ? FRAG_SINGLE : FRAG_END);
+	/* If we get here, something has seriously gone wrong: The caller should
+	 * also destroy the `parent` buf (of which the current fragment
+	 * belongs).
+	 */
+	if (frag) {
+		net_buf_unref(frag);
+	}
+
+	/* `buf` might not get destroyed right away, and its `tx`
+	 * pointer will still be reachable. Make sure that we don't try
+	 * to use the destroyed context later.
+	 */
+	conn_tx_destroy(conn, tx);
+	k_sem_give(bt_conn_get_pkts(conn));
+
+	/* Merge HCI driver errors */
+	return -EIO;
 }
 
 static struct k_poll_signal conn_change =
 		K_POLL_SIGNAL_INITIALIZER(conn_change);
-
-static void conn_cleanup(struct bt_conn *conn)
-{
-	struct net_buf *buf;
-
-	/* Give back any allocated buffers */
-	while ((buf = net_buf_get(&conn->tx_queue, K_NO_WAIT))) {
-		bt_conn_tx_cb_t cb = tx_data(buf)->cb;
-		void *cb_user_data = tx_data(buf)->cb_user_data;
-
-		net_buf_unref(buf);
-		cb(conn, cb_user_data, -ESHUTDOWN);
-	}
-
-	__ASSERT(sys_slist_is_empty(&conn->tx_pending), "Pending TX packets");
-	__ASSERT_NO_MSG(conn->pending_no_cb == 0);
-
-	bt_conn_reset_rx_state(conn);
-
-	k_work_reschedule(&conn->deferred_work, K_NO_WAIT);
-}
 
 static void conn_destroy(struct bt_conn *conn, void *data)
 {
@@ -876,184 +748,288 @@ void bt_conn_cleanup_all(void)
 	bt_conn_foreach(BT_CONN_TYPE_ALL, conn_destroy, NULL);
 }
 
-static int conn_prepare_events(struct bt_conn *conn,
-			       struct k_poll_event *events)
-{
-	if (!atomic_get(&conn->ref)) {
-		return -ENOTCONN;
-	}
-
-	if (conn->state == BT_CONN_DISCONNECTED &&
-	    atomic_test_and_clear_bit(conn->flags, BT_CONN_CLEANUP)) {
-		conn_cleanup(conn);
-		return -ENOTCONN;
-	}
-
-	if (conn->state != BT_CONN_CONNECTED) {
-		return -ENOTCONN;
-	}
-
-	LOG_DBG("Adding conn %p to poll list", conn);
-
-	/* ISO Synchronized Receiver only builds do not transmit and hence
-	 * may not have any tx buffers allocated in a Controller.
-	 */
-	struct k_sem *conn_pkts = bt_conn_get_pkts(conn);
-
-	if (!conn_pkts) {
-		return -ENOTCONN;
-	}
-
-	bool buffers_available = k_sem_count_get(conn_pkts) > 0;
-	bool packets_waiting = !k_fifo_is_empty(&conn->tx_queue);
-
-	if (packets_waiting && !buffers_available) {
-		/* Only resume sending when the controller has buffer space
-		 * available for this connection.
-		 */
-		LOG_DBG("wait on ctlr buffers");
-		k_poll_event_init(&events[0],
-				  K_POLL_TYPE_SEM_AVAILABLE,
-				  K_POLL_MODE_NOTIFY_ONLY,
-				  conn_pkts);
-	} else if (atomic_test_bit(conn->flags, BT_CONN_TX_WOULDBLOCK_FREE_TX) &&
-		   k_fifo_is_empty(&free_tx)) {
-		LOG_DBG("wait on tx contexts");
-		k_poll_event_init(&events[0],
-				  K_POLL_TYPE_FIFO_DATA_AVAILABLE,
-				  K_POLL_MODE_NOTIFY_ONLY,
-				  &free_tx);
-		events[0].tag = BT_EVENT_CONN_FREE_TX;
-	} else {
-		/* This must be the last thing to be waited on, since
-		 * only this event triggers processing.
-		 */
-		/* Wait until there is more data to send. */
-		LOG_DBG("wait on host fifo");
-		k_poll_event_init(&events[0],
-				  K_POLL_TYPE_FIFO_DATA_AVAILABLE,
-				  K_POLL_MODE_NOTIFY_ONLY,
-				  &conn->tx_queue);
-		events[0].tag = BT_EVENT_CONN_TX_QUEUE;
-	}
-
-	return 0;
-}
-
-int bt_conn_prepare_events(struct k_poll_event events[])
-{
-	int i, ev_count = 0;
-	struct bt_conn *conn;
-
-	LOG_DBG("");
-
-	k_poll_signal_init(&conn_change);
-
-	k_poll_event_init(&events[ev_count++], K_POLL_TYPE_SIGNAL,
-			  K_POLL_MODE_NOTIFY_ONLY, &conn_change);
-
 #if defined(CONFIG_BT_CONN)
-	for (i = 0; i < ARRAY_SIZE(acl_conns); i++) {
-		conn = &acl_conns[i];
+/* Returns true if L2CAP has data to send on this conn */
+static bool acl_has_data(struct bt_conn *conn)
+{
+	return sys_slist_peek_head(&conn->l2cap_data_ready) != NULL;
+}
+#endif	/* defined(CONFIG_BT_CONN) */
 
-		if (!conn_prepare_events(conn, &events[ev_count])) {
-			ev_count++;
-		}
+/* Connection "Scheduler" of sorts:
+ *
+ * Will try to get the optimal number of queued buffers for the connection.
+ *
+ * Partitions the controller's buffers to each connection according to some
+ * heuristic. This is made to be tunable, fairness, simplicity, throughput etc.
+ *
+ * In the future, this will be a hook exposed to the application.
+ */
+static bool should_stop_tx(struct bt_conn *conn)
+{
+	LOG_DBG("%p", conn);
+
+	/* TODO: This function should be overridable by the application: they
+	 * should be able to provide their own heuristic.
+	 */
+	if (!conn->has_data(conn)) {
+		LOG_DBG("No more data for %p", conn);
+		return true;
 	}
-#endif /* CONFIG_BT_CONN */
 
-#if defined(CONFIG_BT_ISO)
-	for (i = 0; i < ARRAY_SIZE(iso_conns); i++) {
-		conn = &iso_conns[i];
-
-		if (!conn_prepare_events(conn, &events[ev_count])) {
-			ev_count++;
-		}
+	/* Queue only 3 buffers per-conn for now */
+	if (atomic_get(&conn->in_ll) < 3) {
+		/* The goal of this heuristic is to allow the link-layer to
+		 * extend an ACL connection event as long as the application
+		 * layer can provide data.
+		 *
+		 * Here we chose three buffers, as some LLs need two enqueued
+		 * packets to be able to set the more-data bit, and one more
+		 * buffer to allow refilling by the app while one of them is
+		 * being sent over-the-air.
+		 */
+		return false;
 	}
-#endif
 
-	return ev_count;
+	return true;
 }
 
-void bt_conn_process_tx(struct bt_conn *conn)
+void bt_tx_irq_raise(void)
 {
+	LOG_DBG("");
+	k_work_reschedule(&tx_work, K_NO_WAIT);
+}
+
+void bt_conn_data_ready(struct bt_conn *conn)
+{
+	LOG_DBG("DR");
+
+	/* The TX processor will call the `pull_cb` to get the buf */
+	if (!atomic_set(&conn->_conn_ready_lock, 1)) {
+		sys_slist_append(&bt_dev.le.conn_ready,
+				 &conn->_conn_ready);
+		LOG_DBG("raised");
+	} else {
+		LOG_DBG("already in list");
+	}
+
+	/* Kick the TX processor */
+	bt_tx_irq_raise();
+}
+
+static bool cannot_send_to_controller(struct bt_conn *conn)
+{
+	return k_sem_count_get(bt_conn_get_pkts(conn)) == 0;
+}
+
+static bool dont_have_methods(struct bt_conn *conn)
+{
+	return (conn->tx_data_pull == NULL) ||
+		(conn->get_and_clear_cb == NULL) ||
+		(conn->has_data == NULL);
+}
+
+struct bt_conn *get_conn_ready(void)
+{
+	/* Here we only peek: we pop the conn (and insert it at the back if it
+	 * still has data) after the QoS function returns false.
+	 */
+	sys_snode_t *node  = sys_slist_peek_head(&bt_dev.le.conn_ready);
+
+	if (node == NULL) {
+		return NULL;
+	}
+
+	struct bt_conn *conn = CONTAINER_OF(node, struct bt_conn, _conn_ready);
+
+	if (cannot_send_to_controller(conn)) {
+		/* We will get scheduled again when the buffers are freed. */
+		LOG_DBG("no LL bufs for %p", conn);
+		return NULL;
+	}
+
+	if (dont_have_tx_context(conn)) {
+		/* We will get scheduled again when TX contexts are available. */
+		LOG_DBG("no TX contexts");
+		return NULL;
+	}
+
+	CHECKIF(dont_have_methods(conn)) {
+		LOG_DBG("conn %p (type %d) is missing mandatory methods",
+			conn, conn->type);
+
+		return NULL;
+	}
+
+	if (should_stop_tx(conn)) {
+		sys_snode_t *s = sys_slist_get(&bt_dev.le.conn_ready);
+
+		__ASSERT_NO_MSG(s == node);
+		(void)s;
+
+		atomic_t old = atomic_set(&conn->_conn_ready_lock, 0);
+		/* Note: we can't assert `old` is non-NULL here, as the
+		 * connection might have been marked ready by an l2cap channel
+		 * that cancelled its request to send.
+		 */
+
+		(void)old;
+
+		/* Append connection to list if it still has data */
+		if (conn->has_data(conn)) {
+			LOG_DBG("appending %p to back of TX queue", conn);
+			bt_conn_data_ready(conn);
+		}
+	}
+
+	return conn;
+}
+
+/* Crazy that this file is compiled even if this is not true, but here we are. */
+#if defined(CONFIG_BT_CONN)
+static void acl_get_and_clear_cb(struct bt_conn *conn, struct net_buf *buf,
+				 bt_conn_tx_cb_t *cb, void **ud)
+{
+	__ASSERT_NO_MSG(is_acl_conn(conn));
+
+	*cb = closure_cb(buf->user_data);
+	*ud = closure_data(buf->user_data);
+	memset(buf->user_data, 0, buf->user_data_size);
+}
+#endif	/* defined(CONFIG_BT_CONN) */
+
+/* Acts as a "null-routed" bt_send(). This fn will decrease the refcount of
+ * `buf` and call the user callback with an error code.
+ */
+static void destroy_and_callback(struct bt_conn *conn,
+				 struct net_buf *buf,
+				 bt_conn_tx_cb_t cb,
+				 void *ud)
+{
+	if (!cb) {
+		conn->get_and_clear_cb(conn, buf, &cb, &ud);
+	}
+
+	LOG_DBG("pop: cb %p userdata %p", cb, ud);
+
+	/* bt_send() would've done an unref. Do it here also, so the buffer is
+	 * hopefully destroyed and the user callback can allocate a new one.
+	 */
+	net_buf_unref(buf);
+
+	if (cb) {
+		cb(conn, ud, -ESHUTDOWN);
+	}
+}
+
+void tx_processor(struct k_work *item)
+{
+	LOG_DBG("start");
+	struct bt_conn *conn;
 	struct net_buf *buf;
-	int err;
+	bt_conn_tx_cb_t cb = NULL;
+	void *ud = NULL;
 
-	LOG_DBG("conn %p", conn);
-
-	if (conn->state == BT_CONN_DISCONNECTED &&
-	    atomic_test_and_clear_bit(conn->flags, BT_CONN_CLEANUP)) {
-		LOG_DBG("handle %u disconnected - cleaning up", conn->handle);
-		conn_cleanup(conn);
+	if (!IS_ENABLED(CONFIG_BT_CONN_TX)) {
+		/* Mom, can we have a real compiler? */
 		return;
 	}
 
-	/* Get next ACL packet for connection. The buffer will only get dequeued
-	 * if there is a free controller buffer to put it in.
-	 *
-	 * Important: no operations should be done on `buf` until it is properly
-	 * dequeued from the FIFO, using the `net_buf_get()` API.
-	 */
-	buf = k_fifo_peek_head(&conn->tx_queue);
-	BT_ASSERT(buf);
+	conn = get_conn_ready();
 
-	/* Since we used `peek`, the queue still owns the reference to the
-	 * buffer, so we need to take an explicit additional reference here.
-	 */
-	buf = net_buf_ref(buf);
-	err = send_buf(conn, buf);
-	net_buf_unref(buf);
-
-	/* HCI driver error. `buf` may have been popped from `tx_queue` and
-	 * should be destroyed.
-	 *
-	 * TODO: In that case we might want to disable Bluetooth or at the very
-	 * least tear down the connection.
-	 */
-	if (err  == -EIO) {
-		bt_conn_tx_cb_t cb = tx_data(buf)->cb;
-		void *cb_user_data = tx_data(buf)->cb_user_data;
-
-		/* destroy the buffer */
-		net_buf_unref(buf);
-		cb(conn, cb_user_data, -ESHUTDOWN);
+	if (!conn) {
+		LOG_DBG("no connection wants to do stuff");
+		return;
 	}
+
+	LOG_DBG("processing conn %p", conn);
+
+	if (conn->state != BT_CONN_CONNECTED) {
+		LOG_ERR("conn %p: not connected", conn);
+		/* Call the user callbacks & destroy (final-unref) the buffers
+		 * we were supposed to send.
+		 */
+		buf = conn->tx_data_pull(conn, conn_mtu(conn));
+		while (buf) {
+			destroy_and_callback(conn, buf, cb, ud);
+			buf = conn->tx_data_pull(conn, conn_mtu(conn));
+		}
+		return;
+	}
+
+	/* now that we are guaranteed resources, we can pull data from the upper
+	 * layer (L2CAP or ISO).
+	 */
+	buf = conn->tx_data_pull(conn, conn_mtu(conn));
+	if (!buf) {
+		/* Either there is no more data, or the buffer is already in-use
+		 * by a view on it. In both cases, the TX processor will be
+		 * triggered again, either by the view's destroy callback, or by
+		 * the upper layer when it has more data.
+		 */
+		LOG_DBG("no buf returned");
+		return;
+	}
+
+	bool last_buf = conn_mtu(conn) >= buf->len;
+
+	if (last_buf) {
+		/* Only pull the callback info from the last buffer.
+		 * We still allocate one TX context per-fragment though.
+		 */
+		conn->get_and_clear_cb(conn, buf, &cb, &ud);
+		LOG_DBG("pop: cb %p userdata %p", cb, ud);
+	}
+
+	LOG_DBG("TX process: conn %p buf %p (%s)",
+		conn, buf, last_buf ? "last" : "frag");
+
+	int err = send_buf(conn, buf, cb, ud);
+
+	if (err) {
+		/* -EIO means `unrecoverable error`. It can be an assertion that
+		 *  failed or an error from the HCI driver.
+		 *
+		 * -ENOMEM means we thought we had all the resources to send the
+		 *  buf (ie. TX context + controller buffer) but one of them was
+		 *  not available. This is likely due to a failure of
+		 *  assumption, likely that we have been pre-empted somehow and
+		 *  that `tx_processor()` has been re-entered.
+		 *
+		 *  In both cases, we destroy the buffer and mark the connection
+		 *  as dead.
+		 */
+		LOG_ERR("Fatal error (%d). Disconnecting %p", err, conn);
+		destroy_and_callback(conn, buf, cb, ud);
+		bt_conn_disconnect(conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+
+		return;
+	}
+
+	/* Always kick the TX work. It will self-suspend if it doesn't get
+	 * resources or there is nothing left to send.
+	 */
+	k_work_reschedule(&tx_work, K_NO_WAIT);
 }
 
 static void process_unack_tx(struct bt_conn *conn)
 {
+	LOG_DBG("%p", conn);
+
 	/* Return any unacknowledged packets */
 	while (1) {
 		struct bt_conn_tx *tx;
 		sys_snode_t *node;
-		unsigned int key;
-
-		key = irq_lock();
-
-		if (conn->pending_no_cb) {
-			conn->pending_no_cb--;
-			irq_unlock(key);
-			k_sem_give(bt_conn_get_pkts(conn));
-			continue;
-		}
 
 		node = sys_slist_get(&conn->tx_pending);
-		irq_unlock(key);
 
 		if (!node) {
-			break;
+			return;
 		}
 
 		tx = CONTAINER_OF(node, struct bt_conn_tx, node);
 
-		key = irq_lock();
-		conn->pending_no_cb = tx->pending_no_cb;
-		tx->pending_no_cb = 0U;
-		irq_unlock(key);
-
 		conn_tx_destroy(conn, tx);
-
 		k_sem_give(bt_conn_get_pkts(conn));
 	}
 }
@@ -1131,7 +1107,6 @@ void bt_conn_set_state(struct bt_conn *conn, bt_conn_state_t state)
 			}
 			break;
 		}
-		k_fifo_init(&conn->tx_queue);
 		k_poll_signal_raise(&conn_change, 0);
 
 		if (IS_ENABLED(CONFIG_BT_ISO) &&
@@ -1184,8 +1159,9 @@ void bt_conn_set_state(struct bt_conn *conn, bt_conn_state_t state)
 				k_work_cancel_delayable(&conn->deferred_work);
 			}
 
-			atomic_set_bit(conn->flags, BT_CONN_CLEANUP);
-			k_poll_signal_raise(&conn_change, 0);
+			LOG_DBG("trigger disconnect work");
+			k_work_reschedule(&conn->deferred_work, K_NO_WAIT);
+
 			/* The last ref will be dropped during cleanup */
 			break;
 		case BT_CONN_INITIATING:
@@ -1547,6 +1523,8 @@ static void tx_complete_work(struct k_work *work)
 	struct bt_conn *conn = CONTAINER_OF(work, struct bt_conn,
 					    tx_complete_work);
 
+	LOG_DBG("conn %p", conn);
+
 	tx_notify(conn);
 }
 #endif /* CONFIG_BT_CONN_TX */
@@ -1567,6 +1545,18 @@ static void notify_recycled_conn_slot(void)
 	}
 #endif
 }
+
+#if !defined(CONFIG_BT_CONN)
+int bt_conn_disconnect(struct bt_conn *conn, uint8_t reason)
+{
+	ARG_UNUSED(conn);
+	ARG_UNUSED(reason);
+
+	/* Dummy implementation to satisfy the compiler */
+
+	return 0;
+}
+#endif	/* !CONFIG_BT_CONN */
 
 /* Group Connected BT_CONN only in this */
 #if defined(CONFIG_BT_CONN)
@@ -2187,6 +2177,9 @@ struct bt_conn *bt_conn_add_br(const bt_addr_t *peer)
 
 	bt_addr_copy(&conn->br.dst, peer);
 	conn->type = BT_CONN_TYPE_BR;
+	conn->tx_data_pull = l2cap_br_data_pull;
+	conn->get_and_clear_cb = acl_get_and_clear_cb;
+	conn->has_data = acl_has_data;
 
 	return conn;
 }
@@ -2526,6 +2519,9 @@ struct bt_conn *bt_conn_add_le(uint8_t id, const bt_addr_le_t *peer)
 	conn->required_sec_level = BT_SECURITY_L1;
 #endif /* CONFIG_BT_SMP */
 	conn->type = BT_CONN_TYPE_LE;
+	conn->tx_data_pull = l2cap_data_pull;
+	conn->get_and_clear_cb = acl_get_and_clear_cb;
+	conn->has_data = acl_has_data;
 	conn->le.interval_min = BT_GAP_INIT_CONN_INT_MIN;
 	conn->le.interval_max = BT_GAP_INIT_CONN_INT_MAX;
 

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -49,7 +49,9 @@
 LOG_MODULE_REGISTER(bt_conn);
 
 struct tx_meta {
-	struct bt_conn_tx *tx;
+	bt_conn_tx_cb_t cb;
+	void *cb_user_data;
+
 	/* This flag indicates if the current buffer has already been partially
 	 * sent to the controller (ie, the next fragments should be sent as
 	 * continuations).
@@ -204,6 +206,7 @@ static inline const char *state2str(bt_conn_state_t state)
 
 static void tx_free(struct bt_conn_tx *tx)
 {
+	LOG_DBG("%p", tx);
 	tx->cb = NULL;
 	tx->user_data = NULL;
 	tx->pending_no_cb = 0U;
@@ -425,25 +428,11 @@ void bt_conn_recv(struct bt_conn *conn, struct net_buf *buf, uint8_t flags)
 
 static struct bt_conn_tx *conn_tx_alloc(void)
 {
-	/* The TX context always get freed in the system workqueue,
-	 * so if we're in the same workqueue but there are no immediate
-	 * contexts available, there's no chance we'll get one by waiting.
-	 */
-	if (k_current_get() == &k_sys_work_q.thread) {
-		return k_fifo_get(&free_tx, K_NO_WAIT);
-	}
+	struct bt_conn_tx *ret = k_fifo_get(&free_tx, K_NO_WAIT);
 
-	if (IS_ENABLED(CONFIG_BT_CONN_LOG_LEVEL_DBG)) {
-		struct bt_conn_tx *tx = k_fifo_get(&free_tx, K_NO_WAIT);
+	LOG_DBG("%p", ret);
 
-		if (tx) {
-			return tx;
-		}
-
-		LOG_WRN("Unable to get an immediate free conn_tx");
-	}
-
-	return k_fifo_get(&free_tx, K_FOREVER);
+	return ret;
 }
 
 int bt_conn_send_iso_cb(struct bt_conn *conn, struct net_buf *buf,
@@ -473,8 +462,6 @@ int bt_conn_send_iso_cb(struct bt_conn *conn, struct net_buf *buf,
 int bt_conn_send_cb(struct bt_conn *conn, struct net_buf *buf,
 		    bt_conn_tx_cb_t cb, void *user_data)
 {
-	struct bt_conn_tx *tx;
-
 	LOG_DBG("conn handle %u buf len %u cb %p user_data %p", conn->handle, buf->len, cb,
 		user_data);
 
@@ -489,7 +476,10 @@ int bt_conn_send_cb(struct bt_conn *conn, struct net_buf *buf,
 	}
 
 	if (buf->user_data_size < CONFIG_BT_CONN_TX_USER_DATA_SIZE) {
-		LOG_ERR("not enough room in user_data %d < %d pool %u",
+		/* To find the pool:
+		 *     gdb --batch -ex 'b main' -ex 'r' -ex 'p net_buf_pool_get(pool_id)'
+		 */
+		LOG_ERR("not enough room in user_data %d < %d (pool id %u)",
 			buf->user_data_size,
 			CONFIG_BT_CONN_TX_USER_DATA_SIZE,
 			buf->pool_id);
@@ -501,29 +491,8 @@ int bt_conn_send_cb(struct bt_conn *conn, struct net_buf *buf,
 		return -ENOTCONN;
 	}
 
-	if (cb) {
-		tx = conn_tx_alloc();
-		if (!tx) {
-			LOG_DBG("Unable to allocate TX context");
-			return -ENOBUFS;
-		}
-
-		/* Verify that we're still connected after blocking */
-		if (conn->state != BT_CONN_CONNECTED) {
-			LOG_WRN("Disconnected while allocating context");
-			tx_free(tx);
-			return -ENOTCONN;
-		}
-
-		tx->cb = cb;
-		tx->user_data = user_data;
-		tx->pending_no_cb = 0U;
-
-		tx_data(buf)->tx = tx;
-	} else {
-		tx_data(buf)->tx = NULL;
-	}
-
+	tx_data(buf)->cb = cb;
+	tx_data(buf)->cb_user_data = user_data;
 	tx_data(buf)->is_cont = false;
 
 	net_buf_put(&conn->tx_queue, buf);
@@ -619,9 +588,9 @@ static inline uint16_t conn_mtu(struct bt_conn *conn)
 #endif /* CONFIG_BT_CONN */
 }
 
-static int do_send_frag(struct bt_conn *conn, struct net_buf *buf, uint8_t flags)
+static int do_send_frag(struct bt_conn *conn, struct net_buf *buf, uint8_t flags,
+			struct bt_conn_tx *tx)
 {
-	struct bt_conn_tx *tx = tx_data(buf)->tx;
 	uint32_t *pending_no_cb = NULL;
 	unsigned int key;
 	int err = 0;
@@ -686,7 +655,6 @@ fail:
 		/* `buf` might not get destroyed, and its `tx` pointer will still be reachable.
 		 * Make sure that we don't try to use the destroyed context later.
 		 */
-		tx_data(buf)->tx = NULL;
 		conn_tx_destroy(conn, tx);
 	}
 
@@ -697,6 +665,8 @@ static int send_frag(struct bt_conn *conn,
 		     struct net_buf *buf, struct net_buf *frag,
 		     uint8_t flags)
 {
+	struct bt_conn_tx *tx = NULL;
+
 	/* Check if the controller can accept ACL packets */
 	if (k_sem_take(bt_conn_get_pkts(conn), K_NO_WAIT)) {
 		LOG_DBG("no controller bufs");
@@ -718,6 +688,20 @@ static int send_frag(struct bt_conn *conn,
 		net_buf_add_mem(frag, buf->data, frag_len);
 		net_buf_pull(buf, frag_len);
 	} else {
+		if (tx_data(buf)->cb) {
+			tx = conn_tx_alloc();
+			atomic_set_bit_to(conn->flags, BT_CONN_TX_WOULDBLOCK_FREE_TX, !tx);
+			if (!tx) {
+				LOG_DBG("No available tx context");
+				k_sem_give(bt_conn_get_pkts(conn));
+				return -EWOULDBLOCK;
+			}
+
+			tx->cb = tx_data(buf)->cb;
+			tx->user_data = tx_data(buf)->cb_user_data;
+			tx->pending_no_cb = 0U;
+		}
+
 		/* De-queue the buffer now that we know we can send it.
 		 * Only applies if the buffer to be sent is the original buffer,
 		 * and not one of its fragments.
@@ -727,7 +711,7 @@ static int send_frag(struct bt_conn *conn,
 		frag = buf;
 	}
 
-	return do_send_frag(conn, frag, flags);
+	return do_send_frag(conn, frag, flags, tx);
 }
 
 static struct net_buf *create_frag(struct bt_conn *conn, struct net_buf *buf)
@@ -755,7 +739,7 @@ static struct net_buf *create_frag(struct bt_conn *conn, struct net_buf *buf)
 	}
 
 	/* Fragments never have a TX completion callback */
-	tx_data(frag)->tx = NULL;
+	tx_data(frag)->cb = NULL;
 	tx_data(frag)->is_cont = false;
 	tx_data(frag)->iso_has_ts = tx_data(buf)->iso_has_ts;
 
@@ -834,17 +818,11 @@ static void conn_cleanup(struct bt_conn *conn)
 
 	/* Give back any allocated buffers */
 	while ((buf = net_buf_get(&conn->tx_queue, K_NO_WAIT))) {
-		struct bt_conn_tx *tx = tx_data(buf)->tx;
+		bt_conn_tx_cb_t cb = tx_data(buf)->cb;
+		void *cb_user_data = tx_data(buf)->cb_user_data;
 
-		tx_data(buf)->tx = NULL;
-
-		/* destroy the buffer */
 		net_buf_unref(buf);
-
-		/* destroy the tx context (and any associated meta-data) */
-		if (tx) {
-			conn_tx_destroy(conn, tx);
-		}
+		cb(conn, cb_user_data, -ESHUTDOWN);
 	}
 
 	__ASSERT(sys_slist_is_empty(&conn->tx_pending), "Pending TX packets");
@@ -912,15 +890,26 @@ static int conn_prepare_events(struct bt_conn *conn,
 				  K_POLL_TYPE_SEM_AVAILABLE,
 				  K_POLL_MODE_NOTIFY_ONLY,
 				  conn_pkts);
+	} else if (atomic_test_bit(conn->flags, BT_CONN_TX_WOULDBLOCK_FREE_TX) &&
+		   k_fifo_is_empty(&free_tx)) {
+		LOG_DBG("wait on tx contexts");
+		k_poll_event_init(&events[0],
+				  K_POLL_TYPE_FIFO_DATA_AVAILABLE,
+				  K_POLL_MODE_NOTIFY_ONLY,
+				  &free_tx);
+		events[0].tag = BT_EVENT_CONN_FREE_TX;
 	} else {
+		/* This must be the last thing to be waited on, since
+		 * only this event triggers processing.
+		 */
 		/* Wait until there is more data to send. */
 		LOG_DBG("wait on host fifo");
 		k_poll_event_init(&events[0],
 				  K_POLL_TYPE_FIFO_DATA_AVAILABLE,
 				  K_POLL_MODE_NOTIFY_ONLY,
 				  &conn->tx_queue);
+		events[0].tag = BT_EVENT_CONN_TX_QUEUE;
 	}
-	events[0].tag = BT_EVENT_CONN_TX_QUEUE;
 
 	return 0;
 }
@@ -997,17 +986,12 @@ void bt_conn_process_tx(struct bt_conn *conn)
 	 * least tear down the connection.
 	 */
 	if (err  == -EIO) {
-		struct bt_conn_tx *tx = tx_data(buf)->tx;
-
-		tx_data(buf)->tx = NULL;
+		bt_conn_tx_cb_t cb = tx_data(buf)->cb;
+		void *cb_user_data = tx_data(buf)->cb_user_data;
 
 		/* destroy the buffer */
 		net_buf_unref(buf);
-
-		/* destroy the tx context (and any associated meta-data) */
-		if (tx) {
-			conn_tx_destroy(conn, tx);
-		}
+		cb(conn, cb_user_data, -ESHUTDOWN);
 	}
 }
 

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -51,9 +51,6 @@ LOG_MODULE_REGISTER(bt_conn);
 
 K_FIFO_DEFINE(free_tx);
 
-void tx_processor(struct k_work *item);
-K_WORK_DELAYABLE_DEFINE(tx_work, tx_processor);
-
 static void tx_free(struct bt_conn_tx *tx);
 
 static void conn_tx_destroy(struct bt_conn *conn, struct bt_conn_tx *tx)
@@ -794,12 +791,6 @@ static bool should_stop_tx(struct bt_conn *conn)
 	return true;
 }
 
-void bt_tx_irq_raise(void)
-{
-	LOG_DBG("");
-	k_work_reschedule(&tx_work, K_NO_WAIT);
-}
-
 void bt_conn_data_ready(struct bt_conn *conn)
 {
 	LOG_DBG("DR");
@@ -922,7 +913,20 @@ static void destroy_and_callback(struct bt_conn *conn,
 	}
 }
 
-void tx_processor(struct k_work *item)
+static volatile bool _suspend_tx;
+
+#if defined(CONFIG_BT_TESTING)
+void bt_conn_suspend_tx(bool suspend)
+{
+	_suspend_tx = suspend;
+
+	LOG_DBG("%sing all data TX", suspend ? "suspend" : "resum");
+
+	bt_tx_irq_raise();
+}
+#endif	/* CONFIG_BT_TESTING */
+
+void bt_conn_tx_processor(void)
 {
 	LOG_DBG("start");
 	struct bt_conn *conn;
@@ -932,6 +936,10 @@ void tx_processor(struct k_work *item)
 
 	if (!IS_ENABLED(CONFIG_BT_CONN_TX)) {
 		/* Mom, can we have a real compiler? */
+		return;
+	}
+
+	if (IS_ENABLED(CONFIG_BT_TESTING) && _suspend_tx) {
 		return;
 	}
 
@@ -1009,7 +1017,7 @@ void tx_processor(struct k_work *item)
 	/* Always kick the TX work. It will self-suspend if it doesn't get
 	 * resources or there is nothing left to send.
 	 */
-	k_work_reschedule(&tx_work, K_NO_WAIT);
+	bt_tx_irq_raise();
 }
 
 static void process_unack_tx(struct bt_conn *conn)

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -150,9 +150,7 @@ static struct net_buf *get_data_frag(struct net_buf *outside, size_t winsize)
 		return window;
 	}
 
-	__ASSERT_NO_MSG(outside->ref == 1);
-
-	window = bt_buf_make_view(window, net_buf_ref(outside),
+	window = bt_buf_make_view(window, outside,
 				  winsize, &get_frag_md(window)->view_meta);
 
 	LOG_DBG("get-acl-frag: outside %p window %p size %d", outside, window, winsize);
@@ -606,7 +604,7 @@ static bool is_acl_conn(struct bt_conn *conn)
 }
 
 static int send_buf(struct bt_conn *conn, struct net_buf *buf,
-		    void *cb, void *ud)
+		    size_t len, void *cb, void *ud)
 {
 	struct net_buf *frag = NULL;
 	struct bt_conn_tx *tx = NULL;
@@ -625,7 +623,7 @@ static int send_buf(struct bt_conn *conn, struct net_buf *buf,
 		return -EIO;
 	}
 
-	LOG_DBG("conn %p buf %p len %u", conn, buf, buf->len);
+	LOG_DBG("conn %p buf %p len %u buf->len %u", conn, buf, len, buf->len);
 
 	/* Acquire the right to send 1 packet to the controller */
 	if (k_sem_take(bt_conn_get_pkts(conn), K_NO_WAIT)) {
@@ -652,17 +650,23 @@ static int send_buf(struct bt_conn *conn, struct net_buf *buf,
 	tx->cb = cb;
 	tx->user_data = ud;
 
-	/* If the current buffer doesn't fit a controller buffer */
-	if (buf->len > conn_mtu(conn)) {
-		uint16_t frag_len = MIN(conn_mtu(conn), buf->len);
+	uint16_t frag_len = MIN(conn_mtu(conn), len);
 
-		LOG_DBG("send frag: buf %p len %d", buf, frag_len);
+	__ASSERT_NO_MSG(buf->ref == 1);
 
-		/* get a view into `buf`, sized `frag_len`. Also pull
-		 * `frag_len` bytes from `buf`.
+	if (buf->len > frag_len) {
+		LOG_DBG("keep %p around", buf);
+		frag = get_data_frag(net_buf_ref(buf), frag_len);
+	} else {
+		LOG_DBG("move %p ref in", buf);
+		/* Move the ref into `frag` for the last TX. That way `buf` will
+		 * get destroyed when `frag` is destroyed.
 		 */
 		frag = get_data_frag(buf, frag_len);
+	}
 
+	/* If the current buffer doesn't fit a controller buffer */
+	if (len > conn_mtu(conn)) {
 		flags = conn->next_is_frag ? FRAG_CONT : FRAG_START;
 		conn->next_is_frag = true;
 	} else {
@@ -670,11 +674,13 @@ static int send_buf(struct bt_conn *conn, struct net_buf *buf,
 		conn->next_is_frag = false;
 	}
 
+	LOG_DBG("send frag: buf %p len %d", buf, frag_len);
+
 	/* At this point, the buffer is either a fragment or a full HCI packet.
 	 * The flags are also valid.
 	 */
 	LOG_DBG("conn %p buf %p len %u flags 0x%02x",
-		conn, frag ? frag : buf, buf->len, flags);
+		conn, frag, frag->len, flags);
 
 	/* Keep track of sent buffers. We have to append _before_
 	 * sending, as we might get pre-empted if the HCI driver calls
@@ -688,9 +694,9 @@ static int send_buf(struct bt_conn *conn, struct net_buf *buf,
 	sys_slist_append(&conn->tx_pending, &tx->node);
 
 	if (is_iso_tx_conn(conn)) {
-		err = send_iso(conn, frag ? frag : buf, flags);
+		err = send_iso(conn, frag, flags);
 	} else if (is_acl_conn(conn)) {
-		err = send_acl(conn, frag ? frag : buf, flags);
+		err = send_acl(conn, frag, flags);
 	} else {
 		err = -EINVAL;	/* Some animals disable asserts (╯°□°）╯︵ ┻━┻ */
 		__ASSERT(false, "Invalid connection type %u", conn->type);
@@ -706,13 +712,10 @@ static int send_buf(struct bt_conn *conn, struct net_buf *buf,
 
 	LOG_ERR("Unable to send to driver (err %d)", err);
 
-	/* If we get here, something has seriously gone wrong: The caller should
-	 * also destroy the `parent` buf (of which the current fragment
-	 * belongs).
+	/* If we get here, something has seriously gone wrong: the `parent` buf
+	 * (of which the current fragment belongs) should also be destroyed.
 	 */
-	if (frag) {
-		net_buf_unref(frag);
-	}
+	net_buf_unref(frag);
 
 	/* `buf` might not get destroyed right away, and its `tx`
 	 * pointer will still be reachable. Make sure that we don't try
@@ -932,6 +935,7 @@ void bt_conn_tx_processor(void)
 	struct bt_conn *conn;
 	struct net_buf *buf;
 	bt_conn_tx_cb_t cb = NULL;
+	size_t buf_len;
 	void *ud = NULL;
 
 	if (!IS_ENABLED(CONFIG_BT_CONN_TX)) {
@@ -957,10 +961,10 @@ void bt_conn_tx_processor(void)
 		/* Call the user callbacks & destroy (final-unref) the buffers
 		 * we were supposed to send.
 		 */
-		buf = conn->tx_data_pull(conn, conn_mtu(conn));
+		buf = conn->tx_data_pull(conn, SIZE_MAX, &buf_len);
 		while (buf) {
 			destroy_and_callback(conn, buf, cb, ud);
-			buf = conn->tx_data_pull(conn, conn_mtu(conn));
+			buf = conn->tx_data_pull(conn, SIZE_MAX, &buf_len);
 		}
 		return;
 	}
@@ -968,7 +972,7 @@ void bt_conn_tx_processor(void)
 	/* now that we are guaranteed resources, we can pull data from the upper
 	 * layer (L2CAP or ISO).
 	 */
-	buf = conn->tx_data_pull(conn, conn_mtu(conn));
+	buf = conn->tx_data_pull(conn, conn_mtu(conn), &buf_len);
 	if (!buf) {
 		/* Either there is no more data, or the buffer is already in-use
 		 * by a view on it. In both cases, the TX processor will be
@@ -979,8 +983,9 @@ void bt_conn_tx_processor(void)
 		return;
 	}
 
-	bool last_buf = conn_mtu(conn) >= buf->len;
+	bool last_buf = conn_mtu(conn) >= buf_len;
 
+	/* TODO: add sdu_sent callback on last PDU */
 	if (last_buf) {
 		/* Only pull the callback info from the last buffer.
 		 * We still allocate one TX context per-fragment though.
@@ -992,7 +997,7 @@ void bt_conn_tx_processor(void)
 	LOG_DBG("TX process: conn %p buf %p (%s)",
 		conn, buf, last_buf ? "last" : "frag");
 
-	int err = send_buf(conn, buf, cb, ud);
+	int err = send_buf(conn, buf, buf_len, cb, ud);
 
 	if (err) {
 		/* -EIO means `unrecoverable error`. It can be an assertion that

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -856,18 +856,15 @@ struct bt_conn *get_conn_ready(void)
 	}
 
 	if (should_stop_tx(conn)) {
-		sys_snode_t *s = sys_slist_get(&bt_dev.le.conn_ready);
+		__maybe_unused sys_snode_t *s = sys_slist_get(&bt_dev.le.conn_ready);
 
 		__ASSERT_NO_MSG(s == node);
-		(void)s;
 
-		atomic_t old = atomic_set(&conn->_conn_ready_lock, 0);
+		(void)atomic_set(&conn->_conn_ready_lock, 0);
 		/* Note: we can't assert `old` is non-NULL here, as the
 		 * connection might have been marked ready by an l2cap channel
 		 * that cancelled its request to send.
 		 */
-
-		(void)old;
 
 		/* Append connection to list if it still has data */
 		if (conn->has_data(conn)) {

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -665,6 +665,9 @@ static int send_buf(struct bt_conn *conn, struct net_buf *buf,
 		frag = get_data_frag(buf, frag_len);
 	}
 
+	/* Caller is supposed to check we have all resources to send */
+	__ASSERT_NO_MSG(frag != NULL);
+
 	/* If the current buffer doesn't fit a controller buffer */
 	if (len > conn_mtu(conn)) {
 		flags = conn->next_is_frag ? FRAG_CONT : FRAG_START;
@@ -816,6 +819,25 @@ static bool cannot_send_to_controller(struct bt_conn *conn)
 	return k_sem_count_get(bt_conn_get_pkts(conn)) == 0;
 }
 
+static bool dont_have_viewbufs(void)
+{
+#if defined(CONFIG_BT_CONN_TX)
+	/* The LIFO only tracks buffers that have been destroyed at least once,
+	 * hence the uninit check beforehand.
+	 */
+	if (fragments.uninit_count > 0) {
+		/* If there are uninitialized bufs, we are guaranteed allocation. */
+		return false;
+	}
+
+	/* In practice k_fifo == k_lifo ABI. */
+	return k_fifo_is_empty(&fragments.free);
+
+#else  /* !CONFIG_BT_CONN_TX */
+	return false;
+#endif	/* CONFIG_BT_CONN_TX */
+}
+
 static bool dont_have_methods(struct bt_conn *conn)
 {
 	return (conn->tx_data_pull == NULL) ||
@@ -835,6 +857,14 @@ struct bt_conn *get_conn_ready(void)
 	}
 
 	struct bt_conn *conn = CONTAINER_OF(node, struct bt_conn, _conn_ready);
+
+	if (dont_have_viewbufs()) {
+		/* We will get scheduled again when the (view) buffers are freed. If you
+		 * hit this a lot, try increasing `CONFIG_BT_CONN_FRAG_COUNT`
+		 */
+		LOG_DBG("no view bufs");
+		return NULL;
+	}
 
 	if (cannot_send_to_controller(conn)) {
 		/* We will get scheduled again when the buffers are freed. */

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -80,6 +80,8 @@ enum {
 	BT_CONN_CTE_REQ_ENABLED,              /* CTE request procedure is enabled */
 	BT_CONN_CTE_RSP_ENABLED,              /* CTE response procedure is enabled */
 
+	BT_CONN_TX_WOULDBLOCK_FREE_TX,          /** #bt_conn_process_tx wouldblock on #free_tx */
+
 	/* Total number of flags - must be at the end of the enum */
 	BT_CONN_NUM_FLAGS,
 };

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -541,8 +541,7 @@ void bt_conn_cleanup_all(void);
 /* Selects based on connection type right semaphore for ACL packets */
 struct k_sem *bt_conn_get_pkts(struct bt_conn *conn);
 
-/* k_poll related helpers for the TX thread */
-int bt_conn_prepare_events(struct k_poll_event events[]);
+void bt_conn_tx_processor(void);
 
 /* To be called by upper layers when they want to send something.
  * Functions just like an IRQ.

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -269,7 +269,9 @@ struct bt_conn {
 	 * Scheduling from which channel to pull (e.g. for L2CAP) is done at the
 	 * upper layer's discretion.
 	 */
-	struct net_buf * (*tx_data_pull)(struct bt_conn *conn, size_t amount);
+	struct net_buf * (*tx_data_pull)(struct bt_conn *conn,
+					 size_t amount,
+					 size_t *length);
 
 	/* Get (and clears for ACL conns) callback and user-data for `buf`. */
 	void (*get_and_clear_cb)(struct bt_conn *conn, struct net_buf *buf,

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -392,10 +392,9 @@ int bt_hci_cmd_send_sync(uint16_t opcode, struct net_buf *buf,
 			 * to map the opcode to the HCI command documentation.
 			 * Example: 0x0c03 represents HCI_Reset command.
 			 */
-			bool success = process_pending_cmd(HCI_CMD_TIMEOUT);
+			__maybe_unused bool success = process_pending_cmd(HCI_CMD_TIMEOUT);
 
 			BT_ASSERT_MSG(success, "command opcode 0x%04x timeout", opcode);
-			(void)success; /* cmon zephyr fix your assert macros */
 		} while (buf != cmd);
 	}
 

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -528,37 +528,29 @@ static void hci_num_completed_packets(struct net_buf *buf)
 		}
 
 		while (count--) {
-			struct bt_conn_tx *tx;
 			sys_snode_t *node;
-			unsigned int key;
 
-			key = irq_lock();
+			k_sem_give(bt_conn_get_pkts(conn));
 
-			if (conn->pending_no_cb) {
-				conn->pending_no_cb--;
-				irq_unlock(key);
-				k_sem_give(bt_conn_get_pkts(conn));
-				continue;
-			}
-
+			/* move the next TX context from the `pending` list to
+			 * the `complete` list.
+			 */
 			node = sys_slist_get(&conn->tx_pending);
-			irq_unlock(key);
 
 			if (!node) {
 				LOG_ERR("packets count mismatch");
+				__ASSERT_NO_MSG(0);
 				break;
 			}
 
-			tx = CONTAINER_OF(node, struct bt_conn_tx, node);
+			sys_slist_append(&conn->tx_complete, node);
 
-			key = irq_lock();
-			conn->pending_no_cb = tx->pending_no_cb;
-			tx->pending_no_cb = 0U;
-			sys_slist_append(&conn->tx_complete, &tx->node);
-			irq_unlock(key);
+			/* align the `pending` value */
+			__ASSERT_NO_MSG(atomic_get(&conn->in_ll));
+			atomic_dec(&conn->in_ll);
 
+			/* TX context free + callback happens in there */
 			k_work_submit(&conn->tx_complete_work);
-			k_sem_give(bt_conn_get_pkts(conn));
 		}
 
 		bt_conn_unref(conn);
@@ -2946,34 +2938,14 @@ static void process_events(struct k_poll_event *ev, int count)
 		LOG_DBG("ev->state %u", ev->state);
 
 		switch (ev->state) {
-		case K_POLL_STATE_SIGNALED:
-			break;
-		case K_POLL_STATE_SEM_AVAILABLE:
-			/* After this fn is exec'd, `bt_conn_prepare_events()`
-			 * will be called once again, and this time buffers will
-			 * be available, so the FIFO will be added to the poll
-			 * list instead of the ctlr buffers semaphore.
-			 */
-			break;
 		case K_POLL_STATE_FIFO_DATA_AVAILABLE:
 			if (ev->tag == BT_EVENT_CMD_TX) {
 				send_cmd();
-			} else if (IS_ENABLED(CONFIG_BT_CONN) ||
-				   IS_ENABLED(CONFIG_BT_ISO)) {
-				struct bt_conn *conn;
-
-				if (ev->tag == BT_EVENT_CONN_TX_QUEUE) {
-					conn = CONTAINER_OF(ev->fifo,
-							    struct bt_conn,
-							    tx_queue);
-					bt_conn_process_tx(conn);
-				}
 			}
-			break;
-		case K_POLL_STATE_NOT_READY:
 			break;
 		default:
 			LOG_WRN("Unexpected k_poll event state %u", ev->state);
+			__ASSERT_NO_MSG(0);
 			break;
 		}
 	}
@@ -3013,11 +2985,6 @@ static void hci_tx_thread(void *p1, void *p2, void *p3)
 
 		events[0].state = K_POLL_STATE_NOT_READY;
 		ev_count = 1;
-
-		/* This adds the FIFO per-connection */
-		if (IS_ENABLED(CONFIG_BT_CONN) || IS_ENABLED(CONFIG_BT_ISO)) {
-			ev_count += bt_conn_prepare_events(&events[1]);
-		}
 
 		LOG_DBG("Calling k_poll with %d events", ev_count);
 

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -71,6 +71,8 @@ LOG_MODULE_REGISTER(bt_hci_core);
 #define BT_HCI_BUS  BT_DT_HCI_BUS_GET(BT_HCI_DEV)
 #define BT_HCI_NAME BT_DT_HCI_NAME_GET(BT_HCI_DEV)
 
+void bt_tx_irq_raise(void);
+
 #define HCI_CMD_TIMEOUT      K_SECONDS(10)
 
 /* Stacks for the threads */
@@ -80,8 +82,6 @@ static K_WORK_DEFINE(rx_work, rx_work_handler);
 static struct k_work_q bt_workq;
 static K_KERNEL_STACK_DEFINE(rx_thread_stack, CONFIG_BT_RX_STACK_SIZE);
 #endif /* CONFIG_BT_RECV_WORKQ_BT */
-static struct k_thread tx_thread_data;
-static K_KERNEL_STACK_DEFINE(tx_thread_stack, CONFIG_BT_HCI_TX_STACK_SIZE);
 
 static void init_work(struct k_work *work);
 
@@ -337,10 +337,12 @@ int bt_hci_cmd_send(uint16_t opcode, struct net_buf *buf)
 	}
 
 	net_buf_put(&bt_dev.cmd_tx_queue, buf);
+	bt_tx_irq_raise();
 
 	return 0;
 }
 
+static bool process_pending_cmd(k_timeout_t timeout);
 int bt_hci_cmd_send_sync(uint16_t opcode, struct net_buf *buf,
 			 struct net_buf **rsp)
 {
@@ -357,21 +359,47 @@ int bt_hci_cmd_send_sync(uint16_t opcode, struct net_buf *buf,
 
 	LOG_DBG("buf %p opcode 0x%04x len %u", buf, opcode, buf->len);
 
+	/* This local sem is just for suspending the current thread until the
+	 * command is processed by the LL. It is given (and we are awaken) by
+	 * the cmd_complete/status handlers.
+	 */
 	k_sem_init(&sync_sem, 0, 1);
 	cmd(buf)->sync = &sync_sem;
 
 	net_buf_put(&bt_dev.cmd_tx_queue, net_buf_ref(buf));
+	bt_tx_irq_raise();
 
-	/* Wait for a response from the Bluetooth Controller.
-	 * The Controller may fail to respond if:
-	 *  - It was never programmed or connected.
-	 *  - There was a fatal error.
-	 *
-	 * See the `BT_HCI_OP_` macros in hci_types.h or
-	 * Core_v5.4, Vol 4, Part E, Section 5.4.1 and Section 7
-	 * to map the opcode to the HCI command documentation.
-	 * Example: 0x0c03 represents HCI_Reset command.
+	/* TODO: disallow sending sync commands from syswq altogether */
+
+	/* Since the commands are now processed in the syswq, we cannot suspend
+	 * and wait. We have to send the command from the current context.
 	 */
+	if (k_current_get() == &k_sys_work_q.thread) {
+		/* drain the command queue until we get to send the command of interest. */
+		struct net_buf *cmd = NULL;
+
+		do {
+			cmd = k_fifo_peek_head(&bt_dev.cmd_tx_queue);
+			LOG_DBG("process cmd %p want %p", cmd, buf);
+
+			/* Wait for a response from the Bluetooth Controller.
+			 * The Controller may fail to respond if:
+			 *  - It was never programmed or connected.
+			 *  - There was a fatal error.
+			 *
+			 * See the `BT_HCI_OP_` macros in hci_types.h or
+			 * Core_v5.4, Vol 4, Part E, Section 5.4.1 and Section 7
+			 * to map the opcode to the HCI command documentation.
+			 * Example: 0x0c03 represents HCI_Reset command.
+			 */
+			bool success = process_pending_cmd(HCI_CMD_TIMEOUT);
+
+			BT_ASSERT_MSG(success, "command opcode 0x%04x timeout", opcode);
+			(void)success; /* cmon zephyr fix your assert macros */
+		} while (buf != cmd);
+	}
+
+	/* Now that we have sent the command, suspend until the LL replies */
 	err = k_sem_take(&sync_sem, HCI_CMD_TIMEOUT);
 	BT_ASSERT_MSG(err == 0,
 		      "Controller unresponsive, command opcode 0x%04x timeout with err %d",
@@ -2425,6 +2453,7 @@ static void hci_cmd_done(uint16_t opcode, uint8_t status, struct net_buf *evt_bu
 
 	/* If the command was synchronous wake up bt_hci_cmd_send_sync() */
 	if (cmd(buf)->sync) {
+		LOG_DBG("sync cmd released");
 		cmd(buf)->status = status;
 		k_sem_give(cmd(buf)->sync);
 	}
@@ -2465,6 +2494,7 @@ static void hci_cmd_complete(struct net_buf *buf)
 	/* Allow next command to be sent */
 	if (ncmd) {
 		k_sem_give(&bt_dev.ncmd_sem);
+		bt_tx_irq_raise();
 	}
 }
 
@@ -2485,6 +2515,7 @@ static void hci_cmd_status(struct net_buf *buf)
 	/* Allow next command to be sent */
 	if (ncmd) {
 		k_sem_give(&bt_dev.ncmd_sem);
+		bt_tx_irq_raise();
 	}
 }
 
@@ -2896,19 +2927,15 @@ static void hci_event(struct net_buf *buf)
 	net_buf_unref(buf);
 }
 
-static void send_cmd(void)
+static void hci_core_send_cmd(void)
 {
 	struct net_buf *buf;
 	int err;
 
 	/* Get next command */
-	LOG_DBG("calling net_buf_get");
+	LOG_DBG("fetch cmd");
 	buf = net_buf_get(&bt_dev.cmd_tx_queue, K_NO_WAIT);
 	BT_ASSERT(buf);
-
-	/* Wait until ncmd > 0 */
-	LOG_DBG("calling sem_take_wait");
-	k_sem_take(&bt_dev.ncmd_sem, K_FOREVER);
 
 	/* Clear out any existing sent command */
 	if (bt_dev.sent_cmd) {
@@ -2927,27 +2954,7 @@ static void send_cmd(void)
 		k_sem_give(&bt_dev.ncmd_sem);
 		hci_cmd_done(cmd(buf)->opcode, BT_HCI_ERR_UNSPECIFIED, buf);
 		net_buf_unref(buf);
-	}
-}
-
-static void process_events(struct k_poll_event *ev, int count)
-{
-	LOG_DBG("count %d", count);
-
-	for (; count; ev++, count--) {
-		LOG_DBG("ev->state %u", ev->state);
-
-		switch (ev->state) {
-		case K_POLL_STATE_FIFO_DATA_AVAILABLE:
-			if (ev->tag == BT_EVENT_CMD_TX) {
-				send_cmd();
-			}
-			break;
-		default:
-			LOG_WRN("Unexpected k_poll event state %u", ev->state);
-			__ASSERT_NO_MSG(0);
-			break;
-		}
+		bt_tx_irq_raise();
 	}
 }
 
@@ -2968,38 +2975,6 @@ static void process_events(struct k_poll_event *ev, int count)
 #define EV_COUNT 1
 #endif /* CONFIG_BT_ISO */
 #endif /* CONFIG_BT_CONN */
-
-static void hci_tx_thread(void *p1, void *p2, void *p3)
-{
-	static struct k_poll_event events[EV_COUNT] = {
-		K_POLL_EVENT_STATIC_INITIALIZER(K_POLL_TYPE_FIFO_DATA_AVAILABLE,
-						K_POLL_MODE_NOTIFY_ONLY,
-						&bt_dev.cmd_tx_queue,
-						BT_EVENT_CMD_TX),
-	};
-
-	LOG_DBG("Started");
-
-	while (1) {
-		int ev_count, err;
-
-		events[0].state = K_POLL_STATE_NOT_READY;
-		ev_count = 1;
-
-		LOG_DBG("Calling k_poll with %d events", ev_count);
-
-		err = k_poll(events, ev_count, K_FOREVER);
-		BT_ASSERT(err == 0);
-
-		process_events(events, ev_count);
-
-		/* Make sure we don't hog the CPU if there's all the time
-		 * some ready events.
-		 */
-		k_yield();
-	}
-}
-
 
 static void read_local_ver_complete(struct net_buf *buf)
 {
@@ -4210,7 +4185,8 @@ static void rx_work_handler(struct k_work *work)
 #if defined(CONFIG_BT_TESTING)
 k_tid_t bt_testing_tx_tid_get(void)
 {
-	return &tx_thread_data;
+	/* We now TX everything from the syswq */
+	return &k_sys_work_q.thread;
 }
 #endif
 
@@ -4262,13 +4238,6 @@ int bt_enable(bt_ready_cb_t cb)
 		k_sem_init(&bt_dev.ncmd_sem, 0, 1);
 	}
 	k_fifo_init(&bt_dev.cmd_tx_queue);
-	/* TX thread */
-	k_thread_create(&tx_thread_data, tx_thread_stack,
-			K_KERNEL_STACK_SIZEOF(tx_thread_stack),
-			hci_tx_thread, NULL, NULL, NULL,
-			K_PRIO_COOP(CONFIG_BT_HCI_TX_PRIO),
-			0, K_NO_WAIT);
-	k_thread_name_set(&tx_thread_data, "BT TX");
 
 #if defined(CONFIG_BT_RECV_WORKQ_BT)
 	/* RX thread */
@@ -4340,9 +4309,6 @@ int bt_disable(void)
 	bt_conn_cleanup_all();
 	disconnected_handles_reset();
 #endif /* CONFIG_BT_CONN */
-
-	/* Abort TX thread */
-	k_thread_abort(&tx_thread_data);
 
 #if defined(CONFIG_BT_RECV_WORKQ_BT)
 	/* Abort RX thread */
@@ -4643,4 +4609,42 @@ int bt_configure_data_path(uint8_t dir, uint8_t id, uint8_t vs_config_len,
 	net_buf_unref(rsp);
 
 	return err;
+}
+
+/* Return `true` if a command was processed/sent */
+static bool process_pending_cmd(k_timeout_t timeout)
+{
+	if (!k_fifo_is_empty(&bt_dev.cmd_tx_queue)) {
+		if (k_sem_take(&bt_dev.ncmd_sem, K_NO_WAIT) == 0) {
+			hci_core_send_cmd();
+			return true;
+		}
+	}
+
+	return false;
+}
+
+static void tx_processor(struct k_work *item)
+{
+	LOG_DBG("TX process start");
+	if (process_pending_cmd(K_NO_WAIT)) {
+		/* If we processed a command, let the scheduler run before
+		 * processing another command (or data).
+		 */
+		bt_tx_irq_raise();
+		return;
+	}
+
+	/* Hand over control to conn to process pending data */
+	if (IS_ENABLED(CONFIG_BT_CONN_TX)) {
+		bt_conn_tx_processor();
+	}
+}
+
+K_WORK_DELAYABLE_DEFINE(tx_work, tx_processor);
+
+void bt_tx_irq_raise(void)
+{
+	LOG_DBG("kick TX");
+	k_work_reschedule(&tx_work, K_NO_WAIT);
 }

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -26,6 +26,7 @@
 enum {
 	BT_EVENT_CMD_TX,
 	BT_EVENT_CONN_TX_QUEUE,
+	BT_EVENT_CONN_FREE_TX,
 };
 
 /* bt_dev flags: the flags defined here represent BT controller state */

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -594,3 +594,5 @@ void bt_hci_le_df_cte_req_failed(struct net_buf *buf);
 
 void bt_hci_le_per_adv_subevent_data_request(struct net_buf *buf);
 void bt_hci_le_per_adv_response_report(struct net_buf *buf);
+
+void bt_tx_irq_raise(void);

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -309,6 +309,10 @@ struct bt_dev_le {
 	 */
 	uint8_t                    rl_entries;
 #endif /* CONFIG_BT_SMP */
+	/* List of `struct bt_conn` that have either pending data to send, or
+	 * something to process (e.g. a disconnection event).
+	 */
+	sys_slist_t		conn_ready;
 };
 
 #if defined(CONFIG_BT_CLASSIC)

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -138,7 +138,9 @@ void hci_iso(struct net_buf *buf)
 }
 
 /* Pull data from the ISO layer */
-static struct net_buf *iso_data_pull(struct bt_conn *conn, size_t amount);
+static struct net_buf *iso_data_pull(struct bt_conn *conn,
+				     size_t amount,
+				     size_t *length);
 
 /* Returns true if the ISO layer has data to send on this conn */
 static bool iso_has_data(struct bt_conn *conn);
@@ -734,7 +736,9 @@ static bool iso_has_data(struct bt_conn *conn)
 #endif	/* CONFIG_BT_ISO_TX */
 }
 
-static struct net_buf *iso_data_pull(struct bt_conn *conn, size_t amount)
+static struct net_buf *iso_data_pull(struct bt_conn *conn,
+				     size_t amount,
+				     size_t *length)
 {
 #if defined(CONFIG_BT_ISO_TX)
 	LOG_DBG("conn %p amount %d", conn, amount);
@@ -773,6 +777,8 @@ static struct net_buf *iso_data_pull(struct bt_conn *conn, size_t amount)
 		(void)b;
 		__ASSERT_NO_MSG(b == frag);
 	}
+
+	*length = frag->len;
 
 	return frag;
 #else

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -729,9 +729,9 @@ static bool iso_has_data(struct bt_conn *conn)
 {
 #if defined(CONFIG_BT_ISO_TX)
 	return !k_fifo_is_empty(&conn->iso.txq);
-#else
+#else  /* !CONFIG_BT_ISO_TX */
 	return false;
-#endif
+#endif	/* CONFIG_BT_ISO_TX */
 }
 
 static struct net_buf *iso_data_pull(struct bt_conn *conn, size_t amount)

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -754,10 +754,11 @@ static struct net_buf *iso_data_pull(struct bt_conn *conn,
 	}
 
 	if (conn->iso.chan->state != BT_ISO_STATE_CONNECTED) {
+		__maybe_unused struct net_buf *b = k_fifo_get(&conn->iso.txq, K_NO_WAIT);
+
 		LOG_DBG("channel has been disconnected");
-		struct net_buf *b = k_fifo_get(&conn->iso.txq, K_NO_WAIT);
-		(void)b;
 		__ASSERT_NO_MSG(b == frag);
+
 		return NULL;
 	}
 
@@ -772,9 +773,9 @@ static struct net_buf *iso_data_pull(struct bt_conn *conn,
 	bool last_frag = amount >= frag->len;
 
 	if (last_frag) {
+		__maybe_unused struct net_buf *b = k_fifo_get(&conn->iso.txq, K_NO_WAIT);
+
 		LOG_DBG("last frag, pop buf");
-		struct net_buf *b = k_fifo_get(&conn->iso.txq, K_NO_WAIT);
-		(void)b;
 		__ASSERT_NO_MSG(b == frag);
 	}
 

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -48,11 +48,6 @@ NET_BUF_POOL_FIXED_DEFINE(iso_tx_pool, CONFIG_BT_ISO_TX_BUF_COUNT,
 			  BT_ISO_SDU_BUF_SIZE(CONFIG_BT_ISO_TX_MTU),
 			  CONFIG_BT_CONN_TX_USER_DATA_SIZE, NULL);
 
-#if CONFIG_BT_ISO_TX_FRAG_COUNT > 0
-NET_BUF_POOL_FIXED_DEFINE(iso_frag_pool, CONFIG_BT_ISO_TX_FRAG_COUNT,
-			  BT_ISO_SDU_BUF_SIZE(CONFIG_BT_ISO_TX_MTU),
-			  CONFIG_BT_CONN_TX_USER_DATA_SIZE, NULL);
-#endif /* CONFIG_BT_ISO_TX_FRAG_COUNT > 0 */
 #endif /* CONFIG_BT_ISO_UNICAST || CONFIG_BT_ISO_BROADCAST */
 
 struct bt_conn iso_conns[CONFIG_BT_ISO_MAX_CHAN];
@@ -169,28 +164,6 @@ struct net_buf *bt_iso_create_pdu_timeout(struct net_buf_pool *pool,
 	}
 
 	reserve += sizeof(struct bt_hci_iso_sdu_hdr);
-
-#if defined(CONFIG_NET_BUF_LOG)
-	return bt_conn_create_pdu_timeout_debug(pool, reserve, timeout, func,
-						line);
-#else
-	return bt_conn_create_pdu_timeout(pool, reserve, timeout);
-#endif
-}
-
-#if defined(CONFIG_NET_BUF_LOG)
-struct net_buf *bt_iso_create_frag_timeout_debug(size_t reserve,
-						 k_timeout_t timeout,
-						 const char *func, int line)
-#else
-struct net_buf *bt_iso_create_frag_timeout(size_t reserve, k_timeout_t timeout)
-#endif
-{
-	struct net_buf_pool *pool = NULL;
-
-#if CONFIG_BT_ISO_TX_FRAG_COUNT > 0
-	pool = &iso_frag_pool;
-#endif /* CONFIG_BT_ISO_TX_FRAG_COUNT > 0 */
 
 #if defined(CONFIG_NET_BUF_LOG)
 	return bt_conn_create_pdu_timeout_debug(pool, reserve, timeout, func,

--- a/subsys/bluetooth/host/iso_internal.h
+++ b/subsys/bluetooth/host/iso_internal.h
@@ -158,3 +158,11 @@ void bt_iso_chan_set_state(struct bt_iso_chan *chan, enum bt_iso_state state);
 
 /* Process incoming data for a connection */
 void bt_iso_recv(struct bt_conn *iso, struct net_buf *buf, uint8_t flags);
+
+/* Whether the HCI ISO data packet contains a timestamp or not.
+ * Per spec, the TS flag can only be set for the first fragment.
+ */
+enum bt_iso_timestamp {
+	BT_ISO_TS_ABSENT = 0,
+	BT_ISO_TS_PRESENT,
+};

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -1182,12 +1182,6 @@ static void l2cap_chan_tx_process(struct k_work *work)
 				LOG_DBG("out of credits/windows");
 
 				ch->tx_buf = buf;
-				/* If we don't reschedule, and the app doesn't nudge l2cap (e.g. by
-				 * sending another SDU), the channel will be stuck in limbo. To
-				 * prevent this, we reschedule with a configurable delay.
-				 * FIXME: is this still necessary?
-				 */
-				k_work_schedule(&ch->tx_work, K_MSEC(CONFIG_BT_L2CAP_RESCHED_MS));
 			} else {
 				LOG_WRN("Failed to send (err %d), dropping buf %p", ret, buf);
 				l2cap_tx_buf_destroy(ch->chan.conn, buf, ret);

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -674,17 +674,15 @@ static void raise_data_ready(struct bt_l2cap_le_chan *le_chan)
 static void lower_data_ready(struct bt_l2cap_le_chan *le_chan)
 {
 	struct bt_conn *conn = le_chan->chan.conn;
-	sys_snode_t *s = sys_slist_get(&conn->l2cap_data_ready);
+	__maybe_unused sys_snode_t *s = sys_slist_get(&conn->l2cap_data_ready);
 
 	LOG_DBG("%p", le_chan);
 
 	__ASSERT_NO_MSG(s == &le_chan->_pdu_ready);
-	(void)s;
 
-	atomic_t old = atomic_set(&le_chan->_pdu_ready_lock, 0);
+	__maybe_unused atomic_t old = atomic_set(&le_chan->_pdu_ready_lock, 0);
 
 	__ASSERT_NO_MSG(old);
-	(void)old;
 }
 
 static void cancel_data_ready(struct bt_l2cap_le_chan *le_chan)
@@ -923,10 +921,9 @@ struct net_buf *l2cap_data_pull(struct bt_conn *conn,
 
 	if (last_frag && last_seg) {
 		LOG_DBG("last frag of last seg, dequeuing %p", pdu);
-		struct net_buf *b = k_fifo_get(&lechan->tx_queue, K_NO_WAIT);
+		__maybe_unused struct net_buf *b = k_fifo_get(&lechan->tx_queue, K_NO_WAIT);
 
 		__ASSERT_NO_MSG(b == pdu);
-		(void)b;
 
 		if (L2CAP_LE_CID_IS_DYN(lechan->tx.cid)) {
 			LOG_DBG("adding `sdu_sent` callback");

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -12,6 +12,7 @@
 #include <errno.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/atomic.h>
+#include <zephyr/sys/check.h>
 #include <zephyr/sys/iterable_sections.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/math_extras.h>
@@ -25,6 +26,7 @@
 
 #define LOG_DBG_ENABLED IS_ENABLED(CONFIG_BT_L2CAP_LOG_LEVEL_DBG)
 
+#include "buf_view.h"
 #include "hci_core.h"
 #include "conn_internal.h"
 #include "l2cap_internal.h"
@@ -87,6 +89,86 @@ struct bt_l2cap {
 
 static const struct bt_l2cap_ecred_cb *ecred_cb;
 static struct bt_l2cap bt_l2cap_pool[CONFIG_BT_MAX_CONN];
+
+static void seg_destroy(struct net_buf *buf);
+#define SEGMENTS_COUNT CONFIG_BT_MAX_CONN
+/* see equivalent struct in conn.c */
+NET_BUF_POOL_FIXED_DEFINE(seg_pool, SEGMENTS_COUNT, 0,
+			  CONFIG_BT_CONN_TX_USER_DATA_SIZE, seg_destroy);
+
+struct seg_md {
+	struct bt_l2cap_le_chan *lechan;
+	struct bt_buf_view_meta view_meta;
+};
+
+struct seg_md seg_md_pool[SEGMENTS_COUNT];
+
+struct seg_md *get_seg_md(struct net_buf *seg)
+{
+	return &seg_md_pool[net_buf_id(seg)];
+}
+
+#if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
+static void l2cap_chan_tx_resume(struct bt_l2cap_le_chan *ch);
+#endif
+
+static void seg_destroy(struct net_buf *seg)
+{
+	/* Only relevant if there is segmentation going on. This is not possible
+	 * for LE ACL fixed channels, only for credit-based ones.
+	 */
+#if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
+	struct bt_l2cap_le_chan *lechan = get_seg_md(seg)->lechan;
+
+	get_seg_md(seg)->lechan = NULL;
+
+	LOG_INF("destroy %p (parent %p)", seg, lechan->tx_buf);
+
+	/* allow next view to be allocated (and unlock the parent buf) */
+	bt_buf_destroy_view(seg, &get_seg_md(seg)->view_meta);
+
+	/* try to allocate and send next view PDU */
+	l2cap_chan_tx_resume(lechan);
+#endif
+}
+
+#if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
+static struct net_buf *get_seg(struct net_buf *sdu,
+			       size_t seg_size,
+			       struct bt_l2cap_le_chan *lechan)
+{
+	struct net_buf *view;
+
+	__ASSERT_NO_MSG(!bt_buf_has_view(sdu));
+
+	/* optimization: don't allocate if we know `make_view` will return `sdu` */
+	if ((seg_size >= sdu->len) &&
+	    (net_buf_headroom(sdu) >= BT_L2CAP_BUF_SIZE(0))) {
+
+		LOG_INF("view >= bufsize, returning it");
+
+		return sdu;
+	}
+
+	/* Keeping a ref is the caller's responsibility */
+	view = net_buf_alloc(&seg_pool, K_NO_WAIT);
+	if (!view) {
+		/* This should never happen? If pool properly configured. */
+		__ASSERT_NO_MSG(view);
+		return NULL;
+	}
+
+	__ASSERT_NO_MSG(sdu->ref == 1);
+
+	get_seg_md(view)->lechan = lechan;
+	view = bt_buf_make_view(view, net_buf_ref(sdu),
+				seg_size, &get_seg_md(view)->view_meta);
+
+	LOG_INF("alloc-w-view: sdu %p view %p size %d", sdu, view, seg_size);
+
+	return view;
+}
+#endif	/* CONFIG_BT_L2CAP_DYNAMIC_CHANNEL */
 
 void bt_l2cap_register_ecred_cb(const struct bt_l2cap_ecred_cb *cb)
 {
@@ -648,6 +730,16 @@ int bt_l2cap_send_cb(struct bt_conn *conn, uint16_t cid, struct net_buf *buf,
 	hdr->len = sys_cpu_to_le16(buf->len - sizeof(*hdr));
 	hdr->cid = sys_cpu_to_le16(cid);
 
+	if (buf->ref != 1) {
+		/* The host may alter the buf contents when fragmenting. Higher
+		 * layers cannot expect the buf contents to stay intact. Extra
+		 * refs suggests a silent data corruption would occur if not for
+		 * this error.
+		 */
+		LOG_ERR("Expecting 1 ref, got %d", seg->ref);
+		return -EINVAL;
+	}
+
 	return bt_conn_send_cb(conn, buf, cb, user_data);
 }
 
@@ -924,6 +1016,8 @@ static void l2cap_chan_tx_process(struct k_work *work)
 
 	ch = CONTAINER_OF(k_work_delayable_from_work(work), struct bt_l2cap_le_chan, tx_work);
 
+	LOG_INF("%s: %p", __func__, ch);
+
 	if (bt_l2cap_chan_get_state(&ch->chan) != BT_L2CAP_CONNECTED) {
 		LOG_DBG("Cannot send on non-connected channel");
 		return;
@@ -940,17 +1034,25 @@ static void l2cap_chan_tx_process(struct k_work *work)
 		ret = l2cap_chan_le_send_sdu(ch, buf);
 		if (ret < 0) {
 			if (ret == -EAGAIN) {
+				/* Out of credits or buffer already locked. Work
+				 * will be restarted upon receiving credits and
+				 * when a segment buffer is freed.
+				 */
+				LOG_INF("out of credits/windows");
+
 				ch->tx_buf = buf;
 				/* If we don't reschedule, and the app doesn't nudge l2cap (e.g. by
 				 * sending another SDU), the channel will be stuck in limbo. To
 				 * prevent this, we reschedule with a configurable delay.
+				 * FIXME: is this still necessary?
 				 */
 				k_work_schedule(&ch->tx_work, K_MSEC(CONFIG_BT_L2CAP_RESCHED_MS));
 			} else {
 				LOG_WRN("Failed to send (err %d), dropping buf %p", ret, buf);
 				l2cap_tx_buf_destroy(ch->chan.conn, buf, ret);
 			}
-			break;
+
+			return;
 		}
 	}
 }
@@ -1820,28 +1922,6 @@ static void le_disconn_rsp(struct bt_l2cap *l2cap, uint8_t ident,
 	bt_l2cap_chan_del(&chan->chan);
 }
 
-static struct net_buf *l2cap_alloc_seg(struct bt_l2cap_le_chan *ch)
-{
-	struct net_buf *seg = NULL;
-
-	/* Use the user-defined allocator */
-	if (ch->chan.ops->alloc_seg) {
-		seg = ch->chan.ops->alloc_seg(&ch->chan);
-		__ASSERT_NO_MSG(seg);
-	}
-
-	/* Fallback to using global connection tx pool */
-	if (!seg) {
-		seg = bt_l2cap_create_pdu_timeout(NULL, 0, K_NO_WAIT);
-	}
-
-	if (seg) {
-		net_buf_reserve(seg, BT_L2CAP_CHAN_SEND_RESERVE);
-	}
-
-	return seg;
-}
-
 static void l2cap_chan_tx_resume(struct bt_l2cap_le_chan *ch)
 {
 	if (!atomic_get(&ch->tx.credits) ||
@@ -1896,8 +1976,6 @@ static void l2cap_chan_seg_sent(struct bt_conn *conn, void *user_data, int err)
 		/* Received segment sent callback for disconnected channel */
 		return;
 	}
-
-	l2cap_chan_tx_resume(BT_L2CAP_LE_CHAN(chan));
 }
 
 static bool test_and_dec(atomic_t *target)
@@ -1926,13 +2004,17 @@ static bool test_and_dec(atomic_t *target)
  * In all cases the original buffer is unaffected so it can be pushed back to
  * be sent later.
  */
-static int l2cap_chan_le_send(struct bt_l2cap_le_chan *ch,
-			      struct net_buf *buf, uint16_t sdu_hdr_len)
+static int l2cap_chan_le_send_seg(struct bt_l2cap_le_chan *ch, struct net_buf *buf)
 {
 	struct net_buf *seg;
 	struct net_buf_simple_state state;
 	int len, err;
 	bt_conn_tx_cb_t cb;
+
+	if (bt_buf_has_view(buf)) {
+		LOG_DBG("Already have TX inflight");
+		return -EAGAIN;
+	}
 
 	if (!test_and_dec(&ch->tx.credits)) {
 		LOG_DBG("No credits to transmit packet");
@@ -1942,47 +2024,36 @@ static int l2cap_chan_le_send(struct bt_l2cap_le_chan *ch,
 	/* Save state so it can be restored if we failed to send */
 	net_buf_simple_save(&buf->b, &state);
 
-	if ((buf->len <= ch->tx.mps) &&
-	    (net_buf_headroom(buf) >= BT_L2CAP_BUF_SIZE(0))) {
-		LOG_DBG("len <= MPS, not allocating seg for %p", buf);
-		/* move `buf` to `seg`. `buf` now borrows `seg`. */
-		seg = buf;
+	seg = get_seg(buf, ch->tx.mps, ch);
 
-		len = seg->len;
-	} else {
-		LOG_DBG("allocating segment for %p (%u bytes left)", buf, buf->len);
-		seg = l2cap_alloc_seg(ch);
-		if (!seg) {
-			LOG_DBG("failed to allocate seg for %p", buf);
-			atomic_inc(&ch->tx.credits);
-
-			return -EAGAIN;
-		}
-
-		/* Don't send more than TX MPS */
-		len = MIN(net_buf_tailroom(seg), ch->tx.mps);
-
-		/* Limit if original buffer is smaller than the segment */
-		len = MIN(buf->len, len);
-
-		net_buf_add_mem(seg, buf->data, len);
-		net_buf_pull(buf, len);
+	CHECKIF(!seg) {
+		/* Future work: Give the channel a tx state
+		 * machine, so that we remember that we took a
+		 * credit and don't need to give it back here.
+		 */
+		LOG_WRN("Out of segment buffers.");
+		atomic_inc(&ch->tx.credits);
+		return -ENOBUFS;
 	}
 
 	LOG_DBG("ch %p cid 0x%04x len %u credits %lu", ch, ch->tx.cid, seg->len,
 		atomic_get(&ch->tx.credits));
 
-	len = seg->len - sdu_hdr_len;
+	len = seg->len;
 
 	/* SDU will be considered sent when there is no data left in the
 	 * buffer, or if there will be no data left, if we are sending `buf`
 	 * directly.
 	 */
 	if (buf->len == 0 || (buf == seg && buf->len == len)) {
+		LOG_INF("last PDU");
 		cb = l2cap_chan_sdu_sent;
 	} else {
+		LOG_INF("send PDU left %u", buf->len);
 		cb = l2cap_chan_seg_sent;
 	}
+
+	len = seg->len;
 
 	/* Forward the PDU to the lower layer.
 	 *
@@ -1993,8 +2064,11 @@ static int l2cap_chan_le_send(struct bt_l2cap_le_chan *ch,
 	err = bt_l2cap_send_cb(ch->chan.conn, ch->tx.cid, seg,
 			       cb, UINT_TO_POINTER(ch->tx.cid));
 
+	/* The only possible error is enotconn, in that case the data will be discarded anyways */
+	__ASSERT_NO_MSG(!err || err == -ENOTCONN);
+
 	if (err) {
-		LOG_DBG("Unable to send seg %d", err);
+		LOG_INF("Unable to send seg %d", err);
 		atomic_inc(&ch->tx.credits);
 
 		/* The host takes ownership of the reference in seg when
@@ -2005,18 +2079,10 @@ static int l2cap_chan_le_send(struct bt_l2cap_le_chan *ch,
 			buf == seg ? "orig" : "seg");
 
 		if (seg == buf) {
-			/* move `seg` to `buf` */
+			/* move `buf` back to caller */
 		} else {
 			net_buf_unref(seg);
 		}
-
-		if (err == -ENOBUFS) {
-			/* Restore state since segment could not be sent */
-			net_buf_simple_restore(&buf->b, &state);
-			err =  -EAGAIN;
-		}
-
-		/* move `buf` back to caller */
 
 		return err;
 	}
@@ -2049,7 +2115,10 @@ static int l2cap_chan_le_send_sdu(struct bt_l2cap_le_chan *ch,
 	rem_len = buf->len;
 
 	while (sent != rem_len) {
-		ret = l2cap_chan_le_send(ch, buf, 0);
+		/* `buf` is moved only when it's full consumed.
+		 * (ie. sent == rem_len)
+		 */
+		ret = l2cap_chan_le_send_seg(ch, buf);
 		if (ret < 0) {
 			LOG_DBG("failed to send buf (ch %p cid 0x%04x sent %d)",
 				ch, ch->tx.cid, sent);
@@ -3127,6 +3196,11 @@ int bt_l2cap_chan_send(struct bt_l2cap_chan *chan, struct net_buf *buf)
 	}
 
 	LOG_DBG("chan %p buf %p len %zu", chan, buf, buf->len);
+
+	if (buf->ref != 1) {
+		LOG_DBG("Expecting 1 ref, got %d", buf->ref);
+		return -EINVAL;
+	}
 
 	if (!chan->conn || chan->conn->state != BT_CONN_CONNECTED) {
 		return -ENOTCONN;

--- a/subsys/bluetooth/host/l2cap_internal.h
+++ b/subsys/bluetooth/host/l2cap_internal.h
@@ -214,14 +214,8 @@ struct net_buf *bt_l2cap_create_pdu_timeout(struct net_buf_pool *pool,
  *
  * Buffer ownership is transferred to stack in case of success.
  */
-int bt_l2cap_send_cb(struct bt_conn *conn, uint16_t cid, struct net_buf *buf,
-		     bt_conn_tx_cb_t cb, void *user_data);
-
-static inline int bt_l2cap_send(struct bt_conn *conn, uint16_t cid,
-				struct net_buf *buf)
-{
-	return bt_l2cap_send_cb(conn, cid, buf, NULL, NULL);
-}
+int bt_l2cap_send_pdu(struct bt_l2cap_le_chan *le_chan, struct net_buf *pdu,
+		      bt_conn_tx_cb_t cb, void *user_data);
 
 /* Receive a new L2CAP PDU from a connection */
 void bt_l2cap_recv(struct bt_conn *conn, struct net_buf *buf, bool complete);
@@ -254,4 +248,6 @@ void bt_l2cap_register_ecred_cb(const struct bt_l2cap_ecred_cb *cb);
 struct bt_l2cap_server *bt_l2cap_server_lookup_psm(uint16_t psm);
 
 /* Pull data from the L2CAP layer */
-struct net_buf *l2cap_data_pull(struct bt_conn *conn, size_t amount);
+struct net_buf *l2cap_data_pull(struct bt_conn *conn,
+				size_t amount,
+				size_t *length);

--- a/subsys/bluetooth/host/l2cap_internal.h
+++ b/subsys/bluetooth/host/l2cap_internal.h
@@ -252,3 +252,6 @@ void bt_l2cap_register_ecred_cb(const struct bt_l2cap_ecred_cb *cb);
 
 /* Returns a server if it exists for given psm. */
 struct bt_l2cap_server *bt_l2cap_server_lookup_psm(uint16_t psm);
+
+/* Pull data from the L2CAP layer */
+struct net_buf *l2cap_data_pull(struct bt_conn *conn, size_t amount);

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -1750,7 +1750,9 @@ static void smp_timeout(struct k_work *work)
 static void smp_send(struct bt_smp *smp, struct net_buf *buf,
 		     bt_conn_tx_cb_t cb, void *user_data)
 {
-	int err = bt_l2cap_send_cb(smp->chan.chan.conn, BT_L2CAP_CID_SMP, buf, cb, NULL);
+	__ASSERT_NO_MSG(user_data == NULL);
+
+	int err = bt_l2cap_send_pdu(&smp->chan, buf, cb, NULL);
 
 	if (err) {
 		if (err == -ENOBUFS) {
@@ -1805,7 +1807,7 @@ static int smp_error(struct bt_smp *smp, uint8_t reason)
 	rsp->reason = reason;
 
 	/* SMP timer is not restarted for PairingFailed so don't use smp_send */
-	if (bt_l2cap_send(smp->chan.chan.conn, BT_L2CAP_CID_SMP, buf)) {
+	if (bt_l2cap_send_pdu(&smp->chan, buf, NULL, NULL)) {
 		net_buf_unref(buf);
 	}
 
@@ -2824,7 +2826,7 @@ static int smp_send_security_req(struct bt_conn *conn)
 	req->auth_req = get_auth(smp, BT_SMP_AUTH_DEFAULT);
 
 	/* SMP timer is not restarted for SecRequest so don't use smp_send */
-	err = bt_l2cap_send(conn, BT_L2CAP_CID_SMP, req_buf);
+	err = bt_l2cap_send_pdu(&smp->chan, req_buf, NULL, NULL);
 	if (err) {
 		net_buf_unref(req_buf);
 		return err;

--- a/subsys/bluetooth/host/smp_null.c
+++ b/subsys/bluetooth/host/smp_null.c
@@ -41,7 +41,7 @@ int bt_smp_sign(struct bt_conn *conn, struct net_buf *buf)
 
 static int bt_smp_recv(struct bt_l2cap_chan *chan, struct net_buf *req_buf)
 {
-	struct bt_conn *conn = chan->conn;
+	struct bt_l2cap_le_chan *le_chan = BT_L2CAP_LE_CHAN(chan);
 	struct bt_smp_pairing_fail *rsp;
 	struct bt_smp_hdr *hdr;
 	struct net_buf *buf;
@@ -63,7 +63,7 @@ static int bt_smp_recv(struct bt_l2cap_chan *chan, struct net_buf *req_buf)
 	rsp = net_buf_add(buf, sizeof(*rsp));
 	rsp->reason = BT_SMP_ERR_PAIRING_NOTSUPP;
 
-	if (bt_l2cap_send(conn, BT_L2CAP_CID_SMP, buf)) {
+	if (bt_l2cap_send_pdu(le_chan, buf, NULL, NULL)) {
 		net_buf_unref(buf);
 	}
 

--- a/tests/bsim/bluetooth/host/att/sequential/dut/src/main.c
+++ b/tests/bsim/bluetooth/host/att/sequential/dut/src/main.c
@@ -32,8 +32,8 @@ static atomic_t nwrites;
 static atomic_t indications;
 static atomic_t notifications;
 
-/* Defined in hci_core.c */
-extern k_tid_t bt_testing_tx_tid_get(void);
+/* Defined in conn.c */
+extern void bt_conn_suspend_tx(bool suspend);
 
 static struct bt_conn *dconn;
 
@@ -159,7 +159,7 @@ static ssize_t written_to(struct bt_conn *conn,
 	if (atomic_get(&nwrites) == 0) {
 		/* Suspend on the first write, which is an ATT Request */
 		LOG_INF("suspending HCI TX thread");
-		k_thread_suspend(bt_testing_tx_tid_get());
+		bt_conn_suspend_tx(true);
 	}
 
 	atomic_inc(&nwrites);
@@ -311,7 +311,7 @@ void test_procedure_0(void)
 	WAIT_FOR_VAL(nwrites, 3);
 
 	/* Send RSP to LL */
-	k_thread_resume(bt_testing_tx_tid_get());
+	bt_conn_suspend_tx(false);
 
 	PASS("DUT done\n");
 }

--- a/tests/bsim/bluetooth/host/l2cap/stress/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/stress/src/main.c
@@ -20,17 +20,9 @@ CREATE_FLAG(flag_l2cap_connected);
 #define L2CAP_CHANS     NUM_PERIPHERALS
 #define SDU_NUM         20
 #define SDU_LEN         3000
-#define NUM_SEGMENTS    100
 #define RESCHEDULE_DELAY K_MSEC(100)
 
 static void sdu_destroy(struct net_buf *buf)
-{
-	LOG_DBG("%p", buf);
-
-	net_buf_destroy(buf);
-}
-
-static void segment_destroy(struct net_buf *buf)
 {
 	LOG_DBG("%p", buf);
 
@@ -49,11 +41,6 @@ NET_BUF_POOL_DEFINE(sdu_tx_pool,
 		    CONFIG_BT_MAX_CONN, BT_L2CAP_SDU_BUF_SIZE(SDU_LEN),
 		    CONFIG_BT_CONN_TX_USER_DATA_SIZE, sdu_destroy);
 
-NET_BUF_POOL_DEFINE(segment_pool,
-		    /* MTU + 4 l2cap hdr + 4 ACL hdr */
-		    NUM_SEGMENTS, BT_L2CAP_BUF_SIZE(CONFIG_BT_L2CAP_TX_MTU),
-		    CONFIG_BT_CONN_TX_USER_DATA_SIZE, segment_destroy);
-
 /* Only one SDU per link will be received at a time */
 NET_BUF_POOL_DEFINE(sdu_rx_pool,
 		    CONFIG_BT_MAX_CONN, BT_L2CAP_SDU_BUF_SIZE(SDU_LEN),
@@ -62,7 +49,6 @@ NET_BUF_POOL_DEFINE(sdu_rx_pool,
 static uint8_t tx_data[SDU_LEN];
 static uint16_t rx_cnt;
 static uint8_t disconnect_counter;
-static uint32_t max_seg_allocated;
 
 struct test_ctx {
 	struct k_work_delayable work_item;
@@ -113,19 +99,6 @@ int l2cap_chan_send(struct bt_l2cap_chan *chan, uint8_t *data, size_t len)
 	return ret;
 }
 
-struct net_buf *alloc_seg_cb(struct bt_l2cap_chan *chan)
-{
-	struct net_buf *buf = net_buf_alloc(&segment_pool, K_NO_WAIT);
-
-	if ((NUM_SEGMENTS - segment_pool.avail_count) > max_seg_allocated) {
-		max_seg_allocated++;
-	}
-
-	ASSERT(buf, "Ran out of segment buffers");
-
-	return buf;
-}
-
 struct net_buf *alloc_buf_cb(struct bt_l2cap_chan *chan)
 {
 	return net_buf_alloc(&sdu_rx_pool, K_NO_WAIT);
@@ -163,7 +136,19 @@ int recv_cb(struct bt_l2cap_chan *chan, struct net_buf *buf)
 	rx_cnt++;
 
 	/* Verify SDU data matches TX'd data. */
-	ASSERT(memcmp(buf->data, tx_data, buf->len) == 0, "RX data doesn't match TX");
+	int pos = memcmp(buf->data, tx_data, buf->len);
+
+	if (pos != 0) {
+		LOG_ERR("RX data doesn't match TX: pos %d", pos);
+		LOG_HEXDUMP_ERR(buf->data, buf->len, "RX data");
+		LOG_HEXDUMP_INF(tx_data, buf->len, "TX data");
+
+		for (uint16_t p = 0; p < buf->len; p++) {
+			__ASSERT(buf->data[p] == tx_data[p],
+				 "Failed rx[%d]=%x != expect[%d]=%x",
+				 p, buf->data[p], p, tx_data[p]);
+		}
+	}
 
 	return 0;
 }
@@ -192,7 +177,6 @@ static struct bt_l2cap_chan_ops ops = {
 	.connected = l2cap_chan_connected_cb,
 	.disconnected = l2cap_chan_disconnected_cb,
 	.alloc_buf = alloc_buf_cb,
-	.alloc_seg = alloc_seg_cb,
 	.recv = recv_cb,
 	.sent = sent_cb,
 };
@@ -473,8 +457,6 @@ static void test_central_main(void)
 		k_msleep(100);
 	}
 	LOG_DBG("All peripherals disconnected.");
-
-	LOG_INF("Max segment pool usage: %u bufs", max_seg_allocated);
 
 	PASS("L2CAP STRESS Central passed\n");
 }

--- a/tests/bsim/bluetooth/ll/bis/src/main.c
+++ b/tests/bsim/bluetooth/ll/bis/src/main.c
@@ -153,7 +153,8 @@ bool ll_data_path_sink_create(uint16_t handle, struct ll_iso_datapath *datapath,
 
 #define BUF_ALLOC_TIMEOUT_MS (30) /* milliseconds */
 NET_BUF_POOL_FIXED_DEFINE(tx_pool, CONFIG_BT_ISO_TX_BUF_COUNT,
-			  BT_ISO_SDU_BUF_SIZE(CONFIG_BT_ISO_TX_MTU), 8, NULL);
+			  BT_ISO_SDU_BUF_SIZE(CONFIG_BT_ISO_TX_MTU),
+			  CONFIG_BT_CONN_TX_USER_DATA_SIZE, NULL);
 
 static struct k_work_delayable iso_send_work;
 


### PR DESCRIPTION
This patch series attempts to simplify the data path from the host to the controller.
See individual commit messages for in-depth explanations.

The executive summary is: 
- we get rid of the TX thread
- we get rid of the fragment and segment buffer pools (l2cap + conn)
- buffers are zero-copy throughout the host: no more allocating and memcpy-ing to temporary frag/seg bufs

At the expense of:
- increased user-data requirements in TX'd buffers
- potentially more context-switches (not measured though)
- undoing `pending_no_cb`, which means a `struct bt_conn_tx` per-buffer, even if they have no callbacks

The primary motivation for this change is to aid readability and debugging. Figuring out what state a buggy system is in from the logs is currently harder than it has to be, this patch aims to change that.
If this change also helps with throughput, all the better. But it is not the goal for now.

-------
Documents:

[sequence diagram](https://sequencediagram.org/index.html?presentationMode=readOnly#initialData=C4S2BsFMAIBUA1oBMCGwXQA5oBYCg8BBWWaAWgD5oAZAJgGFCAFALmgCNgB9cWgYxSYuAZ0gA7JF0xIArgAo+OFGOgBGADQcZAMwCUBdgHsAHtABOIAOY5g0Q9poNmLYcENmYAAz7tP0AGTQnjKiZqjofoYqnuw6fiGQYWgoBibmVjZ2DnSMrJgytjFxdio5zNBMACIAqnCIAI4ykE0EZUzkVG1sZiggolzhKFweKEgAngpKKqr6eEamFta29o65bAByhsBeispqfijC5pCjY9Bu0KISrU7tlND0APLr62ycXHxRYgPJwyfjCi+0AADLN5ukllkHs9XtBNtsgp8xCpgQcjiNxudDJdxEgCE8Xh1oAAJegASTITwASgBRN7cYDGLggMz1Ya9URyMFpRaZFakinUunQADWXAA7u4xR5hIpILIoHJGRKpbMBZTHrTKMRYN1IMAZGYUQQALwmjDaSDi6AAW0MNvEwCO4DQiTNBDEWxghgAbokSeSNbS2MrJWYRXh1ULKATYe8kd9lZgzIY+JBhMJ3Fz8TCYzC2JZ9R8vn9Ttm8Cg+KAfa7oS9UgsMssHLG2N4gajoH1jqcsTjrnhY2RjK3oEo-dAkcAU+AoGYtNpLWYAPw5l7D0fjmAISdRbbGYDL6AKdjQADU0BkSFmQ5H+bHh0RHYO4AxZyutnEhhk1iPkEsAB00AAIqGAAymu6wADxkBqLx6gaRpPsiIKeAQSAnFWIA1gisaQZQXTQLwAhCIMUgyLOgIocCmgoHaMhiMAJoCguS6XCAABekCzJW1a1m0DYQny2S3Cw3hTPsXbov8ZwXFceIVuAth0d+jHQFBC6UFAYiCbyzarM4WCQJAIpdox2JtBUNR1NAjTNDAFyFrYHgOBcRTaGheC4gQKBKdAKkMbYVCxNoWniLpTZQoR+SzkEIV+NoKY2gZ7RVLUO52S0bQEaJRGGOKiQ-OgpYArs0z6N5eAYbx2H8bceDZRQo4eIh0TxfhTX3vJXAhXIIU8VhOEwHhcw8pFKyjjaKAijAPogFaJRxcU9yeHNC2oh1o7dZW4ByKt83WqisyDrmFDqpUVJkgAajSVL0iIuJ7Wth2ePo1WDbWI01UNAYUhd123SdLwwWQ52XTdd3IOm06GBM+3ra9VWYXxCJgwDVIdVGmrCu8yosmyPR9JA5ZmhaC12g6jHOq6ZjupGgb-RDlBY8GcIyMl9D2pgUAIkwlYzU6BAszSzOBkK9146y7JE9mQA) of the data flow. Not everything is on it, but the general idea is, and it mentions real function names to follow along in the code. 

[viewmachine.pdf](https://github.com/zephyrproject-rtos/zephyr/files/15274630/viewmachine.pdf): description of the "view" mechanism that allows re-using the original buffer for L2CAP segments and HCI fragments.

-------
TODO

- [x] Release notes: https://github.com/zephyrproject-rtos/zephyr/pull/74567
- [x] Gather ROM/RAM comparisons for a few samples
- [x] Run throughput test: on target and on bsim
- [x] Gather CPU usage / context switches
- [x] #73401
- [x] https://github.com/zephyrproject-rtos/zephyr/pull/73406
- [x] Wait for @larsgk and @jhedberg to test on HW
- [x] Wait for @lylezhu2012 to test Bluetooth classic

-------
Benchmarks / profiling / memory impact

<details>
  <summary>Throughput tests</summary>
  
`tests/bsim/bluetooth/ll/throughput` reports the same throughput before and after the patch: `780800 bps`.
The same code running on a `nrf52840dk/nrf52840` has the same conclusion, a similar throughput at around `312300 bps`. Following are the logs and git revs used for testing.

```
samples/bluetooth/central_gatt_write + samples/bluetooth/peripheral_gatt_write
b3f7eeeebb9689198e615cf319899ddf8fc596ef vs 6a070ee165fe39b2fcbfd365102165ab362dce2f



AFTER REWRITE PATCH
b3f7eeeebb9689198e615cf319899ddf8fc596ef
----------------------------------------

CENTRAL



*** Booting Zephyr OS build v3.6.0-4677-gb3f7eeeebb96 ***
[00:00:00.251,770] <inf> bt_hci_core: HW Platform: Nordic Semiconductor (0x0002)
[00:00:00.251,800] <inf> bt_hci_core: HW Variant: nRF52x (0x0002)
[00:00:00.251,831] <inf> bt_hci_core: Firmware: Standard Bluetooth controller (0x00) Version 3.6 Build 99
[00:00:00.252,441] <wrn> bt_id: No static addresses stored in controller
[00:00:00.252,929] <inf> bt_hci_core: Identity: FC:40:5C:E5:D1:64 (random)
[00:00:00.252,960] <inf> bt_hci_core: HCI: version 5.4 (0x0d) revision 0x0000, manufacturer 0x05f1
[00:00:00.252,990] <inf> bt_hci_core: LMP: version 5.4 (0x0d) subver 0xffff
Bluetooth initialized
start_scan: Scanning successfully started
[DEVICE]: FC:B8:81:04:12:1E (random), AD evt type 0, AD data len 3, RSSI -17
Updated MTU: TX: 23 RX: 23 bytes
connected: FC:B8:81:04:12:1E (random) role 0
mtu_exchange: Current MTU = 23
mtu_exchange: Exchange MTU...
Updated MTU: TX: 247 RX: 247 bytes
Updated MTU: TX: 247 RX: 247 bytes
mtu_exchange_cb: MTU exchange successful (247)
write_cmd_cb: count= 0, len= 0, rate= 0 bps.
security_changed: to level 1 (err 9)
write_cmd_cb: count= 2, len= 488, rate= 9137592 bps.
disconnected: FC:B8:81:04:12:1E (random) role 0 (reason 8)
start_scan: Scanning successfully started
[00:00:04.489,196] <err> bt_conn: conn 0x20000cb8: not connected
[00:00:04.489,288] <wrn> bt_att: Not connected
write_cmd: Write cmd failed (-128).
[DEVICE]: 5C:4A:99:4C:21:AE (random), AD evt type 0, AD data len 19, RSSI -79
[DEVICE]: 5C:4A:99:4C:21:AE (random), AD evt type 4, AD data len 0, RSSI -79
[DEVICE]: D2:86:35:29:2D:89 (random), AD evt type 0, AD data len 3, RSSI -17
Updated MTU: TX: 23 RX: 23 bytes
connected: D2:86:35:29:2D:89 (random) role 0
mtu_exchange: Current MTU = 23
mtu_exchange: Exchange MTU...
Updated MTU: TX: 247 RX: 247 bytes
Updated MTU: TX: 247 RX: 247 bytes
mtu_exchange_cb: MTU exchange successful (247)
write_cmd_cb: count= 2, len= 488, rate= 127928695 bps.
security_changed: to level 2 (err 0)
write_cmd_cb: count= 140, len= 34160, rate= 273973 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312339 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312339 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312329 bps.
le_param_req: int (0x0018, 0x0028) lat 0 to 42
le_param_updated: int 0x0028 lat 0 to 42
write_cmd_cb: count= 160, len= 39040, rate= 312329 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312329 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312329 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312339 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312339 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312320 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312339 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312348 bps.
write_cmd_cb: count= 159, len= 38796, rate= 312302 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312339 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312358 bps.
write_cmd_cb: count= 159, len= 38796, rate= 312302 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312348 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312339 bps.



PERIPHERAL


*** Booting Zephyr OS build v3.6.0-4677-gb3f7eeeebb96 ***
[00:00:00.247,894] <inf> bt_hci_core: HW Platform: Nordic Semiconductor (0x0002)
[00:00:00.247,924] <inf> bt_hci_core: HW Variant: nRF52x (0x0002)
[00:00:00.247,955] <inf> bt_hci_core: Firmware: Standard Bluetooth controller (0x00) Version 3.6 Build 99
[00:00:00.248,535] <wrn> bt_id: No static addresses stored in controller
[00:00:00.248,992] <inf> bt_hci_core: Identity: D2:86:35:29:2D:89 (random)
[00:00:00.249,023] <inf> bt_hci_core: HCI: version 5.4 (0x0d) revision 0x0000, manufacturer 0x05f1
[00:00:00.249,053] <inf> bt_hci_core: LMP: version 5.4 (0x0d) subver 0xffff
Bluetooth initialized
Advertising successfully started
Updated MTU: TX: 23 RX: 23 bytes
connected: FC:40:5C:E5:D1:64 (random) role 1
mtu_exchange: Current MTU = 23
mtu_exchange: Exchange MTU...
Updated MTU: TX: 247 RX: 247 bytes
Updated MTU: TX: 247 RX: 247 bytes
mtu_exchange_cb: MTU exchange successful (247)
write_cmd_cb: count= 0, len= 0, rate= 0 bps.
security_changed: to level 2 (err 0)
write_cmd_cb: count= 115, len= 28060, rate= 224871 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312339 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312339 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312339 bps.
write_cmd_cb: count= 159, len= 38796, rate= 312111 bps.
le_param_updated: int 0x0028 lat 0 to 42
write_cmd_cb: count= 160, len= 39040, rate= 312529 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312329 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312348 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312320 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312339 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312339 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312339 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312329 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312339 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312348 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312320 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312329 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312348 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312339 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312339 bps.






BEFORE REWRITE PATCH
6a070ee165fe39b2fcbfd365102165ab362dce2f
----------------------------------------


CENTRAL


*** Booting Zephyr OS build v3.6.0-4669-g6a070ee165fe ***
[00:00:00.251,342] <inf> bt_hci_core: HW Platform: Nordic Semiconductor (0x0002)
[00:00:00.251,373] <inf> bt_hci_core: HW Variant: nRF52x (0x0002)
[00:00:00.251,403] <inf> bt_hci_core: Firmware: Standard Bluetooth controller (0x00) Version 3.6 Build 99
[00:00:00.251,861] <wrn> bt_id: No static addresses stored in controller
[00:00:00.252,288] <inf> bt_hci_core: Identity: D6:32:DB:97:4F:A1 (random)
[00:00:00.252,319] <inf> bt_hci_core: HCI: version 5.4 (0x0d) revision 0x0000, manufacturer 0x05f1
[00:00:00.252,349] <inf> bt_hci_core: LMP: version 5.4 (0x0d) subver 0xffff
Bluetooth initialized
start_scan: Scanning successfully started
[DEVICE]: DA:D3:69:84:7B:CB (random), AD evt type 0, AD data len 3, RSSI -17
Updated MTU: TX: 23 RX: 23 bytes
connected: DA:D3:69:84:7B:CB (random) role 0
mtu_exchange: Current MTU = 23
mtu_exchange: Exchange MTU...
Updated MTU: TX: 247 RX: 247 bytes
Updated MTU: TX: 247 RX: 247 bytes
mtu_exchange_cb: MTU exchange successful (247)
write_cmd_cb: count= 0, len= 0, rate= 0 bps.
write_cmd_cb: count= 2, len= 488, rate= 11629673 bps.
security_changed: to level 1 (err 9)
disconnected: DA:D3:69:84:7B:CB (random) role 0 (reason 8)
start_scan: Scanning successfully started
[00:00:04.481,170] <wrn> bt_att: Not connected
write_cmd: Write cmd failed (-128).
[DEVICE]: C5:72:57:4B:36:98 (random), AD evt type 0, AD data len 3, RSSI -17
Updated MTU: TX: 23 RX: 23 bytes
connected: C5:72:57:4B:36:98 (random) role 0
mtu_exchange: Current MTU = 23
mtu_exchange: Exchange MTU...
Updated MTU: TX: 247 RX: 247 bytes
Updated MTU: TX: 247 RX: 247 bytes
mtu_exchange_cb: MTU exchange successful (247)
write_cmd_cb: count= 1, len= 244, rate= 63964347 bps.
security_changed: to level 2 (err 0)
write_cmd_cb: count= 133, len= 32452, rate= 260602 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312320 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312339 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312329 bps.
le_param_req: int (0x0018, 0x0028) lat 0 to 42
le_param_updated: int 0x0028 lat 0 to 42
write_cmd_cb: count= 159, len= 38796, rate= 312302 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312358 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312339 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312320 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312339 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312339 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312320 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312339 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312348 bps.
write_cmd_cb: count= 159, len= 38796, rate= 312302 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312358 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312348 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312339 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312339 bps.




PERIPHERAL



*** Booting Zephyr OS build v3.6.0-4669-g6a070ee165fe ***
[00:00:00.247,375] <inf> bt_hci_core: HW Platform: Nordic Semiconductor (0x0002)
[00:00:00.247,436] <inf> bt_hci_core: HW Variant: nRF52x (0x0002)
[00:00:00.247,436] <inf> bt_hci_core: Firmware: Standard Bluetooth controller (0x00) Version 3.6 Build 99
[00:00:00.247,924] <wrn> bt_id: No static addresses stored in controller
[00:00:00.248,352] <inf> bt_hci_core: Identity: C5:72:57:4B:36:98 (random)
[00:00:00.248,382] <inf> bt_hci_core: HCI: version 5.4 (0x0d) revision 0x0000, manufacturer 0x05f1
[00:00:00.248,413] <inf> bt_hci_core: LMP: version 5.4 (0x0d) subver 0xffff
Bluetooth initialized
Advertising successfully started
Updated MTU: TX: 23 RX: 23 bytes
connected: D6:32:DB:97:4F:A1 (random) role 1
mtu_exchange: Current MTU = 23
mtu_exchange: Exchange MTU...
Updated MTU: TX: 247 RX: 247 bytes
Updated MTU: TX: 247 RX: 247 bytes
mtu_exchange_cb: MTU exchange successful (247)
write_cmd_cb: count= 0, len= 0, rate= 0 bps.
security_changed: to level 2 (err 0)
write_cmd_cb: count= 116, len= 28304, rate= 226681 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312339 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312329 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312339 bps.
write_cmd_cb: count= 159, len= 38796, rate= 312111 bps.
le_param_updated: int 0x0028 lat 0 to 42
write_cmd_cb: count= 160, len= 39040, rate= 312539 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312320 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312339 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312348 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312329 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312339 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312339 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312329 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312329 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312339 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312348 bps.
write_cmd_cb: count= 159, len= 38796, rate= 312302 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312358 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312348 bps.
write_cmd_cb: count= 159, len= 38796, rate= 312302 bps.

```
  
</details>

<details>
  <summary>ROM/RAM footprint delta after applying the patch</summary>
  
```
[samples/bluetooth/peripheral_hr/sample.bluetooth.peripheral_hr]
ram delta: -892 bytes / -3.34 %
rom delta: -408 bytes / -0.25 %

[samples/bluetooth/central_hr/sample.bluetooth.central_hr]
ram delta: -1156 bytes / -4.38 %
rom delta: -400 bytes / -0.24 %

[tests/bluetooth/shell/bluetooth.shell.main]
ram delta: -2264 bytes / -3.73 %
rom delta: 392 bytes / 0.08 %
```

</details>

<details>
  <summary>CPU usage</summary>

Results of enabling the Thread Analyzer on the central/peripheral gatt_write samples.

  
```
samples/bluetooth/central_gatt_write + samples/bluetooth/peripheral_gatt_write
b3f7eeeebb9689198e615cf319899ddf8fc596ef vs 6a070ee165fe39b2fcbfd365102165ab362dce2f



AFTER REWRITE PATCH
b3f7eeeebb9689198e615cf319899ddf8fc596ef
----------------------------------------

CENTRAL


 BT *** Booting Zephyr OS build v3.6.0-4677-gb3f7eeeebb96 ***
[00:00:00.253,295] <inf> bt_hci_core: HW Platform: Nordic Semiconductor (0x0002)
[00:00:00.253,326] <inf> bt_hci_core: HW Variant: nRF52x (0x0002)
[00:00:00.253,356] <inf> bt_hci_core: Firmware: Standard Bluetooth controller (0x00) Version 3.6 Build 99
[00:00:00.254,028] <wrn> bt_id: No static addresses stored in controller
[00:00:00.254,547] <inf> bt_hci_core: Identity: CF:C6:A0:D0:55:9F (random)
[00:00:00.254,577] <inf> bt_hci_core: HCI: version 5.4 (0x0d) revision 0x0000, manufacturer 0x05f1
[00:00:00.254,608] <inf> bt_hci_core: LMP: version 5.4 (0x0d) subver 0xffff
Bluetooth initialized
start_scan: Scanning successfully started
[DEVICE]: 44:73:D6:42:3B:05 (public), AD evt type 0, AD data len 15, RSSI -57
[DEVICE]: 44:73:D6:42:3B:05 (public), AD evt type 4, AD data len 20, RSSI -57
Thread analyze:
 BT RX               : STACK: unused 608 usage 160 / 768 (20 %); CPU: 0 %
      : Total CPU cycles used: 5
 BT RX pri           : STACK: unused 296 usage 152 / 448 (33 %); CPU: 0 %
      : Total CPU cycles used: 1
 BT RX WQ            : STACK: unused 592 usage 624 / 1216 (51 %); CPU: 0 %
      : Total CPU cycles used: 15
 thread_analyzer     : STACK: unused 576 usage 448 / 1024 (43 %); CPU: 0 %
      : Total CPU cycles used: 21
 BT LW WQ            : STACK: unused 408 usage 936 / 1344 (69 %); CPU: 75 %
      : Total CPU cycles used: 8767
 sysworkq            : STACK: unused 544 usage 480 / 1024 (46 %); CPU: 0 %
      : Total CPU cycles used: 59
 logging             : STACK: unused 240 usage 528 / 768 (68 %); CPU: 22 %
      : Total CPU cycles used: 2674
 idle                : STACK: unused 272 usage 48 / 320 (15 %); CPU: 0 %
      : Total CPU cycles used: 0
 main                : STACK: unused 544 usage 480 / 1024 (46 %); CPU: 0 %
      : Total CPU cycles used: 96
 ISR0                : STACK: unused 1472 usage 576 / 2048 (28 %)
[DEVICE]: 67:D6:7F:E0:35:1A (random), AD evt type 0, AD data len 19, RSSI -83
[DEVICE]: E0:88:62:3C:5A:84 (random), AD evt type 0, AD data len 3, RSSI -17
Updated MTU: TX: 23 RX: 23 bytes
connected: E0:88:62:3C:5A:84 (random) role 0
mtu_exchange: Current MTU = 23
mtu_exchange: Exchange MTU...
Updated MTU: TX: 247 RX: 247 bytes
Updated MTU: TX: 247 RX: 247 bytes
mtu_exchange_cb: MTU exchange successful (247)
write_cmd_cb: count= 0, len= 0, rate= 0 bps.
security_changed: to level 2 (err 0)
write_cmd_cb: count= 92, len= 22448, rate= 180349 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312320 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312329 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312348 bps.
Thread analyze:
 BT RX               : STACK: unused 600 usage 168 / 768 (21 %); CPU: 5 %
      : Total CPU cycles used: 8478
 BT RX pri           : STACK: unused 184 usage 264 / 448 (58 %); CPU: 3 %
      : Total CPU cycles used: 5432
 BT RX WQ            : STACK: unused 408 usage 808 / 1216 (66 %); CPU: 7 %
      : Total CPU cycles used: 11604
 thread_analyzer     : STACK: unused 552 usage 472 / 1024 (46 %); CPU: 0 %
      : Total CPU cycles used: 86
 BT LW WQ            : STACK: unused 408 usage 936 / 1344 (69 %); CPU: 11 %
      : Total CPU cycles used: 17949
 sysworkq            : STACK: unused 504 usage 520 / 1024 (50 %); CPU: 5 %
      : Total CPU cycles used: 9109
 logging             : STACK: unused 136 usage 632 / 768 (82 %); CPU: 4 %
      : Total CPU cycles used: 7853
 idle                : STACK: unused 256 usage 64 / 320 (20 %); CPU: 60 %
      : Total CPU cycles used: 95088
 main                : STACK: unused 544 usage 480 / 1024 (46 %); CPU: 1 %
      : Total CPU cycles used: 1822
 ISR0                : STACK: unused 1456 usage 592 / 2048 (28 %)
le_param_req: int (0x0018, 0x0028) lat 0 to 42
write_cmd_cb: count= 159, len= 38796, rate= 312101 bps.
le_param_updated: int 0x0028 lat 0 to 42
write_cmd_cb: count= 160, len= 39040, rate= 312520 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312348 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312339 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312329 bps.
Thread analyze:
 BT RX               : STACK: unused 600 usage 168 / 768 (21 %); CPU: 6 %
      : Total CPU cycles used: 20017
 BT RX pri           : STACK: unused 184 usage 264 / 448 (58 %); CPU: 4 %
      : Total CPU cycles used: 12741
 BT RX WQ            : STACK: unused 408 usage 808 / 1216 (66 %); CPU: 9 %
      : Total CPU cycles used: 27105
 thread_analyzer     : STACK: unused 552 usage 472 / 1024 (46 %); CPU: 0 %
      : Total CPU cycles used: 162
 BT LW WQ            : STACK: unused 408 usage 936 / 1344 (69 %); CPU: 6 %
      : Total CPU cycles used: 17949
 sysworkq            : STACK: unused 504 usage 520 / 1024 (50 %); CPU: 7 %
      : Total CPU cycles used: 21152
 logging             : STACK: unused 136 usage 632 / 768 (82 %); CPU: 4 %
      : Total CPU cycles used: 12654
 idle                : STACK: unused 256 usage 64 / 320 (20 %); CPU: 60 %
      : Total CPU cycles used: 180955
 main                : STACK: unused 544 usage 480 / 1024 (46 %); CPU: 1 %
      : Total CPU cycles used: 4013
 ISR0                : STACK: unused 1456 usage 592 / 2048 (28 %)
write_cmd_cb: count= 160, len= 39040, rate= 312329 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312339 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312329 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312329 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312339 bps.
Thread analyze:
 BT RX               : STACK: unused 600 usage 168 / 768 (21 %); CPU: 7 %
      : Total CPU cycles used: 31563
 BT RX pri           : STACK: unused 184 usage 264 / 448 (58 %); CPU: 4 %
      : Total CPU cycles used: 20075
 BT RX WQ            : STACK: unused 408 usage 808 / 1216 (66 %); CPU: 9 %
      : Total CPU cycles used: 42695
 thread_analyzer     : STACK: unused 552 usage 472 / 1024 (46 %); CPU: 0 %
      : Total CPU cycles used: 239
 BT LW WQ            : STACK: unused 408 usage 936 / 1344 (69 %); CPU: 4 %
      : Total CPU cycles used: 17949
 sysworkq            : STACK: unused 504 usage 520 / 1024 (50 %); CPU: 7 %
      : Total CPU cycles used: 33087
 logging             : STACK: unused 136 usage 632 / 768 (82 %); CPU: 3 %
      : Total CPU cycles used: 16897
 idle                : STACK: unused 256 usage 64 / 320 (20 %); CPU: 61 %
      : Total CPU cycles used: 267421
 main                : STACK: unused 544 usage 480 / 1024 (46 %); CPU: 1 %
      : Total CPU cycles used: 6217
 ISR0                : STACK: unused 1456 usage 592 / 2048 (28 %)

--- exit ---




PERIPHERAL



*** Booting Zephyr OS build v3.6.0-4677-gb3f7eeeebb96 ***
[00:00:00.249,114] <inf> bt_hci_core: HW Platform: Nordic Semiconductor (0x0002)
[00:00:00.249,145] <inf> bt_hci_core: HW Variant: nRF52x (0x0002)
[00:00:00.249,176] <inf> bt_hci_core: Firmware: Standard Bluetooth controller (0x00) Version 3.6 Build 99
[00:00:00.249,847] <wrn> bt_id: No static addresses stored in controller
[00:00:00.250,335] <inf> bt_hci_core: Identity: E0:88:62:3C:5A:84 (random)
[00:00:00.250,366] <inf> bt_hci_core: HCI: version 5.4 (0x0d) revision 0x0000, manufacturer 0x05f1
[00:00:00.250,396] <inf> bt_hci_core: LMP: version 5.4 (0x0d) subver 0xffff
Bluetooth initialized
Advertising successfully started
Updated MTU: TX: 23 RX: 23 bytes
connected: CF:C6:A0:D0:55:9F (random) role 1
mtu_exchange: Current MTU = 23
mtu_exchange: Exchange MTU...
Updated MTU: TX: 247 RX: 247 bytes
Updated MTU: TX: 247 RX: 247 bytes
mtu_exchange_cb: MTU exchange successful (247)
Thread analyze:
 BT RX               : STACK: unused 608 usage 160 / 768 (20 %); CPU: 0 %
      : Total CPU cycles used: 11
 BT RX pri           : STACK: unused 184 usage 264 / 448 (58 %); CPU: 0 %
      : Total CPU cycles used: 11
 BT RX WQ            : STACK: unused 560 usage 656 / 1216 (53 %); CPU: 0 %
      : Total CPU cycles used: 37
 thread_analyzer     : STACK: unused 576 usage 448 / 1024 (43 %); CPU: 0 %
      : Total CPU cycles used: 20
 BT LW WQ            : STACK: unused 408 usage 936 / 1344 (69 %); CPU: 72 %
      : Total CPU cycles used: 8643
 sysworkq            : STACK: unused 632 usage 392 / 1024 (38 %); CPU: 0 %
      : Total CPU cycles used: 86
 logging             : STACK: unused 240 usage 528 / 768 (68 %); CPU: 24 %
      : Total CPU cycles used: 2961
 idle                : STACK: unused 272 usage 48 / 320 (15 %); CPU: 0 %
      : Total CPU cycles used: 0
 main                : STACK: unused 512 usage 512 / 1024 (50 %); CPU: 0 %
      : Total CPU cycles used: 90
 ISR0                : STACK: unused 1480 usage 568 / 2048 (27 %)
write_cmd_cb: count= 0, len= 0, rate= 0 bps.
security_changed: to level 2 (err 0)
write_cmd_cb: count= 145, len= 35380, rate= 283316 bps.
write_cmd_cb: count= 159, len= 38796, rate= 312293 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312329 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312348 bps.
Thread analyze:
 BT RX               : STACK: unused 608 usage 160 / 768 (20 %); CPU: 6 %
      : Total CPU cycles used: 10737
 BT RX pri           : STACK: unused 184 usage 264 / 448 (58 %); CPU: 4 %
      : Total CPU cycles used: 6441
 BT RX WQ            : STACK: unused 432 usage 784 / 1216 (64 %); CPU: 9 %
      : Total CPU cycles used: 14531
 thread_analyzer     : STACK: unused 552 usage 472 / 1024 (46 %); CPU: 0 %
      : Total CPU cycles used: 82
 BT LW WQ            : STACK: unused 408 usage 936 / 1344 (69 %); CPU: 11 %
      : Total CPU cycles used: 17943
 sysworkq            : STACK: unused 504 usage 520 / 1024 (50 %); CPU: 6 %
      : Total CPU cycles used: 10685
 logging             : STACK: unused 136 usage 632 / 768 (82 %); CPU: 4 %
      : Total CPU cycles used: 6933
 idle                : STACK: unused 256 usage 64 / 320 (20 %); CPU: 54 %
      : Total CPU cycles used: 84388
 main                : STACK: unused 512 usage 512 / 1024 (50 %); CPU: 1 %
      : Total CPU cycles used: 2234
 ISR0                : STACK: unused 1344 usage 704 / 2048 (34 %)
le_param_updated: int 0x0028 lat 0 to 42
write_cmd_cb: count= 160, len= 39040, rate= 312329 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312329 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312339 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312339 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312339 bps.
Thread analyze:
 BT RX               : STACK: unused 608 usage 160 / 768 (20 %); CPU: 7 %
      : Total CPU cycles used: 22531
 BT RX pri           : STACK: unused 184 usage 264 / 448 (58 %); CPU: 4 %
      : Total CPU cycles used: 13658
 BT RX WQ            : STACK: unused 432 usage 784 / 1216 (64 %); CPU: 10 %
      : Total CPU cycles used: 30097
 thread_analyzer     : STACK: unused 552 usage 472 / 1024 (46 %); CPU: 0 %
      : Total CPU cycles used: 161
 BT LW WQ            : STACK: unused 408 usage 936 / 1344 (69 %); CPU: 6 %
      : Total CPU cycles used: 17943
 sysworkq            : STACK: unused 504 usage 520 / 1024 (50 %); CPU: 7 %
      : Total CPU cycles used: 22701
 logging             : STACK: unused 136 usage 632 / 768 (82 %); CPU: 3 %
      : Total CPU cycles used: 11631
 idle                : STACK: unused 256 usage 64 / 320 (20 %); CPU: 58 %
      : Total CPU cycles used: 170616
 main                : STACK: unused 512 usage 512 / 1024 (50 %); CPU: 1 %
      : Total CPU cycles used: 4720
 ISR0                : STACK: unused 1344 usage 704 / 2048 (34 %)
write_cmd_cb: count= 160, len= 39040, rate= 312329 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312329 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312348 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312339 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312339 bps.
Thread analyze:
 BT RX               : STACK: unused 608 usage 160 / 768 (20 %); CPU: 7 %
      : Total CPU cycles used: 34336
 BT RX pri           : STACK: unused 184 usage 264 / 448 (58 %); CPU: 4 %
      : Total CPU cycles used: 20809
 BT RX WQ            : STACK: unused 432 usage 784 / 1216 (64 %); CPU: 10 %
      : Total CPU cycles used: 45647
 thread_analyzer     : STACK: unused 552 usage 472 / 1024 (46 %); CPU: 0 %
      : Total CPU cycles used: 233
 BT LW WQ            : STACK: unused 408 usage 936 / 1344 (69 %); CPU: 4 %
      : Total CPU cycles used: 17943
 sysworkq            : STACK: unused 504 usage 520 / 1024 (50 %); CPU: 7 %
      : Total CPU cycles used: 34715
 logging             : STACK: unused 136 usage 632 / 768 (82 %); CPU: 3 %
      : Total CPU cycles used: 15839
 idle                : STACK: unused 256 usage 64 / 320 (20 %); CPU: 59 %
      : Total CPU cycles used: 257319
 main                : STACK: unused 512 usage 512 / 1024 (50 %); CPU: 1 %
      : Total CPU cycles used: 7185
 ISR0                : STACK: unused 1344 usage 704 / 2048 (34 %)
write_cmd_cb: count= 160, len= 39040, rate= 312339 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312339 bps.

--- exit ---





BEFORE REWRITE PATCH
6a070ee165fe39b2fcbfd365102165ab362dce2f
----------------------------------------


CENTRAL



write_cmd_cb: *** Booting Zephyr OS build v3.6.0-4669-g6a070ee165fe ***
[00:00:00.252,746] <inf> bt_hci_core: HW Platform: Nordic Semiconductor (0x0002)
[00:00:00.252,777] <inf> bt_hci_core: HW Variant: nRF52x (0x0002)
[00:00:00.252,807] <inf> bt_hci_core: Firmware: Standard Bluetooth controller (0x00) Version 3.6 Build 99
[00:00:00.253,326] <wrn> bt_id: No static addresses stored in controller
[00:00:00.253,753] <inf> bt_hci_core: Identity: C5:FC:03:22:CA:22 (random)
[00:00:00.253,784] <inf> bt_hci_core: HCI: version 5.4 (0x0d) revision 0x0000, manufacturer 0x05f1
[00:00:00.253,814] <inf> bt_hci_core: LMP: version 5.4 (0x0d) subver 0xffff
Bluetooth initialized
start_scan: Scanning successfully started
[DEVICE]: F8:7B:7B:8D:16:71 (random), AD evt type 0, AD data len 3, RSSI -17
Updated MTU: TX: 23 RX: 23 bytes
connected: F8:7B:7B:8D:16:71 (random) role 0
mtu_exchange: Current MTU = 23
mtu_exchange: Exchange MTU...
Updated MTU: TX: 247 RX: 247 bytes
--- 6 messages dropped ---
      : Total CPU cycles used: 8
 BT RX pri           : STACK: unused 208 usage 240 / 448 (53 %); CPU: 0 %
      : Total CPU cycles used: 12
 BT RX WQ            : STACK: unused 568 usage 648 / 1216 (53 %); CPU: 0 %
      : Total CPU cycles used: 48
 BT TX               : STACK: unused 552 usage 472 / 1024 (46 %); CPU: 0 %
      : Total CPU cycles used: 93
 thread_analyzer     : STACK: unused 576 usage 448 / 1024 (43 %); CPU: 0 %
      : Total CPU cycles used: 28
 BT LW WQ            : STACK: unused 408 usage 936 / 1344 (69 %); CPU: 73 %
      : Total CPU cycles used: 8811
 sysworkq            : STACK: unused 848 usage 176 / 1024 (17 %); CPU: 0 %
      : Total CPU cycles used: 2
 logging             : STACK: unused 224 usage 544 / 768 (70 %); CPU: 23 %
      : Total CPU cycles used: 2851
 idle                : STACK: unused 272 usage 48 / 320 (15 %); CPU: 0 %
      : Total CPU cycles used: 0
 main                : STACK: unused 544 usage 480 / 1024 (46 %); CPU: 0 %
      : Total CPU cycles used: 80
 ISR0                : STACK: unused 1464 usage 584 / 2048 (28 %)
write_cmd_cb: count= 0, len= 0, rate= 0 bps.
write_cmd_cb: count= 2, len= 488, rate= 9840495 bps.
disconnected: F8:7B:7B:8D:16:71 (random) role 0 (reason 8)
start_scan: Scanning successfully started
[00:00:04.496,795] <wrn> bt_att: Not connected
write_cmd: Write cmd failed (-128).
[DEVICE]: 44:73:D6:42:3B:05 (public), AD evt type 0, AD data len 15, RSSI -60
[DEVICE]: 44:73:D6:42:3B:05 (public), AD evt type 4, AD data len 20, RSSI -61
[DEVICE]: F4:BB:21:57:10:84 (random), AD evt type 0, AD data len 3, RSSI -17
Updated MTU: TX: 23 RX: 23 bytes
connected: F4:BB:21:57:10:84 (random) role 0
mtu_exchange: Current MTU = 23
mtu_exchange: Exchange MTU...
Updated MTU: TX: 247 RX: 247 bytes
Updated MTU: TX: 247 RX: 247 bytes
mtu_exchange_cb: MTU exchange successful (247)
 BT RX               : STACK: unused 512 usage 256 / 768 (33 %); CPU: 0 %
--- 2 messages dropped ---
      : Total CPU cycles used: 32
 BT RX pri           : STACK: unused 192 usage 256 / 448 (57 %); CPU: 0 %
      : Total CPU cycles used: 59
 BT RX WQ            : STACK: unused 408 usage 808 / 1216 (66 %); CPU: 0 %
      : Total CPU cycles used: 345
 BT TX               : STACK: unused 552 usage 472 / 1024 (46 %); CPU: 0 %
      : Total CPU cycles used: 218
 thread_analyzer     : STACK: unused 552 usage 472 / 1024 (46 %); CPU: 0 %
      : Total CPU cycles used: 96
 BT LW WQ            : STACK: unused 408 usage 936 / 1344 (69 %); CPU: 9 %
      : Total CPU cycles used: 17428
 sysworkq            : STACK: unused 520 usage 504 / 1024 (49 %); CPU: 0 %
      : Total CPU cycles used: 27
 logging             : STACK: unused 136 usage 632 / 768 (82 %); CPU: 4 %
      : Total CPU cycles used: 8583
 idle                : STACK: unused 256 usage 64 / 320 (20 %); CPU: 84 %
      : Total CPU cycles used: 148799
 main                : STACK: unused 544 usage 480 / 1024 (46 %); CPU: 0 %
      : Total CPU cycles used: 143
 ISR0                : STACK: unused 1432 usage 616 / 2048 (30 %)
security_changed: to level 2 (err 0)
write_cmd_cb: count= 132, len= 32208, rate= 258199 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312339 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312348 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312348 bps.
Thread analyze:
--- 3 messages dropped ---
 BT RX               : STACK: unused 512 usage 256 / 768 (33 %); CPU: 3 %
      : Total CPU cycles used: 10629
 BT RX pri           : STACK: unused 192 usage 256 / 448 (57 %); CPU: 2 %
      : Total CPU cycles used: 7069
 BT RX WQ            : STACK: unused 408 usage 808 / 1216 (66 %); CPU: 4 %
      : Total CPU cycles used: 14443
 BT TX               : STACK: unused 552 usage 472 / 1024 (46 %); CPU: 1 %
      : Total CPU cycles used: 3700
 thread_analyzer     : STACK: unused 552 usage 472 / 1024 (46 %); CPU: 0 %
      : Total CPU cycles used: 173
 BT LW WQ            : STACK: unused 408 usage 936 / 1344 (69 %); CPU: 5 %
      : Total CPU cycles used: 17428
 sysworkq            : STACK: unused 520 usage 504 / 1024 (49 %); CPU: 2 %
      : Total CPU cycles used: 7262
 logging             : STACK: unused 136 usage 632 / 768 (82 %); CPU: 4 %
      : Total CPU cycles used: 12974
 idle                : STACK: unused 256 usage 64 / 320 (20 %); CPU: 76 %
      : Total CPU cycles used: 240805
 main                : STACK: unused 544 usage 480 / 1024 (46 %); CPU: 0 %
      : Total CPU cycles used: 2026
 ISR0                : STACK: unused 1432 usage 616 / 2048 (30 %)
write_cmd_cb: count= 160, len= 39040, rate= 312339 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312348 bps.

--- exit ---




PERIPHERAL


[00:00:38.741,241] <wrn> bt_att*** Booting Zephyr OS build v3.6.0-4669-g6a070ee165fe ***
[00:00:00.248,565] <inf> bt_hci_core: HW Platform: Nordic Semiconductor (0x0002)
[00:00:00.248,596] <inf> bt_hci_core: HW Variant: nRF52x (0x0002)
[00:00:00.248,626] <inf> bt_hci_core: Firmware: Standard Bluetooth controller (0x00) Version 3.6 Build 99
[00:00:00.249,145] <wrn> bt_id: No static addresses stored in controller
[00:00:00.249,572] <inf> bt_hci_core: Identity: F4:BB:21:57:10:84 (random)
[00:00:00.249,603] <inf> bt_hci_core: HCI: version 5.4 (0x0d) revision 0x0000, manufacturer 0x05f1
[00:00:00.249,633] <inf> bt_hci_core: LMP: version 5.4 (0x0d) subver 0xffff
Bluetooth initialized
Advertising successfully started
Thread analyze:
 BT RX               : STACK: unused 608 usage 160 / 768 (20 %); CPU: 0 %
      : Total CPU cycles used: 2
 BT RX pri           : STACK: unused 296 usage 152 / 448 (33 %); CPU: 0 %
      : Total CPU cycles used: 1
 BT RX WQ            : STACK: unused 976 usage 240 / 1216 (19 %); CPU: 0 %
      : Total CPU cycles used: 0
 BT TX               : STACK: unused 408 usage 360 / 768 (46 %); CPU: 0 %
      : Total CPU cycles used: 57
 thread_analyzer     : STACK: unused 576 usage 448 / 1024 (43 %); CPU: 0 %
      : Total CPU cycles used: 29
 BT LW WQ            : STACK: unused 408 usage 936 / 1344 (69 %); CPU: 78 %
      : Total CPU cycles used: 8528
 sysworkq            : STACK: unused 848 usage 176 / 1024 (17 %); CPU: 0 %
      : Total CPU cycles used: 0
 logging             : STACK: unused 232 usage 536 / 768 (69 %); CPU: 20 %
      : Total CPU cycles used: 2199
 idle                : STACK: unused 272 usage 48 / 320 (15 %); CPU: 0 %
      : Total CPU cycles used: 0
 main                : STACK: unused 512 usage 512 / 1024 (50 %); CPU: 0 %
      : Total CPU cycles used: 74
 ISR0                : STACK: unused 1480 usage 568 / 2048 (27 %)
Updated MTU: TX: 23 RX: 23 bytes
connected: C5:FC:03:22:CA:22 (random) role 1
mtu_exchange: Current MTU = 23
mtu_exchange: Exchange MTU...
Updated MTU: TX: 247 RX: 247 bytes
Updated MTU: TX: 247 RX: 247 bytes
mtu_exchange_cb: MTU exchange successful (247)
security_changed: to level 2 (err 0)
write_cmd_cb: count= 0, len= 0, rate= 0 bps.
 BT RX               : STACK: unused 592 usage 176 / 768 (22 %); CPU: 0 %
--- 1 messages dropped ---
      : Total CPU cycles used: 1209
 BT RX pri           : STACK: unused 192 usage 256 / 448 (57 %); CPU: 0 %
      : Total CPU cycles used: 713
 BT RX WQ            : STACK: unused 432 usage 784 / 1216 (64 %); CPU: 1 %
      : Total CPU cycles used: 1763
 BT TX               : STACK: unused 352 usage 416 / 768 (54 %); CPU: 0 %
      : Total CPU cycles used: 306
 thread_analyzer     : STACK: unused 576 usage 448 / 1024 (43 %); CPU: 0 %
      : Total CPU cycles used: 102
 BT LW WQ            : STACK: unused 408 usage 936 / 1344 (69 %); CPU: 9 %
      : Total CPU cycles used: 16913
 sysworkq            : STACK: unused 848 usage 176 / 1024 (17 %); CPU: 0 %
      : Total CPU cycles used: 786
 logging             : STACK: unused 136 usage 632 / 768 (82 %); CPU: 3 %
      : Total CPU cycles used: 6759
 idle                : STACK: unused 256 usage 64 / 320 (20 %); CPU: 83 %
      : Total CPU cycles used: 143592
 main                : STACK: unused 512 usage 512 / 1024 (50 %); CPU: 0 %
      : Total CPU cycles used: 219
 ISR0                : STACK: unused 1344 usage 704 / 2048 (34 %)
write_cmd_cb: count= 161, len= 39284, rate= 316133 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312348 bps.
write_cmd_cb: count= 159, len= 38796, rate= 312302 bps.
write_cmd_cb: count= 160, len= 39040, rate= 312348 bps.
le_param_updated: int 0x0028 lat 0 to 42
write_cmd_cb: count= 160, len= 39040, rate= 312329 bps.
Thread analyze:
 BT RX               : STACK: unused 592 usage 176 / 768 (22 %); CPU: 4 %
      : Total CPU cycles used: 13246
 BT RX pri           : STACK: unused 192 usage 256 / 448 (57 %); CPU: 2 %
      : Total CPU cycles used: 7978
 BT RX WQ            : STACK: unused 432 usage 784 / 1216 (64 %); CPU: 5 %
      : Total CPU cycles used: 16575
 BT TX               : STACK: unused 320 usage 448 / 768 (58 %); CPU: 1 %
      : Total CPU cycles used: 3457
 thread_analyzer     : STACK: unused 552 usage 472 / 1024 (46 %); CPU: 0 %
      : Total CPU cycles used: 185
 BT LW WQ            : STACK: unused 408 usage 936 / 1344 (69 %); CPU: 5 %
      : Total CPU cycles used: 16913
 sysworkq            : STACK: unused 744 usage 280 / 1024 (27 %); CPU: 2 %
      : Total CPU cycles used: 8496
 logging             : STACK: unused 136 usage 632 / 768 (82 %); CPU: 3 %
      : Total CPU cycles used: 11674
 idle                : STACK: unused 256 usage 64 / 320 (20 %); CPU: 74 %
      : Total CPU cycles used: 232777
 main                : STACK: unused 512 usage 512 / 1024 (50 %); CPU: 0 %
      : Total CPU cycles used: 1992
 ISR0                : STACK: unused 1344 usage 704 / 2048 (34 %)

--- exit ---

```
</details>

