### PR TITLE
Formatting Output: made copied datatype explicit

### DIFF
--- a/lib/os/cbprintf_packaged.c
+++ b/lib/os/cbprintf_packaged.c
@@ -436,7 +436,7 @@ int cbvprintf_package(void *packaged, size_t len, uint32_t flags,
 						return -ENOSPC;
 					}
 					if (Z_CBPRINTF_VA_STACK_LL_DBL_MEMCPY) {
-						memcpy(buf, &v, size);
+						memcpy(buf, (uint8_t *)&v, size);
 					} else if (fmt[-1] == 'L') {
 						*(long double *)buf = v.ld;
 					} else {
@@ -583,7 +583,7 @@ int cbvprintf_package(void *packaged, size_t len, uint32_t flags,
 						return -ENOSPC;
 					}
 					if (Z_CBPRINTF_VA_STACK_LL_DBL_MEMCPY) {
-						memcpy(buf, &v, size);
+						memcpy(buf, (uint8_t *)&v, size);
 					} else if (fmt[-1] == 'L') {
 						*(long double *)buf = v.ld;
 					} else {
@@ -699,7 +699,7 @@ process_string:
 
 			if (buf0 != NULL) {
 				if (Z_CBPRINTF_VA_STACK_LL_DBL_MEMCPY) {
-					memcpy(buf, &v, sizeof(long long));
+					memcpy(buf, (uint8_t *)&v, sizeof(long long));
 				} else {
 					*(long long *)buf = v;
 				}
@@ -796,7 +796,7 @@ process_string:
 		/* store the pointer position prefix */
 		*buf++ = str_ptr_pos[i];
 		/* copy the string with its terminating '\0' */
-		memcpy(buf, s, size);
+		memcpy(buf, (uint8_t *)s, size);
 		buf += size;
 	}
 


### PR DESCRIPTION
Fix coding guideline MISRA C:2012 Rule 21.15 in lib:

> The pointer arguments to the Standard Library functions memcpy, memmove and memcmp shall be pointers to qualified or unqualified versions of compatible types.

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/7229c127213a1db82deb6abda4788332000ea1ba

This time I found several new occurences of the violation, which found their way into the code **after** BUGSENG went over this code, I also fixed these new violations where I found them.

