### PR TITLE
arch: avoided dead stores

### DIFF
--- a/arch/x86/zefi/printf.h
+++ b/arch/x86/zefi/printf.h
@@ -142,7 +142,7 @@ static int vpf(struct _pfr *r, const char *f, va_list ap)
 
 static inline int snprintf(char *buf, unsigned long len, const char *f, ...)
 {
-	int ret = 0;
+	int ret;
 	struct _pfr r = { .buf = buf, .len = len };
 
 	CALL_VPF(&r);
@@ -151,7 +151,7 @@ static inline int snprintf(char *buf, unsigned long len, const char *f, ...)
 
 static inline int sprintf(char *buf, const char *f, ...)
 {
-	int ret = 0;
+	int ret;
 	struct _pfr r = { .buf = buf, .len = 0x7fffffff };
 
 	CALL_VPF(&r);
@@ -160,7 +160,7 @@ static inline int sprintf(char *buf, const char *f, ...)
 
 static inline int printf(const char *f, ...)
 {
-	int ret = 0;
+	int ret;
 	struct _pfr r = {0};
 
 	CALL_VPF(&r);


### PR DESCRIPTION
Fix coding guideline MISRA C:2012 Rule 2.2 in arch:

> There shall be no dead code

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/88608b2e789f159fc59eeb32a407511cbc65aff3



