### PR TITLE
drivers: ethernet: enc28j60: ESTAT TXABRT bit should be cleared on error

### DIFF
--- a/drivers/ethernet/eth_enc28j60.c
+++ b/drivers/ethernet/eth_enc28j60.c
@@ -527,6 +527,18 @@ static int eth_enc28j60_tx(const struct device *dev, struct net_pkt *pkt)
 
 	if (tx_end & ENC28J60_BIT_ESTAT_TXABRT) {
 		LOG_ERR("%s: TX failed!", dev->name);
+
+		/* 12.1.3 "TRANSMIT ERROR INTERRUPT FLAG (TXERIF)" states:
+		 *
+		 * "After determining the problem and solution, the
+		 * host controller should clear the LATECOL (if set) and
+		 * TXABRT bits so that future aborts can be detected
+		 * accurately."
+		 */
+		eth_enc28j60_clear_eth_reg(dev, ENC28J60_REG_ESTAT,
+					   ENC28J60_BIT_ESTAT_TXABRT
+					   | ENC28J60_BIT_ESTAT_LATECOL);
+
 		return -EIO;
 	}
 


### PR DESCRIPTION
See #72092 for a detailed description of the problem.

If the TXABRT bit from ESTAT is ever set (because of a single failed transmission), the driver will continue showing an error on every subsequent packet sent, although it is correctly sent:

	 <err> eth_enc28j60: TX failed!

The enc28j60 datasheet says under "12.1.3 TRANSMIT ERROR INTERRUPT FLAG (TXERIF)":

	"After determining the problem and solution, the
	host controller should clear the LATECOL (if set) and
	TXABRT bits so that future aborts can be detected
	accurately."

Therefore, clear the TXABRT and LATECOL bits in case of transmission error.

Fixes #72092