### PR TITLE
ci: compliance: upgrade to Python 3.11

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -17,6 +17,11 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
 
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.11
+
     - name: cache-pip
       uses: actions/cache@v4
       with:

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3569,7 +3569,6 @@ STM32 Platforms:
     - GeorgeCGV
   files:
     - boards/st/
-    - drivers/*/*stm32*/
     - drivers/*/*stm32*.c
     - drivers/*/*stm32*.h
     - drivers/*/*/*stm32*
@@ -3698,8 +3697,7 @@ Infineon Platforms:
     - boards/cypress/
     - boards/infineon/
     - drivers/*/*ifx_cat1*
-    - drivers/*/*xmc*/
-    - drivers/*/*xmc*.c
+    - drivers/*/*xmc*
     - drivers/sensor/infineon/
     - dts/arm/infineon/
     - dts/arm/cypress/


### PR DESCRIPTION
The behavior of glob() changedin Python 3.11 and runing the old one means we are missing some changes that trigger a compliance failure when ran on an updated system. Upgrade to 3.11 so those are caught in CI.

Fixes #72087