### PR TITLE
kernel: avoided dead stores

### DIFF
--- a/kernel/mem_slab.c
+++ b/kernel/mem_slab.c
@@ -172,7 +172,7 @@ SYS_INIT(init_mem_slab_obj_core_list, PRE_KERNEL_1,
 int k_mem_slab_init(struct k_mem_slab *slab, void *buffer,
 		    size_t block_size, uint32_t num_blocks)
 {
-	int rc = 0;
+	int rc;
 
 	slab->info.num_blocks = num_blocks;
 	slab->info.block_size = block_size;

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1369,7 +1369,7 @@ void z_impl_k_thread_abort(struct k_thread *thread)
 int z_impl_k_thread_join(struct k_thread *thread, k_timeout_t timeout)
 {
 	k_spinlock_key_t key = k_spin_lock(&_sched_spinlock);
-	int ret = 0;
+	int ret;
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_thread, join, thread, timeout);
 

--- a/kernel/sem.c
+++ b/kernel/sem.c
@@ -131,7 +131,7 @@ static inline void z_vrfy_k_sem_give(struct k_sem *sem)
 
 int z_impl_k_sem_take(struct k_sem *sem, k_timeout_t timeout)
 {
-	int ret = 0;
+	int ret;
 
 	__ASSERT(((arch_is_in_isr() == false) ||
 		  K_TIMEOUT_EQ(timeout, K_NO_WAIT)), "");

--- a/kernel/work.c
+++ b/kernel/work.c
@@ -271,7 +271,7 @@ static inline int queue_submit_locked(struct k_work_q *queue,
 		return -EINVAL;
 	}
 
-	int ret = -EBUSY;
+	int ret;
 	bool chained = (_current == &queue->thread) && !k_is_in_isr();
 	bool draining = flag_test(&queue->flags, K_WORK_QUEUE_DRAIN_BIT);
 	bool plugged = flag_test(&queue->flags, K_WORK_QUEUE_PLUGGED_BIT);
@@ -1018,7 +1018,7 @@ int k_work_reschedule_for_queue(struct k_work_q *queue,
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_work, reschedule_for_queue, queue, dwork, delay);
 
-	int ret = 0;
+	int ret;
 	k_spinlock_key_t key = k_spin_lock(&lock);
 
 	/* Remove any active scheduling. */


### PR DESCRIPTION
Fix coding guideline MISRA C:2012 Rule 2.2 in kernel:

> There shall be no dead code

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/88608b2e789f159fc59eeb32a407511cbc65aff3



