### PR TITLE
twister: Allow to run sysbuild with native_sim

### DIFF
--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -415,7 +415,7 @@ TESTDATA_4 = [
       '--log-file=build_dir/valgrind.log', '--track-origins=yes',
       'generator', 'run_renode_test']),
     (False, True, False, 123, None, ['generator', 'run', '--seed=123']),
-    (False, False, False, None, ['ex1', 'ex2'], ['bin', 'ex1', 'ex2']),
+    (False, False, False, None, ['ex1', 'ex2'], ['build_dir/zephyr/zephyr.exe', 'ex1', 'ex2']),
 ]
 
 @pytest.mark.parametrize(
@@ -441,6 +441,7 @@ def test_binaryhandler_create_command(
     handler.seed = seed
     handler.extra_test_args = extra_args
     handler.build_dir = 'build_dir'
+    handler.instance.testsuite.sysbuild = False
 
     command = handler._create_command(robot_test)
 
@@ -1445,7 +1446,7 @@ TESTDATA_19 = [
     TESTDATA_19,
     ids=['domains build dir', 'self build dir']
 )
-def test_qemuhandler_get_sysbuild_build_dir(
+def test_qemuhandler_get_default_domain_build_dir(
     mocked_instance,
     self_sysbuild,
     self_build_dir,
@@ -1462,7 +1463,7 @@ def test_qemuhandler_get_sysbuild_build_dir(
     handler.build_dir = self_build_dir
 
     with mock.patch('domains.Domains.from_file', from_file_mock):
-        result = handler._get_sysbuild_build_dir()
+        result = handler.get_default_domain_build_dir()
 
     assert result == expected
 
@@ -1984,7 +1985,7 @@ def test_qemuhandler_handle(
     harness = mock.Mock(state=harness_state)
     handler_options_west_flash = []
 
-    sysbuild_build_dir = os.path.join('sysbuild', 'dummydir')
+    domain_build_dir = os.path.join('sysbuild', 'dummydir')
     command = ['generator_cmd', '-C', os.path.join('cmd', 'path'), 'run']
 
     handler.options = mock.Mock(
@@ -1997,7 +1998,7 @@ def test_qemuhandler_handle(
     handler._final_handle_actions = mock.Mock(return_value=None)
     handler._create_command = mock.Mock(return_value=command)
     handler._set_qemu_filenames = mock.Mock(side_effect=mock_filenames)
-    handler._get_sysbuild_build_dir = mock.Mock(return_value=sysbuild_build_dir)
+    handler.get_default_domain_build_dir = mock.Mock(return_value=domain_build_dir)
     handler.terminate = mock.Mock()
 
     unlink_mock = mock.Mock()


### PR DESCRIPTION
Update path to zephyr.exe binary using default domain from domains.yaml file.

Fixes #72083

For future: update paths for bsim and pytest harness
