### PR TITLE
samples: Bluetooth: add `code-sample` tags to hci_ samples

### DIFF
--- a/boards/st/stm32wb5mmg/doc/stm32wb5mmg.rst
+++ b/boards/st/stm32wb5mmg/doc/stm32wb5mmg.rst
@@ -242,10 +242,10 @@ In this case the firmware will be uploaded on the STM32WB5MMG module.
 Flashing `hci_uart` application to STM32WB5MMG
 ----------------------------------------------
 
-Connect the B-U585I-IOT02A to your host computer using the USB port. Put
-the SW4 (MCU SWD) in OFF mode and SW5 (SWD BLE) in ON mode. Then build
-and flash an application. Here is an example for the
-:ref:`hci_uart <bluetooth-hci-uart-sample>` application.
+Connect the B-U585I-IOT02A to your host computer using the USB port. Put the SW4
+(MCU SWD) in OFF mode and SW5 (SWD BLE) in ON mode. Then build and flash an
+application. Here is an example for the :zephyr:code-sample:`HCI UART sample
+<bluetooth-hci-uart-sample>` application.
 
 Run a serial host program to connect with your B-U585I-IOT02A board:
 
@@ -286,8 +286,8 @@ Rest the board and you should see the following messages on the console:
 Debugging
 =========
 
-You can debug an application in the usual way.  Here is an example for the
-:ref:`hci_uart <bluetooth-hci-uart-sample>` application.
+You can debug an application in the usual way. Here is an example for the
+:zephyr:code-sample:`HCI UART sample <bluetooth-hci-uart-sample>` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/bluetooth/observer

--- a/doc/build/dts/api/api.rst
+++ b/doc/build/dts/api/api.rst
@@ -383,7 +383,7 @@ device.
      - Purpose
    * - zephyr,bt-c2h-uart
      - Selects the UART used for host communication in the
-       :ref:`bluetooth-hci-uart-sample`
+       :zephyr:code-sample:`HCI UART sample <bluetooth-hci-uart-sample>`
    * - zephyr,bt-mon-uart
      - Sets UART device used for the Bluetooth monitor logging
    * - zephyr,bt-uart

--- a/doc/connectivity/bluetooth/bluetooth-arch.rst
+++ b/doc/connectivity/bluetooth/bluetooth-arch.rst
@@ -97,9 +97,9 @@ BLE-enabled builds that can be produced from the Zephyr project codebase:
   the Link Layer and a special application. This application is different
   depending on the physical transport chosen for HCI:
 
-  * :ref:`hci_uart <bluetooth-hci-uart-sample>`
-  * :ref:`hci_usb <bluetooth-hci-usb-sample>`
-  * :ref:`hci_spi <bluetooth-hci-spi-sample>`
+  * :zephyr:code-sample:`HCI UART sample <bluetooth-hci-uart-sample>`
+  * :zephyr:code-sample:`HCI USB sample <bluetooth-hci-usb-sample>`
+  * :zephyr:code-sample:`HCI SPI sample <bluetooth-hci-spi-sample>`
 
   This application acts as a bridge between the UART, SPI or USB peripherals and
   the Controller subsystem, listening for HCI commands, sending application data
@@ -160,9 +160,9 @@ must be built with different configurations, yielding two separate images that
 must be programmed into each of the chips respectively. The Host build image
 contains the application, the BLE Host and the selected HCI driver (UART or
 SPI), while the Controller build runs either the
-:ref:`hci_uart <bluetooth-hci-uart-sample>`, or the
-:ref:`hci_spi <bluetooth-hci-spi-sample>` app to provide an interface to
-the BLE Controller.
+:zephyr:code-sample:`HCI UART sample <bluetooth-hci-uart-sample>`, or the
+:zephyr:code-sample:`HCI SPI sample <bluetooth-hci-spi-sample>` app to provide
+an interface to the BLE Controller.
 
 This configuration is not limited to using a Zephyr OS Host, as the right side
 of the image shows. One can indeed take one of the many existing GNU/Linux

--- a/doc/connectivity/bluetooth/bluetooth-tools.rst
+++ b/doc/connectivity/bluetooth/bluetooth-tools.rst
@@ -166,10 +166,12 @@ Using a Zephyr-based BLE Controller
 Depending on which hardware you have available, you can choose between two
 transports when building a single-mode, Zephyr-based BLE Controller:
 
-* UART: Use the :ref:`hci_uart <bluetooth-hci-uart-sample>` sample and follow
-  the instructions in :ref:`bluetooth-hci-uart-qemu-posix`.
-* USB: Use the :ref:`hci_usb <bluetooth-hci-usb-sample>` sample and then
-  treat it as a Host System Bluetooth Controller (see previous section)
+* UART: Use the :zephyr:code-sample:`HCI UART sample
+  <bluetooth-hci-uart-sample>` sample and follow the instructions in
+  :ref:`bluetooth-hci-uart-qemu-posix`.
+* USB: Use the :zephyr:code-sample:`HCI USB sample <bluetooth-hci-usb-sample>`
+  sample and then treat it as a Host System Bluetooth Controller (see previous
+  section)
 
 .. _bluetooth-hci-tracing:
 

--- a/doc/connectivity/usb/device/usb_device.rst
+++ b/doc/connectivity/usb/device/usb_device.rst
@@ -64,7 +64,7 @@ the next interface, preventing other composite functions from working.
 Because of this problem, HCI USB should not be used in a composite configuration.
 This problem is fixed in the implementation for new USB support.
 
-See :ref:`bluetooth-hci-usb-sample` sample for reference.
+See :zephyr:code-sample:`HCI USB sample <bluetooth-hci-usb-sample>` sample for reference.
 
 .. _usb_device_cdc_acm:
 
@@ -168,7 +168,7 @@ List of few Zephyr specific chosen properties which can be used to select
 CDC ACM UART as backend for a subsystem or application:
 
 * ``zephyr,bt-c2h-uart`` used in Bluetooth,
-  for example see :ref:`bluetooth-hci-uart-sample`
+  for example see :zephyr:code-sample:`HCI UART sample <bluetooth-hci-uart-sample>`
 * ``zephyr,ot-uart`` used in OpenThread,
   for example see :zephyr:code-sample:`coprocessor`
 * ``zephyr,shell-uart`` used by shell for serial backend,
@@ -572,39 +572,39 @@ and documented requests.
 
 The following Product IDs are currently used:
 
-+----------------------------------------------------+--------+
-| Sample                                             | PID    |
-+====================================================+========+
-| :zephyr:code-sample:`usb-cdc-acm`                  | 0x0001 |
-+----------------------------------------------------+--------+
-| :zephyr:code-sample:`usb-cdc-acm-composite`        | 0x0002 |
-+----------------------------------------------------+--------+
-| :zephyr:code-sample:`usb-hid-cdc`                  | 0x0003 |
-+----------------------------------------------------+--------+
-| :zephyr:code-sample:`usb-cdc-acm-console`          | 0x0004 |
-+----------------------------------------------------+--------+
-| :zephyr:code-sample:`usb-dfu` (Run-Time)           | 0x0005 |
-+----------------------------------------------------+--------+
-| :zephyr:code-sample:`usb-hid`                      | 0x0006 |
-+----------------------------------------------------+--------+
-| :zephyr:code-sample:`usb-hid-mouse`                | 0x0007 |
-+----------------------------------------------------+--------+
-| :zephyr:code-sample:`usb-mass`                     | 0x0008 |
-+----------------------------------------------------+--------+
-| :zephyr:code-sample:`testusb-app`                  | 0x0009 |
-+----------------------------------------------------+--------+
-| :zephyr:code-sample:`webusb`                       | 0x000A |
-+----------------------------------------------------+--------+
-| :ref:`bluetooth-hci-usb-sample`                    | 0x000B |
-+----------------------------------------------------+--------+
-| :ref:`bluetooth-hci-usb-h4-sample`                 | 0x000C |
-+----------------------------------------------------+--------+
-| :zephyr:code-sample:`wpan-usb`                     | 0x000D |
-+----------------------------------------------------+--------+
-| :zephyr:code-sample:`uac2-explicit-feedback`       | 0x000E |
-+----------------------------------------------------+--------+
-| :zephyr:code-sample:`usb-dfu` (DFU Mode)           | 0xFFFF |
-+----------------------------------------------------+--------+
++-----------------------------------------------------------------------+--------+
+| Sample                                                                | PID    |
++=======================================================================+========+
+| :zephyr:code-sample:`usb-cdc-acm`                                     | 0x0001 |
++-----------------------------------------------------------------------+--------+
+| :zephyr:code-sample:`usb-cdc-acm-composite`                           | 0x0002 |
++-----------------------------------------------------------------------+--------+
+| :zephyr:code-sample:`usb-hid-cdc`                                     | 0x0003 |
++-----------------------------------------------------------------------+--------+
+| :zephyr:code-sample:`usb-cdc-acm-console`                             | 0x0004 |
++-----------------------------------------------------------------------+--------+
+| :zephyr:code-sample:`usb-dfu` (Run-Time)                              | 0x0005 |
++-----------------------------------------------------------------------+--------+
+| :zephyr:code-sample:`usb-hid`                                         | 0x0006 |
++-----------------------------------------------------------------------+--------+
+| :zephyr:code-sample:`usb-hid-mouse`                                   | 0x0007 |
++-----------------------------------------------------------------------+--------+
+| :zephyr:code-sample:`usb-mass`                                        | 0x0008 |
++-----------------------------------------------------------------------+--------+
+| :zephyr:code-sample:`testusb-app`                                     | 0x0009 |
++-----------------------------------------------------------------------+--------+
+| :zephyr:code-sample:`webusb`                                          | 0x000A |
++-----------------------------------------------------------------------+--------+
+| :zephyr:code-sample:`HCI USB sample <bluetooth-hci-usb-sample>`       | 0x000B |
++-----------------------------------------------------------------------+--------+
+| :zephyr:code-sample:`HCI USB-H4 sample <bluetooth-hci-usb-h4-sample>` | 0x000C |
++-----------------------------------------------------------------------+--------+
+| :zephyr:code-sample:`wpan-usb`                                        | 0x000D |
++-----------------------------------------------------------------------+--------+
+| :zephyr:code-sample:`uac2-explicit-feedback`                          | 0x000E |
++-----------------------------------------------------------------------+--------+
+| :zephyr:code-sample:`usb-dfu` (DFU Mode)                              | 0xFFFF |
++-----------------------------------------------------------------------+--------+
 
 The USB device descriptor field ``bcdDevice`` (Device Release Number) represents
 the Zephyr kernel major and minor versions as a binary coded decimal value.

--- a/doc/connectivity/usb/device_next/usb_device.rst
+++ b/doc/connectivity/usb/device_next/usb_device.rst
@@ -24,7 +24,7 @@ Supported USB classes
 Bluetooth HCI USB transport layer
 =================================
 
-See :ref:`bluetooth-hci-usb-sample` sample for reference.
+See :zephyr:code-sample:`HCI USB sample <bluetooth-hci-usb-sample>` sample for reference.
 To build the sample for the new device support, set the configuration
 ``-DCONF_FILE=usbd_next_prj.conf`` either directly or via ``west``.
 

--- a/samples/bluetooth/bluetooth.rst
+++ b/samples/bluetooth/bluetooth.rst
@@ -18,10 +18,10 @@ documentation and are prefixed with :literal:`hci_` in their folder names.
 .. note::
    If you want to run any bluetooth sample on the nRF5340 device (build using
    ``-DBOARD=nrf5340dk/nrf5340/cpuapp`` or
-   ``-DBOARD=nrf5340dk/nrf5340/cpuapp/ns``) you must also build
-   and program the corresponding sample for the nRF5340 network core
-   :ref:`bluetooth-hci-ipc-sample` which implements the Bluetooth
-   Low Energy controller.
+   ``-DBOARD=nrf5340dk/nrf5340/cpuapp/ns``) you must also build and program the
+   corresponding sample for the nRF5340 network core :zephyr:code-sample:`HCI
+   IPC sample <bluetooth-hci-ipc-sample>` which implements the Bluetooth Low
+   Energy controller.
 
 .. note::
    The mutually-shared encryption key created during host-device paring may get

--- a/samples/bluetooth/broadcast_audio_sink/README.rst
+++ b/samples/bluetooth/broadcast_audio_sink/README.rst
@@ -53,7 +53,7 @@ If you prefer to only build the application core image, you can do so by doing i
    :goals: build
 
 In that case you can pair this application core image with the
-:ref:`hci_ipc sample <bluetooth-hci-ipc-sample>`
+:zephyr:code-sample:`HCI IPC sample <bluetooth-hci-ipc-sample>`
 :zephyr_file:`samples/bluetooth/hci_ipc/nrf5340_cpunet_iso-bt_ll_sw_split.conf` configuration.
 
 Building for a simulated nrf5340bsim

--- a/samples/bluetooth/broadcast_audio_source/README.rst
+++ b/samples/bluetooth/broadcast_audio_source/README.rst
@@ -52,7 +52,7 @@ If you prefer to only build the application core image, you can do so by doing i
    :goals: build
 
 In that case you can pair this application core image with the
-:ref:`hci_ipc sample <bluetooth-hci-ipc-sample>`
+:zephyr:code-sample:`HCI IPC sample <bluetooth-hci-ipc-sample>`
 :zephyr_file:`samples/bluetooth/hci_ipc/nrf5340_cpunet_iso-bt_ll_sw_split.conf` configuration.
 
 Building for a simulated nrf5340bsim

--- a/samples/bluetooth/direction_finding_central/README.rst
+++ b/samples/bluetooth/direction_finding_central/README.rst
@@ -37,9 +37,9 @@ changing ``nrf52833dk/nrf52833`` as needed for your board:
    :compact:
 
 To run the application on nRF5340DK, a Bluetooth controller application must
-also run on the network core. The :ref:`bluetooth-hci-ipc-sample` sample
-application may be used. To build this sample with direction finding support
-enabled:
+also run on the network core. The :zephyr:code-sample:`HCI IPC sample
+<bluetooth-hci-ipc-sample>` sample application may be used. To build this sample
+with direction finding support enabled:
 
 * Copy
   :zephyr_file:`samples/bluetooth/direction_finding_central/boards/nrf52833dk_nrf52833.overlay`
@@ -69,8 +69,8 @@ this overlay. See :ref:`set-devicetree-overlays` for information on setting up
 and using overlays.
 
 Note that antenna matrix configuration for the nRF5340 SoC is part of the
-network core application. When :ref:`bluetooth-hci-ipc-sample` is used as the
-network core application, the antenna matrix configuration should be stored in
-the file
+network core application. When :zephyr:code-sample:`HCI IPC sample
+<bluetooth-hci-ipc-sample>` is used as the network core application, the antenna
+matrix configuration should be stored in the file
 :file:`samples/bluetooth/hci_ipc/boards/nrf5340dk_nrf5340_cpunet.overlay`
 instead.

--- a/samples/bluetooth/direction_finding_connectionless_rx/README.rst
+++ b/samples/bluetooth/direction_finding_connectionless_rx/README.rst
@@ -37,9 +37,9 @@ changing ``nrf52833dk/nrf52833`` as needed for your board:
    :compact:
 
 To run the application on nRF5340DK, a Bluetooth controller application must
-also run on the network core. The :ref:`bluetooth-hci-ipc-sample` sample
-application may be used. To build this sample with direction finding support
-enabled:
+also run on the network core. The :ref:`hci_ipc sample
+<bluetooth-hci-ipc-sample>` sample application may be used. To build this sample
+with direction finding support enabled:
 
 * Copy
   :zephyr_file:`samples/bluetooth/direction_finding_connectionless_rx/boards/nrf52833dk_nrf52833.overlay`
@@ -72,8 +72,8 @@ this overlay. See :ref:`set-devicetree-overlays` for information on setting up
 and using overlays.
 
 Note that antenna matrix configuration for the nRF5340 SoC is part of the
-network core application. When :ref:`bluetooth-hci-ipc-sample` is used as the
-network core application, the antenna matrix configuration should be stored in
-the file
+network core application. When :zephyr:code-sample:`HCI IPC sample
+<bluetooth-hci-ipc-sample>` is used as the network core application, the antenna
+matrix configuration should be stored in the file
 :file:`samples/bluetooth/hci_ipc/boards/nrf5340dk_nrf5340_cpunet.overlay`
 instead.

--- a/samples/bluetooth/direction_finding_connectionless_tx/README.rst
+++ b/samples/bluetooth/direction_finding_connectionless_tx/README.rst
@@ -37,9 +37,9 @@ To use Angle of Arrival mode only, build this application as follows, changing
    :compact:
 
 To run the application on nRF5340DK, a Bluetooth controller application must
-also run on the network core. The :zephyr_file:`samples/bluetooth/hci_ipc`
-sample application may be used. To build this sample with direction finding
-support enabled:
+also run on the network core. The :zephyr:code-sample:`HCI IPC sample
+<bluetooth-hci-ipc-sample>` sample application may be used. To build this sample
+with direction finding support enabled:
 
 * Copy
   :zephyr_file:`samples/bluetooth/direction_finding_connectionless_tx/boards/nrf52833dk_nrf52833.overlay`
@@ -73,9 +73,9 @@ this overlay. See :ref:`set-devicetree-overlays` for information on setting up
 and using overlays.
 
 Note that antenna matrix configuration for the nRF5340 SoC is part of the
-network core application. When :ref:`bluetooth-hci-ipc-sample` is used as
-network core application, the antenna matrix configuration should be stored in
-the file
+network core application. When :zephyr:code-sample:`HCI IPC sample
+<bluetooth-hci-ipc-sample>` is used as network core application, the antenna
+matrix configuration should be stored in the file
 :file:`samples/bluetooth/hci_ipc/boards/nrf5340dk_nrf5340_cpunet.overlay`
 instead.
 

--- a/samples/bluetooth/direction_finding_peripheral/README.rst
+++ b/samples/bluetooth/direction_finding_peripheral/README.rst
@@ -36,9 +36,9 @@ changing ``nrf52833dk/nrf52833`` as needed for your board:
    :compact:
 
 To run the application on nRF5340DK, a Bluetooth controller application must
-also run on the network core. The :ref:`bluetooth-hci-ipc-sample` sample
-application may be used. To build this sample with direction finding support
-enabled:
+also run on the network core. The :zephyr:code-sample:`HCI IPC sample
+<bluetooth-hci-ipc-sample>` sample application may be used. To build this sample
+with direction finding support enabled:
 
 * Copy
   :zephyr_file:`samples/bluetooth/direction_finding_peripheral/boards/nrf52833dk_nrf52833.overlay`

--- a/samples/bluetooth/hci_ipc/README.rst
+++ b/samples/bluetooth/hci_ipc/README.rst
@@ -1,13 +1,14 @@
-.. _bluetooth-hci-ipc-sample:
+.. zephyr:code-sample:: bluetooth-hci-ipc-sample
+   :name: Bluetooth: HCI over IPC
+   :relevant-api: hci_raw
 
-Bluetooth: HCI IPC
-##################
+   Expose a Bluetooth controller to another CPU core over IPC.
 
 Overview
 ********
 
 This sample exposes :ref:`bluetooth_controller` support
-to another device or CPU using IPC subsystem.
+to another device or CPU using the IPC subsystem.
 
 Requirements
 ************

--- a/samples/bluetooth/hci_spi/README.rst
+++ b/samples/bluetooth/hci_spi/README.rst
@@ -1,13 +1,18 @@
-.. _bluetooth-hci-spi-sample:
+.. zephyr:code-sample:: bluetooth-hci-spi-sample
+   :name: Bluetooth: HCI over SPI
+   :relevant-api: hci_raw
 
-Bluetooth: HCI SPI
-##################
+   Expose a Bluetooth controller over the Zephyr SPI HCI transport
 
 Overview
 ********
 
-Expose Zephyr Bluetooth Controller support over SPI to another device/CPU using
-the Zephyr SPI HCI transport protocol (similar to BlueNRG).
+Expose Zephyr Bluetooth Controller support over SPI to another device using the
+Zephyr SPI HCI transport protocol.
+
+The SPI HCI transport is not defined by the Bluetooth specification (at the time
+of writing v5.3). It is based on the protocol implemented by STMicro BlueNRG
+devices.
 
 Requirements
 ************

--- a/samples/bluetooth/hci_uart/README.rst
+++ b/samples/bluetooth/hci_uart/README.rst
@@ -1,7 +1,8 @@
-.. _bluetooth-hci-uart-sample:
+.. zephyr:code-sample:: bluetooth-hci-uart-sample
+   :name: Bluetooth: HCI UART
+   :relevant-api: hci_raw
 
-Bluetooth: HCI UART
-####################
+   Expose a Bluetooth controller over serial using the H4 HCI transport
 
 Overview
 *********

--- a/samples/bluetooth/hci_uart_async/README.rst
+++ b/samples/bluetooth/hci_uart_async/README.rst
@@ -1,7 +1,11 @@
-.. _bluetooth-hci-uart-async-sample:
+.. zephyr:code-sample:: bluetooth-hci-uart-async-sample
+   :name: Bluetooth: HCI UART (async)
+   :relevant-api: hci_raw
 
-Bluetooth: HCI UART based on ASYNC UART
-#######################################
+   Expose a Bluetooth controller over async serial using the H4 HCI transport
+
+Overview
+********
 
 Expose a Zephyr Bluetooth Controller over a standard Bluetooth HCI UART interface.
 

--- a/samples/bluetooth/hci_usb/README.rst
+++ b/samples/bluetooth/hci_usb/README.rst
@@ -1,7 +1,8 @@
-.. _bluetooth-hci-usb-sample:
+.. zephyr:code-sample:: bluetooth-hci-usb-sample
+   :name: Bluetooth: HCI USB
+   :relevant-api: hci_raw
 
-Bluetooth: HCI USB
-##################
+   Expose a Bluetooth controller using the native USB HCI transport
 
 Overview
 ********

--- a/samples/bluetooth/hci_usb_h4/README.rst
+++ b/samples/bluetooth/hci_usb_h4/README.rst
@@ -1,7 +1,8 @@
-.. _bluetooth-hci-usb-h4-sample:
+.. zephyr:code-sample:: bluetooth-hci-usb-h4-sample
+   :name: Bluetooth: HCI USB-H4
+   :relevant-api: hci_raw
 
-Bluetooth: HCI H4 over USB
-##########################
+   Expose a Bluetooth controller using the USB-H4 HCI transport
 
 Overview
 ********
@@ -10,10 +11,13 @@ Make a USB H4 Bluetooth dongle out of Zephyr. Requires USB device support from
 the board it runs on (e.g. :ref:`nrf52840dk_nrf52840` supports both BLE and
 USB).
 
+USB-H4 is not defined by the Bluetooth specification (at the time of writing
+v5.3), but is supported by some host implementations, notably BlueZ on Linux.
+
 Requirements
 ************
 
-* Bluetooth stack running on the host (e.g. BlueZ)
+* Bluetooth stack running on the host that supports the USB H4 transport (e.g. BlueZ).
 * A board with Bluetooth and USB support in Zephyr
 
 Building and Running

--- a/samples/bluetooth/mesh/README.rst
+++ b/samples/bluetooth/mesh/README.rst
@@ -44,9 +44,10 @@ For other boards, build and flash the application as follows:
 Refer to your :ref:`board's documentation <boards>` for alternative
 flash instructions if your board doesn't support the ``flash`` target.
 
-To run the application on an :ref:`nrf5340dk_nrf5340`, a Bluetooth controller application
-must also run on the network core. The :ref:`bluetooth-hci-ipc-sample` sample
-application may be used. Build this sample with configuration
+To run the application on an :ref:`nrf5340dk_nrf5340`, a Bluetooth controller
+application must also run on the network core. The :zephyr:code-sample:`HCI IPC
+sample <bluetooth-hci-ipc-sample>` sample application may be used. Build this
+sample with configuration
 :zephyr_file:`samples/bluetooth/hci_ipc/nrf5340_cpunet_bt_mesh-bt_ll_sw_split.conf`
 to enable mesh support.
 

--- a/samples/bluetooth/mesh_demo/README.rst
+++ b/samples/bluetooth/mesh_demo/README.rst
@@ -55,8 +55,9 @@ For other boards, build and flash the application as follows:
 Refer to your :ref:`board's documentation <boards>` for alternative
 flash instructions if your board doesn't support the ``flash`` target.
 
-To run the application on an :ref:`nrf5340dk_nrf5340`, a Bluetooth controller application
-must also run on the network core. The :ref:`bluetooth-hci-ipc-sample` sample
-application may be used. Build this sample with configuration
+To run the application on an :ref:`nrf5340dk_nrf5340`, a Bluetooth controller
+application must also run on the network core. The :zephyr:code-sample:`HCI IPC
+sample <bluetooth-hci-ipc-sample>` sample application may be used. Build this
+sample with configuration
 :zephyr_file:`samples/bluetooth/hci_ipc/nrf5340_cpunet_bt_mesh-bt_ll_sw_split.conf`
 to enable mesh support.

--- a/samples/bluetooth/mesh_provisioner/README.rst
+++ b/samples/bluetooth/mesh_provisioner/README.rst
@@ -53,8 +53,9 @@ For other boards, build and flash the application as follows:
 Refer to your :ref:`board's documentation <boards>` for alternative
 flash instructions if your board doesn't support the ``flash`` target.
 
-To run the application on an :ref:`nrf5340dk_nrf5340`, a Bluetooth controller application
-must also run on the network core. The :ref:`bluetooth-hci-ipc-sample` sample
-application may be used. Build this sample with configuration
+To run the application on an :ref:`nrf5340dk_nrf5340`, a Bluetooth controller
+application must also run on the network core. The :zephyr:code-sample:`HCI IPC
+sample <bluetooth-hci-ipc-sample>` sample application may be used. Build this
+sample with configuration
 :zephyr_file:`samples/bluetooth/hci_ipc/nrf5340_cpunet_bt_mesh-bt_ll_sw_split.conf`
 to enable mesh support.

--- a/samples/bluetooth/public_broadcast_sink/README.rst
+++ b/samples/bluetooth/public_broadcast_sink/README.rst
@@ -50,7 +50,7 @@ If you prefer to only build the application core image, you can do so by doing i
    :goals: build
 
 In that case you can pair this application core image with the
-:ref:`hci_ipc sample <bluetooth-hci-ipc-sample>`
+:zephyr:code-sample:`HCI IPC sample <bluetooth-hci-ipc-sample>`
 :zephyr_file:`samples/bluetooth/hci_ipc/nrf5340_cpunet_iso-bt_ll_sw_split.conf` configuration.
 
 Building for a simulated nrf5340bsim

--- a/samples/bluetooth/public_broadcast_source/README.rst
+++ b/samples/bluetooth/public_broadcast_source/README.rst
@@ -50,7 +50,7 @@ If you prefer to only build the application core image, you can do so by doing i
    :goals: build
 
 In that case you can pair this application core image with the
-:ref:`hci_ipc sample <bluetooth-hci-ipc-sample>`
+:zephyr:code-sample:`HCI IPC sample <bluetooth-hci-ipc-sample>`
 :zephyr_file:`samples/bluetooth/hci_ipc/nrf5340_cpunet_iso-bt_ll_sw_split.conf` configuration.
 
 Building for a simulated nrf5340bsim


### PR DESCRIPTION
Add `zephyr:code-sample` header to the samples exposing the controller over HCI.

They should now be linked to the `hci_raw` documentation page, along with a nicer overlay when referring to them from other places in the docs.