### PR TITLE
net: ipv6: mld: Fix improper reference drop

### DIFF
--- a/subsys/net/ip/ipv6_mld.c
+++ b/subsys/net/ip/ipv6_mld.c
@@ -299,8 +299,10 @@ static int send_mld_report(struct net_if *iface)
 
 	ret = mld_send(pkt);
 	if (ret < 0) {
-		return ret;
+		goto drop;
 	}
+
+	return 0;
 
 drop:
 	net_pkt_unref(pkt);


### PR DESCRIPTION
In case of successful submission, the reference shouldn't be put down, this only should done on error cases.

As reference is put down on success, during the buffer unref, no action is taken due to an uint8 overflow (ref is now 255), so, the buf->frags isn't cleared properly and the next time the frags is used and when L2 inserts a second frag, the first head frag and next frag are same (due to buffer re-use) causing an infinite loop in either net_buf_frag_last or net_pkt_get_len.