### PR TITLE
subsys/settings: add a function to save subtree

### DIFF
--- a/include/zephyr/settings/settings.h
+++ b/include/zephyr/settings/settings.h
@@ -304,6 +304,16 @@ int settings_load_subtree_direct(
 int settings_save(void);
 
 /**
+ * Save limited set of currently running serialized items. All serialized items
+ * that belong to subtree and which are different from currently persisted
+ * values will be saved.
+ *
+ * @param[in] subtree name of the subtree to be loaded.
+ * @return 0 on success, non-zero on failure.
+ */
+int settings_save_subtree(const char *subtree);
+
+/**
  * Write a single serialized value to persisted storage (if it has
  * changed value).
  *

--- a/subsys/settings/src/settings_store.c
+++ b/subsys/settings/src/settings_store.c
@@ -117,6 +117,11 @@ int settings_delete(const char *name)
 
 int settings_save(void)
 {
+	return settings_save_subtree(NULL);
+}
+
+int settings_save_subtree(const char *subtree)
+{
 	struct settings_store *cs;
 	int rc;
 	int rc2;
@@ -132,6 +137,9 @@ int settings_save(void)
 	rc = 0;
 
 	STRUCT_SECTION_FOREACH(settings_handler_static, ch) {
+		if (subtree && !settings_name_steq(ch->name, subtree, NULL)) {
+			continue;
+		}
 		if (ch->h_export) {
 			rc2 = ch->h_export(settings_save_one);
 			if (!rc) {
@@ -143,6 +151,9 @@ int settings_save(void)
 #if defined(CONFIG_SETTINGS_DYNAMIC_HANDLERS)
 	struct settings_handler *ch;
 	SYS_SLIST_FOR_EACH_CONTAINER(&settings_handlers, ch, node) {
+		if (subtree && !settings_name_steq(ch->name, subtree, NULL)) {
+			continue;
+		}
 		if (ch->h_export) {
 			rc2 = ch->h_export(settings_save_one);
 			if (!rc) {


### PR DESCRIPTION
When running multiple subsystems or applications on a MCU, the usual strategy is to use different settings subtrees.

The API provides a way to load or commit a subtree, to avoid adding dependencies between subsystems or applications, but lacks the way to save a subtree only. Fix that by adding a settings_save_subtree() function.