### PR TITLE
lorawan/nvm: do not call settings_save() after writing individual settings

### DIFF
--- a/subsys/lorawan/nvm/lorawan_nvm_settings.c
+++ b/subsys/lorawan/nvm/lorawan_nvm_settings.c
@@ -77,8 +77,6 @@ static void lorawan_nvm_save_settings(uint16_t nvm_notify_flag)
 			}
 		}
 	}
-
-	settings_save();
 }
 
 void lorawan_nvm_data_mgmt_event(uint16_t flags)


### PR DESCRIPTION
The lorawan subsystem do not use settings handler, and instead uses individual calls to settings_save_one(). With this strategy there is no need to call settings_save() at the end.