### PR TITLE
doc: Add 'project timeline' to glossary

### DIFF
--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -127,6 +127,9 @@ Glossary of Terms
       Power gating reduces power consumption by shutting off areas of an
       integrated circuit that are not in use.
 
+   project timeline
+      The Project timeline for the zephyr safety certification
+
    SoC
       A `System on a chip`_, that is, an integrated circuit that contains at
       least one :term:`CPU cluster` (in turn with at least one :term:`CPU core`),


### PR DESCRIPTION
Transfer 'safety certification project timeline' from
safety committee google drive glossary to zephyr doc glossary.