### PR TITLE
tests: boards: add esp32s2_devkitc overlay files

### DIFF
--- a/tests/drivers/adc/adc_api/boards/esp32s2_devkitc.conf
+++ b/tests/drivers/adc/adc_api/boards/esp32s2_devkitc.conf
@@ -1,0 +1,1 @@
+CONFIG_ADC_ASYNC=n

--- a/tests/drivers/adc/adc_api/boards/esp32s2_devkitc.overlay
+++ b/tests/drivers/adc/adc_api/boards/esp32s2_devkitc.overlay
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2022 Wolter HV <wolterhv@gmx.de>
+ * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		/* adjust channel number according to pinmux in board.dts */
+		io-channels = <&adc0 0>, <&adc0 1>;
+	};
+};
+
+&adc0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+};


### PR DESCRIPTION
As this module supports ADC, this test needs conf/overlay files to meet its requirements.