### PR TITLE
drivers: i2s: stm32: use length from i2s_write

### DIFF
--- a/drivers/i2s/i2s_ll_stm32.c
+++ b/drivers/i2s/i2s_ll_stm32.c
@@ -633,7 +633,7 @@ static void dma_tx_callback(const struct device *dma_dev, void *arg,
 #else
 			(void *)LL_SPI_DMA_GetRegAddr(cfg->i2s),
 #endif
-			stream->cfg.block_size);
+			mem_block_size);
 	if (ret < 0) {
 		LOG_DBG("Failed to start TX DMA transfer: %d", ret);
 		goto tx_disable;


### PR DESCRIPTION
The length parameter from `i2s_write` is not used correctly by i2s_ll_stm32.c. E.g. `i2s_write(dev, block, 0)` would work.

Use the length from `i2s_write` in `dma_reload` to fix the issue.