### PR TITLE
twister: Add optional memory footprint report into twister.json

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -386,6 +386,15 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
              "using additional build option `--target footprint`.")
 
     footprint_group.add_argument(
+        "--footprint-symbols",
+        nargs="+",
+        default=None,
+        choices=['all', 'ROM', 'RAM'],
+        help="Select which memory area symbols to include into the 'footprint' data object "
+             "in the 'twister.json' for each test suite built. "
+             "Implies '--create-rom-ram-report' with its source data. Default: %(default)s""")
+
+    footprint_group.add_argument(
         "--enable-size-report",
         action="store_true",
         help="Collect and report ROM/RAM section sizes for each test image built.")
@@ -775,6 +784,9 @@ def parse_arguments(parser, args, options = None):
 
     if options.last_metrics or options.compare_report:
         options.enable_size_report = True
+
+    if options.footprint_symbols:
+        options.create_rom_ram_report = True
 
     if options.aggressive_no_clean:
         options.no_clean = True

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -761,6 +761,8 @@ class ProjectBuilder(FilterBuilder):
             'build.log',
             'device.log',
             'recording.csv',
+            'rom.json',
+            'ram.json',
             # below ones are needed to make --test-only work as well
             'Makefile',
             'CMakeCache.txt',


### PR DESCRIPTION
New Twister option `--footprint-symbols` allows to select which memory area's data to include into `twister.json` report as `footprint` object with detailed memory usage statistics generated by West in `-t footprint` mode.

The new option implies and extends `--create-rom-ram-report`, so there are three choices currently: 'ROM', 'RAM', and 'all'. 
By default, the new option is disabled.

The new option allows to collect detailed footprint results consistently for each test suite instance in the test scope having all metadata from the Twister execution in the same report file. Next, the report file might be filtered and restructured up to the user's needs for further analysis and visualization, depending on a custom data storage schema.