### PR TITLE
includes: added requested parentheses verifying the lack of ambiguities

### DIFF
--- a/include/zephyr/internal/syscall_handler.h
+++ b/include/zephyr/internal/syscall_handler.h
@@ -62,7 +62,7 @@ static inline bool k_is_in_user_syscall(void)
 	 * calls from supervisor mode bypass everything directly to
 	 * the implementation function.
 	 */
-	return !k_is_in_isr() && _current->syscall_frame != NULL;
+	return !k_is_in_isr() && (_current->syscall_frame != NULL);
 }
 
 /**

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -46,7 +46,7 @@ BUILD_ASSERT(sizeof(intptr_t) == sizeof(long));
 
 #define K_ANY NULL
 
-#if CONFIG_NUM_COOP_PRIORITIES + CONFIG_NUM_PREEMPT_PRIORITIES == 0
+#if (CONFIG_NUM_COOP_PRIORITIES + CONFIG_NUM_PREEMPT_PRIORITIES) == 0
 #error Zero available thread priorities defined!
 #endif
 
@@ -5384,7 +5384,7 @@ void k_heap_free(struct k_heap *h, void *mem) __attribute_nonnull(1);
 /* Hand-calculated minimum heap sizes needed to return a successful
  * 1-byte allocation.  See details in lib/os/heap.[ch]
  */
-#define Z_HEAP_MIN_SIZE (sizeof(void *) > 4 ? 56 : 44)
+#define Z_HEAP_MIN_SIZE ((sizeof(void *) > 4) ? 56 : 44)
 
 /**
  * @brief Define a static k_heap in the specified linker section

--- a/include/zephyr/sys/cbprintf_internal.h
+++ b/include/zephyr/sys/cbprintf_internal.h
@@ -676,7 +676,7 @@ do { \
 			Z_CBPRINTF_IS_LONGDOUBLE(_arg) && \
 			!IS_ENABLED(CONFIG_CBPRINTF_PACKAGE_LONGDOUBLE)),\
 			"Packaging of long double not enabled in Kconfig."); \
-	while (_align_offset % Z_CBPRINTF_ALIGNMENT(_arg) != 0UL) { \
+	while ((_align_offset % Z_CBPRINTF_ALIGNMENT(_arg)) != 0UL) { \
 		_idx += sizeof(int); \
 		_align_offset += sizeof(int); \
 	} \

--- a/include/zephyr/sys/list_gen.h
+++ b/include/zephyr/sys/list_gen.h
@@ -72,7 +72,7 @@
 	static inline sys_ ## __nname ## _t *				     \
 	sys_ ## __lname ## _peek_next(sys_ ## __nname ## _t *node)	     \
 	{								     \
-		return node != NULL ?                                        \
+		return (node != NULL) ?                                        \
 			sys_ ## __lname ## _peek_next_no_check(node) :       \
 			      NULL;					     \
 	}

--- a/include/zephyr/sys/math_extras_impl.h
+++ b/include/zephyr/sys/math_extras_impl.h
@@ -187,7 +187,7 @@ static inline bool size_mul_overflow(size_t a, size_t b, size_t *result)
 #if use_builtin(__builtin_clz)
 static inline int u32_count_leading_zeros(uint32_t x)
 {
-	return x == 0 ? 32 : __builtin_clz(x);
+	return (x == 0) ? 32 : __builtin_clz(x);
 }
 #else /* !use_builtin(__builtin_clz) */
 static inline int u32_count_leading_zeros(uint32_t x)
@@ -205,7 +205,7 @@ static inline int u32_count_leading_zeros(uint32_t x)
 #if use_builtin(__builtin_clzll)
 static inline int u64_count_leading_zeros(uint64_t x)
 {
-	return x == 0 ? 64 : __builtin_clzll(x);
+	return (x == 0) ? 64 : __builtin_clzll(x);
 }
 #else /* !use_builtin(__builtin_clzll) */
 static inline int u64_count_leading_zeros(uint64_t x)
@@ -221,7 +221,7 @@ static inline int u64_count_leading_zeros(uint64_t x)
 #if use_builtin(__builtin_ctz)
 static inline int u32_count_trailing_zeros(uint32_t x)
 {
-	return x == 0 ? 32 : __builtin_ctz(x);
+	return (x == 0) ? 32 : __builtin_ctz(x);
 }
 #else /* !use_builtin(__builtin_ctz) */
 static inline int u32_count_trailing_zeros(uint32_t x)
@@ -239,7 +239,7 @@ static inline int u32_count_trailing_zeros(uint32_t x)
 #if use_builtin(__builtin_ctzll)
 static inline int u64_count_trailing_zeros(uint64_t x)
 {
-	return x == 0 ? 64 : __builtin_ctzll(x);
+	return (x == 0) ? 64 : __builtin_ctzll(x);
 }
 #else /* !use_builtin(__builtin_ctzll) */
 static inline int u64_count_trailing_zeros(uint64_t x)

--- a/include/zephyr/sys/time_units.h
+++ b/include/zephyr/sys/time_units.h
@@ -56,7 +56,7 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
 }
 #endif /* CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME */
 
-#if defined(__cplusplus) && __cplusplus >= 201402L
+#if defined(__cplusplus) && (__cplusplus >= 201402L)
   #if defined(CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME)
     #define TIME_CONSTEXPR
   #else

--- a/include/zephyr/toolchain/gcc.h
+++ b/include/zephyr/toolchain/gcc.h
@@ -82,7 +82,7 @@
  * static_assert() is not available)
  */
 #elif !defined(__cplusplus) && \
-	((__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)) ||	\
+	(((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 6))) ||	\
 	 (__STDC_VERSION__) >= 201100)
 #define BUILD_ASSERT(EXPR, MSG...) _Static_assert(EXPR, "" MSG)
 #else
@@ -138,7 +138,7 @@ __extension__ ({							\
 })
 
 
-#if __GNUC__ >= 7 && (defined(CONFIG_ARM) || defined(CONFIG_ARM64))
+#if (__GNUC__ >= 7) && (defined(CONFIG_ARM) || defined(CONFIG_ARM64))
 
 /* Version of UNALIGNED_PUT() which issues a compiler_barrier() after
  * the store. It is required to workaround an apparent optimization
@@ -590,7 +590,7 @@ do {                                                                    \
 		/* random suffix to avoid naming conflict */ \
 		__typeof__(a) _value_a_ = (a); \
 		__typeof__(b) _value_b_ = (b); \
-		_value_a_ > _value_b_ ? _value_a_ : _value_b_; \
+		(_value_a_ > _value_b_) ? _value_a_ : _value_b_; \
 	})
 
 /** @brief Return smaller value of two provided expressions.
@@ -602,7 +602,7 @@ do {                                                                    \
 		/* random suffix to avoid naming conflict */ \
 		__typeof__(a) _value_a_ = (a); \
 		__typeof__(b) _value_b_ = (b); \
-		_value_a_ < _value_b_ ? _value_a_ : _value_b_; \
+		(_value_a_ < _value_b_) ? _value_a_ : _value_b_; \
 	})
 
 /** @brief Return a value clamped to a given range.


### PR DESCRIPTION
Fix coding guideline MISRA C:2012 Rule 12.1 in includes:

> The precedence of operators within expressions should be made explicit.

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/29155bdd6c8f8c2c0bdf0562191b4b968b3a818a