### PR TITLE
dts: nxp: rt1060: Fix wrong reg address of enet2

### DIFF
--- a/dts/arm/nxp/nxp_rt1060.dtsi
+++ b/dts/arm/nxp/nxp_rt1060.dtsi
@@ -50,7 +50,7 @@
 		/* i.MX rt1060 has a second Ethernet controller. */
 		enet2: ethernet@402d4000 {
 			compatible = "nxp,enet";
-			reg = <0x402D8000 0x628>;
+			reg = <0x402d4000 0x628>;
 			clocks = <&ccm IMX_CCM_ENET_CLK 0 0>;
 			enet2_mac: ethernet {
 				compatible = "nxp,enet-mac";


### PR DESCRIPTION
Correction of the reg address of enet2 for nxp_rt1060.

Regression introduced at 537d5c310c3e9d22f1df9a6d0bd1e250c84216fb