### PR TITLE
drivers: spi: gecko: Apply frequency configuration, support devices with a single USART

### DIFF
--- a/drivers/spi/spi_gecko.c
+++ b/drivers/spi/spi_gecko.c
@@ -33,7 +33,10 @@ LOG_MODULE_REGISTER(spi_gecko);
 #define CLOCK_USART(id) _CONCAT(cmuClock_USART, id)
 #define GET_GECKO_USART_CLOCK(n) CLOCK_USART(DT_INST_PROP(n, peripheral_id))
 #else
-#if (USART_COUNT <= 2)
+#if (USART_COUNT == 1)
+#define CLOCK_USART(ref)	(((ref) == USART0) ? cmuClock_USART0 \
+			       : -1)
+#elif (USART_COUNT == 2)
 #define CLOCK_USART(ref)	(((ref) == USART0) ? cmuClock_USART0 \
 			       : ((ref) == USART1) ? cmuClock_USART1 \
 			       : -1)


### PR DESCRIPTION
This patch series fixes two issues with the Gecko SPI driver:
* Compile error on devices with less than 2 USART peripheral instances.
* Apply frequency configuration from devicetree instead of hard-coding 1 MHz operation.
  * The "clock-frequency" devicetree property is used as the default frequency unless the peripheral being communicated with has a lower "max-spi-frequency" (passed to the driver as spi_config::frequency).
  * An error is returned if the requested frequency is higher than the hardware can support. This limit is half the peripheral clock (PCLK on Series 2, HFPERCLK on Series 0/1) for SPI in controller mode.
  * Previously, the driver hard-coded 1 MHz operation. For backwards compatibility, default to 1 MHz if the "clock-frequency" property is not set in devicetree.