### PR TITLE
net: Do not directly use net_buf size field

### DIFF
--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -315,10 +315,10 @@ void net_pkt_print_frags(struct net_pkt *pkt)
 	while (frag) {
 		total += frag->len;
 
-		frag_size = frag->size;
+		frag_size = net_buf_max_len(frag);
 
 		NET_INFO("[%d] frag %p len %d max len %u size %d pool %p",
-			 count, frag, frag->len, net_buf_max_len(frag),
+			 count, frag, frag->len, frag->size,
 			 frag_size, net_buf_pool_get(frag->pool_id));
 
 		count++;
@@ -2130,8 +2130,9 @@ size_t net_pkt_get_contiguous_len(struct net_pkt *pkt)
 		size_t len;
 
 		len = net_pkt_is_being_overwritten(pkt) ?
-			pkt->cursor.buf->len : pkt->cursor.buf->size;
+			pkt->cursor.buf->len : net_buf_max_len(pkt->cursor.buf);
 		len -= pkt->cursor.pos - pkt->cursor.buf->data;
+
 		return len;
 	}
 

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -111,7 +111,7 @@ static int tcp_pkt_linearize(struct net_pkt *pkt, size_t pos, size_t len)
 
 	buf = net_pkt_get_frag(pkt, len, TCP_PKT_ALLOC_TIMEOUT);
 
-	if (!buf || buf->size < len) {
+	if (!buf || net_buf_max_len(buf) < len) {
 		if (buf) {
 			net_buf_unref(buf);
 		}
@@ -119,7 +119,7 @@ static int tcp_pkt_linearize(struct net_pkt *pkt, size_t pos, size_t len)
 		goto out;
 	}
 
-	net_buf_linearize(buf->data, buf->size, pkt->frags, pos, len);
+	net_buf_linearize(buf->data, net_buf_max_len(buf), pkt->frags, pos, len);
 	net_buf_add(buf, len);
 
 	len1 = first->len - (pkt->cursor.pos - pkt->cursor.buf->data);

--- a/subsys/net/lib/dns/llmnr_responder.c
+++ b/subsys/net/lib/dns/llmnr_responder.c
@@ -246,7 +246,7 @@ static int create_answer(struct net_context *ctx,
 	/* Prepare the response into the query buffer: move the name
 	 * query buffer has to get enough free space: dns_hdr + query + answer
 	 */
-	if ((query->size - query->len) < (DNS_MSG_HEADER_SIZE +
+	if ((net_buf_max_len(query) - query->len) < (DNS_MSG_HEADER_SIZE +
 					  (DNS_QTYPE_LEN + DNS_QCLASS_LEN) * 2 +
 					  DNS_TTL_LEN + DNS_RDLENGTH_LEN +
 					  addr_len + query->len)) {
@@ -491,7 +491,7 @@ static int dns_read(struct net_context *ctx,
 		enum dns_rr_type qtype;
 		enum dns_class qclass;
 
-		(void)memset(result->data, 0, result->size);
+		(void)memset(result->data, 0, net_buf_max_len(result));
 		result->len = 0U;
 
 		ret = dns_unpack_query(&dns_msg, result, &qtype, &qclass);

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -238,7 +238,7 @@ static int create_answer(struct net_context *ctx,
 	/* Prepare the response into the query buffer: move the name
 	 * query buffer has to get enough free space: dns_hdr + answer
 	 */
-	if ((query->size - query->len) < (DNS_MSG_HEADER_SIZE +
+	if ((net_buf_max_len(query) - query->len) < (DNS_MSG_HEADER_SIZE +
 					  DNS_QTYPE_LEN + DNS_QCLASS_LEN +
 					  DNS_TTL_LEN + DNS_RDLENGTH_LEN +
 					  addr_len)) {
@@ -453,7 +453,7 @@ static void send_sd_response(struct net_context *ctx,
 			/* Construct the response */
 			if (service_type_enum) {
 				ret = dns_sd_handle_service_type_enum(record, addr4, addr6,
-					result->data, result->size);
+						result->data, net_buf_max_len(result));
 				if (ret < 0) {
 					NET_DBG("dns_sd_handle_service_type_enum() failed (%d)",
 						ret);
@@ -461,7 +461,7 @@ static void send_sd_response(struct net_context *ctx,
 				}
 			} else {
 				ret = dns_sd_handle_ptr_query(record, addr4, addr6,
-					result->data, result->size);
+						result->data, net_buf_max_len(result));
 				if (ret < 0) {
 					NET_DBG("dns_sd_handle_ptr_query() failed (%d)", ret);
 					continue;

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -689,7 +689,7 @@ query_known:
 			if (dns_cname) {
 				ret = dns_copy_qname(dns_cname->data,
 						     &dns_cname->len,
-						     dns_cname->size,
+						     net_buf_max_len(dns_cname),
 						     dns_msg, pos);
 				if (ret < 0) {
 					ret = DNS_EAI_SYSTEM;
@@ -893,7 +893,8 @@ static int dns_write(struct dns_resolve_context *ctx,
 	dns_id = ctx->queries[query_idx].id;
 	query_type = ctx->queries[query_idx].query_type;
 
-	ret = dns_msg_pack_query(dns_data->data, &dns_data->len, dns_data->size,
+	ret = dns_msg_pack_query(dns_data->data, &dns_data->len,
+				 net_buf_max_len(dns_data),
 				 dns_qname->data, dns_qname->len, dns_id,
 				 (enum dns_rr_type)query_type);
 	if (ret < 0) {
@@ -1028,13 +1029,14 @@ int dns_resolve_cancel_with_name(struct dns_resolve_context *ctx,
 			return -ENOMEM;
 		}
 
-		ret = dns_msg_pack_qname(&len, buf->data, buf->size,
+		ret = dns_msg_pack_qname(&len, buf->data,
+					 net_buf_max_len(buf),
 					 query_name);
 		if (ret >= 0) {
 			/* If the query string + \0 + query type (A or AAAA)
 			 * does not fit the tmp buf, then bail out
 			 */
-			if ((len + 2) > buf->size) {
+			if ((len + 2) > net_buf_max_len(buf)) {
 				net_buf_unref(buf);
 				return -ENOMEM;
 			}


### PR DESCRIPTION
The size field in net_buf should not be used directly as then the optional headroom will not be taken into account. There is the net_buf_max_len() API that should be used instead.