### PR TITLE
west.yml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -282,7 +282,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: d4394c2f9b76e0a7b758441cea3a8ceb896f66c8
+      revision: 018dc01d484358d81f889c36471d9ce5590965b6
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  018dc01d484358d81f889c36471d9ce5590965b6

Brings following Zephyr relevant fixes:
  - 018dc01d boot/zephyr: use socs conf
  - d4394c2f mbedtls config: fix too early check_config.h includes

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.