### PR TITLE
spelling: Replace occurrences of "iff" with "if and only if"

### DIFF
--- a/drivers/counter/maxim_ds3231.c
+++ b/drivers/counter/maxim_ds3231.c
@@ -234,7 +234,7 @@ int maxim_ds3231_stat_update(const struct device *dev,
 
 /*
  * Look for current users of the interrupt/square-wave signal and
- * enable monitoring iff at least one consumer is active.
+ * enable monitoring if and only if at least one consumer is active.
  */
 static void validate_isw_monitoring(const struct device *dev)
 {

--- a/dts/bindings/base/mutable.yaml
+++ b/dts/bindings/base/mutable.yaml
@@ -7,7 +7,7 @@ properties:
   zephyr,mutable:
     type: boolean
     description: |
-      True iff the device structure may be mutated.
+      True if and only if the device structure may be mutated.
 
       Inherit this binding for devices that are runtime-modifiable, in-place.
       This places the device structure into SRAM rather than Flash.

--- a/include/zephyr/bluetooth/addr.h
+++ b/include/zephyr/bluetooth/addr.h
@@ -108,8 +108,8 @@ static inline int bt_addr_le_cmp(const bt_addr_le_t *a, const bt_addr_le_t *b)
 
 /** @brief Determine equality of two Bluetooth LE device addresses.
  *
- *  The Bluetooth LE addresses are equal iff both the types and the 48-bit
- *  addresses are numerically equal.
+ *  The Bluetooth LE addresses are equal if and only if both the types and
+ *  the 48-bit addresses are numerically equal.
  *
  *  @retval #true if the two addresses are equal
  *  @retval #false otherwise

--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -1440,9 +1440,9 @@ static bool do_page_fault(void *addr, bool pin)
 	 * during the page-in/out operation.
 	 *
 	 * We do however re-enable interrupts during the page-in/page-out
-	 * operation iff interrupts were enabled when the exception was taken;
-	 * in this configuration page faults in an ISR are a bug; all their
-	 * code/data must be pinned.
+	 * operation if and only if interrupts were enabled when the exception
+	 * was taken; in this configuration page faults in an ISR are a bug;
+	 * all their code/data must be pinned.
 	 *
 	 * If interrupts were disabled when the exception was taken, the
 	 * arch code is responsible for keeping them that way when entering

--- a/scripts/pylib/twister/twisterlib/testsuite.py
+++ b/scripts/pylib/twister/twisterlib/testsuite.py
@@ -82,10 +82,10 @@ def scan_file(inf_name):
         re.MULTILINE)
     # Checks if the file contains a definition of "void test_main(void)"
     # Since ztest provides a plain test_main implementation it is OK to:
-    # 1. register test suites and not call the run function iff the test
-    #    doesn't have a custom test_main.
-    # 2. register test suites and a custom test_main definition iff the test
-    #    also calls ztest_run_registered_test_suites.
+    # 1. register test suites and not call the run function if and only if
+    #    the test doesn't have a custom test_main.
+    # 2. register test suites and a custom test_main definition if and only if
+    #    the test also calls ztest_run_registered_test_suites.
     test_main_regex = re.compile(
         br"^\s*void\s+test_main\(void\)",
         re.MULTILINE)

--- a/scripts/spelling.txt
+++ b/scripts/spelling.txt
@@ -773,6 +773,7 @@ hypervior||hypervisor
 hypter||hyper
 idel||idle
 identidier||identifier
+iff||if and only if
 iligal||illegal
 illigal||illegal
 illgal||illegal

--- a/scripts/west_commands/zspdx/scanner.py
+++ b/scripts/west_commands/zspdx/scanner.py
@@ -159,7 +159,7 @@ def normalizeExpression(licsConcluded):
         return licsConcluded[0]
 
     # more than one, so we'll need to combine them
-    # iff an expression has spaces, it needs parens
+    # if and only if an expression has spaces, it needs parens
     revised = []
     for lic in licsConcluded:
         if lic in ["NONE", "NOASSERTION"]:

--- a/subsys/fs/ext2/ext2_ops.c
+++ b/subsys/fs/ext2/ext2_ops.c
@@ -59,7 +59,7 @@ static int ext2_open(struct fs_file_t *filp, const char *fs_path, fs_mode_t flag
 	/* Inodes allocated by lookup. Must be freed in manually. */
 	struct ext2_inode *found_inode = args.inode;
 
-	/* Not NULL iff FS_O_CREATE and found_inode == NULL */
+	/* Not NULL if FS_O_CREATE and found_inode == NULL */
 	struct ext2_inode *parent = args.parent;
 
 	/* File has to be created */

--- a/tests/kernel/workq/work/src/main.c
+++ b/tests/kernel/workq/work/src/main.c
@@ -1263,7 +1263,7 @@ ZTEST(work_1cpu, test_1cpu_immed_reschedule)
 	zassert_equal(rc, 1);
 }
 
-/* Test no-yield behavior, returns true iff work queue priority is
+/* Test no-yield behavior, returns true if and only if work queue priority is
  * higher than test thread priority
  */
 static bool try_queue_no_yield(struct k_work_q *wq)


### PR DESCRIPTION
Spell checking tools do not recognize "iff", replace with "if and only if".
See https://en.wikipedia.org/wiki/If_and_only_if