### PR TITLE
driver: i2s:  correct the trigger_drain and trigger_stop commands 

### DIFF
--- a/drivers/clock_control/clock_stm32f2_f4_f7.c
+++ b/drivers/clock_control/clock_stm32f2_f4_f7.c
@@ -104,17 +104,10 @@ void config_pll_sysclock(void)
 __unused
 void config_plli2s(void)
 {
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32f4_plli2s_clock)
 	LL_RCC_PLLI2S_ConfigDomain_I2S(get_pll_source(),
 				       pllm(STM32_PLLI2S_M_DIVISOR),
 				       STM32_PLLI2S_N_MULTIPLIER,
 				       plli2sr(STM32_PLLI2S_R_DIVISOR));
-#elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32f412_plli2s_clock)
-	LL_RCC_PLL_ConfigDomain_I2S(get_pll_source(),
-				       plli2sm(STM32_PLLI2S_M_DIVISOR),
-				       STM32_PLLI2S_N_MULTIPLIER,
-				       plli2sr(STM32_PLLI2S_R_DIVISOR));
-#endif
 }
 
 #endif /* STM32_PLLI2S_ENABLED */

--- a/drivers/i2s/i2s_ll_stm32.h
+++ b/drivers/i2s/i2s_ll_stm32.h
@@ -41,6 +41,9 @@ struct stream {
 	bool src_addr_increment;
 	bool dst_addr_increment;
 	uint8_t fifo_threshold;
+	uint8_t sample_tx_block_sent;
+	uint8_t sample_tx_block_dma_sent;
+	bool    sample_tx_stop_drain;
 
 	struct i2s_config cfg;
 	struct ring_buf mem_block_queue;

--- a/dts/bindings/clock/st,stm32f4-plli2s-clock.yaml
+++ b/dts/bindings/clock/st,stm32f4-plli2s-clock.yaml
@@ -27,6 +27,13 @@ properties:
     description: |
         PLLI2S multiplication factor for VCO
         Valid range may vary between parts: 50 - 432 , 192 - 432
+        
+  div-m:
+    type: int
+    required: true
+    description: |
+        Division factor for the PLLI2S input clock
+        Valid range: 2 - 63
 
   div-r:
     type: int

--- a/tests/drivers/i2s/i2s_speed/boards/nucleo_f411re.conf
+++ b/tests/drivers/i2s/i2s_speed/boards/nucleo_f411re.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2024, STmicroelectronics
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_I2S_TEST_SEPARATE_DEVICES=y

--- a/tests/drivers/i2s/i2s_speed/boards/nucleo_f411re.overlay
+++ b/tests/drivers/i2s/i2s_speed/boards/nucleo_f411re.overlay
@@ -1,7 +1,61 @@
-/* i2s-node0 is the transmitter/receiver */
+/* i2s-node0 is the receiver    */
+/* i2s-node1 is the transmitter */
 
 / {
 	aliases {
-		i2s-node0 = &i2s1;
-	};
+		i2s-node0 = &i2s1;  
+		i2s-node1 = &i2s4;
+		};
+};
+
+&plli2s{
+		#clock-cells = <0>;
+		clocks = <&clk_hse>;
+		div-m = <4>;
+		mul-n = <70>;
+		div-r = <2>;
+		status = "okay";
+		};
+		
+&i2s1 {
+		pinctrl-0 = <&i2s1_ws_pa4 &i2s1_ck_pa5 &spi1_miso_pb4 &spi1_mosi_pa7>;
+		pinctrl-names = "default";
+		clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00001000>,
+				<&rcc STM32_SRC_PLLI2S_R I2S_SEL(0)>;
+		dmas = <&dma2 3 3 STM32_DMA_PERIPH_TX 0x3
+				&dma2 2 3 (STM32_DMA_PERIPH_RX | STM32_DMA_PERIPH_NO_INC | STM32_DMA_PERIPH_16BITS | \
+						STM32_DMA_MEM_16BITS | STM32_DMA_PRIORITY_HIGH) 0x3>;
+		dma-names = "tx", "rx";
+		status = "okay";
+		};
+	
+&i2s4 {
+		pinctrl-0 = <&i2s4_ws_pb12 &i2s4_ck_pb13 &spi4_miso_pa11 &spi4_mosi_pa1>;
+		pinctrl-names = "default";
+		clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00002000>,
+				<&rcc STM32_SRC_PLLI2S_R I2S_SEL(0)>;
+		pinctrl-names = "default";
+		dmas = <&dma2 1 4 (STM32_DMA_PERIPH_TX | STM32_DMA_PERIPH_NO_INC |  STM32_DMA_PERIPH_16BITS | \
+							STM32_DMA_MEM_16BITS | STM32_DMA_PRIORITY_VERY_HIGH) 0x3
+				&dma2 0 4 STM32_DMA_PERIPH_RX 0x3>;
+		dma-names = "tx", "rx";
+		status = "okay";
+		};
+	
+&usart2{
+		interrupts = <38 5>;
+};
+
+&spi1 {
+		status = "disabled";
+};
+
+&dma1 {
+		status = "okay";
+};
+
+     /* Tx DMA interrupt has a higher priority than Rx DMA interrupt */
+&dma2 {
+		interrupts = <56 0 57 2 58 3 59 0 60 0 68 0 69 0 70 0>;
+		status = "okay";
 };


### PR DESCRIPTION
The driver is updated to handle correctly the commands TRIGGER_DRAIN and TRIGGER_STOP.
Moreover, the end of the rx_stream and tx_stream via DMA takes into account the state of IP i2s
before disabling I2S IP.