### PR TITLE
net: if: Extend the usage of rejoining the multicast groups

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -4636,6 +4636,18 @@ bool net_if_is_offloaded(struct net_if *iface)
 		net_if_is_socket_offloaded(iface));
 }
 
+static void rejoin_multicast_groups(struct net_if *iface)
+{
+#if defined(CONFIG_NET_NATIVE_IPV6)
+	rejoin_ipv6_mcast_groups(iface);
+	if (l2_flags_get(iface) & NET_L2_MULTICAST) {
+		join_mcast_allnodes(iface);
+	}
+#else
+	ARG_UNUSED(iface);
+#endif
+}
+
 static void notify_iface_up(struct net_if *iface)
 {
 	/* In many places it's assumed that link address was set with
@@ -4662,6 +4674,10 @@ static void notify_iface_up(struct net_if *iface)
 	 */
 	if (!net_if_is_offloaded(iface) &&
 	    !(l2_flags_get(iface) & NET_L2_POINT_TO_POINT)) {
+		/* Make sure that we update the IPv6 addresses and join the
+		 * multicast groups.
+		 */
+		rejoin_multicast_groups(iface);
 		iface_ipv6_start(iface);
 		net_ipv4_autoconf_start(iface);
 	}
@@ -4783,13 +4799,6 @@ static void init_igmp(struct net_if *iface)
 #endif
 }
 
-static void rejoin_multicast_groups(struct net_if *iface)
-{
-#if defined(CONFIG_NET_NATIVE_IPV6)
-	rejoin_ipv6_mcast_groups(iface);
-#endif
-}
-
 int net_if_up(struct net_if *iface)
 {
 	int status = 0;
@@ -4846,14 +4855,6 @@ done:
 	net_if_flag_set(iface, NET_IF_UP);
 	net_mgmt_event_notify(NET_EVENT_IF_ADMIN_UP, iface);
 	update_operational_state(iface);
-
-	if (!net_if_is_offloaded(iface)) {
-		/* Make sure that we update the IPv6 addresses and join the
-		 * multicast groups.
-		 */
-		rejoin_multicast_groups(iface);
-		net_if_start_dad(iface);
-	}
 
 out:
 	net_if_unlock(iface);


### PR DESCRIPTION
It may happen that the interface is up but not yet running when we issue the rejoin_ipv6_mcast_groups(). This can be fixed by calling this function again right after the iface is set to 'running' state in the notify_iface_up handler.