### PR TITLE
soc/intel_adsp: ipc: initialize semaphore in driver init

### DIFF
--- a/soc/intel/intel_adsp/common/ipc.c
+++ b/soc/intel/intel_adsp/common/ipc.c
@@ -100,6 +100,8 @@ int intel_adsp_ipc_init(const struct device *dev)
 
 	memset(devdata, 0, sizeof(*devdata));
 
+	k_sem_init(&devdata->sem, 0, 1);
+
 	/* ACK any latched interrupts (including TDA to clear IDA on
 	 * the other side!), then enable.
 	 */


### PR DESCRIPTION
The ipc driver device data (struct intel_adsp_ipc_data) contains a semaphore. Upon device init, the device data is zeroed out. This is safe for other fields, but the semaphore should be properly initialized before use.

This lack of initialization leads to a system crash when CONFIG_POLL is enabled (e.g. to enable CONFIG_SHELL), IPC driver handles an interrupt and executes k_sem_give() on a uninitialized semaphore object. This will eventually lead to null deferences in z_handle_obj_poll_events().