### PR TITLE
net: coap_client: handle observe requests as intended

### DIFF
--- a/include/zephyr/net/coap_client.h
+++ b/include/zephyr/net/coap_client.h
@@ -138,6 +138,17 @@ int coap_client_req(struct coap_client *client, int sock, const struct sockaddr 
 		    struct coap_client_request *req, struct coap_transmission_parameters *params);
 
 /**
+ * @brief Cancel all current requests.
+ *
+ * This is intended for canceling long-running requests (e.g. GETs with the OBSERVE option set)
+ * which has gone stale for some reason.
+ *
+ * @param client Client instance.
+ */
+void coap_client_cancel_requests(struct coap_client *client);
+
+
+/**
  * @}
  */
 

--- a/subsys/net/lib/coap/coap_client.c
+++ b/subsys/net/lib/coap/coap_client.c
@@ -811,8 +811,17 @@ static int handle_response(struct coap_client *client, const struct coap_packet 
 	}
 fail:
 	client->response_ready = false;
-	internal_req->request_ongoing = false;
+	if (ret != 0 || !coap_request_is_observe(&internal_req->request)) {
+		internal_req->request_ongoing = false;
+	}
 	return ret;
+}
+
+void coap_client_cancel_requests(struct coap_client *client)
+{
+	for (int i = 0; i < ARRAY_SIZE(client->requests); i++) {
+		client->requests[i].request_ongoing = false;
+	}
 }
 
 void coap_client_recv(void *coap_cl, void *a, void *b)


### PR DESCRIPTION
The coap_client lib only handled "one-shot" requests properly. This patch allows it to keep listening for additional responses to a request, if the request was made with the CoAP OBSERVE option appended.

An API for canceling such requests is also added.