### PR TITLE
include: zephyr: coding guidelines: add explicit cast to void

### DIFF
--- a/include/zephyr/spinlock.h
+++ b/include/zephyr/spinlock.h
@@ -316,7 +316,7 @@ static ALWAYS_INLINE void k_spin_unlock(struct k_spinlock *l,
 #ifdef CONFIG_SMP
 #ifdef CONFIG_TICKET_SPINLOCKS
 	/* Give the spinlock to the next CPU in a FIFO */
-	atomic_inc(&l->owner);
+	(void)atomic_inc(&l->owner);
 #else
 	/* Strictly we don't need atomic_clear() here (which is an
 	 * exchange operation that returns the old value).  We are always
@@ -325,7 +325,7 @@ static ALWAYS_INLINE void k_spin_unlock(struct k_spinlock *l,
 	 * a memory barrier when used like this, and we don't have a
 	 * Zephyr framework for that.
 	 */
-	atomic_clear(&l->locked);
+	(void)atomic_clear(&l->locked);
 #endif /* CONFIG_TICKET_SPINLOCKS */
 #endif /* CONFIG_SMP */
 	arch_irq_unlock(key.key);
@@ -364,9 +364,9 @@ static ALWAYS_INLINE void k_spin_release(struct k_spinlock *l)
 #endif
 #ifdef CONFIG_SMP
 #ifdef CONFIG_TICKET_SPINLOCKS
-	atomic_inc(&l->owner);
+	(void)atomic_inc(&l->owner);
 #else
-	atomic_clear(&l->locked);
+	(void)atomic_clear(&l->locked);
 #endif /* CONFIG_TICKET_SPINLOCKS */
 #endif /* CONFIG_SMP */
 }


### PR DESCRIPTION
Added explicit cast to void when returned value is expectedly ignored.

This corresponds to following coding guideline:
> The value returned by a function having non-void return type shall be used

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/f77c7bb2fed765156ff1c82a389c7f943b745422
