### PR TITLE
Bluetooth: Host: Support concurrent initiating and scanning

### DIFF
--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -768,7 +768,8 @@ struct bt_conn_le_create_param {
  *  This uses the General Connection Establishment procedure.
  *
  *  The application must disable explicit scanning before initiating
- *  a new LE connection.
+ *  a new LE connection if @kconfig{CONFIG_BT_SCAN_AND_INITIATE_IN_PARALLEL}
+ *  is not enabled.
  *
  *  @param[in]  peer         Remote address.
  *  @param[in]  create_param Create connection parameters.

--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -276,8 +276,17 @@ struct bt_hci_cmd_hdr {
 #define BT_FEAT_LE_ISO(feat)            (BT_FEAT_LE_CIS(feat) | \
 					BT_FEAT_LE_BIS(feat))
 
-/* LE States */
-#define BT_LE_STATES_PER_CONN_ADV(states)     (states & 0x0000004000000000)
+/* LE States. See Core_v5.4, Vol 4, Part E, Section 7.8.27 */
+#define BT_LE_STATES_PER_CONN_ADV(states)     (states & BIT64_MASK(38))
+
+#if defined(CONFIG_BT_SCAN_AND_INITIATE_IN_PARALLEL)
+/* Both passive and active scanner can be run in parallel with initiator. */
+#define BT_LE_STATES_SCAN_INIT(states) ((states) & BIT64_MASK(22) && \
+					(states) & BIT64_MASK(23))
+
+#else
+#define BT_LE_STATES_SCAN_INIT(states)  0
+#endif
 
 /* Bonding/authentication types */
 #define BT_HCI_NO_BONDING                       0x00

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -760,6 +760,23 @@ config BT_SCAN_WITH_IDENTITY
 	  for for the local identity. If this use case is required, then enable
 	  this option.
 
+config BT_SCAN_AND_INITIATE_IN_PARALLEL
+	bool "Allow concurrent scanning and initiating"
+	depends on (BT_CENTRAL && BT_OBSERVER)
+	select BT_EXT_ADV if BT_BROADCASTER
+	select BT_SCAN_WITH_IDENTITY if !BT_PRIVACY
+	help
+	  Allow concurrent scanning and initiating.
+	  This will allow the application to initiate a connection
+	  to a peer device without stopping the scanner.
+	  If privacy is disabled, the scanner will use its identity
+	  address.
+	  This feature is only available when extended advertising
+	  HCI commands are used to prevent degraded performance
+	  when the advertiser is used.
+	  Scanning with a timeout is not supported when this
+	  feature is enabled.
+
 config BT_DEVICE_NAME_DYNAMIC
 	bool "Allow to set Bluetooth device name on runtime"
 	help
@@ -803,6 +820,7 @@ config BT_DEVICE_APPEARANCE
 
 config BT_ID_MAX
 	int "Maximum number of local identities"
+	range 1 1 if BT_SCAN_AND_INITIATE_IN_PARALLEL
 	range 1 250
 	default 1
 	help

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -3034,7 +3034,8 @@ int bt_conn_le_create_auto(const struct bt_conn_le_create_param *create_param,
 	/* Scanning either to connect or explicit scan, either case scanner was
 	 * started by application and should not be stopped.
 	 */
-	if (atomic_test_bit(bt_dev.flags, BT_DEV_SCANNING)) {
+	if (!BT_LE_STATES_SCAN_INIT(bt_dev.le.states) &&
+	    atomic_test_bit(bt_dev.flags, BT_DEV_SCANNING)) {
 		return -EINVAL;
 	}
 
@@ -3117,7 +3118,8 @@ static int conn_le_create_common_checks(const bt_addr_le_t *peer,
 		return -EINVAL;
 	}
 
-	if (atomic_test_bit(bt_dev.flags, BT_DEV_EXPLICIT_SCAN)) {
+	if (!BT_LE_STATES_SCAN_INIT(bt_dev.le.states) &&
+	    atomic_test_bit(bt_dev.flags, BT_DEV_EXPLICIT_SCAN)) {
 		return -EAGAIN;
 	}
 

--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -342,12 +342,14 @@ int bt_le_scan_update(bool fast_scan)
 	if (IS_ENABLED(CONFIG_BT_CENTRAL)) {
 		struct bt_conn *conn;
 
-		/* don't restart scan if we have pending connection */
-		conn = bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL,
-					       BT_CONN_INITIATING);
-		if (conn) {
-			bt_conn_unref(conn);
-			return 0;
+		if (!BT_LE_STATES_SCAN_INIT(bt_dev.le.states)) {
+			/* don't restart scan if we have pending connection */
+			conn = bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL,
+						BT_CONN_INITIATING);
+			if (conn) {
+				bt_conn_unref(conn);
+				return 0;
+			}
 		}
 
 		conn = bt_conn_lookup_state_le(BT_ID_DEFAULT, NULL,
@@ -378,8 +380,11 @@ static void check_pending_conn(const bt_addr_le_t *id_addr,
 {
 	struct bt_conn *conn;
 
-	/* No connections are allowed during explicit scanning */
-	if (atomic_test_bit(bt_dev.flags, BT_DEV_EXPLICIT_SCAN)) {
+	/* No connections are allowed during explicit scanning
+	 * when the controller does not support concurrent scanning and initiating.
+	 */
+	if (!BT_LE_STATES_SCAN_INIT(bt_dev.le.states) &&
+	    atomic_test_bit(bt_dev.flags, BT_DEV_EXPLICIT_SCAN)) {
 		return;
 	}
 
@@ -394,9 +399,11 @@ static void check_pending_conn(const bt_addr_le_t *id_addr,
 		return;
 	}
 
-	if (atomic_test_bit(bt_dev.flags, BT_DEV_SCANNING) &&
-	    bt_le_scan_set_enable(BT_HCI_LE_SCAN_DISABLE)) {
-		goto failed;
+	if (!BT_LE_STATES_SCAN_INIT(bt_dev.le.states)) {
+		if (atomic_test_bit(bt_dev.flags, BT_DEV_SCANNING) &&
+		   bt_le_scan_set_enable(BT_HCI_LE_SCAN_DISABLE)) {
+			goto failed;
+		}
 	}
 
 	bt_addr_le_copy(&conn->le.resp_addr, addr);
@@ -1516,6 +1523,12 @@ int bt_le_scan_start(const struct bt_le_scan_param *param, bt_le_scan_cb_t cb)
 
 	if (IS_ENABLED(CONFIG_BT_EXT_ADV) &&
 	    BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features)) {
+
+		if (IS_ENABLED(CONFIG_BT_SCAN_AND_INITIATE_IN_PARALLEL) && param->timeout) {
+			atomic_clear_bit(bt_dev.flags, BT_DEV_EXPLICIT_SCAN);
+			return -ENOTSUP;
+		}
+
 		struct bt_hci_ext_scan_phy param_1m;
 		struct bt_hci_ext_scan_phy param_coded;
 


### PR DESCRIPTION
The HCI command LE Read Supported States command returns if the controller supports running the scanner and initiator roles in parallel.

This commit utilizes this information in the host:
- It does not prevent initiating a connection when the scanner is running
- It does not prevent the host from restarting the background scanner when there the host wants to auto-initiate a connection.
- It does not stop the scanner when the host wants to auto-initiate a connection.

To support this feature, the scanner and initiator always have to use the same address. This because the HCI command LE Set Random Address cannot be issued after the initiator or scanner has started.
1. When privacy is disabled, the scanner has to use its identity
   address to ensure it uses the same address as the initiator.
2. Only one identity is supported.
    
To simplify the implementation, it is a requirement to use
extended advertising commands to avoid interfering with
the random address used by the advertiser(s).

The changes in this commit will be tested out of tree as the Zephyr Bluetooth Controller does not support this functionality.