### PR TITLE
toolchain/llvm: Fix integer macros implementation

### DIFF
--- a/include/zephyr/toolchain/llvm.h
+++ b/include/zephyr/toolchain/llvm.h
@@ -30,46 +30,27 @@
 
 #include <zephyr/toolchain/gcc.h>
 
-#ifndef __INT8_C
+/*
+ * Provide these definitions only when minimal libc is used.
+ * Avoid collision with defines from include/zephyr/toolchain/zephyr_stdint.h
+ */
+#ifdef CONFIG_MINIMAL_LIBC
+#ifndef CONFIG_ENFORCE_ZEPHYR_STDINT
+
 #define __INT8_C(x)	x
-#endif
-
-#ifndef __UINT8_C
 #define __UINT8_C(x)	x ## U
-#endif
-
-#ifndef __INT16_C
 #define __INT16_C(x)	x
-#endif
-
-#ifndef __UINT16_C
 #define __UINT16_C(x)	x ## U
-#endif
-
-#ifndef __INT32_C
 #define __INT32_C(x)	x
-#endif
-
-#ifndef __UINT32_C
 #define __UINT32_C(x)	x ## U
-#endif
-
-#ifndef __INT64_C
 #define __INT64_C(x)	x
-#endif
-
-#ifndef __UINT64_C
 #define __UINT64_C(x)	x ## ULL
-#endif
 
-#ifndef __INTMAX_C
+#endif /* !CONFIG_ENFORCE_ZEPHYR_STDINT */
+
 #define __INTMAX_C(x)	x
-#endif
-
-
-#ifndef __UINTMAX_C
 #define __UINTMAX_C(x)	x ## ULL
-#endif
 
+#endif /* CONFIG_MINIMAL_LIBC */
 
 #endif /* ZEPHYR_INCLUDE_TOOLCHAIN_LLVM_H_ */

--- a/include/zephyr/toolchain/llvm.h
+++ b/include/zephyr/toolchain/llvm.h
@@ -37,19 +37,94 @@
 #ifdef CONFIG_MINIMAL_LIBC
 #ifndef CONFIG_ENFORCE_ZEPHYR_STDINT
 
-#define __INT8_C(x)	x
-#define __UINT8_C(x)	x ## U
-#define __INT16_C(x)	x
-#define __UINT16_C(x)	x ## U
+#define __int_c(v, suffix) v ## suffix
+#define int_c(v, suffix) __int_c(v, suffix)
+#define uint_c(v, suffix) __int_c(v ## U, suffix)
+
+#ifdef __INT64_TYPE__
+#undef __int_least64_c_suffix__
+#undef __int_least32_c_suffix__
+#undef __int_least16_c_suffix__
+#undef __int_least8_c_suffix__
+#ifdef __INT64_C_SUFFIX__
+#define __int_least64_c_suffix__ __INT64_C_SUFFIX__
+#define __int_least32_c_suffix__ __INT64_C_SUFFIX__
+#define __int_least16_c_suffix__ __INT64_C_SUFFIX__
+#define __int_least8_c_suffix__ __INT64_C_SUFFIX__
+#endif /* __INT64_C_SUFFIX__ */
+#endif /* __INT64_TYPE__ */
+
+#ifdef __INT_LEAST64_TYPE__
+#ifdef __int_least64_c_suffix__
+#define __INT64_C(x)	int_c(x, __int_least64_c_suffix__)
+#define __UINT64_C(x)	uint_c(x, __int_least64_c_suffix__)
+#else
+#define __INT64_C(x)	x
+#define __UINT64_C(x)	x ## U
+#endif /* __int_least64_c_suffix__ */
+#endif /* __INT_LEAST64_TYPE__ */
+
+#ifdef __INT32_TYPE__
+#undef __int_least32_c_suffix__
+#undef __int_least16_c_suffix__
+#undef __int_least8_c_suffix__
+#ifdef __INT32_C_SUFFIX__
+#define __int_least32_c_suffix__ __INT32_C_SUFFIX__
+#define __int_least16_c_suffix__ __INT32_C_SUFFIX__
+#define __int_least8_c_suffix__ __INT32_C_SUFFIX__
+#endif /* __INT32_C_SUFFIX__ */
+#endif /* __INT32_TYPE__ */
+
+#ifdef __INT_LEAST32_TYPE__
+#ifdef __int_least32_c_suffix__
+#define __INT32_C(x)	int_c(x, __int_least32_c_suffix__)
+#define __UINT32_C(x)	uint_c(x, __int_least32_c_suffix__)
+#else
 #define __INT32_C(x)	x
 #define __UINT32_C(x)	x ## U
-#define __INT64_C(x)	x
-#define __UINT64_C(x)	x ## ULL
+#endif /* __int_least32_c_suffix__ */
+#endif /* __INT_LEAST32_TYPE__ */
+
+#ifdef __INT16_TYPE__
+#undef __int_least16_c_suffix__
+#undef __int_least8_c_suffix__
+#ifdef __INT16_C_SUFFIX__
+#define __int_least16_c_suffix__ __INT16_C_SUFFIX__
+#define __int_least8_c_suffix__ __INT16_C_SUFFIX__
+#endif /* __INT16_C_SUFFIX__ */
+#endif /* __INT16_TYPE__ */
+
+#ifdef __INT_LEAST16_TYPE__
+#ifdef __int_least16_c_suffix__
+#define __INT16_C(x)	int_c(x, __int_least16_c_suffix__)
+#define __UINT16_C(x)	uint_c(x, __int_least16_c_suffix__)
+#else
+#define __INT16_C(x)	x
+#define __UINT16_C(x)	x ## U
+#endif /* __int_least16_c_suffix__ */
+#endif /* __INT_LEAST16_TYPE__ */
+
+#ifdef __INT8_TYPE__
+#undef __int_least8_c_suffix__
+#ifdef __INT8_C_SUFFIX__
+#define __int_least8_c_suffix__ __INT8_C_SUFFIX__
+#endif /* __INT8_C_SUFFIX__ */
+#endif /* __INT8_TYPE__ */
+
+#ifdef __INT_LEAST8_TYPE__
+#ifdef __int_least8_c_suffix__
+#define __INT8_C(x)	int_c(x, __int_least8_c_suffix__)
+#define __UINT8_C(x)	uint_c(x, __int_least8_c_suffix__)
+#else
+#define __INT8_C(x)	x
+#define __UINT8_C(x)	x ## U
+#endif /* __int_least8_c_suffix__ */
+#endif /* __INT_LEAST8_TYPE__ */
 
 #endif /* !CONFIG_ENFORCE_ZEPHYR_STDINT */
 
-#define __INTMAX_C(x)	x
-#define __UINTMAX_C(x)	x ## ULL
+#define __INTMAX_C(x)	int_c(x, __INTMAX_C_SUFFIX__)
+#define __UINTMAX_C(x)	int_c(x, __UINTMAX_C_SUFFIX__)
 
 #endif /* CONFIG_MINIMAL_LIBC */
 

--- a/include/zephyr/toolchain/llvm.h
+++ b/include/zephyr/toolchain/llvm.h
@@ -34,80 +34,42 @@
 #define __INT8_C(x)	x
 #endif
 
-#ifndef INT8_C
-#define INT8_C(x)	__INT8_C(x)
-#endif
-
 #ifndef __UINT8_C
 #define __UINT8_C(x)	x ## U
-#endif
-
-#ifndef UINT8_C
-#define UINT8_C(x)	__UINT8_C(x)
 #endif
 
 #ifndef __INT16_C
 #define __INT16_C(x)	x
 #endif
 
-#ifndef INT16_C
-#define INT16_C(x)	__INT16_C(x)
-#endif
-
 #ifndef __UINT16_C
 #define __UINT16_C(x)	x ## U
-#endif
-
-#ifndef UINT16_C
-#define UINT16_C(x)	__UINT16_C(x)
 #endif
 
 #ifndef __INT32_C
 #define __INT32_C(x)	x
 #endif
 
-#ifndef INT32_C
-#define INT32_C(x)	__INT32_C(x)
-#endif
-
 #ifndef __UINT32_C
 #define __UINT32_C(x)	x ## U
-#endif
-
-#ifndef UINT32_C
-#define UINT32_C(x)	__UINT32_C(x)
 #endif
 
 #ifndef __INT64_C
 #define __INT64_C(x)	x
 #endif
 
-#ifndef INT64_C
-#define INT64_C(x)	__INT64_C(x)
-#endif
-
 #ifndef __UINT64_C
 #define __UINT64_C(x)	x ## ULL
-#endif
-
-#ifndef UINT64_C
-#define UINT64_C(x)	__UINT64_C(x)
 #endif
 
 #ifndef __INTMAX_C
 #define __INTMAX_C(x)	x
 #endif
 
-#ifndef INTMAX_C
-#define INTMAX_C(x)	__INTMAX_C(x)
-#endif
 
 #ifndef __UINTMAX_C
 #define __UINTMAX_C(x)	x ## ULL
 #endif
 
-#ifndef UINTMAX_C
-#define UINTMAX_C(x)	__UINTMAX_C(x)
-#endif
 
 #endif /* ZEPHYR_INCLUDE_TOOLCHAIN_LLVM_H_ */

--- a/lib/libc/minimal/include/stdint.h
+++ b/lib/libc/minimal/include/stdint.h
@@ -104,7 +104,7 @@ typedef __UINT_LEAST64_TYPE__	uint_least64_t;
 typedef __INTPTR_TYPE__		intptr_t;
 typedef __UINTPTR_TYPE__	uintptr_t;
 
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__clang__)
 /* These macros must produce constant integer expressions, which can't
  * be done in the preprocessor (casts aren't allowed).  Defer to the
  * GCC internal functions where they're available.
@@ -120,7 +120,7 @@ typedef __UINTPTR_TYPE__	uintptr_t;
 #define UINT32_C(_v) __UINT32_C(_v)
 #define UINT64_C(_v) __UINT64_C(_v)
 #define UINTMAX_C(_v) __UINTMAX_C(_v)
-#endif /* __GNUC__ */
+#endif /* defined(__GNUC__) || defined(__clang__) */
 
 #ifdef __CCAC__
 #ifndef __INT8_C


### PR DESCRIPTION
Currently `__INT64_C()` doesn't add any suffix to provided constant which
causes the constant to have 'int' type. On the other side, `__UINT64_C()`
adds `ULL` suffix which makes the constant 'unsigned long long'.

Of course, `__INT64_C()` is wrong here because `int` type, in most cases,
has 32 bit width.

According to the C standard, these macros are for minimum-width integer
constants. For example, it means that using `INT16_C()` macro will give
you constant with type the same as `int_least16_t` type.

Clang doesn't provide defines like `__INT_LEAST16_C_SUFFIX__`, which makes
implementation difficult, because we need to determine appropriate type
first.

This PR also removes the integer constant macros (these not prefixed with `__`) from llvm.h,
since we use definitions from stdint.h (more details can be found in commit message).