### PR TITLE
kernel: coding guidelines: add explicit cast to void

### DIFF
--- a/kernel/smp.c
+++ b/kernel/smp.c
@@ -74,7 +74,7 @@ void z_smp_global_unlock(unsigned int key)
 		_current->base.global_lock_count--;
 
 		if (!_current->base.global_lock_count) {
-			atomic_clear(&global_lock);
+			(void)atomic_clear(&global_lock);
 		}
 	}
 
@@ -85,7 +85,7 @@ void z_smp_global_unlock(unsigned int key)
 void z_smp_release_global_lock(struct k_thread *thread)
 {
 	if (!thread->base.global_lock_count) {
-		atomic_clear(&global_lock);
+		(void)atomic_clear(&global_lock);
 	}
 }
 


### PR DESCRIPTION
Added explicit cast to void when returned value is expectedly ignored.

This corresponds to following coding guideline:
> The value returned by a function having non-void return type shall be used

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/f77c7bb2fed765156ff1c82a389c7f943b745422