### PR TITLE
lib: os: coding guidelines: add explicit cast to void

### DIFF
--- a/lib/os/sem.c
+++ b/lib/os/sem.c
@@ -53,7 +53,7 @@ int sys_sem_init(struct sys_sem *sem, unsigned int initial_count,
 		return -EINVAL;
 	}
 
-	atomic_set(&sem->futex.val, initial_count);
+	(void)atomic_set(&sem->futex.val, initial_count);
 	sem->limit = limit;
 
 	return 0;


### PR DESCRIPTION
Added explicit cast to void when returned value is expectedly ignored.

This corresponds to following coding guideline:

> The value returned by a function having non-void return type shall be used

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/f77c7bb2fed765156ff1c82a389c7f943b745422