### PR TITLE
boards: shields: add rk043fn02h_ct and rk043fn66hs_ctg shields

### DIFF
--- a/boards/nxp/mimxrt1060_evk/Kconfig.defconfig
+++ b/boards/nxp/mimxrt1060_evk/Kconfig.defconfig
@@ -11,16 +11,6 @@ config DEVICE_CONFIGURATION_DATA
 config NXP_IMX_EXTERNAL_SDRAM
 	default y
 
-config INPUT
-	default y if LVGL
-
-if INPUT
-
-config INPUT_FT5336_INTERRUPT
-	default y
-
-endif # INPUT
-
 if NETWORKING
 
 config NET_L2_ETHERNET
@@ -34,40 +24,5 @@ config ETH_MCUX_PHY_RESET
 endif # ETH_MCUX
 
 endif # NETWORKING
-
-if LVGL
-
-# LVGL should allocate buffers equal to size of display
-config LV_Z_VDB_SIZE
-	default 100
-
-# Enable double buffering
-config LV_Z_DOUBLE_VDB
-	default y
-
-# Force full refresh. This prevents memory copy associated with partial
-# display refreshes, which is not necessary for the eLCDIF driver
-config LV_Z_FULL_REFRESH
-	default y
-
-config LV_DPI_DEF
-	default 128
-
-config LV_Z_BITS_PER_PIXEL
-	default 16
-
-# Force display buffers to be aligned to cache line size (32 bytes)
-config LV_Z_VDB_ALIGN
-	default 32
-
-# Use offloaded render thread
-config LV_Z_FLUSH_THREAD
-	default y
-
-choice LV_COLOR_DEPTH
-	default LV_COLOR_DEPTH_16
-endchoice
-
-endif # LVGL
 
 endif # BOARD_MIMXRT1060_EVK || BOARD_MIMXRT1060_EVKB

--- a/boards/nxp/mimxrt1060_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1060_evk/doc/index.rst
@@ -115,7 +115,9 @@ already supported, which can also be re-used on this mimxrt1060_evk board:
 +-----------+------------+-------------------------------------+
 | SYSTICK   | on-chip    | systick                             |
 +-----------+------------+-------------------------------------+
-| DISPLAY   | on-chip    | display                             |
+| DISPLAY   | on-chip    | eLCDIF. Tested with                 |
+|           |            | :ref:`rk043fn02h_ct`, and           |
+|           |            | :ref:`rk043fn66hs_ctg` shields      |
 +-----------+------------+-------------------------------------+
 | FLASH     | on-chip    | QSPI flash                          |
 +-----------+------------+-------------------------------------+

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -39,6 +39,33 @@
 		reg = <0x80000000 DT_SIZE_M(32)>;
 	};
 
+	/*
+	 * This node describes the GPIO pins of the parallel FPC interface,
+	 * This interface is standard to several NXP EVKs, and is used with
+	 * several parallel LCD displays (available as zephyr shields)
+	 */
+	nxp_parallel_lcd_connector: parallel-connector {
+		compatible = "nxp,parallel-lcd-connector";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map =	<0  0 &gpio2 31 0>;	/* Pin 1, BL+ */
+	};
+
+	/*
+	 * This node describes the GPIO pins of the I2C display FPC interface,
+	 * This interface is standard to several NXP EVKs, and is used with
+	 * several parallel LCD displays (available as zephyr shields)
+	 */
+	nxp_i2c_touch_fpc: i2c-touch-connector {
+		compatible = "nxp,i2c-tsc-fpc";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map =	<1  0 &gpio1 2 0>,	/* Pin 2, LCD touch RST */
+				<2  0 &gpio1 11 0>;	/* Pin 3, LCD touch INT */
+	};
+
 	leds {
 		compatible = "gpio-leds";
 		green_led: led-1 {
@@ -114,7 +141,7 @@ arduino_serial: &lpuart3 {
 	pinctrl-names = "default", "flowcontrol", "sleep";
 };
 
-&lcdif {
+zephyr_lcdif: &lcdif {
 	status = "okay";
 	width = <480>;
 	height = <272>;
@@ -143,6 +170,8 @@ arduino_serial: &lpuart3 {
 		};
 	};
 };
+
+nxp_touch_i2c: &lpi2c1 {};
 
 arduino_i2c: &lpi2c1 {
 	status = "okay";

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -8,7 +8,6 @@
 
 #include <nxp/nxp_rt1060.dtsi>
 #include "mimxrt1060_evk-pinctrl.dtsi"
-#include <zephyr/dt-bindings/display/panel.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -30,7 +29,6 @@
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,canbus = &flexcan3;
-		zephyr,display = &lcdif;
 	};
 
 	sdram0: memory@80000000 {
@@ -90,11 +88,6 @@
 		};
 	};
 
-	lvgl_pointer {
-		compatible = "zephyr,lvgl-pointer-input";
-		input = <&ft5336>;
-	};
-
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
@@ -123,15 +116,6 @@
 			   <20 0 &gpio1 17 0>,	/* D14 */
 			   <21 0 &gpio1 16 0>;	/* D15 */
 	};
-
-	panel {
-		compatible = "rocktech,rk043fn02h-ct";
-		port {
-			lcd_panel_in: endpoint {
-				remote-endpoint = <&lcd_panel_out>;
-			};
-		};
-	};
 };
 
 arduino_serial: &lpuart3 {
@@ -142,33 +126,8 @@ arduino_serial: &lpuart3 {
 };
 
 zephyr_lcdif: &lcdif {
-	status = "okay";
-	width = <480>;
-	height = <272>;
-	display-timings {
-		compatible = "zephyr,panel-timing";
-		hsync-len = <41>;
-		hfront-porch = <4>;
-		hback-porch = <8>;
-		vsync-len = <10>;
-		vfront-porch = <4>;
-		vback-porch = <2>;
-		de-active= <1>;
-		pixelclk-active = <1>;
-		hsync-active = <0>;
-		vsync-active = <0>;
-		clock-frequency = <9210240>;
-	};
-	pixel-format = <PANEL_PIXEL_FORMAT_BGR_565>;
-	data-bus-width = "16-bit";
 	pinctrl-0 = <&pinmux_lcdif>;
 	pinctrl-names = "default";
-	backlight-gpios = <&gpio2 31 GPIO_ACTIVE_HIGH>;
-	port {
-		lcd_panel_out: endpoint {
-			remote-endpoint = <&lcd_panel_in>;
-		};
-	};
 };
 
 nxp_touch_i2c: &lpi2c1 {};
@@ -177,12 +136,6 @@ arduino_i2c: &lpi2c1 {
 	status = "okay";
 	pinctrl-0 = <&pinmux_lpi2c1>;
 	pinctrl-names = "default";
-
-	ft5336: ft5336@38 {
-		compatible = "focaltech,ft5336";
-		reg = <0x38>;
-		int-gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
-	};
 };
 
 &lpuart1 {

--- a/boards/shields/rk043fn02h_ct/Kconfig.defconfig
+++ b/boards/shields/rk043fn02h_ct/Kconfig.defconfig
@@ -1,0 +1,47 @@
+# Copyright 2024 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+if SHIELD_RK043FN02H_CT
+
+if LVGL
+
+config INPUT
+	default y
+
+config INPUT_FT5336_INTERRUPT
+	default y
+
+# LVGL should allocate buffers equal to size of display
+config LV_Z_VDB_SIZE
+	default 100
+
+# Enable double buffering
+config LV_Z_DOUBLE_VDB
+	default y
+
+# Force full refresh. This prevents memory copy associated with partial
+# display refreshes, which is not necessary for the eLCDIF driver
+config LV_Z_FULL_REFRESH
+	default y
+
+config LV_Z_BITS_PER_PIXEL
+	default 16
+
+config LV_DPI_DEF
+	default 128
+
+# Use offloaded render thread
+config LV_Z_FLUSH_THREAD
+	default y
+
+choice LV_COLOR_DEPTH
+	default LV_COLOR_DEPTH_16
+endchoice
+
+# Force display buffers to be aligned to cache line size (32 bytes)
+config LV_Z_VDB_ALIGN
+	default 32
+
+endif # LVGL
+
+endif # SHIELD_RK043FN02H_CT

--- a/boards/shields/rk043fn02h_ct/Kconfig.shield
+++ b/boards/shields/rk043fn02h_ct/Kconfig.shield
@@ -1,0 +1,5 @@
+# Copyright 2024 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+config SHIELD_RK043FN02H_CT
+	def_bool $(shields_list_contains,rk043fn02h_ct)

--- a/boards/shields/rk043fn02h_ct/doc/index.rst
+++ b/boards/shields/rk043fn02h_ct/doc/index.rst
@@ -1,0 +1,105 @@
+.. _rk043fn02h_ct:
+
+RK043FN02H-CT Parallel Display
+##############################
+
+Overview
+********
+
+RK043FN02H-CT is a 4.3 inch TFT 480*272 pixels with LED backlight and
+capacitive touch panel from Rocktech. This LCD panel can work with several i.MX
+RT EVKs and LPC MCUs for evaluation of applications with display.
+
+More information about the shield can be found at the `RK043FN02H-CT product
+page`_.
+
+This display uses a 40 pin parallel FPC interface plus 6 pin I2C interface,
+available on many NXP EVKs. Note that this parallel FPC interface is not
+compatible with the MIPI FPC interface present on other NXP EVKs.
+
+Pins Assignment of the Rocktech RK043FN02H-CT Parallel Display
+==============================================================
+
++-----------------------+------------------------+
+| Parallel FPC Pin      | Function               |
++=======================+========================+
+| 1                     | LED backlight cathode  |
++-----------------------+------------------------+
+| 2                     | LED backlight anode    |
++-----------------------+------------------------+
+| 3                     | GND                    |
++-----------------------+------------------------+
+| 4                     | VDD (3v3)              |
++-----------------------+------------------------+
+| 5-7                   | GND                    |
++-----------------------+------------------------+
+| 8-12                  | LCD D11-D15            |
++-----------------------+------------------------+
+| 13-14                 | GND                    |
++-----------------------+------------------------+
+| 15-20                 | LCD D5-D10             |
++-----------------------+------------------------+
+| 21-23                 | GND                    |
++-----------------------+------------------------+
+| 24-28                 | LCD D0-D4              |
++-----------------------+------------------------+
+| 29                    | GND                    |
++-----------------------+------------------------+
+| 30                    | LCD CLK                |
++-----------------------+------------------------+
+| 31                    | LCD DISP               |
++-----------------------+------------------------+
+| 32                    | LCD HSYNC              |
++-----------------------+------------------------+
+| 33                    | LCD VSYNC              |
++-----------------------+------------------------+
+| 34                    | LCD DE                 |
++-----------------------+------------------------+
+| 35                    | NC                     |
++-----------------------+------------------------+
+| 36                    | GND                    |
++-----------------------+------------------------+
+| 37-40                 | NC                     |
++-----------------------+------------------------+
+
++-----------------------+------------------------+
+| I2C Connector Pin     | Function               |
++=======================+========================+
+| 1                     | VDD (3v3)              |
++-----------------------+------------------------+
+| 2                     | LCD Touch Reset        |
++-----------------------+------------------------+
+| 3                     | LCD Touch Interrupt    |
++-----------------------+------------------------+
+| 4                     | LCD I2C SCL            |
++-----------------------+------------------------+
+| 5                     | LCD I2C SDA            |
++-----------------------+------------------------+
+| 6                     | GND                    |
++-----------------------+------------------------+
+
+Requirements
+************
+
+This shield can only be used with a board which provides a configuration
+for the 40+6 pin parallel/I2C FPC interface
+
+Programming
+***********
+
+Set ``-DSHIELD=rk043fn02h_ct`` when you invoke ``west build``. For
+example:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/drivers/display
+   :board: mimxrt1060_evk
+   :shield: rk043fn02h_ct
+   :goals: build
+
+References
+**********
+
+.. target-notes::
+
+.. _RK043FN02H-CT product page:
+   https://www.nxp.com/design/design-center/development-boards-and-designs/i-mx-evaluation-and-development-boards/4-3-lcd-panel:RK043FN02H-CT

--- a/boards/shields/rk043fn02h_ct/rk043fn02h_ct.overlay
+++ b/boards/shields/rk043fn02h_ct/rk043fn02h_ct.overlay
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/display/panel.h>
+
+/{
+	chosen {
+		zephyr,display = &zephyr_lcdif;
+	};
+
+	lvgl_pointer {
+		compatible = "zephyr,lvgl-pointer-input";
+		input = <&ft5336_rk043fn02h_ct>;
+	};
+};
+
+&nxp_touch_i2c {
+	status = "okay";
+	ft5336_rk043fn02h_ct: ft5336@38 {
+		compatible = "focaltech,ft5336";
+		reg = <0x38>;
+		int-gpios = <&nxp_i2c_touch_fpc 2 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&zephyr_lcdif {
+	status = "okay";
+	width = <480>;
+	height = <272>;
+	display-timings {
+		compatible = "zephyr,panel-timing";
+		hsync-len = <41>;
+		hfront-porch = <4>;
+		hback-porch = <8>;
+		vsync-len = <10>;
+		vfront-porch = <4>;
+		vback-porch = <2>;
+		de-active= <1>;
+		pixelclk-active = <1>;
+		hsync-active = <0>;
+		vsync-active = <0>;
+		clock-frequency = <9210240>;
+	};
+	pixel-format = <PANEL_PIXEL_FORMAT_BGR_565>;
+	data-bus-width = "16-bit";
+	backlight-gpios = <&nxp_parallel_lcd_connector 0 GPIO_ACTIVE_HIGH>;
+};

--- a/boards/shields/rk043fn66hs_ctg/Kconfig.defconfig
+++ b/boards/shields/rk043fn66hs_ctg/Kconfig.defconfig
@@ -1,0 +1,47 @@
+# Copyright 2024 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+if SHIELD_RK043FN66HS_CTG
+
+if LVGL
+
+config INPUT
+	default y
+
+config INPUT_GT911_INTERRUPT
+	default y
+
+# LVGL should allocate buffers equal to size of display
+config LV_Z_VDB_SIZE
+	default 100
+
+# Enable double buffering
+config LV_Z_DOUBLE_VDB
+	default y
+
+# Force full refresh. This prevents memory copy associated with partial
+# display refreshes, which is not necessary for the eLCDIF driver
+config LV_Z_FULL_REFRESH
+	default y
+
+config LV_Z_BITS_PER_PIXEL
+	default 16
+
+config LV_DPI_DEF
+	default 128
+
+# Use offloaded render thread
+config LV_Z_FLUSH_THREAD
+	default y
+
+choice LV_COLOR_DEPTH
+	default LV_COLOR_DEPTH_16
+endchoice
+
+# Force display buffers to be aligned to cache line size (32 bytes)
+config LV_Z_VDB_ALIGN
+	default 32
+
+endif # LVGL
+
+endif # SHIELD_RK043FN66HS_CTG

--- a/boards/shields/rk043fn66hs_ctg/Kconfig.shield
+++ b/boards/shields/rk043fn66hs_ctg/Kconfig.shield
@@ -1,0 +1,5 @@
+# Copyright 2024 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+config SHIELD_RK043FN66HS_CTG
+	def_bool $(shields_list_contains,rk043fn66hs_ctg)

--- a/boards/shields/rk043fn66hs_ctg/doc/index.rst
+++ b/boards/shields/rk043fn66hs_ctg/doc/index.rst
@@ -1,0 +1,105 @@
+.. _rk043fn66hs_ctg:
+
+RK043FN66HS-CTG Parallel Display
+################################
+
+Overview
+********
+
+RK043FN66HS-CTG is a 4.3 inch TFT 480*272 pixels with LED backlight and
+capacitive touch panel from Rocktech. This LCD panel can work with several i.MX
+RT EVKs and LPC MCUs for evaluation of applications with display.
+
+More information about the shield can be found at the `RK043FN66HS-CTG product
+page`_.
+
+This display uses a 40 pin parallel FPC interface plus 6 pin I2C interface,
+available on many NXP EVKs. Note that this parallel FPC interface is not
+compatible with the MIPI FPC interface present on other NXP EVKs.
+
+Pins Assignment of the Rocktech RK043FN66HS-CTG Parallel Display
+================================================================
+
++-----------------------+------------------------+
+| Parallel FPC Pin      | Function               |
++=======================+========================+
+| 1                     | LED backlight cathode  |
++-----------------------+------------------------+
+| 2                     | LED backlight anode    |
++-----------------------+------------------------+
+| 3                     | GND                    |
++-----------------------+------------------------+
+| 4                     | VDD (3v3)              |
++-----------------------+------------------------+
+| 5-7                   | GND                    |
++-----------------------+------------------------+
+| 8-12                  | LCD D11-D15            |
++-----------------------+------------------------+
+| 13-14                 | GND                    |
++-----------------------+------------------------+
+| 15-20                 | LCD D5-D10             |
++-----------------------+------------------------+
+| 21-23                 | GND                    |
++-----------------------+------------------------+
+| 24-28                 | LCD D0-D4              |
++-----------------------+------------------------+
+| 29                    | GND                    |
++-----------------------+------------------------+
+| 30                    | LCD CLK                |
++-----------------------+------------------------+
+| 31                    | LCD DISP               |
++-----------------------+------------------------+
+| 32                    | LCD HSYNC              |
++-----------------------+------------------------+
+| 33                    | LCD VSYNC              |
++-----------------------+------------------------+
+| 34                    | LCD DE                 |
++-----------------------+------------------------+
+| 35                    | NC                     |
++-----------------------+------------------------+
+| 36                    | GND                    |
++-----------------------+------------------------+
+| 37-40                 | NC                     |
++-----------------------+------------------------+
+
++-----------------------+------------------------+
+| I2C Connector Pin     | Function               |
++=======================+========================+
+| 1                     | VDD (3v3)              |
++-----------------------+------------------------+
+| 2                     | LCD Touch Reset        |
++-----------------------+------------------------+
+| 3                     | LCD Touch Interrupt    |
++-----------------------+------------------------+
+| 4                     | LCD I2C SCL            |
++-----------------------+------------------------+
+| 5                     | LCD I2C SDA            |
++-----------------------+------------------------+
+| 6                     | GND                    |
++-----------------------+------------------------+
+
+Requirements
+************
+
+This shield can only be used with a board which provides a configuration
+for the 40+6 pin parallel/I2C FPC interface
+
+Programming
+***********
+
+Set ``-DSHIELD=rk043fn66hs_ctg`` when you invoke ``west build``. For
+example:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/drivers/display
+   :board: mimxrt1060_evk
+   :shield: rk043fn66hs_ctg
+   :goals: build
+
+References
+**********
+
+.. target-notes::
+
+.. _RK043FN66HS-CTG product page:
+   https://www.nxp.com/design/design-center/development-boards-and-designs/i-mx-evaluation-and-development-boards/4-3-lcd-panel:RK043FN66HS-CTG

--- a/boards/shields/rk043fn66hs_ctg/rk043fn66hs_ctg.overlay
+++ b/boards/shields/rk043fn66hs_ctg/rk043fn66hs_ctg.overlay
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/display/panel.h>
+
+/{
+	chosen {
+		zephyr,display = &zephyr_lcdif;
+	};
+
+	lvgl_pointer {
+		compatible = "zephyr,lvgl-pointer-input";
+		input = <&gt911_rk043fn66hs_ctg>;
+	};
+};
+
+&nxp_touch_i2c {
+	status = "okay";
+	gt911_rk043fn66hs_ctg: gt911@5d {
+		compatible = "goodix,gt911";
+		reg = <0x5d>;
+		irq-gpios = <&nxp_i2c_touch_fpc 2 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&nxp_i2c_touch_fpc 1 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&zephyr_lcdif {
+	status = "okay";
+	width = <480>;
+	height = <272>;
+	display-timings {
+		compatible = "zephyr,panel-timing";
+		hsync-len = <4>;
+		hfront-porch = <8>;
+		hback-porch = <43>;
+		vsync-len = <4>;
+		vfront-porch = <8>;
+		vback-porch = <12>;
+		de-active= <1>;
+		pixelclk-active = <1>;
+		hsync-active = <0>;
+		vsync-active = <0>;
+		clock-frequency = <9210240>;
+	};
+	pixel-format = <PANEL_PIXEL_FORMAT_BGR_565>;
+	data-bus-width = "16-bit";
+	backlight-gpios = <&nxp_parallel_lcd_connector 0 GPIO_ACTIVE_HIGH>;
+};

--- a/dts/bindings/gpio/nxp,i2c-tsc-fpc.yaml
+++ b/dts/bindings/gpio/nxp,i2c-tsc-fpc.yaml
@@ -1,0 +1,20 @@
+# Copyright 2024 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+
+compatible: "nxp,i2c-tsc-fpc"
+
+description: |
+    GPIO pins exposed on NXP LCD touch controller interface. These pins are
+    exposed on a 6 pin flexible printed cable connector. The pins have the
+    following assignments:
+
+      Pin Number    Usage
+      1             VDD
+      2             LCD touch reset
+      3             LCD touch interrupt
+      4             LCD touch controller I2C SCL
+      5             LCD touch controller I2C SDA
+      6             GND
+
+include: [gpio-nexus.yaml, base.yaml]

--- a/dts/bindings/gpio/nxp,parallel-lcd-connector.yaml
+++ b/dts/bindings/gpio/nxp,parallel-lcd-connector.yaml
@@ -1,0 +1,33 @@
+# Copyright 2024 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+
+compatible: "nxp,parallel-lcd-connector"
+
+description: |
+    GPIO pins exposed on NXP LCD interface. These pins are
+    exposed on a 40 pin flexible printed cable connector. The pins have the
+    following assignments:
+
+      FPC Pin      Function
+      1            LED backlight cathode
+      2            LED backlight anode
+      3            GND
+      4            VDD (3v3)
+      5-7          GND
+      8-12         LCD D11-D15
+      13-14        GND
+      15-20        LCD D5-D10
+      21-23        GND
+      24-28        LCD D0-D4
+      29           GND
+      30           LCD CLK
+      31           LCD DISP
+      32           LCD HSYNC
+      33           LCD VSYNC
+      34           LCD DE
+      35           NC
+      36           GND
+      37-40        NC
+
+include: [gpio-nexus.yaml, base.yaml]

--- a/samples/drivers/display/sample.yaml
+++ b/samples/drivers/display/sample.yaml
@@ -175,3 +175,17 @@ tests:
     harness: console
     harness_config:
       fixture: fixture_display
+  sample.display.rk043fn66hs_ctg:
+    platform_allow: mimxrt1060_evk
+    tags: display
+    harness: console
+    extra_args: SHIELD=rk043fn66hs_ctg
+    harness_config:
+      fixture: fixture_display
+  sample.display.rk043fn02h_ct:
+    platform_allow: mimxrt1060_evk
+    tags: display
+    harness: console
+    extra_args: SHIELD=rk043fn02h_ct
+    harness_config:
+      fixture: fixture_display

--- a/samples/subsys/display/lvgl/sample.yaml
+++ b/samples/subsys/display/lvgl/sample.yaml
@@ -70,3 +70,17 @@ tests:
       - shield
       - lvgl
       - gui
+  samples.subsys.display.lvgl.rk043fn66hs_ctg:
+    platform_allow: mimxrt1060_evk
+    tags: display
+    harness: console
+    extra_args: SHIELD=rk043fn66hs_ctg
+    harness_config:
+      fixture: fixture_display
+  samples.subsys.display.lvgl.rk043fn02h_ct:
+    platform_allow: mimxrt1060_evk
+    tags: display
+    harness: console
+    extra_args: SHIELD=rk043fn02h_ct
+    harness_config:
+      fixture: fixture_display


### PR DESCRIPTION
Add `rk043fn02h_ct` and `rk043fn66hs_ctg` shields. These shields both describe Rocktech panels available from NXP, and compatible with several NXP iMX RT EVKs using a FPC interface.

Define nodelabel aliases for these FPC interfaces, and update the RT1060 EVK board definition to no longer define the RK043FN02H_CT as a panel at the board level (and use the shield instead)

Support for additional NXP EVKs (RT1064, RT1050, RT1040) will be added in follow up PRs.