### PR TITLE
boards: nxp: rt1050: remove display definition, use RK043* Rocktech panel shields

### DIFF
--- a/boards/nxp/mimxrt1050_evk/Kconfig.defconfig
+++ b/boards/nxp/mimxrt1050_evk/Kconfig.defconfig
@@ -10,17 +10,6 @@ config DEVICE_CONFIGURATION_DATA
 
 config NXP_IMX_EXTERNAL_SDRAM
 	default y
-
-config INPUT
-	default y if LVGL
-
-if INPUT
-
-config INPUT_FT5336_INTERRUPT
-	default y
-
-endif # INPUT
-
 if NETWORKING
 
 config NET_L2_ETHERNET
@@ -34,40 +23,5 @@ config ETH_MCUX_PHY_RESET
 endif # ETH_MCUX
 
 endif # NETWORKING
-
-if LVGL
-
-# LVGL should allocate buffers equal to size of display
-config LV_Z_VDB_SIZE
-	default 100
-
-# Enable double buffering
-config LV_Z_DOUBLE_VDB
-	default y
-
-# Force full refresh. This prevents memory copy associated with partial
-# display refreshes, which is not necessary for the eLCDIF driver
-config LV_Z_FULL_REFRESH
-	default y
-
-config LV_DPI_DEF
-	default 128
-
-config LV_Z_BITS_PER_PIXEL
-	default 16
-
-# Force display buffers to be aligned to cache line size (32 bytes)
-config LV_Z_VDB_ALIGN
-	default 32
-
-# Use offloaded render thread
-config LV_Z_FLUSH_THREAD
-	default y
-
-choice LV_COLOR_DEPTH
-	default LV_COLOR_DEPTH_16
-endchoice
-
-endif # LVGL
 
 endif # BOARD_MIMXRT1050_EVK

--- a/boards/nxp/mimxrt1050_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1050_evk/doc/index.rst
@@ -119,7 +119,9 @@ already supported, which can also be re-used on this mimxrt1050_evk board:
 +-----------+------------+-------------------------------------+
 | SYSTICK   | on-chip    | systick                             |
 +-----------+------------+-------------------------------------+
-| DISPLAY   | on-chip    | display                             |
+| DISPLAY   | on-chip    | eLCDIF. Tested with                 |
+|           |            | :ref:`rk043fn02h_ct`, and           |
+|           |            | :ref:`rk043fn66hs_ctg` shields      |
 +-----------+------------+-------------------------------------+
 | GPIO      | on-chip    | gpio                                |
 +-----------+------------+-------------------------------------+

--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -8,7 +8,6 @@
 
 #include <nxp/nxp_rt1050.dtsi>
 #include "mimxrt1050_evk-pinctrl.dtsi"
-#include <zephyr/dt-bindings/display/panel.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -30,13 +29,39 @@
 		zephyr,dtcm = &dtcm;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
-		zephyr,display = &lcdif;
 	};
 
 	sdram0: memory@80000000 {
 		/* Micron MT48LC16M16A2B4-6AIT:G */
 		device_type = "memory";
 		reg = <0x80000000 DT_SIZE_M(32)>;
+	};
+
+	/*
+	 * This node describes the GPIO pins of the parallel FPC interface,
+	 * This interface is standard to several NXP EVKs, and is used with
+	 * several parallel LCD displays (available as zephyr shields)
+	 */
+	nxp_parallel_lcd_connector: parallel-connector {
+		compatible = "nxp,parallel-lcd-connector";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map =	<0  0 &gpio2 31 0>;	/* Pin 1, BL+ */
+	};
+
+	/*
+	 * This node describes the GPIO pins of the I2C display FPC interface,
+	 * This interface is standard to several NXP EVKs, and is used with
+	 * several parallel LCD displays (available as zephyr shields)
+	 */
+	nxp_i2c_touch_fpc: i2c-touch-connector {
+		compatible = "nxp,i2c-tsc-fpc";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map =	<1  0 &gpio1 2 0>,	/* Pin 2, LCD touch RST */
+				<2  0 &gpio1 11 0>;	/* Pin 3, LCD touch INT */
 	};
 
 	leds {
@@ -54,11 +79,6 @@
 			gpios = <&gpio5 0 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			zephyr,code = <INPUT_KEY_0>;
 		};
-	};
-
-	lvgl_pointer {
-		compatible = "zephyr,lvgl-pointer-input";
-		input = <&ft5336>;
 	};
 
 	arduino_header: connector {
@@ -89,15 +109,6 @@
 			   <20 0 &gpio1 1 0>,	/* D14 */
 			   <21 0 &gpio1 0 0>;	/* D15 */
 	};
-
-	panel {
-		compatible = "rocktech,rk043fn02h-ct";
-		port {
-			lcd_panel_in: endpoint {
-				remote-endpoint = <&lcd_panel_out>;
-			};
-		};
-	};
 };
 
 arduino_serial: &lpuart3 {
@@ -112,34 +123,11 @@ arduino_serial: &lpuart3 {
 	pinctrl-names = "default";
 };
 
-&lcdif {
-	status = "okay";
-	width = <480>;
-	height = <272>;
-	display-timings {
-		compatible = "zephyr,panel-timing";
-		hsync-len = <41>;
-		hfront-porch = <4>;
-		hback-porch = <8>;
-		vsync-len = <10>;
-		vfront-porch = <4>;
-		vback-porch = <2>;
-		de-active= <1>;
-		pixelclk-active = <1>;
-		hsync-active = <0>;
-		vsync-active = <0>;
-		clock-frequency = <9210240>;
-	};
-	pixel-format = <PANEL_PIXEL_FORMAT_BGR_565>;
-	data-bus-width = "16-bit";
+nxp_touch_i2c: &lpi2c1 {};
+
+zephyr_lcdif: &lcdif {
 	pinctrl-0 = <&pinmux_lcdif>;
 	pinctrl-names = "default";
-	backlight-gpios = <&gpio2 31 GPIO_ACTIVE_HIGH>;
-	port {
-		lcd_panel_out: endpoint {
-			remote-endpoint = <&lcd_panel_in>;
-		};
-	};
 };
 
 &lpi2c1 {
@@ -158,12 +146,6 @@ arduino_serial: &lpuart3 {
 		 */
 		int1-gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
 		int2-gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
-	};
-
-	ft5336: ft5336@38 {
-		compatible = "focaltech,ft5336";
-		reg = <0x38>;
-		int-gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/samples/drivers/display/sample.yaml
+++ b/samples/drivers/display/sample.yaml
@@ -88,12 +88,6 @@ tests:
     harness: console
     harness_config:
       fixture: fixture_display
-  sample.display.mcux_elcdif:
-    platform_allow: mimxrt1050_evk
-    tags: display
-    harness: console
-    harness_config:
-      fixture: fixture_display
   sample.display.mcux_dcnano_lcdif:
     platform_allow: mimxrt595_evk/mimxrt595s/cm33
     tags: display
@@ -176,14 +170,18 @@ tests:
     harness_config:
       fixture: fixture_display
   sample.display.rk043fn66hs_ctg:
-    platform_allow: mimxrt1060_evk
+    platform_allow:
+      - mimxrt1060_evk
+      - mimxrt1050_evk
     tags: display
     harness: console
     extra_args: SHIELD=rk043fn66hs_ctg
     harness_config:
       fixture: fixture_display
   sample.display.rk043fn02h_ct:
-    platform_allow: mimxrt1060_evk
+    platform_allow:
+      - mimxrt1060_evk
+      - mimxrt1050_evk
     tags: display
     harness: console
     extra_args: SHIELD=rk043fn02h_ct

--- a/samples/subsys/display/lvgl/sample.yaml
+++ b/samples/subsys/display/lvgl/sample.yaml
@@ -71,14 +71,18 @@ tests:
       - lvgl
       - gui
   samples.subsys.display.lvgl.rk043fn66hs_ctg:
-    platform_allow: mimxrt1060_evk
+    platform_allow:
+      - mimxrt1060_evk
+      - mimxrt1050_evk
     tags: display
     harness: console
     extra_args: SHIELD=rk043fn66hs_ctg
     harness_config:
       fixture: fixture_display
   samples.subsys.display.lvgl.rk043fn02h_ct:
-    platform_allow: mimxrt1060_evk
+    platform_allow:
+      - mimxrt1060_evk
+      - mimxrt1050_evk
     tags: display
     harness: console
     extra_args: SHIELD=rk043fn02h_ct


### PR DESCRIPTION
Remove display definition from RT1050 EVK board, and use RK043* display shields as these shields support the FPC connector present on the EVK. Add RT1050 to testcases for these shields.

~Depends on #72174~