### PR TITLE
boards: nxp: mimxrt1040: add display support

### DIFF
--- a/boards/nxp/mimxrt1040_evk/CMakeLists.txt
+++ b/boards/nxp/mimxrt1040_evk/CMakeLists.txt
@@ -4,6 +4,11 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+if (CONFIG_DISPLAY)
+message(WARNING "
+CONFIG_DISPLAY: Running this firmware on a board without a display may damage the board
+")
+endif()
 
 if(CONFIG_NXP_IMXRT_BOOT_HEADER)
   zephyr_library()

--- a/boards/nxp/mimxrt1040_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1040_evk/doc/index.rst
@@ -118,6 +118,10 @@ already supported, which can also be re-used on this mimxrt1040_evk board:
 +-----------+------------+-------------------------------------+
 | I2C       | on-chip    | i2c                                 |
 +-----------+------------+-------------------------------------+
+| DISPLAY   | on-chip    | eLCDIF. Tested with                 |
+|           |            | :ref:`rk043fn02h_ct`, and           |
+|           |            | :ref:`rk043fn66hs_ctg` shields      |
++-----------+------------+-------------------------------------+
 
 The default configuration can be found in
 :zephyr_file:`boards/nxp/mimxrt1040_evk/mimxrt1040_evk_defconfig`

--- a/boards/nxp/mimxrt1040_evk/mimxrt1040_evk-pinctrl.dtsi
+++ b/boards/nxp/mimxrt1040_evk/mimxrt1040_evk-pinctrl.dtsi
@@ -94,5 +94,35 @@
 		};
 	};
 
+	pinmux_lcdif: pinmux_lcdif {
+		group0 {
+			pinmux = <&iomuxc_gpio_b0_00_lcdif_clk>,
+				<&iomuxc_gpio_b0_01_lcdif_enable>,
+				<&iomuxc_gpio_b0_02_lcdif_hsync>,
+				<&iomuxc_gpio_b0_03_lcdif_vsync>,
+				<&iomuxc_gpio_b0_04_lcdif_data00>,
+				<&iomuxc_gpio_b0_05_lcdif_data01>,
+				<&iomuxc_gpio_b0_06_lcdif_data02>,
+				<&iomuxc_gpio_b0_07_lcdif_data03>,
+				<&iomuxc_gpio_b0_08_lcdif_data04>,
+				<&iomuxc_gpio_b0_09_lcdif_data05>,
+				<&iomuxc_gpio_b0_10_lcdif_data06>,
+				<&iomuxc_gpio_b0_11_lcdif_data07>,
+				<&iomuxc_gpio_b0_12_lcdif_data08>,
+				<&iomuxc_gpio_b0_13_lcdif_data09>,
+				<&iomuxc_gpio_b0_14_lcdif_data10>,
+				<&iomuxc_gpio_b0_15_lcdif_data11>,
+				<&iomuxc_gpio_b1_00_lcdif_data12>,
+				<&iomuxc_gpio_b1_01_lcdif_data13>,
+				<&iomuxc_gpio_b1_02_lcdif_data14>,
+				<&iomuxc_gpio_b1_03_lcdif_data15>;
+			drive-strength = "r0-6";
+			input-schmitt-enable;
+			bias-pull-up;
+			bias-pull-up-value = "100k";
+			slew-rate = "slow";
+			nxp,speed = "100-mhz";
+		};
+	};
 };
 

--- a/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.dts
+++ b/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.dts
@@ -37,6 +37,33 @@
 		reg = <0x80000000 DT_SIZE_M(32)>;
 	};
 
+	/*
+	 * This node describes the GPIO pins of the parallel FPC interface,
+	 * This interface is standard to several NXP EVKs, and is used with
+	 * several parallel LCD displays (available as zephyr shields)
+	 */
+	nxp_parallel_lcd_connector: parallel-connector {
+		compatible = "nxp,parallel-lcd-connector";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map =	<0  0 &gpio2 31 0>;	/* Pin 1, BL+ */
+	};
+
+	/*
+	 * This node describes the GPIO pins of the I2C display FPC interface,
+	 * This interface is standard to several NXP EVKs, and is used with
+	 * several parallel LCD displays (available as zephyr shields)
+	 */
+	nxp_i2c_touch_fpc: i2c-touch-connector {
+		compatible = "nxp,i2c-tsc-fpc";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map =	<1  0 &gpio1 19 0>,	/* Pin 2, LCD touch RST */
+				<2  0 &gpio1 11 0>;	/* Pin 3, LCD touch INT */
+	};
+
 	leds {
 		compatible = "gpio-leds";
 		green_led: led_0 {
@@ -160,6 +187,13 @@
 &lpi2c1 {
 	status = "okay";
 	pinctrl-0 = <&pinmux_lpi2c1>;
+	pinctrl-names = "default";
+};
+
+nxp_touch_i2c: &lpi2c1 {};
+
+zephyr_lcdif: &lcdif {
+	pinctrl-0 = <&pinmux_lcdif>;
 	pinctrl-names = "default";
 };
 

--- a/samples/drivers/display/sample.yaml
+++ b/samples/drivers/display/sample.yaml
@@ -173,6 +173,7 @@ tests:
     platform_allow:
       - mimxrt1060_evk
       - mimxrt1050_evk
+      - mimxrt1040_evk
     tags: display
     harness: console
     extra_args: SHIELD=rk043fn66hs_ctg
@@ -182,6 +183,7 @@ tests:
     platform_allow:
       - mimxrt1060_evk
       - mimxrt1050_evk
+      - mimxrt1040_evk
     tags: display
     harness: console
     extra_args: SHIELD=rk043fn02h_ct

--- a/samples/subsys/display/lvgl/sample.yaml
+++ b/samples/subsys/display/lvgl/sample.yaml
@@ -74,6 +74,7 @@ tests:
     platform_allow:
       - mimxrt1060_evk
       - mimxrt1050_evk
+      - mimxrt1040_evk
     tags: display
     harness: console
     extra_args: SHIELD=rk043fn66hs_ctg
@@ -83,6 +84,7 @@ tests:
     platform_allow:
       - mimxrt1060_evk
       - mimxrt1050_evk
+      - mimxrt1040_evk
     tags: display
     harness: console
     extra_args: SHIELD=rk043fn02h_ct


### PR DESCRIPTION
Add display support on the MIMXRT1040-EVK, using the Rocktech RK043 panels defined as shields in Zephyr.

~Note that this PR depends on the following PRs:~
- ~#72174~
- ~#72168~