### PR TITLE
pm: System pm fixes and cleanup

### DIFF
--- a/arch/arm/core/cortex_a_r/irq_manage.c
+++ b/arch/arm/core/cortex_a_r/irq_manage.c
@@ -98,7 +98,7 @@ void _arch_isr_direct_pm(void)
 
 	if (_kernel.idle) {
 		_kernel.idle = 0;
-		z_pm_save_idle_exit();
+		pm_system_resume();
 	}
 
 	irq_unlock(key);

--- a/arch/arm/core/cortex_m/irq_manage.c
+++ b/arch/arm/core/cortex_m/irq_manage.c
@@ -131,7 +131,7 @@ void _arch_isr_direct_pm(void)
 
 	if (_kernel.idle) {
 		_kernel.idle = 0;
-		z_pm_save_idle_exit();
+		pm_system_resume();
 	}
 
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)

--- a/arch/arm/core/cortex_m/isr_wrapper.c
+++ b/arch/arm/core/cortex_m/isr_wrapper.c
@@ -42,7 +42,7 @@ void _isr_wrapper(void)
 	 * idle, this ensures that the calculation and programming of the
 	 * device for the next timer deadline is not interrupted.  For
 	 * non-tickless idle, this ensures that the clearing of the kernel idle
-	 * state is not interrupted.  In each case, z_pm_save_idle_exit
+	 * state is not interrupted.  In each case, pm_system_resume
 	 * is called with interrupts disabled.
 	 */
 
@@ -59,7 +59,7 @@ void _isr_wrapper(void)
 	if (_kernel.idle != 0) {
 		/* clear kernel idle state */
 		_kernel.idle = 0;
-		z_pm_save_idle_exit();
+		pm_system_resume();
 	}
 	/* re-enable interrupts */
 	__enable_irq();

--- a/arch/posix/core/swap.c
+++ b/arch/posix/core/swap.c
@@ -112,7 +112,7 @@ void posix_irq_check_idle_exit(void)
 {
 	if (_kernel.idle) {
 		_kernel.idle = 0;
-		z_pm_save_idle_exit();
+		pm_system_resume();
 	}
 }
 #endif

--- a/drivers/clock_control/clock_stm32_ll_common.h
+++ b/drivers/clock_control/clock_stm32_ll_common.h
@@ -50,8 +50,9 @@ void config_plli2s(void);
 #endif
 void config_enable_default_clocks(void);
 
-/* function exported to the soc power.c */
+/* functions exported to the soc power.c */
 int stm32_clock_control_init(const struct device *dev);
+void stm32_clock_control_standby_exit(void);
 
 #ifdef __cplusplus
 }

--- a/drivers/timer/intel_adsp_timer.c
+++ b/drivers/timer/intel_adsp_timer.c
@@ -212,7 +212,6 @@ void smp_timer_init(void)
 {
 }
 
-/* Runs on core 0 only */
 static int sys_clock_driver_init(void)
 {
 	uint64_t curr = count();
@@ -224,14 +223,11 @@ static int sys_clock_driver_init(void)
 	return 0;
 }
 
-#ifdef CONFIG_PM
-
-void sys_clock_idle_exit(void)
+/* Runs on core 0 only */
+void intel_adsp_clock_soft_off_exit(void)
 {
-	sys_clock_driver_init();
+	(void)sys_clock_driver_init();
 }
-
-#endif
 
 SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
 	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -550,14 +550,21 @@ static int sys_clock_driver_init(void)
 	return 0;
 }
 
-void sys_clock_idle_exit(void)
+void stm32_clock_control_standby_exit(void)
 {
 #ifdef CONFIG_STM32_LPTIM_STDBY_TIMER
 	if (clock_control_get_status(clk_ctrl,
 				     (clock_control_subsys_t) &lptim_clk[0])
 				     != CLOCK_CONTROL_STATUS_ON) {
 		sys_clock_driver_init();
-	} else if (timeout_stdby) {
+	}
+#endif /* CONFIG_STM32_LPTIM_STDBY_TIMER */
+}
+
+void sys_clock_idle_exit(void)
+{
+#ifdef CONFIG_STM32_LPTIM_STDBY_TIMER
+	if (timeout_stdby) {
 		cycle_t missed_lptim_cnt;
 		uint32_t stdby_timer_diff, stdby_timer_post, dticks;
 		uint64_t stdby_timer_us;

--- a/include/zephyr/arch/x86/ia32/arch.h
+++ b/include/zephyr/arch/x86/ia32/arch.h
@@ -250,7 +250,7 @@ static inline void arch_irq_direct_pm(void)
 {
 	if (_kernel.idle) {
 		_kernel.idle = 0;
-		z_pm_save_idle_exit();
+		pm_system_resume();
 	}
 }
 

--- a/include/zephyr/pm/pm.h
+++ b/include/zephyr/pm/pm.h
@@ -116,8 +116,28 @@ int pm_notifier_unregister(struct pm_notifier *notifier);
  */
 const struct pm_state_info *pm_state_next_get(uint8_t cpu);
 
+/**
+ * @brief Notify exit from kernel sleep.
+ *
+ * This function would notify exit from kernel idling if a corresponding
+ * pm_system_suspend() notification was handled and did not return
+ * PM_STATE_ACTIVE.
+ *
+ * This function should be called from the ISR context of the event
+ * that caused the exit from kernel idling.
+ *
+ * This is required for cpu power states that would require
+ * interrupts to be enabled while entering low power states. e.g. C1 in x86. In
+ * those cases, the ISR would be invoked immediately after the event wakes up
+ * the CPU, before code following the CPU wait, gets a chance to execute. This
+ * can be ignored if no operation needs to be done at the wake event
+ * notification.
+ */
+void pm_system_resume(void);
+
+
 /** @cond INTERNAL_HIDDEN */
-void z_pm_save_idle_exit(void);
+__deprecated void z_pm_save_idle_exit(void);
 /** @endcond */
 
 /**
@@ -182,6 +202,11 @@ static inline const struct pm_state_info *pm_state_next_get(uint8_t cpu)
 static inline void z_pm_save_idle_exit(void)
 {
 }
+
+static inline void pm_system_resume(void)
+{
+}
+
 #endif /* CONFIG_PM */
 
 #ifdef __cplusplus

--- a/include/zephyr/pm/pm.h
+++ b/include/zephyr/pm/pm.h
@@ -116,6 +116,10 @@ int pm_notifier_unregister(struct pm_notifier *notifier);
  */
 const struct pm_state_info *pm_state_next_get(uint8_t cpu);
 
+/** @cond INTERNAL_HIDDEN */
+void z_pm_save_idle_exit(void);
+/** @endcond */
+
 /**
  * @}
  */
@@ -175,9 +179,10 @@ static inline const struct pm_state_info *pm_state_next_get(uint8_t cpu)
 
 	return NULL;
 }
+static inline void z_pm_save_idle_exit(void)
+{
+}
 #endif /* CONFIG_PM */
-
-void z_pm_save_idle_exit(void);
 
 #ifdef __cplusplus
 }

--- a/kernel/idle.c
+++ b/kernel/idle.c
@@ -18,21 +18,6 @@
 
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
-void z_pm_save_idle_exit(void)
-{
-#ifdef CONFIG_PM
-	/* Some CPU low power states require notification at the ISR
-	 * to allow any operations that needs to be done before kernel
-	 * switches task or processes nested interrupts.
-	 * This can be simply ignored if not required.
-	 */
-	pm_system_resume();
-#endif	/* CONFIG_PM */
-#ifdef CONFIG_SYS_CLOCK_EXISTS
-	sys_clock_idle_exit();
-#endif /* CONFIG_SYS_CLOCK_EXISTS */
-}
-
 void idle(void *unused1, void *unused2, void *unused3)
 {
 	ARG_UNUSED(unused1);

--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -243,26 +243,6 @@ void z_handle_obj_poll_events(sys_dlist_t *events, uint32_t state);
  */
 bool pm_system_suspend(int32_t ticks);
 
-/**
- * Notify exit from kernel idling after PM operations
- *
- * This function would notify exit from kernel idling if a corresponding
- * pm_system_suspend() notification was handled and did not return
- * PM_STATE_ACTIVE.
- *
- * This function would be called from the ISR context of the event
- * that caused the exit from kernel idling. This will be called immediately
- * after interrupts are enabled. This is called to give a chance to do
- * any operations before the kernel would switch tasks or processes nested
- * interrupts. This is required for cpu low power states that would require
- * interrupts to be enabled while entering low power states. e.g. C1 in x86. In
- * those cases, the ISR would be invoked immediately after the event wakes up
- * the CPU, before code following the CPU wait, gets a chance to execute. This
- * can be ignored if no operation needs to be done at the wake event
- * notification.
- */
-void pm_system_resume(void);
-
 #endif /* CONFIG_PM */
 
 #ifdef CONFIG_DEMAND_PAGING_TIMING_HISTOGRAM

--- a/soc/intel/intel_adsp/ace/include/ace15_mtpm/adsp_power.h
+++ b/soc/intel/intel_adsp/ace/include/ace15_mtpm/adsp_power.h
@@ -89,6 +89,12 @@ static ALWAYS_INLINE bool soc_cpu_is_powered(int cpu_num)
 }
 
 /**
+ * @brief Restore timer after leaving soft-off.
+ *
+ */
+void intel_adsp_clock_soft_off_exit(void);
+
+/**
  * @brief Retrieve node identifier for Intel ADSP HOST power domain.
  */
 #define INTEL_ADSP_HST_DOMAIN_DTNODE DT_NODELABEL(hst_domain)

--- a/soc/intel/intel_adsp/ace/include/ace20_lnl/adsp_power.h
+++ b/soc/intel/intel_adsp/ace/include/ace20_lnl/adsp_power.h
@@ -90,6 +90,12 @@ static ALWAYS_INLINE bool soc_cpu_is_powered(int cpu_num)
 }
 
 /**
+ * @brief Restore timer after leaving soft-off.
+ *
+ */
+void intel_adsp_clock_soft_off_exit(void);
+
+/**
  * @brief Retrieve node identifier for Intel ADSP HOST power domain.
  */
 #define INTEL_ADSP_HST_DOMAIN_DTNODE DT_NODELABEL(hst_domain)

--- a/soc/intel/intel_adsp/ace/power.c
+++ b/soc/intel/intel_adsp/ace/power.c
@@ -388,7 +388,7 @@ void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 			imr_layout->imr_state.header.adsp_imr_magic = 0;
 			imr_layout->imr_state.header.imr_restore_vector = NULL;
 			imr_layout->imr_state.header.imr_ram_storage = NULL;
-			sys_clock_idle_exit();
+			intel_adsp_clock_soft_off_exit();
 			mem_window_idle_exit();
 			soc_mp_on_d3_exit();
 		}

--- a/soc/st/stm32/stm32wbax/power.c
+++ b/soc/st/stm32/stm32wbax/power.c
@@ -118,7 +118,7 @@ static void set_mode_suspend_to_ram(void)
 
 	/* Execution is restored at this point after wake up */
 	/* Restore system clock as soon as we exit standby mode */
-	sys_clock_idle_exit();
+	stm32_clock_control_standby_exit();
 }
 #endif
 

--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -280,3 +280,16 @@ const struct pm_state_info *pm_state_next_get(uint8_t cpu)
 {
 	return &z_cpus_pm_state[cpu];
 }
+
+void z_pm_save_idle_exit(void)
+{
+	/* Some CPU low power states require notification at the ISR
+	 * to allow any operations that needs to be done before kernel
+	 * switches task or processes nested interrupts.
+	 * This can be simply ignored if not required.
+	 */
+	pm_system_resume();
+#ifdef CONFIG_SYS_CLOCK_EXISTS
+	sys_clock_idle_exit();
+#endif /* CONFIG_SYS_CLOCK_EXISTS */
+}

--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -144,6 +144,11 @@ void pm_system_resume(void)
 	 * and it may schedule another thread.
 	 */
 	if (atomic_test_and_clear_bit(z_post_ops_required, id)) {
+#if defined(CONFIG_PM_DEVICE) && !defined(CONFIG_PM_DEVICE_RUNTIME_EXCLUSIVE)
+		if (atomic_add(&_cpus_active, 1) == 0) {
+			pm_resume_devices();
+		}
+#endif
 		pm_state_exit_post_ops(z_cpus_pm_state[id].state, z_cpus_pm_state[id].substate_id);
 		pm_state_notify(false);
 		z_cpus_pm_state[id] = (struct pm_state_info){PM_STATE_ACTIVE,
@@ -240,11 +245,6 @@ bool pm_system_suspend(int32_t ticks)
 	pm_stats_stop();
 
 	/* Wake up sequence starts here */
-#if defined(CONFIG_PM_DEVICE) && !defined(CONFIG_PM_DEVICE_RUNTIME_EXCLUSIVE)
-	if (atomic_add(&_cpus_active, 1) == 0) {
-		pm_resume_devices();
-	}
-#endif
 	pm_stats_update(z_cpus_pm_state[id].state);
 	pm_system_resume();
 	k_sched_unlock();

--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -151,6 +151,9 @@ void pm_system_resume(void)
 #endif
 		pm_state_exit_post_ops(z_cpus_pm_state[id].state, z_cpus_pm_state[id].substate_id);
 		pm_state_notify(false);
+#ifdef CONFIG_SYS_CLOCK_EXISTS
+		sys_clock_idle_exit();
+#endif /* CONFIG_SYS_CLOCK_EXISTS */
 		z_cpus_pm_state[id] = (struct pm_state_info){PM_STATE_ACTIVE,
 			0, 0};
 	}
@@ -289,7 +292,4 @@ void z_pm_save_idle_exit(void)
 	 * This can be simply ignored if not required.
 	 */
 	pm_system_resume();
-#ifdef CONFIG_SYS_CLOCK_EXISTS
-	sys_clock_idle_exit();
-#endif /* CONFIG_SYS_CLOCK_EXISTS */
 }


### PR DESCRIPTION
The main fix in this pr is in the wake up procedure. When the system was waking up the notification coming from the ISR was not properly restoring the system. Devices were not being restored there, this means that the ISR wouldn't be able any device that was previously suspended.

- Deprecate API with inconsistent name 
  - Promote `pm_system_resume`
- Fix system clock restoration