### PR TITLE
tests: drivers: dac: use zassert_ok

### DIFF
--- a/tests/drivers/dac/dac_api/src/test_dac.c
+++ b/tests/drivers/dac/dac_api/src/test_dac.c
@@ -118,8 +118,7 @@ static const struct device *init_dac(void)
 	zassert_true(device_is_ready(dac_dev), "DAC device is not ready");
 
 	ret = dac_channel_setup(dac_dev, &dac_ch_cfg);
-	zassert_equal(ret, 0,
-		"Setting up of the first channel failed with code %d", ret);
+	zassert_ok(ret, "Setting up of the first channel failed with code %d", ret);
 
 	return dac_dev;
 }
@@ -136,7 +135,7 @@ ZTEST(dac, test_task_write_value)
 	/* write a value of half the full scale resolution */
 	ret = dac_write_value(dac_dev, DAC_CHANNEL_ID,
 						(1U << DAC_RESOLUTION) / 2);
-	zassert_equal(ret, 0, "dac_write_value() failed with code %d", ret);
+	zassert_ok(ret, "dac_write_value() failed with code %d", ret);
 }
 
 static void *dac_setup(void)

--- a/tests/drivers/dac/dac_loopback/src/test_dac.c
+++ b/tests/drivers/dac/dac_loopback/src/test_dac.c
@@ -198,8 +198,7 @@ static const struct device *init_dac(void)
 	zassert_true(device_is_ready(dac_dev), "DAC device is not ready");
 
 	ret = dac_channel_setup(dac_dev, &dac_ch_cfg);
-	zassert_equal(ret, 0,
-		"Setting up of the first channel failed with code %d", ret);
+	zassert_ok(ret, "Setting up of the first channel failed with code %d", ret);
 
 	return dac_dev;
 }
@@ -213,8 +212,7 @@ static const struct device *init_adc(void)
 	zassert_true(device_is_ready(adc_dev), "ADC device is not ready");
 
 	ret = adc_channel_setup(adc_dev, &adc_ch_cfg);
-	zassert_equal(ret, 0,
-		"Setting up of the ADC channel failed with code %d", ret);
+	zassert_ok(ret, "Setting up of the ADC channel failed with code %d", ret);
 
 	return adc_dev;
 }
@@ -236,7 +234,7 @@ static int test_task_loopback(void)
 	/* write a value of half the full scale resolution */
 	ret = dac_write_value(dac_dev, DAC_CHANNEL_ID,
 		(1U << DAC_RESOLUTION) / 2);
-	zassert_equal(ret, 0, "dac_write_value() failed with code %d", ret);
+	zassert_ok(ret, "dac_write_value() failed with code %d", ret);
 
 	/* wait to let DAC output settle */
 	k_sleep(K_MSEC(10));
@@ -250,7 +248,7 @@ static int test_task_loopback(void)
 	};
 
 	ret = adc_read(adc_dev, &sequence);
-	zassert_equal(ret, 0, "adc_read() failed with code %d", ret);
+	zassert_ok(ret, "adc_read() failed with code %d", ret);
 	zassert_within(m_sample_buffer[0],
 		(1U << ADC_RESOLUTION) / 2, 32,
 		"Value %d read from ADC does not match expected range.",


### PR DESCRIPTION
Replace `zassert_equal` with `zassert_ok` where return value contains 0 or errno.