### PR TITLE
soc/da1469x: Take PD_SYS control only once during initialization

### DIFF
--- a/soc/renesas/smartbond/da1469x/soc.c
+++ b/soc/renesas/smartbond/da1469x/soc.c
@@ -146,9 +146,6 @@ static int renesas_da1469x_init(void)
 				CRG_TOP_PMU_CTRL_REG_COM_SLEEP_Msk     |
 				CRG_TOP_PMU_CTRL_REG_RADIO_SLEEP_Msk);
 
-	/* PDC should take care of PD_SYS */
-	CRG_TOP->PMU_CTRL_REG &= ~CRG_TOP_PMU_CTRL_REG_SYS_SLEEP_Msk;
-
 #if defined(CONFIG_PM)
 	/* Enable cache retainability */
 	CRG_TOP->PMU_CTRL_REG |= CRG_TOP_PMU_CTRL_REG_RETAIN_CACHE_Msk;
@@ -167,14 +164,18 @@ static int renesas_da1469x_init(void)
 				CRG_TOP_BOD_CTRL_REG_BOD_V30_EN_Msk    |
 				CRG_TOP_BOD_CTRL_REG_BOD_VBAT_EN_Msk);
 
-	da1469x_pdc_reset();
-
 	da1469x_otp_init();
 	da1469x_trimv_init_from_otp();
 
 	da1469x_pd_init();
+
+	/*
+	 * Take PD_SYS control.
+	 */
 	da1469x_pd_acquire(MCU_PD_DOMAIN_SYS);
 	da1469x_pd_acquire(MCU_PD_DOMAIN_TIM);
+
+	da1469x_pdc_reset();
 
 	return 0;
 }

--- a/west.yml
+++ b/west.yml
@@ -210,7 +210,7 @@ manifest:
         - hal
     - name: hal_renesas
       path: modules/hal/renesas
-      revision: 8390c9da4d76656934ea135c757ba946bccd736c
+      revision: b4fe8925d95bddc27e6d1666890f560d30cf9166
       groups:
         - hal
     - name: hal_rpi_pico


### PR DESCRIPTION
Take PD_SYS control only once during initialization