### PR TITLE
drivers: cleanup `__subsystem` tags

### DIFF
--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -106,6 +106,13 @@ Device Drivers and Devicetree
         };
     };
 
+* Some of the driver API structs have been rename to have the required ``_driver_api`` suffix.
+  The following types have been renamed:
+
+  * ``emul_sensor_backend_api`` to :c:struct:`emul_sensor_driver_api`
+  * ``emul_bbram_backend_api`` to :c:struct:`emul_bbram_driver_api`
+  * ``usbc_ppc_drv`` to :c:struct:`usbc_ppc_driver_api`
+
 Analog-to-Digital Converter (ADC)
 =================================
 

--- a/drivers/bbram/bbram_it8xxx2_emul.c
+++ b/drivers/bbram/bbram_it8xxx2_emul.c
@@ -45,7 +45,7 @@ static int it8xxx2_emul_backend_get_data(const struct emul *target, size_t offse
 	return 0;
 }
 
-static const struct emul_bbram_backend_api it8xxx2_emul_backend_api = {
+static const struct emul_bbram_driver_api it8xxx2_emul_backend_api = {
 	.set_data = it8xxx2_emul_backend_set_data,
 	.get_data = it8xxx2_emul_backend_get_data,
 };

--- a/drivers/bbram/bbram_microchip_mcp7940n_emul.c
+++ b/drivers/bbram/bbram_microchip_mcp7940n_emul.c
@@ -135,7 +135,7 @@ static int mcp7940n_emul_backend_get_data(const struct emul *target, size_t offs
 	return 0;
 }
 
-static const struct emul_bbram_backend_api mcp7940n_emul_backend_api = {
+static const struct emul_bbram_driver_api mcp7940n_emul_backend_api = {
 	.set_data = mcp7940n_emul_backend_set_data,
 	.get_data = mcp7940n_emul_backend_get_data,
 };

--- a/drivers/bbram/bbram_npcx_emul.c
+++ b/drivers/bbram/bbram_npcx_emul.c
@@ -45,7 +45,7 @@ static int npcx_emul_backend_get_data(const struct emul *target, size_t offset, 
 	return 0;
 }
 
-static const struct emul_bbram_backend_api npcx_emul_backend_api = {
+static const struct emul_bbram_driver_api npcx_emul_backend_api = {
 	.set_data = npcx_emul_backend_set_data,
 	.get_data = npcx_emul_backend_get_data,
 };

--- a/drivers/sensor/amd_sb_tsi/sb_tsi_emul.c
+++ b/drivers/sensor/amd_sb_tsi/sb_tsi_emul.c
@@ -140,7 +140,7 @@ static const struct i2c_emul_api sb_tsi_emul_api_i2c = {
 	.transfer = sb_tsi_emul_transfer_i2c,
 };
 
-static const struct emul_sensor_backend_api sb_tsi_emul_api_sensor = {
+static const struct emul_sensor_driver_api sb_tsi_emul_api_sensor = {
 	.set_channel = sb_tsi_emul_set_channel,
 	.get_sample_range = sb_tsi_emul_get_sample_range,
 };

--- a/drivers/sensor/asahi_kasei/akm09918c/akm09918c_emul.c
+++ b/drivers/sensor/asahi_kasei/akm09918c/akm09918c_emul.c
@@ -208,7 +208,7 @@ static const struct i2c_emul_api akm09918c_emul_api_i2c = {
 	.transfer = akm09918c_emul_transfer_i2c,
 };
 
-static const struct emul_sensor_backend_api akm09918c_emul_sensor_backend_api = {
+static const struct emul_sensor_driver_api akm09918c_emul_sensor_driver_api = {
 	.set_channel = akm09918c_emul_backend_set_channel,
 	.get_sample_range = akm09918c_emul_backend_get_sample_range,
 };
@@ -218,6 +218,6 @@ static const struct emul_sensor_backend_api akm09918c_emul_sensor_backend_api = 
 	struct akm09918c_emul_data akm09918c_emul_data_##n;                                        \
 	EMUL_DT_INST_DEFINE(n, akm09918c_emul_init, &akm09918c_emul_data_##n,                      \
 			    &akm09918c_emul_cfg_##n, &akm09918c_emul_api_i2c,                      \
-			    &akm09918c_emul_sensor_backend_api)
+			    &akm09918c_emul_sensor_driver_api)
 
 DT_INST_FOREACH_STATUS_OKAY(AKM09918C_EMUL)

--- a/drivers/sensor/bosch/bma4xx/bma4xx_emul.c
+++ b/drivers/sensor/bosch/bma4xx/bma4xx_emul.c
@@ -306,7 +306,7 @@ static int bma4xx_emul_backend_get_sample_range(const struct emul *target, enum 
 	return 0;
 }
 
-static const struct emul_sensor_backend_api bma4xx_emul_sensor_backend_api = {
+static const struct emul_sensor_driver_api bma4xx_emul_sensor_driver_api = {
 	.set_channel = bma4xx_emul_backend_set_channel,
 	.get_sample_range = bma4xx_emul_backend_get_sample_range,
 };
@@ -319,6 +319,6 @@ static struct i2c_emul_api bma4xx_emul_api_i2c = {
 	static struct bma4xx_emul_data bma4xx_emul_data_##n = {};                                  \
 	static const struct bma4xx_emul_cfg bma4xx_emul_cfg_##n = {};                              \
 	EMUL_DT_INST_DEFINE(n, bma4xx_emul_init, &bma4xx_emul_data_##n, &bma4xx_emul_cfg_##n,      \
-			    &bma4xx_emul_api_i2c, &bma4xx_emul_sensor_backend_api);
+			    &bma4xx_emul_api_i2c, &bma4xx_emul_sensor_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(INIT_BMA4XX)

--- a/drivers/sensor/bosch/bmi160/emul_bmi160.c
+++ b/drivers/sensor/bosch/bmi160/emul_bmi160.c
@@ -569,7 +569,7 @@ static int bmi160_emul_backend_get_attribute_metadata(const struct emul *target,
 	}
 }
 
-static const struct emul_sensor_backend_api backend_api = {
+static const struct emul_sensor_driver_api backend_api = {
 	.set_channel = bmi160_emul_backend_set_channel,
 	.get_sample_range = bmi160_emul_backend_get_sample_range,
 	.set_attribute = bmi160_emul_backend_set_attribute,

--- a/drivers/sensor/f75303/f75303_emul.c
+++ b/drivers/sensor/f75303/f75303_emul.c
@@ -160,7 +160,7 @@ static const struct i2c_emul_api f75303_emul_api_i2c = {
 	.transfer = f75303_emul_transfer_i2c,
 };
 
-static const struct emul_sensor_backend_api f75303_emul_api_sensor = {
+static const struct emul_sensor_driver_api f75303_emul_api_sensor = {
 	.set_channel = f75303_emul_set_channel,
 	.get_sample_range = f75303_emul_get_sample_range,
 };

--- a/drivers/sensor/tdk/icm42688/icm42688_emul.c
+++ b/drivers/sensor/tdk/icm42688/icm42688_emul.c
@@ -402,14 +402,14 @@ static int icm42688_emul_backend_set_channel(const struct emul *target, enum sen
 	return 0;
 }
 
-static const struct emul_sensor_backend_api icm42688_emul_sensor_backend_api = {
+static const struct emul_sensor_driver_api icm42688_emul_sensor_driver_api = {
 	.set_channel = icm42688_emul_backend_set_channel,
 	.get_sample_range = icm42688_emul_backend_get_sample_range,
 };
 
 #define ICM42688_EMUL_DEFINE(n, api)                                                               \
 	EMUL_DT_INST_DEFINE(n, icm42688_emul_init, &icm42688_emul_data_##n,                        \
-			    &icm42688_emul_cfg_##n, &api, &icm42688_emul_sensor_backend_api)
+			    &icm42688_emul_cfg_##n, &api, &icm42688_emul_sensor_driver_api)
 
 #define ICM42688_EMUL_SPI(n)                                                                       \
 	static struct icm42688_emul_data icm42688_emul_data_##n;                                   \

--- a/drivers/usb_c/ppc/nxp_nx20p3483.c
+++ b/drivers/usb_c/ppc/nxp_nx20p3483.c
@@ -229,7 +229,7 @@ static int nx20p3483_dump_regs(const struct device *dev)
 	return 0;
 }
 
-static struct usbc_ppc_drv nx20p3483_driver_api = {
+static struct usbc_ppc_driver_api nx20p3483_driver_api = {
 	.is_dead_battery_mode = nx20p3483_is_dead_battery_mode,
 	.exit_dead_battery_mode = nx20p3483_exit_dead_battery_mode,
 	.is_vbus_source = nx20p3483_is_vbus_source,

--- a/include/zephyr/drivers/clock_control.h
+++ b/include/zephyr/drivers/clock_control.h
@@ -99,7 +99,7 @@ typedef int (*clock_control_configure_fn)(const struct device *dev,
 					  clock_control_subsys_t sys,
 					  void *data);
 
-struct clock_control_driver_api {
+__subsystem struct clock_control_driver_api {
 	clock_control			on;
 	clock_control			off;
 	clock_control_async_on_fn	async_on;

--- a/include/zephyr/drivers/display.h
+++ b/include/zephyr/drivers/display.h
@@ -217,7 +217,7 @@ typedef int (*display_set_orientation_api)(const struct device *dev,
  * @brief Display driver API
  * API which a display driver should expose
  */
-struct display_driver_api {
+__subsystem struct display_driver_api {
 	display_blanking_on_api blanking_on;
 	display_blanking_off_api blanking_off;
 	display_write_api write;

--- a/include/zephyr/drivers/emul_bbram.h
+++ b/include/zephyr/drivers/emul_bbram.h
@@ -23,7 +23,7 @@
  * These are for internal use only, so skip these in public documentation.
  */
 
-__subsystem struct emul_bbram_backend_api {
+__subsystem struct emul_bbram_driver_api {
 	/** Sets the data */
 	int (*set_data)(const struct emul *target, size_t offset, size_t count,
 			const uint8_t *data);
@@ -53,7 +53,7 @@ static inline int emul_bbram_backend_set_data(const struct emul *target, size_t 
 		return -ENOTSUP;
 	}
 
-	struct emul_bbram_backend_api *api = (struct emul_bbram_backend_api *)target->backend_api;
+	struct emul_bbram_driver_api *api = (struct emul_bbram_driver_api *)target->backend_api;
 
 	if (api->set_data == NULL) {
 		return -ENOTSUP;
@@ -80,7 +80,7 @@ static inline int emul_bbram_backend_get_data(const struct emul *target, size_t 
 		return -ENOTSUP;
 	}
 
-	struct emul_bbram_backend_api *api = (struct emul_bbram_backend_api *)target->backend_api;
+	struct emul_bbram_driver_api *api = (struct emul_bbram_driver_api *)target->backend_api;
 
 	if (api->get_data == NULL) {
 		return -ENOTSUP;

--- a/include/zephyr/drivers/emul_sensor.h
+++ b/include/zephyr/drivers/emul_sensor.h
@@ -25,7 +25,7 @@
 /**
  * @brief Collection of function pointers implementing a common backend API for sensor emulators
  */
-__subsystem struct emul_sensor_backend_api {
+__subsystem struct emul_sensor_driver_api {
 	/** Sets a given fractional value for a given sensor channel. */
 	int (*set_channel)(const struct emul *target, enum sensor_channel ch, const q31_t *value,
 			   int8_t shift);
@@ -75,7 +75,7 @@ static inline int emul_sensor_backend_set_channel(const struct emul *target, enu
 		return -ENOTSUP;
 	}
 
-	struct emul_sensor_backend_api *api = (struct emul_sensor_backend_api *)target->backend_api;
+	struct emul_sensor_driver_api *api = (struct emul_sensor_driver_api *)target->backend_api;
 
 	if (api->set_channel) {
 		return api->set_channel(target, ch, value, shift);
@@ -108,7 +108,7 @@ static inline int emul_sensor_backend_get_sample_range(const struct emul *target
 		return -ENOTSUP;
 	}
 
-	struct emul_sensor_backend_api *api = (struct emul_sensor_backend_api *)target->backend_api;
+	struct emul_sensor_driver_api *api = (struct emul_sensor_driver_api *)target->backend_api;
 
 	if (api->get_sample_range) {
 		return api->get_sample_range(target, ch, lower, upper, epsilon, shift);
@@ -135,7 +135,7 @@ static inline int emul_sensor_backend_set_attribute(const struct emul *target,
 		return -ENOTSUP;
 	}
 
-	struct emul_sensor_backend_api *api = (struct emul_sensor_backend_api *)target->backend_api;
+	struct emul_sensor_driver_api *api = (struct emul_sensor_driver_api *)target->backend_api;
 
 	if (api->set_attribute == NULL) {
 		return -ENOTSUP;
@@ -170,7 +170,7 @@ static inline int emul_sensor_backend_get_attribute_metadata(const struct emul *
 		return -ENOTSUP;
 	}
 
-	struct emul_sensor_backend_api *api = (struct emul_sensor_backend_api *)target->backend_api;
+	struct emul_sensor_driver_api *api = (struct emul_sensor_driver_api *)target->backend_api;
 
 	if (api->get_attribute_metadata == NULL) {
 		return -ENOTSUP;

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -259,7 +259,7 @@ __subsystem struct i2c_driver_api {
 typedef int (*i2c_target_api_register_t)(const struct device *dev);
 typedef int (*i2c_target_api_unregister_t)(const struct device *dev);
 
-struct i2c_target_driver_api {
+__subsystem struct i2c_target_driver_api {
 	i2c_target_api_register_t driver_register;
 	i2c_target_api_unregister_t driver_unregister;
 };

--- a/include/zephyr/drivers/i3c/target_device.h
+++ b/include/zephyr/drivers/i3c/target_device.h
@@ -211,7 +211,7 @@ struct i3c_target_callbacks {
 	int (*stop_cb)(struct i3c_target_config *config);
 };
 
-struct i3c_target_driver_api {
+__subsystem struct i3c_target_driver_api {
 	int (*driver_register)(const struct device *dev);
 	int (*driver_unregister)(const struct device *dev);
 };

--- a/include/zephyr/drivers/interrupt_controller/intel_vtd.h
+++ b/include/zephyr/drivers/interrupt_controller/intel_vtd.h
@@ -45,7 +45,7 @@ typedef void (*vtd_set_irte_msi_f)(const struct device *dev,
 typedef bool (*vtd_irte_is_msi_f)(const struct device *dev,
 				  uint8_t irte_idx);
 
-struct vtd_driver_api {
+__subsystem struct vtd_driver_api {
 	vtd_alloc_entries_f allocate_entries;
 	vtd_remap_msi_f remap_msi;
 	vtd_remap_f remap;

--- a/include/zephyr/drivers/led_strip.h
+++ b/include/zephyr/drivers/led_strip.h
@@ -76,7 +76,7 @@ typedef int (*led_api_update_channels)(const struct device *dev,
  *
  * This is the mandatory API any LED strip driver needs to expose.
  */
-struct led_strip_driver_api {
+__subsystem struct led_strip_driver_api {
 	led_api_update_rgb update_rgb;
 	led_api_update_channels update_channels;
 };

--- a/include/zephyr/drivers/lora.h
+++ b/include/zephyr/drivers/lora.h
@@ -179,7 +179,7 @@ typedef int (*lora_api_recv_async)(const struct device *dev, lora_recv_cb cb);
 typedef int (*lora_api_test_cw)(const struct device *dev, uint32_t frequency,
 				int8_t tx_power, uint16_t duration);
 
-struct lora_driver_api {
+__subsystem struct lora_driver_api {
 	lora_api_config config;
 	lora_api_send send;
 	lora_api_send_async send_async;

--- a/include/zephyr/drivers/pcie/endpoint/pcie_ep.h
+++ b/include/zephyr/drivers/pcie/endpoint/pcie_ep.h
@@ -56,7 +56,7 @@ enum pcie_reset {
 
 typedef void (*pcie_ep_reset_callback_t)(void *arg);
 
-struct pcie_ep_driver_api {
+__subsystem struct pcie_ep_driver_api {
 	int (*conf_read)(const struct device *dev, uint32_t offset,
 			 uint32_t *data);
 	void (*conf_write)(const struct device *dev, uint32_t offset,

--- a/include/zephyr/drivers/usb_c/usbc_ppc.h
+++ b/include/zephyr/drivers/usb_c/usbc_ppc.h
@@ -50,7 +50,7 @@ enum usbc_ppc_event {
 typedef void (*usbc_ppc_event_cb_t)(const struct device *dev, void *data, enum usbc_ppc_event ev);
 
 /** Structure with pointers to the functions implemented by driver */
-__subsystem struct usbc_ppc_drv {
+__subsystem struct usbc_ppc_driver_api {
 	int (*is_dead_battery_mode)(const struct device *dev);
 	int (*exit_dead_battery_mode)(const struct device *dev);
 	int (*is_vbus_source)(const struct device *dev);
@@ -78,7 +78,7 @@ __subsystem struct usbc_ppc_drv {
  */
 static inline int ppc_is_dead_battery_mode(const struct device *dev)
 {
-	const struct usbc_ppc_drv *api = (const struct usbc_ppc_drv *)dev->api;
+	const struct usbc_ppc_driver_api *api = (const struct usbc_ppc_driver_api *)dev->api;
 
 	if (api->is_dead_battery_mode == NULL) {
 		return -ENOSYS;
@@ -101,7 +101,7 @@ static inline int ppc_is_dead_battery_mode(const struct device *dev)
  */
 static inline int ppc_exit_dead_battery_mode(const struct device *dev)
 {
-	const struct usbc_ppc_drv *api = (const struct usbc_ppc_drv *)dev->api;
+	const struct usbc_ppc_driver_api *api = (const struct usbc_ppc_driver_api *)dev->api;
 
 	if (api->exit_dead_battery_mode == NULL) {
 		return -ENOSYS;
@@ -121,7 +121,7 @@ static inline int ppc_exit_dead_battery_mode(const struct device *dev)
  */
 static inline int ppc_is_vbus_source(const struct device *dev)
 {
-	const struct usbc_ppc_drv *api = (const struct usbc_ppc_drv *)dev->api;
+	const struct usbc_ppc_driver_api *api = (const struct usbc_ppc_driver_api *)dev->api;
 
 	if (api->is_vbus_source == NULL) {
 		return -ENOSYS;
@@ -141,7 +141,7 @@ static inline int ppc_is_vbus_source(const struct device *dev)
  */
 static inline int ppc_is_vbus_sink(const struct device *dev)
 {
-	const struct usbc_ppc_drv *api = (const struct usbc_ppc_drv *)dev->api;
+	const struct usbc_ppc_driver_api *api = (const struct usbc_ppc_driver_api *)dev->api;
 
 	if (api->is_vbus_sink == NULL) {
 		return -ENOSYS;
@@ -161,7 +161,7 @@ static inline int ppc_is_vbus_sink(const struct device *dev)
  */
 static inline int ppc_set_snk_ctrl(const struct device *dev, bool enable)
 {
-	const struct usbc_ppc_drv *api = (const struct usbc_ppc_drv *)dev->api;
+	const struct usbc_ppc_driver_api *api = (const struct usbc_ppc_driver_api *)dev->api;
 
 	if (api->set_snk_ctrl == NULL) {
 		return -ENOSYS;
@@ -181,7 +181,7 @@ static inline int ppc_set_snk_ctrl(const struct device *dev, bool enable)
  */
 static inline int ppc_set_src_ctrl(const struct device *dev, bool enable)
 {
-	const struct usbc_ppc_drv *api = (const struct usbc_ppc_drv *)dev->api;
+	const struct usbc_ppc_driver_api *api = (const struct usbc_ppc_driver_api *)dev->api;
 
 	if (api->set_src_ctrl == NULL) {
 		return -ENOSYS;
@@ -201,7 +201,7 @@ static inline int ppc_set_src_ctrl(const struct device *dev, bool enable)
  */
 static inline int ppc_set_vbus_discharge(const struct device *dev, bool enable)
 {
-	const struct usbc_ppc_drv *api = (const struct usbc_ppc_drv *)dev->api;
+	const struct usbc_ppc_driver_api *api = (const struct usbc_ppc_driver_api *)dev->api;
 
 	if (api->set_vbus_discharge == NULL) {
 		return -ENOSYS;
@@ -221,7 +221,7 @@ static inline int ppc_set_vbus_discharge(const struct device *dev, bool enable)
  */
 static inline int ppc_is_vbus_present(const struct device *dev)
 {
-	const struct usbc_ppc_drv *api = (const struct usbc_ppc_drv *)dev->api;
+	const struct usbc_ppc_driver_api *api = (const struct usbc_ppc_driver_api *)dev->api;
 
 	if (api->is_vbus_present == NULL) {
 		return -ENOSYS;
@@ -242,7 +242,7 @@ static inline int ppc_is_vbus_present(const struct device *dev)
 static inline int ppc_set_event_handler(const struct device *dev,
 	usbc_ppc_event_cb_t handler, void *data)
 {
-	const struct usbc_ppc_drv *api = (const struct usbc_ppc_drv *)dev->api;
+	const struct usbc_ppc_driver_api *api = (const struct usbc_ppc_driver_api *)dev->api;
 
 	if (api->set_event_handler == NULL) {
 		return -ENOSYS;
@@ -261,7 +261,7 @@ static inline int ppc_set_event_handler(const struct device *dev,
  */
 static inline int ppc_dump_regs(const struct device *dev)
 {
-	const struct usbc_ppc_drv *api = (const struct usbc_ppc_drv *)dev->api;
+	const struct usbc_ppc_driver_api *api = (const struct usbc_ppc_driver_api *)dev->api;
 
 	if (api->dump_regs == NULL) {
 		return -ENOSYS;

--- a/include/zephyr/drivers/usb_c/usbc_vbus.h
+++ b/include/zephyr/drivers/usb_c/usbc_vbus.h
@@ -32,7 +32,7 @@
 extern "C" {
 #endif
 
-struct usbc_vbus_driver_api {
+__subsystem struct usbc_vbus_driver_api {
 	bool (*check_level)(const struct device *dev, enum tc_vbus_level level);
 	int (*measure)(const struct device *dev, int *vbus_meas);
 	int (*discharge)(const struct device *dev, bool enable);

--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -249,7 +249,7 @@ typedef int (*video_api_set_signal_t)(const struct device *dev,
 				      enum video_endpoint_id ep,
 				      struct k_poll_signal *signal);
 
-struct video_driver_api {
+__subsystem struct video_driver_api {
 	/* mandatory callbacks */
 	video_api_set_format_t set_format;
 	video_api_get_format_t get_format;

--- a/include/zephyr/mgmt/ec_host_cmd/backend.h
+++ b/include/zephyr/mgmt/ec_host_cmd/backend.h
@@ -103,7 +103,7 @@ typedef int (*ec_host_cmd_backend_api_init)(const struct ec_host_cmd_backend *ba
  */
 typedef int (*ec_host_cmd_backend_api_send)(const struct ec_host_cmd_backend *backend);
 
-__subsystem struct ec_host_cmd_backend_api {
+struct ec_host_cmd_backend_api {
 	ec_host_cmd_backend_api_init init;
 	ec_host_cmd_backend_api_send send;
 };

--- a/include/zephyr/shared_irq.h
+++ b/include/zephyr/shared_irq.h
@@ -9,6 +9,7 @@
 #ifndef ZEPHYR_INCLUDE_SHARED_IRQ_H_
 #define ZEPHYR_INCLUDE_SHARED_IRQ_H_
 
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -25,7 +26,7 @@ typedef int (*shared_irq_enable_t)(const struct device *dev,
 typedef int (*shared_irq_disable_t)(const struct device *dev,
 				    const struct device *isr_dev);
 
-struct shared_irq_driver_api {
+__subsystem struct shared_irq_driver_api {
 	shared_irq_register_t isr_register;
 	shared_irq_enable_t enable;
 	shared_irq_disable_t disable;

--- a/scripts/build/gen_kobject_list.py
+++ b/scripts/build/gen_kobject_list.py
@@ -138,6 +138,9 @@ subsystems = [
 net_sockets = [ ]
 
 def subsystem_to_enum(subsys):
+    if not subsys.endswith("_driver_api"):
+        raise Exception("__subsystem is missing _driver_api suffix: (%s)" % subsys)
+
     return "K_OBJ_DRIVER_" + subsys[:-11].upper()
 
 # --- debug stuff ---


### PR DESCRIPTION
In preparation of #71773 all drivers API structs should have a `__subsystem` tag. 
Additionally all `__subsystem` API structs are required to have a `_driver_api` suffix.

Fixes #72009