### PR TITLE
drivers: display: improve documentation for using PXP with eLCDIF

### DIFF
--- a/boards/nxp/mimxrt1050_evk/Kconfig.defconfig
+++ b/boards/nxp/mimxrt1050_evk/Kconfig.defconfig
@@ -37,11 +37,32 @@ endif # NETWORKING
 
 if LVGL
 
+# LVGL should allocate buffers equal to size of display
 config LV_Z_VDB_SIZE
-	default 16
+	default 100
+
+# Enable double buffering
+config LV_Z_DOUBLE_VDB
+	default y
+
+# Force full refresh. This prevents memory copy associated with partial
+# display refreshes, which is not necessary for the eLCDIF driver
+config LV_Z_FULL_REFRESH
+	default y
 
 config LV_DPI_DEF
 	default 128
+
+config LV_Z_BITS_PER_PIXEL
+	default 16
+
+# Force display buffers to be aligned to cache line size (32 bytes)
+config LV_Z_VDB_ALIGN
+	default 32
+
+# Use offloaded render thread
+config LV_Z_FLUSH_THREAD
+	default y
 
 choice LV_COLOR_DEPTH
 	default LV_COLOR_DEPTH_16

--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -249,6 +249,10 @@ zephyr_udc0: &usb1 {
 	status = "okay";
 };
 
+&pxp {
+	status = "okay";
+};
+
 /* GPT and Systick are enabled. If power management is enabled, the GPT
  * timer will be used instead of systick, as allows the core clock to
  * be gated.

--- a/drivers/display/Kconfig.mcux_elcdif
+++ b/drivers/display/Kconfig.mcux_elcdif
@@ -60,8 +60,13 @@ choice MCUX_ELCDIF_PXP_ROTATE_DIRECTION
 	prompt "Rotation angle of PXP"
 	help
 	  Set rotation angle of PXP. The ELCDIF cannot detect the correct
-	  rotation angle based on the call to display_write, so the user
-	  should configure it here.
+	  rotation angle based on the call to display_write, so the user should
+	  configure it here. In order for PXP rotation to work, calls to
+	  display_write MUST supply a framebuffer equal in size to screen width
+	  and height (without rotation applied).  Note that the width and
+	  height settings of the screen in devicetree should not be modified
+	  from their values in the default screen orientation when using this
+	  functionality.
 
 config MCUX_ELCDIF_PXP_ROTATE_0
 	bool "Rotate display by 0 degrees"
@@ -72,17 +77,19 @@ config MCUX_ELCDIF_PXP_ROTATE_0
 config MCUX_ELCDIF_PXP_ROTATE_90
 	bool "Rotate display by 90 degrees"
 	help
-	  Rotate display clockwise by 90 degrees
+	  Rotate display counter-clockwise by 90 degrees.
+	  For LVGL, this corresponds to a rotation of 270 degrees
 
 config MCUX_ELCDIF_PXP_ROTATE_180
 	bool "Rotate display by 180 degrees"
 	help
-	  Rotate display clockwise by 180 degrees
+	  Rotate display counter-clockwise by 180 degrees
 
 config MCUX_ELCDIF_PXP_ROTATE_270
 	bool "Rotate display by 270 degrees"
 	help
-	  Rotate display clockwise by 270 degrees
+	  Rotate display counter-clockwise by 270 degrees
+	  For LVGL, this corresponds to a rotation of 90 degrees
 
 endchoice
 

--- a/drivers/display/display_mcux_elcdif.c
+++ b/drivers/display/display_mcux_elcdif.c
@@ -190,6 +190,9 @@ static int mcux_elcdif_write(const struct device *dev, const uint16_t x, const u
 			return ret;
 		}
 		k_sem_take(&dev_data->pxp_done, K_FOREVER);
+	} else {
+		LOG_WRN("PXP rotation will not work correctly unless a full sized "
+			"framebuffer is provided");
 	}
 #endif /* CONFIG_MCUX_ELCDIF_PXP */
 


### PR DESCRIPTION
Improve documentation for using PXP with eLCDIF for rotation. Also, apply optimized LVGL settings for PXP support on the RT1050 EVK and enable support for the PXP on that board