### PR TITLE
doc: Create CVE-2024 section in vulnerabilities page

### DIFF
--- a/doc/security/vulnerabilities.rst
+++ b/doc/security/vulnerabilities.rst
@@ -1687,6 +1687,9 @@ This has been fixed in main for v3.6.0
 - `PR 66887 fix for 2.7
   <https://github.com/zephyrproject-rtos/zephyr/pull/66887>`_
 
+CVE-2024
+========
+
 CVE-2024-1638
 -------------
 


### PR DESCRIPTION
Just a small fix to create a subheading for the 2024 CVEs