### PR TITLE
drivers: flash: flash_mcux_flexspi_nor: better handle legacy SFDP tables

### DIFF
--- a/drivers/flash/flash_mcux_flexspi_nor.c
+++ b/drivers/flash/flash_mcux_flexspi_nor.c
@@ -718,22 +718,23 @@ static int flash_flexspi_nor_config_flash(struct flash_flexspi_nor_data *data,
 
 	/* Check to see if we can enable 4 byte addressing */
 	ret = jesd216_bfp_decode_dw16(&header->phdr[0], bfp, &dw16);
-	if (ret < 0) {
-		return ret;
-	}
-
-	/* Attempt to enable 4 byte addressing */
-	ret = flash_flexspi_nor_4byte_enable(data, flexspi_lut, dw16.enter_4ba);
 	if (ret == 0) {
-		/* Use 4 byte address width */
-		addr_width = 32;
-		/* Update LUT for ERASE_SECTOR and ERASE_BLOCK to use 32 bit addr */
-		flexspi_lut[ERASE_SECTOR][0] = FLEXSPI_LUT_SEQ(
-				kFLEXSPI_Command_SDR, kFLEXSPI_1PAD, SPI_NOR_CMD_SE,
-				kFLEXSPI_Command_RADDR_SDR, kFLEXSPI_1PAD, addr_width);
-		flexspi_lut[ERASE_BLOCK][0] = FLEXSPI_LUT_SEQ(
-				kFLEXSPI_Command_SDR, kFLEXSPI_1PAD, SPI_NOR_CMD_BE,
-				kFLEXSPI_Command_RADDR_SDR, kFLEXSPI_1PAD, addr_width);
+		/* Attempt to enable 4 byte addressing */
+		ret = flash_flexspi_nor_4byte_enable(data, flexspi_lut,
+						     dw16.enter_4ba);
+		if (ret == 0) {
+			/* Use 4 byte address width */
+			addr_width = 32;
+			/* Update LUT for ERASE_SECTOR and ERASE_BLOCK to use 32 bit addr */
+			flexspi_lut[ERASE_SECTOR][0] = FLEXSPI_LUT_SEQ(
+					kFLEXSPI_Command_SDR, kFLEXSPI_1PAD,
+					SPI_NOR_CMD_SE, kFLEXSPI_Command_RADDR_SDR,
+					kFLEXSPI_1PAD, addr_width);
+			flexspi_lut[ERASE_BLOCK][0] = FLEXSPI_LUT_SEQ(
+					kFLEXSPI_Command_SDR, kFLEXSPI_1PAD,
+					SPI_NOR_CMD_BE, kFLEXSPI_Command_RADDR_SDR,
+					kFLEXSPI_1PAD, addr_width);
+		}
 	}
 	/* Extract the read command.
 	 * Note- enhanced XIP not currently supported, nor is 4-4-4 mode.
@@ -764,20 +765,21 @@ static int flash_flexspi_nor_config_flash(struct flash_flexspi_nor_data *data,
 				kFLEXSPI_Command_STOP, kFLEXSPI_1PAD, 0x0);
 		/* Read 1S-4S-4S enable method */
 		ret = jesd216_bfp_decode_dw15(&header->phdr[0], bfp, &dw15);
-		if (ret < 0) {
-			return ret;
+		if (ret == 0) {
+			ret = flash_flexspi_nor_quad_enable(data, flexspi_lut,
+							    dw15.qer);
+			if (ret == 0) {
+				/* Now, install 1S-1S-4S page program command */
+				flexspi_lut[PAGE_PROGRAM][0] = FLEXSPI_LUT_SEQ(
+						kFLEXSPI_Command_SDR, kFLEXSPI_1PAD,
+						SPI_NOR_CMD_PP_1_1_4, kFLEXSPI_Command_RADDR_SDR,
+						kFLEXSPI_1PAD, addr_width);
+				flexspi_lut[PAGE_PROGRAM][1] = FLEXSPI_LUT_SEQ(
+						kFLEXSPI_Command_WRITE_SDR, kFLEXSPI_4PAD,
+						0x4, kFLEXSPI_Command_STOP,
+						kFLEXSPI_1PAD, 0x0);
+			}
 		}
-		ret = flash_flexspi_nor_quad_enable(data, flexspi_lut, dw15.qer);
-		if (ret < 0) {
-			return ret;
-		}
-		/* Now, install 1S-1S-4S page program command */
-		flexspi_lut[PAGE_PROGRAM][0] = FLEXSPI_LUT_SEQ(
-				kFLEXSPI_Command_SDR, kFLEXSPI_1PAD, SPI_NOR_CMD_PP_1_1_4,
-				kFLEXSPI_Command_RADDR_SDR, kFLEXSPI_1PAD, addr_width);
-		flexspi_lut[PAGE_PROGRAM][1] = FLEXSPI_LUT_SEQ(
-				kFLEXSPI_Command_WRITE_SDR, kFLEXSPI_4PAD, 0x4,
-				kFLEXSPI_Command_STOP, kFLEXSPI_1PAD, 0x0);
 
 	} else if (jesd216_bfp_read_support(&header->phdr[0], bfp,
 	    JESD216_MODE_122, &instr) > 0) {
@@ -817,7 +819,8 @@ static int flash_flexspi_nor_config_flash(struct flash_flexspi_nor_data *data,
 	/* Now, read DW14 to determine the polling method we should use while programming */
 	ret = jesd216_bfp_decode_dw14(&header->phdr[0], bfp, &dw14);
 	if (ret < 0) {
-		return ret;
+		/* Default to legacy polling mode */
+		dw14.poll_options = 0x0;
 	}
 	if (dw14.poll_options & BIT(1)) {
 		/* Read instruction used for polling is 0x70 */


### PR DESCRIPTION
Implement more robust handling for legacy SFDP tables, which may not implement some of the JEDEC defined DWORDS for SFDP data. Instead of failing to probe/initialize the flash when these DWORDS are not defined in the basic flash parameter table, revert to sane defaults for SPI flash.

Fixes #72051

This change was verified on the the following EVKs:
- RT1015 EVK (AT25SF128A QSPI flash)
- RT1060 EVKB (IS25WP064 QSPI flash)
- RT1040 EVK (W25Q64JV QSPI flash)