### PR TITLE
drivers: ncp5623: check led_info for all LEDs

### DIFF
--- a/drivers/led/ncp5623.c
+++ b/drivers/led/ncp5623.c
@@ -156,7 +156,7 @@ static int ncp5623_led_init(const struct device *dev)
 		}
 	} else if (config->num_leds <= 3) { /* three single-channel LEDs */
 		for (i = 0; i < config->num_leds; i++) {
-			led_info = ncp5623_led_to_info(config, 0);
+			led_info = ncp5623_led_to_info(config, i);
 
 			if (!led_info) {
 				return -ENODEV;


### PR DESCRIPTION
With the current code, when three separate monochrome LEDs are defined in DT, only the information from the first LED is checked during driver initialization. This patch fixes the code to verify the information of each LED.