### PR TITLE
device.h: fix unbalanced initializer:  ({ .pm_base = (pm_),)}

### DIFF
--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -934,7 +934,7 @@ __syscall int device_init(const struct device *dev);
 		.state = (state_),                                             \
 		.data = (data_),                                               \
 		IF_ENABLED(CONFIG_DEVICE_DEPS, (.deps = (deps_),)) /**/        \
-		IF_ENABLED(CONFIG_PM_DEVICE, ({ .pm_base = (pm_),)}) /**/         \
+		IF_ENABLED(CONFIG_PM_DEVICE, ({ .pm_base = (pm_),})) /**/         \
 	}
 
 /**


### PR DESCRIPTION
Close parentheses and braces in the reverse order they are opened.

Fixes commit f91d4731af4e ("pm: use braces for .pm_base inside anonymous union initializer")

I have no idea how no compiler caught this!?

I tested very carefully with two different gcc versions and one clang version and generated binaries are strictly identical before and after this commit. Fix the code anyway because C macros are painful enough to debug already, so no need to add more confusion.