### PR TITLE
tests/lib/cpp/cxx/: extend .h coverage to CONFIG_PM and basic device tree

### DIFF
--- a/include/zephyr/pm/device.h
+++ b/include/zephyr/pm/device.h
@@ -242,9 +242,9 @@ BUILD_ASSERT(offsetof(struct pm_device_isr, base) == 0);
  */
 #define Z_PM_DEVICE_BASE_INIT(obj, node_id, pm_action_cb, _flags)	     \
 	{								     \
-		.action_cb = pm_action_cb,				     \
-		.state = PM_DEVICE_STATE_ACTIVE,			     \
 		.flags = ATOMIC_INIT(Z_PM_DEVICE_FLAGS(node_id) | (_flags)), \
+		.state = PM_DEVICE_STATE_ACTIVE,			     \
+		.action_cb = pm_action_cb,				     \
 		Z_PM_DEVICE_POWER_DOMAIN_INIT(node_id)			     \
 	}
 

--- a/tests/lib/cpp/cxx/app.overlay
+++ b/tests/lib/cpp/cxx/app.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ * Copyright (c) 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Application overlay for creating a fake device instance we can use to
+ * test. Tiny subset of tests/kernel/device/app.overlay.
+ */
+
+/ {
+	fakedomain_0: fakedomain_0 {
+		compatible = "fakedomain";
+		status = "okay";
+	};
+};

--- a/tests/lib/cpp/cxx/prj.conf
+++ b/tests/lib/cpp/cxx/prj.conf
@@ -5,8 +5,18 @@ CONFIG_ZTEST_STACK_SIZE=2048
 CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=128
 CONFIG_CRC=y
 
+# Enable optional features that are off by default to cover as much as
+# possible of the same .h files. Unused macros will still lack coverage
+# but short of "randconfig" combinatorial explosion, the more the C++
+# compiler can see and the better.
+
 # RTIO
 CONFIG_RTIO=y
 CONFIG_RTIO_SUBMIT_SEM=y
 CONFIG_RTIO_CONSUME_SEM=y
 CONFIG_RTIO_SYS_MEM_BLOCKS=y
+
+# PM
+CONFIG_PM=y
+CONFIG_PM_DEVICE=y
+CONFIG_PM_DEVICE_RUNTIME=y

--- a/tests/lib/cpp/cxx/src/main.cpp
+++ b/tests/lib/cpp/cxx/src/main.cpp
@@ -136,3 +136,11 @@ ZTEST(cxx_tests, test_new_delete)
 	delete test_foo;
 }
 ZTEST_SUITE(cxx_tests, NULL, NULL, NULL, NULL, NULL);
+
+/*
+ * Unused macros are parsed but not really compiled. Even with all the
+ * NULL arguments this line adds a lot of additional coverage.
+ *
+ * DEVICE_DEFINE(dev_id, name, * init_fn, pm, data, config, level, prio, api)
+ */
+DEVICE_DT_DEFINE(DT_NODELABEL(fakedomain_0), NULL, NULL, NULL, NULL, POST_KERNEL, 33, NULL);

--- a/tests/lib/cpp/cxx/testcase.yaml
+++ b/tests/lib/cpp/cxx/testcase.yaml
@@ -5,6 +5,14 @@ common:
     - mps2/an385
     - qemu_cortex_a53
 
+  # As of commit 8f4ac0d4ab45, CONFIG_PM breaks efr32xg24_dk2601b, see
+  # issue #70466. efr32_radio/efr32mg24b220f1536im48 has similar problems.
+  #
+  # These are generic C++ tests so we don't care about specific boards.
+  platform_exclude:
+    - efr32xg24_dk2601b
+  filter: CONFIG_BOARD != "efr32_radio"
+
 tests:
   cpp.main.minimal:
     extra_configs:


### PR DESCRIPTION
Extend the coverage of `tests/lib/cpp/cxx/` to more .h files.

3 commits, see commit messages for details.

This is a subset of #70403, see that PR for more context.

The extra coverage catches issues like disordered designated initializers in .h files; see fix below.

C++20 now supports designated initializers but in a way much more restricted than C. `tests/lib/cpp/cxx/testcase.yaml` has the unique ability to test multiple CONFIG_STD_CPPxx version at once, very convenient.

In a surprising twist, gcc in C++20 mode can fail to compile code that worked in C++17 mode because the latter accepted whatever designated initializers C99 accepted...
