### PR TITLE
west.yml: Update Espressif HAL to fix SHA1

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -152,7 +152,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: e554857b07d54e2152c6f1a9b39da6d6c13fe7f7
+      revision: c49581173bab8625d1f08d5c41d5a186afc240b3
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
Commit b2ae36087baaa9bc57f5d33a47cb721229294489 introduced the wrong SHA1 for "hal_espressif update for SDHC driver support".

resolves Zephyr issue: #72207