### PR TITLE
lib: added parentheses verifying the lack of ambiguities

### DIFF
--- a/lib/heap/heap.c
+++ b/lib/heap/heap.c
@@ -265,7 +265,7 @@ void *sys_heap_alloc(struct sys_heap *heap, size_t bytes)
 	struct z_heap *h = heap->heap;
 	void *mem;
 
-	if (bytes == 0U || size_too_big(h, bytes)) {
+	if ((bytes == 0U) || size_too_big(h, bytes)) {
 		return NULL;
 	}
 
@@ -323,7 +323,7 @@ void *sys_heap_aligned_alloc(struct sys_heap *heap, size_t align, size_t bytes)
 	}
 	__ASSERT((align & (align - 1)) == 0, "align must be a power of 2");
 
-	if (bytes == 0 || size_too_big(h, bytes)) {
+	if ((bytes == 0) || size_too_big(h, bytes)) {
 		return NULL;
 	}
 

--- a/lib/heap/heap.h
+++ b/lib/heap/heap.h
@@ -214,7 +214,7 @@ static inline void set_left_chunk_size(struct z_heap *h, chunkid_t c,
 
 static inline bool solo_free_header(struct z_heap *h, chunkid_t c)
 {
-	return big_heap(h) && chunk_size(h, c) == 1U;
+	return big_heap(h) && (chunk_size(h, c) == 1U);
 }
 
 static inline size_t chunk_header_bytes(struct z_heap *h)

--- a/lib/heap/heap_info.c
+++ b/lib/heap/heap_info.c
@@ -66,8 +66,8 @@ static void heap_print_info(struct z_heap *h, bool dump_chunks)
 	overhead = total - free_bytes - allocated_bytes;
 	printk("\n%zd free bytes, %zd allocated bytes, overhead = %zd bytes (%zd.%zd%%)\n",
 	       free_bytes, allocated_bytes, overhead,
-	       (1000 * overhead + total/2) / total / 10,
-	       (1000 * overhead + total/2) / total % 10);
+	       (1000 * overhead + total / 2) / total / 10,
+	       (1000 * overhead + total / 2) / total % 10);
 }
 
 void sys_heap_print_info(struct sys_heap *heap, bool dump_chunks)

--- a/lib/heap/heap_validate.c
+++ b/lib/heap/heap_validate.c
@@ -31,7 +31,7 @@ static bool in_bounds(struct z_heap *h, chunkid_t c)
 static bool valid_chunk(struct z_heap *h, chunkid_t c)
 {
 	VALIDATE(chunk_size(h, c) > 0);
-	VALIDATE(c + chunk_size(h, c) <= h->end_chunk);
+	VALIDATE((c + chunk_size(h, c)) <= h->end_chunk);
 	VALIDATE(in_bounds(h, c));
 	VALIDATE(right_chunk(h, left_chunk(h, c)) == c);
 	VALIDATE(left_chunk(h, right_chunk(h, c)) == c);
@@ -128,7 +128,7 @@ bool sys_heap_validate(struct sys_heap *heap)
 			return false;
 		}
 
-		if (empty && h->buckets[b].next != 0) {
+		if (empty && (h->buckets[b].next != 0)) {
 			return false;
 		}
 	}

--- a/lib/libc/minimal/source/stdlib/atoi.c
+++ b/lib/libc/minimal/source/stdlib/atoi.c
@@ -53,7 +53,7 @@ int atoi(const char *s)
 	}
 	/* Compute n as a negative number to avoid overflow on INT_MIN */
 	while (isdigit((unsigned char)*s) != 0) {
-		n = 10*n - (*s++ - '0');
+		n = 10 * n - (*s++ - '0');
 	}
 	return neg ? n : -n;
 }

--- a/lib/libc/minimal/source/stdlib/strtol.c
+++ b/lib/libc/minimal/source/stdlib/strtol.c
@@ -63,7 +63,7 @@ long strtol(const char *nptr, char **endptr, register int base)
 		c = *s++;
 	}
 
-	if ((base == 0 || base == 16) &&
+	if (((base == 0) || (base == 16)) &&
 	    c == '0' && (*s == 'x' || *s == 'X')) {
 		c = s[1];
 		s += 2;
@@ -71,7 +71,7 @@ long strtol(const char *nptr, char **endptr, register int base)
 	}
 
 	if (base == 0) {
-		base = c == '0' ? 8 : 10;
+		base = (c == '0') ? 8 : 10;
 	}
 
 	/*
@@ -105,7 +105,7 @@ long strtol(const char *nptr, char **endptr, register int base)
 		if (c >= base) {
 			break;
 		}
-		if (any < 0 || acc > cutoff || (acc == cutoff && c > cutlim)) {
+		if ((any < 0) || (acc > cutoff) || ((acc == cutoff) && (c > cutlim))) {
 			any = -1;
 		} else {
 			any = 1;
@@ -122,7 +122,7 @@ long strtol(const char *nptr, char **endptr, register int base)
 	}
 
 	if (endptr != NULL) {
-		*endptr = (char *)(any ? s - 1 : nptr);
+		*endptr = (char *)(any ? (s - 1) : nptr);
 	}
 	return acc;
 }

--- a/lib/libc/minimal/source/stdlib/strtoul.c
+++ b/lib/libc/minimal/source/stdlib/strtoul.c
@@ -61,15 +61,15 @@ unsigned long strtoul(const char *nptr, char **endptr, register int base)
 		c = *s++;
 	}
 
-	if ((base == 0 || base == 16) &&
-	    c == '0' && (*s == 'x' || *s == 'X')) {
+	if (((base == 0) || (base == 16)) &&
+	    (c == '0') && ((*s == 'x') || (*s == 'X'))) {
 		c = s[1];
 		s += 2;
 		base = 16;
 	}
 
 	if (base == 0) {
-		base = c == '0' ? 8 : 10;
+		base = (c == '0') ? 8 : 10;
 	}
 
 	cutoff = (unsigned long)ULONG_MAX / (unsigned long)base;
@@ -85,7 +85,7 @@ unsigned long strtoul(const char *nptr, char **endptr, register int base)
 		if (c >= base) {
 			break;
 		}
-		if (any < 0 || acc > cutoff || (acc == cutoff && c > cutlim)) {
+		if ((any < 0) || (acc > cutoff) || ((acc == cutoff) && (c > cutlim))) {
 			any = -1;
 		} else {
 			any = 1;
@@ -100,7 +100,7 @@ unsigned long strtoul(const char *nptr, char **endptr, register int base)
 		acc = -acc;
 	}
 	if (endptr != NULL) {
-		*endptr = (char *)(any ? s - 1 : nptr);
+		*endptr = (char *)(any ? (s - 1) : nptr);
 	}
 	return acc;
 }

--- a/lib/libc/minimal/source/stdout/stdout_console.c
+++ b/lib/libc/minimal/source/stdout/stdout_console.c
@@ -27,7 +27,7 @@ void __stdout_hook_install(int (*hook)(int c))
 
 int z_impl_zephyr_fputc(int c, FILE *stream)
 {
-	return (stream == stdout || stream == stderr) ? _stdout_hook(c) : EOF;
+	return ((stream == stdout) || (stream == stderr)) ? _stdout_hook(c) : EOF;
 }
 
 #ifdef CONFIG_USERSPACE
@@ -50,7 +50,7 @@ int fputs(const char *ZRESTRICT s, FILE *ZRESTRICT stream)
 
 	ret = fwrite(s, 1, len, stream);
 
-	return len == ret ? 0 : EOF;
+	return (len == ret) ? 0 : EOF;
 }
 
 #undef putc
@@ -72,7 +72,7 @@ size_t z_impl_zephyr_fwrite(const void *ZRESTRICT ptr, size_t size,
 	size_t j;
 	const unsigned char *p;
 
-	if ((stream != stdout && stream != stderr) ||
+	if (((stream != stdout) && (stream != stderr)) ||
 	    (nitems == 0) || (size == 0)) {
 		return 0;
 	}
@@ -121,5 +121,5 @@ int puts(const char *s)
 		return EOF;
 	}
 
-	return fputc('\n', stdout) == EOF ? EOF : 0;
+	return (fputc('\n', stdout) == EOF) ? EOF : 0;
 }

--- a/lib/libc/minimal/source/string/string.c
+++ b/lib/libc/minimal/source/string/string.c
@@ -43,7 +43,7 @@ char *strncpy(char *ZRESTRICT d, const char *ZRESTRICT s, size_t n)
 {
 	char *dest = d;
 
-	while ((n > 0) && *s != '\0') {
+	while ((n > 0) && (*s != '\0')) {
 		*d = *s;
 		s++;
 		d++;

--- a/lib/os/cbprintf_complete.c
+++ b/lib/os/cbprintf_complete.c
@@ -1128,7 +1128,7 @@ static char *encode_float(double value,
 		 * representation and correct the precision and zero-pruning
 		 * in accordance with the ISO C rule.
 		 */
-		if (decexp < (-4 + 1) || decexp > precision) {
+		if ((decexp < (-4 + 1)) || (decexp > precision)) {
 			c += 'e' - 'g';  /* e or E */
 			if (precision > 0) {
 				precision--;
@@ -1173,7 +1173,7 @@ static char *encode_float(double value,
 	if (c == 'f') {
 		if (decexp > 0) {
 			/* Emit the digits above the decimal point. */
-			while (decexp > 0 && digit_count > 0) {
+			while ((decexp > 0) && (digit_count > 0)) {
 				*buf++ = _get_digit(&fract, &digit_count);
 				decexp--;
 			}
@@ -1192,7 +1192,7 @@ static char *encode_float(double value,
 			*buf++ = '.';
 		}
 
-		if (decexp < 0 && precision > 0) {
+		if ((decexp < 0) && (precision > 0)) {
 			conv->pad0_value = -decexp;
 			if (conv->pad0_value > precision) {
 				conv->pad0_value = precision;
@@ -1218,7 +1218,7 @@ static char *encode_float(double value,
 		}
 	}
 
-	while (precision > 0 && digit_count > 0) {
+	while ((precision > 0) && (digit_count > 0)) {
 		*buf++ = _get_digit(&fract, &digit_count);
 		precision--;
 	}

--- a/lib/os/cbprintf_packaged.c
+++ b/lib/os/cbprintf_packaged.c
@@ -324,7 +324,7 @@ int cbvprintf_package(void *packaged, size_t len, uint32_t flags,
 	 * Otherwise we must ensure we can store at least
 	 * the pointer to the format string itself.
 	 */
-	if (buf0 != NULL && BUF_OFFSET + sizeof(char *) > len) {
+	if ((buf0 != NULL) && (BUF_OFFSET + sizeof(char *)) > len) {
 		return -ENOSPC;
 	}
 
@@ -432,7 +432,7 @@ int cbvprintf_package(void *packaged, size_t len, uint32_t flags,
 				buf = (void *) ROUND_UP(buf, align);
 				if (buf0 != NULL) {
 					/* make sure it fits */
-					if (BUF_OFFSET + size > len) {
+					if ((BUF_OFFSET + size) > len) {
 						return -ENOSPC;
 					}
 					if (Z_CBPRINTF_VA_STACK_LL_DBL_MEMCPY) {
@@ -605,7 +605,7 @@ int cbvprintf_package(void *packaged, size_t len, uint32_t flags,
 		buf = (void *) ROUND_UP(buf, align);
 
 		/* make sure the data fits */
-		if (buf0 != NULL && BUF_OFFSET + size > len) {
+		if ((buf0 != NULL) && (BUF_OFFSET + size) > len) {
 			return -ENOSPC;
 		}
 
@@ -717,7 +717,7 @@ process_string:
 	 * worth of va_list, or about 127 arguments on a 64-bit system
 	 * (twice that on 32-bit systems). That ought to be good enough.
 	 */
-	if (BUF_OFFSET / sizeof(int) > 255) {
+	if ((BUF_OFFSET / sizeof(int)) > 255) {
 		__ASSERT(false, "too many format args");
 		return -EINVAL;
 	}
@@ -762,7 +762,7 @@ process_string:
 			uint8_t pos = str_ptr_pos[i] & STR_POS_MASK;
 
 			/* make sure it fits */
-			if (BUF_OFFSET + 1 > len) {
+			if ((BUF_OFFSET + 1) > len) {
 				return -ENOSPC;
 			}
 			/* store the pointer position prefix */
@@ -790,7 +790,7 @@ process_string:
 		}
 
 		/* make sure it fits */
-		if (BUF_OFFSET + 1 + size > len) {
+		if ((BUF_OFFSET + 1 + size) > len) {
 			return -ENOSPC;
 		}
 		/* store the pointer position prefix */

--- a/lib/os/fdtable.c
+++ b/lib/os/fdtable.c
@@ -117,7 +117,7 @@ static int _find_fd_entry(void)
 
 static int _check_fd(int fd)
 {
-	if (fd < 0 || fd >= ARRAY_SIZE(fdtable)) {
+	if ((fd < 0) || (fd >= ARRAY_SIZE(fdtable))) {
 		errno = EBADF;
 		return -1;
 	}
@@ -166,7 +166,7 @@ void *z_get_fd_obj(int fd, const struct fd_op_vtable *vtable, int err)
 
 	entry = &fdtable[fd];
 
-	if (vtable != NULL && entry->vtable != vtable) {
+	if ((vtable != NULL) && (entry->vtable != vtable)) {
 		errno = err;
 		return NULL;
 	}

--- a/lib/os/mutex.c
+++ b/lib/os/mutex.c
@@ -14,7 +14,7 @@ static struct k_mutex *get_k_mutex(struct sys_mutex *mutex)
 	struct k_object *obj;
 
 	obj = k_object_find(mutex);
-	if (obj == NULL || obj->type != K_OBJ_SYS_MUTEX) {
+	if ((obj == NULL) || (obj->type != K_OBJ_SYS_MUTEX)) {
 		return NULL;
 	}
 
@@ -56,7 +56,7 @@ int z_impl_z_sys_mutex_kernel_unlock(struct sys_mutex *mutex)
 {
 	struct k_mutex *kernel_mutex = get_k_mutex(mutex);
 
-	if (kernel_mutex == NULL || kernel_mutex->lock_count == 0) {
+	if ((kernel_mutex == NULL) || (kernel_mutex->lock_count == 0)) {
 		return -EINVAL;
 	}
 

--- a/lib/os/printk.c
+++ b/lib/os/printk.c
@@ -225,12 +225,12 @@ struct str_context {
 
 static int str_out(int c, struct str_context *ctx)
 {
-	if (ctx->str == NULL || ctx->count >= ctx->max) {
+	if ((ctx->str == NULL) || (ctx->count >= ctx->max)) {
 		ctx->count++;
 		return c;
 	}
 
-	if (ctx->count == ctx->max - 1) {
+	if (ctx->count == (ctx->max - 1)) {
 		ctx->str[ctx->count++] = '\0';
 	} else {
 		ctx->str[ctx->count++] = c;

--- a/lib/os/sem.c
+++ b/lib/os/sem.c
@@ -38,8 +38,7 @@ static inline atomic_t bounded_inc(atomic_t *val, atomic_t minimum,
 			break;
 		}
 
-		new_value = old_value < minimum ?
-			    minimum + 1 : old_value + 1;
+		new_value = ((old_value < minimum) ? minimum : old_value) + 1;
 	} while (atomic_cas(val, old_value, new_value) == 0U);
 
 	return old_value;
@@ -48,8 +47,8 @@ static inline atomic_t bounded_inc(atomic_t *val, atomic_t minimum,
 int sys_sem_init(struct sys_sem *sem, unsigned int initial_count,
 		 unsigned int limit)
 {
-	if (sem == NULL || limit == SYS_SEM_MINIMUM ||
-	    initial_count > limit || limit > INT_MAX) {
+	if ((sem == NULL) || (limit == SYS_SEM_MINIMUM) ||
+	    (initial_count > limit) || (limit > INT_MAX)) {
 		return -EINVAL;
 	}
 
@@ -103,7 +102,7 @@ unsigned int sys_sem_count_get(struct sys_sem *sem)
 {
 	int value = atomic_get(&sem->futex.val);
 
-	return value > SYS_SEM_MINIMUM ? value : SYS_SEM_MINIMUM;
+	return (value > SYS_SEM_MINIMUM) ? value : SYS_SEM_MINIMUM;
 }
 #else
 int sys_sem_init(struct sys_sem *sem, unsigned int initial_count,
@@ -126,7 +125,7 @@ int sys_sem_take(struct sys_sem *sem, k_timeout_t timeout)
 	int ret_value = 0;
 
 	ret_value = k_sem_take(&sem->kernel_sem, timeout);
-	if (ret_value == -EAGAIN || ret_value == -EBUSY) {
+	if ((ret_value == -EAGAIN) || (ret_value == -EBUSY)) {
 		ret_value = -ETIMEDOUT;
 	}
 

--- a/lib/posix/options/clock.c
+++ b/lib/posix/options/clock.c
@@ -171,7 +171,7 @@ int clock_nanosleep(clockid_t clock_id, int flags, const struct timespec *rqtp,
 	k_spinlock_key_t key;
 	const bool update_rmtp = rmtp != NULL;
 
-	if (!(clock_id == CLOCK_REALTIME || clock_id == CLOCK_MONOTONIC)) {
+	if (!((clock_id == CLOCK_REALTIME) || (clock_id == CLOCK_MONOTONIC))) {
 		errno = EINVAL;
 		return -1;
 	}
@@ -181,7 +181,7 @@ int clock_nanosleep(clockid_t clock_id, int flags, const struct timespec *rqtp,
 		return -1;
 	}
 
-	if (rqtp->tv_sec < 0 || rqtp->tv_nsec < 0 || rqtp->tv_nsec >= NSEC_PER_SEC) {
+	if ((rqtp->tv_sec < 0) || (rqtp->tv_nsec < 0) || (rqtp->tv_nsec >= NSEC_PER_SEC)) {
 		errno = EINVAL;
 		return -1;
 	}

--- a/lib/utils/hex.c
+++ b/lib/utils/hex.c
@@ -11,11 +11,11 @@
 
 int char2hex(char c, uint8_t *x)
 {
-	if (c >= '0' && c <= '9') {
+	if ((c >= '0') && (c <= '9')) {
 		*x = c - '0';
-	} else if (c >= 'a' && c <= 'f') {
+	} else if ((c >= 'a') && (c <= 'f')) {
 		*x = c - 'a' + 10;
-	} else if (c >= 'A' && c <= 'F') {
+	} else if ((c >= 'A') && (c <= 'F')) {
 		*x = c - 'A' + 10;
 	} else {
 		return -EINVAL;
@@ -39,7 +39,7 @@ int hex2char(uint8_t x, char *c)
 
 size_t bin2hex(const uint8_t *buf, size_t buflen, char *hex, size_t hexlen)
 {
-	if (hexlen < (buflen * 2U + 1U)) {
+	if (hexlen < ((buflen * 2U) + 1U)) {
 		return 0;
 	}
 
@@ -60,7 +60,7 @@ size_t hex2bin(const char *hex, size_t hexlen, uint8_t *buf, size_t buflen)
 {
 	uint8_t dec;
 
-	if (buflen < hexlen / 2U + hexlen % 2U) {
+	if (buflen < (hexlen / 2U + hexlen % 2U)) {
 		return 0;
 	}
 
@@ -75,7 +75,7 @@ size_t hex2bin(const char *hex, size_t hexlen, uint8_t *buf, size_t buflen)
 	}
 
 	/* regular hex conversion */
-	for (size_t i = 0; i < hexlen / 2U; i++) {
+	for (size_t i = 0; i < (hexlen / 2U); i++) {
 		if (char2hex(hex[2U * i], &dec) < 0) {
 			return 0;
 		}

--- a/lib/utils/timeutil.c
+++ b/lib/utils/timeutil.c
@@ -34,9 +34,9 @@ static int64_t time_days_from_civil(int64_t y,
 {
 	y -= m <= 2;
 
-	int64_t era = (y >= 0 ? y : y - 399) / 400;
+	int64_t era = ((y >= 0) ? y : (y - 399)) / 400;
 	unsigned int yoe = y - era * 400;
-	unsigned int doy = (153U * (m + (m > 2 ? -3 : 9)) + 2U) / 5U + d;
+	unsigned int doy = (153U * (m + ((m > 2) ? -3 : 9)) + 2U) / 5U + d;
 	unsigned int doe = yoe * 365U + yoe / 4U - yoe / 100U + doy;
 
 	return era * 146097 + (time_t)doe - 719468;


### PR DESCRIPTION
Fix coding guideline MISRA C:2012 Rule 12.1 in lib:

> The precedence of operators within expressions should be made explicit.

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/29155bdd6c8f8c2c0bdf0562191b4b968b3a818a