### PR TITLE
drivers: gpio: fix bug with Px15 pins

### DIFF
--- a/drivers/gpio/gpio_numaker.c
+++ b/drivers/gpio/gpio_numaker.c
@@ -48,7 +48,7 @@ static int gpio_numaker_configure(const struct device *dev, gpio_pin_t pin, gpio
 	ARG_UNUSED(data);
 
 	/* Check for an invalid pin number */
-	if (pin >= 15) {
+	if (pin > 15) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Fix condition in pin number check so that PA15, PB15, etc. can be properly accessed.

Cherry-picked commit from #67267 