### PR TITLE
drivers: modem_cellular: add Sequans GM02S modem

### DIFF
--- a/drivers/modem/Kconfig.cellular
+++ b/drivers/modem/Kconfig.cellular
@@ -16,7 +16,7 @@ config MODEM_CELLULAR
 		    DT_HAS_SIMCOM_SIM7080_ENABLED || DT_HAS_U_BLOX_SARA_R4_ENABLED || \
 		    DT_HAS_U_BLOX_SARA_R5_ENABLED || DT_HAS_SWIR_HL7800_ENABLED || \
 		    DT_HAS_TELIT_ME910G1_ENABLED || DT_HAS_QUECTEL_EG25_G_ENABLED || \
-		    DT_HAS_NORDIC_NRF91_SLM_ENABLED)
+		    DT_HAS_NORDIC_NRF91_SLM_ENABLED || DT_HAS_SQN_GM02S_ENABLED)
 	help
 	  This driver uses the generic 3gpp AT commands, along
 	  with the standard protocols CMUX and PPP, to configure

--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -408,7 +408,7 @@ static void modem_cellular_chat_on_cxreg(struct modem_chat *chat, char **argv, u
 
 	if (argc == 2) {
 		registration_status = atoi(argv[1]);
-	} else if (argc == 3) {
+	} else if (argc == 3 || argc == 6) {
 		registration_status = atoi(argv[2]);
 	} else {
 		return;
@@ -458,7 +458,7 @@ MODEM_CHAT_MATCHES_DEFINE(dial_abort_matches,
 			  MODEM_CHAT_MATCH("NO CARRIER", "", NULL),
 			  MODEM_CHAT_MATCH("NO DIALTONE", "", NULL));
 
-#if DT_HAS_COMPAT_STATUS_OKAY(swir_hl7800)
+#if DT_HAS_COMPAT_STATUS_OKAY(swir_hl7800) || DT_HAS_COMPAT_STATUS_OKAY(sqn_gm02s)
 MODEM_CHAT_MATCH_DEFINE(connect_match, "CONNECT", "", NULL);
 #endif
 
@@ -2038,6 +2038,45 @@ MODEM_CHAT_SCRIPT_DEFINE(nordic_nrf91_slm_periodic_chat_script,
 			 modem_cellular_chat_callback_handler, 4);
 #endif
 
+#if DT_HAS_COMPAT_STATUS_OKAY(sqn_gm02s)
+MODEM_CHAT_SCRIPT_CMDS_DEFINE(sqn_gm02s_init_chat_script_cmds,
+			      MODEM_CHAT_SCRIPT_CMD_RESP("ATE0", ok_match),
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CFUN=4", ok_match),
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CMEE=1", ok_match),
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CEREG=1", ok_match),
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CEREG?", ok_match),
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGSN", imei_match),
+			      MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMM", cgmm_match),
+			      MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMI", cgmi_match),
+			      MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMR", cgmr_match),
+			      MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CMUX=0,0,5,127", ok_match));
+
+MODEM_CHAT_SCRIPT_DEFINE(sqn_gm02s_init_chat_script, sqn_gm02s_init_chat_script_cmds,
+			 abort_matches, modem_cellular_chat_callback_handler, 10);
+
+MODEM_CHAT_SCRIPT_CMDS_DEFINE(sqn_gm02s_dial_chat_script_cmds,
+			      MODEM_CHAT_SCRIPT_CMD_RESP_MULT("AT+CGACT=0,1", allow_match),
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGDCONT=1,\"IP\","
+							 "\""CONFIG_MODEM_CELLULAR_APN"\"",
+							 ok_match),
+			      MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT+CFUN=1", 10000),
+			      MODEM_CHAT_SCRIPT_CMD_RESP("ATD*99***1#", connect_match));
+
+MODEM_CHAT_SCRIPT_DEFINE(sqn_gm02s_dial_chat_script, sqn_gm02s_dial_chat_script_cmds,
+			 dial_abort_matches, modem_cellular_chat_callback_handler, 15);
+
+MODEM_CHAT_SCRIPT_CMDS_DEFINE(sqn_gm02s_periodic_chat_script_cmds,
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CEREG?", ok_match));
+
+MODEM_CHAT_SCRIPT_DEFINE(sqn_gm02s_periodic_chat_script,
+			 sqn_gm02s_periodic_chat_script_cmds, abort_matches,
+			 modem_cellular_chat_callback_handler, 4);
+#endif
+
 #define MODEM_CELLULAR_INST_NAME(name, inst) \
 	_CONCAT(_CONCAT(_CONCAT(name, _), DT_DRV_COMPAT), inst)
 
@@ -2302,6 +2341,36 @@ MODEM_CHAT_SCRIPT_DEFINE(nordic_nrf91_slm_periodic_chat_script,
 			      &MODEM_CELLULAR_INST_NAME(config, inst), POST_KERNEL, 99,            \
 			      &modem_cellular_api);
 
+#define MODEM_CELLULAR_DEVICE_SQN_GM02S(inst)                                                      \
+	MODEM_PPP_DEFINE(MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 98, 1500, 64);                 \
+                                                                                                   \
+	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
+		.chat_delimiter = "\r",                                                            \
+		.chat_filter = "\n",                                                               \
+		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
+	};                                                                                         \
+                                                                                                   \
+	static struct modem_cellular_config MODEM_CELLULAR_INST_NAME(config, inst) = {             \
+		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),                                          \
+		.power_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_power_gpios, {}),                 \
+		.reset_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_reset_gpios, {}),                 \
+		.autostarts = true,                                                                \
+		.power_pulse_duration_ms = 1500,                                                   \
+		.reset_pulse_duration_ms = 100,                                                    \
+		.startup_time_ms = 2000,                                                           \
+		.shutdown_time_ms = 5000,                                                          \
+		.init_chat_script = &sqn_gm02s_init_chat_script,                                   \
+		.dial_chat_script = &sqn_gm02s_dial_chat_script,                                   \
+		.periodic_chat_script = &sqn_gm02s_periodic_chat_script,                           \
+	};                                                                                         \
+                                                                                                   \
+	PM_DEVICE_DT_INST_DEFINE(inst, modem_cellular_pm_action);                                  \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(inst, modem_cellular_init, PM_DEVICE_DT_INST_GET(inst),              \
+			      &MODEM_CELLULAR_INST_NAME(data, inst),                               \
+			      &MODEM_CELLULAR_INST_NAME(config, inst), POST_KERNEL, 99,            \
+			      &modem_cellular_api);
+
 #define DT_DRV_COMPAT quectel_bg95
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_QUECTEL_BG95)
 #undef DT_DRV_COMPAT
@@ -2336,4 +2405,8 @@ DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_TELIT_ME910G1)
 
 #define DT_DRV_COMPAT nordic_nrf91_slm
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_NORDIC_NRF91_SLM)
+#undef DT_DRV_COMPAT
+
+#define DT_DRV_COMPAT sqn_gm02s
+DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_SQN_GM02S)
 #undef DT_DRV_COMPAT

--- a/dts/bindings/modem/sqn,gm02s.yaml
+++ b/dts/bindings/modem/sqn,gm02s.yaml
@@ -1,0 +1,13 @@
+# Copyright(c) 2024 DPTechnics bv
+# SPDX-License-Identifier: Apache-2.0
+
+description: Sequans Monarch 2 GM02S Modem
+
+compatible: "sqn,gm02s"
+
+include: uart-device.yaml
+
+properties:
+  mdm-reset-gpios:
+    type: phandle-array
+    required: true

--- a/tests/drivers/build_all/modem/uart.dtsi
+++ b/tests/drivers/build_all/modem/uart.dtsi
@@ -76,3 +76,9 @@ test_nordic_nrf91_slm: nordic_nrf91_slm {
 
 	mdm-power-gpios = <&test_gpio 0 0>;
 };
+
+test_sqn_gm02s: sqn_gm02s {
+	compatible = "sqn,gm02s";
+
+	mdm-reset-gpios = <&test_gpio 0 0>;
+};


### PR DESCRIPTION
This pull requests adds the Sequans Monarch 2 GM02S modem family to the modem_cellular driver. Tested on the DPTechnics Walter board.

The GM02S modem returns `NO CARRIER` if it isn't registered yet before executing `ATD*99***1#`. Currently, a delay is added after `CFUN=1` to give the modem some time to register. If it didn't manage to register in time, the dial script fails.
Feedback is welcome if there's interest in changing the driver to add a new, or move the existing `AWAIT_REGISTRATION` state before executing the dial command.