### PR TITLE
dts: arm: nuvoton: add rtc node of numaker m2l31x

### DIFF
--- a/dts/arm/nuvoton/m2l31x.dtsi
+++ b/dts/arm/nuvoton/m2l31x.dtsi
@@ -18,6 +18,10 @@
 		zephyr,flash-controller = &rmc;
 	};
 
+	aliases {
+		rtc = &rtc;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -40,6 +44,7 @@
 			compatible = "nuvoton,numaker-scc";
 			reg = <0x40000200 0x100>;
 			#clock-cells = <0>;
+			lxt = "enable";
 			clk-pclkdiv = <(NUMAKER_CLK_PCLKDIV_APB0DIV_DIV2 |
 					NUMAKER_CLK_PCLKDIV_APB1DIV_DIV2)>;
 			core-clock = <DT_FREQ_M(72)>;
@@ -319,6 +324,15 @@
 			channels = <31>;
 			status = "disabled";
 			#io-channel-cells = <1>;
+		};
+
+		rtc: rtc@40041000 {
+			compatible = "nuvoton,numaker-rtc";
+			reg = <0x40041000 0x138>;
+			interrupts = <6 0>;
+			oscillator = "lxt";
+			clocks = <&pcc NUMAKER_RTC_MODULE 0 0>;
+			alarms-count = <1>;
 		};
 	};
 };


### PR DESCRIPTION
This PR is to add rtc node of m2l31x.dtsi for m2l31x rtc driver support.

Test result of rtc_api on numaker_m2l31ki board as:
```
Running TESTSUITE rtc_api
===================================================================
START - test_alarm
 PASS - test_alarm in 26.001 seconds
===================================================================
START - test_alarm_callback
 PASS - test_alarm_callback in 26.001 seconds
===================================================================
START - test_set_get_time
 PASS - test_set_get_time in 0.001 seconds
===================================================================
START - test_time_counting
 PASS - test_time_counting in 10.503 seconds
===================================================================
START - test_y2k
Rollover not supported
 SKIP - test_y2k in 0.003 seconds
===================================================================
TESTSUITE rtc_api succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [rtc_api]: pass = 4, fail = 0, skip = 1, total = 5 duration = 62.509 seconds
 - PASS - [rtc_api.test_alarm] duration = 26.001 seconds
 - PASS - [rtc_api.test_alarm_callback] duration = 26.001 seconds
 - PASS - [rtc_api.test_set_get_time] duration = 0.001 seconds
 - PASS - [rtc_api.test_time_counting] duration = 10.503 seconds
 - SKIP - [rtc_api.test_y2k] duration = 0.003 seconds

------ TESTSUITE SUMMARY END ------

=======================================
```