### PR TITLE
subsys: added parentheses verifying the lack of ambiguities

### DIFF
--- a/subsys/logging/log_minimal.c
+++ b/subsys/logging/log_minimal.c
@@ -43,7 +43,7 @@ static void minimal_hexdump_line_print(const char *data, size_t length)
 		if (i < length) {
 			unsigned char c = data[i];
 
-			printk("%c", isprint((int)c) != 0 ? c : '.');
+			printk("%c", (isprint((int)c) != 0) ? c : '.');
 		} else {
 			printk(" ");
 		}


### PR DESCRIPTION
Fix coding guideline MISRA C:2012 Rule 12.1 in subsys:

> The precedence of operators within expressions should be made explicit.

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/29155bdd6c8f8c2c0bdf0562191b4b968b3a818a