### PR TITLE
kernel: avoided unwanted null pointer if CONFIG_KERNEL_VM_BASE is 0

### DIFF
--- a/kernel/include/mmu.h
+++ b/kernel/include/mmu.h
@@ -30,8 +30,11 @@
 #define Z_PHYS_RAM_END		(Z_PHYS_RAM_START + Z_PHYS_RAM_SIZE)
 #define Z_NUM_PAGE_FRAMES	(Z_PHYS_RAM_SIZE / (size_t)CONFIG_MMU_PAGE_SIZE)
 
+/* The comma operator trick below is needed to avoid to build a null pointer
+ * when CONFIG_KERNEL_VM_BASE is 0
+ */
 /** End virtual address of virtual address space */
-#define Z_VIRT_RAM_START	((uint8_t *)CONFIG_KERNEL_VM_BASE)
+#define Z_VIRT_RAM_START	((uint8_t *)((void) 0, (uintptr_t)CONFIG_KERNEL_VM_BASE))
 #define Z_VIRT_RAM_SIZE		((size_t)CONFIG_KERNEL_VM_SIZE)
 #define Z_VIRT_RAM_END		(Z_VIRT_RAM_START + Z_VIRT_RAM_SIZE)
 


### PR DESCRIPTION
Fix coding guideline MISRA C:2012 Rule 11.9 in kernel:

> The macro NULL shall be the only permitted form of integer null pointer constant.

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

Original commit by BUGSENG:
https://github.com/zephyrproject-rtos/zephyr/commit/839fa857c817ee34d3c9566b4483e5f319e62181