### PR TITLE
include: avoid to use assignment expression value

### DIFF
--- a/include/zephyr/sys/rb.h
+++ b/include/zephyr/sys/rb.h
@@ -232,7 +232,7 @@ struct rbnode *z_rb_foreach_next(struct rbtree *tree, struct _rb_foreach *f);
 	for (struct _rb_foreach __f = _RB_FOREACH_INIT(tree, node);	   \
 			({struct rbnode *n = z_rb_foreach_next(tree, &__f); \
 			 node = n ? CONTAINER_OF(n, __typeof__(*(node)),   \
-					 field) : NULL; }) != NULL;        \
+					 field) : NULL; (node);}) != NULL;        \
 			 /**/)
 
 /** @} */


### PR DESCRIPTION
Fix coding guideline MISRA C:2012 Rule 13.4 in includes:

> The result of an assignment operator should not be used.

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/64336f467c8c4c61f7e926313365e04c8e43f12f

