### PR TITLE
kernel: avoid using result of an assignment operator

### DIFF
--- a/kernel/stack.c
+++ b/kernel/stack.c
@@ -29,7 +29,8 @@ void k_stack_init(struct k_stack *stack, stack_data_t *buffer,
 {
 	z_waitq_init(&stack->wait_q);
 	stack->lock = (struct k_spinlock) {};
-	stack->next = stack->base = buffer;
+	stack->next = buffer;
+	stack->base = buffer;
 	stack->top = stack->base + num_entries;
 
 	SYS_PORT_TRACING_OBJ_INIT(k_stack, stack);


### PR DESCRIPTION
Fix coding guideline MISRA C:2012 Rule 13.4 in kernel:

> The result of an assignment operator should not be used.

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/64336f467c8c4c61f7e926313365e04c8e43f12f