### PR TITLE
libc: minimal: Add 'noreturn' attribute to abort() and exit()

### DIFF
--- a/lib/libc/common/source/stdlib/abort.c
+++ b/lib/libc/common/source/stdlib/abort.c
@@ -7,7 +7,7 @@
 #include <stdlib.h>
 #include <zephyr/kernel.h>
 
-void abort(void)
+FUNC_NORETURN void abort(void)
 {
 	printk("abort()\n");
 	k_panic();

--- a/lib/libc/minimal/include/stdlib.h
+++ b/lib/libc/minimal/include/stdlib.h
@@ -12,6 +12,8 @@
 #include <stddef.h>
 #include <limits.h>
 
+#include <zephyr/toolchain.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -41,12 +43,12 @@ void qsort(void *base, size_t nmemb, size_t size,
 
 #define EXIT_SUCCESS 0
 #define EXIT_FAILURE 1
-void _exit(int status);
-static inline void exit(int status)
+FUNC_NORETURN void _exit(int status);
+FUNC_NORETURN static inline void exit(int status)
 {
 	_exit(status);
 }
-void abort(void);
+FUNC_NORETURN void abort(void);
 
 #ifdef CONFIG_MINIMAL_LIBC_RAND
 #define RAND_MAX INT_MAX

--- a/lib/libc/minimal/source/stdlib/exit.c
+++ b/lib/libc/minimal/source/stdlib/exit.c
@@ -7,7 +7,7 @@
 #include <stdlib.h>
 #include <zephyr/kernel.h>
 
-void _exit(int status)
+FUNC_NORETURN void _exit(int status)
 {
 	printk("exit\n");
 	while (1) {


### PR DESCRIPTION
This aligns abort() and exit() definitions with other libc.

Without `noreturn` attribute, compilers have to assume that we will return from these functions which can lead to surprising errors like `error: non-void function does not return a value`.