### PR TITLE
kernel: avoid using result of an assignment operator

### DIFF
--- a/kernel/condvar.c
+++ b/kernel/condvar.c
@@ -84,8 +84,8 @@ int z_impl_k_condvar_broadcast(struct k_condvar *condvar)
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_condvar, broadcast, condvar);
 
 	/* wake up any threads that are waiting to write */
-	while ((pending_thread = z_unpend_first_thread(&condvar->wait_q)) !=
-	       NULL) {
+	for (pending_thread = z_unpend_first_thread(&condvar->wait_q); pending_thread != NULL;
+		 pending_thread = z_unpend_first_thread(&condvar->wait_q)) {
 		woken++;
 		arch_thread_return_value_set(pending_thread, 0);
 		z_ready_thread(pending_thread);

--- a/kernel/msg_q.c
+++ b/kernel/msg_q.c
@@ -383,7 +383,8 @@ void z_impl_k_msgq_purge(struct k_msgq *msgq)
 	SYS_PORT_TRACING_OBJ_FUNC(k_msgq, purge, msgq);
 
 	/* wake up any threads that are waiting to write */
-	while ((pending_thread = z_unpend_first_thread(&msgq->wait_q)) != NULL) {
+	for (pending_thread = z_unpend_first_thread(&msgq->wait_q); pending_thread != NULL;
+		 pending_thread = z_unpend_first_thread(&msgq->wait_q)) {
 		arch_thread_return_value_set(pending_thread, -ENOMSG);
 		z_ready_thread(pending_thread);
 	}

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -947,7 +947,7 @@ int z_unpend_all(_wait_q_t *wait_q)
 	int need_sched = 0;
 	struct k_thread *thread;
 
-	while ((thread = z_waitq_head(wait_q)) != NULL) {
+	for (thread = z_waitq_head(wait_q); thread != NULL; thread = z_waitq_head(wait_q)) {
 		z_unpend_thread(thread);
 		z_ready_thread(thread);
 		need_sched = 1;
@@ -1258,7 +1258,7 @@ static inline void unpend_all(_wait_q_t *wait_q)
 {
 	struct k_thread *thread;
 
-	while ((thread = z_waitq_head(wait_q)) != NULL) {
+	for (thread = z_waitq_head(wait_q); thread != NULL; thread = z_waitq_head(wait_q)) {
 		unpend_thread_no_timeout(thread);
 		(void)z_abort_thread_timeout(thread);
 		arch_thread_return_value_set(thread, 0);

--- a/kernel/stack.c
+++ b/kernel/stack.c
@@ -29,7 +29,8 @@ void k_stack_init(struct k_stack *stack, stack_data_t *buffer,
 {
 	z_waitq_init(&stack->wait_q);
 	stack->lock = (struct k_spinlock) {};
-	stack->next = stack->base = buffer;
+	stack->next = buffer;
+	stack->base = buffer;
 	stack->top = stack->base + num_entries;
 
 	SYS_PORT_TRACING_OBJ_INIT(k_stack, stack);


### PR DESCRIPTION
Fix coding guideline MISRA C:2012 Rule 13.4 in kernel:

> The result of an assignment operator should not be used.

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/64336f467c8c4c61f7e926313365e04c8e43f12f