### PR TITLE
os: avoid using result of an assignment operator

### DIFF
--- a/lib/os/cbprintf_complete.c
+++ b/lib/os/cbprintf_complete.c
@@ -1060,7 +1060,7 @@ static char *encode_float(double value,
 			/* Fraction is subnormal.  Normalize it and correct
 			 * the exponent.
 			 */
-			while (((fract <<= 1) & BIT_63) == 0) {
+			for (fract <<= 1; (fract & BIT_63) == 0; fract <<= 1) {
 				expo--;
 			}
 		}

--- a/lib/utils/rb.c
+++ b/lib/utils/rb.c
@@ -537,7 +537,7 @@ static inline struct rbnode *stack_left_limb(struct rbnode *n,
 	f->stack[f->top] = n;
 	f->is_left[f->top] = 0U;
 
-	while ((n = get_child(n, 0U)) != NULL) {
+	for (n = get_child(n, 0U); n != NULL; n = get_child(n, 0U)) {
 		f->top++;
 		f->stack[f->top] = n;
 		f->is_left[f->top] = 1;


### PR DESCRIPTION
Fix coding guideline MISRA C:2012 Rule 13.4 in os:

> The result of an assignment operator should not be used.

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/64336f467c8c4c61f7e926313365e04c8e43f12f