### PR TITLE
arch: x86: coding guidelines: cast unused arguments to void

### DIFF
--- a/arch/x86/core/intel64/fatal.c
+++ b/arch/x86/core/intel64/fatal.c
@@ -15,6 +15,8 @@ LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
  */
 __weak bool z_x86_do_kernel_nmi(const z_arch_esf_t *esf)
 {
+	ARG_UNUSED(esf);
+
 	return false;
 }
 

--- a/arch/x86/core/intel64/thread.c
+++ b/arch/x86/core/intel64/thread.c
@@ -37,6 +37,8 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	 * which is only needed if the stack is not memory mapped.
 	 */
 	z_x86_set_stack_guard(stack);
+#else
+	ARG_UNUSED(stack);
 #endif
 #ifdef CONFIG_USERSPACE
 	switch_entry = z_x86_userspace_prepare_thread(thread);
@@ -68,11 +70,16 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 int arch_float_disable(struct k_thread *thread)
 {
 	/* x86-64 always has FP/SSE enabled so cannot be disabled */
+	ARG_UNUSED(thread);
+
 	return -ENOTSUP;
 }
 
 int arch_float_enable(struct k_thread *thread, unsigned int options)
 {
 	/* x86-64 always has FP/SSE enabled so nothing to do here */
+	ARG_UNUSED(thread);
+	ARG_UNUSED(options);
+
 	return 0;
 }

--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -450,6 +450,8 @@ static inline void assert_addr_aligned(uintptr_t addr)
 #if __ASSERT_ON
 	__ASSERT((addr & (CONFIG_MMU_PAGE_SIZE - 1)) == 0U,
 		 "unaligned address 0x%" PRIxPTR, addr);
+#else
+	ARG_UNUSED(addr);
 #endif
 }
 
@@ -481,6 +483,8 @@ static inline void assert_size_aligned(size_t size)
 #if __ASSERT_ON
 	__ASSERT((size & (CONFIG_MMU_PAGE_SIZE - 1)) == 0U,
 		 "unaligned size %zu", size);
+#else
+	ARG_UNUSED(size);
 #endif
 }
 
@@ -828,6 +832,9 @@ static inline pentry_t pte_finalize_value(pentry_t val, bool user_table,
 	    get_entry_phys(val, level) != shared_phys_addr) {
 		val = ~val;
 	}
+#else
+	ARG_UNUSED(user_table);
+	ARG_UNUSED(level);
 #endif
 	return val;
 }

--- a/arch/x86/include/x86_mmu.h
+++ b/arch/x86/include/x86_mmu.h
@@ -217,6 +217,8 @@ static inline pentry_t *z_x86_thread_page_tables_get(struct k_thread *thread)
 		 */
 		return z_mem_virt_addr(thread->arch.ptables);
 	}
+#else
+	ARG_UNUSED(thread);
 #endif
 	return z_x86_kernel_ptables;
 }

--- a/arch/x86/zefi/zefi.c
+++ b/arch/x86/zefi/zefi.c
@@ -134,6 +134,8 @@ static void disable_hpet(void)
  */
 uintptr_t __abi efi_entry(void *img_handle, struct efi_system_table *sys_tab)
 {
+	(void)img_handle;
+
 	efi = sys_tab;
 	z_putchar = efi_putchar;
 	printf("*** Zephyr EFI Loader ***\n");


### PR DESCRIPTION
Added missing ARG_UNUSED. Added void to cast where ARG_UNUSED macro is not available.

This corresponds to following coding guideline:

> There should be no unused parameters in functions

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/5b627ad8b38d1aa24c1a2e7ffd4c6d00bb4b088e