### PR TITLE
west_commands: More explicit error when intelhex is not installed for NRF flashing

### DIFF
--- a/scripts/west_commands/runners/nrf_common.py
+++ b/scripts/west_commands/runners/nrf_common.py
@@ -420,7 +420,7 @@ class NrfBinaryRunner(ZephyrBinaryRunner):
 
         self.ensure_output('hex')
         if IntelHex is None:
-            raise RuntimeError('one or more Python dependencies were missing; '
+            raise RuntimeError('Python dependency intelhex was missing; '
                                'see the getting started guide for details on '
                                'how to fix')
         self.hex_contents = IntelHex()


### PR DESCRIPTION
The  original error message is not explicit, and leads to confusion when trying to flash NRF boards for the first time.

See https://devzone.nordicsemi.com/f/nordic-q-a/100164/vs-code-extension---west-flash-fails-from-missing-python-dependencies for example.

A simple fix is to tell which library was not found.