### PR TITLE
arch: x86: Avoid cast between pointer to void and an arithmetic type.

### DIFF
--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -1162,8 +1162,8 @@ static int range_map(void *virt, uintptr_t phys, size_t size,
 {
 	int ret = 0, ret2;
 
-	LOG_DBG("%s: %p -> %p (%zu) flags " PRI_ENTRY " mask "
-		PRI_ENTRY " opt 0x%x", __func__, (void *)phys, virt, size,
+	LOG_DBG("%s: 0x%" PRIxPTR " -> %p (%zu) flags " PRI_ENTRY " mask "
+		PRI_ENTRY " opt 0x%x", __func__, phys, virt, size,
 		entry_flags, mask, options);
 
 #ifdef CONFIG_X86_64
@@ -1774,8 +1774,8 @@ static inline int apply_region(pentry_t *ptables, void *start,
 __pinned_func
 static void set_stack_perms(struct k_thread *thread, pentry_t *ptables)
 {
-	LOG_DBG("update stack for thread %p's ptables at %p: %p (size %zu)",
-		thread, ptables, (void *)thread->stack_info.start,
+	LOG_DBG("update stack for thread %p's ptables at %p: 0x%" PRIxPTR " (size %zu)",
+		thread, ptables, thread->stack_info.start,
 		thread->stack_info.size);
 	apply_region(ptables, (void *)thread->stack_info.start,
 		     thread->stack_info.size,
@@ -1922,8 +1922,8 @@ int arch_mem_domain_thread_add(struct k_thread *thread)
 	}
 
 	thread->arch.ptables = z_mem_phys_addr(domain->arch.ptables);
-	LOG_DBG("set thread %p page tables to %p", thread,
-		(void *)thread->arch.ptables);
+	LOG_DBG("set thread %p page tables to 0x%" PRIxPTR, thread,
+		thread->arch.ptables);
 
 	/* Check if we're doing a migration from a different memory domain
 	 * and have to remove permissions from its old domain.


### PR DESCRIPTION
Fix coding guideline MISRA C:2012 Rule 11.6 in arch:

> A cast shall not be performed between pointer to void and an arithmetic type.

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

original commit:
https://github.com/zephyrproject-rtos/zephyr/commit/64816d53c041330645f28c554005847920b595fa

