### PR TITLE
cmake: find python path adjustment

### DIFF
--- a/cmake/modules/python.cmake
+++ b/cmake/modules/python.cmake
@@ -25,7 +25,7 @@ if(NOT Python3_EXECUTABLE)
   # cause just using find_program directly could result in a python2.7 as python,
   # and not finding a valid python3.
   foreach(candidate "python" "python3")
-    find_program(Python3_EXECUTABLE ${candidate})
+    find_program(Python3_EXECUTABLE ${candidate} PATHS ENV VIRTUAL_ENV NO_CMAKE_PATH)
     if(Python3_EXECUTABLE)
         execute_process (COMMAND "${Python3_EXECUTABLE}" -c
                                  "import sys; sys.stdout.write('.'.join([str(x) for x in sys.version_info[:2]]))"


### PR DESCRIPTION
Fixes: #70258

Specify NO_CMAKE_PATH to prevent CMake find_program from having a preference for searching CMAKE_PREFIX_PATH.

Some tool like NixOS / Nix package manager sets this variable to point inside the nix store, like this:
CMAKE_PREFIX_PATH=/nix/store/gpvnsgf8zhqjjgk63dd...-python3-3.11.6-env

thus causing `find_program()` to prefer this over the tool in the default path.

Support Nix environments by specifying NO_CMAKE_PATH and in addition support `VIRTUAL_ENV` environment setting for search path when set by the virtual environment.