### PR TITLE
debug: stack: coding guidelines: cast unused arguments to void

### DIFF
--- a/include/zephyr/debug/stack.h
+++ b/include/zephyr/debug/stack.h
@@ -38,6 +38,8 @@ static inline void log_stack_usage(const struct k_thread *thread)
 			thread, tname, unused, size - unused, size,
 			pcnt);
 	}
+#else
+	ARG_UNUSED(thread);
 #endif
 }
 #endif /* ZEPHYR_INCLUDE_DEBUG_STACK_H_ */


### PR DESCRIPTION
Added missing ARG_UNUSED.

This corresponds to following coding guideline:

> There should be no unused parameters in functions

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/5b627ad8b38d1aa24c1a2e7ffd4c6d00bb4b088e