### PR TITLE
Formatting Output: Avoid backwards goto jump

### DIFF
--- a/lib/os/cbprintf_complete.c
+++ b/lib/os/cbprintf_complete.c
@@ -1601,6 +1601,26 @@ int z_cbvprintf_impl(cbprintf_cb out, void *ctx, const char *fp,
 
 			break;
 		}
+		case 'p':
+			/* Implementation-defined: null is "(nil)", non-null
+			 * has 0x prefix followed by significant address hex
+			 * digits, no leading zeros.
+			 */
+			if (value->ptr != NULL) {
+				bps = encode_uint((uintptr_t)value->ptr, conv,
+						  buf, bpe);
+
+				/* Use 0x prefix */
+				conv->altform_0c = true;
+				conv->specifier = 'x';
+
+				goto prec_int_pad0;
+			}
+
+			bps = "(nil)";
+			bpe = bps + 5;
+
+			break;
 		case 'c':
 			bps = buf;
 			buf[0] = CHAR_IS_SIGNED ? value->sint : value->uint;
@@ -1652,26 +1672,6 @@ int z_cbvprintf_impl(cbprintf_cb out, void *ctx, const char *fp,
 					conv->pad0_value = precision - (int)len;
 				}
 			}
-
-			break;
-		case 'p':
-			/* Implementation-defined: null is "(nil)", non-null
-			 * has 0x prefix followed by significant address hex
-			 * digits, no leading zeros.
-			 */
-			if (value->ptr != NULL) {
-				bps = encode_uint((uintptr_t)value->ptr, conv,
-						  buf, bpe);
-
-				/* Use 0x prefix */
-				conv->altform_0c = true;
-				conv->specifier = 'x';
-
-				goto prec_int_pad0;
-			}
-
-			bps = "(nil)";
-			bpe = bps + 5;
 
 			break;
 		case 'n':


### PR DESCRIPTION
Fix coding guideline MISRA C:2012 Rule 15.2 in os:

> The goto statement shall jump to a label declared later in the same function.

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

original commit:
https://github.com/zephyrproject-rtos/zephyr/commit/ac487cf5a46526ebe78305e39d53fc95edd6fd90