### PR TITLE
dts: stm32wba: Fix RNG base address

### DIFF
--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -446,9 +446,9 @@
 			status = "disabled";
 		};
 
-		rng: rng@520c0800 {
+		rng: rng@420c0800 {
 			compatible = "st,stm32-rng";
-			reg = <0x520c0800 0x400>;
+			reg = <0x420c0800 0x400>;
 			interrupts = <59 0>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00040000>,
 				 <&rcc STM32_SRC_HSI16 RNG_SEL(2)>;


### PR DESCRIPTION
Set RNG address to its non-secure alias.
See RM0493 STM32WBA5 Reference manual for details. Using the secure alias (0x5..)instead of the non-secure alias (0x4..) for this peripheral results in a SecureFault during kernel init if TrustZone is activated, Zephyr is running as NSPE and RNG is enabled.