### PR TITLE
kernel: coding guidelines: cast unused arguments to void

### DIFF
--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -981,6 +981,12 @@ static uintptr_t handler_bad_syscall(uintptr_t bad_id, uintptr_t arg2,
 				     uintptr_t arg5, uintptr_t arg6,
 				     void *ssf)
 {
+	ARG_UNUSED(arg2);
+	ARG_UNUSED(arg3);
+	ARG_UNUSED(arg4);
+	ARG_UNUSED(arg5);
+	ARG_UNUSED(arg6);
+
 	LOG_ERR("Bad system call id %" PRIuPTR " invoked", bad_id);
 	arch_syscall_oops(ssf);
 	CODE_UNREACHABLE; /* LCOV_EXCL_LINE */
@@ -990,6 +996,13 @@ static uintptr_t handler_no_syscall(uintptr_t arg1, uintptr_t arg2,
 				    uintptr_t arg3, uintptr_t arg4,
 				    uintptr_t arg5, uintptr_t arg6, void *ssf)
 {
+	ARG_UNUSED(arg1);
+	ARG_UNUSED(arg2);
+	ARG_UNUSED(arg3);
+	ARG_UNUSED(arg4);
+	ARG_UNUSED(arg5);
+	ARG_UNUSED(arg6);
+
 	LOG_ERR("Unimplemented system call");
 	arch_syscall_oops(ssf);
 	CODE_UNREACHABLE; /* LCOV_EXCL_LINE */


### PR DESCRIPTION
Added missing ARG_UNUSED.

This corresponds to following coding guideline:

> There should be no unused parameters in functions

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/5b627ad8b38d1aa24c1a2e7ffd4c6d00bb4b088e