### PR TITLE
west : runners : Fix error message when runners.yaml is not found.

### DIFF
--- a/cmake/flash/CMakeLists.txt
+++ b/cmake/flash/CMakeLists.txt
@@ -131,8 +131,6 @@ function(create_runners_yaml)
   # Write the final contents and set its location in the cache.
   file(GENERATE OUTPUT "${runners_yaml}" CONTENT
     $<TARGET_PROPERTY:runners_yaml_props_target,yaml_contents>)
-  set(ZEPHYR_RUNNERS_YAML "${runners_yaml}" CACHE INTERNAL
-    "a configuration file for the runners Python package")
 endfunction()
 
 get_property(RUNNERS GLOBAL PROPERTY ZEPHYR_RUNNERS)

--- a/scripts/west_commands/run_common.py
+++ b/scripts/west_commands/run_common.py
@@ -514,9 +514,9 @@ def rebuild(command, build_dir, args):
 def runners_yaml_path(build_dir, board):
     ret = Path(build_dir) / 'zephyr' / 'runners.yaml'
     if not ret.is_file():
-        log.die(f'either a pristine build is needed, or board {board} '
-                "doesn't support west flash/debug/simulate "
-                '(no ZEPHYR_RUNNERS_YAML in CMake cache)')
+        log.die(f'no runners.yaml found in {build_dir}/zephyr. '
+        f"Either board {board} doesn't support west flash/debug/simulate,"
+        ' or a pristine build is needed.')
     return ret
 
 def load_runners_yaml(path):


### PR DESCRIPTION
Adjust error message so that it clearly states runners.yaml is missing from <build_dir>/zephyr, instead of referencing CMake cache variable ZEPHYR_RUNNERS_YAML, which is no longer used (since 3124c02987071b045b33bbfa2d12606b2ff0a757 ).
Also clean up that variable in CMake since it is no longer used (0 other references in entire tree).
Fixes #70605