### PR TITLE
arch: added parentheses to avoid ambiguity

### DIFF
--- a/arch/x86/core/fatal.c
+++ b/arch/x86/core/fatal.c
@@ -49,7 +49,7 @@ bool z_x86_check_stack_bounds(uintptr_t addr, size_t size, uint16_t cs)
 {
 	uintptr_t start, end;
 
-	if (_current == NULL || arch_is_in_isr()) {
+	if ((_current == NULL) || arch_is_in_isr()) {
 		/* We were servicing an interrupt or in early boot environment
 		 * and are supposed to be on the interrupt stack */
 		int cpu_id;
@@ -63,8 +63,8 @@ bool z_x86_check_stack_bounds(uintptr_t addr, size_t size, uint16_t cs)
 		    z_interrupt_stacks[cpu_id]);
 		end = start + CONFIG_ISR_STACK_SIZE;
 #ifdef CONFIG_USERSPACE
-	} else if ((cs & 0x3U) == 0U &&
-		   (_current->base.user_options & K_USER) != 0) {
+	} else if (((cs & 0x3U) == 0U) &&
+		   ((_current->base.user_options & K_USER)) != 0) {
 		/* The low two bits of the CS register is the privilege
 		 * level. It will be 0 in supervisor mode and 3 in user mode
 		 * corresponding to ring 0 / ring 3.
@@ -82,7 +82,7 @@ bool z_x86_check_stack_bounds(uintptr_t addr, size_t size, uint16_t cs)
 					_current->stack_info.size);
 	}
 
-	return (addr <= start) || (addr + size > end);
+	return (addr <= start) || ((addr + size) > end);
 }
 #endif
 
@@ -343,8 +343,8 @@ static void dump_page_fault(z_arch_esf_t *esf)
 			LOG_ERR("Linear address not present in page tables");
 		}
 		LOG_ERR("Access violation: %s thread not allowed to %s",
-			(err & PF_US) != 0U ? "user" : "supervisor",
-			(err & PF_ID) != 0U ? "execute" : ((err & PF_WR) != 0U ?
+			((err & PF_US) != 0U) ? "user" : "supervisor",
+			((err & PF_ID) != 0U) ? "execute" : (((err & PF_WR) != 0U) ?
 							   "write" :
 							   "read"));
 		if ((err & PF_PK) != 0) {
@@ -459,8 +459,8 @@ void z_x86_page_fault_handler(z_arch_esf_t *esf)
 			return;
 		}
 #else
-		if ((void *)esf->eip >= exceptions[i].start &&
-		    (void *)esf->eip < exceptions[i].end) {
+		if (((void *)esf->eip >= exceptions[i].start) &&
+		    ((void *)esf->eip < exceptions[i].end)) {
 			esf->eip = (unsigned int)(exceptions[i].fixup);
 			return;
 		}
@@ -504,8 +504,8 @@ void z_x86_do_kernel_oops(const z_arch_esf_t *esf)
 	/* User mode is only allowed to induce oopses and stack check
 	 * failures via this software interrupt
 	 */
-	if ((esf->cs & 0x3) != 0 && !(reason == K_ERR_KERNEL_OOPS ||
-				      reason == K_ERR_STACK_CHK_FAIL)) {
+	if (((esf->cs & 0x3) != 0) && !((reason == K_ERR_KERNEL_OOPS) ||
+				      (reason == K_ERR_STACK_CHK_FAIL))) {
 		reason = K_ERR_KERNEL_OOPS;
 	}
 #endif

--- a/arch/x86/core/pcie.c
+++ b/arch/x86/core/pcie.c
@@ -41,7 +41,7 @@ static void pcie_mm_init(void)
 	if (m != NULL) {
 		int n = (m->header.Length - sizeof(*m)) / sizeof(m->pci_segs[0]);
 
-		for (int i = 0; i < n && i < MAX_PCI_BUS_SEGMENTS; i++) {
+		for (int i = 0; (i < n) && (i < MAX_PCI_BUS_SEGMENTS); i++) {
 			size_t size;
 			uintptr_t phys_addr;
 

--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -372,7 +372,7 @@ static inline void pentry_get(int *paging_level, pentry_t *val,
 	for (int level = 0; level < NUM_LEVELS; level++) {
 		pentry_t entry = get_entry(table, virt, level);
 
-		if ((entry & MMU_P) == 0 || is_leaf(level, entry)) {
+		if (((entry & MMU_P) == 0) || is_leaf(level, entry)) {
 			*val = entry;
 			if (paging_level != NULL) {
 				*paging_level = level;
@@ -399,7 +399,7 @@ static inline void tlb_flush_page(void *addr)
 __pinned_func
 static inline bool is_flipped_pte(pentry_t pte)
 {
-	return (pte & MMU_P) == 0 && (pte & PTE_ZERO) != 0;
+	return ((pte & MMU_P) == 0) && ((pte & PTE_ZERO) != 0);
 }
 #endif
 
@@ -589,7 +589,7 @@ static void print_entries(pentry_t entries_array[], uint8_t *base, int level,
 				if (phys == virt) {
 					/* Identity mappings */
 					COLOR(YELLOW);
-				} else if (phys + Z_MEM_VM_OFFSET == virt) {
+				} else if ((phys + Z_MEM_VM_OFFSET) == virt) {
 					/* Permanent RAM mappings */
 					COLOR(GREEN);
 				} else {
@@ -677,8 +677,8 @@ static void dump_ptables(pentry_t *table, uint8_t *base, int level)
 		pentry_t entry = table[j];
 		pentry_t *next;
 
-		if ((entry & MMU_P) == 0U ||
-			(entry & MMU_PS) != 0U) {
+		if (((entry & MMU_P) == 0U) ||
+			((entry & MMU_PS) != 0U)) {
 			/* Not present or big page, skip */
 			continue;
 		}
@@ -824,8 +824,8 @@ static inline pentry_t pte_finalize_value(pentry_t val, bool user_table,
 	static const uintptr_t shared_phys_addr =
 		Z_MEM_PHYS_ADDR(POINTER_TO_UINT(&z_shared_kernel_page_start));
 
-	if (user_table && (val & MMU_US) == 0 && (val & MMU_P) != 0 &&
-	    get_entry_phys(val, level) != shared_phys_addr) {
+	if (user_table && ((val & MMU_US) == 0) && ((val & MMU_P) != 0) &&
+	    (get_entry_phys(val, level) != shared_phys_addr)) {
 		val = ~val;
 	}
 #endif

--- a/arch/x86/include/x86_mmu.h
+++ b/arch/x86/include/x86_mmu.h
@@ -210,7 +210,7 @@ static inline pentry_t *z_x86_thread_page_tables_get(struct k_thread *thread)
 {
 #if defined(CONFIG_USERSPACE) && !defined(CONFIG_X86_COMMON_PAGE_TABLE)
 	if (!IS_ENABLED(CONFIG_X86_KPTI) ||
-	    (thread->base.user_options & K_USER) != 0U) {
+	    ((thread->base.user_options & K_USER) != 0U)) {
 		/* If KPTI is enabled, supervisor threads always use
 		 * the kernel's page tables and not the page tables associated
 		 * with their memory domain.

--- a/arch/x86/zefi/printf.h
+++ b/arch/x86/zefi/printf.h
@@ -79,13 +79,13 @@ static int vpf(struct _pfr *r, const char *f, va_list ap)
 		}
 
 		/* Ignore (but accept) field width and precision values */
-		while (f[1] >= '0' && f[1] <= '9') {
+		while ((f[1] >= '0') && (f[1] <= '9')) {
 			f++;
 		}
 		if (f[1] == '.') {
 			f++;
 		}
-		while (f[1] >= '0' && f[1] <= '9') {
+		while ((f[1] >= '0') && (f[1] <= '9')) {
 			f++;
 		}
 
@@ -117,7 +117,7 @@ static int vpf(struct _pfr *r, const char *f, va_list ap)
 				int d = (v >> (i*4)) & 0xf;
 
 				sig += !!d;
-				if (sig || i == 0) {
+				if (sig || (i == 0)) {
 					pc(r, "0123456789abcdef"[d]);
 				}
 			}

--- a/arch/x86/zefi/zefi.c
+++ b/arch/x86/zefi/zefi.c
@@ -58,7 +58,7 @@ static void efi_putchar(int c)
 
 	efibuf[n++] = c;
 
-	if (c == '\n' || n == PUTCHAR_BUFSZ) {
+	if ((c == '\n') || (n == PUTCHAR_BUFSZ)) {
 		efibuf[n] = 0U;
 		efi->ConOut->OutputString(efi->ConOut, efibuf);
 		n = 0;
@@ -140,7 +140,7 @@ uintptr_t __abi efi_entry(void *img_handle, struct efi_system_table *sys_tab)
 
 	efi_prepare_boot_arg();
 
-	for (int i = 0; i < sizeof(zefi_zsegs)/sizeof(zefi_zsegs[0]); i++) {
+	for (int i = 0; i < (sizeof(zefi_zsegs)/sizeof(zefi_zsegs[0])); i++) {
 		int bytes = zefi_zsegs[i].sz;
 		uint8_t *dst = (uint8_t *)zefi_zsegs[i].addr;
 
@@ -150,7 +150,7 @@ uintptr_t __abi efi_entry(void *img_handle, struct efi_system_table *sys_tab)
 		}
 	}
 
-	for (int i = 0; i < sizeof(zefi_dsegs)/sizeof(zefi_dsegs[0]); i++) {
+	for (int i = 0; i < (sizeof(zefi_dsegs)/sizeof(zefi_dsegs[0])); i++) {
 		int bytes = zefi_dsegs[i].sz;
 		int off = zefi_dsegs[i].off;
 		uint8_t *dst = (uint8_t *)zefi_dsegs[i].addr;
@@ -170,7 +170,7 @@ uintptr_t __abi efi_entry(void *img_handle, struct efi_system_table *sys_tab)
 		 * starts, because the very first thing it does is
 		 * install its own page table that disallows writes.
 		 */
-		if (((long)dst & 0xfff) == 0 && dst < (uint8_t *)0x100000L) {
+		if ((((long)dst & 0xfff) == 0) && (dst < (uint8_t *)0x100000L)) {
 			for (int i = 0; i < 8; i++) {
 				dst[i] = 0x90; /* 0x90 == 1-byte NOP */
 			}

--- a/arch/x86/zefi/zefi.c
+++ b/arch/x86/zefi/zefi.c
@@ -140,7 +140,7 @@ uintptr_t __abi efi_entry(void *img_handle, struct efi_system_table *sys_tab)
 
 	efi_prepare_boot_arg();
 
-	for (int i = 0; i < (sizeof(zefi_zsegs)/sizeof(zefi_zsegs[0])); i++) {
+	for (int i = 0; i < (ARRAY_SIZE(zefi_zsegs)); i++) {
 		int bytes = zefi_zsegs[i].sz;
 		uint8_t *dst = (uint8_t *)zefi_zsegs[i].addr;
 
@@ -150,7 +150,7 @@ uintptr_t __abi efi_entry(void *img_handle, struct efi_system_table *sys_tab)
 		}
 	}
 
-	for (int i = 0; i < (sizeof(zefi_dsegs)/sizeof(zefi_dsegs[0])); i++) {
+	for (int i = 0; i < (ARRAY_SIZE(zefi_dsegs)); i++) {
 		int bytes = zefi_dsegs[i].sz;
 		int off = zefi_dsegs[i].off;
 		uint8_t *dst = (uint8_t *)zefi_dsegs[i].addr;


### PR DESCRIPTION
Fix coding guideline MISRA C:2012 Rule 12.1 in arch:

> The precedence of operators within expressions should be made explicit.

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/29155bdd6c8f8c2c0bdf0562191b4b968b3a818a