### PR TITLE
drivers: gnss: gnss_publish: replace spinlock with sem

### DIFF
--- a/drivers/gnss/gnss_publish.c
+++ b/drivers/gnss/gnss_publish.c
@@ -8,29 +8,33 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/iterable_sections.h>
 
-static struct k_spinlock lock;
+static K_SEM_DEFINE(semlock, 1, 1);
 
 void gnss_publish_data(const struct device *dev, const struct gnss_data *data)
 {
-	K_SPINLOCK(&lock) {
-		STRUCT_SECTION_FOREACH(gnss_data_callback, callback) {
-			if (callback->dev == NULL || callback->dev == dev) {
-				callback->callback(dev, data);
-			}
+	(void)k_sem_take(&semlock, K_FOREVER);
+
+	STRUCT_SECTION_FOREACH(gnss_data_callback, callback) {
+		if (callback->dev == NULL || callback->dev == dev) {
+			callback->callback(dev, data);
 		}
 	}
+
+	k_sem_give(&semlock);
 }
 
 #if CONFIG_GNSS_SATELLITES
 void gnss_publish_satellites(const struct device *dev, const struct gnss_satellite *satellites,
 			     uint16_t size)
 {
-	K_SPINLOCK(&lock) {
-		STRUCT_SECTION_FOREACH(gnss_satellites_callback, callback) {
-			if (callback->dev == NULL || callback->dev == dev) {
-				callback->callback(dev, satellites, size);
-			}
+	(void)k_sem_take(&semlock, K_FOREVER);
+
+	STRUCT_SECTION_FOREACH(gnss_satellites_callback, callback) {
+		if (callback->dev == NULL || callback->dev == dev) {
+			callback->callback(dev, satellites, size);
 		}
 	}
+
+	k_sem_give(&semlock);
 }
 #endif


### PR DESCRIPTION
The gnss_publish module incorrectly uses a spinlock for mutual exclusion when publishing data and satellites. Update it to use a binary semaphore.