### PR TITLE
samples: drivers: gnss: boards: adjust mimxrt1062 dts overlay

### DIFF
--- a/samples/drivers/gnss/boards/mimxrt1062_fmurt6.overlay
+++ b/samples/drivers/gnss/boards/mimxrt1062_fmurt6.overlay
@@ -6,7 +6,7 @@
 
 / {
 	aliases {
-		gnss = &lpuart2;
+		gnss = &gnss;
 	};
 };
 
@@ -17,7 +17,7 @@
 	pinctrl-1 = <&pinmux_lpuart2_sleep>;
 	pinctrl-names = "default", "sleep";
 
-	u_blox_m10: u-blox,m10 {
+	gnss: u_blox_m10 {
 		status = "okay";
 		compatible = "u-blox,m10";
 		uart-baudrate = <115200>;


### PR DESCRIPTION
The overlay for the mimxrt1062 boards gnss alias is pointing to the uart node rather than the gnss node. Adjust gnss alias and node naming.