### PR TITLE
samples: Bluetooth: broadcast_audio_sink: remove nRF52820 from sample.yaml

### DIFF
--- a/samples/bluetooth/broadcast_audio_sink/sample.yaml
+++ b/samples/bluetooth/broadcast_audio_sink/sample.yaml
@@ -18,7 +18,6 @@ tests:
     harness: bluetooth
     platform_allow:
       - nrf52_bsim
-      - nrf52833dk/nrf52820
       - nrf52833dk/nrf52833
       - nrf52840dongle/nrf52840
     integration_platforms:


### PR DESCRIPTION
nrf52833dk/nrf52820 does not compile so remove it from platform_allow list