### PR TITLE
arch: arm: cortex-m: Change character used to mark immediate operand

### DIFF
--- a/arch/arm/core/cortex_m/irq_relay.S
+++ b/arch/arm/core/cortex_m/irq_relay.S
@@ -31,7 +31,7 @@ GDATA(z_main_stack)
 
 SECTION_FUNC(TEXT, __vector_relay_handler)
 	mrs	r0, ipsr;
-	lsls	r0, r0, $0x02;
+	lsls	r0, r0, #0x02;
 
 	ldr	r1, =_vector_table_pointer;
 	ldr	r1, [r1];


### PR DESCRIPTION
Change the character used to indicate immediate operands from '$' to '#' to resolve an "invalid instruction" error when building with clang.

For arm, binutils allows either '#' or '$' to indicate immediate operands. clang seems to accept '$' for arm in other instances (my build accepts 'subs r0, r0, $0x02', for example), but in this case it produces an error that this is an invalid instruction due to the "$0x02" operand.

Given clang's inconsistent behavior, I'm guessing this is a bug in clang somewhere, but:

  1. '#' for immediate operands seems to be more standard for arm in general and seems to be what is used throughout the rest of Zephyr's arm asm code.
  2. Switching out '$' for '#' shouldn't negatively impact other toolchains.

As such, switch out the character used to unblock clang builds until this can be fixed in clang.