### PR TITLE
cmake: llvm: arm: Remove '--specs' when building with clang for arm

### DIFF
--- a/cmake/toolchain/llvm/target.cmake
+++ b/cmake/toolchain/llvm/target.cmake
@@ -25,8 +25,6 @@ if("${ARCH}" STREQUAL "arm")
     # Default ARM target supported by all processors.
     set(triple arm-none-eabi)
   endif()
-
-  set(CMAKE_EXE_LINKER_FLAGS_INIT "--specs=nosys.specs")
 elseif("${ARCH}" STREQUAL "x86")
   if(CONFIG_64BIT)
     set(triple x86_64-pc-none-elf)


### PR DESCRIPTION
Currently, clang produces a warning that the '--specs=nosys.specs' argument is unused. Remove this flag to fix the warning as clang will generally not honor '--specs' when targeting arm baremetal.

While this flag has been present for some time, I think this should be safe to do. For background, clang does not seem to handle '--specs' [1] besides possibly passing it through to GCC if GCC is used as the driver for linking. However, whether GCC will be used for linking as a fallback depends on the "Toolchain" [1] clang uses internally, which in turn depends on the triple. For arm/thumb baremetal triples, the Toolchain clang uses will not fall back to GCC to drive linking, so '--specs' will never be used here.

I believe this behavior in clang is fairly longstanding as well (since ~2017/LLVM 5 [2]). While there isn't a minimum required clang version for Zephyr, Zephyr currently requires lld >= 14.0.0. So, I don't think removing this flag should impact current users (besides preventing the warning).

[1] https://clang.llvm.org/docs/DriverInternals.html
[2] https://reviews.llvm.org/D33259