### PR TITLE
linker: decouple KERNEL_WHOLE_ARCHIVE from LLEXT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -886,7 +886,7 @@ foreach(zephyr_lib ${ZEPHYR_LIBS_PROPERTY})
   add_dependencies(${zephyr_lib} zephyr_generated_headers)
 endforeach()
 
-if(CONFIG_LLEXT)
+if(CONFIG_KERNEL_WHOLE_ARCHIVE)
   set(WHOLE_ARCHIVE_LIBS ${ZEPHYR_LIBS_PROPERTY} kernel)
 else()
   set(WHOLE_ARCHIVE_LIBS ${ZEPHYR_LIBS_PROPERTY})

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -1020,6 +1020,12 @@ config THREAD_LOCAL_STORAGE
 	help
 	  This option enables thread local storage (TLS) support in kernel.
 
+config KERNEL_WHOLE_ARCHIVE
+	bool
+	help
+	  This option forces every object file in the libkernel.a archive
+	  to be included, rather than searching the archive for required object files.
+
 endmenu
 
 rsource "Kconfig.device"

--- a/subsys/llext/Kconfig
+++ b/subsys/llext/Kconfig
@@ -4,6 +4,7 @@
 menuconfig LLEXT
 	bool "Linkable loadable extensions"
 	select CACHE_MANAGEMENT if DCACHE
+	select KERNEL_WHOLE_ARCHIVE
 	help
 	  Enable the linkable loadable extension subsystem
 


### PR DESCRIPTION
Dynamic code execution applications not using LLEXT for "extension" loading are subject to the same linker optimization symbol resolution issue described in commit 321e395 (in summary, libkernel.a syscalls not used directly by the application result in weak symbol resolution of their z_mrsh_ wrapper).

To support usecases where an application is using alternative methods to load and execute code calling syscalls (likely from userspace) or is using a mechanism where the linker may not be aware, the configuration option has been decoupled from CONFIG_LLEXT (who is now a selector) to KERNEL_WHOLE_ARCHIVE.