### PR TITLE
Bluetooth: conn: check `k_work_submit()` retcode

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -387,6 +387,7 @@ static void wait_for_tx_work(struct bt_conn *conn)
 		tx_notify(conn);
 	} else {
 		struct k_work_sync sync;
+		int err;
 
 		/* API docs mention undefined behavior if syncing on work item
 		 * from wq execution context.
@@ -394,9 +395,12 @@ static void wait_for_tx_work(struct bt_conn *conn)
 		__ASSERT_NO_MSG(k_current_get() !=
 				k_work_queue_thread_get(&k_sys_work_q));
 
-		k_work_submit(&conn->tx_complete_work);
+		err = k_work_submit(&conn->tx_complete_work);
+		__ASSERT(err >= 0, "couldn't submit (err %d)", err);
+
 		k_work_flush(&conn->tx_complete_work, &sync);
 	}
+	LOG_DBG("done");
 #else
 	ARG_UNUSED(conn);
 #endif	/* CONFIG_BT_CONN_TX */


### PR DESCRIPTION
We still don't know how to handle it but at least it's checked now.