### PR TITLE
net: wifi: Fix user request disconnection

### DIFF
--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -427,8 +427,10 @@ enum wifi_conn_status {
  * in the disconnect result event for detailed reason.
  */
 enum wifi_disconn_reason {
+	/** Success, overload status as reason */
+	WIFI_REASON_DISCONN_SUCCESS = 0,
 	/** Unspecified reason */
-	WIFI_REASON_DISCONN_UNSPECIFIED = WIFI_STATUS_DISCONN_FIRST_STATUS,
+	WIFI_REASON_DISCONN_UNSPECIFIED,
 	/** Disconnected due to user request */
 	WIFI_REASON_DISCONN_USER_REQUEST,
 	/** Disconnected due to AP leaving */


### PR DESCRIPTION
When user tries to disconnect the shell, it's always printing "Disconnection request failed".