### PR TITLE
dts: bindings: Move zephyr,memory-region property definition

### DIFF
--- a/dts/bindings/base/zephyr,memory-common.yaml
+++ b/dts/bindings/base/zephyr,memory-common.yaml
@@ -4,6 +4,14 @@
 include: [base.yaml]
 
 properties:
+  zephyr,memory-region:
+    type: string
+    description: |
+      Signify that this node should result in a dedicated linker script
+      memory region in the final executable. The region address and size
+      is taken from the <reg> property, while the name is the value of
+      this property.
+
   zephyr,memory-region-mpu:
     type: string
     deprecated: true

--- a/dts/bindings/base/zephyr,memory-region.yaml
+++ b/dts/bindings/base/zephyr,memory-region.yaml
@@ -5,14 +5,8 @@ description: Compatible for devices resulting in linker memory regions
 
 compatible: "zephyr,memory-region"
 
-include: [base.yaml, "zephyr,memory-attr.yaml"]
+include: [base.yaml, "zephyr,memory-common.yaml"]
 
 properties:
   zephyr,memory-region:
-    type: string
     required: true
-    description: |
-      Signify that this node should result in a dedicated linker script
-      memory region in the final executable. The region address and size
-      is taken from the <reg> property, while the name is the value of
-      this property.

--- a/dts/bindings/test/vnd,memory-attr.yaml
+++ b/dts/bindings/test/vnd,memory-attr.yaml
@@ -5,4 +5,4 @@ description: Test memory and memory attributes
 
 compatible: "vnd,memory-attr"
 
-include: [base.yaml, "zephyr,memory-attr.yaml"]
+include: [base.yaml, "zephyr,memory-common.yaml"]


### PR DESCRIPTION
Move it to a common file named `zephyr,memory-common.yaml`, which replaces `zephyr,memory-attr.yaml` and takes its contents as well.

This is so that another binding, e.g., `vnd,memory-region`, can support being combined with the `zephyr,memory-region` binding like so:
```
  node@deadbeef {
    compatible = "vnd,memory-region", "zephyr,memory-region";
    zephyr,memory-region = "NAME";
    ...
  };
```
To allow this, edtlib would require `vnd,memory-region` to include the property definitions from this new common file.

The same can't be done by including `zephyr,memory-region.yaml` directly because that file marks the property in question as always required, and it shouldn't be required whenever the `vnd,memory-region` compatible is used on its own.