### PR TITLE
drivers: serial: nrfx: Update Kconfig dependencies for RX cache

### DIFF
--- a/drivers/serial/Kconfig.nrfx_uart_instance
+++ b/drivers/serial/Kconfig.nrfx_uart_instance
@@ -76,6 +76,13 @@ config UART_$(nrfx_uart_num)_NRF_HW_ASYNC_TIMER
 	int "Timer instance"
 	depends on UART_$(nrfx_uart_num)_NRF_HW_ASYNC
 
+config UART_$(nrfx_uart_num)_HAS_RX_CACHE_SECTION
+	def_bool $(dt_nodelabel_has_prop,uart$(nrfx_uart_num),memory-regions)
+	imply NRFX_UARTE_CONFIG_RX_CACHE_ENABLED
+	help
+	  This helper symbol indicates the existence of a linker section which
+	  can be dedicated to an RX cache buffer.
+
 config UART_$(nrfx_uart_num)_TX_CACHE_SIZE
 	int "TX cache buffer size"
 	depends on !UART_NRFX_UARTE_LEGACY_SHIM
@@ -87,7 +94,7 @@ config UART_$(nrfx_uart_num)_TX_CACHE_SIZE
 config UART_$(nrfx_uart_num)_RX_CACHE_SIZE
 	int "RX cache buffer size"
 	depends on !UART_NRFX_UARTE_LEGACY_SHIM
-	default 32 if $(dt_nodelabel_has_compat,shared_ram3x_region,$(DT_COMPAT_NORDIC_OWNED_MEMORY))
+	default 32 if UART_$(nrfx_uart_num)_HAS_RX_CACHE_SECTION
 	default 5
 	range 5 255
 	help

--- a/modules/hal_nordic/nrfx/Kconfig
+++ b/modules/hal_nordic/nrfx/Kconfig
@@ -946,7 +946,6 @@ config NRFX_UARTE_CONFIG_TX_LINK
 
 config NRFX_UARTE_CONFIG_RX_CACHE_ENABLED
 	bool "UARTE RX caching support"
-	default y if $(dt_nodelabel_has_compat,shared_ram3x_region,$(DT_COMPAT_NORDIC_OWNED_MEMORY))
 	depends on NRFX_UARTE
 	help
 	  Feature might be enabled on platforms which has limitations regarding addresses


### PR DESCRIPTION
Two Kconfig symbols were tied to a board-specific DT nodelabel - namely the `NRFX_UARTE_CONFIG_RX_CACHE_ENABLED` and `UART_<n>_RX_CACHE_SIZE` were tied to `shared_ram3x_region` - but this is not necessary.

That DT node is where the UARTE driver RX/TX cache buffers are placed in the default nRF54H20 DK memory map, but on another board, they could be located somewhere else.

The exact memory sub-regions used for this purpose are indicated using the `memory-regions` property on each UARTE instance, which should be generic enough already, so let's use that instead.